### PR TITLE
feat(dev): board sources ticket titles from the CTC replica (real titles, not bare IDs) [HOLD FOR REVIEW]

### DIFF
--- a/plugins/dev/scripts/execution-core/replica-read.mjs
+++ b/plugins/dev/scripts/execution-core/replica-read.mjs
@@ -39,6 +39,22 @@ const TERMINAL_SELECT = `SELECT state, completed_at, canceled_at FROM issues WHE
 // not in the hot per-signal path.
 const FRESHNESS_SELECT = `SELECT MAX(updated_at) AS maxUpdated, COUNT(*) AS n FROM issues`;
 
+// CTL-1372: the BATCHED title reader the orch-monitor board sources display
+// titles from. filter-state.db ticket_state has NO title column, and a PARKED
+// ticket (worker dir torn down, no eligible row) has no other durable title
+// source — so its board card otherwise renders as the bare id. The replica's
+// `issues.title` is the complete Linear title for every mirrored ticket, so one
+// index-backed IN-query resolves the whole board at once. Chunked under SQLite's
+// bound-parameter ceiling; removed_at IS NULL drops tombstones (a removed ticket
+// is a MISS → the caller falls through to its existing chain, never a stale
+// title). Built to the SAME fail-open contract as lookup()/freshness().
+const TITLES_CHUNK = 400; // stay well under SQLite's bound-parameter ceiling (999)
+function titlesSelect(n) {
+  return `SELECT identifier, title FROM issues WHERE identifier IN (${Array(n)
+    .fill("?")
+    .join(",")}) AND removed_at IS NULL`;
+}
+
 // coerce a replica `updated_at` cell to epoch-ms. Accepts an epoch-ms integer
 // (the cloud change-feed shape) OR an ISO-8601 string (Date.parse fallback).
 // Anything that resolves to neither (null, NaN, garbage) → undefined → the
@@ -112,5 +128,43 @@ export function createReplicaReader({ dbPath = getReplicaDbPath() } = {}) {
     }
   };
 
-  return { lookup, freshness, close: dropHandle };
+  // titles(identifiers) → { [identifier]: title }  (CTL-1372)
+  //   HIT (non-removed row with a non-empty title) → entry in the map.
+  //   absent / removed / null-or-empty title → OMITTED (the caller falls through
+  //     to its existing title chain — never a fabricated title).
+  //   empty input / no db / any throw → {}  (fail-open, mirroring lookup()).
+  // Batched + chunked under SQLite's bound-parameter ceiling so a whole board
+  // resolves in one (or a few) index-backed reads rather than N per-ticket calls.
+  const titles = (identifiers) => {
+    if (!Array.isArray(identifiers) || identifiers.length === 0) return {};
+    const wanted = [
+      ...new Set(identifiers.filter((id) => typeof id === "string" && id.length > 0)),
+    ];
+    if (wanted.length === 0) return {};
+    const out = {};
+    try {
+      const handle = open();
+      for (let i = 0; i < wanted.length; i += TITLES_CHUNK) {
+        const slice = wanted.slice(i, i + TITLES_CHUNK);
+        const rows = handle.prepare(titlesSelect(slice.length)).all(...slice);
+        for (const row of rows) {
+          if (
+            row &&
+            typeof row.identifier === "string" &&
+            typeof row.title === "string" &&
+            row.title.length > 0
+          ) {
+            out[row.identifier] = row.title;
+          }
+        }
+      }
+      return out;
+    } catch {
+      // Drop the handle so a later call re-opens fresh (DB may be re-seeded).
+      dropHandle();
+      return {};
+    }
+  };
+
+  return { lookup, freshness, titles, close: dropHandle };
 }

--- a/plugins/dev/scripts/execution-core/replica-read.test.mjs
+++ b/plugins/dev/scripts/execution-core/replica-read.test.mjs
@@ -164,3 +164,89 @@ describe("createReplicaReader.freshness (CTL-1366)", () => {
     expect(reader.freshness()).toBeUndefined();
   });
 });
+
+// seedTitles — build a minimal `issues` table carrying titles + the removed_at
+// tombstone column the batched title reader reads (CTL-1372).
+function seedTitles() {
+  const db = new Database(dbPath, { create: true });
+  db.run(`CREATE TABLE issues (identifier TEXT, title TEXT, removed_at TEXT)`);
+  db.run(`CREATE INDEX idx_issues_identifier ON issues (identifier)`);
+  db.run(`INSERT INTO issues VALUES ('CTL-1214', 'Slim .catalyst/config.json down to the essentials', NULL)`);
+  db.run(`INSERT INTO issues VALUES ('CTL-1215', 'Bound the title-desc cache', NULL)`);
+  // removed (tombstoned) — excluded by removed_at IS NULL → MISS (omitted).
+  db.run(`INSERT INTO issues VALUES ('CTL-9000', 'Tombstoned ticket', '2026-06-03T00:00:00Z')`);
+  // null title → omitted (caller falls through to its existing chain).
+  db.run(`INSERT INTO issues VALUES ('CTL-8000', NULL, NULL)`);
+  db.close();
+}
+
+describe("createReplicaReader.titles (CTL-1372 — batched board title source)", () => {
+  test("returns an { identifier → title } map for HITS", () => {
+    seedTitles();
+    reader = createReplicaReader({ dbPath });
+    expect(reader.titles(["CTL-1214", "CTL-1215"])).toEqual({
+      "CTL-1214": "Slim .catalyst/config.json down to the essentials",
+      "CTL-1215": "Bound the title-desc cache",
+    });
+  });
+
+  test("the parked-ticket repro: a single id resolves to its real Linear title", () => {
+    seedTitles();
+    reader = createReplicaReader({ dbPath });
+    // The exact live-diagnosed case — CTL-1214 must NOT render as the bare id.
+    expect(reader.titles(["CTL-1214"])["CTL-1214"]).toBe(
+      "Slim .catalyst/config.json down to the essentials",
+    );
+  });
+
+  test("omits absent ids, tombstoned rows, and null titles (MISS → caller falls through)", () => {
+    seedTitles();
+    reader = createReplicaReader({ dbPath });
+    const map = reader.titles(["CTL-1214", "CTL-9000", "CTL-8000", "CTL-404"]);
+    expect(map).toEqual({ "CTL-1214": "Slim .catalyst/config.json down to the essentials" });
+    expect("CTL-9000" in map).toBe(false); // tombstoned
+    expect("CTL-8000" in map).toBe(false); // null title
+    expect("CTL-404" in map).toBe(false); // absent
+  });
+
+  test("empty / non-array / all-falsy input → {} without touching the DB", () => {
+    reader = createReplicaReader({ dbPath });
+    expect(reader.titles([])).toEqual({});
+    expect(reader.titles(null)).toEqual({});
+    expect(reader.titles(["", null, undefined])).toEqual({});
+  });
+
+  test("de-dupes the requested ids", () => {
+    seedTitles();
+    reader = createReplicaReader({ dbPath });
+    expect(reader.titles(["CTL-1214", "CTL-1214", "CTL-1214"])).toEqual({
+      "CTL-1214": "Slim .catalyst/config.json down to the essentials",
+    });
+  });
+
+  test("chunks beyond the bound-parameter ceiling (>400 ids) without throwing", () => {
+    seedTitles();
+    reader = createReplicaReader({ dbPath });
+    const many = Array.from({ length: 950 }, (_, i) => `CTL-${i}`);
+    many.push("CTL-1214"); // one real hit amid the misses
+    const map = reader.titles(many);
+    expect(map["CTL-1214"]).toBe("Slim .catalyst/config.json down to the essentials");
+  });
+
+  test("fail-open: missing DB → {}, then recovers once created", () => {
+    reader = createReplicaReader({ dbPath });
+    expect(reader.titles(["CTL-1214"])).toEqual({}); // no db yet → fail-open
+    seedTitles();
+    expect(reader.titles(["CTL-1214"])).toEqual({
+      "CTL-1214": "Slim .catalyst/config.json down to the essentials",
+    });
+  });
+
+  test("fail-open: DB without the issues table → {} (query throws → fail-open)", () => {
+    const empty = new Database(dbPath, { create: true });
+    empty.run(`CREATE TABLE unrelated (x INTEGER)`);
+    empty.close();
+    reader = createReplicaReader({ dbPath });
+    expect(reader.titles(["CTL-1214"])).toEqual({});
+  });
+});

--- a/plugins/dev/scripts/orch-monitor/__tests__/board-parked-needs-human.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/board-parked-needs-human.test.ts
@@ -175,7 +175,7 @@ describe("assembleBoard wiring — parked needs-human synthetic tickets", () => 
   });
 
   it("assembleBoard dedupes against existing card ids and appends parkedTickets", () => {
-    expect(boardDataSrc).toContain("synthesizeParkedNeedsHumanTickets(parkedNeedsHuman, existingCardIds, now)");
+    expect(boardDataSrc).toContain("synthesizeParkedNeedsHumanTickets(parkedNeedsHuman, existingCardIds, now, replicaTitles)");
     expect(boardDataSrc).toContain("...parkedTickets");
   });
 });

--- a/plugins/dev/scripts/orch-monitor/__tests__/board-replica-title.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/board-replica-title.test.ts
@@ -1,0 +1,149 @@
+// board-replica-title.test.ts — CTL-1372: the Tickets board must lead with the
+// real Linear TITLE for PARKED tickets, not the bare ticket id.
+//
+// THE BUG (live-diagnosed): filter-state.db ticket_state has NO title column, so a
+// PARKED ticket (worker dir torn down, no eligible row) has no durable title source
+// and its card rendered as "CTL-1214" instead of "Slim .catalyst/config.json…".
+//
+// THE FIX: the CTC replica (catalyst-replica.db — the SDK's live Linear mirror)
+// carries every title. board-data sources a batched { id→title } map from it and
+// slots it into title resolution right after the triage-recorded title. This file
+// drives the PURE board helpers the wiring threads `replicaTitles` through —
+// ticketTitle, collectNullTitleIds, synthesizeQueuedTicket, and
+// synthesizeParkedNeedsHumanTickets — with an in-memory replica map (no DB).
+import { describe, expect, it } from "bun:test";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+import {
+  collectNullTitleIds,
+  synthesizeQueuedTicket,
+  ticketTitle,
+} from "../lib/board-data.mjs";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+
+// synthesizeParkedNeedsHumanTickets is dynamic-imported + cast (same pattern as
+// board-parked-needs-human.test.ts) — it is not declared in board-data.d.mts.
+const boardMod = await import(join(HERE, "..", "lib", "board-data.mjs"));
+const synthesizeParkedNeedsHumanTickets = (boardMod as Record<string, unknown>)
+  .synthesizeParkedNeedsHumanTickets as (
+  parked: unknown,
+  existingIds: unknown,
+  now: number,
+  replicaTitles?: Record<string, string>,
+) => Array<{ id: string; title: string }>;
+
+const KEY = "CTL-1214";
+const REPLICA_TITLE = "Slim .catalyst/config.json down to the essentials";
+const ELIGIBLE_TITLE = "Eligible-projection title";
+const SUMMARY = "A description-y triage summary sentence that must never be the title";
+
+describe("ticketTitle — replica title tier (CTL-1372)", () => {
+  it("uses the replica title when the local caches have none (the parked-ticket fix)", () => {
+    // No triage.title, no linfo title, no eligible title — exactly a parked ticket.
+    expect(ticketTitle(KEY, { summary: SUMMARY }, {}, {}, { [KEY]: REPLICA_TITLE })).toBe(
+      REPLICA_TITLE,
+    );
+  });
+
+  it("prefers an explicit triage.title over the replica title", () => {
+    expect(
+      ticketTitle(KEY, { title: "Triage-recorded", summary: SUMMARY }, {}, {}, { [KEY]: REPLICA_TITLE }),
+    ).toBe("Triage-recorded");
+  });
+
+  it("prefers the replica title over the existing linfo / eligible title", () => {
+    const linfo = { [KEY]: { title: "Stale linfo title" } };
+    const eligibleIndex = { [KEY]: { title: ELIGIBLE_TITLE } };
+    expect(ticketTitle(KEY, null, eligibleIndex, linfo, { [KEY]: REPLICA_TITLE })).toBe(REPLICA_TITLE);
+  });
+
+  it("falls through to the existing chain unchanged when the replica has no hit", () => {
+    // Replica map empty (absent/unreadable) → existing linfo/eligible wins.
+    const eligibleIndex = { [KEY]: { title: ELIGIBLE_TITLE } };
+    expect(ticketTitle(KEY, { summary: SUMMARY }, eligibleIndex, {}, {})).toBe(ELIGIBLE_TITLE);
+    // …and with nothing anywhere it still falls to summary then the id (back-compat).
+    expect(ticketTitle(KEY, { summary: SUMMARY }, {}, {}, {})).toBe(SUMMARY);
+    expect(ticketTitle(KEY, null, {}, {}, {})).toBe(KEY);
+  });
+
+  it("ignores an empty-string replica title (treated as no hit, falls through)", () => {
+    expect(ticketTitle(KEY, { summary: SUMMARY }, {}, {}, { [KEY]: "" })).toBe(SUMMARY);
+  });
+
+  it("is back-compat when called with the old 4-arg signature (no replica map)", () => {
+    const linfo = { [KEY]: { title: "L" } };
+    expect(ticketTitle(KEY, null, {}, linfo)).toBe("L");
+  });
+});
+
+describe("collectNullTitleIds — replica-aware (CTL-1372)", () => {
+  it("treats a replica HIT as 'covered' so the on-demand fetch is skipped", () => {
+    // ADV-1352 has no linfo/eligible title but the replica resolves it → not fetched.
+    const linfo = { "ADV-1352": { title: null } };
+    expect(
+      collectNullTitleIds(["ADV-1352"], linfo, {}, { "ADV-1352": "Demo data should stay current" }),
+    ).toEqual([]);
+  });
+
+  it("still flags ids the replica MISSED (on-demand fetch is the last resort)", () => {
+    const linfo = { "ADV-1352": { title: null }, "ADV-1353": { title: null } };
+    // Only ADV-1352 is in the replica; ADV-1353 still needs the on-demand fetch.
+    expect(
+      collectNullTitleIds(["ADV-1352", "ADV-1353"], linfo, {}, { "ADV-1352": "covered" }),
+    ).toEqual(["ADV-1353"]);
+  });
+
+  it("is back-compat with the old 3-arg signature (no replica map)", () => {
+    expect(collectNullTitleIds(["ADV-999"], {}, {})).toEqual(["ADV-999"]);
+  });
+});
+
+describe("synthesizeParkedNeedsHumanTickets — replica title (CTL-1372 — the repro)", () => {
+  const parked = (over: Record<string, unknown> = {}) => ({
+    ticket: KEY,
+    labels: ["needs-human"],
+    linearState: "Implement",
+    priority: 2,
+    updatedAt: new Date(120_000).toISOString(),
+    ...over,
+  });
+
+  it("renders the replica title instead of the bare ticket id", () => {
+    const cards = synthesizeParkedNeedsHumanTickets([parked()], new Set<string>(), 600_000, {
+      [KEY]: REPLICA_TITLE,
+    });
+    expect(cards).toHaveLength(1);
+    expect(cards[0].title).toBe(REPLICA_TITLE); // NOT "CTL-1214"
+    expect(cards[0].title).not.toBe(KEY);
+  });
+
+  it("falls back to the bare id when the replica has no hit (honest last resort)", () => {
+    const cards = synthesizeParkedNeedsHumanTickets([parked()], new Set<string>(), 600_000, {});
+    expect(cards[0].title).toBe(KEY); // unchanged pre-replica behavior, never crashes
+  });
+
+  it("is back-compat when called without a replica map", () => {
+    const cards = synthesizeParkedNeedsHumanTickets([parked()], new Set<string>(), 600_000);
+    expect(cards[0].title).toBe(KEY);
+  });
+});
+
+describe("synthesizeQueuedTicket — replica title (CTL-1372)", () => {
+  it("prefers the replica title over the eligible projection's title", () => {
+    const e = { id: KEY, title: ELIGIBLE_TITLE };
+    const card = synthesizeQueuedTicket(e, {}, new Map(), {}, { [KEY]: REPLICA_TITLE });
+    expect(card.title).toBe(REPLICA_TITLE);
+  });
+
+  it("falls back to the eligible title, then the id, when the replica has no hit", () => {
+    expect(synthesizeQueuedTicket({ id: KEY, title: ELIGIBLE_TITLE }, {}, new Map(), {}, {}).title).toBe(
+      ELIGIBLE_TITLE,
+    );
+    expect(synthesizeQueuedTicket({ id: KEY }, {}, new Map(), {}, {}).title).toBe(KEY);
+  });
+
+  it("is back-compat without a replica map", () => {
+    expect(synthesizeQueuedTicket({ id: KEY, title: ELIGIBLE_TITLE }, {}).title).toBe(ELIGIBLE_TITLE);
+  });
+});

--- a/plugins/dev/scripts/orch-monitor/__tests__/linear-cache-reader.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/linear-cache-reader.test.ts
@@ -8,7 +8,7 @@ import { describe, it, expect, beforeEach, afterEach } from "bun:test";
 import { mkdtempSync, rmSync, writeFileSync, mkdirSync } from "fs";
 import { tmpdir } from "os";
 import { join } from "path";
-import { readLinearCache } from "../lib/linear-cache-reader.mjs";
+import { readLinearCache, readReplicaTitles } from "../lib/linear-cache-reader.mjs";
 import {
   openBrokerStateDb,
   closeBrokerStateDb,
@@ -264,5 +264,82 @@ describe("readLinearCache end-to-end against a real filter-state.db", () => {
     expect(byId["CTL-200"].title).toBe("queued"); // BFF9: title from eligible
     // BFF10/BFF11: the fence projection flows through the real bulk descriptor read.
     expect(byId["CTL-101"].generation).toBeNull();
+  });
+});
+
+// CTL-1372: the board's CTC-replica title source. readReplicaTitles is driven with
+// an INJECTED reader factory so the contract is exercised offline (no real
+// catalyst-replica.db) — when a factory is injected the file-presence gate is
+// skipped (the fake reader IS the DB).
+describe("readReplicaTitles (CTL-1372 — board title source from the CTC replica)", () => {
+  // A fake reader that records the ids it was asked for and serves a fixed map.
+  function fakeFactory(map: Record<string, string>, spy?: { ids?: string[]; closed?: boolean }) {
+    return (_opts: { dbPath: string }) => ({
+      titles(ids: string[]) {
+        if (spy) spy.ids = ids;
+        const out: Record<string, string> = {};
+        for (const id of ids) if (map[id]) out[id] = map[id];
+        return out;
+      },
+      close() {
+        if (spy) spy.closed = true;
+      },
+    });
+  }
+
+  it("returns the replica title map for the requested ids (parked ticket → real title)", async () => {
+    const map = { "CTL-1214": "Slim .catalyst/config.json down to the essentials" };
+    const titles = await readReplicaTitles({
+      ids: ["CTL-1214"],
+      readerFactory: fakeFactory(map),
+    });
+    expect(titles["CTL-1214"]).toBe("Slim .catalyst/config.json down to the essentials");
+  });
+
+  it("de-dupes ids, passes the wanted set to the reader, and closes the handle", async () => {
+    const spy: { ids?: string[]; closed?: boolean } = {};
+    const map = { "CTL-1": "one", "ADV-2": "two" };
+    const titles = await readReplicaTitles({
+      ids: ["CTL-1", "CTL-1", "ADV-2", ""], // dup CTL-1 + a falsy "" to drop
+      readerFactory: fakeFactory(map, spy),
+    });
+    expect(titles).toEqual({ "CTL-1": "one", "ADV-2": "two" });
+    expect(spy.ids).toEqual(["CTL-1", "ADV-2"]); // de-duped + falsy dropped
+    expect(spy.closed).toBe(true); // handle always released
+  });
+
+  it("empty / non-array ids → {} without invoking the reader", async () => {
+    let called = false;
+    const factory = () => {
+      called = true;
+      return { titles: () => ({}) };
+    };
+    expect(await readReplicaTitles({ ids: [], readerFactory: factory })).toEqual({});
+    expect(await readReplicaTitles({ ids: undefined, readerFactory: factory })).toEqual({});
+    expect(called).toBe(false);
+  });
+
+  it("fails OPEN to {} when the reader throws (replica unreadable → existing chain preserved)", async () => {
+    const factory = () => ({
+      titles() {
+        throw new Error("replica db corrupt");
+      },
+    });
+    const titles: Record<string, string> | "THREW" = await readReplicaTitles({
+      ids: ["CTL-1"],
+      readerFactory: factory,
+    }).catch(() => "THREW" as const);
+    expect(titles).not.toBe("THREW"); // never leaks the throw
+    expect(titles).toEqual({}); // fail-open empty map
+  });
+
+  it("fails OPEN to {} when a non-existent replica path is used (file-presence gate)", async () => {
+    // No readerFactory → the real computed-specifier import path runs, but the
+    // file-presence gate short-circuits on an absent path (never opens/throws).
+    const titles = await readReplicaTitles({
+      ids: ["CTL-1"],
+      dbPath: "/nonexistent/catalyst-replica.db",
+    });
+    expect(titles).toEqual({});
   });
 });

--- a/plugins/dev/scripts/orch-monitor/lib/board-data.d.mts
+++ b/plugins/dev/scripts/orch-monitor/lib/board-data.d.mts
@@ -444,12 +444,15 @@ export function derivePhaseWithRemediate(
   remediateSig: unknown | null | undefined
 ): BoardCurrentPhase;
 /** Build a thin Todo-column BoardTicket from an eligible queue entry (CTL-767).
- *  CTL-1152: optional teamRepoMap (from buildTeamRepoMap) for explicit repo resolution. */
+ *  CTL-1152: optional teamRepoMap (from buildTeamRepoMap) for explicit repo resolution.
+ *  CTL-1372: optional replicaTitles ({id→title} from the CTC replica) — preferred
+ *  over the eligible projection's title, consistent with worker-dir cards. */
 export function synthesizeQueuedTicket(
   eligible: unknown,
   linfo: Record<string, unknown>,
   relationBlockerMap?: Map<string, unknown>,
   teamRepoMap?: Record<string, string>,
+  replicaTitles?: Record<string, string>,
 ): BoardTicket;
 /** CTL-1152: PURE prefix→short-repo-name map from catalyst.monitor.linear.teams[].
  *  Maps each {key,vcsRepo} to UPPERCASE-key → lowercased basename; skips entries
@@ -465,24 +468,28 @@ export function repoForWith(map: Record<string, string>, ticket: string): string
 /** CTL-1152: a ticket's team prefix, verbatim (e.g. "CTL-1152" → "CTL"). */
 export function teamFor(ticket: string): string;
 /** CTL-1041: resolve a ticket's display TITLE (the outcome line — leads on every
- *  surface). Priority: explicit triage.title → the authoritative Linear title
- *  (linfo, then the eligible projection) → triage.summary (last-ditch) → the
- *  ticket key. NEVER lets the triage summary (a description) stand in for a real
- *  Linear title. */
+ *  surface). Priority: explicit triage.title → CTL-1372 the CTC replica title
+ *  (catalyst-replica.db — the complete Linear title that fixes parked tickets) →
+ *  the existing durable caches (linfo, then the eligible projection) →
+ *  triage.summary (last-ditch) → the ticket key. NEVER lets the triage summary (a
+ *  description) stand in for a real Linear title. */
 export function ticketTitle(
   ticket: string,
   triage: { title?: string | null; summary?: string | null } | null | undefined,
   eligibleIndex: Record<string, { title?: string | null } | undefined>,
-  linfo?: Record<string, { title?: string | null } | undefined>
+  linfo?: Record<string, { title?: string | null } | undefined>,
+  replicaTitles?: Record<string, string | null | undefined>
 ): string;
-/** CTL-1046: board IDs whose title is null in BOTH sources ticketTitle() consults
- *  (durable linfo cache + eligible projection) — i.e. cross-team (ADV) records that
- *  reach the payload via ticket_state (no title column) with no eligible entry.
- *  De-duped, order preserved. */
+/** CTL-1046: board IDs whose title is null in EVERY source ticketTitle() consults
+ *  (durable linfo cache + eligible projection + CTL-1372 the CTC replica) — i.e.
+ *  cross-team (ADV) records that reach the payload via ticket_state (no title
+ *  column) with no eligible entry and no replica hit. A replica HIT skips the
+ *  on-demand fetch. De-duped, order preserved. */
 export function collectNullTitleIds(
   boardIds: string[],
   linfo?: Record<string, { title?: string | null } | undefined>,
-  eligibleIndex?: Record<string, { title?: string | null } | undefined>
+  eligibleIndex?: Record<string, { title?: string | null } | undefined>,
+  replicaTitles?: Record<string, string | null | undefined>
 ): string[];
 /** CTL-1046: merge fetched Linear titles into linfo in-place (creates a linfo entry
  *  for eligible-only tickets). A null fetched title is left untouched (honest null).

--- a/plugins/dev/scripts/orch-monitor/lib/board-data.mjs
+++ b/plugins/dev/scripts/orch-monitor/lib/board-data.mjs
@@ -22,7 +22,7 @@ import { readFile, readdir, stat } from "node:fs/promises";
 import { homedir } from "node:os";
 import { join, dirname, basename } from "node:path";
 import { promisify } from "node:util";
-import { readLinearCache, readParkedNeedsHumanTickets } from "./linear-cache-reader.mjs";
+import { readLinearCache, readParkedNeedsHumanTickets, readReplicaTitles } from "./linear-cache-reader.mjs";
 import { fillEstimateFallback, getEstimationMethodAsync } from "./linear-estimate-fallback.mjs";
 // CTL-1046: supplemental Linear-title fallback for cross-team (e.g. ADV) records.
 // CTL records carry their title via the eligible projection (eligible/CTL.json),
@@ -288,11 +288,18 @@ export const PHASE_TO_LINEAR = {
 // synthesizeQueuedTicket — build a thin BoardTicket from an eligible queue entry
 // so it renders in the "Todo" Kanban column (CTL-767). All agent/cost/phase-summary
 // fields default to null / empty since there is no worker dir for these tickets.
-export function synthesizeQueuedTicket(e, linfo, relationBlockerMap = new Map(), teamRepoMap = {}) {
+export function synthesizeQueuedTicket(e, linfo, relationBlockerMap = new Map(), teamRepoMap = {}, replicaTitles = {}) {
   const li = linfo[e.id] ?? {};
+  // CTL-1372: prefer the CTC replica's complete Linear title over the eligible
+  // projection's (and the bare-id fallback) — keeps queued cards consistent with
+  // the worker-dir cards' replica-first title resolution. Replica miss → e.title.
+  const replicaTitle =
+    typeof replicaTitles?.[e.id] === "string" && replicaTitles[e.id].length > 0
+      ? replicaTitles[e.id]
+      : null;
   return {
     id: e.id,
-    title: e.title || e.id,
+    title: replicaTitle || e.title || e.id,
     type: "task",
     repo: e.repo || repoForWith(teamRepoMap, e.id),
     team: e.team || teamFor(e.id),
@@ -1010,14 +1017,24 @@ export function deriveExplanation(phaseSigs) {
 // CTL-1041: the TITLE is the outcome line and must lead on every surface (slot
 // cards, inbox detail, holding rows). The triage `summary` is the DESCRIPTION
 // (e.g. "Live probe confirmed the unified event log…") and must NEVER stand in
-// for the title — leading with it is the CTL-1041 bug. Priority:
+// for the title — leading with it is the CTL-1041 bug.
+//
+// CTL-1372: the durable title chain. filter-state.db ticket_state has NO title
+// column, and a PARKED ticket has no eligible row, so the local caches alone
+// resolve a parked card to its bare id ("CTL-1214"). The CTC replica
+// (catalyst-replica.db) carries every Linear title, so it slots in as the
+// authoritative source right after the triage-recorded title. Priority:
 //   1. an explicit triage.title (a real title the triage pass recorded),
-//   2. the authoritative Linear title (durable cache via linfo, else the
-//      eligible projection),
-//   3. only then the triage.summary (last-ditch when no Linear title exists),
-//   4. the ticket key itself.
-export function ticketTitle(ticket, triage, eligibleIndex, linfo = {}) {
+//   2. the CTC replica title (catalyst-replica.db — the complete Linear title;
+//      this is what fixes parked tickets),
+//   3. the existing durable caches (linfo, then the eligible projection — which
+//      also carries the on-demand Linear fetch merged in by mergeTitleFallback),
+//   4. only then the triage.summary (last-ditch when no title exists anywhere),
+//   5. the ticket key itself.
+export function ticketTitle(ticket, triage, eligibleIndex, linfo = {}, replicaTitles = {}) {
   if (triage?.title) return triage.title;
+  const replicaTitle = replicaTitles?.[ticket];
+  if (typeof replicaTitle === "string" && replicaTitle.length > 0) return replicaTitle;
   const linearTitle = linfo[ticket]?.title ?? eligibleIndex[ticket]?.title ?? null;
   if (linearTitle) return linearTitle;
   if (triage?.summary) return triage.summary;
@@ -1029,11 +1046,18 @@ export function ticketTitle(ticket, triage, eligibleIndex, linfo = {}) {
 // OR the eligible projection). CTL tickets carry their title via the eligible
 // projection; cross-team (ADV) records reach the payload only through ticket_state
 // (no title column) and have no eligible entry → both sources null → fetch needed.
+// CTL-1372: a replica HIT also counts as "present" — the replica is preferred over
+// the on-demand Linear fetch, so a replica-resolved title skips the API call
+// entirely (the on-demand fetch stays the LAST resort for replica MISSES only).
 // Returns a de-duped array (order preserved).
-export function collectNullTitleIds(boardIds, linfo = {}, eligibleIndex = {}) {
+export function collectNullTitleIds(boardIds, linfo = {}, eligibleIndex = {}, replicaTitles = {}) {
   return [
     ...new Set(
-      boardIds.filter((id) => (linfo[id]?.title ?? eligibleIndex[id]?.title ?? null) === null)
+      boardIds.filter((id) => {
+        const replicaTitle = replicaTitles?.[id];
+        if (typeof replicaTitle === "string" && replicaTitle.length > 0) return false;
+        return (linfo[id]?.title ?? eligibleIndex[id]?.title ?? null) === null;
+      })
     ),
   ];
 }
@@ -1285,7 +1309,11 @@ export function synthesizeOrphanTickets(orphanState, now) {
 // live/between/done + queued + orphan) so a ticket with a real card is NEVER
 // duplicated; a duplicate descriptor within the input is also deduped. Exported so
 // unit tests exercise it without the DB read; `now` is injected for the same reason.
-export function synthesizeParkedNeedsHumanTickets(parked, existingIds, now) {
+// CTL-1372: `replicaTitles` ({id→title} from the CTC replica) is the FIX for the
+// bare-id parked card — the parked descriptor (readParkedNeedsHumanTickets) carries
+// NO title, so without the replica these cards rendered as "CTL-1214". Replica miss
+// → p.title (always absent here) → the bare ticket id (honest last resort).
+export function synthesizeParkedNeedsHumanTickets(parked, existingIds, now, replicaTitles = {}) {
   if (!Array.isArray(parked)) return [];
   const seen = existingIds instanceof Set ? new Set(existingIds) : new Set(existingIds ?? []);
   const cards = [];
@@ -1299,9 +1327,13 @@ export function synthesizeParkedNeedsHumanTickets(parked, existingIds, now) {
       labels.includes(ATTENTION_LABEL_NEEDS_INPUT) && !labels.includes(ATTENTION_LABEL_NEEDS_HUMAN)
         ? "Parked — waiting on your input (needs-input)."
         : "Parked — escalated for a human (needs-human).";
+    const replicaTitle =
+      typeof replicaTitles?.[p.ticket] === "string" && replicaTitles[p.ticket].length > 0
+        ? replicaTitles[p.ticket]
+        : null;
     cards.push({
       id: p.ticket,
-      title: p.title || p.ticket,
+      title: replicaTitle || p.title || p.ticket,
       type: "parked-needs-human",
       repo: repoFor(p.ticket),
       team: teamFor(p.ticket),
@@ -1716,6 +1748,22 @@ export async function assembleBoard({ getPrStatus = null, ring = null } = {}) {
   // union of card sources, so a between-phases ticket still gets a BoardTicket.
   const cardTicketIds = new Set([...workers.map((w) => w.ticket), ...workerDirs]);
 
+  // CTL-1372: source authoritative ticket titles from the CTC replica
+  // (catalyst-replica.db). filter-state.db ticket_state has NO title column, and a
+  // PARKED ticket (worker dir torn down, no eligible row) has no other durable
+  // title source — so its card otherwise renders as the bare id ("CTL-1214"
+  // instead of "Slim .catalyst/config.json…"). ONE batched read resolves titles
+  // for every board id (worker-dir ∪ eligible ∪ parked) at once. FAIL-OPEN: a
+  // missing/unreadable replica → {} and the existing title chain (triage.title →
+  // linfo/eligible → on-demand fetch → id) is preserved unchanged.
+  const replicaTitles = await readReplicaTitles({
+    ids: [
+      ...cardTicketIds,
+      ...eligible.map((e) => e.id),
+      ...parkedNeedsHuman.map((p) => p.ticket),
+    ],
+  });
+
   // CTL-974: supplemental estimate fallback — tickets whose durable-cache estimate
   // is null may have an estimate set in Linear that the broker's webhook path has
   // not yet projected (old tickets pre-dating CTL-957, or tickets never touched by
@@ -1799,9 +1847,11 @@ export async function assembleBoard({ getPrStatus = null, ring = null } = {}) {
   // resolves to null here, so ticketTitle()'s honest summary/key fallback still runs.
   await (async () => {
     const allBoardIds = [...[...cardTicketIds], ...eligible.map((e) => e.id)];
-    // Only fetch titles for IDs that have NO title from either source the title
-    // resolver consults (durable linfo cache OR the eligible projection).
-    const nullTitleIds = collectNullTitleIds(allBoardIds, linfo, eligibleIndex);
+    // Only fetch titles for IDs that have NO title from any source the title
+    // resolver consults (durable linfo cache OR the eligible projection OR the CTC
+    // replica). CTL-1372: a replica HIT skips the on-demand Linear fetch entirely —
+    // the fetch is now the LAST resort, for replica MISSES only.
+    const nullTitleIds = collectNullTitleIds(allBoardIds, linfo, eligibleIndex, replicaTitles);
     if (nullTitleIds.length === 0) return;
 
     // Batch-fetch titles (and descriptions/labels/relations) for null-title IDs,
@@ -1873,7 +1923,7 @@ export async function assembleBoard({ getPrStatus = null, ring = null } = {}) {
       });
       return {
         id,
-        title: ticketTitle(id, triage, eligibleIndex, linfo),
+        title: ticketTitle(id, triage, eligibleIndex, linfo, replicaTitles),
         type: ticketType(triage),
         repo: repoFor(id),
         team: teamFor(id),
@@ -1995,7 +2045,7 @@ export async function assembleBoard({ getPrStatus = null, ring = null } = {}) {
   // ANY worker dir is already surfaced as live / between-phases above, so it is
   // excluded here (cardTicketIds) — it is accounted for, not duplicated.
   const notInFlight = eligible.filter((e) => !cardTicketIds.has(e.id));
-  const queuedTickets = notInFlight.map((e) => synthesizeQueuedTicket(e, linfo, relationBlockerMap, TEAM_REPO));
+  const queuedTickets = notInFlight.map((e) => synthesizeQueuedTicket(e, linfo, relationBlockerMap, TEAM_REPO, replicaTitles));
   tickets = [...liveTickets, ...betweenPhases, ...recentDone, ...queuedTickets];
 
   // CTL-1175: orphan-PR Needs-You rows. Synthetic cards (no worker dir, never in
@@ -2013,7 +2063,7 @@ export async function assembleBoard({ getPrStatus = null, ring = null } = {}) {
   // per parked ticket NOT already carded. Deduped against every existing card id;
   // terminal/removed excluded by the reader; fail-open ([] on a db read error).
   const existingCardIds = new Set(tickets.map((t) => t.id));
-  const parkedTickets = synthesizeParkedNeedsHumanTickets(parkedNeedsHuman, existingCardIds, now);
+  const parkedTickets = synthesizeParkedNeedsHumanTickets(parkedNeedsHuman, existingCardIds, now, replicaTitles);
   tickets = [...tickets, ...parkedTickets];
 
   // priority queue: eligible (not yet in-flight), globally ranked (Queue tab)

--- a/plugins/dev/scripts/orch-monitor/lib/linear-cache-reader.d.mts
+++ b/plugins/dev/scripts/orch-monitor/lib/linear-cache-reader.d.mts
@@ -62,3 +62,29 @@ export interface ReadLinearCacheOptions {
 }
 
 export function readLinearCache(opts?: ReadLinearCacheOptions): Promise<LinearCacheById>;
+
+/** CTL-1372: a batched replica title reader — `factory({dbPath})` returns an object
+ *  whose `titles(ids)` yields an { identifier → title } map of HITS only. Injected
+ *  in tests so the contract is driven offline (no real catalyst-replica.db). */
+export interface ReplicaTitleReader {
+  titles(ids: string[]): Record<string, string>;
+  close?: () => void;
+}
+
+export interface ReadReplicaTitlesOptions {
+  /** Board ticket ids to resolve titles for (de-duped; empty/falsy skipped). */
+  ids?: string[];
+  /** Replica DB path; defaults to CATALYST_REPLICA_DB || ~/catalyst/catalyst-replica.db. */
+  dbPath?: string;
+  /** Test seam: a `factory({dbPath})` → ReplicaTitleReader. When set, the
+   *  file-presence gate is skipped (the injected reader IS the DB). */
+  readerFactory?: ((opts: { dbPath: string }) => ReplicaTitleReader) | null;
+}
+
+/** CTL-1372: source authoritative ticket titles from the CTC replica
+ *  (catalyst-replica.db) — the durable source that fixes PARKED tickets
+ *  (filter-state.db ticket_state has no title column). Gates on FILE PRESENCE only
+ *  (NOT the dispatch-side catalyst.linearReplica.mode flag — the board is a
+ *  read-only display) and is FAIL-OPEN: any error returns {} so the existing title
+ *  chain is preserved. Returns { identifier → title } of HITS only. Never throws. */
+export function readReplicaTitles(opts?: ReadReplicaTitlesOptions): Promise<Record<string, string>>;

--- a/plugins/dev/scripts/orch-monitor/lib/linear-cache-reader.mjs
+++ b/plugins/dev/scripts/orch-monitor/lib/linear-cache-reader.mjs
@@ -28,18 +28,36 @@
 // module ever blocking on a refresh.
 
 import { readFile, readdir } from "node:fs/promises";
+import { existsSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
 
 const HOME = homedir();
 const DEFAULT_DB_PATH = join(HOME, "catalyst", "filter-state.db");
 const DEFAULT_ELIGIBLE_DIR = join(HOME, "catalyst", "execution-core", "eligible");
+// CTL-1372: the CTC replica (catalyst-replica.db) — the SDK's live Linear mirror,
+// the only durable source that carries every ticket's title. CATALYST_REPLICA_DB
+// overrides (mirrors getReplicaDbPath in execution-core/config.mjs), default
+// ~/catalyst/catalyst-replica.db. Resolved per call so a test env override works.
+const DEFAULT_REPLICA_DB_PATH = join(HOME, "catalyst", "catalyst-replica.db");
 
 // broker-state.mjs carries a top-level `import { Database } from "bun:sqlite"`.
 // We reach it ONLY through the lazy `import()` in readTicketStateById, but the
 // specifier MUST be computed (not a string literal) — see the long note there.
 // Kept as a module constant so the path lives in one place and reads cleanly.
 const BROKER_STATE_MODULE = ["..", "..", "broker", "broker-state.mjs"].join("/");
+
+// CTL-1372: execution-core/replica-read.mjs ALSO carries a top-level
+// `import { Database } from "bun:sqlite"`, so it is reached ONLY through the same
+// computed-specifier lazy `import()` (never a string literal) for the exact reason
+// BROKER_STATE_MODULE is — board-data.mjs statically imports THIS module, and
+// ui/vite.config.ts statically imports board-data.mjs; a literal
+// `import("../../execution-core/replica-read.mjs")` would let esbuild follow the
+// relative graph and pull bun:sqlite into the Node-evaluated vite config bundle,
+// which throws ERR_UNSUPPORTED_ESM_URL_SCHEME on `bun:` and breaks `vite build`
+// (the monitor's deploy path; the CTL-1561 trap). The computed specifier stays an
+// opaque runtime `import()` esbuild can't follow. DO NOT inline this to a literal.
+const REPLICA_READ_MODULE = ["..", "..", "execution-core", "replica-read.mjs"].join("/");
 
 // Normalize a stored ticket_state descriptor priority to the 0..4 Linear scale.
 // ticket_state stores it as an INTEGER (0 = no priority, 1 = urgent .. 4 = low);
@@ -179,6 +197,68 @@ export async function readParkedNeedsHumanTickets({
     });
   }
   return out;
+}
+
+// ── CTC replica titles (CTL-1372) ───────────────────────────────────────────
+// readReplicaTitles — the board's authoritative TITLE source. filter-state.db
+// ticket_state has NO title column, and a PARKED ticket (worker dir torn down, no
+// eligible row) has no other durable title source — so its board card otherwise
+// renders as the bare id (e.g. "CTL-1214" instead of "Slim .catalyst/config.json…").
+// The CTC replica (catalyst-replica.db) is the SDK's live Linear mirror and carries
+// every title, so one BATCHED read over the board's ids resolves them all.
+//
+// GATING + FAIL-OPEN (board posture, NOT the dispatch path): the board is a
+// read-only display, so this gates on FILE PRESENCE only — it does NOT consult the
+// dispatch-side catalyst.linearReplica.mode flag (that flag governs the daemon's
+// hot terminal-check, a correctness path; a display read has no such risk). When the
+// replica is present it is used; ANY failure (absent file, unreadable, bad schema,
+// lock) returns {} so the existing title chain (triage.title → linfo/eligible →
+// on-demand fetch → id) is preserved EXACTLY. The board must never break or hang on
+// the replica.
+//
+// The replica module (execution-core/replica-read.mjs) carries a top-level
+// bun:sqlite import and is reached ONLY through the computed REPLICA_READ_MODULE
+// specifier — same vite-graph trap-avoidance as readTicketStateById's
+// BROKER_STATE_MODULE. `readerFactory` is injectable so unit tests drive the
+// {id→title} contract offline (no real DB); when injected, the file-presence gate
+// is skipped (the fake reader IS the DB).
+//
+// Returns { [identifier]: title } of HITS only (a miss is simply absent → caller
+// falls through). Never throws.
+export async function readReplicaTitles({
+  ids = [],
+  dbPath = process.env.CATALYST_REPLICA_DB || DEFAULT_REPLICA_DB_PATH,
+  readerFactory = null,
+} = {}) {
+  const wanted = [...new Set((Array.isArray(ids) ? ids : []).filter(Boolean))];
+  if (wanted.length === 0) return {};
+  // File-presence gate (skipped when a test injects a reader). When the replica
+  // isn't on this node, go straight to the existing chain — never open/throw.
+  if (!readerFactory) {
+    try {
+      if (!existsSync(dbPath)) return {};
+    } catch {
+      return {};
+    }
+  }
+  let reader = null;
+  try {
+    let factory = readerFactory;
+    if (!factory) {
+      ({ createReplicaReader: factory } = await import(REPLICA_READ_MODULE));
+    }
+    reader = factory({ dbPath });
+    const titles = reader.titles(wanted);
+    return titles && typeof titles === "object" ? titles : {};
+  } catch {
+    return {}; // any failure → fail-open to the existing title chain
+  } finally {
+    try {
+      reader?.close?.();
+    } catch {
+      /* already closed */
+    }
+  }
 }
 
 // Read the scheduler's eligible projections for priority/project/relations on


### PR DESCRIPTION
## Problem (live-diagnosed)

The Tickets board renders the orchestration skeleton (id, Linear stage, queued/escalated/held labels, idle time) but showed the **bare ticket id** as the title for PARKED tickets — e.g. `CTL-1214` instead of "Slim .catalyst/config.json…".

Root cause: **`filter-state.db` `ticket_state` has no `title` column** (only orchestration fields). `board-data.mjs::ticketTitle()` resolved `triage.json` title → `linfo[ticket].title` (the filter-state.db Linear cache — always `null`, no title col) → `eligibleIndex[ticket].title` → an on-demand Linear fetch (currently degraded) → finally the id. Recently-triaged tickets show a title (worker-dir `triage.title`); **parked tickets** — whose worker dir was torn down and which have no eligible row — hit none of those and fell through to the id. The parked-card builder `synthesizeParkedNeedsHumanTickets()` was even more direct: its descriptor carries **no title field at all**, so `title: p.title || p.ticket` always rendered the bare id.

## Fix — a CTC-replica TITLE tier

Source titles from the **CTC replica** (`catalyst-replica.db`, the SDK's live Linear mirror), whose `issues` table has `identifier + title` for every ticket (already populated on the nodes, ~2.7k rows).

- **`replica-read.mjs`** (CTL-1340 client) gains a batched `titles(ids)` method: one index-backed, chunked `SELECT identifier, title FROM issues WHERE identifier IN (...) AND removed_at IS NULL` → `{ id → title }` of HITS only. Same fail-open contract as `lookup()`/`freshness()`.
- **`linear-cache-reader.mjs`** gains a board-side `readReplicaTitles()` accessor that reads it batched.
- **`board-data.mjs`** reads the replica titles **once** for every board id (worker-dir ∪ eligible ∪ parked) and threads the map through `ticketTitle()`, `collectNullTitleIds()`, `synthesizeParkedNeedsHumanTickets()` (the bare-id repro), and `synthesizeQueuedTicket()`.

### Final precedence chain

```
triage.title
  → catalyst-replica.db title        (authoritative complete Linear title — fixes parked tickets)
  → linfo (filter-state.db ticket_state)  → eligible projection
  → on-demand Linear fetch           (replica MISS only — collectNullTitleIds is replica-aware)
  → triage.summary
  → ticket id
