### PR TITLE
feat(dev): CTL-1397 (1/n) — mandate Linear reads via catalyst-linear (linearis skill + research agents)

### DIFF
--- a/plugins/dev/agents/linear-research.md
+++ b/plugins/dev/agents/linear-research.md
@@ -3,13 +3,14 @@ name: linear-research
 description:
   Research Linear tickets, cycles, projects, and milestones using Linearis CLI. Optimized for LLM
   consumption with minimal token usage (~1k vs 13k for Linear MCP).
-tools: Bash(linearis *), Read, Grep
+tools: Bash(catalyst-linear *), Bash(linearis *), Read, Grep
 model: haiku
 version: 1.0.0
 ---
 
-You are a specialist at researching Linear tickets, cycles, projects, and workflow state using the
-Linearis CLI tool.
+You are a specialist at researching Linear tickets, cycles, projects, and workflow state. Ticket
+reads go through the `catalyst-linear` read CLI; cycles, projects, milestones, and command syntax
+use the Linearis CLI.
 
 ## Core Responsibilities
 
@@ -46,7 +47,7 @@ not guess or improvise commands**.
 
 All linearis output is JSON — use jq for filtering and transformation.
 
-**Read-source mode**: Follow the two-mode Linear read rule in the `catalyst-dev:linearis` skill ("Reading Linear" section) — standard nodes call `linearis` directly; Catalyst Cloud nodes prefer the local replica first and escalate to `linearis` only on concrete evidence of staleness.
+**Read-source mode**: Ticket reads are **mandatory** through `catalyst-linear read|list|search` — **never** bare `linearis issues read|list|search` — per the `catalyst-dev:linearis` skill's mandatory read rule ("Reading Linear" section): `catalyst-linear` owns the two-mode replica logic (replica-first when opted in *and* fresh, automatic fail-open to `linearis` otherwise), so you never decide by node identity. Cycle, project, and milestone reads have no `catalyst-linear` form, so they stay on `linearis` (`linearis cycles|projects|milestones list/read`). Writes always go through `linearis`.
 
 ## Output Format
 

--- a/plugins/dev/skills/describe-pr/SKILL.md
+++ b/plugins/dev/skills/describe-pr/SKILL.md
@@ -237,7 +237,8 @@ in prose. The own ticket's `Fixes https://linear.app/...` line is correct and st
 that link/transition is intended. Sibling neutralization is handled mechanically by the
 guard block appended at write-back time (see below).
 
-Get Linear ticket details using the Linearis CLI (run `linearis issues usage` for read syntax).
+Get Linear ticket details with `catalyst-linear read <ticket>` — reads go through `catalyst-linear`
+(replica-first, never bare `linearis`); see the `linearis` skill's "Reading Linear" section.
 Extract title and description with jq. Use ticket title and description for context.
 
 ### 9. Generate updated title
