### PR TITLE
feat(dev): CTL-1369 (2/n) — catalyst-backup: capture/restore a node's restorable state

### DIFF
--- a/plugins/dev/scripts/__tests__/catalyst-backup.test.sh
+++ b/plugins/dev/scripts/__tests__/catalyst-backup.test.sh
@@ -1,0 +1,175 @@
+#!/usr/bin/env bash
+# Shell tests for `catalyst-backup` (CTL-1369 PR2).
+#
+# Runs the CLI as a SUBPROCESS against a sandbox HOME (every path is env-overridable), so the
+# real ~/.config / ~/Library / ~/catalyst are never touched. Exercises backup capture (incl.
+# a real sqlite .backup + graceful handling of absent artifacts + secret perms), list, and
+# restore (happy path, no-clobber, --force, --dry-run) into a SEPARATE target sandbox.
+#
+# Run: bash plugins/dev/scripts/__tests__/catalyst-backup.test.sh
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+BACKUP="${SCRIPT_DIR}/../catalyst-backup"
+
+FAILURES=0
+PASSES=0
+ok()   { PASSES=$((PASSES + 1)); echo "  PASS: $1"; }
+fail() { FAILURES=$((FAILURES + 1)); echo "  FAIL: $1"; echo "    $2"; }
+expect_eq()       { if [[ "$2" == "$3" ]]; then ok "$1"; else fail "$1" "expected '$2' got '$3'"; fi; }
+expect_contains() { if [[ "$2" == *"$3"* ]]; then ok "$1"; else fail "$1" "'$2' lacks '$3'"; fi; }
+expect_file()     { if [[ -f "$2" ]]; then ok "$1"; else fail "$1" "missing file: $2"; fi; }
+expect_absent()   { if [[ ! -e "$2" ]]; then ok "$1"; else fail "$1" "should not exist: $2"; fi; }
+perms() { stat -f '%Lp' "$1" 2>/dev/null || stat -c '%a' "$1" 2>/dev/null; }
+
+command -v jq >/dev/null 2>&1 || { echo "jq required for these tests — skipping"; exit 0; }
+
+# ── sandbox: a fake SOURCE node with all artifacts present ─────────────────────
+SB="$(mktemp -d)"
+trap 'rm -rf "$SB"' EXIT
+mkdir -p "$SB/.config/catalyst" "$SB/.config/humanlayer" "$SB/LaunchAgents" "$SB/catalyst/execution-core"
+
+printf '{"catalyst":{"node":{"class":"developer"},"host":{"name":"testbox"},"secretToken":"sk-XYZ"}}\n' > "$SB/.config/catalyst/config.json"
+printf 'CATALYST_CLOUD=token-abc\n' > "$SB/.config/catalyst/cluster.env"
+printf '{"humanlayer":{"apiKey":"hl-secret"}}\n' > "$SB/.config/humanlayer/humanlayer.json"
+printf '<plist>stack</plist>\n'   > "$SB/LaunchAgents/ai.coalesce.catalyst-stack.plist"
+printf '<plist>updater</plist>\n' > "$SB/LaunchAgents/ai.coalesce.catalyst-updater.plist"
+printf '<plist>other</plist>\n'   > "$SB/LaunchAgents/com.example.other.plist"   # must NOT be captured
+printf '{"orchestrators":[]}\n'   > "$SB/catalyst/state.json"
+printf '{"teams":{}}\n'           > "$SB/catalyst/execution-core/registry.json"
+# a real sqlite db so `.backup` exercises the WAL-safe path
+sqlite3 "$SB/catalyst/catalyst.db" "CREATE TABLE sessions(id TEXT); INSERT INTO sessions VALUES('s1'),('s2');" 2>/dev/null
+# NOTE: cluster-cloud.json intentionally absent → must be handled gracefully
+
+# env that points the CLI at the sandbox source node
+src_env() {
+  CATALYST_DIR="$SB/catalyst" \
+  CATALYST_LAYER2_CONFIG_FILE="$SB/.config/catalyst/config.json" \
+  CATALYST_LAUNCHAGENTS_DIR="$SB/LaunchAgents" \
+  CATALYST_HUMANLAYER_CONFIG="$SB/.config/humanlayer/humanlayer.json" \
+  CATALYST_DB_FILE="$SB/catalyst/catalyst.db" \
+  CATALYST_BACKUPS_DIR="$SB/backups" \
+  CATALYST_ASSUME_NO_DAEMONS=1 \
+  "$@"
+}
+
+echo "catalyst-backup — backup capture"
+BUNDLE="$(src_env "$BACKUP" backup --label test 2>/dev/null | tail -1)"
+expect_eq "backup prints a bundle path" "yes" "$([[ -d "$BUNDLE" ]] && echo yes || echo no)"
+expect_file "manifest.json written"            "$BUNDLE/manifest.json"
+expect_file "config.json captured"             "$BUNDLE/config/config.json"
+expect_file "cluster.env captured"             "$BUNDLE/config/cluster.env"
+expect_absent "absent cluster-cloud.json not captured (graceful)" "$BUNDLE/config/cluster-cloud.json"
+expect_file "humanlayer creds captured"        "$BUNDLE/humanlayer/humanlayer.json"
+expect_file "stack plist captured"             "$BUNDLE/launchagents/ai.coalesce.catalyst-stack.plist"
+expect_file "updater plist captured"           "$BUNDLE/launchagents/ai.coalesce.catalyst-updater.plist"
+expect_absent "non-catalyst plist NOT captured" "$BUNDLE/launchagents/com.example.other.plist"
+expect_file "catalyst.db captured"             "$BUNDLE/runtime/catalyst.db"
+expect_file "state.json captured"              "$BUNDLE/runtime/state.json"
+expect_file "registry.json captured"           "$BUNDLE/runtime/registry.json"
+
+echo "catalyst-backup — default verb (bare + via router = create a backup)"
+BARE="$(src_env "$BACKUP" 2>/dev/null | tail -1)"
+expect_eq "bare 'catalyst-backup' creates a backup" "yes" "$([[ -f "$BARE/manifest.json" ]] && echo yes || echo no)"
+ROUTER="${SCRIPT_DIR}/../catalyst"
+if [[ -x "$ROUTER" ]]; then
+  RB="$(src_env "$ROUTER" backup 2>/dev/null | tail -1)"
+  expect_eq "'catalyst backup' (router auto-delegate) creates a backup" "yes" "$([[ -f "$RB/manifest.json" ]] && echo yes || echo no)"
+  RL="$(src_env "$ROUTER" backup list --json 2>/dev/null | jq 'length' 2>/dev/null)"
+  expect_eq "'catalyst backup list' (router) lists bundles" "yes" "$([[ "${RL:-0}" -ge 1 ]] && echo yes || echo no)"
+else
+  ok "router delegation (router not present — skipped)"
+fi
+
+echo "catalyst-backup — manifest + db integrity"
+expect_eq "manifest nodeClass"  "developer" "$(jq -r .nodeClass "$BUNDLE/manifest.json")"
+expect_eq "manifest captured count" "9" "$(jq '.captured|length' "$BUNDLE/manifest.json")"
+expect_eq "backed-up db is a valid sqlite snapshot" "2" "$(sqlite3 "$BUNDLE/runtime/catalyst.db" 'SELECT count(*) FROM sessions' 2>/dev/null)"
+
+echo "catalyst-backup — secret perms (bundle 0700, secret files 0600)"
+expect_eq "bundle dir is 0700"        "700" "$(perms "$BUNDLE")"
+expect_eq "config.json is 0600"       "600" "$(perms "$BUNDLE/config/config.json")"
+expect_eq "humanlayer.json is 0600"   "600" "$(perms "$BUNDLE/humanlayer/humanlayer.json")"
+
+echo "catalyst-backup — list"
+expect_contains "list shows the bundle"        "$(src_env "$BACKUP" list 2>/dev/null)" "$BUNDLE"
+LCOUNT="$(src_env "$BACKUP" list --json 2>/dev/null | jq 'length')"
+expect_eq "list --json returns >=1 bundle"     "yes" "$([[ "${LCOUNT:-0}" -ge 1 ]] && echo yes || echo no)"
+expect_eq "list --json includes the bundle"    "1" "$(src_env "$BACKUP" list --json 2>/dev/null | jq --arg p "$BUNDLE" '[.[]|select(.path==$p)]|length')"
+
+# ── restore into a SEPARATE empty target node ─────────────────────────────────
+TB="$SB/target"
+mkdir -p "$TB/.config/catalyst" "$TB/.config/humanlayer" "$TB/LaunchAgents" "$TB/catalyst/execution-core"
+tgt_env() {
+  CATALYST_DIR="$TB/catalyst" \
+  CATALYST_LAYER2_CONFIG_FILE="$TB/.config/catalyst/config.json" \
+  CATALYST_LAUNCHAGENTS_DIR="$TB/LaunchAgents" \
+  CATALYST_HUMANLAYER_CONFIG="$TB/.config/humanlayer/humanlayer.json" \
+  CATALYST_DB_FILE="$TB/catalyst/catalyst.db" \
+  CATALYST_BACKUPS_DIR="$TB/backups" \
+  CATALYST_ASSUME_NO_DAEMONS=1 \
+  "$@"
+}
+
+echo "catalyst-backup — restore (happy path into empty target)"
+tgt_env "$BACKUP" restore "$BUNDLE" >/dev/null 2>&1
+expect_file "config.json restored"   "$TB/.config/catalyst/config.json"
+expect_file "humanlayer restored"    "$TB/.config/humanlayer/humanlayer.json"
+expect_file "db restored"            "$TB/catalyst/catalyst.db"
+expect_file "registry restored"      "$TB/catalyst/execution-core/registry.json"
+expect_file "updater plist restored" "$TB/LaunchAgents/ai.coalesce.catalyst-updater.plist"
+expect_contains "restored config content matches" "$(cat "$TB/.config/catalyst/config.json")" "sk-XYZ"
+expect_eq "restored db queryable" "2" "$(sqlite3 "$TB/catalyst/catalyst.db" 'SELECT count(*) FROM sessions' 2>/dev/null)"
+
+echo "catalyst-backup — restore no-clobber + --force"
+printf 'PRE-EXISTING\n' > "$TB/.config/catalyst/config.json"
+tgt_env "$BACKUP" restore "$BUNDLE" >/dev/null 2>&1
+expect_eq "no-clobber: existing config left intact" "PRE-EXISTING" "$(cat "$TB/.config/catalyst/config.json")"
+tgt_env "$BACKUP" restore "$BUNDLE" --force >/dev/null 2>&1
+expect_contains "--force overwrites existing config" "$(cat "$TB/.config/catalyst/config.json")" "sk-XYZ"
+
+echo "catalyst-backup — restore --dry-run writes nothing"
+TB2="$SB/target2"; mkdir -p "$TB2/.config/catalyst"
+CATALYST_DIR="$TB2/catalyst" CATALYST_LAYER2_CONFIG_FILE="$TB2/.config/catalyst/config.json" \
+  CATALYST_HUMANLAYER_CONFIG="$TB2/.config/humanlayer/humanlayer.json" CATALYST_DB_FILE="$TB2/catalyst/catalyst.db" \
+  CATALYST_LAUNCHAGENTS_DIR="$TB2/LaunchAgents" CATALYST_ASSUME_NO_DAEMONS=1 \
+  "$BACKUP" restore "$BUNDLE" --dry-run >/dev/null 2>&1
+expect_absent "dry-run wrote no config" "$TB2/.config/catalyst/config.json"
+
+echo "catalyst-backup — restore rejects a non-bundle"
+rc=0; tgt_env "$BACKUP" restore "$SB/not-a-bundle" >/dev/null 2>&1 || rc=$?
+expect_eq "restore non-bundle ⇒ non-zero" "1" "$rc"
+
+echo "catalyst-backup — backup FAILS LOUDLY when a present source can't be captured"
+RO="$SB/ro-bundle"; mkdir -p "$RO/config"; chmod 500 "$RO/config"
+rc=0; out="$(src_env "$BACKUP" backup --out "$RO" 2>&1)" || rc=$?
+chmod 700 "$RO/config" 2>/dev/null || true
+expect_eq "uncapturable present source ⇒ non-zero exit" "yes" "$([[ "$rc" -ne 0 ]] && echo yes || echo no)"
+expect_contains "backup reports INCOMPLETE" "$out" "INCOMPLETE"
+
+echo "catalyst-backup — restore FAILS LOUDLY when a dest can't be written"
+RT="$SB/ro-target"; mkdir -p "$RT/.config/catalyst"; chmod 500 "$RT/.config/catalyst"
+rc=0
+out="$(CATALYST_DIR="$RT/c" CATALYST_LAYER2_CONFIG_FILE="$RT/.config/catalyst/config.json" \
+  CATALYST_HUMANLAYER_CONFIG="$RT/hl.json" CATALYST_DB_FILE="$RT/c/x.db" CATALYST_LAUNCHAGENTS_DIR="$RT/LA" \
+  CATALYST_ASSUME_NO_DAEMONS=1 "$BACKUP" restore "$BUNDLE" 2>&1)" || rc=$?
+chmod 700 "$RT/.config/catalyst" 2>/dev/null || true
+expect_eq "unwritable dest ⇒ non-zero exit" "yes" "$([[ "$rc" -ne 0 ]] && echo yes || echo no)"
+expect_contains "restore reports INCOMPLETE" "$out" "INCOMPLETE"
+
+echo "catalyst-backup — daemons_running fails SAFE (sourced helpers)"
+# shellcheck disable=SC1090
+source "$BACKUP"
+# simulate pgrep being unavailable (empty PATH in a subshell) → must fail safe = "assume live"
+rc=0
+# shellcheck disable=SC2123
+( unset CATALYST_ASSUME_NO_DAEMONS; PATH=/var/empty; daemons_running ) 2>/dev/null || rc=$?
+expect_eq "no pgrep ⇒ assume LIVE (rc 0)" "0" "$rc"
+rc=0; CATALYST_ASSUME_NO_DAEMONS=1 daemons_running || rc=$?
+expect_eq "ASSUME_NO_DAEMONS=1 ⇒ not running (rc 1)" "1" "$rc"
+
+echo
+echo "──────────────────────────────────────────"
+echo "catalyst-backup.test.sh: ${PASSES} passed, ${FAILURES} failed"
+[[ "$FAILURES" -eq 0 ]]

