### PR TITLE
feat(dev): CTL-1397 — pivot agent Linear reads to direct SQLite; deprecate catalyst-linear CLI

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,7 +43,7 @@ No build process — this is markdown files and bash scripts.
 - **Wait for all agents before synthesizing** — Don't proceed until research completes
 - **Config drives behavior** — No hardcoded values
 - **Single source of truth** — Don't duplicate information across files:
-  - CLI syntax lives in skills (e.g., the `linearis` skill, which also defines the two-mode rule for agent Linear reads — standard vs. Catalyst Cloud node) — reference it, don't copy
+  - CLI syntax lives in skills (e.g., the `linearis` skill, which also defines the direct-SQLite read rule for agent Linear reads — reads → the local replica, writes → `linearis`) — reference it, don't copy
   - Workflow logic lives in skills — each skill owns its own state transitions
   - Config schema lives in `website/src/content/docs/reference/configuration.md`
 - **Spawn parallel agents** — Maximize efficiency

--- a/plugins/dev/agents/linear-research.md
+++ b/plugins/dev/agents/linear-research.md
@@ -3,14 +3,14 @@ name: linear-research
 description:
   Research Linear tickets, cycles, projects, and milestones using Linearis CLI. Optimized for LLM
   consumption with minimal token usage (~1k vs 13k for Linear MCP).
-tools: Bash(catalyst-linear *), Bash(linearis *), Read, Grep
+tools: Bash(sqlite3 *), Bash(linearis *), Read, Grep
 model: haiku
 version: 1.0.0
 ---
 
 You are a specialist at researching Linear tickets, cycles, projects, and workflow state. Ticket
-reads go through the `catalyst-linear` read CLI; cycles, projects, milestones, and command syntax
-use the Linearis CLI.
+reads query the local Catalyst Cloud replica directly with SQL; cycles, projects, milestones, list
+queries, command syntax, and writes use the Linearis CLI.
 
 ## Core Responsibilities
 
@@ -47,7 +47,7 @@ not guess or improvise commands**.
 
 All linearis output is JSON — use jq for filtering and transformation.
 
-**Read-source mode**: Ticket reads are **mandatory** through `catalyst-linear read|list|search` — **never** bare `linearis issues read|list|search` — per the `catalyst-dev:linearis` skill's mandatory read rule ("Reading Linear" section): `catalyst-linear` owns the two-mode replica logic (replica-first when opted in *and* fresh, automatic fail-open to `linearis` otherwise), so you never decide by node identity. Cycle, project, and milestone reads have no `catalyst-linear` form, so they stay on `linearis` (`linearis cycles|projects|milestones list/read`). Writes always go through `linearis`.
+**Read-source mode (direct SQL)**: Ticket reads → query `~/catalyst/catalyst-replica.db` directly with `sqlite3`, per the `catalyst-dev:linearis` skill's "Reading Linear" section — that section owns the two-gate freshness check (writer.lock + `sync_meta` cursor), the schema, and the **loud** `linearis` fallback rule (a stale/absent replica is an alarm to surface + file, not a silent reroute). Do **not** bare-`linearis`-read a ticket the fresh replica can serve. Cycle/project/milestone reads and filtered `issues list`/`search` have no issue-shaped replica form yet, so they stay on `linearis`. Writes always go through `linearis`.
 
 ## Output Format
 

--- a/plugins/dev/agents/linear-research.md
+++ b/plugins/dev/agents/linear-research.md
@@ -3,7 +3,7 @@ name: linear-research
 description:
   Research Linear tickets, cycles, projects, and milestones using Linearis CLI. Optimized for LLM
   consumption with minimal token usage (~1k vs 13k for Linear MCP).
-tools: Bash(sqlite3 *), Bash(linearis *), Read, Grep
+tools: Bash(sqlite3 *), Bash(stat *), Bash(date *), Bash(linearis *), Read, Grep
 model: haiku
 version: 1.0.0
 ---

--- a/plugins/dev/scripts/__tests__/compound-log.test.sh
+++ b/plugins/dev/scripts/__tests__/compound-log.test.sh
@@ -19,6 +19,13 @@ PASSES=0
 SCRATCH="$(mktemp -d)"
 trap 'rm -rf "$SCRATCH"' EXIT
 
+# CTL-1397: compound-log reads the estimate via direct SQL (linear_read_ticket).
+# Point the replica at a nonexistent path so the helper deterministically falls
+# back to the `linearis issues read` stub on PATH — hermetic, independent of any
+# real replica in the runner's HOME. The direct-SQL HIT path is covered by
+# linear-read-replica.test.sh.
+export CATALYST_REPLICA_DB="${SCRATCH}/no-such-replica.db"
+
 pass() { PASSES=$((PASSES+1)); echo "  PASS: $1"; }
 fail() {
   FAILURES=$((FAILURES+1))
@@ -61,20 +68,6 @@ fi
 exit 0
 EOF
   chmod +x "${bin_dir}/linearis"
-
-  # CTL-1397: compound-log now reads the estimate via `catalyst-linear read`.
-  cat > "${bin_dir}/catalyst-linear" <<'EOF'
-#!/usr/bin/env bash
-if [ "$1" = "read" ]; then
-  if [ -n "${FAKE_LINEARIS_JSON:-}" ]; then
-    echo "$FAKE_LINEARIS_JSON"
-    exit 0
-  fi
-  exit 1
-fi
-exit 0
-EOF
-  chmod +x "${bin_dir}/catalyst-linear"
 }
 
 # Set up an isolated scratch project: thoughts root + fake-bin PATH prefix +

--- a/plugins/dev/scripts/__tests__/linear-read-replica.test.sh
+++ b/plugins/dev/scripts/__tests__/linear-read-replica.test.sh
@@ -123,6 +123,10 @@ if replica_fresh; then ok "cursor restored: replica_fresh → true"; else fail "
 linear_read_ticket "not-a-ticket" >/dev/null 2>&1
 assert_eq "bad id: rc 2" "2" "$?"
 
+# ── 10. DB path resolution honors CATALYST_DIR (matches daemon getReplicaDbPath) ─
+RESOLVED="$(env -u CATALYST_REPLICA_DB CATALYST_DIR=/custom/dir bash -c 'source "'"$HELPER"'"; printf "%s" "$CATALYST_REPLICA_DB"')"
+assert_eq "resolves \$CATALYST_DIR when REPLICA_DB unset" "/custom/dir/catalyst-replica.db" "$RESOLVED"
+
 echo "─────────────────────────────────────────"
 echo "Results: $PASS passed, $FAIL failed"
 [ "$FAIL" -eq 0 ]

