### PR TITLE
feat(dev): CTL-1391 — catalyst-linear, the replica-first Linear read CLI (linearis fallback)

### DIFF
--- a/.github/workflows/execution-core-tests.yml
+++ b/.github/workflows/execution-core-tests.yml
@@ -39,6 +39,7 @@ on:
       # `catalyst install|uninstall|reinstall`; changing them must run the smoke test below.
       - "plugins/dev/scripts/catalyst-install"
       - "plugins/dev/scripts/catalyst"
+      - "plugins/dev/scripts/catalyst-linear"
       - "plugins/dev/scripts/install-cli.sh"
       - "plugins/dev/scripts/check-setup.sh"
       - "plugins/dev/scripts/__tests__/**"
@@ -58,6 +59,7 @@ on:
       # CTL-1369: launcher / router / CLI-registration entry path (see PR-trigger note above).
       - "plugins/dev/scripts/catalyst-install"
       - "plugins/dev/scripts/catalyst"
+      - "plugins/dev/scripts/catalyst-linear"
       - "plugins/dev/scripts/install-cli.sh"
       - "plugins/dev/scripts/check-setup.sh"
       - "plugins/dev/scripts/__tests__/**"
@@ -107,6 +109,15 @@ jobs:
         # ./config.mjs, ../tracing.mjs) would otherwise only fail at install runtime on a node.
         # Walk its static graph.
         run: bun build install-lifecycle.mjs --target=node --outfile /dev/null
+
+      - name: Verify catalyst-linear import graph (node-loadability contract, CTL-1391)
+        # CTL-1391: linear-cli.mjs is the catalyst-linear driver, a separate CLI entrypoint
+        # NOT in daemon.mjs's graph. Its node-loadability is load-bearing — the write-reject +
+        # linearis-fallback paths must load under node (worker/dev hosts without bun), which is
+        # why bun:sqlite + @catalyst-cloud/read-model are DYNAMIC imports. A future static
+        # bun-only import would silently break that; --target=node walks the static graph and
+        # exits non-zero if any bun-only import leaked into it.
+        run: bun build linear-cli.mjs --target=node --outfile /dev/null
 
       - name: catalyst-install launcher + router smoke test
         # CTL-1369 PR3: exercises the REAL catalyst-install bash launcher (symlink resolution →
@@ -276,6 +287,7 @@ jobs:
             linear-reconcile-store.test.mjs \
             linear-reconcile-timer.test.mjs \
             linear-reconcile-cli.test.mjs \
+            linear-cli.test.mjs \
             updater/plugin-pull-defer.test.mjs \
             updater/updater.test.mjs \
             updater/updater-tracing.test.mjs

--- a/plugins/dev/scripts/catalyst-linear
+++ b/plugins/dev/scripts/catalyst-linear
@@ -20,6 +20,22 @@ while [[ -L $_SRC ]]; do _SRC="$(readlink "$_SRC")"; done
 SCRIPT_DIR="$(cd "$(dirname "$_SRC")" && pwd)"
 unset _SRC
 
+# CTL-390 contract: --version handled here, BEFORE the JS driver dispatch, so this
+# registered CLI prints the standard catalyst version block like every sibling
+# catalyst-* command (the driver otherwise treats --version as an unknown flag and
+# exits 1 with usage). SCRIPT_DIR is already symlink-resolved above.
+case "${1:-}" in
+--version | -V)
+	if [[ -f "${SCRIPT_DIR}/lib/catalyst-version.sh" ]]; then
+		# shellcheck source=/dev/null
+		. "${SCRIPT_DIR}/lib/catalyst-version.sh"
+		catalyst_print_version "catalyst-linear" "${BASH_SOURCE[0]}" && exit 0
+	fi
+	echo "error: catalyst-version helper missing at ${SCRIPT_DIR}/lib/catalyst-version.sh" >&2
+	exit 1
+	;;
+esac
+
 DRIVER_MJS="${CATALYST_LINEAR_DRIVER:-${SCRIPT_DIR}/execution-core/linear-cli.mjs}"
 if [[ ! -f $DRIVER_MJS ]]; then
 	echo "error: catalyst-linear driver not found: $DRIVER_MJS" >&2

--- a/plugins/dev/scripts/catalyst-linear
+++ b/plugins/dev/scripts/catalyst-linear
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# catalyst-linear — CTL-1391: the agent-facing REPLICA-FIRST Linear read CLI.
+#
+# Reads Linear from the local Catalyst-Cloud SDK replica when one is present +
+# fresh + opted-in (CATALYST_LINEAR_REPLICA=on / Layer-2 catalyst.linearReplica.mode),
+# and falls back to a direct `linearis` read otherwise. Output matches `linearis`
+# JSON + an additive `_meta`. Reads only — WRITES go through `linearis`.
+#
+# Thin launcher → execution-core/linear-cli.mjs driver. bun is preferred (the
+# replica path imports bun:sqlite + @catalyst-cloud/read-model); node still runs
+# the linearis-fallback + write-rejection paths (the driver guards all bun-only
+# imports behind dynamic import()).
+set -euo pipefail
+
+# Resolve this script's directory through symlinks (matches catalyst-broker /
+# catalyst-execution-core), so the driver resolves whether invoked from the repo,
+# a ~/.catalyst/bin symlink, or the cached plugin.
+_SRC="${BASH_SOURCE[0]}"
+while [[ -L $_SRC ]]; do _SRC="$(readlink "$_SRC")"; done
+SCRIPT_DIR="$(cd "$(dirname "$_SRC")" && pwd)"
+unset _SRC
+
+DRIVER_MJS="${CATALYST_LINEAR_DRIVER:-${SCRIPT_DIR}/execution-core/linear-cli.mjs}"
+if [[ ! -f $DRIVER_MJS ]]; then
+	echo "error: catalyst-linear driver not found: $DRIVER_MJS" >&2
+	exit 1
+fi
+
+RUNTIME="${CATALYST_LINEAR_RUNTIME-}"
+if [[ -z $RUNTIME ]]; then
+	if command -v bun >/dev/null 2>&1; then
+		RUNTIME="bun"
+	elif command -v node >/dev/null 2>&1; then
+		RUNTIME="node"
+	else
+		echo "error: neither bun nor node found on PATH" >&2
+		exit 1
+	fi
+fi
+
+exec "$RUNTIME" "$DRIVER_MJS" "$@"

--- a/plugins/dev/scripts/check-setup.sh
+++ b/plugins/dev/scripts/check-setup.sh
@@ -86,7 +86,7 @@ done
 header "Catalyst CLI Install"
 
 CLI_BIN_DIR="${CATALYST_CLI_BIN_DIR:-$HOME/.catalyst/bin}"
-CLI_NAMES=(catalyst catalyst-backup catalyst-install catalyst-broker catalyst-comms catalyst-events catalyst-execution-core catalyst-filter catalyst-linear-reconcile catalyst-otel-forward catalyst-transitions catalyst-why catalyst-session catalyst-state catalyst-statusline catalyst-db catalyst-monitor catalyst-thoughts catalyst-claude catalyst-stack)
+CLI_NAMES=(catalyst catalyst-backup catalyst-install catalyst-broker catalyst-comms catalyst-events catalyst-execution-core catalyst-filter catalyst-linear catalyst-linear-reconcile catalyst-otel-forward catalyst-transitions catalyst-why catalyst-session catalyst-state catalyst-statusline catalyst-db catalyst-monitor catalyst-thoughts catalyst-claude catalyst-stack)
 
 if [[ -d "$CLI_BIN_DIR" ]]; then
     pass "Bin dir exists: $CLI_BIN_DIR"

