### PR TITLE
feat(dev): CTL-1355 (2/n) — catalyst-doctor grades a node against its class-specific rubric

### DIFF
--- a/plugins/dev/scripts/execution-core/doctor.mjs
+++ b/plugins/dev/scripts/execution-core/doctor.mjs
@@ -1,8 +1,23 @@
 // doctor.mjs — catalyst doctor: fail-closed activation gate for new cluster nodes (CTL-1186).
 //
-// Runs a suite of read-only checks that a new node MUST pass before the
-// execution-core daemon is safe to start. Each check is injectable for unit
-// testing; production defaults wire to the real system calls.
+// Runs a suite of read-only checks that a node MUST pass before its role is safe.
+// Each check is injectable for unit testing; production defaults wire to the real
+// system calls.
+//
+// CTL-1355: the suite is CLASS-AWARE. `runDoctor` resolves catalyst.node.class
+// (resolveNodeClass) once and grades the node against its class-specific rubric:
+//   • worker    — the full CTL-1186 activation gate (would-own-work + Linear/bot
+//                 reachable + roster membership + daemon PATH + member provisioning).
+//                 An UNSET class infers `worker` (today's behavior, zero change).
+//   • developer — services healthy + plugins fresh + read-replica REACHABLE + the
+//                 node will NOT pick up work (out of roster / boot-drained). Reuses
+//                 the daemonless + plugins-fresh rows from `catalyst-stack
+//                 verify-node --json`; computes would-not-own-work + read-replica
+//                 reachability natively.
+//   • monitor   — minimal/stub (no monitor host exists yet); reachability + must-not-
+//                 own-work + a fail-closed profile-stub FAIL (doctor refuses to
+//                 certify a monitor node until the monitor rubric lands).
+// An EXPLICIT but unrecognized class (a typo'd "developr") is a single hard FAIL.
 //
 // Usage:
 //   node doctor.mjs [--json] [--dry-run] [--expected-bot-user-id <id>]
@@ -22,6 +37,12 @@ import {
   hostMembershipWarning,
   getLivenessAnchorIssue,
   getExecutor, // CTL-1367 item 9: resolve the phase-worker executor for the sdk-auth gate
+  // CTL-1355: class-aware grading — resolveNodeClass selects the rubric, isDraining
+  // + getExecutionCoreDir drive the developer/monitor "will NOT pick up work" gate.
+  resolveNodeClass,
+  NODE_CLASSES,
+  isDraining,
+  getExecutionCoreDir,
 } from "./config.mjs";
 import { ownedBy } from "./hrw.mjs";
 import { readPeerHeartbeats } from "./cluster-heartbeat.mjs";
@@ -1580,20 +1601,436 @@ export function checkConfigScopeLeak(deps = {}) {
   return checks;
 }
 
