### PR TITLE
fix(dev): CTL-1385 — board rows use wrong design tokens (bright dividers + selected-state bg)

### DIFF
--- a/plugins/dev/scripts/orch-monitor/ui/src/components/ui/table.tsx
+++ b/plugins/dev/scripts/orch-monitor/ui/src/components/ui/table.tsx
@@ -21,7 +21,7 @@ function TableHeader({ className, ...props }: React.ComponentProps<"thead">) {
   return (
     <thead
       data-slot="table-header"
-      className={cn("[&_tr]:border-b", className)}
+      className={cn("[&_tr]:border-b [&_tr]:border-border-subtle", className)}
       {...props}
     />
   )
@@ -55,7 +55,7 @@ function TableRow({ className, ...props }: React.ComponentProps<"tr">) {
     <tr
       data-slot="table-row"
       className={cn(
-        "border-b transition-colors hover:bg-muted/50 has-aria-expanded:bg-muted/50 data-[state=selected]:bg-muted",
+        "border-b border-border-subtle transition-colors hover:bg-surface-hover/40 has-aria-expanded:bg-surface-hover/40 data-[state=selected]:bg-surface-elevated",
         className
       )}
       {...props}


### PR DESCRIPTION
## Summary

- `TableRow` applied `border-b` without an explicit color class; in Tailwind v4 this falls back to `currentColor` (near-white text in dark) instead of `--border-subtle` (`rgba(255,255,255,0.07)`), producing harsh grid lines on every row
- `data-[state=selected]:bg-muted` mapped to `--color-muted` = `var(--fg-muted)` — a **text-role** color, not a surface — making the selected-row background a medium-gray blob with poor text legibility
- Same token mismatch on `hover:bg-muted/50`

**Fix** — one class-string change in the shared `TableRow` primitive (`ui/src/components/ui/table.tsx`):
- `border-border-subtle` → forces border to `--border-subtle` (7% white alpha in dark, hairline warm edge in light)
- `hover/has-aria-expanded:bg-surface-hover/40` → dedicated hover surface at 40% alpha
- `data-[state=selected]:bg-surface-elevated` → proper elevated surface tier for selection

Also added `[&_tr]:border-border-subtle` to the `TableHeader` wrapper.

## Test plan

- [x] Verified slate-dark: soft hairline dividers, clear selected-row elevation (`#39424f` vs `#181d24` canvas)
- [x] Verified slate-light: hairline warm edge, crisp white selected row
- [x] Verified warm-dark: subtle charcoal dividers, readable selected state
- [x] Verified warm-light: warm paper dividers, clean selected row
- [x] Deployed to mini, all four screenshots confirmed visually

Fixes CTL-1385.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TSaGy9jNUjiM7XMn6qwCAw