### PR TITLE
feat(dev): CTL-1369 (1/n) — top-level `catalyst` CLI router + catalyst.install.* telemetry contract

### DIFF
--- a/.github/workflows/execution-core-tests.yml
+++ b/.github/workflows/execution-core-tests.yml
@@ -225,6 +225,7 @@ jobs:
             unstuck-act-seams.test.mjs \
             lib/catalyst-resource.test.mjs \
             lib/node-class-parity.test.mjs \
+            lib/install-telemetry.test.mjs \
             updater/plugin-pull-defer.test.mjs \
             updater/updater.test.mjs \
             updater/updater-tracing.test.mjs

--- a/plugins/dev/scripts/__tests__/catalyst-router.test.sh
+++ b/plugins/dev/scripts/__tests__/catalyst-router.test.sh
@@ -90,11 +90,31 @@ echo "catalyst router — installed-as-symlink resolution (exec through a symlin
 # must resolve through it so SCRIPT_DIR finds the manifest + lib/host-identity.sh (regression
 # guard: a bare dirname made `version` print 'unknown' and `class` mis-source the resolver).
 if [[ -r "$manifest" ]] && command -v jq >/dev/null 2>&1; then
+  EXPECTED_VER="$(jq -r .version "$manifest")"
+  # absolute-target symlink
   SYMBIN="$(mktemp -d)"
   ln -s "$ROUTER" "$SYMBIN/catalyst"
-  expect_eq "version resolves through a symlink (not 'unknown')" "$(jq -r .version "$manifest")" "$("$SYMBIN/catalyst" version 2>/dev/null)"
+  expect_eq "version resolves through an absolute symlink (not 'unknown')" "$EXPECTED_VER" "$("$SYMBIN/catalyst" version 2>/dev/null)"
   if "$SYMBIN/catalyst" help 2>&1 | grep -q "Lifecycle:"; then ok "help resolves through a symlink"; else fail "help resolves through a symlink" "grouped usage missing"; fi
   rm -rf "$SYMBIN"
+
+  # RELATIVE-target symlink, invoked from an unrelated $PWD — readlink returns a path relative
+  # to the symlink dir, which must be normalized against THAT dir, not the caller's cwd. NB the
+  # relpath is computed from the PHYSICAL dirs (cd -P) so the link isn't dangling on a platform
+  # where TMPDIR lives behind a symlink (macOS /var → /private/var).
+  REL_ROOT="$(mktemp -d)"
+  mkdir -p "$REL_ROOT/bin"
+  if command -v python3 >/dev/null 2>&1; then
+    phys_bin="$(cd -P "$REL_ROOT/bin" && pwd)"
+    router_real="$(cd -P "$(dirname "$ROUTER")" && pwd)/$(basename "$ROUTER")"
+    rel_target="$(python3 -c "import os,sys;print(os.path.relpath(sys.argv[1],sys.argv[2]))" "$router_real" "$phys_bin")"
+    ln -s "$rel_target" "$REL_ROOT/bin/catalyst"
+    rel_ver="$(cd /tmp && "$REL_ROOT/bin/catalyst" version 2>/dev/null)"
+    expect_eq "version resolves through a RELATIVE symlink from another cwd" "$EXPECTED_VER" "$rel_ver"
+  else
+    ok "relative-symlink test (python3 unavailable — skipped)"
+  fi
+  rm -rf "$REL_ROOT"
 else
   ok "symlink resolution (manifest/jq unavailable — skipped)"
 fi

--- a/plugins/dev/scripts/__tests__/catalyst-router.test.sh
+++ b/plugins/dev/scripts/__tests__/catalyst-router.test.sh
@@ -85,6 +85,20 @@ else
   ok "version (manifest/jq unavailable — skipped)"
 fi
 
+echo "catalyst router — installed-as-symlink resolution (exec through a symlink)"
+# install-cli.sh installs the router as a DIRECT symlink from a local checkout; the router
+# must resolve through it so SCRIPT_DIR finds the manifest + lib/host-identity.sh (regression
+# guard: a bare dirname made `version` print 'unknown' and `class` mis-source the resolver).
+if [[ -r "$manifest" ]] && command -v jq >/dev/null 2>&1; then
+  SYMBIN="$(mktemp -d)"
+  ln -s "$ROUTER" "$SYMBIN/catalyst"
+  expect_eq "version resolves through a symlink (not 'unknown')" "$(jq -r .version "$manifest")" "$("$SYMBIN/catalyst" version 2>/dev/null)"
+  if "$SYMBIN/catalyst" help 2>&1 | grep -q "Lifecycle:"; then ok "help resolves through a symlink"; else fail "help resolves through a symlink" "grouped usage missing"; fi
+  rm -rf "$SYMBIN"
+else
+  ok "symlink resolution (manifest/jq unavailable — skipped)"
+fi
+
 echo "catalyst router — class show/set against a temp Layer-2 config"
 TMP_CFG="$(mktemp -t catalyst-router-cfg.XXXXXX)"
 cleanup() { rm -f "$TMP_CFG" "$TMP_CFG".* 2>/dev/null || true; }
@@ -142,6 +156,16 @@ if command -v jq >/dev/null 2>&1; then
   # show: an unparseable config is flagged (not silently rendered as 'unset ⇒ worker')
   printf 'not json at all {\n' > "$TMP_CFG"
   expect_contains "class show: unparseable config flagged" "$(cmd_class 2>&1)" "UNPARSEABLE"
+
+  # empty / whitespace-only config must PERSIST the class (jq-on-empty emits nothing → would
+  # otherwise write an empty file and lie about success)
+  printf '' > "$TMP_CFG"
+  empty_rc=0; cmd_class developer >/dev/null 2>&1 || empty_rc=$?
+  expect_eq "class set on empty config ⇒ rc 0" "0" "$empty_rc"
+  expect_eq "class set on empty config persists the value" "developer" "$(jq -r '.catalyst.node.class' "$TMP_CFG")"
+  printf '   \n' > "$TMP_CFG"
+  cmd_class worker >/dev/null 2>&1
+  expect_eq "class set on whitespace config persists the value" "worker" "$(jq -r '.catalyst.node.class' "$TMP_CFG")"
 else
   ok "class show/set (jq unavailable — skipped)"
 fi

