### PR TITLE
fix(dev): CTL-1315 — J4 reaper skips terminal triage-done dirs (inFlight gate)

### DIFF
--- a/plugins/dev/scripts/execution-core/scheduler.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.mjs
@@ -5512,20 +5512,50 @@ function runTick() {
         clearStall: defaultClearStall(runningOpts.orchDir, runningOpts.writeStatus ?? linearWrite),
         // CTL-1242 J4: wire the read-only GC census + the production rmSync seam.
         // The census only probes tickets whose workers/<T>/ dir exists AND whose
-        // Linear state is provably terminal (Done/Canceled). Same closure shape
-        // as J3's isLinearTerminal — cache-first, no extra subprocess.
-        // Mode is the existing jMode (readStallJanitorConfig() → default 'shadow')
-        // so J4 runs in shadow by default; no new config knob needed.
-        collectTerminalSignalGcCandidates: () =>
-          defaultCollectTerminalSignalGcCandidates({
+        // Linear state is provably terminal (Done/Canceled). Mode is the existing
+        // jMode (readStallJanitorConfig() → default 'shadow') so J4 runs in shadow
+        // by default; no new config knob needed.
+        collectTerminalSignalGcCandidates: () => {
+          // CTL-1315: read the agents snapshot ONCE and pass both its array and its
+          // freshness. liveSessionInWorktree (the sole live-worker fence for a
+          // terminal ticket once the inFlight gate is relaxed) is only trustworthy
+          // when the snapshot is fresh; on a cold/stale snapshot the census collects
+          // nothing and defers the reap (see defaultCollectTerminalSignalGcCandidates).
+          const agentsSnap = getAgentsCached();
+          return defaultCollectTerminalSignalGcCandidates({
             orchDir: runningOpts.orchDir,
-            agents: getAgentsCached().agents,
+            agents: agentsSnap.agents,
+            agentsFresh: agentsSnap.isFresh,
             inFlightTickets: listInFlightTickets(runningOpts.orchDir),
+            // CTL-1315: 3-tier read (cache → gateway → live linearis), matching the
+            // J3/unstuck/reclaim censuses. The original J4 probe called
+            // fetchTicketState(id) with NO cache/gateway — a live `linearis issues read`
+            // per terminal dir per tick (the comment that claimed "cache-first" was
+            // wrong). The cache/gateway tiers also make the terminal verdict resilient
+            // to a transient live-read miss.
             isLinearTerminalOrMerged: (id) => {
-              const state = fetchTicketState(id);
+              const state = fetchTicketState(id, {
+                cache: runningOpts.cache,
+                gateway: runningOpts.gateway,
+              });
               return state != null && isLinearTerminal(state);
             },
-          }),
+            // CTL-1315: thread the worktree resolver so liveSessionInWorktree is a
+            // REACHABLE live-worker fence. It was previously omitted → defaulted to
+            // () => null → liveSessionInWorktree always false. That fence is now
+            // load-bearing: relaxing the in-flight gate (classifyTerminalSignalGc)
+            // means a Linear-terminal ticket with a genuinely-running late-phase
+            // worker (e.g. teardown, whose cwd is its worktree per CTL-1105) is
+            // protected ONLY by this live-session check. Mirrors the unstuck-sweep
+            // resolver below.
+            resolveWorktreePath: (ticket) => {
+              for (const sig of readWorkerSignals(runningOpts.orchDir)) {
+                if (sig.ticket === ticket && sig.worktreePath) return sig.worktreePath;
+              }
+              return null;
+            },
+          });
+        },
         gcTerminalSignals: defaultGcTerminalSignals(runningOpts.orchDir),
       },
       // CTL-1064: wire the unstuck-sweep census (Pass 0u). The census collects

