### PR TITLE
feat(dev): CTL-1383 — uniform -h/--help + bare-usage on user-facing catalyst-* CLIs

### DIFF
--- a/plugins/dev/scripts/__tests__/catalyst-events.test.sh
+++ b/plugins/dev/scripts/__tests__/catalyst-events.test.sh
@@ -57,10 +57,12 @@ write_event() {
 
 echo "catalyst-events tests"
 
-# ── 1. help exits 0 ─────────────────────────────────────────────────────────
-run "help exits 0 and prints usage" bash -c "
-  out=\$($EVENTS help 2>&1)
-  echo \"\$out\" | grep -q 'tail and wait-for'
+# ── 1. help exits 0 and prints a real usage block (CTL-1383 replaces the
+#       CTL-382 brittle phrase grep) ─────────────────────────────────────────
+run "help exits 0" expect_exit 0 "$EVENTS" help
+run "help names the tool and prints a usage block" bash -c "
+  out=\$($EVENTS help 2>&1) || exit 1
+  echo \"\$out\" | grep -q 'catalyst-events' && echo \"\$out\" | grep -q 'Usage:'
 "
 
 # ── 2. unknown subcommand exits 2 ───────────────────────────────────────────

--- a/plugins/dev/scripts/__tests__/cli-help-usage.test.sh
+++ b/plugins/dev/scripts/__tests__/cli-help-usage.test.sh
@@ -51,5 +51,24 @@ TMP="$(mktemp -d)"; ( cd "$TMP" && "${SCRIPTS}/workflow-context.sh" --help >/dev
 if [[ -e "$TMP/.catalyst" ]]; then fail "wc-dev --help does no work" ".catalyst created"; else ok "wc-dev --help does no work"; fi
 rm -rf "$TMP"
 
+# --- catalyst-why: -h/--help → stdout exit 0; bare → usage stderr exit 1 ---
+echo "catalyst-why"
+out="$("${SCRIPTS}/catalyst-why" --help 2>/dev/null)"; rc=$?
+expect_eq "why: --help exits 0" "0" "$rc"
+expect_contains "why: --help names the tool" "$out" "catalyst-why"
+expect_contains "why: --help has Usage block" "$out" "Usage:"
+out="$("${SCRIPTS}/catalyst-why" 2>&1 >/dev/null)"; rc=$?
+expect_ne "why: bare exits non-zero" "0" "$rc"
+expect_contains "why: bare prints usage to stderr" "$out" "Usage:"
+
+# --- catalyst-otel-forward: -h/--help only (bare = daemon, NOT tested) ---
+echo "catalyst-otel-forward"
+out="$("${SCRIPTS}/catalyst-otel-forward" --help 2>/dev/null)"; rc=$?
+expect_eq "otel: --help exits 0" "0" "$rc"
+expect_contains "otel: --help names the tool" "$out" "catalyst-otel-forward"
+expect_contains "otel: --help has Usage block" "$out" "Usage:"
+out="$("${SCRIPTS}/catalyst-otel-forward" -h 2>/dev/null)"; rc=$?
+expect_eq "otel: -h alias exits 0" "0" "$rc"
+
 echo; echo "RESULTS: $PASSES passed, $FAILURES failed"
 [[ "$FAILURES" -eq 0 ]]

--- a/plugins/dev/scripts/__tests__/cli-help-usage.test.sh
+++ b/plugins/dev/scripts/__tests__/cli-help-usage.test.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# CLI -h/--help + bare-usage contract (CTL-1383).
+# Run: bash plugins/dev/scripts/__tests__/cli-help-usage.test.sh
+set -uo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPTS="${SCRIPT_DIR}/.."                              # plugins/dev/scripts
+PMOPS_WC="${SCRIPTS}/../../pm-ops/scripts/workflow-context.sh"
+
+FAILURES=0; PASSES=0
+ok()   { PASSES=$((PASSES+1));  echo "  PASS: $1"; }
+fail() { FAILURES=$((FAILURES+1)); echo "  FAIL: $1"; echo "    $2"; }
+expect_eq()       { if [[ "$2" == "$3" ]]; then ok "$1"; else fail "$1" "expected '$2' got '$3'"; fi; }
+expect_ne()       { if [[ "$2" != "$3" ]]; then ok "$1"; else fail "$1" "expected != '$3'"; fi; }
+expect_contains() { if [[ "$2" == *"$3"* ]]; then ok "$1"; else fail "$1" "'$2' lacks '$3'"; fi; }
+
+# --- helper: assert the standard --help contract on a dispatcher ---
+assert_help_contract() {           # <label> <tool-name-substr> <script> [args...]
+  local label="$1" name="$2" script="$3"; shift 3
+  local out rc
+  out="$("$script" --help 2>/dev/null)"; rc=$?
+  expect_eq    "$label: --help exits 0"            "0" "$rc"
+  expect_contains "$label: --help names the tool"  "$out" "$name"
+  expect_contains "$label: --help has a Usage block" "$out" "Usage:"
+  out="$("$script" -h 2>/dev/null)"; rc=$?
+  expect_eq    "$label: -h alias exits 0"          "0" "$rc"
+  # bare → usage to stderr, non-zero
+  out="$("$script" 2>&1 >/dev/null)"; rc=$?
+  expect_ne    "$label: bare exits non-zero"       "0" "$rc"
+  expect_contains "$label: bare prints usage to stderr" "$out" "Usage:"
+  # unknown subcommand → non-zero + usage
+  out="$("$script" no-such-cmd 2>&1 >/dev/null)"; rc=$?
+  expect_ne    "$label: unknown exits non-zero"    "0" "$rc"
+  expect_contains "$label: unknown prints usage"   "$out" "Usage:"
+}
+
+echo "catalyst-broker";          assert_help_contract "broker"   "catalyst-broker"   "${SCRIPTS}/catalyst-broker"
+echo "catalyst-thoughts.sh";     assert_help_contract "thoughts" "catalyst-thoughts" "${SCRIPTS}/catalyst-thoughts.sh"
+echo "workflow-context (dev)";   assert_help_contract "wc-dev"   "workflow-context"  "${SCRIPTS}/workflow-context.sh"
+echo "workflow-context (pm-ops)";assert_help_contract "wc-pm"    "workflow-context"  "$PMOPS_WC"
+
+# dev copy advertises set-orchestration; pm-ops copy must NOT
+dev_help="$("${SCRIPTS}/workflow-context.sh" --help 2>/dev/null)"
+pm_help="$("$PMOPS_WC" --help 2>/dev/null)"
+expect_contains "wc-dev advertises set-orchestration" "$dev_help" "set-orchestration"
+if [[ "$pm_help" == *"set-orchestration"* ]]; then
+  fail "wc-pm omits set-orchestration" "pm-ops copy lists a subcommand it does not implement"
+else ok "wc-pm omits set-orchestration"; fi
+
+# "no work on --help": running --help in an empty cwd must not create .catalyst/
+TMP="$(mktemp -d)"; ( cd "$TMP" && "${SCRIPTS}/workflow-context.sh" --help >/dev/null 2>&1 )
+if [[ -e "$TMP/.catalyst" ]]; then fail "wc-dev --help does no work" ".catalyst created"; else ok "wc-dev --help does no work"; fi
+rm -rf "$TMP"
+
+echo; echo "RESULTS: $PASSES passed, $FAILURES failed"
+[[ "$FAILURES" -eq 0 ]]

--- a/plugins/dev/scripts/catalyst-broker
+++ b/plugins/dev/scripts/catalyst-broker
@@ -16,6 +16,27 @@
 
 set -uo pipefail
 
+print_help() {
+  cat <<'EOF'
+catalyst-broker — manage the Catalyst event broker daemon.
+
+Usage: catalyst-broker <command> [args]
+
+Commands:
+  start         Start broker daemon in background (idempotent)
+  stop          Stop broker daemon
+  restart       Stop then start
+  probe         Exit 0 if daemon responsive, non-zero otherwise (silent)
+  status        Print running/stopped + pid   [--json]
+  logs          Tail daemon log (follows)
+  run [args]    Run daemon in foreground (debugging)
+
+Options:
+  -h, --help    Show this help and exit
+  -V, --version Print version and exit
+EOF
+}
+
 # CTL-390: --version handling (early, before any arg parsing or stdin reads).
 case "${1:-}" in
   --version|-V)
@@ -30,6 +51,11 @@ case "${1:-}" in
     echo "error: catalyst-version helper missing at ${_CV_DIR}/lib/catalyst-version.sh" >&2
     exit 1
     ;;
+esac
+
+case "${1:-}" in
+  -h|--help|help) print_help; exit 0 ;;
+  "")             print_help >&2; exit 1 ;;
 esac
 
 CATALYST_DIR="${CATALYST_DIR:-$HOME/catalyst}"
