### PR TITLE
feat(dev): CTL-1392 — agents read the Catalyst Cloud replica first (evidence-based fallback)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,7 +43,7 @@ No build process — this is markdown files and bash scripts.
 - **Wait for all agents before synthesizing** — Don't proceed until research completes
 - **Config drives behavior** — No hardcoded values
 - **Single source of truth** — Don't duplicate information across files:
-  - CLI syntax lives in skills (e.g., the `linearis` skill) — reference it, don't copy
+  - CLI syntax lives in skills (e.g., the `linearis` skill, which also defines the two-mode rule for agent Linear reads — standard vs. Catalyst Cloud node) — reference it, don't copy
   - Workflow logic lives in skills — each skill owns its own state transitions
   - Config schema lives in `website/src/content/docs/reference/configuration.md`
 - **Spawn parallel agents** — Maximize efficiency

--- a/plugins/dev/agents/linear-research.md
+++ b/plugins/dev/agents/linear-research.md
@@ -46,6 +46,8 @@ not guess or improvise commands**.
 
 All linearis output is JSON — use jq for filtering and transformation.
 
+**Read-source mode**: Follow the two-mode Linear read rule in the `catalyst-dev:linearis` skill ("Reading Linear" section) — standard nodes call `linearis` directly; Catalyst Cloud nodes prefer the local replica first and escalate to `linearis` only on concrete evidence of staleness.
+
 ## Output Format
 
 Present findings as structured data:

--- a/plugins/dev/skills/compound-estimate/SKILL.md
+++ b/plugins/dev/skills/compound-estimate/SKILL.md
@@ -172,6 +172,7 @@ what_surprised_me: "Prometheus integration wasn't plumbed; local state.json suff
 - **Primary cost source** is local: the `catalyst-state.sh` worker-usage aggregate (when orchestrated) or `catalyst-session.sh history` (standalone). This is deliberate — `claude-code-otel` + Prometheus is referenced in the original spec but not yet wired up in this repo.
 - **Prometheus overlay** is gated by `CATALYST_PROMETHEUS_URL`. When set, the helper logs a note to stderr; the HTTP client itself is a follow-up ticket.
 - **Linear estimate** is read as an integer from `linearis issues read`. The team's estimation config (T-shirt, Fibonacci, linear) is applied client-side when re-scoring in step 3.
+- **Read source:** `linearis issues read` is the standard-node direct read; on a Catalyst Cloud node the replica is read first (evidence-based fallback to `linearis`) — see the `linearis` skill's "Reading Linear" section.
 
 ## Testing
 

--- a/plugins/dev/skills/describe-pr/SKILL.md
+++ b/plugins/dev/skills/describe-pr/SKILL.md
@@ -513,4 +513,4 @@ keys.
 - **Run verification** — attempt all automated checks
 - **Link Linear** — extract ticket, update status
 - **Metadata tracking** — commit history, timestamps
-- For Linearis CLI syntax, see the `linearis` skill reference
+- For Linearis CLI syntax and the two-mode read rule (standard vs Cloud node), see the `linearis` skill's "Reading Linear" section

--- a/plugins/dev/skills/linear/SKILL.md
+++ b/plugins/dev/skills/linear/SKILL.md
@@ -415,7 +415,7 @@ syntax.
 
 ---
 
-For Linearis CLI syntax, see the `linearis` skill reference.
+For Linearis CLI syntax, see the `linearis` skill reference. For the two-mode read rule (standard node direct `linearis` reads vs Catalyst Cloud replica-first reads), see the "Reading Linear" section of the `linearis` skill (`/catalyst-dev:linearis`).
 
 ---
 

--- a/plugins/dev/skills/linearis/SKILL.md
+++ b/plugins/dev/skills/linearis/SKILL.md
@@ -29,17 +29,26 @@ linearis cycles usage         # Just cycle operations
 
 ## Reading Linear
 
