### PR TITLE
feat(dev): CTL-1410 (Phase A) — in-band terminal signal flips for event-only phases + SDK success safety net

### DIFF
--- a/plugins/dev/scripts/__tests__/no-event-only-terminal-emit.test.sh
+++ b/plugins/dev/scripts/__tests__/no-event-only-terminal-emit.test.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# no-event-only-terminal-emit.test.sh — CTL-1410 Phase A regression guard.
+#
+# INVARIANT: no phase-agent SKILL may emit a terminal phase event through the
+# event-only `emit_phase_complete` lib helper (plugins/dev/scripts/lib/
+# phase-emit-complete.sh). That helper ONLY appends the canonical event; it never
+# flips the phase signal file's `status` to done/failed/skipped. Under
+# executor=sdk there is no bg reclaim path to synthesize that flip afterwards, so
+# a phase that ends via emit_phase_complete strands its slot (the triage +
+# monitor-deploy strand CTL-1410 Phase A fixed).
+#
+# Every terminal path MUST instead go through the production wrapper
+# `phase-agent-emit-complete` (which flips the signal in-band). This test greps
+# every phase-*/SKILL.md body for a call to the event-only helper and fails if it
+# finds one. It is the invariant that makes the SDK success⇒done assumption sound.
+#
+# Run: bash plugins/dev/scripts/__tests__/no-event-only-terminal-emit.test.sh
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../../.." && pwd)"
+SKILLS_DIR="${REPO_ROOT}/plugins/dev/skills"
+
+PASS=0
+FAIL=0
+ok()   { PASS=$((PASS+1)); printf '  PASS: %s\n' "$1"; }
+fail() { FAIL=$((FAIL+1)); printf '  FAIL: %s\n    %s\n' "$1" "$2"; }
+
+echo "no-event-only-terminal-emit guard (CTL-1410 Phase A)"
+
+shopt -s nullglob
+SKILL_FILES=("${SKILLS_DIR}"/phase-*/SKILL.md)
+shopt -u nullglob
+
+if [[ ${#SKILL_FILES[@]} -eq 0 ]]; then
+  fail "discovered phase skills" "no phase-*/SKILL.md found under ${SKILLS_DIR}"
+  echo; echo "Results: ${PASS} passed, ${FAIL} failed"; exit 1
+fi
+
+# A CALL to the event-only helper looks like `emit_phase_complete --…` (optionally
+# indented, possibly preceded by nothing). Prose mentions ("the emit_phase_complete
+# helper") carry no flag, and the lib's own `. "$lib"` source line is not a call —
+# so anchoring on the trailing `--<flag>` avoids false positives. The negative
+# lookbehind-ish char class rules out `foo_emit_phase_complete`.
+CALL_RE='(^|[^A-Za-z0-9_])emit_phase_complete[[:space:]]+--'
+
+for skill in "${SKILL_FILES[@]}"; do
+  name="$(basename "$(dirname "$skill")")"
+  offenders="$(grep -nE "$CALL_RE" "$skill" || true)"
+  if [[ -n "$offenders" ]]; then
+    fail "${name}: no terminal path calls the event-only emit_phase_complete helper" \
+      "offending lines (migrate to the phase-agent-emit-complete wrapper):$(printf '\n%s' "$offenders")"
+  else
+    ok "${name}: terminal emits go through the wrapper (no event-only emit_phase_complete call)"
+  fi
+done
+
+echo
+echo "Results: ${PASS} passed, ${FAIL} failed"
+[[ $FAIL -eq 0 ]] || exit 1
+exit 0

--- a/plugins/dev/scripts/__tests__/phase-agent-emit-complete.test.sh
+++ b/plugins/dev/scripts/__tests__/phase-agent-emit-complete.test.sh
@@ -699,6 +699,56 @@ REASON=$(echo "$LINE" | jq -r '.body.payload.failure_reason' 2>/dev/null || echo
 assert_eq "phase.plan.failed.CTL-1097" "$EVENT_NAME" "genuine miss in worktreePath → failed"
 assert_eq "artifact_not_gate_visible" "$REASON" "genuine miss preserves artifact_not_gate_visible reason"
 
+# ─── CTL-1410 Phase A: --payload-json (event-only phases migrate onto this wrapper) ─
+# The caller's terminal-artifact JSON merges into body.payload (caller as base;
+# canonical fields overlay and win; phase_name injected). Absent → byte-identical
+# default. Malformed → fail-open to the base payload (the event is never dropped).
+
+echo ""
+echo "Test 46 (CTL-1410): --payload-json merges caller fields + injects phase_name; canonical fields win"
+fresh_env t46
+"$EMIT_SCRIPT" --phase triage --ticket CTL-100 --status complete \
+	--payload-json '{"classification":"bug","estimated_scope":"small","status":"SHOULD-LOSE","ticket":"SHOULD-LOSE"}' \
+	>/dev/null 2>&1
+LINE=$(read_event_line)
+if [[ -z $LINE ]]; then
+	fail "Test 46: no event line emitted"
+else
+	P_CLASS=$(echo "$LINE" | jq -r '.body.payload.classification')
+	P_SCOPE=$(echo "$LINE" | jq -r '.body.payload.estimated_scope')
+	P_NAME=$(echo "$LINE" | jq -r '.body.payload.phase_name')
+	P_STATUS=$(echo "$LINE" | jq -r '.body.payload.status')
+	P_TICKET=$(echo "$LINE" | jq -r '.body.payload.ticket')
+	assert_eq "bug" "$P_CLASS" "caller field classification carried in body.payload"
+	assert_eq "small" "$P_SCOPE" "caller field estimated_scope carried in body.payload"
+	assert_eq "triage" "$P_NAME" "phase_name injected (lib-helper parity)"
+	assert_eq "complete" "$P_STATUS" "canonical status overlays the caller's"
+	assert_eq "CTL-100" "$P_TICKET" "canonical ticket overlays the caller's"
+fi
+
+echo ""
+echo "Test 47 (CTL-1410): absent --payload-json → byte-identical default payload (no phase_name)"
+fresh_env t47
+"$EMIT_SCRIPT" --phase research --ticket CTL-100 --status complete >/dev/null 2>&1
+LINE=$(read_event_line)
+PAYLOAD_KEYS=$(echo "$LINE" | jq -cS '.body.payload | keys')
+assert_eq '["phase","status","ticket"]' "$PAYLOAD_KEYS" "default payload keys unchanged (no phase_name leak)"
+
+echo ""
+echo "Test 48 (CTL-1410): malformed --payload-json fails open to the base payload"
+fresh_env t48
+"$EMIT_SCRIPT" --phase triage --ticket CTL-100 --status failed --reason "boom" \
+	--payload-json 'NOT VALID JSON {' >/dev/null 2>&1
+LINE=$(read_event_line)
+if [[ -z $LINE ]]; then
+	fail "Test 48: malformed payload dropped the event entirely (must fail open)"
+else
+	EVENT_NAME=$(echo "$LINE" | jq -r '.attributes."event.name"')
+	P_REASON=$(echo "$LINE" | jq -r '.body.payload.failure_reason')
+	assert_eq "phase.triage.failed.CTL-100" "$EVENT_NAME" "malformed payload: event still emitted"
+	assert_eq "boom" "$P_REASON" "malformed payload: base failure_reason preserved"
+fi
+
 echo ""
 echo "─────────────────────────────────────────────"
 echo "phase-agent-emit-complete: ${PASSES} passed, ${FAILURES} failed"

--- a/plugins/dev/scripts/__tests__/phase-monitor-deploy-e2e.test.sh
+++ b/plugins/dev/scripts/__tests__/phase-monitor-deploy-e2e.test.sh
@@ -24,7 +24,8 @@ set -uo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "${SCRIPT_DIR}/../../../.." && pwd)"
 SKILL_FILE="${REPO_ROOT}/plugins/dev/skills/phase-monitor-deploy/SKILL.md"
-EMIT_HELPER="${REPO_ROOT}/plugins/dev/scripts/lib/phase-emit-complete.sh"
+# CTL-1410 Phase A: every terminal emit rides the production wrapper now.
+EMIT_WRAPPER="${REPO_ROOT}/plugins/dev/scripts/phase-agent-emit-complete"
 # shellcheck source=lib/linearis-stub.sh
 source "${SCRIPT_DIR}/lib/linearis-stub.sh"
 
@@ -36,13 +37,24 @@ fail() { FAIL=$((FAIL+1)); printf '  FAIL: %s\n    %s\n' "$1" "$2"; }
 assert_eq() { if [ "$2" = "$3" ]; then ok "$1"; else fail "$1" "expected '$2' got '$3'"; fi; }
 assert_file_exists() { if [ -f "$2" ]; then ok "$1"; else fail "$1" "missing file: $2"; fi; }
 
+# CTL-1410 Phase A: every terminal emit now flows through the phase-agent-emit-complete
+# wrapper, which appends to $CATALYST_DIR/events/YYYY-MM.jsonl (not the lib-only
+# $CATALYST_EVENTS_FILE). Read the last phase event line from a case's catalyst dir.
+read_phase_event_line() {
+  local catalyst_dir="$1" month
+  month=$(date -u +%Y-%m)
+  local logfile="${catalyst_dir}/events/${month}.jsonl"
+  [ -f "$logfile" ] || { echo ""; return 1; }
+  grep -F '"event.name":"phase.' "$logfile" | tail -1
+}
+
 if ! command -v catalyst-events >/dev/null 2>&1; then
   echo "SKIP: catalyst-events not on PATH — phase-monitor-deploy needs it" >&2
   exit 0
 fi
 
 [ -f "$SKILL_FILE" ]  || { echo "FAIL: skill missing: $SKILL_FILE";   exit 1; }
-[ -f "$EMIT_HELPER" ] || { echo "FAIL: helper missing: $EMIT_HELPER"; exit 1; }
+[ -x "$EMIT_WRAPPER" ] || { echo "FAIL: wrapper missing/not executable: $EMIT_WRAPPER"; exit 1; }
 
 # Extract the executable bash body delimited by ```bash phase-monitor-deploy-body```.
 SKILL_BODY_FILE="$(mktemp -t phase-monitor-deploy-body.XXXXXX.sh)"
@@ -156,10 +168,16 @@ jq -nc --arg s "$canary_status" '{status: \$s, observations: ["fixture"]}'
 EOF
   chmod +x "$case_dir/bin/canary-stub"
 
-  # linearis stub (CTL-632 deploy mirror): keep the skill's `linearis issues
-  # discuss` call hermetic — case_dir/bin is first on PATH so this shadows any
-  # real linearis. Logs each call so we can assert the mirror posted.
+  # linearis stub (CTL-632 deploy mirror): keep the skill hermetic —
+  # case_dir/bin is first on PATH so this shadows any real linearis.
   linearis_stub_install "$case_dir/bin" "$case_dir/linearis-calls.log"
+
+  # CTL-550/CTL-1410: the mirror posts through linear-comment-post.sh (app-actor
+  # API), NOT `linearis issues discuss` — stub it and point the skill's
+  # CATALYST_COMMENT_POST_HELPER override at it so the "mirror posted" assertion
+  # is hermetic (independent of machine credentials). The stub logs its args
+  # (ticket, body) to comment-post-calls.log and exits 0.
+  linear_comment_post_stub_install "$case_dir/bin" "$case_dir/comment-post-calls.log"
 
   # Run the skill body in the background so we can append the deploy event
   # AFTER catalyst-events wait-for has begun watching from EOF. This mirrors
@@ -185,11 +203,11 @@ EOF
     CATALYST_ORCHESTRATOR_DIR="$orch_dir" \
     CATALYST_ORCHESTRATOR_ID="orch-test" \
     CATALYST_EVENTS_FILE="$events_file" \
+    CATALYST_COMMENT_POST_HELPER="$case_dir/bin/linear-comment-post.sh" \
     PHASE_DEPLOY_TIMEOUT_SEC="$timeout_sec" \
     PHASE_DEPLOY_ENV="production" \
     PHASE_CANARY_CMD="$case_dir/bin/canary-stub" \
     PHASE_AGENT_REPO_ROOT="$REPO_ROOT" \
-    PHASE_EMIT_HELPER="$EMIT_HELPER" \
       bash "$SKILL_BODY_FILE" > "$case_dir/stdout.log" 2> "$case_dir/stderr.log"
     echo $? > "$case_dir/exit-code"
   ) &
@@ -238,27 +256,35 @@ if [ -f "$CASE_DIR/orch/workers/CTL-9999/phase-monitor-deploy.json" ]; then
 fi
 
 # CTL-632 deploy mirror: a Linear comment was posted with the env + preview URL.
-if grep -q '^discuss$' "$CASE_DIR/linearis-calls.log" 2>/dev/null; then
+# CTL-550/CTL-1410: the mirror rides linear-comment-post.sh (app-actor API), not
+# `linearis issues discuss` — assert against the comment-post stub's log.
+if grep -q 'CTL-9999' "$CASE_DIR/comment-post-calls.log" 2>/dev/null; then
   ok "success: deploy mirror posted to Linear"
 else
-  fail "success: deploy mirror posted" "no discuss in $(cat "$CASE_DIR/linearis-calls.log" 2>/dev/null)"
+  fail "success: deploy mirror posted" "no call in $(cat "$CASE_DIR/comment-post-calls.log" 2>/dev/null)"
 fi
-if grep -q 'Phase Monitor-Deploy' "$CASE_DIR/linearis-calls.log" 2>/dev/null \
-   && grep -q 'preview.example.dev/ctl-9999' "$CASE_DIR/linearis-calls.log" 2>/dev/null; then
+if grep -q 'Phase Monitor-Deploy' "$CASE_DIR/comment-post-calls.log" 2>/dev/null \
+   && grep -q 'preview.example.dev/ctl-9999' "$CASE_DIR/comment-post-calls.log" 2>/dev/null; then
   ok "success: deploy mirror body has header + preview URL"
 else
-  fail "success: deploy mirror body" "log: $(cat "$CASE_DIR/linearis-calls.log" 2>/dev/null)"
+  fail "success: deploy mirror body" "log: $(cat "$CASE_DIR/comment-post-calls.log" 2>/dev/null)"
 fi
 
 # Canary stub was invoked exactly once
 INVOCATIONS="$(wc -l < "$CASE_DIR/canary-invocations.log" 2>/dev/null | tr -d ' ')"
 assert_eq "success: canary stub invoked once" "1" "${INVOCATIONS:-0}"
 
-# Emitted event shape
-EVENT_NAME="$(jq -r '.attributes."event.name"' "$CASE_DIR/events.jsonl" \
-              | tail -1)"
+# Emitted event shape (CTL-1410: from the wrapper sink)
+EVENT_NAME="$(read_phase_event_line "$CASE_DIR/catalyst" \
+              | jq -r '.attributes."event.name"' 2>/dev/null)"
 assert_eq "success: emitted phase event name" \
   "phase.monitor-deploy.complete.CTL-9999" "$EVENT_NAME"
+
+# CTL-1410 Phase A: the wrapper flips the signal file's status to done in-band
+# (merged onto the artifact write, preserving deploy_state/canary_result).
+SUCCESS_SIG_STATUS="$(jq -r '.status' \
+  "$CASE_DIR/orch/workers/CTL-9999/phase-monitor-deploy.json" 2>/dev/null)"
+assert_eq "success: signal status flipped to done (CTL-1410)" "done" "$SUCCESS_SIG_STATUS"
 
 # ─────────────────────────────────────────────────────────────────────────────
 # Case 2: deploy failure → phase.monitor-deploy.failed, canary NOT invoked
@@ -279,10 +305,16 @@ else
   fail "failure: canary not invoked" "canary log exists with $(wc -l < "$CASE_DIR2/canary-invocations.log") lines"
 fi
 
-FAIL_EVENT="$(jq -r '.attributes."event.name"' "$CASE_DIR2/events.jsonl" \
-              | tail -1)"
+FAIL_EVENT="$(read_phase_event_line "$CASE_DIR2/catalyst" \
+              | jq -r '.attributes."event.name"' 2>/dev/null)"
 assert_eq "failure: emitted failed event" \
   "phase.monitor-deploy.failed.CTL-9999" "$FAIL_EVENT"
+
+# CTL-1410 Phase A: the deploy-failure branch writes the artifact then the wrapper
+# flips the signal's status to failed in-band (merged onto the artifact).
+FAIL_SIG_STATUS="$(jq -r '.status' \
+  "$CASE_DIR2/orch/workers/CTL-9999/phase-monitor-deploy.json" 2>/dev/null)"
+assert_eq "failure: signal status flipped to failed (CTL-1410)" "failed" "$FAIL_SIG_STATUS"
 
 # ─────────────────────────────────────────────────────────────────────────────
 # Case 3: no deploy event arrives within timeout → phase.monitor-deploy.skipped
@@ -320,15 +352,19 @@ assert_eq "skipped: emitted skipped event" \
 # Case 4: phase-monitor-merge.json missing → failed event + non-zero
 
 MISS_DIR="$TMPROOT/missing"
-mkdir -p "$MISS_DIR/worker"  # but NO phase-monitor-merge.json
+MISS_ORCH="$MISS_DIR/orch"
+MISS_WORKER="$MISS_ORCH/workers/CTL-8888"
+MISS_CATALYST="$MISS_DIR/catalyst"
+mkdir -p "$MISS_WORKER" "$MISS_CATALYST/events"  # but NO phase-monitor-merge.json
 
 PATH="$PATH" \
 TICKET=CTL-8888 \
-WORKER_DIR="$MISS_DIR/worker" \
-CATALYST_EVENTS_FILE="$MISS_DIR/events.jsonl" \
+WORKER_DIR="$MISS_WORKER" \
+CATALYST_DIR="$MISS_CATALYST" \
+CATALYST_ORCHESTRATOR_DIR="$MISS_ORCH" \
+CATALYST_ORCHESTRATOR_ID="orch-test" \
 PHASE_DEPLOY_TIMEOUT_SEC=1 \
 PHASE_AGENT_REPO_ROOT="$REPO_ROOT" \
-PHASE_EMIT_HELPER="$EMIT_HELPER" \
   bash "$SKILL_BODY_FILE" > "$MISS_DIR/stdout.log" 2> "$MISS_DIR/stderr.log"
 MISS_EXIT=$?
 
@@ -338,15 +374,15 @@ else
   fail "missing-merge: exit code" "expected non-zero, got $MISS_EXIT"
 fi
 
-MISS_EVENT="$(jq -r '.attributes."event.name"' "$MISS_DIR/events.jsonl" 2>/dev/null \
-              | tail -1)"
+MISS_LINE="$(read_phase_event_line "$MISS_CATALYST")"
+MISS_EVENT="$(printf '%s' "$MISS_LINE" | jq -r '.attributes."event.name"' 2>/dev/null)"
 assert_eq "missing-merge: emits failed event" \
   "phase.monitor-deploy.failed.CTL-8888" "$MISS_EVENT"
 
-# Failure reason should cite the new file, not phase-pr.json. The emit helper
-# stores the --reason text in body.message of the canonical event line.
-MISS_REASON="$(jq -r '.body.message // empty' \
-              "$MISS_DIR/events.jsonl" 2>/dev/null | tail -1)"
+# Failure reason should cite the new file, not phase-pr.json. CTL-1410: the
+# wrapper carries the --reason text in body.payload.failure_reason (body.message
+# is a generic "Phase … failed on …" string).
+MISS_REASON="$(printf '%s' "$MISS_LINE" | jq -r '.body.payload.failure_reason // empty' 2>/dev/null)"
 case "$MISS_REASON" in
   *phase-monitor-merge.json*) ok "missing-merge: failure reason cites phase-monitor-merge.json" ;;
   *) fail "missing-merge: failure reason" "expected reason to mention phase-monitor-merge.json, got: $MISS_REASON" ;;