@@ -174,7 +200,8 @@ case "${1:-}" in
   logs)    cmd_logs ;;
   run)     shift; cmd_run "$@" ;;
   *)
-    echo "Usage: catalyst-broker {start|stop|restart|probe|status|logs|run}" >&2
+    echo "error: unknown command: $1" >&2
+    print_help >&2
     exit 1
     ;;
 esac

--- a/plugins/dev/scripts/catalyst-otel-forward
+++ b/plugins/dev/scripts/catalyst-otel-forward
@@ -1,5 +1,28 @@
 #!/usr/bin/env bash
 # catalyst-otel-forward — entry wrapper for the otel-forward daemon
 set -euo pipefail
+
+print_help() {
+  cat <<'EOF'
+catalyst-otel-forward — tail the Catalyst event log and forward events to OTLP / PostHog /
+Cloudflare destinations (long-lived forwarder daemon).
+
+Usage: catalyst-otel-forward [options]
+
+Runs as a daemon with no subcommand. Destinations + behavior come from
+~/.config/catalyst/config-<project>.json (CATALYST_CONFIG_PATH overrides).
+
+Options:
+  -h, --help    Show this help and exit
+
+Environment:
+  CATALYST_DIR, CATALYST_EVENTS_DIR, CATALYST_CONFIG_PATH, CATALYST_PROJECT_KEY
+EOF
+}
+
+case "${1:-}" in
+  -h|--help|help) print_help; exit 0 ;;
+esac
+
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 exec bun run "${SCRIPT_DIR}/otel-forward/index.ts" "$@"

