### PR TITLE
fix(dev): CTL-1363 — cluster-claim resolveIssueId via issue(id:) (unwedge fleet dispatch)

### DIFF
--- a/plugins/dev/scripts/execution-core/cluster-claim.mjs
+++ b/plugins/dev/scripts/execution-core/cluster-claim.mjs
@@ -99,17 +99,27 @@ async function defaultPost(query, variables) {
 
 // ─── identifier → issue UUID ─────────────────────────────────────────────────
 
+// CTL-1363: resolve via the `issue(id:)` query, which accepts the human
+// identifier ("CTL-842") directly and returns the UUID. The previous
+// `issues(filter:{identifier:{eq}})` form was a hard 400 — IssueFilter has no
+// `identifier` field ("Field 'identifier' is not defined by type 'IssueFilter'")
+// — so resolveIssueId ALWAYS 400'd and every cross-host claim write aborted.
+// When multiHost=true that silently wedged fleet dispatch: the monitor's triage
+// dispatch failed the claim and never wrote triage.json, so the scheduler held
+// every new-work candidate at the CTL-1150 triage gate (all at log.debug, so
+// invisible at INFO). Same bug + fix as cluster-heartbeat.mjs (CTL-1255).
+// READ_ATTACHMENTS_QUERY below already uses `issue(id:)` — which is why reads
+// worked while writes silently 400'd.
 const RESOLVE_ISSUE_QUERY = `query ResolveIssueId($id: String!) {
-  issues(filter: { identifier: { eq: $id } }) { nodes { id } }
+  issue(id: $id) { id }
 }`;
 
 // resolveIssueId — a ticket identifier (e.g. "CTL-842") → its issue UUID, or
-// null when no issue matches. Mirrors lib/linear-comment-post.sh's resolution
-// (issues filter on identifier.eq). attachmentCreate needs the UUID, not the
+// null when no issue matches. attachmentCreate needs the UUID, not the
 // identifier. Exported for unit coverage + reuse.
 export async function resolveIssueId(ticket, { post = defaultPost } = {}) {
   const data = await post(RESOLVE_ISSUE_QUERY, { id: ticket });
-  return data?.issues?.nodes?.[0]?.id ?? null;
+  return data?.issue?.id ?? null;
 }
 
 // ─── read ────────────────────────────────────────────────────────────────────

--- a/plugins/dev/scripts/execution-core/cluster-claim.test.mjs
+++ b/plugins/dev/scripts/execution-core/cluster-claim.test.mjs
@@ -51,9 +51,19 @@ function makeFakeLinear({ seed = {}, missingIssues = new Set() } = {}) {
     calls.push({ query, variables });
 
     if (query.includes("ResolveIssueId")) {
+      // CTL-1363: the real Linear API returns HTTP 400 on
+      // issues(filter:{identifier:...}) — IssueFilter has no `identifier` field.
+      // Mirror that here so a regression to the broken query shape FAILS the
+      // test instead of silently passing (the mock gap that let the original
+      // fleet-dispatch wedge ship). Only the issue(id:) form is accepted.
+      if (query.includes("identifier")) {
+        throw new Error(
+          'linear graphql http 400: Field "identifier" is not defined by type "IssueFilter"'
+        );
+      }
       const id = variables.id;
-      if (missingIssues.has(id)) return { issues: { nodes: [] } };
-      return { issues: { nodes: [{ id: `uuid-${id}` }] } };
+      if (missingIssues.has(id)) return { issue: null };
+      return { issue: { id: `uuid-${id}` } };
     }
 
     if (query.includes("ReadFence")) {
@@ -142,6 +152,17 @@ describe("resolveIssueId — identifier → UUID", () => {
   it("returns null when no issue matches", async () => {
     const { post } = makeFakeLinear({ missingIssues: new Set(["CTL-999"]) });
     expect(await resolveIssueId("CTL-999", { post })).toBeNull();
+  });
+  // CTL-1363 regression guard: resolveIssueId MUST query via issue(id:), never
+  // the issues(filter:{identifier:{eq}}) form — IssueFilter has no `identifier`
+  // field, so that form is a hard 400 that silently wedged fleet dispatch.
+  it("queries via issue(id:) and never the issues(filter:{identifier}) form (CTL-1363)", async () => {
+    const { post, calls } = makeFakeLinear();
+    await resolveIssueId("CTL-842", { post });
+    const resolveCall = calls.find((c) => c.query.includes("ResolveIssueId"));
+    expect(resolveCall).toBeDefined();
+    expect(resolveCall.query).toContain("issue(id:");
+    expect(resolveCall.query).not.toContain("identifier");
   });
 });
 
@@ -243,7 +264,7 @@ describe("claimTicket — soft-CAS via read-back", () => {
     // modelling a concurrent host that won the serialized write race.
     let writes = 0;
     async function post(query) {
-      if (query.includes("ResolveIssueId")) return { issues: { nodes: [{ id: "uuid-CTL-842" }] } };
+      if (query.includes("ResolveIssueId")) return { issue: { id: "uuid-CTL-842" } };
       if (query.includes("UpsertFence")) {
         writes += 1;
         return { attachmentCreate: { success: true, attachment: {} } };
@@ -269,7 +290,7 @@ describe("claimTicket — soft-CAS via read-back", () => {
   it("read-back shows a HIGHER generation → won:false (we were leapfrogged)", async () => {
     let writes = 0;
     async function post(query) {
-      if (query.includes("ResolveIssueId")) return { issues: { nodes: [{ id: "uuid-CTL-842" }] } };
+      if (query.includes("ResolveIssueId")) return { issue: { id: "uuid-CTL-842" } };
       if (query.includes("UpsertFence")) {
         writes += 1;
         return { attachmentCreate: { success: true, attachment: {} } };
@@ -329,7 +350,7 @@ describe("claimTicket — stale-claim preemption (CTL-1297)", () => {
     const now = () => Date.parse("2026-06-20T00:00:30.000Z"); // 30s later → fresh
     let writes = 0;
     async function post(query) {
-      if (query.includes("ResolveIssueId")) return { issues: { nodes: [{ id: "uuid-CTL-842" }] } };
+      if (query.includes("ResolveIssueId")) return { issue: { id: "uuid-CTL-842" } };
       if (query.includes("UpsertFence")) {
         writes += 1;
         return { attachmentCreate: { success: true, attachment: {} } };
@@ -445,7 +466,7 @@ describe("runCli — the spawnSync CLI surface (CTL-850)", () => {
     // decides not-to-dispatch from the `won:false` it parses out of stdout.
     let writes = 0;
     async function post(query) {
-      if (query.includes("ResolveIssueId")) return { issues: { nodes: [{ id: "uuid-CTL-842" }] } };
+      if (query.includes("ResolveIssueId")) return { issue: { id: "uuid-CTL-842" } };
       if (query.includes("UpsertFence")) {
         writes += 1;
         return { attachmentCreate: { success: true, attachment: {} } };


### PR DESCRIPTION
## The unwedge (CTL-1363)

`cluster-claim.mjs` `RESOLVE_ISSUE_QUERY` used `issues(filter:{identifier:{eq:$id}})`, but Linear's `IssueFilter` has **no `identifier` field** → every cross-host claim returned **HTTP 400** (`GRAPHQL_VALIDATION_FAILED`). With `multiHost=true` (roster `[mini, mini-2]`) **both** dispatch surfaces route through this claim:

- the monitor's triage dispatch failed the 400 → fail-closed `{won:false}` → logged only at `log.debug` → **never wrote `triage.json`**;
- the scheduler then held **every** new-work candidate at the **CTL-1150 triage gate** (no `triage.json`), also `log.debug`.

Net: **`dispatched:0` fleet-wide**, invisible at INFO, looking like a healthy idle daemon. Latent since CTL-859; only bites when `multiHost=true` with undrained Todo work (i.e. once `mini-2` joined the roster).

Root cause was found + **live-reproduced** by a multi-agent RCA (3/3 adversarial lenses upheld). Full analysis in the CTL-1363 handoff.

## Fix

Resolve via `issue(id:$id){id}` (accepts the identifier directly) — the **same bug+fix** `cluster-heartbeat.mjs` already shipped under **CTL-1255**; `READ_ATTACHMENTS_QUERY` in this same file already uses `issue(id:)`, which is exactly why reads worked while writes silently 400'd.

Also closes the **test-mock gap** that let this ship: the fake Linear now mirrors the real API (throws HTTP 400 on an `identifier` filter), and a regression guard asserts `resolveIssueId` queries via `issue(id:)` and never the identifier-filter form.

Tests: cluster-claim 34 pass, cluster-claim-sync 15 pass.

## ⚠️ DRAFT — deploy is gated

Merging this auto-deploys (broker auto-pull → exec-core restart) and **unwedges dispatch fleet-wide**, which will auto-dispatch the currently-eligible Todo work: **ADV-1398** (8-pt), **ADV-1400, ADV-1401, ADV-1405**, and **CTL-1286** (broker self-heal — core infra). Hold for Ryan's triage of that Todo set before merging.

## Follow-ups (separate tickets, from the RCA)

- claimDispatchSync should fail **loud** on a permanent 400 vs a transient claim loss
- per-tick INFO dispatch-decision line (candidates / dispatched / per-gate held counts)
- alert on `free_slots>0 ∧ eligible>0 ∧ dispatched=0` sustained
- CI test of the full claim round-trip against the real Linear schema
- quiet the `ratelimit-poller: no OAuth token available` red herring

🤖 Generated with [Claude Code](https://claude.com/claude-code)