### PR TITLE
feat(dev): wire Serena code-understanding MCP into research/analysis agents

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,8 @@ website/.astro/
 
 # Plugin-local tooling (orch-monitor)
 plugins/dev/scripts/orch-monitor/node_modules/
+
+# Serena (code-understanding MCP): version project.yml + memories/, ignore per-machine cache/overrides
+.serena/cache/
+.serena/project.local.yml
+.serena/logs/

--- a/.serena/.gitignore
+++ b/.serena/.gitignore
@@ -1,0 +1,2 @@
+/cache
+/project.local.yml

--- a/.serena/memories/codebase_map.md
+++ b/.serena/memories/codebase_map.md
@@ -1,0 +1,54 @@
+# Catalyst — codebase map
+
+Orientation for coding agents. Canonical detail lives in `AGENTS.md` and `docs/architecture.md`;
+read those for depth. This map is the fast "where is X" index.
+
+## What this repo is
+A portable collection of AI dev **agents / skills / workflows** shipped as **plugins**, *and* a
+working orchestration runtime that dogfoods them. Source is markdown + bash + TypeScript/JS. There is
+no build step for the plugins themselves; the orchestration runtime under
+`plugins/dev/scripts/` is real code.
+
+## Top-level layout
+- `plugins/` — plugin source (edit here; surfaced to agents via `.claude/` symlinks)
+  - `plugins/dev/` — the core dev plugin
+    - `agents/` — subagent definitions (codebase-locator, codebase-analyzer, codebase-pattern-finder, external-research, …)
+    - `skills/` — workflow skills (research-codebase, create-plan, implement-plan, validate-*, and the `phase-*` orchestrator phases)
+    - `scripts/` — the runtime (see below)
+    - `templates/` — global-state.json, global-event.json schemas
+  - `plugins/pm/`, `plugins/meta/`, `plugins/legacy/`, `plugins/analytics/`, `plugins/debugging/`, `plugins/foundry/` — other plugins
+- `docs/` — `architecture.md`, `orchestrator-overview.md`, `adrs.md`, `releases.md`
+- `AGENTS.md` — portable, tool-agnostic source of truth (CLAUDE.md is a thin `@AGENTS.md` bridge)
+- `website/` — Astro docs site (`website/src/content/docs/…`, esp. `reference/configuration.md`)
+- `thoughts/` — knowledge store (learnings, retros, plans, research); git-backed, not source
+- `.catalyst/` — project config (`config.json`) + per-worktree workflow state
+
+## The runtime (`plugins/dev/scripts/`)
+- `broker/` — broker daemon. `router.mjs` (event routing, `shouldSkipEvent` self-filter),
+  `namespace-contract.mjs` (the `filter.*` / `broker.daemon.*` / `phase.*` namespace rules)
+- `execution-core/` — the scheduling daemon. `daemon.mjs` (tick loop, Linear mirror), `registry.mjs`
+  (team→repo→eligibleQuery), `hrw.mjs` + `cluster-claim.mjs` (multi-host ownership), reaper, worktree-refresh
+- `orch-monitor/` — web dashboard + node-aware read-model. `filter-state.db` (webhook-synced Linear
+  read replica — use for reads, not linearis), `ui/` (React app), `__tests__/` (contract suites)
+- `lib/` — shared bash libs: `worktree-rebase.sh`, `phase-sequence.sh`, `draft-pr.sh`, `emit-reap-intent.sh`, …
+- `phase-agent-dispatch` — dispatches one `claude --bg` job per pipeline phase
+- `catalyst-*.sh` — CLIs: `catalyst-state.sh`, `catalyst-db.sh`, `catalyst-session.sh`, `catalyst-comms`, `catalyst-events`
+
+## Key concepts (see `thoughts/shared/CONCEPTS.md`)
+- **Unified event log** `~/catalyst/events/YYYY-MM.jsonl` — append-only backbone; all processes read/write it (NOT in repo)
+- **Phase-agent pipeline** — 10 phases: triage → research → plan → implement → verify → review → pr → monitor-merge → monitor-deploy → teardown
+- **dispatchMode** — `phase-agents` (default) / `execution-core` (daemon) / `oneshot-legacy` (fallback); set in `.catalyst/config.json`
+- **Signal files** — `workers/<TICKET>/phase-*.json` are authoritative per-worker state
+- **Durable state** — `~/catalyst/catalyst.db` (SQLite, WAL), `~/catalyst/state.json` (active-orchestrator summary) — runtime, not in repo
+
+## Build / test / verify
+- Plugins (markdown/bash): no build. Reload by restarting the agent session.
+- orch-monitor: `cd plugins/dev/scripts/orch-monitor && bun test` (verify BOTH `ui/` and parent package)
+- TypeScript changes: the `/catalyst-dev:validate-type-safety` gate (tsc + reward-hacking scan + tests + lint)
+- CI gates on `main`: agents-md-gate, docs-gate, audit-references, gitleaks, quality (bun test), CodeQL, Cloudflare Pages
+
+## Conventions
+- Commits: `feat(dev):` / `fix(pm):` / `chore(meta):` etc. (scopes: dev, pm, meta, analytics, debugging, …)
+- main stays on main; every change via worktree → PR. `main` is gated by a ruleset that requires
+  all review threads (incl. the `chatgpt-codex-connector` Codex bot) resolved.
+- Agents are documentarians: describe what EXISTS, don't critique or suggest unless asked.

