### PR TITLE
feat(dev): CTL-1330 — Tier-1 daemon instrumentation (tick timing + event-loop delay + liveness.refresh logs)

### DIFF
--- a/.github/workflows/execution-core-tests.yml
+++ b/.github/workflows/execution-core-tests.yml
@@ -126,6 +126,7 @@ jobs:
             claim.test.mjs \
             claude-agents.test.mjs \
             claude-ids.test.mjs \
+            tick-timing.test.mjs \
             cloud-token-env.test.mjs \
             cluster-claim-sync.test.mjs \
             cluster-claim.test.mjs \

--- a/plugins/dev/scripts/broker/tailer.mjs
+++ b/plugins/dev/scripts/broker/tailer.mjs
@@ -25,6 +25,11 @@ import { getInterests } from "./state.mjs";
 // Identity-stable alias — loadExistingRegistrations reports interests.size.
 const interests = getInterests();
 
+// CTL-1330 Tier 1: broker route-timing gate + slow-route threshold. Boot-fixed
+// (daemon env is set at launch); ON unless CATALYST_TICK_TIMING=off.
+const BROKER_ROUTE_TIMING = process.env.CATALYST_TICK_TIMING !== "off";
+const BROKER_SLOW_ROUTE_MS = Number(process.env.CATALYST_BROKER_SLOW_ROUTE_MS) || 100;
+
 // --- Reactive event log tailing ---
 let lastByteOffset = 0;
 let lastLogPath = "";
@@ -93,7 +98,19 @@ function readNewEvents() {
       } catch {
         continue;
       }
