### PR TITLE
fix(dev): CTL-1372 — serve orch-monitor as a production React build (root-cause leak fix)

### DIFF
--- a/plugins/dev/scripts/catalyst-monitor.sh
+++ b/plugins/dev/scripts/catalyst-monitor.sh
@@ -253,7 +253,16 @@ bootstrap() {
           # keep the previous (good) dist rather than swapping in a leaky bundle.
           if grep -rq "react-dom-client.development" "$_ui_stage" 2>/dev/null; then
             rm -rf "$_ui_stage"
-            echo "error: orch-monitor build produced a DEVELOPMENT React bundle (leaks memory via performance.measure) — keeping previous dist" >&2
+            # Fail-closed: if there is no known-good PRODUCTION dist to fall back to — a
+            # cold host with no prior build, or a prior dist that is itself the leaky dev
+            # bundle from the incident — we have nothing safe to serve, so abort rather
+            # than start a monitor that 404s or leaks. (With NODE_ENV=production pinned
+            # above, this branch should never fire; it is a backstop.)
+            if [[ ! -f "$MONITOR_UI_DIST_DIR/index.html" ]] || grep -rq "react-dom-client.development" "$MONITOR_UI_DIST_DIR" 2>/dev/null; then
+              echo "error: orch-monitor build produced a DEVELOPMENT React bundle and no known-good production dist exists — aborting start (rebuild with NODE_ENV=production)" >&2
+              exit 1
+            fi
+            echo "error: orch-monitor build produced a DEVELOPMENT React bundle (leaks memory via performance.measure) — keeping previous (production) dist" >&2
           else
             # Swap fresh build into place (drops ALL stale chunks); the static-asset copy
             # step below re-populates PWA manifest/sw/icons. mv is atomic on one filesystem.

--- a/plugins/dev/scripts/catalyst-monitor.sh
+++ b/plugins/dev/scripts/catalyst-monitor.sh
@@ -241,13 +241,27 @@ bootstrap() {
         # the build fails (preserving the warn-and-serve-previous behaviour below).
         _ui_stage="${MONITOR_UI_DIST_DIR%/}.staging.$$"
         rm -rf "$_ui_stage"
-        if (cd "$MONITOR_DIR/ui" && MONITOR_UI_DIST_DIR="$_ui_stage" bunx vite build); then
-          # Swap fresh build into place (drops ALL stale chunks); the static-asset copy
-          # step below re-populates PWA manifest/sw/icons. mv is atomic on one filesystem.
-          rm -rf "$MONITOR_UI_DIST_DIR"
-          mv "$_ui_stage" "$MONITOR_UI_DIST_DIR"
-          # Record the built source SHA ONLY on success so a failed build retries next start.
-          [[ -n "$ui_source_sha" ]] && printf '%s\n' "$ui_source_sha" > "$built_sha_file"
+        # CTL-1372: force a PRODUCTION React build. Without NODE_ENV=production, Vite
+        # resolves react-dom's `development` export — which calls performance.measure()
+        # on EVERY render — and the User Timing buffer is never cleared, leaking GBs over
+        # a long-lived PWA session (12 GB / 1.8M PerformanceMeasure entries observed). The
+        # build inherits whatever NODE_ENV the daemon was spawned with (no Catalyst code
+        # sets it; a dependency side effect can leave it "development"), so pin it here.
+        if (cd "$MONITOR_DIR/ui" && MONITOR_UI_DIST_DIR="$_ui_stage" NODE_ENV=production bunx vite build); then
+          # CTL-1372: refuse to serve a development react-dom bundle even if one is somehow
+          # produced — it is the memory-leak signature. Assert on the staged build; on a hit
+          # keep the previous (good) dist rather than swapping in a leaky bundle.
+          if grep -rq "react-dom-client.development" "$_ui_stage" 2>/dev/null; then
+            rm -rf "$_ui_stage"
+            echo "error: orch-monitor build produced a DEVELOPMENT React bundle (leaks memory via performance.measure) — keeping previous dist" >&2
+          else
+            # Swap fresh build into place (drops ALL stale chunks); the static-asset copy
+            # step below re-populates PWA manifest/sw/icons. mv is atomic on one filesystem.
+            rm -rf "$MONITOR_UI_DIST_DIR"
+            mv "$_ui_stage" "$MONITOR_UI_DIST_DIR"
+            # Record the built source SHA ONLY on success so a failed build retries next start.
+            [[ -n "$ui_source_sha" ]] && printf '%s\n' "$ui_source_sha" > "$built_sha_file"
+          fi
         else
           rm -rf "$_ui_stage"
           echo "warning: orch-monitor vite build failed — serving previous dist (will retry next restart)" >&2

--- a/plugins/dev/scripts/check-setup.sh
+++ b/plugins/dev/scripts/check-setup.sh
@@ -498,9 +498,12 @@ fi
 # Timing buffer → unbounded PerformanceMeasure growth (12 GB / 1.8M entries observed
 # in a long-lived PWA tab). The production build emits none. Sniff the served bundle.
 if (echo >/dev/tcp/localhost/"$MONITOR_PORT") 2>/dev/null && command -v curl &>/dev/null; then
-    _main_js=$(curl -s "http://localhost:$MONITOR_PORT/" 2>/dev/null | grep -oE '/assets/[A-Za-z0-9._-]+\.js' | head -1)
+    # `|| true`: a missing /assets match (older build / error page) must not abort the
+    # script under `set -euo pipefail`. `--max-time 3`: a stalled monitor must not hang
+    # the health check (matches the OTel probes above).
+    _main_js=$(curl -s --max-time 3 "http://localhost:$MONITOR_PORT/" 2>/dev/null | grep -oE '/assets/[A-Za-z0-9._-]+\.js' | head -1 || true)
     if [[ -n "$_main_js" ]]; then
-        if curl -s "http://localhost:$MONITOR_PORT$_main_js" 2>/dev/null | grep -q "react-dom-client.development"; then
+        if curl -s --max-time 3 "http://localhost:$MONITOR_PORT$_main_js" 2>/dev/null | grep -q "react-dom-client.development"; then
             fail "Monitor UI is a DEVELOPMENT React build — leaks memory via performance.measure()"
             info "Rebuild production: MONITOR_FORCE_BUILD=1 bash ${LAUNCHER:-plugins/dev/scripts/catalyst-monitor.sh} restart"
         else

--- a/plugins/dev/scripts/check-setup.sh
+++ b/plugins/dev/scripts/check-setup.sh
@@ -493,6 +493,22 @@ else
     fi
 fi
 
+# CTL-1372: verify the SERVED monitor UI is a PRODUCTION React build. A development
+# react-dom calls performance.measure() on every render and never clears the User
+# Timing buffer → unbounded PerformanceMeasure growth (12 GB / 1.8M entries observed
+# in a long-lived PWA tab). The production build emits none. Sniff the served bundle.
+if (echo >/dev/tcp/localhost/"$MONITOR_PORT") 2>/dev/null && command -v curl &>/dev/null; then
+    _main_js=$(curl -s "http://localhost:$MONITOR_PORT/" 2>/dev/null | grep -oE '/assets/[A-Za-z0-9._-]+\.js' | head -1)
+    if [[ -n "$_main_js" ]]; then
+        if curl -s "http://localhost:$MONITOR_PORT$_main_js" 2>/dev/null | grep -q "react-dom-client.development"; then
+            fail "Monitor UI is a DEVELOPMENT React build — leaks memory via performance.measure()"
+            info "Rebuild production: MONITOR_FORCE_BUILD=1 bash ${LAUNCHER:-plugins/dev/scripts/catalyst-monitor.sh} restart"
+        else
+            pass "Monitor UI is a production React build"
+        fi
+    fi
+fi
+
 # ─── 7b2. Log Shipper (Grafana Alloy) (optional) ───────────────────────────
 # CTL-1263: verify the off-the-shelf Alloy daemon-log shipper is installed +
 # configured + (best-effort) running, consistent with the other daemon checks.

--- a/plugins/dev/scripts/execution-core/doctor.mjs
+++ b/plugins/dev/scripts/execution-core/doctor.mjs
@@ -1946,6 +1946,45 @@ export async function checkReadReplicaReachable(deps = {}) {
   }
 }
 
+// ─── Monitor build hygiene (CTL-1372) ─────────────────────────────────────────
+// checkMonitorProductionBuild — flag a DEVELOPMENT react-dom bundle served by the
+// LOCAL monitor. A dev build calls performance.measure() on every render and never
+// clears the User Timing buffer, so PerformanceMeasure entries accumulate unbounded
+// in Blink's native buffer (12 GB / 1.8M entries observed in a long-lived PWA tab).
+// ADVISORY (never FAIL): a leaky monitor must not block the work daemon from
+// activating, but operators should see it. INFO-skips when no local monitor serves.
+export async function checkMonitorProductionBuild(deps = {}) {
+  const {
+    baseUrl = `http://localhost:${process.env.MONITOR_PORT || 7400}`,
+    fetch: _fetch = globalThis.fetch,
+  } = deps;
+  const base = (typeof baseUrl === "string" ? baseUrl : "").replace(/\/+$/, "");
+  const skip = (why) => [mkCheck("monitor-build", STATUS.INFO, why)];
+  try {
+    const rootRes = await _fetch(base + "/", { method: "GET", signal: AbortSignal.timeout(5000) });
+    if (!(rootRes?.ok ?? false)) return skip(`no local monitor serving at ${base} — skipping production-build check`);
+    const html = (await rootRes.text()) || "";
+    const asset = html.match(/\/assets\/[A-Za-z0-9._-]+\.js/);
+    if (!asset) return skip(`monitor at ${base} served no /assets bundle — skipping production-build check`);
+    const jsRes = await _fetch(base + asset[0], { method: "GET", signal: AbortSignal.timeout(5000) });
+    const js = (await jsRes.text()) || "";
+    if (js.includes("react-dom-client.development")) {
+      return [
+        mkCheck(
+          "monitor-build",
+          STATUS.WARN,
+          `local monitor serves a DEVELOPMENT React bundle (${asset[0]}) — it leaks memory via ` +
+            `performance.measure() per render and never clears the User Timing buffer (CTL-1372); ` +
+            `rebuild production: MONITOR_FORCE_BUILD=1 catalyst-monitor restart`,
+        ),
+      ];
+    }
+    return [mkCheck("monitor-build", STATUS.PASS, `local monitor is a production React build (${asset[0]})`)];
+  } catch (err) {
+    return skip(`local monitor at ${base} unreachable (${err?.message ?? err}) — skipping production-build check`);
+  }
+}
+
 // ─── Developer/monitor: "will NOT pick up work" (CTL-1355) ────────────────────
 
 // checkWontOwnWork — a developer/monitor MUST sit out of the work pipeline. The
@@ -2233,6 +2272,7 @@ export function checksForClass(nc, opts = {}) {
       replicaThunk,
       wontOwnThunk,
       () => checkReaper(), // advisory (never FAIL), class-agnostic
+      () => checkMonitorProductionBuild({ fetch: _fetch }), // CTL-1372: warn on a dev-build monitor (advisory)
       () => checkCloudTokenEnv(), // advisory
       () => checkConfigScopeLeak(), // advisory
     ];
@@ -2282,6 +2322,7 @@ export function checksForClass(nc, opts = {}) {
     () => checkSdkExecutorAuth(), // CTL-1367 item 9: under executor=sdk, subscription auth must be correct (no api-key metering)
     () => checkConfigScopeLeak(), // CTL-1214: committed Layer-1 .catalyst/config.json must not carry node/cluster scope (roster/orchestration/feedback/sweep/repoColors/hosts.json)
     () => checkRepoIconTokenScope(), // CTL-1375: monitor daemon's gh token can read configured private repos' contents (else favicons fall back to the org avatar) — advisory (never FAIL)
+    () => checkMonitorProductionBuild(), // CTL-1372: warn if the local monitor serves a dev-build React bundle (leaks via performance.measure) — advisory (never FAIL)
   ];
 }
 