--- a/.serena/project.yml
+++ b/.serena/project.yml
@@ -1,0 +1,145 @@
+# the name by which the project can be referenced within Serena
+project_name: "catalyst"
+
+
+# list of languages for which language servers are started; choose from:
+#   al                  angular             ansible             bash                clojure
+#   cpp                 cpp_ccls            crystal             csharp              csharp_omnisharp
+#   dart                elixir              elm                 erlang              fortran
+#   fsharp              go                  groovy              haskell             haxe
+#   hlsl                html                java                json                julia
+#   kotlin              lean4               lua                 luau                markdown
+#   matlab              msl                 nix                 ocaml               pascal
+#   perl                php                 php_phpactor        powershell          python
+#   python_jedi         python_ty           r                   rego                ruby
+#   ruby_solargraph     rust                scala               scss                solidity
+#   svelte              swift               systemverilog       terraform           toml
+#   typescript          typescript_vts      vue                 yaml                zig
+#   (This list may be outdated. For the current list, see values of Language enum here:
+#   https://github.com/oraios/serena/blob/main/src/solidlsp/ls_config.py
+#   For some languages, there are alternative language servers, e.g. csharp_omnisharp, ruby_solargraph.)
+# Note:
+#   - For C, use cpp
+#   - For JavaScript, use typescript
+#   - For Angular projects, use angular (subsumes typescript+html; requires `npm install` in the project root)
+#   - For Svelte projects, use svelte (subsumes typescript/javascript for .svelte projects; requires npm)
+#   - For SCSS / Sass / plain CSS, use scss (some-sass-language-server handles all three)
+#   - For Free Pascal/Lazarus, use pascal
+# Special requirements:
+#   Some languages require additional setup/installations.
+#   See here for details: https://oraios.github.io/serena/01-about/020_programming-languages.html#language-servers
+# When using multiple languages, the first language server that supports a given file will be used for that file.
+# The first language is the default language and the respective language server will be used as a fallback.
+# Note that when using the JetBrains backend, language servers are not used and this list is correspondingly ignored.
+languages:
+- typescript
+- bash
+
+# the encoding used by text files in the project
+# For a list of possible encodings, see https://docs.python.org/3.11/library/codecs.html#standard-encodings
+encoding: "utf-8"
+
+# whether to use project's .gitignore files to ignore files
+ignore_all_files_in_gitignore: true
+
+# list of additional paths to ignore in this project.
+# Same syntax as gitignore, so you can use * and **.
+# Note: global ignored_paths from serena_config.yml are also applied additively.
+ignored_paths:
+- ".claude/worktrees"
+- ".serena/cache"
+- "thoughts"
+- "mockups"
+- "website/.astro"
+- ".trunk"
+
+# whether the project is in read-only mode
+# If set to true, all editing tools will be disabled and attempts to use them will result in an error
+# Added on 2025-04-18
+read_only: true
+
+# initial prompt for the project. It will always be given to the LLM upon activating the project
+# (contrary to the memories, which are loaded on demand).
+initial_prompt: |
+  Catalyst repo: portable AI dev agents/skills/workflows shipped as plugins, plus a working
+  orchestration runtime (broker, execution-core daemon, orch-monitor). For architecture and
+  conventions, read AGENTS.md and docs/architecture.md before broad exploration. Prefer Serena's
+  get_symbols_overview / find_symbol / find_referencing_symbols over raw grep for symbol-level
+  questions; call read_memory("codebase_map") for the directory map.
+
+# list of mode names that are to be activated by default, overriding the setting in the global configuration.
+# The full set of modes to be activated is base_modes (from global config) + default_modes + added_modes.
+# If the setting is undefined/empty, the default_modes from the global configuration (serena_config.yml) apply.
+# Otherwise, this overrides the setting from the global configuration (serena_config.yml).
+# Therefore, you can set this to [] if you do not want the default modes defined in the global config to apply
+# for this project.
+# This setting can, in turn, be overridden by CLI parameters (--mode).
+# See https://oraios.github.io/serena/02-usage/050_configuration.html#modes
+default_modes:
+
+# list of mode names to be activated additionally for this project, e.g. ["query-projects"]
+# The full set of modes to be activated is base_modes (from global config) + default_modes + added_modes.
+# See https://oraios.github.io/serena/02-usage/050_configuration.html#modes
+added_modes:
+
+# list of tool names to exclude.
+# This extends the existing exclusions (e.g. from the global configuration)
+# Find the list of tools here: https://oraios.github.io/serena/01-about/035_tools.html
+excluded_tools: []
+
+# list of tools to include that would otherwise be disabled (particularly optional tools that are disabled by default).
+# This extends the existing inclusions (e.g. from the global configuration).
+# Find the list of tools here: https://oraios.github.io/serena/01-about/035_tools.html
+included_optional_tools: []
+
+# fixed set of tools to use as the base tool set (if non-empty), replacing Serena's default set of tools.
+# This cannot be combined with non-empty excluded_tools or included_optional_tools.
+# Find the list of tools here: https://oraios.github.io/serena/01-about/035_tools.html
+fixed_tools: []
+
+# time budget (seconds) per tool call for the retrieval of additional symbol information
+# such as docstrings or parameter information.
+# This overrides the corresponding setting in the global configuration; see the documentation there.
+# If null or missing, use the setting from the global configuration.
+symbol_info_budget:
+
+# The language backend to use for this project.
+# If not set, the global setting from serena_config.yml is used.
+# Valid values: LSP, JetBrains
+# Note: the backend is fixed at startup. If a project with a different backend
+# is activated post-init, an error will be returned.
+language_backend:
+
+# line ending convention to use when writing source files.
+# Possible values: unset (use global setting), "lf", "crlf", or "native" (platform default)
+# This does not affect Serena's own files (e.g. memories and configuration files), which always use native line endings.
+line_ending:
+
+# list of regex patterns which, when matched, mark a memory entry as read‑only.
+# Extends the list from the global configuration, merging the two lists.
+read_only_memory_patterns: []
+
+# list of regex patterns for memories to completely ignore.
+# Matching memories will not appear in list_memories or activate_project output
+# and cannot be accessed via read_memory or write_memory.
+# To access ignored memory files, use the read_file tool on the raw file path.
+# Extends the list from the global configuration, merging the two lists.
+# Example: ["_archive/.*", "_episodes/.*"]
+ignored_memory_patterns: []
+
+# advanced configuration option allowing to configure language server-specific options.
+# Maps the language key to the options.
+# Have a look at the docstring of the constructors of the LS implementations within solidlsp (e.g., for C# or PHP) to see which options are available.
+# No documentation on options means no options are available.
+ls_specific_settings: {}
+
+# list of additional workspace folder paths for cross-package reference support (e.g. in monorepos).
+# Paths can be absolute or relative to the project root.
+# Each folder is registered as an LSP workspace folder, enabling language servers to discover
+# symbols and references across package boundaries.
+# Currently supported for: TypeScript.
+# Example:
+#   additional_workspace_folders:
+#     - ../sibling-package
+#     - ../shared-lib
+additional_workspace_folders: []

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -67,6 +67,31 @@ workflow relationships. Agent (subagent) references always use the full
   (CTL-831): `ticket/<date>.md` cross-ticket retros (`catalyst-dev:ticket-retro`);
   `estimate/<YYYY-WW>-compound-log.md` per-PR estimation actuals (`catalyst-dev:compound-estimate`).
 