--- a/plugins/dev/scripts/execution-core/bun.lock
+++ b/plugins/dev/scripts/execution-core/bun.lock
@@ -5,6 +5,7 @@
     "": {
       "name": "catalyst-execution-core",
       "dependencies": {
+        "@catalyst-cloud/read-model": "^0.1.0",
         "@opentelemetry/api": "^1.9.1",
         "@opentelemetry/exporter-trace-otlp-http": "^0.219.0",
         "@opentelemetry/resources": "^2.8.0",
@@ -15,9 +16,40 @@
       "devDependencies": {
         "@types/bun": "^1.3.12",
       },
+      "optionalDependencies": {
+        "@anthropic-ai/claude-agent-sdk": "^0.3.0",
+      },
     },
   },
   "packages": {
+    "@anthropic-ai/claude-agent-sdk": ["@anthropic-ai/claude-agent-sdk@0.3.195", "", { "optionalDependencies": { "@anthropic-ai/claude-agent-sdk-darwin-arm64": "0.3.195", "@anthropic-ai/claude-agent-sdk-darwin-x64": "0.3.195", "@anthropic-ai/claude-agent-sdk-linux-arm64": "0.3.195", "@anthropic-ai/claude-agent-sdk-linux-arm64-musl": "0.3.195", "@anthropic-ai/claude-agent-sdk-linux-x64": "0.3.195", "@anthropic-ai/claude-agent-sdk-linux-x64-musl": "0.3.195", "@anthropic-ai/claude-agent-sdk-win32-arm64": "0.3.195", "@anthropic-ai/claude-agent-sdk-win32-x64": "0.3.195" }, "peerDependencies": { "@anthropic-ai/sdk": ">=0.93.0", "@modelcontextprotocol/sdk": "^1.29.0", "zod": "^4.0.0" } }, "sha512-FVmXu9pvOMbuBKWrF8YsYQdQ/upOpv5rS8lFAnFO5jbyXT/2hN7kEPd2vd2GJpaMvNcO/KptyQUK5AxjjTz3+w=="],
+
+    "@anthropic-ai/claude-agent-sdk-darwin-arm64": ["@anthropic-ai/claude-agent-sdk-darwin-arm64@0.3.195", "", { "os": "darwin", "cpu": "arm64" }, "sha512-WIMM/8HRCLsTDHFTIwQvvE8WCA/oaMJtdQxsP7iNyfzIGwXbuOyU95V8vYIhZfaO2yaSpbBRncunq4CtR5H4ng=="],
+
+    "@anthropic-ai/claude-agent-sdk-darwin-x64": ["@anthropic-ai/claude-agent-sdk-darwin-x64@0.3.195", "", { "os": "darwin", "cpu": "x64" }, "sha512-RY7DB+4LXosE0MJ+XELmakfPrDN1YX4lkk9CTDm28jGCVcESRz9kAEqbyaiC48dZcmN9V1NCLutzINGdcr1TBg=="],
+
+    "@anthropic-ai/claude-agent-sdk-linux-arm64": ["@anthropic-ai/claude-agent-sdk-linux-arm64@0.3.195", "", { "os": "linux", "cpu": "arm64" }, "sha512-JuIq5Fnz/F1snl0aqi1gcuRZqPWoPNrL9dJ0DuievCxKkO8hnEz/Mmn5Zos7x1X8HE//ZnEvmQXoEQEZXonJew=="],
+
+    "@anthropic-ai/claude-agent-sdk-linux-arm64-musl": ["@anthropic-ai/claude-agent-sdk-linux-arm64-musl@0.3.195", "", { "os": "linux", "cpu": "arm64" }, "sha512-ZmyBA/AFzhgutcxb7dbhCm6GTjJytwNYXTxJoKE2B3A409WCYccjMqeji6vCMNxyyfylglGo5D8dVMIxW9aoug=="],
+
+    "@anthropic-ai/claude-agent-sdk-linux-x64": ["@anthropic-ai/claude-agent-sdk-linux-x64@0.3.195", "", { "os": "linux", "cpu": "x64" }, "sha512-s1lNi1cL93luoqsItH+fNO4KpIhdkvnVhWGGQUQ/8ftwa2gfmcIQnOg1hG8Ks+KzeD3UUQ8L9YEVHVADnFI/9A=="],
+
+    "@anthropic-ai/claude-agent-sdk-linux-x64-musl": ["@anthropic-ai/claude-agent-sdk-linux-x64-musl@0.3.195", "", { "os": "linux", "cpu": "x64" }, "sha512-nf8Q/LauB+ZOC6QDjxNhbsvwUtYjKYnaWJLTYFwhkmsLujePnety1AtT/1ubaUoq5AM1j297DhMlYTasa79OUA=="],
+
+    "@anthropic-ai/claude-agent-sdk-win32-arm64": ["@anthropic-ai/claude-agent-sdk-win32-arm64@0.3.195", "", { "os": "win32", "cpu": "arm64" }, "sha512-hbkDE+xPIZzRWm+D+BKrH9uJH6USIZdDIlsyrIlGi3JFHoieYoA1vdUNyldSS9+F3ZqQtfPjr2Qy08IVB6akYA=="],
+
+    "@anthropic-ai/claude-agent-sdk-win32-x64": ["@anthropic-ai/claude-agent-sdk-win32-x64@0.3.195", "", { "os": "win32", "cpu": "x64" }, "sha512-av0piEB3X1Dzhpr8A+DqHVZ9y8s1jpn8enzwX0TKKUPBn5IqLTWC7wD6v66aoUgu4f+g4ThZirmDZA6shyPEZQ=="],
+
+    "@anthropic-ai/sdk": ["@anthropic-ai/sdk@0.107.0", "", { "dependencies": { "json-schema-to-ts": "^3.1.1", "standardwebhooks": "^1.0.0" }, "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" }, "optionalPeers": ["zod"], "bin": { "anthropic-ai-sdk": "bin/cli" } }, "sha512-RWDWyvIeZnatUTzyX8+ayFzAqqLyoDHKnDEODFyW8H89zH+qEsh5h6XAmnbHY5DCoa58o3rjuNe3F3Hg851ayA=="],
+
+    "@babel/runtime": ["@babel/runtime@7.29.7", "", {}, "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw=="],
+
+    "@catalyst-cloud/read-model": ["@catalyst-cloud/read-model@0.1.0", "", {}, "sha512-TODVDFkY5moO0qnWnb/G6+7AI/X9Bl2Zp/2+ymBQDraf1aAjmXloem3qj/FPURjfakx1aDEVEFULO+PpKnC6JQ=="],
+
+    "@hono/node-server": ["@hono/node-server@1.19.14", "", { "peerDependencies": { "hono": "^4" } }, "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw=="],
+
+    "@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.29.0", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.2.1", "express-rate-limit": "^8.2.1", "hono": "^4.11.4", "jose": "^6.1.3", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ=="],
+
     "@opentelemetry/api": ["@opentelemetry/api@1.9.1", "", {}, "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q=="],
 
     "@opentelemetry/api-logs": ["@opentelemetry/api-logs@0.219.0", "", { "dependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-FFx7YnaYJlIjqWW/AG/yAZ0L/NEY724PipXXXQLdtZPbLwBGbUMTGL1i/esI56TWfTUXxhLfpgrnWJCG8aUJyg=="],
@@ -42,15 +74,147 @@
 
     "@pinojs/redact": ["@pinojs/redact@0.4.0", "", {}, "sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg=="],
 
+    "@stablelib/base64": ["@stablelib/base64@1.0.1", "", {}, "sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ=="],
+
     "@types/bun": ["@types/bun@1.3.14", "", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
 
     "@types/node": ["@types/node@25.9.1", "", { "dependencies": { "undici-types": ">=7.24.0 <7.24.7" } }, "sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg=="],
 
+    "accepts": ["accepts@2.0.0", "", { "dependencies": { "mime-types": "^3.0.0", "negotiator": "^1.0.0" } }, "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng=="],
+
+    "ajv": ["ajv@8.20.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA=="],
+
+    "ajv-formats": ["ajv-formats@3.0.1", "", { "dependencies": { "ajv": "^8.0.0" } }, "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ=="],
+
     "atomic-sleep": ["atomic-sleep@1.0.0", "", {}, "sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ=="],
+
+    "body-parser": ["body-parser@2.3.0", "", { "dependencies": { "bytes": "^3.1.2", "content-type": "^2.0.0", "debug": "^4.4.3", "http-errors": "^2.0.1", "iconv-lite": "^0.7.2", "on-finished": "^2.4.1", "qs": "^6.15.2", "raw-body": "^3.0.2", "type-is": "^2.1.0" } }, "sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw=="],
 
     "bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
 
+    "bytes": ["bytes@3.1.2", "", {}, "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg=="],
+
+    "call-bind-apply-helpers": ["call-bind-apply-helpers@1.0.2", "", { "dependencies": { "es-errors": "^1.3.0", "function-bind": "^1.1.2" } }, "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ=="],
+
+    "call-bound": ["call-bound@1.0.4", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "get-intrinsic": "^1.3.0" } }, "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg=="],
+
+    "content-disposition": ["content-disposition@1.1.0", "", {}, "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g=="],
+
+    "content-type": ["content-type@1.0.5", "", {}, "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA=="],
+
+    "cookie": ["cookie@0.7.2", "", {}, "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w=="],
+
+    "cookie-signature": ["cookie-signature@1.2.2", "", {}, "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg=="],
+
+    "cors": ["cors@2.8.6", "", { "dependencies": { "object-assign": "^4", "vary": "^1" } }, "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw=="],
+
+    "cross-spawn": ["cross-spawn@7.0.6", "", { "dependencies": { "path-key": "^3.1.0", "shebang-command": "^2.0.0", "which": "^2.0.1" } }, "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA=="],
+
+    "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
+
+    "depd": ["depd@2.0.0", "", {}, "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw=="],
+
+    "dunder-proto": ["dunder-proto@1.0.1", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.1", "es-errors": "^1.3.0", "gopd": "^1.2.0" } }, "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A=="],
+
+    "ee-first": ["ee-first@1.1.1", "", {}, "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="],
+
+    "encodeurl": ["encodeurl@2.0.0", "", {}, "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg=="],
+
+    "es-define-property": ["es-define-property@1.0.1", "", {}, "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g=="],
+
+    "es-errors": ["es-errors@1.3.0", "", {}, "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw=="],
+
+    "es-object-atoms": ["es-object-atoms@1.1.2", "", { "dependencies": { "es-errors": "^1.3.0" } }, "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw=="],
+
+    "escape-html": ["escape-html@1.0.3", "", {}, "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow=="],
+
+    "etag": ["etag@1.8.1", "", {}, "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg=="],
+
+    "eventsource": ["eventsource@3.0.7", "", { "dependencies": { "eventsource-parser": "^3.0.1" } }, "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA=="],
+
+    "eventsource-parser": ["eventsource-parser@3.1.0", "", {}, "sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg=="],
+
+    "express": ["express@5.2.1", "", { "dependencies": { "accepts": "^2.0.0", "body-parser": "^2.2.1", "content-disposition": "^1.0.0", "content-type": "^1.0.5", "cookie": "^0.7.1", "cookie-signature": "^1.2.1", "debug": "^4.4.0", "depd": "^2.0.0", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "etag": "^1.8.1", "finalhandler": "^2.1.0", "fresh": "^2.0.0", "http-errors": "^2.0.0", "merge-descriptors": "^2.0.0", "mime-types": "^3.0.0", "on-finished": "^2.4.1", "once": "^1.4.0", "parseurl": "^1.3.3", "proxy-addr": "^2.0.7", "qs": "^6.14.0", "range-parser": "^1.2.1", "router": "^2.2.0", "send": "^1.1.0", "serve-static": "^2.2.0", "statuses": "^2.0.1", "type-is": "^2.0.1", "vary": "^1.1.2" } }, "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw=="],
+
+    "express-rate-limit": ["express-rate-limit@8.5.2", "", { "dependencies": { "ip-address": "^10.2.0" }, "peerDependencies": { "express": ">= 4.11" } }, "sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A=="],
+
+    "fast-deep-equal": ["fast-deep-equal@3.1.3", "", {}, "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="],
+
+    "fast-sha256": ["fast-sha256@1.3.0", "", {}, "sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ=="],
+
+    "fast-uri": ["fast-uri@3.1.3", "", {}, "sha512-i70LwGWUduXqzicKXWshooq+sWL1K3WUU5rKZNG/0i3a1OSoX3HqhH5WbWwTmqWfor4urUakGPiRQcleRZTwOg=="],
+
+    "finalhandler": ["finalhandler@2.1.1", "", { "dependencies": { "debug": "^4.4.0", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "on-finished": "^2.4.1", "parseurl": "^1.3.3", "statuses": "^2.0.1" } }, "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA=="],
+
+    "forwarded": ["forwarded@0.2.0", "", {}, "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow=="],
+
+    "fresh": ["fresh@2.0.0", "", {}, "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A=="],
+
+    "function-bind": ["function-bind@1.1.2", "", {}, "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="],
+
+    "get-intrinsic": ["get-intrinsic@1.3.0", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "es-define-property": "^1.0.1", "es-errors": "^1.3.0", "es-object-atoms": "^1.1.1", "function-bind": "^1.1.2", "get-proto": "^1.0.1", "gopd": "^1.2.0", "has-symbols": "^1.1.0", "hasown": "^2.0.2", "math-intrinsics": "^1.1.0" } }, "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ=="],
+
+    "get-proto": ["get-proto@1.0.1", "", { "dependencies": { "dunder-proto": "^1.0.1", "es-object-atoms": "^1.0.0" } }, "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g=="],
+
+    "gopd": ["gopd@1.2.0", "", {}, "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg=="],
+
+    "has-symbols": ["has-symbols@1.1.0", "", {}, "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ=="],
+
+    "hasown": ["hasown@2.0.4", "", { "dependencies": { "function-bind": "^1.1.2" } }, "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A=="],
+
+    "hono": ["hono@4.12.27", "", {}, "sha512-1yrb/+w6HWQJrUCLkJ2IF5jNIPvvFkblV5RNOYl6bV+OA6p9GLcMpHFFGTosSvHvcAUibuUukRqhlYI4z32C7Q=="],
+
+    "http-errors": ["http-errors@2.0.1", "", { "dependencies": { "depd": "~2.0.0", "inherits": "~2.0.4", "setprototypeof": "~1.2.0", "statuses": "~2.0.2", "toidentifier": "~1.0.1" } }, "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ=="],
+
+    "iconv-lite": ["iconv-lite@0.7.2", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw=="],
+
+    "inherits": ["inherits@2.0.4", "", {}, "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="],
+
+    "ip-address": ["ip-address@10.2.0", "", {}, "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA=="],
+
+    "ipaddr.js": ["ipaddr.js@1.9.1", "", {}, "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g=="],
+
+    "is-promise": ["is-promise@4.0.0", "", {}, "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ=="],
+
+    "isexe": ["isexe@2.0.0", "", {}, "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="],
+
+    "jose": ["jose@6.2.3", "", {}, "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw=="],
+
+    "json-schema-to-ts": ["json-schema-to-ts@3.1.1", "", { "dependencies": { "@babel/runtime": "^7.18.3", "ts-algebra": "^2.0.0" } }, "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g=="],
+
+    "json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
+
+    "json-schema-typed": ["json-schema-typed@8.0.2", "", {}, "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA=="],
+
+    "math-intrinsics": ["math-intrinsics@1.1.0", "", {}, "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="],
+
+    "media-typer": ["media-typer@1.1.0", "", {}, "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw=="],
+
+    "merge-descriptors": ["merge-descriptors@2.0.0", "", {}, "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g=="],
+
+    "mime-db": ["mime-db@1.54.0", "", {}, "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ=="],
+
+    "mime-types": ["mime-types@3.0.2", "", { "dependencies": { "mime-db": "^1.54.0" } }, "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A=="],
+
+    "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
+
+    "negotiator": ["negotiator@1.0.0", "", {}, "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg=="],
+
+    "object-assign": ["object-assign@4.1.1", "", {}, "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg=="],
+
+    "object-inspect": ["object-inspect@1.13.4", "", {}, "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew=="],
+
     "on-exit-leak-free": ["on-exit-leak-free@2.1.2", "", {}, "sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA=="],
+
+    "on-finished": ["on-finished@2.4.1", "", { "dependencies": { "ee-first": "1.1.1" } }, "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg=="],
+
+    "once": ["once@1.4.0", "", { "dependencies": { "wrappy": "1" } }, "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w=="],
+
+    "parseurl": ["parseurl@1.3.3", "", {}, "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ=="],
+
+    "path-key": ["path-key@3.1.1", "", {}, "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="],
+
+    "path-to-regexp": ["path-to-regexp@8.4.2", "", {}, "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA=="],
 
     "pino": ["pino@9.14.0", "", { "dependencies": { "@pinojs/redact": "^0.4.0", "atomic-sleep": "^1.0.0", "on-exit-leak-free": "^2.1.0", "pino-abstract-transport": "^2.0.0", "pino-std-serializers": "^7.0.0", "process-warning": "^5.0.0", "quick-format-unescaped": "^4.0.3", "real-require": "^0.2.0", "safe-stable-stringify": "^2.3.1", "sonic-boom": "^4.0.1", "thread-stream": "^3.0.0" }, "bin": { "pino": "bin.js" } }, "sha512-8OEwKp5juEvb/MjpIc4hjqfgCNysrS94RIOMXYvpYCdm/jglrKEiAYmiumbmGhCvs+IcInsphYDFwqrjr7398w=="],
 
@@ -58,20 +222,80 @@
 
     "pino-std-serializers": ["pino-std-serializers@7.1.0", "", {}, "sha512-BndPH67/JxGExRgiX1dX0w1FvZck5Wa4aal9198SrRhZjH3GxKQUKIBnYJTdj2HDN3UQAS06HlfcSbQj2OHmaw=="],
 
+    "pkce-challenge": ["pkce-challenge@5.0.1", "", {}, "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ=="],
+
     "process-warning": ["process-warning@5.0.0", "", {}, "sha512-a39t9ApHNx2L4+HBnQKqxxHNs1r7KF+Intd8Q/g1bUh6q0WIp9voPXJ/x0j+ZL45KF1pJd9+q2jLIRMfvEshkA=="],
+
+    "proxy-addr": ["proxy-addr@2.0.7", "", { "dependencies": { "forwarded": "0.2.0", "ipaddr.js": "1.9.1" } }, "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg=="],
+
+    "qs": ["qs@6.15.3", "", { "dependencies": { "es-define-property": "^1.0.1", "side-channel": "^1.1.1" } }, "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A=="],
 
     "quick-format-unescaped": ["quick-format-unescaped@4.0.4", "", {}, "sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg=="],
 
+    "range-parser": ["range-parser@1.3.0", "", {}, "sha512-hek2mFQpPuI4E1BBKrSto+BU3e3x4xuarsbiwr3+lf7p44juvFMV0XFWQAP3xUyqXA4RrXLIoaSUGbSt056ZMw=="],
+
+    "raw-body": ["raw-body@3.0.2", "", { "dependencies": { "bytes": "~3.1.2", "http-errors": "~2.0.1", "iconv-lite": "~0.7.0", "unpipe": "~1.0.0" } }, "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA=="],
+
     "real-require": ["real-require@0.2.0", "", {}, "sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg=="],
 
+    "require-from-string": ["require-from-string@2.0.2", "", {}, "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="],
+
+    "router": ["router@2.2.0", "", { "dependencies": { "debug": "^4.4.0", "depd": "^2.0.0", "is-promise": "^4.0.0", "parseurl": "^1.3.3", "path-to-regexp": "^8.0.0" } }, "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ=="],
+
     "safe-stable-stringify": ["safe-stable-stringify@2.5.0", "", {}, "sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA=="],
+
+    "safer-buffer": ["safer-buffer@2.1.2", "", {}, "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="],
+
+    "send": ["send@1.2.1", "", { "dependencies": { "debug": "^4.4.3", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "etag": "^1.8.1", "fresh": "^2.0.0", "http-errors": "^2.0.1", "mime-types": "^3.0.2", "ms": "^2.1.3", "on-finished": "^2.4.1", "range-parser": "^1.2.1", "statuses": "^2.0.2" } }, "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ=="],
+
+    "serve-static": ["serve-static@2.2.1", "", { "dependencies": { "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "parseurl": "^1.3.3", "send": "^1.2.0" } }, "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw=="],
+
+    "setprototypeof": ["setprototypeof@1.2.0", "", {}, "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="],
+
+    "shebang-command": ["shebang-command@2.0.0", "", { "dependencies": { "shebang-regex": "^3.0.0" } }, "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA=="],
+
+    "shebang-regex": ["shebang-regex@3.0.0", "", {}, "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="],
+
+    "side-channel": ["side-channel@1.1.1", "", { "dependencies": { "es-errors": "^1.3.0", "object-inspect": "^1.13.4", "side-channel-list": "^1.0.1", "side-channel-map": "^1.0.1", "side-channel-weakmap": "^1.0.2" } }, "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ=="],
+
+    "side-channel-list": ["side-channel-list@1.0.1", "", { "dependencies": { "es-errors": "^1.3.0", "object-inspect": "^1.13.4" } }, "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w=="],
+
+    "side-channel-map": ["side-channel-map@1.0.1", "", { "dependencies": { "call-bound": "^1.0.2", "es-errors": "^1.3.0", "get-intrinsic": "^1.2.5", "object-inspect": "^1.13.3" } }, "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA=="],
+
+    "side-channel-weakmap": ["side-channel-weakmap@1.0.2", "", { "dependencies": { "call-bound": "^1.0.2", "es-errors": "^1.3.0", "get-intrinsic": "^1.2.5", "object-inspect": "^1.13.3", "side-channel-map": "^1.0.1" } }, "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A=="],
 
     "sonic-boom": ["sonic-boom@4.2.1", "", { "dependencies": { "atomic-sleep": "^1.0.0" } }, "sha512-w6AxtubXa2wTXAUsZMMWERrsIRAdrK0Sc+FUytWvYAhBJLyuI4llrMIC1DtlNSdI99EI86KZum2MMq3EAZlF9Q=="],
 
     "split2": ["split2@4.2.0", "", {}, "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg=="],
 
+    "standardwebhooks": ["standardwebhooks@1.0.0", "", { "dependencies": { "@stablelib/base64": "^1.0.0", "fast-sha256": "^1.3.0" } }, "sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg=="],
+
+    "statuses": ["statuses@2.0.2", "", {}, "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw=="],
+
     "thread-stream": ["thread-stream@3.1.0", "", { "dependencies": { "real-require": "^0.2.0" } }, "sha512-OqyPZ9u96VohAyMfJykzmivOrY2wfMSf3C5TtFJVgN+Hm6aj+voFhlK+kZEIv2FBh1X6Xp3DlnCOfEQ3B2J86A=="],
 
+    "toidentifier": ["toidentifier@1.0.1", "", {}, "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA=="],
+
+    "ts-algebra": ["ts-algebra@2.0.0", "", {}, "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw=="],
+
+    "type-is": ["type-is@2.1.0", "", { "dependencies": { "content-type": "^2.0.0", "media-typer": "^1.1.0", "mime-types": "^3.0.0" } }, "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA=="],
+
     "undici-types": ["undici-types@7.24.6", "", {}, "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg=="],
+
+    "unpipe": ["unpipe@1.0.0", "", {}, "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ=="],
+
+    "vary": ["vary@1.1.2", "", {}, "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg=="],
+
+    "which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
+
+    "wrappy": ["wrappy@1.0.2", "", {}, "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="],
+
+    "zod": ["zod@4.4.3", "", {}, "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ=="],
+
+    "zod-to-json-schema": ["zod-to-json-schema@3.25.2", "", { "peerDependencies": { "zod": "^3.25.28 || ^4" } }, "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA=="],
+
+    "body-parser/content-type": ["content-type@2.0.0", "", {}, "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ=="],
+
+    "type-is/content-type": ["content-type@2.0.0", "", {}, "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ=="],
   }
 }

--- a/plugins/dev/scripts/execution-core/linear-cli.mjs
+++ b/plugins/dev/scripts/execution-core/linear-cli.mjs
@@ -60,7 +60,13 @@ export function resolveReplicaMode(env = process.env, cfgPathOverride) {
   }
   try {
     const home = env.HOME || homedir();
-    const cfgPath = cfgPathOverride || resolve(home, ".config", "catalyst", "config.json");
+    // Honor CATALYST_LAYER2_CONFIG_FILE for parity with config.mjs's
+    // getLayer2ConfigPath() — a node launched with a non-default Layer-2 path
+    // must resolve linearReplica.mode from THAT file, not the hardcoded default.
+    const cfgPath =
+      cfgPathOverride ||
+      env.CATALYST_LAYER2_CONFIG_FILE ||
+      resolve(home, ".config", "catalyst", "config.json");
     if (!existsSync(cfgPath)) return "off";
     const cfg = JSON.parse(readFileSync(cfgPath, "utf8"));
     return cfg?.catalyst?.linearReplica?.mode === "on" ? "on" : "off";
@@ -137,12 +143,21 @@ async function openFreshReplica() {
   let mtimeAgeMs;
   try {
     // WAL mode: the writer's appends land in the `-wal` sidecar; the main DB file's
-    // mtime only advances on checkpoint. Take the freshest of the DB + its -wal/-shm
-    // sidecars so an actively-writing-to-WAL replica is not falsely judged stale.
+    // mtime only advances on checkpoint. Take the freshest of the DB + its `-wal`.
+    //
+    // Spoof-resistance (Codex P2): a read-only consumer that merely OPENS a
+    // checkpointed DB can create fresh, EMPTY `-wal`/`-shm` sidecars, which would
+    // make a long-dead replica look fresh. So we (a) drop `-shm` entirely — it is a
+    // reader-touched shared-memory index, never a writer-liveness signal — and (b)
+    // only trust `-wal` when it is NON-EMPTY: a writer's active WAL carries frames,
+    // while a reader artifact is zero-length. Right after a checkpoint+truncate the
+    // WAL is briefly empty, but the checkpoint just WROTE the main DB file, so its
+    // mtime is fresh in that window — no false-stale.
     let newest = statSync(dbPath).mtimeMs;
-    for (const ext of ["-wal", "-shm"]) {
-      try { newest = Math.max(newest, statSync(dbPath + ext).mtimeMs); } catch { /* sidecar absent */ }
-    }
+    try {
+      const wal = statSync(dbPath + "-wal");
+      if (wal.size > 0) newest = Math.max(newest, wal.mtimeMs);
+    } catch { /* -wal absent → main DB mtime only */ }
     mtimeAgeMs = Date.now() - newest;
   } catch {
     return { skip: "stat-failed" };
@@ -187,20 +202,27 @@ function flagPairs(flags) {
 }
 // Throws a tagged error on failure (NOT process.exit — that would be untestable
 // and kill any embedding process); main() catches `_linearis` and returns code 1.
-function runLinearis(args) {
+//
+// timeoutMs: the single-ticket `read` fallback caps a 429-stalled / hung linearis so
+// the hot read can never block indefinitely (mirrors linear-query.mjs's
+// CTL-1339/CTL-1364 8s cap); on timeout we fail safe → exit 1. Pass `timeoutMs: 0`
+// (or any non-positive value) to leave the call UNCAPPED — the `list`/`search`
+// passthrough must match direct `linearis`, where a broad `--limit 200` page or an
+// expensive search legitimately exceeds 8s and must not be SIGKILLed into a failure.
+function runLinearis(args, { timeoutMs } = {}) {
   // env: process.env is explicit (not just inherited) so the CURRENT PATH resolves
   // `linearis` — bun's spawnSync snapshots PATH for bare-command lookup otherwise.
-  // timeout: a 429-stalled / hung linearis must never block the read indefinitely
-  // (mirrors linear-query.mjs's CTL-1339/CTL-1364 8s cap); on timeout we fail safe → exit 1.
-  const timeoutMs = Number(process.env.CATALYST_LINEARIS_TIMEOUT_MS) || 8_000;
-  const r = spawnSync("linearis", args, {
+  const cap =
+    timeoutMs === undefined ? Number(process.env.CATALYST_LINEARIS_TIMEOUT_MS) || 8_000 : timeoutMs;
+  const opts = {
     input: "",
     encoding: "utf8",
     maxBuffer: 64 * 1024 * 1024,
     env: process.env,
-    timeout: timeoutMs,
     killSignal: "SIGKILL",
-  });
+  };
+  if (cap > 0) opts.timeout = cap; // uncapped when cap <= 0 (list/search passthrough)
+  const r = spawnSync("linearis", args, opts);
   const timedOut = r.error?.code === "ETIMEDOUT" || r.signal === "SIGKILL" || r.signal === "SIGTERM";
   if (r.error || r.status !== 0) {
     throw Object.assign(new Error(`linearis ${args.join(" ")} failed`), {
@@ -335,10 +357,24 @@ function metaFor(source, replica, extra = {}) {
 }
 
 // ── command handlers ──
-async function cmdRead(id, replica) {
+async function cmdRead(id, replica, flags = {}) {
   if (!id) {
     process.stderr.write(JSON.stringify({ error: "read: missing <ID> (e.g. catalyst-linear read CTL-1)" }) + "\n");
     return 2;
+  }
+  // Preserve caller-passed `linearis issues read` flags (e.g. --with-attachments,
+  // used by phase-research to fetch linked plan references). The replica serves only
+  // the flagless normalized detail shape, so a flagged read CANNOT be honored by the
+  // replica without silently returning a different, incomplete payload. When any read
+  // flag is present we bypass the replica and passthrough to linearis so the caller
+  // gets the EXACT requested payload (parity > acceleration).
+  const flagArgs = flagPairs(flags);
+  const readArgs = ["issues", "read", id, ...flagArgs];
+  if (flagArgs.length > 0) {
+    if (replica?.db) { try { replica.db.close(); } catch { /* already closed */ } }
+    warnFallback("read-flags", id);
+    emit(runLinearis(readArgs), metaFor("linearis", null, { replica_skip: "read-flags" }));
+    return 0;
   }
   if (replica?.db) {
     let view = null;
@@ -358,12 +394,12 @@ async function cmdRead(id, replica) {
     // _meta.source so monitoring can tell a clean cache-miss from a broken replica.
     replica.db.close();
     warnFallback(threw ? "replica-exception" : "miss", id);
-    emit(runLinearis(["issues", "read", id]), metaFor(threw ? "linearis_exception" : "linearis_miss", replica));
+    emit(runLinearis(readArgs), metaFor(threw ? "linearis_exception" : "linearis_miss", replica));
     return 0;
   }
   // No usable replica: linearis is the direct path. warn only if the operator opted in.
   warnFallback(replica?.skip ?? "replica-absent", id);
-  emit(runLinearis(["issues", "read", id]), metaFor("linearis", null, { replica_skip: replica?.skip ?? null }));
+  emit(runLinearis(readArgs), metaFor("linearis", null, { replica_skip: replica?.skip ?? null }));
   return 0;
 }
 
@@ -372,7 +408,8 @@ async function cmdRead(id, replica) {
 // preserves linearis's exact shape and just annotates _meta, so they are correct
 // today on every node; they simply aren't replica-accelerated yet.
 function cmdList(flags) {
-  emit(runLinearis(["issues", "list", ...flagPairs(flags)]), metaFor("linearis", null, { list_replica: "pending" }));
+  // timeoutMs: 0 — uncapped, matching direct `linearis issues list` (broad pages can exceed 8s).
+  emit(runLinearis(["issues", "list", ...flagPairs(flags)], { timeoutMs: 0 }), metaFor("linearis", null, { list_replica: "pending" }));
   return 0;
 }
 function cmdSearch(query, flags) {
@@ -380,7 +417,8 @@ function cmdSearch(query, flags) {
     process.stderr.write(JSON.stringify({ error: 'search: missing <query> (e.g. catalyst-linear search "auth bug")' }) + "\n");
     return 2;
   }
-  emit(runLinearis(["issues", "search", query, ...flagPairs(flags)]), metaFor("linearis", null, { search_replica: "pending" }));
+  // timeoutMs: 0 — uncapped, matching direct `linearis issues search` (expensive searches can exceed 8s).
+  emit(runLinearis(["issues", "search", query, ...flagPairs(flags)], { timeoutMs: 0 }), metaFor("linearis", null, { search_replica: "pending" }));
   return 0;
 }
 
@@ -421,7 +459,7 @@ export async function main(argv) {
   try {
     if (cmd === "read") {
       replica = await openFreshReplica();
-      return await cmdRead(positionals[0], replica);
+      return await cmdRead(positionals[0], replica, flags);
     }
     if (cmd === "list") return cmdList(flags);
     return cmdSearch(positionals[0], flags);

--- a/plugins/dev/scripts/execution-core/linear-cli.mjs
+++ b/plugins/dev/scripts/execution-core/linear-cli.mjs
@@ -208,7 +208,12 @@ function runLinearis(args) {
         error: `linearis ${args.join(" ")} failed`,
         status: r.status ?? null,
         timedOut,
-        detail: (r.stderr || r.error?.message || "").slice(0, 500),
+        // Defense-in-depth: redact any Linear token shape from linearis's own stderr
+        // before it lands in our error envelope (the replica/CLI never handles tokens,
+        // but linearis carries LINEAR_API_TOKEN — never echo one through us).
+        detail: (r.stderr || r.error?.message || "")
+          .replace(/\blin_(?:api|oauth)_[A-Za-z0-9_-]+/g, "lin_***")
+          .slice(0, 500),
       },
     });
   }

--- a/plugins/dev/scripts/execution-core/linear-cli.mjs
+++ b/plugins/dev/scripts/execution-core/linear-cli.mjs
@@ -1,0 +1,448 @@
+// linear-cli.mjs — CTL-1391: the `catalyst-linear` driver. The agent-facing
+// REPLICA-FIRST Linear read command. Lets any agent (autonomous worker or
+// interactive coding session) read Linear from the local Catalyst-Cloud SDK
+// replica when one is present + fresh, and fall back to a direct `linearis`
+// read otherwise — the executable half of the "Reading Linear" rule the
+// `linearis` skill documents.
+//
+// CONTRACT
+// --------
+//   catalyst-linear read <ID>        single-issue detail   (replica-first)
+//   catalyst-linear list [flags]     issue list            (linearis passthrough, v1)
+//   catalyst-linear search <q> [..]  issue search          (linearis passthrough, v1)
+//   <any write verb>                 REJECTED — replica is read-only; use linearis
+//
+// Output is JSON shaped to MATCH `linearis` so existing jq pipelines + skills are
+// drop-in, plus an additive top-level `_meta` carrying the read source + replica
+// freshness (the evidence-for-escalation signal). The CLI needs NO cloud token —
+// it reads the local replica file; a separate supervised writer keeps it current.
+//
+// NODE-SAFE LOADABILITY (load-bearing): the replica path imports `bun:sqlite` +
+// `@catalyst-cloud/read-model` (a `.ts` source-export). Those are bun-only — a
+// STATIC import would make this whole module fail to load under node, killing the
+// linearis-fallback and write-rejection paths. So every replica-side import is a
+// guarded `await import(...)`; on node (or any import failure) we degrade to the
+// linearis path. The fallback + write-rejection paths use only node built-ins.
+//
+// MODE: replica reads are OPT-IN. `CATALYST_LINEAR_REPLICA` (env) or Layer-2
+// `catalyst.linearReplica.mode`; default OFF. A present/fresh file does not
+// auto-enable — an operator must opt in (mirrors config.mjs readLinearReplica).
+import { existsSync, statSync, readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { resolve } from "node:path";
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+
+const WRITE_VERBS = new Set([
+  "create", "update", "move", "comment", "estimate", "label", "delete", "assign",
+]);
+const DEFAULT_STALE_MS = 300_000; // 5 min — generous; the push feed keeps the replica sub-second in normal operation.
+
+// ── config seam (inlined, node-safe — deliberately NOT importing config.mjs so a
+//    transitive bun-only import there can never break node load on the fallback path) ──
+function catalystDir() {
+  return process.env.CATALYST_DIR || resolve(homedir(), "catalyst");
+}
+function getReplicaDbPath() {
+  return process.env.CATALYST_REPLICA_DB || resolve(catalystDir(), "catalyst-replica.db");
+}
+function staleThresholdMs() {
+  const n = Number(process.env.CATALYST_LINEAR_REPLICA_STALE_MS);
+  return Number.isFinite(n) && n > 0 ? n : DEFAULT_STALE_MS;
+}
+// env wins: "on"/"1" → on; "0"/"off"/any-other-nonempty → off; unset → Layer-2
+// catalyst.linearReplica.mode ("on" only); default off. (Same precedence as
+// config.mjs readLinearReplica, reimplemented inline + node-safe.)
+export function resolveReplicaMode(env = process.env, cfgPathOverride) {
+  const raw = env.CATALYST_LINEAR_REPLICA;
+  if (raw != null && raw !== "") {
+    return raw === "on" || raw === "1" ? "on" : "off";
+  }
+  try {
+    const home = env.HOME || homedir();
+    const cfgPath = cfgPathOverride || resolve(home, ".config", "catalyst", "config.json");
+    if (!existsSync(cfgPath)) return "off";
+    const cfg = JSON.parse(readFileSync(cfgPath, "utf8"));
+    return cfg?.catalyst?.linearReplica?.mode === "on" ? "on" : "off";
+  } catch {
+    return "off"; // unreadable/malformed config never enables the replica
+  }
+}
+
+// ── arg parsing: `<cmd> [positional] [--flag value | --flag=value]` ──
+export function parseArgs(argv) {
+  const positionals = [];
+  const flags = {};
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a.startsWith("--")) {
+      const body = a.slice(2);
+      const eq = body.indexOf("=");
+      if (eq >= 0) flags[body.slice(0, eq)] = body.slice(eq + 1);
+      else if (i + 1 < argv.length && !argv[i + 1].startsWith("--")) flags[body] = argv[++i];
+      else flags[body] = "true";
+    } else {
+      positionals.push(a);
+    }
+  }
+  return { cmd: positionals[0], positionals: positionals.slice(1), flags };
+}
+
+// ── replica executor adapter (inlined; never import host-sync — different workspace) ──
+function bunSqlExecutor(db) {
+  return {
+    exec: (query, ...bindings) => ({
+      toArray: () =>
+        db.query(query).all(...bindings.map((v) => (v instanceof ArrayBuffer ? new Uint8Array(v) : v))),
+    }),
+  };
+}
+
+// Coerce a replica cell to epoch-ms — integer epoch-ms (the change-feed shape) OR
+// an ISO-8601 string. Anything else → undefined (caller fails open).
+function coerceMs(v) {
+  if (v == null) return undefined;
+  const n = Number(v);
+  if (Number.isFinite(n)) return n;
+  const p = Date.parse(String(v));
+  return Number.isFinite(p) ? p : undefined;
+}
+
+// Newest mirror timestamp + row count — observability + a per-read sanity check
+// that the DB has rows. (The freshness GATE is the file mtime — see openFreshReplica.)
+function probeFreshness(db) {
+  try {
+    const row = db.query("SELECT MAX(updated_at) AS maxUpdated, COUNT(*) AS n FROM issues").get();
+    if (!row) return undefined;
+    const ms = coerceMs(row.maxUpdated);
+    return { maxUpdatedAtMs: ms, rowCount: Number(row.n) || 0 };
+  } catch {
+    return undefined;
+  }
+}
+
+// ── read-source resolver. Returns an open replica handle when mode=on AND a
+//    fresh replica file is usable, else null (→ caller uses linearis). FAIL-OPEN:
+//    any doubt returns null so a read can never be wrong, only un-accelerated. ──
+async function openFreshReplica() {
+  const mode = resolveReplicaMode();
+  if (mode === "off") return { skip: "mode-off" };
+  const dbPath = getReplicaDbPath();
+  if (!existsSync(dbPath)) return { skip: "replica-absent" };
+
+  // Freshness GATE = file mtime (writer-liveness proxy): a dead writer stops
+  // touching the file → stale mtime → fall back to live. A live writer on the
+  // push feed touches it as deltas land. A truly-quiet-but-alive feed may
+  // false-stale → linearis (correct answer, just un-cached) — fail-safe by design.
+  let mtimeAgeMs;
+  try {
+    // WAL mode: the writer's appends land in the `-wal` sidecar; the main DB file's
+    // mtime only advances on checkpoint. Take the freshest of the DB + its -wal/-shm
+    // sidecars so an actively-writing-to-WAL replica is not falsely judged stale.
+    let newest = statSync(dbPath).mtimeMs;
+    for (const ext of ["-wal", "-shm"]) {
+      try { newest = Math.max(newest, statSync(dbPath + ext).mtimeMs); } catch { /* sidecar absent */ }
+    }
+    mtimeAgeMs = Date.now() - newest;
+  } catch {
+    return { skip: "stat-failed" };
+  }
+  if (mtimeAgeMs > staleThresholdMs()) return { skip: "stale", mtimeAgeMs };
+
+  let Database, build;
+  try {
+    ({ Database } = await import("bun:sqlite"));
+  } catch {
+    return { skip: "no-bun-sqlite" }; // node (no bun) → linearis
+  }
+  try {
+    build = await import("@catalyst-cloud/read-model");
+  } catch {
+    return { skip: "no-read-model" }; // bun host but read-model not resolvable → linearis
+  }
+  let db;
+  try {
+    db = new Database(dbPath, { readonly: true });
+    db.run("PRAGMA busy_timeout = 250");
+  } catch {
+    return { skip: "open-failed" };
+  }
+  const fresh = probeFreshness(db);
+  if (!fresh || fresh.maxUpdatedAtMs === undefined) {
+    db.close();
+    return { skip: "freshness-undefined" };
+  }
+  return { db, sql: bunSqlExecutor(db), build, fresh, mtimeAgeMs };
+}
+
+// ── linearis fallback (direct read; input:"" == `</dev/null` so it never blocks on stdin) ──
+function flagPairs(flags) {
+  const out = [];
+  for (const [k, v] of Object.entries(flags)) {
+    if (k === "help") continue;
+    out.push(`--${k}`);
+    if (v !== "true") out.push(v);
+  }
+  return out;
+}
+// Throws a tagged error on failure (NOT process.exit — that would be untestable
+// and kill any embedding process); main() catches `_linearis` and returns code 1.
+function runLinearis(args) {
+  // env: process.env is explicit (not just inherited) so the CURRENT PATH resolves
+  // `linearis` — bun's spawnSync snapshots PATH for bare-command lookup otherwise.
+  // timeout: a 429-stalled / hung linearis must never block the read indefinitely
+  // (mirrors linear-query.mjs's CTL-1339/CTL-1364 8s cap); on timeout we fail safe → exit 1.
+  const timeoutMs = Number(process.env.CATALYST_LINEARIS_TIMEOUT_MS) || 8_000;
+  const r = spawnSync("linearis", args, {
+    input: "",
+    encoding: "utf8",
+    maxBuffer: 64 * 1024 * 1024,
+    env: process.env,
+    timeout: timeoutMs,
+    killSignal: "SIGKILL",
+  });
+  const timedOut = r.error?.code === "ETIMEDOUT" || r.signal === "SIGKILL" || r.signal === "SIGTERM";
+  if (r.error || r.status !== 0) {
+    throw Object.assign(new Error(`linearis ${args.join(" ")} failed`), {
+      _linearis: {
+        error: `linearis ${args.join(" ")} failed`,
+        status: r.status ?? null,
+        timedOut,
+        detail: (r.stderr || r.error?.message || "").slice(0, 500),
+      },
+    });
+  }
+  try {
+    return JSON.parse(r.stdout);
+  } catch {
+    throw Object.assign(new Error("linearis output was not valid JSON"), {
+      _linearis: { error: "linearis output was not valid JSON" },
+    });
+  }
+}
+
+// ── normalizer: read-model IssueDetailView (snake_case) → the `linearis issues
+//    read` object shape, so a consumer can't tell which backend served the read.
+//    `sql` is passed for the two parity completions (inverseRelations, branchName)
+//    the detail view does not carry. ──
+function isoOrNull(v) {
+  const ms = coerceMs(v);
+  return ms === undefined ? null : new Date(ms).toISOString();
+}
+export function normalizeDetail(view, sql) {
+  const id = view.identifier;
+  // inverseRelations: who points AT this issue (the blocked-by edge the scheduler
+  // gates on). Emitting [] here would be a silent correctness bug, so query it.
+  let inverse = [];
+  try {
+    inverse = sql
+      .exec("SELECT type, issue_identifier FROM relations WHERE related_identifier = ?", id)
+      .toArray()
+      // linearis's inverseRelations nodes use `issue` (forward `relations` use `relatedIssue`);
+      // live consumers read inverseRelations.nodes[].issue.identifier (scheduler / eligible-set / beliefs).
+      .map((r) => ({ type: r.type, issue: { identifier: r.issue_identifier } }));
+  } catch { /* fail open — empty inverse rather than throw */ }
+  // branchName: not in the detail view; one cheap lookup (issues carries removed_at).
+  let branchName = null;
+  try {
+    const row = sql
+      .exec("SELECT branch_name FROM issues WHERE identifier = ? AND removed_at IS NULL LIMIT 1", id)
+      .toArray()[0];
+    branchName = row?.branch_name ?? null;
+  } catch { /* fail open */ }
+
+  return {
+    id: view.id,
+    identifier: view.identifier,
+    title: view.title,
+    description: view.description ?? null,
+    priority: view.priority ?? null,
+    estimate: view.estimate ?? null,
+    // dueDate: pass the YYYY-MM-DD string THROUGH — never Date.parse (a date-only
+    // string would shift across timezones).
+    dueDate: view.due_date ?? null,
+    createdAt: isoOrNull(view.created_at),
+    updatedAt: isoOrNull(view.updated_at),
+    url: view.url ?? null,
+    state: { name: view.state ?? null }, // no states table in the replica → no state.id
+    assignee:
+      view.assignee_id != null
+        ? { id: view.assignee_id, name: view.assignee_name ?? view.assignee ?? null }
+        : null,
+    team: { id: view.team_id ?? null }, // no teams table → key/name absent (known gap)
+    project: view.project_id != null ? { id: view.project_id, name: view.project_name ?? null } : null,
+    cycle:
+      view.cycle_id != null ? { id: view.cycle_id, name: null, number: view.cycle_number ?? null } : null,
+    parent:
+      view.parent_id != null
+        ? { id: view.parent_id, identifier: view.parent_identifier ?? null, title: null }
+        : null,
+    // KNOWN GAPS (the replica schema lacks these; documented for drop-in callers):
+    //   children.nodes — no children table in the replica → always []
+    //   relations/inverseRelations nodes[].id + .issue/.relatedIssue.id — relations table has no UUID columns
+    //   state.id, team.key/name, parent.title, cycle.name — no states/teams tables → not carried
+    children: { nodes: [] },
+    projectMilestone: null,
+    labels: { nodes: (view.labels ?? []).map((l) => ({ id: l.id, name: l.name })) },
+    relations: {
+      nodes: (view.relations ?? []).map((r) => ({
+        type: r.type,
+        relatedIssue: { identifier: r.related_identifier },
+      })),
+    },
+    inverseRelations: { nodes: inverse },
+    comments: { nodes: (view.comments ?? []).map((c) => ({ id: c.id, body: c.body })) },
+    branchName,
+  };
+}
+
+// ── output ──
+function emit(payload, meta) {
+  process.stdout.write(JSON.stringify({ ...payload, _meta: meta }) + "\n");
+}
+function warnFallback(reason, id) {
+  // Only warn when the operator OPTED IN (mode=on) but the replica didn't serve —
+  // that is the surfacing signal. On a standard node (mode off) this is silent.
+  if (resolveReplicaMode() !== "on") return;
+  process.stderr.write(
+    `[catalyst-linear] replica did not serve ${id ?? ""} (${reason}) — fell back to linearis\n`,
+  );
+}
+function rejectWrite(verb) {
+  process.stderr.write(
+    JSON.stringify({
+      error: `catalyst-linear is read-only — use: linearis issues ${verb} ...`,
+      hint: "Writes always go through linearis; the Catalyst Cloud replica is read-only.",
+    }) + "\n",
+  );
+  return 1;
+}
+
+function metaFor(source, replica, extra = {}) {
+  const m = { source, replica_mode: resolveReplicaMode(), ...extra };
+  if (replica?.fresh) {
+    m.replica_staleness_ms =
+      replica.fresh.maxUpdatedAtMs != null ? Date.now() - replica.fresh.maxUpdatedAtMs : null;
+    m.replica_row_count = replica.fresh.rowCount;
+    if (replica.mtimeAgeMs != null) m.replica_mtime_age_ms = replica.mtimeAgeMs;
+  }
+  return m;
+}
+
+// ── command handlers ──
+async function cmdRead(id, replica) {
+  if (!id) {
+    process.stderr.write(JSON.stringify({ error: "read: missing <ID> (e.g. catalyst-linear read CTL-1)" }) + "\n");
+    return 2;
+  }
+  if (replica?.db) {
+    let view = null;
+    let threw = false;
+    try {
+      view = replica.build.buildIssueDetail(replica.sql, id);
+    } catch {
+      threw = true; // read-model error (schema mismatch / missing table) — distinct from a clean miss
+    }
+    if (view) {
+      const payload = normalizeDetail(view, replica.sql);
+      replica.db.close();
+      emit(payload, metaFor("replica", replica));
+      return 0;
+    }
+    // Absent id (miss) OR read-model threw (exception) → live read, with a DISTINCT
+    // _meta.source so monitoring can tell a clean cache-miss from a broken replica.
+    replica.db.close();
+    warnFallback(threw ? "replica-exception" : "miss", id);
+    emit(runLinearis(["issues", "read", id]), metaFor(threw ? "linearis_exception" : "linearis_miss", replica));
+    return 0;
+  }
+  // No usable replica: linearis is the direct path. warn only if the operator opted in.
+  warnFallback(replica?.skip ?? "replica-absent", id);
+  emit(runLinearis(["issues", "read", id]), metaFor("linearis", null, { replica_skip: replica?.skip ?? null }));
+  return 0;
+}
+
+// list/search are v1 LINEARIS PASSTHROUGH — the replica-backed list view requires
+// a full-shape bulk query + pagination parity (tracked as a follow-up). Passthrough
+// preserves linearis's exact shape and just annotates _meta, so they are correct
+// today on every node; they simply aren't replica-accelerated yet.
+function cmdList(flags) {
+  emit(runLinearis(["issues", "list", ...flagPairs(flags)]), metaFor("linearis", null, { list_replica: "pending" }));
+  return 0;
+}
+function cmdSearch(query, flags) {
+  if (!query) {
+    process.stderr.write(JSON.stringify({ error: 'search: missing <query> (e.g. catalyst-linear search "auth bug")' }) + "\n");
+    return 2;
+  }
+  emit(runLinearis(["issues", "search", query, ...flagPairs(flags)]), metaFor("linearis", null, { search_replica: "pending" }));
+  return 0;
+}
+
+const USAGE = `catalyst-linear — replica-first Linear READ (falls back to linearis)
+
+Usage:
+  catalyst-linear read <ID>           Single-issue detail (replica-first; linearis fallback).
+  catalyst-linear list [flags]        Issue list (linearis passthrough today).
+  catalyst-linear search <q> [flags]  Issue search (linearis passthrough today).
+
+Reads only. WRITES (create/update/move/comment/estimate/label/delete/assign) are
+rejected — the replica is read-only; use \`linearis\` for writes.
+
+Output matches \`linearis\` JSON + an additive \`_meta\` {source, replica_mode,
+replica_staleness_ms, ...}. The replica is used only when opted in
+(CATALYST_LINEAR_REPLICA=on or Layer-2 catalyst.linearReplica.mode) AND a fresh
+local replica is present; otherwise reads go directly to linearis.`;
+
+export async function main(argv) {
+  const { cmd, positionals, flags } = parseArgs(argv);
+
+  if (cmd == null || cmd === "help" || flags.help === "true") {
+    process.stdout.write(USAGE + "\n");
+    return cmd == null && flags.help !== "true" ? 1 : 0;
+  }
+  // Write verbs rejected FIRST — before opening anything (node-safe path).
+  if (WRITE_VERBS.has(cmd)) return rejectWrite(cmd);
+
+  if (cmd !== "read" && cmd !== "list" && cmd !== "search") {
+    process.stderr.write(`error: unknown command ${JSON.stringify(cmd)}\n\n${USAGE}\n`);
+    return 2;
+  }
+
+  // Only `read` consults the replica; list/search are linearis passthrough (v1), so
+  // they never pay the open. The single try/catch maps a linearis failure (tagged
+  // _linearis) → stderr envelope + exit 1 for every command.
+  let replica = null;
+  try {
+    if (cmd === "read") {
+      replica = await openFreshReplica();
+      return await cmdRead(positionals[0], replica);
+    }
+    if (cmd === "list") return cmdList(flags);
+    return cmdSearch(positionals[0], flags);
+  } catch (err) {
+    // A linearis failure → stderr envelope + exit 1 (no stdout written, so a caller
+    // never sees a half-emitted payload).
+    if (err && err._linearis) {
+      process.stderr.write(JSON.stringify(err._linearis) + "\n");
+      return 1;
+    }
+    throw err;
+  } finally {
+    // Defensive: ensure the handle is closed if a read handler returned without closing.
+    try { if (replica?.db) replica.db.close(); } catch { /* already closed */ }
+  }
+}
+
+// Entrypoint guard: run only when invoked directly (not when imported by a test).
+const isMain =
+  import.meta.main === true ||
+  (process.argv[1] && fileURLToPath(import.meta.url) === resolve(process.argv[1]));
+if (isMain) {
+  main(process.argv.slice(2))
+    .then((code) => { process.exitCode = code ?? 0; })
+    .catch((err) => {
+      process.stderr.write(JSON.stringify({ error: "catalyst-linear fatal", detail: String(err?.message ?? err) }) + "\n");
+      process.exitCode = 1;
+    });
+}

--- a/plugins/dev/scripts/execution-core/linear-cli.test.mjs
+++ b/plugins/dev/scripts/execution-core/linear-cli.test.mjs
@@ -1,0 +1,360 @@
+// linear-cli.test.mjs — CTL-1391. Tests for the catalyst-linear driver.
+//
+// Strategy: pure-unit tests for the logic-dense seams (parseArgs, resolveReplicaMode,
+// normalizeDetail) + integration tests that exercise main() end-to-end against (a) a
+// REAL minimal bun:sqlite replica seeded from an inline fixture (the read-model query
+// path) and (b) a FAKE `linearis` on PATH (the fallback path). No @catalyst-cloud/schema
+// dependency (would pull drizzle onto worker nodes) — the fixture hand-rolls only the
+// tables buildIssueDetail/buildIssueActivity read.
+import { test, expect, describe, beforeEach, afterEach } from "bun:test";
+import { Database } from "bun:sqlite";
+import { mkdtempSync, writeFileSync, chmodSync, utimesSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { parseArgs, resolveReplicaMode, normalizeDetail, main } from "./linear-cli.mjs";
+
+// ── fixtures ───────────────────────────────────────────────────────────────
+// Minimal schema covering exactly what buildIssueDetail + buildIssueActivity SELECT.
+// Conditional sub-queries (projects/cycles/users) are skipped for a null-FK issue, so
+// those tables are omitted; the always-run list queries (comments/labels/relations/
+// issue_history) need their tables present even when empty.
+const SCHEMA = `
+CREATE TABLE issues (
+  id TEXT PRIMARY KEY, identifier TEXT, title TEXT, description TEXT, state TEXT,
+  assignee TEXT, assignee_id TEXT, priority INTEGER, estimate REAL,
+  project_id TEXT, cycle_id TEXT, team_id TEXT,
+  delegate_id TEXT, delegate_name TEXT, bot_actor_name TEXT, bot_actor_type TEXT, bot_actor_sub_type TEXT,
+  parent_id TEXT, parent_identifier TEXT,
+  url TEXT, started_at INTEGER, completed_at INTEGER, canceled_at INTEGER, created_at INTEGER, due_date TEXT,
+  priority_label TEXT, sort_order REAL, updated_at INTEGER, removed_at INTEGER, branch_name TEXT
+);
+CREATE TABLE comments (
+  id TEXT PRIMARY KEY, issue_id TEXT, body TEXT, author_id TEXT, author_name TEXT,
+  author_avatar_url TEXT, is_bot INTEGER, parent_id TEXT, updated_at INTEGER, removed_at INTEGER
+);
+CREATE TABLE labels (id TEXT PRIMARY KEY, name TEXT, color TEXT, removed_at INTEGER);
+CREATE TABLE issue_labels (issue_id TEXT, label_id TEXT);
+CREATE TABLE relations (type TEXT, issue_identifier TEXT, related_identifier TEXT);
+CREATE TABLE issue_history (
+  id TEXT PRIMARY KEY, issue_id TEXT, actor_id TEXT, created_at INTEGER, from_state TEXT, to_state TEXT,
+  from_assignee_id TEXT, to_assignee_id TEXT, from_priority INTEGER, to_priority INTEGER,
+  from_estimate REAL, to_estimate REAL, from_title TEXT, to_title TEXT,
+  from_cycle_id TEXT, to_cycle_id TEXT, from_project_id TEXT, to_project_id TEXT,
+  from_parent_id TEXT, to_parent_id TEXT, from_team_id TEXT, to_team_id TEXT,
+  from_due_date TEXT, to_due_date TEXT, added_label_ids TEXT, removed_label_ids TEXT,
+  updated_description INTEGER, archived INTEGER, auto_archived INTEGER, auto_closed INTEGER, trashed INTEGER
+);
+`;
+
+function seedReplica(dbPath, { updatedAt = Date.now() } = {}) {
+  const db = new Database(dbPath);
+  db.run("PRAGMA journal_mode = WAL");
+  for (const stmt of SCHEMA.split(";")) { const s = stmt.trim(); if (s) db.run(s); }
+  db.run(
+    `INSERT INTO issues (id, identifier, title, description, state, team_id, priority, estimate,
+       url, due_date, created_at, updated_at, removed_at, branch_name)
+     VALUES ('uuid-1', 'CTL-TEST', 'Test issue', 'A description', 'Implement', 'team-uuid', 2, 3,
+       'https://linear.app/x/issue/CTL-TEST', '2026-07-01', 1782700000000, ?, NULL, 'ryan/ctl-test-slug')`,
+    updatedAt,
+  );
+  db.run("INSERT INTO labels (id, name, color, removed_at) VALUES ('lbl-1','orchestrator','#fff',NULL)");
+  db.run("INSERT INTO issue_labels (issue_id, label_id) VALUES ('uuid-1','lbl-1')");
+  // forward edge: CTL-TEST blocks CTL-OTHER; inverse edge: CTL-DEP blocks CTL-TEST.
+  db.run("INSERT INTO relations (type, issue_identifier, related_identifier) VALUES ('blocks','CTL-TEST','CTL-OTHER')");
+  db.run("INSERT INTO relations (type, issue_identifier, related_identifier) VALUES ('blocks','CTL-DEP','CTL-TEST')");
+  db.run("INSERT INTO comments (id, issue_id, body, updated_at, removed_at) VALUES ('cmt-1','uuid-1','hello',1782700001000,NULL)");
+  db.close();
+}
+
+// Write a fake `linearis` onto PATH. exitCode 0 → emits `payload`; non-zero → fails.
+function installFakeLinearis(dir, { payload, exitCode = 0 } = {}) {
+  const script = join(dir, "linearis");
+  const body = `#!/usr/bin/env bash\ncat <<'JSON'\n${JSON.stringify(payload ?? {})}\nJSON\nexit ${exitCode}\n`;
+  writeFileSync(script, body);
+  chmodSync(script, 0o755);
+  process.env.PATH = `${dir}:${process.env.PATH}`;
+}
+
+// Run main(argv), capturing stdout. Returns { code, out (parsed JSON or null), raw }.
+async function runMain(argv) {
+  const chunks = [];
+  const errChunks = [];
+  const origWrite = process.stdout.write;
+  const origErr = process.stderr.write;
+  process.stdout.write = (s) => { chunks.push(typeof s === "string" ? s : s.toString()); return true; };
+  process.stderr.write = (s) => { errChunks.push(typeof s === "string" ? s : s.toString()); return true; };
+  let code;
+  try {
+    code = await main(argv);
+  } finally {
+    process.stdout.write = origWrite;
+    process.stderr.write = origErr;
+  }
+  const raw = chunks.join("");
+  const err = errChunks.join("");
+  let out = null;
+  try { out = JSON.parse(raw); } catch { /* non-JSON (e.g. usage) */ }
+  return { code, out, raw, err };
+}
+
+// ── env isolation ────────────────────────────────────────────────────────
+let tmp;
+const SAVED = {};
+const ENV_KEYS = ["CATALYST_LINEAR_REPLICA", "CATALYST_REPLICA_DB", "CATALYST_LINEAR_REPLICA_STALE_MS", "PATH", "CATALYST_DIR"];
+beforeEach(() => {
+  for (const k of ENV_KEYS) SAVED[k] = process.env[k];
+  tmp = mkdtempSync(join(tmpdir(), "catalyst-linear-test-"));
+  // Point CATALYST_DIR somewhere empty so the default replica path is absent unless we set it.
+  process.env.CATALYST_DIR = join(tmp, "no-catalyst");
+  delete process.env.CATALYST_LINEAR_REPLICA;
+  delete process.env.CATALYST_REPLICA_DB;
+  delete process.env.CATALYST_LINEAR_REPLICA_STALE_MS;
+});
+afterEach(() => {
+  for (const k of ENV_KEYS) {
+    if (SAVED[k] === undefined) delete process.env[k];
+    else process.env[k] = SAVED[k];
+  }
+  try { rmSync(tmp, { recursive: true, force: true }); } catch { /* best effort */ }
+});
+
+// ── parseArgs ──────────────────────────────────────────────────────────────
+describe("parseArgs", () => {
+  test("read with id", () => {
+    expect(parseArgs(["read", "CTL-1"])).toEqual({ cmd: "read", positionals: ["CTL-1"], flags: {} });
+  });
+  test("list with flags (space + equals)", () => {
+    const p = parseArgs(["list", "--team", "CTL", "--limit=5"]);
+    expect(p.cmd).toBe("list");
+    expect(p.flags).toEqual({ team: "CTL", limit: "5" });
+  });
+  test("search query + flag", () => {
+    const p = parseArgs(["search", "auth bug", "--team", "CTL"]);
+    expect(p).toEqual({ cmd: "search", positionals: ["auth bug"], flags: { team: "CTL" } });
+  });
+});
+
+// ── resolveReplicaMode ──────────────────────────────────────────────────────
+describe("resolveReplicaMode", () => {
+  test('env "on"/"1" → on; "0"/"off"/garbage → off', () => {
+    expect(resolveReplicaMode({ CATALYST_LINEAR_REPLICA: "on" })).toBe("on");
+    expect(resolveReplicaMode({ CATALYST_LINEAR_REPLICA: "1" })).toBe("on");
+    expect(resolveReplicaMode({ CATALYST_LINEAR_REPLICA: "0" })).toBe("off");
+    expect(resolveReplicaMode({ CATALYST_LINEAR_REPLICA: "off" })).toBe("off");
+    expect(resolveReplicaMode({ CATALYST_LINEAR_REPLICA: "maybe" })).toBe("off");
+  });
+  // NOTE: os.homedir() ignores process.env.HOME on macOS, so the Layer-2 path is
+  // tested via the injectable cfgPathOverride rather than redirecting HOME.
+  test("unset + Layer-2 config absent → off", () => {
+    expect(resolveReplicaMode({}, join(tmp, "nope.json"))).toBe("off");
+  });
+  test('unset + Layer-2 mode:"on" → on', () => {
+    const cfg = join(tmp, "config-on.json");
+    writeFileSync(cfg, JSON.stringify({ catalyst: { linearReplica: { mode: "on" } } }));
+    expect(resolveReplicaMode({}, cfg)).toBe("on");
+  });
+  test("unset + Layer-2 present but mode unset → off", () => {
+    const cfg = join(tmp, "config-off.json");
+    writeFileSync(cfg, JSON.stringify({ catalyst: {} }));
+    expect(resolveReplicaMode({}, cfg)).toBe("off");
+  });
+});
+
+// ── normalizeDetail (the transform; fake view + fake sql) ───────────────────
+describe("normalizeDetail", () => {
+  // fake sql.exec(query, ...binds).toArray() — returns canned rows for the two
+  // parity completions (inverseRelations, branch_name).
+  const fakeSql = {
+    exec(query) {
+      if (/related_identifier = \?/.test(query)) {
+        return { toArray: () => [{ type: "blocks", issue_identifier: "CTL-DEP" }] };
+      }
+      if (/branch_name/.test(query)) {
+        return { toArray: () => [{ branch_name: "ryan/ctl-x" }] };
+      }
+      return { toArray: () => [] };
+    },
+  };
+  const view = {
+    id: "uuid-9", identifier: "CTL-9", title: "T", description: "D", priority: 1, estimate: 2,
+    due_date: "2026-07-04", created_at: 1782700000000, updated_at: 1782700500000,
+    url: "https://linear/CTL-9", state: "Implement",
+    assignee_id: "u1", assignee_name: "Ryan", assignee: "ryan",
+    team_id: "team-1", project_id: "p1", project_name: "Proj",
+    cycle_id: "c1", cycle_number: 7, parent_id: "par1", parent_identifier: "CTL-1",
+    labels: [{ id: "l1", name: "bug", color: "#f00" }],
+    relations: [{ type: "blocks", related_identifier: "CTL-OTHER" }],
+    comments: [{ id: "cm1", body: "hi" }],
+  };
+  const out = normalizeDetail(view, fakeSql);
+
+  test("dueDate passes through (no Date.parse) and timestamps become ISO", () => {
+    expect(out.dueDate).toBe("2026-07-04");
+    expect(out.createdAt).toBe(new Date(1782700000000).toISOString());
+    expect(out.updatedAt).toBe(new Date(1782700500000).toISOString());
+  });
+  test("state is {name} (no state.id); team is {id} only", () => {
+    expect(out.state).toEqual({ name: "Implement" });
+    expect(out.team).toEqual({ id: "team-1" });
+  });
+  test("assignee/project/cycle/parent shapes", () => {
+    expect(out.assignee).toEqual({ id: "u1", name: "Ryan" });
+    expect(out.project).toEqual({ id: "p1", name: "Proj" });
+    expect(out.cycle).toEqual({ id: "c1", name: null, number: 7 });
+    expect(out.parent).toEqual({ id: "par1", identifier: "CTL-1", title: null });
+  });
+  test("labels + forward relations mapped; inverseRelations + branchName from the second queries", () => {
+    expect(out.labels.nodes).toEqual([{ id: "l1", name: "bug" }]);
+    expect(out.relations.nodes).toEqual([{ type: "blocks", relatedIssue: { identifier: "CTL-OTHER" } }]);
+    expect(out.inverseRelations.nodes).toEqual([{ type: "blocks", issue: { identifier: "CTL-DEP" } }]);
+    expect(out.branchName).toBe("ryan/ctl-x");
+  });
+  test("null FKs → null shapes (not fabricated)", () => {
+    const bare = normalizeDetail({ id: "x", identifier: "CTL-0", state: "Backlog" }, { exec: () => ({ toArray: () => [] }) });
+    expect(bare.assignee).toBeNull();
+    expect(bare.project).toBeNull();
+    expect(bare.cycle).toBeNull();
+    expect(bare.parent).toBeNull();
+    expect(bare.inverseRelations.nodes).toEqual([]);
+    expect(bare.branchName).toBeNull();
+  });
+});
+
+// ── write rejection (node-safe path; no replica/cloud import reached) ────────
+describe("write rejection", () => {
+  for (const verb of ["create", "update", "move", "comment", "estimate", "label", "delete", "assign"]) {
+    test(`rejects '${verb}' with exit 1`, async () => {
+      const { code, err } = await runMain([verb, "CTL-1"]);
+      expect(code).toBe(1);
+      expect(JSON.parse(err.trim()).error).toContain("read-only");
+    });
+  }
+});
+
+// ── fallback to linearis (no replica / mode off) ────────────────────────────
+describe("linearis fallback", () => {
+  test("mode off → linearis, replica never consulted", async () => {
+    installFakeLinearis(tmp, { payload: { identifier: "CTL-1", state: { name: "Todo" }, _sentinel: "linearis" } });
+    // mode unset → off; even if a DB existed it would be skipped.
+    const { code, out } = await runMain(["read", "CTL-1"]);
+    expect(code).toBe(0);
+    expect(out._meta.source).toBe("linearis");
+    expect(out._meta.replica_mode).toBe("off");
+    expect(out.identifier).toBe("CTL-1");
+  });
+
+  test("mode on but replica file absent → linearis (replica_skip=replica-absent)", async () => {
+    installFakeLinearis(tmp, { payload: { identifier: "CTL-2", state: { name: "Backlog" } } });
+    process.env.CATALYST_LINEAR_REPLICA = "on";
+    process.env.CATALYST_REPLICA_DB = join(tmp, "does-not-exist.db");
+    const { out } = await runMain(["read", "CTL-2"]);
+    expect(out._meta.source).toBe("linearis");
+    expect(out._meta.replica_skip).toBe("replica-absent");
+  });
+});
+
+// ── replica HIT / MISS / STALE (real bun:sqlite + real read-model) ──────────
+describe("replica reads", () => {
+  test("HIT: fresh replica + mode on → reads replica, NOT linearis", async () => {
+    const dbPath = join(tmp, "catalyst-replica.db");
+    seedReplica(dbPath); // updated_at = now, file mtime = now → fresh
+    process.env.CATALYST_LINEAR_REPLICA = "on";
+    process.env.CATALYST_REPLICA_DB = dbPath;
+    // A sentinel fake linearis: if the replica path is broken and we fall back,
+    // the sentinel surfaces and the assertions fail cleanly (no process death).
+    installFakeLinearis(tmp, { payload: { identifier: "SENTINEL-LINEARIS", state: { name: "x" } } });
+
+    const { code, out } = await runMain(["read", "CTL-TEST"]);
+    expect(code).toBe(0);
+    expect(out._meta.source).toBe("replica");
+    expect(out.identifier).toBe("CTL-TEST");
+    expect(out.title).toBe("Test issue");
+    expect(out.description).toBe("A description");
+    expect(out.state).toEqual({ name: "Implement" });
+    expect(out.dueDate).toBe("2026-07-01");
+    expect(out.branchName).toBe("ryan/ctl-test-slug");
+    expect(out.labels.nodes).toEqual([{ id: "lbl-1", name: "orchestrator" }]);
+    // forward edge (CTL-TEST blocks CTL-OTHER) + inverse edge (CTL-DEP blocks CTL-TEST)
+    expect(out.relations.nodes).toEqual([{ type: "blocks", relatedIssue: { identifier: "CTL-OTHER" } }]);
+    expect(out.inverseRelations.nodes).toEqual([{ type: "blocks", issue: { identifier: "CTL-DEP" } }]);
+    expect(out.comments.nodes).toEqual([{ id: "cmt-1", body: "hello" }]);
+    expect(out._meta.replica_mode).toBe("on");
+    expect(typeof out._meta.replica_staleness_ms).toBe("number");
+    expect(out._meta.replica_row_count).toBe(1);
+  });
+
+  test("per-id MISS: replica fresh but id absent → linearis_miss", async () => {
+    const dbPath = join(tmp, "catalyst-replica.db");
+    seedReplica(dbPath);
+    process.env.CATALYST_LINEAR_REPLICA = "on";
+    process.env.CATALYST_REPLICA_DB = dbPath;
+    installFakeLinearis(tmp, { payload: { identifier: "CTL-ABSENT", state: { name: "Backlog" } } });
+    const { out } = await runMain(["read", "CTL-ABSENT"]);
+    expect(out._meta.source).toBe("linearis_miss");
+    expect(out.identifier).toBe("CTL-ABSENT");
+  });
+
+  test("STALE: old file mtime → linearis (skip=stale)", async () => {
+    const dbPath = join(tmp, "catalyst-replica.db");
+    seedReplica(dbPath, { updatedAt: Date.now() });
+    // age the DB AND its WAL/SHM sidecars far beyond the threshold — the gate takes
+    // the freshest of all three (WAL-mode writes land in -wal), so aging only .db
+    // would (correctly) still read fresh from the sidecars.
+    const old = (Date.now() - 3_600_000) / 1000;
+    for (const ext of ["", "-wal", "-shm"]) { try { utimesSync(dbPath + ext, old, old); } catch { /* sidecar absent */ } }
+    process.env.CATALYST_LINEAR_REPLICA = "on";
+    process.env.CATALYST_REPLICA_DB = dbPath;
+    process.env.CATALYST_LINEAR_REPLICA_STALE_MS = "300000";
+    installFakeLinearis(tmp, { payload: { identifier: "CTL-TEST", state: { name: "Implement" } } });
+    const { out } = await runMain(["read", "CTL-TEST"]);
+    expect(out._meta.source).toBe("linearis");
+    expect(out._meta.replica_skip).toBe("stale");
+  });
+});
+
+// ── list / search passthrough + error paths ─────────────────────────────────
+describe("list / search / errors", () => {
+  test("list → linearis passthrough with _meta annotation", async () => {
+    installFakeLinearis(tmp, { payload: { nodes: [{ identifier: "CTL-1" }], pageInfo: { hasNextPage: false } } });
+    const { code, out } = await runMain(["list", "--team", "CTL"]);
+    expect(code).toBe(0);
+    expect(out._meta.source).toBe("linearis");
+    expect(out._meta.list_replica).toBe("pending");
+    expect(out.nodes).toEqual([{ identifier: "CTL-1" }]);
+  });
+  test("search → linearis passthrough with _meta annotation", async () => {
+    installFakeLinearis(tmp, { payload: { nodes: [{ identifier: "CTL-2" }] } });
+    const { code, out } = await runMain(["search", "auth bug", "--team", "CTL"]);
+    expect(code).toBe(0);
+    expect(out._meta.source).toBe("linearis");
+    expect(out._meta.search_replica).toBe("pending");
+  });
+  test("search with no query → exit 2", async () => {
+    expect((await runMain(["search"])).code).toBe(2);
+  });
+  test("read with no ID → exit 2", async () => {
+    expect((await runMain(["read"])).code).toBe(2);
+  });
+  test("linearis failure → exit 1 with structured stderr envelope", async () => {
+    installFakeLinearis(tmp, { payload: { error: "boom" }, exitCode: 1 });
+    const { code, err } = await runMain(["read", "CTL-1"]);
+    expect(code).toBe(1);
+    const env = JSON.parse(err.trim().split("\n").pop());
+    expect(env.error).toContain("linearis issues read CTL-1 failed");
+    expect(env.status).toBe(1);
+  });
+});
+
+// ── usage / unknown command ─────────────────────────────────────────────────
+describe("usage", () => {
+  test("no command → usage to stdout, exit 1", async () => {
+    const { code, raw } = await runMain([]);
+    expect(code).toBe(1);
+    expect(raw).toContain("catalyst-linear");
+  });
+  test("unknown command → exit 2", async () => {
+    const { code } = await runMain(["frobnicate"]);
+    expect(code).toBe(2);
+  });
+});

--- a/plugins/dev/scripts/execution-core/linear-cli.test.mjs
+++ b/plugins/dev/scripts/execution-core/linear-cli.test.mjs
@@ -76,6 +76,26 @@ function installFakeLinearis(dir, { payload, exitCode = 0 } = {}) {
   process.env.PATH = `${dir}:${process.env.PATH}`;
 }
 
+// Fake `linearis` that echoes the argv it received (as `_args`) so a test can assert
+// flag passthrough. `$*` is the space-joined args (e.g. "issues read CTL-TEST --x").
+function installArgEchoLinearis(dir) {
+  const script = join(dir, "linearis");
+  const body = `#!/usr/bin/env bash\nargs="$*"\ncat <<JSON\n{"identifier":"CTL-TEST","_args":"$args"}\nJSON\n`;
+  writeFileSync(script, body);
+  chmodSync(script, 0o755);
+  process.env.PATH = `${dir}:${process.env.PATH}`;
+}
+
+// Fake `linearis` that sleeps `ms` before emitting — to prove the read cap fires
+// while list/search passthrough stays uncapped.
+function installSlowLinearis(dir, ms) {
+  const script = join(dir, "linearis");
+  const body = `#!/usr/bin/env bash\nsleep ${ms / 1000}\ncat <<'JSON'\n{"identifier":"CTL-SLOW","nodes":[]}\nJSON\n`;
+  writeFileSync(script, body);
+  chmodSync(script, 0o755);
+  process.env.PATH = `${dir}:${process.env.PATH}`;
+}
+
 // Run main(argv), capturing stdout. Returns { code, out (parsed JSON or null), raw }.
 async function runMain(argv) {
   const chunks = [];
@@ -101,7 +121,7 @@ async function runMain(argv) {
 // ── env isolation ────────────────────────────────────────────────────────
 let tmp;
 const SAVED = {};
-const ENV_KEYS = ["CATALYST_LINEAR_REPLICA", "CATALYST_REPLICA_DB", "CATALYST_LINEAR_REPLICA_STALE_MS", "PATH", "CATALYST_DIR"];
+const ENV_KEYS = ["CATALYST_LINEAR_REPLICA", "CATALYST_REPLICA_DB", "CATALYST_LINEAR_REPLICA_STALE_MS", "CATALYST_LINEARIS_TIMEOUT_MS", "CATALYST_LAYER2_CONFIG_FILE", "PATH", "CATALYST_DIR"];
 beforeEach(() => {
   for (const k of ENV_KEYS) SAVED[k] = process.env[k];
   tmp = mkdtempSync(join(tmpdir(), "catalyst-linear-test-"));
@@ -110,6 +130,8 @@ beforeEach(() => {
   delete process.env.CATALYST_LINEAR_REPLICA;
   delete process.env.CATALYST_REPLICA_DB;
   delete process.env.CATALYST_LINEAR_REPLICA_STALE_MS;
+  delete process.env.CATALYST_LINEARIS_TIMEOUT_MS;
+  delete process.env.CATALYST_LAYER2_CONFIG_FILE;
 });
 afterEach(() => {
   for (const k of ENV_KEYS) {
@@ -158,6 +180,20 @@ describe("resolveReplicaMode", () => {
     const cfg = join(tmp, "config-off.json");
     writeFileSync(cfg, JSON.stringify({ catalyst: {} }));
     expect(resolveReplicaMode({}, cfg)).toBe("off");
+  });
+  // Codex P2: honor CATALYST_LAYER2_CONFIG_FILE for parity with config.mjs —
+  // a node launched with a non-default Layer-2 path resolves mode from THAT file.
+  test('unset + CATALYST_LAYER2_CONFIG_FILE → mode:"on" → on', () => {
+    const cfg = join(tmp, "layer2-on.json");
+    writeFileSync(cfg, JSON.stringify({ catalyst: { linearReplica: { mode: "on" } } }));
+    expect(resolveReplicaMode({ CATALYST_LAYER2_CONFIG_FILE: cfg })).toBe("on");
+  });
+  test("cfgPathOverride beats CATALYST_LAYER2_CONFIG_FILE", () => {
+    const override = join(tmp, "override-off.json");
+    writeFileSync(override, JSON.stringify({ catalyst: {} }));
+    const envFile = join(tmp, "env-on.json");
+    writeFileSync(envFile, JSON.stringify({ catalyst: { linearReplica: { mode: "on" } } }));
+    expect(resolveReplicaMode({ CATALYST_LAYER2_CONFIG_FILE: envFile }, override)).toBe("off");
   });
 });
 
@@ -298,9 +334,9 @@ describe("replica reads", () => {
   test("STALE: old file mtime → linearis (skip=stale)", async () => {
     const dbPath = join(tmp, "catalyst-replica.db");
     seedReplica(dbPath, { updatedAt: Date.now() });
-    // age the DB AND its WAL/SHM sidecars far beyond the threshold — the gate takes
-    // the freshest of all three (WAL-mode writes land in -wal), so aging only .db
-    // would (correctly) still read fresh from the sidecars.
+    // age the DB AND its WAL sidecar far beyond the threshold — the gate takes the
+    // freshest of the DB + a non-empty -wal (WAL-mode writes land in -wal), so aging
+    // only .db would (correctly) still read fresh from a populated sidecar.
     const old = (Date.now() - 3_600_000) / 1000;
     for (const ext of ["", "-wal", "-shm"]) { try { utimesSync(dbPath + ext, old, old); } catch { /* sidecar absent */ } }
     process.env.CATALYST_LINEAR_REPLICA = "on";
@@ -310,6 +346,44 @@ describe("replica reads", () => {
     const { out } = await runMain(["read", "CTL-TEST"]);
     expect(out._meta.source).toBe("linearis");
     expect(out._meta.replica_skip).toBe("stale");
+  });
+
+  // Codex P2: a read-only consumer opening a checkpointed DB can create FRESH but
+  // EMPTY -wal/-shm sidecars. The gate must ignore them (empty -wal + -shm entirely)
+  // so a long-dead replica can't be made to look fresh by a mere reader open.
+  test("WAL spoof-resistance: stale .db + freshly-touched EMPTY -wal/-shm → still stale", async () => {
+    const dbPath = join(tmp, "catalyst-replica.db");
+    seedReplica(dbPath, { updatedAt: Date.now() });
+    const oldSec = (Date.now() - 3_600_000) / 1000; // writer dead an hour ago
+    utimesSync(dbPath, oldSec, oldSec);
+    const nowSec = Date.now() / 1000;
+    for (const ext of ["-wal", "-shm"]) {
+      writeFileSync(dbPath + ext, ""); // zero-length reader artifact
+      utimesSync(dbPath + ext, nowSec, nowSec); // bumped to NOW
+    }
+    process.env.CATALYST_LINEAR_REPLICA = "on";
+    process.env.CATALYST_REPLICA_DB = dbPath;
+    process.env.CATALYST_LINEAR_REPLICA_STALE_MS = "300000";
+    installFakeLinearis(tmp, { payload: { identifier: "CTL-TEST", state: { name: "Implement" } } });
+    const { out } = await runMain(["read", "CTL-TEST"]);
+    expect(out._meta.source).toBe("linearis");
+    expect(out._meta.replica_skip).toBe("stale");
+  });
+
+  // Codex P2: read flags (e.g. --with-attachments, used by phase-research) must
+  // reach linearis unchanged. The replica serves only the flagless detail shape, so
+  // a flagged read bypasses the replica entirely (parity > acceleration).
+  test("read flags bypass a FRESH replica → linearis passthrough preserves the flag", async () => {
+    const dbPath = join(tmp, "catalyst-replica.db");
+    seedReplica(dbPath); // fresh + mode on → would normally HIT
+    process.env.CATALYST_LINEAR_REPLICA = "on";
+    process.env.CATALYST_REPLICA_DB = dbPath;
+    installArgEchoLinearis(tmp);
+    const { code, out } = await runMain(["read", "CTL-TEST", "--with-attachments"]);
+    expect(code).toBe(0);
+    expect(out._meta.source).toBe("linearis"); // replica bypassed despite being fresh
+    expect(out._meta.replica_skip).toBe("read-flags");
+    expect(out._args).toBe("issues read CTL-TEST --with-attachments");
   });
 });
 
@@ -343,6 +417,31 @@ describe("list / search / errors", () => {
     const env = JSON.parse(err.trim().split("\n").pop());
     expect(env.error).toContain("linearis issues read CTL-1 failed");
     expect(env.status).toBe(1);
+  });
+});
+
+// ── linearis timeout scoping (Codex P2: read capped, list/search uncapped) ───
+describe("linearis timeout scoping", () => {
+  test("read honors CATALYST_LINEARIS_TIMEOUT_MS — slow linearis → timeout, exit 1", async () => {
+    process.env.CATALYST_LINEARIS_TIMEOUT_MS = "100";
+    installSlowLinearis(tmp, 600); // 600ms > 100ms cap → SIGKILL
+    const { code, err } = await runMain(["read", "CTL-SLOW"]);
+    expect(code).toBe(1);
+    expect(JSON.parse(err.trim().split("\n").pop()).timedOut).toBe(true);
+  });
+  test("list is UNCAPPED — slow linearis completes despite a tiny read cap", async () => {
+    process.env.CATALYST_LINEARIS_TIMEOUT_MS = "100";
+    installSlowLinearis(tmp, 400); // would be killed at 100ms IF the cap applied
+    const { code, out } = await runMain(["list"]);
+    expect(code).toBe(0);
+    expect(out._meta.source).toBe("linearis");
+  });
+  test("search is UNCAPPED — slow linearis completes despite a tiny read cap", async () => {
+    process.env.CATALYST_LINEARIS_TIMEOUT_MS = "100";
+    installSlowLinearis(tmp, 400);
+    const { code, out } = await runMain(["search", "auth bug"]);
+    expect(code).toBe(0);
+    expect(out._meta.source).toBe("linearis");
   });
 });
 

--- a/plugins/dev/scripts/execution-core/package.json
+++ b/plugins/dev/scripts/execution-core/package.json
@@ -6,6 +6,7 @@
     "test": "bun test"
   },
   "dependencies": {
+    "@catalyst-cloud/read-model": "^0.1.0",
     "@opentelemetry/api": "^1.9.1",
     "@opentelemetry/exporter-trace-otlp-http": "^0.219.0",
     "@opentelemetry/resources": "^2.8.0",

--- a/plugins/dev/scripts/gen-cli-reference.sh
+++ b/plugins/dev/scripts/gen-cli-reference.sh
@@ -54,6 +54,7 @@ catalyst-thoughts|Thoughts|1|Repair and verify the HumanLayer thoughts system fo
 register-thought|Thoughts|0|PostToolUse Write hook that auto-registers thoughts/shared writes (reads hook JSON on stdin).
 thoughts-pull-sync|Thoughts|0|Fast-forward every HumanLayer thoughts checkout so cross-host research reads fresh peer state.
 catalyst-cluster|Cluster & Linear|1|Cluster administration — join tokens, roster, drain, concurrency tuning.
+catalyst-linear|Cluster & Linear|1|Replica-first Linear READ CLI — reads the local Catalyst-Cloud SQLite replica when opted in (CATALYST_LINEAR_REPLICA=on), else linearis; read-only (writes via linearis).
 catalyst-linear-reconcile|Cluster & Linear|1|Reconcile Linear ticket state from PR reality (merged→Done, open→In-Review); report or --write.
 catalyst-statusline|HUD & display|0|Claude Code statusLine wrapper that also emits session.context events (reads JSON on stdin each tick).
 catalyst-hud|HUD & display|0|Ink TUI for the catalyst event stream (bare invocation starts the full-screen TUI).

--- a/plugins/dev/scripts/install-cli.sh
+++ b/plugins/dev/scripts/install-cli.sh
@@ -39,6 +39,7 @@ CLI_ENTRIES=(
   "catalyst-events:catalyst-events"
   "catalyst-execution-core:catalyst-execution-core"
   "catalyst-filter:catalyst-filter"
+  "catalyst-linear:catalyst-linear"
   "catalyst-linear-reconcile:catalyst-linear-reconcile"
   "catalyst-otel-forward:catalyst-otel-forward"
   "catalyst-transitions:catalyst-transitions"

--- a/website/src/content/docs/reference/catalyst-cli.md
+++ b/website/src/content/docs/reference/catalyst-cli.md
@@ -12,7 +12,7 @@ sidebar:
 
 Every `catalyst-*` CLI is installed onto your `PATH` by
 [`install-cli.sh`](https://github.com/coalesce-labs/catalyst/blob/main/plugins/dev/scripts/install-cli.sh) (into
-`~/.catalyst/bin` by default). This page lists all 28 of them — one line of
+`~/.catalyst/bin` by default). This page lists all 29 of them — one line of
 purpose plus the key subcommands — grouped by area. Run any tool with `--help`
 for full syntax. The richer tools have their own reference pages (e.g.
 [catalyst-stack](/reference/catalyst-stack/)).
@@ -156,6 +156,14 @@ Cluster administration — join tokens, roster, drain, concurrency tuning.
 **Key subcommands:** _(run `catalyst-cluster --help`)_
 
 [Source](https://github.com/coalesce-labs/catalyst/blob/main/plugins/dev/scripts/catalyst-cluster)
+
+### catalyst-linear
+
+Replica-first Linear READ CLI — reads the local Catalyst-Cloud SQLite replica when opted in (CATALYST_LINEAR_REPLICA=on), else linearis; read-only (writes via linearis).
+
+**Key subcommands:** _(run `catalyst-linear --help`)_
+
+[Source](https://github.com/coalesce-labs/catalyst/blob/main/plugins/dev/scripts/catalyst-linear)
 
 ### catalyst-linear-reconcile
 


### PR DESCRIPTION
## What

`catalyst-linear` — the agent-facing **replica-first Linear READ CLI**. The executable mechanism behind the "Reading Linear" rule (CTL-1392): any agent (autonomous worker *or* interactive session) reads Linear from the local Catalyst-Cloud SDK replica when opted in, with a direct `linearis` fallback. This is what makes "agents actually read the replica" real in every context.

```
catalyst-linear read <ID>      # replica-first (read-model buildIssueDetail) → linearis fallback
catalyst-linear list|search    # linearis passthrough (v1; replica-backed list is a follow-up)
catalyst-linear <write verb>    # rejected, exit 1 — the replica is read-only; use linearis
```

## Design
- **Replica-first when** `CATALYST_LINEAR_REPLICA=on` (or Layer-2 `catalyst.linearReplica.mode`) **and** a fresh local replica is present. Otherwise (mode off / absent / stale / per-id miss / read-model exception) → direct `linearis`. **Fail-open everywhere** — a read is never wrong, only un-accelerated.
- Output matches `linearis issues read` + an additive top-level `_meta` `{source, replica_mode, replica_staleness_ms, replica_row_count, replica_skip}` — the evidence signal for the rule's "escalate only on staleness" clause.
- **Freshness gate** = DB + `-wal`/`-shm` sidecar mtime (writer-liveness proxy; WAL-aware). `linearis` spawn has an **8s timeout** (the CTL-1339/1364 lesson). **No cloud token** needed — reads the local file a separate writer keeps fresh.
- **Node-loadable**: `bun:sqlite` + `@catalyst-cloud/read-model` are dynamic imports, so the module loads under `node` (write-reject + fallback work on node-only hosts). CI walks the static graph (`--target=node`).

## Dependency
`@catalyst-cloud/read-model@0.1.0` — **zero runtime deps, no drizzle** in `bun.lock` (verified). CTC confirmed read-model + the Drizzle schema are the durable read surface (CTC-113 *wraps* them), so swapping to the SDK-managed handle later is one line — no shape change.

## Verification
- **32 bun tests** (replica hit/miss/stale, mode resolution incl. Layer-2 via injectable config path, normalizeDetail mapping incl. `inverseRelations.issue`/branchName/dueDate, write-reject + stderr, list/search passthrough, linearis-failure → exit 1, node-loadability).
- **Live**: `catalyst-linear read CTL-1392` against a real SDK-seeded replica → `source: replica` (mode on) / `source: linearis` (mode off).
- **Adversarial review**: a 6-dimension parallel verification pass (correctness / node-load trap / shape-parity vs real linearis / fail-safety / tests / registration+deps); all P1/P2 findings fixed in this PR (notably the `inverseRelations` field-name data-drop and the `cli-reference-drift` registration).

Part of **CTL-1389**. Refs CTL-1390 (read-source seam), CTL-1392 (prose rule, #2474), CTC-113.

🤖 Generated with [Claude Code](https://claude.com/claude-code)