### PR TITLE
feat(dev): inbox surfaces parked needs-human tickets from the cache [HOLD FOR REVIEW]

### DIFF
--- a/plugins/dev/scripts/orch-monitor/__tests__/board-parked-needs-human.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/board-parked-needs-human.test.ts
@@ -1,0 +1,181 @@
+// board-parked-needs-human.test.ts — surface PARKED needs-human tickets in the
+// inbox from filter-state.db (the worker-dir-scoping gap fix).
+//
+// The board's ticket set is built from LIVE worker dirs (liveTickets +
+// betweenPhases + recentDone + queued + orphan-PR synthetics). A needs-human /
+// needs-input ticket whose worker dir was torn down (the PARKED case) is in NONE
+// of those sets, so it never entered payload.tickets and never reached the inbox —
+// even though deriveAttention already supported the label (~14 parked needs-human
+// were invisible while the inbox showed ~1). These units lock in the cache-sourced
+// fix, modeled on board-orphan-pr.test.ts + home-inbox-attention.test.ts:
+//   • the PURE synthesizer emits one attention card per parked ticket, deduped
+//     against the existing worker-dir / queued / orphan card set;
+//   • classifyTicket / deriveInbox bucket that card into the "Needs you" section;
+//   • the cache reader (readParkedNeedsHumanTickets) mirrors the broker's
+//     countNeedsHumanTickets predicate (terminal/removed excluded) and fails open.
+
+import { describe, it, expect } from "bun:test";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+import { classifyTicket, deriveInbox } from "../ui/src/board/home-inbox";
+import type { BoardPayload, BoardTicket } from "../ui/src/board/types";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const read = (rel: string) => readFileSync(join(HERE, "..", rel), "utf8");
+const boardDataSrc = read("lib/board-data.mjs");
+
+// Dynamic imports so the pure helpers run without the filesystem reads
+// assembleBoard triggers. Cast the modules to typed function shapes (same pattern
+// as board-orphan-pr.test.ts) to keep the no-unsafe-call lint rule happy.
+const boardMod = await import(join(HERE, "..", "lib", "board-data.mjs"));
+const synthesizeParkedNeedsHumanTickets = (boardMod as Record<string, unknown>)
+  .synthesizeParkedNeedsHumanTickets as (
+  parked: unknown,
+  existingIds: unknown,
+  now: number,
+) => BoardTicket[];
+
+const cacheMod = await import(join(HERE, "..", "lib", "linear-cache-reader.mjs"));
+const readParkedNeedsHumanTickets = (cacheMod as Record<string, unknown>)
+  .readParkedNeedsHumanTickets as (opts?: {
+  dbPath?: string;
+  descriptorReader?: (dbPath: string) => Promise<unknown[]>;
+}) => Promise<Array<Record<string, unknown>>>;
+
+// One parked descriptor as readParkedNeedsHumanTickets emits it (the synthesizer's input).
+const parked = (over: Record<string, unknown> = {}): Record<string, unknown> => ({
+  ticket: "CTL-700",
+  labels: ["needs-human"],
+  linearState: "Implement",
+  priority: 2,
+  updatedAt: new Date(120_000).toISOString(),
+  ...over,
+});
+
+function mkPayload(tickets: BoardTicket[]): BoardPayload {
+  return {
+    generatedAt: "2026-06-26T00:00:00Z",
+    config: { maxParallel: 0, inFlight: 0, freeSlots: 0, active: 0, working: 0, stuck: 0 },
+    repos: ["catalyst"],
+    workers: [],
+    tickets,
+    queue: [],
+  };
+}
+
+describe("synthesizeParkedNeedsHumanTickets — the pure card builder", () => {
+  it("(a) a parked needs-human ticket with NO worker-dir card becomes a needs-human attention card", () => {
+    const cards = synthesizeParkedNeedsHumanTickets([parked()], new Set<string>(), 600_000);
+    expect(cards).toHaveLength(1);
+    expect(cards[0].id).toBe("CTL-700");
+    expect(cards[0].attention).toBe("needs-human");
+    // attentionSince is anchored to the cache's updated_at (the "how long parked" stamp).
+    expect(cards[0].attentionSince).toBe(new Date(120_000).toISOString());
+    // classifyTicket buckets it into the inbox "Needs you" (attention) section.
+    expect(classifyTicket(cards[0])).toBe("attention");
+    // …and it shows up in the derived inbox attention section + needsYou count.
+    const model = deriveInbox(mkPayload(cards));
+    expect(model.counts.attention).toBe(1);
+    expect(model.counts.needsYou).toBe(1);
+    expect(model.sections.find((s) => s.kind === "attention")?.rows[0].id).toBe("CTL-700");
+  });
+
+  it("a needs-input (not needs-human) label also surfaces as a needs-human attention card", () => {
+    const cards = synthesizeParkedNeedsHumanTickets(
+      [parked({ ticket: "CTL-701", labels: ["needs-input"] })],
+      new Set<string>(),
+      600_000,
+    );
+    expect(cards).toHaveLength(1);
+    expect(cards[0].attention).toBe("needs-human");
+    expect(String(cards[0].humanQuestion)).toContain("needs-input");
+    expect(classifyTicket(cards[0])).toBe("attention");
+  });
+
+  it("(b) a parked ticket that already has a worker-dir card is NOT duplicated", () => {
+    // CTL-700 already carded by a live/between-phases worker dir → in existingIds.
+    const cards = synthesizeParkedNeedsHumanTickets([parked()], new Set(["CTL-700"]), 600_000);
+    expect(cards).toHaveLength(0);
+  });
+
+  it("dedupes a duplicate descriptor within the input (one card per id)", () => {
+    const cards = synthesizeParkedNeedsHumanTickets([parked(), parked()], new Set<string>(), 600_000);
+    expect(cards).toHaveLength(1);
+  });
+
+  it("derives team/repo from the ticket id and never collides with a real worker card", () => {
+    const cards = synthesizeParkedNeedsHumanTickets([parked()], new Set<string>(), 600_000);
+    expect(cards[0].team).toBe("CTL");
+    expect(cards[0].type).toBe("parked-needs-human");
+    // a parked card is never classified done (status not done, linearState not Done).
+    expect(classifyTicket(cards[0])).not.toBe("done");
+  });
+
+  it("empty / non-array input → no cards (never throws)", () => {
+    expect(synthesizeParkedNeedsHumanTickets([], new Set<string>(), 600_000)).toHaveLength(0);
+    expect(synthesizeParkedNeedsHumanTickets(null, new Set<string>(), 600_000)).toHaveLength(0);
+    // existingIds may arrive as a plain array, too.
+    expect(synthesizeParkedNeedsHumanTickets([parked()], ["CTL-700"], 600_000)).toHaveLength(0);
+  });
+});
+
+describe("readParkedNeedsHumanTickets — the cache reader (broker predicate parity)", () => {
+  // Stand in for getAllTicketDescriptors rows (rowToTicketDescriptor shape).
+  const descriptors = [
+    { ticket: "CTL-700", state: "Implement", labels: ["needs-human"], priority: 2, removed: false, updatedAt: "t1" },
+    { ticket: "CTL-701", state: "Triage", labels: ["needs-input"], priority: 1, removed: false, updatedAt: "t2" },
+    { ticket: "CTL-800", state: "Implement", labels: ["bug"], priority: 0, removed: false, updatedAt: "t3" }, // no label → excluded
+    { ticket: "CTL-900", state: "Done", labels: ["needs-human"], priority: 0, removed: false, updatedAt: "t4" }, // terminal → excluded
+    { ticket: "CTL-901", state: "Canceled", labels: ["needs-human"], priority: 0, removed: false, updatedAt: "t5" }, // terminal → excluded
+    { ticket: "CTL-902", state: "Implement", labels: ["needs-human"], priority: 0, removed: true, updatedAt: "t6" }, // removed → excluded
+  ];
+
+  it("returns only non-terminal, non-removed tickets carrying needs-human/needs-input", async () => {
+    const out = await readParkedNeedsHumanTickets({ descriptorReader: () => Promise.resolve(descriptors) });
+    expect(out.map((d) => d.ticket).sort()).toEqual(["CTL-700", "CTL-701"]);
+    const seven = out.find((d) => d.ticket === "CTL-700");
+    expect(seven?.linearState).toBe("Implement");
+    expect(seven?.updatedAt).toBe("t1");
+    expect(seven?.priority).toBe(2);
+  });
+
+  it("(c) terminal (Done/Canceled) and removed needs-human tickets are excluded", async () => {
+    const out = await readParkedNeedsHumanTickets({ descriptorReader: () => Promise.resolve(descriptors) });
+    const ids = new Set(out.map((d) => d.ticket));
+    expect(ids.has("CTL-900")).toBe(false); // Done
+    expect(ids.has("CTL-901")).toBe(false); // Canceled
+    expect(ids.has("CTL-902")).toBe(false); // removed
+  });
+
+  it("(d) a filter-state.db read failure degrades gracefully to [] (never throws)", async () => {
+    const out = await readParkedNeedsHumanTickets({
+      descriptorReader: () => Promise.reject(new Error("db locked")),
+    });
+    expect(out).toEqual([]);
+  });
+
+  it("a non-array descriptor result degrades to [] (defensive)", async () => {
+    const out = await readParkedNeedsHumanTickets({
+      descriptorReader: () => Promise.resolve(null as unknown as unknown[]),
+    });
+    expect(out).toEqual([]);
+  });
+});
+
+// Static wiring guard — ensures assembleBoard appends the parked cards, sourced
+// from the cache reader, deduped against the existing card-id set.
+describe("assembleBoard wiring — parked needs-human synthetic tickets", () => {
+  it("board-data.mjs exports synthesizeParkedNeedsHumanTickets", () => {
+    expect(boardDataSrc).toContain("export function synthesizeParkedNeedsHumanTickets");
+  });
+
+  it("board-data.mjs reads the parked set via readParkedNeedsHumanTickets (cache-sourced)", () => {
+    expect(boardDataSrc).toContain("readParkedNeedsHumanTickets");
+  });
+
+  it("assembleBoard dedupes against existing card ids and appends parkedTickets", () => {
+    expect(boardDataSrc).toContain("synthesizeParkedNeedsHumanTickets(parkedNeedsHuman, existingCardIds, now)");
+    expect(boardDataSrc).toContain("...parkedTickets");
+  });
+});

