### PR TITLE
feat(dev): CTL-1340 — inert read-replica tier for the scheduler's per-signal terminal checks

### DIFF
--- a/plugins/dev/scripts/execution-core/config.mjs
+++ b/plugins/dev/scripts/execution-core/config.mjs
@@ -1118,6 +1118,53 @@ export function readReclaimGatewayFreshMs(env = process.env) {
   return Number.isFinite(v) && v > 0 ? v : Number.MAX_SAFE_INTEGER;
 }
 
+// CTL-1340: the Catalyst-Cloud read-replica tier for the scheduler's hot
+// per-signal terminal checks (reclaim / recovery / terminal sweeps). When ON,
+// fetchTicketState reads terminal-ness from a local sub-ms SQLite replica
+// (replica-read.mjs) instead of the rate-limited per-tick `linearis` exec —
+// HIT-only acceleration: a MISS falls through to today's gateway+live path.
+// Ships OFF (the inert seam): the live flip happens once a replica is seeded on
+// the host. Binary on/off (NOT the 3-mode recovery family) — there is no
+// "shadow" middle state for a pure read accelerator.
+//   env CATALYST_LINEAR_REPLICA: "on"/"1" → on; "0"/"off"/unset/garbage → off.
+//   Layer-2 override: .catalyst.linearReplica.mode ("on" enables; anything else off).
+// env wins over Layer-2; default off.
+export const LINEAR_REPLICA_MODES = new Set(["on", "off"]);
+
+function readLayer2LinearReplica() {
+  try {
+    const r = JSON.parse(readFileSync(getLayer2ConfigPath(), "utf8"))?.catalyst?.linearReplica;
+    return r && typeof r === "object" ? r : {};
+  } catch {
+    return {};
+  }
+}
+
+export function readLinearReplica(env = process.env) {
+  const l2 = readLayer2LinearReplica();
+  const v = env.CATALYST_LINEAR_REPLICA;
+  let mode;
+  if (v === "on" || v === "1") {
+    mode = "on"; // explicit operator enable
+  } else if (v === "0" || v === "off") {
+    mode = "off"; // explicit kill-switch
+  } else if (typeof v === "string" && v !== "") {
+    mode = "off"; // garbage env value → off (never silently on)
+  } else if (l2.mode === "on") {
+    mode = "on"; // Layer-2 enable (env unset)
+  } else {
+    mode = "off"; // safe default: off — operators opt in
+  }
+  return { mode };
+}
+
+// CTL-1340: path to the local Catalyst-Cloud SQLite replica. CATALYST_REPLICA_DB
+// overrides; default ~/catalyst/catalyst-replica.db. Re-resolved per call (the
+// catalystDir() idiom) so tests redirect via the env var.
+export function getReplicaDbPath() {
+  return process.env.CATALYST_REPLICA_DB || resolve(catalystDir(), "catalyst-replica.db");
+}
+
 export function readDelegateRunnerConfig(env = process.env) {
   const v = env.CATALYST_DELEGATE_RUNNER;
   let mode;

--- a/plugins/dev/scripts/execution-core/config.test.mjs
+++ b/plugins/dev/scripts/execution-core/config.test.mjs
@@ -38,6 +38,8 @@ import {
   readDeadDocWorkerConfig,
   readBoardHealthConfig,
   DEAD_DOC_WORKER_TRANSCRIPT_SILENCE_MS,
+  readLinearReplica,
+  getReplicaDbPath,
 } from "./config.mjs";
 
 const PREV = process.env.CATALYST_WAIT_WATCHER;
@@ -955,5 +957,102 @@ describe("readBoardHealthConfig (CTL-1290)", () => {
   test("accepts an injected env bag (env param overrides process.env)", () => {
     process.env.CATALYST_BOARD_HEALTH = "shadow";
     expect(readBoardHealthConfig({ CATALYST_BOARD_HEALTH: "0" }).mode).toBe("off");
+  });
+});
+
+describe("readLinearReplica (CTL-1340)", () => {
+  const LR_ENVS = ["CATALYST_LINEAR_REPLICA", "CATALYST_LAYER2_CONFIG_FILE"];
+  let saved = {}, tmp;
+  beforeEach(() => {
+    for (const k of LR_ENVS) { saved[k] = process.env[k]; delete process.env[k]; }
+    tmp = mkdtempSync(join(tmpdir(), "ctl1340-lr-"));
+    process.env.CATALYST_LAYER2_CONFIG_FILE = join(tmp, "absent.json");
+  });
+  afterEach(() => {
+    for (const k of LR_ENVS) { saved[k] === undefined ? delete process.env[k] : (process.env[k] = saved[k]); }
+    saved = {}; rmSync(tmp, { recursive: true, force: true });
+  });
+
+  test("default (unset): mode=off (ships inert)", () => {
+    expect(readLinearReplica().mode).toBe("off");
+  });
+  test("CATALYST_LINEAR_REPLICA=on → on", () => {
+    process.env.CATALYST_LINEAR_REPLICA = "on";
+    expect(readLinearReplica().mode).toBe("on");
+  });
+  test("CATALYST_LINEAR_REPLICA=1 → on", () => {
+    process.env.CATALYST_LINEAR_REPLICA = "1";
+    expect(readLinearReplica().mode).toBe("on");
+  });
+  test("CATALYST_LINEAR_REPLICA=off → off (explicit kill-switch)", () => {
+    process.env.CATALYST_LINEAR_REPLICA = "off";
+    expect(readLinearReplica().mode).toBe("off");
+  });
+  test("CATALYST_LINEAR_REPLICA=0 → off (explicit kill-switch)", () => {
+    process.env.CATALYST_LINEAR_REPLICA = "0";
+    expect(readLinearReplica().mode).toBe("off");
+  });
+  test("garbage env → off (never silently on)", () => {
+    process.env.CATALYST_LINEAR_REPLICA = "banana";
+    expect(readLinearReplica().mode).toBe("off");
+  });
+  test("reads catalyst.linearReplica.mode=on from Layer-2 when env absent", () => {
+    const cfg = join(tmp, "config.json");
+    writeFileSync(cfg, JSON.stringify({ catalyst: { linearReplica: { mode: "on" } } }));
+    process.env.CATALYST_LAYER2_CONFIG_FILE = cfg;
+    expect(readLinearReplica().mode).toBe("on");
+  });
+  test("Layer-2 mode other than 'on' → off", () => {
+    const cfg = join(tmp, "config.json");
+    writeFileSync(cfg, JSON.stringify({ catalyst: { linearReplica: { mode: "off" } } }));
+    process.env.CATALYST_LAYER2_CONFIG_FILE = cfg;
+    expect(readLinearReplica().mode).toBe("off");
+  });
+  test("env wins over Layer-2 (env off beats Layer-2 on)", () => {
+    const cfg = join(tmp, "config.json");
+    writeFileSync(cfg, JSON.stringify({ catalyst: { linearReplica: { mode: "on" } } }));
+    process.env.CATALYST_LAYER2_CONFIG_FILE = cfg;
+    process.env.CATALYST_LINEAR_REPLICA = "0";
+    expect(readLinearReplica().mode).toBe("off");
+  });
+  test("env wins over Layer-2 (env on beats absent Layer-2)", () => {
+    process.env.CATALYST_LINEAR_REPLICA = "on";
+    expect(readLinearReplica().mode).toBe("on");
+  });
+  test("malformed Layer-2 file → off (never throws)", () => {
+    const cfg = join(tmp, "config.json"); writeFileSync(cfg, "{ not json");
+    process.env.CATALYST_LAYER2_CONFIG_FILE = cfg;
+    expect(readLinearReplica().mode).toBe("off");
+  });
+  test("accepts an injected env bag (env param overrides process.env)", () => {
+    process.env.CATALYST_LINEAR_REPLICA = "on";
+    expect(readLinearReplica({ CATALYST_LINEAR_REPLICA: "0" }).mode).toBe("off");
+  });
+});
+
+describe("getReplicaDbPath (CTL-1340)", () => {
+  const RD_ENVS = ["CATALYST_REPLICA_DB", "CATALYST_DIR"];
+  let saved = {};
+  beforeEach(() => {
+    for (const k of RD_ENVS) { saved[k] = process.env[k]; delete process.env[k]; }
+  });
+  afterEach(() => {
+    for (const k of RD_ENVS) { saved[k] === undefined ? delete process.env[k] : (process.env[k] = saved[k]); }
+    saved = {};
+  });
+
+  test("CATALYST_REPLICA_DB overrides the default path", () => {
+    process.env.CATALYST_REPLICA_DB = "/custom/path/replica.db";
+    expect(getReplicaDbPath()).toBe("/custom/path/replica.db");
+  });
+  test("default: <catalystDir>/catalyst-replica.db (CATALYST_DIR-rooted)", () => {
+    process.env.CATALYST_DIR = "/tmp/ctl1340-dir";
+    expect(getReplicaDbPath()).toBe("/tmp/ctl1340-dir/catalyst-replica.db");
+  });
+  test("re-resolved per call (env change is observed without re-import)", () => {
+    process.env.CATALYST_DIR = "/tmp/a";
+    expect(getReplicaDbPath()).toBe("/tmp/a/catalyst-replica.db");
+    process.env.CATALYST_DIR = "/tmp/b";
+    expect(getReplicaDbPath()).toBe("/tmp/b/catalyst-replica.db");
   });
 });

--- a/plugins/dev/scripts/execution-core/daemon.mjs
+++ b/plugins/dev/scripts/execution-core/daemon.mjs
@@ -50,6 +50,7 @@ import {
   isHostNamePinnedFromConfig, // CTL-1093
   getCatalystRepoDir,       // CTL-1093 sticky dir
   readDelegateRunnerConfig, // CTL-1331: async board-health delegate runner kill-switch
+  readLinearReplica,        // CTL-1340: read-replica tier flag (inert; default off)
 } from "./config.mjs";
 import { resolveBootIdentity } from "./host-boot-identity.mjs"; // CTL-1093
 import { readStickyIdentity, writeStickyIdentity } from "./host-sticky.mjs"; // CTL-1093
@@ -124,6 +125,7 @@ import { removeLabel as defaultRemoveLabel } from "./linear-write.mjs"; // CTL-5
 // so the phantom worker-dir validity sweep is operative in production.
 import { classifyTicketResolution } from "./linear-query.mjs";
 import { createGatewayReader } from "./gateway-read.mjs";
+import { createReplicaReader } from "./replica-read.mjs"; // CTL-1340: read-replica tier reader
 import { isBgJobAlive, refreshAgents, listClaudeAgentsResult } from "./claude-agents.mjs"; // CTL-1165 D3: fail-closed liveness reader for job-dir GC
 
 const DEFAULT_MAX_PARALLEL = 3;
@@ -597,6 +599,13 @@ export function startDaemon({
     // CTL-823: readonly client over the broker's durable descriptor store
     // (~/catalyst/filter-state.db). Fail-open — see gateway-read.mjs.
     const gatewayReader = createGatewayReader();
+    // CTL-1340: flag-gated read-replica tier (INERT by default). Constructed
+    // ONLY when CATALYST_LINEAR_REPLICA resolves to "on" — otherwise undefined,
+    // so the scheduler's replica block is never reached and behavior is
+    // byte-identical to pre-CTL-1340. HIT-only acceleration of the hot
+    // per-signal terminal reads once a Catalyst-Cloud replica is seeded on host.
+    const replicaReader =
+      readLinearReplica().mode === "on" ? createReplicaReader() : undefined;
     // CTL-565: the monitor needs orchDir to one-shot-dispatch the triage phase
     // agent on a →Triage transition. `dispatch` stays an injectable default
     // (dispatch.mjs) so the daemon's fakes-pass-through pattern still holds.
@@ -646,6 +655,10 @@ export function startDaemon({
       // injections (reclaim + terminal backstop) so the 60s state window is
       // live in production, not just in unit tests.
       gateway: gatewayReader,
+      // CTL-1340: thread the read-replica reader (undefined unless the flag is
+      // on) so the scheduler's per-signal terminal checks can resolve
+      // terminal-ness from the local Catalyst-Cloud replica. undefined → inert.
+      replica: replicaReader,
       isBgJobAlive,
       // CTL-1044: provide the production operator-event appender for the
       // scheduler's `appendIntentEvent` seam (scheduler.mjs:4300). Without this

--- a/plugins/dev/scripts/execution-core/linear-query.mjs
+++ b/plugins/dev/scripts/execution-core/linear-query.mjs
@@ -177,11 +177,26 @@ const GATEWAY_STATE_FRESH_MS = 60_000;
 
 export function fetchTicketState(
   identifier,
-  { exec = defaultExec, cache, gateway, gatewayFreshMs = GATEWAY_STATE_FRESH_MS } = {}
+  { exec = defaultExec, cache, gateway, replica, gatewayFreshMs = GATEWAY_STATE_FRESH_MS } = {}
 ) {
   if (cache) {
     const cached = cache.get(identifier);
     if (cached !== undefined) return cached; // hit
+  }
+  // CTL-1340: flag-gated read-replica tier. Sits BETWEEN the in-mem cache and the
+  // gateway (Tier-2) — a HIT in the local Catalyst-Cloud SQLite replica resolves
+  // the state name sub-ms with no exec. fall-through-on-MISS ONLY: an undefined
+  // lookup (absent/removed row, no db, any throw) FALLS THROUGH to today's
+  // gateway+live path, so a MISS can never make the terminal sweep re-flag a
+  // finished ticket needs-human. When no `replica` is passed (flag off) this
+  // block is fully skipped → byte-identical to the pre-CTL-1340 behavior.
+  if (replica) {
+    const r = replica.lookup(identifier);
+    if (r !== undefined) {
+      if (cache && r.state) cache.set(identifier, r.state); // warm the in-mem tier (never the "" poison)
+      return r.state;
+    }
+    // MISS → fall through to gateway + live read (today's behavior).
   }
   if (gateway) {
     const d = gateway.getDescriptor(identifier);

--- a/plugins/dev/scripts/execution-core/linear-query.test.mjs
+++ b/plugins/dev/scripts/execution-core/linear-query.test.mjs
@@ -26,6 +26,7 @@ import {
   __rawExecForTest,
 } from "./linear-query.mjs";
 import { createTicketStateCache } from "./linear-cache.mjs";
+import { isLinearTerminal } from "./terminal-state.mjs"; // CTL-1340: replica-tier terminal assertions
 
 // A fake exec returning a canned linearis result. `exec(cmd, args)` ->
 // { code, stdout, stderr } — the injectable seam runEligibleQuery uses so a
@@ -942,6 +943,135 @@ describe("fetchTicketState — gateway freshness window (CTL-1331 reclaim fix)",
       fetchTicketState("CTL-9", { exec, gateway, gatewayFreshMs: Number.MAX_SAFE_INTEGER })
     ).toBe("Todo");
     expect(execCalls).toBe(0); // the slow `linearis` exec is NEVER reached
+  });
+});
+
+// ─── read-replica tier (CTL-1340) ───────────────────────────────────────────
+// fetchTicketState gains a flag-gated `replica` tier between the in-mem cache
+// and the gateway. A HIT returns the replica's state name with NO exec; a MISS
+// (lookup → undefined) FALLS THROUGH to today's gateway+live read path.
+
+// fakeReplica — a lookup stub that records its calls and returns a canned result.
+function fakeReplica(result) {
+  const calls = [];
+  return {
+    calls,
+    lookup(identifier) {
+      calls.push(identifier);
+      return result;
+    },
+  };
+}
+
+describe("fetchTicketState — read-replica tier (CTL-1340)", () => {
+  test("flag-OFF (no replica) is byte-identical: exec runs, no replica consulted", () => {
+    // Mirror the existing fetchTicketState contract test exactly — passing NO
+    // replica must reproduce the live-read behavior verbatim.
+    const exec = (cmd, args) => {
+      expect(cmd).toBe("linearis");
+      expect(args).toEqual(["issues", "read", "CTL-99"]);
+      return {
+        code: 0,
+        stdout: JSON.stringify({ identifier: "CTL-99", state: { name: "Backlog" } }),
+        stderr: "",
+      };
+    };
+    // No `replica` key at all.
+    expect(fetchTicketState("CTL-99", { exec })).toBe("Backlog");
+  });
+
+  test("flag-OFF with a gateway present: replica block is fully skipped", () => {
+    let execCalls = 0;
+    const exec = () => {
+      execCalls++;
+      return { code: 0, stdout: JSON.stringify({ state: { name: "Done" } }) };
+    };
+    const gateway = fakeGateway({ state: "Todo", removed: false, updatedAt: FRESH() });
+    // Fresh gateway hit short-circuits — identical to the pre-CTL-1340 path.
+    expect(fetchTicketState("CTL-9", { exec, gateway })).toBe("Todo");
+    expect(execCalls).toBe(0);
+  });
+
+  test("flag-ON HIT terminal (completed_at → Done): returns 'Done', exec NEVER called", () => {
+    const replica = fakeReplica({ terminal: true, state: "Done" });
+    const exec = fakeExec({ code: 0, stdout: JSON.stringify({ state: { name: "Should-Not-Read" } }) });
+    const state = fetchTicketState("CTL-1", { exec, replica });
+    expect(state).toBe("Done");
+    expect(isLinearTerminal(state)).toBe(true);
+    expect(exec.calls.length).toBe(0); // HIT-only acceleration: no live read
+    expect(replica.calls).toEqual(["CTL-1"]);
+  });
+
+  test("flag-ON HIT terminal (canceled_at → Canceled): returns 'Canceled', exec NEVER called", () => {
+    const replica = fakeReplica({ terminal: true, state: "Canceled" });
+    const exec = fakeExec({ code: 0, stdout: "{}" });
+    const state = fetchTicketState("CTL-2", { exec, replica });
+    expect(state).toBe("Canceled");
+    expect(isLinearTerminal(state)).toBe(true);
+    expect(exec.calls.length).toBe(0);
+  });
+
+  test("flag-ON HIT non-terminal: returns the state name, exec NEVER called", () => {
+    const replica = fakeReplica({ terminal: false, state: "In Progress" });
+    const exec = fakeExec({ code: 0, stdout: "{}" });
+    const state = fetchTicketState("CTL-3", { exec, replica });
+    expect(state).toBe("In Progress");
+    expect(isLinearTerminal(state)).toBe(false);
+    expect(exec.calls.length).toBe(0);
+  });
+
+  test("flag-ON MISS (lookup → undefined): the live exec IS called (fall-through, safety lock)", () => {
+    // THIS encodes the adversarial-review safety decision: a replica MISS must
+    // NOT skip the live read — otherwise the terminal sweep would re-flag a
+    // finished ticket needs-human. fall-through-on-MISS ONLY.
+    const replica = fakeReplica(undefined);
+    const exec = fakeExec({
+      code: 0,
+      stdout: JSON.stringify({ identifier: "CTL-9", state: { name: "Done" } }),
+    });
+    const state = fetchTicketState("CTL-9", { exec, replica });
+    expect(state).toBe("Done"); // resolved via the live read, NOT the replica
+    expect(replica.calls).toEqual(["CTL-9"]); // replica was consulted first
+    expect(exec.calls.length).toBe(1); // then fell through to the live exec
+  });
+
+  test("flag-ON MISS with a gateway: falls through to the gateway tier (not the live exec)", () => {
+    const replica = fakeReplica(undefined);
+    let execCalls = 0;
+    const exec = () => {
+      execCalls++;
+      return { code: 0, stdout: JSON.stringify({ state: { name: "Live" } }) };
+    };
+    const gateway = fakeGateway({ state: "Todo", removed: false, updatedAt: FRESH() });
+    // MISS → gateway tier; a fresh gateway hit short-circuits before the exec.
+    expect(fetchTicketState("CTL-9", { exec, replica, gateway })).toBe("Todo");
+    expect(execCalls).toBe(0);
+  });
+
+  test("flag-ON HIT warms the in-mem cache so a second call hits without re-consulting the replica", () => {
+    const cache = createTicketStateCache({ now: () => 0 });
+    const replica = fakeReplica({ terminal: true, state: "Done" });
+    const exec = fakeExec({ code: 0, stdout: "{}" });
+    expect(fetchTicketState("CTL-1", { exec, replica, cache })).toBe("Done");
+    // Second call: in-mem cache hit short-circuits BEFORE the replica block.
+    expect(fetchTicketState("CTL-1", { exec, replica, cache })).toBe("Done");
+    expect(replica.calls).toEqual(["CTL-1"]); // consulted exactly once
+    expect(exec.calls.length).toBe(0);
+  });
+
+  test("empty-state guard: a HIT with state '' does NOT poison the cache", () => {
+    let setCalls = [];
+    const cache = {
+      get: () => undefined,
+      set: (id, state) => setCalls.push([id, state]),
+    };
+    // A non-terminal HIT whose state is the empty string (a missing state name).
+    const replica = fakeReplica({ terminal: false, state: "" });
+    const exec = fakeExec({ code: 0, stdout: "{}" });
+    const state = fetchTicketState("CTL-7", { exec, replica, cache });
+    expect(state).toBe(""); // the falsy state is returned verbatim
+    expect(exec.calls.length).toBe(0); // still a HIT (no fall-through)
+    expect(setCalls).toEqual([]); // but cache.set was NEVER called with ""
   });
 });
 

--- a/plugins/dev/scripts/execution-core/replica-read.mjs
+++ b/plugins/dev/scripts/execution-core/replica-read.mjs
@@ -1,0 +1,78 @@
+// replica-read.mjs — CTL-1340: the daemon's READ client for the local
+// Catalyst-Cloud SQLite replica (~/catalyst/catalyst-replica.db, seeded from the
+// cloud change-feed). The flag-gated "replica tier" of fetchTicketState: when the
+// CATALYST_LINEAR_REPLICA flag is ON, the scheduler's hot per-signal terminal
+// checks read terminal-ness from this sub-ms local DB instead of the
+// rate-limited per-tick `linearis` exec.
+//
+// Sibling of gateway-read.mjs (CTL-823) and built to the SAME contract:
+//   - Deliberately NOT an HTTP client — the scheduler tick is synchronous, so an
+//     HTTP hop would mean another per-call subprocess (the exact cost this tier
+//     removes). SQLite WAL exists for this shape: the replica daemon stays the
+//     single WRITER; this module opens the same file strictly READONLY.
+//   - LIGHT single-row read (NOT the cloud's full buildIssueDetail, which runs
+//     7+ queries): one index-backed SELECT of exactly the three terminal columns.
+//   - Fail-open contract: ANY failure (file absent, schema mismatch, lock
+//     contention, corrupt row, absent ticket) returns `undefined` — and
+//     fetchTicketState FALLS THROUGH to today's gateway+live read path. The
+//     replica is a HIT-only accelerator, NEVER the source of truth; a MISS must
+//     never let the terminal sweep re-flag a finished ticket needs-human.
+//
+// Terminal mapping (robust against team-specific state names): on a HIT we
+// synthesize the canonical Linear category name from the timestamp columns —
+// canceled_at != null → "Canceled", else completed_at != null → "Done" — so
+// isLinearTerminal (terminal-state.mjs: {Done, Canceled}) recognizes terminality
+// even if a team's terminal workflow state carries a custom display name. A
+// non-terminal HIT returns the row's actual `state` name (or null).
+import { Database } from "bun:sqlite";
+import { getReplicaDbPath } from "./config.mjs";
+
+// The light terminal SELECT. Index-backed by idx_issues_identifier (confirmed).
+// removed_at IS NULL excludes tombstoned rows (a removed ticket is a MISS → the
+// caller falls through to the live read, never a stale terminal verdict).
+const TERMINAL_SELECT = `SELECT state, completed_at, canceled_at FROM issues WHERE identifier = ? AND removed_at IS NULL LIMIT 1`;
+
+export function createReplicaReader({ dbPath = getReplicaDbPath() } = {}) {
+  let db = null;
+
+  const open = () => {
+    if (db) return db;
+    db = new Database(dbPath, { readonly: true });
+    // Readonly + WAL: writers never block readers, but a checkpoint can hold the
+    // lock briefly — wait a beat instead of failing the read.
+    db.run("PRAGMA busy_timeout = 250");
+    return db;
+  };
+
+  const dropHandle = () => {
+    try {
+      db?.close();
+    } catch {
+      /* already closed */
+    }
+    db = null;
+  };
+
+  // lookup(identifier) → { terminal, state } | undefined
+  //   HIT canceled_at != null  → { terminal: true,  state: "Canceled" }
+  //   HIT completed_at != null → { terminal: true,  state: "Done" }
+  //   HIT otherwise            → { terminal: false, state: row.state || null }
+  //   no row / no db / any throw → undefined  (fail-open; caller falls through)
+  const lookup = (identifier) => {
+    if (!identifier) return undefined;
+    try {
+      const row = open().prepare(TERMINAL_SELECT).get(identifier);
+      if (!row) return undefined; // absent / removed → MISS, fall through to live
+      if (row.canceled_at != null) return { terminal: true, state: "Canceled" };
+      if (row.completed_at != null) return { terminal: true, state: "Done" };
+      return { terminal: false, state: row.state || null };
+    } catch {
+      // Drop the handle so a later call re-opens fresh — the DB may be
+      // created/migrated/re-seeded by the replica daemon between calls.
+      dropHandle();
+      return undefined;
+    }
+  };
+
+  return { lookup, close: dropHandle };
+}

--- a/plugins/dev/scripts/execution-core/replica-read.test.mjs
+++ b/plugins/dev/scripts/execution-core/replica-read.test.mjs
@@ -1,0 +1,121 @@
+// Tests for replica-read.mjs (CTL-1340) — the daemon's readonly client over the
+// local Catalyst-Cloud SQLite replica. The fixture DB is built with REAL
+// bun:sqlite (the only test exercising the real SQL + adapter), seeding an
+// `issues` table that mirrors the cloud schema's terminal-relevant columns.
+// Run: bun test plugins/dev/scripts/execution-core/replica-read.test.mjs
+
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { Database } from "bun:sqlite";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { createReplicaReader } from "./replica-read.mjs";
+
+let tmpDir;
+let dbPath;
+let reader;
+
+beforeEach(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), "replica-read-test-"));
+  dbPath = join(tmpDir, "catalyst-replica.db");
+});
+
+afterEach(() => {
+  reader?.close();
+  reader = null;
+  rmSync(tmpDir, { recursive: true, force: true });
+});
+
+// seed — build the minimal `issues` table the light terminal SELECT reads, with
+// the index the prod query is backed by, then insert the four canonical rows.
+function seed() {
+  const db = new Database(dbPath, { create: true });
+  db.run(`
+    CREATE TABLE issues (
+      identifier   TEXT,
+      state        TEXT,
+      completed_at TEXT,
+      canceled_at  TEXT,
+      removed_at   TEXT
+    )
+  `);
+  db.run(`CREATE INDEX idx_issues_identifier ON issues (identifier)`);
+  // terminal via completed_at (Done category)
+  db.run(`INSERT INTO issues VALUES ('CTL-1', 'Shipped', '2026-06-01T00:00:00Z', NULL, NULL)`);
+  // terminal via canceled_at (Canceled category) — even with a completed_at set,
+  // canceled wins (canceled_at is checked first).
+  db.run(`INSERT INTO issues VALUES ('CTL-2', 'Abandoned', NULL, '2026-06-02T00:00:00Z', NULL)`);
+  // non-terminal — neither timestamp set; returns the row's actual state name.
+  db.run(`INSERT INTO issues VALUES ('CTL-3', 'In Progress', NULL, NULL, NULL)`);
+  // removed (tombstoned) — excluded by removed_at IS NULL → MISS (undefined).
+  db.run(`INSERT INTO issues VALUES ('CTL-4', 'In Review', NULL, NULL, '2026-06-03T00:00:00Z')`);
+  // non-terminal with NULL state — maps to state: null (not "").
+  db.run(`INSERT INTO issues VALUES ('CTL-5', NULL, NULL, NULL, NULL)`);
+  db.close();
+}
+
+describe("createReplicaReader.lookup (real bun:sqlite)", () => {
+  test("HIT completed_at → { terminal: true, state: 'Done' }", () => {
+    seed();
+    reader = createReplicaReader({ dbPath });
+    expect(reader.lookup("CTL-1")).toEqual({ terminal: true, state: "Done" });
+  });
+
+  test("HIT canceled_at → { terminal: true, state: 'Canceled' } (canceled wins)", () => {
+    seed();
+    reader = createReplicaReader({ dbPath });
+    expect(reader.lookup("CTL-2")).toEqual({ terminal: true, state: "Canceled" });
+  });
+
+  test("HIT non-terminal → { terminal: false, state } with the row's actual name", () => {
+    seed();
+    reader = createReplicaReader({ dbPath });
+    expect(reader.lookup("CTL-3")).toEqual({ terminal: false, state: "In Progress" });
+  });
+
+  test("HIT non-terminal with NULL state → { terminal: false, state: null }", () => {
+    seed();
+    reader = createReplicaReader({ dbPath });
+    expect(reader.lookup("CTL-5")).toEqual({ terminal: false, state: null });
+  });
+
+  test("removed (tombstoned) row → undefined (MISS, caller falls through)", () => {
+    seed();
+    reader = createReplicaReader({ dbPath });
+    expect(reader.lookup("CTL-4")).toBeUndefined();
+  });
+
+  test("absent ticket → undefined (MISS)", () => {
+    seed();
+    reader = createReplicaReader({ dbPath });
+    expect(reader.lookup("CTL-404")).toBeUndefined();
+  });
+
+  test("empty/falsy identifier → undefined without touching the DB", () => {
+    reader = createReplicaReader({ dbPath });
+    expect(reader.lookup("")).toBeUndefined();
+    expect(reader.lookup(null)).toBeUndefined();
+    expect(reader.lookup(undefined)).toBeUndefined();
+  });
+});
+
+describe("createReplicaReader — fail-open", () => {
+  test("missing DB file → undefined, then recovers once created", () => {
+    reader = createReplicaReader({ dbPath });
+    expect(reader.lookup("CTL-1")).toBeUndefined(); // no db yet → fail-open MISS
+    seed(); // replica daemon creates the DB after the failed read
+    expect(reader.lookup("CTL-1")).toEqual({ terminal: true, state: "Done" });
+  });
+
+  test("DB exists but lacks the issues table → undefined; recovers after re-seed", () => {
+    // open-succeeds-then-query-throws path: the SELECT throws, the catch drops
+    // the handle so the next call re-opens and sees the seeded schema.
+    const empty = new Database(dbPath, { create: true });
+    empty.run(`CREATE TABLE unrelated (x INTEGER)`);
+    empty.close();
+    reader = createReplicaReader({ dbPath });
+    expect(reader.lookup("CTL-1")).toBeUndefined();
+    seed();
+    expect(reader.lookup("CTL-3")).toEqual({ terminal: false, state: "In Progress" });
+  });
+});

