### PR TITLE
chore(dev): remove DeepWiki MCP integration

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
     {
       "name": "catalyst-dev",
       "source": "./plugins/dev",
-      "description": "Core development workflow: research → plan → implement → validate → ship. Includes 9 research agents, workflow commands, Linear integration, handoff system. Always enabled. ~3.5k context (lightweight MCPs: DeepWiki, Context7).",
+      "description": "Core development workflow: research → plan → implement → validate → ship. Includes 9 research agents, workflow commands, Linear integration, handoff system. Always enabled. ~3.5k context (lightweight MCP: Context7).",
       "author": {
         "name": "Coalesce Labs",
         "email": "hello@coalesce.dev"

--- a/.mcp.json.template
+++ b/.mcp.json.template
@@ -19,14 +19,6 @@
         "SENTRY_PROJECT": "${SENTRY_PROJECT}"
       }
     },
-    "deepwiki": {
-      "comment": "GitHub repository research - useful for meta workflows. ~1,885 tokens",
-      "command": "npx",
-      "args": ["-y", "@deekard/deepwiki-mcp"],
-      "env": {
-        "GITHUB_TOKEN": "${GITHUB_TOKEN}"
-      }
-    },
     "context7": {
       "comment": "Library documentation - helpful for learning new libraries. ~1,709 tokens",
       "command": "npx",

--- a/README.md
+++ b/README.md
@@ -44,8 +44,6 @@ Catalyst integrates with your development tools through both **CLI-based** (toke
 
 - **Context7** - Library documentation lookup (MCP, ~2k tokens)
   - `catalyst-dev`: Built-in, always available
-- **DeepWiki** - GitHub repository documentation (MCP, ~1.5k tokens)
-  - `catalyst-dev`: Built-in, always available
 - **Exa** - Web research and external documentation (API)
   - `catalyst-dev`: External research agent
 
@@ -80,7 +78,7 @@ and shared memory systems.
 - Linear integration via Linearis CLI
 - CI/automation commands for non-interactive workflows
 - Handoff system for context persistence
-- ~3.5k context (lightweight MCPs: DeepWiki, Context7)
+- ~3.5k context (lightweight MCP: Context7)
 
 **catalyst-pm** (Optional - Enable for product strategy)
 
@@ -370,7 +368,7 @@ When possible, uses CLIs instead of MCPs for token efficiency:
 
 **MCP Tools** (bundled with plugins):
 
-- Context7 & DeepWiki - Built into `catalyst-dev` (~3.5k tokens)
+- Context7 - Built into `catalyst-dev` (~3.5k tokens)
 - PostHog - Built into `catalyst-analytics` (~40k tokens when enabled)
 - Sentry - Built into `catalyst-debugging` (~20k tokens when enabled)
 

--- a/plugins/dev/agents/README.md
+++ b/plugins/dev/agents/README.md
@@ -155,7 +155,7 @@ extract key findings" )
 - Researching best practices from open-source
 - Discovering external documentation
 
-**Tools**: mcp**deepwiki**ask_question, mcp**deepwiki**read_wiki_structure
+**Tools**: mcp**context7**resolve-library-id, mcp**context7**query-docs, WebSearch, WebFetch
 
 **Example invocation:**
 
@@ -397,8 +397,8 @@ Agents specify required tools in frontmatter:
 
 **External:**
 
-- `mcp__deepwiki__ask_question` - Query external repos
-- `mcp__deepwiki__read_wiki_structure` - Read external docs
+- `mcp__context7__query-docs` - Library/framework documentation
+- `WebSearch` / `WebFetch` - General web search and page retrieval
 
 ## Troubleshooting
 

--- a/plugins/dev/agents/codebase-analyzer.md
+++ b/plugins/dev/agents/codebase-analyzer.md
@@ -5,7 +5,7 @@ description:
   detailed information about specific components. As always, the more detailed your request prompt,
   the better! :)
 tools:
-  Read, Grep, Glob, Bash(ls *), mcp__deepwiki__ask_question, mcp__context7__get_library_docs,
+  Read, Grep, Glob, Bash(ls *), mcp__context7__get_library_docs,
   mcp__context7__resolve_library_id
 model: sonnet
 version: 1.0.0
@@ -64,17 +64,10 @@ trace data flow, and explain technical workings with precise file:line reference
 
 If the code uses external libraries or frameworks:
 
-- Use `mcp__deepwiki__ask_question` to understand recommended patterns
-- Example: "How does [library] recommend implementing [feature]?"
+- Use Context7 (`mcp__context7__resolve_library_id` then `mcp__context7__get_library_docs`) to look up the library's recommended patterns
 - Compare local implementation against framework best practices
 - Note any deviations or custom approaches
 - **Important**: Only research external repos, not the local codebase
-
-Example questions for DeepWiki:
-
-- "How does Passport.js recommend implementing authentication strategies?"
-- "What's the standard session management pattern in Express?"
-- "How does React Query recommend handling cache invalidation?"
 
 ### Step 3: Document Key Logic
 

--- a/plugins/dev/agents/codebase-pattern-finder.md
+++ b/plugins/dev/agents/codebase-pattern-finder.md
@@ -6,8 +6,8 @@ description:
   based on what you're looking for! It's sorta like codebase-locator, but it will not only tell you
   the location of files, it will also give you code details!
 tools:
-  Grep, Glob, Read, Bash(ls *), mcp__deepwiki__ask_question, mcp__deepwiki__read_wiki_structure,
-  mcp__context7__get_library_docs, mcp__context7__resolve_library_id
+  Grep, Glob, Read, Bash(ls *), mcp__context7__get_library_docs,
+  mcp__context7__resolve_library_id
 model: sonnet
 version: 1.0.0
 ---
@@ -61,8 +61,8 @@ look for based on request:
 
 - You can use your handy dandy `Grep`, `Glob`, and `LS` tools to to find what you're looking for!
   You know how it's done!
-- **If user asks about external repos/frameworks**: Use DeepWiki tools (see "External Pattern
-  Research" section below)
+- **If user asks about external repos/frameworks**: Use Context7 for library/framework docs (see
+  "External Pattern Research" section below)
 
 ### Step 3: Read and Extract
 
@@ -221,28 +221,17 @@ describe("Pagination", () => {
 
 When the user requests patterns from popular repos or frameworks:
 
-### Step 1: Use DeepWiki to Research External Repos
+### Step 1: Research External Repos
 
-**For specific questions**:
-```
-
-mcp**deepwiki**ask_question({ repoName: "facebook/react", question: "How is [pattern] typically
-implemented?" })
-
-```
-
-**For broad exploration** (get structure first):
-```
-
-mcp**deepwiki**read_wiki_structure({ repoName: "vercel/next.js" }) // See available topics, then ask
-specific questions
-
-````
+- **For library/framework docs**: Use Context7 (`mcp__context7__resolve_library_id` then
+  `mcp__context7__get_library_docs`) to pull current documentation and code examples.
+- **For broader code/web search**: Use Exa or WebSearch/WebFetch when the pattern isn't covered by
+  Context7, or to read a framework's live source.
 
 ### Step 2: Compare with Local Patterns
 
 Present both:
-1. **External framework pattern** (from DeepWiki)
+1. **External framework pattern** (from Context7 / web research)
    - How popular repos do it
    - Recommended approach
    - Code examples if provided
@@ -264,12 +253,12 @@ Present both:
 ### External Pattern: From [Repo Name]
 
 **Recommended approach**:
-[What DeepWiki found]
+[What the external research found]
 
-**Example** (from DeepWiki research):
+**Example** (from external research):
 [Code example if provided]
 
-**Reference**: [DeepWiki search link]
+**Reference**: [Source link]
 
 ---
 
@@ -300,7 +289,7 @@ Present both:
 - **Include tests** - Show existing test patterns
 - **Full file paths** - With line numbers
 - **No evaluation** - Just show what exists without judgment
-- **External research** - Use DeepWiki for popular repo patterns, then compare with local
+- **External research** - Use Context7 for popular repo/framework patterns, then compare with local
 
 ## What NOT to Do
 

--- a/plugins/dev/agents/codebase-pattern-finder.md
+++ b/plugins/dev/agents/codebase-pattern-finder.md
@@ -7,7 +7,7 @@ description:
   the location of files, it will also give you code details!
 tools:
   Grep, Glob, Read, Bash(ls *), mcp__context7__get_library_docs,
-  mcp__context7__resolve_library_id
+  mcp__context7__resolve_library_id, WebSearch, WebFetch
 model: sonnet
 version: 1.0.0
 ---
@@ -225,8 +225,9 @@ When the user requests patterns from popular repos or frameworks:
 
 - **For library/framework docs**: Use Context7 (`mcp__context7__resolve_library_id` then
   `mcp__context7__get_library_docs`) to pull current documentation and code examples.
-- **For broader code/web search**: Use Exa or WebSearch/WebFetch when the pattern isn't covered by
-  Context7, or to read a framework's live source.
+- **For broader code/web search**: Use `WebFetch`/`WebSearch` to read a framework's live source or
+  find real-world examples when Context7 doesn't cover the pattern (Exa code search too, if the Exa
+  MCP is configured).
 
 ### Step 2: Compare with Local Patterns
 

--- a/plugins/dev/agents/external-research.md
+++ b/plugins/dev/agents/external-research.md
@@ -2,11 +2,11 @@
 name: external-research
 description:
   Research external resources including GitHub repositories, frameworks, libraries, and general
-  web content. Uses DeepWiki for repo analysis, Context7 for library docs, Exa for code search,
-  and WebSearch/WebFetch for general web research.
+  web content. Uses Context7 for library docs, Exa for code search, and WebSearch/WebFetch for
+  general web research.
 tools:
-  mcp__deepwiki__ask_question, mcp__deepwiki__read_wiki_structure, mcp__context7__get_library_docs,
-  mcp__context7__resolve_library_id, mcp__exa__search, mcp__exa__search_code, WebSearch, WebFetch
+  mcp__context7__get_library_docs, mcp__context7__resolve_library_id, mcp__exa__search,
+  mcp__exa__search_code, WebSearch, WebFetch
 model: sonnet
 version: 1.0.0
 ---
@@ -26,10 +26,13 @@ libraries, and implementation patterns.
 
 ### Choosing the Right Tool
 
+**For library documentation** (API reference, usage guides, framework docs):
+- Use `mcp__context7__resolve_library_id` then `mcp__context7__get_library_docs`
+
 **For GitHub repository research** (how does X implement Y?):
-- Use `mcp__deepwiki__ask_question` — deep analysis of repo internals
-- Use `mcp__deepwiki__read_wiki_structure` — see available topics first
-- Use `mcp__context7__get_library_docs` — library-specific documentation
+- Use `mcp__exa__search_code` to find how the repo implements a feature in real code
+- Use `WebFetch` to read specific files, READMEs, or docs pages directly from the repo
+- Use `mcp__context7__get_library_docs` when the repo ships a documented library
 
 **For code examples and patterns** (show me code that does X):
 - Use `mcp__exa__search_code` — find real code examples across the web
@@ -38,12 +41,9 @@ libraries, and implementation patterns.
 - Use `WebSearch` — broad web search for articles, docs, discussions
 - Use `WebFetch` — fetch and analyze specific URLs
 
-**For library documentation** (API reference, usage guides):
-- Use `mcp__context7__resolve_library_id` then `mcp__context7__get_library_docs`
-
 **Decision flow:**
-1. Is it about a specific GitHub repo? → DeepWiki
-2. Is it about a library's API/docs? → Context7
+1. Is it about a library's API/docs? → Context7
+2. Is it about how a specific GitHub repo implements something? → Exa code search, then WebFetch the relevant files
 3. Is it about code patterns across the web? → Exa
 4. Is it about best practices, blog posts, or general knowledge? → WebSearch
 5. Need to read a specific URL? → WebFetch
@@ -59,7 +59,7 @@ Based on the user's question, identify relevant repos:
 
 ### Step 2: Start with Focused Questions
 
-Use `mcp__deepwiki__ask_question` for specific queries:
+Frame a specific query before reaching for a tool:
 
 **Good questions**:
 
@@ -74,18 +74,18 @@ Use `mcp__deepwiki__ask_question` for specific queries:
 - "How does this work?" (be specific!)
 - "Explain the framework" (too vague)
 
-### Step 3: Get Structure First (for broad topics)
+### Step 3: Get Oriented First (for broad topics)
 
-If exploring a new framework, use `mcp__deepwiki__read_wiki_structure` first:
+If exploring a new framework, start with Context7 to pull its documentation, then
+`mcp__exa__search_code` to see how the feature is used in real code:
 
 ```javascript
-mcp__deepwiki__read_wiki_structure({
-  repoName: "vercel/next.js",
-});
-// See available topics, then ask specific questions
+mcp__context7__resolve_library_id({ libraryName: "next.js" });
+// Then fetch docs for the resolved id, and use Exa code search to find concrete
+// usage examples before drilling into specifics.
 ```
 
-This shows you what's available, then drill down with specific questions.
+This orients you on what's available, then drill down with specific searches.
 
 ### Step 4: Synthesize and Present
 
@@ -109,7 +109,7 @@ Present findings in this format:
 
 ### Code Examples
 
-[Specific examples if provided by DeepWiki]
+[Specific examples found via Exa code search or repo files]
 
 ### Implementation Considerations
 
@@ -123,8 +123,8 @@ Present findings in this format:
 
 ### References
 
-- DeepWiki search: [link provided in response]
-- Explore more: [relevant wiki pages mentioned]
+- [Documentation, repo files, or search results consulted]
+- Explore more: [relevant pages or sources to dive deeper]
 ```
 
 ## Common Research Scenarios
@@ -132,10 +132,10 @@ Present findings in this format:
 ### Scenario 1: "How should I implement X with framework Y?"
 
 ```
-1. Ask DeepWiki: "How does [framework] recommend implementing [feature]?"
-2. Present recommended approach with examples
-3. Note key patterns and best practices
-4. Suggest how to apply to user's use case
+1. Pull framework docs via Context7 for "[feature]"
+2. Use Exa code search for real-world usage of that feature
+3. Present recommended approach with examples
+4. Note key patterns and best practices, suggest how to apply to user's use case
 ```
 
 Example:
@@ -144,8 +144,8 @@ Example:
 User: How should I implement authentication with Passport.js?
 
 You:
-1. Ask: "How does Passport.js recommend implementing authentication strategies?"
-2. Ask: "What's the session management pattern in Passport.js?"
+1. Fetch Passport.js docs via Context7 on authentication strategies
+2. Use Exa code search for the session management pattern in Passport.js
 3. Synthesize findings
 4. Present structured approach
 ```
@@ -166,13 +166,13 @@ Example:
 
 ### Redux Approach
 
-- [What DeepWiki found]
+- [What the research found]
 - Pros: [...]
 - Cons: [...]
 
 ### Zustand Approach
 
-- [What DeepWiki found]
+- [What the research found]
 - Pros: [...]
 - Cons: [...]
 
@@ -200,9 +200,9 @@ Example:
 ### Scenario 5: "Learn about a new framework"
 
 ```
-1. Get structure: mcp__deepwiki__read_wiki_structure
-2. Ask about core concepts: "What are the core architectural patterns?"
-3. Ask about integration: "How does it recommend [specific integration]?"
+1. Pull the framework's docs via Context7 to orient on core concepts
+2. Use Exa code search for "[specific integration]" usage patterns
+3. WebSearch/WebFetch for architectural overviews and guides
 4. Present learning path with key topics
 ```
 
@@ -222,15 +222,15 @@ Example:
 
 ### Synthesize, Don't Just Paste
 
-- Read DeepWiki output
+- Read the docs, code search results, and fetched pages
 - Extract key insights
 - Add your analysis
 - Structure for readability
 
 ### Include Links
 
-- Always include the DeepWiki search link provided
-- Include wiki page references mentioned in response
+- Always include the documentation, repo files, or search results you consulted
+- Cite specific pages or sources so users can verify
 - Users can explore further on their own
 
 ### Stay External
@@ -268,7 +268,7 @@ Example:
 
 ### Code Examples
 
-[If provided by DeepWiki]
+[From Exa code search or fetched repo files]
 
 ### Best Practices
 
@@ -282,8 +282,8 @@ Example:
 
 ### Additional Resources
 
-- DeepWiki search: [link]
-- Related wiki pages: [if mentioned]
+- [Documentation or repo files consulted]
+- [Related sources]
 - Further exploration: [topics to dive deeper]
 ```
 
@@ -348,17 +348,11 @@ Example:
 - Better: "How does Next.js implement server components?"
 - Best: "What's the recommended pattern for data fetching in Next.js server components?"
 
-### Don't Ignore DeepWiki Links
+### Don't Ignore Your Sources
 
-- Always include the search link from responses
+- Always include the docs, repo files, or search results you consulted
 - It allows users to explore further
 - Shows your research source
-
-### Don't Use read_wiki_contents
-
-- It returns 80k+ tokens (too large!)
-- Use `read_wiki_structure` to see topics
-- Use `ask_question` for specific info
 
 ### Don't Research When Local Check is Needed
 
@@ -376,7 +370,7 @@ Example:
 ```
 Research question: "How does Passport.js recommend implementing OAuth strategies?"
 
-[Call DeepWiki]
+[Fetch Passport.js docs via Context7; Exa code search for OAuth strategy usage]
 
 ## Research: OAuth Implementation in Passport.js
 
@@ -399,7 +393,8 @@ For your use case:
 4. Set up callback routes
 
 ### References
-- DeepWiki search: https://deepwiki.com/search/...
+- Passport.js documentation (via Context7)
+- Example strategy implementations (via Exa code search)
 ```
 
 ### Example 2: Framework Comparison
@@ -411,8 +406,8 @@ For your use case:
 ```
 I'll research the architectural patterns of both frameworks.
 
-[Calls DeepWiki for Next.js]
-[Calls DeepWiki for Remix]
+[Fetch Next.js docs via Context7; Exa code search for data fetching]
+[Fetch Remix docs via Context7; Exa code search for loaders/actions]
 
 ## Comparison: Next.js vs Remix
 
@@ -434,8 +429,8 @@ I'll research the architectural patterns of both frameworks.
 Based on your needs: [analysis]
 
 ### References
-- Next.js research: https://deepwiki.com/search/...
-- Remix research: https://deepwiki.com/search/...
+- Next.js documentation (via Context7) and usage examples (via Exa)
+- Remix documentation (via Context7) and usage examples (via Exa)
 ```
 
 ## Remember

--- a/plugins/dev/agents/external-research.md
+++ b/plugins/dev/agents/external-research.md
@@ -30,12 +30,13 @@ libraries, and implementation patterns.
 - Use `mcp__context7__resolve_library_id` then `mcp__context7__get_library_docs`
 
 **For GitHub repository research** (how does X implement Y?):
-- Use `mcp__exa__search_code` to find how the repo implements a feature in real code
-- Use `WebFetch` to read specific files, READMEs, or docs pages directly from the repo
+- Use `WebFetch` to read the repo's files, READMEs, and docs pages directly from GitHub — always available, no extra MCP required
+- Use `WebSearch` to locate the relevant files, issues, or discussions in the repo first
+- Use `mcp__exa__search_code` for deep code search across the repo _if the Exa MCP is configured_
 - Use `mcp__context7__get_library_docs` when the repo ships a documented library
 
 **For code examples and patterns** (show me code that does X):
-- Use `mcp__exa__search_code` — find real code examples across the web
+- Use `mcp__exa__search_code` — find real code examples across the web _if the Exa MCP is configured_; otherwise `WebSearch` + `WebFetch`
 
 **For general web research** (best practices, blog posts, docs):
 - Use `WebSearch` — broad web search for articles, docs, discussions
@@ -43,8 +44,8 @@ libraries, and implementation patterns.
 
 **Decision flow:**
 1. Is it about a library's API/docs? → Context7
-2. Is it about how a specific GitHub repo implements something? → Exa code search, then WebFetch the relevant files
-3. Is it about code patterns across the web? → Exa
+2. Is it about how a specific GitHub repo implements something? → WebFetch the repo's files (+ WebSearch); Exa code search if configured
+3. Is it about code patterns across the web? → Exa if configured, else WebSearch
 4. Is it about best practices, blog posts, or general knowledge? → WebSearch
 5. Need to read a specific URL? → WebFetch
 

--- a/plugins/dev/scripts/orch-monitor/public/mockups/agent-graph.html
+++ b/plugins/dev/scripts/orch-monitor/public/mockups/agent-graph.html
@@ -674,7 +674,7 @@
           },
         },
         {
-          id: "sub-142-deepwiki",
+          id: "sub-142-external",
           type: "subagent",
           position: { x: 0, y: 0 },
           data: {
@@ -730,7 +730,7 @@
         { id: "e-140-explore", source: "worker-ctl-140", target: "sub-140-explore" },
         { id: "e-140-reviewer", source: "worker-ctl-140", target: "sub-140-code-reviewer" },
         { id: "e-142-general", source: "worker-ctl-142", target: "sub-142-general" },
-        { id: "e-142-deepwiki", source: "sub-142-general", target: "sub-142-deepwiki" },
+        { id: "e-142-external", source: "sub-142-general", target: "sub-142-external" },
         { id: "e-147-pr-test", source: "worker-ctl-147", target: "sub-147-pr-test" },
         { id: "e-140-todos", source: "worker-ctl-140", target: "todo-140" },
         { id: "e-147-todos", source: "worker-ctl-147", target: "todo-147" },

--- a/plugins/dev/skills/create-plan/SKILL.md
+++ b/plugins/dev/skills/create-plan/SKILL.md
@@ -6,9 +6,7 @@ description:
   wants a structured TDD implementation plan before writing code. Works best after
   /research-codebase."
 disable-model-invocation: false
-allowed-tools:
-  Read, Write, Grep, Glob, Task, TodoWrite, Bash, mcp__deepwiki__ask_question,
-  mcp__deepwiki__read_wiki_structure
+allowed-tools: Read, Write, Grep, Glob, Task, TodoWrite, Bash
 version: 1.0.0
 ---
 
@@ -88,8 +86,8 @@ Auto-discovery has already run in Prerequisites above. Check its output and foll
    using Linearis CLI (run `linearis issues usage` for syntax).
    If Linearis CLI is not available, skip silently and continue planning.
 
-3. **Gather context using research sub-agents** — use the same agent palette and DeepWiki
-   orientation process as `/catalyst-dev:research-codebase` (that skill is the single source of
+3. **Gather context using research sub-agents** — use the same agent palette and orientation
+   process as `/catalyst-dev:research-codebase` (that skill is the single source of
    truth for how codebase research works). For planning, focus agents on the specific ticket/task
    scope rather than broad exploration:
    - **codebase-locator** — find all files related to the ticket/task

--- a/plugins/dev/skills/implement-plan/SKILL.md
+++ b/plugins/dev/skills/implement-plan/SKILL.md
@@ -6,9 +6,7 @@ description:
   previously created implementation plan using TDD (Red-Green-Refactor). Supports team mode for
   parallel implementation."
 disable-model-invocation: false
-allowed-tools:
-  Read, Write, Edit, Grep, Glob, Task, TodoWrite, Bash, mcp__deepwiki__ask_question,
-  mcp__deepwiki__read_wiki_structure
+allowed-tools: Read, Write, Edit, Grep, Glob, Task, TodoWrite, Bash
 version: 1.0.0
 ---
 

--- a/plugins/dev/skills/phase-plan/SKILL.md
+++ b/plugins/dev/skills/phase-plan/SKILL.md
@@ -16,8 +16,6 @@ allowed-tools:
   - Glob
   - Task
   - Bash
-  - mcp__deepwiki__ask_question
-  - mcp__deepwiki__read_wiki_structure
 ---
 
 # phase-plan

--- a/plugins/dev/skills/phase-research/SKILL.md
+++ b/plugins/dev/skills/phase-research/SKILL.md
@@ -16,8 +16,6 @@ allowed-tools:
   - Glob
   - Task
   - Bash
-  - mcp__deepwiki__ask_question
-  - mcp__deepwiki__read_wiki_structure
 ---
 
 # phase-research

--- a/plugins/dev/skills/research-codebase/SKILL.md
+++ b/plugins/dev/skills/research-codebase/SKILL.md
@@ -7,8 +7,7 @@ description:
   thoughts/shared/research/ with file:line references."
 disable-model-invocation: false
 allowed-tools:
-  Read, Write, Grep, Glob, Task, TodoWrite, Bash, mcp__deepwiki__ask_question,
-  mcp__deepwiki__read_wiki_structure
+  Read, Write, Grep, Glob, Task, TodoWrite, Bash
 version: 1.0.0
 ---
 
@@ -71,40 +70,6 @@ on single-host setups and never blocks research if offline:
 ```
 
 ## Steps to Follow After Receiving the Research Query
-
-### Step 0: Orient with DeepWiki (ALWAYS attempt this first)
-
-Before reading files or spawning sub-agents, get a high-level understanding from DeepWiki. This
-provides a compressed overview of the codebase that guides all subsequent research and saves tokens.
-
-**Prerequisite check** — only run this step if both conditions are met:
-1. The `mcp__deepwiki__ask_question` tool is available (DeepWiki MCP is installed)
-2. The repo is indexed by DeepWiki (the call returns a meaningful response, not an error)
-
-If either condition fails, skip to Step 1 — do not retry or warn the user.
-
-**Steps:**
-
-1. **Determine the repo name** from the git remote:
-   ```bash
-   gh repo view --json nameWithOwner -q .nameWithOwner
-   ```
-2. **Ask DeepWiki** about the user's research topic on this repo:
-   ```
-   mcp__deepwiki__ask_question({
-     repoName: "<owner/repo>",
-     question: "<rephrase the user's research query for DeepWiki>"
-   })
-   ```
-3. **Use the response to plan your research**: DeepWiki's answer will identify relevant components,
-   files, and architectural patterns. Use this to make your sub-agent prompts specific and targeted
-   rather than exploratory.
-
-**Guidelines:**
-- Rephrase the user's query to be specific and technical (e.g., "How does the orchestration monitor
-  track worker session state?" not "tell me about the monitor")
-- If the topic is broad, ask 1-2 focused questions rather than one vague one
-- DeepWiki results are a starting point — always verify with live code via sub-agents
 
 ### Step 1: Read any directly mentioned files first
 

--- a/plugins/legacy/skills/oneshot/SKILL.md
+++ b/plugins/legacy/skills/oneshot/SKILL.md
@@ -7,8 +7,7 @@ description:
   current session, using agent teams for parallelism when needed."
 disable-model-invocation: false
 allowed-tools:
-  Read, Write, Bash, Task, Grep, Glob, mcp__deepwiki__ask_question,
-  mcp__deepwiki__read_wiki_structure
+  Read, Write, Bash, Task, Grep, Glob
 version: 3.0.0
 ---
 
@@ -587,7 +586,7 @@ This phase runs in the current session to allow user interaction during research
    using the research summary as description, then register the ticket ID:
    `workflow-context.sh set-ticket "NEW-TICKET-ID"`
 5. **Conduct research** — follow the `/catalyst-dev:research-codebase` process exactly. This is the
-   single source of truth for how codebase research works (including DeepWiki orientation, sub-agent
+   single source of truth for how codebase research works (including sub-agent
    spawning, synthesis, and document creation). The research document MUST be written to
    `thoughts/shared/research/` and tracked in workflow context before proceeding to Phase 2.
 

--- a/plugins/meta/skills/discover-workflows/SKILL.md
+++ b/plugins/meta/skills/discover-workflows/SKILL.md
@@ -2,7 +2,7 @@
 name: discover-workflows
 description: Research and catalog workflows from external Claude Code repositories
 disable-model-invocation: false
-allowed-tools: mcp__deepwiki__ask_question, mcp__deepwiki__read_wiki_structure, Read, Write
+allowed-tools: Read, Write
 version: 1.0.0
 ---
 
@@ -67,7 +67,7 @@ Use TodoWrite to track the 3 parallel research tasks.
 Use external-research agent:
 "Research {repo-name}. What commands and agents are available? List all workflows with brief descriptions of what each does."
 
-Tools: mcp__deepwiki__read_wiki_structure, mcp__deepwiki__ask_question
+Tools: WebFetch, WebSearch, mcp__exa__web_search_exa
 Return: Complete list of all workflows found
 ```
 
@@ -77,7 +77,7 @@ Return: Complete list of all workflows found
 Use external-research agent:
 "Research {repo-name}. What frontmatter format is used for agents and commands? Provide specific examples showing all frontmatter fields used."
 
-Tools: mcp__deepwiki__ask_question
+Tools: WebFetch, mcp__exa__get_code_context_exa
 Return: Frontmatter patterns with concrete examples
 ```
 
@@ -87,7 +87,7 @@ Return: Frontmatter patterns with concrete examples
 Use external-research agent:
 "Research {repo-name}. What are the common implementation patterns, structures, and conventions used across workflows? Include naming conventions, file organization, and any templates."
 
-Tools: mcp__deepwiki__ask_question
+Tools: WebFetch, mcp__exa__get_code_context_exa
 Return: Patterns, templates, conventions observed
 ```
 
@@ -218,7 +218,6 @@ Save research to `thoughts/shared/workflows/{repo-name}/analysis.md`:
 
 ## References
 
-- DeepWiki searches: [links]
 - Repository: {URL}
 - Analyzed on: {date}
 ````

--- a/plugins/meta/skills/discover-workflows/SKILL.md
+++ b/plugins/meta/skills/discover-workflows/SKILL.md
@@ -2,7 +2,7 @@
 name: discover-workflows
 description: Research and catalog workflows from external Claude Code repositories
 disable-model-invocation: false
-allowed-tools: Read, Write
+allowed-tools: Read, Write, Task, TodoWrite, WebSearch, WebFetch
 version: 1.0.0
 ---
 
@@ -67,7 +67,7 @@ Use TodoWrite to track the 3 parallel research tasks.
 Use external-research agent:
 "Research {repo-name}. What commands and agents are available? List all workflows with brief descriptions of what each does."
 
-Tools: WebFetch, WebSearch, mcp__exa__web_search_exa
+Tools: WebFetch, WebSearch
 Return: Complete list of all workflows found
 ```
 
@@ -77,7 +77,7 @@ Return: Complete list of all workflows found
 Use external-research agent:
 "Research {repo-name}. What frontmatter format is used for agents and commands? Provide specific examples showing all frontmatter fields used."
 
-Tools: WebFetch, mcp__exa__get_code_context_exa
+Tools: WebFetch, WebSearch
 Return: Frontmatter patterns with concrete examples
 ```
 
@@ -87,7 +87,7 @@ Return: Frontmatter patterns with concrete examples
 Use external-research agent:
 "Research {repo-name}. What are the common implementation patterns, structures, and conventions used across workflows? Include naming conventions, file organization, and any templates."
 
-Tools: WebFetch, mcp__exa__get_code_context_exa
+Tools: WebFetch, WebSearch
 Return: Patterns, templates, conventions observed
 ```
 

--- a/plugins/meta/skills/import-workflow/SKILL.md
+++ b/plugins/meta/skills/import-workflow/SKILL.md
@@ -2,7 +2,7 @@
 name: import-workflow
 description: Import and adapt a workflow from external repositories
 disable-model-invocation: false
-allowed-tools: Read, Write, Edit
+allowed-tools: Read, Write, Edit, Task, TodoWrite
 version: 1.0.0
 ---
 
@@ -50,7 +50,7 @@ Use TodoWrite to track parallel research.
 Use external-research agent:
 "Research {repo}/{workflow}. Explain what this workflow does, how it works, what tools it uses, and provide the complete implementation including frontmatter."
 
-Tools: mcp__context7__* (library/framework docs), Exa (code/web search), WebSearch, WebFetch (read the repo's files on GitHub)
+Tools: WebFetch / WebSearch (read the repo's files on GitHub — always available), mcp__context7__* (library/framework docs), Exa code search if the Exa MCP is configured
 Return: Full workflow understanding and implementation
 ```
 

--- a/plugins/meta/skills/import-workflow/SKILL.md
+++ b/plugins/meta/skills/import-workflow/SKILL.md
@@ -2,7 +2,7 @@
 name: import-workflow
 description: Import and adapt a workflow from external repositories
 disable-model-invocation: false
-allowed-tools: Read, Write, Edit, mcp__deepwiki__ask_question
+allowed-tools: Read, Write, Edit
 version: 1.0.0
 ---
 
@@ -50,7 +50,7 @@ Use TodoWrite to track parallel research.
 Use external-research agent:
 "Research {repo}/{workflow}. Explain what this workflow does, how it works, what tools it uses, and provide the complete implementation including frontmatter."
 
-Tools: mcp__deepwiki__ask_question
+Tools: mcp__context7__* (library/framework docs), Exa (code/web search), WebSearch, WebFetch (read the repo's files on GitHub)
 Return: Full workflow understanding and implementation
 ```
 

--- a/plugins/meta/skills/validate-frontmatter/SKILL.md
+++ b/plugins/meta/skills/validate-frontmatter/SKILL.md
@@ -425,9 +425,6 @@ Claude Code provides these tools:
 
 - `WebFetch` - Fetch web content
 - `WebSearch` - Search the web
-- `mcp__deepwiki__ask_question` - Query external repos
-- `mcp__deepwiki__read_wiki_structure` - Get repo structure
-- `mcp__deepwiki__read_wiki_contents` - Read repo docs
 
 ### Linear Integration
 


### PR DESCRIPTION
## Why

Cognition (Devin) started billing for the **DeepWiki MCP** (`https://mcp.devin.ai/mcp`), costing **$100+/day** across the fleet (every research/plan phase fired a `DeepWiki Step 0` call). We're cutting it off entirely while a replacement is built.

## What

Removes the DeepWiki integration from all plugin source:

- **`.mcp.json.template`** — drop the `deepwiki` server block
- **17 files** total — strip every `mcp__deepwiki__*` tool reference and all DeepWiki prose from the `dev`, `meta`, and `legacy` plugins
- Agents that used DeepWiki for external repo/framework research now fall back to tooling **already present**: Context7 (library docs), Exa (code/web search), WebSearch/WebFetch, and live code reading via sub-agents
- `research-codebase` loses its DeepWiki "Step 0" orientation step (Steps 1–9 renumber cleanly)
- Docs (`README.md`, `marketplace.json`, `agents/README.md`) drop DeepWiki from MCP/tooling listings

## Out of scope (intentional)

- **`plugins/dev/CHANGELOG.md`** is left untouched — it's a release-please historical record, not a live reference.

## Already done outside this PR

- `deepwiki` MCP **registration removed** from the **laptop** and **mini** (user scope, same `apk_user_…` token). **mini-2** was already clean. This stops all new billing immediately — once merged, fleet agents also stop *referencing* the now-absent tool.
- ⚠️ The Devin/DeepWiki **API key itself is still valid** on Cognition's side — revoke it in their dashboard to be fully certain nothing can bill against it.

## Verification

- `git grep -i deepwiki` (excl. CHANGELOG) → **zero hits**; broader sweep for `devin.ai` / `deekard` / `apk_user_` / `read_wiki*` → zero
- `marketplace.json` + `.mcp.json.template` parse as valid JSON; `agent-graph.html` arrays valid (node + edge removed together, no dangling edges)
- All frontmatter `allowed-tools` lists remain valid (no empty lists / trailing commas)

🤖 Generated with [Claude Code](https://claude.com/claude-code)