### PR TITLE
fix(dev): CTL-1362 — per-tick trace_id unique across restarts (boot nonce)

### DIFF
--- a/plugins/dev/scripts/execution-core/scheduler.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.mjs
@@ -2739,12 +2739,26 @@ export function tickTimingEnabled(env = process.env) {
 // spans under one trace_id — a span-hygiene blowout, per-tick flame graph gone). Folding
 // `tick_id` (and `node`) into the seed makes each tick its OWN trace while staying
 // deterministic, so the same id is reproducible at both the log and the span.
-export function deriveTickTraceContext({ orchestratorId, tickId, node }) {
-  const seed = `${orchestratorId ?? ""}:tick:${tickId}:${node ?? ""}`;
+//
+// CTL-1362 (OTL-30): `tick_id` RESETS to 1 on every daemon restart, so `tick 171` recurs
+// across boots and collapses into ONE Tempo trace (observed: 10 scheduler.tick spans over
+// 17.5h under a single trace, all tick_id=171) — exemplars/slow-tick profiling then link to
+// a multi-tick pile, not the one slow tick. Folding a per-BOOT nonce in makes the id unique
+// per (boot, tick) while staying reproducible at log+span (both get the SAME id, computed
+// once per tick and threaded to both).
+export function deriveTickTraceContext({ orchestratorId, tickId, node, bootNonce }) {
+  const seed = `${orchestratorId ?? ""}:tick:${tickId}:${node ?? ""}:${bootNonce ?? ""}`;
   const traceId = createHash("sha256").update(seed).digest("hex").slice(0, 32);
   const spanId = createHash("sha256").update(`${seed}:span`).digest("hex").slice(0, 16);
   return { traceId, spanId };
 }
+
+// CTL-1362: a per-BOOT nonce captured ONCE at scheduler module load (= once per daemon
+// boot — a fresh process/module load each restart). Stable within a boot so a tick's log
+// line and span derive the SAME trace_id; distinct across boots so tick_id reuse can't
+// collide. This is the daemon scheduler (NOT a workflow context), so Date.now()/pid are
+// fine. Format is opaque — only its per-boot uniqueness + within-boot stability matter.
+export const SCHEDULER_BOOT_NONCE = `${Date.now().toString(36)}.${process.pid.toString(36)}`;
 
 // schedulerTick — one pull cycle: (1) advancement sweep, (2) new-work pull,
 // (3) terminal-Done sweep (CTL-558). Idempotent and restart-safe — derives
@@ -5520,6 +5534,7 @@ export function schedulerTick(
       orchestratorId: "catalyst.execution-core",
       tickId: tick.tickId,
       node: self,
+      bootNonce: SCHEDULER_BOOT_NONCE, // CTL-1362: unique per (boot, tick) — tick_id resets each restart
     });
     log.info(
       {

--- a/plugins/dev/scripts/execution-core/tracing.test.mjs
+++ b/plugins/dev/scripts/execution-core/tracing.test.mjs
@@ -159,6 +159,29 @@ describe("deriveTickTraceContext (CTL-1337 — deterministic per-tick id)", () =
     const t2 = deriveTickTraceContext({ ...base, tickId: 2 });
     expect(t1.traceId).not.toBe(t2.traceId);
   });
+
+  // CTL-1362: tick_id resets to 1 on every daemon restart, so the same tick_id across two
+  // boots must NOT collide — the per-boot nonce makes the id unique per (boot, tick).
+  test("the same tick_id across two boots yields DIFFERENT trace_ids (boot-nonce dedupe)", async () => {
+    const { deriveTickTraceContext } = await import("./scheduler.mjs");
+    const base = { orchestratorId: "catalyst.execution-core", node: "mini", tickId: 171 };
+    const bootA = deriveTickTraceContext({ ...base, bootNonce: "boot-a" });
+    const bootB = deriveTickTraceContext({ ...base, bootNonce: "boot-b" });
+    expect(bootA.traceId).not.toBe(bootB.traceId);
+    expect(bootA.spanId).not.toBe(bootB.spanId);
+  });
+
+  test("same (boot, tick) is reproducible — log line and span derive the SAME id", async () => {
+    const { deriveTickTraceContext } = await import("./scheduler.mjs");
+    const args = { orchestratorId: "catalyst.execution-core", node: "mini", tickId: 171, bootNonce: "boot-a" };
+    expect(deriveTickTraceContext(args)).toEqual(deriveTickTraceContext(args));
+  });
+
+  test("SCHEDULER_BOOT_NONCE is a non-empty per-boot constant", async () => {
+    const { SCHEDULER_BOOT_NONCE } = await import("./scheduler.mjs");
+    expect(typeof SCHEDULER_BOOT_NONCE).toBe("string");
+    expect(SCHEDULER_BOOT_NONCE.length).toBeGreaterThan(0);
+  });
 });
 
 describe("emitLivenessRefreshSpan (in-memory exporter)", () => {


### PR DESCRIPTION
## What
Fold a per-boot nonce into the CTL-1337 per-tick `trace_id` so it's unique per (boot, tick).

## Why
`tick_id` resets to 1 on every daemon restart, so the seed `(orchestratorId, tick_id, node)` collided across boots. OTEL (OTL-30 exemplar work) verified trace `66eac83e…` held **10 `scheduler.tick` spans over 17.5h**, all `tick_id=171` — so a slow-tick exemplar links to a multi-tick pile, not the one slow tick.

## How
- `SCHEDULER_BOOT_NONCE` — captured once at scheduler module load (= once per daemon boot; stable within a boot). Scheduler context, so `Date.now()`/`pid` are fine.
- `deriveTickTraceContext` folds it into the seed: `sha256(orchestratorId:tick:tickId:node:bootNonce)`. Unique per (boot, tick); reproducible at both the log line and the span (computed once/tick, threaded to both). Backward-compatible (`bootNonce` defaults to `""`).

## Tests
- New: same `tick_id` across two boots → **different** trace_ids/span_ids; same (boot,tick) reproducible; `SCHEDULER_BOOT_NONCE` non-empty. Existing CTL-1337 determinism/per-tick tests unaffected (assert determinism + difference, not specific hash values).
- Verified directly: `boot-a/tick171` `3ed23dc3…` ≠ `boot-b/tick171` `5870ec3c…`; reproducible; 32hex/16hex preserved.

Unblocks OTL-30 (exemplars → single-tick Tempo trace). Builds on CTL-1337. Closes CTL-1362.

🤖 Generated with [Claude Code](https://claude.com/claude-code)