### PR TITLE
feat(dev): CTL-1365a — executor flag + resolution seam + catalyst.dispatch.mode telemetry (inert, default bg)

### DIFF
--- a/plugins/dev/scripts/__tests__/lib-executor.test.sh
+++ b/plugins/dev/scripts/__tests__/lib-executor.test.sh
@@ -140,6 +140,15 @@ CPU=$(executor_job_cpu "nope0000")
 [ -z "$CPU" ] && pass "missing state.json → empty CPU" || fail "missing state.json → empty CPU" "got: '$CPU'"
 teardown
 
+echo "test 10: executor_kind — CATALYST_EXECUTOR (default bg) (CTL-1365a)"
+setup
+unset CATALYST_EXECUTOR
+[ "$(executor_kind)" = "bg" ] && pass "unset → bg" || fail "unset → bg" "got: $(executor_kind)"
+export CATALYST_EXECUTOR="sdk"
+[ "$(executor_kind)" = "sdk" ] && pass "echoes CATALYST_EXECUTOR" || fail "echoes CATALYST_EXECUTOR" "got: $(executor_kind)"
+unset CATALYST_EXECUTOR
+teardown
+
 echo ""
 echo "─────────────────────────────────────────"
 echo "Results: ${PASSES} pass, ${FAILURES} fail"

--- a/plugins/dev/scripts/execution-core/config.mjs
+++ b/plugins/dev/scripts/execution-core/config.mjs
@@ -375,6 +375,144 @@ export function getNodeClass() {
   return r.class;
 }
 
+// --- CTL-1365a: phase-worker executor selection seam ---
+//
+// `catalyst.orchestration.executor` selects the phase-worker substrate at the
+// dispatch seam. Three substrates:
+//   - "bg"             today's detached `claude --bg` job via phase-agent-dispatch.
+//   - "sdk"            in-process @anthropic-ai/claude-agent-sdk query() worker
+//                      (CTL-1365b). NOT yet implemented — resolves here, but the
+//                      dispatch wiring (dispatch.mjs:dispatchForExecutor) falls
+//                      back to bg + warns until 1b lands.
+//   - "oneshot-legacy" the catalyst-legacy single long-lived job/ticket fallback.
+//
+// Resolution mirrors resolveNodeClass: CATALYST_EXECUTOR env → Layer-1
+// catalyst.orchestration.executor → node-class default. Phase 1: every node-class
+// maps to "bg", so the resolver is a pure no-op (an unset flag never changes
+// behavior) until an operator explicitly flips a node.
+export const EXECUTORS = Object.freeze(["bg", "sdk", "oneshot-legacy"]);
+// The most-restrictive / always-safe substrate. An unrecognized explicit value
+// degrades HERE (never silently to sdk) + warns once, mirroring
+// NODE_CLASS_MOST_RESTRICTIVE — a typo'd flag can never put a node on an
+// unintended substrate.
+const EXECUTOR_DEFAULT = "bg";
+// The node-class default map (Phase 1: all "bg"). Keyed by getNodeClass(); a class
+// absent from the map falls back to EXECUTOR_DEFAULT. This is the ONE place that
+// changes (per class) once Phase 2 validates sdk on a node class.
+const EXECUTOR_BY_NODE_CLASS = Object.freeze({
+  developer: "bg",
+  worker: "bg",
+  monitor: "bg",
+});
+
+// The dispatch-mode telemetry vocab (CTL-1365a / OTEL #43/#44, frozen 2026-06-25).
+// executor → catalyst.dispatch.mode value. Closed enum {phase-agents |
+// oneshot-legacy | sdk}: "bg" maps to the existing "phase-agents" label so the
+// telemetry name is stable across the rename.
+export const DISPATCH_MODES = Object.freeze(["phase-agents", "oneshot-legacy", "sdk"]);
+const DISPATCH_MODE_BY_EXECUTOR = Object.freeze({
+  bg: "phase-agents",
+  sdk: "sdk",
+  "oneshot-legacy": "oneshot-legacy",
+});
+// dispatchModeForExecutor — map a resolved executor to its dispatch-mode telemetry
+// value. Unknown/undefined → "phase-agents" (the safe default that matches today's
+// substrate). Pure; never throws.
+export function dispatchModeForExecutor(executor) {
+  return DISPATCH_MODE_BY_EXECUTOR[executor] ?? "phase-agents";
+}
+
+// readExecutorLayer1 — pull catalyst.orchestration.executor out of a project's
+// Layer-1 .catalyst/config.json. Returns the raw value EXACTLY as written, or
+// undefined when the key is absent or the file is missing/malformed/unreadable
+// (so callers fall back to env/node-class default). Never throws — mirrors
+// readFleetHealthConfigLayer1's ENOENT-tolerant shape. resolveExecutor — not this
+// reader — judges validity, so a present-but-non-string value reaches it as an
+// explicit misconfiguration rather than being flattened to "absent".
+export function readExecutorLayer1(configPath) {
+  if (!configPath) return undefined;
+  try {
+    const parsed = JSON.parse(readFileSync(configPath, "utf8"));
+    return parsed?.catalyst?.orchestration?.executor;
+  } catch (err) {
+    if (err?.code !== "ENOENT") {
+      log.warn(
+        { configPath, err: err.message },
+        "executor: Layer-1 config unreadable; using node-class default"
+      );
+    }
+    return undefined;
+  }
+}
+
+// resolveExecutor — the pure, no-logging executor resolver. Precedence mirrors
+// resolveNodeClass (CATALYST_EXECUTOR env → Layer-1 catalyst.orchestration.executor
+// → node-class default) and never throws. Returns the full resolution detail so
+// the hot dispatch seam stays log-free and getExecutor()/doctor can decide on the
+// warn:
+//   { executor, source, inferred, recognized, raw }
+//   - source     ∈ "env" | "layer1" | "default"
+//   - inferred   = true only for the node-class default (no explicit value anywhere)
+//   - recognized = whether an explicit value named a real executor (true for the
+//                  inferred default; false routes the WARN/doctor to flag the typo)
+//   - raw        = the explicit value exactly as written (for the WARN/doctor text)
+//
+// Validity ladder (mirrors resolveNodeClass):
+//   - absent (no env + key undefined) OR an explicit null/empty "unset" sentinel
+//     ⇒ benign node-class default (inferred; zero behavior change in Phase 1).
+//   - a present non-string value (false/0/[]/{}) ⇒ explicit misconfiguration ⇒
+//     recognized:false (most-restrictive "bg"), never a silent sdk.
+//   - a non-empty string is trimmed + lowercased before the membership check, so
+//     "BG" / " sdk " resolve to their canonical executor; only a genuine
+//     non-member ("bgg") is recognized:false.
+export function resolveExecutor(configPath) {
+  const envRaw = process.env.CATALYST_EXECUTOR;
+  const hasEnv = typeof envRaw === "string" && envRaw.trim().length > 0;
+  const raw = hasEnv ? envRaw : readExecutorLayer1(configPath);
+  const source = hasEnv ? "env" : "layer1";
+
+  const nodeClassDefault = EXECUTOR_BY_NODE_CLASS[resolveNodeClass().class] ?? EXECUTOR_DEFAULT;
+
+  // Absent / explicit "unset" sentinel (undefined key or JSON null) ⇒ node-class default.
+  if (raw === undefined || raw === null) {
+    return { executor: nodeClassDefault, source: "default", inferred: true, recognized: true, raw: null };
+  }
+  // Present but not a string ⇒ explicit misconfiguration, never a silent sdk.
+  if (typeof raw !== "string") {
+    return { executor: EXECUTOR_DEFAULT, source, inferred: false, recognized: false, raw };
+  }
+  const normalized = raw.trim().toLowerCase();
+  // Empty/whitespace string ⇒ "cleared" (mirrors an empty env var) ⇒ node-class default.
+  if (normalized.length === 0) {
+    return { executor: nodeClassDefault, source: "default", inferred: true, recognized: true, raw: null };
+  }
+  if (EXECUTORS.includes(normalized)) {
+    return { executor: normalized, source, inferred: false, recognized: true, raw };
+  }
+  return { executor: EXECUTOR_DEFAULT, source, inferred: false, recognized: false, raw };
+}
+
+// getExecutor — the convenience accessor the dispatch seam reads. Returns the
+// resolved executor string (bg|sdk|oneshot-legacy). Emits a once-per-process WARN
+// ONLY for an unrecognized explicit value (the typo guard — mirrors getNodeClass).
+// An inferred node-class default is silent: in Phase 1 the WHOLE fleet is
+// intentionally defaulted, so there is nothing to declare and a per-boot warn
+// would be pure noise. Never throws.
+const _warnedExecutor = new Set();
+export function getExecutor(configPath) {
+  const r = resolveExecutor(configPath);
+  if (!r.recognized) {
+    const msg =
+      `catalyst.orchestration.executor "${r.raw}" is not one of [${EXECUTORS.join(", ")}] — ` +
+      `falling back to "${r.executor}" (most restrictive)`;
+    if (!_warnedExecutor.has(msg)) {
+      _warnedExecutor.add(msg);
+      log.warn(msg);
+    }
+  }
+  return r.executor;
+}
+
 // getStaticRoster — the `static` escape-hatch roster (CTL-1273). A multi-host
 // operator who does NOT want the Linear anchor can pin an explicit node list in
 // the Layer-2 machine-local config under catalyst.cluster.staticRoster (a JSON

