### PR TITLE
feat(dev): CTL-1397 (2/n) — route per-dispatch Linear reads through the replica (catalyst-linear)

### DIFF
--- a/plugins/dev/scripts/__tests__/compound-log.test.sh
+++ b/plugins/dev/scripts/__tests__/compound-log.test.sh
@@ -61,6 +61,20 @@ fi
 exit 0
 EOF
   chmod +x "${bin_dir}/linearis"
+
+  # CTL-1397: compound-log now reads the estimate via `catalyst-linear read`.
+  cat > "${bin_dir}/catalyst-linear" <<'EOF'
+#!/usr/bin/env bash
+if [ "$1" = "read" ]; then
+  if [ -n "${FAKE_LINEARIS_JSON:-}" ]; then
+    echo "$FAKE_LINEARIS_JSON"
+    exit 0
+  fi
+  exit 1
+fi
+exit 0
+EOF
+  chmod +x "${bin_dir}/catalyst-linear"
 }
 
 # Set up an isolated scratch project: thoughts root + fake-bin PATH prefix +

--- a/plugins/dev/scripts/__tests__/lib/linearis-stub.sh
+++ b/plugins/dev/scripts/__tests__/lib/linearis-stub.sh
@@ -86,6 +86,43 @@ esac
 EOF
 	fi
 	chmod +x "${bin_dir}/linearis"
