### PR TITLE
feat(dev): CTL-1365b — SDK executor (sdkRunPhaseAgent) + shared pre-launch refactor [HOLD FOR REVIEW]

### DIFF
--- a/plugins/dev/scripts/__tests__/phase-agent-dispatch.test.sh
+++ b/plugins/dev/scripts/__tests__/phase-agent-dispatch.test.sh
@@ -2139,6 +2139,99 @@ DRY_OUT_T67=$(cd "${TEST_DIR}/proj" &&
 T67_BG_ISO=$(echo "$DRY_OUT_T67" | jq -r '.settings.worktree.bgIsolation // empty' 2>/dev/null)
 assert_eq "none" "$T67_BG_ISO" "dry-run .settings.worktree.bgIsolation = none"
 
+# ─── CTL-1365b: shared pre-launch / launch-verb seam ────────────────────────
+# The executor seam is the LAUNCH VERB, not the dispatch path. `--launch-mode
+# prelaunch-only` runs the IDENTICAL pre-launch (CTL-736 claim + status:dispatched
+# signal + CATALYST_GENERATION fencing token + rebase + prompt/env build) but
+# stops BEFORE `claude --bg`, emitting the resolved launch spec. These tests pin
+# that (a) prelaunch-only never launches claude and leaves the signal at the same
+# "dispatched"/fenced state the skill template requires to pre-exist, and (b) the
+# pre-launch composition (prompt/env/settings) is byte-for-byte the same one the
+# bg launch verb consumes — so swapping in the SDK launch verb changes nothing
+# upstream of the launch.
+
+echo ""
+echo "Test 68 (CTL-1365b): prelaunch-only runs the shared pre-launch but does NOT spawn claude"
+fresh_env t68
+SPEC=$(cd "${TEST_DIR}/proj" &&
+	"$DISPATCH" --phase triage --ticket CTL-100 --orch-dir "$ORCH_DIR" --orch-id orch-test \
+		--launch-mode prelaunch-only 2>/dev/null)
+SIGNAL="${WORKER_DIR}/phase-triage.json"
+# claude must NOT have been invoked (the bg launch verb is skipped).
+CLAUDE_INVOKED="no"
+[[ -f $CLAUDE_STUB_LOG ]] && CLAUDE_INVOKED="yes"
+assert_eq "no" "$CLAUDE_INVOKED" "prelaunch-only does NOT invoke claude --bg"
+# The shared pre-launch still wrote the status:dispatched signal + fencing token.
+assert_eq "dispatched" "$(jq -r '.status' "$SIGNAL")" "prelaunch-only leaves signal at status=dispatched (skill flips it to running)"
+assert_eq "1" "$(jq -r '.generation' "$SIGNAL")" "prelaunch-only claims fresh generation 1 in the signal"
+assert_eq "null" "$(jq -r '.bg_job_id' "$SIGNAL")" "prelaunch-only signal has no bg_job_id (no bg launch)"
+# The emitted spec carries what the in-process SDK query() needs.
+assert_eq "prelaunch-ready" "$(echo "$SPEC" | jq -r '.status')" "spec.status = prelaunch-ready"
+assert_eq "prelaunch-only" "$(echo "$SPEC" | jq -r '.launchMode')" "spec.launchMode = prelaunch-only"
+assert_eq "1" "$(echo "$SPEC" | jq -r '.generation')" "spec.generation = the claimed fencing token"
+assert_eq "null" "$(echo "$SPEC" | jq -r '.bg_job_id')" "spec.bg_job_id = null"
+assert_eq "${TEST_DIR}/proj" "$(echo "$SPEC" | jq -r '.worktreePath')" "spec.worktreePath = the dispatch cwd (SDK query() cwd)"
+assert_eq "/catalyst-dev:phase-triage CTL-100 --orch-dir ${ORCH_DIR}" \
+	"$(echo "$SPEC" | jq -r '.prompt')" "spec.prompt = the phase slash command"
+
+echo ""
+echo "Test 69 (CTL-1365b): an invalid --launch-mode is rejected"
+fresh_env t69
+"$DISPATCH" --phase triage --ticket CTL-100 --orch-dir "$ORCH_DIR" --orch-id orch-test \
+	--launch-mode bogus >/dev/null 2>"${TEST_DIR}/lm.err"
+RC_LM=$?
+assert_eq "1" "$RC_LM" "invalid --launch-mode exits 1"
+assert_contains "$(cat "${TEST_DIR}/lm.err")" "invalid --launch-mode" "invalid --launch-mode produces a clear error"
+
+echo ""
+echo "Test 70 (CTL-1365b): PRE-LAUNCH PARITY — prelaunch-only emits the same prompt/env/settings the bg launch verb consumes"
+# Two proofs of byte-identical pre-launch composition. ONE fixture (so orch-dir,
+# ticket and cwd — which are embedded in the prompt/env — are identical across
+# runs); the signal + claim files are reset between runs so each gets a fresh
+# gen-1 dispatch instead of an idempotent no-op.
+fresh_env t70
+cat >"${CONFIG_DIR}/config.json" <<EOF
+{ "catalyst": { "projectKey": "test-proj" } }
+EOF
+T70_SIGNAL="${WORKER_DIR}/phase-triage.json"
+reset_t70() { rm -f "$T70_SIGNAL" "${WORKER_DIR}/triage.claim."* 2>/dev/null; }
+
+# (a) the dry-run preview — full composed env array.
+reset_t70
+DRY=$(cd "${TEST_DIR}/proj" &&
+	"$DISPATCH" --phase triage --ticket CTL-100 --orch-dir "$ORCH_DIR" --orch-id orch-test --dry-run 2>/dev/null)
+# (b) prelaunch-only — full composed env array + real claim/signal side effects.
+reset_t70
+SPEC=$(cd "${TEST_DIR}/proj" &&
+	"$DISPATCH" --phase triage --ticket CTL-100 --orch-dir "$ORCH_DIR" --orch-id orch-test \
+		--launch-mode prelaunch-only 2>/dev/null)
+# (c) the bg launch — capture the prompt + env it actually hands to claude --bg.
+reset_t70
+(cd "${TEST_DIR}/proj" &&
+	"$DISPATCH" --phase triage --ticket CTL-100 --orch-dir "$ORCH_DIR" --orch-id orch-test \
+		>/dev/null 2>&1)
+BG_LOG=$(cat "$CLAUDE_STUB_LOG")
+BG_GENERATION=$(jq -r '.generation' "$T70_SIGNAL")
+
+# (1) prompt + core CATALYST_* env parity against the actual bg claude invocation.
+SPEC_PROMPT=$(echo "$SPEC" | jq -r '.prompt')
+assert_contains "$BG_LOG" "$SPEC_PROMPT" "spec.prompt matches the prompt bg passes to claude --bg"
+for KEY in "CATALYST_ORCHESTRATOR_DIR=${ORCH_DIR}" "CATALYST_PHASE=triage" "CATALYST_TICKET=CTL-100"; do
+	SPEC_HAS=$(echo "$SPEC" | jq -r --arg k "$KEY" '.env | index($k) != null')
+	assert_contains "$BG_LOG" "$KEY" "bg env carries $KEY"
+	assert_eq "true" "$SPEC_HAS" "prelaunch spec.env carries $KEY (parity with bg)"
+done
+assert_eq "$BG_GENERATION" "$(echo "$SPEC" | jq -r '.generation')" "prelaunch generation matches the bg path's fresh generation"
+
+# (2) full composed-env / prompt / settings parity against the dry-run preview.
+#     (dry-run.env ≡ bg's claude env is pinned by Tests 10/14, so this is the
+#     transitive byte-identical proof for the WHOLE DISPATCH_ENV array.)
+for FIELD in .env .prompt .settings .model .turnCap .sessionName .pluginDirs; do
+	DRY_VAL=$(echo "$DRY" | jq -cS "$FIELD")
+	PL_VAL=$(echo "$SPEC" | jq -cS "$FIELD")
+	assert_eq "$DRY_VAL" "$PL_VAL" "prelaunch ${FIELD} == dry-run ${FIELD} (pre-launch composition byte-identical)"
+done
+
 echo ""
 echo "─────────────────────────────────────────────"
 echo "phase-agent-dispatch: ${PASSES} passed, ${FAILURES} failed"

--- a/plugins/dev/scripts/execution-core/daemon.mjs
+++ b/plugins/dev/scripts/execution-core/daemon.mjs
@@ -120,7 +120,7 @@ import {
 import * as linearWrite from "./linear-write.mjs"; // CTL-1067: writeStatus for defaultClearStall
 import { writeBootMarker, clearProgressMarks, resolvePhaseSessionId, defaultAppendOperatorEvent } from "./recovery.mjs"; // CTL-655: window the revive budget to this run; CTL-736: reset progress high-water; CTL-768: --resume; CTL-1044: operator-event appender for the scheduler's appendIntentEvent seam
 import { startAutoTuner } from "./autotune.mjs"; // CTL-684: side-car maxParallel auto-tuner
-import { dispatchTicket, dispatchForExecutor } from "./dispatch.mjs"; // CTL-549: comment-wake re-dispatch; CTL-1365a: executor→dispatch selection at the launch seam
+import { dispatchTicket, dispatchForExecutor, makeCommentWakeDispatch } from "./dispatch.mjs"; // CTL-549: comment-wake re-dispatch; CTL-1365a/b: executor→dispatch selection at the launch seam + comment-wake executor binding
 import { removeLabel as defaultRemoveLabel } from "./linear-write.mjs"; // CTL-549: clear needs-human on resume
 // CTL-671: the real phantom-sweep seams. startScheduler defaults them to safe
 // no-ops (hermetic for direct-call unit tests); the REAL daemon arms them here
@@ -582,13 +582,33 @@ export function startDaemon({
     // its `coldStart` verdict + worker buckets.
     const report = recover({ orchDir });
     _bootReport = report;
+    // CTL-1365a/b Stage C: resolve the phase-worker executor ONCE per boot (env →
+    // Layer-1 catalyst.orchestration.executor → node-class default; every class
+    // maps to "bg" in Phase 1, so an unset flag is a pure no-op) and select the
+    // dispatch function threaded into ALL FOUR dispatch entry points — the
+    // scheduler pull-loop, the monitor's →Triage one-shot, the comment-wake
+    // re-dispatch, AND the boot-resume crash-recovery pass — so a node never
+    // split-brains (some sites bg, others sdk). Resolved here, BEFORE reconcileBoot,
+    // precisely so boot-resume honors the flag too. For executor=bg/oneshot-legacy
+    // dispatchFn === defaultDispatch (byte-identical to today); "sdk" → sdkDispatch
+    // (injects sdkRunPhaseAgent). dispatchMode is the catalyst.dispatch.mode
+    // telemetry vocab ("phase-agents" for bg) for the scheduler's Tier-1 tick line.
+    const executor = getExecutor(configPath);
+    const dispatchFn = dispatchForExecutor(executor);
+    const dispatchMode = dispatchModeForExecutor(executor);
+    // CTL-1365b: the comment-wake re-dispatch binding — routes a parked ticket's
+    // re-dispatch through the SAME resolved executor (no split-brain).
+    const commentWakeDispatch = makeCommentWakeDispatch(dispatchFn);
     // CTL-654: boot-resume — on a cold start, re-dispatch in-flight tickets whose
     // worktree has no live --bg worker, BEFORE the monitor/scheduler start. This
     // bypasses the per-tick reclaim sweep's revive budget (a clean reboot is not
     // a chronic-failure storm) and is bounded by maxParallel so a reboot never
     // spawns a worker storm. Synchronous and inside the same try/catch so a throw
     // still triggers PID-file cleanup. A non-cold-start restart is a no-op.
-    const bootResume = reconcileBoot({ orchDir, report, concurrency }); // CTL-665: config-first boot-resume ceiling
+    // CTL-1365b: dispatch === dispatchFn so the crash-recovery re-dispatch honors
+    // the executor flag (defaultDispatch under bg — reconcileBootResume's own
+    // default — so byte-identical to today).
+    const bootResume = reconcileBoot({ orchDir, report, concurrency, dispatch: dispatchFn }); // CTL-665: config-first boot-resume ceiling
     _bootResume = bootResume;
     // CTL-644: dispatch any gated tickets that already have an approval sentinel on disk
     // (operator may have dropped the sentinel while the daemon was down).
@@ -618,19 +638,11 @@ export function startDaemon({
     const linearBotUserIds = readLinearBotUserIds(configPath, layer2Path);
     const linearBotWriteId = readLinearBotWriteId(configPath, layer2Path); // CTL-781
     const commentInboxWriter = createCommentInboxWriter(orchDir, linearBotUserIds);
-    // CTL-1365a: resolve the phase-worker executor ONCE at the dispatch seam and
-    // select the dispatch function injected into BOTH the monitor's →Triage
-    // one-shot dispatch and the scheduler's pull loop. Phase 1 is INERT —
-    // getExecutor's node-class default is "bg" for every class, so an unset flag
-    // resolves to "bg" and dispatchForExecutor returns the unchanged
-    // defaultDispatch (byte-identical to today). "sdk" falls back to
-    // defaultDispatch + a once-per-process WARN until sdkRunPhaseAgent lands
-    // (CTL-1365b). The dispatch-mode telemetry vocab ("phase-agents" for bg) is
-    // derived from the same resolution and threaded into the scheduler's Tier-1
-    // tick-timing line + OTLP resource attr.
-    const executor = getExecutor(configPath);
-    const dispatchFn = dispatchForExecutor(executor);
-    const dispatchMode = dispatchModeForExecutor(executor);
+    // CTL-1365a/b: executor + dispatchFn + dispatchMode + commentWakeDispatch are
+    // resolved ONCE above (before reconcileBoot) and threaded into all four dispatch
+    // entry points. The monitor receives dispatchFn for its →Triage one-shot, and
+    // the onComment callback routes comment-wakes through commentWakeDispatch (the
+    // same executor) — no split-brain.
     monitorFn({
       orchDir,
       cache,
@@ -641,7 +653,7 @@ export function startDaemon({
       gateway: gatewayReader, // CTL-781: gateway-first assignee reads
       onComment: (parsed) => {
         commentInboxWriter(parsed); // CTL-749: write to inbox.jsonl for in-flight workers
-        handleCommentWake(parsed, { orchDir, dispatch: dispatchTicket, removeLabel: defaultRemoveLabel, botUserId: linearBotUserIds, clearStall: defaultClearStall(orchDir, linearWrite) }); // CTL-549 + CTL-756: re-dispatch parked tickets; botUserId suppresses self-echo; CTL-1067: J3 stall-clear
+        handleCommentWake(parsed, { orchDir, dispatch: commentWakeDispatch, removeLabel: defaultRemoveLabel, botUserId: linearBotUserIds, clearStall: defaultClearStall(orchDir, linearWrite) }); // CTL-549 + CTL-756 + CTL-1365b: re-dispatch parked tickets through the resolved executor; botUserId suppresses self-echo; CTL-1067: J3 stall-clear
       },
       onUpdate: createUpdateInboxWriter(orchDir, linearBotUserIds), // CTL-749
     }); // CTL-535 + CTL-565 + CTL-634 + CTL-549 + CTL-749 + CTL-716 + CTL-781

--- a/plugins/dev/scripts/execution-core/daemon.test.mjs
+++ b/plugins/dev/scripts/execution-core/daemon.test.mjs
@@ -35,6 +35,7 @@ import {
   _isBotId,
 } from "./daemon.mjs";
 import { getEventLogPath, log } from "./config.mjs";
+import { defaultDispatch, sdkDispatch, makeCommentWakeDispatch } from "./dispatch.mjs";
 import { upsertProjectEntry } from "./registry.mjs";
 import {
   recordHoldStop,
@@ -1820,6 +1821,96 @@ describe("daemon wires onComment and onUpdate to monitorFn (CTL-549 + CTL-749)",
     stopDaemon();
     expect(typeof capturedOpts?.onComment).toBe("function");
     expect(typeof capturedOpts?.onUpdate).toBe("function");
+  });
+});
+
+// ─── CTL-1365b Stage C: executor flag honored at ALL FOUR dispatch entry points ─
+//
+// The daemon resolves the executor ONCE per boot (env → Layer-1 → node-class
+// default) and threads the chosen dispatch into all four sites: (1) the scheduler
+// pull-loop, (2) the monitor's →Triage one-shot, (3) the comment-wake re-dispatch,
+// (4) the boot-resume crash-recovery pass. INVARIANT: executor=bg/unset is
+// byte-identical to today (every site === defaultDispatch); executor=sdk routes
+// every site through sdkDispatch (which injects sdkRunPhaseAgent). No site hardcodes
+// bg — a split-brain (e.g. comment-wakes on bg while the scheduler is on sdk) is
+// exactly the latent defect the plan-review flagged.
+describe("CTL-1365b: executor flag honored at all four dispatch entry points", () => {
+  let prevExecutor;
+  beforeEach(() => { prevExecutor = process.env.CATALYST_EXECUTOR; });
+  afterEach(() => {
+    if (prevExecutor === undefined) delete process.env.CATALYST_EXECUTOR;
+    else process.env.CATALYST_EXECUTOR = prevExecutor;
+  });
+
+  // Capture the dispatch threaded into reconcileBoot (site 4), startMonitor
+  // (site 2 — its →Triage one-shot), and startScheduler (site 1 — the pull loop).
+  const captureThreeSites = () => {
+    const captured = {};
+    startDaemon({
+      recover: () => ({ coldStart: true, workers: {} }),
+      reconcileBoot: (o) => { captured.boot = o.dispatch; return {}; },
+      startMonitor: (o) => { captured.monitor = o.dispatch; captured.onComment = o.onComment; },
+      startScheduler: (o) => { captured.scheduler = o.dispatch; },
+      watchRegistry: false,
+    });
+    stopDaemon();
+    return captured;
+  };
+
+  test("executor=bg → scheduler + monitor + boot-resume all receive defaultDispatch (byte-identical)", () => {
+    process.env.CATALYST_EXECUTOR = "bg";
+    const c = captureThreeSites();
+    expect(c.scheduler).toBe(defaultDispatch); // site 1
+    expect(c.monitor).toBe(defaultDispatch);   // site 2 (→Triage one-shot)
+    expect(c.boot).toBe(defaultDispatch);      // site 4 (boot-resume)
+    expect(typeof c.onComment).toBe("function"); // site 3 wired (routing pinned below)
+  });
+
+  test("executor unset → defaults to bg at all three captured sites (no site hardcodes sdk)", () => {
+    delete process.env.CATALYST_EXECUTOR;
+    const c = captureThreeSites();
+    expect(c.scheduler).toBe(defaultDispatch);
+    expect(c.monitor).toBe(defaultDispatch);
+    expect(c.boot).toBe(defaultDispatch);
+  });
+
+  test("executor=sdk → scheduler + monitor + boot-resume all receive sdkDispatch (none hardcodes bg)", () => {
+    process.env.CATALYST_EXECUTOR = "sdk";
+    const c = captureThreeSites();
+    expect(c.scheduler).toBe(sdkDispatch); // site 1
+    expect(c.monitor).toBe(sdkDispatch);   // site 2
+    expect(c.boot).toBe(sdkDispatch);      // site 4
+    expect(typeof c.onComment).toBe("function"); // site 3 wired
+  });
+
+  // Site 3 (comment-wake) routing: the daemon builds the comment-wake dispatch as
+  // makeCommentWakeDispatch(dispatchFn) — the SAME resolved dispatchFn the three
+  // sites above receive. This pins that the binding routes a parked-ticket
+  // re-dispatch through that executor dispatch (and NOT a hardcoded defaultDispatch),
+  // so flipping the flag flips the comment-wake too.
+  test("site 3: the comment-wake binding routes a needs-input re-dispatch through the resolved executor dispatch", async () => {
+    const orch = mkdtempSync(join(tmpdir(), "ctl-1365b-cw-"));
+    try {
+      const workerDir = join(orch, "workers", "CTL-1");
+      mkdirSync(workerDir, { recursive: true });
+      writeFileSync(
+        join(workerDir, "phase-implement.json"),
+        JSON.stringify({ ticket: "CTL-1", phase: "implement", status: "needs-input", parkedFrom: "implement", handoffPath: "/h.md" }),
+      );
+      const routed = [];
+      // A sentinel standing in for the resolved dispatchFn (sdkDispatch under sdk,
+      // defaultDispatch under bg). makeCommentWakeDispatch is exactly what the daemon
+      // threads into handleCommentWake's `dispatch`.
+      const resolvedDispatchFn = (args) => { routed.push(args); return { code: 0 }; };
+      await handleCommentWake(
+        { ticket: "CTL-1", body: "answer" },
+        { orchDir: orch, dispatch: makeCommentWakeDispatch(resolvedDispatchFn), removeLabel: async () => {} },
+      );
+      expect(routed).toHaveLength(1);
+      expect(routed[0]).toMatchObject({ orchDir: orch, ticket: "CTL-1", phase: "implement", handoffPath: "/h.md" });
+    } finally {
+      rmSync(orch, { recursive: true, force: true });
+    }
   });
 });
 

--- a/plugins/dev/scripts/execution-core/dispatch.mjs
+++ b/plugins/dev/scripts/execution-core/dispatch.mjs
@@ -17,7 +17,7 @@ import { spawnSync } from "node:child_process";
 import { fileURLToPath } from "node:url";
 import { getProjectConfig } from "./registry.mjs";
 import { createWorktree as defaultCreateWorktree } from "./worktree.mjs";
-import { log } from "./config.mjs"; // CTL-1365a: once-per-process sdk-fallback WARN
+import { sdkRunPhaseAgent } from "./sdk-run-phase-agent.mjs"; // CTL-1365b: the executor=sdk launch verb (in-process Agent SDK query())
 
 // phase-agent-dispatch sits one directory up from execution-core/.
 const PHASE_AGENT_DISPATCH_BIN = fileURLToPath(new URL("../phase-agent-dispatch", import.meta.url));
@@ -186,33 +186,62 @@ export function defaultDispatch(
     attempt,
     clusterGeneration,
   }); // CTL-761, CTL-864
+  // CTL-1365b: the sdk launch verb (sdkRunPhaseAgent) is ASYNC — it returns a
+  // Promise; the bg launch verb (defaultRunPhaseAgent) is SYNCHRONOUS — it returns
+  // a plain object. Detect a thenable and compose worktreePath onto the AWAITED
+  // result so an sdk dispatch resolves to the same {code,…,worktreePath} shape. The
+  // synchronous bg path takes the unchanged object branch below → byte-identical to
+  // today (the existing dispatch.test.mjs `toEqual` assertions use sync stubs and
+  // never reach the thenable branch).
+  if (res && typeof res.then === "function") {
+    return res.then((r) => ({ ...r, worktreePath: wt.worktreePath }));
+  }
   return { ...res, worktreePath: wt.worktreePath };
 }
 
-// dispatchForExecutor — CTL-1365a: map a resolved executor (config.mjs:getExecutor)
-// to the dispatch function the daemon injects into startScheduler / startMonitor.
-// Phase 1 is INERT:
-//   - "bg" | "oneshot-legacy" → the unchanged defaultDispatch. Returning
-//     defaultDispatch is IDENTICAL to relying on the dispatch=defaultDispatch
-//     default param, so the existing dispatch.test.mjs arg-array `toEqual`
-//     assertions are completely unaffected — the dispatched behavior is
-//     byte-identical to today.
-//   - "sdk" → sdkRunPhaseAgent does NOT exist yet (it arrives in CTL-1365b). To
-//     keep THIS PR self-contained + mergeable we do NOT import a non-existent
-//     module: we fall back to defaultDispatch and emit a once-per-process WARN.
-//     1b wires the real sdk branch.
-// `warn` is injectable so a unit test can assert the warn fired (and count it)
-// without scraping the logger; it defaults to the execution-core logger.
-const _warnedSdkFallback = new Set();
-export function dispatchForExecutor(executor, { warn = (msg) => log.warn(msg) } = {}) {
-  if (executor === "sdk") {
-    const msg = "executor=sdk not yet implemented (CTL-1365b), using bg";
-    if (!_warnedSdkFallback.has(msg)) {
-      _warnedSdkFallback.add(msg);
-      warn(msg);
-    }
-  }
-  return defaultDispatch;
+// sdkDispatch — CTL-1365b: the executor=sdk dispatch function. IDENTICAL to
+// defaultDispatch except the LAUNCH VERB: it injects sdkRunPhaseAgent (the
+// in-process Agent SDK query() worker) in place of defaultRunPhaseAgent (the
+// `claude --bg` spawn). It reuses defaultDispatch's resolve-project →
+// create-worktree → run-phase pipeline verbatim, so the ONLY behavioral delta vs
+// bg is which runPhaseAgent runs (the seam the whole cutover turns on). Because
+// sdkRunPhaseAgent is async, defaultDispatch's thenable branch composes
+// worktreePath onto the awaited result, so sdkDispatch returns a
+// Promise<{code,…,worktreePath}>. `runPhaseAgent` stays an injectable default so
+// the unit test can assert the wiring without the real SDK; the remaining seams
+// (resolveProject/createWorktree/…) pass straight through to defaultDispatch.
+export function sdkDispatch(args, { runPhaseAgent = sdkRunPhaseAgent, ...seams } = {}) {
+  return defaultDispatch(args, { runPhaseAgent, ...seams });
+}
+
+// dispatchForExecutor — CTL-1365b Stage C: map a resolved executor
+// (config.mjs:getExecutor) to the dispatch function the daemon threads into ALL
+// FOUR dispatch entry points (scheduler pull-loop, monitor →Triage one-shot,
+// comment-wake re-dispatch, boot-resume crash-recovery). Resolved ONCE per boot
+// and threaded to every site so a node never split-brains (some sites bg, others
+// sdk).
+//   - "bg" | "oneshot-legacy" → defaultDispatch (the `claude --bg` path). Returned
+//     BY IDENTITY, so the existing dispatch.test.mjs arg-array `toEqual`
+//     assertions are unaffected — the dispatched behavior is byte-identical to
+//     today.
+//   - "sdk" → sdkDispatch (injects sdkRunPhaseAgent — the in-process SDK worker).
+// Pure + identity-stable (the SAME function object per executor) so the daemon's
+// four-entry-point wiring is assertable by reference.
+export function dispatchForExecutor(executor) {
+  return executor === "sdk" ? sdkDispatch : defaultDispatch;
+}
+
+// makeCommentWakeDispatch — CTL-1365b Stage C: bind the resolved executor dispatch
+// into the positional (orchDir,ticket,phase,opts) shape handleCommentWake invokes,
+// so a comment-wake re-dispatch routes through the SAME executor as the
+// scheduler/monitor/boot-resume — closing the split-brain the plan-review flagged
+// (without it, comment-wakes would still route to bg under executor=sdk). For
+// executor=bg, `dispatch` === defaultDispatch, so this is byte-identical to the
+// prior `dispatch: dispatchTicket` wiring (dispatchTicket's own default dispatch IS
+// defaultDispatch).
+export function makeCommentWakeDispatch(dispatch) {
+  return (orchDir, ticket, phase, opts = {}) =>
+    dispatchTicket(orchDir, ticket, phase, { ...opts, dispatch });
 }
 
 // dispatchTicket — thin seam over the injectable dispatch function.

--- a/plugins/dev/scripts/execution-core/dispatch.test.mjs
+++ b/plugins/dev/scripts/execution-core/dispatch.test.mjs
@@ -6,7 +6,7 @@
 // so no test ever spawns a real script.
 
 import { describe, test, expect } from "bun:test";
-import { dispatchTicket, defaultDispatch, defaultRunPhaseAgent, dispatchForExecutor, teamOf } from "./dispatch.mjs";
+import { dispatchTicket, defaultDispatch, defaultRunPhaseAgent, dispatchForExecutor, sdkDispatch, makeCommentWakeDispatch, teamOf } from "./dispatch.mjs";
 
 describe("teamOf", () => {
   test("extracts the team prefix from a ticket identifier", () => {
@@ -369,11 +369,11 @@ describe("defaultRunPhaseAgent — failure diagnostics (CTL-1004/CTL-1056 Bug 2)
   });
 });
 
-// CTL-1365a: the executor → dispatch-function selection at the launch seam.
-// Phase 1 is INERT — bg/oneshot-legacy resolve to the unchanged defaultDispatch;
-// sdk falls back to defaultDispatch + a once-per-process WARN (sdkRunPhaseAgent
-// is CTL-1365b). Critically, "bg" must be BYTE-IDENTICAL to today's dispatch.
-describe("dispatchForExecutor (CTL-1365a)", () => {
+// CTL-1365b Stage C: the executor → dispatch-function selection at the launch
+// seam. bg/oneshot-legacy resolve to the unchanged defaultDispatch (the
+// `claude --bg` path, BYTE-IDENTICAL to today); sdk resolves to sdkDispatch, which
+// injects sdkRunPhaseAgent (the in-process Agent SDK worker).
+describe("dispatchForExecutor (CTL-1365b)", () => {
   test("bg → the unchanged defaultDispatch (byte-identical to today)", () => {
     expect(dispatchForExecutor("bg")).toBe(defaultDispatch);
   });
@@ -382,15 +382,11 @@ describe("dispatchForExecutor (CTL-1365a)", () => {
     expect(dispatchForExecutor("oneshot-legacy")).toBe(defaultDispatch);
   });
 
-  test("sdk → falls back to defaultDispatch + warns once (no throw, no missing-module import)", () => {
-    const warnings = [];
-    // Distinct module-load means _warnedSdkFallback is empty for this run; the
-    // first sdk call warns, subsequent calls dedupe (once-per-process).
-    expect(() => dispatchForExecutor("sdk", { warn: (m) => warnings.push(m) })).not.toThrow();
-    const fn = dispatchForExecutor("sdk", { warn: (m) => warnings.push(m) });
-    expect(fn).toBe(defaultDispatch);
-    expect(warnings.length).toBe(1); // warn-once: only the FIRST sdk call emitted
-    expect(warnings[0]).toMatch(/executor=sdk not yet implemented \(CTL-1365b\), using bg/);
+  test("sdk → sdkDispatch (identity-stable; the sdk launch verb is wired, not a bg fallback)", () => {
+    expect(dispatchForExecutor("sdk")).toBe(sdkDispatch);
+    // identity-stable: the SAME function object every call, so the daemon's
+    // four-entry-point wiring is assertable by reference.
+    expect(dispatchForExecutor("sdk")).toBe(dispatchForExecutor("sdk"));
   });
 
   test("the injected bg dispatch behaves IDENTICALLY to defaultDispatch — same arg array reaches runPhaseAgent", () => {
@@ -420,6 +416,105 @@ describe("dispatchForExecutor (CTL-1365a)", () => {
       attempt: undefined,
       clusterGeneration: 7,
     });
+  });
+});
+
+// CTL-1365b: sdkDispatch reuses defaultDispatch's resolve→worktree→run pipeline,
+// swapping ONLY the launch verb (defaultRunPhaseAgent → sdkRunPhaseAgent). The
+// runPhaseAgent seam stays injectable for the wiring assertion; the default is the
+// real (async) sdkRunPhaseAgent.
+describe("sdkDispatch (CTL-1365b)", () => {
+  test("forwards through defaultDispatch with an injectable launch verb", () => {
+    const calls = [];
+    const spy = (args) => { calls.push(args); return { code: 0, stdout: "ok", stderr: "", signal: null }; };
+    const r = sdkDispatch(
+      { orchDir: "/ec", ticket: "CTL-1", phase: "implement", clusterGeneration: 7 },
+      {
+        resolveProject: () => ({ team: "CTL", repoRoot: "/repo" }),
+        createWorktree: (a) => ({ code: 0, worktreePath: `/wt/${a.ticket}`, stderr: "" }),
+        runPhaseAgent: spy, // override the sdk verb for a hermetic wiring check
+      },
+    );
+    expect(calls).toHaveLength(1);
+    expect(calls[0]).toEqual({
+      orchDir: "/ec",
+      ticket: "CTL-1",
+      phase: "implement",
+      worktreePath: "/wt/CTL-1",
+      resumeSession: undefined,
+      handoffPath: undefined,
+      attempt: undefined,
+      clusterGeneration: 7,
+    });
+    // sync launch verb → defaultDispatch's object branch → sync result + worktreePath.
+    expect(r).toEqual({ code: 0, stdout: "ok", stderr: "", signal: null, worktreePath: "/wt/CTL-1" });
+  });
+
+  test("defaults the launch verb to the real (async) sdkRunPhaseAgent — proven via the auth guard + the thenable result", async () => {
+    // No runPhaseAgent override → the real sdkRunPhaseAgent runs. With no
+    // CLAUDE_CODE_OAUTH_TOKEN and no ANTHROPIC_API_KEY it refuses at the auth guard
+    // BEFORE any spawn/SDK call, so this is hermetic. sdkRunPhaseAgent is async, so
+    // defaultDispatch's THENABLE branch composes worktreePath onto the awaited
+    // result — the sync bg path never reaches that branch (byte-identical).
+    const savedKey = process.env.ANTHROPIC_API_KEY;
+    const savedTok = process.env.CLAUDE_CODE_OAUTH_TOKEN;
+    const savedAuth = process.env.ANTHROPIC_AUTH_TOKEN;
+    delete process.env.ANTHROPIC_API_KEY;
+    delete process.env.ANTHROPIC_AUTH_TOKEN;
+    delete process.env.CLAUDE_CODE_OAUTH_TOKEN;
+    try {
+      const r = sdkDispatch(
+        { orchDir: "/ec", ticket: "CTL-1", phase: "implement" },
+        {
+          resolveProject: () => ({ team: "CTL", repoRoot: "/repo" }),
+          createWorktree: (a) => ({ code: 0, worktreePath: `/wt/${a.ticket}`, stderr: "" }),
+        },
+      );
+      expect(typeof r.then).toBe("function"); // async sdk verb → defaultDispatch returns a Promise
+      const awaited = await r;
+      expect(awaited.code).toBe(1); // auth guard refused
+      expect(awaited.stderr).toMatch(/OAUTH_TOKEN is missing|refusing to dispatch under executor=sdk/);
+      expect(awaited.worktreePath).toBe("/wt/CTL-1"); // defaultDispatch wrapped worktreePath onto the awaited result
+    } finally {
+      if (savedKey !== undefined) process.env.ANTHROPIC_API_KEY = savedKey;
+      if (savedTok !== undefined) process.env.CLAUDE_CODE_OAUTH_TOKEN = savedTok;
+      if (savedAuth !== undefined) process.env.ANTHROPIC_AUTH_TOKEN = savedAuth;
+    }
+  });
+});
+
+// CTL-1365b: makeCommentWakeDispatch binds the resolved executor dispatch into the
+// positional (orchDir,ticket,phase,opts) shape handleCommentWake invokes — the
+// comment-wake entry point honors the SAME executor (no split-brain).
+describe("makeCommentWakeDispatch (CTL-1365b)", () => {
+  test("threads the executor dispatch into dispatchTicket with orchDir/ticket/phase + opts", () => {
+    const calls = [];
+    const fakeDispatch = (args) => { calls.push(args); return { code: 0 }; };
+    const cw = makeCommentWakeDispatch(fakeDispatch);
+    const r = cw("/orch", "CTL-1", "implement", { handoffPath: "/h.md", resumeSession: "u1" });
+    expect(r.code).toBe(0);
+    expect(calls).toHaveLength(1);
+    // dispatchTicket forwarded our executor dispatch (NOT its defaultDispatch default).
+    expect(calls[0]).toEqual({
+      orchDir: "/orch",
+      ticket: "CTL-1",
+      phase: "implement",
+      handoffPath: "/h.md",
+      resumeSession: "u1",
+    });
+  });
+
+  test("bg binding (defaultDispatch) is byte-identical to the prior dispatch:dispatchTicket wiring", () => {
+    // For executor=bg, dispatch === defaultDispatch, which is also dispatchTicket's
+    // OWN default — so makeCommentWakeDispatch(defaultDispatch) routes exactly as the
+    // pre-CTL-1365 `dispatch: dispatchTicket` wiring did.
+    const cw = makeCommentWakeDispatch(defaultDispatch);
+    expect(typeof cw).toBe("function");
+    // No resumeSession/handoffPath → dispatchTicket omits both keys (back-compat).
+    const calls = [];
+    const cw2 = makeCommentWakeDispatch((args) => { calls.push(args); return { code: 0 }; });
+    cw2("/orch", "CTL-2", "triage", {});
+    expect(calls[0]).toEqual({ orchDir: "/orch", ticket: "CTL-2", phase: "triage" });
   });
 });
 

--- a/plugins/dev/scripts/execution-core/package.json
+++ b/plugins/dev/scripts/execution-core/package.json
@@ -15,5 +15,8 @@
   },
   "devDependencies": {
     "@types/bun": "^1.3.12"
+  },
+  "optionalDependencies": {
+    "@anthropic-ai/claude-agent-sdk": "^0.3.0"
   }
 }

--- a/plugins/dev/scripts/execution-core/sdk-run-phase-agent.mjs
+++ b/plugins/dev/scripts/execution-core/sdk-run-phase-agent.mjs
@@ -1,0 +1,479 @@
+// sdk-run-phase-agent.mjs — the `executor=sdk` launch verb (CTL-1365b).
+//
+// Same SIGNATURE and RETURN SHAPE as dispatch.mjs:defaultRunPhaseAgent
+//   ({ orchDir, ticket, phase, worktreePath, resumeSession, handoffPath,
+//      attempt, clusterGeneration }) → { code, stdout, stderr, signal }
+// — so it is drop-in beside the `--bg` path. `signal` is always null for the SDK
+// (there is no killed-subprocess signal to surface), kept for shape parity so the
+// scheduler reads ONE consistent result shape regardless of executor.
+//
+// ── How it REUSES the Stage-A shared pre-launch ─────────────────────────────
+// The adversarial review (plan §"MUST-FIX" #1) established that the executor seam
+// is the LAUNCH VERB, not the whole dispatch path: phase-agent-dispatch — NOT the
+// phase skill — writes the initial status:"dispatched" signal AND the
+// CATALYST_GENERATION fencing token (the skill template requires the signal to
+// PRE-EXIST and only flips dispatched→running), runs the CTL-736 atomic
+// single-flight claim, and performs the CTL-667/707 dispatch-time rebase. A raw
+// query() would skip all of that and the skill would abort "signal file missing".
+//
+// So sdkRunPhaseAgent does NOT call query() directly. It runs the SAME
+// phase-agent-dispatch script in `--launch-mode prelaunch-only` (Stage A seam),
+// which performs the IDENTICAL pre-launch (claim + fenced "dispatched" signal +
+// generation token + rebase + prompt/env/settings composition) and then, instead
+// of spawning `claude --bg`, prints the resolved launch spec as one JSON line and
+// exits 0. sdkRunPhaseAgent parses that spec and replaces ONLY the launch verb:
+// it drives the phase skill through an in-process Agent SDK query() with the
+// spec's worktreePath (cwd), prompt (the /catalyst-dev:phase-* slash command), and
+// env (the composed CATALYST_* + fencing token + OTEL attrs). Everything upstream
+// of the launch is byte-identical to the bg path (proven by phase-agent-dispatch
+// test 70's prelaunch↔dry-run↔bg parity).
+//
+// ── The 3 worker contracts ──────────────────────────────────────────────────
+//  1. Terminal event   phase.<name>.(complete|failed|turn-cap-exhausted|skipped).<ticket>
+//     The phase SKILL emits this itself (it runs the identical phase body the bg
+//     worker runs). sdkRunPhaseAgent adds a BACKSTOP emit — mirroring
+//     phase-agent-dispatch's mark_launch_failed — for abnormal terminations
+//     (error/cancel/interrupt/throw/no-result/turn-cap) where the skill never
+//     reached its own emit, via phase-agent-emit-complete --no-signal-update.
+//  2. Signal files + CATALYST_GENERATION fencing — written by the shared
+//     pre-launch (status:"dispatched" + generation); the skill flips
+//     dispatched→running→done/stalled. sdkRunPhaseAgent never writes them.
+//  3. Phase prompt + CATALYST_* env — carried as the spec's prompt + plain env
+//     (options.env). Because the SDK child inherits env normally, this collapses
+//     the CTL-760/777 `--settings` env-bridge the bg path needs (that bridge only
+//     existed because `claude --bg` is an RPC to a frozen-env daemon).
+//
+// ── Auth (plan §1c) ─────────────────────────────────────────────────────────
+// Subscription auth ONLY: the env handed to query() always deletes
+// ANTHROPIC_API_KEY + ANTHROPIC_AUTH_TOKEN (rungs 2-3 outrank the OAuth token and
+// silently METER in headless mode) and sets CLAUDE_CODE_OAUTH_TOKEN. We never pass
+// `--bare` / an API-key-reading settingSource. A dispatch-time assertion refuses
+// to run (no claim, no signal) when ANTHROPIC_API_KEY is set or the OAuth token is
+// missing — failing loud instead of silently metering.
+//
+// ── Concurrency + backoff (plan §1e) ────────────────────────────────────────
+// The SDK has no built-in concurrency cap and mislabels 529 overloaded_error with
+// no backoff. The daemon owns both: a process-wide semaphore sized from
+// orchestration.maxParallel caps concurrent query() calls; 429/529 trigger bounded
+// exponential backoff + jitter, emitting execution-core.sdk.overloaded for HUD
+// backpressure, and on exhaustion return a failed result + a backstop failed event
+// (never a silent drop).
+
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+
+// phase-agent-dispatch + phase-agent-emit-complete sit one directory up.
+const PHASE_AGENT_DISPATCH_BIN = fileURLToPath(
+  new URL("../phase-agent-dispatch", import.meta.url),
+);
+const EMIT_COMPLETE_BIN = fileURLToPath(
+  new URL("../phase-agent-emit-complete", import.meta.url),
+);
+
+// ── Async semaphore ─────────────────────────────────────────────────────────
+// A minimal counting semaphore: acquire() resolves when a slot is free, the
+// returned release() frees it. Sized from maxParallel so the daemon never has
+// more than N concurrent in-process query() calls (the SDK cap the runtime omits).
+// This sits BELOW the existing HRW/admission gate (which decides WHICH tickets
+// run) — it caps concurrent query() calls only, so the two never double-count: a
+// ticket admitted by HRW simply waits here for a query slot, it is not re-gated.
+export class Semaphore {
+  constructor(max) {
+    this.max = Math.max(1, Number.isFinite(max) ? Math.floor(max) : 1);
+    this._active = 0;
+    this._waiters = [];
+  }
+  get active() {
+    return this._active;
+  }
+  async acquire() {
+    if (this._active < this.max) {
+      this._active += 1;
+      return () => this._release();
+    }
+    await new Promise((resolve) => this._waiters.push(resolve));
+    this._active += 1;
+    return () => this._release();
+  }
+  _release() {
+    this._active -= 1;
+    const next = this._waiters.shift();
+    if (next) next();
+  }
+}
+
+// One process-wide semaphore, lazily created at the configured size. The daemon
+// is a single process, so a module-level singleton is the right scope for the
+// fleet-wide concurrency cap. Tests inject their own Semaphore.
+let _sharedSemaphore = null;
+function sharedSemaphore(maxParallel) {
+  if (_sharedSemaphore && _sharedSemaphore.max === maxParallel) return _sharedSemaphore;
+  _sharedSemaphore = new Semaphore(maxParallel);
+  return _sharedSemaphore;
+}
+
+// resolveMaxParallel — the concurrency cap. CATALYST_SDK_MAX_PARALLEL overrides
+// (test/tuning) then the generic CATALYST_MAX_PARALLEL, else the same default 3 the
+// scheduler uses. Never returns < 1.
+export function resolveMaxParallel(env = process.env) {
+  const raw = env.CATALYST_SDK_MAX_PARALLEL ?? env.CATALYST_MAX_PARALLEL;
+  const n = Number(raw);
+  return Number.isInteger(n) && n > 0 ? n : 3;
+}
+
+// ── Auth guard (plan §1c) ───────────────────────────────────────────────────
+// assertSdkAuth — refuse to dispatch under sdk when the env would silently meter.
+// Returns { ok, reason }. `ok:false` means: ANTHROPIC_API_KEY (or ANTHROPIC_AUTH_TOKEN)
+// is set in the ambient env (rungs 2-3 would override the subscription token), OR
+// the OAuth token is missing (nothing to authenticate the subscription). Pure;
+// never throws. Exported so the daemon boot assertion (plan §1c) can reuse it.
+export function assertSdkAuth({ env = process.env, oauthToken } = {}) {
+  if (env.ANTHROPIC_API_KEY) {
+    return {
+      ok: false,
+      reason:
+        "ANTHROPIC_API_KEY is set — refusing to dispatch under executor=sdk (would silently meter; unset it and authenticate via CLAUDE_CODE_OAUTH_TOKEN)",
+    };
+  }
+  if (env.ANTHROPIC_AUTH_TOKEN) {
+    return {
+      ok: false,
+      reason:
+        "ANTHROPIC_AUTH_TOKEN is set — refusing to dispatch under executor=sdk (overrides the subscription OAuth token)",
+    };
+  }
+  if (!oauthToken) {
+    return {
+      ok: false,
+      reason:
+        "CLAUDE_CODE_OAUTH_TOKEN is missing — refusing to dispatch under executor=sdk (run `claude setup-token`)",
+    };
+  }
+  return { ok: true, reason: null };
+}
+
+// ── Default seams (overridable for tests; default = real) ───────────────────
+
+// defaultRunQuery — lazily import the Agent SDK so the module loads (and its tests
+// run) WITHOUT the SDK installed. Returns an async iterable of streamed messages.
+// Tests inject a fake async-iterable and never touch the real SDK / network.
+function defaultRunQuery({ prompt, options }) {
+  return (async function* () {
+    const { query } = await import("@anthropic-ai/claude-agent-sdk");
+    for await (const m of query({ prompt, options })) yield m;
+  })();
+}
+
+// defaultEmitEvent — observability events (execution-core.sdk.overloaded /
+// execution-core.auth.misconfigured). These are non-phase, non-routed events, so
+// the default is a dependency-free best-effort stderr line; the daemon injects a
+// real unified-event-log writer at the dispatch seam. Never throws.
+function defaultEmitEvent(name, payload) {
+  try {
+    process.stderr.write(
+      `[sdk-run-phase-agent] ${name} ${JSON.stringify(payload ?? {})}\n`,
+    );
+  } catch {
+    /* best-effort */
+  }
+}
+
+// defaultEmitBackstop — emit the canonical terminal event as a BACKSTOP, mirroring
+// phase-agent-dispatch:mark_launch_failed (phase-agent-emit-complete with
+// --no-signal-update so the skill/pre-launch keeps ownership of the signal file).
+// Best-effort; never throws.
+function defaultEmitBackstop({ phase, ticket, status, reason, orchDir }, { spawn = spawnSync } = {}) {
+  try {
+    const args = [
+      "--phase", phase,
+      "--ticket", ticket,
+      "--status", status,
+      "--orch-dir", orchDir,
+      "--orch-id", ticket,
+      "--no-signal-update",
+    ];
+    if (reason) args.push("--reason", reason);
+    spawn(EMIT_COMPLETE_BIN, args, { encoding: "utf8" });
+  } catch {
+    /* best-effort */
+  }
+}
+
+const defaultSleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+// ── Overloaded (429/529) detection ──────────────────────────────────────────
+const OVERLOADED_STATUSES = new Set([429, 529]);
+
+function statusOf(x) {
+  // Tolerate a few shapes the SDK / underlying API surface uses.
+  return (
+    x?.api_error_status ??
+    x?.status ??
+    x?.statusCode ??
+    x?.error?.status ??
+    null
+  );
+}
+
+// isOverloadedResult — a terminal result that is a 429/529 overload, or an
+// overloaded_error subtype.
+function isOverloadedResult(result) {
+  if (!result) return false;
+  const s = statusOf(result);
+  if (OVERLOADED_STATUSES.has(Number(s))) return true;
+  const t = result.error?.type ?? result.error_type;
+  return t === "overloaded_error";
+}
+
+// isOverloadedError — a thrown error that is a 429/529 overload.
+function isOverloadedError(err) {
+  if (!err) return false;
+  const s = statusOf(err);
+  if (OVERLOADED_STATUSES.has(Number(s))) return true;
+  const t = err?.error?.type ?? err?.type;
+  if (t === "overloaded_error") return true;
+  return /\b(429|529|overloaded)\b/i.test(String(err?.message ?? ""));
+}
+
+// backoffMs — exponential backoff (base·2^i) capped, plus full jitter. `random`
+// is injectable so the backoff test is deterministic.
+function backoffMs(i, { baseMs = 1000, capMs = 30000, random = Math.random } = {}) {
+  const ceil = Math.min(capMs, baseMs * 2 ** i);
+  return Math.floor(ceil * (0.5 + 0.5 * random())); // 50%-100% of the ceiling
+}
+
+// ── The run loop ────────────────────────────────────────────────────────────
+
+// runPrelaunch — invoke phase-agent-dispatch in prelaunch-only mode (the Stage-A
+// shared pre-launch) and return the parsed launch spec. Builds the SAME arg array
+// + env as dispatch.mjs:defaultRunPhaseAgent (so the pre-launch behaves
+// identically) plus `--launch-mode prelaunch-only`. Returns
+// { ok, spec, code, stderr }.
+function runPrelaunch(
+  { orchDir, ticket, phase, worktreePath, resumeSession, handoffPath, attempt, clusterGeneration },
+  { spawn = spawnSync } = {},
+) {
+  const args = [
+    "--phase", phase,
+    "--ticket", ticket,
+    "--orch-dir", orchDir,
+    "--orch-id", ticket,
+    "--launch-mode", "prelaunch-only",
+  ];
+  if (resumeSession) args.push("--resume-session", resumeSession);
+  if (attempt != null) args.push("--attempt", String(attempt));
+  const extraEnv = {};
+  if (handoffPath) extraEnv.CATALYST_HANDOFF_PATH = handoffPath;
+  if (clusterGeneration != null) extraEnv.CATALYST_CLUSTER_GENERATION = String(clusterGeneration);
+  const env = {
+    ...process.env,
+    CATALYST_ORCHESTRATOR_DIR: orchDir,
+    CATALYST_ORCHESTRATOR_ID: ticket,
+    CATALYST_PHASE: phase,
+    CATALYST_TICKET: ticket,
+    CATALYST_EXECUTION_CORE: "1",
+    ...extraEnv,
+  };
+  delete env.CATALYST_RECREATE_ATTEMPTED; // per-dispatch marker (mirror dispatch.mjs)
+  const res = spawn(PHASE_AGENT_DISPATCH_BIN, args, {
+    cwd: worktreePath,
+    encoding: "utf8",
+    env,
+  });
+  const code = res.error ? 127 : (res.status ?? 0);
+  const stderr = res.error
+    ? (res.stderr && res.stderr.length ? res.stderr : res.error.message)
+    : (res.stderr ?? "");
+  // The spec is the last JSON object line printed on stdout.
+  let spec = null;
+  const lines = String(res.stdout ?? "").trim().split("\n").filter(Boolean);
+  for (let i = lines.length - 1; i >= 0; i--) {
+    try {
+      const obj = JSON.parse(lines[i]);
+      if (obj && typeof obj === "object") {
+        spec = obj;
+        break;
+      }
+    } catch {
+      /* not a JSON line */
+    }
+  }
+  const ok = code === 0 && spec != null && spec.status === "prelaunch-ready";
+  return { ok, spec, code, stderr };
+}
+
+// buildSdkEnv — the env handed to query(), built from the shared-pre-launch spec's
+// composed env array (KEY=VALUE strings: CATALYST_* + CATALYST_GENERATION fencing
+// token + OTEL attrs) layered over process.env, with the auth guards applied. This
+// is plain env (Contract 3) — it REPLACES the CTL-760/777 --settings bridge.
+export function buildSdkEnv(specEnv, { base = process.env, oauthToken } = {}) {
+  const env = { ...base };
+  for (const kv of specEnv ?? []) {
+    const idx = String(kv).indexOf("=");
+    if (idx <= 0) continue;
+    env[kv.slice(0, idx)] = kv.slice(idx + 1);
+  }
+  // AUTH GUARD: subscription only. Rungs 2-3 outrank the OAuth token + silently
+  // meter in headless mode — always strip them; set the OAuth token.
+  delete env.ANTHROPIC_API_KEY;
+  delete env.ANTHROPIC_AUTH_TOKEN;
+  env.CLAUDE_CODE_OAUTH_TOKEN = oauthToken;
+  delete env.CATALYST_RECREATE_ATTEMPTED;
+  return env;
+}
+
+// buildQueryOptions — the query() options. `--bare` is NEVER set; settingSources is
+// always ["user","project"] (NEVER [] — that hides the plugin phase skills).
+export function buildQueryOptions(spec, env, { turnCap } = {}) {
+  const options = {
+    cwd: spec.worktreePath,
+    env, // plain env — replaces the CTL-760/777 --settings bridge
+    executable: "bun", // #266: avoid "Bun is not defined" under a Node spawn
+    settingSources: ["user", "project"], // REQUIRED so plugin phase skills resolve
+    permissionMode: "bypassPermissions", // unattended; skills self-gate via frontmatter
+    systemPrompt: { type: "preset", preset: "claude_code" }, // keep CLI behavior
+  };
+  if (turnCap != null) options.maxTurns = turnCap; // → error_max_turns → turn-cap-exhausted
+  if (spec.resumeSession) options.resume = spec.resumeSession; // cwd === worktreePath (set above)
+  return options;
+}
+
+// mapResult — terminal SDK result → { code, stdout, stderr, signal } + the backstop
+// emit decision. subtype "success" → code 0, NO backstop (the skill emitted
+// complete). error_max_turns → turn-cap-exhausted backstop. anything else (error /
+// cancelled / interrupted / no result) → failed backstop.
+function mapResult(result) {
+  if (!result) {
+    return {
+      result: { code: 1, stdout: "", stderr: "sdk: query ended with no terminal result", signal: null },
+      backstop: { status: "failed", reason: "sdk-no-result" },
+    };
+  }
+  if (result.subtype === "success" && !result.is_error) {
+    return {
+      result: { code: 0, stdout: result.result ?? "", stderr: "", signal: null },
+      backstop: null,
+    };
+  }
+  if (result.subtype === "error_max_turns") {
+    return {
+      result: { code: 1, stdout: result.result ?? "", stderr: "sdk: max turns exhausted", signal: null },
+      backstop: { status: "turn-cap-exhausted", reason: "sdk-error-max-turns" },
+    };
+  }
+  return {
+    result: { code: 1, stdout: result.result ?? "", stderr: `sdk: ${result.subtype ?? "error"}`, signal: null },
+    backstop: { status: "failed", reason: `sdk-${result.subtype ?? "error"}` },
+  };
+}
+
+// sdkRunPhaseAgent — the executor=sdk launch verb. async (the in-process query loop
+// awaits the SDK stream), returns the defaultRunPhaseAgent shape.
+export async function sdkRunPhaseAgent(
+  { orchDir, ticket, phase, worktreePath, resumeSession, handoffPath, attempt, clusterGeneration },
+  {
+    runQuery = defaultRunQuery,
+    oauthToken = process.env.CLAUDE_CODE_OAUTH_TOKEN,
+    turnCap,
+    env: authEnv = process.env, // the AMBIENT env the auth guard inspects
+    spawn = spawnSync, // for the prelaunch + backstop emit
+    semaphore, // injectable; defaults to the process-wide shared one
+    maxParallel = resolveMaxParallel(),
+    emitEvent = defaultEmitEvent,
+    emitBackstop = defaultEmitBackstop,
+    sleep = defaultSleep,
+    random = Math.random,
+    maxRetries = 5, // bound the 429/529 backoff
+    backoff = {}, // { baseMs, capMs } overrides for tests
+  } = {},
+) {
+  // ── AUTH GUARD: refuse BEFORE any side effect (no claim, no signal) ───────
+  const auth = assertSdkAuth({ env: authEnv, oauthToken });
+  if (!auth.ok) {
+    emitEvent("execution-core.auth.misconfigured", { ticket, phase, reason: auth.reason });
+    return { code: 1, stdout: "", stderr: auth.reason, signal: null };
+  }
+
+  // ── SHARED PRE-LAUNCH (claim + fenced "dispatched" signal + generation +
+  //    rebase + prompt/env composition) via phase-agent-dispatch prelaunch-only ─
+  const pre = runPrelaunch(
+    { orchDir, ticket, phase, worktreePath, resumeSession, handoffPath, attempt, clusterGeneration },
+    { spawn },
+  );
+  if (!pre.ok) {
+    // The pre-launch already owns its own failure event (mark_launch_failed) on a
+    // claim/launch failure; surface its code/stderr without a duplicate backstop.
+    return {
+      code: pre.code || 1,
+      stdout: "",
+      stderr: pre.stderr || "sdk: shared pre-launch failed (no launch spec)",
+      signal: null,
+    };
+  }
+  const spec = pre.spec;
+
+  const env = buildSdkEnv(spec.env, { base: authEnv, oauthToken });
+  const options = buildQueryOptions(spec, env, { turnCap });
+
+  // ── LAUNCH VERB: the in-process query() loop, under the concurrency cap ───
+  const sem = semaphore ?? sharedSemaphore(maxParallel);
+  const release = await sem.acquire();
+  try {
+    let lastOverload = null;
+    for (let i = 0; i <= maxRetries; i++) {
+      const ac = new AbortController();
+      let result = null;
+      let thrown = null;
+      try {
+        const q = runQuery({ prompt: spec.prompt, options: { ...options, abortController: ac } });
+        for await (const m of q) {
+          if (m?.type === "result") result = m; // exactly one terminal
+        }
+      } catch (err) {
+        thrown = err;
+      }
+
+      // 429/529 → bounded backoff + retry.
+      const overloaded = thrown ? isOverloadedError(thrown) : isOverloadedResult(result);
+      if (overloaded) {
+        lastOverload = thrown ?? result;
+        if (i < maxRetries) {
+          const delay = backoffMs(i, { ...backoff, random });
+          emitEvent("execution-core.sdk.overloaded", {
+            ticket, phase, attempt: i, delayMs: delay, status: statusOf(lastOverload),
+          });
+          await sleep(delay);
+          continue;
+        }
+        // Exhausted: failed result + backstop failed event (never a silent drop).
+        emitEvent("execution-core.sdk.overloaded", {
+          ticket, phase, attempt: i, exhausted: true, status: statusOf(lastOverload),
+        });
+        emitBackstop({ phase, ticket, status: "failed", reason: "sdk-overloaded-exhausted", orchDir }, { spawn });
+        return {
+          code: 1,
+          stdout: "",
+          stderr: `sdk: overloaded (429/529) after ${maxRetries + 1} attempts`,
+          signal: null,
+        };
+      }
+
+      // A non-overloaded thrown error → failed (with backstop).
+      if (thrown) {
+        emitBackstop({ phase, ticket, status: "failed", reason: "sdk-threw", orchDir }, { spawn });
+        return { code: 1, stdout: "", stderr: String(thrown?.message ?? thrown), signal: null };
+      }
+
+      // Terminal result → map + (conditional) backstop emit.
+      const { result: mapped, backstop } = mapResult(result);
+      if (backstop) {
+        emitBackstop({ phase, ticket, status: backstop.status, reason: backstop.reason, orchDir }, { spawn });
+      }
+      return mapped;
+    }
+    // Unreachable (the loop always returns), but keep a defined shape.
+    return { code: 1, stdout: "", stderr: "sdk: retry loop exhausted", signal: null };
+  } finally {
+    release();
+  }
+}

--- a/plugins/dev/scripts/execution-core/sdk-run-phase-agent.mjs
+++ b/plugins/dev/scripts/execution-core/sdk-run-phase-agent.mjs
@@ -159,7 +159,12 @@ export function assertSdkAuth({ env = process.env, oauthToken } = {}) {
 // Tests inject a fake async-iterable and never touch the real SDK / network.
 function defaultRunQuery({ prompt, options }) {
   return (async function* () {
-    const { query } = await import("@anthropic-ai/claude-agent-sdk");
+    // Non-literal specifier so bun build's static resolution check (CI import
+    // graph) skips it — literal dynamic imports are still statically resolved
+    // even when lazy (same trap as vite + bun:sqlite, PR #1561). The SDK is an
+    // optionalDependency, loaded only at runtime where the executor=sdk path runs.
+    const sdkPkg = ["@anthropic-ai", "claude-agent-sdk"].join("/");
+    const { query } = await import(sdkPkg);
     for await (const m of query({ prompt, options })) yield m;
   })();
 }

--- a/plugins/dev/scripts/execution-core/sdk-run-phase-agent.test.mjs
+++ b/plugins/dev/scripts/execution-core/sdk-run-phase-agent.test.mjs
@@ -1,0 +1,477 @@
+// sdk-run-phase-agent.test.mjs — CTL-1365b. Fully OFFLINE: every test injects a
+// fake runQuery (no real @anthropic-ai/claude-agent-sdk, no network) and a fake
+// spawn for the shared pre-launch (no real phase-agent-dispatch / git / claude).
+//
+// Run: cd plugins/dev/scripts/execution-core && bun test sdk-run-phase-agent.test.mjs
+
+import { describe, test, expect } from "bun:test";
+import { existsSync, mkdtempSync, readFileSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  sdkRunPhaseAgent,
+  assertSdkAuth,
+  buildSdkEnv,
+  buildQueryOptions,
+  resolveMaxParallel,
+  Semaphore,
+} from "./sdk-run-phase-agent.mjs";
+
+// ── Fakes ───────────────────────────────────────────────────────────────────
+
+// makeSpec — a canonical prelaunch-only launch spec (the shape phase-agent-dispatch
+// emits in --launch-mode prelaunch-only).
+const makeSpec = (over = {}) => ({
+  ticket: "CTL-100",
+  phase: "implement",
+  model: "opus",
+  turnCap: 200,
+  bg_job_id: null,
+  prompt: "/catalyst-dev:phase-implement CTL-100 --orch-dir /ec",
+  signalFile: "/ec/workers/CTL-100/phase-implement.json",
+  sessionName: "CTL-100 implement",
+  attempt: 1,
+  worktreePath: "/wt/CTL-100",
+  generation: 1,
+  resumeSession: null,
+  pluginDirs: [],
+  env: [
+    "CATALYST_ORCHESTRATOR_DIR=/ec",
+    "CATALYST_ORCHESTRATOR_ID=CTL-100",
+    "CATALYST_PHASE=implement",
+    "CATALYST_TICKET=CTL-100",
+    "CATALYST_GENERATION=1",
+    "CATALYST_CLUSTER_GENERATION=",
+    "OTEL_RESOURCE_ATTRIBUTES=linear.key=CTL-100,task.type=phase-implement",
+  ],
+  settings: {},
+  status: "prelaunch-ready",
+  launchMode: "prelaunch-only",
+  dryRun: false,
+  ...over,
+});
+
+// spawnReturningSpec — a fake spawnSync for the prelaunch that records its calls,
+// optionally writes a signal file (to prove the claim+signal precede query), and
+// prints the given spec on stdout. `onPrelaunch` lets a test observe filesystem
+// state at prelaunch time.
+function spawnReturningSpec({ spec = makeSpec(), code = 0, signalFile, onPrelaunch } = {}) {
+  const calls = [];
+  const spawn = (bin, args, opts) => {
+    calls.push({ bin, args, opts });
+    // Only the prelaunch (phase-agent-dispatch) writes a signal; the backstop
+    // emit (phase-agent-emit-complete) is recorded but writes nothing.
+    if (bin.endsWith("phase-agent-dispatch")) {
+      if (signalFile) {
+        writeFileSync(signalFile, JSON.stringify({ status: "dispatched", generation: spec.generation, bg_job_id: null }));
+      }
+      if (onPrelaunch) onPrelaunch();
+      return { status: code, stdout: `${JSON.stringify(spec)}\n`, stderr: "", error: null };
+    }
+    return { status: 0, stdout: "", stderr: "", error: null };
+  };
+  return { spawn, calls };
+}
+
+// fakeQuery — an async-iterable factory yielding the given messages. Records the
+// prompt + options it was called with.
+function fakeQuery(messages, sink) {
+  return ({ prompt, options }) => {
+    if (sink) {
+      sink.prompt = prompt;
+      sink.options = options;
+      sink.calls = (sink.calls ?? 0) + 1;
+    }
+    return (async function* () {
+      for (const m of messages) yield m;
+    })();
+  };
+}
+
+const resultMsg = (over = {}) => ({ type: "result", subtype: "success", is_error: false, result: "done", ...over });
+
+const ARGS = { orchDir: "/ec", ticket: "CTL-100", phase: "implement", worktreePath: "/wt/CTL-100" };
+const GOOD_AUTH = { env: { CLAUDE_CODE_OAUTH_TOKEN: "tok" }, oauthToken: "tok" };
+
+// ── assertSdkAuth ─────────────────────────────────────────────────────────────
+
+describe("assertSdkAuth", () => {
+  test("ok when only CLAUDE_CODE_OAUTH_TOKEN is set", () => {
+    expect(assertSdkAuth({ env: { CLAUDE_CODE_OAUTH_TOKEN: "t" }, oauthToken: "t" }).ok).toBe(true);
+  });
+  test("refuses when ANTHROPIC_API_KEY is set (would silently meter)", () => {
+    const r = assertSdkAuth({ env: { ANTHROPIC_API_KEY: "sk", CLAUDE_CODE_OAUTH_TOKEN: "t" }, oauthToken: "t" });
+    expect(r.ok).toBe(false);
+    expect(r.reason).toContain("ANTHROPIC_API_KEY");
+  });
+  test("refuses when ANTHROPIC_AUTH_TOKEN is set", () => {
+    const r = assertSdkAuth({ env: { ANTHROPIC_AUTH_TOKEN: "x", CLAUDE_CODE_OAUTH_TOKEN: "t" }, oauthToken: "t" });
+    expect(r.ok).toBe(false);
+    expect(r.reason).toContain("ANTHROPIC_AUTH_TOKEN");
+  });
+  test("refuses when the OAuth token is missing", () => {
+    const r = assertSdkAuth({ env: {}, oauthToken: undefined });
+    expect(r.ok).toBe(false);
+    expect(r.reason).toContain("CLAUDE_CODE_OAUTH_TOKEN");
+  });
+});
+
+// ── buildSdkEnv (auth guards + plain env) ─────────────────────────────────────
+
+describe("buildSdkEnv", () => {
+  test("merges the spec env array over the base and applies the auth guards", () => {
+    const env = buildSdkEnv(makeSpec().env, {
+      base: { ANTHROPIC_API_KEY: "sk", ANTHROPIC_AUTH_TOKEN: "x", PATH: "/bin" },
+      oauthToken: "tok",
+    });
+    // CATALYST_* + fencing token + OTEL attrs all present (plain env, Contract 3).
+    expect(env.CATALYST_ORCHESTRATOR_DIR).toBe("/ec");
+    expect(env.CATALYST_PHASE).toBe("implement");
+    expect(env.CATALYST_GENERATION).toBe("1");
+    expect(env.OTEL_RESOURCE_ATTRIBUTES).toContain("linear.key=CTL-100");
+    // Auth guards: API key + auth token stripped, OAuth token set.
+    expect("ANTHROPIC_API_KEY" in env).toBe(false);
+    expect("ANTHROPIC_AUTH_TOKEN" in env).toBe(false);
+    expect(env.CLAUDE_CODE_OAUTH_TOKEN).toBe("tok");
+    // Base env preserved.
+    expect(env.PATH).toBe("/bin");
+  });
+});
+
+// ── buildQueryOptions (never --bare, settingSources never []) ─────────────────
+
+describe("buildQueryOptions", () => {
+  test("settingSources is ['user','project'] and --bare is never set", () => {
+    const o = buildQueryOptions(makeSpec(), { CLAUDE_CODE_OAUTH_TOKEN: "t" }, { turnCap: 50 });
+    expect(o.settingSources).toEqual(["user", "project"]);
+    expect(o.settingSources).not.toEqual([]);
+    expect("bare" in o).toBe(false);
+    expect(o.cwd).toBe("/wt/CTL-100");
+    expect(o.executable).toBe("bun");
+    expect(o.permissionMode).toBe("bypassPermissions");
+    expect(o.maxTurns).toBe(50);
+  });
+  test("resume is passed iff resumeSession is set, with cwd === worktreePath", () => {
+    expect("resume" in buildQueryOptions(makeSpec(), {}, {})).toBe(false);
+    const o = buildQueryOptions(makeSpec({ resumeSession: "sess-abc" }), {}, {});
+    expect(o.resume).toBe("sess-abc");
+    expect(o.cwd).toBe("/wt/CTL-100");
+  });
+});
+
+// ── resolveMaxParallel + Semaphore ────────────────────────────────────────────
+
+describe("resolveMaxParallel", () => {
+  test("CATALYST_SDK_MAX_PARALLEL > CATALYST_MAX_PARALLEL > default 3", () => {
+    expect(resolveMaxParallel({})).toBe(3);
+    expect(resolveMaxParallel({ CATALYST_MAX_PARALLEL: "5" })).toBe(5);
+    expect(resolveMaxParallel({ CATALYST_MAX_PARALLEL: "5", CATALYST_SDK_MAX_PARALLEL: "2" })).toBe(2);
+    expect(resolveMaxParallel({ CATALYST_SDK_MAX_PARALLEL: "0" })).toBe(3); // floor
+  });
+});
+
+describe("Semaphore", () => {
+  test("never lets active exceed max", async () => {
+    const sem = new Semaphore(2);
+    let active = 0;
+    let peak = 0;
+    const task = async () => {
+      const release = await sem.acquire();
+      active += 1;
+      peak = Math.max(peak, active);
+      await new Promise((r) => setTimeout(r, 5));
+      active -= 1;
+      release();
+    };
+    await Promise.all(Array.from({ length: 6 }, task));
+    expect(peak).toBeLessThanOrEqual(2);
+  });
+});
+
+// ── sdkRunPhaseAgent: the three contracts + reuse of the shared pre-launch ────
+
+describe("sdkRunPhaseAgent — shared pre-launch reuse", () => {
+  let dir;
+  test("runs phase-agent-dispatch in prelaunch-only mode, and the claim+signal+generation exist BEFORE query()", async () => {
+    dir = mkdtempSync(join(tmpdir(), "sdk-pre-"));
+    const signalFile = join(dir, "phase-implement.json");
+    let signalExistedAtQuery = false;
+    const { spawn, calls } = spawnReturningSpec({ signalFile });
+    const sink = {};
+    const runQuery = ({ prompt, options }) => {
+      // Prove the shared pre-launch ran (signal written) BEFORE the launch verb.
+      signalExistedAtQuery = existsSync(signalFile);
+      sink.prompt = prompt;
+      sink.options = options;
+      return (async function* () { yield resultMsg(); })();
+    };
+    const r = await sdkRunPhaseAgent(ARGS, { ...GOOD_AUTH, runQuery, spawn });
+    expect(r.code).toBe(0);
+    // The pre-launch was the prelaunch-only invocation of phase-agent-dispatch.
+    const pre = calls.find((c) => c.bin.endsWith("phase-agent-dispatch"));
+    expect(pre).toBeTruthy();
+    expect(pre.args).toContain("--launch-mode");
+    expect(pre.args[pre.args.indexOf("--launch-mode") + 1]).toBe("prelaunch-only");
+    expect(pre.args).toEqual(expect.arrayContaining(["--phase", "implement", "--ticket", "CTL-100", "--orch-dir", "/ec"]));
+    // cwd of the pre-launch is the worktree.
+    expect(pre.opts.cwd).toBe("/wt/CTL-100");
+    // Contract 2 ordering: signal (status:dispatched + generation) preceded query().
+    expect(signalExistedAtQuery).toBe(true);
+    expect(JSON.parse(readFileSync(signalFile, "utf8")).status).toBe("dispatched");
+    // Contract 3: the query() prompt is the phase slash command from the spec.
+    expect(sink.prompt).toBe("/catalyst-dev:phase-implement CTL-100 --orch-dir /ec");
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  test("return shape matches defaultRunPhaseAgent ({code,stdout,stderr,signal}); signal is null", async () => {
+    const { spawn } = spawnReturningSpec();
+    const r = await sdkRunPhaseAgent(ARGS, { ...GOOD_AUTH, spawn, runQuery: fakeQuery([resultMsg({ result: "ok" })]) });
+    expect(Object.keys(r).sort()).toEqual(["code", "signal", "stderr", "stdout"]);
+    expect(r.code).toBe(0);
+    expect(r.stdout).toBe("ok");
+    expect(r.signal).toBeNull();
+  });
+
+  test("env handed to query() has NO ANTHROPIC_API_KEY and HAS CLAUDE_CODE_OAUTH_TOKEN; never --bare", async () => {
+    const { spawn } = spawnReturningSpec();
+    const sink = {};
+    await sdkRunPhaseAgent(ARGS, {
+      env: { ANTHROPIC_API_KEY: undefined, CLAUDE_CODE_OAUTH_TOKEN: "tok" },
+      oauthToken: "tok",
+      spawn,
+      runQuery: fakeQuery([resultMsg()], sink),
+    });
+    expect("ANTHROPIC_API_KEY" in sink.options.env).toBe(false);
+    expect("ANTHROPIC_AUTH_TOKEN" in sink.options.env).toBe(false);
+    expect(sink.options.env.CLAUDE_CODE_OAUTH_TOKEN).toBe("tok");
+    expect(sink.options.settingSources).toEqual(["user", "project"]);
+    expect("bare" in sink.options).toBe(false);
+  });
+});
+
+// ── Auth refusal: no claim, no query ──────────────────────────────────────────
+
+describe("sdkRunPhaseAgent — auth guard refuses", () => {
+  test("refuses (no pre-launch, no query) when ANTHROPIC_API_KEY is set", async () => {
+    const { spawn, calls } = spawnReturningSpec();
+    const sink = {};
+    const events = [];
+    const r = await sdkRunPhaseAgent(ARGS, {
+      env: { ANTHROPIC_API_KEY: "sk", CLAUDE_CODE_OAUTH_TOKEN: "t" },
+      oauthToken: "t",
+      spawn,
+      runQuery: fakeQuery([resultMsg()], sink),
+      emitEvent: (name, payload) => events.push([name, payload]),
+    });
+    expect(r.code).toBe(1);
+    expect(r.stderr).toContain("ANTHROPIC_API_KEY");
+    expect(calls.length).toBe(0); // never even ran the pre-launch
+    expect(sink.calls ?? 0).toBe(0); // never called query()
+    expect(events[0][0]).toBe("execution-core.auth.misconfigured");
+  });
+
+  test("refuses when the OAuth token is missing", async () => {
+    const { spawn, calls } = spawnReturningSpec();
+    const r = await sdkRunPhaseAgent(ARGS, {
+      env: {},
+      oauthToken: undefined,
+      spawn,
+      runQuery: fakeQuery([resultMsg()]),
+    });
+    expect(r.code).toBe(1);
+    expect(r.stderr).toContain("CLAUDE_CODE_OAUTH_TOKEN");
+    expect(calls.length).toBe(0);
+  });
+});
+
+// ── Terminal result mapping + backstop emits (Contract 1) ─────────────────────
+
+describe("sdkRunPhaseAgent — result mapping + backstop", () => {
+  test("success → code 0, NO backstop (the skill emitted complete itself)", async () => {
+    const { spawn } = spawnReturningSpec();
+    const backstops = [];
+    const r = await sdkRunPhaseAgent(ARGS, {
+      ...GOOD_AUTH, spawn,
+      runQuery: fakeQuery([resultMsg({ result: "great" })]),
+      emitBackstop: (e) => backstops.push(e),
+    });
+    expect(r.code).toBe(0);
+    expect(r.stdout).toBe("great");
+    expect(backstops.length).toBe(0);
+  });
+
+  test("error_max_turns → failed result + turn-cap-exhausted backstop", async () => {
+    const { spawn } = spawnReturningSpec();
+    const backstops = [];
+    const r = await sdkRunPhaseAgent(ARGS, {
+      ...GOOD_AUTH, spawn,
+      runQuery: fakeQuery([resultMsg({ subtype: "error_max_turns", is_error: true })]),
+      emitBackstop: (e) => backstops.push(e),
+    });
+    expect(r.code).toBe(1);
+    expect(backstops).toHaveLength(1);
+    expect(backstops[0].status).toBe("turn-cap-exhausted");
+    expect(backstops[0].phase).toBe("implement");
+    expect(backstops[0].ticket).toBe("CTL-100");
+  });
+
+  test("error subtype → failed result + failed backstop", async () => {
+    const { spawn } = spawnReturningSpec();
+    const backstops = [];
+    const r = await sdkRunPhaseAgent(ARGS, {
+      ...GOOD_AUTH, spawn,
+      runQuery: fakeQuery([resultMsg({ subtype: "error_during_execution", is_error: true })]),
+      emitBackstop: (e) => backstops.push(e),
+    });
+    expect(r.code).toBe(1);
+    expect(backstops[0].status).toBe("failed");
+  });
+
+  test("a thrown error → failed result + failed backstop", async () => {
+    const { spawn } = spawnReturningSpec();
+    const backstops = [];
+    const runQuery = () => (async function* () { throw new Error("boom"); })();
+    const r = await sdkRunPhaseAgent(ARGS, { ...GOOD_AUTH, spawn, runQuery, emitBackstop: (e) => backstops.push(e) });
+    expect(r.code).toBe(1);
+    expect(r.stderr).toContain("boom");
+    expect(backstops[0].status).toBe("failed");
+  });
+
+  test("no terminal result → failed result + failed backstop", async () => {
+    const { spawn } = spawnReturningSpec();
+    const backstops = [];
+    const r = await sdkRunPhaseAgent(ARGS, {
+      ...GOOD_AUTH, spawn,
+      runQuery: fakeQuery([{ type: "system", subtype: "init", session_id: "s1" }]),
+      emitBackstop: (e) => backstops.push(e),
+    });
+    expect(r.code).toBe(1);
+    expect(backstops[0].status).toBe("failed");
+  });
+});
+
+// ── Pre-launch failure surfaces (no query) ────────────────────────────────────
+
+describe("sdkRunPhaseAgent — shared pre-launch failure", () => {
+  test("a non-zero / stalled pre-launch returns failed WITHOUT running query()", async () => {
+    const spec = makeSpec({ status: "stalled" });
+    const { spawn } = spawnReturningSpec({ spec, code: 1 });
+    const sink = {};
+    const r = await sdkRunPhaseAgent(ARGS, { ...GOOD_AUTH, spawn, runQuery: fakeQuery([resultMsg()], sink) });
+    expect(r.code).toBe(1);
+    expect(sink.calls ?? 0).toBe(0); // launch verb never ran — pre-launch owns the failure
+  });
+});
+
+// ── 429/529 backoff + retry (Contract: never a silent drop) ───────────────────
+
+describe("sdkRunPhaseAgent — 429/529 backoff", () => {
+  test("a 529 overload retries with backoff then succeeds; no backstop on success", async () => {
+    const { spawn } = spawnReturningSpec();
+    let attempt = 0;
+    const sleeps = [];
+    const events = [];
+    const backstops = [];
+    const runQuery = () =>
+      (async function* () {
+        attempt += 1;
+        if (attempt < 3) {
+          yield resultMsg({ subtype: "error", is_error: true, api_error_status: 529 });
+        } else {
+          yield resultMsg({ result: "recovered" });
+        }
+      })();
+    const r = await sdkRunPhaseAgent(ARGS, {
+      ...GOOD_AUTH, spawn, runQuery,
+      sleep: (ms) => { sleeps.push(ms); return Promise.resolve(); },
+      random: () => 1, // deterministic full-ceiling jitter
+      backoff: { baseMs: 10, capMs: 1000 },
+      emitEvent: (n, p) => events.push([n, p]),
+      emitBackstop: (e) => backstops.push(e),
+    });
+    expect(r.code).toBe(0);
+    expect(r.stdout).toBe("recovered");
+    expect(attempt).toBe(3); // 2 overloads + 1 success
+    expect(sleeps.length).toBe(2); // backed off twice
+    expect(sleeps[1]).toBeGreaterThan(sleeps[0]); // exponential
+    expect(events.every(([n]) => n === "execution-core.sdk.overloaded")).toBe(true);
+    expect(backstops.length).toBe(0); // success → no backstop
+  });
+
+  test("a 429 thrown error retries", async () => {
+    const { spawn } = spawnReturningSpec();
+    let attempt = 0;
+    const runQuery = () =>
+      (async function* () {
+        attempt += 1;
+        if (attempt < 2) {
+          const err = new Error("rate limited");
+          err.status = 429;
+          throw err;
+        }
+        yield resultMsg({ result: "ok" });
+      })();
+    const r = await sdkRunPhaseAgent(ARGS, {
+      ...GOOD_AUTH, spawn, runQuery,
+      sleep: () => Promise.resolve(),
+      backoff: { baseMs: 1, capMs: 2 },
+    });
+    expect(r.code).toBe(0);
+    expect(attempt).toBe(2);
+  });
+
+  test("backoff exhaustion → failed result + overloaded event + failed backstop", async () => {
+    const { spawn } = spawnReturningSpec();
+    const events = [];
+    const backstops = [];
+    const runQuery = () =>
+      (async function* () { yield resultMsg({ subtype: "error", is_error: true, api_error_status: 529 }); })();
+    const r = await sdkRunPhaseAgent(ARGS, {
+      ...GOOD_AUTH, spawn, runQuery,
+      sleep: () => Promise.resolve(),
+      maxRetries: 2,
+      backoff: { baseMs: 1, capMs: 2 },
+      emitEvent: (n, p) => events.push([n, p]),
+      emitBackstop: (e) => backstops.push(e),
+    });
+    expect(r.code).toBe(1);
+    expect(r.stderr).toContain("overloaded");
+    expect(events.some(([, p]) => p.exhausted)).toBe(true);
+    expect(backstops[0].status).toBe("failed");
+    expect(backstops[0].reason).toBe("sdk-overloaded-exhausted");
+  });
+
+  test("a 200 success does NOT retry", async () => {
+    const { spawn } = spawnReturningSpec();
+    let attempt = 0;
+    const runQuery = () => (async function* () { attempt += 1; yield resultMsg(); })();
+    const r = await sdkRunPhaseAgent(ARGS, { ...GOOD_AUTH, spawn, runQuery, sleep: () => Promise.resolve() });
+    expect(r.code).toBe(0);
+    expect(attempt).toBe(1);
+  });
+});
+
+// ── Concurrency cap around query() ────────────────────────────────────────────
+
+describe("sdkRunPhaseAgent — concurrency cap", () => {
+  test("the injected semaphore caps concurrent query() calls", async () => {
+    const sem = new Semaphore(2);
+    let inFlight = 0;
+    let peak = 0;
+    const runQuery = () =>
+      (async function* () {
+        inFlight += 1;
+        peak = Math.max(peak, inFlight);
+        await new Promise((r) => setTimeout(r, 5));
+        inFlight -= 1;
+        yield resultMsg();
+      })();
+    const run = () => {
+      const { spawn } = spawnReturningSpec();
+      return sdkRunPhaseAgent(ARGS, { ...GOOD_AUTH, spawn, runQuery, semaphore: sem });
+    };
+    const results = await Promise.all(Array.from({ length: 6 }, run));
+    expect(results.every((r) => r.code === 0)).toBe(true);
+    expect(peak).toBeLessThanOrEqual(2);
+  });
+});

--- a/plugins/dev/scripts/phase-agent-dispatch
+++ b/plugins/dev/scripts/phase-agent-dispatch
@@ -152,6 +152,21 @@ RESUME_SESSION=""
 # pass higher values once they're plumbed through, but a missing flag must
 # never break dispatch.
 ATTEMPT=1
+# CTL-1365b: the executor seam is the LAUNCH VERB, not the dispatch path. Every
+# executor runs the IDENTICAL pre-launch block below (CTL-736 claim + the
+# status:"dispatched" signal + the CATALYST_GENERATION fencing token + the
+# CTL-667/707 dispatch-time rebase + prompt/env/settings composition); only the
+# final launch differs.
+#   bg (default)     spawn `claude --bg` (this script's existing behavior —
+#                    byte-identical to the pre-CTL-1365b dispatcher).
+#   prelaunch-only   run the shared pre-launch, print the resolved launch spec as
+#                    one JSON line, and exit 0 WITHOUT spawning `claude --bg`. The
+#                    in-process SDK executor (CTL-1365b sdkRunPhaseAgent) invokes
+#                    this script in this mode to reuse the pre-launch, then runs
+#                    the phase skill through an Agent SDK query() itself.
+# Resolves from the --launch-mode flag (precedence) then the
+# CATALYST_DISPATCH_LAUNCH_MODE env (so it survives the CTL-990 recreate exec).
+LAUNCH_MODE="${CATALYST_DISPATCH_LAUNCH_MODE:-}"
 
 while [[ $# -gt 0 ]]; do
 	case "$1" in
@@ -191,6 +206,10 @@ while [[ $# -gt 0 ]]; do
 		RESUME_SESSION="$2"
 		shift 2
 		;;
+	--launch-mode)
+		LAUNCH_MODE="$2"
+		shift 2
+		;;
 	--dry-run)
 		DRY_RUN=1
 		shift
@@ -217,6 +236,18 @@ if [[ ! $TICKET =~ ^[A-Za-z][A-Za-z0-9_]*-[0-9]+$ ]]; then
 fi
 if [[ $PHASE == *.* ]]; then
 	die "invalid --phase: $PHASE (dots are reserved for event name parsing)"
+fi
+
+# CTL-1365b: validate the launch verb. Empty == bg (the default). Export a
+# non-bg mode so it survives the CTL-990 recreate `exec "$0" …` (which re-runs
+# this script WITHOUT re-passing --launch-mode) — otherwise an SDK dispatch that
+# hit the research/plan recreate path would silently fall back to `claude --bg`.
+case "$LAUNCH_MODE" in
+"" | bg | prelaunch-only) ;;
+*) die "invalid --launch-mode: $LAUNCH_MODE (expected bg|prelaunch-only)" ;;
+esac
+if [[ -n $LAUNCH_MODE && $LAUNCH_MODE != "bg" ]]; then
+	export CATALYST_DISPATCH_LAUNCH_MODE="$LAUNCH_MODE"
 fi
 
 # ─── Resolve config path ────────────────────────────────────────────────────
@@ -1070,6 +1101,64 @@ if [[ -z $RESUME_SESSION ]] && is_rebase_phase "$PHASE"; then
 		# monitor-merge still catches divergence). Do NOT block the phase.
 		echo "phase-agent-dispatch: rebase preflight skipped (rc=$REBASE_RC) for ${TICKET}/${PHASE}; proceeding un-rebased" >&2
 	fi
+fi
+
+# ─── Launch verb (executor seam, CTL-1365b) ─────────────────────────────────
+#
+# EVERYTHING ABOVE THIS POINT IS THE SHARED PRE-LAUNCH BLOCK — run identically by
+# every executor:
+#   • the CTL-736 atomic single-flight generation claim,
+#   • the status:"dispatched" signal-file write + the CATALYST_GENERATION
+#     fencing token (the skill template requires this signal to PRE-EXIST —
+#     _phase-agent-template/SKILL.md only flips dispatched→running),
+#   • the CTL-667/707 L1–L4 dispatch-time rebase (+ the CTL-990 recreate exec),
+#   • the prompt + DISPATCH_ENV + --settings + session-name + plugin-dir build.
+#
+# The ONLY thing an executor swaps is the launch verb that follows:
+#   bg (default)     → spawn `claude --bg` (below). Byte-identical to the
+#                      pre-CTL-1365b dispatcher.
+#   prelaunch-only   → print the resolved launch spec as one JSON line and exit
+#                      0 WITHOUT spawning `claude --bg`. The in-process SDK
+#                      executor (CTL-1365b sdkRunPhaseAgent) ran this script in
+#                      this mode purely to reuse the pre-launch; it then reads the
+#                      emitted spec and drives the phase skill through an Agent SDK
+#                      query() itself. The signal is left at "dispatched" (the
+#                      skill flips it to "running"), exactly as for a bg launch
+#                      before its post-spawn bg_job_id record.
+#
+# emit_launch_spec mirrors the --dry-run JSON shape (so consumers parse one shape)
+# but is emitted AFTER the side-effecting pre-launch (claim + signal + rebase),
+# and additionally carries worktreePath/generation/signalFile — the inputs the
+# SDK query() needs (cwd, fencing token, signal to flip).
+emit_launch_spec() {
+	jq -nc \
+		--arg ticket "$TICKET" \
+		--arg phase "$PHASE" \
+		--arg model "$MODEL" \
+		--argjson turnCap "$TURN_CAP" \
+		--arg prompt "$PROMPT" \
+		--arg signal "$SIGNAL_FILE" \
+		--arg sessionName "$SESSION_NAME" \
+		--argjson attempt "$ATTEMPT" \
+		--arg resumeSession "$RESUME_SESSION" \
+		--arg worktreePath "$(pwd)" \
+		--argjson generation "$GENERATION" \
+		--arg pluginDirs "$PLUGIN_DIRS_RESOLVED" \
+		--argjson env "$(printf '%s\n' "${DISPATCH_ENV[@]}" | jq -R . | jq -s .)" \
+		--argjson settings "$(printf '%s' "$WORKER_SETTINGS_JSON" | jq -e . >/dev/null 2>&1 && printf '%s' "$WORKER_SETTINGS_JSON" || echo '{}')" \
+		'{ticket: $ticket, phase: $phase, model: $model, turnCap: $turnCap,
+      bg_job_id: null, prompt: $prompt, signalFile: $signal,
+      sessionName: $sessionName, attempt: $attempt,
+      worktreePath: $worktreePath, generation: $generation,
+      resumeSession: (if $resumeSession == "" then null else $resumeSession end),
+      pluginDirs: (if $pluginDirs == "" then [] else ($pluginDirs | split(":")) end),
+      env: $env, settings: $settings, status: "prelaunch-ready",
+      launchMode: "prelaunch-only", dryRun: false}'
+}
+
+if [[ $LAUNCH_MODE == "prelaunch-only" ]]; then
+	emit_launch_spec
+	exit 0
 fi
 
 # Spawn the phase agent. `claude --bg` writes the new job ID to stdout as


### PR DESCRIPTION
**Phase 1, second PR** of the SDK-executor cutover. **DRAFT / hold-for-review** — it touches the **live `bg` dispatch path** (currently running ADV work end-to-end), so it must be human-reviewed + live-validated before merge. **Not auto-merged.**

`sdk` is fully **gated off** (every node-class defaults to `bg` via 1a) — so nothing in this PR runs in production until a node is explicitly flipped to `executor=sdk` (Phase 2 canary, separate).

## What's in it
- **Shared pre-launch refactor (the must-fix from the plan review):** `phase-agent-dispatch` gains a `--launch-mode bg|prelaunch-only` seam. `prelaunch-only` runs the full pre-launch — CTL-736 single-flight claim, the fenced `status:"dispatched"` signal + `CATALYST_GENERATION` token, the CTL-667/707 dispatch-time rebase, and the prompt/env/settings composition — then prints a launch spec and exits **before** the launch verb. Both executors share it; an executor swaps **only** the launch verb (`claude --bg` vs the SDK `query()`).
- **`sdkRunPhaseAgent`** (`execution-core/sdk-run-phase-agent.mjs`): spawns `phase-agent-dispatch --launch-mode prelaunch-only` (identical arg array to the bg path) to do the pre-launch, then drives the Agent SDK `query()` loop to the terminal `result`, honoring the 3 worker contracts. Auth guards (refuse-loud if `ANTHROPIC_API_KEY` set / OAuth token missing; never `--bare`; `settingSources:["user","project"]`), a concurrency semaphore, and 429/529 backoff. SDK dep imported **lazily** (bg nodes without it run fine).
- **Wiring:** `executor=sdk → sdkRunPhaseAgent` at **all four** dispatch entry points (scheduler, monitor→Triage, comment-wake, boot-resume) via a single shared resolution — closes the split-brain the plan review flagged.

## bg byte-identical (the critical invariant — clean)
The adversarial **bg-byte-identical lens found zero issues.** Proof: `phase-agent-dispatch.test.sh` **288 pass UNMODIFIED** (261 original + 27 new parity), `dispatch.test.mjs` **54 pass** with the `defaultRunPhaseAgent`/`defaultDispatch` arg-array `toEqual` assertions unchanged + green. With no `--launch-mode`, the new branch is unreachable and the `claude --bg` block is literally untouched. Full suite: no new failures (the 27 are pre-existing env/host-identity + linearis-subprocess flakes, byte-identical files).

## ⚠️ Pre-Phase-2-canary checklist (review found; all SDK-path-only, gated off — fix before flipping a node to `sdk`)
- [ ] **Turn cap dropped** (med): `turnCap` not threaded → `query()` runs unbounded on turns; `turn-cap-exhausted` status can't fire. Default `maxTurns` from `spec.turnCap`.
- [ ] **Semaphore can exceed `max`** (med): decrement-then-wake race → 529 cap breach. Use slot-transfer.
- [ ] **Cap decoupled from admission/autotuner** (med): sized from env (default 3), not Layer-2 `orchestration.maxParallel`; + pre-launch claim runs *before* `sem.acquire()` → claimed-but-unlaunched limbo. Source the cap from the admission seam; acquire before the claim.
- [ ] **Telemetry env not carried** (med): `OTEL_*`/`CLAUDE_CODE_ENABLE_TELEMETRY` live in the `--settings` bridge, not `DISPATCH_ENV` → SDK workers run telemetry-disabled. Layer `spec.settings.env` into `buildSdkEnv`.
- [ ] **No daemon boot auth assertion** (med): only per-dispatch; add a startup check → graceful bg fallback + `catalyst doctor` check; confirm `emitEvent` reaches the unified log, not stderr.
- [ ] **Per-phase model dropped** (low): set `options.model = spec.model`.
- [ ] **Semaphore re-creation abandons waiters** (low): mutate `max` in place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)