### PR TITLE
chore(meta): document the automated PR reviewer's no-findings signal (👍 = clean pass)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -162,6 +162,13 @@ A pull request is **not mergeable** until BOTH are true:
 
 So after opening a PR: watch the checks to green, then address every review comment (push fixes), reply, and resolve each thread before considering the PR done.
 
+**Reading the automated reviewer's signal.** When the automated code reviewer finds nothing, it
+signals a clean pass with a 👍 reaction (or a brief "no major issues" note) **instead of** opening
+review threads — that counts as a resolved review with nothing to address, not a missing one. The
+clean-pass result may arrive as a reaction or a plain comment rather than a structured review
+object, so detect it via reactions/comments, not only the reviews API. A re-review after a fix
+push may need to be requested explicitly rather than firing automatically.
+
 ## Reference Docs
 
 Read these on demand:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,6 +19,20 @@ stays tool-agnostic.)
 - Phase-agent workers run as `claude --bg` jobs; the legacy oneshot mode runs a long-lived
   `claude -p /catalyst-legacy:oneshot` per ticket.
 
+### Pull request review (Codex)
+
+The repo runs **Codex** (`chatgpt-codex-connector[bot]`) as an automated PR reviewer (this is the
+concrete instance of the tool-agnostic "automated code reviewer" in `AGENTS.md` → "Pull requests").
+
+- **Triggers:** PR opened for review, draft marked ready, or a `@codex review` comment — **not**
+  every push. After a remediation push, request a re-review with `@codex review`.
+- **Findings:** posted as inline **review threads** (P1/P2/P3). Resolve each via GraphQL
+  `addPullRequestReviewThreadReply` + `resolveReviewThread` — never `--admin`.
+- **No findings = a clean pass:** Codex reacts 👍 **or** posts an issue comment "Codex Review:
+  Didn't find any major issues 🎉 / Reviewed commit: `<sha>`". This is a resolved review, not a
+  missing one. Note the clean-pass result is an **issue comment / reaction**, not a `reviews` API
+  node — so a `reviews{}`-only poll misses it; also check `issues/<n>/comments` and reactions.
+
 ### Code understanding (Serena MCP)
 
 Serena is wired into the research/analysis agents for semantic code retrieval — see


### PR DESCRIPTION
Records a fact Ryan confirmed (2026-06-27): the Codex reviewer's **👍 reaction is its no-findings signal** — a clean pass with nothing to resolve, not a missing review. This keeps the PR merge-contract review gate read correctly (a green PR with a 👍 and no open threads is mergeable).

- **AGENTS.md** (vendor-neutral, per the agents-md-gate): the automated reviewer signals "no findings" with a 👍 / short note instead of opening threads; detect via reactions/comments, not only the structured reviews API; a re-review after a fix push may need an explicit request.
- **CLAUDE.md** (Codex-specific bridge): `chatgpt-codex-connector[bot]` triggers on open/ready/`@codex review` (not every push); findings → review threads (resolve via GraphQL, never `--admin`); no findings → 👍 or a "Didn't find any major issues" **issue comment** (not a `reviews{}` node — a reviews-only poll misses it).

Tool-agnostic guidance lives in AGENTS.md; the tool name lives only in the CLAUDE.md bridge — `scripts/ci/check-agents-md-bridge.sh` passes locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)