### PR TITLE
fix(dev): CTL-1323 — a recovery-pass-only worker dir strands its ticket from the new-work pull

### DIFF
--- a/.github/workflows/execution-core-tests.yml
+++ b/.github/workflows/execution-core-tests.yml
@@ -119,6 +119,7 @@ jobs:
             autotune-writeback.test.mjs \
             board-health.test.mjs \
             board-health-seam.test.mjs \
+            phantom-worker-dir.test.mjs \
             boot-resume-approval.test.mjs \
             boot-resume.test.mjs \
             claim.test.mjs \

--- a/plugins/dev/scripts/execution-core/phantom-worker-dir.test.mjs
+++ b/plugins/dev/scripts/execution-core/phantom-worker-dir.test.mjs
@@ -1,0 +1,148 @@
+// phantom-worker-dir.test.mjs — CTL-1323. A board-health recovery-pass leaves a
+// worker dir whose only signal is `phase-recovery-pass.json:done`; bare directory
+// existence (listStartedTickets) then strands the ticket from the new-work pull
+// forever, and isTicketInFlight counts it as occupying a slot — so the ticket sits
+// in Todo with no live worker (the live ADV-1398/1400/1306 wedge). These tests pin
+// the phantom-dir fix that lets such a ticket be re-pulled fresh.
+//
+// CI-INCLUDED (registered in .github/workflows/execution-core-tests.yml). The
+// scheduler.test.mjs real-timer suite is excluded from CI, so the wedge coverage
+// lives here over the pure exported helpers — the CTL-1290 board-health-seam pattern.
+//
+// Run: cd plugins/dev/scripts/execution-core && bun test phantom-worker-dir.test.mjs
+
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  isPhantomWorkerDir,
+  listStartedTickets,
+  listInFlightTickets,
+  buildGlobalRanking,
+} from "./scheduler.mjs";
+
+let orchDir;
+
+beforeEach(() => {
+  orchDir = mkdtempSync(join(tmpdir(), "ctl1323-phantom-"));
+  mkdirSync(join(orchDir, "workers"), { recursive: true });
+});
+
+afterEach(() => {
+  rmSync(orchDir, { recursive: true, force: true });
+});
+
+// Seed workers/<ticket>/phase-<phase>.json = { status } (the readPhaseSignals shape).
+function seedSignal(ticket, phase, status) {
+  const dir = join(orchDir, "workers", ticket);
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(join(dir, `phase-${phase}.json`), JSON.stringify({ status }));
+}
+
+describe("isPhantomWorkerDir (CTL-1323)", () => {
+  test("a completed recovery-pass-only dir is phantom", () => {
+    expect(isPhantomWorkerDir({ "recovery-pass": "done" })).toBe(true);
+  });
+
+  test("'complete' / 'skipped' terminal-success recovery-pass dirs are also phantom", () => {
+    expect(isPhantomWorkerDir({ "recovery-pass": "complete" })).toBe(true);
+    expect(isPhantomWorkerDir({ "recovery-pass": "skipped" })).toBe(true);
+  });
+
+  test("an ACTIVE recovery-pass (dispatched/running) is NOT phantom — it holds a real slot", () => {
+    expect(isPhantomWorkerDir({ "recovery-pass": "running" })).toBe(false);
+    expect(isPhantomWorkerDir({ "recovery-pass": "dispatched" })).toBe(false);
+  });
+
+  test("a PARKED / ESCALATED / PREEMPTED / FAILED recovery-pass is NOT phantom — never re-pulled", () => {
+    // These statuses surface a pending operator decision (needs-human / Needs-You) or
+    // are resumable (preempted) or hold the slot — re-pulling them would bury that state.
+    for (const status of ["needs-human", "needs-input", "turn-cap-exhausted", "preempted", "failed", "stalled", "aborted"]) {
+      expect(isPhantomWorkerDir({ "recovery-pass": status })).toBe(false);
+    }
+  });
+
+  test("ANY real pipeline signal makes it NOT phantom — even a terminal one beside a recovery-pass", () => {
+    expect(isPhantomWorkerDir({ implement: "running" })).toBe(false);
+    expect(isPhantomWorkerDir({ research: "done" })).toBe(false);
+    expect(isPhantomWorkerDir({ "recovery-pass": "done", implement: "failed" })).toBe(false);
+    expect(isPhantomWorkerDir({ "recovery-pass": "done", "monitor-deploy": "done" })).toBe(false);
+  });
+
+  test("an ancillary phase (remediate) is real pipeline work, not phantom", () => {
+    expect(isPhantomWorkerDir({ remediate: "done" })).toBe(false);
+  });
+
+  test("an empty / nullish signal set is NOT phantom (conservative)", () => {
+    expect(isPhantomWorkerDir({})).toBe(false);
+    expect(isPhantomWorkerDir(null)).toBe(false);
+    expect(isPhantomWorkerDir(undefined)).toBe(false);
+  });
+});
+
+describe("listStartedTickets / listInFlightTickets ignore phantom dirs (CTL-1323)", () => {
+  test("a recovery-pass-done dir is NEITHER started nor in-flight", () => {
+    seedSignal("ADV-1398", "recovery-pass", "done");
+    expect(listStartedTickets(orchDir).has("ADV-1398")).toBe(false);
+    expect(listInFlightTickets(orchDir).has("ADV-1398")).toBe(false);
+  });
+
+  test("a real in-flight dir is BOTH started and in-flight (regression guard)", () => {
+    seedSignal("CTL-1", "implement", "running");
+    expect(listStartedTickets(orchDir).has("CTL-1")).toBe(true);
+    expect(listInFlightTickets(orchDir).has("CTL-1")).toBe(true);
+  });
+
+  test("an ACTIVE recovery-pass dir is still counted — no premature re-pull/double-dispatch", () => {
+    seedSignal("ADV-9", "recovery-pass", "running");
+    expect(listStartedTickets(orchDir).has("ADV-9")).toBe(true);
+  });
+
+  test("a needs-human ESCALATED recovery-pass dir is still started (held, not re-pulled)", () => {
+    seedSignal("ADV-esc", "recovery-pass", "needs-human");
+    expect(listStartedTickets(orchDir).has("ADV-esc")).toBe(true);
+  });
+
+  test("an empty worker dir (no phase signals yet) is started but NOT in-flight — conservative, not re-pulled", () => {
+    mkdirSync(join(orchDir, "workers", "CTL-fresh"), { recursive: true });
+    expect(listStartedTickets(orchDir).has("CTL-fresh")).toBe(true);
+    expect(listInFlightTickets(orchDir).has("CTL-fresh")).toBe(false);
+  });
+});
+
+describe("buildGlobalRanking re-pulls a phantom-wedged eligible ticket (CTL-1323)", () => {
+  test("ADV-1398 (recovery-pass:done) eligible → exactly ONE fresh new-work descriptor (no dup)", () => {
+    seedSignal("ADV-1398", "recovery-pass", "done");
+    const eligible = [{ identifier: "ADV-1398", priority: 2, createdAt: "2026-06-23T10:00:00Z" }];
+    const ranking = buildGlobalRanking(orchDir, eligible);
+    const adv = ranking.filter((d) => d.identifier === "ADV-1398");
+    expect(adv).toHaveLength(1); // not double-listed as in-flight AND eligible
+    expect(adv[0].inFlight).toBe(false); // re-pulled as FRESH new work — the unstick
+  });
+
+  test("a real in-flight ticket stays EXCLUDED from the new-work pull", () => {
+    seedSignal("CTL-7", "implement", "running");
+    const eligible = [{ identifier: "CTL-7", priority: 2, createdAt: "2026-06-23T10:00:00Z" }];
+    const ranking = buildGlobalRanking(orchDir, eligible);
+    const c7 = ranking.filter((d) => d.identifier === "CTL-7");
+    expect(c7).toHaveLength(1);
+    expect(c7[0].inFlight).toBe(true); // listed as in-flight, NOT re-pulled as new work
+  });
+
+  test("an ACTIVE recovery-pass:running eligible ticket is held (inFlight:true), not re-pulled", () => {
+    seedSignal("ADV-run", "recovery-pass", "running");
+    const eligible = [{ identifier: "ADV-run", priority: 2, createdAt: "2026-06-23T10:00:00Z" }];
+    const adv = buildGlobalRanking(orchDir, eligible).filter((d) => d.identifier === "ADV-run");
+    expect(adv).toHaveLength(1);
+    expect(adv[0].inFlight).toBe(true);
+  });
+
+  test("a needs-human ESCALATED recovery-pass eligible ticket is held (inFlight:true), NOT re-pulled — escalation preserved", () => {
+    seedSignal("ADV-esc", "recovery-pass", "needs-human");
+    const eligible = [{ identifier: "ADV-esc", priority: 2, createdAt: "2026-06-23T10:00:00Z" }];
+    const adv = buildGlobalRanking(orchDir, eligible).filter((d) => d.identifier === "ADV-esc");
+    expect(adv).toHaveLength(1);
+    expect(adv[0].inFlight).toBe(true); // the pending Needs-You signal is not buried by a fresh re-pull
+  });
+});

