### PR TITLE
feat(dev): CTL-1368 — catalyst.node.class as a core fleet-wide resource dimension

### DIFF
--- a/.github/workflows/execution-core-tests.yml
+++ b/.github/workflows/execution-core-tests.yml
@@ -223,6 +223,8 @@ jobs:
             recovery-reasoning.test.mjs \
             recovery-evidence.test.mjs \
             unstuck-act-seams.test.mjs \
+            lib/catalyst-resource.test.mjs \
+            lib/node-class-parity.test.mjs \
             updater/plugin-pull-defer.test.mjs \
             updater/updater.test.mjs \
             updater/updater-tracing.test.mjs

--- a/plugins/dev/references/event-schema.md
+++ b/plugins/dev/references/event-schema.md
@@ -34,7 +34,8 @@ Every event in `~/catalyst/events/YYYY-MM.jsonl` has this shape. One canonical e
   "resource": {
     "service.name": "catalyst.github",
     "service.namespace": "catalyst",
-    "service.version": "8.2.0"
+    "service.version": "8.2.0",
+    "catalyst.node.class": "worker"
   },
   "attributes": {
     "event.name": "github.pr.merged",
@@ -99,6 +100,14 @@ hostile for jq. The sidecar (CTL-306) handles that translation mechanically.
 | `catalyst.orchestrator` | Bash (`catalyst-state.sh`, `emit-worker-status-change.sh`) |
 | `catalyst.comms` | Bash (`catalyst-comms`) |
 | `catalyst.broker` | Bash/daemon (`broker/index.mjs`) — see [[broker]]. Supersedes legacy `catalyst.filter` producer (CTL-303). |
+
+`resource."catalyst.node.class"` (CTL-1368) is the node's ROLE — one of `developer`, `worker`,
+or `monitor` — orthogonal to `host.name`/`host.id` (WHICH machine). It is stamped last in the
+resource block by the shared `buildCatalystResource()` builder, defaulting to `worker` when
+`catalyst.node.class` is unset in Layer-2 config (and overridable via the `CATALYST_NODE_CLASS`
+env var). Low-cardinality, so the OTEL collector surfaces it as a fleet-wide `node_class`
+dashboard dimension. It is optional: external (webhook / broker-daemon) events that build a bare
+resource block may omit it.
 
 ---
 
@@ -257,7 +266,8 @@ one-time migration, already complete on any installation that ran CTL-300.
   "resource": {
     "service.name": "catalyst.github",
     "service.namespace": "catalyst",
-    "service.version": "8.2.0"
+    "service.version": "8.2.0",
+    "catalyst.node.class": "worker"
   },
   "attributes": {
     "event.name": "github.pr.merged",
@@ -299,7 +309,8 @@ absent and the consumer must check `body.payload.prNumbers`. Use:
   "resource": {
     "service.name": "catalyst.linear",
     "service.namespace": "catalyst",
-    "service.version": "8.2.0"
+    "service.version": "8.2.0",
+    "catalyst.node.class": "worker"
   },
   "attributes": {
     "event.name": "linear.issue.state_changed",
@@ -338,7 +349,8 @@ Update topic selection: `stateId` → `state_changed`; `priority` → `priority_
   "resource": {
     "service.name": "catalyst.session",
     "service.namespace": "catalyst",
-    "service.version": "8.2.0"
+    "service.version": "8.2.0",
+    "catalyst.node.class": "worker"
   },
   "attributes": {
     "event.name": "session.phase",
@@ -380,7 +392,8 @@ mirrors the `to` state so HUD/filter can check it without descending into payloa
   "resource": {
     "service.name": "catalyst.orchestrator",
     "service.namespace": "catalyst",
-    "service.version": "8.2.0"
+    "service.version": "8.2.0",
+    "catalyst.node.class": "worker"
   },
   "attributes": {
     "event.name": "orchestrator.worker.status_terminal",
@@ -415,7 +428,8 @@ Normal posted message (`severityText: "INFO"`):
   "resource": {
     "service.name": "catalyst.comms",
     "service.namespace": "catalyst",
-    "service.version": "8.2.0"
+    "service.version": "8.2.0",
+    "catalyst.node.class": "worker"
   },
   "attributes": {
     "event.name": "comms.message.posted",
@@ -468,7 +482,8 @@ Filters that previously matched `.event == "filter.wake.${id}"` now match:
   "resource": {
     "service.name": "catalyst.filter",
     "service.namespace": "catalyst",
-    "service.version": "8.2.0"
+    "service.version": "8.2.0",
+    "catalyst.node.class": "worker"
   },
   "attributes": {
     "event.name": "filter.wake",
@@ -509,7 +524,8 @@ the event — it's metadata stamped at write time.
   "resource": {
     "service.name": "catalyst.orchestrator",
     "service.namespace": "catalyst",
-    "service.version": "9.3.0"
+    "service.version": "9.3.0",
+    "catalyst.node.class": "worker"
   },
   "attributes": {
     "event.name": "worker.state_changed",

--- a/plugins/dev/references/event-schema.md
+++ b/plugins/dev/references/event-schema.md
@@ -103,11 +103,15 @@ hostile for jq. The sidecar (CTL-306) handles that translation mechanically.
 
 `resource."catalyst.node.class"` (CTL-1368) is the node's ROLE — one of `developer`, `worker`,
 or `monitor` — orthogonal to `host.name`/`host.id` (WHICH machine). It is stamped last in the
-resource block by the shared `buildCatalystResource()` builder, defaulting to `worker` when
-`catalyst.node.class` is unset in Layer-2 config (and overridable via the `CATALYST_NODE_CLASS`
-env var). Low-cardinality, so the OTEL collector surfaces it as a fleet-wide `node_class`
-dashboard dimension. It is optional: external (webhook / broker-daemon) events that build a bare
-resource block may omit it.
+resource block by the canonical builder in EACH runtime — MJS `buildCatalystResource()`
+(`execution-core/lib/catalyst-resource.mjs`), the TS twin (`orch-monitor/lib/canonical-event-shared.ts`),
+and Bash `lib/canonical-event.sh` (via `catalyst_node_class`, which the Bash producers above —
+`catalyst-session.sh`, `catalyst-state.sh`, `catalyst-comms`, the phase-agent emitters — all
+route through). It defaults to `worker` when `catalyst.node.class` is unset in Layer-2 config
+(and is overridable via the `CATALYST_NODE_CLASS` env var); an unrecognized explicit value
+degrades to `monitor`. Low-cardinality, so the OTEL collector surfaces it as a fleet-wide
+`node_class` dashboard dimension. It remains optional in the schema: a few direct emitters that
+build a bare resource block (e.g. some webhook paths) may still omit it.
 
 ---
 

--- a/plugins/dev/scripts/__tests__/canonical-event.test.sh
+++ b/plugins/dev/scripts/__tests__/canonical-event.test.sh
@@ -156,6 +156,13 @@ LINE="$(build_canonical_line \
 EVENT_NAME="$(echo "$LINE" | jq -r '.attributes."event.name"')"
 expect_eq "build_canonical_line event.name" "session.phase" "$EVENT_NAME"
 
+# CTL-1368: every canonical line carries the node-class core dimension (a valid role)
+NODE_CLASS_OUT="$(echo "$LINE" | jq -r '.resource."catalyst.node.class"')"
+case "$NODE_CLASS_OUT" in
+  developer|worker|monitor) ok "build_canonical_line catalyst.node.class present ($NODE_CLASS_OUT)" ;;
+  *) fail "build_canonical_line catalyst.node.class" "got '$NODE_CLASS_OUT' (expected developer|worker|monitor)" ;;
+esac
+
 # build_canonical_line emits top-level id (CTL-344)
 ID_OUT="$(echo "$LINE" | jq -r '.id')"
 if [[ -n "$ID_OUT" && "$ID_OUT" != "null" && ${#ID_OUT} -ge 16 ]]; then

--- a/plugins/dev/scripts/broker/alert-emit.mjs
+++ b/plugins/dev/scripts/broker/alert-emit.mjs
@@ -18,8 +18,7 @@ import { dirname } from "node:path";
 import {
   generateEventId,
   severityNumber,
-  hostName,
-  hostId,
+  buildCatalystResource,
 } from "../orch-monitor/lib/canonical-event-shared.ts";
 import { getEventLogPath, log } from "./config.mjs";
 
@@ -78,13 +77,8 @@ export function buildAlertEnvelope(
     traceId: null,
     spanId: null,
     caused_by: causedBy ?? null,
-    resource: {
-      // the broker is the emitter — the surviving process that raised the alert.
-      "service.name": "catalyst.broker",
-      "service.namespace": "catalyst",
-      "host.name": hostName(),
-      "host.id": hostId(),
-    },
+    // the broker is the emitter — the surviving process that raised the alert.
+    resource: buildCatalystResource({ serviceName: "catalyst.broker" }),
     attributes: {
       "event.name": eventName,
       "event.entity": "alert",

--- a/plugins/dev/scripts/broker/ingestion-recency.mjs
+++ b/plugins/dev/scripts/broker/ingestion-recency.mjs
@@ -30,8 +30,7 @@ import { dirname } from "node:path";
 import {
   generateEventId,
   severityNumber,
-  hostName,
-  hostId,
+  buildCatalystResource,
 } from "../orch-monitor/lib/canonical-event-shared.ts";
 import { getEventLogPath, log } from "./config.mjs";
 
@@ -97,15 +96,10 @@ export function buildIngestionRecencyEnvelope(
     // (for stale, the final heartbeat before silence; for recovered, the fresh
     // beat that cleared it). null when the source was never observed.
     caused_by: causedBy ?? null,
-    resource: {
-      // The broker is the emitter — the host that OBSERVED the silence. Matches
-      // every other broker emission so the monitor composes the per-host stream
-      // identically.
-      "service.name": "catalyst.broker",
-      "service.namespace": "catalyst",
-      "host.name": hostName(),
-      "host.id": hostId(),
-    },
+    // The broker is the emitter — the host that OBSERVED the silence. Matches
+    // every other broker emission so the monitor composes the per-host stream
+    // identically.
+    resource: buildCatalystResource({ serviceName: "catalyst.broker" }),
     attributes: {
       "event.name": eventName,
       "event.entity": "ingestion",

--- a/plugins/dev/scripts/broker/router.mjs
+++ b/plugins/dev/scripts/broker/router.mjs
@@ -98,8 +98,7 @@ import {
   deriveSpanId,
   generateEventId,
   synthesizeEventId,
-  hostName,
-  hostId,
+  buildCatalystResource,
 } from "../orch-monitor/lib/canonical-event-shared.ts";
 import {
   PHASE_EVENT_PATTERN as _PHASE_EVENT_PATTERN,
@@ -321,13 +320,10 @@ export function buildCanonicalEnvelope(legacy) {
       (Array.isArray(legacy.detail?.source_event_ids)
         ? legacy.detail.source_event_ids[0] ?? null
         : null),
-    resource: {
-      "service.name": "catalyst.broker",
-      "service.namespace": "catalyst",
-      "service.version": pluginVersion(),
-      "host.name": hostName(),
-      "host.id": hostId(),
-    },
+    resource: buildCatalystResource({
+      serviceName: "catalyst.broker",
+      serviceVersion: pluginVersion(),
+    }),
     attributes,
     body: { payload: legacy.detail ?? null },
   };

--- a/plugins/dev/scripts/catalyst-agent/emit.mjs
+++ b/plugins/dev/scripts/catalyst-agent/emit.mjs
@@ -25,6 +25,7 @@ import { dirname } from "node:path";
 import { randomBytes } from "node:crypto";
 import { hostname } from "node:os";
 import { hostName, hostId } from "../execution-core/lib/host-identity.mjs";
+import { nodeClass } from "../execution-core/lib/node-class.mjs";
 import { serviceVersion } from "./build-info.mjs";
 
 // shortHostname — os.hostname() with the macOS-appended ".local" suffix
@@ -85,6 +86,7 @@ export function buildAgentEnvelope(name, { entity, label, attrs = {}, payload = 
       hostname: shortHostname(),
       "host.name": hostName(),
       "host.id": hostId(),
+      "catalyst.node.class": nodeClass(),
     },
     body: { payload },
     attributes,
@@ -302,6 +304,7 @@ export function metricResource() {
     hostname: shortHostname(),
     "host.name": hostName(),
     "host.id": hostId(),
+    "catalyst.node.class": nodeClass(),
   };
   // CTL-1235: stamp the running semver (OTel semconv `service.version`) on the
   // shared metric resource so EVERY agent metric can be grouped/filtered by the

--- a/plugins/dev/scripts/execution-core/boot-event.mjs
+++ b/plugins/dev/scripts/execution-core/boot-event.mjs
@@ -7,6 +7,7 @@ import { fileURLToPath } from "node:url";
 import {
   getEventLogPath, getHostName, log, readGovernanceConfig, readGovernanceSources,
 } from "./config.mjs";
+import { nodeClass } from "./lib/node-class.mjs";
 
 const __dir = dirname(fileURLToPath(import.meta.url));
 // plugins/dev/scripts/execution-core/ → plugins/dev/scripts/ → plugins/dev/
@@ -30,7 +31,9 @@ export function buildBootEnvelope({
   return {
     ts,
     attributes: { "event.name": "node.boot" },
-    resource: { "host.name": host },
+    // node.boot keeps its minimal resource (just host.name) but stamps the core
+    // catalyst.node.class dimension like every other signal (CTL-1368).
+    resource: { "host.name": host, "catalyst.node.class": nodeClass() },
     body: {
       payload: {
         "host.name": host,

--- a/plugins/dev/scripts/execution-core/capacity-event.mjs
+++ b/plugins/dev/scripts/execution-core/capacity-event.mjs
@@ -7,7 +7,7 @@ import { mkdirSync, appendFileSync } from "node:fs";
 import { dirname } from "node:path";
 import { randomBytes } from "node:crypto";
 import { getEventLogPath, getHostName, log } from "./config.mjs";
-import { hostName, hostId } from "./lib/host-identity.mjs";
+import { buildCatalystResource } from "./lib/catalyst-resource.mjs";
 
 export const CAPACITY_CHANGED_EVENT = "node.capacity.changed";
 
@@ -25,12 +25,7 @@ export function buildCapacityChangedEnvelope({ oldMaxParallel, newMaxParallel, r
     severityNumber: 9,
     traceId: null,
     spanId: null,
-    resource: {
-      "service.name": "catalyst.execution-core",
-      "service.namespace": "catalyst",
-      "host.name": hostName(),
-      "host.id": hostId(),
-    },
+    resource: buildCatalystResource({ serviceName: "catalyst.execution-core" }),
     attributes: {
       "event.name": CAPACITY_CHANGED_EVENT,
       "event.entity": "node",

--- a/plugins/dev/scripts/execution-core/drain-event.mjs
+++ b/plugins/dev/scripts/execution-core/drain-event.mjs
@@ -12,7 +12,7 @@ import { mkdirSync, appendFileSync } from "node:fs";
 import { dirname } from "node:path";
 import { randomBytes } from "node:crypto";
 import { getEventLogPath, getHostName, log } from "./config.mjs";
-import { hostName, hostId } from "./lib/host-identity.mjs";
+import { buildCatalystResource } from "./lib/catalyst-resource.mjs";
 
 export const DRAIN_CHANGED_EVENT = "node.drain.changed";
 export const DRAINED_EVENT = "node.drain.drained";
@@ -31,12 +31,7 @@ export function buildDrainChangedEnvelope({ draining, inFlightCount, now } = {})
     severityNumber: 9,
     traceId: null,
     spanId: null,
-    resource: {
-      "service.name": "catalyst.execution-core",
-      "service.namespace": "catalyst",
-      "host.name": hostName(),
-      "host.id": hostId(),
-    },
+    resource: buildCatalystResource({ serviceName: "catalyst.execution-core" }),
     attributes: {
       "event.name": DRAIN_CHANGED_EVENT,
       "event.entity": "node",
@@ -67,12 +62,7 @@ export function buildDrainedEnvelope({ inFlightCount = 0, now } = {}) {
     severityNumber: 9,
     traceId: null,
     spanId: null,
-    resource: {
-      "service.name": "catalyst.execution-core",
-      "service.namespace": "catalyst",
-      "host.name": hostName(),
-      "host.id": hostId(),
-    },
+    resource: buildCatalystResource({ serviceName: "catalyst.execution-core" }),
     attributes: {
       "event.name": DRAINED_EVENT,
       "event.entity": "node",

--- a/plugins/dev/scripts/execution-core/fleet-health-event.mjs
+++ b/plugins/dev/scripts/execution-core/fleet-health-event.mjs
@@ -17,7 +17,7 @@ import { mkdirSync, appendFileSync } from "node:fs";
 import { dirname } from "node:path";
 import { randomBytes } from "node:crypto";
 import { getEventLogPath, log } from "./config.mjs";
-import { hostName, hostId } from "./lib/host-identity.mjs";
+import { buildCatalystResource } from "./lib/catalyst-resource.mjs";
 
 export const FLEET_HEALTH_DEGRADED = "fleet.health.degraded";
 
@@ -49,12 +49,7 @@ export function buildFleetHealthEnvelope(payload = {}, { now } = {}) {
     severityNumber: 13,
     traceId: null,
     spanId: null,
-    resource: {
-      "service.name": "catalyst.execution-core",
-      "service.namespace": "catalyst",
-      "host.name": hostName(),
-      "host.id": hostId(),
-    },
+    resource: buildCatalystResource({ serviceName: "catalyst.execution-core" }),
     attributes: {
       "event.name": FLEET_HEALTH_DEGRADED,
       "event.entity": "fleet",

--- a/plugins/dev/scripts/execution-core/heartbeat-event.mjs
+++ b/plugins/dev/scripts/execution-core/heartbeat-event.mjs
@@ -23,7 +23,7 @@ import {
   log,
   readGovernanceConfig,
 } from "./config.mjs";
-import { hostName, hostId } from "./lib/host-identity.mjs";
+import { buildCatalystResource } from "./lib/catalyst-resource.mjs";
 import { logDaemonHeartbeat } from "../lib/daemon-heartbeat.mjs";
 
 export const HEARTBEAT_EVENT = "node.heartbeat";
@@ -64,15 +64,7 @@ export function buildHeartbeatEnvelope({ now, epochFn, governanceFn, admissionFn
     severityNumber: 9,
     traceId: null,
     spanId: null,
-    resource: {
-      "service.name": "catalyst.execution-core",
-      "service.namespace": "catalyst",
-      // CTL-1093 Phase 2: pass the config-aware name as override so resource
-      // and body.payload["host.name"] always agree, even when Layer-2 is pinned
-      // but CATALYST_HOST_NAME env was not yet injected by the boot guard.
-      "host.name": hostName({ override: host }),
-      "host.id": hostId({ override: host }),
-    },
+    resource: buildCatalystResource({ serviceName: "catalyst.execution-core", host }),
     attributes: {
       "event.name": HEARTBEAT_EVENT,
       "event.entity": "node",

--- a/plugins/dev/scripts/execution-core/lib/catalyst-resource.mjs
+++ b/plugins/dev/scripts/execution-core/lib/catalyst-resource.mjs
@@ -1,0 +1,42 @@
+// lib/catalyst-resource.mjs — the SINGLE shared builder for a catalyst telemetry resource
+// block (CTL-1368). Before this, ~15 MJS emitters each inlined
+//   { "service.name", "service.namespace": "catalyst", "host.name", "host.id" }
+// which made adding a fleet-wide dimension a 15-file edit. This is the one place that shape
+// lives, so `catalyst.node.class` (and any future core dimension) is added once.
+//
+// A LEAF (host-identity.mjs + node-class.mjs are both leaves) — no config.mjs / pino /
+// bun:sqlite — so the broker and catalyst-agent can adopt it without dragging heavy graphs.
+//
+// catalyst.node.class is the node's ROLE (developer|worker|monitor) — orthogonal to
+// host.name/host.id (WHICH machine). Low-cardinality, so it is a safe universal metric
+// label; the OTEL collector surfaces it as a fleet-wide `node_class` dashboard dimension.
+
+import { hostName, hostId } from "./host-identity.mjs";
+import { nodeClass } from "./node-class.mjs";
+
+/**
+ * buildCatalystResource — assemble the canonical resource attribute block.
+ *
+ * @param {object} opts
+ * @param {string} opts.serviceName        the catalyst.* service name (required)
+ * @param {string} [opts.serviceVersion]   service.version, included ONLY when provided
+ *                                          (the broker / orch-monitor stamp it; most
+ *                                          execution-core emitters omit it)
+ * @param {string} [opts.host]             explicit host override forwarded to
+ *                                          hostName/hostId (the heartbeat path passes the
+ *                                          config-resolved name); omit for the bare resolve
+ * @returns {object} resource block with keys in canonical order, node.class LAST
+ */
+export function buildCatalystResource({ serviceName, serviceVersion, host } = {}) {
+  const hostOpts = host !== undefined ? { override: host } : {};
+  const resource = {
+    "service.name": serviceName,
+    "service.namespace": "catalyst",
+  };
+  if (serviceVersion !== undefined) resource["service.version"] = serviceVersion;
+  resource["host.name"] = hostName(hostOpts);
+  resource["host.id"] = hostId(hostOpts);
+  // node.class LAST — matches the updater reference impl + keeps existing key order stable.
+  resource["catalyst.node.class"] = nodeClass();
+  return resource;
+}

--- a/plugins/dev/scripts/execution-core/lib/catalyst-resource.test.mjs
+++ b/plugins/dev/scripts/execution-core/lib/catalyst-resource.test.mjs
@@ -1,0 +1,60 @@
+// catalyst-resource.test.mjs — CTL-1368. The shared MJS resource builder: every catalyst
+// signal's resource block comes from here, so this pins the shape — service.namespace,
+// short host.name/host.id, and the new core dimension catalyst.node.class (LAST), with
+// service.version conditional and host override honored.
+import { describe, test, expect, afterEach } from "bun:test";
+import { buildCatalystResource } from "./catalyst-resource.mjs";
+
+const saved = {};
+function setEnv(k, v) {
+  if (!(k in saved)) saved[k] = process.env[k];
+  if (v === undefined) delete process.env[k];
+  else process.env[k] = v;
+}
+afterEach(() => {
+  for (const [k, v] of Object.entries(saved)) { if (v === undefined) delete process.env[k]; else process.env[k] = v; }
+  for (const k of Object.keys(saved)) delete saved[k];
+});
+
+describe("buildCatalystResource (CTL-1368 single source of truth)", () => {
+  test("stamps the canonical block with catalyst.node.class LAST", () => {
+    setEnv("CATALYST_NODE_CLASS", "developer");
+    setEnv("CATALYST_HOST_NAME", "mini");
+    const r = buildCatalystResource({ serviceName: "catalyst.execution-core" });
+    expect(r["service.name"]).toBe("catalyst.execution-core");
+    expect(r["service.namespace"]).toBe("catalyst");
+    expect(r["host.name"]).toBe("mini");
+    expect(r["host.id"]).toMatch(/^[0-9a-f]{16}$/);
+    expect(r["catalyst.node.class"]).toBe("developer");
+    expect(Object.keys(r)[Object.keys(r).length - 1]).toBe("catalyst.node.class"); // LAST
+    expect(r).not.toHaveProperty("service.version"); // omitted when not provided
+  });
+
+  test("node.class reflects the resolver (worker default when unset)", () => {
+    setEnv("CATALYST_NODE_CLASS", undefined);
+    setEnv("CATALYST_LAYER2_CONFIG_FILE", "/nonexistent/config.json");
+    setEnv("CATALYST_HOST_NAME", "mini");
+    expect(buildCatalystResource({ serviceName: "catalyst.broker" })["catalyst.node.class"]).toBe("worker");
+  });
+
+  test("monitor for an unrecognized explicit class (most-restrictive)", () => {
+    setEnv("CATALYST_NODE_CLASS", "developr"); // typo
+    setEnv("CATALYST_HOST_NAME", "mini");
+    expect(buildCatalystResource({ serviceName: "catalyst.execution-core" })["catalyst.node.class"]).toBe("monitor");
+  });
+
+  test("service.version included only when provided", () => {
+    setEnv("CATALYST_HOST_NAME", "mini");
+    const r = buildCatalystResource({ serviceName: "catalyst.broker", serviceVersion: "1.2.3" });
+    expect(r["service.version"]).toBe("1.2.3");
+  });
+
+  test("host override is honored (short host.name + matching id)", () => {
+    setEnv("CATALYST_NODE_CLASS", "worker");
+    setEnv("CATALYST_HOST_NAME", undefined);
+    const r = buildCatalystResource({ serviceName: "catalyst.execution-core", host: "mini-2" });
+    expect(r["host.name"]).toBe("mini-2");
+    const r2 = buildCatalystResource({ serviceName: "catalyst.execution-core", host: "mini-2" });
+    expect(r.host?.id ?? r["host.id"]).toBe(r2["host.id"]); // deterministic
+  });
+});

--- a/plugins/dev/scripts/execution-core/lib/node-class-parity.test.mjs
+++ b/plugins/dev/scripts/execution-core/lib/node-class-parity.test.mjs
@@ -1,0 +1,79 @@
+// node-class-parity.test.mjs — CTL-1368. The leaf lib/node-class.mjs duplicates config.mjs's
+// resolveNodeClass (so the resource builder stays a leaf, free of the heavy config.mjs
+// graph). This test is the DRIFT GUARD: the two resolvers MUST return byte-identical results
+// across the full input matrix (env × Layer-2, valid/invalid/non-string/empty), the same way
+// host-identity has a parity contract. If config.mjs's ladder changes, this fails until the
+// leaf is updated to match.
+import { describe, test, expect, afterEach } from "bun:test";
+import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { resolveNodeClass as leafResolve, nodeClass as leafNodeClass, NODE_CLASSES as LEAF_CLASSES } from "./node-class.mjs";
+import { resolveNodeClass as canonResolve, NODE_CLASSES as CANON_CLASSES } from "../config.mjs";
+
+const ENV = "CATALYST_NODE_CLASS";
+const L2 = "CATALYST_LAYER2_CONFIG_FILE";
+const saved = {};
+function setEnv(k, v) {
+  if (!(k in saved)) saved[k] = process.env[k];
+  if (v === undefined) delete process.env[k];
+  else process.env[k] = v;
+}
+function layer2With(nodeClassValue) {
+  const dir = mkdtempSync(join(tmpdir(), "ncparity-"));
+  const path = join(dir, "config.json");
+  // nodeClassValue === Symbol("absent") → write a config with no node.class key
+  const cfg = nodeClassValue === ABSENT ? { catalyst: { host: { name: "x" } } } : { catalyst: { node: { class: nodeClassValue } } };
+  writeFileSync(path, JSON.stringify(cfg));
+  return path;
+}
+const ABSENT = Symbol("absent");
+
+afterEach(() => {
+  for (const [k, v] of Object.entries(saved)) {
+    if (v === undefined) delete process.env[k];
+    else process.env[k] = v;
+  }
+  for (const k of Object.keys(saved)) delete saved[k];
+});
+
+describe("node-class parity: leaf resolveNodeClass === config.mjs resolveNodeClass", () => {
+  test("constants agree", () => {
+    expect([...LEAF_CLASSES]).toEqual([...CANON_CLASSES]);
+    expect([...LEAF_CLASSES]).toEqual(["developer", "worker", "monitor"]);
+  });
+
+  // env-driven cases (Layer-2 ignored when env is set+non-empty)
+  for (const env of ["developer", "worker", "monitor", "Worker", " developer ", "MONITOR", "developr", "", "   ", undefined]) {
+    test(`env=${JSON.stringify(env)} → both resolvers agree`, () => {
+      setEnv(ENV, env);
+      setEnv(L2, undefined); // no Layer-2 file
+      expect(leafResolve()).toEqual(canonResolve());
+    });
+  }
+
+  // Layer-2-driven cases (env unset) — value written into a temp Layer-2 config
+  for (const l2 of [ABSENT, "developer", "worker", "monitor", "Worker", " monitor ", "developr", "", null, false, 0, []]) {
+    test(`layer2 node.class=${String(l2?.toString?.() ?? l2)} → both resolvers agree`, () => {
+      setEnv(ENV, undefined);
+      const path = layer2With(l2);
+      setEnv(L2, path);
+      try {
+        const a = leafResolve();
+        const b = canonResolve();
+        expect(a).toEqual(b);
+        // nodeClass() string accessor matches resolveNodeClass().class
+        expect(leafNodeClass()).toBe(a.class);
+      } finally {
+        rmSync(path, { force: true });
+      }
+    });
+  }
+
+  test("missing Layer-2 file (unreadable) → both default to worker", () => {
+    setEnv(ENV, undefined);
+    setEnv(L2, "/nonexistent/dir/config.json");
+    expect(leafResolve()).toEqual(canonResolve());
+    expect(leafResolve().class).toBe("worker");
+  });
+});

--- a/plugins/dev/scripts/execution-core/lib/node-class.mjs
+++ b/plugins/dev/scripts/execution-core/lib/node-class.mjs
@@ -1,0 +1,78 @@
+// lib/node-class.mjs — node-class resolution primitives for MJS emitters (CTL-1368).
+//
+// A dependency-free LEAF (node builtins only — no config.mjs, no pino, no bun:sqlite) so
+// the shared resource builder (lib/catalyst-resource.mjs) and any light emitter (broker,
+// catalyst-agent) can stamp `catalyst.node.class` WITHOUT dragging the heavy config.mjs
+// graph. Mirrors execution-core/config.mjs's resolveNodeClass EXACTLY — the same way
+// lib/host-identity.mjs mirrors getHostName's Layer-2 read rather than importing config.mjs.
+// Drift is guarded by lib/__tests__/node-class-parity.test.mjs (asserts this resolver and
+// config.mjs's agree across the full input matrix). config.mjs stays the canonical home for
+// the dispatch/doctor logic; this leaf is the read-only mirror for telemetry.
+
+import { homedir } from "node:os";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+// The three node classes (frozen). Mirrors config.mjs NODE_CLASSES.
+export const NODE_CLASSES = Object.freeze(["developer", "worker", "monitor"]);
+// Absent ⇒ worker ⇒ today's behavior, zero change.
+const NODE_CLASS_DEFAULT = "worker";
+// An EXPLICIT but unrecognized value (a typo'd "developr") degrades to the MOST
+// RESTRICTIVE class so a typo can never make a node work-eligible (recognized:false
+// routes catalyst doctor to FAIL).
+const NODE_CLASS_MOST_RESTRICTIVE = "monitor";
+
+// Layer-2 (machine-local) config path — mirrors config.mjs getLayer2ConfigPath()
+// (CATALYST_LAYER2_CONFIG_FILE || ~/.config/catalyst/config.json), duplicated here to
+// keep this a leaf (same pattern host-identity.mjs uses for layer2HostName).
+function getLayer2ConfigPath() {
+  return process.env.CATALYST_LAYER2_CONFIG_FILE || resolve(homedir(), ".config", "catalyst", "config.json");
+}
+
+// readLayer2NodeClass — the raw catalyst.node.class value from the Layer-2 file EXACTLY as
+// written (whatever JSON type), or undefined when absent/missing/malformed. Never throws.
+function readLayer2NodeClass() {
+  try {
+    return JSON.parse(readFileSync(getLayer2ConfigPath(), "utf8"))?.catalyst?.node?.class;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * resolveNodeClass — the pure, no-logging node-class resolver (verbatim mirror of
+ * config.mjs resolveNodeClass). Precedence CATALYST_NODE_CLASS env → Layer-2
+ * catalyst.node.class → default worker; never throws. Returns
+ *   { class, source, inferred, recognized, raw }
+ * Validity ladder: absent/null/empty ⇒ worker (inferred); present non-string ⇒ monitor
+ * (recognized:false); non-empty string is trimmed+lowercased then membership-checked
+ * (a genuine non-member ⇒ monitor, recognized:false).
+ */
+export function resolveNodeClass() {
+  const envRaw = process.env.CATALYST_NODE_CLASS;
+  const hasEnv = typeof envRaw === "string" && envRaw.trim().length > 0;
+  const raw = hasEnv ? envRaw : readLayer2NodeClass();
+  const source = hasEnv ? "env" : "layer2";
+
+  if (raw === undefined || raw === null) {
+    return { class: NODE_CLASS_DEFAULT, source: "default", inferred: true, recognized: true, raw: null };
+  }
+  if (typeof raw !== "string") {
+    return { class: NODE_CLASS_MOST_RESTRICTIVE, source, inferred: false, recognized: false, raw };
+  }
+  const normalized = raw.trim().toLowerCase();
+  if (normalized.length === 0) {
+    return { class: NODE_CLASS_DEFAULT, source: "default", inferred: true, recognized: true, raw: null };
+  }
+  if (NODE_CLASSES.includes(normalized)) {
+    return { class: normalized, source, inferred: false, recognized: true, raw };
+  }
+  return { class: NODE_CLASS_MOST_RESTRICTIVE, source, inferred: false, recognized: false, raw };
+}
+
+// nodeClass — the resolved class STRING (developer|worker|monitor). The log-free hot-path
+// accessor for telemetry resources (no warn — that stays with config.mjs getNodeClass for
+// the boot/doctor paths). Always returns a valid member.
+export function nodeClass() {
+  return resolveNodeClass().class;
+}

--- a/plugins/dev/scripts/execution-core/linear-state-write-event.mjs
+++ b/plugins/dev/scripts/execution-core/linear-state-write-event.mjs
@@ -25,7 +25,7 @@ import { randomBytes } from "node:crypto";
 import { appendFileSync, mkdirSync } from "node:fs";
 import { dirname } from "node:path";
 import { getEventLogPath, log } from "./config.mjs";
-import { hostName, hostId } from "./lib/host-identity.mjs";
+import { buildCatalystResource } from "./lib/catalyst-resource.mjs";
 import { UNKNOWN_TICKET_TYPE } from "./ticket-type.mjs"; // CTL-1023: work-type dimension
 
 // defaultAppend — writes a JSONL line to the canonical event log.
@@ -67,12 +67,7 @@ export function buildLinearStateWriteEvent({
       // channel="execution-core" — NOT "webhook"; the jq separator that tells a
       // daemon-initiated state-write apart from an inbound state_changed echo.
       channel: "execution-core",
-      resource: {
-        "service.name": "catalyst.execution-core",
-        "service.namespace": "catalyst",
-        "host.name": hostName(),
-        "host.id": hostId(),
-      },
+      resource: buildCatalystResource({ serviceName: "catalyst.execution-core" }),
       attributes: {
         "event.name": `linear.state.write.${ticket}`,
         "event.entity": "linear",

--- a/plugins/dev/scripts/execution-core/memory-event.mjs
+++ b/plugins/dev/scripts/execution-core/memory-event.mjs
@@ -11,7 +11,7 @@ import { mkdirSync, appendFileSync } from "node:fs";
 import { dirname } from "node:path";
 import { randomBytes } from "node:crypto";
 import { getEventLogPath, log } from "./config.mjs";
-import { hostName, hostId } from "./lib/host-identity.mjs";
+import { buildCatalystResource } from "./lib/catalyst-resource.mjs";
 
 export const MEMORY_EVENT_SAMPLED = "worker.memory.sampled";
 export const MEMORY_EVENT_WARN = "worker.memory.warn";
@@ -53,12 +53,7 @@ export function buildMemoryEnvelope(name, payload = {}, { now } = {}) {
     severityNumber,
     traceId: randomBytes(16).toString("hex"),
     spanId: randomBytes(8).toString("hex"),
-    resource: {
-      "service.name": "catalyst.execution-core",
-      "service.namespace": "catalyst",
-      "host.name": hostName(),
-      "host.id": hostId(),
-    },
+    resource: buildCatalystResource({ serviceName: "catalyst.execution-core" }),
     attributes: {
       "event.name": name,
       "event.entity": "worker",

--- a/plugins/dev/scripts/execution-core/ratelimit-event.mjs
+++ b/plugins/dev/scripts/execution-core/ratelimit-event.mjs
@@ -17,7 +17,7 @@ import { mkdirSync, appendFileSync } from "node:fs";
 import { dirname } from "node:path";
 import { randomBytes } from "node:crypto";
 import { getEventLogPath, log } from "./config.mjs";
-import { hostName, hostId } from "./lib/host-identity.mjs";
+import { buildCatalystResource } from "./lib/catalyst-resource.mjs";
 
 export const RATELIMIT_EVENT_SAMPLED = "account.ratelimit.sampled";
 
@@ -77,12 +77,7 @@ export function buildRatelimitEnvelope(name, payload = {}, { now } = {}) {
     severityNumber,
     traceId: randomBytes(16).toString("hex"),
     spanId: randomBytes(8).toString("hex"),
-    resource: {
-      "service.name": "catalyst.execution-core",
-      "service.namespace": "catalyst",
-      "host.name": hostName(),
-      "host.id": hostId(),
-    },
+    resource: buildCatalystResource({ serviceName: "catalyst.execution-core" }),
     attributes,
     body: {
       payload: {

--- a/plugins/dev/scripts/execution-core/reconcile-health-event.mjs
+++ b/plugins/dev/scripts/execution-core/reconcile-health-event.mjs
@@ -20,7 +20,7 @@ import { randomBytes } from "node:crypto";
 import { appendFileSync, mkdirSync } from "node:fs";
 import { dirname } from "node:path";
 import { getEventLogPath, log } from "./config.mjs";
-import { hostName, hostId } from "./lib/host-identity.mjs";
+import { buildCatalystResource } from "./lib/catalyst-resource.mjs";
 
 export const RECONCILE_FAILING_ACTION = "failing";
 export const RECONCILE_RECOVERED_ACTION = "recovered";
@@ -56,12 +56,7 @@ export function buildReconcileHealthEvent({
       severityNumber: failing ? 13 : 9,
       traceId: randomBytes(16).toString("hex"),
       spanId: randomBytes(8).toString("hex"),
-      resource: {
-        "service.name": "catalyst.execution-core",
-        "service.namespace": "catalyst",
-        "host.name": hostName(),
-        "host.id": hostId(),
-      },
+      resource: buildCatalystResource({ serviceName: "catalyst.execution-core" }),
       attributes: {
         "event.name": `monitor.reconcile.${action}.${team}`,
         "event.entity": "monitor",

--- a/plugins/dev/scripts/execution-core/recovery-reasoning.mjs
+++ b/plugins/dev/scripts/execution-core/recovery-reasoning.mjs
@@ -43,7 +43,7 @@ import {
   log as defaultLog,
   getEventLogPath,
 } from "./config.mjs";
-import { hostName, hostId } from "./lib/host-identity.mjs";
+import { buildCatalystResource } from "./lib/catalyst-resource.mjs";
 import { captureEvidence } from "./diagnostician.mjs";
 
 // Wrap defaultLog to ensure it's a function (config.mjs may export an object)
@@ -930,12 +930,7 @@ export function buildRecoveryEnvelope(event, { now } = {}) {
     severityNumber: escalated ? 13 : 9,
     traceId: null,
     spanId: null,
-    resource: {
-      "service.name": "catalyst.execution-core",
-      "service.namespace": "catalyst",
-      "host.name": hostName(),
-      "host.id": hostId(),
-    },
+    resource: buildCatalystResource({ serviceName: "catalyst.execution-core" }),
     attributes: {
       // ← THE canonical name. The board reader matches attributes["event.name"].
       "event.name": type,

--- a/plugins/dev/scripts/execution-core/recovery.mjs
+++ b/plugins/dev/scripts/execution-core/recovery.mjs
@@ -25,7 +25,7 @@ import { homedir } from "node:os";
 import { spawnSync } from "node:child_process";
 import { fileURLToPath } from "node:url";
 import { randomBytes } from "node:crypto";
-import { hostName, hostId } from "./lib/host-identity.mjs";
+import { buildCatalystResource } from "./lib/catalyst-resource.mjs";
 import {
   getJobsRoot,
   getEventLogPath,
@@ -322,12 +322,7 @@ function buildEventEnvelope({
       severityNumber,
       traceId: randomBytes(16).toString("hex"),
       spanId: randomBytes(8).toString("hex"),
-      resource: {
-        "service.name": "catalyst.execution-core",
-        "service.namespace": "catalyst",
-        "host.name": hostName(),
-        "host.id": hostId(),
-      },
+      resource: buildCatalystResource({ serviceName: "catalyst.execution-core" }),
       attributes: {
         "event.name": `phase.${phase}.${action}.${ticket}`,
         "event.entity": "phase",
@@ -1275,12 +1270,7 @@ export function defaultAppendOperatorEvent(evt) {
         severityNumber: 9,
         traceId: randomBytes(16).toString("hex"),
         spanId: randomBytes(8).toString("hex"),
-        resource: {
-          "service.name": "catalyst.execution-core",
-          "service.namespace": "catalyst",
-          "host.name": hostName(),
-          "host.id": hostId(),
-        },
+        resource: buildCatalystResource({ serviceName: "catalyst.execution-core" }),
         attributes: {
           "event.name": name,
         },

--- a/plugins/dev/scripts/execution-core/sdk-run-phase-agent.mjs
+++ b/plugins/dev/scripts/execution-core/sdk-run-phase-agent.mjs
@@ -64,6 +64,7 @@ import { appendFileSync, mkdirSync, readFileSync, renameSync, writeFileSync } fr
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { getEventLogPath } from "./config.mjs";
+import { nodeClass } from "./lib/node-class.mjs";
 
 // phase-agent-dispatch + phase-agent-emit-complete sit one directory up.
 const PHASE_AGENT_DISPATCH_BIN = fileURLToPath(
@@ -480,6 +481,7 @@ function defaultAppendEventLog({ phase, ticket, status, reason }) {
       resource: {
         "service.name": "catalyst.execution-core",
         "service.namespace": "catalyst",
+        "catalyst.node.class": nodeClass(),
       },
       attributes: {
         "event.name": `phase.${phase}.${status}.${ticket}`,

--- a/plugins/dev/scripts/execution-core/tracing.mjs
+++ b/plugins/dev/scripts/execution-core/tracing.mjs
@@ -22,6 +22,7 @@
 
 import { hostname as osHostname } from "node:os";
 import { createRequire } from "node:module";
+import { nodeClass } from "./lib/node-class.mjs";
 
 // CTL-1338: load @opentelemetry/api via createRequire (synchronous — the emit helpers
 // below use trace/context/SpanKind/SpanStatusCode on the sync tick path) wrapped in
@@ -87,6 +88,7 @@ export function buildTracingResource({ serviceName, dispatchMode = "phase-agents
     "host.name": shortHostName(),
     "catalyst.node.name": resolveNodeName(env),
     "catalyst.dispatch.mode": dispatchMode,
+    "catalyst.node.class": nodeClass(),
   };
 }
 

--- a/plugins/dev/scripts/execution-core/triage-transition-event.mjs
+++ b/plugins/dev/scripts/execution-core/triage-transition-event.mjs
@@ -8,7 +8,7 @@ import { randomBytes } from "node:crypto";
 import { appendFileSync, mkdirSync } from "node:fs";
 import { dirname } from "node:path";
 import { getEventLogPath, log } from "./config.mjs";
-import { hostName, hostId } from "./lib/host-identity.mjs";
+import { buildCatalystResource } from "./lib/catalyst-resource.mjs";
 import { UNKNOWN_TICKET_TYPE } from "./ticket-type.mjs"; // CTL-1023: work-type dimension
 
 // defaultAppend — writes a JSONL line to the canonical event log.
@@ -43,12 +43,7 @@ export function buildTriageTransitionEvent({
       severityNumber: 9,
       traceId: randomBytes(16).toString("hex"),
       spanId: randomBytes(8).toString("hex"),
-      resource: {
-        "service.name": "catalyst.execution-core",
-        "service.namespace": "catalyst",
-        "host.name": hostName(),
-        "host.id": hostId(),
-      },
+      resource: buildCatalystResource({ serviceName: "catalyst.execution-core" }),
       attributes: {
         "event.name": `phase.triage.linear-transition.${ticket}`,
         "event.entity": "phase",

--- a/plugins/dev/scripts/execution-core/wait-event.mjs
+++ b/plugins/dev/scripts/execution-core/wait-event.mjs
@@ -14,7 +14,7 @@ import { dirname } from "node:path";
 import { randomBytes } from "node:crypto";
 import { getEventLogPath, log } from "./config.mjs";
 import { shortIdFromSessionId } from "./claude-ids.mjs";
-import { hostName, hostId } from "./lib/host-identity.mjs";
+import { buildCatalystResource } from "./lib/catalyst-resource.mjs";
 
 /**
  * buildWaitEnvelope — assemble the canonical OTel envelope for a wait/resume
@@ -54,12 +54,7 @@ export function buildWaitEnvelope(name, { a = {}, state, waitingText, detail, me
     severityNumber: 9,
     traceId: randomBytes(16).toString("hex"),
     spanId: randomBytes(8).toString("hex"),
-    resource: {
-      "service.name": "catalyst.execution-core",
-      "service.namespace": "catalyst",
-      "host.name": hostName(),
-      "host.id": hostId(),
-    },
+    resource: buildCatalystResource({ serviceName: "catalyst.execution-core" }),
     attributes: {
       "event.name": name,
       "event.entity": "agent",

--- a/plugins/dev/scripts/lib/canonical-event.sh
+++ b/plugins/dev/scripts/lib/canonical-event.sh
@@ -258,11 +258,12 @@ build_canonical_line() {
       | grep -oE 'project=[^,]+' | head -1 | cut -d= -f2- || true)"
   fi
 
-  local sev_num event_id host_name host_id_val
+  local sev_num event_id host_name host_id_val node_class_val
   sev_num="$(severity_number "$severity")"
   event_id="$(generate_event_id)"
   host_name="$(catalyst_host_name)"
   host_id_val="$(catalyst_host_id)"
+  node_class_val="$(catalyst_node_class)"  # CTL-1368: the node ROLE core dimension
 
   jq -nc \
     --arg ts "$ts" \
@@ -275,6 +276,7 @@ build_canonical_line() {
     --arg svc_ver "$service_version" \
     --arg host_name "$host_name" \
     --arg host_id "$host_id_val" \
+    --arg node_class "$node_class_val" \
     --arg event_name "$event_name" \
     --arg entity "$entity" \
     --arg action "$action" \
@@ -321,7 +323,8 @@ build_canonical_line() {
           "service.namespace": "catalyst",
           "service.version": $svc_ver,
           "host.name": $host_name,
-          "host.id": $host_id
+          "host.id": $host_id,
+          "catalyst.node.class": $node_class
         }
         + (if $project    == "" then {} else { "project": $project } end)
         + (if $linear_key == "" then {} else { "linear.key": $linear_key } end)

--- a/plugins/dev/scripts/lib/host-identity.sh
+++ b/plugins/dev/scripts/lib/host-identity.sh
@@ -52,3 +52,26 @@ __host_id_from() {
 
 # catalyst_host_id — sha256(catalyst_host_name)[:16].
 catalyst_host_id() { __host_id_from "$(catalyst_host_name)"; }
+
+# catalyst_node_class — resolve the node ROLE (developer|worker|monitor) for telemetry
+# (CTL-1368). The Bash mirror of execution-core resolveNodeClass / lib/node-class.mjs:
+# CATALYST_NODE_CLASS env → Layer-2 catalyst.node.class → worker; trim + lowercase; a
+# non-member explicit value degrades to the most-restrictive `monitor` (parity with the
+# MJS/TS resolvers). Best-effort (needs jq to read Layer-2); falls back to worker without it.
+catalyst_node_class() {
+  local _raw=""
+  if [[ -n "${CATALYST_NODE_CLASS:-}" ]]; then
+    _raw="$CATALYST_NODE_CLASS"
+  else
+    local _cfg="${CATALYST_LAYER2_CONFIG_FILE:-${HOME}/.config/catalyst/config.json}"
+    if [[ -r "$_cfg" ]] && command -v jq >/dev/null 2>&1; then
+      _raw="$(jq -r '.catalyst.node.class // empty' "$_cfg" 2>/dev/null || true)"
+    fi
+  fi
+  _raw="$(printf '%s' "$_raw" | tr '[:upper:]' '[:lower:]' | xargs 2>/dev/null || true)"
+  case "$_raw" in
+    developer|worker|monitor) printf '%s' "$_raw" ;;
+    "") printf 'worker' ;;
+    *) printf 'monitor' ;;
+  esac
+}

--- a/plugins/dev/scripts/orch-monitor/docs/otel-attribute-audit.md
+++ b/plugins/dev/scripts/orch-monitor/docs/otel-attribute-audit.md
@@ -12,8 +12,8 @@ Do **not** edit this file directly.
 | --- | --- |
 | ✓ Conforming | 20 |
 | → Rename-to | 37 |
-| ● Legitimately Custom | 27 |
-| **Total** | 84 |
+| ● Legitimately Custom | 28 |
+| **Total** | 85 |
 
 ## Classification by Emitter
 
@@ -21,6 +21,7 @@ Do **not** edit this file directly.
 
 | Key | Source | Classification | Target | Cluster | Note |
 | --- | --- | --- | --- | --- | --- |
+| `catalyst.node.class` | `canonical-event.ts:52` | ● custom |  |  | CTL-1368 |
 | `catalyst.node.name` | `canonical-event.ts:55` | ● custom |  |  | CTL-1262 |
 | `catalyst.orchestration` | `canonical-event.ts:54` | ● custom |  |  |  |
 | `catalyst.orchestrator.id` | `canonical-event.ts:67` | ● custom |  |  |  |

--- a/plugins/dev/scripts/orch-monitor/lib/canonical-event-shared.ts
+++ b/plugins/dev/scripts/orch-monitor/lib/canonical-event-shared.ts
@@ -127,6 +127,62 @@ export function hostId(opts: { raw?: string; override?: string } = {}): string {
   return sha256Hex(hostName(opts)).slice(0, 16);
 }
 
+const NODE_CLASSES = ["developer", "worker", "monitor"] as const;
+export type NodeClass = (typeof NODE_CLASSES)[number];
+
+/**
+ * Resolve this node's catalyst.node.class as the role STRING — the TS mirror of
+ * execution-core/lib/node-class.mjs nodeClass() (and config.mjs resolveNodeClass). Same
+ * precedence (CATALYST_NODE_CLASS env → Layer-2 catalyst.node.class → worker) and the same
+ * validity ladder (absent/null/empty ⇒ worker; present non-string OR a non-member string ⇒
+ * monitor, the most-restrictive). Inlined here (like layer2HostName) to keep this a leaf.
+ */
+export function nodeClass(): NodeClass {
+  const envRaw = process.env.CATALYST_NODE_CLASS;
+  const hasEnv = typeof envRaw === "string" && envRaw.trim().length > 0;
+  let raw: unknown = hasEnv ? envRaw : undefined;
+  if (!hasEnv) {
+    const path = process.env.CATALYST_LAYER2_CONFIG_FILE ??
+      resolve(homedir(), ".config", "catalyst", "config.json");
+    try {
+      raw = (JSON.parse(readFileSync(path, "utf8")) as
+        { catalyst?: { node?: { class?: unknown } } })?.catalyst?.node?.class;
+    } catch { raw = undefined; }
+  }
+  if (raw === undefined || raw === null) return "worker";
+  if (typeof raw !== "string") return "monitor";
+  const normalized = raw.trim().toLowerCase();
+  if (normalized.length === 0) return "worker";
+  return (NODE_CLASSES as readonly string[]).includes(normalized) ? (normalized as NodeClass) : "monitor";
+}
+
+/**
+ * buildCatalystResource — the TS twin of execution-core/lib/catalyst-resource.mjs. The one
+ * place the broker (3 MJS files import this leaf) and the orch-monitor / otel-forward TS
+ * emitters build their resource block, so catalyst.node.class is stamped once. node.class is
+ * LAST. service.version included only when provided. Extra resource keys (e.g.
+ * otel-forward's catalyst.node.name) are merged AFTER via the `extra` param so node.class
+ * still lands in a stable position.
+ */
+export function buildCatalystResource(opts: {
+  serviceName: string;
+  serviceVersion?: string;
+  host?: string;
+  extra?: Record<string, unknown>;
+}): Record<string, unknown> {
+  const hostOpts = opts.host !== undefined ? { override: opts.host } : {};
+  const resource: Record<string, unknown> = {
+    "service.name": opts.serviceName,
+    "service.namespace": "catalyst",
+  };
+  if (opts.serviceVersion !== undefined) resource["service.version"] = opts.serviceVersion;
+  resource["host.name"] = hostName(hostOpts);
+  resource["host.id"] = hostId(hostOpts);
+  resource["catalyst.node.class"] = nodeClass();
+  if (opts.extra) Object.assign(resource, opts.extra);
+  return resource;
+}
+
 /**
  * Stable synthetic id for legacy records that lack a real `id`. Inputs that
  * are most likely to differ between events: traceId, spanId, ts, event name.

--- a/plugins/dev/scripts/orch-monitor/lib/canonical-event-shared.ts
+++ b/plugins/dev/scripts/orch-monitor/lib/canonical-event-shared.ts
@@ -142,7 +142,9 @@ export function nodeClass(): NodeClass {
   const hasEnv = typeof envRaw === "string" && envRaw.trim().length > 0;
   let raw: unknown = hasEnv ? envRaw : undefined;
   if (!hasEnv) {
-    const path = process.env.CATALYST_LAYER2_CONFIG_FILE ??
+    // `||` (not `??`): an EMPTY CATALYST_LAYER2_CONFIG_FILE must fall back to the default
+    // path — matching config.mjs resolveNodeClass + the MJS leaf (Codex P2 parity).
+    const path = process.env.CATALYST_LAYER2_CONFIG_FILE ||
       resolve(homedir(), ".config", "catalyst", "config.json");
     try {
       raw = (JSON.parse(readFileSync(path, "utf8")) as

--- a/plugins/dev/scripts/orch-monitor/lib/canonical-event.ts
+++ b/plugins/dev/scripts/orch-monitor/lib/canonical-event.ts
@@ -20,9 +20,8 @@ import { dirname, resolve } from "node:path";
 
 import {
   type Severity,
+  buildCatalystResource,
   generateEventId,
-  hostId,
-  hostName,
   severityNumber,
 } from "./canonical-event-shared";
 
@@ -46,6 +45,11 @@ export interface Resource {
   // CTL-852: host identity fields, always present on canonical events.
   "host.name": string;
   "host.id": string;
+  // CTL-1368: node CLASS (developer|worker|monitor) — the role this node plays.
+  // Stamped by buildCatalystResource (always present when the resource is built
+  // through it). Optional so external (webhook/broker-daemon) events that build
+  // a bare resource block remain valid.
+  "catalyst.node.class"?: string;
   // CTL-1262: stable Catalyst node name, distinct from the OS hostname
   // (host.name). Resolved the same way as getHostName() / hostName()
   // (CATALYST_HOST_NAME env -> catalyst.host.name Layer-2 config ->
@@ -206,13 +210,13 @@ export function buildCanonicalEvent(input: BuildInput): CanonicalEvent {
   const observedTs = input.observedTs ?? input.ts;
   const version = input.resource["service.version"] ?? pluginVersion();
 
-  const resource: Resource = {
-    "service.name": input.resource["service.name"],
-    "service.namespace": "catalyst",
-    "service.version": version,
-    "host.name": hostName(),
-    "host.id": hostId(),
-  };
+  // `as unknown as Resource`: the shared builder returns Record<string, unknown> (it can't
+  // import the Resource type without a cycle), so bridge the index-signature gap. The
+  // runtime shape IS a valid Resource — serviceVersion is always passed here.
+  const resource: Resource = buildCatalystResource({
+    serviceName: input.resource["service.name"],
+    serviceVersion: version,
+  }) as unknown as Resource;
   // CTL-636: promote orchestration context into resource. Explicit resource
   // input wins; otherwise fall back to the matching attribute (TS emitters
   // already set these) or the ambient env (project only).

--- a/plugins/dev/scripts/orch-monitor/lib/event-filter.ts
+++ b/plugins/dev/scripts/orch-monitor/lib/event-filter.ts
@@ -43,7 +43,7 @@ export function validatePredicate(predicate: string): ValidationResult {
     // same shape producers emit, so jq predicates referencing canonical paths
     // (.attributes."event.name", .body.payload, etc) compile cleanly.
     const sample =
-      '{"ts":"","id":"00000000-0000-4000-8000-000000000000","observedTs":"","severityText":"INFO","severityNumber":9,"traceId":null,"spanId":null,"resource":{"service.name":"","service.namespace":"catalyst","service.version":""},"attributes":{"event.name":""},"body":{}}';
+      '{"ts":"","id":"00000000-0000-4000-8000-000000000000","observedTs":"","severityText":"INFO","severityNumber":9,"traceId":null,"spanId":null,"resource":{"service.name":"","service.namespace":"catalyst","service.version":"","catalyst.node.class":""},"attributes":{"event.name":""},"body":{}}';
     const r = Bun.spawnSync({
       cmd: [
         "jq",

--- a/plugins/dev/scripts/orch-monitor/lib/otel-attribute-audit.ts
+++ b/plugins/dev/scripts/orch-monitor/lib/otel-attribute-audit.ts
@@ -26,6 +26,8 @@ export const AUDIT_MANIFEST: AttributeAuditEntry[] = [
   { key: "service.version",   emitter: "ts", source: "canonical-event.ts:45", classification: "conforming" },
   { key: "host.name",         emitter: "ts", source: "canonical-event.ts:47", classification: "conforming" },
   { key: "host.id",           emitter: "ts", source: "canonical-event.ts:48", classification: "conforming" },
+  // CTL-1368: node CLASS (developer|worker|monitor) — fleet-wide role dimension, catalyst.* custom
+  { key: "catalyst.node.class",     emitter: "ts", source: "canonical-event.ts:52", classification: "legitimately-custom", note: "CTL-1368" },
   // CTL-1262: stable Catalyst node name (distinct from the OS host.name) — catalyst.* custom
   { key: "catalyst.node.name",      emitter: "ts", source: "canonical-event.ts:55", classification: "legitimately-custom", note: "CTL-1262" },
   // CTL-636 optional resource context

--- a/plugins/dev/scripts/orch-monitor/lib/respond-ticket.mjs
+++ b/plugins/dev/scripts/orch-monitor/lib/respond-ticket.mjs
@@ -52,6 +52,7 @@ import { homedir } from "node:os";
 import { dirname, join } from "node:path";
 import { readClusterHostCount, runFenceCheck } from "./stop-worker.mjs";
 import { PHASE_ORDER } from "./board-data.mjs";
+import { nodeClass } from "./canonical-event-shared.ts";
 
 // The execution-core worker tree root — ~/catalyst/execution-core/workers/<T>/.
 // Byte-identical to ticket-runs.mjs::DEFAULT_WORKERS_DIR and board-data.mjs's
@@ -100,6 +101,10 @@ export function buildResumeEvent({ ticket, response, now = new Date() }) {
     resource: {
       "service.name": "catalyst.orch-monitor",
       "service.namespace": "catalyst",
+      // CTL-1368: node CLASS (developer|worker|monitor). host fields are
+      // deliberately omitted here (this bare resource never carried them);
+      // node.class is the only added key, sourced from nodeClass(), kept LAST.
+      "catalyst.node.class": nodeClass(),
     },
     attributes: {
       "event.name": "linear.comment.created",

--- a/plugins/dev/scripts/orch-monitor/ui/src/hooks/use-activity.ts
+++ b/plugins/dev/scripts/orch-monitor/ui/src/hooks/use-activity.ts
@@ -173,6 +173,13 @@ function projectEnvelope(raw: unknown): CanonicalEvent {
           : "",
       "host.id":
         typeof resource["host.id"] === "string" ? resource["host.id"] : "",
+      // CTL-1368: node CLASS (developer|worker|monitor). Browser normalizer —
+      // CANNOT read Layer-2 from disk, so this is a pure wire pass-through with a
+      // "" fallback, mirroring the host.name/host.id default above (CTL-852).
+      "catalyst.node.class":
+        typeof resource["catalyst.node.class"] === "string"
+          ? resource["catalyst.node.class"]
+          : "",
     },
     attributes: {
       "event.name":

--- a/plugins/dev/scripts/otel-forward/lib/canonical.ts
+++ b/plugins/dev/scripts/otel-forward/lib/canonical.ts
@@ -1,5 +1,5 @@
 import type { CanonicalEvent } from "../../orch-monitor/lib/canonical-event.ts";
-import { hostName, hostId } from "../../orch-monitor/lib/canonical-event-shared.ts";
+import { hostName, buildCatalystResource } from "../../orch-monitor/lib/canonical-event-shared.ts";
 
 // CTL-1262: stable Catalyst node name. Identical resolution to
 // execution-core/config.mjs getHostName(): CATALYST_HOST_NAME env ->
@@ -56,24 +56,21 @@ export function buildCanonicalEnvelope(opts: BuildOpts): CanonicalEvent {
     severityNumber: opts.severityNumber ?? 9,
     traceId: null,
     spanId: null,
-    resource: {
-      "service.name": opts.serviceName,
-      "service.namespace": "catalyst",
-      "service.version": opts.serviceVersion ?? "0.0.0",
-      "host.name": hostName(),
-      "host.id": hostId(),
-      // CTL-1262: stable Catalyst node name as a DISTINCT resource attribute so
-      // dashboards / the delegate can attribute signals per node. Resolved the
-      // SAME way as execution-core/config.mjs getHostName() — the shared
-      // hostName() helper applies the identical precedence (CATALYST_HOST_NAME
-      // env -> catalyst.host.name in Layer-2 config -> os.hostname() first DNS
-      // label) and never throws, falling back safely. NOT the Tailscale device
-      // name. Keyed distinctly from the OS hostname (host.name); when the two
-      // resolve to the same value today they remain semantically separate keys.
-      // buildOtlpPayload's generic toAttrArray serializes the whole resource, so
-      // this lands on the OTLP wire with no otlp.ts change.
-      "catalyst.node.name": nodeName(),
-    },
+    // CTL-1368: built through buildCatalystResource so catalyst.node.class (the
+    // node ROLE) is stamped LAST. service.name / service.version / host identity
+    // are unchanged (host resolved via the bare hostName()/hostId() the helper
+    // uses internally with no override). The CTL-1262 catalyst.node.name — a
+    // DISTINCT resource attribute (the stable coordination name HRW / the
+    // delegate key off, resolved the SAME way as getHostName()) — is carried
+    // through `extra` so it lands AFTER node.class on the OTLP wire (toAttrArray
+    // serializes the whole resource generically, so no otlp.ts change).
+    // as unknown as: the shared builder returns Record<string, unknown>; bridge the
+    // index-signature gap (runtime shape is a valid resource — version always set here).
+    resource: buildCatalystResource({
+      serviceName: opts.serviceName,
+      serviceVersion: opts.serviceVersion ?? "0.0.0",
+      extra: { "catalyst.node.name": nodeName() },
+    }) as unknown as CanonicalEvent["resource"],
     attributes: {
       "event.name": opts.eventName,
       ...opts.attributes,

--- a/plugins/dev/skills/broker/SKILL.md
+++ b/plugins/dev/skills/broker/SKILL.md
@@ -658,7 +658,8 @@ payload directly rather than making round-trip REST/GraphQL calls.
   "severityNumber": 9,
   "resource": {
     "service.name": "catalyst.broker",
-    "service.namespace": "catalyst"
+    "service.namespace": "catalyst",
+    "catalyst.node.class": "worker"
   },
   "attributes": {
     "event.name": "filter.wake.<interest_id>",


### PR DESCRIPTION
## What & why

Promotes `catalyst.node.class` (the node ROLE — `developer` | `worker` | `monitor`) to a **core resource attribute on every catalyst telemetry signal**, not just the updater. Before this, ~16 emitters each inlined their resource block, so a fleet-wide dimension was a 16-file edit. Now there's a **single shared builder**, and the dimension is added once.

`node.class` is low-cardinality (3 values) and orthogonal to identity (`host.name`/`host.id` = *which machine*; `node.class` = *what role*) — a safe universal metric label. The OTEL agent surfaces it as a reusable `node_class` dashboard dimension (OTL-38), so the whole fleet becomes sliceable by role.

## How — single source of truth

- **`execution-core/lib/node-class.mjs`** — a dependency-free leaf mirroring `config.mjs`'s `resolveNodeClass` (env → Layer-2 → worker; the validity ladder), so the builder stays free of the heavy config.mjs/pino graph. The **same duplicate-with-parity pattern `host-identity.mjs` uses** — guarded by `node-class-parity.test.mjs` (asserts the leaf and config.mjs agree across the full env × Layer-2 matrix). config.mjs is untouched.
- **`execution-core/lib/catalyst-resource.mjs`** — `buildCatalystResource({serviceName, serviceVersion, host})` → the canonical resource block with `catalyst.node.class` **last**. Pino-free, so the broker adopts it.
- **`orch-monitor/lib/canonical-event-shared.ts`** — the TS twin (`buildCatalystResource` + `nodeClass()`) for the broker MJS files and the orch-monitor/otel-forward TS emitters.

Then **~16 emitters** route through the builder (or, for non-standard shapes — tracing spans, catalyst-agent's extra `hostname` key, sdk-run/respond-ticket backstops — hand-add the one `node.class` line). The browser `use-activity.ts` gets a wire pass-through (default `""`, can't read disk). `updater.mjs` already stamped it (CTL-1348, the reference impl).

## Built with a Workflow

The foundation was built + verified inline; the fan-out (16 swaps), the verification/fixture sweep, and an adversarial review ran as a multi-agent workflow. The review caught a real **TS2352** (the TS builder's `Record<string,unknown>` cast to `Resource` at 2 typed call sites — fixed with `as unknown as`), a **completeness gap** (the `event-filter.ts` jq-validation sample — added), and **dead imports** in `router.mjs` (removed). The regression pass confirmed the change is **purely additive** for consumers (OTLP serializer iterates the resource generically; all readers key on `service.name`; the browser normalizer falls back to `""`).

## Tests / verification

- Foundation: `node-class-parity.test.mjs` + `catalyst-resource.test.mjs` — **29 pass** (both added to the execution-core CI list).
- Full suites green across execution-core / broker / orch-monitor / ui / otel-forward / catalyst-agent (the only failures are two **pre-existing, env-specific** ones: a heartbeat host.name test that keys on this machine's Layer-2, and a nav-signal test that reads the live local DB — both verified failing identically on clean HEAD).
- `orch-monitor` parent + `otel-forward` tsc clean (TS2352 fixed); import graphs (daemon/updater/router) clean.
- Docs updated: `event-schema.md` (8 examples + prose), broker `SKILL.md`, the otel-attribute-audit manifest + regenerated doc.

Unblocks the OTEL `node_class` template variable. Relates to CTL-1348 (the updater pilot) and CTL-1369.

🤖 Generated with [Claude Code](https://claude.com/claude-code)