@@ -373,8 +409,8 @@ if [ -f "$CASE_DIR5/orch/workers/CTL-9999/phase-monitor-deploy.json" ]; then
     "fallbeef" "$DSHA5"
 fi
 
-CMPL5="$(jq -r '.attributes."event.name"' "$CASE_DIR5/events.jsonl" \
-         | tail -1)"
+CMPL5="$(read_phase_event_line "$CASE_DIR5/catalyst" \
+         | jq -r '.attributes."event.name"' 2>/dev/null)"
 assert_eq "fallback: emitted complete event after fallback" \
   "phase.monitor-deploy.complete.CTL-9999" "$CMPL5"
 
@@ -393,8 +429,8 @@ else
   fail "fallback-fail: exit code" "expected non-zero, got $EXIT6"
 fi
 
-REASON6="$(jq -r '.body.message // empty' \
-          "$CASE_DIR6/events.jsonl" 2>/dev/null | tail -1)"
+REASON6="$(read_phase_event_line "$CASE_DIR6/catalyst" \
+          | jq -r '.body.payload.failure_reason // empty' 2>/dev/null)"
 case "$REASON6" in
   *gh*|*REST*|*fallback*|*empty*) ok "fallback-fail: failure reason mentions fallback path" ;;
   *) fail "fallback-fail: reason" "expected reason to mention gh/REST/fallback/empty, got: $REASON6" ;;