--- a/plugins/dev/scripts/execution-core/scheduler.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.mjs
@@ -54,6 +54,7 @@ import {
   TERMINAL_PHASE,
   NEW_WORK_ENTRY_PHASE,
   NON_PREEMPTABLE_PHASES,
+  ANCILLARY_PHASES, // CTL-1323: remediate etc. — still real pipeline work (PHASES is already imported from phase-fsm above)
 } from "../lib/workflow-descriptor.mjs";
 export { STAGE_RANK, NON_PREEMPTABLE_PHASES };
 // CTL-653: the verdict-router reads (verify.json verdict + event-counted cycle
@@ -686,6 +687,44 @@ export function isTicketInFlight(signals) {
   return true;
 }
 
+// CTL-1323: the set of REAL pipeline phases — a signal whose phase is one of these
+// represents genuine pipeline work occupying a slot. Phases NOT in this set (e.g.
+// "recovery-pass", the board-health delegate's inspection sweep) are transient
+// artifacts, not pipeline work.
+const REAL_PIPELINE_PHASES = new Set([...PHASES, ...ANCILLARY_PHASES]);
+
+// CTL-1323: the terminal-SUCCESS statuses that mean a non-pipeline signal is truly
+// inert — no live worker, and no pending operator decision. ONLY these make a dir
+// phantom. We deliberately use a POSITIVE allow-list (not "anything not running"):
+// a recovery-pass that ESCALATED (needs-human), PARKED (needs-input/turn-cap-exhausted),
+// was PREEMPTED, or FAILED must stay held — it surfaces a Needs-You signal or is
+// resumable, and re-pulling it would bury that pending state / abandon recovery context.
+const PHANTOM_TERMINAL_STATUSES = new Set(["done", "complete", "skipped"]);
+
+// CTL-1323: isPhantomWorkerDir — true when a worker dir is a PHANTOM: it carries
+// signals, but NONE is a real pipeline phase AND every signal is terminal-success.
+// The canonical case is a board-health recovery-pass that ran+completed, leaving only
+// `phase-recovery-pass.json:done`. Such a dir is NOT pipeline work — yet bare
+// directory-existence (listStartedTickets) excludes the ticket from the new-work pull
+// FOREVER, and isTicketInFlight counts it as occupying a slot, so the ticket strands in
+// Todo with no live worker (the CTL-1323 wedge: ADV-1398/1400/1306). Treating it as a
+// phantom lets both list functions ignore it so the ticket is re-pulled fresh.
+//
+// A non-pipeline signal that is NOT terminal-success (dispatched/running/preempted/
+// needs-human/needs-input/turn-cap-exhausted/failed/…) makes the dir NON-phantom — it
+// holds a real slot or a pending operator/recovery state we must not clobber. An EMPTY
+// signal set is NOT phantom (conservative — a bare/just-created dir we don't re-pull).
+// Pure over a phase→status map; exported for the CI unit suite.
+export function isPhantomWorkerDir(signals) {
+  const entries = Object.entries(signals ?? {});
+  if (entries.length === 0) return false;
+  for (const [phase, status] of entries) {
+    if (REAL_PIPELINE_PHASES.has(phase)) return false; // a genuine pipeline signal
+    if (!PHANTOM_TERMINAL_STATUSES.has(status)) return false; // active / parked / escalated → not phantom
+  }
+  return true; // only terminal-success non-pipeline signals (e.g. recovery-pass:done)
+}
+
 // listInFlightTickets — Set of ticket ids currently occupying a worker slot.
 export function listInFlightTickets(orchDir) {
   const inFlight = new Set();
@@ -697,7 +736,11 @@ export function listInFlightTickets(orchDir) {
   }
   for (const d of dirs) {
     if (!d.isDirectory()) continue;
-    if (isTicketInFlight(readPhaseSignals(orchDir, d.name))) inFlight.add(d.name);
+    const signals = readPhaseSignals(orchDir, d.name);
+    // CTL-1323: a phantom recovery-pass dir is not real in-flight work — skip it so it
+    // isn't counted as occupying a slot (and so buildGlobalRanking doesn't list it both
+    // as in-flight here AND as a fresh new-work candidate once listStartedTickets drops it).
+    if (isTicketInFlight(signals) && !isPhantomWorkerDir(signals)) inFlight.add(d.name);
   }
   return inFlight;
 }