--- a/plugins/dev/scripts/execution-core/doctor.test.mjs
+++ b/plugins/dev/scripts/execution-core/doctor.test.mjs
@@ -28,6 +28,7 @@ import {
   defaultConfiguredRepos,
   checkNodeClass,
   checkReadReplicaReachable,
+  checkMonitorProductionBuild,
   checkWontOwnWork,
   checkDaemonlessLocal,
   checksForClass,
@@ -1494,6 +1495,55 @@ describe("checkReadReplicaReachable (CTL-1355)", () => {
     });
     expect(checks[0].status).toBe(STATUS.FAIL);
     expect(checks[0].detail).toContain("ECONNREFUSED");
+  });
+});
+
+describe("checkMonitorProductionBuild (CTL-1372)", () => {
+  const htmlWithAsset = '<script type="module" src="/assets/main-abc123.js"></script>';
+  const servedFetch = (jsBody) => async (url) =>
+    url.endsWith(".js")
+      ? { ok: true, status: 200, text: async () => jsBody }
+      : { ok: true, status: 200, text: async () => htmlWithAsset };
+
+  it("PASSes a production bundle (no dev react-dom)", async () => {
+    const checks = await checkMonitorProductionBuild({
+      baseUrl: "http://localhost:7400",
+      fetch: servedFetch("var x=1;/* production */"),
+    });
+    expect(checks[0].name).toBe("monitor-build");
+    expect(checks[0].status).toBe(STATUS.PASS);
+  });
+
+  it("WARNs (never FAILs) when the served bundle is a development react-dom", async () => {
+    const checks = await checkMonitorProductionBuild({
+      baseUrl: "http://localhost:7400",
+      fetch: servedFetch("loaded react-dom-client.development chunk"),
+    });
+    expect(checks[0].status).toBe(STATUS.WARN);
+    expect(checks[0].detail).toContain("DEVELOPMENT");
+    expect(checks[0].detail).toContain("CTL-1372");
+  });
+
+  it("INFO-skips when no local monitor is serving (non-2xx root)", async () => {
+    const checks = await checkMonitorProductionBuild({
+      baseUrl: "http://localhost:7400",
+      fetch: async () => ({ ok: false, status: 502 }),
+    });
+    expect(checks[0].status).toBe(STATUS.INFO);
+  });
+
+  it("INFO-skips when the monitor is unreachable", async () => {
+    const checks = await checkMonitorProductionBuild({
+      baseUrl: "http://localhost:7400",
+      fetch: async () => {
+        throw new Error("ECONNREFUSED");
+      },
+    });
+    expect(checks[0].status).toBe(STATUS.INFO);
+  });
+
+  it("is wired into the worker + developer suites as an advisory check", () => {
+    expect(checksForClass.toString()).toContain("checkMonitorProductionBuild");
   });
 });
 

