### PR TITLE
fix(dev): CTL-1382 — thin-launcher catalyst CLIs resolve their symlink before locating their driver

### DIFF
--- a/plugins/dev/scripts/catalyst-doctor
+++ b/plugins/dev/scripts/catalyst-doctor
@@ -10,7 +10,18 @@
 # --dry-run accepted (documented as default read-only behavior, no separate code path).
 set -uo pipefail
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# Resolve symlinks before deriving SCRIPT_DIR — install-cli.sh installs this as a symlink in the bin
+# dir (~/.catalyst/bin), so a bare dirname would point there and the execution-core/doctor.mjs lookup
+# would miss ("catalyst doctor: missing <bin>/execution-core/doctor.mjs"). Normalize each hop against
+# the symlink's own dir so a RELATIVE target resolves too (same idiom as catalyst / catalyst-install /
+# catalyst-backup).
+_SRC="${BASH_SOURCE[0]}"
+while [[ -L "$_SRC" ]]; do
+  _DIR="$(cd -P "$(dirname "$_SRC")" && pwd)"
+  _SRC="$(readlink "$_SRC")"
+  [[ "$_SRC" != /* ]] && _SRC="$_DIR/$_SRC"
+done
+SCRIPT_DIR="$(cd -P "$(dirname "$_SRC")" && pwd)"
 DOCTOR_MJS="${DOCTOR_MJS:-${SCRIPT_DIR}/execution-core/doctor.mjs}"
 
 # Resolve a JS runtime (bun preferred, node fallback) — matches sibling .mjs CLIs.

--- a/plugins/dev/scripts/catalyst-otel-forward
+++ b/plugins/dev/scripts/catalyst-otel-forward
@@ -24,5 +24,14 @@ case "${1:-}" in
   -h|--help|help) print_help; exit 0 ;;
 esac
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# Resolve symlinks before deriving SCRIPT_DIR — install-cli.sh installs this as a symlink in the bin
+# dir, so a bare dirname would point at ~/.catalyst/bin and miss otel-forward/index.ts. Normalize each
+# hop against the symlink's own dir so a RELATIVE target resolves too (same idiom as catalyst-install).
+_SRC="${BASH_SOURCE[0]}"
+while [[ -L "$_SRC" ]]; do
+  _DIR="$(cd -P "$(dirname "$_SRC")" && pwd)"
+  _SRC="$(readlink "$_SRC")"
+  [[ "$_SRC" != /* ]] && _SRC="$_DIR/$_SRC"
+done
+SCRIPT_DIR="$(cd -P "$(dirname "$_SRC")" && pwd)"
 exec bun run "${SCRIPT_DIR}/otel-forward/index.ts" "$@"

--- a/plugins/dev/scripts/catalyst-why
+++ b/plugins/dev/scripts/catalyst-why
@@ -62,11 +62,16 @@ case "${1:-}" in
   "")             print_help >&2; exit 1 ;;
 esac
 
-# Resolve this script's directory through symlinks.
+# Resolve this script's directory through symlinks. Normalize each hop against the symlink's own dir
+# so a RELATIVE target resolves too (canonical idiom shared with catalyst / catalyst-install).
 _SRC="${BASH_SOURCE[0]}"
-while [[ -L $_SRC ]]; do _SRC="$(readlink "$_SRC")"; done
-SCRIPT_DIR="$(cd "$(dirname "$_SRC")" && pwd)"
-unset _SRC
+while [[ -L $_SRC ]]; do
+  _DIR="$(cd -P "$(dirname "$_SRC")" && pwd)"
+  _SRC="$(readlink "$_SRC")"
+  [[ "$_SRC" != /* ]] && _SRC="$_DIR/$_SRC"
+done
+SCRIPT_DIR="$(cd -P "$(dirname "$_SRC")" && pwd)"
+unset _SRC _DIR
 
 WHY_SCRIPT="${SCRIPT_DIR}/execution-core/beliefs/why.mjs"
 


### PR DESCRIPTION
## CTL-1382 — `catalyst doctor` (and other thin launchers) broken via the installed symlink

**The bug you hit:** `catalyst doctor` → `catalyst doctor: missing ~/.catalyst/bin/execution-core/doctor.mjs`.

`catalyst-doctor` and `catalyst-otel-forward` derived `SCRIPT_DIR` from `BASH_SOURCE` **without resolving symlinks**, then looked for their `.mjs`/`.ts` driver relative to it. `install-cli.sh` installs each tool as a symlink in `~/.catalyst/bin`, so when invoked by name `SCRIPT_DIR` became the bin dir and the driver lookup missed.

## Fix
- **`catalyst-doctor`** + **`catalyst-otel-forward`**: add the canonical `readlink` resolution loop (shared with `catalyst` / `catalyst-install` / `catalyst-backup`) that normalizes each hop against the symlink's own dir, so **absolute and relative** symlink targets resolve to the real script dir.
- **`catalyst-why`**: hardened its existing loop to the same relative-target-safe idiom (it resolved symlinks but not relative targets).

`catalyst-why` already resolved symlinks (so it wasn't broken); the audit in CTL-1382 covered all three.

## Verification
`catalyst doctor` invoked through the `~/.catalyst/bin/catalyst-doctor` symlink now runs the full activation report (10 pass / 3 warn / 1 fail) instead of erroring. shellcheck clean (only an `SC1091` info on a sourced lib).

Found while fixing the related symlink-distribution gap (CTL-1381 — the updater doesn't re-run `install-cli` after a pull, so these newly-added tools were never symlinked on existing nodes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)