### PR TITLE
feat(dev): CTL-1331 Phase A — async board-health delegate queue (inert land)

### DIFF
--- a/.github/workflows/execution-core-tests.yml
+++ b/.github/workflows/execution-core-tests.yml
@@ -134,6 +134,10 @@ jobs:
             comms-drain.test.mjs \
             config-pino-fallback.test.mjs \
             config.test.mjs \
+            delegate-config-event.test.mjs \
+            delegate-queue.test.mjs \
+            delegate-runner.test.mjs \
+            delegate-slot-reservation.test.mjs \
             diagnostician.test.mjs \
             dispatch.test.mjs \
             eligible-set.test.mjs \

--- a/plugins/dev/scripts/execution-core/config.mjs
+++ b/plugins/dev/scripts/execution-core/config.mjs
@@ -8,7 +8,7 @@
 
 import { homedir, hostname } from "node:os";
 import { resolve, join } from "node:path";
-import { readFileSync, existsSync, rmSync, writeFileSync } from "node:fs";
+import { readFileSync, existsSync, rmSync, writeFileSync, readdirSync } from "node:fs";
 
 // CTL-1211: schema-version policy for cluster config. config-schema.mjs is a
 // dep-free sibling leaf, so this import cannot reintroduce the bun-install crash
@@ -1076,6 +1076,84 @@ export function readBoardHealthConfig(env = process.env) {
   return { mode };
 }
 
+// CTL-1331: delegate-runner config reader. Gates the DETACHED process that
+// drains the board-health delegate queue (where the heavy worktree-provision +
+// `claude --bg` spawn moved off the daemon event loop). Mirrors the
+// readBoardHealthConfig style — env override > a default — with the key twist
+// that the runner's default is COUPLED to board-health: it only makes sense to
+// run the drainer when board-health is actually enqueuing intents. So:
+//   mode default = "on"  when board-health resolves to "enforce" (it enqueues)
+//                  "off" otherwise (shadow/off never enqueue → nothing to drain).
+// An explicit CATALYST_DELEGATE_RUNNER ∈ {on,off} overrides the coupling (off =
+// a fully-observable shadow-of-enforce: intents accumulate + emit
+// phase.dispatch.enqueued without any worker launching; on = force-drain). A
+// garbage value falls back to the coupling. Phase A ships with board-health
+// typically shadow, so the default resolves "off" — the runner is INERT and
+// nothing drains until an operator flips board-health to enforce (or sets the
+// runner on explicitly). interval/intentTtl are plain numeric env knobs with
+// the §7 defaults; a non-numeric/empty override falls back to the default.
+export const DELEGATE_RUNNER_MODES = new Set(["on", "off"]);
+
+function readPositiveIntEnv(raw, fallback) {
+  const n = Number(raw);
+  return typeof raw === "string" && raw !== "" && Number.isFinite(n) && n > 0
+    ? n
+    : fallback;
+}
+
+export function readDelegateRunnerConfig(env = process.env) {
+  const v = env.CATALYST_DELEGATE_RUNNER;
+  let mode;
+  if (typeof v === "string" && DELEGATE_RUNNER_MODES.has(v)) {
+    mode = v; // explicit operator override (on|off)
+  } else {
+    // Coupled default: on iff board-health is enforce (the only mode that enqueues).
+    mode = readBoardHealthConfig(env).mode === "enforce" ? "on" : "off";
+  }
+  return {
+    mode,
+    intervalMs: readPositiveIntEnv(env.CATALYST_DELEGATE_RUNNER_INTERVAL_MS, 15000),
+    intentTtlMs: readPositiveIntEnv(env.CATALYST_DELEGATE_INTENT_TTL_MS, 1800000),
+  };
+}
+
+// CTL-1331: read-only delegate-queue depth probe for the governance snapshot.
+// NEVER load-bearing — a pure, best-effort dir scan that counts the reserving
+// intents (`queued|claimed`, the same set countQueuedDelegates folds into the
+// slot reservation; `launched` is excluded because the live `claude --bg`
+// session is already counted by liveBackgroundCount). It reads the on-disk
+// queue artifact directly (no import of delegate-queue.mjs → no coupling to the
+// drainer module's internals and no risk of a missing-module import error while
+// the queue module lands separately in Phase A). Returns 0 when the dir is
+// absent (empty queue / inert Phase A) and 0 on ANY read error — it must never
+// throw into the heartbeat path. The queue lives under the per-host
+// execution-core dir (getExecutionCoreDir() === the daemon's orchDir).
+const DELEGATE_QUEUE_DIRNAME = ".delegate-queue";
+const DELEGATE_RESERVING_STATUSES = new Set(["queued", "claimed"]);
+
+export function readDelegateQueueDepth() {
+  const dir = join(getExecutionCoreDir(), DELEGATE_QUEUE_DIRNAME);
+  let names;
+  try {
+    names = readdirSync(dir);
+  } catch {
+    return 0; // dir absent (empty/inert) or unreadable — report 0, never throw
+  }
+  let depth = 0;
+  for (const name of names) {
+    // Canonical intent files only — skip `<TICKET>.json.claimed-…` sidecars and
+    // `<TICKET>.json.tmp-…` artifacts (mirrors countQueuedDelegates' filter).
+    if (!name.endsWith(".json") || name.includes(".json.")) continue;
+    try {
+      const intent = JSON.parse(readFileSync(join(dir, name), "utf8"));
+      if (DELEGATE_RESERVING_STATUSES.has(intent?.status)) depth += 1;
+    } catch {
+      // a half-written / unparseable intent file — ignore it for the readout
+    }
+  }
+  return depth;
+}
+
 // --- Governance snapshot for operator visibility (CTL-1062/CTL-1084) ---
 // READ-ONLY, NEVER load-bearing. Recomputes each governance value the same way
 // its per-tick gate site does so the heartbeat payload and the
@@ -1126,6 +1204,16 @@ export function readGovernanceConfig(env = process.env) {
     stallJanitor: { mode: readStallJanitorConfig().mode },
     watchdog: { mode: readWatchdogConfig().mode },
     unstuckSweep: { mode: readUnstuckSweepConfig().mode },
+    // CTL-1331: surface the async board-health delegate runner so operators can
+    // see at a glance whether the drainer is on and how deep the intent queue
+    // is. READ-ONLY / NEVER load-bearing (matches every other governance field):
+    // the gate sites keep their own inline reads. `mode` renders in the human
+    // `catalyst-execution-core governance` view (renderGovernance picks .mode);
+    // `queueDepth` is a best-effort dir scan visible in the --json view.
+    delegateRunner: {
+      mode: readDelegateRunnerConfig(env).mode,
+      queueDepth: readDelegateQueueDepth(),
+    },
   };
 }
 

--- a/plugins/dev/scripts/execution-core/daemon.mjs
+++ b/plugins/dev/scripts/execution-core/daemon.mjs
@@ -49,6 +49,7 @@ import {
   CLUSTER_SYNC_INTERVAL_MS, // CTL-1274: cluster-repo auto-pull cadence
   isHostNamePinnedFromConfig, // CTL-1093
   getCatalystRepoDir,       // CTL-1093 sticky dir
+  readDelegateRunnerConfig, // CTL-1331: async board-health delegate runner kill-switch
 } from "./config.mjs";
 import { resolveBootIdentity } from "./host-boot-identity.mjs"; // CTL-1093
 import { readStickyIdentity, writeStickyIdentity } from "./host-sticky.mjs"; // CTL-1093
@@ -83,6 +84,10 @@ import {
   startWorktreeRefreshTimer,
   readWorktreeRefreshConfig,
 } from "./worktree-refresh-timer.mjs";
+// CTL-1331: the async board-health delegate runner timer (kicks the DETACHED
+// drainer that does the heavy worktree-provision + `claude --bg` off the daemon
+// event loop). Gated by readDelegateRunnerConfig; Phase A ships it inert.
+import { startDelegateRunnerTimer } from "./delegate-runner.mjs";
 import {
   startStalePrRescueTimer,
   readStalePrRescueConfig,
@@ -133,6 +138,8 @@ let _reaper = null;
 let _orphanTimer = null;
 // CTL-707: periodic background worktree refresh timer.
 let _refreshTimer = null;
+// CTL-1331: async board-health delegate runner timer (gated CATALYST_DELEGATE_RUNNER).
+let _delegateRunnerTimer = null;
 // CTL-782: periodic stale/conflicting-PR rescue timer.
 let _stalePrRescueTimer = null;
 // CTL-1175: periodic orphan-PR detect+notify sweep timer.
@@ -1058,6 +1065,21 @@ function startReaperAndTimer({
     });
   }
 
+  // CTL-1331: start the async board-health delegate runner timer. Gated by
+  // CATALYST_DELEGATE_RUNNER — readDelegateRunnerConfig().mode resolves "off"
+  // unless board-health is enforce, so Phase A is inert: startDelegateRunnerTimer
+  // returns a no-op { stop } handle and nothing drains. When "on" (Phase B), the
+  // timer kicks a DETACHED child each interval that does the heavy
+  // worktree-provision + `claude --bg` off the daemon event loop. (Phase B also
+  // wires CATALYST_EXECUTION_CORE_DIR onto the child spawn so the entry resolves
+  // orchDir; until then a forced-on child fails safe — "no orchDir" → exit 0.)
+  const delegateRunnerCfg = readDelegateRunnerConfig();
+  _delegateRunnerTimer = startDelegateRunnerTimer({
+    enabled: delegateRunnerCfg.mode === "on",
+    intervalMs: delegateRunnerCfg.intervalMs,
+    orchDir,
+  });
+
   // CTL-782: start the periodic stale/conflicting-PR rescue timer.
   // No orchId / linearWrite threading needed: the timer derives the per-ticket
   // orchestrator id from the phase signal's `.orchestrator` (orchId === ticket
@@ -1242,6 +1264,15 @@ export function stopDaemon() {
       /* timer already stopped */
     }
     _refreshTimer = null;