--- a/plugins/dev/scripts/orch-monitor/ui/src/components/app-shell.tsx
+++ b/plugins/dev/scripts/orch-monitor/ui/src/components/app-shell.tsx
@@ -182,6 +182,24 @@ export function AppShell({ children }: { children: React.ReactNode }) {
   // at rest and never shift layout.
   useEffect(() => installOverlayScroll(), []);
 
+  // CTL-1372: bound the User Timing buffer. The monitor is a long-lived PWA (runs
+  // for days); any performance.measure()/mark() emitter — e.g. a stray React dev
+  // build, which marks every render — accumulates PerformanceMeasure entries that
+  // are never GC'd (1.8M / 12 GB observed in a leaked tab). A production build emits
+  // ~none, so this is a cheap no-op there and a hard backstop if a dev bundle ships.
+  useEffect(() => {
+    const clear = () => {
+      try {
+        performance.clearMeasures();
+        performance.clearMarks();
+      } catch {
+        /* User Timing API unavailable — nothing to clear */
+      }
+    };
+    const id = window.setInterval(clear, 30_000);
+    return () => window.clearInterval(id);
+  }, []);
+
   // CTL-1025: surface jump + create actions, built once per navigate change.
   // Declared BEFORE the keydown effect below — that effect reads `surfaceActions`
   // in its dependency array, so the const must already be initialized. A later


### PR DESCRIPTION
## The leak, finally pinned

The orch-monitor PWA grew to **12 GB** over long sessions (the original CTL-1372 incident). A **live heap snapshot** of a leaking tab vs a healthy one settled it:

| | leaked tab | healthy tab |
|---|---|---|
| `PerformanceMeasure` objects | **1,801,615** | 6 |
| detached DOM nodes | **0** | 0 |

It was never detached DOM (CTL-1372's defensive caps in #2434 targeted the wrong surface). The 12 GB is **React 19's `performance.measure()` render instrumentation** accumulating in Chrome's User Timing buffer, which by spec is never auto-cleared. Those entries live in Blink's native `PerformanceEntry` buffer (PartitionAlloc) — which is why native tools showed "not V8, not GPU" memory and a fresh tab never reproduced it (needs hours of renders).

## Root cause

`react-dom-client.**development**` calls `performance.measure()` on every render; the **production** build has **zero** such calls. The live mini bundle (`/assets/main-*.js`) contained `react-dom-client.development` — i.e. **a development React build was deployed**. `catalyst-monitor.sh`'s `bunx vite build` inherited a stray `NODE_ENV=development` from the daemon's spawn environment (no Catalyst code sets it; it's a per-process side effect).

## The fix

- **`catalyst-monitor.sh`** — pin `NODE_ENV=production` on the vite build, and **refuse to swap in** a staged bundle that still contains `react-dom-client.development` (keep the previous good dist) → a self-verifying build, immune to ambient `NODE_ENV`.
- **`app-shell.tsx`** — periodic `performance.clearMeasures()/clearMarks()` backstop so any future stray emitter can never grow the buffer unbounded (a pure no-op on a production build).
- **`check-setup.sh`** — health check that sniffs the served bundle and **fails** if a development react-dom is being served.

## Verified

Built on mini with `NODE_ENV=production` → **no `react-dom-client.development`, 0 `performance.measure` calls**, clean 6.7s build. CI covers typecheck + the ui test suite.

## Deploy

After merge: `MONITOR_FORCE_BUILD=1 bash catalyst-monitor.sh restart` on mini + mini-2 to rebuild production and end the leak.

🤖 Generated with [Claude Code](https://claude.com/claude-code)