### PR TITLE
fix(dev): CTL-1321 — exec-core boots accepting work by default (clear stale drain flag on boot)

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -335,6 +335,7 @@ hand.
 | `NODE_USE_ENV_PROXY` | Set to `1` to make Node's native `fetch`/undici honor the `*_PROXY` vars. **Required whenever you set a proxy** — see rationale below. |
 | `NODE_EXTRA_CA_CERTS` | Absolute path to a CA cert to trust (e.g. `$HOME/.mitmproxy/mitmproxy-ca-cert.pem`) so a MITM proxy's intercepted TLS validates. |
 | `LINEAR_STATE_CACHE_TTL_MS` | Widen the daemon's in-process Linear workflow-state cache window (milliseconds) to cut per-ticket read volume. Independent of the proxy. |
+| `CATALYST_BOOT_DRAINED` | Set to the literal `1` to boot this node **drained** (heartbeats normally, admits no new work) — for a deliberately parked laptop/debug host. Default (unset or any other value): the daemon clears any leftover `drain` flag on boot so a restart resumes accepting work (CTL-1321). Honored only on `catalyst-execution-core start`/`restart`, which sources this file. |
 
 ### Debugging Linear API rate-limiting (mitmproxy — opt-in, default OFF)
 

--- a/plugins/dev/scripts/execution-core/config.mjs
+++ b/plugins/dev/scripts/execution-core/config.mjs
@@ -8,7 +8,7 @@
 
 import { homedir, hostname } from "node:os";
 import { resolve, join } from "node:path";
-import { readFileSync, existsSync } from "node:fs";
+import { readFileSync, existsSync, rmSync, writeFileSync } from "node:fs";
 
 // CTL-1211: schema-version policy for cluster config. config-schema.mjs is a
 // dep-free sibling leaf, so this import cannot reintroduce the bun-install crash