+## Code Understanding (Serena)
+
+Coding agents orient on this codebase through **Serena** — a self-hosted, local, LSP-backed MCP
+server that provides semantic code retrieval (the replacement for the removed DeepWiki MCP). It lets
+agents answer "where does X live / how is Y wired / who calls Z" in a few precise calls instead of
+many broad `Grep`s, getting up to speed with far fewer tool calls and tokens.
+
+- **Install (per machine):** `uv tool install -p 3.13 serena-agent`, then register it as a
+  **user-scope MCP server** that runs `serena start-mcp-server`. Use the absolute path to the
+  `serena` binary so background worker jobs with a restricted `PATH` can launch it, and run it
+  headless on servers. It connects with no startup project and activates lazily. The exact
+  per-agent registration command lives in the bridge file.
+- **Versioned config (committed):** `.serena/project.yml` (languages `typescript` + `bash`,
+  `read_only: true`, ignores the harness worktree dir / `thoughts` / build output, plus an
+  `initial_prompt` pointer) and
+  `.serena/memories/codebase_map.md` (the directory map agents read via `read_memory("codebase_map")`).
+  The per-machine symbol cache `.serena/cache/` is gitignored; build it with `serena project index`.
+- **Wiring:** the research/analysis agents (`codebase-analyzer`, `codebase-locator`,
+  `codebase-pattern-finder`) and skills (`research-codebase`, `create-plan`, `phase-research`,
+  `phase-plan`) grant the read-only `mcp__serena__*` tools; `research-codebase` Step 0 activates the
+  project, reads the `codebase_map` memory, and maps symbols before spawning sub-agents.
+- **Use it:** `activate_project` (repo root / `.`) → `list_memories` / `read_memory` →
+  `get_symbols_overview`, `find_symbol`, `find_referencing_symbols`, `search_for_pattern`. It is
+  read-only — editing stays with the implement agents' `Edit`/`Write`.
+
 ## Commit Conventions
 
 - `feat(dev): add new skill` — catalyst-dev minor bump

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,6 +19,22 @@ stays tool-agnostic.)
 - Phase-agent workers run as `claude --bg` jobs; the legacy oneshot mode runs a long-lived
   `claude -p /catalyst-legacy:oneshot` per ticket.
 