--- a/plugins/dev/scripts/catalyst-thoughts.sh
+++ b/plugins/dev/scripts/catalyst-thoughts.sh
@@ -18,6 +18,24 @@
 
 set -uo pipefail
 
+print_help() {
+  cat <<'EOF'
+catalyst-thoughts.sh — repair and verify the humanlayer thoughts system for a Catalyst project.
+
+Usage: catalyst-thoughts.sh <command>
+
+Commands:
+  init-or-repair   Create or repair thoughts/ for a Catalyst project. Re-uses humanlayer
+                   when configured; fails loudly if thoughts/shared exists as a regular
+                   directory (the symlink-clobbered bug state).
+  check            Verify thoughts/ state; non-zero on any broken state.
+
+Options:
+  -h, --help    Show this help and exit
+  -V, --version Print version and exit
+EOF
+}
+
 # CTL-390: --version handling (early, before any arg parsing or stdin reads).
 case "${1:-}" in
   --version|-V)
@@ -32,6 +50,11 @@ case "${1:-}" in
     echo "error: catalyst-version helper missing at ${_CV_DIR}/lib/catalyst-version.sh" >&2
     exit 1
     ;;
+esac
+
+case "${1:-}" in
+  -h|--help|help) print_help; exit 0 ;;
+  "")             print_help >&2; exit 1 ;;
 esac
 
 CMD="${1:-}"
@@ -203,15 +226,8 @@ case "$CMD" in
 	init-or-repair) cmd_init_or_repair "$@" ;;
 	check) cmd_check "$@" ;;
 	*)
-		cat >&2 <<EOF
-Usage: catalyst-thoughts.sh {init-or-repair|check}
-
-  init-or-repair   Create or repair thoughts/ for a Catalyst project.
-                   Re-uses humanlayer when configured; fails loudly if thoughts/shared
-                   exists as a regular directory (the symlink-clobbered bug state).
-
-  check            Verify thoughts/ state; non-zero on any broken state.
-EOF
-		exit 64
+		echo "error: unknown command: $CMD" >&2
+		print_help >&2
+		exit 1
 		;;
 esac

