### PR TITLE
feat(dev): CTL-1369 (3/n) — `catalyst install|uninstall|reinstall` per node class

### DIFF
--- a/.github/workflows/execution-core-tests.yml
+++ b/.github/workflows/execution-core-tests.yml
@@ -79,6 +79,14 @@ jobs:
         # would otherwise only fail at launchd runtime on a node. Walk its static graph.
         run: bun build updater/updater.mjs --target=node --outfile /dev/null
 
+      - name: Verify install-lifecycle import graph (bun build resolution check)
+        # CTL-1369 PR3: the catalyst-install lifecycle driver (install-lifecycle.mjs) is a
+        # separate CLI entrypoint (the catalyst-install bash launcher execs it), NOT in
+        # daemon.mjs's import graph — so a bad cross-module import (./lib/install-telemetry.mjs,
+        # ./config.mjs, ../tracing.mjs) would otherwise only fail at install runtime on a node.
+        # Walk its static graph.
+        run: bun build install-lifecycle.mjs --target=node --outfile /dev/null
+
       - name: Run stable unit tests
         # EXCLUDED SUITES — do NOT add these back without fixing the underlying
         # timing / sandbox incompatibility:
@@ -226,6 +234,7 @@ jobs:
             lib/catalyst-resource.test.mjs \
             lib/node-class-parity.test.mjs \
             lib/install-telemetry.test.mjs \
+            install-lifecycle.test.mjs \
             linear-reconcile.test.mjs \
             linear-reconcile-store.test.mjs \
             linear-reconcile-timer.test.mjs \

--- a/.github/workflows/execution-core-tests.yml
+++ b/.github/workflows/execution-core-tests.yml
@@ -34,6 +34,14 @@ on:
       # gate the broker cutover invariant in broker/plugin-refresh.mjs, so a PR touching
       # only the broker must run this suite too (Codex P2).
       - "plugins/dev/scripts/broker/**"
+      # CTL-1369: the catalyst-install launcher, the `catalyst` router, and the CLI
+      # registration (install-cli.sh / check-setup.sh) are the production entry path to
+      # `catalyst install|uninstall|reinstall`; changing them must run the smoke test below.
+      - "plugins/dev/scripts/catalyst-install"
+      - "plugins/dev/scripts/catalyst"
+      - "plugins/dev/scripts/install-cli.sh"
+      - "plugins/dev/scripts/check-setup.sh"
+      - "plugins/dev/scripts/__tests__/**"
       - ".github/workflows/execution-core-tests.yml"
   push:
     branches: [main]
@@ -43,6 +51,12 @@ on:
       # gate the broker cutover invariant in broker/plugin-refresh.mjs, so a PR touching
       # only the broker must run this suite too (Codex P2).
       - "plugins/dev/scripts/broker/**"
+      # CTL-1369: launcher / router / CLI-registration entry path (see PR-trigger note above).
+      - "plugins/dev/scripts/catalyst-install"
+      - "plugins/dev/scripts/catalyst"
+      - "plugins/dev/scripts/install-cli.sh"
+      - "plugins/dev/scripts/check-setup.sh"
+      - "plugins/dev/scripts/__tests__/**"
       - ".github/workflows/execution-core-tests.yml"
 
 jobs:
@@ -86,6 +100,14 @@ jobs:
         # ./config.mjs, ../tracing.mjs) would otherwise only fail at install runtime on a node.
         # Walk its static graph.
         run: bun build install-lifecycle.mjs --target=node --outfile /dev/null
+
+      - name: catalyst-install launcher + router smoke test
+        # CTL-1369 PR3: exercises the REAL catalyst-install bash launcher (symlink resolution →
+        # node → driver) and the `catalyst` router dispatch end-to-end via --dry-run. The mjs unit
+        # suite tests the driver directly; this covers the production entry path (launcher / router /
+        # CLI registration) that the unit tests bypass.
+        working-directory: plugins/dev/scripts
+        run: bash __tests__/catalyst-install.test.sh
 
       - name: Run stable unit tests
         # EXCLUDED SUITES — do NOT add these back without fixing the underlying

--- a/plugins/dev/scripts/__tests__/catalyst-install.test.sh
+++ b/plugins/dev/scripts/__tests__/catalyst-install.test.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+# Shell smoke tests for the `catalyst-install` LAUNCHER + router wiring (CTL-1369 PR3).
+#
+# The lifecycle LOGIC is unit-tested in execution-core/install-lifecycle.test.mjs (bun, GitHub
+# CI-gated). This suite exercises the real bash launcher end-to-end (symlink resolution → bun/node
+# exec → mjs) and the router's `catalyst install|uninstall|reinstall` dispatch, using --dry-run so
+# nothing is provisioned. All assertions pass --class explicitly so they don't depend on the host's
+# configured node class.
+#
+# Run: bash plugins/dev/scripts/__tests__/catalyst-install.test.sh
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+INSTALL="${SCRIPT_DIR}/../catalyst-install"
+ROUTER="${SCRIPT_DIR}/../catalyst"
+
+FAILURES=0
+PASSES=0
+ok()   { PASSES=$((PASSES + 1)); echo "  PASS: $1"; }
+fail() { FAILURES=$((FAILURES + 1)); echo "  FAIL: $1"; echo "    $2"; }
+expect_eq()       { if [[ "$2" == "$3" ]]; then ok "$1"; else fail "$1" "expected '$2' got '$3'"; fi; }
+expect_contains() { if [[ "$2" == *"$3"* ]]; then ok "$1"; else fail "$1" "'$2' lacks '$3'"; fi; }
+expect_absent()   { if [[ "$2" != *"$3"* ]]; then ok "$1"; else fail "$1" "'$2' unexpectedly contains '$3'"; fi; }
+
+# A runtime is required (the launcher execs bun, falling back to node).
+if ! command -v bun >/dev/null 2>&1 && ! command -v node >/dev/null 2>&1; then
+  echo "SKIP: neither bun nor node available"
+  exit 0
+fi
+
+echo "catalyst-install — launcher --help"
+out="$("$INSTALL" --help 2>&1)"; rc=$?
+expect_eq "--help exits 0" "0" "$rc"
+expect_contains "--help names the tool" "$out" "catalyst-install"
+
+echo "catalyst-install — install/worker dry-run (full work stack, no updater)"
+out="$("$INSTALL" install --class worker --dry-run 2>&1)"; rc=$?
+expect_eq "worker dry-run exits 0" "0" "$rc"
+expect_contains "worker runs install-services" "$out" "install-services"
+expect_absent  "worker never adopts updater" "$out" "adopt-updater"
+
+echo "catalyst-install — install/developer dry-run (updater + drain, no work stack)"
+out="$("$INSTALL" install --class developer --dry-run 2>&1)"; rc=$?
+expect_eq "developer dry-run exits 0" "0" "$rc"
+expect_contains "developer adopts updater" "$out" "adopt-updater"
+expect_absent  "developer never installs services" "$out" "install-services"
+
+echo "catalyst-install — invalid inputs"
+"$INSTALL" bogus-op >/dev/null 2>&1; expect_eq "unknown operation → rc 2" "2" "$?"
+"$INSTALL" install --class nope >/dev/null 2>&1; expect_eq "unknown class → rc 2" "2" "$?"
+
+echo "catalyst-install — uninstall dry-run (teardown, secrets preserved)"
+out="$("$INSTALL" uninstall --class worker --dry-run 2>&1)"; rc=$?
+expect_eq "uninstall dry-run exits 0" "0" "$rc"
+expect_contains "uninstall removes agents" "$out" "uninstall-services"
+expect_contains "uninstall preserves secrets" "$out" "secrets preserved"
+
+echo "catalyst — router dispatches install → catalyst-install"
+out="$("$ROUTER" install --class worker --dry-run 2>&1)"; rc=$?
+expect_eq "router install dry-run exits 0" "0" "$rc"
+expect_contains "router reaches the lifecycle driver" "$out" "install-services"
+
+echo "catalyst-install — resolves through a symlink (the on-PATH production invocation)"
+sym_tmp="$(mktemp -d)"
+ln -s "$INSTALL" "$sym_tmp/catalyst-install"
+out="$("$sym_tmp/catalyst-install" install --class worker --dry-run 2>&1)"; rc=$?
+rm -rf "$sym_tmp"
+expect_eq "symlinked launcher exits 0" "0" "$rc"
+expect_contains "symlinked launcher still resolves the driver" "$out" "install-services"
+
+echo
+echo "──────────────────────────────────────────"
+echo "catalyst-install.test.sh: ${PASSES} passed, ${FAILURES} failed"
+[[ "$FAILURES" -eq 0 ]]

--- a/plugins/dev/scripts/catalyst-install
+++ b/plugins/dev/scripts/catalyst-install
@@ -22,8 +22,9 @@ while [[ -L $SOURCE ]]; do
 done
 DIR="$(cd -P "$(dirname "$SOURCE")" >/dev/null 2>&1 && pwd)"
 
-# Prefer bun (the toolchain default); node is a fine fallback — the driver uses no
-# bun-only APIs of its own (install-telemetry/config are plain ESM).
-RUNTIME="bun"
-command -v bun >/dev/null 2>&1 || RUNTIME="node"
+# Prefer node: the driver uses only Node-standard APIs (no bun:* imports), and some Bun versions
+# crash on a direct `bun <file>.mjs` run of this CLI (observed exit 132), so Bun would otherwise kill
+# `catalyst install` before it even prints help. Fall back to bun only if node is unavailable.
+RUNTIME="node"
+command -v node >/dev/null 2>&1 || RUNTIME="bun"
 exec "$RUNTIME" "$DIR/execution-core/install-lifecycle.mjs" "$@"