--- a/plugins/dev/scripts/__tests__/phase-triage-e2e.test.sh
+++ b/plugins/dev/scripts/__tests__/phase-triage-e2e.test.sh
@@ -2,17 +2,21 @@
 # E2E test for plugins/dev/skills/phase-triage/SKILL.md (CTL-451 Initiative 1 Phase 5).
 #
 # Strategy:
-#   1. Build a tempdir scratch worker dir.
+#   1. Build a tempdir scratch orch/worker dir, pre-seeding the phase signal file
+#      (status:"dispatched") the dispatcher would have written.
 #   2. Stand up a fake `linearis` shim on PATH:
 #        - `linearis issues read <id>` → prints fixture JSON
 #        - `linearis issues discuss <id> --body <text>` → records call to a log
 #      (phase-triage never calls `linearis issues update` for a `triaged`
 #       label — there is no such label; triage completion is signaled by the
 #       analysis comment plus the local triage.json.)
-#   3. Point CATALYST_EVENTS_FILE at a tempfile.
-#   4. Extract the executable bash body from the skill (fenced by
+#   3. Point CATALYST_DIR at a scratch dir — CTL-1410 Phase A: terminal events now
+#      go through the phase-agent-emit-complete WRAPPER, which appends to
+#      $CATALYST_DIR/events/YYYY-MM.jsonl (NOT the lib-only $CATALYST_EVENTS_FILE)
+#      and flips the phase signal file's `status` in-band.
+#   4. Extract the executable bash body from the skill (fenced
 #      `bash phase-triage-body`).
-#   5. Run it with TICKET set; assert artifact + comment + event (no label call).
+#   5. Run it with TICKET set; assert artifact + comment + event + signal flip.
 #
 # Run: bash plugins/dev/scripts/__tests__/phase-triage-e2e.test.sh
 
@@ -21,7 +25,7 @@ set -uo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "${SCRIPT_DIR}/../../../.." && pwd)"
 SKILL_FILE="${REPO_ROOT}/plugins/dev/skills/phase-triage/SKILL.md"
-EMIT_HELPER="${REPO_ROOT}/plugins/dev/scripts/lib/phase-emit-complete.sh"
+EMIT_WRAPPER="${REPO_ROOT}/plugins/dev/scripts/phase-agent-emit-complete"
 # CTL-632 Phase 6 refactor: adopt the shared linearis-stub helper.
 # shellcheck source=lib/linearis-stub.sh
 source "${SCRIPT_DIR}/lib/linearis-stub.sh"
@@ -46,9 +50,23 @@ assert_file_exists() { if [ -f "$2" ]; then ok "$1"; else fail "$1" "missing fil
 	echo "FAIL: skill missing: $SKILL_FILE"
 	exit 1
 }
