### PR TITLE
feat(dev): CTL-1322 — admission state visible in telemetry + UI (heartbeat block + FleetOps holding)

### DIFF
--- a/plugins/dev/scripts/execution-core/admission-state.mjs
+++ b/plugins/dev/scripts/execution-core/admission-state.mjs
@@ -1,0 +1,68 @@
+// admission-state.mjs — CTL-1322. Resolve the daemon's live ADMISSION state —
+// is this node accepting new work, and if not, why — from the SAME source fns the
+// scheduler's new-work gate enforces, so the heartbeat (which carries this block)
+// never lies relative to the enforced gate for the GATE-TRUTH fields — `accepting`
+// and `holdReason` are computed from live `isDraining()` + the live agents snapshot.
+// (`effectiveCapacity` is the BOOT-snapshot ceiling: it reads the boot-captured
+// `concurrency`, so after the CTL-684 auto-tuner hot-reloads maxParallel at runtime it
+// can lag the live gate ceiling. It is NOT surfaced in the UI today; the
+// effectiveCapacity shift-left follow-up makes it live everywhere.)
+//
+// The scheduler gate (scheduler.mjs:4680-4698) is:
+//   livenessFresh = livenessIsFresh()           // prod default: getAgentsCached().isFresh
+//   draining      = isDraining()                 // orchDir/drain flag (CTL-1095)
+//   freeSlots     = (livenessFresh && !draining) // accept-work predicate
+//                     ? max(0, computeFreeSlots(maxParallel, liveCount) - …) : 0
+//   liveCount     = countBackgroundAgents()      // the live `claude agents` bg count
+// We recompute the SAME predicates here (the heartbeat runs on its own cadence,
+// not inside the tick, so it must recompute — but from identical sources → zero
+// drift). DO NOT swap in listInFlightTickets(orchDir): that is a worker-dir scan
+// that over-counts leaked workers and diverges from the gate's liveCount.
+//
+// effectiveCapacity is the admission CAPACITY ceiling: maxParallel when accepting,
+// 0 when held (the gate already collapses freeSlots → 0 on a hold) — NOT the
+// volatile per-tick freeSlots (which subtracts same-tick resume/promote terms).
+
+import { isDraining } from "./config.mjs";
+import { getAgentsCached, countBackgroundAgents } from "./claude-agents.mjs";
+import { readMaxParallel } from "./scheduler.mjs";
+
+/**
+ * readAdmissionState — compute { accepting, holdReason, effectiveCapacity, activeWorkers }.
+ *
+ * holdReason precedence: drain takes precedence over liveness-cold. Drain is the
+ * persistent operator-intent hold (CTL-1095); liveness-cold is the transient
+ * self-healing snapshot-staleness hold (CTL-731). Both can be true in one tick;
+ * the single enum reports the operator-meaningful one (drain) first.
+ *
+ * All four reads are injectable seams (default to the real production fns) so the
+ * truth table is unit-testable without real subprocess / fs. The agents snapshot
+ * is taken ONCE and shared between the freshness check and the worker count so the
+ * two values are mutually consistent within a single resolution.
+ *
+ * @param {object} [opts]
+ * @param {string} [opts.orchDir]
+ * @param {object} [opts.concurrency]            committed executionCore knobs (maxParallel)
+ * @param {Function} [opts.agentsSnapshotFn]     () => { agents, isFresh, … }  (getAgentsCached)
+ * @param {Function} [opts.isDrainingFn]         (orchDir) => boolean          (isDraining)
+ * @param {Function} [opts.countWorkersFn]       ({ agents }) => number        (countBackgroundAgents)
+ * @param {Function} [opts.maxParallelFn]        (orchDir, concurrency) => int (readMaxParallel)
+ * @returns {{ accepting: boolean, holdReason: "drain"|"liveness-cold"|null, effectiveCapacity: number, activeWorkers: number }}
+ */
+export function readAdmissionState({
+  orchDir,
+  concurrency = {},
+  agentsSnapshotFn = getAgentsCached,
+  isDrainingFn = isDraining,
+  countWorkersFn = countBackgroundAgents,
+  maxParallelFn = readMaxParallel,
+} = {}) {
+  const snap = agentsSnapshotFn() ?? {};
+  const livenessFresh = snap.isFresh === true;
+  const draining = isDrainingFn(orchDir) === true;
+  const accepting = livenessFresh && !draining;
+  const holdReason = accepting ? null : draining ? "drain" : "liveness-cold";
+  const activeWorkers = countWorkersFn({ agents: snap.agents ?? [] }) ?? 0;
+  const effectiveCapacity = accepting ? maxParallelFn(orchDir, concurrency) : 0;
+  return { accepting, holdReason, effectiveCapacity, activeWorkers };
+}

--- a/plugins/dev/scripts/execution-core/admission-state.test.mjs
+++ b/plugins/dev/scripts/execution-core/admission-state.test.mjs
@@ -1,0 +1,85 @@
+// admission-state.test.mjs — CTL-1322. readAdmissionState truth table: the
+// heartbeat admission block must mirror the scheduler's new-work gate exactly.
+//
+// Run: cd plugins/dev/scripts/execution-core && bun test admission-state.test.mjs
+
+import { describe, test, expect } from "bun:test";
+import { readAdmissionState } from "./admission-state.mjs";
+
+// Build a readAdmissionState call with all four seams injected so no real
+// subprocess / fs runs. `fresh`/`draining` drive the gate; `workers`/`maxParallel`
+// drive the capacity values.
+function resolve({ fresh, draining, workers = 0, maxParallel = 6 }) {
+  return readAdmissionState({
+    orchDir: "/tmp/ec",
+    concurrency: {},
+    agentsSnapshotFn: () => ({ isFresh: fresh, agents: [] }),
+    isDrainingFn: () => draining,
+    countWorkersFn: () => workers,
+    maxParallelFn: () => maxParallel,
+  });
+}
+
+describe("readAdmissionState (CTL-1322)", () => {
+  test("fresh + not draining → accepting, no hold, capacity = maxParallel", () => {
+    const a = resolve({ fresh: true, draining: false, workers: 2, maxParallel: 6 });
+    expect(a.accepting).toBe(true);
+    expect(a.holdReason).toBe(null);
+    expect(a.effectiveCapacity).toBe(6);
+    expect(a.activeWorkers).toBe(2);
+  });
+
+  test("draining → not accepting, holdReason=drain, effectiveCapacity=0", () => {
+    const a = resolve({ fresh: true, draining: true, workers: 3, maxParallel: 6 });
+    expect(a.accepting).toBe(false);
+    expect(a.holdReason).toBe("drain");
+    expect(a.effectiveCapacity).toBe(0);
+    expect(a.activeWorkers).toBe(3); // still reports live workers while held
+  });
+
+  test("stale liveness (not draining) → not accepting, holdReason=liveness-cold, capacity=0", () => {
+    const a = resolve({ fresh: false, draining: false, workers: 1, maxParallel: 6 });
+    expect(a.accepting).toBe(false);
+    expect(a.holdReason).toBe("liveness-cold");
+    expect(a.effectiveCapacity).toBe(0);
+  });
+
+  test("draining + stale → holdReason=drain (drain takes precedence)", () => {
+    const a = resolve({ fresh: false, draining: true, workers: 0, maxParallel: 6 });
+    expect(a.accepting).toBe(false);
+    expect(a.holdReason).toBe("drain");
+    expect(a.effectiveCapacity).toBe(0);
+  });
+
+  test("activeWorkers reflects the live background count even at capacity", () => {
+    const a = resolve({ fresh: true, draining: false, workers: 6, maxParallel: 6 });
+    expect(a.activeWorkers).toBe(6);
+    expect(a.accepting).toBe(true); // capacity is a ceiling, not free-slots — accepting stays true
+  });
+
+  test("shares a single agents snapshot between freshness and worker count", () => {
+    let snapCalls = 0;
+    const snap = { isFresh: true, agents: [{ kind: "background" }] };
+    const a = readAdmissionState({
+      orchDir: "/tmp/ec",
+      agentsSnapshotFn: () => { snapCalls++; return snap; },
+      isDrainingFn: () => false,
+      countWorkersFn: ({ agents }) => agents.length, // receives the SAME snapshot's agents
+      maxParallelFn: () => 4,
+    });
+    expect(snapCalls).toBe(1);
+    expect(a.activeWorkers).toBe(1);
+  });
+
+  test("fail-safe: a null/empty snapshot reads as not-fresh → held, never throws", () => {
+    const a = readAdmissionState({
+      orchDir: "/tmp/ec",
+      agentsSnapshotFn: () => null,
+      isDrainingFn: () => false,
+      countWorkersFn: () => 0,
+      maxParallelFn: () => 6,
+    });
+    expect(a.accepting).toBe(false);
+    expect(a.holdReason).toBe("liveness-cold");
+  });
+});