--- a/plugins/dev/scripts/execution-core/scheduler.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.mjs
@@ -2878,6 +2878,12 @@ export function schedulerTick(
     // fetchState injections below. undefined in bare unit ticks (fail-open —
     // fetchTicketState without gateway behaves exactly as before).
     gateway = undefined,
+    // CTL-1340: the daemon's read-replica tier reader (flag-gated, default off →
+    // undefined). Threaded into the SAME fetchState injections below so a HIT in
+    // the local Catalyst-Cloud replica resolves terminal-ness sub-ms; a MISS
+    // falls through to gateway+live (fall-through-on-MISS). undefined → every
+    // fetchTicketState skips the replica block and behaves exactly as before.
+    replica = undefined,
     // CTL-781: respect-assignment + self-assign. botUserIds is the Set of known
     // bot UUIDs (predicate membership); botWriteId is the single orchestrator
     // UUID written as assignee on claim. undefined / empty Set → the gate and
@@ -3808,7 +3814,7 @@ export function schedulerTick(
                 ticket: sig.ticket,
                 signal: sig,
                 cache,
-                fetchState: (id, o = {}) => fetchTicketState(id, { ...o, cache, gateway }),
+                fetchState: (id, o = {}) => fetchTicketState(id, { ...o, cache, gateway, replica }),
               }).terminal
           );
         // CTL-1241: buildRecoveryItems attaches the current-tick escalate_human