@@ -1238,6 +1281,10 @@ export function listStartedTickets(orchDir) {
     return new Set(
       readdirSync(join(orchDir, "workers"), { withFileTypes: true })
         .filter((d) => d.isDirectory())
+        // CTL-1323: a phantom recovery-pass dir does NOT count as "started" — otherwise
+        // the new-work pull (buildGlobalRanking) excludes the ticket forever and it
+        // strands in Todo with no live worker. Dropping it here re-pulls it as fresh work.
+        .filter((d) => !isPhantomWorkerDir(readPhaseSignals(orchDir, d.name)))
         .map((d) => d.name)
     );
   } catch {

--- a/website/src/content/docs/reference/configuration.md
+++ b/website/src/content/docs/reference/configuration.md
@@ -337,10 +337,10 @@ A daemon that is **alive but not accepting new work** (draining, or a liveness-c
 
 The orch-monitor surfaces it for the **local** node: the FleetOps Hosts "Daemon" column renders `holding (<reason>)` (amber) instead of a misleading "live", and the footer health tooltip gains a `<host> holding (<reason>)` line — without bumping the health pill (a drain is operator intent, not a fleet alarm). Remote peers omit the field (the cross-host anchor transport carries no admission yet) and render "live".
 
-**Alerting** is a host-side Loki/Grafana rule over the new field (the same out-of-band, delivery-out-of-scope contract as CTL-1123) — no in-repo change, no secrets in the daemon. The `admission` block rides the `node.heartbeat` **event** (the unified event log → `otel-forward` → Loki as the `{job="catalyst-events"}` stream — *not* the Alloy-shipped daemon `.log` stream, which only carries a bare heartbeat marker with no admission JSON):
+**Alerting** is a host-side Loki/Grafana rule (the same out-of-band, delivery-out-of-scope contract as CTL-1123) — no in-repo change, no secrets in the daemon. Note the two telemetry paths: the structured `admission` block rides the `node.heartbeat` **event** (the unified event log), which on the current stack is **not** shipped to Loki — it powers the orch-monitor UI (the server reads the local event log directly) and any on-host event consumer. What **is** in Loki — via the Alloy daemon-`.log` shipper, stream `service_name="catalyst.execution-core"` — is the scheduler's free-text hold line, so alert on that:
 
 ```logql
-count_over_time({job="catalyst-events"} | json | attributes["event.name"]="node.heartbeat" |= "\"accepting\":false" [12m]) > 0
+count_over_time({service_name="catalyst.execution-core"} |= "holding new-work dispatch" [12m]) > 0
 ```
 
-with a `for: 10m` window. The host lives inside the JSON body (`body.payload."host.name"`), so scope per node with a body match (e.g. `|= "\"host.name\":\"mini\""`), not a stream label. A daemon-emitted, debounced `catalyst.alert.not_accepting` edge (cleaner raised/cleared semantics) is a planned follow-up.
+with a `for: 10m` window; scope per node with `| host_name="mini.rozich"`. This one line fires for **both** the drain hold (CTL-1095) and the liveness-cold hold (CTL-731). Follow-ups: ship the catalyst event log to Loki so the *structured* admission field becomes queryable, plus a daemon-emitted debounced `catalyst.alert.not_accepting` edge (cleaner raised/cleared semantics).


### PR DESCRIPTION
## What & why

Fixes [CTL-1323](https://linear.app/coalesce-labs/issue/CTL-1323) — **the active cause of "why isn't work moving" on the live board.**

A board-health recovery-pass that ran+completed leaves `workers/<ticket>/` with only a `phase-recovery-pass.json:done` signal (no pipeline-phase signal). `listStartedTickets` — a pure **directory-existence** check — then excludes that ticket from the new-work pull **forever**, and `isTicketInFlight` counts it as occupying a slot. So the ticket strands in Todo with **no live worker**, while eligible tickets pile up.

Live right now: **ADV-1398, ADV-1400** (mini) and **ADV-1306** (mini-2) are wedged exactly this way, with ~20 ADV tickets eligible and nothing dispatching. Grounding (`wf_d811f417`) confirmed this is a **distinct bug** from drain / CTL-1321 / the CTL-1301 drained-sentinel — which is why it ships standalone, ahead of CTL-1301.

## The fix

A pure `isPhantomWorkerDir(signals)` predicate — `true` only when a worker dir carries signals, **none** is a real pipeline phase (`PHASES ∪ ANCILLARY_PHASES`, so `recovery-pass` qualifies), **and** every signal is **terminal-success** (`done`/`complete`/`skipped`). Both `listStartedTickets` and `listInFlightTickets` skip phantom dirs, so the ticket is re-pulled fresh (and isn't double-listed in `buildGlobalRanking`). `isTicketInFlight` is untouched.

The **positive terminal-success allow-list is deliberate** (from review): a recovery-pass that **escalated** (`needs-human`), **parked** (`needs-input`/`turn-cap-exhausted`), was **preempted**, or **failed** is *not* phantom — it holds its slot / surfaces a pending **Needs-You** signal that re-pulling would bury.

## Blast radius (reviewed)
Adversarial multi-agent review traced every consumer of the two list functions: no new orphan (worker-dir-gc uses `isTicketInFlight`, unchanged), no double-dispatch (re-pull held at the triage-artifact gate; `deriveAdvancement` ignores non-`PHASES` signals), drain sentinel **improved** (a phantom dir previously wedged drain open), and free-slot math uses the live-agent count, not `listInFlightTickets` — so admission accounting is untouched.

## Testing
- New **CI-included** `phantom-worker-dir.test.mjs` (16 cases): the `buildGlobalRanking` re-pull (proven to fail pre-fix), the dedup guard (forces both list functions fixed in tandem), the escalation/park/preempt/failed **hold** cases, mixed-signal cases, and the real-in-flight regression guard. Registered in `execution-core-tests.yml`.
- `bun build daemon.mjs` clean; scheduler.test.mjs stable failures are the 2 pre-existing CTL-781 (mac-only, CI-excluded suite) — no new regressions.

Also corrects the CTL-1322 admission alerting LogQL (the catalyst event log isn't shipped to this Loki — alert on the daemon-`.log` hold line `{service_name="catalyst.execution-core"} |= "holding new-work dispatch"`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)