### PR TITLE
feat(dev): CTL-1346 — read-replica resolver is node-class + Layer-2 aware

### DIFF
--- a/plugins/dev/scripts/orch-monitor/cli/hooks/useReadModel.ts
+++ b/plugins/dev/scripts/orch-monitor/cli/hooks/useReadModel.ts
@@ -22,7 +22,11 @@ import {
   type ReadModelStatus,
 } from "../lib/read-model-connection";
 import { createNodeEventSource } from "../lib/node-event-source";
-import { resolveReadModelUrl } from "../lib/read-model-url";
+import {
+  resolveReadModelStreamUrl,
+  type ReadModelStreamUrlResult,
+} from "../lib/read-model-url";
+import { readReplicaBaseUrlFromLayer2, nodeClassForRead } from "../lib/read-replica-config";
 import {
   groupByHost,
   type ReadModelPayload,
@@ -60,19 +64,37 @@ export interface UseReadModelResult {
 export function useReadModel(options: UseReadModelOptions = {}): UseReadModelResult {
   // Host identity is stable for the process lifetime; resolve once.
   const localRef = useRef(localHostRef()).current;
-  const url = useRef(options.url ?? resolveReadModelUrl(process.env)).current;
+  // Resolve the read-replica endpoint once, node-class + Layer-2 aware (CTL-1346).
+  // A developer node with no endpoint configured returns `{ ok:false }` rather than
+  // a localhost URL, so the HUD never silently reads an empty local replica.
+  const resolved = useRef<ReadModelStreamUrlResult>(
+    options.url
+      ? { ok: true, base: options.url, url: options.url }
+      : resolveReadModelStreamUrl({
+          env: process.env,
+          layer2BaseUrl: readReplicaBaseUrlFromLayer2(),
+          nodeClass: nodeClassForRead(),
+        }),
+  ).current;
   const factory = useRef(
     options.eventSourceFactory ?? ((u: string) => createNodeEventSource(u)),
   ).current;
 
-  const [state, setState] = useState<ReadModelConnectionState>({
-    status: "connecting",
-    payload: null,
-  });
+  const [state, setState] = useState<ReadModelConnectionState>(
+    resolved.ok ? { status: "connecting", payload: null } : { status: "down", payload: null },
+  );
 
   useEffect(() => {
+    if (!resolved.ok) {
+      // Developer node with no read-replica endpoint: never connect to localhost
+      // (an empty replica). Report `down` so callers fall back to their raw-file
+      // readers, and surface the reason once.
+      process.stderr.write(`[read-model] ${resolved.reason}\n`);
+      setState({ status: "down", payload: null });
+      return;
+    }
     const conn = createReadModelConnection({
-      url,
+      url: resolved.url,
       eventSourceFactory: factory,
       onChange: setState,
     });
@@ -80,7 +102,7 @@ export function useReadModel(options: UseReadModelOptions = {}): UseReadModelRes
     // Seed initial state in case start() synchronously transitioned.
     setState(conn.snapshot());
     return () => conn.stop();
-  }, [url, factory]);
+  }, [resolved, factory]);
 
   const cluster = state.payload ? groupByHost(state.payload, localRef) : null;
 

--- a/plugins/dev/scripts/orch-monitor/cli/lib/read-model-connection.ts
+++ b/plugins/dev/scripts/orch-monitor/cli/lib/read-model-connection.ts
@@ -36,7 +36,7 @@ export interface ReadModelConnectionState {
 }
 
 export interface ReadModelConnectionOptions {
-  /** Absolute SSE URL (see resolveReadModelUrl). */
+  /** Absolute SSE URL (see resolveReadModelStreamUrl). */
   url: string;
   /** Node EventSource factory (createNodeEventSource); tests inject a fake. */
   eventSourceFactory: (url: string) => ReadModelEventSource;

--- a/plugins/dev/scripts/orch-monitor/cli/lib/read-model-url.test.ts
+++ b/plugins/dev/scripts/orch-monitor/cli/lib/read-model-url.test.ts
@@ -1,41 +1,103 @@
-// CTL-920 / HUD2: the HUD resolves the local orch-monitor server's read-model
-// SSE URL the same way the server binds its port — MONITOR_PORT env, else the
-// 7400 default — so the HUD's new client path points at the exact stream the
-// web/iPad consume. Pure + env-injectable so we never touch process.env in tests.
+// CTL-920 / HUD2 + CTL-1346: the HUD resolves the orch-monitor read-model SSE URL
+// the same way the server binds its port (MONITOR_PORT env, else 7400), now
+// node-class + Layer-2 aware. Pure + injectable so we never touch process.env, the
+// filesystem, or node class here — those are passed in.
 import { describe, it, expect } from "bun:test";
-import { resolveReadModelUrl, DEFAULT_MONITOR_PORT } from "./read-model-url";
+import {
+  resolveReadModelBase,
+  resolveReadModelStreamUrl,
+  DEFAULT_MONITOR_PORT,
+} from "./read-model-url";
 
-describe("resolveReadModelUrl (CTL-920)", () => {
-  it("defaults to the loopback host on the server's default port", () => {
-    expect(resolveReadModelUrl({})).toBe(
-      `http://127.0.0.1:${DEFAULT_MONITOR_PORT}/api/board/stream`,
-    );
+const STREAM = "/api/board/stream";
+
+describe("resolveReadModelStreamUrl — port/default resolution (CTL-920)", () => {
+  it("defaults to the loopback host on the server's default port (no class ⇒ worker-like)", () => {
+    const r = resolveReadModelStreamUrl({ env: {} });
+    expect(r).toEqual({
+      ok: true,
+      base: `http://127.0.0.1:${DEFAULT_MONITOR_PORT}`,
+      url: `http://127.0.0.1:${DEFAULT_MONITOR_PORT}${STREAM}`,
+    });
   });
 
   it("honours MONITOR_PORT exactly as server.ts does", () => {
-    expect(resolveReadModelUrl({ MONITOR_PORT: "8123" })).toBe(
-      "http://127.0.0.1:8123/api/board/stream",
-    );
+    const r = resolveReadModelStreamUrl({ env: { MONITOR_PORT: "8123" } });
+    expect(r.ok && r.url).toBe(`http://127.0.0.1:8123${STREAM}`);
   });
 
   it("falls back to the default port when MONITOR_PORT is empty or non-numeric", () => {
-    expect(resolveReadModelUrl({ MONITOR_PORT: "" })).toBe(
-      `http://127.0.0.1:${DEFAULT_MONITOR_PORT}/api/board/stream`,
-    );
-    expect(resolveReadModelUrl({ MONITOR_PORT: "not-a-port" })).toBe(
-      `http://127.0.0.1:${DEFAULT_MONITOR_PORT}/api/board/stream`,
-    );
+    for (const port of ["", "not-a-port", "-5", "0"]) {
+      const r = resolveReadModelStreamUrl({ env: { MONITOR_PORT: port } });
+      expect(r.ok && r.url).toBe(`http://127.0.0.1:${DEFAULT_MONITOR_PORT}${STREAM}`);
+    }
   });
 
   it("an explicit CATALYST_MONITOR_URL base wins over the port (remote/proxied server)", () => {
-    expect(resolveReadModelUrl({ CATALYST_MONITOR_URL: "http://mac-mini.local:9000" })).toBe(
-      "http://mac-mini.local:9000/api/board/stream",
-    );
+    const r = resolveReadModelStreamUrl({ env: { CATALYST_MONITOR_URL: "http://mac-mini.local:9000" } });
+    expect(r.ok && r.url).toBe(`http://mac-mini.local:9000${STREAM}`);
   });
 
   it("trims a trailing slash on the base URL so the path is not doubled", () => {
-    expect(resolveReadModelUrl({ CATALYST_MONITOR_URL: "http://host:9000/" })).toBe(
-      "http://host:9000/api/board/stream",
-    );
+    const r = resolveReadModelStreamUrl({ env: { CATALYST_MONITOR_URL: "http://host:9000/" } });
+    expect(r.ok && r.url).toBe(`http://host:9000${STREAM}`);
+  });
+});
+
+describe("resolveReadModelBase — Layer-2 binding + class-aware fallback (CTL-1346)", () => {
+  it("binds catalyst.readReplica.baseUrl (Layer-2) when no env override is set", () => {
+    expect(resolveReadModelBase({ env: {}, layer2BaseUrl: "http://mini:7400" })).toEqual({
+      ok: true,
+      base: "http://mini:7400",
+    });
+  });
+
+  it("CATALYST_MONITOR_URL env still wins over the Layer-2 baseUrl", () => {
+    const r = resolveReadModelBase({
+      env: { CATALYST_MONITOR_URL: "http://from-env:7400" },
+      layer2BaseUrl: "http://from-layer2:7400",
+    });
+    expect(r).toEqual({ ok: true, base: "http://from-env:7400" });
+  });
+
+  it("trims a trailing slash on a Layer-2 baseUrl", () => {
+    expect(resolveReadModelBase({ env: {}, layer2BaseUrl: "http://mini:7400/" })).toEqual({
+      ok: true,
+      base: "http://mini:7400",
+    });
+  });
+
+  it("a developer node with NO endpoint configured returns ok:false (no silent localhost)", () => {
+    const r = resolveReadModelBase({ env: {}, nodeClass: "developer" });
+    expect(r.ok).toBe(false);
+    expect(!r.ok && r.reason).toContain("developer node");
+    // the whole point: it must NOT produce a localhost base
+    expect(JSON.stringify(r)).not.toContain("127.0.0.1");
+  });
+
+  it("a developer node WITH a configured endpoint resolves normally (env or Layer-2)", () => {
+    expect(resolveReadModelBase({ env: { CATALYST_MONITOR_URL: "http://mini:7400" }, nodeClass: "developer" })).toEqual({
+      ok: true,
+      base: "http://mini:7400",
+    });
+    expect(resolveReadModelBase({ env: {}, layer2BaseUrl: "http://mini:7400", nodeClass: "developer" })).toEqual({
+      ok: true,
+      base: "http://mini:7400",
+    });
+  });
+
+  it("worker / monitor / unknown class with no endpoint keeps the localhost default", () => {
+    for (const nodeClass of ["worker", "monitor", undefined] as const) {
+      expect(resolveReadModelBase({ env: {}, nodeClass })).toEqual({
+        ok: true,
+        base: `http://127.0.0.1:${DEFAULT_MONITOR_PORT}`,
+      });
+    }
+  });
+
+  it("resolveReadModelStreamUrl propagates the developer ok:false unchanged", () => {
+    const r = resolveReadModelStreamUrl({ env: {}, nodeClass: "developer" });
+    expect(r.ok).toBe(false);
+    expect(!r.ok && r.reason).toContain("developer node");
   });
 });

--- a/plugins/dev/scripts/orch-monitor/cli/lib/read-model-url.test.ts
+++ b/plugins/dev/scripts/orch-monitor/cli/lib/read-model-url.test.ts
@@ -67,27 +67,31 @@ describe("resolveReadModelBase — Layer-2 binding + class-aware fallback (CTL-1
     });
   });
 
-  it("a developer node with NO endpoint configured returns ok:false (no silent localhost)", () => {
-    const r = resolveReadModelBase({ env: {}, nodeClass: "developer" });
-    expect(r.ok).toBe(false);
-    expect(!r.ok && r.reason).toContain("developer node");
-    // the whole point: it must NOT produce a localhost base
-    expect(JSON.stringify(r)).not.toContain("127.0.0.1");
+  it("a developer or monitor node with NO endpoint returns ok:false (no silent localhost)", () => {
+    for (const nodeClass of ["developer", "monitor"] as const) {
+      const r = resolveReadModelBase({ env: {}, nodeClass });
+      expect(r.ok).toBe(false);
+      expect(!r.ok && r.reason).toContain(`${nodeClass} node`);
+      // the whole point: it must NOT produce a localhost base
+      expect(JSON.stringify(r)).not.toContain("127.0.0.1");
+    }
   });
 
-  it("a developer node WITH a configured endpoint resolves normally (env or Layer-2)", () => {
-    expect(resolveReadModelBase({ env: { CATALYST_MONITOR_URL: "http://mini:7400" }, nodeClass: "developer" })).toEqual({
-      ok: true,
-      base: "http://mini:7400",
-    });
-    expect(resolveReadModelBase({ env: {}, layer2BaseUrl: "http://mini:7400", nodeClass: "developer" })).toEqual({
-      ok: true,
-      base: "http://mini:7400",
-    });
+  it("a developer/monitor node WITH a configured endpoint resolves normally (env or Layer-2)", () => {
+    for (const nodeClass of ["developer", "monitor"] as const) {
+      expect(resolveReadModelBase({ env: { CATALYST_MONITOR_URL: "http://mini:7400" }, nodeClass })).toEqual({
+        ok: true,
+        base: "http://mini:7400",
+      });
+      expect(resolveReadModelBase({ env: {}, layer2BaseUrl: "http://mini:7400", nodeClass })).toEqual({
+        ok: true,
+        base: "http://mini:7400",
+      });
+    }
   });
 
-  it("worker / monitor / unknown class with no endpoint keeps the localhost default", () => {
-    for (const nodeClass of ["worker", "monitor", undefined] as const) {
+  it("worker / unknown class with no endpoint keeps the localhost default (reads its own replica)", () => {
+    for (const nodeClass of ["worker", undefined] as const) {
       expect(resolveReadModelBase({ env: {}, nodeClass })).toEqual({
         ok: true,
         base: `http://127.0.0.1:${DEFAULT_MONITOR_PORT}`,

--- a/plugins/dev/scripts/orch-monitor/cli/lib/read-model-url.ts
+++ b/plugins/dev/scripts/orch-monitor/cli/lib/read-model-url.ts
@@ -13,10 +13,11 @@
 //   1. `CATALYST_MONITOR_URL` env (explicit override — unchanged, still wins)
 //   2. `catalyst.readReplica.baseUrl` (Layer-2 machine-local config)
 //   3. class-aware default:
-//        - developer ⇒ NO base — refuse the localhost fallback (which would serve
-//          an empty replica); the caller surfaces an explicit unset/error.
-//        - worker / monitor / unknown ⇒ `http://127.0.0.1:<MONITOR_PORT|7400>`
-//          (its own broker fills + serves the local replica).
+//        - developer / monitor ⇒ NO base — refuse the localhost fallback (which
+//          would serve an empty replica); the caller surfaces an explicit
+//          unset/error. Both read a REMOTE replica (design §3 read-source table).
+//        - worker / unknown ⇒ `http://127.0.0.1:<MONITOR_PORT|7400>` (its own
+//          broker fills + serves the local replica).
 //
 // This module stays PURE: the Layer-2 baseUrl + node class are INJECTED (read by
 // read-replica-config.ts on the Node side), so it imports no fs/config and never
@@ -59,8 +60,9 @@ export type ReadModelStreamUrlResult =
  * Resolve the read-replica base URL (no path). Precedence:
  *   1. `CATALYST_MONITOR_URL` env (explicit override)
  *   2. `catalyst.readReplica.baseUrl` (Layer-2)
- *   3. class-aware default — developer ⇒ `{ ok:false }` (no silent localhost);
- *      worker / monitor / unknown ⇒ `http://127.0.0.1:<MONITOR_PORT|7400>`.
+ *   3. class-aware default — developer / monitor ⇒ `{ ok:false }` (no silent
+ *      localhost; both read a remote replica); worker / unknown ⇒
+ *      `http://127.0.0.1:<MONITOR_PORT|7400>`.
  */
 export function resolveReadModelBase(inputs: ReadModelBaseInputs): ReadModelBaseResult {
   const envBase = explicitBase(inputs.env.CATALYST_MONITOR_URL);
@@ -69,12 +71,17 @@ export function resolveReadModelBase(inputs: ReadModelBaseInputs): ReadModelBase
   const layer2Base = explicitBase(inputs.layer2BaseUrl ?? undefined);
   if (layer2Base) return { ok: true, base: layer2Base };
 
-  if (inputs.nodeClass === "developer") {
+  // developer and monitor both read a REMOTE replica (design §3 read-source
+  // table — only worker reads its own local replica). An invalid explicit class
+  // resolves to the most-restrictive `monitor` (read-replica-config.ts), so this
+  // also closes the typo footgun: a misconfigured node never silently reads the
+  // empty localhost replica.
+  if (inputs.nodeClass === "developer" || inputs.nodeClass === "monitor") {
     return {
       ok: false,
       reason:
-        "developer node has no read-replica endpoint — set CATALYST_MONITOR_URL or " +
-        "catalyst.readReplica.baseUrl to a worker's monitor (e.g. http://mini:7400); " +
+        `${inputs.nodeClass} node has no read-replica endpoint — set CATALYST_MONITOR_URL ` +
+        "or catalyst.readReplica.baseUrl to a worker's monitor (e.g. http://mini:7400); " +
         "refusing to fall back to localhost, which would serve an empty replica",
     };
   }

--- a/plugins/dev/scripts/orch-monitor/cli/lib/read-model-url.ts
+++ b/plugins/dev/scripts/orch-monitor/cli/lib/read-model-url.ts
@@ -1,17 +1,26 @@
-// read-model-url.ts — resolve the local orch-monitor server's read-model SSE
-// URL for the terminal HUD (CTL-920 / HUD2).
+// read-model-url.ts — resolve the orch-monitor read-model SSE URL for the
+// terminal HUD (CTL-920 / HUD2), node-class + Layer-2 aware (CTL-1346).
 //
 // The HUD has historically made ZERO `fetch`/`EventSource` calls — it scanned
 // raw files itself. HUD2 makes it a CONSUMER of the shared read-model SSE the
 // web/iPad already consume (`/api/board/stream`). The web client uses a
 // browser-relative path (the page origin IS the server); the Node-side HUD has
-// no page origin, so it must build an ABSOLUTE URL pointing at the local server.
+// no page origin, so it must build an ABSOLUTE URL pointing at a monitor.
 //
-// It resolves the port the SAME way the server binds it (server.ts:2189-2190 —
-// `MONITOR_PORT` env, else the 7400 default) so the HUD always targets the exact
-// stream the server is serving. An explicit `CATALYST_MONITOR_URL` base wins for
-// the rare proxied/remote case. This is pure + env-injectable; the HUD passes
-// `process.env`, tests pass a literal.
+// CTL-1346 — read-architecture per node class. A `developer` (daemonless) node
+// runs no broker, so its LOCAL `filter-state.db` replica is empty; it must read a
+// WORKER's monitor. The base now resolves through:
+//   1. `CATALYST_MONITOR_URL` env (explicit override — unchanged, still wins)
+//   2. `catalyst.readReplica.baseUrl` (Layer-2 machine-local config)
+//   3. class-aware default:
+//        - developer ⇒ NO base — refuse the localhost fallback (which would serve
+//          an empty replica); the caller surfaces an explicit unset/error.
+//        - worker / monitor / unknown ⇒ `http://127.0.0.1:<MONITOR_PORT|7400>`
+//          (its own broker fills + serves the local replica).
+//
+// This module stays PURE: the Layer-2 baseUrl + node class are INJECTED (read by
+// read-replica-config.ts on the Node side), so it imports no fs/config and never
+// pulls a runtime config module into a bundler graph.
 
 import { READ_MODEL_STREAM_PATH } from "../../lib/read-model-client";
 
@@ -25,19 +34,63 @@ export const DEFAULT_MONITOR_PORT = 7400;
  */
 export type ReadModelUrlEnv = Record<string, string | undefined>;
 
+/** The node classes whose read behavior differs (CTL-1344 enum). */
+export type NodeClass = "developer" | "worker" | "monitor";
+
+/** Inputs to the node-aware base resolver. All injected → the module stays pure. */
+export interface ReadModelBaseInputs {
+  /** process.env (or a test literal). `CATALYST_MONITOR_URL` + `MONITOR_PORT`. */
+  env: ReadModelUrlEnv;
+  /** `catalyst.readReplica.baseUrl` from Layer-2 (null/undefined when unset). */
+  layer2BaseUrl?: string | null;
+  /** This node's class. Only `developer` changes the no-endpoint behavior. */
+  nodeClass?: NodeClass;
+}
+
+export type ReadModelBaseResult =
+  | { ok: true; base: string }
+  | { ok: false; reason: string };
+
+export type ReadModelStreamUrlResult =
+  | { ok: true; base: string; url: string }
+  | { ok: false; reason: string };
+
 /**
- * Resolve the absolute SSE URL the HUD subscribes to.
- *
- * Precedence:
- *   1. `CATALYST_MONITOR_URL` base (trailing slash trimmed) + the stream path.
- *   2. `http://127.0.0.1:<MONITOR_PORT|7400>` + the stream path.
- *
- * The path component is the shared `READ_MODEL_STREAM_PATH` from the contract,
- * so the HUD and the web client agree on the endpoint by construction.
+ * Resolve the read-replica base URL (no path). Precedence:
+ *   1. `CATALYST_MONITOR_URL` env (explicit override)
+ *   2. `catalyst.readReplica.baseUrl` (Layer-2)
+ *   3. class-aware default — developer ⇒ `{ ok:false }` (no silent localhost);
+ *      worker / monitor / unknown ⇒ `http://127.0.0.1:<MONITOR_PORT|7400>`.
  */
-export function resolveReadModelUrl(env: ReadModelUrlEnv): string {
-  const base = explicitBase(env.CATALYST_MONITOR_URL) ?? `http://127.0.0.1:${resolvePort(env)}`;
-  return `${base}${READ_MODEL_STREAM_PATH}`;
+export function resolveReadModelBase(inputs: ReadModelBaseInputs): ReadModelBaseResult {
+  const envBase = explicitBase(inputs.env.CATALYST_MONITOR_URL);
+  if (envBase) return { ok: true, base: envBase };
+
+  const layer2Base = explicitBase(inputs.layer2BaseUrl ?? undefined);
+  if (layer2Base) return { ok: true, base: layer2Base };
+
+  if (inputs.nodeClass === "developer") {
+    return {
+      ok: false,
+      reason:
+        "developer node has no read-replica endpoint — set CATALYST_MONITOR_URL or " +
+        "catalyst.readReplica.baseUrl to a worker's monitor (e.g. http://mini:7400); " +
+        "refusing to fall back to localhost, which would serve an empty replica",
+    };
+  }
+
+  return { ok: true, base: `http://127.0.0.1:${resolvePort(inputs.env)}` };
+}
+
+/**
+ * Resolve the absolute SSE stream URL (resolved base + the shared
+ * `READ_MODEL_STREAM_PATH`, so the HUD and the web client agree by construction).
+ * Propagates the `{ ok:false }` developer-no-endpoint case unchanged.
+ */
+export function resolveReadModelStreamUrl(inputs: ReadModelBaseInputs): ReadModelStreamUrlResult {
+  const resolved = resolveReadModelBase(inputs);
+  if (!resolved.ok) return resolved;
+  return { ok: true, base: resolved.base, url: `${resolved.base}${READ_MODEL_STREAM_PATH}` };
 }
 
 function explicitBase(raw: string | undefined): string | null {

--- a/plugins/dev/scripts/orch-monitor/cli/lib/read-replica-config.test.ts
+++ b/plugins/dev/scripts/orch-monitor/cli/lib/read-replica-config.test.ts
@@ -1,12 +1,13 @@
 // read-replica-config.test.ts — CTL-1346. Exercises the Node-side Layer-2 reads
 // (catalyst.readReplica.baseUrl + node class) that feed the read-replica resolver.
 import { describe, it, expect, beforeEach, afterEach } from "bun:test";
-import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { spawnSync } from "node:child_process";
 import { readReplicaBaseUrlFromLayer2, nodeClassForRead } from "./read-replica-config";
 
-const ENV_KEYS = ["CATALYST_NODE_CLASS", "CATALYST_LAYER2_CONFIG_FILE"];
+const ENV_KEYS = ["CATALYST_NODE_CLASS", "CATALYST_LAYER2_CONFIG_FILE", "HOME"];
 let saved: Record<string, string | undefined>;
 let tmp: string;
 
@@ -84,8 +85,40 @@ describe("nodeClassForRead", () => {
     expect(nodeClassForRead()).toBe("developer");
   });
 
-  it("an unrecognized class resolves to worker for read purposes (doctor flags the typo)", () => {
+  it("a present-but-invalid class resolves to monitor (most-restrictive, mirrors config.mjs)", () => {
     process.env.CATALYST_NODE_CLASS = "developr";
+    expect(nodeClassForRead()).toBe("monitor");
+    delete process.env.CATALYST_NODE_CLASS;
+    writeLayer2({ catalyst: { node: { class: "wokrer" } } });
+    expect(nodeClassForRead()).toBe("monitor");
+  });
+
+  it("a present non-string class resolves to monitor; null/blank resolve to worker", () => {
+    writeLayer2({ catalyst: { node: { class: 7 } } });
+    expect(nodeClassForRead()).toBe("monitor");
+    writeLayer2({ catalyst: { node: { class: null } } });
     expect(nodeClassForRead()).toBe("worker");
+    writeLayer2({ catalyst: { node: { class: "  " } } });
+    expect(nodeClassForRead()).toBe("worker");
+  });
+
+  it("an empty CATALYST_LAYER2_CONFIG_FILE falls back to the default ~/.config path", () => {
+    // os.homedir() locks to $HOME at process startup, so redirecting it needs a
+    // fresh subprocess: HOME=temp + an EMPTY override must read temp/.config/...
+    // (the `||` fix) rather than resolving the path to "" (the `??` bug → worker).
+    const home = mkdtempSync(join(tmpdir(), "ctl1346-home-"));
+    mkdirSync(join(home, ".config", "catalyst"), { recursive: true });
+    writeFileSync(
+      join(home, ".config", "catalyst", "config.json"),
+      JSON.stringify({ catalyst: { node: { class: "developer" } } }),
+    );
+    const modulePath = join(import.meta.dir, "read-replica-config.ts");
+    const res = spawnSync(
+      "bun",
+      ["-e", `const m = await import(${JSON.stringify(modulePath)}); console.log(m.nodeClassForRead());`],
+      { env: { ...process.env, HOME: home, CATALYST_LAYER2_CONFIG_FILE: "" }, encoding: "utf8" },
+    );
+    expect(res.stdout.trim()).toBe("developer");
+    rmSync(home, { recursive: true, force: true });
   });
 });

--- a/plugins/dev/scripts/orch-monitor/cli/lib/read-replica-config.test.ts
+++ b/plugins/dev/scripts/orch-monitor/cli/lib/read-replica-config.test.ts
@@ -1,0 +1,91 @@
+// read-replica-config.test.ts — CTL-1346. Exercises the Node-side Layer-2 reads
+// (catalyst.readReplica.baseUrl + node class) that feed the read-replica resolver.
+import { describe, it, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { readReplicaBaseUrlFromLayer2, nodeClassForRead } from "./read-replica-config";
+
+const ENV_KEYS = ["CATALYST_NODE_CLASS", "CATALYST_LAYER2_CONFIG_FILE"];
+let saved: Record<string, string | undefined>;
+let tmp: string;
+
+beforeEach(() => {
+  saved = Object.fromEntries(ENV_KEYS.map((k) => [k, process.env[k]]));
+  tmp = mkdtempSync(join(tmpdir(), "ctl1346-"));
+  delete process.env.CATALYST_NODE_CLASS;
+  // Point Layer-2 at a guaranteed-absent file so an ambient config never leaks in.
+  process.env.CATALYST_LAYER2_CONFIG_FILE = join(tmp, "absent.json");
+});
+
+afterEach(() => {
+  for (const k of ENV_KEYS) {
+    if (saved[k] === undefined) delete process.env[k];
+    else process.env[k] = saved[k];
+  }
+  try {
+    rmSync(tmp, { recursive: true, force: true });
+  } catch {
+    /* best-effort */
+  }
+});
+
+function writeLayer2(obj: unknown): void {
+  const p = join(tmp, "config.json");
+  writeFileSync(p, JSON.stringify(obj));
+  process.env.CATALYST_LAYER2_CONFIG_FILE = p;
+}
+
+describe("readReplicaBaseUrlFromLayer2", () => {
+  it("reads a string catalyst.readReplica.baseUrl (trimmed)", () => {
+    writeLayer2({ catalyst: { readReplica: { baseUrl: "  http://mini:7400  " } } });
+    expect(readReplicaBaseUrlFromLayer2()).toBe("http://mini:7400");
+  });
+
+  it("returns null when the key is absent", () => {
+    writeLayer2({ catalyst: { host: { name: "mini" } } });
+    expect(readReplicaBaseUrlFromLayer2()).toBeNull();
+  });
+
+  it("returns null for a blank or non-string value", () => {
+    writeLayer2({ catalyst: { readReplica: { baseUrl: "   " } } });
+    expect(readReplicaBaseUrlFromLayer2()).toBeNull();
+    writeLayer2({ catalyst: { readReplica: { baseUrl: 7400 } } });
+    expect(readReplicaBaseUrlFromLayer2()).toBeNull();
+  });
+
+  it("never throws on a malformed/absent file", () => {
+    const p = join(tmp, "config.json");
+    writeFileSync(p, "{ not json");
+    process.env.CATALYST_LAYER2_CONFIG_FILE = p;
+    expect(() => readReplicaBaseUrlFromLayer2()).not.toThrow();
+    expect(readReplicaBaseUrlFromLayer2()).toBeNull();
+  });
+});
+
+describe("nodeClassForRead", () => {
+  it("defaults to worker when nothing is set", () => {
+    expect(nodeClassForRead()).toBe("worker");
+  });
+
+  it("reads CATALYST_NODE_CLASS env (trim + lowercase)", () => {
+    process.env.CATALYST_NODE_CLASS = "  Developer ";
+    expect(nodeClassForRead()).toBe("developer");
+  });
+
+  it("reads catalyst.node.class from Layer-2 when env is unset", () => {
+    writeLayer2({ catalyst: { node: { class: "developer" } } });
+    expect(nodeClassForRead()).toBe("developer");
+  });
+
+  it("env wins over Layer-2", () => {
+    writeLayer2({ catalyst: { node: { class: "worker" } } });
+    process.env.CATALYST_NODE_CLASS = "developer";
+    expect(nodeClassForRead()).toBe("developer");
+  });
+
+  it("an unrecognized class resolves to worker for read purposes (doctor flags the typo)", () => {
+    process.env.CATALYST_NODE_CLASS = "developr";
+    expect(nodeClassForRead()).toBe("worker");
+  });
+});

--- a/plugins/dev/scripts/orch-monitor/cli/lib/read-replica-config.ts
+++ b/plugins/dev/scripts/orch-monitor/cli/lib/read-replica-config.ts
@@ -14,12 +14,18 @@ import { homedir } from "node:os";
 import type { NodeClass } from "./read-model-url";
 
 const NODE_CLASSES: readonly NodeClass[] = ["developer", "worker", "monitor"];
+// An explicit but unrecognized class degrades to the most restrictive one, exactly
+// as config.mjs resolveNodeClass does, so a typo (e.g. `developr`) never reads the
+// empty localhost replica this resolver exists to avoid.
+const MOST_RESTRICTIVE_CLASS: NodeClass = "monitor";
 
 // Mirrors config.mjs getLayer2ConfigPath(): CATALYST_LAYER2_CONFIG_FILE override,
-// else ~/.config/catalyst/config.json.
+// else ~/.config/catalyst/config.json. Uses `||` (not `??`) so an empty-string
+// override (`CATALYST_LAYER2_CONFIG_FILE=`) falls back to the default path instead
+// of resolving to "" — parity with config.mjs.
 function layer2Path(): string {
   return (
-    process.env.CATALYST_LAYER2_CONFIG_FILE ??
+    process.env.CATALYST_LAYER2_CONFIG_FILE ||
     resolve(homedir(), ".config", "catalyst", "config.json")
   );
 }
@@ -43,22 +49,28 @@ export function readReplicaBaseUrlFromLayer2(): string | null {
 }
 
 /**
- * This node's class for read-resolution. Mirrors config.mjs getNodeClass
- * precedence: `CATALYST_NODE_CLASS` env → `catalyst.node.class` (Layer-2) →
- * default `worker`. The read path only branches on `developer`, so a
- * present-but-unrecognized value resolves to `worker` here (it reads its own
- * replica, the same as today); `catalyst doctor` is what FAILs a typo'd class
- * (see config.mjs resolveNodeClass). Never throws.
+ * This node's class for read-resolution. Mirrors config.mjs resolveNodeClass
+ * precedence and validity ladder: `CATALYST_NODE_CLASS` env → `catalyst.node.class`
+ * (Layer-2) → default `worker`.
+ *   - absent / null / empty-string ⇒ `worker` (the unset, zero-config default).
+ *   - a present-but-invalid value (non-string, or an unknown string like
+ *     `developr`) ⇒ the most-restrictive `monitor`, so a typo can never make a
+ *     developer node silently read the empty localhost replica (it errors instead;
+ *     `catalyst doctor` separately FAILs the typo'd class). Never throws.
  */
 export function nodeClassForRead(): NodeClass {
   const envRaw = process.env.CATALYST_NODE_CLASS;
-  const raw =
-    typeof envRaw === "string" && envRaw.trim().length > 0
-      ? envRaw
-      : (readLayer2() as { catalyst?: { node?: { class?: unknown } } } | null)?.catalyst?.node?.class;
-  if (typeof raw === "string") {
-    const normalized = raw.trim().toLowerCase();
-    if ((NODE_CLASSES as readonly string[]).includes(normalized)) return normalized as NodeClass;
-  }
-  return "worker";
+  const hasEnv = typeof envRaw === "string" && envRaw.trim().length > 0;
+  const raw = hasEnv
+    ? envRaw
+    : (readLayer2() as { catalyst?: { node?: { class?: unknown } } } | null)?.catalyst?.node?.class;
+
+  // Absent / explicit null/empty "unset" sentinel ⇒ worker (reads its own replica).
+  if (raw === undefined || raw === null) return "worker";
+  // Present but not a string ⇒ explicit misconfiguration ⇒ most restrictive.
+  if (typeof raw !== "string") return MOST_RESTRICTIVE_CLASS;
+  const normalized = raw.trim().toLowerCase();
+  if (normalized.length === 0) return "worker"; // empty/blank ⇒ unset (mirrors empty env)
+  if ((NODE_CLASSES as readonly string[]).includes(normalized)) return normalized as NodeClass;
+  return MOST_RESTRICTIVE_CLASS; // present non-empty but unknown ⇒ invalid
 }

--- a/plugins/dev/scripts/orch-monitor/cli/lib/read-replica-config.ts
+++ b/plugins/dev/scripts/orch-monitor/cli/lib/read-replica-config.ts
@@ -1,0 +1,64 @@
+// read-replica-config.ts — Node-side Layer-2 reads for the read-replica resolver
+// (CTL-1346). Mirrors execution-core/config.mjs (getLayer2ConfigPath / the
+// getNodeClass precedence / the catalyst.readReplica.baseUrl key) in TS so the CLI
+// never imports the `.mjs` config module — the same cross-runtime mirroring
+// lib/canonical-event-shared.ts already uses for the host name. Keeping the Layer-2
+// reads here (not in read-model-url.ts) keeps that resolver pure + bundler-safe.
+// Never throws: a missing/malformed/unreadable Layer-2 file falls through to the
+// safe default.
+
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { homedir } from "node:os";
+
+import type { NodeClass } from "./read-model-url";
+
+const NODE_CLASSES: readonly NodeClass[] = ["developer", "worker", "monitor"];
+
+// Mirrors config.mjs getLayer2ConfigPath(): CATALYST_LAYER2_CONFIG_FILE override,
+// else ~/.config/catalyst/config.json.
+function layer2Path(): string {
+  return (
+    process.env.CATALYST_LAYER2_CONFIG_FILE ??
+    resolve(homedir(), ".config", "catalyst", "config.json")
+  );
+}
+
+function readLayer2(): unknown {
+  try {
+    return JSON.parse(readFileSync(layer2Path(), "utf8"));
+  } catch {
+    return null; // missing/malformed → caller falls through to its safe default
+  }
+}
+
+/**
+ * `catalyst.readReplica.baseUrl` from the Layer-2 config, trimmed, or null when
+ * the key is unset / blank / non-string / the file is unreadable.
+ */
+export function readReplicaBaseUrlFromLayer2(): string | null {
+  const value = (readLayer2() as { catalyst?: { readReplica?: { baseUrl?: unknown } } } | null)
+    ?.catalyst?.readReplica?.baseUrl;
+  return typeof value === "string" && value.trim().length > 0 ? value.trim() : null;
+}
+
+/**
+ * This node's class for read-resolution. Mirrors config.mjs getNodeClass
+ * precedence: `CATALYST_NODE_CLASS` env → `catalyst.node.class` (Layer-2) →
+ * default `worker`. The read path only branches on `developer`, so a
+ * present-but-unrecognized value resolves to `worker` here (it reads its own
+ * replica, the same as today); `catalyst doctor` is what FAILs a typo'd class
+ * (see config.mjs resolveNodeClass). Never throws.
+ */
+export function nodeClassForRead(): NodeClass {
+  const envRaw = process.env.CATALYST_NODE_CLASS;
+  const raw =
+    typeof envRaw === "string" && envRaw.trim().length > 0
+      ? envRaw
+      : (readLayer2() as { catalyst?: { node?: { class?: unknown } } } | null)?.catalyst?.node?.class;
+  if (typeof raw === "string") {
+    const normalized = raw.trim().toLowerCase();
+    if ((NODE_CLASSES as readonly string[]).includes(normalized)) return normalized as NodeClass;
+  }
+  return "worker";
+}

--- a/website/src/content/docs/reference/configuration.md
+++ b/website/src/content/docs/reference/configuration.md
@@ -305,25 +305,29 @@ per-repo:
 
 ### Read-replica endpoint (`catalyst.readReplica.baseUrl`, CTL-1346)
 
-Board reads (the HUD, ticket detail, search) come from a monitor's `filter-state.db` replica, which is
-written **only** by a node's local broker. A daemonless `developer` node runs no broker, so its local
-replica is empty — it must read a **worker's** monitor over the network. The read endpoint resolves
+Board data lives in a monitor's `filter-state.db` replica, which is written **only** by a node's local
+broker. A daemonless `developer` node runs no broker, so its local replica is empty — it must read a
+**worker's** monitor over the network. `catalyst.readReplica.baseUrl` names that endpoint, resolved
 through:
 
 | Precedence | Source |
 | --- | --- |
 | 1 | `CATALYST_MONITOR_URL` env var (explicit override) |
 | 2 | `catalyst.readReplica.baseUrl` in the Layer-2 config (e.g. `http://mini:7400`) |
-| 3 | class-aware default — `developer` ⇒ **no fallback** (explicit error); `worker`/`monitor` ⇒ `http://127.0.0.1:7400` |
+| 3 | class-aware default — `developer`/`monitor` ⇒ **no fallback** (explicit error; both read a remote replica); `worker` ⇒ `http://127.0.0.1:7400` |
 
 ```json
 { "catalyst": { "readReplica": { "baseUrl": "http://mini:7400" } } }
 ```
 
-A `developer` node with **no** endpoint configured returns an explicit unset/error rather than silently
-reading an empty `localhost` replica. A `worker` or `monitor` node keeps the `127.0.0.1:7400` default
-(its own broker fills and serves the replica). This is **reads only** — writes still require a host with
-its own Linear key, preserving per-host rate-limit isolation.
+A `developer` (or `monitor`) node with **no** endpoint configured returns an explicit unset/error rather
+than silently reading an empty `localhost` replica; a `worker` keeps the `127.0.0.1:7400` default (its
+own broker fills and serves the replica). This is **reads only** — writes still require a host with its
+own Linear key, preserving per-host rate-limit isolation.
+
+> **Scope:** this resolver currently backs the **terminal HUD's** board reads. Pointing the browser/PWA
+> ticket-detail and search flows, and the `catalyst monitor` command, at the same remote endpoint is the
+> "split" deployment topology tracked in CTL-1347 / CTL-1354.
 
 ## GitHub merge rules live in GitHub
 

--- a/website/src/content/docs/reference/configuration.md
+++ b/website/src/content/docs/reference/configuration.md
@@ -303,6 +303,28 @@ per-repo:
   until the value is corrected — so a typo can never make a node pick up work.
 - A missing or malformed Layer-2 file never throws; it falls through to the `worker` default.
 
+### Read-replica endpoint (`catalyst.readReplica.baseUrl`, CTL-1346)
+
+Board reads (the HUD, ticket detail, search) come from a monitor's `filter-state.db` replica, which is
+written **only** by a node's local broker. A daemonless `developer` node runs no broker, so its local
+replica is empty — it must read a **worker's** monitor over the network. The read endpoint resolves
+through:
+
+| Precedence | Source |
+| --- | --- |
+| 1 | `CATALYST_MONITOR_URL` env var (explicit override) |
+| 2 | `catalyst.readReplica.baseUrl` in the Layer-2 config (e.g. `http://mini:7400`) |
+| 3 | class-aware default — `developer` ⇒ **no fallback** (explicit error); `worker`/`monitor` ⇒ `http://127.0.0.1:7400` |
+
+```json
+{ "catalyst": { "readReplica": { "baseUrl": "http://mini:7400" } } }
+```
+
+A `developer` node with **no** endpoint configured returns an explicit unset/error rather than silently
+reading an empty `localhost` replica. A `worker` or `monitor` node keeps the `127.0.0.1:7400` default
+(its own broker fills and serves the replica). This is **reads only** — writes still require a host with
+its own Linear key, preserving per-host rate-limit isolation.
+
 ## GitHub merge rules live in GitHub
 
 Catalyst can open PRs, fix CI, answer review bots, and merge. But GitHub decides what must pass before code lands. Those rules live in **GitHub branch protection or rulesets**, not in `.catalyst/config.json`.


### PR DESCRIPTION
## What

M2 of **Node Classes & Packaging**. A `developer` (daemonless) node runs no broker, so its local `filter-state.db` replica is empty — it must read a **worker's** monitor. This evolves the read-model URL resolver (`orch-monitor/cli/lib/read-model-url.ts`) to be node-class + Layer-2 aware, per the CTL-1345 audit (the resolver already existed — adopt, don't reinvent).

## Resolution precedence

1. `CATALYST_MONITOR_URL` env (explicit override — still wins)
2. `catalyst.readReplica.baseUrl` (Layer-2 machine-local config)
3. class-aware default — `developer` ⇒ explicit unset/error (**no** silent localhost, which would serve an empty replica); `worker`/`monitor` ⇒ `http://127.0.0.1:7400`

## Acceptance criteria → coverage

| AC | Where |
| --- | --- |
| Adopt the resolver as canonical for board reads | `resolveReadModelBase`/`resolveReadModelStreamUrl`; `useReadModel` consumes it |
| `catalyst.readReplica.baseUrl` binds (env still wins) | `read-replica-config.ts` + resolver precedence; tests |
| Developer + no endpoint ⇒ explicit error, no localhost | `{ ok:false }` path; `useReadModel` reports `down` + stderr, never connects to localhost |
| Worker/monitor + no key ⇒ `127.0.0.1:7400` | class-aware default; tests |
| Writes (linearis) unchanged — reads only | no write path touched; per-host-key 429 isolation preserved |

## Design notes

- The resolver stays **pure** (env + Layer-2 baseUrl + node class all injected), so it imports no fs/config and stays bundler-safe (no `bun:sqlite`/vite trap).
- `read-replica-config.ts` does the Node-side Layer-2 reads in TS, **mirroring** `execution-core/config.mjs` (the same cross-runtime pattern `lib/canonical-event-shared.ts` uses for the host name) so the CLI never imports the `.mjs` config.
- Replaces the old `resolveReadModelUrl` with the node-aware `resolveReadModelStreamUrl` (single canonical resolver; no dead export — knip clean).

## Gates

- `bun test` (resolver + Layer-2 reader): 21 new/updated tests pass
- `typecheck` (tsc), `knip:ci` (dead-code), `eslint`: clean
- Docs site builds clean (`npm run build`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)