### PR TITLE
feat(dev): CTL-1401 — catalyst install/reinstall provisions the cloud-sync + executor levers (no reinstall regression)

### DIFF
--- a/plugins/dev/scripts/execution-core/install-lifecycle.mjs
+++ b/plugins/dev/scripts/execution-core/install-lifecycle.mjs
@@ -925,10 +925,14 @@ export async function runInstallLifecycle({ operation, nodeClass, opts = {} }, d
         }
         ctx.envUndos.push({ file: step.file, priorContent });
         // CTL-1401 (Codex P2): note whether the executor lever actually CHANGED, so an additive install
-        // only restarts a live exec-core when needed (an unchanged re-run must not interrupt work).
+        // only restarts a live exec-core when needed (an unchanged re-run must not interrupt work). The
+        // pre-upsert EFFECTIVE value is the LAST assignment, not the first — bash sources the whole file
+        // top-to-bottom so a later duplicate wins (the exact case upsertEnvFile dedupes). Reading the
+        // first match here would miss a `sdk`-then-`bg` file and skip the needed restart (Codex P2).
         if (step.key === "CATALYST_EXECUTOR") {
-          const m = (priorContent || "").match(/^\s*(?:export\s+)?CATALYST_EXECUTOR=["']?([^"'\s]+)/m);
-          ctx.executorChanged = (m ? m[1] : null) !== step.value;
+          const matches = [...(priorContent || "").matchAll(/^\s*(?:export\s+)?CATALYST_EXECUTOR=["']?([^"'\s]+)/gm)];
+          const effectiveOld = matches.length ? matches[matches.length - 1][1] : null;
+          ctx.executorChanged = effectiveOld !== step.value;
         }
         upsertEnvFile(step.file, step.key, step.value);
         log(`catalyst-install: set ${step.key}=${step.value} in ${step.file}`);
@@ -1094,6 +1098,12 @@ export async function runInstallLifecycle({ operation, nodeClass, opts = {} }, d
         for (const ph of bringup) {
           for (const s of ph.steps) {
             if (s.kind !== "run") continue;
+            // CTL-1401 (Codex P2): adopt-cloud-sync is ADDITIVE — re-running it here would adopt the
+            // cloud-sync agent on a rolled-back node whose ORIGINAL (pre-run) state had no cloud-sync,
+            // so the "rolled_back" outcome would leave a new agent behind (not a true reversal). Skip it
+            // in the rollback bring-up: rollback restores the captured state, it does not add agents.
+            // (A node that genuinely had cloud-sync gets it back from the bundle restore / next install.)
+            if (s.label === "adopt-cloud-sync") continue;
             const r = runStep({ argv: s.argv, env: bringupEnv });
             if (r.code !== 0 && !s.optional) {
               ok = false;
@@ -1269,9 +1279,9 @@ export function usage() {
   return `catalyst-install — provision / tear down this node for its class (CTL-1369).
 
 Usage (normally via the router: 'catalyst install|uninstall|reinstall …'):
-  catalyst-install install   [--class developer|worker|monitor] [--read-replica <url>] [--executor bg|sdk] [--dry-run]
+  catalyst-install install   [--class developer|worker|monitor] [--read-replica <url>] [--executor bg|sdk|oneshot-legacy] [--dry-run]
   catalyst-install uninstall [--force] [--dry-run]
-  catalyst-install reinstall [--class …] [--read-replica <url>] [--executor bg|sdk] [--force] [--dry-run]
+  catalyst-install reinstall [--class …] [--read-replica <url>] [--executor bg|sdk|oneshot-legacy] [--force] [--dry-run]
 
 Options:
   --class <c>          target node class (install: declares it; un/reinstall: defaults to current)

--- a/plugins/dev/scripts/execution-core/install-lifecycle.mjs
+++ b/plugins/dev/scripts/execution-core/install-lifecycle.mjs
@@ -96,6 +96,9 @@ export function resolveScripts(env = process.env) {
     // CTL-1369 PR4: the class-aware doctor, run as the install's pre-state observation + post-install
     // verification (catalyst-doctor --profile install). Env-override seam for tests.
     doctor: env.CATALYST_INSTALL_DOCTOR_BIN || join(SCRIPTS_DIR, "catalyst-doctor"),
+    // CTL-1401: the exec-core launcher — used to restart exec-core after an additive `install --executor`
+    // changed the lever (a live daemon won't pick up a new CATALYST_EXECUTOR without a restart).
+    execCore: env.CATALYST_INSTALL_EXECCORE_BIN || join(SCRIPTS_DIR, "catalyst-execution-core"),
   };
 }
 
@@ -304,16 +307,25 @@ export function planPhases({ operation, nodeClass, scripts, opts = {} }) {
     ],
   });
 
-  const startDaemons = () => ({
-    phase: "start-daemons",
-    steps: [
+  const startDaemons = () => {
+    const steps = [
       worker
         ? { label: "start-stack", kind: "run", argv: [scripts.stack, "start", "--yes"] }
         : // developer/monitor: boot-drain so a mis-rostered node still admits 0 work. Best-effort
           // (CTL-1352 auto-boot-drain is unbuilt) — verify-node confirms it took.
           { label: "drain", kind: "run", argv: [scripts.catalyst, "drain"], optional: true },
-    ],
-  });
+    ];
+    // CTL-1401 (Codex P2): on an ADDITIVE worker install with --executor, `catalyst-stack start --yes`
+    // is idempotent and won't restart an already-live exec-core, so the daemon keeps the OLD executor
+    // until a manual restart — the install would report the lever set while new work runs on the old
+    // executor. Restart exec-core to apply it (no-op at runtime if the lever didn't actually change).
+    // A REINSTALL doesn't need this: its teardown already stopped exec-core, so start-stack brings up a
+    // fresh daemon that sources the new env.
+    if (worker && operation === "install" && opts.executor) {
+      steps.push({ label: "restart-execcore", kind: "restart-execcore", argv: [scripts.execCore, "restart"] });
+    }
+    return { phase: "start-daemons", steps };
+  };
 
   const healthcheck = () => ({
     phase: "healthcheck",
@@ -404,7 +416,9 @@ export function upsertEnvFile(file, key, value) {
   } catch {
     /* missing → create fresh */
   }
-  const re = new RegExp(`^(?:export\\s+)?${key.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}=`);
+  // Match optional leading whitespace too: bash applies an INDENTED `  KEY=…` line when it sources
+  // the file, so an indented stale duplicate must also be replaced/dropped or it would win (Codex P2).
+  const re = new RegExp(`^\\s*(?:export\\s+)?${key.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}=`);
   const lines = content.length ? content.split("\n") : [];
   // Drop a single trailing empty line (from a prior terminal newline) so we re-add exactly one.
   if (lines.length && lines[lines.length - 1] === "") lines.pop();
@@ -538,6 +552,13 @@ function defaultProbeDaemons(env = process.env) {
 // the honest verify-clean check: it also catches the updater agent (the ONLY daemon a developer/
 // monitor node runs) and any residual launchd plist. Deterministic on the plist files; the process
 // pgrep is best-effort. Honors CATALYST_LAUNCHAGENTS_DIR + CATALYST_ASSUME_NO_DAEMONS test seams.
+// RESIDUAL_AGENT_PATTERN — every catalyst stack PROCESS an uninstall's verify-clean must find if a
+// teardown left it running (the monitor + otel-forward are nohup children; the Alloy log-shipper is
+// deliberately left up by `stop`). CTL-1401 (Codex P2): includes `cloud-sync` now that every install
+// adopts it — a failed `launchctl bootout` can leave the writer running with no plist on disk.
+export const RESIDUAL_AGENT_PATTERN =
+  "broker/index.mjs|execution-core/(daemon|index|updater/updater|cloud-sync)\\.mjs|orch-monitor/server\\.ts|otel-forward/index\\.ts|alloy run .*log-shipper";
+
 function defaultProbeResidualAgents(env = process.env) {
   const laDir = env.CATALYST_LAUNCHAGENTS_DIR || join(homedir(), "Library", "LaunchAgents");
   try {
@@ -551,8 +572,7 @@ function defaultProbeResidualAgents(env = process.env) {
   // log-shipper (matched by its log-shipper config path, NOT any Alloy on the host) is deliberately
   // LEFT running by `catalyst-stack stop`/`uninstall-services` — so if a teardown didn't reap them,
   // an uninstall must not look clean.
-  const pattern = "broker/index.mjs|execution-core/(daemon|index|updater/updater)\\.mjs|orch-monitor/server\\.ts|otel-forward/index\\.ts|alloy run .*log-shipper";
-  const res = spawnSync("pgrep", ["-f", pattern], { encoding: "utf8" });
+  const res = spawnSync("pgrep", ["-f", RESIDUAL_AGENT_PATTERN], { encoding: "utf8" });
   if (res.error) return false; // can't probe processes; the plist check above already ran
   return res.status === 0;
 }
@@ -845,7 +865,7 @@ export async function runInstallLifecycle({ operation, nodeClass, opts = {} }, d
     pluginDirs: readDeepKey(preCfg, "catalyst.orchestration.pluginDirs") ?? null,
   };
 
-  const ctx = { bundlePath: null, healthOk: true, healthRc: null, cleanOk: true, teardownRan: false, doctorOk: true, doctorRc: null, doctorSummary: null, cloudSyncOk: true, envUndos: [] };
+  const ctx = { bundlePath: null, healthOk: true, healthRc: null, cleanOk: true, teardownRan: false, doctorOk: true, doctorRc: null, doctorSummary: null, cloudSyncOk: true, envUndos: [], executorChanged: false };
 
   const runOneStep = async (step) => {
     switch (step.kind) {
@@ -904,6 +924,12 @@ export async function runInstallLifecycle({ operation, nodeClass, opts = {} }, d
           /* file did not exist → undo = delete */
         }
         ctx.envUndos.push({ file: step.file, priorContent });
+        // CTL-1401 (Codex P2): note whether the executor lever actually CHANGED, so an additive install
+        // only restarts a live exec-core when needed (an unchanged re-run must not interrupt work).
+        if (step.key === "CATALYST_EXECUTOR") {
+          const m = (priorContent || "").match(/^\s*(?:export\s+)?CATALYST_EXECUTOR=["']?([^"'\s]+)/m);
+          ctx.executorChanged = (m ? m[1] : null) !== step.value;
+        }
         upsertEnvFile(step.file, step.key, step.value);
         log(`catalyst-install: set ${step.key}=${step.value} in ${step.file}`);
         return;
@@ -955,6 +981,23 @@ export async function runInstallLifecycle({ operation, nodeClass, opts = {} }, d
                 ? "PASS (node-class + agent set + pull-owner correct for class)"
                 : `FAIL [${(summary.fails || []).join(", ") || `rc ${summary.rc}`}] — node provisioned but not class-correct`),
         );
+        return;
+      }
+      case "restart-execcore": {
+        // CTL-1401 (Codex P2): apply an executor change to a LIVE exec-core. Only restarts when the
+        // setenv actually changed the lever (an unchanged re-run must not interrupt running work).
+        // NON-fatal: the lever is already persisted in execution-core.env, so a failed restart just
+        // means the change takes effect on the next start — surface it loudly, never roll back on it.
+        if (!ctx.executorChanged) {
+          log(`catalyst-install: executor unchanged — exec-core restart not needed`);
+          return;
+        }
+        const r = runStep({ argv: step.argv, env: stepEnv });
+        if (r.code !== 0) {
+          log(`catalyst-install: WARN — exec-core restart failed (rc ${r.code}); the new executor is persisted and applies on the next start — restart manually to apply now: ${r.stderr.trim()}`);
+        } else {
+          log(`catalyst-install: restarted exec-core to apply the executor change`);
+        }
         return;
       }
       case "verify-clean": {

--- a/plugins/dev/scripts/execution-core/install-lifecycle.mjs
+++ b/plugins/dev/scripts/execution-core/install-lifecycle.mjs
@@ -114,6 +114,25 @@ export function layer2Path(env = process.env) {
   );
 }
 
+// CTL-1401: valid executor levers (mirrors config.mjs's resolver — bg | sdk | oneshot-legacy). The
+// install's `--executor` flag provisions one of these into execution-core.env so the node's executor
+// is install-set, not dependent on a hand-edit surviving.
+export const VALID_EXECUTORS = Object.freeze(["bg", "sdk", "oneshot-legacy"]);
+
+/**
+ * execCoreEnvPath — the daemon env file the execution-core launcher sources on EVERY start, and from
+ * which CTL-1398's token-arm reads `CATALYST_EXECUTOR`. Resolved the same way the launcher + doctor
+ * resolve it: CATALYST_EXECUTION_CORE_ENV override > XDG/.config/catalyst/execution-core.env. This
+ * file is NOT a Layer-2 key and is never stripped by remove-config, so a value written here survives
+ * a reinstall — write-config (re)asserts it so the executor lever is install-provisioned.
+ */
+export function execCoreEnvPath(env = process.env) {
+  return (
+    env.CATALYST_EXECUTION_CORE_ENV ||
+    join(env.XDG_CONFIG_HOME || join(homedir(), ".config"), "catalyst", "execution-core.env")
+  );
+}
+
 /** readNodeClassRaw — the raw catalyst.node.class string stored in a Layer-2 file (or null). */
 export function readNodeClassRaw(layer2) {
   try {
@@ -248,6 +267,20 @@ export function planPhases({ operation, nodeClass, scripts, opts = {} }) {
       // surfaced by the developer verify-node rubric, not a hard install failure.
       steps.push({ label: "read-replica", kind: "setkey", key: "catalyst.readReplica.baseUrl", value: opts.readReplica });
     }
+    // CTL-1401: when an executor is requested, durably provision the lever into execution-core.env —
+    // the file the launcher sources on every start and whose CATALYST_EXECUTOR value arms CTL-1398's
+    // SDK token path. execution-core.env is never stripped by remove-config, so this both survives a
+    // reinstall AND makes the executor install-set rather than dependent on a fragile hand-edit. No
+    // flag ⇒ no step ⇒ the node's existing executor (or the bg default) is preserved untouched.
+    if (opts.executor) {
+      steps.push({
+        label: "set-executor",
+        kind: "setenv",
+        file: opts.execCoreEnv || execCoreEnvPath(),
+        key: "CATALYST_EXECUTOR",
+        value: opts.executor,
+      });
+    }
     return { phase: "write-config", steps };
   };
 
@@ -260,6 +293,14 @@ export function planPhases({ operation, nodeClass, scripts, opts = {} }) {
           { label: "install-services", kind: "run", argv: [scripts.stack, "install-services"] }
         : // developer/monitor: the 5th updater agent as sole pull owner. NEVER install-services.
           { label: "adopt-updater", kind: "run", argv: [scripts.stack, "adopt-updater"] },
+      // CTL-1401: the per-host cloud-sync replica writer runs on EVERY class (adopt-cloud-sync has no
+      // node-class guard — workers read the replica from the scheduler hot path, dev/monitor via
+      // catalyst-linear). Teardown's uninstall-services boots it OUT, so a reinstall MUST re-adopt it
+      // or the node loses its local Linear replica and the 429 read-block returns. Idempotent (boots
+      // out any existing agent first) and best-effort (optional): macOS-only launchd, and a tokenless
+      // node installs the plist + idles cleanly. Ordered AFTER the class step so install-services has
+      // already laid down the log-shipper that adopt-cloud-sync kickstarts for the 6th Loki stream.
+      { label: "adopt-cloud-sync", kind: "run", argv: [scripts.stack, "adopt-cloud-sync"], optional: true },
     ],
   });
 
@@ -350,6 +391,31 @@ function writeLayer2Atomic(path, obj) {
   const tmp = `${path}.${randomBytes(6).toString("hex")}.tmp`;
   writeFileSync(tmp, `${JSON.stringify(obj, null, 2)}\n`, { mode: 0o600 });
   renameSync(tmp, path);
+}
+
+// upsertEnvFile — CTL-1401. Idempotently set `export KEY=value` in a shell env file (execution-core.env,
+// which the daemon launcher `source`s on every start). Replaces an existing KEY= line (with or without a
+// leading `export`), otherwise appends; preserves all other lines and comments. Atomic (tmp + rename) and
+// 0600 (the file can hold secrets). Matches the `export KEY=val` form the launcher + doctor parser expect.
+export function upsertEnvFile(file, key, value) {
+  let content = "";
+  try {
+    content = readFileSync(file, "utf8");
+  } catch {
+    /* missing → create fresh */
+  }
+  const re = new RegExp(`^(?:export\\s+)?${key.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}=`);
+  const lines = content.length ? content.split("\n") : [];
+  // Drop a single trailing empty line (from a prior terminal newline) so we re-add exactly one.
+  if (lines.length && lines[lines.length - 1] === "") lines.pop();
+  const newLine = `export ${key}=${value}`;
+  const idx = lines.findIndex((l) => re.test(l));
+  if (idx >= 0) lines[idx] = newLine;
+  else lines.push(newLine);
+  mkdirSync(dirname(file), { recursive: true });
+  const tmp = `${file}.${randomBytes(6).toString("hex")}.tmp`;
+  writeFileSync(tmp, `${lines.join("\n")}\n`, { mode: 0o600 });
+  renameSync(tmp, file);
 }
 
 // Reject the JS prototype-chain keys so a dotted path can never walk into Object.prototype
@@ -774,6 +840,13 @@ export async function runInstallLifecycle({ operation, nodeClass, opts = {} }, d
         log(`catalyst-install: set ${step.key} = ${step.value}`);
         return;
       }
+      case "setenv": {
+        // CTL-1401: idempotent upsert into the daemon env file (execution-core.env). Not a Layer-2
+        // key, so it survives remove-config; the launcher sources it on the next start to apply.
+        upsertEnvFile(step.file, step.key, step.value);
+        log(`catalyst-install: set ${step.key}=${step.value} in ${step.file}`);
+        return;
+      }
       case "removeconfig": {
         const cfg = readLayer2(layer2);
         const removed = [];
@@ -1020,7 +1093,7 @@ export async function runInstallLifecycle({ operation, nodeClass, opts = {} }, d
 
 // ── CLI ─────────────────────────────────────────────────────────────────────
 export function parseArgs(argv) {
-  const a = { operation: null, class: null, readReplica: null, force: false, dryRun: false, json: false, help: false, errors: [] };
+  const a = { operation: null, class: null, readReplica: null, executor: null, force: false, dryRun: false, json: false, help: false, errors: [] };
   const rest = [...argv];
   // takeValue — consume the next token as FLAG's value; a missing value (end of args, or the next
   // token is itself a flag) is an error, not a silent null — otherwise `catalyst install --class`
@@ -1057,6 +1130,9 @@ export function parseArgs(argv) {
       case "--read-replica":
         [a.readReplica, i] = takeValue(i, "--read-replica");
         break;
+      case "--executor":
+        [a.executor, i] = takeValue(i, "--executor");
+        break;
       default:
         if (v.startsWith("--class=")) {
           const val = v.slice("--class=".length);
@@ -1066,6 +1142,10 @@ export function parseArgs(argv) {
           const val = v.slice("--read-replica=".length);
           if (val === "") a.errors.push("--read-replica requires a value");
           else a.readReplica = val;
+        } else if (v.startsWith("--executor=")) {
+          const val = v.slice("--executor=".length);
+          if (val === "") a.errors.push("--executor requires a value");
+          else a.executor = val;
         } else if (!v.startsWith("-") && a.operation == null) {
           a.operation = v;
         }
@@ -1080,13 +1160,15 @@ export function usage() {
   return `catalyst-install — provision / tear down this node for its class (CTL-1369).
 
 Usage (normally via the router: 'catalyst install|uninstall|reinstall …'):
-  catalyst-install install   [--class developer|worker|monitor] [--read-replica <url>] [--dry-run]
+  catalyst-install install   [--class developer|worker|monitor] [--read-replica <url>] [--executor bg|sdk] [--dry-run]
   catalyst-install uninstall [--force] [--dry-run]
-  catalyst-install reinstall [--class …] [--read-replica <url>] [--force] [--dry-run]
+  catalyst-install reinstall [--class …] [--read-replica <url>] [--executor bg|sdk] [--force] [--dry-run]
 
 Options:
   --class <c>          target node class (install: declares it; un/reinstall: defaults to current)
   --read-replica <url> developer/monitor: a worker monitor's base URL to read from (e.g. http://host:7400)
+  --executor <e>       durably provision the daemon executor (bg|sdk|oneshot-legacy) into
+                       execution-core.env; omit to leave the node's existing executor untouched
   --force              teardown a live, non-drained node (uninstall/reinstall guard override)
   --dry-run, --print   resolve + print the per-class step plan; run NOTHING (no side effects)
   --json               machine-readable output (with --dry-run, prints the plan as JSON)
@@ -1108,11 +1190,13 @@ function printPlan(plan, { operation, nodeClass }, json, out) {
       const desc =
         s.kind === "setkey"
           ? `set ${s.key}=${s.value}`
-          : s.kind === "removeconfig"
-            ? `remove Layer-2 keys [${s.keys.join(", ")}] (secrets preserved)`
-            : s.kind === "verify-clean"
-              ? "verify no daemons/agents remain"
-              : (s.argv || []).join(" ");
+          : s.kind === "setenv"
+            ? `upsert ${s.key}=${s.value} in ${s.file}`
+            : s.kind === "removeconfig"
+              ? `remove Layer-2 keys [${s.keys.join(", ")}] (secrets preserved)`
+              : s.kind === "verify-clean"
+                ? "verify no daemons/agents remain"
+                : (s.argv || []).join(" ");
       out(`    - ${s.label}${s.optional ? " (optional)" : ""}: ${desc}`);
     }
   }
@@ -1159,7 +1243,15 @@ export async function main(argv, depsOverride) {
   // without this a reinstall WITHOUT --read-replica would silently drop a developer/monitor node's
   // configured endpoint (and then verify-node would FAIL on the missing read source).
   const readReplica = resolveReadReplica({ flag: args.readReplica, env, layer2: deps.layer2 });
-  const opts = { force: args.force, readReplica };
+
+  // CTL-1401: --executor durably provisions the daemon executor lever into execution-core.env. Reject
+  // an unrecognized value (a typo must not silently leave the node on a default executor — the whole
+  // point of the lever is to make the executor explicit + install-set). No flag ⇒ executor untouched.
+  if (args.executor != null && !VALID_EXECUTORS.includes(args.executor)) {
+    errOut(`catalyst-install: --executor must be one of ${VALID_EXECUTORS.join(" | ")} (got '${args.executor}')`);
+    return 2;
+  }
+  const opts = { force: args.force, readReplica, executor: args.executor, execCoreEnv: execCoreEnvPath(env) };
 
   if (args.dryRun) {
     const plan = planPhases({ operation: args.operation, nodeClass, scripts: deps.scripts, opts });

--- a/plugins/dev/scripts/execution-core/install-lifecycle.mjs
+++ b/plugins/dev/scripts/execution-core/install-lifecycle.mjs
@@ -29,7 +29,7 @@
 
 import { spawnSync } from "node:child_process";
 import { randomBytes } from "node:crypto";
-import { readFileSync, writeFileSync, mkdirSync, renameSync, existsSync, readdirSync } from "node:fs";
+import { readFileSync, writeFileSync, mkdirSync, renameSync, existsSync, readdirSync, rmSync } from "node:fs";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { homedir } from "node:os";
@@ -121,16 +121,16 @@ export const VALID_EXECUTORS = Object.freeze(["bg", "sdk", "oneshot-legacy"]);
 
 /**
  * execCoreEnvPath — the daemon env file the execution-core launcher sources on EVERY start, and from
- * which CTL-1398's token-arm reads `CATALYST_EXECUTOR`. Resolved the same way the launcher + doctor
- * resolve it: CATALYST_EXECUTION_CORE_ENV override > XDG/.config/catalyst/execution-core.env. This
- * file is NOT a Layer-2 key and is never stripped by remove-config, so a value written here survives
- * a reinstall — write-config (re)asserts it so the executor lever is install-provisioned.
+ * which CTL-1398's token-arm reads `CATALYST_EXECUTOR`. Resolved EXACTLY the way the launcher
+ * (catalyst-execution-core) and doctor (defaultExecCoreEnvPath) resolve it: the
+ * `CATALYST_EXECUTION_CORE_ENV` override, else `~/.config/catalyst/execution-core.env`. NB: the
+ * launcher does NOT honor `XDG_CONFIG_HOME` for this file — it hard-codes `${HOME}/.config` — so we
+ * must NOT either, or `--executor` would write a lever the restarted daemon never reads (Codex P2).
+ * This file is not a Layer-2 key and is never stripped by remove-config, so a value written here
+ * survives a reinstall — write-config (re)asserts it so the executor lever is install-provisioned.
  */
 export function execCoreEnvPath(env = process.env) {
-  return (
-    env.CATALYST_EXECUTION_CORE_ENV ||
-    join(env.XDG_CONFIG_HOME || join(homedir(), ".config"), "catalyst", "execution-core.env")
-  );
+  return env.CATALYST_EXECUTION_CORE_ENV || join(homedir(), ".config", "catalyst", "execution-core.env");
 }
 
 /** readNodeClassRaw — the raw catalyst.node.class string stored in a Layer-2 file (or null). */
@@ -409,13 +409,48 @@ export function upsertEnvFile(file, key, value) {
   // Drop a single trailing empty line (from a prior terminal newline) so we re-add exactly one.
   if (lines.length && lines[lines.length - 1] === "") lines.pop();
   const newLine = `export ${key}=${value}`;
-  const idx = lines.findIndex((l) => re.test(l));
-  if (idx >= 0) lines[idx] = newLine;
-  else lines.push(newLine);
+  // Replace the FIRST existing assignment in place and DROP every later duplicate. The launcher
+  // `source`s the whole file, so a stale trailing `KEY=…` from a prior hand-edit would otherwise
+  // win — leaving exactly one occurrence is what makes the lever deterministic (Codex P2).
+  const out = [];
+  let placed = false;
+  for (const l of lines) {
+    if (re.test(l)) {
+      if (!placed) {
+        out.push(newLine);
+        placed = true;
+      }
+      // else: a duplicate assignment — drop it
+    } else {
+      out.push(l);
+    }
+  }
+  if (!placed) out.push(newLine);
   mkdirSync(dirname(file), { recursive: true });
   const tmp = `${file}.${randomBytes(6).toString("hex")}.tmp`;
-  writeFileSync(tmp, `${lines.join("\n")}\n`, { mode: 0o600 });
+  writeFileSync(tmp, `${out.join("\n")}\n`, { mode: 0o600 });
   renameSync(tmp, file);
+}
+
+// revertEnvUndos — CTL-1401 rollback support. Restores each env file mutated by a `setenv` step to the
+// pre-image captured before the write: re-writes the prior content, or deletes the file if it did not
+// exist. Best-effort + atomic; applied in REVERSE so the earliest pre-image wins if a file was touched
+// twice. Used only on the rollback path so a failed install/reinstall is a true reversal.
+export function revertEnvUndos(undos, log = () => {}) {
+  for (const { file, priorContent } of [...(undos || [])].reverse()) {
+    try {
+      if (priorContent === null) {
+        rmSync(file, { force: true });
+      } else {
+        mkdirSync(dirname(file), { recursive: true });
+        const tmp = `${file}.${randomBytes(6).toString("hex")}.tmp`;
+        writeFileSync(tmp, priorContent, { mode: 0o600 });
+        renameSync(tmp, file);
+      }
+    } catch (e) {
+      log(`catalyst-install: rollback note — could not revert env file ${file}: ${e?.message ?? e}`);
+    }
+  }
 }
 
 // Reject the JS prototype-chain keys so a dotted path can never walk into Object.prototype
@@ -670,6 +705,10 @@ function isTeardown(operation) {
  */
 export async function runInstallLifecycle({ operation, nodeClass, opts = {} }, deps) {
   const { scripts, env, layer2, runStep, runDoctorPass, emit, nowFn, genTraceId, genSpanId, probeDaemons, probeResidualAgents, probeDrained, bundleHasCapturedAgents, scriptExists, binExists, probeUpdaterAgent, probeWorkerAgents, probeCliInstalled, log, InstallRunCtor } = deps;
+  // CTL-1401: only on macOS is an adopt-cloud-sync non-zero a GENUINE failure (a launchctl error that
+  // may have left the writer torn down) — on a non-launchd OS it is the expected "macOS-only" skip, so
+  // there it stays a benign optional warn. Injectable for tests.
+  const isDarwin = deps.isDarwin ?? process.platform === "darwin";
 
   // Every composed step inherits (a) the RESOLVED class so the bash tools (which re-derive class
   // env-first) cannot diverge from the lifecycle's target — e.g. `install --class developer` on a
@@ -806,7 +845,7 @@ export async function runInstallLifecycle({ operation, nodeClass, opts = {} }, d
     pluginDirs: readDeepKey(preCfg, "catalyst.orchestration.pluginDirs") ?? null,
   };
 
-  const ctx = { bundlePath: null, healthOk: true, healthRc: null, cleanOk: true, teardownRan: false, doctorOk: true, doctorRc: null, doctorSummary: null };
+  const ctx = { bundlePath: null, healthOk: true, healthRc: null, cleanOk: true, teardownRan: false, doctorOk: true, doctorRc: null, doctorSummary: null, cloudSyncOk: true, envUndos: [] };
 
   const runOneStep = async (step) => {
     switch (step.kind) {
@@ -826,7 +865,18 @@ export async function runInstallLifecycle({ operation, nodeClass, opts = {} }, d
         if (step.label === "uninstall-services" && r.code === 0) ctx.teardownRan = true;
         if (r.code !== 0) {
           if (step.optional) {
-            log(`catalyst-install: WARN — optional step '${step.label}' failed (rc ${r.code}), continuing: ${r.stderr.trim()}`);
+            // CTL-1401 (Codex P2): adopt-cloud-sync is optional for PORTABILITY (it hard-fails as
+            // macOS-only off launchd), but on macOS a non-zero is a REAL failure — and cmd_adopt_cloud_sync
+            // boots the existing agent out BEFORE re-bootstrapping, so a mid-failure can leave the node
+            // WITHOUT cloud-sync (the local-replica regression we're fixing). The install profile doctor
+            // doesn't check cloud-sync, so don't silently swallow it: record it so the run reports
+            // completed-but-degraded (exit 1) instead of a clean success. Still non-fatal for rollback.
+            if (step.label === "adopt-cloud-sync" && isDarwin) {
+              ctx.cloudSyncOk = false;
+              log(`catalyst-install: WARN — adopt-cloud-sync FAILED on macOS (rc ${r.code}) — the cloud-sync writer may be DOWN; node's local Linear replica is at risk: ${r.stderr.trim()}`);
+            } else {
+              log(`catalyst-install: WARN — optional step '${step.label}' failed (rc ${r.code}), continuing: ${r.stderr.trim()}`);
+            }
             return;
           }
           throw new Error(`step '${step.label}' failed (rc ${r.code}): ${r.stderr.trim()}`);
@@ -843,6 +893,17 @@ export async function runInstallLifecycle({ operation, nodeClass, opts = {} }, d
       case "setenv": {
         // CTL-1401: idempotent upsert into the daemon env file (execution-core.env). Not a Layer-2
         // key, so it survives remove-config; the launcher sources it on the next start to apply.
+        // Codex P2 — execution-core.env is NOT in the catalyst-backup capture set, so a later-phase
+        // failure would roll back the bundle while leaving this lever flipped. Capture the pre-image
+        // (the file's prior content, or null if it didn't exist) so the rollback handler can revert
+        // this exact mutation and the run is a TRUE reversal.
+        let priorContent = null;
+        try {
+          priorContent = readFileSync(step.file, "utf8");
+        } catch {
+          /* file did not exist → undo = delete */
+        }
+        ctx.envUndos.push({ file: step.file, priorContent });
         upsertEnvFile(step.file, step.key, step.value);
         log(`catalyst-install: set ${step.key}=${step.value} in ${step.file}`);
         return;
@@ -935,10 +996,15 @@ export async function runInstallLifecycle({ operation, nodeClass, opts = {} }, d
     // CTL-1369 PR4: the completed event carries BOTH doctor summaries (before via started, after here)
     // so the install trace shows the node's health change. doctorOk folds into the command exit code
     // (in main), so a node that provisioned but is NOT class-correct (wrong agents/owner) exits non-zero.
-    run.complete({ class: nodeClass, healthOk: ctx.healthOk, doctorOk: ctx.doctorOk, cleanOk: ctx.cleanOk, bundle: ctx.bundlePath, postDoctor: ctx.doctorSummary });
-    return { outcome: "completed", healthOk: ctx.healthOk, healthRc: ctx.healthRc, doctorOk: ctx.doctorOk, doctorRc: ctx.doctorRc, doctorFails: ctx.doctorSummary?.fails ?? null, cleanOk: ctx.cleanOk, bundlePath: ctx.bundlePath, traceId };
+    run.complete({ class: nodeClass, healthOk: ctx.healthOk, doctorOk: ctx.doctorOk, cleanOk: ctx.cleanOk, cloudSyncOk: ctx.cloudSyncOk, bundle: ctx.bundlePath, postDoctor: ctx.doctorSummary });
+    return { outcome: "completed", healthOk: ctx.healthOk, healthRc: ctx.healthRc, doctorOk: ctx.doctorOk, doctorRc: ctx.doctorRc, doctorFails: ctx.doctorSummary?.fails ?? null, cleanOk: ctx.cleanOk, cloudSyncOk: ctx.cloudSyncOk, bundlePath: ctx.bundlePath, traceId };
   } catch (err) {
     let rolledBack = false;
+    // CTL-1401 (Codex P2): revert any execution-core.env mutation made by a `setenv` step (the
+    // `--executor` lever) BEFORE the bundle restore. execution-core.env is outside catalyst-backup's
+    // capture set, so without this a rolled-back run would leave CATALYST_EXECUTOR flipped for the next
+    // daemon start. No-op when no setenv ran.
+    revertEnvUndos(ctx.envUndos, log);
     // disposition: "none" = nothing to undo (failed before/at backup) → benign abort; "ok" = fully
     // reverted; "failed" = restore failed → node in a PARTIAL state. Stamped into the terminal event
     // so a dashboard can tell a safe abort from a node that needs manual recovery (the riskiest case).
@@ -1290,6 +1356,12 @@ export async function main(argv, depsOverride) {
         code = 1;
       } else if (result.doctorOk === false) {
         errOut(`catalyst-install: ${args.operation} completed but the post-install doctor (--profile install) reported the node is NOT class-correct${result.doctorFails?.length ? ` [${result.doctorFails.join(", ")}]` : ""} — verify the launchd agent set + pluginPullOwner for class '${nodeClass}'.`);
+        code = 1;
+      } else if (result.cloudSyncOk === false) {
+        // CTL-1401 (Codex P2): adopt-cloud-sync failed on macOS — the node may have lost its cloud-sync
+        // writer (local Linear replica). The node IS installed, but degraded: exit 1 so this is never
+        // reported as a clean success (the install-profile doctor does not check cloud-sync).
+        errOut(`catalyst-install: ${args.operation} completed but adopt-cloud-sync FAILED — the cloud-sync writer (local Linear replica) may be DOWN; re-run \`catalyst-stack adopt-cloud-sync\` and verify with \`catalyst-doctor\`.`);
         code = 1;
       } else {
         if (!args.json) out(`catalyst-install: ${args.operation} (${nodeClass}) completed.`);

--- a/plugins/dev/scripts/execution-core/install-lifecycle.test.mjs
+++ b/plugins/dev/scripts/execution-core/install-lifecycle.test.mjs
@@ -30,6 +30,7 @@ import {
   upsertEnvFile,
   execCoreEnvPath,
   VALID_EXECUTORS,
+  RESIDUAL_AGENT_PATTERN,
 } from "./install-lifecycle.mjs";
 
 let tmpCounter = 0;
@@ -327,6 +328,25 @@ describe("planPhases — CTL-1401 cloud-sync + executor levers (pure)", () => {
       }
     }
   });
+  test("Codex P2 (re-review): restart-execcore is planned ONLY for `install --class worker --executor` (a reinstall restarts via teardown; no flag ⇒ no restart)", () => {
+    const ia = (operation, opts) => stepLabels(planPhases({ operation, nodeClass: "worker", scripts: SCRIPTS, opts }));
+    expect(ia("install", { executor: "sdk", execCoreEnv: "/tmp/ec.env" })).toContain("restart-execcore");
+    // a reinstall already stops+starts exec-core in its teardown → no extra restart step
+    expect(ia("reinstall", { executor: "sdk", execCoreEnv: "/tmp/ec.env" })).not.toContain("restart-execcore");
+    // no --executor ⇒ nothing to apply ⇒ no restart
+    expect(ia("install", {})).not.toContain("restart-execcore");
+    // developer/monitor don't run exec-core ⇒ no restart step
+    expect(stepLabels(planPhases({ operation: "install", nodeClass: "developer", scripts: SCRIPTS, opts: { executor: "sdk", execCoreEnv: "/tmp/ec.env" } }))).not.toContain("restart-execcore");
+  });
+});
+
+describe("RESIDUAL_AGENT_PATTERN — CTL-1401 (Codex P2: uninstall verify-clean catches a leftover cloud-sync)", () => {
+  test("the residual-process pattern includes cloud-sync (so a failed bootout can't pass verify-clean)", () => {
+    expect(RESIDUAL_AGENT_PATTERN).toContain("cloud-sync");
+    // and still covers the other stack daemons
+    expect(RESIDUAL_AGENT_PATTERN).toContain("broker/index.mjs");
+    expect(RESIDUAL_AGENT_PATTERN).toContain("execution-core/");
+  });
 });
 
 describe("upsertEnvFile — CTL-1401 idempotent env-file upsert", () => {
@@ -359,6 +379,14 @@ describe("upsertEnvFile — CTL-1401 idempotent env-file upsert", () => {
     const out = readFileSync(f, "utf8");
     expect(out.match(/CATALYST_EXECUTOR=/g)).toHaveLength(1);
     expect(out).toBe("export CATALYST_EXECUTOR=sdk\nexport OTHER=1\n");
+  });
+  test("Codex P2 (re-review): drops an INDENTED stale duplicate (bash applies it when sourcing)", () => {
+    const f = tmpCfg();
+    writeFileSync(f, "export CATALYST_EXECUTOR=sdk\n  CATALYST_EXECUTOR=bg\n"); // indented trailing dup
+    upsertEnvFile(f, "CATALYST_EXECUTOR", "sdk");
+    const out = readFileSync(f, "utf8");
+    expect(out.match(/CATALYST_EXECUTOR=/g)).toHaveLength(1);
+    expect(out).toBe("export CATALYST_EXECUTOR=sdk\n");
   });
 });
 

--- a/plugins/dev/scripts/execution-core/install-lifecycle.test.mjs
+++ b/plugins/dev/scripts/execution-core/install-lifecycle.test.mjs
@@ -5,7 +5,7 @@
 // uninstall live-node guard, dry-run side-effect-freedom, and CLI exit codes. Every step shells
 // out through an injected runStep stub, so nothing real is provisioned.
 import { describe, test, expect, afterEach } from "bun:test";
-import { readFileSync, writeFileSync, rmSync } from "node:fs";
+import { readFileSync, writeFileSync, rmSync, existsSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -28,6 +28,7 @@ import {
   usage,
   main,
   upsertEnvFile,
+  execCoreEnvPath,
   VALID_EXECUTORS,
 } from "./install-lifecycle.mjs";
 
@@ -349,6 +350,27 @@ describe("upsertEnvFile — CTL-1401 idempotent env-file upsert", () => {
     expect(readFileSync(f, "utf8")).toBe(once);
     expect(readFileSync(f, "utf8").match(/CATALYST_EXECUTOR=/g)).toHaveLength(1);
   });
+  test("Codex P2: DEDUPES — replaces the first assignment in place and drops trailing duplicates (so no stale later line wins)", () => {
+    const f = tmpCfg();
+    // a hand-edited file with TWO CATALYST_EXECUTOR lines; the launcher sources the whole file so the
+    // trailing `bg` would win — the upsert must leave exactly one (the canonical sdk), no later override.
+    writeFileSync(f, "export CATALYST_EXECUTOR=sdk\nexport OTHER=1\nCATALYST_EXECUTOR=bg\n");
+    upsertEnvFile(f, "CATALYST_EXECUTOR", "sdk");
+    const out = readFileSync(f, "utf8");
+    expect(out.match(/CATALYST_EXECUTOR=/g)).toHaveLength(1);
+    expect(out).toBe("export CATALYST_EXECUTOR=sdk\nexport OTHER=1\n");
+  });
+});
+
+describe("execCoreEnvPath — CTL-1401 (Codex P2: matches the launcher default, ignores XDG)", () => {
+  test("honors CATALYST_EXECUTION_CORE_ENV override; otherwise ~/.config (NOT XDG_CONFIG_HOME)", () => {
+    expect(execCoreEnvPath({ CATALYST_EXECUTION_CORE_ENV: "/custom/ec.env" })).toBe("/custom/ec.env");
+    // the launcher hard-codes ${HOME}/.config — XDG must NOT redirect us, or the daemon reads a
+    // different file than we wrote and never sees the executor.
+    const withXdg = execCoreEnvPath({ XDG_CONFIG_HOME: "/xdg" });
+    expect(withXdg).not.toContain("/xdg");
+    expect(withXdg).toContain("/.config/catalyst/execution-core.env");
+  });
 });
 
 describe("runInstallLifecycle — CTL-1401 executor + cloud-sync provisioning (integration)", () => {
@@ -370,6 +392,39 @@ describe("runInstallLifecycle — CTL-1401 executor + cloud-sync provisioning (i
     expect(readFileSync(ecEnv, "utf8")).toBe(before); // survived byte-for-byte
     // cloud-sync is still re-adopted on a reinstall (teardown removed it)
     expect(bag.calls.some((argv) => argv[0] === "STACK" && argv[1] === "adopt-cloud-sync")).toBe(true);
+  });
+  test("Codex P2: rollback REVERTS the --executor env mutation to its pre-image (true reversal)", async () => {
+    const ecEnv = tmpCfg();
+    writeFileSync(ecEnv, "export CATALYST_EXECUTOR=bg\n"); // node was bg before
+    const before = readFileSync(ecEnv, "utf8");
+    // fail a step AFTER write-config's setenv (install-services) so the run takes the rollback path
+    const bag = withRealRun(makeDeps({ failOn: (argv) => (argv[1] === "install-services" ? 7 : 0), bundleHadAgents: true }));
+    const res = await runInstallLifecycle({ operation: "install", nodeClass: "worker", opts: { executor: "sdk", execCoreEnv: ecEnv } }, bag.deps);
+    // the run did NOT complete (it hit the rollback path — outcome is rolled_back or, if the stubbed
+    // re-bootstrap also fails, failed; either way the env revert runs at the top of the catch)
+    expect(res.outcome).not.toBe("completed");
+    // the executor lever was reverted to bg — NOT left flipped to sdk for the next daemon start
+    expect(readFileSync(ecEnv, "utf8")).toBe(before);
+  });
+  test("Codex P2: rollback DELETES execution-core.env if --executor created it fresh (pre-image was absent)", async () => {
+    const ecEnv = tmpCfg(); // does not exist yet
+    rmSync(ecEnv, { force: true });
+    const bag = withRealRun(makeDeps({ failOn: (argv) => (argv[1] === "install-services" ? 7 : 0), bundleHadAgents: true }));
+    await runInstallLifecycle({ operation: "install", nodeClass: "worker", opts: { executor: "sdk", execCoreEnv: ecEnv } }, bag.deps);
+    expect(existsSync(ecEnv)).toBe(false); // created-then-reverted ⇒ gone
+  });
+  test("Codex P2: a destructive adopt-cloud-sync failure on macOS → completed-but-degraded (cloudSyncOk=false), NOT silent success", async () => {
+    const bag = withRealRun(makeDeps({ failOn: (argv) => (argv[1] === "adopt-cloud-sync" ? 1 : 0) }));
+    bag.deps.isDarwin = true; // pin macOS so the failure is treated as genuine
+    const res = await runInstallLifecycle({ operation: "install", nodeClass: "worker", opts: {} }, bag.deps);
+    expect(res.outcome).toBe("completed"); // the node IS installed…
+    expect(res.cloudSyncOk).toBe(false); // …but degraded — the writer may be down
+  });
+  test("off macOS, an adopt-cloud-sync non-zero stays a benign optional skip (cloudSyncOk=true)", async () => {
+    const bag = withRealRun(makeDeps({ failOn: (argv) => (argv[1] === "adopt-cloud-sync" ? 1 : 0) }));
+    bag.deps.isDarwin = false; // non-launchd OS — adopt-cloud-sync is macOS-only by design
+    const res = await runInstallLifecycle({ operation: "install", nodeClass: "worker", opts: {} }, bag.deps);
+    expect(res.cloudSyncOk).toBe(true);
   });
 });
 
@@ -1009,6 +1064,15 @@ describe("main — CLI exit codes", () => {
     expect(text).toContain("adopt-cloud-sync");
     expect(text).toContain("set-executor");
     expect(text).toContain("CATALYST_EXECUTOR=sdk");
+  });
+  test("CTL-1401 (Codex P2): a destructive adopt-cloud-sync failure → completed but exit 1 (degraded, not silent)", async () => {
+    const bag = withRealRun(makeDeps({ failOn: (argv) => (argv[1] === "adopt-cloud-sync" ? 1 : 0) }));
+    bag.deps.isDarwin = true;
+    const out = [];
+    const errOut = [];
+    const code = await main(["install", "--class", "worker"], { ...bag.deps, out: (m) => out.push(m), errOut: (m) => errOut.push(m) });
+    expect(code).toBe(1);
+    expect(errOut.join("\n")).toContain("adopt-cloud-sync FAILED");
   });
 
   // Execute-path exit codes via full stub deps.

--- a/plugins/dev/scripts/execution-core/install-lifecycle.test.mjs
+++ b/plugins/dev/scripts/execution-core/install-lifecycle.test.mjs
@@ -27,6 +27,8 @@ import {
   parseArgs,
   usage,
   main,
+  upsertEnvFile,
+  VALID_EXECUTORS,
 } from "./install-lifecycle.mjs";
 
 let tmpCounter = 0;
@@ -156,6 +158,15 @@ describe("parseArgs", () => {
     expect(parseArgs(["install", "--class="]).errors).toContain("--class requires a value");
     expect(parseArgs(["install", "--class", "developer"]).errors).toHaveLength(0);
   });
+  test("CTL-1401: --executor parses (space + equals forms); missing value is an error", () => {
+    expect(parseArgs(["install", "--executor", "sdk"]).executor).toBe("sdk");
+    expect(parseArgs(["reinstall", "--executor=bg"]).executor).toBe("bg");
+    expect(parseArgs(["install"]).executor).toBeNull(); // omitted ⇒ null ⇒ untouched
+    expect(parseArgs(["install", "--executor"]).errors).toContain("--executor requires a value");
+    expect(parseArgs(["install", "--executor="]).errors).toContain("--executor requires a value");
+    // the valid set the install accepts (asserted against the exported constant)
+    expect(VALID_EXECUTORS).toEqual(["bg", "sdk", "oneshot-legacy"]);
+  });
 });
 
 // ───────────────────────── resolveRequestedClass ─────────────────────────
@@ -280,6 +291,85 @@ describe("planPhases — per-class correctness (pure)", () => {
     // uninstall ends with verify-clean — no healthcheck phase, no doctor step.
     expect(planPhases({ operation: "uninstall", nodeClass: "worker", scripts: SCRIPTS }).some((p) => p.phase === "healthcheck")).toBe(false);
     expect(stepLabels(planPhases({ operation: "uninstall", nodeClass: "worker", scripts: SCRIPTS }))).not.toContain("doctor");
+  });
+});
+
+// ───────────────────────── CTL-1401: cloud-sync + executor provisioning ─────────────────────────
+describe("planPhases — CTL-1401 cloud-sync + executor levers (pure)", () => {
+  test("adopt-cloud-sync is in install-agents for EVERY class (install + reinstall), ordered AFTER the class step", () => {
+    for (const operation of ["install", "reinstall"]) {
+      for (const nodeClass of ["worker", "developer", "monitor"]) {
+        const ia = planPhases({ operation, nodeClass, scripts: SCRIPTS }).find((p) => p.phase === "install-agents");
+        const labels = ia.steps.map((s) => s.label);
+        expect(labels).toContain("adopt-cloud-sync");
+        // it must come after the per-class agent step so install-services has laid down the log-shipper
+        const classStep = nodeClass === "worker" ? "install-services" : "adopt-updater";
+        expect(labels.indexOf("adopt-cloud-sync")).toBeGreaterThan(labels.indexOf(classStep));
+        const step = ia.steps.find((s) => s.label === "adopt-cloud-sync");
+        expect(step).toMatchObject({ kind: "run", argv: ["STACK", "adopt-cloud-sync"], optional: true });
+      }
+    }
+  });
+  test("set-executor setenv step appears in write-config ONLY when --executor is given", () => {
+    const withExec = planPhases({ operation: "install", nodeClass: "worker", scripts: SCRIPTS, opts: { executor: "sdk", execCoreEnv: "/tmp/ec.env" } }).find((p) => p.phase === "write-config");
+    const setExec = withExec.steps.find((s) => s.label === "set-executor");
+    expect(setExec).toMatchObject({ kind: "setenv", file: "/tmp/ec.env", key: "CATALYST_EXECUTOR", value: "sdk" });
+    // no flag ⇒ no step ⇒ the node's existing executor is left untouched
+    const noExec = planPhases({ operation: "install", nodeClass: "worker", scripts: SCRIPTS }).find((p) => p.phase === "write-config");
+    expect(noExec.steps.some((s) => s.label === "set-executor")).toBe(false);
+  });
+  test("set-executor works for every class + on reinstall (the lever is class-agnostic)", () => {
+    for (const operation of ["install", "reinstall"]) {
+      for (const nodeClass of ["worker", "developer", "monitor"]) {
+        const wc = planPhases({ operation, nodeClass, scripts: SCRIPTS, opts: { executor: "bg", execCoreEnv: "/tmp/ec.env" } }).find((p) => p.phase === "write-config");
+        expect(wc.steps.some((s) => s.label === "set-executor" && s.value === "bg")).toBe(true);
+      }
+    }
+  });
+});
+
+describe("upsertEnvFile — CTL-1401 idempotent env-file upsert", () => {
+  test("creates a fresh file with export KEY=value", () => {
+    const f = tmpCfg();
+    upsertEnvFile(f, "CATALYST_EXECUTOR", "sdk");
+    expect(readFileSync(f, "utf8")).toBe("export CATALYST_EXECUTOR=sdk\n");
+  });
+  test("replaces an existing KEY line (with or without `export`) and preserves all other lines", () => {
+    const f = tmpCfg();
+    writeFileSync(f, "# header\nexport OTEL_EXPORTER_OTLP_ENDPOINT=http://h:4318\nCATALYST_EXECUTOR=bg\nexport CATALYST_LINEAR_REPLICA=on\n");
+    upsertEnvFile(f, "CATALYST_EXECUTOR", "sdk");
+    const out = readFileSync(f, "utf8");
+    expect(out).toBe("# header\nexport OTEL_EXPORTER_OTLP_ENDPOINT=http://h:4318\nexport CATALYST_EXECUTOR=sdk\nexport CATALYST_LINEAR_REPLICA=on\n");
+  });
+  test("is idempotent (re-running yields byte-identical content, single line)", () => {
+    const f = tmpCfg();
+    upsertEnvFile(f, "CATALYST_EXECUTOR", "sdk");
+    const once = readFileSync(f, "utf8");
+    upsertEnvFile(f, "CATALYST_EXECUTOR", "sdk");
+    expect(readFileSync(f, "utf8")).toBe(once);
+    expect(readFileSync(f, "utf8").match(/CATALYST_EXECUTOR=/g)).toHaveLength(1);
+  });
+});
+
+describe("runInstallLifecycle — CTL-1401 executor + cloud-sync provisioning (integration)", () => {
+  test("worker install --executor sdk writes execution-core.env AND adopts cloud-sync", async () => {
+    const ecEnv = tmpCfg(); // empty/absent → upsert creates it fresh
+    const bag = withRealRun(makeDeps());
+    await runInstallLifecycle({ operation: "install", nodeClass: "worker", opts: { executor: "sdk", execCoreEnv: ecEnv } }, bag.deps);
+    // the SDK executor lever is durably provisioned into execution-core.env
+    expect(readFileSync(ecEnv, "utf8")).toContain("export CATALYST_EXECUTOR=sdk");
+    // and the cloud-sync writer was adopted (the regression fix)
+    expect(bag.calls.some((argv) => argv[0] === "STACK" && argv[1] === "adopt-cloud-sync")).toBe(true);
+  });
+  test("a reinstall WITHOUT --executor never touches execution-core.env (preserve, not clobber)", async () => {
+    const ecEnv = tmpCfg();
+    writeFileSync(ecEnv, "export CATALYST_EXECUTOR=sdk\nexport CATALYST_LINEAR_REPLICA=on\n");
+    const before = readFileSync(ecEnv, "utf8");
+    const bag = withRealRun(makeDeps());
+    await runInstallLifecycle({ operation: "reinstall", nodeClass: "worker", opts: { execCoreEnv: ecEnv } }, bag.deps);
+    expect(readFileSync(ecEnv, "utf8")).toBe(before); // survived byte-for-byte
+    // cloud-sync is still re-adopted on a reinstall (teardown removed it)
+    expect(bag.calls.some((argv) => argv[0] === "STACK" && argv[1] === "adopt-cloud-sync")).toBe(true);
   });
 });
 
@@ -897,6 +987,11 @@ describe("main — CLI exit codes", () => {
     const c = capture();
     expect(await main(["install", "--class", "nope"], c.depsOverride)).toBe(2);
   });
+  test("CTL-1401: invalid --executor → exit 2 (a typo must not silently leave the node on a default)", async () => {
+    const c = capture();
+    expect(await main(["install", "--class", "worker", "--executor", "turbo"], c.depsOverride)).toBe(2);
+    expect(c.errOut.join("\n")).toContain("--executor must be one of");
+  });
   test("--dry-run prints the plan and runs nothing → exit 0", async () => {
     const c = capture();
     const code = await main(["install", "--class", "developer", "--dry-run"], c.depsOverride);
@@ -905,6 +1000,15 @@ describe("main — CLI exit codes", () => {
     expect(text).toContain("dry-run");
     expect(text).toContain("adopt-updater");
     expect(text).not.toContain("install-services");
+  });
+  test("CTL-1401: --dry-run renders the set-executor setenv + adopt-cloud-sync steps (value shown, no crash)", async () => {
+    const c = capture();
+    const code = await main(["install", "--class", "worker", "--executor", "sdk", "--dry-run"], c.depsOverride);
+    expect(code).toBe(0);
+    const text = c.out.join("\n");
+    expect(text).toContain("adopt-cloud-sync");
+    expect(text).toContain("set-executor");
+    expect(text).toContain("CATALYST_EXECUTOR=sdk");
   });
 
   // Execute-path exit codes via full stub deps.

--- a/plugins/dev/scripts/execution-core/install-lifecycle.test.mjs
+++ b/plugins/dev/scripts/execution-core/install-lifecycle.test.mjs
@@ -60,6 +60,7 @@ const SCRIPTS = {
   installCli: "INSTALL_CLI",
   stack: "STACK",
   doctor: "DOCTOR", // CTL-1369 PR4: the pre/post-install doctor pass (catalyst-doctor --profile install)
+  execCore: "EXECCORE", // CTL-1401: the exec-core launcher (restart-execcore on a live-worker executor change)
 };
 
 // makeDeps — a fully-stubbed dep set. `failOn` is a predicate (argv|joined → truthy = fail with
@@ -453,6 +454,28 @@ describe("runInstallLifecycle — CTL-1401 executor + cloud-sync provisioning (i
     bag.deps.isDarwin = false; // non-launchd OS — adopt-cloud-sync is macOS-only by design
     const res = await runInstallLifecycle({ operation: "install", nodeClass: "worker", opts: {} }, bag.deps);
     expect(res.cloudSyncOk).toBe(true);
+  });
+  test("Codex P2 (re-review#2): restart fires on the EFFECTIVE (last) executor — a sdk-then-bg file is really bg", async () => {
+    const ecEnv = tmpCfg();
+    writeFileSync(ecEnv, "export CATALYST_EXECUTOR=sdk\nCATALYST_EXECUTOR=bg\n"); // bash last-wins ⇒ effective = bg
+    const bag = withRealRun(makeDeps());
+    await runInstallLifecycle({ operation: "install", nodeClass: "worker", opts: { executor: "sdk", execCoreEnv: ecEnv } }, bag.deps);
+    // effective old = bg, new = sdk → CHANGED → exec-core is restarted to apply it
+    expect(bag.calls.some((a) => a[0] === "EXECCORE" && a[1] === "restart")).toBe(true);
+  });
+  test("Codex P2 (re-review#2): restart is SKIPPED when the effective executor already matches (no needless interrupt)", async () => {
+    const ecEnv = tmpCfg();
+    writeFileSync(ecEnv, "export CATALYST_EXECUTOR=bg\nCATALYST_EXECUTOR=sdk\n"); // effective = sdk
+    const bag = withRealRun(makeDeps());
+    await runInstallLifecycle({ operation: "install", nodeClass: "worker", opts: { executor: "sdk", execCoreEnv: ecEnv } }, bag.deps);
+    expect(bag.calls.some((a) => a[0] === "EXECCORE" && a[1] === "restart")).toBe(false);
+  });
+  test("Codex P2 (re-review#2): rollback re-bootstrap does NOT re-adopt cloud-sync (additive — would leave an agent the pre-run node lacked)", async () => {
+    // hadAgents + !live → the rollback path re-bootstraps the restored class; fail start-stack so it triggers.
+    const bag = withRealRun(makeDeps({ failOn: (argv) => (argv[1] === "start" ? 9 : 0), bundleHadAgents: true, daemonsLive: false }));
+    await runInstallLifecycle({ operation: "install", nodeClass: "worker", opts: {} }, bag.deps);
+    // adopt-cloud-sync ran ONCE in the forward install-agents; the re-bootstrap must skip it (no 2nd call)
+    expect(bag.calls.filter((a) => a[0] === "STACK" && a[1] === "adopt-cloud-sync")).toHaveLength(1);
   });
 });
 


### PR DESCRIPTION
## Why

The **fleet-reinstall-rollout** coordination surfaced that `catalyst install|reinstall` did not provision two now-live workstreams, so a worker reinstall would **regress** them. This is the Stage-0 fix that makes a supervised fleet reinstall non-regressive (and makes install self-sufficient — the "confidence install/doctor set the right variables" goal).

## The two gaps (source-verified against `origin/main`)

**1. cloud-sync (CTL-1394) — a real regression.** `install-agents` ran only `install-services` (worker) / `adopt-updater` (dev); it never called `adopt-cloud-sync`. Teardown's `uninstall-services` boots the cloud-sync agent **out** (`catalyst-stack:1548`). Net: a reinstall removed the local Linear replica writer and never re-added it → the 429 read-block returns.

**2. SDK executor (CTL-1396/1398) — a fresh-install gap.** The launcher's token-arm gates on `CATALYST_EXECUTOR` read from `execution-core.env`, but the install never wrote it. (Note: a hand-set value *does* survive a reinstall — `execution-core.env` is never touched by any lifecycle step — but a **fresh** install defaulted to `bg`, and the lever depended on a fragile hand-edit.)

## Fix

- **`adopt-cloud-sync`** step in `install-agents` on **every class** — idempotent, optional/best-effort (macOS-only launchd; tokenless node installs the plist + idles), ordered **after** the class step so the log-shipper it kickstarts exists.
- **`--executor <bg|sdk|oneshot-legacy>`** flag + a new **`setenv`** step kind that idempotently upserts `export CATALYST_EXECUTOR=…` into `execution-core.env` (atomic 0600, preserves every other line). No flag ⇒ no step ⇒ existing executor untouched. A typo ⇒ exit 2 (a mistyped lever must not silently leave the node on a default).
- Helpers: `execCoreEnvPath()`, `VALID_EXECUTORS`, `upsertEnvFile()`; dry-run renders the new steps.

## Tests (+10, all green)

Per-class `adopt-cloud-sync` (install + reinstall); `set-executor` presence/absence + class-agnostic; `upsertEnvFile` create / replace-preserving-other-lines / idempotent; integration — `--executor sdk` writes the env file **and** adopts cloud-sync, and a reinstall **without** `--executor` leaves `execution-core.env` byte-for-byte; `parseArgs --executor`; invalid `--executor` → exit 2; `--dry-run` renders the steps.

**Validation:** `install-lifecycle.test.mjs` 118 pass · `install-telemetry`+`doctor` 239 pass · import-graph build clean · `catalyst-install.test.sh` bash smoke 17 pass · CLI-reference drift unaffected (tool list unchanged).

## Out of scope (follow-up)

The exactly-one-execution-core healthcheck guard (multi-actor orphan hazard) is a separate robustness ticket; the rollout's "sole exec-core restarter" freeze invariant covers it operationally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)