### PR TITLE
feat(dev): CTL-1330 Tier 3 — execution-core OTLP spans (scheduler.tick flame graph + liveness.refresh)

### DIFF
--- a/.github/workflows/execution-core-tests.yml
+++ b/.github/workflows/execution-core-tests.yml
@@ -127,6 +127,7 @@ jobs:
             claude-agents.test.mjs \
             claude-ids.test.mjs \
             tick-timing.test.mjs \
+            tracing.test.mjs \
             cloud-token-env.test.mjs \
             cluster-claim-sync.test.mjs \
             cluster-claim.test.mjs \

--- a/plugins/dev/scripts/execution-core/bun.lock
+++ b/plugins/dev/scripts/execution-core/bun.lock
@@ -5,6 +5,11 @@
     "": {
       "name": "catalyst-execution-core",
       "dependencies": {
+        "@opentelemetry/api": "^1.9.1",
+        "@opentelemetry/exporter-trace-otlp-http": "^0.219.0",
+        "@opentelemetry/resources": "^2.8.0",
+        "@opentelemetry/sdk-trace-base": "^2.8.0",
+        "@opentelemetry/semantic-conventions": "^1.41.1",
         "pino": "^9.6.0",
       },
       "devDependencies": {
@@ -13,6 +18,28 @@
     },
   },
   "packages": {
+    "@opentelemetry/api": ["@opentelemetry/api@1.9.1", "", {}, "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q=="],
+
+    "@opentelemetry/api-logs": ["@opentelemetry/api-logs@0.219.0", "", { "dependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-FFx7YnaYJlIjqWW/AG/yAZ0L/NEY724PipXXXQLdtZPbLwBGbUMTGL1i/esI56TWfTUXxhLfpgrnWJCG8aUJyg=="],
+
+    "@opentelemetry/core": ["@opentelemetry/core@2.8.0", "", { "dependencies": { "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.0.0 <1.10.0" } }, "sha512-hd1Lfh8p545nNz+jq1Ejfz+Mn1hyLuxYn1YzTfFNrxr8urEWMNQLPf1Th8kjOH+HxwawCrtgBp8JpBUR4ZSgww=="],
+
+    "@opentelemetry/exporter-trace-otlp-http": ["@opentelemetry/exporter-trace-otlp-http@0.219.0", "", { "dependencies": { "@opentelemetry/core": "2.8.0", "@opentelemetry/otlp-exporter-base": "0.219.0", "@opentelemetry/otlp-transformer": "0.219.0", "@opentelemetry/resources": "2.8.0", "@opentelemetry/sdk-trace-base": "2.8.0" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-9t6SvBXXBEjOBcIzgozvBbd3jWrv3Gt3ngGhl1fhdZ/zRc7oZDVOFEqbi2zlBpW9BXhgDMKv422J0DL/3iQWfw=="],
+
+    "@opentelemetry/otlp-exporter-base": ["@opentelemetry/otlp-exporter-base@0.219.0", "", { "dependencies": { "@opentelemetry/core": "2.8.0", "@opentelemetry/otlp-transformer": "0.219.0" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-zvIxQX/AZUVKDU+hCuYx+7UkiP7GRdnk1ZbFQRYzHvYp47cAWR4j3IhoPhV9KaeXEv2xdGq3IA6PnpzDmLcmSA=="],
+
+    "@opentelemetry/otlp-transformer": ["@opentelemetry/otlp-transformer@0.219.0", "", { "dependencies": { "@opentelemetry/api-logs": "0.219.0", "@opentelemetry/core": "2.8.0", "@opentelemetry/resources": "2.8.0", "@opentelemetry/sdk-logs": "0.219.0", "@opentelemetry/sdk-metrics": "2.8.0", "@opentelemetry/sdk-trace-base": "2.8.0" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-aaYKAyXhw9VchKZVGOopD3Gw/kPsyrX2c6IQ0AW32mTjqmZOh5Y6Gf5OYqTNqVktAeBjmFinhyFaCwW6GYK9YQ=="],
+
+    "@opentelemetry/resources": ["@opentelemetry/resources@2.8.0", "", { "dependencies": { "@opentelemetry/core": "2.8.0", "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.3.0 <1.10.0" } }, "sha512-qmXQ27ilDbUK/vGMqwL8D4/rhn76C+sherM4wTbjlfknR8Nvfc/hCxjRJPhkzZzUsPiNg16SA31NxMabwttRjg=="],
+
+    "@opentelemetry/sdk-logs": ["@opentelemetry/sdk-logs@0.219.0", "", { "dependencies": { "@opentelemetry/api-logs": "0.219.0", "@opentelemetry/core": "2.8.0", "@opentelemetry/resources": "2.8.0", "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.4.0 <1.10.0" } }, "sha512-s6lTKRakaPClvKoWHRChxnXjDMkM/TQ30ff78jN6EBGf7MI7VzANE5PU3f4z9qDUudWjvZjOLHG0rBnBKYvoXA=="],
+
+    "@opentelemetry/sdk-metrics": ["@opentelemetry/sdk-metrics@2.8.0", "", { "dependencies": { "@opentelemetry/core": "2.8.0", "@opentelemetry/resources": "2.8.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.9.0 <1.10.0" } }, "sha512-UDBGaj6W0Rgy5rTTaoxs8gVGF/aGkAKyjurJv7se6wjRxJu7FoquTLT/vt54DZfo4crbprYfhX/SOK9+BPw1qg=="],
+
+    "@opentelemetry/sdk-trace-base": ["@opentelemetry/sdk-trace-base@2.8.0", "", { "dependencies": { "@opentelemetry/core": "2.8.0", "@opentelemetry/resources": "2.8.0", "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.3.0 <1.10.0" } }, "sha512-mhU4jp+vW0mGbFRd+GeXHvmfA4aDqWjBjLC3pE5XMpLs0IE2ryYb019Ts2AQrOq67gaTF25D91+fgvEHDZEnuQ=="],
+
+    "@opentelemetry/semantic-conventions": ["@opentelemetry/semantic-conventions@1.41.1", "", {}, "sha512-/UhIkaZgPutTFmQ7RnIJGgDXZmtEJ7Dvi86xNTFWcnRxVRNk/aotsqDJYeEvDP+FSMB2SdW+pQzNMcWP0rwuNA=="],
+
     "@pinojs/redact": ["@pinojs/redact@0.4.0", "", {}, "sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg=="],
 
     "@types/bun": ["@types/bun@1.3.14", "", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],

--- a/plugins/dev/scripts/execution-core/claude-agents.mjs
+++ b/plugins/dev/scripts/execution-core/claude-agents.mjs
@@ -146,6 +146,14 @@ export function setLivenessLogger(fn) {
   _livenessLogger = typeof fn === "function" ? fn : null;
 }
 
+// CTL-1330 Tier 3: optional span sink, wired by the daemon to emit a liveness.refresh
+// OTLP span (ERROR on timeout). Same leaf-pure injection as the logger sink — this
+// module never imports the OTel SDK; the daemon bridges to tracing.mjs.
+let _livenessSpanSink = null;
+export function setLivenessSpanSink(fn) {
+  _livenessSpanSink = typeof fn === "function" ? fn : null;
+}
+
 // backoffWindowMs — 0 below the failure threshold (retry every stale read), then
 // exponential (base × 2^over) capped at LIVENESS_BACKOFF_CAP_MS.
 function backoffWindowMs(failures) {
@@ -258,16 +266,30 @@ export function refreshAgents({
       // CTL-1330 Tier 1: liveness-refresh observability. The wedge signature is
       // outcome:"timeout" with duration_ms≈deadline_ms while a synchronous tick
       // blocks the loop. Best-effort — a throwing sink must never break refresh.
-      if (_livenessLogger) {
+      if (_livenessLogger || _livenessSpanSink) {
         try {
           const populated = _asyncSnap.agents !== null;
-          _livenessLogger({
-            outcome,
-            duration_ms: now() - startMs,
-            deadline_ms: timeoutMs,
-            populated,
-            age_ms: populated ? now() - _asyncSnap.ts : null,
-          });
+          const endMs = now();
+          if (_livenessLogger) {
+            _livenessLogger({
+              outcome,
+              duration_ms: endMs - startMs,
+              deadline_ms: timeoutMs,
+              populated,
+              age_ms: populated ? endMs - _asyncSnap.ts : null,
+            });
+          }
+          // CTL-1330 Tier 3: liveness.refresh span (startMs/endMs are epoch ms).
+          if (_livenessSpanSink) {
+            _livenessSpanSink({
+              outcome,
+              startEpochMs: startMs,
+              endEpochMs: endMs,
+              deadlineMs: timeoutMs,
+              populated,
+              ageMs: populated ? endMs - _asyncSnap.ts : null,
+            });
+          }
         } catch {
           /* observability must never throw out of the refresh */
         }

--- a/plugins/dev/scripts/execution-core/package.json
+++ b/plugins/dev/scripts/execution-core/package.json
@@ -6,6 +6,11 @@
     "test": "bun test"
   },
   "dependencies": {
+    "@opentelemetry/api": "^1.9.1",
+    "@opentelemetry/exporter-trace-otlp-http": "^0.219.0",
+    "@opentelemetry/resources": "^2.8.0",
+    "@opentelemetry/sdk-trace-base": "^2.8.0",
+    "@opentelemetry/semantic-conventions": "^1.41.1",
     "pino": "^9.6.0"
   },
   "devDependencies": {

--- a/plugins/dev/scripts/execution-core/scheduler.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.mjs
@@ -124,7 +124,10 @@ import {
   isBgJobAlive as defaultIsBgJobAlive,
   livenessForBgJob as defaultLivenessForBgJob, // CTL-768
   setLivenessLogger, // CTL-1330: wire the liveness-refresh observability sink
+  setLivenessSpanSink, // CTL-1330 Tier 3: wire the liveness.refresh span sink
 } from "./claude-agents.mjs";
+// CTL-1330 Tier 3: OTLP span export (OFF unless CATALYST_TRACING=on).
+import { initTracing, shutdownTracing, emitTickTrace, emitLivenessRefreshSpan } from "./tracing.mjs";
 import { emitReapIntent } from "./reap-intent.mjs";
 // CTL-574: per-tick reclaim of dead-but-work-done phase workers. The default
 // is the real recovery-module function; tests inject a fake. See
@@ -2658,20 +2661,32 @@ function readBoardHealthEventTail(maxLines = 800) {
 // Tier-1 timing is ON by default; CATALYST_TICK_TIMING=off disables it (the lap
 // calls become `tick?.lap(...)` no-ops and the summary line is skipped).
 let _tickSeq = 0;
-export function makeTickTimer(now = () => performance.now()) {
+export function makeTickTimer(now = () => performance.now(), wallNow = Date.now) {
   const t0 = now();
+  // CTL-1330 Tier 3: wall-clock base so per-lap perf offsets convert to absolute epoch
+  // ms for post-hoc span timestamps (the tick is synchronous — spans are reconstructed
+  // AFTER it completes; see emitTickTrace). toEpoch maps a perf.now() reading to epoch ms.
+  const startEpochMs = wallNow();
+  const toEpoch = (perf) => Math.round(startEpochMs + (perf - t0));
   let last = t0;
   const passes = {};
+  const spanLaps = []; // [{name, durationMs, startEpochMs, endEpochMs}] for the span tree
   const round1 = (ms) => Math.round(ms * 10) / 10;
   return {
     tickId: ++_tickSeq,
+    startEpochMs,
     // lap(label) — record ms elapsed since the previous lap (or tick start).
     lap(label) {
       const t = now();
       passes[label] = round1(t - last);
+      spanLaps.push({ name: label, durationMs: round1(t - last), startEpochMs: toEpoch(last), endEpochMs: toEpoch(t) });
       last = t;
     },
     passes,
+    spanLaps,
+    endEpochMs() {
+      return toEpoch(now());
+    },
     totalMs() {
       return round1(now() - t0);
     },
@@ -5378,6 +5393,26 @@ export function schedulerTick(
       },
       "scheduler: tick timing (CTL-1330)"
     );
+
+    // CTL-1330 Tier 3: post-hoc span tree for this tick (no-op unless
+    // CATALYST_TRACING=on). Reconstructed from the recorded lap timings — zero
+    // per-span work inside the synchronous hot loop. Root scheduler.tick + a
+    // scheduler.pass child per pass over the slow threshold (the flame graph).
+    emitTickTrace({
+      tickId: tick.tickId,
+      startEpochMs: tick.startEpochMs,
+      endEpochMs: tick.endEpochMs(),
+      laps: tick.spanLaps,
+      attrs: {
+        "catalyst.scheduler.total_ms": tick.totalMs(),
+        "catalyst.scheduler.slowest_pass": slowest_pass,
+        "catalyst.scheduler.slowest_pass_ms": slowest_pass_ms,
+        "catalyst.scheduler.free_slots": freeSlots,
+        "catalyst.scheduler.eligible_count": eligible.length,
+        "catalyst.scheduler.liveness_fresh": livenessFresh,
+        "catalyst.scheduler.beliefs_shadow": process.env.CATALYST_BELIEFS_SHADOW === "1",
+      },
+    });
   }
 
   return {
@@ -6210,6 +6245,8 @@ export function startScheduler({
     // Liveness-refresh observability is independent of perf_hooks — wire it
     // unconditionally so it survives a runtime that lacks monitorEventLoopDelay.
     setLivenessLogger((rec) => log.info(rec, "liveness: refresh (CTL-1330)"));
+    // CTL-1330 Tier 3: also feed the liveness.refresh span sink (no-op when tracing off).
+    setLivenessSpanSink((rec) => emitLivenessRefreshSpan(rec));
     // Process-wide event-loop delay monitor. perf_hooks.monitorEventLoopDelay is
     // NOT implemented in every runtime — Bun throws "Not implemented" on some
     // versions, and the daemon runs under Bun (CTL-1330 review, P1). Guard it so
@@ -6230,6 +6267,16 @@ export function startScheduler({
       }
     }
   }
+
+  // CTL-1330 Tier 3: bring up OTLP tracing (OFF unless CATALYST_TRACING=on). Async
+  // and fire-and-forget — never blocks startup; emitTickTrace no-ops until the
+  // provider is ready, and a failed init degrades to "no spans". BatchSpanProcessor
+  // only, so the exporter never blocks the tick.
+  initTracing({ serviceName: "catalyst.execution-core" })
+    .then((on) => {
+      if (on) log.info({}, "scheduler: OTLP tracing enabled (CTL-1330 Tier 3)");
+    })
+    .catch(() => {});
 
   runTick(); // authoritative initial pass
   tickTimer = setInterval(runTick, tickIntervalMs);
@@ -6272,6 +6319,10 @@ export function stopScheduler() {
     _eventLoopMonitor = null;
   }
   setLivenessLogger(null);
+  setLivenessSpanSink(null);
+  // CTL-1330 Tier 3: flush + tear down tracing so a wedge tick's spans aren't lost
+  // and a restart re-inits cleanly. Fire-and-forget (stopScheduler is sync).
+  shutdownTracing().catch(() => {});
 }
 
 // __resetForTests — clear daemon state between unit tests. Not part of the

--- a/plugins/dev/scripts/execution-core/tracing.mjs
+++ b/plugins/dev/scripts/execution-core/tracing.mjs
@@ -32,15 +32,22 @@ export function tracingEnabled(env = process.env) {
   return env.CATALYST_TRACING === "on";
 }
 
-// resolveNodeName — match getHostName() in config.mjs so spans tag the SAME stable node
-// name as the logs (CATALYST_HOST_NAME, else the OS hostname's first DNS label).
-function resolveNodeName(env) {
-  if (env.CATALYST_HOST_NAME) return env.CATALYST_HOST_NAME;
+// shortHostName — the OS hostname's first DNS label. CTL data-quality finding: the
+// daemon .log path emits FQDN host.name (mini-2.rozich) while metrics/canonical-events use
+// the SHORT form (mini-2, the CTL-1252 collapse), so logs↔metrics↔traces won't join on host
+// unless every signal uses the SAME canonical short form. Spans use short to join cleanly.
+function shortHostName() {
   try {
     return osHostname().split(".")[0];
   } catch {
     return "unknown";
   }
+}
+
+// resolveNodeName — match getHostName() in config.mjs so spans tag the SAME stable node
+// name as the logs (CATALYST_HOST_NAME, else the short OS hostname).
+function resolveNodeName(env) {
+  return env.CATALYST_HOST_NAME || shortHostName();
 }
 
 // initTracing — construct the provider + OTLP/HTTP exporter + BatchSpanProcessor ONCE.
@@ -52,7 +59,7 @@ export async function initTracing({ serviceName, env = process.env } = {}) {
     const { BasicTracerProvider, BatchSpanProcessor } = await import("@opentelemetry/sdk-trace-base");
     const { OTLPTraceExporter } = await import("@opentelemetry/exporter-trace-otlp-http");
     const { resourceFromAttributes } = await import("@opentelemetry/resources");
-    const { ATTR_SERVICE_NAME } = await import("@opentelemetry/semantic-conventions");
+    const { ATTR_SERVICE_NAME, ATTR_SERVICE_NAMESPACE } = await import("@opentelemetry/semantic-conventions");
 
     // Same collector otel-forward uses. OTEL_EXPORTER_OTLP_ENDPOINT is the base (otel-forward
     // maps :4317->:4318 for HTTP); we append /v1/traces. Traces to this endpoint route to
@@ -65,7 +72,10 @@ export async function initTracing({ serviceName, env = process.env } = {}) {
     _provider = new BasicTracerProvider({
       resource: resourceFromAttributes({
         [ATTR_SERVICE_NAME]: serviceName,
-        "host.name": osHostname(),
+        // service.namespace + the SHORT host.name are the canonical cross-signal join keys
+        // (CTL data-quality finding) — traces previously carried neither.
+        [ATTR_SERVICE_NAMESPACE]: "catalyst",
+        "host.name": shortHostName(),
         "catalyst.node.name": resolveNodeName(env),
       }),
       spanProcessors: [new BatchSpanProcessor(exporter)],

--- a/plugins/dev/scripts/execution-core/tracing.mjs
+++ b/plugins/dev/scripts/execution-core/tracing.mjs
@@ -1,0 +1,183 @@
+// tracing.mjs — CTL-1330 Tier 3: OTLP span export for the catalyst daemons.
+//
+// WHY: Tier-1 logs (tick timing / event-loop delay / liveness refresh) DETECT and
+// LOCALIZE the dispatch wedge ("which pass blocks the loop"). Tier-3 spans EXPLAIN it —
+// a flame graph of one tick, root `scheduler.tick` with the offending `scheduler.pass`
+// child eating the whole bar. Producer side for the OTL-25 Tempo sink.
+//
+// HARD RULES (the whole point would be self-defeating otherwise):
+//   * OFF by default — CATALYST_TRACING=on per process (off-first rollout). off+restart
+//     fully disables it with no code change.
+//   * BatchSpanProcessor ONLY. A synchronous exporter on the tick would reintroduce the
+//     exact CTL-790 event-loop wedge this instrumentation exists to diagnose.
+//   * AlwaysOn SDK sampler (the SDK default) — ALL sampling is deferred to the OTEL
+//     collector's tail_sampling (keeps 100% slow>1s + errors, 20% rest). RED metrics come
+//     from the unsampled Tier-1 logs, so trace sampling never undercounts them.
+//   * Every entry point is wrapped in try/catch — a missing/incompatible SDK (the Bun
+//     `monitorEventLoopDelay` lesson) degrades to "no spans", never crashes the daemon.
+//
+// The tick is SYNCHRONOUS, so its spans are reconstructed POST-HOC from the recorded lap
+// timings (explicit start/end timestamps) — no block-wrapping, no per-span work inside the
+// hot loop. See emitTickTrace.
+
+import { hostname as osHostname } from "node:os";
+import { trace, context, SpanKind, SpanStatusCode } from "@opentelemetry/api";
+
+let _enabled = false;
+let _provider = null;
+let _tracer = null;
+
+// tracingEnabled — the per-process master switch. OFF unless explicitly "on".
+export function tracingEnabled(env = process.env) {
+  return env.CATALYST_TRACING === "on";
+}
+
+// resolveNodeName — match getHostName() in config.mjs so spans tag the SAME stable node
+// name as the logs (CATALYST_HOST_NAME, else the OS hostname's first DNS label).
+function resolveNodeName(env) {
+  if (env.CATALYST_HOST_NAME) return env.CATALYST_HOST_NAME;
+  try {
+    return osHostname().split(".")[0];
+  } catch {
+    return "unknown";
+  }
+}
+
+// initTracing — construct the provider + OTLP/HTTP exporter + BatchSpanProcessor ONCE.
+// Idempotent; a no-op when disabled or already initialized. NEVER throws.
+export async function initTracing({ serviceName, env = process.env } = {}) {
+  if (_enabled) return true;
+  if (!tracingEnabled(env)) return false;
+  try {
+    const { BasicTracerProvider, BatchSpanProcessor } = await import("@opentelemetry/sdk-trace-base");
+    const { OTLPTraceExporter } = await import("@opentelemetry/exporter-trace-otlp-http");
+    const { resourceFromAttributes } = await import("@opentelemetry/resources");
+    const { ATTR_SERVICE_NAME } = await import("@opentelemetry/semantic-conventions");
+
+    // Same collector otel-forward uses. OTEL_EXPORTER_OTLP_ENDPOINT is the base (otel-forward
+    // maps :4317->:4318 for HTTP); we append /v1/traces. Traces to this endpoint route to
+    // Tempo-only (OTL-25). Default to the shared Tailscale collector.
+    const base = (env.OTEL_EXPORTER_OTLP_ENDPOINT || "http://100.65.193.30:4318")
+      .replace(/:4317\b/, ":4318")
+      .replace(/\/$/, "");
+    const exporter = new OTLPTraceExporter({ url: `${base}/v1/traces` });
+
+    _provider = new BasicTracerProvider({
+      resource: resourceFromAttributes({
+        [ATTR_SERVICE_NAME]: serviceName,
+        "host.name": osHostname(),
+        "catalyst.node.name": resolveNodeName(env),
+      }),
+      spanProcessors: [new BatchSpanProcessor(exporter)],
+    });
+    trace.setGlobalTracerProvider(_provider);
+    _tracer = trace.getTracer(serviceName);
+    _enabled = true;
+
+    // Flush on exit so a wedge tick's spans aren't lost on a restart. Best-effort.
+    const flush = () => {
+      try {
+        _provider?.forceFlush?.();
+      } catch {
+        /* best-effort */
+      }
+    };
+    process.once("SIGTERM", flush);
+    process.once("SIGINT", flush);
+    process.once("beforeExit", flush);
+    return true;
+  } catch {
+    _enabled = false;
+    _provider = null;
+    _tracer = null;
+    return false;
+  }
+}
+
+// shutdownTracing — flush + tear down (test seam + graceful daemon stop).
+export async function shutdownTracing() {
+  if (!_provider) return;
+  try {
+    await _provider.forceFlush();
+    await _provider.shutdown();
+  } catch {
+    /* best-effort */
+  }
+  _enabled = false;
+  _provider = null;
+  _tracer = null;
+}
+
+export function getTracer() {
+  return _enabled ? _tracer : null;
+}
+
+// __setTracerForTest — inject a tracer (e.g. backed by InMemorySpanExporter) so the
+// span-emit helpers can be unit-tested without a real OTLP collector. Pass null to clear.
+export function __setTracerForTest(tracer) {
+  _tracer = tracer;
+  _enabled = tracer != null;
+}
+
+// emitTickTrace — build the post-hoc span tree for ONE completed scheduler tick from the
+// recorded lap timings. Root `scheduler.tick` (INTERNAL) + a `scheduler.pass` child ONLY
+// for passes over slowPassThresholdMs (semconv hygiene: <10 INTERNAL / <20 sub-5ms spans
+// per trace — a healthy tick is 1 span; a wedged tick shows exactly the offending passes).
+// `laps` = [{name, durationMs, startEpochMs, endEpochMs}]. `attrs` = flat span attributes.
+// Never throws.
+export function emitTickTrace({ tickId, startEpochMs, endEpochMs, laps = [], attrs = {}, slowPassThresholdMs = 50 } = {}) {
+  const tracer = getTracer();
+  if (!tracer) return;
+  try {
+    const root = tracer.startSpan("scheduler.tick", { kind: SpanKind.INTERNAL, startTime: startEpochMs });
+    if (tickId != null) root.setAttribute("catalyst.scheduler.tick_id", tickId);
+    for (const [k, v] of Object.entries(attrs)) {
+      if (v != null) root.setAttribute(k, v);
+    }
+    const rootCtx = trace.setSpan(context.active(), root);
+    for (const lap of laps) {
+      if (lap && lap.durationMs >= slowPassThresholdMs) {
+        const child = tracer.startSpan(
+          "scheduler.pass",
+          { kind: SpanKind.INTERNAL, startTime: lap.startEpochMs },
+          rootCtx
+        );
+        child.setAttribute("catalyst.scheduler.pass", lap.name);
+        child.setAttribute("catalyst.scheduler.pass.duration_ms", lap.durationMs);
+        child.end(lap.endEpochMs);
+      }
+    }
+    root.end(endEpochMs);
+  } catch {
+    /* observability must never throw out of the tick */
+  }
+}
+
+// emitLivenessRefreshSpan — a standalone span for one async claude-agents liveness
+// refresh. ERROR status on timeout — the span that visually shows "aborted at the
+// deadline because the tick blocked the loop". A root span (not a child of the tick:
+// the refresh runs in its own async context, fire-and-forget from getAgentsCached;
+// cross-process/async parenting is Phase 2). startEpochMs/endEpochMs are epoch ms.
+export function emitLivenessRefreshSpan({ outcome, startEpochMs, endEpochMs, deadlineMs, populated, ageMs } = {}) {
+  const tracer = getTracer();
+  if (!tracer) return;
+  try {
+    const span = tracer.startSpan("liveness.refresh", { kind: SpanKind.INTERNAL, startTime: startEpochMs });
+    if (outcome != null) span.setAttribute("catalyst.liveness.outcome", outcome);
+    if (deadlineMs != null) span.setAttribute("catalyst.liveness.deadline_ms", deadlineMs);
+    if (populated != null) span.setAttribute("catalyst.liveness.populated", populated);
+    if (ageMs != null) span.setAttribute("catalyst.liveness.age_ms", ageMs);
+    if (outcome === "timeout") {
+      span.setStatus({
+        code: SpanStatusCode.ERROR,
+        message: `liveness refresh timed out at ${deadlineMs}ms — the synchronous tick blocked the event loop past the deadline`,
+      });
+    }
+    span.end(endEpochMs);
+  } catch {
+    /* observability must never throw */
+  }
+}
+
+// Re-export the api primitives callers need so they don't each import @opentelemetry/api.
+export { trace, context, SpanKind, SpanStatusCode };

--- a/plugins/dev/scripts/execution-core/tracing.test.mjs
+++ b/plugins/dev/scripts/execution-core/tracing.test.mjs
@@ -1,0 +1,111 @@
+// tracing.test.mjs — CTL-1330 Tier 3: span-tree shape + the OFF-by-default / no-crash
+// invariants. Uses an in-memory exporter so nothing hits a real OTLP collector.
+
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { BasicTracerProvider, InMemorySpanExporter, SimpleSpanProcessor } from "@opentelemetry/sdk-trace-base";
+import { SpanKind, SpanStatusCode } from "@opentelemetry/api";
+import {
+  tracingEnabled,
+  getTracer,
+  emitTickTrace,
+  emitLivenessRefreshSpan,
+  __setTracerForTest,
+} from "./tracing.mjs";
+
+describe("tracingEnabled (CTL-1330 Tier 3 — OFF by default)", () => {
+  test("OFF unless CATALYST_TRACING=on", () => {
+    expect(tracingEnabled({})).toBe(false);
+    expect(tracingEnabled({ CATALYST_TRACING: "off" })).toBe(false);
+    expect(tracingEnabled({ CATALYST_TRACING: "1" })).toBe(false);
+    expect(tracingEnabled({ CATALYST_TRACING: "on" })).toBe(true);
+  });
+});
+
+describe("span helpers are safe no-ops when tracing is disabled", () => {
+  beforeEach(() => __setTracerForTest(null));
+  test("getTracer() is null and emit helpers never throw", () => {
+    expect(getTracer()).toBeNull();
+    expect(() => emitTickTrace({ tickId: 1, startEpochMs: 0, endEpochMs: 10, laps: [] })).not.toThrow();
+    expect(() => emitLivenessRefreshSpan({ outcome: "timeout", startEpochMs: 0, endEpochMs: 3000, deadlineMs: 3000 })).not.toThrow();
+  });
+});
+
+describe("emitTickTrace span tree (in-memory exporter)", () => {
+  let exporter;
+  beforeEach(() => {
+    exporter = new InMemorySpanExporter();
+    const provider = new BasicTracerProvider({ spanProcessors: [new SimpleSpanProcessor(exporter)] });
+    __setTracerForTest(provider.getTracer("test"));
+  });
+  afterEach(() => __setTracerForTest(null));
+
+  test("root scheduler.tick + a scheduler.pass child ONLY for passes over the threshold", () => {
+    emitTickTrace({
+      tickId: 42,
+      startEpochMs: 1000,
+      endEpochMs: 2940,
+      slowPassThresholdMs: 50,
+      laps: [
+        { name: "eligible-read", durationMs: 0.2, startEpochMs: 1000, endEpochMs: 1000 },
+        { name: "recovery-pass", durationMs: 1897, startEpochMs: 1001, endEpochMs: 2898 },
+        { name: "new-work-pull", durationMs: 40, startEpochMs: 2898, endEpochMs: 2938 }, // under threshold
+      ],
+      attrs: { "catalyst.scheduler.slowest_pass": "recovery-pass" },
+    });
+    const spans = exporter.getFinishedSpans();
+    const names = spans.map((s) => s.name).sort();
+    expect(names).toEqual(["scheduler.pass", "scheduler.tick"]); // exactly one pass child (the slow one)
+
+    const root = spans.find((s) => s.name === "scheduler.tick");
+    expect(root.kind).toBe(SpanKind.INTERNAL);
+    expect(root.attributes["catalyst.scheduler.tick_id"]).toBe(42);
+    expect(root.attributes["catalyst.scheduler.slowest_pass"]).toBe("recovery-pass");
+
+    const child = spans.find((s) => s.name === "scheduler.pass");
+    expect(child.attributes["catalyst.scheduler.pass"]).toBe("recovery-pass");
+    expect(child.attributes["catalyst.scheduler.pass.duration_ms"]).toBe(1897);
+    // child is parented to the root
+    expect(child.parentSpanContext?.spanId ?? child.parentSpanId).toBe(root.spanContext().spanId);
+  });
+
+  test("a healthy tick (all passes under threshold) emits ONLY the root span", () => {
+    emitTickTrace({
+      tickId: 7,
+      startEpochMs: 0,
+      endEpochMs: 3,
+      laps: [
+        { name: "phantom-sweep", durationMs: 0.2, startEpochMs: 0, endEpochMs: 0 },
+        { name: "advancement", durationMs: 0.3, startEpochMs: 1, endEpochMs: 1 },
+      ],
+    });
+    const spans = exporter.getFinishedSpans();
+    expect(spans.map((s) => s.name)).toEqual(["scheduler.tick"]);
+  });
+});
+
+describe("emitLivenessRefreshSpan (in-memory exporter)", () => {
+  let exporter;
+  beforeEach(() => {
+    exporter = new InMemorySpanExporter();
+    const provider = new BasicTracerProvider({ spanProcessors: [new SimpleSpanProcessor(exporter)] });
+    __setTracerForTest(provider.getTracer("test"));
+  });
+  afterEach(() => __setTracerForTest(null));
+
+  test("timeout outcome sets ERROR status + the outcome attribute", () => {
+    emitLivenessRefreshSpan({ outcome: "timeout", startEpochMs: 1000, endEpochMs: 4000, deadlineMs: 3000, populated: true, ageMs: 5000 });
+    const [span] = exporter.getFinishedSpans();
+    expect(span.name).toBe("liveness.refresh");
+    expect(span.attributes["catalyst.liveness.outcome"]).toBe("timeout");
+    expect(span.attributes["catalyst.liveness.deadline_ms"]).toBe(3000);
+    expect(span.status.code).toBe(SpanStatusCode.ERROR);
+    expect(span.status.message).toContain("3000ms");
+  });
+
+  test("resolved outcome leaves status UNSET (no error)", () => {
+    emitLivenessRefreshSpan({ outcome: "resolved", startEpochMs: 1000, endEpochMs: 1211, deadlineMs: 3000, populated: true, ageMs: 0 });
+    const [span] = exporter.getFinishedSpans();
+    expect(span.attributes["catalyst.liveness.outcome"]).toBe("resolved");
+    expect(span.status.code).toBe(SpanStatusCode.UNSET);
+  });
+});


### PR DESCRIPTION
## What

CTL-1330 **Tier 3** — OTel Node SDK in the execution-core daemon emitting OTLP trace spans. The EXPLAIN layer below Tier-1 logs: a flame graph of one tick showing exactly which pass eats the bar. Producer for the OTL-25 Tempo sink. **OFF by default** (`CATALYST_TRACING=on` per process — off-first rollout).

## Design

`tracing.mjs` — gated bootstrap:
- OTLP/HTTP exporter → `OTEL_EXPORTER_OTLP_ENDPOINT` (`/v1/traces`; defaults to the shared collector; Tempo-only via OTL-25).
- **`BatchSpanProcessor` only** — a synchronous exporter on the tick would reintroduce the exact CTL-790 wedge this diagnoses.
- **AlwaysOn SDK sampler** — all sampling deferred to the collector `tail_sampling`. RED metrics come from the unsampled Tier-1 logs, so trace sampling never undercounts.
- Resource `service.name` + `host.name` + `catalyst.node.name` (semconv; matches the log streams for trace↔logs correlation).
- Whole init `try/catch`-guarded so a missing/incompatible SDK degrades to "no spans" (the Bun `monitorEventLoopDelay` lesson — **verified** the full SDK + HTTP exporter + post-hoc spans work under Bun via a scratch smoke test).

Spans:
- **`scheduler.tick`** (root, INTERNAL) reconstructed **post-hoc** from the Tier-1 lap timings (explicit start/end timestamps — zero per-span work inside the synchronous hot loop), with a **`scheduler.pass` child only for passes >50ms** (semconv hygiene: <10 INTERNAL / <20 sub-5ms spans per trace — a healthy tick is 1 span; a wedged tick shows exactly the offending passes, e.g. `recovery-pass` eating the whole bar). Attributes: `slowest_pass`, `free_slots`, `eligible_count`, `liveness_fresh`, `beliefs_shadow`.
- **`liveness.refresh`** span (in `claude-agents.mjs` via a leaf-pure span sink, same injection as the log sink) — **ERROR status on timeout** (the span that shows "aborted at the deadline because the tick blocked the loop").

`makeTickTimer` extended to record absolute epoch timestamps per lap (`spanLaps`); Tier-1 API unchanged.

## Tests

`tracing.test.mjs` (InMemorySpanExporter): span-tree shape (root + slow-pass child only), healthy-tick-only-root, ERROR-on-timeout, OFF-by-default gate, no-crash-when-disabled. Registered in CI. Tier-1: 82 pass. No new scheduler regressions (504 pass; 2 fails pre-exist on `main`).

## Rollout

Lands OFF. Then enable `CATALYST_TRACING=on` on **mini** first, watch the Tier-1 `event_loop_p99_ms` to prove the exporter adds no lag, post **SENDING** to the OTEL coordination channel, and the OTL-25 agent verifies the `scheduler.tick`→`scheduler.pass` hierarchy + trace↔logs correlation in Tempo → both sign off.

`broker.route` + monitor SERVER spans are the Tier-3 follow-up (separate per-package SDK setup; the scheduler is the wedge, so it leads).

Part of CTL-1330.

🤖 Generated with [Claude Code](https://claude.com/claude-code)