+### Code understanding (Serena MCP)
+
+Serena is wired into the research/analysis agents for semantic code retrieval — see
+`AGENTS.md` → "Code Understanding (Serena)" for what it is and how it's used. Register it
+once per machine as a **user-scope** MCP (the absolute `serena` path lets restricted-`PATH`
+`claude --bg` phase-agent workers launch it; the headless flags keep it browser-free on servers):
+
+```bash
+uv tool install -p 3.13 serena-agent
+claude mcp add --scope user serena -- "$HOME/.local/bin/serena" start-mcp-server \
+  --context claude-code --enable-web-dashboard False --enable-gui-log-window False
+```
+
+It connects with no startup project and activates lazily, so a fresh session connects fast and pays
+the language-server startup cost only when an agent first calls `activate_project`.
+
 ### Always-loaded reference docs
 
 `@`-imports are a Claude Code feature and load the file in full at session start (they do **not**

--- a/plugins/dev/agents/codebase-analyzer.md
+++ b/plugins/dev/agents/codebase-analyzer.md
@@ -6,7 +6,10 @@ description:
   the better! :)
 tools:
   Read, Grep, Glob, Bash(ls *), mcp__context7__get_library_docs,
-  mcp__context7__resolve_library_id
+  mcp__context7__resolve_library_id, mcp__serena__activate_project, mcp__serena__list_memories,
+  mcp__serena__read_memory, mcp__serena__get_symbols_overview, mcp__serena__find_symbol,
+  mcp__serena__find_referencing_symbols, mcp__serena__search_for_pattern, mcp__serena__find_file,
+  mcp__serena__list_dir
 model: sonnet
 version: 1.0.0
 ---