@@ -80,6 +80,43 @@ export function getDrainFlagPath(orchDir) {
 
 export function isDraining(orchDir) {
   return existsSync(getDrainFlagPath(orchDir));
+}
+
+// CTL-1095/CTL-1321: path of the once-per-episode "drained" sentinel marker. The
+// scheduler writes it when a drain episode quiesces (in-flight hits 0) and
+// applyBootDrainPolicy clears it on boot — both go through this one resolver so
+// the two writers can never drift to different filenames (the sentinel was the
+// one drain-family path not previously behind a resolver).
+export function getDrainedMarkerPath(orchDir) {
+  return join(orchDir, "drain.drained");
+}
+
+// CTL-1321: boot drain policy. The `drain` flag is a PERSISTENT file (set by
+// `catalyst-execution-core drain`, cleared only by `drain --off`), so a
+// quiesce→restart otherwise comes back SILENTLY DRAINED — heartbeating healthy
+// while admitting zero new work. On boot we clear the flag (plus the
+// `drain.drained` sentinel a prior drain episode may have left, see
+// scheduler.mjs) so a restart always resumes accepting work. A node deliberately
+// kept out of rotation (laptop/debug) opts in via CATALYST_BOOT_DRAINED=1, which
+// RE-SETS the flag AFTER the clear ("on restart, always set the flag").
+//
+// Scope: this gates only NEW-work admission (the scheduler's `!draining` gate).
+// It does NOT stop boot-resume (CTL-654) from re-adopting already-running
+// in-flight workers — re-adopting a live ticket is not new work. Best-effort and
+// never throws, so a transient fs error cannot abort daemon boot (mirrors
+// writeBootMarker's fail-open contract + setDrain at cli/drain.mjs). `env` is an
+// injectable seam for unit tests; matches the `=== "1"` opt-in idiom used by
+// EXECUTION_CORE_FLEET_SELF_HEAL and the beliefs flags. Returns { drained }.
+export function applyBootDrainPolicy(orchDir, { env = process.env } = {}) {
+  const flag = getDrainFlagPath(orchDir);
+  const drainedMarker = getDrainedMarkerPath(orchDir);
+  try { rmSync(flag, { force: true }); } catch { /* best-effort */ }
+  try { rmSync(drainedMarker, { force: true }); } catch { /* best-effort */ }
+  const drained = env.CATALYST_BOOT_DRAINED === "1";
+  if (drained) {
+    try { writeFileSync(flag, ""); } catch { /* best-effort */ }
+  }
+  return { drained };
 }
 
 export function getEligibleDir() {

--- a/plugins/dev/scripts/execution-core/config.test.mjs
+++ b/plugins/dev/scripts/execution-core/config.test.mjs
@@ -7,7 +7,7 @@
 // Run: cd plugins/dev/scripts/execution-core && bun test config.test.mjs
 
 import { describe, test, expect, beforeEach, afterEach } from "bun:test";
-import { mkdtempSync, writeFileSync, rmSync, mkdirSync } from "node:fs";
+import { mkdtempSync, writeFileSync, rmSync, mkdirSync, existsSync } from "node:fs";
 import { tmpdir, hostname } from "node:os";
 import { join } from "node:path";
 import {
@@ -28,6 +28,8 @@ import {
   hostMembershipWarning,
   getDrainFlagPath,
   isDraining,
+  getDrainedMarkerPath,
+  applyBootDrainPolicy,
   getLivenessAnchorIssue,
   LIVENESS_PUBLISH_INTERVAL_MS,
   getStaticRoster,
@@ -688,6 +690,98 @@ describe("getDrainFlagPath + isDraining (CTL-1095)", () => {
     expect(isDraining(tmp)).toBe(true);
     rmSync(flag);
     expect(isDraining(tmp)).toBe(false);
+  });
+});
+
+// CTL-1321: applyBootDrainPolicy — boot accepting work by default. A prior drain
+// leaves a persistent `drain` flag (+ `drain.drained` sentinel) that survives
+// restart; boot must clear them unless CATALYST_BOOT_DRAINED=1 opts the node out
+// of rotation (re-set the flag AFTER the clear).
+describe("applyBootDrainPolicy (CTL-1321)", () => {
+  let tmp;
+
+  beforeEach(() => {
+    tmp = mkdtempSync(join(tmpdir(), "boot-drain-"));
+  });
+
+  afterEach(() => {
+    rmSync(tmp, { recursive: true, force: true });
+  });
+
+  test("getDrainedMarkerPath joins orchDir/drain.drained (shared with scheduler)", () => {
+    expect(getDrainedMarkerPath("/tmp/ec")).toBe(join("/tmp/ec", "drain.drained"));
+  });
+
+  test("default boot clears a pre-existing drain flag → node accepts work", () => {
+    writeFileSync(getDrainFlagPath(tmp), "");
+    const r = applyBootDrainPolicy(tmp, { env: {} });
+    expect(r.drained).toBe(false);
+    expect(existsSync(getDrainFlagPath(tmp))).toBe(false);
+    expect(isDraining(tmp)).toBe(false);
+  });
+
+  test("default boot also removes the drain.drained sentinel", () => {
+    writeFileSync(getDrainFlagPath(tmp), "");
+    writeFileSync(join(tmp, "drain.drained"), "");
+    applyBootDrainPolicy(tmp, { env: {} });
+    expect(existsSync(getDrainFlagPath(tmp))).toBe(false);
+    expect(existsSync(join(tmp, "drain.drained"))).toBe(false);
+  });
+
+  test("CATALYST_BOOT_DRAINED=1 re-sets the drain flag after the default clear", () => {
+    // Stale sentinel only (no drain flag): the opt-in must (re)create the flag
+    // AND clear the sentinel so the once-per-episode dedup latch re-arms.
+    writeFileSync(join(tmp, "drain.drained"), "");
+    const r = applyBootDrainPolicy(tmp, { env: { CATALYST_BOOT_DRAINED: "1" } });
+    expect(r.drained).toBe(true);
+    expect(isDraining(tmp)).toBe(true);
+    expect(existsSync(getDrainFlagPath(tmp))).toBe(true);
+    expect(existsSync(join(tmp, "drain.drained"))).toBe(false);
+  });
+
+  test("CATALYST_BOOT_DRAINED=1 with a pre-existing drain flag keeps it drained (clear-then-set)", () => {
+    // The most direct guard against a set-then-clear inversion: a drain flag that
+    // was already present must remain present (the clear runs first, the re-set last).
+    writeFileSync(getDrainFlagPath(tmp), "");
+    const r = applyBootDrainPolicy(tmp, { env: { CATALYST_BOOT_DRAINED: "1" } });
+    expect(r.drained).toBe(true);
+    expect(existsSync(getDrainFlagPath(tmp))).toBe(true);
+    expect(isDraining(tmp)).toBe(true);
+  });
+
+  test('only the exact string "1" opts in — "true" falls through to clear', () => {
+    writeFileSync(getDrainFlagPath(tmp), "");
+    const r = applyBootDrainPolicy(tmp, { env: { CATALYST_BOOT_DRAINED: "true" } });
+    expect(r.drained).toBe(false);
+    expect(isDraining(tmp)).toBe(false);
+  });
+
+  test('"0" falls through to clear (opt-in idiom, not the kill-switch !== "0")', () => {
+    writeFileSync(getDrainFlagPath(tmp), "");
+    const r = applyBootDrainPolicy(tmp, { env: { CATALYST_BOOT_DRAINED: "0" } });
+    expect(r.drained).toBe(false);
+    expect(isDraining(tmp)).toBe(false);
+  });
+
+  test("idempotent — default applied twice stays live", () => {
+    writeFileSync(getDrainFlagPath(tmp), "");
+    applyBootDrainPolicy(tmp, { env: {} });
+    applyBootDrainPolicy(tmp, { env: {} });
+    expect(isDraining(tmp)).toBe(false);
+  });
+
+  test("idempotent — opt-in applied twice stays drained with sentinel cleared", () => {
+    applyBootDrainPolicy(tmp, { env: { CATALYST_BOOT_DRAINED: "1" } });
+    applyBootDrainPolicy(tmp, { env: { CATALYST_BOOT_DRAINED: "1" } });
+    expect(isDraining(tmp)).toBe(true);
+    expect(existsSync(join(tmp, "drain.drained"))).toBe(false);
+  });
+
+  test("missing-file safety — clean orchDir never throws (default + opt-in)", () => {
+    expect(() => applyBootDrainPolicy(tmp, { env: {} })).not.toThrow();
+    expect(isDraining(tmp)).toBe(false);
+    expect(() => applyBootDrainPolicy(tmp, { env: { CATALYST_BOOT_DRAINED: "1" } })).not.toThrow();
+    expect(isDraining(tmp)).toBe(true);
   });
 });
 

--- a/plugins/dev/scripts/execution-core/daemon.mjs
+++ b/plugins/dev/scripts/execution-core/daemon.mjs
@@ -31,6 +31,7 @@ import { homedir } from "node:os";
 import { parseEventTailChunk } from "./event-tail.mjs";
 import {
   getExecutionCoreDir,
+  applyBootDrainPolicy, // CTL-1321: boot accepting work by default
   getRegistryPath,
   getEventLogPath,
   getJobsRoot,      // CTL-1165 D3: job-dir GC root
@@ -506,6 +507,19 @@ export function startDaemon({
   // CTL-736 Phase 3: reset the per-(ticket, phase) progress high-water markers so a
   // stale mark from a prior daemon run cannot false-STOP the first death this run.
   clearProgressMarks(orchDir);
+  // CTL-1321: boot accepting work by default — clear the persistent drain flag
+  // (+ drain.drained sentinel) a prior drain left, so a quiesce→restart resumes
+  // new-work admission instead of coming up silently drained. CATALYST_BOOT_DRAINED=1
+  // re-arms drain for nodes deliberately kept out of rotation. Best-effort/fail-open;
+  // grouped with the writeBootMarker/clearProgressMarks prior-run resets and ahead of
+  // schedulerFn, the sole consumer of the `!draining` new-work gate.
+  const _bootDrain = applyBootDrainPolicy(orchDir);
+  log.info(
+    { drained: _bootDrain.drained },
+    _bootDrain.drained
+      ? "boot: CATALYST_BOOT_DRAINED set — node boots drained, holding new-work admission (CTL-1321)"
+      : "boot: drain flag cleared — node accepting work (CTL-1321)",
+  );
   _stopMonitor = stopMonitorFn;
   _stopScheduler = stopSchedulerFn;
 

--- a/plugins/dev/scripts/execution-core/daemon.test.mjs
+++ b/plugins/dev/scripts/execution-core/daemon.test.mjs
@@ -65,6 +65,48 @@ afterEach(() => {
   rmSync(catalystDir, { recursive: true, force: true });
 });
 
+// CTL-1321: the boot-drain policy must run AT startDaemon so a quiesce→restart
+// comes up accepting work (clears the persistent drain flag), and a deliberately
+// out-of-rotation node re-arms drain via CATALYST_BOOT_DRAINED=1. This guards the
+// call site: the pure-helper unit tests in config.test.mjs cannot catch a dropped
+// or misordered applyBootDrainPolicy() call (which would silently reintroduce the
+// "drained after restart" bug).
+describe("startDaemon boot drain policy (CTL-1321)", () => {
+  const drainPath = () => join(catalystDir, "execution-core", "drain");
+  const FAKES = {
+    recover: () => ({}),
+    reconcileBoot: () => ({}),
+    startMonitor: () => {},
+    startScheduler: () => {},
+    watchRegistry: false,
+  };
+  let prevBootDrained;
+
+  beforeEach(() => {
+    prevBootDrained = process.env.CATALYST_BOOT_DRAINED;
+  });
+
+  afterEach(() => {
+    if (prevBootDrained === undefined) delete process.env.CATALYST_BOOT_DRAINED;
+    else process.env.CATALYST_BOOT_DRAINED = prevBootDrained;
+  });
+
+  test("clears a stale drain flag on boot (restart resumes accepting work)", () => {
+    delete process.env.CATALYST_BOOT_DRAINED;
+    writeFileSync(drainPath(), "");
+    expect(existsSync(drainPath())).toBe(true);
+    startDaemon({ ...FAKES });
+    expect(existsSync(drainPath())).toBe(false);
+  });
+
+  test("CATALYST_BOOT_DRAINED=1 re-sets the drain flag on boot (out-of-rotation node)", () => {
+    process.env.CATALYST_BOOT_DRAINED = "1";
+    expect(existsSync(drainPath())).toBe(false);
+    startDaemon({ ...FAKES });
+    expect(existsSync(drainPath())).toBe(true);
+  });
+});
+
 describe("startDaemon", () => {
   test("calls recover, boot, startMonitor, startScheduler exactly once each in order", () => {
     const calls = [];

--- a/plugins/dev/scripts/execution-core/scheduler.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.mjs
@@ -265,6 +265,7 @@ import {
   getClusterHosts,
   hostMembershipWarning,
   isDraining as isDrainingDefault,
+  getDrainedMarkerPath, // CTL-1321: shared resolver for the drain.drained sentinel
   HEARTBEAT_GRACE_MS, // CTL-1191: dead-host grace for surviving-roster recovery gate
 } from "./config.mjs";
 import { emitDrainedEvent as defaultEmitDrainedEvent } from "./drain-event.mjs"; // CTL-1095: drained sentinel
@@ -4707,7 +4708,7 @@ export function schedulerTick(
   // CTL-1095: drained sentinel. Once draining and nothing in flight, emit
   // node.drain.drained exactly once per episode via a marker file. Clears
   // the marker when drain turns off so a subsequent episode re-arms.
-  const drainedMarker = join(orchDir, "drain.drained");
+  const drainedMarker = getDrainedMarkerPath(orchDir);
   if (draining) {
     if (listInFlightTickets(orchDir).size === 0 && !existsSync(drainedMarker)) {
       emitDrained();

--- a/plugins/dev/templates/execution-core.env.example
+++ b/plugins/dev/templates/execution-core.env.example
@@ -53,3 +53,21 @@
 # per-ticket read volume. Default is the daemon's built-in TTL; raise it to make
 # the daemon re-read Linear states less often. Unrelated to the proxy.
 # export LINEAR_STATE_CACHE_TTL_MS=180000
+#
+# ─── Optional: keep this node out of rotation (boot drained) ──────────────────
+#
+# By DEFAULT a daemon boots ACCEPTING WORK: on every start it clears any leftover
+# `drain` flag (CTL-1321), so a quiesce→restart never comes up silently drained.
+# Set this to the exact string "1" to flip that — the daemon RE-SETS the drain
+# flag on boot, so the node heartbeats normally but admits no new work. For nodes
+# deliberately parked (a laptop, a debugging host). Lift at runtime with
+# `catalyst-execution-core drain --off` (until the next restart re-arms it), or
+# remove this line and restart to rejoin rotation.
+#
+# NOTE: only the literal "1" opts in (matching the codebase's opt-in idiom);
+# "true"/"yes"/"0" all fall through to the default "accept work". And like every
+# var here, it is honored only when the daemon is launched via
+# `catalyst-execution-core start`/`restart` (which sources this file) — a direct
+# or launchd-plist launch that does not source this file ignores it. The
+# default-clear half always runs (it lives in the daemon boot path, not here).
+# export CATALYST_BOOT_DRAINED=1


### PR DESCRIPTION
## What & why

Fixes [CTL-1321](https://linear.app/coalesce-labs/issue/CTL-1321) — the direct cause of the recurring **"why isn't work moving across the board?"** failure.

The execution-core `drain` flag (`orchDir/drain`) is a **persistent file**: set by `catalyst-execution-core drain`, cleared **only** by an explicit `drain --off`. Neither `cmd_stop`/`cmd_restart` (plain kill + rm pidfile) nor daemon boot cleared it — so the common **drain/quiesce → restart** flow came back **still drained**: `isDraining()` held the new-work gate at 0 slots, the node heartbeated healthy, and it silently pulled no work until a human noticed.

## The fix

- **Default boot = accept work.** New fail-open helper `applyBootDrainPolicy(orchDir)` in `config.mjs` clears the `drain` flag **and** the `drain.drained` sentinel on boot. Called in `startDaemon` right after `clearProgressMarks` — grouped with the existing prior-run resets and strictly ahead of the scheduler (the sole `!draining` new-work-gate consumer).
- **Opt-in persistent-disable.** `CATALYST_BOOT_DRAINED=1` re-sets the flag *after* the clear, for nodes deliberately kept out of rotation (laptop/debug). Matches the codebase's `=== "1"` opt-in idiom.
- **DRY:** extracts a shared `getDrainedMarkerPath()` resolver used by both the boot-clearer and the scheduler sentinel (the one drain-family path not previously behind a resolver) so they can't drift.
- A boot `log.info` announces the decision (Loki-visible); structured `admission` state on the heartbeat is the next ticket (CTL-1322).
- Docs: `CATALYST_BOOT_DRAINED` added to both `execution-core.env.example` and the canonical `docs/configuration.md` Options table.

## Acceptance criteria

- **quiesce → restart → accepts work**: a leftover `drain` flag is cleared on boot → node resumes admission. ✅
- **deliberate persistent-disable**: `CATALYST_BOOT_DRAINED=1` → boot re-sets the flag → node boots drained. ✅

## Scope / limitations

- Gates **new-work admission only**. Boot-resume (CTL-654) still re-adopts already-running in-flight workers regardless of the flag — re-adopting a live ticket is not new work (intentionally out of scope).
- The opt-in is honored only when the daemon is launched via `catalyst-execution-core start`/`restart` (which sources `execution-core.env`); the **default-clear half always runs** (it lives in the daemon boot path). Documented in the env template.

## Testing

- TDD: red captured (missing export + uncleared flag on boot), then green.
- `config.test.mjs`: 11 helper/resolver cases (both Gherkin scenarios, clear-then-set ordering incl. pre-existing-flag, `"true"`/`"0"` opt-in rejection, both-mode idempotency, both-mode missing-file safety).
- `daemon.test.mjs`: 2 boot-integration tests guarding the **call site** (verified fail-before/pass-after on a dropped call) — the pure-helper tests can't catch a missing/misordered call.
- Full affected suite green (`config`/`daemon`/`cli/drain`/`scheduler`/`drain-event`): +12 tests; the 4 remaining failures are pre-existing & unrelated (`getHostName` hostname-dependent, `CTL-781` delegate-on-Todo) — identical on pristine `main`.
- Import-safety: `bun build --target=bun` clean for `daemon.mjs`/`config.mjs`/`scheduler.mjs`.

Design + implementation adversarially verified via multi-agent workflows (grounding → design → 3-lens refute; then 3-lens diff review).

🤖 Generated with [Claude Code](https://claude.com/claude-code)