@@ -245,9 +246,9 @@ Extract title and description with jq. Use ticket title and description for cont
 **Title generation rules:**
 
 ```bash
-# If ticket exists and linearis available, read ticket title (see `linearis issues usage`)
-if [[ "$ticket" ]] && command -v linearis &>/dev/null; then
-    ticket_title=$(linearis issues read "$ticket" | jq -r '.title')
+# If ticket exists, read ticket title via catalyst-linear (reads → catalyst-linear, never bare linearis)
+if [[ "$ticket" ]] && command -v catalyst-linear &>/dev/null; then
+    ticket_title=$(catalyst-linear read "$ticket" | jq -r '.title')
     title="$ticket: ${ticket_title:0:60}"
 elif [[ "$ticket" ]]; then
     # Fallback: generate title from branch name + commits

--- a/plugins/dev/skills/linearis/SKILL.md
+++ b/plugins/dev/skills/linearis/SKILL.md
@@ -57,7 +57,7 @@ the Cloud change-feed — is present:
   specific item *only* when you have concrete evidence the replica read is wrong:
   it contradicts something you just directly observed; the replica freshness/staleness
   signal shows it is behind; or a ticket you expect is missing. When you escalate:
-  - (a) read that item directly with `linearis`, **and**
+  - (a) read that item through `catalyst-linear read <ID>` (it still surfaces staleness via `_meta` and fails open to a direct `linearis` read), **and**
   - (b) **surface the staleness as an issue** — a stale replica read signals a mirror
     gap (e.g. a missed webhook) worth investigating, not just a one-off retry.
 
@@ -68,21 +68,10 @@ through `linearis`. The replica is **read-only** in both modes.
 
 ### How reads resolve
 
-- **Daemon read paths** resolve the mode automatically via the read-source seam
-  (CTL-1390) — callers do not choose.
-- **Agent / skill ad-hoc reads:** use **`catalyst-linear read <ID>`** (CTL-1391). It
-  applies the rule above for you — replica-first when opted in *and* fresh, automatic
-  fail-open to `linearis` otherwise — so the **same command is correct on every node**.
-  Output matches `linearis` JSON plus an additive `_meta` (read source + replica
-  freshness). `list`/`search` are `linearis` passthrough today (a replica-backed list
-  view is a follow-up).
+- **Daemon read paths** resolve the mode automatically via the read-source seam (CTL-1390) — callers do not choose.
+- **Agent / skill / script ad-hoc reads — MANDATORY:** read Linear **only** through **`catalyst-linear read|list|search`** (CTL-1391). **Never call bare `linearis issues read|list|search` to read** — not in agent or skill instructions, not in helper scripts. The same `catalyst-linear` command is correct on every node: replica-first when opted in *and* fresh, automatic fail-open to `linearis` otherwise. Output matches `linearis` JSON plus an additive `_meta` (read source + replica freshness).
 
-> **Mechanism note.** `catalyst-linear` is the executable form of this rule (read-model
-> over the replica first, `linearis` fallback). Plain `linearis issues read|list|search`
-> stays correct everywhere — it is exactly what `catalyst-linear` falls back to — so
-> existing direct calls are fine. Prefer `catalyst-linear` for ad-hoc reads so a node
-> that *has* opted into the replica actually gets replica-first behavior automatically,
-> instead of every caller re-deciding from node identity.
+> **Why mandatory, not "preferred".** Bare `linearis` reads always hit Linear directly and bypass the replica entirely — even on a node that opted in. On the rate-limited worker minis that burns the shared Linear quota and 429s the fleet. `catalyst-linear` is the executable form of the read rule; routing **all** reads through it is what makes "every client reads the replica" actually true. (Writes are unaffected — always `linearis`.)
 
 ## Gotchas & Traps
 
@@ -130,10 +119,16 @@ v2026.4.9.
 
 ## Core Operations
 
+> **Reads run through `catalyst-linear`.** The `linearis issues read|list|search` examples
+> below document the CLI **syntax** — the flags carry over verbatim. Per the mandatory read
+> rule above, **run issue reads via `catalyst-linear read|list|search`** (it shares linearis's
+> flags and fails open to linearis). Stay on bare `linearis` only for reads that need fields
+> the replica omits (relations, estimate) or non-issue domains (`cycles`/`projects`/`milestones`).
+
 ### Read a ticket
 
 ```bash
-linearis issues read ENG-123
+catalyst-linear read ENG-123        # replica-first; fails open to linearis
 ```
 
 ### Search tickets

--- a/plugins/dev/skills/recovery-pass/SKILL.md
+++ b/plugins/dev/skills/recovery-pass/SKILL.md
@@ -317,8 +317,8 @@ sits at `needs-human`/`failed`/`stalled`, or its worker died with the signal fro
   mergeable,mergeStateStatus,reviewDecision,statusCheckRollup`: is there a PR, is
   it green, is it BEHIND/CONFLICTING, is it just sitting there mergeable.
 - **The Linear cache** — the `linear-state=…` / `labels=…` the context script
-  printed for the item (orientation snapshot only; always verify with `linearis
-  issues read <T>` before acting — see the Verify-before-act callout).
+  printed for the item (orientation snapshot only; always verify with `catalyst-linear
+  read <T>` before acting — see the Verify-before-act callout).
 
 **Then diagnose like a senior engineer.** From those: what phase is it in? what
 failed — a conflict, a failed check, a dead worker, an un-merged green PR, a