-**Two-mode rule — pick your read source by deployment context. Writes never change.**
+**The read source is decided by whether the local Catalyst Cloud replica is opted in
+*and* live — NOT by whether the node has a Cloud key. Writes never change.** The easiest
+way to honor this rule is to call **`catalyst-linear read|list|search`** (CTL-1391): it
+resolves the source itself and fails open to `linearis`, so you never decide based on
+node identity.
 
-### Mode 1 — Standard node (no Catalyst Cloud key)
+### Mode 1 — Direct (default)
 
-Read Linear **directly**: `linearis issues read|list|search`. There is **no local
-mirror**. (The broker's `filter-state.db` still exists for orchestration fencing and
-the board UI, but it is **not** a Linear read path — do not read ticket state from it.)
+When the replica is **not opted in** (`CATALYST_LINEAR_REPLICA` unset/`off` *and* Layer-2
+`catalyst.linearReplica.mode` not `on`) **or** no fresh replica file is present, read Linear
+**directly**: `linearis issues read|list|search`. There is **no local mirror**. A node that
+*has* a Cloud key but has not flipped the replica flag on is in this mode. (The broker's
+`filter-state.db` still exists for orchestration fencing and the board UI, but it is **not**
+a Linear read path — do not read ticket state from it.)
 
-### Mode 2 — Catalyst Cloud node (`@catalyst-cloud/sdk` replica active)
+### Mode 2 — Replica-first (opted in *and* a live replica present)
 
-A live local SQLite replica is kept current by the Cloud change-feed.
+When the replica is **opted in** (`CATALYST_LINEAR_REPLICA=on` or Layer-2
+`catalyst.linearReplica.mode=on`) **and** a fresh local SQLite replica — kept current by
+the Cloud change-feed — is present:
 
 - **Read the replica FIRST** and **trust it** as the authoritative local copy.
 - Do **NOT** reflexively re-verify against live Linear — that defeats the cache and
@@ -61,17 +70,19 @@ through `linearis`. The replica is **read-only** in both modes.
 
 - **Daemon read paths** resolve the mode automatically via the read-source seam
   (CTL-1390) — callers do not choose.
-- **Agent / skill ad-hoc reads:** prefer the replica-backed read on a Cloud node;
-  `linearis` is the direct path on a standard node and the evidence-triggered fallback
-  on a Cloud node.
+- **Agent / skill ad-hoc reads:** use **`catalyst-linear read <ID>`** (CTL-1391). It
+  applies the rule above for you — replica-first when opted in *and* fresh, automatic
+  fail-open to `linearis` otherwise — so the **same command is correct on every node**.
+  Output matches `linearis` JSON plus an additive `_meta` (read source + replica
+  freshness). `list`/`search` are `linearis` passthrough today (a replica-backed list
+  view is a follow-up).
 
-> **Mechanism note (honest status).** A first-class replica-aware read command for
-> ad-hoc agent use is **forthcoming** (CTL-1391, child of CTL-1390). Until it ships,
-> `linearis issues read|list|search` is the concrete command in both modes: the direct
-> path on a standard node, and the manual path on a Cloud node (you will not yet get
-> automatic replica-first behavior for ad-hoc reads — only the daemon does, via the
-> seam). Write this rule against the intent; use `linearis` as the executable command
-> today.
+> **Mechanism note.** `catalyst-linear` is the executable form of this rule (read-model
+> over the replica first, `linearis` fallback). Plain `linearis issues read|list|search`
+> stays correct everywhere — it is exactly what `catalyst-linear` falls back to — so
+> existing direct calls are fine. Prefer `catalyst-linear` for ad-hoc reads so a node
+> that *has* opted into the replica actually gets replica-first behavior automatically,
+> instead of every caller re-deciding from node identity.
 
 ## Gotchas & Traps
 

