### PR TITLE
feat(dev): CTL-1397 — route remaining skill-prose Linear reads through catalyst-linear

### DIFF
--- a/plugins/dev/skills/compound-estimate/SKILL.md
+++ b/plugins/dev/skills/compound-estimate/SKILL.md
@@ -81,7 +81,7 @@ plugins/dev/scripts/compound-log.sh write "$TICKET_ID" \
 
 The helper resolves the rest:
 - `pr_number`, `merged_at`, `created_at` via `gh pr view`
-- `estimate_at_start` via `linearis issues read <ticket> | jq .estimate`
+- `estimate_at_start` via `catalyst-linear read <ticket> | jq .estimate`
 - `cost_usd` from `catalyst-state.sh` worker aggregate (orchestrator mode) or `catalyst-session.sh history --ticket` (local fallback)
 - `wall_time_hours` computed from PR `createdAt` → `mergedAt`
 
@@ -171,8 +171,8 @@ what_surprised_me: "Prometheus integration wasn't plumbed; local state.json suff
 
 - **Primary cost source** is local: the `catalyst-state.sh` worker-usage aggregate (when orchestrated) or `catalyst-session.sh history` (standalone). This is deliberate — `claude-code-otel` + Prometheus is referenced in the original spec but not yet wired up in this repo.
 - **Prometheus overlay** is gated by `CATALYST_PROMETHEUS_URL`. When set, the helper logs a note to stderr; the HTTP client itself is a follow-up ticket.
-- **Linear estimate** is read as an integer from `linearis issues read`. The team's estimation config (T-shirt, Fibonacci, linear) is applied client-side when re-scoring in step 3.
-- **Read source:** `linearis issues read` is the standard-node direct read; on a Catalyst Cloud node the replica is read first (evidence-based fallback to `linearis`) — see the `linearis` skill's "Reading Linear" section.
+- **Linear estimate** is read as an integer from `catalyst-linear read`. The team's estimation config (T-shirt, Fibonacci, linear) is applied client-side when re-scoring in step 3.
+- **Read source:** reads go through `catalyst-linear read` (replica-first when opted in *and* fresh, automatic fail-open to a direct `linearis` read otherwise) — see the `linearis` skill's "Reading Linear" section.
 
 ## Testing
 

--- a/plugins/dev/skills/morning-briefing/SKILL.md
+++ b/plugins/dev/skills/morning-briefing/SKILL.md
@@ -76,7 +76,7 @@ Populate the `decisions:` array from four sources:
    that drift from the codebase. See [ADR-DRIFT.md](./ADR-DRIFT.md).
 2. **Blocked PRs** — `gh search prs --review-requested @me --state open --json …` filtered to
    PRs with no commit in the last 48h. Each becomes one `{type: blocked_pr, …}` decision.
-3. **Judgment-call Linear tickets** — `catalyst-linear list --team <team> --status "Triage,In Progress" --label needs-decision` (label name is informational; substitute whatever signal the operator uses).
+3. **Judgment-call Linear tickets** — `linearis issues list --team <team> --status "Triage,In Progress" --label needs-decision` (label name is informational; substitute whatever signal the operator uses).
 4. **Pending compound-engineering ADR proposals** — the `ticket-compound` curator queues
    APPROVE-gated ADR changes at `thoughts/shared/compound/pending/<TICKET>.md`. Each pending file
    becomes one decision the morning ritual can approve via `briefing-followup`'s
@@ -219,7 +219,7 @@ fi
 
 ## Step 4: Gather "today"
 
-- In-progress Linear tickets — `catalyst-linear list --team <team> --status "In Progress" --limit 20`
+- In-progress Linear tickets — `linearis issues list --team <team> --status "In Progress" --limit 20`
 - Today's calendar — already gathered in Step 2, reuse `$SCRATCH/calendar.json`
 - Follow-ups — extract action items from the prior day's Granola notes (`$SCRATCH/granola.json`)
   via a Claude-side synthesis pass
