### PR TITLE
fix(dev): CTL-1373 — icon-picker Reload hard-recovers the PWA (unregister SW + clear caches)

### DIFF
--- a/plugins/dev/scripts/orch-monitor/ui/src/components/settings/icon-picker-popover.tsx
+++ b/plugins/dev/scripts/orch-monitor/ui/src/components/settings/icon-picker-popover.tsx
@@ -28,6 +28,7 @@ import {
 import { NAMED_COLORS } from "@/lib/color-palette";
 import { ProjectMarkIcon } from "@/components/project-mark-icon";
 import { enumeratePhosphorGlyphNames, useManifestLoadFailed } from "@/lib/phosphor-icons";
+import { hardRecoverAndReload } from "@/lib/sw-recovery";
 import {
   buildBasePickerItems,
   buildAllGlyphItems,
@@ -337,8 +338,8 @@ export function IconPickerPopover({ value, onChange, candidates, hue }: IconPick
                   <span>Some icons couldn&apos;t load.</span>
                   <button
                     type="button"
-                    onClick={() => window.location.reload()}
-                    title="Reload the page to fetch the latest icon assets"
+                    onClick={() => void hardRecoverAndReload()}
+                    title="Clear the cached app shell and reload to fetch the latest icon assets"
                     className="rounded-sm px-1.5 py-0.5 font-medium text-foreground hover:bg-accent focus:outline-none focus-visible:ring-1 focus-visible:ring-ring"
                   >
                     Reload

--- a/plugins/dev/scripts/orch-monitor/ui/src/lib/sw-recovery.test.ts
+++ b/plugins/dev/scripts/orch-monitor/ui/src/lib/sw-recovery.test.ts
@@ -1,0 +1,69 @@
+// sw-recovery.test.ts — unit tests for the PWA hard-recovery (CTL-1373). Stubs the browser
+// serviceWorker + CacheStorage globals so the recovery is exercised without a real browser.
+import { describe, it, expect, afterEach } from "bun:test";
+import { hardRecoverAndReload } from "./sw-recovery";
+
+const g = globalThis as Record<string, unknown>;
+const savedNavigator = g.navigator;
+const savedCaches = g.caches;
+
+afterEach(() => {
+  g.navigator = savedNavigator;
+  g.caches = savedCaches;
+});
+
+describe("hardRecoverAndReload", () => {
+  it("unregisters every service worker, deletes every cache, then reloads", async () => {
+    const unregistered: string[] = [];
+    const deleted: string[] = [];
+    g.navigator = {
+      serviceWorker: {
+        getRegistrations: async () => [
+          { unregister: async () => (unregistered.push("a"), true) },
+          { unregister: async () => (unregistered.push("b"), true) },
+        ],
+      },
+    };
+    g.caches = {
+      keys: async () => ["catalyst-shell-v1", "other"],
+      delete: async (k: string) => (deleted.push(k), true),
+    };
+    const order: string[] = [];
+    await hardRecoverAndReload(() => order.push("reload"));
+
+    expect(unregistered).toEqual(["a", "b"]);
+    expect(deleted).toEqual(["catalyst-shell-v1", "other"]);
+    expect(order).toEqual(["reload"]); // reload happens after the cleanup awaits resolve
+  });
+
+  it("reloads even when the SW / cache APIs throw (best-effort)", async () => {
+    g.navigator = {
+      serviceWorker: {
+        getRegistrations: async () => {
+          throw new Error("SW API blew up");
+        },
+      },
+    };
+    g.caches = {
+      keys: async () => {
+        throw new Error("CacheStorage blew up");
+      },
+      delete: async () => true,
+    };
+    let reloaded = false;
+    await hardRecoverAndReload(() => {
+      reloaded = true;
+    });
+    expect(reloaded).toBe(true); // the user is never trapped by a failed cleanup
+  });
+
+  it("reloads in a non-PWA context (no serviceWorker, no caches)", async () => {
+    g.navigator = {}; // no serviceWorker
+    g.caches = undefined;
+    let reloaded = false;
+    await hardRecoverAndReload(() => {
+      reloaded = true;
+    });
+    expect(reloaded).toBe(true);
+  });
+});

--- a/plugins/dev/scripts/orch-monitor/ui/src/lib/sw-recovery.ts
+++ b/plugins/dev/scripts/orch-monitor/ui/src/lib/sw-recovery.ts
@@ -1,0 +1,31 @@
+// sw-recovery.ts — escape a stale PWA shell (CTL-1373).
+//
+// The monitor's service worker (`public/service-worker.js`, cache `catalyst-shell-v1`) serves
+// /assets/* CACHE-FIRST from a cache name that is never version-bumped, and the app ships no
+// cache-control headers. So a plain `location.reload()` re-runs the SAME stale main bundle — which
+// import()s an old manifest-chunk hash a redeploy/atomic-swap deleted — and the icons stay blank
+// (the CTL-1370 reload affordance couldn't actually recover). This does the reliable recovery:
+// unregister every service worker + delete every CacheStorage cache, THEN reload so the browser
+// fetches the fresh build. Best-effort — if the SW/Cache APIs are absent or throw, we still reload.
+//
+// `reload` is injectable so the recovery is unit-testable without a real browser. The systemic
+// deploy-hygiene cure (SW versioning + cache-control + retaining old chunks) is tracked in CTL-1374.
+
+export async function hardRecoverAndReload(
+  reload: () => void = () => window.location.reload(),
+): Promise<void> {
+  try {
+    if (typeof navigator !== "undefined" && "serviceWorker" in navigator) {
+      const regs = await navigator.serviceWorker.getRegistrations();
+      await Promise.all(regs.map((r) => r.unregister()));
+    }
+    if (typeof caches !== "undefined") {
+      const keys = await caches.keys();
+      await Promise.all(keys.map((k) => caches.delete(k)));
+    }
+  } catch {
+    // Best-effort: a failed unregister/clear must not trap the user — fall through to the reload,
+    // which at minimum revalidates the navigation document (the SW serves it network-first).
+  }
+  reload();
+}


### PR DESCRIPTION
## CTL-1373 — make the picker's "Reload" actually recover

Follow-up to CTL-1370. The "Some icons couldn't load — **Reload**" affordance called `window.location.reload()`, which **does not bypass the PWA service worker** (`catalyst-shell-v1`, cache-first `/assets/*`, never version-bumped) or the HTTP cache — so it re-ran the *same* stale main bundle that `import()`s an old manifest-chunk hash a redeploy deleted, and the icons stayed blank. **Confirmed live on mini 2026-06-27** (manifest serves 200 at the current hash; a truly-fresh load works, but `location.reload()` can't escape the cached shell).

### Fix
`lib/sw-recovery.ts` `hardRecoverAndReload()`: unregister every service-worker registration + delete every CacheStorage cache, **then** reload so the browser fetches the fresh build. Best-effort — if the SW/Cache APIs are absent or throw, it still reloads (the SW serves the navigation doc network-first), so the user is never trapped. The picker's Reload button now calls it.

```gherkin
Scenario: Reload escapes the stale service-worker shell
  Given the icon manifest is stranded by a stale cached bundle
  When the user clicks "Reload" in the icon picker
  Then all service workers are unregistered and all caches deleted
  And the page reloads and fetches the fresh bundle so icons render
  And it stays best-effort (a plain reload still happens if the APIs throw)
```

### Tests
`reload` is injectable; 3 unit tests cover the happy path (SWs unregistered, caches cleared, then reload), the throw-still-reloads path, and a non-PWA context. UI-only.

### Validation
typecheck / lint (0 errors) / knip / `ui` vite build all clean; 57 ui-lib + picker tests pass.

> The **systemic** deploy-hygiene cure (SW cache versioning + cache-control headers + retaining old chunks so cached bundles self-recover) is tracked separately in **CTL-1374**; private-repo icon detection (Adva) in **CTL-1375**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)