--- a/plugins/dev/scripts/execution-core/stall-janitor.mjs
+++ b/plugins/dev/scripts/execution-core/stall-janitor.mjs
@@ -192,20 +192,35 @@ export function classifyStallClear(ctx = {}) {
 // classifyTerminalSignalGc (J4, CTL-1242) — PURE. Given a ticket that has been
 // identified as terminal/merged, decide whether its workers/<T>/ signal dir can
 // be GC'd this tick. Safety fences first, then positive "gc" verdict:
-//   "gc"   — ticket is terminal/merged, no live session, not in-flight, not already GC'd.
-//   "skip" — anything ambiguous, live, in-flight, or already removed.
+//   "gc"   — ticket is terminal/merged, no live session, not already GC'd.
+//            A stale in-flight signal does NOT block a terminal ticket (CTL-1315) —
+//            the live-worker fence is liveSessionInWorktree, not the slot-accounting bit.
+//   "skip" — non-terminal, a live session, already removed, or a NON-terminal in-flight.
 //
 // ctx fields:
 //   linearTerminalOrMerged — ticket is terminal via Linear state OR merged PR.
 //   liveSessionInWorktree  — a live session has its cwd inside the ticket's worktree.
-//   inFlight               — the ticket has an active (non-terminal) phase worker.
+//   inFlight               — the ticket holds a worker slot (a non-terminal-phase signal
+//                            that is not failed/stalled/aborted). For a terminal ticket
+//                            this is stale residue, not a live worker (CTL-1315).
 //   alreadyGcd             — a .janitor-gc.applied marker is present in the worker dir,
 //                            meaning a prior GC write started but the dir wasn't removed
 //                            (e.g., EACCES). Prevents infinite retry.
 export function classifyTerminalSignalGc(ctx = {}) {
   if (!ctx.linearTerminalOrMerged) return { action: "skip", reason: "not-terminal-or-merged" };
   if (ctx.liveSessionInWorktree) return { action: "skip", reason: "live-session-in-worktree" };
-  if (ctx.inFlight) return { action: "skip", reason: "in-flight" };
+  // CTL-1315: a Linear-terminal ticket has no legitimately-advancing worker, so a
+  // stale mid-pipeline phase signal (e.g. a stranded triage-done dir whose pipeline
+  // never advanced past triage) must NOT block its reap. The genuine live-worker
+  // protection is liveSessionInWorktree (checked above); ctx.inFlight here is pure
+  // slot-accounting residue from listInFlightTickets (isTicketInFlight treats any
+  // non-terminal-phase `done` as still mid-pipeline). We therefore only honor inFlight
+  // for NON-terminal tickets — but the J4 census pre-filters those out
+  // (linearTerminalOrMerged is hard-coded true on every candidate), so this guard is
+  // effectively dead for J4 and retained only for defensive symmetry. Do NOT "restore"
+  // it to an unconditional skip — that reintroduces the CTL-1246/1249/774 leak.
+  if (ctx.inFlight && !ctx.linearTerminalOrMerged)
+    return { action: "skip", reason: "in-flight" };
   if (ctx.alreadyGcd) return { action: "skip", reason: "already-gc'd" };
   return { action: "gc", reason: "terminal-or-merged-no-live-session" };
 }
@@ -849,8 +864,20 @@ export function defaultCollectTerminalSignalGcCandidates({
   // resolveWorktreePath(ticket) → worktree path or null. Optional: when
   // omitted, liveSessionInWorktree is always false (conservative).
   resolveWorktreePath = () => null,
+  // CTL-1315: liveSessionInWorktree (computed from `agents`) is the SOLE live-worker
+  // fence for a terminal ticket now that the inFlight gate is relaxed in
+  // classifyTerminalSignalGc. The agents snapshot is empty on cold start and
+  // stale-last-good after a failed `claude agents --json` refresh, so reaping on
+  // such a tick could remove a genuinely-running late-phase worker's signal dir.
+  // When the snapshot is not fresh, collect NO candidates — defer every J4 reap to a
+  // tick where the live-worker fence is trustworthy (mirrors the CTL-731 new-work
+  // freshness gate). Defaults true so unit tests that inject a known agents array
+  // keep their explicit behavior.
+  agentsFresh = true,
 } = {}) {
   const out = [];
+  // CTL-1315: bail the whole pass when liveness is unknown — never reap blind.
+  if (!agentsFresh) return out;
   let workerDirs;
   try {
     workerDirs = readdirSync(join(orchDir, "workers"), { withFileTypes: true });

--- a/plugins/dev/scripts/execution-core/stall-janitor.test.mjs
+++ b/plugins/dev/scripts/execution-core/stall-janitor.test.mjs
@@ -888,10 +888,32 @@ describe("classifyTerminalSignalGc (CTL-1242 J4)", () => {
     expect(d.reason).toBe("live-session-in-worktree");
   });
 
-  test("skip when in-flight (active worker signal)", () => {
+  // CTL-1315: a Linear-terminal ticket has no legitimately-advancing worker, so a
+  // stale mid-pipeline signal (e.g. a stranded triage-done dir) must NOT block its
+  // reap. The live-worker protection is liveSessionInWorktree (checked first), not
+  // the stale inFlight slot-accounting bit.
+  test("gc when terminal + in-flight but no live session (stale triage-done)", () => {
     const d = classifyTerminalSignalGc({ ...base, inFlight: true });
+    expect(d.action).toBe("gc");
+    expect(d.reason).toBe("terminal-or-merged-no-live-session");
+  });
+
+  test("skip when terminal + in-flight AND a live session is in the worktree", () => {
+    const d = classifyTerminalSignalGc({ ...base, inFlight: true, liveSessionInWorktree: true });
     expect(d.action).toBe("skip");
-    expect(d.reason).toBe("in-flight");
+    expect(d.reason).toBe("live-session-in-worktree");
+  });
+
+  test("skip when NOT terminal even if in-flight (non-terminal mid-advance never reaped)", () => {
+    const d = classifyTerminalSignalGc({ ...base, linearTerminalOrMerged: false, inFlight: true });
+    expect(d.action).toBe("skip");
+    expect(d.reason).toBe("not-terminal-or-merged");
+  });
+
+  test("skip already-gc'd even when terminal + in-flight (marker still wins)", () => {
+    const d = classifyTerminalSignalGc({ ...base, inFlight: true, alreadyGcd: true });
+    expect(d.action).toBe("skip");
+    expect(d.reason).toBe("already-gc'd");
   });
 
   test("skip when already GC'd this worker-dir lifetime", () => {
@@ -970,6 +992,18 @@ describe("runStallJanitorPass — J4 enforce (CTL-1242)", () => {
     });
     await runStallJanitorPass(makeGcOpts(world, { mode: "enforce", gcd }));
     expect(gcd).toEqual([]);
+  });
+
+  test("terminal + in-flight (stale signal) + no live session: GCs the dir (CTL-1315)", async () => {
+    const events = [];
+    const gcd = [];
+    const world = makeGcWorld({
+      gcCandidates: [{ ...makeGcWorld().gcCandidates[0], inFlight: true }],
+    });
+    const res = await runStallJanitorPass(makeGcOpts(world, { mode: "enforce", events, gcd }));
+    expect(gcd).toEqual(["CTL-1242-J4"]);
+    expect(events.find((e) => e.type === "janitor.signals.gc")?.ticket).toBe("CTL-1242-J4");
+    expect(res.signalsGcd).toEqual([{ ticket: "CTL-1242-J4" }]);
   });
 });
 
@@ -1102,5 +1136,56 @@ describe("defaultCollectTerminalSignalGcCandidates (CTL-1242 J4)", () => {
     });
     const c = out.find((o) => o.ticket === "CTL-1242-E");
     expect(c?.alreadyGcd).toBe(true);
+  });
+
+  test("CTL-1315 repro: triage-done-only terminal dir → census emits an inFlight candidate the classifier now GCs", () => {
+    // The live bug (CTL-1246/1249/774): a worker dir whose ONLY signal is
+    // phase-triage.json (status done) reads as in-flight (triage != TERMINAL_PHASE),
+    // so the census marks inFlight:true. listInFlightTickets computes that Set in
+    // production; here we inject it to keep this a stall-janitor-local unit test.
+    const d = join(orchDir, "workers", "CTL-1315-REPRO");
+    mkdirSync(d, { recursive: true });
+    writeFileSync(
+      join(d, "phase-triage.json"),
+      JSON.stringify({ ticket: "CTL-1315-REPRO", status: "done" }),
+    );
+    const out = defaultCollectTerminalSignalGcCandidates({
+      orchDir,
+      isLinearTerminalOrMerged: () => true,
+      inFlightTickets: new Set(["CTL-1315-REPRO"]),
+    });
+    const c = out.find((o) => o.ticket === "CTL-1315-REPRO");
+    expect(c).toBeDefined();
+    expect(c.linearTerminalOrMerged).toBe(true);
+    expect(c.inFlight).toBe(true);
+    expect(c.liveSessionInWorktree).toBe(false);
+    // Before CTL-1315 this classified as skip "in-flight"; now a Linear-terminal
+    // ticket with a stale in-flight signal and no live session must be reaped.
+    expect(classifyTerminalSignalGc(c).action).toBe("gc");
+  });
+
+  test("CTL-1315 freshness gate: agentsFresh:false collects NO candidates (never reap blind)", () => {
+    // A would-be candidate (terminal, failed signal) that the census normally emits...
+    mkWorkerSignal("CTL-1315-COLD");
+    // ...is withheld entirely when the agents snapshot is not fresh, because
+    // liveSessionInWorktree (the sole live-worker fence for a terminal ticket) is
+    // unreliable on a cold/stale snapshot. Deferring avoids reaping a genuinely-live
+    // late-phase worker's signal dir on a daemon-boot tick.
+    const out = defaultCollectTerminalSignalGcCandidates({
+      orchDir,
+      isLinearTerminalOrMerged: () => true,
+      agentsFresh: false,
+    });
+    expect(out).toEqual([]);
+  });
+
+  test("CTL-1315 freshness gate: agentsFresh:true (the default) still collects candidates", () => {
+    mkWorkerSignal("CTL-1315-WARM");
+    const out = defaultCollectTerminalSignalGcCandidates({
+      orchDir,
+      isLinearTerminalOrMerged: () => true,
+      agentsFresh: true,
+    });
+    expect(out.some((c) => c.ticket === "CTL-1315-WARM")).toBe(true);
   });
 });