+
+	# CTL-1397: scripts and phase-bodies now read Linear through `catalyst-linear`
+	# (replica-first), so the read path needs a `catalyst-linear` shim alongside
+	# the `linearis` one. `read|list|search` return the same fixture/`{}` the
+	# linearis `issues read` arm does; writes still go through the linearis shim.
+	if [ -n "$read_fixture" ]; then
+		cat >"${bin_dir}/catalyst-linear" <<EOF
+#!/usr/bin/env bash
+LOG="${log_file}"
+printf '%s\n' "catalyst-linear" "\$@" >> "\$LOG"
+case "\$1" in
+  read|list|search)
+    cat "${read_fixture}"
+    ;;
+  *)
+    printf 'catalyst-linear stub: unsupported subcommand: %s\n' "\$1" >&2
+    exit 2
+    ;;
+esac
+EOF
+	else
+		cat >"${bin_dir}/catalyst-linear" <<EOF
+#!/usr/bin/env bash
+LOG="${log_file}"
+printf '%s\n' "catalyst-linear" "\$@" >> "\$LOG"
+case "\$1" in
+  read|list|search)
+    echo '{}'
+    ;;
+  *)
+    printf 'catalyst-linear stub: unsupported subcommand: %s\n' "\$1" >&2
+    exit 2
+    ;;
+esac
+EOF
+	fi
+	chmod +x "${bin_dir}/catalyst-linear"
 }
 
 linearis_stub_install_failing() {

--- a/plugins/dev/scripts/__tests__/linear-transition.test.sh
+++ b/plugins/dev/scripts/__tests__/linear-transition.test.sh
@@ -75,10 +75,10 @@ build_config() {
 EOF
 }
 
-# Install a fake `linearis` on PATH that records calls and returns a canned
-# issue state. Controlled by env vars:
-#   FAKE_LINEARIS_STATE      - state to report for `issues read`
-#   FAKE_LINEARIS_LOG        - path where commands get appended
+# Install a fake `linearis` (writes) + `catalyst-linear` (reads) on PATH that
+# record calls and return a canned issue state. Controlled by env vars:
+#   FAKE_LINEARIS_STATE       - state to report for `catalyst-linear read`
+#   FAKE_LINEARIS_LOG         - path where commands get appended
 #   FAKE_LINEARIS_UPDATE_EXIT - exit code for `issues update` (default 0)
 install_fake_linearis() {
   local bin_dir="$1"
@@ -103,6 +103,23 @@ fi
 exit 0
 EOF
   chmod +x "${bin_dir}/linearis"
+
+  # CTL-1397: linear-transition.sh now reads current state through the replica
+  # wrapper (`catalyst-linear read`) for the idempotency check; writes still go
+  # through `linearis issues update`. This shim mirrors the linearis `read` arm.
+  cat > "${bin_dir}/catalyst-linear" <<'EOF'
+#!/usr/bin/env bash
+echo "catalyst-linear $*" >> "${FAKE_LINEARIS_LOG:-/dev/null}"
+if [ "$1" = "read" ]; then
+  STATE="${FAKE_LINEARIS_STATE:-In Review}"
+  cat <<JSON
+{"identifier":"${2:-TST-1}","title":"Fake","state":{"name":"${STATE}"}}
+JSON
+  exit 0
+fi
+exit 0
+EOF
+  chmod +x "${bin_dir}/catalyst-linear"
 }
 
 # Install a fake `curl` that echoes a canned GraphQL response, so the real
@@ -192,8 +209,8 @@ run "idempotent: skips update when state matches" \
 run "idempotent: no update call recorded when already Done" \
   bash -c "! grep -q 'issues update' '$LOG4'"
 
-run "idempotent: read call IS recorded (check was performed)" \
-  expect_contains "$LOG4" "linearis issues read TST-4"
+run "idempotent: read call IS recorded (check was performed via replica)" \
+  expect_contains "$LOG4" "catalyst-linear read TST-4"
 
 # ─── Test 5: --force bypasses idempotency check ────────────────────────────
 WORK5="${SCRATCH}/t5"

--- a/plugins/dev/scripts/__tests__/phase-triage-e2e.test.sh
+++ b/plugins/dev/scripts/__tests__/phase-triage-e2e.test.sh
@@ -361,6 +361,23 @@ case "\$1" in
 esac
 EOF
 chmod +x "$DISCUSS_429_DIR/bin/linearis"
+# CTL-1397: triage reads via `catalyst-linear` now — stub it (read → fixture) so
+# the body's ticket read succeeds and reaches the best-effort comment-post path
+# this case exercises (without it, the body falls through to the real binary on
+# PATH and the test is non-hermetic / red in CI).
+cat >"$DISCUSS_429_DIR/bin/catalyst-linear" <<EOF
+#!/usr/bin/env bash
+case "\$1" in
+  read)
+    cat "$FIXTURE_429"
+    ;;
+  *)
+    echo "catalyst-linear stub: unsupported subcommand: \$1" >&2
+    exit 2
+    ;;
+esac
+EOF
+chmod +x "$DISCUSS_429_DIR/bin/catalyst-linear"
 linear_comment_post_stub_install_failing "$DISCUSS_429_DIR/bin" "$DISCUSS_429_DIR/comment-post-calls.log"
 
 PATH="$DISCUSS_429_DIR/bin:$PATH" \

--- a/plugins/dev/scripts/__tests__/phase-triage-e2e.test.sh
+++ b/plugins/dev/scripts/__tests__/phase-triage-e2e.test.sh
@@ -295,12 +295,14 @@ fi
 
 FAIL_DIR="$TMPROOT/lin-fail"
 mkdir -p "$FAIL_DIR/bin"
-cat >"$FAIL_DIR/bin/linearis" <<'EOF'
+# CTL-1397: the triage body now reads via `catalyst-linear read`, so the
+# read-failure case stubs a failing catalyst-linear (not linearis).
+cat >"$FAIL_DIR/bin/catalyst-linear" <<'EOF'
 #!/usr/bin/env bash
-echo "linearis stub: simulated failure" >&2
+echo "catalyst-linear stub: simulated read failure" >&2
 exit 1
 EOF
-chmod +x "$FAIL_DIR/bin/linearis"
+chmod +x "$FAIL_DIR/bin/catalyst-linear"
 
 PATH="$FAIL_DIR/bin:$PATH" \
 	TICKET=CTL-9001 \