--- a/plugins/dev/skills/linearis/SKILL.md
+++ b/plugins/dev/skills/linearis/SKILL.md
@@ -27,6 +27,52 @@ linearis milestones usage     # Just milestone operations
 linearis cycles usage         # Just cycle operations
 ```
 
+## Reading Linear
+
+**Two-mode rule — pick your read source by deployment context. Writes never change.**
+
+### Mode 1 — Standard node (no Catalyst Cloud key)
+
+Read Linear **directly**: `linearis issues read|list|search`. There is **no local
+mirror**. (The broker's `filter-state.db` still exists for orchestration fencing and
+the board UI, but it is **not** a Linear read path — do not read ticket state from it.)
+
+### Mode 2 — Catalyst Cloud node (`@catalyst-cloud/sdk` replica active)
+
+A live local SQLite replica is kept current by the Cloud change-feed.
+
+- **Read the replica FIRST** and **trust it** as the authoritative local copy.
+- Do **NOT** reflexively re-verify against live Linear — that defeats the cache and
+  burns the API budget.
+- **Evidence-based escalation only.** Fall back to a direct `linearis` read for a
+  specific item *only* when you have concrete evidence the replica read is wrong:
+  it contradicts something you just directly observed; the replica freshness/staleness
+  signal shows it is behind; or a ticket you expect is missing. When you escalate:
+  - (a) read that item directly with `linearis`, **and**
+  - (b) **surface the staleness as an issue** — a stale replica read signals a mirror
+    gap (e.g. a missed webhook) worth investigating, not just a one-off retry.
+
+### Writes — always `linearis`, both modes
+
+`create` / `update` / state transitions / `discuss` / estimate / label **always** go
+through `linearis`. The replica is **read-only** in both modes.
+
+### How reads resolve
+
+- **Daemon read paths** resolve the mode automatically via the read-source seam
+  (CTL-1390) — callers do not choose.
+- **Agent / skill ad-hoc reads:** prefer the replica-backed read on a Cloud node;
+  `linearis` is the direct path on a standard node and the evidence-triggered fallback
+  on a Cloud node.
+
+> **Mechanism note (honest status).** A first-class replica-aware read command for
+> ad-hoc agent use is **forthcoming** (CTL-1391, child of CTL-1390). Until it ships,
+> `linearis issues read|list|search` is the concrete command in both modes: the direct
+> path on a standard node, and the manual path on a Cloud node (you will not yet get
+> automatic replica-first behavior for ad-hoc reads — only the daemon does, via the
+> seam). Write this rule against the intent; use `linearis` as the executable command
+> today.
+
 ## Gotchas & Traps
 
 These are non-obvious behaviors that silently produce wrong results. Verified empirically against

--- a/plugins/dev/skills/monitor-events/SKILL.md
+++ b/plugins/dev/skills/monitor-events/SKILL.md
@@ -117,9 +117,6 @@ else
     FILTER_MISMATCH=true
   fi
 
-  TUNNEL_STATE=$(catalyst-monitor status --json 2>/dev/null | jq -r '.webhookTunnel.connected // false')
-  [ "$TUNNEL_STATE" != "true" ] && { echo "WARN: Webhook tunnel not running"; STALLED=true; }
-
   if [ "$FILTER_MISMATCH" = "false" ] && [ "$STALLED" = "false" ]; then
     # Infrastructure healthy — extend to Phase 2.
     EVENT=$(catalyst-events wait-for \
@@ -626,7 +623,7 @@ flowing normally.
 ### Prefer status JSON when available
 
 Once CTL-244 lands, `catalyst-monitor status --json` will expose a `webhookTunnel`
-object (`{connected, smeeUrl, lastEventAt, eventCount24h, eventCount24hByRepo}`). That
+object (`{connected, lastEventAt, eventCount24h, eventCount24hByRepo}`). That
 is the structured first diagnostic step and should be checked before reaching for the
 recipes above. The diagnostic recipes here are the manual deep-dive when status JSON is
 unavailable, insufficient, or contradicts what you expect.

--- a/plugins/dev/skills/monitor-events/SKILL.md
+++ b/plugins/dev/skills/monitor-events/SKILL.md
@@ -117,6 +117,14 @@ else
     FILTER_MISMATCH=true
   fi
 
+  # The smee→monitor webhook tunnel is the GitHub-event ingestion path and is NOT yet
+  # retired (Linear smee retires first; GitHub smee is gated on CTC-134). A dead tunnel
+  # produces zero events while the monitor keeps heartbeating — so without this check a
+  # worker would treat infra as healthy and enter the 2-hour Phase 2 wait. Tunnel down →
+  # skip the extension and rely on the authoritative REST confirmation below.
+  TUNNEL_STATE=$(catalyst-monitor status --json 2>/dev/null | jq -r '.webhookTunnel.connected // false')
+  [ "$TUNNEL_STATE" != "true" ] && { echo "WARN: Webhook tunnel not running"; STALLED=true; }
+
   if [ "$FILTER_MISMATCH" = "false" ] && [ "$STALLED" = "false" ]; then
     # Infrastructure healthy — extend to Phase 2.
     EVENT=$(catalyst-events wait-for \
@@ -623,7 +631,7 @@ flowing normally.
 ### Prefer status JSON when available
 
 Once CTL-244 lands, `catalyst-monitor status --json` will expose a `webhookTunnel`
-object (`{connected, lastEventAt, eventCount24h, eventCount24hByRepo}`). That
+object (`{connected, smeeUrl, lastEventAt, eventCount24h, eventCount24hByRepo}`). That
 is the structured first diagnostic step and should be checked before reaching for the
 recipes above. The diagnostic recipes here are the manual deep-dive when status JSON is
 unavailable, insufficient, or contradicts what you expect.

--- a/plugins/dev/skills/morning-briefing/SKILL.md
+++ b/plugins/dev/skills/morning-briefing/SKILL.md
@@ -47,6 +47,8 @@ echo "Output path: $OUT_PATH"
 
 ## Step 2: Gather "yesterday" — parallel MCP/CLI queries
 
+> **Read source:** the `linearis` queries below are the standard-node direct read. On a Catalyst Cloud node the local replica is read first (evidence-based fallback to `linearis`) — see the `linearis` skill's "Reading Linear" section.
+
 Launch the five gather helpers in parallel. Each prints a JSON fragment to its own scratch file;
 each degrades silently to `{}` if its credentials are absent so the briefing always renders.
 

--- a/plugins/dev/skills/recovery-pass/SKILL.md
+++ b/plugins/dev/skills/recovery-pass/SKILL.md
@@ -317,7 +317,8 @@ sits at `needs-human`/`failed`/`stalled`, or its worker died with the signal fro
   mergeable,mergeStateStatus,reviewDecision,statusCheckRollup`: is there a PR, is
   it green, is it BEHIND/CONFLICTING, is it just sitting there mergeable.
 - **The Linear cache** — the `linear-state=…` / `labels=…` the context script
