### PR TITLE
feat(dev): CTL-1157 — Self-Healing Delegate wave 1 (board-health sees + acts on stuck work; shadow-gated, dark merge)

### DIFF
--- a/plugins/dev/scripts/broker/broker-state.mjs
+++ b/plugins/dev/scripts/broker/broker-state.mjs
@@ -286,6 +286,23 @@ export function setFilterStateMerged(interestId, mergeCommitSha) {
   return result.changes > 0 ? { interestId } : null;
 }
 
+// setFilterStateClosed — CTL-1157 (Codex round-7): mark a PR's lifecycle row 'closed'
+// when it was closed WITHOUT merging. Before this the github.pr.closed webhook only
+// recorded a wake reason and never updated filter_state, so the row stayed 'open'
+// indefinitely — and board-health's orphaned-open-PR cohort then treated the
+// already-closed PR as a stale orphan forever, dispatching recovery for a PR that no
+// longer exists. 'closed' matches neither the orphaned cohort's `status === "open"`
+// nor the phantom cohort's merged/deployed test, so the PR is correctly excluded.
+export function setFilterStateClosed(interestId) {
+  const result = ensure().run(
+    `UPDATE filter_state
+       SET status = 'closed', updated_at = ?
+       WHERE interest_id = ?`,
+    [nowIso(), interestId]
+  );
+  return result.changes > 0 ? { interestId } : null;
+}
+
 export function setFilterStateDeploying(mergeCommitSha, deploymentId, environment) {
   const row = ensure()
     .prepare(`SELECT interest_id FROM filter_state WHERE merge_commit_sha = ? LIMIT 1`)

--- a/plugins/dev/scripts/broker/broker-state.mjs
+++ b/plugins/dev/scripts/broker/broker-state.mjs
@@ -653,18 +653,43 @@ export function getAllTicketDescriptors({ includeRemoved = false } = {}) {
 // table for board-health's phantom-merged-PR / orphaned-open-PR invariants. A
 // PR's status walks a monotone lifecycle (open → merged → deploying → deployed/
 // failed), so for each pr_number the most-recently-updated row is the current
-// status. ORDER BY updated_at DESC + first-row-per-pr_number wins. Returns
-// Map<number,{status,updatedAt}> (frozen once at board-assemble time). Empty map
-// when filter_state has no rows → the new invariants stay observable:false
-// (shadow-safe by default).
+// status. ORDER BY updated_at DESC + first-row-per-pr_number wins.
+//
+// MULTI-REPO COLLISION (CTL-1157): a (repo, pr_number) pair — NOT pr_number alone
+// — identifies a PR. With filter_state rows from >1 GitHub repo, PR numbers
+// collide: a merged #42 in repo X and an open #42 in repo Y are DIFFERENT PRs.
+// Keying by pr_number alone would let repo X's `merged` shadow repo Y's `open`
+// (the board would treat Y's #42 as merged → false phantom, or hide its orphaned
+// open PR). Since the board descriptor carries no per-ticket repo, we cannot say
+// WHICH #42 a ticket points at — so a number seen in TWO distinct repos is marked
+// `ambiguous:true`, and board-health skips it rather than borrow the wrong repo's
+// status. Each entry also carries its `repo` for downstream repo+number matching.
+//
+// Returns Map<number,{status,updatedAt,repo,ambiguous}> (frozen once at
+// board-assemble time). Empty map when filter_state has no rows → the new
+// invariants stay observable:false (shadow-safe by default).
 export function getAllPrStatuses() {
   const rows = ensure()
-    .prepare(`SELECT pr_number, status, updated_at FROM filter_state ORDER BY updated_at DESC`)
+    .prepare(`SELECT pr_number, repo, status, updated_at FROM filter_state ORDER BY updated_at DESC`)
     .all();
   const map = new Map();
   for (const row of rows) {
-    if (row.pr_number != null && !map.has(row.pr_number)) {
-      map.set(row.pr_number, { status: row.status, updatedAt: row.updated_at });
+    if (row.pr_number == null) continue;
+    const existing = map.get(row.pr_number);
+    if (!existing) {
+      map.set(row.pr_number, {
+        status: row.status,
+        updatedAt: row.updated_at,
+        repo: row.repo ?? null,
+        ambiguous: false,
+      });
+      continue;
+    }
+    // A repeated row for the SAME repo is just an older lifecycle state — the
+    // most-recent already won. A row for a DIFFERENT repo is a colliding PR number
+    // across repos → ambiguous (board-health must not match it to one repo).
+    if (row.repo != null && existing.repo != null && row.repo !== existing.repo) {
+      existing.ambiguous = true;
     }
   }
   return map;

--- a/plugins/dev/scripts/broker/broker-state.mjs
+++ b/plugins/dev/scripts/broker/broker-state.mjs
@@ -652,22 +652,29 @@ export function getAllTicketDescriptors({ includeRemoved = false } = {}) {
 // getAllPrStatuses — CTL-1157: one batch read of the filter_state lifecycle
 // table for board-health's phantom-merged-PR / orphaned-open-PR invariants. A
 // PR's status walks a monotone lifecycle (open → merged → deploying → deployed/
-// failed), so for each pr_number the most-recently-updated row is the current
-// status. ORDER BY updated_at DESC + first-row-per-pr_number wins.
+// failed), so for each (repo, pr_number) the most-recently-updated row is the
+// current status. ORDER BY updated_at DESC + first-row-per-(repo,number) wins.
 //
-// MULTI-REPO COLLISION (CTL-1157): a (repo, pr_number) pair — NOT pr_number alone
-// — identifies a PR. With filter_state rows from >1 GitHub repo, PR numbers
-// collide: a merged #42 in repo X and an open #42 in repo Y are DIFFERENT PRs.
-// Keying by pr_number alone would let repo X's `merged` shadow repo Y's `open`
-// (the board would treat Y's #42 as merged → false phantom, or hide its orphaned
-// open PR). Since the board descriptor carries no per-ticket repo, we cannot say
-// WHICH #42 a ticket points at — so a number seen in TWO distinct repos is marked
-// `ambiguous:true`, and board-health skips it rather than borrow the wrong repo's
-// status. Each entry also carries its `repo` for downstream repo+number matching.
+// MULTI-REPO COLLISION (CTL-1157, Codex #4): a (repo, pr_number) pair — NOT
+// pr_number alone — identifies a PR. With filter_state rows from >1 GitHub repo,
+// PR numbers collide: a merged #42 in repo X and an open #42 in repo Y are
+// DIFFERENT PRs. Keying by pr_number ALONE forced an `ambiguous` skip whenever a
+// number appeared in two repos — which is safe for phantom-merged (no false
+// phantom) but HID a genuine orphaned open PR whenever an unrelated repo happened
+// to reuse the number. The proper fix is COMPOSITE keying: this returns a nested
+// `Map<number, Map<repo, {status,updatedAt,repo}>>`, so a caller that knows the
+// ticket's repo (board-health resolves it from the registry) can look up the
+// EXACT (repo, number) entry and never confuse two repos' #42. The number-only
+// `ambiguous` fallback now exists ONLY at lookup time and ONLY when the ticket's
+// repo is genuinely underivable AND the number collides (board-health's
+// lookupPrStatus owns that last-resort).
 //
-// Returns Map<number,{status,updatedAt,repo,ambiguous}> (frozen once at
-// board-assemble time). Empty map when filter_state has no rows → the new
-// invariants stay observable:false (shadow-safe by default).
+// Returns Map<number, Map<repoKey, {status,updatedAt,repo}>> (frozen once at
+// board-assemble time). The inner key is the repo string ("" for a null/empty
+// repo) so single-repo installs always have exactly one inner entry per number
+// (no collision → number-only lookup stays byte-identical). Empty outer map when
+// filter_state has no rows → the new invariants stay observable:false
+// (shadow-safe by default).
 export function getAllPrStatuses() {
   const rows = ensure()
     .prepare(`SELECT pr_number, repo, status, updated_at FROM filter_state ORDER BY updated_at DESC`)
@@ -675,22 +682,21 @@ export function getAllPrStatuses() {
   const map = new Map();
   for (const row of rows) {
     if (row.pr_number == null) continue;
-    const existing = map.get(row.pr_number);
-    if (!existing) {
-      map.set(row.pr_number, {
-        status: row.status,
-        updatedAt: row.updated_at,
-        repo: row.repo ?? null,
-        ambiguous: false,
-      });
-      continue;
+    const repo = row.repo ?? null;
+    const repoKey = repo ?? "";
+    let byRepo = map.get(row.pr_number);
+    if (!byRepo) {
+      byRepo = new Map();
+      map.set(row.pr_number, byRepo);
     }
-    // A repeated row for the SAME repo is just an older lifecycle state — the
-    // most-recent already won. A row for a DIFFERENT repo is a colliding PR number
-    // across repos → ambiguous (board-health must not match it to one repo).
-    if (row.repo != null && existing.repo != null && row.repo !== existing.repo) {
-      existing.ambiguous = true;
-    }
+    // First row for a given (repo, number) wins (ORDER BY updated_at DESC); a later
+    // row for the SAME (repo, number) is an older lifecycle state → keep the newer.
+    if (byRepo.has(repoKey)) continue;
+    byRepo.set(repoKey, {
+      status: row.status,
+      updatedAt: row.updated_at,
+      repo,
+    });
   }
   return map;
 }

--- a/plugins/dev/scripts/broker/broker-state.mjs
+++ b/plugins/dev/scripts/broker/broker-state.mjs
@@ -22,14 +22,33 @@ import { resolve, dirname } from "node:path";
 import { mkdirSync } from "node:fs";
 
 let db = null;
+// CTL-1157 (Codex round-6 follow-up): track the path the singleton handle is open on.
+// openBrokerStateDb ignored a NEW dbPath when a handle was already open, so a caller
+// that left the singleton open on path A (e.g. the exec-core scheduler's board-health
+// binding, which now opens the DB every tick) would hand path A's handle to a later
+// caller/test that asked for path B — its reads/writes then silently hit the wrong DB
+// (the gateway-read cross-file test pollution). Reopen when the requested path differs.
+// Production is unaffected: every real caller uses DEFAULT_DB_PATH, so the path always
+// matches and the handle is reused verbatim.
+let dbOpenPath = null;
 
 const CATALYST_DIR = process.env.CATALYST_DIR ?? `${homedir()}/catalyst`;
 const DEFAULT_DB_PATH = resolve(CATALYST_DIR, "filter-state.db");
 
 export function openBrokerStateDb(dbPath = DEFAULT_DB_PATH) {
-  if (db) return db;
+  if (db && dbOpenPath === dbPath) return db; // already open on the SAME path → reuse
+  if (db && dbOpenPath !== dbPath) {
+    // Open on a DIFFERENT path → close the stale handle and reopen on the requested one.
+    try {
+      db.close();
+    } catch {
+      /* best-effort */
+    }
+    db = null;
+  }
   mkdirSync(dirname(dbPath), { recursive: true });
   db = new Database(dbPath, { create: true });
+  dbOpenPath = dbPath;
   db.run("PRAGMA journal_mode=WAL");
   // CTL-821: don't fail instantly on transient WAL contention (live broker +
   // orch-monitor + test drivers can hold handles on the same file).
@@ -229,6 +248,7 @@ export function closeBrokerStateDb() {
     db.close();
     db = null;
   }
+  dbOpenPath = null;
 }
 
 function ensure() {

--- a/plugins/dev/scripts/broker/broker-state.mjs
+++ b/plugins/dev/scripts/broker/broker-state.mjs
@@ -649,6 +649,27 @@ export function getAllTicketDescriptors({ includeRemoved = false } = {}) {
   return ensure().prepare(sql).all().map(rowToTicketDescriptor);
 }
 
+// getAllPrStatuses — CTL-1157: one batch read of the filter_state lifecycle
+// table for board-health's phantom-merged-PR / orphaned-open-PR invariants. A
+// PR's status walks a monotone lifecycle (open → merged → deploying → deployed/
+// failed), so for each pr_number the most-recently-updated row is the current
+// status. ORDER BY updated_at DESC + first-row-per-pr_number wins. Returns
+// Map<number,{status,updatedAt}> (frozen once at board-assemble time). Empty map
+// when filter_state has no rows → the new invariants stay observable:false
+// (shadow-safe by default).
+export function getAllPrStatuses() {
+  const rows = ensure()
+    .prepare(`SELECT pr_number, status, updated_at FROM filter_state ORDER BY updated_at DESC`)
+    .all();
+  const map = new Map();
+  for (const row of rows) {
+    if (row.pr_number != null && !map.has(row.pr_number)) {
+      map.set(row.pr_number, { status: row.status, updatedAt: row.updated_at });
+    }
+  }
+  return map;
+}
+
 // getTicketDescriptorByUuid — the UUID→identifier index lookup. Linear's
 // `remove` webhook payload carries only the entityId UUID; this resolves it to
 // the descriptor row populated by earlier create/update webhooks.

--- a/plugins/dev/scripts/broker/broker-state.test.mjs
+++ b/plugins/dev/scripts/broker/broker-state.test.mjs
@@ -23,6 +23,7 @@ import {
   upsertFilterStateOpen,
   setFilterStateMerged,
   getFilterStateByInterest,
+  getAllPrStatuses,
 } from "./broker-state.mjs";
 
 let tmpDir;
@@ -199,5 +200,35 @@ describe("filter_state (CTL-284 backward compat)", () => {
     expect(getFilterStateByInterest("coexist-1")).not.toBeNull();
     expect(getAgentBySession("coexist-agent")).not.toBeNull();
     expect(getTicketState("CTL-1")).not.toBeNull();
+  });
+});
+
+// ─── getAllPrStatuses — (repo, pr_number) keying / collision (CTL-1157) ───────
+
+describe("getAllPrStatuses — multi-repo PR-number collision (CTL-1157)", () => {
+  test("a cross-repo PR-number collision is marked ambiguous (no silent shadow)", () => {
+    // #42 exists in TWO GitHub repos: merged in org/x, still open in org/y. They
+    // are DIFFERENT PRs. Keying by pr_number alone would let org/x's `merged`
+    // shadow org/y's `open` (the false-phantom / hidden-orphan bug). Both repos
+    // sharing #42 ⇒ the entry is ambiguous.
+    upsertFilterStateOpen({ interestId: "x-42", prNumber: 42, repo: "org/x" });
+    setFilterStateMerged("x-42", "sha-x");
+    upsertFilterStateOpen({ interestId: "y-42", prNumber: 42, repo: "org/y" });
+    const map = getAllPrStatuses();
+    expect(map.get(42).ambiguous).toBe(true);
+  });
+
+  test("a SAME-repo repeated PR number is NOT ambiguous (older lifecycle state, not a collision)", () => {
+    upsertFilterStateOpen({ interestId: "z-7a", prNumber: 7, repo: "org/z" });
+    upsertFilterStateOpen({ interestId: "z-7b", prNumber: 7, repo: "org/z" });
+    const map = getAllPrStatuses();
+    expect(map.get(7).ambiguous).toBe(false);
+    expect(map.get(7).repo).toBe("org/z");
+  });
+
+  test("a non-colliding PR carries its repo + status and stays unambiguous", () => {
+    upsertFilterStateOpen({ interestId: "solo-9", prNumber: 9, repo: "org/solo" });
+    const map = getAllPrStatuses();
+    expect(map.get(9)).toMatchObject({ status: "open", repo: "org/solo", ambiguous: false });
   });
 });

--- a/plugins/dev/scripts/broker/broker-state.test.mjs
+++ b/plugins/dev/scripts/broker/broker-state.test.mjs
@@ -203,32 +203,37 @@ describe("filter_state (CTL-284 backward compat)", () => {
   });
 });
 
-// ─── getAllPrStatuses — (repo, pr_number) keying / collision (CTL-1157) ───────
+// ─── getAllPrStatuses — composite (repo, pr_number) keying (CTL-1157, Codex #4) ─
 
-describe("getAllPrStatuses — multi-repo PR-number collision (CTL-1157)", () => {
-  test("a cross-repo PR-number collision is marked ambiguous (no silent shadow)", () => {
+describe("getAllPrStatuses — composite (repo, pr_number) keying (CTL-1157)", () => {
+  test("a cross-repo PR-number collision keeps BOTH repos' statuses (no shadowing)", () => {
     // #42 exists in TWO GitHub repos: merged in org/x, still open in org/y. They
-    // are DIFFERENT PRs. Keying by pr_number alone would let org/x's `merged`
-    // shadow org/y's `open` (the false-phantom / hidden-orphan bug). Both repos
-    // sharing #42 ⇒ the entry is ambiguous.
+    // are DIFFERENT PRs. The old number-only keying forced an `ambiguous` skip; the
+    // composite shape keeps a per-repo entry so a caller that knows the ticket's
+    // repo resolves the EXACT (repo, number) — org/x→merged, org/y→open — and never
+    // confuses the two (the false-phantom / hidden-orphan bug is gone at the source).
     upsertFilterStateOpen({ interestId: "x-42", prNumber: 42, repo: "org/x" });
     setFilterStateMerged("x-42", "sha-x");
     upsertFilterStateOpen({ interestId: "y-42", prNumber: 42, repo: "org/y" });
-    const map = getAllPrStatuses();
-    expect(map.get(42).ambiguous).toBe(true);
+    const byRepo = getAllPrStatuses().get(42);
+    expect(byRepo).toBeInstanceOf(Map);
+    expect(byRepo.size).toBe(2);
+    expect(byRepo.get("org/x")).toMatchObject({ status: "merged", repo: "org/x" });
+    expect(byRepo.get("org/y")).toMatchObject({ status: "open", repo: "org/y" });
   });
 
-  test("a SAME-repo repeated PR number is NOT ambiguous (older lifecycle state, not a collision)", () => {
+  test("a SAME-repo repeated PR number collapses to ONE inner entry (most-recent wins, not a collision)", () => {
     upsertFilterStateOpen({ interestId: "z-7a", prNumber: 7, repo: "org/z" });
     upsertFilterStateOpen({ interestId: "z-7b", prNumber: 7, repo: "org/z" });
-    const map = getAllPrStatuses();
-    expect(map.get(7).ambiguous).toBe(false);
-    expect(map.get(7).repo).toBe("org/z");
+    const byRepo = getAllPrStatuses().get(7);
+    expect(byRepo.size).toBe(1); // single repo → no collision
+    expect(byRepo.get("org/z")).toMatchObject({ status: "open", repo: "org/z" });
   });
 
-  test("a non-colliding PR carries its repo + status and stays unambiguous", () => {
+  test("a non-colliding PR carries its repo + status under its repo key", () => {
     upsertFilterStateOpen({ interestId: "solo-9", prNumber: 9, repo: "org/solo" });
-    const map = getAllPrStatuses();
-    expect(map.get(9)).toMatchObject({ status: "open", repo: "org/solo", ambiguous: false });
+    const byRepo = getAllPrStatuses().get(9);
+    expect(byRepo.size).toBe(1);
+    expect(byRepo.get("org/solo")).toMatchObject({ status: "open", repo: "org/solo" });
   });
 });

--- a/plugins/dev/scripts/broker/broker-state.test.mjs
+++ b/plugins/dev/scripts/broker/broker-state.test.mjs
@@ -22,6 +22,7 @@ import {
   // filter_state (backward compat)
   upsertFilterStateOpen,
   setFilterStateMerged,
+  setFilterStateClosed,
   getFilterStateByInterest,
   getAllPrStatuses,
 } from "./broker-state.mjs";
@@ -191,6 +192,20 @@ describe("filter_state (CTL-284 backward compat)", () => {
     const state = getFilterStateByInterest("sess-bc2");
     expect(state.status).toBe("merged");
     expect(state.mergeCommitSha).toBe("sha-abc");
+  });
+
+  // CTL-1157 (Codex round-7): a PR closed WITHOUT merging must leave 'open' so
+  // board-health's orphaned-open-PR cohort stops treating it as a stale orphan forever.
+  test("setFilterStateClosed transitions an open row to closed", () => {
+    upsertFilterStateOpen({ interestId: "sess-closed", prNumber: 503, repo: "org/repo" });
+    const res = setFilterStateClosed("sess-closed");
+    expect(res).toEqual({ interestId: "sess-closed" });
+    const state = getFilterStateByInterest("sess-closed");
+    expect(state.status).toBe("closed"); // no longer "open"
+  });
+
+  test("setFilterStateClosed is a no-op (null) when the interest has no row", () => {
+    expect(setFilterStateClosed("sess-absent")).toBeNull();
   });
 
   test("both tables coexist in the same DB file", () => {

--- a/plugins/dev/scripts/broker/router.mjs
+++ b/plugins/dev/scripts/broker/router.mjs
@@ -63,6 +63,7 @@ import {
 import {
   upsertFilterStateOpen,
   setFilterStateMerged,
+  setFilterStateClosed,
   setFilterStateDeploying,
   setFilterStateDeployed,
   setFilterStateFailed,
@@ -1347,6 +1348,16 @@ export function tryDeterministicRoute(event, interestsMap) {
     } else if (name === "github.pr.closed") {
       if (prList.includes(scope.pr) && detail.merged === false) {
         reason = `PR #${scope.pr} closed without merging`;
+        // CTL-1157 (Codex round-7): mark the filter_state row 'closed' so a PR closed
+        // WITHOUT merging stops reading as an open orphan forever (board-health's
+        // orphaned-open-PR cohort trusts filter_state.status === "open"). Without this
+        // the row stays 'open' indefinitely and recovery gets dispatched on a PR that
+        // no longer exists. Best-effort — a missing DB handle must not drop the wake.
+        try {
+          setFilterStateClosed(interestId);
+        } catch {
+          /* DB not opened */
+        }
       }
     } else if (name === "github.pr_review.submitted") {
       if (prList.includes(scope.pr)) {

--- a/plugins/dev/scripts/execution-core/board-health-seam.test.mjs
+++ b/plugins/dev/scripts/execution-core/board-health-seam.test.mjs
@@ -16,7 +16,7 @@ import { describe, test, expect, beforeEach, afterEach } from "bun:test";
 import { mkdtempSync, rmSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
-import { schedulerTick } from "./scheduler.mjs";
+import { schedulerTick, holisticBoardHealthAct } from "./scheduler.mjs";
 
 let orchDir;
 let catalystDir;
@@ -103,5 +103,97 @@ describe("schedulerTick — board-health seam (CTL-1290 §9.4)", () => {
       boardHealthPassFn: (opts) => calls.push(opts),
     });
     expect(calls.length).toBe(0);
+  });
+});
+
+// CTL-1157 (MUST-FIX 2 + GROUP-3 #3): the holistic board-health `act` loop, tested
+// pure via the extracted holisticBoardHealthAct (the daemon binds the real recovery
+// seams around it).
+describe("holisticBoardHealthAct — one real dispatch per scan, skip non-dispatch (CTL-1157)", () => {
+  const ctx = { candidates: [], boardContext: { anomaly: "wip" }, decision: { gate: { reason: "wip-spike" } } };
+
+  test("dispatches the FIRST actionable candidate and stops (exactly one dispatch)", () => {
+    const invoked = [];
+    const recorded = [];
+    const r = holisticBoardHealthAct(
+      { ...ctx, candidates: ["CTL-1", "CTL-2", "CTL-3"] },
+      {
+        shouldSkipItem: () => false,
+        invokeRecoveryPass: (cand) => { invoked.push(cand); return { dispatched: true, ticket: cand }; },
+        recordIntent: (cand, intent) => recorded.push({ cand, intent }),
+      },
+    );
+    expect(r.dispatched).toBe(true);
+    expect(r.ticket).toBe("CTL-1");
+    expect(invoked).toEqual(["CTL-1"]); // stopped after the first real dispatch
+    expect(recorded).toHaveLength(1);
+    expect(recorded[0].intent.outcome).toBe(true);
+  });
+
+  test("a ledger-latched candidate (shouldSkipItem) is skipped without invoking (MUST-FIX 2)", () => {
+    const invoked = [];
+    const r = holisticBoardHealthAct(
+      { ...ctx, candidates: ["CTL-latched", "CTL-ok"] },
+      {
+        shouldSkipItem: (cand) => cand === "CTL-latched",
+        invokeRecoveryPass: (cand) => { invoked.push(cand); return { dispatched: true, ticket: cand }; },
+        recordIntent: () => {},
+      },
+    );
+    expect(invoked).toEqual(["CTL-ok"]); // latched one never invoked
+    expect(r.ticket).toBe("CTL-ok");
+  });
+
+  test("a NON-dispatch RESULT (cap-exhausted) is a SKIP → CONTINUE to the next candidate (GROUP-3 #3)", () => {
+    // CTL-1 passes the ledger gate but its RESULT is a cap-exhausted no-op; the loop
+    // must NOT return there (which would starve the cohort) — it dispatches CTL-2.
+    const invoked = [];
+    const recorded = [];
+    const r = holisticBoardHealthAct(
+      { ...ctx, candidates: ["CTL-1", "CTL-2"] },
+      {
+        shouldSkipItem: () => false, // ledger gate does NOT see the event-counted cycle cap
+        invokeRecoveryPass: (cand) => {
+          invoked.push(cand);
+          return cand === "CTL-1"
+            ? { dispatched: false, reason: "recovery-pass-cycle-cap-exhausted" }
+            : { dispatched: true, ticket: cand };
+        },
+        recordIntent: (cand, intent) => recorded.push({ cand, intent }),
+      },
+    );
+    expect(invoked).toEqual(["CTL-1", "CTL-2"]); // continued past the cap-exhausted one
+    expect(r.dispatched).toBe(true);
+    expect(r.ticket).toBe("CTL-2");
+    // Both attempts recorded an intent (cooldown started on the failure too).
+    expect(recorded.map((x) => x.cand)).toEqual(["CTL-1", "CTL-2"]);
+    expect(recorded[0].intent.outcome).toBe(false);
+  });
+
+  test("ALL candidates non-dispatch → {dispatched:false, all-candidates-cooldown} (no starvation, no false dispatch)", () => {
+    const r = holisticBoardHealthAct(
+      { ...ctx, candidates: ["CTL-1", "CTL-2"] },
+      {
+        shouldSkipItem: () => false,
+        invokeRecoveryPass: () => ({ dispatched: false, reason: "recovery-pass-cycle-cap-exhausted" }),
+        recordIntent: () => {},
+      },
+    );
+    expect(r.dispatched).toBe(false);
+    expect(r.reason).toBe("all-candidates-cooldown");
+  });
+
+  test("empty cohort falls back to the anchor", () => {
+    const invoked = [];
+    const r = holisticBoardHealthAct(
+      { anchor: "CTL-anchor", candidates: [], boardContext: null, decision: null },
+      {
+        shouldSkipItem: () => false,
+        invokeRecoveryPass: (cand) => { invoked.push(cand); return { dispatched: true, ticket: cand }; },
+        recordIntent: () => {},
+      },
+    );
+    expect(invoked).toEqual(["CTL-anchor"]);
+    expect(r.ticket).toBe("CTL-anchor");
   });
 });

--- a/plugins/dev/scripts/execution-core/board-health.mjs
+++ b/plugins/dev/scripts/execution-core/board-health.mjs
@@ -500,6 +500,10 @@ function checkPhantomMergedPr(b) {
     const prNum = prNumberOf(d);
     if (prNum == null) continue;
     const pr = map.get(prNum);
+    // CTL-1157 multi-repo: a PR number that collides across repos is `ambiguous` —
+    // we cannot tell WHICH repo's #N this ticket points at, so skip rather than
+    // borrow the wrong repo's `merged` status and manufacture a false phantom.
+    if (pr && pr.ambiguous) continue;
     if (pr && PR_MERGED_RE.test(String(pr.status))) flagged.push(id);
   }
   return invariant(
@@ -532,6 +536,9 @@ function checkOrphanedOpenPr(b, t) {
     const prNum = prNumberOf(d);
     if (prNum == null) continue;
     const pr = map.get(prNum);
+    // CTL-1157 multi-repo: an ambiguous (cross-repo collision) PR number can't be
+    // matched to this ticket's repo — skip it rather than read another repo's status.
+    if (pr && pr.ambiguous) continue;
     if (!pr || String(pr.status).toLowerCase() !== "open") continue;
     if (liveTickets.has(id)) continue; // a worker is on it → not orphaned
     const updatedMs = pr.updatedAt ? Date.parse(pr.updatedAt) : NaN;

--- a/plugins/dev/scripts/execution-core/board-health.mjs
+++ b/plugins/dev/scripts/execution-core/board-health.mjs
@@ -79,11 +79,56 @@ const PR_MERGED_RE = /^(merged|deployed)$/i;
 const NEEDS_HUMAN_LABEL_RE = /needs.?human/i;
 const NEEDS_HUMAN_STATUSES = new Set(["needs-human", "needs_human", "stalled"]);
 
-// prNumberOf / prStatusOf — read a ticket descriptor's linked PR number and its
-// current lifecycle status from the frozen prStatusMap (keyed by pr_number).
+// prNumberOf — read a ticket descriptor's linked PR number.
 function prNumberOf(d) {
   const n = d?.prNumber ?? d?.pr_number ?? null;
   return n == null ? null : Number(n);
+}
+
+// lookupPrStatus — resolve the lifecycle status of (prNumber, repo) against the
+// composite prStatusMap (`Map<number, Map<repoKey, {status,updatedAt,repo}>>`,
+// produced by broker-state.getAllPrStatuses). The disambiguation rules (CTL-1157,
+// Codex #4):
+//   • No entry for the number → null (not observable for this ticket).
+//   • Exactly ONE repo holds the number → return it (no collision; this is the
+//     N=1 / single-repo path → byte-identical to the old number-only lookup,
+//     whether or not the ticket's repo was derived).
+//   • The number COLLIDES across repos AND the ticket's repo is known → return
+//     that repo's entry (or null when the ticket's own repo has no such PR). A
+//     cross-repo #-collision NO LONGER hides the ticket's real PR.
+//   • The number collides AND the ticket's repo is genuinely underivable → the
+//     TRUE residual: we cannot pick → return {ambiguous:true} so the cohort skips
+//     rather than borrow the wrong repo's status.
+// `repo` is the ticket's GitHub "owner/repo" (or null when underivable).
+function lookupPrStatus(map, prNumber, repo) {
+  if (!(map instanceof Map)) return null;
+  const byRepo = map.get(prNumber);
+  if (!(byRepo instanceof Map) || byRepo.size === 0) return null;
+  // No collision: exactly one repo owns this number → number-only resolution.
+  if (byRepo.size === 1) {
+    const [only] = byRepo.values();
+    return only;
+  }
+  // Collision: ≥2 repos share this number. Disambiguate by the ticket's repo.
+  if (repo != null && repo !== "") {
+    // Known repo → the ticket's OWN repo's #N, or null when it has none.
+    return byRepo.get(repo) ?? null;
+  }
+  // Repo underivable + collision → the documented true residual: ambiguous skip.
+  return { status: null, updatedAt: null, repo: null, ambiguous: true };
+}
+
+// safeRepoOf — call the injected ticket→owner/repo resolver, fail-open to null
+// (a throwing/absent resolver must never abort an invariant; null → number-only
+// lookup, i.e. the pre-CTL-1157 behavior).
+function safeRepoOf(resolver, id) {
+  if (typeof resolver !== "function") return null;
+  try {
+    const r = resolver(id);
+    return typeof r === "string" && r.length > 0 ? r : null;
+  } catch {
+    return null;
+  }
 }
 function labelsOf(d) {
   const l = d?.labels;
@@ -201,6 +246,13 @@ export function assembleBoardState({
   capacity = { maxParallel: 0, liveCount: 0, freeSlots: 0 },
   readEventRing = () => [],
   ownerForTicket = null,
+  // CTL-1157 (Codex #4): resolve a stuck ticket → its GitHub "owner/repo" so the
+  // phantom/orphaned-PR cohorts look up the EXACT (repo, number) entry in the
+  // composite prStatusMap instead of skipping a cross-repo #-collision. Daemon-
+  // bound at the scheduler call site (teamOf → registry repoRoot →
+  // ownerRepoFromRepoRoot); null default ⇒ repo underivable ⇒ number-only lookup
+  // (N=1 byte-identical; a true collision with no repo stays the ambiguous skip).
+  repoForTicket = null,
   getReconcileMarkers = () => ({}),
   // CTL-1157: PR-lifecycle status map (filter_state). Empty Map default ⇒ the
   // phantom-merged-PR / orphaned-open-PR invariants stay observable:false (the
@@ -279,6 +331,9 @@ export function assembleBoardState({
     prStatusMap: mode === "off" ? new Map() : safe(() => getPrStatusMap(), new Map()),
     ring: deriveRing(safe(() => readEventRing({ orchDir }), []), nowMs),
     ownerForTicket: typeof ownerForTicket === "function" ? ownerForTicket : null,
+    // CTL-1157 (Codex #4): the ticket→owner/repo resolver for the composite
+    // (repo, number) PR-status lookup. Null when unbound (number-only fallback).
+    repoForTicket: typeof repoForTicket === "function" ? repoForTicket : null,
     now: nowMs,
   });
 }
@@ -499,10 +554,12 @@ function checkPhantomMergedPr(b) {
     if (!state || !PR_STATE_RE.test(String(state))) continue;
     const prNum = prNumberOf(d);
     if (prNum == null) continue;
-    const pr = map.get(prNum);
-    // CTL-1157 multi-repo: a PR number that collides across repos is `ambiguous` —
-    // we cannot tell WHICH repo's #N this ticket points at, so skip rather than
-    // borrow the wrong repo's `merged` status and manufacture a false phantom.
+    // CTL-1157 (Codex #4) multi-repo: resolve the ticket's repo and look up the
+    // EXACT (repo, number) status. A cross-repo #-collision is disambiguated by
+    // the ticket's repo; only a collision with a genuinely underivable repo stays
+    // `ambiguous` and is skipped (never borrow the wrong repo's `merged` status).
+    const repo = b.repoForTicket ? safeRepoOf(b.repoForTicket, id) : null;
+    const pr = lookupPrStatus(map, prNum, repo);
     if (pr && pr.ambiguous) continue;
     if (pr && PR_MERGED_RE.test(String(pr.status))) flagged.push(id);
   }
@@ -535,9 +592,12 @@ function checkOrphanedOpenPr(b, t) {
   for (const [id, d] of b.ticketsById) {
     const prNum = prNumberOf(d);
     if (prNum == null) continue;
-    const pr = map.get(prNum);
-    // CTL-1157 multi-repo: an ambiguous (cross-repo collision) PR number can't be
-    // matched to this ticket's repo — skip it rather than read another repo's status.
+    // CTL-1157 (Codex #4) multi-repo: resolve the ticket's repo and look up the
+    // EXACT (repo, number) status. With the repo known, a cross-repo #-collision
+    // NO LONGER hides the ticket's genuine orphaned open PR (the missed-detection
+    // bug); only a collision whose repo is genuinely underivable stays `ambiguous`.
+    const repo = b.repoForTicket ? safeRepoOf(b.repoForTicket, id) : null;
+    const pr = lookupPrStatus(map, prNum, repo);
     if (pr && pr.ambiguous) continue;
     if (!pr || String(pr.status).toLowerCase() !== "open") continue;
     if (liveTickets.has(id)) continue; // a worker is on it → not orphaned
@@ -865,6 +925,7 @@ export function boardHealthPass({
   capacity,
   readEventRing,
   ownerForTicket,
+  repoForTicket, // CTL-1157 (Codex #4): ticket→owner/repo resolver (daemon-bound)
   getReconcileMarkers,
   getPrStatusMap, // CTL-1157: filter_state PR-status reader (daemon-bound)
   deadHosts, // CTL-1157: provably-dead host set (daemon-computed)
@@ -884,7 +945,7 @@ export function boardHealthPass({
 
   const board = assembleBoardState({
     orchDir, getBoard, getWorkerSignals, getEligible,
-    roster, self, multiHost, capacity, readEventRing, ownerForTicket, getReconcileMarkers,
+    roster, self, multiHost, capacity, readEventRing, ownerForTicket, repoForTicket, getReconcileMarkers,
     getPrStatusMap, deadHosts, mode, now,
   });
   const invariants = evaluateInvariants(board, { mode });

--- a/plugins/dev/scripts/execution-core/board-health.mjs
+++ b/plugins/dev/scripts/execution-core/board-health.mjs
@@ -710,7 +710,17 @@ function checkNeedsHumanPile(b) {
   for (const s of b.signals) {
     if (!s.ticket) continue;
     const st = s.status != null ? String(s.status).toLowerCase() : null;
-    if (st && NEEDS_HUMAN_STATUSES.has(st)) flagged.push(s.ticket);
+    if (!(st && NEEDS_HUMAN_STATUSES.has(st))) continue;
+    // CTL-1157 F (Codex round-5): a Done/Canceled/Duplicate ticket can retain a stale
+    // needs-human/stalled worker signal, and signal-reader prefers a NON-terminal
+    // needs-human signal over the terminal phase signal — so without this an already-
+    // terminal ticket becomes a tier-1 board-health anchor and gets a recovery-pass
+    // dispatched in enforce. Mirror the label path's terminal exclusion (line ~684).
+    // Fail-OPEN when the descriptor is absent (uncached): we skip ONLY when we can
+    // CONFIRM the ticket is terminal, never dropping a genuinely stuck ticket.
+    const d = b.ticketsById?.get?.(s.ticket) ?? null;
+    if (d && isTerminalLinearState(d)) continue;
+    flagged.push(s.ticket);
   }
   return invariant(
     flagged.length === 0,

--- a/plugins/dev/scripts/execution-core/board-health.mjs
+++ b/plugins/dev/scripts/execution-core/board-health.mjs
@@ -206,6 +206,11 @@ export function assembleBoardState({
   // phantom-merged-PR / orphaned-open-PR invariants stay observable:false (the
   // shadow-first seam: wiring lands before the invariants begin observing).
   getPrStatusMap = () => new Map(),
+  // CTL-1157 off-gate: the run mode threads in so `off` is provably DARK. In off
+  // we never invoke getPrStatusMap() (the getAllPrStatuses() filter_state SELECT
+  // must not run), and evaluateInvariants reads board.mode to skip the cohort
+  // checks — together making an off scan byte-identical to origin/main.
+  mode = undefined,
   now = () => Date.now(),
 } = {}) {
   const nowMs = now();
@@ -259,13 +264,19 @@ export function assembleBoardState({
     deadHosts: Array.isArray(deadHosts) ? deadHosts : [],
     self: self ?? "",
     multiHost: !!multiHost,
+    // CTL-1157 off-gate: carried so evaluateInvariants can skip the cohort checks
+    // in off without re-threading mode through every call site.
+    mode,
     capacity: {
       maxParallel: capacity?.maxParallel ?? 0,
       liveCount: capacity?.liveCount ?? 0,
       freeSlots: capacity?.freeSlots ?? 0,
     },
     reconcileMarkers: safe(() => getReconcileMarkers(), {}),
-    prStatusMap: safe(() => getPrStatusMap(), new Map()),
+    // CTL-1157 off-gate: in off the filter_state PR-status SELECT must NOT run —
+    // skip getPrStatusMap() entirely so off is byte-identical to origin/main (the
+    // phantom/orphaned-PR invariants also stay out of evaluateInvariants in off).
+    prStatusMap: mode === "off" ? new Map() : safe(() => getPrStatusMap(), new Map()),
     ring: deriveRing(safe(() => readEventRing({ orchDir }), []), nowMs),
     ownerForTicket: typeof ownerForTicket === "function" ? ownerForTicket : null,
     now: nowMs,
@@ -273,7 +284,7 @@ export function assembleBoardState({
 }
 
 // ── (2) evaluateInvariants — PURE. Each check fails-open on a throw. ─────────
-export function evaluateInvariants(boardState, { thresholds = DEFAULT_THRESHOLDS } = {}) {
+export function evaluateInvariants(boardState, { thresholds = DEFAULT_THRESHOLDS, mode = boardState?.mode } = {}) {
   const checks = {
     cacheCoherence: () => checkCacheCoherence(boardState),
     dispatchLiveness: () => checkDispatchLiveness(boardState, thresholds),
@@ -282,13 +293,27 @@ export function evaluateInvariants(boardState, { thresholds = DEFAULT_THRESHOLDS
     projectSilence: () => checkProjectSilence(boardState, thresholds),
     rateLimitHeadroom: () => checkRateLimitHeadroom(boardState),
     strandedNode: () => checkStrandedNode(boardState),
-    // CTL-1157: the three stuck cohorts board-health was blind to + the
-    // status-based needs-human catch-all (Workstream B).
-    phantomMergedPr: () => checkPhantomMergedPr(boardState),
-    orphanedOpenPr: () => checkOrphanedOpenPr(boardState, thresholds),
-    frozenNeedsHuman: () => checkFrozenNeedsHuman(boardState, thresholds),
-    needsHumanPile: () => checkNeedsHumanPile(boardState),
   };
+  // CTL-1157 off-gate: the four NEW cohort invariants run ONLY in shadow/enforce
+  // — never in off. In off this set is omitted entirely, so the board-scan event's
+  // details.invariants is byte-identical to origin/main (the legacy 7 keys only),
+  // and checkNeedsHumanPile (always-observable, status-based) no longer runs in
+  // off — it is gated here exactly like its three cohort siblings. SHADOW DOES run
+  // them: that is intentional read-only telemetry (the OTEL before/after baseline);
+  // the no-action guarantee is enforced separately in boardHealthPass (act is
+  // reached ONLY in enforce). `mode` defaults from boardState.mode (set by
+  // assembleBoardState); an undefined mode (bare unit call) keeps the legacy
+  // behavior of running them.
+  if (mode !== "off") {
+    Object.assign(checks, {
+      // CTL-1157: the three stuck cohorts board-health was blind to + the
+      // status-based needs-human catch-all (Workstream B).
+      phantomMergedPr: () => checkPhantomMergedPr(boardState),
+      orphanedOpenPr: () => checkOrphanedOpenPr(boardState, thresholds),
+      frozenNeedsHuman: () => checkFrozenNeedsHuman(boardState, thresholds),
+      needsHumanPile: () => checkNeedsHumanPile(boardState),
+    });
+  }
   const out = {};
   for (const [name, fn] of Object.entries(checks)) {
     try {
@@ -608,7 +633,7 @@ function decision(gateDecision, reason, invariantsFailed, moves) {
 
 // ── (4) proposeMoves — PURE. Maps failed invariants → tiered proposals. Never
 // executes. The tier is "does this change the SYSTEM or just unstick a THING?"
-export function proposeMoves(invariants, b) {
+export function proposeMoves(invariants, _b) {
   const tier1 = [];
   const tier2 = [];
   const tier3 = [];
@@ -853,9 +878,9 @@ export function boardHealthPass({
   const board = assembleBoardState({
     orchDir, getBoard, getWorkerSignals, getEligible,
     roster, self, multiHost, capacity, readEventRing, ownerForTicket, getReconcileMarkers,
-    getPrStatusMap, deadHosts, now,
+    getPrStatusMap, deadHosts, mode, now,
   });
-  const invariants = evaluateInvariants(board, {});
+  const invariants = evaluateInvariants(board, { mode });
   const dec = decideBoardHealth(invariants, board);
 
   try {

--- a/plugins/dev/scripts/execution-core/board-health.mjs
+++ b/plugins/dev/scripts/execution-core/board-health.mjs
@@ -150,6 +150,35 @@ function emptyMoves() {
 function isTerminalStatus(status) {
   return status != null && TERMINAL_STATUSES.has(String(status).toLowerCase());
 }
+// SLOT_FREED_STATUSES — a worker signal in one of these no longer occupies a
+// slot / is no longer live. Mirrors the scheduler's isTicketInFlight (failed /
+// stalled / aborted FREE the slot, scheduler.mjs) and signal-reader.TERMINAL
+// (adds turn-cap-exhausted). Distinct from TERMINAL_STATUSES (success-like only,
+// used by worker-age): a failed/stalled worker is NOT terminal-success but is
+// also NOT live, so a PR stuck behind a dead/failed worker reads as orphaned.
+const SLOT_FREED_STATUSES = new Set([
+  ...TERMINAL_STATUSES,
+  "failed",
+  "stalled",
+  "aborted",
+  "turn-cap-exhausted",
+]);
+// isLiveWorkerStatus — true when a worker signal still represents active,
+// slot-occupying work (not terminal-success AND not failed/stalled/aborted).
+function isLiveWorkerStatus(status) {
+  return status != null && !SLOT_FREED_STATUSES.has(String(status).toLowerCase());
+}
+// isTerminalLinearState — the ticket's Linear workflow state is terminal
+// (Done/Canceled/Duplicate/merged). Reuses the same terminal-state pattern the
+// blocked-tree walk uses (BLOCKER_DONE_RE) and mirrors the reconcile's
+// Done/Canceled/Duplicate exclusion (linear-reconcile.mjs terminalStates), so
+// board-health never proposes recovery for already-terminal work whose only
+// remaining signal is a stale cached label (the CTL-1157/1162 stale-label class
+// that terminal-needs-human-reconcile strips lazily).
+function isTerminalLinearState(d) {
+  const state = d?.state ?? d?.linear_state ?? null;
+  return state != null && BLOCKER_DONE_RE.test(String(state));
+}
 function dedupeFlagged(invariants) {
   const seen = new Set();
   for (const v of Object.values(invariants)) {
@@ -585,8 +614,12 @@ function checkOrphanedOpenPr(b, t) {
   if (!(map instanceof Map) || map.size === 0) {
     return invariant(true, 0, false, [], "no PR-status map → orphaned open-PR not observable");
   }
+  // A worker only counts as "live" (→ NOT orphaned) when it still occupies a
+  // slot. failed/stalled/aborted FREE the slot (isTicketInFlight), so a PR stuck
+  // behind a dead/failed worker is exactly the orphaned case this cohort catches
+  // — do NOT let a terminal-FAILURE signal mask it as "has a live worker".
   const liveTickets = new Set(
-    b.signals.filter((s) => s.ticket && !isTerminalStatus(s.status)).map((s) => s.ticket),
+    b.signals.filter((s) => s.ticket && isLiveWorkerStatus(s.status)).map((s) => s.ticket),
   );
   const flagged = [];
   for (const [id, d] of b.ticketsById) {
@@ -628,6 +661,11 @@ function checkFrozenNeedsHuman(b, t) {
     const labels = labelsOf(d);
     if (labels) haveLabels = true;
     if (!labels || !labels.some((l) => NEEDS_HUMAN_LABEL_RE.test(labelName(l)))) continue;
+    // A Done/Canceled/Duplicate ticket can keep a stale cached needs-human label
+    // until terminal-needs-human-reconcile strips it. Flagging it purely by age
+    // would propose recovery for already-terminal work — mirror the reconcile's
+    // terminal-state exclusion and skip it (the CTL-1157/1162 stale-label class).
+    if (isTerminalLinearState(d)) continue;
     const updatedAt = d.updatedAt ?? d.updated_at ?? null;
     const updatedMs = updatedAt ? Date.parse(updatedAt) : NaN;
     const ageMs = Number.isFinite(updatedMs) ? b.now - updatedMs : null;

--- a/plugins/dev/scripts/execution-core/board-health.mjs
+++ b/plugins/dev/scripts/execution-core/board-health.mjs
@@ -641,6 +641,14 @@ function checkOrphanedOpenPr(b, t) {
   for (const [id, d] of b.ticketsById) {
     const prNum = prNumberOf(d);
     if (prNum == null) continue;
+    // CTL-1157 (Codex round-6): skip a ticket already in a terminal Linear state
+    // (Done/Canceled/Duplicate). getBoard = getAllTicketDescriptors({includeRemoved:false})
+    // only drops removed_at rows, NOT terminal ones, so a terminal ticket whose PR was
+    // never merged/closed still carries an "open" filter_state row — without this guard
+    // it becomes a tier-1 orphaned-PR anchor and gets a recovery-pass dispatched on
+    // already-finished work (a wasted slot, recurring every cooldown). Mirrors the
+    // terminal exclusion the frozen-needs-human + needs-human-pile cohorts already apply.
+    if (isTerminalLinearState(d)) continue;
     // CTL-1157 (Codex #4) multi-repo: resolve the ticket's repo and look up the
     // EXACT (repo, number) status. With the repo known, a cross-repo #-collision
     // NO LONGER hides the ticket's genuine orphaned open PR (the missed-detection

--- a/plugins/dev/scripts/execution-core/board-health.mjs
+++ b/plugins/dev/scripts/execution-core/board-health.mjs
@@ -41,6 +41,10 @@ const DEFAULT_THRESHOLDS = {
   dispatchStallMs: Number(process.env.CATALYST_BH_DISPATCH_STALL_MS) || 10 * 60_000,
   workerAgeMs: Number(process.env.CATALYST_BH_WORKER_AGE_MS) || 4 * 3_600_000,
   projectSilenceMs: Number(process.env.CATALYST_BH_PROJECT_SILENCE_MS) || 24 * 3_600_000,
+  // CTL-1157: an open PR with no live worker is "orphaned" past this age; a
+  // needs-human-labelled ticket is "frozen" past this age. 48h defaults.
+  orphanedPrAgeMs: Number(process.env.CATALYST_BH_ORPHANED_PR_MS) || 48 * 3_600_000,
+  frozenNeedsHumanMs: Number(process.env.CATALYST_BH_FROZEN_NH_MS) || 48 * 3_600_000,
 };
 
 // single-LLM cadence floor: most ticks are a near-instant no-op (cheap gates),
@@ -65,6 +69,29 @@ const PHASE_NORMAL_MS = {
 const TERMINAL_STATUSES = new Set(["complete", "completed", "done", "merged", "skipped"]);
 // linear states a blocker can sit in and still NOT be a dead chain.
 const BLOCKER_DONE_RE = /done|complete|merged|cancel|duplicate/i;
+
+// CTL-1157 cohort matchers. PR_STATE_RE = a Linear state that means "a PR is
+// open/in review" (the phantom-merged-PR cohort lives here); PR_MERGED_RE = a
+// filter_state status that means the PR already landed/shipped.
+const PR_STATE_RE = /^pr$|in.?review/i;
+const PR_MERGED_RE = /^(merged|deployed)$/i;
+// label/status forms of "needs a human".
+const NEEDS_HUMAN_LABEL_RE = /needs.?human/i;
+const NEEDS_HUMAN_STATUSES = new Set(["needs-human", "needs_human", "stalled"]);
+
+// prNumberOf / prStatusOf — read a ticket descriptor's linked PR number and its
+// current lifecycle status from the frozen prStatusMap (keyed by pr_number).
+function prNumberOf(d) {
+  const n = d?.prNumber ?? d?.pr_number ?? null;
+  return n == null ? null : Number(n);
+}
+function labelsOf(d) {
+  const l = d?.labels;
+  return Array.isArray(l) ? l : null;
+}
+function labelName(l) {
+  return String(l?.name ?? l ?? "");
+}
 
 let _lastRunMs = 0; // host-local throttle state (mirrors unstuck-sweep)
 
@@ -164,12 +191,21 @@ export function assembleBoardState({
   getWorkerSignals = () => [],
   getEligible = () => [],
   roster = [],
+  // CTL-1157 (MUST-FIX 1): the provably-dead host set — hosts whose heartbeat is
+  // stale past the grace window. The daemon computes it from computeSurvivingRoster
+  // (scheduler.mjs); empty default keeps the holistic foreign-failover unreachable
+  // (shadow-safe AND N=1-safe).
+  deadHosts = [],
   self = "",
   multiHost = false,
   capacity = { maxParallel: 0, liveCount: 0, freeSlots: 0 },
   readEventRing = () => [],
   ownerForTicket = null,
   getReconcileMarkers = () => ({}),
+  // CTL-1157: PR-lifecycle status map (filter_state). Empty Map default ⇒ the
+  // phantom-merged-PR / orphaned-open-PR invariants stay observable:false (the
+  // shadow-first seam: wiring lands before the invariants begin observing).
+  getPrStatusMap = () => new Map(),
   now = () => Date.now(),
 } = {}) {
   const nowMs = now();
@@ -199,6 +235,10 @@ export function assembleBoardState({
       updatedAt,
       ageMs: Number.isFinite(updatedMs) ? nowMs - updatedMs : null,
       host: s.host ?? s.owner_host ?? null,
+      // CTL-1157: preserve the worker's typed failure reason so the delegate's
+      // injected brief carries it per-ticket (consumed by the stuck-PR cohort
+      // brief) without re-reading each signal file.
+      failureReason: s.raw?.failureReason ?? s.failureReason ?? null,
     };
   });
 
@@ -216,6 +256,7 @@ export function assembleBoardState({
     signals,
     eligible,
     roster: Array.isArray(roster) ? roster : [],
+    deadHosts: Array.isArray(deadHosts) ? deadHosts : [],
     self: self ?? "",
     multiHost: !!multiHost,
     capacity: {
@@ -224,6 +265,7 @@ export function assembleBoardState({
       freeSlots: capacity?.freeSlots ?? 0,
     },
     reconcileMarkers: safe(() => getReconcileMarkers(), {}),
+    prStatusMap: safe(() => getPrStatusMap(), new Map()),
     ring: deriveRing(safe(() => readEventRing({ orchDir }), []), nowMs),
     ownerForTicket: typeof ownerForTicket === "function" ? ownerForTicket : null,
     now: nowMs,
@@ -240,6 +282,12 @@ export function evaluateInvariants(boardState, { thresholds = DEFAULT_THRESHOLDS
     projectSilence: () => checkProjectSilence(boardState, thresholds),
     rateLimitHeadroom: () => checkRateLimitHeadroom(boardState),
     strandedNode: () => checkStrandedNode(boardState),
+    // CTL-1157: the three stuck cohorts board-health was blind to + the
+    // status-based needs-human catch-all (Workstream B).
+    phantomMergedPr: () => checkPhantomMergedPr(boardState),
+    orphanedOpenPr: () => checkOrphanedOpenPr(boardState, thresholds),
+    frozenNeedsHuman: () => checkFrozenNeedsHuman(boardState, thresholds),
+    needsHumanPile: () => checkNeedsHumanPile(boardState),
   };
   const out = {};
   for (const [name, fn] of Object.entries(checks)) {
@@ -411,6 +459,122 @@ function checkStrandedNode(b) {
   );
 }
 
+// #7 — phantom merged-PR (CTL-1157). A ticket sitting in a PR/in-review Linear
+// state whose linked PR has already merged/deployed — the GitHub-PR→Done
+// automation was removed (multi-PR tickets falsely went Done on first merge), so
+// nothing advances these now. Empty prStatusMap ⇒ observable:false (shadow-safe).
+function checkPhantomMergedPr(b) {
+  const map = b.prStatusMap;
+  if (!(map instanceof Map) || map.size === 0) {
+    return invariant(true, 0, false, [], "no PR-status map → phantom merged-PR not observable");
+  }
+  const flagged = [];
+  for (const [id, d] of b.ticketsById) {
+    const state = d.state ?? d.linear_state ?? null;
+    if (!state || !PR_STATE_RE.test(String(state))) continue;
+    const prNum = prNumberOf(d);
+    if (prNum == null) continue;
+    const pr = map.get(prNum);
+    if (pr && PR_MERGED_RE.test(String(pr.status))) flagged.push(id);
+  }
+  return invariant(
+    flagged.length === 0,
+    flagged.length,
+    true,
+    flagged,
+    flagged.length
+      ? `${flagged.length} ticket(s) in a PR state with an already-merged/deployed PR`
+      : "no phantom merged-PR tickets",
+  );
+}
+
+// #8 — orphaned open PR (CTL-1157). An open PR whose ticket has no live (non-
+// terminal) worker and whose last activity is past the orphan-age threshold —
+// "nothing rots silently". filter_state.updated_at is the last WEBHOOK, not last
+// PR activity (a freshly-rebased PR has no push webhook), so this is a
+// conservative SIGNAL: the delegate MUST `gh pr view` before acting. Empty map ⇒
+// observable:false.
+function checkOrphanedOpenPr(b, t) {
+  const map = b.prStatusMap;
+  if (!(map instanceof Map) || map.size === 0) {
+    return invariant(true, 0, false, [], "no PR-status map → orphaned open-PR not observable");
+  }
+  const liveTickets = new Set(
+    b.signals.filter((s) => s.ticket && !isTerminalStatus(s.status)).map((s) => s.ticket),
+  );
+  const flagged = [];
+  for (const [id, d] of b.ticketsById) {
+    const prNum = prNumberOf(d);
+    if (prNum == null) continue;
+    const pr = map.get(prNum);
+    if (!pr || String(pr.status).toLowerCase() !== "open") continue;
+    if (liveTickets.has(id)) continue; // a worker is on it → not orphaned
+    const updatedMs = pr.updatedAt ? Date.parse(pr.updatedAt) : NaN;
+    const ageMs = Number.isFinite(updatedMs) ? b.now - updatedMs : null;
+    if (ageMs != null && ageMs > t.orphanedPrAgeMs) flagged.push(id);
+  }
+  return invariant(
+    flagged.length === 0,
+    flagged.length,
+    true,
+    flagged,
+    flagged.length
+      ? `${flagged.length} open PR(s) with no live worker past ${Math.round(t.orphanedPrAgeMs / 3_600_000)}h`
+      : "no orphaned open PRs",
+    { caveat: "filter_state.updated_at is last-webhook, not last-PR-activity — verify with gh pr view" },
+  );
+}
+
+// #9 — frozen needs-human (CTL-1157, LABEL-based). A ticket carrying the
+// needs-human Linear label that has not moved past the frozen-age threshold.
+// Distinct from #10 needsHumanPile (STATUS-based, from the signal file). No
+// labels in the cache ⇒ observable:false.
+function checkFrozenNeedsHuman(b, t) {
+  let haveLabels = false;
+  const flagged = [];
+  for (const [id, d] of b.ticketsById) {
+    const labels = labelsOf(d);
+    if (labels) haveLabels = true;
+    if (!labels || !labels.some((l) => NEEDS_HUMAN_LABEL_RE.test(labelName(l)))) continue;
+    const updatedAt = d.updatedAt ?? d.updated_at ?? null;
+    const updatedMs = updatedAt ? Date.parse(updatedAt) : NaN;
+    const ageMs = Number.isFinite(updatedMs) ? b.now - updatedMs : null;
+    if (ageMs != null && ageMs > t.frozenNeedsHumanMs) flagged.push(id);
+  }
+  return invariant(
+    flagged.length === 0,
+    flagged.length,
+    haveLabels,
+    flagged,
+    flagged.length
+      ? `${flagged.length} needs-human ticket(s) frozen past ${Math.round(t.frozenNeedsHumanMs / 3_600_000)}h`
+      : haveLabels
+        ? "no frozen needs-human tickets"
+        : "no labels in cache → frozen needs-human not observable",
+  );
+}
+
+// #10 — needs-human pile (CTL-1157 Workstream B, STATUS-based). A worker signal
+// parked at needs-human/stalled, regardless of age — checkWorkerAge requires
+// past-phase-age and misses a FRESH needs-human, so this opens the holistic
+// delegate's catch-all for untyped stuck items that no longer dead-end at an
+// escalate latch. Always observable (it judges the signal-file status set).
+function checkNeedsHumanPile(b) {
+  const flagged = [];
+  for (const s of b.signals) {
+    if (!s.ticket) continue;
+    const st = s.status != null ? String(s.status).toLowerCase() : null;
+    if (st && NEEDS_HUMAN_STATUSES.has(st)) flagged.push(s.ticket);
+  }
+  return invariant(
+    flagged.length === 0,
+    flagged.length,
+    true,
+    flagged,
+    flagged.length ? `${flagged.length} worker(s) parked at needs-human/stalled` : "no needs-human/stalled workers",
+  );
+}
+
 // ── (3) decideBoardHealth — PURE. The cheap-gate funnel. First match wins. ───
 export function decideBoardHealth(invariants, boardState) {
   const observableFailed = Object.values(invariants).filter((v) => v.observable && !v.ok);
@@ -457,8 +621,25 @@ export function proposeMoves(invariants, b) {
   if (invariants.cacheCoherence && invariants.cacheCoherence.observable && !invariants.cacheCoherence.ok) {
     tier1.push({ move: "note-cache-drift", rationale: invariants.cacheCoherence.note });
   }
+  // CTL-1157: the most-actionable stuck work — phantom merged-PR tickets (judge
+  // Done vs reopen) and orphaned open PRs (finish or close) — is tier1 (highest
+  // anchor priority); the status-based needs-human pile is the untyped catch-all.
+  for (const t of invariants.phantomMergedPr?.flagged ?? []) {
+    if (!invariants.phantomMergedPr.ok) tier1.push({ ticket: t, move: "judge-done-or-reopen", rationale: "PR merged/deployed but ticket still in a PR/in-review state" });
+  }
+  for (const t of invariants.orphanedOpenPr?.flagged ?? []) {
+    if (!invariants.orphanedOpenPr.ok) tier1.push({ ticket: t, move: "finish-or-close-pr", rationale: "open PR with no live worker past age" });
+  }
+  for (const t of invariants.needsHumanPile?.flagged ?? []) {
+    if (!invariants.needsHumanPile.ok) tier1.push({ ticket: t, move: "holistic-triage", rationale: "worker parked at needs-human/stalled" });
+  }
   for (const t of invariants.blockedTree?.flagged ?? []) {
     if (!invariants.blockedTree.ok) tier2.push({ ticket: t, move: "re-dispatch-blocker", rationale: "blocked by unscheduled/stuck blocker" });
+  }
+  // CTL-1157: a needs-human-LABELLED ticket frozen past 48h has already been
+  // escalated once → tier2 (review, lower urgency than the actionable PR work).
+  for (const t of invariants.frozenNeedsHuman?.flagged ?? []) {
+    if (!invariants.frozenNeedsHuman.ok) tier2.push({ ticket: t, move: "review-needs-human", rationale: "needs-human label frozen past threshold" });
   }
   for (const h of invariants.strandedNode?.flagged ?? []) {
     if (!invariants.strandedNode.ok) tier3.push({ host: h, move: "escalate-stranded-node", rationale: "rostered node owns work but reconcile is failing" });
@@ -487,28 +668,75 @@ export function proposeMoves(invariants, b) {
 // LATER flagged ticket it could act on. So we filter every candidate to self-owned
 // before applying the tier-1 > tier-2 > eligible priority. Single-host (no roster /
 // no ownerForTicket / multiHost false) owns everything → behavior unchanged.
-export function selectAnchor(moves, board) {
+// CTL-1157 (MUST-FIX 1+2): selectAnchorCandidates — PURE. Returns the ORDERED
+// candidate list (most-stuck first) the act site iterates, instead of a single
+// anchor that wedges the whole pass when it latches. The self-owned chain is
+// byte-identical to the old firstOwned ordering (tier1 → tier2 → eligible), just
+// collecting ALL of them in order. selectAnchor stays a thin wrapper over [0] so
+// every existing caller is unchanged.
+//
+// HRW-safety: a foreign-owned flagged ticket is appended ONLY in `holistic` mode
+// AND ONLY when its owner is provably unavailable (∈ strandedOrDeadHosts) — never
+// unconditionally, never the eligible queue. So a healthy peer's tickets are
+// never stolen (no double-dispatch on one branch). Self-owned always sorts ahead
+// of foreign-failover. N=1 (no roster / no ownerForTicket / !multiHost) ⇒ owns()
+// ≡ true and strandedOrDeadHosts is empty ⇒ the foreign branch is unreachable ⇒
+// byte-identical to today.
+export function selectAnchorCandidates(moves, board, { holistic = false, strandedOrDeadHosts = new Set() } = {}) {
+  const multiHost = !!(board && board.multiHost && typeof board.ownerForTicket === "function");
   const owns = (ticket) => {
     if (!ticket) return false;
-    if (!board || !board.multiHost || typeof board.ownerForTicket !== "function") return true;
+    if (!multiHost) return true;
     try {
       return board.ownerForTicket(ticket, board.roster) === board.self;
     } catch {
       return true; // fail-open: a broken HRW read must not block self-owned actuation
     }
   };
-  const firstOwned = (arr) => (arr ?? []).map((m) => m && m.ticket).filter(Boolean).find(owns) ?? null;
-  return (
-    firstOwned(moves?.tier1) ??
-    firstOwned(moves?.tier2) ??
-    ((board?.eligible ?? []).map((e) => e && e.id).filter(Boolean).find(owns) ?? null)
-  );
+  const out = [];
+  const seen = new Set();
+  const add = (t) => {
+    if (t && !seen.has(t)) {
+      seen.add(t);
+      out.push(t);
+    }
+  };
+  const ticketsOf = (arr) => (arr ?? []).map((m) => m && m.ticket).filter(Boolean);
+  // self-owned chain first (unchanged tier1 > tier2 > eligible ordering).
+  for (const t of ticketsOf(moves?.tier1).filter(owns)) add(t);
+  for (const t of ticketsOf(moves?.tier2).filter(owns)) add(t);
+  for (const e of (board?.eligible ?? []).map((x) => x && x.id).filter(Boolean).filter(owns)) add(e);
+  // holistic foreign-failover: a flagged tier1/tier2 ticket this host does NOT own,
+  // ONLY when its owner is provably dead/stranded. Appended AFTER all self-owned.
+  if (holistic && multiHost) {
+    const ownerDead = (ticket) => {
+      try {
+        return strandedOrDeadHosts.has(board.ownerForTicket(ticket, board.roster));
+      } catch {
+        return false; // a broken HRW read must not trigger a foreign failover
+      }
+    };
+    const failover = (arr) => ticketsOf(arr).filter((t) => !owns(t) && ownerDead(t));
+    for (const t of failover(moves?.tier1)) add(t);
+    for (const t of failover(moves?.tier2)) add(t);
+  }
+  return out;
+}
+
+export function selectAnchor(moves, board) {
+  return selectAnchorCandidates(moves, board)[0] ?? null;
 }
 
 // ── (5) buildBoardContext — PURE. The whole-board brief the dispatched delegate
 // gets injected into recovery-pass.json (today it gets NONE).
 export function buildBoardContext(boardState, invariants) {
-  const stuckWorkers = (invariants.workerAge?.flagged ?? []).map((t) => {
+  // CTL-1157: the stuck-worker set is the UNION of the age-flagged workers and the
+  // status-based needs-human pile (Workstream B), deduped by ticket.
+  const stuckTickets = [
+    ...(invariants.workerAge?.flagged ?? []),
+    ...(invariants.needsHumanPile?.flagged ?? []),
+  ];
+  const stuckWorkers = [...new Set(stuckTickets)].map((t) => {
     const s = boardState.signals.find((x) => x.ticket === t);
     return {
       ticket: t,
@@ -518,7 +746,9 @@ export function buildBoardContext(boardState, invariants) {
     };
   });
   return {
-    schema: "recovery-board-context/v1",
+    // CTL-1157: v2 adds the three stuck cohorts (additive; readers default each
+    // field to []). The skill reads them defensively, never gates on the schema.
+    schema: "recovery-board-context/v2",
     snapshotAt: new Date(boardState.now).toISOString(),
     host: { self: boardState.self, roster: boardState.roster, multiHost: boardState.multiHost },
     slots: {
@@ -531,6 +761,12 @@ export function buildBoardContext(boardState, invariants) {
       topTickets: boardState.eligible.slice(0, 5).map((e) => e.id).filter(Boolean),
     },
     stuckWorkers,
+    // CTL-1157 v2: the three stuck cohorts, surfaced additively so the delegate
+    // sees them without re-scanning. Empty arrays when the invariant is green /
+    // not observable (shadow-safe).
+    phantomPrs: invariants.phantomMergedPr?.flagged ?? [],
+    orphanedPrs: invariants.orphanedOpenPr?.flagged ?? [],
+    frozenNeedsHuman: invariants.frozenNeedsHuman?.flagged ?? [],
     strandedNodes: (invariants.strandedNode?.flagged ?? []).map((host) => ({
       host,
       // the tickets HRW-owned by this stranded host — the delegate's actionable
@@ -598,6 +834,8 @@ export function boardHealthPass({
   readEventRing,
   ownerForTicket,
   getReconcileMarkers,
+  getPrStatusMap, // CTL-1157: filter_state PR-status reader (daemon-bound)
+  deadHosts, // CTL-1157: provably-dead host set (daemon-computed)
   lastRunMs = _lastRunMs,
   intervalMs = BOARD_HEALTH_INTERVAL_MS,
   isThrottledFn = isThrottled,
@@ -614,7 +852,8 @@ export function boardHealthPass({
 
   const board = assembleBoardState({
     orchDir, getBoard, getWorkerSignals, getEligible,
-    roster, self, multiHost, capacity, readEventRing, ownerForTicket, getReconcileMarkers, now,
+    roster, self, multiHost, capacity, readEventRing, ownerForTicket, getReconcileMarkers,
+    getPrStatusMap, deadHosts, now,
   });
   const invariants = evaluateInvariants(board, {});
   const dec = decideBoardHealth(invariants, board);
@@ -635,19 +874,26 @@ export function boardHealthPass({
   // binds is the audited-real, capped, cooldown'd defaultInvokeRecoveryPass.
   let actResult;
   if (mode === "enforce" && typeof act === "function" && dec.gate.decision === "proceed") {
-    // CTL-1302: selectAnchor already HRW-filters to a SELF-OWNED ticket (or null
-    // when this host owns none of the flagged/eligible) — so there is no separate
-    // cross-host skip here. A null anchor means "nothing of mine to act on this
-    // scan" (e.g. all flagged work is owned by other hosts, or only host/project
-    // tier-3 moves with no ticket handle).
-    const anchor = selectAnchor(dec.moves, board);
+    // CTL-1157 (MUST-FIX 1+2): compute the ORDERED holistic candidate list. The
+    // self-owned chain comes first (byte-identical to CTL-1302's single anchor);
+    // a foreign-owned flagged ticket is appended ONLY when its owner is provably
+    // dead/stranded (owner ∈ strandedNode.flagged ∪ deadHosts) — never a live
+    // peer's branch. The act site (daemon) iterates the list and dispatches the
+    // first ACTIONABLE (non-cooldown/non-latched) candidate, one per scan, so a
+    // single latched anchor no longer wedges the whole flagged cohort.
+    const strandedOrDeadHosts = new Set([
+      ...(invariants.strandedNode?.flagged ?? []),
+      ...(board.deadHosts ?? []),
+    ]);
+    const candidates = selectAnchorCandidates(dec.moves, board, { holistic: true, strandedOrDeadHosts });
+    const anchor = candidates[0] ?? null;
     if (!anchor) {
-      log({ reason: "no-owned-anchor" }, "board-health: proceed but no self-owned ticket anchor — no holistic dispatch this scan");
+      log({ reason: "no-owned-anchor" }, "board-health: proceed but no actionable ticket anchor — no holistic dispatch this scan");
     } else {
       const boardContext = buildBoardContext(board, invariants);
       try {
-        actResult = act({ anchor, boardContext, decision: dec, board }) ?? null;
-        log({ anchor, dispatched: actResult?.dispatched ?? null }, "board-health: holistic recovery-pass delegate actuated");
+        actResult = act({ anchor, candidates, boardContext, decision: dec, board }) ?? null;
+        log({ anchor, candidates: candidates.length, dispatched: actResult?.dispatched ?? null }, "board-health: holistic recovery-pass delegate actuated");
       } catch (err) {
         log({ err: err.message, anchor }, "board-health: act failed (continuing)");
       }

--- a/plugins/dev/scripts/execution-core/board-health.mjs
+++ b/plugins/dev/scripts/execution-core/board-health.mjs
@@ -639,6 +639,14 @@ function checkOrphanedOpenPr(b, t) {
   );
   const flagged = [];
   for (const [id, d] of b.ticketsById) {
+    // KNOWN LIMITATION (CTL-1157, Codex round-7 — deferred to a follow-up): the ticket
+    // descriptor exposes a SINGLE pr_number (ticket_state has one pr_number column) and
+    // filter_state rows are keyed by webhook interest_id, not by ticket — so there is no
+    // ticket→all-PRs mapping to iterate. A multi-PR ticket whose descriptor points at a
+    // newer merged PR while an OLDER PR stays open therefore reads green here (a false
+    // NEGATIVE — we miss the older orphan). Closing this needs a ticket→PRs data model
+    // (descriptor multi-PR field or an interest_id→ticket join), out of scope for this PR.
+    // Impact is bounded: shadow-only until the enforce flip, and a rare multi-PR case.
     const prNum = prNumberOf(d);
     if (prNum == null) continue;
     // CTL-1157 (Codex round-6): skip a ticket already in a terminal Linear state

--- a/plugins/dev/scripts/execution-core/board-health.mjs
+++ b/plugins/dev/scripts/execution-core/board-health.mjs
@@ -87,34 +87,50 @@ function prNumberOf(d) {
 
 // lookupPrStatus — resolve the lifecycle status of (prNumber, repo) against the
 // composite prStatusMap (`Map<number, Map<repoKey, {status,updatedAt,repo}>>`,
-// produced by broker-state.getAllPrStatuses). The disambiguation rules (CTL-1157,
-// Codex #4):
-//   • No entry for the number → null (not observable for this ticket).
-//   • Exactly ONE repo holds the number → return it (no collision; this is the
-//     N=1 / single-repo path → byte-identical to the old number-only lookup,
-//     whether or not the ticket's repo was derived).
-//   • The number COLLIDES across repos AND the ticket's repo is known → return
-//     that repo's entry (or null when the ticket's own repo has no such PR). A
-//     cross-repo #-collision NO LONGER hides the ticket's real PR.
-//   • The number collides AND the ticket's repo is genuinely underivable → the
-//     TRUE residual: we cannot pick → return {ambiguous:true} so the cohort skips
-//     rather than borrow the wrong repo's status.
+// produced by broker-state.getAllPrStatuses; repoKey is the row's "owner/repo" or
+// "" when the lifecycle row carries no repo attribution). The disambiguation rules
+// (CTL-1157, Codex #4 round-4 — require the exact repo when it is KNOWN, never borrow
+// an unrelated repo's row for the same number):
+//   • No entry for the number → null (not observable).
+//   • Ticket repo KNOWN:
+//       – exact `byRepo.get(repo)` hit → return it (definitive).
+//       – no exact hit, but the number has a SINGLE UNATTRIBUTED ("") row → return it
+//         (a legacy / single-repo lifecycle row written before repo attribution; using
+//         it preserves phantom/orphan detection on the single-repo fleet).
+//       – otherwise (rows exist ONLY for other KNOWN repos, or ambiguous) → null. This
+//         is the fix: a ticket in org/y with PR #42 must NOT inherit org/x#42's status
+//         just because org/x is the only row for #42.
+//   • Ticket repo UNDERIVABLE:
+//       – exactly one repo holds the number → number-only resolution (legacy N=1).
+//       – the number collides across repos → {ambiguous:true} so the cohort skips
+//         rather than borrow a wrong repo's status.
 // `repo` is the ticket's GitHub "owner/repo" (or null when underivable).
 function lookupPrStatus(map, prNumber, repo) {
   if (!(map instanceof Map)) return null;
   const byRepo = map.get(prNumber);
   if (!(byRepo instanceof Map) || byRepo.size === 0) return null;
-  // No collision: exactly one repo owns this number → number-only resolution.
+
+  const repoKnown = repo != null && repo !== "";
+  if (repoKnown) {
+    // (1) Exact match on the ticket's OWN repo — definitive.
+    const exact = byRepo.get(repo);
+    if (exact) return exact;
+    // (2) No row attributed to the ticket's repo. The ONLY row we may still trust is a
+    //     LONE unattributed ("") row — a lifecycle row written before repo attribution.
+    //     This keeps single-repo detection while never borrowing another KNOWN repo's #N.
+    if (byRepo.size === 1) {
+      const [[onlyKey, only]] = byRepo.entries();
+      if (onlyKey === "") return only;
+    }
+    // (3) Rows exist only for OTHER known repos (or are ambiguous) → do not borrow.
+    return null;
+  }
+
+  // Repo underivable: fall back to number-only resolution, ambiguous on collision.
   if (byRepo.size === 1) {
     const [only] = byRepo.values();
     return only;
   }
-  // Collision: ≥2 repos share this number. Disambiguate by the ticket's repo.
-  if (repo != null && repo !== "") {
-    // Known repo → the ticket's OWN repo's #N, or null when it has none.
-    return byRepo.get(repo) ?? null;
-  }
-  // Repo underivable + collision → the documented true residual: ambiguous skip.
   return { status: null, updatedAt: null, repo: null, ambiguous: true };
 }
 

--- a/plugins/dev/scripts/execution-core/board-health.test.mjs
+++ b/plugins/dev/scripts/execution-core/board-health.test.mjs
@@ -402,6 +402,81 @@ describe("CTL-1157 multi-repo collision — composite (repo,number) disambiguati
   });
 });
 
+// ─── CTL-1157 (Group 2, Codex) — cohort liveness/terminal correctness ────────
+// (1) orphaned-open PR: a failed/stalled worker FREES the slot → NOT live, so a
+//     PR stuck behind it IS the orphaned case (must not read as "has a worker").
+// (2) frozen-needs-human: a terminal (Done/Canceled/Duplicate) ticket carrying a
+//     stale cached needs-human label must NOT be flagged for recovery.
+describe("CTL-1157 cohort correctness — dead-worker orphans + terminal stale-label", () => {
+  const staleOpen = { prNumber: 7, repo: "org/solo", status: "open", updatedAt: new Date(NOW - 100 * HOUR).toISOString() };
+
+  test("orphaned-open: a stale open PR whose ONLY worker signal is FAILED IS flagged", () => {
+    const ticketsById = new Map([["CTL-DEAD", { identifier: "CTL-DEAD", prNumber: 7 }]]);
+    const r = evaluateInvariants(
+      mkBoard({
+        ticketsById,
+        prStatusMap: mkPrStatusMap([staleOpen]),
+        signals: [{ ticket: "CTL-DEAD", phase: "implement", status: "failed" }],
+      }),
+      { mode: "shadow" },
+    );
+    expect(r.orphanedOpenPr.flagged).toContain("CTL-DEAD"); // failed worker ≠ live
+  });
+
+  test("orphaned-open: a stale open PR whose ONLY worker signal is STALLED IS flagged", () => {
+    const ticketsById = new Map([["CTL-STALL", { identifier: "CTL-STALL", prNumber: 7 }]]);
+    const r = evaluateInvariants(
+      mkBoard({
+        ticketsById,
+        prStatusMap: mkPrStatusMap([staleOpen]),
+        signals: [{ ticket: "CTL-STALL", phase: "implement", status: "stalled" }],
+      }),
+      { mode: "shadow" },
+    );
+    expect(r.orphanedOpenPr.flagged).toContain("CTL-STALL");
+  });
+
+  test("orphaned-open: a LIVE (running) worker still masks the PR as not-orphaned", () => {
+    const ticketsById = new Map([["CTL-LIVE", { identifier: "CTL-LIVE", prNumber: 7 }]]);
+    const r = evaluateInvariants(
+      mkBoard({
+        ticketsById,
+        prStatusMap: mkPrStatusMap([staleOpen]),
+        signals: [{ ticket: "CTL-LIVE", phase: "implement", status: "running" }],
+      }),
+      { mode: "shadow" },
+    );
+    expect(r.orphanedOpenPr.flagged).not.toContain("CTL-LIVE"); // running worker → live
+  });
+
+  test("frozen-needs-human: a TERMINAL ticket with a stale needs-human label is NOT flagged", () => {
+    const old = new Date(NOW - 100 * HOUR).toISOString();
+    const ticketsById = new Map([
+      ["CTL-DONE", { identifier: "CTL-DONE", state: "Done", labels: [{ name: "needs-human" }], updatedAt: old }],
+      ["CTL-CANCEL", { identifier: "CTL-CANCEL", state: "Canceled", labels: [{ name: "needs-human" }], updatedAt: old }],
+      ["CTL-DUP", { identifier: "CTL-DUP", state: "Duplicate", labels: [{ name: "needs-human" }], updatedAt: old }],
+    ]);
+    const r = evaluateInvariants(mkBoard({ ticketsById }), { mode: "shadow" });
+    expect(r.frozenNeedsHuman.flagged).not.toContain("CTL-DONE");
+    expect(r.frozenNeedsHuman.flagged).not.toContain("CTL-CANCEL");
+    expect(r.frozenNeedsHuman.flagged).not.toContain("CTL-DUP");
+    expect(r.frozenNeedsHuman.observable).toBe(true); // labels present → still observable
+  });
+
+  test("frozen-needs-human: a NON-terminal ticket with a stale needs-human label IS still flagged", () => {
+    const ticketsById = new Map([
+      ["CTL-STUCK", {
+        identifier: "CTL-STUCK",
+        state: "In Progress",
+        labels: [{ name: "needs-human" }],
+        updatedAt: new Date(NOW - 100 * HOUR).toISOString(),
+      }],
+    ]);
+    const r = evaluateInvariants(mkBoard({ ticketsById }), { mode: "shadow" });
+    expect(r.frozenNeedsHuman.flagged).toContain("CTL-STUCK"); // real frozen escalation preserved
+  });
+});
+
 // ─── decideBoardHealth — the cheap-gate funnel (§6) ─────────────────────────
 function inv(ok, failed = 0, observable = true, flagged = []) {
   return { ok, failed, observable, flagged, note: "" };

--- a/plugins/dev/scripts/execution-core/board-health.test.mjs
+++ b/plugins/dev/scripts/execution-core/board-health.test.mjs
@@ -400,6 +400,34 @@ describe("CTL-1157 multi-repo collision — composite (repo,number) disambiguati
     const r = evaluateInvariants(mkBoard({ ticketsById, prStatusMap }), { mode: "shadow" });
     expect(r.orphanedOpenPr.flagged).toContain("CTL-Z");
   });
+
+  // THE ROUND-4 FIX (Codex #4 borrow-across-repos): the ticket repo is KNOWN and the
+  // ONLY row for #42 belongs to a DIFFERENT repo. The pre-fix `byRepo.size===1` fast
+  // path returned that unrelated row, so a ticket in org/y inherited org/x#42's MERGED
+  // status → a FALSE phantom. Now a known repo requires the exact row → never borrow.
+  test("phantom-merged: known repo org/y is NOT flagged when the ONLY #42 row is org/x (no cross-repo borrow)", () => {
+    const ticketsById = new Map([["CTL-Y", { identifier: "CTL-Y", state: "In Review", prNumber: 42 }]]);
+    const prStatusMap = mkPrStatusMap([{ prNumber: 42, repo: "org/x", status: "merged" }]);
+    const r = evaluateInvariants(
+      mkBoard({ ticketsById, prStatusMap, repoForTicket: () => "org/y" }),
+      { mode: "shadow" },
+    );
+    expect(r.phantomMergedPr.flagged).not.toContain("CTL-Y"); // org/x#42's status is not CTL-Y's
+    expect(r.phantomMergedPr.ok).toBe(true);
+  });
+
+  // Single-repo preservation: a KNOWN repo with a LONE UNATTRIBUTED ("") lifecycle row
+  // (written before repo attribution) is still trusted — detection must not regress on
+  // the single-repo fleet whose filter_state rows carry no repo.
+  test("phantom-merged: known repo still flags off a lone UNATTRIBUTED row (single-repo preservation)", () => {
+    const ticketsById = new Map([["CTL-Y", { identifier: "CTL-Y", state: "In Review", prNumber: 42 }]]);
+    const prStatusMap = mkPrStatusMap([{ prNumber: 42, repo: null, status: "merged" }]); // repoKey ""
+    const r = evaluateInvariants(
+      mkBoard({ ticketsById, prStatusMap, repoForTicket: () => "org/y" }),
+      { mode: "shadow" },
+    );
+    expect(r.phantomMergedPr.flagged).toContain("CTL-Y");
+  });
 });
 
 // ─── CTL-1157 (Group 2, Codex) — cohort liveness/terminal correctness ────────

--- a/plugins/dev/scripts/execution-core/board-health.test.mjs
+++ b/plugins/dev/scripts/execution-core/board-health.test.mjs
@@ -34,6 +34,9 @@ function mkBoard(o = {}) {
     roster: o.roster ?? [],
     self: o.self ?? "mini",
     multiHost: o.multiHost ?? false,
+    // CTL-1157: assembleBoardState now records the run mode on the board so
+    // evaluateInvariants can default-gate the cohort checks (off → dark).
+    mode: o.mode,
     capacity: { maxParallel: 4, liveCount: 0, freeSlots: 4, ...(o.capacity ?? {}) },
     reconcileMarkers: o.reconcileMarkers ?? {},
     ring: {
@@ -206,6 +209,76 @@ describe("evaluateInvariants — per-invariant green/fail", () => {
     // the rest of the scan still completed
     expect(r.dispatchLiveness).toBeDefined();
     expect(r.workerAge).toBeDefined();
+  });
+});
+
+// ─── CTL-1157 off-gate: off = truly dark (no cohort code, no PR SELECT) ──────
+describe("CTL-1157 off-gate — cohort invariants + PR SELECT are dark in off", () => {
+  const COHORT_KEYS = ["phantomMergedPr", "orphanedOpenPr", "frozenNeedsHuman", "needsHumanPile"];
+
+  test("evaluateInvariants(mode:off) omits ALL four cohort invariants (legacy set only)", () => {
+    const r = evaluateInvariants(mkBoard(), { mode: "off" });
+    for (const k of COHORT_KEYS) expect(r[k]).toBeUndefined();
+    // the legacy invariants still all ran → byte-identical key set to origin/main.
+    expect(Object.keys(r).sort()).toEqual(
+      [
+        "blockedTree",
+        "cacheCoherence",
+        "dispatchLiveness",
+        "projectSilence",
+        "rateLimitHeadroom",
+        "strandedNode",
+        "workerAge",
+      ].sort(),
+    );
+  });
+
+  test("evaluateInvariants(mode:shadow) RUNS all four cohort invariants (telemetry)", () => {
+    const r = evaluateInvariants(mkBoard(), { mode: "shadow" });
+    for (const k of COHORT_KEYS) expect(r[k]).toBeDefined();
+    // needsHumanPile is the status-based catch-all → observable in shadow (it judges
+    // the signal-status set, always present), exactly like its siblings when wired.
+    expect(r.needsHumanPile.observable).toBe(true);
+  });
+
+  test("evaluateInvariants picks up board.mode (off) when no explicit mode passed", () => {
+    const r = evaluateInvariants(mkBoard({ mode: "off" }));
+    for (const k of COHORT_KEYS) expect(r[k]).toBeUndefined();
+  });
+
+  test("assembleBoardState(mode:off) NEVER invokes getPrStatusMap (no getAllPrStatuses SELECT)", () => {
+    let called = 0;
+    const board = assembleBoardState({
+      orchDir: "/tmp/x",
+      getBoard: () => [],
+      getWorkerSignals: () => [],
+      getEligible: () => [],
+      getPrStatusMap: () => {
+        called += 1;
+        return new Map([[1, { status: "merged" }]]);
+      },
+      mode: "off",
+      now: () => NOW,
+    });
+    expect(called).toBe(0); // the filter_state SELECT did not run
+    expect(board.prStatusMap.size).toBe(0); // empty Map → invariants would be inert anyway
+  });
+
+  test("assembleBoardState(mode:shadow) DOES invoke getPrStatusMap (telemetry needs it)", () => {
+    let called = 0;
+    assembleBoardState({
+      orchDir: "/tmp/x",
+      getBoard: () => [],
+      getWorkerSignals: () => [],
+      getEligible: () => [],
+      getPrStatusMap: () => {
+        called += 1;
+        return new Map();
+      },
+      mode: "shadow",
+      now: () => NOW,
+    });
+    expect(called).toBe(1);
   });
 });
 
@@ -486,6 +559,13 @@ describe("boardHealthPass — mode branching + shadow safety", () => {
     expect(emits.length).toBe(1);
     expect(emits[0].type).toBe("recovery.board-scan");
     expect(emits[0].details.mode).toBe("shadow");
+    // CTL-1157: shadow telemetry carries the cohort counts (OTEL before/after
+    // baseline) — present in the scan event, but the act seam threw and was never
+    // reached → telemetry-only, zero action.
+    for (const k of ["phantomMergedPr", "orphanedOpenPr", "frozenNeedsHuman", "needsHumanPile"]) {
+      expect(emits[0].details.invariants[k]).toBeDefined();
+    }
+    expect(r.act).toBeNull();
   });
 
   test("mode:enforce with NO act seam (the scheduler reality) → emits, mutates nothing, no throw", () => {

--- a/plugins/dev/scripts/execution-core/board-health.test.mjs
+++ b/plugins/dev/scripts/execution-core/board-health.test.mjs
@@ -39,6 +39,10 @@ function mkBoard(o = {}) {
     mode: o.mode,
     capacity: { maxParallel: 4, liveCount: 0, freeSlots: 4, ...(o.capacity ?? {}) },
     reconcileMarkers: o.reconcileMarkers ?? {},
+    // CTL-1157: the filter_state PR-lifecycle map (number → {status,updatedAt,repo,
+    // ambiguous}). Default empty Map ⇒ the phantom/orphaned-PR cohorts stay
+    // observable:false, exactly like an unwired board.
+    prStatusMap: o.prStatusMap ?? new Map(),
     ring: {
       recentDispatchTs: null,
       cacheReconcile: null,
@@ -279,6 +283,55 @@ describe("CTL-1157 off-gate — cohort invariants + PR SELECT are dark in off", 
       now: () => NOW,
     });
     expect(called).toBe(1);
+  });
+});
+
+// ─── CTL-1157 (Codex GROUP-A fix #3): multi-repo PR-number collision ─────────
+// A (repo, pr_number) pair — not pr_number alone — identifies a PR. When the same
+// number exists in two repos, getAllPrStatuses marks the entry `ambiguous` and the
+// cohorts must SKIP it rather than borrow the wrong repo's status (which would
+// manufacture a false phantom-merged PR or hide a genuinely-orphaned open one).
+describe("CTL-1157 multi-repo collision — ambiguous PR numbers are not misclassified", () => {
+  test("checkPhantomMergedPr does NOT flag a ticket whose PR number is ambiguous (cross-repo collision)", () => {
+    const ticketsById = new Map([
+      // CTL-Y sits in a PR/in-review state and points at #42 — but #42 collides
+      // across repos (merged in repo X, open in repo Y) → ambiguous.
+      ["CTL-Y", { identifier: "CTL-Y", state: "In Review", prNumber: 42 }],
+    ]);
+    const ambiguous = mkBoard({
+      ticketsById,
+      prStatusMap: new Map([[42, { status: "merged", repo: "org/x", ambiguous: true }]]),
+    });
+    const r = evaluateInvariants(ambiguous, { mode: "shadow" });
+    expect(r.phantomMergedPr.flagged).not.toContain("CTL-Y"); // no false phantom
+    expect(r.phantomMergedPr.ok).toBe(true);
+  });
+
+  test("control: the SAME ticket+number IS flagged when the PR number is unambiguous (single repo, merged)", () => {
+    const ticketsById = new Map([
+      ["CTL-Y", { identifier: "CTL-Y", state: "In Review", prNumber: 42 }],
+    ]);
+    const unambiguous = mkBoard({
+      ticketsById,
+      prStatusMap: new Map([[42, { status: "merged", repo: "org/x", ambiguous: false }]]),
+    });
+    const r = evaluateInvariants(unambiguous, { mode: "shadow" });
+    expect(r.phantomMergedPr.flagged).toContain("CTL-Y"); // genuine phantom is still caught
+  });
+
+  test("checkOrphanedOpenPr skips an ambiguous (cross-repo collision) PR number", () => {
+    const ticketsById = new Map([
+      ["CTL-Z", { identifier: "CTL-Z", prNumber: 99 }],
+    ]);
+    const board = mkBoard({
+      ticketsById,
+      // open + stale + no live worker would normally flag — but ambiguous ⇒ skip.
+      prStatusMap: new Map([
+        [99, { status: "open", repo: "org/x", ambiguous: true, updatedAt: new Date(NOW - 100 * HOUR).toISOString() }],
+      ]),
+    });
+    const r = evaluateInvariants(board, { mode: "shadow" });
+    expect(r.orphanedOpenPr.flagged).not.toContain("CTL-Z");
   });
 });
 

--- a/plugins/dev/scripts/execution-core/board-health.test.mjs
+++ b/plugins/dev/scripts/execution-core/board-health.test.mjs
@@ -350,7 +350,7 @@ describe("buildBoardContext", () => {
     const invs = { ...allGreen(), workerAge: inv(false, 1, true, ["CTL-OLD"]) };
     const ctx = buildBoardContext(board, invs);
 
-    expect(ctx.schema).toBe("recovery-board-context/v1");
+    expect(ctx.schema).toBe("recovery-board-context/v2");
     expect(ctx.slots).toEqual({ capacity: 4, inUse: 2, free: 2 });
     expect(ctx.eligibleQueue.depth).toBe(2);
     expect(ctx.eligibleQueue.topTickets).toEqual(["CTL-1", "CTL-2"]);
@@ -512,7 +512,7 @@ describe("boardHealthPass — mode branching + shadow safety", () => {
     // falls back to the top eligible ticket.
     expect(acted[0].anchor).toBe("CTL-1");
     // the delegate gets the WHOLE-board context, not a per-item brief.
-    expect(acted[0].boardContext.schema).toBe("recovery-board-context/v1");
+    expect(acted[0].boardContext.schema).toBe("recovery-board-context/v2");
     expect(acted[0].decision.gate.decision).toBe("proceed");
     // the act result is threaded back into the pass result (observability).
     expect(r.act).toEqual({ dispatched: true, attempts: 1 });

--- a/plugins/dev/scripts/execution-core/board-health.test.mjs
+++ b/plugins/dev/scripts/execution-core/board-health.test.mjs
@@ -24,6 +24,25 @@ const NOW = Date.parse("2026-06-20T12:00:00Z");
 const MIN = 60_000;
 const HOUR = 3_600_000;
 
+// mkPrStatusMap — build the composite `Map<number, Map<repoKey, entry>>` shape
+// (CTL-1157, Codex #4) that broker-state.getAllPrStatuses now returns, from flat
+// {prNumber, repo, status, updatedAt} rows. Mirrors how the real reader nests
+// per-(repo, number); multiple rows with the same number but different repos form
+// the collision case.
+function mkPrStatusMap(rows = []) {
+  const map = new Map();
+  for (const { prNumber, repo = null, status, updatedAt } of rows) {
+    const key = repo ?? "";
+    let byRepo = map.get(prNumber);
+    if (!byRepo) {
+      byRepo = new Map();
+      map.set(prNumber, byRepo);
+    }
+    byRepo.set(key, { status, updatedAt, repo });
+  }
+  return map;
+}
+
 // A complete, default-healthy boardState shape (the frozen output assembleBoardState
 // produces). Overrides are shallow-merged per top-level key.
 function mkBoard(o = {}) {
@@ -39,9 +58,10 @@ function mkBoard(o = {}) {
     mode: o.mode,
     capacity: { maxParallel: 4, liveCount: 0, freeSlots: 4, ...(o.capacity ?? {}) },
     reconcileMarkers: o.reconcileMarkers ?? {},
-    // CTL-1157: the filter_state PR-lifecycle map (number → {status,updatedAt,repo,
-    // ambiguous}). Default empty Map ⇒ the phantom/orphaned-PR cohorts stay
-    // observable:false, exactly like an unwired board.
+    // CTL-1157 (Codex #4): the filter_state PR-lifecycle map — composite
+    // `Map<number, Map<repoKey, {status,updatedAt,repo}>>`. Default empty Map ⇒ the
+    // phantom/orphaned-PR cohorts stay observable:false, exactly like an unwired
+    // board. `mkPrStatusMap` below builds the nested shape from flat rows.
     prStatusMap: o.prStatusMap ?? new Map(),
     ring: {
       recentDispatchTs: null,
@@ -51,6 +71,8 @@ function mkBoard(o = {}) {
       ...(o.ring ?? {}),
     },
     ownerForTicket: o.ownerForTicket ?? null,
+    // CTL-1157 (Codex #4): ticket→owner/repo resolver for the composite lookup.
+    repoForTicket: o.repoForTicket ?? null,
     now: o.now ?? NOW,
   };
 }
@@ -286,52 +308,97 @@ describe("CTL-1157 off-gate — cohort invariants + PR SELECT are dark in off", 
   });
 });
 
-// ─── CTL-1157 (Codex GROUP-A fix #3): multi-repo PR-number collision ─────────
-// A (repo, pr_number) pair — not pr_number alone — identifies a PR. When the same
-// number exists in two repos, getAllPrStatuses marks the entry `ambiguous` and the
-// cohorts must SKIP it rather than borrow the wrong repo's status (which would
-// manufacture a false phantom-merged PR or hide a genuinely-orphaned open one).
-describe("CTL-1157 multi-repo collision — ambiguous PR numbers are not misclassified", () => {
-  test("checkPhantomMergedPr does NOT flag a ticket whose PR number is ambiguous (cross-repo collision)", () => {
-    const ticketsById = new Map([
-      // CTL-Y sits in a PR/in-review state and points at #42 — but #42 collides
-      // across repos (merged in repo X, open in repo Y) → ambiguous.
-      ["CTL-Y", { identifier: "CTL-Y", state: "In Review", prNumber: 42 }],
+// ─── CTL-1157 (Codex #4): multi-repo PR-number collision — composite keying ──
+// A (repo, pr_number) pair — not pr_number alone — identifies a PR. getAllPrStatuses
+// now returns a composite Map<number, Map<repo, status>>; board-health resolves the
+// stuck ticket's repo (repoForTicket) and looks up the EXACT (repo, number). A
+// cross-repo #-collision is disambiguated by the ticket's repo — it NO LONGER hides
+// a genuine orphaned open PR. Only a collision whose repo is genuinely underivable
+// stays the ambiguous skip (the documented true residual).
+describe("CTL-1157 multi-repo collision — composite (repo,number) disambiguation", () => {
+  // #42 collides: MERGED in org/x, OPEN in org/y — two different PRs.
+  const COLLIDE_42 = () =>
+    mkPrStatusMap([
+      { prNumber: 42, repo: "org/x", status: "merged" },
+      { prNumber: 42, repo: "org/y", status: "open" },
     ]);
-    const ambiguous = mkBoard({
-      ticketsById,
-      prStatusMap: new Map([[42, { status: "merged", repo: "org/x", ambiguous: true }]]),
-    });
-    const r = evaluateInvariants(ambiguous, { mode: "shadow" });
-    expect(r.phantomMergedPr.flagged).not.toContain("CTL-Y"); // no false phantom
+
+  test("phantom-merged: a ticket in org/x (the MERGED repo) IS flagged despite the collision", () => {
+    const ticketsById = new Map([["CTL-Y", { identifier: "CTL-Y", state: "In Review", prNumber: 42 }]]);
+    const r = evaluateInvariants(
+      mkBoard({ ticketsById, prStatusMap: COLLIDE_42(), repoForTicket: () => "org/x" }),
+      { mode: "shadow" },
+    );
+    expect(r.phantomMergedPr.flagged).toContain("CTL-Y"); // genuine phantom still caught
+  });
+
+  test("phantom-merged: a ticket in org/y (the OPEN repo) is NOT flagged — no false phantom from org/x's merged", () => {
+    const ticketsById = new Map([["CTL-Y", { identifier: "CTL-Y", state: "In Review", prNumber: 42 }]]);
+    const r = evaluateInvariants(
+      mkBoard({ ticketsById, prStatusMap: COLLIDE_42(), repoForTicket: () => "org/y" }),
+      { mode: "shadow" },
+    );
+    expect(r.phantomMergedPr.flagged).not.toContain("CTL-Y"); // org/y's #42 is open, not merged
     expect(r.phantomMergedPr.ok).toBe(true);
   });
 
-  test("control: the SAME ticket+number IS flagged when the PR number is unambiguous (single repo, merged)", () => {
-    const ticketsById = new Map([
-      ["CTL-Y", { identifier: "CTL-Y", state: "In Review", prNumber: 42 }],
-    ]);
-    const unambiguous = mkBoard({
-      ticketsById,
-      prStatusMap: new Map([[42, { status: "merged", repo: "org/x", ambiguous: false }]]),
-    });
-    const r = evaluateInvariants(unambiguous, { mode: "shadow" });
-    expect(r.phantomMergedPr.flagged).toContain("CTL-Y"); // genuine phantom is still caught
+  test("phantom-merged: collision + repo UNDERIVABLE (no repoForTicket) → ambiguous skip (true residual)", () => {
+    const ticketsById = new Map([["CTL-Y", { identifier: "CTL-Y", state: "In Review", prNumber: 42 }]]);
+    const r = evaluateInvariants(
+      mkBoard({ ticketsById, prStatusMap: COLLIDE_42() /* repoForTicket: null */ }),
+      { mode: "shadow" },
+    );
+    expect(r.phantomMergedPr.flagged).not.toContain("CTL-Y"); // can't pick → skip, never borrow
   });
 
-  test("checkOrphanedOpenPr skips an ambiguous (cross-repo collision) PR number", () => {
-    const ticketsById = new Map([
-      ["CTL-Z", { identifier: "CTL-Z", prNumber: 99 }],
+  // THE HEADLINE FIX (Codex #4 missed-detection): a genuine orphaned open PR in the
+  // ticket's OWN repo must be flagged even when an UNRELATED repo reuses the number.
+  test("orphaned-open: a stale open PR in org/y IS flagged even though org/x reuses #99 (no longer hidden)", () => {
+    const ticketsById = new Map([["CTL-Z", { identifier: "CTL-Z", prNumber: 99 }]]);
+    const prStatusMap = mkPrStatusMap([
+      // org/x's #99 is merged & fresh — the unrelated collision that used to hide CTL-Z.
+      { prNumber: 99, repo: "org/x", status: "merged", updatedAt: new Date(NOW - 1 * HOUR).toISOString() },
+      // org/y's #99 — CTL-Z's real PR: open, stale, no live worker → orphaned.
+      { prNumber: 99, repo: "org/y", status: "open", updatedAt: new Date(NOW - 100 * HOUR).toISOString() },
     ]);
-    const board = mkBoard({
-      ticketsById,
-      // open + stale + no live worker would normally flag — but ambiguous ⇒ skip.
-      prStatusMap: new Map([
-        [99, { status: "open", repo: "org/x", ambiguous: true, updatedAt: new Date(NOW - 100 * HOUR).toISOString() }],
-      ]),
-    });
-    const r = evaluateInvariants(board, { mode: "shadow" });
-    expect(r.orphanedOpenPr.flagged).not.toContain("CTL-Z");
+    const r = evaluateInvariants(
+      mkBoard({ ticketsById, prStatusMap, repoForTicket: () => "org/y" }),
+      { mode: "shadow" },
+    );
+    expect(r.orphanedOpenPr.flagged).toContain("CTL-Z"); // detection no longer hidden
+  });
+
+  test("orphaned-open: collision + repo UNDERIVABLE → ambiguous skip (true residual)", () => {
+    const ticketsById = new Map([["CTL-Z", { identifier: "CTL-Z", prNumber: 99 }]]);
+    const prStatusMap = mkPrStatusMap([
+      { prNumber: 99, repo: "org/x", status: "merged", updatedAt: new Date(NOW - 1 * HOUR).toISOString() },
+      { prNumber: 99, repo: "org/y", status: "open", updatedAt: new Date(NOW - 100 * HOUR).toISOString() },
+    ]);
+    const r = evaluateInvariants(
+      mkBoard({ ticketsById, prStatusMap /* repoForTicket: null */ }),
+      { mode: "shadow" },
+    );
+    expect(r.orphanedOpenPr.flagged).not.toContain("CTL-Z"); // can't pick → skip
+  });
+
+  // N=1 / single-repo: NO collision (one inner entry per number) → number-only
+  // resolution, byte-identical whether or not the ticket's repo was derived.
+  test("single-repo (N=1): phantom-merged still flags with NO repoForTicket bound", () => {
+    const ticketsById = new Map([["CTL-Y", { identifier: "CTL-Y", state: "In Review", prNumber: 42 }]]);
+    const r = evaluateInvariants(
+      mkBoard({ ticketsById, prStatusMap: mkPrStatusMap([{ prNumber: 42, repo: "org/solo", status: "merged" }]) }),
+      { mode: "shadow" },
+    );
+    expect(r.phantomMergedPr.flagged).toContain("CTL-Y");
+  });
+
+  test("single-repo (N=1): orphaned-open still flags with NO repoForTicket bound", () => {
+    const ticketsById = new Map([["CTL-Z", { identifier: "CTL-Z", prNumber: 99 }]]);
+    const prStatusMap = mkPrStatusMap([
+      { prNumber: 99, repo: "org/solo", status: "open", updatedAt: new Date(NOW - 100 * HOUR).toISOString() },
+    ]);
+    const r = evaluateInvariants(mkBoard({ ticketsById, prStatusMap }), { mode: "shadow" });
+    expect(r.orphanedOpenPr.flagged).toContain("CTL-Z");
   });
 });
 

--- a/plugins/dev/scripts/execution-core/board-health.test.mjs
+++ b/plugins/dev/scripts/execution-core/board-health.test.mjs
@@ -464,6 +464,33 @@ describe("CTL-1157 cohort correctness — dead-worker orphans + terminal stale-l
     expect(r.orphanedOpenPr.flagged).toContain("CTL-STALL");
   });
 
+  // CTL-1157 (Codex round-6): a TERMINAL ticket (Done/Canceled/Duplicate) whose PR was
+  // never merged/closed still carries an "open" filter_state row, but must NOT be flagged
+  // as an orphaned-PR anchor — dispatching a recovery-pass on already-finished work wastes
+  // a slot. Mirrors the terminal exclusion the needs-human cohorts already apply.
+  test("orphaned-open: a TERMINAL (Canceled) ticket with a stale open PR is NOT flagged", () => {
+    const ticketsById = new Map([["CTL-TERM", { identifier: "CTL-TERM", prNumber: 7, state: "Canceled" }]]);
+    const r = evaluateInvariants(
+      mkBoard({
+        ticketsById,
+        prStatusMap: mkPrStatusMap([staleOpen]),
+        signals: [{ ticket: "CTL-TERM", phase: "implement", status: "failed" }],
+      }),
+      { mode: "shadow" },
+    );
+    expect(r.orphanedOpenPr.flagged).not.toContain("CTL-TERM"); // terminal → not a recovery anchor
+    expect(r.orphanedOpenPr.ok).toBe(true);
+  });
+
+  test("orphaned-open: a Done ticket with a stale open PR is NOT flagged", () => {
+    const ticketsById = new Map([["CTL-DONE", { identifier: "CTL-DONE", prNumber: 7, state: "Done" }]]);
+    const r = evaluateInvariants(
+      mkBoard({ ticketsById, prStatusMap: mkPrStatusMap([staleOpen]), signals: [] }),
+      { mode: "shadow" },
+    );
+    expect(r.orphanedOpenPr.flagged).not.toContain("CTL-DONE");
+  });
+
   test("orphaned-open: a LIVE (running) worker still masks the PR as not-orphaned", () => {
     const ticketsById = new Map([["CTL-LIVE", { identifier: "CTL-LIVE", prNumber: 7 }]]);
     const r = evaluateInvariants(

--- a/plugins/dev/scripts/execution-core/delegate-queue.mjs
+++ b/plugins/dev/scripts/execution-core/delegate-queue.mjs
@@ -93,13 +93,22 @@ function resolveMaxParallel(src) {
 // workers/<TICKET>/phase-recovery-pass.json is dispatched|running AND its
 // bg_job_id is alive per the injected isBgJobAlive. Reads the signal file
 // directly (the same shape phase-agent-dispatch writes: {status, bg_job_id}).
-function recoveryPassWorkerLive(orchDir, ticket, isBgJobAlive) {
+//
+// CTL-1157 (GROUP-3 #2): under executor=sdk the recovery-pass worker runs
+// IN-PROCESS (Agent SDK query()) and its prelaunch signal NEVER carries a
+// bg_job_id (dispatch.mjs E3 / signal-reader.countSdkInflight). A dispatched|running
+// sdk signal with no bg_job_id is a LIVE worker, not a dead one — so a bare
+// no-bg_job_id ⇒ not-live rule (correct for bg) would let a SECOND board-health
+// scan re-enqueue and double-dispatch the same in-flight sdk ticket. When the
+// caller is sdk-aware (executor==="sdk"), treat that shape as LIVE. Under bg the
+// discriminator is absent → behavior is byte-identical.
+function recoveryPassWorkerLive(orchDir, ticket, isBgJobAlive, executor) {
   const signalPath = join(orchDir, "workers", ticket, "phase-recovery-pass.json");
   const sig = readIntentFile(signalPath);
   if (!sig) return false;
   if (sig.status !== "dispatched" && sig.status !== "running") return false;
   const bgJobId = sig.bg_job_id ?? null;
-  if (!bgJobId) return false;
+  if (!bgJobId) return executor === "sdk"; // sdk in-process worker: live with no bg id
   try {
     return isBgJobAlive(bgJobId) === true;
   } catch {
@@ -123,6 +132,11 @@ export function enqueueDelegateIntent(anchor, payload = {}, deps = {}) {
 
   const now = deps.now ?? (() => Date.now());
   const isBgJobAlive = deps.isBgJobAlive ?? (() => false);
+  // CTL-1157 (GROUP-3 #2): the resolved executor ("sdk" | else). Threaded from the
+  // scheduler (dispatchMode==="sdk"). Makes the live-worker probe sdk-aware so a
+  // dispatched|running sdk signal with no bg_job_id dedups a second enqueue instead
+  // of double-dispatching. Absent/"bg" → byte-identical to today.
+  const executor = deps.executor ?? null;
 
   // (1) queue-file existence — one non-terminal intent per anchor.
   const existing = readIntentFile(intentPath(orchDir, anchor));
@@ -131,7 +145,7 @@ export function enqueueDelegateIntent(anchor, payload = {}, deps = {}) {
   }
 
   // (2) live recovery-pass worker — never even queue a redundant run.
-  if (recoveryPassWorkerLive(orchDir, anchor, isBgJobAlive)) {
+  if (recoveryPassWorkerLive(orchDir, anchor, isBgJobAlive, executor)) {
     return { enqueued: false, reason: "worker-live" };
   }
 
@@ -249,6 +263,14 @@ export function gcDelegateIntents(orchDir, now, deps = {}) {
   const ttlMs = Number.isFinite(deps.ttlMs) ? deps.ttlMs : DEFAULT_INTENT_TTL_MS;
   const isBgJobAlive = deps.isBgJobAlive ?? (() => false);
   const nowMs = typeof now === "number" ? now : Date.now();
+  // CTL-1157 (GROUP-3 #2): the resolved executor ("sdk" | else), threaded from the
+  // scheduler (dispatchMode==="sdk"). Under sdk a delegate launches an IN-PROCESS
+  // query() and its intent flips to `launched` with bg_job_id:null LEGITIMATELY —
+  // dropping it as "dead bg job" (case c) would free the reservation and let the
+  // next scan re-dispatch the same in-flight ticket. When sdk-aware, a launched
+  // no-bg_job_id intent is kept LIVE; its cleanup rides the worker-terminal (case b)
+  // + TTL (case a) paths instead. Absent/"bg" → byte-identical to today.
+  const executor = deps.executor ?? null;
 
   let removed = 0;
   for (const name of entries) {
@@ -276,7 +298,12 @@ export function gcDelegateIntents(orchDir, now, deps = {}) {
       const bgJobId = intent.bg_job_id ?? null;
       let alive = false;
       try {
-        alive = bgJobId ? isBgJobAlive(bgJobId) === true : false;
+        // CTL-1157 (GROUP-3 #2): under sdk a launched delegate carries NO bg_job_id
+        // (in-process query()) — that is a LIVE worker, not a dead bg job. Keep it
+        // (its cleanup rides case b's worker-terminal check + case a's TTL). Under
+        // bg a missing/dead bg_job_id stays droppable (byte-identical).
+        if (!bgJobId) alive = executor === "sdk";
+        else alive = isBgJobAlive(bgJobId) === true;
       } catch {
         alive = false;
       }

--- a/plugins/dev/scripts/execution-core/delegate-queue.test.mjs
+++ b/plugins/dev/scripts/execution-core/delegate-queue.test.mjs
@@ -296,6 +296,30 @@ describe("enqueueDelegateIntent — live-worker idempotency", () => {
     );
     expect(r.enqueued).toBe(true);
   });
+
+  // CTL-1157 (GROUP-3 #2): under executor=sdk the recovery-pass worker runs in-process
+  // with NO bg_job_id. That dispatched|running signal is a LIVE worker — a second scan
+  // must dedup it (worker-live) instead of double-dispatching.
+  test("sdk: a dispatched recovery-pass worker with NO bg_job_id blocks enqueue when executor==='sdk'", () => {
+    seedRecoveryPassSignal("CTL-1", "dispatched", null); // sdk shape: no bg id
+    const r = enqueueDelegateIntent(
+      "CTL-1",
+      INTENT,
+      deps({ isBgJobAlive: () => false, executor: "sdk" })
+    );
+    expect(r.enqueued).toBe(false);
+    expect(r.reason).toBe("worker-live");
+  });
+
+  test("bg (default): a dispatched worker with NO bg_job_id does NOT block enqueue (byte-identical)", () => {
+    seedRecoveryPassSignal("CTL-1", "dispatched", null);
+    const r = enqueueDelegateIntent(
+      "CTL-1",
+      INTENT,
+      deps({ isBgJobAlive: () => false }) // no executor → bg semantics
+    );
+    expect(r.enqueued).toBe(true);
+  });
 });
 
 // ─── enqueue idempotency layer 3: hard ceiling ───────────────────────────────
@@ -426,6 +450,32 @@ describe("gcDelegateIntents — removal & retention", () => {
     );
     expect(removed).toBe(0);
     expect(existsSync(intentPath("CTL-running"))).toBe(true);
+  });
+
+  // CTL-1157 (GROUP-3 #2): under executor=sdk a launched delegate carries NO bg_job_id
+  // (in-process query()). The GC must NOT drop it as a dead bg job — dropping it frees
+  // the reservation/existence guard and lets the next scan re-dispatch the same ticket.
+  test("sdk: RETAINS a launched intent with NO bg_job_id when executor==='sdk' (worker non-terminal, within TTL)", () => {
+    seedIntent("CTL-sdk", { status: "launched", bg_job_id: null, launchedAt: FIXED_NOW });
+    seedRecoveryPassSignal("CTL-sdk", "running", null); // in-process worker still live
+    const removed = gcDelegateIntents(orchDir, FIXED_NOW, deps({ executor: "sdk" }));
+    expect(removed).toBe(0);
+    expect(existsSync(intentPath("CTL-sdk"))).toBe(true);
+  });
+
+  test("sdk: still DROPS a launched no-bg_job_id intent once the worker signal is terminal", () => {
+    seedIntent("CTL-sdk-done", { status: "launched", bg_job_id: null, launchedAt: FIXED_NOW });
+    seedRecoveryPassSignal("CTL-sdk-done", "done", null); // worker finished (terminal → case b)
+    const removed = gcDelegateIntents(orchDir, FIXED_NOW, deps({ executor: "sdk" }));
+    expect(removed).toBe(1);
+    expect(existsSync(intentPath("CTL-sdk-done"))).toBe(false);
+  });
+
+  test("bg (default): a launched intent with NO bg_job_id is STILL dropped (byte-identical)", () => {
+    seedIntent("CTL-bg-null", { status: "launched", bg_job_id: null, launchedAt: FIXED_NOW });
+    const removed = gcDelegateIntents(orchDir, FIXED_NOW, deps()); // no executor → bg
+    expect(removed).toBe(1);
+    expect(existsSync(intentPath("CTL-bg-null"))).toBe(false);
   });
 
   test("RETAINS a claimed intent (mid-flight, no bg job yet, within TTL)", () => {

--- a/plugins/dev/scripts/execution-core/delegate-runner-entry.mjs
+++ b/plugins/dev/scripts/execution-core/delegate-runner-entry.mjs
@@ -54,6 +54,7 @@ import {
 import { defaultInvokeRecoveryPass } from "./recovery-reasoning.mjs";
 import { countBackgroundAgents as defaultCountBackgroundAgents } from "./claude-agents.mjs";
 import { isBgJobAlive as defaultIsBgJobAlive } from "./claude-agents.mjs";
+import { countSdkInflight as defaultCountSdkInflight } from "./signal-reader.mjs"; // CTL-1157 Codex round-6: existing dispatched/running sdk workers occupancy (no bg job → countBg misses them)
 import { computeFreeSlots, readMaxParallel } from "./scheduler.mjs";
 
 const RECOVERY_PASS_PHASE = "recovery-pass";
@@ -159,6 +160,7 @@ export function drainOnce(deps = {}) {
   const reclaimFn = deps.reclaimFn ?? defaultReclaimStaleClaims;
   const invokeFn = deps.invokeFn ?? defaultInvokeRecoveryPass;
   const countBg = deps.countBackgroundAgents ?? defaultCountBackgroundAgents;
+  const countSdkInflight = deps.countSdkInflight ?? defaultCountSdkInflight;
   const isBgJobAlive = deps.isBgJobAlive ?? defaultIsBgJobAlive;
   const appendRequested =
     deps.appendRequested ?? defaultAppendDispatchRequestedEvent;
@@ -180,6 +182,18 @@ export function drainOnce(deps = {}) {
   // byte-identical.
   const executor = deps.executor ?? null;
   let localLaunched = 0;
+  // CTL-1157 (Codex round-6, corrected): the sdk slot budget is the SUM of three
+  // DISJOINT terms — countBg (bg workers, re-read per iteration) + the PRE-EXISTING
+  // sdk in-flight workers sampled ONCE below + localLaunched (this pass's sdk launches).
+  // This mirrors the scheduler's sample-once occupiedCount + per-launch increment
+  // (scheduler.mjs). The tempting one-liner "re-read countSdkInflight each iteration AND
+  // add localLaunched" DOUBLE-COUNTS every launch: an sdk dispatch's synchronous
+  // prelaunch writes workers/<ticket>/phase-<phase>.json (dispatched, no bg_job_id)
+  // BEFORE invokeFn returns, so a per-iteration countSdkInflight already sees this pass's
+  // launches — adding localLaunched on top halves effective parallelism at maxParallel≥2.
+  // Sampling ONCE here (no this-pass launch has happened yet) keeps the two terms disjoint.
+  let sdkInflightBaseline = 0;
+  let sdkBaselineOk = true;
   // CTL-1157 F P1: under executor=sdk each dispatch launches an IN-PROCESS query()
   // that settles asynchronously (invokeFn returns the settled chain in
   // details.pendingSdk). This disposable child must await those before exiting or
@@ -194,6 +208,23 @@ export function drainOnce(deps = {}) {
     result.reclaimed = reclaimFn(orchDir, now(), ceilingMs);
   } catch (err) {
     log.warn({ err: err?.message }, "delegate-runner: reclaim failed");
+  }
+
+  // (0b) Sample the PRE-EXISTING sdk in-flight occupancy ONCE (dispatched/running sdk
+  // phase workers, no bg job → invisible to countBg). Disjoint from localLaunched below.
+  // A count failure fails CLOSED (the drain holds every intent), matching the per-item
+  // countBg posture (CTL-731: never over-spawn on an untrustworthy live count). bg stays
+  // 0 (bg workers surface in countBg) → byte-identical to before.
+  if (executor === "sdk") {
+    try {
+      sdkInflightBaseline = countSdkInflight(orchDir) ?? 0;
+    } catch (err) {
+      sdkBaselineOk = false;
+      log.warn(
+        { err: err?.message },
+        "delegate-runner: sdk in-flight baseline count failed — fail-closed (holding all intents this pass)"
+      );
+    }
   }
 
   for (const ticket of listQueuedTickets(orchDir)) {
@@ -246,12 +277,15 @@ export function drainOnce(deps = {}) {
         "delegate-runner: bg count failed — un-claiming (fail-closed, no launch on unknown count)"
       );
     }
-    // Under sdk, fold this pass's synchronous launches into the live count so the
-    // slot limit is honored across multiple queued intents in one drain (bg jobs
-    // already show up in countBg, so localLaunched stays 0 there).
+    // effectiveLive = live bg workers (re-read each iteration) + PRE-EXISTING sdk
+    // workers (sampled once in step 0b) + THIS pass's sdk launches (localLaunched). All
+    // three are disjoint, so the slot limit is honored across queued intents AND
+    // concurrent sdk phase workers with no double-count. bg path is byte-identical
+    // (sdkInflightBaseline and localLaunched both stay 0). A failed sdk baseline sample
+    // (sdkBaselineOk=false) holds every intent this pass (fail-closed).
     const effectiveLive =
-      executor === "sdk" ? (live ?? 0) + localLaunched : live;
-    if (!countOk || computeFreeSlots(max, effectiveLive) <= 0) {
+      executor === "sdk" ? (live ?? 0) + sdkInflightBaseline + localLaunched : live;
+    if (!countOk || !sdkBaselineOk || computeFreeSlots(max, effectiveLive) <= 0) {
       try {
         transitionFn(orchDir, ticket, { from: claimPath, status: "queued" });
       } catch (err) {

--- a/plugins/dev/scripts/execution-core/delegate-runner-entry.mjs
+++ b/plugins/dev/scripts/execution-core/delegate-runner-entry.mjs
@@ -165,6 +165,16 @@ export function drainOnce(deps = {}) {
     ? deps.claimCeilingMs
     : DEFAULT_CLAIM_CEILING_MS;
   const max = resolveMaxParallel(deps.maxParallel);
+  // CTL-1157 GROUP C: the executor this drain dispatches through. An sdk dispatch
+  // settles SYNCHRONOUSLY with no bg job, so countBg cannot see it on the next
+  // loop iteration — without a local counter, multiple queued intents would each
+  // pass the free-slot check and overrun the scheduler's slot limit at
+  // maxParallel=1. Track the synchronous launches already performed in THIS pass
+  // and count them toward the capacity check when executor==="sdk". bg launches
+  // DO surface in countBg, so for bg this counter is unused and behavior is
+  // byte-identical.
+  const executor = deps.executor ?? null;
+  let localLaunched = 0;
 
   // (0) Crash safety: reclaim claimed-* sidecars older than one ceiling window
   //     back to queued so a dead runner doesn't strand an intent forever.
@@ -224,7 +234,12 @@ export function drainOnce(deps = {}) {
         "delegate-runner: bg count failed — un-claiming (fail-closed, no launch on unknown count)"
       );
     }
-    if (!countOk || computeFreeSlots(max, live) <= 0) {
+    // Under sdk, fold this pass's synchronous launches into the live count so the
+    // slot limit is honored across multiple queued intents in one drain (bg jobs
+    // already show up in countBg, so localLaunched stays 0 there).
+    const effectiveLive =
+      executor === "sdk" ? (live ?? 0) + localLaunched : live;
+    if (!countOk || computeFreeSlots(max, effectiveLive) <= 0) {
       try {
         transitionFn(orchDir, ticket, { from: claimPath, status: "queued" });
       } catch (err) {
@@ -306,6 +321,10 @@ export function drainOnce(deps = {}) {
       } catch {
         /* best-effort */
       }
+      // Count this dispatch toward the in-pass slot reservation. Only consulted
+      // when executor==="sdk" (synchronous, invisible to countBg); for bg the
+      // launched job is counted by countBg on the next iteration instead.
+      localLaunched++;
       result.drained++;
     } else {
       const failReason = r?.reason ?? "dispatch-failed";
@@ -458,7 +477,7 @@ if (isEntrypoint) {
         ...invokeDeps,
         dispatchTicket: (o, t, p) => dispatchTicketSeam(o, t, p, { dispatch: executorDispatch }),
       });
-    const r = drainOnce({ orchDir, maxParallel: readMaxParallel(orchDir, {}), invokeFn });
+    const r = drainOnce({ orchDir, maxParallel: readMaxParallel(orchDir, {}), invokeFn, executor });
     log.info({ ...r, executor }, "delegate-runner-entry: drain complete");
   } catch (err) {
     log.warn({ err: err?.message }, "delegate-runner-entry: drain threw");

--- a/plugins/dev/scripts/execution-core/delegate-runner-entry.mjs
+++ b/plugins/dev/scripts/execution-core/delegate-runner-entry.mjs
@@ -34,7 +34,11 @@ import {
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
 
-import { log } from "./config.mjs";
+import { log, getExecutor } from "./config.mjs";
+// CTL-1157 F3: route the detached delegate's dispatch through the node's executor
+// (sdk vs bg) instead of the hardcoded bg path baked into defaultInvokeRecoveryPass.
+import { dispatchForExecutor, dispatchTicket as dispatchTicketSeam } from "./dispatch.mjs";
+import { resolveSdkBootExecutor } from "./sdk-run-phase-agent.mjs"; // auth-aware sdk→bg degrade (this detached child does NOT run the daemon-boot gate)
 import {
   delegateQueueDir,
   claimIntent as defaultClaimIntent,
@@ -439,8 +443,23 @@ if (isEntrypoint) {
     // → Infinity, which would let the runner launch a delegate past maxParallel even
     // when the board is full. readMaxParallel(orchDir, {}) reads the same state.json
     // ceiling the scheduler tick uses.
-    const r = drainOnce({ orchDir, maxParallel: readMaxParallel(orchDir, {}) });
-    log.info({ ...r }, "delegate-runner-entry: drain complete");
+    // CTL-1157 F3: re-resolve the executor in this DETACHED child (it does NOT run
+    // the daemon-boot resolveSdkBootExecutor gate), degrading sdk→bg when the
+    // subscription-auth precondition fails (no CLAUDE_CODE_OAUTH_TOKEN) so a
+    // detached delegate never attempts an sdk launch it can't authenticate. On a
+    // bg fleet this is a pure no-op (dispatchForExecutor("bg") === defaultDispatch),
+    // so the launched delegate is byte-identical to today. The invokeFn wrapper
+    // curries the resolved dispatch into defaultInvokeRecoveryPass via its
+    // deps.dispatchTicket seam.
+    const { executor } = resolveSdkBootExecutor(getExecutor(), { log });
+    const executorDispatch = dispatchForExecutor(executor);
+    const invokeFn = (ticket, briefObj, invokeDeps) =>
+      defaultInvokeRecoveryPass(ticket, briefObj, {
+        ...invokeDeps,
+        dispatchTicket: (o, t, p) => dispatchTicketSeam(o, t, p, { dispatch: executorDispatch }),
+      });
+    const r = drainOnce({ orchDir, maxParallel: readMaxParallel(orchDir, {}), invokeFn });
+    log.info({ ...r, executor }, "delegate-runner-entry: drain complete");
   } catch (err) {
     log.warn({ err: err?.message }, "delegate-runner-entry: drain threw");
   } finally {

--- a/plugins/dev/scripts/execution-core/delegate-runner-entry.mjs
+++ b/plugins/dev/scripts/execution-core/delegate-runner-entry.mjs
@@ -180,6 +180,13 @@ export function drainOnce(deps = {}) {
   // byte-identical.
   const executor = deps.executor ?? null;
   let localLaunched = 0;
+  // CTL-1157 F P1: under executor=sdk each dispatch launches an IN-PROCESS query()
+  // that settles asynchronously (invokeFn returns the settled chain in
+  // details.pendingSdk). This disposable child must await those before exiting or
+  // process.exit kills the just-launched workers. Collect them here; the entrypoint
+  // awaits result.pending before process.exit(0). bg dispatch is synchronous, so
+  // pendingSdk is null and this array stays empty (byte-identical to before).
+  const pending = [];
 
   // (0) Crash safety: reclaim claimed-* sidecars older than one ceiling window
   //     back to queued so a dead runner doesn't strand an intent forever.
@@ -331,6 +338,10 @@ export function drainOnce(deps = {}) {
       // launched job is counted by countBg on the next iteration instead.
       localLaunched++;
       result.drained++;
+      // CTL-1157 F P1: hold the in-process sdk query's settled chain so the
+      // entrypoint can await it before process.exit. Null on the bg path.
+      const pendingSdk = r.details?.pendingSdk;
+      if (pendingSdk && typeof pendingSdk.then === "function") pending.push(pendingSdk);
     } else {
       const failReason = r?.reason ?? "dispatch-failed";
       try {
@@ -359,6 +370,9 @@ export function drainOnce(deps = {}) {
     }
   }
 
+  // CTL-1157 F P1: expose the in-process sdk query promises so the detached
+  // entrypoint can await them before process.exit. Empty on the bg path.
+  result.pending = pending;
   return result;
 }
 
@@ -483,7 +497,23 @@ if (isEntrypoint) {
         dispatchTicket: (o, t, p) => dispatchTicketSeam(o, t, p, { dispatch: executorDispatch }),
       });
     const r = drainOnce({ orchDir, maxParallel: readMaxParallel(orchDir, {}), invokeFn, executor });
-    log.info({ ...r, executor }, "delegate-runner-entry: drain complete");
+    // CTL-1157 F P1: under executor=sdk each launched delegate is an IN-PROCESS
+    // query() that resolves only AFTER the whole recovery-pass runs. drainOnce
+    // returns those settled chains in r.pending. Await them here — otherwise the
+    // process.exit(0) below kills the just-launched worker mid-run (the intent is
+    // already marked "launched", so the recovery item would never actually run). The
+    // chains NEVER reject (settleDispatchSync swallows), so allSettled is belt-and-
+    // suspenders. On bg, r.pending is empty and this resolves immediately (the bg job
+    // is a separate OS process that survives this child's exit — byte-identical).
+    if (Array.isArray(r.pending) && r.pending.length > 0) {
+      log.info(
+        { executor, pending: r.pending.length },
+        "delegate-runner-entry: awaiting in-process sdk delegate(s) before exit"
+      );
+      await Promise.allSettled(r.pending);
+    }
+    const { pending: _pending, ...summary } = r;
+    log.info({ ...summary, executor }, "delegate-runner-entry: drain complete");
   } catch (err) {
     log.warn({ err: err?.message }, "delegate-runner-entry: drain threw");
   } finally {

--- a/plugins/dev/scripts/execution-core/delegate-runner-entry.mjs
+++ b/plugins/dev/scripts/execution-core/delegate-runner-entry.mjs
@@ -84,14 +84,19 @@ function readJsonFile(path) {
 // bg_job_id is alive. Mirrors delegate-queue's enqueue-time live-worker check so
 // the runner re-checks the same condition at DRAIN time (the worker may have
 // launched between enqueue and drain).
-function recoveryPassWorkerLive(orchDir, ticket, isBgJobAlive) {
+//
+// CTL-1157 (GROUP-3 #2): sdk-aware. Under executor=sdk the recovery-pass worker
+// runs IN-PROCESS with no bg_job_id (dispatch.mjs E3); a dispatched|running sdk
+// signal with no bg_job_id is LIVE, so a second drain scan dedups it instead of
+// re-launching the same ticket. Under bg the discriminator is absent → byte-identical.
+function recoveryPassWorkerLive(orchDir, ticket, isBgJobAlive, executor) {
   const sig = readJsonFile(
     join(orchDir, "workers", ticket, "phase-recovery-pass.json")
   );
   if (!sig) return false;
   if (sig.status !== "dispatched" && sig.status !== "running") return false;
   const bgJobId = sig.bg_job_id ?? null;
-  if (!bgJobId) return false;
+  if (!bgJobId) return executor === "sdk"; // sdk in-process worker: live with no bg id
   try {
     return isBgJobAlive(bgJobId) === true;
   } catch {
@@ -202,7 +207,7 @@ export function drainOnce(deps = {}) {
     //     (the work it would have started already exists), so it is removed:
     //     it must NOT keep reserving a slot, and there is nothing to re-drain.
     //     We unlink the consumed claim sidecar and the canonical intent file.
-    if (recoveryPassWorkerLive(orchDir, ticket, isBgJobAlive)) {
+    if (recoveryPassWorkerLive(orchDir, ticket, isBgJobAlive, executor)) {
       for (const p of [claimPath, intentPath(orchDir, ticket)]) {
         try {
           unlinkSync(p);

--- a/plugins/dev/scripts/execution-core/delegate-runner.test.mjs
+++ b/plugins/dev/scripts/execution-core/delegate-runner.test.mjs
@@ -170,6 +170,31 @@ describe("drainOnce — drains a queued intent → launched", () => {
     expect(res.drained).toBe(1);
   });
 
+  // CTL-1157 F P1 (Codex round-4): under executor=sdk the recovery-pass runs as an
+  // IN-PROCESS query() that settles asynchronously; invokeFn surfaces its settled chain
+  // in details.pendingSdk. drainOnce must collect those into result.pending so the
+  // detached entrypoint can await them before process.exit (else it kills the worker it
+  // just launched). bg dispatch has no pendingSdk → result.pending stays empty.
+  test("collects details.pendingSdk (executor=sdk) into result.pending; bg leaves it empty", () => {
+    seedQueued("CTL-1");
+    const pendingSdk = Promise.resolve({ code: 0 });
+    const sdkDeps = makeDeps();
+    sdkDeps.executor = "sdk";
+    sdkDeps.invokeFn = () => ({
+      dispatched: true,
+      details: { bg_job_id: null, worktreePath: "/wt/CTL-1", pendingSdk },
+    });
+    const sdkRes = drainOnce(sdkDeps);
+    expect(Array.isArray(sdkRes.pending)).toBe(true);
+    expect(sdkRes.pending).toContain(pendingSdk);
+
+    seedQueued("CTL-2");
+    const bgDeps = makeDeps();
+    bgDeps.invokeFn = () => ({ dispatched: true, details: { bg_job_id: "bg-1", worktreePath: "/wt/CTL-2" } });
+    const bgRes = drainOnce(bgDeps);
+    expect(bgRes.pending).toEqual([]); // bg job is a separate OS process — nothing to await
+  });
+
   test("emits phase.dispatch.requested then phase.dispatch.launched (in order, with bg_job_id)", () => {
     seedQueued("CTL-1");
     const deps = makeDeps();

--- a/plugins/dev/scripts/execution-core/delegate-runner.test.mjs
+++ b/plugins/dev/scripts/execution-core/delegate-runner.test.mjs
@@ -409,6 +409,69 @@ describe("drainOnce — free-slot re-check", () => {
     expect(invokes).toBe(2);
     expect(res.drained).toBe(2);
   });
+
+  // CTL-1157 (Codex round-6): the sdk slot budget is countBg + a ONCE-sampled
+  // pre-existing sdk baseline + localLaunched — three DISJOINT terms. The earlier
+  // round-6 attempt re-read countSdkInflight per iteration AND added localLaunched,
+  // which double-counted each launch (the synchronous prelaunch signal is on disk
+  // before invokeFn returns, so a per-iteration re-read already sees this pass's
+  // launches) and halved effective parallelism at maxParallel>=2.
+  test("executor=sdk: baseline sampled ONCE — all queued intents launch when slots are free (no halving)", () => {
+    seedQueued("CTL-SDK-A");
+    seedQueued("CTL-SDK-B");
+    seedQueued("CTL-SDK-C");
+    let sdkCalls = 0;
+    const deps = makeDeps({
+      maxParallel: 3,
+      executor: "sdk",
+      countBackgroundAgents: () => 0,
+      countSdkInflight: () => {
+        sdkCalls++;
+        return 0; // no pre-existing sdk work
+      },
+      invokeFn: () => ({ dispatched: true, details: { bg_job_id: null, worktreePath: "/wt", pendingSdk: null } }),
+    });
+
+    const res = drainOnce(deps);
+
+    expect(res.drained).toBe(3); // ALL three — not ceil(3/2)=2 (the double-count bug)
+    expect(sdkCalls).toBe(1); // sampled ONCE as a baseline, never re-read per iteration
+  });
+
+  test("executor=sdk: PRE-EXISTING sdk workers (baseline) consume slots — only free slots launch", () => {
+    seedQueued("CTL-SDK-A");
+    seedQueued("CTL-SDK-B");
+    seedQueued("CTL-SDK-C");
+    const deps = makeDeps({
+      maxParallel: 3,
+      executor: "sdk",
+      countBackgroundAgents: () => 0,
+      countSdkInflight: () => 2, // two sdk phase workers already in flight → 1 free slot
+      invokeFn: () => ({ dispatched: true, details: { bg_job_id: null, worktreePath: "/wt", pendingSdk: null } }),
+    });
+
+    const res = drainOnce(deps);
+
+    expect(res.drained).toBe(1); // only the one genuinely-free slot launches
+  });
+
+  test("executor=sdk: a baseline sdk count failure fails CLOSED (holds every intent)", () => {
+    seedQueued("CTL-SDK-A");
+    const deps = makeDeps({
+      maxParallel: 3,
+      executor: "sdk",
+      countBackgroundAgents: () => 0,
+      countSdkInflight: () => {
+        throw new Error("signal scan failed");
+      },
+      invokeFn: () => ({ dispatched: true, details: {} }),
+    });
+
+    const res = drainOnce(deps);
+
+    expect(res.drained).toBe(0); // never launch on an untrustworthy sdk occupancy count
+    expect(readIntent("CTL-SDK-A").status).toBe("queued"); // un-claimed back to queued
+  });
 });
 
 describe("drainOnce — live-worker supersede (idempotency)", () => {

--- a/plugins/dev/scripts/execution-core/delegate-runner.test.mjs
+++ b/plugins/dev/scripts/execution-core/delegate-runner.test.mjs
@@ -416,6 +416,32 @@ describe("drainOnce — live-worker supersede (idempotency)", () => {
     drainOnce(deps);
     expect(readIntent("CTL-7").status).toBe("launched");
   });
+
+  // CTL-1157 (GROUP-3 #2): under executor=sdk the recovery-pass worker runs in-process
+  // with NO bg_job_id — a dispatched|running signal there is LIVE. A second drain scan
+  // must SUPERSEDE (not re-launch) it, otherwise the same ticket double-dispatches.
+  test("sdk: a running recovery-pass worker with NO bg_job_id → superseded (no re-dispatch) when executor==='sdk'", () => {
+    seedQueued("CTL-sdk");
+    seedRecoveryPassSignal("CTL-sdk", "running", null); // sdk shape: no bg id
+    const deps = makeDeps({ executor: "sdk", isBgJobAlive: () => false });
+    let invoked = false;
+    deps.invokeFn = () => {
+      invoked = true;
+      return { dispatched: true, details: {} };
+    };
+    const res = drainOnce(deps);
+    expect(invoked).toBe(false);
+    expect(existsSync(intentPath("CTL-sdk"))).toBe(false); // GC'd, not launched
+    expect(res.superseded).toBe(1);
+  });
+
+  test("bg (default): a running worker with NO bg_job_id does NOT supersede → dispatches (byte-identical)", () => {
+    seedQueued("CTL-bgnull");
+    seedRecoveryPassSignal("CTL-bgnull", "running", null);
+    const deps = makeDeps({ isBgJobAlive: () => false }); // no executor → bg
+    drainOnce(deps);
+    expect(readIntent("CTL-bgnull").status).toBe("launched");
+  });
 });
 
 describe("drainOnce — single-flight (two concurrent drains)", () => {

--- a/plugins/dev/scripts/execution-core/delegate-runner.test.mjs
+++ b/plugins/dev/scripts/execution-core/delegate-runner.test.mjs
@@ -334,6 +334,56 @@ describe("drainOnce — free-slot re-check", () => {
     drainOnce(deps);
     expect(readIntent("CTL-5").status).toBe("launched");
   });
+
+  // GROUP C: an sdk dispatch settles synchronously with NO bg job, so countBg
+  // cannot see this pass's launches. drainOnce must count them locally so it does
+  // not overrun maxParallel across multiple queued intents in one drain.
+  test("executor=sdk: with maxParallel=1 and two queued intents, only ONE launches (the second un-claims)", () => {
+    seedQueued("CTL-SDK-1");
+    seedQueued("CTL-SDK-2");
+    let invokes = 0;
+    const deps = makeDeps({
+      maxParallel: 1,
+      executor: "sdk",
+      // sdk dispatch is synchronous & invisible to countBg — it stays 0 the
+      // whole pass, exactly the condition that used to let BOTH intents launch.
+      countBackgroundAgents: () => 0,
+      invokeFn: () => {
+        invokes++;
+        return { dispatched: true, details: {} }; // sdk: no bg_job_id
+      },
+    });
+
+    const res = drainOnce(deps);
+
+    expect(invokes).toBe(1); // slot limit honored despite the static bg count
+    expect(res.drained).toBe(1);
+    const statuses = ["CTL-SDK-1", "CTL-SDK-2"].map((t) => readIntent(t).status).sort();
+    expect(statuses).toEqual(["launched", "queued"]); // one launched, one held
+    expect(deps._emitted.launched).toHaveLength(1);
+  });
+
+  // The bg path is unchanged: localLaunched is never consulted (executor != sdk),
+  // so the per-intent countBg check governs exactly as before.
+  test("executor=bg: localLaunched is NOT consulted (bg jobs surface in countBg)", () => {
+    seedQueued("CTL-BG-1");
+    seedQueued("CTL-BG-2");
+    let invokes = 0;
+    const deps = makeDeps({
+      maxParallel: 8,
+      executor: "bg",
+      countBackgroundAgents: () => 0, // plenty of headroom for both
+      invokeFn: (ticket) => {
+        invokes++;
+        return { dispatched: true, details: { bg_job_id: `bg-${ticket}` } };
+      },
+    });
+
+    const res = drainOnce(deps);
+
+    expect(invokes).toBe(2);
+    expect(res.drained).toBe(2);
+  });
 });
 
 describe("drainOnce — live-worker supersede (idempotency)", () => {

--- a/plugins/dev/scripts/execution-core/dispatch.mjs
+++ b/plugins/dev/scripts/execution-core/dispatch.mjs
@@ -356,13 +356,20 @@ export function settleDispatchSync(result, { verifySync, onSettled } = {}) {
     // (a) Detached settle handler — the query runs to completion in the background;
     // its terminal event is emitted by the worker/backstop. Swallow the settlement
     // so it can never surface as an unhandled rejection on the daemon event loop.
-    Promise.resolve(result).then(
-      (r) => { if (onSettled) { try { onSettled(r, null); } catch { /* best-effort */ } } },
-      (err) => { if (onSettled) { try { onSettled(null, err); } catch { /* best-effort */ } } },
+    // CTL-1157 F P1: capture the settled chain as `pending`. Both handlers RETURN
+    // (never re-throw), so `pending` NEVER rejects — awaiting it is always safe. The
+    // long-lived daemon entry points ignore it (byte-identical to before: the chain is
+    // still detached + swallowed). The ONE caller that must await it is the disposable,
+    // out-of-process delegate-runner child, whose executor=sdk query() runs IN-PROCESS
+    // and would be killed by the child's process.exit if it exited before the query
+    // finished (delegate-runner-entry). It reads `pending` and awaits it before exiting.
+    const pending = Promise.resolve(result).then(
+      (r) => { if (onSettled) { try { onSettled(r, null); } catch { /* best-effort */ } } return r; },
+      (err) => { if (onSettled) { try { onSettled(null, err); } catch { /* best-effort */ } } return { code: 1, error: err }; },
     );
     // (b) Synchronous provisional: the prelaunch signal IS the launch confirmation.
     const ok = verifySync ? verifySync() !== false : true;
-    return { code: ok ? 0 : 1, async: true };
+    return { code: ok ? 0 : 1, async: true, pending };
   }
   return result;
 }

--- a/plugins/dev/scripts/execution-core/dispatch.test.mjs
+++ b/plugins/dev/scripts/execution-core/dispatch.test.mjs
@@ -1015,13 +1015,20 @@ describe("settleDispatchSync (CTL-1367 P1)", () => {
     let settled = false;
     const p = Promise.resolve({ code: 0 });
     const r = settleDispatchSync(p, { verifySync: () => true, onSettled: () => { settled = true; } });
-    expect(r).toEqual({ code: 0, async: true }); // resolved SYNCHRONOUSLY
-    await p; await Promise.resolve(); // let the detached handler run
+    // CTL-1157 F P1: the provisional now also carries `pending` (the never-rejecting
+    // settled chain) so the detached delegate-runner child can await the in-process
+    // sdk query before process.exit. The long-lived daemon entry points ignore it.
+    expect(r.code).toBe(0); // resolved SYNCHRONOUSLY
+    expect(r.async).toBe(true);
+    expect(typeof r.pending?.then).toBe("function");
+    await r.pending; await Promise.resolve(); // let the detached handler run
     expect(settled).toBe(true);
   });
   test("a Promise → { code:1 } when verifySync fails (prelaunch never wrote a runnable signal)", () => {
     const r = settleDispatchSync(Promise.resolve({ code: 1 }), { verifySync: () => false });
-    expect(r).toEqual({ code: 1, async: true });
+    expect(r.code).toBe(1);
+    expect(r.async).toBe(true);
+    expect(typeof r.pending?.then).toBe("function"); // CTL-1157 F P1
   });
   test("a rejecting Promise never escapes as an unhandled rejection", async () => {
     let err = null;
@@ -1138,8 +1145,9 @@ describe("backstopOnRejection (CTL-1367 P1)", () => {
         { emitBackstop: (a) => calls.push(a) },
       ),
     });
-    expect(r).toEqual({ code: 0, async: true }); // provisional success off the prelaunch signal
-    await Promise.resolve(); await Promise.resolve(); // let the detached handler run
+    expect(r.code).toBe(0); // provisional success off the prelaunch signal
+    expect(r.async).toBe(true);
+    await r.pending; await Promise.resolve(); // let the detached handler run (CTL-1157 F P1)
     expect(calls).toHaveLength(1);
     expect(calls[0]).toMatchObject({ ticket: "CTL-10", phase: "implement", status: "failed" });
     expect(calls[0].reason).toMatch(/non-array spec.env/);

--- a/plugins/dev/scripts/execution-core/integration-ctl-1240.test.mjs
+++ b/plugins/dev/scripts/execution-core/integration-ctl-1240.test.mjs
@@ -15,6 +15,8 @@ import {
   mkdirSync,
   rmSync,
   writeFileSync,
+  readFileSync,
+  readdirSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -141,9 +143,31 @@ describe("CTL-1240 Phase 1 — gateway threaded through startScheduler spine", (
     // PRE-FIX: gateway is dropped at startScheduler → this assertion fails (calls.length === 0).
     expect(gateway.calls.length).toBeGreaterThan(0);
 
-    // Behavioral proof: Done ticket was filtered (terminal → no marker);
-    // In-Progress ticket was processed (non-terminal → marker written).
-    expect(existsSync(recoveryIntentMarker(LIVE_TICKET))).toBe(true);
+    // Behavioral proof: Done ticket was filtered (terminal → not processed);
+    // In-Progress ticket was processed (non-terminal). CTL-1157 F #5 retired the
+    // recovery-intent MARKER as the observable — shadow mode no longer writes a
+    // cooldown marker for a DEFERRED (untyped stuck) item (it would mutate enforce
+    // scheduler state). The processing observable is now the recovery.would-defer
+    // EVENT in the unified log (under the redirected CATALYST_DIR): the non-terminal
+    // LIVE ticket emits it; the terminal DONE ticket is filtered by Pass 0r → no
+    // recovery event names it.
+    const eventsDir = join(catalystDir, "events");
+    const eventLines = existsSync(eventsDir)
+      ? readdirSync(eventsDir)
+          .flatMap((f) => readFileSync(join(eventsDir, f), "utf8").split("\n"))
+          .filter(Boolean)
+      : [];
+    // LIVE (non-terminal) was PROCESSED by the reasoning pass → per-item would-defer.
+    expect(eventLines.some((l) => l.includes(LIVE_TICKET) && l.includes("would-defer"))).toBe(true);
+    // DONE (terminal) was FILTERED by Pass 0r before the reasoning pass → it has NO
+    // per-item reasoning event (recovery.decision / recovery.would-*). It legitimately
+    // appears in the whole-board recovery.board-scan snapshot — that is a census, not
+    // processing — so match only the per-item event names, not a bare "recovery.".
+    const donePerItem = eventLines.some(
+      (l) => l.includes(DONE_TICKET) && (l.includes("recovery.decision") || l.includes("would-")),
+    );
+    expect(donePerItem).toBe(false);
+    // And the DONE ticket is still never cooled down (terminal → filtered before processing).
     expect(existsSync(recoveryIntentMarker(DONE_TICKET))).toBe(false);
   });
 });

--- a/plugins/dev/scripts/execution-core/linear-reconcile-cli.mjs
+++ b/plugins/dev/scripts/execution-core/linear-reconcile-cli.mjs
@@ -15,6 +15,7 @@ import { readFileSync, existsSync, appendFileSync, mkdirSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { homedir } from "node:os";
 import { fileURLToPath } from "node:url";
+import { spawnSync } from "node:child_process";
 import { reconcileDeclarations, orderedStatesForMap } from "./linear-reconcile.mjs";
 import { buildCatalystResource } from "./lib/catalyst-resource.mjs";
 import {
@@ -67,6 +68,12 @@ export function parseArgs(argv) {
       case "--decls-dir":
         a.declsDir = next();
         break;
+      case "--branch":
+        a.branch = next();
+        break; // optional: known Linear branchName for the open-PR head pass
+      case "--require-prs-merged":
+        a.requirePrsMerged = true;
+        break; // opt-in open-PR gate (always on for --by recovery-pass; see cmdDeclare)
       case "--states-file":
         a.statesFile = next();
         break; // offline/test read seam
@@ -111,6 +118,11 @@ Options:
                     (default: <cwd>/.catalyst/config.json)
   --write           reconcile: actually write (default dry-run)
   --no-write        declare: persist + emit only, don't write Linear now
+  --require-prs-merged
+                    declare: refuse the Done write (fail-closed, exit 2) if ANY
+                    unmerged PR for the ticket is still open. ALWAYS enforced when
+                    --by is 'recovery-pass' (the autonomous delegate) — H1/CTL-1157.
+  --branch <name>   declare: known Linear branchName for the open-PR head pass
   --graphql         read current state via Linear GraphQL ($LINEAR_API_TOKEN)
                     for tickets absent from the local cache (unenrolled repos)
   --json            machine-readable output
@@ -225,14 +237,109 @@ function resolveConfig(args) {
   return { configPath, stateMap, teamKeys, terminalStates };
 }
 
+// ── open-PR gate (H1 / CTL-1157) ────────────────────────────────────────────────
+//
+// The autonomous recovery-pass delegate may move a ticket to Done, but ONLY after
+// every PR for that ticket is merged. A wrong Done write clears the needs-human
+// label and stops all scheduler attention, and is hard to undo — exactly the
+// false-positive that got the GitHub-PR→Done automation removed (one merged PR +
+// one still-open PR on a non-standard branch → falsely Done). This gate is the
+// deterministic CODE backstop for that scenario; it is NOT a prompt step the LLM
+// could forget. Authoritative source is GitHub (never the local cache), and it is
+// FAIL-CLOSED: an unverifiable PR set (gh missing/auth/network) refuses the write.
+//
+// Returns { ok:true, prs:[] } when no unmerged PR remains; { ok:false, prs:[…] }
+// when open PRs exist; { ok:false, reason } when the check itself could not run.
+export function defaultCheckOpenPrs(ticket, { branchName, cwd } = {}) {
+  const runGh = (ghArgs) => {
+    const r = spawnSync("gh", ghArgs, { encoding: "utf8", cwd: cwd || process.cwd() });
+    if (r.error || r.status !== 0) {
+      const detail = (r.stderr || r.error?.message || `exit ${r.status}`).toString().trim();
+      throw new Error(`\`gh ${ghArgs.join(" ")}\` failed: ${detail}`);
+    }
+    try {
+      return JSON.parse(r.stdout || "[]");
+    } catch {
+      throw new Error(`\`gh ${ghArgs.join(" ")}\` returned unparseable JSON`);
+    }
+  };
+  const fields = "number,state,isDraft,title";
+  const seen = new Map();
+  try {
+    // Primary check: any OPEN PR mentioning the ticket key (title/body/branch via
+    // gh search). `--state open` ⇒ every returned PR is unmerged-and-open.
+    for (const p of runGh([
+      "pr",
+      "list",
+      "--search",
+      ticket,
+      "--state",
+      "open",
+      "--json",
+      fields,
+      "--limit",
+      "100",
+    ]))
+      if (p && p.number != null) seen.set(p.number, p);
+    // Secondary net: open PRs on the ticket's known branch (catches a PR whose
+    // title omits the ticket key but whose branch is the canonical one).
+    if (branchName) {
+      for (const p of runGh([
+        "pr",
+        "list",
+        "--head",
+        branchName,
+        "--state",
+        "open",
+        "--json",
+        fields,
+        "--limit",
+        "100",
+      ]))
+        if (p && p.number != null) seen.set(p.number, p);
+    }
+  } catch (err) {
+    return { ok: false, reason: err?.message || String(err), prs: [] };
+  }
+  const prs = [...seen.values()];
+  return { ok: prs.length === 0, prs };
+}
+
 // ── commands ──────────────────────────────────────────────────────────────────
 
-async function cmdDeclare(args) {
+async function cmdDeclare(args, deps = {}) {
   const ticket = args._[1];
   if (!ticket || !TICKET_RE.test(ticket)) {
     process.stderr.write("error: declare needs a ticket id (e.g. CTL-123)\n");
     return 2;
   }
+
+  // H1 (CTL-1157): MANDATORY, non-bypassable open-PR gate for the autonomous
+  // recovery-pass delegate. Keyed on the DECLARER IDENTITY (`--by recovery-pass`)
+  // so it cannot be skipped by forgetting a flag; `--require-prs-merged` opts any
+  // other caller in. Runs BEFORE storeDeclare so a refusal persists NO durable
+  // marker — otherwise a later `reconcile --write` drain could land the Done write
+  // unchecked. Teardown / CTL-1371 reconciler use other `--by` values and are
+  // unaffected (byte-identical) unless they pass the flag.
+  const openPrGateRequired = args.by === "recovery-pass" || args.requirePrsMerged === true;
+  if (openPrGateRequired) {
+    const checkOpenPrs = deps.checkOpenPrs || defaultCheckOpenPrs;
+    const gate = checkOpenPrs(ticket, { branchName: args.branch });
+    if (!gate || !gate.ok) {
+      const detail = gate?.reason
+        ? `open-PR set could not be verified (${gate.reason})`
+        : `${gate?.prs?.length ?? 0} unmerged PR(s) still open (${(gate?.prs ?? [])
+            .map((p) => `#${p.number}`)
+            .join(", ")})`;
+      process.stderr.write(
+        `error: ${ticket} refusing Done declaration — ${detail}; merge/close the open PR(s) first\n`
+      );
+      // Fail-closed: nothing persisted, nothing written. The delegate gates on this
+      // non-zero exit and escalates (Rubric Three) instead of advertising Done.
+      return 2;
+    }
+  }
+
   const dir = args.declsDir || completionsDir();
   const decl = storeDeclare(
     { ticket, state: args.state, declaredBy: args.by, note: args.note },
@@ -356,7 +463,7 @@ function cmdStatus(args) {
   return 0;
 }
 
-export async function main(argv = process.argv.slice(2)) {
+export async function main(argv = process.argv.slice(2), deps = {}) {
   const args = parseArgs(argv);
   if (args.help || args._.length === 0) {
     process.stdout.write(HELP + "\n");
@@ -367,7 +474,7 @@ export async function main(argv = process.argv.slice(2)) {
     return 2;
   }
   const cmd = args._[0];
-  if (cmd === "declare") return cmdDeclare(args);
+  if (cmd === "declare") return cmdDeclare(args, deps);
   if (cmd === "reconcile") return cmdReconcile(args);
   if (cmd === "status") return cmdStatus(args);
   // Back-compat alias: `--team`/`--repo`-style PR sweeps are GONE; guide the user.

--- a/plugins/dev/scripts/execution-core/linear-reconcile-cli.mjs
+++ b/plugins/dev/scripts/execution-core/linear-reconcile-cli.mjs
@@ -326,31 +326,77 @@ async function cmdDeclare(args, deps = {}) {
       markReconciled(ticket, wrote.to_state ?? wrote.target ?? wrote.currentState, { dir });
   }
 
-  // CTL-1157 SLICE 3 (Done-moves panel): emit the broad recovery.done-applied for
-  // the delegate's OWN autonomous Done. This carries the agent's PR-2 remediation
-  // counts (prs_closed / prs_kept) and how many PRs were STILL open at the Done
-  // (open_prs_at_done > 0 = the red-line). The agent supplies them via flags — this
-  // path NEVER consults the open-PR enumerator (THE REVERSAL: declare is not gated),
-  // so the count comes from the agent's own prior enumeration, not a re-scan here.
-  // Shadow-safe: --no-write (no actual Done write) emits the would-apply telemetry
-  // variant; a real applied Done transition emits the enforce variant. Best-effort.
+  // CTL-1157 SLICE 3 (Done-moves panel) + GROUP 1 (observable teardown Done): emit
+  // the broad recovery.done-applied so OTEL charts every autonomous Done. Three shapes:
+  //
+  //  (a) PIPELINE RECORD-ONLY marker (`--no-write --by pipeline`): phase-teardown has
+  //      ALREADY performed the REAL Linear Done (via linear-transition.sh, no
+  //      telemetry) and is now dropping a durable record. This is the RECORD OF A REAL
+  //      EXTERNAL DONE — NOT a shadow. Emit recovery.done-applied in ENFORCE mode (a
+  //      real applied Done, NOT a would-event — re-introducing a shadow here was Codex
+  //      round-1 #7) AND run the open-PR enumeration → fire the loud
+  //      recovery.done-applied-with-open-pr alarm if ≥1 open PR (or unverifiable). This
+  //      is the ONLY observability for a normal-pipeline teardown Done: the real Done
+  //      emits nothing, the later terminal-sweep sees already-Done → action:"skipped"
+  //      → emits nothing, so WITHOUT this a teardown Done with an open PR is SILENT.
+  //      No agent supplied PR tallies here (this is pure-pipeline, not the delegate),
+  //      so prs_closed/prs_kept are 0 and open_prs_at_done carries the enumerated count
+  //      — observable + alarmed exactly like the two pure-code backstops (drain +
+  //      terminal sweep).
+  //  (b) GENUINE SHADOW (any other actor's true --no-write declaration): the delegate
+  //      does not write Done → emit the recovery.would-done-applied SHADOW variant
+  //      (telemetry only, no write, no enumeration/alarm). The agent supplies its own
+  //      PR-2 remediation tallies (prs_closed / prs_kept / open_prs_at_done) via flags.
+  //  (c) REAL APPLIED DONE on this path (not --no-write): emit recovery.done-applied
+  //      (enforce) with the agent-supplied tallies. An idempotent already-Done noop is
+  //      not a "move" and emits nothing.
   if (!args.noEmit && String(args.state).toLowerCase() === "done") {
     const emitDoneApplied = deps.emitDoneApplied || appendRecoveryDoneAppliedEvent;
-    // Only a real done transition (or a no-write declaration) emits a move; an
-    // idempotent already-Done noop is not a "move".
     const realDone = wrote && wrote.kind === "done" && wrote.applied && wrote.writeAction !== "skipped";
-    // CTL-1157 GROUP B (Done-event accuracy): distinguish a TRUE shadow/no-write
-    // declaration from a record-only marker. phase-teardown records durable
-    // completion with `declare --state done --by pipeline --no-write` AFTER it has
-    // ALREADY performed the real Linear Done (via linear-transition.sh) — that
-    // --no-write is a record-only marker, NOT a shadow. Emitting the
-    // recovery.would-done-applied SHADOW event for it would pollute shadow telemetry
-    // and undercount real Done moves. Suppress the shadow emit for the pipeline
-    // record-only marker; the genuine shadow path (any other actor's true no-write
-    // declaration) and a real applied Done are unaffected.
     const pipelineRecordOnly =
       args.noWrite && String(args.by).toLowerCase() === "pipeline";
-    if ((args.noWrite && !pipelineRecordOnly) || realDone) {
+    if (pipelineRecordOnly) {
+      // (a) record of a REAL external Done — enumerate open PRs so the teardown Done is
+      // observable + alarmed. Best-effort; observability must never break declare.
+      const checkOpenPrs = deps.checkOpenPrs || defaultCheckOpenPrs;
+      const emitDoneWithOpenPr = deps.emitDoneWithOpenPr || appendRecoveryDoneOpenPrEvent;
+      const { configPath } = resolveConfig(args);
+      const repoRoot = existsSync(configPath) ? dirname(dirname(configPath)) : null;
+      let openPrs = [];
+      let unverifiable = false;
+      try {
+        const facts = checkOpenPrs(ticket, repoRoot ? { cwd: repoRoot } : {});
+        if (facts && facts.unverifiable) unverifiable = true;
+        if (facts && Array.isArray(facts.prs)) openPrs = facts.prs;
+      } catch {
+        unverifiable = true; // could not confirm clean ⇒ surface (don't assume zero)
+      }
+      try {
+        emitDoneApplied({
+          ticket,
+          openPrsAtDone: openPrs.length,
+          prsClosed: 0,
+          prsKept: 0,
+          // The real Done ALREADY landed via linear-transition.sh — this is a genuine
+          // applied Done, so enforce (NOT shadow). Codex round-1 #7: no would-event here.
+          recoveryMode: "enforce",
+          by: args.by,
+        });
+      } catch {
+        /* observability must never break declare */
+      }
+      // ALARM-NOT-BLOCK: a Done that landed while ≥1 open PR remains — OR whose open-PR
+      // check was UNVERIFIABLE (a Done that landed without confirming the board was
+      // clean) — fires the loud alarm. A clean, CONFIRMED teardown Done stays silent.
+      if (openPrs.length >= 1 || unverifiable) {
+        try {
+          emitDoneWithOpenPr({ ticket, openPrs, by: "pipeline-teardown", unverifiable });
+        } catch {
+          /* observability must never break declare */
+        }
+      }
+    } else if (args.noWrite || realDone) {
+      // (b) genuine shadow would-apply, or (c) a real applied Done on this path.
       try {
         emitDoneApplied({
           ticket,

--- a/plugins/dev/scripts/execution-core/linear-reconcile-cli.mjs
+++ b/plugins/dev/scripts/execution-core/linear-reconcile-cli.mjs
@@ -339,7 +339,18 @@ async function cmdDeclare(args, deps = {}) {
     // Only a real done transition (or a no-write declaration) emits a move; an
     // idempotent already-Done noop is not a "move".
     const realDone = wrote && wrote.kind === "done" && wrote.applied && wrote.writeAction !== "skipped";
-    if (args.noWrite || realDone) {
+    // CTL-1157 GROUP B (Done-event accuracy): distinguish a TRUE shadow/no-write
+    // declaration from a record-only marker. phase-teardown records durable
+    // completion with `declare --state done --by pipeline --no-write` AFTER it has
+    // ALREADY performed the real Linear Done (via linear-transition.sh) — that
+    // --no-write is a record-only marker, NOT a shadow. Emitting the
+    // recovery.would-done-applied SHADOW event for it would pollute shadow telemetry
+    // and undercount real Done moves. Suppress the shadow emit for the pipeline
+    // record-only marker; the genuine shadow path (any other actor's true no-write
+    // declaration) and a real applied Done are unaffected.
+    const pipelineRecordOnly =
+      args.noWrite && String(args.by).toLowerCase() === "pipeline";
+    if ((args.noWrite && !pipelineRecordOnly) || realDone) {
       try {
         emitDoneApplied({
           ticket,

--- a/plugins/dev/scripts/execution-core/linear-reconcile-cli.mjs
+++ b/plugins/dev/scripts/execution-core/linear-reconcile-cli.mjs
@@ -15,7 +15,6 @@ import { readFileSync, existsSync, appendFileSync, mkdirSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { homedir } from "node:os";
 import { fileURLToPath } from "node:url";
-import { spawnSync } from "node:child_process";
 import { reconcileDeclarations, orderedStatesForMap } from "./linear-reconcile.mjs";
 import { buildCatalystResource } from "./lib/catalyst-resource.mjs";
 import {
@@ -24,6 +23,11 @@ import {
   markReconciled,
   completionsDir,
 } from "./linear-reconcile-store.mjs";
+// CTL-1157: the open-PR Done gate lives in its own module so the execution-core
+// terminal sweep (scheduler.mjs terminalDoneOnce) runs the IDENTICAL check. Kept
+// re-exported here for back-compat (tests import defaultCheckOpenPrs from the CLI).
+import { defaultCheckOpenPrs, defaultDeriveBranchName } from "./open-pr-gate.mjs";
+export { defaultCheckOpenPrs, defaultDeriveBranchName };
 
 const TICKET_RE = /^[A-Za-z][A-Za-z0-9_]*-\d+$/;
 
@@ -73,7 +77,7 @@ export function parseArgs(argv) {
         break; // optional: known Linear branchName for the open-PR head pass
       case "--require-prs-merged":
         a.requirePrsMerged = true;
-        break; // opt-in open-PR gate (always on for --by recovery-pass; see cmdDeclare)
+        break; // no-op opt-in: the open-PR gate is now UNIVERSAL for `--state done` (CTL-1157)
       case "--states-file":
         a.statesFile = next();
         break; // offline/test read seam
@@ -119,10 +123,14 @@ Options:
   --write           reconcile: actually write (default dry-run)
   --no-write        declare: persist + emit only, don't write Linear now
   --require-prs-merged
-                    declare: refuse the Done write (fail-closed, exit 2) if ANY
-                    unmerged PR for the ticket is still open. ALWAYS enforced when
-                    --by is 'recovery-pass' (the autonomous delegate) — H1/CTL-1157.
-  --branch <name>   declare: known Linear branchName for the open-PR head pass
+                    no-op (retained for back-compat): the open-PR gate is now
+                    UNIVERSAL — EVERY '--state done' declare (any --by: recovery-pass,
+                    pipeline/teardown, model, human) refuses the Done write
+                    (fail-closed, exit 2) if ANY unmerged PR for the ticket is still
+                    open. Merge/close the open PR first. (CTL-1157)
+  --branch <name>   declare: known Linear branchName for the open-PR head pass.
+                    Optional — when omitted the gate derives it from the local
+                    replica/cache (catalyst-linear source:replica, never linearis).
   --graphql         read current state via Linear GraphQL ($LINEAR_API_TOKEN)
                     for tickets absent from the local cache (unenrolled repos)
   --json            machine-readable output
@@ -237,74 +245,6 @@ function resolveConfig(args) {
   return { configPath, stateMap, teamKeys, terminalStates };
 }
 
-// ── open-PR gate (H1 / CTL-1157) ────────────────────────────────────────────────
-//
-// The autonomous recovery-pass delegate may move a ticket to Done, but ONLY after
-// every PR for that ticket is merged. A wrong Done write clears the needs-human
-// label and stops all scheduler attention, and is hard to undo — exactly the
-// false-positive that got the GitHub-PR→Done automation removed (one merged PR +
-// one still-open PR on a non-standard branch → falsely Done). This gate is the
-// deterministic CODE backstop for that scenario; it is NOT a prompt step the LLM
-// could forget. Authoritative source is GitHub (never the local cache), and it is
-// FAIL-CLOSED: an unverifiable PR set (gh missing/auth/network) refuses the write.
-//
-// Returns { ok:true, prs:[] } when no unmerged PR remains; { ok:false, prs:[…] }
-// when open PRs exist; { ok:false, reason } when the check itself could not run.
-export function defaultCheckOpenPrs(ticket, { branchName, cwd } = {}) {
-  const runGh = (ghArgs) => {
-    const r = spawnSync("gh", ghArgs, { encoding: "utf8", cwd: cwd || process.cwd() });
-    if (r.error || r.status !== 0) {
-      const detail = (r.stderr || r.error?.message || `exit ${r.status}`).toString().trim();
-      throw new Error(`\`gh ${ghArgs.join(" ")}\` failed: ${detail}`);
-    }
-    try {
-      return JSON.parse(r.stdout || "[]");
-    } catch {
-      throw new Error(`\`gh ${ghArgs.join(" ")}\` returned unparseable JSON`);
-    }
-  };
-  const fields = "number,state,isDraft,title";
-  const seen = new Map();
-  try {
-    // Primary check: any OPEN PR mentioning the ticket key (title/body/branch via
-    // gh search). `--state open` ⇒ every returned PR is unmerged-and-open.
-    for (const p of runGh([
-      "pr",
-      "list",
-      "--search",
-      ticket,
-      "--state",
-      "open",
-      "--json",
-      fields,
-      "--limit",
-      "100",
-    ]))
-      if (p && p.number != null) seen.set(p.number, p);
-    // Secondary net: open PRs on the ticket's known branch (catches a PR whose
-    // title omits the ticket key but whose branch is the canonical one).
-    if (branchName) {
-      for (const p of runGh([
-        "pr",
-        "list",
-        "--head",
-        branchName,
-        "--state",
-        "open",
-        "--json",
-        fields,
-        "--limit",
-        "100",
-      ]))
-        if (p && p.number != null) seen.set(p.number, p);
-    }
-  } catch (err) {
-    return { ok: false, reason: err?.message || String(err), prs: [] };
-  }
-  const prs = [...seen.values()];
-  return { ok: prs.length === 0, prs };
-}
-
 // ── commands ──────────────────────────────────────────────────────────────────
 
 async function cmdDeclare(args, deps = {}) {
@@ -314,16 +254,28 @@ async function cmdDeclare(args, deps = {}) {
     return 2;
   }
 
-  // H1 (CTL-1157): MANDATORY, non-bypassable open-PR gate for the autonomous
-  // recovery-pass delegate. Keyed on the DECLARER IDENTITY (`--by recovery-pass`)
-  // so it cannot be skipped by forgetting a flag; `--require-prs-merged` opts any
-  // other caller in. Runs BEFORE storeDeclare so a refusal persists NO durable
+  // CTL-1157 (UNIVERSAL gate): MANDATORY, non-bypassable open-PR gate for EVERY
+  // declaration that targets terminal Done — regardless of `--by`. The owner's #1
+  // rule is "NEVER mark a ticket Done while it still has an open/unmerged PR", so
+  // the gate is keyed on the TARGET STATE (`done`), not the declarer identity: the
+  // autonomous recovery-pass delegate, the teardown/pipeline completion-signal path
+  // (`--by pipeline`), the default `--by model`, and a human all run it. A wrong
+  // Done write clears the needs-human label and stops all scheduler attention, and
+  // is hard to undo — exactly the false-positive that got the GitHub-PR→Done
+  // automation removed (one merged PR + one still-open PR on a NON-standard branch →
+  // falsely Done). This is the deterministic CODE backstop, NOT a prompt step the
+  // LLM could forget. Runs BEFORE storeDeclare so a refusal persists NO durable
   // marker — otherwise a later `reconcile --write` drain could land the Done write
-  // unchecked. Teardown / CTL-1371 reconciler use other `--by` values and are
-  // unaffected (byte-identical) unless they pass the flag.
-  const openPrGateRequired = args.by === "recovery-pass" || args.requirePrsMerged === true;
+  // unchecked (THAT is what makes the drain safe by construction). It is FAIL-CLOSED:
+  // an unverifiable PR set (gh missing/auth/network) refuses the write. A non-`done`
+  // target (e.g. `--state canceled` / a phase state) is NOT gated — only completion.
+  // `--require-prs-merged` is retained as a no-op opt-in for callers/tests.
+  const openPrGateRequired = args.state === "done";
   if (openPrGateRequired) {
     const checkOpenPrs = deps.checkOpenPrs || defaultCheckOpenPrs;
+    // branchName is ALWAYS resolved (CTL-1157): use --branch when passed, else the
+    // gate derives it from the local replica/cache (catalyst-linear source:replica,
+    // NEVER bare linearis) so a non-standard-branch PR is still caught.
     const gate = checkOpenPrs(ticket, { branchName: args.branch });
     if (!gate || !gate.ok) {
       const detail = gate?.reason

--- a/plugins/dev/scripts/execution-core/linear-reconcile-cli.mjs
+++ b/plugins/dev/scripts/execution-core/linear-reconcile-cli.mjs
@@ -415,16 +415,25 @@ async function cmdReconcile(args, deps = {}) {
     const checkOpenPrs = deps.checkOpenPrs || defaultCheckOpenPrs;
     const emit = deps.emitDoneWithOpenPr || appendRecoveryDoneOpenPrEvent;
     const emitDoneApplied = deps.emitDoneApplied || appendRecoveryDoneAppliedEvent;
+    // CTL-1157 fix #2: run the gh enumeration in the TICKET's repository. The drain
+    // knows the project repoRoot from its --config (.catalyst/config.json lives at
+    // <repoRoot>/.catalyst/config.json), so pass it as the gh cwd — multi-repo /
+    // per-project installs must query the right repo, NEVER bare linearis and never
+    // the process cwd. When config is absent, defaultCheckOpenPrs falls back to its
+    // own registry-based repo derivation (and reports unverifiable if that fails).
+    const drainRepoRoot = existsSync(configPath) ? dirname(dirname(configPath)) : null;
     for (const r of rows) {
       // A real Done transition that actually changed state (not an idempotent
       // already-Done noop, not a dry-run, not a failed/skip row).
       if (r.kind !== "done" || !r.applied || r.writeAction === "skipped") continue;
       let openPrs = [];
+      let unverifiable = false;
       try {
-        const facts = checkOpenPrs(r.ticket, {});
+        const facts = checkOpenPrs(r.ticket, drainRepoRoot ? { cwd: drainRepoRoot } : {});
+        if (facts && facts.unverifiable) unverifiable = true;
         if (facts && Array.isArray(facts.prs)) openPrs = facts.prs;
       } catch {
-        openPrs = []; // unverifiable ⇒ no alarm (we no longer fail closed)
+        unverifiable = true; // could not confirm clean ⇒ surface (don't assume zero)
       }
       // CTL-1157 SLICE 3 (Done-moves panel): emit the broad recovery.done-applied on
       // EVERY drained Done (not just the open-PR subset). The drain is a pure-code
@@ -442,9 +451,13 @@ async function cmdReconcile(args, deps = {}) {
       } catch {
         /* observability must never break the drain */
       }
-      if (openPrs.length >= 1) {
+      // CTL-1157 (ALARM-NOT-BLOCK): alarm when ≥1 open PR remains OR the open-PR
+      // check was UNVERIFIABLE — a Done that landed without confirming the board was
+      // clean is the silent-Done risk this alarm surfaces. A clean, CONFIRMED Done is
+      // silent.
+      if (openPrs.length >= 1 || unverifiable) {
         try {
-          emit({ ticket: r.ticket, openPrs, by: "reconcile-drain" });
+          emit({ ticket: r.ticket, openPrs, by: "reconcile-drain", unverifiable });
         } catch {
           /* observability must never break the drain */
         }

--- a/plugins/dev/scripts/execution-core/linear-reconcile-cli.mjs
+++ b/plugins/dev/scripts/execution-core/linear-reconcile-cli.mjs
@@ -23,10 +23,16 @@ import {
   markReconciled,
   completionsDir,
 } from "./linear-reconcile-store.mjs";
-// CTL-1157: the open-PR Done gate lives in its own module so the execution-core
-// terminal sweep (scheduler.mjs terminalDoneOnce) runs the IDENTICAL check. Kept
-// re-exported here for back-compat (tests import defaultCheckOpenPrs from the CLI).
+// CTL-1157: the open-PR ENUMERATOR lives in its own module (open-pr-gate.mjs). It
+// is a FACTS source, NOT a refuse-gate (see THE REVERSAL there). The agent `declare`
+// path does NOT consult it — the senior-engineer delegate already enumerated and
+// reasoned about the ticket's open PRs (finishing/merging the needed ones, closing
+// the abandoned ones) BEFORE calling declare. The reconciler drain (cmdReconcile)
+// consults it only to fire the LOUD `recovery.done-applied-with-open-pr` alarm when
+// a pure-code Done write lands while an open PR still exists. Re-exported for
+// back-compat (tests import defaultCheckOpenPrs from the CLI).
 import { defaultCheckOpenPrs, defaultDeriveBranchName } from "./open-pr-gate.mjs";
+import { appendRecoveryDoneOpenPrEvent } from "./recovery-done-open-pr-event.mjs";
 export { defaultCheckOpenPrs, defaultDeriveBranchName };
 
 const TICKET_RE = /^[A-Za-z][A-Za-z0-9_]*-\d+$/;
@@ -123,14 +129,15 @@ Options:
   --write           reconcile: actually write (default dry-run)
   --no-write        declare: persist + emit only, don't write Linear now
   --require-prs-merged
-                    no-op (retained for back-compat): the open-PR gate is now
-                    UNIVERSAL — EVERY '--state done' declare (any --by: recovery-pass,
-                    pipeline/teardown, model, human) refuses the Done write
-                    (fail-closed, exit 2) if ANY unmerged PR for the ticket is still
-                    open. Merge/close the open PR first. (CTL-1157)
-  --branch <name>   declare: known Linear branchName for the open-PR head pass.
-                    Optional — when omitted the gate derives it from the local
-                    replica/cache (catalyst-linear source:replica, never linearis).
+                    no-op (retained for back-compat). CTL-1157 REVERSED the old
+                    fail-closed gate: declare no longer refuses a Done write when an
+                    open PR exists — the senior-engineer delegate enumerates and
+                    resolves the ticket's open PRs itself BEFORE declaring. The
+                    reconcile drain (pure code) instead emits the loud
+                    recovery.done-applied-with-open-pr event when it lands a Done
+                    while a PR is still open.
+  --branch <name>   no-op (retained for back-compat): the open-PR ENUMERATOR derives
+                    the branchName from the local replica/cache itself.
   --graphql         read current state via Linear GraphQL ($LINEAR_API_TOKEN)
                     for tickets absent from the local cache (unenrolled repos)
   --json            machine-readable output
@@ -254,44 +261,17 @@ async function cmdDeclare(args, deps = {}) {
     return 2;
   }
 
-  // CTL-1157 (UNIVERSAL gate): MANDATORY, non-bypassable open-PR gate for EVERY
-  // declaration that targets terminal Done — regardless of `--by`. The owner's #1
-  // rule is "NEVER mark a ticket Done while it still has an open/unmerged PR", so
-  // the gate is keyed on the TARGET STATE (`done`), not the declarer identity: the
-  // autonomous recovery-pass delegate, the teardown/pipeline completion-signal path
-  // (`--by pipeline`), the default `--by model`, and a human all run it. A wrong
-  // Done write clears the needs-human label and stops all scheduler attention, and
-  // is hard to undo — exactly the false-positive that got the GitHub-PR→Done
-  // automation removed (one merged PR + one still-open PR on a NON-standard branch →
-  // falsely Done). This is the deterministic CODE backstop, NOT a prompt step the
-  // LLM could forget. Runs BEFORE storeDeclare so a refusal persists NO durable
-  // marker — otherwise a later `reconcile --write` drain could land the Done write
-  // unchecked (THAT is what makes the drain safe by construction). It is FAIL-CLOSED:
-  // an unverifiable PR set (gh missing/auth/network) refuses the write. A non-`done`
-  // target (e.g. `--state canceled` / a phase state) is NOT gated — only completion.
-  // `--require-prs-merged` is retained as a no-op opt-in for callers/tests.
-  const openPrGateRequired = args.state === "done";
-  if (openPrGateRequired) {
-    const checkOpenPrs = deps.checkOpenPrs || defaultCheckOpenPrs;
-    // branchName is ALWAYS resolved (CTL-1157): use --branch when passed, else the
-    // gate derives it from the local replica/cache (catalyst-linear source:replica,
-    // NEVER bare linearis) so a non-standard-branch PR is still caught.
-    const gate = checkOpenPrs(ticket, { branchName: args.branch });
-    if (!gate || !gate.ok) {
-      const detail = gate?.reason
-        ? `open-PR set could not be verified (${gate.reason})`
-        : `${gate?.prs?.length ?? 0} unmerged PR(s) still open (${(gate?.prs ?? [])
-            .map((p) => `#${p.number}`)
-            .join(", ")})`;
-      process.stderr.write(
-        `error: ${ticket} refusing Done declaration — ${detail}; merge/close the open PR(s) first\n`
-      );
-      // Fail-closed: nothing persisted, nothing written. The delegate gates on this
-      // non-zero exit and escalates (Rubric Three) instead of advertising Done.
-      return 2;
-    }
-  }
-
+  // CTL-1157 (THE REVERSAL): the agent `declare` path is NOT gated. The
+  // Done-safety mechanism is AGENT JUDGMENT, not a mechanical fail-closed block.
+  // By the time the senior-engineer recovery-pass delegate calls `declare --state
+  // done` it has ALREADY enumerated this ticket's open PRs (open-pr-gate.mjs) and
+  // reasoned about each — finishing/merging the ones that are part of the solution,
+  // CLOSING the abandoned/superseded ones itself — then decided, autonomously, to
+  // mark Done. Handcuffing that decision with a refuse-gate (the prior behavior,
+  // now removed) would override a senior engineer's judgment and force needless
+  // human escalation. The hard block is held IN RESERVE; the `reconcile` drain
+  // backstop (cmdReconcile) carries the observability alarm that would justify
+  // adding it. `--require-prs-merged` / `--branch` are retained as no-op back-compat.
   const dir = args.declsDir || completionsDir();
   const decl = storeDeclare(
     { ticket, state: args.state, declaredBy: args.by, note: args.note },
@@ -337,7 +317,7 @@ async function cmdDeclare(args, deps = {}) {
   return 0;
 }
 
-async function cmdReconcile(args) {
+async function cmdReconcile(args, deps = {}) {
   const { configPath, stateMap, terminalStates } = resolveConfig(args);
   const dir = args.declsDir || completionsDir();
   const pending = listDeclarations({ dir, pendingOnly: true });
@@ -345,8 +325,14 @@ async function cmdReconcile(args) {
 
   let applyCorrection;
   if (args.write) {
-    const { applyTerminalDone, applyPhaseStatus } = await import("./linear-write.mjs");
-    applyCorrection = buildApplyCorrection(configPath, { applyTerminalDone, applyPhaseStatus });
+    // Test seam: deps.applyCorrection lets a test simulate the Linear write without
+    // shelling to linearis. Production passes none → the real linear-write primitive.
+    if (deps.applyCorrection) {
+      applyCorrection = deps.applyCorrection;
+    } else {
+      const { applyTerminalDone, applyPhaseStatus } = await import("./linear-write.mjs");
+      applyCorrection = buildApplyCorrection(configPath, { applyTerminalDone, applyPhaseStatus });
+    }
   }
 
   const { rows, summary } = await reconcileDeclarations({
@@ -363,6 +349,37 @@ async function cmdReconcile(args) {
   for (const r of rows) {
     const satisfied = r.decision === "in-sync" || (r.decision === "correct" && r.applied);
     if (satisfied) markReconciled(r.ticket, r.to_state ?? r.target ?? r.currentState, { dir });
+  }
+
+  // CTL-1157 (ALARM-NOT-BLOCK): the `reconcile` drain is a PURE-CODE backstop — no
+  // agent reasons here. Per THE REVERSAL it PROCEEDS (never wedges the board, never
+  // escalates), but when it just LANDED a real Done transition for a ticket that
+  // still has ≥1 OPEN PR, it emits the loud `recovery.done-applied-with-open-pr`
+  // event so we get the signal that would justify adding a hard block later. A clean
+  // Done (0 open PRs) emits nothing. Best-effort: enumeration/emit failure NEVER
+  // affects the drain's outcome. Only runs on a real write (`--write`).
+  if (args.write) {
+    const checkOpenPrs = deps.checkOpenPrs || defaultCheckOpenPrs;
+    const emit = deps.emitDoneWithOpenPr || appendRecoveryDoneOpenPrEvent;
+    for (const r of rows) {
+      // A real Done transition that actually changed state (not an idempotent
+      // already-Done noop, not a dry-run, not a failed/skip row).
+      if (r.kind !== "done" || !r.applied || r.writeAction === "skipped") continue;
+      let openPrs = [];
+      try {
+        const facts = checkOpenPrs(r.ticket, {});
+        if (facts && Array.isArray(facts.prs)) openPrs = facts.prs;
+      } catch {
+        openPrs = []; // unverifiable ⇒ no alarm (we no longer fail closed)
+      }
+      if (openPrs.length >= 1) {
+        try {
+          emit({ ticket: r.ticket, openPrs, by: "reconcile-drain" });
+        } catch {
+          /* observability must never break the drain */
+        }
+      }
+    }
   }
 
   const mode = args.write ? "write" : "dry-run";
@@ -427,7 +444,7 @@ export async function main(argv = process.argv.slice(2), deps = {}) {
   }
   const cmd = args._[0];
   if (cmd === "declare") return cmdDeclare(args, deps);
-  if (cmd === "reconcile") return cmdReconcile(args);
+  if (cmd === "reconcile") return cmdReconcile(args, deps);
   if (cmd === "status") return cmdStatus(args);
   // Back-compat alias: `--team`/`--repo`-style PR sweeps are GONE; guide the user.
   process.stderr.write(`error: unknown command '${cmd}'. Use declare | reconcile | status.\n`);

--- a/plugins/dev/scripts/execution-core/linear-reconcile-cli.mjs
+++ b/plugins/dev/scripts/execution-core/linear-reconcile-cli.mjs
@@ -87,6 +87,12 @@ export function parseArgs(argv) {
       case "--require-prs-merged":
         a.requirePrsMerged = true;
         break; // no-op opt-in: the open-PR gate is now UNIVERSAL for `--state done` (CTL-1157)
+      case "--transition-verified":
+        a.transitionVerified = true;
+        break; // CTL-1157 F #3: the caller confirmed the REAL Linear Done transition
+        // succeeded (rc=0). Gates the pipeline-record-only ENFORCE recovery.done-applied:
+        // without it we would report an applied Done even when linear-transition.sh
+        // failed or was missing. Absent → treat as pending/shadow (the drain lands it).
       case "--states-file":
         a.statesFile = next();
         break; // offline/test read seam
@@ -355,7 +361,14 @@ async function cmdDeclare(args, deps = {}) {
     const realDone = wrote && wrote.kind === "done" && wrote.applied && wrote.writeAction !== "skipped";
     const pipelineRecordOnly =
       args.noWrite && String(args.by).toLowerCase() === "pipeline";
-    if (pipelineRecordOnly) {
+    // CTL-1157 F #3: only the pipeline marker whose REAL Done transition was VERIFIED
+    // (rc=0, via --transition-verified) is a record of a Done that actually landed →
+    // ENFORCE done-applied + open-PR alarm. A marker dropped after a FAILED or MISSING
+    // linear-transition.sh (SKILL.md still runs `declare` on that path) is NOT proof of
+    // a Done: it falls through to the shadow would-event below (recoveryMode:"shadow"),
+    // so OTEL never charts an applied Done that did not happen; the reconcile drain /
+    // terminalDoneOnce backstop lands the real Done and re-declares it later.
+    if (pipelineRecordOnly && args.transitionVerified) {
       // (a) record of a REAL external Done — enumerate open PRs so the teardown Done is
       // observable + alarmed. Best-effort; observability must never break declare.
       const checkOpenPrs = deps.checkOpenPrs || defaultCheckOpenPrs;

--- a/plugins/dev/scripts/execution-core/linear-reconcile-cli.mjs
+++ b/plugins/dev/scripts/execution-core/linear-reconcile-cli.mjs
@@ -485,13 +485,14 @@ async function cmdReconcile(args, deps = {}) {
     const checkOpenPrs = deps.checkOpenPrs || defaultCheckOpenPrs;
     const emit = deps.emitDoneWithOpenPr || appendRecoveryDoneOpenPrEvent;
     const emitDoneApplied = deps.emitDoneApplied || appendRecoveryDoneAppliedEvent;
-    // CTL-1157 fix #2: run the gh enumeration in the TICKET's repository. The drain
-    // knows the project repoRoot from its --config (.catalyst/config.json lives at
-    // <repoRoot>/.catalyst/config.json), so pass it as the gh cwd — multi-repo /
-    // per-project installs must query the right repo, NEVER bare linearis and never
-    // the process cwd. When config is absent, defaultCheckOpenPrs falls back to its
-    // own registry-based repo derivation (and reports unverifiable if that fails).
-    const drainRepoRoot = existsSync(configPath) ? dirname(dirname(configPath)) : null;
+    // CTL-1157 fix #2 (+ Codex round-8): run the gh enumeration in EACH ticket's OWN
+    // repository. The drain processes pending declarations from the GLOBAL completions
+    // store, so its rows can belong to DIFFERENT project repos than this CLI's --config.
+    // Forcing the CLI's config repoRoot as cwd for every ticket would query gh in the
+    // wrong repo for cross-project rows (a false-clean or false-open result). Pass NO
+    // cwd → defaultCheckOpenPrs derives the repo PER TICKET from the registry
+    // (deriveRepoRoot(ticket)); an underivable ticket surfaces as unverifiable, never a
+    // silent clean. NEVER bare linearis, never the process cwd.
     for (const r of rows) {
       // A real Done transition that actually changed state (not an idempotent
       // already-Done noop, not a dry-run, not a failed/skip row).
@@ -499,7 +500,7 @@ async function cmdReconcile(args, deps = {}) {
       let openPrs = [];
       let unverifiable = false;
       try {
-        const facts = checkOpenPrs(r.ticket, drainRepoRoot ? { cwd: drainRepoRoot } : {});
+        const facts = checkOpenPrs(r.ticket, {});
         if (facts && facts.unverifiable) unverifiable = true;
         if (facts && Array.isArray(facts.prs)) openPrs = facts.prs;
       } catch {

--- a/plugins/dev/scripts/execution-core/linear-reconcile-cli.mjs
+++ b/plugins/dev/scripts/execution-core/linear-reconcile-cli.mjs
@@ -32,7 +32,10 @@ import {
 // a pure-code Done write lands while an open PR still exists. Re-exported for
 // back-compat (tests import defaultCheckOpenPrs from the CLI).
 import { defaultCheckOpenPrs, defaultDeriveBranchName } from "./open-pr-gate.mjs";
-import { appendRecoveryDoneOpenPrEvent } from "./recovery-done-open-pr-event.mjs";
+import {
+  appendRecoveryDoneOpenPrEvent,
+  appendRecoveryDoneAppliedEvent,
+} from "./recovery-done-open-pr-event.mjs";
 export { defaultCheckOpenPrs, defaultDeriveBranchName };
 
 const TICKET_RE = /^[A-Za-z][A-Za-z0-9_]*-\d+$/;
@@ -90,6 +93,20 @@ export function parseArgs(argv) {
       case "--no-emit":
         a.noEmit = true;
         break; // offline/test
+      // CTL-1157 SLICE 3: the delegate's PR-2 remediation counts, threaded into the
+      // recovery.done-applied "Done-moves" event. The agent enumerated + reasoned
+      // about every open PR before declaring; these record WHAT it did (closed N,
+      // kept N) and how many were STILL open at the Done (open-at-done>0 = red-line).
+      // Default 0 (a non-agent declare emits a clean 0/0/0 move).
+      case "--prs-closed":
+        a.prsClosed = Number(next());
+        break;
+      case "--prs-kept":
+        a.prsKept = Number(next());
+        break;
+      case "--open-prs-at-done":
+        a.openPrsAtDone = Number(next());
+        break;
       case "-h":
       case "--help":
         a.help = true;
@@ -124,6 +141,12 @@ Options:
   --state <key>     target stateMap key for declare (default 'done')
   --note <text>     freeform note stored with the declaration
   --by <who>        who declared it (default 'model')
+  --prs-closed <n>  declare: # of the ticket's PRs the agent CLOSED during PR-2
+                    remediation — recorded on the recovery.done-applied event
+  --prs-kept <n>    declare: # of PRs the agent finished/merged as part-of-solution
+  --open-prs-at-done <n>
+                    declare: # of PRs STILL open at the Done (>0 = the red-line the
+                    Done-moves panel alarms on; a clean delegate Done is 0)
   --config <path>   .catalyst/config.json supplying stateMap + repoRoot
                     (default: <cwd>/.catalyst/config.json)
   --write           reconcile: actually write (default dry-run)
@@ -303,6 +326,36 @@ async function cmdDeclare(args, deps = {}) {
       markReconciled(ticket, wrote.to_state ?? wrote.target ?? wrote.currentState, { dir });
   }
 
+  // CTL-1157 SLICE 3 (Done-moves panel): emit the broad recovery.done-applied for
+  // the delegate's OWN autonomous Done. This carries the agent's PR-2 remediation
+  // counts (prs_closed / prs_kept) and how many PRs were STILL open at the Done
+  // (open_prs_at_done > 0 = the red-line). The agent supplies them via flags — this
+  // path NEVER consults the open-PR enumerator (THE REVERSAL: declare is not gated),
+  // so the count comes from the agent's own prior enumeration, not a re-scan here.
+  // Shadow-safe: --no-write (no actual Done write) emits the would-apply telemetry
+  // variant; a real applied Done transition emits the enforce variant. Best-effort.
+  if (!args.noEmit && String(args.state).toLowerCase() === "done") {
+    const emitDoneApplied = deps.emitDoneApplied || appendRecoveryDoneAppliedEvent;
+    // Only a real done transition (or a no-write declaration) emits a move; an
+    // idempotent already-Done noop is not a "move".
+    const realDone = wrote && wrote.kind === "done" && wrote.applied && wrote.writeAction !== "skipped";
+    if (args.noWrite || realDone) {
+      try {
+        emitDoneApplied({
+          ticket,
+          openPrsAtDone: Number.isFinite(args.openPrsAtDone) ? args.openPrsAtDone : 0,
+          prsClosed: Number.isFinite(args.prsClosed) ? args.prsClosed : 0,
+          prsKept: Number.isFinite(args.prsKept) ? args.prsKept : 0,
+          // --no-write = no actual Done write yet (the drain lands it) → shadow/would.
+          recoveryMode: args.noWrite ? "shadow" : "enforce",
+          by: args.by,
+        });
+      } catch {
+        /* observability must never break declare */
+      }
+    }
+  }
+
   if (args.json) {
     process.stdout.write(JSON.stringify({ declared: decl, write: wrote }, null, 2) + "\n");
   } else {
@@ -361,6 +414,7 @@ async function cmdReconcile(args, deps = {}) {
   if (args.write) {
     const checkOpenPrs = deps.checkOpenPrs || defaultCheckOpenPrs;
     const emit = deps.emitDoneWithOpenPr || appendRecoveryDoneOpenPrEvent;
+    const emitDoneApplied = deps.emitDoneApplied || appendRecoveryDoneAppliedEvent;
     for (const r of rows) {
       // A real Done transition that actually changed state (not an idempotent
       // already-Done noop, not a dry-run, not a failed/skip row).
@@ -371,6 +425,22 @@ async function cmdReconcile(args, deps = {}) {
         if (facts && Array.isArray(facts.prs)) openPrs = facts.prs;
       } catch {
         openPrs = []; // unverifiable ⇒ no alarm (we no longer fail closed)
+      }
+      // CTL-1157 SLICE 3 (Done-moves panel): emit the broad recovery.done-applied on
+      // EVERY drained Done (not just the open-PR subset). The drain is a pure-code
+      // backstop with no agent to reason about PRs → prs_closed/prs_kept are 0;
+      // open_prs_at_done carries the enumerated count (the red-line). Best-effort.
+      try {
+        emitDoneApplied({
+          ticket: r.ticket,
+          openPrsAtDone: openPrs.length,
+          prsClosed: 0,
+          prsKept: 0,
+          recoveryMode: "enforce", // the drain only ever does real writes
+          by: "reconcile-drain",
+        });
+      } catch {
+        /* observability must never break the drain */
       }
       if (openPrs.length >= 1) {
         try {

--- a/plugins/dev/scripts/execution-core/linear-reconcile-cli.test.mjs
+++ b/plugins/dev/scripts/execution-core/linear-reconcile-cli.test.mjs
@@ -2,10 +2,10 @@ import { test, expect } from "bun:test";
 import { mkdtempSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { parseArgs, main } from "./linear-reconcile-cli.mjs";
+import { parseArgs, main, defaultCheckOpenPrs } from "./linear-reconcile-cli.mjs";
 import { readDeclaration, listDeclarations } from "./linear-reconcile-store.mjs";
 
-async function runCli(argv) {
+async function runCli(argv, deps = {}) {
   const out = [];
   const err = [];
   const o = process.stdout.write.bind(process.stdout);
@@ -19,7 +19,7 @@ async function runCli(argv) {
     return true;
   };
   try {
-    const code = await main(argv);
+    const code = await main(argv, deps);
     return { code, out: out.join(""), err: err.join("") };
   } finally {
     process.stdout.write = o;
@@ -146,4 +146,118 @@ test("reconcile over an already-Done ticket is in-sync (idempotent), exit 0", as
   expect(code).toBe(0);
   expect(JSON.parse(out).summary.inSync).toBe(1);
   expect(JSON.parse(out).summary.drift).toBe(0);
+});
+
+// ── H1 open-PR gate (CTL-1157) ────────────────────────────────────────────────
+// The recovery-pass delegate must be unable to declare Done while any PR for the
+// ticket is still open. The gate is keyed on `--by recovery-pass` (not an opt-in
+// flag), runs BEFORE any durable marker is persisted, and is fail-closed.
+
+test("parseArgs: --require-prs-merged / --branch", () => {
+  const a = parseArgs(["declare", "CTL-9", "--require-prs-merged", "--branch", "ryan/ctl-9-x"]);
+  expect(a.requirePrsMerged).toBe(true);
+  expect(a.branch).toBe("ryan/ctl-9-x");
+});
+
+test("H1: recovery-pass Done is REFUSED when a non-standard-branch PR is still open (one merged + one open)", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "decl-"));
+  // The false-Done scenario: #100 already merged, #101 still open on a weird branch.
+  // The gate sees the OPEN PR and must refuse — nothing written, nothing persisted.
+  const calls = [];
+  const checkOpenPrs = (ticket, opts) => {
+    calls.push({ ticket, opts });
+    return { ok: false, prs: [{ number: 101, state: "OPEN", isDraft: false, title: "wip" }] };
+  };
+  const { code, err } = await runCli(
+    ["declare", "CTL-9", "--by", "recovery-pass", "--no-emit", "--decls-dir", dir],
+    { checkOpenPrs }
+  );
+  expect(code).toBe(2);
+  expect(err).toContain("refusing Done declaration");
+  expect(err).toContain("#101");
+  expect(calls).toHaveLength(1);
+  expect(calls[0].ticket).toBe("CTL-9");
+  // Fail-closed: NO durable declaration marker is left behind for the drain to land.
+  expect(listDeclarations({ dir, pendingOnly: true })).toEqual([]);
+});
+
+test("H1: recovery-pass Done is ALLOWED when the ticket's only PR is merged (no open PRs)", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "decl-"));
+  let called = 0;
+  const checkOpenPrs = () => {
+    called++;
+    return { ok: true, prs: [] };
+  };
+  const { code, out } = await runCli(
+    ["declare", "CTL-9", "--by", "recovery-pass", "--no-write", "--no-emit", "--decls-dir", dir],
+    { checkOpenPrs }
+  );
+  expect(code).toBe(0);
+  expect(out).toContain("declared (no write)");
+  expect(called).toBe(1);
+  // Gate cleared ⇒ the declaration proceeds and the durable marker persists.
+  const d = readDeclaration("CTL-9", dir);
+  expect(d.state).toBe("done");
+  expect(listDeclarations({ dir, pendingOnly: true }).map((x) => x.ticket)).toEqual(["CTL-9"]);
+});
+
+test("H1: gate is FAIL-CLOSED — an unverifiable PR set (gh failure) refuses the write", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "decl-"));
+  const checkOpenPrs = () => ({ ok: false, reason: "`gh pr list` failed: not authenticated", prs: [] });
+  const { code, err } = await runCli(
+    ["declare", "CTL-9", "--by", "recovery-pass", "--no-emit", "--decls-dir", dir],
+    { checkOpenPrs }
+  );
+  expect(code).toBe(2);
+  expect(err).toContain("could not be verified");
+  expect(listDeclarations({ dir, pendingOnly: true })).toEqual([]);
+});
+
+test("H1: the gate cannot be bypassed via --no-write (refusal happens before the marker is dropped)", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "decl-"));
+  const checkOpenPrs = () => ({ ok: false, prs: [{ number: 7, state: "OPEN", isDraft: false }] });
+  const { code } = await runCli(
+    ["declare", "CTL-9", "--by", "recovery-pass", "--no-write", "--no-emit", "--decls-dir", dir],
+    { checkOpenPrs }
+  );
+  expect(code).toBe(2);
+  // No poison marker ⇒ a later `reconcile --write` drain has nothing to land.
+  expect(listDeclarations({ dir, pendingOnly: true })).toEqual([]);
+});
+
+test("H1: --require-prs-merged opts a non-delegate declarer into the same gate", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "decl-"));
+  const checkOpenPrs = () => ({ ok: false, prs: [{ number: 9, state: "OPEN", isDraft: false }] });
+  const { code } = await runCli(
+    ["declare", "CTL-9", "--by", "model", "--require-prs-merged", "--no-emit", "--decls-dir", dir],
+    { checkOpenPrs }
+  );
+  expect(code).toBe(2);
+  expect(listDeclarations({ dir, pendingOnly: true })).toEqual([]);
+});
+
+test("teardown/CTL-1371 callers are UNAFFECTED — no gate runs without recovery-pass or the flag", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "decl-"));
+  let called = 0;
+  const checkOpenPrs = () => {
+    called++;
+    return { ok: false, prs: [{ number: 1, state: "OPEN" }] };
+  };
+  // `--by teardown` (and the default `model`) must NOT trigger the gate even when
+  // an open PR exists — these completion-signal callers keep today's behavior.
+  for (const by of ["teardown", "model"]) {
+    const { code, out } = await runCli(
+      ["declare", "CTL-9", "--by", by, "--no-write", "--no-emit", "--decls-dir", dir],
+      { checkOpenPrs }
+    );
+    expect(code).toBe(0);
+    expect(out).toContain("declared (no write)");
+  }
+  expect(called).toBe(0); // the gate function was never even consulted
+});
+
+test("defaultCheckOpenPrs is fail-closed when `gh` is unavailable", () => {
+  // No gh binary on a clean PATH ⇒ spawnSync errors ⇒ the gate refuses (ok:false).
+  const r = defaultCheckOpenPrs("CTL-9", { cwd: tmpdir() });
+  expect(r.ok).toBe(false);
 });

--- a/plugins/dev/scripts/execution-core/linear-reconcile-cli.test.mjs
+++ b/plugins/dev/scripts/execution-core/linear-reconcile-cli.test.mjs
@@ -283,6 +283,91 @@ test("DRAIN: a CLEAN Done (0 open PRs) emits NO alarm", async () => {
   expect(alarms).toEqual([]); // clean Done is silent
 });
 
+// ── CTL-1157 SLICE 3 — the broad recovery.done-applied "Done-moves" event ──────
+// Unlike the open-PR alarm, this fires on EVERY autonomous Done (clean or not).
+
+test("DRAIN done-applied: fires on EVERY drained Done (clean too), by=reconcile-drain, 0/0 counts", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "decl-"));
+  const statesFile = join(dir, "states.json");
+  writeFileSync(statesFile, JSON.stringify({ "CTL-9": "Implement" }));
+  await runCli(["declare", "CTL-9", "--no-write", "--no-emit", "--decls-dir", dir], {
+    checkOpenPrs: PASS,
+  });
+  const moves = [];
+  const { code } = await runCli(
+    ["reconcile", "--write", "--decls-dir", dir, "--states-file", statesFile, "--config", configFixture(), "--json"],
+    {
+      applyCorrection: applyCorrectionDone,
+      checkOpenPrs: () => ({ ok: true, prs: [] }), // CLEAN — alarm stays silent
+      emitDoneApplied: (f) => moves.push(f),
+    }
+  );
+  expect(code).toBe(0);
+  expect(moves).toHaveLength(1); // the move event fires even on a clean Done
+  expect(moves[0]).toMatchObject({
+    ticket: "CTL-9",
+    by: "reconcile-drain",
+    openPrsAtDone: 0,
+    prsClosed: 0,
+    prsKept: 0,
+    recoveryMode: "enforce",
+  });
+});
+
+test("DRAIN done-applied: open_prs_at_done carries the red-line count when a PR is still open", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "decl-"));
+  const statesFile = join(dir, "states.json");
+  writeFileSync(statesFile, JSON.stringify({ "CTL-9": "Implement" }));
+  await runCli(["declare", "CTL-9", "--no-write", "--no-emit", "--decls-dir", dir], {
+    checkOpenPrs: PASS,
+  });
+  const moves = [];
+  await runCli(
+    ["reconcile", "--write", "--decls-dir", dir, "--states-file", statesFile, "--config", configFixture(), "--json"],
+    {
+      applyCorrection: applyCorrectionDone,
+      checkOpenPrs: () => ({ ok: false, prs: [{ number: 101, state: "OPEN" }] }),
+      emitDoneApplied: (f) => moves.push(f),
+    }
+  );
+  expect(moves).toHaveLength(1);
+  expect(moves[0].openPrsAtDone).toBe(1); // >0 = the red-line
+});
+
+test("DECLARE done-applied: the agent's own Done carries its PR-2 tallies (by=recovery-pass)", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "decl-"));
+  const moves = [];
+  const { code } = await runCli(
+    [
+      "declare", "CTL-9", "--by", "recovery-pass", "--state", "done", "--no-write",
+      "--prs-closed", "2", "--prs-kept", "1", "--open-prs-at-done", "0",
+      "--decls-dir", dir,
+    ],
+    { emitDoneApplied: (f) => moves.push(f), checkOpenPrs: PASS }
+  );
+  expect(code).toBe(0);
+  expect(moves).toHaveLength(1);
+  expect(moves[0]).toMatchObject({
+    ticket: "CTL-9",
+    by: "recovery-pass",
+    prsClosed: 2,
+    prsKept: 1,
+    openPrsAtDone: 0,
+    // --no-write ⇒ no actual Done write yet ⇒ shadow/would-apply telemetry
+    recoveryMode: "shadow",
+  });
+});
+
+test("DECLARE done-applied: --no-emit suppresses the move event", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "decl-"));
+  const moves = [];
+  await runCli(
+    ["declare", "CTL-9", "--by", "recovery-pass", "--no-write", "--no-emit", "--decls-dir", dir],
+    { emitDoneApplied: (f) => moves.push(f), checkOpenPrs: PASS }
+  );
+  expect(moves).toEqual([]);
+});
+
 test("DRAIN: an idempotent already-Done write (writeAction=skipped) emits NO alarm", async () => {
   const dir = mkdtempSync(join(tmpdir(), "decl-"));
   const statesFile = join(dir, "states.json");

--- a/plugins/dev/scripts/execution-core/linear-reconcile-cli.test.mjs
+++ b/plugins/dev/scripts/execution-core/linear-reconcile-cli.test.mjs
@@ -5,6 +5,11 @@ import { join } from "node:path";
 import { parseArgs, main, defaultCheckOpenPrs } from "./linear-reconcile-cli.mjs";
 import { readDeclaration, listDeclarations } from "./linear-reconcile-store.mjs";
 
+// The open-PR Done gate is now UNIVERSAL (CTL-1157): every `--state done` declare
+// runs checkOpenPrs. Tests that aren't exercising the gate inject this pass-through
+// so they never shell out to real `gh`.
+const PASS = () => ({ ok: true, prs: [] });
+
 async function runCli(argv, deps = {}) {
   const out = [];
   const err = [];
@@ -72,14 +77,10 @@ test("declare without a ticket exits 2", async () => {
 
 test("declare --no-write persists a pending marker and emits nothing to Linear", async () => {
   const dir = mkdtempSync(join(tmpdir(), "decl-"));
-  const { code, out } = await runCli([
-    "declare",
-    "CTL-9",
-    "--no-write",
-    "--no-emit",
-    "--decls-dir",
-    dir,
-  ]);
+  const { code, out } = await runCli(
+    ["declare", "CTL-9", "--no-write", "--no-emit", "--decls-dir", dir],
+    { checkOpenPrs: PASS }
+  );
   expect(code).toBe(0);
   expect(out).toContain("declared (no write)");
   const d = readDeclaration("CTL-9", dir);
@@ -92,7 +93,9 @@ test("declare --no-write persists a pending marker and emits nothing to Linear",
 
 test("status --json lists pending declarations", async () => {
   const dir = mkdtempSync(join(tmpdir(), "decl-"));
-  await runCli(["declare", "CTL-9", "--no-write", "--no-emit", "--decls-dir", dir]);
+  await runCli(["declare", "CTL-9", "--no-write", "--no-emit", "--decls-dir", dir], {
+    checkOpenPrs: PASS,
+  });
   const { code, out } = await runCli(["status", "--json", "--decls-dir", dir]);
   expect(code).toBe(0);
   expect(JSON.parse(out).pending.map((x) => x.ticket)).toEqual(["CTL-9"]);
@@ -104,7 +107,9 @@ test("reconcile --json drains pending → reports drift, writes nothing, exit 0"
   const dir = mkdtempSync(join(tmpdir(), "decl-"));
   const statesFile = join(dir, "states.json");
   writeFileSync(statesFile, JSON.stringify({ "CTL-9": "Implement" }));
-  await runCli(["declare", "CTL-9", "--no-write", "--no-emit", "--decls-dir", dir]);
+  await runCli(["declare", "CTL-9", "--no-write", "--no-emit", "--decls-dir", dir], {
+    checkOpenPrs: PASS,
+  });
 
   const { code, out } = await runCli([
     "reconcile",
@@ -132,7 +137,9 @@ test("reconcile over an already-Done ticket is in-sync (idempotent), exit 0", as
   const dir = mkdtempSync(join(tmpdir(), "decl-"));
   const statesFile = join(dir, "states.json");
   writeFileSync(statesFile, JSON.stringify({ "CTL-9": "Done" }));
-  await runCli(["declare", "CTL-9", "--no-write", "--no-emit", "--decls-dir", dir]);
+  await runCli(["declare", "CTL-9", "--no-write", "--no-emit", "--decls-dir", dir], {
+    checkOpenPrs: PASS,
+  });
   const { code, out } = await runCli([
     "reconcile",
     "--decls-dir",
@@ -148,10 +155,11 @@ test("reconcile over an already-Done ticket is in-sync (idempotent), exit 0", as
   expect(JSON.parse(out).summary.drift).toBe(0);
 });
 
-// ── H1 open-PR gate (CTL-1157) ────────────────────────────────────────────────
-// The recovery-pass delegate must be unable to declare Done while any PR for the
-// ticket is still open. The gate is keyed on `--by recovery-pass` (not an opt-in
-// flag), runs BEFORE any durable marker is persisted, and is fail-closed.
+// ── UNIVERSAL open-PR gate (CTL-1157) ─────────────────────────────────────────
+// NO declarer may move a ticket to Done while any PR for it is still open. The gate
+// is keyed on the TARGET STATE (`--state done`), not the declarer — it fires for
+// recovery-pass, pipeline/teardown, the default model, and humans alike. It runs
+// BEFORE any durable marker is persisted, and is fail-closed.
 
 test("parseArgs: --require-prs-merged / --branch", () => {
   const a = parseArgs(["declare", "CTL-9", "--require-prs-merged", "--branch", "ryan/ctl-9-x"]);
@@ -236,28 +244,126 @@ test("H1: --require-prs-merged opts a non-delegate declarer into the same gate",
   expect(listDeclarations({ dir, pendingOnly: true })).toEqual([]);
 });
 
-test("teardown/CTL-1371 callers are UNAFFECTED — no gate runs without recovery-pass or the flag", async () => {
+test("UNIVERSAL (a): --by pipeline (teardown) with one merged + one open PR is REFUSED (exit 2, no marker)", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "decl-"));
+  // Teardown's completion-signal path is now gated too: #100 merged, #101 still open.
+  const calls = [];
+  const checkOpenPrs = (ticket, opts) => {
+    calls.push({ ticket, opts });
+    return { ok: false, prs: [{ number: 101, state: "OPEN", isDraft: false, title: "wip" }] };
+  };
+  const { code, err } = await runCli(
+    ["declare", "CTL-9", "--by", "pipeline", "--no-emit", "--decls-dir", dir],
+    { checkOpenPrs }
+  );
+  expect(code).toBe(2);
+  expect(err).toContain("refusing Done declaration");
+  expect(err).toContain("#101");
+  expect(calls).toHaveLength(1); // the universal gate WAS consulted for --by pipeline
+  // Fail-closed: nothing persisted ⇒ the reconcile drain has nothing to land.
+  expect(listDeclarations({ dir, pendingOnly: true })).toEqual([]);
+});
+
+test("UNIVERSAL (b): --by pipeline (teardown) with only a MERGED PR is ALLOWED — legitimate completion preserved", async () => {
   const dir = mkdtempSync(join(tmpdir(), "decl-"));
   let called = 0;
   const checkOpenPrs = () => {
     called++;
-    return { ok: false, prs: [{ number: 1, state: "OPEN" }] };
+    return { ok: true, prs: [] }; // only-merged ⇒ no open PR
   };
-  // `--by teardown` (and the default `model`) must NOT trigger the gate even when
-  // an open PR exists — these completion-signal callers keep today's behavior.
-  for (const by of ["teardown", "model"]) {
-    const { code, out } = await runCli(
-      ["declare", "CTL-9", "--by", by, "--no-write", "--no-emit", "--decls-dir", dir],
-      { checkOpenPrs }
-    );
-    expect(code).toBe(0);
-    expect(out).toContain("declared (no write)");
-  }
-  expect(called).toBe(0); // the gate function was never even consulted
+  const { code, out } = await runCli(
+    ["declare", "CTL-9", "--by", "pipeline", "--no-write", "--no-emit", "--decls-dir", dir],
+    { checkOpenPrs }
+  );
+  expect(code).toBe(0);
+  expect(out).toContain("declared (no write)");
+  expect(called).toBe(1);
+  expect(readDeclaration("CTL-9", dir).state).toBe("done");
+});
+
+test("UNIVERSAL (c): the default --by model with an open PR is REFUSED", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "decl-"));
+  const checkOpenPrs = () => ({ ok: false, prs: [{ number: 42, state: "OPEN", isDraft: false }] });
+  // No --by ⇒ defaults to model; the gate still fires on --state done.
+  const { code, err } = await runCli(
+    ["declare", "CTL-9", "--no-emit", "--decls-dir", dir],
+    { checkOpenPrs }
+  );
+  expect(code).toBe(2);
+  expect(err).toContain("#42");
+  expect(listDeclarations({ dir, pendingOnly: true })).toEqual([]);
+});
+
+test("UNIVERSAL: a NON-done target (--state canceled) is NOT gated", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "decl-"));
+  let called = 0;
+  const checkOpenPrs = () => {
+    called++;
+    return { ok: false, prs: [{ number: 7, state: "OPEN" }] };
+  };
+  const { code } = await runCli(
+    ["declare", "CTL-9", "--state", "canceled", "--no-write", "--no-emit", "--decls-dir", dir],
+    { checkOpenPrs }
+  );
+  expect(code).toBe(0);
+  expect(called).toBe(0); // canceling is not a completion claim ⇒ gate never consulted
+});
+
+test("UNIVERSAL (d): a non-standard-branch open PR (title omits the ticket key) is caught via the branchName head pass", () => {
+  // The ticket-key SEARCH pass returns nothing (the PR title/body never mention
+  // CTL-9), but the HEAD pass on the derived branchName finds the open PR. Inject
+  // both gh + branch-derivation seams so the union logic is exercised hermetically.
+  const calls = [];
+  const runGh = (args) => {
+    calls.push(args);
+    if (args.includes("--search")) return []; // key-search misses the non-standard PR
+    if (args.includes("--head")) return [{ number: 555, state: "OPEN", isDraft: false, title: "random title" }];
+    return [];
+  };
+  const deriveBranchName = () => "ryan/some-unconventional-branch";
+  const r = defaultCheckOpenPrs("CTL-9", { runGh, deriveBranchName });
+  expect(r.ok).toBe(false);
+  expect(r.prs.map((p) => p.number)).toEqual([555]);
+  expect(r.branchName).toBe("ryan/some-unconventional-branch");
+  // The head pass ran with the replica-derived branch (proves the ALWAYS-derive path).
+  expect(calls.some((a) => a.includes("--head") && a.includes("ryan/some-unconventional-branch"))).toBe(true);
+});
+
+test("UNIVERSAL (e): the reconcile drain cannot land a Done while a PR is open (no poison marker to drain)", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "decl-"));
+  const checkOpenPrs = () => ({ ok: false, prs: [{ number: 9, state: "OPEN", isDraft: false }] });
+  // Step 1: a Done declaration is REFUSED while the PR is open → no marker persists.
+  const refused = await runCli(
+    ["declare", "CTL-9", "--by", "pipeline", "--no-emit", "--decls-dir", dir],
+    { checkOpenPrs }
+  );
+  expect(refused.code).toBe(2);
+  expect(listDeclarations({ dir, pendingOnly: true })).toEqual([]);
+  // Step 2: `reconcile --write` over the same store has NOTHING pending → it cannot
+  // write Done. The drain is safe by construction: the ONLY producer of a Done
+  // marker is the gated declare, which refused above.
+  const statesFile = join(dir, "states.json");
+  writeFileSync(statesFile, JSON.stringify({ "CTL-9": "Implement" }));
+  const { code, out } = await runCli([
+    "reconcile",
+    "--write",
+    "--decls-dir",
+    dir,
+    "--states-file",
+    statesFile,
+    "--config",
+    configFixture(),
+    "--json",
+  ]);
+  expect(code).toBe(0);
+  const parsed = JSON.parse(out);
+  expect(parsed.summary.tickets).toBe(0); // nothing drained → no Done written
+  expect(parsed.rows).toEqual([]);
 });
 
 test("defaultCheckOpenPrs is fail-closed when `gh` is unavailable", () => {
   // No gh binary on a clean PATH ⇒ spawnSync errors ⇒ the gate refuses (ok:false).
-  const r = defaultCheckOpenPrs("CTL-9", { cwd: tmpdir() });
+  // deriveBranchName is stubbed null so the test stays hermetic (no catalyst-linear spawn).
+  const r = defaultCheckOpenPrs("CTL-9", { cwd: tmpdir(), deriveBranchName: () => null });
   expect(r.ok).toBe(false);
 });

--- a/plugins/dev/scripts/execution-core/linear-reconcile-cli.test.mjs
+++ b/plugins/dev/scripts/execution-core/linear-reconcile-cli.test.mjs
@@ -527,4 +527,40 @@ test("ENUMERATOR: reports unverifiable (ok:false, reason) when `gh` list is unav
   });
   expect(r.ok).toBe(false);
   expect(r.reason).toBeTruthy();
+  expect(r.unverifiable).toBe(true); // an unparseable/failed authoritative check is unverifiable
+});
+
+// CTL-1157 (Codex GROUP-A fix #1): an attachment-discovered PR we KNOW exists but
+// cannot `gh pr view` (transient GitHub/auth/rate-limit) makes the WHOLE
+// enumeration unverifiable — it must NOT be silently dropped into a clean empty
+// list, which would let a backstop mark Done with no alarm on an unverified check.
+test("ENUMERATOR (CTL-1157): an attachment `gh pr view` FAILURE → UNVERIFIABLE, never a clean empty list", () => {
+  const runGh = (args) => {
+    if (args.includes("list")) return []; // search + head passes find nothing
+    if (args.includes("view")) throw new Error("gh: API rate limit exceeded");
+    return [];
+  };
+  const r = defaultCheckOpenPrs("CTL-9", {
+    runGh,
+    deriveBranchName: () => null,
+    deriveAttachmentPrNumbers: () => [808], // Linear says #808 is attached
+  });
+  expect(r.ok).toBe(false);
+  expect(r.unverifiable).toBe(true);
+  expect(r.reason).toMatch(/808/); // names the attachment PR it could not view
+});
+
+// CTL-1157 (Codex GROUP-A fix #2): when we must spawn REAL gh (no runGh seam) but
+// cannot derive the ticket's repo, the check is UNVERIFIABLE — we refuse to run gh
+// in the daemon's cwd (which would falsely report zero open PRs for a multi-repo
+// ticket). The repo is derived from the registry/config, NEVER bare linearis.
+test("ENUMERATOR (CTL-1157): an UNDERIVABLE repo is UNVERIFIABLE (never runs gh in the wrong repo)", () => {
+  const r = defaultCheckOpenPrs("CTL-9", {
+    deriveRepoRoot: () => null, // registry has no entry for this ticket's team
+    deriveBranchName: () => null,
+    deriveAttachmentPrNumbers: () => [],
+  });
+  expect(r.ok).toBe(false);
+  expect(r.unverifiable).toBe(true);
+  expect(r.reason).toBe("repo-underivable");
 });

--- a/plugins/dev/scripts/execution-core/linear-reconcile-cli.test.mjs
+++ b/plugins/dev/scripts/execution-core/linear-reconcile-cli.test.mjs
@@ -358,12 +358,14 @@ test("DECLARE done-applied: the agent's own Done carries its PR-2 tallies (by=re
   });
 });
 
-test("DECLARE done-applied: a pipeline record-only marker (--by pipeline --no-write) emits NO would-done shadow event", async () => {
-  // CTL-1157 GROUP B: phase-teardown records durable completion with
-  // `declare --state done --by pipeline --no-write` AFTER it has ALREADY performed
-  // the real Linear Done (via linear-transition.sh). That --no-write is a
-  // record-only marker, NOT a shadow — emitting recovery.would-done-applied here
-  // would pollute shadow telemetry and undercount real Done moves.
+test("DECLARE done-applied: a pipeline record-only marker (--by pipeline --no-write) emits an ENFORCE done-applied, never a shadow would-event", async () => {
+  // CTL-1157 GROUP 1 (observable teardown Done): phase-teardown records durable
+  // completion with `declare --state done --by pipeline --no-write` AFTER it has
+  // ALREADY performed the real Linear Done (via linear-transition.sh, no telemetry).
+  // That --no-write is the RECORD OF A REAL EXTERNAL DONE, NOT a shadow — it must
+  // emit recovery.done-applied in ENFORCE mode (so the normal-pipeline teardown Done
+  // is observable, not SILENT), and must NOT emit the recovery.would-done-applied
+  // shadow variant (Codex round-1 #7).
   const dir = mkdtempSync(join(tmpdir(), "decl-"));
   const moves = [];
   const { code } = await runCli(
@@ -374,7 +376,87 @@ test("DECLARE done-applied: a pipeline record-only marker (--by pipeline --no-wr
     { emitDoneApplied: (f) => moves.push(f), checkOpenPrs: PASS }
   );
   expect(code).toBe(0);
-  expect(moves).toEqual([]); // record-only marker → no shadow would-done event
+  expect(moves).toHaveLength(1); // the teardown Done is observable — not silent
+  expect(moves[0]).toMatchObject({
+    ticket: "CTL-9",
+    by: "pipeline",
+    openPrsAtDone: 0,
+    prsClosed: 0,
+    prsKept: 0,
+    // the real Done ALREADY landed externally ⇒ enforce, NOT a shadow would-event
+    recoveryMode: "enforce",
+  });
+});
+
+test("DECLARE (GROUP 1): a pipeline record-only Done WITH an open PR is observable + alarmed — not silent", async () => {
+  // The Problem-A regression: real teardown Done (external) → pipeline record-only
+  // marker → later terminal-sweep sees already-Done → skipped. WITHOUT this fix the
+  // teardown Done with an open PR emitted NEITHER done-applied NOR the open-PR alarm.
+  // Now the record-only marker enumerates open PRs itself and fires both.
+  const dir = mkdtempSync(join(tmpdir(), "decl-"));
+  const moves = [];
+  const alarms = [];
+  const { code } = await runCli(
+    [
+      "declare", "CTL-9", "--by", "pipeline", "--state", "done", "--no-write",
+      "--decls-dir", dir,
+    ],
+    {
+      emitDoneApplied: (f) => moves.push(f),
+      emitDoneWithOpenPr: (ev) => alarms.push(ev),
+      checkOpenPrs: () => ({ ok: false, prs: [{ number: 202, state: "OPEN", isDraft: false }] }),
+    }
+  );
+  expect(code).toBe(0);
+  // done-applied fires (enforce) carrying the red-line open count
+  expect(moves).toHaveLength(1);
+  expect(moves[0]).toMatchObject({ ticket: "CTL-9", recoveryMode: "enforce", openPrsAtDone: 1 });
+  // and the loud recovery.done-applied-with-open-pr alarm fires
+  expect(alarms).toHaveLength(1);
+  expect(alarms[0]).toMatchObject({ ticket: "CTL-9", by: "pipeline-teardown", unverifiable: false });
+  expect(alarms[0].openPrs.map((p) => p.number)).toEqual([202]);
+});
+
+test("DECLARE (GROUP 1): a pipeline record-only Done with an UNVERIFIABLE open-PR check still alarms (unverifiable ≠ clean)", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "decl-"));
+  const moves = [];
+  const alarms = [];
+  const { code } = await runCli(
+    [
+      "declare", "CTL-9", "--by", "pipeline", "--state", "done", "--no-write",
+      "--decls-dir", dir,
+    ],
+    {
+      emitDoneApplied: (f) => moves.push(f),
+      emitDoneWithOpenPr: (ev) => alarms.push(ev),
+      checkOpenPrs: () => ({ ok: false, unverifiable: true, reason: "repo-underivable", prs: [] }),
+    }
+  );
+  expect(code).toBe(0);
+  expect(moves).toHaveLength(1); // still observable
+  expect(moves[0].openPrsAtDone).toBe(0);
+  expect(alarms).toHaveLength(1); // unverifiable ⇒ surfaced, not silently assumed clean
+  expect(alarms[0]).toMatchObject({ ticket: "CTL-9", by: "pipeline-teardown", unverifiable: true });
+});
+
+test("DECLARE (GROUP 1): a CLEAN pipeline record-only Done emits done-applied but NO alarm", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "decl-"));
+  const moves = [];
+  const alarms = [];
+  const { code } = await runCli(
+    [
+      "declare", "CTL-9", "--by", "pipeline", "--state", "done", "--no-write",
+      "--decls-dir", dir,
+    ],
+    {
+      emitDoneApplied: (f) => moves.push(f),
+      emitDoneWithOpenPr: (ev) => alarms.push(ev),
+      checkOpenPrs: PASS, // verifiably clean
+    }
+  );
+  expect(code).toBe(0);
+  expect(moves).toHaveLength(1); // observable
+  expect(alarms).toEqual([]); // clean, confirmed Done is silent
 });
 
 test("DECLARE done-applied: --no-emit suppresses the move event", async () => {

--- a/plugins/dev/scripts/execution-core/linear-reconcile-cli.test.mjs
+++ b/plugins/dev/scripts/execution-core/linear-reconcile-cli.test.mjs
@@ -155,161 +155,221 @@ test("reconcile over an already-Done ticket is in-sync (idempotent), exit 0", as
   expect(JSON.parse(out).summary.drift).toBe(0);
 });
 
-// ── UNIVERSAL open-PR gate (CTL-1157) ─────────────────────────────────────────
-// NO declarer may move a ticket to Done while any PR for it is still open. The gate
-// is keyed on the TARGET STATE (`--state done`), not the declarer — it fires for
-// recovery-pass, pipeline/teardown, the default model, and humans alike. It runs
-// BEFORE any durable marker is persisted, and is fail-closed.
+// ── CTL-1157 THE REVERSAL: agent judgment, not a mechanical block ─────────────
+// The Done-safety mechanism is AGENT JUDGMENT. The senior-engineer delegate
+// enumerates a ticket's open PRs and resolves them ITSELF (finish/merge the needed
+// ones, CLOSE the abandoned ones) BEFORE it declares Done — so `declare` is NOT
+// gated and NEVER refuses. The hard block is held in reserve. The two pure-code
+// backstops (terminal sweep + reconcile drain) PROCEED but emit the loud
+// `recovery.done-applied-with-open-pr` alarm when they land a Done with an open PR.
 
-test("parseArgs: --require-prs-merged / --branch", () => {
+test("parseArgs: --require-prs-merged / --branch (retained as no-op back-compat)", () => {
   const a = parseArgs(["declare", "CTL-9", "--require-prs-merged", "--branch", "ryan/ctl-9-x"]);
   expect(a.requirePrsMerged).toBe(true);
   expect(a.branch).toBe("ryan/ctl-9-x");
 });
 
-test("H1: recovery-pass Done is REFUSED when a non-standard-branch PR is still open (one merged + one open)", async () => {
+test("REVERSAL: declare PROCEEDS (exit 0, marker persists) even with an open PR — the agent already reasoned", async () => {
   const dir = mkdtempSync(join(tmpdir(), "decl-"));
-  // The false-Done scenario: #100 already merged, #101 still open on a weird branch.
-  // The gate sees the OPEN PR and must refuse — nothing written, nothing persisted.
-  const calls = [];
-  const checkOpenPrs = (ticket, opts) => {
-    calls.push({ ticket, opts });
-    return { ok: false, prs: [{ number: 101, state: "OPEN", isDraft: false, title: "wip" }] };
-  };
-  const { code, err } = await runCli(
-    ["declare", "CTL-9", "--by", "recovery-pass", "--no-emit", "--decls-dir", dir],
-    { checkOpenPrs }
-  );
-  expect(code).toBe(2);
-  expect(err).toContain("refusing Done declaration");
-  expect(err).toContain("#101");
-  expect(calls).toHaveLength(1);
-  expect(calls[0].ticket).toBe("CTL-9");
-  // Fail-closed: NO durable declaration marker is left behind for the drain to land.
-  expect(listDeclarations({ dir, pendingOnly: true })).toEqual([]);
-});
-
-test("H1: recovery-pass Done is ALLOWED when the ticket's only PR is merged (no open PRs)", async () => {
-  const dir = mkdtempSync(join(tmpdir(), "decl-"));
-  let called = 0;
+  // An open PR is present, but the senior-engineer delegate decided (autonomously)
+  // to mark Done. The CLI must NOT refuse, and must NOT consult any PR gate.
+  let consulted = 0;
   const checkOpenPrs = () => {
-    called++;
-    return { ok: true, prs: [] };
+    consulted++;
+    return { ok: false, prs: [{ number: 101, state: "OPEN", isDraft: false, title: "wip" }] };
   };
   const { code, out } = await runCli(
     ["declare", "CTL-9", "--by", "recovery-pass", "--no-write", "--no-emit", "--decls-dir", dir],
     { checkOpenPrs }
   );
-  expect(code).toBe(0);
+  expect(code).toBe(0); // no handcuff — proceeds
   expect(out).toContain("declared (no write)");
-  expect(called).toBe(1);
-  // Gate cleared ⇒ the declaration proceeds and the durable marker persists.
-  const d = readDeclaration("CTL-9", dir);
-  expect(d.state).toBe("done");
+  expect(consulted).toBe(0); // the agent declare path does NOT consult the enumerator
+  // The durable marker persists (no fail-closed swallow).
+  expect(readDeclaration("CTL-9", dir).state).toBe("done");
   expect(listDeclarations({ dir, pendingOnly: true }).map((x) => x.ticket)).toEqual(["CTL-9"]);
 });
 
-test("H1: gate is FAIL-CLOSED — an unverifiable PR set (gh failure) refuses the write", async () => {
+test("REVERSAL: a clean Done declaration (no open PR) proceeds exactly as before", async () => {
   const dir = mkdtempSync(join(tmpdir(), "decl-"));
-  const checkOpenPrs = () => ({ ok: false, reason: "`gh pr list` failed: not authenticated", prs: [] });
-  const { code, err } = await runCli(
-    ["declare", "CTL-9", "--by", "recovery-pass", "--no-emit", "--decls-dir", dir],
-    { checkOpenPrs }
-  );
-  expect(code).toBe(2);
-  expect(err).toContain("could not be verified");
-  expect(listDeclarations({ dir, pendingOnly: true })).toEqual([]);
-});
-
-test("H1: the gate cannot be bypassed via --no-write (refusal happens before the marker is dropped)", async () => {
-  const dir = mkdtempSync(join(tmpdir(), "decl-"));
-  const checkOpenPrs = () => ({ ok: false, prs: [{ number: 7, state: "OPEN", isDraft: false }] });
-  const { code } = await runCli(
-    ["declare", "CTL-9", "--by", "recovery-pass", "--no-write", "--no-emit", "--decls-dir", dir],
-    { checkOpenPrs }
-  );
-  expect(code).toBe(2);
-  // No poison marker ⇒ a later `reconcile --write` drain has nothing to land.
-  expect(listDeclarations({ dir, pendingOnly: true })).toEqual([]);
-});
-
-test("H1: --require-prs-merged opts a non-delegate declarer into the same gate", async () => {
-  const dir = mkdtempSync(join(tmpdir(), "decl-"));
-  const checkOpenPrs = () => ({ ok: false, prs: [{ number: 9, state: "OPEN", isDraft: false }] });
-  const { code } = await runCli(
-    ["declare", "CTL-9", "--by", "model", "--require-prs-merged", "--no-emit", "--decls-dir", dir],
-    { checkOpenPrs }
-  );
-  expect(code).toBe(2);
-  expect(listDeclarations({ dir, pendingOnly: true })).toEqual([]);
-});
-
-test("UNIVERSAL (a): --by pipeline (teardown) with one merged + one open PR is REFUSED (exit 2, no marker)", async () => {
-  const dir = mkdtempSync(join(tmpdir(), "decl-"));
-  // Teardown's completion-signal path is now gated too: #100 merged, #101 still open.
-  const calls = [];
-  const checkOpenPrs = (ticket, opts) => {
-    calls.push({ ticket, opts });
-    return { ok: false, prs: [{ number: 101, state: "OPEN", isDraft: false, title: "wip" }] };
-  };
-  const { code, err } = await runCli(
-    ["declare", "CTL-9", "--by", "pipeline", "--no-emit", "--decls-dir", dir],
-    { checkOpenPrs }
-  );
-  expect(code).toBe(2);
-  expect(err).toContain("refusing Done declaration");
-  expect(err).toContain("#101");
-  expect(calls).toHaveLength(1); // the universal gate WAS consulted for --by pipeline
-  // Fail-closed: nothing persisted ⇒ the reconcile drain has nothing to land.
-  expect(listDeclarations({ dir, pendingOnly: true })).toEqual([]);
-});
-
-test("UNIVERSAL (b): --by pipeline (teardown) with only a MERGED PR is ALLOWED — legitimate completion preserved", async () => {
-  const dir = mkdtempSync(join(tmpdir(), "decl-"));
-  let called = 0;
-  const checkOpenPrs = () => {
-    called++;
-    return { ok: true, prs: [] }; // only-merged ⇒ no open PR
-  };
   const { code, out } = await runCli(
     ["declare", "CTL-9", "--by", "pipeline", "--no-write", "--no-emit", "--decls-dir", dir],
-    { checkOpenPrs }
+    { checkOpenPrs: PASS }
   );
   expect(code).toBe(0);
   expect(out).toContain("declared (no write)");
-  expect(called).toBe(1);
   expect(readDeclaration("CTL-9", dir).state).toBe("done");
 });
 
-test("UNIVERSAL (c): the default --by model with an open PR is REFUSED", async () => {
-  const dir = mkdtempSync(join(tmpdir(), "decl-"));
-  const checkOpenPrs = () => ({ ok: false, prs: [{ number: 42, state: "OPEN", isDraft: false }] });
-  // No --by ⇒ defaults to model; the gate still fires on --state done.
-  const { code, err } = await runCli(
-    ["declare", "CTL-9", "--no-emit", "--decls-dir", dir],
-    { checkOpenPrs }
-  );
-  expect(code).toBe(2);
-  expect(err).toContain("#42");
-  expect(listDeclarations({ dir, pendingOnly: true })).toEqual([]);
+// ── Reconcile drain backstop: ALARM-NOT-BLOCK ────────────────────────────────
+// The pure-code drain has no agent to reason. It PROCEEDS (always writes), but when
+// it lands a real Done transition for a ticket that still has ≥1 OPEN PR it fires
+// recovery.done-applied-with-open-pr. A clean Done emits nothing.
+
+// applyCorrectionDone — a fake Linear write that reports a real Done transition.
+const applyCorrectionDone = ({ ticket, target }) => ({
+  applied: true,
+  action: "transitioned",
+  from_state: "Implement",
+  to_state: target,
+  ticket,
 });
 
-test("UNIVERSAL: a NON-done target (--state canceled) is NOT gated", async () => {
+test("DRAIN: emits recovery.done-applied-with-open-pr when it writes Done with an open PR present", async () => {
   const dir = mkdtempSync(join(tmpdir(), "decl-"));
-  let called = 0;
-  const checkOpenPrs = () => {
-    called++;
-    return { ok: false, prs: [{ number: 7, state: "OPEN" }] };
-  };
-  const { code } = await runCli(
-    ["declare", "CTL-9", "--state", "canceled", "--no-write", "--no-emit", "--decls-dir", dir],
-    { checkOpenPrs }
+  const statesFile = join(dir, "states.json");
+  writeFileSync(statesFile, JSON.stringify({ "CTL-9": "Implement" })); // drifted ⇒ a real Done write
+  await runCli(["declare", "CTL-9", "--no-write", "--no-emit", "--decls-dir", dir], {
+    checkOpenPrs: PASS,
+  });
+
+  const alarms = [];
+  const { code, out } = await runCli(
+    [
+      "reconcile",
+      "--write",
+      "--decls-dir",
+      dir,
+      "--states-file",
+      statesFile,
+      "--config",
+      configFixture(),
+      "--json",
+    ],
+    {
+      applyCorrection: applyCorrectionDone,
+      checkOpenPrs: () => ({ ok: false, prs: [{ number: 101, state: "OPEN", isDraft: false }] }),
+      emitDoneWithOpenPr: (ev) => alarms.push(ev),
+    }
   );
   expect(code).toBe(0);
-  expect(called).toBe(0); // canceling is not a completion claim ⇒ gate never consulted
+  const parsed = JSON.parse(out);
+  expect(parsed.summary.corrected).toBe(1); // the drain PROCEEDED — Done was written
+  // The alarm fired with the ticket, the open PR list, and the backstop label.
+  expect(alarms).toHaveLength(1);
+  expect(alarms[0].ticket).toBe("CTL-9");
+  expect(alarms[0].by).toBe("reconcile-drain");
+  expect(alarms[0].openPrs.map((p) => p.number)).toEqual([101]);
 });
 
-test("UNIVERSAL (d): a non-standard-branch open PR (title omits the ticket key) is caught via the branchName head pass", () => {
+test("DRAIN: a CLEAN Done (0 open PRs) emits NO alarm", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "decl-"));
+  const statesFile = join(dir, "states.json");
+  writeFileSync(statesFile, JSON.stringify({ "CTL-9": "Implement" }));
+  await runCli(["declare", "CTL-9", "--no-write", "--no-emit", "--decls-dir", dir], {
+    checkOpenPrs: PASS,
+  });
+
+  const alarms = [];
+  const { code } = await runCli(
+    [
+      "reconcile",
+      "--write",
+      "--decls-dir",
+      dir,
+      "--states-file",
+      statesFile,
+      "--config",
+      configFixture(),
+      "--json",
+    ],
+    {
+      applyCorrection: applyCorrectionDone,
+      checkOpenPrs: () => ({ ok: true, prs: [] }), // clean
+      emitDoneWithOpenPr: (ev) => alarms.push(ev),
+    }
+  );
+  expect(code).toBe(0);
+  expect(alarms).toEqual([]); // clean Done is silent
+});
+
+test("DRAIN: an idempotent already-Done write (writeAction=skipped) emits NO alarm", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "decl-"));
+  const statesFile = join(dir, "states.json");
+  // Current state is already past target in a way that yields an applied:skipped write.
+  writeFileSync(statesFile, JSON.stringify({ "CTL-9": "Implement" }));
+  await runCli(["declare", "CTL-9", "--no-write", "--no-emit", "--decls-dir", dir], {
+    checkOpenPrs: PASS,
+  });
+  const alarms = [];
+  const applyCorrectionNoop = ({ ticket, target }) => ({
+    applied: true,
+    action: "skipped", // idempotent: already Done before this drain
+    to_state: target,
+    ticket,
+  });
+  await runCli(
+    [
+      "reconcile",
+      "--write",
+      "--decls-dir",
+      dir,
+      "--states-file",
+      statesFile,
+      "--config",
+      configFixture(),
+      "--json",
+    ],
+    {
+      applyCorrection: applyCorrectionNoop,
+      checkOpenPrs: () => ({ ok: false, prs: [{ number: 7, state: "OPEN" }] }),
+      emitDoneWithOpenPr: (ev) => alarms.push(ev),
+    }
+  );
+  expect(alarms).toEqual([]); // not a real transition ⇒ no alarm
+});
+
+test("DRAIN: a dry-run reconcile never alarms (no write landed)", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "decl-"));
+  const statesFile = join(dir, "states.json");
+  writeFileSync(statesFile, JSON.stringify({ "CTL-9": "Implement" }));
+  await runCli(["declare", "CTL-9", "--no-write", "--no-emit", "--decls-dir", dir], {
+    checkOpenPrs: PASS,
+  });
+  const alarms = [];
+  await runCli(
+    ["reconcile", "--decls-dir", dir, "--states-file", statesFile, "--config", configFixture(), "--json"],
+    {
+      checkOpenPrs: () => ({ ok: false, prs: [{ number: 9, state: "OPEN" }] }),
+      emitDoneWithOpenPr: (ev) => alarms.push(ev),
+    }
+  );
+  expect(alarms).toEqual([]); // dry-run wrote nothing
+});
+
+test("UNIVERSAL: a NON-done target (--state canceled) is never alarmed by the drain", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "decl-"));
+  const statesFile = join(dir, "states.json");
+  writeFileSync(statesFile, JSON.stringify({ "CTL-9": "Implement" }));
+  await runCli(
+    ["declare", "CTL-9", "--state", "canceled", "--no-write", "--no-emit", "--decls-dir", dir],
+    { checkOpenPrs: PASS }
+  );
+  const alarms = [];
+  await runCli(
+    [
+      "reconcile",
+      "--write",
+      "--decls-dir",
+      dir,
+      "--states-file",
+      statesFile,
+      "--config",
+      configFixture(),
+      "--json",
+    ],
+    {
+      applyCorrection: applyCorrectionDone,
+      checkOpenPrs: () => ({ ok: false, prs: [{ number: 7, state: "OPEN" }] }),
+      emitDoneWithOpenPr: (ev) => alarms.push(ev),
+    }
+  );
+  expect(alarms).toEqual([]); // kind!=="done" ⇒ never alarmed
+});
+
+// ── Enumerator (open-pr-gate): FACTS, three discovery passes ──────────────────
+
+test("ENUMERATOR: a non-standard-branch open PR (title omits the ticket key) is caught via the branchName head pass", () => {
   // The ticket-key SEARCH pass returns nothing (the PR title/body never mention
   // CTL-9), but the HEAD pass on the derived branchName finds the open PR. Inject
   // both gh + branch-derivation seams so the union logic is exercised hermetically.
@@ -321,7 +381,11 @@ test("UNIVERSAL (d): a non-standard-branch open PR (title omits the ticket key) 
     return [];
   };
   const deriveBranchName = () => "ryan/some-unconventional-branch";
-  const r = defaultCheckOpenPrs("CTL-9", { runGh, deriveBranchName });
+  const r = defaultCheckOpenPrs("CTL-9", {
+    runGh,
+    deriveBranchName,
+    deriveAttachmentPrNumbers: () => [],
+  });
   expect(r.ok).toBe(false);
   expect(r.prs.map((p) => p.number)).toEqual([555]);
   expect(r.branchName).toBe("ryan/some-unconventional-branch");
@@ -329,41 +393,53 @@ test("UNIVERSAL (d): a non-standard-branch open PR (title omits the ticket key) 
   expect(calls.some((a) => a.includes("--head") && a.includes("ryan/some-unconventional-branch"))).toBe(true);
 });
 
-test("UNIVERSAL (e): the reconcile drain cannot land a Done while a PR is open (no poison marker to drain)", async () => {
-  const dir = mkdtempSync(join(tmpdir(), "decl-"));
-  const checkOpenPrs = () => ({ ok: false, prs: [{ number: 9, state: "OPEN", isDraft: false }] });
-  // Step 1: a Done declaration is REFUSED while the PR is open → no marker persists.
-  const refused = await runCli(
-    ["declare", "CTL-9", "--by", "pipeline", "--no-emit", "--decls-dir", dir],
-    { checkOpenPrs }
-  );
-  expect(refused.code).toBe(2);
-  expect(listDeclarations({ dir, pendingOnly: true })).toEqual([]);
-  // Step 2: `reconcile --write` over the same store has NOTHING pending → it cannot
-  // write Done. The drain is safe by construction: the ONLY producer of a Done
-  // marker is the gated declare, which refused above.
-  const statesFile = join(dir, "states.json");
-  writeFileSync(statesFile, JSON.stringify({ "CTL-9": "Implement" }));
-  const { code, out } = await runCli([
-    "reconcile",
-    "--write",
-    "--decls-dir",
-    dir,
-    "--states-file",
-    statesFile,
-    "--config",
-    configFixture(),
-    "--json",
-  ]);
-  expect(code).toBe(0);
-  const parsed = JSON.parse(out);
-  expect(parsed.summary.tickets).toBe(0); // nothing drained → no Done written
-  expect(parsed.rows).toEqual([]);
+test("ENUMERATOR (slice 4): a PR with no key + non-standard branch but a Linear attachment is caught via the attachment pass", () => {
+  // Search misses (no key in text); head pass misses (no branch). The PR is only
+  // discoverable through Linear's own attachment — gh pr view confirms it OPEN.
+  const viewed = [];
+  const runGh = (args) => {
+    if (args.includes("list") && args.includes("--search")) return [];
+    if (args.includes("list") && args.includes("--head")) return [];
+    if (args.includes("view")) {
+      viewed.push(args);
+      return { number: 808, state: "OPEN", isDraft: false, title: "attachment-linked" };
+    }
+    return [];
+  };
+  const r = defaultCheckOpenPrs("CTL-9", {
+    runGh,
+    deriveBranchName: () => null,
+    deriveAttachmentPrNumbers: () => [808],
+  });
+  expect(r.ok).toBe(false);
+  expect(r.prs.map((p) => p.number)).toEqual([808]);
+  expect(viewed.some((a) => a.includes("808"))).toBe(true);
 });
 
-test("defaultCheckOpenPrs is fail-closed when `gh` is unavailable", () => {
-  // No gh binary on a clean PATH ⇒ spawnSync errors ⇒ the gate refuses (ok:false).
-  // deriveBranchName is stubbed null so the test stays hermetic (no catalyst-linear spawn).
-  const r = defaultCheckOpenPrs("CTL-9", { cwd: tmpdir(), deriveBranchName: () => null });
+test("ENUMERATOR (slice 4): a MERGED attachment PR does not count (gh pr view reports non-OPEN)", () => {
+  const runGh = (args) => {
+    if (args.includes("list")) return [];
+    if (args.includes("view")) return { number: 808, state: "MERGED", isDraft: false };
+    return [];
+  };
+  const r = defaultCheckOpenPrs("CTL-9", {
+    runGh,
+    deriveBranchName: () => null,
+    deriveAttachmentPrNumbers: () => [808],
+  });
+  expect(r.ok).toBe(true); // merged attachment ⇒ no open PR
+  expect(r.prs).toEqual([]);
+});
+
+test("ENUMERATOR: reports unverifiable (ok:false, reason) when `gh` list is unavailable", () => {
+  // No gh binary on a clean PATH ⇒ spawnSync errors ⇒ the list pass throws ⇒ the
+  // enumeration is unverifiable. (Callers no longer refuse on this — they proceed.)
+  // deriveBranchName/attachment stubbed so the test stays hermetic (no spawn).
+  const r = defaultCheckOpenPrs("CTL-9", {
+    cwd: tmpdir(),
+    deriveBranchName: () => null,
+    deriveAttachmentPrNumbers: () => [],
+  });
   expect(r.ok).toBe(false);
+  expect(r.reason).toBeTruthy();
 });

--- a/plugins/dev/scripts/execution-core/linear-reconcile-cli.test.mjs
+++ b/plugins/dev/scripts/execution-core/linear-reconcile-cli.test.mjs
@@ -3,6 +3,7 @@ import { mkdtempSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { parseArgs, main, defaultCheckOpenPrs } from "./linear-reconcile-cli.mjs";
+import { defaultDeriveAttachmentPrs } from "./open-pr-gate.mjs";
 import { readDeclaration, listDeclarations } from "./linear-reconcile-store.mjs";
 
 // The open-PR Done gate is now UNIVERSAL (CTL-1157): every `--state done` declare
@@ -570,7 +571,7 @@ test("ENUMERATOR: a non-standard-branch open PR (title omits the ticket key) is 
   const r = defaultCheckOpenPrs("CTL-9", {
     runGh,
     deriveBranchName,
-    deriveAttachmentPrNumbers: () => [],
+    deriveAttachmentPrs: () => [],
   });
   expect(r.ok).toBe(false);
   expect(r.prs.map((p) => p.number)).toEqual([555]);
@@ -595,7 +596,7 @@ test("ENUMERATOR (slice 4): a PR with no key + non-standard branch but a Linear 
   const r = defaultCheckOpenPrs("CTL-9", {
     runGh,
     deriveBranchName: () => null,
-    deriveAttachmentPrNumbers: () => [808],
+    deriveAttachmentPrs: () => [808],
   });
   expect(r.ok).toBe(false);
   expect(r.prs.map((p) => p.number)).toEqual([808]);
@@ -611,10 +612,111 @@ test("ENUMERATOR (slice 4): a MERGED attachment PR does not count (gh pr view re
   const r = defaultCheckOpenPrs("CTL-9", {
     runGh,
     deriveBranchName: () => null,
-    deriveAttachmentPrNumbers: () => [808],
+    deriveAttachmentPrs: () => [808],
   });
   expect(r.ok).toBe(true); // merged attachment ⇒ no open PR
   expect(r.prs).toEqual([]);
+});
+
+// CTL-1157 (GROUP-3 #1): an attached OPEN PR that lives in a DIFFERENT repo than the
+// ticket's project repo must be `gh pr view`'d against ITS OWN repo (-R owner/repo).
+// The ticket-repo passes see nothing (or a same-numbered UNRELATED PR); collapsing the
+// attachment to the ticket repo would check #808 in the wrong repo → report it
+// closed/absent → a FALSE clean. -R org/other confirms it OPEN.
+test("ENUMERATOR (CTL-1157 GROUP-3 #1): a cross-repo attachment PR is viewed with -R against its OWN repo", () => {
+  const viewed = [];
+  const runGh = (args) => {
+    if (args.includes("list")) return []; // ticket-repo search + head find nothing
+    if (args.includes("view")) {
+      viewed.push(args);
+      return { number: 808, state: "OPEN", isDraft: false, title: "cross-repo open PR" };
+    }
+    return [];
+  };
+  const r = defaultCheckOpenPrs("CTL-9", {
+    runGh,
+    deriveBranchName: () => null,
+    deriveAttachmentPrs: () => [{ owner: "org", repo: "other", number: 808 }],
+  });
+  expect(r.ok).toBe(false); // the open cross-repo PR is caught, not falsely clean
+  expect(r.prs.map((p) => p.number)).toEqual([808]);
+  // The view targeted the attachment's OWN repo, not the ticket repo cwd.
+  const viewCall = viewed.find((a) => a.includes("808"));
+  expect(viewCall).toBeTruthy();
+  const rIdx = viewCall.indexOf("-R");
+  expect(rIdx).toBeGreaterThan(-1);
+  expect(viewCall[rIdx + 1]).toBe("org/other");
+  // The resolving repo is annotated on the returned PR (composite-key disambiguation).
+  expect(r.prs[0].repo).toBe("org/other");
+});
+
+// CTL-1157 (GROUP-3 #1): a cross-repo attachment (#808 in org/other) is NOT deduped
+// against a same-numbered OPEN PR the ticket-repo passes already found — they are
+// DISTINCT PRs. Both are reported (keyed by repo#number vs bare number).
+test("ENUMERATOR (CTL-1157 GROUP-3 #1): a cross-repo attachment is not collapsed onto a same-numbered ticket-repo PR", () => {
+  const runGh = (args) => {
+    // The ticket-repo key-search already found #808 (a DIFFERENT PR that happens to
+    // share the number).
+    if (args.includes("list") && args.includes("--search"))
+      return [{ number: 808, state: "OPEN", isDraft: false, title: "ticket-repo #808" }];
+    if (args.includes("list")) return [];
+    // -R org/other resolves the cross-repo attachment (also #808, but distinct).
+    if (args.includes("view")) return { number: 808, state: "OPEN", isDraft: false, title: "org/other #808" };
+    return [];
+  };
+  const r = defaultCheckOpenPrs("CTL-9", {
+    runGh,
+    deriveBranchName: () => null,
+    deriveAttachmentPrs: () => [{ owner: "org", repo: "other", number: 808 }],
+  });
+  expect(r.ok).toBe(false);
+  // Both the ticket-repo #808 and the cross-repo org/other#808 are present — the
+  // composite key kept them distinct instead of hiding the orphaned open PR.
+  expect(r.prs.length).toBe(2);
+});
+
+// CTL-1157 (GROUP-3 #1): defaultDeriveAttachmentPrs preserves each attachment's OWN
+// (owner/repo, number) from a full GitHub PR URL, and yields {owner:null,repo:null}
+// for a bare numeric attachment.
+test("ENUMERATOR (CTL-1157 GROUP-3 #1): defaultDeriveAttachmentPrs parses owner/repo/number from the URL", () => {
+  const rec = {
+    attachments: {
+      nodes: [
+        { url: "https://github.com/org/other/pull/808" },
+        { sourceUrl: "https://github.com/coalesce-labs/catalyst/pull/42" },
+        1234, // bare number → ticket repo (owner/repo null)
+      ],
+    },
+  };
+  const out = defaultDeriveAttachmentPrs("CTL-9", { read: () => rec });
+  expect(out).toEqual([
+    { owner: "org", repo: "other", number: 808 },
+    { owner: "coalesce-labs", repo: "catalyst", number: 42 },
+    { owner: null, repo: null, number: 1234 },
+  ]);
+});
+
+// CTL-1157 (GROUP-3 #1): a bare-number attachment (no recorded repo URL) keeps the
+// legacy behavior — viewed in the ticket-repo cwd with NO -R.
+test("ENUMERATOR (CTL-1157 GROUP-3 #1): a bare-number attachment is viewed WITHOUT -R (ticket repo)", () => {
+  const viewed = [];
+  const runGh = (args) => {
+    if (args.includes("list")) return [];
+    if (args.includes("view")) {
+      viewed.push(args);
+      return { number: 808, state: "OPEN", isDraft: false };
+    }
+    return [];
+  };
+  const r = defaultCheckOpenPrs("CTL-9", {
+    runGh,
+    deriveBranchName: () => null,
+    deriveAttachmentPrs: () => [808],
+  });
+  expect(r.ok).toBe(false);
+  expect(r.prs.map((p) => p.number)).toEqual([808]);
+  const viewCall = viewed.find((a) => a.includes("808"));
+  expect(viewCall.includes("-R")).toBe(false);
 });
 
 test("ENUMERATOR: reports unverifiable (ok:false, reason) when `gh` list is unavailable", () => {
@@ -624,7 +726,7 @@ test("ENUMERATOR: reports unverifiable (ok:false, reason) when `gh` list is unav
   const r = defaultCheckOpenPrs("CTL-9", {
     cwd: tmpdir(),
     deriveBranchName: () => null,
-    deriveAttachmentPrNumbers: () => [],
+    deriveAttachmentPrs: () => [],
   });
   expect(r.ok).toBe(false);
   expect(r.reason).toBeTruthy();
@@ -644,7 +746,7 @@ test("ENUMERATOR (CTL-1157): an attachment `gh pr view` FAILURE → UNVERIFIABLE
   const r = defaultCheckOpenPrs("CTL-9", {
     runGh,
     deriveBranchName: () => null,
-    deriveAttachmentPrNumbers: () => [808], // Linear says #808 is attached
+    deriveAttachmentPrs: () => [808], // Linear says #808 is attached
   });
   expect(r.ok).toBe(false);
   expect(r.unverifiable).toBe(true);
@@ -659,7 +761,7 @@ test("ENUMERATOR (CTL-1157): an UNDERIVABLE repo is UNVERIFIABLE (never runs gh 
   const r = defaultCheckOpenPrs("CTL-9", {
     deriveRepoRoot: () => null, // registry has no entry for this ticket's team
     deriveBranchName: () => null,
-    deriveAttachmentPrNumbers: () => [],
+    deriveAttachmentPrs: () => [],
   });
   expect(r.ok).toBe(false);
   expect(r.unverifiable).toBe(true);

--- a/plugins/dev/scripts/execution-core/linear-reconcile-cli.test.mjs
+++ b/plugins/dev/scripts/execution-core/linear-reconcile-cli.test.mjs
@@ -358,6 +358,25 @@ test("DECLARE done-applied: the agent's own Done carries its PR-2 tallies (by=re
   });
 });
 
+test("DECLARE done-applied: a pipeline record-only marker (--by pipeline --no-write) emits NO would-done shadow event", async () => {
+  // CTL-1157 GROUP B: phase-teardown records durable completion with
+  // `declare --state done --by pipeline --no-write` AFTER it has ALREADY performed
+  // the real Linear Done (via linear-transition.sh). That --no-write is a
+  // record-only marker, NOT a shadow — emitting recovery.would-done-applied here
+  // would pollute shadow telemetry and undercount real Done moves.
+  const dir = mkdtempSync(join(tmpdir(), "decl-"));
+  const moves = [];
+  const { code } = await runCli(
+    [
+      "declare", "CTL-9", "--by", "pipeline", "--state", "done", "--no-write",
+      "--decls-dir", dir,
+    ],
+    { emitDoneApplied: (f) => moves.push(f), checkOpenPrs: PASS }
+  );
+  expect(code).toBe(0);
+  expect(moves).toEqual([]); // record-only marker → no shadow would-done event
+});
+
 test("DECLARE done-applied: --no-emit suppresses the move event", async () => {
   const dir = mkdtempSync(join(tmpdir(), "decl-"));
   const moves = [];

--- a/plugins/dev/scripts/execution-core/linear-reconcile-cli.test.mjs
+++ b/plugins/dev/scripts/execution-core/linear-reconcile-cli.test.mjs
@@ -372,7 +372,7 @@ test("DECLARE done-applied: a pipeline record-only marker (--by pipeline --no-wr
   const { code } = await runCli(
     [
       "declare", "CTL-9", "--by", "pipeline", "--state", "done", "--no-write",
-      "--decls-dir", dir,
+      "--transition-verified", "--decls-dir", dir,
     ],
     { emitDoneApplied: (f) => moves.push(f), checkOpenPrs: PASS }
   );
@@ -389,6 +389,36 @@ test("DECLARE done-applied: a pipeline record-only marker (--by pipeline --no-wr
   });
 });
 
+test("DECLARE done-applied: a pipeline marker WITHOUT --transition-verified (failed/missing real Done) emits a SHADOW would-event, never an enforce Done-move or alarm", async () => {
+  // CTL-1157 F #3 (Codex round-4): phase-teardown drops the `--by pipeline --no-write`
+  // marker EVEN when linear-transition.sh failed or was missing (SKILL.md runs it with
+  // `|| true`). Without --transition-verified we must NOT report an applied Done that
+  // never landed — no enforce done-applied, no open-PR alarm. It degrades to the shadow
+  // would-event so the reconcile drain / terminalDoneOnce backstop lands the real Done.
+  const dir = mkdtempSync(join(tmpdir(), "decl-"));
+  const moves = [];
+  const alarms = [];
+  const openPrCalls = [];
+  const { code } = await runCli(
+    [
+      "declare", "CTL-9", "--by", "pipeline", "--state", "done", "--no-write",
+      "--decls-dir", dir,
+    ],
+    {
+      emitDoneApplied: (f) => moves.push(f),
+      emitDoneWithOpenPr: (ev) => alarms.push(ev),
+      checkOpenPrs: (...a) => { openPrCalls.push(a); return PASS(...a); },
+    }
+  );
+  expect(code).toBe(0);
+  // still observable — but as a SHADOW would-event, not an enforce Done-move.
+  expect(moves).toHaveLength(1);
+  expect(moves[0]).toMatchObject({ ticket: "CTL-9", recoveryMode: "shadow" });
+  // no open-PR enumeration + NO alarm on the unverified path (it never claims a Done).
+  expect(alarms).toEqual([]);
+  expect(openPrCalls).toEqual([]);
+});
+
 test("DECLARE (GROUP 1): a pipeline record-only Done WITH an open PR is observable + alarmed — not silent", async () => {
   // The Problem-A regression: real teardown Done (external) → pipeline record-only
   // marker → later terminal-sweep sees already-Done → skipped. WITHOUT this fix the
@@ -400,7 +430,7 @@ test("DECLARE (GROUP 1): a pipeline record-only Done WITH an open PR is observab
   const { code } = await runCli(
     [
       "declare", "CTL-9", "--by", "pipeline", "--state", "done", "--no-write",
-      "--decls-dir", dir,
+      "--transition-verified", "--decls-dir", dir,
     ],
     {
       emitDoneApplied: (f) => moves.push(f),
@@ -425,7 +455,7 @@ test("DECLARE (GROUP 1): a pipeline record-only Done with an UNVERIFIABLE open-P
   const { code } = await runCli(
     [
       "declare", "CTL-9", "--by", "pipeline", "--state", "done", "--no-write",
-      "--decls-dir", dir,
+      "--transition-verified", "--decls-dir", dir,
     ],
     {
       emitDoneApplied: (f) => moves.push(f),
@@ -447,7 +477,7 @@ test("DECLARE (GROUP 1): a CLEAN pipeline record-only Done emits done-applied bu
   const { code } = await runCli(
     [
       "declare", "CTL-9", "--by", "pipeline", "--state", "done", "--no-write",
-      "--decls-dir", dir,
+      "--transition-verified", "--decls-dir", dir,
     ],
     {
       emitDoneApplied: (f) => moves.push(f),

--- a/plugins/dev/scripts/execution-core/open-pr-gate.mjs
+++ b/plugins/dev/scripts/execution-core/open-pr-gate.mjs
@@ -20,15 +20,23 @@
 // the local Catalyst-Cloud REPLICA/cache via `catalyst-linear read`
 // (source:replica) — NEVER bare `linearis` (rate-limited; stalls the fleet).
 //
-// Returns { ok:true,  prs:[] }            when no unmerged PR remains
-//         { ok:false, prs:[…] }           when ≥1 open PR exists
-//         { ok:false, reason, prs:[] }     when the GitHub check itself could not run.
-// `ok` is now ADVISORY ("are there zero open PRs?"), retained for back-compat with
+// Returns { ok:true,  prs:[] }                          when no unmerged PR remains
+//         { ok:false, prs:[…] }                         when ≥1 open PR exists
+//         { ok:false, unverifiable:true, reason, prs }  when the authoritative GitHub
+//           check could NOT be completed — a `gh` list/view failure, OR the ticket's
+//           repo could not be derived (so we refuse to run gh in the wrong repo).
+//           UNVERIFIABLE ≠ CLEAN: an unverifiable authoritative check is never a clean
+//           list. Callers/backstops MUST treat it as "could not confirm zero open PRs"
+//           — surface it / fire the alarm — and never assume an empty list. (`prs` may
+//           carry the PRs discovered before the failure; the load-bearing field is
+//           `unverifiable`.)
+// `ok` is ADVISORY ("are there zero open PRs?"), retained for back-compat with
 // callers/tests; it no longer implies any refusal.
 import { spawnSync } from "node:child_process";
 import { existsSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
+import { getProjectConfig } from "./registry.mjs";
 
 // readTicketReplica — read a ticket's record from the local REPLICA/cache via
 // `catalyst-linear read <TICKET>` (replica-first; the CLI itself degrades to its
@@ -46,6 +54,33 @@ export function readTicketReplica(ticket, { cwd } = {}) {
     });
     if (r.status !== 0 || !r.stdout) return null;
     return JSON.parse(r.stdout);
+  } catch {
+    return null;
+  }
+}
+
+// teamOf — "CTL-123" → "CTL". The registry key that resolves a ticket to its
+// project repo. Null for anything not <prefix>-<n>. (Inlined here rather than
+// imported from dispatch.mjs to keep this enumerator off the daemon-heavy
+// dispatch import graph — it must stay loadable from the plain-node reconcile CLI.)
+const TEAM_RE = /^([A-Za-z][A-Za-z0-9_]*)-[0-9]+$/;
+function teamOf(ticket) {
+  const m = TEAM_RE.exec(ticket ?? "");
+  return m ? m[1] : null;
+}
+
+// defaultDeriveRepoRoot — resolve a ticket's project repoRoot from the
+// execution-core REGISTRY (the `.catalyst` project config: team → repoRoot),
+// NEVER bare linearis (rate-limited; stalls the fleet) and never the Linear API.
+// The gh enumeration runs in THIS cwd so a multi-repo / per-project install
+// queries the ticket's OWN repository — not the daemon's process cwd, which would
+// report zero open PRs for tickets whose PRs live in a different repo. Best-effort:
+// null on a malformed ticket, a missing registry entry, or any read failure.
+export function defaultDeriveRepoRoot(ticket) {
+  try {
+    const team = teamOf(ticket);
+    if (!team) return null;
+    return getProjectConfig(team)?.repoRoot ?? null;
   } catch {
     return null;
   }
@@ -139,17 +174,37 @@ export function defaultCheckOpenPrs(
     cwd,
     deriveBranchName = defaultDeriveBranchName,
     deriveAttachmentPrNumbers = defaultDeriveAttachmentPrNumbers,
+    deriveRepoRoot = defaultDeriveRepoRoot,
     runGh,
   } = {}
 ) {
-  const gh = runGh || ((args) => defaultRunGh(args, cwd));
+  // Resolve the cwd the REAL gh calls run in so the enumeration queries the
+  // TICKET's repository, not the daemon's process cwd (multi-repo / per-project
+  // correctness — CTL-1157). An explicit `cwd` wins; otherwise derive the repoRoot
+  // from the registry (the `.catalyst` project config, NEVER bare linearis). When
+  // we must spawn real gh (no `runGh` seam injected) and cannot pin a repo, the
+  // check is UNVERIFIABLE — running in the wrong repo would falsely report zero
+  // open PRs and let a backstop mark Done with no alarm. (When `runGh` is injected,
+  // the test controls gh entirely and the repo cwd is moot.)
+  let repoCwd = cwd;
+  if (!runGh && !repoCwd) {
+    try {
+      repoCwd = deriveRepoRoot(ticket) || null;
+    } catch {
+      repoCwd = null;
+    }
+    if (!repoCwd) {
+      return { ok: false, unverifiable: true, reason: "repo-underivable", prs: [] };
+    }
+  }
+  const gh = runGh || ((args) => defaultRunGh(args, repoCwd));
   const fields = "number,state,isDraft,title";
   // Resolve a branchName for the head pass — derive from the replica/cache when not
   // supplied (NEVER bare linearis). Derivation failure ⇒ head pass skipped.
   let head = branchName;
   if (!head) {
     try {
-      head = deriveBranchName(ticket, { cwd });
+      head = deriveBranchName(ticket, { cwd: repoCwd });
     } catch {
       head = null;
     }
@@ -184,13 +239,12 @@ export function defaultCheckOpenPrs(
       ]))
         if (p && p.number != null) seen.set(p.number, p);
     }
-    // Pass 3: Linear-attachment PRs (best-effort). Confirm OPEN state via gh so a
-    // merged/closed attachment never falsely counts. A view failure for one PR is
-    // swallowed (that single PR is just not added) — it must not turn the whole
-    // enumeration unverifiable.
+    // Pass 3: Linear-attachment PRs. Confirm OPEN state via gh so a merged/closed
+    // attachment never falsely counts. Deriving the attachment numbers is
+    // best-effort (a derivation failure just means we have no attachment hints).
     let attachmentNums = [];
     try {
-      attachmentNums = deriveAttachmentPrNumbers(ticket, { cwd }) || [];
+      attachmentNums = deriveAttachmentPrNumbers(ticket, { cwd: repoCwd }) || [];
     } catch {
       attachmentNums = [];
     }
@@ -199,8 +253,20 @@ export function defaultCheckOpenPrs(
       let view;
       try {
         view = gh(["pr", "view", String(n), "--json", fields]);
-      } catch {
-        continue; // undiscoverable state for this one attachment — skip, don't fail
+      } catch (err) {
+        // CTL-1157: an attachment-linked PR we KNOW exists (Linear recorded it) but
+        // cannot view — a transient GitHub/auth/rate-limit failure — makes the whole
+        // enumeration UNVERIFIABLE. We cannot confirm this PR is merged/closed, so
+        // the list is NOT a clean "zero open PRs". Swallowing the error and returning
+        // {ok:true,prs:[]} here would let a backstop mark Done with NO alarm on an
+        // unverified check. Surface it instead — never silently drop the PR.
+        return {
+          ok: false,
+          unverifiable: true,
+          reason: `attachment PR #${n} view failed: ${err?.message || String(err)}`,
+          prs: [...seen.values()],
+          branchName: head ?? null,
+        };
       }
       // `gh pr view --json` returns a single object (not an array).
       const pr = Array.isArray(view) ? view[0] : view;
@@ -209,7 +275,9 @@ export function defaultCheckOpenPrs(
       }
     }
   } catch (err) {
-    return { ok: false, reason: err?.message || String(err), prs: [] };
+    // An authoritative gh list/view pass failed — the enumeration is UNVERIFIABLE,
+    // never a clean list. Keep this CONSISTENT with the attachment-view path above.
+    return { ok: false, unverifiable: true, reason: err?.message || String(err), prs: [] };
   }
   const prs = [...seen.values()];
   return { ok: prs.length === 0, prs, branchName: head ?? null };

--- a/plugins/dev/scripts/execution-core/open-pr-gate.mjs
+++ b/plugins/dev/scripts/execution-core/open-pr-gate.mjs
@@ -96,23 +96,30 @@ export function defaultDeriveBranchName(ticket, { cwd, read = readTicketReplica 
   }
 }
 
-// PR_URL_RE — pull a GitHub PR number out of a `.../pull/<n>` URL.
-const PR_URL_RE = /github\.com\/[^/\s]+\/[^/\s]+\/pull\/(\d+)/i;
+// PR_URL_RE — pull the (owner, repo, number) out of a `github.com/<owner>/<repo>/pull/<n>`
+// URL. CTL-1157 (GROUP-3 #1): the owner/repo are load-bearing — an attached PR lives
+// in the repo NAMED BY ITS URL, which in a multi-repo install is NOT necessarily the
+// ticket's project repo. Capturing them lets the attachment pass `gh pr view -R
+// <owner/repo>` against the PR's OWN repo instead of the ticket repo (where the same
+// number could be a different PR, or absent → a false clean).
+const PR_URL_RE = /github\.com\/([^/\s]+)\/([^/\s]+)\/pull\/(\d+)/i;
 
-// defaultDeriveAttachmentPrNumbers — CTL-1157 (Path 2 / slice 4): enumerate the
-// ticket's PRs from LINEAR'S OWN attachments / linked-PR records via the replica.
-// This is the third discovery source, UNIONed with the gh ticket-key search and
-// the branch-head pass — it catches a PR that has NO ticket key in its title/body
-// AND a non-standard head branch, but that IS attached to the Linear issue (the
-// common GitHub<>Linear auto-link). Best-effort: returns a number[] of PR numbers
-// parsed from any attachment whose url/href/subtitle points at a `/pull/<n>`.
+// defaultDeriveAttachmentPrs — CTL-1157 (Path 2 / slice 4 + GROUP-3 #1): enumerate
+// the ticket's PRs from LINEAR'S OWN attachments / linked-PR records via the replica,
+// preserving each PR's OWN GitHub repo. This is the third discovery source, UNIONed
+// with the gh ticket-key search and the branch-head pass — it catches a PR that has
+// NO ticket key in its title/body AND a non-standard head branch, but that IS attached
+// to the Linear issue (the common GitHub<>Linear auto-link). Best-effort: returns
+// `{owner, repo, number}[]` — `owner`/`repo` are non-null when parsed from a full
+// `/<owner>/<repo>/pull/<n>` URL, and null for a bare numeric attachment (no recorded
+// cross-repo linkage → treated as the ticket's own repo by the caller).
 //
 // KNOWN RESIDUAL (documented, not a logic bug): a PR with ZERO discoverable
 // linkage — no ticket key in its text, a non-standard head branch, AND no Linear
 // attachment — is genuinely undiscoverable from data. All three of our sources key
 // off SOME recorded linkage; an orphan PR records none. That is an
 // input-completeness limit, not a gap in this enumerator.
-export function defaultDeriveAttachmentPrNumbers(ticket, { cwd, read = readTicketReplica } = {}) {
+export function defaultDeriveAttachmentPrs(ticket, { cwd, read = readTicketReplica } = {}) {
   try {
     const rec = read(ticket, { cwd });
     if (!rec) return [];
@@ -122,24 +129,41 @@ export function defaultDeriveAttachmentPrNumbers(ticket, { cwd, read = readTicke
       .concat(rec.attachments?.nodes ?? rec.attachments ?? [])
       .concat(rec.pullRequests?.nodes ?? rec.pullRequests ?? [])
       .concat(rec.prLinks ?? []);
-    const nums = new Set();
+    const out = [];
+    const seen = new Set();
+    const push = (owner, repo, number) => {
+      if (!Number.isFinite(number)) return;
+      // A cross-repo attachment is a DISTINCT PR from a same-numbered ticket-repo PR,
+      // so key dedup by owner/repo#number when the repo is known; bare numbers by #n.
+      const key = owner && repo ? `${owner}/${repo}#${number}` : `#${number}`;
+      if (seen.has(key)) return;
+      seen.add(key);
+      out.push({ owner: owner ?? null, repo: repo ?? null, number });
+    };
     for (const a of atts) {
       if (a == null) continue;
-      // A plain number / numeric string is taken as a PR number directly.
+      // A plain number / numeric string is taken as a PR number in the ticket's repo.
       if (typeof a === "number" && Number.isFinite(a)) {
-        nums.add(a);
+        push(null, null, a);
         continue;
       }
       const hay = [a.url, a.href, a.sourceUrl, a.subtitle, a.title, typeof a === "string" ? a : null]
         .filter(Boolean)
         .join(" ");
       const m = PR_URL_RE.exec(hay);
-      if (m) nums.add(Number(m[1]));
+      if (m) push(m[1], m[2], Number(m[3]));
     }
-    return [...nums];
+    return out;
   } catch {
     return [];
   }
+}
+
+// defaultDeriveAttachmentPrNumbers — back-compat: the bare PR numbers (repo dropped).
+// Retained for any caller/test that only needs the numbers; the enumerator itself
+// uses defaultDeriveAttachmentPrs so it can target each PR's own repo.
+export function defaultDeriveAttachmentPrNumbers(ticket, opts) {
+  return defaultDeriveAttachmentPrs(ticket, opts).map((p) => p.number);
 }
 
 function defaultRunGh(ghArgs, cwd) {
@@ -162,18 +186,20 @@ function defaultRunGh(ghArgs, cwd) {
 //   2. branch-head pass    — `gh pr list --head <branchName> --state open` (branch
 //      derived from the replica when not supplied — catches a PR whose text omits
 //      the key).
-//   3. attachment pass     — for each PR number from Linear's attachments (replica)
-//      not already seen, `gh pr view <n>` and include it iff still OPEN (catches a
-//      PR with neither the key nor a matching branch, but linked in Linear).
+//   3. attachment pass     — for each PR from Linear's attachments (replica) not
+//      already seen, `gh pr view <n> -R <owner/repo>` against the ATTACHMENT'S OWN
+//      repo (CTL-1157 GROUP-3 #1) and include it iff still OPEN (catches a PR with
+//      neither the key nor a matching branch, but linked in Linear — possibly in a
+//      DIFFERENT repo than the ticket's project repo).
 // `--state open` ⇒ every returned PR is unmerged-and-open. `runGh` /
-// `deriveBranchName` / `deriveAttachmentPrNumbers` are injectable seams for tests.
+// `deriveBranchName` / `deriveAttachmentPrs` are injectable seams for tests.
 export function defaultCheckOpenPrs(
   ticket,
   {
     branchName,
     cwd,
     deriveBranchName = defaultDeriveBranchName,
-    deriveAttachmentPrNumbers = defaultDeriveAttachmentPrNumbers,
+    deriveAttachmentPrs = defaultDeriveAttachmentPrs,
     deriveRepoRoot = defaultDeriveRepoRoot,
     runGh,
   } = {}
@@ -240,30 +266,50 @@ export function defaultCheckOpenPrs(
         if (p && p.number != null) seen.set(p.number, p);
     }
     // Pass 3: Linear-attachment PRs. Confirm OPEN state via gh so a merged/closed
-    // attachment never falsely counts. Deriving the attachment numbers is
-    // best-effort (a derivation failure just means we have no attachment hints).
-    let attachmentNums = [];
+    // attachment never falsely counts. Deriving the attachments is best-effort (a
+    // derivation failure just means we have no attachment hints).
+    let attachmentPrs = [];
     try {
-      attachmentNums = deriveAttachmentPrNumbers(ticket, { cwd: repoCwd }) || [];
+      attachmentPrs = deriveAttachmentPrs(ticket, { cwd: repoCwd }) || [];
     } catch {
-      attachmentNums = [];
+      attachmentPrs = [];
     }
-    for (const n of attachmentNums) {
-      if (seen.has(n)) continue;
+    for (const item of attachmentPrs) {
+      // Normalize both shapes: an object carries the attachment's OWN (owner/repo,
+      // number) parsed from the GitHub URL; a bare number means "PR <n> in the
+      // ticket's own repo" (no cross-repo linkage recorded).
+      const isObj = typeof item === "object" && item !== null;
+      const n = isObj ? Number(item.number) : Number(item);
+      if (!Number.isFinite(n)) continue;
+      const owner = isObj ? item.owner ?? null : null;
+      const repo = isObj ? item.repo ?? null : null;
+      const repoSlug = owner && repo ? `${owner}/${repo}` : null;
+      // Dedup key: a cross-repo attachment is a DIFFERENT PR than a same-numbered PR
+      // caught by the ticket-repo list/head passes (keyed by bare number), so key it
+      // by owner/repo#number; a bare-number attachment shares the numeric key.
+      const key = repoSlug ? `${repoSlug}#${n}` : n;
+      if (seen.has(key)) continue;
+      // Target the attachment's OWN repo (-R owner/repo) so a multi-repo / #-collision
+      // does NOT check <n> in the ticket repo and falsely report it closed/absent (a
+      // false clean). A bare number stays in the ticket-repo cwd (its recorded repo).
+      const viewArgs = ["pr", "view", String(n), "--json", fields];
+      if (repoSlug) viewArgs.push("-R", repoSlug);
       let view;
       try {
-        view = gh(["pr", "view", String(n), "--json", fields]);
+        view = gh(viewArgs);
       } catch (err) {
         // CTL-1157: an attachment-linked PR we KNOW exists (Linear recorded it) but
-        // cannot view — a transient GitHub/auth/rate-limit failure — makes the whole
-        // enumeration UNVERIFIABLE. We cannot confirm this PR is merged/closed, so
-        // the list is NOT a clean "zero open PRs". Swallowing the error and returning
-        // {ok:true,prs:[]} here would let a backstop mark Done with NO alarm on an
-        // unverified check. Surface it instead — never silently drop the PR.
+        // cannot view — a transient GitHub/auth/rate-limit failure, OR a repo we are
+        // not authorized against — makes the whole enumeration UNVERIFIABLE. We cannot
+        // confirm this PR is merged/closed, so the list is NOT a clean "zero open PRs".
+        // Swallowing the error and returning {ok:true,prs:[]} here would let a backstop
+        // mark Done with NO alarm on an unverified check. Surface it instead — never
+        // silently drop the PR (nor collapse it to the ticket repo).
+        const label = repoSlug ? `${repoSlug}#${n}` : `#${n}`;
         return {
           ok: false,
           unverifiable: true,
-          reason: `attachment PR #${n} view failed: ${err?.message || String(err)}`,
+          reason: `attachment PR ${label} view failed: ${err?.message || String(err)}`,
           prs: [...seen.values()],
           branchName: head ?? null,
         };
@@ -271,7 +317,10 @@ export function defaultCheckOpenPrs(
       // `gh pr view --json` returns a single object (not an array).
       const pr = Array.isArray(view) ? view[0] : view;
       if (pr && pr.number != null && String(pr.state).toUpperCase() === "OPEN") {
-        seen.set(pr.number, pr);
+        // Annotate the resolving repo so a caller keying by (repo,number) can
+        // disambiguate a cross-repo open PR (scheduler composite key, CTL-1157).
+        if (repoSlug && pr.repo == null) pr.repo = repoSlug;
+        seen.set(key, pr);
       }
     }
   } catch (err) {

--- a/plugins/dev/scripts/execution-core/open-pr-gate.mjs
+++ b/plugins/dev/scripts/execution-core/open-pr-gate.mjs
@@ -1,0 +1,120 @@
+// open-pr-gate.mjs — CTL-1157 deterministic open-PR Done gate (single source of truth).
+//
+// "Does this ticket still have an open/unmerged PR?" — the one check that EVERY
+// code path which writes Linear `Done` must run, so a ticket can never be marked
+// Done while a PR is still open (the owner's #1 rule; the false-positive that got
+// the GitHub-PR→Done automation removed: one merged PR + one still-open PR on a
+// NON-standard branch → falsely Done). Shared by the completion-declaration CLI
+// (linear-reconcile-cli.mjs `declare`) AND the execution-core terminal sweep
+// (scheduler.mjs `terminalDoneOnce`) so both run the IDENTICAL gate.
+//
+// Authoritative source is GitHub (`gh`), NEVER the local cache — a cache lag must
+// never green-light a Done. The ticket's branchName (the secondary "non-standard
+// branch" net) is read from the local Catalyst-Cloud REPLICA/cache via
+// `catalyst-linear read` (source:replica) — NEVER bare `linearis` (rate-limited;
+// stalls the fleet). FAIL-CLOSED: an unverifiable PR set (gh missing/auth/network)
+// refuses the write.
+//
+// Returns { ok:true,  prs:[] }            when no unmerged PR remains (Done allowed)
+//         { ok:false, prs:[…] }           when ≥1 open PR exists      (Done refused)
+//         { ok:false, reason, prs:[] }     when the check itself could not run.
+import { spawnSync } from "node:child_process";
+import { existsSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+// defaultDeriveBranchName — resolve a ticket's Linear branchName from the local
+// REPLICA/cache via `catalyst-linear read <TICKET>` (replica-first; the CLI itself
+// degrades to its own linearis fallback only internally — this module NEVER shells
+// `linearis` directly). Best-effort: any failure returns null and the branch-head
+// pass is simply skipped (the ticket-key search pass still runs).
+export function defaultDeriveBranchName(ticket, { cwd } = {}) {
+  try {
+    const here = dirname(fileURLToPath(import.meta.url));
+    const sibling = join(here, "..", "catalyst-linear");
+    const bin = existsSync(sibling) ? sibling : "catalyst-linear";
+    const r = spawnSync(bin, ["read", ticket], {
+      encoding: "utf8",
+      cwd: cwd || process.cwd(),
+    });
+    if (r.status !== 0 || !r.stdout) return null;
+    return JSON.parse(r.stdout)?.branchName ?? null;
+  } catch {
+    return null;
+  }
+}
+
+function defaultRunGh(ghArgs, cwd) {
+  const r = spawnSync("gh", ghArgs, { encoding: "utf8", cwd: cwd || process.cwd() });
+  if (r.error || r.status !== 0) {
+    const detail = (r.stderr || r.error?.message || `exit ${r.status}`).toString().trim();
+    throw new Error(`\`gh ${ghArgs.join(" ")}\` failed: ${detail}`);
+  }
+  try {
+    return JSON.parse(r.stdout || "[]");
+  } catch {
+    throw new Error(`\`gh ${ghArgs.join(" ")}\` returned unparseable JSON`);
+  }
+}
+
+// defaultCheckOpenPrs — the gate. Combines two `gh pr list --state open` passes and
+// UNIONs them so an open PR is caught by EITHER its ticket-key mention OR its head
+// branch:
+//   1. ticket-key search  — `gh pr list --search <TICKET> --state open`
+//   2. branch-head pass    — `gh pr list --head <branchName> --state open`  (ALWAYS,
+//      with branchName derived from the replica/cache when the caller didn't pass
+//      one — catches a PR whose title/body omits the ticket key).
+// `--state open` ⇒ every returned PR is unmerged-and-open. `runGh`/`deriveBranchName`
+// are injectable seams for tests.
+export function defaultCheckOpenPrs(
+  ticket,
+  { branchName, cwd, deriveBranchName = defaultDeriveBranchName, runGh } = {}
+) {
+  const gh = runGh || ((args) => defaultRunGh(args, cwd));
+  const fields = "number,state,isDraft,title";
+  // Always resolve a branchName for the head pass — derive from the replica/cache
+  // when not supplied (NEVER bare linearis). Derivation failure ⇒ head pass skipped.
+  let head = branchName;
+  if (!head) {
+    try {
+      head = deriveBranchName(ticket, { cwd });
+    } catch {
+      head = null;
+    }
+  }
+  const seen = new Map();
+  try {
+    for (const p of gh([
+      "pr",
+      "list",
+      "--search",
+      ticket,
+      "--state",
+      "open",
+      "--json",
+      fields,
+      "--limit",
+      "100",
+    ]))
+      if (p && p.number != null) seen.set(p.number, p);
+    if (head) {
+      for (const p of gh([
+        "pr",
+        "list",
+        "--head",
+        head,
+        "--state",
+        "open",
+        "--json",
+        fields,
+        "--limit",
+        "100",
+      ]))
+        if (p && p.number != null) seen.set(p.number, p);
+    }
+  } catch (err) {
+    return { ok: false, reason: err?.message || String(err), prs: [] };
+  }
+  const prs = [...seen.values()];
+  return { ok: prs.length === 0, prs, branchName: head ?? null };
+}

--- a/plugins/dev/scripts/execution-core/open-pr-gate.mjs
+++ b/plugins/dev/scripts/execution-core/open-pr-gate.mjs
@@ -163,6 +163,18 @@ export function defaultDeriveAttachmentPrs(ticket, { cwd, read = readTicketRepli
         push(null, null, a);
         continue;
       }
+      // CTL-1157 F #3 (Codex round-5): a BARE numeric string ("42" / "#42") is the
+      // "numeric string" case the comment promises — the replica can expose a linked PR
+      // as a bare number. Without this it fell through to the URL regex (no match) and
+      // was silently dropped, so a Linear-attached PR with no ticket-key mention and a
+      // non-standard branch escaped the enumeration → a false-clean open-PR check.
+      if (typeof a === "string") {
+        const bare = a.trim().match(/^#?(\d+)$/);
+        if (bare) {
+          push(null, null, Number(bare[1]));
+          continue;
+        }
+      }
       const hay = [a.url, a.href, a.sourceUrl, a.subtitle, a.title, typeof a === "string" ? a : null]
         .filter(Boolean)
         .join(" ");

--- a/plugins/dev/scripts/execution-core/open-pr-gate.mjs
+++ b/plugins/dev/scripts/execution-core/open-pr-gate.mjs
@@ -38,6 +38,20 @@ import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { getProjectConfig } from "./registry.mjs";
 
+// CTL-1157 F #7 (Codex round-4): a finite cap on every enumeration subprocess. In
+// production `defaultCheckOpenPrs` runs on the SYNCHRONOUS terminal sweep before the
+// Done-write/alarm path, so a `gh` (or `catalyst-linear`) invocation hung on network,
+// auth, or keychain state would block the whole scheduler tick indefinitely — this
+// enumeration is best-effort observability and must never wedge the tick. A timeout
+// fire makes spawnSync set r.error (ETIMEDOUT) + r.status=null: the gh path throws →
+// defaultCheckOpenPrs collapses it to {unverifiable:true} (never a false clean list);
+// the replica read is best-effort → null. Env-overridable; "0" disables the cap.
+const ENUM_SUBPROCESS_TIMEOUT_MS = (() => {
+  const raw = Number(process.env.CATALYST_OPEN_PR_GATE_TIMEOUT_MS);
+  if (Number.isFinite(raw) && raw >= 0) return raw; // 0 → disabled (no timeout)
+  return 15_000;
+})();
+
 // readTicketReplica — read a ticket's record from the local REPLICA/cache via
 // `catalyst-linear read <TICKET>` (replica-first; the CLI itself degrades to its
 // own linearis fallback only internally — this module NEVER shells `linearis`
@@ -51,7 +65,9 @@ export function readTicketReplica(ticket, { cwd } = {}) {
     const r = spawnSync(bin, ["read", ticket], {
       encoding: "utf8",
       cwd: cwd || process.cwd(),
+      timeout: ENUM_SUBPROCESS_TIMEOUT_MS, // CTL-1157 F #7: same synchronous-tick wedge risk
     });
+    // best-effort: a timeout sets r.status=null → falls into the null return below.
     if (r.status !== 0 || !r.stdout) return null;
     return JSON.parse(r.stdout);
   } catch {
@@ -167,9 +183,18 @@ export function defaultDeriveAttachmentPrNumbers(ticket, opts) {
 }
 
 function defaultRunGh(ghArgs, cwd) {
-  const r = spawnSync("gh", ghArgs, { encoding: "utf8", cwd: cwd || process.cwd() });
+  const r = spawnSync("gh", ghArgs, {
+    encoding: "utf8",
+    cwd: cwd || process.cwd(),
+    timeout: ENUM_SUBPROCESS_TIMEOUT_MS, // CTL-1157 F #7: bound the tick (0 → no cap)
+  });
   if (r.error || r.status !== 0) {
-    const detail = (r.stderr || r.error?.message || `exit ${r.status}`).toString().trim();
+    // A timeout fire sets r.error.code === "ETIMEDOUT" (r.status null); surface it
+    // explicitly so the unverifiable reason is diagnosable rather than a bare "exit null".
+    const timedOut = r.error?.code === "ETIMEDOUT";
+    const detail = timedOut
+      ? `timed out after ${ENUM_SUBPROCESS_TIMEOUT_MS}ms`
+      : (r.stderr || r.error?.message || `exit ${r.status}`).toString().trim();
     throw new Error(`\`gh ${ghArgs.join(" ")}\` failed: ${detail}`);
   }
   try {

--- a/plugins/dev/scripts/execution-core/open-pr-gate.mjs
+++ b/plugins/dev/scripts/execution-core/open-pr-gate.mjs
@@ -36,7 +36,7 @@ import { spawnSync } from "node:child_process";
 import { existsSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
-import { getProjectConfig } from "./registry.mjs";
+import { getProjectConfig, ownerRepoFromRepoRoot } from "./registry.mjs";
 
 // CTL-1157 F #7 (Codex round-4): a finite cap on every enumeration subprocess. In
 // production `defaultCheckOpenPrs` runs on the SYNCHRONOUS terminal sweep before the
@@ -47,8 +47,17 @@ import { getProjectConfig } from "./registry.mjs";
 // defaultCheckOpenPrs collapses it to {unverifiable:true} (never a false clean list);
 // the replica read is best-effort → null. Env-overridable; "0" disables the cap.
 const ENUM_SUBPROCESS_TIMEOUT_MS = (() => {
-  const raw = Number(process.env.CATALYST_OPEN_PR_GATE_TIMEOUT_MS);
-  if (Number.isFinite(raw) && raw >= 0) return raw; // 0 → disabled (no timeout)
+  // CTL-1157 (Codex round-6): guard the EMPTY/whitespace case. Number("") and
+  // Number("  ") are 0 (NOT NaN), which would pass the isFinite && >=0 test and
+  // silently DISABLE the cap (spawnSync timeout:0 = no limit) — reintroducing the
+  // scheduler-tick wedge this cap exists to prevent. A set-but-empty env var
+  // (CATALYST_OPEN_PR_GATE_TIMEOUT_MS= in an env file) is the plausible misconfig.
+  // Treat a blank value as UNSET → the 15s default; only an explicit non-blank numeric
+  // literal (including "0" to intentionally disable) is honored.
+  const rawStr = process.env.CATALYST_OPEN_PR_GATE_TIMEOUT_MS;
+  if (rawStr == null || String(rawStr).trim() === "") return 15_000;
+  const raw = Number(rawStr);
+  if (Number.isFinite(raw) && raw >= 0) return raw; // explicit 0 → disabled (no timeout)
   return 15_000;
 })();
 
@@ -311,6 +320,17 @@ export function defaultCheckOpenPrs(
     } catch {
       attachmentPrs = [];
     }
+    // CTL-1157 (Codex round-6): the ticket's OWN GitHub "owner/repo", so a same-repo
+    // attachment URL dedups against the bare-number key the ticket-key/head list passes
+    // used (they ran in the ticket repo and key by p.number). Null when underivable
+    // (explicit cwd / non-registry path) → the sameRepo test is false → the old
+    // owner/repo#n keying stands (over-report, never under-report). NEVER bare linearis.
+    let ticketRepoSlug = null;
+    try {
+      ticketRepoSlug = ownerRepoFromRepoRoot(repoCwd) || null;
+    } catch {
+      ticketRepoSlug = null;
+    }
     for (const item of attachmentPrs) {
       // Normalize both shapes: an object carries the attachment's OWN (owner/repo,
       // number) parsed from the GitHub URL; a bare number means "PR <n> in the
@@ -321,10 +341,14 @@ export function defaultCheckOpenPrs(
       const owner = isObj ? item.owner ?? null : null;
       const repo = isObj ? item.repo ?? null : null;
       const repoSlug = owner && repo ? `${owner}/${repo}` : null;
-      // Dedup key: a cross-repo attachment is a DIFFERENT PR than a same-numbered PR
-      // caught by the ticket-repo list/head passes (keyed by bare number), so key it
-      // by owner/repo#number; a bare-number attachment shares the numeric key.
-      const key = repoSlug ? `${repoSlug}#${n}` : n;
+      // Dedup key: a CROSS-repo attachment is a DIFFERENT PR than a same-numbered PR
+      // caught by the ticket-repo list/head passes (keyed by bare number), so key it by
+      // owner/repo#number. But an attachment in the ticket's OWN repo IS that same PR —
+      // CTL-1157 (Codex round-6): key it by the bare number too so a single same-repo
+      // open PR isn't counted twice (which would inflate open_prs_at_done + the alarm).
+      // A bare-number attachment already shares the numeric key.
+      const isCrossRepo = repoSlug != null && repoSlug !== ticketRepoSlug;
+      const key = isCrossRepo ? `${repoSlug}#${n}` : n;
       if (seen.has(key)) continue;
       // Target the attachment's OWN repo (-R owner/repo) so a multi-repo / #-collision
       // does NOT check <n> in the ticket repo and falsely report it closed/absent (a
@@ -362,8 +386,18 @@ export function defaultCheckOpenPrs(
     }
   } catch (err) {
     // An authoritative gh list/view pass failed — the enumeration is UNVERIFIABLE,
-    // never a clean list. Keep this CONSISTENT with the attachment-view path above.
-    return { ok: false, unverifiable: true, reason: err?.message || String(err), prs: [] };
+    // never a clean list. CTL-1157 (Codex round-6): PRESERVE the PRs already discovered
+    // by an EARLIER pass (e.g. the ticket-key search found open PRs, then the head pass
+    // threw) — return [...seen.values()], matching the attachment-view failure path
+    // above. Returning [] here would make the pure-code Done paths emit openPrsAtDone:0
+    // + an alarm with no PR numbers even though known-open PRs exist.
+    return {
+      ok: false,
+      unverifiable: true,
+      reason: err?.message || String(err),
+      prs: [...seen.values()],
+      branchName: head ?? null,
+    };
   }
   const prs = [...seen.values()];
   return { ok: prs.length === 0, prs, branchName: head ?? null };

--- a/plugins/dev/scripts/execution-core/open-pr-gate.mjs
+++ b/plugins/dev/scripts/execution-core/open-pr-gate.mjs
@@ -1,34 +1,41 @@
-// open-pr-gate.mjs — CTL-1157 deterministic open-PR Done gate (single source of truth).
+// open-pr-gate.mjs — CTL-1157 open-PR ENUMERATOR (single source of truth).
 //
-// "Does this ticket still have an open/unmerged PR?" — the one check that EVERY
-// code path which writes Linear `Done` must run, so a ticket can never be marked
-// Done while a PR is still open (the owner's #1 rule; the false-positive that got
-// the GitHub-PR→Done automation removed: one merged PR + one still-open PR on a
-// NON-standard branch → falsely Done). Shared by the completion-declaration CLI
-// (linear-reconcile-cli.mjs `declare`) AND the execution-core terminal sweep
-// (scheduler.mjs `terminalDoneOnce`) so both run the IDENTICAL gate.
+// "Which open/unmerged PRs does this ticket still have?" — the FACTS that the
+// senior-engineer recovery-pass delegate reads before it declares a ticket Done,
+// and that the two pure-code backstops (scheduler.mjs `terminalDoneOnce`, the
+// reconciler drain) consult to decide whether to fire the
+// `recovery.done-applied-with-open-pr` alarm.
 //
-// Authoritative source is GitHub (`gh`), NEVER the local cache — a cache lag must
-// never green-light a Done. The ticket's branchName (the secondary "non-standard
-// branch" net) is read from the local Catalyst-Cloud REPLICA/cache via
-// `catalyst-linear read` (source:replica) — NEVER bare `linearis` (rate-limited;
-// stalls the fleet). FAIL-CLOSED: an unverifiable PR set (gh missing/auth/network)
-// refuses the write.
+// THE REVERSAL (owner's decision): this module does NOT refuse a write. It is a
+// data source, not a mechanical block. The earlier fail-closed "gate that refuses"
+// behavior was the handcuff that got removed — the delegate is a senior engineer
+// with autonomy: it enumerates the open PRs and reasons about EACH (finish/merge
+// the ones that are part of the solution; CLOSE the abandoned/superseded ones
+// itself), THEN marks Done. The hard block is held in reserve. Callers DECIDE what
+// to do with this list.
 //
-// Returns { ok:true,  prs:[] }            when no unmerged PR remains (Done allowed)
-//         { ok:false, prs:[…] }           when ≥1 open PR exists      (Done refused)
-//         { ok:false, reason, prs:[] }     when the check itself could not run.
+// Authoritative open-state source is GitHub (`gh`), NEVER the local cache — a
+// cache lag must never misreport a PR as merged. The ticket's branchName (the
+// "non-standard branch" net) and its Linear ATTACHMENTS (linked PRs) are read from
+// the local Catalyst-Cloud REPLICA/cache via `catalyst-linear read`
+// (source:replica) — NEVER bare `linearis` (rate-limited; stalls the fleet).
+//
+// Returns { ok:true,  prs:[] }            when no unmerged PR remains
+//         { ok:false, prs:[…] }           when ≥1 open PR exists
+//         { ok:false, reason, prs:[] }     when the GitHub check itself could not run.
+// `ok` is now ADVISORY ("are there zero open PRs?"), retained for back-compat with
+// callers/tests; it no longer implies any refusal.
 import { spawnSync } from "node:child_process";
 import { existsSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
-// defaultDeriveBranchName — resolve a ticket's Linear branchName from the local
-// REPLICA/cache via `catalyst-linear read <TICKET>` (replica-first; the CLI itself
-// degrades to its own linearis fallback only internally — this module NEVER shells
-// `linearis` directly). Best-effort: any failure returns null and the branch-head
-// pass is simply skipped (the ticket-key search pass still runs).
-export function defaultDeriveBranchName(ticket, { cwd } = {}) {
+// readTicketReplica — read a ticket's record from the local REPLICA/cache via
+// `catalyst-linear read <TICKET>` (replica-first; the CLI itself degrades to its
+// own linearis fallback only internally — this module NEVER shells `linearis`
+// directly). Best-effort: any failure returns null. Shared by branchName +
+// attachment derivation so they pay a single spawn.
+export function readTicketReplica(ticket, { cwd } = {}) {
   try {
     const here = dirname(fileURLToPath(import.meta.url));
     const sibling = join(here, "..", "catalyst-linear");
@@ -38,9 +45,65 @@ export function defaultDeriveBranchName(ticket, { cwd } = {}) {
       cwd: cwd || process.cwd(),
     });
     if (r.status !== 0 || !r.stdout) return null;
-    return JSON.parse(r.stdout)?.branchName ?? null;
+    return JSON.parse(r.stdout);
   } catch {
     return null;
+  }
+}
+
+// defaultDeriveBranchName — resolve a ticket's Linear branchName from the replica.
+// Best-effort: null on any failure (the branch-head pass is simply skipped).
+export function defaultDeriveBranchName(ticket, { cwd, read = readTicketReplica } = {}) {
+  try {
+    return read(ticket, { cwd })?.branchName ?? null;
+  } catch {
+    return null;
+  }
+}
+
+// PR_URL_RE — pull a GitHub PR number out of a `.../pull/<n>` URL.
+const PR_URL_RE = /github\.com\/[^/\s]+\/[^/\s]+\/pull\/(\d+)/i;
+
+// defaultDeriveAttachmentPrNumbers — CTL-1157 (Path 2 / slice 4): enumerate the
+// ticket's PRs from LINEAR'S OWN attachments / linked-PR records via the replica.
+// This is the third discovery source, UNIONed with the gh ticket-key search and
+// the branch-head pass — it catches a PR that has NO ticket key in its title/body
+// AND a non-standard head branch, but that IS attached to the Linear issue (the
+// common GitHub<>Linear auto-link). Best-effort: returns a number[] of PR numbers
+// parsed from any attachment whose url/href/subtitle points at a `/pull/<n>`.
+//
+// KNOWN RESIDUAL (documented, not a logic bug): a PR with ZERO discoverable
+// linkage — no ticket key in its text, a non-standard head branch, AND no Linear
+// attachment — is genuinely undiscoverable from data. All three of our sources key
+// off SOME recorded linkage; an orphan PR records none. That is an
+// input-completeness limit, not a gap in this enumerator.
+export function defaultDeriveAttachmentPrNumbers(ticket, { cwd, read = readTicketReplica } = {}) {
+  try {
+    const rec = read(ticket, { cwd });
+    if (!rec) return [];
+    // Tolerate several shapes the replica may expose: an `attachments` array (Linear
+    // GraphQL nodes), a `prLinks`/`pullRequests` array, or `attachments.nodes`.
+    const atts = []
+      .concat(rec.attachments?.nodes ?? rec.attachments ?? [])
+      .concat(rec.pullRequests?.nodes ?? rec.pullRequests ?? [])
+      .concat(rec.prLinks ?? []);
+    const nums = new Set();
+    for (const a of atts) {
+      if (a == null) continue;
+      // A plain number / numeric string is taken as a PR number directly.
+      if (typeof a === "number" && Number.isFinite(a)) {
+        nums.add(a);
+        continue;
+      }
+      const hay = [a.url, a.href, a.sourceUrl, a.subtitle, a.title, typeof a === "string" ? a : null]
+        .filter(Boolean)
+        .join(" ");
+      const m = PR_URL_RE.exec(hay);
+      if (m) nums.add(Number(m[1]));
+    }
+    return [...nums];
+  } catch {
+    return [];
   }
 }
 
@@ -57,23 +120,32 @@ function defaultRunGh(ghArgs, cwd) {
   }
 }
 
-// defaultCheckOpenPrs — the gate. Combines two `gh pr list --state open` passes and
-// UNIONs them so an open PR is caught by EITHER its ticket-key mention OR its head
-// branch:
+// defaultCheckOpenPrs — the enumerator. UNIONs THREE discovery passes so an open
+// PR is caught by ANY of: its ticket-key mention, its head branch, or its Linear
+// attachment.
 //   1. ticket-key search  — `gh pr list --search <TICKET> --state open`
-//   2. branch-head pass    — `gh pr list --head <branchName> --state open`  (ALWAYS,
-//      with branchName derived from the replica/cache when the caller didn't pass
-//      one — catches a PR whose title/body omits the ticket key).
-// `--state open` ⇒ every returned PR is unmerged-and-open. `runGh`/`deriveBranchName`
-// are injectable seams for tests.
+//   2. branch-head pass    — `gh pr list --head <branchName> --state open` (branch
+//      derived from the replica when not supplied — catches a PR whose text omits
+//      the key).
+//   3. attachment pass     — for each PR number from Linear's attachments (replica)
+//      not already seen, `gh pr view <n>` and include it iff still OPEN (catches a
+//      PR with neither the key nor a matching branch, but linked in Linear).
+// `--state open` ⇒ every returned PR is unmerged-and-open. `runGh` /
+// `deriveBranchName` / `deriveAttachmentPrNumbers` are injectable seams for tests.
 export function defaultCheckOpenPrs(
   ticket,
-  { branchName, cwd, deriveBranchName = defaultDeriveBranchName, runGh } = {}
+  {
+    branchName,
+    cwd,
+    deriveBranchName = defaultDeriveBranchName,
+    deriveAttachmentPrNumbers = defaultDeriveAttachmentPrNumbers,
+    runGh,
+  } = {}
 ) {
   const gh = runGh || ((args) => defaultRunGh(args, cwd));
   const fields = "number,state,isDraft,title";
-  // Always resolve a branchName for the head pass — derive from the replica/cache
-  // when not supplied (NEVER bare linearis). Derivation failure ⇒ head pass skipped.
+  // Resolve a branchName for the head pass — derive from the replica/cache when not
+  // supplied (NEVER bare linearis). Derivation failure ⇒ head pass skipped.
   let head = branchName;
   if (!head) {
     try {
@@ -111,6 +183,30 @@ export function defaultCheckOpenPrs(
         "100",
       ]))
         if (p && p.number != null) seen.set(p.number, p);
+    }
+    // Pass 3: Linear-attachment PRs (best-effort). Confirm OPEN state via gh so a
+    // merged/closed attachment never falsely counts. A view failure for one PR is
+    // swallowed (that single PR is just not added) — it must not turn the whole
+    // enumeration unverifiable.
+    let attachmentNums = [];
+    try {
+      attachmentNums = deriveAttachmentPrNumbers(ticket, { cwd }) || [];
+    } catch {
+      attachmentNums = [];
+    }
+    for (const n of attachmentNums) {
+      if (seen.has(n)) continue;
+      let view;
+      try {
+        view = gh(["pr", "view", String(n), "--json", fields]);
+      } catch {
+        continue; // undiscoverable state for this one attachment — skip, don't fail
+      }
+      // `gh pr view --json` returns a single object (not an array).
+      const pr = Array.isArray(view) ? view[0] : view;
+      if (pr && pr.number != null && String(pr.state).toUpperCase() === "OPEN") {
+        seen.set(pr.number, pr);
+      }
     }
   } catch (err) {
     return { ok: false, reason: err?.message || String(err), prs: [] };

--- a/plugins/dev/scripts/execution-core/open-pr-gate.mjs
+++ b/plugins/dev/scripts/execution-core/open-pr-gate.mjs
@@ -61,17 +61,23 @@ const ENUM_SUBPROCESS_TIMEOUT_MS = (() => {
   return 15_000;
 })();
 
-// readTicketReplica — read a ticket's record from the local REPLICA/cache via
-// `catalyst-linear read <TICKET>` (replica-first; the CLI itself degrades to its
-// own linearis fallback only internally — this module NEVER shells `linearis`
-// directly). Best-effort: any failure returns null. Shared by branchName +
-// attachment derivation so they pay a single spawn.
-export function readTicketReplica(ticket, { cwd } = {}) {
+// readTicketReplica — read a ticket's record via `catalyst-linear read <TICKET>`.
+// Best-effort: any failure returns null.
+//
+// CTL-1157 (Codex round-7): `withAttachments` adds `--with-attachments`. The replica's
+// normalized detail does NOT carry Linear attachments, and catalyst-linear only bypasses
+// to the attachment-capable LIVE read when that flag is present — so the branch-name path
+// (replica-only, cheap) MUST NOT set it, but the attachment-discovery path MUST, or the
+// whole Linear-attachment pass is inert and a PR linked only as an attachment (no
+// ticket-key mention, non-matching branch) is missed → a false-clean open-PR check. This
+// is a live read, but it is bounded (timeout below) and only runs on the attachment pass.
+export function readTicketReplica(ticket, { cwd, withAttachments = false } = {}) {
   try {
     const here = dirname(fileURLToPath(import.meta.url));
     const sibling = join(here, "..", "catalyst-linear");
     const bin = existsSync(sibling) ? sibling : "catalyst-linear";
-    const r = spawnSync(bin, ["read", ticket], {
+    const args = withAttachments ? ["read", ticket, "--with-attachments"] : ["read", ticket];
+    const r = spawnSync(bin, args, {
       encoding: "utf8",
       cwd: cwd || process.cwd(),
       timeout: ENUM_SUBPROCESS_TIMEOUT_MS, // CTL-1157 F #7: same synchronous-tick wedge risk
@@ -146,7 +152,10 @@ const PR_URL_RE = /github\.com\/([^/\s]+)\/([^/\s]+)\/pull\/(\d+)/i;
 // input-completeness limit, not a gap in this enumerator.
 export function defaultDeriveAttachmentPrs(ticket, { cwd, read = readTicketReplica } = {}) {
   try {
-    const rec = read(ticket, { cwd });
+    // CTL-1157 (Codex round-7): MUST request attachments — the replica omits them, so a
+    // flagless read returns none and this whole pass is inert. withAttachments makes
+    // catalyst-linear do the attachment-capable live read.
+    const rec = read(ticket, { cwd, withAttachments: true });
     if (!rec) return [];
     // Tolerate several shapes the replica may expose: an `attachments` array (Linear
     // GraphQL nodes), a `prLinks`/`pullRequests` array, or `attachments.nodes`.

--- a/plugins/dev/scripts/execution-core/recovery-done-open-pr-event.mjs
+++ b/plugins/dev/scripts/execution-core/recovery-done-open-pr-event.mjs
@@ -50,8 +50,19 @@ function normalizePrNumbers(openPrs = []) {
 // buildRecoveryDoneOpenPrEvent — canonical OTel envelope (string + "\n"). The
 // dimensions land in `attributes` so they forward to Loki as STRUCTURED METADATA
 // (per-line, not stream labels): open_prs_count [value], pr_numbers [value],
-// by [label], and event.label = ticket. severity WARN (loud).
-export function buildRecoveryDoneOpenPrEvent({ ticket, openPrs = [], by = "unknown" } = {}) {
+// by [label], unverifiable [label], and event.label = ticket. severity WARN (loud).
+//
+// CTL-1157: `unverifiable:true` carries the case where the open-PR enumeration
+// itself could not be completed (a `gh` failure, or the ticket's repo could not be
+// derived). UNVERIFIABLE ≠ CLEAN — a backstop that lands a Done on an unverified
+// check is exactly the silent-Done risk this alarm exists to surface, so the alarm
+// fires even when no OPEN PR number is known (`open_prs_count` may be 0).
+export function buildRecoveryDoneOpenPrEvent({
+  ticket,
+  openPrs = [],
+  by = "unknown",
+  unverifiable = false,
+} = {}) {
   const ts = new Date().toISOString().replace(/\.\d{3}Z$/, "Z");
   const prNumbers = normalizePrNumbers(openPrs);
   return (
@@ -74,11 +85,19 @@ export function buildRecoveryDoneOpenPrEvent({ ticket, openPrs = [], by = "unkno
         // [value] dimensions:
         open_prs_count: prNumbers.length,
         pr_numbers: prNumbers.map((n) => `#${n}`).join(","),
-        // [label] dimension: WHICH pure-code backstop wrote the Done.
+        // [label] dimensions: WHICH pure-code backstop wrote the Done; whether the
+        // open-PR check was unverifiable (Done landed without confirming clean).
         by,
+        unverifiable: !!unverifiable,
       },
       body: {
-        payload: { ticket, by, open_prs_count: prNumbers.length, pr_numbers: prNumbers },
+        payload: {
+          ticket,
+          by,
+          open_prs_count: prNumbers.length,
+          pr_numbers: prNumbers,
+          unverifiable: !!unverifiable,
+        },
       },
     }) + "\n"
   );
@@ -88,10 +107,12 @@ export function buildRecoveryDoneOpenPrEvent({ ticket, openPrs = [], by = "unkno
 // (observability must NEVER abort a write or wedge the tick). The `append` seam
 // defaults to the real file write; inject a recorder in tests. Returns true on
 // success, false on any error. No-op (returns false, emits nothing) when there are
-// zero open PRs — a clean Done is silent.
+// zero open PRs AND the check was verifiable — a clean, confirmed Done is silent.
+// CTL-1157: an UNVERIFIABLE check still alarms even with zero known open PRs (the
+// Done landed without confirming the board was clean).
 export function appendRecoveryDoneOpenPrEvent({ append = defaultAppend, ...fields } = {}) {
   try {
-    if (normalizePrNumbers(fields.openPrs).length === 0) return false;
+    if (normalizePrNumbers(fields.openPrs).length === 0 && !fields.unverifiable) return false;
     append(buildRecoveryDoneOpenPrEvent(fields));
     return true;
   } catch {

--- a/plugins/dev/scripts/execution-core/recovery-done-open-pr-event.mjs
+++ b/plugins/dev/scripts/execution-core/recovery-done-open-pr-event.mjs
@@ -38,13 +38,36 @@ function defaultAppend(line) {
   appendFileSync(file, line);
 }
 
-// normalizePrNumbers — accepts the open-PR list (objects with `.number`) OR a raw
-// array of numbers, returns a sorted unique number[] of OPEN PR numbers.
-function normalizePrNumbers(openPrs = []) {
-  const nums = (Array.isArray(openPrs) ? openPrs : [])
-    .map((p) => (typeof p === "number" ? p : p?.number))
-    .filter((n) => Number.isFinite(n));
-  return [...new Set(nums)].sort((a, b) => a - b);
+// normalizePrRefs — accepts the open-PR list (objects with `.number` and optional
+// `.repo`) OR a raw array of numbers, returns a sorted unique array of PR REFERENCES:
+// `owner/repo#number` when the repo is known, else `#number`.
+//
+// CTL-1157 (Codex round-7): key by (repo, number), NOT number alone. open-pr-gate
+// intentionally keeps a ticket-repo `#808` and an attached `org/other#808` DISTINCT
+// (they are two different PRs); collapsing them by number would report open_prs_count:1
+// and drop the repo-qualified PR that still needs remediation. A bare-number PR (no
+// repo recorded) keeps the `#number` form — unchanged for the common single-repo case.
+function normalizePrRefs(openPrs = []) {
+  const refs = (Array.isArray(openPrs) ? openPrs : [])
+    .map((p) => {
+      if (typeof p === "number") return Number.isFinite(p) ? `#${p}` : null;
+      const n = p?.number;
+      if (!Number.isFinite(n)) return null;
+      const repo = typeof p?.repo === "string" && p.repo ? p.repo : null;
+      return repo ? `${repo}#${n}` : `#${n}`;
+    })
+    .filter(Boolean);
+  // Sort by repo prefix (bare `#n` first), then by PR number NUMERICALLY (not lexically,
+  // so #42 sorts before #101).
+  const parse = (ref) => {
+    const i = ref.lastIndexOf("#");
+    return { repo: ref.slice(0, i), num: Number(ref.slice(i + 1)) };
+  };
+  return [...new Set(refs)].sort((a, b) => {
+    const pa = parse(a);
+    const pb = parse(b);
+    return pa.repo.localeCompare(pb.repo) || pa.num - pb.num;
+  });
 }
 
 // buildRecoveryDoneOpenPrEvent — canonical OTel envelope (string + "\n"). The
@@ -64,7 +87,7 @@ export function buildRecoveryDoneOpenPrEvent({
   unverifiable = false,
 } = {}) {
   const ts = new Date().toISOString().replace(/\.\d{3}Z$/, "Z");
-  const prNumbers = normalizePrNumbers(openPrs);
+  const prRefs = normalizePrRefs(openPrs);
   return (
     JSON.stringify({
       ts,
@@ -82,9 +105,10 @@ export function buildRecoveryDoneOpenPrEvent({
         // bare `| ticket="…"` filter works alongside `| event_label="…"`.
         "event.label": ticket,
         ticket,
-        // [value] dimensions:
-        open_prs_count: prNumbers.length,
-        pr_numbers: prNumbers.map((n) => `#${n}`).join(","),
+        // [value] dimensions: count DISTINCT (repo,number) refs so a cross-repo
+        // same-numbered PR isn't lost (CTL-1157 Codex round-7).
+        open_prs_count: prRefs.length,
+        pr_numbers: prRefs.join(","),
         // [label] dimensions: WHICH pure-code backstop wrote the Done; whether the
         // open-PR check was unverifiable (Done landed without confirming clean).
         by,
@@ -94,8 +118,8 @@ export function buildRecoveryDoneOpenPrEvent({
         payload: {
           ticket,
           by,
-          open_prs_count: prNumbers.length,
-          pr_numbers: prNumbers,
+          open_prs_count: prRefs.length,
+          pr_numbers: prRefs,
           unverifiable: !!unverifiable,
         },
       },
@@ -112,7 +136,7 @@ export function buildRecoveryDoneOpenPrEvent({
 // Done landed without confirming the board was clean).
 export function appendRecoveryDoneOpenPrEvent({ append = defaultAppend, ...fields } = {}) {
   try {
-    if (normalizePrNumbers(fields.openPrs).length === 0 && !fields.unverifiable) return false;
+    if (normalizePrRefs(fields.openPrs).length === 0 && !fields.unverifiable) return false;
     append(buildRecoveryDoneOpenPrEvent(fields));
     return true;
   } catch {

--- a/plugins/dev/scripts/execution-core/recovery-done-open-pr-event.mjs
+++ b/plugins/dev/scripts/execution-core/recovery-done-open-pr-event.mjs
@@ -1,0 +1,99 @@
+// recovery-done-open-pr-event.mjs — CTL-1157 LOUD observability alarm:
+// `recovery.done-applied-with-open-pr`.
+//
+// THE REVERSAL (owner's decision): the Done-safety mechanism is AGENT JUDGMENT,
+// not a mechanical fail-closed block. The senior-engineer delegate enumerates a
+// ticket's open PRs (via open-pr-gate.mjs) and reasons about each BEFORE it
+// declares Done — finishing/merging the ones that are part of the solution and
+// closing the abandoned ones itself. So the agent `declare` path is NOT gated.
+//
+// But two pure-CODE paths have no agent to reason: the execution-core terminal
+// sweep (scheduler.mjs `terminalDoneOnce`) and the reconciler drain
+// (linear-reconcile-cli.mjs `reconcile`). Per the reversal they must PROCEED —
+// never wedge the board, never mechanically escalate — but when they would write
+// Done while ≥1 OPEN PR still exists, they emit THIS event so we get the signal
+// that would justify adding a real hard block later (held in reserve). A clean
+// Done (0 open PRs) emits nothing.
+//
+// Loki (structured metadata — filter with `| field="…"`, NOT `{}` stream labels):
+//   {service_namespace="catalyst"} | event_name="recovery.done-applied-with-open-pr"
+//     | open_prs_count, pr_numbers, by, event_label   (ticket = event.label)
+import { randomBytes } from "node:crypto";
+import { appendFileSync, mkdirSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { homedir } from "node:os";
+import { buildCatalystResource } from "./lib/catalyst-resource.mjs";
+
+// defaultAppend — append a JSONL line to the canonical unified event log. Path is
+// resolved the same way the rest of the reconciler emits (CATALYST_DIR, monthly
+// rotation) so this module stays runtime-portable: it works under the daemon AND
+// under the plain-node CLI without importing the bun-tinted config.mjs.
+function defaultAppend(line) {
+  const dir = process.env.CATALYST_DIR || join(homedir(), "catalyst");
+  const d = new Date();
+  const month = `${d.getUTCFullYear()}-${String(d.getUTCMonth() + 1).padStart(2, "0")}`;
+  const file = join(dir, "events", `${month}.jsonl`);
+  mkdirSync(dirname(file), { recursive: true });
+  appendFileSync(file, line);
+}
+
+// normalizePrNumbers — accepts the open-PR list (objects with `.number`) OR a raw
+// array of numbers, returns a sorted unique number[] of OPEN PR numbers.
+function normalizePrNumbers(openPrs = []) {
+  const nums = (Array.isArray(openPrs) ? openPrs : [])
+    .map((p) => (typeof p === "number" ? p : p?.number))
+    .filter((n) => Number.isFinite(n));
+  return [...new Set(nums)].sort((a, b) => a - b);
+}
+
+// buildRecoveryDoneOpenPrEvent — canonical OTel envelope (string + "\n"). The
+// dimensions land in `attributes` so they forward to Loki as STRUCTURED METADATA
+// (per-line, not stream labels): open_prs_count [value], pr_numbers [value],
+// by [label], and event.label = ticket. severity WARN (loud).
+export function buildRecoveryDoneOpenPrEvent({ ticket, openPrs = [], by = "unknown" } = {}) {
+  const ts = new Date().toISOString().replace(/\.\d{3}Z$/, "Z");
+  const prNumbers = normalizePrNumbers(openPrs);
+  return (
+    JSON.stringify({
+      ts,
+      id: randomBytes(8).toString("hex"),
+      observedTs: ts,
+      severityText: "WARN",
+      severityNumber: 13,
+      channel: "execution-core",
+      resource: buildCatalystResource({ serviceName: "catalyst.execution-core" }),
+      attributes: {
+        "event.name": "recovery.done-applied-with-open-pr",
+        "event.entity": "linear",
+        "event.action": "done-applied-with-open-pr",
+        // ticket = event_label (the owner's spec). Lower-cased mirror kept too so a
+        // bare `| ticket="…"` filter works alongside `| event_label="…"`.
+        "event.label": ticket,
+        ticket,
+        // [value] dimensions:
+        open_prs_count: prNumbers.length,
+        pr_numbers: prNumbers.map((n) => `#${n}`).join(","),
+        // [label] dimension: WHICH pure-code backstop wrote the Done.
+        by,
+      },
+      body: {
+        payload: { ticket, by, open_prs_count: prNumbers.length, pr_numbers: prNumbers },
+      },
+    }) + "\n"
+  );
+}
+
+// appendRecoveryDoneOpenPrEvent — emit the alarm. Best-effort + swallow-on-error
+// (observability must NEVER abort a write or wedge the tick). The `append` seam
+// defaults to the real file write; inject a recorder in tests. Returns true on
+// success, false on any error. No-op (returns false, emits nothing) when there are
+// zero open PRs — a clean Done is silent.
+export function appendRecoveryDoneOpenPrEvent({ append = defaultAppend, ...fields } = {}) {
+  try {
+    if (normalizePrNumbers(fields.openPrs).length === 0) return false;
+    append(buildRecoveryDoneOpenPrEvent(fields));
+    return true;
+  } catch {
+    return false; // never throw from an observability emit
+  }
+}

--- a/plugins/dev/scripts/execution-core/recovery-done-open-pr-event.mjs
+++ b/plugins/dev/scripts/execution-core/recovery-done-open-pr-event.mjs
@@ -23,6 +23,7 @@ import { appendFileSync, mkdirSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { homedir } from "node:os";
 import { buildCatalystResource } from "./lib/catalyst-resource.mjs";
+import { hostName } from "./lib/host-identity.mjs";
 
 // defaultAppend — append a JSONL line to the canonical unified event log. Path is
 // resolved the same way the rest of the reconciler emits (CATALYST_DIR, monthly
@@ -92,6 +93,104 @@ export function appendRecoveryDoneOpenPrEvent({ append = defaultAppend, ...field
   try {
     if (normalizePrNumbers(fields.openPrs).length === 0) return false;
     append(buildRecoveryDoneOpenPrEvent(fields));
+    return true;
+  } catch {
+    return false; // never throw from an observability emit
+  }
+}
+
+// ── CTL-1157 SLICE 3 — the broad "Done-moves" event: `recovery.done-applied` ───
+//
+// Unlike the loud `recovery.done-applied-with-open-pr` alarm above (the open-PR
+// SUBSET), THIS event fires on EVERY autonomous Done so OTEL has a "Done-moves"
+// panel — the delegate's clean Done declarations AND the two pure-code backstops.
+// The red-line is `open_prs_at_done > 0`: a clean Done (the agent finished/closed
+// every open PR before declaring) carries 0 and is INFO; a Done that lands while a
+// PR is still open carries >0 and is WARN — the same signal the alarm watches, now
+// also visible as a chartable rate across every Done. open_prs_at_done is the
+// count STILL open at the Done write; prs_closed / prs_kept are what the agent did
+// during its PR-2 remediation (0/0 for the no-agent pure-code paths).
+//
+// SHADOW-SAFE: in shadow the delegate does not write Done — the caller passes
+// recoveryMode:"shadow" and we emit `recovery.would-done-applied` (would-apply
+// telemetry, INFO, no write happened). In enforce the real write emits
+// `recovery.done-applied`. recoveryMode is BOTH the name selector and the
+// recovery_mode label, mirroring the recovery-reasoning shadow/enforce precedent.
+//
+// Loki (structured metadata — `| field="…"`, NOT `{}` stream labels):
+//   {service_namespace="catalyst"} | event_name="recovery.done-applied"
+//     | open_prs_at_done > 0           ← the red-line
+//   sum by (by) (count_over_time({…} | event_name="recovery.done-applied" [1d]))
+//
+// dimensions: open_prs_at_done [value] · prs_closed [value] · prs_kept [value] ·
+//             recovery_mode [label] · host_name [label] · by [label] ·
+//             event.label = ticket.
+const toCount = (v) => (Number.isFinite(Number(v)) ? Math.max(0, Math.trunc(Number(v))) : 0);
+
+export function buildRecoveryDoneAppliedEvent({
+  ticket,
+  openPrsAtDone = 0,
+  prsClosed = 0,
+  prsKept = 0,
+  recoveryMode = "enforce",
+  by = "unknown",
+  host = hostName(),
+} = {}) {
+  const ts = new Date().toISOString().replace(/\.\d{3}Z$/, "Z");
+  const openCount = toCount(openPrsAtDone);
+  const shadow = recoveryMode === "shadow";
+  const name = shadow ? "recovery.would-done-applied" : "recovery.done-applied";
+  const action = shadow ? "would-done-applied" : "done-applied";
+  // The red-line: a Done that lands with ≥1 open PR is WARN (mirrors the alarm's
+  // severity). A clean Done — and any shadow would-apply — stays INFO.
+  const redLine = !shadow && openCount > 0;
+  return (
+    JSON.stringify({
+      ts,
+      id: randomBytes(8).toString("hex"),
+      observedTs: ts,
+      severityText: redLine ? "WARN" : "INFO",
+      severityNumber: redLine ? 13 : 9,
+      channel: "execution-core",
+      resource: buildCatalystResource({ serviceName: "catalyst.execution-core" }),
+      attributes: {
+        "event.name": name,
+        "event.entity": "linear",
+        "event.action": action,
+        // ticket = event_label (the owner's spec); lower-cased mirror kept too.
+        "event.label": ticket,
+        ticket,
+        // [value] dimensions — chartable counts:
+        open_prs_at_done: openCount,
+        prs_closed: toCount(prsClosed),
+        prs_kept: toCount(prsKept),
+        // [label] dimensions:
+        recovery_mode: recoveryMode,
+        host_name: host,
+        by,
+      },
+      body: {
+        payload: {
+          ticket,
+          by,
+          open_prs_at_done: openCount,
+          prs_closed: toCount(prsClosed),
+          prs_kept: toCount(prsKept),
+          recovery_mode: recoveryMode,
+          host_name: host,
+        },
+      },
+    }) + "\n"
+  );
+}
+
+// appendRecoveryDoneAppliedEvent — emit the Done-moves event. Best-effort +
+// swallow-on-error (observability must NEVER abort a Done write or wedge a tick).
+// Unlike the open-PR alarm this is NOT conditional on open PRs — it fires on every
+// autonomous Done. Returns true on success, false on any error.
+export function appendRecoveryDoneAppliedEvent({ append = defaultAppend, ...fields } = {}) {
+  try {
+    append(buildRecoveryDoneAppliedEvent(fields));
     return true;
   } catch {
     return false; // never throw from an observability emit

--- a/plugins/dev/scripts/execution-core/recovery-done-open-pr-event.test.mjs
+++ b/plugins/dev/scripts/execution-core/recovery-done-open-pr-event.test.mjs
@@ -54,6 +54,23 @@ test("append: a clean Done (0 open PRs) emits NOTHING and returns false", () => 
   expect(lines).toEqual([]);
 });
 
+test("append: an UNVERIFIABLE check alarms even with ZERO known open PRs (CTL-1157)", () => {
+  const lines = [];
+  const ok = appendRecoveryDoneOpenPrEvent({
+    ticket: "CTL-9",
+    by: "terminal-sweep",
+    openPrs: [], // no KNOWN open PR…
+    unverifiable: true, // …but the check could not confirm clean → surface it
+    append: (l) => lines.push(l),
+  });
+  expect(ok).toBe(true);
+  expect(lines).toHaveLength(1);
+  const a = JSON.parse(lines[0]).attributes;
+  expect(a.unverifiable).toBe(true);
+  expect(a.open_prs_count).toBe(0);
+  expect(a.by).toBe("terminal-sweep");
+});
+
 test("append: never throws (swallows an emitter error)", () => {
   expect(
     appendRecoveryDoneOpenPrEvent({

--- a/plugins/dev/scripts/execution-core/recovery-done-open-pr-event.test.mjs
+++ b/plugins/dev/scripts/execution-core/recovery-done-open-pr-event.test.mjs
@@ -30,6 +30,36 @@ test("accepts a raw number[] for openPrs and dedupes", () => {
   expect(env.attributes.pr_numbers).toBe("#3,#7");
 });
 
+// CTL-1157 (Codex round-7): two DISTINCT open PRs with the same number from different
+// repos (open-pr-gate keeps them distinct) must NOT collapse by number — the alarm has
+// to count + name BOTH the repo-qualified PR and the bare ticket-repo one.
+test("keeps same-number cross-repo PRs distinct (repo#number keying)", () => {
+  const env = JSON.parse(
+    buildRecoveryDoneOpenPrEvent({
+      ticket: "CTL-808",
+      openPrs: [
+        { number: 808 }, // ticket-repo #808 (no repo recorded → bare)
+        { number: 808, repo: "org/other" }, // attached cross-repo #808 — DISTINCT
+      ],
+    }),
+  );
+  expect(env.attributes.open_prs_count).toBe(2); // NOT collapsed to 1
+  expect(env.attributes.pr_numbers).toBe("#808,org/other#808"); // bare first, then repo-qualified
+  expect(env.body.payload.pr_numbers).toEqual(["#808", "org/other#808"]);
+});
+
+// A same repo + same number is still a single PR (real dedup preserved).
+test("dedupes an identical repo#number ref", () => {
+  const env = JSON.parse(
+    buildRecoveryDoneOpenPrEvent({
+      ticket: "CTL-9",
+      openPrs: [{ number: 42, repo: "org/x" }, { number: 42, repo: "org/x" }],
+    }),
+  );
+  expect(env.attributes.open_prs_count).toBe(1);
+  expect(env.attributes.pr_numbers).toBe("org/x#42");
+});
+
 test("append: emits via the injected seam when ≥1 open PR", () => {
   const lines = [];
   const ok = appendRecoveryDoneOpenPrEvent({

--- a/plugins/dev/scripts/execution-core/recovery-done-open-pr-event.test.mjs
+++ b/plugins/dev/scripts/execution-core/recovery-done-open-pr-event.test.mjs
@@ -1,0 +1,65 @@
+import { test, expect } from "bun:test";
+import {
+  buildRecoveryDoneOpenPrEvent,
+  appendRecoveryDoneOpenPrEvent,
+} from "./recovery-done-open-pr-event.mjs";
+
+test("event shape: name, ticket=event.label, open_prs_count, pr_numbers, by (structured metadata)", () => {
+  const line = buildRecoveryDoneOpenPrEvent({
+    ticket: "CTL-9",
+    by: "terminal-sweep",
+    openPrs: [{ number: 101, state: "OPEN" }, { number: 42, state: "OPEN" }],
+  });
+  expect(line.endsWith("\n")).toBe(true);
+  const env = JSON.parse(line);
+  expect(env.severityText).toBe("WARN");
+  const a = env.attributes;
+  expect(a["event.name"]).toBe("recovery.done-applied-with-open-pr");
+  expect(a["event.label"]).toBe("CTL-9");
+  expect(a.ticket).toBe("CTL-9");
+  expect(a.open_prs_count).toBe(2);
+  expect(a.pr_numbers).toBe("#42,#101"); // sorted, deduped, joined
+  expect(a.by).toBe("terminal-sweep");
+});
+
+test("accepts a raw number[] for openPrs and dedupes", () => {
+  const env = JSON.parse(buildRecoveryDoneOpenPrEvent({ ticket: "CTL-9", openPrs: [7, 7, 3] }));
+  expect(env.attributes.open_prs_count).toBe(2);
+  expect(env.attributes.pr_numbers).toBe("#3,#7");
+});
+
+test("append: emits via the injected seam when ≥1 open PR", () => {
+  const lines = [];
+  const ok = appendRecoveryDoneOpenPrEvent({
+    ticket: "CTL-9",
+    by: "reconcile-drain",
+    openPrs: [{ number: 5 }],
+    append: (l) => lines.push(l),
+  });
+  expect(ok).toBe(true);
+  expect(lines).toHaveLength(1);
+  expect(JSON.parse(lines[0]).attributes.by).toBe("reconcile-drain");
+});
+
+test("append: a clean Done (0 open PRs) emits NOTHING and returns false", () => {
+  const lines = [];
+  const ok = appendRecoveryDoneOpenPrEvent({
+    ticket: "CTL-9",
+    openPrs: [],
+    append: (l) => lines.push(l),
+  });
+  expect(ok).toBe(false);
+  expect(lines).toEqual([]);
+});
+
+test("append: never throws (swallows an emitter error)", () => {
+  expect(
+    appendRecoveryDoneOpenPrEvent({
+      ticket: "CTL-9",
+      openPrs: [{ number: 1 }],
+      append: () => {
+        throw new Error("disk full");
+      },
+    })
+  ).toBe(false);
+});

--- a/plugins/dev/scripts/execution-core/recovery-done-open-pr-event.test.mjs
+++ b/plugins/dev/scripts/execution-core/recovery-done-open-pr-event.test.mjs
@@ -2,6 +2,8 @@ import { test, expect } from "bun:test";
 import {
   buildRecoveryDoneOpenPrEvent,
   appendRecoveryDoneOpenPrEvent,
+  buildRecoveryDoneAppliedEvent,
+  appendRecoveryDoneAppliedEvent,
 } from "./recovery-done-open-pr-event.mjs";
 
 test("event shape: name, ticket=event.label, open_prs_count, pr_numbers, by (structured metadata)", () => {
@@ -57,6 +59,95 @@ test("append: never throws (swallows an emitter error)", () => {
     appendRecoveryDoneOpenPrEvent({
       ticket: "CTL-9",
       openPrs: [{ number: 1 }],
+      append: () => {
+        throw new Error("disk full");
+      },
+    })
+  ).toBe(false);
+});
+
+// ── CTL-1157 SLICE 3 — the broad `recovery.done-applied` Done-moves event ──────
+
+test("done-applied: a CLEAN delegate Done — name/action/label + underscored count+label dims, INFO", () => {
+  const env = JSON.parse(
+    buildRecoveryDoneAppliedEvent({
+      ticket: "CTL-9",
+      openPrsAtDone: 0,
+      prsClosed: 2,
+      prsKept: 1,
+      recoveryMode: "enforce",
+      by: "recovery-pass",
+      host: "mini",
+    })
+  );
+  const a = env.attributes;
+  // final OTEL names (the match-check contract):
+  expect(a["event.name"]).toBe("recovery.done-applied");
+  expect(a["event.action"]).toBe("done-applied");
+  expect(a["event.label"]).toBe("CTL-9"); // ticket=event_label
+  expect(a.ticket).toBe("CTL-9");
+  expect(a.open_prs_at_done).toBe(0); // [value]
+  expect(a.prs_closed).toBe(2); // [value]
+  expect(a.prs_kept).toBe(1); // [value]
+  expect(a.recovery_mode).toBe("enforce"); // [label]
+  expect(a.host_name).toBe("mini"); // [label]
+  expect(a.by).toBe("recovery-pass"); // [label]
+  // a clean Done (0 open) is INFO — no alarm.
+  expect(env.severityText).toBe("INFO");
+});
+
+test("done-applied: the red-line — open_prs_at_done>0 flips the event to WARN", () => {
+  const env = JSON.parse(
+    buildRecoveryDoneAppliedEvent({ ticket: "CTL-9", openPrsAtDone: 2, by: "terminal-sweep" })
+  );
+  expect(env.attributes.open_prs_at_done).toBe(2);
+  expect(env.severityText).toBe("WARN");
+  expect(env.attributes.by).toBe("terminal-sweep");
+  // defaults: a no-agent path carries 0/0 for closed/kept and enforce mode.
+  expect(env.attributes.prs_closed).toBe(0);
+  expect(env.attributes.prs_kept).toBe(0);
+  expect(env.attributes.recovery_mode).toBe("enforce");
+});
+
+test("done-applied: SHADOW is would-apply telemetry (would-done-applied name, never WARN)", () => {
+  const env = JSON.parse(
+    buildRecoveryDoneAppliedEvent({ ticket: "CTL-9", openPrsAtDone: 3, recoveryMode: "shadow" })
+  );
+  expect(env.attributes["event.name"]).toBe("recovery.would-done-applied");
+  expect(env.attributes["event.action"]).toBe("would-done-applied");
+  expect(env.attributes.recovery_mode).toBe("shadow");
+  // shadow never alarms even with open PRs — no actual Done was written.
+  expect(env.severityText).toBe("INFO");
+});
+
+test("done-applied: counts are clamped to non-negative integers", () => {
+  const a = JSON.parse(
+    buildRecoveryDoneAppliedEvent({
+      ticket: "CTL-9",
+      openPrsAtDone: -4,
+      prsClosed: 2.9,
+      prsKept: "x",
+    })
+  ).attributes;
+  expect(a.open_prs_at_done).toBe(0);
+  expect(a.prs_closed).toBe(2);
+  expect(a.prs_kept).toBe(0);
+});
+
+test("done-applied append: fires UNCONDITIONALLY (even on a clean 0-open Done) and never throws", () => {
+  const lines = [];
+  expect(
+    appendRecoveryDoneAppliedEvent({
+      ticket: "CTL-9",
+      openPrsAtDone: 0,
+      by: "reconcile-drain",
+      append: (l) => lines.push(l),
+    })
+  ).toBe(true);
+  expect(lines).toHaveLength(1); // unlike the alarm, a clean Done STILL emits a move
+  expect(
+    appendRecoveryDoneAppliedEvent({
+      ticket: "CTL-9",
       append: () => {
         throw new Error("disk full");
       },

--- a/plugins/dev/scripts/execution-core/recovery-reasoning.mjs
+++ b/plugins/dev/scripts/execution-core/recovery-reasoning.mjs
@@ -229,28 +229,42 @@ export function reasoningRecoveryPass(items, opts = {}) {
 
     if (decision === "defer") {
       // CTL-1157 Workstream B: an untyped stuck item DEFERS rather than latching
-      // at escalate. Write a cooldown-ONLY marker — NO escalated latch, and pin
-      // `attempts` to the prior value so it does NOT auto-increment (shadow must
-      // not burn the enforce budget). After the 30-min window both the per-item
-      // path AND board-health's holistic pass can reconsider it. Same in shadow +
-      // enforce; only the event name differs.
-      const priorAttempts = (() => {
+      // at escalate. In ENFORCE, write a cooldown-ONLY marker — NO escalated latch,
+      // and pin `attempts` to the prior value so it does NOT auto-increment. After
+      // the 30-min window both the per-item path AND board-health's holistic pass
+      // can reconsider it.
+      //
+      // CTL-1157 F #4 (Codex round-4): SHADOW must NOT write the marker. A
+      // `decision:"defer"` marker is honored by defaultShouldSkipItem in ENFORCE too,
+      // so a shadow-written defer marker would suppress the ticket for up to the whole
+      // cooldown window after an operator flips shadow→enforce — shadow silently
+      // mutating enforce scheduler state, violating the shadow-first contract (shadow =
+      // telemetry only, zero mutation). Skipping the marker is safe here: the defer
+      // path posts NO comment and defaultClassifyTicket is a pure deterministic
+      // classifier, so re-processing a deferred item on the next tick costs only a
+      // cheap re-classify + one recovery.would-defer emit — NOT the comment/fork storm
+      // the CTL-1176 rate-limit marker on the fix/escalate shadow path guards against.
+      if (mode !== "shadow") {
+        const priorAttempts = (() => {
+          try {
+            return readIntentAttempts(item.ticket) ?? 0;
+          } catch {
+            return 0;
+          }
+        })();
         try {
-          return readIntentAttempts(item.ticket) ?? 0;
-        } catch {
-          return 0;
+          recordIntent(item.ticket, {
+            type: "recovery-pass",
+            decision: "defer",
+            fix_class: fix_class ?? "board-health",
+            attempts: priorAttempts, // pin → no auto-increment, no latch
+          });
+          actionLog.push("recorded defer marker (cooldown-only, no latch)");
+        } catch (err) {
+          log(`recovery-reasoning: ${item.ticket} defer marker write failed: ${err.message}`);
         }
-      })();
-      try {
-        recordIntent(item.ticket, {
-          type: "recovery-pass",
-          decision: "defer",
-          fix_class: fix_class ?? "board-health",
-          attempts: priorAttempts, // pin → no auto-increment, no latch
-        });
-        actionLog.push("recorded defer marker (cooldown-only, no latch)");
-      } catch (err) {
-        log(`recovery-reasoning: ${item.ticket} defer marker write failed: ${err.message}`);
+      } else {
+        actionLog.push("would-defer (shadow: no cooldown marker written)");
       }
       emitEvent({
         type: mode === "shadow" ? "recovery.would-defer" : "recovery.deferred",
@@ -909,6 +923,12 @@ function writeEscalationSignal(orchDir, ticket, escalationPayload, opts = {}) {
     const nowIso = new Date().toISOString();
     const signal = {
       ...prior,
+      // CTL-1157 F #6 (Codex round-4): persist the ticket on the signal. signal-reader
+      // parseSignal keys off raw.ticket, and status:"needs-human" is NON-terminal, so
+      // this fresh recovery-pass signal wins over the failed phase signal — WITHOUT a
+      // ticket, readWorkerSignals() would then report ticket:null and scheduler-recovery
+      // / board-health consumers would lose the escalated ticket after the first pass.
+      ticket,
       status: "needs-human",
       needsHumanSince:
         typeof prior.needsHumanSince === "string" && prior.needsHumanSince !== ""
@@ -1460,11 +1480,14 @@ export function defaultInvokeRecoveryPass(ticket, briefObj = {}, deps = {}) {
 
   // Lazy imports — same rationale as defaultInvokeRemediateCapped (avoid loading
   // the dispatch graph on the off/shadow paths; no import cycle).
-  let dispatchTicket, countRecoveryPassCycles, settleDispatchSync, isThenable, backstopOnRejection;
+  let dispatchTicket, countRecoveryPassCycles, settleDispatchSync, isThenable, backstopOnRejection, sdkSignalRunnable;
   try {
     // CTL-1157 F2: also pull the async-settlement seam so an sdk dispatch Promise
     // is turned into the synchronous {code,async:true} the rest of this fn expects.
-    ({ dispatchTicket, settleDispatchSync, isThenable, backstopOnRejection } =
+    // CTL-1157 F #4: sdkSignalRunnable is the SDK-aware verifySync — it confirms the
+    // synchronously-written prelaunch signal is actually runnable, so a resolved
+    // {code:1} (auth/prelaunch failure) is NOT reported as a successful dispatch.
+    ({ dispatchTicket, settleDispatchSync, isThenable, backstopOnRejection, sdkSignalRunnable } =
       deps.dispatchMod ?? requireSync("./dispatch.mjs"));
     ({ countRecoveryPassCycles } = deps.eventScanMod ?? requireSync("./event-scan.mjs"));
   } catch (err) {
@@ -1558,9 +1581,14 @@ export function defaultInvokeRecoveryPass(ticket, briefObj = {}, deps = {}) {
     // by the attempts cap of 2.
     if (isThenable && isThenable(rawR)) {
       const onSettled = (_res, err) => {
-        if (!err) return; // clean resolution → the worker owns its terminal event
+        // CTL-1157 F #4: fail on BOTH a rejection AND a resolved non-zero code. A
+        // resolved {code:1} (e.g. sdkRunPhaseAgent reporting an auth/prelaunch failure
+        // WITHOUT throwing) previously slipped through — onSettled only checked `err`,
+        // so the recovery-pass was recorded as dispatched while no worker was runnable.
+        const failed = err || (_res && Number.isFinite(_res.code) && _res.code !== 0);
+        if (!failed) return; // clean resolution → the worker owns its terminal event
         try {
-          backstopOnRejection?.({ orchDir, ticket, phase: RECOVERY_PASS_PHASE, log: defaultLogFn })(_res, err);
+          backstopOnRejection?.({ orchDir, ticket, phase: RECOVERY_PASS_PHASE, log: defaultLogFn })(_res, err ?? new Error(`sdk recovery-pass resolved code=${_res?.code}`));
         } catch {
           /* best-effort */
         }
@@ -1570,7 +1598,15 @@ export function defaultInvokeRecoveryPass(ticket, briefObj = {}, deps = {}) {
           /* best-effort */
         }
       };
-      r = settleDispatchSync(rawR, { onSettled });
+      // verifySync (sdkSignalRunnable) makes the SYNCHRONOUS provisional code reflect
+      // whether the prelaunch actually wrote a runnable signal — mirrors the canonical
+      // monitor/scheduler/recovery entry-point wiring, so an sdk dispatch whose
+      // prelaunch failed is reported as a dispatch FAILURE (r.code:1) instead of a
+      // blind success.
+      r = settleDispatchSync(rawR, {
+        verifySync: () => (sdkSignalRunnable ? sdkSignalRunnable(orchDir, ticket, RECOVERY_PASS_PHASE) : true),
+        onSettled,
+      });
     } else {
       r = rawR;
     }
@@ -1596,6 +1632,12 @@ export function defaultInvokeRecoveryPass(ticket, briefObj = {}, deps = {}) {
         bg_job_id: r.signal?.bg_job_id ?? null,
         worktreePath: r.worktreePath ?? null,
         seamsTriedCount: seamsTried.length,
+        // CTL-1157 F P1: under executor=sdk the query() runs IN-PROCESS and settles
+        // asynchronously; `r.pending` is the (never-rejecting) settled chain. The
+        // disposable delegate-runner child MUST await this before process.exit, or it
+        // kills the in-process worker it just launched. bg dispatch is synchronous →
+        // r.pending is undefined → no-op.
+        pendingSdk: r.async ? r.pending ?? null : null,
       },
     };
   }

--- a/plugins/dev/scripts/execution-core/recovery-reasoning.mjs
+++ b/plugins/dev/scripts/execution-core/recovery-reasoning.mjs
@@ -89,6 +89,15 @@ export function reasoningRecoveryPass(items, opts = {}) {
     postComment = defaultPostComment,
     emitEvent = defaultEmitEvent,
     shouldSkipItem = defaultShouldSkipItem,
+    // CTL-1157 Workstream B: read prior intent attempts so a DEFER marker can pin
+    // `attempts` (no auto-increment → does not burn the bounded-LLM budget).
+    // Bound to the tick's orchDir at the scheduler call site (like recordIntent).
+    readIntentAttempts = defaultReadIntentAttempts,
+    // CTL-1157 Workstream C: write the curated 6-field explanation signal on every
+    // enforce escalate so the Needs-You inbox + detail pane render it. Bound to the
+    // tick's orchDir at the scheduler call site; default resolves orchDir from env
+    // (a no-op when unset, e.g. unit tests).
+    writeEscalationSignal = defaultWriteEscalationSignal,
     // CTL-1176: DIAGNOSE evidence-collector. Read-only — populates an item's
     // {logsOutput, jobState} from `claude logs` + the bg job state when the
     // caller didn't already attach them. Injectable for tests.
@@ -140,7 +149,7 @@ export function reasoningRecoveryPass(items, opts = {}) {
   const tickStats = {
     queueSize: items.length,
     processed: 0,
-    decisions: { fix_seam: 0, fix_bounded_llm: 0, escalate: 0 },
+    decisions: { fix_seam: 0, fix_bounded_llm: 0, escalate: 0, defer: 0 },
     actions: { fixed: 0, fixFailed: 0, escalated: 0, deferred: 0, errors: 0 },
     ledgerSkipped: [],
     terminalSkipped: [],
@@ -201,8 +210,9 @@ export function reasoningRecoveryPass(items, opts = {}) {
     // rollup. Emitted in BOTH shadow and enforce: it records the classifier's
     // verdict, independent of whether the mode then acts on it.
     tickStats.processed += 1;
-    const rule = decision === "escalate" ? 3 : fix_class === "bounded-llm" ? 2 : 1;
+    const rule = decision === "escalate" || decision === "defer" ? 3 : fix_class === "bounded-llm" ? 2 : 1;
     if (decision === "escalate") tickStats.decisions.escalate += 1;
+    else if (decision === "defer") tickStats.decisions.defer += 1;
     else if (fix_class === "bounded-llm") tickStats.decisions.fix_bounded_llm += 1;
     else tickStats.decisions.fix_seam += 1;
     emitEvent({
@@ -217,7 +227,40 @@ export function reasoningRecoveryPass(items, opts = {}) {
     let outcome = null;
     let actionLog = [];
 
-    if (mode === "shadow") {
+    if (decision === "defer") {
+      // CTL-1157 Workstream B: an untyped stuck item DEFERS rather than latching
+      // at escalate. Write a cooldown-ONLY marker — NO escalated latch, and pin
+      // `attempts` to the prior value so it does NOT auto-increment (shadow must
+      // not burn the enforce budget). After the 30-min window both the per-item
+      // path AND board-health's holistic pass can reconsider it. Same in shadow +
+      // enforce; only the event name differs.
+      const priorAttempts = (() => {
+        try {
+          return readIntentAttempts(item.ticket) ?? 0;
+        } catch {
+          return 0;
+        }
+      })();
+      try {
+        recordIntent(item.ticket, {
+          type: "recovery-pass",
+          decision: "defer",
+          fix_class: fix_class ?? "board-health",
+          attempts: priorAttempts, // pin → no auto-increment, no latch
+        });
+        actionLog.push("recorded defer marker (cooldown-only, no latch)");
+      } catch (err) {
+        log(`recovery-reasoning: ${item.ticket} defer marker write failed: ${err.message}`);
+      }
+      emitEvent({
+        type: mode === "shadow" ? "recovery.would-defer" : "recovery.deferred",
+        ticket: item.ticket,
+        reason: details.reason,
+        details: { mode },
+      });
+      tickStats.actions.deferred += 1;
+      outcome = { ticket: item.ticket, decision: "defer", reason: details.reason, actionLog, mode };
+    } else if (mode === "shadow") {
       // Shadow mode: emit .would-* events, post diagnoses, invoke nothing
       actionLog.push(`would-classify: ${decision} (${fix_class})`);
       const reasonStr = details.reason || "no reason";
@@ -348,6 +391,18 @@ export function reasoningRecoveryPass(items, opts = {}) {
       } else if (decision === "escalate") {
         const escalationPayload = buildEscalationPayload(item, classification);
 
+        // CTL-1157 Workstream C: write the curated 6-field explanation signal so
+        // the orch-monitor Needs-You inbox + detail pane render a real brief for a
+        // router-originated escalation (previously they found no `explanation` and
+        // rendered nothing). Best-effort in its OWN try/catch so a write failure
+        // never skips the recordIntent latch below.
+        try {
+          writeEscalationSignal(item.ticket, escalationPayload, { log });
+          actionLog.push("wrote curated escalation signal (phase-recovery-pass.json)");
+        } catch (err) {
+          log(`recovery-reasoning: ${item.ticket} escalation signal write failed: ${err.message}`);
+        }
+
         try {
           recordIntent(item.ticket, {
             type: "recovery-pass",
@@ -441,12 +496,26 @@ export function defaultClassifyTicket(evidence, opts = {}) {
     };
   }
 
-  // Rule 3: Check for human escalations (default)
+  // Rule 3: human escalation — but ONLY latch (escalate) when there is concrete
+  // evidence a human is genuinely needed. CTL-1157 Workstream B: an UNTYPED stuck
+  // item (no R12 belief, the generic "unclassified" reason) no longer dead-ends at
+  // the permanent escalate latch; it DEFERS (cooldown-only, no latch) so the
+  // holistic board-health delegate can triage it after the window.
+  const reason = determineEscalationReason(logsOutput, jobState, signal, beliefState);
+  const hasConcreteEvidence =
+    Boolean(beliefState?.escalate_human) || reason !== UNCLASSIFIED_ESCALATION_REASON;
+  if (hasConcreteEvidence) {
+    return {
+      decision: "escalate",
+      fix_class: "human",
+      details: { reason },
+    };
+  }
   return {
-    decision: "escalate",
-    fix_class: "human",
+    decision: "defer",
+    fix_class: "board-health",
     details: {
-      reason: determineEscalationReason(logsOutput, jobState, signal, beliefState),
+      reason: "No typed failure signature; holistic board-health delegate will triage",
     },
   };
 }
@@ -629,6 +698,14 @@ export function generateRemediateBrief(category) {
   return briefs[category] ?? `Resolve the ${category} issue and retry the phase.`;
 }
 
+// CTL-1157: the sentinel "no concrete evidence" escalation reason. Shared between
+// determineEscalationReason (its default) and defaultClassifyTicket's Rule-3
+// escalate-vs-defer split (Workstream B): when the reason IS this sentinel and no
+// R12 belief fired, there is no typed failure signature, so the item DEFERS to the
+// holistic board-health delegate instead of dead-ending at a permanent escalate
+// latch. Keep the exact string stable — it is the discriminator.
+export const UNCLASSIFIED_ESCALATION_REASON = "Unclassified stuck state requires human review";
+
 // Determine escalation reason (human decision)
 export function determineEscalationReason(logsOutput, jobState, signal, beliefState) {
   const reasons = [];
@@ -649,7 +726,7 @@ export function determineEscalationReason(logsOutput, jobState, signal, beliefSt
     reasons.push(`Failure reason: ${signal.failureReason}`);
   }
 
-  return reasons.length > 0 ? reasons.join("; ") : "Unclassified stuck state requires human review";
+  return reasons.length > 0 ? reasons.join("; ") : UNCLASSIFIED_ESCALATION_REASON;
 }
 
 // ─── Act phase (guarded fix: seam or remediate cap) ────────────────────────
@@ -776,6 +853,90 @@ Reasoning pass determined this requires human judgment.
 **Reason:** ${details.reason || "unclassified"}
 
 This ticket is now marked for human review.`;
+}
+
+// synthesizeEscalationExplanation — PURE. Build the 6-field curated brief
+// (the keys match orch-monitor board-data.mjs EXPLANATION_RENDER_FIELDS exactly:
+// call_to_action / outcome / problem / why_you / why_not_auto / what_to_do)
+// (+escalation_type for deriveEscalationType) from a buildEscalationPayload-shaped
+// object. The fields that pass through verbatim (call_to_action/problem/
+// why_not_auto) come from the payload; outcome/why_you/what_to_do are synthesized
+// when the payload doesn't already carry a richer authored value. Never
+// tautological ("requires human judgment").
+export function synthesizeEscalationExplanation(escalationPayload = {}) {
+  const p = escalationPayload || {};
+  const reason = p.observed?.diagnosis ?? p.problem ?? "an unclassified stuck state";
+  const instructions = Array.isArray(p.instructions) ? p.instructions.filter(Boolean) : [];
+  const what_to_do = instructions.length
+    ? `${instructions.map((s) => String(s).replace(/[.\s]+$/, "")).join(". ")}. Once resolved, the next scheduler tick picks it up.`
+    : (p.remediation_then_retry
+      ?? "Resolve the stuck state by hand; the next scheduler tick re-evaluates the ticket and re-dispatches if appropriate.");
+  const outcome = p.remediation_then_retry
+    ?? "Once the stuck state is resolved by hand, the next scheduler tick re-evaluates the ticket and re-dispatches if appropriate.";
+  const why_you = p.why_you
+    ?? `No autonomous fix path matched this failure: ${reason}. A human must read the raw evidence and decide: re-dispatch the phase, fix the branch by hand, or close the ticket.`;
+  const why_not_auto = p.why_not_auto
+    ?? p.blocked_capability
+    ?? "neither a deterministic act-seam nor a bounded-LLM fix matched this failure signature, so the pass has no safe action to take";
+  return {
+    escalation_type: typeof p.escalation_type === "string" ? p.escalation_type : "manual",
+    call_to_action: p.call_to_action ?? `Look at this ticket's worker log and decide whether to re-dispatch the phase, fix the branch by hand, or close it`,
+    problem: p.problem ?? `This ticket is stuck and the recovery pass could not classify it for an autonomous fix: ${reason}`,
+    why_you,
+    why_not_auto,
+    what_to_do,
+    outcome,
+  };
+}
+
+// writeEscalationSignal — CTL-1157 Workstream C. Write workers/<ticket>/
+// phase-recovery-pass.json carrying the curated `.explanation` so the UI renders a
+// real Needs-You brief for a router-originated escalation. Read-modify-write
+// (preserve a prior needsHumanSince) + atomic tmp+rename (mkdir -p the worker
+// dir). Best-effort: catches all, logs via opts.log, NEVER throws.
+function writeEscalationSignal(orchDir, ticket, escalationPayload, opts = {}) {
+  const log = opts.log ?? defaultLogFn;
+  if (!orchDir || !ticket) return;
+  try {
+    const p = join(orchDir, "workers", ticket, "phase-recovery-pass.json");
+    const explanation = synthesizeEscalationExplanation(escalationPayload);
+    let prior = {};
+    try {
+      prior = JSON.parse(readFileSync(p, "utf8")) ?? {};
+    } catch {
+      prior = {};
+    }
+    const nowIso = new Date().toISOString();
+    const signal = {
+      ...prior,
+      status: "needs-human",
+      needsHumanSince:
+        typeof prior.needsHumanSince === "string" && prior.needsHumanSince !== ""
+          ? prior.needsHumanSince
+          : nowIso,
+      updatedAt: nowIso,
+      phase: RECOVERY_PASS_PHASE,
+      explanation,
+    };
+    mkdirSync(dirname(p), { recursive: true });
+    const tmp = `${p}.tmp.${process.pid}`;
+    writeFileSync(tmp, JSON.stringify(signal, null, 2));
+    renameSync(tmp, p); // atomic
+  } catch (err) {
+    try {
+      log(`recovery-reasoning: ${ticket} escalation signal write failed: ${err.message}`);
+    } catch {
+      /* logging must never break the escalate path */
+    }
+  }
+}
+
+// defaultWriteEscalationSignal — the injectable default the scheduler binds to the
+// tick's orchDir. Resolves orchDir from opts/env (a no-op when unset).
+export function defaultWriteEscalationSignal(ticket, escalationPayload, opts = {}) {
+  const orchDir = opts.orchDir ?? resolveOrchDir();
+  if (!orchDir) return;
+  writeEscalationSignal(orchDir, ticket, escalationPayload, opts);
 }
 
 // buildEscalationPayload — the composer-ready EscalationPayload for the router's
@@ -1291,9 +1452,12 @@ export function defaultInvokeRecoveryPass(ticket, briefObj = {}, deps = {}) {
 
   // Lazy imports — same rationale as defaultInvokeRemediateCapped (avoid loading
   // the dispatch graph on the off/shadow paths; no import cycle).
-  let dispatchTicket, countRecoveryPassCycles;
+  let dispatchTicket, countRecoveryPassCycles, settleDispatchSync, isThenable, backstopOnRejection;
   try {
-    ({ dispatchTicket } = deps.dispatchMod ?? requireSync("./dispatch.mjs"));
+    // CTL-1157 F2: also pull the async-settlement seam so an sdk dispatch Promise
+    // is turned into the synchronous {code,async:true} the rest of this fn expects.
+    ({ dispatchTicket, settleDispatchSync, isThenable, backstopOnRejection } =
+      deps.dispatchMod ?? requireSync("./dispatch.mjs"));
     ({ countRecoveryPassCycles } = deps.eventScanMod ?? requireSync("./event-scan.mjs"));
   } catch (err) {
     return {
@@ -1375,7 +1539,33 @@ export function defaultInvokeRecoveryPass(ticket, briefObj = {}, deps = {}) {
   //     phase `recovery-pass` to /catalyst-dev:recovery-pass (skill_for_phase).
   let r;
   try {
-    r = dispatch(orchDir, ticket, RECOVERY_PASS_PHASE);
+    const rawR = dispatch(orchDir, ticket, RECOVERY_PASS_PHASE);
+    // CTL-1157 F2: on an sdk fleet `dispatch` returns a Promise; settle it
+    // synchronously into {code:0,async:true} so the success check below works
+    // exactly as it does for a synchronous bg dispatch. On a bg fleet rawR is a
+    // plain object → isThenable false → r = rawR (byte-identical no-op). On a
+    // REJECTED async launch, onSettled composes the FAILED terminal backstop
+    // (so the ticket doesn't strand at "dispatched") with a cooldown clear
+    // (preserving attempts) so a reliably-failing launch retries sooner, bounded
+    // by the attempts cap of 2.
+    if (isThenable && isThenable(rawR)) {
+      const onSettled = (_res, err) => {
+        if (!err) return; // clean resolution → the worker owns its terminal event
+        try {
+          backstopOnRejection?.({ orchDir, ticket, phase: RECOVERY_PASS_PHASE, log: defaultLogFn })(_res, err);
+        } catch {
+          /* best-effort */
+        }
+        try {
+          defaultClearIntentCooldown(ticket, { orchDir });
+        } catch {
+          /* best-effort */
+        }
+      };
+      r = settleDispatchSync(rawR, { onSettled });
+    } else {
+      r = rawR;
+    }
   } catch (err) {
     return {
       success: false,
@@ -1504,6 +1694,15 @@ export function defaultShouldSkipItem(ticket, opts = {}) {
     return false; // no ledger / malformed → never acted → don't skip
   }
 
+  // CTL-1157 Workstream B: a DEFER marker is cooldown-ONLY — never attempts-
+  // latched, never escalated. Gate purely on the 30-min window so after it elapses
+  // BOTH the per-item path AND board-health's holistic pass can reconsider the
+  // untyped stuck item (it never dead-ends at a permanent latch).
+  if (data?.decision === "defer") {
+    const last = typeof data?.lastTs === "number" ? data.lastTs : data?.ts;
+    return typeof last === "number" && now() - last < RECOVERY_COOLDOWN_MS;
+  }
+
   // (c) already escalated → terminal, hand off to human, stop acting.
   if (data?.escalated === true) return true;
 
@@ -1535,5 +1734,52 @@ export function defaultForgetIntent(ticket, opts = {}) {
     return true;
   } catch {
     return false; // absent (ENOENT) or unremovable → nothing to forget
+  }
+}
+
+// defaultReadIntentAttempts — CTL-1157 Workstream B: the prior `attempts` count
+// from a ticket's recovery-intent ledger entry (0 when absent/malformed). Lets a
+// DEFER marker pin attempts so recordIntent does NOT auto-increment (a deferred
+// item must not burn the bounded-LLM budget). Never throws.
+export function defaultReadIntentAttempts(ticket, opts = {}) {
+  const orchDir = opts.orchDir ?? resolveOrchDir();
+  if (!orchDir || !ticket) return 0;
+  const p = recoveryIntentPath(orchDir, ticket);
+  try {
+    const data = JSON.parse(readFileSync(p, "utf8"));
+    return typeof data?.attempts === "number" ? data.attempts : 0;
+  } catch {
+    return 0;
+  }
+}
+
+// defaultClearIntentCooldown — CTL-1157 Workstream F2 (MUST-FIX 5 / H2). Reset a
+// ticket's cooldown window so a reliably-FAILING async (sdk) recovery launch
+// retries sooner instead of being silenced for the full 30-min window. Deletes
+// BOTH `lastTs` AND `ts` — defaultShouldSkipItem's cooldown branch falls back to
+// `ts` when `lastTs` is absent, so clearing only `lastTs` would STILL silence via
+// `ts`. PRESERVES `attempts` (the affirmed-sound storm bound: the attempts cap of
+// 2 still latches a persistently-failing launch after two retries, so the faster
+// retry is BOUNDED, not an immediate-retry storm) and `escalated` (the terminal
+// latch). Distinct from defaultForgetIntent, which deletes the whole entry
+// (resetting attempts to 0 → removes the storm bound). Idempotent; never throws.
+export function defaultClearIntentCooldown(ticket, opts = {}) {
+  const orchDir = opts.orchDir ?? resolveOrchDir();
+  if (!orchDir || !ticket) return false;
+  const p = recoveryIntentPath(orchDir, ticket);
+  let prior;
+  try {
+    prior = JSON.parse(readFileSync(p, "utf8"));
+  } catch {
+    return false; // absent / malformed → nothing to clear
+  }
+  if (!prior || typeof prior !== "object") return false;
+  delete prior.lastTs;
+  delete prior.ts;
+  try {
+    writeFileSync(p, JSON.stringify(prior));
+    return true;
+  } catch {
+    return false;
   }
 }

--- a/plugins/dev/scripts/execution-core/recovery-reasoning.mjs
+++ b/plugins/dev/scripts/execution-core/recovery-reasoning.mjs
@@ -1065,6 +1065,13 @@ function promoteNumericAttrs(type, details) {
     for (const [name, r] of Object.entries(details.invariants ?? {})) {
       num(`recovery.inv.${name}.failed`, r?.failed);
     }
+    // CTL-1157 SLICE 3 (OTEL turn-56): promote the three stuck-cohort failed-counts
+    // under the AGREED underscored top-level names so the Done-safety dashboards bind
+    // to a stable contract (not the camelCase recovery.inv.<key>.failed mirror above).
+    // These are the cohorts board-health was blind to before CTL-1157.
+    num("cohort_phantom_merged_pr", details.invariants?.phantomMergedPr?.failed);
+    num("cohort_orphaned_pr", details.invariants?.orphanedOpenPr?.failed);
+    num("cohort_frozen_needs_human", details.invariants?.frozenNeedsHuman?.failed);
   }
   return a;
 }

--- a/plugins/dev/scripts/execution-core/recovery-reasoning.mjs
+++ b/plugins/dev/scripts/execution-core/recovery-reasoning.mjs
@@ -1038,6 +1038,7 @@ function promoteNumericAttrs(type, details) {
     num("recovery.decisions.fix_seam", details.decisions?.fix_seam);
     num("recovery.decisions.fix_bounded_llm", details.decisions?.fix_bounded_llm);
     num("recovery.decisions.escalate", details.decisions?.escalate);
+    num("recovery.decisions.defer", details.decisions?.defer);
     num("recovery.actions.fixed", details.actions?.fixed);
     num("recovery.actions.fix_failed", details.actions?.fixFailed);
     num("recovery.actions.escalated", details.actions?.escalated);

--- a/plugins/dev/scripts/execution-core/recovery-reasoning.test.mjs
+++ b/plugins/dev/scripts/execution-core/recovery-reasoning.test.mjs
@@ -783,7 +783,7 @@ describe("buildRecoveryEnvelope numeric/enum promotion (CTL-1291)", () => {
       mode: "enforce",
       queueSize: 12,
       processed: 3,
-      decisions: { fix_seam: 1, fix_bounded_llm: 1, escalate: 1 },
+      decisions: { fix_seam: 1, fix_bounded_llm: 1, escalate: 1, defer: 4 },
       actions: { fixed: 2, fixFailed: 0, escalated: 1, deferred: 0, errors: 0 },
       ledgerSkipped: ["CTL-1", "CTL-2"],
       terminalSkipped: ["CTL-3"],
@@ -795,6 +795,9 @@ describe("buildRecoveryEnvelope numeric/enum promotion (CTL-1291)", () => {
     expect(a["recovery.decisions.fix_seam"]).toBe(1);
     expect(a["recovery.decisions.fix_bounded_llm"]).toBe(1);
     expect(a["recovery.decisions.escalate"]).toBe(1);
+    // CTL-1157 GROUP B: the defer counter must be promoted so defer volume is
+    // queryable after otel-forward (else it's left only in body.payload.details).
+    expect(a["recovery.decisions.defer"]).toBe(4);
     expect(a["recovery.actions.fixed"]).toBe(2);
     expect(a["recovery.actions.fix_failed"]).toBe(0);
     expect(a["recovery.actions.escalated"]).toBe(1);

--- a/plugins/dev/scripts/execution-core/recovery-reasoning.test.mjs
+++ b/plugins/dev/scripts/execution-core/recovery-reasoning.test.mjs
@@ -16,6 +16,7 @@ import {
   defaultForgetIntent,
   defaultInvokeRemediateCapped,
   defaultInvokeRecoveryPass,
+  defaultWriteEscalationSignal,
   RECOVERY_PASS_CYCLE_CAP,
   RECOVERY_PASS_PHASE,
   RECOVERY_MAX_ATTEMPTS,
@@ -527,6 +528,46 @@ describe("reasoningRecoveryPass", () => {
     expect(result.results[2].fix_class).toBe("human");
     expect(events.filter((e) => e.type === "recovery.would-fix").length).toBe(2);
     expect(events.filter((e) => e.type === "recovery.would-escalate").length).toBe(1);
+  });
+
+  // CTL-1157 F #5 (Codex round-4): a `defer` decision must NOT write the cooldown
+  // marker in SHADOW mode — defaultShouldSkipItem honors a defer marker in enforce too,
+  // so a shadow-written marker would silently suppress the ticket after an operator
+  // flips shadow→enforce (shadow mutating enforce scheduler state). Enforce still writes.
+  const deferClassifier = () => ({
+    decision: "defer",
+    fix_class: "board-health",
+    details: { reason: "untyped stuck item" },
+  });
+
+  test("defer in SHADOW emits would-defer but writes NO cooldown marker", () => {
+    const intents = [];
+    const events = [];
+    const result = reasoningRecoveryPass([baseItem], {
+      mode: "shadow",
+      classifyTicket: deferClassifier,
+      recordIntent: (ticket, intent) => intents.push({ ticket, intent }),
+      emitEvent: (e) => events.push(e),
+      postComment: () => {},
+    });
+    expect(result.results[0].decision).toBe("defer");
+    expect(intents).toEqual([]); // shadow mutates NO scheduler state
+    expect(events.some((e) => e.type === "recovery.would-defer")).toBe(true);
+  });
+
+  test("defer in ENFORCE writes the cooldown-only defer marker", () => {
+    const intents = [];
+    const events = [];
+    reasoningRecoveryPass([baseItem], {
+      mode: "enforce",
+      classifyTicket: deferClassifier,
+      recordIntent: (ticket, intent) => intents.push({ ticket, intent }),
+      emitEvent: (e) => events.push(e),
+      postComment: () => {},
+    });
+    expect(intents).toHaveLength(1);
+    expect(intents[0].intent).toMatchObject({ decision: "defer" });
+    expect(events.some((e) => e.type === "recovery.deferred")).toBe(true);
   });
 
   test("format diagnosis comment correctly", () => {
@@ -1588,5 +1629,31 @@ describe("reasoningRecoveryPass decision visibility (CTL-1287)", () => {
     expect(env.attributes["event.label"]).toBeNull();
     expect(env.severityText).toBe("INFO");
     expect(env.body.payload.details.queueSize).toBe(3);
+  });
+});
+
+// ─── CTL-1157 F #6 (Codex round-4): escalation signal must carry `ticket` ─────
+// signal-reader parseSignal keys off raw.ticket and status:"needs-human" is
+// non-terminal, so this fresh recovery-pass signal wins over the failed phase.
+// Without a ticket, readWorkerSignals() reports ticket:null and scheduler-recovery /
+// board-health consumers lose the escalated ticket after the first pass.
+describe("defaultWriteEscalationSignal (CTL-1157 F #6)", () => {
+  test("the written phase-recovery-pass.json carries the ticket", () => {
+    const orchDir = mkdtempSync(pathJoin(tmpdir(), "esc-"));
+    try {
+      defaultWriteEscalationSignal(
+        "CTL-42",
+        { escalation_type: "manual", problem: "stuck", call_to_action: "look" },
+        { orchDir },
+      );
+      const p = pathJoin(orchDir, "workers", "CTL-42", "phase-recovery-pass.json");
+      expect(existsSync(p)).toBe(true);
+      const signal = JSON.parse(readFileSync(p, "utf8"));
+      expect(signal.ticket).toBe("CTL-42"); // the fix: never null
+      expect(signal.status).toBe("needs-human");
+      expect(signal.explanation).toBeDefined();
+    } finally {
+      rmSync(orchDir, { recursive: true, force: true });
+    }
   });
 });

--- a/plugins/dev/scripts/execution-core/recovery-reasoning.test.mjs
+++ b/plugins/dev/scripts/execution-core/recovery-reasoning.test.mjs
@@ -898,6 +898,31 @@ describe("buildRecoveryEnvelope numeric/enum promotion (CTL-1291)", () => {
     expect(a["event.label"]).toBeNull();
   });
 
+  // CTL-1157 SLICE 3 (OTEL turn-56): the three stuck-cohort failed-counts promote
+  // under the AGREED underscored top-level names (queryable structured metadata, not
+  // body-buried), in ADDITION to the camelCase recovery.inv.<key>.failed mirror.
+  test("recovery.board-scan promotes the three cohort failed-counts under cohort_* names", () => {
+    const details = {
+      mode: "shadow",
+      invariantsFailed: 3,
+      gateDecision: "proceed",
+      gateReason: "3 invariant(s) flagged",
+      proposedTier1: 0, proposedTier2: 0, proposedTier3: 0,
+      invariants: {
+        phantomMergedPr: { ok: false, failed: 2, observable: true },
+        orphanedOpenPr: { ok: false, failed: 1, observable: true },
+        frozenNeedsHuman: { ok: false, failed: 4, observable: true },
+        needsHumanPile: { ok: true, failed: 0, observable: true },
+      },
+    };
+    const a = buildRecoveryEnvelope({ type: "recovery.board-scan", ticket: null, details }).attributes;
+    expect(a.cohort_phantom_merged_pr).toBe(2);
+    expect(a.cohort_orphaned_pr).toBe(1);
+    expect(a.cohort_frozen_needs_human).toBe(4);
+    // the camelCase per-invariant mirror still rides alongside (back-compat)
+    expect(a["recovery.inv.phantomMergedPr.failed"]).toBe(2);
+  });
+
   test("recovery.board-scan never promotes rosters/move arrays (cardinality)", () => {
     const details = {
       mode: "shadow",

--- a/plugins/dev/scripts/execution-core/registry.mjs
+++ b/plugins/dev/scripts/execution-core/registry.mjs
@@ -70,6 +70,27 @@ export function getProjectConfig(team) {
   return listProjects().find((p) => p.team === team) ?? null;
 }
 
+// ownerRepoFromRepoRoot — map a registry `repoRoot` filesystem path to the GitHub
+// "owner/repo" slug that filter_state.repo stores (the GitHub webhook's
+// `repository.full_name`, e.g. "coalesce-labs/catalyst"). The registry only knows
+// the on-disk repoRoot; our checkout convention nests it under a `/github/<owner>/
+// <repo>` segment ("/Users/x/code-repos/github/coalesce-labs/catalyst" →
+// "coalesce-labs/catalyst"), mirroring monitor-config's registry derivation and
+// doctor.mjs's _ownerRepoFromRepoRoot. Returns null when no such segment exists —
+// the documented TRUE residual: a repoRoot we cannot reconcile to an owner/repo
+// leaves the ticket's repo underivable, so board-health falls back to the
+// number-only ambiguous skip rather than guess. Pure string op (no IO).
+export function ownerRepoFromRepoRoot(repoRoot) {
+  if (typeof repoRoot !== "string") return null;
+  const i = repoRoot.indexOf("/github/");
+  if (i === -1) return null;
+  const seg = repoRoot
+    .slice(i + "/github/".length)
+    .split("/")
+    .filter(Boolean);
+  return seg.length >= 2 ? `${seg[0]}/${seg[1]}` : null;
+}
+
 // resolveEligibleQuery — normalize a registry entry into the runnable query the
 // monitor + linear-query layer needs. The entry's `team` lives at the top level
 // (the eligibleQuery object never carries it); this is the single place it is

--- a/plugins/dev/scripts/execution-core/registry.test.mjs
+++ b/plugins/dev/scripts/execution-core/registry.test.mjs
@@ -17,6 +17,7 @@ import {
   getProjectConfig,
   upsertProjectEntry,
   resolveEligibleQuery,
+  ownerRepoFromRepoRoot,
 } from "./registry.mjs";
 
 let catalystDir;
@@ -44,6 +45,29 @@ function writeRegistry(obj) {
     typeof obj === "string" ? obj : JSON.stringify(obj, null, 2)
   );
 }
+
+// ─── ownerRepoFromRepoRoot (CTL-1157, Codex #4) ──────────────────────────────
+describe("ownerRepoFromRepoRoot — repoRoot path → GitHub owner/repo", () => {
+  test("extracts owner/repo from a /github/<owner>/<repo> checkout path", () => {
+    expect(ownerRepoFromRepoRoot("/Users/x/code-repos/github/coalesce-labs/catalyst")).toBe(
+      "coalesce-labs/catalyst",
+    );
+    expect(ownerRepoFromRepoRoot("/Users/x/code-repos/github/groundworkapp/Adva")).toBe(
+      "groundworkapp/Adva",
+    );
+  });
+
+  test("ignores trailing path segments past owner/repo", () => {
+    expect(ownerRepoFromRepoRoot("/home/ci/github/org/repo/worktrees/wt-1")).toBe("org/repo");
+  });
+
+  test("returns null when there is no /github/ segment (the documented true residual)", () => {
+    expect(ownerRepoFromRepoRoot("/Users/x/projects/catalyst")).toBeNull();
+    expect(ownerRepoFromRepoRoot("/github/onlyowner")).toBeNull(); // owner without repo
+    expect(ownerRepoFromRepoRoot(null)).toBeNull();
+    expect(ownerRepoFromRepoRoot(undefined)).toBeNull();
+  });
+});
 
 describe("getRegistryPath", () => {
   test("resolves to <CATALYST_DIR>/execution-core/registry.json", () => {

--- a/plugins/dev/scripts/execution-core/scheduler.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.mjs
@@ -229,6 +229,12 @@ import {
   // tick's orchDir at the call site. Still entirely behind CATALYST_RECOVERY_PASS
   // (mode=off ⇒ the pass never runs), so no live behavior change until opt-in.
   defaultInvokeRecoveryPass as recoveryInvokeRecoveryPass,
+  // CTL-1157: the curated-escalation signal writer (Workstream C) + the defer
+  // attempts reader (Workstream B). Bound to the tick's orchDir at the call site
+  // (like recordIntent) — the daemon never sets CATALYST_ORCHESTRATOR_DIR on its
+  // own process, so the env-resolving defaults would otherwise no-op.
+  defaultWriteEscalationSignal as recoveryWriteEscalationSignal,
+  defaultReadIntentAttempts as recoveryReadIntentAttempts,
 } from "./recovery-reasoning.mjs";
 // CTL-1331: the async board-health delegate queue. countQueuedDelegates is the
 // slot reservation (a queued/claimed delegate has taken a slot its `claude --bg`
@@ -289,7 +295,7 @@ import { emitDrainedEvent as defaultEmitDrainedEvent } from "./drain-event.mjs";
 import { defaultCheckSequencing } from "./sequencing.mjs"; // CTL-537
 import { ownedBy, ownerForTicket } from "./hrw.mjs"; // CTL-850: HRW ownership filter (CTL-1191 also uses it for the diagnostician gate); ownerForTicket: CTL-1290 board-health stranded-node + enforce HRW gate
 import { boardHealthPass } from "./board-health.mjs"; // CTL-1290: the whole-board health delegate (shadow-first)
-import { getAllTicketDescriptors } from "../broker/broker-state.mjs"; // CTL-1290: board snapshot (reads only). bun:sqlite-backed — safe here: scheduler.mjs is daemon-only and NOT in the orch-monitor vite/UI graph (see MEMORY vite_config_bun_sqlite_trap).
+import { getAllTicketDescriptors, getAllPrStatuses } from "../broker/broker-state.mjs"; // CTL-1290: board snapshot (reads only). bun:sqlite-backed — safe here: scheduler.mjs is daemon-only and NOT in the orch-monitor vite/UI graph (see MEMORY vite_config_bun_sqlite_trap). CTL-1157: getAllPrStatuses = the filter_state PR-lifecycle reader for the phantom/orphaned-PR invariants.
 import { readReconcileHealthMarkers } from "./reconcile-health.mjs"; // CTL-1290: stranded-node reconcile signal
 import { claimDispatchSync } from "./cluster-claim-sync.mjs"; // CTL-850: cross-host claim soft-CAS
 // CTL-954: team estimation method — lazy-cached from Linear, used to expand
@@ -4015,6 +4021,14 @@ export function schedulerTick(
             shouldSkipItem: (ticket) => recoveryShouldSkipItem(ticket, { orchDir }),
             recordIntent: (ticket, intent) =>
               recoveryRecordIntent(ticket, intent, { orchDir }),
+            // CTL-1157 Workstream C: write the curated 6-field explanation signal
+            // on enforce escalates (bound to this tick's orchDir).
+            writeEscalationSignal: (ticket, payload) =>
+              recoveryWriteEscalationSignal(ticket, payload, { orchDir }),
+            // CTL-1157 Workstream B: read prior attempts so a defer marker pins
+            // them (no auto-increment, no budget burn).
+            readIntentAttempts: (ticket) =>
+              recoveryReadIntentAttempts(ticket, { orchDir }),
             invokeSeam: (ticket, seamId, brief) =>
               recoveryInvokeSeam(ticket, seamId, brief, { orchDir }),
             // CTL-1176 rung 3: dispatch the recovery-pass skill for the
@@ -4397,6 +4411,12 @@ export function schedulerTick(
           readEventRing: _boardHealth.readEventRing,
           ownerForTicket,
           getReconcileMarkers: _boardHealth.getReconcileMarkers,
+          // CTL-1157: thread the PR-status reader + the provably-dead host set.
+          // Both are daemon-bound (the binding below); a bare tick passes neither
+          // → empty-Map / empty-array defaults keep the new invariants
+          // observable:false and the holistic failover unreachable (shadow-safe).
+          getPrStatusMap: _boardHealth.getPrStatusMap,
+          deadHosts: _boardHealth.deadHosts ? _boardHealth.deadHosts(roster) : [],
           lastRunMs: _boardHealthLastRunMs,
           // emit defaults to defaultEmitEvent. CTL-1300: thread the optional `act`
           // seam — supplied ONLY by the daemon binding (the holistic recovery-pass
@@ -6488,31 +6508,52 @@ function runTick() {
         getBoard: () => getAllTicketDescriptors({ includeRemoved: false }),
         readEventRing: () => readBoardHealthEventTail(),
         getReconcileMarkers: () => readReconcileHealthMarkers({}),
-        act: ({ anchor, boardContext, decision }) => {
-          const deps = { orchDir: runningOpts.orchDir };
-          // Reuse the recovery cooldown ledger so we don't re-dispatch the same
-          // anchor every board-health interval (the cap counts only `.complete`).
-          if (recoveryShouldSkipItem(anchor, deps)) {
-            return { dispatched: false, reason: "recovery-cooldown", anchor };
-          }
-          const r = recoveryInvokeRecoveryPass(
-            anchor,
-            {
-              boardContext,
-              reason: `board-health: ${decision?.gate?.reason ?? "board anomaly"} — holistic recovery-pass delegate`,
-            },
-            deps,
-          );
-          // Start the cooldown window on a dispatch attempt (success OR failure) so
-          // a failing anchor isn't re-dispatched until the window elapses.
-          try {
-            recoveryRecordIntent(
-              anchor,
-              { type: "recovery-pass", decision: "fix", fix_class: "board-health", outcome: !!r?.dispatched, source: "board-health" },
+        // CTL-1157 (A11): the filter_state PR-status reader (phantom/orphaned-PR
+        // invariants) + the provably-dead host set for the HRW-safe holistic
+        // failover. computeSurvivingRoster already exists (scheduler.mjs) and
+        // returns the roster unchanged for roster ≤ 1 → empty dead set at N=1.
+        getPrStatusMap: () => getAllPrStatuses(),
+        deadHosts: (roster) => roster.filter((h) => !computeSurvivingRoster(roster).includes(h)),
+        // CTL-1157 (MUST-FIX 2): iterate the ordered candidate list and dispatch
+        // the FIRST actionable (non-cooldown/non-latched) candidate — instead of
+        // returning {dispatched:false} on the first skip, which wedged the whole
+        // holistic pass on one latched anchor and starved the rest of the cohort.
+        // The per-candidate cooldown gate + the recovery-pass intent ledger
+        // (decision:"fix" auto-increments attempts; cap 2 + 30-min cooldown) are
+        // preserved verbatim inside the loop — still exactly ONE dispatch per scan.
+        // CTL-1157 (F1): thread the executor-resolved dispatch fn (runningOpts.dispatch)
+        // through dispatchTicket so a delegate launches under the node's executor
+        // (sdk vs bg) instead of a hardcoded claude --bg. On a bg fleet this is a
+        // pure no-op (dispatchForExecutor("bg") === defaultDispatch).
+        act: ({ anchor, candidates = [], boardContext, decision }) => {
+          const deps = {
+            orchDir: runningOpts.orchDir,
+            dispatchTicket: (o, t, p) => dispatchTicket(o, t, p, { dispatch: runningOpts.dispatch }),
+          };
+          const ordered = candidates.length ? candidates : (anchor ? [anchor] : []);
+          for (const cand of ordered) {
+            // cooldown/attempts-latched → try the next candidate (MUST-FIX 2).
+            if (recoveryShouldSkipItem(cand, deps)) continue;
+            const r = recoveryInvokeRecoveryPass(
+              cand,
+              {
+                boardContext,
+                reason: `board-health: ${decision?.gate?.reason ?? "board anomaly"} — holistic recovery-pass delegate`,
+              },
               deps,
             );
-          } catch { /* ledger write is best-effort — never block the tick */ }
-          return r;
+            // Start the cooldown window on a dispatch attempt (success OR failure)
+            // so a failing anchor isn't re-dispatched until the window elapses.
+            try {
+              recoveryRecordIntent(
+                cand,
+                { type: "recovery-pass", decision: "fix", fix_class: "board-health", outcome: !!r?.dispatched, source: "board-health" },
+                deps,
+              );
+            } catch { /* ledger write is best-effort — never block the tick */ }
+            return r; // exactly ONE dispatch per scan
+          }
+          return { dispatched: false, reason: "all-candidates-cooldown" };
         },
       },
     });

--- a/plugins/dev/scripts/execution-core/scheduler.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.mjs
@@ -2402,14 +2402,19 @@ function terminalDoneOnce(
   // justify adding a real hard block later (held in reserve). The enumerator is
   // dep-injected: schedulerTick's permissive no-op default keeps bare unit ticks
   // silent; runTick arms the real defaultCheckOpenPrs in production. An unverifiable
-  // enumeration (gh failure) is no longer fatal — we proceed without an alarm.
+  // enumeration (a `gh` failure, or the ticket's repo could not be derived) is no
+  // longer FATAL — we still PROCEED (alarm-not-block) — but UNVERIFIABLE ≠ CLEAN: we
+  // could not confirm zero open PRs, so we surface it via the loud alarm rather than
+  // silently assuming an empty list.
   let openPrs = [];
+  let unverifiable = false;
   if (typeof checkOpenPrs === "function") {
     try {
       const facts = checkOpenPrs(ticket, {});
+      if (facts && facts.unverifiable) unverifiable = true;
       if (facts && Array.isArray(facts.prs)) openPrs = facts.prs;
     } catch {
-      openPrs = []; // unverifiable ⇒ proceed, no alarm (no longer fail-closed)
+      unverifiable = true; // could not confirm clean ⇒ surface (don't assume zero)
     }
   }
   try {
@@ -2450,18 +2455,20 @@ function terminalDoneOnce(
       } catch {
         /* observability must never break the sweep */
       }
-      // CTL-1157 (ALARM-NOT-BLOCK): the Done write LANDED. If the ticket still has
-      // ≥1 open PR, fire the loud alarm (best-effort; never throws, never aborts the
-      // tick). A clean Done (0 open PRs) emits nothing.
-      if (openPrs.length >= 1) {
+      // CTL-1157 (ALARM-NOT-BLOCK): the Done write LANDED. Fire the loud alarm when
+      // the ticket still has ≥1 open PR OR the open-PR check was UNVERIFIABLE (a Done
+      // that landed without confirming the board was clean is the same silent-Done
+      // risk this alarm exists to surface). Best-effort; never throws, never aborts
+      // the tick. A clean, CONFIRMED Done (0 open PRs, verifiable) emits nothing.
+      if (openPrs.length >= 1 || unverifiable) {
         try {
-          emitDoneWithOpenPr({ ticket, openPrs, by: "terminal-sweep" });
+          emitDoneWithOpenPr({ ticket, openPrs, by: "terminal-sweep", unverifiable });
         } catch {
           /* observability must never break the sweep */
         }
         log.warn(
-          { ticket, open_prs_count: openPrs.length },
-          "ctl-1157: terminal-sweep wrote Done while an open PR still exists — alarm emitted (recovery.done-applied-with-open-pr)"
+          { ticket, open_prs_count: openPrs.length, unverifiable },
+          "ctl-1157: terminal-sweep wrote Done while an open PR still exists or the check was unverifiable — alarm emitted (recovery.done-applied-with-open-pr)"
         );
       }
     }

--- a/plugins/dev/scripts/execution-core/scheduler.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.mjs
@@ -2438,38 +2438,48 @@ function terminalDoneOnce(
     // success so the once-semantics stay testable without a real result.
     if (res === undefined || res?.applied) {
       writeFileSync(marker, "");
-      // CTL-1157 SLICE 3 (Done-moves panel): the Done write LANDED — emit the broad
-      // recovery.done-applied on EVERY terminal-sweep Done so OTEL charts the move
-      // and watches the open_prs_at_done>0 red-line. This pure-code path has no agent
-      // to reason about PRs, so prs_closed/prs_kept are 0; open_prs_at_done carries
-      // the enumerated count (the red-line). Best-effort — never aborts the tick.
-      try {
-        emitDoneApplied({
-          ticket,
-          openPrsAtDone: openPrs.length,
-          prsClosed: 0,
-          prsKept: 0,
-          recoveryMode: "enforce", // a real terminal-sweep write is always enforce
-          by: "terminal-sweep",
-        });
-      } catch {
-        /* observability must never break the sweep */
-      }
-      // CTL-1157 (ALARM-NOT-BLOCK): the Done write LANDED. Fire the loud alarm when
-      // the ticket still has ≥1 open PR OR the open-PR check was UNVERIFIABLE (a Done
-      // that landed without confirming the board was clean is the same silent-Done
-      // risk this alarm exists to surface). Best-effort; never throws, never aborts
-      // the tick. A clean, CONFIRMED Done (0 open PRs, verifiable) emits nothing.
-      if (openPrs.length >= 1 || unverifiable) {
+      // CTL-1157 GROUP B (Done-event accuracy): only emit on a REAL Done write. An
+      // idempotent terminal SKIP (Linear already Done) returns {applied:true,
+      // action:"skipped"} and performs NO actual write — so emitting done-applied
+      // here would corrupt OTEL's before/after Done-move counts, and the open-PR
+      // alarm could fire for an already-Done ticket carrying a stale open PR. The
+      // marker still lands above (once-semantics). A test-stub `undefined` result is
+      // treated as a real write so the emit/alarm stay unit-testable.
+      const realDoneWrite = res === undefined || res?.action !== "skipped";
+      if (realDoneWrite) {
+        // CTL-1157 SLICE 3 (Done-moves panel): the Done write LANDED — emit the broad
+        // recovery.done-applied on EVERY terminal-sweep Done so OTEL charts the move
+        // and watches the open_prs_at_done>0 red-line. This pure-code path has no agent
+        // to reason about PRs, so prs_closed/prs_kept are 0; open_prs_at_done carries
+        // the enumerated count (the red-line). Best-effort — never aborts the tick.
         try {
-          emitDoneWithOpenPr({ ticket, openPrs, by: "terminal-sweep", unverifiable });
+          emitDoneApplied({
+            ticket,
+            openPrsAtDone: openPrs.length,
+            prsClosed: 0,
+            prsKept: 0,
+            recoveryMode: "enforce", // a real terminal-sweep write is always enforce
+            by: "terminal-sweep",
+          });
         } catch {
           /* observability must never break the sweep */
         }
-        log.warn(
-          { ticket, open_prs_count: openPrs.length, unverifiable },
-          "ctl-1157: terminal-sweep wrote Done while an open PR still exists or the check was unverifiable — alarm emitted (recovery.done-applied-with-open-pr)"
-        );
+        // CTL-1157 (ALARM-NOT-BLOCK): the Done write LANDED. Fire the loud alarm when
+        // the ticket still has ≥1 open PR OR the open-PR check was UNVERIFIABLE (a Done
+        // that landed without confirming the board was clean is the same silent-Done
+        // risk this alarm exists to surface). Best-effort; never throws, never aborts
+        // the tick. A clean, CONFIRMED Done (0 open PRs, verifiable) emits nothing.
+        if (openPrs.length >= 1 || unverifiable) {
+          try {
+            emitDoneWithOpenPr({ ticket, openPrs, by: "terminal-sweep", unverifiable });
+          } catch {
+            /* observability must never break the sweep */
+          }
+          log.warn(
+            { ticket, open_prs_count: openPrs.length, unverifiable },
+            "ctl-1157: terminal-sweep wrote Done while an open PR still exists or the check was unverifiable — alarm emitted (recovery.done-applied-with-open-pr)"
+          );
+        }
       }
     }
   } catch (err) {

--- a/plugins/dev/scripts/execution-core/scheduler.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.mjs
@@ -307,7 +307,7 @@ import { emitDrainedEvent as defaultEmitDrainedEvent } from "./drain-event.mjs";
 import { defaultCheckSequencing } from "./sequencing.mjs"; // CTL-537
 import { ownedBy, ownerForTicket } from "./hrw.mjs"; // CTL-850: HRW ownership filter (CTL-1191 also uses it for the diagnostician gate); ownerForTicket: CTL-1290 board-health stranded-node + enforce HRW gate
 import { boardHealthPass } from "./board-health.mjs"; // CTL-1290: the whole-board health delegate (shadow-first)
-import { getAllTicketDescriptors, getAllPrStatuses } from "../broker/broker-state.mjs"; // CTL-1290: board snapshot (reads only). bun:sqlite-backed — safe here: scheduler.mjs is daemon-only and NOT in the orch-monitor vite/UI graph (see MEMORY vite_config_bun_sqlite_trap). CTL-1157: getAllPrStatuses = the filter_state PR-lifecycle reader for the phantom/orphaned-PR invariants.
+import { getAllTicketDescriptors, getAllPrStatuses, openBrokerStateDb } from "../broker/broker-state.mjs"; // CTL-1290: board snapshot (reads only). bun:sqlite-backed — safe here: scheduler.mjs is daemon-only and NOT in the orch-monitor vite/UI graph (see MEMORY vite_config_bun_sqlite_trap). CTL-1157: getAllPrStatuses = the filter_state PR-lifecycle reader for the phantom/orphaned-PR invariants. openBrokerStateDb (CTL-1157 Codex round-6): the exec-core daemon must open the broker DB handle before these readers — ensure() throws otherwise and assembleBoardState swallows it, leaving the board/PR maps empty and the cohorts inert.
 import { readReconcileHealthMarkers } from "./reconcile-health.mjs"; // CTL-1290: stranded-node reconcile signal
 import { claimDispatchSync } from "./cluster-claim-sync.mjs"; // CTL-850: cross-host claim soft-CAS
 // CTL-954: team estimation method — lazy-cached from Linear, used to expand
@@ -6643,14 +6643,30 @@ function runTick() {
       // re-dispatch of one anchor to once per cooldown window, exactly like the
       // per-item path (scheduler.mjs recovery block).
       boardHealth: runningOpts.boardHealth ?? {
-        getBoard: () => getAllTicketDescriptors({ includeRemoved: false }),
+        // CTL-1157 (Codex round-6, P1): OPEN the broker DB handle before any reader.
+        // getAllTicketDescriptors + getAllPrStatuses both go through broker-state's
+        // ensure(), which THROWS when the module-level handle was never opened — and
+        // the exec-core daemon never opens it here (only the separate reconcile timer
+        // does, on a boot-order that isn't guaranteed before the first board-health
+        // tick). assembleBoardState swallows the throw, so the board AND the PR-status
+        // map silently come back empty and the phantom-merged / orphaned-open-PR cohorts
+        // this change adds are unobservable in BOTH shadow and enforce. openBrokerStateDb
+        // is idempotent (returns the existing handle) and read-safe under WAL, so calling
+        // it per reader is cheap and correct whether or not another opener ran first.
+        getBoard: () => {
+          try { openBrokerStateDb(); } catch { /* best-effort — empty board on open failure */ }
+          return getAllTicketDescriptors({ includeRemoved: false });
+        },
         readEventRing: () => readBoardHealthEventTail(),
         getReconcileMarkers: () => readReconcileHealthMarkers({}),
         // CTL-1157 (A11): the filter_state PR-status reader (phantom/orphaned-PR
         // invariants) + the provably-dead host set for the HRW-safe holistic
         // failover. computeSurvivingRoster already exists (scheduler.mjs) and
         // returns the roster unchanged for roster ≤ 1 → empty dead set at N=1.
-        getPrStatusMap: () => getAllPrStatuses(),
+        getPrStatusMap: () => {
+          try { openBrokerStateDb(); } catch { /* best-effort — empty PR map on open failure */ }
+          return getAllPrStatuses();
+        },
         // CTL-1157 (Codex #4): resolve a stuck ticket → its GitHub "owner/repo" so
         // the phantom/orphaned-PR cohorts disambiguate a cross-repo #-collision by
         // the ticket's repo (registry repoRoot → ownerRepoFromRepoRoot) instead of

--- a/plugins/dev/scripts/execution-core/scheduler.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.mjs
@@ -119,11 +119,15 @@ import { executeEscalations } from "./beliefs/escalate.mjs";
 // never per-tick / per-ticket — the gh subprocess only fires from inside prView
 // on the rare merged-zombie / drift path, not on construction.
 import { makePrView } from "./scan-adapters.mjs";
-// CTL-1157: the SAME deterministic open-PR Done gate the completion-declaration CLI
-// runs, so the terminal sweep's direct Done write (terminalDoneOnce) also refuses to
-// Done a ticket that still has an open/unmerged PR (e.g. a second non-standard-branch
-// PR). Permissive no-op default in schedulerTick; armed with this real impl by runTick.
+// CTL-1157 (ALARM-NOT-BLOCK): the open-PR ENUMERATOR the terminal sweep's direct
+// Done write (terminalDoneOnce) consults — NOT a refuse-gate (THE REVERSAL). It no
+// longer blocks the write; it supplies the FACTS used to decide whether to fire the
+// recovery.done-applied-with-open-pr alarm. Permissive no-op default in schedulerTick;
+// armed with this real impl by runTick.
 import { defaultCheckOpenPrs } from "./open-pr-gate.mjs";
+// CTL-1157 (ALARM-NOT-BLOCK): the loud `recovery.done-applied-with-open-pr` event
+// the pure-code terminal sweep emits when it lands a Done while an open PR exists.
+import { appendRecoveryDoneOpenPrEvent } from "./recovery-done-open-pr-event.mjs";
 import {
   countBackgroundAgents,
   getAgentsCached,
@@ -2367,7 +2371,7 @@ function terminalDoneOnce(
   ticket,
   writeStatus,
   emitStateWrite,
-  { multiHost = false, checkOpenPrs } = {}
+  { multiHost = false, checkOpenPrs, emitDoneWithOpenPr = appendRecoveryDoneOpenPrEvent } = {}
 ) {
   const marker = join(orchDir, "workers", ticket, ".terminal-done.applied");
   if (existsSync(marker)) return;
@@ -2378,32 +2382,24 @@ function terminalDoneOnce(
     );
     return;
   }
-  // CTL-1157 (UNIVERSAL gate): the terminal sweep writes Done DIRECTLY (it does not
-  // go through the gated `declare` CLI), so it must run the IDENTICAL open-PR check
-  // here — otherwise a second still-open PR on a non-standard branch (the pipeline's
-  // own PR is merged by the time teardown completes) would be falsely Done'd. The gate
-  // is dep-injected: schedulerTick's permissive no-op default keeps bare unit ticks
-  // unchanged; runTick arms the real, FAIL-CLOSED defaultCheckOpenPrs in production.
-  // On a refusal (open PR OR an unverifiable gh) we skip the write and DON'T stamp the
-  // once-marker → the sweep re-checks next tick and self-heals once the PR is resolved.
+  // CTL-1157 (ALARM-NOT-BLOCK — THE REVERSAL): the terminal sweep writes Done
+  // DIRECTLY (no agent to reason). The earlier behavior REFUSED the write when an
+  // open PR existed, which could wedge the board on a phantom/non-standard PR. The
+  // owner reversed that: this pure-code path now PROCEEDS — it never wedges, never
+  // mechanically escalates — but it CONSULTS the open-PR enumerator and, when it
+  // lands a Done while ≥1 OPEN PR still exists, emits the loud
+  // `recovery.done-applied-with-open-pr` alarm so we get the signal that would
+  // justify adding a real hard block later (held in reserve). The enumerator is
+  // dep-injected: schedulerTick's permissive no-op default keeps bare unit ticks
+  // silent; runTick arms the real defaultCheckOpenPrs in production. An unverifiable
+  // enumeration (gh failure) is no longer fatal — we proceed without an alarm.
+  let openPrs = [];
   if (typeof checkOpenPrs === "function") {
-    let gate;
     try {
-      gate = checkOpenPrs(ticket, {});
-    } catch (err) {
-      gate = { ok: false, reason: err?.message || String(err), prs: [] };
-    }
-    if (!gate || !gate.ok) {
-      const detail = gate?.reason
-        ? `open-PR set unverifiable (${gate.reason})`
-        : `${gate?.prs?.length ?? 0} open PR(s): ${(gate?.prs ?? [])
-            .map((p) => `#${p.number}`)
-            .join(", ")}`;
-      log.warn(
-        { ticket, detail },
-        "ctl-1157: terminal-sweep Done write REFUSED — ticket still has an open/unmerged PR; retrying next tick"
-      );
-      return;
+      const facts = checkOpenPrs(ticket, {});
+      if (facts && Array.isArray(facts.prs)) openPrs = facts.prs;
+    } catch {
+      openPrs = []; // unverifiable ⇒ proceed, no alarm (no longer fail-closed)
     }
   }
   try {
@@ -2427,6 +2423,20 @@ function terminalDoneOnce(
     // success so the once-semantics stay testable without a real result.
     if (res === undefined || res?.applied) {
       writeFileSync(marker, "");
+      // CTL-1157 (ALARM-NOT-BLOCK): the Done write LANDED. If the ticket still has
+      // ≥1 open PR, fire the loud alarm (best-effort; never throws, never aborts the
+      // tick). A clean Done (0 open PRs) emits nothing.
+      if (openPrs.length >= 1) {
+        try {
+          emitDoneWithOpenPr({ ticket, openPrs, by: "terminal-sweep" });
+        } catch {
+          /* observability must never break the sweep */
+        }
+        log.warn(
+          { ticket, open_prs_count: openPrs.length },
+          "ctl-1157: terminal-sweep wrote Done while an open PR still exists — alarm emitted (recovery.done-applied-with-open-pr)"
+        );
+      }
     }
   } catch (err) {
     log.warn(
@@ -3028,14 +3038,17 @@ export function schedulerTick(
     // runningOpts.prAdapter → runTick, so both paths fire live. Injectable so
     // tests can exercise the pr-merged branch without shelling out to `gh`.
     prAdapter = undefined,
-    // CTL-1157: the open-PR Done gate for the terminal sweep's DIRECT Done write
-    // (terminalDoneOnce). The DEFAULT here is a deliberately PERMISSIVE no-op (always
-    // ok) so a bare unit tick never shells out to `gh`/`catalyst-linear` and keeps its
-    // existing terminal-Done behavior. PRODUCTION wires the real, FAIL-CLOSED
-    // defaultCheckOpenPrs via startScheduler → runningOpts.checkOpenPrs → runTick, so
-    // a ticket with an open/unmerged PR is never Done'd by the sweep. Injectable so the
-    // gate-refusal branch is testable without shelling out.
+    // CTL-1157 (ALARM-NOT-BLOCK): the open-PR ENUMERATOR the terminal sweep's DIRECT
+    // Done write (terminalDoneOnce) consults — it no longer refuses the write, it
+    // only decides whether to fire the recovery.done-applied-with-open-pr alarm. The
+    // DEFAULT here is a deliberately PERMISSIVE no-op (zero open PRs) so a bare unit
+    // tick never shells out to `gh`/`catalyst-linear` and stays silent. PRODUCTION
+    // wires the real defaultCheckOpenPrs via startScheduler → runningOpts.checkOpenPrs
+    // → runTick. Injectable so the alarm branch is testable without shelling out.
     checkOpenPrs = () => ({ ok: true, prs: [] }),
+    // CTL-1157: the alarm emitter for the terminal sweep (default = real append to
+    // the unified event log). Injectable so tests record the alarm without writing.
+    emitDoneWithOpenPr = appendRecoveryDoneOpenPrEvent,
     // CTL-671: phantom worker-dir validity sweep seams. classifyResolution is
     // the 3-valued Linear probe (exists|not-found|unknown); isBgJobAlive maps a
     // dead worker's bg_job_id to a live `claude agents` session. The DEFAULTS
@@ -5703,7 +5716,11 @@ export function schedulerTick(
       // CTL-863: thread multiHost so terminalDoneOnce's internal fence guard
       // suppresses a post-takeover zombie's terminal Done write on a multi-host
       // cluster (no-op single-host: multiHost=false → guard always passes).
-      terminalDoneOnce(orchDir, ticket, writeStatus, emitStateWrite, { multiHost, checkOpenPrs });
+      terminalDoneOnce(orchDir, ticket, writeStatus, emitStateWrite, {
+        multiHost,
+        checkOpenPrs,
+        emitDoneWithOpenPr,
+      });
       // CTL-646: terminal Done unconditionally clears needs-human (belt + teardown path).
       // CTL-703: worktree teardown is now the `teardown` FSM phase (teardownWorktreeOnce
       // removed) — only the label clear remains inline here.
@@ -6306,10 +6323,11 @@ function runTick() {
       // A test may inject its own via startScheduler({ prAdapter }); production
       // gets the real makePrView-backed adapter.
       prAdapter: runningOpts.prAdapter,
-      // CTL-1157: arm the real, FAIL-CLOSED open-PR Done gate in production so the
-      // terminal sweep's direct Done write refuses a ticket with an open/unmerged PR.
-      // A test may inject its own via startScheduler({ checkOpenPrs }); a bare unit
-      // tick (no runningOpts override) gets schedulerTick's permissive no-op default.
+      // CTL-1157 (ALARM-NOT-BLOCK): arm the real open-PR ENUMERATOR in production so
+      // the terminal sweep can fire the recovery.done-applied-with-open-pr alarm when
+      // it lands a Done while a PR is still open (it no longer refuses the write). A
+      // test may inject its own via startScheduler({ checkOpenPrs }); a bare unit tick
+      // (no runningOpts override) gets schedulerTick's permissive no-op default.
       checkOpenPrs: runningOpts.checkOpenPrs ?? defaultCheckOpenPrs,
       // CTL-671: phantom-sweep seams threaded from startScheduler. Undefined for
       // a direct startScheduler caller that did not opt in (unit tests) →
@@ -6737,9 +6755,9 @@ export function startScheduler({
     }),
   },
   preflight = preflightWorkspaceLabels, // CTL-585
-  // CTL-1157: optional override for the terminal-sweep open-PR Done gate.
-  // Undefined → runTick arms the real defaultCheckOpenPrs (production); a test may
-  // inject its own to exercise the gate-refusal branch hermetically.
+  // CTL-1157 (ALARM-NOT-BLOCK): optional override for the terminal-sweep open-PR
+  // enumerator. Undefined → runTick arms the real defaultCheckOpenPrs (production);
+  // a test may inject its own to exercise the alarm branch hermetically.
   checkOpenPrs,
   // CTL-671: phantom-sweep seams. Undefined → schedulerTick's safe no-op
   // defaults (hermetic for unit tests that call startScheduler directly). The

--- a/plugins/dev/scripts/execution-core/scheduler.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.mjs
@@ -4153,6 +4153,11 @@ export function schedulerTick(
                 // time too, but this avoids the wasted enqueue→claim→supersede and a
                 // transient slot reservation.
                 isBgJobAlive: (id) => isBgJobAlive(id, { agents: getAgents().agents }),
+                // CTL-1157 (GROUP-3 #2): make the enqueue-time worker-live probe
+                // sdk-aware so a dispatched|running sdk recovery-pass worker (no
+                // bg_job_id) dedups a re-enqueue instead of double-dispatching. Inert
+                // under bg/oneshot-legacy (executor stays null → byte-identical).
+                executor: dispatchMode === "sdk" ? "sdk" : null,
               }),
           });
           if (rResult.processed > 0) {
@@ -4457,7 +4462,12 @@ export function schedulerTick(
   // only ever LOWERS freeSlots (conservative-only, §3b); with an empty queue both
   // calls return 0, so occupiedCount === liveCount (Phase A inert: zero change).
   try {
-    gcDelegateIntents(orchDir, now());
+    // CTL-1157 (GROUP-3 #2): pass the resolved executor so the GC keeps a launched
+    // sdk delegate intent (in-process query(), no bg_job_id) LIVE instead of dropping
+    // it as a dead bg job — dropping it would free the reservation/existence guard and
+    // let the next scan re-dispatch the same in-flight ticket. Inert under bg (executor
+    // null → the no-bg_job_id launched intent still drops exactly as today).
+    gcDelegateIntents(orchDir, now(), { executor: dispatchMode === "sdk" ? "sdk" : null });
   } catch {
     /* GC is best-effort — never block the tick */
   }
@@ -6662,30 +6672,14 @@ function runTick() {
             orchDir: runningOpts.orchDir,
             dispatchTicket: (o, t, p) => dispatchTicket(o, t, p, { dispatch: runningOpts.dispatch }),
           };
-          const ordered = candidates.length ? candidates : (anchor ? [anchor] : []);
-          for (const cand of ordered) {
-            // cooldown/attempts-latched → try the next candidate (MUST-FIX 2).
-            if (recoveryShouldSkipItem(cand, deps)) continue;
-            const r = recoveryInvokeRecoveryPass(
-              cand,
-              {
-                boardContext,
-                reason: `board-health: ${decision?.gate?.reason ?? "board anomaly"} — holistic recovery-pass delegate`,
-              },
-              deps,
-            );
-            // Start the cooldown window on a dispatch attempt (success OR failure)
-            // so a failing anchor isn't re-dispatched until the window elapses.
-            try {
-              recoveryRecordIntent(
-                cand,
-                { type: "recovery-pass", decision: "fix", fix_class: "board-health", outcome: !!r?.dispatched, source: "board-health" },
-                deps,
-              );
-            } catch { /* ledger write is best-effort — never block the tick */ }
-            return r; // exactly ONE dispatch per scan
-          }
-          return { dispatched: false, reason: "all-candidates-cooldown" };
+          return holisticBoardHealthAct(
+            { anchor, candidates, boardContext, decision },
+            {
+              shouldSkipItem: (cand) => recoveryShouldSkipItem(cand, deps),
+              invokeRecoveryPass: (cand, ctx) => recoveryInvokeRecoveryPass(cand, ctx, deps),
+              recordIntent: (cand, intent) => recoveryRecordIntent(cand, intent, deps),
+            },
+          );
         },
       },
     });
@@ -6760,6 +6754,49 @@ function runTick() {
 function scheduleDebouncedTick(debounceMs) {
   clearTimeout(debounceTimer);
   debounceTimer = setTimeout(runTick, debounceMs);
+}
+
+// holisticBoardHealthAct — CTL-1157 (MUST-FIX 2 + GROUP-3 #3): the board-health
+// holistic `act` loop, extracted pure so it is unit-testable (the daemon wiring
+// binds the real recovery seams around it). Walk the ordered candidate cohort and
+// perform EXACTLY ONE real recovery-pass dispatch per scan. A candidate is SKIPPED
+// (continue to the next) when EITHER:
+//   (a) the intent-LEDGER cooldown/attempts gate latches it (shouldSkipItem), OR
+//   (b) the invoke RESULT is a NON-dispatch — recovery-pass-cycle-cap-exhausted /
+//       latched / no-op. The ledger gate (a) does NOT see the event-counted recovery
+//       cycle cap, so a candidate can pass (a) yet not dispatch; returning that result
+//       would wedge the whole pass on one cap-exhausted anchor and starve the cohort.
+// recordIntent starts the cooldown window on EVERY real invoke attempt (success or
+// non-dispatch) so a chronically-flagged anchor isn't re-hammered next scan. Only a
+// REAL dispatch (r.dispatched) ends the scan. Returns the dispatching candidate's
+// result, or {dispatched:false, reason:"all-candidates-cooldown"} when none dispatched.
+export function holisticBoardHealthAct(
+  { anchor = null, candidates = [], boardContext, decision } = {},
+  { shouldSkipItem, invokeRecoveryPass, recordIntent } = {}
+) {
+  const ordered = candidates.length ? candidates : (anchor ? [anchor] : []);
+  for (const cand of ordered) {
+    // (a) cooldown/attempts-latched → try the next candidate (MUST-FIX 2).
+    if (shouldSkipItem(cand)) continue;
+    const r = invokeRecoveryPass(cand, {
+      boardContext,
+      reason: `board-health: ${decision?.gate?.reason ?? "board anomaly"} — holistic recovery-pass delegate`,
+    });
+    // Start the cooldown window on a dispatch attempt (success OR failure).
+    try {
+      recordIntent(cand, {
+        type: "recovery-pass",
+        decision: "fix",
+        fix_class: "board-health",
+        outcome: !!r?.dispatched,
+        source: "board-health",
+      });
+    } catch { /* ledger write is best-effort — never block the tick */ }
+    // (b) a NON-dispatch RESULT is a SKIP, not this scan's dispatch — CONTINUE.
+    if (!r?.dispatched) continue;
+    return r; // exactly ONE real dispatch per scan
+  }
+  return { dispatched: false, reason: "all-candidates-cooldown" };
 }
 
 // startScheduler — immediate authoritative tick, arm the periodic timer, then

--- a/plugins/dev/scripts/execution-core/scheduler.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.mjs
@@ -127,7 +127,10 @@ import { makePrView } from "./scan-adapters.mjs";
 import { defaultCheckOpenPrs } from "./open-pr-gate.mjs";
 // CTL-1157 (ALARM-NOT-BLOCK): the loud `recovery.done-applied-with-open-pr` event
 // the pure-code terminal sweep emits when it lands a Done while an open PR exists.
-import { appendRecoveryDoneOpenPrEvent } from "./recovery-done-open-pr-event.mjs";
+import {
+  appendRecoveryDoneOpenPrEvent,
+  appendRecoveryDoneAppliedEvent,
+} from "./recovery-done-open-pr-event.mjs";
 import {
   countBackgroundAgents,
   getAgentsCached,
@@ -2371,7 +2374,14 @@ function terminalDoneOnce(
   ticket,
   writeStatus,
   emitStateWrite,
-  { multiHost = false, checkOpenPrs, emitDoneWithOpenPr = appendRecoveryDoneOpenPrEvent } = {}
+  {
+    multiHost = false,
+    checkOpenPrs,
+    emitDoneWithOpenPr = appendRecoveryDoneOpenPrEvent,
+    // CTL-1157 SLICE 3: the broad "Done-moves" emitter — fires on EVERY confirmed
+    // terminal-sweep Done (not just the open-PR subset). Injectable for tests.
+    emitDoneApplied = appendRecoveryDoneAppliedEvent,
+  } = {}
 ) {
   const marker = join(orchDir, "workers", ticket, ".terminal-done.applied");
   if (existsSync(marker)) return;
@@ -2423,6 +2433,23 @@ function terminalDoneOnce(
     // success so the once-semantics stay testable without a real result.
     if (res === undefined || res?.applied) {
       writeFileSync(marker, "");
+      // CTL-1157 SLICE 3 (Done-moves panel): the Done write LANDED — emit the broad
+      // recovery.done-applied on EVERY terminal-sweep Done so OTEL charts the move
+      // and watches the open_prs_at_done>0 red-line. This pure-code path has no agent
+      // to reason about PRs, so prs_closed/prs_kept are 0; open_prs_at_done carries
+      // the enumerated count (the red-line). Best-effort — never aborts the tick.
+      try {
+        emitDoneApplied({
+          ticket,
+          openPrsAtDone: openPrs.length,
+          prsClosed: 0,
+          prsKept: 0,
+          recoveryMode: "enforce", // a real terminal-sweep write is always enforce
+          by: "terminal-sweep",
+        });
+      } catch {
+        /* observability must never break the sweep */
+      }
       // CTL-1157 (ALARM-NOT-BLOCK): the Done write LANDED. If the ticket still has
       // ≥1 open PR, fire the loud alarm (best-effort; never throws, never aborts the
       // tick). A clean Done (0 open PRs) emits nothing.
@@ -3049,6 +3076,9 @@ export function schedulerTick(
     // CTL-1157: the alarm emitter for the terminal sweep (default = real append to
     // the unified event log). Injectable so tests record the alarm without writing.
     emitDoneWithOpenPr = appendRecoveryDoneOpenPrEvent,
+    // CTL-1157 SLICE 3: the broad Done-moves emitter for the terminal sweep (fires on
+    // EVERY confirmed Done, not just the open-PR subset). Injectable for tests.
+    emitDoneApplied = appendRecoveryDoneAppliedEvent,
     // CTL-671: phantom worker-dir validity sweep seams. classifyResolution is
     // the 3-valued Linear probe (exists|not-found|unknown); isBgJobAlive maps a
     // dead worker's bg_job_id to a live `claude agents` session. The DEFAULTS
@@ -5720,6 +5750,7 @@ export function schedulerTick(
         multiHost,
         checkOpenPrs,
         emitDoneWithOpenPr,
+        emitDoneApplied,
       });
       // CTL-646: terminal Done unconditionally clears needs-human (belt + teardown path).
       // CTL-703: worktree teardown is now the `teardown` FSM phase (teardownWorktreeOnce

--- a/plugins/dev/scripts/execution-core/scheduler.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.mjs
@@ -4491,7 +4491,10 @@ export function schedulerTick(
       /* best-effort — never block the tick on a signal-scan failure */
     }
   }
-  const occupiedCount = liveCount + queuedDelegates + sdkInflight;
+  // `let` (not const): a successful board-health enforce dispatch below reserves a
+  // slot by incrementing this AFTER the sample — see the board-health pass (CTL-1157
+  // Codex round-5). Every other read of occupiedCount is downstream of that point.
+  let occupiedCount = liveCount + queuedDelegates + sdkInflight;
 
   tick?.lap("liveness-read");
 
@@ -4542,6 +4545,15 @@ export function schedulerTick(
           now,
         });
         if (_bhResult?.ran) _boardHealthLastRunMs = _bhResult.ranAtMs;
+        // CTL-1157 (Codex round-5): a successful board-health ENFORCE dispatch enqueued
+        // a recovery-pass delegate intent AFTER occupiedCount was sampled (queuedDelegates
+        // is now stale by one). RESERVE that slot here so the same tick's resume + new-work
+        // admission (every computeFreeSlots(maxParallel, occupiedCount) below) cannot fill
+        // the slot board-health just claimed — otherwise at maxParallel=1 with one free
+        // slot the tick launches board-health's delegate AND promotes/admits another worker,
+        // overrunning the limit. holisticBoardHealthAct dispatches exactly ONE per scan, so
+        // reserve one. shadow/off never reach `act` → dispatched is never true → no reserve.
+        if (_bhResult?.act?.dispatched === true) occupiedCount += 1;
       } catch (err) {
         log.warn?.(
           { step: "board-health", err: err.message },

--- a/plugins/dev/scripts/execution-core/scheduler.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.mjs
@@ -119,6 +119,11 @@ import { executeEscalations } from "./beliefs/escalate.mjs";
 // never per-tick / per-ticket — the gh subprocess only fires from inside prView
 // on the rare merged-zombie / drift path, not on construction.
 import { makePrView } from "./scan-adapters.mjs";
+// CTL-1157: the SAME deterministic open-PR Done gate the completion-declaration CLI
+// runs, so the terminal sweep's direct Done write (terminalDoneOnce) also refuses to
+// Done a ticket that still has an open/unmerged PR (e.g. a second non-standard-branch
+// PR). Permissive no-op default in schedulerTick; armed with this real impl by runTick.
+import { defaultCheckOpenPrs } from "./open-pr-gate.mjs";
 import {
   countBackgroundAgents,
   getAgentsCached,
@@ -2362,7 +2367,7 @@ function terminalDoneOnce(
   ticket,
   writeStatus,
   emitStateWrite,
-  { multiHost = false } = {}
+  { multiHost = false, checkOpenPrs } = {}
 ) {
   const marker = join(orchDir, "workers", ticket, ".terminal-done.applied");
   if (existsSync(marker)) return;
@@ -2372,6 +2377,34 @@ function terminalDoneOnce(
       "ctl-863: stale fence — suppressing terminalDoneOnce write (zombie guard)"
     );
     return;
+  }
+  // CTL-1157 (UNIVERSAL gate): the terminal sweep writes Done DIRECTLY (it does not
+  // go through the gated `declare` CLI), so it must run the IDENTICAL open-PR check
+  // here — otherwise a second still-open PR on a non-standard branch (the pipeline's
+  // own PR is merged by the time teardown completes) would be falsely Done'd. The gate
+  // is dep-injected: schedulerTick's permissive no-op default keeps bare unit ticks
+  // unchanged; runTick arms the real, FAIL-CLOSED defaultCheckOpenPrs in production.
+  // On a refusal (open PR OR an unverifiable gh) we skip the write and DON'T stamp the
+  // once-marker → the sweep re-checks next tick and self-heals once the PR is resolved.
+  if (typeof checkOpenPrs === "function") {
+    let gate;
+    try {
+      gate = checkOpenPrs(ticket, {});
+    } catch (err) {
+      gate = { ok: false, reason: err?.message || String(err), prs: [] };
+    }
+    if (!gate || !gate.ok) {
+      const detail = gate?.reason
+        ? `open-PR set unverifiable (${gate.reason})`
+        : `${gate?.prs?.length ?? 0} open PR(s): ${(gate?.prs ?? [])
+            .map((p) => `#${p.number}`)
+            .join(", ")}`;
+      log.warn(
+        { ticket, detail },
+        "ctl-1157: terminal-sweep Done write REFUSED — ticket still has an open/unmerged PR; retrying next tick"
+      );
+      return;
+    }
   }
   try {
     const res = writeStatus.applyTerminalDone({ ticket });
@@ -2995,6 +3028,14 @@ export function schedulerTick(
     // runningOpts.prAdapter → runTick, so both paths fire live. Injectable so
     // tests can exercise the pr-merged branch without shelling out to `gh`.
     prAdapter = undefined,
+    // CTL-1157: the open-PR Done gate for the terminal sweep's DIRECT Done write
+    // (terminalDoneOnce). The DEFAULT here is a deliberately PERMISSIVE no-op (always
+    // ok) so a bare unit tick never shells out to `gh`/`catalyst-linear` and keeps its
+    // existing terminal-Done behavior. PRODUCTION wires the real, FAIL-CLOSED
+    // defaultCheckOpenPrs via startScheduler → runningOpts.checkOpenPrs → runTick, so
+    // a ticket with an open/unmerged PR is never Done'd by the sweep. Injectable so the
+    // gate-refusal branch is testable without shelling out.
+    checkOpenPrs = () => ({ ok: true, prs: [] }),
     // CTL-671: phantom worker-dir validity sweep seams. classifyResolution is
     // the 3-valued Linear probe (exists|not-found|unknown); isBgJobAlive maps a
     // dead worker's bg_job_id to a live `claude agents` session. The DEFAULTS
@@ -5662,7 +5703,7 @@ export function schedulerTick(
       // CTL-863: thread multiHost so terminalDoneOnce's internal fence guard
       // suppresses a post-takeover zombie's terminal Done write on a multi-host
       // cluster (no-op single-host: multiHost=false → guard always passes).
-      terminalDoneOnce(orchDir, ticket, writeStatus, emitStateWrite, { multiHost });
+      terminalDoneOnce(orchDir, ticket, writeStatus, emitStateWrite, { multiHost, checkOpenPrs });
       // CTL-646: terminal Done unconditionally clears needs-human (belt + teardown path).
       // CTL-703: worktree teardown is now the `teardown` FSM phase (teardownWorktreeOnce
       // removed) — only the label clear remains inline here.
@@ -6265,6 +6306,11 @@ function runTick() {
       // A test may inject its own via startScheduler({ prAdapter }); production
       // gets the real makePrView-backed adapter.
       prAdapter: runningOpts.prAdapter,
+      // CTL-1157: arm the real, FAIL-CLOSED open-PR Done gate in production so the
+      // terminal sweep's direct Done write refuses a ticket with an open/unmerged PR.
+      // A test may inject its own via startScheduler({ checkOpenPrs }); a bare unit
+      // tick (no runningOpts override) gets schedulerTick's permissive no-op default.
+      checkOpenPrs: runningOpts.checkOpenPrs ?? defaultCheckOpenPrs,
       // CTL-671: phantom-sweep seams threaded from startScheduler. Undefined for
       // a direct startScheduler caller that did not opt in (unit tests) →
       // schedulerTick's SAFE no-op defaults apply, so a bare daemon tick never
@@ -6691,6 +6737,10 @@ export function startScheduler({
     }),
   },
   preflight = preflightWorkspaceLabels, // CTL-585
+  // CTL-1157: optional override for the terminal-sweep open-PR Done gate.
+  // Undefined → runTick arms the real defaultCheckOpenPrs (production); a test may
+  // inject its own to exercise the gate-refusal branch hermetically.
+  checkOpenPrs,
   // CTL-671: phantom-sweep seams. Undefined → schedulerTick's safe no-op
   // defaults (hermetic for unit tests that call startScheduler directly). The
   // real daemon (startDaemon) and the standalone main() pass the real impls.
@@ -6730,6 +6780,7 @@ export function startScheduler({
     fetchBatch, // CTL-755/784: optional admission-gate batch hydration seam
     appendPhaseAdvanceHeldEvent, // CTL-755: optional held-indicator emit seam
     prAdapter, // CTL-642/758: live PR-merged adapter (built once above), threaded per-tick
+    checkOpenPrs, // CTL-1157: optional terminal-sweep open-PR gate override (runTick arms the real one)
     classifyResolution, // CTL-671: optional phantom-sweep Linear-probe seam
     isBgJobAlive, // CTL-671: optional phantom-sweep bg-liveness seam
     botUserIds, // CTL-781: respect-assignment predicate membership set

--- a/plugins/dev/scripts/execution-core/scheduler.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.mjs
@@ -76,7 +76,7 @@ import {
   readTicketLabels,
 } from "./linear-query.mjs";
 import { gatewayLabelsHit } from "./gateway-read.mjs"; // CTL-1079
-import { getProjectConfig, listProjects } from "./registry.mjs";
+import { getProjectConfig, listProjects, ownerRepoFromRepoRoot } from "./registry.mjs"; // CTL-1157: ownerRepoFromRepoRoot reconciles registry repoRoot → GitHub owner/repo for board-health's composite (repo,number) PR-status lookup
 // CTL-703: worktree teardown is now handled by the dedicated phase-teardown
 // phase agent (the 10th pipeline phase), not the scheduler's terminal sweep.
 // The gatedTeardownWorktree import is removed; the teardown phase agent
@@ -4511,6 +4511,10 @@ export function schedulerTick(
           capacity: { maxParallel, liveCount, freeSlots: computeFreeSlots(maxParallel, occupiedCount) },
           readEventRing: _boardHealth.readEventRing,
           ownerForTicket,
+          // CTL-1157 (Codex #4): ticket→owner/repo resolver for the composite
+          // (repo, number) PR-status lookup. Daemon-bound below; a bare tick
+          // passes none → null → number-only fallback (N=1 byte-identical).
+          repoForTicket: _boardHealth.repoForTicket,
           getReconcileMarkers: _boardHealth.getReconcileMarkers,
           // CTL-1157: thread the PR-status reader + the provably-dead host set.
           // Both are daemon-bound (the binding below); a bare tick passes neither
@@ -6625,6 +6629,22 @@ function runTick() {
         // failover. computeSurvivingRoster already exists (scheduler.mjs) and
         // returns the roster unchanged for roster ≤ 1 → empty dead set at N=1.
         getPrStatusMap: () => getAllPrStatuses(),
+        // CTL-1157 (Codex #4): resolve a stuck ticket → its GitHub "owner/repo" so
+        // the phantom/orphaned-PR cohorts disambiguate a cross-repo #-collision by
+        // the ticket's repo (registry repoRoot → ownerRepoFromRepoRoot) instead of
+        // skipping it and hiding a genuine orphaned open PR. NEVER bare linearis
+        // (QUOTA rule): teamOf + the local registry only. Null when the team/
+        // repoRoot is unknown or the path carries no /github/<owner>/<repo> segment
+        // (the documented true residual → number-only/ambiguous fallback).
+        repoForTicket: (ticket) => {
+          try {
+            const team = teamOf(ticket);
+            if (!team) return null;
+            return ownerRepoFromRepoRoot(getProjectConfig(team)?.repoRoot ?? null);
+          } catch {
+            return null;
+          }
+        },
         deadHosts: (roster) => roster.filter((h) => !computeSurvivingRoster(roster).includes(h)),
         // CTL-1157 (MUST-FIX 2): iterate the ordered candidate list and dispatch
         // the FIRST actionable (non-cooldown/non-latched) candidate — instead of

--- a/plugins/dev/scripts/execution-core/scheduler.test.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.test.mjs
@@ -5567,6 +5567,60 @@ describe("schedulerTick — terminal-Done once-marker (CTL-597)", () => {
     expect(existsSync(join(orchDir, "workers", "CTL-26", ".terminal-done.applied"))).toBe(true);
     expect(alarms).toEqual([]); // clean Done is silent
   });
+
+  // CTL-1157 GROUP B (Done-event accuracy): an idempotent terminal SKIP (Linear
+  // already Done) returns {applied:true, action:"skipped"} and performs NO actual
+  // write. Emitting recovery.done-applied for it would corrupt OTEL's Done-move
+  // counts, and the open-PR alarm could fire for an already-Done ticket carrying a
+  // stale open PR. The marker still lands (once-semantics), but NEITHER emit fires.
+  test("CTL-1157: an idempotent SKIP (action:'skipped') stamps the marker but emits NO done-applied and NO alarm — even with a stale open PR", () => {
+    writeSignal("CTL-28", "teardown", "done");
+    writeFileSync(join(orchDir, "state.json"), JSON.stringify({ maxParallel: 1 }));
+    const writeStatus = {
+      ...terminalNoWrites(),
+      // already-Done in Linear → no real write, just the idempotent skip outcome.
+      applyTerminalDone: () => ({ applied: true, action: "skipped" }),
+    };
+    // A stale open PR is present — would have alarmed on a REAL Done write.
+    const checkOpenPrs = () => ({ ok: false, prs: [{ number: 999, state: "OPEN" }] });
+    const doneApplied = [];
+    const alarms = [];
+    schedulerTick(orchDir, {
+      readEligible: () => [],
+      dispatch: fakeDispatch(),
+      writeStatus,
+      checkOpenPrs,
+      emitDoneApplied: (ev) => doneApplied.push(ev),
+      emitDoneWithOpenPr: (ev) => alarms.push(ev),
+    });
+    // Once-semantics: the marker still lands on the confirming tick.
+    expect(existsSync(join(orchDir, "workers", "CTL-28", ".terminal-done.applied"))).toBe(true);
+    // But a SKIP is not a "move" — no done-applied, no open-PR alarm.
+    expect(doneApplied).toEqual([]);
+    expect(alarms).toEqual([]);
+  });
+
+  // CTL-1157 GROUP B: a REAL Done write (no action:"skipped") still emits the broad
+  // recovery.done-applied move (guards against the skipped-gate over-suppressing).
+  test("CTL-1157: a REAL terminal-sweep Done (applied, not skipped) DOES emit recovery.done-applied", () => {
+    writeSignal("CTL-29", "teardown", "done");
+    writeFileSync(join(orchDir, "state.json"), JSON.stringify({ maxParallel: 1 }));
+    const writeStatus = {
+      ...terminalNoWrites(),
+      applyTerminalDone: () => ({ applied: true, action: "applied" }),
+    };
+    const doneApplied = [];
+    schedulerTick(orchDir, {
+      readEligible: () => [],
+      dispatch: fakeDispatch(),
+      writeStatus,
+      checkOpenPrs: () => ({ ok: true, prs: [] }),
+      emitDoneApplied: (ev) => doneApplied.push(ev),
+    });
+    expect(doneApplied).toHaveLength(1);
+    expect(doneApplied[0].ticket).toBe("CTL-29");
+    expect(doneApplied[0].by).toBe("terminal-sweep");
+  });
 });
 
 // ─── CTL-653: end-to-end verify⇄remediate cycle through schedulerTick ───

--- a/plugins/dev/scripts/execution-core/scheduler.test.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.test.mjs
@@ -9602,9 +9602,10 @@ describe("CTL-1191 — recovery passes HRW-gated over the surviving roster (Pass
 //
 // The reasoning pass must NOT reason over a ticket already finished (terminal
 // Linear state / merged PR) — doing so burns cooldown + re-posts diagnoses on a
-// Done ticket. The pass writes a per-ticket marker under .recovery-intents/ for
-// every item it processes (shadow mode), so the marker's presence/absence is the
-// observable. Single-host so the ownership gate is identity (we isolate the
+// Done ticket. In shadow the pass emits a per-item recovery.would-* event for every
+// item it processes (CTL-1157 F #5 retired the .recovery-intents cooldown marker in
+// shadow), so the event's presence/absence is the observable. Single-host so the
+// ownership gate is identity (we isolate the
 // terminal filter). A gateway descriptor supplies the Linear state without any
 // network — "Done" ⇒ terminal ⇒ filtered; "In Progress" ⇒ kept.
 describe("CTL-1191 — reasoning pass skips terminal tickets (Pass 0r terminal-state filter)", () => {
@@ -9642,12 +9643,19 @@ describe("CTL-1191 — reasoning pass skips terminal tickets (Pass 0r terminal-s
         applyTerminalDone: () => {},
         applyLabel: () => ({ applied: true }),
       },
-      recoveryPass: { mode: "shadow" }, // shadow still writes the cooldown marker
+      recoveryPass: { mode: "shadow" },
     });
 
-    // The in-flight ticket was reasoned over (marker written); the Done ticket
-    // was filtered BEFORE the pass (no marker — never processed).
-    expect(existsSync(recoveryIntentMarker("CTL-LIVE"))).toBe(true);
+    // CTL-1157 F #5: shadow no longer writes a cooldown marker for a DEFERRED (untyped
+    // stuck) item — that would mutate enforce scheduler state. So the observable that
+    // the in-flight CTL-LIVE was PROCESSED is now its recovery.would-defer EVENT; the
+    // terminal CTL-DONE, filtered BEFORE the pass, has NO per-item reasoning event
+    // (recovery.decision / recovery.would-*) and is never cooled down.
+    const events = readEventLog().map((e) => JSON.stringify(e));
+    expect(events.some((e) => e.includes("CTL-LIVE") && e.includes("would-defer"))).toBe(true);
+    expect(
+      events.some((e) => e.includes("CTL-DONE") && (e.includes("recovery.decision") || e.includes("would-"))),
+    ).toBe(false);
     expect(existsSync(recoveryIntentMarker("CTL-DONE"))).toBe(false);
   });
 });

--- a/plugins/dev/scripts/execution-core/scheduler.test.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.test.mjs
@@ -5446,43 +5446,68 @@ describe("schedulerTick — terminal-Done once-marker (CTL-597)", () => {
     expect(existsSync(join(orchDir, "workers", "CTL-23", ".terminal-done.applied"))).toBe(false);
   });
 
-  // CTL-1157: the terminal sweep writes Done DIRECTLY (it does not go through the
-  // gated `declare` CLI), so it runs the SAME universal open-PR gate. A still-open
-  // PR for the ticket (e.g. a second non-standard-branch PR) REFUSES the Done write
-  // and leaves NO once-marker → it self-heals on a later tick once the PR is resolved.
-  test("CTL-1157: an OPEN PR refuses the terminal-sweep Done write and leaves no marker (retries next tick)", () => {
+  // CTL-1157 (THE REVERSAL — ALARM-NOT-BLOCK): the terminal sweep writes Done
+  // DIRECTLY (no agent to reason). It no longer REFUSES on an open PR — it PROCEEDS
+  // (never wedges the board) and emits the loud recovery.done-applied-with-open-pr
+  // alarm so observability would justify adding a hard block later. A clean Done is
+  // silent.
+  test("CTL-1157: an OPEN PR does NOT block the terminal-sweep Done write — it PROCEEDS and fires the alarm", () => {
     writeSignal("CTL-24", "teardown", "done");
     writeFileSync(join(orchDir, "state.json"), JSON.stringify({ maxParallel: 1 }));
     const dones = [];
-    const writeStatus = { ...terminalNoWrites(), applyTerminalDone: (a) => dones.push(a) };
+    const writeStatus = {
+      ...terminalNoWrites(),
+      applyTerminalDone: (a) => {
+        dones.push(a);
+        return { applied: true };
+      },
+    };
     const checkOpenPrs = () => ({ ok: false, prs: [{ number: 321, state: "OPEN" }] });
+    const alarms = [];
     schedulerTick(orchDir, {
       readEligible: () => [],
       dispatch: fakeDispatch(),
       writeStatus,
       checkOpenPrs,
+      emitDoneWithOpenPr: (ev) => alarms.push(ev),
     });
-    expect(dones).toHaveLength(0); // gate refused → no Done write
-    expect(existsSync(join(orchDir, "workers", "CTL-24", ".terminal-done.applied"))).toBe(false);
+    expect(dones).toHaveLength(1); // proceeds — board never wedges
+    expect(existsSync(join(orchDir, "workers", "CTL-24", ".terminal-done.applied"))).toBe(true);
+    // The alarm fired with the ticket, the open PR list, and the backstop label.
+    expect(alarms).toHaveLength(1);
+    expect(alarms[0].ticket).toBe("CTL-24");
+    expect(alarms[0].by).toBe("terminal-sweep");
+    expect(alarms[0].openPrs.map((p) => p.number)).toEqual([321]);
   });
 
-  test("CTL-1157: an UNVERIFIABLE gate (fail-closed) also refuses the terminal-sweep Done write", () => {
+  test("CTL-1157: an UNVERIFIABLE enumeration (gh failure) still PROCEEDS and emits NO alarm (no longer fail-closed)", () => {
     writeSignal("CTL-25", "teardown", "done");
     writeFileSync(join(orchDir, "state.json"), JSON.stringify({ maxParallel: 1 }));
     const dones = [];
-    const writeStatus = { ...terminalNoWrites(), applyTerminalDone: (a) => dones.push(a) };
-    const checkOpenPrs = () => ({ ok: false, reason: "`gh` not authenticated", prs: [] });
+    const writeStatus = {
+      ...terminalNoWrites(),
+      applyTerminalDone: (a) => {
+        dones.push(a);
+        return { applied: true };
+      },
+    };
+    const checkOpenPrs = () => {
+      throw new Error("`gh` not authenticated");
+    };
+    const alarms = [];
     schedulerTick(orchDir, {
       readEligible: () => [],
       dispatch: fakeDispatch(),
       writeStatus,
       checkOpenPrs,
+      emitDoneWithOpenPr: (ev) => alarms.push(ev),
     });
-    expect(dones).toHaveLength(0);
-    expect(existsSync(join(orchDir, "workers", "CTL-25", ".terminal-done.applied"))).toBe(false);
+    expect(dones).toHaveLength(1); // proceeds — unverifiable is no longer fatal
+    expect(existsSync(join(orchDir, "workers", "CTL-25", ".terminal-done.applied"))).toBe(true);
+    expect(alarms).toEqual([]); // no known open PR ⇒ no alarm
   });
 
-  test("CTL-1157: no open PR (gate ok) ALLOWS the terminal-sweep Done write + stamps the marker", () => {
+  test("CTL-1157: no open PR (clean) writes Done, stamps the marker, and is SILENT (no alarm)", () => {
     writeSignal("CTL-26", "teardown", "done");
     writeFileSync(join(orchDir, "state.json"), JSON.stringify({ maxParallel: 1 }));
     const dones = [];
@@ -5494,14 +5519,17 @@ describe("schedulerTick — terminal-Done once-marker (CTL-597)", () => {
       },
     };
     const checkOpenPrs = () => ({ ok: true, prs: [] });
+    const alarms = [];
     schedulerTick(orchDir, {
       readEligible: () => [],
       dispatch: fakeDispatch(),
       writeStatus,
       checkOpenPrs,
+      emitDoneWithOpenPr: (ev) => alarms.push(ev),
     });
     expect(dones).toHaveLength(1); // legitimate completion preserved
     expect(existsSync(join(orchDir, "workers", "CTL-26", ".terminal-done.applied"))).toBe(true);
+    expect(alarms).toEqual([]); // clean Done is silent
   });
 });
 

--- a/plugins/dev/scripts/execution-core/scheduler.test.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.test.mjs
@@ -5445,6 +5445,64 @@ describe("schedulerTick — terminal-Done once-marker (CTL-597)", () => {
     // No marker on a thrown apply → retried next tick.
     expect(existsSync(join(orchDir, "workers", "CTL-23", ".terminal-done.applied"))).toBe(false);
   });
+
+  // CTL-1157: the terminal sweep writes Done DIRECTLY (it does not go through the
+  // gated `declare` CLI), so it runs the SAME universal open-PR gate. A still-open
+  // PR for the ticket (e.g. a second non-standard-branch PR) REFUSES the Done write
+  // and leaves NO once-marker → it self-heals on a later tick once the PR is resolved.
+  test("CTL-1157: an OPEN PR refuses the terminal-sweep Done write and leaves no marker (retries next tick)", () => {
+    writeSignal("CTL-24", "teardown", "done");
+    writeFileSync(join(orchDir, "state.json"), JSON.stringify({ maxParallel: 1 }));
+    const dones = [];
+    const writeStatus = { ...terminalNoWrites(), applyTerminalDone: (a) => dones.push(a) };
+    const checkOpenPrs = () => ({ ok: false, prs: [{ number: 321, state: "OPEN" }] });
+    schedulerTick(orchDir, {
+      readEligible: () => [],
+      dispatch: fakeDispatch(),
+      writeStatus,
+      checkOpenPrs,
+    });
+    expect(dones).toHaveLength(0); // gate refused → no Done write
+    expect(existsSync(join(orchDir, "workers", "CTL-24", ".terminal-done.applied"))).toBe(false);
+  });
+
+  test("CTL-1157: an UNVERIFIABLE gate (fail-closed) also refuses the terminal-sweep Done write", () => {
+    writeSignal("CTL-25", "teardown", "done");
+    writeFileSync(join(orchDir, "state.json"), JSON.stringify({ maxParallel: 1 }));
+    const dones = [];
+    const writeStatus = { ...terminalNoWrites(), applyTerminalDone: (a) => dones.push(a) };
+    const checkOpenPrs = () => ({ ok: false, reason: "`gh` not authenticated", prs: [] });
+    schedulerTick(orchDir, {
+      readEligible: () => [],
+      dispatch: fakeDispatch(),
+      writeStatus,
+      checkOpenPrs,
+    });
+    expect(dones).toHaveLength(0);
+    expect(existsSync(join(orchDir, "workers", "CTL-25", ".terminal-done.applied"))).toBe(false);
+  });
+
+  test("CTL-1157: no open PR (gate ok) ALLOWS the terminal-sweep Done write + stamps the marker", () => {
+    writeSignal("CTL-26", "teardown", "done");
+    writeFileSync(join(orchDir, "state.json"), JSON.stringify({ maxParallel: 1 }));
+    const dones = [];
+    const writeStatus = {
+      ...terminalNoWrites(),
+      applyTerminalDone: (a) => {
+        dones.push(a);
+        return { applied: true };
+      },
+    };
+    const checkOpenPrs = () => ({ ok: true, prs: [] });
+    schedulerTick(orchDir, {
+      readEligible: () => [],
+      dispatch: fakeDispatch(),
+      writeStatus,
+      checkOpenPrs,
+    });
+    expect(dones).toHaveLength(1); // legitimate completion preserved
+    expect(existsSync(join(orchDir, "workers", "CTL-26", ".terminal-done.applied"))).toBe(true);
+  });
 });
 
 // ─── CTL-653: end-to-end verify⇄remediate cycle through schedulerTick ───

--- a/plugins/dev/scripts/execution-core/scheduler.test.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.test.mjs
@@ -5480,7 +5480,11 @@ describe("schedulerTick — terminal-Done once-marker (CTL-597)", () => {
     expect(alarms[0].openPrs.map((p) => p.number)).toEqual([321]);
   });
 
-  test("CTL-1157: an UNVERIFIABLE enumeration (gh failure) still PROCEEDS and emits NO alarm (no longer fail-closed)", () => {
+  // CTL-1157 (Codex GROUP-A fix #1 — UNVERIFIABLE ≠ CLEAN): a thrown/unverifiable
+  // enumeration is NOT a clean list. Per alarm-not-block the sweep still PROCEEDS
+  // (never wedges), but it now SURFACES the unverifiable Done via the loud alarm
+  // (flagged unverifiable) rather than silently assuming zero open PRs.
+  test("CTL-1157: an UNVERIFIABLE enumeration (gh throw) PROCEEDS and FIRES the alarm (unverifiable, surfaced not silent)", () => {
     writeSignal("CTL-25", "teardown", "done");
     writeFileSync(join(orchDir, "state.json"), JSON.stringify({ maxParallel: 1 }));
     const dones = [];
@@ -5502,9 +5506,41 @@ describe("schedulerTick — terminal-Done once-marker (CTL-597)", () => {
       checkOpenPrs,
       emitDoneWithOpenPr: (ev) => alarms.push(ev),
     });
-    expect(dones).toHaveLength(1); // proceeds — unverifiable is no longer fatal
+    expect(dones).toHaveLength(1); // proceeds — alarm-not-block (never wedges)
     expect(existsSync(join(orchDir, "workers", "CTL-25", ".terminal-done.applied"))).toBe(true);
-    expect(alarms).toEqual([]); // no known open PR ⇒ no alarm
+    // unverifiable ⇒ could-not-confirm-clean ⇒ surface it (not silent).
+    expect(alarms).toHaveLength(1);
+    expect(alarms[0].ticket).toBe("CTL-25");
+    expect(alarms[0].by).toBe("terminal-sweep");
+    expect(alarms[0].unverifiable).toBe(true);
+    expect(alarms[0].openPrs).toEqual([]); // no KNOWN open PR, but still alarmed
+  });
+
+  // The structured {ok:false, unverifiable:true} return (no throw) — e.g. the
+  // attachment-view-failure path or an underivable repo — alarms the same way.
+  test("CTL-1157: a RETURNED unverifiable fact (no throw) also PROCEEDS and FIRES the alarm", () => {
+    writeSignal("CTL-27", "teardown", "done");
+    writeFileSync(join(orchDir, "state.json"), JSON.stringify({ maxParallel: 1 }));
+    const dones = [];
+    const writeStatus = {
+      ...terminalNoWrites(),
+      applyTerminalDone: (a) => {
+        dones.push(a);
+        return { applied: true };
+      },
+    };
+    const checkOpenPrs = () => ({ ok: false, unverifiable: true, reason: "repo-underivable", prs: [] });
+    const alarms = [];
+    schedulerTick(orchDir, {
+      readEligible: () => [],
+      dispatch: fakeDispatch(),
+      writeStatus,
+      checkOpenPrs,
+      emitDoneWithOpenPr: (ev) => alarms.push(ev),
+    });
+    expect(dones).toHaveLength(1);
+    expect(alarms).toHaveLength(1);
+    expect(alarms[0].unverifiable).toBe(true);
   });
 
   test("CTL-1157: no open PR (clean) writes Done, stamps the marker, and is SILENT (no alarm)", () => {

--- a/plugins/dev/scripts/execution-core/scheduler.test.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.test.mjs
@@ -55,6 +55,7 @@ import {
   verifyDispatchedSignal,
   gcDispatchCooldowns,
   maybeEscalateDispatchFailures,
+  holisticBoardHealthAct,
   __resetForTests,
   __getRunningOpts,
   // CTL-705: Phase 2 helpers

--- a/plugins/dev/skills/phase-teardown/SKILL.md
+++ b/plugins/dev/skills/phase-teardown/SKILL.md
@@ -299,9 +299,24 @@ fi
 # worker dir + signals[teardown]==='done'). --no-write: the Done write above is
 # authoritative; this only records the declaration. The drain marks it reconciled
 # once Linear shows Done, or re-writes it if the transition above silently failed.
+#
+# CTL-1157 F #3: pass --transition-verified ONLY when the real linear-transition.sh
+# above returned rc=0. That flag gates the ENFORCE recovery.done-applied telemetry +
+# open-PR alarm: without it, a marker dropped after a FAILED/MISSING transition would
+# report an applied Done that never happened. On the failure path we still drop the
+# marker (so the drain/terminalDoneOnce backstop reconciles), but as a shadow would-
+# event, not an enforce Done-move.
 LINEAR_RECONCILE="${PLUGIN_ROOT}/scripts/catalyst-linear-reconcile"
 if [[ -x "$LINEAR_RECONCILE" ]]; then
-  "$LINEAR_RECONCILE" declare "$TICKET" --state done --by pipeline --no-write >/dev/null 2>&1 || true
+  # Single no-space token → a set-but-empty string is safe under `set -u` and the
+  # unquoted expansion contributes no arg when empty (avoids the bash-3.2 empty-array
+  # trap). LINEAR_DONE_RC is unset when the transition script was missing → :-1 → shadow.
+  TRANSITION_VERIFIED_FLAG=""
+  if [[ "${LINEAR_DONE_RC:-1}" -eq 0 ]]; then
+    TRANSITION_VERIFIED_FLAG="--transition-verified"
+  fi
+  "$LINEAR_RECONCILE" declare "$TICKET" --state done --by pipeline --no-write \
+    $TRANSITION_VERIFIED_FLAG >/dev/null 2>&1 || true
 fi
 ```
 

--- a/plugins/dev/skills/phase-teardown/SKILL.md
+++ b/plugins/dev/skills/phase-teardown/SKILL.md
@@ -247,7 +247,12 @@ if [[ -f "$OPEN_PR_ENUM" ]] && command -v node >/dev/null 2>&1; then
       const t = process.env.TICKET;
       const branchName = process.env.TD_BRANCH || undefined;
       try {
-        const r = defaultCheckOpenPrs(t, { branchName });
+        // CTL-1157 (Codex round-8): teardown ALREADY runs inside the ticket worktree, so
+        // pass cwd=process.cwd() — defaultCheckOpenPrs then queries gh in THIS repo
+        // directly instead of relying on registry derivation, which reports
+        // repo-underivable/UNVERIFIABLE on an unenrolled repo or a repoRoot the registry
+        // convention cannot map, even though the current worktree is the right repo.
+        const r = defaultCheckOpenPrs(t, { branchName, cwd: process.cwd() });
         process.stdout.write(JSON.stringify({ prs: r.prs || [], unverifiable: !!r.unverifiable, reason: r.reason || "" }));
       } catch (e) {
         process.stdout.write(JSON.stringify({ prs: [], unverifiable: true, reason: String((e && e.message) || e) }));

--- a/plugins/dev/skills/phase-teardown/SKILL.md
+++ b/plugins/dev/skills/phase-teardown/SKILL.md
@@ -168,6 +168,80 @@ for signal_f in "$WORKER_DIR"/phase-*.json; do
 done
 ```
 
+## Done-judgment — verify the ticket is GENUINELY done before you tear down (CTL-1157)
+
+You are a phase agent that CAN reason, and teardown is the LAST gate before the
+ticket is marked Done and its worktree destroyed. **Before you write Done, verify
+the ticket is genuinely done — do NOT trust "monitor-merge merged a PR" as proof
+the whole ticket is complete.** A ticket commonly has more than one PR (a second
+PR, a human PR opened outside the pipeline, an abandoned spike); monitor-merge
+tracked only the pipeline's OWN PR. Marking Done while another PR that is part of
+the solution is still open is the silent-rot failure CTL-1157 exists to prevent.
+
+This is the same open-PR remediation rubric the recovery-pass delegate uses —
+applied here as **"teardown verifies it's done."** It complements (does not
+replace) the merge safety-gate above.
+
+**STEP 1 — Enumerate the ticket's OPEN PRs (the facts).** The fence below runs the
+CTL-1157 open-PR ENUMERATOR (`open-pr-gate.mjs` — the single source of truth that
+UNIONs the ticket-key search + the branch-head pass + the Linear-attachment pass,
+confirming OPEN via `gh`) and prints any still-open PRs. It is a FACTS source, not
+a block: it never aborts teardown on its own (alarm-not-block). YOU read its output.
+
+**STEP 2 — Reason about EACH open PR and remediate it yourself.** For every PR the
+enumerator printed:
+
+- **Still needed / part of the solution** → FINISH it (rebase onto base, fix CI,
+  merge it) before you proceed. Do NOT tear down with deliverable work unmerged.
+- **Abandoned / superseded** (a later PR replaced it, a dead spike, a duplicate) →
+  CLOSE it yourself: `gh pr close <n> --comment "<why — superseded by #X /
+  abandoned / duplicate of #Y>"`. Closing a dead PR is autonomous, not an escalation.
+- **Genuine judgment call** (the open PR conflicts with an ADR/principle, or you
+  cannot safely decide needed-vs-abandoned) → do NOT mark Done; emit
+  `phase.teardown.failed.${TICKET}` via the failure template with a concrete reason
+  so the stuck PR surfaces (the scheduler/recovery layer then escalates it). This
+  is the rare case — mechanically-resolvable PRs you finish/close yourself.
+
+**STEP 3 — Only once no open PR remains that SHOULD remain**, continue to the Linear
+Done transition below and tear down. A clean teardown (every open PR finished or
+closed) leaves the backstops silent; tearing down with an open PR still present
+fires the loud `recovery.done-applied-with-open-pr` alarm — which is exactly the
+signal that you skipped this verification.
+
+```bash phase-teardown-open-pr-verify
+# ─── Done-judgment: enumerate the ticket's open PRs (FACTS, non-blocking) ──────
+# CTL-1157: print any still-open PRs for this ticket so the agent can reason about
+# each (finish/merge the needed, close the abandoned) BEFORE the Done write below.
+# Runs the shared open-PR ENUMERATOR; this is alarm-not-block — it NEVER aborts
+# teardown by itself. The agent's reasoning (STEP 2 above) is what acts.
+EXEC_CORE_TD="${PLUGIN_ROOT}/scripts/execution-core"
+OPEN_PR_ENUM="${EXEC_CORE_TD}/open-pr-gate.mjs"
+TD_BRANCH="$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "")"
+if [[ -f "$OPEN_PR_ENUM" ]] && command -v node >/dev/null 2>&1; then
+  # Invoke the enumerator's defaultCheckOpenPrs; print the open-PR list as JSON.
+  # Best-effort: any failure prints an empty result and never blocks teardown.
+  TD_OPEN_PRS="$(OPEN_PR_ENUM="$OPEN_PR_ENUM" TICKET="$TICKET" TD_BRANCH="$TD_BRANCH" \
+    node --input-type=module -e '
+      const { defaultCheckOpenPrs } = await import(process.env.OPEN_PR_ENUM);
+      const t = process.env.TICKET;
+      const branchName = process.env.TD_BRANCH || undefined;
+      try {
+        const r = defaultCheckOpenPrs(t, { branchName });
+        process.stdout.write(JSON.stringify(r.prs || []));
+      } catch { process.stdout.write("[]"); }
+    ' 2>/dev/null || echo "[]")"
+  [[ -n "$TD_OPEN_PRS" ]] || TD_OPEN_PRS="[]"
+  TD_OPEN_COUNT="$(printf '%s' "$TD_OPEN_PRS" | jq 'length' 2>/dev/null || echo 0)"
+  if [[ "$TD_OPEN_COUNT" =~ ^[0-9]+$ && "$TD_OPEN_COUNT" -gt 0 ]]; then
+    echo "phase-teardown: CTL-1157 Done-judgment — ${TD_OPEN_COUNT} OPEN PR(s) still exist for ${TICKET}:" >&2
+    printf '%s\n' "$TD_OPEN_PRS" | jq -r '.[] | "  #\(.number) [\(.state)] \(.title // "")"' 2>/dev/null >&2 || true
+    echo "phase-teardown: reason about EACH (STEP 2): finish/merge the needed, close the abandoned (gh pr close <n> --comment ...), or fail-out on a genuine judgment call — BEFORE the Done transition below." >&2
+  else
+    echo "phase-teardown: CTL-1157 Done-judgment — no open PR remains for ${TICKET}; proceeding to Done." >&2
+  fi
+fi
+```
+
 ```bash phase-teardown-linear-done
 # ─── Linear Done transition ───────────────────────────────────────────────────
 # THIS IS THE ONLY Done writer when phase-teardown is in the pipeline.

--- a/plugins/dev/skills/phase-teardown/SKILL.md
+++ b/plugins/dev/skills/phase-teardown/SKILL.md
@@ -206,8 +206,14 @@ enumerator printed:
 - **Still needed / part of the solution** → FINISH it (rebase onto base, fix CI,
   merge it) before you proceed. Do NOT tear down with deliverable work unmerged.
 - **Abandoned / superseded** (a later PR replaced it, a dead spike, a duplicate) →
-  CLOSE it yourself: `gh pr close <n> --comment "<why — superseded by #X /
-  abandoned / duplicate of #Y>"`. Closing a dead PR is autonomous, not an escalation.
+  CLOSE it yourself: `gh pr close <n> -R <owner/repo> --comment "<why — superseded by
+  #X / abandoned / duplicate of #Y>"`. Closing a dead PR is autonomous, not an escalation.
+- **Cross-repo PRs (CTL-1157):** when the enumerator printed a PR as `owner/repo#n`
+  (a cross-repo Linear attachment — a DIFFERENT repo than this ticket's), you MUST
+  target that repo explicitly on BOTH paths — `gh pr merge <n> -R <owner/repo> …` and
+  `gh pr close <n> -R <owner/repo> …`. A bare `gh pr merge/close <n>` runs against the
+  ticket's repo and would merge/close the wrong same-numbered PR while leaving the
+  attached `owner/repo#n` open (this matches the fence's own `-R` warning above).
 - **Genuine judgment call** (the open PR conflicts with an ADR/principle, or you
   cannot safely decide needed-vs-abandoned) → do NOT mark Done; emit
   `phase.teardown.failed.${TICKET}` via the failure template with a concrete reason

--- a/plugins/dev/skills/phase-teardown/SKILL.md
+++ b/plugins/dev/skills/phase-teardown/SKILL.md
@@ -283,20 +283,24 @@ fi
 # THIS IS THE ONLY Done writer when phase-teardown is in the pipeline.
 # Called while still in the ticket worktree so .catalyst/config.json is adjacent.
 LINEAR_TRANSITION="${PLUGIN_ROOT}/scripts/linear-transition.sh"
+LINEAR_DONE_ACTION=""
 if [[ -x "$LINEAR_TRANSITION" ]]; then
-  # Capture rc + stderr instead of suppressing them: linear-transition.sh can
-  # print "transitioned" even when the underlying linearis update fails (memory:
-  # linear_transition_silent_success), so a silent failure here would leave the
-  # ticket at PR/inReview while the pipeline reports success. Non-fatal — the
-  # scheduler's terminalDoneOnce backstop (fires on teardown===done) retries the
-  # Done write — but the failure must be LOUD so it is diagnosable.
+  # Capture rc + the JSON result: linear-transition.sh can print "transitioned" even
+  # when the underlying linearis update fails (memory: linear_transition_silent_success),
+  # AND it exits 0 for idempotent skip, dry-run, and skipped-no-linearis — so rc==0 alone
+  # is NOT proof a Done was actually written (CTL-1157 Codex round-7). Run with --json and
+  # read `.action`: only "transitioned" (a real move) or "skipped" (confirmed already in
+  # the target Done state) count as a genuine Done. "skipped-no-linearis" / "dry-run" do
+  # NOT. Non-fatal — terminalDoneOnce backstop (fires on teardown===done) retries — but
+  # the failure must be LOUD so it is diagnosable.
   LINEAR_DONE_OUT="$("$LINEAR_TRANSITION" --ticket "$TICKET" --transition done \
-    --config .catalyst/config.json 2>&1)"
+    --config .catalyst/config.json --json 2>&1)"
   LINEAR_DONE_RC=$?
+  LINEAR_DONE_ACTION="$(printf '%s' "$LINEAR_DONE_OUT" | jq -r '.action // ""' 2>/dev/null || echo "")"
   if [[ $LINEAR_DONE_RC -ne 0 ]]; then
     echo "phase-teardown: Linear Done transition FAILED (rc=${LINEAR_DONE_RC}) — terminalDoneOnce backstop will retry: ${LINEAR_DONE_OUT}" >&2
   else
-    echo "phase-teardown: Linear Done transition: ${LINEAR_DONE_OUT}"
+    echo "phase-teardown: Linear Done transition (action=${LINEAR_DONE_ACTION:-unknown}): ${LINEAR_DONE_OUT}"
   fi
 else
   echo "phase-teardown: linear-transition.sh not found at $LINEAR_TRANSITION; skipping Done transition" >&2
@@ -310,19 +314,22 @@ fi
 # authoritative; this only records the declaration. The drain marks it reconciled
 # once Linear shows Done, or re-writes it if the transition above silently failed.
 #
-# CTL-1157 F #3: pass --transition-verified ONLY when the real linear-transition.sh
-# above returned rc=0. That flag gates the ENFORCE recovery.done-applied telemetry +
-# open-PR alarm: without it, a marker dropped after a FAILED/MISSING transition would
-# report an applied Done that never happened. On the failure path we still drop the
-# marker (so the drain/terminalDoneOnce backstop reconciles), but as a shadow would-
-# event, not an enforce Done-move.
+# CTL-1157 F #3 (+ Codex round-7): pass --transition-verified ONLY when the real
+# linear-transition.sh above reported a GENUINE Done — action "transitioned" (a real
+# move) or "skipped" (confirmed already in the Done state). rc==0 alone is NOT enough:
+# it also covers dry-run and "skipped-no-linearis" (a node without linearis writes
+# NOTHING yet still exits 0). That flag gates the ENFORCE recovery.done-applied telemetry
+# + open-PR alarm: without it, a marker dropped after a failed/missing/no-op transition
+# would report an applied Done that never happened. On the unverified path we still drop
+# the marker (so the drain/terminalDoneOnce backstop reconciles), but as a shadow
+# would-event, not an enforce Done-move.
 LINEAR_RECONCILE="${PLUGIN_ROOT}/scripts/catalyst-linear-reconcile"
 if [[ -x "$LINEAR_RECONCILE" ]]; then
   # Single no-space token → a set-but-empty string is safe under `set -u` and the
   # unquoted expansion contributes no arg when empty (avoids the bash-3.2 empty-array
-  # trap). LINEAR_DONE_RC is unset when the transition script was missing → :-1 → shadow.
+  # trap). LINEAR_DONE_ACTION is empty when the transition script was missing → shadow.
   TRANSITION_VERIFIED_FLAG=""
-  if [[ "${LINEAR_DONE_RC:-1}" -eq 0 ]]; then
+  if [[ "$LINEAR_DONE_ACTION" == "transitioned" || "$LINEAR_DONE_ACTION" == "skipped" ]]; then
     TRANSITION_VERIFIED_FLAG="--transition-verified"
   fi
   "$LINEAR_RECONCILE" declare "$TICKET" --state done --by pipeline --no-write \

--- a/plugins/dev/skills/phase-teardown/SKILL.md
+++ b/plugins/dev/skills/phase-teardown/SKILL.md
@@ -254,8 +254,12 @@ if [[ -f "$OPEN_PR_ENUM" ]] && command -v node >/dev/null 2>&1; then
   TD_OPEN_COUNT="$(printf '%s' "$TD_OPEN_PRS" | jq 'length' 2>/dev/null || echo 0)"
   if [[ "$TD_OPEN_COUNT" =~ ^[0-9]+$ && "$TD_OPEN_COUNT" -gt 0 ]]; then
     echo "phase-teardown: CTL-1157 Done-judgment — ${TD_OPEN_COUNT} OPEN PR(s) still exist for ${TICKET}:" >&2
-    printf '%s\n' "$TD_OPEN_PRS" | jq -r '.[] | "  #\(.number) [\(.state)] \(.title // "")"' 2>/dev/null >&2 || true
-    echo "phase-teardown: reason about EACH (STEP 2): finish/merge the needed, close the abandoned (gh pr close <n> --comment ...), or fail-out on a genuine judgment call — BEFORE the Done transition below." >&2
+    # CTL-1157 (Codex round-5): print the PR's OWN repo (owner/repo#n) when the
+    # enumerator recorded it — a cross-repo Linear attachment is a DIFFERENT PR than a
+    # same-numbered PR in the ticket's repo. Printing a bare "#n" would let the agent
+    # inspect/close the ticket-repo's #n while leaving the attached org/other#n open.
+    printf '%s\n' "$TD_OPEN_PRS" | jq -r '.[] | "  " + (if .repo then .repo + "#" else "#" end) + (.number|tostring) + " [" + (.state // "?") + "] " + (.title // "")' 2>/dev/null >&2 || true
+    echo "phase-teardown: reason about EACH (STEP 2): finish/merge the needed, close the abandoned, or fail-out on a genuine judgment call — BEFORE the Done transition below. IMPORTANT: for any entry printed as owner/repo#n, target THAT repo explicitly — 'gh pr close <n> -R <owner/repo> --comment ...' — never a bare 'gh pr close <n>' (which would act on the ticket repo's same-numbered PR)." >&2
   elif [[ "$TD_UNVERIFIABLE" == "true" ]]; then
     # UNVERIFIABLE ≠ CLEAN. The authoritative gh check could NOT confirm zero open PRs
     # (repo underivable, gh/auth/rate-limit failure, or an attachment PR we could not

--- a/plugins/dev/skills/phase-teardown/SKILL.md
+++ b/plugins/dev/skills/phase-teardown/SKILL.md
@@ -188,6 +188,18 @@ UNIONs the ticket-key search + the branch-head pass + the Linear-attachment pass
 confirming OPEN via `gh`) and prints any still-open PRs. It is a FACTS source, not
 a block: it never aborts teardown on its own (alarm-not-block). YOU read its output.
 
+**STEP 1½ — If the check came back UNVERIFIABLE, do NOT treat it as clean.** The
+enumerator returns `unverifiable:true` (with a reason) when the authoritative GitHub
+check could not be completed — the ticket's repo could not be derived, a `gh`
+list/view failed, or an attachment-linked PR could not be viewed. The fence surfaces
+that state explicitly ("open-PR verification was UNVERIFIABLE … (reason)") instead of
+collapsing it to an empty list. **UNVERIFIABLE ≠ CLEAN.** An unverifiable check is
+NOT "no open PR remains" — do not mark Done and remove the worktree on it. Finish the
+verification (re-run the enumerator, or eyeball the ticket's PRs by hand) and, if you
+still cannot confirm the board is clean, fail-out per STEP 2's genuine-judgment path
+(emit `phase.teardown.failed.${TICKET}` with the reason) so the unverified teardown
+surfaces rather than proceeding silently.
+
 **STEP 2 — Reason about EACH open PR and remediate it yourself.** For every PR the
 enumerator printed:
 
@@ -218,24 +230,38 @@ EXEC_CORE_TD="${PLUGIN_ROOT}/scripts/execution-core"
 OPEN_PR_ENUM="${EXEC_CORE_TD}/open-pr-gate.mjs"
 TD_BRANCH="$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "")"
 if [[ -f "$OPEN_PR_ENUM" ]] && command -v node >/dev/null 2>&1; then
-  # Invoke the enumerator's defaultCheckOpenPrs; print the open-PR list as JSON.
-  # Best-effort: any failure prints an empty result and never blocks teardown.
-  TD_OPEN_PRS="$(OPEN_PR_ENUM="$OPEN_PR_ENUM" TICKET="$TICKET" TD_BRANCH="$TD_BRANCH" \
+  # Invoke the enumerator's defaultCheckOpenPrs; print the FULL result as JSON —
+  # both the open-PR list AND the `unverifiable` flag + reason. UNVERIFIABLE ≠ CLEAN:
+  # if we serialized only `r.prs`, an unverifiable result (repo underivable / gh
+  # failed) would collapse to an empty list and falsely read as "no open PR remains".
+  # Best-effort: any throw is itself UNVERIFIABLE (never a silent clean list).
+  TD_OPEN_RESULT="$(OPEN_PR_ENUM="$OPEN_PR_ENUM" TICKET="$TICKET" TD_BRANCH="$TD_BRANCH" \
     node --input-type=module -e '
       const { defaultCheckOpenPrs } = await import(process.env.OPEN_PR_ENUM);
       const t = process.env.TICKET;
       const branchName = process.env.TD_BRANCH || undefined;
       try {
         const r = defaultCheckOpenPrs(t, { branchName });
-        process.stdout.write(JSON.stringify(r.prs || []));
-      } catch { process.stdout.write("[]"); }
-    ' 2>/dev/null || echo "[]")"
-  [[ -n "$TD_OPEN_PRS" ]] || TD_OPEN_PRS="[]"
+        process.stdout.write(JSON.stringify({ prs: r.prs || [], unverifiable: !!r.unverifiable, reason: r.reason || "" }));
+      } catch (e) {
+        process.stdout.write(JSON.stringify({ prs: [], unverifiable: true, reason: String((e && e.message) || e) }));
+      }
+    ' 2>/dev/null || echo "{\"prs\":[],\"unverifiable\":true,\"reason\":\"enumerator invocation failed\"}")"
+  [[ -n "$TD_OPEN_RESULT" ]] || TD_OPEN_RESULT="{\"prs\":[],\"unverifiable\":true,\"reason\":\"empty enumerator output\"}"
+  TD_OPEN_PRS="$(printf '%s' "$TD_OPEN_RESULT" | jq -c '.prs // []' 2>/dev/null || echo "[]")"
+  TD_UNVERIFIABLE="$(printf '%s' "$TD_OPEN_RESULT" | jq -r '.unverifiable // false' 2>/dev/null || echo "false")"
+  TD_UNVERIF_REASON="$(printf '%s' "$TD_OPEN_RESULT" | jq -r '.reason // ""' 2>/dev/null || echo "")"
   TD_OPEN_COUNT="$(printf '%s' "$TD_OPEN_PRS" | jq 'length' 2>/dev/null || echo 0)"
   if [[ "$TD_OPEN_COUNT" =~ ^[0-9]+$ && "$TD_OPEN_COUNT" -gt 0 ]]; then
     echo "phase-teardown: CTL-1157 Done-judgment — ${TD_OPEN_COUNT} OPEN PR(s) still exist for ${TICKET}:" >&2
     printf '%s\n' "$TD_OPEN_PRS" | jq -r '.[] | "  #\(.number) [\(.state)] \(.title // "")"' 2>/dev/null >&2 || true
     echo "phase-teardown: reason about EACH (STEP 2): finish/merge the needed, close the abandoned (gh pr close <n> --comment ...), or fail-out on a genuine judgment call — BEFORE the Done transition below." >&2
+  elif [[ "$TD_UNVERIFIABLE" == "true" ]]; then
+    # UNVERIFIABLE ≠ CLEAN. The authoritative gh check could NOT confirm zero open PRs
+    # (repo underivable, gh/auth/rate-limit failure, or an attachment PR we could not
+    # view). Do NOT let this read as clean — surface it so the agent reasons (STEP 1½).
+    echo "phase-teardown: CTL-1157 Done-judgment — open-PR verification was UNVERIFIABLE for ${TICKET} (${TD_UNVERIF_REASON:-reason unknown})." >&2
+    echo "phase-teardown: UNVERIFIABLE ≠ CLEAN — the authoritative gh check could NOT confirm zero open PRs. Do NOT assume the board is clean and do NOT silently mark Done + remove the worktree. Finish the verification (re-run the enumerator / eyeball the ticket's PRs by hand) or, on a genuine judgment call, fail-out: emit phase.teardown.failed.${TICKET} via the failure template carrying this reason so the unverified teardown surfaces." >&2
   else
     echo "phase-teardown: CTL-1157 Done-judgment — no open PR remains for ${TICKET}; proceeding to Done." >&2
   fi

--- a/plugins/dev/skills/recovery-pass/SKILL.md
+++ b/plugins/dev/skills/recovery-pass/SKILL.md
@@ -460,7 +460,8 @@ governs deciding a human is genuinely needed and authoring the brief for them.
 > call you cannot safely decide — never just because an open PR exists.
 >
 > **STEP PR-1 — Enumerate ALL the ticket's PRs (open + merged + closed) — the FACTS.** Run `gh pr
-> list --search "<TICKET>" --state all --json number,title,state,merged,mergedAt,isDraft,reviewDecision`.
+> list --search "<TICKET>" --state all --json number,title,state,mergedAt,isDraft,reviewDecision` (a PR
+> is merged when `state == "MERGED"` / `mergedAt` is non-null — there is no `merged` JSON field).
 > Also read `workers/<T>/phase-pr.json` and `workers/<T>/phase-monitor-merge.json` for `.pr.number`;
 > also check `gh pr list --head "<branch>"` (the `ryan/<ticket>-slug` Linear branch — catches human
 > PRs whose title omits the key); and the ticket's **Linear attachments** (linked PRs) via

--- a/plugins/dev/skills/recovery-pass/SKILL.md
+++ b/plugins/dev/skills/recovery-pass/SKILL.md
@@ -26,7 +26,7 @@ allowed-tools:
   - Glob
   - Edit
   - Write
-  - Task
+  - Task  # spawns thoughts-locator / thoughts-analyzer subagents for Rubric One (plan-deliverable read)
 ---
 
 # recovery-pass
@@ -425,6 +425,177 @@ The line is simple: **does this change the SYSTEM, or just unstick a stuck THING
   it is, why we have it, why it's failing, your recommendation* — plain language, no
   jargon. He decides; the decision becomes a durable setting so next time it's Tier 1/2.
 
+## The three delegate rubrics — the senior-engineer judgment gates
+
+The 3-tier rope says *how much* you may do. These three rubrics say *exactly how to
+judge* the three hardest cases the delegate faces, and they are the **gating
+heuristics you MUST satisfy before any autonomous action** of that kind. They make
+the Step 0–4 loop below concrete: Rubric One governs moving a PR-state ticket to
+Done, Rubric Two governs finishing a stuck PR yourself vs. escalating, Rubric Three
+governs deciding a human is genuinely needed and authoring the brief for them.
+
+> **Consistency with the code gates (CTL-1157).** Rubric One's autonomous Done write
+> goes through `linear-reconcile-cli.mjs declare … --by "recovery-pass"`, which carries
+> a **mandatory, non-bypassable open-PR gate** keyed on the `--by recovery-pass`
+> declarer identity: the CLI itself runs an authoritative `gh pr list --search "<TICKET>"
+> --state open` and **refuses the Done write (exit 2, nothing persisted), fail-closed on
+> any `gh` error**, while ANY non-merged PR for the ticket remains. The rubric never
+> claims a Done-move the code would refuse — STEP PR-6 gates the success emissions on the
+> declare exit code. You cannot "forget" the gate; it is the declarer, not a flag.
+
+### RUBRIC ONE — Done-judgment over a PR-state ticket
+
+> You may move a ticket to Done autonomously, but ONLY after this exact sequence clears. This is
+> never a mechanical merge→Done. If any step is ambiguous, you escalate (Rubric Three), you do not
+> guess — a wrong Done write clears the needs-human label and stops all scheduler attention, and is
+> hard to undo.
+>
+> **STEP PR-1 — Enumerate ALL PRs.** Run `gh pr list --search "<TICKET>" --state all --json
+> number,title,state,merged,mergedAt,isDraft,reviewDecision`. Also read `workers/<T>/phase-pr.json`
+> and `workers/<T>/phase-monitor-merge.json` for `.pr.number`. Also check `gh pr list --head
+> "<branch>"` and the `ryan/<ticket>-slug` branch prefix (catches human PRs with non-standard
+> titles). Union all PR numbers. The signal file records only the phase-pr agent's OWN PR — never
+> trust it as the complete set. (This is the multi-PR trap that got the old GitHub-PR→Done
+> automation removed; the code gate in STEP PR-6 is the deterministic backstop, but you enumerate
+> here so you understand the ticket before you touch it.)
+>
+> **STEP PR-2 — Open-PR gate (blocking).** If any non-draft PR in the union is `state:"open"` → the
+> ticket is NOT done. Treat that open PR as the stuck item (rebase it, fix CI, merge it via the
+> finish-PR path — Rubric Two), then loop back to PR-1.
+>
+> **STEP PR-3 — Read the plan.** Spawn the `thoughts-locator` subagent (via the Task tool) to find
+> docs in `thoughts/shared/{plans,prs,research}/` mentioning the ticket; spawn `thoughts-analyzer`
+> on the most recent plan. Extract the declared deliverable scope (how many PRs, what subsystems,
+> any "requires follow-up"/"multi-PR" note). No plan doc → fall back to `catalyst-linear read <T>`
+> (the mandatory Linear read path) for the description+title. If scope is ambiguous → escalate (do
+> NOT Done).
+>
+> **STEP PR-4 — Deliverable completeness gate.** Cross-reference each merged PR's coverage
+> (`gh pr view <n> --json files,title,body`) against the plan's declared deliverable. ALL plan
+> phases/subsystems must be covered. Partial coverage with an unmerged non-closed PR → loop to PR-2.
+> Missing work that is in NO PR (never built) → escalate (`escalation_type:"decision"`): reopen vs.
+> scope a new ticket.
+>
+> **STEP PR-5 — Children gate.** `catalyst-linear read <T>` → `.children`. Any child in a
+> non-terminal state → this is a parent tracker; do NOT Done it. Surface the open children as the
+> real blockers.
+>
+> **STEP PR-6 — Autonomous Done write (only when PR-1..PR-5 all clear).** First confirm live state is
+> non-terminal (`catalyst-linear read <T>` — verify-before-act). Then write a completion
+> declaration via the reconcile-store, NOT a direct `linearis` call. **The CLI surface is POSITIONAL:
+> `declare <TICKET>` — the ticket is a positional arg, the author flag is `--by` (NOT `--declared-by`),
+> and `--state` defaults to `done`. There is no `--ticket` flag; an unknown `--` flag makes the CLI
+> error out.** Declaring `--by "recovery-pass"` **automatically arms the mandatory open-PR gate** (it
+> is keyed on the declarer identity, not an opt-in flag you could forget):
+>
+> ```bash
+> node "${EXEC_CORE}/linear-reconcile-cli.mjs" declare "$TICKET" \
+>   --by "recovery-pass" --state done ${BRANCH:+--branch "$BRANCH"}
+> DECLARE_RC=$?
+> ```
+>
+> (`--state done` is the default; pass it for clarity. Pass `--branch "$BRANCH"` when you know the
+> Linear branch name — it adds the `gh pr list --head` secondary net for a PR whose title omits the
+> key.) `declare` writes Linear immediately by default; the durable declaration is always persisted
+> only on a *passing* gate. **Gate on the exit code — do NOT proceed on a non-zero exit.** The
+> open-PR gate exits **2 and writes NOTHING** when any non-merged PR for the ticket still exists, OR
+> when the PR set cannot be verified (`gh` missing/auth/network → fail-closed). `CATALYST_RECONCILE_MODE=notify`
+> (not `write`) queues but never lands. **On any non-zero declare exit → escalate (Rubric Three), and
+> do NOT emit the UNSTUCK comment or `recovery-emit fixed`** — advertising Done on a stuck ticket is
+> the exact failure mode this fixes. ONLY on `DECLARE_RC == 0` with a confirmed write:
+>
+> ```bash
+> node "${EXEC_CORE}/recovery-emit.mjs" fixed --ticket "$TICKET" \
+>   --reason "All PRs merged; deliverable verified against plan; declared Done via reconcile-store."
+> _rp_comment "$TICKET" "✅ **recovery-pass** verified every PR merged + the plan deliverable covered → declared Done."
+> ```
+>
+> **STEP PR-7 — When to escalate instead of Done** (any one → Rubric Three):
+> a. Plan declared N PRs; only M<N merged; the rest are CLOSED (abandoned) — ship now vs. new ticket.
+> b. Merged-PR diff does not cover a plan-declared subsystem — partial deliverable.
+> c. Plan/description says "requires follow-up not yet a separate ticket" — create follow-up vs. block.
+> d. Non-terminal children that the plan says are in-scope for this parent — surface as blockers.
+> e. A PR was merged via `--admin` with CI red (`gh pr view <n> --json statusCheckRollup`; any
+>    required check in FAILURE at merge) — authorization escalate, the deliverable may be broken.
+> f. No plan doc AND ambiguous Linear description — escalate rather than guess.
+
+### RUBRIC TWO — Finish-the-PR vs. escalate
+
+> When you anchor on a stuck PR, you are the senior engineer who unsticks it. Default to FINISHING it.
+> Source the lib primitives once: `source "${PLUGIN_ROOT}/scripts/lib/worktree-rebase.sh"` and
+> `source "${PLUGIN_ROOT}/scripts/lib/draft-pr.sh"`. `$BASE` is `origin/<the PR's base branch>`.
+>
+> **FINISH (do it yourself), bounded engineering:**
+> - BEHIND/DIRTY worktree → `rebase_onto_base_classified "$BASE"`, then branch on the rc:
+>   - rc=0 (clean/additive) → `draft_pr_push_verify`, re-arm the failed monitor-merge signal to
+>     `status:"pending"` (atomic tmp+mv) so the scheduler re-queues it, `recovery-emit fixed`.
+>   - rc=1 (fetch fail) → proceed un-rebased; log; NOT an escalation.
+>   - rc=2 (source conflict — the ctl708 auto-resolver stub always returns rc=2 for ANY real source
+>     conflict) → **resolve it yourself**: `git log --merge`, `git diff`, pick the resolution
+>     consistent with the ticket goal, `git add`, `git rebase --continue`, `draft_pr_push_verify`.
+>     This is bounded-LLM engineering, NOT an automatic escalation.
+> - Green PR just sitting there → `gh pr view <n> --json mergeable,mergeStateStatus,reviewDecision`,
+>   then run the cluster fence guard (`"${PLUGIN_ROOT}/scripts/lib/cluster-fence-guard.sh" --phase
+>   recovery-pass --ticket <T>`), then `gh pr merge <n> --squash --delete-branch`. Verify the merge
+>   via REST (`gh api repos/<repo>/pulls/<n> --jq '.merged'`) — `--delete-branch` exits non-zero from
+>   a worktree even when the squash succeeded.
+> - Red CI with a deterministic cause (type error, lint, a flaky test) → fix it, push, re-check
+>   (bounded by the attempts cap of 2 — after honest attempts that still fail on a *genuine design
+>   incompatibility*, it becomes an escalation, below).
+>
+> **ESCALATE instead of finishing (→ Rubric Three) when:**
+> - rc=3 (thoughts/ symlink conflict) → always escalate (symlink safety; never auto-resolve).
+> - `draft_pr_push_verify` rc=3 (workflow-scope OAuth missing, no `CATALYST_WORKFLOW_GITHUB_TOKEN`) →
+>   authorization escalate: "add CATALYST_WORKFLOW_GITHUB_TOKEN to claude-accounts.env and re-run".
+> - Human reviewer (not a bot) left CHANGES_REQUESTED → authorization escalate with the reviewer's ask.
+> - Source conflict spans a load-bearing API boundary (the conflicting hunk is another ticket's merged
+>   public contract, not a local impl detail) → decision escalate with both options.
+> - CI persistently red after 3+ honest fix attempts where the root cause is a genuine design
+>   incompatibility (not a type/lint error) → authorization escalate. **NEVER `--admin` / force-merge
+>   past a failing or pending check.** This is the load-bearing safety property.
+
+### RUBRIC THREE — When a human is GENUINELY needed
+
+> Escalate ONLY when you decide one of these is true. Otherwise you keep the board moving yourself.
+> Every escalation writes the curated 6-field brief (below) authored FOR the human.
+>
+> 1. **ADR / principle conflict** — the fix would violate a documented architectural decision or a
+>    stated principle. `escalation_type:"decision"`. Name the ADR/principle and the two shapes.
+> 2. **Real regression risk** — the only way forward changes a shipped, load-bearing contract another
+>    ticket depends on, and you cannot prove the change is safe. `escalation_type:"decision"`.
+> 3. **Un-contemplated decision** — the plan/description does not cover the situation and choosing
+>    wrong is expensive or hard to undo (e.g. reopen vs. new ticket; ship partial vs. block).
+>    `escalation_type:"decision"`.
+> 4. **Authority/credential you lack** — `--admin` bypass, a missing OAuth scope/token, a human
+>    reviewer's explicit change request, an action outside your granted tools. `escalation_type:"authorization"`.
+>
+> NOT a reason to escalate: a merge conflict you can resolve; a red CI with a deterministic cause; a
+> BEHIND branch; a green PR awaiting merge; a phantom merged-PR ticket whose plan is fully delivered.
+> Those you finish yourself.
+>
+> **The curated 6-field escalation brief.** Every escalation authors these six fields (via
+> `escalation-explain.mjs` in Step 4 below — the field → flag map is in parentheses), and they MUST be
+> CONCRETE, never tautological:
+>
+> - `escalation_type` (`--type`) — `decision | authorization | manual`. Prefer the first two when you
+>   have a recommendation; bare `manual`/"needs a human" is the anti-pattern.
+> - `call_to_action` (`--call-to-action`) — the specific question/action for the operator (NEVER
+>   tautological, never "review this ticket").
+> - `problem` (`--problem`) — what is stuck and why, ticket-specific (name the files/PRs/tickets).
+> - `why_you` (`--why-you`) — why THIS stuck state needs a human: the authorization/credential/
+>   value-judgment YOU lack (the senior-engineer default is to fix it yourself, so justify the exception).
+> - `why_not_auto` (`--why-not-auto`) — the concrete capability boundary you hit (NEVER "requires
+>   human judgment"; name the `--admin` bypass / missing token / ADR clause / coexisting-contract that
+>   stopped you).
+> - `what_to_do` (`--instructions`, numbered) + `outcome` (`--remediation-then-retry`) — numbered
+>   concrete steps for the human, and what happens once they resolve it (the next scheduler tick
+>   re-evaluates and re-dispatches).
+>
+> For a `decision` escalation also pass `--options '[{"label":…,"tradeoff":…}, …]'`. This is the same
+> payload the router's curated-brief writer renders into the Needs-You inbox card + the matching Linear
+> comment, so a CTL-1157 Gherkin "genuine human decision" row reads as the *decision needed* — never
+> "go rebase this".
+
 ## Filing a delegate finding (the compounding loop)
 
 Everything you do feeds the **Self-Healing Delegate** Linear project so the system
@@ -489,7 +660,12 @@ seam that is in `deterministicSeamsTried`.
 ### Step 2 — Resolve it MYSELF with bounded engineering (BOUNDED-LLM → FIX)
 
 You have full tool access. These are ALL things you do autonomously — never
-escalate them:
+escalate them. **For a stuck PR, follow RUBRIC TWO** (the rc=0/1/2/3 decision over
+`rebase_onto_base_classified` + `draft_pr_push_verify`) — it is the authoritative
+version of the bullets below. **For a PR-state / phantom merged-PR ticket you think
+is "done", do NOT mechanically Done it — run RUBRIC ONE first** (enumerate ALL PRs,
+read the plan via `thoughts-locator`/`thoughts-analyzer`, then declare via the
+mandatory-gated `--by recovery-pass` path).
 
 - **Merge / rebase conflict** → read BOTH sides (`git log --merge`,
   `git diff`, the two conflicting hunks). Pick the resolution consistent with this
@@ -542,8 +718,9 @@ the ticket-visible signal, the event is the log record.)
 
 ### Step 3 — Escalate ONLY IF one of these is genuinely true
 
-Walk the checklist. If NONE are checked, it is NOT an escalation — go back to
-Step 1/2 and FIX it.
+**This is RUBRIC THREE** — the checklist below is its concrete form. Walk it; if NONE
+are checked, it is NOT an escalation — go back to Step 1/2 and FIX it. When one IS
+genuinely true, Step 4 authors the curated 6-field brief (Rubric Three) for the human.
 
 ```
 [ ] Value judgment — a product / priority / UX call only the operator can make
@@ -616,6 +793,7 @@ EXPL_JSON="$(node "${EXEC_CORE}/escalation-explain.mjs" \
   --call-to-action "Which dispatch shape should win — per-host pinning or quota-aware?" \
   --options '[{"label":"Keep CTL-1188 per-host pinning","tradeoff":"CTL-1190 quota-aware load balancing must be re-derived on top"},{"label":"Keep CTL-1190 quota-aware","tradeoff":"loses CTL-1188 host pinning that shipped Tuesday"}]' \
   --why-you "both are valid architectures; the choice is a product-priority call, not an engineering one" \
+  --why-not-auto "the two merged shapes touch the same public dispatch contract; picking one silently undelivers the other — not a conflict I can resolve without a priority call" \
   --observed "$(jq -nc --argjson b "$(cat "$BRIEF" 2>/dev/null || echo '{}')" '$b.diagnosis // {}')" \
   2>/dev/null || echo '{}')"
 [ -n "$EXPL_JSON" ] || EXPL_JSON='{}'

--- a/plugins/dev/skills/recovery-pass/SKILL.md
+++ b/plugins/dev/skills/recovery-pass/SKILL.md
@@ -480,10 +480,15 @@ governs deciding a human is genuinely needed and authoring the brief for them.
 > - **Still needed / part of the solution** (it carries deliverable scope that hasn't landed
 >   elsewhere) → **FINISH it**: rebase, fix CI, merge it via **Rubric Two**'s rc=0/1/2/3 flow
 >   (`rebase_onto_base_classified` + `draft_pr_push_verify` + the green-PR merge). Do NOT close it.
+>   If the enumerator printed it as `owner/repo#n` (cross-repo), pass `-R <owner/repo>` on the merge
+>   (see Rubric Two) so you don't merge the ticket-repo's same-numbered PR instead.
 > - **Abandoned / superseded** (a later PR replaced it, a dead spike, a duplicate, scope dropped) →
->   **CLOSE it yourself**: `gh pr close <n> --comment "<why — superseded by #X / abandoned spike /
->   duplicate of #Y / scope moved to CTL-NNN>"`. Closing a dead PR is an autonomous senior-engineer
->   call, NOT an escalation.
+>   **CLOSE it yourself**: `gh pr close <n> -R <owner/repo> --comment "<why — superseded by #X /
+>   abandoned spike / duplicate of #Y / scope moved to CTL-NNN>"`. ALWAYS pass `-R <owner/repo>` when
+>   the open-PR enumerator reported the PR in a repo OTHER than the ticket's own (a cross-repo Linear
+>   attachment prints as `owner/repo#n`) — a bare `gh pr close <n>` runs against the ticket's repo and
+>   would close the wrong same-numbered PR while leaving the attached one open. Closing a dead PR is an
+>   autonomous senior-engineer call, NOT an escalation.
 > - **Genuine judgment call** — the open PR conflicts with an ADR/principle you must not override, OR
 >   you genuinely cannot safely decide needed-vs-abandoned (e.g. it has truly diverged from a sibling
 >   change and only one can coexist, or it's a release-cut decision) → **escalate (Rubric Three)**.
@@ -519,7 +524,14 @@ governs deciding a human is genuinely needed and authoring the brief for them.
 > There is no `--ticket` flag; an unknown `--` flag makes the CLI error out.**
 >
 > ```bash
-> node "${EXEC_CORE}/linear-reconcile-cli.mjs" declare "$TICKET" \
+> # Use the catalyst-linear-reconcile WRAPPER (prefers bun, node fallback) — NOT bare
+> # `node`. The CLI's default current-state reader imports bun:sqlite; under node it
+> # degrades to unknown-current, so a `--state done` write is SKIPPED as
+> # "unknown-current-unsafe" WHILE the CLI still exits 0 (it persisted the declaration).
+> # That records the ticket Done while Linear stays non-terminal until a later drain —
+> # exactly the silent false-Done this rubric must avoid. The wrapper runs bun so the
+> # current-state read is real and the Done write actually lands.
+> "${EXEC_CORE%/*}/catalyst-linear-reconcile" declare "$TICKET" \
 >   --by "recovery-pass" --state done ${BRANCH:+--branch "$BRANCH"} \
 >   --prs-closed "$PRS_CLOSED" --prs-kept "$PRS_KEPT" --open-prs-at-done "$PRS_STILL_OPEN"
 > ```
@@ -583,9 +595,13 @@ governs deciding a human is genuinely needed and authoring the brief for them.
 >     This is bounded-LLM engineering, NOT an automatic escalation.
 > - Green PR just sitting there → `gh pr view <n> --json mergeable,mergeStateStatus,reviewDecision`,
 >   then run the cluster fence guard (`"${PLUGIN_ROOT}/scripts/lib/cluster-fence-guard.sh" --phase
->   recovery-pass --ticket <T>`), then `gh pr merge <n> --squash --delete-branch`. Verify the merge
->   via REST (`gh api repos/<repo>/pulls/<n> --jq '.merged'`) — `--delete-branch` exits non-zero from
->   a worktree even when the squash succeeded.
+>   recovery-pass --ticket <T>`), then `gh pr merge <n> --squash --delete-branch`. **When the open-PR
+>   enumerator printed this PR as `owner/repo#n` (a cross-repo Linear attachment, a DIFFERENT repo than
+>   the ticket's), you MUST pass `-R <owner/repo>` on the view AND the merge (`gh pr merge <n> -R
+>   <owner/repo> …`)** — a bare `gh pr merge <n>` runs against the ticket's repo and would merge the
+>   wrong same-numbered PR (landing unintended code + deleting its branch) while the attached one stays
+>   open. Verify the merge via REST (`gh api repos/<owner/repo>/pulls/<n> --jq '.merged'`) —
+>   `--delete-branch` exits non-zero from a worktree even when the squash succeeded.
 > - Red CI with a deterministic cause (type error, lint, a flaky test) → fix it, push, re-check
 >   (bounded by the attempts cap of 2 — after honest attempts that still fail on a *genuine design
 >   incompatibility*, it becomes an escalation, below).
@@ -726,7 +742,10 @@ then declare Done autonomously via `declare --by recovery-pass`, which now just 
   cause (type error / lint / test), commit, push to re-trigger.
 - **A green PR just sitting there** → verify it is CLEAN
   (`gh pr view <n> --json mergeable,mergeStateStatus,reviewDecision`), then
-  `gh pr merge <n> --squash --delete-branch`.
+  `gh pr merge <n> --squash --delete-branch`. **For a cross-repo PR the enumerator
+  printed as `owner/repo#n`, pass `-R <owner/repo>` on both** (`gh pr merge <n> -R
+  <owner/repo> …`) — a bare merge targets the ticket's repo and would land the wrong
+  same-numbered PR while the attached one stays open.
 
 > **NEVER `--admin` / force-merge past a failing or pending check.** You may merge
 > a PR ONLY when its required checks are genuinely GREEN (`gh pr checks <n>` all

--- a/plugins/dev/skills/recovery-pass/SKILL.md
+++ b/plugins/dev/skills/recovery-pass/SKILL.md
@@ -519,8 +519,16 @@ governs deciding a human is genuinely needed and authoring the brief for them.
 >
 > ```bash
 > node "${EXEC_CORE}/linear-reconcile-cli.mjs" declare "$TICKET" \
->   --by "recovery-pass" --state done ${BRANCH:+--branch "$BRANCH"}
+>   --by "recovery-pass" --state done ${BRANCH:+--branch "$BRANCH"} \
+>   --prs-closed "$PRS_CLOSED" --prs-kept "$PRS_KEPT" --open-prs-at-done "$PRS_STILL_OPEN"
 > ```
+>
+> Pass your PR-2 tallies so the **Done-moves panel** (SLICE 3) records WHAT you did: `--prs-closed`
+> = how many abandoned/superseded PRs you closed; `--prs-kept` = how many you finished/merged as
+> part-of-solution; `--open-prs-at-done` = how many are STILL open at the Done (this should be **0**
+> for a clean delegate Done — every open PR was finished or closed in PR-2 — and `>0` is the red-line
+> that fires the `recovery.done-applied` WARN). These ride the `recovery.done-applied` event
+> (`recovery_mode=enforce`, `by=recovery-pass`); they default to 0 if omitted.
 >
 > This **now just WRITES** — there is NO refuse-gate and it exits 0; the durable declaration is
 > dropped regardless of the immediate Linear write (a pending write is retried by the reconcile
@@ -533,11 +541,16 @@ governs deciding a human is genuinely needed and authoring the brief for them.
 > _rp_comment "$TICKET" "✅ **recovery-pass** resolved every open PR (merged the needed, closed the abandoned) + verified the plan deliverable → declared Done."
 > ```
 >
-> **The Done write itself no longer fires any alarm** — that's the point of having done the PR-2 work.
-> The observability from SLICE 3 (`recovery.done-applied-with-open-pr`, WARN) is emitted only by the
-> pure-code backstops (`terminalDoneOnce` / the reconcile drain) IF a Done ever lands while an open PR
-> still exists. A clean Done (every open PR finished or closed) is silent; a Done-with-open-PR is
-> loud. So PR-2 is load-bearing: enumerate-and-remediate is what keeps your Done writes silent.
+> **The Done write itself no longer fires any ALARM** — that's the point of having done the PR-2 work.
+> Two SLICE 3 events distinguish a clean Done from a dirty one: (1) EVERY autonomous Done — yours and
+> the pure-code backstops' — emits the broad `recovery.done-applied` (INFO) "Done-moves" event with
+> your `prs_closed` / `prs_kept` tallies and `open_prs_at_done`; (2) the loud
+> `recovery.done-applied-with-open-pr` (WARN) alarm fires ONLY from the pure-code backstops
+> (`terminalDoneOnce` / the reconcile drain) IF a Done lands while an open PR still exists. For YOUR
+> Done, `open_prs_at_done` should be **0** — every open PR finished or closed in PR-2 — which keeps the
+> Done-moves event INFO and fires no WARN. A Done that lands with `open_prs_at_done > 0` flips the
+> event to WARN and is the red-line the panel alarms on. So PR-2 is load-bearing: enumerate-and-remediate
+> is what keeps `open_prs_at_done` at 0 and your Done alarm-silent.
 >
 > **STEP PR-7 — When to escalate instead of Done (genuine judgment ONLY → Rubric Three):**
 > a. An open PR conflicts with an ADR/principle you must not override.

--- a/plugins/dev/skills/recovery-pass/SKILL.md
+++ b/plugins/dev/skills/recovery-pass/SKILL.md
@@ -434,90 +434,123 @@ the Step 0–4 loop below concrete: Rubric One governs moving a PR-state ticket 
 Done, Rubric Two governs finishing a stuck PR yourself vs. escalating, Rubric Three
 governs deciding a human is genuinely needed and authoring the brief for them.
 
-> **Consistency with the code gates (CTL-1157).** Rubric One's autonomous Done write
-> goes through `linear-reconcile-cli.mjs declare … --by "recovery-pass"`, which carries
-> a **mandatory, non-bypassable open-PR gate** keyed on the `--by recovery-pass`
-> declarer identity: the CLI itself runs an authoritative `gh pr list --search "<TICKET>"
-> --state open` and **refuses the Done write (exit 2, nothing persisted), fail-closed on
-> any `gh` error**, while ANY non-merged PR for the ticket remains. The rubric never
-> claims a Done-move the code would refuse — STEP PR-6 gates the success emissions on the
-> declare exit code. You cannot "forget" the gate; it is the declarer, not a flag.
+> **Consistency with the code (CTL-1157 — THE REVERSAL).** Rubric One's autonomous Done write goes
+> through `linear-reconcile-cli.mjs declare … --by "recovery-pass"`, which **now just WRITES the Done
+> declaration — there is NO refuse-gate.** The earlier fail-closed open-PR gate (the CLI ran its own
+> `gh pr list … --state open` and refused the write, exit 2, nothing persisted, while any non-merged
+> PR remained) was the handcuff the owner REMOVED. Done-safety is YOUR judgment as a senior engineer,
+> not a mechanical block. `open-pr-gate.mjs` is no longer a gate that refuses — it is an open-PR
+> **ENUMERATOR**, a FACTS source you (and the pure-code backstops) read; callers DECIDE. You
+> enumerate the ticket's open PRs, reason about and remediate EACH yourself (finish/merge the ones
+> that are part of the solution, CLOSE the abandoned/superseded ones), THEN declare Done —
+> autonomously, no human in the loop. The hard block is held IN RESERVE. If a Done ever lands while an
+> open PR still exists — via a pure-code backstop (`terminalDoneOnce` / the reconcile drain), NOT via
+> you — those backstops emit the loud `recovery.done-applied-with-open-pr` alarm (SLICE 3). That
+> observability is the signal that would justify reinstating the block, and is exactly why STEP PR-2's
+> remediate-every-open-PR work is load-bearing: a clean Done (every open PR finished or closed) is
+> silent; a Done-with-open-PR is loud.
 
 ### RUBRIC ONE — Done-judgment over a PR-state ticket
 
-> You may move a ticket to Done autonomously, but ONLY after this exact sequence clears. This is
-> never a mechanical merge→Done. If any step is ambiguous, you escalate (Rubric Three), you do not
-> guess — a wrong Done write clears the needs-human label and stops all scheduler attention, and is
-> hard to undo.
+> You are a senior engineer with the authority to move a ticket to Done autonomously. This is NEVER a
+> mechanical merge→Done, and it is NOT a fail-closed gate that refuses you (the owner removed that
+> handcuff — see "Consistency with the code" above). It is a JUDGMENT you make after reading the facts
+> and remediating every open PR yourself. The open-PR check is FACTS you read, not an auto-refuse and
+> not an auto-escalate. You escalate (Rubric Three) ONLY when an open PR presents a genuine judgment
+> call you cannot safely decide — never just because an open PR exists.
 >
-> **STEP PR-1 — Enumerate ALL PRs.** Run `gh pr list --search "<TICKET>" --state all --json
-> number,title,state,merged,mergedAt,isDraft,reviewDecision`. Also read `workers/<T>/phase-pr.json`
-> and `workers/<T>/phase-monitor-merge.json` for `.pr.number`. Also check `gh pr list --head
-> "<branch>"` and the `ryan/<ticket>-slug` branch prefix (catches human PRs with non-standard
-> titles). Union all PR numbers. The signal file records only the phase-pr agent's OWN PR — never
-> trust it as the complete set. (This is the multi-PR trap that got the old GitHub-PR→Done
-> automation removed; the code gate in STEP PR-6 is the deterministic backstop, but you enumerate
-> here so you understand the ticket before you touch it.)
+> **STEP PR-1 — Enumerate ALL the ticket's PRs (open + merged + closed) — the FACTS.** Run `gh pr
+> list --search "<TICKET>" --state all --json number,title,state,merged,mergedAt,isDraft,reviewDecision`.
+> Also read `workers/<T>/phase-pr.json` and `workers/<T>/phase-monitor-merge.json` for `.pr.number`;
+> also check `gh pr list --head "<branch>"` (the `ryan/<ticket>-slug` Linear branch — catches human
+> PRs whose title omits the key); and the ticket's **Linear attachments** (linked PRs) via
+> `catalyst-linear read <T>` (source:replica — NEVER bare `linearis`). Union all PR numbers. The
+> facts helper `open-pr-gate.mjs` (`defaultCheckOpenPrs`) already UNIONs exactly these three
+> discovery passes (ticket-key search + branch-head + replica attachments) and confirms OPEN state via
+> `gh` — it is the single source of truth for "which PRs are still open"; `gh` directly is the manual
+> equivalent. The signal file records only the phase-pr agent's OWN PR — never trust it as the
+> complete set.
 >
-> **STEP PR-2 — Open-PR gate (blocking).** If any non-draft PR in the union is `state:"open"` → the
-> ticket is NOT done. Treat that open PR as the stuck item (rebase it, fix CI, merge it via the
-> finish-PR path — Rubric Two), then loop back to PR-1.
+> **STEP PR-2 — THE MULTI-PR TRAP: reason about EACH open PR and remediate it YOURSELF.** Do NOT mark
+> the ticket Done just because ONE of several PRs merged — a ticket commonly has more than one PR, and
+> a single merge says nothing about the others. For EVERY PR in the union with `state:"open"`, make a
+> senior-engineer call:
 >
-> **STEP PR-3 — Read the plan.** Spawn the `thoughts-locator` subagent (via the Task tool) to find
-> docs in `thoughts/shared/{plans,prs,research}/` mentioning the ticket; spawn `thoughts-analyzer`
-> on the most recent plan. Extract the declared deliverable scope (how many PRs, what subsystems,
-> any "requires follow-up"/"multi-PR" note). No plan doc → fall back to `catalyst-linear read <T>`
-> (the mandatory Linear read path) for the description+title. If scope is ambiguous → escalate (do
-> NOT Done).
+> - **Still needed / part of the solution** (it carries deliverable scope that hasn't landed
+>   elsewhere) → **FINISH it**: rebase, fix CI, merge it via **Rubric Two**'s rc=0/1/2/3 flow
+>   (`rebase_onto_base_classified` + `draft_pr_push_verify` + the green-PR merge). Do NOT close it.
+> - **Abandoned / superseded** (a later PR replaced it, a dead spike, a duplicate, scope dropped) →
+>   **CLOSE it yourself**: `gh pr close <n> --comment "<why — superseded by #X / abandoned spike /
+>   duplicate of #Y / scope moved to CTL-NNN>"`. Closing a dead PR is an autonomous senior-engineer
+>   call, NOT an escalation.
+> - **Genuine judgment call** — the open PR conflicts with an ADR/principle you must not override, OR
+>   you genuinely cannot safely decide needed-vs-abandoned (e.g. it has truly diverged from a sibling
+>   change and only one can coexist, or it's a release-cut decision) → **escalate (Rubric Three)**.
+>   This is the ONLY open-PR branch that escalates.
 >
-> **STEP PR-4 — Deliverable completeness gate.** Cross-reference each merged PR's coverage
-> (`gh pr view <n> --json files,title,body`) against the plan's declared deliverable. ALL plan
-> phases/subsystems must be covered. Partial coverage with an unmerged non-closed PR → loop to PR-2.
-> Missing work that is in NO PR (never built) → escalate (`escalation_type:"decision"`): reopen vs.
-> scope a new ticket.
+> Loop until NO open PR remains that SHOULD remain (every one is finished/merged, or closed, or
+> escalated). A stale/BEHIND open PR, a red-CI open PR with a deterministic fix, and an abandoned PR
+> are NEVER escalations — you remediate them here.
+>
+> **STEP PR-3 — Read the plan (deliverable scope).** Spawn the `thoughts-locator` subagent (via the
+> Task tool) to find docs in `thoughts/shared/{plans,prs,research}/` mentioning the ticket; spawn
+> `thoughts-analyzer` on the most recent plan. Extract the declared deliverable scope (how many PRs,
+> what subsystems, any "requires follow-up"/"multi-PR" note). No plan doc → fall back to
+> `catalyst-linear read <T>` for the description+title. This is what lets you judge in PR-2 whether an
+> open PR is "still needed" vs "abandoned", and in PR-4 whether the merged work actually covers the
+> deliverable. If scope is genuinely ambiguous and the call is expensive/hard-to-undo → escalate.
+>
+> **STEP PR-4 — Deliverable completeness (judgment, not a block).** Cross-reference each merged PR's
+> coverage (`gh pr view <n> --json files,title,body`) against the plan's declared deliverable. If a
+> plan subsystem is covered by an open PR, that PR was already handled in PR-2. Work that is in NO PR
+> at all (never built) and is load-bearing → escalate (`escalation_type:"decision"`: reopen vs. scope
+> a new ticket) — do NOT Done over a missing deliverable.
 >
 > **STEP PR-5 — Children gate.** `catalyst-linear read <T>` → `.children`. Any child in a
-> non-terminal state → this is a parent tracker; do NOT Done it. Surface the open children as the
-> real blockers.
+> non-terminal state that the plan says is in-scope for this parent → this is a parent tracker; do NOT
+> Done it. Surface the open children as the real blockers.
 >
-> **STEP PR-6 — Autonomous Done write (only when PR-1..PR-5 all clear).** First confirm live state is
-> non-terminal (`catalyst-linear read <T>` — verify-before-act). Then write a completion
-> declaration via the reconcile-store, NOT a direct `linearis` call. **The CLI surface is POSITIONAL:
-> `declare <TICKET>` — the ticket is a positional arg, the author flag is `--by` (NOT `--declared-by`),
-> and `--state` defaults to `done`. There is no `--ticket` flag; an unknown `--` flag makes the CLI
-> error out.** Declaring `--by "recovery-pass"` **automatically arms the mandatory open-PR gate** (it
-> is keyed on the declarer identity, not an opt-in flag you could forget):
+> **STEP PR-6 — Mark the ticket Done autonomously (no human in the loop).** Once every open PR is
+> finished/merged or closed (PR-2), the deliverable is covered (PR-4), and no non-terminal in-scope
+> child remains (PR-5), confirm live state is non-terminal (`catalyst-linear read <T>` —
+> verify-before-act), then declare Done. **The CLI surface is POSITIONAL: `declare <TICKET>` — ticket
+> is a positional arg, the author flag is `--by` (NOT `--declared-by`), `--state` defaults to `done`.
+> There is no `--ticket` flag; an unknown `--` flag makes the CLI error out.**
 >
 > ```bash
 > node "${EXEC_CORE}/linear-reconcile-cli.mjs" declare "$TICKET" \
 >   --by "recovery-pass" --state done ${BRANCH:+--branch "$BRANCH"}
-> DECLARE_RC=$?
 > ```
 >
-> (`--state done` is the default; pass it for clarity. Pass `--branch "$BRANCH"` when you know the
-> Linear branch name — it adds the `gh pr list --head` secondary net for a PR whose title omits the
-> key.) `declare` writes Linear immediately by default; the durable declaration is always persisted
-> only on a *passing* gate. **Gate on the exit code — do NOT proceed on a non-zero exit.** The
-> open-PR gate exits **2 and writes NOTHING** when any non-merged PR for the ticket still exists, OR
-> when the PR set cannot be verified (`gh` missing/auth/network → fail-closed). `CATALYST_RECONCILE_MODE=notify`
-> (not `write`) queues but never lands. **On any non-zero declare exit → escalate (Rubric Three), and
-> do NOT emit the UNSTUCK comment or `recovery-emit fixed`** — advertising Done on a stuck ticket is
-> the exact failure mode this fixes. ONLY on `DECLARE_RC == 0` with a confirmed write:
+> This **now just WRITES** — there is NO refuse-gate and it exits 0; the durable declaration is
+> dropped regardless of the immediate Linear write (a pending write is retried by the reconcile
+> drain). `--state done` is the default (pass it for clarity); pass `--branch "$BRANCH"` when you know
+> the Linear branch name. Then record the win:
 >
 > ```bash
 > node "${EXEC_CORE}/recovery-emit.mjs" fixed --ticket "$TICKET" \
->   --reason "All PRs merged; deliverable verified against plan; declared Done via reconcile-store."
-> _rp_comment "$TICKET" "✅ **recovery-pass** verified every PR merged + the plan deliverable covered → declared Done."
+>   --reason "Reasoned about every open PR (finished/merged the needed, closed the abandoned); deliverable verified against plan; declared Done."
+> _rp_comment "$TICKET" "✅ **recovery-pass** resolved every open PR (merged the needed, closed the abandoned) + verified the plan deliverable → declared Done."
 > ```
 >
-> **STEP PR-7 — When to escalate instead of Done** (any one → Rubric Three):
-> a. Plan declared N PRs; only M<N merged; the rest are CLOSED (abandoned) — ship now vs. new ticket.
-> b. Merged-PR diff does not cover a plan-declared subsystem — partial deliverable.
-> c. Plan/description says "requires follow-up not yet a separate ticket" — create follow-up vs. block.
-> d. Non-terminal children that the plan says are in-scope for this parent — surface as blockers.
-> e. A PR was merged via `--admin` with CI red (`gh pr view <n> --json statusCheckRollup`; any
->    required check in FAILURE at merge) — authorization escalate, the deliverable may be broken.
+> **The Done write itself no longer fires any alarm** — that's the point of having done the PR-2 work.
+> The observability from SLICE 3 (`recovery.done-applied-with-open-pr`, WARN) is emitted only by the
+> pure-code backstops (`terminalDoneOnce` / the reconcile drain) IF a Done ever lands while an open PR
+> still exists. A clean Done (every open PR finished or closed) is silent; a Done-with-open-PR is
+> loud. So PR-2 is load-bearing: enumerate-and-remediate is what keeps your Done writes silent.
+>
+> **STEP PR-7 — When to escalate instead of Done (genuine judgment ONLY → Rubric Three):**
+> a. An open PR conflicts with an ADR/principle you must not override.
+> b. You genuinely cannot safely decide an open PR's needed-vs-abandoned (truly-diverged sibling, or a
+>    product/release-cut call) — the Gherkin "genuine human decision" case.
+> c. Plan declared N PRs; M<N merged, the rest CLOSED — and ship-now-vs-new-ticket is a real call.
+> d. Merged-PR diff misses a plan-declared subsystem that's in NO PR (partial, load-bearing deliverable).
+> e. Non-terminal in-scope children that the plan owns under this parent.
 > f. No plan doc AND ambiguous Linear description — escalate rather than guess.
+>
+> NOT escalations (you remediate these in PR-2 yourself): a stale/BEHIND open PR (rebase + merge it), a
+> red-CI open PR with a deterministic fix (fix it, push, re-check), an abandoned/superseded open PR
+> (close it). Mechanically-resolvable ⇒ FIX; genuine-judgment ⇒ escalate.
 
 ### RUBRIC TWO — Finish-the-PR vs. escalate
 
@@ -663,9 +696,10 @@ You have full tool access. These are ALL things you do autonomously — never
 escalate them. **For a stuck PR, follow RUBRIC TWO** (the rc=0/1/2/3 decision over
 `rebase_onto_base_classified` + `draft_pr_push_verify`) — it is the authoritative
 version of the bullets below. **For a PR-state / phantom merged-PR ticket you think
-is "done", do NOT mechanically Done it — run RUBRIC ONE first** (enumerate ALL PRs,
-read the plan via `thoughts-locator`/`thoughts-analyzer`, then declare via the
-mandatory-gated `--by recovery-pass` path).
+is "done", do NOT mechanically Done it — run RUBRIC ONE first** (enumerate ALL the
+ticket's PRs, reason about and remediate EACH open one yourself — finish/merge the
+needed, close the abandoned — read the plan via `thoughts-locator`/`thoughts-analyzer`,
+then declare Done autonomously via `declare --by recovery-pass`, which now just writes).
 
 - **Merge / rebase conflict** → read BOTH sides (`git log --merge`,
   `git diff`, the two conflicting hunks). Pick the resolution consistent with this


### PR DESCRIPTION
## What

Wave 1 of the **Self-Healing Delegate** (CTL-1157): turns the holistic board-health pass into a senior engineer that **moves stuck work** instead of only escalating. Built shadow-first — **this merge is dark** (byte-identical behavior under current fleet defaults; nothing changes until an operator flips `CATALYST_BOARD_HEALTH` / `CATALYST_RECOVERY_PASS`).

Closes the two gaps behind "the board isn't moving" for the **old needs-human / stuck pile**:
1. board-health was **observability-dark and dispatched nothing** (`anchor:null`) — it couldn't *see* the stuck cohorts.
2. recovery was **escalate-only** — untyped stalls dead-ended at the human with a generic "Unclassified" message.

## How

- **board-health SEES the 3 stuck cohorts** — new invariants flag (a) phantom merged-PR-in-PR-state tickets, (b) orphaned/conflicting open PRs, (c) frozen `needs-human` items; cohort counts emit on `recovery.board-scan` as queryable structured metadata.
- **Acts like a senior engineer (judgment, not handcuffs)** — the delegate + the normal teardown agent enumerate a ticket's open PRs and **reason per-PR**: still needed → finish/merge; abandoned → close it themselves; then mark Done **autonomously**. Escalation happens **only** on a genuine ADR/principle/value judgment call — never mechanically. The multi-PR trap is explicit (don't Done because *one* of several PRs merged).
- **No false-Done, without a block** — instead of a refuse-gate, the open-PR check is *facts* the agent reads. The two pure-code backstops (`terminalDoneOnce`, the reconciler drain) **never block the board**; they emit a loud `recovery.done-applied-with-open-pr` alarm if a Done ever lands with an open PR — the trigger to add a hard block only if reality diverges.
- **Untyped stalls reach the delegate** — Rule-3 escalate becomes `defer` (cooldown-only, no permanent latch) so the holistic pass can pick them up; curated 6-field human briefs replace the generic escalation.
- **HRW-safe anchor + no starvation** — ordered candidate list; foreign-owned failover only when the owner is provably stranded/dead (no double-dispatch across hosts); the act loop iterates past cooldown-latched anchors.
- **sdk-aware dispatch** — recovery/board-health dispatch now routes through the executor abstraction (honors `CATALYST_EXECUTOR=sdk`) instead of hardcoded `claude --bg`.
- **Observability for retros + the flip gate** — every autonomous Done emits `recovery.done-applied` with `open_prs_at_done` / `prs_closed` / `prs_kept` (underscored structured metadata).

## Safety / rollout

- **Dark merge:** `OFF` = byte-identical to main; `SHADOW` = cohort telemetry only, **zero action**; `ENFORCE` = acts. Verified by the adversarial review panel (autonomy-not-handcuff, backstop-alarm-not-block, off-dark/shadow-no-action all PASS).
- **Quota-safe:** all Linear reads go through the local replica/cache (`catalyst-linear`, source:replica); GitHub reads via `gh`; only low-volume Linear writes use `linearis`.
- **Rollout:** merge dark → deploy in **shadow** (delegate logs what it *would* do against the live stuck board while OTEL builds the before/after baseline) → operator-gated **shadow→enforce flip**.
- Rebased onto current `origin/main` (preserves #2501's per-dispatch read-path changes).

Implementation plan: `thoughts/shared/plans/2026-06-30-self-healing-delegate-wave1.md`. Acceptance spec = CTL-1157's own Gherkin.

Refs CTL-1157

🤖 Generated with [Claude Code](https://claude.com/claude-code)