### PR TITLE
fix(dev): CTL-1404 — SDK phase-agent workers emit claude_code_* OTel again (daemon env lacked the OTLP endpoint)

### DIFF
--- a/plugins/dev/scripts/__tests__/catalyst-execution-core.test.sh
+++ b/plugins/dev/scripts/__tests__/catalyst-execution-core.test.sh
@@ -239,6 +239,14 @@ JSON
 	export OTEL_EXPORTER_OTLP_ENDPOINT="http://daemon-env-wins:4318"
 	_default_otel_from_user_settings
 	if [ "${OTEL_EXPORTER_OTLP_ENDPOINT}" = "http://daemon-env-wins:4318" ]; then pass "does not override an already-set endpoint"; else fail "does not override an already-set endpoint" "got=${OTEL_EXPORTER_OTLP_ENDPOINT}"; fi
+	# (d) Codex P1: a BARE (non-exported) value sourced from execution-core.env — e.g.
+	# catalyst-join.sh's `OTEL_EXPORTER_OTLP_ENDPOINT=...` without export — must be PROMOTED to
+	# exported so the nohup'd daemon child inherits it (else SDK workers start endpoint-less).
+	unset OTEL_EXPORTER_OTLP_ENDPOINT
+	OTEL_EXPORTER_OTLP_ENDPOINT="http://bare-sourced:4318" # bare assignment, NOT exported
+	_default_otel_from_user_settings
+	CHILD_SEES="$(bash -c 'printf %s "${OTEL_EXPORTER_OTLP_ENDPOINT-}"')"
+	if [ "$CHILD_SEES" = "http://bare-sourced:4318" ]; then pass "promotes a bare daemon-env value to exported (child inherits)"; else fail "promotes a bare daemon-env value to exported" "child_sees=$CHILD_SEES"; fi
 	# (c) settings file absent → no-op success, env untouched
 	unset OTEL_EXPORTER_OTLP_ENDPOINT
 	export CLAUDE_SETTINGS_JSON="$SETTINGS_DIR/does-not-exist.json"

--- a/plugins/dev/scripts/__tests__/catalyst-execution-core.test.sh
+++ b/plugins/dev/scripts/__tests__/catalyst-execution-core.test.sh
@@ -213,6 +213,41 @@ else
 fi
 teardown
 
+echo "test 10 (CTL-1404): _default_otel_from_user_settings fills unset OTLP keys from settings.json"
+# helper already sourced in test 5. Needs jq (the function no-ops without it).
+if ! command -v jq >/dev/null 2>&1; then
+	echo "  SKIP: jq not installed"
+else
+	SETTINGS_DIR="$(mktemp -d)"
+	cat >"$SETTINGS_DIR/settings.json" <<'JSON'
+{ "env": {
+  "OTEL_EXPORTER_OTLP_ENDPOINT": "http://collector.example:4318",
+  "OTEL_EXPORTER_OTLP_PROTOCOL": "http/protobuf",
+  "OTEL_METRICS_EXPORTER": "otlp",
+  "OTEL_LOGS_EXPORTER": "otlp",
+  "CLAUDE_CODE_ENABLE_TELEMETRY": "1"
+} }
+JSON
+	export CLAUDE_SETTINGS_JSON="$SETTINGS_DIR/settings.json"
+	# (a) unset → filled from settings.json
+	unset OTEL_EXPORTER_OTLP_ENDPOINT OTEL_EXPORTER_OTLP_PROTOCOL OTEL_METRICS_EXPORTER OTEL_LOGS_EXPORTER CLAUDE_CODE_ENABLE_TELEMETRY
+	_default_otel_from_user_settings
+	if [ "${OTEL_EXPORTER_OTLP_ENDPOINT:-}" = "http://collector.example:4318" ]; then pass "fills endpoint from settings.json"; else fail "fills endpoint from settings.json" "got=${OTEL_EXPORTER_OTLP_ENDPOINT:-<unset>}"; fi
+	if [ "${OTEL_EXPORTER_OTLP_PROTOCOL:-}" = "http/protobuf" ]; then pass "fills protocol from settings.json"; else fail "fills protocol from settings.json" "got=${OTEL_EXPORTER_OTLP_PROTOCOL:-<unset>}"; fi
+	if [ "${CLAUDE_CODE_ENABLE_TELEMETRY:-}" = "1" ]; then pass "fills enable-telemetry"; else fail "fills enable-telemetry" "got=${CLAUDE_CODE_ENABLE_TELEMETRY:-<unset>}"; fi
+	# (b) already set → NOT overridden (execution-core.env wins)
+	export OTEL_EXPORTER_OTLP_ENDPOINT="http://daemon-env-wins:4318"
+	_default_otel_from_user_settings
+	if [ "${OTEL_EXPORTER_OTLP_ENDPOINT}" = "http://daemon-env-wins:4318" ]; then pass "does not override an already-set endpoint"; else fail "does not override an already-set endpoint" "got=${OTEL_EXPORTER_OTLP_ENDPOINT}"; fi
+	# (c) settings file absent → no-op success, env untouched
+	unset OTEL_EXPORTER_OTLP_ENDPOINT
+	export CLAUDE_SETTINGS_JSON="$SETTINGS_DIR/does-not-exist.json"
+	if _default_otel_from_user_settings; then pass "absent settings.json → no-op success"; else fail "absent settings.json → no-op success"; fi
+	if [ -z "${OTEL_EXPORTER_OTLP_ENDPOINT:-}" ]; then pass "absent settings.json leaves env unset"; else fail "absent settings.json leaves env unset" "got=${OTEL_EXPORTER_OTLP_ENDPOINT}"; fi
+	unset CLAUDE_SETTINGS_JSON OTEL_EXPORTER_OTLP_ENDPOINT OTEL_EXPORTER_OTLP_PROTOCOL OTEL_METRICS_EXPORTER OTEL_LOGS_EXPORTER CLAUDE_CODE_ENABLE_TELEMETRY
+	rm -rf "$SETTINGS_DIR"
+fi
+
 echo ""
 echo "─────────────────────────────────────────"
 echo "Results: ${PASSES} pass, ${FAILURES} fail"