-[ -f "$EMIT_HELPER" ] || {
-	echo "FAIL: helper missing: $EMIT_HELPER"
+[ -x "$EMIT_WRAPPER" ] || {
+	echo "FAIL: wrapper missing/not executable: $EMIT_WRAPPER"
 	exit 1
+}
+
+# Read the phase event line from a case's wrapper event sink
+# ($CATALYST_DIR/events/YYYY-MM.jsonl). catalyst-session.sh end (which the wrapper
+# also invokes) may append session lines after, so we grep the phase prefix.
+read_phase_event() {
+	local catalyst_dir="$1" month
+	month=$(date -u +%Y-%m)
+	local logfile="${catalyst_dir}/events/${month}.jsonl"
+	[ -f "$logfile" ] || {
+		echo ""
+		return 1
+	}
+	grep -F '"event.name":"phase.' "$logfile" | tail -1
 }
 
 # Extract the executable bash body delimited by ```bash phase-triage-body``` fences.
@@ -90,25 +108,37 @@ trap 'rm -rf "$TMPROOT" "$SKILL_BODY_FILE"' EXIT
 # hermetic, independent of any real replica in the runner's HOME.
 export CATALYST_REPLICA_DB="$TMPROOT/no-such-replica.db"
 
+# CTL-1410 Phase A: resolve a case's worker dir (triage.json + phase-triage.json
+# both live here, modeling production: WORKER_DIR == ORCH_DIR/workers/TICKET).
+case_worker_dir() { echo "$TMPROOT/$1/orch/workers/$2"; }
+case_catalyst_dir() { echo "$TMPROOT/$1/catalyst"; }
+
 run_case() {
 	local case_name="$1" fixture="$2" ticket="$3"
 	local body_file="${4:-$SKILL_BODY_FILE}"
 	local case_dir="$TMPROOT/$case_name"
-	mkdir -p "$case_dir/bin"
+	local orch_dir="$case_dir/orch"
+	local worker="$orch_dir/workers/$ticket"
+	local catalyst_dir="$case_dir/catalyst"
+	mkdir -p "$case_dir/bin" "$worker" "$catalyst_dir/events"
+
+	# Pre-seed the phase signal file exactly as the dispatcher would leave it
+	# (status:"dispatched") so the wrapper's terminal flip to done/failed is
+	# observable on disk.
+	printf '{"status":"dispatched","ticket":"%s","phase":"triage"}\n' "$ticket" \
+		>"$worker/phase-triage.json"
 
 	# CTL-632: use the shared helper instead of inlining the stub body.
 	linearis_stub_install "$case_dir/bin" "$case_dir/linearis-calls.log" "$fixture"
 	linear_comment_post_stub_install "$case_dir/bin" "$case_dir/comment-post-calls.log"
 
-	# Run the skill body with the stub on PATH.
-	local events_file="$case_dir/events.jsonl"
-
 	PATH="$case_dir/bin:$PATH" \
 		TICKET="$ticket" \
-		WORKER_DIR="$case_dir/worker" \
-		CATALYST_EVENTS_FILE="$events_file" \
+		WORKER_DIR="$worker" \
+		CATALYST_DIR="$catalyst_dir" \
+		CATALYST_ORCHESTRATOR_DIR="$orch_dir" \
+		CATALYST_ORCHESTRATOR_ID="orch-test" \
 		PHASE_AGENT_REPO_ROOT="$REPO_ROOT" \
-		PHASE_EMIT_HELPER="$EMIT_HELPER" \
 		bash "$body_file" >"$case_dir/stdout.log" 2>"$case_dir/stderr.log"
 	echo $? >"$case_dir/exit-code"
 
@@ -132,13 +162,15 @@ cat >"$FIXTURE_HAPPY" <<'EOF'
 EOF
 
 CASE_DIR="$(run_case happy "$FIXTURE_HAPPY" CTL-9999)"
+HAPPY_WORKER="$(case_worker_dir happy CTL-9999)"
+HAPPY_CATALYST="$(case_catalyst_dir happy)"
 
 # Assert: skill exited 0
 EXIT_CODE="$(cat "$CASE_DIR/exit-code")"
 assert_eq "happy: exit code 0" 0 "$EXIT_CODE"
 
 # Assert: triage.json exists and parses
-TRIAGE_FILE="$CASE_DIR/worker/triage.json"
+TRIAGE_FILE="$HAPPY_WORKER/triage.json"
 assert_file_exists "happy: triage.json created" "$TRIAGE_FILE"
 
 if [ -f "$TRIAGE_FILE" ]; then
@@ -184,18 +216,26 @@ else
 	ok "happy: phase-triage does not write any Linear label (no triaged label exists)"
 fi
 
-# Assert: emitted event has the right shape
-EVENT_NAME="$(jq -r '.attributes."event.name"' "$CASE_DIR/events.jsonl" 2>/dev/null | head -1)"
+# Assert: emitted event has the right shape (CTL-1410: from the wrapper sink)
+HAPPY_EVENT="$(read_phase_event "$HAPPY_CATALYST")"
+EVENT_NAME="$(printf '%s' "$HAPPY_EVENT" | jq -r '.attributes."event.name"' 2>/dev/null)"
 assert_eq "happy: emitted event name" "phase.triage.complete.CTL-9999" "$EVENT_NAME"
 
-EVENT_TICKET="$(jq -r '.attributes."linear.issue.identifier"' "$CASE_DIR/events.jsonl" 2>/dev/null | head -1)"
+EVENT_TICKET="$(printf '%s' "$HAPPY_EVENT" | jq -r '.attributes."linear.issue.identifier"' 2>/dev/null)"
 assert_eq "happy: event has linear.issue.identifier" "CTL-9999" "$EVENT_TICKET"
 
-EVENT_PHASE="$(jq -r '.body.payload.phase_name' "$CASE_DIR/events.jsonl" 2>/dev/null | head -1)"
+EVENT_PHASE="$(printf '%s' "$HAPPY_EVENT" | jq -r '.body.payload.phase_name' 2>/dev/null)"
 assert_eq "happy: event payload has phase_name" "triage" "$EVENT_PHASE"
 
-EVENT_CLASS="$(jq -r '.body.payload.classification' "$CASE_DIR/events.jsonl" 2>/dev/null | head -1)"
+EVENT_CLASS="$(printf '%s' "$HAPPY_EVENT" | jq -r '.body.payload.classification' 2>/dev/null)"
 assert_nonempty "happy: event payload includes classification" "$EVENT_CLASS"
+
+# CTL-1410 Phase A: the wrapper flips the phase signal file to done in-band.
+HAPPY_SIGNAL="$HAPPY_WORKER/phase-triage.json"
+SIG_STATUS="$(jq -r '.status' "$HAPPY_SIGNAL" 2>/dev/null)"
+assert_eq "happy: signal status flipped to done (CTL-1410)" "done" "$SIG_STATUS"
+HAS_COMPLETED="$(jq -r 'has("completedAt")' "$HAPPY_SIGNAL" 2>/dev/null)"
+assert_eq "happy: signal gained completedAt (terminal)" "true" "$HAS_COMPLETED"
 
 # ─────────────────────────────────────────────────────────────────────────────
 # Case 1b: all-caps + project-vocab acronyms (CTL-498 Bug 1).
@@ -215,7 +255,7 @@ CASE_DIR_ACR="$(run_case acronyms "$FIXTURE_ACRONYMS" CTL-9998)"
 
 assert_eq "acronyms: exit code 0" 0 "$(cat "$CASE_DIR_ACR/exit-code")"
 
-TRIAGE_ACR="$CASE_DIR_ACR/worker/triage.json"
+TRIAGE_ACR="$(case_worker_dir acronyms CTL-9998)/triage.json"
 assert_file_exists "acronyms: triage.json created" "$TRIAGE_ACR"
 
 if [ -f "$TRIAGE_ACR" ]; then
@@ -248,7 +288,7 @@ CASE_DIR_MD="$(run_case markdown "$FIXTURE_MD" CTL-9997)"
 
 assert_eq "markdown: exit code 0" 0 "$(cat "$CASE_DIR_MD/exit-code")"
 
-TRIAGE_MD="$CASE_DIR_MD/worker/triage.json"
+TRIAGE_MD="$(case_worker_dir markdown CTL-9997)/triage.json"
 assert_file_exists "markdown: triage.json created" "$TRIAGE_MD"
 
 if [ -f "$TRIAGE_MD" ]; then
@@ -288,19 +328,25 @@ CASE_DIR2="$(run_case bug "$FIXTURE_BUG" CTL-7777)"
 EXIT_CODE2="$(cat "$CASE_DIR2/exit-code")"
 assert_eq "bug: exit code 0" 0 "$EXIT_CODE2"
 
-if [ -f "$CASE_DIR2/worker/triage.json" ]; then
-	CLASS2="$(jq -r '.classification' "$CASE_DIR2/worker/triage.json")"
+BUG_TRIAGE="$(case_worker_dir bug CTL-7777)/triage.json"
+if [ -f "$BUG_TRIAGE" ]; then
+	CLASS2="$(jq -r '.classification' "$BUG_TRIAGE")"
 	assert_eq "bug: classified as bug" "bug" "$CLASS2"
 
-	SCOPE2="$(jq -r '.estimated_scope' "$CASE_DIR2/worker/triage.json")"
+	SCOPE2="$(jq -r '.estimated_scope' "$BUG_TRIAGE")"
 	assert_eq "bug: scope is small" "small" "$SCOPE2"
 fi
 
 # ─────────────────────────────────────────────────────────────────────────────
-# Case 3: linearis read fails — skill must emit failed event + nonzero exit
+# Case 3: linearis read fails — skill must emit failed event + nonzero exit +
+# flip the signal to failed (CTL-1410 Phase A).
 
 FAIL_DIR="$TMPROOT/lin-fail"
-mkdir -p "$FAIL_DIR/bin"
+FAIL_ORCH="$FAIL_DIR/orch"
+FAIL_WORKER="$FAIL_ORCH/workers/CTL-9001"
+FAIL_CATALYST="$FAIL_DIR/catalyst"
+mkdir -p "$FAIL_DIR/bin" "$FAIL_WORKER" "$FAIL_CATALYST/events"
+printf '{"status":"dispatched","ticket":"CTL-9001","phase":"triage"}\n' >"$FAIL_WORKER/phase-triage.json"
 # CTL-1397: the triage body reads via direct SQL and falls back to `linearis`
 # when the replica is absent (which it is here — CATALYST_REPLICA_DB points at a
 # nonexistent file). Simulate a hard read failure by stubbing a failing
@@ -314,10 +360,11 @@ chmod +x "$FAIL_DIR/bin/linearis"
 
 PATH="$FAIL_DIR/bin:$PATH" \
 	TICKET=CTL-9001 \
-	WORKER_DIR="$FAIL_DIR/worker" \
-	CATALYST_EVENTS_FILE="$FAIL_DIR/events.jsonl" \
+	WORKER_DIR="$FAIL_WORKER" \
+	CATALYST_DIR="$FAIL_CATALYST" \
+	CATALYST_ORCHESTRATOR_DIR="$FAIL_ORCH" \
+	CATALYST_ORCHESTRATOR_ID="orch-test" \
 	PHASE_AGENT_REPO_ROOT="$REPO_ROOT" \
-	PHASE_EMIT_HELPER="$EMIT_HELPER" \
 	bash "$SKILL_BODY_FILE" >"$FAIL_DIR/stdout.log" 2>"$FAIL_DIR/stderr.log"
 FAIL_EXIT=$?
 
@@ -327,8 +374,11 @@ else
 	fail "lin-fail: exit code" "expected non-zero, got $FAIL_EXIT"
 fi
 
-FAIL_EVENT="$(jq -r '.attributes."event.name"' "$FAIL_DIR/events.jsonl" 2>/dev/null | head -1)"
+FAIL_EVENT="$(read_phase_event "$FAIL_CATALYST" | jq -r '.attributes."event.name"' 2>/dev/null)"
 assert_eq "lin-fail: emits phase.triage.failed event" "phase.triage.failed.CTL-9001" "$FAIL_EVENT"
+
+FAIL_SIG_STATUS="$(jq -r '.status' "$FAIL_WORKER/phase-triage.json" 2>/dev/null)"
+assert_eq "lin-fail: signal flipped to failed (CTL-1410)" "failed" "$FAIL_SIG_STATUS"
 
 # ─────────────────────────────────────────────────────────────────────────────
 # Case 4 (CTL-614): linearis issues discuss returns 429 — must NOT fail phase.
@@ -336,7 +386,11 @@ assert_eq "lin-fail: emits phase.triage.failed event" "phase.triage.failed.CTL-9
 # 429 stderr must surface to the skill's stderr (no longer swallowed).
 
 DISCUSS_429_DIR="$TMPROOT/discuss-429"
-mkdir -p "$DISCUSS_429_DIR/bin"
+D429_ORCH="$DISCUSS_429_DIR/orch"
+D429_WORKER="$D429_ORCH/workers/CTL-9002"
+D429_CATALYST="$DISCUSS_429_DIR/catalyst"
+mkdir -p "$DISCUSS_429_DIR/bin" "$D429_WORKER" "$D429_CATALYST/events"
+printf '{"status":"dispatched","ticket":"CTL-9002","phase":"triage"}\n' >"$D429_WORKER/phase-triage.json"
 
 FIXTURE_429="$TMPROOT/fixture-429.json"
 cat >"$FIXTURE_429" <<'EOF'
@@ -376,18 +430,19 @@ linear_comment_post_stub_install_failing "$DISCUSS_429_DIR/bin" "$DISCUSS_429_DI
 
 PATH="$DISCUSS_429_DIR/bin:$PATH" \
 	TICKET=CTL-9002 \
-	WORKER_DIR="$DISCUSS_429_DIR/worker" \
-	CATALYST_EVENTS_FILE="$DISCUSS_429_DIR/events.jsonl" \
+	WORKER_DIR="$D429_WORKER" \
+	CATALYST_DIR="$D429_CATALYST" \
+	CATALYST_ORCHESTRATOR_DIR="$D429_ORCH" \
+	CATALYST_ORCHESTRATOR_ID="orch-test" \
 	PHASE_AGENT_REPO_ROOT="$REPO_ROOT" \
-	PHASE_EMIT_HELPER="$EMIT_HELPER" \
 	bash "$SKILL_BODY_FILE" >"$DISCUSS_429_DIR/stdout.log" 2>"$DISCUSS_429_DIR/stderr.log"
 D429_EXIT=$?
 
 assert_eq "discuss-429: exit code 0 (best-effort)" 0 "$D429_EXIT"
 assert_file_exists "discuss-429: triage.json written despite discuss failure" \
-	"$DISCUSS_429_DIR/worker/triage.json"
+	"$D429_WORKER/triage.json"
 
-D429_EVENT="$(jq -r '.attributes."event.name"' "$DISCUSS_429_DIR/events.jsonl" 2>/dev/null | head -1)"
+D429_EVENT="$(read_phase_event "$D429_CATALYST" | jq -r '.attributes."event.name"' 2>/dev/null)"
 assert_eq "discuss-429: emits phase.triage.complete (not failed)" \
 	"phase.triage.complete.CTL-9002" "$D429_EVENT"
 
@@ -422,7 +477,7 @@ CASE_DIR_SUBST="$(run_case subst "$FIXTURE_HAPPY" CTL-9999 "$SUBST_BODY")"
 
 assert_eq "ctl602-dynamic: substituted body exits 0" 0 "$(cat "$CASE_DIR_SUBST/exit-code")"
 
-TRIAGE_SUBST="$CASE_DIR_SUBST/worker/triage.json"
+TRIAGE_SUBST="$(case_worker_dir subst CTL-9999)/triage.json"
 assert_file_exists "ctl602-dynamic: substituted body produced triage.json" "$TRIAGE_SUBST"
 
 if [ -f "$TRIAGE_SUBST" ]; then
@@ -468,7 +523,7 @@ EOF
 
 CASE_DIR_MENTIONS="$(run_case mentions "$FIXTURE_MENTIONS" CTL-863)"
 assert_eq "ctl838-noscrape: exit code 0" 0 "$(cat "$CASE_DIR_MENTIONS/exit-code")"
-TRIAGE_MENTIONS="$CASE_DIR_MENTIONS/worker/triage.json"
+TRIAGE_MENTIONS="$(case_worker_dir mentions CTL-863)/triage.json"
 assert_file_exists "ctl838-noscrape: triage.json created" "$TRIAGE_MENTIONS"
 if [ -f "$TRIAGE_MENTIONS" ]; then
 	DEPS_MENTIONS="$(jq -c '.dependencies' "$TRIAGE_MENTIONS")"

--- a/plugins/dev/scripts/execution-core/sdk-run-phase-agent.mjs
+++ b/plugins/dev/scripts/execution-core/sdk-run-phase-agent.mjs
@@ -469,6 +469,72 @@ function defaultWriteSignalStalled(signalFile, reason) {
   return defaultWriteSignalTerminal(signalFile, "stalled", reason);
 }
 
+// CTL-1410 Phase A: the SDK success-branch signal flip. When query() resolves
+// subtype==="success", mapResult returns backstop:null — historically the phase
+// SKILL was solely responsible for flipping its own signal to done (via the
+// phase-agent-emit-complete wrapper). That holds now that the two event-only
+// phases (triage, monitor-deploy) route their terminal emit through the wrapper,
+// but this is the in-process belt-and-suspenders net: on a clean success, if the
+// signal is STILL in-flight (dispatched|running) — the skill exited 0 without its
+// own flip — flip it to done here so occupancy (countSdkInflight) releases the
+// slot and deriveAdvancement sees a terminal status. Under executor=sdk there is
+// no bg reclaim path to synthesize the flip, so without this a success that
+// skipped its wrapper call would strand the slot.
+//
+// Distinct from defaultWriteSignalTerminal on purpose:
+//   - acts ONLY on an in-flight (dispatched|running) signal — it NEVER resurrects
+//     a parked (needs-input) hold into done, and never clobbers an already-terminal
+//     status (done/failed/skipped/turn-cap-exhausted);
+//   - honors the CTL-736 generation fence — a stale superseded worker must NOT
+//     write an outcome (see below);
+//   - writes status:"done" + completedAt (a SUCCESS terminal), no attentionReason
+//     (an attentionReason/failureReason would trip revive's escalate branch).
+const SIGNAL_INFLIGHT_STATUSES = new Set(["dispatched", "running"]);
+
+// Plain-integer test shared by the generation fence — mirrors the bash
+// `[[ $x =~ ^[0-9]+$ ]]` in phase-agent-emit-complete and claim.mjs's
+// isCurrentGeneration semantics exactly.
+const isPlainInt = (v) => /^[0-9]+$/.test(String(v));
+
+export function flipSignalDoneOnSuccess(signalFile, generation) {
+  if (!signalFile) return;
+  try {
+    let sig;
+    try {
+      sig = JSON.parse(readFileSync(signalFile, "utf8"));
+    } catch {
+      return; // no signal on disk (prelaunch never wrote one) — nothing to flip
+    }
+    if (!sig || typeof sig !== "object") return;
+    // In-flight-only precondition. A terminal signal is already correct; a
+    // needs-input (parked) signal must stay parked.
+    if (!SIGNAL_INFLIGHT_STATUSES.has(String(sig.status))) return;
+    // CTL-736 generation fence (adversarial-review catch, CTL-1410 Phase A): an
+    // in-process query cannot be killed (preemption's killBgJob(null) is a no-op,
+    // the per-attempt AbortController is not externally wired), so a preempt→
+    // re-dispatch or revive leaves a stale gen-N query floating while gen-N+1 owns
+    // the SAME signal path. That stale worker's skill correctly bows out at the
+    // wrapper's fence — this flip must not override that refusal by flipping the
+    // newer dispatch's in-flight signal to done (slot over-admission + premature
+    // advancement). Bow out ONLY when both generations are plain integers AND
+    // mine < signal's; anything missing/non-numeric fails open so legacy and
+    // unfenced dispatches are unaffected (isCurrentGeneration parity).
+    if (isPlainInt(generation) && isPlainInt(sig.generation) && Number(generation) < Number(sig.generation)) {
+      return;
+    }
+    const ts = new Date().toISOString().replace(/\.\d{3}Z$/, "Z");
+    sig.status = "done";
+    sig.completedAt = ts;
+    sig.updatedAt = ts;
+    sig.phaseTimestamps = { ...(sig.phaseTimestamps ?? {}), done: ts };
+    const tmp = `${signalFile}.tmp.${process.pid}`;
+    writeFileSync(tmp, JSON.stringify(sig));
+    renameSync(tmp, signalFile);
+  } catch {
+    /* best-effort — the skill's own wrapper flip is the primary path */
+  }
+}
+
 // defaultAppendEventLog — CTL-1367 item 5. Last-resort terminal-event append when
 // the phase-agent-emit-complete binary is missing or fails. Writes one canonical
 // v2 envelope `phase.<phase>.<status>.<ticket>` to the unified event log so the
@@ -1058,6 +1124,12 @@ export async function sdkRunPhaseAgent(
       }
       if (backstop) {
         emitBackstop({ phase, ticket, status: backstop.status, reason: backstop.reason, orchDir, signalFile }, { spawn });
+      } else if (signalFile) {
+        // CTL-1410 Phase A: clean SDK success (no backstop) — in-process safety
+        // net that flips a still-in-flight signal to done. No-op when the phase
+        // SKILL already flipped it via the wrapper (the primary path), or when
+        // this run's generation is stale (superseded by a newer dispatch).
+        flipSignalDoneOnSuccess(signalFile, spec.generation);
       }
       return mapped;
     }

--- a/plugins/dev/scripts/execution-core/sdk-run-phase-agent.test.mjs
+++ b/plugins/dev/scripts/execution-core/sdk-run-phase-agent.test.mjs
@@ -18,6 +18,7 @@ import {
   Semaphore,
   scrubSecrets,
   defaultEmitBackstop,
+  flipSignalDoneOnSuccess,
 } from "./sdk-run-phase-agent.mjs";
 
 // ── Fakes ───────────────────────────────────────────────────────────────────
@@ -1087,6 +1088,177 @@ describe("sdkRunPhaseAgent — CTL-1367 item 4 (backstop → stalled signal)", (
     expect(after.status).toBe("stalled");
     expect(after.attentionReason).toBe("sdk-threw"); // NOT failureReason (revive retries)
     expect("failureReason" in after).toBe(false);
+    rmSync(dir, { recursive: true, force: true });
+  });
+});
+
+// ── CTL-1410 Phase A: SDK success-branch signal flip ──────────────────────────
+// mapResult subtype==="success" returns backstop:null — historically the ONE
+// abstaining branch (the skill was solely responsible for its own flip). With the
+// event-only phases migrated onto the wrapper, this in-process net flips a
+// still-in-flight (dispatched|running) signal to done so occupancy releases and
+// deriveAdvancement sees a terminal status even if a skill skipped its wrapper
+// call. It must NEVER clobber a terminal status, resurrect a parked hold, nor
+// act on a stale generation (superseded worker).
+
+describe("flipSignalDoneOnSuccess — CTL-1410 Phase A truth table", () => {
+  const flipCase = (startStatus) => {
+    const dir = mkdtempSync(join(tmpdir(), "sdk-flip-"));
+    const signalFile = join(dir, "phase-triage.json");
+    writeFileSync(signalFile, JSON.stringify({ status: startStatus, ticket: "CTL-1", phase: "triage" }));
+    flipSignalDoneOnSuccess(signalFile);
+    const after = JSON.parse(readFileSync(signalFile, "utf8"));
+    rmSync(dir, { recursive: true, force: true });
+    return after;
+  };
+
+  test("dispatched (in-flight) → done + completedAt, no attentionReason", () => {
+    const after = flipCase("dispatched");
+    expect(after.status).toBe("done");
+    expect(typeof after.completedAt).toBe("string");
+    expect("attentionReason" in after).toBe(false);
+    expect("failureReason" in after).toBe(false);
+  });
+
+  test("running (in-flight) → done", () => {
+    expect(flipCase("running").status).toBe("done");
+  });
+
+  test("needs-input (parked) is NEVER resurrected to done", () => {
+    const after = flipCase("needs-input");
+    expect(after.status).toBe("needs-input");
+    expect("completedAt" in after).toBe(false);
+  });
+
+  for (const terminal of ["done", "failed", "stalled", "skipped", "turn-cap-exhausted"]) {
+    test(`already-terminal '${terminal}' is not clobbered`, () => {
+      const after = flipCase(terminal);
+      expect(after.status).toBe(terminal);
+      expect("completedAt" in after).toBe(false);
+    });
+  }
+
+  test("missing / empty / null signalFile never throws", () => {
+    expect(() => {
+      flipSignalDoneOnSuccess("/nonexistent/dir/sig.json");
+      flipSignalDoneOnSuccess("");
+      flipSignalDoneOnSuccess(null);
+    }).not.toThrow();
+  });
+
+  // CTL-736 generation fence (adversarial-review catch): a stale superseded
+  // worker's late success must NOT flip the newer dispatch's in-flight signal.
+  const fenceCase = (mine, sigGen) => {
+    const dir = mkdtempSync(join(tmpdir(), "sdk-fence-"));
+    const signalFile = join(dir, "phase-implement.json");
+    const sig = { status: "dispatched", ticket: "CTL-1", phase: "implement" };
+    if (sigGen !== undefined) sig.generation = sigGen;
+    writeFileSync(signalFile, JSON.stringify(sig));
+    flipSignalDoneOnSuccess(signalFile, mine);
+    const after = JSON.parse(readFileSync(signalFile, "utf8"));
+    rmSync(dir, { recursive: true, force: true });
+    return after.status;
+  };
+
+  test("stale generation (mine < signal) bows out — signal stays in-flight", () => {
+    expect(fenceCase(5, 6)).toBe("dispatched");
+  });
+
+  test("current generation (mine == signal) flips", () => {
+    expect(fenceCase(6, 6)).toBe("done");
+  });
+
+  test("newer generation (mine > signal) flips (fail-open, matches isCurrentGeneration)", () => {
+    expect(fenceCase(7, 6)).toBe("done");
+  });
+
+  test("missing own generation fails open (legacy/unfenced dispatch) — flips", () => {
+    expect(fenceCase(undefined, 6)).toBe("done");
+  });
+
+  test("missing signal generation fails open — flips", () => {
+    expect(fenceCase(5, undefined)).toBe("done");
+  });
+
+  test("non-numeric generations fail open — flips", () => {
+    expect(fenceCase("garbage", "alsogarbage")).toBe("done");
+  });
+});
+
+describe("sdkRunPhaseAgent — CTL-1410 Phase A (success flips in-flight signal to done)", () => {
+  test("success + signal still 'dispatched' → flipped to done (the safety net)", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "sdk-flip-e2e-"));
+    const signalFile = join(dir, "phase-triage.json");
+    const spec = makeSpec({ signalFile });
+    const { spawn } = spawnReturningSpec({ spec, signalFile });
+    const backstops = [];
+    const r = await sdkRunPhaseAgent(ARGS, {
+      ...GOOD_AUTH, spawn,
+      runQuery: fakeQuery([resultMsg()]),
+      emitBackstop: (e) => backstops.push(e),
+    });
+    expect(r.code).toBe(0);
+    expect(backstops).toHaveLength(0);
+    const after = JSON.parse(readFileSync(signalFile, "utf8"));
+    expect(after.status).toBe("done");
+    expect(typeof after.completedAt).toBe("string");
+    expect("attentionReason" in after).toBe(false);
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  test("success + skill already flipped (done) → untouched (primary path wins)", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "sdk-flip-e2e-"));
+    const signalFile = join(dir, "phase-triage.json");
+    const spec = makeSpec({ signalFile });
+    // Prelaunch writes dispatched; the fake query simulates the skill's own
+    // wrapper flip (status done + its own completedAt) before resolving success.
+    const { spawn } = spawnReturningSpec({ spec, signalFile });
+    const skillFlip = () => (async function* () {
+      writeFileSync(signalFile, JSON.stringify({ status: "done", completedAt: "2026-07-01T00:00:00Z", ticket: "CTL-100" }));
+      yield resultMsg();
+    })();
+    const r = await sdkRunPhaseAgent(ARGS, { ...GOOD_AUTH, spawn, runQuery: skillFlip });
+    expect(r.code).toBe(0);
+    const after = JSON.parse(readFileSync(signalFile, "utf8"));
+    expect(after.status).toBe("done");
+    expect(after.completedAt).toBe("2026-07-01T00:00:00Z"); // NOT overwritten
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  test("success + parked (needs-input) → NOT flipped (in-flight-only precondition)", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "sdk-flip-e2e-"));
+    const signalFile = join(dir, "phase-triage.json");
+    const spec = makeSpec({ signalFile });
+    const { spawn } = spawnReturningSpec({ spec, signalFile });
+    const parkThenSucceed = () => (async function* () {
+      writeFileSync(signalFile, JSON.stringify({ status: "needs-input", parkedFrom: "triage", ticket: "CTL-100" }));
+      yield resultMsg();
+    })();
+    const r = await sdkRunPhaseAgent(ARGS, { ...GOOD_AUTH, spawn, runQuery: parkThenSucceed });
+    expect(r.code).toBe(0);
+    const after = JSON.parse(readFileSync(signalFile, "utf8"));
+    expect(after.status).toBe("needs-input");
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  test("stale-generation success (superseded worker) does NOT flip the newer dispatch's signal", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "sdk-flip-e2e-"));
+    const signalFile = join(dir, "phase-triage.json");
+    // This run carries generation 1; a newer dispatch has since claimed the
+    // signal at generation 2 (preempt→re-dispatch / revive supersede). The stale
+    // run's clean success must bow out exactly like the wrapper's fence does.
+    const spec = makeSpec({ signalFile, generation: 1 });
+    const { spawn } = spawnReturningSpec({ spec, signalFile });
+    const supersede = () => (async function* () {
+      writeFileSync(signalFile, JSON.stringify({ status: "dispatched", generation: 2, ticket: "CTL-100" }));
+      yield resultMsg();
+    })();
+    const r = await sdkRunPhaseAgent(ARGS, { ...GOOD_AUTH, spawn, runQuery: supersede });
+    expect(r.code).toBe(0);
+    const after = JSON.parse(readFileSync(signalFile, "utf8"));
+    expect(after.status).toBe("dispatched"); // the gen-2 worker still owns it
+    expect(after.generation).toBe(2);
+    expect("completedAt" in after).toBe(false);
     rmSync(dir, { recursive: true, force: true });
   });
 });