--- a/plugins/dev/scripts/execution-core/config.test.mjs
+++ b/plugins/dev/scripts/execution-core/config.test.mjs
@@ -40,6 +40,12 @@ import {
   DEAD_DOC_WORKER_TRANSCRIPT_SILENCE_MS,
   readLinearReplica,
   getReplicaDbPath,
+  EXECUTORS,
+  DISPATCH_MODES,
+  readExecutorLayer1,
+  resolveExecutor,
+  getExecutor,
+  dispatchModeForExecutor,
 } from "./config.mjs";
 
 const PREV = process.env.CATALYST_WAIT_WATCHER;
@@ -410,6 +416,148 @@ describe("getStaticRoster (CTL-1273)", () => {
   test("CATALYST_STATIC_ROSTER env override (comma-separated)", () => {
     process.env.CATALYST_STATIC_ROSTER = "mini, mini-2 ,";
     expect(getStaticRoster()).toEqual(["mini", "mini-2"]);
+  });
+});
+
+describe("executor flag + resolver (CTL-1365a)", () => {
+  // CATALYST_NODE_CLASS + a temp Layer-2 file keep the node-class default
+  // deterministic (worker → "bg" in Phase 1) so the precedence assertions don't
+  // depend on the host's real Layer-2 config.
+  const ENVS = ["CATALYST_EXECUTOR", "CATALYST_NODE_CLASS", "CATALYST_LAYER2_CONFIG_FILE"];
+  let saved = {};
+  let tmp, l1, l2;
+
+  beforeEach(() => {
+    for (const k of ENVS) {
+      saved[k] = process.env[k];
+      delete process.env[k];
+    }
+    tmp = mkdtempSync(join(tmpdir(), "ctl1365-exec-"));
+    l1 = join(tmp, "config.json"); // Layer-1 .catalyst/config.json
+    l2 = join(tmp, "layer2.json"); // Layer-2 machine-local (empty → node-class default worker)
+    process.env.CATALYST_LAYER2_CONFIG_FILE = l2;
+  });
+
+  afterEach(() => {
+    for (const k of ENVS) {
+      if (saved[k] === undefined) delete process.env[k];
+      else process.env[k] = saved[k];
+    }
+    saved = {};
+    rmSync(tmp, { recursive: true, force: true });
+  });
+
+  const writeL1 = (executor) =>
+    writeFileSync(l1, JSON.stringify({ catalyst: { orchestration: { executor } } }));
+
+  test("EXECUTORS + DISPATCH_MODES are frozen closed enums", () => {
+    expect(EXECUTORS).toEqual(["bg", "sdk", "oneshot-legacy"]);
+    expect(Object.isFrozen(EXECUTORS)).toBe(true);
+    expect(DISPATCH_MODES).toEqual(["phase-agents", "oneshot-legacy", "sdk"]);
+    expect(Object.isFrozen(DISPATCH_MODES)).toBe(true);
+    expect(() => {
+      EXECUTORS.push("rogue");
+    }).toThrow();
+  });
+
+  test("dispatchModeForExecutor maps bg→phase-agents, sdk→sdk, oneshot-legacy→oneshot-legacy, unknown→phase-agents", () => {
+    expect(dispatchModeForExecutor("bg")).toBe("phase-agents");
+    expect(dispatchModeForExecutor("sdk")).toBe("sdk");
+    expect(dispatchModeForExecutor("oneshot-legacy")).toBe("oneshot-legacy");
+    expect(dispatchModeForExecutor("nonsense")).toBe("phase-agents");
+    expect(dispatchModeForExecutor(undefined)).toBe("phase-agents");
+  });
+
+  test("node-class default is bg in Phase 1 (no env, no Layer-1)", () => {
+    const r = resolveExecutor(l1); // l1 does not exist yet
+    expect(r.executor).toBe("bg");
+    expect(r.source).toBe("default");
+    expect(r.inferred).toBe(true);
+    expect(r.recognized).toBe(true);
+    expect(getExecutor(l1)).toBe("bg");
+  });
+
+  test("Layer-1 catalyst.orchestration.executor overrides the node-class default", () => {
+    writeL1("sdk");
+    const r = resolveExecutor(l1);
+    expect(r.executor).toBe("sdk");
+    expect(r.source).toBe("layer1");
+    expect(r.inferred).toBe(false);
+    expect(getExecutor(l1)).toBe("sdk");
+  });
+
+  test("CATALYST_EXECUTOR env outranks Layer-1 (env > Layer-1 > node-class default)", () => {
+    writeL1("oneshot-legacy");
+    process.env.CATALYST_EXECUTOR = "sdk";
+    const r = resolveExecutor(l1);
+    expect(r.executor).toBe("sdk");
+    expect(r.source).toBe("env");
+    expect(getExecutor(l1)).toBe("sdk");
+  });
+
+  test("env/Layer-1 values are trimmed + lowercased to canonical executors", () => {
+    process.env.CATALYST_EXECUTOR = "  SDK ";
+    expect(resolveExecutor(l1).executor).toBe("sdk");
+    delete process.env.CATALYST_EXECUTOR;
+    writeL1("ONESHOT-LEGACY");
+    expect(resolveExecutor(l1).executor).toBe("oneshot-legacy");
+  });
+
+  test("unrecognized explicit value → bg (most restrictive) + recognized:false", () => {
+    process.env.CATALYST_EXECUTOR = "bgg";
+    const r = resolveExecutor(l1);
+    expect(r.executor).toBe("bg");
+    expect(r.recognized).toBe(false);
+    expect(r.raw).toBe("bgg");
+  });
+
+  test("getExecutor warns exactly ONCE per unique unrecognized value", () => {
+    const warnings = [];
+    const orig = console.warn;
+    // The console-shim path logs WARN to stderr; capture via process.stderr.write.
+    const origWrite = process.stderr.write.bind(process.stderr);
+    process.stderr.write = (chunk, ...rest) => {
+      warnings.push(String(chunk));
+      return true;
+    };
+    try {
+      process.env.CATALYST_EXECUTOR = "ctl1365-unique-typo-A";
+      getExecutor(l1);
+      getExecutor(l1);
+      getExecutor(l1);
+    } finally {
+      process.stderr.write = origWrite;
+      console.warn = orig;
+    }
+    const hits = warnings.filter((w) => w.includes("ctl1365-unique-typo-A"));
+    expect(hits.length).toBe(1); // warn-once dedupe
+  });
+
+  test("present-but-non-string Layer-1 value → bg + recognized:false (never silent sdk)", () => {
+    writeFileSync(l1, JSON.stringify({ catalyst: { orchestration: { executor: false } } }));
+    const r = resolveExecutor(l1);
+    expect(r.executor).toBe("bg");
+    expect(r.recognized).toBe(false);
+  });
+
+  test("ENOENT / malformed Layer-1 → bg, never throws", () => {
+    // Missing file (readExecutorLayer1 returns undefined → node-class default).
+    expect(() => resolveExecutor(join(tmp, "does-not-exist.json"))).not.toThrow();
+    expect(resolveExecutor(join(tmp, "does-not-exist.json")).executor).toBe("bg");
+    expect(readExecutorLayer1(join(tmp, "does-not-exist.json"))).toBeUndefined();
+    // Malformed JSON.
+    writeFileSync(l1, "{ not json");
+    expect(() => resolveExecutor(l1)).not.toThrow();
+    expect(resolveExecutor(l1).executor).toBe("bg");
+    // No configPath at all.
+    expect(readExecutorLayer1(undefined)).toBeUndefined();
+    expect(resolveExecutor(undefined).executor).toBe("bg");
+  });
+
+  test("empty-string env is 'cleared' → node-class default", () => {
+    process.env.CATALYST_EXECUTOR = "   ";
+    writeL1("sdk"); // empty env falls through to Layer-1
+    expect(resolveExecutor(l1).executor).toBe("sdk");
   });
 });
 