--- a/plugins/dev/scripts/__tests__/catalyst-backup.test.sh
+++ b/plugins/dev/scripts/__tests__/catalyst-backup.test.sh
@@ -21,7 +21,9 @@ expect_eq()       { if [[ "$2" == "$3" ]]; then ok "$1"; else fail "$1" "expecte
 expect_contains() { if [[ "$2" == *"$3"* ]]; then ok "$1"; else fail "$1" "'$2' lacks '$3'"; fi; }
 expect_file()     { if [[ -f "$2" ]]; then ok "$1"; else fail "$1" "missing file: $2"; fi; }
 expect_absent()   { if [[ ! -e "$2" ]]; then ok "$1"; else fail "$1" "should not exist: $2"; fi; }
-perms() { stat -f '%Lp' "$1" 2>/dev/null || stat -c '%a' "$1" 2>/dev/null; }
+# GNU stat uses `-c %a`; BSD/macOS stat uses `-f %Lp`. Try GNU first (on BSD `-c` errors out;
+# on GNU `-f` means file-system status and would wrongly succeed) so we get mode bits on both.
+perms() { stat -c '%a' "$1" 2>/dev/null || stat -f '%Lp' "$1" 2>/dev/null; }
 
 command -v jq >/dev/null 2>&1 || { echo "jq required for these tests — skipping"; exit 0; }
 
@@ -84,7 +86,9 @@ fi
 
 echo "catalyst-backup — manifest + db integrity"
 expect_eq "manifest nodeClass"  "developer" "$(jq -r .nodeClass "$BUNDLE/manifest.json")"
-expect_eq "manifest captured count" "9" "$(jq '.captured|length' "$BUNDLE/manifest.json")"
+# >=8 deterministic artifacts (the launchctl snapshot is macOS-only + best-effort, so don't pin exact)
+CCOUNT="$(jq '.captured|length' "$BUNDLE/manifest.json")"
+expect_eq "manifest captured >= 8 required artifacts" "yes" "$([[ "${CCOUNT:-0}" -ge 8 ]] && echo yes || echo no)"
 expect_eq "backed-up db is a valid sqlite snapshot" "2" "$(sqlite3 "$BUNDLE/runtime/catalyst.db" 'SELECT count(*) FROM sessions' 2>/dev/null)"
 
 echo "catalyst-backup — secret perms (bundle 0700, secret files 0600)"
@@ -141,22 +145,57 @@ echo "catalyst-backup — restore rejects a non-bundle"
 rc=0; tgt_env "$BACKUP" restore "$SB/not-a-bundle" >/dev/null 2>&1 || rc=$?
 expect_eq "restore non-bundle ⇒ non-zero" "1" "$rc"
 
-echo "catalyst-backup — backup FAILS LOUDLY when a present source can't be captured"
-RO="$SB/ro-bundle"; mkdir -p "$RO/config"; chmod 500 "$RO/config"
-rc=0; out="$(src_env "$BACKUP" backup --out "$RO" 2>&1)" || rc=$?
-chmod 700 "$RO/config" 2>/dev/null || true
-expect_eq "uncapturable present source ⇒ non-zero exit" "yes" "$([[ "$rc" -ne 0 ]] && echo yes || echo no)"
-expect_contains "backup reports INCOMPLETE" "$out" "INCOMPLETE"
+# NB: these inject failure via read-only DIR mode bits, which uid 0 ignores — so skip under root.
+if [[ "$(id -u)" != "0" ]]; then
+  echo "catalyst-backup — backup FAILS LOUDLY when a present source can't be captured"
+  RO="$SB/ro-bundle"; mkdir -p "$RO/config"; chmod 500 "$RO/config"
+  rc=0; out="$(src_env "$BACKUP" backup --out "$RO" 2>&1)" || rc=$?
+  chmod 700 "$RO/config" 2>/dev/null || true
+  expect_eq "uncapturable present source ⇒ non-zero exit" "yes" "$([[ "$rc" -ne 0 ]] && echo yes || echo no)"
+  expect_contains "backup reports INCOMPLETE" "$out" "INCOMPLETE"
 
-echo "catalyst-backup — restore FAILS LOUDLY when a dest can't be written"
-RT="$SB/ro-target"; mkdir -p "$RT/.config/catalyst"; chmod 500 "$RT/.config/catalyst"
+  echo "catalyst-backup — restore FAILS LOUDLY when a dest can't be written"
+  RT="$SB/ro-target"; mkdir -p "$RT/.config/catalyst"; chmod 500 "$RT/.config/catalyst"
+  rc=0
+  out="$(CATALYST_DIR="$RT/c" CATALYST_LAYER2_CONFIG_FILE="$RT/.config/catalyst/config.json" \
+    CATALYST_HUMANLAYER_CONFIG="$RT/hl.json" CATALYST_DB_FILE="$RT/c/x.db" CATALYST_LAUNCHAGENTS_DIR="$RT/LA" \
+    CATALYST_ASSUME_NO_DAEMONS=1 "$BACKUP" restore "$BUNDLE" 2>&1)" || rc=$?
+  chmod 700 "$RT/.config/catalyst" 2>/dev/null || true
+  expect_eq "unwritable dest ⇒ non-zero exit" "yes" "$([[ "$rc" -ne 0 ]] && echo yes || echo no)"
+  expect_contains "restore reports INCOMPLETE" "$out" "INCOMPLETE"
+else
+  ok "loud-fail injection tests (skipped under root — dir mode bits don't block uid 0)"
+fi
+
+echo "catalyst-backup — captures per-project config-<key>.json secrets (Codex P1)"
+printf '{"linear":{"token":"lin_secret"}}\n' > "$SB/.config/catalyst/config-CTL.json"
+PB="$(src_env "$BACKUP" backup 2>/dev/null | tail -1)"
+expect_file "per-project config-CTL.json captured" "$PB/config/config-CTL.json"
+expect_eq "config-CTL.json is 0600" "600" "$(perms "$PB/config/config-CTL.json")"
+rm -f "$SB/.config/catalyst/config-CTL.json"
+
+echo "catalyst-backup — restore rejects a malformed manifest (no captured array)"
+BAD="$SB/bad-bundle"; mkdir -p "$BAD"; printf '{"schemaVersion":1}\n' > "$BAD/manifest.json"
+rc=0; tgt_env "$BACKUP" restore "$BAD" >/dev/null 2>&1 || rc=$?
+expect_eq "malformed manifest ⇒ non-zero" "yes" "$([[ "$rc" -ne 0 ]] && echo yes || echo no)"
+
+echo "catalyst-backup — restore fails when a manifest-listed file is missing from the bundle"
+MB="$SB/missing-bundle"; cp -R "$BUNDLE" "$MB"; rm -f "$MB/runtime/state.json"
+TM="$SB/missing-target"; mkdir -p "$TM"
 rc=0
-out="$(CATALYST_DIR="$RT/c" CATALYST_LAYER2_CONFIG_FILE="$RT/.config/catalyst/config.json" \
-  CATALYST_HUMANLAYER_CONFIG="$RT/hl.json" CATALYST_DB_FILE="$RT/c/x.db" CATALYST_LAUNCHAGENTS_DIR="$RT/LA" \
-  CATALYST_ASSUME_NO_DAEMONS=1 "$BACKUP" restore "$BUNDLE" 2>&1)" || rc=$?
-chmod 700 "$RT/.config/catalyst" 2>/dev/null || true
-expect_eq "unwritable dest ⇒ non-zero exit" "yes" "$([[ "$rc" -ne 0 ]] && echo yes || echo no)"
-expect_contains "restore reports INCOMPLETE" "$out" "INCOMPLETE"
+out="$(CATALYST_DIR="$TM/c" CATALYST_LAYER2_CONFIG_FILE="$TM/.config/catalyst/config.json" \
+  CATALYST_HUMANLAYER_CONFIG="$TM/hl.json" CATALYST_DB_FILE="$TM/c/x.db" CATALYST_LAUNCHAGENTS_DIR="$TM/LA" \
+  CATALYST_ASSUME_NO_DAEMONS=1 "$BACKUP" restore "$MB" 2>&1)" || rc=$?
+expect_eq "manifest-listed-but-missing ⇒ non-zero" "yes" "$([[ "$rc" -ne 0 ]] && echo yes || echo no)"
+expect_contains "restore flags the missing artifact" "$out" "missing"
+
+echo "catalyst-backup — restore fails on a non-regular-file dest (dir at a config path)"
+DD="$SB/dir-target"; mkdir -p "$DD/.config/catalyst/config.json"  # config.json is a DIRECTORY
+rc=0
+CATALYST_DIR="$DD/c" CATALYST_LAYER2_CONFIG_FILE="$DD/.config/catalyst/config.json" \
+  CATALYST_HUMANLAYER_CONFIG="$DD/hl.json" CATALYST_DB_FILE="$DD/c/x.db" CATALYST_LAUNCHAGENTS_DIR="$DD/LA" \
+  CATALYST_ASSUME_NO_DAEMONS=1 "$BACKUP" restore "$BUNDLE" --force >/dev/null 2>&1 || rc=$?
+expect_eq "dir-at-dest ⇒ non-zero (no mv-into-dir)" "yes" "$([[ "$rc" -ne 0 ]] && echo yes || echo no)"
 
 echo "catalyst-backup — daemons_running fails SAFE (sourced helpers)"
 # shellcheck disable=SC1090

--- a/plugins/dev/scripts/catalyst-backup
+++ b/plugins/dev/scripts/catalyst-backup
@@ -75,20 +75,25 @@ cmd_backup() {
   done
   command -v jq >/dev/null 2>&1 || { err "jq is required"; return 3; }
 
-  local host ts bundle
+  local host ts bundle n
   host="$(node_host)"; ts="$(date -u +%Y%m%dT%H%M%SZ)"
   bundle="${out:-$(backups_root)/${host}-${ts}}"
+  # Collision-resistant: the timestamp is second-granular, so two backups in the same second
+  # (or two processes) would otherwise overwrite each other's restore point. Append a counter.
+  if [[ -z "$out" && -e "$bundle" ]]; then n=1; while [[ -e "${bundle}-${n}" ]]; do n=$((n+1)); done; bundle="${bundle}-${n}"; fi
   mkdir -p "$bundle"/config "$bundle"/humanlayer "$bundle"/launchagents "$bundle"/runtime \
     || { err "cannot create bundle dir: $bundle"; return 1; }
 
   local -a captured=() failed=() degraded=()
-  local f l2dir la db cdir plist sx
+  local f l2dir l2base la db cdir plist sx
 
-  # capture SRC RELDEST — absent source ⇒ legitimate skip (no-op); present source whose copy
-  # FAILS ⇒ recorded in failed[] (+ partial debris removed) so the run fails loudly.
+  # capture SRC RELDEST — ABSENT source ⇒ legitimate skip (no-op); PRESENT-but-unreadable
+  # (perms/ownership) or a failed copy ⇒ recorded in failed[] so the run fails loudly (a secret
+  # we can't read is NOT the same as one that isn't there).
   capture() {
     local src="$1" rel="$2"
-    [[ -r "$src" ]] || return 0
+    [[ -e "$src" ]] || return 0
+    if [[ ! -r "$src" ]]; then failed+=("$rel"); err "FAILED — present but unreadable: $src"; return 0; fi
     if cp -p "$src" "$bundle/$rel" 2>/dev/null; then
       captured+=("$rel")
     else
@@ -97,9 +102,16 @@ cmd_backup() {
     fi
   }
 
-  # 1. Layer-2 machine config (secrets)
-  l2dir="$(layer2_dir)"
-  for f in config.json cluster-cloud.json cluster.env; do capture "$l2dir/$f" "config/$f"; done
+  # 1. Layer-2 machine config (secrets) — config.json AND the per-project config-<key>.json files
+  # (API/webhook tokens live there too), plus cluster files. Also the configured basename if it's
+  # non-standard (CATALYST_LAYER2_CONFIG_FILE pointed elsewhere).
+  l2dir="$(layer2_dir)"; l2base="$(basename "$(layer2_config)")"
+  shopt -s nullglob
+  for f in "$l2dir"/config*.json "$l2dir/cluster-cloud.json" "$l2dir/cluster.env"; do
+    capture "$f" "config/$(basename "$f")"
+  done
+  shopt -u nullglob
+  case "$l2base" in config*.json) : ;; *) capture "$l2dir/$l2base" "config/$l2base" ;; esac
 
   # 2. thoughts creds (secrets)
   capture "$(humanlayer_config)" "humanlayer/humanlayer.json"
@@ -119,7 +131,9 @@ cmd_backup() {
   # WAL db copied without them loses un-checkpointed commits) and mark it degraded. If BOTH fail,
   # record it as failed (the both-fail path is real: a full disk dooms .backup and cp alike).
   db="$(db_file)"
-  if [[ -r "$db" ]]; then
+  if [[ -e "$db" && ! -r "$db" ]]; then
+    failed+=("runtime/catalyst.db"); err "FAILED — present but unreadable: $db"
+  elif [[ -r "$db" ]]; then
     if command -v sqlite3 >/dev/null 2>&1 && sqlite3 "$db" ".backup '$bundle/runtime/catalyst.db'" 2>/dev/null; then
       captured+=("runtime/catalyst.db")
     else
@@ -185,9 +199,7 @@ rel_to_dest() {
   # NB: command substitution strips trailing newlines, so this composes clean single-line paths
   # (layer2_dir uses dirname, which would otherwise inject a newline mid-path).
   case "$1" in
-    config/config.json)         printf '%s/config.json' "$(layer2_dir)" ;;
-    config/cluster-cloud.json)  printf '%s/cluster-cloud.json' "$(layer2_dir)" ;;
-    config/cluster.env)         printf '%s/cluster.env' "$(layer2_dir)" ;;
+    config/*)                   printf '%s/%s' "$(layer2_dir)" "$(basename "$1")" ;;
     humanlayer/humanlayer.json) printf '%s' "$(humanlayer_config)" ;;
     runtime/catalyst.db)        printf '%s' "$(db_file)" ;;
     runtime/catalyst.db-wal)    printf '%s-wal' "$(db_file)" ;;
@@ -205,6 +217,9 @@ restore_one() {
   [[ -r "$src" ]] || return 10
   if $RESTORE_DRYRUN; then log "would restore → $dest"; return 0; fi
   if [[ -e "$dest" ]] && ! $RESTORE_FORCE; then err "skip (exists; use --force) → $dest"; return 11; fi
+  # A non-regular-file destination (e.g. a directory at the config/db path) can't be safely
+  # replaced — `mv` would move the staged file INSIDE it and falsely report success.
+  if [[ -e "$dest" && ! -f "$dest" ]]; then err "dest exists and is not a regular file → $dest"; return 12; fi
   mkdir -p "$(dirname "$dest")" || return 12
   local tmp; tmp="$(mktemp "${dest}.XXXXXX")" || { err "cannot stage → $dest"; return 12; }
   if cp -p "$src" "$tmp" && mv "$tmp" "$dest"; then log "restored → $dest"; return 0; fi
@@ -227,6 +242,7 @@ cmd_restore() {
   [[ -n "$bundle" ]] || { err "restore: bundle path required (see 'catalyst-backup list')"; return 2; }
   [[ -d "$bundle" ]] || { err "not a backup bundle: $bundle"; return 1; }
   jq -e . "$bundle/manifest.json" >/dev/null 2>&1 || { err "not a backup bundle (missing/invalid manifest.json): $bundle"; return 1; }
+  jq -e '.captured | type == "array"' "$bundle/manifest.json" >/dev/null 2>&1 || { err "manifest.json has no valid 'captured' array — refusing to restore a malformed bundle: $bundle"; return 1; }
 
   # Restoring config/db over a LIVE node is unsafe — refuse unless --force.
   if ! $RESTORE_DRYRUN && daemons_running; then
@@ -240,14 +256,19 @@ cmd_restore() {
   while IFS= read -r rel; do
     [[ -n "$rel" ]] || continue
     if ! dest="$(rel_to_dest "$rel")"; then err "manifest names an unknown artifact, skipping: $rel"; continue; fi
-    # Clear stale WAL sidecars at the destination before restoring the db, so a clean .backup
-    # snapshot isn't silently overlaid by leftover -wal/-shm from a prior unclean shutdown.
-    if [[ "$rel" == "runtime/catalyst.db" ]] && ! $RESTORE_DRYRUN; then rm -f "${dest}-wal" "${dest}-shm" 2>/dev/null; fi
     restore_one "$bundle/$rel" "$dest"
     case $? in
-      0)  restored=$((restored+1)) ;;
+      0)
+        restored=$((restored+1))
+        # Only AFTER the db was actually overwritten: clear stale -wal/-shm at the destination
+        # so a clean .backup snapshot isn't silently overlaid by leftover sidecars from a prior
+        # unclean shutdown. (Doing this before the no-clobber decision would drop live WAL data
+        # on a skipped restore — Codex P1.) Bundle-carried sidecars, if any, restore in later
+        # iterations and overwrite these.
+        [[ "$rel" == "runtime/catalyst.db" ]] && rm -f "${dest}-wal" "${dest}-shm" 2>/dev/null
+        ;;
       11) skipped=$((skipped+1)) ;;
-      10) : ;;  # listed in manifest but missing from disk — counted via failures below
+      10) failures=$((failures+1)); err "manifest lists $rel but it is missing/unreadable in the bundle" ;;
       *)  failures=$((failures+1)) ;;
     esac
   done < <(jq -r '.captured[]' "$bundle/manifest.json")

--- a/plugins/dev/scripts/catalyst-backup
+++ b/plugins/dev/scripts/catalyst-backup
@@ -1,0 +1,325 @@
+#!/usr/bin/env bash
+# catalyst-backup — capture / restore a Catalyst node's restorable state (CTL-1369 PR2).
+#
+# Usage:
+#   catalyst-backup backup [--out <dir>] [--label <name>]   capture a timestamped bundle
+#   catalyst-backup restore <bundle> [--force] [--dry-run]   restore a bundle's files
+#   catalyst-backup list [--json]                            list available bundles
+#
+# Captures everything needed to restore a node's IDENTITY + state (NOT large transient logs):
+#   - Layer-2 machine config  (~/.config/catalyst/{config,cluster-cloud}.json, cluster.env)  [secrets]
+#   - thoughts creds          (~/.config/humanlayer/humanlayer.json)                          [secrets]
+#   - launchd agent inventory (~/Library/LaunchAgents/ai.coalesce.catalyst-*.plist + a launchctl snapshot)
+#   - catalyst.db             (WAL-safe via `sqlite3 .backup`; falls back to a file copy)
+#   - runtime pointers        (state.json, execution-core/registry.json — denormalized, small)
+#
+# This is the foundation the install lifecycle (PR3) composes — `catalyst install/uninstall/
+# reinstall` back up before they overwrite/tear down, so the node is reversible.
+#
+# Bundles + every file they hold may contain SECRETS (config tokens, creds) → umask 077,
+# bundle dirs 0700, files 0600. All paths are env-overridable (testability + non-standard homes).
+set -uo pipefail
+umask 077
+
+# Resolve symlinks before deriving SCRIPT_DIR (install-cli installs this as a symlink) — same
+# idiom as catalyst / catalyst-stack: normalize each hop against the symlink's own directory.
+_SRC="${BASH_SOURCE[0]}"
+while [[ -L "$_SRC" ]]; do
+  _DIR="$(cd -P "$(dirname "$_SRC")" && pwd)"
+  _SRC="$(readlink "$_SRC")"
+  [[ "$_SRC" != /* ]] && _SRC="$_DIR/$_SRC"
+done
+SCRIPT_DIR="$(cd -P "$(dirname "$_SRC")" && pwd)"
+# host.name / node.class for the manifest (best-effort; the lib is optional).
+# shellcheck source=lib/host-identity.sh
+[[ -r "${SCRIPT_DIR}/lib/host-identity.sh" ]] && source "${SCRIPT_DIR}/lib/host-identity.sh"
+
+# ── path resolution (all env-overridable; defaults match the rest of the toolchain) ──
+catalyst_dir()      { printf '%s' "${CATALYST_DIR:-$HOME/catalyst}"; }
+layer2_config()     { printf '%s' "${CATALYST_LAYER2_CONFIG_FILE:-$HOME/.config/catalyst/config.json}"; }
+layer2_dir()        { dirname "$(layer2_config)"; }
+launchagents_dir()  { printf '%s' "${CATALYST_LAUNCHAGENTS_DIR:-$HOME/Library/LaunchAgents}"; }
+humanlayer_config() { printf '%s' "${CATALYST_HUMANLAYER_CONFIG:-$HOME/.config/humanlayer/humanlayer.json}"; }
+db_file()           { printf '%s' "${CATALYST_DB_FILE:-$(catalyst_dir)/catalyst.db}"; }
+backups_root()      { printf '%s' "${CATALYST_BACKUPS_DIR:-$(catalyst_dir)/backups}"; }
+
+err() { printf 'catalyst-backup: %s\n' "$*" >&2; }
+log() { printf '  %s\n' "$*"; }
+
+# plugin_version — for the manifest; same source the router reads.
+plugin_version() {
+  local manifest="${SCRIPT_DIR}/../.claude-plugin/plugin.json"
+  if [[ -r "$manifest" ]] && command -v jq >/dev/null 2>&1; then
+    jq -r '.version // "unknown"' "$manifest" 2>/dev/null || echo "unknown"
+  else
+    echo "unknown"
+  fi
+}
+
+node_host()  { if declare -F catalyst_host_name >/dev/null 2>&1; then catalyst_host_name; else hostname -s 2>/dev/null || echo node; fi; }
+node_class() { if declare -F catalyst_node_class >/dev/null 2>&1; then catalyst_node_class; else echo unknown; fi; }
+
+# cmd_backup — capture a bundle. Prints progress; LAST stdout line is the bundle path so a
+# caller (the install command) can `bundle="$(catalyst-backup backup ... | tail -1)"`. Exits
+# NON-ZERO if any PRESENT source failed to capture — so the install lifecycle aborts before it
+# overwrites a node it couldn't back up (an absent source is a legitimate, silent skip).
+cmd_backup() {
+  local out="" label="node"
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --out)   out="$2"; shift 2 ;;
+      --label) label="$2"; shift 2 ;;
+      -h|--help) usage; return 0 ;;
+      *) err "backup: unknown flag: $1"; return 2 ;;
+    esac
+  done
+  command -v jq >/dev/null 2>&1 || { err "jq is required"; return 3; }
+
+  local host ts bundle
+  host="$(node_host)"; ts="$(date -u +%Y%m%dT%H%M%SZ)"
+  bundle="${out:-$(backups_root)/${host}-${ts}}"
+  mkdir -p "$bundle"/config "$bundle"/humanlayer "$bundle"/launchagents "$bundle"/runtime \
+    || { err "cannot create bundle dir: $bundle"; return 1; }
+
+  local -a captured=() failed=() degraded=()
+  local f l2dir la db cdir plist sx
+
+  # capture SRC RELDEST — absent source ⇒ legitimate skip (no-op); present source whose copy
+  # FAILS ⇒ recorded in failed[] (+ partial debris removed) so the run fails loudly.
+  capture() {
+    local src="$1" rel="$2"
+    [[ -r "$src" ]] || return 0
+    if cp -p "$src" "$bundle/$rel" 2>/dev/null; then
+      captured+=("$rel")
+    else
+      rm -f "$bundle/$rel" 2>/dev/null
+      failed+=("$rel"); err "FAILED to capture present source: $src → $rel"
+    fi
+  }
+
+  # 1. Layer-2 machine config (secrets)
+  l2dir="$(layer2_dir)"
+  for f in config.json cluster-cloud.json cluster.env; do capture "$l2dir/$f" "config/$f"; done
+
+  # 2. thoughts creds (secrets)
+  capture "$(humanlayer_config)" "humanlayer/humanlayer.json"
+
+  # 3. launchd agents + the loaded inventory
+  la="$(launchagents_dir)"
+  shopt -s nullglob
+  for plist in "$la"/ai.coalesce.catalyst-*.plist; do capture "$plist" "launchagents/$(basename "$plist")"; done
+  shopt -u nullglob
+  if command -v launchctl >/dev/null 2>&1; then  # auxiliary inventory — best-effort, never fails the run
+    launchctl list 2>/dev/null | grep -i "ai.coalesce.catalyst" > "$bundle/launchagents/launchctl-snapshot.txt" 2>/dev/null || true
+    if [[ -s "$bundle/launchagents/launchctl-snapshot.txt" ]]; then captured+=("launchagents/launchctl-snapshot.txt"); else rm -f "$bundle/launchagents/launchctl-snapshot.txt"; fi
+  fi
+
+  # 4. catalyst.db — WAL-safe snapshot via `.backup` (one consistent file, no sidecars). If that
+  # is unavailable/fails, DEGRADE to a plain copy of the db PLUS its -wal/-shm sidecars (a live
+  # WAL db copied without them loses un-checkpointed commits) and mark it degraded. If BOTH fail,
+  # record it as failed (the both-fail path is real: a full disk dooms .backup and cp alike).
+  db="$(db_file)"
+  if [[ -r "$db" ]]; then
+    if command -v sqlite3 >/dev/null 2>&1 && sqlite3 "$db" ".backup '$bundle/runtime/catalyst.db'" 2>/dev/null; then
+      captured+=("runtime/catalyst.db")
+    else
+      local db_ok=true
+      cp -p "$db" "$bundle/runtime/catalyst.db" 2>/dev/null || db_ok=false
+      for sx in -wal -shm; do
+        if [[ -r "${db}${sx}" ]]; then cp -p "${db}${sx}" "$bundle/runtime/catalyst.db${sx}" 2>/dev/null || db_ok=false; fi
+      done
+      if $db_ok; then
+        captured+=("runtime/catalyst.db"); degraded+=("runtime/catalyst.db")
+        [[ -r "${db}-wal" ]] && captured+=("runtime/catalyst.db-wal")
+        [[ -r "${db}-shm" ]] && captured+=("runtime/catalyst.db-shm")
+        err "WARN: sqlite3 .backup unavailable/failed — copied catalyst.db + WAL sidecars (DEGRADED snapshot)"
+      else
+        rm -f "$bundle/runtime/catalyst.db" "$bundle/runtime/catalyst.db-wal" "$bundle/runtime/catalyst.db-shm"
+        failed+=("runtime/catalyst.db"); err "FAILED to capture catalyst.db (sqlite3 .backup AND cp both failed)"
+      fi
+    fi
+  fi
+
+  # 5. runtime pointers (small, denormalized — NOT the events log)
+  cdir="$(catalyst_dir)"
+  capture "$cdir/state.json" "runtime/state.json"
+  capture "$cdir/execution-core/registry.json" "runtime/registry.json"
+
+  # manifest (validated) — entries are recorded ONLY for successful copies, so it never overstates.
+  local cap_json deg_json
+  cap_json="[]"; [[ ${#captured[@]} -gt 0 ]] && cap_json="$(printf '%s\n' "${captured[@]}" | jq -R . | jq -s .)"
+  deg_json="[]"; [[ ${#degraded[@]} -gt 0 ]] && deg_json="$(printf '%s\n' "${degraded[@]}" | jq -R . | jq -s .)"
+  jq -n --argjson sv 1 --arg ts "$ts" --arg host "$host" --arg nc "$(node_class)" \
+        --arg label "$label" --arg ver "$(plugin_version)" --argjson cap "$cap_json" --argjson deg "$deg_json" \
+        '{schemaVersion:$sv, created:$ts, host:$host, nodeClass:$nc, label:$label, pluginVersion:$ver, captured:$cap, degraded:$deg}' \
+        > "$bundle/manifest.json" 2>/dev/null
+  if ! jq -e . "$bundle/manifest.json" >/dev/null 2>&1; then err "FAILED to write a valid manifest.json"; return 1; fi
+  chmod -R go-rwx "$bundle" 2>/dev/null || true
+
+  if [[ ${#failed[@]} -gt 0 ]]; then
+    err "backup INCOMPLETE — ${#failed[@]} present artifact(s) could not be captured: ${failed[*]}"
+    err "bundle (partial): $bundle"
+    return 1
+  fi
+  [[ ${#captured[@]} -eq 0 ]] && err "WARN: backup captured 0 artifacts — nothing present to back up at this node"
+  log "backup complete — ${#captured[@]} artifact(s)$([[ ${#degraded[@]} -gt 0 ]] && printf ' (%s degraded)' "${#degraded[@]}") → $bundle"
+  printf '%s\n' "$bundle"
+}
+
+# ── restore ──────────────────────────────────────────────────────────────────
+RESTORE_FORCE=false
+RESTORE_DRYRUN=false
+
+# daemons_running — true if a broker/execution-core daemon is live (restoring config/db over
+# them is unsafe). Honors CATALYST_ASSUME_NO_DAEMONS=1 as a test seam. FAILS SAFE: if liveness
+# can't be determined (pgrep missing), assume LIVE so restore refuses without --force.
+daemons_running() {
+  [[ "${CATALYST_ASSUME_NO_DAEMONS:-}" == "1" ]] && return 1
+  command -v pgrep >/dev/null 2>&1 || { err "cannot determine daemon state (pgrep missing) — assuming LIVE"; return 0; }
+  pgrep -f "broker/index.mjs|execution-core/(daemon|index)\.mjs" >/dev/null 2>&1
+}
+
+# rel_to_dest BUNDLE_REL — the live destination for a bundle-relative captured path (or rc 1 if
+# the manifest names an artifact this version doesn't know how to place).
+rel_to_dest() {
+  # NB: command substitution strips trailing newlines, so this composes clean single-line paths
+  # (layer2_dir uses dirname, which would otherwise inject a newline mid-path).
+  case "$1" in
+    config/config.json)         printf '%s/config.json' "$(layer2_dir)" ;;
+    config/cluster-cloud.json)  printf '%s/cluster-cloud.json' "$(layer2_dir)" ;;
+    config/cluster.env)         printf '%s/cluster.env' "$(layer2_dir)" ;;
+    humanlayer/humanlayer.json) printf '%s' "$(humanlayer_config)" ;;
+    runtime/catalyst.db)        printf '%s' "$(db_file)" ;;
+    runtime/catalyst.db-wal)    printf '%s-wal' "$(db_file)" ;;
+    runtime/catalyst.db-shm)    printf '%s-shm' "$(db_file)" ;;
+    runtime/state.json)         printf '%s/state.json' "$(catalyst_dir)" ;;
+    runtime/registry.json)      printf '%s/execution-core/registry.json' "$(catalyst_dir)" ;;
+    launchagents/*.plist)       printf '%s/%s' "$(launchagents_dir)" "$(basename "$1")" ;;
+    *) return 1 ;;
+  esac
+}
+
+# restore_one SRC DEST → 0 restored | 10 absent in bundle | 11 skip-exists | 12 write failure.
+restore_one() {
+  local src="$1" dest="$2"
+  [[ -r "$src" ]] || return 10
+  if $RESTORE_DRYRUN; then log "would restore → $dest"; return 0; fi
+  if [[ -e "$dest" ]] && ! $RESTORE_FORCE; then err "skip (exists; use --force) → $dest"; return 11; fi
+  mkdir -p "$(dirname "$dest")" || return 12
+  local tmp; tmp="$(mktemp "${dest}.XXXXXX")" || { err "cannot stage → $dest"; return 12; }
+  if cp -p "$src" "$tmp" && mv "$tmp" "$dest"; then log "restored → $dest"; return 0; fi
+  rm -f "$tmp"; err "failed to restore → $dest"; return 12
+}
+
+cmd_restore() {
+  local bundle=""
+  RESTORE_FORCE=false; RESTORE_DRYRUN=false
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --force)   RESTORE_FORCE=true; shift ;;
+      --dry-run) RESTORE_DRYRUN=true; shift ;;
+      -h|--help) usage; return 0 ;;
+      -*) err "restore: unknown flag: $1"; return 2 ;;
+      *) bundle="$1"; shift ;;
+    esac
+  done
+  command -v jq >/dev/null 2>&1 || { err "jq is required"; return 3; }
+  [[ -n "$bundle" ]] || { err "restore: bundle path required (see 'catalyst-backup list')"; return 2; }
+  [[ -d "$bundle" ]] || { err "not a backup bundle: $bundle"; return 1; }
+  jq -e . "$bundle/manifest.json" >/dev/null 2>&1 || { err "not a backup bundle (missing/invalid manifest.json): $bundle"; return 1; }
+
+  # Restoring config/db over a LIVE node is unsafe — refuse unless --force.
+  if ! $RESTORE_DRYRUN && daemons_running; then
+    err "catalyst daemons appear to be running — stop them first (catalyst-stack stop)"
+    $RESTORE_FORCE || { err "refusing to restore over a live node without --force"; return 1; }
+  fi
+
+  # Drive restore from the manifest's `captured` list (the recorded source of truth) — never
+  # from on-disk debris a partially-failed backup might have left behind.
+  local rel dest restored=0 skipped=0 failures=0
+  while IFS= read -r rel; do
+    [[ -n "$rel" ]] || continue
+    if ! dest="$(rel_to_dest "$rel")"; then err "manifest names an unknown artifact, skipping: $rel"; continue; fi
+    # Clear stale WAL sidecars at the destination before restoring the db, so a clean .backup
+    # snapshot isn't silently overlaid by leftover -wal/-shm from a prior unclean shutdown.
+    if [[ "$rel" == "runtime/catalyst.db" ]] && ! $RESTORE_DRYRUN; then rm -f "${dest}-wal" "${dest}-shm" 2>/dev/null; fi
+    restore_one "$bundle/$rel" "$dest"
+    case $? in
+      0)  restored=$((restored+1)) ;;
+      11) skipped=$((skipped+1)) ;;
+      10) : ;;  # listed in manifest but missing from disk — counted via failures below
+      *)  failures=$((failures+1)) ;;
+    esac
+  done < <(jq -r '.captured[]' "$bundle/manifest.json")
+
+  if $RESTORE_DRYRUN; then
+    log "dry-run — $restored file(s) would be restored from $bundle"
+    return 0
+  fi
+  log "restore from $bundle: $restored restored, $skipped skipped (exists), $failures failed"
+  if [[ $failures -gt 0 ]]; then
+    err "restore INCOMPLETE — $failures file(s) failed to write; the node is NOT fully restored"
+    return 1
+  fi
+  log "next: reload launchd (launchctl) + restart the stack as needed — restore does NOT touch running daemons"
+}
+
+cmd_list() {
+  local json=false; [[ "${1:-}" == "--json" ]] && json=true
+  command -v jq >/dev/null 2>&1 || { err "jq is required"; return 3; }
+  local root d; root="$(backups_root)"
+  if [[ ! -d "$root" ]]; then $json && printf '[]\n' || log "no backups at $root"; return 0; fi
+  if $json; then
+    local first=true; printf '['
+    for d in "$root"/*/; do
+      [[ -r "${d}manifest.json" ]] || continue
+      $first || printf ','; first=false
+      jq -c --arg path "${d%/}" '. + {path:$path}' "${d}manifest.json"
+    done
+    printf ']\n'
+  else
+    local found=false
+    for d in "$root"/*/; do
+      [[ -r "${d}manifest.json" ]] || continue; found=true
+      printf '  %s  host=%s class=%s artifacts=%s\n    %s\n' \
+        "$(jq -r .created "${d}manifest.json")" "$(jq -r .host "${d}manifest.json")" \
+        "$(jq -r .nodeClass "${d}manifest.json")" "$(jq '.captured|length' "${d}manifest.json")" "${d%/}"
+    done
+    $found || log "no backups at $root"
+  fi
+}
+
+usage() {
+  cat <<EOF
+catalyst-backup — capture / restore a Catalyst node's restorable state.
+
+Usage (direct, or via the router as 'catalyst backup …'):
+  catalyst-backup [backup] [--out <dir>] [--label <name>]   capture a timestamped bundle (default)
+  catalyst-backup restore <bundle> [--force] [--dry-run]    restore a bundle's files
+  catalyst-backup list [--json]                             list available bundles
+
+Via the top-level CLI: 'catalyst backup' (create), 'catalyst backup restore <bundle>',
+'catalyst backup list'.
+
+Captures: Layer-2 config (secrets), thoughts creds (secrets), launchd agents,
+catalyst.db (WAL-safe), and runtime pointers (state.json, registry.json).
+Bundles are 0700/0600 (they hold secrets). restore refuses to clobber without --force
+and refuses a live node (running daemons) without --force.
+EOF
+}
+
+# Dispatch — guarded so tests can source the file to reach pure helpers without running.
+# `backup` is the DEFAULT verb: a bare invocation (which is what `catalyst backup` becomes after
+# the router's auto-delegate, `catalyst <x> → catalyst-<x>`) creates a backup. `restore`/`list`
+# are sub-verbs (`catalyst backup restore <bundle>`, `catalyst backup list`). Backup is safe +
+# non-destructive, so defaulting to it on a bare call is fine.
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+  case "${1:-}" in
+    backup)        shift; cmd_backup "$@" ;;
+    restore)       shift; cmd_restore "$@" ;;
+    list)          shift; cmd_list "$@" ;;
+    -h|--help)     usage ;;
+    ""|--*)        cmd_backup "$@" ;;
+    *) err "unknown command: $1 (try: backup | restore | list)"; usage >&2; exit 2 ;;
+  esac
+fi

--- a/plugins/dev/scripts/check-setup.sh
+++ b/plugins/dev/scripts/check-setup.sh
@@ -86,7 +86,7 @@ done
 header "Catalyst CLI Install"
 
 CLI_BIN_DIR="${CATALYST_CLI_BIN_DIR:-$HOME/.catalyst/bin}"
-CLI_NAMES=(catalyst catalyst-broker catalyst-comms catalyst-events catalyst-execution-core catalyst-filter catalyst-linear-reconcile catalyst-otel-forward catalyst-transitions catalyst-why catalyst-session catalyst-state catalyst-statusline catalyst-db catalyst-monitor catalyst-thoughts catalyst-claude catalyst-stack)
+CLI_NAMES=(catalyst catalyst-backup catalyst-broker catalyst-comms catalyst-events catalyst-execution-core catalyst-filter catalyst-linear-reconcile catalyst-otel-forward catalyst-transitions catalyst-why catalyst-session catalyst-state catalyst-statusline catalyst-db catalyst-monitor catalyst-thoughts catalyst-claude catalyst-stack)
 
 if [[ -d "$CLI_BIN_DIR" ]]; then
     pass "Bin dir exists: $CLI_BIN_DIR"

--- a/plugins/dev/scripts/install-cli.sh
+++ b/plugins/dev/scripts/install-cli.sh
@@ -56,6 +56,7 @@ CLI_ENTRIES=(
   "catalyst-hud-classic.sh:catalyst-hud-classic"
   "catalyst-stack:catalyst-stack"
   "catalyst-doctor:catalyst-doctor"
+  "catalyst-backup:catalyst-backup"
   "catalyst:catalyst"
   "thoughts-pull-sync.sh:thoughts-pull-sync"
   "../hooks/emit-lifecycle-event.sh:emit-lifecycle-event"


### PR DESCRIPTION
Part **2 of 4** for **CTL-1369**. Resliced ahead of the install command (it was planned as 3/n) because backup is **foundational** — every install/uninstall phase backs up before it overwrites/tears down, so a node stays reversible.

## What ships
`plugins/dev/scripts/catalyst-backup` (the router auto-delegates `catalyst backup` → `catalyst-backup`):

- **`backup`** (default verb) — a timestamped bundle capturing everything needed to restore a node's identity + state:
  - Layer-2 config (`config.json` + `cluster-cloud.json`/`cluster.env`) — **secrets**
  - thoughts creds (`humanlayer.json`) — **secrets**
  - launchd agent inventory (`ai.coalesce.catalyst-*.plist` + a `launchctl` snapshot)
  - `catalyst.db` — **WAL-safe** via `sqlite3 .backup` (degrades to db + `-wal`/`-shm` copy with a `degraded` marker)
  - runtime pointers (`state.json`, `registry.json`) — *not* the events log
  - `manifest.json` records exactly what was captured.
- **`restore <bundle>` `[--force] [--dry-run]`** — manifest-driven, atomic per file, no-clobber without `--force`, clears stale WAL sidecars before the db, refuses a **live node** (running daemons) without `--force`.
- **`list [--json]`**.

## Security + safety
`umask 077`; bundle dirs `0700`, files `0600` (it holds secrets). **Fails LOUDLY (non-zero)** when a *present* source can't be captured, or when a restore write fails — so the install lifecycle (3/n) aborts rather than overwrite a node it couldn't back up (an *absent* source is a legitimate silent skip). `daemons_running` **fails safe** (pgrep missing ⇒ assume live). All paths env-overridable.

## Test plan
41-case shell test (`__tests__/catalyst-backup.test.sh`, auto-discovered by `run-tests.sh`): capture + graceful absent-artifact handling, secret perms, WAL-safe db snapshot/round-trip, list (+ `--json`), restore happy/no-clobber/`--force`/`--dry-run`, **loud-fail accounting** (uncapturable source / unwritable dest ⇒ non-zero + INCOMPLETE), and the **fail-safe** daemon guard. shellcheck clean.

Two adversarial review passes (security + silent-failure); their shared core finding — *silent success masking a partial capture/restore* — drove the fail-loud accounting + manifest-driven restore.

**Deferred (noted):** `restore --force` overwrites without a pre-restore snapshot (explicit operator choice); multi-file restore isn't transactional (surfaced via the loud failure count).

🤖 Generated with [Claude Code](https://claude.com/claude-code)