--- a/plugins/dev/scripts/catalyst-install
+++ b/plugins/dev/scripts/catalyst-install
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# catalyst-install — provision / tear down this node for its class (CTL-1369 PR3).
+#
+# Thin launcher: resolves its own real location (symlink-safe — install-cli.sh
+# symlinks this onto PATH) and execs the Node lifecycle driver in execution-core/.
+# All flags pass through. Invoked via the router as `catalyst install|uninstall|
+# reinstall …` (the router passes the operation as the first arg). See
+# `catalyst-install --help`.
+#
+# Composes the existing setup scripts per node class and drives the catalyst.install.*
+# telemetry contract so each run is an observable trace. worker → the full work stack;
+# developer/monitor → the updater agent + boot-drain (never broker/exec-core).
+set -euo pipefail
+
+# Resolve symlinks to find the real script directory (same idiom as
+# catalyst-linear-reconcile / catalyst-stack).
+SOURCE="${BASH_SOURCE[0]}"
+while [[ -L $SOURCE ]]; do
+	DIR="$(cd -P "$(dirname "$SOURCE")" >/dev/null 2>&1 && pwd)"
+	SOURCE="$(readlink "$SOURCE")"
+	[[ $SOURCE != /* ]] && SOURCE="$DIR/$SOURCE"
+done
+DIR="$(cd -P "$(dirname "$SOURCE")" >/dev/null 2>&1 && pwd)"
+
+# Prefer bun (the toolchain default); node is a fine fallback — the driver uses no
+# bun-only APIs of its own (install-telemetry/config are plain ESM).
+RUNTIME="bun"
+command -v bun >/dev/null 2>&1 || RUNTIME="node"
+exec "$RUNTIME" "$DIR/execution-core/install-lifecycle.mjs" "$@"

--- a/plugins/dev/scripts/check-setup.sh
+++ b/plugins/dev/scripts/check-setup.sh
@@ -86,7 +86,7 @@ done
 header "Catalyst CLI Install"
 
 CLI_BIN_DIR="${CATALYST_CLI_BIN_DIR:-$HOME/.catalyst/bin}"
-CLI_NAMES=(catalyst catalyst-backup catalyst-broker catalyst-comms catalyst-events catalyst-execution-core catalyst-filter catalyst-linear-reconcile catalyst-otel-forward catalyst-transitions catalyst-why catalyst-session catalyst-state catalyst-statusline catalyst-db catalyst-monitor catalyst-thoughts catalyst-claude catalyst-stack)
+CLI_NAMES=(catalyst catalyst-backup catalyst-install catalyst-broker catalyst-comms catalyst-events catalyst-execution-core catalyst-filter catalyst-linear-reconcile catalyst-otel-forward catalyst-transitions catalyst-why catalyst-session catalyst-state catalyst-statusline catalyst-db catalyst-monitor catalyst-thoughts catalyst-claude catalyst-stack)
 
 if [[ -d "$CLI_BIN_DIR" ]]; then
     pass "Bin dir exists: $CLI_BIN_DIR"

--- a/plugins/dev/scripts/execution-core/install-lifecycle.mjs
+++ b/plugins/dev/scripts/execution-core/install-lifecycle.mjs
@@ -217,6 +217,12 @@ export function planPhases({ operation, nodeClass, scripts, opts = {} }) {
   });
 
   const writeConfig = () => {
+    // NB: setup-catalyst.sh writes per-project secrets to the DEFAULT ~/.config/catalyst/config-<key>.json
+    // path regardless of a CATALYST_LAYER2_CONFIG_FILE / CATALYST_MACHINE_CONFIG redirect (it does not
+    // honor a config-dir override). On a real node the selected scope IS ~/.config/catalyst, so there is
+    // no split; the split is only possible under a non-default config scope (a test/sandbox seam), where
+    // those secrets land outside the backup/restore scope. A scoped-secrets override belongs in
+    // setup-catalyst.sh, not here. set-class / pluginPullOwner / readReplica all stay under the selected scope.
     const steps = [
       { label: "set-class", kind: "run", argv: [scripts.catalyst, "class", nodeClass] },
       { label: "setup-catalyst", kind: "run", argv: [scripts.setup, "--non-interactive"] },
@@ -339,6 +345,16 @@ function isUnsafeKey(k) {
   return k === "__proto__" || k === "prototype" || k === "constructor";
 }
 
+// readDeepKey — value at a dotted path (or undefined). Read-only; no prototype-walk risk.
+export function readDeepKey(obj, dottedKey) {
+  let cur = obj;
+  for (const k of dottedKey.split(".")) {
+    if (cur == null || typeof cur !== "object") return undefined;
+    cur = cur[k];
+  }
+  return cur;
+}
+
 export function setDeepKey(obj, dottedKey, value) {
   const parts = dottedKey.split(".");
   let cur = obj;
@@ -451,16 +467,20 @@ function defaultBundleHasCapturedAgents(bundlePath) {
   }
 }
 
-// bundleIsEmpty — did the backup capture NOTHING (a truly fresh node)? When false the node had prior
-// state (config/db) that restore re-lays, so rollback must NOT strip install-managed keys / uninstall
-// CLI symlinks (they may have pre-existed). Unreadable/absent manifest ⇒ treat as empty (fresh).
-function defaultBundleIsEmpty(bundlePath) {
-  try {
-    const m = JSON.parse(readFileSync(join(bundlePath, "manifest.json"), "utf8"));
-    return !Array.isArray(m.captured) || m.captured.length === 0;
-  } catch {
-    return true;
-  }
+// probeWorkerAgents — is the worker stack LaunchAgent installed (even if its daemons are stopped)?
+// A stopped-but-installed worker stack would RunAtLoad/StartInterval broker/exec-core back, so a
+// developer/monitor install must refuse it, not just a currently-LIVE stack. Honors CATALYST_LAUNCHAGENTS_DIR.
+function defaultProbeWorkerAgents(env = process.env) {
+  const laDir = env.CATALYST_LAUNCHAGENTS_DIR || join(homedir(), "Library", "LaunchAgents");
+  return existsSync(join(laDir, "ai.coalesce.catalyst-stack.plist"));
+}
+
+// probeCliInstalled — was a `catalyst` CLI symlink already on the node before this run? Used to decide
+// whether a fresh-install rollback should uninstall the symlinks (created this run) or leave them
+// (pre-existed). Honors CATALYST_BIN_DIR (the install-cli target).
+function defaultProbeCliInstalled(env = process.env) {
+  const binDir = env.CATALYST_BIN_DIR || env.CATALYST_CLI_BIN_DIR || join(homedir(), ".catalyst", "bin");
+  return existsSync(join(binDir, "catalyst"));
 }
 
 // probeDrained — is this node FULLY drained, i.e. admitting 0 new work AND with 0 in-flight tickets?
@@ -503,7 +523,8 @@ export function buildDefaultDeps(env) {
     probeResidualAgents: () => defaultProbeResidualAgents(env),
     probeDrained: () => defaultProbeDrained({ scripts, env }),
     bundleHasCapturedAgents: (p) => defaultBundleHasCapturedAgents(p),
-    bundleIsEmpty: (p) => defaultBundleIsEmpty(p),
+    probeWorkerAgents: () => defaultProbeWorkerAgents(env),
+    probeCliInstalled: () => defaultProbeCliInstalled(env),
     scriptExists: (p) => existsSync(p),
     binExists: (name) => {
       const r = spawnSync("sh", ["-c", `command -v "${name}" >/dev/null 2>&1`]);
@@ -537,7 +558,7 @@ function isTeardown(operation) {
  *   InstallRunCtor.
  */
 export async function runInstallLifecycle({ operation, nodeClass, opts = {} }, deps) {
-  const { scripts, env, layer2, runStep, emit, nowFn, genTraceId, genSpanId, probeDaemons, probeResidualAgents, probeDrained, bundleHasCapturedAgents, bundleIsEmpty, scriptExists, binExists, probeUpdaterAgent, log, InstallRunCtor } = deps;
+  const { scripts, env, layer2, runStep, emit, nowFn, genTraceId, genSpanId, probeDaemons, probeResidualAgents, probeDrained, bundleHasCapturedAgents, scriptExists, binExists, probeUpdaterAgent, probeWorkerAgents, probeCliInstalled, log, InstallRunCtor } = deps;
 
   // Every composed step inherits (a) the RESOLVED class so the bash tools (which re-derive class
   // env-first) cannot diverge from the lifecycle's target — e.g. `install --class developer` on a
@@ -599,15 +620,15 @@ export async function runInstallLifecycle({ operation, nodeClass, opts = {} }, d
     );
     return { outcome: "refused", reason: "stale-updater" };
   }
-  // The symmetric case: a `install --class developer|monitor` over a LIVE worker stack would set the
-  // class + adopt the updater while leaving broker/exec-core running — the exact mixed profile the
-  // per-class invariant forbids (verify-node would only flag it AFTER the changes landed). Refuse and
-  // steer to `reinstall` (whose teardown stops the worker stack), unless --force.
-  if (operation === "install" && !isWorker(nodeClass) && !opts.force && probeDaemons()) {
+  // The symmetric case: a `install --class developer|monitor` over a worker stack would set the class +
+  // adopt the updater while leaving the worker stack in place — the exact mixed profile the per-class
+  // invariant forbids. Check both LIVE daemons AND an INSTALLED-but-stopped stack agent (which would
+  // RunAtLoad/StartInterval the daemons back on a developer node). Refuse → reinstall, unless --force.
+  if (operation === "install" && !isWorker(nodeClass) && !opts.force && (probeDaemons() || probeWorkerAgents())) {
     log(
-      `catalyst-install: refusing install --class ${nodeClass} — broker/execution-core are running ` +
-        `(this looks like a worker). Switch profiles with 'catalyst reinstall --class ${nodeClass}' ` +
-        `(its teardown stops the worker stack), or pass --force.`,
+      `catalyst-install: refusing install --class ${nodeClass} — a worker stack (broker/execution-core ` +
+        `daemons or their LaunchAgent) is present. Switch profiles with 'catalyst reinstall --class ` +
+        `${nodeClass}' (its teardown removes the worker stack), or pass --force.`,
     );
     return { outcome: "refused", reason: "live-worker-stack" };
   }
@@ -615,6 +636,23 @@ export async function runInstallLifecycle({ operation, nodeClass, opts = {} }, d
   const traceId = genTraceId();
   const spanId = genSpanId();
   const run = new InstallRunCtor({ operation, nodeClass, emit, traceId, spanId, nowFn }).start({ class: nodeClass });
+
+  // Snapshot the node's PRE-RUN state BEFORE the first phase (acquire) writes anything. Used by
+  // rollback: a fresh node (no managed keys / no CLI before the run) gets those artifacts removed,
+  // and a custom pre-existing pluginDirs (which acquire overwrites before the install backup) is
+  // restored. (Captured from the live config now, not from the backup — acquire runs before the
+  // install backup, so the bundle already reflects acquire's pluginDirs write.)
+  let preCfg = {};
+  try {
+    preCfg = readLayer2(layer2);
+  } catch {
+    /* malformed pre-run config — resolveRequestedClass already failed closed; treat as empty here */
+  }
+  const preInstall = {
+    hadManagedKeys: INSTALL_MANAGED_KEYS.some((k) => readDeepKey(preCfg, k) != null),
+    hadCli: probeCliInstalled(),
+    pluginDirs: readDeepKey(preCfg, "catalyst.orchestration.pluginDirs") ?? null,
+  };
 
   const ctx = { bundlePath: null, healthOk: true, healthRc: null, cleanOk: true, teardownRan: false };
 
@@ -722,7 +760,26 @@ export async function runInstallLifecycle({ operation, nodeClass, opts = {} }, d
       // state (the backup) had launchd agents and whether this run already tore the node down.
       const teardownRan = ctx.teardownRan;
       const hadAgents = bundleHasCapturedAgents(ctx.bundlePath);
-      const restoreNode = () => runStep({ argv: [scripts.backup, "restore", ctx.bundlePath, "--force"], env: stepEnv });
+      const restoreNode = () => {
+        const r = runStep({ argv: [scripts.backup, "restore", ctx.bundlePath, "--force"], env: stepEnv });
+        // On `install`, acquire overwrites pluginDirs BEFORE the backup, so the bundle holds the NEW
+        // value; restore the node's original pre-run pluginDirs if it differed (a custom/older
+        // checkout), so a failed install doesn't permanently repoint it. (reinstall backs up first, so
+        // its bundle already has the original — this is a no-op there.)
+        if (r.code === 0 && preInstall.pluginDirs) {
+          try {
+            const cfg = readLayer2(layer2);
+            if (readDeepKey(cfg, "catalyst.orchestration.pluginDirs") !== preInstall.pluginDirs) {
+              setDeepKey(cfg, "catalyst.orchestration.pluginDirs", preInstall.pluginDirs);
+              writeLayer2Atomic(layer2, cfg);
+              log(`catalyst-install: rollback — restored prior pluginDirs ${preInstall.pluginDirs}`);
+            }
+          } catch (e) {
+            log(`catalyst-install: rollback note — could not restore prior pluginDirs: ${e.message}`);
+          }
+        }
+        return r;
+      };
       const bootOutAgents = () => {
         const unsvc = runStep({ argv: [scripts.stack, "uninstall-services"], env: stepEnv });
         if (unsvc.code !== 0) log(`catalyst-install: rollback note — uninstall-services rc ${unsvc.code} (agents may remain): ${unsvc.stderr.trim()}`);
@@ -775,14 +832,16 @@ export async function runInstallLifecycle({ operation, nodeClass, opts = {} }, d
             // (not captured in the backup) so the restored node still has `catalyst` on PATH.
             const cli = runStep({ argv: [scripts.installCli], env: stepEnv });
             if (cli.code !== 0) log(`catalyst-install: rollback note — re-install CLI symlinks rc ${cli.code}: ${cli.stderr.trim()}`);
-          } else if (bundleIsEmpty(ctx.bundlePath)) {
-            // TRULY fresh node (empty backup — nothing to restore): the config keys + symlinks present
-            // were all created THIS run, so delete them. (We do NOT do this when the backup captured
-            // prior config — restore re-laid the node's pre-existing settings; stripping would erase
-            // them. Per-project secret files are left either way — re-usable, not an operational footprint.)
-            const cli = runStep({ argv: [scripts.installCli, "--uninstall"], env: stepEnv });
-            if (cli.code !== 0) log(`catalyst-install: rollback note — uninstall CLI symlinks rc ${cli.code}: ${cli.stderr.trim()}`);
-            stripManagedKeys();
+          } else {
+            // install on a no-agent node. Remove ONLY the artifacts THIS run created, determined from
+            // the PRE-RUN snapshot (NOT the post-acquire bundle, whose pluginDirs write makes it look
+            // non-empty even on a fresh node). A node that already had these keeps them (restore re-laid
+            // its config). Per-project secret files are left either way — re-usable, not operational.
+            if (!preInstall.hadCli) {
+              const cli = runStep({ argv: [scripts.installCli, "--uninstall"], env: stepEnv });
+              if (cli.code !== 0) log(`catalyst-install: rollback note — uninstall CLI symlinks rc ${cli.code}: ${cli.stderr.trim()}`);
+            }
+            if (!preInstall.hadManagedKeys) stripManagedKeys();
           }
         }
         rolledBack = restore.code === 0;
@@ -796,11 +855,26 @@ export async function runInstallLifecycle({ operation, nodeClass, opts = {} }, d
         const live = probeDaemons();
         if (live) {
           const stop = runStep({ argv: [scripts.stack, "stop"], env: stepEnv });
-          if (stop.code !== 0) log(`catalyst-install: rollback note — stop-before-restore rc ${stop.code}`);
-          restore = restoreNode();
-          const start = runStep({ argv: [scripts.stack, "start", "--yes"], env: stepEnv });
-          if (start.code !== 0) log(`catalyst-install: rollback note — restart-after-restore rc ${start.code} (run 'catalyst-stack start')`);
-          rolledBack = restore.code === 0;
+          if (stop.code !== 0) {
+            // The stack did NOT stop — do NOT force a restore over still-live broker/exec-core (it can
+            // corrupt config/db). Leave the node as-is and report an incomplete rollback for manual recovery.
+            log(`catalyst-install: rollback INCOMPLETE — could not stop the live worker stack (rc ${stop.code}); NOT restoring over live daemons. Stop the stack and 'catalyst-backup restore ${ctx.bundlePath} --force' manually.`);
+            restore = stop; // non-zero → rolledBack stays false
+            rolledBack = false;
+          } else {
+            restore = restoreNode();
+            if (restore.code === 0) {
+              // Restart with the RESTORED class (not the requested target pinned in stepEnv), so the
+              // started daemons stamp the node's actual class.
+              const rawClass = readNodeClassRaw(layer2);
+              const restoredClass = rawClass && NODE_CLASSES.includes(rawClass.trim().toLowerCase()) ? rawClass.trim().toLowerCase() : "worker";
+              const start = runStep({ argv: [scripts.stack, "start", "--yes"], env: { ...stepEnv, CATALYST_NODE_CLASS: restoredClass } });
+              if (start.code !== 0) log(`catalyst-install: rollback note — restart-after-restore rc ${start.code} (run 'catalyst-stack start')`);
+              rolledBack = start.code === 0; // the original stack must come back up for a clean rollback
+            } else {
+              rolledBack = false;
+            }
+          }
         } else {
           restore = restoreNode();
           const bringupOk = restore.code === 0 ? reBootstrapRestoredClass() : false;

--- a/plugins/dev/scripts/execution-core/install-lifecycle.mjs
+++ b/plugins/dev/scripts/execution-core/install-lifecycle.mjs
@@ -1,0 +1,728 @@
+// install-lifecycle.mjs — CTL-1369 PR3: the `catalyst install | uninstall | reinstall`
+// per-class lifecycle driver (run via the thin `catalyst-install` bash launcher).
+//
+// It is a THIN ORCHESTRATOR, not a re-implementation of provisioning. It (a) composes the
+// existing setup scripts per node class and (b) drives the PR1 `InstallRun` telemetry contract
+// so each lifecycle run is an observable trace + a `catalyst.install.*` event stream.
+//
+// The composition surface (each step shells out; every path is an env-override SEAM so tests
+// stub them — mirrors catalyst-join.sh's CATALYST_JOIN_*_SCRIPT pattern):
+//   - setup-plugin-source.sh   (acquire)      clone/update the plugin checkout + register pluginDirs
+//   - catalyst-backup backup   (backup)       snapshot restorable state BEFORE any overwrite
+//   - catalyst class <x>       (write-config)  set Layer-2 node.class
+//   - setup-catalyst.sh        (write-config)  Layer-1 config + Layer-2 secrets
+//   - install-cli.sh           (install-agents) install the catalyst-* symlinks
+//   - catalyst-stack install-services | adopt-updater (install-agents) — THE PER-CLASS SPLIT
+//   - catalyst-stack start | catalyst drain  (start-daemons)
+//   - catalyst-stack verify-node (healthcheck) class-aware health (NON-fatal)
+//
+// THE PER-CLASS INVARIANT (the heart of correctness, enforced by tests):
+//   * worker     → runs `install-services` (broker/exec-core/monitor); NEVER `adopt-updater`
+//                  (the broker is the plugin-pull owner).
+//   * developer  → runs `adopt-updater` (5th updater agent, sole pull owner) + boot-drain;
+//                  NEVER `install-services` (a developer node must not run broker/exec-core).
+//   * monitor    → enum-slot stub: developer-shaped (updater + drain), no work stack (design §10).
+//
+// Phase enums are LOCKED with OTEL (it sized dashboards on {operation, phase}). install uses the
+// PR1 INSTALL_PHASES; uninstall/reinstall finalized here. Telemetry is best-effort throughout —
+// it must never break a lifecycle run. Provisioning failures roll back from the backup bundle.
+
+import { spawnSync } from "node:child_process";
+import { randomBytes } from "node:crypto";
+import { readFileSync, writeFileSync, mkdirSync, renameSync, existsSync, readdirSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { homedir } from "node:os";
+
+import { InstallRun, makeInstallEmitFn } from "./lib/install-telemetry.mjs";
+import { NODE_CLASSES, getNodeClass } from "./config.mjs";
+
+// ── phase enums ───────────────────────────────────────────────────────────────
+// install: the PR1 locked set (acquire → backup → write-config → install-agents →
+// start-daemons → healthcheck) imported from install-telemetry.
+// uninstall: finalized here — reverse of install, backup-first.
+export const UNINSTALL_PHASES = Object.freeze([
+  "backup",
+  "stop-daemons",
+  "remove-agents",
+  "remove-config",
+  "verify-clean",
+]);
+// reinstall = uninstall's teardown (one backup at the top) THEN install's provisioning, under
+// ONE root span (operation=reinstall). No second backup — the top-of-run snapshot covers both.
+export const REINSTALL_PHASES = Object.freeze([
+  "backup",
+  "stop-daemons",
+  "remove-agents",
+  "remove-config",
+  "acquire",
+  "write-config",
+  "install-agents",
+  "start-daemons",
+  "healthcheck",
+]);
+
+export const LIFECYCLE_OPERATIONS = Object.freeze(["install", "uninstall", "reinstall"]);
+
+// Layer-2 machine-config keys the install lifecycle OWNS — set on install, stripped on uninstall.
+// SECRETS (per-project config-<key>.json) are deliberately NOT in this list: uninstall preserves
+// the node's secret identity (it is also captured in the backup), so a reinstall does not have to
+// re-prompt for tokens. A future --purge can extend teardown to the secrets.
+export const INSTALL_MANAGED_KEYS = Object.freeze([
+  "catalyst.node.class",
+  "catalyst.orchestration.pluginPullOwner",
+  "catalyst.readReplica.baseUrl",
+]);
+
+const SCRIPT_DIR = dirname(fileURLToPath(import.meta.url)); // …/plugins/dev/scripts/execution-core
+const SCRIPTS_DIR = resolve(SCRIPT_DIR, ".."); // …/plugins/dev/scripts
+const REPO_ROOT = resolve(SCRIPT_DIR, "..", "..", "..", ".."); // repo root (setup-catalyst.sh lives here)
+
+/**
+ * resolveScripts — the composition seams. Each path is `env override > computed default` so the
+ * bash setup steps can be stubbed in tests (CATALYST_INSTALL_*_SCRIPT) without touching the real
+ * toolchain. Defaults are derived from THIS module's location (works in a checkout; install is a
+ * checkout-context operation, not a bare-cache one).
+ */
+export function resolveScripts(env = process.env) {
+  return {
+    pluginSrc: env.CATALYST_INSTALL_PLUGIN_SRC_SCRIPT || join(SCRIPTS_DIR, "setup-plugin-source.sh"),
+    backup: env.CATALYST_INSTALL_BACKUP_BIN || join(SCRIPTS_DIR, "catalyst-backup"),
+    catalyst: env.CATALYST_INSTALL_CATALYST_BIN || join(SCRIPTS_DIR, "catalyst"),
+    setup: env.CATALYST_INSTALL_SETUP_SCRIPT || join(REPO_ROOT, "setup-catalyst.sh"),
+    installCli: env.CATALYST_INSTALL_CLI_SCRIPT || join(SCRIPTS_DIR, "install-cli.sh"),
+    stack: env.CATALYST_INSTALL_STACK_BIN || join(SCRIPTS_DIR, "catalyst-stack"),
+  };
+}
+
+/** layer2Path — the Layer-2 machine config (same precedence the rest of the toolchain uses). */
+export function layer2Path(env = process.env) {
+  return env.CATALYST_LAYER2_CONFIG_FILE || join(homedir(), ".config", "catalyst", "config.json");
+}
+
+/**
+ * resolveRequestedClass — the class this lifecycle run targets. Precedence:
+ *   explicit --class > CATALYST_NODE_CLASS env > current Layer-2 class (getNodeClass).
+ * An explicit but UNRECOGNIZED --class is a hard error (the §3 footgun fix — never silently
+ * fall back to worker on a typo'd developer node). Returns { nodeClass, source }.
+ */
+export function resolveRequestedClass({ optsClass, env = process.env, currentFn = getNodeClass } = {}) {
+  if (optsClass != null && optsClass !== "") {
+    const normalized = String(optsClass).trim().toLowerCase();
+    if (!NODE_CLASSES.includes(normalized)) {
+      throw new Error(`unrecognized node class: '${optsClass}' (valid: ${NODE_CLASSES.join(", ")})`);
+    }
+    return { nodeClass: normalized, source: "--class" };
+  }
+  if (env.CATALYST_NODE_CLASS) {
+    const normalized = String(env.CATALYST_NODE_CLASS).trim().toLowerCase();
+    if (!NODE_CLASSES.includes(normalized)) {
+      throw new Error(`unrecognized CATALYST_NODE_CLASS: '${env.CATALYST_NODE_CLASS}' (valid: ${NODE_CLASSES.join(", ")})`);
+    }
+    return { nodeClass: normalized, source: "env" };
+  }
+  return { nodeClass: currentFn(), source: "config" };
+}
+
+/**
+ * resolveReadReplica — the read-replica endpoint for this run, with the SAME default-to-current
+ * precedence as the node class: explicit --read-replica > CATALYST_MONITOR_URL env > the value
+ * already in Layer-2. Defaulting to the current value is what keeps `reinstall` (whose teardown
+ * strips the key) from silently dropping a developer/monitor node's configured read source.
+ * Returns the url or null. (Worker installs ignore it — a worker reads its own local replica.)
+ */
+export function resolveReadReplica({ flag = null, env = process.env, layer2 } = {}) {
+  if (flag) return flag;
+  if (env.CATALYST_MONITOR_URL) return env.CATALYST_MONITOR_URL;
+  try {
+    const v = readLayer2(layer2)?.catalyst?.readReplica?.baseUrl;
+    return typeof v === "string" && v ? v : null;
+  } catch {
+    return null;
+  }
+}
+
+// A worker is the only class that runs the full work stack (broker/exec-core/monitor); every
+// other class is daemonless-with-updater. Centralized so the plan and the tests agree.
+function isWorker(nodeClass) {
+  return nodeClass === "worker";
+}
+
+/**
+ * planPhases — PURE. Returns the ordered [{phase, steps}] plan for an operation+class. This is
+ * both what `--dry-run` prints and what the per-class-correctness tests assert on (no execution).
+ * Each step is data: { label, kind, argv?, key?, value?, keys?, optional?, fatalOnHealth? }.
+ *   kind: "run" (shell argv) | "backup" (run + capture bundle) | "healthcheck" (run, non-fatal) |
+ *         "setkey" | "removeconfig" | "verify-clean" (mjs-internal).
+ */
+export function planPhases({ operation, nodeClass, scripts, opts = {} }) {
+  const worker = isWorker(nodeClass);
+
+  // acquire registers the pluginDirs checkout, which writes catalyst.orchestration.pluginDirs into
+  // Layer-2 BEFORE the (OTEL-locked) backup phase. This is an INTENTIONAL exemption from
+  // backup-before-overwrite: the plugin-source checkout is git-reconstructable infra outside the
+  // lifecycle's restore contract (hence pluginDirs is not in INSTALL_MANAGED_KEYS), and on a fresh
+  // node the write is a first-time set, on an already-canonical node it is a no-op. reinstall is
+  // unaffected (its backup is phase 1). Everything the lifecycle actually overwrites (node.class,
+  // readReplica, secrets, launchd agents, catalyst.db) is written AFTER backup and so is restorable.
+  const acquire = () => ({
+    phase: "acquire",
+    steps: [{ label: "plugin-source", kind: "run", argv: [scripts.pluginSrc] }],
+  });
+
+  const backup = (label) => ({
+    phase: "backup",
+    steps: [{ label: "backup", kind: "backup", argv: [scripts.backup, "backup", "--label", label] }],
+  });
+
+  const writeConfig = () => {
+    const steps = [
+      { label: "set-class", kind: "run", argv: [scripts.catalyst, "class", nodeClass] },
+      { label: "setup-catalyst", kind: "run", argv: [scripts.setup, "--non-interactive"] },
+    ];
+    // A developer/monitor node reads a worker's monitor over HTTP — bind it when given. (Worker
+    // reads its own local replica, so the key is meaningless there.) Optional: a missing endpoint
+    // is surfaced by the developer verify-node rubric, not a hard install failure.
+    if (!worker && opts.readReplica) {
+      steps.push({ label: "read-replica", kind: "setkey", key: "catalyst.readReplica.baseUrl", value: opts.readReplica });
+    }
+    return { phase: "write-config", steps };
+  };
+
+  const installAgents = () => ({
+    phase: "install-agents",
+    steps: [
+      { label: "install-cli", kind: "run", argv: [scripts.installCli] },
+      worker
+        ? // worker: the full work stack (and its 4 launchd agents). NEVER adopt-updater.
+          { label: "install-services", kind: "run", argv: [scripts.stack, "install-services"] }
+        : // developer/monitor: the 5th updater agent as sole pull owner. NEVER install-services.
+          { label: "adopt-updater", kind: "run", argv: [scripts.stack, "adopt-updater"] },
+    ],
+  });
+
+  const startDaemons = () => ({
+    phase: "start-daemons",
+    steps: [
+      worker
+        ? { label: "start-stack", kind: "run", argv: [scripts.stack, "start", "--yes"] }
+        : // developer/monitor: boot-drain so a mis-rostered node still admits 0 work. Best-effort
+          // (CTL-1352 auto-boot-drain is unbuilt) — verify-node confirms it took.
+          { label: "drain", kind: "run", argv: [scripts.catalyst, "drain"], optional: true },
+    ],
+  });
+
+  const healthcheck = () => ({
+    phase: "healthcheck",
+    steps: [{ label: "verify-node", kind: "healthcheck", argv: [scripts.stack, "verify-node"] }],
+  });
+
+  const stopDaemons = () => ({
+    phase: "stop-daemons",
+    steps: [{ label: "stop-stack", kind: "run", argv: [scripts.stack, "stop"] }],
+  });
+
+  const removeAgents = () => ({
+    phase: "remove-agents",
+    steps: [
+      // uninstall-services removes ALL launchd agents including the updater + reconciles the
+      // pull-owner back to broker (CTL-1348).
+      { label: "uninstall-services", kind: "run", argv: [scripts.stack, "uninstall-services"] },
+      { label: "uninstall-cli", kind: "run", argv: [scripts.installCli, "--uninstall"] },
+    ],
+  });
+
+  const removeConfig = () => ({
+    phase: "remove-config",
+    steps: [{ label: "remove-keys", kind: "removeconfig", keys: [...INSTALL_MANAGED_KEYS] }],
+  });
+
+  const verifyClean = () => ({
+    phase: "verify-clean",
+    steps: [{ label: "verify-clean", kind: "verify-clean" }],
+  });
+
+  switch (operation) {
+    case "install":
+      return [acquire(), backup(`install-${nodeClass}`), writeConfig(), installAgents(), startDaemons(), healthcheck()];
+    case "uninstall":
+      return [backup(`uninstall-${nodeClass}`), stopDaemons(), removeAgents(), removeConfig(), verifyClean()];
+    case "reinstall":
+      // One backup at the top covers the whole reinstall; teardown then fresh provisioning.
+      return [
+        backup(`reinstall-${nodeClass}`),
+        stopDaemons(),
+        removeAgents(),
+        removeConfig(),
+        acquire(),
+        writeConfig(),
+        installAgents(),
+        startDaemons(),
+        healthcheck(),
+      ];
+    default:
+      throw new Error(`unknown operation: ${operation} (valid: ${LIFECYCLE_OPERATIONS.join(", ")})`);
+  }
+}
+
+// ── Layer-2 surgical edits (mjs-internal, jq-free, atomic) ──────────────────────
+function readLayer2(path) {
+  if (!existsSync(path)) return {};
+  const raw = readFileSync(path, "utf8");
+  if (!raw.trim()) return {};
+  return JSON.parse(raw); // a malformed config is a real error — let it throw (fail closed)
+}
+
+function writeLayer2Atomic(path, obj) {
+  mkdirSync(dirname(path), { recursive: true });
+  const tmp = `${path}.${randomBytes(6).toString("hex")}.tmp`;
+  writeFileSync(tmp, `${JSON.stringify(obj, null, 2)}\n`, { mode: 0o600 });
+  renameSync(tmp, path);
+}
+
+function setDeepKey(obj, dottedKey, value) {
+  const parts = dottedKey.split(".");
+  let cur = obj;
+  for (let i = 0; i < parts.length - 1; i++) {
+    if (typeof cur[parts[i]] !== "object" || cur[parts[i]] == null) cur[parts[i]] = {};
+    cur = cur[parts[i]];
+  }
+  cur[parts[parts.length - 1]] = value;
+}
+
+function deleteDeepKey(obj, dottedKey) {
+  const parts = dottedKey.split(".");
+  let cur = obj;
+  for (let i = 0; i < parts.length - 1; i++) {
+    if (typeof cur[parts[i]] !== "object" || cur[parts[i]] == null) return false; // path absent → nothing to delete
+    cur = cur[parts[i]];
+  }
+  const leaf = parts[parts.length - 1];
+  if (Object.prototype.hasOwnProperty.call(cur, leaf)) {
+    delete cur[leaf];
+    return true;
+  }
+  return false;
+}
+
+// ── default real deps (overridable for tests) ──────────────────────────────────
+// cwd is pinned to REPO_ROOT: setup-catalyst.sh derives its target repo from the cwd's git root,
+// so without this `catalyst install` from an arbitrary directory would hard-fail or onboard the
+// wrong repo. The other composed tools self-resolve via BASH_SOURCE (cwd-independent), so pinning
+// the checkout root for all steps is safe + deterministic regardless of where the operator runs it.
+function defaultRunStep({ argv, env, cwd }) {
+  const res = spawnSync(argv[0], argv.slice(1), {
+    encoding: "utf8",
+    cwd: cwd || REPO_ROOT,
+    env: { ...process.env, ...(env || {}) },
+  });
+  if (res.error) return { code: 127, stdout: "", stderr: String(res.error.message || res.error) };
+  return { code: res.status == null ? 1 : res.status, stdout: res.stdout || "", stderr: res.stderr || "" };
+}
+
+// probeDaemons — is a broker/execution-core daemon live? Honors CATALYST_ASSUME_NO_DAEMONS=1 as a
+// test seam, and (like catalyst-backup) FAILS SAFE: if liveness can't be determined, assume LIVE
+// so the teardown guard refuses without --force.
+function defaultProbeDaemons(env = process.env) {
+  if (env.CATALYST_ASSUME_NO_DAEMONS === "1") return false;
+  const res = spawnSync("pgrep", ["-f", "broker/index.mjs|execution-core/(daemon|index)\\.mjs"], { encoding: "utf8" });
+  if (res.error) return true; // pgrep missing → assume LIVE (safe)
+  return res.status === 0;
+}
+
+// probeResidualAgents — after teardown, is ANYTHING catalyst still installed/running? Unlike
+// probeDaemons (broker/exec-core only — the work-liveness signal the teardown GUARD uses), this is
+// the honest verify-clean check: it also catches the updater agent (the ONLY daemon a developer/
+// monitor node runs) and any residual launchd plist. Deterministic on the plist files; the process
+// pgrep is best-effort. Honors CATALYST_LAUNCHAGENTS_DIR + CATALYST_ASSUME_NO_DAEMONS test seams.
+function defaultProbeResidualAgents(env = process.env) {
+  const laDir = env.CATALYST_LAUNCHAGENTS_DIR || join(homedir(), "Library", "LaunchAgents");
+  try {
+    if (readdirSync(laDir).some((f) => /^ai\.coalesce\.catalyst-.*\.plist$/.test(f))) return true;
+  } catch {
+    /* launchagents dir absent → no agents */
+  }
+  if (env.CATALYST_ASSUME_NO_DAEMONS === "1") return false;
+  const res = spawnSync("pgrep", ["-f", "broker/index.mjs|execution-core/(daemon|index|updater/updater)\\.mjs"], { encoding: "utf8" });
+  if (res.error) return false; // can't probe processes; the plist check above already ran
+  return res.status === 0;
+}
+
+// probeDrained — is this node draining (admitting 0 new work)? Best-effort; unknown ⇒ false (the
+// guard then requires --force on a live node, the safe default).
+function defaultProbeDrained({ scripts, env = process.env } = {}) {
+  if (env.CATALYST_ASSUME_DRAINED === "1") return true;
+  const res = spawnSync(scripts.catalyst, ["drain", "--status-read", "--json"], { encoding: "utf8" });
+  if (res.error || res.status !== 0 || !res.stdout) return false;
+  try {
+    const parsed = JSON.parse(res.stdout);
+    return parsed.draining === true || parsed.drained === true;
+  } catch {
+    return false;
+  }
+}
+
+export function buildDefaultDeps(env) {
+  const scripts = resolveScripts(env);
+  return {
+    scripts,
+    env,
+    layer2: layer2Path(env),
+    runStep: defaultRunStep,
+    emit: makeInstallEmitFn({}),
+    nowFn: Date.now,
+    genTraceId: () => randomBytes(16).toString("hex"),
+    genSpanId: () => randomBytes(8).toString("hex"),
+    probeDaemons: () => defaultProbeDaemons(env),
+    probeResidualAgents: () => defaultProbeResidualAgents(env),
+    probeDrained: () => defaultProbeDrained({ scripts, env }),
+    scriptExists: (p) => existsSync(p),
+    log: (msg) => process.stderr.write(`${msg}\n`),
+    InstallRunCtor: InstallRun,
+  };
+}
+
+// Only install + reinstall overwrite node state, so only they roll back. Uninstall teardown is not
+// auto-rolled-back (restoring a half-torn-down node is riskier than leaving it with a loud backup
+// pointer for the operator).
+function autoRollbacks(operation) {
+  return operation === "install" || operation === "reinstall";
+}
+
+// Teardown operations stop daemons — refuse to run one against a live, non-drained node unless
+// forced (the "uninstall guards a live node" property).
+function isTeardown(operation) {
+  return operation === "uninstall" || operation === "reinstall";
+}
+
+/**
+ * runInstallLifecycle — drives the plan through an InstallRun. Returns a result object; never
+ * throws for a normal lifecycle failure (the outcome is in the return). Telemetry is best-effort.
+ *
+ * deps (all injectable): scripts, env, layer2, runStep, emit, nowFn, genTraceId, genSpanId,
+ *   probeDaemons, probeResidualAgents, probeDrained, scriptExists, log, InstallRunCtor.
+ */
+export async function runInstallLifecycle({ operation, nodeClass, opts = {} }, deps) {
+  const { scripts, env, layer2, runStep, emit, nowFn, genTraceId, genSpanId, probeDaemons, probeResidualAgents, probeDrained, scriptExists, log, InstallRunCtor } = deps;
+
+  // Every composed step inherits the RESOLVED class so the bash tools (which re-derive class env-
+  // first) cannot diverge from the lifecycle's target — e.g. `install --class developer` on a shell
+  // exporting CATALYST_NODE_CLASS=worker must still adopt-updater, not hit the worker refusal. Mirrors
+  // doctor.mjs pinning CATALYST_NODE_CLASS when it spawns verify-node.
+  const stepEnv = { ...env, CATALYST_NODE_CLASS: nodeClass };
+
+  // Pre-flight live-node guard (teardown only) — refuse BEFORE starting a run.
+  if (isTeardown(operation) && !opts.force) {
+    if (probeDaemons() && !probeDrained()) {
+      log(
+        `catalyst-install: refusing to ${operation} a live, non-drained node — drain first ` +
+          `('catalyst drain') then retry, or pass --force.`,
+      );
+      return { outcome: "refused", reason: "live-node" };
+    }
+  }
+
+  const plan = planPhases({ operation, nodeClass, scripts, opts });
+
+  // Pre-flight: every composed script the plan will shell out to must exist. setup-catalyst.sh lives
+  // at the repo root (NOT packaged in the plugin cache), so a cache-context run would otherwise take
+  // a full backup — or, on reinstall, TEAR THE NODE DOWN — and only then fail. Fail fast instead.
+  const planScripts = [...new Set(plan.flatMap((p) => p.steps).filter((s) => s.argv).map((s) => s.argv[0]))];
+  const missingScripts = planScripts.filter((p) => !scriptExists(p));
+  if (missingScripts.length) {
+    log(
+      `catalyst-install: refusing ${operation} — required script(s) not found: ${missingScripts.join(", ")}. ` +
+        `Run from a repo checkout (not the plugin cache), or set the CATALYST_INSTALL_*_SCRIPT overrides.`,
+    );
+    return { outcome: "refused", reason: "missing-script", missing: missingScripts };
+  }
+
+  const traceId = genTraceId();
+  const spanId = genSpanId();
+  const run = new InstallRunCtor({ operation, nodeClass, emit, traceId, spanId, nowFn }).start({ class: nodeClass });
+
+  const ctx = { bundlePath: null, healthOk: true, healthRc: null, cleanOk: true };
+
+  const runOneStep = async (step) => {
+    switch (step.kind) {
+      case "backup": {
+        const r = runStep({ argv: step.argv, env: stepEnv });
+        if (r.code !== 0) throw new Error(`backup failed (rc ${r.code}) — aborting before any overwrite: ${r.stderr.trim()}`);
+        // catalyst-backup prints the bundle path on its LAST stdout line.
+        const lines = r.stdout.trim().split("\n").filter(Boolean);
+        ctx.bundlePath = lines.length ? lines[lines.length - 1] : null;
+        log(`catalyst-install: backup → ${ctx.bundlePath}`);
+        return;
+      }
+      case "run": {
+        const r = runStep({ argv: step.argv, env: stepEnv });
+        if (r.code !== 0) {
+          if (step.optional) {
+            log(`catalyst-install: WARN — optional step '${step.label}' failed (rc ${r.code}), continuing: ${r.stderr.trim()}`);
+            return;
+          }
+          throw new Error(`step '${step.label}' failed (rc ${r.code}): ${r.stderr.trim()}`);
+        }
+        return;
+      }
+      case "setkey": {
+        const cfg = readLayer2(layer2);
+        setDeepKey(cfg, step.key, step.value);
+        writeLayer2Atomic(layer2, cfg);
+        log(`catalyst-install: set ${step.key} = ${step.value}`);
+        return;
+      }
+      case "removeconfig": {
+        const cfg = readLayer2(layer2);
+        const removed = [];
+        for (const k of step.keys) if (deleteDeepKey(cfg, k)) removed.push(k);
+        writeLayer2Atomic(layer2, cfg);
+        log(
+          `catalyst-install: removed install-managed keys [${removed.join(", ") || "none"}] from ${layer2} ` +
+            `(secrets preserved — they are also in the backup)`,
+        );
+        return;
+      }
+      case "healthcheck": {
+        // NON-fatal for rollback (an unhealthy node is still installed — never roll back on it), but
+        // the verdict DOES drive the command's exit code (see main()).
+        const r = runStep({ argv: step.argv, env: stepEnv });
+        ctx.healthRc = r.code;
+        ctx.healthOk = r.code === 0;
+        log(`catalyst-install: healthcheck (verify-node) ${ctx.healthOk ? "PASS" : `FAIL (rc ${r.code})`}`);
+        return;
+      }
+      case "verify-clean": {
+        // NON-fatal for rollback, but the verdict drives the exit code for teardown ops (see main()).
+        // Uses the residual-agent probe (NOT probeDaemons) so it honestly catches the updater agent —
+        // the only daemon a developer/monitor node runs — and any leftover launchd plist.
+        const residual = probeResidualAgents();
+        ctx.cleanOk = !residual;
+        log(`catalyst-install: verify-clean ${ctx.cleanOk ? "PASS (no catalyst agents/daemons remain)" : "FAIL (catalyst agents/daemons STILL PRESENT)"}`);
+        return;
+      }
+      default:
+        throw new Error(`unknown step kind: ${step.kind}`);
+    }
+  };
+
+  try {
+    for (const { phase, steps } of plan) {
+      // One InstallRun.phase per phase (times + emits catalyst.install.phase); a phase groups its
+      // ordered steps. A thrown step aborts the phase and re-raises to the rollback handler.
+      // eslint-disable-next-line no-await-in-loop
+      await run.phase(phase, async () => {
+        for (const step of steps) {
+          // eslint-disable-next-line no-await-in-loop
+          await runOneStep(step);
+        }
+      });
+    }
+    run.complete({ class: nodeClass, healthOk: ctx.healthOk, cleanOk: ctx.cleanOk, bundle: ctx.bundlePath });
+    return { outcome: "completed", healthOk: ctx.healthOk, healthRc: ctx.healthRc, cleanOk: ctx.cleanOk, bundlePath: ctx.bundlePath, traceId };
+  } catch (err) {
+    let rolledBack = false;
+    // disposition: "none" = nothing to undo (failed before/at backup) → benign abort; "ok" = fully
+    // reverted; "failed" = restore failed → node in a PARTIAL state. Stamped into the terminal event
+    // so a dashboard can tell a safe abort from a node that needs manual recovery (the riskiest case).
+    let rollbackDisposition = "none";
+    if (autoRollbacks(operation) && ctx.bundlePath) {
+      log(`catalyst-install: ${operation} failed — rolling back from ${ctx.bundlePath}`);
+      // A restore alone is ADDITIVE — it re-lays captured config/db/plist FILES but cannot un-bootstrap
+      // launchd agents that provisioning just installed (and a worker's stack keep-alive would restart
+      // the daemon). So tear those down FIRST (boot out agents, then stop any survivors), THEN restore
+      // the captured state. Both teardown steps are best-effort; the restore is the authoritative
+      // "node state put back" signal. NB: install-cli symlinks are intentionally left in place — they
+      // are not captured in the backup, so removing them would be an unrecoverable, not a reversal.
+      const unsvc = runStep({ argv: [scripts.stack, "uninstall-services"], env: stepEnv });
+      if (unsvc.code !== 0) log(`catalyst-install: rollback note — uninstall-services rc ${unsvc.code} (agents may remain): ${unsvc.stderr.trim()}`);
+      const stop = runStep({ argv: [scripts.stack, "stop"], env: stepEnv });
+      if (stop.code !== 0) log(`catalyst-install: rollback note — stop rc ${stop.code}`);
+      const restore = runStep({ argv: [scripts.backup, "restore", ctx.bundlePath, "--force"], env: stepEnv });
+      rolledBack = restore.code === 0;
+      rollbackDisposition = rolledBack ? "ok" : "failed";
+      log(
+        rolledBack
+          ? `catalyst-install: rolled back — restored ${ctx.bundlePath} + tore down provisioned agents (verify launchd/daemon state)`
+          : `catalyst-install: rollback INCOMPLETE (restore rc ${restore.code}) — node is in a PARTIAL state; bundle at ${ctx.bundlePath}`,
+      );
+    } else if (ctx.bundlePath) {
+      log(`catalyst-install: ${operation} failed — NOT auto-rolled-back; restore manually from ${ctx.bundlePath} if needed`);
+    }
+    run.fail(err, { rolledBack, detail: { rollback: rollbackDisposition, bundle: ctx.bundlePath } });
+    return { outcome: rolledBack ? "rolled_back" : "failed", error: err.message, rolledBack, rollbackDisposition, bundlePath: ctx.bundlePath, traceId };
+  }
+}
+
+// ── CLI ─────────────────────────────────────────────────────────────────────
+export function parseArgs(argv) {
+  const a = { operation: null, class: null, readReplica: null, force: false, dryRun: false, json: false, help: false };
+  const rest = [...argv];
+  // First non-flag token is the operation (the router passes it as argv[0]).
+  for (let i = 0; i < rest.length; i++) {
+    const v = rest[i];
+    switch (v) {
+      case "-h":
+      case "--help":
+        a.help = true;
+        break;
+      case "--force":
+        a.force = true;
+        break;
+      case "--dry-run":
+      case "--print":
+        a.dryRun = true;
+        break;
+      case "--json":
+        a.json = true;
+        break;
+      case "--class":
+        a.class = rest[++i] ?? null;
+        break;
+      case "--read-replica":
+        a.readReplica = rest[++i] ?? null;
+        break;
+      default:
+        if (v.startsWith("--class=")) a.class = v.slice("--class=".length);
+        else if (v.startsWith("--read-replica=")) a.readReplica = v.slice("--read-replica=".length);
+        else if (!v.startsWith("-") && a.operation == null) a.operation = v;
+        // unknown flags are ignored (forward-compat); an unknown operation is caught by validation
+        break;
+    }
+  }
+  return a;
+}
+
+export function usage() {
+  return `catalyst-install — provision / tear down this node for its class (CTL-1369).
+
+Usage (normally via the router: 'catalyst install|uninstall|reinstall …'):
+  catalyst-install install   [--class developer|worker|monitor] [--read-replica <url>] [--dry-run]
+  catalyst-install uninstall [--force] [--dry-run]
+  catalyst-install reinstall [--class …] [--read-replica <url>] [--force] [--dry-run]
+
+Options:
+  --class <c>          target node class (install: declares it; un/reinstall: defaults to current)
+  --read-replica <url> developer/monitor: a worker monitor's base URL to read from (e.g. http://host:7400)
+  --force              teardown a live, non-drained node (uninstall/reinstall guard override)
+  --dry-run, --print   resolve + print the per-class step plan; run NOTHING (no side effects)
+  --json               machine-readable output (with --dry-run, prints the plan as JSON)
+  -h, --help           this help
+
+Per class: worker runs the full work stack (install-services); developer/monitor run the updater
+agent (adopt-updater) + boot-drain and never start broker/exec-core.`;
+}
+
+function printPlan(plan, { operation, nodeClass }, json, out) {
+  if (json) {
+    out(JSON.stringify({ operation, nodeClass, dryRun: true, plan }, null, 2));
+    return;
+  }
+  out(`catalyst-install ${operation} --class ${nodeClass}  (dry-run — nothing will run)`);
+  for (const { phase, steps } of plan) {
+    out(`  ${phase}:`);
+    for (const s of steps) {
+      const desc =
+        s.kind === "setkey"
+          ? `set ${s.key}=${s.value}`
+          : s.kind === "removeconfig"
+            ? `remove Layer-2 keys [${s.keys.join(", ")}] (secrets preserved)`
+            : s.kind === "verify-clean"
+              ? "verify no daemons/agents remain"
+              : (s.argv || []).join(" ");
+      out(`    - ${s.label}${s.optional ? " (optional)" : ""}: ${desc}`);
+    }
+  }
+}
+
+/**
+ * main — CLI entry. Returns an exit code. Side effects via injected deps (default: real).
+ * Exit codes: 0 = completed + healthy; 1 = completed-unhealthy / failed / rolled_back; 2 = usage
+ * error or refused (live node).
+ */
+export async function main(argv, depsOverride) {
+  const env = depsOverride?.env || process.env;
+  const out = depsOverride?.out || ((m) => process.stdout.write(`${m}\n`));
+  const errOut = depsOverride?.errOut || ((m) => process.stderr.write(`${m}\n`));
+
+  const args = parseArgs(argv);
+  if (args.help) {
+    out(usage());
+    return 0;
+  }
+  if (!args.operation || !LIFECYCLE_OPERATIONS.includes(args.operation)) {
+    errOut(`catalyst-install: expected one of ${LIFECYCLE_OPERATIONS.join(" | ")}${args.operation ? ` (got '${args.operation}')` : ""}`);
+    errOut(usage());
+    return 2;
+  }
+
+  const deps = { ...buildDefaultDeps(env), ...(depsOverride || {}), env };
+
+  let nodeClass;
+  try {
+    ({ nodeClass } = resolveRequestedClass({ optsClass: args.class, env }));
+  } catch (e) {
+    errOut(`catalyst-install: ${e.message}`);
+    return 2;
+  }
+
+  // Resolve the read-replica with the same default-to-current precedence as --class: flag > env >
+  // current Layer-2. CRUCIAL for reinstall — remove-config strips readReplica during teardown, so
+  // without this a reinstall WITHOUT --read-replica would silently drop a developer/monitor node's
+  // configured endpoint (and then verify-node would FAIL on the missing read source).
+  const readReplica = resolveReadReplica({ flag: args.readReplica, env, layer2: deps.layer2 });
+  const opts = { force: args.force, readReplica };
+
+  if (args.dryRun) {
+    const plan = planPhases({ operation: args.operation, nodeClass, scripts: deps.scripts, opts });
+    printPlan(plan, { operation: args.operation, nodeClass }, args.json, out);
+    return 0;
+  }
+
+  const result = await runInstallLifecycle({ operation: args.operation, nodeClass, opts }, deps);
+
+  if (args.json) out(JSON.stringify(result));
+  switch (result.outcome) {
+    case "completed":
+      if (!result.healthOk) {
+        errOut(`catalyst-install: ${args.operation} completed but verify-node reported the node UNHEALTHY (rc ${result.healthRc ?? "?"}).`);
+        return 1;
+      }
+      // A teardown that left catalyst agents/daemons present is a FAILED teardown — surface it as a
+      // non-zero exit (symmetric with the healthOk treatment above), not a silent "completed".
+      if (isTeardown(args.operation) && result.cleanOk === false) {
+        errOut(`catalyst-install: ${args.operation} completed but verify-clean found catalyst agents/daemons STILL PRESENT — node not fully torn down (run 'catalyst-stack stop' / 'catalyst-stack uninstall-services').`);
+        return 1;
+      }
+      out(`catalyst-install: ${args.operation} (${nodeClass}) completed.`);
+      return 0;
+    case "rolled_back":
+      errOut(`catalyst-install: ${args.operation} failed and was rolled back: ${result.error}`);
+      return 1;
+    case "failed":
+      errOut(`catalyst-install: ${args.operation} failed: ${result.error}`);
+      return 1;
+    case "refused":
+      return 2;
+    default:
+      return 1;
+  }
+}
+
+// Direct-exec guard: run main() only when invoked as a script (not when imported by tests).
+const INVOKED_DIRECTLY = (() => {
+  try {
+    return process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url);
+  } catch {
+    return false;
+  }
+})();
+
+if (INVOKED_DIRECTLY) {
+  main(process.argv.slice(2))
+    .then((code) => process.exit(code))
+    .catch((e) => {
+      process.stderr.write(`catalyst-install: unexpected error: ${e?.stack || e}\n`);
+      process.exit(1);
+    });
+}

--- a/plugins/dev/scripts/execution-core/install-lifecycle.mjs
+++ b/plugins/dev/scripts/execution-core/install-lifecycle.mjs
@@ -34,7 +34,8 @@ import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { homedir } from "node:os";
 
-import { InstallRun, makeInstallEmitFn } from "./lib/install-telemetry.mjs";
+import { InstallRun, makeInstallEmitFn, INSTALL_SERVICE_NAME } from "./lib/install-telemetry.mjs";
+import { initTracing, shutdownTracing } from "./tracing.mjs";
 import { NODE_CLASSES, getNodeClass } from "./config.mjs";
 
 // ── phase enums ───────────────────────────────────────────────────────────────
@@ -330,6 +331,10 @@ function defaultRunStep({ argv, env, cwd }) {
   const res = spawnSync(argv[0], argv.slice(1), {
     encoding: "utf8",
     cwd: cwd || REPO_ROOT,
+    // The composed setup tools (setup-catalyst.sh, install-cli.sh, brew/git helpers) are chatty;
+    // the default 1 MB pipe buffer would make spawnSync ENOBUFS-error on a verbose-but-successful
+    // child and the lifecycle would wrongly treat it as a failure. 64 MB headroom.
+    maxBuffer: 64 * 1024 * 1024,
     env: { ...process.env, ...(env || {}) },
   });
   if (res.error) return { code: 127, stdout: "", stderr: String(res.error.message || res.error) };
@@ -359,9 +364,27 @@ function defaultProbeResidualAgents(env = process.env) {
     /* launchagents dir absent → no agents */
   }
   if (env.CATALYST_ASSUME_NO_DAEMONS === "1") return false;
-  const res = spawnSync("pgrep", ["-f", "broker/index.mjs|execution-core/(daemon|index|updater/updater)\\.mjs"], { encoding: "utf8" });
+  // Covers every stack daemon, not just broker/exec-core: the monitor (orch-monitor/server.ts) and
+  // otel-forward (otel-forward/index.ts) are nohup children of the stack — if `catalyst-stack stop`
+  // failed to kill them after the plists were removed, an uninstall would otherwise look clean.
+  const pattern = "broker/index.mjs|execution-core/(daemon|index|updater/updater)\\.mjs|orch-monitor/server\\.ts|otel-forward/index\\.ts";
+  const res = spawnSync("pgrep", ["-f", pattern], { encoding: "utf8" });
   if (res.error) return false; // can't probe processes; the plist check above already ran
   return res.status === 0;
+}
+
+// bundleHasCapturedAgents — did the backup snapshot any launchd agent plists? If so the node had
+// PRE-EXISTING agents before this run (a retry/reinstall on a working node), so rollback must NOT
+// boot them out (catalyst-backup restore re-lays the plist FILES but never re-bootstraps them, so a
+// teardown would leave a previously-working node's services down). When false (a fresh node, no
+// agents captured) rollback safely removes whatever provisioning installed this run.
+function defaultBundleHasCapturedAgents(bundlePath) {
+  try {
+    const m = JSON.parse(readFileSync(join(bundlePath, "manifest.json"), "utf8"));
+    return Array.isArray(m.captured) && m.captured.some((p) => p.startsWith("launchagents/") && p.endsWith(".plist"));
+  } catch {
+    return false; // unreadable manifest → treat as fresh (safe to tear down newly-installed agents)
+  }
 }
 
 // probeDrained — is this node draining (admitting 0 new work)? Best-effort; unknown ⇒ false (the
@@ -392,6 +415,7 @@ export function buildDefaultDeps(env) {
     probeDaemons: () => defaultProbeDaemons(env),
     probeResidualAgents: () => defaultProbeResidualAgents(env),
     probeDrained: () => defaultProbeDrained({ scripts, env }),
+    bundleHasCapturedAgents: (p) => defaultBundleHasCapturedAgents(p),
     scriptExists: (p) => existsSync(p),
     log: (msg) => process.stderr.write(`${msg}\n`),
     InstallRunCtor: InstallRun,
@@ -419,13 +443,16 @@ function isTeardown(operation) {
  *   probeDaemons, probeResidualAgents, probeDrained, scriptExists, log, InstallRunCtor.
  */
 export async function runInstallLifecycle({ operation, nodeClass, opts = {} }, deps) {
-  const { scripts, env, layer2, runStep, emit, nowFn, genTraceId, genSpanId, probeDaemons, probeResidualAgents, probeDrained, scriptExists, log, InstallRunCtor } = deps;
+  const { scripts, env, layer2, runStep, emit, nowFn, genTraceId, genSpanId, probeDaemons, probeResidualAgents, probeDrained, bundleHasCapturedAgents, scriptExists, log, InstallRunCtor } = deps;
 
-  // Every composed step inherits the RESOLVED class so the bash tools (which re-derive class env-
-  // first) cannot diverge from the lifecycle's target — e.g. `install --class developer` on a shell
-  // exporting CATALYST_NODE_CLASS=worker must still adopt-updater, not hit the worker refusal. Mirrors
-  // doctor.mjs pinning CATALYST_NODE_CLASS when it spawns verify-node.
-  const stepEnv = { ...env, CATALYST_NODE_CLASS: nodeClass };
+  // Every composed step inherits (a) the RESOLVED class so the bash tools (which re-derive class
+  // env-first) cannot diverge from the lifecycle's target — e.g. `install --class developer` on a
+  // shell exporting CATALYST_NODE_CLASS=worker must still adopt-updater (mirrors doctor.mjs pinning
+  // CATALYST_NODE_CLASS for verify-node); and (b) the driver's exact Layer-2 file under BOTH config
+  // env names the child tools honor, so the whole run reads/writes ONE config (else an XDG/
+  // CATALYST_MACHINE_CONFIG redirect would split node.class/readReplica and pluginDirs/pluginPullOwner
+  // across two files and break rollback's single restorable state).
+  const stepEnv = { ...env, CATALYST_NODE_CLASS: nodeClass, CATALYST_LAYER2_CONFIG_FILE: layer2, CATALYST_MACHINE_CONFIG: layer2 };
 
   // Pre-flight live-node guard (teardown only) — refuse BEFORE starting a run.
   if (isTeardown(operation) && !opts.force) {
@@ -544,16 +571,23 @@ export async function runInstallLifecycle({ operation, nodeClass, opts = {} }, d
     let rollbackDisposition = "none";
     if (autoRollbacks(operation) && ctx.bundlePath) {
       log(`catalyst-install: ${operation} failed — rolling back from ${ctx.bundlePath}`);
-      // A restore alone is ADDITIVE — it re-lays captured config/db/plist FILES but cannot un-bootstrap
-      // launchd agents that provisioning just installed (and a worker's stack keep-alive would restart
-      // the daemon). So tear those down FIRST (boot out agents, then stop any survivors), THEN restore
-      // the captured state. Both teardown steps are best-effort; the restore is the authoritative
-      // "node state put back" signal. NB: install-cli symlinks are intentionally left in place — they
-      // are not captured in the backup, so removing them would be an unrecoverable, not a reversal.
-      const unsvc = runStep({ argv: [scripts.stack, "uninstall-services"], env: stepEnv });
-      if (unsvc.code !== 0) log(`catalyst-install: rollback note — uninstall-services rc ${unsvc.code} (agents may remain): ${unsvc.stderr.trim()}`);
-      const stop = runStep({ argv: [scripts.stack, "stop"], env: stepEnv });
-      if (stop.code !== 0) log(`catalyst-install: rollback note — stop rc ${stop.code}`);
+      // A restore alone is ADDITIVE — it re-lays captured config/db/plist FILES but cannot
+      // un-bootstrap launchd agents provisioning just installed (and a worker's stack keep-alive would
+      // restart the daemon). So when this run installed agents onto a FRESH node, tear them down first
+      // (boot out, then stop survivors) before restoring. But if the backup captured PRE-EXISTING
+      // agents (a retry/reinstall on a working node), DON'T tear them down: restore re-lays their plist
+      // files but never re-bootstraps them, so a teardown would leave a previously-working node's
+      // services down. Either way the restore is the authoritative "state put back" signal. (install-cli
+      // symlinks are intentionally left in place — not captured in the backup, so removing them would be
+      // an unrecoverable loss, not a reversal.)
+      if (bundleHasCapturedAgents(ctx.bundlePath)) {
+        log(`catalyst-install: rollback — backup captured pre-existing launchd agents; leaving them in place (restore re-lays their config; reload them if needed)`);
+      } else {
+        const unsvc = runStep({ argv: [scripts.stack, "uninstall-services"], env: stepEnv });
+        if (unsvc.code !== 0) log(`catalyst-install: rollback note — uninstall-services rc ${unsvc.code} (agents may remain): ${unsvc.stderr.trim()}`);
+        const stop = runStep({ argv: [scripts.stack, "stop"], env: stepEnv });
+        if (stop.code !== 0) log(`catalyst-install: rollback note — stop rc ${stop.code}`);
+      }
       const restore = runStep({ argv: [scripts.backup, "restore", ctx.bundlePath, "--force"], env: stepEnv });
       rolledBack = restore.code === 0;
       rollbackDisposition = rolledBack ? "ok" : "failed";
@@ -572,8 +606,19 @@ export async function runInstallLifecycle({ operation, nodeClass, opts = {} }, d
 
 // ── CLI ─────────────────────────────────────────────────────────────────────
 export function parseArgs(argv) {
-  const a = { operation: null, class: null, readReplica: null, force: false, dryRun: false, json: false, help: false };
+  const a = { operation: null, class: null, readReplica: null, force: false, dryRun: false, json: false, help: false, errors: [] };
   const rest = [...argv];
+  // takeValue — consume the next token as FLAG's value; a missing value (end of args, or the next
+  // token is itself a flag) is an error, not a silent null — otherwise `catalyst install --class`
+  // would fall back to the current/default class and a typo could provision the wrong node.
+  const takeValue = (i, flag) => {
+    const next = rest[i + 1];
+    if (next === undefined || next.startsWith("-")) {
+      a.errors.push(`${flag} requires a value`);
+      return [null, i];
+    }
+    return [next, i + 1];
+  };
   // First non-flag token is the operation (the router passes it as argv[0]).
   for (let i = 0; i < rest.length; i++) {
     const v = rest[i];
@@ -593,16 +638,24 @@ export function parseArgs(argv) {
         a.json = true;
         break;
       case "--class":
-        a.class = rest[++i] ?? null;
+        [a.class, i] = takeValue(i, "--class");
         break;
       case "--read-replica":
-        a.readReplica = rest[++i] ?? null;
+        [a.readReplica, i] = takeValue(i, "--read-replica");
         break;
       default:
-        if (v.startsWith("--class=")) a.class = v.slice("--class=".length);
-        else if (v.startsWith("--read-replica=")) a.readReplica = v.slice("--read-replica=".length);
-        else if (!v.startsWith("-") && a.operation == null) a.operation = v;
-        // unknown flags are ignored (forward-compat); an unknown operation is caught by validation
+        if (v.startsWith("--class=")) {
+          const val = v.slice("--class=".length);
+          if (val === "") a.errors.push("--class requires a value");
+          else a.class = val;
+        } else if (v.startsWith("--read-replica=")) {
+          const val = v.slice("--read-replica=".length);
+          if (val === "") a.errors.push("--read-replica requires a value");
+          else a.readReplica = val;
+        } else if (!v.startsWith("-") && a.operation == null) {
+          a.operation = v;
+        }
+        // other unknown flags are ignored (forward-compat); an unknown operation is caught by validation
         break;
     }
   }
@@ -666,6 +719,11 @@ export async function main(argv, depsOverride) {
     out(usage());
     return 0;
   }
+  if (args.errors?.length) {
+    for (const e of args.errors) errOut(`catalyst-install: ${e}`);
+    errOut(usage());
+    return 2;
+  }
   if (!args.operation || !LIFECYCLE_OPERATIONS.includes(args.operation)) {
     errOut(`catalyst-install: expected one of ${LIFECYCLE_OPERATIONS.join(" | ")}${args.operation ? ` (got '${args.operation}')` : ""}`);
     errOut(usage());
@@ -695,34 +753,51 @@ export async function main(argv, depsOverride) {
     return 0;
   }
 
+  // Install the OTLP tracer BEFORE the run so InstallRun.complete()/fail() → emitInstallTrace()
+  // actually export the catalyst.install root/phase spans (the tracer is a no-op until initTracing
+  // runs). Off-first: only when CATALYST_TRACING=on, matching updater.mjs. Flushed below.
+  const tracingOn = env.CATALYST_TRACING === "on";
+  if (tracingOn) await initTracing({ serviceName: INSTALL_SERVICE_NAME });
+
   const result = await runInstallLifecycle({ operation: args.operation, nodeClass, opts }, deps);
 
+  // With --json the result JSON is the ONLY thing on stdout — the human success line is suppressed
+  // so automation can parse stdout as a single document. (Error/warning lines go to stderr.)
   if (args.json) out(JSON.stringify(result));
+
+  let code;
   switch (result.outcome) {
     case "completed":
       if (!result.healthOk) {
         errOut(`catalyst-install: ${args.operation} completed but verify-node reported the node UNHEALTHY (rc ${result.healthRc ?? "?"}).`);
-        return 1;
-      }
-      // A teardown that left catalyst agents/daemons present is a FAILED teardown — surface it as a
-      // non-zero exit (symmetric with the healthOk treatment above), not a silent "completed".
-      if (isTeardown(args.operation) && result.cleanOk === false) {
+        code = 1;
+      } else if (isTeardown(args.operation) && result.cleanOk === false) {
+        // A teardown that left catalyst agents/daemons present is a FAILED teardown — surface it as a
+        // non-zero exit (symmetric with the healthOk treatment above), not a silent "completed".
         errOut(`catalyst-install: ${args.operation} completed but verify-clean found catalyst agents/daemons STILL PRESENT — node not fully torn down (run 'catalyst-stack stop' / 'catalyst-stack uninstall-services').`);
-        return 1;
+        code = 1;
+      } else {
+        if (!args.json) out(`catalyst-install: ${args.operation} (${nodeClass}) completed.`);
+        code = 0;
       }
-      out(`catalyst-install: ${args.operation} (${nodeClass}) completed.`);
-      return 0;
+      break;
     case "rolled_back":
       errOut(`catalyst-install: ${args.operation} failed and was rolled back: ${result.error}`);
-      return 1;
+      code = 1;
+      break;
     case "failed":
       errOut(`catalyst-install: ${args.operation} failed: ${result.error}`);
-      return 1;
+      code = 1;
+      break;
     case "refused":
-      return 2;
+      code = 2;
+      break;
     default:
-      return 1;
+      code = 1;
   }
+
+  if (tracingOn) await shutdownTracing(); // flush spans before the process exits
+  return code;
 }
 
 // Direct-exec guard: run main() only when invoked as a script (not when imported by tests).

--- a/plugins/dev/scripts/execution-core/install-lifecycle.mjs
+++ b/plugins/dev/scripts/execution-core/install-lifecycle.mjs
@@ -280,8 +280,19 @@ function writeLayer2Atomic(path, obj) {
   renameSync(tmp, path);
 }
 
-function setDeepKey(obj, dottedKey, value) {
+// Reject the JS prototype-chain keys so a dotted path can never walk into Object.prototype
+// (prototype-pollution guard — the install-managed keys are all hardcoded constants today, but this
+// keeps setDeepKey/deleteDeepKey safe by construction for any future caller).
+const UNSAFE_KEY_SEGMENTS = new Set(["__proto__", "prototype", "constructor"]);
+function assertSafeSegments(parts) {
+  for (const p of parts) {
+    if (UNSAFE_KEY_SEGMENTS.has(p)) throw new Error(`unsafe config key segment: '${p}'`);
+  }
+}
+
+export function setDeepKey(obj, dottedKey, value) {
   const parts = dottedKey.split(".");
+  assertSafeSegments(parts);
   let cur = obj;
   for (let i = 0; i < parts.length - 1; i++) {
     if (typeof cur[parts[i]] !== "object" || cur[parts[i]] == null) cur[parts[i]] = {};
@@ -290,8 +301,9 @@ function setDeepKey(obj, dottedKey, value) {
   cur[parts[parts.length - 1]] = value;
 }
 
-function deleteDeepKey(obj, dottedKey) {
+export function deleteDeepKey(obj, dottedKey) {
   const parts = dottedKey.split(".");
+  assertSafeSegments(parts);
   let cur = obj;
   for (let i = 0; i < parts.length - 1; i++) {
     if (typeof cur[parts[i]] !== "object" || cur[parts[i]] == null) return false; // path absent → nothing to delete

--- a/plugins/dev/scripts/execution-core/install-lifecycle.mjs
+++ b/plugins/dev/scripts/execution-core/install-lifecycle.mjs
@@ -273,8 +273,11 @@ export function planPhases({ operation, nodeClass, scripts, opts = {} }) {
     phase: "remove-agents",
     steps: [
       // uninstall-services removes ALL launchd agents including the updater + reconciles the
-      // pull-owner back to broker (CTL-1348).
+      // pull-owner back to broker (CTL-1348). It removes the log-shipper plist but deliberately
+      // leaves Alloy RUNNING; a `stop` now (plist gone) reaps the now-unmanaged Alloy so verify-clean
+      // passes. Best-effort.
       { label: "uninstall-services", kind: "run", argv: [scripts.stack, "uninstall-services"] },
+      { label: "reap-shipper", kind: "run", argv: [scripts.stack, "stop"], optional: true },
       { label: "uninstall-cli", kind: "run", argv: [scripts.installCli, "--uninstall"] },
     ],
   });
@@ -425,7 +428,12 @@ function defaultProbeResidualAgents(env = process.env) {
 // CTL-1348 two-puller race). Honors CATALYST_LAUNCHAGENTS_DIR.
 function defaultProbeUpdaterAgent(env = process.env) {
   const laDir = env.CATALYST_LAUNCHAGENTS_DIR || join(homedir(), "Library", "LaunchAgents");
-  return existsSync(join(laDir, "ai.coalesce.catalyst-updater.plist"));
+  if (existsSync(join(laDir, "ai.coalesce.catalyst-updater.plist"))) return true;
+  // Plist-gone-but-process-alive: a manual/partial cleanup can leave the updater daemon running
+  // without its plist — still the two-puller hazard, so check process liveness too.
+  if (env.CATALYST_ASSUME_NO_DAEMONS === "1") return false;
+  const r = spawnSync("pgrep", ["-f", "execution-core/updater/updater\\.mjs"], { encoding: "utf8" });
+  return !r.error && r.status === 0;
 }
 
 // bundleHasCapturedAgents — did the backup snapshot any launchd agent plists? If so the node had
@@ -577,6 +585,18 @@ export async function runInstallLifecycle({ operation, nodeClass, opts = {} }, d
     );
     return { outcome: "refused", reason: "stale-updater" };
   }
+  // The symmetric case: a `install --class developer|monitor` over a LIVE worker stack would set the
+  // class + adopt the updater while leaving broker/exec-core running — the exact mixed profile the
+  // per-class invariant forbids (verify-node would only flag it AFTER the changes landed). Refuse and
+  // steer to `reinstall` (whose teardown stops the worker stack), unless --force.
+  if (operation === "install" && !isWorker(nodeClass) && !opts.force && probeDaemons()) {
+    log(
+      `catalyst-install: refusing install --class ${nodeClass} — broker/execution-core are running ` +
+        `(this looks like a worker). Switch profiles with 'catalyst reinstall --class ${nodeClass}' ` +
+        `(its teardown stops the worker stack), or pass --force.`,
+    );
+    return { outcome: "refused", reason: "live-worker-stack" };
+  }
 
   const traceId = genTraceId();
   const spanId = genSpanId();
@@ -682,43 +702,62 @@ export async function runInstallLifecycle({ operation, nodeClass, opts = {} }, d
     let rollbackDisposition = "none";
     if (autoRollbacks(operation) && ctx.bundlePath) {
       log(`catalyst-install: ${operation} failed — rolling back from ${ctx.bundlePath}`);
-      // `catalyst-backup restore` is ADDITIVE — it re-lays captured config/db/plist FILES but never
-      // DELETES plists created after the snapshot, nor re-bootstraps/restarts agents. So rollback has
-      // three cases, keyed first on whether the node's ORIGINAL state (the backup) had launchd agents.
-      const teardownRan = ctx.teardownRan; // a reinstall already booted out the node's agents this run
+      // `catalyst-backup restore` is ADDITIVE: it re-lays captured config/db/plist FILES but never
+      // DELETES files created after the snapshot, nor re-bootstraps/restarts agents, and it can corrupt
+      // config/db if forced over LIVE broker/exec-core. Four cases, keyed on whether the node's ORIGINAL
+      // state (the backup) had launchd agents and whether this run already tore the node down.
+      const teardownRan = ctx.teardownRan;
       const hadAgents = bundleHasCapturedAgents(ctx.bundlePath);
       const restoreNode = () => runStep({ argv: [scripts.backup, "restore", ctx.bundlePath, "--force"], env: stepEnv });
-      if (!hadAgents) {
-        // ORIGINAL node had NO agents (a fresh install, or a config-only reinstall). Anything present
-        // now was installed THIS run — even if provisioning reached install-agents before failing at
-        // start-daemons — and restore won't delete it (and a worker's stack keep-alive would restart
-        // it). Boot it out, then restore. No re-bootstrap: the snapshot had no agents to bring back.
+      const bootOutAgents = () => {
         const unsvc = runStep({ argv: [scripts.stack, "uninstall-services"], env: stepEnv });
         if (unsvc.code !== 0) log(`catalyst-install: rollback note — uninstall-services rc ${unsvc.code} (agents may remain): ${unsvc.stderr.trim()}`);
         const stop = runStep({ argv: [scripts.stack, "stop"], env: stepEnv });
         if (stop.code !== 0) log(`catalyst-install: rollback note — stop rc ${stop.code}`);
-        const restore = restoreNode();
-        // A reinstall's remove-agents ran `install-cli --uninstall` (the symlinks are NOT in the
-        // backup), so even on a config-only node a teardown leaves the box without `catalyst` on PATH.
-        // Reinstall the CLI symlinks (idempotent) so rollback truly restores the node.
-        if (ctx.teardownRan && restore.code === 0) {
-          const cli = runStep({ argv: [scripts.installCli], env: stepEnv });
-          if (cli.code !== 0) log(`catalyst-install: rollback note — re-installing CLI symlinks rc ${cli.code}: ${cli.stderr.trim()}`);
+      };
+      const stripManagedKeys = () => {
+        try {
+          const cfg = readLayer2(layer2);
+          let changed = false;
+          for (const k of INSTALL_MANAGED_KEYS) if (deleteDeepKey(cfg, k)) changed = true;
+          if (changed) writeLayer2Atomic(layer2, cfg);
+        } catch (e) {
+          log(`catalyst-install: rollback note — could not strip install-managed keys: ${e.message}`);
+        }
+      };
+      let restore;
+      if (!hadAgents && !teardownRan) {
+        // (1) FRESH install: the node had NOTHING. Everything present now was created THIS run and
+        // restore (empty/no-config bundle) can't undo it — so boot out the agents, restore, then remove
+        // the install-managed config keys + uninstall the catalyst-* symlinks so the node is genuinely
+        // clean. (Per-project secret files are left — re-usable on retry, not an operational footprint.)
+        bootOutAgents();
+        restore = restoreNode();
+        if (restore.code === 0) {
+          const cli = runStep({ argv: [scripts.installCli, "--uninstall"], env: stepEnv });
+          if (cli.code !== 0) log(`catalyst-install: rollback note — uninstall CLI symlinks rc ${cli.code}: ${cli.stderr.trim()}`);
+          stripManagedKeys();
         }
         rolledBack = restore.code === 0;
-        rollbackDisposition = rolledBack ? "ok" : "failed";
-        log(
-          rolledBack
-            ? `catalyst-install: rolled back — restored ${ctx.bundlePath} + tore down agents installed this run (verify launchd/daemon state)`
-            : `catalyst-install: rollback INCOMPLETE (restore rc ${restore.code}) — node is in a PARTIAL state; bundle at ${ctx.bundlePath}`,
-        );
+        log(rolledBack ? `catalyst-install: rolled back — removed everything this fresh install created (verify launchd/daemon state)` : `catalyst-install: rollback INCOMPLETE (restore rc ${restore.code}); bundle at ${ctx.bundlePath}`);
+      } else if (!hadAgents && teardownRan) {
+        // (2) CONFIG-ONLY reinstall: the node had config (restored below) but no agents. Boot out any
+        // agents provisioning installed this run, restore the config, then RE-INSTALL the catalyst-*
+        // symlinks the teardown's `install-cli --uninstall` removed (they aren't in the backup).
+        bootOutAgents();
+        restore = restoreNode();
+        if (restore.code === 0) {
+          const cli = runStep({ argv: [scripts.installCli], env: stepEnv });
+          if (cli.code !== 0) log(`catalyst-install: rollback note — re-install CLI symlinks rc ${cli.code}: ${cli.stderr.trim()}`);
+        }
+        rolledBack = restore.code === 0;
+        log(rolledBack ? `catalyst-install: rolled back — restored config + re-installed CLI symlinks (verify launchd/daemon state)` : `catalyst-install: rollback INCOMPLETE (restore rc ${restore.code}); bundle at ${ctx.bundlePath}`);
       } else if (teardownRan) {
-        // reinstall failed AFTER remove-agents booted out the node's PRE-EXISTING agents. Restore the
-        // captured state, then RE-BOOTSTRAP — restore alone can't re-load launchd. Re-bootstrap to the
-        // RESTORED class (absent ⇒ worker default), NOT the requested reinstall target — else a failed
-        // `reinstall --class developer` of an original default-worker node would come back as developer
-        // (adopt-updater/drain) and lose the worker's broker/exec-core stack.
-        const restore = restoreNode();
+        // (3) reinstall failed AFTER remove-agents booted out the node's PRE-EXISTING agents. Restore,
+        // then RE-BOOTSTRAP to the RESTORED class (absent ⇒ worker default), NOT the requested target —
+        // else a failed `reinstall --class developer` of an original default-worker node would come back
+        // as developer and lose the worker's broker/exec-core stack.
+        restore = restoreNode();
         let bringupOk = true;
         if (restore.code === 0) {
           const rawClass = readNodeClassRaw(layer2);
@@ -739,27 +778,26 @@ export async function runInstallLifecycle({ operation, nodeClass, opts = {} }, d
           }
         }
         rolledBack = restore.code === 0 && bringupOk;
-        rollbackDisposition = rolledBack ? "ok" : "failed";
-        log(
-          rolledBack
-            ? `catalyst-install: rolled back — restored ${ctx.bundlePath} + re-bootstrapped the torn-down agents (verify launchd/daemon state)`
-            : `catalyst-install: rollback INCOMPLETE — config restored from ${ctx.bundlePath} but launchd agents are NOT fully re-bootstrapped; re-run 'catalyst install' or 'catalyst-stack install-services && catalyst-stack start' to bring the node back`,
-        );
+        log(rolledBack ? `catalyst-install: rolled back — restored + re-bootstrapped the torn-down agents (verify launchd/daemon state)` : `catalyst-install: rollback INCOMPLETE — config restored from ${ctx.bundlePath} but agents are NOT fully re-bootstrapped; run 'catalyst install' or 'catalyst-stack install-services && catalyst-stack start'`);
       } else {
-        // install on an EXISTING node: its pre-existing agents were NOT touched this run — leave them
-        // running untouched (tearing them down would down a working node with no re-bootstrap) and just
-        // restore. (install-cli symlinks are left in place — not in the backup, so removing them would
-        // be an unrecoverable loss, not a reversal.)
-        log(`catalyst-install: rollback — backup captured pre-existing launchd agents; leaving them in place (restore re-lays their config; reload them if needed)`);
-        const restore = restoreNode();
+        // (4) install retry on an EXISTING node whose pre-existing agents were NOT touched this run.
+        // Leave the agents installed, but if the worker stack is LIVE, STOP it around the restore —
+        // catalyst-backup --force over running broker/exec-core can corrupt config/db — then restart it.
+        const live = probeDaemons();
+        if (live) {
+          const stop = runStep({ argv: [scripts.stack, "stop"], env: stepEnv });
+          if (stop.code !== 0) log(`catalyst-install: rollback note — stop-before-restore rc ${stop.code}`);
+          restore = restoreNode();
+          const start = runStep({ argv: [scripts.stack, "start", "--yes"], env: stepEnv });
+          if (start.code !== 0) log(`catalyst-install: rollback note — restart-after-restore rc ${start.code} (run 'catalyst-stack start')`);
+        } else {
+          log(`catalyst-install: rollback — pre-existing agents present but no live worker stack; restoring in place`);
+          restore = restoreNode();
+        }
         rolledBack = restore.code === 0;
-        rollbackDisposition = rolledBack ? "ok" : "failed";
-        log(
-          rolledBack
-            ? `catalyst-install: rolled back — restored ${ctx.bundlePath} (verify launchd/daemon state)`
-            : `catalyst-install: rollback INCOMPLETE (restore rc ${restore.code}) — node is in a PARTIAL state; bundle at ${ctx.bundlePath}`,
-        );
+        log(rolledBack ? `catalyst-install: rolled back — restored ${ctx.bundlePath} (verify launchd/daemon state)` : `catalyst-install: rollback INCOMPLETE (restore rc ${restore.code}); bundle at ${ctx.bundlePath}`);
       }
+      rollbackDisposition = rolledBack ? "ok" : "failed";
     } else if (ctx.bundlePath) {
       log(`catalyst-install: ${operation} failed — NOT auto-rolled-back; restore manually from ${ctx.bundlePath} if needed`);
     }

--- a/plugins/dev/scripts/execution-core/install-lifecycle.mjs
+++ b/plugins/dev/scripts/execution-core/install-lifecycle.mjs
@@ -36,7 +36,7 @@ import { homedir } from "node:os";
 
 import { InstallRun, makeInstallEmitFn, INSTALL_SERVICE_NAME } from "./lib/install-telemetry.mjs";
 import { initTracing, shutdownTracing } from "./tracing.mjs";
-import { NODE_CLASSES, getNodeClass } from "./config.mjs";
+import { NODE_CLASSES } from "./config.mjs";
 
 // ── phase enums ───────────────────────────────────────────────────────────────
 // install: the PR1 locked set (acquire → backup → write-config → install-agents →
@@ -111,13 +111,27 @@ export function layer2Path(env = process.env) {
   );
 }
 
+/** readNodeClassRaw — the raw catalyst.node.class string stored in a Layer-2 file (or null). */
+export function readNodeClassRaw(layer2) {
+  try {
+    const v = readLayer2(layer2)?.catalyst?.node?.class;
+    return typeof v === "string" ? v : null;
+  } catch {
+    return null;
+  }
+}
+
 /**
  * resolveRequestedClass — the class this lifecycle run targets. Precedence:
- *   explicit --class > CATALYST_NODE_CLASS env > current Layer-2 class (getNodeClass).
- * An explicit but UNRECOGNIZED --class is a hard error (the §3 footgun fix — never silently
- * fall back to worker on a typo'd developer node). Returns { nodeClass, source }.
+ *   explicit --class > CATALYST_NODE_CLASS env > the class IN THE SELECTED Layer-2 file.
+ * The config fallback reads the SAME file the driver resolved (`layer2`) — NOT getNodeClass(),
+ * which only honors CATALYST_LAYER2_CONFIG_FILE/~/.config and would mis-resolve a developer config
+ * supplied via CATALYST_MACHINE_CONFIG/XDG as worker. An explicit-but-UNRECOGNIZED class (from
+ * --class, env, OR the config) is a hard error (the §3 footgun — never silently fall back to worker
+ * on a typo'd developer node); an ABSENT config class ⇒ worker (the zero-config default).
+ * Returns { nodeClass, source }. (A test may inject `currentFn` to stub the config read.)
  */
-export function resolveRequestedClass({ optsClass, env = process.env, currentFn = getNodeClass } = {}) {
+export function resolveRequestedClass({ optsClass, env = process.env, layer2, currentFn } = {}) {
   if (optsClass != null && optsClass !== "") {
     const normalized = String(optsClass).trim().toLowerCase();
     if (!NODE_CLASSES.includes(normalized)) {
@@ -132,7 +146,14 @@ export function resolveRequestedClass({ optsClass, env = process.env, currentFn 
     }
     return { nodeClass: normalized, source: "env" };
   }
-  return { nodeClass: currentFn(), source: "config" };
+  if (typeof currentFn === "function") return { nodeClass: currentFn(), source: "config" };
+  const raw = readNodeClassRaw(layer2);
+  if (raw == null || raw.trim() === "") return { nodeClass: "worker", source: "config-default" };
+  const normalized = raw.trim().toLowerCase();
+  if (!NODE_CLASSES.includes(normalized)) {
+    throw new Error(`unrecognized node class in ${layer2}: '${raw}' (valid: ${NODE_CLASSES.join(", ")}) — pass --class to override`);
+  }
+  return { nodeClass: normalized, source: "config" };
 }
 
 /**
@@ -191,10 +212,16 @@ export function planPhases({ operation, nodeClass, scripts, opts = {} }) {
       { label: "set-class", kind: "run", argv: [scripts.catalyst, "class", nodeClass] },
       { label: "setup-catalyst", kind: "run", argv: [scripts.setup, "--non-interactive"] },
     ];
-    // A developer/monitor node reads a worker's monitor over HTTP — bind it when given. (Worker
-    // reads its own local replica, so the key is meaningless there.) Optional: a missing endpoint
-    // is surfaced by the developer verify-node rubric, not a hard install failure.
-    if (!worker && opts.readReplica) {
+    if (worker) {
+      // The worker path never runs adopt-updater (the broker is the puller), and install-services
+      // doesn't touch pluginPullOwner — so a node promoted from developer would keep
+      // pluginPullOwner=updater and the broker would defer pulls to a now-absent updater. Reset it to
+      // broker so the worker's broker owns plugin freshness.
+      steps.push({ label: "pull-owner", kind: "setkey", key: "catalyst.orchestration.pluginPullOwner", value: "broker" });
+    } else if (opts.readReplica) {
+      // A developer/monitor node reads a worker's monitor over HTTP — bind it when given. (Worker
+      // reads its own local replica, so the key is meaningless there.) A missing endpoint is
+      // surfaced by the developer verify-node rubric, not a hard install failure.
       steps.push({ label: "read-replica", kind: "setkey", key: "catalyst.readReplica.baseUrl", value: opts.readReplica });
     }
     return { phase: "write-config", steps };
@@ -278,7 +305,7 @@ export function planPhases({ operation, nodeClass, scripts, opts = {} }) {
 
 // ── Layer-2 surgical edits (mjs-internal, jq-free, atomic) ──────────────────────
 function readLayer2(path) {
-  if (!existsSync(path)) return {};
+  if (!path || !existsSync(path)) return {};
   const raw = readFileSync(path, "utf8");
   if (!raw.trim()) return {};
   return JSON.parse(raw); // a malformed config is a real error — let it throw (fail closed)
@@ -575,6 +602,16 @@ export async function runInstallLifecycle({ operation, nodeClass, opts = {} }, d
         }
       });
     }
+    if (!ctx.cleanOk) {
+      // A teardown that left catalyst agents/daemons present is a FAILED teardown: emit `failed`
+      // telemetry (NOT `completed`) so dashboards/alerts keyed on the low-card terminal outcome don't
+      // count a dirty uninstall as a success. (verify-clean is non-fatal for ROLLBACK — it never
+      // triggers a restore — but the run's OUTCOME is a failure.) cleanOk is only ever false for
+      // uninstall (the only op with a verify-clean phase).
+      const e = new Error("verify-clean: catalyst agents/daemons still present after teardown — node not fully torn down");
+      run.fail(e, { rolledBack: false, detail: { reason: "dirty-teardown", cleanOk: false } });
+      return { outcome: "failed", error: e.message, healthOk: ctx.healthOk, healthRc: ctx.healthRc, cleanOk: false, bundlePath: ctx.bundlePath, traceId };
+    }
     run.complete({ class: nodeClass, healthOk: ctx.healthOk, cleanOk: ctx.cleanOk, bundle: ctx.bundlePath });
     return { outcome: "completed", healthOk: ctx.healthOk, healthRc: ctx.healthRc, cleanOk: ctx.cleanOk, bundlePath: ctx.bundlePath, traceId };
   } catch (err) {
@@ -590,19 +627,24 @@ export async function runInstallLifecycle({ operation, nodeClass, opts = {} }, d
       const teardownRan = ctx.teardownRan; // a reinstall already booted out the node's agents this run
       const hadAgents = bundleHasCapturedAgents(ctx.bundlePath);
       if (teardownRan) {
-        // (3) reinstall failed AFTER remove-agents: the agents are already DOWN; restore alone can't
-        // bring them back. Restore the captured state, then RE-BOOTSTRAP the node to its restored class.
+        // (3) reinstall failed AFTER remove-agents. Restore the captured state. Then, ONLY if the
+        // node actually HAD agents (the backup captured plists), RE-BOOTSTRAP them — the teardown
+        // booted them out and restore alone can't bring them back. If the node had NO agents
+        // (config-only node), restore is the full rollback; re-bootstrapping would install agents the
+        // snapshot never had.
         const restore = runStep({ argv: [scripts.backup, "restore", ctx.bundlePath, "--force"], env: stepEnv });
-        let bringupOk = false;
-        if (restore.code === 0) {
-          // The restored config carries the node's original class; re-run install-agents + start-daemons
-          // for it so the node comes back up (idempotent; catalyst-stack re-renders + bootstraps).
-          const restoredClass = readLayer2(layer2)?.catalyst?.node?.class || nodeClass;
+        let bringupOk = true;
+        if (restore.code === 0 && hadAgents) {
+          // Re-bootstrap to the RESTORED class: read it from the restored config, defaulting an
+          // ABSENT class to worker (the unset/default), NOT the requested reinstall target — else a
+          // failed `reinstall --class developer` of an original default-worker node would re-bring-up
+          // as developer (adopt-updater/drain) and lose the worker's broker/exec-core stack.
+          const rawClass = readNodeClassRaw(layer2);
+          const restoredClass = rawClass && NODE_CLASSES.includes(rawClass.trim().toLowerCase()) ? rawClass.trim().toLowerCase() : "worker";
           const bringupEnv = { ...stepEnv, CATALYST_NODE_CLASS: restoredClass };
           const bringup = planPhases({ operation: "install", nodeClass: restoredClass, scripts, opts: {} }).filter(
             (p) => p.phase === "install-agents" || p.phase === "start-daemons",
           );
-          bringupOk = true;
           for (const ph of bringup) {
             for (const s of ph.steps) {
               if (s.kind !== "run") continue;
@@ -618,7 +660,7 @@ export async function runInstallLifecycle({ operation, nodeClass, opts = {} }, d
         rollbackDisposition = rolledBack ? "ok" : "failed";
         log(
           rolledBack
-            ? `catalyst-install: rolled back — restored ${ctx.bundlePath} + re-bootstrapped the torn-down agents (verify launchd/daemon state)`
+            ? `catalyst-install: rolled back — restored ${ctx.bundlePath}${hadAgents ? " + re-bootstrapped the torn-down agents" : ""} (verify launchd/daemon state)`
             : `catalyst-install: rollback INCOMPLETE — config restored from ${ctx.bundlePath} but launchd agents are NOT fully re-bootstrapped; re-run 'catalyst install' or 'catalyst-stack install-services && catalyst-stack start' to bring the node back`,
         );
       } else {
@@ -783,7 +825,7 @@ export async function main(argv, depsOverride) {
 
   let nodeClass;
   try {
-    ({ nodeClass } = resolveRequestedClass({ optsClass: args.class, env }));
+    ({ nodeClass } = resolveRequestedClass({ optsClass: args.class, env, layer2: deps.layer2 }));
   } catch (e) {
     errOut(`catalyst-install: ${e.message}`);
     return 2;
@@ -823,13 +865,11 @@ export async function main(argv, depsOverride) {
   let code;
   switch (result.outcome) {
     case "completed":
+      // A dirty teardown (verify-clean found residual agents) is returned as outcome "failed" by
+      // runInstallLifecycle, so a "completed" install/uninstall here is genuinely clean. An unhealthy
+      // verify-node is still "completed" (the node IS installed) but exits 1.
       if (!result.healthOk) {
         errOut(`catalyst-install: ${args.operation} completed but verify-node reported the node UNHEALTHY (rc ${result.healthRc ?? "?"}).`);
-        code = 1;
-      } else if (isTeardown(args.operation) && result.cleanOk === false) {
-        // A teardown that left catalyst agents/daemons present is a FAILED teardown — surface it as a
-        // non-zero exit (symmetric with the healthOk treatment above), not a silent "completed".
-        errOut(`catalyst-install: ${args.operation} completed but verify-clean found catalyst agents/daemons STILL PRESENT — node not fully torn down (run 'catalyst-stack stop' / 'catalyst-stack uninstall-services').`);
         code = 1;
       } else {
         if (!args.json) out(`catalyst-install: ${args.operation} (${nodeClass}) completed.`);

--- a/plugins/dev/scripts/execution-core/install-lifecycle.mjs
+++ b/plugins/dev/scripts/execution-core/install-lifecycle.mjs
@@ -411,12 +411,21 @@ function defaultProbeResidualAgents(env = process.env) {
   }
   if (env.CATALYST_ASSUME_NO_DAEMONS === "1") return false;
   // Covers every stack daemon, not just broker/exec-core: the monitor (orch-monitor/server.ts) and
-  // otel-forward (otel-forward/index.ts) are nohup children of the stack — if `catalyst-stack stop`
-  // failed to kill them after the plists were removed, an uninstall would otherwise look clean.
-  const pattern = "broker/index.mjs|execution-core/(daemon|index|updater/updater)\\.mjs|orch-monitor/server\\.ts|otel-forward/index\\.ts";
+  // otel-forward (otel-forward/index.ts) are nohup children of the stack, and Alloy (the log-shipper)
+  // is deliberately LEFT running by `catalyst-stack stop`/`uninstall-services` — so if a teardown
+  // didn't reap them, an uninstall must not look clean.
+  const pattern = "broker/index.mjs|execution-core/(daemon|index|updater/updater)\\.mjs|orch-monitor/server\\.ts|otel-forward/index\\.ts|alloy run ";
   const res = spawnSync("pgrep", ["-f", pattern], { encoding: "utf8" });
   if (res.error) return false; // can't probe processes; the plist check above already ran
   return res.status === 0;
+}
+
+// probeUpdaterAgent — is the developer/monitor catalyst-updater LaunchAgent installed? Used to refuse
+// a `install --class worker` that would otherwise leave the updater running alongside the broker (the
+// CTL-1348 two-puller race). Honors CATALYST_LAUNCHAGENTS_DIR.
+function defaultProbeUpdaterAgent(env = process.env) {
+  const laDir = env.CATALYST_LAUNCHAGENTS_DIR || join(homedir(), "Library", "LaunchAgents");
+  return existsSync(join(laDir, "ai.coalesce.catalyst-updater.plist"));
 }
 
 // bundleHasCapturedAgents — did the backup snapshot any launchd agent plists? If so the node had
@@ -474,6 +483,11 @@ export function buildDefaultDeps(env) {
     probeDrained: () => defaultProbeDrained({ scripts, env }),
     bundleHasCapturedAgents: (p) => defaultBundleHasCapturedAgents(p),
     scriptExists: (p) => existsSync(p),
+    binExists: (name) => {
+      const r = spawnSync("sh", ["-c", `command -v "${name}" >/dev/null 2>&1`]);
+      return !r.error && r.status === 0;
+    },
+    probeUpdaterAgent: () => defaultProbeUpdaterAgent(env),
     log: (msg) => process.stderr.write(`${msg}\n`),
     InstallRunCtor: InstallRun,
   };
@@ -501,16 +515,20 @@ function isTeardown(operation) {
  *   InstallRunCtor.
  */
 export async function runInstallLifecycle({ operation, nodeClass, opts = {} }, deps) {
-  const { scripts, env, layer2, runStep, emit, nowFn, genTraceId, genSpanId, probeDaemons, probeResidualAgents, probeDrained, bundleHasCapturedAgents, scriptExists, log, InstallRunCtor } = deps;
+  const { scripts, env, layer2, runStep, emit, nowFn, genTraceId, genSpanId, probeDaemons, probeResidualAgents, probeDrained, bundleHasCapturedAgents, scriptExists, binExists, probeUpdaterAgent, log, InstallRunCtor } = deps;
 
   // Every composed step inherits (a) the RESOLVED class so the bash tools (which re-derive class
   // env-first) cannot diverge from the lifecycle's target — e.g. `install --class developer` on a
   // shell exporting CATALYST_NODE_CLASS=worker must still adopt-updater (mirrors doctor.mjs pinning
-  // CATALYST_NODE_CLASS for verify-node); and (b) the driver's exact Layer-2 file under BOTH config
-  // env names the child tools honor, so the whole run reads/writes ONE config (else an XDG/
+  // CATALYST_NODE_CLASS for verify-node); (b) the driver's exact Layer-2 file under BOTH config env
+  // names the child tools honor, so the whole run reads/writes ONE config (else an XDG/
   // CATALYST_MACHINE_CONFIG redirect would split node.class/readReplica and pluginDirs/pluginPullOwner
-  // across two files and break rollback's single restorable state).
-  const stepEnv = { ...env, CATALYST_NODE_CLASS: nodeClass, CATALYST_LAYER2_CONFIG_FILE: layer2, CATALYST_MACHINE_CONFIG: layer2 };
+  // across two files and break rollback's single restorable state); and (c) the standard install-bin
+  // dirs on PATH so a later step (e.g. adopt-updater's `command -v bun` preflight) finds a tool that
+  // setup-catalyst just installed into ~/.bun/bin / ~/.local/bin within its own child process.
+  const home = (env.HOME || homedir());
+  const seededPath = [`${home}/.bun/bin`, `${home}/.local/bin`, env.PATH].filter(Boolean).join(":");
+  const stepEnv = { ...env, CATALYST_NODE_CLASS: nodeClass, CATALYST_LAYER2_CONFIG_FILE: layer2, CATALYST_MACHINE_CONFIG: layer2, PATH: seededPath };
 
   // Pre-flight live-node guard (teardown only) — refuse BEFORE starting a run.
   if (isTeardown(operation) && !opts.force) {
@@ -536,6 +554,28 @@ export async function runInstallLifecycle({ operation, nodeClass, opts = {} }, d
         `Run from a repo checkout (not the plugin cache), or set the CATALYST_INSTALL_*_SCRIPT overrides.`,
     );
     return { outcome: "refused", reason: "missing-script", missing: missingScripts };
+  }
+
+  // Pre-flight: the hard CLI prerequisites the early phases need (acquire's setup-plugin-source and
+  // the backup both `require_cmd jq`/git). The installer is a checkout-context op, not a bare-metal
+  // bootstrapper — fail fast with an actionable message rather than dying mid-acquire.
+  const missingBins = ["git", "jq"].filter((b) => !binExists(b));
+  if (missingBins.length) {
+    log(`catalyst-install: refusing ${operation} — required tool(s) not on PATH: ${missingBins.join(", ")}. Install them first (e.g. brew install ${missingBins.join(" ")}).`);
+    return { outcome: "refused", reason: "missing-prereq", missing: missingBins };
+  }
+
+  // Pre-flight: a `install --class worker` on a node that still has the developer/monitor updater
+  // agent would run BOTH the broker AND the updater pulling the plugin checkout (the CTL-1348
+  // two-puller race) — resetting pluginPullOwner alone doesn't STOP the updater daemon. Refuse and
+  // steer to `reinstall` (whose teardown removes the updater), unless --force.
+  if (operation === "install" && isWorker(nodeClass) && !opts.force && probeUpdaterAgent()) {
+    log(
+      `catalyst-install: refusing install --class worker — a developer/monitor updater agent is still ` +
+        `installed (the two-puller hazard). Switch profiles with 'catalyst reinstall --class worker' ` +
+        `(its teardown removes the updater), or pass --force.`,
+    );
+    return { outcome: "refused", reason: "stale-updater" };
   }
 
   const traceId = genTraceId();
@@ -658,6 +698,13 @@ export async function runInstallLifecycle({ operation, nodeClass, opts = {} }, d
         const stop = runStep({ argv: [scripts.stack, "stop"], env: stepEnv });
         if (stop.code !== 0) log(`catalyst-install: rollback note — stop rc ${stop.code}`);
         const restore = restoreNode();
+        // A reinstall's remove-agents ran `install-cli --uninstall` (the symlinks are NOT in the
+        // backup), so even on a config-only node a teardown leaves the box without `catalyst` on PATH.
+        // Reinstall the CLI symlinks (idempotent) so rollback truly restores the node.
+        if (ctx.teardownRan && restore.code === 0) {
+          const cli = runStep({ argv: [scripts.installCli], env: stepEnv });
+          if (cli.code !== 0) log(`catalyst-install: rollback note — re-installing CLI symlinks rc ${cli.code}: ${cli.stderr.trim()}`);
+        }
         rolledBack = restore.code === 0;
         rollbackDisposition = rolledBack ? "ok" : "failed";
         log(

--- a/plugins/dev/scripts/execution-core/install-lifecycle.mjs
+++ b/plugins/dev/scripts/execution-core/install-lifecycle.mjs
@@ -282,34 +282,38 @@ function writeLayer2Atomic(path, obj) {
 
 // Reject the JS prototype-chain keys so a dotted path can never walk into Object.prototype
 // (prototype-pollution guard — the install-managed keys are all hardcoded constants today, but this
-// keeps setDeepKey/deleteDeepKey safe by construction for any future caller).
-const UNSAFE_KEY_SEGMENTS = new Set(["__proto__", "prototype", "constructor"]);
-function assertSafeSegments(parts) {
-  for (const p of parts) {
-    if (UNSAFE_KEY_SEGMENTS.has(p)) throw new Error(`unsafe config key segment: '${p}'`);
-  }
+// keeps setDeepKey/deleteDeepKey safe by construction for any future caller). The check is INLINED
+// at each computed-member access (not factored into a helper) so static analysis recognises it as a
+// sanitiser of the very key used in the bracket write.
+function isUnsafeKey(k) {
+  return k === "__proto__" || k === "prototype" || k === "constructor";
 }
 
 export function setDeepKey(obj, dottedKey, value) {
   const parts = dottedKey.split(".");
-  assertSafeSegments(parts);
   let cur = obj;
   for (let i = 0; i < parts.length - 1; i++) {
-    if (typeof cur[parts[i]] !== "object" || cur[parts[i]] == null) cur[parts[i]] = {};
-    cur = cur[parts[i]];
+    const k = parts[i];
+    if (isUnsafeKey(k)) throw new Error(`unsafe config key segment: '${k}'`);
+    if (typeof cur[k] !== "object" || cur[k] == null) cur[k] = {};
+    cur = cur[k];
   }
-  cur[parts[parts.length - 1]] = value;
+  const leaf = parts[parts.length - 1];
+  if (isUnsafeKey(leaf)) throw new Error(`unsafe config key segment: '${leaf}'`);
+  cur[leaf] = value;
 }
 
 export function deleteDeepKey(obj, dottedKey) {
   const parts = dottedKey.split(".");
-  assertSafeSegments(parts);
   let cur = obj;
   for (let i = 0; i < parts.length - 1; i++) {
-    if (typeof cur[parts[i]] !== "object" || cur[parts[i]] == null) return false; // path absent → nothing to delete
-    cur = cur[parts[i]];
+    const k = parts[i];
+    if (isUnsafeKey(k)) throw new Error(`unsafe config key segment: '${k}'`);
+    if (typeof cur[k] !== "object" || cur[k] == null) return false; // path absent → nothing to delete
+    cur = cur[k];
   }
   const leaf = parts[parts.length - 1];
+  if (isUnsafeKey(leaf)) throw new Error(`unsafe config key segment: '${leaf}'`);
   if (Object.prototype.hasOwnProperty.call(cur, leaf)) {
     delete cur[leaf];
     return true;

--- a/plugins/dev/scripts/execution-core/install-lifecycle.mjs
+++ b/plugins/dev/scripts/execution-core/install-lifecycle.mjs
@@ -570,7 +570,11 @@ export async function runInstallLifecycle({ operation, nodeClass, opts = {} }, d
   // dirs on PATH so a later step (e.g. adopt-updater's `command -v bun` preflight) finds a tool that
   // setup-catalyst just installed into ~/.bun/bin / ~/.local/bin within its own child process.
   const home = (env.HOME || homedir());
-  const seededPath = [`${home}/.bun/bin`, `${home}/.local/bin`, env.PATH].filter(Boolean).join(":");
+  // Seed the catalyst CLI bin dir (where install-cli.sh just created the symlinks) + the standard
+  // install-bin dirs, so a later step finds tools this run installed — e.g. `catalyst-stack start`
+  // shells out to catalyst-broker/monitor/execution-core by name, and adopt-updater's `command -v bun`.
+  const cliBinDir = env.CATALYST_BIN_DIR || env.CATALYST_CLI_BIN_DIR || `${home}/.catalyst/bin`;
+  const seededPath = [cliBinDir, `${home}/.bun/bin`, `${home}/.local/bin`, env.PATH].filter(Boolean).join(":");
   const stepEnv = { ...env, CATALYST_NODE_CLASS: nodeClass, CATALYST_LAYER2_CONFIG_FILE: layer2, CATALYST_MACHINE_CONFIG: layer2, PATH: seededPath };
 
   // Pre-flight live-node guard (teardown only) — refuse BEFORE starting a run.
@@ -760,31 +764,15 @@ export async function runInstallLifecycle({ operation, nodeClass, opts = {} }, d
       // state (the backup) had launchd agents and whether this run already tore the node down.
       const teardownRan = ctx.teardownRan;
       const hadAgents = bundleHasCapturedAgents(ctx.bundlePath);
-      const restoreNode = () => {
-        const r = runStep({ argv: [scripts.backup, "restore", ctx.bundlePath, "--force"], env: stepEnv });
-        // On `install`, acquire overwrites pluginDirs BEFORE the backup, so the bundle holds the NEW
-        // value; restore the node's original pre-run pluginDirs if it differed (a custom/older
-        // checkout), so a failed install doesn't permanently repoint it. (reinstall backs up first, so
-        // its bundle already has the original — this is a no-op there.)
-        if (r.code === 0 && preInstall.pluginDirs) {
-          try {
-            const cfg = readLayer2(layer2);
-            if (readDeepKey(cfg, "catalyst.orchestration.pluginDirs") !== preInstall.pluginDirs) {
-              setDeepKey(cfg, "catalyst.orchestration.pluginDirs", preInstall.pluginDirs);
-              writeLayer2Atomic(layer2, cfg);
-              log(`catalyst-install: rollback — restored prior pluginDirs ${preInstall.pluginDirs}`);
-            }
-          } catch (e) {
-            log(`catalyst-install: rollback note — could not restore prior pluginDirs: ${e.message}`);
-          }
-        }
-        return r;
-      };
+      const restoreNode = () => runStep({ argv: [scripts.backup, "restore", ctx.bundlePath, "--force"], env: stepEnv });
+      // bootOutAgents → true iff BOTH uninstall-services and stop succeeded. A failed cleanup must drop
+      // the rollback to incomplete (agents could still be running), so the caller folds this into rolledBack.
       const bootOutAgents = () => {
         const unsvc = runStep({ argv: [scripts.stack, "uninstall-services"], env: stepEnv });
         if (unsvc.code !== 0) log(`catalyst-install: rollback note — uninstall-services rc ${unsvc.code} (agents may remain): ${unsvc.stderr.trim()}`);
         const stop = runStep({ argv: [scripts.stack, "stop"], env: stepEnv });
         if (stop.code !== 0) log(`catalyst-install: rollback note — stop rc ${stop.code}`);
+        return unsvc.code === 0 && stop.code === 0;
       };
       const stripManagedKeys = () => {
         try {
@@ -824,7 +812,7 @@ export async function runInstallLifecycle({ operation, nodeClass, opts = {} }, d
       if (!hadAgents) {
         // The node's ORIGINAL state had NO launchd agents (a fresh install, or a config-only node).
         // Boot out anything provisioning installed this run, then restore.
-        bootOutAgents();
+        const bootOk = bootOutAgents();
         restore = restoreNode();
         if (restore.code === 0) {
           if (teardownRan) {
@@ -844,8 +832,10 @@ export async function runInstallLifecycle({ operation, nodeClass, opts = {} }, d
             if (!preInstall.hadManagedKeys) stripManagedKeys();
           }
         }
-        rolledBack = restore.code === 0;
-        log(rolledBack ? `catalyst-install: rolled back — restored ${ctx.bundlePath} (verify launchd/daemon state)` : `catalyst-install: rollback INCOMPLETE (restore rc ${restore.code}); bundle at ${ctx.bundlePath}`);
+        // A failed boot-out (agents possibly still running) makes the rollback INCOMPLETE even if the
+        // file restore succeeded.
+        rolledBack = restore.code === 0 && bootOk;
+        log(rolledBack ? `catalyst-install: rolled back — restored ${ctx.bundlePath} (verify launchd/daemon state)` : `catalyst-install: rollback INCOMPLETE (restore rc ${restore.code}, cleanup ${bootOk ? "ok" : "FAILED"}); bundle at ${ctx.bundlePath}`);
       } else {
         // The node HAD agents: a reinstall teardown booted out PRE-EXISTING agents, OR an install-retry
         // where a failed provisioning step (adopt-updater/install-services) backed an agent out. If the
@@ -885,6 +875,22 @@ export async function runInstallLifecycle({ operation, nodeClass, opts = {} }, d
       rollbackDisposition = rolledBack ? "ok" : "failed";
     } else if (ctx.bundlePath) {
       log(`catalyst-install: ${operation} failed — NOT auto-rolled-back; restore manually from ${ctx.bundlePath} if needed`);
+    }
+    // Restore the node's prior pluginDirs that acquire overwrote — UNCONDITIONALLY, even when there is
+    // no bundle (the install backup itself failed AFTER acquire repointed it, so the bundle-driven
+    // restore above never ran). The catch-level restore above re-laid the post-acquire value; this puts
+    // the original back. (No-op for reinstall — it backs up before acquire — and for a fresh node.)
+    if (preInstall.pluginDirs) {
+      try {
+        const cfg = readLayer2(layer2);
+        if (readDeepKey(cfg, "catalyst.orchestration.pluginDirs") !== preInstall.pluginDirs) {
+          setDeepKey(cfg, "catalyst.orchestration.pluginDirs", preInstall.pluginDirs);
+          writeLayer2Atomic(layer2, cfg);
+          log(`catalyst-install: rollback — restored prior pluginDirs ${preInstall.pluginDirs}`);
+        }
+      } catch (e) {
+        log(`catalyst-install: rollback note — could not restore prior pluginDirs: ${e.message}`);
+      }
     }
     run.fail(err, { rolledBack, detail: { rollback: rollbackDisposition, bundle: ctx.bundlePath } });
     return { outcome: rolledBack ? "rolled_back" : "failed", error: err.message, rolledBack, rollbackDisposition, bundlePath: ctx.bundlePath, traceId };

--- a/plugins/dev/scripts/execution-core/install-lifecycle.mjs
+++ b/plugins/dev/scripts/execution-core/install-lifecycle.mjs
@@ -414,10 +414,11 @@ function defaultProbeResidualAgents(env = process.env) {
   }
   if (env.CATALYST_ASSUME_NO_DAEMONS === "1") return false;
   // Covers every stack daemon, not just broker/exec-core: the monitor (orch-monitor/server.ts) and
-  // otel-forward (otel-forward/index.ts) are nohup children of the stack, and Alloy (the log-shipper)
-  // is deliberately LEFT running by `catalyst-stack stop`/`uninstall-services` — so if a teardown
-  // didn't reap them, an uninstall must not look clean.
-  const pattern = "broker/index.mjs|execution-core/(daemon|index|updater/updater)\\.mjs|orch-monitor/server\\.ts|otel-forward/index\\.ts|alloy run ";
+  // otel-forward (otel-forward/index.ts) are nohup children of the stack, and the CATALYST Alloy
+  // log-shipper (matched by its log-shipper config path, NOT any Alloy on the host) is deliberately
+  // LEFT running by `catalyst-stack stop`/`uninstall-services` — so if a teardown didn't reap them,
+  // an uninstall must not look clean.
+  const pattern = "broker/index.mjs|execution-core/(daemon|index|updater/updater)\\.mjs|orch-monitor/server\\.ts|otel-forward/index\\.ts|alloy run .*log-shipper";
   const res = spawnSync("pgrep", ["-f", pattern], { encoding: "utf8" });
   if (res.error) return false; // can't probe processes; the plist check above already ran
   return res.status === 0;
@@ -447,6 +448,18 @@ function defaultBundleHasCapturedAgents(bundlePath) {
     return Array.isArray(m.captured) && m.captured.some((p) => p.startsWith("launchagents/") && p.endsWith(".plist"));
   } catch {
     return false; // unreadable manifest → treat as fresh (safe to tear down newly-installed agents)
+  }
+}
+
+// bundleIsEmpty — did the backup capture NOTHING (a truly fresh node)? When false the node had prior
+// state (config/db) that restore re-lays, so rollback must NOT strip install-managed keys / uninstall
+// CLI symlinks (they may have pre-existed). Unreadable/absent manifest ⇒ treat as empty (fresh).
+function defaultBundleIsEmpty(bundlePath) {
+  try {
+    const m = JSON.parse(readFileSync(join(bundlePath, "manifest.json"), "utf8"));
+    return !Array.isArray(m.captured) || m.captured.length === 0;
+  } catch {
+    return true;
   }
 }
 
@@ -490,6 +503,7 @@ export function buildDefaultDeps(env) {
     probeResidualAgents: () => defaultProbeResidualAgents(env),
     probeDrained: () => defaultProbeDrained({ scripts, env }),
     bundleHasCapturedAgents: (p) => defaultBundleHasCapturedAgents(p),
+    bundleIsEmpty: (p) => defaultBundleIsEmpty(p),
     scriptExists: (p) => existsSync(p),
     binExists: (name) => {
       const r = spawnSync("sh", ["-c", `command -v "${name}" >/dev/null 2>&1`]);
@@ -523,7 +537,7 @@ function isTeardown(operation) {
  *   InstallRunCtor.
  */
 export async function runInstallLifecycle({ operation, nodeClass, opts = {} }, deps) {
-  const { scripts, env, layer2, runStep, emit, nowFn, genTraceId, genSpanId, probeDaemons, probeResidualAgents, probeDrained, bundleHasCapturedAgents, scriptExists, binExists, probeUpdaterAgent, log, InstallRunCtor } = deps;
+  const { scripts, env, layer2, runStep, emit, nowFn, genTraceId, genSpanId, probeDaemons, probeResidualAgents, probeDrained, bundleHasCapturedAgents, bundleIsEmpty, scriptExists, binExists, probeUpdaterAgent, log, InstallRunCtor } = deps;
 
   // Every composed step inherits (a) the RESOLVED class so the bash tools (which re-derive class
   // env-first) cannot diverge from the lifecycle's target — e.g. `install --class developer` on a
@@ -725,64 +739,60 @@ export async function runInstallLifecycle({ operation, nodeClass, opts = {} }, d
           log(`catalyst-install: rollback note — could not strip install-managed keys: ${e.message}`);
         }
       };
-      let restore;
-      if (!hadAgents && !teardownRan) {
-        // (1) FRESH install: the node had NOTHING. Everything present now was created THIS run and
-        // restore (empty/no-config bundle) can't undo it — so boot out the agents, restore, then remove
-        // the install-managed config keys + uninstall the catalyst-* symlinks so the node is genuinely
-        // clean. (Per-project secret files are left — re-usable on retry, not an operational footprint.)
-        bootOutAgents();
-        restore = restoreNode();
-        if (restore.code === 0) {
-          const cli = runStep({ argv: [scripts.installCli, "--uninstall"], env: stepEnv });
-          if (cli.code !== 0) log(`catalyst-install: rollback note — uninstall CLI symlinks rc ${cli.code}: ${cli.stderr.trim()}`);
-          stripManagedKeys();
-        }
-        rolledBack = restore.code === 0;
-        log(rolledBack ? `catalyst-install: rolled back — removed everything this fresh install created (verify launchd/daemon state)` : `catalyst-install: rollback INCOMPLETE (restore rc ${restore.code}); bundle at ${ctx.bundlePath}`);
-      } else if (!hadAgents && teardownRan) {
-        // (2) CONFIG-ONLY reinstall: the node had config (restored below) but no agents. Boot out any
-        // agents provisioning installed this run, restore the config, then RE-INSTALL the catalyst-*
-        // symlinks the teardown's `install-cli --uninstall` removed (they aren't in the backup).
-        bootOutAgents();
-        restore = restoreNode();
-        if (restore.code === 0) {
-          const cli = runStep({ argv: [scripts.installCli], env: stepEnv });
-          if (cli.code !== 0) log(`catalyst-install: rollback note — re-install CLI symlinks rc ${cli.code}: ${cli.stderr.trim()}`);
-        }
-        rolledBack = restore.code === 0;
-        log(rolledBack ? `catalyst-install: rolled back — restored config + re-installed CLI symlinks (verify launchd/daemon state)` : `catalyst-install: rollback INCOMPLETE (restore rc ${restore.code}); bundle at ${ctx.bundlePath}`);
-      } else if (teardownRan) {
-        // (3) reinstall failed AFTER remove-agents booted out the node's PRE-EXISTING agents. Restore,
-        // then RE-BOOTSTRAP to the RESTORED class (absent ⇒ worker default), NOT the requested target —
-        // else a failed `reinstall --class developer` of an original default-worker node would come back
-        // as developer and lose the worker's broker/exec-core stack.
-        restore = restoreNode();
-        let bringupOk = true;
-        if (restore.code === 0) {
-          const rawClass = readNodeClassRaw(layer2);
-          const restoredClass = rawClass && NODE_CLASSES.includes(rawClass.trim().toLowerCase()) ? rawClass.trim().toLowerCase() : "worker";
-          const bringupEnv = { ...stepEnv, CATALYST_NODE_CLASS: restoredClass };
-          const bringup = planPhases({ operation: "install", nodeClass: restoredClass, scripts, opts: {} }).filter(
-            (p) => p.phase === "install-agents" || p.phase === "start-daemons",
-          );
-          for (const ph of bringup) {
-            for (const s of ph.steps) {
-              if (s.kind !== "run") continue;
-              const r = runStep({ argv: s.argv, env: bringupEnv });
-              if (r.code !== 0 && !s.optional) {
-                bringupOk = false;
-                log(`catalyst-install: rollback re-bootstrap step '${s.label}' failed (rc ${r.code}): ${r.stderr.trim()}`);
-              }
+      // reBootstrapRestoredClass — re-run install-agents + start-daemons for the RESTORED class (absent
+      // ⇒ worker default, NOT the requested target), bringing back agents that were booted out (by a
+      // reinstall teardown, or by a failed adopt-updater/install-services that backs itself out).
+      const reBootstrapRestoredClass = () => {
+        const rawClass = readNodeClassRaw(layer2);
+        const restoredClass = rawClass && NODE_CLASSES.includes(rawClass.trim().toLowerCase()) ? rawClass.trim().toLowerCase() : "worker";
+        const bringupEnv = { ...stepEnv, CATALYST_NODE_CLASS: restoredClass };
+        const bringup = planPhases({ operation: "install", nodeClass: restoredClass, scripts, opts: {} }).filter(
+          (p) => p.phase === "install-agents" || p.phase === "start-daemons",
+        );
+        let ok = true;
+        for (const ph of bringup) {
+          for (const s of ph.steps) {
+            if (s.kind !== "run") continue;
+            const r = runStep({ argv: s.argv, env: bringupEnv });
+            if (r.code !== 0 && !s.optional) {
+              ok = false;
+              log(`catalyst-install: rollback re-bootstrap step '${s.label}' failed (rc ${r.code}): ${r.stderr.trim()}`);
             }
           }
         }
-        rolledBack = restore.code === 0 && bringupOk;
-        log(rolledBack ? `catalyst-install: rolled back — restored + re-bootstrapped the torn-down agents (verify launchd/daemon state)` : `catalyst-install: rollback INCOMPLETE — config restored from ${ctx.bundlePath} but agents are NOT fully re-bootstrapped; run 'catalyst install' or 'catalyst-stack install-services && catalyst-stack start'`);
+        return ok;
+      };
+
+      let restore;
+      if (!hadAgents) {
+        // The node's ORIGINAL state had NO launchd agents (a fresh install, or a config-only node).
+        // Boot out anything provisioning installed this run, then restore.
+        bootOutAgents();
+        restore = restoreNode();
+        if (restore.code === 0) {
+          if (teardownRan) {
+            // config-only reinstall: teardown ran `install-cli --uninstall`; re-install the symlinks
+            // (not captured in the backup) so the restored node still has `catalyst` on PATH.
+            const cli = runStep({ argv: [scripts.installCli], env: stepEnv });
+            if (cli.code !== 0) log(`catalyst-install: rollback note — re-install CLI symlinks rc ${cli.code}: ${cli.stderr.trim()}`);
+          } else if (bundleIsEmpty(ctx.bundlePath)) {
+            // TRULY fresh node (empty backup — nothing to restore): the config keys + symlinks present
+            // were all created THIS run, so delete them. (We do NOT do this when the backup captured
+            // prior config — restore re-laid the node's pre-existing settings; stripping would erase
+            // them. Per-project secret files are left either way — re-usable, not an operational footprint.)
+            const cli = runStep({ argv: [scripts.installCli, "--uninstall"], env: stepEnv });
+            if (cli.code !== 0) log(`catalyst-install: rollback note — uninstall CLI symlinks rc ${cli.code}: ${cli.stderr.trim()}`);
+            stripManagedKeys();
+          }
+        }
+        rolledBack = restore.code === 0;
+        log(rolledBack ? `catalyst-install: rolled back — restored ${ctx.bundlePath} (verify launchd/daemon state)` : `catalyst-install: rollback INCOMPLETE (restore rc ${restore.code}); bundle at ${ctx.bundlePath}`);
       } else {
-        // (4) install retry on an EXISTING node whose pre-existing agents were NOT touched this run.
-        // Leave the agents installed, but if the worker stack is LIVE, STOP it around the restore —
-        // catalyst-backup --force over running broker/exec-core can corrupt config/db — then restart it.
+        // The node HAD agents: a reinstall teardown booted out PRE-EXISTING agents, OR an install-retry
+        // where a failed provisioning step (adopt-updater/install-services) backed an agent out. If the
+        // worker stack is LIVE, STOP it around the forced restore (catalyst-backup --force over running
+        // broker/exec-core can corrupt config/db) then restart; otherwise restore + re-bootstrap the
+        // restored class so a backed-out agent (e.g. a developer's updater) comes back.
         const live = probeDaemons();
         if (live) {
           const stop = runStep({ argv: [scripts.stack, "stop"], env: stepEnv });
@@ -790,12 +800,13 @@ export async function runInstallLifecycle({ operation, nodeClass, opts = {} }, d
           restore = restoreNode();
           const start = runStep({ argv: [scripts.stack, "start", "--yes"], env: stepEnv });
           if (start.code !== 0) log(`catalyst-install: rollback note — restart-after-restore rc ${start.code} (run 'catalyst-stack start')`);
+          rolledBack = restore.code === 0;
         } else {
-          log(`catalyst-install: rollback — pre-existing agents present but no live worker stack; restoring in place`);
           restore = restoreNode();
+          const bringupOk = restore.code === 0 ? reBootstrapRestoredClass() : false;
+          rolledBack = restore.code === 0 && bringupOk;
         }
-        rolledBack = restore.code === 0;
-        log(rolledBack ? `catalyst-install: rolled back — restored ${ctx.bundlePath} (verify launchd/daemon state)` : `catalyst-install: rollback INCOMPLETE (restore rc ${restore.code}); bundle at ${ctx.bundlePath}`);
+        log(rolledBack ? `catalyst-install: rolled back — restored ${ctx.bundlePath} + re-established the node's agents (verify launchd/daemon state)` : `catalyst-install: rollback INCOMPLETE — config restored from ${ctx.bundlePath} but agents are NOT fully re-established; run 'catalyst install' or 'catalyst-stack install-services && catalyst-stack start'`);
       }
       rollbackDisposition = rolledBack ? "ok" : "failed";
     } else if (ctx.bundlePath) {

--- a/plugins/dev/scripts/execution-core/install-lifecycle.mjs
+++ b/plugins/dev/scripts/execution-core/install-lifecycle.mjs
@@ -147,9 +147,18 @@ export function resolveRequestedClass({ optsClass, env = process.env, layer2, cu
     return { nodeClass: normalized, source: "env" };
   }
   if (typeof currentFn === "function") return { nodeClass: currentFn(), source: "config" };
-  const raw = readNodeClassRaw(layer2);
-  if (raw == null || raw.trim() === "") return { nodeClass: "worker", source: "config-default" };
-  const normalized = raw.trim().toLowerCase();
+  // Read the config DIRECTLY (not readNodeClassRaw, which swallows errors) so a MALFORMED config
+  // FAILS CLOSED — refusing before any side effect — rather than reading as absent ⇒ worker and then
+  // running the worker path on a developer/monitor node.
+  let cfg;
+  try {
+    cfg = readLayer2(layer2);
+  } catch (e) {
+    throw new Error(`Layer-2 config at ${layer2} is unreadable/malformed (${e.message}) — fix it or pass --class`);
+  }
+  const raw = cfg?.catalyst?.node?.class;
+  if (raw == null || String(raw).trim() === "") return { nodeClass: "worker", source: "config-default" };
+  const normalized = String(raw).trim().toLowerCase();
   if (!NODE_CLASSES.includes(normalized)) {
     throw new Error(`unrecognized node class in ${layer2}: '${raw}' (valid: ${NODE_CLASSES.join(", ")}) — pass --class to override`);
   }
@@ -424,15 +433,26 @@ function defaultBundleHasCapturedAgents(bundlePath) {
   }
 }
 
-// probeDrained — is this node draining (admitting 0 new work)? Best-effort; unknown ⇒ false (the
-// guard then requires --force on a live node, the safe default).
+// probeDrained — is this node FULLY drained, i.e. admitting 0 new work AND with 0 in-flight tickets?
+// `draining:true` alone is NOT enough — a worker can be draining with work still landing, and stopping
+// its daemon then would kill in-flight work. So the teardown guard only treats the node as drained
+// when an explicit drained sentinel is set OR draining is on with inFlightCount === 0. Best-effort;
+// unknown ⇒ false (the guard then requires --force on a live node, the safe default).
+// isDrainedStatus — PURE interpretation of `catalyst-execution-core drain --json` output: fully
+// drained iff an explicit `drained` sentinel is set, OR `draining` is on with ZERO in-flight tickets.
+export function isDrainedStatus(parsed) {
+  if (!parsed || typeof parsed !== "object") return false;
+  if (parsed.drained === true) return true;
+  const inFlight = Number(parsed.inFlightCount ?? parsed.inflight ?? 0);
+  return parsed.draining === true && Number.isFinite(inFlight) && inFlight === 0;
+}
+
 function defaultProbeDrained({ scripts, env = process.env } = {}) {
   if (env.CATALYST_ASSUME_DRAINED === "1") return true;
   const res = spawnSync(scripts.catalyst, ["drain", "--status-read", "--json"], { encoding: "utf8" });
   if (res.error || res.status !== 0 || !res.stdout) return false;
   try {
-    const parsed = JSON.parse(res.stdout);
-    return parsed.draining === true || parsed.drained === true;
+    return isDrainedStatus(JSON.parse(res.stdout));
   } catch {
     return false;
   }
@@ -623,22 +643,37 @@ export async function runInstallLifecycle({ operation, nodeClass, opts = {} }, d
     if (autoRollbacks(operation) && ctx.bundlePath) {
       log(`catalyst-install: ${operation} failed — rolling back from ${ctx.bundlePath}`);
       // `catalyst-backup restore` is ADDITIVE — it re-lays captured config/db/plist FILES but never
-      // re-bootstraps launchd agents or restarts daemons. So rollback has three cases:
+      // DELETES plists created after the snapshot, nor re-bootstraps/restarts agents. So rollback has
+      // three cases, keyed first on whether the node's ORIGINAL state (the backup) had launchd agents.
       const teardownRan = ctx.teardownRan; // a reinstall already booted out the node's agents this run
       const hadAgents = bundleHasCapturedAgents(ctx.bundlePath);
-      if (teardownRan) {
-        // (3) reinstall failed AFTER remove-agents. Restore the captured state. Then, ONLY if the
-        // node actually HAD agents (the backup captured plists), RE-BOOTSTRAP them — the teardown
-        // booted them out and restore alone can't bring them back. If the node had NO agents
-        // (config-only node), restore is the full rollback; re-bootstrapping would install agents the
-        // snapshot never had.
-        const restore = runStep({ argv: [scripts.backup, "restore", ctx.bundlePath, "--force"], env: stepEnv });
+      const restoreNode = () => runStep({ argv: [scripts.backup, "restore", ctx.bundlePath, "--force"], env: stepEnv });
+      if (!hadAgents) {
+        // ORIGINAL node had NO agents (a fresh install, or a config-only reinstall). Anything present
+        // now was installed THIS run — even if provisioning reached install-agents before failing at
+        // start-daemons — and restore won't delete it (and a worker's stack keep-alive would restart
+        // it). Boot it out, then restore. No re-bootstrap: the snapshot had no agents to bring back.
+        const unsvc = runStep({ argv: [scripts.stack, "uninstall-services"], env: stepEnv });
+        if (unsvc.code !== 0) log(`catalyst-install: rollback note — uninstall-services rc ${unsvc.code} (agents may remain): ${unsvc.stderr.trim()}`);
+        const stop = runStep({ argv: [scripts.stack, "stop"], env: stepEnv });
+        if (stop.code !== 0) log(`catalyst-install: rollback note — stop rc ${stop.code}`);
+        const restore = restoreNode();
+        rolledBack = restore.code === 0;
+        rollbackDisposition = rolledBack ? "ok" : "failed";
+        log(
+          rolledBack
+            ? `catalyst-install: rolled back — restored ${ctx.bundlePath} + tore down agents installed this run (verify launchd/daemon state)`
+            : `catalyst-install: rollback INCOMPLETE (restore rc ${restore.code}) — node is in a PARTIAL state; bundle at ${ctx.bundlePath}`,
+        );
+      } else if (teardownRan) {
+        // reinstall failed AFTER remove-agents booted out the node's PRE-EXISTING agents. Restore the
+        // captured state, then RE-BOOTSTRAP — restore alone can't re-load launchd. Re-bootstrap to the
+        // RESTORED class (absent ⇒ worker default), NOT the requested reinstall target — else a failed
+        // `reinstall --class developer` of an original default-worker node would come back as developer
+        // (adopt-updater/drain) and lose the worker's broker/exec-core stack.
+        const restore = restoreNode();
         let bringupOk = true;
-        if (restore.code === 0 && hadAgents) {
-          // Re-bootstrap to the RESTORED class: read it from the restored config, defaulting an
-          // ABSENT class to worker (the unset/default), NOT the requested reinstall target — else a
-          // failed `reinstall --class developer` of an original default-worker node would re-bring-up
-          // as developer (adopt-updater/drain) and lose the worker's broker/exec-core stack.
+        if (restore.code === 0) {
           const rawClass = readNodeClassRaw(layer2);
           const restoredClass = rawClass && NODE_CLASSES.includes(rawClass.trim().toLowerCase()) ? rawClass.trim().toLowerCase() : "worker";
           const bringupEnv = { ...stepEnv, CATALYST_NODE_CLASS: restoredClass };
@@ -660,25 +695,16 @@ export async function runInstallLifecycle({ operation, nodeClass, opts = {} }, d
         rollbackDisposition = rolledBack ? "ok" : "failed";
         log(
           rolledBack
-            ? `catalyst-install: rolled back — restored ${ctx.bundlePath}${hadAgents ? " + re-bootstrapped the torn-down agents" : ""} (verify launchd/daemon state)`
+            ? `catalyst-install: rolled back — restored ${ctx.bundlePath} + re-bootstrapped the torn-down agents (verify launchd/daemon state)`
             : `catalyst-install: rollback INCOMPLETE — config restored from ${ctx.bundlePath} but launchd agents are NOT fully re-bootstrapped; re-run 'catalyst install' or 'catalyst-stack install-services && catalyst-stack start' to bring the node back`,
         );
       } else {
-        // (1) FRESH node (no pre-existing agents captured): boot out whatever provisioning installed
-        // this run (a worker's stack keep-alive would otherwise restart it), then stop survivors. Or
-        // (2) install on an EXISTING node (agents not removed this run): leave the pre-existing agents
-        // running untouched — tearing them down would leave a working node's services down with no
-        // re-bootstrap. (install-cli symlinks are left in place either way — not in the backup, so
-        // removing them would be an unrecoverable loss, not a reversal.)
-        if (hadAgents) {
-          log(`catalyst-install: rollback — backup captured pre-existing launchd agents; leaving them in place (restore re-lays their config; reload them if needed)`);
-        } else {
-          const unsvc = runStep({ argv: [scripts.stack, "uninstall-services"], env: stepEnv });
-          if (unsvc.code !== 0) log(`catalyst-install: rollback note — uninstall-services rc ${unsvc.code} (agents may remain): ${unsvc.stderr.trim()}`);
-          const stop = runStep({ argv: [scripts.stack, "stop"], env: stepEnv });
-          if (stop.code !== 0) log(`catalyst-install: rollback note — stop rc ${stop.code}`);
-        }
-        const restore = runStep({ argv: [scripts.backup, "restore", ctx.bundlePath, "--force"], env: stepEnv });
+        // install on an EXISTING node: its pre-existing agents were NOT touched this run — leave them
+        // running untouched (tearing them down would down a working node with no re-bootstrap) and just
+        // restore. (install-cli symlinks are left in place — not in the backup, so removing them would
+        // be an unrecoverable loss, not a reversal.)
+        log(`catalyst-install: rollback — backup captured pre-existing launchd agents; leaving them in place (restore re-lays their config; reload them if needed)`);
+        const restore = restoreNode();
         rolledBack = restore.code === 0;
         rollbackDisposition = rolledBack ? "ok" : "failed";
         log(

--- a/plugins/dev/scripts/execution-core/install-lifecycle.mjs
+++ b/plugins/dev/scripts/execution-core/install-lifecycle.mjs
@@ -96,9 +96,19 @@ export function resolveScripts(env = process.env) {
   };
 }
 
-/** layer2Path — the Layer-2 machine config (same precedence the rest of the toolchain uses). */
+/**
+ * layer2Path — the Layer-2 machine config, resolved the way the WHOLE toolchain resolves it so the
+ * driver and every child tool agree on one file: CATALYST_LAYER2_CONFIG_FILE (config.mjs runtime) >
+ * CATALYST_MACHINE_CONFIG (setup-plugin-source / lib/plugin-dirs.sh / catalyst-stack pluginPullOwner)
+ * > XDG_CONFIG_HOME/catalyst/config.json > ~/.config/catalyst/config.json. Honoring CATALYST_MACHINE_CONFIG
+ * here is what keeps a caller that set ONLY that var from having the run silently target ~/.config.
+ */
 export function layer2Path(env = process.env) {
-  return env.CATALYST_LAYER2_CONFIG_FILE || join(homedir(), ".config", "catalyst", "config.json");
+  return (
+    env.CATALYST_LAYER2_CONFIG_FILE ||
+    env.CATALYST_MACHINE_CONFIG ||
+    join(env.XDG_CONFIG_HOME || join(homedir(), ".config"), "catalyst", "config.json")
+  );
 }
 
 /**
@@ -440,7 +450,8 @@ function isTeardown(operation) {
  * throws for a normal lifecycle failure (the outcome is in the return). Telemetry is best-effort.
  *
  * deps (all injectable): scripts, env, layer2, runStep, emit, nowFn, genTraceId, genSpanId,
- *   probeDaemons, probeResidualAgents, probeDrained, scriptExists, log, InstallRunCtor.
+ *   probeDaemons, probeResidualAgents, probeDrained, bundleHasCapturedAgents, scriptExists, log,
+ *   InstallRunCtor.
  */
 export async function runInstallLifecycle({ operation, nodeClass, opts = {} }, deps) {
   const { scripts, env, layer2, runStep, emit, nowFn, genTraceId, genSpanId, probeDaemons, probeResidualAgents, probeDrained, bundleHasCapturedAgents, scriptExists, log, InstallRunCtor } = deps;
@@ -484,7 +495,7 @@ export async function runInstallLifecycle({ operation, nodeClass, opts = {} }, d
   const spanId = genSpanId();
   const run = new InstallRunCtor({ operation, nodeClass, emit, traceId, spanId, nowFn }).start({ class: nodeClass });
 
-  const ctx = { bundlePath: null, healthOk: true, healthRc: null, cleanOk: true };
+  const ctx = { bundlePath: null, healthOk: true, healthRc: null, cleanOk: true, teardownRan: false };
 
   const runOneStep = async (step) => {
     switch (step.kind) {
@@ -499,6 +510,9 @@ export async function runInstallLifecycle({ operation, nodeClass, opts = {} }, d
       }
       case "run": {
         const r = runStep({ argv: step.argv, env: stepEnv });
+        // Record that this run booted out the node's launchd agents (the reinstall teardown), so the
+        // rollback handler knows the agents are DOWN and must re-bootstrap rather than file-restore alone.
+        if (step.label === "uninstall-services" && r.code === 0) ctx.teardownRan = true;
         if (r.code !== 0) {
           if (step.optional) {
             log(`catalyst-install: WARN — optional step '${step.label}' failed (rc ${r.code}), continuing: ${r.stderr.trim()}`);
@@ -571,31 +585,66 @@ export async function runInstallLifecycle({ operation, nodeClass, opts = {} }, d
     let rollbackDisposition = "none";
     if (autoRollbacks(operation) && ctx.bundlePath) {
       log(`catalyst-install: ${operation} failed — rolling back from ${ctx.bundlePath}`);
-      // A restore alone is ADDITIVE — it re-lays captured config/db/plist FILES but cannot
-      // un-bootstrap launchd agents provisioning just installed (and a worker's stack keep-alive would
-      // restart the daemon). So when this run installed agents onto a FRESH node, tear them down first
-      // (boot out, then stop survivors) before restoring. But if the backup captured PRE-EXISTING
-      // agents (a retry/reinstall on a working node), DON'T tear them down: restore re-lays their plist
-      // files but never re-bootstraps them, so a teardown would leave a previously-working node's
-      // services down. Either way the restore is the authoritative "state put back" signal. (install-cli
-      // symlinks are intentionally left in place — not captured in the backup, so removing them would be
-      // an unrecoverable loss, not a reversal.)
-      if (bundleHasCapturedAgents(ctx.bundlePath)) {
-        log(`catalyst-install: rollback — backup captured pre-existing launchd agents; leaving them in place (restore re-lays their config; reload them if needed)`);
+      // `catalyst-backup restore` is ADDITIVE — it re-lays captured config/db/plist FILES but never
+      // re-bootstraps launchd agents or restarts daemons. So rollback has three cases:
+      const teardownRan = ctx.teardownRan; // a reinstall already booted out the node's agents this run
+      const hadAgents = bundleHasCapturedAgents(ctx.bundlePath);
+      if (teardownRan) {
+        // (3) reinstall failed AFTER remove-agents: the agents are already DOWN; restore alone can't
+        // bring them back. Restore the captured state, then RE-BOOTSTRAP the node to its restored class.
+        const restore = runStep({ argv: [scripts.backup, "restore", ctx.bundlePath, "--force"], env: stepEnv });
+        let bringupOk = false;
+        if (restore.code === 0) {
+          // The restored config carries the node's original class; re-run install-agents + start-daemons
+          // for it so the node comes back up (idempotent; catalyst-stack re-renders + bootstraps).
+          const restoredClass = readLayer2(layer2)?.catalyst?.node?.class || nodeClass;
+          const bringupEnv = { ...stepEnv, CATALYST_NODE_CLASS: restoredClass };
+          const bringup = planPhases({ operation: "install", nodeClass: restoredClass, scripts, opts: {} }).filter(
+            (p) => p.phase === "install-agents" || p.phase === "start-daemons",
+          );
+          bringupOk = true;
+          for (const ph of bringup) {
+            for (const s of ph.steps) {
+              if (s.kind !== "run") continue;
+              const r = runStep({ argv: s.argv, env: bringupEnv });
+              if (r.code !== 0 && !s.optional) {
+                bringupOk = false;
+                log(`catalyst-install: rollback re-bootstrap step '${s.label}' failed (rc ${r.code}): ${r.stderr.trim()}`);
+              }
+            }
+          }
+        }
+        rolledBack = restore.code === 0 && bringupOk;
+        rollbackDisposition = rolledBack ? "ok" : "failed";
+        log(
+          rolledBack
+            ? `catalyst-install: rolled back — restored ${ctx.bundlePath} + re-bootstrapped the torn-down agents (verify launchd/daemon state)`
+            : `catalyst-install: rollback INCOMPLETE — config restored from ${ctx.bundlePath} but launchd agents are NOT fully re-bootstrapped; re-run 'catalyst install' or 'catalyst-stack install-services && catalyst-stack start' to bring the node back`,
+        );
       } else {
-        const unsvc = runStep({ argv: [scripts.stack, "uninstall-services"], env: stepEnv });
-        if (unsvc.code !== 0) log(`catalyst-install: rollback note — uninstall-services rc ${unsvc.code} (agents may remain): ${unsvc.stderr.trim()}`);
-        const stop = runStep({ argv: [scripts.stack, "stop"], env: stepEnv });
-        if (stop.code !== 0) log(`catalyst-install: rollback note — stop rc ${stop.code}`);
+        // (1) FRESH node (no pre-existing agents captured): boot out whatever provisioning installed
+        // this run (a worker's stack keep-alive would otherwise restart it), then stop survivors. Or
+        // (2) install on an EXISTING node (agents not removed this run): leave the pre-existing agents
+        // running untouched — tearing them down would leave a working node's services down with no
+        // re-bootstrap. (install-cli symlinks are left in place either way — not in the backup, so
+        // removing them would be an unrecoverable loss, not a reversal.)
+        if (hadAgents) {
+          log(`catalyst-install: rollback — backup captured pre-existing launchd agents; leaving them in place (restore re-lays their config; reload them if needed)`);
+        } else {
+          const unsvc = runStep({ argv: [scripts.stack, "uninstall-services"], env: stepEnv });
+          if (unsvc.code !== 0) log(`catalyst-install: rollback note — uninstall-services rc ${unsvc.code} (agents may remain): ${unsvc.stderr.trim()}`);
+          const stop = runStep({ argv: [scripts.stack, "stop"], env: stepEnv });
+          if (stop.code !== 0) log(`catalyst-install: rollback note — stop rc ${stop.code}`);
+        }
+        const restore = runStep({ argv: [scripts.backup, "restore", ctx.bundlePath, "--force"], env: stepEnv });
+        rolledBack = restore.code === 0;
+        rollbackDisposition = rolledBack ? "ok" : "failed";
+        log(
+          rolledBack
+            ? `catalyst-install: rolled back — restored ${ctx.bundlePath} (verify launchd/daemon state)`
+            : `catalyst-install: rollback INCOMPLETE (restore rc ${restore.code}) — node is in a PARTIAL state; bundle at ${ctx.bundlePath}`,
+        );
       }
-      const restore = runStep({ argv: [scripts.backup, "restore", ctx.bundlePath, "--force"], env: stepEnv });
-      rolledBack = restore.code === 0;
-      rollbackDisposition = rolledBack ? "ok" : "failed";
-      log(
-        rolledBack
-          ? `catalyst-install: rolled back — restored ${ctx.bundlePath} + tore down provisioned agents (verify launchd/daemon state)`
-          : `catalyst-install: rollback INCOMPLETE (restore rc ${restore.code}) — node is in a PARTIAL state; bundle at ${ctx.bundlePath}`,
-      );
     } else if (ctx.bundlePath) {
       log(`catalyst-install: ${operation} failed — NOT auto-rolled-back; restore manually from ${ctx.bundlePath} if needed`);
     }
@@ -755,9 +804,15 @@ export async function main(argv, depsOverride) {
 
   // Install the OTLP tracer BEFORE the run so InstallRun.complete()/fail() → emitInstallTrace()
   // actually export the catalyst.install root/phase spans (the tracer is a no-op until initTracing
-  // runs). Off-first: only when CATALYST_TRACING=on, matching updater.mjs. Flushed below.
+  // runs). Off-first: only when CATALYST_TRACING=on, matching updater.mjs. Flushed below. Pin
+  // CATALYST_NODE_CLASS to the REQUESTED class first so the tracer resource's catalyst.node.class
+  // (built from process config via lib/node-class.mjs) matches the run's class on a fresh/reclassed
+  // node, instead of the old/default config value — so dashboards bucket the spans correctly.
   const tracingOn = env.CATALYST_TRACING === "on";
-  if (tracingOn) await initTracing({ serviceName: INSTALL_SERVICE_NAME });
+  if (tracingOn) {
+    process.env.CATALYST_NODE_CLASS = nodeClass;
+    await initTracing({ serviceName: INSTALL_SERVICE_NAME });
+  }
 
   const result = await runInstallLifecycle({ operation: args.operation, nodeClass, opts }, deps);
 

--- a/plugins/dev/scripts/execution-core/install-lifecycle.mjs
+++ b/plugins/dev/scripts/execution-core/install-lifecycle.mjs
@@ -157,8 +157,14 @@ export function resolveRequestedClass({ optsClass, env = process.env, layer2, cu
     throw new Error(`Layer-2 config at ${layer2} is unreadable/malformed (${e.message}) — fix it or pass --class`);
   }
   const raw = cfg?.catalyst?.node?.class;
-  if (raw == null || String(raw).trim() === "") return { nodeClass: "worker", source: "config-default" };
-  const normalized = String(raw).trim().toLowerCase();
+  if (raw == null) return { nodeClass: "worker", source: "config-default" };
+  // A present-but-non-string class (e.g. [] / ["developer"] / 0 from a malformed config) must FAIL
+  // CLOSED, not be String()-coerced into "" (→ worker) or a bogus class.
+  if (typeof raw !== "string") {
+    throw new Error(`malformed node class in ${layer2}: expected a string, got ${JSON.stringify(raw)} — fix it or pass --class`);
+  }
+  if (raw.trim() === "") return { nodeClass: "worker", source: "config-default" };
+  const normalized = raw.trim().toLowerCase();
   if (!NODE_CLASSES.includes(normalized)) {
     throw new Error(`unrecognized node class in ${layer2}: '${raw}' (valid: ${NODE_CLASSES.join(", ")}) — pass --class to override`);
   }
@@ -493,7 +499,11 @@ function defaultProbeCliInstalled(env = process.env) {
 export function isDrainedStatus(parsed) {
   if (!parsed || typeof parsed !== "object") return false;
   if (parsed.drained === true) return true;
-  const inFlight = Number(parsed.inFlightCount ?? parsed.inflight ?? 0);
+  // draining:true alone is NOT drained — require an explicit, present, finite in-flight count of 0.
+  // A MISSING count (skewed/degraded status) is UNKNOWN ⇒ fail closed (the guard requires --force).
+  const rawCount = parsed.inFlightCount ?? parsed.inflight;
+  if (rawCount == null) return false;
+  const inFlight = Number(rawCount);
   return parsed.draining === true && Number.isFinite(inFlight) && inFlight === 0;
 }
 
@@ -813,29 +823,36 @@ export async function runInstallLifecycle({ operation, nodeClass, opts = {} }, d
         // The node's ORIGINAL state had NO launchd agents (a fresh install, or a config-only node).
         // Boot out anything provisioning installed this run, then restore.
         const bootOk = bootOutAgents();
-        restore = restoreNode();
-        if (restore.code === 0) {
-          if (teardownRan) {
-            // config-only reinstall: teardown ran `install-cli --uninstall`; re-install the symlinks
-            // (not captured in the backup) so the restored node still has `catalyst` on PATH.
-            const cli = runStep({ argv: [scripts.installCli], env: stepEnv });
-            if (cli.code !== 0) log(`catalyst-install: rollback note — re-install CLI symlinks rc ${cli.code}: ${cli.stderr.trim()}`);
-          } else {
-            // install on a no-agent node. Remove ONLY the artifacts THIS run created, determined from
-            // the PRE-RUN snapshot (NOT the post-acquire bundle, whose pluginDirs write makes it look
-            // non-empty even on a fresh node). A node that already had these keeps them (restore re-laid
-            // its config). Per-project secret files are left either way — re-usable, not operational.
-            if (!preInstall.hadCli) {
-              const cli = runStep({ argv: [scripts.installCli, "--uninstall"], env: stepEnv });
-              if (cli.code !== 0) log(`catalyst-install: rollback note — uninstall CLI symlinks rc ${cli.code}: ${cli.stderr.trim()}`);
+        if (!bootOk) {
+          // Cleanup could NOT stop the agents/daemons it tried to remove — do NOT force a config/db
+          // restore over possibly-live broker/exec-core (corruption). Report incomplete (same guard as
+          // the live had-agents path). The catch-level pluginDirs restore below still runs.
+          log(`catalyst-install: rollback INCOMPLETE — could not boot out the agents this run installed; NOT restoring over possibly-live daemons. Stop the stack and 'catalyst-backup restore ${ctx.bundlePath} --force' manually.`);
+          restore = { code: 1 };
+          rolledBack = false;
+        } else {
+          restore = restoreNode();
+          if (restore.code === 0) {
+            if (teardownRan) {
+              // config-only reinstall: teardown ran `install-cli --uninstall`; re-install the symlinks
+              // (not captured in the backup) so the restored node still has `catalyst` on PATH.
+              const cli = runStep({ argv: [scripts.installCli], env: stepEnv });
+              if (cli.code !== 0) log(`catalyst-install: rollback note — re-install CLI symlinks rc ${cli.code}: ${cli.stderr.trim()}`);
+            } else {
+              // install on a no-agent node. Remove ONLY the artifacts THIS run created, determined from
+              // the PRE-RUN snapshot (NOT the post-acquire bundle, whose pluginDirs write makes it look
+              // non-empty even on a fresh node). A node that already had these keeps them (restore re-laid
+              // its config). Per-project secret files are left either way — re-usable, not operational.
+              if (!preInstall.hadCli) {
+                const cli = runStep({ argv: [scripts.installCli, "--uninstall"], env: stepEnv });
+                if (cli.code !== 0) log(`catalyst-install: rollback note — uninstall CLI symlinks rc ${cli.code}: ${cli.stderr.trim()}`);
+              }
+              if (!preInstall.hadManagedKeys) stripManagedKeys();
             }
-            if (!preInstall.hadManagedKeys) stripManagedKeys();
           }
+          rolledBack = restore.code === 0;
+          log(rolledBack ? `catalyst-install: rolled back — restored ${ctx.bundlePath} (verify launchd/daemon state)` : `catalyst-install: rollback INCOMPLETE (restore rc ${restore.code}); bundle at ${ctx.bundlePath}`);
         }
-        // A failed boot-out (agents possibly still running) makes the rollback INCOMPLETE even if the
-        // file restore succeeded.
-        rolledBack = restore.code === 0 && bootOk;
-        log(rolledBack ? `catalyst-install: rolled back — restored ${ctx.bundlePath} (verify launchd/daemon state)` : `catalyst-install: rollback INCOMPLETE (restore rc ${restore.code}, cleanup ${bootOk ? "ok" : "FAILED"}); bundle at ${ctx.bundlePath}`);
       } else {
         // The node HAD agents: a reinstall teardown booted out PRE-EXISTING agents, OR an install-retry
         // where a failed provisioning step (adopt-updater/install-services) backed an agent out. If the

--- a/plugins/dev/scripts/execution-core/install-lifecycle.test.mjs
+++ b/plugins/dev/scripts/execution-core/install-lifecycle.test.mjs
@@ -57,7 +57,7 @@ const SCRIPTS = {
 
 // makeDeps — a fully-stubbed dep set. `failOn` is a predicate (argv|joined → truthy = fail with
 // that rc). `bundle` is the path catalyst-backup "prints". probeDaemons/probeDrained are flags.
-function makeDeps({ failOn, bundle = "/tmp/bundle-xyz", daemonsLive = false, residual = false, drained = false, layer2Initial } = {}) {
+function makeDeps({ failOn, bundle = "/tmp/bundle-xyz", daemonsLive = false, residual = false, drained = false, bundleHadAgents = false, layer2Initial } = {}) {
   const events = [];
   const calls = [];
   const stepCalls = []; // {argv, env} per spawned step — lets tests assert the pinned step env
@@ -83,6 +83,7 @@ function makeDeps({ failOn, bundle = "/tmp/bundle-xyz", daemonsLive = false, res
     probeDaemons: () => daemonsLive,
     probeResidualAgents: () => residual,
     probeDrained: () => drained,
+    bundleHasCapturedAgents: () => bundleHadAgents,
     scriptExists: () => true,
     log: () => {},
     InstallRunCtor: undefined, // filled below with the real InstallRun
@@ -124,6 +125,13 @@ describe("parseArgs", () => {
   test("unknown flags are ignored (forward-compat)", () => {
     const a = parseArgs(["install", "--future-flag", "x"]);
     expect(a.operation).toBe("install");
+  });
+  test("a trailing --class / --read-replica with no value is an error (not a silent fallback)", () => {
+    expect(parseArgs(["install", "--class"]).errors).toContain("--class requires a value");
+    expect(parseArgs(["install", "--class", "--dry-run"]).errors).toContain("--class requires a value");
+    expect(parseArgs(["reinstall", "--read-replica"]).errors).toContain("--read-replica requires a value");
+    expect(parseArgs(["install", "--class="]).errors).toContain("--class requires a value");
+    expect(parseArgs(["install", "--class", "developer"]).errors).toHaveLength(0);
   });
 });
 
@@ -370,6 +378,14 @@ describe("node-class env pinning (composed tools cannot diverge from --class)", 
     const verify = bag.stepCalls.find((c) => c.argv.join(" ") === "STACK verify-node");
     expect(verify.env.CATALYST_NODE_CLASS).toBe("developer");
   });
+  test("spawned steps are pinned to the driver's Layer-2 file under BOTH config env names", async () => {
+    const bag = withRealRun(makeDeps());
+    await runInstallLifecycle({ operation: "install", nodeClass: "worker", opts: {} }, bag.deps);
+    for (const c of bag.stepCalls) {
+      expect(c.env.CATALYST_LAYER2_CONFIG_FILE).toBe(bag.layer2);
+      expect(c.env.CATALYST_MACHINE_CONFIG).toBe(bag.layer2);
+    }
+  });
 });
 
 describe("script preflight (fail fast before backup/teardown)", () => {
@@ -419,6 +435,15 @@ describe("rollback is a true reversal + partial-state telemetry", () => {
     expect(last.event).toBe("catalyst.install.failed");
     expect(last.detail.rollback).toBe("failed"); // partial-state disposition in body
     expect(last.detail.bundle).toBe("/tmp/bundle-xyz"); // recovery pointer for the operator
+  });
+  test("rollback does NOT tear down PRE-EXISTING agents (backup captured plists → retry on a working node)", async () => {
+    const { deps, calls } = withRealRun(makeDeps({ bundleHadAgents: true, failOn: (a) => (a.join(" ") === "STACK install-services" ? 3 : 0) }));
+    const res = await runInstallLifecycle({ operation: "install", nodeClass: "worker", opts: {} }, deps);
+    expect(res.outcome).toBe("rolled_back");
+    const joined = calls.map((a) => a.join(" "));
+    expect(joined).not.toContain("STACK uninstall-services"); // pre-existing agents left in place
+    expect(joined).not.toContain("STACK stop");
+    expect(joined.some((c) => c.startsWith("BACKUP restore"))).toBe(true); // still restored
   });
   test("a benign abort (backup fails) carries rollback disposition 'none' (distinguishable from partial-state)", async () => {
     const { deps, events } = withRealRun(makeDeps({ failOn: (a) => (a[0] === "BACKUP" && a[1] === "backup" ? 1 : 0) }));
@@ -520,6 +545,18 @@ describe("main — CLI exit codes", () => {
     expect(code).toBe(0);
     const cfg = JSON.parse(readFileSync(d.bag.layer2, "utf8"));
     expect(cfg.catalyst.readReplica.baseUrl).toBe("http://mini:7400");
+  });
+  test("--json on a successful run emits ONE stdout document (no trailing human line)", async () => {
+    const d = execDeps();
+    const code = await main(["install", "--class", "developer", "--json"], d.depsOverride);
+    expect(code).toBe(0);
+    expect(d.out).toHaveLength(1); // only the JSON, no "… completed." line
+    expect(() => JSON.parse(d.out[0])).not.toThrow();
+    expect(JSON.parse(d.out[0]).outcome).toBe("completed");
+  });
+  test("missing --class value → exit 2", async () => {
+    const c = capture();
+    expect(await main(["install", "--class"], c.depsOverride)).toBe(2);
   });
 });
 

--- a/plugins/dev/scripts/execution-core/install-lifecycle.test.mjs
+++ b/plugins/dev/scripts/execution-core/install-lifecycle.test.mjs
@@ -17,6 +17,8 @@ import {
   resolveScripts,
   resolveRequestedClass,
   resolveReadReplica,
+  setDeepKey,
+  deleteDeepKey,
   planPhases,
   runInstallLifecycle,
   buildDefaultDeps,
@@ -545,5 +547,19 @@ describe("invariants", () => {
   test("usage() names all three operations", () => {
     const u = usage();
     for (const op of ["install", "uninstall", "reinstall"]) expect(u).toContain(op);
+  });
+  test("setDeepKey / deleteDeepKey reject prototype-chain segments (prototype-pollution guard)", () => {
+    for (const bad of ["__proto__.polluted", "a.__proto__.x", "constructor.prototype.x", "a.prototype.b"]) {
+      expect(() => setDeepKey({}, bad, 1)).toThrow(/unsafe config key segment/);
+      expect(() => deleteDeepKey({}, bad)).toThrow(/unsafe config key segment/);
+    }
+    // Object.prototype is not polluted by a normal call
+    const o = {};
+    setDeepKey(o, "catalyst.node.class", "developer");
+    expect(o.catalyst.node.class).toBe("developer");
+    expect({}.polluted).toBeUndefined();
+  });
+  test("INSTALL_MANAGED_KEYS contains no unsafe segments", () => {
+    for (const k of INSTALL_MANAGED_KEYS) for (const seg of k.split(".")) expect(["__proto__", "prototype", "constructor"]).not.toContain(seg);
   });
 });

--- a/plugins/dev/scripts/execution-core/install-lifecycle.test.mjs
+++ b/plugins/dev/scripts/execution-core/install-lifecycle.test.mjs
@@ -148,8 +148,13 @@ describe("resolveRequestedClass", () => {
     expect(resolveRequestedClass({ env: { CATALYST_NODE_CLASS: "worker" } }).nodeClass).toBe("worker");
     expect(() => resolveRequestedClass({ env: { CATALYST_NODE_CLASS: "nope" } })).toThrow(/unrecognized CATALYST_NODE_CLASS/);
   });
-  test("falls back to the current configured class", () => {
+  test("falls back to the current configured class (injected currentFn)", () => {
     expect(resolveRequestedClass({ env: {}, currentFn: () => "monitor" }).nodeClass).toBe("monitor");
+  });
+  test("config fallback reads the class from the SELECTED layer2 file (consistent with the children, not getNodeClass)", () => {
+    expect(resolveRequestedClass({ env: {}, layer2: tmpCfg({ catalyst: { node: { class: "developer" } } }) }).nodeClass).toBe("developer");
+    expect(resolveRequestedClass({ env: {}, layer2: tmpCfg({}) }).nodeClass).toBe("worker"); // absent ⇒ worker
+    expect(() => resolveRequestedClass({ env: {}, layer2: tmpCfg({ catalyst: { node: { class: "develper" } } }) })).toThrow(/unrecognized node class in/);
   });
 });
 
@@ -195,6 +200,13 @@ describe("planPhases — per-class correctness (pure)", () => {
     expect(worker).not.toContain("read-replica");
     const devNoUrl = stepLabels(planPhases({ operation: "install", nodeClass: "developer", scripts: SCRIPTS }));
     expect(devNoUrl).not.toContain("read-replica");
+  });
+  test("worker install resets pluginPullOwner to broker; developer/monitor never do (adopt-updater owns it)", () => {
+    const wc = planPhases({ operation: "install", nodeClass: "worker", scripts: SCRIPTS }).find((p) => p.phase === "write-config");
+    const po = wc.steps.find((s) => s.label === "pull-owner");
+    expect(po).toMatchObject({ kind: "setkey", key: "catalyst.orchestration.pluginPullOwner", value: "broker" });
+    const devWc = planPhases({ operation: "install", nodeClass: "developer", scripts: SCRIPTS }).find((p) => p.phase === "write-config");
+    expect(devWc.steps.some((s) => s.label === "pull-owner")).toBe(false);
   });
   test("backup label carries operation + class", () => {
     const plan = planPhases({ operation: "install", nodeClass: "developer", scripts: SCRIPTS });
@@ -341,11 +353,13 @@ describe("runInstallLifecycle — uninstall", () => {
     const res = await runInstallLifecycle({ operation: "uninstall", nodeClass: "worker", opts: { force: true } }, deps);
     expect(res.cleanOk).toBe(true);
   });
-  test("verify-clean FAILS (cleanOk=false) when a residual agent survives — e.g. the updater on a developer node", async () => {
-    const { deps } = withRealRun(makeDeps({ residual: true }));
+  test("a dirty teardown (residual agent survives) → outcome failed + catalyst.install.failed telemetry", async () => {
+    const { deps, events } = withRealRun(makeDeps({ residual: true }));
     const res = await runInstallLifecycle({ operation: "uninstall", nodeClass: "developer", opts: { force: true } }, deps);
-    expect(res.outcome).toBe("completed");
+    expect(res.outcome).toBe("failed"); // NOT completed — a dirty teardown is a failure
     expect(res.cleanOk).toBe(false);
+    expect(events.at(-1).event).toBe("catalyst.install.failed");
+    expect(events.at(-1).detail.reason).toBe("dirty-teardown");
   });
 });
 
@@ -360,25 +374,36 @@ describe("runInstallLifecycle — reinstall", () => {
     expect(joined).toContain("STACK adopt-updater"); // provisioning
     for (const e of events) expect(e.operation).toBe("reinstall");
   });
-  test("reinstall fails BEFORE install-agents → rollback restores AND re-bootstraps the torn-down agents", async () => {
-    // Fail at write-config (setup-catalyst); teardown already booted out the agents. Rollback must
-    // restore + re-run install-agents/start-daemons so the node comes back up → rolled_back.
-    const { deps, calls } = withRealRun(makeDeps({ layer2Initial: { catalyst: { node: { class: "developer" } } }, failOn: (a) => (a.join(" ") === "SETUP --non-interactive" ? 1 : 0) }));
+  test("reinstall fails after teardown → rollback re-bootstraps to the RESTORED class (default worker), not the requested target", async () => {
+    // `reinstall --class developer` on an ORIGINAL default-worker node (no node.class) that captured
+    // agents; fail at write-config (before install-agents). After restore re-lays the classless config,
+    // re-bootstrap must bring up the WORKER stack (install-services), NOT the requested developer's
+    // adopt-updater — else the rolled-back worker loses its broker/exec-core.
+    const { deps, calls } = withRealRun(makeDeps({ bundleHadAgents: true, failOn: (a) => (a.join(" ") === "SETUP --non-interactive" ? 1 : 0) }));
     const res = await runInstallLifecycle({ operation: "reinstall", nodeClass: "developer", opts: { force: true } }, deps);
     expect(res.outcome).toBe("rolled_back");
     expect(res.rollbackDisposition).toBe("ok");
     const joined = calls.map((a) => a.join(" "));
-    expect(joined.some((c) => c.startsWith("BACKUP restore"))).toBe(true);
-    // re-bootstrap ran adopt-updater (developer install-agents) AFTER the restore
     const restoreIdx = joined.findIndex((c) => c.startsWith("BACKUP restore"));
-    const adoptIdx = joined.lastIndexOf("STACK adopt-updater");
-    expect(adoptIdx).toBeGreaterThan(restoreIdx);
+    expect(restoreIdx).toBeGreaterThanOrEqual(0);
+    expect(joined.lastIndexOf("STACK install-services")).toBeGreaterThan(restoreIdx); // worker re-bootstrap
+    expect(joined.some((c) => c === "STACK adopt-updater")).toBe(false); // NOT the requested developer
   });
   test("reinstall whose failure PERSISTS through re-bootstrap → outcome failed (honest, not a false rolled_back)", async () => {
-    const { deps } = withRealRun(makeDeps({ layer2Initial: { catalyst: { node: { class: "developer" } } }, failOn: (a) => (a.join(" ") === "STACK adopt-updater" ? 1 : 0) }));
-    const res = await runInstallLifecycle({ operation: "reinstall", nodeClass: "developer", opts: { force: true } }, deps);
-    expect(res.outcome).toBe("failed"); // adopt-updater fails in provisioning AND in re-bootstrap
+    // Worker reinstall, captured agents, install-services fails in BOTH provisioning and re-bootstrap.
+    const { deps } = withRealRun(makeDeps({ bundleHadAgents: true, failOn: (a) => (a.join(" ") === "STACK install-services" ? 1 : 0) }));
+    const res = await runInstallLifecycle({ operation: "reinstall", nodeClass: "worker", opts: { force: true } }, deps);
+    expect(res.outcome).toBe("failed");
     expect(res.rollbackDisposition).toBe("failed");
+  });
+  test("reinstall on a config-only node (no captured agents) → rollback restores WITHOUT re-bootstrapping agents", async () => {
+    const { deps, calls } = withRealRun(makeDeps({ bundleHadAgents: false, failOn: (a) => (a.join(" ") === "SETUP --non-interactive" ? 1 : 0) }));
+    const res = await runInstallLifecycle({ operation: "reinstall", nodeClass: "developer", opts: { force: true } }, deps);
+    expect(res.outcome).toBe("rolled_back");
+    const joined = calls.map((a) => a.join(" "));
+    const restoreIdx = joined.findIndex((c) => c.startsWith("BACKUP restore"));
+    // no agent bring-up after restore (the snapshot had none)
+    expect(joined.slice(restoreIdx + 1).some((c) => c === "STACK install-services" || c === "STACK adopt-updater")).toBe(false);
   });
 });
 

--- a/plugins/dev/scripts/execution-core/install-lifecycle.test.mjs
+++ b/plugins/dev/scripts/execution-core/install-lifecycle.test.mjs
@@ -59,7 +59,7 @@ const SCRIPTS = {
 
 // makeDeps — a fully-stubbed dep set. `failOn` is a predicate (argv|joined → truthy = fail with
 // that rc). `bundle` is the path catalyst-backup "prints". probeDaemons/probeDrained are flags.
-function makeDeps({ failOn, bundle = "/tmp/bundle-xyz", daemonsLive = false, residual = false, drained = false, bundleHadAgents = false, bundleEmpty = true, updaterAgent = false, missingBins = [], layer2Initial } = {}) {
+function makeDeps({ failOn, bundle = "/tmp/bundle-xyz", daemonsLive = false, residual = false, drained = false, bundleHadAgents = false, updaterAgent = false, workerAgents = false, cliInstalled = false, restorePluginDirs, missingBins = [], layer2Initial } = {}) {
   const events = [];
   const calls = [];
   const stepCalls = []; // {argv, env} per spawned step — lets tests assert the pinned step env
@@ -76,6 +76,14 @@ function makeDeps({ failOn, bundle = "/tmp/bundle-xyz", daemonsLive = false, res
       const rc = typeof failOn === "function" ? failOn(argv, joined) : 0;
       if (rc) return { code: rc, stdout: "", stderr: `stub fail ${joined}` };
       if (argv[0] === "BACKUP" && argv[1] === "backup") return { code: 0, stdout: `capturing…\n${bundle}\n`, stderr: "" };
+      if (argv[0] === "BACKUP" && argv[1] === "restore" && restorePluginDirs !== undefined) {
+        // simulate restore re-laying the captured (post-acquire) pluginDirs into the config
+        const cfg = JSON.parse(readFileSync(layer2, "utf8") || "{}");
+        cfg.catalyst = cfg.catalyst || {};
+        cfg.catalyst.orchestration = cfg.catalyst.orchestration || {};
+        cfg.catalyst.orchestration.pluginDirs = restorePluginDirs;
+        writeFileSync(layer2, JSON.stringify(cfg));
+      }
       return { code: 0, stdout: "", stderr: "" };
     },
     emit: (f) => events.push(f),
@@ -86,8 +94,9 @@ function makeDeps({ failOn, bundle = "/tmp/bundle-xyz", daemonsLive = false, res
     probeResidualAgents: () => residual,
     probeDrained: () => drained,
     bundleHasCapturedAgents: () => bundleHadAgents,
-    bundleIsEmpty: () => bundleEmpty,
     probeUpdaterAgent: () => updaterAgent,
+    probeWorkerAgents: () => workerAgents,
+    probeCliInstalled: () => cliInstalled,
     scriptExists: () => true,
     binExists: (name) => !missingBins.includes(name),
     log: () => {},
@@ -514,6 +523,46 @@ describe("fresh-node bootstrap + profile-switch guards (Codex round 5)", () => {
     expect(res.reason).toBe("live-worker-stack");
     expect(calls).toHaveLength(0);
   });
+  test("install --class developer over a STOPPED-but-installed worker stack also REFUSES", async () => {
+    const { deps } = withRealRun(makeDeps({ daemonsLive: false, workerAgents: true }));
+    const res = await runInstallLifecycle({ operation: "install", nodeClass: "developer", opts: {} }, deps);
+    expect(res.outcome).toBe("refused");
+    expect(res.reason).toBe("live-worker-stack");
+  });
+  test("live-agent rollback: a FAILED stop skips the restore (no --force over live daemons) → failed", async () => {
+    const { deps, calls } = withRealRun(makeDeps({ bundleHadAgents: true, daemonsLive: true, failOn: (a) => (["STACK install-services", "STACK stop"].includes(a.join(" ")) ? 1 : 0) }));
+    const res = await runInstallLifecycle({ operation: "install", nodeClass: "worker", opts: {} }, deps);
+    expect(res.outcome).toBe("failed");
+    expect(calls.some((a) => a[0] === "BACKUP" && a[1] === "restore")).toBe(false); // never restored over a live stack
+  });
+  test("live-agent rollback: a FAILED restart → incomplete rollback (outcome failed)", async () => {
+    const { deps } = withRealRun(makeDeps({ bundleHadAgents: true, daemonsLive: true, failOn: (a) => (["STACK install-services", "STACK start --yes"].includes(a.join(" ")) ? 1 : 0) }));
+    const res = await runInstallLifecycle({ operation: "install", nodeClass: "worker", opts: {} }, deps);
+    expect(res.outcome).toBe("failed"); // restore ok but the stack didn't come back up
+  });
+  test("live-agent rollback restarts with the RESTORED class env, not the requested target", async () => {
+    // reinstall --class developer over a worker whose stop didn't quiesce (daemonsLive stays true).
+    const { deps, stepCalls } = withRealRun(makeDeps({ bundleHadAgents: true, daemonsLive: true, layer2Initial: { catalyst: { node: { class: "worker" } } }, failOn: (a) => (a.join(" ") === "STACK adopt-updater" ? 1 : 0) }));
+    await runInstallLifecycle({ operation: "reinstall", nodeClass: "developer", opts: { force: true } }, deps);
+    const start = stepCalls.find((c) => c.argv.join(" ") === "STACK start --yes");
+    expect(start.env.CATALYST_NODE_CLASS).toBe("worker"); // restored class, NOT the requested developer
+  });
+  test("install rollback restores the node's prior pluginDirs that acquire overwrote", async () => {
+    // node had a custom pluginDirs; restore re-lays the post-acquire (canonical) value → rollback writes back custom.
+    const { deps, layer2 } = withRealRun(
+      makeDeps({
+        bundleHadAgents: false,
+        cliInstalled: true,
+        layer2Initial: { catalyst: { node: { class: "developer" }, orchestration: { pluginDirs: "/custom/checkout/plugins/dev" } } },
+        restorePluginDirs: "/canonical/plugin-source/plugins/dev",
+        failOn: (a) => (a.join(" ") === "STACK adopt-updater" ? 1 : 0),
+      }),
+    );
+    const res = await runInstallLifecycle({ operation: "install", nodeClass: "developer", opts: {} }, deps);
+    expect(res.outcome).toBe("rolled_back");
+    const cfg = JSON.parse(readFileSync(layer2, "utf8") || "{}");
+    expect(cfg.catalyst.orchestration.pluginDirs).toBe("/custom/checkout/plugins/dev"); // prior value restored
+  });
   test("install retry on a LIVE existing node STOPS the worker stack around the restore (no live-restore corruption)", async () => {
     const { deps, calls } = withRealRun(makeDeps({ bundleHadAgents: true, daemonsLive: true, failOn: (a) => (a.join(" ") === "STACK install-services" ? 1 : 0) }));
     const res = await runInstallLifecycle({ operation: "install", nodeClass: "worker", opts: {} }, deps);
@@ -524,7 +573,7 @@ describe("fresh-node bootstrap + profile-switch guards (Codex round 5)", () => {
     expect(joined.slice(restoreIdx + 1)).toContain("STACK start --yes"); // restarted after
   });
   test("fresh-node rollback (EMPTY backup) removes the install-managed config keys + uninstalls the CLI symlinks", async () => {
-    const { deps, calls, layer2 } = withRealRun(makeDeps({ bundleHadAgents: false, bundleEmpty: true, failOn: (a) => (a.join(" ") === "STACK install-services" ? 1 : 0) }));
+    const { deps, calls, layer2 } = withRealRun(makeDeps({ bundleHadAgents: false, cliInstalled: false, failOn: (a) => (a.join(" ") === "STACK install-services" ? 1 : 0) }));
     const res = await runInstallLifecycle({ operation: "install", nodeClass: "worker", opts: {} }, deps);
     expect(res.outcome).toBe("rolled_back");
     const joined = calls.map((a) => a.join(" "));
@@ -537,7 +586,7 @@ describe("fresh-node bootstrap + profile-switch guards (Codex round 5)", () => {
     // install (not reinstall) on a configured-but-daemonless developer node that fails; the backup
     // captured its config (non-empty) → restore re-lays it → rollback must NOT strip node.class.
     const initial = { catalyst: { node: { class: "developer" }, readReplica: { baseUrl: "http://mini:7400" } } };
-    const { deps, calls, layer2 } = withRealRun(makeDeps({ bundleHadAgents: false, bundleEmpty: false, layer2Initial: initial, failOn: (a) => (a.join(" ") === "STACK adopt-updater" ? 1 : 0) }));
+    const { deps, calls, layer2 } = withRealRun(makeDeps({ bundleHadAgents: false, cliInstalled: true, layer2Initial: initial, failOn: (a) => (a.join(" ") === "STACK adopt-updater" ? 1 : 0) }));
     const res = await runInstallLifecycle({ operation: "install", nodeClass: "developer", opts: {} }, deps);
     expect(res.outcome).toBe("rolled_back");
     const joined = calls.map((a) => a.join(" "));

--- a/plugins/dev/scripts/execution-core/install-lifecycle.test.mjs
+++ b/plugins/dev/scripts/execution-core/install-lifecycle.test.mjs
@@ -59,7 +59,7 @@ const SCRIPTS = {
 
 // makeDeps — a fully-stubbed dep set. `failOn` is a predicate (argv|joined → truthy = fail with
 // that rc). `bundle` is the path catalyst-backup "prints". probeDaemons/probeDrained are flags.
-function makeDeps({ failOn, bundle = "/tmp/bundle-xyz", daemonsLive = false, residual = false, drained = false, bundleHadAgents = false, updaterAgent = false, missingBins = [], layer2Initial } = {}) {
+function makeDeps({ failOn, bundle = "/tmp/bundle-xyz", daemonsLive = false, residual = false, drained = false, bundleHadAgents = false, bundleEmpty = true, updaterAgent = false, missingBins = [], layer2Initial } = {}) {
   const events = [];
   const calls = [];
   const stepCalls = []; // {argv, env} per spawned step — lets tests assert the pinned step env
@@ -86,6 +86,7 @@ function makeDeps({ failOn, bundle = "/tmp/bundle-xyz", daemonsLive = false, res
     probeResidualAgents: () => residual,
     probeDrained: () => drained,
     bundleHasCapturedAgents: () => bundleHadAgents,
+    bundleIsEmpty: () => bundleEmpty,
     probeUpdaterAgent: () => updaterAgent,
     scriptExists: () => true,
     binExists: (name) => !missingBins.includes(name),
@@ -522,8 +523,8 @@ describe("fresh-node bootstrap + profile-switch guards (Codex round 5)", () => {
     expect(joined.slice(0, restoreIdx)).toContain("STACK stop"); // stopped before restore
     expect(joined.slice(restoreIdx + 1)).toContain("STACK start --yes"); // restarted after
   });
-  test("fresh-node rollback removes the install-managed config keys + uninstalls the CLI symlinks", async () => {
-    const { deps, calls, layer2 } = withRealRun(makeDeps({ bundleHadAgents: false, failOn: (a) => (a.join(" ") === "STACK install-services" ? 1 : 0) }));
+  test("fresh-node rollback (EMPTY backup) removes the install-managed config keys + uninstalls the CLI symlinks", async () => {
+    const { deps, calls, layer2 } = withRealRun(makeDeps({ bundleHadAgents: false, bundleEmpty: true, failOn: (a) => (a.join(" ") === "STACK install-services" ? 1 : 0) }));
     const res = await runInstallLifecycle({ operation: "install", nodeClass: "worker", opts: {} }, deps);
     expect(res.outcome).toBe("rolled_back");
     const joined = calls.map((a) => a.join(" "));
@@ -531,6 +532,30 @@ describe("fresh-node bootstrap + profile-switch guards (Codex round 5)", () => {
     expect(joined.slice(restoreIdx + 1)).toContain("INSTALL_CLI --uninstall"); // symlinks removed
     const cfg = JSON.parse(readFileSync(layer2, "utf8") || "{}");
     expect(cfg.catalyst?.orchestration?.pluginPullOwner).toBeUndefined(); // managed key stripped
+  });
+  test("config-only daemonless install rollback (NON-empty backup) PRESERVES the node's saved settings", async () => {
+    // install (not reinstall) on a configured-but-daemonless developer node that fails; the backup
+    // captured its config (non-empty) → restore re-lays it → rollback must NOT strip node.class.
+    const initial = { catalyst: { node: { class: "developer" }, readReplica: { baseUrl: "http://mini:7400" } } };
+    const { deps, calls, layer2 } = withRealRun(makeDeps({ bundleHadAgents: false, bundleEmpty: false, layer2Initial: initial, failOn: (a) => (a.join(" ") === "STACK adopt-updater" ? 1 : 0) }));
+    const res = await runInstallLifecycle({ operation: "install", nodeClass: "developer", opts: {} }, deps);
+    expect(res.outcome).toBe("rolled_back");
+    const joined = calls.map((a) => a.join(" "));
+    expect(joined.some((c) => c === "INSTALL_CLI --uninstall")).toBe(false); // symlinks NOT removed
+    const cfg = JSON.parse(readFileSync(layer2, "utf8") || "{}");
+    expect(cfg.catalyst.node.class).toBe("developer"); // saved setting preserved
+    expect(cfg.catalyst.readReplica.baseUrl).toBe("http://mini:7400");
+  });
+  test("install retry on an existing developer node whose updater step backed out → rollback re-bootstraps the updater", async () => {
+    // hadAgents (updater plist captured), install (teardownRan=false), fail BEFORE install-agents so the
+    // re-bootstrap's adopt-updater succeeds and brings the updater back.
+    const initial = { catalyst: { node: { class: "developer" } } };
+    const { deps, calls } = withRealRun(makeDeps({ bundleHadAgents: true, layer2Initial: initial, failOn: (a) => (a.join(" ") === "SETUP --non-interactive" ? 1 : 0) }));
+    const res = await runInstallLifecycle({ operation: "install", nodeClass: "developer", opts: {} }, deps);
+    expect(res.outcome).toBe("rolled_back");
+    const joined = calls.map((a) => a.join(" "));
+    const restoreIdx = joined.findIndex((c) => c.startsWith("BACKUP restore"));
+    expect(joined.slice(restoreIdx + 1)).toContain("STACK adopt-updater"); // updater re-bootstrapped after restore
   });
 });
 
@@ -582,13 +607,12 @@ describe("rollback is a true reversal + partial-state telemetry", () => {
     expect(last.detail.rollback).toBe("failed"); // partial-state disposition in body
     expect(last.detail.bundle).toBe("/tmp/bundle-xyz"); // recovery pointer for the operator
   });
-  test("rollback does NOT tear down PRE-EXISTING agents (backup captured plists → retry on a working node)", async () => {
-    const { deps, calls } = withRealRun(makeDeps({ bundleHadAgents: true, failOn: (a) => (a.join(" ") === "STACK install-services" ? 3 : 0) }));
+  test("rollback on a working node with pre-existing agents NEVER boots them out (uninstall-services)", async () => {
+    const { deps, calls } = withRealRun(makeDeps({ bundleHadAgents: true, daemonsLive: true, failOn: (a) => (a.join(" ") === "STACK install-services" ? 3 : 0) }));
     const res = await runInstallLifecycle({ operation: "install", nodeClass: "worker", opts: {} }, deps);
     expect(res.outcome).toBe("rolled_back");
     const joined = calls.map((a) => a.join(" "));
-    expect(joined).not.toContain("STACK uninstall-services"); // pre-existing agents left in place
-    expect(joined).not.toContain("STACK stop");
+    expect(joined).not.toContain("STACK uninstall-services"); // pre-existing agents never torn down
     expect(joined.some((c) => c.startsWith("BACKUP restore"))).toBe(true); // still restored
   });
   test("a benign abort (backup fails) carries rollback disposition 'none' (distinguishable from partial-state)", async () => {

--- a/plugins/dev/scripts/execution-core/install-lifecycle.test.mjs
+++ b/plugins/dev/scripts/execution-core/install-lifecycle.test.mjs
@@ -1,0 +1,549 @@
+// install-lifecycle.test.mjs — CTL-1369 PR3. Pins the `catalyst install|uninstall|reinstall`
+// lifecycle driver: the PER-CLASS step plan (the core invariant — a developer never runs the
+// work stack; a worker never adopts the updater), the catalyst.install.* telemetry sequence it
+// drives, backup-before-overwrite, rollback-from-backup on a failed phase, idempotency, the
+// uninstall live-node guard, dry-run side-effect-freedom, and CLI exit codes. Every step shells
+// out through an injected runStep stub, so nothing real is provisioned.
+import { describe, test, expect, afterEach } from "bun:test";
+import { readFileSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { INSTALL_PHASES } from "./lib/install-telemetry.mjs";
+import {
+  UNINSTALL_PHASES,
+  REINSTALL_PHASES,
+  INSTALL_MANAGED_KEYS,
+  resolveScripts,
+  resolveRequestedClass,
+  resolveReadReplica,
+  planPhases,
+  runInstallLifecycle,
+  buildDefaultDeps,
+  parseArgs,
+  usage,
+  main,
+} from "./install-lifecycle.mjs";
+
+let tmpCounter = 0;
+const tmpFiles = [];
+function tmpCfg(initial) {
+  const p = join(tmpdir(), `install-lifecycle-test-${process.pid}-${tmpCounter++}.json`);
+  tmpFiles.push(p);
+  if (initial !== undefined) writeFileSync(p, JSON.stringify(initial, null, 2));
+  return p;
+}
+afterEach(() => {
+  for (const f of tmpFiles.splice(0)) {
+    try {
+      rmSync(f, { force: true });
+    } catch {
+      /* ignore */
+    }
+  }
+});
+
+// Stable stub script paths so plan argv is deterministic + greppable.
+const SCRIPTS = {
+  pluginSrc: "PLUGIN_SRC",
+  backup: "BACKUP",
+  catalyst: "CATALYST",
+  setup: "SETUP",
+  installCli: "INSTALL_CLI",
+  stack: "STACK",
+};
+
+// makeDeps — a fully-stubbed dep set. `failOn` is a predicate (argv|joined → truthy = fail with
+// that rc). `bundle` is the path catalyst-backup "prints". probeDaemons/probeDrained are flags.
+function makeDeps({ failOn, bundle = "/tmp/bundle-xyz", daemonsLive = false, residual = false, drained = false, layer2Initial } = {}) {
+  const events = [];
+  const calls = [];
+  const stepCalls = []; // {argv, env} per spawned step — lets tests assert the pinned step env
+  const layer2 = tmpCfg(layer2Initial);
+  let t = 0;
+  const deps = {
+    scripts: { ...SCRIPTS },
+    env: { CATALYST_ASSUME_NO_DAEMONS: "1" },
+    layer2,
+    runStep: ({ argv, env }) => {
+      calls.push(argv);
+      stepCalls.push({ argv, env: env || {} });
+      const joined = argv.join(" ");
+      const rc = typeof failOn === "function" ? failOn(argv, joined) : 0;
+      if (rc) return { code: rc, stdout: "", stderr: `stub fail ${joined}` };
+      if (argv[0] === "BACKUP" && argv[1] === "backup") return { code: 0, stdout: `capturing…\n${bundle}\n`, stderr: "" };
+      return { code: 0, stdout: "", stderr: "" };
+    },
+    emit: (f) => events.push(f),
+    nowFn: () => (t += 1000),
+    genTraceId: () => "trace0000000000000000000000000000",
+    genSpanId: () => "span000000000000",
+    probeDaemons: () => daemonsLive,
+    probeResidualAgents: () => residual,
+    probeDrained: () => drained,
+    scriptExists: () => true,
+    log: () => {},
+    InstallRunCtor: undefined, // filled below with the real InstallRun
+  };
+  return { deps, events, calls, stepCalls, layer2 };
+}
+
+// The real InstallRun must drive the real telemetry contract in these tests.
+import { InstallRun } from "./lib/install-telemetry.mjs";
+function withRealRun(bag) {
+  bag.deps.InstallRunCtor = InstallRun;
+  return bag;
+}
+
+const phaseNames = (plan) => plan.map((p) => p.phase);
+const stepLabels = (plan) => plan.flatMap((p) => p.steps.map((s) => s.label));
+const eventNames = (events) => events.map((e) => e.event);
+
+// ───────────────────────── parseArgs ─────────────────────────
+describe("parseArgs", () => {
+  test("first positional is the operation; flags parse", () => {
+    const a = parseArgs(["install", "--class", "developer", "--read-replica", "http://mini:7400", "--dry-run"]);
+    expect(a.operation).toBe("install");
+    expect(a.class).toBe("developer");
+    expect(a.readReplica).toBe("http://mini:7400");
+    expect(a.dryRun).toBe(true);
+  });
+  test("--class= and --read-replica= equals-forms", () => {
+    const a = parseArgs(["reinstall", "--class=worker", "--read-replica=http://h:7400"]);
+    expect(a.class).toBe("worker");
+    expect(a.readReplica).toBe("http://h:7400");
+  });
+  test("--print is an alias for --dry-run; --force/--json/-h flags", () => {
+    expect(parseArgs(["install", "--print"]).dryRun).toBe(true);
+    expect(parseArgs(["uninstall", "--force"]).force).toBe(true);
+    expect(parseArgs(["install", "--json"]).json).toBe(true);
+    expect(parseArgs(["-h"]).help).toBe(true);
+  });
+  test("unknown flags are ignored (forward-compat)", () => {
+    const a = parseArgs(["install", "--future-flag", "x"]);
+    expect(a.operation).toBe("install");
+  });
+});
+
+// ───────────────────────── resolveRequestedClass ─────────────────────────
+describe("resolveRequestedClass", () => {
+  test("explicit --class wins and normalizes case/space", () => {
+    expect(resolveRequestedClass({ optsClass: " Developer " }).nodeClass).toBe("developer");
+  });
+  test("explicit unrecognized class throws (the §3 footgun fix)", () => {
+    expect(() => resolveRequestedClass({ optsClass: "develper" })).toThrow(/unrecognized node class/);
+  });
+  test("CATALYST_NODE_CLASS env is used when no --class; invalid env throws", () => {
+    expect(resolveRequestedClass({ env: { CATALYST_NODE_CLASS: "worker" } }).nodeClass).toBe("worker");
+    expect(() => resolveRequestedClass({ env: { CATALYST_NODE_CLASS: "nope" } })).toThrow(/unrecognized CATALYST_NODE_CLASS/);
+  });
+  test("falls back to the current configured class", () => {
+    expect(resolveRequestedClass({ env: {}, currentFn: () => "monitor" }).nodeClass).toBe("monitor");
+  });
+});
+
+// ───────────────────────── planPhases: the per-class invariant ─────────────────────────
+describe("planPhases — per-class correctness (pure)", () => {
+  test("install/developer adopts the updater + drains; NEVER runs install-services", () => {
+    const plan = planPhases({ operation: "install", nodeClass: "developer", scripts: SCRIPTS });
+    const labels = stepLabels(plan);
+    expect(labels).toContain("adopt-updater");
+    expect(labels).not.toContain("install-services");
+    expect(labels).toContain("drain");
+    expect(labels).not.toContain("start-stack");
+  });
+  test("install/worker runs the full work stack; NEVER adopts the updater", () => {
+    const plan = planPhases({ operation: "install", nodeClass: "worker", scripts: SCRIPTS });
+    const labels = stepLabels(plan);
+    expect(labels).toContain("install-services");
+    expect(labels).not.toContain("adopt-updater");
+    expect(labels).toContain("start-stack");
+    expect(labels).not.toContain("drain");
+  });
+  test("install/monitor is developer-shaped (updater + drain, no work stack)", () => {
+    const labels = stepLabels(planPhases({ operation: "install", nodeClass: "monitor", scripts: SCRIPTS }));
+    expect(labels).toContain("adopt-updater");
+    expect(labels).not.toContain("install-services");
+  });
+  test("install phase order EXACTLY matches the OTEL-locked INSTALL_PHASES", () => {
+    expect(phaseNames(planPhases({ operation: "install", nodeClass: "worker", scripts: SCRIPTS }))).toEqual([...INSTALL_PHASES]);
+  });
+  test("uninstall / reinstall phase orders match their exported enums", () => {
+    expect(phaseNames(planPhases({ operation: "uninstall", nodeClass: "worker", scripts: SCRIPTS }))).toEqual([...UNINSTALL_PHASES]);
+    expect(phaseNames(planPhases({ operation: "reinstall", nodeClass: "developer", scripts: SCRIPTS }))).toEqual([...REINSTALL_PHASES]);
+  });
+  test("reinstall backs up exactly ONCE (one top-of-run snapshot covers teardown+provision)", () => {
+    const plan = planPhases({ operation: "reinstall", nodeClass: "worker", scripts: SCRIPTS });
+    expect(plan.filter((p) => p.phase === "backup")).toHaveLength(1);
+    expect(stepLabels(plan).filter((l) => l === "backup")).toHaveLength(1);
+  });
+  test("read-replica binds only for developer/monitor when supplied; never for worker", () => {
+    const dev = stepLabels(planPhases({ operation: "install", nodeClass: "developer", scripts: SCRIPTS, opts: { readReplica: "http://h:7400" } }));
+    expect(dev).toContain("read-replica");
+    const worker = stepLabels(planPhases({ operation: "install", nodeClass: "worker", scripts: SCRIPTS, opts: { readReplica: "http://h:7400" } }));
+    expect(worker).not.toContain("read-replica");
+    const devNoUrl = stepLabels(planPhases({ operation: "install", nodeClass: "developer", scripts: SCRIPTS }));
+    expect(devNoUrl).not.toContain("read-replica");
+  });
+  test("backup label carries operation + class", () => {
+    const plan = planPhases({ operation: "install", nodeClass: "developer", scripts: SCRIPTS });
+    const backupStep = plan.find((p) => p.phase === "backup").steps[0];
+    expect(backupStep.argv).toEqual(["BACKUP", "backup", "--label", "install-developer"]);
+  });
+  test("unknown operation throws", () => {
+    expect(() => planPhases({ operation: "frobnicate", nodeClass: "worker", scripts: SCRIPTS })).toThrow(/unknown operation/);
+  });
+});
+
+// ───────────────────────── runInstallLifecycle: telemetry + behavior ─────────────────────────
+describe("runInstallLifecycle — install happy path", () => {
+  test("developer: completes, healthy, emits started→6 phases→completed, captures bundle", async () => {
+    const { deps, events, calls } = withRealRun(makeDeps());
+    const res = await runInstallLifecycle({ operation: "install", nodeClass: "developer", opts: {} }, deps);
+    expect(res.outcome).toBe("completed");
+    expect(res.healthOk).toBe(true);
+    expect(res.bundlePath).toBe("/tmp/bundle-xyz");
+    // event sequence
+    expect(eventNames(events)[0]).toBe("catalyst.install.started");
+    expect(eventNames(events).at(-1)).toBe("catalyst.install.completed");
+    const phaseEvents = events.filter((e) => e.event === "catalyst.install.phase").map((e) => e.phase);
+    expect(phaseEvents).toEqual([...INSTALL_PHASES]);
+    // every event carries operation + node class + trace context
+    for (const e of events) {
+      expect(e.operation).toBe("install");
+      expect(e.nodeClass).toBe("developer");
+      expect(e.traceId).toBe("trace0000000000000000000000000000");
+    }
+    // composed the developer-correct steps
+    const joined = calls.map((a) => a.join(" "));
+    expect(joined).toContain("STACK adopt-updater");
+    expect(joined.some((c) => c.includes("install-services"))).toBe(false);
+  });
+
+  test("worker: runs install-services + start-stack, never adopt-updater", async () => {
+    const { deps, calls } = withRealRun(makeDeps());
+    const res = await runInstallLifecycle({ operation: "install", nodeClass: "worker", opts: {} }, deps);
+    expect(res.outcome).toBe("completed");
+    const joined = calls.map((a) => a.join(" "));
+    expect(joined).toContain("STACK install-services");
+    expect(joined).toContain("STACK start --yes");
+    expect(joined.some((c) => c.includes("adopt-updater"))).toBe(false);
+  });
+
+  test("read-replica setkey writes the Layer-2 file (developer)", async () => {
+    const { deps, layer2 } = withRealRun(makeDeps());
+    await runInstallLifecycle({ operation: "install", nodeClass: "developer", opts: { readReplica: "http://mini:7400" } }, deps);
+    const cfg = JSON.parse(readFileSync(layer2, "utf8"));
+    expect(cfg.catalyst.readReplica.baseUrl).toBe("http://mini:7400");
+  });
+});
+
+describe("runInstallLifecycle — failure handling", () => {
+  test("backup failure ABORTS before any overwrite, no rollback (nothing changed)", async () => {
+    const { deps, events, calls } = withRealRun(makeDeps({ failOn: (a) => (a[0] === "BACKUP" && a[1] === "backup" ? 1 : 0) }));
+    const res = await runInstallLifecycle({ operation: "install", nodeClass: "worker", opts: {} }, deps);
+    expect(res.outcome).toBe("failed");
+    expect(res.bundlePath).toBeNull();
+    // never reached write-config / install-agents
+    const joined = calls.map((a) => a.join(" "));
+    expect(joined.some((c) => c.includes("install-services"))).toBe(false);
+    expect(joined.some((c) => c.includes("restore"))).toBe(false); // no rollback attempt
+    expect(eventNames(events).at(-1)).toBe("catalyst.install.failed");
+  });
+
+  test("a failed provisioning phase ROLLS BACK from the captured bundle", async () => {
+    const { deps, events, calls } = withRealRun(makeDeps({ failOn: (a) => (a.join(" ") === "STACK install-services" ? 3 : 0) }));
+    const res = await runInstallLifecycle({ operation: "install", nodeClass: "worker", opts: {} }, deps);
+    expect(res.outcome).toBe("rolled_back");
+    const restore = calls.find((a) => a[0] === "BACKUP" && a[1] === "restore");
+    expect(restore).toEqual(["BACKUP", "restore", "/tmp/bundle-xyz", "--force"]);
+    expect(eventNames(events).at(-1)).toBe("catalyst.install.rolled_back");
+  });
+
+  test("an OPTIONAL step failure (drain) does not fail the run", async () => {
+    const { deps } = withRealRun(makeDeps({ failOn: (a) => (a.join(" ") === "CATALYST drain" ? 1 : 0) }));
+    const res = await runInstallLifecycle({ operation: "install", nodeClass: "developer", opts: {} }, deps);
+    expect(res.outcome).toBe("completed");
+  });
+
+  test("healthcheck failure is NON-fatal: completed but healthOk=false, no rollback", async () => {
+    const { deps, calls } = withRealRun(makeDeps({ failOn: (a) => (a.join(" ") === "STACK verify-node" ? 1 : 0) }));
+    const res = await runInstallLifecycle({ operation: "install", nodeClass: "developer", opts: {} }, deps);
+    expect(res.outcome).toBe("completed");
+    expect(res.healthOk).toBe(false);
+    expect(res.healthRc).toBe(1);
+    expect(calls.some((a) => a[1] === "restore")).toBe(false);
+  });
+});
+
+describe("runInstallLifecycle — idempotency", () => {
+  test("re-running install produces the identical step sequence (converges)", async () => {
+    const run1 = withRealRun(makeDeps());
+    await runInstallLifecycle({ operation: "install", nodeClass: "worker", opts: {} }, run1.deps);
+    const run2 = withRealRun(makeDeps());
+    await runInstallLifecycle({ operation: "install", nodeClass: "worker", opts: {} }, run2.deps);
+    const seq = (bag) => bag.calls.map((a) => a.join(" "));
+    expect(seq(run1)).toEqual(seq(run2));
+  });
+});
+
+describe("runInstallLifecycle — uninstall", () => {
+  test("REFUSES a live, non-drained node without --force (no run started)", async () => {
+    const { deps, events } = withRealRun(makeDeps({ daemonsLive: true, drained: false }));
+    const res = await runInstallLifecycle({ operation: "uninstall", nodeClass: "worker", opts: { force: false } }, deps);
+    expect(res.outcome).toBe("refused");
+    expect(events).toHaveLength(0); // never emitted a started event
+  });
+  test("proceeds on a live node when DRAINED", async () => {
+    const { deps } = withRealRun(makeDeps({ daemonsLive: true, drained: true }));
+    const res = await runInstallLifecycle({ operation: "uninstall", nodeClass: "worker", opts: { force: false } }, deps);
+    expect(res.outcome).toBe("completed");
+  });
+  test("proceeds on a live node with --force", async () => {
+    const { deps } = withRealRun(makeDeps({ daemonsLive: true, drained: false }));
+    const res = await runInstallLifecycle({ operation: "uninstall", nodeClass: "worker", opts: { force: true } }, deps);
+    expect(res.outcome).toBe("completed");
+  });
+  test("remove-config strips install-managed keys but PRESERVES secrets", async () => {
+    const initial = {
+      catalyst: {
+        node: { class: "developer" },
+        orchestration: { pluginPullOwner: "updater", pluginDirs: "/x/plugins/dev" },
+        readReplica: { baseUrl: "http://mini:7400" },
+        secretKeep: "KEEP-ME",
+      },
+    };
+    const { deps, layer2 } = withRealRun(makeDeps({ layer2Initial: initial }));
+    const res = await runInstallLifecycle({ operation: "uninstall", nodeClass: "developer", opts: {} }, deps);
+    expect(res.outcome).toBe("completed");
+    const cfg = JSON.parse(readFileSync(layer2, "utf8"));
+    // managed keys gone
+    expect(cfg.catalyst.node?.class).toBeUndefined();
+    expect(cfg.catalyst.orchestration?.pluginPullOwner).toBeUndefined();
+    expect(cfg.catalyst.readReplica?.baseUrl).toBeUndefined();
+    // secrets + unrelated keys preserved
+    expect(cfg.catalyst.secretKeep).toBe("KEEP-ME");
+    expect(cfg.catalyst.orchestration.pluginDirs).toBe("/x/plugins/dev");
+  });
+  test("verify-clean PASSES when no catalyst agents/daemons remain", async () => {
+    const { deps } = withRealRun(makeDeps({ residual: false }));
+    const res = await runInstallLifecycle({ operation: "uninstall", nodeClass: "worker", opts: { force: true } }, deps);
+    expect(res.cleanOk).toBe(true);
+  });
+  test("verify-clean FAILS (cleanOk=false) when a residual agent survives — e.g. the updater on a developer node", async () => {
+    const { deps } = withRealRun(makeDeps({ residual: true }));
+    const res = await runInstallLifecycle({ operation: "uninstall", nodeClass: "developer", opts: { force: true } }, deps);
+    expect(res.outcome).toBe("completed");
+    expect(res.cleanOk).toBe(false);
+  });
+});
+
+describe("runInstallLifecycle — reinstall", () => {
+  test("one backup, teardown THEN provisioning, operation=reinstall on every event", async () => {
+    const { deps, events, calls } = withRealRun(makeDeps({ daemonsLive: false }));
+    const res = await runInstallLifecycle({ operation: "reinstall", nodeClass: "developer", opts: { force: true } }, deps);
+    expect(res.outcome).toBe("completed");
+    const joined = calls.map((a) => a.join(" "));
+    expect(joined.filter((c) => c.startsWith("BACKUP backup"))).toHaveLength(1);
+    expect(joined).toContain("STACK uninstall-services"); // teardown
+    expect(joined).toContain("STACK adopt-updater"); // provisioning
+    for (const e of events) expect(e.operation).toBe("reinstall");
+  });
+  test("reinstall rolls back from the backup if provisioning fails after teardown", async () => {
+    const { deps, calls } = withRealRun(makeDeps({ daemonsLive: false, failOn: (a) => (a.join(" ") === "STACK adopt-updater" ? 1 : 0) }));
+    const res = await runInstallLifecycle({ operation: "reinstall", nodeClass: "developer", opts: { force: true } }, deps);
+    expect(res.outcome).toBe("rolled_back");
+    expect(calls.some((a) => a[1] === "restore")).toBe(true);
+  });
+});
+
+// ───────────────────────── adversarial-review remediations ─────────────────────────
+describe("node-class env pinning (composed tools cannot diverge from --class)", () => {
+  test("spawned steps inherit CATALYST_NODE_CLASS = resolved class, overriding a conflicting inherited env", async () => {
+    const bag = withRealRun(makeDeps());
+    bag.deps.env = { CATALYST_ASSUME_NO_DAEMONS: "1", CATALYST_NODE_CLASS: "worker" }; // operator shell exports worker
+    await runInstallLifecycle({ operation: "install", nodeClass: "developer", opts: {} }, bag.deps);
+    const adopt = bag.stepCalls.find((c) => c.argv.join(" ") === "STACK adopt-updater");
+    expect(adopt.env.CATALYST_NODE_CLASS).toBe("developer"); // the lifecycle's target, NOT the inherited worker
+    const verify = bag.stepCalls.find((c) => c.argv.join(" ") === "STACK verify-node");
+    expect(verify.env.CATALYST_NODE_CLASS).toBe("developer");
+  });
+});
+
+describe("script preflight (fail fast before backup/teardown)", () => {
+  test("refuses when a composed script is missing — no step ever runs (no backup taken)", async () => {
+    const bag = withRealRun(makeDeps());
+    bag.deps.scriptExists = (p) => p !== "SETUP"; // setup-catalyst.sh not found (cache-context)
+    const res = await runInstallLifecycle({ operation: "install", nodeClass: "worker", opts: {} }, bag.deps);
+    expect(res.outcome).toBe("refused");
+    expect(res.reason).toBe("missing-script");
+    expect(res.missing).toContain("SETUP");
+    expect(bag.calls).toHaveLength(0);
+  });
+  test("uninstall does NOT require setup-catalyst.sh (only the scripts its plan uses)", async () => {
+    const bag = withRealRun(makeDeps());
+    bag.deps.scriptExists = (p) => p !== "SETUP"; // setup missing, but uninstall never invokes it
+    const res = await runInstallLifecycle({ operation: "uninstall", nodeClass: "worker", opts: { force: true } }, bag.deps);
+    expect(res.outcome).toBe("completed");
+  });
+});
+
+describe("rollback is a true reversal + partial-state telemetry", () => {
+  test("a failed provisioning phase boots out provisioned agents + stops + restores", async () => {
+    const { deps, calls } = withRealRun(makeDeps({ failOn: (a) => (a.join(" ") === "STACK install-services" ? 3 : 0) }));
+    const res = await runInstallLifecycle({ operation: "install", nodeClass: "worker", opts: {} }, deps);
+    expect(res.outcome).toBe("rolled_back");
+    expect(res.rollbackDisposition).toBe("ok");
+    const joined = calls.map((a) => a.join(" "));
+    expect(joined).toContain("STACK uninstall-services"); // booted out the freshly-provisioned agents
+    expect(joined).toContain("STACK stop");
+    expect(joined.some((c) => c.startsWith("BACKUP restore"))).toBe(true);
+  });
+  test("rollback-FAILURE (restore non-zero) → outcome failed + partial-state stamped in the terminal event", async () => {
+    const { deps, events } = withRealRun(
+      makeDeps({
+        failOn: (a) => {
+          const j = a.join(" ");
+          if (j === "STACK install-services") return 3; // provisioning fails
+          if (a[0] === "BACKUP" && a[1] === "restore") return 1; // AND rollback restore fails
+          return 0;
+        },
+      }),
+    );
+    const res = await runInstallLifecycle({ operation: "install", nodeClass: "worker", opts: {} }, deps);
+    expect(res.outcome).toBe("failed"); // NOT rolled_back — restore did not succeed
+    expect(res.rollbackDisposition).toBe("failed");
+    const last = events.at(-1);
+    expect(last.event).toBe("catalyst.install.failed");
+    expect(last.detail.rollback).toBe("failed"); // partial-state disposition in body
+    expect(last.detail.bundle).toBe("/tmp/bundle-xyz"); // recovery pointer for the operator
+  });
+  test("a benign abort (backup fails) carries rollback disposition 'none' (distinguishable from partial-state)", async () => {
+    const { deps, events } = withRealRun(makeDeps({ failOn: (a) => (a[0] === "BACKUP" && a[1] === "backup" ? 1 : 0) }));
+    const res = await runInstallLifecycle({ operation: "install", nodeClass: "worker", opts: {} }, deps);
+    expect(res.outcome).toBe("failed");
+    expect(res.rollbackDisposition).toBe("none");
+    expect(events.at(-1).detail.rollback).toBe("none");
+  });
+});
+
+describe("read-replica resolution (reinstall must not drop it)", () => {
+  test("flag > env > current Layer-2 > null", () => {
+    expect(resolveReadReplica({ flag: "http://flag:7400", env: {}, layer2: tmpCfg({}) })).toBe("http://flag:7400");
+    expect(resolveReadReplica({ flag: null, env: { CATALYST_MONITOR_URL: "http://env:7400" }, layer2: tmpCfg({}) })).toBe("http://env:7400");
+    expect(resolveReadReplica({ flag: null, env: {}, layer2: tmpCfg({ catalyst: { readReplica: { baseUrl: "http://cfg:7400" } } }) })).toBe("http://cfg:7400");
+    expect(resolveReadReplica({ flag: null, env: {}, layer2: tmpCfg({}) })).toBeNull();
+  });
+});
+
+describe("default trace-context generators (locked W3C widths)", () => {
+  test("genTraceId is 32 hex chars, genSpanId is 16 hex chars", () => {
+    const d = buildDefaultDeps({});
+    expect(d.genTraceId()).toMatch(/^[0-9a-f]{32}$/);
+    expect(d.genSpanId()).toMatch(/^[0-9a-f]{16}$/);
+  });
+});
+
+// ───────────────────────── main: CLI exit codes ─────────────────────────
+describe("main — CLI exit codes", () => {
+  function capture(extra = {}) {
+    const out = [];
+    const errOut = [];
+    return {
+      out,
+      errOut,
+      depsOverride: { out: (m) => out.push(m), errOut: (m) => errOut.push(m), env: { CATALYST_ASSUME_NO_DAEMONS: "1" }, ...extra },
+    };
+  }
+
+  test("--help prints usage, exit 0", async () => {
+    const c = capture();
+    const code = await main(["--help"], c.depsOverride);
+    expect(code).toBe(0);
+    expect(c.out.join("\n")).toContain("catalyst-install");
+  });
+  test("no operation → exit 2", async () => {
+    const c = capture();
+    expect(await main([], c.depsOverride)).toBe(2);
+  });
+  test("invalid operation → exit 2", async () => {
+    const c = capture();
+    expect(await main(["frobnicate"], c.depsOverride)).toBe(2);
+  });
+  test("invalid --class → exit 2", async () => {
+    const c = capture();
+    expect(await main(["install", "--class", "nope"], c.depsOverride)).toBe(2);
+  });
+  test("--dry-run prints the plan and runs nothing → exit 0", async () => {
+    const c = capture();
+    const code = await main(["install", "--class", "developer", "--dry-run"], c.depsOverride);
+    expect(code).toBe(0);
+    const text = c.out.join("\n");
+    expect(text).toContain("dry-run");
+    expect(text).toContain("adopt-updater");
+    expect(text).not.toContain("install-services");
+  });
+
+  // Execute-path exit codes via full stub deps.
+  function execDeps(over = {}) {
+    const bag = withRealRun(makeDeps(over));
+    const out = [];
+    const errOut = [];
+    return { out, errOut, depsOverride: { ...bag.deps, out: (m) => out.push(m), errOut: (m) => errOut.push(m) }, bag };
+  }
+  test("completed + healthy → exit 0", async () => {
+    const d = execDeps();
+    expect(await main(["install", "--class", "developer"], d.depsOverride)).toBe(0);
+  });
+  test("completed + unhealthy verify-node → exit 1", async () => {
+    const d = execDeps({ failOn: (a) => (a.join(" ") === "STACK verify-node" ? 1 : 0) });
+    expect(await main(["install", "--class", "developer"], d.depsOverride)).toBe(1);
+  });
+  test("failed provisioning → exit 1", async () => {
+    const d = execDeps({ failOn: (a) => (a.join(" ") === "STACK adopt-updater" ? 1 : 0) });
+    expect(await main(["install", "--class", "developer"], d.depsOverride)).toBe(1);
+  });
+  test("refused live node → exit 2", async () => {
+    const d = execDeps({ daemonsLive: true, drained: false });
+    expect(await main(["uninstall"], d.depsOverride)).toBe(2);
+  });
+  test("teardown that left agents present (cleanOk=false) → exit 1 (not a silent success)", async () => {
+    const d = execDeps({ residual: true });
+    expect(await main(["uninstall", "--force"], d.depsOverride)).toBe(1);
+  });
+  test("reinstall WITHOUT --read-replica preserves the configured endpoint (no data loss, exit 0)", async () => {
+    const initial = { catalyst: { node: { class: "developer" }, readReplica: { baseUrl: "http://mini:7400" } } };
+    const d = execDeps({ layer2Initial: initial });
+    const code = await main(["reinstall", "--class", "developer", "--force"], d.depsOverride);
+    expect(code).toBe(0);
+    const cfg = JSON.parse(readFileSync(d.bag.layer2, "utf8"));
+    expect(cfg.catalyst.readReplica.baseUrl).toBe("http://mini:7400");
+  });
+});
+
+// ───────────────────────── seams + invariants ─────────────────────────
+describe("resolveScripts seams", () => {
+  test("env overrides win over computed defaults", () => {
+    const s = resolveScripts({ CATALYST_INSTALL_SETUP_SCRIPT: "/custom/setup.sh", CATALYST_INSTALL_STACK_BIN: "/custom/stack" });
+    expect(s.setup).toBe("/custom/setup.sh");
+    expect(s.stack).toBe("/custom/stack");
+  });
+  test("computed defaults resolve real toolchain paths", () => {
+    const s = resolveScripts({});
+    expect(s.installCli).toMatch(/install-cli\.sh$/);
+    expect(s.setup).toMatch(/setup-catalyst\.sh$/);
+    expect(s.backup).toMatch(/catalyst-backup$/);
+  });
+});
+
+describe("invariants", () => {
+  test("INSTALL_MANAGED_KEYS does not include any per-project secret file key", () => {
+    // The keys are dotted Layer-2 paths, never the config-<key>.json secret files.
+    for (const k of INSTALL_MANAGED_KEYS) expect(k).not.toMatch(/config-.*\.json/);
+    expect(INSTALL_MANAGED_KEYS).toContain("catalyst.node.class");
+  });
+  test("usage() names all three operations", () => {
+    const u = usage();
+    for (const op of ["install", "uninstall", "reinstall"]) expect(u).toContain(op);
+  });
+});

--- a/plugins/dev/scripts/execution-core/install-lifecycle.test.mjs
+++ b/plugins/dev/scripts/execution-core/install-lifecycle.test.mjs
@@ -183,13 +183,19 @@ describe("resolveRequestedClass", () => {
     writeFileSync(bad, "{ not valid json");
     expect(() => resolveRequestedClass({ env: {}, layer2: bad })).toThrow(/unreadable|malformed/);
   });
+  test("a present-but-non-string config class fails closed (no String() coercion to worker / bogus class)", () => {
+    expect(() => resolveRequestedClass({ env: {}, layer2: tmpCfg({ catalyst: { node: { class: [] } } }) })).toThrow(/malformed node class/);
+    expect(() => resolveRequestedClass({ env: {}, layer2: tmpCfg({ catalyst: { node: { class: ["developer"] } } }) })).toThrow(/malformed node class/);
+    expect(() => resolveRequestedClass({ env: {}, layer2: tmpCfg({ catalyst: { node: { class: 0 } } }) })).toThrow(/malformed node class/);
+  });
 });
 
 describe("isDrainedStatus (teardown guard requires zero in-flight, not just draining)", () => {
-  test("draining with zero in-flight ⇒ drained; with in-flight ⇒ not drained", () => {
+  test("draining with zero in-flight ⇒ drained; with in-flight or UNKNOWN count ⇒ not drained", () => {
     expect(isDrainedStatus({ draining: true, inFlightCount: 0 })).toBe(true);
     expect(isDrainedStatus({ draining: true, inFlightCount: 3 })).toBe(false); // work still landing
-    expect(isDrainedStatus({ draining: true })).toBe(true); // no count ⇒ treat as 0
+    expect(isDrainedStatus({ draining: true })).toBe(false); // MISSING count ⇒ unknown ⇒ fail closed
+    expect(isDrainedStatus({ draining: true, inflight: 0 })).toBe(true); // alternate key name
     expect(isDrainedStatus({ drained: true, inFlightCount: 5 })).toBe(true); // explicit sentinel wins
     expect(isDrainedStatus({ draining: false })).toBe(false);
     expect(isDrainedStatus(null)).toBe(false);
@@ -556,10 +562,11 @@ describe("fresh-node bootstrap + profile-switch guards (Codex round 5)", () => {
     const start = stepCalls.find((c) => c.argv.join(" ") === "STACK start --yes");
     expect(start.env.CATALYST_NODE_CLASS).toBe("worker"); // restored class, NOT the requested developer
   });
-  test("fresh-node rollback whose boot-out (cleanup) FAILS → incomplete rollback (outcome failed)", async () => {
-    const { deps } = withRealRun(makeDeps({ bundleHadAgents: false, failOn: (a) => (["STACK install-services", "STACK uninstall-services"].includes(a.join(" ")) ? 1 : 0) }));
+  test("fresh-node rollback whose boot-out (cleanup) FAILS → incomplete + SKIPS the restore (no --force over live daemons)", async () => {
+    const { deps, calls } = withRealRun(makeDeps({ bundleHadAgents: false, failOn: (a) => (["STACK install-services", "STACK uninstall-services"].includes(a.join(" ")) ? 1 : 0) }));
     const res = await runInstallLifecycle({ operation: "install", nodeClass: "worker", opts: {} }, deps);
-    expect(res.outcome).toBe("failed"); // restore may succeed but agents could still be running
+    expect(res.outcome).toBe("failed");
+    expect(calls.some((a) => a[0] === "BACKUP" && a[1] === "restore")).toBe(false); // never restored over possibly-live daemons
   });
   test("backup failing AFTER acquire repointed pluginDirs still restores the prior value (no bundle)", async () => {
     const { deps, layer2 } = withRealRun(

--- a/plugins/dev/scripts/execution-core/install-lifecycle.test.mjs
+++ b/plugins/dev/scripts/execution-core/install-lifecycle.test.mjs
@@ -16,6 +16,7 @@ import {
   INSTALL_MANAGED_KEYS,
   resolveScripts,
   layer2Path,
+  isDrainedStatus,
   resolveRequestedClass,
   resolveReadReplica,
   setDeepKey,
@@ -155,6 +156,23 @@ describe("resolveRequestedClass", () => {
     expect(resolveRequestedClass({ env: {}, layer2: tmpCfg({ catalyst: { node: { class: "developer" } } }) }).nodeClass).toBe("developer");
     expect(resolveRequestedClass({ env: {}, layer2: tmpCfg({}) }).nodeClass).toBe("worker"); // absent ⇒ worker
     expect(() => resolveRequestedClass({ env: {}, layer2: tmpCfg({ catalyst: { node: { class: "develper" } } }) })).toThrow(/unrecognized node class in/);
+  });
+  test("a MALFORMED config fails closed (does not silently default to worker)", () => {
+    const bad = join(tmpdir(), `install-lifecycle-bad-${process.pid}-${tmpCounter++}.json`);
+    tmpFiles.push(bad);
+    writeFileSync(bad, "{ not valid json");
+    expect(() => resolveRequestedClass({ env: {}, layer2: bad })).toThrow(/unreadable|malformed/);
+  });
+});
+
+describe("isDrainedStatus (teardown guard requires zero in-flight, not just draining)", () => {
+  test("draining with zero in-flight ⇒ drained; with in-flight ⇒ not drained", () => {
+    expect(isDrainedStatus({ draining: true, inFlightCount: 0 })).toBe(true);
+    expect(isDrainedStatus({ draining: true, inFlightCount: 3 })).toBe(false); // work still landing
+    expect(isDrainedStatus({ draining: true })).toBe(true); // no count ⇒ treat as 0
+    expect(isDrainedStatus({ drained: true, inFlightCount: 5 })).toBe(true); // explicit sentinel wins
+    expect(isDrainedStatus({ draining: false })).toBe(false);
+    expect(isDrainedStatus(null)).toBe(false);
   });
 });
 
@@ -396,7 +414,7 @@ describe("runInstallLifecycle — reinstall", () => {
     expect(res.outcome).toBe("failed");
     expect(res.rollbackDisposition).toBe("failed");
   });
-  test("reinstall on a config-only node (no captured agents) → rollback restores WITHOUT re-bootstrapping agents", async () => {
+  test("reinstall on a config-only node (no captured agents) failing BEFORE install-agents → restore, no re-bootstrap", async () => {
     const { deps, calls } = withRealRun(makeDeps({ bundleHadAgents: false, failOn: (a) => (a.join(" ") === "SETUP --non-interactive" ? 1 : 0) }));
     const res = await runInstallLifecycle({ operation: "reinstall", nodeClass: "developer", opts: { force: true } }, deps);
     expect(res.outcome).toBe("rolled_back");
@@ -404,6 +422,19 @@ describe("runInstallLifecycle — reinstall", () => {
     const restoreIdx = joined.findIndex((c) => c.startsWith("BACKUP restore"));
     // no agent bring-up after restore (the snapshot had none)
     expect(joined.slice(restoreIdx + 1).some((c) => c === "STACK install-services" || c === "STACK adopt-updater")).toBe(false);
+  });
+  test("reinstall on a config-only node that INSTALLS agents then fails → rollback boots out the newly-installed agents", async () => {
+    // worker reinstall, no captured agents, install-agents (install-services) succeeds, start fails.
+    const { deps, calls } = withRealRun(makeDeps({ bundleHadAgents: false, failOn: (a) => (a.join(" ") === "STACK start --yes" ? 1 : 0) }));
+    const res = await runInstallLifecycle({ operation: "reinstall", nodeClass: "worker", opts: { force: true } }, deps);
+    expect(res.outcome).toBe("rolled_back");
+    const joined = calls.map((a) => a.join(" "));
+    const provisionIdx = joined.lastIndexOf("STACK install-services");
+    const restoreIdx = joined.findIndex((c) => c.startsWith("BACKUP restore"));
+    expect(provisionIdx).toBeGreaterThanOrEqual(0); // provisioning installed the agents this run
+    // rollback booted them out (uninstall-services) AFTER provisioning, BEFORE restore
+    const bootedOut = joined.some((c, i) => c === "STACK uninstall-services" && i > provisionIdx && i < restoreIdx);
+    expect(bootedOut).toBe(true);
   });
 });
 

--- a/plugins/dev/scripts/execution-core/install-lifecycle.test.mjs
+++ b/plugins/dev/scripts/execution-core/install-lifecycle.test.mjs
@@ -548,16 +548,21 @@ describe("invariants", () => {
     const u = usage();
     for (const op of ["install", "uninstall", "reinstall"]) expect(u).toContain(op);
   });
-  test("setDeepKey / deleteDeepKey reject prototype-chain segments (prototype-pollution guard)", () => {
+  test("setDeepKey rejects prototype-chain segments (the pollution vector) and writes normal keys", () => {
+    // setDeepKey creates intermediates, so an unsafe segment anywhere in the path is always reached.
     for (const bad of ["__proto__.polluted", "a.__proto__.x", "constructor.prototype.x", "a.prototype.b"]) {
       expect(() => setDeepKey({}, bad, 1)).toThrow(/unsafe config key segment/);
-      expect(() => deleteDeepKey({}, bad)).toThrow(/unsafe config key segment/);
     }
-    // Object.prototype is not polluted by a normal call
+    expect({}.polluted).toBeUndefined(); // Object.prototype untouched
     const o = {};
     setDeepKey(o, "catalyst.node.class", "developer");
     expect(o.catalyst.node.class).toBe("developer");
-    expect({}.polluted).toBeUndefined();
+  });
+  test("deleteDeepKey refuses an unsafe segment when reached; safely no-ops an absent path", () => {
+    for (const bad of ["__proto__", "constructor.x", "__proto__.x"]) {
+      expect(() => deleteDeepKey({}, bad)).toThrow(/unsafe config key segment/);
+    }
+    expect(deleteDeepKey({}, "a.b.c")).toBe(false); // absent intermediate → safe no-op (no throw, no write)
   });
   test("INSTALL_MANAGED_KEYS contains no unsafe segments", () => {
     for (const k of INSTALL_MANAGED_KEYS) for (const seg of k.split(".")) expect(["__proto__", "prototype", "constructor"]).not.toContain(seg);

--- a/plugins/dev/scripts/execution-core/install-lifecycle.test.mjs
+++ b/plugins/dev/scripts/execution-core/install-lifecycle.test.mjs
@@ -204,6 +204,12 @@ describe("planPhases — per-class correctness (pure)", () => {
   test("install phase order EXACTLY matches the OTEL-locked INSTALL_PHASES", () => {
     expect(phaseNames(planPhases({ operation: "install", nodeClass: "worker", scripts: SCRIPTS }))).toEqual([...INSTALL_PHASES]);
   });
+  test("uninstall remove-agents reaps the log-shipper (a `stop` after the plist is removed)", () => {
+    const ra = planPhases({ operation: "uninstall", nodeClass: "worker", scripts: SCRIPTS }).find((p) => p.phase === "remove-agents");
+    const labels = ra.steps.map((s) => s.label);
+    expect(labels).toContain("reap-shipper");
+    expect(labels.indexOf("uninstall-services")).toBeLessThan(labels.indexOf("reap-shipper"));
+  });
   test("uninstall / reinstall phase orders match their exported enums", () => {
     expect(phaseNames(planPhases({ operation: "uninstall", nodeClass: "worker", scripts: SCRIPTS }))).toEqual([...UNINSTALL_PHASES]);
     expect(phaseNames(planPhases({ operation: "reinstall", nodeClass: "developer", scripts: SCRIPTS }))).toEqual([...REINSTALL_PHASES]);
@@ -499,6 +505,32 @@ describe("fresh-node bootstrap + profile-switch guards (Codex round 5)", () => {
     const joined = calls.map((a) => a.join(" "));
     const restoreIdx = joined.findIndex((c) => c.startsWith("BACKUP restore"));
     expect(joined.slice(restoreIdx + 1)).toContain("INSTALL_CLI"); // symlinks re-installed after restore
+  });
+  test("install --class developer over a LIVE worker stack REFUSES (mixed-profile guard)", async () => {
+    const { deps, calls } = withRealRun(makeDeps({ daemonsLive: true }));
+    const res = await runInstallLifecycle({ operation: "install", nodeClass: "developer", opts: {} }, deps);
+    expect(res.outcome).toBe("refused");
+    expect(res.reason).toBe("live-worker-stack");
+    expect(calls).toHaveLength(0);
+  });
+  test("install retry on a LIVE existing node STOPS the worker stack around the restore (no live-restore corruption)", async () => {
+    const { deps, calls } = withRealRun(makeDeps({ bundleHadAgents: true, daemonsLive: true, failOn: (a) => (a.join(" ") === "STACK install-services" ? 1 : 0) }));
+    const res = await runInstallLifecycle({ operation: "install", nodeClass: "worker", opts: {} }, deps);
+    expect(res.outcome).toBe("rolled_back");
+    const joined = calls.map((a) => a.join(" "));
+    const restoreIdx = joined.findIndex((c) => c.startsWith("BACKUP restore"));
+    expect(joined.slice(0, restoreIdx)).toContain("STACK stop"); // stopped before restore
+    expect(joined.slice(restoreIdx + 1)).toContain("STACK start --yes"); // restarted after
+  });
+  test("fresh-node rollback removes the install-managed config keys + uninstalls the CLI symlinks", async () => {
+    const { deps, calls, layer2 } = withRealRun(makeDeps({ bundleHadAgents: false, failOn: (a) => (a.join(" ") === "STACK install-services" ? 1 : 0) }));
+    const res = await runInstallLifecycle({ operation: "install", nodeClass: "worker", opts: {} }, deps);
+    expect(res.outcome).toBe("rolled_back");
+    const joined = calls.map((a) => a.join(" "));
+    const restoreIdx = joined.findIndex((c) => c.startsWith("BACKUP restore"));
+    expect(joined.slice(restoreIdx + 1)).toContain("INSTALL_CLI --uninstall"); // symlinks removed
+    const cfg = JSON.parse(readFileSync(layer2, "utf8") || "{}");
+    expect(cfg.catalyst?.orchestration?.pluginPullOwner).toBeUndefined(); // managed key stripped
   });
 });
 

--- a/plugins/dev/scripts/execution-core/install-lifecycle.test.mjs
+++ b/plugins/dev/scripts/execution-core/install-lifecycle.test.mjs
@@ -15,6 +15,7 @@ import {
   REINSTALL_PHASES,
   INSTALL_MANAGED_KEYS,
   resolveScripts,
+  layer2Path,
   resolveRequestedClass,
   resolveReadReplica,
   setDeepKey,
@@ -359,11 +360,25 @@ describe("runInstallLifecycle — reinstall", () => {
     expect(joined).toContain("STACK adopt-updater"); // provisioning
     for (const e of events) expect(e.operation).toBe("reinstall");
   });
-  test("reinstall rolls back from the backup if provisioning fails after teardown", async () => {
-    const { deps, calls } = withRealRun(makeDeps({ daemonsLive: false, failOn: (a) => (a.join(" ") === "STACK adopt-updater" ? 1 : 0) }));
+  test("reinstall fails BEFORE install-agents → rollback restores AND re-bootstraps the torn-down agents", async () => {
+    // Fail at write-config (setup-catalyst); teardown already booted out the agents. Rollback must
+    // restore + re-run install-agents/start-daemons so the node comes back up → rolled_back.
+    const { deps, calls } = withRealRun(makeDeps({ layer2Initial: { catalyst: { node: { class: "developer" } } }, failOn: (a) => (a.join(" ") === "SETUP --non-interactive" ? 1 : 0) }));
     const res = await runInstallLifecycle({ operation: "reinstall", nodeClass: "developer", opts: { force: true } }, deps);
     expect(res.outcome).toBe("rolled_back");
-    expect(calls.some((a) => a[1] === "restore")).toBe(true);
+    expect(res.rollbackDisposition).toBe("ok");
+    const joined = calls.map((a) => a.join(" "));
+    expect(joined.some((c) => c.startsWith("BACKUP restore"))).toBe(true);
+    // re-bootstrap ran adopt-updater (developer install-agents) AFTER the restore
+    const restoreIdx = joined.findIndex((c) => c.startsWith("BACKUP restore"));
+    const adoptIdx = joined.lastIndexOf("STACK adopt-updater");
+    expect(adoptIdx).toBeGreaterThan(restoreIdx);
+  });
+  test("reinstall whose failure PERSISTS through re-bootstrap → outcome failed (honest, not a false rolled_back)", async () => {
+    const { deps } = withRealRun(makeDeps({ layer2Initial: { catalyst: { node: { class: "developer" } } }, failOn: (a) => (a.join(" ") === "STACK adopt-updater" ? 1 : 0) }));
+    const res = await runInstallLifecycle({ operation: "reinstall", nodeClass: "developer", opts: { force: true } }, deps);
+    expect(res.outcome).toBe("failed"); // adopt-updater fails in provisioning AND in re-bootstrap
+    expect(res.rollbackDisposition).toBe("failed");
   });
 });
 
@@ -572,6 +587,11 @@ describe("resolveScripts seams", () => {
     expect(s.installCli).toMatch(/install-cli\.sh$/);
     expect(s.setup).toMatch(/setup-catalyst\.sh$/);
     expect(s.backup).toMatch(/catalyst-backup$/);
+  });
+  test("layer2Path honors CATALYST_LAYER2_CONFIG_FILE > CATALYST_MACHINE_CONFIG > XDG (no silent clobber)", () => {
+    expect(layer2Path({ CATALYST_LAYER2_CONFIG_FILE: "/a.json", CATALYST_MACHINE_CONFIG: "/b.json" })).toBe("/a.json");
+    expect(layer2Path({ CATALYST_MACHINE_CONFIG: "/b.json" })).toBe("/b.json");
+    expect(layer2Path({ XDG_CONFIG_HOME: "/xdg" })).toBe("/xdg/catalyst/config.json");
   });
 });
 

--- a/plugins/dev/scripts/execution-core/install-lifecycle.test.mjs
+++ b/plugins/dev/scripts/execution-core/install-lifecycle.test.mjs
@@ -59,7 +59,7 @@ const SCRIPTS = {
 
 // makeDeps — a fully-stubbed dep set. `failOn` is a predicate (argv|joined → truthy = fail with
 // that rc). `bundle` is the path catalyst-backup "prints". probeDaemons/probeDrained are flags.
-function makeDeps({ failOn, bundle = "/tmp/bundle-xyz", daemonsLive = false, residual = false, drained = false, bundleHadAgents = false, layer2Initial } = {}) {
+function makeDeps({ failOn, bundle = "/tmp/bundle-xyz", daemonsLive = false, residual = false, drained = false, bundleHadAgents = false, updaterAgent = false, missingBins = [], layer2Initial } = {}) {
   const events = [];
   const calls = [];
   const stepCalls = []; // {argv, env} per spawned step — lets tests assert the pinned step env
@@ -86,7 +86,9 @@ function makeDeps({ failOn, bundle = "/tmp/bundle-xyz", daemonsLive = false, res
     probeResidualAgents: () => residual,
     probeDrained: () => drained,
     bundleHasCapturedAgents: () => bundleHadAgents,
+    probeUpdaterAgent: () => updaterAgent,
     scriptExists: () => true,
+    binExists: (name) => !missingBins.includes(name),
     log: () => {},
     InstallRunCtor: undefined, // filled below with the real InstallRun
   };
@@ -456,6 +458,47 @@ describe("node-class env pinning (composed tools cannot diverge from --class)", 
       expect(c.env.CATALYST_LAYER2_CONFIG_FILE).toBe(bag.layer2);
       expect(c.env.CATALYST_MACHINE_CONFIG).toBe(bag.layer2);
     }
+  });
+});
+
+describe("fresh-node bootstrap + profile-switch guards (Codex round 5)", () => {
+  test("spawned steps get ~/.bun/bin + ~/.local/bin seeded on PATH (so a post-setup tool is found)", async () => {
+    const bag = withRealRun(makeDeps());
+    bag.deps.env = { CATALYST_ASSUME_NO_DAEMONS: "1", HOME: "/home/me", PATH: "/usr/bin" };
+    await runInstallLifecycle({ operation: "install", nodeClass: "developer", opts: {} }, bag.deps);
+    const adopt = bag.stepCalls.find((c) => c.argv.join(" ") === "STACK adopt-updater");
+    expect(adopt.env.PATH).toContain("/home/me/.bun/bin");
+    expect(adopt.env.PATH).toContain("/usr/bin"); // original PATH preserved at the end
+  });
+  test("refuses fast when a hard prerequisite (jq) is missing — before any step runs", async () => {
+    const bag = withRealRun(makeDeps({ missingBins: ["jq"] }));
+    const res = await runInstallLifecycle({ operation: "install", nodeClass: "worker", opts: {} }, bag.deps);
+    expect(res.outcome).toBe("refused");
+    expect(res.reason).toBe("missing-prereq");
+    expect(res.missing).toContain("jq");
+    expect(bag.calls).toHaveLength(0);
+  });
+  test("install --class worker REFUSES on a node with a stale updater agent (two-puller hazard) → use reinstall", async () => {
+    const bag = withRealRun(makeDeps({ updaterAgent: true }));
+    const res = await runInstallLifecycle({ operation: "install", nodeClass: "worker", opts: {} }, bag.deps);
+    expect(res.outcome).toBe("refused");
+    expect(res.reason).toBe("stale-updater");
+    expect(bag.calls).toHaveLength(0);
+  });
+  test("--force overrides the stale-updater guard; reinstall is never blocked by it", async () => {
+    const forced = withRealRun(makeDeps({ updaterAgent: true }));
+    expect((await runInstallLifecycle({ operation: "install", nodeClass: "worker", opts: { force: true } }, forced.deps)).outcome).toBe("completed");
+    const re = withRealRun(makeDeps({ updaterAgent: true }));
+    expect((await runInstallLifecycle({ operation: "reinstall", nodeClass: "worker", opts: { force: true } }, re.deps)).outcome).toBe("completed");
+  });
+  test("config-only reinstall rollback re-installs the CLI symlinks the teardown removed", async () => {
+    // bundleHadAgents:false (config-only), fail at write-config; teardown ran install-cli --uninstall.
+    const { deps, calls } = withRealRun(makeDeps({ bundleHadAgents: false, failOn: (a) => (a.join(" ") === "SETUP --non-interactive" ? 1 : 0) }));
+    const res = await runInstallLifecycle({ operation: "reinstall", nodeClass: "worker", opts: { force: true } }, deps);
+    expect(res.outcome).toBe("rolled_back");
+    const joined = calls.map((a) => a.join(" "));
+    const restoreIdx = joined.findIndex((c) => c.startsWith("BACKUP restore"));
+    expect(joined.slice(restoreIdx + 1)).toContain("INSTALL_CLI"); // symlinks re-installed after restore
   });
 });
 

--- a/plugins/dev/scripts/execution-core/install-lifecycle.test.mjs
+++ b/plugins/dev/scripts/execution-core/install-lifecycle.test.mjs
@@ -59,7 +59,7 @@ const SCRIPTS = {
 
 // makeDeps — a fully-stubbed dep set. `failOn` is a predicate (argv|joined → truthy = fail with
 // that rc). `bundle` is the path catalyst-backup "prints". probeDaemons/probeDrained are flags.
-function makeDeps({ failOn, bundle = "/tmp/bundle-xyz", daemonsLive = false, residual = false, drained = false, bundleHadAgents = false, updaterAgent = false, workerAgents = false, cliInstalled = false, restorePluginDirs, missingBins = [], layer2Initial } = {}) {
+function makeDeps({ failOn, bundle = "/tmp/bundle-xyz", daemonsLive = false, residual = false, drained = false, bundleHadAgents = false, updaterAgent = false, workerAgents = false, cliInstalled = false, restorePluginDirs, acquireWritesPluginDirs, missingBins = [], layer2Initial } = {}) {
   const events = [];
   const calls = [];
   const stepCalls = []; // {argv, env} per spawned step — lets tests assert the pinned step env
@@ -75,6 +75,14 @@ function makeDeps({ failOn, bundle = "/tmp/bundle-xyz", daemonsLive = false, res
       const joined = argv.join(" ");
       const rc = typeof failOn === "function" ? failOn(argv, joined) : 0;
       if (rc) return { code: rc, stdout: "", stderr: `stub fail ${joined}` };
+      if (argv[0] === "PLUGIN_SRC" && acquireWritesPluginDirs !== undefined) {
+        // simulate setup-plugin-source.sh repointing pluginDirs to the canonical checkout (pre-backup)
+        const cfg = JSON.parse(readFileSync(layer2, "utf8") || "{}");
+        cfg.catalyst = cfg.catalyst || {};
+        cfg.catalyst.orchestration = cfg.catalyst.orchestration || {};
+        cfg.catalyst.orchestration.pluginDirs = acquireWritesPluginDirs;
+        writeFileSync(layer2, JSON.stringify(cfg));
+      }
       if (argv[0] === "BACKUP" && argv[1] === "backup") return { code: 0, stdout: `capturing…\n${bundle}\n`, stderr: "" };
       if (argv[0] === "BACKUP" && argv[1] === "restore" && restorePluginDirs !== undefined) {
         // simulate restore re-laying the captured (post-acquire) pluginDirs into the config
@@ -483,6 +491,7 @@ describe("fresh-node bootstrap + profile-switch guards (Codex round 5)", () => {
     bag.deps.env = { CATALYST_ASSUME_NO_DAEMONS: "1", HOME: "/home/me", PATH: "/usr/bin" };
     await runInstallLifecycle({ operation: "install", nodeClass: "developer", opts: {} }, bag.deps);
     const adopt = bag.stepCalls.find((c) => c.argv.join(" ") === "STACK adopt-updater");
+    expect(adopt.env.PATH).toContain("/home/me/.catalyst/bin"); // CLI bin dir (just-installed symlinks)
     expect(adopt.env.PATH).toContain("/home/me/.bun/bin");
     expect(adopt.env.PATH).toContain("/usr/bin"); // original PATH preserved at the end
   });
@@ -546,6 +555,25 @@ describe("fresh-node bootstrap + profile-switch guards (Codex round 5)", () => {
     await runInstallLifecycle({ operation: "reinstall", nodeClass: "developer", opts: { force: true } }, deps);
     const start = stepCalls.find((c) => c.argv.join(" ") === "STACK start --yes");
     expect(start.env.CATALYST_NODE_CLASS).toBe("worker"); // restored class, NOT the requested developer
+  });
+  test("fresh-node rollback whose boot-out (cleanup) FAILS → incomplete rollback (outcome failed)", async () => {
+    const { deps } = withRealRun(makeDeps({ bundleHadAgents: false, failOn: (a) => (["STACK install-services", "STACK uninstall-services"].includes(a.join(" ")) ? 1 : 0) }));
+    const res = await runInstallLifecycle({ operation: "install", nodeClass: "worker", opts: {} }, deps);
+    expect(res.outcome).toBe("failed"); // restore may succeed but agents could still be running
+  });
+  test("backup failing AFTER acquire repointed pluginDirs still restores the prior value (no bundle)", async () => {
+    const { deps, layer2 } = withRealRun(
+      makeDeps({
+        layer2Initial: { catalyst: { orchestration: { pluginDirs: "/custom/checkout/plugins/dev" } } },
+        acquireWritesPluginDirs: "/canonical/plugin-source/plugins/dev",
+        failOn: (a) => (a[0] === "BACKUP" && a[1] === "backup" ? 1 : 0),
+      }),
+    );
+    const res = await runInstallLifecycle({ operation: "install", nodeClass: "worker", opts: {} }, deps);
+    expect(res.outcome).toBe("failed"); // backup abort (no rollback bundle)
+    expect(res.bundlePath).toBeNull();
+    const cfg = JSON.parse(readFileSync(layer2, "utf8") || "{}");
+    expect(cfg.catalyst.orchestration.pluginDirs).toBe("/custom/checkout/plugins/dev"); // prior value restored even without a bundle
   });
   test("install rollback restores the node's prior pluginDirs that acquire overwrote", async () => {
     // node had a custom pluginDirs; restore re-lays the post-acquire (canonical) value → rollback writes back custom.

--- a/plugins/dev/scripts/execution-core/lib/install-telemetry.mjs
+++ b/plugins/dev/scripts/execution-core/lib/install-telemetry.mjs
@@ -203,9 +203,12 @@ export class InstallRun {
     return this;
   }
 
-  // fail(err, {rolledBack}) — terminal event + trace for a failed run. rolledBack:true emits
-  // catalyst.install.rolled_back (+ an install.rollback span); else catalyst.install.failed.
-  fail(err, { rolledBack = false } = {}) {
+  // fail(err, {rolledBack, detail}) — terminal event + trace for a failed run. rolledBack:true emits
+  // catalyst.install.rolled_back (+ an install.rollback span); else catalyst.install.failed. `detail`
+  // merges extra HIGH-CARD body fields (e.g. rollback disposition + bundle path) so a partial-state
+  // node — provisioning failed AND rollback failed — is distinguishable from a benign safe-abort on a
+  // dashboard. These stay in body.payload, never on a label (the OTEL cardinality contract).
+  fail(err, { rolledBack = false, detail = null } = {}) {
     const endEpochMs = this.nowFn();
     const outcome = rolledBack ? "rolled_back" : "failed";
     const errMsg = err?.message ?? (err != null ? String(err) : null);
@@ -213,7 +216,7 @@ export class InstallRun {
       event: rolledBack ? INSTALL_EVENT.rolledBack : INSTALL_EVENT.failed,
       outcome,
       severity: "ERROR",
-      detail: { error: errMsg },
+      detail: { error: errMsg, ...(detail || {}) },
     });
     emitInstallTrace({
       operation: this.operation,

--- a/plugins/dev/scripts/install-cli.sh
+++ b/plugins/dev/scripts/install-cli.sh
@@ -57,6 +57,7 @@ CLI_ENTRIES=(
   "catalyst-stack:catalyst-stack"
   "catalyst-doctor:catalyst-doctor"
   "catalyst-backup:catalyst-backup"
+  "catalyst-install:catalyst-install"
   "catalyst:catalyst"
   "thoughts-pull-sync.sh:thoughts-pull-sync"
   "../hooks/emit-lifecycle-event.sh:emit-lifecycle-event"


### PR DESCRIPTION
## CTL-1369 PR 3/4 — the observable install lifecycle

Third PR of the umbrella **CTL-1369** ("observable install/uninstall/reinstall lifecycle"). Builds the `catalyst install | uninstall | reinstall` command per node class. Absorbs **CTL-1358**.

Composes on PR1 (`catalyst` router + `catalyst.install.*` telemetry contract, #2429) and PR2 (`catalyst-backup`, #2446).

### What it is
A **thin orchestrator** — it does NOT reimplement provisioning. It composes the existing setup scripts per class and drives the PR1 `InstallRun` telemetry so each run is an observable `catalyst.install.*` trace + event stream.

- `plugins/dev/scripts/execution-core/install-lifecycle.mjs` — the driver (injectable seams throughout).
- `plugins/dev/scripts/catalyst-install` — thin bash launcher (mirrors `catalyst-linear-reconcile`; the router already routes `catalyst install|uninstall|reinstall` → `catalyst-install <op>`).

### The per-class invariant (enforced by tests)
| class | daemons |
|---|---|
| **worker** | `catalyst-stack install-services` (broker/exec-core/monitor) — **never** `adopt-updater` |
| **developer / monitor** | `catalyst-stack adopt-updater` (5th updater agent, sole pull owner) + boot-drain — **never** broker/exec-core |

### Phases (OTEL-locked)
- **install**: `acquire → backup → write-config → install-agents → start-daemons → healthcheck`
- **uninstall**: `backup → stop-daemons → remove-agents → remove-config → verify-clean`
- **reinstall**: one backup, teardown, then provision (one root span, `operation=reinstall`)

### Safety
- **backup-before-overwrite** — aborts before any overwrite if `catalyst-backup` exits non-zero.
- **rollback = true reversal** — a failed provisioning phase boots out the just-provisioned agents + stops + restores from the bundle; a partial-state disposition is stamped into the terminal `catalyst.install.failed`/`rolled_back` event (body, not a label).
- **live-node guard** — uninstall/reinstall refuse a live, non-drained node without `--force`.
- **secrets preserved** — `remove-config` strips only install-managed Layer-2 keys (`node.class`, `pluginPullOwner`, `readReplica.baseUrl`); per-project `config-<key>.json` secrets are kept (and are in the backup), so reinstall doesn't re-prompt.
- **reinstall preserves the read-replica** (flag > env > current Layer-2).
- **`CATALYST_NODE_CLASS` pinned** for every composed step so the bash tools can't diverge from `--class`.
- **script preflight** — refuses fast (before any backup/teardown) if a composed script is missing (cache-context).
- **`--dry-run` / `--print`** — prints the resolved per-class plan with zero side effects.

### Tests & CI
- `install-lifecycle.test.mjs` (69 tests) added to the **execution-core CI allowlist** + an import-graph `bun build` check.
- `__tests__/catalyst-install.test.sh` (17 launcher/router smoke tests, shellcheck-clean).
- Registered in `install-cli.sh` (`CLI_ENTRIES`) + `check-setup.sh` (`CLI_NAMES`).

Built TDD, then hardened against a **6-lens adversarial-review workflow** (per-class / rollback / idempotency / uninstall-safety / telemetry / portability) — **11 confirmed findings all fixed**, incl. a HIGH (reinstall dropping the read-replica) and the rollback-reversal/partial-state-telemetry mediums.

Next: PR 4/4 — class-aware `catalyst-doctor` pre/post-install pass + OTEL dashboard/alert handoff, then CTL-1369 → Done.

🤖 Generated with [Claude Code](https://claude.com/claude-code)