### PR TITLE
chore(meta): tighten .gitignore for local tool state and mockup screenshots

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,9 +5,14 @@ Thumbs.db
 # Editor files
 .vscode/
 .idea/
+.obsidian/
 *.swp
 *.swo
 *~
+
+# Local AI-tool state (not shared with team)
+.codex/
+.playwright-mcp/
 
 # Temporary files
 *.tmp
@@ -68,3 +73,14 @@ plugins/dev/scripts/orch-monitor/node_modules/
 .serena/cache/
 .serena/project.local.yml
 .serena/logs/
+
+# mockups/: HTML mockups are reviewed source and stay tracked; the screenshots
+# captured while iterating on them are ephemeral and don't belong in history.
+mockups/**/*.png
+
+# Ad hoc root-level package install (e.g. `npm install linearis` for local CLI use)
+/node_modules/
+
+# Worktree-safety machine-local noise marker (see MACHINE_LOCAL_NOISE in
+# plugins/dev/scripts/execution-core/worktree-safety.mjs)
+.orphaned_at


### PR DESCRIPTION
## Summary

- Ignore local editor/tool state that was showing up as untracked noise: `.obsidian/`, `.codex/`, `.playwright-mcp/`.
- Ignore ephemeral screenshots captured while iterating on `mockups/` (`mockups/**/*.png`) — the `.html` mockups themselves stay tracked/reviewable, matching the existing pattern (`catalyst-board.html`, `retheme-board-warm.html`, `typography-specimen.html`).
- Ignore a root-level `/node_modules/` (from an ad hoc `npm install linearis` for local CLI use) — `package.json`/`package-lock.json` stay tracked since they document that dependency.
- Ignore `.orphaned_at`, already documented as `MACHINE_LOCAL_NOISE` in `plugins/dev/scripts/execution-core/worktree-safety.mjs` but not previously in `.gitignore`.

## Scope note

This PR only touches `.gitignore`. While surveying untracked files I found a batch of new `mockups/*.html` design mockups (governance/rulebook/rules-explorer) that look like real deliverables worth checking in properly — and a broader question of whether `mockups/` needs a better home (e.g. `docs/specs/{draft,accepted}/`, distinct from ADRs and from the external `thoughts/` repo). Deliberately left out of scope here; tracking as a follow-up.

## Test plan

- [x] `git check-ignore -v` verified against real untracked paths on the main checkout: `.codex`, `.obsidian`, `.playwright-mcp`, `node_modules`, `mockups/*.png` (including nested subfolder) all match; `package.json`, `package-lock.json`, `mockups/*.html`, and real source files (`claude-accounts-usage.mjs`) do **not** match.
- [x] Branched from an up-to-date `origin/main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)