### PR TITLE
fix(dev): catalyst-cloud#127 — bump @catalyst-cloud/sdk → ^0.4.0 (forward-compat filter + auto-reseed backfill)

### DIFF
--- a/plugins/dev/scripts/execution-core/bun.lock
+++ b/plugins/dev/scripts/execution-core/bun.lock
@@ -6,7 +6,7 @@
       "name": "catalyst-execution-core",
       "dependencies": {
         "@catalyst-cloud/read-model": "^0.1.0",
-        "@catalyst-cloud/sdk": "^0.3.1",
+        "@catalyst-cloud/sdk": "^0.4.0",
         "@opentelemetry/api": "^1.9.1",
         "@opentelemetry/exporter-trace-otlp-http": "^0.219.0",
         "@opentelemetry/resources": "^2.8.0",
@@ -47,11 +47,11 @@
 
     "@catalyst-cloud/read-model": ["@catalyst-cloud/read-model@0.1.0", "", {}, "sha512-TODVDFkY5moO0qnWnb/G6+7AI/X9Bl2Zp/2+ymBQDraf1aAjmXloem3qj/FPURjfakx1aDEVEFULO+PpKnC6JQ=="],
 
-    "@catalyst-cloud/replicate": ["@catalyst-cloud/replicate@0.1.1", "", { "dependencies": { "@catalyst-cloud/schema": "^0.1.0" } }, "sha512-OPA1LZNdcqky+UgBwJjx7B0zlz8k73WrReZ72NRA89ichYvMHl9TZUa17tUztN2gHYMd0fA95z4Wnye3YZNnTQ=="],
+    "@catalyst-cloud/replicate": ["@catalyst-cloud/replicate@0.1.3", "", { "dependencies": { "@catalyst-cloud/schema": "^0.1.3" } }, "sha512-7LyYJTG5fkjq9RA8OaCpCzP2b/gjPOYJJmCxRce++TPsIviQULpTiaffL7MuBfwGODf2dwGrO0ozeW7n8slTTQ=="],
 
-    "@catalyst-cloud/schema": ["@catalyst-cloud/schema@0.1.1", "", { "dependencies": { "drizzle-orm": "0.44.7" } }, "sha512-IOLGOSJyhYkjjZLs/r+Gp6P+hSMOqGzYStnXgdjxeQ0M/I0EGd7wtEB4EJHVyOJo5+A6XJ45ELcptWARjmeyww=="],
+    "@catalyst-cloud/schema": ["@catalyst-cloud/schema@0.1.3", "", { "dependencies": { "drizzle-orm": "0.44.7" } }, "sha512-qZGbGvJuvputQlX2TCH5IYAGGVJjunh7tZc9tsp4YxoE82Bj34F+zjqgtCuMTAc6yzR7rNJv90ZjZBLDNoKYwg=="],
 
-    "@catalyst-cloud/sdk": ["@catalyst-cloud/sdk@0.3.1", "", { "dependencies": { "@catalyst-cloud/read-model": "^0.1.0", "@catalyst-cloud/replicate": "^0.1.0", "@catalyst-cloud/schema": "^0.1.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.3.0 <2", "@sqlite.org/sqlite-wasm": "*", "better-sqlite3": "*" }, "optionalPeers": ["@opentelemetry/api", "@sqlite.org/sqlite-wasm", "better-sqlite3"] }, "sha512-fbnZYLywR1NH+zgIXOEQDuYCwqjNzRbS22FfzVumpdvUS/0YuXpy+8VtJLc/dcYeBOxcElVEG0jEwbx8UQQVGQ=="],
+    "@catalyst-cloud/sdk": ["@catalyst-cloud/sdk@0.4.0", "", { "dependencies": { "@catalyst-cloud/read-model": "^0.1.0", "@catalyst-cloud/replicate": "^0.1.3", "@catalyst-cloud/schema": "^0.1.3" }, "peerDependencies": { "@opentelemetry/api": ">=1.3.0 <2", "@sqlite.org/sqlite-wasm": "*", "better-sqlite3": "*" }, "optionalPeers": ["@opentelemetry/api", "@sqlite.org/sqlite-wasm", "better-sqlite3"] }, "sha512-jRqjHH9KJ7/BBOpGxMRwj+aLyrVqOr1CFOU5/q+eUEL5VPt3iFz+YKfY6GNgOd81g0G0Q+DAQ0+tH4cRl/Htfw=="],
 
     "@hono/node-server": ["@hono/node-server@1.19.14", "", { "peerDependencies": { "hono": "^4" } }, "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw=="],
 

--- a/plugins/dev/scripts/execution-core/cloud-sync.mjs
+++ b/plugins/dev/scripts/execution-core/cloud-sync.mjs
@@ -10,13 +10,22 @@
 // serve Linear reads from this local DB instead of the rate-limited `linearis` —
 // the unblock for nodes drowning in 429s.
 //
-// ENGINE: @catalyst-cloud/sdk@0.3.1 `CatalystReplica` — `start()` opens + migrates +
+// ENGINE: @catalyst-cloud/sdk@0.4.0 `CatalystReplica` — `start()` opens + migrates +
 // stream-seeds (/snapshot) + live-applies, resolving on the FIRST 'live' (seed
 // complete); background sync then runs until close(). The SDK owns reconnect/backoff
 // and a single-writer lock (<dbPath>.writer.lock, pid+heartbeat) — so a second
 // concurrent writer throws loudly rather than corrupting the file.
 //
-// APPLY-RESULT TELEMETRY (CTL-1402): 0.3.1's `applyFrame` records ONE outcome per live
+// #127 SCHEMA-SKEW FIX (0.4.0 + schema@0.1.3 + replicate@0.1.3): a mirror AHEAD of the
+// client's bundled schema no longer errno:1s. (1) the apply path DROPS a column the local
+// schema lacks instead of throwing (forward-compat by construction — additive mirror
+// column-adds can't recur this failure); (2) when a column-ADDING migration runs on boot,
+// start() forces ONE `/snapshot` re-seed to BACKFILL rows written before the column existed
+// (so already-stale rows — the CTL-1397 Backlog-vs-Done casualty — self-heal); (3) a
+// warn-once "mirror is ahead: dropping unknown column(s)" drift log. Expect a one-time
+// snapshot re-pull per node on the first boot after this bump — normal, not a stall.
+//
+// APPLY-RESULT TELEMETRY (CTL-1402): `applyFrame` records ONE outcome per live
 // frame via a structured `catalyst.replica.apply` LOG line through our `log` callback below
 // — `{result: applied|skipped|failed, seq, entity, source, err_message?}`. This REPLACES the
 // old string-interpolated "apply failed for … seq=" line (no in-repo bridge, no double-emit),

--- a/plugins/dev/scripts/execution-core/package.json
+++ b/plugins/dev/scripts/execution-core/package.json
@@ -7,7 +7,7 @@
   },
   "dependencies": {
     "@catalyst-cloud/read-model": "^0.1.0",
-    "@catalyst-cloud/sdk": "^0.3.1",
+    "@catalyst-cloud/sdk": "^0.4.0",
     "@opentelemetry/api": "^1.9.1",
     "@opentelemetry/exporter-trace-otlp-http": "^0.219.0",
     "@opentelemetry/resources": "^2.8.0",


### PR DESCRIPTION
## What & why

Completes the **node side** of the `catalyst-cloud#127` schema-skew fix. CTC shipped the SDK side (comms #84); this bumps cloud-sync to consume it.

**Root cause** (pinned by CTL-1402's telemetry on day one): the live mirror began emitting migration-0008 columns (`state_id`/`team_key`/`team_name`, CTC-148) while the client's bundled `@catalyst-cloud/schema` was at 0007 → `applyUpsert` INSERTed a column the node replica lacked → `SQLITE_ERROR errno:1` → the row went stale. The failed-apply line surfaced it exactly: `err_message: "table issues has no column named state_id"` (seq 344719, fleet-wide).

## The fix — `sdk@0.4.0` (pulls `schema@0.1.3` + `replicate@0.1.3`)
1. **Forward-compat filter** (`replicate@0.1.3`): the apply path **drops** a column the local schema lacks instead of throwing — additive mirror column-adds are now non-breaking by construction; this class of errno:1 can't recur.
2. **Auto re-seed** (`sdk@0.4.0`): on first boot after the bump, `applyMigrations` adds 0008's columns, the SDK detects the row-shape change and forces **one `/snapshot` re-pull → backfills** rows written before the column existed (the already-stale set self-heals). One-time snapshot re-pull per node on first boot — normal, not a stall.
3. **Warn-once** `"mirror is ahead: dropping unknown column(s)"` drift log.

`telemetry:true` + the CTL-1402 pino routing (`cloud-sync-log.mjs:sdkLogRecord`) are **unchanged** and carry forward.

## Verification
- sdk@0.4.0 constructor accepts `telemetry:true` + all existing options (construct smoke test); `/node` import + `.cursor`/`.close()` intact.
- Auto-reseed + structured `catalyst.replica.apply` emit confirmed present in the 0.4.0 dist.
- cloud-sync import graph resolves; 214 execution-core tests pass.
- **Post-deploy** (per host `bun install` + restart): expect one snapshot re-pull, then `catalyst.replica.apply{result:failed}` for `issues` → ~0 and CTL-1397's replica row flips `Backlog→Done` (backfill). I'll verify on both minis after merge.

Closes `catalyst-cloud#127`; completes the CTL-1402 deploy story.

🤖 Generated with [Claude Code](https://claude.com/claude-code)