-  printed for the item (from the webhook-fed cache; no direct Linear call needed).
+  printed for the item (orientation snapshot only; always verify with `linearis
+  issues read <T>` before acting — see the Verify-before-act callout).
 
 **Then diagnose like a senior engineer.** From those: what phase is it in? what
 failed — a conflict, a failed check, a dead worker, an un-merged green PR, a
@@ -399,12 +400,15 @@ each, print `BOARD <invariant> OK` or `BOARD <invariant> ANOMALY: <what> → <ac
 If the board scan is all-OK and the flagged YOURS set is empty, you are done — print
 `BOARD all-clear` and stop (no LLM thrash on a healthy board). Otherwise continue.
 
-> **Verify-before-act (do NOT trust the board cache).** The board derives state /
-> labels / relations from a LOCAL cache (`filter-state.db`) that DRIFTS from live
-> Linear (it misses label-removed and relation webhooks). Before you act on or
-> escalate ANY ticket, read its LIVE Linear state (`linearis issues read <T>`) —
-> never act on the cache alone. A ticket the board shows blocked / needs-human / in a
-> given column may be none of those live.
+> **Verify-before-act (do NOT trust the context-script snapshot).** The
+> `linear-state=…` / `labels=…` values the context script printed are an orientation
+> snapshot that may lag live Linear. Before you act on or escalate ANY ticket, read
+> its LIVE Linear state (`linearis issues read <T>`) — never act on the snapshot
+> alone. A ticket the context shows blocked / needs-human / in a given column may be
+> none of those live. (Reading Linear: on a standard Catalyst node `linearis issues
+> read` is always the direct source; on a Catalyst Cloud node the local replica is
+> authoritative — see the `linearis` skill's "Reading Linear" section for the
+> two-mode rule.)
 
 ## The 3-tier rope — how much you may do on your own
 

--- a/plugins/dev/skills/ticket-compound/SKILL.md
+++ b/plugins/dev/skills/ticket-compound/SKILL.md
@@ -45,7 +45,7 @@ For `<TICKET>`, collect:
    - `thoughts/shared/friction/<TICKET>.md` — the dedicated per-phase friction log (primary friction source).
 2. **The diff** — `git log --oneline origin/main..HEAD` and `git diff --stat origin/main..HEAD`
    (or the merged SHA from `phase-monitor-merge.json`).
-3. **Ticket** — `linearis issues read <TICKET>` (title, description, final state, estimate).
+3. **Ticket** — `linearis issues read <TICKET>` (title, description, final state, estimate). Standard-node direct read; on a Catalyst Cloud node the replica is read first — see the `linearis` skill's "Reading Linear" section.
 4. **Event trail** (optional) — the ticket's lines in `~/catalyst/events/YYYY-MM.jsonl`.
 
 Capture learnings from **failed/abandoned** tickets too — the dead-ends are high-signal ("what

--- a/plugins/pm/agents/linear-research.md
+++ b/plugins/pm/agents/linear-research.md
@@ -56,6 +56,8 @@ For exact command syntax, run `linearis <domain> usage` (e.g., `linearis issues 
 `linearis cycles usage`, `linearis milestones usage`). The `/catalyst-dev:linearis` skill is the
 authoritative reference — **do not guess or improvise commands**.
 
