### PR TITLE
feat(dev): CTL-1410 (Phase B) — unified in-process SDK worker registry + liveness re-points

### DIFF
--- a/.github/workflows/execution-core-tests.yml
+++ b/.github/workflows/execution-core-tests.yml
@@ -278,6 +278,7 @@ jobs:
             scheduler-replica-freshness.test.mjs \
             sdk-run-phase-agent.test.mjs \
             sdk-slot-gate.test.mjs \
+            sdk-worker-registry.test.mjs \
             sequencing.test.mjs \
             session-recency.test.mjs \
             signal-reader.test.mjs \

--- a/plugins/dev/scripts/execution-core/daemon.mjs
+++ b/plugins/dev/scripts/execution-core/daemon.mjs
@@ -137,6 +137,7 @@ import { classifyTicketResolution } from "./linear-query.mjs";
 import { createGatewayReader } from "./gateway-read.mjs";
 import { createReplicaReader } from "./replica-read.mjs"; // CTL-1340: read-replica tier reader
 import { isBgJobAlive, refreshAgents, listClaudeAgentsResult } from "./claude-agents.mjs"; // CTL-1165 D3: fail-closed liveness reader for job-dir GC
+import { reconcileSdkRegistryOnBoot } from "./sdk-worker-registry.mjs"; // CTL-1410 Phase B
 
 const DEFAULT_MAX_PARALLEL = 3;
 
@@ -626,6 +627,17 @@ export function startDaemon({
       log,
     });
     const executor = bootExec.executor;
+    // CTL-1410 Phase B: reap stale SDK-worker disk projections. No in-process
+    // worker survives a daemon restart, so any projection whose pid is dead is
+    // a leftover of the previous daemon; delete it BEFORE boot-resume and the
+    // scheduler run, so no liveness consumer trusts a ghost projection.
+    const sdkRegistryBoot = reconcileSdkRegistryOnBoot(orchDir);
+    if (sdkRegistryBoot.removed.length > 0) {
+      log.info(
+        { removed: sdkRegistryBoot.removed, kept: sdkRegistryBoot.kept },
+        "boot: reaped stale sdk-worker projections (CTL-1410)"
+      );
+    }
     // CTL-1396 (Codex P2): under executor=sdk, inject the unified-event-log appender
     // into the dispatch path so sdkRunPhaseAgent's telemetry (execution-core.sdk.phase-turns
     // — the turn-cap calibration signal — plus .overloaded/.auth.misconfigured) lands in

--- a/plugins/dev/scripts/execution-core/delegate-queue.mjs
+++ b/plugins/dev/scripts/execution-core/delegate-queue.mjs
@@ -30,6 +30,7 @@ import {
 } from "node:fs";
 import { join } from "node:path";
 import { log } from "./config.mjs";
+import { isSdkWorkerLive as registrySdkWorkerLive } from "./sdk-worker-registry.mjs";
 
 // The queue dir name, derived from orchDir exactly like recovery-reasoning.mjs
 // derives `.recovery-intents/` (recoveryIntentPath: join(orchDir, ".recovery-intents", …)).
