### PR TITLE
fix(dev): CTL-1334 — log-shipper emits short host.name (first DNS label) so logs join metrics

### DIFF
--- a/plugins/dev/scripts/log-shipper/README.md
+++ b/plugins/dev/scripts/log-shipper/README.md
@@ -89,7 +89,12 @@ which are exactly 9/13/17/21.)
 
 Every shipped record carries **two** host identities as resource attributes:
 
-- `host.name` — the **OS hostname** (`constants.hostname`).
+- `host.name` — the **OS hostname's first DNS label** (the canonical SHORT form,
+  `mini` not `mini.rozich`). `constants.hostname` is the FQDN on macOS, so the
+  config emits `string.split(constants.hostname, ".")[0]`. This matches the short
+  host the metrics + canonical-events paths emit (CTL-1252 first-DNS-label
+  collapse), so daemon `.log` records join with metrics/events on `host.name`
+  instead of splitting FQDN vs short (CTL-1334).
 - `catalyst.host.name` — the **stable Catalyst node name**.
 
 ### Node name
@@ -105,9 +110,10 @@ Because Alloy/River cannot read the Layer-2 JSON or compute the first-DNS-label
 reduction itself, **the launcher is responsible for resolving the node name and
 exporting it as `CATALYST_HOST_NAME`** before starting Alloy — using the exact
 `getHostName()` precedence above. The config then reads
-`coalesce(sys.env("CATALYST_HOST_NAME"), constants.hostname)`: if the launcher
-provides the env var (the expected path) it is used verbatim; otherwise it falls
-back to the OS hostname so records are still node-tagged.
+`coalesce(sys.env("CATALYST_HOST_NAME"), string.split(constants.hostname, ".")[0])`:
+if the launcher provides the env var (the expected path) it is used verbatim;
+otherwise it falls back to the OS hostname's first DNS label so records are still
+node-tagged with the short form.
 
 > **The node name is NEVER the Tailscale device name.** Tailscale reports e.g.
 > `RyansMini250233`, but the stable Catalyst node name is `mini`. Deriving the

--- a/plugins/dev/scripts/log-shipper/config.alloy
+++ b/plugins/dev/scripts/log-shipper/config.alloy
@@ -28,7 +28,14 @@
 //   as unstructured records — never dropped.
 //
 // MACHINE + NODE TAGGING  (load-bearing — see the README "Node name" section)
-//   host.name           = constants.hostname (the OS hostname — the MACHINE)
+//   host.name           = constants.hostname's FIRST DNS LABEL (the OS hostname's
+//                         canonical SHORT form, `mini` not `mini.rozich` — the
+//                         MACHINE). constants.hostname is the FQDN on macOS, so we
+//                         take string.split(constants.hostname, ".")[0]. This is the
+//                         SAME normalized short host the metrics + canonical-events
+//                         paths emit (CTL-1252 first-DNS-label collapse), so daemon
+//                         `.log` records JOIN with metrics/events on host.name
+//                         instead of splitting FQDN vs short (CTL-1334).
 //   catalyst.node.name  = the stable Catalyst NODE name, from CATALYST_HOST_NAME
 //   The launcher (sibling ticket) MUST export CATALYST_HOST_NAME resolved the
 //   SAME way as getHostName() in execution-core/config.mjs:
@@ -37,8 +44,8 @@
 //         -> os.hostname() first DNS label
 //   The node name is STABLE and is NEVER derived from the Tailscale device name
 //   (RyansMini250233 != mini). If CATALYST_HOST_NAME is unset, this config
-//   falls back to constants.hostname so records are still tagged (the launcher
-//   is responsible for providing the correct stable value).
+//   falls back to constants.hostname's first DNS label so records are still tagged
+//   (the launcher is responsible for providing the correct stable value).
 //
 // SEMCONV MAPPING  (OTel logs data model)
 //   pino numeric level -> severityNumber / severityText