@@ -45,6 +48,13 @@ trace data flow, and explain technical workings with precise file:line reference
    - Find integration points between systems
 
 ## Analysis Strategy
+
+**Navigate with Serena when available.** If the `mcp__serena__*` tools are present (Catalyst's local
+code-understanding MCP), prefer them over raw `Grep` for symbol-level work — they are precise and
+cheaper in tool calls/tokens: `get_symbols_overview` to map a file's top-level symbols,
+`find_symbol` to jump straight to a definition, and `find_referencing_symbols` to trace callers/data
+flow. Fall back to `Grep`/`Read` when Serena is unavailable or for non-symbol text searches. If
+Serena reports no active project, call `activate_project` with the repo root (`.`) first.
 
 ### Step 1: Read Entry Points
 

--- a/plugins/dev/agents/codebase-locator.md
+++ b/plugins/dev/agents/codebase-locator.md
@@ -4,7 +4,9 @@ description:
   Locates files, directories, and components relevant to a feature or task. Call `codebase-locator`
   with human language prompt describing what you're looking for. Basically a "Super Grep/Glob/LS
   tool" — Use it if you find yourself desiring to use one of these tools more than once.
-tools: Grep, Glob, Bash(ls *)
+tools: Grep, Glob, Bash(ls *), mcp__serena__activate_project, mcp__serena__find_symbol,
+  mcp__serena__find_file, mcp__serena__list_dir, mcp__serena__get_symbols_overview,
+  mcp__serena__search_for_pattern
 model: haiku
 version: 1.0.0
 ---

--- a/plugins/dev/agents/codebase-pattern-finder.md
+++ b/plugins/dev/agents/codebase-pattern-finder.md
@@ -7,7 +7,9 @@ description:
   the location of files, it will also give you code details!
 tools:
   Grep, Glob, Read, Bash(ls *), mcp__context7__get_library_docs,
-  mcp__context7__resolve_library_id, WebSearch, WebFetch
+  mcp__context7__resolve_library_id, WebSearch, WebFetch, mcp__serena__activate_project,
+  mcp__serena__get_symbols_overview, mcp__serena__find_symbol, mcp__serena__find_referencing_symbols,
+  mcp__serena__search_for_pattern, mcp__serena__find_file, mcp__serena__list_dir
 model: sonnet
 version: 1.0.0
 ---

--- a/plugins/dev/skills/create-plan/SKILL.md
+++ b/plugins/dev/skills/create-plan/SKILL.md
@@ -6,7 +6,10 @@ description:
   wants a structured TDD implementation plan before writing code. Works best after
   /research-codebase."
 disable-model-invocation: false