--- a/plugins/dev/scripts/execution-core/daemon.mjs
+++ b/plugins/dev/scripts/execution-core/daemon.mjs
@@ -60,6 +60,7 @@ import { startFleetHealthProbe as realStartFleetHealthProbe } from "./fleet-heal
 import { startRatelimitPoller as realStartRatelimitPoller } from "./ratelimit-poller.mjs";
 import { listProjects as realListProjects } from "./registry.mjs"; // CTL-854: boot health check
 import { startHeartbeat as realStartHeartbeat } from "./heartbeat-event.mjs"; // CTL-859: node.heartbeat emitter
+import { readAdmissionState } from "./admission-state.mjs"; // CTL-1322: live admission block for the heartbeat
 import { startLivenessPublisher as realStartLivenessPublisher } from "./cluster-heartbeat-publisher.mjs"; // CTL-1090: cross-host liveness
 import { emitBootEvent } from "./boot-event.mjs"; // CTL-1084: node.boot self-report
 import {
@@ -726,7 +727,13 @@ export function startDaemon({
     // silence. ADDITIVE/dormant — pure observability, no behavior consumes it
     // yet. Inside the same try/catch so a throw triggers PID-file cleanup.
     if (enableHeartbeat) {
-      _heartbeat = startHeartbeat();
+      // CTL-1322: supply the live admission-state closure so each heartbeat carries
+      // { accepting, holdReason, effectiveCapacity, activeWorkers } — computed from
+      // the same gate source fns the scheduler enforces (orchDir + concurrency are
+      // both in scope here). Fail-open: readAdmissionState never throws.
+      _heartbeat = startHeartbeat({
+        admissionFn: () => readAdmissionState({ orchDir, concurrency }),
+      });
       // CTL-1090: cross-host liveness publisher (multi-host only; single-host no-op).
       // startLivenessPublisher self-gates on roster.length > 1, so this is always safe.
       _livenessPublisher = startLivenessPublisher({ orchDir });

--- a/plugins/dev/scripts/execution-core/daemon.test.mjs
+++ b/plugins/dev/scripts/execution-core/daemon.test.mjs
@@ -107,6 +107,32 @@ describe("startDaemon boot drain policy (CTL-1321)", () => {
   });
 });
 
+// CTL-1322: the daemon must supply an admissionFn to startHeartbeat so each
+// node.heartbeat carries the live admission block. Without this wiring the
+// heartbeat admission would silently be null in production — the same "field is
+// half-wired → silent no-op" class the ticket exists to prevent.
+describe("startDaemon heartbeat admission wiring (CTL-1322)", () => {
+  test("passes an admissionFn to startHeartbeat that returns the admission shape", () => {
+    let captured = null;
+    startDaemon({
+      recover: () => ({}),
+      reconcileBoot: () => ({}),
+      startMonitor: () => {},
+      startScheduler: () => {},
+      startHeartbeat: (opts) => { captured = opts; return { stop() {}, started: Promise.resolve() }; },
+      watchRegistry: false,
+    });
+    expect(captured).not.toBe(null);
+    expect(typeof captured.admissionFn).toBe("function");
+    let admission;
+    expect(() => { admission = captured.admissionFn(); }).not.toThrow();
+    expect(admission).toHaveProperty("accepting");
+    expect(admission).toHaveProperty("holdReason");
+    expect(admission).toHaveProperty("effectiveCapacity");
+    expect(admission).toHaveProperty("activeWorkers");
+  });
+});
+
 describe("startDaemon", () => {
   test("calls recover, boot, startMonitor, startScheduler exactly once each in order", () => {
     const calls = [];

--- a/plugins/dev/scripts/execution-core/heartbeat-event.mjs
+++ b/plugins/dev/scripts/execution-core/heartbeat-event.mjs
@@ -41,13 +41,20 @@ export const HEARTBEAT_EVENT = "node.heartbeat";
  * @param {Function} [opts.now]  injectable timestamp fn (returns ISO string)
  * @param {Function} [opts.epochFn]  injectable epoch fn (returns ms number)
  * @param {Function} [opts.governanceFn]  injectable governance snapshot fn (CTL-1062)
+ * @param {Function} [opts.admissionFn]  injectable admission-state fn (CTL-1322); the
+ *   daemon supplies a closure over orchDir + concurrency. null when not supplied.
  * @returns {object} the envelope object
  */
-export function buildHeartbeatEnvelope({ now, epochFn, governanceFn } = {}) {
+export function buildHeartbeatEnvelope({ now, epochFn, governanceFn, admissionFn } = {}) {
   const ts = now ? now() : new Date().toISOString().replace(/\.\d{3}Z$/, "Z");
   const epoch = epochFn ? epochFn() : Date.now();
   const host = getHostName();
   const governance = governanceFn ? governanceFn() : readGovernanceConfig();
+  // CTL-1322: live admission state — { accepting, holdReason, effectiveCapacity,
+  // activeWorkers } — so a draining/liveness-cold daemon is visible in telemetry
+  // instead of hidden behind a healthy heartbeat. Supplied by the daemon; null for
+  // non-daemon callers/tests so the key is always present for consumers.
+  const admission = admissionFn ? admissionFn() : null;
 
   return {
     ts,
@@ -77,6 +84,7 @@ export function buildHeartbeatEnvelope({ now, epochFn, governanceFn } = {}) {
         "host.name": host,
         epoch,
         governance, // CTL-1062: live governance snapshot for operator visibility
+        admission, // CTL-1322: live new-work admission state (accepting + holdReason)
       },
     },
   };
@@ -88,8 +96,17 @@ export function buildHeartbeatEnvelope({ now, epochFn, governanceFn } = {}) {
  * throws). `logPath` is injectable for tests; defaults to the same
  * getEventLogPath() every other emitter uses (no new log path).
  */
-export async function emitHeartbeatEvent({ logPath = getEventLogPath(), now, epochFn } = {}) {
-  const line = `${JSON.stringify(buildHeartbeatEnvelope({ now, epochFn }))}\n`;
+export async function emitHeartbeatEvent({
+  logPath = getEventLogPath(),
+  now,
+  epochFn,
+  // CTL-1322: thread the injectable seams through to the builder. The prior signature
+  // didn't accept governanceFn (a dormant seam gap), so an injected governanceFn never
+  // reached buildHeartbeatEnvelope from here; now both governanceFn + admissionFn flow.
+  governanceFn,
+  admissionFn,
+} = {}) {
+  const line = `${JSON.stringify(buildHeartbeatEnvelope({ now, epochFn, governanceFn, admissionFn }))}\n`;
   try {
     await mkdir(dirname(logPath), { recursive: true });
     await appendFile(logPath, line);
@@ -109,15 +126,17 @@ export async function emitHeartbeatEvent({ logPath = getEventLogPath(), now, epo
  * @param {object} [opts]
  * @param {number} [opts.intervalMs]  cadence; defaults to HEARTBEAT_INTERVAL_MS
  * @param {string} [opts.logPath]     event-log path (injectable for tests)
+ * @param {Function} [opts.admissionFn]  CTL-1322: live admission-state fn (daemon-supplied)
+ * @param {Function} [opts.governanceFn] CTL-1062: live governance snapshot fn (optional override)
  */
-export function startHeartbeat({ intervalMs = HEARTBEAT_INTERVAL_MS, logPath } = {}) {
+export function startHeartbeat({ intervalMs = HEARTBEAT_INTERVAL_MS, logPath, admissionFn, governanceFn } = {}) {
   const tick = () => {
     // CTL-1280: deterministic liveness heartbeat to daemon.log (Alloy→Loki),
     // riding the same cadence as the node.heartbeat event but on the .log stream
     // so a liveness check can watch the heartbeat marker independent of the
     // otel-forward event pipeline (a quiet-but-healthy daemon must still prove it).
     logDaemonHeartbeat(log, "execution-core");
-    return emitHeartbeatEvent({ logPath }).catch(() => {});
+    return emitHeartbeatEvent({ logPath, admissionFn, governanceFn }).catch(() => {});
   };
   const started = tick(); // emit once at boot; Promise for callers that need to await it
   const timer = setInterval(tick, intervalMs);

--- a/plugins/dev/scripts/execution-core/heartbeat-event.test.mjs
+++ b/plugins/dev/scripts/execution-core/heartbeat-event.test.mjs
@@ -151,6 +151,28 @@ describe("startHeartbeat (CTL-859)", () => {
       h.stop();
     }
   });
+
+  test("CTL-1322: forwards admissionFn + governanceFn through the tick to the appended line", async () => {
+    process.env.CATALYST_HOST_NAME = "mini";
+    const h = startHeartbeat({
+      intervalMs: 1_000_000,
+      logPath,
+      admissionFn: () => ({ accepting: false, holdReason: "drain", effectiveCapacity: 0, activeWorkers: 0 }),
+      governanceFn: () => ({ beliefsShadow: true }),
+    });
+    try {
+      await h.started;
+      // Guards the startHeartbeat→emitHeartbeatEvent forward — the actual production
+      // path. A dropped seam in tick() would otherwise silently emit admission:null in
+      // prod while the rest of the suite stays green (the half-wired-field class).
+      const line = JSON.parse(readFileSync(logPath, "utf8").trim().split("\n")[0]);
+      expect(line.body.payload.admission.holdReason).toBe("drain");
+      expect(line.body.payload.admission.accepting).toBe(false);
+      expect(line.body.payload.governance.beliefsShadow).toBe(true);
+    } finally {
+      h.stop();
+    }
+  });
 });
 
 describe("readClusterHeartbeats (CTL-859)", () => {
@@ -283,5 +305,59 @@ describe("heartbeat governance block (CTL-1062)", () => {
     const env = buildHeartbeatEnvelope();
     expect(typeof env.body.payload.governance).toBe("object");
     expect(env.body.payload.governance).toHaveProperty("beliefsShadow");
+  });
+});
+
+describe("heartbeat admission block (CTL-1322)", () => {
+  test("payload carries the injected admission state", () => {
+    const env = buildHeartbeatEnvelope({
+      admissionFn: () => ({ accepting: false, holdReason: "drain", effectiveCapacity: 0, activeWorkers: 6 }),
+    });
+    expect(env.body.payload.admission).toEqual({
+      accepting: false, holdReason: "drain", effectiveCapacity: 0, activeWorkers: 6,
+    });
+  });
+
+  test("admission is null when no admissionFn is injected (key always present for consumers)", () => {
+    const env = buildHeartbeatEnvelope({ epochFn: () => 1700000000000 });
+    expect(env.body.payload).toHaveProperty("admission");
+    expect(env.body.payload.admission).toBe(null);
+  });
+
+  test("still carries host.name + epoch + governance alongside admission (no regression)", () => {
+    process.env.CATALYST_HOST_NAME = "mini";
+    const env = buildHeartbeatEnvelope({
+      epochFn: () => 1700000000000,
+      governanceFn: () => ({ beliefsShadow: true }),
+      admissionFn: () => ({ accepting: true, holdReason: null, effectiveCapacity: 6, activeWorkers: 1 }),
+    });
+    expect(env.body.payload["host.name"]).toBe("mini");
+    expect(env.body.payload.epoch).toBe(1700000000000);
+    expect(env.body.payload.governance).toEqual({ beliefsShadow: true });
+    expect(env.body.payload.admission.accepting).toBe(true);
+  });
+});
+
+// CTL-1322: emitHeartbeatEvent previously dropped governanceFn (and had no way to
+// forward admissionFn), so an injected seam never reached buildHeartbeatEnvelope on
+// the production startHeartbeat path — only the builder's default reader ran. Assert
+// both seams now flow through to the appended line.
+describe("emitHeartbeatEvent forwards governanceFn + admissionFn (CTL-1322 seam fix)", () => {
+  let tmp;
+  beforeEach(() => { tmp = mkdtempSync(join(tmpdir(), "hb-seam-")); });
+  afterEach(() => { rmSync(tmp, { recursive: true, force: true }); });
+
+  test("the appended heartbeat line carries the injected governance + admission", async () => {
+    const logPath = join(tmp, "events.jsonl");
+    const ok = await emitHeartbeatEvent({
+      logPath,
+      governanceFn: () => ({ beliefsShadow: true, intentsEnforce: false }),
+      admissionFn: () => ({ accepting: false, holdReason: "liveness-cold", effectiveCapacity: 0, activeWorkers: 0 }),
+    });
+    expect(ok).toBe(true);
+    const line = JSON.parse(readFileSync(logPath, "utf8").trim());
+    expect(line.body.payload.governance.beliefsShadow).toBe(true);
+    expect(line.body.payload.admission.holdReason).toBe("liveness-cold");
+    expect(line.body.payload.admission.accepting).toBe(false);
   });
 });

--- a/plugins/dev/scripts/execution-core/recovery-admission.test.mjs
+++ b/plugins/dev/scripts/execution-core/recovery-admission.test.mjs
@@ -1,0 +1,97 @@
+// recovery-admission.test.mjs — CTL-1322. readClusterAdmission extracts the
+// per-node admission block from the local event log (newest-line-wins, fail-open).
+//
+// Run: cd plugins/dev/scripts/execution-core && bun test recovery-admission.test.mjs
+
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { readClusterAdmission } from "./recovery.mjs";
+
+const HB = "node.heartbeat";
+
+function hbLine(host, ts, admission) {
+  return JSON.stringify({
+    ts,
+    attributes: { "event.name": HB },
+    body: { payload: { "host.name": host, admission } },
+  });
+}
+
+describe("readClusterAdmission (CTL-1322)", () => {
+  let tmp;
+  let logPath;
+
+  beforeEach(() => {
+    tmp = mkdtempSync(join(tmpdir(), "cluster-adm-"));
+    logPath = join(tmp, "events.jsonl");
+  });
+
+  afterEach(() => {
+    rmSync(tmp, { recursive: true, force: true });
+  });
+
+  test("extracts the admission block per host", () => {
+    writeFileSync(
+      logPath,
+      hbLine("mini", "2026-06-23T10:00:00Z", { accepting: false, holdReason: "drain", effectiveCapacity: 0, activeWorkers: 6 }) + "\n",
+    );
+    expect(readClusterAdmission({ logPath })).toEqual({
+      mini: { accepting: false, holdReason: "drain", effectiveCapacity: 0, activeWorkers: 6 },
+    });
+  });
+
+  test("newest line wins — a later accepting:true overrides an earlier hold", () => {
+    writeFileSync(logPath, [
+      hbLine("mini", "2026-06-23T10:00:00Z", { accepting: false, holdReason: "drain", effectiveCapacity: 0, activeWorkers: 6 }),
+      hbLine("mini", "2026-06-23T10:00:30Z", { accepting: true, holdReason: null, effectiveCapacity: 6, activeWorkers: 2 }),
+    ].join("\n") + "\n");
+    const r = readClusterAdmission({ logPath });
+    expect(r.mini.accepting).toBe(true);
+    expect(r.mini.holdReason).toBe(null);
+  });
+
+  test("a fresh admission:null clears a stale hold (host omitted)", () => {
+    writeFileSync(logPath, [
+      hbLine("mini", "2026-06-23T10:00:00Z", { accepting: false, holdReason: "drain", effectiveCapacity: 0, activeWorkers: 6 }),
+      hbLine("mini", "2026-06-23T10:00:30Z", null),
+    ].join("\n") + "\n");
+    expect(readClusterAdmission({ logPath })).toEqual({});
+  });
+
+  test("a heartbeat with no admission key omits the host", () => {
+    writeFileSync(
+      logPath,
+      JSON.stringify({ ts: "2026-06-23T10:00:00Z", attributes: { "event.name": HB }, body: { payload: { "host.name": "mini" } } }) + "\n",
+    );
+    expect(readClusterAdmission({ logPath })).toEqual({});
+  });
+
+  test("missing log file → {} (fail-open, never throws)", () => {
+    const gone = join(tmp, "nope.jsonl");
+    expect(() => readClusterAdmission({ logPath: gone })).not.toThrow();
+    expect(readClusterAdmission({ logPath: gone })).toEqual({});
+  });
+
+  test("garbage + non-heartbeat lines are skipped", () => {
+    writeFileSync(logPath, [
+      "not json at all",
+      JSON.stringify({ ts: "2026-06-23T09:00:00Z", attributes: { "event.name": "node.boot" }, body: { payload: { "host.name": "mini", admission: { accepting: false } } } }),
+      hbLine("mini-2", "2026-06-23T10:00:00Z", { accepting: false, holdReason: "liveness-cold", effectiveCapacity: 0, activeWorkers: 0 }),
+    ].join("\n") + "\n");
+    expect(readClusterAdmission({ logPath })).toEqual({
+      "mini-2": { accepting: false, holdReason: "liveness-cold", effectiveCapacity: 0, activeWorkers: 0 },
+    });
+  });
+
+  test("multiple hosts each carry their own admission", () => {
+    writeFileSync(logPath, [
+      hbLine("mini", "2026-06-23T10:00:00Z", { accepting: true, holdReason: null, effectiveCapacity: 6, activeWorkers: 1 }),
+      hbLine("mini-2", "2026-06-23T10:00:00Z", { accepting: false, holdReason: "drain", effectiveCapacity: 0, activeWorkers: 3 }),
+    ].join("\n") + "\n");
+    const r = readClusterAdmission({ logPath });
+    expect(r.mini.accepting).toBe(true);
+    expect(r["mini-2"].holdReason).toBe("drain");
+  });
+});

--- a/plugins/dev/scripts/execution-core/recovery.mjs
+++ b/plugins/dev/scripts/execution-core/recovery.mjs
@@ -3049,6 +3049,54 @@ export function readClusterHeartbeats({
   return lastSeen;
 }
 
+// CTL-1322: readClusterAdmission — sibling of readClusterHeartbeats that extracts
+// the per-node ADMISSION block (accepting / holdReason / effectiveCapacity /
+// activeWorkers, written by heartbeat-event.mjs at body.payload.admission) so the
+// orch-monitor can surface a draining/liveness-cold-but-live daemon instead of
+// rendering it "live". LOCAL event log ONLY — no cross-host peer merge: the anchor
+// liveness transport carries no admission field yet, so a remote node's hold is
+// unknowable here and such peers render as "unknown"/live (never a false hold).
+// Keeps the NEWEST heartbeat line's admission per host (ISO ts sorts
+// lexicographically for the local second-precision log), so a fresh accepting:true
+// overrides an earlier hold, and a fresh admission:null clears a stale one. A host
+// whose newest admission is null/absent is omitted. Best-effort/fail-open: missing
+// or unreadable log → {}; malformed lines skipped; never throws. `logPath`
+// injectable for tests.
+export function readClusterAdmission({ logPath = getEventLogPath() } = {}) {
+  const byHost = {}; // host -> { ts, admission|null }
+  let raw;
+  try {
+    raw = readFileSync(logPath, "utf8");
+  } catch {
+    return {}; // no event log yet
+  }
+  for (const line of raw.split("\n")) {
+    if (!line) continue;
+    if (!line.includes(HEARTBEAT_EVENT)) continue; // cheap pre-filter
+    let evt;
+    try {
+      evt = JSON.parse(line);
+    } catch {
+      continue; // partial/garbage line
+    }
+    if (evt?.attributes?.["event.name"] !== HEARTBEAT_EVENT) continue;
+    const host = evt?.body?.payload?.["host.name"] ?? evt?.resource?.["host.name"];
+    const ts = evt?.ts;
+    if (typeof host !== "string" || host.length === 0) continue;
+    if (typeof ts !== "string" || ts.length === 0) continue;
+    // Track the newest line per host EVEN IF it carries no admission, so a fresh
+    // heartbeat with admission:null correctly clears a host's stale hold.
+    const admission = evt?.body?.payload?.admission;
+    const prev = byHost[host];
+    if (!prev || ts > prev.ts) byHost[host] = { ts, admission: admission ?? null };
+  }
+  const out = {};
+  for (const [host, rec] of Object.entries(byHost)) {
+    if (rec.admission && typeof rec.admission === "object") out[host] = rec.admission;
+  }
+  return out;
+}
+
 // phaseAlreadyComplete — true when the unified event log already contains a
 // `phase.<phase>.complete.<ticket>` event. The resume path checks this before
 // re-dispatching so a survivor never re-emits a completion the dead host already

--- a/plugins/dev/scripts/orch-monitor/__tests__/cluster-signal-ui.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/cluster-signal-ui.test.ts
@@ -67,6 +67,19 @@ describe("cluster-signal UI contract (CTL-898 / SHELL8)", () => {
       expect(decodeClusterSignalFrame("{ not json")).toBeNull();
       expect(decodeClusterSignalFrame(JSON.stringify({ singleHost: 1 }))).toBeNull();
     });
+
+    it("CTL-1322: decodes both a frame WITH admission fields and an OLD frame WITHOUT them (back-compat)", () => {
+      const withAdmission = signal({
+        nodes: [{ host: "mini", status: "live", accepting: false, holdReason: "drain" }],
+      });
+      expect(isClusterSignal(withAdmission)).toBe(true);
+      const decoded = decodeClusterSignalFrame(JSON.stringify(withAdmission));
+      expect(decoded?.nodes[0].accepting).toBe(false);
+      expect(decoded?.nodes[0].holdReason).toBe("drain");
+      // An OLD frame (no admission fields) still decodes — the guard treats them optional.
+      expect(isClusterSignal(signal())).toBe(true);
+      expect(decodeClusterSignalFrame(JSON.stringify(signal()))?.nodes[0].accepting).toBeUndefined();
+    });
   });
 
   describe("nodeDotClass / nodeStatusLabel", () => {

--- a/plugins/dev/scripts/orch-monitor/__tests__/cluster-view-capacity.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/cluster-view-capacity.test.ts
@@ -180,3 +180,113 @@ describe("createClusterEntity forwards capacityReader + aliases through project(
     expect(view.nodes.find((n) => n.host === "mini")?.status).toBe("live");
   });
 });
+
+describe("assembleClusterView admissionReader seam (CTL-1322)", () => {
+  it("attaches accepting/holdReason via admissionReader", () => {
+    const view = assembleClusterView({
+      board: board([ticket("CTL-1")]),
+      hosts: ["mini", "laptop"],
+      heartbeats: { mini: "2026-06-13T10:00:00Z", laptop: "2026-06-13T10:00:00Z" },
+      admissionReader: (h) =>
+        h === "mini" ? { accepting: false, holdReason: "drain" } : { accepting: true, holdReason: null },
+      now,
+    });
+    expect(view.nodes.find((n) => n.host === "mini")).toMatchObject({ accepting: false, holdReason: "drain" });
+    expect(view.nodes.find((n) => n.host === "laptop")).toMatchObject({ accepting: true, holdReason: null });
+  });
+
+  it("offline node → accepting:false, holdReason:null (never a stale hold word)", () => {
+    const view = assembleClusterView({
+      board: board([ticket("CTL-1")]),
+      hosts: ["mini", "laptop"],
+      heartbeats: { mini: "2026-06-13T10:00:00Z" }, // laptop missing → offline
+      admissionReader: () => ({ accepting: true, holdReason: null }),
+      now,
+    });
+    const laptop = view.nodes.find((n) => n.host === "laptop");
+    expect(laptop?.status).toBe("offline");
+    expect(laptop).toMatchObject({ accepting: false, holdReason: null });
+  });
+
+  it("admissionReader absent → no admission fields (backward compat → renders live)", () => {
+    const view = assembleClusterView({
+      board: board([ticket("CTL-1")]),
+      hosts: ["mini"],
+      heartbeats: { mini: "2026-06-13T10:00:00Z" },
+      now,
+    });
+    const mini = view.nodes.find((n) => n.host === "mini");
+    expect(mini).toBeDefined();
+    expect(mini).not.toHaveProperty("accepting");
+    expect(mini).not.toHaveProperty("holdReason");
+  });
+
+  it("admissionReader returning null / throwing → no admission fields (fail-open)", () => {
+    const viaNull = assembleClusterView({
+      board: board([ticket("CTL-1")]),
+      hosts: ["mini"],
+      heartbeats: { mini: "2026-06-13T10:00:00Z" },
+      admissionReader: () => null,
+      now,
+    });
+    expect(viaNull.nodes.find((n) => n.host === "mini")).not.toHaveProperty("accepting");
+    const viaThrow = assembleClusterView({
+      board: board([ticket("CTL-1")]),
+      hosts: ["mini"],
+      heartbeats: { mini: "2026-06-13T10:00:00Z" },
+      admissionReader: () => {
+        throw new Error("boom");
+      },
+      now,
+    });
+    expect(viaThrow.nodes.find((n) => n.host === "mini")).not.toHaveProperty("accepting");
+  });
+});
+
+describe("deriveClusterSignal admission pass-through (CTL-1322)", () => {
+  it("preserves accepting/holdReason on signal nodes; omits effectiveCapacity/activeWorkers", async () => {
+    const { deriveClusterSignal } = await import("../lib/cluster-signal.mjs");
+    const view = assembleClusterView({
+      board: board([ticket("CTL-1")]),
+      hosts: ["mini"],
+      heartbeats: { mini: "2026-06-13T10:00:00Z" },
+      admissionReader: () => ({ accepting: false, holdReason: "liveness-cold" }),
+      now,
+    });
+    const sig = deriveClusterSignal(view);
+    expect(sig.nodes[0]).toMatchObject({ host: "mini", accepting: false, holdReason: "liveness-cold" });
+    expect(sig.nodes[0]).not.toHaveProperty("effectiveCapacity");
+    expect(sig.nodes[0]).not.toHaveProperty("activeWorkers");
+  });
+
+  it("a node without admission omits both fields (frame stays tiny + back-compat)", async () => {
+    const { deriveClusterSignal } = await import("../lib/cluster-signal.mjs");
+    const view = assembleClusterView({
+      board: board([ticket("CTL-1")]),
+      hosts: ["mini"],
+      heartbeats: { mini: "2026-06-13T10:00:00Z" },
+      now,
+    });
+    const sig = deriveClusterSignal(view);
+    expect(sig.nodes[0]).not.toHaveProperty("accepting");
+    expect(sig.nodes[0]).not.toHaveProperty("holdReason");
+  });
+});
+
+// CTL-1322 REGRESSION GUARD — the SAME prod-dead class as CTL-1092. createClusterEntity
+// must FORWARD admissionReader into assembleClusterView in project(); the seam tests
+// above pass even if the forward is dropped. This test fails the instant the forward at
+// cluster-view.mjs project() is removed.
+describe("createClusterEntity forwards admissionReader through project() (CTL-1322)", () => {
+  it("surfaces per-node accepting/holdReason via project() — proves the forward, not just the seam", async () => {
+    const entity = createClusterEntity({
+      ownerHostProvider: () => ({ "CTL-1": "mini" }),
+      rosterProvider: () => ["mini"],
+      heartbeatReader: () => ({ mini: new Date(now - 1000).toISOString() }),
+      admissionReader: (h) => (h === "mini" ? { accepting: false, holdReason: "drain" } : null),
+      now: () => now,
+    });
+    const view = await entity.project(board([ticket("CTL-1")]));
+    expect(view.nodes.find((n) => n.host === "mini")).toMatchObject({ accepting: false, holdReason: "drain" });
+  });
+});

--- a/plugins/dev/scripts/orch-monitor/lib/cluster-signal.mjs
+++ b/plugins/dev/scripts/orch-monitor/lib/cluster-signal.mjs
@@ -27,6 +27,8 @@
  * @typedef {object} ClusterSignalNode
  * @property {string} host    the roster host name (the node label)
  * @property {ClusterNodeStatus} status  the node's heartbeat-overlay liveness
+ * @property {boolean} [accepting]  CTL-1322: local node's new-work admission (absent ⇒ unknown/live)
+ * @property {"drain"|"liveness-cold"|null} [holdReason]  CTL-1322: why a non-accepting node is held
  */
 
 /**
@@ -57,6 +59,11 @@ export function deriveClusterSignal(view) {
     if (n.maxParallel != null) node.maxParallel = n.maxParallel;
     if (n.inFlightCount != null) node.inFlightCount = n.inFlightCount;
     if (n.freeSlots != null) node.freeSlots = n.freeSlots;
+    // CTL-1322: per-node admission (local node only). Conditional-copy keeps the SSE
+    // frame tiny + back-compat — a node without admission omits both fields so the UI
+    // renders "live". effectiveCapacity/activeWorkers are intentionally NOT projected.
+    if (typeof n.accepting === "boolean") node.accepting = n.accepting;
+    if (n.holdReason != null) node.holdReason = n.holdReason;
     projected.push(node);
   }
   return {

--- a/plugins/dev/scripts/orch-monitor/lib/cluster-view.d.mts
+++ b/plugins/dev/scripts/orch-monitor/lib/cluster-view.d.mts
@@ -21,6 +21,10 @@ export interface ClusterNode {
   freeSlots?: number;
   /** CTL-1095: drain state. Present when drainReader is wired. */
   draining?: boolean;
+  /** CTL-1322: admission state from the node.heartbeat block. Present when admissionReader
+   *  is wired (LOCAL node only — remote peers omit it and render "live"). */
+  accepting?: boolean;
+  holdReason?: "drain" | "liveness-cold" | null;
 }
 
 export interface ClusterView {
@@ -47,6 +51,10 @@ export interface AssembleClusterViewArgs extends LivenessThresholds {
     | null;
   /** CTL-1092: host alias map { oldName → pinnedName } for collapsing pre-pin heartbeat keys. */
   aliases?: Record<string, string> | null;
+  /** CTL-1322: per-host admission reader → { accepting, holdReason }. */
+  admissionReader?:
+    | ((host: string) => { accepting?: boolean; holdReason?: "drain" | "liveness-cold" | null } | null | undefined)
+    | null;
 }
 
 export function assembleClusterView(args: AssembleClusterViewArgs): ClusterView;
@@ -68,6 +76,10 @@ export interface ClusterEntityDeps {
   aliases?: Record<string, string> | null;
   /** CTL-1095: live drain reader, forwarded to assembleClusterView. */
   drainReader?: ((host: string) => { draining?: boolean; inFlightCount?: number } | null | undefined) | null;
+  /** CTL-1322: live admission reader, forwarded to assembleClusterView. */
+  admissionReader?:
+    | ((host: string) => { accepting?: boolean; holdReason?: "drain" | "liveness-cold" | null } | null | undefined)
+    | null;
   /** Injected clock for tests. */
   now?: () => number;
 }

--- a/plugins/dev/scripts/orch-monitor/lib/cluster-view.mjs
+++ b/plugins/dev/scripts/orch-monitor/lib/cluster-view.mjs
@@ -88,6 +88,9 @@ export function assembleClusterView({
   capacityReader = null,
   // CTL-1092: host alias map { oldName → pinnedName } for collapsing pre-pin heartbeat keys.
   aliases = null,
+  // CTL-1322: injectable admission reader. (host) → { accepting, holdReason, … } | null.
+  // Default → no admission info (fields absent → UI renders "live", never a false hold).
+  admissionReader = null,
 }) {
   const roster = Array.isArray(hosts) && hosts.length > 0 ? hosts : [];
   const tickets = Array.isArray(board?.tickets) ? board.tickets : [];
@@ -173,6 +176,23 @@ export function assembleClusterView({
     }
   };
 
+  // CTL-1322: resolve admission state per host — only { accepting, holdReason } (the
+  // two UI surfaces; maxParallel/inFlightCount already come from capacity). Shares NO
+  // field with drain/capacity, so spread order is irrelevant. Offline → not accepting,
+  // no hold reason. Fail-open: no reader / null / throw → contribute NO fields, so a
+  // node without admission data renders "live" rather than a false hold.
+  const resolveAdmission = (host, status) => {
+    if (!admissionReader || host === null) return {};
+    if (status === "offline") return { accepting: false, holdReason: null };
+    try {
+      const a = admissionReader(host);
+      if (!a) return {};
+      return { accepting: Boolean(a.accepting), holdReason: a.holdReason ?? null };
+    } catch {
+      return {};
+    }
+  };
+
   // ── grouping ──────────────────────────────────────────────────────────────
   // A node entry is { host, status, lastSeen, tickets[] }. The `null` host is the
   // synthetic "unassigned" bucket for tickets with no fence owner — used ONLY in
@@ -194,6 +214,7 @@ export function assembleClusterView({
           lastSeen: node.lastSeen,
           ...resolveDrain(host),
           ...resolveCapacity(host, node.status),
+          ...resolveAdmission(host, node.status),
           tickets: tickets.map((t) => makeTicket(t, host)),
         },
       ],
@@ -224,7 +245,7 @@ export function assembleClusterView({
       continue;
     }
     const node = livenessByHost.get(host) ?? { status: "offline", lastSeen: null };
-    nodes.push({ host, status: node.status, lastSeen: node.lastSeen, ...resolveDrain(host), ...resolveCapacity(host, node.status), tickets: groupTickets });
+    nodes.push({ host, status: node.status, lastSeen: node.lastSeen, ...resolveDrain(host), ...resolveCapacity(host, node.status), ...resolveAdmission(host, node.status), tickets: groupTickets });
   }
 
   return {
@@ -289,6 +310,9 @@ export function createClusterEntity({
   // createClusterEntity is the SOLE prod entry, so this param keeps the seam symmetric — a
   // future live drainReader only needs the server.ts builder, not another edit here.
   drainReader = null,
+  // CTL-1322: injectable admission reader; forwarded verbatim to assembleClusterView.
+  // (host) -> { accepting, holdReason, … } | null. Default null = feature off.
+  admissionReader = null,
   now = () => Date.now(),
 } = {}) {
   // Memoize the lazy execution-core import so repeated assembles don't re-import.
@@ -347,6 +371,7 @@ export function createClusterEntity({
         capacityReader,
         aliases,
         drainReader,
+        admissionReader,
       });
     },
   };

--- a/plugins/dev/scripts/orch-monitor/server.ts
+++ b/plugins/dev/scripts/orch-monitor/server.ts
@@ -1303,8 +1303,15 @@ export function createServer(opts: CreateServerOptions): BunServer {
     max_parallel?: number | null;
     in_flight_count?: number;
   };
+  type NodeAdmission = {
+    accepting: boolean;
+    holdReason: "drain" | "liveness-cold" | null;
+    effectiveCapacity: number;
+    activeWorkers: number;
+  };
   let daemonDepsPromise: Promise<{
     readClusterHeartbeats: (opts: { logPath?: string }) => Record<string, string>;
+    readClusterAdmission: (opts: { logPath?: string }) => Record<string, NodeAdmission>;
     getHostName: () => string;
     getClusterHosts: () => string[];
     getLivenessAnchorIssue: () => string | null;
@@ -1319,7 +1326,10 @@ export function createServer(opts: CreateServerOptions): BunServer {
           const configMod = ["..", "execution-core", "config.mjs"].join("/");
           const heartbeatSyncMod = ["..", "execution-core", "cluster-heartbeat-sync.mjs"].join("/");
           const [recovery, config, heartbeatSync, navSignal] = await Promise.all([
-            import(recoveryMod) as Promise<{ readClusterHeartbeats: (opts: { logPath?: string }) => Record<string, string> }>,
+            import(recoveryMod) as Promise<{
+              readClusterHeartbeats: (opts: { logPath?: string }) => Record<string, string>;
+              readClusterAdmission: (opts: { logPath?: string }) => Record<string, NodeAdmission>;
+            }>,
             import(configMod) as Promise<{
               getHostName: () => string;
               getClusterHosts: () => string[];
@@ -1332,6 +1342,7 @@ export function createServer(opts: CreateServerOptions): BunServer {
           ]);
           return {
             readClusterHeartbeats: recovery.readClusterHeartbeats,
+            readClusterAdmission: recovery.readClusterAdmission,
             getHostName: config.getHostName,
             getClusterHosts: config.getClusterHosts,
             getLivenessAnchorIssue: config.getLivenessAnchorIssue,
@@ -1491,11 +1502,36 @@ export function createServer(opts: CreateServerOptions): BunServer {
   const anchorCapacityCache: {
     map: Record<string, { maxParallel: number; inFlightCount: number }>;
   } = { map: {} };
+  // CTL-1322: LOCAL-node admission cache, read from the local event log's
+  // node.heartbeat admission block (readClusterAdmission). Local-only by design —
+  // the anchor transport carries no admission field, so remote peers stay absent
+  // here and render "live". Refreshed on the same poll as the anchor caches, but
+  // populated BEFORE the no-anchor early-return so it works single-host too.
+  const localAdmissionCache: { map: Record<string, NodeAdmission> } = { map: {} };
   let execCoreDeps: Awaited<ReturnType<typeof loadDaemonDeps>> = null;
   let anchorPollTimer: ReturnType<typeof setInterval> | null = null;
   const pollAnchorHeartbeats = (): void => {
     try {
       if (!execCoreDeps) return;
+      // CTL-1322: refresh local-node admission from the local event log. Runs BEFORE
+      // the no-anchor early-return so single-host installs (no anchor) still surface
+      // their own daemon's hold. The raw heartbeat host key can be an un-pinned OS
+      // hostname (pre-CTL-1093), so fold it through the SAME alias map
+      // assembleClusterView uses — otherwise admissionReader, queried with the PINNED
+      // display name, would miss the raw-keyed entry and the hold would render "live"
+      // (mirrors cluster-view.mjs's lastSeen alias-folding). hostAliases is captured by
+      // closure and resolved at call time (the first poll runs after setup completes).
+      // Fail-open: keep the last cache on any error.
+      try {
+        const rawAdmission = execCoreDeps.readClusterAdmission({}) ?? {};
+        const foldedAdmission: Record<string, NodeAdmission> = {};
+        for (const [host, adm] of Object.entries(rawAdmission)) {
+          foldedAdmission[resolveHostAlias(host, hostAliases)] = adm;
+        }
+        localAdmissionCache.map = foldedAdmission;
+      } catch {
+        /* keep last admission cache */
+      }
       const anchor = execCoreDeps.getLivenessAnchorIssue();
       if (!anchor) {
         anchorHeartbeatCache.map = {}; // no anchor configured → no peers
@@ -1575,6 +1611,14 @@ export function createServer(opts: CreateServerOptions): BunServer {
     capacityReader: (host: string) => {
       const resolved = resolveHostAlias(host, hostAliases);
       return anchorCapacityCache.map[resolved] ?? anchorCapacityCache.map[host] ?? null;
+    },
+    // CTL-1322: live per-node admission from the LOCAL event log (the self host).
+    // Only the local node is in localAdmissionCache → a remote host resolves to null
+    // → resolveAdmission contributes no fields → the peer renders "live" (honest
+    // "unknown", not a false hold). The self host gets accurate accepting/holdReason.
+    admissionReader: (host: string) => {
+      const resolved = resolveHostAlias(host, hostAliases);
+      return localAdmissionCache.map[resolved] ?? localAdmissionCache.map[host] ?? null;
     },
   });
   const readClusterView = async (board: BoardPayload): Promise<ClusterView> => {

--- a/plugins/dev/scripts/orch-monitor/ui/src/components/app-footer.test.tsx
+++ b/plugins/dev/scripts/orch-monitor/ui/src/components/app-footer.test.tsx
@@ -221,6 +221,44 @@ describe("AppFooter service-health indicator (CTL-1172)", () => {
     expect(containsText(el, "mac-mini offline")).toBe(true);
   });
 
+  it("live-but-holding node → tooltip 'holding (drain)', pill stays HEALTHY (CTL-1322)", () => {
+    // The FleetOps blind spot: a node that is UP but admitting no work never
+    // appears via the offline/degraded branch — CTL-1322 surfaces it in the tooltip.
+    serviceHealthState = { services: [svc({ id: "monitor" })], unavailable: false };
+    navState = { daemon: "healthy", workerCount: 0, queueDepth: 0, anomaly: false, generatedAt: "" };
+    clusterState = {
+      singleHost: true,
+      nodes: [{ host: "mac-mini", status: "live", accepting: false, holdReason: "drain" }],
+      generatedAt: "",
+    };
+    const el = AppFooter();
+    expect(containsText(el, "mac-mini holding (drain)")).toBe(true);
+    // A drain is operator intent, NOT a fleet alarm → worstSeverity unchanged.
+    expect(containsText(el, "HEALTHY")).toBe(true);
+    expect(containsText(el, "DOWN")).toBe(false);
+  });
+
+  it("degraded AND holding node reports only the worse (degraded) line — no dup (CTL-1322)", () => {
+    serviceHealthState = { services: [svc({ id: "monitor" })], unavailable: false };
+    navState = { daemon: "healthy", workerCount: 0, queueDepth: 0, anomaly: false, generatedAt: "" };
+    clusterState = {
+      singleHost: false,
+      nodes: [{ host: "mac-mini", status: "degraded", accepting: false, holdReason: "drain" }],
+      generatedAt: "",
+    };
+    const el = AppFooter();
+    expect(containsText(el, "mac-mini degraded")).toBe(true);
+    expect(containsText(el, "holding")).toBe(false); // else-if: only the worse line
+  });
+
+  it("a node WITHOUT admission renders no hold line (absent ⇒ live, CTL-1322)", () => {
+    serviceHealthState = { services: [svc({ id: "monitor" })], unavailable: false };
+    navState = { daemon: "healthy", workerCount: 0, queueDepth: 0, anomaly: false, generatedAt: "" };
+    clusterState = { singleHost: true, nodes: [{ host: "mac-mini", status: "live" }], generatedAt: "" };
+    const el = AppFooter();
+    expect(containsText(el, "holding")).toBe(false);
+  });
+
   it("degraded service only → DEGRADED (AC-B)", () => {
     serviceHealthState = {
       services: [svc({ id: "loki", label: "Loki", severity: "degraded" })],

--- a/plugins/dev/scripts/orch-monitor/ui/src/components/app-footer.tsx
+++ b/plugins/dev/scripts/orch-monitor/ui/src/components/app-footer.tsx
@@ -80,6 +80,14 @@ export function AppFooter() {
         for (const n of cluster?.nodes ?? []) {
           if (n.status === "offline" || n.status === "degraded") {
             out.push(nodeStatusLabel(n.host, n.status));
+          } else if (n.accepting === false) {
+            // CTL-1322: a live-but-holding node (drain / liveness-cold) never appears
+            // via the offline/degraded branch — surface it so an operator sees the node
+            // is up but admitting no work. else-if so a node that is BOTH degraded and
+            // holding reports only the worse (degraded) line. worstSeverity (above) is
+            // deliberately NOT bumped: a drain is operator intent, not a fleet alarm —
+            // the pill stays healthy, only the tooltip gains the line (the calm choice).
+            out.push(`${n.host} holding${n.holdReason ? ` (${n.holdReason})` : ""}`);
           }
         }
         if (nav && nav.daemon !== "healthy") out.push(daemonLabel(nav.daemon));

--- a/plugins/dev/scripts/orch-monitor/ui/src/components/observe/fleetops-kit.test.ts
+++ b/plugins/dev/scripts/orch-monitor/ui/src/components/observe/fleetops-kit.test.ts
@@ -16,6 +16,7 @@ import {
   hostWorkerCount,
   shortHostName,
   nodeStatusVar,
+  daemonCell,
   SILENCE_STALL_MS,
   type ReapWorkerInput,
 } from "./fleetops-kit";
@@ -244,5 +245,46 @@ describe("hostWorkerCount / shortHostName / nodeStatusVar — host-matrix helper
     expect(nodeStatusVar("live")).toBe("var(--chart-2)");
     expect(nodeStatusVar("degraded")).toBe("var(--chart-3)");
     expect(nodeStatusVar("offline")).toBe("var(--chart-4)");
+  });
+});
+
+describe("daemonCell — admission-aware Daemon cell (CTL-1322)", () => {
+  it("a live node accepting work reads 'live' (green), no title", () => {
+    const cell = daemonCell(node({ status: "live", accepting: true, holdReason: null }));
+    expect(cell.label).toBe("live");
+    expect(cell.color).toBe("var(--chart-2)");
+    expect(cell.title).toBeUndefined();
+  });
+
+  it("a live-but-holding node reads 'holding (<reason>)' in amber — the blind spot", () => {
+    const drain = daemonCell(node({ status: "live", accepting: false, holdReason: "drain" }));
+    expect(drain.label).toBe("holding (drain)");
+    expect(drain.color).toBe("var(--chart-3)"); // amber/warn, NOT red
+    expect(drain.title).toContain("not accepting");
+    const cold = daemonCell(node({ status: "live", accepting: false, holdReason: "liveness-cold" }));
+    expect(cold.label).toBe("holding (liveness-cold)");
+  });
+
+  it("holding with no reason falls back to bare 'holding'", () => {
+    const cell = daemonCell(node({ status: "live", accepting: false, holdReason: null }));
+    expect(cell.label).toBe("holding");
+  });
+
+  it("offline ALWAYS wins — a dead daemon is 'OFFLINE', never 'holding'", () => {
+    const cell = daemonCell(node({ status: "offline", accepting: false, holdReason: "drain" }));
+    expect(cell.label).toBe("OFFLINE");
+    expect(cell.color).toBe("var(--chart-4)");
+  });
+
+  it("absent accepting (remote peer / unknown) → plain liveness word, never a false hold", () => {
+    expect(daemonCell(node({ status: "live" })).label).toBe("live");
+    expect(daemonCell(node({ status: "degraded" })).label).toBe("degraded");
+  });
+
+  it("a degraded node holding work shows the liveness word 'degraded' (liveness wins, matches footer)", () => {
+    const cell = daemonCell(node({ status: "degraded", accepting: false, holdReason: "drain" }));
+    expect(cell.label).toBe("degraded");
+    expect(cell.color).toBe("var(--chart-3)"); // degraded is amber too, but it's the liveness word
+    expect(cell.title).toBeUndefined();
   });
 });

--- a/plugins/dev/scripts/orch-monitor/ui/src/components/observe/fleetops-kit.ts
+++ b/plugins/dev/scripts/orch-monitor/ui/src/components/observe/fleetops-kit.ts
@@ -301,3 +301,42 @@ export function nodeStatusVar(status: ClusterNodeStatus): string {
   if (status === "degraded") return "var(--chart-3)";
   return "var(--chart-4)";
 }
+
+/** The rendered FleetOps "Daemon" cell for a node. */
+export interface DaemonCell {
+  /** The cell word: "live" | "degraded" | "OFFLINE" | "holding" | "holding (<reason>)". */
+  label: string;
+  /** The status-color CSS var for the label. */
+  color: string;
+  /** Hover title spelling out a hold reason, else undefined. */
+  title?: string;
+}
+
+/**
+ * The FleetOps "Daemon" cell for a node (CTL-1322). Normally the liveness word,
+ * BUT a LIVE node that is NOT accepting new work (admission `accepting === false`)
+ * is the exact FleetOps blind spot — it would otherwise read "live" while the
+ * new-work gate is shut. Such a node renders "holding (<reason>)" in AMBER (warn),
+ * never red — a drain / liveness-cold hold is operator-intent or transient, not a
+ * failure. Precedence: the liveness word wins when the node is degraded or offline
+ * (a shaky/dead daemon's holding sub-state is less actionable than its liveness) —
+ * matching the footer tooltip's offline/degraded-first ordering, so the two surfaces
+ * agree. The check is STRICT `=== false`, so an ABSENT `accepting` (remote peer /
+ * unknown) falls through to the plain liveness word — never a fabricated hold.
+ * PURE + exported.
+ */
+export function daemonCell(
+  node: Pick<ClusterSignalNode, "status" | "accepting" | "holdReason">,
+): DaemonCell {
+  const { status } = node;
+  if (status === "live" && node.accepting === false) {
+    const reason = node.holdReason ?? null;
+    return {
+      label: reason ? `holding (${reason})` : "holding",
+      color: "var(--chart-3)", // amber/warn — operator-intent hold, not a failure
+      title: `not accepting new work${reason ? ` — ${reason}` : ""}`,
+    };
+  }
+  const label = status === "live" ? "live" : status === "degraded" ? "degraded" : "OFFLINE";
+  return { label, color: nodeStatusVar(status) };
+}

--- a/plugins/dev/scripts/orch-monitor/ui/src/components/observe/host-matrix.tsx
+++ b/plugins/dev/scripts/orch-monitor/ui/src/components/observe/host-matrix.tsx
@@ -16,7 +16,7 @@ import { useNavigate } from "@tanstack/react-router";
 import { Panel, PanelHeader, SectionLabel } from "@/components/ui/panel";
 import type { ClusterSignalNode } from "@/lib/cluster-signal";
 import type { BoardWorker } from "@/board/types";
-import { hostWorkerCount, shortHostName, nodeStatusVar } from "./fleetops-kit";
+import { hostWorkerCount, shortHostName, nodeStatusVar, daemonCell } from "./fleetops-kit";
 
 export interface HostMatrixProps {
   /** The cluster roster (one row per node). null ⇒ cluster signal unreachable. */
@@ -96,12 +96,20 @@ export function HostMatrix({ nodes, workers, maxParallel, boardAgeMs }: HostMatr
                   <span className="truncate font-mono">{shortHostName(n.host)}</span>
                 </span>
 
-                {/* daemon — liveness status word, tone-colored. The UI cluster signal
-                    carries no lastSeen, so we render the status word (not a heartbeat
-                    age — that needs the OBS-15 reader) honestly. */}
-                <span style={{ color: daemonColor }}>
-                  {n.status === "live" ? "live" : n.status === "degraded" ? "degraded" : "OFFLINE"}
-                </span>
+                {/* daemon — liveness word, tone-colored. CTL-1322: a node that is UP
+                    but NOT accepting new work (admission hold) renders
+                    "holding (<reason>)" in amber instead of a misleading "live" — the
+                    exact FleetOps blind spot. The host dot above stays status-colored
+                    (hardware up, gate closed). The UI cluster signal carries no
+                    lastSeen, so we render the word, not a heartbeat age (OBS-15). */}
+                {(() => {
+                  const cell = daemonCell(n);
+                  return (
+                    <span style={{ color: cell.color }} title={cell.title}>
+                      {cell.label}
+                    </span>
+                  );
+                })()}
 
                 {/* broker — board-freshness proxy (the board IS the broker projection). */}
                 <span

--- a/plugins/dev/scripts/orch-monitor/ui/src/lib/cluster-signal.ts
+++ b/plugins/dev/scripts/orch-monitor/ui/src/lib/cluster-signal.ts
@@ -18,6 +18,9 @@
 /** One node's heartbeat-overlay liveness — the footer dot color (mirrors the server). */
 export type ClusterNodeStatus = "live" | "degraded" | "offline";
 
+/** CTL-1322: why a live-but-not-accepting node is holding new-work admission. */
+export type HoldReason = "drain" | "liveness-cold";
+
 /** One real roster node in the footer signal: its host name + liveness. */
 export interface ClusterSignalNode {
   host: string;
@@ -28,6 +31,10 @@ export interface ClusterSignalNode {
   freeSlots?: number;
   /** CTL-1092: in-flight ticket ids from the heartbeat (for remote slot labels). */
   tickets?: string[];
+  /** CTL-1322: local node's new-work admission from its heartbeat. ABSENT ⇒ unknown
+   *  (render "live"); a remote peer always omits it. `accepting:false` ⇒ holding. */
+  accepting?: boolean;
+  holdReason?: HoldReason | null;
 }
 
 /** The per-node cluster-health wire shape the footer renders (server's ClusterSignal). */

--- a/website/src/content/docs/reference/configuration.md
+++ b/website/src/content/docs/reference/configuration.md
@@ -322,3 +322,25 @@ The detector above only emits low-level `catalyst.ingestion.*` events. CTL-1123 
   - `FILTER_PILEUP_THRESHOLD` (default `3`) — minimum labelled-ticket count to alert.
   - `FILTER_PILEUP_PERSISTENCE_MS` (default `300000`) — the count must stay at/above the threshold this long before one alert fires (spike guard).
   - `FILTER_PILEUP_COOLDOWN_MS` (default `3600000`) — minimum gap after a clear before it can re-fire (flap guard).
+
+### Node admission state on the heartbeat (CTL-1322)
+
+A daemon that is **alive but not accepting new work** (draining, or a liveness-cold hold) otherwise looks fully healthy to uptime monitoring while pulling zero work — the recurring "why isn't work moving?" blind spot. CTL-1322 makes that state **visible in telemetry**: every `node.heartbeat` event now carries an `admission` block in `body.payload`:
+
+```json
+"admission": { "accepting": false, "holdReason": "drain", "effectiveCapacity": 0, "activeWorkers": 6 }
+```
+
+- `accepting` mirrors the scheduler's new-work gate exactly (`livenessFresh && !isDraining()`), so the heartbeat can never disagree with what the daemon actually enforces.
+- `holdReason` is `"drain"` (the persistent operator-intent hold, CTL-1095), `"liveness-cold"` (the transient snapshot-staleness hold, CTL-731), or `null` when accepting. Drain takes precedence when both apply.
+- `effectiveCapacity` is the admission ceiling (`maxParallel` when accepting, `0` when held); `activeWorkers` is the live background-worker count.
+
+The orch-monitor surfaces it for the **local** node: the FleetOps Hosts "Daemon" column renders `holding (<reason>)` (amber) instead of a misleading "live", and the footer health tooltip gains a `<host> holding (<reason>)` line — without bumping the health pill (a drain is operator intent, not a fleet alarm). Remote peers omit the field (the cross-host anchor transport carries no admission yet) and render "live".
+
+**Alerting** is a host-side Loki/Grafana rule over the new field (the same out-of-band, delivery-out-of-scope contract as CTL-1123) — no in-repo change, no secrets in the daemon. The `admission` block rides the `node.heartbeat` **event** (the unified event log → `otel-forward` → Loki as the `{job="catalyst-events"}` stream — *not* the Alloy-shipped daemon `.log` stream, which only carries a bare heartbeat marker with no admission JSON):
+
+```logql
+count_over_time({job="catalyst-events"} | json | attributes["event.name"]="node.heartbeat" |= "\"accepting\":false" [12m]) > 0
+```
+
+with a `for: 10m` window. The host lives inside the JSON body (`body.payload."host.name"`), so scope per node with a body match (e.g. `|= "\"host.name\":\"mini\""`), not a stream label. A daemon-emitted, debounced `catalyst.alert.not_accepting` edge (cleaner raised/cleared semantics) is a planned follow-up.


### PR DESCRIPTION
## What & why

Fixes [CTL-1322](https://linear.app/coalesce-labs/issue/CTL-1322). A daemon that is **alive but not accepting new work** (draining, or a liveness-cold hold) heartbeats healthy to uptime monitoring while pulling **zero** work — the recurring **"why isn't work moving?"** blind spot, with no queryable signal. (Live example today: a draining/wedged node reads "live" everywhere.)

## The fix

**Telemetry (the data substrate):** every `node.heartbeat` now carries
```json
"admission": { "accepting": false, "holdReason": "drain", "effectiveCapacity": 0, "activeWorkers": 6 }
```
computed by a new `readAdmissionState()` (`admission-state.mjs`) that **mirrors the scheduler's new-work gate exactly** — `accepting = livenessFresh && !isDraining()`, `activeWorkers = countBackgroundAgents()` (the gate's live count, not the leaky dir-scan), `holdReason` drain-first — so the heartbeat can't disagree with what the daemon enforces. Threaded via an `admissionFn` seam through `heartbeat-event.mjs` (which also **fixes a latent dropped-`governanceFn` seam**). `recovery.readClusterAdmission()` reads it back from the local event log (newest-wins, `admission:null` clears a stale hold, fail-open).

**UI exposure (visible to the operator):** surfaced for the **local** node through the existing `/api/cluster` pipe → the FleetOps Hosts **"Daemon" column reads `holding (drain)` (amber)** instead of a misleading "live" (the exact blind spot), and the always-on **footer tooltip** gains a `<host> holding (<reason>)` line — without bumping the health pill (a drain is operator intent, not a fleet alarm). Remote peers omit the field (the cross-host anchor transport carries no admission yet) and honestly render "live".

**Alerting:** a host-side Loki/Grafana rule over the new field (the decoupled out-of-band pattern — no in-repo change, no secrets in the daemon), documented with the correct `{job="catalyst-events"}` event-log query.

## Scope / deferred (filed as follow-ups)
- Daemon-emitted debounced `catalyst.alert.not_accepting` edge (cleaner raised/cleared) + the host-side delivery rule.
- **Belief-store inference** of admission state (the shadow→enforce seed — the belief store is hold-blind + static-`6` today).
- Remote-peer admission over the anchor transport (today remote peers render "live").

## Testing
- New: `readAdmissionState` truth-table (4 holdReason/capacity cases incl. drain-precedence); `readClusterAdmission` (newest-wins/null-clears/fail-open); heartbeat `admission` block + the `governanceFn`/`admissionFn` seam-fix (fail-before/pass-after); the `startHeartbeat→emitHeartbeatEvent` forward (mutation-proved); daemon `admissionFn` wiring; the cluster-view `admissionReader` **forward-guard** (the CTL-1092 prod-dead class); `deriveClusterSignal` pass-through; UI `daemonCell` + footer holding tooltip + decode back-compat.
- All new tests pass in isolation; parent+ui typecheck clean, **lint 0 errors, knip clean**. The only full-suite failures are pre-existing on `main` (mac-only host-identity tests + known flaky integration pollution).

## Review
Design, server→UI data-flow, and the diff were each verified via multi-agent workflows. Applied review findings: alias host-key fold in the admission cache, the `startHeartbeat` forward test, the doc LogQL stream correction, `effectiveCapacity` boot-snapshot scoping, and matrix/footer precedence alignment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)