### PR TITLE
fix(dev): CTL-1371 — make the reconcile timer multi-team/fleet-functional

### DIFF
--- a/plugins/dev/scripts/execution-core/linear-reconcile-timer.mjs
+++ b/plugins/dev/scripts/execution-core/linear-reconcile-timer.mjs
@@ -87,6 +87,9 @@ function defaultReadStateFactory() {
 // Lazy bun:sqlite imports (daemon runs under bun, like scheduler.mjs).
 let openBrokerStateDb = null;
 let getTicketDescriptor = null;
+// One-time "no config stateMap" notice (the fleet daemon resolves per-team via
+// the registry) so the per-tick log isn't spammed.
+let _warnedNoStateMap = false;
 async function ensureCacheReader() {
   if (openBrokerStateDb) return;
   const mod = await import("../broker/broker-state.mjs");
@@ -255,12 +258,22 @@ export function startLinearReconcileTimer({
     try {
       const full = readFullConfig(configPath);
       const stateMap = full?.catalyst?.linear?.stateMap ?? {};
-      // Fail CLOSED on an unreadable/empty config: without a stateMap we can't
-      // resolve target states correctly, so a transient bad config edit must NOT
-      // drive writes off the hardcoded fallback (Codex P2). Skip the tick.
-      if (Object.keys(stateMap).length === 0) {
-        log.warn({ configPath }, "linear-reconcile: empty/unreadable stateMap — skipping tick");
-        return;
+      // The multi-team fleet daemon resolves each team's state PER-TEAM via the
+      // registry, so its own config legitimately has NO single stateMap. That is
+      // fine for completion reconciliation: 'done' → "Done" is contract-universal,
+      // the terminal guards below use literal names, and the actual write resolves
+      // the per-team Done stateId through the registry (applyTerminalDone → team
+      // repoRoot) — so an empty stateMap never drives an off-team write. A
+      // stateMap is only needed to map a NON-'done' declared kind (rare); those
+      // skip per-declaration (decideCorrection → unmapped-target) without blocking
+      // the tick. (This relaxes the earlier blanket fail-closed, which was scoped
+      // to the removed PR-inference model and wrongly made the fleet timer inert.)
+      if (Object.keys(stateMap).length === 0 && !_warnedNoStateMap) {
+        _warnedNoStateMap = true;
+        log.info(
+          { configPath },
+          "linear-reconcile: no config stateMap — reconciling 'done' via contract-universal fallback + per-team registry writes"
+        );
       }
       const terminalStates = [
         ...new Set(

--- a/plugins/dev/scripts/execution-core/linear-reconcile-timer.test.mjs
+++ b/plugins/dev/scripts/execution-core/linear-reconcile-timer.test.mjs
@@ -101,6 +101,45 @@ test("a 'done' declaration with unreadable state is unconfirmed (no write), not 
   expect(res.summary.unconfirmed).toBe(1);
 });
 
+test("fleet/multi-team: a 'done' declaration reconciles with NO config stateMap (literal fallback + per-team write)", async () => {
+  // The multi-team fleet daemon has no single catalyst.linear.stateMap (resolved
+  // per-team via the registry). 'done' → "Done" is contract-universal, so it must
+  // still drain — the write resolves the per-team Done stateId.
+  const h = harness({
+    pending: [{ ticket: "ADV-1", state: "done" }],
+    states: { "ADV-1": "PR" },
+    mode: "write",
+  });
+  h.args.stateMap = {}; // empty (fleet daemon config)
+  h.args.terminalStates = ["Done", "Canceled", "Duplicate"]; // literals
+  const res = await runReconcileDrain(h.args);
+  expect(h.writes).toEqual([{ ticket: "ADV-1", kind: "done" }]);
+  expect(res.summary.corrected).toBe(1);
+});
+
+test("startLinearReconcileTimer: an empty-stateMap config tick still drains (no longer fails closed)", async () => {
+  const clock = fakeClock();
+  const writes = [];
+  startLinearReconcileTimer({
+    mode: "write",
+    orchDir: "/tmp/x",
+    configPath: "/ignored",
+    clock,
+    readFullConfig: () => ({ catalyst: { linear: {} } }), // no stateMap (fleet daemon)
+    listPending: () => [{ ticket: "CTL-9", state: "done" }],
+    readState: async () => "PR",
+    applyCorrection: async ({ ticket, kind }) => {
+      writes.push({ ticket, kind });
+      return { applied: true, action: "transitioned", from_state: "PR", to_state: "Done" };
+    },
+    markReconciledFn: () => {},
+    emit: () => {},
+    persist: () => {},
+  });
+  await clock.tick();
+  expect(writes).toEqual([{ ticket: "CTL-9", kind: "done" }]);
+});
+
 // ── guardedTerminalDone: confirm authoritative state before guard-exempt write ─
 
 test("guardedTerminalDone refuses a Done write when the authoritative read is terminal (stale-cache safety)", () => {


### PR DESCRIPTION
Follow-up to #2431 (completion-signal reconciler). Deploying to the mini fleet daemon surfaced that the in-daemon timer was **inert on a multi-team daemon**: it reads a single `catalyst.linear.stateMap`, and the fail-closed guard skipped every tick because the fleet daemon's own config has no single stateMap — it resolves each team's state **per-team via the registry**.

## Fix
`done` reconciliation (the phase-teardown case) doesn't need a config stateMap:
- `"Done"` is contract-universal across teams,
- the terminal guards use literal names (`Done`/`Canceled`/`Duplicate`),
- the actual write resolves the per-team `Done` stateId through the registry (`applyTerminalDone` → team repoRoot),

so an empty stateMap never drives an off-team write. A stateMap is only needed to map a NON-`done` declared kind; those skip per-declaration (`unmapped-target`) without blocking the tick. One-time info log instead of a per-tick skip.

(The earlier blanket fail-closed was scoped to the removed PR-inference model, where ticket prefixes were harvested from PR text. In the declaration model, declarations are explicit per-ticket and writes are registry-scoped.)

## Tests
42 unit tests (+2: empty-stateMap drain at both the core and timer level); trunk clean; daemon import graph resolves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VSmztTLoBxNPYhHJKG9F6n