--- a/plugins/dev/scripts/execution-core/daemon.mjs
+++ b/plugins/dev/scripts/execution-core/daemon.mjs
@@ -51,6 +51,8 @@ import {
   getCatalystRepoDir,       // CTL-1093 sticky dir
   readDelegateRunnerConfig, // CTL-1331: async board-health delegate runner kill-switch
   readLinearReplica,        // CTL-1340: read-replica tier flag (inert; default off)
+  getExecutor,              // CTL-1365a: phase-worker executor resolver (env→Layer-1→node-class default; all "bg" in Phase 1)
+  dispatchModeForExecutor,  // CTL-1365a: executor → catalyst.dispatch.mode telemetry vocab
 } from "./config.mjs";
 import { resolveBootIdentity } from "./host-boot-identity.mjs"; // CTL-1093
 import { readStickyIdentity, writeStickyIdentity } from "./host-sticky.mjs"; // CTL-1093
@@ -118,7 +120,7 @@ import {
 import * as linearWrite from "./linear-write.mjs"; // CTL-1067: writeStatus for defaultClearStall
 import { writeBootMarker, clearProgressMarks, resolvePhaseSessionId, defaultAppendOperatorEvent } from "./recovery.mjs"; // CTL-655: window the revive budget to this run; CTL-736: reset progress high-water; CTL-768: --resume; CTL-1044: operator-event appender for the scheduler's appendIntentEvent seam
 import { startAutoTuner } from "./autotune.mjs"; // CTL-684: side-car maxParallel auto-tuner
-import { dispatchTicket } from "./dispatch.mjs"; // CTL-549: comment-wake re-dispatch
+import { dispatchTicket, dispatchForExecutor } from "./dispatch.mjs"; // CTL-549: comment-wake re-dispatch; CTL-1365a: executor→dispatch selection at the launch seam
 import { removeLabel as defaultRemoveLabel } from "./linear-write.mjs"; // CTL-549: clear needs-human on resume
 // CTL-671: the real phantom-sweep seams. startScheduler defaults them to safe
 // no-ops (hermetic for direct-call unit tests); the REAL daemon arms them here
@@ -616,9 +618,23 @@ export function startDaemon({
     const linearBotUserIds = readLinearBotUserIds(configPath, layer2Path);
     const linearBotWriteId = readLinearBotWriteId(configPath, layer2Path); // CTL-781
     const commentInboxWriter = createCommentInboxWriter(orchDir, linearBotUserIds);
+    // CTL-1365a: resolve the phase-worker executor ONCE at the dispatch seam and
+    // select the dispatch function injected into BOTH the monitor's →Triage
+    // one-shot dispatch and the scheduler's pull loop. Phase 1 is INERT —
+    // getExecutor's node-class default is "bg" for every class, so an unset flag
+    // resolves to "bg" and dispatchForExecutor returns the unchanged
+    // defaultDispatch (byte-identical to today). "sdk" falls back to
+    // defaultDispatch + a once-per-process WARN until sdkRunPhaseAgent lands
+    // (CTL-1365b). The dispatch-mode telemetry vocab ("phase-agents" for bg) is
+    // derived from the same resolution and threaded into the scheduler's Tier-1
+    // tick-timing line + OTLP resource attr.
+    const executor = getExecutor(configPath);
+    const dispatchFn = dispatchForExecutor(executor);
+    const dispatchMode = dispatchModeForExecutor(executor);
     monitorFn({
       orchDir,
       cache,
+      dispatch: dispatchFn, // CTL-1365a: →Triage one-shot dispatch substrate (bg today)
       concurrency, // CTL-716: slot-gate uses the same ceiling as the scheduler
       botUserIds: linearBotUserIds, // CTL-781: respect-assignment gate
       botWriteId: linearBotWriteId, // CTL-781: self-assign on claim
@@ -635,6 +651,8 @@ export function startDaemon({
     schedulerFn({
       orchDir,
       cache,
+      dispatch: dispatchFn, // CTL-1365a: scheduler pull-loop dispatch substrate (bg today)
+      dispatchMode, // CTL-1365a: catalyst.dispatch.mode for the Tier-1 tick line + OTLP resource attr
       concurrency,
       configPath,
       layer2Path,

--- a/plugins/dev/scripts/execution-core/dispatch.mjs
+++ b/plugins/dev/scripts/execution-core/dispatch.mjs
@@ -17,6 +17,7 @@ import { spawnSync } from "node:child_process";
 import { fileURLToPath } from "node:url";
 import { getProjectConfig } from "./registry.mjs";
 import { createWorktree as defaultCreateWorktree } from "./worktree.mjs";
+import { log } from "./config.mjs"; // CTL-1365a: once-per-process sdk-fallback WARN
 
 // phase-agent-dispatch sits one directory up from execution-core/.
 const PHASE_AGENT_DISPATCH_BIN = fileURLToPath(new URL("../phase-agent-dispatch", import.meta.url));
@@ -186,6 +187,32 @@ export function defaultDispatch(
     clusterGeneration,
   }); // CTL-761, CTL-864
   return { ...res, worktreePath: wt.worktreePath };
+}
+
+// dispatchForExecutor — CTL-1365a: map a resolved executor (config.mjs:getExecutor)
+// to the dispatch function the daemon injects into startScheduler / startMonitor.
+// Phase 1 is INERT:
+//   - "bg" | "oneshot-legacy" → the unchanged defaultDispatch. Returning
+//     defaultDispatch is IDENTICAL to relying on the dispatch=defaultDispatch
+//     default param, so the existing dispatch.test.mjs arg-array `toEqual`
+//     assertions are completely unaffected — the dispatched behavior is
+//     byte-identical to today.
+//   - "sdk" → sdkRunPhaseAgent does NOT exist yet (it arrives in CTL-1365b). To
+//     keep THIS PR self-contained + mergeable we do NOT import a non-existent
+//     module: we fall back to defaultDispatch and emit a once-per-process WARN.
+//     1b wires the real sdk branch.
+// `warn` is injectable so a unit test can assert the warn fired (and count it)
+// without scraping the logger; it defaults to the execution-core logger.
+const _warnedSdkFallback = new Set();
+export function dispatchForExecutor(executor, { warn = (msg) => log.warn(msg) } = {}) {
+  if (executor === "sdk") {
+    const msg = "executor=sdk not yet implemented (CTL-1365b), using bg";
+    if (!_warnedSdkFallback.has(msg)) {
+      _warnedSdkFallback.add(msg);
+      warn(msg);
+    }
+  }
+  return defaultDispatch;
 }
 
 // dispatchTicket — thin seam over the injectable dispatch function.

--- a/plugins/dev/scripts/execution-core/dispatch.test.mjs
+++ b/plugins/dev/scripts/execution-core/dispatch.test.mjs
@@ -6,7 +6,7 @@
 // so no test ever spawns a real script.
 
 import { describe, test, expect } from "bun:test";
-import { dispatchTicket, defaultDispatch, defaultRunPhaseAgent, teamOf } from "./dispatch.mjs";
+import { dispatchTicket, defaultDispatch, defaultRunPhaseAgent, dispatchForExecutor, teamOf } from "./dispatch.mjs";
 
 describe("teamOf", () => {
   test("extracts the team prefix from a ticket identifier", () => {
@@ -366,6 +366,60 @@ describe("defaultRunPhaseAgent — failure diagnostics (CTL-1004/CTL-1056 Bug 2)
     );
     expect(r.signal).toBe("SIGKILL");
     expect(r.stderr).toMatch(/killed mid-run/);
+  });
+});
+
+// CTL-1365a: the executor → dispatch-function selection at the launch seam.
+// Phase 1 is INERT — bg/oneshot-legacy resolve to the unchanged defaultDispatch;
+// sdk falls back to defaultDispatch + a once-per-process WARN (sdkRunPhaseAgent
+// is CTL-1365b). Critically, "bg" must be BYTE-IDENTICAL to today's dispatch.
+describe("dispatchForExecutor (CTL-1365a)", () => {
+  test("bg → the unchanged defaultDispatch (byte-identical to today)", () => {
+    expect(dispatchForExecutor("bg")).toBe(defaultDispatch);
+  });
+
+  test("oneshot-legacy → the unchanged defaultDispatch", () => {
+    expect(dispatchForExecutor("oneshot-legacy")).toBe(defaultDispatch);
+  });
+
+  test("sdk → falls back to defaultDispatch + warns once (no throw, no missing-module import)", () => {
+    const warnings = [];
+    // Distinct module-load means _warnedSdkFallback is empty for this run; the
+    // first sdk call warns, subsequent calls dedupe (once-per-process).
+    expect(() => dispatchForExecutor("sdk", { warn: (m) => warnings.push(m) })).not.toThrow();
+    const fn = dispatchForExecutor("sdk", { warn: (m) => warnings.push(m) });
+    expect(fn).toBe(defaultDispatch);
+    expect(warnings.length).toBe(1); // warn-once: only the FIRST sdk call emitted
+    expect(warnings[0]).toMatch(/executor=sdk not yet implemented \(CTL-1365b\), using bg/);
+  });
+
+  test("the injected bg dispatch behaves IDENTICALLY to defaultDispatch — same arg array reaches runPhaseAgent", () => {
+    // Prove the executor=bg path threads through to runPhaseAgent with the exact
+    // arg array the existing dispatch tests assert, via the same injectable seams.
+    const calls = [];
+    const seams = {
+      resolveProject: () => ({ team: "CTL", repoRoot: "/repo" }),
+      createWorktree: (args) => ({ code: 0, worktreePath: `/wt/${args.ticket}`, stderr: "" }),
+      runPhaseAgent: (args) => {
+        calls.push(args);
+        return { code: 0, stdout: "ok", stderr: "", signal: null };
+      },
+    };
+    const dispatch = dispatchForExecutor("bg"); // === defaultDispatch
+    dispatch(
+      { orchDir: "/ec", ticket: "CTL-1", phase: "implement", clusterGeneration: 7 },
+      seams
+    );
+    expect(calls[0]).toEqual({
+      orchDir: "/ec",
+      ticket: "CTL-1",
+      phase: "implement",
+      worktreePath: "/wt/CTL-1",
+      resumeSession: undefined,
+      handoffPath: undefined,
+      attempt: undefined,
+      clusterGeneration: 7,
+    });
   });
 });
 

--- a/plugins/dev/scripts/execution-core/scheduler.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.mjs
@@ -3076,6 +3076,12 @@ export function schedulerTick(
     // `ReferenceError: env is not defined` and aborted the whole tick on any
     // escalation branch.
     env = process.env,
+    // CTL-1365a: catalyst.dispatch.mode telemetry vocab ({phase-agents |
+    // oneshot-legacy | sdk}) stamped on the CTL-1330 Tier-1 tick-timing line so
+    // OTEL's ParseJSON(body)→signaltometrics leg labels the scheduler histograms
+    // by dispatch mode. Default "phase-agents" = today's bg substrate; every
+    // direct-call test keeps the stable label with no wiring.
+    dispatchMode = "phase-agents",
   } = {}
 ) {
   // CTL-850: resolve this host + the cluster roster ONCE per tick (cheap
@@ -5650,6 +5656,11 @@ export function schedulerTick(
         eligible_count: eligible.length,
         liveness_fresh: livenessFresh,
         beliefs_shadow: process.env.CATALYST_BELIEFS_SHADOW === "1",
+        // CTL-1365a: the dispatch-mode dimension. Dotted JSON key so Loki `| json`
+        // + the OTEL signaltometrics leg both yield the frozen metric label
+        // `catalyst_dispatch_mode` (dots→underscores) that the OTEL "Execution-model
+        // A/B" dashboard splits `by (catalyst_dispatch_mode)`.
+        "catalyst.dispatch.mode": dispatchMode,
       },
       "scheduler: tick timing (CTL-1330)"
     );
@@ -6019,6 +6030,7 @@ function runTick() {
     const tickResult = schedulerTick(runningOpts.orchDir, {
       readEligible: runningOpts.readEligible,
       dispatch: runningOpts.dispatch,
+      dispatchMode: runningOpts.dispatchMode, // CTL-1365a: stamp the Tier-1 tick-timing line
       exec: runningOpts.exec,
       writeStatus: runningOpts.writeStatus,
       cache: runningOpts.cache, // CTL-634: shared out-of-set blocker state cache
@@ -6415,6 +6427,12 @@ function scheduleDebouncedTick(debounceMs) {
 export function startScheduler({
   orchDir,
   dispatch,
+  // CTL-1365a: the catalyst.dispatch.mode telemetry vocab ({phase-agents |
+  // oneshot-legacy | sdk}) resolved once by the daemon from the executor flag.
+  // Threaded into runningOpts → the Tier-1 tick-timing log field AND the OTLP
+  // resource attr (initTracing). Default "phase-agents" keeps every direct-call
+  // test + standalone main() on today's label with no wiring.
+  dispatchMode = "phase-agents",
   readEligible,
   exec,
   writeStatus,
@@ -6483,6 +6501,7 @@ export function startScheduler({
   runningOpts = {
     orchDir,
     dispatch,
+    dispatchMode, // CTL-1365a: threaded to schedulerTick (tick-timing log field)
     readEligible,
     exec,
     writeStatus,
@@ -6549,7 +6568,7 @@ export function startScheduler({
   // and fire-and-forget — never blocks startup; emitTickTrace no-ops until the
   // provider is ready, and a failed init degrades to "no spans". BatchSpanProcessor
   // only, so the exporter never blocks the tick.
-  initTracing({ serviceName: "catalyst.execution-core" })
+  initTracing({ serviceName: "catalyst.execution-core", dispatchMode })
     .then((on) => {
       if (on) log.info({}, "scheduler: OTLP tracing enabled (CTL-1330 Tier 3)");
     })

--- a/plugins/dev/scripts/execution-core/tracing.mjs
+++ b/plugins/dev/scripts/execution-core/tracing.mjs
@@ -71,16 +71,42 @@ function resolveNodeName(env) {
   return env.CATALYST_HOST_NAME || shortHostName();
 }
 
+// buildTracingResource — CTL-1365a: the trace RESOURCE attribute object, factored
+// out so the dispatch-mode dimension is unit-testable WITHOUT standing up an OTLP
+// provider. service.name / service.namespace + the SHORT host.name are the
+// canonical cross-signal join keys (CTL data-quality finding). catalyst.dispatch.mode
+// rides the resource so Tempo splits traces via resource.catalyst.dispatch.mode —
+// deliberately NOT promoted onto metrics (the tick-timing log field is the metric
+// source; promoting the resource attr too re-triggers the OTL-20 duplicate-label
+// collision that silently drops the metric). Pure; never throws. ATTR_SERVICE_NAME /
+// ATTR_SERVICE_NAMESPACE are literally "service.name" / "service.namespace".
+export function buildTracingResource({ serviceName, dispatchMode = "phase-agents", env = process.env } = {}) {
+  return {
+    "service.name": serviceName,
+    "service.namespace": "catalyst",
+    "host.name": shortHostName(),
+    "catalyst.node.name": resolveNodeName(env),
+    "catalyst.dispatch.mode": dispatchMode,
+  };
+}
+
 // initTracing — construct the provider + OTLP/HTTP exporter + BatchSpanProcessor ONCE.
 // Idempotent; a no-op when disabled or already initialized. NEVER throws.
-export async function initTracing({ serviceName, env = process.env } = {}) {
+// CTL-1365a: `dispatchMode` is the catalyst.dispatch.mode telemetry vocab
+// ({phase-agents | oneshot-legacy | sdk}) the daemon resolves once from the
+// executor flag. It rides the trace RESOURCE so Tempo splits traces via
+// `resource.catalyst.dispatch.mode` — deliberately NOT promoted onto metrics
+// (the log field on the tick line is the metric source; promoting the resource
+// attr too re-triggers the OTL-20 duplicate-label collision that drops the
+// metric). OFF-safe: reading the string is the only new work when tracing is off;
+// the SDK/provider work below still short-circuits on the tracingEnabled gate.
+export async function initTracing({ serviceName, dispatchMode = "phase-agents", env = process.env } = {}) {
   if (_enabled) return true;
   if (!tracingEnabled(env)) return false;
   try {
     const { BasicTracerProvider, BatchSpanProcessor } = await import("@opentelemetry/sdk-trace-base");
     const { OTLPTraceExporter } = await import("@opentelemetry/exporter-trace-otlp-http");
     const { resourceFromAttributes } = await import("@opentelemetry/resources");
-    const { ATTR_SERVICE_NAME, ATTR_SERVICE_NAMESPACE } = await import("@opentelemetry/semantic-conventions");
 
     // Same collector otel-forward uses. OTEL_EXPORTER_OTLP_ENDPOINT is the base (otel-forward
     // maps :4317->:4318 for HTTP); we append /v1/traces. Traces to this endpoint route to
@@ -91,14 +117,10 @@ export async function initTracing({ serviceName, env = process.env } = {}) {
     const exporter = new OTLPTraceExporter({ url: `${base}/v1/traces` });
 
     _provider = new BasicTracerProvider({
-      resource: resourceFromAttributes({
-        [ATTR_SERVICE_NAME]: serviceName,
-        // service.namespace + the SHORT host.name are the canonical cross-signal join keys
-        // (CTL data-quality finding) — traces previously carried neither.
-        [ATTR_SERVICE_NAMESPACE]: "catalyst",
-        "host.name": shortHostName(),
-        "catalyst.node.name": resolveNodeName(env),
-      }),
+      // CTL-1365a: resource attrs (incl. catalyst.dispatch.mode) built by the pure,
+      // unit-tested buildTracingResource helper. service.namespace + the SHORT
+      // host.name are the canonical cross-signal join keys (CTL data-quality finding).
+      resource: resourceFromAttributes(buildTracingResource({ serviceName, dispatchMode, env })),
       spanProcessors: [new BatchSpanProcessor(exporter)],
     });
     trace.setGlobalTracerProvider(_provider);

--- a/plugins/dev/scripts/execution-core/tracing.test.mjs
+++ b/plugins/dev/scripts/execution-core/tracing.test.mjs
@@ -2,6 +2,9 @@
 // invariants. Uses an in-memory exporter so nothing hits a real OTLP collector.
 
 import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, mkdirSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { BasicTracerProvider, InMemorySpanExporter, SimpleSpanProcessor } from "@opentelemetry/sdk-trace-base";
 import { SpanKind, SpanStatusCode } from "@opentelemetry/api";
 import {
@@ -9,8 +12,13 @@ import {
   getTracer,
   emitTickTrace,
   emitLivenessRefreshSpan,
+  buildTracingResource,
+  initTracing,
+  shutdownTracing,
   __setTracerForTest,
 } from "./tracing.mjs";
+import { schedulerTick } from "./scheduler.mjs";
+import { dispatchModeForExecutor } from "./config.mjs";
 
 describe("tracingEnabled (CTL-1330 Tier 3 — OFF by default)", () => {
   test("OFF unless CATALYST_TRACING=on", () => {
@@ -502,5 +510,124 @@ describe("emitLivenessRefreshSpan (in-memory exporter)", () => {
     const [span] = exporter.getFinishedSpans();
     expect(span.attributes["catalyst.liveness.outcome"]).toBe("resolved");
     expect(span.status.code).toBe(SpanStatusCode.UNSET);
+  });
+});
+
+// CTL-1365a: the catalyst.dispatch.mode telemetry dimension (OTEL #43/#44, frozen).
+// Resource attr for traces; log field for metrics — each sourced its own way.
+describe("buildTracingResource — catalyst.dispatch.mode (CTL-1365a)", () => {
+  test("defaults to phase-agents (today's bg substrate) when no mode passed", () => {
+    const r = buildTracingResource({ serviceName: "catalyst.execution-core", env: {} });
+    expect(r["catalyst.dispatch.mode"]).toBe("phase-agents");
+    expect(r["service.name"]).toBe("catalyst.execution-core");
+    expect(r["service.namespace"]).toBe("catalyst");
+    expect(typeof r["host.name"]).toBe("string");
+    expect("catalyst.node.name" in r).toBe(true);
+  });
+
+  test("carries the passed mode (sdk) verbatim", () => {
+    const r = buildTracingResource({ serviceName: "x", dispatchMode: "sdk", env: {} });
+    expect(r["catalyst.dispatch.mode"]).toBe("sdk");
+  });
+
+  test("the executor→mode mapping flows through (bg→phase-agents)", () => {
+    const r = buildTracingResource({
+      serviceName: "x",
+      dispatchMode: dispatchModeForExecutor("bg"),
+      env: {},
+    });
+    expect(r["catalyst.dispatch.mode"]).toBe("phase-agents");
+  });
+});
+
+describe("initTracing tags the trace resource with catalyst.dispatch.mode (CTL-1365a)", () => {
+  afterEach(async () => {
+    await shutdownTracing();
+    __setTracerForTest(null);
+  });
+
+  test("OFF (CATALYST_TRACING unset) → returns false, no tracer, no SDK work", async () => {
+    const on = await initTracing({ serviceName: "catalyst.execution-core", dispatchMode: "sdk", env: {} });
+    expect(on).toBe(false);
+    expect(getTracer()).toBeNull();
+  });
+
+  test("ON → the resource on emitted spans carries the resolved dispatch mode", async () => {
+    const on = await initTracing({
+      serviceName: "catalyst.execution-core",
+      dispatchMode: "sdk",
+      env: { CATALYST_TRACING: "on" },
+    });
+    expect(on).toBe(true);
+    const span = getTracer().startSpan("ctl1365a-probe");
+    // SDK ReadableSpan carries the provider resource.
+    expect(span.resource.attributes["catalyst.dispatch.mode"]).toBe("sdk");
+    expect(span.resource.attributes["service.name"]).toBe("catalyst.execution-core");
+    span.end();
+  });
+});
+
+// CTL-1365a: the metric leg — the CTL-1330 tick-timing log line carries the
+// dispatch-mode field (OTEL ParseJSON(body)→signaltometrics labels metrics from it).
+// Drives a real (empty-board) schedulerTick under a temp CATALYST_DIR and captures
+// the pino line off stderr.
+describe("tick-timing log line carries catalyst.dispatch.mode (CTL-1365a)", () => {
+  let prevCatalystDir, catalystDir, orchDir;
+
+  beforeEach(() => {
+    prevCatalystDir = process.env.CATALYST_DIR;
+    catalystDir = mkdtempSync(join(tmpdir(), "ctl1365a-tick-"));
+    if (!catalystDir.startsWith(tmpdir())) {
+      throw new Error(`refused: catalystDir not under tmpdir: ${catalystDir}`);
+    }
+    process.env.CATALYST_DIR = catalystDir;
+    mkdirSync(join(catalystDir, "events"), { recursive: true });
+    orchDir = join(catalystDir, "orch");
+    mkdirSync(join(orchDir, "workers"), { recursive: true });
+  });
+
+  afterEach(() => {
+    if (prevCatalystDir === undefined) delete process.env.CATALYST_DIR;
+    else process.env.CATALYST_DIR = prevCatalystDir;
+    rmSync(catalystDir, { recursive: true, force: true });
+  });
+
+  // Run one empty-board tick, capturing stderr (pino → process.stderr), and return
+  // the parsed "scheduler: tick timing" log object.
+  const captureTickTimingLine = (opts) => {
+    const lines = [];
+    const orig = process.stderr.write.bind(process.stderr);
+    process.stderr.write = (chunk) => {
+      lines.push(String(chunk));
+      return true;
+    };
+    try {
+      schedulerTick(orchDir, {
+        readEligible: () => [],
+        dispatch: () => ({ code: 0 }),
+        writeStatus: {
+          applyPhaseStatus: () => {},
+          applyTerminalDone: () => {},
+          applyLabel: () => ({ applied: true }),
+        },
+        ...opts,
+      });
+    } finally {
+      process.stderr.write = orig;
+    }
+    const raw = lines.join("").split("\n").filter(Boolean).find((l) => l.includes("scheduler: tick timing"));
+    return raw ? JSON.parse(raw) : null;
+  };
+
+  test("stamps the threaded dispatch mode (sdk)", () => {
+    const line = captureTickTimingLine({ dispatchMode: "sdk" });
+    expect(line).not.toBeNull();
+    expect(line["catalyst.dispatch.mode"]).toBe("sdk");
+  });
+
+  test("defaults to phase-agents (bg substrate) when no mode threaded", () => {
+    const line = captureTickTimingLine({});
+    expect(line).not.toBeNull();
+    expect(line["catalyst.dispatch.mode"]).toBe("phase-agents");
   });
 });

--- a/plugins/dev/scripts/lib/executor.sh
+++ b/plugins/dev/scripts/lib/executor.sh
@@ -30,6 +30,15 @@ executor_claude_bin() {
 	echo "${CATALYST_DISPATCH_CLAUDE_BIN:-claude}"
 }
 
+# executor_kind — CTL-1365a: which phase-worker substrate this node uses
+# (bg|sdk|oneshot-legacy). Reads CATALYST_EXECUTOR; defaults to "bg" when unset —
+# the seam 1b/1c branch on (e.g. executor_reap → no-op under sdk). INERT in this
+# PR: the bg launch verb (executor_claude_bin) and executor_reap are unchanged,
+# so a node with CATALYST_EXECUTOR unset behaves byte-identically to today.
+executor_kind() {
+	echo "${CATALYST_EXECUTOR:-bg}"
+}
+
 # _executor_jobs_root — where `claude --bg` writes per-job state.json dirs.
 _executor_jobs_root() {
 	echo "${CATALYST_EXECUTOR_JOBS_ROOT:-${CLAUDE_BG_JOBS_DIR:-$HOME/.claude/jobs}}"

--- a/website/src/content/docs/reference/configuration.md
+++ b/website/src/content/docs/reference/configuration.md
@@ -77,6 +77,7 @@ The `orchestration.dispatchMode` key picks how Catalyst runs each ticket:
 | Key | Default | What it does |
 | --- | --- | --- |
 | `orchestration.dispatchMode` | `oneshot-legacy` | Which run mode to use (above) |
+| `orchestration.executor` | `bg` | Which substrate runs a phase worker: `bg` (a `claude --bg` background job, today's behavior), `oneshot-legacy`, or `sdk` (the in-process Claude Agent SDK — **not yet implemented; falls back to `bg`**, CTL-1365b). Resolution: `CATALYST_EXECUTOR` env → this key → node-class default (all classes → `bg` today). Distinct from `dispatchMode`. |
 | `orchestration.maxParallel` | `3` | How many tickets run at once |
 | `orchestration.worktreeDir` | `~/catalyst/wt/<projectKey>` | Where worktrees are created |
 | `orchestration.pluginDirs` | unset | Path(s) to the plugin checkout(s) workers run from (`<checkout>/plugins/dev`). Set by `setup-plugin-source.sh`; resolved by `phase-agent-dispatch` and refreshed by `catalyst-stack hotpatch` / merge-to-main. String or `:`-joined array. May also live in the machine config (Layer 2); the `CATALYST_PLUGIN_DIRS` env var overrides both. |


### PR DESCRIPTION
**Phase 1, first PR** of the SDK-executor cutover (CTL-1365, plan reviewed + approved). **Fully inert** — default `executor=bg` → dispatch is byte-identical to today. No SDK executor is built here; this is the foundation + the telemetry dimension OTEL pre-staged its A/B canvas for.

## What's in this PR
- **`orchestration.executor` config flag + resolver** (`config.mjs`): `EXECUTORS=[bg,sdk,oneshot-legacy]`, node-class-defaulted (all → `bg` today), precedence `CATALYST_EXECUTOR` env → Layer-1 → node-class. Unrecognized → `bg` + warn-once; ENOENT/malformed → `bg`, never throws. Mirrors `readFleetHealthConfigLayer1`/`getNodeClass`.
- **Inert dispatch wiring** (`daemon.mjs`/`dispatch.mjs`): `dispatchForExecutor(executor)` resolved once at the scheduler + monitor→Triage seams. `bg`/`oneshot-legacy` → the exact `defaultDispatch` reference (byte-identical). `sdk` → falls back to `defaultDispatch` + a once-per-process WARN (`executor=sdk not yet implemented (CTL-1365b), using bg`) — **no import of the not-yet-existing `sdk-run-phase-agent.mjs`**, so the PR is self-contained.
- **`lib/executor.sh`**: `executor_kind()` reads `CATALYST_EXECUTOR` (default `bg`); inert when unset.
- **`catalyst.dispatch.mode` telemetry dimension** (frozen with OTEL #43/#44): resource attr in `tracing.mjs` `initTracing` (traces) + a log field on the CTL-1330 tick-timing line (metrics via OTEL's ParseJSON→signaltometrics leg). Closed enum `{phase-agents|oneshot-legacy|sdk}`, mapped `bg→phase-agents`. **No `resource_to_telemetry_conversion`/metric-promotion** (avoids the OTL-20 duplicate-label drop).
- **Doc**: `orchestration.executor` row added to `configuration.md` (schema source-of-truth), noting it's distinct from `dispatchMode`.

## Inertness proof
`executor=bg`/unset returns the exact `defaultDispatch` reference with the same arg array — the **existing `dispatch.test.mjs` arg-array `toEqual` assertions are unmodified and green**. `defaultDispatch`/`defaultRunPhaseAgent`/`dispatchTicket` bodies untouched. No control-flow change.

## Tests
config (11 new) + dispatch (4) + tracing (7) + `lib-executor.test.sh` (2) — all green. Full execution-core suite: **+21 passing, 0 new failures** (the pre-existing `getHostName`/CTL-859 FQDN + CTL-587 integration-flake failures are unrelated — confirmed identical on the base tree; this diff touches none of those files).

## Not in this PR (next PRs)
- **CTL-1365b**: `sdkRunPhaseAgent` + the shared pre-launch refactor (extract `phase-agent-dispatch`'s claim+signal+generation+rebase so the SDK executor reuses it and replaces only the launch verb — the must-fix from the plan review) + wiring the remaining 2 dispatch entry points (`handleCommentWake`, `reconcileBootResume`).
- **CTL-1365c**: auth guards (assert `ANTHROPIC_API_KEY` unset, `CLAUDE_CODE_OAUTH_TOKEN`, never `--bare`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)