--- a/plugins/dev/scripts/compound-log.sh
+++ b/plugins/dev/scripts/compound-log.sh
@@ -98,7 +98,8 @@ probe_pr() {
 
 probe_linear_estimate() {
   local ticket="$1" json
-  json=$(linearis issues read "$ticket" 2>/dev/null) || return 1
+  # CTL-1397: read the estimate through the replica wrapper, never bare linearis.
+  json=$(catalyst-linear read "$ticket" 2>/dev/null) || return 1
   [ -z "$json" ] && return 1
   echo "$json" | jq -r '.estimate // empty'
 }

--- a/plugins/dev/scripts/file-feedback.sh
+++ b/plugins/dev/scripts/file-feedback.sh
@@ -212,7 +212,9 @@ try_linearis() {
 
   # Fetch URL if the create response didn't include one.
   if [ -z "$linear_url" ]; then
-    linear_url=$(linearis issues read "$identifier" --output json 2>/dev/null \
+    # CTL-1397: read through the replica wrapper (catalyst-linear is JSON by
+    # default; dropping --output json avoids the flag parity-bypass to linearis).
+    linear_url=$(catalyst-linear read "$identifier" 2>/dev/null \
       | jq -r '.url // empty' 2>/dev/null || echo "")
   fi
 

--- a/plugins/dev/scripts/linear-transition.sh
+++ b/plugins/dev/scripts/linear-transition.sh
@@ -185,7 +185,13 @@ fi
 # ─── Idempotency check (read current state first) ──────────────────────────
 CURRENT_STATE=""
 if [ "$FORCE" -ne 1 ] && command -v jq >/dev/null 2>&1; then
-  READ_JSON=$(linearis issues read "$TICKET" 2>/dev/null || echo "")
+  # CTL-1397: read current state through the replica wrapper (`catalyst-linear
+  # read`), never bare `linearis` — keeps this per-transition idempotency read
+  # off the shared Linear quota. `catalyst-linear` is replica-first and fails
+  # open to linearis internally. If it is not installed at all the read returns
+  # empty, the check is skipped, and the transition proceeds (a same-state write
+  # is a Linear no-op), so the swap degrades safely.
+  READ_JSON=$(catalyst-linear read "$TICKET" 2>/dev/null || echo "")
   if [ -n "$READ_JSON" ]; then
     CURRENT_STATE=$(echo "$READ_JSON" | jq -r '.state.name // empty' 2>/dev/null || echo "")
   fi

--- a/plugins/dev/scripts/pre-assign-migrations.sh
+++ b/plugins/dev/scripts/pre-assign-migrations.sh
@@ -59,14 +59,15 @@ fi
 
 # Build ticket JSON if not supplied.
 if [ -z "$TICKETS_JSON" ]; then
-  if ! command -v linearis >/dev/null 2>&1; then
-    echo "error: --tickets requires linearis CLI; pass --tickets-json instead" >&2
+  # CTL-1397: ticket reads go through the replica wrapper (catalyst-linear).
+  if ! command -v catalyst-linear >/dev/null 2>&1; then
+    echo "error: --tickets requires the catalyst-linear CLI; pass --tickets-json instead" >&2
     exit 1
   fi
   TICKETS_JSON="["
   FIRST=1
   for T in $TICKETS; do
-    RAW=$(linearis issues read "$T" 2>/dev/null || echo '{}')
+    RAW=$(catalyst-linear read "$T" 2>/dev/null || echo '{}')
     OBJ=$(echo "$RAW" | jq -c --arg id "$T" '{
       id: $id,
       title: (.title // ""),

--- a/plugins/dev/skills/phase-triage/SKILL.md
+++ b/plugins/dev/skills/phase-triage/SKILL.md
@@ -92,19 +92,20 @@ WORKER_DIR="${WORKER_DIR:-${ORCH_DIR:+${ORCH_DIR}/workers/${TICKET}}}"
 WORKER_DIR="${WORKER_DIR:-$(pwd)}"
 mkdir -p "$WORKER_DIR"
 
-# 1. Read ticket via linearis (test stubs override $PATH).
+# 1. Read ticket via the replica wrapper (catalyst-linear; CTL-1397 — never bare
+#    linearis for reads). Test stubs override $PATH.
 TICKET_JSON_FILE="$(mktemp)"
 trap 'rm -f "$TICKET_JSON_FILE"' EXIT
 
-if ! linearis issues read "$TICKET" > "$TICKET_JSON_FILE" 2>/dev/null; then
+if ! catalyst-linear read "$TICKET" > "$TICKET_JSON_FILE" 2>/dev/null; then
   emit_phase_complete --phase triage --ticket "$TICKET" --status failed \
-    --reason "linearis issues read failed"
+    --reason "catalyst-linear read failed"
   exit 1
 fi
 
 if ! jq -e . "$TICKET_JSON_FILE" >/dev/null 2>&1; then
   emit_phase_complete --phase triage --ticket "$TICKET" --status failed \
-    --reason "linearis returned non-JSON output"
+    --reason "catalyst-linear returned non-JSON output"
   exit 1
 fi
 


### PR DESCRIPTION
## What

Swap the **per-dispatch executable `linearis issues read` callsites** to `catalyst-linear read` (replica-first) so dispatched phase-agents stop burning the shared Linear quota on reads. This is **2/n** of CTL-1397 — the runtime/scripted half. 1/n (the prose **mandate** in the `linearis` skill + research agents) merged in #2496.

## Why (unstick the 429s)

The fleet was hitting Linear rate-limits. The replica is healthy and opted-in on the workers (mini/mini-2: `CATALYST_LINEAR_REPLICA=on`, ~90s-fresh), so the burn was the read sites that still called **bare `linearis`** on every dispatch. The dominant one is `linear-transition.sh`, which reads current state on **every one of the ~10 phase transitions per ticket**.

## Swaps (reads → `catalyst-linear read`; writes unchanged)

| Site | Frequency |
|---|---|
| `linear-transition.sh` idempotency read | per phase transition (~10×/ticket) |
| `phase-triage` body ticket read | per ticket (first read of every lifecycle) |
| `compound-log.sh` estimate probe | per merge |
| `pre-assign-migrations.sh` `--tickets` read (guard now checks `catalyst-linear`) | infrequent |
| `file-feedback.sh` URL fetch (dropped `--output json`) | per feedback |

`catalyst-linear` is replica-first and fails open to `linearis` internally; where it isn't installed the reads degrade safely (idempotency check skipped → a same-state write is a Linear no-op).

## Intentionally left on `linearis`

- **Writes** — always `linearis`.
- **`phase-research --with-attachments`** — attachments aren't mirrored in the replica (a genuine live read).
- **`list`/`search`** — `catalyst-linear` routes these as `linearis` passthrough today (no replica relief yet), so they're not the quota win; covered by the prose mandate.
- `file-feedback`'s `--output json` was dropped because **any flag triggers `catalyst-linear`'s parity bypass** back to `linearis` (it's JSON by default).

## Tests

- Shared `lib/linearis-stub.sh` `linearis_stub_install` gains a `catalyst-linear read|list|search` shim (returns the same fixture/`{}`); writes still log via the `linearis` shim.
- `linear-transition.test.sh` `install_fake_linearis` installs a `catalyst-linear` read shim; the idempotency assertion checks `catalyst-linear read`.
- `phase-triage-e2e` read-failure case stubs a failing `catalyst-linear`; `compound-log` fake adds a `catalyst-linear` arm.
- Green: `linear-transition` 63/0 · `phase-triage-e2e` 40/0 · `compound-log` 19/0 · `pre-assign-migrations` 14/0 · `linearis-stub` 13/0 · full `phase-*-e2e` suite (research/plan/implement/verify/review/teardown) green. (`phase-monitor-deploy-e2e`'s 6 failures are pre-existing on `main` — unrelated.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)