--- a/plugins/dev/scripts/catalyst-why
+++ b/plugins/dev/scripts/catalyst-why
@@ -34,6 +34,34 @@ case "${1:-}" in
     ;;
 esac
 
+print_help() {
+  cat <<'EOF'
+catalyst-why — explain why the daemon believes a worker is alive, stuck, or dead
+(the belief → rule → source-facts trace for a ticket).
+
+Usage:
+  catalyst-why <ticket> [--tick N] [--json]
+  catalyst why  <ticket> [--tick N] [--json]
+
+Arguments:
+  <ticket>        Linear ticket id (e.g. CTL-1383)
+
+Options:
+  --tick N        Trace a specific tick instead of the latest
+  --json          Emit the raw trace as JSON
+  -h, --help      Show this help and exit
+  -V, --version   Print version and exit
+
+Reads the read-only shadow belief store at
+${CATALYST_BELIEFS_DB:-$CATALYST_DIR/beliefs.db}. Never writes.
+EOF
+}
+
+case "${1:-}" in
+  -h|--help|help) print_help; exit 0 ;;
+  "")             print_help >&2; exit 1 ;;
+esac
+
 # Resolve this script's directory through symlinks.
 _SRC="${BASH_SOURCE[0]}"
 while [[ -L $_SRC ]]; do _SRC="$(readlink "$_SRC")"; done

--- a/plugins/dev/scripts/workflow-context.sh
+++ b/plugins/dev/scripts/workflow-context.sh
@@ -3,6 +3,27 @@
 
 set -euo pipefail
 
+print_help() {
+  cat <<'EOF'
+workflow-context.sh — manage the per-worktree workflow context (.catalyst/.workflow-context.json).
+
+Usage: workflow-context.sh <command> [args]
+
+Commands:
+  init                          Initialize the context file if absent
+  add <type> <path> [ticket]    Record a workflow document pointer
+  recent <type>                 Print recent documents of a type
+  most-recent                   Print the most recent document
+  set-ticket <ticket>           Set the current ticket
+  set-orchestration <json>      Set orchestration metadata
+  ticket <ticket>               Print documents for a ticket
+
+Options:
+  -h, --help    Show this help and exit
+  -V, --version Print version and exit
+EOF
+}
+
 # CTL-390: --version handling (early, before any arg parsing).
 case "${1:-}" in
   --version|-V)
@@ -17,6 +38,11 @@ case "${1:-}" in
     echo "error: catalyst-version helper missing at ${_CV_DIR}/lib/catalyst-version.sh" >&2
     exit 1
     ;;
+esac
+
+case "${1:-}" in
+  -h|--help|help) print_help; exit 0 ;;
+  "")             print_help >&2; exit 1 ;;
 esac
 
 # Resolve project root from git, then fall back to CWD
@@ -164,7 +190,8 @@ ticket)
 	get_by_ticket "$2"
 	;;
 *)
-	echo "Usage: $0 {init|add|recent|most-recent|set-ticket|set-orchestration|ticket}"
+	echo "error: unknown command: $1" >&2
+	print_help >&2
 	exit 1
 	;;
 esac

--- a/plugins/pm-ops/scripts/workflow-context.sh
+++ b/plugins/pm-ops/scripts/workflow-context.sh
@@ -3,6 +3,30 @@
 
 set -euo pipefail
 
+print_help() {
+  cat <<'EOF'
+workflow-context.sh — manage the per-worktree workflow context (.catalyst/.workflow-context.json).
+
+Usage: workflow-context.sh <command> [args]
+
+Commands:
+  init                          Initialize the context file if absent
+  add <type> <path> [ticket]    Record a workflow document pointer
+  recent <type>                 Print recent documents of a type
+  most-recent                   Print the most recent document
+  set-ticket <ticket>           Set the current ticket
+  ticket <ticket>               Print documents for a ticket
+
+Options:
+  -h, --help    Show this help and exit
+EOF
+}
+
+case "${1:-}" in
+  -h|--help|help) print_help; exit 0 ;;
+  "")             print_help >&2; exit 1 ;;
+esac
+
 # Primary: .catalyst/ — Fallback: .claude/ (deprecated)
 if [[ -f ".catalyst/.workflow-context.json" ]]; then
 	CONTEXT_FILE=".catalyst/.workflow-context.json"