@@ -261,7 +261,7 @@ jq -nc --slurpfile rs <(jq -sc '.' "$SCRATCH/retro-signals.jsonl") \
 Query Linear for tickets that look ready for `/catalyst-legacy:orchestrate`:
 
 ```bash
-catalyst-linear list \
+linearis issues list \
   --team "$(jq -r '.catalyst.linear.teamKey' .catalyst/config.json)" \
   --status "Triage,Backlog" \
   --priority 1 --priority 2 \

--- a/plugins/dev/skills/morning-briefing/SKILL.md
+++ b/plugins/dev/skills/morning-briefing/SKILL.md
@@ -76,7 +76,7 @@ Populate the `decisions:` array from four sources:
    that drift from the codebase. See [ADR-DRIFT.md](./ADR-DRIFT.md).
 2. **Blocked PRs** — `gh search prs --review-requested @me --state open --json …` filtered to
    PRs with no commit in the last 48h. Each becomes one `{type: blocked_pr, …}` decision.
-3. **Judgment-call Linear tickets** — `linearis issues list --team <team> --status "Triage,In Progress" --label needs-decision` (label name is informational; substitute whatever signal the operator uses).
+3. **Judgment-call Linear tickets** — `catalyst-linear list --team <team> --status "Triage,In Progress" --label needs-decision` (label name is informational; substitute whatever signal the operator uses).
 4. **Pending compound-engineering ADR proposals** — the `ticket-compound` curator queues
    APPROVE-gated ADR changes at `thoughts/shared/compound/pending/<TICKET>.md`. Each pending file
    becomes one decision the morning ritual can approve via `briefing-followup`'s
@@ -219,7 +219,7 @@ fi
 
 ## Step 4: Gather "today"
 
-- In-progress Linear tickets — `linearis issues list --team <team> --status "In Progress" --limit 20`
+- In-progress Linear tickets — `catalyst-linear list --team <team> --status "In Progress" --limit 20`
 - Today's calendar — already gathered in Step 2, reuse `$SCRATCH/calendar.json`
 - Follow-ups — extract action items from the prior day's Granola notes (`$SCRATCH/granola.json`)
   via a Claude-side synthesis pass
@@ -261,7 +261,7 @@ jq -nc --slurpfile rs <(jq -sc '.' "$SCRATCH/retro-signals.jsonl") \
 Query Linear for tickets that look ready for `/catalyst-legacy:orchestrate`:
 
 ```bash
-linearis issues list \
+catalyst-linear list \
   --team "$(jq -r '.catalyst.linear.teamKey' .catalyst/config.json)" \
   --status "Triage,Backlog" \
   --priority 1 --priority 2 \

--- a/plugins/dev/skills/phase-triage/SKILL.md
+++ b/plugins/dev/skills/phase-triage/SKILL.md
@@ -373,7 +373,7 @@ and your job here is the second one:
 
 2. **Triage as a SECOND PAIR OF EYES (your job).** You are NOT a parser. Do **not** add a dependency
    because an id appears in the prose. Instead: read the ticket's intent, then **examine the
-   relevant backlog** — `catalyst-linear list` for the ticket's team / area (and
+   relevant backlog** — `linearis issues list` for the ticket's team / area (and
    `catalyst-linear read <id>` to confirm a candidate) — and judge whether any in-flight or planned
    work is a **true prerequisite the author may have missed**: work that must reach a terminal state
    before this ticket can sensibly start (a shared interface not yet built, a migration that must
@@ -399,8 +399,8 @@ STEP E, `scheduler.mjs` — it reads `triage.json.dependencies`, re-validates ea
 **cross-team (CTL-838)** ids before writing the durable edge with `applyBlockedByRelation`). Keeping
 the write scheduler-side preserves the CTL-497/CTL-558 contract — the phase-triage e2e negative
 guard fails the build if this skill ever emits a `linearis issues update` call.
-The `catalyst-linear read` / `list` backlog reads above are read-only and are fine. STEP E tolerates
-BOTH the flat-string and the rich `{id}` shapes.
+The `catalyst-linear read` (and the `linearis issues list` backlog scan) reads above are read-only
+and are fine. STEP E tolerates BOTH the flat-string and the rich `{id}` shapes.
 
 3. If the refined fields differ materially, post a follow-up `linearis issues discuss` comment
    marking the refinement.

--- a/plugins/dev/skills/phase-triage/SKILL.md
+++ b/plugins/dev/skills/phase-triage/SKILL.md
@@ -373,8 +373,8 @@ and your job here is the second one:
 
 2. **Triage as a SECOND PAIR OF EYES (your job).** You are NOT a parser. Do **not** add a dependency
    because an id appears in the prose. Instead: read the ticket's intent, then **examine the
-   relevant backlog** — `linearis issues list` for the ticket's team / area (and
-   `linearis issues read <id>` to confirm a candidate) — and judge whether any in-flight or planned
+   relevant backlog** — `catalyst-linear list` for the ticket's team / area (and
+   `catalyst-linear read <id>` to confirm a candidate) — and judge whether any in-flight or planned
    work is a **true prerequisite the author may have missed**: work that must reach a terminal state
    before this ticket can sensibly start (a shared interface not yet built, a migration that must
    land first, an explicit "must follow" sequencing). Record **only** blockers you can justify, in