--- a/plugins/dev/scripts/__tests__/catalyst-router.test.sh
+++ b/plugins/dev/scripts/__tests__/catalyst-router.test.sh
@@ -1,0 +1,152 @@
+#!/usr/bin/env bash
+# Shell tests for the top-level `catalyst` router (CTL-1369; absorbs CTL-1353).
+#
+# The router is SOURCED (its dispatch is guarded by BASH_SOURCE[0]==$0, so sourcing defines
+# the helpers without running a command). Dispatch is exercised by overriding the two seams
+# `resolve_tool` (where a catalyst-<x> tool resolves) and `run_tool` (the exec), so NO real
+# tool runs, no process is replaced, and no daemon/network/mutation happens. The `class`
+# verb is tested against a temp Layer-2 config; `version` against the real plugin manifest.
+#
+# Run: bash plugins/dev/scripts/__tests__/catalyst-router.test.sh
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROUTER="${SCRIPT_DIR}/../catalyst"
+
+FAILURES=0
+PASSES=0
+
+ok()   { PASSES=$((PASSES + 1)); echo "  PASS: $1"; }
+fail() { FAILURES=$((FAILURES + 1)); echo "  FAIL: $1"; echo "    $2"; }
+
+expect_eq() {
+  local name="$1" expected="$2" actual="$3"
+  if [[ "$expected" == "$actual" ]]; then ok "$name"; else fail "$name" "expected '$expected' got '$actual'"; fi
+}
+expect_contains() {
+  local name="$1" haystack="$2" needle="$3"
+  if [[ "$haystack" == *"$needle"* ]]; then ok "$name"; else fail "$name" "'$haystack' does not contain '$needle'"; fi
+}
+
+# Source the router (guard keeps dispatch from firing).
+# shellcheck disable=SC1090
+source "$ROUTER"
+
+# ─── Dispatch seams: capture instead of exec ──────────────────────────────────
+CAPTURED=""
+run_tool() { CAPTURED="$*"; return 0; }
+# Fake every catalyst-<x> as resolvable to "catalyst-<x>" so routing is deterministic.
+resolve_tool() { printf 'catalyst-%s' "$1"; return 0; }
+
+route() { CAPTURED=""; dispatch "$@" >/dev/null 2>&1; printf '%s' "$CAPTURED"; }
+
+echo "catalyst router — curated lifecycle verb routing"
+expect_eq "start → catalyst-stack start"            "catalyst-stack start --foo"        "$(route start --foo)"
+expect_eq "stop → catalyst-stack stop"              "catalyst-stack stop"               "$(route stop)"
+expect_eq "restart → catalyst-stack restart"        "catalyst-stack restart"            "$(route restart)"
+expect_eq "status → catalyst-stack status"          "catalyst-stack status"             "$(route status)"
+expect_eq "doctor → catalyst-doctor"                "catalyst-doctor --json"            "$(route doctor --json)"
+expect_eq "update → catalyst-stack hotpatch"        "catalyst-stack hotpatch"           "$(route update)"
+expect_eq "drain → catalyst-execution-core drain"   "catalyst-execution-core drain --off" "$(route drain --off)"
+expect_eq "install → catalyst-install install"      "catalyst-install install --class developer" "$(route install --class developer)"
+expect_eq "uninstall → catalyst-install uninstall"  "catalyst-install uninstall"        "$(route uninstall)"
+expect_eq "reinstall → catalyst-install reinstall"  "catalyst-install reinstall"        "$(route reinstall)"
+
+echo "catalyst router — component auto-delegation (catalyst <x> → catalyst-<x>)"
+expect_eq "broker → catalyst-broker"                "catalyst-broker tail"              "$(route broker tail)"
+expect_eq "monitor → catalyst-monitor"              "catalyst-monitor"                  "$(route monitor)"
+expect_eq "events → catalyst-events"                "catalyst-events wait-for x"        "$(route events wait-for x)"
+
+echo "catalyst router — unknown command (no curated verb, no catalyst-<x>)"
+# Re-point resolve_tool to FAIL so the not-found path is exercised.
+resolve_tool() { return 1; }
+unknown_rc=0
+unknown_err="$(dispatch frobnicate 2>&1 >/dev/null)" || unknown_rc=$?
+expect_eq "unknown command exits non-zero" "127" "$unknown_rc"
+expect_contains "unknown command explains itself" "$unknown_err" "unknown command: frobnicate"
+# Restore the resolvable seam.
+resolve_tool() { printf 'catalyst-%s' "$1"; return 0; }
+
+echo "catalyst router — help / usage"
+help_out="$(dispatch help 2>&1)"
+expect_contains "help lists Lifecycle group"  "$help_out" "Lifecycle:"
+expect_contains "help lists Components group" "$help_out" "Components"
+bare_out="$(dispatch 2>&1)"
+expect_contains "bare catalyst prints usage"  "$bare_out" "Usage: catalyst <command>"
+
+echo "catalyst router — version"
+# NB: sourcing the router reassigned SCRIPT_DIR to the scripts dir, so the manifest is one
+# level up from here (plugins/dev/.claude-plugin/), exactly where plugin_version() reads it.
+manifest="${SCRIPT_DIR}/../.claude-plugin/plugin.json"
+if [[ -r "$manifest" ]] && command -v jq >/dev/null 2>&1; then
+  expect_eq "version matches the plugin manifest" "$(jq -r .version "$manifest")" "$(plugin_version)"
+else
+  ok "version (manifest/jq unavailable — skipped)"
+fi
+
+echo "catalyst router — class show/set against a temp Layer-2 config"
+TMP_CFG="$(mktemp -t catalyst-router-cfg.XXXXXX)"
+cleanup() { rm -f "$TMP_CFG" "$TMP_CFG".* 2>/dev/null || true; }
+trap cleanup EXIT
+export CATALYST_LAYER2_CONFIG_FILE="$TMP_CFG"
+
+if command -v jq >/dev/null 2>&1; then
+  printf '{}\n' > "$TMP_CFG"
+  # show: unset env, empty config ⇒ default worker
+  unset CATALYST_NODE_CLASS
+  show_out="$(cmd_class 2>&1)"
+  expect_contains "class show (unset) ⇒ worker default" "$show_out" "node class: worker"
+
+  # set: valid value writes Layer-2 atomically
+  set_rc=0; set_out="$(cmd_class developer 2>&1)" || set_rc=$?
+  expect_eq "class set valid ⇒ rc 0" "0" "$set_rc"
+  expect_eq "class set writes catalyst.node.class" "developer" "$(jq -r '.catalyst.node.class' "$TMP_CFG")"
+  expect_contains "class set advises restart" "$set_out" "catalyst restart"
+
+  # show after set reflects the configured value
+  expect_contains "class show reflects Layer-2 value" "$(cmd_class 2>&1)" "node class: developer"
+
+  # set must PRESERVE every other Layer-2 key (it's a targeted merge, not a clobber)
+  printf '{"catalyst":{"host":{"name":"mini"},"cluster":{"x":1}},"other":true}\n' > "$TMP_CFG"
+  cmd_class worker >/dev/null 2>&1
+  expect_eq "class set preserves catalyst.host.name"  "mini" "$(jq -r '.catalyst.host.name' "$TMP_CFG")"
+  expect_eq "class set preserves catalyst.cluster.x"  "1"    "$(jq -r '.catalyst.cluster.x' "$TMP_CFG")"
+  expect_eq "class set preserves unrelated top key"   "true" "$(jq -r '.other' "$TMP_CFG")"
+  expect_eq "class set still wrote the new class"     "worker" "$(jq -r '.catalyst.node.class' "$TMP_CFG")"
+
+  # invalid value rejected, config untouched (assert against the pre-attempt value, so the
+  # test is independent of which valid class the config happened to hold beforehand)
+  before_invalid="$(jq -r '.catalyst.node.class' "$TMP_CFG")"
+  bad_rc=0; bad_out="$(cmd_class bogus 2>&1)" || bad_rc=$?
+  expect_eq "class set invalid ⇒ rc 2" "2" "$bad_rc"
+  expect_contains "class set invalid explains valid set" "$bad_out" "valid: developer, worker, monitor"
+  expect_eq "class set invalid leaves config unchanged" "$before_invalid" "$(jq -r '.catalyst.node.class' "$TMP_CFG")"
+
+  # no-clobber: a malformed config is NOT overwritten on set
+  printf 'this is not json\n' > "$TMP_CFG"
+  clobber_rc=0; cmd_class worker >/dev/null 2>&1 || clobber_rc=$?
+  expect_eq "class set on malformed config ⇒ rc 3" "3" "$clobber_rc"
+  expect_eq "malformed config left untouched" "this is not json" "$(cat "$TMP_CFG")"
+
+  # mv failure must FAIL CLOSED, not lie: override the mv seam to fail, assert rc 3 + NO
+  # success line (regression guard for the silent-success bug the adversarial review caught).
+  printf '{}\n' > "$TMP_CFG"
+  mv() { return 1; }
+  mvfail_rc=0; mvfail_out="$(cmd_class developer 2>&1)" || mvfail_rc=$?
+  unset -f mv
+  expect_eq "class set: mv failure ⇒ rc 3" "3" "$mvfail_rc"
+  expect_contains "class set: mv failure reports the failure" "$mvfail_out" "failed to write"
+  if [[ "$mvfail_out" != *"node class set to"* ]]; then ok "class set: mv failure prints NO success line"; else fail "class set: mv failure prints NO success line" "leaked: $mvfail_out"; fi
+
+  # show: an unparseable config is flagged (not silently rendered as 'unset ⇒ worker')
+  printf 'not json at all {\n' > "$TMP_CFG"
+  expect_contains "class show: unparseable config flagged" "$(cmd_class 2>&1)" "UNPARSEABLE"
+else
+  ok "class show/set (jq unavailable — skipped)"
+fi
+
+echo
+echo "──────────────────────────────────────────"
+echo "catalyst-router.test.sh: ${PASSES} passed, ${FAILURES} failed"
+[[ "$FAILURES" -eq 0 ]]

--- a/plugins/dev/scripts/catalyst
+++ b/plugins/dev/scripts/catalyst
@@ -25,10 +25,16 @@ set -uo pipefail
 
 # Resolve through symlinks before deriving SCRIPT_DIR — install-cli.sh installs this router
 # as a DIRECT symlink from a local checkout, so a bare dirname would point at ~/.catalyst/bin
-# (manifest + lib/host-identity.sh lookups would miss). Same idiom as catalyst-stack.
+# (manifest + lib/host-identity.sh lookups would miss). Normalize each hop against the
+# SYMLINK's own directory so a RELATIVE target (e.g. `catalyst -> ../plugins/dev/scripts/catalyst`)
+# resolves correctly regardless of the caller's $PWD, not just absolute targets.
 _SRC="${BASH_SOURCE[0]}"