--- a/plugins/dev/scripts/catalyst-execution-core
+++ b/plugins/dev/scripts/catalyst-execution-core
@@ -86,6 +86,36 @@ _neutralize_otel_attrs() {
 	printf '%s' "$out"
 }
 
+# CTL-1404: the executor=sdk path runs phase agents via the Agent SDK's query(), which
+# spawns the instrumented `claude` CLI as a child process. That child emits Claude Code's
+# built-in claude_code_* OTel metrics (token/cost/session) ONLY when OTEL_EXPORTER_OTLP_ENDPOINT
+# is present in its process env. The bg path inherited it because `claude --bg` RPCs to the user
+# claude daemon, which sources ~/.claude/settings.json (where the OTEL_* keys live); the in-process
+# SDK daemon never had them (execution-core.env carries no OTEL keys), so SDK worker token/cost
+# telemetry went dark. Default the OTLP telemetry env from the single per-node source of truth —
+# ~/.claude/settings.json's .env block — for any key the daemon env hasn't already set
+# (execution-core.env, sourced first, wins). Self-heals every node on restart, no per-node
+# provisioning and no reinstall. tracing.mjs normalizes a grpc :4317 endpoint to http :4318 for its
+# own spans, so propagating settings.json's value verbatim is safe for both signals. jq or the
+# settings file absent → no-op (env left as-is). Verified live (CTL-1404): with the endpoint armed,
+# a 1-turn SDK query() emitted claude_code_cost_usage_USD_total{host_name=...}.
+_default_otel_from_user_settings() {
+	local settings="${CLAUDE_SETTINGS_JSON:-${HOME}/.claude/settings.json}"
+	[[ -f "$settings" ]] || return 0
+	command -v jq >/dev/null 2>&1 || return 0
+	local key val
+	for key in \
+		OTEL_EXPORTER_OTLP_ENDPOINT \
+		OTEL_EXPORTER_OTLP_PROTOCOL \
+		OTEL_METRICS_EXPORTER \
+		OTEL_LOGS_EXPORTER \
+		CLAUDE_CODE_ENABLE_TELEMETRY; do
+		[[ -n "${!key:-}" ]] && continue # execution-core.env / inherited env win — fill gaps only
+		val="$(jq -r --arg k "$key" '.env[$k] // empty' "$settings" 2>/dev/null)" || continue
+		[[ -n "$val" ]] && export "$key=$val"
+	done
+}
+
 # CTL-846: is host:port accepting TCP connections? bash /dev/tcp first, nc fallback.
 # Used to gate mitmproxy proxy vars so a down proxy degrades to direct mode instead of
 # breaking every daemon/worker API call with "connection refused".