@@ -91,24 +92,30 @@ function resolveMaxParallel(src) {
 //
 // A live recovery-pass worker for the anchor already exists when
 // workers/<TICKET>/phase-recovery-pass.json is dispatched|running AND its
-// bg_job_id is alive per the injected isBgJobAlive. Reads the signal file
-// directly (the same shape phase-agent-dispatch writes: {status, bg_job_id}).
-//
-// CTL-1157 (GROUP-3 #2): under executor=sdk the recovery-pass worker runs
-// IN-PROCESS (Agent SDK query()) and its prelaunch signal NEVER carries a
-// bg_job_id (dispatch.mjs E3 / signal-reader.countSdkInflight). A dispatched|running
-// sdk signal with no bg_job_id is a LIVE worker, not a dead one — so a bare
-// no-bg_job_id ⇒ not-live rule (correct for bg) would let a SECOND board-health
-// scan re-enqueue and double-dispatch the same in-flight sdk ticket. When the
-// caller is sdk-aware (executor==="sdk"), treat that shape as LIVE. Under bg the
-// discriminator is absent → behavior is byte-identical.
-function recoveryPassWorkerLive(orchDir, ticket, isBgJobAlive, executor) {
+// worker is alive. Three probes, most-precise first:
+//   bg worker (bg_job_id set)  → isBgJobAlive(bgJobId).
+//   sdk worker (bg_job_id null) → the in-process registry probe (CTL-1410
+//     Phase B — the exact same-process liveness fact), FALLING BACK to the
+//     CTL-1157 GROUP-3 #2 coarse rule: under executor==="sdk" any
+//     dispatched|running no-bg-id signal is presumed LIVE (fail-closed against
+//     double-dispatch for callers where the registry is blind — e.g. a
+//     worker registered before a daemon restart, or an out-of-process caller).
+// Reads the signal file directly (the same shape phase-agent-dispatch writes:
+// {status, bg_job_id}).
+function recoveryPassWorkerLive(orchDir, ticket, isBgJobAlive, isSdkWorkerLive, executor) {
   const signalPath = join(orchDir, "workers", ticket, "phase-recovery-pass.json");
   const sig = readIntentFile(signalPath);
   if (!sig) return false;
   if (sig.status !== "dispatched" && sig.status !== "running") return false;
   const bgJobId = sig.bg_job_id ?? null;
-  if (!bgJobId) return executor === "sdk"; // sdk in-process worker: live with no bg id
+  if (!bgJobId) {
+    try {
+      if (isSdkWorkerLive(ticket) === true) return true; // precise in-process fact
+    } catch {
+      /* fall through to the coarse rule */
+    }
+    return executor === "sdk"; // CTL-1157 fail-closed fallback (registry-blind callers)
+  }
   try {
     return isBgJobAlive(bgJobId) === true;
   } catch {
@@ -124,7 +131,7 @@ function recoveryPassWorkerLive(orchDir, ticket, isBgJobAlive, executor) {
 //   2. a live recovery-pass worker for the anchor already exists           → worker-live
 //   3. hard ceiling: countQueuedDelegates >= maxParallel                   → queue-full
 //
-// deps: { orchDir, isBgJobAlive, now, maxParallel }.
+// deps: { orchDir, isBgJobAlive, isSdkWorkerLive, executor, now, maxParallel }.
 export function enqueueDelegateIntent(anchor, payload = {}, deps = {}) {
   const orchDir = deps.orchDir;
   if (!orchDir) return { enqueued: false, reason: "no-orch-dir" };
@@ -133,10 +140,13 @@ export function enqueueDelegateIntent(anchor, payload = {}, deps = {}) {
   const now = deps.now ?? (() => Date.now());
   const isBgJobAlive = deps.isBgJobAlive ?? (() => false);
   // CTL-1157 (GROUP-3 #2): the resolved executor ("sdk" | else). Threaded from the
-  // scheduler (dispatchMode==="sdk"). Makes the live-worker probe sdk-aware so a
-  // dispatched|running sdk signal with no bg_job_id dedups a second enqueue instead
-  // of double-dispatching. Absent/"bg" → byte-identical to today.
+  // scheduler (dispatchMode==="sdk"). The coarse sdk-aware fallback for the
+  // live-worker probe. Absent/"bg" → byte-identical to pre-CTL-1157.
   const executor = deps.executor ?? null;
+  // CTL-1410 Phase B: the precise probe — default = the real in-process
+  // registry (enqueue runs inside the daemon process, the same one that
+  // registered the worker).
+  const isSdkWorkerLive = deps.isSdkWorkerLive ?? registrySdkWorkerLive;
 
   // (1) queue-file existence — one non-terminal intent per anchor.
   const existing = readIntentFile(intentPath(orchDir, anchor));
@@ -145,7 +155,7 @@ export function enqueueDelegateIntent(anchor, payload = {}, deps = {}) {
   }
 
   // (2) live recovery-pass worker — never even queue a redundant run.
-  if (recoveryPassWorkerLive(orchDir, anchor, isBgJobAlive, executor)) {
+  if (recoveryPassWorkerLive(orchDir, anchor, isBgJobAlive, isSdkWorkerLive, executor)) {
     return { enqueued: false, reason: "worker-live" };
   }
 

--- a/plugins/dev/scripts/execution-core/delegate-queue.test.mjs
+++ b/plugins/dev/scripts/execution-core/delegate-queue.test.mjs
@@ -298,8 +298,8 @@ describe("enqueueDelegateIntent — live-worker idempotency", () => {
   });
 
   // CTL-1157 (GROUP-3 #2): under executor=sdk the recovery-pass worker runs in-process
-  // with NO bg_job_id. That dispatched|running signal is a LIVE worker — a second scan
-  // must dedup it (worker-live) instead of double-dispatching.
+  // with NO bg_job_id. That dispatched|running signal is presumed LIVE (coarse
+  // fail-closed fallback) — a second scan must dedup it instead of double-dispatching.
   test("sdk: a dispatched recovery-pass worker with NO bg_job_id blocks enqueue when executor==='sdk'", () => {
     seedRecoveryPassSignal("CTL-1", "dispatched", null); // sdk shape: no bg id
     const r = enqueueDelegateIntent(
@@ -317,6 +317,31 @@ describe("enqueueDelegateIntent — live-worker idempotency", () => {
       "CTL-1",
       INTENT,
       deps({ isBgJobAlive: () => false }) // no executor → bg semantics
+    );
+    expect(r.enqueued).toBe(true);
+  });
+
+  // CTL-1410 Phase B: the PRECISE probe — an in-process SDK worker has
+  // bg_job_id null, so the bg probe can never see it; the registry closes that
+  // fail-open regardless of the executor value.
+  test("a running SDK worker (bg_job_id null, live in the registry) no-ops with worker-live", () => {
+    seedRecoveryPassSignal("CTL-1", "running", null);
+    const r = enqueueDelegateIntent(
+      "CTL-1",
+      INTENT,
+      deps({ isSdkWorkerLive: (ticket) => ticket === "CTL-1" })
+    );
+    expect(r.enqueued).toBe(false);
+    expect(r.reason).toBe("worker-live");
+    expect(existsSync(intentPath("CTL-1"))).toBe(false);
+  });
+
+  test("a running signal with bg_job_id null, NO registry entry, and no executor rule still enqueues (dead worker)", () => {
+    seedRecoveryPassSignal("CTL-1", "running", null);
+    const r = enqueueDelegateIntent(
+      "CTL-1",
+      INTENT,
+      deps({ isSdkWorkerLive: () => false })
     );
     expect(r.enqueued).toBe(true);
   });

--- a/plugins/dev/scripts/execution-core/scheduler.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.mjs
@@ -83,6 +83,9 @@ import { getProjectConfig, listProjects, ownerRepoFromRepoRoot } from "./registr
 // re-implements the gate in bash (merge-confirmation evidence + worktree
 // presweep + non-force `git worktree remove`) in phase-teardown/SKILL.md.
 import { readWorkerSignals, countSdkInflight as defaultCountSdkInflight, hasFreshClaim } from "./signal-reader.mjs";
+// CTL-1410 Phase B: the in-process SDK worker registry — the liveness fact for
+// workers with no bg job (leaf module; a Map read, never a shell-out).
+import { isSdkWorkerLive as registrySdkWorkerLive } from "./sdk-worker-registry.mjs";
 // CTL-933: shadow belief-store fact collector (opt-in CATALYST_BELIEFS_SHADOW=1).
 // CTL-937: getBeliefsDb exposes the module-level db handle for the diagnostician.
 // CTL-1241: getEscalateHumanBelief reads the latest escalate_human belief for the
@@ -3106,6 +3109,11 @@ export function schedulerTick(
     // production; sweep-specific tests inject their own stubs.
     classifyResolution = () => "unknown",
     isBgJobAlive = () => true,
+    // CTL-1410 Phase B: in-process SDK-worker probe for the sweep. The REAL
+    // registry read is the safe default here — it is a local Map lookup in this
+    // same process (never shells out), and an empty registry (bare unit tick)
+    // protects nothing, which is exactly the pre-Phase-B behavior.
+    isSdkWorkerLive = registrySdkWorkerLive,
     // CTL-823: the daemon's durable-descriptor-store reader; threaded into the
     // fetchState injections below. undefined in bare unit ticks (fail-open —
     // fetchTicketState without gateway behaves exactly as before).
@@ -3601,6 +3609,11 @@ export function schedulerTick(
     // (no snapshot fetch, no async `claude agents` warmer kick). The skip decision (incl. the
     // cold-cache fail-open) lives in the pure, unit-tested bgLivenessProtects helper.
     if (bgId && bgLivenessProtects(bgId, getAgents(), isBgJobAlive)) continue;
+    // (c-sdk) CTL-1410 Phase B: an in-process SDK worker has NO bg id, so the bg
+    // gate above is blind to it — consult the in-process registry before probing
+    // Linear. A live registry entry is a fact (same process as the dispatch), so
+    // this can never mis-protect a phantom: phantoms are never registered.
+    if (isSdkWorkerLive(sig.ticket)) continue;
     if (classifyResolution(sig.ticket, { exec }) !== "not-found") continue; // (b) definitive only
     if (maybeQuarantinePhantom(orchDir, sig.ticket, sig.phase)) {
       quarantinedPhantoms.push({ ticket: sig.ticket, phase: sig.phase });

--- a/plugins/dev/scripts/execution-core/scheduler.test.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.test.mjs
@@ -1324,6 +1324,26 @@ describe("phantom worker-dir validity sweep (CTL-671)", () => {
     expect(sig.stalledReason).toBe("phantom-ticket");
   });
 
+  test("does NOT quarantine a live in-process SDK worker (CTL-1410 Phase B)", () => {
+    // An SDK worker has NO bg id (liveness.value null), so the bg gate can't
+    // protect it — only the in-process registry probe can. not-found +
+    // not-eligible would otherwise quarantine it.
+    writeSignal("CTL-9", "implement", "running");
+    const r = schedulerTick(orchDir, {
+      readEligible: () => [],
+      dispatch: () => ({ code: 0 }),
+      liveBackgroundCount: () => 0,
+      classifyResolution: resolveTo("not-found"),
+      isBgJobAlive: () => false,
+      isSdkWorkerLive: (ticket) => ticket === "CTL-9",
+    });
+    const sig = JSON.parse(
+      readFileSync(join(orchDir, "workers", "CTL-9", "phase-implement.json"), "utf8")
+    );
+    expect(sig.status).toBe("running"); // untouched
+    expect(r.quarantinedPhantoms ?? []).toEqual([]);
+  });
+
   test("does NOT quarantine when Linear resolution is unknown (outage safety)", () => {
     writeSignal("CTL-100", "implement", "running");
     schedulerTick(orchDir, {

--- a/plugins/dev/scripts/execution-core/sdk-run-phase-agent.mjs
+++ b/plugins/dev/scripts/execution-core/sdk-run-phase-agent.mjs
@@ -67,6 +67,7 @@ import { fileURLToPath } from "node:url";
 import { getEventLogPath } from "./config.mjs";
 import { buildCatalystResource } from "./lib/catalyst-resource.mjs";
 import { nodeClass } from "./lib/node-class.mjs";
+import { registerSdkWorker as defaultRegisterSdkWorker } from "./sdk-worker-registry.mjs";
 
 // phase-agent-dispatch + phase-agent-emit-complete sit one directory up.
 const PHASE_AGENT_DISPATCH_BIN = fileURLToPath(
@@ -945,6 +946,7 @@ export async function sdkRunPhaseAgent(
     random = Math.random,
     maxRetries = 5, // bound the 429/529 backoff
     backoff = {}, // { baseMs, capMs } overrides for tests
+    registerWorker = defaultRegisterSdkWorker, // CTL-1410 Phase B: the in-process worker registry
   } = {},
 ) {
   // ── AUTH GUARD: refuse BEFORE any side effect (no claim, no signal) ───────
@@ -1005,6 +1007,20 @@ export async function sdkRunPhaseAgent(
   const env = buildSdkEnv(spec.env, { base: authEnv, oauthToken, settingsEnv: spec.settings?.env });
   const options = buildQueryOptions(spec, env, { turnCap });
 
+  // CTL-1410 Phase B: register in the in-process worker registry — the SDK-native
+  // liveness fact (bg_job_id is null, so every bg-keyed probe is blind to this
+  // worker). Registered BEFORE sem.acquire on purpose: a parked waiter already
+  // owns its claim + "dispatched" signal, so the phantom-sweep / worktree-refresh
+  // consumers must see it as live while it queues. The three early-returns above
+  // never register (no claim, or another worker owns the phase).
+  const reg = registerWorker({
+    ticket,
+    phase,
+    worktreePath: spec.worktreePath ?? worktreePath,
+    generation: spec.generation,
+    orchDir,
+  });
+
   // ── LAUNCH VERB: the in-process query() loop, under the concurrency cap ───
   //
   // CTL-1367 item 16 (semaphore scope — DOCUMENTED DECISION): the cap wraps ONLY
@@ -1022,11 +1038,15 @@ export async function sdkRunPhaseAgent(
     let lastOverload = null;
     for (let i = 0; i <= maxRetries; i++) {
       const ac = new AbortController();
+      // Phase B: expose the per-attempt controller so cancel/abort (preemption,
+      // watchdog) can reach the live query; a pending abort fires immediately.
+      reg.setAbortController(ac);
       let result = null;
       let thrown = null;
       try {
         const q = runQuery({ prompt: spec.prompt, options: { ...options, abortController: ac } });
         for await (const m of q) {
+          reg.touch(); // registry heartbeat (internally throttled to disk)
           if (m?.type === "result") result = m; // exactly one terminal
         }
       } catch (err) {
@@ -1136,6 +1156,7 @@ export async function sdkRunPhaseAgent(
     // Unreachable (the loop always returns), but keep a defined shape.
     return { code: 1, stdout: "", stderr: "sdk: retry loop exhausted", signal: null };
   } finally {
+    reg.deregister(); // every post-registration exit path, including throws
     release();
   }
 }

--- a/plugins/dev/scripts/execution-core/sdk-run-phase-agent.test.mjs
+++ b/plugins/dev/scripts/execution-core/sdk-run-phase-agent.test.mjs
@@ -1592,3 +1592,157 @@ describe("sdkRunPhaseAgent — overload shape table", () => {
     }
   });
 });
+
+// ── CTL-1410 Phase B: in-process worker-registry wiring ───────────────────────
+// The registry is the SDK-native liveness source of truth (sdk-worker-registry.mjs).
+// The runner must register exactly once per real launch (after the spec resolves,
+// before the query loop), swap the abort controller per retry, heartbeat on
+// streamed messages, and deregister on EVERY exit path — while the three
+// pre-launch early-returns never register at all.
+
+describe("sdkRunPhaseAgent — CTL-1410 Phase B (worker registry wiring)", () => {
+  const fakeRegistry = () => {
+    const state = { registered: [], handles: [] };
+    const registerWorker = (entry) => {
+      state.registered.push(entry);
+      const h = {
+        controllers: [],
+        touches: 0,
+        deregistered: 0,
+        setAbortController(ac) {
+          h.controllers.push(ac);
+        },
+        touch() {
+          h.touches += 1;
+        },
+        deregister() {
+          h.deregistered += 1;
+        },
+      };
+      state.handles.push(h);
+      return h;
+    };
+    return { registerWorker, state };
+  };
+
+  test("registers after spec resolve, before the query; wires the AC; touches per message; deregisters on success", async () => {
+    const { spawn } = spawnReturningSpec();
+    const { registerWorker, state } = fakeRegistry();
+    let registeredAtQuery = -1;
+    const sink = {};
+    const runQuery = ({ prompt, options }) => {
+      registeredAtQuery = state.registered.length;
+      sink.options = options;
+      return (async function* () {
+        yield { type: "assistant", message: {} };
+        yield resultMsg();
+      })();
+    };
+    const r = await sdkRunPhaseAgent(ARGS, { ...GOOD_AUTH, spawn, runQuery, registerWorker });
+    expect(r.code).toBe(0);
+    expect(state.registered).toHaveLength(1);
+    expect(registeredAtQuery).toBe(1); // registered BEFORE the query launched
+    expect(state.registered[0]).toMatchObject({
+      ticket: "CTL-100",
+      phase: "implement",
+      worktreePath: "/wt/CTL-100",
+      generation: 1,
+      orchDir: "/ec",
+    });
+    const h = state.handles[0];
+    expect(h.controllers).toHaveLength(1);
+    expect(h.controllers[0]).toBe(sink.options.abortController); // the SAME ac query() got
+    expect(h.touches).toBe(2); // one per streamed message
+    expect(h.deregistered).toBe(1);
+  });
+
+  test("deregisters when the query throws (generic sdk-threw path)", async () => {
+    const { spawn } = spawnReturningSpec();
+    const { registerWorker, state } = fakeRegistry();
+    const runQuery = () =>
+      (async function* () {
+        throw new Error("boom");
+      })();
+    const r = await sdkRunPhaseAgent(ARGS, {
+      ...GOOD_AUTH, spawn, runQuery, registerWorker,
+      emitBackstop: () => {},
+    });
+    expect(r.code).toBe(1);
+    expect(state.handles[0].deregistered).toBe(1);
+  });
+
+  test("deregisters when the overload backoff exhausts", async () => {
+    const { spawn } = spawnReturningSpec();
+    const { registerWorker, state } = fakeRegistry();
+    const runQuery = () =>
+      (async function* () {
+        yield resultMsg({ subtype: "error", is_error: true, api_error_status: 529 });
+      })();
+    const r = await sdkRunPhaseAgent(ARGS, {
+      ...GOOD_AUTH, spawn, runQuery, registerWorker,
+      sleep: () => Promise.resolve(),
+      backoff: { baseMs: 1, capMs: 2 },
+      maxRetries: 1,
+      emitEvent: () => {},
+      emitBackstop: () => {},
+    });
+    expect(r.code).toBe(1);
+    expect(state.registered).toHaveLength(1); // register once, NOT per retry
+    expect(state.handles[0].deregistered).toBe(1);
+  });
+
+  test("swaps the abort controller on every retry (distinct AC per attempt)", async () => {
+    const { spawn } = spawnReturningSpec();
+    const { registerWorker, state } = fakeRegistry();
+    let attempt = 0;
+    const runQuery = () =>
+      (async function* () {
+        attempt += 1;
+        if (attempt === 1) {
+          yield resultMsg({ subtype: "error", is_error: true, api_error_status: 429 });
+        } else {
+          yield resultMsg();
+        }
+      })();
+    const r = await sdkRunPhaseAgent(ARGS, {
+      ...GOOD_AUTH, spawn, runQuery, registerWorker,
+      sleep: () => Promise.resolve(),
+      backoff: { baseMs: 1, capMs: 2 },
+      emitEvent: () => {},
+    });
+    expect(r.code).toBe(0);
+    const h = state.handles[0];
+    expect(h.controllers).toHaveLength(2);
+    expect(h.controllers[0]).not.toBe(h.controllers[1]);
+    expect(h.deregistered).toBe(1);
+  });
+
+  test("auth-guard early return never registers", async () => {
+    const { registerWorker, state } = fakeRegistry();
+    const r = await sdkRunPhaseAgent(ARGS, {
+      env: { ANTHROPIC_API_KEY: "sk", CLAUDE_CODE_OAUTH_TOKEN: "t" },
+      oauthToken: "t",
+      registerWorker,
+      emitEvent: () => {},
+    });
+    expect(r.code).toBe(1);
+    expect(state.registered).toHaveLength(0);
+  });
+
+  test("idempotent prelaunch never registers", async () => {
+    const spec = makeSpec({ status: "claim-lost", idempotent: true });
+    const { spawn } = spawnReturningSpec({ spec });
+    const { registerWorker, state } = fakeRegistry();
+    const r = await sdkRunPhaseAgent(ARGS, { ...GOOD_AUTH, spawn, registerWorker });
+    expect(r.code).toBe(0);
+    expect(state.registered).toHaveLength(0);
+  });
+
+  test("failed prelaunch never registers", async () => {
+    const { spawn } = spawnReturningSpec({ code: 1 });
+    const { registerWorker, state } = fakeRegistry();
+    const r = await sdkRunPhaseAgent(ARGS, { ...GOOD_AUTH, spawn, registerWorker });
+    expect(r.code).toBe(1);
+    expect(state.registered).toHaveLength(0);
+  });
+});

--- a/plugins/dev/scripts/execution-core/sdk-worker-registry.mjs
+++ b/plugins/dev/scripts/execution-core/sdk-worker-registry.mjs
@@ -1,0 +1,313 @@
+// sdk-worker-registry.mjs — CTL-1410 Phase B: the ONE authoritative in-process
+// registry of live SDK phase workers. An in-process worker has bg_job_id null,
+// so every bg-keyed liveness probe (isBgJobAlive, jobLifecycle, `claude agents`)
+// is blind to it; this registry is the SDK-native answer that the watchdog
+// (Phase C), preemption cancel (Phase D), and reclaim/boot-resume (Phases E/F)
+// all consume. LEAF MODULE: node:fs/node:path only — importers must never be
+// imported back from here, or the split-brain this consolidates returns as an
+// import cycle.
+//
+// Liveness is process-local by design: the daemon's `settleDispatchSync`
+// detaches the query promise onto the SAME event loop, so a Map here IS the
+// ground truth for this daemon. The disk projection (<orchDir>/.sdk-workers/)
+// exists only for OTHER processes (delegate-runner child, doctor) and for boot
+// reconcile — pid-alive is its primary check, freshness the secondary.
+
+import { mkdirSync, readdirSync, readFileSync, renameSync, rmSync, unlinkSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+// A worker whose projection hasn't been touched in this long is presumed dead
+// even if a same-numbered pid exists (pid reuse). In-memory entries never
+// expire — the daemon owns them for exactly as long as the query runs.
+export const SDK_WORKER_FRESH_MS = 30 * 60 * 1000;
+
+// Sentinel abort reason for CTL-705 preemption: the runner must resolve a
+// preempted query cleanly (no phase.*.failed, no signal clobber), so it needs
+// to distinguish "the scheduler preempted me" from a genuine failure abort.
+export const PREEMPTION_ABORT_REASON = "catalyst-sdk-preempted";
+
+export function isPreemptionAbort(reasonOrError) {
+  if (reasonOrError == null) return false;
+  const msg = typeof reasonOrError === "string" ? reasonOrError : String(reasonOrError?.message ?? "");
+  return msg === PREEMPTION_ABORT_REASON;
+}
+
+// Throttle for projection rewrites from touch(): streamed SDK messages can
+// arrive many times a second; the projection only needs coarse freshness.
+const PROJECTION_TOUCH_THROTTLE_MS = 30_000;
+
+const PROJECTION_DIR = ".sdk-workers";
+
+/** @type {Map<string, object>} ticket → live entry */
+const _live = new Map();
+/** @type {Map<string, string>} worktreePath → ticket (reverse index) */
+const _byWorktree = new Map();
+let _tokenSeq = 0;
+
+function projectionDir(orchDir) {
+  return join(orchDir, PROJECTION_DIR);
+}
+
+function projectionPath(orchDir, ticket) {
+  return join(projectionDir(orchDir), `${ticket}.json`);
+}
+
+// Every disk effect is best-effort: an unwritable orchDir must never take down
+// the dispatch path — the in-memory registry stays correct regardless.
+function writeProjection(entry) {
+  if (!entry.orchDir) return;
+  try {
+    mkdirSync(projectionDir(entry.orchDir), { recursive: true });
+    const file = projectionPath(entry.orchDir, entry.ticket);
+    const tmp = `${file}.tmp-${process.pid}`;
+    writeFileSync(
+      tmp,
+      JSON.stringify({
+        ticket: entry.ticket,
+        phase: entry.phase,
+        worktreePath: entry.worktreePath,
+        generation: entry.generation ?? null,
+        pid: entry.pid,
+        startedAt: entry.startedAt,
+        updatedAt: entry.updatedAt,
+      }),
+    );
+    renameSync(tmp, file);
+    entry.lastProjectionWriteAt = entry.updatedAt;
+  } catch {
+    /* best-effort */
+  }
+}
+
+function removeProjection(entry) {
+  if (!entry.orchDir) return;
+  try {
+    unlinkSync(projectionPath(entry.orchDir, entry.ticket));
+  } catch {
+    /* already gone / unwritable */
+  }
+}
+
+function removeEntry(entry) {
+  _live.delete(entry.ticket);
+  if (_byWorktree.get(entry.worktreePath) === entry.ticket) _byWorktree.delete(entry.worktreePath);
+  removeProjection(entry);
+}
+
+function publicView(entry) {
+  return {
+    ticket: entry.ticket,
+    phase: entry.phase,
+    worktreePath: entry.worktreePath,
+    generation: entry.generation,
+    startedAt: entry.startedAt,
+    updatedAt: entry.updatedAt,
+    pid: entry.pid,
+    orchDir: entry.orchDir,
+    aborted: entry.aborted,
+  };
+}
+
+// Same fence as flipSignalDoneOnSuccess / claim.mjs isCurrentGeneration: bow
+// out iff BOTH generations are plain ints AND the caller's is older. Anything
+// non-numeric fails open (the cancel proceeds).
+function isPlainInt(v) {
+  return (typeof v === "number" || typeof v === "string") && /^[0-9]+$/.test(String(v));
+}
+
+/**
+ * Register a live in-process SDK worker. Idempotent per ticket: a resume
+ * re-register replaces the entry in place (new token), so the superseded
+ * handle's deregister becomes a no-op (compare-and-delete).
+ *
+ * @param {{ticket:string, phase?:string, worktreePath?:string, generation?:number|string, orchDir?:string}} spec
+ * @param {{now?: () => number}} [opts] injectable clock
+ * @returns handle {setAbortController, touch, deregister, aborted}
+ */
+export function registerSdkWorker({ ticket, phase, worktreePath, generation, orchDir }, { now = Date.now } = {}) {
+  if (!ticket) throw new TypeError("registerSdkWorker: ticket is required");
+  const prev = _live.get(ticket);
+  if (prev && _byWorktree.get(prev.worktreePath) === ticket) _byWorktree.delete(prev.worktreePath);
+
+  const ts = now();
+  const entry = {
+    ticket,
+    phase,
+    worktreePath,
+    generation,
+    orchDir,
+    pid: process.pid,
+    startedAt: ts,
+    updatedAt: ts,
+    lastProjectionWriteAt: 0,
+    token: ++_tokenSeq,
+    abortController: null,
+    pendingAbortReason: null,
+    aborted: false,
+    now,
+  };
+  _live.set(ticket, entry);
+  if (worktreePath) _byWorktree.set(worktreePath, ticket);
+  writeProjection(entry);
+
+  return {
+    // A cancel/abort can land before the runner creates its per-retry
+    // controller — the pending reason fires the moment one is installed.
+    setAbortController(ac) {
+      entry.abortController = ac;
+      if (entry.pendingAbortReason != null && ac && !ac.signal.aborted) {
+        ac.abort(entry.pendingAbortReason);
+        entry.aborted = true;
+        entry.pendingAbortReason = null;
+      }
+    },
+    touch() {
+      entry.updatedAt = entry.now();
+      if (entry.updatedAt - entry.lastProjectionWriteAt >= PROJECTION_TOUCH_THROTTLE_MS) {
+        writeProjection(entry);
+      }
+    },
+    deregister() {
+      const current = _live.get(ticket);
+      if (current?.token !== entry.token) return; // superseded by a resume re-register
+      removeEntry(current);
+    },
+    get aborted() {
+      return entry.aborted;
+    },
+  };
+}
+
+/** Force-remove regardless of handle token (daemon-level cleanup). */
+export function deregisterSdkWorker(ticket) {
+  const entry = _live.get(ticket);
+  if (entry) removeEntry(entry);
+}
+
+export function isSdkWorkerLive(ticket) {
+  return _live.has(ticket);
+}
+
+export function sdkWorkerForTicket(ticket) {
+  const entry = _live.get(ticket);
+  return entry ? publicView(entry) : null;
+}
+
+export function sdkWorkerForWorktree(worktreePath) {
+  const ticket = _byWorktree.get(worktreePath);
+  return ticket ? sdkWorkerForTicket(ticket) : null;
+}
+
+export function countLiveSdkWorkers() {
+  return _live.size;
+}
+
+/**
+ * Abort a live worker's current query (watchdog / operator kill). If no
+ * controller is installed yet the abort is queued for setAbortController.
+ * @returns {{found: boolean, aborted: boolean}}
+ */
+export function abortSdkWorker(ticket, reason) {
+  const entry = _live.get(ticket);
+  if (!entry) return { found: false, aborted: false };
+  const ac = entry.abortController;
+  if (ac && !ac.signal.aborted) {
+    ac.abort(reason);
+    entry.aborted = true;
+    return { found: true, aborted: true };
+  }
+  if (!ac) {
+    entry.pendingAbortReason = reason;
+    return { found: true, aborted: false };
+  }
+  return { found: true, aborted: ac.signal.aborted };
+}
+
+/**
+ * Preemption cancel (CTL-705 re-point): aborts with the preemption sentinel so
+ * the runner resolves cleanly instead of emitting a failed backstop. The
+ * generation fence protects a NEWER dispatch from a stale scheduler decision:
+ * stale iff both generations are plain ints and the caller's is older.
+ * @returns {{found: boolean, stale: boolean, aborted: boolean}}
+ */
+export function cancelSdkRun({ ticket, generation, reason = PREEMPTION_ABORT_REASON } = {}) {
+  const entry = _live.get(ticket);
+  if (!entry) return { found: false, stale: false, aborted: false };
+  if (isPlainInt(generation) && isPlainInt(entry.generation) && Number(generation) < Number(entry.generation)) {
+    return { found: true, stale: true, aborted: false };
+  }
+  const res = abortSdkWorker(ticket, reason);
+  return { found: true, stale: false, aborted: res.aborted };
+}
+
+function defaultPidAlive(pid) {
+  if (!Number.isInteger(pid) || pid <= 0) return false;
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (err) {
+    return err?.code === "EPERM"; // alive but owned by another user
+  }
+}
+
+/**
+ * Cross-process liveness read from the disk projection (for the delegate-runner
+ * child and other non-daemon processes). pid-alive is primary; freshness is the
+ * pid-reuse guard. Missing/corrupt projection reads as not-live, never throws.
+ */
+export function isSdkWorkerLiveOnDisk(orchDir, ticket, { pidAlive = defaultPidAlive, now = Date.now, freshMs = SDK_WORKER_FRESH_MS } = {}) {
+  let proj;
+  try {
+    proj = JSON.parse(readFileSync(projectionPath(orchDir, ticket), "utf8"));
+  } catch {
+    return false;
+  }
+  if (!pidAlive(proj?.pid)) return false;
+  const updatedAt = Number(proj?.updatedAt);
+  if (!Number.isFinite(updatedAt)) return false;
+  return now() - updatedAt <= freshMs;
+}
+
+/**
+ * Boot reconcile: no in-process worker survives a daemon restart, so any
+ * projection whose pid is dead (or that is unreadable) is a leftover from the
+ * previous daemon and is deleted. Runs before any dispatch entry point.
+ * @returns {{removed: string[], kept: string[]}}
+ */
+export function reconcileSdkRegistryOnBoot(orchDir, { pidAlive = defaultPidAlive } = {}) {
+  const removed = [];
+  const kept = [];
+  let files;
+  try {
+    files = readdirSync(projectionDir(orchDir)).filter((f) => f.endsWith(".json"));
+  } catch {
+    return { removed, kept };
+  }
+  for (const f of files) {
+    const ticket = f.slice(0, -".json".length);
+    const file = join(projectionDir(orchDir), f);
+    let proj = null;
+    try {
+      proj = JSON.parse(readFileSync(file, "utf8"));
+    } catch {
+      /* corrupt → remove below */
+    }
+    if (proj && pidAlive(proj.pid)) {
+      kept.push(ticket);
+      continue;
+    }
+    try {
+      rmSync(file, { force: true });
+    } catch {
+      /* best-effort */
+    }
+    removed.push(ticket);
+  }
+  return { removed, kept };
+}
+
+/** Test seam: clear all in-memory state (projections are per-test tmp dirs). */
+export function resetSdkWorkerRegistry() {
+  _live.clear();
+  _byWorktree.clear();
+}

--- a/plugins/dev/scripts/execution-core/sdk-worker-registry.mjs
+++ b/plugins/dev/scripts/execution-core/sdk-worker-registry.mjs
@@ -142,7 +142,7 @@ export function registerSdkWorker({ ticket, phase, worktreePath, generation, orc
     lastProjectionWriteAt: 0,
     token: ++_tokenSeq,
     abortController: null,
-    pendingAbortReason: null,
+    abortReason: null,
     aborted: false,
     now,
   };
@@ -151,17 +151,23 @@ export function registerSdkWorker({ ticket, phase, worktreePath, generation, orc
   writeProjection(entry);
 
   return {
-    // A cancel/abort can land before the runner creates its per-retry
-    // controller — the pending reason fires the moment one is installed.
+    // Abort is STICKY on the registration, not on one controller: an abort can
+    // land before any controller is installed, or between retry attempts while
+    // the stored controller is a previous attempt's already-settled one (the
+    // 429/529 backoff window). Every future controller of an aborted
+    // registration is aborted on install, so a cancelled worker can never
+    // resurrect on its next retry (Phase B review catch).
     setAbortController(ac) {
       entry.abortController = ac;
-      if (entry.pendingAbortReason != null && ac && !ac.signal.aborted) {
-        ac.abort(entry.pendingAbortReason);
-        entry.aborted = true;
-        entry.pendingAbortReason = null;
+      if (entry.aborted && ac && !ac.signal.aborted) {
+        ac.abort(entry.abortReason);
       }
     },
     touch() {
+      // Same token fence as deregister: a superseded handle's touch must never
+      // clobber — or, after the successor deregisters, resurrect — the shared
+      // projection file (Phase B review catch).
+      if (_live.get(ticket)?.token !== entry.token) return;
       entry.updatedAt = entry.now();
       if (entry.updatedAt - entry.lastProjectionWriteAt >= PROJECTION_TOUCH_THROTTLE_MS) {
         writeProjection(entry);
@@ -203,24 +209,27 @@ export function countLiveSdkWorkers() {
 }
 
 /**
- * Abort a live worker's current query (watchdog / operator kill). If no
- * controller is installed yet the abort is queued for setAbortController.
+ * Abort a live worker (watchdog / operator kill). Sticky: marks the whole
+ * registration aborted (even with a nullish reason), aborts the current
+ * controller when one is installed and un-aborted, and guarantees every
+ * FUTURE controller (next retry attempt) is aborted on install — so an abort
+ * landing in the overload-backoff window can never be lost.
+ * `aborted` reports whether a live controller was aborted NOW (or already
+ * was); a pre-controller abort returns aborted:false (queued, fires on
+ * install).
  * @returns {{found: boolean, aborted: boolean}}
  */
 export function abortSdkWorker(ticket, reason) {
   const entry = _live.get(ticket);
   if (!entry) return { found: false, aborted: false };
+  entry.aborted = true;
+  entry.abortReason = reason;
   const ac = entry.abortController;
   if (ac && !ac.signal.aborted) {
     ac.abort(reason);
-    entry.aborted = true;
     return { found: true, aborted: true };
   }
-  if (!ac) {
-    entry.pendingAbortReason = reason;
-    return { found: true, aborted: false };
-  }
-  return { found: true, aborted: ac.signal.aborted };
+  return { found: true, aborted: ac ? ac.signal.aborted : false };
 }
 
 /**
@@ -254,6 +263,13 @@ function defaultPidAlive(pid) {
  * Cross-process liveness read from the disk projection (for the delegate-runner
  * child and other non-daemon processes). pid-alive is primary; freshness is the
  * pid-reuse guard. Missing/corrupt projection reads as not-live, never throws.
+ *
+ * ADVISORY, not authoritative (Phase B review, deferred): the projection is
+ * touched only while the query streams, so a worker parked at the semaphore
+ * longer than freshMs reads as dead here while isSdkWorkerLive (in-process) is
+ * still true. Until a consumer needs stronger on-disk freshness (Phase F
+ * delegate-runner re-point), treat a dead read as "probably not live", never
+ * as license to clobber the worker's signal/worktree.
  */
 export function isSdkWorkerLiveOnDisk(orchDir, ticket, { pidAlive = defaultPidAlive, now = Date.now, freshMs = SDK_WORKER_FRESH_MS } = {}) {
   let proj;

--- a/plugins/dev/scripts/execution-core/sdk-worker-registry.test.mjs
+++ b/plugins/dev/scripts/execution-core/sdk-worker-registry.test.mjs
@@ -321,6 +321,51 @@ describe("abort / cancel", () => {
     h.setAbortController(ac);
     const res = cancelSdkRun({ ticket: "CTL-1", generation: 1 });
     expect(res.aborted).toBe(true); // fail-open: cancel proceeds
+    h.deregister(); // don't leak module state into later files in this bun process
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  // Phase B review catches — the abort must be sticky on the REGISTRATION:
+  test("an abort landing between retry attempts re-arms onto the next controller (backoff-window loss)", () => {
+    const dir = freshDir();
+    const h = registerSdkWorker(entry(dir));
+    const ac1 = new AbortController(); // attempt 0's controller — query already settled
+    h.setAbortController(ac1);
+    const res = abortSdkWorker("CTL-1", "watchdog-timeout");
+    expect(res).toEqual({ found: true, aborted: true });
+    // attempt 1 (post-backoff) installs a fresh controller — must abort on install
+    const ac2 = new AbortController();
+    h.setAbortController(ac2);
+    expect(ac2.signal.aborted).toBe(true);
+    expect(ac2.signal.reason).toBe("watchdog-timeout");
+    expect(h.aborted).toBe(true);
+    h.deregister();
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  test("a queued abort with NO reason still fires on controller install (nullish-reason drop)", () => {
+    const dir = freshDir();
+    const h = registerSdkWorker(entry(dir));
+    const res = abortSdkWorker("CTL-1"); // reason undefined, no controller yet
+    expect(res).toEqual({ found: true, aborted: false });
+    const ac = new AbortController();
+    h.setAbortController(ac);
+    expect(ac.signal.aborted).toBe(true);
+    h.deregister();
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  test("a superseded handle's touch never clobbers or resurrects the projection (token fence)", () => {
+    const dir = freshDir();
+    let t = T0;
+    const hOld = registerSdkWorker(entry(dir, { generation: 1 }), { now: () => t });
+    const hNew = registerSdkWorker(entry(dir, { generation: 2 }), { now: () => t });
+    t = T0 + 120_000; // far past the projection throttle
+    hOld.touch(); // superseded — must NOT overwrite gen-2's projection
+    expect(readProjection(dir, "CTL-1").generation).toBe(2);
+    hNew.deregister(); // unlinks the projection
+    hOld.touch(); // must NOT resurrect the file as a ghost
+    expect(existsSync(join(dir, ".sdk-workers", "CTL-1.json"))).toBe(false);
     rmSync(dir, { recursive: true, force: true });
   });
 

--- a/plugins/dev/scripts/execution-core/sdk-worker-registry.test.mjs
+++ b/plugins/dev/scripts/execution-core/sdk-worker-registry.test.mjs
@@ -1,0 +1,333 @@
+// sdk-worker-registry.test.mjs — CTL-1410 Phase B. Fully OFFLINE: the registry
+// is a leaf module (node:fs/node:path only); tests fake time via an injected
+// now() and pid liveness via an injected pidAlive(). No network, no spawn.
+//
+// Run: cd plugins/dev/scripts/execution-core && bun test sdk-worker-registry.test.mjs
+
+import { describe, test, expect } from "bun:test";
+import { existsSync, mkdtempSync, readdirSync, readFileSync, rmSync, writeFileSync, mkdirSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import {
+  SDK_WORKER_FRESH_MS,
+  PREEMPTION_ABORT_REASON,
+  isPreemptionAbort,
+  registerSdkWorker,
+  deregisterSdkWorker,
+  isSdkWorkerLive,
+  sdkWorkerForTicket,
+  sdkWorkerForWorktree,
+  countLiveSdkWorkers,
+  abortSdkWorker,
+  cancelSdkRun,
+  isSdkWorkerLiveOnDisk,
+  reconcileSdkRegistryOnBoot,
+  resetSdkWorkerRegistry,
+} from "./sdk-worker-registry.mjs";
+
+const T0 = 1_700_000_000_000;
+
+// Every test starts from a clean singleton; cleanup is inline (house style —
+// no beforeEach/afterEach in the sdk-* suites).
+function freshDir(prefix = "sdk-reg-") {
+  resetSdkWorkerRegistry();
+  return mkdtempSync(join(tmpdir(), prefix));
+}
+
+function entry(orchDir, over = {}) {
+  return {
+    ticket: "CTL-1",
+    phase: "implement",
+    worktreePath: "/wt/ctl-1",
+    generation: 1,
+    orchDir,
+    ...over,
+  };
+}
+
+function readProjection(orchDir, ticket) {
+  return JSON.parse(readFileSync(join(orchDir, ".sdk-workers", `${ticket}.json`), "utf8"));
+}
+
+describe("register / deregister / lookups", () => {
+  test("register makes the worker live; deregister makes it dead", () => {
+    const dir = freshDir();
+    const h = registerSdkWorker(entry(dir));
+    expect(isSdkWorkerLive("CTL-1")).toBe(true);
+    expect(countLiveSdkWorkers()).toBe(1);
+    h.deregister();
+    expect(isSdkWorkerLive("CTL-1")).toBe(false);
+    expect(countLiveSdkWorkers()).toBe(0);
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  test("sdkWorkerForTicket returns a copy without the abort controller", () => {
+    const dir = freshDir();
+    const h = registerSdkWorker(entry(dir), { now: () => T0 });
+    h.setAbortController(new AbortController());
+    const got = sdkWorkerForTicket("CTL-1");
+    expect(got.ticket).toBe("CTL-1");
+    expect(got.phase).toBe("implement");
+    expect(got.worktreePath).toBe("/wt/ctl-1");
+    expect(got.generation).toBe(1);
+    expect(got.startedAt).toBe(T0);
+    expect(got.pid).toBe(process.pid);
+    expect("abortController" in got).toBe(false);
+    expect(sdkWorkerForTicket("CTL-404")).toBe(null);
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  test("sdkWorkerForWorktree reverse lookup finds the live worker", () => {
+    const dir = freshDir();
+    registerSdkWorker(entry(dir));
+    expect(sdkWorkerForWorktree("/wt/ctl-1")?.ticket).toBe("CTL-1");
+    expect(sdkWorkerForWorktree("/wt/other")).toBe(null);
+    deregisterSdkWorker("CTL-1");
+    expect(sdkWorkerForWorktree("/wt/ctl-1")).toBe(null);
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  test("re-register for the same ticket updates in place (resume), including the worktree index", () => {
+    const dir = freshDir();
+    registerSdkWorker(entry(dir, { generation: 1, worktreePath: "/wt/a" }));
+    registerSdkWorker(entry(dir, { generation: 2, worktreePath: "/wt/b" }));
+    expect(countLiveSdkWorkers()).toBe(1);
+    expect(sdkWorkerForTicket("CTL-1").generation).toBe(2);
+    expect(sdkWorkerForWorktree("/wt/b")?.ticket).toBe("CTL-1");
+    expect(sdkWorkerForWorktree("/wt/a")).toBe(null); // stale index entry cleaned
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  test("compare-and-delete by token: a stale handle's deregister does not evict the resume registration", () => {
+    const dir = freshDir();
+    const hOld = registerSdkWorker(entry(dir, { generation: 1 }));
+    const hNew = registerSdkWorker(entry(dir, { generation: 2 })); // resume re-register
+    hOld.deregister(); // stale — must be a no-op
+    expect(isSdkWorkerLive("CTL-1")).toBe(true);
+    expect(sdkWorkerForTicket("CTL-1").generation).toBe(2);
+    hNew.deregister();
+    expect(isSdkWorkerLive("CTL-1")).toBe(false);
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  test("deregisterSdkWorker (registry-level) force-removes regardless of handle", () => {
+    const dir = freshDir();
+    registerSdkWorker(entry(dir));
+    deregisterSdkWorker("CTL-1");
+    expect(isSdkWorkerLive("CTL-1")).toBe(false);
+    // unknown ticket never throws
+    expect(() => deregisterSdkWorker("CTL-404")).not.toThrow();
+    rmSync(dir, { recursive: true, force: true });
+  });
+});
+
+describe("disk projection", () => {
+  test("register writes an atomic projection; deregister unlinks it", () => {
+    const dir = freshDir();
+    const h = registerSdkWorker(entry(dir), { now: () => T0 });
+    const proj = readProjection(dir, "CTL-1");
+    expect(proj.ticket).toBe("CTL-1");
+    expect(proj.phase).toBe("implement");
+    expect(proj.worktreePath).toBe("/wt/ctl-1");
+    expect(proj.generation).toBe(1);
+    expect(proj.pid).toBe(process.pid);
+    expect(proj.startedAt).toBe(T0);
+    expect(proj.updatedAt).toBe(T0);
+    // atomic tmp+rename — no .tmp debris
+    expect(readdirSync(join(dir, ".sdk-workers")).filter((f) => f.includes(".tmp"))).toEqual([]);
+    h.deregister();
+    expect(existsSync(join(dir, ".sdk-workers", "CTL-1.json"))).toBe(false);
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  test("touch refreshes updatedAt in memory and (throttled) on disk", () => {
+    const dir = freshDir();
+    let t = T0;
+    const h = registerSdkWorker(entry(dir), { now: () => t });
+    t = T0 + 60_000; // beyond any projection-write throttle
+    h.touch();
+    expect(readProjection(dir, "CTL-1").updatedAt).toBe(T0 + 60_000);
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  test("touch within the throttle window skips the disk write but a later touch lands", () => {
+    const dir = freshDir();
+    let t = T0;
+    const h = registerSdkWorker(entry(dir), { now: () => t });
+    t = T0 + 1_000; // inside throttle
+    h.touch();
+    expect(readProjection(dir, "CTL-1").updatedAt).toBe(T0);
+    t = T0 + 120_000;
+    h.touch();
+    expect(readProjection(dir, "CTL-1").updatedAt).toBe(T0 + 120_000);
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  test("an unwritable orchDir never throws — in-memory registration still works", () => {
+    resetSdkWorkerRegistry();
+    const h = registerSdkWorker(entry("/nonexistent-root-path/definitely/not/writable"));
+    expect(isSdkWorkerLive("CTL-1")).toBe(true);
+    expect(() => h.touch()).not.toThrow();
+    expect(() => h.deregister()).not.toThrow();
+    expect(isSdkWorkerLive("CTL-1")).toBe(false);
+  });
+});
+
+describe("isSdkWorkerLiveOnDisk (pidAlive primary, freshness secondary)", () => {
+  test("true iff projection present AND pid alive AND fresh", () => {
+    const dir = freshDir();
+    registerSdkWorker(entry(dir), { now: () => T0 });
+    const alive = () => true;
+    const dead = () => false;
+    expect(isSdkWorkerLiveOnDisk(dir, "CTL-1", { pidAlive: alive, now: () => T0 + 1000 })).toBe(true);
+    expect(isSdkWorkerLiveOnDisk(dir, "CTL-1", { pidAlive: dead, now: () => T0 + 1000 })).toBe(false);
+    expect(
+      isSdkWorkerLiveOnDisk(dir, "CTL-1", { pidAlive: alive, now: () => T0 + SDK_WORKER_FRESH_MS + 1 }),
+    ).toBe(false); // stale
+    expect(isSdkWorkerLiveOnDisk(dir, "CTL-404", { pidAlive: alive })).toBe(false); // missing
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  test("freshMs is overridable", () => {
+    const dir = freshDir();
+    registerSdkWorker(entry(dir), { now: () => T0 });
+    expect(
+      isSdkWorkerLiveOnDisk(dir, "CTL-1", { pidAlive: () => true, now: () => T0 + 5_000, freshMs: 1_000 }),
+    ).toBe(false);
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  test("a corrupt projection file reads as not-live, never throws", () => {
+    const dir = freshDir();
+    mkdirSync(join(dir, ".sdk-workers"), { recursive: true });
+    writeFileSync(join(dir, ".sdk-workers", "CTL-9.json"), "{not json");
+    expect(isSdkWorkerLiveOnDisk(dir, "CTL-9", { pidAlive: () => true })).toBe(false);
+    rmSync(dir, { recursive: true, force: true });
+  });
+});
+
+describe("reconcileSdkRegistryOnBoot", () => {
+  test("deletes dead-pid projections, keeps live-pid ones", () => {
+    const dir = freshDir();
+    mkdirSync(join(dir, ".sdk-workers"), { recursive: true });
+    writeFileSync(
+      join(dir, ".sdk-workers", "CTL-1.json"),
+      JSON.stringify({ ticket: "CTL-1", pid: 11111, updatedAt: T0 }),
+    );
+    writeFileSync(
+      join(dir, ".sdk-workers", "CTL-2.json"),
+      JSON.stringify({ ticket: "CTL-2", pid: 22222, updatedAt: T0 }),
+    );
+    const res = reconcileSdkRegistryOnBoot(dir, { pidAlive: (pid) => pid === 22222 });
+    expect(res.removed).toEqual(["CTL-1"]);
+    expect(res.kept).toEqual(["CTL-2"]);
+    expect(existsSync(join(dir, ".sdk-workers", "CTL-1.json"))).toBe(false);
+    expect(existsSync(join(dir, ".sdk-workers", "CTL-2.json"))).toBe(true);
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  test("no projection dir → clean empty result, never throws", () => {
+    const dir = freshDir();
+    const res = reconcileSdkRegistryOnBoot(dir);
+    expect(res.removed).toEqual([]);
+    expect(res.kept).toEqual([]);
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  test("corrupt projection is removed (unreadable = not recoverable)", () => {
+    const dir = freshDir();
+    mkdirSync(join(dir, ".sdk-workers"), { recursive: true });
+    writeFileSync(join(dir, ".sdk-workers", "CTL-9.json"), "{not json");
+    const res = reconcileSdkRegistryOnBoot(dir, { pidAlive: () => true });
+    expect(res.removed).toEqual(["CTL-9"]);
+    expect(existsSync(join(dir, ".sdk-workers", "CTL-9.json"))).toBe(false);
+    rmSync(dir, { recursive: true, force: true });
+  });
+});
+
+describe("abort / cancel", () => {
+  test("abortSdkWorker aborts the stored controller with the given reason", () => {
+    const dir = freshDir();
+    const h = registerSdkWorker(entry(dir));
+    const ac = new AbortController();
+    h.setAbortController(ac);
+    const res = abortSdkWorker("CTL-1", "watchdog-timeout");
+    expect(res).toEqual({ found: true, aborted: true });
+    expect(ac.signal.aborted).toBe(true);
+    expect(ac.signal.reason).toBe("watchdog-timeout");
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  test("unknown ticket → {found:false}, never throws", () => {
+    freshDir();
+    expect(abortSdkWorker("CTL-404", "x")).toEqual({ found: false, aborted: false });
+    expect(cancelSdkRun({ ticket: "CTL-404" })).toEqual({ found: false, stale: false, aborted: false });
+  });
+
+  test("abort before setAbortController: a later setAbortController aborts immediately", () => {
+    const dir = freshDir();
+    const h = registerSdkWorker(entry(dir));
+    const res = abortSdkWorker("CTL-1", PREEMPTION_ABORT_REASON);
+    expect(res).toEqual({ found: true, aborted: false }); // no controller yet — pending
+    const ac = new AbortController();
+    h.setAbortController(ac);
+    expect(ac.signal.aborted).toBe(true);
+    expect(ac.signal.reason).toBe(PREEMPTION_ABORT_REASON);
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  test("per-retry controller swap: abort hits only the latest controller", () => {
+    const dir = freshDir();
+    const h = registerSdkWorker(entry(dir));
+    const ac1 = new AbortController();
+    const ac2 = new AbortController();
+    h.setAbortController(ac1);
+    h.setAbortController(ac2);
+    abortSdkWorker("CTL-1", "x");
+    expect(ac1.signal.aborted).toBe(false);
+    expect(ac2.signal.aborted).toBe(true);
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  test("cancelSdkRun uses the preemption sentinel by default and marks the entry aborted", () => {
+    const dir = freshDir();
+    const h = registerSdkWorker(entry(dir, { generation: 3 }));
+    const ac = new AbortController();
+    h.setAbortController(ac);
+    const res = cancelSdkRun({ ticket: "CTL-1", generation: 3 });
+    expect(res).toEqual({ found: true, stale: false, aborted: true });
+    expect(ac.signal.aborted).toBe(true);
+    expect(isPreemptionAbort(ac.signal.reason)).toBe(true);
+    expect(h.aborted).toBe(true);
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  test("generation fence: a stale cancel returns {stale:true} and does NOT abort", () => {
+    const dir = freshDir();
+    const h = registerSdkWorker(entry(dir, { generation: 5 }));
+    const ac = new AbortController();
+    h.setAbortController(ac);
+    const res = cancelSdkRun({ ticket: "CTL-1", generation: 4 }); // older than the live gen
+    expect(res).toEqual({ found: true, stale: true, aborted: false });
+    expect(ac.signal.aborted).toBe(false);
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  test("generation fence fails open on non-numeric generations (parity with the signal flip)", () => {
+    const dir = freshDir();
+    const h = registerSdkWorker(entry(dir, { generation: undefined }));
+    const ac = new AbortController();
+    h.setAbortController(ac);
+    const res = cancelSdkRun({ ticket: "CTL-1", generation: 1 });
+    expect(res.aborted).toBe(true); // fail-open: cancel proceeds
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  test("isPreemptionAbort recognizes the sentinel as reason string and as Error message", () => {
+    expect(isPreemptionAbort(PREEMPTION_ABORT_REASON)).toBe(true);
+    expect(isPreemptionAbort(new Error(PREEMPTION_ABORT_REASON))).toBe(true);
+    expect(isPreemptionAbort("sdk-threw")).toBe(false);
+    expect(isPreemptionAbort(undefined)).toBe(false);
+  });
+});

--- a/plugins/dev/scripts/execution-core/worktree-refresh-timer.mjs
+++ b/plugins/dev/scripts/execution-core/worktree-refresh-timer.mjs
@@ -9,6 +9,7 @@ import { spawnSync } from "node:child_process";
 import { fileURLToPath } from "node:url";
 import { readWorkerSignals } from "./signal-reader.mjs";
 import { isBgJobAlive } from "./claude-agents.mjs";
+import { isSdkWorkerLive as registrySdkWorkerLive } from "./sdk-worker-registry.mjs";
 import { log } from "./config.mjs";
 
 const REFRESH_BIN = fileURLToPath(
@@ -63,6 +64,7 @@ function spawnRefresh(worktreePath, base) {
  * @param {Function}[opts.readSignals]            injectable signal reader
  * @param {Function}[opts.statWorktree]           injectable fs.statSync
  * @param {Function}[opts.isSessionLive]          injectable isBgJobAlive
+ * @param {Function}[opts.isSdkWorkerLive]        injectable in-process registry probe (CTL-1410)
  * @param {Function}[opts.refresh]                injectable spawnRefresh
  * @param {Function}[opts.emit]                   optional telemetry emitter
  * @param {object}  [opts.clock]                  fake-clock seam for tests
@@ -75,6 +77,7 @@ export function startWorktreeRefreshTimer({
   readSignals = readWorkerSignals,
   statWorktree = (p) => statSync(p),
   isSessionLive = isBgJobAlive,
+  isSdkWorkerLive = registrySdkWorkerLive,
   refresh = spawnRefresh,
   emit,
   clock = realClock(),
@@ -93,6 +96,11 @@ export function startWorktreeRefreshTimer({
 
         const bgJobId = signal.liveness?.value;
         if (bgJobId && isSessionLive(bgJobId)) continue;
+        // CTL-1410 Phase B: an in-process SDK worker has NO bg id (liveness
+        // value null), so the guard above is blind to it — without this check
+        // the timer can rebase a worktree a LIVE worker is editing. The default
+        // reads the in-process registry (same daemon process as the dispatch).
+        if (isSdkWorkerLive(signal.ticket)) continue;
 
         let mtime;
         try {

--- a/plugins/dev/scripts/execution-core/worktree-refresh-timer.test.mjs
+++ b/plugins/dev/scripts/execution-core/worktree-refresh-timer.test.mjs
@@ -79,6 +79,27 @@ describe("startWorktreeRefreshTimer", () => {
     expect(refreshed.length).toBe(0);
   });
 
+  it("skips workers with a live in-process SDK worker (bg id null) — CTL-1410 Phase B", () => {
+    const clock = fakeClock();
+    const refreshed = [];
+    startWorktreeRefreshTimer({
+      intervalSeconds: 60,
+      quietSeconds: 0,
+      orchDir: "/fake/orch",
+      readSignals: () => [
+        mkSignal("/wt/A", { ticket: "CTL-SDK" }), // live in the registry — must be skipped
+        mkSignal("/wt/B", { ticket: "CTL-IDLE" }), // not registered — still refreshed
+      ],
+      statWorktree: () => ({ mtimeMs: 0 }),
+      isSessionLive: () => false, // bg leg sees nothing (bg id is null)
+      isSdkWorkerLive: (ticket) => ticket === "CTL-SDK",
+      refresh: (wt) => { refreshed.push(wt); return 0; },
+      clock,
+    });
+    clock.advance(60_000);
+    expect(refreshed).toEqual(["/wt/B"]);
+  });
+
   it("skips workers whose worktree mtime is too recent", () => {
     const clock = fakeClock();
     const refreshed = [];


### PR DESCRIPTION
## Summary

Phase B of CTL-1410 (SDK-only standardization, plan §Phase B): ONE authoritative in-process registry for live SDK workers — the liveness fact that replaces `bg_job_id`-keyed inference for workers the bg probes can't see. Builds on Phase A (#2524).

### New: `sdk-worker-registry.mjs` (leaf module)

- `registerSdkWorker → handle{setAbortController, touch, deregister, aborted}` — idempotent per ticket (resume replaces in place; superseded handles are token-fenced no-ops for BOTH deregister and touch)
- **Sticky abort** (`abortSdkWorker`/`cancelSdkRun`): an abort marks the registration, aborts the current controller, and re-arms onto every future controller — an abort landing in the 429/529 backoff window can never be lost
- `cancelSdkRun` carries `PREEMPTION_ABORT_REASON` + a CTL-736-parity generation fence (stale cancel bows out `{stale:true}`; fails open on non-numeric)
- Disk projection `<orchDir>/.sdk-workers/<ticket>.json` (atomic tmp+rename, throttled touch) + `isSdkWorkerLiveOnDisk` (pid-alive primary, freshness secondary — advisory until the Phase F delegate-runner re-point) + `reconcileSdkRegistryOnBoot`

### Wiring

- **sdk-run-phase-agent**: register after spec resolve (before `sem.acquire` — a parked waiter owns its claim/signal), per-retry `setAbortController`, `touch()` heartbeat per streamed message, deregister on every exit path; the three pre-launch early-returns never register
- **worktree-refresh-timer**: skips a live SDK worker's worktree (the bg guard is blind to a null bg id — previously rebasable mid-run)
- **delegate-queue**: worker-live dedup closes the null-`bg_job_id` fail-open
- **scheduler Pass-0a**: phantom-sweep never quarantines a live SDK worker
- **daemon boot**: `reconcileSdkRegistryOnBoot` reaps dead-pid projections before any liveness consumer runs

## Review

Adversarially reviewed by a 13-agent workflow (4 finder lenses → per-finding refutation): 9 raw findings → 4 distinct defects, all fixed in the second commit (sticky abort, touch token-fence, nullish-reason queue, test leak) + 1 documented deferral.

## Tests

27 registry tests, 7 runner-wiring tests, +1 refresh-timer, +2 delegate-queue, +1 scheduler phantom-sweep — 208/208 across the five touched suites. `sdk-worker-registry.test.mjs` added to the CI allowlist. Scheduler CTL-781 failures are pre-existing on main (identical baseline verified).

## What this enables

Phase C (hang/crash watchdog → slot reclaim), Phase D (in-process preemption cancel), Phases E/F (crash-revive + reclaim re-point). The `.abort()` semantics were verified against SDK 0.3.195: aborting the query controller kills the spawned `claude` child (stdin-EOF → SIGTERM → SIGKILL, ~7s worst case).

Part of CTL-1410. Plan: `thoughts/shared/plans/2026-07-01-CTL-1410-sdk-only-standardization-delete-bg-executor.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ArmgujXD5Kdx2HX4ZGNim6