--- a/plugins/dev/scripts/orch-monitor/lib/board-data.mjs
+++ b/plugins/dev/scripts/orch-monitor/lib/board-data.mjs
@@ -22,7 +22,7 @@ import { readFile, readdir, stat } from "node:fs/promises";
 import { homedir } from "node:os";
 import { join, dirname, basename } from "node:path";
 import { promisify } from "node:util";
-import { readLinearCache } from "./linear-cache-reader.mjs";
+import { readLinearCache, readParkedNeedsHumanTickets } from "./linear-cache-reader.mjs";
 import { fillEstimateFallback, getEstimationMethodAsync } from "./linear-estimate-fallback.mjs";
 // CTL-1046: supplemental Linear-title fallback for cross-team (e.g. ADV) records.
 // CTL records carry their title via the eligible projection (eligible/CTL.json),
@@ -1273,6 +1273,63 @@ export function synthesizeOrphanTickets(orphanState, now) {
     });
 }
 
+// synthesizeParkedNeedsHumanTickets — pure helper: one attention card per PARKED
+// needs-human/needs-input ticket that has NO worker-dir / queued / orphan card.
+// The board's ticket set is built from LIVE worker dirs, so a needs-human ticket
+// whose worker dir was torn down is in none of those sets and never reached the
+// inbox — even though deriveAttention already supports the label. This mirrors
+// synthesizeOrphanTickets: it turns the cache-sourced parked descriptors
+// (readParkedNeedsHumanTickets — the broker's countNeedsHumanTickets predicate)
+// into BoardTicket cards that classifyTicket buckets into the inbox "Needs you"
+// (attention) section. `existingIds` is every id ALREADY carded (worker-dir
+// live/between/done + queued + orphan) so a ticket with a real card is NEVER
+// duplicated; a duplicate descriptor within the input is also deduped. Exported so
+// unit tests exercise it without the DB read; `now` is injected for the same reason.
+export function synthesizeParkedNeedsHumanTickets(parked, existingIds, now) {
+  if (!Array.isArray(parked)) return [];
+  const seen = existingIds instanceof Set ? new Set(existingIds) : new Set(existingIds ?? []);
+  const cards = [];
+  for (const p of parked) {
+    if (!p || !p.ticket) continue;
+    if (seen.has(p.ticket)) continue; // already carded (worker-dir / queued / orphan) — never double-count
+    seen.add(p.ticket);
+    const labels = Array.isArray(p.labels) ? p.labels : [];
+    // needs-input reads as "waiting on your input"; needs-human as a generic escalation.
+    const reason =
+      labels.includes(ATTENTION_LABEL_NEEDS_INPUT) && !labels.includes(ATTENTION_LABEL_NEEDS_HUMAN)
+        ? "Parked — waiting on your input (needs-input)."
+        : "Parked — escalated for a human (needs-human).";
+    cards.push({
+      id: p.ticket,
+      title: p.title || p.ticket,
+      type: "parked-needs-human",
+      repo: repoFor(p.ticket),
+      team: teamFor(p.ticket),
+      // No worker dir / phase signal — these are off-board parked tickets. phase
+      // "queued" + the cached Linear state keep the board column honest.
+      phase: "queued", status: "parked", model: null,
+      linearState: typeof p.linearState === "string" ? p.linearState : "",
+      workerStatus: null, activeState: null, working: false,
+      lastActiveMs: null, priority: typeof p.priority === "number" ? p.priority : 0,
+      estimate: null, scope: null, project: null,
+      held: heldFor(labels), heldSince: null, currentPhaseSince: null,
+      // surface as a Needs-You row, reusing the CTL-1158 inbox derivation.
+      attention: "needs-human",
+      // "how long has it needed you" anchor — the descriptor's last-updated stamp
+      // from the cache (honest null when the cache carried none).
+      attentionSince: p.updatedAt ?? null,
+      humanQuestion: reason,
+      explanation: null,
+      pr: null, prUrl: null, mergeStateStatus: null, prStuckReason: null,
+      costUSD: null, tokens: null, turns: null, phaseCosts: null, phaseSummary: [],
+      blockers: [],
+      updatedAt: p.updatedAt ?? new Date(now).toISOString(),
+      host: null, generation: null, failureReason: null,
+    });
+  }
+  return cards;
+}
+
 // ── Linear enrichment: priority / estimate / project / labels / relations /
 // assignee, read EXCLUSIVELY from the broker's durable caches (CTL-883).
 //