-// runDoctor — orchestrate all checks, render, and return the fail count.
-export async function runDoctor(opts = {}) {
+// ─── CTL-1355: class-aware grading ───────────────────────────────────────────
+
+// checkNodeClass — grade catalyst.node.class itself. An EXPLICIT but unrecognized
+// value (resolveNodeClass.recognized === false, e.g. a typo'd "developr") is the
+// single hard FAIL that fail-closes the gate until the value is corrected (the
+// resolver already degraded it to the most-restrictive `monitor`). An INFERRED
+// default (class unset) is a benign INFO — it grades as `worker` (today's
+// behavior, zero change), just noting the role was never declared. An explicit,
+// recognized class PASSes. Injectable for tests.
+export function checkNodeClass(deps = {}) {
+  const { nodeClass = resolveNodeClass() } = deps;
+  const nc = nodeClass;
+  if (!nc.recognized) {
+    return [
+      mkCheck(
+        "node-class",
+        STATUS.FAIL,
+        `catalyst.node.class "${nc.raw}" is not one of [${NODE_CLASSES.join(", ")}] — ` +
+          `treating this node as "${nc.class}" (most restrictive); correct or unset ` +
+          `the value in ~/.config/catalyst/config.json (or CATALYST_NODE_CLASS) (CTL-1355)`,
+      ),
+    ];
+  }
+  if (nc.inferred) {
+    return [
+      mkCheck(
+        "node-class",
+        STATUS.INFO,
+        `catalyst.node.class is not explicitly set — grading as "${nc.class}" ` +
+          `(absent ⇒ worker ⇒ today's behavior, zero change). Set CATALYST_NODE_CLASS ` +
+          `or catalyst.node.class to make the role explicit`,
+      ),
+    ];
+  }
+  return [
+    mkCheck(
+      "node-class",
+      STATUS.PASS,
+      `catalyst.node.class="${nc.class}" (explicit, source=${nc.source})`,
+    ),
+  ];
+}
+
+// ─── Developer/monitor: read-replica REACHABILITY (CTL-1346 + CTL-1355) ───────
+
+// defaultReadReplicaBaseUrl — mirror catalyst-stack _vn_read_replica_base /
+// read-replica-config.ts readReplicaBaseUrlFromLayer2: CATALYST_MONITOR_URL env
+// override, else Layer-2 catalyst.readReplica.baseUrl. Trimmed; null when neither
+// is set (a developer/monitor reads from a worker monitor, never an empty local
+// replica). Never throws.
+function defaultReadReplicaBaseUrl() {
+  const env = process.env.CATALYST_MONITOR_URL;
+  if (typeof env === "string" && env.trim().length > 0) return env.trim();
+  try {
+    const v = JSON.parse(readFileSync(layer2Path(), "utf8"))?.catalyst?.readReplica?.baseUrl;
+    return typeof v === "string" && v.trim().length > 0 ? v.trim() : null;
+  } catch {
+    return null;
+  }
+}
+
+// checkReadReplicaReachable — doctor's value-add over verify-node (which only
+// CLASSIFIES the config): an ACTUAL reachability probe of the read endpoint. A
+// developer/monitor that can't reach its worker monitor serves a stale/empty board.
+//   • unset              → FAIL (no endpoint; resolver refuses to fall back to localhost)
+//   • localhost/127      → FAIL (an empty local replica; point at a worker monitor)
+//   • remote + 2xx       → PASS
+//   • remote + non-2xx   → FAIL (a TCP/any-response check would mask an unhealthy monitor)
+//   • remote + unreach   → FAIL (the probe threw / timed out)
+// GET + 5 s timeout; a 2xx is the health floor (CTL-1355 F4 — was "any response").
+export async function checkReadReplicaReachable(deps = {}) {
+  const { baseUrl = defaultReadReplicaBaseUrl(), fetch: _fetch = globalThis.fetch } = deps;
+  const base = typeof baseUrl === "string" ? baseUrl.trim() : "";
+
+  if (!base) {
+    return [
+      mkCheck(
+        "read-replica",
+        STATUS.FAIL,
+        `no read-replica endpoint (CATALYST_MONITOR_URL / catalyst.readReplica.baseUrl ` +
+          `unset) — a non-worker node reads from a worker monitor (CTL-1346); point it at ` +
+          `one, e.g. http://mini:7400`,
+      ),
+    ];
+  }
+  if (/^https?:\/\/(localhost|127\.0\.0\.1)\b/i.test(base)) {
+    return [
+      mkCheck(
+        "read-replica",
+        STATUS.FAIL,
+        `read-replica endpoint is localhost (${base}) — serves an empty local replica; ` +
+          `point at a worker monitor (e.g. http://mini:7400)`,
+      ),
+    ];
+  }
+  const url = base.replace(/\/+$/, "") + "/api/health";
+  try {
+    const res = await _fetch(url, { method: "GET", signal: AbortSignal.timeout(5000) });
+    // F4 (CTL-1355): a 2xx is the health floor — any other response (404/5xx/…)
+    // means the endpoint answered but is NOT healthy. Honor a real Response.ok;
+    // fall back to a 2xx status-range test when a mock omits `ok`.
+    const status = res?.status;
+    const ok =
+      res?.ok ?? (typeof status === "number" && status >= 200 && status < 300);
+    if (!ok) {
+      return [
+        mkCheck(
+          "read-replica",
+          STATUS.FAIL,
+          `read-replica ${url} returned HTTP ${status ?? "?"} — not healthy (a 2xx is required)`,
+        ),
+      ];
+    }
+    return [
+      mkCheck("read-replica", STATUS.PASS, `read-replica endpoint healthy: ${url} → HTTP ${status}`),
+    ];
+  } catch (err) {
+    return [
+      mkCheck(
+        "read-replica",
+        STATUS.FAIL,
+        `read-replica endpoint ${url} unreachable: ${err?.message ?? err}`,
+      ),
+    ];
+  }
+}
+
+// ─── Developer/monitor: "will NOT pick up work" (CTL-1355) ────────────────────
+
+// checkWontOwnWork — a developer/monitor MUST sit out of the work pipeline. The
+// node class is a LABEL ONLY today — it does not auto-drain or auto-leave the
+// roster (config.mjs applyBootDrainPolicy keys drain off CATALYST_BOOT_DRAINED,
+// resolveClusterHosts is class-blind) — so this is the check that actually proves
+// the node won't be assigned work.
+//
+// FAIL-CLOSED (CTL-1355 F1): resolveClusterHosts is FAIL-OPEN — an absent/stale/
+// malformed cluster-repo clone (the COMMON case on a daemonless dev laptop)
+// collapses to { hosts:[self], source:"single-host", multiHost:false }, so a node
+// that would own 100% of work under HRW must NOT grade as safe. The PASS condition
+// is therefore that we can POSITIVELY confirm the node sits out — never the mere
+// ABSENCE of a confirmed conflict. Structural test (offline, deterministic):
+//   • boot-drained / draining                       → PASS (admits no new work)
+//   • AUTHORITATIVE roster (cluster-repo / static),
+//     node NOT in it                                → PASS (HRW assigns it nothing)
+//   • in the roster, not drained                    → FAIL (HRW would assign work)
+//   • single-host / fail-open / unresolved roster,
+//     not drained                                   → FAIL (can't confirm out-of-roster;
+//                                                      a fail-open collapse = owns 100%)
+// "Authoritative" = a real configured roster source (cluster-repo or an explicit
+// static roster) — NOT the single-host collapse the resolver returns when nothing
+// resolves. If the resolver exposes no source flag (defensive), only multiHost===true
+// is treated as authoritative; a single-host/unflagged roster is the dangerous case.
+// The would-own COUNT is printed separately by checkHrwPartition (kept in every
+// suite for visibility). Injectable for tests.
+export function checkWontOwnWork(deps = {}) {
   const {
-    checks: checkFns = null,
-    json = false,
-    log: _log = (msg) => process.stdout.write(msg + "\n"),
-    host = null,
-    seed = process.env.CATALYST_SEED_HOST ?? null,
-    otel = process.env.OTEL_EXPORTER_OTLP_ENDPOINT ?? null,
+    resolveRoster = resolveClusterHosts,
+    getHostName: _getHostName = getHostName,
+    isDraining: _isDraining = isDraining,
+    orchDir = getExecutionCoreDir(),
+    bootDrained = process.env.CATALYST_BOOT_DRAINED === "1",
+  } = deps;
+
+  const resolved = resolveRoster() ?? {};
+  const hosts = Array.isArray(resolved.hosts) ? resolved.hosts : [];
+  const source = resolved.source;
+  const multiHost = resolved.multiHost === true;
+  const self = _getHostName();
+  const inRoster = hosts.includes(self);
+  const drained = _isDraining(orchDir) || bootDrained;
+
+  // 1. Explicitly drained → PASS (admits no new work regardless of roster).
+  if (drained) {
+    return [
+      mkCheck("would-not-own-work", STATUS.PASS, "drained — will not own work (boot-drained / draining; admits no new work)"),
+    ];
+  }
+
+  // A roster is AUTHORITATIVELY resolved only when it came from a real configured
+  // source (the cluster repo or an explicit static roster). The fail-open
+  // single-host collapse (source==="single-host", or — defensively, if the resolver
+  // exposes no source flag — anything that is not multiHost) is NOT authoritative.
+  const authoritative =
+    source === "cluster-repo" ||
+    source === "static" ||
+    (source === undefined && multiHost);
+
+  // 2. Authoritative roster that does NOT contain this node → PASS (HRW assigns it
+  //    nothing; we can POSITIVELY confirm it sits out).
+  if (authoritative && !inRoster) {
+    return [
+      mkCheck(
+        "would-not-own-work",
+        STATUS.PASS,
+        `"${self}" is not in the authoritative cluster roster [${hosts.join(", ")}] ` +
+          `(source=${source ?? "?"}) — HRW assigns it nothing`,
+      ),
+    ];
+  }
+
+  // 3. Everything else (in the roster, OR a single-host/fail-open/unresolved roster
+  //    we cannot confirm excludes this node) → FAIL, fail-closed.
+  const why = inRoster
+    ? `it is in the cluster roster [${hosts.join(", ")}] (source=${source ?? "?"}) and is NOT drained, ` +
+      `so HRW would assign it work`
+    : `the cluster roster could not be authoritatively confirmed (source=${source ?? "?"}, ` +
+      `multiHost=${multiHost}), so a fail-open single-host collapse means this node would own ` +
+      `100% of tickets if the daemons start`;
+  return [
+    mkCheck(
+      "would-not-own-work",
+      STATUS.FAIL,
+      `"${self}" would own work — a developer/monitor must be drained or out of an authoritative ` +
+        `roster; set CATALYST_BOOT_DRAINED=1 (or drain) — ${why}`,
+    ),
+  ];
+}
+
+// ─── Developer: daemonless + plugins-fresh, folded from verify-node ───────────
+
+// resolveStackBin — the catalyst-stack script. Prefer the sibling in this repo
+// (deterministic, same version as doctor.mjs); fall back to PATH.
+function resolveStackBin() {
+  const sibling = resolve(dirname(fileURLToPath(import.meta.url)), "..", "catalyst-stack");
+  return existsSync(sibling) ? sibling : "catalyst-stack";
+}
+
+// defaultRunVerifyNode — shell out to `catalyst-stack verify-node --json` (a
+// read-only, class-aware LOCAL smoke test) and parse its JSON. verify-node EXITS
+// non-zero when a required check FAILs — that is expected, not a spawn error, so
+// we parse stdout regardless of status; only a missing binary / empty output
+// throws. The child grades the SAME class (env-pinned) so its rows match ours.
+function defaultRunVerifyNode(nodeClass) {
+  const bin = resolveStackBin();
+  const r = spawnSync(bin, ["verify-node", "--json"], {
+    encoding: "utf8",
+    timeout: 120_000,
+    env: { ...process.env, CATALYST_NODE_CLASS: nodeClass },
+  });
+  if (r.error) throw r.error;
+  if (!r.stdout || !r.stdout.trim()) {
+    throw new Error(`verify-node produced no output (status ${r.status}): ${r.stderr?.trim() ?? ""}`);
+  }
+  const parsed = JSON.parse(r.stdout);
+  // F2 (CTL-1355): the child's ACTUAL exit status is the authoritative liveness
+  // signal — capture it (don't discard r.status) so checkDaemonlessLocal can
+  // fail-close on a non-zero exit even when the JSON body omits exit_code.
+  if (typeof parsed.exit_code !== "number" && typeof r.status === "number") {
+    parsed.exit_code = r.status;
+  }
+  return parsed;
+}
+
+// verify-node statuses are UPPERCASE (PASS|FAIL|WARN|SKIP, no INFO); translate to
+// doctor's lowercase STATUS (SKIP has no doctor analogue → INFO).
+const VN_STATUS_MAP = {
+  PASS: STATUS.PASS,
+  FAIL: STATUS.FAIL,
+  WARN: STATUS.WARN,
+  SKIP: STATUS.INFO,
+};
+
+// checkDaemonlessLocal — fold the daemonless + plugins-fresh rows from verify-node
+// into doctor checks rather than re-implementing the broker/exec-core process
+// probes and the entire verify-updater stack.
+//
+// FAIL-CLOSED (CTL-1355 F2): verify-node is the ONLY net that catches a developer
+// actually executing work (running daemons / stale plugins). A spawn error, an
+// empty/unparseable result, jq unavailability, a non-zero child exit, a `fail`
+// verdict, a missing required row, or an unmappable row status all mean we CANNOT
+// certify the node is daemonless + fresh — so each is a FAIL (was WARN, which
+// masked exactly the dangerous states). Injectable for tests (inject a JSON
+// fixture instead of spawning).
+export function checkDaemonlessLocal(deps = {}) {
+  const {
+    nodeClass = "developer",
+    runVerifyNode = defaultRunVerifyNode,
+    rows = ["broker-stopped", "exec-core-stopped", "plugins-fresh"],
+  } = deps;
+
+  let result;
+  try {
+    result = runVerifyNode(nodeClass);
+  } catch (err) {
+    return [
+      mkCheck(
+        "verify-node",
+        STATUS.FAIL,
+        `could not verify daemonless local state — could not run ` +
+          `'catalyst-stack verify-node --json': ${err?.message ?? err}; ` +
+          `cannot certify the developer is daemonless + fresh`,
+      ),
+    ];
+  }
+
+  // A parsed-but-unusable verify-node result cannot certify daemonless+fresh.
+  const checks = Array.isArray(result?.checks) ? result.checks : [];
+  const exit = typeof result?.exit_code === "number" ? result.exit_code : null;
+  if (
+    checks.length === 0 ||
+    result?.jq === false ||
+    (exit !== null && exit !== 0) ||
+    result?.verdict === "fail"
+  ) {
+    return [
+      mkCheck(
+        "verify-node",
+        STATUS.FAIL,
+        `could not verify daemonless local state — verify-node unavailable/failed ` +
+          `(exit ${exit ?? "?"}, verdict ${result?.verdict ?? "?"}, jq ${result?.jq ?? "?"}, ` +
+          `checks ${checks.length}); cannot certify the developer is daemonless + fresh`,
+      ),
+    ];
+  }
+
+  const out = [];
+  for (const name of rows) {
+    const row = checks.find((c) => c?.name === name);
+    if (!row) {
+      out.push(
+        mkCheck(
+          name,
+          STATUS.FAIL,
+          `verify-node did not report "${name}" (class=${result?.node_class ?? "?"}) — ` +
+            `cannot certify daemonless + fresh`,
+        ),
+      );
+      continue;
+    }
+    out.push(mkCheck(name, VN_STATUS_MAP[row.status] ?? STATUS.FAIL, row.detail ?? ""));
+  }
+  return out;
+}
+
+// ─── Suite selection ─────────────────────────────────────────────────────────
+
+// checksForClass — build the check-thunk suite for a resolved node class. This is
+// the single class switch; runDoctor calls it unless an explicit `checks` array is
+// injected. `opts` carries seed/otel/expectedBotUserId plus the injectable seams
+// the developer/monitor checks honor (runVerifyNode, baseUrl, fetch, roster/drain).
+// Undefined seams fall through to each check's real default (JS default params
+// apply for `undefined`), so production passes nothing and tests inject fixtures.
+export function checksForClass(nc, opts = {}) {
+  const {
+    seed = null,
+    otel = null,
     expectedBotUserId = null,
+    runVerifyNode,
+    readReplicaBaseUrl,
+    fetch: _fetch,
+    resolveRoster,
+    isDraining: _isDraining,
+    orchDir,
+    bootDrained,
+    getHostName: _getHostName,
   } = opts;
 
-  // Default check suite — all check functions with real deps
-  const defaultChecks = [
+  const nodeClassCheck = () => checkNodeClass({ nodeClass: nc });
+
+  // Unrecognized explicit class → a single hard FAIL; grade no profile (CTL-1355).
+  if (!nc.recognized) {
+    return [nodeClassCheck];
+  }
+
+  const replicaThunk = () => checkReadReplicaReachable({ baseUrl: readReplicaBaseUrl, fetch: _fetch });
+  const wontOwnThunk = () =>
+    checkWontOwnWork({
+      resolveRoster,
+      isDraining: _isDraining,
+      orchDir,
+      bootDrained,
+      getHostName: _getHostName,
+    });
+
+  if (nc.class === "developer") {
+    // A developer's interactive token need not be the BOT — keep linear-connectivity
+    // as a gate, but downgrade bot-identity FAIL → INFO (worker-only gating).
+    const developerBotCredentials = async () => {
+      const cs = await checkBotCredentials({ expectedBotUserId, fetch: _fetch });
+      return cs.map((c) =>
+        c.name === "bot-identity" && c.status === STATUS.FAIL
+          ? mkCheck(c.name, STATUS.INFO, `${c.detail} (advisory for a developer — interactive token need not be the bot)`)
+          : c,
+      );
+    };
+    return [
+      nodeClassCheck,
+      () => checkConnectivity({ seed, otel, fetch: _fetch }),
+      () => checkSecretsHygiene(),
+      () => checkClaudeSettings(),
+      developerBotCredentials,
+      () => checkHrwPartition(), // would-own count (visibility)
+      () => checkDaemonlessLocal({ nodeClass: nc.class, runVerifyNode }), // broker/exec-core down + plugins fresh
+      replicaThunk,
+      wontOwnThunk,
+      () => checkReaper(), // advisory (never FAIL), class-agnostic
+      () => checkCloudTokenEnv(), // advisory
+      () => checkConfigScopeLeak(), // advisory
+    ];
+  }
+
+  if (nc.class === "monitor") {
+    // Most-restrictive STUB (no monitor host exists yet): reachability + must-not-
+    // own-work + a fail-closed profile stub. monitor grading is unimplemented, so
+    // doctor must REFUSE to certify a monitor node (FAIL, not WARN) — a WARN would
+    // exit 0 and let a misconfigured monitor running the work daemons masquerade as
+    // verified-healthy. This is correct because no real monitor nodes exist yet;
+    // the FAIL is removed when the monitor rubric lands (CTL-1355 F3).
+    return [
+      nodeClassCheck,
+      () => checkConnectivity({ seed, otel, fetch: _fetch }),
+      () => checkHrwPartition(), // would-own count (visibility)
+      replicaThunk,
+      wontOwnThunk,
+      () => [
+        mkCheck(
+          "monitor-profile",
+          STATUS.FAIL,
+          "monitor profile grading is not yet implemented — fail-closed (no monitor host " +
+            "exists yet); a monitor node cannot be certified by doctor until the monitor " +
+            "rubric lands (CTL-1355)",
+        ),
+      ],
+    ];
+  }
+
+  // worker (explicit OR inferred default) → today's full CTL-1186 activation gate,
+  // unchanged, with the node-class check prepended (INFO/PASS — never FAILs here).
+  return [
+    nodeClassCheck,
     () => checkHostIdentity(),
     () => checkHrwPartition(),
     () => checkPeerUniqueness(),
@@ -1609,8 +2046,26 @@ export async function runDoctor(opts = {}) {
     () => checkSdkExecutorAuth(), // CTL-1367 item 9: under executor=sdk, subscription auth must be correct (no api-key metering)
     () => checkConfigScopeLeak(), // CTL-1214: committed Layer-1 .catalyst/config.json must not carry node/cluster scope (roster/orchestration/feedback/sweep/repoColors/hosts.json)
   ];
+}
 
-  const fns = checkFns ?? defaultChecks;
+// runDoctor — orchestrate all checks, render, and return the fail count.
+export async function runDoctor(opts = {}) {
+  const {
+    checks: checkFns = null,
+    json = false,
+    log: _log = (msg) => process.stdout.write(msg + "\n"),
+    host = null,
+    seed = process.env.CATALYST_SEED_HOST ?? null,
+    otel = process.env.OTEL_EXPORTER_OTLP_ENDPOINT ?? null,
+    expectedBotUserId = null,
+    // CTL-1355: the class resolver is injectable so tests can drive each rubric.
+    resolveClass = resolveNodeClass,
+  } = opts;
+
+  // CTL-1355: resolve the node class once, then grade against its rubric. An
+  // explicit `checks` array still bypasses selection entirely (the test seam).
+  const nc = resolveClass();
+  const fns = checkFns ?? checksForClass(nc, { ...opts, seed, otel, expectedBotUserId });
 
   // Run all check functions concurrently
   const results = await Promise.all(fns.map((fn) => Promise.resolve().then(fn)));

--- a/plugins/dev/scripts/execution-core/doctor.mjs
+++ b/plugins/dev/scripts/execution-core/doctor.mjs
@@ -1671,6 +1671,9 @@ function defaultReadReplicaBaseUrl() {
 //   • remote + non-2xx   → FAIL (a TCP/any-response check would mask an unhealthy monitor)
 //   • remote + unreach   → FAIL (the probe threw / timed out)
 // GET + 5 s timeout; a 2xx is the health floor (CTL-1355 F4 — was "any response").
+// Probes the lightweight, always-on GET /api/version (server.ts) — orch-monitor
+// serves no plain /api/health (only the heavier /api/health/{otel,services}), so a
+// /api/health probe would 404 and false-FAIL a healthy read-replica (CTL-1355 P1).
 export async function checkReadReplicaReachable(deps = {}) {
   const { baseUrl = defaultReadReplicaBaseUrl(), fetch: _fetch = globalThis.fetch } = deps;
   const base = typeof baseUrl === "string" ? baseUrl.trim() : "";
@@ -1696,7 +1699,7 @@ export async function checkReadReplicaReachable(deps = {}) {
       ),
     ];
   }
-  const url = base.replace(/\/+$/, "") + "/api/health";
+  const url = base.replace(/\/+$/, "") + "/api/version";
   try {
     const res = await _fetch(url, { method: "GET", signal: AbortSignal.timeout(5000) });
     // F4 (CTL-1355): a 2xx is the health floor — any other response (404/5xx/…)
@@ -1951,6 +1954,7 @@ export function checksForClass(nc, opts = {}) {
     runVerifyNode,
     readReplicaBaseUrl,
     fetch: _fetch,
+    linearToken: _linearToken, // CTL-1355 P3: injectable for the developer Linear-token gate
     resolveRoster,
     isDraining: _isDraining,
     orchDir,
@@ -1976,21 +1980,38 @@ export function checksForClass(nc, opts = {}) {
     });
 
   if (nc.class === "developer") {
-    // A developer's interactive token need not be the BOT — keep linear-connectivity
-    // as a gate, but downgrade bot-identity FAIL → INFO (worker-only gating).
+    // A developer is a FUNCTIONAL node: it reads the board via the read-replica
+    // (CTL-1346) AND its operator's skills write transitions/comments to Linear, so a
+    // working Linear token is REQUIRED (CTL-1355 P3). checkBotCredentials degrades a
+    // missing token to WARN; for a developer that is a fail-closed FAIL on
+    // linear-connectivity (an unreachable token already FAILs upstream). The
+    // bot-identity ACTOR-match, by contrast, stays advisory — a developer's
+    // interactive token need not be the bot — so a FAIL there downgrades to INFO.
     const developerBotCredentials = async () => {
-      const cs = await checkBotCredentials({ expectedBotUserId, fetch: _fetch });
-      return cs.map((c) =>
-        c.name === "bot-identity" && c.status === STATUS.FAIL
-          ? mkCheck(c.name, STATUS.INFO, `${c.detail} (advisory for a developer — interactive token need not be the bot)`)
-          : c,
-      );
+      const cs = await checkBotCredentials({ expectedBotUserId, fetch: _fetch, linearToken: _linearToken });
+      return cs.map((c) => {
+        if (c.name === "linear-connectivity" && c.status === STATUS.WARN) {
+          return mkCheck(
+            c.name,
+            STATUS.FAIL,
+            `${c.detail} — a developer needs a working Linear token to read the board ` +
+              `(read-replica, CTL-1346) and write transitions/comments`,
+          );
+        }
+        if (c.name === "bot-identity" && c.status === STATUS.FAIL) {
+          return mkCheck(c.name, STATUS.INFO, `${c.detail} (advisory for a developer — interactive token need not be the bot)`);
+        }
+        return c;
+      });
     };
+    // NOTE (CTL-1355 P2): no checkClaudeSettings here — that gates worker-cluster-MEMBER
+    // telemetry/host-pin provisioning. A developer is a CLIENT, not a roster member; a
+    // developer deliberately out of a multi-host roster must not be graded against
+    // worker-member Claude settings that don't apply to it.
     return [
       nodeClassCheck,
       () => checkConnectivity({ seed, otel, fetch: _fetch }),
       () => checkSecretsHygiene(),
-      () => checkClaudeSettings(),
       developerBotCredentials,
       () => checkHrwPartition(), // would-own count (visibility)
       () => checkDaemonlessLocal({ nodeClass: nc.class, runVerifyNode }), // broker/exec-core down + plugins fresh

--- a/plugins/dev/scripts/execution-core/doctor.test.mjs
+++ b/plugins/dev/scripts/execution-core/doctor.test.mjs
@@ -1464,14 +1464,15 @@ describe("checkReadReplicaReachable (CTL-1355)", () => {
     expect(checks[0].status).toBe(STATUS.FAIL);
   });
 
-  it("PASSes a reachable remote endpoint returning 2xx (probes /api/health)", async () => {
+  it("PASSes a reachable remote endpoint returning 2xx (probes /api/version, P1)", async () => {
     let probed = null;
     const checks = await checkReadReplicaReachable({
       baseUrl: "http://mini:7400",
       fetch: async (url) => { probed = url; return { ok: true, status: 200 }; },
     });
     expect(checks[0].status).toBe(STATUS.PASS);
-    expect(probed).toBe("http://mini:7400/api/health");
+    // P1: orch-monitor serves no plain /api/health — probe the lightweight /api/version
+    expect(probed).toBe("http://mini:7400/api/version");
   });
 
   it("FAILs a remote endpoint that answers with a non-2xx status (F4 — 2xx is the floor)", async () => {
@@ -1732,6 +1733,9 @@ describe("checksForClass — suite selection (CTL-1355)", () => {
     expect(s).not.toContain("checkWebhookIngestion()");
     expect(s).not.toContain("checkThoughts()");
     expect(s).not.toContain("checkSdkExecutorAuth()");
+    // P2: checkClaudeSettings is a worker-cluster-MEMBER concern — a developer client
+    // (deliberately out of a multi-host roster) must not be graded against it.
+    expect(s).not.toContain("checkClaudeSettings()");
   });
 
   it("monitor → minimal stub: reachability + wont-own + a fail-closed profile-stub", () => {
@@ -1755,6 +1759,34 @@ describe("checksForClass — suite selection (CTL-1355)", () => {
     expect(out[0].name).toBe("monitor-profile");
     expect(out[0].status).toBe(STATUS.FAIL);
     expect(out[0].detail).toContain("fail-closed");
+  });
+});
+
+describe("developer Linear-token gate (CTL-1355 P3)", () => {
+  const devNc = nodeClassOf({ class: "developer", raw: "developer" });
+  // The developer bot-credentials thunk is the only one whose source references
+  // checkBotCredentials; pull it out of the rubric and run it with an injected token.
+  const botThunkOf = (opts) =>
+    checksForClass(devNc, opts).find((f) => f.toString().includes("checkBotCredentials"));
+
+  it("developer with NO Linear token → linear-connectivity FAILs (fail-closed)", async () => {
+    const thunk = botThunkOf({ linearToken: () => "" });
+    expect(thunk).toBeDefined();
+    const out = await thunk();
+    const conn = out.find((c) => c.name === "linear-connectivity");
+    expect(conn.status).toBe(STATUS.FAIL);
+    expect(conn.detail).toContain("Linear token");
+  });
+
+  it("developer with a working Linear token → linear-connectivity PASSes; bot-identity stays advisory (never FAIL)", async () => {
+    const thunk = botThunkOf({
+      linearToken: () => "lin_api_dev",
+      fetch: fakeFetch({ data: { viewer: { id: "dev-actor", email: "dev@example.com" } } }),
+    });
+    const out = await thunk();
+    expect(out.find((c) => c.name === "linear-connectivity").status).toBe(STATUS.PASS);
+    // a developer's interactive token need not be the bot → bot-identity never gates
+    expect(out.find((c) => c.name === "bot-identity").status).not.toBe(STATUS.FAIL);
   });
 });
 

--- a/plugins/dev/scripts/execution-core/doctor.test.mjs
+++ b/plugins/dev/scripts/execution-core/doctor.test.mjs
@@ -24,6 +24,11 @@ import {
   checkCloudTokenEnv,
   checkSdkExecutorAuth,
   checkConfigScopeLeak,
+  checkNodeClass,
+  checkReadReplicaReachable,
+  checkWontOwnWork,
+  checkDaemonlessLocal,
+  checksForClass,
   summarize,
   renderJson,
   renderHuman,
@@ -1346,10 +1351,10 @@ describe("checkConfigScopeLeak (CTL-1214)", () => {
     expect(checks[0].status).toBe(STATUS.INFO);
   });
 
-  it("runDoctor wires checkConfigScopeLeak into its default Promise.all suite", () => {
-    // runDoctor's default check suite is defined inline in its body; assert the
-    // wiring without running the networked default checks.
-    expect(runDoctor.toString()).toContain("checkConfigScopeLeak()");
+  it("checksForClass wires checkConfigScopeLeak into the worker suite (CTL-1355: the suite moved out of runDoctor)", () => {
+    // The default (worker) suite is built by checksForClass now; assert the wiring
+    // without running the networked default checks.
+    expect(checksForClass.toString()).toContain("checkConfigScopeLeak()");
   });
 
   // ─── Regression: the doctor-exit / join-gate contract (CTL-1214) ────────────
@@ -1393,5 +1398,422 @@ describe("checkConfigScopeLeak (CTL-1214)", () => {
       log: () => {},
     });
     expect(code).toBe(0);
+  });
+});
+
+// ─── CTL-1355: class-aware grading ───────────────────────────────────────────
+
+const nodeClassOf = (over = {}) => ({
+  class: "worker",
+  source: "layer2",
+  inferred: false,
+  recognized: true,
+  raw: "worker",
+  ...over,
+});
+
+describe("checkNodeClass (CTL-1355)", () => {
+  it("PASSes an explicit, recognized class", () => {
+    const checks = checkNodeClass({ nodeClass: nodeClassOf({ class: "developer", raw: "developer" }) });
+    expect(checks).toHaveLength(1);
+    expect(checks[0].name).toBe("node-class");
+    expect(checks[0].status).toBe(STATUS.PASS);
+    expect(checks[0].detail).toContain("developer");
+  });
+
+  it("INFO-notes an inferred (unset) class — graded as worker, not a fail", () => {
+    const checks = checkNodeClass({
+      nodeClass: nodeClassOf({ class: "worker", source: "default", inferred: true, recognized: true, raw: null }),
+    });
+    expect(checks[0].status).toBe(STATUS.INFO);
+    expect(checks[0].detail).toContain("not explicitly set");
+  });
+
+  it("FAILs an explicit, UNRECOGNIZED class and names the raw value", () => {
+    const checks = checkNodeClass({
+      nodeClass: nodeClassOf({ class: "monitor", source: "env", inferred: false, recognized: false, raw: "developr" }),
+    });
+    expect(checks[0].status).toBe(STATUS.FAIL);
+    expect(checks[0].detail).toContain("developr");
+    expect(checks[0].detail).toContain("not one of");
+  });
+});
+
+describe("checkReadReplicaReachable (CTL-1355)", () => {
+  it("FAILs when no endpoint is configured", async () => {
+    const checks = await checkReadReplicaReachable({ baseUrl: null, fetch: async () => ({ status: 200 }) });
+    expect(checks[0].name).toBe("read-replica");
+    expect(checks[0].status).toBe(STATUS.FAIL);
+    expect(checks[0].detail).toContain("unset");
+  });
+
+  it("FAILs a localhost endpoint (empty local replica)", async () => {
+    const checks = await checkReadReplicaReachable({
+      baseUrl: "http://localhost:7400",
+      fetch: async () => ({ status: 200 }),
+    });
+    expect(checks[0].status).toBe(STATUS.FAIL);
+    expect(checks[0].detail).toContain("localhost");
+  });
+
+  it("FAILs a 127.0.0.1 endpoint", async () => {
+    const checks = await checkReadReplicaReachable({
+      baseUrl: " http://127.0.0.1:7400 ", // padded — trimmed first
+      fetch: async () => ({ status: 200 }),
+    });
+    expect(checks[0].status).toBe(STATUS.FAIL);
+  });
+
+  it("PASSes a reachable remote endpoint returning 2xx (probes /api/health)", async () => {
+    let probed = null;
+    const checks = await checkReadReplicaReachable({
+      baseUrl: "http://mini:7400",
+      fetch: async (url) => { probed = url; return { ok: true, status: 200 }; },
+    });
+    expect(checks[0].status).toBe(STATUS.PASS);
+    expect(probed).toBe("http://mini:7400/api/health");
+  });
+
+  it("FAILs a remote endpoint that answers with a non-2xx status (F4 — 2xx is the floor)", async () => {
+    const checks = await checkReadReplicaReachable({
+      baseUrl: "http://mini:7400",
+      fetch: async () => ({ ok: false, status: 503 }),
+    });
+    expect(checks[0].status).toBe(STATUS.FAIL);
+    expect(checks[0].detail).toContain("503");
+    expect(checks[0].detail).toContain("not healthy");
+  });
+
+  it("FAILs a remote endpoint that is unreachable", async () => {
+    const checks = await checkReadReplicaReachable({
+      baseUrl: "http://mini:7400",
+      fetch: async () => { throw new Error("ECONNREFUSED"); },
+    });
+    expect(checks[0].status).toBe(STATUS.FAIL);
+    expect(checks[0].detail).toContain("ECONNREFUSED");
+  });
+});
+
+describe("checkWontOwnWork (CTL-1355 — fail-closed F1)", () => {
+  const multiInRoster = () => ({ hosts: ["mini", "laptop"], source: "cluster-repo", multiHost: true });
+  const outOfRoster = () => ({ hosts: ["mini", "mini-2"], source: "cluster-repo", multiHost: true });
+  const staticOutOfRoster = () => ({ hosts: ["mini", "mini-2"], source: "static", multiHost: true });
+  // The COMMON dangerous case: resolveClusterHosts is FAIL-OPEN, so an
+  // absent/stale cluster-repo clone collapses to a single-host roster of self.
+  const singleSelf = () => ({ hosts: ["laptop"], source: "single-host", multiHost: false });
+  // A source-less, non-multiHost roster that omits self (defensive: resolver
+  // exposes no source flag) — NOT authoritative, so out-of-roster can't be confirmed.
+  const sourcelessSingle = () => ({ hosts: ["mini"], multiHost: false });
+
+  it("PASSes when boot-drained (admits no new work)", () => {
+    const checks = checkWontOwnWork({
+      resolveRoster: multiInRoster,
+      getHostName: () => "laptop",
+      isDraining: () => false,
+      bootDrained: true,
+    });
+    expect(checks[0].name).toBe("would-not-own-work");
+    expect(checks[0].status).toBe(STATUS.PASS);
+    expect(checks[0].detail).toContain("drained");
+  });
+
+  it("PASSes when the drain flag file is present", () => {
+    const checks = checkWontOwnWork({
+      resolveRoster: multiInRoster,
+      getHostName: () => "laptop",
+      isDraining: () => true,
+      bootDrained: false,
+    });
+    expect(checks[0].status).toBe(STATUS.PASS);
+  });
+
+  it("PASSes when confirmed out of an AUTHORITATIVE (cluster-repo) roster — HRW assigns nothing", () => {
+    const checks = checkWontOwnWork({
+      resolveRoster: outOfRoster,
+      getHostName: () => "laptop",
+      isDraining: () => false,
+      bootDrained: false,
+    });
+    expect(checks[0].status).toBe(STATUS.PASS);
+    expect(checks[0].detail).toContain("not in the authoritative cluster roster");
+  });
+
+  it("PASSes when confirmed out of an explicit static roster (also authoritative)", () => {
+    const checks = checkWontOwnWork({
+      resolveRoster: staticOutOfRoster,
+      getHostName: () => "laptop",
+      isDraining: () => false,
+      bootDrained: false,
+    });
+    expect(checks[0].status).toBe(STATUS.PASS);
+  });
+
+  it("FAILs when in a roster and not drained (HRW would assign work)", () => {
+    const checks = checkWontOwnWork({
+      resolveRoster: multiInRoster,
+      getHostName: () => "laptop",
+      isDraining: () => false,
+      bootDrained: false,
+    });
+    expect(checks[0].status).toBe(STATUS.FAIL);
+    expect(checks[0].detail).toContain("would own work");
+    expect(checks[0].detail).toContain("CATALYST_BOOT_DRAINED");
+  });
+
+  it("FAILs (not WARN) a fail-open single-host roster including self, not drained — the common dev-laptop collapse", () => {
+    const checks = checkWontOwnWork({
+      resolveRoster: singleSelf,
+      getHostName: () => "laptop",
+      isDraining: () => false,
+      bootDrained: false,
+    });
+    expect(checks[0].status).toBe(STATUS.FAIL);
+    expect(checks[0].detail).toContain("would own work");
+  });
+
+  it("FAILs a non-authoritative source-less roster that omits self, not drained (can't confirm out-of-roster → fail-open 100%)", () => {
+    const checks = checkWontOwnWork({
+      resolveRoster: sourcelessSingle,
+      getHostName: () => "laptop",
+      isDraining: () => false,
+      bootDrained: false,
+    });
+    expect(checks[0].status).toBe(STATUS.FAIL);
+    // not in the (non-authoritative) roster → the "can't confirm" fail-open reason
+    expect(checks[0].detail).toContain("100%");
+  });
+});
+
+describe("checkDaemonlessLocal (CTL-1355 — folds verify-node --json)", () => {
+  const vnFixture = (statusFor = {}) => ({
+    node_class: "developer",
+    verdict: "pass",
+    exit_code: 0,
+    required_failures: 0,
+    checks: [
+      { name: "node-class", tier: "T1", required: true, status: "PASS", detail: "node.class=developer" },
+      { name: "broker-stopped", tier: "T1", required: true, status: statusFor["broker-stopped"] ?? "PASS", detail: "broker not running" },
+      { name: "exec-core-stopped", tier: "T1", required: true, status: statusFor["exec-core-stopped"] ?? "PASS", detail: "exec-core not running" },
+      { name: "plugins-fresh", tier: "T1", required: true, status: statusFor["plugins-fresh"] ?? "PASS", detail: "verify-updater all-green" },
+      { name: "read-replica", tier: "T1", required: true, status: "PASS", detail: "remote" },
+      { name: "would-not-own-work", tier: "T1", required: true, status: "PASS", detail: "out of roster" },
+    ],
+  });
+
+  it("folds the daemonless + plugins-fresh rows, all PASS", () => {
+    const checks = checkDaemonlessLocal({ runVerifyNode: () => vnFixture() });
+    expect(checks.map((c) => c.name)).toEqual(["broker-stopped", "exec-core-stopped", "plugins-fresh"]);
+    expect(checks.every((c) => c.status === STATUS.PASS)).toBe(true);
+    // it does NOT fold read-replica / would-not-own-work (doctor computes those natively)
+    expect(checks.find((c) => c.name === "read-replica")).toBeUndefined();
+  });
+
+  it("translates a verify-node FAIL row to a doctor FAIL", () => {
+    const checks = checkDaemonlessLocal({ runVerifyNode: () => vnFixture({ "broker-stopped": "FAIL" }) });
+    const broker = checks.find((c) => c.name === "broker-stopped");
+    expect(broker.status).toBe(STATUS.FAIL);
+  });
+
+  it("translates a plugins-fresh FAIL (stale plugins) to a doctor FAIL", () => {
+    const checks = checkDaemonlessLocal({ runVerifyNode: () => vnFixture({ "plugins-fresh": "FAIL" }) });
+    expect(checks.find((c) => c.name === "plugins-fresh").status).toBe(STATUS.FAIL);
+  });
+
+  it("translates an uppercase SKIP to INFO", () => {
+    const checks = checkDaemonlessLocal({ runVerifyNode: () => vnFixture({ "broker-stopped": "SKIP" }) });
+    expect(checks.find((c) => c.name === "broker-stopped").status).toBe(STATUS.INFO);
+  });
+
+  it("FAILs (fail-closed, F2) when a required row is missing from verify-node output", () => {
+    const checks = checkDaemonlessLocal({
+      runVerifyNode: () => ({ node_class: "developer", checks: [{ name: "node-class", status: "PASS" }] }),
+    });
+    expect(checks.every((c) => c.status === STATUS.FAIL)).toBe(true);
+  });
+
+  it("FAILs (fail-closed, F2) an unmappable row status", () => {
+    const checks = checkDaemonlessLocal({
+      runVerifyNode: () => vnFixture({ "broker-stopped": "BOGUS" }),
+    });
+    expect(checks.find((c) => c.name === "broker-stopped").status).toBe(STATUS.FAIL);
+  });
+
+  it("FAILs (fail-closed, F2) when verify-node cannot be run (spawn error)", () => {
+    const checks = checkDaemonlessLocal({
+      runVerifyNode: () => { throw new Error("catalyst-stack: command not found"); },
+    });
+    expect(checks).toHaveLength(1);
+    expect(checks[0].name).toBe("verify-node");
+    expect(checks[0].status).toBe(STATUS.FAIL);
+    expect(checks[0].detail).toContain("cannot certify");
+  });
+
+  it("FAILs (fail-closed, F2) when verify-node returns an empty checks array", () => {
+    const checks = checkDaemonlessLocal({
+      runVerifyNode: () => ({ node_class: "developer", exit_code: 0, checks: [] }),
+    });
+    expect(checks).toHaveLength(1);
+    expect(checks[0].name).toBe("verify-node");
+    expect(checks[0].status).toBe(STATUS.FAIL);
+  });
+
+  it("FAILs (fail-closed, F2) when verify-node reports jq:false", () => {
+    const checks = checkDaemonlessLocal({
+      runVerifyNode: () => ({ ...vnFixture(), jq: false }),
+    });
+    expect(checks).toHaveLength(1);
+    expect(checks[0].name).toBe("verify-node");
+    expect(checks[0].status).toBe(STATUS.FAIL);
+  });
+
+  it("FAILs (fail-closed, F2) when verify-node exits non-zero (captured child status)", () => {
+    const checks = checkDaemonlessLocal({
+      runVerifyNode: () => ({ ...vnFixture(), exit_code: 2 }),
+    });
+    expect(checks).toHaveLength(1);
+    expect(checks[0].name).toBe("verify-node");
+    expect(checks[0].status).toBe(STATUS.FAIL);
+    expect(checks[0].detail).toContain("exit 2");
+  });
+
+  it("FAILs (fail-closed, F2) when verify-node reports a fail verdict", () => {
+    const checks = checkDaemonlessLocal({
+      runVerifyNode: () => ({ ...vnFixture(), verdict: "fail" }),
+    });
+    expect(checks).toHaveLength(1);
+    expect(checks[0].status).toBe(STATUS.FAIL);
+  });
+});
+
+describe("checksForClass — suite selection (CTL-1355)", () => {
+  // Each suite is an array of THUNKS; .toString() reveals which check each calls.
+  const src = (nc, opts = {}) => checksForClass(nc, opts).map((f) => f.toString()).join("\n");
+
+  it("unrecognized class → exactly one thunk (the node-class FAIL), nothing graded", async () => {
+    const nc = nodeClassOf({ recognized: false, raw: "developr", class: "monitor" });
+    const suite = checksForClass(nc);
+    expect(suite).toHaveLength(1);
+    const out = (await suite[0]());
+    expect(out[0].name).toBe("node-class");
+    expect(out[0].status).toBe(STATUS.FAIL);
+  });
+
+  it("worker (explicit) → today's full CTL-1186 gate (host-identity, daemon-PATH, peer, sdk, scope-leak)", () => {
+    const s = src(nodeClassOf({ class: "worker", raw: "worker" }));
+    expect(s).toContain("checkHostIdentity()");
+    expect(s).toContain("checkDaemonToolPath()");
+    expect(s).toContain("checkPeerUniqueness()");
+    expect(s).toContain("checkWebhookIngestion()");
+    expect(s).toContain("checkThoughts()");
+    expect(s).toContain("checkSdkExecutorAuth()");
+    expect(s).toContain("checkConfigScopeLeak()");
+    expect(s).toContain("checkHrwPartition()"); // would-own visibility
+  });
+
+  it("an inferred (unset) class grades as the worker suite (zero change)", () => {
+    const inferred = nodeClassOf({ class: "worker", source: "default", inferred: true, recognized: true, raw: null });
+    const s = src(inferred);
+    expect(s).toContain("checkHostIdentity()");
+    expect(s).toContain("checkDaemonToolPath()");
+  });
+
+  it("developer → daemonless fold + read-replica + wont-own + Linear; EXCLUDES worker-only gates", () => {
+    const s = src(nodeClassOf({ class: "developer", raw: "developer" }));
+    // developer value-add + reused checks
+    expect(s).toContain("checkDaemonlessLocal");
+    expect(s).toContain("checkReadReplicaReachable");
+    expect(s).toContain("checkWontOwnWork");
+    expect(s).toContain("checkBotCredentials"); // Linear reachable (bot-identity downgraded)
+    expect(s).toContain("checkHrwPartition()"); // would-own visibility
+    // worker-only gates are excluded
+    expect(s).not.toContain("checkHostIdentity()");
+    expect(s).not.toContain("checkDaemonToolPath()");
+    expect(s).not.toContain("checkPeerUniqueness()");
+    expect(s).not.toContain("checkWebhookIngestion()");
+    expect(s).not.toContain("checkThoughts()");
+    expect(s).not.toContain("checkSdkExecutorAuth()");
+  });
+
+  it("monitor → minimal stub: reachability + wont-own + a fail-closed profile-stub", () => {
+    const nc = nodeClassOf({ class: "monitor", raw: "monitor" });
+    const s = src(nc);
+    expect(s).toContain("checkReadReplicaReachable");
+    expect(s).toContain("checkWontOwnWork");
+    expect(s).toContain("checkHrwPartition()");
+    expect(s).toContain("monitor-profile"); // the fail-closed stub
+    expect(s).not.toContain("checkHostIdentity()");
+    expect(s).not.toContain("checkDaemonlessLocal"); // monitor doesn't fold verify-node
+  });
+
+  it("monitor → monitor-profile is a fail-closed FAIL (F3 — doctor refuses to certify monitors)", async () => {
+    const nc = nodeClassOf({ class: "monitor", raw: "monitor" });
+    const suite = checksForClass(nc);
+    // The profile-stub is the only thunk whose source mentions monitor-profile.
+    const profileThunk = suite.find((f) => f.toString().includes("monitor-profile"));
+    expect(profileThunk).toBeDefined();
+    const out = await profileThunk();
+    expect(out[0].name).toBe("monitor-profile");
+    expect(out[0].status).toBe(STATUS.FAIL);
+    expect(out[0].detail).toContain("fail-closed");
+  });
+});
+
+describe("runDoctor — class-aware routing (CTL-1355)", () => {
+  it("unrecognized class → single node-class FAIL, exit 1", async () => {
+    const logs = [];
+    const code = await runDoctor({
+      resolveClass: () => nodeClassOf({ class: "monitor", source: "env", inferred: false, recognized: false, raw: "developr" }),
+      json: true,
+      log: (m) => logs.push(m),
+    });
+    expect(code).toBe(1);
+    const parsed = JSON.parse(logs[0]);
+    expect(parsed.checks).toHaveLength(1);
+    expect(parsed.checks[0].name).toBe("node-class");
+    expect(parsed.checks[0].status).toBe(STATUS.FAIL);
+  });
+
+  it("developer rubric (daemonless+fresh+replica+wont-own all green) → exit 0", async () => {
+    // Build the deterministic developer value-add subset and run it end-to-end so the
+    // exit-code contract is exercised without touching real network/process state.
+    const vn = () => ({
+      node_class: "developer",
+      checks: [
+        { name: "broker-stopped", status: "PASS", detail: "down" },
+        { name: "exec-core-stopped", status: "PASS", detail: "down" },
+        { name: "plugins-fresh", status: "PASS", detail: "fresh" },
+      ],
+    });
+    const code = await runDoctor({
+      checks: [
+        () => checkDaemonlessLocal({ runVerifyNode: vn }),
+        () => checkReadReplicaReachable({ baseUrl: "http://mini:7400", fetch: async () => ({ status: 200 }) }),
+        () =>
+          checkWontOwnWork({
+            resolveRoster: () => ({ hosts: ["mini", "mini-2"], multiHost: true }),
+            getHostName: () => "laptop",
+            isDraining: () => false,
+            bootDrained: false,
+          }),
+      ],
+      log: () => {},
+    });
+    expect(code).toBe(0);
+  });
+
+  it("developer that WOULD pick up work (in multi-host roster, not drained) → non-zero exit", async () => {
+    const code = await runDoctor({
+      checks: [
+        () =>
+          checkWontOwnWork({
+            resolveRoster: () => ({ hosts: ["mini", "laptop"], multiHost: true }),
+            getHostName: () => "laptop",
+            isDraining: () => false,
+            bootDrained: false,
+          }),
+      ],
+      log: () => {},
+    });
+    expect(code).toBe(1);
   });
 });


### PR DESCRIPTION
## What & why

Completes **CTL-1355**: `catalyst-doctor` now grades a node against its **class-specific rubric** instead of treating every node as a worker activation gate (which made a lone laptop grade as a healthy single-host cluster that owns all work). This is the "broader doctor" — the comprehensive grading that builds on `verify-node` (CTL-1355 1/n).

## Per-class rubric

| Class | doctor grades |
|---|---|
| **worker** (+ inferred-worker) | the existing **CTL-1186 activation gate** — would-own-work + Linear + bot reachable + roster membership. **Unchanged** (the common case; `catalyst-join` keys on this exit code). |
| **developer** | daemonless (broker/exec-core stopped) + plugins fresh + read-replica **reachable** + **will-not-own-work**. Reuses `verify-node`/`verify-updater` (read-only). |
| **monitor** | fail-closed stub (can't be certified until the monitor rubric lands). |
| **unrecognized class** | single hard FAIL naming the value (CTL-1344). |

The HRW would-own count is still printed for visibility.

## Adversarially hardened (fail-closed)

A doctor false-pass *certifies a misconfigured node* — and `catalyst-join` keys the gate on doctor's exit code, so the false-pass review focused on "should-be-FAIL degraded to WARN/exit-0":
- **F1 (HIGH):** the **fail-open roster resolver** — a dev laptop is the *least* likely to have the cluster repo cloned, so it collapsed to single-host and downgraded "won't own work" from FAIL to WARN (the most dangerous state — owns 100% if daemons start — graded as safe). Now PASS requires explicit **drain** OR **confirmed-out-of-an-authoritative-roster**, else FAIL.
- **F2 (HIGH):** a missing/failed `verify-node` fold now **FAILs** (not WARN), using `exit_code`/`verdict`/`jq` as backstops — the daemon-down safety net is no longer fail-open.
- **F3 (HIGH):** the monitor stub is **fail-closed** (FAIL, not a silent exit-0 PASS).
- **F4:** read-replica reachability requires a **2xx**, not any response.

The worker path + its CTL-1186/CTL-1214 contracts are **untouched** (verified live: the inferred-worker run is byte-identical plus one INFO line). **136 tests**; doctor + daemon import graphs clean; validated read-only across worker / developer / monitor / unrecognized on this laptop.

Closes CTL-1355. Relates to CTL-1349 (`verify-updater`), CTL-1355/1n (`verify-node`, reused), CTL-1346 (read-replica).

🤖 Generated with [Claude Code](https://claude.com/claude-code)