### PR TITLE
fix(dev): CTL-1332 — log shipper keeps full pino JSON body so Tier-1 fields reach Loki

### DIFF
--- a/plugins/dev/scripts/log-shipper/README.md
+++ b/plugins/dev/scripts/log-shipper/README.md
@@ -45,7 +45,7 @@ output and is **not** JSON — it ships best-effort as unstructured records and 
 loki.source.file (per file, tags service_name)
         │
         ├── pino logs ──▶ loki.process "pino"  (stage.json → stage.timestamp →
-        │                                        stage.structured_metadata → stage.output=msg)
+        │                                        stage.structured_metadata; body = full JSON line, CTL-1332)
         │
         └── monitor.log ▶ loki.process "plain" (passthrough, body = whole line)
                                    │
@@ -69,8 +69,8 @@ The pino fields are mapped to the OTel logs data model:
 | --------------- | --------------------------------------------- |
 | `level` (30/40/50/60) | `severityNumber` / `severityText` (see below) |
 | `time` (Unix ms)| log record timestamp (Alloy converts ms → ns) |
-| `msg`           | log record **body**                           |
-| other context   | log-record **attributes**                     |
+| full JSON line  | log record **body** (CTL-1332: kept whole so every field — `msg` + all context — is queryable via `\| json`) |
+| `level`, `name` | log-record **attributes** (drive severity + service.name) |
 | `name`          | resource **service.name** as `catalyst.<name>`|
 
 Severity:
@@ -192,7 +192,8 @@ live hosts by this ticket.
    - the correct `host.name` (OS hostname) and `catalyst.host.name` (stable node
      name, e.g. `mini` — **not** `RyansMini250233`),
    - `severityText`/`severityNumber` derived from the pino level,
-   - the pino `msg` as the log body.
+   - the full pino JSON line as the log body — confirm field extraction with
+     `{service_name="catalyst.execution-core"} | json | total_ms > 1000` (CTL-1332).
 
 4. Spot-check `monitor.log`'s plain-text lines arrive under
    `{service_name="catalyst.monitor"}` (unstructured, body = the raw line).

--- a/plugins/dev/scripts/log-shipper/config.alloy
+++ b/plugins/dev/scripts/log-shipper/config.alloy
@@ -45,8 +45,8 @@
 //       30 = INFO  / 9      40 = WARN  / 13
 //       50 = ERROR / 17     60 = FATAL / 21
 //   pino time(ms)      -> log record timestamp (Alloy converts ms -> nanos)
-//   pino msg           -> log record body
-//   remaining context  -> log-record attributes
+//   full pino JSON line-> log record body (CTL-1332: kept whole so every field —
+//                         msg + all context — is queryable via `| json`)
 //   pino name          -> resource service.name as catalyst.<name>
 //
 // OVERRIDABLE ENV (all optional; safe defaults below)
@@ -197,13 +197,26 @@ loki.source.file "otel_forward" {
 }
 
 // pino-JSON processing, shared by the three structured daemon logs.
-//   * stage.json              — lift level/time/name/msg out of the JSON line
+//   * stage.json              — lift level/time/name out of the JSON line (drives
+//                               severity + service mapping + the record timestamp)
 //   * stage.timestamp         — pino time is Unix MILLISECONDS -> record timestamp
 //   * stage.structured_metadata — keep level + name as attributes (the transform
 //                               reads attributes["level"] to derive severity)
-//   * stage.output            — set the log body to msg (the human-readable text)
+//   (NO stage.output)         — the body stays the FULL original pino JSON line so
+//                               downstream `| json` can parse EVERY field.
 // service_name comes from the source target label above and is preserved, so the
 // otel bridge maps it to the service.name resource attribute (catalyst.<name>).
+//
+// CTL-1332: the body is deliberately the whole pino JSON line, NOT just `msg`. A
+// prior `stage.output { source = "msg" }` discarded every field except msg on-host
+// before OTLP export — so CTL-1330 Tier-1 fields (total_ms, pass_durations,
+// slowest_pass, eligible_count, outcome, event_loop_*…) never reached Loki and the
+// logs→metrics connectors had nothing to read. Keeping the full JSON body makes all
+// fields queryable via `| json` (e.g. `{service_name="catalyst.execution-core"} |
+// json | total_ms > 3000`) for every daemon log, with zero per-field config.
+// Severity/service mapping is unaffected (they read the level/service_name
+// attributes, not the body); `|= "..."` substring grep still matches text inside the
+// JSON body; and msg is recoverable with `| json | line_format "{{.msg}}"`.
 loki.process "pino" {
 	forward_to = [otelcol.receiver.loki.catalyst.receiver]
 
@@ -212,7 +225,6 @@ loki.process "pino" {
 			"level" = "level",
 			"time"  = "time",
 			"name"  = "name",
-			"msg"   = "msg",
 		}
 	}
 
@@ -222,18 +234,13 @@ loki.process "pino" {
 	}
 
 	// Keep the pino level + name as attributes (level drives severity; name is the
-	// context that informed service.name). The whole original line is preserved as
-	// the body until stage.output overrides it with msg below.
+	// context that informed service.name). With no stage.output below, the body
+	// remains the full original pino JSON line.
 	stage.structured_metadata {
 		values = {
 			"level" = "level",
 			"name"  = "name",
 		}
-	}
-
-	// Body of the OTel log record = the pino msg field.
-	stage.output {
-		source = "msg"
 	}
 }
 


### PR DESCRIPTION
## What

The Alloy daemon-log shipper (`plugins/dev/scripts/log-shipper/config.alloy`, `loki.process "pino"`) set the OTel log body to `msg` only (`stage.output { source = "msg" }`), discarding every other pino field **on-host before OTLP export**. So CTL-1330 Tier-1 fields (`total_ms`, `pass_durations`, `slowest_pass`, `eligible_count`, `outcome`, `event_loop_*`) never reached Loki — the OTL-25 logs→metrics connectors had nothing to read.

## Why it matters

This blocks the entire CTL-1330 scheduler-health metrics/dashboard/alert track. Discovered while deploying CTL-1330 Tier-1 to mini and verifying in live Loki:

- `{service_name="catalyst.execution-core"} |= "tick timing (CTL-1330)"` → stream exists, body is literally `"scheduler: tick timing (CTL-1330)"` (just the msg).
- `| total_ms != ""` → 0 rows (not structured metadata). `| json | total_ms != ""` → 0 rows (body isn't JSON). Fields **dropped**, not body-trapped — a collector-side parse can't recover them.

## Fix (option A)

Drop the `stage.output { source = "msg" }` override so the body stays the **full original pino JSON line**. Then `| json` parses every field for all daemon logs:

```logql
{service_name="catalyst.execution-core"} | json | total_ms > 3000
```

Future-proof (zero per-field config), and:
- Severity/service mapping unaffected — they read the `level`/`service_name` attributes, not the body.
- `|= "..."` substring grep still matches text inside the JSON body.
- `msg` recoverable via `| json | line_format "{{.msg}}"`.

`alloy fmt` clean. README + semconv table updated.

## Deploy (after merge)

plugin-source auto-pulls on merge; restart the `ai.coalesce.catalyst-log-shipper` Alloy agent on both nodes (mini + mini-2), then verify `| json | total_ms > 1000` returns rows. Coordinated with the OTL-25 agent (owns the Prometheus derivation off these fields).

Closes CTL-1332.

🤖 Generated with [Claude Code](https://claude.com/claude-code)