@@ -122,6 +152,10 @@ cmd_start() {
 	local _daemon_env="${CATALYST_EXECUTION_CORE_ENV:-${HOME}/.config/catalyst/execution-core.env}"
 	# shellcheck disable=SC1090
 	[[ -f "$_daemon_env" ]] && source "$_daemon_env"
+	# CTL-1404: after the machine-local env wins, fill any unset OTLP telemetry keys from
+	# ~/.claude/settings.json so the SDK-path child `claude` CLI can export claude_code_* metrics
+	# (token/cost/session). No-op when the keys are already set or settings.json/jq are absent.
+	_default_otel_from_user_settings
 	# CTL-1398: arm the SDK subscription token on EVERY daemon start (not just login
 	# shells) so executor=sdk survives NON-login restarts (deploy / broker reload /
 	# launchd / fresh boot) on every host. The token lives in claude-accounts.env

--- a/plugins/dev/scripts/catalyst-execution-core
+++ b/plugins/dev/scripts/catalyst-execution-core
@@ -97,12 +97,21 @@ _neutralize_otel_attrs() {
 # (execution-core.env, sourced first, wins). Self-heals every node on restart, no per-node
 # provisioning and no reinstall. tracing.mjs normalizes a grpc :4317 endpoint to http :4318 for its
 # own spans, so propagating settings.json's value verbatim is safe for both signals. jq or the
-# settings file absent → no-op (env left as-is). Verified live (CTL-1404): with the endpoint armed,
-# a 1-turn SDK query() emitted claude_code_cost_usage_USD_total{host_name=...}.
+# settings file absent → still EXPORT any value the daemon env already set (see below). Verified live
+# (CTL-1404): with the endpoint armed, a 1-turn SDK query() emitted
+# claude_code_cost_usage_USD_total{host_name=...}.
+#
+# EXPORT, don't just skip (Codex P1): a key already present may be a BARE assignment sourced from
+# execution-core.env (e.g. catalyst-join.sh writes `OTEL_EXPORTER_OTLP_ENDPOINT=...` WITHOUT export at
+# :702-703). A bare shell var satisfies `${!key}` but is NOT inherited by the nohup'd daemon child, so
+# the SDK worker would still start endpoint-less. So for a set key we re-`export` it (idempotent;
+# promotes a bare assignment to exported, execution-core.env's value winning); only an UNSET key is
+# filled from settings.json. This is also why the jq/settings guard is per-key, not an early return —
+# the bare→export promotion must run even when settings.json/jq are absent.
 _default_otel_from_user_settings() {
 	local settings="${CLAUDE_SETTINGS_JSON:-${HOME}/.claude/settings.json}"
-	[[ -f "$settings" ]] || return 0
-	command -v jq >/dev/null 2>&1 || return 0
+	local have_src=0
+	[[ -f "$settings" ]] && command -v jq >/dev/null 2>&1 && have_src=1
 	local key val
 	for key in \
 		OTEL_EXPORTER_OTLP_ENDPOINT \
@@ -110,7 +119,11 @@ _default_otel_from_user_settings() {
 		OTEL_METRICS_EXPORTER \
 		OTEL_LOGS_EXPORTER \
 		CLAUDE_CODE_ENABLE_TELEMETRY; do
-		[[ -n "${!key:-}" ]] && continue # execution-core.env / inherited env win — fill gaps only
+		if [[ -n "${!key:-}" ]]; then
+			export "$key" # promote a (possibly bare) daemon-env value so the nohup child inherits it
+			continue
+		fi
+		[[ "$have_src" -eq 1 ]] || continue # unset + no source → leave unset
 		val="$(jq -r --arg k "$key" '.env[$k] // empty' "$settings" 2>/dev/null)" || continue
 		[[ -n "$val" ]] && export "$key=$val"
 	done


### PR DESCRIPTION
## What & why

`executor=sdk` phase-agent workers stopped emitting Claude Code's built-in `claude_code_*` OTel metrics (token/cost/session) that the old `claude --bg` workers emitted. **FinOps + Utilization OBSERVE surfaces went dark for all worker activity** (CTL-1404).

**Root cause (live-verified):** the Agent SDK's `query()` **spawns the instrumented `claude` CLI as a child process**, which exports `claude_code_*` *only* when `OTEL_EXPORTER_OTLP_ENDPOINT` is in its process env. The execution-core daemon's env carried **no OTLP endpoint** (`execution-core.env` has zero OTEL keys), so the SDK child's exporter started *enabled-but-with-nowhere-to-send* → zero metrics. The bg path worked only because `claude --bg` RPCs to the *user* claude daemon, which sources `~/.claude/settings.json` (where the endpoint lives).

This **overturns** the earlier "SDK has no instrumentation / needs a Catalyst MeterProvider shim" theory — the instrumentation is reachable; the endpoint was simply missing from the daemon env.

## Fix

`catalyst-execution-core` (the launcher) now defaults the OTLP telemetry env (`OTEL_EXPORTER_OTLP_ENDPOINT`, `_PROTOCOL`, `OTEL_METRICS_EXPORTER`, `OTEL_LOGS_EXPORTER`, `CLAUDE_CODE_ENABLE_TELEMETRY`) from `~/.claude/settings.json`'s `.env` block — but **only for keys the daemon env hasn't already set** (`execution-core.env`, sourced first, still wins). Self-heals every node on restart: no per-node provisioning, no reinstall. `jq`/settings absent → no-op.

Safe for both signals: `tracing.mjs` already normalizes a grpc `:4317` endpoint to http `:4318` for its own spans, so propagating settings.json verbatim doesn't break daemon traces.

## Verification

Live on mini: armed the endpoint → 1-turn SDK `query()` → `claude_code_cost_usage_USD_total{host_name="mini"}=0.0969515` (== the probe's `cost_usd`) + the `token_usage` series landed in Prometheus seconds later. Previously only `laptop` (interactive CLI) emitted.

Both worker nodes (mini, mini-2) were also armed manually via `execution-core.env` as an interim until this lands fleet-wide.

## Tests

Adds **test 10** to `catalyst-execution-core.test.sh`: fills-when-unset, does-not-override-an-already-set value, absent-settings no-op. Helper verified in isolation; `bash -n` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)