--- a/plugins/dev/scripts/__tests__/linear-read-replica.test.sh
+++ b/plugins/dev/scripts/__tests__/linear-read-replica.test.sh
@@ -1,0 +1,128 @@
+#!/usr/bin/env bash
+# linear-read-replica.test.sh — CTL-1397: unit tests for the direct-SQLite Linear
+# read helper (lib/linear-read-replica.sh). Covers the two-gate freshness check
+# (writer.lock heartbeat + sync_meta cursor), the normalized SQL HIT shape (which
+# must match `catalyst-linear read` / `linearis issues read`), and the LOUD
+# linearis fallback on stale / seed-incomplete / absent-lock / MISS.
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+HELPER="${SCRIPT_DIR}/../lib/linear-read-replica.sh"
+
+PASS=0
+FAIL=0
+ok() {
+	PASS=$((PASS + 1))
+	printf '  PASS: %s\n' "$1"
+}
+fail() {
+	FAIL=$((FAIL + 1))
+	printf '  FAIL: %s\n    %s\n' "$1" "$2"
+}
+assert_eq() { if [ "$2" = "$3" ]; then ok "$1"; else fail "$1" "expected '$2' got '$3'"; fi; }
+
+command -v sqlite3 >/dev/null 2>&1 || {
+	echo "SKIP: sqlite3 not available"
+	exit 0
+}
+command -v jq >/dev/null 2>&1 || {
+	echo "SKIP: jq not available"
+	exit 0
+}
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+# ── Fixture replica DB (a realistic subset of the live schema) ────────────────
+DB="$TMP/replica.db"
+sqlite3 "$DB" <<'SQL'
+CREATE TABLE issues (id TEXT PRIMARY KEY, identifier TEXT, title TEXT, state TEXT,
+  estimate REAL, description TEXT, url TEXT, branch_name TEXT, assignee TEXT,
+  assignee_id TEXT, priority INTEGER, removed_at INTEGER);
+CREATE TABLE labels (id TEXT PRIMARY KEY, name TEXT);
+CREATE TABLE issue_labels (issue_id TEXT, label_id TEXT);
+CREATE TABLE sync_meta (key TEXT PRIMARY KEY, value TEXT);
+INSERT INTO issues (id,identifier,title,state,estimate,description,url,assignee_id,assignee,priority,removed_at)
+  VALUES ('i1','TST-1','Fix the thing','Implement',3,'A description','https://linear.app/x/TST-1','u1','Ryan',2,NULL);
+INSERT INTO issues (id,identifier,title,state,removed_at) VALUES ('i2','TST-2','Tombstoned','Done',12345);
+INSERT INTO labels (id,name) VALUES ('l1','bug'),('l2','backend');
+INSERT INTO issue_labels (issue_id,label_id) VALUES ('i1','l1'),('i1','l2');
+INSERT INTO sync_meta (key,value) VALUES ('cursor','9999');
+SQL
+
+fresh_lock() { : >"$DB.writer.lock"; } # heartbeat = now
+fresh_lock
+
+export CATALYST_REPLICA_DB="$DB"
+# shellcheck source=/dev/null
+source "$HELPER"
+
+# ── linearis stub on PATH for the fallback cases ──────────────────────────────
+STUBBIN="$TMP/bin"
+mkdir -p "$STUBBIN"
+cat >"$STUBBIN/linearis" <<'EOF'
+#!/usr/bin/env bash
+echo "LINEARIS_CALLED $*" >&2
+echo '{"identifier":"FALLBACK","state":{"name":"FromLinearis"}}'
+EOF
+chmod +x "$STUBBIN/linearis"
+export PATH="$STUBBIN:$PATH"
+
+echo "linear-read-replica: freshness gates + HIT shape + loud fallback"
+
+# ── 1. Freshness gate ─────────────────────────────────────────────────────────
+if replica_fresh; then ok "replica_fresh: fresh lock + cursor → true"; else fail "replica_fresh true" "returned false"; fi
+
+# ── 2. HIT: normalized fields match the canonical shape ───────────────────────
+HIT="$(linear_read_ticket TST-1 2>/dev/null)"
+assert_eq "HIT: state.name" "Implement" "$(echo "$HIT" | jq -r '.state.name')"
+assert_eq "HIT: estimate is 3" "3" "$(echo "$HIT" | jq -r '.estimate | floor')"
+assert_eq "HIT: title" "Fix the thing" "$(echo "$HIT" | jq -r '.title')"
+assert_eq "HIT: url" "https://linear.app/x/TST-1" "$(echo "$HIT" | jq -r '.url')"
+assert_eq "HIT: description" "A description" "$(echo "$HIT" | jq -r '.description')"
+assert_eq "HIT: labels canonical {nodes:[…]}" "backend,bug" "$(echo "$HIT" | jq -r '[.labels.nodes[].name] | sort | join(",")')"
+assert_eq "HIT: assignee.name" "Ryan" "$(echo "$HIT" | jq -r '.assignee.name')"
+
+# ── 3. HIT does NOT touch linearis (the whole point: quota relief) ─────────────
+HIT_ERR="$(linear_read_ticket TST-1 2>&1 >/dev/null)"
+if echo "$HIT_ERR" | grep -q "LINEARIS_CALLED"; then
+	fail "HIT avoids linearis" "linearis was called on a fresh HIT"
+else
+	ok "HIT does not call linearis"
+fi
+
+# ── 4. Tombstoned row (removed_at set) → MISS → loud fallback ──────────────────
+OUT="$(linear_read_ticket TST-2 2>"$TMP/e4.err")"
+assert_eq "tombstone: fell back to linearis" "FromLinearis" "$(echo "$OUT" | jq -r '.state.name')"
+if grep -q "MISS" "$TMP/e4.err"; then ok "tombstone: emitted loud MISS warning"; else fail "tombstone warning" "no MISS on stderr"; fi
+
+# ── 5. Absent id → MISS → fallback ────────────────────────────────────────────
+OUT="$(linear_read_ticket TST-999 2>/dev/null)"
+assert_eq "absent id: fell back to linearis" "FromLinearis" "$(echo "$OUT" | jq -r '.state.name')"
+
+# ── 6. Stale writer.lock (heartbeat old) → not fresh → loud fallback ──────────
+touch -t 202001010000 "$DB.writer.lock"
+if replica_fresh; then fail "stale lock" "replica_fresh returned true on a stale lock"; else ok "stale lock: replica_fresh → false"; fi
+OUT="$(linear_read_ticket TST-1 2>"$TMP/e6.err")"
+assert_eq "stale lock: fell back to linearis" "FromLinearis" "$(echo "$OUT" | jq -r '.state.name')"
+if grep -q "STALE/ABSENT" "$TMP/e6.err"; then ok "stale lock: emitted loud STALE warning"; else fail "stale warning" "no STALE on stderr"; fi
+fresh_lock
+
+# ── 7. Absent writer.lock → not fresh → fallback ──────────────────────────────
+rm -f "$DB.writer.lock"
+if replica_fresh; then fail "absent lock" "replica_fresh returned true with no lock"; else ok "absent lock: replica_fresh → false"; fi
+fresh_lock
+
+# ── 8. Seed incomplete (no cursor row) → not fresh → fallback ─────────────────
+sqlite3 "$DB" "DELETE FROM sync_meta WHERE key='cursor';"
+if replica_fresh; then fail "no cursor" "replica_fresh returned true mid-reseed (no cursor)"; else ok "no cursor: replica_fresh → false"; fi
+sqlite3 "$DB" "INSERT INTO sync_meta (key,value) VALUES ('cursor','9999');"
+if replica_fresh; then ok "cursor restored: replica_fresh → true"; else fail "cursor restore" "still false"; fi
+
+# ── 9. Bad ticket id → rc 2, no read attempted ────────────────────────────────
+linear_read_ticket "not-a-ticket" >/dev/null 2>&1
+assert_eq "bad id: rc 2" "2" "$?"
+
+echo "─────────────────────────────────────────"
+echo "Results: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ]

--- a/plugins/dev/scripts/__tests__/linear-transition.test.sh
+++ b/plugins/dev/scripts/__tests__/linear-transition.test.sh
@@ -19,6 +19,13 @@ PASSES=0
 SCRATCH="$(mktemp -d)"
 trap 'rm -rf "$SCRATCH"' EXIT
 
+# CTL-1397: linear-transition reads current state via direct SQL (linear_read_ticket).
+# Point the replica at a nonexistent path so the helper deterministically falls back
+# to the `linearis issues read` stub on PATH — hermetic, independent of any real
+# replica in the runner's HOME. The direct-SQL HIT path is covered by
+# linear-read-replica.test.sh.
+export CATALYST_REPLICA_DB="${SCRATCH}/no-such-replica.db"
+
 # CTL-577: the stateIds UUID cache is a machine-level registry at
 # $HOME/.config/catalyst/linear-state-ids.json. Fake HOME so the registry path
 # is hermetic — an absent registry makes every transition fall back to the
@@ -103,23 +110,6 @@ fi
 exit 0
 EOF
   chmod +x "${bin_dir}/linearis"
-
-  # CTL-1397: linear-transition.sh now reads current state through the replica
-  # wrapper (`catalyst-linear read`) for the idempotency check; writes still go
-  # through `linearis issues update`. This shim mirrors the linearis `read` arm.
-  cat > "${bin_dir}/catalyst-linear" <<'EOF'
-#!/usr/bin/env bash
-echo "catalyst-linear $*" >> "${FAKE_LINEARIS_LOG:-/dev/null}"
-if [ "$1" = "read" ]; then
-  STATE="${FAKE_LINEARIS_STATE:-In Review}"
-  cat <<JSON
-{"identifier":"${2:-TST-1}","title":"Fake","state":{"name":"${STATE}"}}
-JSON
-  exit 0
-fi
-exit 0
-EOF
-  chmod +x "${bin_dir}/catalyst-linear"
 }
 
 # Install a fake `curl` that echoes a canned GraphQL response, so the real
@@ -209,8 +199,8 @@ run "idempotent: skips update when state matches" \
 run "idempotent: no update call recorded when already Done" \
   bash -c "! grep -q 'issues update' '$LOG4'"
 
-run "idempotent: read call IS recorded (check was performed via replica)" \
-  expect_contains "$LOG4" "catalyst-linear read TST-4"
+run "idempotent: read call IS recorded (state check happened before the write)" \
+  expect_contains "$LOG4" "issues read TST-4"
 
 # ─── Test 5: --force bypasses idempotency check ────────────────────────────
 WORK5="${SCRATCH}/t5"

--- a/plugins/dev/scripts/__tests__/phase-triage-e2e.test.sh
+++ b/plugins/dev/scripts/__tests__/phase-triage-e2e.test.sh
@@ -84,6 +84,12 @@ fi
 TMPROOT="$(mktemp -d -t phase-triage-test.XXXXXX)"
 trap 'rm -rf "$TMPROOT" "$SKILL_BODY_FILE"' EXIT
 