```

## Fail-open / back-compat guarantee

The board is a **read-only display**, so `readReplicaTitles` gates on **file presence only** — it does NOT consult the dispatch-side `catalyst.linearReplica.mode` flag (that flag governs the daemon's hot terminal-check, a correctness path; a display read has no such risk). **Any** replica error — missing file, unreadable, bad schema, lock — returns `{}` and every existing title path resolves exactly as before. The board never breaks or hangs when the replica is absent.

## bun:sqlite computed-import note

`replica-read.mjs` carries a top-level `import { Database } from "bun:sqlite"`. `board-data.mjs` is statically imported by `ui/vite.config.ts`, and esbuild follows **literal** relative dynamic imports — so a literal `import("../../execution-core/replica-read.mjs")` would pull `bun:sqlite` into the Node-evaluated vite config bundle and throw `ERR_UNSUPPORTED_ESM_URL_SCHEME 'bun:'` (the CTL-1561 trap). `readReplicaTitles` reaches the module **only through a COMPUTED specifier** (`REPLICA_READ_MODULE = [..].join("/")`) + lazy `import()` — exactly mirroring `readTicketStateById`'s `BROKER_STATE_MODULE` and `readParkedNeedsHumanTickets`. **`bun run build` passes with no `bun:` scheme in the graph.**

## Tests (offline — injected fake reader, no real DB)

- `replica-read.test.mjs`: batched `titles()` returns the right map; the parked repro (`CTL-1214` → real title); omits absent/tombstoned/null-title rows; de-dupe; >400-id chunking; fail-open on missing db / missing table.
- `linear-cache-reader.test.ts`: replica title used when present; de-dupe + handle-close; empty ids → no reader call; fail-OPEN on reader throw; file-presence gate on an absent path.
- `board-replica-title.test.ts`: `ticketTitle` replica tier (replica beats linfo/eligible, triage.title still wins, empty-string ignored, back-compat 4-arg); `collectNullTitleIds` replica-aware (HIT skips fetch, MISS still flagged); `synthesizeParkedNeedsHumanTickets`/`synthesizeQueuedTicket` render the replica title and fall back honestly.
- Existing triage/eligible title resolution unchanged.

## Validation

- `bun test` (replica reader + title/board files): all green.
- `tsc --noEmit`: clean. `eslint .`: 0 errors. `knip`: 0 unused.
- `bun run build` (monitor vite build): passes, **no `bun:sqlite` in the graph**.
- Reward-hacking scan of the diff: clean (no `as any` / `as unknown as` / `@ts-ignore` / non-null assertions in source).

> One unrelated pre-existing failure (`GET /api/nav` "empty fleet" `anomaly`) reproduces with this code path neutralized (`CATALYST_REPLICA_DB=/nonexistent`) — it stems from `readParkedNeedsHumanTickets` reading the homedir `filter-state.db` rather than the test's injected temp dir, independent of this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)