### PR TITLE
feat(dev): CTL-1369 (4/n) — class-aware doctor install verification + phase_duration_ms promotion

### DIFF
--- a/plugins/dev/scripts/execution-core/doctor.mjs
+++ b/plugins/dev/scripts/execution-core/doctor.mjs
@@ -1281,6 +1281,10 @@ Exit code equals the number of FAIL-level checks (0 = safe to activate).
 
 Options:
   --json                      Emit machine-readable JSON ({ok, counts, checks[]})
+  --profile <activation|install>  activation (default — the full class rubric) | install
+                              (the focused post-install verification: node-class + agent-set +
+                              pull-owner, fail-closed). 'catalyst install' runs --profile install.
+  --install                   Shorthand for --profile install
   --dry-run                   No-op flag (all checks are already read-only)
   --expected-bot-user-id <id> Assert that the configured token belongs to <id>
   --help, -h                  Print this help and exit 0
@@ -1292,17 +1296,25 @@ export function parseArgs(argv) {
   let json = false;
   let expectedBotUserId = null;
   let help = false;
+  // CTL-1369 PR4: "activation" (default) | "install" (the post-install verification subset).
+  let profile = "activation";
   // --dry-run is the default behavior (no separate code path); accept it silently
   for (let i = 0; i < args.length; i++) {
     const a = args[i];
     if (a === "--json") json = true;
     else if (a === "--dry-run") { /* default behavior; no-op */ }
     else if (a === "--help" || a === "-h") help = true;
-    else if (a === "--expected-bot-user-id") {
+    else if (a === "--install") profile = "install";
+    else if (a === "--profile") {
+      const v = args[++i];
+      // Only the two recognized profiles take effect; an unknown/missing value leaves the default
+      // "activation" (a typo must never silently weaken the gate to a smaller suite).
+      if (v === "install" || v === "activation") profile = v;
+    } else if (a === "--expected-bot-user-id") {
       expectedBotUserId = args[++i] ?? null;
     }
   }
-  return { json, expectedBotUserId, help };
+  return { json, expectedBotUserId, help, profile };
 }
 
 // defaultReaperState — load state + last exit of the orphan-sweep LaunchAgent.
@@ -2192,6 +2204,151 @@ export function checkDaemonlessLocal(deps = {}) {
   return out;
 }
 
+// ─── CTL-1369 PR4: install-correctness checks (agent-set + pull-owner per class) ──
+//
+// These two checks make `catalyst install` self-verifying: they assert the node ended up with the
+// CORRECT launchd agent SET and plugin-pull owner for its class — the heart of the per-class
+// invariant (catalyst-stack work-stack ⟺ worker; catalyst-updater + pluginPullOwner=updater ⟺
+// developer/monitor). A genuine class MISMATCH (the two-puller / mixed-profile hazard) is always a
+// FAIL. The `strict` flag governs only the NOT-YET-PROVISIONED case: in the always-on activation
+// rubric (strict:false) a missing agent / unset owner is a WARN (a fresh node legitimately has
+// neither, and catalyst-join's do_doctor_gate runs BEFORE install-services — a FAIL would fail-close
+// the join gate, the same trap checkReaper/checkConfigScopeLeak avoid). In the install-verification
+// profile (strict:true, run by `catalyst install` as its post-install pass) a missing agent / unset
+// owner is a FAIL — post-install the agents + owner MUST be correct or the install did not take.
+
+const STACK_AGENT_LABEL = "ai.coalesce.catalyst-stack"; // the worker work-stack supervisor (broker/exec-core/monitor)
+const UPDATER_AGENT_LABEL = "ai.coalesce.catalyst-updater"; // the 5th updater agent (sole puller) on developer/monitor
+
+function defaultLaunchAgentsDir() {
+  return process.env.CATALYST_LAUNCHAGENTS_DIR || resolve(homedir(), "Library", "LaunchAgents");
+}
+
+// defaultAgentInstalled — is the launchd plist for <label> present? Deterministic file probe
+// (mirrors install-lifecycle.mjs defaultProbeWorkerAgents/defaultProbeUpdaterAgent). Honors
+// CATALYST_LAUNCHAGENTS_DIR for sandbox tests.
+function defaultAgentInstalled(label, dir = defaultLaunchAgentsDir()) {
+  try {
+    return existsSync(resolve(dir, `${label}.plist`));
+  } catch {
+    return false;
+  }
+}
+
+// checkAgentsForClass — assert the correct launchd agent SET for the class. The two discriminators
+// are the worker stack agent and the developer/monitor updater agent; their PRESENCE is mutually
+// exclusive (a node running both is the CTL-1348 two-puller hazard). Injectable for tests.
+export function checkAgentsForClass(deps = {}) {
+  const {
+    nodeClass,
+    strict = false,
+    hasStackAgent = defaultAgentInstalled(STACK_AGENT_LABEL),
+    hasUpdaterAgent = defaultAgentInstalled(UPDATER_AGENT_LABEL),
+  } = deps;
+
+  if (nodeClass === "worker") {
+    // A worker's broker owns the pull; the updater agent must NOT be present (two-puller race).
+    if (hasUpdaterAgent) {
+      return [
+        mkCheck(
+          "agents-for-class",
+          STATUS.FAIL,
+          `worker node has the developer/monitor updater agent (${UPDATER_AGENT_LABEL}) installed — ` +
+            `the two-puller hazard (the broker AND the updater would both pull the plugin checkout). ` +
+            `Run 'catalyst reinstall --class worker' (its teardown removes the updater) or 'catalyst-stack uninstall-services'`,
+        ),
+      ];
+    }
+    if (hasStackAgent) {
+      return [mkCheck("agents-for-class", STATUS.PASS, `worker work-stack agent (${STACK_AGENT_LABEL}) installed; no updater agent (correct for class=worker)`)];
+    }
+    return [
+      mkCheck(
+        "agents-for-class",
+        strict ? STATUS.FAIL : STATUS.WARN,
+        `no worker work-stack agent (${STACK_AGENT_LABEL}) installed — this node is not yet provisioned as a worker; run 'catalyst install --class worker'`,
+      ),
+    ];
+  }
+
+  // developer / monitor: the updater agent is the sole puller; the worker stack must NOT be present.
+  if (hasStackAgent) {
+    return [
+      mkCheck(
+        "agents-for-class",
+        STATUS.FAIL,
+        `${nodeClass} node has the worker work-stack agent (${STACK_AGENT_LABEL}) installed — a developer/monitor must NOT run ` +
+          `the broker/execution-core (it would pick up work). Run 'catalyst reinstall --class ${nodeClass}' (its teardown removes the worker stack)`,
+      ),
+    ];
+  }
+  if (hasUpdaterAgent) {
+    return [mkCheck("agents-for-class", STATUS.PASS, `updater agent (${UPDATER_AGENT_LABEL}) installed; no worker work-stack agent (correct for class=${nodeClass})`)];
+  }
+  return [
+    mkCheck(
+      "agents-for-class",
+      strict ? STATUS.FAIL : STATUS.WARN,
+      `no updater agent (${UPDATER_AGENT_LABEL}) installed — this ${nodeClass} node has no plugin-freshness puller; run 'catalyst install --class ${nodeClass}' (or 'catalyst-stack adopt-updater')`,
+    ),
+  ];
+}
+
+// defaultPluginPullOwner — which process owns the plugin pull on this node: "broker" (default) or
+// "updater". MIRRORS broker/plugin-refresh.mjs::resolvePluginPullOwner (env CATALYST_PLUGIN_PULL_OWNER
+// → Layer-2 catalyst.orchestration.pluginPullOwner → default "broker"; any non-"updater" value
+// coerces to "broker"). Inlined — like readLinearBotUserIds above — to keep doctor's runtime dep
+// surface minimal (doctor runs under bare `node`); a parity test pins it to the canonical resolver.
+function defaultPluginPullOwner(env = process.env) {
+  const coerce = (v) => (typeof v === "string" && v.trim() === "updater" ? "updater" : "broker");
+  const fromEnv = env.CATALYST_PLUGIN_PULL_OWNER;
+  if (typeof fromEnv === "string" && fromEnv.trim().length > 0) return coerce(fromEnv);
+  try {
+    const v = JSON.parse(readFileSync(layer2Path(), "utf8"))?.catalyst?.orchestration?.pluginPullOwner;
+    if (typeof v === "string" && v.trim().length > 0) return coerce(v);
+  } catch {
+    /* unreadable/malformed Layer-2 → fail safe to broker (matches resolvePluginPullOwner) */
+  }
+  return "broker";
+}
+
+// checkPluginPullOwner — assert pluginPullOwner is sane for the class. worker → broker (its broker
+// pulls); developer/monitor → updater (the standalone updater agent pulls; the node runs no broker).
+// A class MISMATCH is always a FAIL. For a developer/monitor an UNSET owner (resolves to broker) is a
+// WARN in the activation rubric (not yet adopted) and a FAIL under strict (post-install it must be
+// updater). Injectable for tests.
+export function checkPluginPullOwner(deps = {}) {
+  const { nodeClass, strict = false, owner = defaultPluginPullOwner() } = deps;
+
+  if (nodeClass === "worker") {
+    if (owner === "updater") {
+      return [
+        mkCheck(
+          "plugin-pull-owner",
+          STATUS.FAIL,
+          `pluginPullOwner=updater on a worker — the broker DEFERS the pull to a catalyst-updater agent a worker does not run, ` +
+            `so the plugin checkout goes stale. Reset it to broker (a 'catalyst install --class worker' does this; or set ` +
+            `catalyst.orchestration.pluginPullOwner=broker / unset it)`,
+        ),
+      ];
+    }
+    return [mkCheck("plugin-pull-owner", STATUS.PASS, `pluginPullOwner resolves to broker — the worker's broker owns plugin freshness (correct for class=worker)`)];
+  }
+
+  // developer / monitor
+  if (owner === "updater") {
+    return [mkCheck("plugin-pull-owner", STATUS.PASS, `pluginPullOwner=updater — the standalone catalyst-updater agent owns the pull (correct for class=${nodeClass}, which runs no broker)`)];
+  }
+  return [
+    mkCheck(
+      "plugin-pull-owner",
+      strict ? STATUS.FAIL : STATUS.WARN,
+      `pluginPullOwner resolves to broker on a ${nodeClass} node — a developer/monitor runs no broker, so NOTHING pulls the plugin ` +
+        `checkout (it goes stale). Run 'catalyst-stack adopt-updater' (sets pluginPullOwner=updater)`,
+    ),
+  ];
+}
+
 // ─── Suite selection ─────────────────────────────────────────────────────────
 
 // checksForClass — build the check-thunk suite for a resolved node class. This is
@@ -2214,6 +2371,13 @@ export function checksForClass(nc, opts = {}) {
     orchDir,
     bootDrained,
     getHostName: _getHostName,
+    // CTL-1369 PR4: install-correctness seams (agent-set + pull-owner). `strict` is false in the
+    // always-on activation rubric (missing agent / unset owner = WARN, safe for the pre-install join
+    // gate) and true in installChecksForClass (the post-install verification pass).
+    strict = false,
+    hasStackAgent,
+    hasUpdaterAgent,
+    pluginPullOwner,
   } = opts;
 
   const nodeClassCheck = () => checkNodeClass({ nodeClass: nc });
@@ -2222,6 +2386,12 @@ export function checksForClass(nc, opts = {}) {
   if (!nc.recognized) {
     return [nodeClassCheck];
   }
+
+  // CTL-1369 PR4: the install-correctness thunks, shared by all class arms. The agent-set + pull-owner
+  // for the resolved class; `strict` distinguishes the activation rubric (advisory) from the
+  // post-install verification (fail-closed). Seams (undefined in production) fall through to defaults.
+  const agentsThunk = () => checkAgentsForClass({ nodeClass: nc.class, strict, hasStackAgent, hasUpdaterAgent });
+  const pullOwnerThunk = () => checkPluginPullOwner({ nodeClass: nc.class, strict, owner: pluginPullOwner });
 
   const replicaThunk = () => checkReadReplicaReachable({ baseUrl: readReplicaBaseUrl, fetch: _fetch });
   const wontOwnThunk = () =>
@@ -2269,6 +2439,8 @@ export function checksForClass(nc, opts = {}) {
       developerBotCredentials,
       () => checkHrwPartition(), // would-own count (visibility)
       () => checkDaemonlessLocal({ nodeClass: nc.class, runVerifyNode }), // broker/exec-core down + plugins fresh
+      agentsThunk, // CTL-1369 PR4: updater agent installed, no worker stack (correct class agent set)
+      pullOwnerThunk, // CTL-1369 PR4: pluginPullOwner=updater (a developer runs no broker)
       replicaThunk,
       wontOwnThunk,
       () => checkReaper(), // advisory (never FAIL), class-agnostic
@@ -2289,6 +2461,8 @@ export function checksForClass(nc, opts = {}) {
       nodeClassCheck,
       () => checkConnectivity({ seed, otel, fetch: _fetch }),
       () => checkHrwPartition(), // would-own count (visibility)
+      agentsThunk, // CTL-1369 PR4: updater agent installed, no worker stack (monitor is adopt-updater-shaped)
+      pullOwnerThunk, // CTL-1369 PR4: pluginPullOwner=updater
       replicaThunk,
       wontOwnThunk,
       () => [
@@ -2314,6 +2488,8 @@ export function checksForClass(nc, opts = {}) {
     () => checkConnectivity({ seed, otel }),
     () => checkSecretsHygiene(),
     () => checkDaemonToolPath(), // CTL-1289: daemon launchd PATH resolves linearis/node/claude
+    agentsThunk, // CTL-1369 PR4: worker work-stack agent installed, no updater agent (correct class agent set)
+    pullOwnerThunk, // CTL-1369 PR4: pluginPullOwner=broker (the worker's broker owns the pull)
     () => checkWebhookIngestion(), // CTL-1284: multiHost member ingests webhooks; single-host does not
     () => checkThoughts(), // CTL-1293: member thoughts repo provisioned + non-foreign primary
     () => checkClaudeSettings(), // CTL-1231: member settings.json pins host identity + OTLP endpoint
@@ -2323,6 +2499,26 @@ export function checksForClass(nc, opts = {}) {
     () => checkConfigScopeLeak(), // CTL-1214: committed Layer-1 .catalyst/config.json must not carry node/cluster scope (roster/orchestration/feedback/sweep/repoColors/hosts.json)
     () => checkRepoIconTokenScope(), // CTL-1375: monitor daemon's gh token can read configured private repos' contents (else favicons fall back to the org avatar) — advisory (never FAIL)
     () => checkMonitorProductionBuild(), // CTL-1372: warn if the local monitor serves a dev-build React bundle (leaks via performance.measure) — advisory (never FAIL)
+  ];
+}
+
+// installChecksForClass — CTL-1369 PR4: the FOCUSED install-verification rubric, run by
+// `catalyst install` as its post-install pass (`catalyst-doctor --profile install`). Unlike the
+// activation rubric, it grades ONLY what an install actually CONTROLS and lands deterministically +
+// offline: the node-class itself (CTL-1355 unrecognized → FAIL), the correct launchd agent SET, and a
+// sane plugin-pull owner — each `strict:true` (a not-yet-provisioned agent/owner is a FAIL, because
+// post-install it MUST be correct). It deliberately OMITS the network/operational checks (Linear/bot/
+// read-replica reachability/webhooks/thoughts): those depend on remote nodes + tokens an install
+// can't guarantee, so failing them would mis-attribute an operational gap to the install run.
+export function installChecksForClass(nc, opts = {}) {
+  const { hasStackAgent, hasUpdaterAgent, pluginPullOwner } = opts;
+  const nodeClassCheck = () => checkNodeClass({ nodeClass: nc });
+  // Unrecognized explicit class → the single hard FAIL, same as the activation rubric.
+  if (!nc.recognized) return [nodeClassCheck];
+  return [
+    nodeClassCheck,
+    () => checkAgentsForClass({ nodeClass: nc.class, strict: true, hasStackAgent, hasUpdaterAgent }),
+    () => checkPluginPullOwner({ nodeClass: nc.class, strict: true, owner: pluginPullOwner }),
   ];
 }
 
@@ -2336,6 +2532,9 @@ export async function runDoctor(opts = {}) {
     seed = process.env.CATALYST_SEED_HOST ?? null,
     otel = process.env.OTEL_EXPORTER_OTLP_ENDPOINT ?? null,
     expectedBotUserId = null,
+    // CTL-1369 PR4: "activation" (default — the full class rubric) | "install" (the focused
+    // post-install verification subset). Selects which suite builder runDoctor uses.
+    profile = "activation",
     // CTL-1355: the class resolver is injectable so tests can drive each rubric.
     resolveClass = resolveNodeClass,
   } = opts;
@@ -2343,7 +2542,11 @@ export async function runDoctor(opts = {}) {
   // CTL-1355: resolve the node class once, then grade against its rubric. An
   // explicit `checks` array still bypasses selection entirely (the test seam).
   const nc = resolveClass();
-  const fns = checkFns ?? checksForClass(nc, { ...opts, seed, otel, expectedBotUserId });
+  const fns =
+    checkFns ??
+    (profile === "install"
+      ? installChecksForClass(nc, { ...opts })
+      : checksForClass(nc, { ...opts, seed, otel, expectedBotUserId }));
 
   // Run all check functions concurrently
   const results = await Promise.all(fns.map((fn) => Promise.resolve().then(fn)));

--- a/plugins/dev/scripts/execution-core/doctor.mjs
+++ b/plugins/dev/scripts/execution-core/doctor.mjs
@@ -2294,32 +2294,25 @@ export function checkAgentsForClass(deps = {}) {
   ];
 }
 
-// pullOwnerConfigPath — the Layer-2 machine config the install ACTUALLY wrote pluginPullOwner into,
-// resolved with the SAME precedence as install-lifecycle.layer2Path() (CATALYST_LAYER2_CONFIG_FILE >
-// CATALYST_MACHINE_CONFIG > XDG_CONFIG_HOME > ~/.config). doctor's generic layer2Path() honors only
-// CATALYST_LAYER2_CONFIG_FILE/~/.config, so a standalone `catalyst-doctor --profile install` run with
-// only CATALYST_MACHINE_CONFIG/XDG selecting the config would otherwise read the WRONG file and
-// misreport the owner (CTL-1369 PR4 Codex P2). This mirrors the resolver the broker is handed.
-function pullOwnerConfigPath(env = process.env) {
-  return (
-    env.CATALYST_LAYER2_CONFIG_FILE ||
-    env.CATALYST_MACHINE_CONFIG ||
-    resolve(env.XDG_CONFIG_HOME || resolve(homedir(), ".config"), "catalyst", "config.json")
-  );
-}
-
 // defaultPluginPullOwner — the PERSISTED plugin-pull owner this node was INSTALLED with: the Layer-2
-// catalyst.orchestration.pluginPullOwner value (any non-"updater" / unset ⇒ "broker"). Deliberately
-// reads ONLY the persisted config — NOT the transient CATALYST_PLUGIN_PULL_OWNER env that
-// broker/plugin-refresh.mjs::resolvePluginPullOwner honors at runtime (CTL-1369 PR4 Codex P2): the
-// install writes the owner into the config (adopt-updater / write-config) and the launchd updater
-// agent does NOT inherit a caller's shell env, so a stray `CATALYST_PLUGIN_PULL_OWNER=broker` in the
-// operator's shell must not make a correctly-adopted developer's post-install doctor falsely FAIL.
-// The doctor verifies INSTALLED STATE, not a runtime override. Inlined (doctor runs under bare node).
-function defaultPluginPullOwner(env = process.env) {
+// catalyst.orchestration.pluginPullOwner value (any non-"updater" / unset ⇒ "broker"). Two deliberate
+// properties (both from Codex P2):
+//   (1) It reads from doctor's UNIFORM Layer-2 path — layer2Path() (CATALYST_LAYER2_CONFIG_FILE →
+//       ~/.config) — which is exactly the path resolveNodeClass uses for the CLASS. Reading class AND
+//       owner from one config file is what keeps them from skewing (round 2): an earlier revision honored
+//       CATALYST_MACHINE_CONFIG here but NOT in the class resolver, so a config selected only via
+//       CATALYST_MACHINE_CONFIG graded the class as an inferred worker while the owner read developer.
+//       install-lifecycle pins CATALYST_LAYER2_CONFIG_FILE (= its own layer2Path) in the doctor step env,
+//       so this reads the node's actual installed config.
+//   (2) It IGNORES the transient CATALYST_PLUGIN_PULL_OWNER env that broker/plugin-refresh.mjs honors at
+//       runtime (round 1): the launchd updater agent never inherits a caller's shell env, so a stray
+//       `CATALYST_PLUGIN_PULL_OWNER=broker` must not make a correctly-adopted developer's post-install
+//       doctor falsely FAIL. The doctor verifies INSTALLED STATE, not a runtime override.
+// Inlined (doctor runs under bare node).
+function defaultPluginPullOwner() {
   const coerce = (v) => (typeof v === "string" && v.trim() === "updater" ? "updater" : "broker");
   try {
-    const v = JSON.parse(readFileSync(pullOwnerConfigPath(env), "utf8"))?.catalyst?.orchestration?.pluginPullOwner;
+    const v = JSON.parse(readFileSync(layer2Path(), "utf8"))?.catalyst?.orchestration?.pluginPullOwner;
     if (typeof v === "string" && v.trim().length > 0) return coerce(v);
   } catch {
     /* unreadable/malformed/absent Layer-2 → fail safe to broker */

--- a/plugins/dev/scripts/execution-core/doctor.mjs
+++ b/plugins/dev/scripts/execution-core/doctor.mjs
@@ -2294,20 +2294,35 @@ export function checkAgentsForClass(deps = {}) {
   ];
 }
 
-// defaultPluginPullOwner — which process owns the plugin pull on this node: "broker" (default) or
-// "updater". MIRRORS broker/plugin-refresh.mjs::resolvePluginPullOwner (env CATALYST_PLUGIN_PULL_OWNER
-// → Layer-2 catalyst.orchestration.pluginPullOwner → default "broker"; any non-"updater" value
-// coerces to "broker"). Inlined — like readLinearBotUserIds above — to keep doctor's runtime dep
-// surface minimal (doctor runs under bare `node`); a parity test pins it to the canonical resolver.
+// pullOwnerConfigPath — the Layer-2 machine config the install ACTUALLY wrote pluginPullOwner into,
+// resolved with the SAME precedence as install-lifecycle.layer2Path() (CATALYST_LAYER2_CONFIG_FILE >
+// CATALYST_MACHINE_CONFIG > XDG_CONFIG_HOME > ~/.config). doctor's generic layer2Path() honors only
+// CATALYST_LAYER2_CONFIG_FILE/~/.config, so a standalone `catalyst-doctor --profile install` run with
+// only CATALYST_MACHINE_CONFIG/XDG selecting the config would otherwise read the WRONG file and
+// misreport the owner (CTL-1369 PR4 Codex P2). This mirrors the resolver the broker is handed.
+function pullOwnerConfigPath(env = process.env) {
+  return (
+    env.CATALYST_LAYER2_CONFIG_FILE ||
+    env.CATALYST_MACHINE_CONFIG ||
+    resolve(env.XDG_CONFIG_HOME || resolve(homedir(), ".config"), "catalyst", "config.json")
+  );
+}
+
+// defaultPluginPullOwner — the PERSISTED plugin-pull owner this node was INSTALLED with: the Layer-2
+// catalyst.orchestration.pluginPullOwner value (any non-"updater" / unset ⇒ "broker"). Deliberately
+// reads ONLY the persisted config — NOT the transient CATALYST_PLUGIN_PULL_OWNER env that
+// broker/plugin-refresh.mjs::resolvePluginPullOwner honors at runtime (CTL-1369 PR4 Codex P2): the
+// install writes the owner into the config (adopt-updater / write-config) and the launchd updater
+// agent does NOT inherit a caller's shell env, so a stray `CATALYST_PLUGIN_PULL_OWNER=broker` in the
+// operator's shell must not make a correctly-adopted developer's post-install doctor falsely FAIL.
+// The doctor verifies INSTALLED STATE, not a runtime override. Inlined (doctor runs under bare node).
 function defaultPluginPullOwner(env = process.env) {
   const coerce = (v) => (typeof v === "string" && v.trim() === "updater" ? "updater" : "broker");
-  const fromEnv = env.CATALYST_PLUGIN_PULL_OWNER;
-  if (typeof fromEnv === "string" && fromEnv.trim().length > 0) return coerce(fromEnv);
   try {
-    const v = JSON.parse(readFileSync(layer2Path(), "utf8"))?.catalyst?.orchestration?.pluginPullOwner;
+    const v = JSON.parse(readFileSync(pullOwnerConfigPath(env), "utf8"))?.catalyst?.orchestration?.pluginPullOwner;
     if (typeof v === "string" && v.trim().length > 0) return coerce(v);
   } catch {
-    /* unreadable/malformed Layer-2 → fail safe to broker (matches resolvePluginPullOwner) */
+    /* unreadable/malformed/absent Layer-2 → fail safe to broker */
   }
   return "broker";
 }

--- a/plugins/dev/scripts/execution-core/doctor.mjs
+++ b/plugins/dev/scripts/execution-core/doctor.mjs
@@ -1838,7 +1838,7 @@ export function checkRepoIconTokenScope(deps = {}) {
 // behavior, zero change), just noting the role was never declared. An explicit,
 // recognized class PASSes. Injectable for tests.
 export function checkNodeClass(deps = {}) {
-  const { nodeClass = resolveNodeClass() } = deps;
+  const { nodeClass = resolveNodeClass(), strict = false } = deps;
   const nc = nodeClass;
   if (!nc.recognized) {
     return [
@@ -1852,6 +1852,21 @@ export function checkNodeClass(deps = {}) {
     ];
   }
   if (nc.inferred) {
+    // CTL-1369 PR4 (Codex P2): under the install-verification profile (strict), an INFERRED class is a
+    // FAIL — the install's write-config (`catalyst class <x>`) must have PERSISTED catalyst.node.class,
+    // so an inferred/absent class means the class write did not take (else later daemons boot as the
+    // default worker). In the activation rubric (non-strict) it stays INFO (absent ⇒ worker, zero change).
+    if (strict) {
+      return [
+        mkCheck(
+          "node-class",
+          STATUS.FAIL,
+          `catalyst.node.class is NOT explicitly persisted (inferred "${nc.class}") — the install's ` +
+            `write-config must persist it into the Layer-2 config; an inferred class means the ` +
+            `'catalyst class <x>' write did not take (the node would boot as the default worker)`,
+        ),
+      ];
+    }
     return [
       mkCheck(
         "node-class",
@@ -2235,6 +2250,17 @@ function defaultAgentInstalled(label, dir = defaultLaunchAgentsDir()) {
   }
 }
 
+// defaultUpdaterProcessAlive — is a catalyst-updater daemon RUNNING, even with its plist removed?
+// Mirrors install-lifecycle.mjs defaultProbeUpdaterAgent (CTL-1369 PR4 Codex P2): a manual/partial
+// cleanup can leave the updater process alive without its plist — still the CTL-1348 two-puller hazard
+// — so the strict post-install verification must catch it, not just the plist. Honors the
+// CATALYST_ASSUME_NO_DAEMONS test seam (same as install-lifecycle).
+function defaultUpdaterProcessAlive() {
+  if (process.env.CATALYST_ASSUME_NO_DAEMONS === "1") return false;
+  const r = spawnSync("pgrep", ["-f", "execution-core/updater/updater\\.mjs"], { timeout: 5_000 });
+  return !r.error && r.status === 0;
+}
+
 // checkAgentsForClass — assert the correct launchd agent SET for the class. The two discriminators
 // are the worker stack agent and the developer/monitor updater agent; their PRESENCE is mutually
 // exclusive (a node running both is the CTL-1348 two-puller hazard). Injectable for tests.
@@ -2243,7 +2269,12 @@ export function checkAgentsForClass(deps = {}) {
     nodeClass,
     strict = false,
     hasStackAgent = defaultAgentInstalled(STACK_AGENT_LABEL),
-    hasUpdaterAgent = defaultAgentInstalled(UPDATER_AGENT_LABEL),
+    // injectable updater-process probe (so the plist-gone-but-process-alive path is testable).
+    updaterProcessAlive = defaultUpdaterProcessAlive,
+    // updater present = plist OR a live updater process (plist-gone-but-process-alive is still the
+    // CTL-1348 two-puller hazard). `updaterProcessAlive` is in scope (earlier destructure) for this default.
+    hasUpdaterAgent = defaultAgentInstalled(UPDATER_AGENT_LABEL) ||
+      (typeof updaterProcessAlive === "function" ? updaterProcessAlive() : !!updaterProcessAlive),
   } = deps;
 
   if (nodeClass === "worker") {
@@ -2520,7 +2551,9 @@ export function checksForClass(nc, opts = {}) {
 // can't guarantee, so failing them would mis-attribute an operational gap to the install run.
 export function installChecksForClass(nc, opts = {}) {
   const { hasStackAgent, hasUpdaterAgent, pluginPullOwner } = opts;
-  const nodeClassCheck = () => checkNodeClass({ nodeClass: nc });
+  // strict:true — under install verification an INFERRED/unpersisted class is a FAIL (the install's
+  // write-config must have persisted catalyst.node.class), not the activation INFO (CTL-1369 PR4 Codex P2).
+  const nodeClassCheck = () => checkNodeClass({ nodeClass: nc, strict: true });
   // Unrecognized explicit class → the single hard FAIL, same as the activation rubric.
   if (!nc.recognized) return [nodeClassCheck];
   return [

--- a/plugins/dev/scripts/execution-core/doctor.mjs
+++ b/plugins/dev/scripts/execution-core/doctor.mjs
@@ -2269,29 +2269,30 @@ export function checkAgentsForClass(deps = {}) {
     nodeClass,
     strict = false,
     hasStackAgent = defaultAgentInstalled(STACK_AGENT_LABEL),
-    // injectable updater-process probe (so the plist-gone-but-process-alive path is testable).
+    // the DURABLE updater LaunchAgent plist (survives reboot/logout) — REQUIRED for a developer/monitor PASS.
+    hasUpdaterAgent = defaultAgentInstalled(UPDATER_AGENT_LABEL),
+    // a live updater PROCESS (may exist WITHOUT a plist after a partial cleanup). Used ONLY to catch the
+    // worker two-puller hazard (CTL-1369 PR4 Codex P2); a process with no plist is NOT a durable install.
     updaterProcessAlive = defaultUpdaterProcessAlive,
-    // updater present = plist OR a live updater process (plist-gone-but-process-alive is still the
-    // CTL-1348 two-puller hazard). `updaterProcessAlive` is in scope (earlier destructure) for this default.
-    hasUpdaterAgent = defaultAgentInstalled(UPDATER_AGENT_LABEL) ||
-      (typeof updaterProcessAlive === "function" ? updaterProcessAlive() : !!updaterProcessAlive),
   } = deps;
+  const updaterProc = typeof updaterProcessAlive === "function" ? updaterProcessAlive() : !!updaterProcessAlive;
 
   if (nodeClass === "worker") {
-    // A worker's broker owns the pull; the updater agent must NOT be present (two-puller race).
-    if (hasUpdaterAgent) {
+    // A worker's broker owns the pull; an updater present in ANY form — durable plist OR a live process
+    // (a manual cleanup can leave the process without its plist) — is the two-puller race.
+    if (hasUpdaterAgent || updaterProc) {
       return [
         mkCheck(
           "agents-for-class",
           STATUS.FAIL,
-          `worker node has the developer/monitor updater agent (${UPDATER_AGENT_LABEL}) installed — ` +
+          `worker node has a developer/monitor updater ${hasUpdaterAgent ? `agent (${UPDATER_AGENT_LABEL})` : "process running (no plist)"} present — ` +
             `the two-puller hazard (the broker AND the updater would both pull the plugin checkout). ` +
             `Run 'catalyst reinstall --class worker' (its teardown removes the updater) or 'catalyst-stack uninstall-services'`,
         ),
       ];
     }
     if (hasStackAgent) {
-      return [mkCheck("agents-for-class", STATUS.PASS, `worker work-stack agent (${STACK_AGENT_LABEL}) installed; no updater agent (correct for class=worker)`)];
+      return [mkCheck("agents-for-class", STATUS.PASS, `worker work-stack agent (${STACK_AGENT_LABEL}) installed; no updater agent/process (correct for class=worker)`)];
     }
     return [
       mkCheck(
@@ -2313,8 +2314,20 @@ export function checkAgentsForClass(deps = {}) {
       ),
     ];
   }
+  // A developer/monitor PASS REQUIRES the DURABLE plist — a live process with NO plist won't restart
+  // after reboot/logout, so it is not a provisioned node (CTL-1369 PR4 Codex P2).
   if (hasUpdaterAgent) {
     return [mkCheck("agents-for-class", STATUS.PASS, `updater agent (${UPDATER_AGENT_LABEL}) installed; no worker work-stack agent (correct for class=${nodeClass})`)];
+  }
+  if (updaterProc) {
+    return [
+      mkCheck(
+        "agents-for-class",
+        strict ? STATUS.FAIL : STATUS.WARN,
+        `${nodeClass} node has a live updater process but NO ${UPDATER_AGENT_LABEL} plist — it will NOT restart after ` +
+          `reboot/logout (not durably installed). Run 'catalyst install --class ${nodeClass}' (or 'catalyst-stack adopt-updater')`,
+      ),
+    ];
   }
   return [
     mkCheck(

--- a/plugins/dev/scripts/execution-core/doctor.test.mjs
+++ b/plugins/dev/scripts/execution-core/doctor.test.mjs
@@ -31,7 +31,10 @@ import {
   checkMonitorProductionBuild,
   checkWontOwnWork,
   checkDaemonlessLocal,
+  checkAgentsForClass,
+  checkPluginPullOwner,
   checksForClass,
+  installChecksForClass,
   summarize,
   renderJson,
   renderHuman,
@@ -39,6 +42,8 @@ import {
   runDoctor,
 } from "./doctor.mjs";
 import { validateLayer1Config } from "../lib/validate-catalyst-config.mjs";
+// CTL-1369 PR4: parity source for doctor's inlined defaultPluginPullOwner.
+import { resolvePluginPullOwner } from "../broker/plugin-refresh.mjs";
 
 // ─── Phase 1: checkHostIdentity ──────────────────────────────────────────────
 
@@ -2051,5 +2056,254 @@ describe("runDoctor — class-aware routing (CTL-1355)", () => {
       log: () => {},
     });
     expect(code).toBe(1);
+  });
+});
+
+// ─── CTL-1369 PR4: install-correctness checks ────────────────────────────────
+
+describe("checkAgentsForClass (CTL-1369 PR4)", () => {
+  const only = (deps) => checkAgentsForClass(deps)[0];
+
+  describe("worker", () => {
+    it("stack agent installed, no updater → PASS", () => {
+      const c = only({ nodeClass: "worker", hasStackAgent: true, hasUpdaterAgent: false });
+      expect(c.name).toBe("agents-for-class");
+      expect(c.status).toBe(STATUS.PASS);
+    });
+    it("updater agent present on a worker → FAIL (two-puller hazard), regardless of stack", () => {
+      expect(only({ nodeClass: "worker", hasStackAgent: true, hasUpdaterAgent: true }).status).toBe(STATUS.FAIL);
+      expect(only({ nodeClass: "worker", hasStackAgent: false, hasUpdaterAgent: true }).status).toBe(STATUS.FAIL);
+    });
+    it("no agents → WARN in activation (strict:false), FAIL under strict (post-install)", () => {
+      expect(only({ nodeClass: "worker", hasStackAgent: false, hasUpdaterAgent: false, strict: false }).status).toBe(STATUS.WARN);
+      expect(only({ nodeClass: "worker", hasStackAgent: false, hasUpdaterAgent: false, strict: true }).status).toBe(STATUS.FAIL);
+    });
+  });
+
+  describe("developer / monitor", () => {
+    for (const nodeClass of ["developer", "monitor"]) {
+      it(`${nodeClass}: updater installed, no stack → PASS`, () => {
+        expect(only({ nodeClass, hasStackAgent: false, hasUpdaterAgent: true }).status).toBe(STATUS.PASS);
+      });
+      it(`${nodeClass}: worker stack present → FAIL (must not run broker/exec-core), regardless of updater`, () => {
+        expect(only({ nodeClass, hasStackAgent: true, hasUpdaterAgent: true }).status).toBe(STATUS.FAIL);
+        expect(only({ nodeClass, hasStackAgent: true, hasUpdaterAgent: false }).status).toBe(STATUS.FAIL);
+      });
+      it(`${nodeClass}: no agents → WARN in activation, FAIL under strict`, () => {
+        expect(only({ nodeClass, hasStackAgent: false, hasUpdaterAgent: false, strict: false }).status).toBe(STATUS.WARN);
+        expect(only({ nodeClass, hasStackAgent: false, hasUpdaterAgent: false, strict: true }).status).toBe(STATUS.FAIL);
+      });
+    }
+  });
+});
+
+describe("checkPluginPullOwner (CTL-1369 PR4)", () => {
+  const only = (deps) => checkPluginPullOwner(deps)[0];
+
+  it("worker + owner=broker → PASS; worker + owner=updater → FAIL (broker defers to absent updater)", () => {
+    expect(only({ nodeClass: "worker", owner: "broker" }).status).toBe(STATUS.PASS);
+    const fail = only({ nodeClass: "worker", owner: "updater" });
+    expect(fail.status).toBe(STATUS.FAIL);
+    expect(fail.name).toBe("plugin-pull-owner");
+  });
+
+  for (const nodeClass of ["developer", "monitor"]) {
+    it(`${nodeClass} + owner=updater → PASS`, () => {
+      expect(only({ nodeClass, owner: "updater" }).status).toBe(STATUS.PASS);
+    });
+    it(`${nodeClass} + owner=broker → WARN in activation, FAIL under strict`, () => {
+      expect(only({ nodeClass, owner: "broker", strict: false }).status).toBe(STATUS.WARN);
+      expect(only({ nodeClass, owner: "broker", strict: true }).status).toBe(STATUS.FAIL);
+    });
+  }
+});
+
+// Parity: doctor's inlined defaultPluginPullOwner must agree with the canonical
+// broker/plugin-refresh.mjs::resolvePluginPullOwner across representative inputs. We can't call the
+// (unexported) inline directly, so we exercise it END-TO-END via checkPluginPullOwner's default
+// `owner` seam (omit owner → it reads via defaultPluginPullOwner) and compare the resulting verdict
+// to what the canonical resolver would yield for the same env/config.
+describe("defaultPluginPullOwner ↔ resolvePluginPullOwner parity (CTL-1369 PR4)", () => {
+  let dir;
+  beforeEach(() => { dir = mkdtempSync(join(tmpdir(), "doctor-pull-owner-")); });
+  afterEach(() => { rmSync(dir, { recursive: true, force: true }); });
+
+  const cases = [
+    { name: "env=updater wins", env: { CATALYST_PLUGIN_PULL_OWNER: "updater" }, cfg: null },
+    { name: "env=broker", env: { CATALYST_PLUGIN_PULL_OWNER: "broker" }, cfg: null },
+    { name: "env garbage coerces to broker", env: { CATALYST_PLUGIN_PULL_OWNER: "weird" }, cfg: null },
+    { name: "config updater (no env)", env: {}, cfg: { catalyst: { orchestration: { pluginPullOwner: "updater" } } } },
+    { name: "config broker (no env)", env: {}, cfg: { catalyst: { orchestration: { pluginPullOwner: "broker" } } } },
+    { name: "unset everywhere → broker", env: {}, cfg: {} },
+    { name: "malformed config → broker", env: {}, cfg: "MALFORMED" },
+  ];
+
+  for (const tc of cases) {
+    it(tc.name, () => {
+      const cfgPath = join(dir, "config.json");
+      if (tc.cfg !== null) writeFileSync(cfgPath, tc.cfg === "MALFORMED" ? "{not json" : JSON.stringify(tc.cfg));
+      const env = { ...tc.env, CATALYST_LAYER2_CONFIG_FILE: cfgPath };
+      const canonical = resolvePluginPullOwner({ env, machineConfigPath: cfgPath });
+      // Drive doctor's inline via its default seam: set process.env to match, omit `owner`.
+      const savedEnv = process.env.CATALYST_PLUGIN_PULL_OWNER;
+      const savedCfg = process.env.CATALYST_LAYER2_CONFIG_FILE;
+      try {
+        if ("CATALYST_PLUGIN_PULL_OWNER" in tc.env) process.env.CATALYST_PLUGIN_PULL_OWNER = tc.env.CATALYST_PLUGIN_PULL_OWNER;
+        else delete process.env.CATALYST_PLUGIN_PULL_OWNER;
+        process.env.CATALYST_LAYER2_CONFIG_FILE = cfgPath;
+        // A worker grades owner=broker→PASS, owner=updater→FAIL — so the verdict encodes the resolved owner.
+        const verdict = checkPluginPullOwner({ nodeClass: "worker" })[0].status;
+        const expected = canonical === "updater" ? STATUS.FAIL : STATUS.PASS;
+        expect(verdict).toBe(expected);
+      } finally {
+        if (savedEnv === undefined) delete process.env.CATALYST_PLUGIN_PULL_OWNER;
+        else process.env.CATALYST_PLUGIN_PULL_OWNER = savedEnv;
+        if (savedCfg === undefined) delete process.env.CATALYST_LAYER2_CONFIG_FILE;
+        else process.env.CATALYST_LAYER2_CONFIG_FILE = savedCfg;
+      }
+    });
+  }
+});
+
+describe("checksForClass wires the PR4 install-correctness checks into every arm (CTL-1369 PR4)", () => {
+  const srcOf = (nc, opts = {}) => checksForClass(nc, opts).map((f) => f.toString()).join("\n");
+  for (const cls of ["worker", "developer", "monitor"]) {
+    it(`${cls} suite includes checkAgentsForClass + checkPluginPullOwner`, () => {
+      const s = srcOf(nodeClassOf({ class: cls, raw: cls }));
+      expect(s).toContain("checkAgentsForClass");
+      expect(s).toContain("checkPluginPullOwner");
+    });
+  }
+  // E2E: EXECUTE the thunks checksForClass actually builds (not a source-string match) so the
+  // strict:false default + correct nc.class are pinned through the real wiring. This is the load-bearing
+  // join-gate invariant: catalyst-join do_doctor_gate runs doctor BEFORE install-services and exits
+  // non-zero on any FAIL, so a fresh/not-yet-provisioned node MUST grade WARN here. A regression that
+  // wired strict:true (or the wrong class) into the activation arm would FAIL this test.
+  // We source-match ONLY to SELECT the two thunks, then EXECUTE them to assert behavior.
+  const runPicked = async (suite, needle) => {
+    const picked = suite.filter((f) => f.toString().includes(needle));
+    return (await Promise.all(picked.map((f) => Promise.resolve().then(f)))).flat();
+  };
+  it("worker activation arm runs agents/pull-owner at strict:false (fresh worker → agents WARN, owner=broker PASS)", async () => {
+    const suite = checksForClass(nodeClassOf({ class: "worker", raw: "worker" }), { hasStackAgent: false, hasUpdaterAgent: false, pluginPullOwner: "broker" });
+    const agents = (await runPicked(suite, "checkAgentsForClass")).find((c) => c.name === "agents-for-class");
+    const owner = (await runPicked(suite, "checkPluginPullOwner")).find((c) => c.name === "plugin-pull-owner");
+    expect(agents.status).toBe(STATUS.WARN); // NOT FAIL — would fail-close the join gate on a fresh node
+    expect(owner.status).toBe(STATUS.PASS); // worker + broker = correct
+  });
+  it("developer activation arm runs agents/pull-owner at strict:false (fresh developer → both WARN, not FAIL)", async () => {
+    const suite = checksForClass(nodeClassOf({ class: "developer", raw: "developer" }), { hasStackAgent: false, hasUpdaterAgent: false, pluginPullOwner: "broker" });
+    const agents = (await runPicked(suite, "checkAgentsForClass")).find((c) => c.name === "agents-for-class");
+    const owner = (await runPicked(suite, "checkPluginPullOwner")).find((c) => c.name === "plugin-pull-owner");
+    expect(agents.status).toBe(STATUS.WARN); // not-yet-adopted developer → advisory, not FAIL
+    expect(owner.status).toBe(STATUS.WARN); // developer + broker (not updater) → advisory in activation
+  });
+});
+
+describe("installChecksForClass — the focused post-install verification (CTL-1369 PR4)", () => {
+  it("unrecognized class → single node-class check", () => {
+    const fns = installChecksForClass(nodeClassOf({ recognized: false, raw: "developr", class: "monitor" }));
+    expect(fns).toHaveLength(1);
+  });
+
+  it("grades node-class + agents + pull-owner, and OMITS the network/operational checks", () => {
+    const s = installChecksForClass(nodeClassOf({ class: "worker", raw: "worker" })).map((f) => f.toString()).join("\n");
+    expect(s).toContain("checkNodeClass");
+    expect(s).toContain("checkAgentsForClass");
+    expect(s).toContain("checkPluginPullOwner");
+    // deliberately excluded — operational/network checks an install can't guarantee:
+    expect(s).not.toContain("checkReadReplicaReachable");
+    expect(s).not.toContain("checkBotCredentials");
+    expect(s).not.toContain("checkWebhookIngestion");
+  });
+
+  it("grades the agent/owner checks strict:true (a not-yet-provisioned worker FAILs, unlike activation)", async () => {
+    // Execute the install-profile thunks for a worker with NO agents + unset owner. Under strict the
+    // missing agent + unset owner are FAILs (post-install they must be correct), where the activation
+    // rubric would only WARN.
+    const fns = installChecksForClass(nodeClassOf({ class: "worker", raw: "worker" }), {
+      hasStackAgent: false,
+      hasUpdaterAgent: false,
+      pluginPullOwner: "broker", // a worker w/ broker is fine; the FAIL here is the missing stack agent
+    });
+    const results = (await Promise.all(fns.map((f) => Promise.resolve().then(f)))).flat();
+    const agents = results.find((c) => c.name === "agents-for-class");
+    expect(agents.status).toBe(STATUS.FAIL);
+  });
+
+  it("FAILs a worker post-install whose updater agent is still present (mixed profile)", async () => {
+    const code = await runDoctor({
+      checks: installChecksForClass(nodeClassOf({ class: "worker", raw: "worker" }), {
+        hasStackAgent: true,
+        hasUpdaterAgent: true, // the two-puller hazard
+        pluginPullOwner: "broker",
+      }),
+      log: () => {},
+    });
+    expect(code).toBe(1);
+  });
+
+  it("PASSes a correctly-provisioned worker post-install (stack only, owner=broker)", async () => {
+    const code = await runDoctor({
+      resolveClass: () => nodeClassOf({ class: "worker", raw: "worker" }),
+      profile: "install",
+      hasStackAgent: true,
+      hasUpdaterAgent: false,
+      pluginPullOwner: "broker",
+      log: () => {},
+    });
+    expect(code).toBe(0);
+  });
+
+  it("PASSes a correctly-provisioned developer post-install (updater only, owner=updater)", async () => {
+    const code = await runDoctor({
+      resolveClass: () => nodeClassOf({ class: "developer", source: "layer2", raw: "developer" }),
+      profile: "install",
+      hasStackAgent: false,
+      hasUpdaterAgent: true,
+      pluginPullOwner: "updater",
+      log: () => {},
+    });
+    expect(code).toBe(0);
+  });
+});
+
+describe("parseArgs --profile / --install (CTL-1369 PR4)", () => {
+  it("defaults to the activation profile", () => {
+    expect(parseArgs([]).profile).toBe("activation");
+  });
+  it("--profile install selects the install profile", () => {
+    expect(parseArgs(["--profile", "install"]).profile).toBe("install");
+  });
+  it("--install is shorthand for --profile install", () => {
+    expect(parseArgs(["--install"]).profile).toBe("install");
+  });
+  it("an unknown/typo'd --profile value leaves the default (never silently weakens the gate)", () => {
+    expect(parseArgs(["--profile", "instal"]).profile).toBe("activation");
+    expect(parseArgs(["--profile"]).profile).toBe("activation");
+  });
+});
+
+describe("runDoctor profile routing (CTL-1369 PR4)", () => {
+  it("profile:install routes to installChecksForClass (the focused subset), not the full rubric", async () => {
+    const logs = [];
+    const code = await runDoctor({
+      resolveClass: () => nodeClassOf({ class: "worker", raw: "worker" }),
+      profile: "install",
+      json: true,
+      hasStackAgent: true,
+      hasUpdaterAgent: false,
+      pluginPullOwner: "broker",
+      log: (m) => logs.push(m),
+    });
+    const parsed = JSON.parse(logs[0]);
+    const names = parsed.checks.map((c) => c.name);
+    expect(names).toContain("node-class");
+    expect(names).toContain("agents-for-class");
+    expect(names).toContain("plugin-pull-owner");
+    // the heavy activation-only checks must NOT appear in the install subset:
+    expect(names).not.toContain("host-identity");
+    expect(names).not.toContain("webhook-ingestion");
+    expect(code).toBe(0);
   });
 });

--- a/plugins/dev/scripts/execution-core/doctor.test.mjs
+++ b/plugins/dev/scripts/execution-core/doctor.test.mjs
@@ -3,7 +3,7 @@
 //
 // Run: cd plugins/dev/scripts/execution-core && bun test doctor.test.mjs
 
-import { describe, it, expect, beforeEach, afterEach } from "bun:test";
+import { describe, it, expect, beforeAll, afterAll, beforeEach, afterEach } from "bun:test";
 import { mkdtempSync, writeFileSync, rmSync, readFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -44,6 +44,13 @@ import {
 import { validateLayer1Config } from "../lib/validate-catalyst-config.mjs";
 // CTL-1369 PR4: parity source for doctor's inlined defaultPluginPullOwner.
 import { resolvePluginPullOwner } from "../broker/plugin-refresh.mjs";
+
+// CTL-1369 PR4: checkAgentsForClass's updater-process probe (defaultUpdaterProcessAlive) pgreps the real
+// host. Pin CATALYST_ASSUME_NO_DAEMONS=1 for the whole file so it deterministically returns false (this
+// box may actually be running the updater); tests that exercise the process path inject updaterProcessAlive.
+let _savedAssumeNoDaemons;
+beforeAll(() => { _savedAssumeNoDaemons = process.env.CATALYST_ASSUME_NO_DAEMONS; process.env.CATALYST_ASSUME_NO_DAEMONS = "1"; });
+afterAll(() => { if (_savedAssumeNoDaemons === undefined) delete process.env.CATALYST_ASSUME_NO_DAEMONS; else process.env.CATALYST_ASSUME_NO_DAEMONS = _savedAssumeNoDaemons; });
 
 // ─── Phase 1: checkHostIdentity ──────────────────────────────────────────────
 
@@ -2388,6 +2395,18 @@ describe("checkAgentsForClass detects a live updater PROCESS, not just the plist
   it("no plist and no live process → worker grades on the stack only (PASS)", () => {
     const c = checkAgentsForClass({ nodeClass: "worker", hasStackAgent: true, updaterProcessAlive: () => false })[0];
     expect(c.status).toBe(STATUS.PASS);
+  });
+  // Codex P2 round 4: a developer/monitor PASS REQUIRES the durable plist — a live process with no plist
+  // won't restart after reboot/logout, so it is not a provisioned node.
+  it("developer with a live updater PROCESS but NO plist → not durably installed → FAIL (strict), WARN (activation)", () => {
+    const noPlist = { nodeClass: "developer", hasStackAgent: false, hasUpdaterAgent: false, updaterProcessAlive: () => true };
+    const failStrict = checkAgentsForClass({ ...noPlist, strict: true })[0];
+    expect(failStrict.status).toBe(STATUS.FAIL);
+    expect(failStrict.detail).toMatch(/no .*plist|won.t restart/i);
+    expect(checkAgentsForClass({ ...noPlist, strict: false })[0].status).toBe(STATUS.WARN);
+    // the durable plist still PASSes (the success case requires it).
+    const withPlist = checkAgentsForClass({ nodeClass: "developer", hasStackAgent: false, hasUpdaterAgent: true, updaterProcessAlive: () => true })[0];
+    expect(withPlist.status).toBe(STATUS.PASS);
   });
 });
 

--- a/plugins/dev/scripts/execution-core/doctor.test.mjs
+++ b/plugins/dev/scripts/execution-core/doctor.test.mjs
@@ -4,7 +4,7 @@
 // Run: cd plugins/dev/scripts/execution-core && bun test doctor.test.mjs
 
 import { describe, it, expect, beforeEach, afterEach } from "bun:test";
-import { mkdtempSync, mkdirSync, writeFileSync, rmSync, readFileSync } from "node:fs";
+import { mkdtempSync, writeFileSync, rmSync, readFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
@@ -2130,16 +2130,19 @@ describe("doctor pull-owner reads persisted installed state (CTL-1369 PR4 / Code
   afterEach(() => { rmSync(dir, { recursive: true, force: true }); });
 
   // Set the given env keys (deleting absent ones), run fn, then restore — so process.env can't leak.
-  const ENV_KEYS = ["CATALYST_PLUGIN_PULL_OWNER", "CATALYST_LAYER2_CONFIG_FILE", "CATALYST_MACHINE_CONFIG", "XDG_CONFIG_HOME"];
+  // Await-aware: if fn returns a promise, restore only after it settles (else an async runDoctor would
+  // see the env restored mid-flight).
+  const ENV_KEYS = ["CATALYST_PLUGIN_PULL_OWNER", "CATALYST_LAYER2_CONFIG_FILE", "CATALYST_MACHINE_CONFIG", "XDG_CONFIG_HOME", "CATALYST_NODE_CLASS"];
   const withEnv = (vars, fn) => {
     const saved = {};
     for (const k of ENV_KEYS) saved[k] = process.env[k];
-    try {
-      for (const k of ENV_KEYS) { if (k in vars) process.env[k] = vars[k]; else delete process.env[k]; }
-      return fn();
-    } finally {
-      for (const k of ENV_KEYS) { if (saved[k] === undefined) delete process.env[k]; else process.env[k] = saved[k]; }
-    }
+    const restore = () => { for (const k of ENV_KEYS) { if (saved[k] === undefined) delete process.env[k]; else process.env[k] = saved[k]; } };
+    for (const k of ENV_KEYS) { if (k in vars) process.env[k] = vars[k]; else delete process.env[k]; }
+    let r;
+    try { r = fn(); } catch (e) { restore(); throw e; }
+    if (r && typeof r.then === "function") return r.then((v) => { restore(); return v; }, (e) => { restore(); throw e; });
+    restore();
+    return r;
   };
   const ownerVerdict = (nodeClass) => checkPluginPullOwner({ nodeClass })[0].status;
   const writeCfg = (owner, d = dir) => {
@@ -2179,17 +2182,20 @@ describe("doctor pull-owner reads persisted installed state (CTL-1369 PR4 / Code
       expect(ownerVerdict("worker")).toBe(STATUS.PASS);
     });
   });
-  // Codex P2 (thread 2): honor CATALYST_MACHINE_CONFIG / XDG when CATALYST_LAYER2_CONFIG_FILE is unset.
-  it("honors CATALYST_MACHINE_CONFIG and XDG_CONFIG_HOME for the config path (parity with install-lifecycle.layer2Path)", () => {
-    const p = writeCfg("updater");
-    withEnv({ CATALYST_MACHINE_CONFIG: p }, () => expect(ownerVerdict("developer")).toBe(STATUS.PASS));
-    const xdg = mkdtempSync(join(tmpdir(), "doctor-xdg-"));
-    mkdirSync(join(xdg, "catalyst"), { recursive: true });
-    writeFileSync(join(xdg, "catalyst", "config.json"), JSON.stringify({ catalyst: { orchestration: { pluginPullOwner: "updater" } } }));
-    withEnv({ XDG_CONFIG_HOME: xdg }, () => expect(ownerVerdict("developer")).toBe(STATUS.PASS));
-    rmSync(xdg, { recursive: true, force: true });
+  // Codex P2 (round 2): the owner reads via CATALYST_LAYER2_CONFIG_FILE — the SAME path resolveNodeClass
+  // uses for the CLASS — and does NOT consult CATALYST_MACHINE_CONFIG, so class + owner never skew.
+  it("reads via CATALYST_LAYER2_CONFIG_FILE and does NOT consult CATALYST_MACHINE_CONFIG (no class/owner skew)", () => {
+    const mcDir = mkdtempSync(join(tmpdir(), "doctor-mc-"));
+    const updaterAt = writeCfg("updater", mcDir); // CATALYST_MACHINE_CONFIG would point here
+    const brokerAt = writeCfg("broker"); // CATALYST_LAYER2_CONFIG_FILE points here
+    // LAYER2 says broker, MACHINE_CONFIG says updater → the owner MUST come from LAYER2 (broker), the
+    // same path the class resolver reads — so a worker grades PASS (not a stale-pull FAIL from MACHINE_CONFIG).
+    withEnv({ CATALYST_LAYER2_CONFIG_FILE: brokerAt, CATALYST_MACHINE_CONFIG: updaterAt }, () => {
+      expect(ownerVerdict("worker")).toBe(STATUS.PASS);
+    });
+    rmSync(mcDir, { recursive: true, force: true });
   });
-  // Narrow parity: with NO transient env, doctor's config read agrees with the canonical resolver's config read.
+  // Narrow parity: with no transient env, doctor's config read agrees with the canonical resolver's config read.
   it("agrees with resolvePluginPullOwner on the CONFIG value when no transient env is set", () => {
     for (const owner of ["updater", "broker", null]) {
       const p = writeCfg(owner);
@@ -2199,6 +2205,23 @@ describe("doctor pull-owner reads persisted installed state (CTL-1369 PR4 / Code
         expect(ownerVerdict("worker")).toBe(expected);
       });
     }
+  });
+  // Codex P2 (round 2): end-to-end — the install profile resolves the CLASS and the OWNER from the SAME
+  // CATALYST_LAYER2_CONFIG_FILE, so a developer config is graded as a developer (not an inferred worker).
+  it("install profile resolves class + owner from one config (developer config → developer rubric, all PASS)", async () => {
+    const cfg = join(dir, "config.json");
+    writeFileSync(cfg, JSON.stringify({ catalyst: { node: { class: "developer" }, orchestration: { pluginPullOwner: "updater" } } }));
+    const logs = [];
+    await withEnv({ CATALYST_LAYER2_CONFIG_FILE: cfg }, async () => {
+      // real resolveNodeClass + real defaultPluginPullOwner (both read CATALYST_LAYER2_CONFIG_FILE);
+      // only the launchd agent probe is injected (it is env-dependent).
+      const code = await runDoctor({ profile: "install", json: true, hasStackAgent: false, hasUpdaterAgent: true, log: (m) => logs.push(m) });
+      const parsed = JSON.parse(logs[0]);
+      expect(parsed.checks.map((c) => c.name)).toEqual(["node-class", "agents-for-class", "plugin-pull-owner"]);
+      expect(parsed.checks.find((c) => c.name === "node-class").detail).toContain("developer"); // class from the SAME file
+      expect(parsed.ok).toBe(true); // class + owner consistent → developer rubric PASSes
+      expect(code).toBe(0);
+    });
   });
 });
 

--- a/plugins/dev/scripts/execution-core/doctor.test.mjs
+++ b/plugins/dev/scripts/execution-core/doctor.test.mjs
@@ -2367,3 +2367,43 @@ describe("runDoctor profile routing (CTL-1369 PR4)", () => {
     expect(code).toBe(0);
   });
 });
+
+// ─── CTL-1369 PR4 / Codex round 3: verify PERSISTED installed state rigorously ───
+describe("checkAgentsForClass detects a live updater PROCESS, not just the plist (CTL-1369 PR4 / Codex P2)", () => {
+  let emptyLA, savedLA;
+  beforeEach(() => {
+    emptyLA = mkdtempSync(join(tmpdir(), "doctor-la-"));
+    savedLA = process.env.CATALYST_LAUNCHAGENTS_DIR;
+    process.env.CATALYST_LAUNCHAGENTS_DIR = emptyLA; // no plists on disk
+  });
+  afterEach(() => {
+    if (savedLA === undefined) delete process.env.CATALYST_LAUNCHAGENTS_DIR;
+    else process.env.CATALYST_LAUNCHAGENTS_DIR = savedLA;
+    rmSync(emptyLA, { recursive: true, force: true });
+  });
+  it("a live updater process with NO plist → worker FAIL (the two-puller hazard install-lifecycle also probes)", () => {
+    const c = checkAgentsForClass({ nodeClass: "worker", hasStackAgent: true, updaterProcessAlive: () => true })[0];
+    expect(c.status).toBe(STATUS.FAIL);
+  });
+  it("no plist and no live process → worker grades on the stack only (PASS)", () => {
+    const c = checkAgentsForClass({ nodeClass: "worker", hasStackAgent: true, updaterProcessAlive: () => false })[0];
+    expect(c.status).toBe(STATUS.PASS);
+  });
+});
+
+describe("strict node-class — install profile requires an explicitly persisted class (CTL-1369 PR4 / Codex P2)", () => {
+  const inferred = nodeClassOf({ class: "worker", source: "default", inferred: true, recognized: true, raw: null });
+  it("checkNodeClass: inferred → FAIL under strict, INFO in activation", () => {
+    expect(checkNodeClass({ nodeClass: inferred, strict: true })[0].status).toBe(STATUS.FAIL);
+    expect(checkNodeClass({ nodeClass: inferred, strict: false })[0].status).toBe(STATUS.INFO);
+    // an explicitly-persisted class still PASSes under strict.
+    expect(checkNodeClass({ nodeClass: nodeClassOf({ class: "worker", raw: "worker" }), strict: true })[0].status).toBe(STATUS.PASS);
+  });
+  it("installChecksForClass FAILs an inferred/unpersisted class even when agents + owner look correct", async () => {
+    // a worker-shaped node (stack agent present, owner broker) but catalyst.node.class never persisted →
+    // the post-install verifier must FAIL (the class write did not take), not exit 0.
+    const fns = installChecksForClass(inferred, { hasStackAgent: true, hasUpdaterAgent: false, pluginPullOwner: "broker" });
+    const results = (await Promise.all(fns.map((f) => Promise.resolve().then(f)))).flat();
+    expect(results.find((c) => c.name === "node-class").status).toBe(STATUS.FAIL);
+  });
+});

--- a/plugins/dev/scripts/execution-core/doctor.test.mjs
+++ b/plugins/dev/scripts/execution-core/doctor.test.mjs
@@ -4,7 +4,7 @@
 // Run: cd plugins/dev/scripts/execution-core && bun test doctor.test.mjs
 
 import { describe, it, expect, beforeEach, afterEach } from "bun:test";
-import { mkdtempSync, writeFileSync, rmSync, readFileSync } from "node:fs";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync, readFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
@@ -2118,51 +2118,88 @@ describe("checkPluginPullOwner (CTL-1369 PR4)", () => {
   }
 });
 
-// Parity: doctor's inlined defaultPluginPullOwner must agree with the canonical
-// broker/plugin-refresh.mjs::resolvePluginPullOwner across representative inputs. We can't call the
-// (unexported) inline directly, so we exercise it END-TO-END via checkPluginPullOwner's default
-// `owner` seam (omit owner → it reads via defaultPluginPullOwner) and compare the resulting verdict
-// to what the canonical resolver would yield for the same env/config.
-describe("defaultPluginPullOwner ↔ resolvePluginPullOwner parity (CTL-1369 PR4)", () => {
+// doctor's pull-owner read = the PERSISTED INSTALLED STATE (CTL-1369 PR4 + Codex P2). It reads ONLY the
+// Layer-2 catalyst.orchestration.pluginPullOwner value the install wrote — it deliberately IGNORES the
+// transient CATALYST_PLUGIN_PULL_OWNER env (which the launchd updater agent never inherits), and it
+// honors the SAME config-path precedence as install-lifecycle.layer2Path (CATALYST_LAYER2_CONFIG_FILE >
+// CATALYST_MACHINE_CONFIG > XDG > ~/.config). We drive the unexported inline END-TO-END via
+// checkPluginPullOwner's default `owner` seam (omit owner → it reads via defaultPluginPullOwner).
+describe("doctor pull-owner reads persisted installed state (CTL-1369 PR4 / Codex P2)", () => {
   let dir;
   beforeEach(() => { dir = mkdtempSync(join(tmpdir(), "doctor-pull-owner-")); });
   afterEach(() => { rmSync(dir, { recursive: true, force: true }); });
 
-  const cases = [
-    { name: "env=updater wins", env: { CATALYST_PLUGIN_PULL_OWNER: "updater" }, cfg: null },
-    { name: "env=broker", env: { CATALYST_PLUGIN_PULL_OWNER: "broker" }, cfg: null },
-    { name: "env garbage coerces to broker", env: { CATALYST_PLUGIN_PULL_OWNER: "weird" }, cfg: null },
-    { name: "config updater (no env)", env: {}, cfg: { catalyst: { orchestration: { pluginPullOwner: "updater" } } } },
-    { name: "config broker (no env)", env: {}, cfg: { catalyst: { orchestration: { pluginPullOwner: "broker" } } } },
-    { name: "unset everywhere → broker", env: {}, cfg: {} },
-    { name: "malformed config → broker", env: {}, cfg: "MALFORMED" },
-  ];
+  // Set the given env keys (deleting absent ones), run fn, then restore — so process.env can't leak.
+  const ENV_KEYS = ["CATALYST_PLUGIN_PULL_OWNER", "CATALYST_LAYER2_CONFIG_FILE", "CATALYST_MACHINE_CONFIG", "XDG_CONFIG_HOME"];
+  const withEnv = (vars, fn) => {
+    const saved = {};
+    for (const k of ENV_KEYS) saved[k] = process.env[k];
+    try {
+      for (const k of ENV_KEYS) { if (k in vars) process.env[k] = vars[k]; else delete process.env[k]; }
+      return fn();
+    } finally {
+      for (const k of ENV_KEYS) { if (saved[k] === undefined) delete process.env[k]; else process.env[k] = saved[k]; }
+    }
+  };
+  const ownerVerdict = (nodeClass) => checkPluginPullOwner({ nodeClass })[0].status;
+  const writeCfg = (owner, d = dir) => {
+    const p = join(d, "config.json");
+    writeFileSync(p, JSON.stringify(owner == null ? {} : { catalyst: { orchestration: { pluginPullOwner: owner } } }));
+    return p;
+  };
 
-  for (const tc of cases) {
-    it(tc.name, () => {
-      const cfgPath = join(dir, "config.json");
-      if (tc.cfg !== null) writeFileSync(cfgPath, tc.cfg === "MALFORMED" ? "{not json" : JSON.stringify(tc.cfg));
-      const env = { ...tc.env, CATALYST_LAYER2_CONFIG_FILE: cfgPath };
-      const canonical = resolvePluginPullOwner({ env, machineConfigPath: cfgPath });
-      // Drive doctor's inline via its default seam: set process.env to match, omit `owner`.
-      const savedEnv = process.env.CATALYST_PLUGIN_PULL_OWNER;
-      const savedCfg = process.env.CATALYST_LAYER2_CONFIG_FILE;
-      try {
-        if ("CATALYST_PLUGIN_PULL_OWNER" in tc.env) process.env.CATALYST_PLUGIN_PULL_OWNER = tc.env.CATALYST_PLUGIN_PULL_OWNER;
-        else delete process.env.CATALYST_PLUGIN_PULL_OWNER;
-        process.env.CATALYST_LAYER2_CONFIG_FILE = cfgPath;
-        // A worker grades owner=broker→PASS, owner=updater→FAIL — so the verdict encodes the resolved owner.
-        const verdict = checkPluginPullOwner({ nodeClass: "worker" })[0].status;
-        const expected = canonical === "updater" ? STATUS.FAIL : STATUS.PASS;
-        expect(verdict).toBe(expected);
-      } finally {
-        if (savedEnv === undefined) delete process.env.CATALYST_PLUGIN_PULL_OWNER;
-        else process.env.CATALYST_PLUGIN_PULL_OWNER = savedEnv;
-        if (savedCfg === undefined) delete process.env.CATALYST_LAYER2_CONFIG_FILE;
-        else process.env.CATALYST_LAYER2_CONFIG_FILE = savedCfg;
-      }
+  it("reads config=updater (worker → FAIL stale-pull; developer → PASS)", () => {
+    const p = writeCfg("updater");
+    withEnv({ CATALYST_LAYER2_CONFIG_FILE: p }, () => {
+      expect(ownerVerdict("worker")).toBe(STATUS.FAIL);
+      expect(ownerVerdict("developer")).toBe(STATUS.PASS);
     });
-  }
+  });
+  it("config=broker / unset / malformed → broker (worker PASS, developer WARN; fail-safe)", () => {
+    for (const owner of ["broker", null]) {
+      const p = writeCfg(owner);
+      withEnv({ CATALYST_LAYER2_CONFIG_FILE: p }, () => {
+        expect(ownerVerdict("worker")).toBe(STATUS.PASS);
+        expect(ownerVerdict("developer")).toBe(STATUS.WARN);
+      });
+    }
+    const bad = join(dir, "config.json"); writeFileSync(bad, "{not json");
+    withEnv({ CATALYST_LAYER2_CONFIG_FILE: bad }, () => expect(ownerVerdict("worker")).toBe(STATUS.PASS));
+  });
+  // Codex P2 (thread 3): a transient CATALYST_PLUGIN_PULL_OWNER env must NOT override the persisted config.
+  it("IGNORES the transient CATALYST_PLUGIN_PULL_OWNER env (installed state, not a runtime override)", () => {
+    const up = writeCfg("updater");
+    // env says broker, config says updater → a correctly-adopted developer still PASSes (env ignored).
+    withEnv({ CATALYST_LAYER2_CONFIG_FILE: up, CATALYST_PLUGIN_PULL_OWNER: "broker" }, () => {
+      expect(ownerVerdict("developer")).toBe(STATUS.PASS);
+    });
+    const br = writeCfg("broker");
+    // env says updater, config says broker → a worker still PASSes (no stale-pull false FAIL from a stray env).
+    withEnv({ CATALYST_LAYER2_CONFIG_FILE: br, CATALYST_PLUGIN_PULL_OWNER: "updater" }, () => {
+      expect(ownerVerdict("worker")).toBe(STATUS.PASS);
+    });
+  });
+  // Codex P2 (thread 2): honor CATALYST_MACHINE_CONFIG / XDG when CATALYST_LAYER2_CONFIG_FILE is unset.
+  it("honors CATALYST_MACHINE_CONFIG and XDG_CONFIG_HOME for the config path (parity with install-lifecycle.layer2Path)", () => {
+    const p = writeCfg("updater");
+    withEnv({ CATALYST_MACHINE_CONFIG: p }, () => expect(ownerVerdict("developer")).toBe(STATUS.PASS));
+    const xdg = mkdtempSync(join(tmpdir(), "doctor-xdg-"));
+    mkdirSync(join(xdg, "catalyst"), { recursive: true });
+    writeFileSync(join(xdg, "catalyst", "config.json"), JSON.stringify({ catalyst: { orchestration: { pluginPullOwner: "updater" } } }));
+    withEnv({ XDG_CONFIG_HOME: xdg }, () => expect(ownerVerdict("developer")).toBe(STATUS.PASS));
+    rmSync(xdg, { recursive: true, force: true });
+  });
+  // Narrow parity: with NO transient env, doctor's config read agrees with the canonical resolver's config read.
+  it("agrees with resolvePluginPullOwner on the CONFIG value when no transient env is set", () => {
+    for (const owner of ["updater", "broker", null]) {
+      const p = writeCfg(owner);
+      const canonical = resolvePluginPullOwner({ env: {}, machineConfigPath: p });
+      withEnv({ CATALYST_LAYER2_CONFIG_FILE: p }, () => {
+        const expected = canonical === "updater" ? STATUS.FAIL : STATUS.PASS; // worker verdict encodes the owner
+        expect(ownerVerdict("worker")).toBe(expected);
+      });
+    }
+  });
 });
 
 describe("checksForClass wires the PR4 install-correctness checks into every arm (CTL-1369 PR4)", () => {

--- a/plugins/dev/scripts/execution-core/install-lifecycle.mjs
+++ b/plugins/dev/scripts/execution-core/install-lifecycle.mjs
@@ -622,13 +622,19 @@ export async function runInstallLifecycle({ operation, nodeClass, opts = {} }, d
   const seededPath = [cliBinDir, `${home}/.bun/bin`, `${home}/.local/bin`, env.PATH].filter(Boolean).join(":");
   const stepEnv = { ...env, CATALYST_NODE_CLASS: nodeClass, CATALYST_LAYER2_CONFIG_FILE: layer2, CATALYST_MACHINE_CONFIG: layer2, PATH: seededPath };
 
-  // CTL-1369 PR4: the doctor pre/post passes route through the lifecycle's INJECTED runStep by default
-  // (so a test stubbing runStep automatically stubs doctor too — no separate spawn), and remain
-  // overridable via deps.runDoctorPass for focused tests. Production passes neither → real runStep.
+  // CTL-1369 PR4: the doctor pre/post passes verify the node's PERSISTED installed state. The composed
+  // bash tools get CATALYST_NODE_CLASS pinned to the REQUESTED class (they must act on the target), but
+  // the DOCTOR must NOT — resolveNodeClass reads CATALYST_NODE_CLASS before Layer-2, so pinning it would
+  // make the node-class check PASS from the requested class even if write-config never persisted
+  // catalyst.node.class (Codex P2). So doctorEnv clears it (empty ⇒ resolveNodeClass falls through to the
+  // Layer-2 the install wrote, which CATALYST_LAYER2_CONFIG_FILE still points at). The doctor passes route
+  // through the lifecycle's INJECTED runStep by default (so a test stubbing runStep stubs doctor too) and
+  // remain overridable via deps.runDoctorPass for focused tests.
+  const doctorEnv = { ...stepEnv, CATALYST_NODE_CLASS: "" };
   const callDoctor = (argv) =>
     typeof runDoctorPass === "function"
-      ? runDoctorPass({ argv, env: stepEnv })
-      : defaultRunDoctorPass({ argv, env: stepEnv, runStep });
+      ? runDoctorPass({ argv, env: doctorEnv })
+      : defaultRunDoctorPass({ argv, env: doctorEnv, runStep });
 
   // Pre-flight live-node guard (teardown only) — refuse BEFORE starting a run.
   if (isTeardown(operation) && !opts.force) {

--- a/plugins/dev/scripts/execution-core/install-lifecycle.mjs
+++ b/plugins/dev/scripts/execution-core/install-lifecycle.mjs
@@ -646,7 +646,10 @@ export async function runInstallLifecycle({ operation, nodeClass, opts = {} }, d
   // Pre-flight: every composed script the plan will shell out to must exist. setup-catalyst.sh lives
   // at the repo root (NOT packaged in the plugin cache), so a cache-context run would otherwise take
   // a full backup — or, on reinstall, TEAR THE NODE DOWN — and only then fail. Fail fast instead.
-  const planScripts = [...new Set(plan.flatMap((p) => p.steps).filter((s) => s.argv).map((s) => s.argv[0]))];
+  // EXCEPTION: the kind:"doctor" step is ADVISORY (best-effort) — an absent catalyst-doctor binary must
+  // degrade the doctor pass to ok:null (defaultRunDoctorPass), NOT refuse an otherwise-valid install
+  // (CTL-1369 PR4 Codex P2). So it is excluded from this hard-prerequisite preflight.
+  const planScripts = [...new Set(plan.flatMap((p) => p.steps).filter((s) => s.argv && s.kind !== "doctor").map((s) => s.argv[0]))];
   const missingScripts = planScripts.filter((p) => !scriptExists(p));
   if (missingScripts.length) {
     log(

--- a/plugins/dev/scripts/execution-core/install-lifecycle.mjs
+++ b/plugins/dev/scripts/execution-core/install-lifecycle.mjs
@@ -93,6 +93,9 @@ export function resolveScripts(env = process.env) {
     setup: env.CATALYST_INSTALL_SETUP_SCRIPT || join(REPO_ROOT, "setup-catalyst.sh"),
     installCli: env.CATALYST_INSTALL_CLI_SCRIPT || join(SCRIPTS_DIR, "install-cli.sh"),
     stack: env.CATALYST_INSTALL_STACK_BIN || join(SCRIPTS_DIR, "catalyst-stack"),
+    // CTL-1369 PR4: the class-aware doctor, run as the install's pre-state observation + post-install
+    // verification (catalyst-doctor --profile install). Env-override seam for tests.
+    doctor: env.CATALYST_INSTALL_DOCTOR_BIN || join(SCRIPTS_DIR, "catalyst-doctor"),
   };
 }
 
@@ -273,7 +276,14 @@ export function planPhases({ operation, nodeClass, scripts, opts = {} }) {
 
   const healthcheck = () => ({
     phase: "healthcheck",
-    steps: [{ label: "verify-node", kind: "healthcheck", argv: [scripts.stack, "verify-node"] }],
+    steps: [
+      { label: "verify-node", kind: "healthcheck", argv: [scripts.stack, "verify-node"] },
+      // CTL-1369 PR4: the class-aware post-install verification — node-class + correct launchd agent
+      // SET + sane pluginPullOwner for the class (catalyst-doctor --profile install). Complements
+      // verify-node (daemon liveness + plugins-fresh). NON-fatal for rollback, but its verdict folds
+      // into healthOk → the command exit code, so a mis-provisioned node (wrong agents/owner) fails.
+      { label: "doctor", kind: "doctor", argv: [scripts.doctor, "--profile", "install", "--json"] },
+    ],
   });
 
   const stopDaemons = () => ({
@@ -518,6 +528,31 @@ function defaultProbeDrained({ scripts, env = process.env } = {}) {
   }
 }
 
+// runDoctorPass — CTL-1369 PR4. Run `catalyst-doctor --profile install --json` and parse its summary.
+// doctor's exit code is its FAIL count; its stdout is { ok, counts:{pass,warn,fail}, checks:[...] }.
+// Best-effort: an unrunnable/unparseable doctor returns { ok: null } (advisory — never fails an
+// otherwise-good install on a doctor/telemetry hiccup; the install IS done). Drives BOTH the
+// pre-install before-snapshot (observe-only) and the post-install verification (folds into healthOk).
+// Injectable runStep for tests.
+function defaultRunDoctorPass({ argv, env, runStep = defaultRunStep }) {
+  const r = runStep({ argv, env });
+  let parsed = null;
+  try {
+    parsed = JSON.parse(r.stdout);
+  } catch {
+    /* unparseable doctor output → advisory (ok:null) */
+  }
+  const fails = Array.isArray(parsed?.checks)
+    ? parsed.checks.filter((c) => c?.status === "fail").map((c) => c?.name)
+    : null;
+  return {
+    ok: parsed && typeof parsed.ok === "boolean" ? parsed.ok : null, // null = could not determine (advisory)
+    rc: r.code,
+    counts: parsed?.counts ?? null,
+    fails,
+  };
+}
+
 export function buildDefaultDeps(env) {
   const scripts = resolveScripts(env);
   return {
@@ -568,7 +603,7 @@ function isTeardown(operation) {
  *   InstallRunCtor.
  */
 export async function runInstallLifecycle({ operation, nodeClass, opts = {} }, deps) {
-  const { scripts, env, layer2, runStep, emit, nowFn, genTraceId, genSpanId, probeDaemons, probeResidualAgents, probeDrained, bundleHasCapturedAgents, scriptExists, binExists, probeUpdaterAgent, probeWorkerAgents, probeCliInstalled, log, InstallRunCtor } = deps;
+  const { scripts, env, layer2, runStep, runDoctorPass, emit, nowFn, genTraceId, genSpanId, probeDaemons, probeResidualAgents, probeDrained, bundleHasCapturedAgents, scriptExists, binExists, probeUpdaterAgent, probeWorkerAgents, probeCliInstalled, log, InstallRunCtor } = deps;
 
   // Every composed step inherits (a) the RESOLVED class so the bash tools (which re-derive class
   // env-first) cannot diverge from the lifecycle's target — e.g. `install --class developer` on a
@@ -586,6 +621,14 @@ export async function runInstallLifecycle({ operation, nodeClass, opts = {} }, d
   const cliBinDir = env.CATALYST_BIN_DIR || env.CATALYST_CLI_BIN_DIR || `${home}/.catalyst/bin`;
   const seededPath = [cliBinDir, `${home}/.bun/bin`, `${home}/.local/bin`, env.PATH].filter(Boolean).join(":");
   const stepEnv = { ...env, CATALYST_NODE_CLASS: nodeClass, CATALYST_LAYER2_CONFIG_FILE: layer2, CATALYST_MACHINE_CONFIG: layer2, PATH: seededPath };
+
+  // CTL-1369 PR4: the doctor pre/post passes route through the lifecycle's INJECTED runStep by default
+  // (so a test stubbing runStep automatically stubs doctor too — no separate spawn), and remain
+  // overridable via deps.runDoctorPass for focused tests. Production passes neither → real runStep.
+  const callDoctor = (argv) =>
+    typeof runDoctorPass === "function"
+      ? runDoctorPass({ argv, env: stepEnv })
+      : defaultRunDoctorPass({ argv, env: stepEnv, runStep });
 
   // Pre-flight live-node guard (teardown only) — refuse BEFORE starting a run.
   if (isTeardown(operation) && !opts.force) {
@@ -647,9 +690,29 @@ export async function runInstallLifecycle({ operation, nodeClass, opts = {} }, d
     return { outcome: "refused", reason: "live-worker-stack" };
   }
 
+  // CTL-1369 PR4: pre-install doctor — capture the node's BEFORE-state on the SAME class-aware
+  // install rubric the post-install verification uses, so the install trace shows before→after (the
+  // "SEE an install run" thesis). OBSERVE-ONLY: a fresh node legitimately FAILs the install profile
+  // (no agents yet), so this never refuses — the lifecycle's typed guards above (stale-updater /
+  // live-worker-stack / live-node) are the refusal mechanism for a genuinely bad pre-state. Only
+  // install/reinstall (the provisioning ops, which have doctor in their plan) get a before-snapshot.
+  // Best-effort (ok:null when doctor can't run); the summary rides the started event's body payload.
+  let preDoctor = null;
+  if (operation === "install" || operation === "reinstall") {
+    try {
+      preDoctor = callDoctor([scripts.doctor, "--profile", "install", "--json"]);
+      if (preDoctor) {
+        const c = preDoctor.counts;
+        log(`catalyst-install: pre-install doctor (--profile install): ${preDoctor.ok === null ? "could not run (advisory)" : preDoctor.ok ? "PASS" : `${c ? c.fail : "?"} fail`} (before-state)`);
+      }
+    } catch {
+      preDoctor = null; // observation must never break an install
+    }
+  }
+
   const traceId = genTraceId();
   const spanId = genSpanId();
-  const run = new InstallRunCtor({ operation, nodeClass, emit, traceId, spanId, nowFn }).start({ class: nodeClass });
+  const run = new InstallRunCtor({ operation, nodeClass, emit, traceId, spanId, nowFn }).start({ class: nodeClass, preDoctor });
 
   // Snapshot the node's PRE-RUN state BEFORE the first phase (acquire) writes anything. Used by
   // rollback: a fresh node (no managed keys / no CLI before the run) gets those artifacts removed,
@@ -668,7 +731,7 @@ export async function runInstallLifecycle({ operation, nodeClass, opts = {} }, d
     pluginDirs: readDeepKey(preCfg, "catalyst.orchestration.pluginDirs") ?? null,
   };
 
-  const ctx = { bundlePath: null, healthOk: true, healthRc: null, cleanOk: true, teardownRan: false };
+  const ctx = { bundlePath: null, healthOk: true, healthRc: null, cleanOk: true, teardownRan: false, doctorOk: true, doctorRc: null, doctorSummary: null };
 
   const runOneStep = async (step) => {
     switch (step.kind) {
@@ -722,6 +785,35 @@ export async function runInstallLifecycle({ operation, nodeClass, opts = {} }, d
         log(`catalyst-install: healthcheck (verify-node) ${ctx.healthOk ? "PASS" : `FAIL (rc ${r.code})`}`);
         return;
       }
+      case "doctor": {
+        // CTL-1369 PR4: post-install class-aware verification. NON-fatal for rollback (the node IS
+        // installed), but its verdict folds into healthOk → the command exit code. Best-effort: a
+        // doctor that can't run / can't be parsed (ok:null) is ADVISORY — it must not fail an
+        // otherwise-good install on a doctor hiccup; only an explicit doctor FAIL (ok:false) does.
+        // Best-effort + fail-safe: a doctor pass that THROWS (a future runStep/runDoctorPass contract
+        // change, or an injected stub that throws) must NOT propagate out of run.phase("healthcheck")
+        // into the outer catch — that would ROLL BACK an already-fully-provisioned node. Degrade to
+        // advisory (ok:null) instead, symmetric with the try/catch-guarded pre-install pass.
+        let summary;
+        try {
+          summary = callDoctor(step.argv) || { ok: null, rc: null, counts: null, fails: null };
+        } catch (e) {
+          summary = { ok: null, rc: null, counts: null, fails: null };
+          log(`catalyst-install: post-install doctor errored (advisory — install not failed): ${e?.message ?? e}`);
+        }
+        ctx.doctorSummary = summary;
+        ctx.doctorRc = summary.rc;
+        ctx.doctorOk = summary.ok !== false; // null (couldn't determine) → advisory PASS; false → fail
+        log(
+          `catalyst-install: doctor (--profile install) ` +
+            (summary.ok === null
+              ? "could not run (advisory — install not failed on this)"
+              : summary.ok
+                ? "PASS (node-class + agent set + pull-owner correct for class)"
+                : `FAIL [${(summary.fails || []).join(", ") || `rc ${summary.rc}`}] — node provisioned but not class-correct`),
+        );
+        return;
+      }
       case "verify-clean": {
         // NON-fatal for rollback, but the verdict drives the exit code for teardown ops (see main()).
         // Uses the residual-agent probe (NOT probeDaemons) so it honestly catches the updater agent —
@@ -758,8 +850,11 @@ export async function runInstallLifecycle({ operation, nodeClass, opts = {} }, d
       run.fail(e, { rolledBack: false, detail: { reason: "dirty-teardown", cleanOk: false } });
       return { outcome: "failed", error: e.message, healthOk: ctx.healthOk, healthRc: ctx.healthRc, cleanOk: false, bundlePath: ctx.bundlePath, traceId };
     }
-    run.complete({ class: nodeClass, healthOk: ctx.healthOk, cleanOk: ctx.cleanOk, bundle: ctx.bundlePath });
-    return { outcome: "completed", healthOk: ctx.healthOk, healthRc: ctx.healthRc, cleanOk: ctx.cleanOk, bundlePath: ctx.bundlePath, traceId };
+    // CTL-1369 PR4: the completed event carries BOTH doctor summaries (before via started, after here)
+    // so the install trace shows the node's health change. doctorOk folds into the command exit code
+    // (in main), so a node that provisioned but is NOT class-correct (wrong agents/owner) exits non-zero.
+    run.complete({ class: nodeClass, healthOk: ctx.healthOk, doctorOk: ctx.doctorOk, cleanOk: ctx.cleanOk, bundle: ctx.bundlePath, postDoctor: ctx.doctorSummary });
+    return { outcome: "completed", healthOk: ctx.healthOk, healthRc: ctx.healthRc, doctorOk: ctx.doctorOk, doctorRc: ctx.doctorRc, doctorFails: ctx.doctorSummary?.fails ?? null, cleanOk: ctx.cleanOk, bundlePath: ctx.bundlePath, traceId };
   } catch (err) {
     let rolledBack = false;
     // disposition: "none" = nothing to undo (failed before/at backup) → benign abort; "ok" = fully
@@ -1085,10 +1180,15 @@ export async function main(argv, depsOverride) {
   switch (result.outcome) {
     case "completed":
       // A dirty teardown (verify-clean found residual agents) is returned as outcome "failed" by
-      // runInstallLifecycle, so a "completed" install/uninstall here is genuinely clean. An unhealthy
-      // verify-node is still "completed" (the node IS installed) but exits 1.
+      // runInstallLifecycle, so a "completed" install/uninstall here is genuinely clean. A node that
+      // installed but is UNHEALTHY (verify-node) or NOT class-correct (post-install doctor FAIL —
+      // CTL-1369 PR4) is still "completed" (the node IS installed) but exits 1. doctorOk===false is an
+      // explicit doctor FAIL; doctorOk:true also covers the advisory "couldn't run" (ok:null) case.
       if (!result.healthOk) {
         errOut(`catalyst-install: ${args.operation} completed but verify-node reported the node UNHEALTHY (rc ${result.healthRc ?? "?"}).`);
+        code = 1;
+      } else if (result.doctorOk === false) {
+        errOut(`catalyst-install: ${args.operation} completed but the post-install doctor (--profile install) reported the node is NOT class-correct${result.doctorFails?.length ? ` [${result.doctorFails.join(", ")}]` : ""} — verify the launchd agent set + pluginPullOwner for class '${nodeClass}'.`);
         code = 1;
       } else {
         if (!args.json) out(`catalyst-install: ${args.operation} (${nodeClass}) completed.`);

--- a/plugins/dev/scripts/execution-core/install-lifecycle.test.mjs
+++ b/plugins/dev/scripts/execution-core/install-lifecycle.test.mjs
@@ -391,6 +391,23 @@ describe("runInstallLifecycle — doctor pre/post-install pass (CTL-1369 PR4)", 
     expect(res.outcome).toBe("completed");
     expect(res.doctorOk).toBe(true); // doctor couldn't run → advisory (ok:null)
   });
+
+  // Codex P2 (round 3): the doctor must verify the PERSISTED class, not the requested class pinned in env.
+  test("the doctor pre/post passes CLEAR CATALYST_NODE_CLASS (verify Layer-2 class) but keep CATALYST_LAYER2_CONFIG_FILE", async () => {
+    const bag = withRealRun(makeDeps());
+    bag.deps.env = { ...bag.deps.env, CATALYST_NODE_CLASS: "worker" }; // operator shell exports a conflicting class
+    const doctorEnvs = [];
+    bag.deps.runDoctorPass = ({ env }) => { doctorEnvs.push(env); return { ok: true, rc: 0, counts: { pass: 3, warn: 0, fail: 0 }, fails: [] }; };
+    await runInstallLifecycle({ operation: "install", nodeClass: "developer", opts: {} }, bag.deps);
+    expect(doctorEnvs.length).toBeGreaterThan(0); // pre + post
+    for (const env of doctorEnvs) {
+      expect(env.CATALYST_NODE_CLASS).toBe(""); // cleared → resolveNodeClass falls through to Layer-2 (the persisted class)
+      expect(env.CATALYST_LAYER2_CONFIG_FILE).toBe(bag.layer2); // but still points at the install's config
+    }
+    // the COMPOSED bash tools, by contrast, still get the requested class pinned (adopt-updater must act on it).
+    const adopt = bag.stepCalls.find((c) => c.argv.join(" ") === "STACK adopt-updater");
+    expect(adopt.env.CATALYST_NODE_CLASS).toBe("developer");
+  });
 });
 
 // ───────────────────────── runInstallLifecycle: telemetry + behavior ─────────────────────────

--- a/plugins/dev/scripts/execution-core/install-lifecycle.test.mjs
+++ b/plugins/dev/scripts/execution-core/install-lifecycle.test.mjs
@@ -9,7 +9,7 @@ import { readFileSync, writeFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
-import { INSTALL_PHASES } from "./lib/install-telemetry.mjs";
+import { INSTALL_PHASES, INSTALL_EVENT } from "./lib/install-telemetry.mjs";
 import {
   UNINSTALL_PHASES,
   REINSTALL_PHASES,
@@ -55,6 +55,7 @@ const SCRIPTS = {
   setup: "SETUP",
   installCli: "INSTALL_CLI",
   stack: "STACK",
+  doctor: "DOCTOR", // CTL-1369 PR4: the pre/post-install doctor pass (catalyst-doctor --profile install)
 };
 
 // makeDeps — a fully-stubbed dep set. `failOn` is a predicate (argv|joined → truthy = fail with
@@ -265,6 +266,120 @@ describe("planPhases — per-class correctness (pure)", () => {
   });
   test("unknown operation throws", () => {
     expect(() => planPhases({ operation: "frobnicate", nodeClass: "worker", scripts: SCRIPTS })).toThrow(/unknown operation/);
+  });
+  // CTL-1369 PR4: the healthcheck phase runs verify-node AND the class-aware doctor (--profile install).
+  test("install/reinstall healthcheck runs verify-node then doctor (--profile install); uninstall has neither", () => {
+    for (const operation of ["install", "reinstall"]) {
+      const hc = planPhases({ operation, nodeClass: "worker", scripts: SCRIPTS }).find((p) => p.phase === "healthcheck");
+      const labels = hc.steps.map((s) => s.label);
+      expect(labels).toEqual(["verify-node", "doctor"]);
+      const doctorStep = hc.steps.find((s) => s.label === "doctor");
+      expect(doctorStep.kind).toBe("doctor");
+      expect(doctorStep.argv).toEqual(["DOCTOR", "--profile", "install", "--json"]);
+    }
+    // uninstall ends with verify-clean — no healthcheck phase, no doctor step.
+    expect(planPhases({ operation: "uninstall", nodeClass: "worker", scripts: SCRIPTS }).some((p) => p.phase === "healthcheck")).toBe(false);
+    expect(stepLabels(planPhases({ operation: "uninstall", nodeClass: "worker", scripts: SCRIPTS }))).not.toContain("doctor");
+  });
+});
+
+// ───────────────────────── CTL-1369 PR4: doctor pre/post-install pass ─────────────────────────
+describe("runInstallLifecycle — doctor pre/post-install pass (CTL-1369 PR4)", () => {
+  // Inject a runDoctorPass returning a fixed summary so the pre/post passes are deterministic.
+  const withDoctor = (summary, over = {}) => {
+    const bag = withRealRun(makeDeps(over));
+    bag.deps.runDoctorPass = () => summary;
+    return bag;
+  };
+
+  // Both provisioning ops (install AND reinstall) capture the before-snapshot — parametrized so the
+  // `|| operation === "reinstall"` arm is genuinely exercised (a future narrowing to install-only fails here).
+  for (const operation of ["install", "reinstall"]) {
+    test(`the ${operation} started event carries the pre-install doctor before-snapshot; completed carries the after`, async () => {
+      const summary = { ok: false, rc: 1, counts: { pass: 1, warn: 0, fail: 1 }, fails: ["agents-for-class"] };
+      const { deps, events } = withDoctor(summary); // makeDeps default daemonsLive=false → reinstall passes the teardown guard
+      await runInstallLifecycle({ operation, nodeClass: "worker", opts: {} }, deps);
+      const started = events.find((e) => e.event === INSTALL_EVENT.started);
+      const completed = events.find((e) => e.event === INSTALL_EVENT.completed);
+      expect(started.detail.preDoctor).toEqual(summary); // before-state observable in the trace
+      expect(completed.detail.postDoctor).toEqual(summary); // after-state too
+    });
+  }
+
+  test("a post-install doctor FAIL → outcome completed (node IS installed) but doctorOk=false", async () => {
+    const { deps } = withDoctor({ ok: false, rc: 1, counts: { pass: 1, warn: 0, fail: 1 }, fails: ["agents-for-class"] });
+    const res = await runInstallLifecycle({ operation: "install", nodeClass: "worker", opts: {} }, deps);
+    expect(res.outcome).toBe("completed");
+    expect(res.doctorOk).toBe(false);
+    expect(res.doctorFails).toEqual(["agents-for-class"]);
+  });
+
+  test("a post-install doctor PASS → doctorOk=true", async () => {
+    const { deps } = withDoctor({ ok: true, rc: 0, counts: { pass: 3, warn: 0, fail: 0 }, fails: [] });
+    const res = await runInstallLifecycle({ operation: "install", nodeClass: "worker", opts: {} }, deps);
+    expect(res.outcome).toBe("completed");
+    expect(res.doctorOk).toBe(true);
+  });
+
+  test("a doctor that can't run (ok:null) is ADVISORY — doctorOk stays true (never fails a good install)", async () => {
+    const { deps } = withDoctor({ ok: null, rc: 127, counts: null, fails: null });
+    const res = await runInstallLifecycle({ operation: "install", nodeClass: "worker", opts: {} }, deps);
+    expect(res.outcome).toBe("completed");
+    expect(res.doctorOk).toBe(true);
+  });
+
+  test("uninstall does NOT run a pre-install doctor (no before-snapshot on a teardown-only op)", async () => {
+    const { deps, events } = withDoctor({ ok: true, rc: 0, counts: { pass: 3, warn: 0, fail: 0 }, fails: [] }, { drained: true });
+    await runInstallLifecycle({ operation: "uninstall", nodeClass: "worker", opts: { force: true } }, deps);
+    const started = events.find((e) => e.event === INSTALL_EVENT.started);
+    expect(started.detail.preDoctor ?? null).toBeNull();
+  });
+
+  test("the pre-install doctor is OBSERVE-only — a FAIL before-state does NOT refuse a fresh install", async () => {
+    // Fresh worker: pre-install doctor FAILs (no agents yet) but the install must still proceed.
+    const { deps } = withDoctor({ ok: false, rc: 1, counts: { pass: 0, warn: 0, fail: 2 }, fails: ["agents-for-class", "node-class"] });
+    const res = await runInstallLifecycle({ operation: "install", nodeClass: "worker", opts: {} }, deps);
+    expect(res.outcome).toBe("completed"); // proceeded despite the FAIL before-state
+  });
+
+  // The PRODUCTION parser (defaultRunDoctorPass) — exercised by OMITTING deps.runDoctorPass and feeding
+  // representative `catalyst-doctor --json` stdout through the lifecycle's runStep seam. This pins the
+  // load-bearing coupling to doctor's renderJson shape (status==="fail" ↔ STATUS.FAIL, ok/counts/checks).
+  const withDoctorStdout = ({ code, stdout }) => {
+    const bag = withRealRun(makeDeps());
+    const orig = bag.deps.runStep;
+    bag.deps.runStep = (call) => (call.argv[0] === "DOCTOR" ? { code, stdout, stderr: "" } : orig(call));
+    // NB: deliberately NOT setting bag.deps.runDoctorPass → defaultRunDoctorPass parses for real.
+    return bag;
+  };
+
+  test("defaultRunDoctorPass parses real doctor JSON into { ok, rc, counts, fails }", async () => {
+    const doctorJson = JSON.stringify({
+      ok: false,
+      counts: { pass: 1, warn: 0, fail: 1 },
+      checks: [{ name: "agents-for-class", status: "fail" }, { name: "node-class", status: "pass" }],
+    });
+    const { deps, events } = withDoctorStdout({ code: 1, stdout: doctorJson });
+    const res = await runInstallLifecycle({ operation: "install", nodeClass: "worker", opts: {} }, deps);
+    expect(res.doctorOk).toBe(false);
+    expect(res.doctorFails).toEqual(["agents-for-class"]); // only the fail-status check names
+    const completed = events.find((e) => e.event === INSTALL_EVENT.completed);
+    expect(completed.detail.postDoctor).toMatchObject({ ok: false, rc: 1, counts: { pass: 1, warn: 0, fail: 1 }, fails: ["agents-for-class"] });
+  });
+
+  test("defaultRunDoctorPass degrades unparseable doctor stdout to ok:null (advisory — install not failed)", async () => {
+    const { deps } = withDoctorStdout({ code: 2, stdout: "{not valid json" });
+    const res = await runInstallLifecycle({ operation: "install", nodeClass: "worker", opts: {} }, deps);
+    expect(res.outcome).toBe("completed");
+    expect(res.doctorOk).toBe(true); // ok:null → advisory
+  });
+
+  test("a post-install doctor that THROWS is advisory — the install completes, NOT rolled back (best-effort invariant)", async () => {
+    const bag = withRealRun(makeDeps());
+    bag.deps.runDoctorPass = () => { throw new Error("doctor blew up"); };
+    const res = await runInstallLifecycle({ operation: "install", nodeClass: "worker", opts: {} }, bag.deps);
+    expect(res.outcome).toBe("completed"); // a throwing doctor must NOT propagate → rollback
+    expect(res.doctorOk).toBe(true); // degraded to advisory
   });
 });
 
@@ -812,20 +927,48 @@ describe("main — CLI exit codes", () => {
     const c = capture();
     expect(await main(["install", "--class"], c.depsOverride)).toBe(2);
   });
+  // CTL-1369 PR4: the post-install doctor verdict folds into the command exit code.
+  test("completed install but post-install doctor FAIL → exit 1, with a class-correctness message", async () => {
+    const d = execDeps();
+    const code = await main(["install", "--class", "worker"], {
+      ...d.depsOverride,
+      runDoctorPass: () => ({ ok: false, rc: 1, counts: { pass: 1, warn: 0, fail: 1 }, fails: ["agents-for-class"] }),
+    });
+    expect(code).toBe(1);
+    expect(d.errOut.join("\n")).toMatch(/NOT class-correct.*agents-for-class/);
+  });
+  test("completed install, doctor PASS → exit 0", async () => {
+    const d = execDeps();
+    const code = await main(["install", "--class", "worker"], {
+      ...d.depsOverride,
+      runDoctorPass: () => ({ ok: true, rc: 0, counts: { pass: 3, warn: 0, fail: 0 }, fails: [] }),
+    });
+    expect(code).toBe(0);
+  });
+  test("completed install, doctor advisory (ok:null, couldn't run) → exit 0 (never fails a good install)", async () => {
+    const d = execDeps();
+    const code = await main(["install", "--class", "worker"], {
+      ...d.depsOverride,
+      runDoctorPass: () => ({ ok: null, rc: 127, counts: null, fails: null }),
+    });
+    expect(code).toBe(0);
+  });
 });
 
 // ───────────────────────── seams + invariants ─────────────────────────
 describe("resolveScripts seams", () => {
   test("env overrides win over computed defaults", () => {
-    const s = resolveScripts({ CATALYST_INSTALL_SETUP_SCRIPT: "/custom/setup.sh", CATALYST_INSTALL_STACK_BIN: "/custom/stack" });
+    const s = resolveScripts({ CATALYST_INSTALL_SETUP_SCRIPT: "/custom/setup.sh", CATALYST_INSTALL_STACK_BIN: "/custom/stack", CATALYST_INSTALL_DOCTOR_BIN: "/custom/doctor" });
     expect(s.setup).toBe("/custom/setup.sh");
     expect(s.stack).toBe("/custom/stack");
+    expect(s.doctor).toBe("/custom/doctor"); // CTL-1369 PR4 seam
   });
   test("computed defaults resolve real toolchain paths", () => {
     const s = resolveScripts({});
     expect(s.installCli).toMatch(/install-cli\.sh$/);
     expect(s.setup).toMatch(/setup-catalyst\.sh$/);
     expect(s.backup).toMatch(/catalyst-backup$/);
+    expect(s.doctor).toMatch(/catalyst-doctor$/); // CTL-1369 PR4
   });
   test("layer2Path honors CATALYST_LAYER2_CONFIG_FILE > CATALYST_MACHINE_CONFIG > XDG (no silent clobber)", () => {
     expect(layer2Path({ CATALYST_LAYER2_CONFIG_FILE: "/a.json", CATALYST_MACHINE_CONFIG: "/b.json" })).toBe("/a.json");

--- a/plugins/dev/scripts/execution-core/install-lifecycle.test.mjs
+++ b/plugins/dev/scripts/execution-core/install-lifecycle.test.mjs
@@ -381,6 +381,16 @@ describe("runInstallLifecycle — doctor pre/post-install pass (CTL-1369 PR4)", 
     expect(res.outcome).toBe("completed"); // a throwing doctor must NOT propagate → rollback
     expect(res.doctorOk).toBe(true); // degraded to advisory
   });
+
+  // Codex P2 (thread 1): the advisory doctor binary is NOT a hard install prerequisite.
+  test("an ABSENT catalyst-doctor binary does NOT refuse the install (excluded from the missing-script preflight)", async () => {
+    const bag = withRealRun(makeDeps());
+    bag.deps.scriptExists = (p) => p !== "DOCTOR"; // doctor missing, every other composed script present
+    const res = await runInstallLifecycle({ operation: "install", nodeClass: "worker", opts: {} }, bag.deps);
+    expect(res.outcome).not.toBe("refused"); // a missing advisory verifier must not block provisioning
+    expect(res.outcome).toBe("completed");
+    expect(res.doctorOk).toBe(true); // doctor couldn't run → advisory (ok:null)
+  });
 });
 
 // ───────────────────────── runInstallLifecycle: telemetry + behavior ─────────────────────────

--- a/plugins/dev/scripts/execution-core/lib/install-telemetry.mjs
+++ b/plugins/dev/scripts/execution-core/lib/install-telemetry.mjs
@@ -67,6 +67,13 @@ export function buildInstallEnvelope({
   hostNameVal,
   phase = null,
   outcome = null,
+  // CTL-1369 PR4: per-phase duration PROMOTED to a top-level attribute (see the attributes block)
+  // so the OTEL histogram connector — which gates on event_name=="catalyst.install.phase" and reads
+  // attributes["catalyst.install.phase_duration_ms"] — can build
+  // catalyst_install_duration_seconds{operation,phase}. Kept in MILLISECONDS (the connector divides
+  // by 1000); null on every non-phase event. (catalyst-updater-otel md-channel turn 21: name + unit
+  // LOCKED.) It is NOT a low-card label dim — it is a numeric measurement the connector reads.
+  phaseDurationMs = null,
   detail = null,
   severity = "INFO",
   traceId = null,
@@ -105,6 +112,10 @@ export function buildInstallEnvelope({
       "catalyst.install.phase": phase,
       "catalyst.install.outcome": outcome,
       "event.label": operation,
+      // CTL-1369 PR4 / OTEL turn 21: per-phase duration in MILLISECONDS, top-level so the histogram
+      // connector reads it directly. null on non-phase events (the connector only reads it on
+      // catalyst.install.phase). A measurement, not a label — kept out of the low-card dims above.
+      "catalyst.install.phase_duration_ms": Number.isFinite(phaseDurationMs) ? phaseDurationMs : null,
     },
     body: { payload: detail ?? {} },
     caused_by: null,
@@ -123,10 +134,10 @@ export function makeInstallEmitFn({ getLogPathFn = getEventLogPath, nowFn = Date
   // (which owns the run's class + trace context) stamps every event authoritatively — e.g.
   // `reinstall --class developer` on a worker node must stamp the REQUESTED class, not the
   // current config's. Falls back to the baked class when the caller omits it.
-  return ({ event, operation = null, phase = null, outcome = null, detail = null, severity = "INFO", nodeClass: ncOverride, traceId = null, spanId = null } = {}) => {
+  return ({ event, operation = null, phase = null, outcome = null, phaseDurationMs = null, detail = null, severity = "INFO", nodeClass: ncOverride, traceId = null, spanId = null } = {}) => {
     try {
       const logPath = getLogPathFn();
-      const envelope = buildInstallEnvelope({ event, operation, nodeClass: ncOverride ?? cls, hostNameVal: host, phase, outcome, detail, severity, traceId, spanId, nowFn });
+      const envelope = buildInstallEnvelope({ event, operation, nodeClass: ncOverride ?? cls, hostNameVal: host, phase, outcome, phaseDurationMs, detail, severity, traceId, spanId, nowFn });
       mkdirSync(dirname(logPath), { recursive: true });
       appendFileSync(logPath, `${JSON.stringify(envelope)}\n`);
     } catch {
@@ -176,13 +187,18 @@ export class InstallRun {
       const result = typeof fn === "function" ? await fn() : undefined;
       const endEpochMs = this.nowFn();
       this.phases.push({ name, startEpochMs, endEpochMs, ok: true });
-      this._emit({ event: INSTALL_EVENT.phase, phase: name, detail: { duration_ms: endEpochMs - startEpochMs } });
+      // duration_ms stays in body.payload (back-compat) AND is promoted to the top-level
+      // catalyst.install.phase_duration_ms attribute the OTEL histogram connector reads (PR4).
+      this._emit({ event: INSTALL_EVENT.phase, phase: name, phaseDurationMs: endEpochMs - startEpochMs, detail: { duration_ms: endEpochMs - startEpochMs } });
       return result;
     } catch (err) {
       const endEpochMs = this.nowFn();
       const errMsg = err?.message ?? String(err);
       this.phases.push({ name, startEpochMs, endEpochMs, ok: false, error: errMsg });
-      this._emit({ event: INSTALL_EVENT.phase, phase: name, outcome: "failed", severity: "ERROR", detail: { error: errMsg } });
+      // A FAILED phase still has a measured duration — promote it too so the histogram captures the
+      // time spent before the failure (the connector buckets by {operation,phase} regardless of outcome).
+      // duration_ms also rides the body here (parity with the success emit), alongside the error.
+      this._emit({ event: INSTALL_EVENT.phase, phase: name, outcome: "failed", severity: "ERROR", phaseDurationMs: endEpochMs - startEpochMs, detail: { error: errMsg, duration_ms: endEpochMs - startEpochMs } });
       throw err;
     }
   }

--- a/plugins/dev/scripts/execution-core/lib/install-telemetry.test.mjs
+++ b/plugins/dev/scripts/execution-core/lib/install-telemetry.test.mjs
@@ -186,3 +186,65 @@ describe("InstallRun (the lifecycle recorder PR2 drives)", () => {
     expect(INSTALL_PHASES).toEqual(["acquire", "backup", "write-config", "install-agents", "start-daemons", "healthcheck"]);
   });
 });
+
+// CTL-1369 PR4 / OTEL turn 21: per-phase duration promoted to a top-level attribute so the OTEL
+// histogram connector (gates on event_name=="catalyst.install.phase", reads
+// attributes["catalyst.install.phase_duration_ms"], divides ÷1000) can build
+// catalyst_install_duration_seconds{operation,phase}. The attribute is MILLISECONDS, null elsewhere.
+describe("phase_duration_ms promotion (the OTEL histogram input)", () => {
+  test("buildInstallEnvelope promotes a finite phaseDurationMs to the top-level attribute (ms)", () => {
+    const env = buildInstallEnvelope({ event: INSTALL_EVENT.phase, operation: "install", phase: "backup", phaseDurationMs: 42 });
+    expect(env.attributes["catalyst.install.phase_duration_ms"]).toBe(42);
+    // It is a measurement attribute, NOT one of the low-card label dims.
+    expect(env.attributes["catalyst.install.phase"]).toBe("backup");
+  });
+
+  test("the attribute is null on a non-phase event (and when phaseDurationMs is omitted)", () => {
+    expect(buildInstallEnvelope({ event: INSTALL_EVENT.started, operation: "install" }).attributes["catalyst.install.phase_duration_ms"]).toBeNull();
+    expect(buildInstallEnvelope({ event: INSTALL_EVENT.completed, outcome: "completed" }).attributes["catalyst.install.phase_duration_ms"]).toBeNull();
+    // a non-finite value (e.g. NaN/Infinity) degrades to null, never leaks a bad number to the connector.
+    expect(buildInstallEnvelope({ event: INSTALL_EVENT.phase, phaseDurationMs: Number.NaN }).attributes["catalyst.install.phase_duration_ms"]).toBeNull();
+  });
+
+  test("makeInstallEmitFn writes the phase_duration_ms attribute to the JSONL line", () => {
+    const logPath = tmpLog();
+    const emit = makeInstallEmitFn({ getLogPathFn: () => logPath, nowFn: () => 0, nodeClass: "worker", hostNameVal: "mini" });
+    emit({ event: INSTALL_EVENT.phase, operation: "install", phase: "acquire", phaseDurationMs: 7 });
+    const env = JSON.parse(readFileSync(logPath, "utf8").trim());
+    expect(env.attributes["catalyst.install.phase_duration_ms"]).toBe(7);
+  });
+
+  test("InstallRun.phase emits the measured duration as the top-level attribute (ms) on success", async () => {
+    const events = [];
+    // increment-by-1 clock (the file's idiom): phase-start and phase-end are consecutive nowFn calls,
+    // so the measured delta is a positive integer. We assert the PROMOTED value === the body's measured
+    // duration (both = endEpochMs-startEpochMs), proving the promotion carries the same timed delta.
+    const run = new InstallRun({
+      operation: "install",
+      nodeClass: "worker",
+      emit: (e) => events.push(e),
+      nowFn: (() => { let t = 0; return () => (t += 1); })(),
+    });
+    run.start();
+    await run.phase("acquire", () => "ok");
+    const phaseEvent = events.find((e) => e.event === INSTALL_EVENT.phase);
+    expect(phaseEvent.phaseDurationMs).toBeGreaterThan(0);
+    expect(phaseEvent.phaseDurationMs).toBe(phaseEvent.detail.duration_ms);
+  });
+
+  test("a FAILED phase also carries phase_duration_ms (the histogram buckets by phase regardless of outcome)", async () => {
+    const events = [];
+    const run = new InstallRun({
+      operation: "install",
+      nodeClass: "worker",
+      emit: (e) => events.push(e),
+      nowFn: (() => { let t = 0; return () => (t += 1); })(),
+    });
+    run.start();
+    await expect(run.phase("backup", () => { throw new Error("boom"); })).rejects.toThrow("boom");
+    const phaseEvent = events.find((e) => e.event === INSTALL_EVENT.phase);
+    expect(phaseEvent.outcome).toBe("failed");
+    expect(typeof phaseEvent.phaseDurationMs).toBe("number");
+    expect(phaseEvent.phaseDurationMs).toBeGreaterThanOrEqual(0);
+  });
+});


### PR DESCRIPTION
The **CTL-1369 endgame (PR 4/4)** — makes `catalyst install` self-verifying and closes the OTEL per-phase duration histogram gate. After this merges, CTL-1369 → Done. Additive; INERT until someone runs `catalyst install`.

## What's in it

**1. Telemetry — promote `catalyst.install.phase_duration_ms`** to a top-level attribute (milliseconds) on the `catalyst.install.phase` event (success *and* failure emits). The OTEL histogram connector reads it (÷1000) to build `catalyst_install_duration_seconds{operation,phase}`. Name + unit locked with OTEL (`catalyst-updater-otel` md-channel turn 21). `body.payload.duration_ms` retained for back-compat.

**2. Doctor — two class-correctness checks** + a focused install-verification profile:
- `checkAgentsForClass` — the correct launchd agent SET per class (`catalyst-stack` ⟺ worker, `catalyst-updater` ⟺ developer/monitor; a node with **both** = the CTL-1348 two-puller hazard).
- `checkPluginPullOwner` — worker→broker, developer/monitor→updater. Mirrors `broker/plugin-refresh.mjs::resolvePluginPullOwner` (with a parity test).
- Wired into all three `checksForClass` arms at **`strict:false`**: a genuine class **mismatch** is always FAIL, but a not-yet-provisioned node is **WARN** — so `catalyst-join`'s `do_doctor_gate` (which runs doctor *before* `install-services`) does not fail-close on a fresh node.
- `installChecksForClass` (the strict, offline post-install subset) + a `--profile install` / `--install` flag.

**3. Install wiring — `catalyst install` runs a doctor pre/post pass:**
- **Pre** (observe-only) → the node's before-snapshot rides the `started` event body.
- **Post** → a `doctor` step inside the **OTEL-locked `healthcheck` phase** (no new phase); its verdict rides the `completed` event body and folds into the command exit code (a node that installed but is *not* class-correct exits non-zero).
- Both passes are **best-effort + fail-safe**: a doctor that can't run / can't be parsed / throws is advisory and never fails (or rolls back) an otherwise-good install.

## Verification
- Built TDD. Reviewed with a 5-lens adversarial workflow — the *per-class-correctness* and *join-gate-safety* lenses found nothing; the verifier's 3 confirmed test-coverage gaps are fixed and 2 refuted items hardened defensively (post-doctor `try/catch` symmetry, trimmed an untested alias).
- **316** execution-core mjs tests green; bash launcher smoke test, CLI-reference drift test, and install-lifecycle import-graph build all pass.
- Live: `catalyst-doctor --profile install` returns a clean PASS on the laptop developer node (node-class + agent-set + pull-owner all correct).

🤖 Generated with [Claude Code](https://claude.com/claude-code)