### PR DESCRIPTION
## What & why

The stall-janitor **J4 terminal-dir reaper** never reaps a Linear-terminal ticket whose only worker signal is a stale `phase-triage.json: done`. The board renders one card per surviving `workers/<T>/` directory, so finished tickets pile up as live / "stuck" cards. Confirmed live on mini: **CTL-1246, CTL-1249, CTL-774** (all Linear Done, triage-done-only, skipped with reason `in-flight`).

## Root cause (verified two ways)

`classifyTerminalSignalGc` skipped any `inFlight` candidate. `ctx.inFlight` comes from `listInFlightTickets → isTicketInFlight`, which treats a `done` on **any non-terminal phase** (triage ≠ `TERMINAL_PHASE` = `teardown`) as still mid-pipeline. So a triage-done-only dir reads in-flight *forever*, even when Linear says Done. The competing "uncached probe returns null" theory was **refuted** — the live probe returns Done, so the dir *is* a candidate; the inFlight gate is what skips it.

Confirmed by (1) a 6-agent root-cause workflow and (2) direct live inspection on mini (`phase-triage.status=done`, live `linearis` read returns Done).

## Fix

All changes live in the J4 census/classifier — `isTicketInFlight`'s slot-accounting semantics are intentionally left untouched (CTL-565):