@@ -95,7 +102,7 @@ otelcol.processor.batch "catalyst" {
 // (below) lift pino fields into log-record attributes (level, name); this OTTL
 // transform turns them into the proper OTel semconv shape:
 //   * numeric pino level -> severity_number + severity_text
-//   * host.name resource attribute          = OS hostname (the MACHINE)
+//   * host.name resource attribute          = OS hostname's first DNS label (short, the MACHINE)
 //   * catalyst.node.name resource attribute = stable Catalyst node name (the NODE)
 //   * service.name resource attribute       = catalyst.<daemon>, promoted from the
 //     per-file service_name label (the loki->otel receiver carries it as a log
@@ -132,19 +139,26 @@ otelcol.processor.transform "catalyst" {
 	}
 
 	// --- per-resource: machine + node identity --------------------------------
-	// host.name          = the OS hostname (constants.hostname) — the MACHINE.
+	// host.name          = the OS hostname's FIRST DNS LABEL — the MACHINE in its
+	//   canonical SHORT form (`mini`, not `mini.rozich`). constants.hostname is the
+	//   FQDN on macOS, so we take string.split(...)[0] to strip the domain. This
+	//   matches the normalized short host the metrics + canonical-events paths emit
+	//   (the CTL-1252 first-DNS-label collapse), so daemon `.log` records JOIN with
+	//   metrics/events on host.name instead of splitting FQDN vs short (CTL-1334).
+	//   string.split always returns a non-empty list — a bare hostname with no "."
+	//   yields [hostname], so [0] is a safe fallback for non-FQDN hosts.
 	// catalyst.node.name = the stable Catalyst NODE name (custom + namespaced;
 	//   host.* is the OTel registry machine namespace, so the cluster node uses a
 	//   catalyst.* attribute). Resolved by the launcher exactly like getHostName(),
 	//   and matches the event path so logs + events query by the same node tag.
-	// Falls back to the OS hostname so records are always node-tagged even if the
-	// env var is missing. Spliced into the OTTL strings via River concatenation
-	// (OTTL itself cannot read River symbols).
+	// Falls back to the OS hostname's first DNS label so records are always
+	// node-tagged even if the env var is missing. Spliced into the OTTL strings via
+	// River concatenation (OTTL itself cannot read River symbols).
 	log_statements {
 		context    = "resource"
 		statements = [
-			`set(resource.attributes["host.name"], "` + constants.hostname + `")`,
-			`set(resource.attributes["catalyst.node.name"], "` + coalesce(sys.env("CATALYST_HOST_NAME"), constants.hostname) + `")`,
+			`set(resource.attributes["host.name"], "` + string.split(constants.hostname, ".")[0] + `")`,
+			`set(resource.attributes["catalyst.node.name"], "` + coalesce(sys.env("CATALYST_HOST_NAME"), string.split(constants.hostname, ".")[0]) + `")`,
 		]
 	}
 


### PR DESCRIPTION
## CTL-1334 — log-shipper `host.name` FQDN → short (first DNS label)

### Problem
The Grafana Alloy daemon-log shipper (`plugins/dev/scripts/log-shipper/config.alloy`) tagged every shipped `.log` record with `host.name = constants.hostname`. On macOS `constants.hostname` is the **FQDN** (`mini.rozich`, `mini-2.rozich`). Metrics and canonical-events emit the normalized **short** host (`mini`, `mini-2` — the CTL-1252 first-DNS-label collapse), so logs could not join metrics/events on host. Per the OTL-25 data-quality audit, ~62% of catalyst log lines over 24h carried the FQDN form, splitting host identity by emission path.

### Fix
Emit the **first DNS label** instead of the FQDN, using a valid Alloy River expression:

```river
string.split(constants.hostname, ".")[0]
```

Applied to both:
- the `host.name` resource attribute (the headline fix), and
- the `catalyst.node.name` fallback (used when `CATALYST_HOST_NAME` is unset — keeping that as the FQDN would have reintroduced the same FQDN/short split for the node tag).

`string.split` always returns a non-empty list, so a bare hostname with no `.` yields `[hostname]` and `[0]` is a safe fallback for non-FQDN hosts.

Header comments + `README.md` host-tagging section updated to match.

### River-expression choice (verified)
- Alloy **v1.17.0** (installed locally) was used to validate.
- `alloy fmt` — passes, **no formatting drift** on the real config.
- `alloy validate` (full semantic, resolves the function) — **RC=0, zero warnings** for `string.split(...)[0]`.
- The deprecated **top-level `split()`** was **rejected** by `alloy validate` (`this stdlib function is deprecated … validation failed`), confirming the namespaced `string.split` is the correct v1.x form.

### Deploy / verify — PENDING (human step, NOT done here)
This PR does **not** restart anything. The live cutover is a human step:
1. Restart `ai.coalesce.catalyst-log-shipper` on **mini** and **mini-2** (this re-reads the Alloy config).
2. Confirm the short host: `{service_name="catalyst.execution-core"} | json` should report a **short** `host_name` (`mini` / `mini-2`), not the FQDN.
3. Spot-check the logs↔metrics host join now works (`sum by (host_name)` over the same window matches metrics' short form).

### Files
- `plugins/dev/scripts/log-shipper/config.alloy`
- `plugins/dev/scripts/log-shipper/README.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)