--- a/plugins/dev/scripts/phase-agent-emit-complete
+++ b/plugins/dev/scripts/phase-agent-emit-complete
@@ -28,10 +28,17 @@
 #     --ticket <id> \
 #     --status complete|failed \
 #     [--reason <text>] \
+#     [--payload-json <json>] \
 #     [--orch-dir <path>] \
 #     [--orch-id <id>] \
 #     [--session-id <id>] \
 #     [--no-signal-update]
+#
+# --payload-json (CTL-1410): merge a caller-supplied JSON object into the event's
+#   body.payload (caller fields as base; the canonical phase/ticket/status fields
+#   overlay and win; phase_name injected). Used by the event-only phases migrating
+#   onto this wrapper so their terminal artifact detail still rides the completion
+#   event. Absent → byte-identical default payload. Malformed → fail-open to base.
 #
 # --no-signal-update (CTL-511): emit the canonical event (step 1) and end the
 #   catalyst-session (step 3) but skip the signal-file mutation (step 2). Used
@@ -81,6 +88,7 @@ TICKET=""
 STATUS=""
 REASON=""
 HANDOFF_PATH=""
+CALLER_PAYLOAD=""
 ORCH_DIR="${CATALYST_ORCHESTRATOR_DIR-}"
 ORCH_ID="${CATALYST_ORCHESTRATOR_ID-}"
 SESSION_ID="${CATALYST_SESSION_ID-}"