@@ -1527,9 +1584,9 @@ async function loadDispatchCooldowns(now) {
 // instead of full-reading the ~190MB log on every 3s recompute. Ring-less
 // callers (tests) pass nothing and keep the legacy readFileSync path.
 export async function assembleBoard({ getPrStatus = null, ring = null } = {}) {
-  const [agents, costs, phaseCostsByTicket, eligible, linfo, mp, catalystSessByUuid, cooldowns] = await Promise.all([
+  const [agents, costs, phaseCostsByTicket, eligible, linfo, mp, catalystSessByUuid, cooldowns, parkedNeedsHuman] = await Promise.all([
     liveAgents(), costByTicket(), costByPhase(), loadEligible(TEAM_REPO), linearInfo(), maxParallel(),
-    catalystSessionByCcUuid(), loadDispatchCooldowns(Date.now()),
+    catalystSessionByCcUuid(), loadDispatchCooldowns(Date.now()), readParkedNeedsHumanTickets(),
   ]);
   const eligibleIndex = Object.fromEntries(eligible.map((e) => [e.id, e]));
 
@@ -1946,6 +2003,18 @@ export async function assembleBoard({ getPrStatus = null, ring = null } = {}) {
   // deriveInbox surfaces them via the existing attention bucket (CTL-1158 reuse).
   const orphanTickets = synthesizeOrphanTickets(readOrphanPrState(), now);
   tickets = [...tickets, ...orphanTickets];
+
+  // Parked needs-human cards. A needs-human/needs-input ticket whose worker dir
+  // was torn down is in NONE of the worker-dir-sourced sets above (live /
+  // between-phases / recent-done / queued / orphan), so it never reached the inbox
+  // even though deriveAttention supports the label. Read the SAME cache the board
+  // enriches from (filter-state.db descriptors, via readParkedNeedsHumanTickets —
+  // the broker's countNeedsHumanTickets predicate) and append one attention card
+  // per parked ticket NOT already carded. Deduped against every existing card id;
+  // terminal/removed excluded by the reader; fail-open ([] on a db read error).
+  const existingCardIds = new Set(tickets.map((t) => t.id));
+  const parkedTickets = synthesizeParkedNeedsHumanTickets(parkedNeedsHuman, existingCardIds, now);
+  tickets = [...tickets, ...parkedTickets];
 
   // priority queue: eligible (not yet in-flight), globally ranked (Queue tab)
   const queue = await Promise.all(

--- a/plugins/dev/scripts/orch-monitor/lib/linear-cache-reader.mjs
+++ b/plugins/dev/scripts/orch-monitor/lib/linear-cache-reader.mjs
@@ -113,6 +113,74 @@ async function readTicketStateById(dbPath) {
   }
 }
 
+// ── parked needs-human tickets (off-board attention) ─────────────────────────
+// The board's ticket set is built from LIVE worker dirs (liveTickets +
+// betweenPhases + recentDone + queued + orphan-PR synthetics). A needs-human /
+// needs-input ticket whose worker dir was torn down (the PARKED case — most
+// parked tickets) is in NONE of those sets, so it never enters payload.tickets
+// and never reaches the inbox — even though deriveAttention already supports the
+// label. This reader is the cache source for that missing set: it mirrors
+// router.mjs::countNeedsHumanTickets EXACTLY — SAME accessor
+// (getAllTicketDescriptors → filter-state.db) and SAME predicate (non-removed,
+// non-terminal, carries a needs-human/needs-input label) — so the inbox surfaces
+// precisely the set the broker's pile-up signal counts.
+//
+// Labels + the Linear terminal set are mirrored LOCALLY (from
+// broker/alert-emit.mjs NEEDS_HUMAN_LABELS + execution-core/terminal-state.mjs)
+// so this cache reader pulls in nothing from the broker beyond the descriptor
+// accessor — keeping the vite config graph free of bun:sqlite (see the long note
+// in readTicketStateById).
+const NEEDS_HUMAN_LABELS = ["needs-human", "needs-input"];
+const TERMINAL_LINEAR_STATES = new Set(["Done", "Canceled"]);
+
+// readAllTicketDescriptors — the SAME bulk descriptor accessor readTicketStateById
+// uses, via the SAME computed-specifier lazy import (BROKER_STATE_MODULE — never a
+// string literal, see that note). Returns the full descriptor rows (incl.
+// updatedAt + removed) the parked filter below needs.
+async function readAllTicketDescriptors(dbPath) {
+  const { openBrokerStateDb, getAllTicketDescriptors } = await import(BROKER_STATE_MODULE);
+  openBrokerStateDb(dbPath);
+  return getAllTicketDescriptors();
+}
+
+// readParkedNeedsHumanTickets — the cache-sourced parked needs-human set. Returns
+// minimal descriptors { ticket, labels, linearState, priority, updatedAt } for
+// every non-removed, non-terminal ticket carrying a needs-human/needs-input label.
+// Fail-OPEN: any read error degrades to [] — the inbox keeps its current
+// worker-dir-sourced behavior and never throws out of the assemble (CTL-883
+// posture, consistent with countNeedsHumanTickets returning 0 on a db error).
+// `descriptorReader` is injectable so unit tests drive the predicate without a DB.
+export async function readParkedNeedsHumanTickets({
+  dbPath = DEFAULT_DB_PATH,
+  descriptorReader = readAllTicketDescriptors,
+} = {}) {
+  let descriptors;
+  try {
+    descriptors = await descriptorReader(dbPath);
+  } catch {
+    return []; // db locked/absent → no parked cards (degrade to current behavior)
+  }
+  if (!Array.isArray(descriptors)) return [];
+  const out = [];
+  for (const d of descriptors) {
+    if (!d || !d.ticket) continue;
+    if (d.removed) continue; // tombstoned (getAllTicketDescriptors excludes these by default)
+    if (d.state && TERMINAL_LINEAR_STATES.has(d.state)) continue; // Done/Canceled
+    const labels = Array.isArray(d.labels) ? d.labels.filter(Boolean) : [];
+    if (!labels.some((l) => NEEDS_HUMAN_LABELS.includes(l))) continue;
+    out.push({
+      ticket: d.ticket,
+      labels,
+      linearState: typeof d.state === "string" ? d.state : null,
+      priority: normPriority(d.priority),
+      // The freshest cache stamp on the descriptor — the honest "how long parked"
+      // anchor for the inbox attention row. null when the row carried none.
+      updatedAt: typeof d.updatedAt === "string" ? d.updatedAt : null,
+    });
+  }
+  return out;
+}
+
 // Read the scheduler's eligible projections for priority/project/relations on
 // tickets that may not have a ticket_state row yet (queued, not-yet-worked).
 async function readEligibleById(eligibleDir) {


### PR DESCRIPTION
## The gap (live-verified)

The orch-monitor home **Inbox "Needs you"** was sourced entirely from **live worker dirs**. `assembleBoard` (`lib/board-data.mjs`) builds `payload.tickets` from `liveTickets` + `betweenPhases` (cap 30) + `recentDone` (cap 12) + `queued` (eligible) + orphan-PR synthetics.

A `needs-human` / `needs-input` ticket whose **worker dir was torn down** (the *parked* case — most parked tickets) is in **none** of those sets, so it never enters `payload.tickets` and never reaches the inbox — even though `deriveAttention` already supports the label (`ATTENTION_LABEL_NEEDS_HUMAN`). On the live fleet the broker's `filter-state.db` carried **~14** non-terminal `needs-human` tickets across teams while the inbox surfaced only **~1**.

The broker already counts this exact set: `router.mjs::countNeedsHumanTickets()` reads `getAllTicketDescriptors()` from `filter-state.db` and counts non-terminal `needs-human`/`needs-input` tickets. The inbox was simply not reading from it.

## The fix (cache-sourced synthesizer, mirrors the orphan-PR path)

- **`readParkedNeedsHumanTickets()`** (`lib/linear-cache-reader.mjs`) reads the **SAME** descriptor accessor the board already enriches from — `getAllTicketDescriptors()` → `filter-state.db`, via the same computed-specifier lazy import that keeps `bun:sqlite` out of the Vite config graph — and applies the broker's `countNeedsHumanTickets` predicate **exactly**: non-removed, non-terminal (`Done`/`Canceled` excluded), carries a `needs-human`/`needs-input` label.
- **`synthesizeParkedNeedsHumanTickets()`** (`lib/board-data.mjs`, pure + exported, mirrors `synthesizeOrphanTickets`) turns each parked descriptor into an attention card: `type:"parked-needs-human"`, `attention:"needs-human"`, `humanQuestion` derived from the label, `attentionSince` anchored to the descriptor's `updated_at`. `classifyTicket` buckets it into the inbox **"Needs you"** (attention) section, and the cached Linear state keeps its board column honest.
- `assembleBoard` reads the parked set in its top `Promise.all` and appends the cards after the orphan cards.

## Guarantees

- **No double-counting** — deduped by id against **every** existing card (`existingCardIds` = worker-dir live/between/done + queued + orphan); a ticket with a real card is skipped. Duplicate descriptors within the input are also deduped.
- **Terminal/removed excluded** — the reader drops `removed` rows and `Done`/`Canceled` states, mirroring the broker predicate (so a stale `needs-human` label on a finished ticket can't surface).
- **Fail-open** — a `filter-state.db` read error degrades to `[]`; the inbox keeps its current worker-dir-sourced behavior and never throws out of the assemble.
- **Calm by construction** — cards are the real needs-human set (not a flood); each genuinely needs a human.

## Tests

New `__tests__/board-parked-needs-human.test.ts` (modeled on `board-orphan-pr` / `home-inbox-attention`) proves: (a) a `needs-human` ticket in `filter-state.db` with **no** worker dir now appears in the inbox attention set (via `deriveInbox`); (b) a ticket that already has a worker-dir card is **not** duplicated; (c) terminal (`Done`/`Canceled`) and removed `needs-human` tickets are excluded; (d) a `filter-state.db` read failure degrades gracefully to `[]`.

## Validation

`plugins/dev/scripts/orch-monitor` (the CI quality gate, both parent + `ui/`): `tsc --noEmit` ✅, `eslint .` ✅ (0 errors), `knip:ci` ✅, `bun test` ✅ (6030 pass / 1 skip / 0 fail in a clean env — the one dev-machine-only failure was a pre-existing fleet-data-dependent `nav-signal-endpoints` test that also fails on `main` and is green in a clean `$HOME`), and `vite build` ✅.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DPp7MzGbQqyvHtEcQAAPBK