@@ -399,8 +399,8 @@ STEP E, `scheduler.mjs` — it reads `triage.json.dependencies`, re-validates ea
 **cross-team (CTL-838)** ids before writing the durable edge with `applyBlockedByRelation`). Keeping
 the write scheduler-side preserves the CTL-497/CTL-558 contract — the phase-triage e2e negative
 guard fails the build if this skill ever emits a `linearis issues update` call.
-`linearis issues read` is read-only and is fine. STEP E tolerates BOTH the flat-string and the rich
-`{id}` shapes.
+The `catalyst-linear read` / `list` backlog reads above are read-only and are fine. STEP E tolerates
+BOTH the flat-string and the rich `{id}` shapes.
 
 3. If the refined fields differ materially, post a follow-up `linearis issues discuss` comment
    marking the refinement.


### PR DESCRIPTION
## Summary

CTL-1397 mandates that AI agents' Linear **reads** go through the replica-first `catalyst-linear read|list|search` wrapper (CTL-1391) instead of bare `linearis`, so reads hit the local Catalyst Cloud replica when present and don't burn the rate-limited Linear API. The mandate is mostly enforced (linearis skill + research agents + the phase-triage bash body), but a few **SKILL.md prose** callsites still told agents to use bare `linearis` for reads. This converts **only** those clear read references. **No writes are touched.**

## Changes (before → after)

### `plugins/dev/skills/phase-triage/SKILL.md` (highest value — on the quota every dispatch)
- **L376** the per-dispatch blocker-scan: `linearis issues list` → `catalyst-linear list` (read the backlog for the ticket's team/area)
- **L377** `linearis issues read <id>` → `catalyst-linear read <id>` (confirm a candidate blocker)
- **L402** prose: ``\`linearis issues read\` is read-only and is fine`` → ``The \`catalyst-linear read\` / \`list\` backlog reads above are read-only and are fine`` (keeps the read-vs-write contrast; the read is now via the wrapper)

> The phase-triage **bash body** already reads via `catalyst-linear` (the e2e test at `phase-triage-e2e.test.sh:298` confirms it). This change aligns the human-readable "second pair of eyes" prose guidance with the already-converted body.

### `plugins/dev/skills/morning-briefing/SKILL.md`
- **L79** judgment-call tickets: `linearis issues list --team … --label needs-decision` → `catalyst-linear list …`
- **L222** in-progress tickets: `linearis issues list --team … --status "In Progress" --limit 20` → `catalyst-linear list …`
- **L264** orchestrator-suggest query: `linearis issues list \ …` → `catalyst-linear list \ …` (flags/pipes/jq unchanged; the wrapper's `list` is a pure linearis passthrough so output — incl. `.relations.nodes` used for `blocked_by` filtering — is identical)

### `plugins/dev/skills/compound-estimate/SKILL.md`
- **L84** `estimate_at_start` via `linearis issues read <ticket> | jq .estimate` → `catalyst-linear read …` (the replica normalizer serves `estimate` — `linear-cli.mjs:287` — and fails open to `linearis` otherwise)
- **L174–175** the "Linear estimate" + "Read source" notes updated to reference `catalyst-linear read` as the read path

## Left UNCHANGED (intentional)

- **`plugins/dev/skills/phase-research/SKILL.md:128`** — `linearis issues read $TICKET --with-attachments`. **Carve-out:** attachments are not mirrored to the replica, so a flagged read must stay on bare `linearis`. (The wrapper *would* fail open on a read flag, but per the handoff this stays explicit.)
- **`plugins/dev/skills/linearis/SKILL.md`** — the linearis skill's own command-reference examples document `linearis` itself; leaving them.
- **`plugins/dev/agents/linear-research.md` / `plugins/pm/agents/linear-research.md`** — research agents; already mandate `catalyst-linear read|list|search`.
- **`plugins/dev/skills/monitor-events/SKILL.md:16`** / **`recovery-pass/SKILL.md:410`** — explanatory prose about the read path, not commands to run.
- **`plugins/legacy/skills/orchestrate/SKILL.md:474`** — a real read (`linearis issues read … | jq .title`), but in the **catalyst-legacy** plugin (different plugin/scope, preserved fallback runtime). Out of the named scope; flagged for follow-up rather than converted.
- **All writes** — `linearis issues update`, status transitions, `--status`, `issues discuss` comments — stay on `linearis`.
- **`plugins/dev/scripts/**`, tests, CHANGELOG** — not skill prose; the daemon's `linear-query.mjs`/`linear-cache.mjs` reads already go through the resolved read-source seam.

## Test impact

None. No test asserts the prose strings changed. The phase-triage e2e test already stubs `catalyst-linear` (not `linearis`) for the triage read path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Dfk5ZoEmBbh7SMamrCcsFW