### PR TITLE
feat(dev): CTL-1397 — replica-backed board-list discovery (board-freeze unstick)

### DIFF
--- a/plugins/dev/scripts/execution-core/daemon.mjs
+++ b/plugins/dev/scripts/execution-core/daemon.mjs
@@ -708,7 +708,15 @@ export function startDaemon({
         handleCommentWake(parsed, { orchDir, dispatch: commentWakeDispatch, removeLabel: defaultRemoveLabel, botUserId: linearBotUserIds, clearStall: defaultClearStall(orchDir, linearWrite) }); // CTL-549 + CTL-756 + CTL-1365b: re-dispatch parked tickets through the resolved executor; botUserId suppresses self-echo; CTL-1067: J3 stall-clear
       },
       onUpdate: createUpdateInboxWriter(orchDir, linearBotUserIds), // CTL-749
-    }); // CTL-535 + CTL-565 + CTL-634 + CTL-549 + CTL-749 + CTL-716 + CTL-781
+      // CTL-1397: inject the SAME mode-gated replica reader the scheduler uses
+      // (constructed above, bun-only) so the monitor's board-list discovery
+      // reconcile reads the local Catalyst-Cloud replica instead of `linearis
+      // issues list` — immune to the shared Linear quota + the CTL-679 breaker.
+      // undefined when the flag is off → the monitor falls to the linearis path.
+      // Injecting here (not importing in monitor.mjs) keeps the Node broker's
+      // monitor/recovery import path free of the bun:sqlite static import.
+      eligibleReplica: replicaReader,
+    }); // CTL-535 + CTL-565 + CTL-634 + CTL-549 + CTL-749 + CTL-716 + CTL-781 + CTL-1397
     // CTL-558: the scheduler writes Linear status via its default `writeStatus`
     // (linear-write.mjs) on every committed phase transition — no daemon wiring
     // needed; production uses the real module, tests inject fakes.