@@ -403,12 +403,13 @@ If the board scan is all-OK and the flagged YOURS set is empty, you are done —
 > **Verify-before-act (do NOT trust the context-script snapshot).** The
 > `linear-state=…` / `labels=…` values the context script printed are an orientation
 > snapshot that may lag live Linear. Before you act on or escalate ANY ticket, read
-> its LIVE Linear state (`linearis issues read <T>`) — never act on the snapshot
+> its LIVE Linear state (`catalyst-linear read <T>`) — never act on the snapshot
 > alone. A ticket the context shows blocked / needs-human / in a given column may be
-> none of those live. (Reading Linear: on a standard Catalyst node `linearis issues
-> read` is always the direct source; on a Catalyst Cloud node the local replica is
-> authoritative — see the `linearis` skill's "Reading Linear" section for the
-> two-mode rule.)
+> none of those live. (Reading Linear: reads → `catalyst-linear`, never bare
+> linearis — `catalyst-linear` serves the local Catalyst Cloud replica when one is
+> present + fresh + opted-in and falls back to a direct linearis read otherwise, so
+> it is the correct read on both a standard node and a Catalyst Cloud node; see the
+> `linearis` skill's mandatory read rule / "Reading Linear" section.)
 
 ## The 3-tier rope — how much you may do on your own
 

--- a/plugins/dev/skills/ticket-compound/SKILL.md
+++ b/plugins/dev/skills/ticket-compound/SKILL.md
@@ -45,7 +45,7 @@ For `<TICKET>`, collect:
    - `thoughts/shared/friction/<TICKET>.md` — the dedicated per-phase friction log (primary friction source).
 2. **The diff** — `git log --oneline origin/main..HEAD` and `git diff --stat origin/main..HEAD`
    (or the merged SHA from `phase-monitor-merge.json`).
-3. **Ticket** — `linearis issues read <TICKET>` (title, description, final state, estimate). Standard-node direct read; on a Catalyst Cloud node the replica is read first — see the `linearis` skill's "Reading Linear" section.
+3. **Ticket** — `catalyst-linear read <TICKET>` (title, description, final state, estimate) — reads go through `catalyst-linear` (replica-first, never bare `linearis`); see the `linearis` skill's "Reading Linear" section.
 4. **Event trail** (optional) — the ticket's lines in `~/catalyst/events/YYYY-MM.jsonl`.
 
 Capture learnings from **failed/abandoned** tickets too — the dead-ends are high-signal ("what

--- a/plugins/pm/agents/linear-research.md
+++ b/plugins/pm/agents/linear-research.md
@@ -3,7 +3,7 @@ name: linear-research
 description:
   Research Linear tickets, cycles, projects, and milestones using Linearis CLI. Accepts natural
   language requests and returns structured JSON data. Optimized for fast data gathering.
-tools: Bash(linearis *), Bash(jq *), Read
+tools: Bash(catalyst-linear *), Bash(linearis *), Bash(jq *), Read
 model: haiku
 color: cyan
 version: 1.0.0
@@ -13,12 +13,13 @@ version: 1.0.0
 
 ## Mission
 
-Gather data from Linear using the Linearis CLI. This is a **data collection specialist** - not an
-analyzer. Returns structured JSON for other agents to analyze.
+Gather data from Linear: ticket reads through `catalyst-linear`, and cycles/projects/milestones
+through the Linearis CLI. This is a **data collection specialist** - not an analyzer. Returns
+structured JSON for other agents to analyze.
 
 ## Core Responsibilities
 
-1. **Execute Linearis CLI commands** based on natural language requests
+1. **Execute Linear read commands** — `catalyst-linear` for tickets, `linearis` for cycles/projects/milestones — based on natural language requests
 2. **Parse and validate JSON output** from linearis
 3. **Return structured data** to calling commands
 4. **Handle errors gracefully** with clear error messages
@@ -39,9 +40,9 @@ Accept requests like:
 ## Request Processing
 
 1. **Parse the natural language request**
-2. **Determine the appropriate linearis command**:
+2. **Determine the appropriate read command**:
    - Cycle queries → `linearis cycles list/read`
-   - Issue queries → `linearis issues list/search`
+   - Issue queries → `catalyst-linear list/search` (single ticket: `catalyst-linear read <ID>`)
    - Milestone queries → `linearis milestones list/read`
    - Project queries → `linearis projects list`
 
@@ -56,7 +57,7 @@ For exact command syntax, run `linearis <domain> usage` (e.g., `linearis issues 
 `linearis cycles usage`, `linearis milestones usage`). The `/catalyst-dev:linearis` skill is the
 authoritative reference — **do not guess or improvise commands**.
 
-**Read-source mode**: Follow the two-mode Linear read rule in the `catalyst-dev:linearis` skill ("Reading Linear" section) — standard nodes call `linearis` directly; Catalyst Cloud nodes prefer the local replica first and escalate to `linearis` only on concrete evidence of staleness.
+**Read-source mode**: Ticket reads are **mandatory** through `catalyst-linear read|list|search` — **never** bare `linearis issues read|list|search` — per the `catalyst-dev:linearis` skill's mandatory read rule ("Reading Linear" section): `catalyst-linear` owns the two-mode replica logic (replica-first when opted in *and* fresh, automatic fail-open to `linearis` otherwise), so you never decide by node identity. Cycle, project, and milestone reads have no `catalyst-linear` form, so they stay on `linearis` (`linearis cycles|projects|milestones list/read`). Writes always go through `linearis`.
 
 ## Examples
 
@@ -70,8 +71,8 @@ authoritative reference — **do not guess or improvise commands**.
 
 **Request**: "List all issues in Backlog status for team PROJ with no cycle"
 
-**Steps**: Use `linearis issues usage` for list syntax. Filter by team and status with jq. Further
-filter for `cycle == null`.
+**Steps**: Read via `catalyst-linear list` (`linearis issues usage` documents the flags). Filter by
+team and status with jq. Further filter for `cycle == null`.
 
 ### Example 3: Get Milestone Details
 


### PR DESCRIPTION
## What

Hardens the **linearis skill's read rule** from a soft preference ("existing direct calls are fine. Prefer `catalyst-linear`") to a **MANDATE**:

> Agent / skill / script ad-hoc Linear **reads** go through `catalyst-linear read|list|search` (replica-first, fails open to `linearis`). **Never bare `linearis` for reads.** Writes stay on `linearis`.

Updates the `linear-research` agents (dev + pm) and `recovery-pass` / `describe-pr` / `ticket-compound` prose to match, and bridges the skill's CLI-reference examples to the rule.

## Why (urgent)

Bare `linearis` reads bypass the local replica entirely and hit Linear directly — on the rate-limited worker minis that burns the shared quota and 429s the fleet. This is the read-path half of the catalyst-cloud replica cutover (the read-replica guarantee). Landing the **prose half first** (no executed-code changes → no test churn) lets it propagate to the fleet via the updater **before** newly-dispatched ticket agents burn the quota on bare-`linearis` reads.

## Scope / follow-up

This PR is **prose-only** (skill + agent instructions). The **scripted-read swaps** — `phase-triage`/`phase-research` skill bodies (extracted+run by e2e tests) and the `.sh` helpers (`linear-transition`, `compound-log`, `pre-assign-migrations`, `file-feedback`, `gather-linear`) — land in **2/n** together with their e2e/script **test updates** (a `catalyst-linear` stub in `lib/linearis-stub.sh`, etc.) and a re-verified output-parity check (reads that need replica-omitted fields like `.estimate`/relations stay on `linearis`).

## Verification

Local gates green: `agents-md-bridge`, `cli-reference-drift` (119/0), `linear-team-keys-docs` (3/0), `phase-skill-no-linear-prose` (11/0), `audit-references --ci` (rc=0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)