### PR TITLE
fix(dev): CTL-1372 — bound orch-monitor renderer memory growth on long sessions

### DIFF
--- a/plugins/dev/scripts/orch-monitor/ui/src/components/observe/spend-over-time-panel.tsx
+++ b/plugins/dev/scripts/orch-monitor/ui/src/components/observe/spend-over-time-panel.tsx
@@ -116,6 +116,12 @@ export function SpendOverTimePanel({
         <Bar
           dataKey="usd"
           shape={<SpendBarShape />}
+          // CTL-1372: disable per-refresh animation. This panel re-renders on the
+          // 15s OBSERVE poll cadence; recharts' react-smooth animation manager
+          // allocates tween state + retains the prior SVG subtree on every
+          // re-animation, ratcheting renderer memory over a long-lived session.
+          // Matches the board charts' hardening (activity-timeline / worker-burn).
+          isAnimationActive={false}
           // Click a spiking bar → drill into that hour (layout spec §2 P-A).
           onClick={(data: { payload?: SpendBar }) => {
             const bar = data?.payload;

--- a/plugins/dev/scripts/orch-monitor/ui/src/components/observe/token-donut-panel.tsx
+++ b/plugins/dev/scripts/orch-monitor/ui/src/components/observe/token-donut-panel.tsx
@@ -96,6 +96,13 @@ export function TokenDonutPanel({ tokens, cacheHitRate }: TokenDonutPanelProps) 
             outerRadius={78}
             strokeWidth={2}
             paddingAngle={2}
+            // CTL-1372: disable per-refresh animation. This panel re-renders on
+            // the 15s OBSERVE poll cadence; recharts' react-smooth animation
+            // manager allocates tween state + retains the prior SVG subtree on
+            // every re-animation, which over a long-lived (overnight) session
+            // ratchets renderer memory. Matches the board charts' hardening
+            // (activity-timeline.tsx / worker-burn-chart.tsx).
+            isAnimationActive={false}
           >
             <Label
               content={({ viewBox }) => {

--- a/plugins/dev/scripts/orch-monitor/ui/src/hooks/use-comms.ts
+++ b/plugins/dev/scripts/orch-monitor/ui/src/hooks/use-comms.ts
@@ -5,6 +5,14 @@ import type {
   CommsMessage,
 } from "@/lib/types";
 
+// CTL-1372: cap the per-connection retained comms-message buffer. The `message`
+// SSE handler below appends every newly-streamed message; without a bound a
+// long-lived, continuously-connected channel view grows the array (and its
+// non-virtualized DOM list) without limit over hours. Matches the sibling SSE
+// hooks' caps (use-monitor MAX_EVENTS=200, use-activity MAX_EVENTS=500, board
+// live-tail LIVE_BUFFER_CAP=500). Drop-oldest, retaining the newest 500.
+const MAX_COMMS_MESSAGES = 500;
+
 export type CommsStatus = "loading" | "ok" | "empty" | "error";
 
 interface UseCommsChannelsResult {
@@ -141,7 +149,11 @@ export function useCommsStream(
           const current = detailRef.current;
           if (!current) return;
           if (current.messages.some((m) => m.id === msg.id)) return;
-          const nextMessages = [...current.messages, msg];
+          const appended = [...current.messages, msg];
+          const nextMessages =
+            appended.length > MAX_COMMS_MESSAGES
+              ? appended.slice(appended.length - MAX_COMMS_MESSAGES)
+              : appended;
           const nextDetail: CommsChannelDetail = {
             ...current,
             messages: nextMessages,

--- a/plugins/dev/scripts/orch-monitor/ui/src/hooks/use-monitor.ts
+++ b/plugins/dev/scripts/orch-monitor/ui/src/hooks/use-monitor.ts
@@ -17,6 +17,44 @@ import { derivePrVariant } from "../../../lib/pr-variant";
 const MAX_EVENTS = 200;
 const STALE_THRESHOLD = 900;
 
+// CTL-1372: cap the dashboard's long-lived dedup refs. seenAttentionRef /
+// briefingSeenRef / prevWaveStatusRef are only ever added to (unlike
+// prevWorkerRef, which is pruned of vanished keys below), so across a multi-hour
+// session they grow monotonically by distinct attention items / waves /
+// briefings. A generous drop-oldest cap keeps them bounded; the live working set
+// per snapshot is tiny, so eviction only ever removes long-stale keys and never
+// re-fires an event for a still-present item.
+const DEDUP_REF_CAP = 5000;
+
+function addBounded<T>(set: Set<T>, key: T, cap = DEDUP_REF_CAP): void {
+  set.add(key);
+  if (set.size > cap) {
+    const it = set.values();
+    for (let drop = set.size - cap; drop > 0; drop--) {
+      const next = it.next();
+      if (next.done) break;
+      set.delete(next.value);
+    }
+  }
+}
+
+function setBounded<K, V>(
+  map: Map<K, V>,
+  key: K,
+  value: V,
+  cap = DEDUP_REF_CAP,
+): void {
+  map.set(key, value);
+  if (map.size > cap) {
+    const it = map.keys();
+    for (let drop = map.size - cap; drop > 0; drop--) {
+      const next = it.next();
+      if (next.done) break;
+      map.delete(next.value);
+    }
+  }
+}
+
 interface WorkerPrev {
   status: string;
   phase: number;
@@ -200,20 +238,20 @@ export function useMonitor() {
                 orch.id,
               );
             }
-            prevWaveStatusRef.current.set(key, w.status);
+            setBounded(prevWaveStatusRef.current, key, w.status);
           }
           // Briefings
           if (orch.briefings && primedRef.current) {
             for (const nStr of Object.keys(orch.briefings)) {
               const bKey = orch.id + ":" + nStr;
               if (!briefingSeenRef.current.has(bKey)) {
-                briefingSeenRef.current.add(bKey);
+                addBounded(briefingSeenRef.current, bKey);
                 addEvent("brief", `Wave ${nStr} briefing written`, undefined, orch.id);
               }
             }
           } else if (orch.briefings) {
             for (const nStr of Object.keys(orch.briefings)) {
-              briefingSeenRef.current.add(orch.id + ":" + nStr);
+              addBounded(briefingSeenRef.current, orch.id + ":" + nStr);
             }
           }
         }
@@ -229,7 +267,7 @@ export function useMonitor() {
                 (raw.ticket as string) ||
                 JSON.stringify(raw));
             if (!seenAttentionRef.current.has(key)) {
-              seenAttentionRef.current.add(key);
+              addBounded(seenAttentionRef.current, key);
               const ticket =
                 (raw.ticket as string) || (raw.workerName as string) || "";
               const reason =

--- a/plugins/dev/scripts/orch-monitor/ui/src/hooks/use-monitor.ts
+++ b/plugins/dev/scripts/orch-monitor/ui/src/hooks/use-monitor.ts
@@ -17,25 +17,36 @@ import { derivePrVariant } from "../../../lib/pr-variant";
 const MAX_EVENTS = 200;
 const STALE_THRESHOLD = 900;
 
-// CTL-1372: cap the dashboard's long-lived dedup refs. seenAttentionRef /
-// briefingSeenRef / prevWaveStatusRef are only ever added to (unlike
-// prevWorkerRef, which is pruned of vanished keys below), so across a multi-hour
-// session they grow monotonically by distinct attention items / waves /
-// briefings. A generous drop-oldest cap keeps them bounded; the live working set
-// per snapshot is tiny, so eviction only ever removes long-stale keys and never
-// re-fires an event for a still-present item.
+// CTL-1372: cap the dashboard's long-lived dedup structures with LRU (drop-oldest)
+// eviction. seenAttentionRef / briefingSeenRef / prevWaveStatusRef are only ever
+// added to (unlike prevWorkerRef, which is pruned of vanished keys below), so across
+// a multi-hour session they grow monotonically by distinct attention items / waves /
+// briefings. Eviction REFRESHES recency on every observation so a still-present key
+// is never the oldest — otherwise a long-active item could be evicted past the cap
+// and then re-emit its one-time `attn`/`brief` event as a phantom duplicate, in
+// exactly the long busy sessions this hardens (PR #2434 review).
 const DEDUP_REF_CAP = 5000;
 
-function addBounded<T>(set: Set<T>, key: T, cap = DEDUP_REF_CAP): void {
-  set.add(key);
-  if (set.size > cap) {
-    const it = set.values();
-    for (let drop = set.size - cap; drop > 0; drop--) {
-      const next = it.next();
-      if (next.done) break;
-      set.delete(next.value);
-    }
+function evictOldest<T>(coll: Set<T> | Map<T, unknown>, cap: number): void {
+  if (coll.size <= cap) return;
+  const it = coll.keys();
+  for (let drop = coll.size - cap; drop > 0; drop--) {
+    const next = it.next();
+    if (next.done) break;
+    coll.delete(next.value);
   }
+}
+
+// Mark `key` as observed in the current snapshot: refresh its recency (move it to the
+// newest position so an active key is never the eviction target) and add it if new,
+// then cap. Returns true ONLY when the key was not already present, so the caller
+// emits its one-time event exactly once.
+function markSeen<T>(set: Set<T>, key: T, cap = DEDUP_REF_CAP): boolean {
+  const isNew = !set.has(key);
+  if (!isNew) set.delete(key);
+  set.add(key);
+  evictOldest(set, cap);
+  return isNew;
 }
 
 function setBounded<K, V>(
@@ -44,15 +55,9 @@ function setBounded<K, V>(
   value: V,
   cap = DEDUP_REF_CAP,
 ): void {
+  map.delete(key); // refresh recency (no-op if absent) so active keys aren't evicted
   map.set(key, value);
-  if (map.size > cap) {
-    const it = map.keys();
-    for (let drop = map.size - cap; drop > 0; drop--) {
-      const next = it.next();
-      if (next.done) break;
-      map.delete(next.value);
-    }
-  }
+  evictOldest(map, cap);
 }
 
 interface WorkerPrev {
@@ -244,14 +249,13 @@ export function useMonitor() {
           if (orch.briefings && primedRef.current) {
             for (const nStr of Object.keys(orch.briefings)) {
               const bKey = orch.id + ":" + nStr;
-              if (!briefingSeenRef.current.has(bKey)) {
-                addBounded(briefingSeenRef.current, bKey);
+              if (markSeen(briefingSeenRef.current, bKey)) {
                 addEvent("brief", `Wave ${nStr} briefing written`, undefined, orch.id);
               }
             }
           } else if (orch.briefings) {
             for (const nStr of Object.keys(orch.briefings)) {
-              addBounded(briefingSeenRef.current, orch.id + ":" + nStr);
+              markSeen(briefingSeenRef.current, orch.id + ":" + nStr);
             }
           }
         }
@@ -266,8 +270,7 @@ export function useMonitor() {
               ((raw.id as string) ||
                 (raw.ticket as string) ||
                 JSON.stringify(raw));
-            if (!seenAttentionRef.current.has(key)) {
-              addBounded(seenAttentionRef.current, key);
+            if (markSeen(seenAttentionRef.current, key)) {
               const ticket =
                 (raw.ticket as string) || (raw.workerName as string) || "";
               const reason =


### PR DESCRIPTION
## What & why

The **Catalyst Monitor** PWA grew to **7.1 GB** after running overnight (a fresh tab is ~16–37 MB). This PR bounds three unbounded-growth defects on the surfaces a monitor tab sits on for hours. Fixes **CTL-1372**.

## Diagnosis (CDP profiling via chrome-devtools-mcp + a 29-agent static review)

**Ruled out:**
- **Not a single uncapped array** — the data layer is disciplined (events capped 200, board holds only `latest`, live-tail rings at 500, worker-drawer replaces at `limit=40`, beliefs Map replaces by key).
- **Not console retention** — 0 normal-operation `console.*` calls in the UI.
- **Not a fast leak** — parking `/telemetry` (2 min) and `/finops` with both animated charts (**20 min**) stayed flat (~22 MB post-GC); 24 in-SPA navigations stayed flat. The footprint exceeded the ~4 GB JS-heap cap, so much of the 7 GB is **external/non-V8 memory** (detached DOM/SVG backing) accreted over many hours.

## Changes

1. **OBSERVE charts → `isAnimationActive={false}`** (`spend-over-time-panel.tsx` `<Bar>`, `token-donut-panel.tsx` `<Pie>`), matching the already-hardened board charts (`activity-timeline.tsx`, `worker-burn-chart.tsx`). recharts' react-smooth animation manager allocated tween state + retained the prior SVG subtree on every 15s re-animation.
2. **`useCommsStream` capped at 500 messages** (drop-oldest) — it was the lone SSE consumer missing the cap its siblings have (`use-monitor` 200, `use-activity` 500, board live-tail 500).
3. **`use-monitor` dedup refs bounded** — `seenAttentionRef` / `briefingSeenRef` / `prevWaveStatusRef` now use drop-oldest eviction (cap 5000), like the already-pruned `prevWorkerRef`.

## Test plan

- [x] `vite build` succeeds
- [x] `bun test` — 684 pass, 0 fail
- [ ] Live: keep a monitor tab open under active orchestration overnight and confirm the renderer footprint holds steady-state.

## Honesty note / follow-up

A fresh tab did **not** reproduce the 7 GB growth (chart pages flat over 20 min; nav-churn flat), so these are **defensive bounds on real defects**, not a reproduced-and-cured root cause. The dominant overnight driver needs a heap snapshot from a genuinely-bloated tab. Recommended follow-up (separate ticket): a renderer watchdog that **auto-captures a heap snapshot when memory crosses a threshold**, plus an optional periodic-reload safety-valve for multi-day sessions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
