### PR TITLE
fix(dev): CTL-1338 — tracing.mjs degrades to no-op when @opentelemetry/api is absent (unbreak orch-monitor quality)

### DIFF
--- a/plugins/dev/scripts/execution-core/tracing.mjs
+++ b/plugins/dev/scripts/execution-core/tracing.mjs
@@ -21,7 +21,22 @@
 // hot loop. See emitTickTrace.
 
 import { hostname as osHostname } from "node:os";
-import { trace, context, SpanKind, SpanStatusCode } from "@opentelemetry/api";
+import { createRequire } from "node:module";
+
+// CTL-1338: load @opentelemetry/api via createRequire (synchronous — the emit helpers
+// below use trace/context/SpanKind/SpanStatusCode on the sync tick path) wrapped in
+// try/catch so a MISSING dep degrades to no-op instead of crashing on module load. This
+// honors the "missing SDK → no spans, never crash" invariant above — a STATIC
+// `import ... from "@opentelemetry/api"` violated it: any importer of scheduler.mjs (e.g.
+// orch-monitor's quality `bun test`, which uses scheduler.mjs's pure helpers but does NOT
+// install the OTel deps) crashed on module load. The other four OTel packages are already
+// lazy-loaded inside initTracing; only `api` was static, inconsistently.
+let trace, context, SpanKind, SpanStatusCode;
+try {
+  ({ trace, context, SpanKind, SpanStatusCode } = createRequire(import.meta.url)("@opentelemetry/api"));
+} catch {
+  // @opentelemetry/api not installed in this consumer's context — tracing stays a no-op.
+}
 
 let _enabled = false;
 let _provider = null;


### PR DESCRIPTION
## Why (main is red)

The orch-monitor `quality` check fails on every PR touching `orch-monitor/**`:

```
quality › Test: error: Cannot find module '@opentelemetry/api' from
  '.../plugins/dev/scripts/execution-core/tracing.mjs'
```

**Root cause.** CTL-1330 Tier-3 (#2354) added `tracing.mjs` with a **static** top-level `import { trace } from "@opentelemetry/api"`. orch-monitor tests transitively import `execution-core/scheduler.mjs` → `tracing.mjs` (pure helpers in `lib/journey.mjs` + the journey contract tests). The `orch-monitor-quality.yml` job only runs `bun install` in `orch-monitor/`, not execution-core — so `@opentelemetry/api` is unresolvable and `bun test` crashes on module load.

**Not a force-merge.** #2354 was a normal squash by Ryan with all its required checks green. The `quality` job is path-filtered to `orch-monitor/**`, so an execution-core-only PR never triggers it — the regression surfaced on the next orch-monitor PR (#2345). A path-filter CI gap.

## Fix

Load `@opentelemetry/api` via a synchronous `createRequire` wrapped in try/catch. The primitives stay available synchronously for the sync emit helpers, but a **missing dep degrades to no-op** instead of crashing every importer — honoring `tracing.mjs`'s own documented invariant ("a missing/incompatible SDK degrades to 'no spans', never crashes the daemon"). The static `@opentelemetry/api` import violated that; the other four OTel packages were already lazy-loaded inside `initTracing` — only `api` was static, inconsistently.

## Verification

- ✅ `createRequire("@opentelemetry/api")` returns **identical primitives** under Bun where the dep is present (`SpanKind.INTERNAL=0`, `SpanStatusCode.ERROR=2`) → **zero behavior change for the live daemon** (mini is tracing right now).
- ✅ `tracing.test.mjs` — **6/6 pass** (no regression where deps exist).
- ✅ With `@opentelemetry/api` hidden (CI quality-job conditions): `tracing.mjs` loads **without throwing**, `getTracer()=null`, `emitTickTrace` no-throw, and the previously-failing `orch-monitor/__tests__/governance-journey.contract.test.ts` **passes 3/3**.

> Note: this PR touches execution-core, so the path-filtered `orch-monitor-quality` job won't run here — the validation above reproduces that job's exact conditions locally. A follow-up to harden the CI path-filter (run quality when an execution-core change is in orch-monitor's transitive graph) is noted on CTL-1338.

Fixes CTL-1338. Relates CTL-1330.

🤖 Generated with [Claude Code](https://claude.com/claude-code)