+**Read-source mode**: Follow the two-mode Linear read rule in the `catalyst-dev:linearis` skill ("Reading Linear" section) — standard nodes call `linearis` directly; Catalyst Cloud nodes prefer the local replica first and escalate to `linearis` only on concrete evidence of staleness.
+
 ## Examples
 
 ### Example 1: Get Active Cycle

--- a/website/src/content/docs/autonomous-workflow/see-your-work.md
+++ b/website/src/content/docs/autonomous-workflow/see-your-work.md
@@ -39,6 +39,8 @@ In a **split** setup — a developer laptop plus an always-on **worker** machine
 
 Everything here is **read-only**. You still act on the work from Linear and GitHub, and writing to Linear still requires a host that has its own Linear key — so pointing more devices at the worker's board never changes who can make changes.
 
+This dashboard is for **human visibility** — it is *not* how Catalyst's agents read Linear during a workflow. Agent reads follow the two-mode rule in the `catalyst-dev:linearis` skill's "Reading Linear" section (standard node → direct `linearis`; Catalyst Cloud node → the SDK-managed local replica first, with `linearis` as the evidence-triggered fallback).
+
 ## A live terminal view
 
 Prefer the terminal? Run `catalyst-hud` for a live stream of events as they happen. On a minimal setup (like SSH from an iPad), use `catalyst-hud-classic` instead.

--- a/website/src/content/docs/reference/configuration.md
+++ b/website/src/content/docs/reference/configuration.md
@@ -281,7 +281,7 @@ packaging — one declarative field that sets sensible **defaults for levers tha
 
 | Class | What it is |
 | --- | --- |
-| `developer` | A daemonless client you chat on. Not in the cluster roster, boots drained, runs no execution-core daemon or broker — it reads board data from a worker's monitor. |
+| `developer` | A daemonless client you chat on. Not in the cluster roster, boots drained, runs no execution-core daemon or broker — it reads board UI data from a worker's monitor (agent Linear reads follow the two-mode rule — see the `catalyst-dev:linearis` skill's "Reading Linear" section). |
 | `worker` | Runs the full stack and picks up work (the default; a laptop that both runs the daemon and is chatted on is a "head-full worker"). |
 | `monitor` | A reporting host. An **enum slot only** for now — its class-specific build-out is descoped until a real reporting node exists. |
 
@@ -309,6 +309,13 @@ per-repo:
 - A missing or malformed Layer-2 file never throws; it falls through to the `worker` default.
 
 ### Read-replica endpoint (`catalyst.readReplica.baseUrl`, CTL-1346)