+# CTL-1397: the triage body reads via direct SQL (linear_read_ticket). Point the
+# replica at a path that does not exist so `replica_fresh` is always false and the
+# helper deterministically falls back to the `linearis` stub installed on PATH —
+# hermetic, independent of any real replica in the runner's HOME.
+export CATALYST_REPLICA_DB="$TMPROOT/no-such-replica.db"
+
 run_case() {
 	local case_name="$1" fixture="$2" ticket="$3"
 	local body_file="${4:-$SKILL_BODY_FILE}"
@@ -295,14 +301,16 @@ fi
 
 FAIL_DIR="$TMPROOT/lin-fail"
 mkdir -p "$FAIL_DIR/bin"
-# CTL-1397: the triage body now reads via `catalyst-linear read`, so the
-# read-failure case stubs a failing catalyst-linear (not linearis).
-cat >"$FAIL_DIR/bin/catalyst-linear" <<'EOF'
+# CTL-1397: the triage body reads via direct SQL and falls back to `linearis`
+# when the replica is absent (which it is here — CATALYST_REPLICA_DB points at a
+# nonexistent file). Simulate a hard read failure by stubbing a failing
+# `linearis issues read`.
+cat >"$FAIL_DIR/bin/linearis" <<'EOF'
 #!/usr/bin/env bash
-echo "catalyst-linear stub: simulated read failure" >&2
+echo "linearis stub: simulated read failure" >&2
 exit 1
 EOF
-chmod +x "$FAIL_DIR/bin/catalyst-linear"
+chmod +x "$FAIL_DIR/bin/linearis"
 
 PATH="$FAIL_DIR/bin:$PATH" \
 	TICKET=CTL-9001 \
@@ -361,23 +369,9 @@ case "\$1" in
 esac
 EOF
 chmod +x "$DISCUSS_429_DIR/bin/linearis"
-# CTL-1397: triage reads via `catalyst-linear` now — stub it (read → fixture) so
-# the body's ticket read succeeds and reaches the best-effort comment-post path
-# this case exercises (without it, the body falls through to the real binary on
-# PATH and the test is non-hermetic / red in CI).
-cat >"$DISCUSS_429_DIR/bin/catalyst-linear" <<EOF
-#!/usr/bin/env bash
-case "\$1" in
-  read)
-    cat "$FIXTURE_429"
-    ;;
-  *)
-    echo "catalyst-linear stub: unsupported subcommand: \$1" >&2
-    exit 2
-    ;;
-esac
-EOF
-chmod +x "$DISCUSS_429_DIR/bin/catalyst-linear"
+# CTL-1397: triage reads via direct SQL now; CATALYST_REPLICA_DB is absent so the
+# read falls back to the `linearis issues read` stub above (→ fixture), reaching
+# the best-effort comment-post path this case exercises.
 linear_comment_post_stub_install_failing "$DISCUSS_429_DIR/bin" "$DISCUSS_429_DIR/comment-post-calls.log"
 
 PATH="$DISCUSS_429_DIR/bin:$PATH" \

--- a/plugins/dev/scripts/compound-log.sh
+++ b/plugins/dev/scripts/compound-log.sh
@@ -46,6 +46,10 @@
 
 set -uo pipefail
 
+# CTL-1397: direct-SQLite Linear reads (replica-first, loud linearis fallback).
+_COMPOUND_LOG_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${_COMPOUND_LOG_DIR}/lib/linear-read-replica.sh"
+
 # ─── utilities ──────────────────────────────────────────────────────────────
 
 err() { echo "error: $*" >&2; }