@@ -3994,7 +4000,7 @@ export function schedulerTick(
         repoRoot,
         cache,
         fetchState: (id, o = {}) =>
-          fetchTicketState(id, { ...o, gateway, gatewayFreshMs: reclaimGatewayFreshMs }),
+          fetchTicketState(id, { ...o, gateway, replica, gatewayFreshMs: reclaimGatewayFreshMs }),
         prAdapter,
         // CTL-809 — thread the warm agents snapshot so the reclaim alive-branch can
         // cross-check a jobLifecycle-alive-but-process-gone ghost (getAgentsCached is
@@ -5367,7 +5373,7 @@ export function schedulerTick(
       {
         cache,
         prAdapter,
-        fetchState: (id, o = {}) => fetchTicketState(id, { ...o, gateway }),
+        fetchState: (id, o = {}) => fetchTicketState(id, { ...o, gateway, replica }),
         multiHost,
       }
     );
@@ -5400,7 +5406,7 @@ export function schedulerTick(
         const term = isTicketTerminalOrMerged({
           ticket,
           signal: signalByTicket.get(ticket),
-          fetchState: (id, o = {}) => fetchTicketState(id, { ...o, cache, gateway }),
+          fetchState: (id, o = {}) => fetchTicketState(id, { ...o, cache, gateway, replica }),
           cache,
           prAdapter,
         });
@@ -5902,6 +5908,7 @@ function runTick() {
       writeStatus: runningOpts.writeStatus,
       cache: runningOpts.cache, // CTL-634: shared out-of-set blocker state cache
       gateway: runningOpts.gateway, // CTL-1240/823: enables tier-2 reads in reclaim + reasoning filter
+      replica: runningOpts.replica, // CTL-1340: enables the flag-gated read-replica tier (undefined → inert)
       concurrency, // CTL-665 + CTL-676: per-tick re-read, then threaded into readMaxParallel
       // CTL-676: forward the optional liveBackgroundCount seam (test-only) so
       // a unit test can drive freeSlots deterministically without shelling
@@ -5987,9 +5994,11 @@ function runTick() {
               // CTL-1240: 3-tier read (cache → gateway/filter-state.db → live linearis),
               // matching the reclaim + reasoning-pass paths. TTL/gateway hits suppress
               // the live `linearis issues read` storm this census otherwise caused.
+              // CTL-1340: + the flag-gated read-replica tier (undefined → inert).
               const state = fetchTicketState(id, {
                 cache: runningOpts.cache,
                 gateway: runningOpts.gateway,
+                replica: runningOpts.replica,
               });
               return state != null && isLinearTerminal(state);
             },
@@ -6019,9 +6028,11 @@ function runTick() {
             // wrong). The cache/gateway tiers also make the terminal verdict resilient
             // to a transient live-read miss.
             isLinearTerminalOrMerged: (id) => {
+              // CTL-1340: + the flag-gated read-replica tier (undefined → inert).
               const state = fetchTicketState(id, {
                 cache: runningOpts.cache,
                 gateway: runningOpts.gateway,
+                replica: runningOpts.replica,
               });
               return state != null && isLinearTerminal(state);
             },
@@ -6056,9 +6067,11 @@ function runTick() {
             isLinearTerminal: (id) => {
               // CTL-1240: 3-tier read (cache → gateway → live linearis). Matches
               // the stall-clear census path above and the reclaim/reasoning paths.
+              // CTL-1340: + the flag-gated read-replica tier (undefined → inert).
               const state = fetchTicketState(id, {
                 cache: runningOpts.cache,
                 gateway: runningOpts.gateway,
+                replica: runningOpts.replica,
               });
               return state != null && isLinearTerminal(state);
             },
@@ -6292,6 +6305,7 @@ export function startScheduler({
   writeStatus,
   cache, // CTL-634: shared out-of-set blocker state cache (from startDaemon)
   gateway, // CTL-1240/823: durable filter-state.db reader; threaded into runningOpts → schedulerTick
+  replica, // CTL-1340: flag-gated read-replica reader (undefined unless on); threaded into runningOpts → schedulerTick
   concurrency = {}, // CTL-665 + CTL-676: boot-captured executionCore knobs. When
   // `configPath` is also set (production wiring), runTick re-reads the live
   // file every tick and ignores this object; the boot-captured value is the
@@ -6359,6 +6373,7 @@ export function startScheduler({
     writeStatus,
     cache,
     gateway, // CTL-1240: thread the durable descriptor reader into the per-tick options
+    replica, // CTL-1340: thread the flag-gated read-replica reader into the per-tick options
     concurrency,
     configPath, // CTL-676: per-tick Layer-1 re-read source
     layer2Path, // CTL-678: per-tick Layer-2 re-read source (host-wide override)


### PR DESCRIPTION
## What
The catalyst half of the ADR-0008 read repoint, landed **INERT** behind `CATALYST_LINEAR_REPLICA` (default **off** → byte-identical current behavior).

When the flag is on, `fetchTicketState` resolves terminal-ness from a local Catalyst-Cloud SQLite replica — sub-ms, no `linearis` exec — instead of the rate-limited per-tick `linearis issues read`.

## Why
OTEL's p99 showed the recovery-pass tail is the wedge risk. CTL-1339 (#2371) capped the >8s *tail* spikes; this targets the remaining **~3s per-signal floor** — every flagged-ticket terminal check pays a ~3s `linearis` read under the 429 storm. The Cloud-SDK live replica makes that a sub-ms local read and removes it from the rate-limit budget entirely (proven end-to-end tonight on the real `bun:sqlite` replica: CTL-790 terminal=true, ADV-1400 resolves).

## How (all gated; flag-OFF is a true no-op)
- **`config.mjs`**: `readLinearReplica()` (binary on/off, env wins over Layer-2, garbage→off, default off) + `getReplicaDbPath()` (`CATALYST_REPLICA_DB` || `~/catalyst/catalyst-replica.db`).
- **`replica-read.mjs`** (new): `createReplicaReader()` — read-only `bun:sqlite` (mirrors `gateway-read.mjs`: busy_timeout, fail-open-by-dropping-handle). **Light single-row** `SELECT state, completed_at, canceled_at FROM issues WHERE identifier=? AND removed_at IS NULL LIMIT 1` (index-backed by `idx_issues_identifier`). Terminal mapping: `canceled_at`→"Canceled", `completed_at`→"Done", else actual state (robust against team-specific terminal names).
- **`linear-query.mjs`**: `fetchTicketState` gains a flag-gated `replica` tier between the in-mem cache and the gateway. **fall-through-on-MISS only** (a MISS never lets the terminal sweep re-flag a finished ticket needs-human). Empty-state cache guard (`if (cache && r.state)`).
- **`daemon.mjs`/`scheduler.mjs`**: `replicaReader` constructed **only** when `readLinearReplica().mode === "on"`; `replica` threaded into all 8 `fetchTicketState` terminal-check sites; `undefined` → inert.

## Safety (adversarial-review-driven)
- **flag-OFF byte-identical**: replica block fully wrapped in `if (replica)`; `replica` defaults `undefined` in `schedulerTick`; reader built only when on.
- **fall-through-on-MISS only** — the strict skip-exec variant (which would re-flag Done tickets) was explicitly rejected.
- **no empty-string cache poison**; **light read** (not the 7-query `buildIssueDetail`).

## Tests
- `replica-read.test.mjs` 9/9 (real `bun:sqlite` fixture: Done/Canceled/non-terminal/NULL-state/removed→MISS/absent→MISS/fail-open).
- `linear-query.test.mjs` 162/162 incl. flag-OFF byte-identical, HIT terminal (exec never called), MISS→live-exec-fires (safety lock), empty-state-no-poison.
- `config.test.mjs` +14 (env/Layer-2 matrix). Regression in isolation green (scheduler 506, recovery 271, daemon 117, gateway-read 17).

## Follow-on
Seed a supervised `catalyst-replica sync` on the host + flip `CATALYST_LINEAR_REPLICA=on` → live recovery-pass crater (schema-reviewed with the Cloud agent first).

Builds on CTL-1339. Closes CTL-1340.

🤖 Generated with [Claude Code](https://claude.com/claude-code)