-      processEvent(event);
+      // CTL-1330 Tier 1: time each route; surface ONLY slow routes (default
+      // >100ms) so we catch a broker-side hot-loop stall without flooding Loki —
+      // the broker routes every appended event. ON by default (CATALYST_TICK_TIMING).
+      if (BROKER_ROUTE_TIMING) {
+        const t0 = performance.now();
+        processEvent(event);
+        const total_ms = Math.round((performance.now() - t0) * 10) / 10;
+        if (total_ms >= BROKER_SLOW_ROUTE_MS) {
+          log.warn({ event_name: getEventName(event), total_ms }, "broker: slow route (CTL-1330)");
+        }
+      } else {
+        processEvent(event);
+      }
     }
   } catch {
     // Log file not yet created or transient read error

--- a/plugins/dev/scripts/execution-core/claude-agents.mjs
+++ b/plugins/dev/scripts/execution-core/claude-agents.mjs
@@ -135,6 +135,17 @@ let _inflight = null; // (c) single-flight latch — a Promise or null
 let _failures = 0; // (d) consecutive failure counter
 let _backoffUntil = 0; // (d) suppress refresh until now() ≥ this
 
+// CTL-1330 Tier 1: liveness-refresh observability sink. The daemon wires this to
+// its pino logger (setLivenessLogger) so each refresh records {outcome,
+// duration_ms, deadline_ms, populated, age_ms} — the data that makes "refresh
+// aborted at 3000ms because the tick blocked the loop 3.2s" queryable. Null by
+// default so CLI/test callers never log. Kept as an injectable module sink (not a
+// config.mjs import) to keep this leaf module dependency-free and unit-testable.
+let _livenessLogger = null;
+export function setLivenessLogger(fn) {
+  _livenessLogger = typeof fn === "function" ? fn : null;
+}
+
 // backoffWindowMs — 0 below the failure threshold (retry every stale read), then
 // exponential (base × 2^over) capped at LIVENESS_BACKOFF_CAP_MS.
 function backoffWindowMs(failures) {
@@ -193,6 +204,8 @@ export function refreshAgents({
   const controller = new AbortController();
   let timer = null;
   let settled = false; // (b) set the instant the read resolves/rejects
+  const startMs = now(); // CTL-1330: refresh wall-clock start
+  let outcome = "resolved"; // CTL-1330: flipped to timeout/error on the failure paths
   const run = (async () => {
     try {
       // (a) async read, bound to the abort signal for (b). `.child` (when the
@@ -219,6 +232,7 @@ export function refreshAgents({
             if (settled) return; // read already completed — honor it
             const child = readP.child;
             if (!child || (child.exitCode === null && child.signalCode === null)) {
+              outcome = "timeout"; // CTL-1330: deadline aborted a still-running child
               controller.abort();
               reject(new Error("claude agents --json timed out"));
             }
@@ -234,12 +248,30 @@ export function refreshAgents({
       _backoffUntil = 0;
       return parsed;
     } catch {
+      if (outcome !== "timeout") outcome = "error"; // (CTL-1330) read/parse failure vs deadline
       _failures += 1; // (d) arm/extend backoff
       _backoffUntil = now() + backoffWindowMs(_failures);
       return _asyncSnap.agents ?? []; // serve last-good (or [] cold)
     } finally {
       if (timer !== null) clearTimer(timer);
       _inflight = null; // (c) release the latch
+      // CTL-1330 Tier 1: liveness-refresh observability. The wedge signature is
+      // outcome:"timeout" with duration_ms≈deadline_ms while a synchronous tick
+      // blocks the loop. Best-effort — a throwing sink must never break refresh.
+      if (_livenessLogger) {
+        try {
+          const populated = _asyncSnap.agents !== null;
+          _livenessLogger({
+            outcome,
+            duration_ms: now() - startMs,
+            deadline_ms: timeoutMs,
+            populated,
+            age_ms: populated ? now() - _asyncSnap.ts : null,
+          });
+        } catch {
+          /* observability must never throw out of the refresh */
+        }
+      }
     }
   })();
   _inflight = run;

--- a/plugins/dev/scripts/execution-core/claude-agents.test.mjs
+++ b/plugins/dev/scripts/execution-core/claude-agents.test.mjs
@@ -19,6 +19,7 @@ import {
   claudeStop,
   isBgJobDead,
   defaultStatJobState,
+  setLivenessLogger,
 } from "./claude-agents.mjs";
 
 const agents = [
@@ -735,5 +736,86 @@ describe("refreshAgents + getAgentsCached (Phase 00 hardened liveness read)", ()
     // statJob: allAlive so this test exercises the warm-snapshot path without
     // depending on real ~/.claude/jobs/ state (CTL-1055: default statJob does fs I/O).
     expect(countBackgroundAgents({ now: () => 1000, statJob: () => ({ state: "working", firstTerminalAt: null }) })).toBe(2);
+  });
+});
+
+describe("setLivenessLogger + refreshAgents observability (CTL-1330 Tier 1)", () => {
+  beforeEach(() => {
+    resetLivenessCache();
+    setLivenessLogger(null); // clear any sink between cases
+  });
+
+  test("resolved read records {outcome:'resolved', populated, deadline_ms, duration_ms}", async () => {
+    const records = [];
+    setLivenessLogger((r) => records.push(r));
+    let t = 1000;
+    await refreshAgents({
+      execFileAsync: async () => JSON.stringify(agents),
+      now: () => t,
+      timeoutMs: 3000,
+    });
+    expect(records).toHaveLength(1);
+    expect(records[0].outcome).toBe("resolved");
+    expect(records[0].deadline_ms).toBe(3000);
+    expect(records[0].populated).toBe(true);
+    expect(typeof records[0].duration_ms).toBe("number");
+  });
+
+  test("read error records {outcome:'error'} and still serves last-good (never throws)", async () => {
+    const records = [];
+    setLivenessLogger((r) => records.push(r));
+    const result = await refreshAgents({
+      execFileAsync: async () => {
+        throw new Error("boom");
+      },
+      now: () => 1000,
+      timeoutMs: 3000,
+    });
+    expect(result).toEqual([]); // cold fallback
+    expect(records).toHaveLength(1);
+    expect(records[0].outcome).toBe("error");
+  });
+
+  test("deadline timeout records {outcome:'timeout'} with duration≈deadline", async () => {
+    const records = [];
+    setLivenessLogger((r) => records.push(r));
+    const hanging = () => new Promise(() => {}); // never settles, no .child
+    let timeoutCb = null;
+    const p = refreshAgents({
+      execFileAsync: hanging,
+      now: () => 5000,
+      timeoutMs: 3000,
+      setTimer: (cb) => {
+        timeoutCb = cb;
+        return 1;
+      },
+      clearTimer: () => {},
+      deferDecision: (cb) => cb(), // run the verdict synchronously
+    });
+    timeoutCb(); // fire the deadline
+    await p;
+    expect(records).toHaveLength(1);
+    expect(records[0].outcome).toBe("timeout");
+    expect(records[0].deadline_ms).toBe(3000);
+  });
+
+  test("a null sink (default) never throws out of refreshAgents", async () => {
+    setLivenessLogger(null);
+    const result = await refreshAgents({
+      execFileAsync: async () => JSON.stringify(agents),
+      now: () => 1000,
+    });
+    expect(result).toEqual(agents);
+  });
+
+  test("a THROWING sink never breaks the refresh (best-effort observability)", async () => {
+    setLivenessLogger(() => {
+      throw new Error("sink blew up");
+    });
+    const result = await refreshAgents({
+      execFileAsync: async () => JSON.stringify(agents),
+      now: () => 1000,
+    });
+    expect(result).toEqual(agents);
   });
 });

--- a/plugins/dev/scripts/execution-core/scheduler.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.mjs
@@ -5491,18 +5491,32 @@ let _eventLoopMonitor = null;
 // nanoseconds, so convert to ms for parity with the tick-timing line.
 function emitEventLoopDelay() {
   const h = _eventLoopMonitor;
-  if (!h || h.count === 0) return;
-  const toMs = (ns) => Math.round((ns / 1e6) * 10) / 10;
-  log.info(
-    {
-      event_loop_p50_ms: toMs(h.percentile(50)),
-      event_loop_p99_ms: toMs(h.percentile(99)),
-      event_loop_max_ms: toMs(h.max),
-      samples: h.count,
-    },
-    "scheduler: event-loop delay (CTL-1330)"
-  );
-  h.reset();
+  if (!h) return;
+  try {
+    if (h.count === 0) return;
+    const toMs = (ns) => Math.round((ns / 1e6) * 10) / 10;
+    log.info(
+      {
+        event_loop_p50_ms: toMs(h.percentile(50)),
+        event_loop_p99_ms: toMs(h.percentile(99)),
+        event_loop_max_ms: toMs(h.max),
+        samples: h.count,
+      },
+      "scheduler: event-loop delay (CTL-1330)"
+    );
+    h.reset();
+  } catch (err) {
+    // A runtime that constructed the monitor but can't read it (partial
+    // perf_hooks support) — disable to avoid per-tick noise; tick-timing +
+    // liveness lines are unaffected.
+    log.warn({ err: err?.message }, "scheduler: event-loop delay read failed — disabling (CTL-1330)");
+    try {
+      h.disable?.();
+    } catch {
+      /* best-effort */
+    }
+    _eventLoopMonitor = null;
+  }
 }
 
 // CTL-702: observed yield tombstones for the lifetime of this daemon process.
@@ -6191,16 +6205,30 @@ export function startScheduler({
     log.info({ err: err.message }, "scheduler: preflight wrapper threw — swallowed");
   }
 
-  // CTL-1330 Tier 1: enable the process-wide event-loop delay monitor (ON by
-  // default). resolution:20ms catches a tick blocking the loop past the 3s
-  // liveness deadline with no measurable overhead; emitEventLoopDelay drains it
-  // once per tick.
-  if (tickTimingEnabled() && !_eventLoopMonitor) {
-    _eventLoopMonitor = monitorEventLoopDelay({ resolution: 20 });
-    _eventLoopMonitor.enable();
-    // CTL-1330: route each async liveness refresh to the daemon's pino logger so
-    // an aborted-at-deadline refresh during a blocked tick is queryable in Loki.
+  // CTL-1330 Tier 1 wiring (ON by default).
+  if (tickTimingEnabled()) {
+    // Liveness-refresh observability is independent of perf_hooks — wire it
+    // unconditionally so it survives a runtime that lacks monitorEventLoopDelay.
     setLivenessLogger((rec) => log.info(rec, "liveness: refresh (CTL-1330)"));
+    // Process-wide event-loop delay monitor. perf_hooks.monitorEventLoopDelay is
+    // NOT implemented in every runtime — Bun throws "Not implemented" on some
+    // versions, and the daemon runs under Bun (CTL-1330 review, P1). Guard it so
+    // a missing API degrades to "no event-loop-delay line" instead of crashing
+    // the daemon on boot — the tick-timing total_ms already measures the
+    // synchronous event-loop block directly.
+    if (!_eventLoopMonitor) {
+      try {
+        const mon = monitorEventLoopDelay({ resolution: 20 });
+        mon.enable();
+        _eventLoopMonitor = mon;
+      } catch (err) {
+        _eventLoopMonitor = null;
+        log.warn(
+          { err: err?.message },
+          "scheduler: event-loop delay monitor unavailable in this runtime — continuing without it (CTL-1330)"
+        );
+      }
+    }
   }
 
   runTick(); // authoritative initial pass

--- a/plugins/dev/scripts/execution-core/scheduler.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.mjs
@@ -5369,6 +5369,10 @@ export function schedulerTick(
         slowest_pass,
         slowest_pass_ms,
         free_slots: freeSlots,
+        // CTL-1330: eligible_count lets the highest-severity alert require
+        // "new-work held WITH work waiting" (held + eligible_count>0) — the exact
+        // condition that masked the week-long wedge when the board was drained.
+        eligible_count: eligible.length,
         liveness_fresh: livenessFresh,
         beliefs_shadow: process.env.CATALYST_BELIEFS_SHADOW === "1",
       },

--- a/plugins/dev/scripts/execution-core/scheduler.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.mjs
@@ -25,6 +25,7 @@ import {
   statSync,
 } from "node:fs";
 import { spawnSync } from "node:child_process";
+import { monitorEventLoopDelay } from "node:perf_hooks";
 import { join, dirname, basename } from "node:path";
 import {
   analyzeDependencyGraph,
@@ -122,6 +123,7 @@ import {
   getAgentsCached,
   isBgJobAlive as defaultIsBgJobAlive,
   livenessForBgJob as defaultLivenessForBgJob, // CTL-768
+  setLivenessLogger, // CTL-1330: wire the liveness-refresh observability sink
 } from "./claude-agents.mjs";
 import { emitReapIntent } from "./reap-intent.mjs";
 // CTL-574: per-tick reclaim of dead-but-work-done phase workers. The default
@@ -2645,6 +2647,43 @@ function readBoardHealthEventTail(maxLines = 800) {
   }
 }
 
+// CTL-1330 Tier 1 — per-pass tick timing. The scheduler tick is SYNCHRONOUS, so
+// its wall-clock duration IS the Node event-loop block (and a tick that blocks
+// longer than the 3s liveness-refresh deadline — claude-agents.mjs — starves the
+// `claude agents` refresh → isFresh stays false → new-work admission held at 0
+// slots: the 2026-06-24 dispatch wedge). makeTickTimer records monotonic
+// performance.now() laps at each pass boundary so ONE structured line per tick
+// shows WHERE the time goes. Pure arithmetic — no IO, negligible cost.
+//
+// Tier-1 timing is ON by default; CATALYST_TICK_TIMING=off disables it (the lap
+// calls become `tick?.lap(...)` no-ops and the summary line is skipped).
+let _tickSeq = 0;
+export function makeTickTimer(now = () => performance.now()) {
+  const t0 = now();
+  let last = t0;
+  const passes = {};
+  const round1 = (ms) => Math.round(ms * 10) / 10;
+  return {
+    tickId: ++_tickSeq,
+    // lap(label) — record ms elapsed since the previous lap (or tick start).
+    lap(label) {
+      const t = now();
+      passes[label] = round1(t - last);
+      last = t;
+    },
+    passes,
+    totalMs() {
+      return round1(now() - t0);
+    },
+  };
+}
+
+// CTL-1330: Tier-1 timing gate. ON unless explicitly disabled — it is just
+// better-structured logging shipped to Loki via the existing Alloy pipeline.
+export function tickTimingEnabled(env = process.env) {
+  return env.CATALYST_TICK_TIMING !== "off";
+}
+
 // schedulerTick — one pull cycle: (1) advancement sweep, (2) new-work pull,
 // (3) terminal-Done sweep (CTL-558). Idempotent and restart-safe — derives
 // every action from filesystem state. `exec` is the injectable seam for the
@@ -3162,12 +3201,19 @@ export function schedulerTick(
     return { ok: false, code: r.code, reason, signal: r.signal ?? null };
   }
 
+  // CTL-1330 Tier 1: start the per-pass timer at the top of the executable body
+  // (everything above is param-default + closure definitions — negligible). Null
+  // when timing is disabled, so every `tick?.lap(...)` below is a cheap no-op.
+  const tick = tickTimingEnabled() ? makeTickTimer() : null;
+
   // CTL-671: compute the eligible set ONCE per tick. Consumed by the phantom
   // validity sweep (Pass 0a, below) and the new-work pull (Pass 2). readEligible
   // is the test injection seam; production reads all per-project eligible
   // projections (written exclusively from a live `linearis issues list`).
   const eligible = readEligible ? readEligible() : readAllEligibleTickets();
   const eligibleIds = new Set(eligible.map((t) => t.identifier));
+
+  tick?.lap("eligible-read");
 
   // (0a) CTL-671 phantom/orphan validity sweep — quarantine a worker dir whose
   // ticket is definitively non-existent in Linear, NOT in the eligible set, and
@@ -3212,6 +3258,8 @@ export function schedulerTick(
       );
     }
   }
+
+  tick?.lap("phantom-sweep");
 
   // (0w) CTL-729 progress-watchdog. Force-kill a worker that is running/dispatched
   // with a silent transcript and zero commits past its phase budget. Runs AFTER the
@@ -3323,6 +3371,8 @@ export function schedulerTick(
     }
   }
 
+  tick?.lap("watchdog");
+
   // (0c) CTL-1137 cost-cap watcher. Out-of-process preemption (the daemon, NEVER the
   // worker — watcher-is-the-watched caused the 2026-06-14 outage) of an AUTONOMOUS
   // phase worker whose cumulative Claude-session cost (Prometheus = the single source
@@ -3374,6 +3424,8 @@ export function schedulerTick(
       }
     }
   }
+
+  tick?.lap("cost-cap");
 
   // (0j) CTL-1004 stall-janitor. Collapse already-terminal, unambiguous leftovers
   // the event-driven reaper never names: J1 orphan worktrees (teardown=done +
@@ -3510,6 +3562,8 @@ export function schedulerTick(
     }
   }
 
+  tick?.lap("stall-janitor");
+
   // CTL-1064: Pass 0u — throttled unstuck-sweep. Low-frequency (default 15 min)
   // classify-then-act pass over the stalled/needs-human ticket backlog. A bare tick
   // has no census producer → skip cleanly. Mode='off' by default; operators opt in
@@ -3626,6 +3680,8 @@ export function schedulerTick(
       }
     }
   }
