### PR TITLE
fix(dev): reclaim terminal-check trusts the read-replica regardless of age (crater the reclaim lap)

### DIFF
--- a/plugins/dev/scripts/execution-core/config.mjs
+++ b/plugins/dev/scripts/execution-core/config.mjs
@@ -1104,6 +1104,20 @@ function readPositiveIntEnv(raw, fallback) {
     : fallback;
 }
 
+// CTL-1331 follow-up: the gateway freshness window for the RECLAIM sweep's per-signal
+// Linear terminal-check (fetchTicketState). The default 60s GATEWAY_STATE_FRESH_MS is
+// far too tight for STUCK tickets: a ticket that isn't changing gets no webhooks, so
+// its read-replica descriptor ages past 60s and every reclaim tick falls back to a
+// slow `linearis` exec (the 3.8-5.3s reclaim-lap spike; ADV-1400's descriptor was 29h
+// stale). The reclaim terminal short-circuit is a best-effort optimization, and a
+// stale "non-terminal" descriptor is reliable — a real terminal transition would have
+// refreshed it via webhook — so the reclaim check TRUSTS the read-replica's last-known
+// state regardless of age. Operator-tunable; unset/0/invalid → effectively unbounded.
+export function readReclaimGatewayFreshMs(env = process.env) {
+  const v = Number(env.CATALYST_RECLAIM_GATEWAY_FRESH_MS);
+  return Number.isFinite(v) && v > 0 ? v : Number.MAX_SAFE_INTEGER;
+}
+
 export function readDelegateRunnerConfig(env = process.env) {
   const v = env.CATALYST_DELEGATE_RUNNER;
   let mode;

--- a/plugins/dev/scripts/execution-core/linear-query.test.mjs
+++ b/plugins/dev/scripts/execution-core/linear-query.test.mjs
@@ -915,6 +915,34 @@ function fakeGateway(descriptor) {
 const FRESH = () => new Date().toISOString();
 const STALE = () => new Date(Date.now() - 11 * 60_000).toISOString();
 
+describe("fetchTicketState — gateway freshness window (CTL-1331 reclaim fix)", () => {
+  test("a STALE descriptor is rejected at the default 60s window → falls to the live read", () => {
+    let execCalls = 0;
+    const exec = () => {
+      execCalls++;
+      return { code: 0, stdout: JSON.stringify({ state: { name: "Done" } }) };
+    };
+    const gateway = fakeGateway({ state: "Todo", removed: false, updatedAt: STALE() });
+    // default gatewayFreshMs (60s) → the 11-min-stale descriptor is rejected → live read.
+    expect(fetchTicketState("CTL-9", { exec, gateway })).toBe("Done");
+    expect(execCalls).toBe(1); // the slow `linearis` exec ran (the reclaim-lap spike)
+  });
+
+  test("a large gatewayFreshMs ACCEPTS a stale descriptor → ZERO live read (the reclaim fix)", () => {
+    let execCalls = 0;
+    const exec = () => {
+      execCalls++;
+      return { code: 0, stdout: JSON.stringify({ state: { name: "Done" } }) };
+    };
+    const gateway = fakeGateway({ state: "Todo", removed: false, updatedAt: STALE() });
+    // unbounded freshness → the stale read-replica descriptor is trusted → no exec.
+    expect(
+      fetchTicketState("CTL-9", { exec, gateway, gatewayFreshMs: Number.MAX_SAFE_INTEGER })
+    ).toBe("Todo");
+    expect(execCalls).toBe(0); // the slow `linearis` exec is NEVER reached
+  });
+});
+
 describe("classifyTicketResolution — gateway short-circuit (CTL-823)", () => {
   test("fresh + present + not-removed → exists with ZERO live reads", () => {
     const exec = fakeExec({ code: 0, stdout: "{}" });

--- a/plugins/dev/scripts/execution-core/scheduler.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.mjs
@@ -245,7 +245,7 @@ import {
 // to production deps at the unstuckSweep wiring point below. Wiring this does NOT
 // flip enforce on — the mode gate stays at its safe 'off' default (ADR-023).
 import { buildUnstuckActSeams } from "./unstuck-act-seams.mjs";
-import { readUnstuckSweepConfig, readRecoveryPassConfig, readBoardHealthConfig, isThrottled } from "./config.mjs";
+import { readUnstuckSweepConfig, readRecoveryPassConfig, readBoardHealthConfig, readReclaimGatewayFreshMs, isThrottled } from "./config.mjs";
 // CTL-558: the deterministic Linear status/label write seam. The whole module
 // is injected as `writeStatus` so tests pass fakes; production uses the real
 // module (best-effort — every write swallows its own failures).
@@ -3928,6 +3928,11 @@ export function schedulerTick(
   // neither pipeline-complete (monitor-deploy done/skipped) nor
   // failed/stalled/aborted" — exactly the set this sweep cares about.
   const inFlightTickets = listInFlightTickets(orchDir);
+  // CTL-1331 follow-up: the reclaim terminal-check trusts the read-replica's
+  // last-known state regardless of age (default unbounded) so STUCK tickets — whose
+  // descriptors age past the 60s default because they get no webhooks — stop forcing
+  // a per-tick `linearis` exec (the reclaim-lap spike). Resolved once per tick.
+  const reclaimGatewayFreshMs = readReclaimGatewayFreshMs();
 
   // CTL-736: the reclaim death trigger is the authoritative LOCAL state.json
   // lifecycle (jobLifecycle), so the reclaim sweep no longer reads the `claude
@@ -3988,7 +3993,8 @@ export function schedulerTick(
       const reclaimOpts = {
         repoRoot,
         cache,
-        fetchState: (id, o = {}) => fetchTicketState(id, { ...o, gateway }),
+        fetchState: (id, o = {}) =>
+          fetchTicketState(id, { ...o, gateway, gatewayFreshMs: reclaimGatewayFreshMs }),
         prAdapter,
         // CTL-809 — thread the warm agents snapshot so the reclaim alive-branch can
         // cross-check a jobLifecycle-alive-but-process-gone ghost (getAgentsCached is


### PR DESCRIPTION
Eliminates the per-tick `linearis` exec that spikes the scheduler **reclaim lap** to 3.8–5.3s on mini.

**Root cause (diagnosed live):** the reclaim-dead-work sweep does a per-signal `fetchTicketState` terminal-check, which rejects any read-replica (gateway) descriptor older than `GATEWAY_STATE_FRESH_MS` (60s) and falls back to a slow `linearis issues read` exec. Stuck tickets get no webhooks, so their descriptors age past 60s (`ADV-1400` was **29h stale**) → every tick execs `linearis` per stuck signal.

**Fix:** the reclaim terminal short-circuit is a best-effort optimization that **never kills a live worker** (the death trigger is the local `state.json` jobLifecycle). A stale *non-terminal* descriptor is reliable (a real terminal transition would have refreshed it via webhook; a non-changing ticket's last-known state IS its current state). So the reclaim check now **trusts the read-replica's last-known state regardless of age** — `gatewayFreshMs = readReclaimGatewayFreshMs()` (default unbounded; `CATALYST_RECLAIM_GATEWAY_FRESH_MS` to tune). New-work admission keeps the 60s default.

**Safety:** low blast radius (terminal-short-circuit path only). New `linear-query` test: a stale gateway descriptor is rejected at 60s but accepted at a large window with **zero exec**. 151 query/scheduler tests green; import graph clean.

Pairs with #2367 (the lap split) — `reclaim` p99 should crater after deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)