### PR TITLE
feat(dev): CTL-1320 — Rulebook redesign v1 (calm prose textbook + PerspectiveToggle)

### DIFF
--- a/plugins/dev/scripts/execution-core/beliefs/compiler/manifest.mjs
+++ b/plugins/dev/scripts/execution-core/beliefs/compiler/manifest.mjs
@@ -36,13 +36,18 @@ import { fileURLToPath } from "node:url";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
+// CTL-1320: each stratum carries a PLAIN-LANGUAGE layer (plain_headline +
+// plain_body) that leads in the Rulebook UI, with the technical `label`/`prose`
+// demoted to subtext. Single source of truth for the surface copy — the ladder
+// and the section headings both read these, so the wording never drifts and the
+// embedded "S{id}" prefix is printed exactly once (from `id`, not the label).
 const STRATA_META = [
-  { id: 1, label: "S1 ground correlations",           prose: "Read obs_* EDB only; establish per-phase session, turn, heartbeat, and job-state correlations." },
-  { id: 2, label: "S2 liveness verdicts",             prose: "Stratified negation over S1 beliefs; derive lease validity, expiry, wedge detection, and board-drift." },
-  { id: 3, label: "S3 capacity aggregation",          prose: "Aggregate over S2 lease_valid beliefs and obs_agent to compute free_slots per host." },
-  { id: 4, label: "S4 escalation ladder",             prose: "Negation over intent table; fire diagnostician wake-up, detect action_ineffective, escalate to human." },
-  { id: 5, label: "S5 recursive dependency beliefs",  prose: "Transitive blocker closure (WITH RECURSIVE); derive blocker_rank, cycle_detected, and ready." },
-  { id: 6, label: "S6 FSM advancement prediction",    prose: "Derive advance_to and cycle_exhausted from obs_signal/obs_verdict/obs_cycle; no negation over beliefs." },
+  { id: 1, label: "S1 ground correlations",           plain_headline: "What we directly observe to be true",  plain_body: "The ground floor — raw facts, lined up per worker. No judgment yet.",        prose: "Read obs_* EDB only; establish per-phase session, turn, heartbeat, and job-state correlations." },
+  { id: 2, label: "S2 liveness verdicts",             plain_headline: "Who is alive, and who is wedged",       plain_body: "Where 'running' becomes 'alive' or 'wedged'.",                                prose: "Stratified negation over S1 beliefs; derive lease validity, expiry, wedge detection, and board-drift." },
+  { id: 3, label: "S3 capacity aggregation",          plain_headline: "How much capacity is free",             plain_body: "A headcount of free slots per host.",                                        prose: "Aggregate over S2 lease_valid beliefs and obs_agent to compute free_slots per host." },
+  { id: 4, label: "S4 escalation ladder",             plain_headline: "When it's time to get a human",         plain_body: "The escalation ladder — cheaper moves first, raise a hand last.",             prose: "Negation over intent table; fire diagnostician wake-up, detect action_ineffective, escalate to human." },
+  { id: 5, label: "S5 recursive dependency beliefs",  plain_headline: "What is blocked by what",               plain_body: "Follows the blocker chain; flags loops that can't resolve.",                  prose: "Transitive blocker closure (WITH RECURSIVE); derive blocker_rank, cycle_detected, and ready." },
+  { id: 6, label: "S6 FSM advancement prediction",    plain_headline: "What happens next",                     plain_body: "Predicts where each worker advances, spots exhausted cycles.",                prose: "Derive advance_to and cycle_exhausted from obs_signal/obs_verdict/obs_cycle; no negation over beliefs." },
 ];
 
 const PREFACE = Object.freeze({

--- a/plugins/dev/scripts/execution-core/beliefs/rules.generated.mjs
+++ b/plugins/dev/scripts/execution-core/beliefs/rules.generated.mjs
@@ -466,31 +466,43 @@ export const RULE_MANIFEST = _deepFreeze({
     {
       "id": 1,
       "label": "S1 ground correlations",
+      "plain_headline": "What we directly observe to be true",
+      "plain_body": "The ground floor — raw facts, lined up per worker. No judgment yet.",
       "prose": "Read obs_* EDB only; establish per-phase session, turn, heartbeat, and job-state correlations."
     },
     {
       "id": 2,
       "label": "S2 liveness verdicts",
+      "plain_headline": "Who is alive, and who is wedged",
+      "plain_body": "Where 'running' becomes 'alive' or 'wedged'.",
       "prose": "Stratified negation over S1 beliefs; derive lease validity, expiry, wedge detection, and board-drift."
     },
     {
       "id": 3,
       "label": "S3 capacity aggregation",
+      "plain_headline": "How much capacity is free",
+      "plain_body": "A headcount of free slots per host.",
       "prose": "Aggregate over S2 lease_valid beliefs and obs_agent to compute free_slots per host."
     },
     {
       "id": 4,
       "label": "S4 escalation ladder",
+      "plain_headline": "When it's time to get a human",
+      "plain_body": "The escalation ladder — cheaper moves first, raise a hand last.",
       "prose": "Negation over intent table; fire diagnostician wake-up, detect action_ineffective, escalate to human."
     },
     {
       "id": 5,
       "label": "S5 recursive dependency beliefs",
+      "plain_headline": "What is blocked by what",
+      "plain_body": "Follows the blocker chain; flags loops that can't resolve.",
       "prose": "Transitive blocker closure (WITH RECURSIVE); derive blocker_rank, cycle_detected, and ready."
     },
     {
       "id": 6,
       "label": "S6 FSM advancement prediction",
+      "plain_headline": "What happens next",
+      "plain_body": "Predicts where each worker advances, spots exhausted cycles.",
       "prose": "Derive advance_to and cycle_exhausted from obs_signal/obs_verdict/obs_cycle; no negation over beliefs."
     }
   ],

--- a/plugins/dev/scripts/orch-monitor/ui/src/components/rulebook/perspective-toggle.tsx
+++ b/plugins/dev/scripts/orch-monitor/ui/src/components/rulebook/perspective-toggle.tsx
@@ -1,0 +1,53 @@
+// perspective-toggle.tsx — CTL-1320: ONE hoisted control that switches every rule
+// card between Plain English | Datalog | SQL. This replaces the 17 repeating
+// per-card tab strips (the "nested chrome" the operator flagged): switch once and
+// all cards follow, with cross-visit memory (atomWithStorage). The Datalog/SQL
+// triggers are muted to keep the jargon demoted by default.
+import { atomWithStorage } from "jotai/utils";
+import { useAtom } from "jotai";
+import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group";
+
+export type Perspective = "english" | "datalog" | "sql";
+
+/** The active per-rule perspective, shared by every RuleCard. Persisted so a
+ *  chosen lens (e.g. an engineer who lives in Datalog) survives a reload. */
+export const perspectiveAtom = atomWithStorage<Perspective>(
+  "rulebook-perspective",
+  "english",
+);
+
+export function PerspectiveToggle() {
+  const [perspective, setPerspective] = useAtom(perspectiveAtom);
+  return (
+    <div className="sticky top-0 z-10 -mx-6 mb-2 flex items-center gap-3 border-b bg-background/80 px-6 py-2.5 backdrop-blur">
+      <span className="text-xs text-muted-foreground">Show each rule as</span>
+      <ToggleGroup
+        type="single"
+        size="sm"
+        value={perspective}
+        // A single-select toggle can return "" when the active item is re-clicked;
+        // ignore that so a lens is always selected.
+        onValueChange={(v) => v && setPerspective(v as Perspective)}
+      >
+        <ToggleGroupItem value="english" className="px-3 text-xs">
+          Plain English
+        </ToggleGroupItem>
+        <ToggleGroupItem
+          value="datalog"
+          className="px-3 text-xs text-muted-foreground data-[state=on]:text-foreground"
+        >
+          Datalog
+        </ToggleGroupItem>
+        <ToggleGroupItem
+          value="sql"
+          className="px-3 text-xs text-muted-foreground data-[state=on]:text-foreground"
+        >
+          SQL
+        </ToggleGroupItem>
+      </ToggleGroup>
+      <span className="ml-auto hidden text-xs text-muted-foreground/60 sm:inline">
+        switch once — all rules follow
+      </span>
+    </div>
+  );
+}

--- a/plugins/dev/scripts/orch-monitor/ui/src/components/rulebook/preface-section.tsx
+++ b/plugins/dev/scripts/orch-monitor/ui/src/components/rulebook/preface-section.tsx
@@ -1,19 +1,59 @@
-// preface-section.tsx — CTL-1103 Phase 3: renders the Rulebook's opening card.
+// preface-section.tsx — CTL-1320: the Rulebook opening, reframed.
+// Lead with plain, approachable prose (no card, capped measure); the daemon's
+// terms of art are italicized inline, never headlined. The dense Datalog primer
+// is tucked into a closed-by-default Collapsible so a newcomer is not met by a
+// wall of text. The reframed "why" is the surface's editorial voice; the engine's
+// canonical preface.problem stays in the manifest for API consumers.
 import type { Preface } from "@/lib/rulebook-model";
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from "@/components/ui/collapsible";
+import { ChevronRight } from "lucide-react";
 
 export function PrefaceSection({ preface }: { preface: Preface }) {
   return (
-    <div className="mb-6 rounded-lg border bg-card p-6 space-y-4">
-      <h2 className="text-base font-semibold">Why does this engine exist?</h2>
-      <p className="text-sm leading-relaxed text-foreground">{preface.problem}</p>
-      <div className="border-t pt-4">
-        <p className="mb-1 text-xs font-medium uppercase tracking-wide text-muted-foreground">
-          Datalog primer
+    <section className="mb-8">
+      <h2 className="text-base font-semibold mb-2">Why this engine exists</h2>
+      <div className="space-y-3 text-[15px] leading-7 text-foreground/90">
+        <p>
+          Every few seconds, the daemon has to answer one question on its own:
+          who&apos;s actually working, and who only looks like they are? A worker
+          can be running but stuck (<em>stalled-alive</em>), checked in but never
+          actually start (<em>never-started wedge</em>), or busily producing output
+          against a board that no longer matches Linear (<em>board drift</em>).
         </p>
-        <p className="text-sm leading-relaxed text-muted-foreground">
-          {preface.datalog_primer}
+        <p>
+          This engine is that reasoning. It starts from plain observations —
+          heartbeats, turns, job states — and walks them up until it reaches a
+          verdict: alive, wedged, retry, or get-a-human. Nothing is a black box:
+          open any belief and trace which facts triggered which rule.
+        </p>
+        <p className="text-muted-foreground">
+          The engine reasons in layers — each rule turns facts it already trusts
+          into a new, named belief. That layering (its <em>strata</em>) keeps the
+          logic ordered and every conclusion traceable.
         </p>
       </div>
-    </div>
+
+      <Collapsible className="mt-5 rounded-lg border bg-card/40">
+        <CollapsibleTrigger className="group flex w-full items-center gap-2 px-4 py-3 text-sm">
+          <ChevronRight className="size-4 text-muted-foreground transition-transform group-data-[state=open]:rotate-90" />
+          <span>
+            How the rules work{" "}
+            <span className="text-muted-foreground">(the Datalog model)</span>
+          </span>
+          <span className="ml-auto font-mono text-xs text-muted-foreground/70">
+            17 rules · rules.dl
+          </span>
+        </CollapsibleTrigger>
+        <CollapsibleContent>
+          <p className="px-4 pb-4 text-sm leading-relaxed text-muted-foreground">
+            {preface.datalog_primer}
+          </p>
+        </CollapsibleContent>
+      </Collapsible>
+    </section>
   );
 }

--- a/plugins/dev/scripts/orch-monitor/ui/src/components/rulebook/rule-card.tsx
+++ b/plugins/dev/scripts/orch-monitor/ui/src/components/rulebook/rule-card.tsx
@@ -1,36 +1,42 @@
-// rule-card.tsx — CTL-1103 Phase 3+5: tri-lingual card (Plain English | Datalog | SQL).
-// Border color uses strataTone() CSS variable; severity chip uses severityTone()
-// CSS class; both are distinct from liveIndicatorTone() (Phase 5 contract).
-import { useState } from "react";
+// rule-card.tsx — CTL-1103 / CTL-1320: one rule, shown in the perspective chosen
+// by the single hoisted PerspectiveToggle (Plain English | Datalog | SQL). The
+// per-card Tabs strip is gone — all 17 cards render the same lens, driven by
+// perspectiveAtom — so the page reads as a calm column, not 17 repeating toolbars.
+// The stratum-colored left accent is a thin tick, not a heavy 4px bar.
+import type { ReactNode } from "react";
+import { useAtomValue } from "jotai";
 import { cn } from "@/lib/utils";
 import { Badge } from "@/components/ui/badge";
-import {
-  Tabs,
-  TabsList,
-  TabsTrigger,
-  TabsContent,
-} from "@/components/ui/tabs";
 import { ruleCardTabs } from "./rule-card-model";
 import { severityTone } from "@/lib/rulebook-model";
 import { stratumColorForId } from "./strata-ladder";
+import { perspectiveAtom } from "./perspective-toggle";
 import type { RuleManifestRule } from "@/lib/rulebook-model";
+
+function CodeBlock({ content }: { content: string | null }) {
+  return (
+    <pre className="rounded bg-muted px-3 py-2 text-[11px] font-mono leading-relaxed overflow-x-auto whitespace-pre-wrap">
+      {content}
+    </pre>
+  );
+}
 
 export function RuleCard({
   rule,
   liveSlot,
 }: {
   rule: RuleManifestRule;
-  liveSlot?: React.ReactNode;
+  liveSlot?: ReactNode;
 }) {
-  const [tab, setTab] = useState<string>("english");
-  const tabs = ruleCardTabs(rule);
+  const perspective = useAtomValue(perspectiveAtom);
+  const tabs = ruleCardTabs(rule); // [Plain English, Datalog, SQL]
   const sevClass = severityTone(rule.severity);
   const stratumColor = stratumColorForId(rule.stratum); // CSS var e.g. "var(--chart-1)"
 
   return (
     <div
       id={`rule-${rule.rule_id}`}
-      className={cn("rounded-lg border bg-card mb-4 overflow-hidden border-l-4")}
+      className={cn("rounded-lg border bg-card mb-3 overflow-hidden border-l-2")}
       style={{ borderLeftColor: stratumColor }}
     >
       {/* Header */}
@@ -85,45 +91,26 @@ export function RuleCard({
         {liveSlot && <div className="shrink-0">{liveSlot}</div>}
       </div>
 
-      {/* Tri-lingual tabs */}
-      <Tabs value={tab} onValueChange={setTab} className="px-4 pb-3">
-        <TabsList className="h-7 mb-2">
-          <TabsTrigger value="english" className="text-[11px] px-2">
-            Plain English
-          </TabsTrigger>
-          <TabsTrigger value="datalog" className="text-[11px] px-2">
-            Datalog
-          </TabsTrigger>
-          <TabsTrigger value="sql" className="text-[11px] px-2">
-            SQL
-          </TabsTrigger>
-        </TabsList>
-
-        <TabsContent value="english" className="mt-0">
+      {/* Body — the single active perspective (driven by the hoisted toggle) */}
+      <div className="px-4 pb-3">
+        {perspective === "english" && (
           <p className="text-sm leading-relaxed text-foreground">
             {tabs[0].content ?? "No description available."}
           </p>
-        </TabsContent>
-
-        <TabsContent value="datalog" className="mt-0">
-          {tabs[1].isExtern ? (
+        )}
+        {perspective === "datalog" &&
+          (tabs[1].isExtern ? (
             <p className="text-xs text-muted-foreground italic">
               This rule embeds hand-authored SQL (an <em>extern</em> block) — no
               Datalog source is compiled for it.
             </p>
           ) : (
-            <pre className="rounded bg-muted px-3 py-2 text-[11px] font-mono leading-relaxed overflow-x-auto whitespace-pre-wrap">
-              {tabs[1].content}
-            </pre>
-          )}
-        </TabsContent>
-
-        <TabsContent value="sql" className="mt-0">
-          <pre className="rounded bg-muted px-3 py-2 text-[11px] font-mono leading-relaxed overflow-x-auto whitespace-pre-wrap">
-            {tabs[2].content ?? "-- SQL unavailable"}
-          </pre>
-        </TabsContent>
-      </Tabs>
+            <CodeBlock content={tabs[1].content} />
+          ))}
+        {perspective === "sql" && (
+          <CodeBlock content={tabs[2].content ?? "-- SQL unavailable"} />
+        )}
+      </div>
     </div>
   );
 }

--- a/plugins/dev/scripts/orch-monitor/ui/src/components/rulebook/rulebook-surface.tsx
+++ b/plugins/dev/scripts/orch-monitor/ui/src/components/rulebook/rulebook-surface.tsx
@@ -1,7 +1,8 @@
-// rulebook-surface.tsx — CTL-1103 Phase 3+4: full static textbook + live margins.
-// Renders preface → strata ladder → per-stratum rule cards → thresholds.
-// Live firing counts come from useBeliefsContext() (the already-open shared SSE
-// — zero new EventSources, SSE dedup contract CTL-945).
+// rulebook-surface.tsx — CTL-1103 / CTL-1320: the Belief Engine Rulebook as a
+// calm prose textbook. One capped reading column: plain "why" → ladder of
+// reasoning → per-stratum rule sections (one hoisted perspective toggle) →
+// collapsed thresholds. Live firing counts come from useBeliefsContext() (the
+// already-open shared SSE — zero new EventSources, SSE dedup contract CTL-945).
 import { useEffect, useState } from "react";
 import { useBeliefsContext } from "@/hooks/use-beliefs";
 import {
@@ -12,62 +13,52 @@ import {
 } from "@/lib/rulebook-model";
 import { countFiringByRule, subjectsForRule } from "@/lib/rulebook-live";
 import { PrefaceSection } from "./preface-section";
-import { StrataLadder, stratumColorForId } from "./strata-ladder";
+import { LadderOfReasoning } from "./strata-ladder";
+import { PerspectiveToggle } from "./perspective-toggle";
 import { RuleCard } from "./rule-card";
 import { LiveIndicator } from "./live-indicator";
 import { DerivationsRail } from "./derivations-rail";
 import { ThresholdsAppendix } from "./thresholds-appendix";
-import { cn } from "@/lib/utils";
+import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group";
 import type { RuleManifestRule } from "@/lib/rulebook-model";
+
+/** "S1 ground correlations" → "ground correlations" (the redundant number prefix
+ *  is rendered once, from the id, in the heading — never doubled). */
+function techLabel(label: string): string {
+  return label.replace(/^S\d+\s+/, "");
+}
 
 function StratumSection({
   group,
   firingCounts,
-  selectedRuleId,
   onSelectRule,
 }: {
   group: StratumGroup;
   firingCounts: Map<string, number>;
-  selectedRuleId: string | null;
   onSelectRule: (id: string) => void;
 }) {
-  const color = stratumColorForId(group.stratum.id); // CSS var e.g. "var(--chart-1)"
   return (
-    <section id={`stratum-${group.stratum.id}`} className="mb-8">
-      <div
-        className={cn("flex items-baseline gap-2 mb-3 pb-2 border-b-2")}
-        style={{ borderBottomColor: color }}
-      >
-        <span className="font-mono text-xs text-muted-foreground">
-          S{group.stratum.id}
-        </span>
-        <h3 className="text-sm font-semibold">{group.stratum.label}</h3>
-        <span className="text-xs text-muted-foreground hidden sm:inline">
-          — {group.stratum.prose}
-        </span>
-      </div>
+    <section id={`stratum-${group.stratum.id}`} className="pt-8 scroll-mt-4">
+      {/* The number appears exactly once, leading the plain headline. */}
+      <h2 className="text-lg font-semibold">
+        {group.stratum.id} · {group.stratum.plain_headline}
+      </h2>
+      <p className="mt-0.5 mb-4 font-mono text-xs text-muted-foreground/70">
+        {techLabel(group.stratum.label)} · {group.stratum.prose}
+      </p>
       {group.rules.map((rule) => {
         const count = firingCounts.get(rule.rule_id) ?? 0;
-        // CTL-1103 remediate: selection is scoped to the LiveIndicator badge (the
-        // dedicated header affordance) rather than wrapping the whole card in a
-        // <button>. That wrapper nested the card's Tabs buttons + feed/cfg anchors
-        // inside a button (invalid HTML) and let tab/anchor clicks bubble out as
-        // unintended rule selections. The badge only renders when count > 0, so
-        // selection stays gated on a firing rule exactly as before.
         return (
-          <div key={rule.rule_id}>
-            <RuleCard
-              rule={rule}
-              liveSlot={
-                <LiveIndicator
-                  count={count}
-                  onSelect={
-                    count > 0 ? () => onSelectRule(rule.rule_id) : undefined
-                  }
-                />
-              }
-            />
-          </div>
+          <RuleCard
+            key={rule.rule_id}
+            rule={rule}
+            liveSlot={
+              <LiveIndicator
+                count={count}
+                onSelect={count > 0 ? () => onSelectRule(rule.rule_id) : undefined}
+              />
+            }
+          />
         );
       })}
     </section>
@@ -119,30 +110,50 @@ export function RulebookSurface() {
 
   return (
     <div className="flex flex-1 overflow-hidden">
-      {/* Main textbook column */}
+      {/* Main reading column — capped measure, centered, calm. */}
       <div className="flex-1 overflow-y-auto">
-        <div className="mx-auto max-w-3xl px-6 py-6">
-          <div className="mb-6">
-            <h1 className="text-xl font-bold">Belief Engine Rulebook</h1>
-            <p className="text-sm text-muted-foreground mt-1">
-              17 rules · 6 strata · compiled from{" "}
-              <span className="font-mono">beliefs/rules.dl</span>
+        <div className="mx-auto max-w-[72ch] px-6 py-10">
+          <header className="mb-7">
+            <h1 className="text-2xl font-bold tracking-tight">
+              Belief Engine Rulebook
+            </h1>
+            <p className="mt-1 text-sm text-muted-foreground">
+              How the daemon decides who&apos;s working, who&apos;s wedged, and when
+              to call a human.
             </p>
-          </div>
+            {/* CTL-1320: Read / Map mode switch. The React Flow strata map is a
+                deferred fast-follow (?view=map) — Map is disabled until it lands. */}
+            <div className="mt-4">
+              <ToggleGroup type="single" size="sm" value="read">
+                <ToggleGroupItem value="read" className="px-3 text-xs">
+                  Read
+                </ToggleGroupItem>
+                <ToggleGroupItem
+                  value="map"
+                  disabled
+                  title="Strata map — coming soon"
+                  className="px-3 text-xs"
+                >
+                  Map
+                </ToggleGroupItem>
+              </ToggleGroup>
+            </div>
+          </header>
 
           {manifest === null ? (
             <LoadingSkeleton />
           ) : (
             <>
               <PrefaceSection preface={manifest.preface} />
-              <StrataLadder groups={groups} />
+              <LadderOfReasoning groups={groups} />
+
+              <PerspectiveToggle />
 
               {groups.map((group) => (
                 <StratumSection
                   key={group.stratum.id}
                   group={group}
                   firingCounts={firingCounts}
-                  selectedRuleId={selectedRuleId}
                   onSelectRule={setSelectedRuleId}
                 />
               ))}

--- a/plugins/dev/scripts/orch-monitor/ui/src/components/rulebook/strata-ladder.tsx
+++ b/plugins/dev/scripts/orch-monitor/ui/src/components/rulebook/strata-ladder.tsx
@@ -1,6 +1,9 @@
-// strata-ladder.tsx — CTL-1103 Phase 3+5: vertical ladder of the 6 belief strata.
-// Uses strataTone() from rulebook-theme.ts (--chart-N tokens; distinct from
-// severity and live-indicator per Phase 5 contract).
+// strata-ladder.tsx — CTL-1320: "The ladder of reasoning".
+// The six belief strata as a quiet, scannable ladder rather than peer cards:
+// the PLAIN headline leads, the technical label is demoted to muted subtext, and
+// the stratum NUMBER is rendered exactly once (the dot on the connector spine —
+// the old design printed it twice because the label already embeds "S{id}").
+// A left spine, tinted strataTone(id), reads bottom-to-top: facts rise to decisions.
 import type { StratumGroup } from "@/lib/rulebook-model";
 import { strataTone } from "@/lib/rulebook-theme";
 
@@ -9,38 +12,63 @@ export function stratumColorForId(id: number): string {
   return strataTone(id);
 }
 
-export function StrataLadder({ groups }: { groups: StratumGroup[] }) {
+/** "S1 ground correlations" → "ground correlations" — the technical label with its
+ *  redundant stratum-number prefix stripped (belt-and-suspenders; STRATA_META now
+ *  also leads with plain_headline so this only formats the subtext). */
+function techLabel(label: string): string {
+  return label.replace(/^S\d+\s+/, "");
+}
+
+/** First clause of the technical prose — a short implementation hint for the subtext. */
+function techHint(prose: string): string {
+  return prose.split(/[;.]/)[0]?.trim() ?? "";
+}
+
+export function LadderOfReasoning({ groups }: { groups: StratumGroup[] }) {
   return (
-    <div className="mb-6 rounded-lg border bg-card p-4">
-      <p className="mb-3 text-xs font-medium uppercase tracking-wide text-muted-foreground">
-        Strata
+    <section className="mb-12">
+      <h2 className="text-base font-semibold">The ladder of reasoning</h2>
+      <p className="mt-1 mb-5 text-sm text-muted-foreground">
+        Facts enter at the bottom and rise into decisions. Six layers, 17 rules.
       </p>
-      <ol className="space-y-2">
+
+      <ol className="relative">
+        {/* the spine */}
+        <span
+          aria-hidden
+          className="pointer-events-none absolute left-[11px] top-3 bottom-3 w-px bg-border"
+        />
         {groups.map((g) => {
           const color = strataTone(g.stratum.id);
+          const n = g.rules.length;
           return (
             <li key={g.stratum.id}>
               <a
                 href={`#stratum-${g.stratum.id}`}
-                className="flex items-start gap-3 rounded-md px-3 py-2 text-sm hover:bg-muted/50 transition-colors border-l-2"
-                style={{ borderLeftColor: color, color }}
+                className="group relative block rounded-lg py-2.5 pl-9 pr-3 -ml-2 hover:bg-foreground/[0.025] transition-colors"
               >
-                <span className="shrink-0 font-mono text-xs font-semibold mt-0.5">
-                  S{g.stratum.id}
+                <span
+                  aria-hidden
+                  className="absolute left-[3px] top-3.5 grid size-[18px] place-items-center rounded-full text-[10px] font-semibold text-background"
+                  style={{ backgroundColor: color }}
+                >
+                  {g.stratum.id}
                 </span>
-                <span>
-                  <span className="font-medium" style={{ color }}>
-                    {g.stratum.label}
-                  </span>
-                  <span className="ml-2 text-muted-foreground">
-                    {g.stratum.prose}
-                  </span>
-                </span>
+                <div className="font-medium text-[15px] text-foreground">
+                  {g.stratum.plain_headline}
+                </div>
+                <div className="text-sm text-muted-foreground">
+                  {g.stratum.plain_body}
+                </div>
+                <div className="mt-0.5 font-mono text-xs text-muted-foreground/60">
+                  {techLabel(g.stratum.label)} · {techHint(g.stratum.prose)} · {n}{" "}
+                  {n === 1 ? "rule" : "rules"}
+                </div>
               </a>
             </li>
           );
         })}
       </ol>
-    </div>
+    </section>
   );
 }

--- a/plugins/dev/scripts/orch-monitor/ui/src/components/rulebook/thresholds-appendix.tsx
+++ b/plugins/dev/scripts/orch-monitor/ui/src/components/rulebook/thresholds-appendix.tsx
@@ -1,6 +1,13 @@
-// thresholds-appendix.tsx — CTL-1103 Phase 3: fetches /api/beliefs/cfg and
-// renders the threshold key/value table. Degrades quietly on fetch failure.
+// thresholds-appendix.tsx — CTL-1103 / CTL-1320: the tunable cfg thresholds, now
+// in a closed-by-default Collapsible so the reading column stays calm (the table
+// is reference material, not part of the narrative). Degrades quietly on failure.
 import { useEffect, useState } from "react";
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from "@/components/ui/collapsible";
+import { ChevronRight } from "lucide-react";
 
 interface CfgRow {
   key: string;
@@ -23,54 +30,66 @@ export function ThresholdsAppendix() {
         if (!r.ok) throw new Error(`${r.status}`);
         // CTL-1317: the server returns { rows } (server.ts /api/beliefs/cfg), NOT
         // { cfg }. Reading the wrong key set rows = undefined, which slipped past
-        // the `rows === null` guard below and crashed on rows.length (#185-adjacent
-        // TypeError on every /rules visit). Read `rows`, and fall back to [] so a
-        // future shape drift degrades to "no thresholds" instead of crashing.
+        // the `rows == null` guard below and crashed on rows.length. Read `rows`,
+        // and fall back to [] so a future shape drift degrades to "no thresholds".
         return r.json() as Promise<{ rows?: CfgRow[] }>;
       })
       .then((d) => setRows(d.rows ?? []))
       .catch(() => setUnavailable(true));
   }, []);
 
+  const count = rows?.length ?? null;
+
   return (
-    <div id="thresholds" className="mt-8 rounded-lg border bg-card p-4">
-      <p className="mb-3 text-xs font-medium uppercase tracking-wide text-muted-foreground">
-        Thresholds (cfg)
-      </p>
-      {unavailable ? (
-        <p className="text-xs text-muted-foreground">Thresholds unavailable.</p>
-      ) : rows == null ? (
-        <p className="text-xs text-muted-foreground">Loading…</p>
-      ) : rows.length === 0 ? (
-        <p className="text-xs text-muted-foreground">No thresholds configured.</p>
-      ) : (
-        <table className="w-full text-sm">
-          <thead>
-            <tr className="border-b">
-              <th className="pb-2 text-left font-medium text-muted-foreground text-xs">
-                Key
-              </th>
-              <th className="pb-2 text-right font-medium text-muted-foreground text-xs">
-                Value
-              </th>
-            </tr>
-          </thead>
-          <tbody>
-            {rows.map((row) => (
-              <tr
-                key={row.key}
-                id={`cfg-${row.key}`}
-                className="border-b last:border-0"
-              >
-                <td className="py-1.5 font-mono text-xs">{row.key}</td>
-                <td className="py-1.5 text-right">
-                  <CfgValue row={row} />
-                </td>
-              </tr>
-            ))}
-          </tbody>
-        </table>
-      )}
-    </div>
+    <Collapsible id="thresholds" className="mt-10 rounded-lg border bg-card/40">
+      <CollapsibleTrigger className="group flex w-full items-center gap-2 px-4 py-3 text-sm">
+        <ChevronRight className="size-4 text-muted-foreground transition-transform group-data-[state=open]:rotate-90" />
+        <span>
+          Thresholds{" "}
+          <span className="text-muted-foreground">(the tunable numbers)</span>
+        </span>
+        <span className="ml-auto font-mono text-xs text-muted-foreground/70">
+          cfg{count != null ? ` · ${count} keys` : ""}
+        </span>
+      </CollapsibleTrigger>
+      <CollapsibleContent>
+        <div className="px-4 pb-4">
+          {unavailable ? (
+            <p className="text-xs text-muted-foreground">Thresholds unavailable.</p>
+          ) : rows == null ? (
+            <p className="text-xs text-muted-foreground">Loading…</p>
+          ) : rows.length === 0 ? (
+            <p className="text-xs text-muted-foreground">No thresholds configured.</p>
+          ) : (
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="border-b">
+                  <th className="pb-2 text-left font-medium text-muted-foreground text-xs">
+                    Key
+                  </th>
+                  <th className="pb-2 text-right font-medium text-muted-foreground text-xs">
+                    Value
+                  </th>
+                </tr>
+              </thead>
+              <tbody>
+                {rows.map((row) => (
+                  <tr
+                    key={row.key}
+                    id={`cfg-${row.key}`}
+                    className="border-b last:border-0"
+                  >
+                    <td className="py-1.5 font-mono text-xs">{row.key}</td>
+                    <td className="py-1.5 text-right">
+                      <CfgValue row={row} />
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          )}
+        </div>
+      </CollapsibleContent>
+    </Collapsible>
   );
 }

--- a/plugins/dev/scripts/orch-monitor/ui/src/lib/rulebook-model.ts
+++ b/plugins/dev/scripts/orch-monitor/ui/src/lib/rulebook-model.ts
@@ -16,6 +16,11 @@ export interface RuleManifestStratum {
   id: number;
   label: string;
   prose: string;
+  /** CTL-1320: plain-language layer that LEADS in the UI (the technical `label`/
+   *  `prose` are demoted to subtext). Sourced from STRATA_META, so the ladder and
+   *  the section headings read one source and the "S{id}" prefix is never doubled. */
+  plain_headline: string;
+  plain_body: string;
 }
 
 export interface RuleManifestRule {


### PR DESCRIPTION
Reworks `/rules` from a card-heavy, jargon-first wall into a **calm prose textbook** (the house Linear-calm reading-surface principle). Mockup approved by Ryan; full spec: `thoughts/shared/plans/2026-06-22-rulebook-redesign-spec.md`.

## What changed
- **Lead with plain prose** — reframed "Why this engine exists" (terms of art italicized, never headlined) + a teaser that **defines "stratum" before the word appears**. The dense Datalog primer is now a **closed Collapsible** (no wall on arrival).
- **Ladder of Reasoning** replaces the strata cards: six plain-language rungs on a tinted connector spine, technical label demoted to muted subtext, and the stratum **number rendered exactly once** — fixes the **"S1" doubling** (the label already embeds `S1`, and the code also printed `S{id}`, in *both* the ladder and the section headings). The naked "Strata" eyebrow is gone.
- **One hoisted `PerspectiveToggle`** (Plain English | Datalog | SQL, jotai-persisted) drives all 17 rule cards — replacing the 17 repeating per-card Tabs strips (the "nested chrome"). Rule cards lose the heavy 4px accent for a thin tick.
- **72ch reading column**; thresholds appendix **collapsed**; Read/Map mode pill (Map disabled — the React Flow strata map is a deferred `?view=map` fast-follow).

## Single-sourced copy
`STRATA_META` (`compiler/manifest.mjs`) gains `plain_headline` + `plain_body`; `rules.generated.mjs` regenerated (**manifest-only diff — executable SQL byte-identical**); `RuleManifestStratum` extended.

## Validation
Typecheck clean; **41 rulebook + 8 manifest-contract + 470 beliefs** tests pass. (2 full-suite fails are pre-existing env flakes — nav-signal + SSE-stream — both pass/identical off-branch.)

_(CTL-1320 is a forward-ref; Linear was rate-limited at commit time — ticket to be created/reconciled.)_