### PR TITLE
fix(meta): restore LLM release notes — retired claude-sonnet-4 → env-overridable claude-sonnet-4-6

### DIFF
--- a/scripts/backfill-release-notes.sh
+++ b/scripts/backfill-release-notes.sh
@@ -20,6 +20,11 @@ REPO="${GITHUB_REPOSITORY:-coalesce-labs/catalyst}"
 PROMPT_TEMPLATE="$SCRIPT_DIR/templates/backfill-release-notes-prompt.md"
 API_KEY="${LOCAL_ANTHROPIC_API_KEY:-${ANTHROPIC_API_KEY:-}}"
 
+# Model is overridable so the next Anthropic retirement is a config change, not
+# a code edit. Default is the current drop-in for the retired claude-sonnet-4.
+# Set before call_claude runs (visible inside the function as a top-level var).
+MODEL="${RELEASE_NOTES_MODEL:-claude-sonnet-4-6}"
+
 if [[ -z "$API_KEY" ]]; then
   echo "Error: LOCAL_ANTHROPIC_API_KEY (or ANTHROPIC_API_KEY) not set"
   exit 1
@@ -43,8 +48,9 @@ call_claude() {
   local request_body
   request_body=$(jq -nc \
     --arg content "$prompt_content" \
+    --arg model "$MODEL" \
     '{
-      model: "claude-sonnet-4-20250514",
+      model: $model,
       max_tokens: 4096,
       messages: [{role: "user", content: $content}]
     }')
@@ -59,6 +65,12 @@ call_claude() {
     echo ""
     return
   }
+
+  # Make a model-decommission failure visible (to stderr so it can't pollute the
+  # captured stdout). Non-blocking — the caller still skips and keeps going.
+  if echo "$response" | jq -e '.error.type == "not_found_error"' >/dev/null 2>&1; then
+    echo "::error::Release-notes model '$MODEL' returned not_found_error (model decommissioned?). Update RELEASE_NOTES_MODEL / the default in this script. Response: $response" >&2
+  fi
 
   echo "$response" | jq -r '.content[0].text // empty' 2>/dev/null || echo ""
 }

--- a/scripts/enhance-release-notes.sh
+++ b/scripts/enhance-release-notes.sh
@@ -16,6 +16,10 @@ BACKFILL_PROMPT_TEMPLATE="$SCRIPT_DIR/templates/backfill-release-notes-prompt.md
 # Falls back to ANTHROPIC_API_KEY for CI environments.
 API_KEY="${LOCAL_ANTHROPIC_API_KEY:-${ANTHROPIC_API_KEY:-}}"
 
+# Model is overridable so the next Anthropic retirement is a config change, not
+# a code edit. Default is the current drop-in for the retired claude-sonnet-4.
+MODEL="${RELEASE_NOTES_MODEL:-claude-sonnet-4-6}"
+
 if [[ -z "$API_KEY" ]]; then
   echo "::warning::LOCAL_ANTHROPIC_API_KEY (or ANTHROPIC_API_KEY) not set — skipping release notes enhancement"
   exit 0
@@ -110,8 +114,9 @@ prompt_content=$(jq -Rrs \
 
 request_body=$(jq -nc \
   --arg content "$prompt_content" \
+  --arg model "$MODEL" \
   '{
-    model: "claude-sonnet-4-20250514",
+    model: $model,
     max_tokens: 4096,
     messages: [{role: "user", content: $content}]
   }')
@@ -136,6 +141,9 @@ ai_notes=$(echo "$response" | jq -r '.content[0].text // empty' 2>/dev/null) || 
 if [[ -z "$ai_notes" ]]; then
   echo "::warning::Claude API returned empty response — keeping original release notes"
   echo "Response: $response"
+  if echo "$response" | jq -e '.error.type == "not_found_error"' >/dev/null 2>&1; then
+    echo "::error::Release-notes model '$MODEL' returned not_found_error (model decommissioned?). Update RELEASE_NOTES_MODEL / the default in this script. Response: $response"
+  fi
   exit 0
 fi
 
@@ -233,8 +241,9 @@ if [[ -n "$head_branch" ]]; then
 
     plugin_request=$(jq -nc \
       --arg content "$plugin_prompt" \
+      --arg model "$MODEL" \
       '{
-        model: "claude-sonnet-4-20250514",
+        model: $model,
         max_tokens: 1024,
         messages: [{role: "user", content: $content}]
       }')


### PR DESCRIPTION
## Problem

The LLM release-notes automation hardcoded the Anthropic model `claude-sonnet-4-20250514` (Claude Sonnet 4), which Anthropic **retired on 2026-06-15**. Since then every call returns HTTP 404 `not_found_error`, the script swallows it (`exit 0`), CI stays green, and no AI release notes are generated. The mechanical release-please CHANGELOG still works; only the LLM-enhanced notes stopped (last good: dev `12.9.0` on Jun 15; missing `12.10.0`+).

## Fix

- **Move off the retired model + make it overridable.** Both `scripts/enhance-release-notes.sh` and `scripts/backfill-release-notes.sh` now define `MODEL="${RELEASE_NOTES_MODEL:-claude-sonnet-4-6}"` right after the API key is resolved. `claude-sonnet-4-6` (Claude Sonnet 4.6) is the current drop-in replacement for retired Sonnet 4 — an appropriate tier for this low-stakes generation. A future retirement is now a `RELEASE_NOTES_MODEL` config change, not a code edit.
- **All 3 hardcoded model strings** replaced with the variable, passed through `jq` as an arg (`--arg model "$MODEL"` → `model: $model`), never string-interpolated into the jq program: `enhance-release-notes.sh` primary request body + per-version CHANGELOG request body, and `backfill-release-notes.sh` `call_claude`.
- **Decommission visibility (non-blocking).** When the API response is a `not_found_error`, both scripts now emit a GitHub Actions `::error::` annotation so the next retirement isn't silent. The surrounding `exit 0` is preserved — notes generation never blocks a release. (`backfill`'s annotation goes to stderr so it can't pollute the stdout captured into `ai_notes`.)

No other params changed — endpoint, `anthropic-version: 2023-06-01` header, `ANTHROPIC_API_KEY` usage, and `max_tokens` are all untouched.

## Verification

- `bash -n scripts/enhance-release-notes.sh && bash -n scripts/backfill-release-notes.sh` → OK.
- `grep -rn claude-sonnet-4-20250514 scripts/` → empty (zero remaining).
- Did **not** call the Anthropic API or run the scripts (needs the secret).

## Follow-up after merge

Run `scripts/backfill-release-notes.sh` (or `scripts/backfill-release-notes.sh dev`) to regenerate the missing notes for dev `12.10.0`–`12.16.0`. It skips already-enhanced sections via the `<!-- ai-enhanced -->` marker, so it's safe to re-run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)