@@ -121,7 +145,8 @@ ticket)
 	get_by_ticket "$2"
 	;;
 *)
-	echo "Usage: $0 {init|add|recent|most-recent|set-ticket|ticket}"
+	echo "error: unknown command: $1" >&2
+	print_help >&2
 	exit 1
 	;;
 esac


### PR DESCRIPTION
<!-- Auto-generated: 2026-06-29T12:49:40Z -->
<!-- Last updated: 2026-06-29T12:49:40Z -->
<!-- PR: #2459 -->
<!-- Previous commits: 61c7ef2ffa0e98ad39aeb61617fa836959000fca,2746e08e1b69a236907a38ed86af58756960e1a2,8f8d223d5a56a200b41fdd5ea6686ff3a3f0f94a -->

## Summary

Makes `-h`/`--help` a reliable, consistent way to learn any user-facing `catalyst-*` CLI. Most of the lifecycle surface already printed real usage, but ~6 user-facing tools (`catalyst-broker`, `catalyst-otel-forward`, `catalyst-thoughts`, `catalyst-why`, and `workflow-context` in both the dev and pm-ops plugins) either fell through to an unknown-command catch-all or only handled `--version` — so a coding agent running `<tool> --help` got inconsistent results.

This PR gives every one of those tools a uniform contract:

- `-h` / `--help` → prints a real usage block (names the tool, has a `Usage:` section) and exits `0`, doing no other work.
- bare invocation (no args) → prints usage to **stderr** and exits non-zero.
- unknown subcommand → prints usage and exits non-zero.

## Changes Made

**Help/usage contract on dispatchers (1/3, 2/3):**

- `catalyst-broker` — adds `-h`/`--help` + bare-usage handling.
- `catalyst-otel-forward` — adds `-h`/`--help` + usage block (exec passthrough wrapper).
- `catalyst-thoughts.sh` — adds `-h`/`--help` intercept + bare usage.
- `catalyst-why` — adds `-h`/`--help` + bare-usage handling.
- `workflow-context.sh` (plugins/dev) — adds the help contract; advertises `set-orchestration`.
- `workflow-context.sh` (plugins/pm-ops) — adds the help contract; omits the dev-only `set-orchestration` subcommand.

The `-h`/`--help` intercept is added on the exec-passthrough wrappers so help short-circuits **before** the passthrough exec, ensuring `--help` does no work.

**Tests (3/3):**

- New `plugins/dev/scripts/__tests__/cli-help-usage.test.sh` — 44 assertions covering the uniform contract (`--help` exits 0 / names the tool / has a Usage block, `-h` alias, bare exits non-zero + usage to stderr, unknown subcommand exits non-zero) across all touched tools, plus dev-vs-pm-ops subcommand differentiation.
- `plugins/dev/scripts/__tests__/catalyst-events.test.sh` — replaces the brittle CTL-382 phrase grep (`'tail and wait-for'`) with a structural assertion (exits 0, names the tool, has a `Usage:` block).

## How to Verify It

- [x] New CLI help/usage suite passes: `bash plugins/dev/scripts/__tests__/cli-help-usage.test.sh` — **44 passed, 0 failed** ✅
- [x] catalyst-events help assertion passes (the changed test #1) ✅
- [x] Manual: `<tool> --help` exits 0 and prints a Usage block; bare invocation prints usage to stderr and exits non-zero, for each touched tool ✅

_Note: `catalyst-events.test.sh` shows 3 pre-existing, environment/cwd-dependent failures at line 55 (temp-dir handling in `write_event`) that also fail on `origin/main` — unrelated to this change._

## Related Issues/PRs

- Fixes https://linear.app/coalesce-labs/issue/CTL-1383

Refs: CTL-1383