-allowed-tools: Read, Write, Grep, Glob, Task, TodoWrite, Bash
+allowed-tools: Read, Write, Grep, Glob, Task, TodoWrite, Bash, mcp__serena__activate_project,
+  mcp__serena__list_memories, mcp__serena__read_memory, mcp__serena__get_symbols_overview,
+  mcp__serena__find_symbol, mcp__serena__find_referencing_symbols, mcp__serena__search_for_pattern,
+  mcp__serena__find_file, mcp__serena__list_dir
 version: 1.0.0
 ---
 

--- a/plugins/dev/skills/phase-plan/SKILL.md
+++ b/plugins/dev/skills/phase-plan/SKILL.md
@@ -16,6 +16,15 @@ allowed-tools:
   - Glob
   - Task
   - Bash
+  - mcp__serena__activate_project
+  - mcp__serena__list_memories
+  - mcp__serena__read_memory
+  - mcp__serena__get_symbols_overview
+  - mcp__serena__find_symbol
+  - mcp__serena__find_referencing_symbols
+  - mcp__serena__search_for_pattern
+  - mcp__serena__find_file
+  - mcp__serena__list_dir
 ---
 
 # phase-plan

--- a/plugins/dev/skills/phase-research/SKILL.md
+++ b/plugins/dev/skills/phase-research/SKILL.md
@@ -16,6 +16,15 @@ allowed-tools:
   - Glob
   - Task
   - Bash
+  - mcp__serena__activate_project
+  - mcp__serena__list_memories
+  - mcp__serena__read_memory
+  - mcp__serena__get_symbols_overview
+  - mcp__serena__find_symbol
+  - mcp__serena__find_referencing_symbols
+  - mcp__serena__search_for_pattern
+  - mcp__serena__find_file
+  - mcp__serena__list_dir
 ---
 
 # phase-research

--- a/plugins/dev/skills/research-codebase/SKILL.md
+++ b/plugins/dev/skills/research-codebase/SKILL.md
@@ -7,7 +7,10 @@ description:
   thoughts/shared/research/ with file:line references."
 disable-model-invocation: false
 allowed-tools:
-  Read, Write, Grep, Glob, Task, TodoWrite, Bash
+  Read, Write, Grep, Glob, Task, TodoWrite, Bash,
+  mcp__serena__activate_project, mcp__serena__list_memories, mcp__serena__read_memory,
+  mcp__serena__get_symbols_overview, mcp__serena__find_symbol, mcp__serena__find_referencing_symbols,
+  mcp__serena__search_for_pattern, mcp__serena__find_file, mcp__serena__list_dir
 version: 1.0.0
 ---
 
