### PR TITLE
fix(dev): CTL-1341 — a timed-out linearis read trips the breaker so a degraded pass short-circuits

### DIFF
--- a/plugins/dev/scripts/execution-core/linear-breaker.mjs
+++ b/plugins/dev/scripts/execution-core/linear-breaker.mjs
@@ -98,7 +98,13 @@ export function withBreaker(rawExec, { breaker = linearBreaker, now = Date.now }
       return { code: 1, stdout: "", stderr: "circuit-open" };
     }
     const res = rawExec(cmd, args, opts);
-    if (res.code !== 0 && isRateLimitError(res.stderr)) {
+    // CTL-1341: a wall-clock TIMEOUT (the CTL-1339 per-call cap fired) is a
+    // degraded-API signal — open the breaker so the next read in a multi-read
+    // pass short-circuits (`circuit-open`, no spawn) instead of paying the full
+    // cap again. This bounds the per-PASS aggregate to ~1 cap, not N×cap (a
+    // per-call cap alone left recovery-pass at ~N×8s). A >8s linearis read is
+    // genuinely abnormal (healthy reads are sub-second), so the backoff is right.
+    if (res.code !== 0 && (res.timedOut || isRateLimitError(res.stderr))) {
       breaker.recordRateLimited(t);
     } else if (res.code === 0) {
       breaker.recordSuccess();

--- a/plugins/dev/scripts/execution-core/linear-breaker.test.mjs
+++ b/plugins/dev/scripts/execution-core/linear-breaker.test.mjs
@@ -144,6 +144,46 @@ describe("withBreaker", () => {
     expect(breaker.isOpen()).toBe(false);
   });
 
+  // CTL-1341: a wall-clock TIMEOUT (the CTL-1339 cap fired) is a degraded-API
+  // signal — it must trip the breaker so the next read in a multi-read pass
+  // short-circuits instead of paying the full cap again (bounds the per-PASS
+  // aggregate to ~1 cap, not N×cap).
+  test("a timed-out read (timedOut:true) opens the breaker", () => {
+    const breaker = createLinearBreaker({ logger: silentLogger, baseCooldownMs: 1000 });
+    const raw = () => ({ code: 127, stdout: "", stderr: "spawnSync linearis ETIMEDOUT", timedOut: true });
+    const exec = withBreaker(raw, { breaker, now: () => 0 });
+    exec("linearis", ["issues", "read", "CTL-1"], { timeoutMs: 8000 });
+    expect(breaker.isOpen(0)).toBe(true);
+  });
+
+  test("after a timeout opens the breaker, the next read short-circuits (per-pass bound)", () => {
+    const breaker = createLinearBreaker({ logger: silentLogger, baseCooldownMs: 1000 });
+    const calls = [];
+    const raw = (...all) => {
+      calls.push(all);
+      return { code: 127, stdout: "", stderr: "spawnSync linearis ETIMEDOUT", timedOut: true };
+    };
+    let clock = 0;
+    const exec = withBreaker(raw, { breaker, now: () => clock });
+    // first per-signal read times out → opens the breaker (one real spawn)
+    const first = exec("linearis", ["issues", "read", "CTL-1"], { timeoutMs: 8000 });
+    expect(first.code).toBe(127);
+    expect(calls).toHaveLength(1);
+    // the SAME pass's next per-signal read short-circuits — NO second 8s stall
+    clock = 10;
+    const second = exec("linearis", ["issues", "read", "CTL-2"], { timeoutMs: 8000 });
+    expect(calls).toHaveLength(1); // raw NOT spawned again
+    expect(second.stderr).toBe("circuit-open");
+  });
+
+  test("a non-timeout spawn error (ENOENT, timedOut:false) does NOT open the breaker", () => {
+    const breaker = createLinearBreaker({ logger: silentLogger });
+    const raw = () => ({ code: 127, stdout: "", stderr: "spawnSync linearis ENOENT", timedOut: false });
+    const exec = withBreaker(raw, { breaker });
+    exec("linearis", ["issues", "read", "CTL-1"], { timeoutMs: 8000 });
+    expect(breaker.isOpen()).toBe(false);
+  });
+
   // CTL-1339: the opt-in per-call wall-clock cap rides a 3rd `opts` arg that the
   // wrapper must forward to the inner rawExec untouched.
   test("forwards a 3rd opts arg (e.g. { timeoutMs }) to the inner rawExec", () => {

--- a/plugins/dev/scripts/execution-core/linear-query.mjs
+++ b/plugins/dev/scripts/execution-core/linear-query.mjs
@@ -96,7 +96,14 @@ function rawExec(cmd, args, { timeoutMs } = {}) {
   }
   const res = spawnSync(cmd, args, opts);
   if (res.error) {
-    return { code: 127, stdout: "", stderr: res.error.message };
+    // CTL-1341: flag a wall-clock TIMEOUT (the CTL-1339 cap fired) distinctly from
+    // other spawn errors. spawnSync on timeout sets error.code "ETIMEDOUT" +
+    // signal === killSignal ("SIGKILL"); a missing binary sets error.code "ENOENT"
+    // with no signal. withBreaker trips the breaker on `timedOut` (a >8s read is a
+    // degraded-API signal) so the rest of a multi-read pass short-circuits — but
+    // NOT on ENOENT (a config error, not rate-limiting).
+    const timedOut = res.error.code === "ETIMEDOUT" || res.signal === "SIGKILL";
+    return { code: 127, stdout: "", stderr: res.error.message, timedOut };
   }
   return {
     code: res.status ?? 0,

--- a/plugins/dev/scripts/execution-core/linear-query.test.mjs
+++ b/plugins/dev/scripts/execution-core/linear-query.test.mjs
@@ -1629,6 +1629,7 @@ describe("CTL-1339 rawExec timeout wiring (integration)", () => {
     const elapsed = Date.now() - t0;
     expect(res.code).toBe(127); // spawnSync ETIMEDOUT → res.error → code 127
     expect(elapsed).toBeLessThan(1000); // killed at ~200ms, NOT after 5s
+    expect(res.timedOut).toBe(true); // CTL-1341: a real timeout flags timedOut → trips the breaker
   });
 
   test("no timeoutMs → the same `sleep` is NOT killed early (uncapped path)", () => {
@@ -1636,5 +1637,13 @@ describe("CTL-1339 rawExec timeout wiring (integration)", () => {
     // (exit 0). Kept short (0.2s) so the suite stays fast.
     const res = __rawExecForTest("sleep", ["0.2"]);
     expect(res.code).toBe(0);
+  });
+
+  test("CTL-1341: a missing binary (ENOENT) returns code 127 but timedOut:false (not a degraded signal)", () => {
+    // The breaker must distinguish a wall-clock timeout (trip) from a spawn error
+    // like binary-not-found (do NOT trip — it's a config error, not rate-limiting).
+    const res = __rawExecForTest("catalyst-no-such-binary-xyz", [], { timeoutMs: 8000 });
+    expect(res.code).toBe(127);
+    expect(res.timedOut).toBe(false);
   });
 });


### PR DESCRIPTION
## What
A wall-clock-timed-out `linearis` read now trips the CTL-679 rate-limit breaker, so the next read in a multi-read scheduler pass short-circuits instead of paying the full ~8s cap again.

## Why
CTL-1339 (#2371) caps each per-signal read at ~8s, but the cap is **per-call**. OTEL measured recovery-pass still hitting **15.4s post-cap** (≈ 2×7.7s) — a multi-read pass (recovery-pass does ≥2 `fetchTicketState` reads) aggregates to N×8s. Root cause: a timeout-killed read returns `{code:127, stderr:"…ETIMEDOUT"}`, which doesn't match the breaker's `/rate limit exceeded/i` stderr test → the breaker stays **closed** → the next read also stalls to the full cap.

## How
- **`linear-query.mjs` `rawExec`**: flag a wall-clock timeout (`error.code === "ETIMEDOUT"` or `signal === "SIGKILL"`) as `timedOut: true`, distinct from other spawn errors (ENOENT binary-not-found → `timedOut: false`). (Verified the bun `spawnSync` timeout shape empirically: `status:null, signal:"SIGKILL", error.code:"ETIMEDOUT"`.)
- **`linear-breaker.mjs` `withBreaker`**: trip the breaker on `res.timedOut` (alongside the existing 429-stderr test). The first timed-out read opens it → subsequent reads in that pass + the cooldown window short-circuit to `circuit-open` (fast, fail-safe `null`/`unknown`) → **per-pass aggregate bounded to ~1 cap (~8s), not N×8s**.

A >8s `linearis` read is genuinely abnormal (healthy reads are sub-second), so treating it as a degraded-API signal and backing off is correct. Same fail-safe semantics; reuses the existing exponential cooldown. **ENOENT does NOT trip the breaker** (config error, not rate-limiting).

## Tests
- `linear-breaker.test.mjs`: timed-out read opens the breaker; the next read short-circuits (per-pass bound proven); ENOENT (`timedOut:false`) does NOT open it.
- `linear-query.test.mjs` (integration, real spawn): a real `sleep 5` capped at 200ms returns `timedOut:true`; a missing binary returns `code:127` + `timedOut:false`.
- **180 pass** (breaker+query) + **363 consumer-regression** (linear-write + recovery) green.

Follow-up to CTL-1339. Subsumed structurally by the CTL-1340 replica flip (sub-ms local reads, N-independent) — this bounds the gap until the flip lands. Closes CTL-1341.

🤖 Generated with [Claude Code](https://claude.com/claude-code)