### PR TITLE
fix(dev): CTL-1405 — sdkDispatch passes emitEvent in the wrong param → phase-turns telemetry never reached the event log

### DIFF
--- a/plugins/dev/scripts/execution-core/dispatch.mjs
+++ b/plugins/dev/scripts/execution-core/dispatch.mjs
@@ -222,7 +222,12 @@ export function defaultDispatch(
 // (other callers / unit tests) → sdkRunPhaseAgent keeps its dependency-free stderr
 // default, byte-identical to before.
 export function sdkDispatch(args, { runPhaseAgent = sdkRunPhaseAgent, emitEvent, ...seams } = {}) {
-  const launch = emitEvent ? (a) => runPhaseAgent({ ...a, emitEvent }) : runPhaseAgent;
+  // CTL-1405: sdkRunPhaseAgent reads `emitEvent` from its SECOND (options) param,
+  // NOT the first (input) object — so bind it there. The prior CTL-1396 shape
+  // `runPhaseAgent({ ...a, emitEvent })` spread it into the input object, where
+  // sdkRunPhaseAgent never reads it → it silently kept the stderr defaultEmitEvent,
+  // so phase-turns/overloaded/auth telemetry never reached the JSONL event log.
+  const launch = emitEvent ? (a) => runPhaseAgent(a, { emitEvent }) : runPhaseAgent;
   return defaultDispatch(args, { runPhaseAgent: launch, ...seams });
 }
 

--- a/plugins/dev/scripts/execution-core/dispatch.test.mjs
+++ b/plugins/dev/scripts/execution-core/dispatch.test.mjs
@@ -453,13 +453,15 @@ describe("sdkDispatch (CTL-1365b)", () => {
     expect(r).toEqual({ code: 0, stdout: "ok", stderr: "", signal: null, worktreePath: "/wt/CTL-1" });
   });
 
-  test("CTL-1396 (Codex P2): an injected emitEvent is bound onto the launch verb (phase-turns reaches the unified log, not stderr)", () => {
+  test("CTL-1405: an injected emitEvent reaches sdkRunPhaseAgent's SECOND (options) param (phase-turns reaches the unified log, not stderr)", () => {
     const emitted = [];
     const emitEvent = (name, payload) => emitted.push({ name, payload });
-    // The launch verb stands in for sdkRunPhaseAgent: it emits phase-turns via the
-    // injected emitEvent exactly as the real one does at sdk-run-phase-agent.mjs:942.
-    const spy = (args) => {
-      args.emitEvent("execution-core.sdk.phase-turns", { ticket: args.ticket, num_turns: 5 });
+    // The stub mirrors the REAL sdkRunPhaseAgent signature: (input, opts) where
+    // emitEvent lives in opts (sdk-run-phase-agent.mjs:771). It emits phase-turns via
+    // opts.emitEvent exactly as the real one does at :942. Reading it from `input`
+    // (the CTL-1396 bug) would silently fall back to defaultEmitEvent → stderr.
+    const spy = (input, opts = {}) => {
+      opts.emitEvent("execution-core.sdk.phase-turns", { ticket: input.ticket, num_turns: 5 });
       return { code: 0, stdout: "", stderr: "", signal: null };
     };
     sdkDispatch(
@@ -474,11 +476,24 @@ describe("sdkDispatch (CTL-1365b)", () => {
     expect(emitted).toHaveLength(1);
     expect(emitted[0].name).toBe("execution-core.sdk.phase-turns");
     expect(emitted[0].payload.ticket).toBe("CTL-1");
+    // Guard against the CTL-1396 regression: emitEvent must NOT be smuggled into the
+    // input object (where the real sdkRunPhaseAgent never reads it).
+    const inputSeen = [];
+    sdkDispatch(
+      { orchDir: "/ec", ticket: "CTL-2", phase: "implement" },
+      {
+        resolveProject: () => ({ team: "CTL", repoRoot: "/repo" }),
+        createWorktree: (a) => ({ code: 0, worktreePath: `/wt/${a.ticket}`, stderr: "" }),
+        runPhaseAgent: (input) => { inputSeen.push("emitEvent" in input); return { code: 0, stdout: "", stderr: "", signal: null }; },
+        emitEvent,
+      },
+    );
+    expect(inputSeen[0]).toBe(false); // emitEvent is in opts, never the input object
   });
 
-  test("CTL-1396: without an injected emitEvent the launch verb keeps its own stderr default (non-daemon callers unchanged)", () => {
+  test("CTL-1396: without an injected emitEvent the launch verb gets no opts.emitEvent (non-daemon callers unchanged)", () => {
     let received = "unset";
-    const spy = (args) => { received = args.emitEvent; return { code: 0, stdout: "", stderr: "", signal: null }; };
+    const spy = (_input, opts = {}) => { received = opts.emitEvent; return { code: 0, stdout: "", stderr: "", signal: null }; };
     sdkDispatch(
       { orchDir: "/ec", ticket: "CTL-1", phase: "implement" },
       {


### PR DESCRIPTION
## Bug

CTL-1396 (#2484, merged) wired the daemon-injected unified-event-log `emitEvent` into the SDK dispatch path so `execution-core.sdk.phase-turns` (the turn-cap calibration signal) + `.overloaded`/`.auth.misconfigured` reach the JSONL event log / Loki. **It bound emitEvent to the wrong parameter, so it never took effect.**

`dispatch.mjs` (before):
```js
const launch = emitEvent ? (a) => runPhaseAgent({ ...a, emitEvent }) : runPhaseAgent;
```
`sdkRunPhaseAgent(input, { …, emitEvent = defaultEmitEvent, … })` reads `emitEvent` from its **second** (options) param. Spreading it into the **first** (input) object — which `sdkRunPhaseAgent` destructures as `{orchDir,ticket,phase,…}` and never reads emitEvent from — meant the injected emitEvent was ignored and `defaultEmitEvent` (stderr) was used.

**Caught by Codex** (P2 on #2484, post-merge) and **confirmed live 2026-06-30**: zero real `execution-core.sdk.phase-turns` events in the mini event log despite real SDK dispatches → the turn-cap calibration has had no data.

## Fix
```js
const launch = emitEvent ? (a) => runPhaseAgent(a, { emitEvent }) : runPhaseAgent;
```
The daemon-side binding (`daemon.mjs`) was always correct — only `sdkDispatch`'s forwarding was wrong.

## Test
The CTL-1396 test passed only because its stub read `args.emitEvent` (first-arg), matching the wrong assumption — it validated the wrong contract. The test now:
- mirrors the **real two-param** `sdkRunPhaseAgent` signature (`(input, opts)`, emitEvent in `opts`), and
- adds a guard asserting emitEvent is **not** smuggled into the input object.

Verified: the updated test **FAILS against the old `{ ...a, emitEvent }` shape**, passes against the fix. `dispatch` 74/0, `daemon` 122/0.

Resolves the unresolved Codex P2 on #2484. CTL-1398/executor=sdk validation is unaffected (that was real); this only restores the phase-turns/overloaded/auth telemetry wiring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)