+  }
+  // CTL-1331: stop the delegate runner timer (no-op handle when gated off).
+  if (_delegateRunnerTimer) {
+    try {
+      _delegateRunnerTimer.stop();
+    } catch {
+      /* timer already stopped */
+    }
+    _delegateRunnerTimer = null;
   }
   if (_stalePrRescueTimer) {
     try {

--- a/plugins/dev/scripts/execution-core/delegate-config-event.test.mjs
+++ b/plugins/dev/scripts/execution-core/delegate-config-event.test.mjs
@@ -1,0 +1,289 @@
+// CTL-1331 — tests for the delegate (async board-health worker) creation-event
+// emitter + the runner config reader. Phase A lands these INERT: the emitter
+// adds one new `phase.dispatch.enqueued.<TICKET>` producer (dispatch slot is an
+// allowed namespace exception) and the config reader gates a runner that does
+// not run on its own yet.
+//
+// Run: cd plugins/dev/scripts/execution-core && bun test delegate-config-event.test.mjs
+//
+// The dispatch-enqueued round-trip redirects the unified event log via
+// CATALYST_DIR (the same seam recovery.test.mjs's CTL-660 dispatch block uses):
+// getEventLogPath() resolves under catalystDir(), so pointing CATALYST_DIR at a
+// temp dir captures the JSONL line for byte-level assertions.
+
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync, readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { appendDispatchEnqueuedEvent } from "./recovery.mjs";
+import {
+  readDelegateRunnerConfig,
+  readDelegateQueueDepth,
+  readGovernanceConfig,
+} from "./config.mjs";
+
+// ---------------------------------------------------------------------------
+// appendDispatchEnqueuedEvent — round-trip (mirrors the CTL-660 dispatch block)
+// ---------------------------------------------------------------------------
+describe("appendDispatchEnqueuedEvent (CTL-1331 creation telemetry)", () => {
+  let envCatalystDir;
+  let prevCatalystDir;
+  beforeEach(() => {
+    prevCatalystDir = process.env.CATALYST_DIR;
+    envCatalystDir = mkdtempSync(join(tmpdir(), "ctl1331-enq-"));
+    process.env.CATALYST_DIR = envCatalystDir;
+    mkdirSync(join(envCatalystDir, "events"), { recursive: true });
+  });
+  afterEach(() => {
+    if (prevCatalystDir === undefined) delete process.env.CATALYST_DIR;
+    else process.env.CATALYST_DIR = prevCatalystDir;
+    rmSync(envCatalystDir, { recursive: true, force: true });
+  });
+
+  // Read back the single envelope written this test (current UTC month log).
+  function readBackEnvelope() {
+    const now = new Date();
+    const ym = `${now.getUTCFullYear()}-${String(now.getUTCMonth() + 1).padStart(2, "0")}`;
+    const lines = readFileSync(join(envCatalystDir, "events", `${ym}.jsonl`), "utf8")
+      .split("\n")
+      .filter(Boolean);
+    return JSON.parse(lines[lines.length - 1]);
+  }
+
+  test("writes a phase.dispatch.enqueued.<TICKET> envelope (INFO, dispatch slot)", () => {
+    const ok = appendDispatchEnqueuedEvent({
+      orchId: "orch-enq",
+      ticket: "CTL-ENQ-1",
+      target_phase: "recovery-pass",
+      kind: "board-health",
+    });
+    expect(ok).toBe(true);
+    const env = readBackEnvelope();
+    // Routes via the dispatch slot (an allowed namespace exception), NOT
+    // phase.recovery-pass.* — and the "enqueued" action does not collide with
+    // PHASE_EVENT_PATTERN's terminal set (complete|failed|turn-cap-exhausted|skipped).
+    expect(env.attributes["event.name"]).toBe("phase.dispatch.enqueued.CTL-ENQ-1");
+    expect(env.attributes["event.action"]).toBe("enqueued");
+    expect(env.resource["service.name"]).toBe("catalyst.execution-core");
+    // body.payload carries the kind + the real phase (target_phase) so operators
+    // can filter the enqueue stream.
+    expect(env.body.payload.status).toBe("enqueued");
+    expect(env.body.payload.target_phase).toBe("recovery-pass");
+    expect(env.body.payload.kind).toBe("board-health");
+    expect(env.attributes["catalyst.orchestration"]).toBe("orch-enq");
+    // CTL-700: healthy lifecycle events emit INFO, not WARN.
+    expect(env.severityText).toBe("INFO");
+    expect(env.severityNumber).toBe(9);
+  });
+
+  test("reason defaults to 'board-health' when omitted", () => {
+    const ok = appendDispatchEnqueuedEvent({
+      orchId: "orch-enq",
+      ticket: "CTL-ENQ-2",
+      target_phase: "recovery-pass",
+      kind: "board-health",
+    });
+    expect(ok).toBe(true);
+    const env = readBackEnvelope();
+    expect(env.body.payload.reason).toBe("board-health");
+  });
+
+  test("an explicit reason rides through to the envelope", () => {
+    const ok = appendDispatchEnqueuedEvent({
+      orchId: "orch-enq",
+      ticket: "CTL-ENQ-3",
+      target_phase: "recovery-pass",
+      kind: "board-health",
+      reason: "board anomaly — holistic delegate",
+    });
+    expect(ok).toBe(true);
+    const env = readBackEnvelope();
+    expect(env.body.payload.reason).toBe("board anomaly — holistic delegate");
+  });
+
+  test("CTL-1023: enqueued carries catalyst.ticket.type from triage.json", () => {
+    const orchDir = mkdtempSync(join(tmpdir(), "ctl1331-enq-tt-"));
+    mkdirSync(join(orchDir, "workers", "CTL-ENQ-TT"), { recursive: true });
+    writeFileSync(
+      join(orchDir, "workers", "CTL-ENQ-TT", "triage.json"),
+      JSON.stringify({ classification: "bug" }),
+    );
+    const ok = appendDispatchEnqueuedEvent({
+      orchId: "orch-enq",
+      orchDir,
+      ticket: "CTL-ENQ-TT",
+      target_phase: "recovery-pass",
+      kind: "board-health",
+    });
+    expect(ok).toBe(true);
+    const env = readBackEnvelope();
+    expect(env.attributes["catalyst.ticket.type"]).toBe("bug");
+    rmSync(orchDir, { recursive: true, force: true });
+  });
+
+  test("catalyst.ticket.type defaults to 'unknown' when no triage.json exists", () => {
+    const ok = appendDispatchEnqueuedEvent({
+      orchId: "orch-enq",
+      orchDir: undefined,
+      ticket: "CTL-ENQ-NT",
+      target_phase: "recovery-pass",
+      kind: "board-health",
+    });
+    expect(ok).toBe(true);
+    const env = readBackEnvelope();
+    expect(env.attributes["catalyst.ticket.type"]).toBe("unknown");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// readDelegateRunnerConfig — defaults, env overrides, board-health coupling
+// ---------------------------------------------------------------------------
+describe("readDelegateRunnerConfig (CTL-1331)", () => {
+  // Pure reader over an injected env object — no global env mutation needed.
+  // The board-health coupling reads CATALYST_BOARD_HEALTH from the SAME injected
+  // env (so it is deterministic without touching Layer-2). We pass a Layer-2
+  // override path that does not exist so readBoardHealthConfig's Layer-2 read
+  // resolves to {} and only the injected env decides the mode.
+  const NO_L2 = { CATALYST_LAYER2_CONFIG_FILE: "/nonexistent/ctl1331/config.json" };
+
+  test("defaults: interval 15000, intentTtl 1800000; mode 'off' when board-health is shadow (default)", () => {
+    const cfg = readDelegateRunnerConfig({ ...NO_L2 });
+    expect(cfg.intervalMs).toBe(15000);
+    expect(cfg.intentTtlMs).toBe(1800000);
+    // board-health defaults to shadow → runner default resolves "off" (inert).
+    expect(cfg.mode).toBe("off");
+  });
+
+  test("default mode resolves 'on' when board-health is enforce", () => {
+    const cfg = readDelegateRunnerConfig({ ...NO_L2, CATALYST_BOARD_HEALTH: "enforce" });
+    expect(cfg.mode).toBe("on");
+  });
+
+  test("default mode resolves 'off' when board-health is explicitly shadow", () => {
+    const cfg = readDelegateRunnerConfig({ ...NO_L2, CATALYST_BOARD_HEALTH: "shadow" });
+    expect(cfg.mode).toBe("off");
+  });
+
+  test("default mode resolves 'off' when board-health is off", () => {
+    const cfg = readDelegateRunnerConfig({ ...NO_L2, CATALYST_BOARD_HEALTH: "off" });
+    expect(cfg.mode).toBe("off");
+  });
+
+  test("CATALYST_DELEGATE_RUNNER=off overrides even when board-health is enforce", () => {
+    const cfg = readDelegateRunnerConfig({
+      ...NO_L2,
+      CATALYST_BOARD_HEALTH: "enforce",
+      CATALYST_DELEGATE_RUNNER: "off",
+    });
+    expect(cfg.mode).toBe("off");
+  });
+
+  test("CATALYST_DELEGATE_RUNNER=on overrides even when board-health is shadow", () => {
+    const cfg = readDelegateRunnerConfig({
+      ...NO_L2,
+      CATALYST_BOARD_HEALTH: "shadow",
+      CATALYST_DELEGATE_RUNNER: "on",
+    });
+    expect(cfg.mode).toBe("on");
+  });
+
+  test("a garbage CATALYST_DELEGATE_RUNNER value falls back to the board-health coupling", () => {
+    const cfg = readDelegateRunnerConfig({
+      ...NO_L2,
+      CATALYST_BOARD_HEALTH: "enforce",
+      CATALYST_DELEGATE_RUNNER: "banana",
+    });
+    expect(cfg.mode).toBe("on");
+  });
+
+  test("CATALYST_DELEGATE_RUNNER_INTERVAL_MS overrides the interval", () => {
+    const cfg = readDelegateRunnerConfig({ ...NO_L2, CATALYST_DELEGATE_RUNNER_INTERVAL_MS: "30000" });
+    expect(cfg.intervalMs).toBe(30000);
+  });
+
+  test("CATALYST_DELEGATE_INTENT_TTL_MS overrides the intent TTL", () => {
+    const cfg = readDelegateRunnerConfig({ ...NO_L2, CATALYST_DELEGATE_INTENT_TTL_MS: "600000" });
+    expect(cfg.intentTtlMs).toBe(600000);
+  });
+
+  test("non-numeric interval / ttl overrides fall back to the defaults", () => {
+    const cfg = readDelegateRunnerConfig({
+      ...NO_L2,
+      CATALYST_DELEGATE_RUNNER_INTERVAL_MS: "not-a-number",
+      CATALYST_DELEGATE_INTENT_TTL_MS: "",
+    });
+    expect(cfg.intervalMs).toBe(15000);
+    expect(cfg.intentTtlMs).toBe(1800000);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Governance surfacing — read-only delegate queue depth + runner mode
+// ---------------------------------------------------------------------------
+describe("delegate governance surfacing (CTL-1331)", () => {
+  let envCatalystDir;
+  let prevCatalystDir;
+  beforeEach(() => {
+    prevCatalystDir = process.env.CATALYST_DIR;
+    envCatalystDir = mkdtempSync(join(tmpdir(), "ctl1331-gov-"));
+    process.env.CATALYST_DIR = envCatalystDir; // getExecutionCoreDir() resolves under this
+  });
+  afterEach(() => {
+    if (prevCatalystDir === undefined) delete process.env.CATALYST_DIR;
+    else process.env.CATALYST_DIR = prevCatalystDir;
+    rmSync(envCatalystDir, { recursive: true, force: true });
+  });
+
+  function writeIntent(ticket, status) {
+    const dir = join(envCatalystDir, "execution-core", ".delegate-queue");
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(join(dir, `${ticket}.json`), JSON.stringify({ status, kind: "board-health" }));
+  }
+
+  test("readDelegateQueueDepth returns 0 when the queue dir is absent (inert Phase A)", () => {
+    expect(readDelegateQueueDepth()).toBe(0);
+  });
+
+  test("counts only queued|claimed intents, never launched/failed/superseded", () => {
+    writeIntent("CTL-Q1", "queued");
+    writeIntent("CTL-Q2", "queued");
+    writeIntent("CTL-C1", "claimed");
+    writeIntent("CTL-L1", "launched");
+    writeIntent("CTL-F1", "failed");
+    writeIntent("CTL-S1", "superseded");
+    expect(readDelegateQueueDepth()).toBe(3);
+  });
+
+  test("ignores claim sidecars / tmp artifacts and unparseable files", () => {
+    const dir = join(envCatalystDir, "execution-core", ".delegate-queue");
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(join(dir, "CTL-Q1.json"), JSON.stringify({ status: "queued" }));
+    writeFileSync(join(dir, "CTL-Q1.json.claimed-123-456"), JSON.stringify({ status: "queued" }));
+    writeFileSync(join(dir, "CTL-Q2.json.tmp-1-2"), JSON.stringify({ status: "queued" }));
+    writeFileSync(join(dir, "CTL-BAD.json"), "{ not valid json");
+    expect(readDelegateQueueDepth()).toBe(1);
+  });
+
+  test("readGovernanceConfig surfaces delegateRunner { mode, queueDepth } (read-only)", () => {
+    writeIntent("CTL-Q1", "queued");
+    const gov = readGovernanceConfig({
+      CATALYST_DIR: envCatalystDir,
+      CATALYST_LAYER2_CONFIG_FILE: "/nonexistent/ctl1331/config.json",
+      CATALYST_BOARD_HEALTH: "enforce",
+    });
+    expect(gov.delegateRunner).toBeDefined();
+    expect(gov.delegateRunner.mode).toBe("on"); // coupled to board-health=enforce
+    expect(gov.delegateRunner.queueDepth).toBe(1);
+  });
+
+  test("governance delegateRunner mode is 'off' when board-health is shadow (default)", () => {
+    const gov = readGovernanceConfig({
+      CATALYST_DIR: envCatalystDir,
+      CATALYST_LAYER2_CONFIG_FILE: "/nonexistent/ctl1331/config.json",
+      CATALYST_BOARD_HEALTH: "shadow",
+    });
+    expect(gov.delegateRunner.mode).toBe("off");
+    expect(gov.delegateRunner.queueDepth).toBe(0);
+  });
+});

--- a/plugins/dev/scripts/execution-core/delegate-queue.mjs
+++ b/plugins/dev/scripts/execution-core/delegate-queue.mjs
@@ -1,0 +1,382 @@
+// delegate-queue.mjs — CTL-1331. The intent queue + slot-reservation ledger for
+// the async board-health delegate (design doc §2c, §3a, §4b-claim, §5-GC).
+//
+// The core scheduler tick is never allowed to spawn a heavy LLM-worker dispatch
+// directly. Its only sanctioned board-health side effect is enqueueDelegateIntent
+// — an atomic tmp+rename write of a `delegate-intent/v1` file at
+//   <orchDir>/.delegate-queue/<TICKET>.json   { status:"queued", kind, phase, … }
+// A detached delegate runner (delegate-runner.mjs / -entry.mjs, separate module)
+// claims and drains these out of process. This module is PURE bookkeeping:
+// atomic file writes (tmp + rename), O_EXCL/rename-based single-flight claims,
+// and a dir-scan GC. Nothing here spawns, fetches, or touches the network — every
+// liveness check (isBgJobAlive) and clock (now) is injected so tests are
+// deterministic with no real claude/git/worktree (mirrors worktree-refresh-timer.mjs).
+//
+// PHASE A — LAND INERT: with an empty queue, countQueuedDelegates and
+// gcDelegateIntents both return 0 → zero behavior change. Nothing here runs on
+// its own; it is invoked only by the (separately-integrated) scheduler/runner.
+//
+// NAMESPACE: this module emits NO events. Event emission (phase.dispatch.*) is
+// the caller's responsibility (the act seam / the runner). It never emits
+// phase.recovery-pass.* — only the worker emits completion.
+
+import {
+  mkdirSync,
+  writeFileSync,
+  readFileSync,
+  readdirSync,
+  renameSync,
+  unlinkSync,
+} from "node:fs";
+import { join } from "node:path";
+import { log } from "./config.mjs";
+
+// The queue dir name, derived from orchDir exactly like recovery-reasoning.mjs
+// derives `.recovery-intents/` (recoveryIntentPath: join(orchDir, ".recovery-intents", …)).
+export const DELEGATE_QUEUE_DIR = ".delegate-queue";
+
+// Hard GC ceiling for a stale intent (design §5.4 / §7 CATALYST_DELEGATE_INTENT_TTL_MS).
+export const DEFAULT_INTENT_TTL_MS = 1_800_000; // 30 min
+
+// Stale-claim reclaim window (design §4 / CATALYST_DISPATCH_TIMEOUT_MS = 15 min).
+// A `claimed-*` sidecar older than one ceiling window is renamed back to queued.
+export const DEFAULT_CLAIM_CEILING_MS = 900_000; // 15 min
+
+export const INTENT_SCHEMA = "delegate-intent/v1";
+
+// Statuses that hold a slot reservation (counted by countQueuedDelegates) and
+// block a re-enqueue (idempotency layer 1). `launched` is non-terminal for
+// re-enqueue blocking but NOT counted as a reservation (its claude --bg session
+// is now visible to liveBackgroundCount — see design §3b "disjoint by status").
+const RESERVING_STATUSES = new Set(["queued", "claimed"]);
+const NON_TERMINAL_STATUSES = new Set(["queued", "claimed", "launched"]);
+
+// ── path helpers ─────────────────────────────────────────────────────────────
+
+export function delegateQueueDir(orchDir) {
+  return join(orchDir, DELEGATE_QUEUE_DIR);
+}
+
+function intentPath(orchDir, ticket) {
+  return join(delegateQueueDir(orchDir), `${ticket}.json`);
+}
+
+// ── atomic write (tmp + rename) ──────────────────────────────────────────────
+
+function atomicWriteIntent(orchDir, ticket, body) {
+  const dir = delegateQueueDir(orchDir);
+  mkdirSync(dir, { recursive: true });
+  const finalPath = intentPath(orchDir, ticket);
+  const tmpPath = `${finalPath}.tmp-${process.pid}-${Date.now()}`;
+  writeFileSync(tmpPath, JSON.stringify(body));
+  renameSync(tmpPath, finalPath);
+}
+
+// readIntentFile — parse one queue file; null on absent/malformed (never throws).
+function readIntentFile(path) {
+  try {
+    return JSON.parse(readFileSync(path, "utf8"));
+  } catch {
+    return null;
+  }
+}
+
+// resolveMaxParallel — maxParallel may be a number or a () => number source.
+function resolveMaxParallel(src) {
+  const v = typeof src === "function" ? src() : src;
+  return Number.isFinite(v) ? v : Infinity;
+}
+
+// ── live-worker idempotency probe (design §2c-3) ─────────────────────────────
+//
+// A live recovery-pass worker for the anchor already exists when
+// workers/<TICKET>/phase-recovery-pass.json is dispatched|running AND its
+// bg_job_id is alive per the injected isBgJobAlive. Reads the signal file
+// directly (the same shape phase-agent-dispatch writes: {status, bg_job_id}).
+function recoveryPassWorkerLive(orchDir, ticket, isBgJobAlive) {
+  const signalPath = join(orchDir, "workers", ticket, "phase-recovery-pass.json");
+  const sig = readIntentFile(signalPath);
+  if (!sig) return false;
+  if (sig.status !== "dispatched" && sig.status !== "running") return false;
+  const bgJobId = sig.bg_job_id ?? null;
+  if (!bgJobId) return false;
+  try {
+    return isBgJobAlive(bgJobId) === true;
+  } catch {
+    return false;
+  }
+}
+
+// ── enqueueDelegateIntent (design §2b/§2c) ───────────────────────────────────
+//
+// Atomic tmp+rename write of a delegate-intent/v1 file with status:"queued".
+// THREE idempotency no-ops checked BEFORE writing (return {enqueued:false, reason}):
+//   1. a non-terminal intent file already exists (queued|claimed|launched) → already-pending
+//   2. a live recovery-pass worker for the anchor already exists           → worker-live
+//   3. hard ceiling: countQueuedDelegates >= maxParallel                   → queue-full
+//
+// deps: { orchDir, isBgJobAlive, now, maxParallel }.
+export function enqueueDelegateIntent(anchor, payload = {}, deps = {}) {
+  const orchDir = deps.orchDir;
+  if (!orchDir) return { enqueued: false, reason: "no-orch-dir" };
+  if (!anchor) return { enqueued: false, reason: "no-anchor" };
+
+  const now = deps.now ?? (() => Date.now());
+  const isBgJobAlive = deps.isBgJobAlive ?? (() => false);
+
+  // (1) queue-file existence — one non-terminal intent per anchor.
+  const existing = readIntentFile(intentPath(orchDir, anchor));
+  if (existing && NON_TERMINAL_STATUSES.has(existing.status)) {
+    return { enqueued: false, reason: "already-pending" };
+  }
+
+  // (2) live recovery-pass worker — never even queue a redundant run.
+  if (recoveryPassWorkerLive(orchDir, anchor, isBgJobAlive)) {
+    return { enqueued: false, reason: "worker-live" };
+  }
+
+  // (3) hard ceiling — reservation can never exceed the whole board.
+  const max = resolveMaxParallel(deps.maxParallel);
+  if (countQueuedDelegates(orchDir) >= max) {
+    return { enqueued: false, reason: "queue-full" };
+  }
+
+  const intent = {
+    schema: INTENT_SCHEMA,
+    ticket: anchor,
+    status: "queued",
+    kind: payload.kind ?? null,
+    phase: payload.phase ?? null,
+    boardContext: payload.boardContext ?? null,
+    reason: payload.reason ?? null,
+    enqueuedAt: now(),
+  };
+
+  try {
+    atomicWriteIntent(orchDir, anchor, intent);
+  } catch (err) {
+    log.warn({ anchor, err: err.message }, "delegate-queue: enqueue write failed");
+    return { enqueued: false, reason: "write-failed" };
+  }
+  return { enqueued: true, reason: "enqueued" };
+}
+
+// ── countQueuedDelegates (design §3a — the slot reservation) ──────────────────
+//
+// The number of .delegate-queue/*.json whose status is queued OR claimed (NOT
+// launched/failed/superseded). Disjoint from liveBackgroundCount by status:
+// once an intent flips to `launched`, its claude --bg session is counted there
+// instead. Missing dir / malformed files → ignored. Never throws.
+export function countQueuedDelegates(orchDir) {
+  if (!orchDir) return 0;
+  let entries;
+  try {
+    entries = readdirSync(delegateQueueDir(orchDir));
+  } catch {
+    return 0; // missing dir
+  }
+  let n = 0;
+  for (const name of entries) {
+    // Canonical intent files only: exactly <TICKET>.json (skip claim sidecars
+    // like <TICKET>.json.claimed-… and tmp-… artifacts).
+    if (!name.endsWith(".json") || name.includes(".json.")) continue;
+    const intent = readIntentFile(join(delegateQueueDir(orchDir), name));
+    if (intent && RESERVING_STATUSES.has(intent.status)) n++;
+  }
+  return n;
+}
+
+// ── gcDelegateIntents (design §5.4 — release stale/terminal reservations) ─────
+//
+// Removes intents whose worker signal reached a terminal phase-recovery-pass.json,
+// OR whose bg_job_id is dead (injected isBgJobAlive), OR older than a TTL
+// (default DEFAULT_INTENT_TTL_MS, injectable via deps.ttlMs). Returns count
+// removed. Pure dir-scan + unlink — no spawn. Leaves live queued/claimed and
+// launched-with-live-bg intents within TTL.
+//
+// deps: { isBgJobAlive, ttlMs }.
+export function gcDelegateIntents(orchDir, now, deps = {}) {
+  if (!orchDir) return 0;
+  const dir = delegateQueueDir(orchDir);
+  let entries;
+  try {
+    entries = readdirSync(dir);
+  } catch {
+    return 0; // missing dir
+  }
+  const ttlMs = Number.isFinite(deps.ttlMs) ? deps.ttlMs : DEFAULT_INTENT_TTL_MS;
+  const isBgJobAlive = deps.isBgJobAlive ?? (() => false);
+  const nowMs = typeof now === "number" ? now : Date.now();
+
+  let removed = 0;
+  for (const name of entries) {
+    if (!name.endsWith(".json") || name.includes(".json.")) continue;
+    const path = join(dir, name);
+    const intent = readIntentFile(path);
+    if (!intent) continue; // leave malformed/foreign files alone
+
+    let drop = false;
+
+    // (a) hard TTL — any intent older than the ceiling, regardless of status.
+    const stamp =
+      typeof intent.launchedAt === "number"
+        ? intent.launchedAt
+        : typeof intent.enqueuedAt === "number"
+          ? intent.enqueuedAt
+          : null;
+    if (stamp !== null && nowMs - stamp >= ttlMs) drop = true;
+
+    // (b) worker reached a terminal recovery-pass signal.
+    if (!drop && workerSignalTerminal(orchDir, intent.ticket)) drop = true;
+
+    // (c) launched intent whose bg job is dead (the live count no longer covers it).
+    if (!drop && intent.status === "launched") {
+      const bgJobId = intent.bg_job_id ?? null;
+      let alive = false;
+      try {
+        alive = bgJobId ? isBgJobAlive(bgJobId) === true : false;
+      } catch {
+        alive = false;
+      }
+      if (!alive) drop = true;
+    }
+
+    if (drop) {
+      try {
+        unlinkSync(path);
+        removed++;
+      } catch {
+        /* already gone / unremovable — best effort */
+      }
+    }
+  }
+  return removed;
+}
+
+// workerSignalTerminal — true when workers/<TICKET>/phase-recovery-pass.json has
+// reached a terminal status (the worker finished). Mirrors the phantom-dir
+// terminal-success set + the failure/abort terminals.
+const TERMINAL_RECOVERY_PASS = new Set([
+  "done",
+  "complete",
+  "skipped",
+  "failed",
+  "aborted",
+  "stalled",
+]);
+function workerSignalTerminal(orchDir, ticket) {
+  if (!ticket) return false;
+  const signalPath = join(orchDir, "workers", ticket, "phase-recovery-pass.json");
+  const sig = readIntentFile(signalPath);
+  if (!sig) return false;
+  return TERMINAL_RECOVERY_PASS.has(sig.status);
+}
+
+// ── claimIntent (design §4b-claim — O_EXCL/rename single-flight) ──────────────
+//
+// Atomically claim a queued intent by renaming
+//   <TICKET>.json  →  <TICKET>.json.claimed-<pid>-<ts>
+// renameSync of a single source inode is atomic: exactly one concurrent racer
+// wins; the loser's source is already gone → rename throws → {claimed:false}.
+// (Mirrors phase-agent-dispatch's CTL-736 single-flight discipline: a rename
+// that one and only one racer can complete.)
+export function claimIntent(orchDir, ticket, pid, ts) {
+  const from = intentPath(orchDir, ticket);
+  const claimPath = `${from}.claimed-${pid}-${ts}`;
+  try {
+    renameSync(from, claimPath);
+  } catch {
+    // source absent (already claimed by a racer, or never existed) → lost.
+    return { claimed: false };
+  }
+  return { claimed: true, claimPath };
+}
+
+// ── transitionIntent (design §4b — persist status changes) ───────────────────
+//
+// Persist a status change for a claimed intent. Reads the `from` sidecar (the
+// claimed-* path), merges the new fields, atomically writes the canonical
+// <TICKET>.json with the new status, and removes the consumed sidecar. Used by
+// the runner to flip claimed → launched (bg_job_id/worktreePath/launchedAt) or
+// claimed → failed (reason). Atomic tmp+rename for the canonical write.
+export function transitionIntent(orchDir, ticket, opts = {}) {
+  const { from, status, ...rest } = opts;
+  if (!status) return { ok: false, reason: "no-status" };
+  let prior = {};
+  if (from) {
+    prior = readIntentFile(from) ?? {};
+  } else {
+    prior = readIntentFile(intentPath(orchDir, ticket)) ?? {};
+  }
+  const next = {
+    schema: prior.schema ?? INTENT_SCHEMA,
+    ticket: prior.ticket ?? ticket,
+    ...prior,
+    ...rest,
+    status,
+  };
+  try {
+    atomicWriteIntent(orchDir, ticket, next);
+  } catch (err) {
+    log.warn({ ticket, err: err.message }, "delegate-queue: transition write failed");
+    return { ok: false, reason: "write-failed" };
+  }
+  // Remove the consumed claim sidecar (best-effort; never block on it).
+  if (from && from !== intentPath(orchDir, ticket)) {
+    try {
+      unlinkSync(from);
+    } catch {
+      /* already gone */
+    }
+  }
+  return { ok: true };
+}
+
+// ── reclaimStaleClaims (design §4b crash-safety) ─────────────────────────────
+//
+// A `claimed-<pid>-<ts>` sidecar left by a crashed runner older than one ceiling
+// window (default DEFAULT_CLAIM_CEILING_MS, injectable) is renamed back to the
+// canonical <TICKET>.json with status:"queued" so the next cycle re-claims it.
+// The claim timestamp is parsed from the sidecar filename suffix. Returns count
+// reclaimed. Pure rename — no spawn. Never throws.
+export function reclaimStaleClaims(orchDir, now, ceilingMs = DEFAULT_CLAIM_CEILING_MS) {
+  if (!orchDir) return 0;
+  const dir = delegateQueueDir(orchDir);
+  let entries;
+  try {
+    entries = readdirSync(dir);
+  } catch {
+    return 0;
+  }
+  const nowMs = typeof now === "number" ? now : Date.now();
+  let reclaimed = 0;
+
+  for (const name of entries) {
+    // <TICKET>.json.claimed-<pid>-<ts>
+    const m = name.match(/^(.+)\.json\.claimed-\d+-(\d+)$/);
+    if (!m) continue;
+    const ticket = m[1];
+    const ts = Number(m[2]);
+    if (!Number.isFinite(ts)) continue;
+    if (nowMs - ts < ceilingMs) continue; // still within the window — leave it
+
+    const claimPath = join(dir, name);
+    const finalPath = intentPath(orchDir, ticket);
+    const sidecar = readIntentFile(claimPath) ?? {};
+    const requeued = {
+      schema: sidecar.schema ?? INTENT_SCHEMA,
+      ticket: sidecar.ticket ?? ticket,
+      ...sidecar,
+      status: "queued",
+    };
+    try {
+      // Atomic-ish: write the canonical queued file, then drop the stale sidecar.
+      atomicWriteIntent(orchDir, ticket, requeued);
+      unlinkSync(claimPath);
+      reclaimed++;
+    } catch {
+      /* concurrent reclaim / unremovable — best effort */
+    }
+  }
+  return reclaimed;
+}

--- a/plugins/dev/scripts/execution-core/delegate-queue.test.mjs
+++ b/plugins/dev/scripts/execution-core/delegate-queue.test.mjs
@@ -1,0 +1,506 @@
+// delegate-queue.test.mjs — CTL-1331. The intent queue + slot-reservation ledger
+// for the async board-health delegate. Deterministic: orchDir is a tmpdir, every
+// clock / isBgJobAlive / maxParallel is injected — NO real claude/git/worktree.
+//
+// Mirrors the §10a TDD plan in
+//   thoughts/shared/plans/2026-06-24-ctl-1331-async-worker-design.md
+//   - atomic write + correct fields
+//   - idempotent second enqueue (no overwrite)
+//   - worker-live no-op (fake phase-recovery-pass.json running + injected isBgJobAlive→true)
+//   - queue-full ceiling
+//   - countQueuedDelegates counts only queued|claimed
+//   - gcDelegateIntents removal/retention + returns count
+//   - claim single-flight (second concurrent claim loses)
+//   - stale-claim reclaim
+//
+// Run: cd plugins/dev/scripts/execution-core && bun test delegate-queue.test.mjs
+
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import {
+  mkdtempSync,
+  mkdirSync,
+  writeFileSync,
+  readFileSync,
+  readdirSync,
+  existsSync,
+  rmSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  enqueueDelegateIntent,
+  countQueuedDelegates,
+  gcDelegateIntents,
+  claimIntent,
+  transitionIntent,
+  reclaimStaleClaims,
+  DELEGATE_QUEUE_DIR,
+  delegateQueueDir,
+} from "./delegate-queue.mjs";
+
+let orchDir;
+const FIXED_NOW = 1_700_000_000_000;
+
+beforeEach(() => {
+  orchDir = mkdtempSync(join(tmpdir(), "ctl1331-queue-"));
+  mkdirSync(join(orchDir, "workers"), { recursive: true });
+});
+
+afterEach(() => {
+  rmSync(orchDir, { recursive: true, force: true });
+});
+
+// ─── helpers ────────────────────────────────────────────────────────────────
+
+function queueDir() {
+  return join(orchDir, DELEGATE_QUEUE_DIR);
+}
+
+function intentPath(ticket) {
+  return join(queueDir(), `${ticket}.json`);
+}
+
+function readIntent(ticket) {
+  return JSON.parse(readFileSync(intentPath(ticket), "utf8"));
+}
+
+function listQueueFiles() {
+  try {
+    return readdirSync(queueDir());
+  } catch {
+    return [];
+  }
+}
+
+// Seed a worker phase-recovery-pass.json signal (the live-worker idempotency input).
+function seedRecoveryPassSignal(ticket, status, bgJobId = "bg-live-1") {
+  const dir = join(orchDir, "workers", ticket);
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(
+    join(dir, "phase-recovery-pass.json"),
+    JSON.stringify({ ticket, phase: "recovery-pass", status, bg_job_id: bgJobId })
+  );
+}
+
+// Default deps: nothing alive, generous ceiling, fixed clock.
+function deps(over = {}) {
+  return {
+    orchDir,
+    isBgJobAlive: () => false,
+    now: () => FIXED_NOW,
+    maxParallel: 8,
+    ...over,
+  };
+}
+
+const INTENT = {
+  kind: "board-health",
+  phase: "recovery-pass",
+  boardContext: { anomaly: "wip-spike", anchors: ["CTL-1"] },
+  reason: "board-health: wip spike — holistic delegate",
+};
+
+// ─── dir derivation parity with .recovery-intents/ ───────────────────────────
+
+describe("delegateQueueDir (matches the .recovery-intents/ derivation convention)", () => {
+  test("derives <orchDir>/.delegate-queue", () => {
+    expect(delegateQueueDir(orchDir)).toBe(join(orchDir, ".delegate-queue"));
+    expect(DELEGATE_QUEUE_DIR).toBe(".delegate-queue");
+  });
+});
+
+// ─── enqueue: atomic write + correct fields ──────────────────────────────────
+
+describe("enqueueDelegateIntent — atomic write + fields", () => {
+  test("writes a delegate-intent/v1 file with status:queued and all carried fields", () => {
+    const r = enqueueDelegateIntent("CTL-1", INTENT, deps());
+    expect(r.enqueued).toBe(true);
+
+    const intent = readIntent("CTL-1");
+    expect(intent.schema).toBe("delegate-intent/v1");
+    expect(intent.ticket).toBe("CTL-1");
+    expect(intent.status).toBe("queued");
+    expect(intent.kind).toBe("board-health");
+    expect(intent.phase).toBe("recovery-pass");
+    expect(intent.boardContext).toEqual(INTENT.boardContext);
+    expect(intent.reason).toBe(INTENT.reason);
+    expect(intent.enqueuedAt).toBe(FIXED_NOW);
+  });
+
+  test("no tmp file is left behind after the rename", () => {
+    enqueueDelegateIntent("CTL-1", INTENT, deps());
+    const files = listQueueFiles();
+    expect(files).toContain("CTL-1.json");
+    expect(files.some((f) => f.includes(".tmp"))).toBe(false);
+  });
+});
+
+// ─── enqueue idempotency layer 1: existing non-terminal intent ───────────────
+
+describe("enqueueDelegateIntent — idempotent (queue-file existence)", () => {
+  test("second enqueue while queued no-ops with already-pending and does NOT overwrite", () => {
+    expect(enqueueDelegateIntent("CTL-1", INTENT, deps()).enqueued).toBe(true);
+    const firstBody = readFileSync(intentPath("CTL-1"), "utf8");
+
+    const r2 = enqueueDelegateIntent(
+      "CTL-1",
+      { ...INTENT, reason: "DIFFERENT reason should not overwrite" },
+      deps()
+    );
+    expect(r2.enqueued).toBe(false);
+    expect(r2.reason).toBe("already-pending");
+    // byte-for-byte unchanged
+    expect(readFileSync(intentPath("CTL-1"), "utf8")).toBe(firstBody);
+  });
+
+  test("claimed and launched intents also block a re-enqueue (non-terminal states)", () => {
+    for (const status of ["claimed", "launched"]) {
+      const t = `CTL-${status}`;
+      mkdirSync(queueDir(), { recursive: true });
+      writeFileSync(
+        intentPath(t),
+        JSON.stringify({ schema: "delegate-intent/v1", ticket: t, status })
+      );
+      const r = enqueueDelegateIntent(t, INTENT, deps());
+      expect(r.enqueued).toBe(false);
+      expect(r.reason).toBe("already-pending");
+    }
+  });
+
+  test("a terminal intent (failed/superseded) does NOT block — re-enqueue overwrites", () => {
+    for (const status of ["failed", "superseded"]) {
+      const t = `CTL-${status}`;
+      mkdirSync(queueDir(), { recursive: true });
+      writeFileSync(
+        intentPath(t),
+        JSON.stringify({ schema: "delegate-intent/v1", ticket: t, status })
+      );
+      const r = enqueueDelegateIntent(t, INTENT, deps());
+      expect(r.enqueued).toBe(true);
+      expect(readIntent(t).status).toBe("queued");
+    }
+  });
+});
+
+// ─── enqueue idempotency layer 2: live recovery-pass worker ──────────────────
+
+describe("enqueueDelegateIntent — live-worker idempotency", () => {
+  test("a running recovery-pass worker with a live bg job no-ops with worker-live", () => {
+    seedRecoveryPassSignal("CTL-1", "running", "bg-live-1");
+    const r = enqueueDelegateIntent(
+      "CTL-1",
+      INTENT,
+      deps({ isBgJobAlive: (id) => id === "bg-live-1" })
+    );
+    expect(r.enqueued).toBe(false);
+    expect(r.reason).toBe("worker-live");
+    expect(existsSync(intentPath("CTL-1"))).toBe(false); // never queued
+  });
+
+  test("a dispatched recovery-pass worker with a live bg job also no-ops", () => {
+    seedRecoveryPassSignal("CTL-1", "dispatched", "bg-live-1");
+    const r = enqueueDelegateIntent(
+      "CTL-1",
+      INTENT,
+      deps({ isBgJobAlive: () => true })
+    );
+    expect(r.enqueued).toBe(false);
+    expect(r.reason).toBe("worker-live");
+  });
+
+  test("a running worker whose bg job is DEAD does not block enqueue", () => {
+    seedRecoveryPassSignal("CTL-1", "running", "bg-dead-1");
+    const r = enqueueDelegateIntent(
+      "CTL-1",
+      INTENT,
+      deps({ isBgJobAlive: () => false })
+    );
+    expect(r.enqueued).toBe(true);
+  });
+
+  test("a terminal recovery-pass worker (done) does not block enqueue", () => {
+    seedRecoveryPassSignal("CTL-1", "done", "bg-live-1");
+    const r = enqueueDelegateIntent(
+      "CTL-1",
+      INTENT,
+      deps({ isBgJobAlive: () => true })
+    );
+    expect(r.enqueued).toBe(true);
+  });
+});
+
+// ─── enqueue idempotency layer 3: hard ceiling ───────────────────────────────
+
+describe("enqueueDelegateIntent — queue-full ceiling", () => {
+  test("refuses to enqueue once countQueuedDelegates >= maxParallel", () => {
+    const max = 3;
+    mkdirSync(queueDir(), { recursive: true });
+    for (let i = 0; i < max; i++) {
+      writeFileSync(
+        intentPath(`CTL-q${i}`),
+        JSON.stringify({ schema: "delegate-intent/v1", ticket: `CTL-q${i}`, status: "queued" })
+      );
+    }
+    const r = enqueueDelegateIntent("CTL-new", INTENT, deps({ maxParallel: max }));
+    expect(r.enqueued).toBe(false);
+    expect(r.reason).toBe("queue-full");
+    expect(existsSync(intentPath("CTL-new"))).toBe(false);
+  });
+
+  test("launched/failed intents do NOT count toward the ceiling (only queued|claimed)", () => {
+    const max = 2;
+    mkdirSync(queueDir(), { recursive: true });
+    writeFileSync(
+      intentPath("CTL-launched"),
+      JSON.stringify({ schema: "delegate-intent/v1", ticket: "CTL-launched", status: "launched" })
+    );
+    writeFileSync(
+      intentPath("CTL-failed"),
+      JSON.stringify({ schema: "delegate-intent/v1", ticket: "CTL-failed", status: "failed" })
+    );
+    // 0 queued|claimed → below ceiling → enqueue allowed
+    const r = enqueueDelegateIntent("CTL-new", INTENT, deps({ maxParallel: max }));
+    expect(r.enqueued).toBe(true);
+  });
+
+  test("maxParallel as a function source is honored", () => {
+    mkdirSync(queueDir(), { recursive: true });
+    writeFileSync(
+      intentPath("CTL-q0"),
+      JSON.stringify({ schema: "delegate-intent/v1", ticket: "CTL-q0", status: "queued" })
+    );
+    const r = enqueueDelegateIntent("CTL-new", INTENT, deps({ maxParallel: () => 1 }));
+    expect(r.enqueued).toBe(false);
+    expect(r.reason).toBe("queue-full");
+  });
+});
+
+// ─── countQueuedDelegates ────────────────────────────────────────────────────
+
+describe("countQueuedDelegates — counts only queued|claimed", () => {
+  test("empty / missing queue dir → 0 (zero behavior change baseline)", () => {
+    expect(countQueuedDelegates(orchDir)).toBe(0);
+  });
+
+  test("counts queued and claimed, excludes launched/failed/superseded", () => {
+    mkdirSync(queueDir(), { recursive: true });
+    const seed = (t, status) =>
+      writeFileSync(intentPath(t), JSON.stringify({ schema: "delegate-intent/v1", ticket: t, status }));
+    seed("CTL-a", "queued");
+    seed("CTL-b", "claimed");
+    seed("CTL-c", "launched");
+    seed("CTL-d", "failed");
+    seed("CTL-e", "superseded");
+    seed("CTL-f", "queued");
+    expect(countQueuedDelegates(orchDir)).toBe(3); // a, b, f
+  });
+
+  test("ignores claim sidecar files and malformed json", () => {
+    mkdirSync(queueDir(), { recursive: true });
+    writeFileSync(intentPath("CTL-a"), JSON.stringify({ schema: "delegate-intent/v1", ticket: "CTL-a", status: "queued" }));
+    writeFileSync(join(queueDir(), "CTL-b.json.claimed-123-456"), "{}");
+    writeFileSync(join(queueDir(), "CTL-c.json"), "not json {");
+    expect(countQueuedDelegates(orchDir)).toBe(1);
+  });
+});
+
+// ─── gcDelegateIntents ───────────────────────────────────────────────────────
+
+describe("gcDelegateIntents — removal & retention", () => {
+  function seedIntent(t, fields) {
+    mkdirSync(queueDir(), { recursive: true });
+    writeFileSync(
+      intentPath(t),
+      JSON.stringify({ schema: "delegate-intent/v1", ticket: t, enqueuedAt: FIXED_NOW, ...fields })
+    );
+  }
+
+  test("removes an intent whose worker reached a terminal phase-recovery-pass.json", () => {
+    seedIntent("CTL-done", { status: "launched", bg_job_id: "bg-x", launchedAt: FIXED_NOW });
+    seedRecoveryPassSignal("CTL-done", "done", "bg-x");
+    const removed = gcDelegateIntents(orchDir, FIXED_NOW, deps({ isBgJobAlive: () => true }));
+    expect(removed).toBe(1);
+    expect(existsSync(intentPath("CTL-done"))).toBe(false);
+  });
+
+  test("removes a launched intent whose bg_job_id is dead", () => {
+    seedIntent("CTL-dead", { status: "launched", bg_job_id: "bg-dead", launchedAt: FIXED_NOW });
+    const removed = gcDelegateIntents(orchDir, FIXED_NOW, deps({ isBgJobAlive: () => false }));
+    expect(removed).toBe(1);
+    expect(existsSync(intentPath("CTL-dead"))).toBe(false);
+  });
+
+  test("removes any intent older than the TTL regardless of status", () => {
+    seedIntent("CTL-old", { status: "queued", enqueuedAt: FIXED_NOW - 2_000_000 });
+    const removed = gcDelegateIntents(
+      orchDir,
+      FIXED_NOW,
+      deps({ ttlMs: 1_800_000 })
+    );
+    expect(removed).toBe(1);
+    expect(existsSync(intentPath("CTL-old"))).toBe(false);
+  });
+
+  test("RETAINS a live queued intent (within TTL, no worker yet)", () => {
+    seedIntent("CTL-live", { status: "queued", enqueuedAt: FIXED_NOW });
+    const removed = gcDelegateIntents(orchDir, FIXED_NOW, deps());
+    expect(removed).toBe(0);
+    expect(existsSync(intentPath("CTL-live"))).toBe(true);
+  });
+
+  test("RETAINS a launched intent whose bg job is still alive and within TTL", () => {
+    seedIntent("CTL-running", { status: "launched", bg_job_id: "bg-live", launchedAt: FIXED_NOW });
+    const removed = gcDelegateIntents(
+      orchDir,
+      FIXED_NOW,
+      deps({ isBgJobAlive: (id) => id === "bg-live" })
+    );
+    expect(removed).toBe(0);
+    expect(existsSync(intentPath("CTL-running"))).toBe(true);
+  });
+
+  test("RETAINS a claimed intent (mid-flight, no bg job yet, within TTL)", () => {
+    seedIntent("CTL-claimed", { status: "claimed", enqueuedAt: FIXED_NOW });
+    const removed = gcDelegateIntents(orchDir, FIXED_NOW, deps());
+    expect(removed).toBe(0);
+    expect(existsSync(intentPath("CTL-claimed"))).toBe(true);
+  });
+
+  test("default TTL is 1_800_000ms when none injected", () => {
+    seedIntent("CTL-justover", { status: "queued", enqueuedAt: FIXED_NOW - 1_800_001 });
+    seedIntent("CTL-justunder", { status: "queued", enqueuedAt: FIXED_NOW - 1_799_999 });
+    const removed = gcDelegateIntents(orchDir, FIXED_NOW, deps());
+    expect(removed).toBe(1);
+    expect(existsSync(intentPath("CTL-justover"))).toBe(false);
+    expect(existsSync(intentPath("CTL-justunder"))).toBe(true);
+  });
+
+  test("empty / missing queue dir → 0 removed, no throw", () => {
+    expect(gcDelegateIntents(orchDir, FIXED_NOW, deps())).toBe(0);
+  });
+});
+
+// ─── claim single-flight ─────────────────────────────────────────────────────
+
+describe("claimIntent — O_EXCL single-flight", () => {
+  function seedQueued(t) {
+    mkdirSync(queueDir(), { recursive: true });
+    writeFileSync(
+      intentPath(t),
+      JSON.stringify({ schema: "delegate-intent/v1", ticket: t, status: "queued", enqueuedAt: FIXED_NOW })
+    );
+  }
+
+  test("a single claim succeeds and renames the intent file away", () => {
+    seedQueued("CTL-1");
+    const r = claimIntent(orchDir, "CTL-1", 111, FIXED_NOW);
+    expect(r.claimed).toBe(true);
+    expect(existsSync(intentPath("CTL-1"))).toBe(false); // original gone (renamed)
+    expect(r.claimPath).toContain("CTL-1.json.claimed-111-");
+    expect(existsSync(r.claimPath)).toBe(true);
+  });
+
+  test("a second concurrent claim of the same intent LOSES (rename source gone)", () => {
+    seedQueued("CTL-1");
+    const first = claimIntent(orchDir, "CTL-1", 111, FIXED_NOW);
+    const second = claimIntent(orchDir, "CTL-1", 222, FIXED_NOW);
+    expect(first.claimed).toBe(true);
+    expect(second.claimed).toBe(false);
+  });
+
+  test("claiming a non-existent intent loses cleanly", () => {
+    const r = claimIntent(orchDir, "CTL-nope", 111, FIXED_NOW);
+    expect(r.claimed).toBe(false);
+  });
+});
+
+// ─── transitionIntent ────────────────────────────────────────────────────────
+
+describe("transitionIntent — persist status changes", () => {
+  test("flips a claimed sidecar to launched + records bg_job_id/worktreePath/launchedAt", () => {
+    mkdirSync(queueDir(), { recursive: true });
+    const claimPath = join(queueDir(), "CTL-1.json.claimed-111-222");
+    writeFileSync(
+      claimPath,
+      JSON.stringify({ schema: "delegate-intent/v1", ticket: "CTL-1", status: "claimed", enqueuedAt: FIXED_NOW })
+    );
+    const r = transitionIntent(orchDir, "CTL-1", {
+      from: claimPath,
+      status: "launched",
+      bg_job_id: "bg-9",
+      worktreePath: "/wt/CTL-1",
+      launchedAt: FIXED_NOW,
+    });
+    expect(r.ok).toBe(true);
+    const intent = readIntent("CTL-1"); // back to canonical <TICKET>.json
+    expect(intent.status).toBe("launched");
+    expect(intent.bg_job_id).toBe("bg-9");
+    expect(intent.worktreePath).toBe("/wt/CTL-1");
+    expect(intent.launchedAt).toBe(FIXED_NOW);
+    expect(existsSync(claimPath)).toBe(false); // sidecar consumed
+  });
+
+  test("marks a failed transition with a reason", () => {
+    mkdirSync(queueDir(), { recursive: true });
+    const claimPath = join(queueDir(), "CTL-2.json.claimed-1-2");
+    writeFileSync(
+      claimPath,
+      JSON.stringify({ schema: "delegate-intent/v1", ticket: "CTL-2", status: "claimed" })
+    );
+    const r = transitionIntent(orchDir, "CTL-2", {
+      from: claimPath,
+      status: "failed",
+      reason: "dispatch-error",
+    });
+    expect(r.ok).toBe(true);
+    const intent = readIntent("CTL-2");
+    expect(intent.status).toBe("failed");
+    expect(intent.reason).toBe("dispatch-error");
+  });
+});
+
+// ─── reclaimStaleClaims ──────────────────────────────────────────────────────
+
+describe("reclaimStaleClaims — renames a stale claimed-* back to queued", () => {
+  test("a claimed-* older than the ceiling window is reclaimed to <TICKET>.json queued", () => {
+    mkdirSync(queueDir(), { recursive: true });
+    const staleTs = FIXED_NOW - 1_000_000; // > 900_000 default
+    const claimPath = join(queueDir(), `CTL-1.json.claimed-999-${staleTs}`);
+    writeFileSync(
+      claimPath,
+      JSON.stringify({ schema: "delegate-intent/v1", ticket: "CTL-1", status: "claimed", enqueuedAt: staleTs })
+    );
+    const reclaimed = reclaimStaleClaims(orchDir, FIXED_NOW);
+    expect(reclaimed).toBe(1);
+    expect(existsSync(claimPath)).toBe(false);
+    expect(existsSync(intentPath("CTL-1"))).toBe(true);
+    expect(readIntent("CTL-1").status).toBe("queued");
+  });
+
+  test("a fresh claimed-* (within the window) is left alone", () => {
+    mkdirSync(queueDir(), { recursive: true });
+    const freshTs = FIXED_NOW - 1_000; // well within 900_000
+    const claimPath = join(queueDir(), `CTL-1.json.claimed-999-${freshTs}`);
+    writeFileSync(
+      claimPath,
+      JSON.stringify({ schema: "delegate-intent/v1", ticket: "CTL-1", status: "claimed" })
+    );
+    const reclaimed = reclaimStaleClaims(orchDir, FIXED_NOW);
+    expect(reclaimed).toBe(0);
+    expect(existsSync(claimPath)).toBe(true);
+    expect(existsSync(intentPath("CTL-1"))).toBe(false);
+  });
+
+  test("the ceiling window is injectable (ceilingMs)", () => {
+    mkdirSync(queueDir(), { recursive: true });
+    const ts = FIXED_NOW - 5_000;
+    const claimPath = join(queueDir(), `CTL-1.json.claimed-1-${ts}`);
+    writeFileSync(claimPath, JSON.stringify({ ticket: "CTL-1", status: "claimed" }));
+    expect(reclaimStaleClaims(orchDir, FIXED_NOW, 1_000)).toBe(1); // 5s > 1s ceiling
+    expect(readIntent("CTL-1").status).toBe("queued");
+  });
+
+  test("empty / missing queue dir → 0, no throw", () => {
+    expect(reclaimStaleClaims(orchDir, FIXED_NOW)).toBe(0);
+  });
+});

--- a/plugins/dev/scripts/execution-core/delegate-runner-entry.mjs
+++ b/plugins/dev/scripts/execution-core/delegate-runner-entry.mjs
@@ -1,0 +1,436 @@
+// delegate-runner-entry.mjs — CTL-1331. The standalone, DETACHED drainer body.
+//
+// This is the out-of-process worker the in-daemon timer (delegate-runner.mjs)
+// spawns with spawn(process.execPath, [THIS_FILE], { detached:true }).unref().
+// It drains the .delegate-queue once and exits. Everything HEAVY — the
+// worktree provision + spawnSync(phase-agent-dispatch) + `claude --bg` (15-min
+// SIGKILL ceiling, dispatch.mjs:59) — runs inside defaultInvokeRecoveryPass HERE,
+// in this disposable child, so it NEVER blocks the daemon event loop or the
+// scheduler tick (design §4).
+//
+// PHASE A — LAND INERT: with an empty queue, drainOnce does zero work and emits
+// nothing. The detached child is only ever spawned by the timer, which the
+// daemon starts gated CATALYST_DELEGATE_RUNNER=off by default → nothing drains.
+//
+// NAMESPACE: this module emits ONLY phase.dispatch.{requested,launched,failed}
+// .<TICKET> (the `dispatch` slot is an allowed namespace exception) via the
+// recovery.mjs appenders. It NEVER emits phase.recovery-pass.* — the recovery
+// pass completion is emitted by the launched `claude --bg` worker itself, not
+// here. `target_phase: "recovery-pass"` rides in the event PAYLOAD, not the slot.
+//
+// PURE/INJECTABLE: drainOnce(deps) takes every side-effecting seam as an
+// injected dep (claimFn / invokeFn / countBackgroundAgents / isBgJobAlive /
+// emit* / clock / fs) so tests drive it with NO real claude/git/worktree
+// (mirrors worktree-refresh-timer.mjs + delegate-queue.test.mjs).
+
+import {
+  openSync,
+  writeSync,
+  closeSync,
+  readFileSync,
+  unlinkSync,
+  readdirSync,
+} from "node:fs";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { log } from "./config.mjs";
+import {
+  delegateQueueDir,
+  claimIntent as defaultClaimIntent,
+  transitionIntent as defaultTransitionIntent,
+  reclaimStaleClaims as defaultReclaimStaleClaims,
+  DEFAULT_CLAIM_CEILING_MS,
+} from "./delegate-queue.mjs";
+import {
+  defaultAppendDispatchRequestedEvent,
+  defaultAppendDispatchLaunchedEvent,
+  defaultAppendDispatchFailedEvent,
+} from "./recovery.mjs";
+import { defaultInvokeRecoveryPass } from "./recovery-reasoning.mjs";
+import { countBackgroundAgents as defaultCountBackgroundAgents } from "./claude-agents.mjs";
+import { isBgJobAlive as defaultIsBgJobAlive } from "./claude-agents.mjs";
+import { computeFreeSlots } from "./scheduler.mjs";
+
+const RECOVERY_PASS_PHASE = "recovery-pass";
+
+// resolveMaxParallel — maxParallel may be a number or a () => number source.
+function resolveMaxParallel(src) {
+  const v = typeof src === "function" ? src() : src;
+  return Number.isFinite(v) ? v : Infinity;
+}
+
+// intentPath — the canonical <orchDir>/.delegate-queue/<TICKET>.json path.
+function intentPath(orchDir, ticket) {
+  return join(delegateQueueDir(orchDir), `${ticket}.json`);
+}
+
+// readJsonFile — parse one file; null on absent/malformed (never throws).
+function readJsonFile(path) {
+  try {
+    return JSON.parse(readFileSync(path, "utf8"));
+  } catch {
+    return null;
+  }
+}
+
+// recoveryPassWorkerLive — the supersede idempotency probe (design §4b-step2).
+// A live recovery-pass worker for the anchor already exists when
+// workers/<TICKET>/phase-recovery-pass.json is dispatched|running AND its
+// bg_job_id is alive. Mirrors delegate-queue's enqueue-time live-worker check so
+// the runner re-checks the same condition at DRAIN time (the worker may have
+// launched between enqueue and drain).
+function recoveryPassWorkerLive(orchDir, ticket, isBgJobAlive) {
+  const sig = readJsonFile(
+    join(orchDir, "workers", ticket, "phase-recovery-pass.json")
+  );
+  if (!sig) return false;
+  if (sig.status !== "dispatched" && sig.status !== "running") return false;
+  const bgJobId = sig.bg_job_id ?? null;
+  if (!bgJobId) return false;
+  try {
+    return isBgJobAlive(bgJobId) === true;
+  } catch {
+    return false;
+  }
+}
+
+// listQueuedTickets — the <TICKET>.json canonical intent files whose status is
+// "queued" (the only drainable status; claimed/launched/terminal are skipped).
+// Skips claim sidecars (<TICKET>.json.claimed-…) and tmp artifacts. Never throws.
+function listQueuedTickets(orchDir) {
+  const dir = delegateQueueDir(orchDir);
+  let entries;
+  try {
+    entries = readdirSync(dir);
+  } catch {
+    return [];
+  }
+  const out = [];
+  for (const name of entries) {
+    if (!name.endsWith(".json") || name.includes(".json.")) continue;
+    const intent = readJsonFile(join(dir, name));
+    if (intent && intent.status === "queued" && intent.ticket) {
+      out.push(intent.ticket);
+    }
+  }
+  return out;
+}
+
+/**
+ * drainOnce — drain every currently-queued delegate intent once.
+ *
+ * For each queued <TICKET>.json:
+ *   1. CLAIM (O_EXCL/rename single-flight). Lost → skip.
+ *   2. RE-CHECK SUPERSEDE: a live recovery-pass worker now exists → mark the
+ *      intent superseded, GC it, skip (no dispatch).
+ *   3. RE-CHECK FREE SLOTS: computeFreeSlots(maxParallel, live) <= 0 → un-claim
+ *      back to queued (leave for next cycle), skip (no dispatch).
+ *   4. INVOKE the heavy path defaultInvokeRecoveryPass(ticket, {boardContext,
+ *      reason}, {orchDir}) — emits phase.dispatch.requested FIRST.
+ *   5. On {dispatched:true}: flip → launched + bg_job_id + worktreePath +
+ *      launchedAt, emit phase.dispatch.launched. Else: flip → failed + reason,
+ *      emit phase.dispatch.failed.
+ *
+ * Before the loop it reclaims stale claims (crash safety) so a runner that died
+ * mid-flight doesn't permanently strand an intent.
+ *
+ * @param {object} deps  every seam injectable for deterministic tests.
+ * @returns {{drained:number, superseded:number, failed:number, reclaimed:number}}
+ */
+export function drainOnce(deps = {}) {
+  const orchDir = deps.orchDir;
+  const result = { drained: 0, superseded: 0, failed: 0, reclaimed: 0 };
+  if (!orchDir) return result;
+
+  const now = typeof deps.now === "function" ? deps.now : () => Date.now();
+  const pid = deps.pid ?? process.pid;
+  const claimFn = deps.claimFn ?? defaultClaimIntent;
+  const transitionFn = deps.transitionFn ?? defaultTransitionIntent;
+  const reclaimFn = deps.reclaimFn ?? defaultReclaimStaleClaims;
+  const invokeFn = deps.invokeFn ?? defaultInvokeRecoveryPass;
+  const countBg = deps.countBackgroundAgents ?? defaultCountBackgroundAgents;
+  const isBgJobAlive = deps.isBgJobAlive ?? defaultIsBgJobAlive;
+  const appendRequested =
+    deps.appendRequested ?? defaultAppendDispatchRequestedEvent;
+  const appendLaunched =
+    deps.appendLaunched ?? defaultAppendDispatchLaunchedEvent;
+  const appendFailed = deps.appendFailed ?? defaultAppendDispatchFailedEvent;
+  const orchId = deps.orchId ?? null;
+  const ceilingMs = Number.isFinite(deps.claimCeilingMs)
+    ? deps.claimCeilingMs
+    : DEFAULT_CLAIM_CEILING_MS;
+  const max = resolveMaxParallel(deps.maxParallel);
+
+  // (0) Crash safety: reclaim claimed-* sidecars older than one ceiling window
+  //     back to queued so a dead runner doesn't strand an intent forever.
+  try {
+    result.reclaimed = reclaimFn(orchDir, now(), ceilingMs);
+  } catch (err) {
+    log.warn({ err: err?.message }, "delegate-runner: reclaim failed");
+  }
+
+  for (const ticket of listQueuedTickets(orchDir)) {
+    // (1) CLAIM — O_EXCL/rename single-flight. The loser's source is already
+    //     gone (a racer renamed it away) → claimed:false → skip.
+    let claim;
+    try {
+      claim = claimFn(orchDir, ticket, pid, now());
+    } catch (err) {
+      log.warn({ ticket, err: err?.message }, "delegate-runner: claim threw");
+      continue;
+    }
+    if (!claim?.claimed) continue; // lost the race
+    const claimPath = claim.claimPath;
+
+    // (2) RE-CHECK SUPERSEDE — a live recovery-pass worker launched between
+    //     enqueue and now → don't double-launch. The intent has done its job
+    //     (the work it would have started already exists), so it is removed:
+    //     it must NOT keep reserving a slot, and there is nothing to re-drain.
+    //     We unlink the consumed claim sidecar and the canonical intent file.
+    if (recoveryPassWorkerLive(orchDir, ticket, isBgJobAlive)) {
+      for (const p of [claimPath, intentPath(orchDir, ticket)]) {
+        try {
+          unlinkSync(p);
+        } catch {
+          /* already gone — best effort */
+        }
+      }
+      result.superseded++;
+      continue;
+    }
+
+    // (3) RE-CHECK FREE SLOTS — compete fairly for the same slots as real work
+    //     at DRAIN time. No headroom → un-claim back to queued (next cycle).
+    //     The live count is read here; if it CANNOT be read (countBg threw) we
+    //     fail CLOSED — treat it as no headroom and un-claim — rather than
+    //     launching on an unknown live count. This matches the scheduler tick's
+    //     own fail-safe posture (CTL-731: a stale/untrustworthy live count holds
+    //     new-work admission, never over-spawns) and preserves the §3b
+    //     conservative-only invariant: a delegate launches ONLY when there is
+    //     provably free headroom.
+    let live;
+    let countOk = true;
+    try {
+      live = countBg({});
+    } catch (err) {
+      countOk = false;
+      log.warn(
+        { ticket, err: err?.message },
+        "delegate-runner: bg count failed — un-claiming (fail-closed, no launch on unknown count)"
+      );
+    }
+    if (!countOk || computeFreeSlots(max, live) <= 0) {
+      try {
+        transitionFn(orchDir, ticket, { from: claimPath, status: "queued" });
+      } catch (err) {
+        log.warn(
+          { ticket, err: err?.message },
+          "delegate-runner: un-claim failed"
+        );
+      }
+      continue;
+    }
+
+    // (4) INVOKE the heavy path. requested FIRST (it's a dispatch DECISION
+    //     marker, emitted before the spawn — matching dispatch.requested
+    //     semantics), then the worktree provision + claude --bg happens INSIDE
+    //     defaultInvokeRecoveryPass, here in the disposable child.
+    const claimed = readJsonFile(claimPath) ?? {};
+    const boardContext = claimed.boardContext ?? null;
+    const reason = claimed.reason ?? null;
+
+    try {
+      appendRequested({
+        orchId,
+        orchDir,
+        ticket,
+        target_phase: RECOVERY_PASS_PHASE,
+        reason: "board-health",
+      });
+    } catch {
+      /* best-effort telemetry — never block the drain */
+    }
+
+    let r;
+    try {
+      r = invokeFn(
+        ticket,
+        { boardContext, reason, phase: RECOVERY_PASS_PHASE },
+        { orchDir }
+      );
+    } catch (err) {
+      r = { dispatched: false, reason: `invoke threw: ${err?.message}` };
+    }
+
+    // (5) Apply the result.
+    if (r && r.dispatched) {
+      const bgJobId = r.details?.bg_job_id ?? null;
+      const worktreePath = r.details?.worktreePath ?? null;
+      try {
+        transitionFn(orchDir, ticket, {
+          from: claimPath,
+          status: "launched",
+          bg_job_id: bgJobId,
+          worktreePath,
+          launchedAt: now(),
+        });
+      } catch (err) {
+        log.warn(
+          { ticket, err: err?.message },
+          "delegate-runner: launched transition failed"
+        );
+      }
+      try {
+        appendLaunched({
+          orchId,
+          orchDir,
+          ticket,
+          target_phase: RECOVERY_PASS_PHASE,
+          bg_job_id: bgJobId,
+          worktree_path: worktreePath,
+        });
+      } catch {
+        /* best-effort */
+      }
+      result.drained++;
+    } else {
+      const failReason = r?.reason ?? "dispatch-failed";
+      try {
+        transitionFn(orchDir, ticket, {
+          from: claimPath,
+          status: "failed",
+          reason: failReason,
+        });
+      } catch (err) {
+        log.warn(
+          { ticket, err: err?.message },
+          "delegate-runner: failed transition failed"
+        );
+      }
+      try {
+        appendFailed({
+          orchId,
+          ticket,
+          target_phase: RECOVERY_PASS_PHASE,
+          reason: failReason,
+        });
+      } catch {
+        /* best-effort */
+      }
+      result.failed++;
+    }
+  }
+
+  return result;
+}
+
+// ── single-instance top-level lock (design §4a) ──────────────────────────────
+//
+// A top-level O_EXCL lock at <orchDir>/.delegate-runner.lock guards against two
+// detached drainers overlapping. open(O_CREAT|O_EXCL) ("wx") creates-or-fails:
+// the winner writes its pid; a loser that finds the file checks whether the
+// recorded pid is still alive — a STALE lock (dead pid) is reclaimed, a LIVE one
+// makes the loser exit immediately. Mirrors claim.mjs's "wx" discipline.
+
+export function runnerLockPath(orchDir) {
+  return join(orchDir, ".delegate-runner.lock");
+}
+
+// pidAlive — process.kill(pid, 0) probes liveness without signalling. Injectable
+// for tests via deps.pidAlive.
+function defaultPidAlive(pid) {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (e) {
+    // ESRCH = no such process (dead); EPERM = alive but not ours (treat alive).
+    return e.code === "EPERM";
+  }
+}
+
+/**
+ * acquireRunnerLock — take the single-instance lock. Returns
+ * { acquired:true, release } for the winner, { acquired:false } when a LIVE
+ * runner already holds it. A stale lock (dead recorded pid) is reclaimed.
+ *
+ * deps: { pid, pidAlive } injectable for tests.
+ */
+export function acquireRunnerLock(orchDir, deps = {}) {
+  const path = runnerLockPath(orchDir);
+  const pid = deps.pid ?? process.pid;
+  const pidAlive = deps.pidAlive ?? defaultPidAlive;
+
+  const tryCreate = () => {
+    const fd = openSync(path, "wx");
+    try {
+      writeSync(fd, JSON.stringify({ pid, acquiredAt: new Date().toISOString() }));
+    } finally {
+      closeSync(fd);
+    }
+  };
+
+  try {
+    tryCreate();
+  } catch (e) {
+    if (e.code !== "EEXIST") throw e;
+    // A lock exists — is its owner alive?
+    const held = readJsonFile(path);
+    const heldPid = held?.pid ?? null;
+    if (heldPid && pidAlive(heldPid)) {
+      return { acquired: false };
+    }
+    // Stale lock — reclaim it (unlink + recreate). If a racer beats us to the
+    // recreate we lose the EEXIST again and bail conservatively.
+    try {
+      unlinkSync(path);
+      tryCreate();
+    } catch {
+      return { acquired: false };
+    }
+  }
+
+  return {
+    acquired: true,
+    release: () => {
+      try {
+        unlinkSync(path);
+      } catch {
+        /* already gone */
+      }
+    },
+  };
+}
+
+// ── top-level detached-entry body ────────────────────────────────────────────
+//
+// When this file is run directly (the detached child the timer spawns), take the
+// single-instance lock, drain once, release, exit. Guarded so importing the
+// module for tests (drainOnce) does NOT run the drain.
+const isEntrypoint =
+  process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1];
+
+if (isEntrypoint) {
+  const orchDir =
+    process.env.CATALYST_EXECUTION_CORE_DIR ||
+    process.env.CATALYST_ORCH_DIR ||
+    null;
+  if (!orchDir) {
+    log.warn({}, "delegate-runner-entry: no orchDir resolved — nothing to drain");
+    process.exit(0);
+  }
+  const lock = acquireRunnerLock(orchDir);
+  if (!lock.acquired) {
+    // Another runner is live — exit immediately (single-instance).
+    process.exit(0);
+  }
+  try {
+    const r = drainOnce({ orchDir });
+    log.info({ ...r }, "delegate-runner-entry: drain complete");
+  } catch (err) {
+    log.warn({ err: err?.message }, "delegate-runner-entry: drain threw");
+  } finally {
+    lock.release();
+  }
+  process.exit(0);
+}

--- a/plugins/dev/scripts/execution-core/delegate-runner-entry.mjs
+++ b/plugins/dev/scripts/execution-core/delegate-runner-entry.mjs
@@ -50,7 +50,7 @@ import {
 import { defaultInvokeRecoveryPass } from "./recovery-reasoning.mjs";
 import { countBackgroundAgents as defaultCountBackgroundAgents } from "./claude-agents.mjs";
 import { isBgJobAlive as defaultIsBgJobAlive } from "./claude-agents.mjs";
-import { computeFreeSlots } from "./scheduler.mjs";
+import { computeFreeSlots, readMaxParallel } from "./scheduler.mjs";
 
 const RECOVERY_PASS_PHASE = "recovery-pass";
 
@@ -425,7 +425,12 @@ if (isEntrypoint) {
     process.exit(0);
   }
   try {
-    const r = drainOnce({ orchDir });
+    // Resolve a FINITE maxParallel so the drain-time free-slot re-check (drainOnce
+    // step 3) actually competes for headroom. Without it resolveMaxParallel(undefined)
+    // → Infinity, which would let the runner launch a delegate past maxParallel even
+    // when the board is full. readMaxParallel(orchDir, {}) reads the same state.json
+    // ceiling the scheduler tick uses.
+    const r = drainOnce({ orchDir, maxParallel: readMaxParallel(orchDir, {}) });
     log.info({ ...r }, "delegate-runner-entry: drain complete");
   } catch (err) {
     log.warn({ err: err?.message }, "delegate-runner-entry: drain threw");

--- a/plugins/dev/scripts/execution-core/delegate-runner.mjs
+++ b/plugins/dev/scripts/execution-core/delegate-runner.mjs
@@ -1,0 +1,147 @@
+// delegate-runner.mjs — CTL-1331. The in-daemon timer that drives the DETACHED
+// delegate drainer (delegate-runner-entry.mjs).
+//
+// Structurally modeled on worktree-refresh-timer.mjs (startWorktreeRefreshTimer):
+// enabled/interval/orchDir, an injectable fake-clock seam, handle.unref(), and a
+// returned { stop } handle. The CRITICAL difference (design §4a): the timer
+// callback body is ONLY a single-instance check + a DETACHED async spawn —
+//
+//   spawn(process.execPath, [ENTRY], { detached:true, stdio:["ignore",fd,fd] }).unref()
+//
+// It NEVER calls spawnSync and NEVER uses stdio:"ignore" for the child's output.
+// The heavy work (worktree provision + claude --bg, 15-min ceiling) runs inside
+// the disposable detached child, never on the daemon event loop. Redirecting the
+// child's stdout/stderr to <orchDir>/logs/delegate-runner.log (instead of
+// discarding it) leaves a post-mortem trail if the child wedges before reaching
+// `claude --bg` (grafted from the minimal-fire-and-forget diagnosability fix).
+//
+// CONFIG SEPARATION: intervalMs / enabled come from opts. The daemon passes the
+// values from readDelegateRunnerConfig (config.mjs) — this module deliberately
+// does NOT import that reader (mirrors how worktree-refresh-timer keeps
+// readWorktreeRefreshConfig out of the timer body; config lives in the caller).
+//
+// PHASE A — LAND INERT: the daemon starts this gated CATALYST_DELEGATE_RUNNER=off
+// by default, so the timer never kicks and nothing drains. An empty queue means
+// zero behavior change.
+//
+// NAMESPACE: this module emits NO events. Dispatch lifecycle events
+// (phase.dispatch.*) are emitted by the detached drainer (delegate-runner-entry.mjs).
+
+import { openSync, mkdirSync } from "node:fs";
+import { spawn as nodeSpawn } from "node:child_process";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { log } from "./config.mjs";
+import { acquireRunnerLock } from "./delegate-runner-entry.mjs";
+
+// The detached drainer entrypoint this timer spawns. Resolved relative to this
+// module so it works regardless of cwd (mirrors worktree-refresh-timer's
+// REFRESH_BIN resolution via import.meta.url).
+const DELEGATE_RUNNER_ENTRY = fileURLToPath(
+  new URL("./delegate-runner-entry.mjs", import.meta.url)
+);
+
+function realClock() {
+  return {
+    setInterval: (fn, ms) => setInterval(fn, ms),
+    clearInterval: (handle) => clearInterval(handle),
+  };
+}
+
+// defaultOpenLogFd — open (append, create) the child's combined stdout/stderr
+// log at <orchDir>/logs/delegate-runner.log and return its fd. Injectable so
+// tests assert the redirect target without touching the real fs.
+function defaultOpenLogFd(logPath) {
+  mkdirSync(dirname(logPath), { recursive: true });
+  return openSync(logPath, "a");
+}
+
+// defaultIsRunnerRunning — the single-instance guard the timer consults BEFORE
+// kicking, so overlapping ticks don't stack detached runners. It checks the
+// top-level lock the way the entry's acquireRunnerLock does, but WITHOUT taking
+// the lock (the child takes it). Injectable for tests. A live lock-holder → true
+// (skip the kick); no/stale lock → false (kick).
+function defaultIsRunnerRunning(orchDir) {
+  // acquireRunnerLock both probes AND (when free) takes the lock; we only want a
+  // probe here, so we acquire-then-immediately-release. The detached child
+  // re-acquires its own lock on start (the authoritative single-instance check);
+  // this is a cheap pre-filter to avoid spawning a child that will just exit.
+  let lock;
+  try {
+    lock = acquireRunnerLock(orchDir);
+  } catch {
+    return false; // lock probe failed → don't block the kick
+  }
+  if (!lock.acquired) return true; // a live runner holds it
+  lock.release();
+  return false;
+}
+
+/**
+ * startDelegateRunnerTimer — start the in-daemon interval that kicks the
+ * detached delegate drainer. Returns a { stop } handle.
+ *
+ * The callback body is ONLY: single-instance check + detached spawn().unref().
+ * NO spawnSync, NO stdio:"ignore".
+ *
+ * @param {object} opts
+ * @param {boolean}  [opts.enabled=true]
+ * @param {number}   [opts.intervalMs=15000]   runner cadence (from readDelegateRunnerConfig)
+ * @param {string}   [opts.orchDir]            execution-core orch dir
+ * @param {string}   [opts.entryPath]          detached entrypoint (injectable for tests)
+ * @param {Function} [opts.spawn]              injectable async spawn (NEVER spawnSync)
+ * @param {Function} [opts.openLogFd]          injectable fd opener for the child log
+ * @param {Function} [opts.isRunnerRunning]    injectable single-instance probe
+ * @param {object}   [opts.clock]              fake-clock seam for tests
+ */
+export function startDelegateRunnerTimer({
+  enabled = true,
+  intervalMs = 15000,
+  orchDir,
+  entryPath = DELEGATE_RUNNER_ENTRY,
+  spawn = nodeSpawn,
+  openLogFd = defaultOpenLogFd,
+  isRunnerRunning = defaultIsRunnerRunning,
+  clock = realClock(),
+} = {}) {
+  if (!enabled || !orchDir) return { stop: () => {} };
+  const ms = Math.max(1, intervalMs);
+  const logPath = join(orchDir, "logs", "delegate-runner.log");
+
+  const handle = clock.setInterval(() => {
+    try {
+      // (1) Single-instance guard — never stack overlapping detached runners.
+      if (isRunnerRunning(orchDir)) return;
+
+      // (2) Open (or create) the child's combined stdout/stderr log fd. NEVER
+      //     discard the child's output — a wedge before `claude --bg` must leave
+      //     a trail, not silence.
+      let logFd;
+      try {
+        logFd = openLogFd(logPath);
+      } catch (err) {
+        log.warn(
+          { err: err?.message, logPath },
+          "delegate-runner: log fd open failed; skipping kick"
+        );
+        return;
+      }
+
+      // (3) DETACHED spawn + unref. stdin ignored; stdout/stderr → the log fd.
+      //     spawn (async) ONLY — never spawnSync (which would block the daemon
+      //     loop, the exact thing this whole design moves work OFF of).
+      const child = spawn(process.execPath, [entryPath], {
+        detached: true,
+        stdio: ["ignore", logFd, logFd],
+      });
+      if (child && typeof child.unref === "function") child.unref();
+    } catch (err) {
+      log.warn({ err: err?.message }, "delegate-runner: kick error");
+    }
+  }, ms);
+
+  if (typeof handle?.unref === "function") handle.unref();
+  return {
+    stop: () => clock.clearInterval(handle),
+  };
+}

--- a/plugins/dev/scripts/execution-core/delegate-runner.test.mjs
+++ b/plugins/dev/scripts/execution-core/delegate-runner.test.mjs
@@ -1,0 +1,641 @@
+// delegate-runner.test.mjs — CTL-1331. The detached delegate RUNNER: the
+// in-daemon timer (startDelegateRunnerTimer) that spawns the detached drainer,
+// and the drainer body (drainOnce) that claims queued intents and moves the
+// heavy worktree-provision + `claude --bg` spawn OFF the daemon event loop.
+//
+// Deterministic: orchDir is a tmpdir; clock / spawn / claimFn / invokeFn /
+// countBackgroundAgents / emit* / fs are all injected — NO real claude/git/
+// worktree/network (mirrors worktree-refresh-timer.test.mjs +
+// delegate-queue.test.mjs).
+//
+// Mirrors the §10d TDD plan in
+//   thoughts/shared/plans/2026-06-24-ctl-1331-async-worker-design.md:
+//   - drains a queued intent → claimed→launched + bg_job_id + requested+launched emitted
+//   - invoke failure → failed status + failed emitted
+//   - free-slot re-check (countBackgroundAgents >= maxParallel → un-claim, no dispatch)
+//   - live-worker supersede → superseded, gc, no dispatch
+//   - single-flight (two concurrent drains, one claims)
+//   - stale-claim reclaim
+//   - DETACHED invariant: the timer kick uses spawn(...).unref(), NEVER spawnSync,
+//     NEVER stdio:"ignore"
+//
+// Run: cd plugins/dev/scripts/execution-core && bun test delegate-runner.test.mjs
+
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import {
+  mkdtempSync,
+  mkdirSync,
+  writeFileSync,
+  readFileSync,
+  readdirSync,
+  existsSync,
+  rmSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { startDelegateRunnerTimer } from "./delegate-runner.mjs";
+import { drainOnce } from "./delegate-runner-entry.mjs";
+import { DELEGATE_QUEUE_DIR, claimIntent } from "./delegate-queue.mjs";
+
+let orchDir;
+const FIXED_NOW = 1_700_000_000_000;
+
+beforeEach(() => {
+  orchDir = mkdtempSync(join(tmpdir(), "ctl1331-runner-"));
+  mkdirSync(join(orchDir, "workers"), { recursive: true });
+});
+
+afterEach(() => {
+  rmSync(orchDir, { recursive: true, force: true });
+});
+
+// ─── helpers ──────────────────────────────────────────────────────────────────
+
+function queueDir() {
+  return join(orchDir, DELEGATE_QUEUE_DIR);
+}
+
+function intentPath(ticket) {
+  return join(queueDir(), `${ticket}.json`);
+}
+
+function readIntent(ticket) {
+  return JSON.parse(readFileSync(intentPath(ticket), "utf8"));
+}
+
+function listQueueFiles() {
+  try {
+    return readdirSync(queueDir());
+  } catch {
+    return [];
+  }
+}
+
+// Seed a queued <TICKET>.json the runner will drain.
+function seedQueued(ticket, fields = {}) {
+  mkdirSync(queueDir(), { recursive: true });
+  writeFileSync(
+    intentPath(ticket),
+    JSON.stringify({
+      schema: "delegate-intent/v1",
+      ticket,
+      status: "queued",
+      kind: "board-health",
+      phase: "recovery-pass",
+      boardContext: { anomaly: "wip-spike" },
+      reason: "board-health: wip spike — holistic delegate",
+      enqueuedAt: FIXED_NOW,
+      ...fields,
+    })
+  );
+}
+
+// Seed a live recovery-pass worker signal (the supersede input).
+function seedRecoveryPassSignal(ticket, status, bgJobId = "bg-live-1") {
+  const dir = join(orchDir, "workers", ticket);
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(
+    join(dir, "phase-recovery-pass.json"),
+    JSON.stringify({ ticket, phase: "recovery-pass", status, bg_job_id: bgJobId })
+  );
+}
+
+// A spy-bag of the emitters + the invoke/count seams the drainer uses.
+function makeDeps(over = {}) {
+  const emitted = { requested: [], launched: [], failed: [] };
+  return {
+    orchDir,
+    now: () => FIXED_NOW,
+    maxParallel: 8,
+    pid: 4242,
+    // injected slot probe — default: nothing live → headroom available.
+    countBackgroundAgents: () => 0,
+    // injected idempotency probe — default: no live worker.
+    isBgJobAlive: () => false,
+    // injected heavy path — default: dispatched OK with a bg job + worktree.
+    invokeFn: (ticket, brief, d) => ({
+      success: true,
+      dispatched: true,
+      attempts: 1,
+      reason: "recovery-pass dispatched",
+      details: {
+        phase: "recovery-pass",
+        bg_job_id: `bg-${ticket}`,
+        worktreePath: `/wt/${ticket}`,
+      },
+    }),
+    appendRequested: (e) => emitted.requested.push(e),
+    appendLaunched: (e) => emitted.launched.push(e),
+    appendFailed: (e) => emitted.failed.push(e),
+    _emitted: emitted,
+    ...over,
+  };
+}
+
+// ════════════════════════════════════════════════════════════════════════════
+// drainOnce — the detached drainer body
+// ════════════════════════════════════════════════════════════════════════════
+
+describe("drainOnce — drains a queued intent → launched", () => {
+  test("claims the intent, invokes recovery-pass, flips to launched + records bg_job_id/worktreePath/launchedAt", () => {
+    seedQueued("CTL-1");
+    const deps = makeDeps();
+    const invoked = [];
+    deps.invokeFn = (ticket, brief, d) => {
+      invoked.push({ ticket, brief, d });
+      return {
+        dispatched: true,
+        details: { bg_job_id: "bg-9", worktreePath: "/wt/CTL-1" },
+      };
+    };
+
+    const res = drainOnce(deps);
+
+    // invoked with the intent's boardContext + reason
+    expect(invoked).toHaveLength(1);
+    expect(invoked[0].ticket).toBe("CTL-1");
+    expect(invoked[0].brief.boardContext).toEqual({ anomaly: "wip-spike" });
+    expect(invoked[0].brief.reason).toContain("wip spike");
+
+    // intent flipped to launched with the launch fields
+    const intent = readIntent("CTL-1");
+    expect(intent.status).toBe("launched");
+    expect(intent.bg_job_id).toBe("bg-9");
+    expect(intent.worktreePath).toBe("/wt/CTL-1");
+    expect(intent.launchedAt).toBe(FIXED_NOW);
+
+    // no claim sidecar left behind
+    expect(listQueueFiles().some((f) => f.includes(".claimed-"))).toBe(false);
+
+    expect(res.drained).toBe(1);
+  });
+
+  test("emits phase.dispatch.requested then phase.dispatch.launched (in order, with bg_job_id)", () => {
+    seedQueued("CTL-1");
+    const deps = makeDeps();
+    deps.invokeFn = () => ({
+      dispatched: true,
+      details: { bg_job_id: "bg-7", worktreePath: "/wt/CTL-1" },
+    });
+
+    drainOnce(deps);
+
+    expect(deps._emitted.requested).toHaveLength(1);
+    expect(deps._emitted.requested[0].ticket).toBe("CTL-1");
+    expect(deps._emitted.requested[0].target_phase).toBe("recovery-pass");
+
+    expect(deps._emitted.launched).toHaveLength(1);
+    expect(deps._emitted.launched[0].ticket).toBe("CTL-1");
+    expect(deps._emitted.launched[0].bg_job_id).toBe("bg-7");
+    expect(deps._emitted.launched[0].worktree_path).toBe("/wt/CTL-1");
+
+    expect(deps._emitted.failed).toHaveLength(0);
+  });
+
+  test("NEVER emits a phase.recovery-pass.* event (only the worker emits completion)", () => {
+    seedQueued("CTL-1");
+    const names = [];
+    const deps = makeDeps({
+      appendRequested: (e) => names.push(`requested:${e.target_phase}`),
+      appendLaunched: (e) => names.push(`launched:${e.target_phase}`),
+      appendFailed: (e) => names.push(`failed:${e.target_phase}`),
+    });
+    drainOnce(deps);
+    // target_phase rides as recovery-pass in payload, but the EVENT slot is dispatch.
+    // Assert the drainer never produced any recovery-pass-slotted emission of its own.
+    expect(names.every((n) => n.startsWith("requested:") || n.startsWith("launched:") || n.startsWith("failed:"))).toBe(true);
+  });
+});
+
+describe("drainOnce — invoke failure → failed", () => {
+  test("a non-dispatched invoke result flips the intent to failed + emits phase.dispatch.failed", () => {
+    seedQueued("CTL-2");
+    const deps = makeDeps();
+    deps.invokeFn = () => ({
+      dispatched: false,
+      reason: "recovery-pass-cycle-cap-exhausted",
+    });
+
+    const res = drainOnce(deps);
+
+    const intent = readIntent("CTL-2");
+    expect(intent.status).toBe("failed");
+    expect(intent.reason).toBe("recovery-pass-cycle-cap-exhausted");
+
+    expect(deps._emitted.failed).toHaveLength(1);
+    expect(deps._emitted.failed[0].ticket).toBe("CTL-2");
+    expect(deps._emitted.failed[0].reason).toBe("recovery-pass-cycle-cap-exhausted");
+
+    expect(deps._emitted.launched).toHaveLength(0);
+    expect(res.drained).toBe(0);
+  });
+
+  test("an invoke that THROWS is caught → failed (never crashes the drainer)", () => {
+    seedQueued("CTL-3");
+    const deps = makeDeps();
+    deps.invokeFn = () => {
+      throw new Error("boom");
+    };
+
+    expect(() => drainOnce(deps)).not.toThrow();
+    expect(readIntent("CTL-3").status).toBe("failed");
+    expect(deps._emitted.failed).toHaveLength(1);
+  });
+});
+
+describe("drainOnce — free-slot re-check", () => {
+  test("countBackgroundAgents >= maxParallel → un-claims (back to queued), does NOT dispatch", () => {
+    seedQueued("CTL-4");
+    const deps = makeDeps({
+      maxParallel: 2,
+      countBackgroundAgents: () => 2, // no headroom
+    });
+    let invoked = false;
+    deps.invokeFn = () => {
+      invoked = true;
+      return { dispatched: true, details: {} };
+    };
+
+    const res = drainOnce(deps);
+
+    expect(invoked).toBe(false); // never reached the heavy path
+    // intent un-claimed back to queued (left for next cycle), no claim sidecar
+    expect(existsSync(intentPath("CTL-4"))).toBe(true);
+    expect(readIntent("CTL-4").status).toBe("queued");
+    expect(listQueueFiles().some((f) => f.includes(".claimed-"))).toBe(false);
+
+    expect(deps._emitted.requested).toHaveLength(0);
+    expect(deps._emitted.launched).toHaveLength(0);
+    expect(res.drained).toBe(0);
+  });
+
+  test("countBackgroundAgents THROWS → fail-CLOSED: un-claims, does NOT dispatch (CTL-1331 §3b conservative-only)", () => {
+    seedQueued("CTL-4b");
+    const deps = makeDeps({
+      maxParallel: 2,
+      countBackgroundAgents: () => {
+        throw new Error("claude agents RPC failed");
+      },
+    });
+    let invoked = false;
+    deps.invokeFn = () => {
+      invoked = true;
+      return { dispatched: true, details: {} };
+    };
+
+    const res = drainOnce(deps);
+
+    // A live count we CANNOT read must never launch on unknown headroom — fail
+    // closed (un-claim, retry next cycle), matching the scheduler tick's own
+    // CTL-731 hold-on-stale-liveness posture. Never over-spawn.
+    expect(invoked).toBe(false);
+    expect(readIntent("CTL-4b").status).toBe("queued");
+    expect(listQueueFiles().some((f) => f.includes(".claimed-"))).toBe(false);
+    expect(deps._emitted.requested).toHaveLength(0);
+    expect(deps._emitted.launched).toHaveLength(0);
+    expect(res.drained).toBe(0);
+  });
+
+  test("with headroom (countBackgroundAgents < maxParallel) it DOES dispatch", () => {
+    seedQueued("CTL-5");
+    const deps = makeDeps({ maxParallel: 2, countBackgroundAgents: () => 1 });
+    drainOnce(deps);
+    expect(readIntent("CTL-5").status).toBe("launched");
+  });
+});
+
+describe("drainOnce — live-worker supersede (idempotency)", () => {
+  test("a live recovery-pass worker already exists → superseded, GC, no dispatch", () => {
+    seedQueued("CTL-6");
+    seedRecoveryPassSignal("CTL-6", "running", "bg-live-6");
+    const deps = makeDeps({ isBgJobAlive: (id) => id === "bg-live-6" });
+    let invoked = false;
+    deps.invokeFn = () => {
+      invoked = true;
+      return { dispatched: true, details: {} };
+    };
+
+    const res = drainOnce(deps);
+
+    expect(invoked).toBe(false);
+    // GC'd — the intent file (and any claim sidecar) is gone
+    expect(existsSync(intentPath("CTL-6"))).toBe(false);
+    expect(listQueueFiles().some((f) => f.startsWith("CTL-6"))).toBe(false);
+
+    expect(deps._emitted.requested).toHaveLength(0);
+    expect(deps._emitted.launched).toHaveLength(0);
+    expect(res.superseded).toBe(1);
+  });
+
+  test("a DEAD recovery-pass worker does NOT supersede → it dispatches normally", () => {
+    seedQueued("CTL-7");
+    seedRecoveryPassSignal("CTL-7", "running", "bg-dead-7");
+    const deps = makeDeps({ isBgJobAlive: () => false });
+    drainOnce(deps);
+    expect(readIntent("CTL-7").status).toBe("launched");
+  });
+});
+
+describe("drainOnce — single-flight (two concurrent drains)", () => {
+  test("two drains over the same intent → exactly one claims+dispatches, the other skips", () => {
+    seedQueued("CTL-8");
+
+    // Inject a claimFn that lets us interleave: the first drain claims, then while
+    // it holds the claim we run a SECOND drain (which must lose the claim).
+    const realClaim = claimIntent;
+    let secondResult = null;
+    const depsA = makeDeps();
+    depsA.claimFn = (od, ticket, pid, ts) => {
+      const r = realClaim(od, ticket, pid, ts);
+      if (r.claimed && secondResult === null) {
+        // run the competing drain WHILE the intent is claimed away
+        const depsB = makeDeps({ pid: 9999 });
+        secondResult = drainOnce(depsB);
+      }
+      return r;
+    };
+
+    const firstResult = drainOnce(depsA);
+
+    // exactly one dispatched
+    const totalLaunched =
+      depsA._emitted.launched.length + (secondResult ? 1 : 0) * 0; // B has its own bag
+    expect(depsA._emitted.launched).toHaveLength(1);
+    expect(firstResult.drained).toBe(1);
+    // the second drain saw nothing claimable (the only intent was already claimed)
+    expect(secondResult.drained).toBe(0);
+    expect(readIntent("CTL-8").status).toBe("launched");
+  });
+});
+
+describe("drainOnce — stale-claim reclaim", () => {
+  test("a claimed-* sidecar older than the ceiling is reclaimed to queued, then drained", () => {
+    mkdirSync(queueDir(), { recursive: true });
+    const staleTs = FIXED_NOW - 1_000_000; // > 900_000 default ceiling
+    const claimPath = join(queueDir(), `CTL-9.json.claimed-555-${staleTs}`);
+    writeFileSync(
+      claimPath,
+      JSON.stringify({
+        schema: "delegate-intent/v1",
+        ticket: "CTL-9",
+        status: "claimed",
+        kind: "board-health",
+        phase: "recovery-pass",
+        boardContext: { anomaly: "x" },
+        reason: "r",
+        enqueuedAt: staleTs,
+      })
+    );
+    const deps = makeDeps();
+
+    const res = drainOnce(deps);
+
+    // reclaimed (stale sidecar gone) then drained to launched
+    expect(existsSync(claimPath)).toBe(false);
+    expect(readIntent("CTL-9").status).toBe("launched");
+    expect(res.reclaimed).toBeGreaterThanOrEqual(1);
+    expect(res.drained).toBe(1);
+  });
+
+  test("a FRESH claimed-* (within the window) is left alone, not double-dispatched", () => {
+    mkdirSync(queueDir(), { recursive: true });
+    const freshTs = FIXED_NOW - 1_000;
+    const claimPath = join(queueDir(), `CTL-10.json.claimed-555-${freshTs}`);
+    writeFileSync(
+      claimPath,
+      JSON.stringify({ schema: "delegate-intent/v1", ticket: "CTL-10", status: "claimed", enqueuedAt: freshTs })
+    );
+    const deps = makeDeps();
+    const res = drainOnce(deps);
+    expect(existsSync(claimPath)).toBe(true); // untouched
+    expect(res.drained).toBe(0);
+    expect(deps._emitted.launched).toHaveLength(0);
+  });
+});
+
+describe("drainOnce — empty queue is inert (Phase A invariant)", () => {
+  test("no queue dir → zero work, no throw, all-zero result", () => {
+    const deps = makeDeps();
+    const res = drainOnce(deps);
+    expect(res.drained).toBe(0);
+    expect(res.superseded).toBe(0);
+    expect(deps._emitted.requested).toHaveLength(0);
+    expect(deps._emitted.launched).toHaveLength(0);
+    expect(deps._emitted.failed).toHaveLength(0);
+  });
+
+  test("a queue with only terminal intents (failed) drains nothing", () => {
+    mkdirSync(queueDir(), { recursive: true });
+    writeFileSync(
+      intentPath("CTL-term"),
+      JSON.stringify({ schema: "delegate-intent/v1", ticket: "CTL-term", status: "failed" })
+    );
+    const deps = makeDeps();
+    const res = drainOnce(deps);
+    expect(res.drained).toBe(0);
+    expect(readIntent("CTL-term").status).toBe("failed"); // untouched
+  });
+});
+
+// ════════════════════════════════════════════════════════════════════════════
+// startDelegateRunnerTimer — the in-daemon timer (kick = detached spawn().unref())
+// ════════════════════════════════════════════════════════════════════════════
+
+// Fake clock mirroring worktree-refresh-timer.test.mjs.
+function fakeClock() {
+  let reg = null;
+  return {
+    setInterval: (fn, ms) => {
+      reg = { fn, ms };
+      return { unref() {} };
+    },
+    clearInterval: () => {
+      reg = null;
+    },
+    advance: (elapsedMs) => {
+      if (!reg) return;
+      const ticks = Math.floor(elapsedMs / reg.ms);
+      for (let i = 0; i < ticks; i++) reg.fn();
+    },
+    registered: () => reg,
+  };
+}
+
+// A spawn spy returning a child handle with an .unref() spy.
+function makeSpawnSpy() {
+  const calls = [];
+  let unrefCount = 0;
+  const spawn = (...args) => {
+    calls.push(args);
+    return {
+      unref: () => {
+        unrefCount++;
+      },
+      pid: 1234,
+    };
+  };
+  return { spawn, calls, unrefCount: () => unrefCount };
+}
+
+describe("startDelegateRunnerTimer — detached spawn().unref() kick", () => {
+  test("each interval kicks the entry via spawn(process.execPath, [entry], {detached}).unref()", () => {
+    const clock = fakeClock();
+    const spy = makeSpawnSpy();
+    startDelegateRunnerTimer({
+      enabled: true,
+      intervalMs: 15000,
+      orchDir,
+      entryPath: "/fake/delegate-runner-entry.mjs",
+      spawn: spy.spawn,
+      clock,
+      isRunnerRunning: () => false, // single-instance check passes
+    });
+    clock.advance(15000);
+
+    expect(spy.calls).toHaveLength(1);
+    const [cmd, argv, opts] = spy.calls[0];
+    expect(cmd).toBe(process.execPath);
+    expect(argv).toEqual(["/fake/delegate-runner-entry.mjs"]);
+    expect(opts.detached).toBe(true);
+    expect(spy.unrefCount()).toBe(1); // .unref() called on the child
+  });
+
+  test("DETACHED INVARIANT — stdio redirects child stdout/stderr to a log fd, NEVER stdio:'ignore'", () => {
+    const clock = fakeClock();
+    const spy = makeSpawnSpy();
+    let openedLogPath = null;
+    startDelegateRunnerTimer({
+      enabled: true,
+      intervalMs: 15000,
+      orchDir,
+      entryPath: "/fake/entry.mjs",
+      spawn: spy.spawn,
+      clock,
+      isRunnerRunning: () => false,
+      // injectable fd opener so the test can assert the log target without real fs.
+      openLogFd: (p) => {
+        openedLogPath = p;
+        return 77; // a fake fd
+      },
+    });
+    clock.advance(15000);
+
+    const opts = spy.calls[0][2];
+    // stdio is [ignore-stdin, logFd, logFd] — NOT the string "ignore".
+    expect(opts.stdio).not.toBe("ignore");
+    expect(Array.isArray(opts.stdio)).toBe(true);
+    expect(opts.stdio[0]).toBe("ignore"); // stdin ignored is fine
+    expect(opts.stdio[1]).toBe(77); // stdout → log fd
+    expect(opts.stdio[2]).toBe(77); // stderr → log fd
+    // the log target is under <orchDir>/logs/delegate-runner.log
+    expect(openedLogPath).toContain(join(orchDir, "logs"));
+    expect(openedLogPath).toContain("delegate-runner.log");
+  });
+
+  test("DETACHED INVARIANT — the spawn fn is the injectable async spawn, NEVER spawnSync", () => {
+    // The timer must accept (and only ever call) the injected `spawn` seam. We
+    // assert by making the spy throw if a `sync`-flavored option ever appears,
+    // and by confirming the body never imports spawnSync (the spy is the only
+    // spawn the timer can reach in this test).
+    const clock = fakeClock();
+    const spy = makeSpawnSpy();
+    startDelegateRunnerTimer({
+      enabled: true,
+      intervalMs: 15000,
+      orchDir,
+      entryPath: "/fake/entry.mjs",
+      spawn: spy.spawn,
+      clock,
+      isRunnerRunning: () => false,
+      openLogFd: () => 5,
+    });
+    clock.advance(15000);
+    // Exactly one async spawn; no third positional that smells synchronous.
+    expect(spy.calls).toHaveLength(1);
+    const opts = spy.calls[0][2];
+    expect(opts).not.toHaveProperty("input"); // spawnSync-only option
+    expect(typeof opts.detached).toBe("boolean");
+  });
+
+  test("single-instance guard — skips the kick when a runner is already running", () => {
+    const clock = fakeClock();
+    const spy = makeSpawnSpy();
+    startDelegateRunnerTimer({
+      enabled: true,
+      intervalMs: 15000,
+      orchDir,
+      entryPath: "/fake/entry.mjs",
+      spawn: spy.spawn,
+      clock,
+      isRunnerRunning: () => true, // already running
+      openLogFd: () => 5,
+    });
+    clock.advance(15000);
+    expect(spy.calls).toHaveLength(0); // no overlapping runner stacked
+  });
+
+  test("is a no-op when disabled (mode off)", () => {
+    const clock = fakeClock();
+    const spy = makeSpawnSpy();
+    const handle = startDelegateRunnerTimer({
+      enabled: false,
+      orchDir,
+      spawn: spy.spawn,
+      clock,
+    });
+    clock.advance(600000);
+    expect(spy.calls).toHaveLength(0);
+    expect(clock.registered()).toBeNull();
+    expect(typeof handle.stop).toBe("function");
+  });
+
+  test("is a no-op when orchDir is missing", () => {
+    const clock = fakeClock();
+    const spy = makeSpawnSpy();
+    startDelegateRunnerTimer({
+      enabled: true,
+      orchDir: undefined,
+      spawn: spy.spawn,
+      clock,
+    });
+    clock.advance(600000);
+    expect(spy.calls).toHaveLength(0);
+  });
+
+  test("stop() clears the interval — no further kicks", () => {
+    const clock = fakeClock();
+    const spy = makeSpawnSpy();
+    const handle = startDelegateRunnerTimer({
+      enabled: true,
+      intervalMs: 15000,
+      orchDir,
+      entryPath: "/fake/entry.mjs",
+      spawn: spy.spawn,
+      clock,
+      isRunnerRunning: () => false,
+      openLogFd: () => 5,
+    });
+    handle.stop();
+    clock.advance(600000);
+    expect(spy.calls).toHaveLength(0);
+  });
+
+  test("handle.unref() is called on the interval registration (does not hold the loop open)", () => {
+    let unrefed = false;
+    const clock = {
+      setInterval: () => ({ unref: () => { unrefed = true; } }),
+      clearInterval: () => {},
+    };
+    startDelegateRunnerTimer({
+      enabled: true,
+      intervalMs: 15000,
+      orchDir,
+      entryPath: "/fake/entry.mjs",
+      spawn: () => ({ unref() {} }),
+      clock,
+      isRunnerRunning: () => false,
+      openLogFd: () => 5,
+    });
+    expect(unrefed).toBe(true);
+  });
+});

--- a/plugins/dev/scripts/execution-core/delegate-slot-reservation.test.mjs
+++ b/plugins/dev/scripts/execution-core/delegate-slot-reservation.test.mjs
@@ -1,0 +1,99 @@
+// delegate-slot-reservation.test.mjs — CTL-1331. The scheduler-side slot
+// reservation for the async board-health delegate queue (design §3, §10b).
+//
+// Run: cd plugins/dev/scripts/execution-core && bun test delegate-slot-reservation.test.mjs
+//
+// In its OWN file (NOT scheduler.test.mjs — excluded from the CI allowlist for its
+// real-timer / fs.watch "debounced tick" suite) so this runs in CI. Each case
+// calls schedulerTick ONCE, synchronously, with injected
+// countQueuedDelegates/gcDelegateIntents/liveBackgroundCount stubs — no timers, no
+// fs.watch — and reads back the board-health capacity the tick computed (the
+// tick's authoritative freeSlots view). It asserts the CTL-1331 invariant: a
+// queued/claimed delegate RESERVES a slot (occupiedCount = liveCount +
+// queuedDelegates), the reservation only ever LOWERS freeSlots (conservative-only,
+// §3b), and an EMPTY queue is a strict no-op (Phase A inert: occupiedCount ===
+// liveCount → zero behavior change). Mirrors board-health-seam.test.mjs's
+// single-sync-tick discipline.
+
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { schedulerTick, computeFreeSlots } from "./scheduler.mjs";
+
+let orchDir;
+let catalystDir;
+let prevCatalystDir;
+beforeEach(() => {
+  orchDir = mkdtempSync(join(tmpdir(), "delegate-slot-"));
+  prevCatalystDir = process.env.CATALYST_DIR;
+  catalystDir = mkdtempSync(join(tmpdir(), "delegate-slot-cat-"));
+  process.env.CATALYST_DIR = catalystDir; // getEventLogPath() resolves under the fixture
+});
+afterEach(() => {
+  rmSync(orchDir, { recursive: true, force: true });
+  if (prevCatalystDir === undefined) delete process.env.CATALYST_DIR;
+  else process.env.CATALYST_DIR = prevCatalystDir;
+  rmSync(catalystDir, { recursive: true, force: true });
+});
+
+// Drive one tick with injected slot seams and return the capacity the board-health
+// pass observed. The board-health capacity.freeSlots is computed from occupiedCount
+// (scheduler.mjs §3a), so it is the cleanest observable of the reservation.
+function tickCapacity({ maxParallel, live, queued, gcSpy }) {
+  let captured = null;
+  schedulerTick(orchDir, {
+    readEligible: () => [],
+    dispatch: () => ({ code: 0 }),
+    writeStatus: () => {},
+    reclaimDeadWork: () => "noop",
+    concurrency: { maxParallel },
+    liveBackgroundCount: () => live,
+    countQueuedDelegates: () => queued,
+    gcDelegateIntents: (dir, now) => {
+      gcSpy?.(dir, now);
+      return 0;
+    },
+    boardHealth: { mode: "shadow" },
+    boardHealthPassFn: (opts) => {
+      captured = opts.capacity;
+      return { ran: true, ranAtMs: 1 };
+    },
+  });
+  return captured;
+}
+
+describe("schedulerTick — CTL-1331 delegate slot reservation (§3/§10b)", () => {
+  test("empty queue → occupiedCount === liveCount (Phase A inert: zero behavior change)", () => {
+    const cap = tickCapacity({ maxParallel: 4, live: 2, queued: 0 });
+    expect(cap.liveCount).toBe(2);
+    // freeSlots identical to the pre-CTL-1331 value computeFreeSlots(4, liveCount).
+    expect(cap.freeSlots).toBe(computeFreeSlots(4, 2));
+    expect(cap.freeSlots).toBe(2);
+  });
+
+  test("N queued delegates reserve N slots → freeSlots drops by N", () => {
+    const cap = tickCapacity({ maxParallel: 4, live: 1, queued: 2 });
+    // occupiedCount = live(1) + queued(2) = 3 → freeSlots = 4 - 3 = 1.
+    expect(cap.liveCount).toBe(1); // the reported live count is UNCHANGED…
+    expect(cap.freeSlots).toBe(computeFreeSlots(4, 3)); // …only freeSlots reflects the reservation
+    expect(cap.freeSlots).toBe(1);
+  });
+
+  test("conservative-only: a reservation never RAISES freeSlots vs no reservation (§3b)", () => {
+    const withoutRes = tickCapacity({ maxParallel: 4, live: 2, queued: 0 });
+    const withRes = tickCapacity({ maxParallel: 4, live: 2, queued: 1 });
+    expect(withRes.freeSlots).toBeLessThanOrEqual(withoutRes.freeSlots);
+  });
+
+  test("over-reservation never drives freeSlots below 0 (clamped, never negative)", () => {
+    const cap = tickCapacity({ maxParallel: 2, live: 2, queued: 5 });
+    expect(cap.freeSlots).toBe(0);
+  });
+
+  test("gcDelegateIntents runs each tick (releases stale/terminal reservations before reserving)", () => {
+    let gcCalls = 0;
+    tickCapacity({ maxParallel: 4, live: 0, queued: 0, gcSpy: () => { gcCalls++; } });
+    expect(gcCalls).toBe(1);
+  });
+});

--- a/plugins/dev/scripts/execution-core/delegate-slot-reservation.test.mjs
+++ b/plugins/dev/scripts/execution-core/delegate-slot-reservation.test.mjs
@@ -96,4 +96,27 @@ describe("schedulerTick — CTL-1331 delegate slot reservation (§3/§10b)", () 
     tickCapacity({ maxParallel: 4, live: 0, queued: 0, gcSpy: () => { gcCalls++; } });
     expect(gcCalls).toBe(1);
   });
+
+  // The board-health capacity above proves occupiedCount reaches ONE consumer. The
+  // new-work / promotion / resume gates all derive from inFlightCount =
+  // occupiedCount (scheduler.mjs §3b). Assert the tick RESULT's inFlightCount
+  // directly so a future regression that re-points only the new-work path back to
+  // bare liveCount — which the capacity assertion alone would NOT catch — fails here.
+  test("tick result inFlightCount reflects the reservation (new-work/resume gate lock)", () => {
+    const tick = (queued) =>
+      schedulerTick(orchDir, {
+        readEligible: () => [],
+        dispatch: () => ({ code: 0 }),
+        writeStatus: () => {},
+        reclaimDeadWork: () => "noop",
+        concurrency: { maxParallel: 4 },
+        liveBackgroundCount: () => 1,
+        countQueuedDelegates: () => queued,
+        gcDelegateIntents: () => 0,
+      });
+    expect(tick(0).inFlightCount).toBe(1); // empty queue → inFlightCount === liveCount (inert)
+    expect(tick(2).inFlightCount).toBe(3); // live(1) + queued(2) reservations
+    // …and the reservation withholds new-work headroom.
+    expect(tick(2).freeSlots).toBeLessThan(tick(0).freeSlots);
+  });
 });

--- a/plugins/dev/scripts/execution-core/recovery.mjs
+++ b/plugins/dev/scripts/execution-core/recovery.mjs
@@ -970,6 +970,47 @@ export function defaultAppendDispatchLaunchedEvent({
   );
 }
 
+// CTL-1331: appendDispatchEnqueuedEvent — phase.dispatch.enqueued.<TICKET>.
+// The creation-telemetry marker for the async board-health delegate (the
+// operator's "log when it's created"). Emitted by the tick `act` seam the
+// moment a delegate intent is written to the queue — BEFORE any worktree
+// provision or `claude --bg` spawn, which now happen out-of-process in the
+// detached delegate-runner. It mirrors defaultAppendDispatchRequestedEvent
+// exactly (phase slot "dispatch", INFO severity, ticketType from triage.json),
+// adding `kind` to the payload so the queue's intent-type rides on the event.
+// The `dispatch` phase slot is an allowed namespace exception, and the
+// "enqueued" action does NOT collide with PHASE_EVENT_PATTERN's terminal set
+// (complete|failed|turn-cap-exhausted|skipped) — same property as the existing
+// dispatch.requested/.launched actions, so it introduces no broker-routing
+// collision. We deliberately do NOT introduce any phase.recovery-pass.*
+// producer here: "recovery-pass" is not an allowed phase slot; the worker (not
+// this emitter) emits the recovery-pass completion. Best-effort like every
+// other audit emitter — no caller gates on the return.
+export function appendDispatchEnqueuedEvent({
+  orchId,
+  orchDir,
+  ticket,
+  target_phase,
+  kind,
+  reason = "board-health",
+}) {
+  return appendEnvelopeBestEffort(
+    buildEventEnvelope({
+      phase: "dispatch",
+      ticket,
+      orchId,
+      action: "enqueued",
+      reason,
+      payloadExtras: { target_phase, kind },
+      severityText: "INFO",
+      severityNumber: 9,
+      // CTL-1023: resolves to "unknown" pre-triage (no triage.json yet) — correct.
+      ticketType: resolveTicketType(orchDir, ticket),
+    }),
+    "dispatch-enqueued"
+  );
+}
+
 // CTL-705: preemption and resume-after-preemption event emitters.
 
 // defaultAppendPreemptedEvent — phase.<phase>.preempted.<TICKET>.

--- a/plugins/dev/scripts/execution-core/scheduler.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.mjs
@@ -230,6 +230,15 @@ import {
   // (mode=off ⇒ the pass never runs), so no live behavior change until opt-in.
   defaultInvokeRecoveryPass as recoveryInvokeRecoveryPass,
 } from "./recovery-reasoning.mjs";
+// CTL-1331: the async board-health delegate queue. countQueuedDelegates is the
+// slot reservation (a queued/claimed delegate has taken a slot its `claude --bg`
+// hasn't filled yet, so it is invisible to liveBackgroundCount); gcDelegateIntents
+// releases terminal/stale reservations. Both are injectable seams on schedulerTick
+// (defaults below) so a bare tick with an empty queue is a strict no-op (Phase A).
+import {
+  countQueuedDelegates as defaultCountQueuedDelegates,
+  gcDelegateIntents as defaultGcDelegateIntents,
+} from "./delegate-queue.mjs";
 // CTL-1219: the per-category enforcement seam registry (dirty-tree /
 // source-conflict / orphan-stale / stale-label). Pure-cored + injectable; bound
 // to production deps at the unstuckSweep wiring point below. Wiring this does NOT
@@ -2769,6 +2778,14 @@ export function schedulerTick(
     // its slot. Interactive sessions are excluded (unlimited). Injectable for
     // tests so a unit tick need not shell out to `claude`.
     liveBackgroundCount = () => countBackgroundAgents(),
+    // CTL-1331: slot-reservation seams for the async board-health delegate queue.
+    // countQueuedDelegates reserves a slot per queued/claimed intent (so the tick
+    // can't admit real work into a slot a queued delegate will claim);
+    // gcDelegateIntents releases terminal/stale reservations. Injectable so a unit
+    // tick injects a deterministic count; the default reads the real
+    // .delegate-queue. Empty queue → 0 → zero behavior change (Phase A inert).
+    countQueuedDelegates = defaultCountQueuedDelegates,
+    gcDelegateIntents = defaultGcDelegateIntents,
     // CTL-731 Phase 00 / CTL-736: `livenessIsFresh` gates new-work admission — a
     // stale/never-populated `claude agents` snapshot means the live count is
     // untrustworthy, so we HOLD new dispatch (fail-safe, never over-spawn) while
@@ -4050,6 +4067,27 @@ export function schedulerTick(
 
   const liveCount = liveBackgroundCount();
 
+  // CTL-1331: a board-health delegate runs async — the tick enqueues an intent and
+  // a detached runner does the heavy spawn later. A queued/claimed intent has
+  // RESERVED a slot it has not yet filled (its `claude --bg` isn't live, so
+  // liveBackgroundCount can't see it). Reserve it here — GC terminal/stale
+  // reservations first — so new-work/promotion/resume admission can't over-fill
+  // past maxParallel into a slot a queued delegate will claim. The reservation
+  // only ever LOWERS freeSlots (conservative-only, §3b); with an empty queue both
+  // calls return 0, so occupiedCount === liveCount (Phase A inert: zero change).
+  try {
+    gcDelegateIntents(orchDir, now());
+  } catch {
+    /* GC is best-effort — never block the tick */
+  }
+  let queuedDelegates = 0;
+  try {
+    queuedDelegates = countQueuedDelegates(orchDir);
+  } catch {
+    /* reservation read is best-effort — fall back to 0 reserved */
+  }
+  const occupiedCount = liveCount + queuedDelegates;
+
   tick?.lap("liveness-read");
 
   // CTL-1290: board-health delegate cadence hook — SHADOW-FIRST. Runs ONLY when
@@ -4075,7 +4113,7 @@ export function schedulerTick(
           roster,
           self,
           multiHost,
-          capacity: { maxParallel, liveCount, freeSlots: computeFreeSlots(maxParallel, liveCount) },
+          capacity: { maxParallel, liveCount, freeSlots: computeFreeSlots(maxParallel, occupiedCount) },
           readEventRing: _boardHealth.readEventRing,
           ownerForTicket,
           getReconcileMarkers: _boardHealth.getReconcileMarkers,
@@ -4210,7 +4248,7 @@ export function schedulerTick(
       // here — they flow through sweep 2; their presence only makes the triaged
       // candidates compete fairly.
       const freeSlotsForPromotion = livenessIsFresh()
-        ? Math.max(0, computeFreeSlots(maxParallel, liveCount))
+        ? Math.max(0, computeFreeSlots(maxParallel, occupiedCount))
         : 0;
       const readyCandidates = rankTickets(admissionPool.filter((t) => readyIds.has(t.identifier)));
       const admittedSlice = selectDispatchablePerProject(
@@ -4441,7 +4479,7 @@ export function schedulerTick(
   // 30s hysteresis. Runs after reclaim (so a just-reclaimed slot is counted)
   // and before advancement (so a preempted signal isn't falsely advanced).
   {
-    if (computeFreeSlots(maxParallel, liveCount) <= 0) {
+    if (computeFreeSlots(maxParallel, occupiedCount) <= 0) {
       // Build the global ranking to find topQueued and potential victim.
       const ranking = buildGlobalRanking(orchDir, eligible);
       const topQueued = ranking.find((d) => !d.inFlight);
@@ -4751,7 +4789,7 @@ export function schedulerTick(
     // tick, before this sweep) and a resume cannot both claim the same free slot.
     // Symmetric to STEP C's sweep-2 subtraction — the same double-fill class CTL-705
     // closed for resume-vs-new-work, now also closed for promotion-vs-resume.
-    let resumeSlots = Math.max(0, computeFreeSlots(maxParallel, liveCount) - promotedCount);
+    let resumeSlots = Math.max(0, computeFreeSlots(maxParallel, occupiedCount) - promotedCount);
     if (resumeSlots > 0) {
       // Collect parked tickets: in-flight tickets with status === PREEMPTED_STATUS.
       const parkedDescriptors = [];
@@ -4926,7 +4964,7 @@ export function schedulerTick(
   // CTL-705: reuse the tick-hoisted liveCount (a single `claude agents --json`
   // read) instead of re-shelling-out — `claude stop` does not deregister within
   // the same tick, so the count is stable since sweep 0.5.
-  const inFlightCount = liveCount;
+  const inFlightCount = occupiedCount; // CTL-1331: + queued delegate slot reservations
   // CTL-665: config-first ceiling — a committed executionCore.maxParallel
   // (threaded via `concurrency`) wins over state.json; clamped to the bounds.
   // CTL-705: subtract resumed slots (sweep 1.5) so resume and new-work don't


### PR DESCRIPTION
## CTL-1331 Phase A — move the board-health delegate's synchronous dispatch prelude off the tick

**Problem (CTL-1330).** The board-health delegate's LLM loop already runs async (`claude --bg`). What spikes the scheduler tick is the **synchronous provisioning + launch prelude** on the daemon event loop: `createWorktree` + `spawnSync(phase-agent-dispatch)` (15-min SIGKILL ceiling). On mini the `recovery-pass` pass is ~99% of the tick (p99 ≈ 3835ms).

**This PR (Phase A) lands the machinery INERT.** It adds an intent queue + a detached runner + the slot-reservation accounting, but **changes no behavior**: the `act` seam still dispatches synchronously, the runner is gated `CATALYST_DELEGATE_RUNNER=off`, and an **empty queue is a strict no-op** (`occupiedCount === liveCount`). Phase B flips the seam and live-validates on mini (where the recovery-pass p99 craters); Phase C removes the synchronous path.

### New modules (TDD)
- **`delegate-queue.mjs`** — `enqueueDelegateIntent` (3 idempotency no-ops: already-pending / live-worker / queue-full), `countQueuedDelegates` (the slot reservation), `gcDelegateIntents`, O_EXCL `claim`/`transition`/`reclaim` helpers. `delegate-intent/v1` schema; atomic tmp+rename.
- **`delegate-runner.mjs` / `delegate-runner-entry.mjs`** — the in-daemon timer (mirrors `worktree-refresh-timer`) that kicks a **detached, single-instance** drainer. `drainOnce` claims → re-checks supersede + free-slots → `defaultInvokeRecoveryPass` → emits `phase.dispatch.{requested,launched,failed}`. Never `spawnSync`, never `stdio:"ignore"`; the free-slot re-check **fails closed** on an unreadable live count.
- **`recovery.mjs`** — `appendDispatchEnqueuedEvent` (`phase.dispatch.enqueued`).
- **`config.mjs`** — `readDelegateRunnerConfig` + governance queue-depth surfacing.

### Integration (scheduler / daemon)
- **`scheduler.mjs`** — `occupiedCount = liveCount + countQueuedDelegates`, GC each tick, threaded into the board-health capacity, promotion, new-work, resume, and `inFlightCount` gates as **injectable seams**. A queued/claimed delegate reserves a slot its `claude --bg` hasn't filled yet, so the tick can't over-admit real work into it. The reservation **only ever lowers `freeSlots`** → over-dispatch past `maxParallel` is structurally impossible (design §3b, conservative-only).
- **`daemon.mjs`** — start/stop the runner timer, gated off by default.

### Tests
- **81 new unit tests** across 4 CI-gated files (queue 33, runner 23, config 20, slot-reservation property 5 — incl. the conservative-only invariant + the Phase-A inert property + the fail-closed branch). All four added to the `execution-core-tests.yml` allowlist.
- `scheduler.test.mjs` **504 / 2** — the 2 failures are the **pre-existing CTL-781** assignee tests (`applyAssignee`/`botWriteId`), unrelated to this change.
- Import graph (`bun build daemon.mjs --target=node`) ✅ · broker namespace parity ✅ · `integration-ctl-705` (freeSlots/liveCount sharing) ✅.

### Namespace
Emits only `phase.dispatch.{enqueued,requested,launched,failed}.<TICKET>` (the `dispatch` slot is the whitelisted exception) + `recovery.*` — **never** `phase.recovery-pass.*` (the worker emits completion). `appendDispatchEnqueuedEvent` adds `phase: "dispatch"` (already in the parity snapshot), so the broker namespace parity test passes unchanged.

Design: `thoughts/shared/plans/2026-06-24-ctl-1331-async-worker-design.md` (§8 staged migration A→B→C).

🤖 Generated with [Claude Code](https://claude.com/claude-code)