-while [[ -L "$_SRC" ]]; do _SRC="$(readlink "$_SRC")"; done
-SCRIPT_DIR="$(cd "$(dirname "$_SRC")" && pwd)"
+while [[ -L "$_SRC" ]]; do
+  _DIR="$(cd -P "$(dirname "$_SRC")" && pwd)"
+  _SRC="$(readlink "$_SRC")"
+  [[ "$_SRC" != /* ]] && _SRC="$_DIR/$_SRC"
+done
+SCRIPT_DIR="$(cd -P "$(dirname "$_SRC")" && pwd)"
 
 # Bring in catalyst_node_class (CTL-1368 Bash resolver) for `catalyst class` show. Best-effort:
 # the router still dispatches if the lib is missing (the `class` verb degrades gracefully).

--- a/plugins/dev/scripts/catalyst
+++ b/plugins/dev/scripts/catalyst
@@ -1,0 +1,212 @@
+#!/usr/bin/env bash
+# catalyst — the single front door to the Catalyst toolchain (CTL-1369; absorbs CTL-1353).
+#
+# Usage: catalyst <command> [args...]
+#
+# A git-style dispatch router. It holds NO business logic: a curated lifecycle verb runs
+# the right tool, and any OTHER <command> execs `catalyst-<command>` by convention — so
+# every existing AND future `catalyst-*` tool is a subcommand for free, with zero upkeep.
+# Single-source-of-truth is preserved: the logic lives in each tool, never duplicated here.
+#
+# Lifecycle:
+#   install | uninstall | reinstall   provision / tear down this node for its class
+#   start | stop | restart | status    class-appropriate services up/down   (→ catalyst-stack)
+#   doctor                             class-aware health / activation grade (→ catalyst-doctor)
+#   update                             refresh plugins now (one-shot pull)   (→ catalyst-stack hotpatch)
+#   drain [--off]                      pause / resume work pickup            (→ catalyst-execution-core)
+#   class [<value>]                    show or set this node's class in Layer-2
+#   version | --version                the installed plugin version
+#   help [command]                     this help, or a tool's own --help
+#
+# Components (auto-delegated, `catalyst <x>` → `catalyst-<x>`):
+#   broker · monitor · events · comms · hud · session · db · state · transitions · why
+#   · cluster · filter · thoughts · execution-core · otel-forward
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Bring in catalyst_node_class (CTL-1368 Bash resolver) for `catalyst class` show. Best-effort:
+# the router still dispatches if the lib is missing (the `class` verb degrades gracefully).
+# shellcheck source=lib/host-identity.sh
+[[ -r "${SCRIPT_DIR}/lib/host-identity.sh" ]] && source "${SCRIPT_DIR}/lib/host-identity.sh"
+
+# Component tools surfaced in grouped help. Dispatch is by `catalyst-<x>` convention (not
+# this list) so a NEW catalyst-* tool is picked up automatically — this is help text only.
+readonly COMPONENT_VERBS="broker monitor events comms hud session db state transitions why cluster filter thoughts execution-core otel-forward"
+# Valid node classes. Source of truth: execution-core/config.mjs NODE_CLASSES (mirrored here
+# for the Bash `class` setter, the same way lib/host-identity.sh:catalyst_node_class mirrors it).
+readonly VALID_NODE_CLASSES="developer worker monitor"
+
+err() { printf 'catalyst: %s\n' "$*" >&2; }
+
+# resolve_tool NAME — absolute path to a sibling catalyst-NAME tool: prefer one on PATH
+# (the installed ~/.catalyst/bin wrapper), else the co-located script in this checkout
+# (with or without a .sh suffix). Empty + rc 1 when none exists.
+resolve_tool() {
+  local name="catalyst-$1" p
+  if p="$(command -v "$name" 2>/dev/null)"; then printf '%s' "$p"; return 0; fi
+  if [[ -x "${SCRIPT_DIR}/${name}" ]]; then printf '%s' "${SCRIPT_DIR}/${name}"; return 0; fi
+  if [[ -x "${SCRIPT_DIR}/${name}.sh" ]]; then printf '%s' "${SCRIPT_DIR}/${name}.sh"; return 0; fi
+  return 1
+}
+
+# run_tool TOOL ARGS... — hand the process off to a resolved tool. This is the dispatch
+# SEAM: the router's tests override it to capture the would-be exec instead of replacing
+# the process. In normal use it execs (the router adds zero runtime overhead to the tool).
+run_tool() { exec "$@"; }
+
+# delegate NAME ARGS... — resolve catalyst-NAME and hand off; otherwise print grouped usage
+# (never a stack trace) and fail. This is the auto-delegation that makes every catalyst-*
+# tool a subcommand.
+delegate() {
+  local name="$1"; shift
+  local tool
+  if tool="$(resolve_tool "$name")"; then
+    run_tool "$tool" "$@"
+  else
+    err "unknown command: $name"
+    err "no curated verb and no 'catalyst-$name' on PATH or in ${SCRIPT_DIR}"
+    usage >&2
+    return 127
+  fi
+}
+
+# plugin_version — the installed catalyst-dev plugin version from the plugin manifest.
+plugin_version() {
+  local manifest="${SCRIPT_DIR}/../.claude-plugin/plugin.json"
+  if [[ ! -r "$manifest" ]]; then echo "unknown"; return 0; fi
+  if command -v jq >/dev/null 2>&1; then
+    jq -r '.version // "unknown"' "$manifest" 2>/dev/null || echo "unknown"
+  else
+    # jq-free fallback: first "version": "x.y.z" in the manifest.
+    grep -o '"version"[[:space:]]*:[[:space:]]*"[^"]*"' "$manifest" 2>/dev/null \
+      | head -1 | sed -E 's/.*"([^"]*)"$/\1/' || echo "unknown"
+  fi
+}
+
+# layer2_config_path — the machine-local Layer-2 config (same precedence the rest of the
+# toolchain uses: CATALYST_LAYER2_CONFIG_FILE override, else ~/.config/catalyst/config.json).
+layer2_config_path() {
+  printf '%s' "${CATALYST_LAYER2_CONFIG_FILE:-${HOME}/.config/catalyst/config.json}"
+}
+
+# cmd_class [VALUE] — with no arg, show this node's effective class + its source; with a
+# value, set catalyst.node.class in Layer-2 (validated against VALID_NODE_CLASSES, written
+# atomically, 0600). A restart is required for daemons to pick up the new class.
+cmd_class() {
+  local val="${1:-}"
+  if [[ -z "$val" ]]; then
+    local raw="" source effective
+    if [[ -n "${CATALYST_NODE_CLASS:-}" ]]; then
+      raw="$CATALYST_NODE_CLASS"; source="env (CATALYST_NODE_CLASS)"
+    else
+      local cfg unparseable=false; cfg="$(layer2_config_path)"
+      if [[ -r "$cfg" ]] && command -v jq >/dev/null 2>&1; then
+        # Distinguish "key absent" from "file unparseable" — otherwise a broken config reads
+        # as 'unset ⇒ worker' and the operator never sees WHY their set class isn't taking.
+        if jq -e . "$cfg" >/dev/null 2>&1; then
+          raw="$(jq -r '.catalyst.node.class // empty' "$cfg" 2>/dev/null || true)"
+        else
+          unparseable=true
+        fi
+      fi
+      if [[ "$unparseable" == true ]]; then source="Layer-2 ($cfg) — UNPARSEABLE, treated as default"
+      elif [[ -n "$raw" ]]; then source="Layer-2 ($cfg)"
+      else source="default (unset ⇒ worker)"; fi
+    fi
+    if declare -F catalyst_node_class >/dev/null 2>&1; then effective="$(catalyst_node_class)"; else effective="worker"; fi
+    printf 'node class: %s\n' "$effective"
+    printf '  source:   %s\n' "$source"
+    if [[ -n "$raw" && "$raw" != "$effective" ]]; then
+      printf '  configured: %s (unrecognized ⇒ treated as %s)\n' "$raw" "$effective"
+    fi
+    return 0
+  fi
+
+  val="$(printf '%s' "$val" | tr '[:upper:]' '[:lower:]' | xargs 2>/dev/null || true)"
+  case " $VALID_NODE_CLASSES " in
+    *" $val "*) ;;
+    *) err "invalid node class: '$1' (valid: ${VALID_NODE_CLASSES// /, })"; return 2 ;;
+  esac
+  command -v jq >/dev/null 2>&1 || { err "jq is required to set the node class"; return 3; }
+  local cfg; cfg="$(layer2_config_path)"
+  mkdir -p "$(dirname "$cfg")" 2>/dev/null || true
+  local base='{}'
+  [[ -r "$cfg" ]] && base="$(cat "$cfg")"
+  local tmp; tmp="$(mktemp "${cfg}.XXXXXX")" || { err "cannot create temp file next to $cfg"; return 3; }
+  # No-clobber: a malformed existing config makes jq fail → abort, leaving it untouched.
+  if ! printf '%s' "$base" | jq --arg c "$val" '.catalyst.node.class = $c' > "$tmp" 2>/dev/null; then
+    rm -f "$tmp"
+    err "failed to update $cfg (is it valid JSON?)"
+    return 3
+  fi
+  chmod 600 "$tmp" 2>/dev/null || true
+  # The script runs under `set -uo pipefail` (no `-e`), so a failed `mv` would otherwise fall
+  # through to the success print and return 0 — a config write that lies. Gate on it: clean up
+  # the temp and FAIL CLOSED (e.g. a root-owned / immutable / directory target).
+  if ! mv "$tmp" "$cfg"; then
+    rm -f "$tmp"
+    err "failed to write $cfg (could not replace it — check ownership/permissions)"
+    return 3
+  fi
+  printf 'node class set to %s in %s\n' "$val" "$cfg"
+  printf 'restart services for it to take effect: catalyst restart\n'
+}
+
+# usage — the grouped command list (Lifecycle / Components). Printed for bare `catalyst`,
+# `catalyst help`, and any unknown command.
+usage() {
+  cat <<EOF
+catalyst — the single front door to the Catalyst toolchain.
+
+Usage: catalyst <command> [args...]
+
+Lifecycle:
+  install | uninstall | reinstall   provision / tear down this node for its class
+  start | stop | restart | status   class-appropriate services up/down
+  doctor                            class-aware health / activation grade
+  update                            refresh plugins now (one-shot pull)
+  drain [--off]                     pause / resume work pickup
+  class [<value>]                   show or set this node's class (developer|worker|monitor)
+  version                           the installed plugin version
+  help [command]                    this help, or a tool's own --help
+
+Components ('catalyst <x>' → 'catalyst-<x>'):
+  ${COMPONENT_VERBS// / · }
+
+Any other command delegates to 'catalyst-<command>' when it exists.
+EOF
+}
+
+# cmd_help [TOPIC] — grouped usage, or (when TOPIC resolves to a catalyst-TOPIC tool) that
+# tool's own --help.
+cmd_help() {
+  local topic="${1:-}"
+  if [[ -z "$topic" ]]; then usage; return 0; fi
+  local tool
+  if tool="$(resolve_tool "$topic")"; then run_tool "$tool" --help; else usage; fi
+}
+
+# dispatch COMMAND ARGS... — the router. Curated lifecycle verbs route to their backing
+# tool; everything else auto-delegates to catalyst-<command>.
+dispatch() {
+  local cmd="${1:-}"
+  [[ $# -gt 0 ]] && shift
+  case "$cmd" in
+    ""|help|-h|--help)            cmd_help "$@" ;;
+    version|--version|-v)         plugin_version ;;
+    class)                        cmd_class "$@" ;;
+    start|stop|restart|status)    delegate stack "$cmd" "$@" ;;
+    doctor)                       delegate doctor "$@" ;;
+    update)                       delegate stack hotpatch "$@" ;;
+    drain)                        delegate execution-core drain "$@" ;;
+    install|uninstall|reinstall)  delegate install "$cmd" "$@" ;;
+    *)                            delegate "$cmd" "$@" ;;
+  esac
+}
+
+# Guard so the file can be SOURCED (by __tests__/catalyst-router.test.sh) to reach the pure
+# helpers without dispatching. Executed directly, BASH_SOURCE[0] == $0 and dispatch runs.
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+  dispatch "$@"
+fi

--- a/plugins/dev/scripts/catalyst
+++ b/plugins/dev/scripts/catalyst
@@ -23,7 +23,12 @@
 #   · cluster · filter · thoughts · execution-core · otel-forward
 set -uo pipefail
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# Resolve through symlinks before deriving SCRIPT_DIR — install-cli.sh installs this router
+# as a DIRECT symlink from a local checkout, so a bare dirname would point at ~/.catalyst/bin
+# (manifest + lib/host-identity.sh lookups would miss). Same idiom as catalyst-stack.
+_SRC="${BASH_SOURCE[0]}"
+while [[ -L "$_SRC" ]]; do _SRC="$(readlink "$_SRC")"; done
+SCRIPT_DIR="$(cd "$(dirname "$_SRC")" && pwd)"
 
 # Bring in catalyst_node_class (CTL-1368 Bash resolver) for `catalyst class` show. Best-effort:
 # the router still dispatches if the lib is missing (the `class` verb degrades gracefully).
@@ -132,12 +137,24 @@ cmd_class() {
   local cfg; cfg="$(layer2_config_path)"
   mkdir -p "$(dirname "$cfg")" 2>/dev/null || true
   local base='{}'
-  [[ -r "$cfg" ]] && base="$(cat "$cfg")"
+  if [[ -r "$cfg" ]]; then
+    base="$(cat "$cfg")"
+    # An empty / whitespace-only config feeds jq zero JSON values → jq emits nothing and
+    # exits 0, which would write an EMPTY file and falsely report success. Treat it as a
+    # fresh object so the class is actually persisted.
+    [[ -z "${base//[[:space:]]/}" ]] && base='{}'
+  fi
   local tmp; tmp="$(mktemp "${cfg}.XXXXXX")" || { err "cannot create temp file next to $cfg"; return 3; }
   # No-clobber: a malformed existing config makes jq fail → abort, leaving it untouched.
   if ! printf '%s' "$base" | jq --arg c "$val" '.catalyst.node.class = $c' > "$tmp" 2>/dev/null; then
     rm -f "$tmp"
     err "failed to update $cfg (is it valid JSON?)"
+    return 3
+  fi
+  # Defence in depth: never move an empty temp into place (jq produced no document).
+  if [[ ! -s "$tmp" ]]; then
+    rm -f "$tmp"
+    err "refusing to write an empty $cfg"
     return 3
   fi
   chmod 600 "$tmp" 2>/dev/null || true

--- a/plugins/dev/scripts/check-setup.sh
+++ b/plugins/dev/scripts/check-setup.sh
@@ -86,7 +86,7 @@ done
 header "Catalyst CLI Install"
 
 CLI_BIN_DIR="${CATALYST_CLI_BIN_DIR:-$HOME/.catalyst/bin}"
-CLI_NAMES=(catalyst-broker catalyst-comms catalyst-events catalyst-execution-core catalyst-filter catalyst-otel-forward catalyst-transitions catalyst-why catalyst-session catalyst-state catalyst-statusline catalyst-db catalyst-monitor catalyst-thoughts catalyst-claude catalyst-stack)
+CLI_NAMES=(catalyst catalyst-broker catalyst-comms catalyst-events catalyst-execution-core catalyst-filter catalyst-otel-forward catalyst-transitions catalyst-why catalyst-session catalyst-state catalyst-statusline catalyst-db catalyst-monitor catalyst-thoughts catalyst-claude catalyst-stack)
 
 if [[ -d "$CLI_BIN_DIR" ]]; then
     pass "Bin dir exists: $CLI_BIN_DIR"

--- a/plugins/dev/scripts/execution-core/lib/install-telemetry.mjs
+++ b/plugins/dev/scripts/execution-core/lib/install-telemetry.mjs
@@ -1,0 +1,216 @@
+// install-telemetry.mjs — CTL-1369: the `catalyst.install.*` observability contract.
+//
+// The `catalyst install | uninstall | reinstall` lifecycle (PR 2) is modeled as BOTH:
+//   * a TRACE — root `catalyst.install` span + one child per phase that ran
+//     (acquire → backup → write-config → install-agents → start-daemons → healthcheck),
+//     plus an `install.rollback` child on a rolled-back run. This is the OTEL agent's
+//     locked turn-01 lifecycle-trace model (catalyst-updater-otel md-channel, turn 04).
+//   * canonical EVENTS — `catalyst.install.{started,phase,completed,failed,rolled_back}`
+//     appended to the unified event log, with LOW-CARD label dims ONLY (operation,
+//     node_class, phase, outcome) per the OTEL cardinality rule; paths / shas / error
+//     strings stay in the body payload, never on a label.
+//
+// This module owns the catalyst.install.* EVENTS + the InstallRun recorder; the per-run
+// SPAN tree lives in tracing.mjs:emitInstallTrace (the same events-near-caller / spans-in-
+// tracing split as updater.mjs:makeEmitFn + tracing.mjs:emitUpdaterRefreshSpan). It is the
+// CONTRACT, INERT until the install command drives an InstallRun. service.name =
+// "catalyst.install", service.namespace = "catalyst", short host.name/id, and
+// catalyst.node.class on the resource. Best-effort throughout — telemetry must never break
+// an install.
+import { appendFileSync, mkdirSync } from "node:fs";
+import { dirname } from "node:path";
+import { randomBytes } from "node:crypto";
+import { getEventLogPath, getNodeClass, getHostName } from "../config.mjs";
+import { hostName, hostId } from "./host-identity.mjs";
+import { emitInstallTrace } from "../tracing.mjs";
+
+export const INSTALL_SERVICE_NAME = "catalyst.install";
+// The install lifecycle phases, in order. Source of truth for both the span tree and the
+// `phase` label enum; the install command (PR 2) wraps each real step in run.phase(<name>).
+export const INSTALL_PHASES = Object.freeze([
+  "acquire",
+  "backup",
+  "write-config",
+  "install-agents",
+  "start-daemons",
+  "healthcheck",
+]);
+export const INSTALL_OPERATIONS = Object.freeze(["install", "uninstall", "reinstall"]);
+export const INSTALL_OUTCOMES = Object.freeze(["completed", "failed", "rolled_back"]);
+
+// The catalyst.install.* event family. Dot-form so the OTEL OTL-20 connectors auto-decompose
+// `catalyst.install.<action>` into event_entity=install + event_action=<action>.
+export const INSTALL_EVENT = Object.freeze({
+  started: "catalyst.install.started",
+  phase: "catalyst.install.phase",
+  completed: "catalyst.install.completed",
+  failed: "catalyst.install.failed",
+  rolledBack: "catalyst.install.rolled_back",
+});
+
+const SEVERITY_NUMBER = { TRACE: 1, DEBUG: 5, INFO: 9, WARN: 13, ERROR: 17, FATAL: 21 };
+
+function isoNow(nowFn = Date.now) {
+  return new Date(nowFn()).toISOString().replace(/\.\d{3}Z$/, "Z");
+}
+
+/**
+ * buildInstallEnvelope — the v2 OTel canonical envelope for one catalyst.install.* event,
+ * stamped service.name=catalyst.install. Pure (modulo a random id + ts). The low-card
+ * label dims (operation / phase / outcome) ride attributes; everything high-card (paths,
+ * shas, error strings, durations) stays in body.payload.
+ */
+export function buildInstallEnvelope({
+  event,
+  operation = null,
+  nodeClass,
+  hostNameVal,
+  phase = null,
+  outcome = null,
+  detail = null,
+  severity = "INFO",
+  nowFn = Date.now,
+} = {}) {
+  const ts = isoNow(nowFn);
+  const host = hostNameVal ?? getHostName();
+  const cls = nodeClass ?? getNodeClass();
+  const sev = severity || "INFO";
+  const action = typeof event === "string" ? event.split(".").pop() : null;
+  return {
+    ts,
+    id: randomBytes(8).toString("hex"),
+    observedTs: ts,
+    severityText: sev,
+    severityNumber: SEVERITY_NUMBER[sev] ?? 9,
+    traceId: null,
+    spanId: null,
+    resource: {
+      "service.name": INSTALL_SERVICE_NAME,
+      "service.namespace": "catalyst",
+      "host.name": hostName({ override: host }),
+      "host.id": hostId({ override: host }),
+      "catalyst.node.class": cls,
+    },
+    attributes: {
+      "event.name": event,
+      "event.entity": "install",
+      "event.action": action,
+      // LOW-CARD label dims only (OTEL cardinality rule) — bounded enums.
+      "catalyst.install.operation": operation,
+      "catalyst.install.phase": phase,
+      "catalyst.install.outcome": outcome,
+      "event.label": operation,
+    },
+    body: { payload: detail ?? {} },
+    caused_by: null,
+  };
+}
+
+/**
+ * makeInstallEmitFn — the canonical-envelope appender the install command drives. Resolves
+ * the event-log path PER CALL (UTC month rollover, same Codex P2 the updater hit). Synchronous
+ * appendFileSync; a log-append failure must never break an install.
+ */
+export function makeInstallEmitFn({ getLogPathFn = getEventLogPath, nowFn = Date.now, nodeClass, hostNameVal } = {}) {
+  const host = hostNameVal ?? getHostName();
+  const cls = nodeClass ?? getNodeClass();
+  return ({ event, operation = null, phase = null, outcome = null, detail = null, severity = "INFO" } = {}) => {
+    try {
+      const logPath = getLogPathFn();
+      const envelope = buildInstallEnvelope({ event, operation, nodeClass: cls, hostNameVal: host, phase, outcome, detail, severity, nowFn });
+      mkdirSync(dirname(logPath), { recursive: true });
+      appendFileSync(logPath, `${JSON.stringify(envelope)}\n`);
+    } catch {
+      /* best-effort — observability append must never break an install */
+    }
+  };
+}
+
+/**
+ * InstallRun — the lifecycle recorder the `catalyst install|uninstall|reinstall` command
+ * (PR 2) drives. It wraps each real step in `.phase(name, fn)`: times it, emits
+ * catalyst.install.phase, and re-throws on failure so the command owns rollback.
+ * `.complete()` / `.fail()` emit the terminal event AND the per-run trace. Pure modulo the
+ * injected `emit` + clock — the command injects the real makeInstallEmitFn; tests inject a
+ * capturing stub. Telemetry is best-effort and never breaks the install.
+ */
+export class InstallRun {
+  constructor({ operation, nodeClass, emit, traceId, spanId, nowFn = Date.now } = {}) {
+    this.operation = operation;
+    this.nodeClass = nodeClass ?? getNodeClass();
+    this.emit = typeof emit === "function" ? emit : () => {};
+    this.nowFn = nowFn;
+    this.traceId = traceId;
+    this.spanId = spanId;
+    this.phases = [];
+    this.startEpochMs = nowFn();
+  }
+
+  start(detail = null) {
+    this.startEpochMs = this.nowFn();
+    this.emit({ event: INSTALL_EVENT.started, operation: this.operation, detail });
+    return this;
+  }
+
+  // phase(name, fn) — run fn (sync or async), record timing, emit catalyst.install.phase.
+  // On throw, record the failed phase and re-raise (the command decides whether to roll back).
+  async phase(name, fn) {
+    const startEpochMs = this.nowFn();
+    try {
+      const result = typeof fn === "function" ? await fn() : undefined;
+      const endEpochMs = this.nowFn();
+      this.phases.push({ name, startEpochMs, endEpochMs, ok: true });
+      this.emit({ event: INSTALL_EVENT.phase, operation: this.operation, phase: name, detail: { duration_ms: endEpochMs - startEpochMs } });
+      return result;
+    } catch (err) {
+      const endEpochMs = this.nowFn();
+      const errMsg = err?.message ?? String(err);
+      this.phases.push({ name, startEpochMs, endEpochMs, ok: false, error: errMsg });
+      this.emit({ event: INSTALL_EVENT.phase, operation: this.operation, phase: name, outcome: "failed", severity: "ERROR", detail: { error: errMsg } });
+      throw err;
+    }
+  }
+
+  complete(detail = null) {
+    const endEpochMs = this.nowFn();
+    this.emit({ event: INSTALL_EVENT.completed, operation: this.operation, outcome: "completed", detail });
+    emitInstallTrace({
+      operation: this.operation,
+      nodeClass: this.nodeClass,
+      phases: this.phases,
+      outcome: "completed",
+      startEpochMs: this.startEpochMs,
+      endEpochMs,
+      traceId: this.traceId,
+      spanId: this.spanId,
+    });
+    return this;
+  }
+
+  // fail(err, {rolledBack}) — terminal event + trace for a failed run. rolledBack:true emits
+  // catalyst.install.rolled_back (+ an install.rollback span); else catalyst.install.failed.
+  fail(err, { rolledBack = false } = {}) {
+    const endEpochMs = this.nowFn();
+    const outcome = rolledBack ? "rolled_back" : "failed";
+    const errMsg = err?.message ?? (err != null ? String(err) : null);
+    this.emit({
+      event: rolledBack ? INSTALL_EVENT.rolledBack : INSTALL_EVENT.failed,
+      operation: this.operation,
+      outcome,
+      severity: "ERROR",
+      detail: { error: errMsg },
+    });
+    emitInstallTrace({
+      operation: this.operation,
+      nodeClass: this.nodeClass,
+      phases: this.phases,
+      outcome,
+      startEpochMs: this.startEpochMs,
+      endEpochMs,
+      traceId: this.traceId,
+      spanId: this.spanId,
+      rollback: rolledBack ? { startEpochMs: endEpochMs, endEpochMs, error: errMsg } : null,
+    });
+    return this;
+  }
+}

--- a/plugins/dev/scripts/execution-core/lib/install-telemetry.mjs
+++ b/plugins/dev/scripts/execution-core/lib/install-telemetry.mjs
@@ -69,6 +69,8 @@ export function buildInstallEnvelope({
   outcome = null,
   detail = null,
   severity = "INFO",
+  traceId = null,
+  spanId = null,
   nowFn = Date.now,
 } = {}) {
   const ts = isoNow(nowFn);
@@ -82,8 +84,11 @@ export function buildInstallEnvelope({
     observedTs: ts,
     severityText: sev,
     severityNumber: SEVERITY_NUMBER[sev] ?? 9,
-    traceId: null,
-    spanId: null,
+    // Carry the run's trace context so the catalyst.install.* log lines join to the root
+    // `catalyst.install` span in Loki/Tempo (these EVENTS are the install's only log, unlike
+    // the updater which also writes a pino refresh line). Null when tracing is off.
+    traceId: traceId ?? null,
+    spanId: spanId ?? null,
     resource: {
       "service.name": INSTALL_SERVICE_NAME,
       "service.namespace": "catalyst",
@@ -114,10 +119,14 @@ export function buildInstallEnvelope({
 export function makeInstallEmitFn({ getLogPathFn = getEventLogPath, nowFn = Date.now, nodeClass, hostNameVal } = {}) {
   const host = hostNameVal ?? getHostName();
   const cls = nodeClass ?? getNodeClass();
-  return ({ event, operation = null, phase = null, outcome = null, detail = null, severity = "INFO" } = {}) => {
+  // Per-call `nodeClass`/`traceId`/`spanId` override the baked defaults so the InstallRun
+  // (which owns the run's class + trace context) stamps every event authoritatively — e.g.
+  // `reinstall --class developer` on a worker node must stamp the REQUESTED class, not the
+  // current config's. Falls back to the baked class when the caller omits it.
+  return ({ event, operation = null, phase = null, outcome = null, detail = null, severity = "INFO", nodeClass: ncOverride, traceId = null, spanId = null } = {}) => {
     try {
       const logPath = getLogPathFn();
-      const envelope = buildInstallEnvelope({ event, operation, nodeClass: cls, hostNameVal: host, phase, outcome, detail, severity, nowFn });
+      const envelope = buildInstallEnvelope({ event, operation, nodeClass: ncOverride ?? cls, hostNameVal: host, phase, outcome, detail, severity, traceId, spanId, nowFn });
       mkdirSync(dirname(logPath), { recursive: true });
       appendFileSync(logPath, `${JSON.stringify(envelope)}\n`);
     } catch {
@@ -146,9 +155,16 @@ export class InstallRun {
     this.startEpochMs = nowFn();
   }
 
+  // _emit — every install event carries the run's operation + node class + trace context, so
+  // the log lines join to the root span (traceId) and are stamped with the REQUESTED class
+  // even when it differs from the node's current config (e.g. `reinstall --class developer`).
+  _emit(fields) {
+    this.emit({ operation: this.operation, nodeClass: this.nodeClass, traceId: this.traceId, spanId: this.spanId, ...fields });
+  }
+
   start(detail = null) {
     this.startEpochMs = this.nowFn();
-    this.emit({ event: INSTALL_EVENT.started, operation: this.operation, detail });
+    this._emit({ event: INSTALL_EVENT.started, detail });
     return this;
   }
 
@@ -160,20 +176,20 @@ export class InstallRun {
       const result = typeof fn === "function" ? await fn() : undefined;
       const endEpochMs = this.nowFn();
       this.phases.push({ name, startEpochMs, endEpochMs, ok: true });
-      this.emit({ event: INSTALL_EVENT.phase, operation: this.operation, phase: name, detail: { duration_ms: endEpochMs - startEpochMs } });
+      this._emit({ event: INSTALL_EVENT.phase, phase: name, detail: { duration_ms: endEpochMs - startEpochMs } });
       return result;
     } catch (err) {
       const endEpochMs = this.nowFn();
       const errMsg = err?.message ?? String(err);
       this.phases.push({ name, startEpochMs, endEpochMs, ok: false, error: errMsg });
-      this.emit({ event: INSTALL_EVENT.phase, operation: this.operation, phase: name, outcome: "failed", severity: "ERROR", detail: { error: errMsg } });
+      this._emit({ event: INSTALL_EVENT.phase, phase: name, outcome: "failed", severity: "ERROR", detail: { error: errMsg } });
       throw err;
     }
   }
 
   complete(detail = null) {
     const endEpochMs = this.nowFn();
-    this.emit({ event: INSTALL_EVENT.completed, operation: this.operation, outcome: "completed", detail });
+    this._emit({ event: INSTALL_EVENT.completed, outcome: "completed", detail });
     emitInstallTrace({
       operation: this.operation,
       nodeClass: this.nodeClass,
@@ -193,9 +209,8 @@ export class InstallRun {
     const endEpochMs = this.nowFn();
     const outcome = rolledBack ? "rolled_back" : "failed";
     const errMsg = err?.message ?? (err != null ? String(err) : null);
-    this.emit({
+    this._emit({
       event: rolledBack ? INSTALL_EVENT.rolledBack : INSTALL_EVENT.failed,
-      operation: this.operation,
       outcome,
       severity: "ERROR",
       detail: { error: errMsg },

--- a/plugins/dev/scripts/execution-core/lib/install-telemetry.test.mjs
+++ b/plugins/dev/scripts/execution-core/lib/install-telemetry.test.mjs
@@ -76,6 +76,15 @@ describe("buildInstallEnvelope (the canonical catalyst.install.* event shape)", 
     expect(buildInstallEnvelope({ event: INSTALL_EVENT.failed, severity: "ERROR" }).severityNumber).toBe(17);
     expect(buildInstallEnvelope({ event: INSTALL_EVENT.started }).severityText).toBe("INFO");
   });
+
+  test("carries trace context when seeded (the trace↔log join), null otherwise", () => {
+    const seeded = buildInstallEnvelope({ event: INSTALL_EVENT.started, traceId: "abc", spanId: "def" });
+    expect(seeded.traceId).toBe("abc");
+    expect(seeded.spanId).toBe("def");
+    const bare = buildInstallEnvelope({ event: INSTALL_EVENT.started });
+    expect(bare.traceId).toBeNull();
+    expect(bare.spanId).toBeNull();
+  });
 });
 
 describe("makeInstallEmitFn (appends one JSONL envelope per call)", () => {
@@ -95,6 +104,17 @@ describe("makeInstallEmitFn (appends one JSONL envelope per call)", () => {
   test("an emit failure never throws (best-effort observability)", () => {
     const emit = makeInstallEmitFn({ getLogPathFn: () => "/nonexistent-dir/\0/x.jsonl", nodeClass: "worker", hostNameVal: "mini" });
     expect(() => emit({ event: INSTALL_EVENT.started, operation: "install" })).not.toThrow();
+  });
+
+  test("per-call nodeClass/traceId/spanId override the baked defaults", () => {
+    const logPath = tmpLog();
+    const emit = makeInstallEmitFn({ getLogPathFn: () => logPath, nowFn: () => 0, nodeClass: "worker", hostNameVal: "mini" });
+    // a `reinstall --class developer` on a worker node must stamp the REQUESTED class + the trace
+    emit({ event: INSTALL_EVENT.started, operation: "reinstall", nodeClass: "developer", traceId: "tid", spanId: "sid" });
+    const env = JSON.parse(readFileSync(logPath, "utf8").trim());
+    expect(env.resource["catalyst.node.class"]).toBe("developer"); // override, NOT the baked worker
+    expect(env.traceId).toBe("tid");
+    expect(env.spanId).toBe("sid");
   });
 });
 
@@ -145,6 +165,21 @@ describe("InstallRun (the lifecycle recorder PR2 drives)", () => {
     expect(terminal.event).toBe(INSTALL_EVENT.rolledBack);
     expect(terminal.outcome).toBe("rolled_back");
     expect(terminal.detail.error).toBe("nope");
+  });
+
+  test("every emitted event carries the run's operation + node class + trace context", () => {
+    const events = [];
+    // reinstall --class developer on a node whose config differs: events must stamp developer
+    const run = new InstallRun({ operation: "reinstall", nodeClass: "developer", emit: (e) => events.push(e), traceId: "tid", spanId: "sid", nowFn: () => 0 });
+    run.start();
+    run.fail(new Error("x"));
+    expect(events.length).toBeGreaterThan(0);
+    for (const e of events) {
+      expect(e.operation).toBe("reinstall");
+      expect(e.nodeClass).toBe("developer");
+      expect(e.traceId).toBe("tid");
+      expect(e.spanId).toBe("sid");
+    }
   });
 
   test("INSTALL_PHASES is the locked, ordered phase enum", () => {

--- a/plugins/dev/scripts/execution-core/lib/install-telemetry.test.mjs
+++ b/plugins/dev/scripts/execution-core/lib/install-telemetry.test.mjs
@@ -1,0 +1,153 @@
+// install-telemetry.test.mjs — CTL-1369. Pins the catalyst.install.* EVENT contract: the
+// canonical envelope (service.name + low-card label dims + high-card detail kept in the
+// body), the file appender, and the InstallRun recorder's start → phase → complete / fail
+// emission sequence. The per-run SPAN tree (emitInstallTrace) is tested in tracing.test.mjs
+// alongside the other span emitters, against an in-memory exporter.
+import { describe, test, expect, afterEach } from "bun:test";
+import { readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  INSTALL_SERVICE_NAME,
+  INSTALL_EVENT,
+  INSTALL_PHASES,
+  buildInstallEnvelope,
+  makeInstallEmitFn,
+  InstallRun,
+} from "./install-telemetry.mjs";
+
+let tmpCounter = 0;
+const tmpFiles = [];
+function tmpLog() {
+  const p = join(tmpdir(), `install-telemetry-test-${process.pid}-${tmpCounter++}.jsonl`);
+  tmpFiles.push(p);
+  return p;
+}
+
+afterEach(() => {
+  for (const f of tmpFiles.splice(0)) {
+    try {
+      rmSync(f, { force: true });
+    } catch {
+      /* ignore */
+    }
+  }
+});
+
+describe("buildInstallEnvelope (the canonical catalyst.install.* event shape)", () => {
+  test("stamps service.name=catalyst.install + namespace + host + node.class", () => {
+    const env = buildInstallEnvelope({
+      event: INSTALL_EVENT.started,
+      operation: "install",
+      nodeClass: "developer",
+      hostNameVal: "mini",
+      nowFn: () => 0,
+    });
+    expect(env.resource["service.name"]).toBe(INSTALL_SERVICE_NAME);
+    expect(env.resource["service.namespace"]).toBe("catalyst");
+    expect(env.resource["host.name"]).toBe("mini");
+    expect(env.resource["host.id"]).toMatch(/^[0-9a-f]{16}$/);
+    expect(env.resource["catalyst.node.class"]).toBe("developer");
+  });
+
+  test("event.entity is install; event.action is the trailing dot-segment", () => {
+    expect(buildInstallEnvelope({ event: "catalyst.install.completed" }).attributes["event.entity"]).toBe("install");
+    expect(buildInstallEnvelope({ event: "catalyst.install.completed" }).attributes["event.action"]).toBe("completed");
+    expect(buildInstallEnvelope({ event: INSTALL_EVENT.rolledBack }).attributes["event.action"]).toBe("rolled_back");
+  });
+
+  test("low-card dims ride attributes; high-card detail rides the body payload", () => {
+    const env = buildInstallEnvelope({
+      event: INSTALL_EVENT.phase,
+      operation: "reinstall",
+      phase: "write-config",
+      outcome: null,
+      detail: { path: "/Users/x/.config/catalyst/config.json", duration_ms: 42 },
+    });
+    expect(env.attributes["catalyst.install.operation"]).toBe("reinstall");
+    expect(env.attributes["catalyst.install.phase"]).toBe("write-config");
+    expect(env.attributes["catalyst.install.outcome"]).toBeNull();
+    // the path (high-card) must NOT leak onto an attribute/label — it stays in the body.
+    expect(JSON.stringify(env.attributes)).not.toContain("/Users/x/");
+    expect(env.body.payload.path).toBe("/Users/x/.config/catalyst/config.json");
+  });
+
+  test("severity maps to the OTel severityNumber", () => {
+    expect(buildInstallEnvelope({ event: INSTALL_EVENT.failed, severity: "ERROR" }).severityNumber).toBe(17);
+    expect(buildInstallEnvelope({ event: INSTALL_EVENT.started }).severityText).toBe("INFO");
+  });
+});
+
+describe("makeInstallEmitFn (appends one JSONL envelope per call)", () => {
+  test("writes a parseable catalyst.install.* line to the resolved log path", () => {
+    const logPath = tmpLog();
+    const emit = makeInstallEmitFn({ getLogPathFn: () => logPath, nowFn: () => 0, nodeClass: "worker", hostNameVal: "mini" });
+    emit({ event: INSTALL_EVENT.started, operation: "install" });
+    emit({ event: INSTALL_EVENT.phase, operation: "install", phase: "acquire", detail: { duration_ms: 5 } });
+    const lines = readFileSync(logPath, "utf8").trim().split("\n");
+    expect(lines.length).toBe(2);
+    const first = JSON.parse(lines[0]);
+    expect(first.attributes["event.name"]).toBe("catalyst.install.started");
+    expect(first.resource["service.name"]).toBe(INSTALL_SERVICE_NAME);
+    expect(JSON.parse(lines[1]).attributes["catalyst.install.phase"]).toBe("acquire");
+  });
+
+  test("an emit failure never throws (best-effort observability)", () => {
+    const emit = makeInstallEmitFn({ getLogPathFn: () => "/nonexistent-dir/\0/x.jsonl", nodeClass: "worker", hostNameVal: "mini" });
+    expect(() => emit({ event: INSTALL_EVENT.started, operation: "install" })).not.toThrow();
+  });
+});
+
+describe("InstallRun (the lifecycle recorder PR2 drives)", () => {
+  test("start → phase → complete emits started, phase, completed in order", async () => {
+    const events = [];
+    const run = new InstallRun({
+      operation: "install",
+      nodeClass: "developer",
+      emit: (e) => events.push(e),
+      nowFn: (() => {
+        let t = 0;
+        return () => (t += 1);
+      })(),
+    });
+    run.start();
+    await run.phase("acquire", () => "ok");
+    run.complete();
+    expect(events.map((e) => e.event)).toEqual([
+      INSTALL_EVENT.started,
+      INSTALL_EVENT.phase,
+      INSTALL_EVENT.completed,
+    ]);
+    expect(events[1].phase).toBe("acquire");
+    expect(events[2].outcome).toBe("completed");
+    expect(run.phases).toEqual([expect.objectContaining({ name: "acquire", ok: true })]);
+  });
+
+  test("a throwing phase records ok:false, emits a failed phase event, and re-throws", async () => {
+    const events = [];
+    const run = new InstallRun({ operation: "install", nodeClass: "worker", emit: (e) => events.push(e), nowFn: () => 0 });
+    run.start();
+    await expect(run.phase("backup", () => {
+      throw new Error("boom");
+    })).rejects.toThrow("boom");
+    const phaseEvent = events.find((e) => e.event === INSTALL_EVENT.phase);
+    expect(phaseEvent.outcome).toBe("failed");
+    expect(phaseEvent.severity).toBe("ERROR");
+    expect(run.phases[0]).toEqual(expect.objectContaining({ name: "backup", ok: false, error: "boom" }));
+  });
+
+  test("fail({rolledBack:true}) emits catalyst.install.rolled_back", () => {
+    const events = [];
+    const run = new InstallRun({ operation: "reinstall", nodeClass: "worker", emit: (e) => events.push(e), nowFn: () => 0 });
+    run.start();
+    run.fail(new Error("nope"), { rolledBack: true });
+    const terminal = events[events.length - 1];
+    expect(terminal.event).toBe(INSTALL_EVENT.rolledBack);
+    expect(terminal.outcome).toBe("rolled_back");
+    expect(terminal.detail.error).toBe("nope");
+  });
+
+  test("INSTALL_PHASES is the locked, ordered phase enum", () => {
+    expect(INSTALL_PHASES).toEqual(["acquire", "backup", "write-config", "install-agents", "start-daemons", "healthcheck"]);
+  });
+});

--- a/plugins/dev/scripts/execution-core/tracing.mjs
+++ b/plugins/dev/scripts/execution-core/tracing.mjs
@@ -383,5 +383,60 @@ export function emitUpdaterRefreshSpan({ reason, startEpochMs, endEpochMs, roots
   }
 }
 
+// emitInstallTrace — CTL-1369: one TRACE per `catalyst install|uninstall|reinstall` run.
+// Root `catalyst.install` (INTERNAL) + one child span per phase that ran (acquire → backup
+// → write-config → install-agents → start-daemons → healthcheck), plus an `install.rollback`
+// child on a rolled-back run. The OTEL agent's locked turn-01 lifecycle-trace model. Mirrors
+// emitUpdaterRefreshSpan's trace↔log seeding (pass traceId+spanId and the root's trace_id
+// equals the id on the install log lines) and its never-throw discipline. The catalyst.install.*
+// EVENTS + the InstallRun recorder live in lib/install-telemetry.mjs (events near the caller,
+// spans here — the same split as updater.mjs:makeEmitFn + this module's emitUpdaterRefreshSpan).
+// `phases` = [{ name, startEpochMs, endEpochMs, ok, error }].
+export function emitInstallTrace({
+  operation,
+  nodeClass,
+  phases = [],
+  outcome,
+  startEpochMs,
+  endEpochMs,
+  traceId,
+  spanId,
+  rollback = null,
+} = {}) {
+  const tracer = getTracer();
+  if (!tracer) return;
+  try {
+    let startCtx = context.active();
+    if (traceId && spanId && TraceFlags && typeof trace.setSpanContext === "function") {
+      startCtx = trace.setSpanContext(startCtx, { traceId, spanId, traceFlags: TraceFlags.SAMPLED, isRemote: true });
+    }
+    const root = tracer.startSpan("catalyst.install", { kind: SpanKind.INTERNAL, startTime: startEpochMs }, startCtx);
+    if (operation != null) root.setAttribute("catalyst.install.operation", operation);
+    if (nodeClass != null) root.setAttribute("catalyst.node.class", nodeClass);
+    if (outcome != null) root.setAttribute("catalyst.install.outcome", outcome);
+    const rootCtx = trace.setSpan(context.active(), root);
+    for (const p of phases) {
+      if (!p || !p.name) continue;
+      const child = tracer.startSpan(`install.${p.name}`, { kind: SpanKind.INTERNAL, startTime: p.startEpochMs ?? startEpochMs }, rootCtx);
+      child.setAttribute("catalyst.install.phase", p.name);
+      if (p.ok === false || p.error) {
+        child.setStatus({ code: SpanStatusCode.ERROR, message: p.error ? String(p.error) : `install phase failed: ${p.name}` });
+      }
+      child.end(p.endEpochMs ?? endEpochMs);
+    }
+    if (rollback) {
+      const rb = tracer.startSpan("install.rollback", { kind: SpanKind.INTERNAL, startTime: rollback.startEpochMs ?? startEpochMs }, rootCtx);
+      if (rollback.error) rb.setStatus({ code: SpanStatusCode.ERROR, message: String(rollback.error) });
+      rb.end(rollback.endEpochMs ?? endEpochMs);
+    }
+    if (outcome === "failed" || outcome === "rolled_back") {
+      root.setStatus({ code: SpanStatusCode.ERROR, message: `install ${operation} ${outcome}` });
+    }
+    root.end(endEpochMs);
+  } catch {
+    /* observability must never throw */
+  }
+}
+
 // Re-export the api primitives callers need so they don't each import @opentelemetry/api.
 export { trace, context, SpanKind, SpanStatusCode, TraceFlags };

--- a/plugins/dev/scripts/execution-core/tracing.test.mjs
+++ b/plugins/dev/scripts/execution-core/tracing.test.mjs
@@ -13,6 +13,7 @@ import {
   getTracer,
   emitTickTrace,
   emitLivenessRefreshSpan,
+  emitInstallTrace,
   buildTracingResource,
   initTracing,
   shutdownTracing,
@@ -641,5 +642,78 @@ describe("tick-timing log line carries catalyst.dispatch.mode (CTL-1365a)", () =
     const line = captureTickTimingLine({});
     expect(line).not.toBeNull();
     expect(line["catalyst.dispatch.mode"]).toBe("phase-agents");
+  });
+});
+
+// CTL-1369: the catalyst.install lifecycle trace — one root per install run + a child per
+// phase, plus a rollback child on a rolled-back run (the OTEL turn-01 lifecycle model).
+describe("emitInstallTrace span tree (in-memory exporter)", () => {
+  let exporter;
+  beforeEach(() => {
+    exporter = new InMemorySpanExporter();
+    const provider = new BasicTracerProvider({ spanProcessors: [new SimpleSpanProcessor(exporter)] });
+    __setTracerForTest(provider.getTracer("test"));
+  });
+  afterEach(() => __setTracerForTest(null));
+
+  test("OFF (no tracer) ⇒ no spans, never throws", () => {
+    __setTracerForTest(null);
+    expect(() => emitInstallTrace({ operation: "install", phases: [{ name: "acquire", ok: true }], outcome: "completed" })).not.toThrow();
+  });
+
+  test("root catalyst.install + one child per phase; completed ⇒ no ERROR status", () => {
+    emitInstallTrace({
+      operation: "install",
+      nodeClass: "developer",
+      phases: [
+        { name: "acquire", startEpochMs: 0, endEpochMs: 1, ok: true },
+        { name: "healthcheck", startEpochMs: 1, endEpochMs: 2, ok: true },
+      ],
+      outcome: "completed",
+      startEpochMs: 0,
+      endEpochMs: 2,
+    });
+    const spans = exporter.getFinishedSpans();
+    expect(spans.map((s) => s.name).sort()).toEqual(["catalyst.install", "install.acquire", "install.healthcheck"]);
+    const root = spans.find((s) => s.name === "catalyst.install");
+    expect(root.attributes["catalyst.install.operation"]).toBe("install");
+    expect(root.attributes["catalyst.node.class"]).toBe("developer");
+    expect(root.attributes["catalyst.install.outcome"]).toBe("completed");
+    expect(root.status.code).toBe(SpanStatusCode.UNSET);
+    // every phase child carries its low-card phase label
+    expect(spans.find((s) => s.name === "install.acquire").attributes["catalyst.install.phase"]).toBe("acquire");
+  });
+
+  test("child spans nest under the root (shared trace id, parent = root)", () => {
+    emitInstallTrace({ operation: "install", phases: [{ name: "backup", ok: true }], outcome: "completed", startEpochMs: 0, endEpochMs: 1 });
+    const spans = exporter.getFinishedSpans();
+    const root = spans.find((s) => s.name === "catalyst.install");
+    const child = spans.find((s) => s.name === "install.backup");
+    expect(child.spanContext().traceId).toBe(root.spanContext().traceId);
+    expect(child.parentSpanContext?.spanId ?? child.parentSpanId).toBe(root.spanContext().spanId);
+  });
+
+  test("a failed phase + rollback child set ERROR on the right spans", () => {
+    emitInstallTrace({
+      operation: "install",
+      phases: [{ name: "write-config", ok: false, error: "disk full" }],
+      outcome: "rolled_back",
+      startEpochMs: 0,
+      endEpochMs: 3,
+      rollback: { startEpochMs: 2, endEpochMs: 3, error: "disk full" },
+    });
+    const spans = exporter.getFinishedSpans();
+    expect(spans.map((s) => s.name).sort()).toEqual(["catalyst.install", "install.rollback", "install.write-config"]);
+    expect(spans.find((s) => s.name === "install.write-config").status.code).toBe(SpanStatusCode.ERROR);
+    expect(spans.find((s) => s.name === "install.rollback").status.code).toBe(SpanStatusCode.ERROR);
+    expect(spans.find((s) => s.name === "catalyst.install").status.code).toBe(SpanStatusCode.ERROR);
+  });
+
+  test("trace↔log seeding: a passed traceId becomes the root's trace id", () => {
+    const traceId = "0123456789abcdef0123456789abcdef";
+    const spanId = "0123456789abcdef";
+    emitInstallTrace({ operation: "install", phases: [{ name: "acquire", ok: true }], outcome: "completed", startEpochMs: 0, endEpochMs: 1, traceId, spanId });
+    const root = exporter.getFinishedSpans().find((s) => s.name === "catalyst.install");
+    expect(root.spanContext().traceId).toBe(traceId);
   });
 });

--- a/plugins/dev/scripts/install-cli.sh
+++ b/plugins/dev/scripts/install-cli.sh
@@ -55,6 +55,7 @@ CLI_ENTRIES=(
   "catalyst-hud-classic.sh:catalyst-hud-classic"
   "catalyst-stack:catalyst-stack"
   "catalyst-doctor:catalyst-doctor"
+  "catalyst:catalyst"
   "thoughts-pull-sync.sh:thoughts-pull-sync"
   "../hooks/emit-lifecycle-event.sh:emit-lifecycle-event"
 )


### PR DESCRIPTION
Part **1 of 4** for **CTL-1369** — the observable install / uninstall / reinstall lifecycle. This PR lays the foundation and is **INERT on main** (nothing auto-runs on merge; the install *command* that drives the telemetry lands in 2/n). Absorbs **CTL-1353** (the top-level `catalyst` router).

## What ships

**1. `plugins/dev/scripts/catalyst` — the single front-door router** (absorbs CTL-1353)
A git-style dispatch router holding **no business logic**:
- Curated lifecycle verbs route to existing tools: `start|stop|restart|status` → `catalyst-stack`, `doctor` → `catalyst-doctor`, `update` → `catalyst-stack hotpatch`, `drain` → `catalyst-execution-core`, `install|uninstall|reinstall` → `catalyst-install` (lands in 2/n).
- `class [<value>]` shows/sets this node's Layer-2 class inline — validated against the enum, **atomic 0600 write**, **no-clobber** on a malformed config, and **fail-closed** if the final `mv` fails (no lying success).
- Any other command **auto-delegates** to `catalyst-<x>`, so every existing *and future* `catalyst-*` tool is a subcommand for free.
- Grouped help; unknown command → usage (not a stack trace). Sourceable for tests (`BASH_SOURCE` guard, like `catalyst-stack`). Wired into `install-cli.sh` + `check-setup.sh`.

**2. `execution-core/lib/install-telemetry.mjs` + `tracing.mjs:emitInstallTrace` — the `catalyst.install.*` contract**
The OTEL agent's locked install-as-a-trace model (coordinated on the `catalyst-updater-otel` md-channel):
- Canonical events: `catalyst.install.{started,phase,completed,failed,rolled_back}`.
- One **TRACE** per run: root `catalyst.install` + one `install.<phase>` child per phase + an `install.rollback` child on a rolled-back run.
- **Low-card label dims only** (`operation`/`phase`/`outcome`/`node_class`/`host_name`); high-card detail (paths/shas/errors/durations) stays in the body payload.
- Mirrors `updater.mjs:makeEmitFn` (events) + `emitUpdaterRefreshSpan` (spans): `service.name=catalyst.install`, short `host.name`/`host.id`, `catalyst.node.class` on the resource. INERT until the `InstallRun` recorder is driven by the install command (2/n).

## Test plan
- `__tests__/catalyst-router.test.sh` — 37 cases: dispatch routing, auto-delegate, unknown-command, help/version, and `class` show/set (preserve-keys, no-clobber, **mv-fail-closed**, unparseable-show).
- `execution-core/lib/install-telemetry.test.mjs` — event envelope (cardinality), file appender, `InstallRun` start→phase→complete/fail.
- `execution-core/tracing.test.mjs` — `emitInstallTrace` span-tree (root + per-phase + rollback, ERROR status, trace↔log seeding), against an in-memory exporter.
- New lib test wired into the `execution-core-tests.yml` CI allowlist; router test auto-discovered by `run-tests.sh`.

Adversarially reviewed (correctness + silent-failure passes); both findings (the `mv` fail-closed bug + unparseable-config show) fixed and regression-tested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)