### PR TITLE
fix(dev): repo-icon empty-favicon → avatar fallback (no blank icons) [HOLD FOR REVIEW]

### DIFF
--- a/plugins/dev/scripts/orch-monitor/__tests__/repo-icon-fetcher.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/repo-icon-fetcher.test.ts
@@ -1,7 +1,7 @@
 // repo-icon-fetcher.test.ts — unit tests for CTL-961 repo icon path resolver,
 // cache helpers, and repoOwners config parsing.
 import { describe, it, expect, beforeEach, afterEach } from "bun:test";
-import { mkdirSync, writeFileSync, rmSync } from "fs";
+import { mkdirSync, writeFileSync, readFileSync, rmSync } from "fs";
 import { join } from "path";
 import { tmpdir } from "os";
 import {
@@ -84,9 +84,10 @@ describe("inferIconFormat", () => {
 });
 
 describe("pickBestCandidate", () => {
-  const mk = (path: string): IconCandidate => ({
+  // Renderable by default: a non-empty base64 payload after the `,` separator.
+  const mk = (path: string, dataUrl: string | null = "data:image/png;base64,AAAA"): IconCandidate => ({
     path, format: inferIconFormat(path),
-    downloadUrl: `https://x/${path}`, dataUrl: null,
+    downloadUrl: `https://x/${path}`, dataUrl,
   });
 
   it("prefers svg over png over ico regardless of probe order", () => {
@@ -109,6 +110,46 @@ describe("pickBestCandidate", () => {
     const result = pickBestCandidate(cands);
     expect(result).not.toBeNull();
     expect(["unknown-a.svg", "unknown-b.svg"]).toContain(result?.path ?? "");
+  });
+
+  // ── renderability filtering (empty-favicon bug) ─────────────────────────────
+  it("never selects a candidate with a null dataUrl", () => {
+    // The crispest format (svg) is NOT renderable → the renderable png wins instead.
+    const cands = [mk("logo.svg", null), mk("favicon.png")];
+    expect(pickBestCandidate(cands)?.path).toBe("favicon.png");
+  });
+  it("never selects a candidate with a prefix-only (empty base64) dataUrl", () => {
+    const cands = [mk("logo.svg", "data:image/svg+xml;base64,"), mk("favicon.png")];
+    expect(pickBestCandidate(cands)?.path).toBe("favicon.png");
+  });
+  it("returns null when NO candidate is renderable (all null/empty dataUrls)", () => {
+    const cands = [mk("favicon.ico", null), mk("logo.svg", "data:image/svg+xml;base64,")];
+    expect(pickBestCandidate(cands)).toBeNull();
+  });
+  it("selects the only renderable candidate even when a crisper format is empty", () => {
+    const cands = [mk("logo.svg", null), mk("favicon.ico")];
+    expect(pickBestCandidate(cands)?.path).toBe("favicon.ico");
+  });
+});
+
+// ── hasRenderableDataUrl (empty-favicon bug) ──────────────────────────────────
+
+import { hasRenderableDataUrl } from "../lib/repo-icon-fetcher";
+
+describe("hasRenderableDataUrl", () => {
+  it("is false for a null dataUrl", () => {
+    expect(hasRenderableDataUrl({ dataUrl: null })).toBe(false);
+  });
+  it("is false for the exact prefix-only ICO data URL from the live bug (length 37)", () => {
+    const empty = "data:image/vnd.microsoft.icon;base64,";
+    expect(empty.length).toBe(37); // matches the live blank-icon cache evidence
+    expect(hasRenderableDataUrl({ dataUrl: empty })).toBe(false);
+  });
+  it("is false for an empty string", () => {
+    expect(hasRenderableDataUrl({ dataUrl: "" })).toBe(false);
+  });
+  it("is true for a data URL with real base64 payload after the comma", () => {
+    expect(hasRenderableDataUrl({ dataUrl: "data:image/png;base64,AAAA" })).toBe(true);
   });
 });
 
@@ -170,6 +211,163 @@ describe("resolveOwnerAvatar (CTL-1380) — owner extraction guards", () => {
 
   it("returns null when the owner segment is empty ('/repo')", () => {
     expect(resolveOwnerAvatar("/repo")).toBeNull();
+  });
+});
+
+// ── fetchAsDataUrl — empty body guard (empty-favicon bug) ─────────────────────
+
+import { fetchAsDataUrl } from "../lib/repo-icon-fetcher";
+
+describe("fetchAsDataUrl — empty-body guard", () => {
+  const realFetch = globalThis.fetch;
+  // Typed offline mock: matches typeof globalThis.fetch (call signature + preconnect) so
+  // no `as`-cast is needed. Always restored in afterEach — global mocks are process-wide.
+  const setMockFetch = (make: () => Response): void => {
+    globalThis.fetch = Object.assign(
+      (_input: string | URL | Request, _init?: RequestInit): Promise<Response> => Promise.resolve(make()),
+      { preconnect: (_url: string | URL, _options?: unknown): void => {} },
+    );
+  };
+  afterEach(() => {
+    globalThis.fetch = realFetch;
+  });
+
+  it("returns null when the response body is EMPTY even though HTTP is 200", async () => {
+    setMockFetch(() =>
+      new Response(new ArrayBuffer(0), {
+        status: 200,
+        headers: { "content-type": "image/vnd.microsoft.icon" },
+      }),
+    );
+    expect(await fetchAsDataUrl("https://example/favicon.ico")).toBeNull();
+  });
+
+  it("returns null on a non-ok response", async () => {
+    setMockFetch(() => new Response("nope", { status: 404 }));
+    expect(await fetchAsDataUrl("https://example/missing.ico")).toBeNull();
+  });
+
+  it("returns a renderable data URL when the body has bytes", async () => {
+    setMockFetch(() =>
+      new Response(new Uint8Array([1, 2, 3, 4]), {
+        status: 200,
+        headers: { "content-type": "image/png" },
+      }),
+    );
+    const out = await fetchAsDataUrl("https://example/logo.png");
+    expect(out).toBe("data:image/png;base64,AQIDBA==");
+    expect(hasRenderableDataUrl({ dataUrl: out })).toBe(true);
+  });
+});
+
+// ── fetchRepoIcon — empty-favicon → avatar fallback (offline, deps-injected) ──
+
+import { fetchRepoIcon, type RepoIconDeps, type IconResult } from "../lib/repo-icon-fetcher";
+
+describe("fetchRepoIcon — empty-favicon never positive-caches a blank icon", () => {
+  let cacheDir: string;
+  beforeEach(() => {
+    cacheDir = join(tmpdir(), `repo-icon-empty-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+  });
+  afterEach(() => {
+    rmSync(cacheDir, { recursive: true, force: true });
+  });
+
+  const VALID = "data:image/svg+xml;base64,PHN2Zz48L3N2Zz4=";
+  const AVATAR_URL = "https://avatars.githubusercontent.com/u/1?v=4";
+  const AVATAR_DATA = "data:image/png;base64,QVZBVEFS";
+
+  // Read back what was persisted to the disk cache for the slug.
+  const readCacheFile = (ownerRepo: string): { schemaVersion: number; result: IconResult } | null => {
+    const file = join(cacheDir, `${ownerRepo.replace(/\//g, "--")}.json`);
+    try {
+      return JSON.parse(readFileSync(file, "utf8")) as { schemaVersion: number; result: IconResult };
+    } catch {
+      return null;
+    }
+  };
+
+  it("a hit whose body fetched EMPTY (null dataUrl) → falls through to the avatar fallback", async () => {
+    const deps: RepoIconDeps = {
+      resolveCandidates: () => [{ path: "favicon.ico", downloadUrl: "https://repo/favicon.ico" }],
+      resolveAvatar: () => AVATAR_URL,
+      fetchDataUrl: (url) => Promise.resolve(url === AVATAR_URL ? AVATAR_DATA : null), // favicon body empty → null
+    };
+    const res = await fetchRepoIcon("coalesce-labs/catalyst", cacheDir, deps);
+    expect(res.found).toBe(true);
+    if (!res.found) throw new Error("unreachable");
+    expect(res.selectedPath).toBe(OWNER_AVATAR_PATH);
+    expect(res.candidates).toHaveLength(1);
+    expect(res.candidates[0].dataUrl).toBe(AVATAR_DATA);
+    // cached found:true, and the cached candidate is renderable
+    const cached = readCacheFile("coalesce-labs/catalyst");
+    expect(cached?.schemaVersion).toBe(4);
+    expect(cached?.result.found).toBe(true);
+    if (cached?.result.found) {
+      expect(cached.result.candidates.every((c) => hasRenderableDataUrl(c))).toBe(true);
+    }
+  });
+
+  it("a hit whose body fetched a prefix-only empty data URL → still treated as no-icon → avatar fallback", async () => {
+    const deps: RepoIconDeps = {
+      resolveCandidates: () => [{ path: "favicon.ico", downloadUrl: "https://repo/favicon.ico" }],
+      resolveAvatar: () => AVATAR_URL,
+      // a length-37 prefix-only data URL (the live blank-icon evidence) is NOT renderable
+      fetchDataUrl: (url) =>
+        Promise.resolve(url === AVATAR_URL ? AVATAR_DATA : "data:image/vnd.microsoft.icon;base64,"),
+    };
+    const res = await fetchRepoIcon("coalesce-labs/catalyst", cacheDir, deps);
+    expect(res.found).toBe(true);
+    if (!res.found) throw new Error("unreachable");
+    expect(res.selectedPath).toBe(OWNER_AVATAR_PATH);
+  });
+
+  it("empty favicon AND no avatar available → found:false, cached NEGATIVE (not positive)", async () => {
+    const deps: RepoIconDeps = {
+      resolveCandidates: () => [{ path: "favicon.ico", downloadUrl: "https://repo/favicon.ico" }],
+      resolveAvatar: () => null, // no avatar either
+      fetchDataUrl: () => Promise.resolve(null),
+    };
+    const res = await fetchRepoIcon("coalesce-labs/catalyst", cacheDir, deps);
+    expect(res).toEqual({ found: false });
+    const cached = readCacheFile("coalesce-labs/catalyst");
+    expect(cached?.result).toEqual({ found: false }); // negative-cached, never found:true
+  });
+
+  it("a hit with valid content is KEPT and selected (no avatar fallback)", async () => {
+    let avatarCalls = 0;
+    const deps: RepoIconDeps = {
+      resolveCandidates: () => [{ path: "logo.svg", downloadUrl: "https://repo/logo.svg" }],
+      resolveAvatar: () => {
+        avatarCalls++;
+        return AVATAR_URL;
+      },
+      fetchDataUrl: () => Promise.resolve(VALID),
+    };
+    const res = await fetchRepoIcon("coalesce-labs/catalyst", cacheDir, deps);
+    expect(res.found).toBe(true);
+    if (!res.found) throw new Error("unreachable");
+    expect(res.selectedPath).toBe("logo.svg");
+    expect(res.dataUrl).toBe(VALID);
+    expect(avatarCalls).toBe(0); // fallback not consulted when a renderable favicon exists
+  });
+
+  it("mixed empty + valid hits → only the valid candidate survives and is selected", async () => {
+    const deps: RepoIconDeps = {
+      resolveCandidates: () => [
+        { path: "favicon.ico", downloadUrl: "https://repo/favicon.ico" }, // empty
+        { path: "logo.svg", downloadUrl: "https://repo/logo.svg" }, // valid
+      ],
+      resolveAvatar: () => AVATAR_URL,
+      fetchDataUrl: (url) => Promise.resolve(url === "https://repo/logo.svg" ? VALID : null),
+    };
+    const res = await fetchRepoIcon("coalesce-labs/catalyst", cacheDir, deps);
+    expect(res.found).toBe(true);
+    if (!res.found) throw new Error("unreachable");
+    expect(res.candidates).toHaveLength(1); // empty one dropped
+    expect(res.candidates[0].path).toBe("logo.svg");
+    expect(res.selectedPath).toBe("logo.svg");
+    expect(res.candidates.every((c) => hasRenderableDataUrl(c))).toBe(true);
   });
 });
 

--- a/plugins/dev/scripts/orch-monitor/lib/repo-icon-fetcher.ts
+++ b/plugins/dev/scripts/orch-monitor/lib/repo-icon-fetcher.ts
@@ -31,9 +31,18 @@
 // so a configured team still shows a real image instead of a blank circle — this also
 // covers PRIVATE repos (the avatar is public even when the repo contents are not).
 // Cache: JSON files in cacheDir (default ~/catalyst/repo-icon-cache/), keyed by
-//   owner-repo slug, TTL 7 days (schema v3 — older-schema entries re-probe once). A negative
+//   owner-repo slug, TTL 7 days (schema v4 — older-schema entries re-probe once). A negative
 //   result ("no icon found") is also cached (with a 1-day TTL) so we don't hammer
 //   the GitHub API on every boot.
+//
+// A favicon PATH existing does NOT mean it renders: a probed path can fetch to an
+// empty/transiently-failed body, which renders as a BLANK icon. Such candidates are
+// treated as no-icon — filtered out before selection and before caching — and when NO
+// renderable candidate survives we fall through to the SAME owner-avatar fallback used
+// when no favicon path exists at all. Invariant: a cached `found:true` ALWAYS carries at
+// least one renderable (non-empty dataUrl) candidate. (Without this an empty-but-present
+// favicon would positive-cache for 7 days, render blank, AND suppress the avatar fallback
+// forever — because that fallback only fired on zero probed paths.)
 //
 // Fail-open: any error (no gh binary, API rate-limit, no internet) returns null
 // so the UI falls through to the manual-override / lucide fallback.
@@ -62,10 +71,30 @@ export function inferIconFormat(path: string): IconFormat {
   return "png";
 }
 
-/** Best = lowest FORMAT_RANK, tie-broken by ICON_PATH_PRIORITY index. */
+/**
+ * A candidate is RENDERABLE iff its dataUrl carries actual image bytes — i.e. there is
+ * non-empty base64 payload after the `data:<ct>;base64,` separator. A favicon PATH can
+ * resolve while its body is empty/transiently-failed, yielding either a null dataUrl or a
+ * prefix-only `data:image/...;base64,` URL (the latter renders as a BLANK icon). Neither
+ * is renderable, so neither may ever be selected or positive-cached.
+ */
+export function hasRenderableDataUrl(c: Pick<IconCandidate, "dataUrl">): boolean {
+  const u = c.dataUrl;
+  if (!u) return false;
+  const comma = u.indexOf(",");
+  return comma !== -1 && comma < u.length - 1;
+}
+
+/**
+ * Best = lowest FORMAT_RANK, tie-broken by ICON_PATH_PRIORITY index.
+ * Only ever selects a RENDERABLE candidate (hasRenderableDataUrl) — non-renderable
+ * candidates (null/empty dataUrl) are dropped first so a blank icon is never "best".
+ * Returns null when no renderable candidate exists.
+ */
 export function pickBestCandidate(cands: readonly IconCandidate[]): IconCandidate | null {
-  if (cands.length === 0) return null;
-  return [...cands].sort((a, b) => {
+  const renderable = cands.filter(hasRenderableDataUrl);
+  if (renderable.length === 0) return null;
+  return [...renderable].sort((a, b) => {
     const fr = FORMAT_RANK[a.format] - FORMAT_RANK[b.format];
     if (fr !== 0) return fr;
     return ICON_PATH_PRIORITY.indexOf(a.path) - ICON_PATH_PRIORITY.indexOf(b.path);
@@ -111,7 +140,7 @@ export type IconResult =
     }
   | { found: false };
 
-const CACHE_SCHEMA_VERSION = 3; // v3 adds the owner-avatar fallback (CTL-1380); v1/v2 entries re-probe once
+const CACHE_SCHEMA_VERSION = 4; // v4 stops positive-caching empty/unrenderable favicons; v1–v3 entries re-probe once
 
 /** Sentinel `path` for the owner-avatar fallback candidate (CTL-1380, Bug B). Not a
  *  real in-repo file path, so it never collides with ICON_PATH_PRIORITY entries. */
@@ -215,6 +244,10 @@ export async function fetchAsDataUrl(url: string): Promise<string | null> {
     if (!resp.ok) return null;
     const ct = resp.headers.get("content-type") ?? "image/png";
     const buf = await resp.arrayBuffer();
+    // An empty body is NOT a renderable image — a path can exist while the fetch returns
+    // zero bytes (transient failure / placeholder). Returning a prefix-only
+    // `data:...;base64,` URL here would render as a blank icon, so treat it as no-icon.
+    if (buf.byteLength === 0) return null;
     const b64 = Buffer.from(buf).toString("base64");
     return `data:${ct};base64,${b64}`;
   } catch {
@@ -232,7 +265,8 @@ export function buildAvatarIconResult(
   avatarUrl: string | null,
   avatarDataUrl: string | null,
 ): IconResult {
-  if (!avatarUrl || !avatarDataUrl) return { found: false };
+  // Require a RENDERABLE avatar data URL — never emit a found:true that would render blank.
+  if (!avatarUrl || !hasRenderableDataUrl({ dataUrl: avatarDataUrl })) return { found: false };
   const avatar: IconCandidate = {
     path: OWNER_AVATAR_PATH,
     format: "png",
@@ -272,50 +306,88 @@ export function resolveRepoIconCandidates(
  */
 
 /**
+ * Injectable I/O seam for fetchRepoIcon — lets tests run fully offline (no `gh`, no
+ * network) by supplying fakes. Defaults wire the real GitHub-backed implementations.
+ */
+export interface RepoIconDeps {
+  resolveCandidates: (ownerRepo: string) => { path: string; downloadUrl: string }[];
+  resolveAvatar: (ownerRepo: string) => string | null;
+  fetchDataUrl: (url: string) => Promise<string | null>;
+}
+
+const DEFAULT_REPO_ICON_DEPS: RepoIconDeps = {
+  resolveCandidates: resolveRepoIconCandidates,
+  resolveAvatar: resolveOwnerAvatar,
+  fetchDataUrl: fetchAsDataUrl,
+};
+
+/**
  * Fetch the best icon for a GitHub repo, with disk cache.
  * Returns all detected candidates plus the default-best (SVG > PNG > ICO).
  * Legacy top-level path/downloadUrl/dataUrl fields mirror the best candidate.
  * Falls through gracefully (returns `{ found: false }`) on any error.
+ *
+ * Only RENDERABLE candidates (non-empty dataUrl) are kept: a probed favicon PATH whose
+ * body fetched empty/failed is dropped, and if NO renderable candidate survives we fall
+ * through to the SAME owner-avatar fallback used when zero favicon paths exist. So a
+ * cached `found:true` always carries a renderable candidate; a zero-renderable outcome is
+ * either the avatar (found:true, renderable) or a negative (found:false, 1-day) cache —
+ * never a 7-day positive cache of a blank icon.
  */
 export async function fetchRepoIcon(
   ownerRepo: string,
   cacheDir?: string,
+  deps: RepoIconDeps = DEFAULT_REPO_ICON_DEPS,
 ): Promise<IconResult> {
   const dir = cacheDir ?? join(homedir(), "catalyst", "repo-icon-cache");
 
   const cached = readCache(dir, ownerRepo);
   if (cached !== null) return cached;
 
+  // CTL-1380 (Bug B) owner-avatar fallback. Used both when NO favicon path exists AND
+  // when every probed favicon fetched to an empty/unrenderable body. Covers favicon-less
+  // repos AND private repos (the avatar is public). If the avatar can't be resolved/
+  // fetched (offline, no gh, unknown owner) buildAvatarIconResult fails open to
+  // { found: false } → the UI lucide fallback.
+  const avatarFallback = async (): Promise<IconResult> => {
+    const avatarUrl = deps.resolveAvatar(ownerRepo);
+    const avatarDataUrl = avatarUrl ? await deps.fetchDataUrl(avatarUrl) : null;
+    return buildAvatarIconResult(avatarUrl, avatarDataUrl);
+  };
+
   let result: IconResult;
   try {
-    const hits = resolveRepoIconCandidates(ownerRepo);
+    const hits = deps.resolveCandidates(ownerRepo);
     if (hits.length === 0) {
-      // CTL-1380 (Bug B): no favicon at any probed path → fall back to the GitHub
-      // owner/org avatar so the project still renders a real image instead of a blank
-      // circle. Covers favicon-less repos AND private repos (the avatar is public).
-      // If the avatar can't be resolved/fetched (offline, no gh, unknown owner) we
-      // still fail-open to { found: false } → the UI lucide fallback.
-      const avatarUrl = resolveOwnerAvatar(ownerRepo);
-      const avatarDataUrl = avatarUrl ? await fetchAsDataUrl(avatarUrl) : null;
-      result = buildAvatarIconResult(avatarUrl, avatarDataUrl);
+      result = await avatarFallback();
     } else {
       const candidates: IconCandidate[] = await Promise.all(
         hits.map(async (h) => ({
           path: h.path,
           format: inferIconFormat(h.path),
           downloadUrl: h.downloadUrl,
-          dataUrl: await fetchAsDataUrl(h.downloadUrl),
+          dataUrl: await deps.fetchDataUrl(h.downloadUrl),
         })),
       );
-      const best = pickBestCandidate(candidates) ?? candidates[0];
-      result = {
-        found: true,
-        candidates,
-        selectedPath: best.path,
-        path: best.path,
-        downloadUrl: best.downloadUrl,
-        dataUrl: best.dataUrl,
-      };
+      // Keep only candidates that actually fetched a renderable (non-empty) image. A
+      // favicon PATH can exist while its body is empty/transiently-failed; keeping such a
+      // candidate would render a BLANK icon AND (because hits.length > 0) suppress the
+      // owner-avatar fallback forever once positive-cached. Drop them.
+      const renderable = candidates.filter(hasRenderableDataUrl);
+      if (renderable.length === 0) {
+        // Every probed favicon was empty/unfetchable → same fallback as no-favicon.
+        result = await avatarFallback();
+      } else {
+        const best = pickBestCandidate(renderable) ?? renderable[0];
+        result = {
+          found: true,
+          candidates: renderable,
+          selectedPath: best.path,
+          path: best.path,
+          downloadUrl: best.downloadUrl,
+          dataUrl: best.dataUrl,
+        };
+      }
     }
   } catch {
     // Don't cache unexpected errors — let a retry happen next time


### PR DESCRIPTION
## Problem (live-diagnosed)

`orch-monitor`'s repo-icon auto-detect probes favicon paths via `resolveRepoIconCandidates()` (`gh api contents` → `download_url`), then fetches each into a data URL. A probed favicon **PATH existing does not mean it renders**: when a path resolves but its body fetches empty / transiently-fails, `fetchAsDataUrl()` returned a **non-null but EMPTY** data URL — e.g. `data:image/vnd.microsoft.icon;base64,` (length 37, no base64 payload).

That empty-content candidate was then:

1. cached as `found:true` with the **7-day positive TTL**, and
2. rendered as a **BLANK** icon, and
3. — worse — because `hits.length > 0`, the CTL-1380 **owner-avatar fallback** (which only fires when `hits.length === 0`) **never triggered**. So a repo with an empty-but-"present" favicon showed blank **forever**, even after the cache TTL refreshed (it just re-cached the same blank).

**Live evidence:** the cache held `found:true` `favicon.ico` with `dataUrl` length 37 (prefix only) for `coalesce-labs/catalyst`, while the raw `favicon.ico` fetched fine (HTTP 200, 15086 bytes). The live cache was cleared as a stopgap; this PR is the **durable** fix so it can't recur.

## Fix

- **`fetchAsDataUrl()`** — returns `null` when the fetched body is **empty** (`buf.byteLength === 0`). An empty `data:…;base64,` URL is not a renderable image. (Keeps the existing `!resp.ok → null`.)
- **`fetchRepoIcon()`** — filters out candidates whose `dataUrl` is null/empty **before** `pickBestCandidate`. If **no** renderable candidate remains, it falls through to the **same** owner-avatar fallback path used when `hits.length === 0` (`resolveOwnerAvatar` + `buildAvatarIconResult`). It never returns `found:true` with zero renderable candidates.
- **`pickBestCandidate()`** — only ever selects a renderable candidate (new exported `hasRenderableDataUrl` helper); `buildAvatarIconResult()` likewise requires a renderable avatar data URL.
- **Caching invariant** — a zero-renderable outcome is either the avatar (`found:true`, renderable) or a **negative** (`found:false`, 1-day) cache — **never** a 7-day positive cache of a blank icon. **Key invariant: a cached `found:true` ALWAYS has at least one renderable candidate.**
- **`CACHE_SCHEMA_VERSION` 3 → 4** — so any existing stale empty-content entries on other machines re-probe once.
- **Testability** — `fetchRepoIcon` gains an injectable deps seam (`probe` / `avatar` / `fetch`) so the new cases run fully **offline**.

## Tests (extended `__tests__/repo-icon-fetcher.test.ts`)

- empty body → `fetchAsDataUrl` returns `null`; non-ok → `null`; bytes → renderable data URL
- `hasRenderableDataUrl`: null / empty-string / the exact length-37 prefix-only ICO URL → false; real payload → true
- `pickBestCandidate` never selects a null/empty-dataUrl candidate; returns null when none renderable
- `fetchRepoIcon`: empty favicon body → avatar fallback fires (avatar available) / `found:false` + **negative** cache (not available); valid content → kept + selected (avatar not consulted); mixed empty+valid → only the valid one survives and is selected; cached entry is schema v4 and carries only renderable candidates

## Validation

- parent `tsc --noEmit` ✅, `eslint .` ✅ (0 errors)
- repo-icon suite 54/54 ✅; full parent `bun test` green except one pre-existing, environment-dependent `/api/nav` "empty fleet" test (fails identically on `origin/main` — it boots a real server and reads live host `~/catalyst` state)
- monitor UI `vite build` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DPp7MzGbQqyvHtEcQAAPBK