@@ -70,6 +73,26 @@ on single-host setups and never blocks research if offline:
 ```
 
 ## Steps to Follow After Receiving the Research Query
+
+### Step 0: Orient with Serena (ALWAYS attempt this first)
+
+Before reading files or spawning sub-agents, get a fast semantic map of the codebase from Serena —
+Catalyst's self-hosted, local code-understanding MCP (the DeepWiki replacement). This is free and
+usually answers "where does X live / how is Y wired" in one call instead of many `Grep`s, so your
+sub-agent prompts come out specific rather than exploratory.
+
+**Prerequisite check** — only do this if the `mcp__serena__*` tools are available (Serena MCP is
+installed). If they are not, skip straight to Step 1 — do not retry or warn the user.
+
+1. **Activate the project** so the language servers target this repo:
+   `mcp__serena__activate_project` with the repo root (the current working directory, or `.`).
+2. **Read the persisted orientation**: `mcp__serena__list_memories`, then
+   `mcp__serena__read_memory("codebase_map")` for the directory map and key concepts.
+3. **Map the relevant area** instead of broad grepping: `mcp__serena__get_symbols_overview` on a key
+   file, `mcp__serena__find_symbol` to jump to a definition, and
+   `mcp__serena__find_referencing_symbols` to see its callers.
+
+Serena's results are a starting point — always verify against live code via the sub-agents below.
 
 ### Step 1: Read any directly mentioned files first
 

--- a/plugins/meta/skills/validate-frontmatter/SKILL.md
+++ b/plugins/meta/skills/validate-frontmatter/SKILL.md
@@ -426,6 +426,15 @@ Claude Code provides these tools:
 - `WebFetch` - Fetch web content
 - `WebSearch` - Search the web
 
+### Code Understanding (Serena MCP)
+
+- `mcp__serena__activate_project` - Activate the repo so language servers target it
+- `mcp__serena__list_memories` / `mcp__serena__read_memory` - Read persisted project orientation
+- `mcp__serena__get_symbols_overview` - Map a file's top-level symbols
+- `mcp__serena__find_symbol` - Jump to a symbol's definition (semantic, not grep)
+- `mcp__serena__find_referencing_symbols` - Find callers/references of a symbol
+- `mcp__serena__search_for_pattern` / `mcp__serena__find_file` / `mcp__serena__list_dir` - Search/list
+
 ### Linear Integration
 
 - `linear_get_ticket` - Get Linear ticket details


### PR DESCRIPTION
## Why

DeepWiki (removed in #2364) gave our coding agents codebase orientation — "where does X live / how is Y wired" — so they got up to speed fast. This restores that capability with **[Serena](https://github.com/oraios/serena)**: a self-hosted, local, LSP-backed MCP server. Free, no metered SaaS, runs on our own machines.

**Goal:** agents dive into a codebase and orient with **far fewer tool calls / tokens** than blind `Grep`-ing.

## What

**Installed + connected** (outside this PR, user-scope MCP, absolute `serena` path so the restricted-`PATH` `claude --bg` phase-agent workers can launch it):
- ✅ laptop, ✅ **mini**, ✅ **mini-2** (`uv tool install -p 3.13 serena-agent` → `serena start-mcp-server --context claude-code`, headless)

**This PR wires it into the pipeline:**
- **`.serena/project.yml`** (versioned) — languages `typescript`+`bash`, `read_only: true`, ignores `.claude/worktrees` (a symlink loop that crashes indexing) + `thoughts`/build dirs, and an `initial_prompt` that points agents at AGENTS.md / architecture.md and nudges Serena-over-grep.
- **`.serena/memories/codebase_map.md`** (versioned) — the directory map + key concepts agents read via `read_memory("codebase_map")`. Shared across all worktrees + fleet machines, so no per-session re-onboarding.
- **Tool grants** — read-only `mcp__serena__*` tools (`activate_project`, `list_memories`/`read_memory`, `get_symbols_overview`, `find_symbol`, `find_referencing_symbols`, `search_for_pattern`, `find_file`, `list_dir`) added to `codebase-analyzer`/`codebase-locator`/`codebase-pattern-finder` and `research-codebase`/`create-plan`/`phase-research`/`phase-plan`.
- **`research-codebase` Step 0 "Orient with Serena"** — activate the project, read the `codebase_map` memory, map symbols, *then* spawn sub-agents (mirrors the old DeepWiki Step 0).
- **Docs** — vendor-neutral section in `AGENTS.md`; exact registration command in `CLAUDE.md` (bridge); Serena tools listed in `validate-frontmatter`.

## Design notes

- **Read-only**: Serena's editing tools are disabled (`read_only: true`); editing stays with the implement agents' `Edit`/`Write`. Serena can never dirty the repo.
- **Lazy activation**: the MCP connects with no startup project, so a fresh session connects fast and pays the LSP-startup cost only when an agent first calls `activate_project` — important for the high-churn fleet.
- **Graceful absence**: every agent's Step 0 checks `mcp__serena__*` availability and falls back to `Grep` if Serena isn't installed on a machine.

## Verification

- `serena project health-check` on this repo: **passed, all tools working** (typescript + bash LSPs, `find_referencing_symbols` + `search_for_pattern` across 3,800 files)
- All edited frontmatter parses as valid YAML; `agents-md-gate` passes (AGENTS.md kept vendor-neutral — the `claude mcp add` command lives in CLAUDE.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)