1. **`classifyTerminalSignalGc`**: only honor `inFlight` for NON-terminal tickets (`ctx.inFlight && !ctx.linearTerminalOrMerged`). A terminal ticket has no legitimately-advancing worker; the live-worker fence is `liveSessionInWorktree`, checked first.
2. **Wire `resolveWorktreePath`** into the J4 census (mirror unstuck-sweep). It was omitted → `liveSessionInWorktree` was always false. Now load-bearing: the only thing protecting a genuinely-running late-phase worker (e.g. teardown, cwd in its worktree per CTL-1105) once `inFlight` is relaxed.
3. **Freshness gate (`agentsFresh`)**: `liveSessionInWorktree` reads the agents snapshot, which is `[]` on cold start / stale after a failed `claude agents --json` refresh. Since it's now the sole live-worker fence, the census collects **no candidates when the snapshot isn't fresh** — defer the reap rather than reap blind on a daemon-boot tick (mirrors the CTL-731 new-work gate). *Found by adversarial review; this is what makes the fix safe at `enforce` (mini runs J4 in enforce).*
4. **3-tier probe** `fetchTicketState(id, {cache, gateway})` to match the J3/unstuck/reclaim censuses (the comment already claimed "cache-first"; the code wasn't) — stops a per-terminal-dir `linearis` read every tick.

## Tests

81 pass (`bun test stall-janitor.test.mjs`), daemon builds clean. New/updated: classifier contract, J4-enforce integration, census→classifier repro of the triage-done case, and the `agentsFresh` gate. Pre-existing unrelated scheduler-suite failures (CTL-558/653/781/826) are identical on `origin/main`.

## Verification plan

3 fixture dirs (CTL-1246/1249/774) are left in place on mini. After deploy + daemon restart they must be reaped (the live close-the-loop test).

## Context

Supersedes the J4 half of the orphaned **CTL-1311** — that ticket was closed Done by an unrelated board-crash hotfix (#2322) that reused its branch name. Phantom-reaper "part 2" is filed as **CTL-1316**.

🤖 Root cause + adversarial verification via dynamic multi-agent workflows.
