### PR TITLE
feat(dev): CTL-1344 — node-class seam (getNodeClass) + Layer-2 catalyst.node.class

### DIFF
--- a/.github/workflows/execution-core-tests.yml
+++ b/.github/workflows/execution-core-tests.yml
@@ -133,6 +133,7 @@ jobs:
             cluster-claim.test.mjs \
             comms-drain.test.mjs \
             config-pino-fallback.test.mjs \
+            config-node-class.test.mjs \
             config.test.mjs \
             delegate-config-event.test.mjs \
             delegate-queue.test.mjs \

--- a/plugins/dev/scripts/execution-core/__tests__/config-node-class.test.mjs
+++ b/plugins/dev/scripts/execution-core/__tests__/config-node-class.test.mjs
@@ -92,6 +92,43 @@ describe("resolveNodeClass", () => {
     expect(r.class).not.toBe("worker");
   });
 
+  // A present-but-non-string Layer-2 value is an explicit misconfiguration, NOT an
+  // absent default — it must take the restrictive path so doctor can FAIL (the
+  // footgun guard; flagged in code review). false / 0 / [] / {}.
+  for (const [label, value] of [
+    ["false", false],
+    ["0", 0],
+    ["empty array", []],
+    ["object", { developer: true }],
+  ]) {
+    test(`present non-string Layer-2 value (${label}) → monitor, recognized:false, NOT worker`, () => {
+      writeLayer2({ catalyst: { node: { class: value } } });
+      const r = resolveNodeClass();
+      expect(r.class).toBe("monitor");
+      expect(r.recognized).toBe(false);
+      expect(r.inferred).toBe(false);
+      expect(r.source).toBe("layer2");
+      expect(r.class).not.toBe("worker");
+    });
+  }
+
+  test("explicit null Layer-2 value → worker (the codebase's unset sentinel)", () => {
+    writeLayer2({ catalyst: { node: { class: null } } });
+    const r = resolveNodeClass();
+    expect(r.class).toBe("worker");
+    expect(r.inferred).toBe(true);
+    expect(r.recognized).toBe(true);
+    expect(r.source).toBe("default");
+  });
+
+  test("empty/whitespace string Layer-2 value → worker (cleared, mirrors empty env)", () => {
+    writeLayer2({ catalyst: { node: { class: "   " } } });
+    const r = resolveNodeClass();
+    expect(r.class).toBe("worker");
+    expect(r.inferred).toBe(true);
+    expect(r.source).toBe("default");
+  });
+
   test("env overrides Layer-2", () => {
     writeLayer2({ catalyst: { node: { class: "worker" } } });
     process.env.CATALYST_NODE_CLASS = "developer";

--- a/plugins/dev/scripts/execution-core/__tests__/config-node-class.test.mjs
+++ b/plugins/dev/scripts/execution-core/__tests__/config-node-class.test.mjs
@@ -1,0 +1,147 @@
+// config-node-class.test.mjs — tests for resolveNodeClass()/getNodeClass() in
+// execution-core/config.mjs (CTL-1344). Run:
+//   cd plugins/dev/scripts/execution-core && bun test config-node-class
+
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { resolveNodeClass, getNodeClass, NODE_CLASSES } from "../config.mjs";
+
+const ENV_KEYS = ["CATALYST_NODE_CLASS", "CATALYST_LAYER2_CONFIG_FILE"];
+let saved;
+let tmp;
+
+beforeEach(() => {
+  saved = Object.fromEntries(ENV_KEYS.map((k) => [k, process.env[k]]));
+  tmp = mkdtempSync(join(tmpdir(), "ctl1344-"));
+  // No class set + point Layer-2 at a guaranteed-absent file so an ambient
+  // ~/.config/catalyst/config.json on the dev machine never leaks into a test.
+  delete process.env.CATALYST_NODE_CLASS;
+  process.env.CATALYST_LAYER2_CONFIG_FILE = join(tmp, "absent.json");
+});
+
+afterEach(() => {
+  for (const k of ENV_KEYS) {
+    if (saved[k] === undefined) delete process.env[k];
+    else process.env[k] = saved[k];
+  }
+  try { rmSync(tmp, { recursive: true, force: true }); } catch { /* best-effort */ }
+});
+
+// Write a Layer-2 config file and point the resolver at it.
+function writeLayer2(obj) {
+  const p = join(tmp, "config.json");
+  writeFileSync(p, JSON.stringify(obj));
+  process.env.CATALYST_LAYER2_CONFIG_FILE = p;
+}
+
+describe("resolveNodeClass", () => {
+  test("absent everywhere → worker, inferred, recognized, source=default", () => {
+    const r = resolveNodeClass();
+    expect(r.class).toBe("worker");
+    expect(r.source).toBe("default");
+    expect(r.inferred).toBe(true);
+    expect(r.recognized).toBe(true);
+    expect(r.raw).toBeNull();
+  });
+
+  for (const c of ["developer", "worker", "monitor"]) {
+    test(`explicit env "${c}" → that class, source=env, recognized`, () => {
+      process.env.CATALYST_NODE_CLASS = c;
+      const r = resolveNodeClass();
+      expect(r.class).toBe(c);
+      expect(r.source).toBe("env");
+      expect(r.inferred).toBe(false);
+      expect(r.recognized).toBe(true);
+    });
+  }
+
+  test("env value is trimmed + lowercased to its canonical class", () => {
+    process.env.CATALYST_NODE_CLASS = "  Developer  ";
+    const r = resolveNodeClass();
+    expect(r.class).toBe("developer");
+    expect(r.recognized).toBe(true);
+  });
+
+  test("unrecognized explicit env → most-restrictive monitor, recognized:false (NOT worker)", () => {
+    process.env.CATALYST_NODE_CLASS = "developr";
+    const r = resolveNodeClass();
+    expect(r.class).toBe("monitor");
+    expect(r.recognized).toBe(false);
+    expect(r.source).toBe("env");
+    expect(r.raw).toBe("developr");
+    // The footgun guard: a typo must never resolve to the work-eligible worker class.
+    expect(r.class).not.toBe("worker");
+  });
+
+  test("Layer-2 catalyst.node.class is read when env is unset", () => {
+    writeLayer2({ catalyst: { node: { class: "developer" } } });
+    const r = resolveNodeClass();
+    expect(r.class).toBe("developer");
+    expect(r.source).toBe("layer2");
+    expect(r.recognized).toBe(true);
+  });
+
+  test("unrecognized Layer-2 value → monitor, recognized:false, NOT worker", () => {
+    writeLayer2({ catalyst: { node: { class: "wokrer" } } });
+    const r = resolveNodeClass();
+    expect(r.class).toBe("monitor");
+    expect(r.recognized).toBe(false);
+    expect(r.source).toBe("layer2");
+    expect(r.class).not.toBe("worker");
+  });
+
+  test("env overrides Layer-2", () => {
+    writeLayer2({ catalyst: { node: { class: "worker" } } });
+    process.env.CATALYST_NODE_CLASS = "developer";
+    const r = resolveNodeClass();
+    expect(r.class).toBe("developer");
+    expect(r.source).toBe("env");
+  });
+
+  test("empty/whitespace env is treated as absent (falls through to Layer-2)", () => {
+    process.env.CATALYST_NODE_CLASS = "   ";
+    writeLayer2({ catalyst: { node: { class: "developer" } } });
+    expect(resolveNodeClass().class).toBe("developer");
+  });
+
+  test("malformed Layer-2 JSON never throws → default worker", () => {
+    const p = join(tmp, "config.json");
+    writeFileSync(p, "{ not valid json ");
+    process.env.CATALYST_LAYER2_CONFIG_FILE = p;
+    expect(() => resolveNodeClass()).not.toThrow();
+    const r = resolveNodeClass();
+    expect(r.class).toBe("worker");
+    expect(r.inferred).toBe(true);
+  });
+
+  test("Layer-2 present but no catalyst.node.class key → default worker (inferred)", () => {
+    writeLayer2({ catalyst: { host: { name: "mini" } } });
+    const r = resolveNodeClass();
+    expect(r.class).toBe("worker");
+    expect(r.inferred).toBe(true);
+    expect(r.source).toBe("default");
+  });
+});
+
+describe("getNodeClass", () => {
+  test("returns the resolved class string (worker by default)", () => {
+    expect(getNodeClass()).toBe("worker");
+  });
+  test("returns an explicit valid class", () => {
+    process.env.CATALYST_NODE_CLASS = "developer";
+    expect(getNodeClass()).toBe("developer");
+  });
+  test("returns the most-restrictive class for an unrecognized explicit value", () => {
+    process.env.CATALYST_NODE_CLASS = "nope";
+    expect(getNodeClass()).toBe("monitor");
+  });
+});
+
+describe("NODE_CLASSES", () => {
+  test("is the frozen canonical enum", () => {
+    expect(NODE_CLASSES).toEqual(["developer", "worker", "monitor"]);
+    expect(Object.isFrozen(NODE_CLASSES)).toBe(true);
+  });
+});

--- a/plugins/dev/scripts/execution-core/config.mjs
+++ b/plugins/dev/scripts/execution-core/config.mjs
@@ -265,6 +265,95 @@ export function isHostNamePinnedFromConfig() {
   } catch { return false; }
 }
 
+// --- Node class (CTL-1344) ---
+// catalyst.node.class names WHAT KIND of machine this is — `developer` (a
+// daemonless client you chat on), `worker` (runs the full stack and picks up
+// work), or `monitor` (a reporting host; an enum slot only for now — see the
+// node-classes plan §10). The class sets DEFAULTS for levers that already exist
+// (roster membership, boot-drain, which daemons start, where board reads come
+// from); it adds NO new dispatch gate and the scheduler is unchanged. Stored in
+// Layer-2 (machine-local ~/.config/catalyst/config.json) beside catalyst.host.name
+// — the same repo is checked out on every machine, so the role is per-machine,
+// not per-repo (Layer-1).
+export const NODE_CLASSES = Object.freeze(["developer", "worker", "monitor"]);
+// Absent ⇒ worker ⇒ today's behavior, zero change (the whole fleet is unset until
+// the M6 migration sets it explicitly).
+const NODE_CLASS_DEFAULT = "worker";
+// An EXPLICIT but unrecognized value (a typo'd "developr") must NOT silently
+// become a work-eligible worker (plan §3 footgun guard). It degrades to the most
+// restrictive class — `monitor` starts the fewest services, sits out of the
+// roster, and boots drained — so a typo can never make a node pick up work, and it
+// is flagged recognized:false so `catalyst doctor` (CTL-1355) FAILs until the
+// value is corrected.
+const NODE_CLASS_MOST_RESTRICTIVE = "monitor";
+
+// readLayer2NodeClass — the raw catalyst.node.class string from the Layer-2 file,
+// or null when absent/malformed/unreadable. Never throws (parity with getHostName).
+function readLayer2NodeClass() {
+  try {
+    const raw = JSON.parse(readFileSync(getLayer2ConfigPath(), "utf8"))?.catalyst?.node?.class;
+    if (typeof raw === "string" && raw.trim().length > 0) return raw;
+  } catch {
+    /* missing/malformed Layer-2 file → null (default-to-worker) */
+  }
+  return null;
+}
+
+// resolveNodeClass — the pure, no-logging node-class resolver. Mirrors
+// getHostName's precedence (CATALYST_NODE_CLASS env → Layer-2 catalyst.node.class
+// → default worker) and never throws. Returns the full resolution detail so
+// hot-path callers stay log-free and doctor (CTL-1355) can FAIL on an unrecognized
+// explicit value:
+//   { class, source, inferred, recognized, raw }
+//   - source     ∈ "env" | "layer2" | "default"
+//   - inferred   = true only for the default (no explicit value anywhere)
+//   - recognized = whether the explicit value named a real class (always true for
+//                  the inferred default; false is what routes doctor to FAIL)
+//   - raw        = the explicit value exactly as written (for the WARN/doctor text)
+// Values are trimmed + lowercased before the membership check, so "Worker" /
+// " developer " resolve to their canonical class; only a genuine non-member
+// ("developr") is treated as unrecognized.
+export function resolveNodeClass() {
+  const envRaw = process.env.CATALYST_NODE_CLASS;
+  const hasEnv = typeof envRaw === "string" && envRaw.trim().length > 0;
+  const raw = hasEnv ? envRaw : readLayer2NodeClass();
+  if (raw === null) {
+    return { class: NODE_CLASS_DEFAULT, source: "default", inferred: true, recognized: true, raw: null };
+  }
+  const source = hasEnv ? "env" : "layer2";
+  const normalized = raw.trim().toLowerCase();
+  if (NODE_CLASSES.includes(normalized)) {
+    return { class: normalized, source, inferred: false, recognized: true, raw };
+  }
+  return { class: NODE_CLASS_MOST_RESTRICTIVE, source, inferred: false, recognized: false, raw };
+}
+
+// getNodeClass — the convenience accessor the rest of the system reads. Returns
+// the resolved class string (developer|worker|monitor). Emits a once-per-process
+// WARN for the two soft-failure cases — an inferred default (so the operator knows
+// the class was never declared) and an unrecognized explicit value (so the typo is
+// visible) — without spamming. Hot-path callers that must stay strictly log-free
+// use resolveNodeClass().class directly. Never throws.
+const _warnedNodeClass = new Set();
+export function getNodeClass() {
+  const r = resolveNodeClass();
+  let msg = null;
+  if (r.inferred) {
+    msg =
+      `catalyst.node.class is not set; inferring "${r.class}" ` +
+      `(set CATALYST_NODE_CLASS or catalyst.node.class in ${getLayer2ConfigPath()} to make the role explicit)`;
+  } else if (!r.recognized) {
+    msg =
+      `catalyst.node.class "${r.raw}" is not one of [${NODE_CLASSES.join(", ")}] — ` +
+      `treating this node as "${r.class}" (most restrictive); catalyst doctor will FAIL until the value is corrected`;
+  }
+  if (msg && !_warnedNodeClass.has(msg)) {
+    _warnedNodeClass.add(msg);
+    log.warn(msg);
+  }
+  return r.class;
+}
+
 // getStaticRoster — the `static` escape-hatch roster (CTL-1273). A multi-host
 // operator who does NOT want the Linear anchor can pin an explicit node list in
 // the Layer-2 machine-local config under catalyst.cluster.staticRoster (a JSON

--- a/plugins/dev/scripts/execution-core/config.mjs
+++ b/plugins/dev/scripts/execution-core/config.mjs
@@ -287,16 +287,19 @@ const NODE_CLASS_DEFAULT = "worker";
 // value is corrected.
 const NODE_CLASS_MOST_RESTRICTIVE = "monitor";
 
-// readLayer2NodeClass — the raw catalyst.node.class string from the Layer-2 file,
-// or null when absent/malformed/unreadable. Never throws (parity with getHostName).
+// readLayer2NodeClass — the raw catalyst.node.class value from the Layer-2 file
+// EXACTLY as written (whatever JSON type), or undefined when the key is absent or
+// the file is missing/malformed/unreadable. Never throws (parity with getHostName).
+// resolveNodeClass — not this reader — judges validity, so a present-but-non-string
+// value (`false`, `0`, `[]`) reaches it as an explicit misconfiguration rather than
+// being silently flattened to "absent".
 function readLayer2NodeClass() {
   try {
-    const raw = JSON.parse(readFileSync(getLayer2ConfigPath(), "utf8"))?.catalyst?.node?.class;
-    if (typeof raw === "string" && raw.trim().length > 0) return raw;
+    return JSON.parse(readFileSync(getLayer2ConfigPath(), "utf8"))?.catalyst?.node?.class;
   } catch {
-    /* missing/malformed Layer-2 file → null (default-to-worker) */
+    /* missing/malformed Layer-2 file → undefined (default-to-worker) */
+    return undefined;
   }
-  return null;
 }
 
 // resolveNodeClass — the pure, no-logging node-class resolver. Mirrors
@@ -310,18 +313,36 @@ function readLayer2NodeClass() {
 //   - recognized = whether the explicit value named a real class (always true for
 //                  the inferred default; false is what routes doctor to FAIL)
 //   - raw        = the explicit value exactly as written (for the WARN/doctor text)
-// Values are trimmed + lowercased before the membership check, so "Worker" /
-// " developer " resolve to their canonical class; only a genuine non-member
-// ("developr") is treated as unrecognized.
+//
+// Validity ladder:
+//   - absent (no env + key undefined) OR an explicit null/empty "unset" sentinel
+//     ⇒ benign default-to-worker (inferred; zero behavior change). null is the
+//     codebase's "unset" convention and an empty string mirrors an empty env var.
+//   - a present non-string value (`false`, `0`, `[]`, `{}`) is NOT an absent
+//     default — it is an explicit misconfiguration ⇒ recognized:false (most
+//     restrictive), so a typo'd config can never make a node work-eligible.
+//   - a non-empty string is trimmed + lowercased before the membership check, so
+//     "Worker" / " developer " resolve to their canonical class; only a genuine
+//     non-member ("developr") is recognized:false.
 export function resolveNodeClass() {
   const envRaw = process.env.CATALYST_NODE_CLASS;
   const hasEnv = typeof envRaw === "string" && envRaw.trim().length > 0;
   const raw = hasEnv ? envRaw : readLayer2NodeClass();
-  if (raw === null) {
+  const source = hasEnv ? "env" : "layer2";
+
+  // Absent / explicit "unset" sentinel (undefined key or JSON null) ⇒ worker.
+  if (raw === undefined || raw === null) {
     return { class: NODE_CLASS_DEFAULT, source: "default", inferred: true, recognized: true, raw: null };
   }
-  const source = hasEnv ? "env" : "layer2";
+  // Present but not a string ⇒ explicit misconfiguration, never a silent worker.
+  if (typeof raw !== "string") {
+    return { class: NODE_CLASS_MOST_RESTRICTIVE, source, inferred: false, recognized: false, raw };
+  }
   const normalized = raw.trim().toLowerCase();
+  // Empty/whitespace string ⇒ "cleared" (mirrors an empty env var) ⇒ worker.
+  if (normalized.length === 0) {
+    return { class: NODE_CLASS_DEFAULT, source: "default", inferred: true, recognized: true, raw: null };
+  }
   if (NODE_CLASSES.includes(normalized)) {
     return { class: normalized, source, inferred: false, recognized: true, raw };
   }

--- a/website/src/content/docs/reference/configuration.md
+++ b/website/src/content/docs/reference/configuration.md
@@ -267,6 +267,42 @@ token is decrypted but not yet projected to the machine-level env. The operator 
 adding/rotating the secret in the `catalyst-cluster` repo lives in the `docs/cluster-onboarding.md`
 developer guide ("Provisioning the shared cloud token").
 
+## Node class (`catalyst.node.class`, CTL-1344)
+
+`catalyst.node.class` names **what kind of machine this is**. It is the front door to per-class
+packaging — one declarative field that sets sensible **defaults for levers that already exist**
+(cluster-roster membership, boot-drain, which daemons start, where board reads come from). It adds
+**no** new dispatch gate; the scheduler is unchanged.
+
+| Class | What it is |
+| --- | --- |
+| `developer` | A daemonless client you chat on. Not in the cluster roster, boots drained, runs no execution-core daemon or broker — it reads board data from a worker's monitor. |
+| `worker` | Runs the full stack and picks up work (the default; a laptop that both runs the daemon and is chatted on is a "head-full worker"). |
+| `monitor` | A reporting host. An **enum slot only** for now — its class-specific build-out is descoped until a real reporting node exists. |
+
+The class is **machine-local**, so it lives in **Layer-2** (`~/.config/catalyst/config.json`) beside
+`catalyst.host.name` — the same repo is checked out on every machine, so the role is per-machine, not
+per-repo:
+
+```json
+{ "catalyst": { "node": { "class": "developer" } } }
+```
+
+**Resolution** mirrors `catalyst.host.name` (`getNodeClass()` in `execution-core/config.mjs`):
+
+| Precedence | Source |
+| --- | --- |
+| 1 | `CATALYST_NODE_CLASS` env var (test/override) |
+| 2 | `catalyst.node.class` in the Layer-2 config |
+| 3 | default `worker` |
+
+- **Absent everywhere ⇒ `worker`** — today's behavior, zero change (the whole fleet is unset until it
+  is migrated explicitly). A WARN notes that the class was inferred.
+- **An explicit but unrecognized value** (a typo'd `developr`) does **not** silently become a
+  work-eligible worker. It is treated as the most restrictive class and `catalyst doctor` **FAILs**
+  until the value is corrected — so a typo can never make a node pick up work.
+- A missing or malformed Layer-2 file never throws; it falls through to the `worker` default.
+
 ## GitHub merge rules live in GitHub
 
 Catalyst can open PRs, fix CI, answer review bots, and merge. But GitHub decides what must pass before code lands. Those rules live in **GitHub branch protection or rulesets**, not in `.catalyst/config.json`.


### PR DESCRIPTION
## What

Keystone of the **Node Classes & Packaging** project (M1, CTL-1344). Adds one declarative machine-local field — `catalyst.node.class ∈ {developer, worker, monitor}` — read through a single `getNodeClass()` seam in `execution-core/config.mjs` that mirrors `getHostName`'s precedence.

This is a **pure addition**: no consumer reads the class yet (later milestones wire class-aware start/doctor/install/read-architecture over existing levers). It adds **no new dispatch gate**; the scheduler is unchanged.

## Resolution (mirrors `getHostName`)

`CATALYST_NODE_CLASS` env → `catalyst.node.class` (Layer-2 `~/.config/catalyst/config.json`) → default `worker`.

- `resolveNodeClass()` — pure, no-logging resolver returning `{class, source, inferred, recognized, raw}`, so hot-path callers stay log-free and `catalyst doctor` (CTL-1355) can FAIL on an unrecognized explicit value.
- `getNodeClass()` — convenience accessor returning the class string; emits a once-per-process WARN for the inferred-default and unrecognized-explicit cases.
- `NODE_CLASSES` exported as the single canonical enum for downstream reuse.

## Acceptance criteria → coverage

| AC | Where |
| --- | --- |
| Precedence env → Layer-2 → default worker | `resolveNodeClass()`; tests cover all three |
| Absent ⇒ worker, zero change + WARN | returns `{class:"worker", inferred:true}`; WARN in `getNodeClass()` |
| Unrecognized **explicit** ⇒ hard WARN + doctor FAIL, **not** silent worker | degrades to most-restrictive `monitor`, `recognized:false`; test asserts `!== "worker"` |
| Malformed/unreadable Layer-2 never throws | `try/catch` parity with `getHostName`; `not.toThrow()` test |
| Enum documented in configuration.md | new "Node class" section |

## Footgun guard (plan §3)

An absent class is a benign default-to-worker (today's fleet behavior). But an **explicit yet unrecognized** value (a typo'd `developr`) must never silently become a work-eligible worker — it degrades to the most restrictive class (`monitor`: out of roster, boot-drained, fewest services) and is flagged `recognized:false` so doctor FAILs until corrected.

## Tests / gates

- `config-node-class.test.mjs` — 16 tests, all precedence + normalization + footgun + malformed-file paths. **Added to the `execution-core-tests.yml` CI list** (the suite runs a curated explicit list).
- Import-graph check (`bun build daemon.mjs`) resolves clean.
- Docs site builds clean (`npm run build`, 337 pages).

🤖 Generated with [Claude Code](https://claude.com/claude-code)