--- a/plugins/dev/scripts/execution-core/linear-query.mjs
+++ b/plugins/dev/scripts/execution-core/linear-query.mjs
@@ -894,7 +894,56 @@ export function fetchTicketsDelegateBatch(team, identifiers, { exec = defaultDel
 // batch enrichment. Wrapped in try/catch so a delegate hiccup never blocks
 // the state/priority/relations refresh. An absent key (batch miss) leaves
 // the ticket's delegate field unset; `?? null` in contentKey collapses it.
-export function runEligibleQuery(query, { exec = defaultExec, delegateExec = defaultDelegateBatchExec } = {}) {
+// CTL-1397: `replica` (createReplicaReader, with an eligible() method) is the
+// board-list discovery accelerator. When present and it RETURNS { nodes } (a
+// valid answer — even { nodes: [] }), the query is served from the local
+// Catalyst-Cloud SQLite replica WITHOUT shelling out to `linearis issues list`,
+// so per-tick discovery is immune to the shared Linear quota + the CTL-679
+// circuit breaker that froze the fleet board. FAIL-OPEN: the tier can only
+// ACCELERATE — undefined / any throw falls through to the UNCHANGED linearis
+// path. `onSource("replica"|"linearis", count)` is the OTEL/Loki verification
+// marker (the daemon logs eligible_source so a query can confirm WHICH source
+// served). The replica already populates delegate, so a replica HIT skips the
+// GraphQL delegate batch.
+export function runEligibleQuery(
+  query,
+  { exec = defaultExec, delegateExec = defaultDelegateBatchExec, replica, onSource } = {}
+) {
+  // CTL-1397: replica-backed board-list tier. Fail-open: a throw out of
+  // eligible() is swallowed → local undefined → fall through to linearis.
+  if (replica?.eligible) {
+    let local;
+    try {
+      local = replica.eligible(query);
+    } catch {
+      local = undefined; // any replica failure → fall through to linearis
+    }
+    if (local && Array.isArray(local.nodes)) {
+      let tickets = local.nodes.map(normalizeTicket);
+      // Apply the SAME priority floor the linearis path applies below.
+      if (query.priority != null) {
+        tickets = tickets.filter((t) => t.priority >= 1 && t.priority <= query.priority);
+      }
+      // CTL-1397 (P1 fix) — DISTRUST a replica-empty. Serve from the replica ONLY
+      // when it yields a NON-EMPTY result. A confident "the board is empty" verdict
+      // can zero a team's dispatch set fleet-wide, and a feed-hole (CTL-139
+      // replica-hole: cursor present but a team's rows dropped) presents exactly as
+      // a replica-empty — so an empty result FALLS THROUGH to linearis, the source
+      // of truth for "is this board really empty". If the breaker is open during a
+      // crunch, that linearis call throws → reconcileProject's catch preserves the
+      // prior eligible set (correct — never zeroes). The OLD reasoning ("fresh-empty
+      // {nodes:[]} is a real answer — return without touching linearis") is REVERSED
+      // by the P1 review: only a non-empty replica result is trusted locally.
+      if (tickets.length > 0) {
+        // The replica already populated delegate (no GraphQL batch needed).
+        onSource?.("replica", tickets.length);
+        return tickets;
+      }
+      // Replica-empty (or filtered-to-empty) → fall through to the linearis
+      // confirmation below (which reports onSource("linearis") itself).
+    }
+    // MISS (undefined) / replica-empty → fall through to the UNCHANGED linearis path below.
+  }
   // CTL-1364 regression fix: the eligible-list poll MUST stay UNCAPPED. The
   // CTL-1364 default floor is for the hot per-signal terminal reads only; a
   // blanket cap here would SIGKILL a slow-but-VALID 200-ticket page, open the
@@ -934,5 +983,8 @@ export function runEligibleQuery(query, { exec = defaultExec, delegateExec = def
       /* best-effort: a delegate hiccup never blocks the state/priority/relations refresh */
     }
   }
+  // CTL-1397: mark the source (linearis) for the same verification seam as the
+  // replica HIT above, so the daemon can log eligible_source for both paths.
+  onSource?.("linearis", tickets.length);
   return tickets;
 }

--- a/plugins/dev/scripts/execution-core/linear-query.test.mjs
+++ b/plugins/dev/scripts/execution-core/linear-query.test.mjs
@@ -215,6 +215,182 @@ describe("runEligibleQuery", () => {
   });
 });
 
+// CTL-1397 — the replica-backed board-list tier. When a `replica` with an
+// eligible() method is injected and it RETURNS { nodes } (a valid answer), the
+// query is served from the local Catalyst-Cloud SQLite replica WITHOUT shelling
+// out to `linearis issues list` — the durable fix for the fleet board-freeze
+// (the linearis discovery query burns the shared quota + trips the CTL-679
+// breaker). The linearis path stays UNCHANGED as the fall-through when the
+// replica does not serve (undefined). `onSource("replica"|"linearis", n)` is the
+// OTEL/Loki verification marker.
+describe("runEligibleQuery — replica tier (CTL-1397)", () => {
+  const query = { team: "CTL", status: "Todo", project: null, label: null, priority: null };
+
+  // A replica stub whose eligible() returns a canned linearis-list-shaped result.
+  function replicaReturning(nodes) {
+    const calls = [];
+    return {
+      calls,
+      eligible: (q) => {
+        calls.push(q);
+        return { nodes };
+      },
+    };
+  }
+
+  // An exec that fails the test if it is ever called — proves the replica path
+  // does NOT shell out to linearis.
+  function execMustNotRun() {
+    const fn = () => {
+      throw new Error("linearis exec must NOT run on a replica HIT");
+    };
+    return fn;
+  }
+
+  test("HIT: serves from the replica, never calls exec, normalizes + records onSource('replica')", () => {
+    const replica = replicaReturning([
+      {
+        identifier: "CTL-100",
+        title: "Repoint board-list",
+        state: "Todo",
+        priority: 2,
+        estimate: 3,
+        project: "Harden the core",
+        updatedAt: "2026-06-01T00:00:00Z",
+        createdAt: "2026-05-01T00:00:00Z",
+        parent: "CTL-1",
+        relations: { nodes: [] },
+        inverseRelations: { nodes: [] },
+        delegate: { id: "del-1", name: "Bot" },
+      },
+    ]);
+    const sources = [];
+    const tickets = runEligibleQuery(query, {
+      exec: execMustNotRun(),
+      replica,
+      onSource: (source, count) => sources.push([source, count]),
+    });
+    expect(tickets).toHaveLength(1);
+    expect(tickets[0]).toMatchObject({
+      identifier: "CTL-100",
+      state: "Todo",
+      priority: 2,
+      estimate: 3,
+      project: "Harden the core",
+      parent: "CTL-1",
+      delegate: "del-1", // normalizeTicket flattens delegate.id
+    });
+    expect(replica.calls).toEqual([query]); // eligible() received the query
+    expect(sources).toEqual([["replica", 1]]);
+  });
+
+  test("HIT applies the priority floor (same filter as the linearis path)", () => {
+    const replica = replicaReturning([
+      { identifier: "CTL-1", state: "Todo", priority: 1 },
+      { identifier: "CTL-2", state: "Todo", priority: 2 },
+      { identifier: "CTL-3", state: "Todo", priority: 3 },
+      { identifier: "CTL-0", state: "Todo", priority: 0 },
+    ]);
+    const tickets = runEligibleQuery({ ...query, priority: 2 }, {
+      exec: execMustNotRun(),
+      replica,
+    });
+    expect(tickets.map((t) => t.identifier).sort()).toEqual(["CTL-1", "CTL-2"]);
+  });
+
+  // CTL-1397 (P1 fix) — a replica-EMPTY is NOT trusted. A confident "the board
+  // is empty" verdict can zero a team's dispatch set fleet-wide; a feed-hole
+  // (CTL-139 replica-hole: cursor present but a team's rows dropped) presents as
+  // a replica-empty. So an empty replica result FALLS THROUGH to linearis (the
+  // source of truth for "is this board really empty") — only a NON-EMPTY replica
+  // result is served locally.
+  test("replica-EMPTY ({ nodes: [] }) FALLS THROUGH to linearis (confirmation), records onSource('linearis')", () => {
+    const replica = replicaReturning([]);
+    const exec = fakeExec({
+      // The confirmation: linearis says the board is NOT actually empty.
+      stdout: ticketsJson([{ identifier: "CTL-9", state: { name: "Todo" }, priority: 2 }]),
+    });
+    const sources = [];
+    const tickets = runEligibleQuery(query, {
+      exec,
+      replica,
+      onSource: (source, count) => sources.push([source, count]),
+    });
+    expect(exec.calls).toHaveLength(1); // linearis WAS called to confirm
+    // The linearis result (not the replica-empty) is what served.
+    expect(tickets.map((t) => t.identifier)).toEqual(["CTL-9"]);
+    expect(sources).toEqual([["linearis", 1]]);
+  });
+
+  test("replica filters to EMPTY via the priority floor → also falls through to linearis", () => {
+    // Replica returns rows, but the priority floor drops them all → empty result.
+    const replica = replicaReturning([
+      { identifier: "CTL-3", state: "Todo", priority: 3 },
+      { identifier: "CTL-4", state: "Todo", priority: 4 },
+    ]);
+    const exec = fakeExec({
+      stdout: ticketsJson([{ identifier: "CTL-2", state: { name: "Todo" }, priority: 2 }]),
+    });
+    const tickets = runEligibleQuery({ ...query, priority: 2 }, { exec, replica });
+    expect(exec.calls).toHaveLength(1); // empty-after-filter → linearis confirms
+    expect(tickets.map((t) => t.identifier)).toEqual(["CTL-2"]);
+  });
+
+  test("replica-EMPTY AND linearis throws (circuit open) → the throw PROPAGATES (caller preserves prior set)", () => {
+    const replica = replicaReturning([]);
+    // linearis exits non-zero (e.g. breaker open / auth failure) — runEligibleQuery
+    // throws, exactly as the linearis-only path does today. reconcileProject's
+    // catch then PRESERVES the prior eligible set (never zeroes the board).
+    const exec = fakeExec({ code: 1, stderr: "linearis: circuit open" });
+    expect(() => runEligibleQuery(query, { exec, replica })).toThrow(/exit 1/);
+  });
+
+  test("MISS (eligible() → undefined): falls through to the linearis exec, records onSource('linearis')", () => {
+    const replica = { eligible: () => undefined };
+    const exec = fakeExec({
+      stdout: ticketsJson([{ identifier: "CTL-9", state: { name: "Todo" }, priority: 2 }]),
+    });
+    const sources = [];
+    const tickets = runEligibleQuery(query, {
+      exec,
+      replica,
+      onSource: (source, count) => sources.push([source, count]),
+    });
+    expect(exec.calls).toHaveLength(1); // linearis WAS called
+    expect(exec.calls[0].cmd).toBe("linearis");
+    expect(tickets.map((t) => t.identifier)).toEqual(["CTL-9"]);
+    expect(sources).toEqual([["linearis", 1]]);
+  });
+
+  test("a replica whose eligible() THROWS falls through to linearis (fail-open)", () => {
+    const replica = {
+      eligible: () => {
+        throw new Error("replica blew up");
+      },
+    };
+    const exec = fakeExec({
+      stdout: ticketsJson([{ identifier: "CTL-9", state: { name: "Todo" } }]),
+    });
+    const tickets = runEligibleQuery(query, { exec, replica });
+    expect(exec.calls).toHaveLength(1);
+    expect(tickets.map((t) => t.identifier)).toEqual(["CTL-9"]);
+  });
+
+  test("no replica injected: behaves exactly like today (linearis path), onSource('linearis') still fires", () => {
+    const exec = fakeExec({
+      stdout: ticketsJson([{ identifier: "CTL-9", state: { name: "Todo" } }]),
+    });
+    const sources = [];
+    const tickets = runEligibleQuery(query, {
+      exec,
+      onSource: (source, count) => sources.push([source, count]),
+    });
+    expect(exec.calls).toHaveLength(1);
+    expect(tickets.map((t) => t.identifier)).toEqual(["CTL-9"]);
+    expect(sources).toEqual([["linearis", 1]]);
+  });
+});
+
 // CTL-565 D5 — fetchTicketState wraps `linearis issues read <id>` to hydrate
 // an out-of-set blocker's live Linear state. linearis emits JSON by default
 // (its header: "CLI for Linear.app with JSON output") — no --json flag exists.

--- a/plugins/dev/scripts/execution-core/monitor.mjs
+++ b/plugins/dev/scripts/execution-core/monitor.mjs
@@ -37,7 +37,9 @@ import {
   getClusterHosts, // CTL-862
   hostMembershipWarning, // CTL-1057
   isDraining as isDrainingDefault, // CTL-1095: drain gate
+  readLinearReplica, // CTL-1397: replica-backed board-list discovery (mode gate)
 } from "./config.mjs";
+import { createReplicaReader } from "./replica-read.mjs"; // CTL-1397
 import { ownedBy } from "./hrw.mjs"; // CTL-862: HRW ownership filter
 import { claimDispatchSync } from "./cluster-claim-sync.mjs"; // CTL-862: cross-host claim soft-CAS
 import { listProjects, getProjectConfig, resolveEligibleQuery } from "./registry.mjs";
@@ -250,6 +252,30 @@ export function handleCommentCreatedEvent(event, { onComment } = {}) {
 
 // --- Reconcile -----------------------------------------------------------
 
+// CTL-1397: the replica-backed board-list discovery reader, mode-gated EXACTLY
+// like the daemon's per-signal replica tier (daemon.mjs:681 —
+// readLinearReplica().mode === "on" ? createReplicaReader() : null). Lazily
+// resolved ONCE: `undefined` = not-yet-resolved, `null` = resolved-off (flag off
+// or construction failed). When off the reconcile path never touches the replica,
+// so behavior is byte-identical to pre-CTL-1397. Fail-open: a construction throw
+// resolves to null → linearis path.
+let _eligibleReplica; // undefined = not yet resolved
+function eligibleReplica() {
+  if (_eligibleReplica !== undefined) return _eligibleReplica;
+  try {
+    _eligibleReplica = readLinearReplica().mode === "on" ? createReplicaReader() : null;
+  } catch {
+    _eligibleReplica = null; // any resolution failure → linearis path
+  }
+  return _eligibleReplica;
+}
+
+// __resetEligibleReplicaForTests — drop the memoized singleton so a test that
+// flips the mode flag (or injects its own replica) starts from a clean slate.
+export function __resetEligibleReplicaForTests() {
+  _eligibleReplica = undefined;
+}
+
 // Teams that have been reconciled at least once — used by reconcileAll to
 // detect teams dropped from the registry that must be dropProject'd.
 const knownProjects = new Set();
@@ -269,7 +295,7 @@ const knownProjects = new Set();
 // `monitor.reconcile.failing.<TEAM>` event onto the unified event log so the
 // orch-monitor dashboard surfaces the silently-starving team, and a recovering
 // poll clears the alert. `appendHealthEvent` is an injectable test seam.
-export function reconcileProject(team, { exec, delegateExec, appendHealthEvent } = {}) {
+export function reconcileProject(team, { exec, delegateExec, appendHealthEvent, replica, onSource } = {}) {
   const entry = getProjectConfig(team);
   if (!entry) {
     log.warn({ team }, "reconcile: no registry entry for team — skipping");
@@ -278,7 +304,21 @@ export function reconcileProject(team, { exec, delegateExec, appendHealthEvent }
   const query = resolveEligibleQuery(entry);
   let tickets;
   try {
-    tickets = runEligibleQuery(query, { exec, delegateExec });
+    // CTL-1397: pass the replica-backed board-list reader (injectable for tests,
+    // else the mode-gated module singleton) so discovery reads the local replica
+    // instead of `linearis issues list` — immune to the shared Linear quota + the
+    // CTL-679 circuit breaker. onSource logs a structured eligible_source marker
+    // (value "replica"|"linearis") so OTEL/Loki can verify which source served.
+    const eligibleSource =
+      onSource ??
+      ((source, count) =>
+        log.info({ team, eligible_source: source, eligible_count: count }, "eligible: source"));
+    tickets = runEligibleQuery(query, {
+      exec,
+      delegateExec,
+      replica: replica ?? eligibleReplica(),
+      onSource: eligibleSource,
+    });
   } catch (err) {
     log.error({ team, err: err.message }, "reconcile poll failed — preserving prior eligible set");
     // CTL-867: escalate persistent failures beyond the buried log line.
@@ -1138,4 +1178,5 @@ export function __resetForTests() {
   tailerOpts = {};
   resetLivenessCache();
   __resetReconcileHealthForTests(); // CTL-867: clear per-team reconcile-health map
+  _eligibleReplica = undefined; // CTL-1397: drop the memoized board-list replica singleton
 }

--- a/plugins/dev/scripts/execution-core/monitor.mjs
+++ b/plugins/dev/scripts/execution-core/monitor.mjs
@@ -37,9 +37,15 @@ import {
   getClusterHosts, // CTL-862
   hostMembershipWarning, // CTL-1057
   isDraining as isDrainingDefault, // CTL-1095: drain gate
-  readLinearReplica, // CTL-1397: replica-backed board-list discovery (mode gate)
 } from "./config.mjs";
-import { createReplicaReader } from "./replica-read.mjs"; // CTL-1397
+// CTL-1397 (Node-loadability): monitor.mjs MUST NOT import replica-read.mjs — that
+// module statically imports `bun:sqlite`, which the Node ESM loader rejects at
+// module-load (the broker entrypoint is `#!/usr/bin/env node` and loads
+// broker/index.mjs → recovery.mjs → monitor.mjs). So the replica reader is
+// constructed in daemon.mjs (a bun-only context, mode-gated) and INJECTED into
+// startMonitor — exactly the param-injection pattern the per-signal tier uses
+// (linear-query.mjs never imports replica-read.mjs either; daemon.mjs:681 builds
+// the reader and passes it in). monitor.mjs stays Node-loadable.
 import { ownedBy } from "./hrw.mjs"; // CTL-862: HRW ownership filter
 import { claimDispatchSync } from "./cluster-claim-sync.mjs"; // CTL-862: cross-host claim soft-CAS
 import { listProjects, getProjectConfig, resolveEligibleQuery } from "./registry.mjs";
@@ -252,29 +258,13 @@ export function handleCommentCreatedEvent(event, { onComment } = {}) {
 
 // --- Reconcile -----------------------------------------------------------
 
-// CTL-1397: the replica-backed board-list discovery reader, mode-gated EXACTLY
-// like the daemon's per-signal replica tier (daemon.mjs:681 —
-// readLinearReplica().mode === "on" ? createReplicaReader() : null). Lazily
-// resolved ONCE: `undefined` = not-yet-resolved, `null` = resolved-off (flag off
-// or construction failed). When off the reconcile path never touches the replica,
-// so behavior is byte-identical to pre-CTL-1397. Fail-open: a construction throw
-// resolves to null → linearis path.
-let _eligibleReplica; // undefined = not yet resolved
-function eligibleReplica() {
-  if (_eligibleReplica !== undefined) return _eligibleReplica;
-  try {
-    _eligibleReplica = readLinearReplica().mode === "on" ? createReplicaReader() : null;
-  } catch {
-    _eligibleReplica = null; // any resolution failure → linearis path
-  }
-  return _eligibleReplica;
-}
-
-// __resetEligibleReplicaForTests — drop the memoized singleton so a test that
-// flips the mode flag (or injects its own replica) starts from a clean slate.
-export function __resetEligibleReplicaForTests() {
-  _eligibleReplica = undefined;
-}
+// CTL-1397: the replica-backed board-list discovery reader, INJECTED by the
+// daemon (daemon.mjs constructs `readLinearReplica().mode === "on" ?
+// createReplicaReader() : undefined` in its bun-only context and passes it into
+// startMonitor — see the Node-loadability note at the import block). `null` =
+// no reader (mode off, or the Node broker which never injects one) → the reconcile
+// path falls to the linearis exec, byte-identical to pre-CTL-1397.
+let _injectedEligibleReplica = null;
 
 // Teams that have been reconciled at least once — used by reconcileAll to
 // detect teams dropped from the registry that must be dropProject'd.
@@ -316,7 +306,7 @@ export function reconcileProject(team, { exec, delegateExec, appendHealthEvent, 
     tickets = runEligibleQuery(query, {
       exec,
       delegateExec,
-      replica: replica ?? eligibleReplica(),
+      replica: replica ?? _injectedEligibleReplica,
       onSource: eligibleSource,
     });
   } catch (err) {
@@ -1064,7 +1054,14 @@ export function startMonitor({
   botUserIds,
   botWriteId,
   gateway,
+  // CTL-1397: the daemon-injected replica-backed board-list reader (constructed
+  // in daemon.mjs's bun context, mode-gated). undefined/absent → the reconcile
+  // path uses linearis (the Node broker never injects one, so monitor.mjs needs
+  // no bun:sqlite import). Stored module-level so reconcileAll/reconcileProject
+  // (which the reconcile timer drives) read it without re-threading.
+  eligibleReplica,
 } = {}) {
+  _injectedEligibleReplica = eligibleReplica ?? null;
   // CTL-565: orchDir + dispatch + abortWorker are stored in tailerOpts so the
   // tailer-driven readNewEvents → handleStateChangedEvent path can one-shot-
   // dispatch triage and abort a dragged-out worker. When abortWorker is left
@@ -1178,5 +1175,5 @@ export function __resetForTests() {
   tailerOpts = {};
   resetLivenessCache();
   __resetReconcileHealthForTests(); // CTL-867: clear per-team reconcile-health map
-  _eligibleReplica = undefined; // CTL-1397: drop the memoized board-list replica singleton
+  _injectedEligibleReplica = null; // CTL-1397: drop the daemon-injected board-list replica reader
 }

--- a/plugins/dev/scripts/execution-core/monitor.test.mjs
+++ b/plugins/dev/scripts/execution-core/monitor.test.mjs
@@ -5,10 +5,10 @@
 // (registry.mjs) and keys the eligible projection on Linear team — the
 // per-repo enrollment records are gone.
 
-import { describe, test, expect, beforeEach, afterEach, mock } from "bun:test";
+import { describe, test, expect, beforeEach, afterEach, mock, spyOn } from "bun:test";
 import { ownerForTicket } from "./hrw.mjs"; // CTL-862: HRW owner computation for ownership-filter tests
 import { readClusterGeneration } from "./scheduler.mjs"; // CTL-1028: persistence assertion
-import { mkdtempSync, rmSync, mkdirSync, writeFileSync, appendFileSync, statSync, existsSync } from "node:fs";
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync, appendFileSync, statSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
@@ -28,6 +28,7 @@ import {
   __tailerOffset,
   __resetForTests,
 } from "./monitor.mjs";
+import { log } from "./config.mjs"; // CTL-1397: spy on the shared logger for the eligible_source marker
 import { setProjectEligible, getEligibleSet, dropProject } from "./eligible-set.mjs";
 import { loadCursor, saveCursor } from "./event-cursor.mjs";
 import { createTicketStateCache } from "./linear-cache.mjs";
@@ -204,6 +205,69 @@ describe("reconcileProject", () => {
     writeFileSync(join(projDir, "sentinel"), "x");
     expect(() => reconcileProject("ENG", { exec })).not.toThrow();
     rmSync(projDir, { recursive: true, force: true });
+  });
+});
+
+// --- CTL-1397: replica-backed board-list discovery --------------------------
+//
+// reconcileProject threads an injectable `replica` into runEligibleQuery so the
+// per-tick eligible discovery reads the local Catalyst-Cloud SQLite replica
+// instead of `linearis issues list --team X --status Y` — the durable fix for
+// the fleet board-freeze (the linearis discovery query burns the shared Linear
+// quota + trips the CTL-679 circuit breaker). A replica HIT must NOT shell out
+// to linearis; a MISS falls through unchanged.
+describe("reconcileProject — replica tier (CTL-1397)", () => {
+  // A replica stub whose eligible() returns a canned eligible answer (or
+  // undefined to fall through). Shaped so normalizeTicket consumes it directly.
+  function replicaReturning(nodesOrUndefined) {
+    return { eligible: () => nodesOrUndefined };
+  }
+
+  // An exec that fails the test if it is ever called — proves the replica HIT
+  // path does NOT shell out to linearis.
+  function execMustNotRun() {
+    return () => {
+      throw new Error("linearis exec must NOT run on a replica HIT");
+    };
+  }
+
+  test("a replica HIT writes the eligible set WITHOUT calling the linearis exec", () => {
+    enroll("ENG", { status: "Todo" });
+    const replica = replicaReturning({
+      nodes: [
+        { identifier: "ENG-100", state: "Todo", priority: 2 },
+        { identifier: "ENG-101", state: "Todo", priority: 2 },
+      ],
+    });
+    reconcileProject("ENG", { exec: execMustNotRun(), replica });
+    expect(getEligibleSet("ENG").map((t) => t.identifier)).toEqual(["ENG-100", "ENG-101"]);
+  });
+
+  test("a replica MISS (undefined) falls through to the injected linearis exec", () => {
+    enroll("ENG", { status: "Todo" });
+    const replica = replicaReturning(undefined);
+    const exec = execReturning({ ENG: [node("ENG-9")] });
+    reconcileProject("ENG", { exec, replica });
+    expect(exec.calls).toBe(1); // linearis WAS called on the miss
+    expect(getEligibleSet("ENG").map((t) => t.identifier)).toEqual(["ENG-9"]);
+  });
+
+  test("emits a structured eligible_source marker via the logger (replica HIT)", () => {
+    enroll("ENG", { status: "Todo" });
+    const replica = replicaReturning({ nodes: [{ identifier: "ENG-100", state: "Todo", priority: 2 }] });
+    const infoSpy = spyOn(log, "info");
+    try {
+      reconcileProject("ENG", { exec: execMustNotRun(), replica });
+      // The eligible_source field is the OTEL/Loki verification marker.
+      const marked = infoSpy.mock.calls.find(
+        ([obj]) => obj && typeof obj === "object" && obj.eligible_source !== undefined,
+      );
+      expect(marked).toBeDefined();
+      expect(marked[0].eligible_source).toBe("replica");
+      expect(marked[0].eligible_count).toBe(1);
+    } finally {
+      infoSpy.mockRestore();
+    }
   });
 });
 

--- a/plugins/dev/scripts/execution-core/monitor.test.mjs
+++ b/plugins/dev/scripts/execution-core/monitor.test.mjs
@@ -269,6 +269,31 @@ describe("reconcileProject — replica tier (CTL-1397)", () => {
       infoSpy.mockRestore();
     }
   });
+
+  // CTL-1397 (Node-loadability fix) — the reader is constructed in daemon.mjs
+  // (bun-only) and INJECTED into startMonitor, NOT imported by monitor.mjs (which
+  // the Node broker loads). startMonitor stores the injected reader, and a later
+  // reconcileProject with no explicit `replica` opt uses it.
+  test("startMonitor({ eligibleReplica }) injects the reader; a later reconcileProject uses it", () => {
+    enroll("ENG", { status: "Todo" });
+    const replica = replicaReturning({
+      nodes: [{ identifier: "ENG-200", state: "Todo", priority: 2 }],
+    });
+    // startMonitor seeds the module-level injected reader (reconcileAll inside it
+    // runs once; then we reconcile again WITHOUT passing replica in the opts).
+    startMonitor({ exec: execMustNotRun(), eligibleReplica: replica, reconcileIntervalMs: 60_000 });
+    reconcileProject("ENG", { exec: execMustNotRun() }); // no opts.replica → uses the injected reader
+    expect(getEligibleSet("ENG").map((t) => t.identifier)).toEqual(["ENG-200"]);
+  });
+
+  test("no eligibleReplica injected (Node broker / mode off): reconcileProject falls to the linearis path", () => {
+    enroll("ENG", { status: "Todo" });
+    const exec = execReturning({ ENG: [node("ENG-9")] });
+    // startMonitor without eligibleReplica leaves the injected reader null.
+    startMonitor({ exec, reconcileIntervalMs: 60_000 });
+    expect(getEligibleSet("ENG").map((t) => t.identifier)).toEqual(["ENG-9"]);
+    expect(exec.calls).toBeGreaterThan(0); // linearis served (no replica)
+  });
 });
 
 // --- CTL-867: per-team reconcile-health escalation --------------------------

--- a/plugins/dev/scripts/execution-core/replica-read.mjs
+++ b/plugins/dev/scripts/execution-core/replica-read.mjs
@@ -246,58 +246,76 @@ export function createReplicaReader({ dbPath = getReplicaDbPath() } = {}) {
     if (!isReplicaFresh(dbPath)) return undefined;
     try {
       const handle = open();
-      // CTL-1397 (P1 fix) — SEED-COMPLETENESS gate, BEFORE the eligible SELECT.
-      // A fresh mtime only proves the writer is live; mid-reseed the `issues`
-      // table is truncated/partial while the cursor row is absent. If the cursor
-      // is missing/empty the seed is not known-complete → fall through to linearis
-      // rather than serve an empty/partial board. Inside the try so a missing
-      // `sync_meta` table (or any throw) routes to the catch → dropHandle +
-      // undefined (fail-open).
-      if (!handle.prepare(SEED_COMPLETE_SELECT).get()) return undefined;
-      const rows = handle
-        .prepare(ELIGIBLE_SELECT)
-        .all(`${query.team}-%`, query.status, ELIGIBLE_LIMIT);
-      const fwdStmt = handle.prepare(RELATIONS_FORWARD_SELECT);
-      const invStmt = handle.prepare(RELATIONS_INVERSE_SELECT);
-      const nodes = rows.map((row) => {
-        // forward relations this issue owns; linearis's forward `relations`
-        // nodes carry `relatedIssue` (live consumers read relatedIssue.identifier).
-        const relations = {
-          nodes: fwdStmt.all(row.identifier).map((r) => ({
-            type: r.type,
-            relatedIssue: { identifier: r.related_identifier },
-          })),
-        };
-        // inverse relations (the blocked-by edge the scheduler gates on);
-        // linearis's inverseRelations nodes carry `issue` (issue.identifier).
-        const inverseRelations = {
-          nodes: invStmt.all(row.identifier).map((r) => ({
-            type: r.type,
-            issue: { identifier: r.issue_identifier },
-          })),
-        };
-        // epoch-ms → ISO-8601 (the scheduler tie-break compares these as the
-        // linearis path emits them); uncoercible → null.
-        const updMs = coerceMs(row.updated_at);
-        const creMs = coerceMs(row.created_at);
-        return {
-          identifier: row.identifier,
-          title: row.title,
-          state: row.state,
-          priority: row.priority,
-          estimate: row.estimate,
-          updatedAt: updMs === undefined ? null : new Date(updMs).toISOString(),
-          createdAt: creMs === undefined ? null : new Date(creMs).toISOString(),
-          project: row.project_name ?? null,
-          parent: row.parent_identifier ?? null,
-          relations,
-          inverseRelations,
-          // delegate is already populated by the replica, so the linear-query
-          // replica tier skips the GraphQL delegate batch entirely.
-          delegate: row.delegate_id != null ? { id: row.delegate_id, name: row.delegate_name ?? null } : null,
-        };
+      // CTL-1397 (P1 fix #2, Codex review) — read the SEED-COMPLETENESS cursor
+      // AND the board/relation rows inside ONE deferred read transaction, so the
+      // whole answer comes from a single consistent snapshot. As separate
+      // autocommit reads (the prior shape), the cursor check and the data SELECTs
+      // could straddle a forced re-seed: the writer DELETEs the cursor +
+      // TRUNCATEs `issues` + batch-repopulates, so the gate would pass on the
+      // pre-reseed cursor, then the SELECTs would observe a partially-repopulated
+      // table — the exact partial board the gate exists to reject, which
+      // runEligibleQuery would then trust (it serves any non-empty replica
+      // result). A deferred read transaction pins one snapshot across the cursor,
+      // issues, and relation reads, so within it cursor-present ⟺ a complete seed.
+      // bun:sqlite's transaction() defaults to BEGIN DEFERRED (read-only — never
+      // attempts a write lock, so it is safe on the readonly handle) and
+      // COMMIT/ROLLBACKs automatically; a throw inside rolls back + rethrows into
+      // the outer catch → dropHandle + undefined (fail-open). Holds in WAL (prod)
+      // and rollback-journal (test fixture) alike.
+      const readSnapshot = handle.transaction(() => {
+        // SEED-COMPLETENESS gate (see SEED_COMPLETE_SELECT): cursor present = seed
+        // complete; absent/empty = mid-reseed → don't serve. Now read in the SAME
+        // snapshot as the board below so a re-seed can't slip between the two.
+        // undefined here = gate failed → fall through to linearis.
+        if (!handle.prepare(SEED_COMPLETE_SELECT).get()) return undefined;
+        const rows = handle
+          .prepare(ELIGIBLE_SELECT)
+          .all(`${query.team}-%`, query.status, ELIGIBLE_LIMIT);
+        const fwdStmt = handle.prepare(RELATIONS_FORWARD_SELECT);
+        const invStmt = handle.prepare(RELATIONS_INVERSE_SELECT);
+        return rows.map((row) => {
+          // forward relations this issue owns; linearis's forward `relations`
+          // nodes carry `relatedIssue` (live consumers read relatedIssue.identifier).
+          const relations = {
+            nodes: fwdStmt.all(row.identifier).map((r) => ({
+              type: r.type,
+              relatedIssue: { identifier: r.related_identifier },
+            })),
+          };
+          // inverse relations (the blocked-by edge the scheduler gates on);
+          // linearis's inverseRelations nodes carry `issue` (issue.identifier).
+          const inverseRelations = {
+            nodes: invStmt.all(row.identifier).map((r) => ({
+              type: r.type,
+              issue: { identifier: r.issue_identifier },
+            })),
+          };
+          // epoch-ms → ISO-8601 (the scheduler tie-break compares these as the
+          // linearis path emits them); uncoercible → null.
+          const updMs = coerceMs(row.updated_at);
+          const creMs = coerceMs(row.created_at);
+          return {
+            identifier: row.identifier,
+            title: row.title,
+            state: row.state,
+            priority: row.priority,
+            estimate: row.estimate,
+            updatedAt: updMs === undefined ? null : new Date(updMs).toISOString(),
+            createdAt: creMs === undefined ? null : new Date(creMs).toISOString(),
+            project: row.project_name ?? null,
+            parent: row.parent_identifier ?? null,
+            relations,
+            inverseRelations,
+            // delegate is already populated by the replica, so the linear-query
+            // replica tier skips the GraphQL delegate batch entirely.
+            delegate: row.delegate_id != null ? { id: row.delegate_id, name: row.delegate_name ?? null } : null,
+          };
+        });
       });
-      return { nodes };
+      const nodes = readSnapshot();
+      // undefined = the seed-completeness gate failed inside the snapshot → fall
+      // through to linearis (never serve an empty/partial board on a re-seed).
+      return nodes === undefined ? undefined : { nodes };
     } catch {
       // Drop the handle so a later call re-opens fresh (DB may be re-seeded).
       dropHandle();

--- a/plugins/dev/scripts/execution-core/replica-read.mjs
+++ b/plugins/dev/scripts/execution-core/replica-read.mjs
@@ -25,6 +25,7 @@
 // even if a team's terminal workflow state carries a custom display name. A
 // non-terminal HIT returns the row's actual `state` name (or null).
 import { Database } from "bun:sqlite";
+import { statSync } from "node:fs";
 import { getReplicaDbPath } from "./config.mjs";
 
 // The light terminal SELECT. Index-backed by idx_issues_identifier (confirmed).
@@ -65,6 +66,62 @@ function coerceMs(v) {
   if (Number.isFinite(n)) return n; // epoch-ms integer
   const p = Date.parse(v); // ISO-8601 text
   return Number.isFinite(p) ? p : undefined;
+}
+
+// CTL-1397: the replica-backed board-list / eligible discovery query. The
+// daemon's per-tick reconcile runs this INSTEAD of `linearis issues list --team
+// X --status Y` — the linearis discovery query burns the shared Linear quota and
+// trips the CTL-679 circuit breaker, freezing board discovery fleet-wide. Reading
+// the local sub-ms replica makes discovery immune to the breaker/quota.
+//
+// The `issues` table has team_id (UUID) but NO team_key column, so we filter by
+// the Linear identifier prefix: identifiers are `<teamKey>-<number>`, so
+// `identifier LIKE 'CTL-%'` selects exactly team CTL (the hyphen disambiguates
+// CTL- from CTC-). state is the workflow-state NAME string (matches query.status).
+// removed_at IS NULL drops tombstones. LIMIT 200 matches linear-query DEFAULT_LIMIT.
+const ELIGIBLE_SELECT = `SELECT i.identifier, i.title, i.state, i.priority, i.estimate, i.updated_at, i.created_at, i.parent_identifier, i.delegate_id, i.delegate_name, p.name AS project_name FROM issues i LEFT JOIN projects p ON p.id = i.project_id WHERE i.identifier LIKE ? AND i.state = ? AND i.removed_at IS NULL ORDER BY i.updated_at DESC LIMIT ?`;
+const ELIGIBLE_LIMIT = 200;
+// Relation enrichment, mirroring normalizeDetail in linear-cli.mjs. forward:
+// edges this issue OWNS (relatedIssue is the target); inverse: edges that point
+// AT this issue (the blocked-by edge the scheduler gates on).
+const RELATIONS_FORWARD_SELECT = `SELECT type, related_identifier FROM relations WHERE issue_identifier = ?`;
+const RELATIONS_INVERSE_SELECT = `SELECT type, issue_identifier FROM relations WHERE related_identifier = ?`;
+
+// CTL-1397 (P1 fix) — the SEED-COMPLETENESS gate. The mtime gate
+// (isReplicaFresh) proves the cloud-sync writer is LIVE; it does NOT prove the
+// seed is COMPLETE. The writer's forced re-seed (the exact quota/outage-recovery
+// path this feature exists to survive) TRUNCATES + batch-repopulates the `issues`
+// table while the file mtime stays fresh, so a read landing mid-reseed sees either
+// an EMPTY table (→ would zero the board) or a PARTIAL table (→ a trusted
+// incomplete set). The writer DELETES the `sync_meta` cursor row at re-seed start
+// and re-writes it only on completion (@catalyst-cloud/sdk: catalyst-replica.ts +
+// replicate.ts), so a present, non-empty cursor IS the seed-completeness signal:
+// cursor-present = seed complete; cursor-absent/empty = mid-reseed → don't serve.
+const SEED_COMPLETE_SELECT = `SELECT 1 FROM sync_meta WHERE key = 'cursor' AND value IS NOT NULL AND value <> '' LIMIT 1`;
+
+// The eligible freshness GATE — the SAME mtime-based writer-liveness proxy as
+// linear-cli.mjs's openFreshReplica. A dead writer stops touching the file →
+// stale mtime → fall through to linearis (correct answer, just un-accelerated).
+// WAL mode: appends land in the `-wal` sidecar; the main DB mtime only advances
+// on checkpoint, so take the freshest of the DB + a NON-EMPTY `-wal` (an empty
+// `-wal` is a reader artifact, never a writer-liveness signal — see the spoof-
+// resistance note in linear-cli.mjs). Threshold = CATALYST_LINEAR_REPLICA_STALE_MS
+// (default 5 min). Returns true when fresh, false when absent/stale/unstattable.
+function isReplicaFresh(dbPath) {
+  let newest;
+  try {
+    newest = statSync(dbPath).mtimeMs; // throws if the file is absent → not fresh
+  } catch {
+    return false;
+  }
+  try {
+    const wal = statSync(dbPath + "-wal");
+    if (wal.size > 0) newest = Math.max(newest, wal.mtimeMs);
+  } catch {
+    /* -wal absent → main DB mtime only */
+  }
+  const thresholdMs = Number(process.env.CATALYST_LINEAR_REPLICA_STALE_MS) || 300_000;
+  return Date.now() - newest <= thresholdMs;
 }
 
 export function createReplicaReader({ dbPath = getReplicaDbPath() } = {}) {
@@ -166,5 +223,87 @@ export function createReplicaReader({ dbPath = getReplicaDbPath() } = {}) {
     }
   };
 
-  return { lookup, freshness, titles, close: dropHandle };
+  // eligible(query) → { nodes: [...] } | undefined  (CTL-1397)
+  //   A VALID answer is { nodes: [...] } — even { nodes: [] } (a fresh replica
+  //   with genuinely zero eligible tickets is a REAL answer, NOT a miss; the
+  //   caller must NOT fall through and re-run linearis for it).
+  //   undefined = "fall through to linearis" — returned when:
+  //     - the query is missing team or status (can't build the filter), OR
+  //     - query.project or query.label is set (v1 scope: filtered queries stay
+  //       on linearis — the replica filter is team+state only), OR
+  //     - the replica file is absent OR STALE by mtime (writer-liveness gate), OR
+  //     - any throw (→ dropHandle + undefined).
+  //   Fail-open everywhere: this tier can only ACCELERATE; any doubt falls
+  //   through to today's linearis behavior, never makes discovery WORSE.
+  const eligible = (query) => {
+    // Guard: need both filter dimensions, and v1 does NOT serve project/label
+    // filtered queries (the SQL filters team+state only — a project/label query
+    // would silently over-return, so fall through to linearis instead).
+    if (!query || !query.team || !query.status) return undefined;
+    if (query.project != null || query.label != null) return undefined;
+    // Freshness GATE (writer-liveness proxy) — a stale/absent replica falls
+    // through so a dead writer can never freeze discovery on a stale board.
+    if (!isReplicaFresh(dbPath)) return undefined;
+    try {
+      const handle = open();
+      // CTL-1397 (P1 fix) — SEED-COMPLETENESS gate, BEFORE the eligible SELECT.
+      // A fresh mtime only proves the writer is live; mid-reseed the `issues`
+      // table is truncated/partial while the cursor row is absent. If the cursor
+      // is missing/empty the seed is not known-complete → fall through to linearis
+      // rather than serve an empty/partial board. Inside the try so a missing
+      // `sync_meta` table (or any throw) routes to the catch → dropHandle +
+      // undefined (fail-open).
+      if (!handle.prepare(SEED_COMPLETE_SELECT).get()) return undefined;
+      const rows = handle
+        .prepare(ELIGIBLE_SELECT)
+        .all(`${query.team}-%`, query.status, ELIGIBLE_LIMIT);
+      const fwdStmt = handle.prepare(RELATIONS_FORWARD_SELECT);
+      const invStmt = handle.prepare(RELATIONS_INVERSE_SELECT);
+      const nodes = rows.map((row) => {
+        // forward relations this issue owns; linearis's forward `relations`
+        // nodes carry `relatedIssue` (live consumers read relatedIssue.identifier).
+        const relations = {
+          nodes: fwdStmt.all(row.identifier).map((r) => ({
+            type: r.type,
+            relatedIssue: { identifier: r.related_identifier },
+          })),
+        };
+        // inverse relations (the blocked-by edge the scheduler gates on);
+        // linearis's inverseRelations nodes carry `issue` (issue.identifier).
+        const inverseRelations = {
+          nodes: invStmt.all(row.identifier).map((r) => ({
+            type: r.type,
+            issue: { identifier: r.issue_identifier },
+          })),
+        };
+        // epoch-ms → ISO-8601 (the scheduler tie-break compares these as the
+        // linearis path emits them); uncoercible → null.
+        const updMs = coerceMs(row.updated_at);
+        const creMs = coerceMs(row.created_at);
+        return {
+          identifier: row.identifier,
+          title: row.title,
+          state: row.state,
+          priority: row.priority,
+          estimate: row.estimate,
+          updatedAt: updMs === undefined ? null : new Date(updMs).toISOString(),
+          createdAt: creMs === undefined ? null : new Date(creMs).toISOString(),
+          project: row.project_name ?? null,
+          parent: row.parent_identifier ?? null,
+          relations,
+          inverseRelations,
+          // delegate is already populated by the replica, so the linear-query
+          // replica tier skips the GraphQL delegate batch entirely.
+          delegate: row.delegate_id != null ? { id: row.delegate_id, name: row.delegate_name ?? null } : null,
+        };
+      });
+      return { nodes };
+    } catch {
+      // Drop the handle so a later call re-opens fresh (DB may be re-seeded).
+      dropHandle();
+      return undefined;
+    }
+  };
+
+  return { lookup, freshness, titles, eligible, close: dropHandle };
 }

--- a/plugins/dev/scripts/execution-core/replica-read.test.mjs
+++ b/plugins/dev/scripts/execution-core/replica-read.test.mjs
@@ -509,4 +509,39 @@ describe("createReplicaReader.eligible (CTL-1397 board-list)", () => {
     // responsibilities stay distinct.
     expect(reader.eligible({ team: "ZZZ", status: "Todo" })).toEqual({ nodes: [] });
   });
+
+  // CTL-1397 (P1 fix #2, Codex review) — the cursor gate + board + relation reads
+  // now run inside ONE deferred read transaction so a forced re-seed can't slip
+  // between the gate and the data SELECTs (serving a partial board). The race is
+  // single-snapshot SQLite isolation that a synchronous fixture can't interleave,
+  // so these lock the OBSERVABLE properties of the wrapped path: it works in WAL
+  // (prod journal mode), it commits/releases the snapshot every call (a botched
+  // COMMIT would leak a read txn → the second call's BEGIN nests/throws or the WAL
+  // never releases), and the gate still composes inside the transaction.
+  test("WAL journal mode (prod shape): repeated eligible() calls each commit/release the snapshot and return the consistent board", () => {
+    const db = new Database(dbPath, { create: true });
+    db.run(`PRAGMA journal_mode = WAL`); // exercise the prod journal mode the snapshot fix targets
+    db.run(`CREATE TABLE issues (identifier TEXT, title TEXT, state TEXT, priority INTEGER, estimate INTEGER, project_id TEXT, parent_identifier TEXT, delegate_id TEXT, delegate_name TEXT, removed_at TEXT, updated_at INTEGER, created_at INTEGER)`);
+    db.run(`CREATE INDEX idx_issues_identifier ON issues (identifier)`);
+    db.run(`CREATE TABLE relations (type TEXT, issue_identifier TEXT, related_identifier TEXT)`);
+    db.run(`CREATE TABLE projects (id TEXT, name TEXT)`);
+    db.run(`CREATE TABLE sync_meta (key TEXT PRIMARY KEY, value TEXT)`);
+    db.run(`INSERT INTO sync_meta VALUES ('cursor', '42')`);
+    db.run(`INSERT INTO issues VALUES ('CTL-100', 'Repoint board-list', 'Todo', 2, 3, NULL, NULL, NULL, NULL, NULL, 3000, 100)`);
+    db.run(`INSERT INTO issues VALUES ('CTL-101', 'Second todo', 'Todo', 0, NULL, NULL, NULL, NULL, NULL, NULL, 2000, 90)`);
+    db.run(`INSERT INTO relations VALUES ('blocks', 'CTL-7', 'CTL-100')`);
+    db.close();
+    freshen();
+    reader = createReplicaReader({ dbPath });
+    const first = reader.eligible({ team: "CTL", status: "Todo" });
+    expect(first.nodes.map((n) => n.identifier)).toEqual(["CTL-100", "CTL-101"]);
+    // A second call must succeed identically — proving the prior call's read
+    // transaction was committed/released (not left open pinning the WAL snapshot).
+    const second = reader.eligible({ team: "CTL", status: "Todo" });
+    expect(second.nodes.map((n) => n.identifier)).toEqual(["CTL-100", "CTL-101"]);
+    // The inverse (blocked-by) relation, enriched INSIDE the same snapshot, survives.
+    expect(second.nodes[0].inverseRelations.nodes).toEqual([
+      { type: "blocks", issue: { identifier: "CTL-7" } },
+    ]);
+  });
 });

--- a/plugins/dev/scripts/execution-core/replica-read.test.mjs
+++ b/plugins/dev/scripts/execution-core/replica-read.test.mjs
@@ -6,7 +6,7 @@
 
 import { describe, test, expect, beforeEach, afterEach } from "bun:test";
 import { Database } from "bun:sqlite";
-import { mkdtempSync, rmSync } from "node:fs";
+import { mkdtempSync, rmSync, utimesSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { createReplicaReader } from "./replica-read.mjs";
@@ -248,5 +248,265 @@ describe("createReplicaReader.titles (CTL-1372 — batched board title source)",
     empty.close();
     reader = createReplicaReader({ dbPath });
     expect(reader.titles(["CTL-1214"])).toEqual({});
+  });
+});
+
+// CTL-1397 — board-list / eligible() tests. The replica-backed discovery query
+// the daemon's reconcile uses instead of `linearis issues list --team X --status
+// Y` (which burns the shared Linear quota + trips the CTL-679 circuit breaker,
+// freezing board discovery fleet-wide). The fixture mirrors the cloud schema's
+// eligible-relevant columns + relations + projects so the SQL + enrichment +
+// timestamp coercion are exercised against REAL bun:sqlite.
+
+// fresh — bump the DB + a NON-EMPTY -wal sidecar's mtime to NOW so the
+// mtime-based staleness gate (writer-liveness proxy) reads the fixture as fresh.
+// Without this, a fixture written "in the past" relative to the 5-min threshold
+// would (correctly) fall through, masking the row assertions we're after.
+function freshen() {
+  const now = new Date();
+  utimesSync(dbPath, now, now);
+  try {
+    // open + WAL-checkpoint leaves a -wal sidecar; if it's empty the gate ignores
+    // it (reader artifact). Write a byte so its mtime counts, then touch it now.
+    writeFileSync(dbPath + "-wal", "x");
+    utimesSync(dbPath + "-wal", now, now);
+  } catch {
+    /* best-effort: the DB mtime alone is enough when -wal is absent */
+  }
+}
+
+// seedEligible — the full eligible fixture: issues (with team-prefixed
+// identifiers, state, priority, estimate, project_id, parent_identifier,
+// delegate, removed_at, timestamps), a relations table (forward + inverse), and
+// a projects table (LEFT JOIN name source).
+function seedEligible() {
+  const db = new Database(dbPath, { create: true });
+  db.run(`
+    CREATE TABLE issues (
+      identifier        TEXT,
+      title             TEXT,
+      state             TEXT,
+      priority          INTEGER,
+      estimate          INTEGER,
+      project_id        TEXT,
+      parent_identifier TEXT,
+      delegate_id       TEXT,
+      delegate_name     TEXT,
+      removed_at        TEXT,
+      updated_at        INTEGER,
+      created_at        INTEGER
+    )
+  `);
+  db.run(`CREATE INDEX idx_issues_identifier ON issues (identifier)`);
+  db.run(`CREATE TABLE relations (type TEXT, issue_identifier TEXT, related_identifier TEXT)`);
+  db.run(`CREATE TABLE projects (id TEXT, name TEXT)`);
+  // CTL-1397: sync_meta carries the seed-completeness cursor. The cloud-sync
+  // writer DELETES the cursor row at re-seed start and re-writes it only on
+  // completion, so cursor-present = seed complete (the gate eligible() checks).
+  db.run(`CREATE TABLE sync_meta (key TEXT PRIMARY KEY, value TEXT)`);
+  db.run(`INSERT INTO sync_meta VALUES ('cursor', '42')`);
+  db.run(`INSERT INTO projects VALUES ('proj-1', 'Harden the core')`);
+  // CTL-100: Todo, priority 2, in a project, has a parent + a delegate, newest.
+  db.run(
+    `INSERT INTO issues VALUES ('CTL-100', 'Repoint board-list', 'Todo', 2, 3, 'proj-1', 'CTL-1', 'del-1', 'Bot', NULL, 3000, 100)`,
+  );
+  // CTL-101: Todo, priority 0 (no priority), no project/parent/delegate, older.
+  db.run(
+    `INSERT INTO issues VALUES ('CTL-101', 'Second todo', 'Todo', 0, NULL, NULL, NULL, NULL, NULL, NULL, 2000, 90)`,
+  );
+  // CTL-102: Backlog (NOT Todo) — excluded by the state filter.
+  db.run(
+    `INSERT INTO issues VALUES ('CTL-102', 'Backlogged', 'Backlog', 1, NULL, NULL, NULL, NULL, NULL, NULL, 2500, 80)`,
+  );
+  // CTL-103: Todo but tombstoned (removed_at set) — excluded by removed_at IS NULL.
+  db.run(
+    `INSERT INTO issues VALUES ('CTL-103', 'Removed todo', 'Todo', 2, NULL, NULL, NULL, NULL, NULL, '2026-06-03T00:00:00Z', 2600, 70)`,
+  );
+  // CTC-100: a DIFFERENT team (the hyphen disambiguates CTL- from CTC-) — must
+  // not leak into a CTL query via a naive prefix match.
+  db.run(
+    `INSERT INTO issues VALUES ('CTC-100', 'Other team todo', 'Todo', 2, NULL, NULL, NULL, NULL, NULL, NULL, 2700, 60)`,
+  );
+  // relations: CTL-100 blocks CTL-9 (forward); CTL-7 blocks CTL-100 (inverse).
+  db.run(`INSERT INTO relations VALUES ('blocks', 'CTL-100', 'CTL-9')`);
+  db.run(`INSERT INTO relations VALUES ('blocks', 'CTL-7', 'CTL-100')`);
+  db.close();
+  freshen();
+}
+
+describe("createReplicaReader.eligible (CTL-1397 board-list)", () => {
+  test("returns { nodes } filtered by identifier-prefix + state, excludes removed + other teams", () => {
+    seedEligible();
+    reader = createReplicaReader({ dbPath });
+    const res = reader.eligible({ team: "CTL", status: "Todo" });
+    expect(Array.isArray(res?.nodes)).toBe(true);
+    // CTL-100 (newest) then CTL-101 (ORDER BY updated_at DESC). NOT CTL-102
+    // (Backlog), NOT CTL-103 (removed), NOT CTC-100 (other team).
+    expect(res.nodes.map((n) => n.identifier)).toEqual(["CTL-100", "CTL-101"]);
+  });
+
+  test("builds a node normalizeTicket consumes: state/priority/estimate/project/parent/delegate + ISO timestamps", () => {
+    seedEligible();
+    reader = createReplicaReader({ dbPath });
+    const res = reader.eligible({ team: "CTL", status: "Todo" });
+    const n = res.nodes.find((x) => x.identifier === "CTL-100");
+    expect(n.title).toBe("Repoint board-list");
+    expect(n.state).toBe("Todo");
+    expect(n.priority).toBe(2);
+    expect(n.estimate).toBe(3);
+    expect(n.project).toBe("Harden the core");
+    expect(n.parent).toBe("CTL-1");
+    expect(n.delegate).toEqual({ id: "del-1", name: "Bot" });
+    // epoch-ms → ISO-8601 string (the scheduler tie-break compares these).
+    expect(n.updatedAt).toBe(new Date(3000).toISOString());
+    expect(n.createdAt).toBe(new Date(100).toISOString());
+  });
+
+  test("enriches relations (forward) + inverseRelations from the relations table", () => {
+    seedEligible();
+    reader = createReplicaReader({ dbPath });
+    const res = reader.eligible({ team: "CTL", status: "Todo" });
+    const n = res.nodes.find((x) => x.identifier === "CTL-100");
+    expect(n.relations.nodes).toEqual([
+      { type: "blocks", relatedIssue: { identifier: "CTL-9" } },
+    ]);
+    expect(n.inverseRelations.nodes).toEqual([
+      { type: "blocks", issue: { identifier: "CTL-7" } },
+    ]);
+  });
+
+  test("a row with no project/parent/delegate maps those to null + empty relation node lists", () => {
+    seedEligible();
+    reader = createReplicaReader({ dbPath });
+    const res = reader.eligible({ team: "CTL", status: "Todo" });
+    const n = res.nodes.find((x) => x.identifier === "CTL-101");
+    expect(n.project).toBeNull();
+    expect(n.parent).toBeNull();
+    expect(n.delegate).toBeNull();
+    expect(n.priority).toBe(0);
+    expect(n.estimate).toBeNull();
+    expect(n.relations.nodes).toEqual([]);
+    expect(n.inverseRelations.nodes).toEqual([]);
+  });
+
+  test("fresh-empty (no matching rows) → { nodes: [] }, NOT undefined", () => {
+    seedEligible();
+    reader = createReplicaReader({ dbPath });
+    // A team with zero Todo rows: a fresh replica genuinely has no eligible
+    // tickets — that is a REAL answer, not a fall-through miss.
+    const res = reader.eligible({ team: "ZZZ", status: "Todo" });
+    expect(res).toEqual({ nodes: [] });
+  });
+
+  test("returns undefined (fall through) when team is missing", () => {
+    seedEligible();
+    reader = createReplicaReader({ dbPath });
+    expect(reader.eligible({ status: "Todo" })).toBeUndefined();
+  });
+
+  test("returns undefined (fall through) when status is missing", () => {
+    seedEligible();
+    reader = createReplicaReader({ dbPath });
+    expect(reader.eligible({ team: "CTL" })).toBeUndefined();
+  });
+
+  test("returns undefined (v1 scope) when query.project is set", () => {
+    seedEligible();
+    reader = createReplicaReader({ dbPath });
+    expect(reader.eligible({ team: "CTL", status: "Todo", project: "Harden" })).toBeUndefined();
+  });
+
+  test("returns undefined (v1 scope) when query.label is set", () => {
+    seedEligible();
+    reader = createReplicaReader({ dbPath });
+    expect(reader.eligible({ team: "CTL", status: "Todo", label: "bug" })).toBeUndefined();
+  });
+
+  test("returns undefined when the replica file is absent", () => {
+    reader = createReplicaReader({ dbPath });
+    expect(reader.eligible({ team: "CTL", status: "Todo" })).toBeUndefined();
+  });
+
+  test("returns undefined when the replica is STALE by mtime", () => {
+    seedEligible();
+    // Backdate the DB + -wal well past the default 5-min staleness threshold.
+    const old = new Date(Date.now() - 10 * 60_000);
+    utimesSync(dbPath, old, old);
+    try { utimesSync(dbPath + "-wal", old, old); } catch { /* -wal may be absent */ }
+    reader = createReplicaReader({ dbPath });
+    expect(reader.eligible({ team: "CTL", status: "Todo" })).toBeUndefined();
+  });
+
+  test("honors CATALYST_LINEAR_REPLICA_STALE_MS override for the freshness gate", () => {
+    seedEligible();
+    const old = new Date(Date.now() - 2 * 60_000); // 2 min old
+    utimesSync(dbPath, old, old);
+    try { utimesSync(dbPath + "-wal", old, old); } catch { /* -wal may be absent */ }
+    const prev = process.env.CATALYST_LINEAR_REPLICA_STALE_MS;
+    process.env.CATALYST_LINEAR_REPLICA_STALE_MS = "60000"; // 1 min threshold → 2-min-old is stale
+    try {
+      reader = createReplicaReader({ dbPath });
+      expect(reader.eligible({ team: "CTL", status: "Todo" })).toBeUndefined();
+    } finally {
+      if (prev === undefined) delete process.env.CATALYST_LINEAR_REPLICA_STALE_MS;
+      else process.env.CATALYST_LINEAR_REPLICA_STALE_MS = prev;
+    }
+  });
+
+  test("fail-open: DB without the issues table → undefined (query throws)", () => {
+    const empty = new Database(dbPath, { create: true });
+    empty.run(`CREATE TABLE unrelated (x INTEGER)`);
+    empty.close();
+    freshen();
+    reader = createReplicaReader({ dbPath });
+    expect(reader.eligible({ team: "CTL", status: "Todo" })).toBeUndefined();
+  });
+
+  // CTL-1397 (P1 fix) — seed-completeness gate. The mtime gate proves the writer
+  // is LIVE, not that the seed is COMPLETE. The cloud-sync forced re-seed
+  // truncates + batch-repopulates `issues` while the mtime stays fresh, so a
+  // mid-reseed read would (a) see an EMPTY table → trusted-empty zeroes the board
+  // or (b) see a PARTIAL table → trusted-incomplete set. The writer deletes the
+  // `sync_meta` cursor row at re-seed start and re-writes it only on completion,
+  // so cursor-absent = mid-reseed → eligible() must NOT serve (fall through).
+
+  test("cursor row ABSENT (mid-reseed) on a fresh+populated DB → undefined (fall through)", () => {
+    seedEligible(); // fresh + populated + cursor present
+    // Simulate the writer mid-reseed: it deletes the cursor row at re-seed start.
+    const db = new Database(dbPath);
+    db.run(`DELETE FROM sync_meta WHERE key = 'cursor'`);
+    db.close();
+    freshen(); // the writer is STILL live (fresh mtime) — only the seed is incomplete
+    reader = createReplicaReader({ dbPath });
+    // Even though CTL-100/CTL-101 rows are present, a missing cursor means the
+    // seed is not known-complete → do not trust the read.
+    expect(reader.eligible({ team: "CTL", status: "Todo" })).toBeUndefined();
+  });
+
+  test("cursor present (seed complete) + matching rows → returns { nodes } as before", () => {
+    seedEligible();
+    reader = createReplicaReader({ dbPath });
+    const res = reader.eligible({ team: "CTL", status: "Todo" });
+    expect(res.nodes.map((n) => n.identifier)).toEqual(["CTL-100", "CTL-101"]);
+  });
+
+  test("cursor present but EMPTY value (key exists, value '') → undefined (mid-reseed sentinel)", () => {
+    seedEligible();
+    const db = new Database(dbPath);
+    db.run(`UPDATE sync_meta SET value = '' WHERE key = 'cursor'`);
+    db.close();
+    freshen();
+    reader = createReplicaReader({ dbPath });
+    expect(reader.eligible({ team: "CTL", status: "Todo" })).toBeUndefined();
+  });
+
+  test("cursor present + ZERO matching rows → still { nodes: [] } at the READER level (empty-distrust lives in runEligibleQuery, not here)", () => {
+    seedEligible(); // cursor present, but no ZZZ-team rows
+    reader = createReplicaReader({ dbPath });
+    // The reader's contract is unchanged for a genuinely-empty, seed-complete
+    // result: it returns { nodes: [] }. The decision to DISTRUST a replica-empty
+    // (and confirm via linearis) belongs to runEligibleQuery — the two layers'
+    // responsibilities stay distinct.
+    expect(reader.eligible({ team: "ZZZ", status: "Todo" })).toEqual({ nodes: [] });
   });
 });


### PR DESCRIPTION
## The fire this puts out

The fleet board has been **freezing** (OTEL escalation, fleet-reinstall channel #59/#60): the execution-core reconcile runs `linearis issues list --team X --status Y` every tick to discover dispatchable tickets. Under Linear quota pressure that trips the **CTL-679 circuit breaker**, which rejects the board-list poll → **board discovery returns nothing → the whole fleet's board freezes**. The `linearis issues list` poll is a top *complexity-cost* burner on the shared quota.

`#2501` (CTL-1397 2/n) fixed the *per-dispatch* reads but **not** this discovery path. This PR is the durable fix: **repoint board-list discovery to the local Catalyst-Cloud replica**, making it immune to the breaker/quota. Board discovery keeps working even during a quota crunch.

## Change (fail-open throughout — can only accelerate)

- **`replica-read.mjs` `eligible(query)`** — filtered SELECT over the replica `issues` table. Filters by **identifier prefix** (`identifier LIKE 'CTL-%'`) because the deployed `issues` table has `team_id` (UUID), not `team_key` (that's the unshipped CTC-148); the `<teamKey>-<n>` identifier shape makes this exact. Enriches relations/inverseRelations (dependency graph) + delegate + project, ISO timestamps. **Two gates:** (1) mtime freshness (writer-liveness); (2) **`sync_meta` cursor presence (seed-completeness)** — a forced re-seed truncates the table with a *fresh mtime*, and the cursor (deleted at re-seed start, re-written on completion) is the don't-serve-mid-reseed signal.
- **`linear-query.mjs` `runEligibleQuery`** — replica tier that serves locally **only a non-empty result**. A replica-`{nodes:[]}` is **not trusted** to zero a board — it falls through to the linearis confirmation (catches feed-holes; a breaker-open throw then preserves the prior eligible set). Emits an `onSource` marker.
- **`monitor.mjs`** — mode-gated `eligibleReplica()` singleton; `reconcileProject` logs **`eligible_source={replica|linearis}`** for end-to-end verification.

The linearis path and the CTL-679 breaker are **unchanged**. v1 scope: project/label-filtered eligible queries stay on linearis (the common team+status case is served from the replica).

## Two safety guards came from adversarial review (a real P1)

A silent-failure-hunter pass caught that the naive "fresh mtime + 0 rows = empty board" would **silently zero the dispatch board fleet-wide during a writer re-seed** (the exact recovery this feature targets). Both the cursor gate and the empty-distrust guard exist to make that impossible — verified the `sync_meta` cursor mechanism against the live replica DB.

## Tests
`replica-read` 39 · `linear-query` 184 · `monitor` 134 — including: mid-reseed (cursor-absent) → fall-through; replica-empty → linearis confirmation; breaker-open → throw preserves the prior set.

## Verification plan
After merge+deploy, OTEL watches the `eligible_source=replica` marker (the `linearis issues list` op should vanish from the Linear-audit-proxy log), and the discovery-path circuit-open rate should flatline → `DURABLE-RECOVERED`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)