@@ -106,6 +114,10 @@ while [[ $# -gt 0 ]]; do
 		;;
 	--handoff-path)
 		HANDOFF_PATH="$2"
+		shift 2
+		;;
+	--payload-json)
+		CALLER_PAYLOAD="$2"
 		shift 2
 		;;
 	--orch-dir)
@@ -317,7 +329,7 @@ fi
 # optional failure_reason, optional handoff_path (CTL-484 turn-cap-exhausted),
 # optional duration_seconds (CTL-760). The broker's tryPhaseLifecycleRoute parser
 # reads only event.name + ticket, so payload extras don't change routing.
-PAYLOAD=$(jq -nc \
+BASE_PAYLOAD=$(jq -nc \
 	--arg phase "$PHASE" \
 	--arg ticket "$TICKET" \
 	--arg status "$STATUS" \
@@ -328,6 +340,26 @@ PAYLOAD=$(jq -nc \
    + (if ($reason == "" or $status == "complete") then {} else {failure_reason: $reason} end)
    + (if $handoff == "" then {} else {handoff_path: $handoff} end)
    + (if $duration == "" then {} else {duration_seconds: ($duration | tonumber)} end)')
+
+# CTL-1410 Phase A: optional --payload-json <json>. The event-only phases
+# (phase-triage, phase-monitor-deploy) migrating from the emit_phase_complete
+# helper to this wrapper pass their terminal artifact JSON (triage.json /
+# phase-monitor-deploy.json) so the completion event still carries that detail
+# plus phase_name — matching what the lib helper attached. The caller fields form
+# the base; the wrapper's canonical fields (phase/ticket/status/failure_reason/…)
+# overlay so they always win, then phase_name is injected. When absent, PAYLOAD is
+# byte-identical to the pre-CTL-1410 default (no phase_name). A malformed caller
+# payload fails open to the base default — the completion event is never dropped.
+PAYLOAD="$BASE_PAYLOAD"
+if [[ -n $CALLER_PAYLOAD ]]; then
+	PAYLOAD=$(jq -nc \
+		--argjson base "$BASE_PAYLOAD" \
+		--argjson caller "$CALLER_PAYLOAD" \
+		--arg phase "$PHASE" \
+		'($caller // {}) + $base + {phase_name: $phase}' 2>/dev/null) ||
+		PAYLOAD="$BASE_PAYLOAD"
+	[[ -n $PAYLOAD ]] || PAYLOAD="$BASE_PAYLOAD"
+fi
 
 LINE=$(build_canonical_line \
 	--ts "$TS" \

--- a/plugins/dev/skills/phase-monitor-deploy/SKILL.md
+++ b/plugins/dev/skills/phase-monitor-deploy/SKILL.md
@@ -83,21 +83,15 @@ set -uo pipefail
 __PM_SCRIPT_PATH="${BASH_SOURCE[0]:-${0}}"
 __PM_SKILL_DIR="$(cd "$(dirname "$__PM_SCRIPT_PATH")" && pwd 2>/dev/null || pwd)"
 __PM_REPO_ROOT="${PHASE_AGENT_REPO_ROOT:-$(cd "$__PM_SKILL_DIR/../../../.." 2>/dev/null && pwd || pwd)}"
-__PM_LIB="${PHASE_EMIT_HELPER:-${__PM_REPO_ROOT}/plugins/dev/scripts/lib/phase-emit-complete.sh}"
-# CTL-512: emit terminal events via the production wrapper so the signal
-# file's `status` field is written canonically. The lib helper at
-# $__PM_LIB only emits events — it never touches the signal file, which
-# is why pre-CTL-512 skipped runs relied on orchestrate-revive to
-# synthesize a `done` status. The wrapper also handles the broker emit,
-# the session DB close, and the completedAt timestamp.
+# CTL-512 → CTL-1410 Phase A: every terminal event goes through the production
+# wrapper (phase-agent-emit-complete) so the phase signal file's `status` field is
+# written canonically in-band. CTL-512 first moved the `skipped` branch here;
+# CTL-1410 completes the migration for complete+failed so monitor-deploy →
+# teardown advances under executor=sdk — the event-only phase-emit-complete.sh lib
+# helper (which only emitted events and never touched the signal file, leaving the
+# terminal status to the bg-only reclaim path that silently no-ops under sdk) is no
+# longer sourced. The wrapper also owns the broker emit, session DB close, completedAt.
 __PM_WRAPPER="${PHASE_EMIT_WRAPPER:-${__PM_REPO_ROOT}/plugins/dev/scripts/phase-agent-emit-complete}"
-
-if [[ ! -r "$__PM_LIB" ]]; then
-  echo "phase-monitor-deploy: cannot find phase-emit-complete.sh at $__PM_LIB" >&2
-  exit 1
-fi
-# shellcheck disable=SC1090
-. "$__PM_LIB"
 
 if [[ ! -x "$__PM_WRAPPER" ]]; then
   echo "phase-monitor-deploy: cannot find phase-agent-emit-complete wrapper at $__PM_WRAPPER" >&2
@@ -117,7 +111,7 @@ CANARY_CMD="${PHASE_CANARY_CMD:-claude --model haiku -p /canary --output-format 
 # 1. Read merge SHA from phase-monitor-merge.json (the prior phase artifact).
 MERGE_FILE="$WORKER_DIR/phase-monitor-merge.json"
 if [[ ! -f "$MERGE_FILE" ]]; then
-  emit_phase_complete --phase monitor-deploy --ticket "$TICKET" --status failed \
+  "$__PM_WRAPPER" --phase monitor-deploy --ticket "$TICKET" --status failed \
     --reason "phase-monitor-merge.json missing at $MERGE_FILE"
   exit 1
 fi
@@ -132,19 +126,19 @@ if [[ -z "$MERGE_SHA" ]]; then
     PR_NUMBER="$(jq -r '.pr.number // empty' "$PR_FILE" 2>/dev/null)"
   fi
   if [[ -z "$PR_NUMBER" ]]; then
-    emit_phase_complete --phase monitor-deploy --ticket "$TICKET" --status failed \
+    "$__PM_WRAPPER" --phase monitor-deploy --ticket "$TICKET" --status failed \
       --reason "phase-monitor-merge.json has empty .pr.mergeCommitSha and no PR number available for gh REST fallback"
     exit 1
   fi
   REPO="$(gh repo view --json nameWithOwner --jq '.nameWithOwner' 2>/dev/null || echo "")"
   if [[ -z "$REPO" ]]; then
-    emit_phase_complete --phase monitor-deploy --ticket "$TICKET" --status failed \
+    "$__PM_WRAPPER" --phase monitor-deploy --ticket "$TICKET" --status failed \
       --reason "phase-monitor-merge.json has empty .pr.mergeCommitSha and gh repo view returned empty"
     exit 1
   fi
   MERGE_SHA="$(gh api "repos/${REPO}/pulls/${PR_NUMBER}" --jq '.merge_commit_sha // empty' 2>/dev/null || echo "")"
   if [[ -z "$MERGE_SHA" ]]; then
-    emit_phase_complete --phase monitor-deploy --ticket "$TICKET" --status failed \
+    "$__PM_WRAPPER" --phase monitor-deploy --ticket "$TICKET" --status failed \
       --reason "phase-monitor-merge.json has empty .pr.mergeCommitSha and gh REST fallback also returned empty for pr#${PR_NUMBER}"
     exit 1
   fi
@@ -229,7 +223,7 @@ case "$DEPLOY_STATE" in
         canary_result: null,
         completed_at: $ts
       }' > "$WORKER_DIR/phase-monitor-deploy.json"
-    emit_phase_complete --phase monitor-deploy --ticket "$TICKET" --status failed \
+    "$__PM_WRAPPER" --phase monitor-deploy --ticket "$TICKET" --status failed \
       --reason "deployment_status reported state=$DEPLOY_STATE for $MERGE_SHA on $DEPLOY_ENV" \
       --payload-json "$(cat "$WORKER_DIR/phase-monitor-deploy.json")"
     exit 1
@@ -238,7 +232,7 @@ case "$DEPLOY_STATE" in
     # pending / in_progress / queued — wait-for already filtered terminal states
     # via the test fixture, so this branch is mainly defensive. Treat as failed
     # to escalate; future work can re-enter the wait loop instead.
-    emit_phase_complete --phase monitor-deploy --ticket "$TICKET" --status failed \
+    "$__PM_WRAPPER" --phase monitor-deploy --ticket "$TICKET" --status failed \
       --reason "unexpected non-terminal deployment state: $DEPLOY_STATE"
     exit 1
     ;;
@@ -252,13 +246,13 @@ CANARY_OUT_FILE="$WORKER_DIR/canary-output.json"
 CANARY_STDERR_FILE="$WORKER_DIR/canary-stderr.log"
 
 if ! eval "$CANARY_CMD" > "$CANARY_OUT_FILE" 2> "$CANARY_STDERR_FILE"; then
-  emit_phase_complete --phase monitor-deploy --ticket "$TICKET" --status failed \
+  "$__PM_WRAPPER" --phase monitor-deploy --ticket "$TICKET" --status failed \
     --reason "canary command exited non-zero (see $CANARY_STDERR_FILE)"
   exit 1
 fi
 
 if ! jq -e . "$CANARY_OUT_FILE" >/dev/null 2>&1; then
-  emit_phase_complete --phase monitor-deploy --ticket "$TICKET" --status failed \
+  "$__PM_WRAPPER" --phase monitor-deploy --ticket "$TICKET" --status failed \
     --reason "canary stdout did not parse as JSON"
   exit 1
 fi
@@ -314,7 +308,14 @@ ${MIRROR_FOOTER}"
   fi
   # CTL-864: cross-host fence — bow out if a takeover superseded us. No-op single-host.
   "${__PM_REPO_ROOT}/plugins/dev/scripts/lib/cluster-fence-guard.sh" --phase "${CATALYST_PHASE:-monitor-deploy}" --ticket "$TICKET" || exit 10
-  COMMENT_POST="${CATALYST_COMMENT_POST_HELPER:-${PLUGIN_ROOT}/scripts/lib/linear-comment-post.sh}"
+  # CTL-1410 Phase A bug fix (pre-existing since CTL-550): this line referenced
+  # ${PLUGIN_ROOT}, which this body never defines (unlike the model-driven phase
+  # skills, which resolve it from CLAUDE_PLUGIN_ROOT in an early step). Under the
+  # body's `set -u` the unbound expansion killed the SUCCESS path right here —
+  # after the artifact write, before the terminal emit — so no complete event was
+  # ever emitted. Resolve from __PM_REPO_ROOT (this body's own root idiom),
+  # mirroring phase-triage's __PT_COMMENT_POST.
+  COMMENT_POST="${CATALYST_COMMENT_POST_HELPER:-${__PM_REPO_ROOT}/plugins/dev/scripts/lib/linear-comment-post.sh}"
   if [[ ! -x "$COMMENT_POST" ]]; then COMMENT_POST="$(command -v linear-comment-post.sh 2>/dev/null || true)"; fi
   if [[ -n "$COMMENT_POST" && -x "$COMMENT_POST" ]] && "$COMMENT_POST" "${TICKET}" "${MIRROR_BODY}" >/dev/null; then
     : > "${LINEAR_MIRROR_MARKER}"
@@ -323,14 +324,17 @@ ${MIRROR_FOOTER}"
   fi
 fi
 
-# 6. Emit the canonical phase event based on canary status.
+# 6. Emit the canonical phase event based on canary status. CTL-1410 Phase A: via
+#    $__PM_WRAPPER so the signal file's terminal `status` is flipped in-band under
+#    executor=sdk (the artifact write above already landed the same file, so the
+#    wrapper merges status/completedAt on top without clobbering deploy_* fields).
 if [[ "$CANARY_STATUS" == "success" ]]; then
-  emit_phase_complete --phase monitor-deploy --ticket "$TICKET" --status complete \
+  "$__PM_WRAPPER" --phase monitor-deploy --ticket "$TICKET" --status complete \
     --payload-json "$(cat "$RESULT_FILE")"
   exit 0
 fi
 
-emit_phase_complete --phase monitor-deploy --ticket "$TICKET" --status failed \
+"$__PM_WRAPPER" --phase monitor-deploy --ticket "$TICKET" --status failed \
   --reason "canary status=${CANARY_STATUS:-unknown}" \
   --payload-json "$(cat "$RESULT_FILE")"
 exit 1

--- a/plugins/dev/skills/phase-triage/SKILL.md
+++ b/plugins/dev/skills/phase-triage/SKILL.md
@@ -77,14 +77,19 @@ set -uo pipefail
 __PT_SCRIPT_PATH="${BASH_SOURCE[0]:-${0}}"
 __PT_SKILL_DIR="$(cd "$(dirname "$__PT_SCRIPT_PATH")" && pwd 2>/dev/null || pwd)"
 __PT_REPO_ROOT="${PHASE_AGENT_REPO_ROOT:-$(cd "$__PT_SKILL_DIR/../../../.." 2>/dev/null && pwd || pwd)}"
-__PT_LIB="${PHASE_EMIT_HELPER:-${__PT_REPO_ROOT}/plugins/dev/scripts/lib/phase-emit-complete.sh}"
+# CTL-1410 Phase A: terminal events go through the production wrapper
+# (phase-agent-emit-complete) instead of the event-only phase-emit-complete.sh
+# lib helper, so the phase signal file's `status` field is flipped to done/failed
+# canonically in-band. Triage previously delegated that flip to the bg-only
+# reclaim path, which silently no-ops under executor=sdk (bg_job_id null →
+# classifyWorker "unknown" → reclaim "noop") — the strand this phase closes. The
+# wrapper also owns the broker emit, the session-DB close, and completedAt.
+__PT_WRAPPER="${PHASE_EMIT_WRAPPER:-${__PT_REPO_ROOT}/plugins/dev/scripts/phase-agent-emit-complete}"
 
-if [[ ! -r "$__PT_LIB" ]]; then
-  echo "phase-triage: cannot find phase-emit-complete.sh at $__PT_LIB" >&2
+if [[ ! -x "$__PT_WRAPPER" ]]; then
+  echo "phase-triage: cannot find phase-agent-emit-complete wrapper at $__PT_WRAPPER" >&2
   exit 1
 fi
-# shellcheck disable=SC1090
-. "$__PT_LIB"
 
 # CTL-1397: direct-SQLite Linear reads (replica-first, loud linearis fallback).
 __PT_READ_LIB="${PHASE_LINEAR_READ_HELPER:-${__PT_REPO_ROOT}/plugins/dev/scripts/lib/linear-read-replica.sh}"
@@ -110,13 +115,13 @@ TICKET_JSON_FILE="$(mktemp)"
 trap 'rm -f "$TICKET_JSON_FILE"' EXIT
 
 if ! linear_read_ticket "$TICKET" > "$TICKET_JSON_FILE"; then
-  emit_phase_complete --phase triage --ticket "$TICKET" --status failed \
+  "$__PT_WRAPPER" --phase triage --ticket "$TICKET" --status failed \
     --reason "linear read failed"
   exit 1
 fi
 
 if ! jq -e . "$TICKET_JSON_FILE" >/dev/null 2>&1; then
-  emit_phase_complete --phase triage --ticket "$TICKET" --status failed \
+  "$__PT_WRAPPER" --phase triage --ticket "$TICKET" --status failed \
     --reason "linear read returned non-JSON output"
   exit 1
 fi
@@ -301,8 +306,9 @@ fi
 #    (Historical note for anyone grepping CTL-558: the old coordinator label
 #    sweep that tagged `triaged` was removed.)
 
-# 6. Emit the canonical phase event.
-emit_phase_complete --phase triage --ticket "$TICKET" --status complete \
+# 6. Emit the canonical phase event + flip the signal to done (CTL-1410 Phase A:
+#    via the wrapper, so the terminal status is written in-band under executor=sdk).
+"$__PT_WRAPPER" --phase triage --ticket "$TICKET" --status complete \
   --payload-json "$(cat "$TRIAGE_FILE")"
 
 # Self-halt after complete to prevent zombie workers (CTL-778 step 2).


### PR DESCRIPTION
## Summary

Phase A of the CTL-1410 SDK-only standardization (plan: `thoughts/shared/plans/2026-07-01-CTL-1410-sdk-only-standardization-delete-bg-executor.md`). Subsumes CTL-1409.

Under `executor=sdk`, workers run in-process (`bg_job_id: null`), so the bg reclaim stack that used to synthesize terminal signal-file flips silently no-ops (`classifyWorker` → `"unknown"` → `"noop"`). Any phase that emits its terminal event through the **event-only** `emit_phase_complete` lib helper therefore strands: the event fires but the signal file never leaves `dispatched`/`running`, the slot never frees, and advancement never sees a terminal status. Today that is **triage (all paths)** and **monitor-deploy (complete + failed)** — CTL-512 migrated only monitor-deploy's `skipped` branch.

## Changes

- **`phase-agent-emit-complete` — new `--payload-json <json>`**: caller artifact JSON (triage.json / phase-monitor-deploy.json) merges into `body.payload` — caller fields as base, canonical `phase`/`ticket`/`status` overlay, `phase_name` injected (lib-helper parity). Absent → byte-identical default payload; malformed → fail-open to base (the event is never dropped).
- **`phase-triage` + `phase-monitor-deploy` SKILL bodies**: every terminal emit migrated to the full wrapper (`$__PT_WRAPPER` / `$__PM_WRAPPER`) so the signal flips to `done`/`failed` in-band; the event-only lib source is dropped. Monitor-deploy preserves the artifact-write-then-wrapper ordering (same file — the wrapper merges `status`/`completedAt` on top of `deploy_*`).
- **Pre-existing bug fix (latent since CTL-550)**: monitor-deploy's Linear-mirror block referenced `${PLUGIN_ROOT}`, which that body never defines — under the body's `set -u` the **success path died after the artifact write and before any terminal emit**. Baseline on `main` reproduces (its e2e suite fails 6 assertions). Now resolves via `__PM_REPO_ROOT`, mirroring phase-triage.
- **`sdk-run-phase-agent.mjs` — `flipSignalDoneOnSuccess` safety net**: on a clean SDK success with no backstop (the one branch that abstained), flip a still-in-flight (`dispatched|running`) signal to `done`+`completedAt` (no `attentionReason`). Never clobbers terminal statuses, never resurrects `needs-input`, and honors the **CTL-736 generation fence** — an adversarial-review catch: a stale superseded worker's late success (preempt→re-dispatch leaves an unkillable in-process query floating) must not flip the newer dispatch's signal. `isCurrentGeneration` parity, fail-open on missing/non-numeric generations.

## Tests

- **NEW `no-event-only-terminal-emit.test.sh`** — greps every `phase-*/SKILL.md` for event-only terminal emits; the invariant that makes the SDK success⇒done assumption sound (11/11).
- Wrapper `--payload-json` tests 46–48 (merge/overlay/phase_name; byte-identical default; malformed fail-open) — 98/0.
- `flipSignalDoneOnSuccess` truth table + generation-fence cases + 4 `sdkRunPhaseAgent` e2e tests (success flip, primary-path-wins, parked-not-resurrected, stale-generation bow-out) — 111/0.
- Both phase e2e suites re-pointed at the wrapper sink (`$CATALYST_DIR/events/YYYY-MM.jsonl`) with signal-flip assertions — triage 43/0, monitor-deploy 28/0. The monitor-deploy mirror is now asserted via a hermetic `linear-comment-post` stub (`CATALYST_COMMENT_POST_HELPER`) — the old `linearis discuss` assertion had been stale since CTL-550 moved posting to the app-actor API (also failing on `main`).

## Verification

- Adversarial review workflow over the diff (4 lenses → refutation verify, 14 agents): 10 findings raised, 8 refuted, 2 confirmed — both the same missing generation fence, fixed in this PR with tests.
- bash+zsh parse checks on both SKILL bodies; CTL-602 bare-positional guard clean.

## Note for reviewers

While verifying, a local `make test` run **deleted this (dirty) worktree mid-suite** — the late-alphabet shell suites all failed because the tree vanished under them (prime suspect: an orphan-sweep-style suite operating on the real `~/catalyst/wt`). The work was reconstructed and committed. Filed as a follow-up to investigate — flagging here so nobody else loses uncommitted work to a full-suite run from a catalyst worktree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)