### PR TITLE
fix(dev): dedupe nav projects + repo icon auto-detect [HOLD FOR REVIEW]

### DIFF
--- a/plugins/dev/scripts/orch-monitor/__tests__/repo-icon-fetcher.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/repo-icon-fetcher.test.ts
@@ -112,6 +112,67 @@ describe("pickBestCandidate", () => {
   });
 });
 
+// ── owner-avatar fallback (CTL-1380, Bug B) ───────────────────────────────────
+
+import {
+  OWNER_AVATAR_PATH,
+  buildAvatarIconResult,
+  resolveOwnerAvatar,
+} from "../lib/repo-icon-fetcher";
+
+describe("OWNER_AVATAR_PATH (CTL-1380)", () => {
+  it("is a sentinel that never collides with a real probed icon path", () => {
+    expect(OWNER_AVATAR_PATH).toBe("owner-avatar");
+    expect(ICON_PATH_PRIORITY).not.toContain(OWNER_AVATAR_PATH);
+  });
+});
+
+describe("buildAvatarIconResult (CTL-1380, Bug B)", () => {
+  it("builds a found:true single-candidate result keyed on the avatar sentinel", () => {
+    const res = buildAvatarIconResult(
+      "https://avatars.githubusercontent.com/u/123?v=4",
+      "data:image/png;base64,AAAA",
+    );
+    expect(res.found).toBe(true);
+    if (!res.found) throw new Error("unreachable");
+    expect(res.candidates).toHaveLength(1);
+    expect(res.candidates[0].path).toBe(OWNER_AVATAR_PATH);
+    expect(res.candidates[0].format).toBe("png");
+    expect(res.candidates[0].dataUrl).toBe("data:image/png;base64,AAAA");
+    // selectedPath + legacy mirror fields all point at the avatar
+    expect(res.selectedPath).toBe(OWNER_AVATAR_PATH);
+    expect(res.path).toBe(OWNER_AVATAR_PATH);
+    expect(res.downloadUrl).toBe("https://avatars.githubusercontent.com/u/123?v=4");
+    expect(res.dataUrl).toBe("data:image/png;base64,AAAA");
+  });
+
+  it("fails open to found:false when the avatar URL is missing", () => {
+    expect(buildAvatarIconResult(null, "data:image/png;base64,AAAA")).toEqual({ found: false });
+  });
+
+  it("fails open to found:false when the avatar data URL could not be fetched", () => {
+    expect(buildAvatarIconResult("https://avatars.githubusercontent.com/u/1", null)).toEqual({
+      found: false,
+    });
+  });
+
+  it("the avatar candidate is renderable by pickBestCandidate (path absent from priority list)", () => {
+    const res = buildAvatarIconResult("https://x/avatar", "data:image/png;base64,AAAA");
+    if (!res.found) throw new Error("unreachable");
+    expect(pickBestCandidate(res.candidates)?.path).toBe(OWNER_AVATAR_PATH);
+  });
+});
+
+describe("resolveOwnerAvatar (CTL-1380) — owner extraction guards", () => {
+  it("returns null for an empty slug without shelling out", () => {
+    expect(resolveOwnerAvatar("")).toBeNull();
+  });
+
+  it("returns null when the owner segment is empty ('/repo')", () => {
+    expect(resolveOwnerAvatar("/repo")).toBeNull();
+  });
+});
+
 // ── buildRepoOwnerMap ─────────────────────────────────────────────────────────
 
 describe("buildRepoOwnerMap", () => {

--- a/plugins/dev/scripts/orch-monitor/lib/project-roster.ts
+++ b/plugins/dev/scripts/orch-monitor/lib/project-roster.ts
@@ -14,6 +14,15 @@
 //      repo short-name UPPERCASED, vcsRepo/defaultColor/repoRoot null, hasWork=true).
 //      Never dropped, never collapsed to an "other" bucket.
 //
+// CTL-1380 (Bug A): before the union, observed-work repo identifiers are NORMALIZED
+// into the configured short-name key space via buildObservedRepoAliases /
+// normalizeObservedRepo. BoardPayload.repos arrives as lowercased team keys ("ctl",
+// "adv") and/or full owner/repos ("coalesce-labs/catalyst") — none of which equal a
+// configured short-name ("catalyst", "adva") — so without normalization the union
+// never collapsed them and the nav showed a duplicate "unconfigured" lane per
+// configured team. Normalization folds each alias onto the team's short-name so
+// observed work flips the configured descriptor's hasWork instead.
+//
 // Identity authority is config teams[]; registry.json (CATALYST_DIR-relative)
 // contributes repoRoot ONLY, joined by team key — its team identity can DIVERGE
 // from config (e.g. ADV registry repoRoot=groundworkapp/Adva vs config vcsRepo=
@@ -105,6 +114,75 @@ function shortName(vcsRepo: string): string {
 }
 
 /**
+ * CTL-1380 (Bug A): build the alias → configured-short-name lookup that normalizes
+ * observed-work repo identifiers (BoardPayload.repos) into the SAME key space the
+ * configured team descriptors use (the vcsRepo short-name).
+ *
+ * WHY this is needed: BoardPayload.repos does NOT carry configured short-names.
+ * board-data.mjs's repoFor() derives a ticket's repo from its team-key prefix, and
+ * in the daemon-spawned monitor (cwd has no .catalyst/config.json) board-data's own
+ * team→short map loads empty, so repoFor() falls back to the LOWERCASED TEAM KEY
+ * ("ctl", "adv", "otl", "sli"); some tickets also carry an explicit FULL owner/repo
+ * ("coalesce-labs/catalyst"). None of those equal a configured short-name
+ * ("catalyst", "adva", …), so the UNION rule below never collapsed them → duplicate
+ * source:"unconfigured" lanes for teams that ARE configured (the 10-entry nav bug).
+ *
+ * This map folds every known alias of a configured team — its short-name (identity),
+ * its team key, its full owner/repo, and (via registry, joined by team key) its
+ * repoRoot basename — onto that team's short-name, so observed work merges into the
+ * configured descriptor instead of spawning a duplicate.
+ */
+export function buildObservedRepoAliases(
+  teams: TeamEntry[],
+  registry: RegistryEntry[],
+): Map<string, string> {
+  const aliases = new Map<string, string>();
+  const shortByTeamKey = new Map<string, string>();
+  for (const t of teams ?? []) {
+    if (!t || typeof t.key !== "string" || typeof t.vcsRepo !== "string") continue;
+    if (!t.vcsRepo.includes("/")) continue;
+    const short = shortName(t.vcsRepo);
+    shortByTeamKey.set(t.key.toUpperCase(), short);
+    aliases.set(short, short); // short-name → itself (identity)
+    aliases.set(t.key.toLowerCase(), short); // lowercased team key (repoFor fallback)
+    aliases.set(t.vcsRepo.toLowerCase(), short); // full owner/repo (e.g. e.repo passthrough)
+  }
+  // registry repoRoot basename → the team's short-name, joined by team key. Enriches
+  // the alias set so a ticket whose repo was derived from a registry repoRoot path
+  // also folds onto the configured descriptor.
+  for (const r of registry ?? []) {
+    if (!r || typeof r.team !== "string" || typeof r.repoRoot !== "string") continue;
+    const short = shortByTeamKey.get(r.team.toUpperCase());
+    if (!short) continue;
+    const base = basename(r.repoRoot).toLowerCase();
+    if (base) aliases.set(base, short);
+  }
+  return aliases;
+}
+
+/**
+ * Normalize ONE observed-work repo identifier into the configured short-name key
+ * space. An exact alias hit wins; a FULL owner/repo ("owner/name") with no exact
+ * alias collapses to its basename (so it matches a configured team keyed by
+ * basename AND, for a genuinely-unconfigured repo, yields a "/"-free key the
+ * repo-icon endpoint accepts); everything else passes through lowercased so a
+ * genuinely-unconfigured short name still appears once.
+ */
+export function normalizeObservedRepo(
+  raw: string,
+  aliases: Map<string, string>,
+): string {
+  const r = String(raw).trim().toLowerCase();
+  const hit = aliases.get(r);
+  if (hit) return hit;
+  if (r.includes("/")) {
+    const base = basename(r);
+    return aliases.get(base) ?? base;
+  }
+  return r;
+}
+
+/**
  * PURE builder. Iterates configured teams (deriving repo, joining repoColors by
  * owner/repo and registry by team key, computing hasWork), then appends an
  * unconfigured descriptor for every observed repo no team already covers.
@@ -118,7 +196,14 @@ export function buildProjects(
   registry: RegistryEntry[],
   observedRepos: string[],
 ): ProjectDescriptor[] {
-  const observed = new Set((observedRepos ?? []).map((r) => String(r)));
+  // CTL-1380 (Bug A): normalize observed-work repo identifiers into the configured
+  // short-name key space BEFORE the union, so observed work (which arrives as team
+  // keys / full owner-repos) merges into the configured descriptor instead of
+  // spawning a duplicate source:"unconfigured" lane.
+  const aliases = buildObservedRepoAliases(teams ?? [], registry ?? []);
+  const observed = new Set(
+    (observedRepos ?? []).map((r) => normalizeObservedRepo(String(r), aliases)),
+  );
   const repoRootByTeam = new Map<string, string>();
   for (const r of registry ?? []) {
     if (r && typeof r.team === "string" && typeof r.repoRoot === "string") {

--- a/plugins/dev/scripts/orch-monitor/lib/repo-icon-fetcher.ts
+++ b/plugins/dev/scripts/orch-monitor/lib/repo-icon-fetcher.ts
@@ -25,8 +25,13 @@
 //  22. apps/website/public/favicon.png
 //
 // All matching paths are collected; the best by format (SVG > PNG > ICO) is the default.
+//
+// CTL-1380 (Bug B): when NO favicon is found at any probed path, fall back to the
+// GitHub owner/org AVATAR (resolveOwnerAvatar, via the public /users/<owner> endpoint)
+// so a configured team still shows a real image instead of a blank circle — this also
+// covers PRIVATE repos (the avatar is public even when the repo contents are not).
 // Cache: JSON files in cacheDir (default ~/catalyst/repo-icon-cache/), keyed by
-//   owner-repo slug, TTL 7 days (schema v2 — v1 entries re-probe once). A negative
+//   owner-repo slug, TTL 7 days (schema v3 — older-schema entries re-probe once). A negative
 //   result ("no icon found") is also cached (with a 1-day TTL) so we don't hammer
 //   the GitHub API on every boot.
 //
@@ -106,7 +111,11 @@ export type IconResult =
     }
   | { found: false };
 
-const CACHE_SCHEMA_VERSION = 2; // v2 carries candidates[] (CTL-997)
+const CACHE_SCHEMA_VERSION = 3; // v3 adds the owner-avatar fallback (CTL-1380); v1/v2 entries re-probe once
+
+/** Sentinel `path` for the owner-avatar fallback candidate (CTL-1380, Bug B). Not a
+ *  real in-repo file path, so it never collides with ICON_PATH_PRIORITY entries. */
+export const OWNER_AVATAR_PATH = "owner-avatar";
 
 interface CacheEntry {
   schemaVersion: number;
@@ -170,6 +179,32 @@ export function probeRepoPath(ownerRepo: string, path: string): string | null {
 }
 
 /**
+ * Resolve the GitHub OWNER avatar URL for an `owner/repo` slug (CTL-1380, Bug B).
+ *
+ * Last-resort fallback used by fetchRepoIcon when a repo exposes NO favicon at any
+ * probed path — so a configured team still shows a real image instead of a blank
+ * circle. Queries the public `/users/<owner>` endpoint (NOT `/repos/<owner>/<repo>`),
+ * so it resolves even for PRIVATE repos the token cannot read: the org/user avatar is
+ * public. Returns the avatar URL, or null on any failure (no gh binary, offline,
+ * unknown owner) — the caller then fail-opens to the lucide fallback.
+ */
+export function resolveOwnerAvatar(ownerRepo: string): string | null {
+  const owner = ownerRepo.split("/")[0]?.trim();
+  if (!owner) return null;
+  try {
+    const out = execSync(`gh api "/users/${owner}" --jq ".avatar_url" 2>/dev/null`, {
+      encoding: "utf8",
+      timeout: 8000,
+      stdio: ["pipe", "pipe", "pipe"],
+    }).trim();
+    if (!out || out === "null") return null;
+    return out;
+  } catch {
+    return null;
+  }
+}
+
+/**
  * Fetch a URL and convert it to a data URL (base64-encoded) so the browser
  * can render it without cross-origin issues.
  * Returns null on any fetch/encoding failure.
@@ -185,6 +220,33 @@ export async function fetchAsDataUrl(url: string): Promise<string | null> {
   } catch {
     return null;
   }
+}
+
+/**
+ * Build the owner-avatar fallback IconResult (CTL-1380, Bug B). PURE (no I/O) so the
+ * candidate/result shape is unit-testable offline. Returns `{ found: false }` when
+ * either the avatar URL or its fetched data URL is unavailable — the caller then
+ * fail-opens to the lucide fallback.
+ */
+export function buildAvatarIconResult(
+  avatarUrl: string | null,
+  avatarDataUrl: string | null,
+): IconResult {
+  if (!avatarUrl || !avatarDataUrl) return { found: false };
+  const avatar: IconCandidate = {
+    path: OWNER_AVATAR_PATH,
+    format: "png",
+    downloadUrl: avatarUrl,
+    dataUrl: avatarDataUrl,
+  };
+  return {
+    found: true,
+    candidates: [avatar],
+    selectedPath: OWNER_AVATAR_PATH,
+    path: OWNER_AVATAR_PATH,
+    downloadUrl: avatarUrl,
+    dataUrl: avatarDataUrl,
+  };
 }
 
 /**
@@ -228,7 +290,14 @@ export async function fetchRepoIcon(
   try {
     const hits = resolveRepoIconCandidates(ownerRepo);
     if (hits.length === 0) {
-      result = { found: false };
+      // CTL-1380 (Bug B): no favicon at any probed path → fall back to the GitHub
+      // owner/org avatar so the project still renders a real image instead of a blank
+      // circle. Covers favicon-less repos AND private repos (the avatar is public).
+      // If the avatar can't be resolved/fetched (offline, no gh, unknown owner) we
+      // still fail-open to { found: false } → the UI lucide fallback.
+      const avatarUrl = resolveOwnerAvatar(ownerRepo);
+      const avatarDataUrl = avatarUrl ? await fetchAsDataUrl(avatarUrl) : null;
+      result = buildAvatarIconResult(avatarUrl, avatarDataUrl);
     } else {
       const candidates: IconCandidate[] = await Promise.all(
         hits.map(async (h) => ({

--- a/plugins/dev/scripts/orch-monitor/project-roster.test.ts
+++ b/plugins/dev/scripts/orch-monitor/project-roster.test.ts
@@ -20,7 +20,14 @@ import { describe, it, expect } from "bun:test";
 import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { buildProjects, loadProjects, readProjectsOverlay, applyProjectsOverlay } from "./lib/project-roster";
+import {
+  buildProjects,
+  loadProjects,
+  readProjectsOverlay,
+  applyProjectsOverlay,
+  buildObservedRepoAliases,
+  normalizeObservedRepo,
+} from "./lib/project-roster";
 
 const TEAMS = [
   { key: "CTL", vcsRepo: "coalesce-labs/catalyst" },
@@ -103,6 +110,119 @@ describe("buildProjects (CTL-1152) — UNION rule for unconfigured observed work
   it("does NOT duplicate a configured team's repo even when it is observed", () => {
     const out = buildProjects(TEAMS, {}, [], ["catalyst"]);
     expect(out.filter((p) => p.repo === "catalyst")).toHaveLength(1);
+  });
+});
+
+// ─── CTL-1380 (Bug A): observed-repo normalization / dedupe ───────────────────
+//
+// Regression coverage for the 10-entry nav bug: GET /api/projects returned the 5
+// configured teams PLUS 5 source:"unconfigured" DUPLICATES, because the observed-
+// work repo identifiers (BoardPayload.repos) arrive as lowercased TEAM KEYS ("ctl",
+// "adv", "otl", "sli") and one FULL owner/repo ("coalesce-labs/catalyst") — none of
+// which equal the configured short-names ("catalyst", "adva", …) — so the union rule
+// never collapsed them. buildProjects now normalizes observed repos into the
+// configured short-name key space before the union.
+
+const FIVE_TEAM_LIST = [
+  { key: "CTL", vcsRepo: "coalesce-labs/catalyst" },
+  { key: "ADV", vcsRepo: "rightsite-cloud/Adva" },
+  { key: "OTL", vcsRepo: "coalesce-labs/catalyst-otel" },
+  { key: "SLI", vcsRepo: "ryanrozich/slides" },
+  { key: "EVR", vcsRepo: "coalesce-labs/evergreen" },
+];
+
+describe("buildObservedRepoAliases (CTL-1380)", () => {
+  it("folds short-name, team key, and full owner/repo onto the team short-name", () => {
+    const a = buildObservedRepoAliases(TEAMS, []);
+    expect(a.get("catalyst")).toBe("catalyst"); // identity
+    expect(a.get("ctl")).toBe("catalyst"); // lowercased team key
+    expect(a.get("coalesce-labs/catalyst")).toBe("catalyst"); // full owner/repo
+    expect(a.get("adv")).toBe("adva");
+    expect(a.get("catalyst-otel")).toBe("catalyst-otel");
+    expect(a.get("otl")).toBe("catalyst-otel");
+  });
+
+  it("folds a registry repoRoot basename onto the team short-name (joined by team key)", () => {
+    const a = buildObservedRepoAliases(
+      [{ key: "ADV", vcsRepo: "rightsite-cloud/Adva" }],
+      [{ team: "ADV", repoRoot: "/Users/x/code-repos/github/groundworkapp/Adva" }],
+    );
+    expect(a.get("adva")).toBe("adva"); // basename("…/Adva") lowercased == the short-name
+  });
+});
+
+describe("normalizeObservedRepo (CTL-1380)", () => {
+  const aliases = buildObservedRepoAliases(TEAMS, []);
+  it("maps a lowercased team key to the configured short-name", () => {
+    expect(normalizeObservedRepo("ctl", aliases)).toBe("catalyst");
+    expect(normalizeObservedRepo("adv", aliases)).toBe("adva");
+  });
+  it("maps a full owner/repo to the configured short-name", () => {
+    expect(normalizeObservedRepo("coalesce-labs/catalyst", aliases)).toBe("catalyst");
+  });
+  it("passes through an already-correct short-name", () => {
+    expect(normalizeObservedRepo("catalyst", aliases)).toBe("catalyst");
+  });
+  it("collapses a genuinely-unconfigured full owner/repo to its basename (a '/'-free key)", () => {
+    expect(normalizeObservedRepo("some-org/mystery", aliases)).toBe("mystery");
+  });
+  it("passes through a genuinely-unconfigured short name unchanged (lowercased)", () => {
+    expect(normalizeObservedRepo("Mystery", aliases)).toBe("mystery");
+  });
+});
+
+describe("buildProjects (CTL-1380) — observed work merges into the configured descriptor", () => {
+  it("an observed lowercased TEAM KEY flips the configured team's hasWork — no duplicate lane", () => {
+    const out = buildProjects(TEAMS, {}, [], ["ctl"]);
+    const ctl = out.find((p) => p.key === "CTL")!;
+    expect(ctl.hasWork).toBe(true);
+    expect(ctl.source).toBe("config");
+    // exactly one descriptor for the catalyst repo, and zero unconfigured lanes
+    expect(out.filter((p) => p.repo === "catalyst")).toHaveLength(1);
+    expect(out.some((p) => p.source === "unconfigured")).toBe(false);
+  });
+
+  it("an observed FULL owner/repo merges into the configured descriptor — no duplicate lane", () => {
+    const out = buildProjects(TEAMS, {}, [], ["coalesce-labs/catalyst"]);
+    expect(out.find((p) => p.key === "CTL")!.hasWork).toBe(true);
+    expect(out.some((p) => p.source === "unconfigured")).toBe(false);
+    expect(out.some((p) => p.repo === "coalesce-labs/catalyst")).toBe(false);
+  });
+
+  it("the real-world 5-dupe scenario yields EXACTLY the 5 configured teams, no unconfigured dupes", () => {
+    // The exact observed-repo set the live /api/projects produced pre-fix.
+    const observed = ["adv", "coalesce-labs/catalyst", "ctl", "otl", "sli"];
+    const out = buildProjects(FIVE_TEAM_LIST, {}, [], observed);
+    expect(out).toHaveLength(5);
+    expect(out.every((p) => p.source === "config")).toBe(true);
+    expect(out.map((p) => p.key).sort()).toEqual(["ADV", "CTL", "EVR", "OTL", "SLI"]);
+    // the 4 teams with observed work flip hasWork; evergreen (no work) stays false
+    expect(out.find((p) => p.key === "CTL")!.hasWork).toBe(true);
+    expect(out.find((p) => p.key === "ADV")!.hasWork).toBe(true);
+    expect(out.find((p) => p.key === "OTL")!.hasWork).toBe(true);
+    expect(out.find((p) => p.key === "SLI")!.hasWork).toBe(true);
+    expect(out.find((p) => p.key === "EVR")!.hasWork).toBe(false);
+    // every descriptor keeps a clean, "/"-free icon key
+    expect(out.every((p) => !p.iconUrl.slice("/api/repo-icon/".length).includes("/"))).toBe(true);
+  });
+
+  it("does NOT regress a genuinely-unconfigured observed repo — it still appears once", () => {
+    const out = buildProjects(TEAMS, {}, [], ["ctl", "mystery"]);
+    // configured CTL got the work...
+    expect(out.find((p) => p.key === "CTL")!.hasWork).toBe(true);
+    // ...and the truly-unknown repo still surfaces as its own single unconfigured lane
+    const mystery = out.filter((p) => p.repo === "mystery");
+    expect(mystery).toHaveLength(1);
+    expect(mystery[0].source).toBe("unconfigured");
+    expect(mystery[0].hasWork).toBe(true);
+  });
+
+  it("a genuinely-unconfigured FULL owner/repo surfaces once under its basename key", () => {
+    const out = buildProjects(TEAMS, {}, [], ["some-org/mystery"]);
+    const lanes = out.filter((p) => p.source === "unconfigured");
+    expect(lanes).toHaveLength(1);
+    expect(lanes[0].repo).toBe("mystery");
+    expect(lanes[0].iconUrl).toBe("/api/repo-icon/mystery"); // no slash → endpoint-safe
   });
 });
 


### PR DESCRIPTION
## Summary

orch-monitor's nav showed **10 project entries instead of 5**, and every project's "Auto (best detected)" icon rendered as a **blank circle**. Two related bugs in the project roster / repo-icon resolution.

**Before** (live `GET /api/projects`): 5 configured teams (`source:"config"`, all `hasWork:false`) **+ 5 `source:"unconfigured"` duplicates** (`CTL`/`ctl`, `ADV`/`adv`, `OTL`/`otl`, `SLI`/`sli`, `COALESCE-LABS/CATALYST`/`coalesce-labs/catalyst`, all `hasWork:true`) → 10 nav entries, blank icons.

**After**: exactly the 5 configured teams (`source:"config"`), `hasWork` reflecting real observed work, **no unconfigured duplicates**, icons resolve to real images.

## Bug A — DEDUPE (observed-repo key normalization)

`buildProjects()` (`lib/project-roster.ts`) unions configured teams with observed-work repos (`BoardPayload.repos`) keyed by **short repo name** (`descriptor.repo`, e.g. `catalyst`, `adva`). But the observed identifiers don't arrive in that key space:

- `board-data.mjs`'s `repoFor()` derives a ticket's repo from its **team-key prefix**. In the daemon-spawned monitor (cwd = `…/execution-core`, no `.catalyst/config.json`) board-data's own team→short map loads empty, so `repoFor()` falls back to the **lowercased team key** (`"ctl"`, `"adv"`, `"otl"`, `"sli"`).
- Some tickets carry an explicit **full owner/repo** (`"coalesce-labs/catalyst"`) via `e.repo`.

None of those equal a configured short-name, so the union **never collapsed them** → a duplicate `source:"unconfigured"` lane per configured team.

**Fix:** normalize observed-repo identifiers into the configured short-name key space **before** the union — new pure helpers `buildObservedRepoAliases()` + `normalizeObservedRepo()`, built from `teams[]` / `registry`. Each team's **short-name (identity)**, **team key**, **full owner/repo**, and **registry repoRoot basename** all fold onto that team's short-name. Observed work now flips the **configured** descriptor's `hasWork`; the 5 dupes disappear. A genuinely-unconfigured observed repo (matching no team) still appears **once** — and a full `owner/repo` form collapses to its `/`-free basename so the repo-icon endpoint accepts the key.

## Bug B — REPO ICON AUTO-DETECT

**Root cause is mostly Bug A.** The descriptor's `iconUrl` is `/api/repo-icon/<descriptor.repo>` and the nav/icon hook keys off it. The configured descriptors already resolved real images — live `/api/repo-icon/catalyst` → **200** (30 KB), `/api/repo-icon/adva` → **200**, `/api/repo-icon/slides` → **200** — but they had `hasWork:false`, while the **unconfigured dupes** (`/api/repo-icon/ctl`, `/api/repo-icon/adv`) had no owner mapping → **204** blank, and the nav rendered those. Fixing Bug A makes the nav key off the working configured descriptors.

**Residual defect + fix:** a configured team whose repo exposes **no favicon at any probed path** (or a private repo, or a stale negative cache) still went blank — e.g. `catalyst-otel`, `evergreen` were live **204** despite having `favicon.ico` on the remote. Added an **owner-avatar fallback** in `lib/repo-icon-fetcher.ts`: when no favicon is found, resolve the GitHub owner/org avatar via the **public `/users/<owner>` endpoint** (resolves even for **private** repos — the avatar is public, no repo-read needed) and return it as the icon candidate. Bumped the icon cache schema `v2 → v3` so stale negative entries re-probe once on deploy.

**Documented limitation:** the favicon probe and avatar lookup depend on `gh` + network. If `gh` is unauthenticated/offline or the owner avatar can't be fetched, it still fail-opens to the existing lucide fallback (no regression).

## Validation

- `bun run typecheck` (tsc --noEmit) — clean
- `bun run lint` — 0 errors (only pre-existing non-null-assertion warnings in tests)
- `bun run knip:ci` — clean
- `bun run build:ui` (vite monitor build) — passes
- `bun test` — full suite green except two **pre-existing, unrelated** failures verified on pristine `main` (a `/api/nav` empty-fleet anomaly assertion; a `POST /api/summarize` network flake)
- New tests: project-roster dedupe (team-key + full-owner-repo merge into the configured team; the exact 5-dupe scenario → exactly 5 `source:"config"`; genuine-unconfigured still appears once); repo-icon avatar fallback (pure `buildAvatarIconResult` shape + `resolveOwnerAvatar` owner-extraction guards)

## Files changed

- `lib/project-roster.ts` — `buildObservedRepoAliases` + `normalizeObservedRepo`; normalize observed repos before the union
- `lib/repo-icon-fetcher.ts` — `resolveOwnerAvatar` + `buildAvatarIconResult` owner-avatar fallback; cache schema v3
- `project-roster.test.ts`, `__tests__/repo-icon-fetcher.test.ts` — new tests

**HOLD FOR REVIEW** — auto-merge intentionally not armed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DPp7MzGbQqyvHtEcQAAPBK