+
+  tick?.lap("unstuck-sweep");
 
   // CTL-1176: Pass 0r — LLM reasoning recovery pass. Low-frequency autonomous
   // triage of the stalled/failed/needs-human/UNKNOWN backlog. Mode resolves from
@@ -3920,7 +3976,11 @@ export function schedulerTick(
   // verify-remediate test timeout). freeSlots is recomputed arithmetically per
   // sweep (subtracting resumedCount in sweep 2) rather than re-shelling-out.
   const maxParallel = readMaxParallel(orchDir, concurrency);
+  tick?.lap("recovery-pass");
+
   const liveCount = liveBackgroundCount();
+
+  tick?.lap("liveness-read");
 
   // CTL-1290: board-health delegate cadence hook — SHADOW-FIRST. Runs ONLY when
   // the daemon threads the `boardHealth` seam (its real-IO readers); a bare
@@ -4302,6 +4362,8 @@ export function schedulerTick(
     }
   }
 
+  tick?.lap("board-health");
+
   // (0.5) Preemption sweep — if slots are saturated AND the top-ranked queued
   // ticket out-ranks the lowest-ranked preemptable in-flight worker, stop that
   // worker and park it for resume when a slot frees. Safety guards prevent
@@ -4486,6 +4548,8 @@ export function schedulerTick(
       );
     }
   }
