### PR TITLE
feat(dev): CTL-1397 (4/n) — gate replica discovery on the writer heartbeat lock (close the quiet-feed linearis fallback)

### DIFF
--- a/plugins/dev/scripts/execution-core/replica-read.mjs
+++ b/plugins/dev/scripts/execution-core/replica-read.mjs
@@ -99,15 +99,34 @@ const RELATIONS_INVERSE_SELECT = `SELECT type, issue_identifier FROM relations W
 // cursor-present = seed complete; cursor-absent/empty = mid-reseed → don't serve.
 const SEED_COMPLETE_SELECT = `SELECT 1 FROM sync_meta WHERE key = 'cursor' AND value IS NOT NULL AND value <> '' LIMIT 1`;
 
-// The eligible freshness GATE — the SAME mtime-based writer-liveness proxy as
-// linear-cli.mjs's openFreshReplica. A dead writer stops touching the file →
-// stale mtime → fall through to linearis (correct answer, just un-accelerated).
-// WAL mode: appends land in the `-wal` sidecar; the main DB mtime only advances
-// on checkpoint, so take the freshest of the DB + a NON-EMPTY `-wal` (an empty
-// `-wal` is a reader artifact, never a writer-liveness signal — see the spoof-
-// resistance note in linear-cli.mjs). Threshold = CATALYST_LINEAR_REPLICA_STALE_MS
-// (default 5 min). Returns true when fresh, false when absent/stale/unstattable.
+// The eligible freshness GATE — a writer-LIVENESS proxy. A dead writer must stop
+// the replica from serving discovery, so we fall through to linearis (correct
+// answer, just un-accelerated).
+//
+// CTL-1397 (4/n): gate on the cloud-sync writer's HEARTBEAT file
+// `<db>.writer.lock`, NOT the db/`-wal` mtime. The `-wal` mtime only advances on
+// an actual APPLY, so during a QUIET Linear feed (live writer, no issue updates)
+// it goes stale within the threshold even though the replica is perfectly current
+// — and gating discovery on that false-falls-through to `linearis issues list`
+// exactly when the board is UNCHANGED, burning the shared quota + tripping the
+// CTL-679 breaker (the residual board-freeze this closes; observed live: mini
+// `-wal` 520s stale while `.writer.lock` heartbeated 5s ago). The writer touches
+// `.writer.lock` every few seconds regardless of data changes, so its mtime
+// tracks the WRITER being alive. Fall back to the db/`-wal` mtime only when the
+// lock is absent (bootstrap / an older writer without the heartbeat file).
+// Threshold = CATALYST_LINEAR_REPLICA_STALE_MS (default 5 min). Returns true when
+// fresh, false when absent/stale/unstattable.
 function isReplicaFresh(dbPath) {
+  const thresholdMs = Number(process.env.CATALYST_LINEAR_REPLICA_STALE_MS) || 300_000;
+  // Preferred signal: the writer's heartbeat lock (advances on liveness, not on
+  // data changes). Present → it is authoritative (a present-but-stale lock means
+  // the writer died, so we do NOT serve even if a recent apply left `-wal` fresh).
+  try {
+    const lock = statSync(dbPath + ".writer.lock");
+    return Date.now() - lock.mtimeMs <= thresholdMs;
+  } catch {
+    /* lock absent → fall back to the db/-wal mtime liveness proxy below */
+  }
   let newest;
   try {
     newest = statSync(dbPath).mtimeMs; // throws if the file is absent → not fresh
@@ -120,7 +139,6 @@ function isReplicaFresh(dbPath) {
   } catch {
     /* -wal absent → main DB mtime only */
   }
-  const thresholdMs = Number(process.env.CATALYST_LINEAR_REPLICA_STALE_MS) || 300_000;
   return Date.now() - newest <= thresholdMs;
 }
 

--- a/plugins/dev/scripts/execution-core/replica-read.test.mjs
+++ b/plugins/dev/scripts/execution-core/replica-read.test.mjs
@@ -442,6 +442,7 @@ describe("createReplicaReader.eligible (CTL-1397 board-list)", () => {
     const old = new Date(Date.now() - 2 * 60_000); // 2 min old
     utimesSync(dbPath, old, old);
     try { utimesSync(dbPath + "-wal", old, old); } catch { /* -wal may be absent */ }
+    // no writer.lock in this fixture → the gate falls back to the db/-wal mtime.
     const prev = process.env.CATALYST_LINEAR_REPLICA_STALE_MS;
     process.env.CATALYST_LINEAR_REPLICA_STALE_MS = "60000"; // 1 min threshold → 2-min-old is stale
     try {
@@ -451,6 +452,36 @@ describe("createReplicaReader.eligible (CTL-1397 board-list)", () => {
       if (prev === undefined) delete process.env.CATALYST_LINEAR_REPLICA_STALE_MS;
       else process.env.CATALYST_LINEAR_REPLICA_STALE_MS = prev;
     }
+  });
+
+  // CTL-1397 (4/n) — the freshness gate prefers the writer's HEARTBEAT lock
+  // (`<db>.writer.lock`) over the db/-wal mtime, so a QUIET feed (live writer, no
+  // issue updates → stale -wal) still serves discovery from the replica instead of
+  // false-falling-through to linearis.
+  test("QUIET FEED: fresh .writer.lock + STALE db/-wal → still serves the replica (no linearis fallback)", () => {
+    seedEligible();
+    // Simulate a quiet feed: the db + -wal went stale (no recent apply)…
+    const old = new Date(Date.now() - 10 * 60_000);
+    utimesSync(dbPath, old, old);
+    try { utimesSync(dbPath + "-wal", old, old); } catch { /* -wal may be absent */ }
+    // …but the writer is alive and heartbeated its lock just now.
+    writeFileSync(dbPath + ".writer.lock", "");
+    utimesSync(dbPath + ".writer.lock", new Date(), new Date());
+    reader = createReplicaReader({ dbPath });
+    const res = reader.eligible({ team: "CTL", status: "Todo" });
+    expect(res?.nodes.map((n) => n.identifier)).toEqual(["CTL-100", "CTL-101"]);
+  });
+
+  test("DEAD WRITER: STALE .writer.lock is authoritative → undefined even if db/-wal is fresh", () => {
+    seedEligible(); // db + -wal fresh (a recent apply just before the writer died)
+    // The writer died: its lock stopped heartbeating and is now well past the threshold.
+    const old = new Date(Date.now() - 10 * 60_000);
+    writeFileSync(dbPath + ".writer.lock", "");
+    utimesSync(dbPath + ".writer.lock", old, old);
+    reader = createReplicaReader({ dbPath });
+    // A present-but-stale lock means the writer is gone → do NOT serve (the data
+    // will only drift from here), even though the db/-wal mtime is fresh.
+    expect(reader.eligible({ team: "CTL", status: "Todo" })).toBeUndefined();
   });
 
   test("fail-open: DB without the issues table → undefined (query throws)", () => {


### PR DESCRIPTION
## Why

The board-freeze fix (#2502 board-list→replica, #2509 empty-trust) only **half-worked** in production. Live verification after deploy:

- `eligible_source` = **~50% replica / ~50% linearis** during an active feed;
- **~100% linearis during a QUIET feed** (the reader MISSed 6/6 for CTL/Todo on mini).

### Root cause — the freshness gate false-positives during a quiet feed

`isReplicaFresh` gated on the db/`-wal` mtime. But `-wal` mtime only advances on an actual **apply**. During a quiet Linear feed (live writer, no issue updates) the `-wal` goes stale within the 5-min threshold even though the replica is **perfectly current** — so `eligible()` returns a MISS and discovery false-falls-through to `linearis issues list`, burning the shared quota + tripping the CTL-679 breaker **exactly when the board is unchanged**.

Observed live on mini: `-wal` **520s** stale while the writer was demonstrably alive — `.writer.lock` heartbeated **5s** ago and the cursor advancing (330766). The `.writer.lock` mtime advanced +10s over a 7s sample → it heartbeats.

## What

Gate on the cloud-sync writer's **heartbeat file `<db>.writer.lock`** (touched every few seconds regardless of data changes — already doctor's writer-liveness signal), not the update-driven `-wal`:

- lock **fresh** → writer alive → serve the (current) replica, even on a quiet feed;
- lock **present but stale** → writer died → do NOT serve (authoritative, even if a final apply left `-wal` fresh);
- lock **absent** → fall back to the db/`-wal` mtime (bootstrap / older writer).

Threshold unchanged (`CATALYST_LINEAR_REPLICA_STALE_MS`, default 5 min). Eligible-path only (`lookup`/`freshness`/`titles` already fail-open on error).

## Tests

`replica-read` **42 pass** — added **QUIET-FEED** (fresh lock + stale db/`-wal` → serves) and **DEAD-WRITER** (stale lock authoritative → undefined even with fresh db/`-wal`); existing stale/override tests exercise the lock-absent fallback.

## Verify after deploy

On mini/mini-2, `eligible_source` should go to **~100% replica** (with periodic linearis re-confirms per #2509's confirmed-empty window), and the CTL-679 breaker → quiet even through quiet-feed periods.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Dfk5ZoEmBbh7SMamrCcsFW