### PR TITLE
fix(dev): CTL-1339 — cap the hot per-signal linearis read so a 429 stall can't wedge the scheduler tick

### DIFF
--- a/plugins/dev/scripts/execution-core/linear-breaker.mjs
+++ b/plugins/dev/scripts/execution-core/linear-breaker.mjs
@@ -87,13 +87,17 @@ export const linearBreaker = createLinearBreaker();
 // synthetic non-zero result (stderr "circuit-open") WITHOUT spawning. After a
 // real spawn: a 429 opens the breaker; a clean exit (code 0) closes it. A
 // non-429 failure leaves the breaker untouched (it is not a rate-limit signal).
+// CTL-1339: a 3rd `opts` arg (e.g. { timeoutMs }) is forwarded to the inner
+// rawExec untouched — opt-in per-call wall-clock cap for the hot terminal reads.
+// The breaker logic is unchanged; an open breaker still short-circuits before
+// any spawn (so the cap is moot when open).
 export function withBreaker(rawExec, { breaker = linearBreaker, now = Date.now } = {}) {
-  return (cmd, args) => {
+  return (cmd, args, opts) => {
     const t = now();
     if (breaker.isOpen(t)) {
       return { code: 1, stdout: "", stderr: "circuit-open" };
     }
-    const res = rawExec(cmd, args);
+    const res = rawExec(cmd, args, opts);
     if (res.code !== 0 && isRateLimitError(res.stderr)) {
       breaker.recordRateLimited(t);
     } else if (res.code === 0) {

--- a/plugins/dev/scripts/execution-core/linear-breaker.test.mjs
+++ b/plugins/dev/scripts/execution-core/linear-breaker.test.mjs
@@ -143,4 +143,31 @@ describe("withBreaker", () => {
     exec("linearis", ["x"]);
     expect(breaker.isOpen()).toBe(false);
   });
+
+  // CTL-1339: the opt-in per-call wall-clock cap rides a 3rd `opts` arg that the
+  // wrapper must forward to the inner rawExec untouched.
+  test("forwards a 3rd opts arg (e.g. { timeoutMs }) to the inner rawExec", () => {
+    const breaker = createLinearBreaker({ logger: silentLogger });
+    const calls = [];
+    const raw = (...all) => {
+      calls.push(all);
+      return { code: 0, stdout: "", stderr: "" };
+    };
+    const exec = withBreaker(raw, { breaker });
+    exec("linearis", ["issues", "read", "CTL-1"], { timeoutMs: 8000 });
+    expect(calls).toHaveLength(1);
+    expect(calls[0]).toEqual(["linearis", ["issues", "read", "CTL-1"], { timeoutMs: 8000 }]);
+  });
+
+  test("omitting the opts arg forwards undefined (uncapped, as before)", () => {
+    const breaker = createLinearBreaker({ logger: silentLogger });
+    const calls = [];
+    const raw = (...all) => {
+      calls.push(all);
+      return { code: 0, stdout: "", stderr: "" };
+    };
+    const exec = withBreaker(raw, { breaker });
+    exec("linearis", ["issues", "list"]);
+    expect(calls[0][2]).toBeUndefined();
+  });
 });

--- a/plugins/dev/scripts/execution-core/linear-query.mjs
+++ b/plugins/dev/scripts/execution-core/linear-query.mjs
@@ -14,6 +14,26 @@ import { withAuthRemint, linearReminter, isBatchAuthError } from "./linear-remin
 // set without pagination (the reconcile poll runs every 10 min anyway).
 const DEFAULT_LIMIT = 200;
 
+// CTL-1339: per-call wall-clock cap for the HOT per-signal terminal reads
+// (phantom-sweep classifyTicketResolution + recovery/reclaim fetchTicketState tier-3).
+// A linearis read that stalls under a Linear 429 would otherwise block the
+// synchronous scheduler tick its full ~30s wall-clock. Timed-out read fails SAFE
+// (-> code 127 -> classifyTicketResolution "unknown" / fetchTicketState null).
+// env CATALYST_LINEARIS_TERMINAL_TIMEOUT_MS: default 8000; "0" disables (no cap).
+// Opt-in ONLY: applied to exactly the two terminal reads, NOT the eligible-list
+// poll (a blanket cap would trip false monitor.reconcile.failing alerts) or any
+// other linearis call.
+// parseTerminalTimeoutMs — pure env-parse, exported for unit coverage of the
+// default/disable contract (8000 default; "0" → undefined = no cap).
+export function parseTerminalTimeoutMs(raw) {
+  if (raw === "0") return undefined;
+  const n = Number(raw);
+  return n > 0 ? n : 8000;
+}
+const LINEARIS_TERMINAL_READ_TIMEOUT_MS = parseTerminalTimeoutMs(
+  process.env.CATALYST_LINEARIS_TERMINAL_TIMEOUT_MS,
+);
+
 // CTL-784: batched multi-issue read. The Linear GraphQL endpoint, the named
 // operation (so the proxy audit can tell a batch read apart from the per-ticket
 // `GetIssueByIdentifier` storm), and the chunk ceiling (Linear caps a page at
@@ -62,8 +82,19 @@ export function buildLinearisArgs(query) {
 
 // rawExec — thin spawnSync wrapper. Injected in tests so no test ever
 // shells out to the real linearis CLI or touches the network.
-function rawExec(cmd, args) {
-  const res = spawnSync(cmd, args, { encoding: "utf8" });
+// CTL-1339: opt-in per-call wall-clock cap. `timeoutMs` is threaded through the
+// exec chain (withBreaker → withAuthRemint → rawExec) and applied ONLY by the
+// hot per-signal terminal reads; every other call omits it (uncapped, as today).
+// On a `timeout` fire spawnSync sets res.error (ETIMEDOUT) + res.status === null,
+// so the existing res.error branch returns { code: 127 } — the same fail-safe a
+// missing binary produces, which callers already treat as unknown/null.
+function rawExec(cmd, args, { timeoutMs } = {}) {
+  const opts = { encoding: "utf8" };
+  if (typeof timeoutMs === "number" && timeoutMs > 0) {
+    opts.timeout = timeoutMs;
+    opts.killSignal = "SIGKILL";
+  }
+  const res = spawnSync(cmd, args, opts);
   if (res.error) {
     return { code: 127, stdout: "", stderr: res.error.message };
   }
@@ -73,6 +104,12 @@ function rawExec(cmd, args) {
     stderr: res.stderr ?? "",
   };
 }
+
+// CTL-1339: test-only seam. rawExec is module-private (every prod caller injects
+// `exec`), but the integration test must drive the REAL spawnSync path to prove
+// the `timeout` option is actually wired (all stub tests bypass rawExec). Not for
+// production use — callers go through defaultExec/withBreaker.
+export const __rawExecForTest = rawExec;
 
 // defaultExec — rawExec behind the CTL-679 process-wide rate-limit breaker. The
 // eligible poll and per-ticket reads short-circuit without spawning linearis
@@ -158,7 +195,11 @@ export function fetchTicketState(
       return d.state;
     }
   }
-  const { code, stdout } = exec("linearis", ["issues", "read", identifier]);
+  // CTL-1339: hot per-signal terminal read — cap the wall-clock so a 429-stalled
+  // linearis can't block the synchronous tier-3 reclaim/recovery read its full ~30s.
+  const { code, stdout } = exec("linearis", ["issues", "read", identifier], {
+    timeoutMs: LINEARIS_TERMINAL_READ_TIMEOUT_MS,
+  });
   if (code !== 0) return null; // fail-safe — not cached
   try {
     const node = JSON.parse(stdout);
@@ -461,7 +502,12 @@ export function classifyTicketResolution(
     const d = gateway.getDescriptor(identifier);
     if (d && !d.removed && descriptorAgeMs(d) <= gatewayFreshMs) return "exists";
   }
-  const { code, stdout } = exec("linearis", ["issues", "read", identifier]);
+  // CTL-1339: hot per-signal terminal read (phantom-sweep) — cap the wall-clock
+  // so a 429-stalled linearis can't block the synchronous tick. A timed-out read
+  // fails SAFE via the code-127 → "unknown" branch (never a false quarantine).
+  const { code, stdout } = exec("linearis", ["issues", "read", identifier], {
+    timeoutMs: LINEARIS_TERMINAL_READ_TIMEOUT_MS,
+  });
   if (code !== 0) return "unknown"; // nonzero is ambiguous — NEVER not-found
   let node;
   try {

--- a/plugins/dev/scripts/execution-core/linear-query.test.mjs
+++ b/plugins/dev/scripts/execution-core/linear-query.test.mjs
@@ -22,6 +22,8 @@ import {
   fetchTicketDelegate,
   buildDelegateBatchCurlArgs,
   fetchTicketsDelegateBatch,
+  parseTerminalTimeoutMs,
+  __rawExecForTest,
 } from "./linear-query.mjs";
 import { createTicketStateCache } from "./linear-cache.mjs";
 
@@ -1394,5 +1396,115 @@ describe("runEligibleQuery — delegate enrichment (CTL-1174)", () => {
     const delegateExec = (...a) => { calls.push(a); return null; };
     runEligibleQuery({ ...query, priority: 2 }, { exec, delegateExec });
     expect(calls).toHaveLength(0);
+  });
+});
+
+// ─── CTL-1339: hot-path per-call wall-clock timeout ──────────────────────────
+// A linearis read that stalls under a Linear 429 would otherwise block the
+// synchronous scheduler tick its full ~30s. The two hot per-signal terminal
+// reads pass an opt-in { timeoutMs } 3rd exec arg; a timed-out read returns
+// code 127 (the spawnSync ETIMEDOUT fail-safe) and the readers fail SAFE.
+
+// recordingExec — captures EVERY positional arg (incl. the 3rd opts) so the
+// threading/opt-in-scope assertions can inspect the timeout. fakeExec above only
+// records { cmd, args } and would miss the 3rd arg.
+function recordingExec({ code = 0, stdout = "", stderr = "" } = {}) {
+  const calls = [];
+  const fn = (...all) => {
+    calls.push(all);
+    return { code, stdout, stderr };
+  };
+  fn.calls = calls;
+  return fn;
+}
+
+describe("CTL-1339 terminal-read timeout — fail-safe on timeout (code 127)", () => {
+  test("classifyTicketResolution: timed-out read (code 127) → 'unknown' (NEVER 'not-found')", () => {
+    // A timeout is indistinguishable from a missing binary: spawnSync sets
+    // res.error → code 127. That MUST NOT quarantine a real ticket.
+    const exec = () => ({ code: 127, stdout: "", stderr: "spawnSync linearis ETIMEDOUT" });
+    expect(classifyTicketResolution("CTL-9", { exec })).toBe("unknown");
+  });
+
+  test("fetchTicketState: timed-out read (code 127) → null (non-terminal, fail-safe)", () => {
+    const exec = () => ({ code: 127, stdout: "", stderr: "spawnSync linearis ETIMEDOUT" });
+    expect(fetchTicketState("CTL-9", { exec })).toBeNull();
+  });
+});
+
+describe("CTL-1339 terminal-read timeout — opt-in threading scope", () => {
+  test("fetchTicketState tier-3 read passes { timeoutMs: 8000 } as the 3rd exec arg", () => {
+    const exec = recordingExec({ code: 0, stdout: JSON.stringify({ state: { name: "Done" } }) });
+    fetchTicketState("CTL-1", { exec });
+    expect(exec.calls).toHaveLength(1);
+    const [cmd, args, opts] = exec.calls[0];
+    expect(cmd).toBe("linearis");
+    expect(args).toEqual(["issues", "read", "CTL-1"]);
+    expect(opts).toEqual({ timeoutMs: 8000 });
+  });
+
+  test("classifyTicketResolution read passes { timeoutMs: 8000 } as the 3rd exec arg", () => {
+    const exec = recordingExec({ code: 0, stdout: JSON.stringify({ identifier: "CTL-1" }) });
+    classifyTicketResolution("CTL-1", { exec });
+    expect(exec.calls).toHaveLength(1);
+    const [cmd, args, opts] = exec.calls[0];
+    expect(cmd).toBe("linearis");
+    expect(args).toEqual(["issues", "read", "CTL-1"]);
+    expect(opts).toEqual({ timeoutMs: 8000 });
+  });
+
+  test("runEligibleQuery (non-hot poll) calls exec WITHOUT a timeoutMs (opt-in scoping)", () => {
+    // The eligible-list poll must stay UNCAPPED — a blanket cap would trip false
+    // monitor.reconcile.failing alerts (the adversarial-review finding).
+    const exec = recordingExec({ code: 0, stdout: ticketsJson([]) });
+    runEligibleQuery({ team: "CTL", status: "Todo" }, { exec, delegateExec: () => null });
+    expect(exec.calls).toHaveLength(1);
+    const opts = exec.calls[0][2];
+    expect(opts).toBeUndefined();
+  });
+
+  test("fetchTicketRelations (non-hot reader) calls exec WITHOUT a timeoutMs", () => {
+    const exec = recordingExec({ code: 0, stdout: JSON.stringify({ state: { name: "Todo" } }) });
+    fetchTicketRelations("CTL-1", { exec });
+    expect(exec.calls).toHaveLength(1);
+    const opts = exec.calls[0][2];
+    expect(opts).toBeUndefined();
+  });
+});
+
+describe("CTL-1339 parseTerminalTimeoutMs — default/disable contract", () => {
+  test("unset (undefined) → 8000 default", () => {
+    expect(parseTerminalTimeoutMs(undefined)).toBe(8000);
+  });
+  test("'0' → undefined (cap disabled — no timeout passed)", () => {
+    expect(parseTerminalTimeoutMs("0")).toBeUndefined();
+  });
+  test("a positive numeric string → that number", () => {
+    expect(parseTerminalTimeoutMs("1500")).toBe(1500);
+  });
+  test("garbage / non-positive → 8000 default", () => {
+    expect(parseTerminalTimeoutMs("abc")).toBe(8000);
+    expect(parseTerminalTimeoutMs("-5")).toBe(8000);
+    expect(parseTerminalTimeoutMs("")).toBe(8000);
+  });
+});
+
+// integration — drives the REAL rawExec/spawnSync path (NOT a stub) to prove the
+// `timeout` option is actually wired to spawnSync. This is the ONLY test that
+// exercises spawnSync; every other test injects an `exec` and bypasses rawExec.
+describe("CTL-1339 rawExec timeout wiring (integration)", () => {
+  test("a real `sleep 5` capped at timeoutMs:200 returns code 127 in well under 1s", () => {
+    const t0 = Date.now();
+    const res = __rawExecForTest("sleep", ["5"], { timeoutMs: 200 });
+    const elapsed = Date.now() - t0;
+    expect(res.code).toBe(127); // spawnSync ETIMEDOUT → res.error → code 127
+    expect(elapsed).toBeLessThan(1000); // killed at ~200ms, NOT after 5s
+  });
+
+  test("no timeoutMs → the same `sleep` is NOT killed early (uncapped path)", () => {
+    // Prove the cap is opt-in: a short sleep with no timeout runs to completion
+    // (exit 0). Kept short (0.2s) so the suite stays fast.
+    const res = __rawExecForTest("sleep", ["0.2"]);
+    expect(res.code).toBe(0);
   });
 });

--- a/plugins/dev/scripts/execution-core/linear-remint.mjs
+++ b/plugins/dev/scripts/execution-core/linear-remint.mjs
@@ -147,11 +147,14 @@ export const linearReminter = createReminter();
 // re-mint; if a fresh token was applied, retry the call once (the spawned
 // child inherits the updated process.env). Composes UNDER withBreaker so an
 // open breaker still short-circuits before any spawn.
+// CTL-1339: a 3rd `opts` arg (e.g. { timeoutMs }) is forwarded to the wrapped
+// exec on BOTH the initial call AND the post-remint retry, so the opt-in
+// per-call wall-clock cap applies to both attempts. The remint logic is unchanged.
 export function withAuthRemint(rawExec, { reminter = linearReminter, now = Date.now } = {}) {
-  return (cmd, args) => {
-    const res = rawExec(cmd, args);
+  return (cmd, args, opts) => {
+    const res = rawExec(cmd, args, opts);
     if (res.code !== 0 && isAuthError(res.stderr) && reminter.attempt(now())) {
-      return rawExec(cmd, args);
+      return rawExec(cmd, args, opts);
     }
     return res;
   };

--- a/plugins/dev/scripts/execution-core/linear-remint.test.mjs
+++ b/plugins/dev/scripts/execution-core/linear-remint.test.mjs
@@ -367,6 +367,38 @@ describe("withAuthRemint", () => {
     expect(r.code).toBe(1);
     expect(callN).toBe(2); // original + one retry only
   });
+
+  // CTL-1339: the opt-in per-call wall-clock cap rides a 3rd `opts` arg that the
+  // wrapper must forward to the wrapped exec on BOTH attempts.
+  test("forwards the 3rd opts arg to the wrapped exec on a clean (single) call", () => {
+    const reminter = makeReminter();
+    const calls = [];
+    const raw = (...all) => { calls.push(all); return { code: 0, stdout: "ok", stderr: "" }; };
+    const exec = withAuthRemint(raw, { reminter, now: () => 0 });
+    exec("linearis", ["issues", "read", "CTL-1"], { timeoutMs: 8000 });
+    expect(calls).toHaveLength(1);
+    expect(calls[0]).toEqual(["linearis", ["issues", "read", "CTL-1"], { timeoutMs: 8000 }]);
+  });
+
+  test("forwards the 3rd opts arg on BOTH the initial call AND the post-remint retry", () => {
+    const reminter = makeReminter(true); // mint succeeds → retry happens
+    let callN = 0;
+    const calls = [];
+    const raw = (...all) => {
+      callN++;
+      calls.push(all);
+      return callN === 1
+        ? { code: 1, stdout: "", stderr: "Unauthorized" } // initial: auth error
+        : { code: 0, stdout: "retry-ok", stderr: "" }; // retry: success
+    };
+    const exec = withAuthRemint(raw, { reminter, now: () => 0 });
+    const r = exec("linearis", ["issues", "read", "CTL-1"], { timeoutMs: 8000 });
+    expect(r.stdout).toBe("retry-ok");
+    expect(callN).toBe(2);
+    // the opts must reach BOTH spawns — the timeout applies on the retry too.
+    expect(calls[0][2]).toEqual({ timeoutMs: 8000 });
+    expect(calls[1][2]).toEqual({ timeoutMs: 8000 });
+  });
 });
 
 // ── breaker + remint composition ──────────────────────────────────────────────


### PR DESCRIPTION
## What
Cap the hot per-signal `linearis issues read` so a Linear 429 stall can't wedge the synchronous scheduler tick.

## Why
OTEL's unsampled p99 showed the scheduler tail is wedge-grade: **phantom-sweep 30.8s + recovery-pass 15.4s p99, tick p99 to 31s**. Root cause (verified — parallel investigation workflow + Loki): both passes call `defaultExec → rawExec → spawnSync("linearis", ["issues","read", id])` with **no `timeout`** (`linear-query.mjs:66`). Under a 429 storm (**140 circuit-breaker-OPEN events in 3h on mini, every spike adjacent to a 429 cluster**), a read that slips the *closed* CTL-679 breaker rides linearis's own 30s request-timeout and blocks the synchronous tick its full wall-clock.

## How
- Opt-in per-call `{ timeoutMs }` threaded `rawExec` → `withBreaker` → `withAuthRemint` (forwarded on both remint attempts).
- Applied to EXACTLY the two hot terminal reads: `fetchTicketState` tier-3 + `classifyTicketResolution`. ~8s default, env `CATALYST_LINEARIS_TERMINAL_TIMEOUT_MS` (`"0"` disables).
- A timed-out read fails SAFE via the existing `code 127` branch → `unknown`/`null` (never a false quarantine or false Done — **CTL-671 contract preserved**).
- The eligible-list poll + every other linearis call stay **UNCAPPED** (an adversarial review caught that a blanket cap would trip false `monitor.reconcile.failing` alerts).

## Tests
- **223 pass** (linear-query/breaker/remint) + **720 consumer-regression** green (linear-write, linear-cache, recovery, phantom-worker-dir, work-done-probes).
- Fail-safe (ETIMEDOUT→unknown/null), opt-in threading scope (hot reads get `timeoutMs`; eligible poll + `fetchTicketRelations` do NOT), parser default/disable contract, and a real-spawn integration test (`sleep 5` capped at 200ms → code 127 in <1s).

Complements (does not replace) the Cloud-SDK live-replica read repoint (CTL-1331 follow-on), which eliminates the per-signal exec entirely.

Closes CTL-1339.

🤖 Generated with [Claude Code](https://claude.com/claude-code)