@@ -98,8 +102,8 @@ probe_pr() {
 
 probe_linear_estimate() {
   local ticket="$1" json
-  # CTL-1397: read the estimate through the replica wrapper, never bare linearis.
-  json=$(catalyst-linear read "$ticket" 2>/dev/null) || return 1
+  # CTL-1397: read the estimate via direct SQL against the replica, never bare linearis.
+  json=$(linear_read_ticket "$ticket" 2>/dev/null) || return 1
   [ -z "$json" ] && return 1
   echo "$json" | jq -r '.estimate // empty'
 }

--- a/plugins/dev/scripts/file-feedback.sh
+++ b/plugins/dev/scripts/file-feedback.sh
@@ -32,6 +32,8 @@ set -uo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 CONSENT_SCRIPT="${SCRIPT_DIR}/feedback-consent.sh"
+# CTL-1397: direct-SQLite Linear reads (replica-first, loud linearis fallback).
+source "${SCRIPT_DIR}/lib/linear-read-replica.sh"
 
 TITLE=""
 BODY=""
@@ -212,9 +214,8 @@ try_linearis() {
 
   # Fetch URL if the create response didn't include one.
   if [ -z "$linear_url" ]; then
-    # CTL-1397: read through the replica wrapper (catalyst-linear is JSON by
-    # default; dropping --output json avoids the flag parity-bypass to linearis).
-    linear_url=$(catalyst-linear read "$identifier" 2>/dev/null \
+    # CTL-1397: read via direct SQL against the replica (loud linearis fallback).
+    linear_url=$(linear_read_ticket "$identifier" 2>/dev/null \
       | jq -r '.url // empty' 2>/dev/null || echo "")
   fi
 

--- a/plugins/dev/scripts/lib/linear-read-replica.sh
+++ b/plugins/dev/scripts/lib/linear-read-replica.sh
@@ -30,12 +30,35 @@
 [[ -n "${_CATALYST_LINEAR_READ_REPLICA_SH:-}" ]] && return 0
 _CATALYST_LINEAR_READ_REPLICA_SH=1
 
-: "${CATALYST_REPLICA_DB:=${HOME:-}/catalyst/catalyst-replica.db}"
+# Resolve the replica DB path the SAME way the daemon does (config.mjs
+# getReplicaDbPath): CATALYST_REPLICA_DB overrides; else $CATALYST_DIR/…; else
+# $HOME/catalyst/… — so an install that sets CATALYST_DIR is honored.
+: "${CATALYST_REPLICA_DB:=${CATALYST_DIR:-${HOME:-}/catalyst}/catalyst-replica.db}"
 # Freshness threshold in ms (matches the daemon env var); default 5 min.
 : "${CATALYST_LINEAR_REPLICA_STALE_MS:=300000}"
+# Live-read fallback cap in ms (matches catalyst-linear's runLinearis); default 8s.
+: "${CATALYST_LINEARIS_TIMEOUT_MS:=8000}"
 
-# _lrr_mtime <path> → epoch-seconds mtime (portable macOS/Linux); empty if absent.
-_lrr_mtime() { stat -f %m "$1" 2>/dev/null || stat -c %Y "$1" 2>/dev/null; }
+# _lrr_live_read <ID> → run the linearis fallback, CAPPED so a 429-stalled / hung
+# linearis can't block the caller forever (parity with catalyst-linear's runLinearis
+# 8s cap). Uses `timeout` when present (GNU coreutils on the fleet); on timeout the
+# non-zero exit propagates so callers fail safe. macOS without `timeout` runs bare.
+_lrr_live_read() {
+  local id="$1" cap_ms="${CATALYST_LINEARIS_TIMEOUT_MS:-8000}" secs
+  if command -v timeout >/dev/null 2>&1 && [[ "$cap_ms" =~ ^[0-9]+$ ]] && ((cap_ms > 0)); then
+    secs=$(((cap_ms + 999) / 1000)) # ceil ms → whole seconds, min 1
+    timeout "${secs}s" linearis issues read "$id" </dev/null
+  else
+    linearis issues read "$id" </dev/null
+  fi
+}
+
+# _lrr_mtime <path> → epoch-seconds mtime; empty if absent. GNU (`stat -c %Y`)
+# FIRST, BSD (`stat -f %m`) as the fallback: on GNU/Linux `-f` means
+# `--file-system` (it would NOT error, it prints filesystem text), so probing BSD
+# first would yield garbage on the Linux fleet. macOS lacks `-c`, so it errors
+# cleanly and falls through to `-f`.
+_lrr_mtime() { stat -c %Y "$1" 2>/dev/null || stat -f %m "$1" 2>/dev/null; }
 
 # replica_fresh [db] → rc 0 when the replica is safe to read:
 #   • sqlite3 available, and
@@ -90,6 +113,7 @@ linear_read_ticket() {
   else
     printf '[linear-read-replica] replica STALE/ABSENT (writer heartbeat >%ds or seed incomplete) — falling back to linearis for %s; this is a writer/mirror gap to fix, not a retry.\n' "$(( ${CATALYST_LINEAR_REPLICA_STALE_MS:-300000} / 1000 ))" "$id" >&2
   fi
-  # Loud fallback — one un-accelerated live read. Writes stay on linearis elsewhere.
-  linearis issues read "$id" </dev/null
+  # Loud fallback — one un-accelerated, timeout-capped live read. Writes stay on
+  # linearis elsewhere.
+  _lrr_live_read "$id"
 }

--- a/plugins/dev/scripts/lib/linear-read-replica.sh
+++ b/plugins/dev/scripts/lib/linear-read-replica.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+# linear-read-replica.sh — CTL-1397: direct-SQLite Linear read helper for scripts.
+#
+# The read rule (single source: the `catalyst-dev:linearis` skill, "Reading
+# Linear"): Linear READS → the local Catalyst Cloud replica by direct SQL; WRITES
+# → always `linearis`. This helper is the scripted form of that rule — it replaces
+# the deprecated `catalyst-linear read` CLI wrapper for the handful of bash scripts
+# that parse a single ticket's fields.
+#
+# `linear_read_ticket <ID>` echoes the ticket JSON in the SAME shape `linearis
+# issues read` / `catalyst-linear read` return (state.name, estimate, url,
+# labels.nodes[], …), built from the replica's join tables so the label shape is
+# always canonical (raw.labels is inconsistently array-vs-{nodes} across rows).
+# Existing `jq` expressions keep working unchanged.
+#
+# Freshness is GATED, not assumed (mirrors execution-core/replica-read.mjs
+# isReplicaFresh): the writer heartbeat `<db>.writer.lock` must be recent AND the
+# `sync_meta` cursor must be present (proves the seed is complete, not mid-reseed).
+# On stale / absent / MISS the helper is LOUD (stderr) and falls back to `linearis`
+# for that one read — never silent: a stale replica is a writer/mirror gap to fix,
+# per the read-replica-no-silent-fallback principle. Writes stay on `linearis`.
+#
+# Usage:
+#   source "${SCRIPT_DIR}/lib/linear-read-replica.sh"
+#   json=$(linear_read_ticket ENG-123) || return 1
+#   title=$(printf '%s' "$json" | jq -r '.title // empty')
+#
+# This module is idempotent: sourcing it twice is a no-op.
+
+[[ -n "${_CATALYST_LINEAR_READ_REPLICA_SH:-}" ]] && return 0
+_CATALYST_LINEAR_READ_REPLICA_SH=1
+
+: "${CATALYST_REPLICA_DB:=${HOME:-}/catalyst/catalyst-replica.db}"
+# Freshness threshold in ms (matches the daemon env var); default 5 min.
+: "${CATALYST_LINEAR_REPLICA_STALE_MS:=300000}"
+
+# _lrr_mtime <path> → epoch-seconds mtime (portable macOS/Linux); empty if absent.
+_lrr_mtime() { stat -f %m "$1" 2>/dev/null || stat -c %Y "$1" 2>/dev/null; }
+
+# replica_fresh [db] → rc 0 when the replica is safe to read:
+#   • sqlite3 available, and
+#   • the writer heartbeat lock is younger than the staleness threshold, and
+#   • sync_meta has a non-empty `cursor` row (seed complete, not mid-reseed).
+# Any failure → rc 1 (caller falls back to linearis). Never prints.
+replica_fresh() {
+  local db="${1:-$CATALYST_REPLICA_DB}" lock now m age thr
+  command -v sqlite3 >/dev/null 2>&1 || return 1
+  lock="$db.writer.lock"
+  [[ -f "$lock" ]] || return 1
+  m=$(_lrr_mtime "$lock"); [[ -n "$m" ]] || return 1
+  now=$(date +%s); age=$(( now - m ))
+  thr=$(( ${CATALYST_LINEAR_REPLICA_STALE_MS:-300000} / 1000 ))
+  (( age <= thr )) || return 1
+  [[ -n "$(sqlite3 "$db" "SELECT 1 FROM sync_meta WHERE key='cursor' AND value<>'' LIMIT 1;" 2>/dev/null)" ]]
+}
+
+# linear_read_ticket <ID> [db] → echo ticket JSON (linearis-shaped) on stdout.
+# rc 0 on any successful read (replica HIT or linearis fallback); rc 2 on bad id.
+linear_read_ticket() {
+  local id="$1" db="${2:-$CATALYST_REPLICA_DB}" json
+  if [[ ! "$id" =~ ^[A-Za-z0-9]+-[0-9]+$ ]]; then
+    printf '[linear-read-replica] bad ticket id: %s\n' "${id:-<empty>}" >&2
+    return 2
+  fi
+  if replica_fresh "$db"; then
+    json=$(sqlite3 "$db" "
+      SELECT json_object(
+        'id', i.id,
+        'identifier', i.identifier,
+        'title', i.title,
+        'description', i.description,
+        'priority', i.priority,
+        'estimate', i.estimate,
+        'url', i.url,
+        'branchName', i.branch_name,
+        'state', json_object('name', i.state),
+        'assignee', CASE WHEN i.assignee_id IS NOT NULL
+                         THEN json_object('id', i.assignee_id, 'name', i.assignee) END,
+        'labels', json_object('nodes', json((
+            SELECT COALESCE(json_group_array(json_object('id', l.id, 'name', l.name)), '[]')
+            FROM issue_labels il JOIN labels l ON l.id = il.label_id WHERE il.issue_id = i.id)))
+      )
+      FROM issues i WHERE i.identifier = '$id' AND i.removed_at IS NULL LIMIT 1;" 2>/dev/null)
+    if [[ -n "$json" && "$json" != "null" ]]; then
+      printf '%s\n' "$json"
+      return 0
+    fi
+    # Fresh replica, but the row is absent (not yet mirrored / tombstoned).
+    printf '[linear-read-replica] MISS for %s (replica fresh, row absent) — falling back to linearis; file a ticket if this recurs.\n' "$id" >&2
+  else
+    printf '[linear-read-replica] replica STALE/ABSENT (writer heartbeat >%ds or seed incomplete) — falling back to linearis for %s; this is a writer/mirror gap to fix, not a retry.\n' "$(( ${CATALYST_LINEAR_REPLICA_STALE_MS:-300000} / 1000 ))" "$id" >&2
+  fi
+  # Loud fallback — one un-accelerated live read. Writes stay on linearis elsewhere.
+  linearis issues read "$id" </dev/null
+}

--- a/plugins/dev/scripts/linear-transition.sh
+++ b/plugins/dev/scripts/linear-transition.sh
@@ -30,6 +30,9 @@ set -uo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
+# CTL-1397: direct-SQLite Linear reads (replica-first, loud linearis fallback).
+source "${SCRIPT_DIR}/lib/linear-read-replica.sh"
+
 # ─── Default state fallbacks (when config doesn't specify them) ────────────
 # These match the defaults documented in oneshot/orchestrate skills.
 default_state_for() {
@@ -185,13 +188,13 @@ fi
 # ─── Idempotency check (read current state first) ──────────────────────────
 CURRENT_STATE=""
 if [ "$FORCE" -ne 1 ] && command -v jq >/dev/null 2>&1; then
-  # CTL-1397: read current state through the replica wrapper (`catalyst-linear
-  # read`), never bare `linearis` — keeps this per-transition idempotency read
-  # off the shared Linear quota. `catalyst-linear` is replica-first and fails
-  # open to linearis internally. If it is not installed at all the read returns
-  # empty, the check is skipped, and the transition proceeds (a same-state write
-  # is a Linear no-op), so the swap degrades safely.
-  READ_JSON=$(catalyst-linear read "$TICKET" 2>/dev/null || echo "")
+  # CTL-1397: read current state via direct SQL against the replica
+  # (`linear_read_ticket`), never bare `linearis` — keeps this per-transition
+  # idempotency read off the shared Linear quota. The helper is replica-first and
+  # falls back loudly to linearis when the replica is stale/absent. If the read
+  # returns empty the check is skipped and the transition proceeds (a same-state
+  # write is a Linear no-op), so it degrades safely.
+  READ_JSON=$(linear_read_ticket "$TICKET" 2>/dev/null || echo "")
   if [ -n "$READ_JSON" ]; then
     CURRENT_STATE=$(echo "$READ_JSON" | jq -r '.state.name // empty' 2>/dev/null || echo "")
   fi

--- a/plugins/dev/scripts/pre-assign-migrations.sh
+++ b/plugins/dev/scripts/pre-assign-migrations.sh
@@ -29,6 +29,10 @@
 
 set -euo pipefail
 
+# CTL-1397: direct-SQLite Linear reads (replica-first, loud linearis fallback).
+_PAM_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${_PAM_DIR}/lib/linear-read-replica.sh"
+
 TICKETS=""
 TICKETS_JSON=""
 MIG_DIR="supabase/migrations"
@@ -59,15 +63,17 @@ fi
 
 # Build ticket JSON if not supplied.
 if [ -z "$TICKETS_JSON" ]; then
-  # CTL-1397: ticket reads go through the replica wrapper (catalyst-linear).
-  if ! command -v catalyst-linear >/dev/null 2>&1; then
-    echo "error: --tickets requires the catalyst-linear CLI; pass --tickets-json instead" >&2
+  # CTL-1397: ticket reads go through direct SQL against the replica
+  # (linear_read_ticket, loud linearis fallback). Needs sqlite3 (replica) or
+  # linearis (fallback); tests bypass both via --tickets-json.
+  if ! command -v sqlite3 >/dev/null 2>&1 && ! command -v linearis >/dev/null 2>&1; then
+    echo "error: --tickets requires sqlite3 (replica) or linearis; pass --tickets-json instead" >&2
     exit 1
   fi
   TICKETS_JSON="["
   FIRST=1
   for T in $TICKETS; do
-    RAW=$(catalyst-linear read "$T" 2>/dev/null || echo '{}')
+    RAW=$(linear_read_ticket "$T" 2>/dev/null || echo '{}')
     OBJ=$(echo "$RAW" | jq -c --arg id "$T" '{
       id: $id,
       title: (.title // ""),

--- a/plugins/dev/skills/compound-estimate/SKILL.md
+++ b/plugins/dev/skills/compound-estimate/SKILL.md
@@ -81,7 +81,7 @@ plugins/dev/scripts/compound-log.sh write "$TICKET_ID" \
 
 The helper resolves the rest:
 - `pr_number`, `merged_at`, `created_at` via `gh pr view`
-- `estimate_at_start` via `catalyst-linear read <ticket> | jq .estimate`
+- `estimate_at_start` via direct SQL against the replica (`compound-log.sh`'s `linear_read_ticket` → `.estimate`)
 - `cost_usd` from `catalyst-state.sh` worker aggregate (orchestrator mode) or `catalyst-session.sh history --ticket` (local fallback)
 - `wall_time_hours` computed from PR `createdAt` → `mergedAt`
 
@@ -171,8 +171,8 @@ what_surprised_me: "Prometheus integration wasn't plumbed; local state.json suff
 
 - **Primary cost source** is local: the `catalyst-state.sh` worker-usage aggregate (when orchestrated) or `catalyst-session.sh history` (standalone). This is deliberate — `claude-code-otel` + Prometheus is referenced in the original spec but not yet wired up in this repo.
 - **Prometheus overlay** is gated by `CATALYST_PROMETHEUS_URL`. When set, the helper logs a note to stderr; the HTTP client itself is a follow-up ticket.
-- **Linear estimate** is read as an integer from `catalyst-linear read`. The team's estimation config (T-shirt, Fibonacci, linear) is applied client-side when re-scoring in step 3.
-- **Read source:** reads go through `catalyst-linear read` (replica-first when opted in *and* fresh, automatic fail-open to a direct `linearis` read otherwise) — see the `linearis` skill's "Reading Linear" section.
+- **Linear estimate** is read from the replica via direct SQL (the `compound-log.sh` helper). The team's estimation config (T-shirt, Fibonacci, linear) is applied client-side when re-scoring in step 3.
+- **Read source:** reads → the replica via direct SQL; writes → `linearis`. See the `linearis` skill's "Reading Linear" section.
 
 ## Testing
 

--- a/plugins/dev/skills/describe-pr/SKILL.md
+++ b/plugins/dev/skills/describe-pr/SKILL.md
@@ -237,22 +237,26 @@ in prose. The own ticket's `Fixes https://linear.app/...` line is correct and st
 that link/transition is intended. Sibling neutralization is handled mechanically by the
 guard block appended at write-back time (see below).
 
-Get Linear ticket details with `catalyst-linear read <ticket>` — reads go through `catalyst-linear`
-(replica-first, never bare `linearis`); see the `linearis` skill's "Reading Linear" section.
-Extract title and description with jq. Use ticket title and description for context.
+Get Linear ticket details via direct SQL against the replica (see the `linearis` skill's
+"Reading Linear" section). Extract title and description with jq. Use ticket title and
+description for context.
 
 ### 9. Generate updated title
 
 **Title generation rules:**
 
 ```bash
-# If ticket exists, read ticket title via catalyst-linear (reads → catalyst-linear, never bare linearis)
-if [[ "$ticket" ]] && command -v catalyst-linear &>/dev/null; then
-    ticket_title=$(catalyst-linear read "$ticket" | jq -r '.title')
-    title="$ticket: ${ticket_title:0:60}"
-elif [[ "$ticket" ]]; then
-    # Fallback: generate title from branch name + commits
-    title="$ticket: $(echo "$branch" | sed "s/^.*$ticket-//" | tr '-' ' ')"
+# If ticket exists, read its title via direct SQL against the replica
+# (linear_read_ticket — replica-first, loud linearis fallback; CTL-1397).
+source "${CLAUDE_PLUGIN_ROOT}/scripts/lib/linear-read-replica.sh"
+if [[ "$ticket" ]]; then
+    ticket_title=$(linear_read_ticket "$ticket" 2>/dev/null | jq -r '.title // empty')
+    if [[ -n "$ticket_title" ]]; then
+        title="$ticket: ${ticket_title:0:60}"
+    else
+        # Fallback: generate title from branch name + commits
+        title="$ticket: $(echo "$branch" | sed "s/^.*$ticket-//" | tr '-' ' ')"
+    fi
 else
     # No ticket: generate from primary change
     title="Brief summary of main change"
@@ -514,4 +518,4 @@ keys.
 - **Run verification** — attempt all automated checks
 - **Link Linear** — extract ticket, update status
 - **Metadata tracking** — commit history, timestamps
-- For Linearis CLI syntax and the two-mode read rule (standard vs Cloud node), see the `linearis` skill's "Reading Linear" section
+- For Linearis CLI syntax and the direct-SQLite read rule (reads → replica, writes → linearis), see the `linearis` skill's "Reading Linear" section

--- a/plugins/dev/skills/linear/SKILL.md
+++ b/plugins/dev/skills/linear/SKILL.md
@@ -415,7 +415,7 @@ syntax.
 
 ---
 
-For Linearis CLI syntax, see the `linearis` skill reference. For the two-mode read rule (standard node direct `linearis` reads vs Catalyst Cloud replica-first reads), see the "Reading Linear" section of the `linearis` skill (`/catalyst-dev:linearis`).
+For Linearis CLI syntax, see the `linearis` skill reference. For the Linear read rule (reads → the local replica via direct SQL; writes → `linearis`), see the "Reading Linear" section of the `linearis` skill (`/catalyst-dev:linearis`).
 
 ---
 

--- a/plugins/dev/skills/linearis/SKILL.md
+++ b/plugins/dev/skills/linearis/SKILL.md
@@ -74,11 +74,13 @@ read**, including the label/relation joins the old CLI couldn't. This supersedes
 ### Freshness gate (copy-paste, portable macOS/Linux)
 
 ```bash
-DB="$HOME/catalyst/catalyst-replica.db"
+# Resolve the DB the way the daemon does: $CATALYST_REPLICA_DB, else $CATALYST_DIR, else $HOME.
+DB="${CATALYST_REPLICA_DB:-${CATALYST_DIR:-$HOME/catalyst}/catalyst-replica.db}"
 replica_fresh() {
   local lock="$DB.writer.lock" now age
   [[ -f "$lock" ]] || return 1
-  now=$(date +%s); age=$(( now - $(stat -f %m "$lock" 2>/dev/null || stat -c %Y "$lock") ))
+  # GNU `stat -c %Y` first, BSD `stat -f %m` fallback (on Linux `-f` is --file-system, not mtime).
+  now=$(date +%s); age=$(( now - $(stat -c %Y "$lock" 2>/dev/null || stat -f %m "$lock") ))
   (( age < 300 )) || return 1                                    # writer heartbeat < 5 min
   [[ -n "$(sqlite3 "$DB" "SELECT 1 FROM sync_meta WHERE key='cursor' AND value<>'' LIMIT 1;")" ]]  # seed complete
 }
@@ -109,8 +111,11 @@ sqlite3 -json "$DB" "
   SELECT i.identifier, i.title, i.state, i.estimate,
          (SELECT group_concat(l.name, ', ') FROM issue_labels il
             JOIN labels l ON l.id = il.label_id WHERE il.issue_id = i.id) AS labels
-  FROM issues i WHERE i.identifier = 'ENG-123';"
+  FROM issues i WHERE i.identifier = 'ENG-123' AND i.removed_at IS NULL;"
 ```
+
+> `AND removed_at IS NULL` is REQUIRED: a tombstoned (removed) issue must read as a
+> MISS → fall back to live Linear, never as a stale hit.
 
 ### Still needs `linearis` (no issue-shaped replica form)
 
@@ -190,8 +195,8 @@ v2026.4.9.
 
 ```bash
 # Preferred — direct SQL (gate on freshness first; see Reading Linear)
-sqlite3 -json "$HOME/catalyst/catalyst-replica.db" \
-  "SELECT identifier, title, state, estimate FROM issues WHERE identifier='ENG-123';"
+sqlite3 -json "${CATALYST_REPLICA_DB:-${CATALYST_DIR:-$HOME/catalyst}/catalyst-replica.db}" \
+  "SELECT identifier, title, state, estimate FROM issues WHERE identifier='ENG-123' AND removed_at IS NULL;"
 
 # Fallback only (replica stale/absent) — and surface it as an anomaly + file a ticket
 linearis issues read ENG-123

--- a/plugins/dev/skills/linearis/SKILL.md
+++ b/plugins/dev/skills/linearis/SKILL.md
@@ -29,49 +29,111 @@ linearis cycles usage         # Just cycle operations
 
 ## Reading Linear
 
-**The read source is decided by whether the local Catalyst Cloud replica is opted in
-*and* live — NOT by whether the node has a Cloud key. Writes never change.** The easiest
-way to honor this rule is to call **`catalyst-linear read|list|search`** (CTL-1391): it
-resolves the source itself and fails open to `linearis`, so you never decide based on
-node identity.
+> **This is the single source of the Linear read rule.** Other skills/agents reference this
+> section — they do **not** restate it.
 
-### Mode 1 — Direct (default)
+**Linear READS → query the local Catalyst Cloud replica directly with SQL. Linear WRITES →
+always `linearis`.** The replica (`~/catalyst/catalyst-replica.db`, a SQLite mirror kept
+current by the per-host `catalyst-cloud-sync` change-feed writer) holds every issue field plus
+labels, relations, projects, cycles, users, and PR/review state — so **one SQL query serves ANY
+read**, including the label/relation joins the old CLI couldn't. This supersedes the
+`catalyst-linear` wrapper (now deprecated — see below) for agent/skill ad-hoc reads.
 
-When the replica is **not opted in** (`CATALYST_LINEAR_REPLICA` unset/`off` *and* Layer-2
-`catalyst.linearReplica.mode` not `on`) **or** no fresh replica file is present, read Linear
-**directly**: `linearis issues read|list|search`. There is **no local mirror**. A node that
-*has* a Cloud key but has not flipped the replica flag on is in this mode. (The broker's
-`filter-state.db` still exists for orchestration fencing and the board UI, but it is **not**
-a Linear read path — do not read ticket state from it.)
+> **Why direct SQL, not bare `linearis`.** Bare `linearis` reads always hit the rate-limited
+> Linear API. On the shared-quota fleet that burns budget and 429s everyone. The replica is a
+> sub-ms local copy that already has the answer — reading it is what makes "every client reads
+> the replica" actually true.
 
-### Mode 2 — Replica-first (opted in *and* a live replica present)
+### The rule
 
-When the replica is **opted in** (`CATALYST_LINEAR_REPLICA=on` or Layer-2
-`catalyst.linearReplica.mode=on`) **and** a fresh local SQLite replica — kept current by
-the Cloud change-feed — is present:
+1. **Confirm the replica is FRESH + SEEDED** — both gates (mirrors the daemon's `isReplicaFresh`,
+   `execution-core/replica-read.mjs`):
+   - **Writer alive:** `<db>.writer.lock` mtime is **< 5 min** old. The writer heartbeats this
+     file every few seconds regardless of Linear activity, so it tracks *liveness*, not
+     data-change cadence — do **NOT** gate on the `.db`/`-wal` mtime (a quiet feed makes those
+     look stale even when the mirror is perfectly current).
+   - **Seed complete:** `sync_meta` has a **non-empty `cursor` row**. The writer deletes it at
+     the start of a re-seed and rewrites it on completion, so its presence means you are not
+     reading a half-truncated table mid-reseed.
+2. **Fresh + seeded → query the replica and TRUST it.** Do **not** re-verify against live
+   Linear — that defeats the cache and re-burns the quota.
+3. **Not fresh / not seeded / your row missing → this is an ALARM, not a silent reroute.** Say
+   so loudly, fall back to `linearis` for that one read, **and file a ticket** — a stale/absent
+   replica signals a writer or mirror gap worth fixing, not a one-off retry.
 
-- **Read the replica FIRST** and **trust it** as the authoritative local copy.
-- Do **NOT** reflexively re-verify against live Linear — that defeats the cache and
-  burns the API budget.
-- **Evidence-based escalation only.** Fall back to a direct `linearis` read for a
-  specific item *only* when you have concrete evidence the replica read is wrong:
-  it contradicts something you just directly observed; the replica freshness/staleness
-  signal shows it is behind; or a ticket you expect is missing. When you escalate:
-  - (a) read that item through `catalyst-linear read <ID>` (it still surfaces staleness via `_meta` and fails open to a direct `linearis` read), **and**
-  - (b) **surface the staleness as an issue** — a stale replica read signals a mirror
-    gap (e.g. a missed webhook) worth investigating, not just a one-off retry.
+> **Caveat — the gates prove writer-liveness + seed-completeness, NOT per-row apply success.**
+> A rare class of rows (~0.7%) can be *present but stale* because their change-feed apply silently
+> failed (the `errno:1` apply-drift, catalyst-cloud#127 / CTL-1402) — the writer heartbeats and the
+> cursor advances past them, so the freshness gate reads green while that one row holds an old value.
+> Direct SQL cannot make this loud on its own. So: if a specific field **contradicts something you
+> just directly observed** (e.g. a state you just wrote), treat that one field as an anomaly —
+> re-read it via `linearis`, use the live value, and surface it. This is the residual reason
+> **writer reliability + apply-failure telemetry** (CTL-1402) matter; it is not license to re-verify
+> reads that don't contradict anything.
 
-### Writes — always `linearis`, both modes
+### Freshness gate (copy-paste, portable macOS/Linux)
 
-`create` / `update` / state transitions / `discuss` / estimate / label **always** go
-through `linearis`. The replica is **read-only** in both modes.
+```bash
+DB="$HOME/catalyst/catalyst-replica.db"
+replica_fresh() {
+  local lock="$DB.writer.lock" now age
+  [[ -f "$lock" ]] || return 1
+  now=$(date +%s); age=$(( now - $(stat -f %m "$lock" 2>/dev/null || stat -c %Y "$lock") ))
+  (( age < 300 )) || return 1                                    # writer heartbeat < 5 min
+  [[ -n "$(sqlite3 "$DB" "SELECT 1 FROM sync_meta WHERE key='cursor' AND value<>'' LIMIT 1;")" ]]  # seed complete
+}
+```
 
-### How reads resolve
+Scripts should use the shared helper instead of re-implementing this: source
+`plugins/dev/scripts/lib/linear-read-replica.sh` and call `linear_read_ticket <ID>` (freshness
+gate → SQL → loud `linearis` fallback).
 
-- **Daemon read paths** resolve the mode automatically via the read-source seam (CTL-1390) — callers do not choose.
-- **Agent / skill / script ad-hoc reads — MANDATORY:** read Linear **only** through **`catalyst-linear read|list|search`** (CTL-1391). **Never call bare `linearis issues read|list|search` to read** — not in agent or skill instructions, not in helper scripts. The same `catalyst-linear` command is correct on every node: replica-first when opted in *and* fresh, automatic fail-open to `linearis` otherwise. Output matches `linearis` JSON plus an additive `_meta` (read source + replica freshness).
+### Querying (discover the schema — don't guess columns)
 
-> **Why mandatory, not "preferred".** Bare `linearis` reads always hit Linear directly and bypass the replica entirely — even on a node that opted in. On the rate-limited worker minis that burns the shared Linear quota and 429s the fleet. `catalyst-linear` is the executable form of the read rule; routing **all** reads through it is what makes "every client reads the replica" actually true. (Writes are unaffected — always `linearis`.)
+Run `sqlite3 "$DB" .schema` (or `.schema issues`) to see the live columns. Verified 2026-07-01:
+
+- `issues.state` is the **state NAME** directly (`Backlog`/`Implement`/`PR`/`Done`…) — no join.
+- `issues` also has: `identifier`, `title`, `estimate`, `priority`/`priority_label`,
+  `description`, `url`, `branch_name`, `parent_identifier`, `project_id`, `cycle_id`, `team_id`,
+  `assignee_id`, the timestamp columns, and a **`raw`** column with the full Linear JSON.
+- **Labels:** `issue_labels ⋈ labels` — `JOIN labels l ON l.id = il.label_id WHERE il.issue_id = i.id`.
+- **Relations (blocks / blocked-by / …):** the `relations` table (`type, issue_identifier,
+  related_identifier`). **Relations lag ≤ 5 min** (reconcile poll, no webhook) — everything
+  else is real-time.
+- **Any uncolumned field:** `json_extract(raw,'$.path')` (e.g. `json_extract(raw,'$.state.type')`).
+
+Representative read — identifier, title, state, estimate, and labels in one query:
+
+```bash
+sqlite3 -json "$DB" "
+  SELECT i.identifier, i.title, i.state, i.estimate,
+         (SELECT group_concat(l.name, ', ') FROM issue_labels il
+            JOIN labels l ON l.id = il.label_id WHERE il.issue_id = i.id) AS labels
+  FROM issues i WHERE i.identifier = 'ENG-123';"
+```
+
+### Still needs `linearis` (no issue-shaped replica form)
+
+- **Non-issue domains:** `cycles` / `projects` / `milestones` / `initiatives` list & read — use
+  `linearis` (Core Operations below). Simple `cycles`/`projects` lookups can use those replica
+  tables, but the linearis commands are the full path.
+- **Genuinely unmirrored gaps:** cross-team-unsynced parent/child, plus a few unselected fields
+  (`relation.id`, `cycle.name` — CTC-147; `state.id`, `team.key` — CTC-148; `children` is always
+  `[]`). These are **closeable gaps, not permanent carve-outs** — file/track them; don't route
+  around the replica by habit.
+
+### Writes — always `linearis`
+
+`create` / `update` / state transitions / `discuss` / estimate / label **always** go through
+`linearis`. The replica is **read-only**.
+
+### `catalyst-linear` CLI — DEPRECATED
+
+The `catalyst-linear read|list|search` wrapper (CTL-1391) is **superseded by direct SQL** for
+agent/skill reads and retained only as a fail-open compatibility shim. Prefer direct SQL.
+(`list`/`search` were always `linearis` passthrough — no replica benefit — and the wrapper's
+additive `_meta` field + duplicate-flag collapsing broke bare-`linearis` jq pipelines.) The
+daemon's own read paths use `replica-read.mjs` directly and are unaffected by this deprecation.
 
 ## Gotchas & Traps
 
@@ -119,16 +181,20 @@ v2026.4.9.
 
 ## Core Operations
 
-> **Reads run through `catalyst-linear`.** The `linearis issues read|list|search` examples
-> below document the CLI **syntax** — the flags carry over verbatim. Per the mandatory read
-> rule above, **run issue reads via `catalyst-linear read|list|search`** (it shares linearis's
-> flags and fails open to linearis). Stay on bare `linearis` only for reads that need fields
-> the replica omits (relations, estimate) or non-issue domains (`cycles`/`projects`/`milestones`).
+> **Reads → direct SQL against the replica** (see [Reading Linear](#reading-linear)). The
+> `linearis issues read|list|search` examples below document the CLI **syntax** for the cases
+> that still use it — the stale/absent fallback path, non-issue domains, and writes. The flags
+> carry over verbatim.
 
 ### Read a ticket
 
 ```bash
-catalyst-linear read ENG-123        # replica-first; fails open to linearis
+# Preferred — direct SQL (gate on freshness first; see Reading Linear)
+sqlite3 -json "$HOME/catalyst/catalyst-replica.db" \
+  "SELECT identifier, title, state, estimate FROM issues WHERE identifier='ENG-123';"
+
+# Fallback only (replica stale/absent) — and surface it as an anomaly + file a ticket
+linearis issues read ENG-123
 ```
 
 ### Search tickets

--- a/plugins/dev/skills/morning-briefing/SKILL.md
+++ b/plugins/dev/skills/morning-briefing/SKILL.md
@@ -47,7 +47,7 @@ echo "Output path: $OUT_PATH"
 
 ## Step 2: Gather "yesterday" — parallel MCP/CLI queries
 
-> **Read source:** the `linearis` queries below are the standard-node direct read. On a Catalyst Cloud node the local replica is read first (evidence-based fallback to `linearis`) — see the `linearis` skill's "Reading Linear" section.
+> **Read source:** per the `linearis` skill's "Reading Linear" section, ticket reads go to the replica via direct SQL. The `gather-linear.sh` helper below uses a *filtered `issues list`* (an activity window, not a single-ticket read) — the list-shaped case that has no replica form yet, so it stays on `linearis`.
 
 Launch the five gather helpers in parallel. Each prints a JSON fragment to its own scratch file;
 each degrades silently to `{}` if its credentials are absent so the briefing always renders.

--- a/plugins/dev/skills/phase-triage/SKILL.md
+++ b/plugins/dev/skills/phase-triage/SKILL.md
@@ -86,26 +86,38 @@ fi
 # shellcheck disable=SC1090
 . "$__PT_LIB"
 
+# CTL-1397: direct-SQLite Linear reads (replica-first, loud linearis fallback).
+__PT_READ_LIB="${PHASE_LINEAR_READ_HELPER:-${__PT_REPO_ROOT}/plugins/dev/scripts/lib/linear-read-replica.sh}"
+if [[ ! -r "$__PT_READ_LIB" ]]; then
+  echo "phase-triage: cannot find linear-read-replica.sh at $__PT_READ_LIB" >&2
+  exit 1
+fi
+# shellcheck disable=SC1090
+. "$__PT_READ_LIB"
+
 : "${TICKET:?phase-triage: TICKET env var required}"
 
 WORKER_DIR="${WORKER_DIR:-${ORCH_DIR:+${ORCH_DIR}/workers/${TICKET}}}"
 WORKER_DIR="${WORKER_DIR:-$(pwd)}"
 mkdir -p "$WORKER_DIR"
 
-# 1. Read ticket via the replica wrapper (catalyst-linear; CTL-1397 — never bare
-#    linearis for reads). Test stubs override $PATH.
+# 1. Read ticket via direct SQL against the replica (CTL-1397 — never bare
+#    linearis; the helper falls back loudly to linearis when the replica is
+#    stale/absent). stderr is left visible so the loud fallback surfaces in the
+#    phase log. Test stubs point CATALYST_REPLICA_DB at a nonexistent path to
+#    force the deterministic linearis-stub fallback.
 TICKET_JSON_FILE="$(mktemp)"
 trap 'rm -f "$TICKET_JSON_FILE"' EXIT
 
-if ! catalyst-linear read "$TICKET" > "$TICKET_JSON_FILE" 2>/dev/null; then
+if ! linear_read_ticket "$TICKET" > "$TICKET_JSON_FILE"; then
   emit_phase_complete --phase triage --ticket "$TICKET" --status failed \
-    --reason "catalyst-linear read failed"
+    --reason "linear read failed"
   exit 1
 fi
 
 if ! jq -e . "$TICKET_JSON_FILE" >/dev/null 2>&1; then
   emit_phase_complete --phase triage --ticket "$TICKET" --status failed \
-    --reason "catalyst-linear returned non-JSON output"
+    --reason "linear read returned non-JSON output"
   exit 1
 fi
 
@@ -373,9 +385,10 @@ and your job here is the second one:
 
 2. **Triage as a SECOND PAIR OF EYES (your job).** You are NOT a parser. Do **not** add a dependency
    because an id appears in the prose. Instead: read the ticket's intent, then **examine the
-   relevant backlog** — `linearis issues list` for the ticket's team / area (and
-   `catalyst-linear read <id>` to confirm a candidate) — and judge whether any in-flight or planned
-   work is a **true prerequisite the author may have missed**: work that must reach a terminal state
+   relevant backlog** — query the replica for the ticket's team / area, and read any candidate
+   ticket, via direct SQL (see the `linearis` skill's "Reading Linear" section) — and judge whether
+   any in-flight or planned work is a **true prerequisite the author may have missed**: work that
+   must reach a terminal state
    before this ticket can sensibly start (a shared interface not yet built, a migration that must
    land first, an explicit "must follow" sequencing). Record **only** blockers you can justify, in
    the rich shape with a `reason`:
@@ -399,8 +412,8 @@ STEP E, `scheduler.mjs` — it reads `triage.json.dependencies`, re-validates ea
 **cross-team (CTL-838)** ids before writing the durable edge with `applyBlockedByRelation`). Keeping
 the write scheduler-side preserves the CTL-497/CTL-558 contract — the phase-triage e2e negative
 guard fails the build if this skill ever emits a `linearis issues update` call.
-The `catalyst-linear read` (and the `linearis issues list` backlog scan) reads above are read-only
-and are fine. STEP E tolerates BOTH the flat-string and the rich `{id}` shapes.
+The replica SQL reads above (ticket detail + backlog scan) are read-only and are fine. STEP E
+tolerates BOTH the flat-string and the rich `{id}` shapes.
 
 3. If the refined fields differ materially, post a follow-up `linearis issues discuss` comment
    marking the refinement.

--- a/plugins/dev/skills/recovery-pass/SKILL.md
+++ b/plugins/dev/skills/recovery-pass/SKILL.md
@@ -317,8 +317,8 @@ sits at `needs-human`/`failed`/`stalled`, or its worker died with the signal fro
   mergeable,mergeStateStatus,reviewDecision,statusCheckRollup`: is there a PR, is
   it green, is it BEHIND/CONFLICTING, is it just sitting there mergeable.
 - **The Linear cache** — the `linear-state=…` / `labels=…` the context script
-  printed for the item (orientation snapshot only; always verify with `catalyst-linear
-  read <T>` before acting — see the Verify-before-act callout).
+  printed for the item (orientation snapshot only; always verify by reading the ticket
+  via direct SQL against the replica before acting — see the Verify-before-act callout).
 
 **Then diagnose like a senior engineer.** From those: what phase is it in? what
 failed — a conflict, a failed check, a dead worker, an un-merged green PR, a
@@ -402,14 +402,11 @@ If the board scan is all-OK and the flagged YOURS set is empty, you are done —
 
 > **Verify-before-act (do NOT trust the context-script snapshot).** The
 > `linear-state=…` / `labels=…` values the context script printed are an orientation
-> snapshot that may lag live Linear. Before you act on or escalate ANY ticket, read
-> its LIVE Linear state (`catalyst-linear read <T>`) — never act on the snapshot
-> alone. A ticket the context shows blocked / needs-human / in a given column may be
-> none of those live. (Reading Linear: reads → `catalyst-linear`, never bare
-> linearis — `catalyst-linear` serves the local Catalyst Cloud replica when one is
-> present + fresh + opted-in and falls back to a direct linearis read otherwise, so
-> it is the correct read on both a standard node and a Catalyst Cloud node; see the
-> `linearis` skill's mandatory read rule / "Reading Linear" section.)
+> snapshot that may lag. Before you act on or escalate ANY ticket, read its current
+> Linear state via direct SQL against the replica (see the `linearis` skill's
+> "Reading Linear" section) — never act on the snapshot alone. A ticket the context
+> shows blocked / needs-human / in a given column may be none of those. Reads → the
+> replica; writes → `linearis`.
 
 ## The 3-tier rope — how much you may do on your own
 

--- a/plugins/dev/skills/ticket-compound/SKILL.md
+++ b/plugins/dev/skills/ticket-compound/SKILL.md
@@ -45,7 +45,7 @@ For `<TICKET>`, collect:
    - `thoughts/shared/friction/<TICKET>.md` — the dedicated per-phase friction log (primary friction source).
 2. **The diff** — `git log --oneline origin/main..HEAD` and `git diff --stat origin/main..HEAD`
    (or the merged SHA from `phase-monitor-merge.json`).
-3. **Ticket** — `catalyst-linear read <TICKET>` (title, description, final state, estimate) — reads go through `catalyst-linear` (replica-first, never bare `linearis`); see the `linearis` skill's "Reading Linear" section.
+3. **Ticket** — read via direct SQL against the replica (title, description, final state, estimate); see the `linearis` skill's "Reading Linear" section.
 4. **Event trail** (optional) — the ticket's lines in `~/catalyst/events/YYYY-MM.jsonl`.
 
 Capture learnings from **failed/abandoned** tickets too — the dead-ends are high-signal ("what

--- a/plugins/pm/agents/linear-research.md
+++ b/plugins/pm/agents/linear-research.md
@@ -3,7 +3,7 @@ name: linear-research
 description:
   Research Linear tickets, cycles, projects, and milestones using Linearis CLI. Accepts natural
   language requests and returns structured JSON data. Optimized for fast data gathering.
-tools: Bash(sqlite3 *), Bash(linearis *), Bash(jq *), Read
+tools: Bash(sqlite3 *), Bash(stat *), Bash(date *), Bash(linearis *), Bash(jq *), Read
 model: haiku
 color: cyan
 version: 1.0.0

--- a/plugins/pm/agents/linear-research.md
+++ b/plugins/pm/agents/linear-research.md
@@ -3,7 +3,7 @@ name: linear-research
 description:
   Research Linear tickets, cycles, projects, and milestones using Linearis CLI. Accepts natural
   language requests and returns structured JSON data. Optimized for fast data gathering.
-tools: Bash(catalyst-linear *), Bash(linearis *), Bash(jq *), Read
+tools: Bash(sqlite3 *), Bash(linearis *), Bash(jq *), Read
 model: haiku
 color: cyan
 version: 1.0.0
@@ -13,13 +13,13 @@ version: 1.0.0
 
 ## Mission
 
-Gather data from Linear: ticket reads through `catalyst-linear`, and cycles/projects/milestones
-through the Linearis CLI. This is a **data collection specialist** - not an analyzer. Returns
-structured JSON for other agents to analyze.
+Gather data from Linear: ticket reads via direct SQL against the local Catalyst Cloud replica, and
+cycles/projects/milestones/list queries through the Linearis CLI. This is a **data collection
+specialist** - not an analyzer. Returns structured JSON for other agents to analyze.
 
 ## Core Responsibilities
 
-1. **Execute Linear read commands** — `catalyst-linear` for tickets, `linearis` for cycles/projects/milestones — based on natural language requests
+1. **Execute Linear read commands** — direct SQL for tickets, `linearis` for cycles/projects/milestones — based on natural language requests
 2. **Parse and validate JSON output** from linearis
 3. **Return structured data** to calling commands
 4. **Handle errors gracefully** with clear error messages
@@ -42,7 +42,8 @@ Accept requests like:
 1. **Parse the natural language request**
 2. **Determine the appropriate read command**:
    - Cycle queries → `linearis cycles list/read`
-   - Issue queries → `catalyst-linear list/search` (single ticket: `catalyst-linear read <ID>`)
+   - Single ticket read → direct SQL against the replica (see the `linearis` skill's "Reading Linear")
+   - Issue list/search queries → `linearis issues list/search` (no replica form yet)
    - Milestone queries → `linearis milestones list/read`
    - Project queries → `linearis projects list`
 
@@ -57,7 +58,7 @@ For exact command syntax, run `linearis <domain> usage` (e.g., `linearis issues 
 `linearis cycles usage`, `linearis milestones usage`). The `/catalyst-dev:linearis` skill is the
 authoritative reference — **do not guess or improvise commands**.
 
-**Read-source mode**: Ticket reads are **mandatory** through `catalyst-linear read|list|search` — **never** bare `linearis issues read|list|search` — per the `catalyst-dev:linearis` skill's mandatory read rule ("Reading Linear" section): `catalyst-linear` owns the two-mode replica logic (replica-first when opted in *and* fresh, automatic fail-open to `linearis` otherwise), so you never decide by node identity. Cycle, project, and milestone reads have no `catalyst-linear` form, so they stay on `linearis` (`linearis cycles|projects|milestones list/read`). Writes always go through `linearis`.
+**Read-source mode (direct SQL)**: Ticket reads → query `~/catalyst/catalyst-replica.db` directly with `sqlite3`, per the `catalyst-dev:linearis` skill's "Reading Linear" section — that section owns the two-gate freshness check (writer.lock + `sync_meta` cursor), the schema, and the **loud** `linearis` fallback rule (a stale/absent replica is an alarm to surface + file, not a silent reroute). Do **not** bare-`linearis`-read a ticket the fresh replica can serve. Cycle/project/milestone reads and filtered `issues list`/`search` have no issue-shaped replica form yet, so they stay on `linearis`. Writes always go through `linearis`.
 
 ## Examples
 
@@ -71,8 +72,8 @@ authoritative reference — **do not guess or improvise commands**.
 
 **Request**: "List all issues in Backlog status for team PROJ with no cycle"
 
-**Steps**: Read via `catalyst-linear list` (`linearis issues usage` documents the flags). Filter by
-team and status with jq. Further filter for `cycle == null`.
+**Steps**: Read via `linearis issues list` (`linearis issues usage` documents the flags; list/search
+have no replica form yet). Filter by team and status with jq. Further filter for `cycle == null`.
 
 ### Example 3: Get Milestone Details
 


### PR DESCRIPTION
## What & why

Ryan course-corrected the CTL-1391 direction: instead of routing agent Linear **reads** through the `catalyst-linear` CLI wrapper (a linearis-shaped indirection that forced a piecemeal command-coverage roadmap — `list`/`search` were passthrough, labels/relations unsupported), agents now **query the local Catalyst Cloud replica (`~/catalyst/catalyst-replica.db`) directly with SQL**. One query serves any read (issues + labels + relations + a `raw` JSON fallback), including the joins the CLI couldn't do. Writes stay on `linearis`.

## Changes

- **Single source of the read rule** now lives ONLY in the `linearis` skill's **"Reading Linear"** section:
  - Reads → replica via direct SQL, gated on a two-part freshness check mirroring the daemon's `isReplicaFresh`: **writer.lock heartbeat < 5 min** (liveness, not data-cadence) **+ non-empty `sync_meta.cursor`** (seed complete, not mid-reseed).
  - Stale / absent / MISS → **loud** fallback to `linearis` + file a ticket (never a silent reroute, per Ryan's principle).
  - Documents the schema (`.schema`), the label/relation joins, the ≤5-min relations lag, and the **errno:1 present-but-stale caveat** (a fresh+seeded replica can still hold a stale row whose apply silently failed — catalyst-cloud#127 / CTL-1402).
- **DRY (full pull-back)**: removed the scattered per-skill/agent read-source prose (from #2511); `morning-briefing`, `compound-estimate`, `ticket-compound`, `describe-pr`, `recovery-pass`, `linear`, and both `linear-research` agents now **reference** that one section. `AGENTS.md` updated (was "two-mode rule").
- **New shared helper** `plugins/dev/scripts/lib/linear-read-replica.sh` — `linear_read_ticket <ID>`: freshness-gate → normalized SQL (output matches `catalyst-linear read` / `linearis issues read`, so existing `jq` keeps working) → loud `linearis` fallback. Routes the script callsites: `linear-transition`, `compound-log`, `pre-assign-migrations`, `file-feedback`, and the `phase-triage` body.
- **`catalyst-linear` CLI marked deprecated** (compat shim only). The daemon's own read path (`replica-read.mjs`) is untouched.

## Tests

- New `linear-read-replica.test.sh` — **19 cases**: freshness gates (fresh / stale lock / absent lock / no-cursor), the normalized HIT shape (state.name, estimate, labels `{nodes}`, url, assignee), HIT-avoids-linearis, and loud fallback (tombstone / MISS).
- Updated `phase-triage-e2e` (40), `compound-log` (19), `linear-transition` (63), `pre-assign-migrations` (14) to the direct-SQL path (force the deterministic linearis-stub fallback; the SQL HIT path is covered by the helper unit test). **All green.**
- Pre-existing unrelated `docs-drift-references` failures (setup-health-check.md / configuration.md) are not touched by this PR.

## Notes

Proven live during authoring: CTL-1397's own replica row was **present-but-stale** (errno:1 class) — a real instance of the caveat now documented in the read rule.

Refs CTL-1391, CTL-1397, catalyst-cloud#127, CTL-1402.

🤖 Generated with [Claude Code](https://claude.com/claude-code)