+
+> **Scope — board UI display only.** `catalyst.readReplica.baseUrl` governs the terminal HUD and
+> browser board/search display. It is **not** the agent Linear read path. For how agents read Linear
+> ticket data, see the `catalyst-dev:linearis` skill's "Reading Linear" section (two-mode rule:
+> standard node → `linearis issues read|list|search` directly; Catalyst Cloud node →
+> `@catalyst-cloud/sdk`-managed local replica first, with `linearis` as the evidence-triggered
+> fallback — CTL-1390). Writes always go through `linearis` in both modes.
 
 Board data lives in a monitor's `filter-state.db` replica, which is written **only** by a node's local
 broker. A daemonless `developer` node runs no broker, so its local replica is empty — it must read a

--- a/website/src/content/docs/reference/configuration.md
+++ b/website/src/content/docs/reference/configuration.md
@@ -310,8 +310,9 @@ per-repo:
 
 ### Read-replica endpoint (`catalyst.readReplica.baseUrl`, CTL-1346)
 
-> **Scope — board UI display only.** `catalyst.readReplica.baseUrl` governs the terminal HUD and
-> browser board/search display. It is **not** the agent Linear read path. For how agents read Linear
+> **Scope — board UI display only.** `catalyst.readReplica.baseUrl` governs the terminal HUD's board
+> reads today (pointing the browser/PWA ticket-detail and search flows at the same endpoint is the
+> forthcoming "split" topology — CTL-1347 / CTL-1354). It is **not** the agent Linear read path. For how agents read Linear
 > ticket data, see the `catalyst-dev:linearis` skill's "Reading Linear" section (two-mode rule:
 > standard node → `linearis issues read|list|search` directly; Catalyst Cloud node →
 > `@catalyst-cloud/sdk`-managed local replica first, with `linearis` as the evidence-triggered


### PR DESCRIPTION
## What

Rolls out the **agent-facing prose layer** of the Linear read-path cutover (CTL-1389 / CTC-133): one canonical **"Reading Linear" two-mode rule**, plus corrections to every doc that still pointed agents at the retired homegrown read mirror.

**The rule (canonical in the `linearis` skill):**
- **Standard node (no Cloud key)** → read Linear **directly** via `linearis`.
- **Catalyst Cloud node (replica active)** → **read the replica first and trust it**; escalate to a direct `linearis` read **+ surface a mirror-gap issue** *only* on concrete evidence of staleness (freshness gauge behind / missing ticket / contradiction).
- **Writes always via `linearis`** in both modes (replica is read-only).

## Changes
- **Canonical SSOT:** new "Reading Linear" section in `linearis/SKILL.md` (46 lines).
- **DRY pointers** (one-liners, no rule duplication): `linear`, `describe-pr`, `compound-estimate`, `morning-briefing`, `ticket-compound` skills; `dev` + `pm` `linear-research` agents; `AGENTS.md` (tool-agnostic).
- **Stale-source fixes** (these actively misdirected agents): `recovery-pass` (Verify-before-act reframed off `filter-state.db`), `monitor-events` (drop the retired smee tunnel probe + `smeeUrl`), `configuration.md` (scope `readReplica.baseUrl` to board-UI-only + developer-node row), `see-your-work` (Monitor = human visibility, not the agent read path).

## Honest mechanism note
The rule is written against intent. Until the replica-aware **`catalyst-linear`** read CLI (CTL-1391) ships, `linearis` is the executable command in both modes; the **daemon** already resolves the mode automatically via the read-source seam (CTL-1390). The canonical section says so explicitly.

## Scope / safety
Docs/prose only — no code paths change. Verified the `STALLED` var stays initialized after dropping the smee probe in `monitor-events`. AGENTS.md stays tool-agnostic (gate-clean).

Part of **CTL-1389**. Refs CTL-1390 (seam), CTL-1391 (CLI), CTC-133 (cloud umbrella).

🤖 Generated with [Claude Code](https://claude.com/claude-code)