+
+  tick?.lap("preemption-sweep");
 
   // (1) Advancement sweep — dispatch the FSM-owed next phase per in-flight ticket.
   // CTL-705: preempted workers are skipped — their active status is not "done" so
@@ -4731,6 +4795,8 @@ export function schedulerTick(
       }
     }
   }
+
+  tick?.lap("advancement");
 
   // (2) New-work pull — fill free slots with top-ranked ready tickets. D5:
   // hydrate the live state of every out-of-set blocker first so a Ready ticket
@@ -5091,6 +5157,8 @@ export function schedulerTick(
     }
   }
 
+  tick?.lap("new-work-pull");
+
   // (3) Terminal-Done + label sweep (CTL-558) — one pass over every started
   // ticket. deriveAdvancement returns null once monitor-deploy completes, so
   // terminal `Done` is not a dispatch — it needs this dedicated sweep. In the
@@ -5265,6 +5333,8 @@ export function schedulerTick(
     }
   }
 
+  tick?.lap("terminal-sweep");
+
   // (4) Cooldown GC sweep (CTL-713) — reap expired markers for tickets that
   // have left the eligible set so .dispatch-cooldowns/ self-cleans instead of
   // accumulating orphans. Runs last: GC must not influence this tick's dispatch
@@ -5272,6 +5342,38 @@ export function schedulerTick(
   // phantom-sweep block) and is already in scope here.
   for (const { ticket, phase } of gcDispatchCooldowns(orchDir, eligibleIds, now())) {
     appendCooldownGcEvent({ ticket, orchId: ticket, target_phase: phase });
+  }
+
+  // CTL-1330 Tier 1: one structured line per tick. total_ms IS the synchronous
+  // event-loop block; pass_durations attributes it; free_slots/liveness_fresh
+  // expose whether new-work admission was held this tick (the wedge symptom).
+  // Loki: {service_name="catalyst.execution-core"} | json | total_ms > 3000
+  if (tick) {
+    tick.lap("cooldown-gc");
+    // CTL-1330: flat slowest-pass fields turn "which pass dominated this tick"
+    // into a one-line Loki→Prometheus label (OTL-25 health dashboards) without
+    // unwrapping the nested pass_durations map.
+    let slowest_pass = null;
+    let slowest_pass_ms = 0;
+    for (const [name, ms] of Object.entries(tick.passes)) {
+      if (ms > slowest_pass_ms) {
+        slowest_pass_ms = ms;
+        slowest_pass = name;
+      }
+    }
+    log.info(
+      {
+        tick_id: tick.tickId,
+        total_ms: tick.totalMs(),
+        pass_durations: tick.passes,
+        slowest_pass,
+        slowest_pass_ms,
+        free_slots: freeSlots,
+        liveness_fresh: livenessFresh,
+        beliefs_shadow: process.env.CATALYST_BELIEFS_SHADOW === "1",
+      },
+      "scheduler: tick timing (CTL-1330)"
+    );
   }
 
   return {
@@ -5372,6 +5474,33 @@ let debounceTimer = null;
 let watcher = null;
 let runningOpts = null;
 
+// CTL-1330 Tier 1: process-wide event-loop delay histogram. Enabled by the
+// daemon (startScheduler) when tick timing is on; null otherwise so direct
+// schedulerTick callers (tests/CLI) never touch perf_hooks. Read+reset once per
+// runTick so each line reports the lag accumulated since the previous tick —
+// crucially the prior SYNCHRONOUS schedulerTick block, which libuv records only
+// after control returns to the loop (i.e. after that tick returned).
+let _eventLoopMonitor = null;
+
+// emitEventLoopDelay — log p50/p99/max (ms) and reset. No-op until the daemon
+// enables the monitor; skips the first, empty read (count 0). perf_hooks reports
+// nanoseconds, so convert to ms for parity with the tick-timing line.
+function emitEventLoopDelay() {
+  const h = _eventLoopMonitor;
+  if (!h || h.count === 0) return;
+  const toMs = (ns) => Math.round((ns / 1e6) * 10) / 10;
+  log.info(
+    {
+      event_loop_p50_ms: toMs(h.percentile(50)),
+      event_loop_p99_ms: toMs(h.percentile(99)),
+      event_loop_max_ms: toMs(h.max),
+      samples: h.count,
+    },
+    "scheduler: event-loop delay (CTL-1330)"
+  );
+  h.reset();
+}
+
 // CTL-702: observed yield tombstones for the lifetime of this daemon process.
 // Keyed by absolute path so the same file across multiple ticks emits exactly
 // one event. Cleared only on daemon restart (via __resetForTests in tests).
@@ -5397,6 +5526,10 @@ let _stallJanitorCensusLastRunMs = 0;
 
 function runTick() {
   try {
+    // CTL-1330 Tier 1: emit the event-loop delay accumulated since the previous
+    // tick (which captures that tick's synchronous block) before doing this
+    // tick's work, then reset. Cheap no-op when the monitor is disabled.
+    emitEventLoopDelay();
     // CTL-676 + CTL-678: hot-reload the concurrency knobs by re-reading the
     // project config at the top of every tick. When `configPath` is unset
     // (back-compat scheduler harnesses that never threaded it), fall back to
@@ -6054,6 +6187,18 @@ export function startScheduler({
     log.info({ err: err.message }, "scheduler: preflight wrapper threw — swallowed");
   }
 
+  // CTL-1330 Tier 1: enable the process-wide event-loop delay monitor (ON by
+  // default). resolution:20ms catches a tick blocking the loop past the 3s
+  // liveness deadline with no measurable overhead; emitEventLoopDelay drains it
+  // once per tick.
+  if (tickTimingEnabled() && !_eventLoopMonitor) {
+    _eventLoopMonitor = monitorEventLoopDelay({ resolution: 20 });
+    _eventLoopMonitor.enable();
+    // CTL-1330: route each async liveness refresh to the daemon's pino logger so
+    // an aborted-at-deadline refresh during a blocked tick is queryable in Loki.
+    setLivenessLogger((rec) => log.info(rec, "liveness: refresh (CTL-1330)"));
+  }
+
   runTick(); // authoritative initial pass
   tickTimer = setInterval(runTick, tickIntervalMs);
 
@@ -6088,6 +6233,13 @@ export function stopScheduler() {
   watcher = null;
   runningOpts = null;
   rankedAboveSince.clear(); // CTL-705: reset hysteresis state on daemon stop
+  // CTL-1330: tear down the event-loop monitor + liveness sink so a restart
+  // re-arms cleanly (and tests don't leak the pino sink across cases).
+  if (_eventLoopMonitor) {
+    _eventLoopMonitor.disable();
+    _eventLoopMonitor = null;
+  }
+  setLivenessLogger(null);
 }
 
 // __resetForTests — clear daemon state between unit tests. Not part of the

--- a/plugins/dev/scripts/execution-core/tick-timing.test.mjs
+++ b/plugins/dev/scripts/execution-core/tick-timing.test.mjs
@@ -1,0 +1,51 @@
+// tick-timing.test.mjs — CTL-1330 Tier 1: the per-pass tick timer + its gate.
+// These are pure functions (no timers / no fs.watch), so unlike the bulk of
+// scheduler.test.mjs they are safe to run in the CI sandbox.
+
+import { describe, test, expect } from "bun:test";
+import { makeTickTimer, tickTimingEnabled } from "./scheduler.mjs";
+
+describe("makeTickTimer (CTL-1330)", () => {
+  test("lap records ms since the previous lap; totalMs is from tick start", () => {
+    let t = 0;
+    const now = () => t;
+    const tick = makeTickTimer(now);
+    t = 5;
+    tick.lap("one");
+    t = 12;
+    tick.lap("two");
+    expect(tick.passes).toEqual({ one: 5, two: 7 });
+    t = 20;
+    expect(tick.totalMs()).toBe(20);
+  });
+
+  test("durations round to 0.1ms", () => {
+    let t = 0;
+    const now = () => t;
+    const tick = makeTickTimer(now);
+    t = 1.234;
+    tick.lap("x");
+    expect(tick.passes.x).toBe(1.2);
+  });
+
+  test("tickId increments monotonically across timers", () => {
+    const a = makeTickTimer(() => 0);
+    const b = makeTickTimer(() => 0);
+    expect(b.tickId).toBe(a.tickId + 1);
+  });
+});
+
+describe("tickTimingEnabled (CTL-1330 gate — ON by default)", () => {
+  test("ON when unset", () => {
+    expect(tickTimingEnabled({})).toBe(true);
+  });
+
+  test("ON for any value other than the literal 'off'", () => {
+    expect(tickTimingEnabled({ CATALYST_TICK_TIMING: "1" })).toBe(true);
+    expect(tickTimingEnabled({ CATALYST_TICK_TIMING: "on" })).toBe(true);
+  });
+
+  test("OFF only when explicitly 'off'", () => {
+    expect(tickTimingEnabled({ CATALYST_TICK_TIMING: "off" })).toBe(false);
+  });
+});

--- a/plugins/dev/scripts/orch-monitor/server.ts
+++ b/plugins/dev/scripts/orch-monitor/server.ts
@@ -1691,11 +1691,21 @@ export function createServer(opts: CreateServerOptions): BunServer {
     5 * 60 * 1000,
   );
 
+  // CTL-1330 Tier 1: monitor request-timing. Surface only slow requests
+  // (default >250ms) so healthy traffic doesn't flood the log. ON unless
+  // CATALYST_TICK_TIMING=off. Fields land as structured attributes for the
+  // OTL metrics pipeline.
+  const MONITOR_REQUEST_TIMING = process.env.CATALYST_TICK_TIMING !== "off";
+  const MONITOR_SLOW_REQUEST_MS =
+    Number(process.env.CATALYST_MONITOR_SLOW_REQUEST_MS) || 250;
+
   const server = Bun.serve({
     port,
     hostname,
     idleTimeout: 0,
     async fetch(req) {
+      const _reqT0 = performance.now();
+      const _doFetch = async (): Promise<Response> => {
       try {
         const url = new URL(req.url);
 
@@ -4602,6 +4612,30 @@ export function createServer(opts: CreateServerOptions): BunServer {
         console.error(`[server] fetch handler error:`, err);
         return new Response("Internal Server Error", { status: 500 });
       }
+      };
+      const res = await _doFetch();
+      // CTL-1330: emit one structured line for a slow request — where a monitor
+      // request blocked the loop. status>=500 always emits (it's an error).
+      if (MONITOR_REQUEST_TIMING) {
+        const total_ms = Math.round((performance.now() - _reqT0) * 10) / 10;
+        if (total_ms >= MONITOR_SLOW_REQUEST_MS || res.status >= 500) {
+          let path = "";
+          try {
+            path = new URL(req.url).pathname;
+          } catch {
+            /* unparseable URL — leave path empty */
+          }
+          console.warn(
+            `[server] slow request (CTL-1330) ${JSON.stringify({
+              method: req.method,
+              path,
+              status: res.status,
+              total_ms,
+            })}`,
+          );
+        }
+      }
+      return res;
     },
   });
 


### PR DESCRIPTION
## What

Tier-1 instrumentation (CTL-1330) for the three long-lived daemons — **execution-core, broker, monitor** — as structured logs. **ON by default** (`CATALYST_TICK_TIMING=off` disables). Tempo-independent; ships to Loki via the existing Alloy/otel-forward pipeline. This is the wedge-cracking data the 2026-06-24 liveness-starvation dispatch freeze needed but didn't have.

## Why

The synchronous `schedulerTick` blocks the Node event loop; when a tick blocks longer than the 3s liveness-refresh deadline, `claude agents` never refreshes → `isFresh` stays false → new-work admission held at 0 slots (the week-long wedge on mini). Static analysis got us ~90% there; this turns "which pass blocks the loop" into a Loki query.

## Signals

- **execution-core** — `scheduler: tick timing` per tick: `{tick_id, total_ms, pass_durations{14 passes}, slowest_pass, free_slots, liveness_fresh, beliefs_shadow}`. `total_ms` **is** the event-loop block; `liveness_fresh:false` + `free_slots:0` is the wedge symptom. Plus `scheduler: event-loop delay` (`monitorEventLoopDelay` p50/p99/max) and `liveness: refresh` (`{outcome: resolved|timeout|error, duration_ms, deadline_ms, populated, age_ms}` — `outcome:timeout` with `duration≈deadline` is the smoking gun).
- **broker** — `broker: slow route` `{event_name, total_ms}` for routes over `CATALYST_BROKER_SLOW_ROUTE_MS` (100ms).
- **monitor** — `slow request` `{method, path, status, total_ms}` for requests over `CATALYST_MONITOR_SLOW_REQUEST_MS` (250ms) or any 5xx.

## Semconv

Aligned per the dash0 OTel skills: metric names will omit units (seconds, not ms), and fields are designed to land as structured attributes for the OTL logs→metrics pipeline (coordinated with the OTL-25 / catalyst-otel team). **Tier-3 OTLP spans follow in a separate PR** (the OTL-25 Tempo sink is ready).

## Tests

- `tick-timing.test.mjs` — `makeTickTimer` (laps/totalMs/tickId) + `tickTimingEnabled` gate. Registered in `execution-core-tests.yml`.
- `claude-agents.test.mjs` — `setLivenessLogger` + `refreshAgents` outcomes (resolved/timeout/error/null-sink/throwing-sink).
- Verified: execution-core daemon bundles (141 modules); full `scheduler.test.mjs` shows no new regressions vs `main` (the 2 CTL-781 + timer-flake failures pre-exist on `main`); broker tests pass; `server.ts` typechecks clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)