### PR TITLE
fix(dev): CTL-1415 — age-gate and auto-clear a stale plugin-source .git/index.lock

### DIFF
--- a/plugins/dev/scripts/broker/plugin-refresh.mjs
+++ b/plugins/dev/scripts/broker/plugin-refresh.mjs
@@ -33,11 +33,12 @@
 // deterministically testable without real load, timers, network, or a checkout.
 // Mirrors the gc-liveness.mjs / autotune.mjs seam-injection convention.
 
-import { readFileSync } from "node:fs";
+import { readFileSync, rmSync } from "node:fs";
 import { execFileSync } from "node:child_process";
 import { homedir } from "node:os";
 import { resolve } from "node:path";
 import { getEventName } from "./event-name.mjs"; // CTL-1348: leaf, not the heavy router
+import { staleLockStatus, indexLockPath, STALE_LOCK_THRESHOLD_MS } from "../lib/stale-lock.mjs"; // CTL-1415
 
 // Throttle window: at most one pull per N seconds per checkout root. A merge
 // often arrives as both a github.pr.merged AND a github.push to main within the
@@ -107,6 +108,59 @@ function defaultGitFn(root, args) {
     killSignal: "SIGKILL",
     env: { ...process.env, GIT_TERMINAL_PROMPT: "0" },
   }).trim();
+}
+
+// defaultRmFn — remove a path, tolerating a concurrent removal (force). Used only
+// to clear a stale git index.lock (CTL-1415); seam-injected for tests.
+function defaultRmFn(path) {
+  rmSync(path, { force: true });
+}
+
+/**
+ * clearStaleIndexLock — CTL-1415: age-gated removal of a crashed-op leftover
+ * `.git/index.lock` before a pull, so a stale lock can't silently freeze the
+ * checkout's `git reset --hard` for hours (the ~8.5h laptop freeze in CTL-1401).
+ *
+ * Removes ONLY when staleLockStatus reports the lock is older than the safe
+ * threshold, so an in-flight git op's lock is never disturbed. On removal, emits
+ * plugin.checkout.stale_lock_cleared (WARN — clearing means a git op had crashed,
+ * worth a signal). NEVER throws: a removal failure emits
+ * plugin.checkout.stale_lock_clear_failed (WARN) and the caller proceeds to the
+ * git op anyway (which then fails loudly via refresh_failed rather than this
+ * masking it).
+ *
+ * @returns {{present, ageMs, stale, cleared:boolean, error?:string}}
+ */
+export function clearStaleIndexLock({
+  root,
+  now = Date.now(),
+  emitFn,
+  statFn,
+  rmFn = defaultRmFn,
+  thresholdMs = STALE_LOCK_THRESHOLD_MS,
+}) {
+  const status = staleLockStatus({ root, now, thresholdMs, statFn });
+  if (!status.present || !status.stale) return { ...status, cleared: false };
+  try {
+    rmFn(indexLockPath(root));
+    emitFn?.({
+      event: "plugin.checkout.stale_lock_cleared",
+      orchestrator: null,
+      worker: null,
+      severity: "WARN",
+      detail: { checkout: root, lock_age_ms: status.ageMs, threshold_ms: thresholdMs },
+    });
+    return { ...status, cleared: true };
+  } catch (err) {
+    emitFn?.({
+      event: "plugin.checkout.stale_lock_clear_failed",
+      orchestrator: null,
+      worker: null,
+      severity: "WARN",
+      detail: { checkout: root, lock_age_ms: status.ageMs, error: err?.message ?? String(err) },
+    });
+    return { ...status, cleared: false, error: err?.message ?? String(err) };
+  }
 }
 
 // Dep install can take longer than a git op (lockfile resolution); generous ceiling.
@@ -407,6 +461,10 @@ export function refreshPluginCheckout({
   // ALWAYS returns changed:false so decideStackReload (stack-reload.mjs) stays a no-op
   // (a behind checkout the broker never pulled must not trigger a stack restart loop).
   pull = true,
+  // CTL-1415: seams for the pre-pull stale-index.lock age-gate. Undefined statFn
+  // falls through to staleLockStatus's real statSync default in production.
+  statFn = undefined,
+  rmFn = defaultRmFn,
 }) {
   if (!root) return { pulled: false, throttled: false, changed: false, failed: false, root, oldSha: null, newSha: null, restartNeeded: false };
 
@@ -463,6 +521,12 @@ export function refreshPluginCheckout({
   } catch {
     oldSha = null;
   }
+
+  // CTL-1415: clear a stale (crashed-op) index.lock BEFORE the reset --hard it
+  // would otherwise block on forever. Age-gated, so a live git op is untouched;
+  // never throws, so a clear failure surfaces as its own WARN and we still
+  // attempt the pull (which then fails loudly rather than being masked).
+  clearStaleIndexLock({ root, now, emitFn, statFn, rmFn });
 
   try {
     gitFn(root, ["fetch", "--no-tags", "origin", "main"]);

--- a/plugins/dev/scripts/broker/plugin-refresh.mjs
+++ b/plugins/dev/scripts/broker/plugin-refresh.mjs
@@ -129,6 +129,16 @@ function defaultRmFn(path) {
  * git op anyway (which then fails loudly via refresh_failed rather than this
  * masking it).
  *
+ * Codex P1 (#2530): two overlapping cleanup attempts could both classify the SAME
+ * old lock as stale; the first removes it and starts git (creating a fresh
+ * index.lock), then the second — still acting on its earlier classification —
+ * would unlink that brand-new live lock, defeating git's mutual exclusion. Right
+ * before removing, we re-run staleLockStatus and bail (no-op) if the lock is no
+ * longer present-and-stale at that instant — this narrows the race window to the
+ * single re-check rather than the whole caller's prior work, and a second
+ * concurrent attempt that loses the race simply leaves the winner's fresh lock
+ * alone instead of destroying it.
+ *
  * @returns {{present, ageMs, stale, cleared:boolean, error?:string}}
  */
 export function clearStaleIndexLock({
@@ -141,6 +151,13 @@ export function clearStaleIndexLock({
 }) {
   const status = staleLockStatus({ root, now, thresholdMs, statFn });
   if (!status.present || !status.stale) return { ...status, cleared: false };
+  // Re-verify immediately before removing (see Codex P1 note above). Reuses the
+  // same `now` as the classification above — what matters is a fresh statFn
+  // read of the lock's mtime, not wall-clock drift between the two calls (this
+  // whole function runs synchronously), and reusing `now` keeps the recheck
+  // seam-injectable/deterministic for tests instead of reaching for a real clock.
+  const recheck = staleLockStatus({ root, now, thresholdMs, statFn });
+  if (!recheck.present || !recheck.stale) return { ...status, cleared: false };
   try {
     rmFn(indexLockPath(root));
     emitFn?.({

--- a/plugins/dev/scripts/broker/plugin-refresh.mjs
+++ b/plugins/dev/scripts/broker/plugin-refresh.mjs
@@ -38,6 +38,7 @@ import { execFileSync } from "node:child_process";
 import { homedir } from "node:os";
 import { resolve, join } from "node:path";
 import { getEventName } from "./event-name.mjs"; // CTL-1348: leaf, not the heavy router
+import { staleLockStatus, indexLockPath, STALE_LOCK_THRESHOLD_MS } from "../lib/stale-lock.mjs"; // CTL-1415
 
 // Throttle window: at most one pull per N seconds per checkout root. A merge
 // often arrives as both a github.pr.merged AND a github.push to main within the
@@ -107,6 +108,59 @@ function defaultGitFn(root, args) {
     killSignal: "SIGKILL",
     env: { ...process.env, GIT_TERMINAL_PROMPT: "0" },
   }).trim();
+}
+
+// defaultRmFn — remove a path, tolerating a concurrent removal (force). Used only
+// to clear a stale git index.lock (CTL-1415); seam-injected for tests.
+function defaultRmFn(path) {
+  rmSync(path, { force: true });
+}
+
+/**
+ * clearStaleIndexLock — CTL-1415: age-gated removal of a crashed-op leftover
+ * `.git/index.lock` before a pull, so a stale lock can't silently freeze the
+ * checkout's `git reset --hard` for hours (the ~8.5h laptop freeze in CTL-1401).
+ *
+ * Removes ONLY when staleLockStatus reports the lock is older than the safe
+ * threshold, so an in-flight git op's lock is never disturbed. On removal, emits
+ * plugin.checkout.stale_lock_cleared (WARN — clearing means a git op had crashed,
+ * worth a signal). NEVER throws: a removal failure emits
+ * plugin.checkout.stale_lock_clear_failed (WARN) and the caller proceeds to the
+ * git op anyway (which then fails loudly via refresh_failed rather than this
+ * masking it).
+ *
+ * @returns {{present, ageMs, stale, cleared:boolean, error?:string}}
+ */
+export function clearStaleIndexLock({
+  root,
+  now = Date.now(),
+  emitFn,
+  statFn,
+  rmFn = defaultRmFn,
+  thresholdMs = STALE_LOCK_THRESHOLD_MS,
+}) {
+  const status = staleLockStatus({ root, now, thresholdMs, statFn });
+  if (!status.present || !status.stale) return { ...status, cleared: false };
+  try {
+    rmFn(indexLockPath(root));
+    emitFn?.({
+      event: "plugin.checkout.stale_lock_cleared",
+      orchestrator: null,
+      worker: null,
+      severity: "WARN",
+      detail: { checkout: root, lock_age_ms: status.ageMs, threshold_ms: thresholdMs },
+    });
+    return { ...status, cleared: true };
+  } catch (err) {
+    emitFn?.({
+      event: "plugin.checkout.stale_lock_clear_failed",
+      orchestrator: null,
+      worker: null,
+      severity: "WARN",
+      detail: { checkout: root, lock_age_ms: status.ageMs, error: err?.message ?? String(err) },
+    });
+    return { ...status, cleared: false, error: err?.message ?? String(err) };
+  }
 }
 
 // Dep install can take longer than a git op (lockfile resolution); generous ceiling.
@@ -462,6 +516,10 @@ export function refreshPluginCheckout({
   // ALWAYS returns changed:false so decideStackReload (stack-reload.mjs) stays a no-op
   // (a behind checkout the broker never pulled must not trigger a stack restart loop).
   pull = true,
+  // CTL-1415: seams for the pre-pull stale-index.lock age-gate. Undefined statFn
+  // falls through to staleLockStatus's real statSync default in production.
+  statFn = undefined,
+  rmFn = defaultRmFn,
 }) {
   if (!root) return { pulled: false, throttled: false, changed: false, failed: false, root, oldSha: null, newSha: null, restartNeeded: false };
 
@@ -518,6 +576,12 @@ export function refreshPluginCheckout({
   } catch {
     oldSha = null;
   }
+
+  // CTL-1415: clear a stale (crashed-op) index.lock BEFORE the reset --hard it
+  // would otherwise block on forever. Age-gated, so a live git op is untouched;
+  // never throws, so a clear failure surfaces as its own WARN and we still
+  // attempt the pull (which then fails loudly rather than being masked).
+  clearStaleIndexLock({ root, now, emitFn, statFn, rmFn });
 
   try {
     gitFn(root, ["fetch", "--no-tags", "origin", "main"]);

--- a/plugins/dev/scripts/broker/plugin-refresh.test.mjs
+++ b/plugins/dev/scripts/broker/plugin-refresh.test.mjs
@@ -25,6 +25,7 @@ import {
   isThisRepoMergeEvent,
   isDaemonLocalMergeSignal,
   refreshPluginCheckout,
+  clearStaleIndexLock,
   refreshAllPluginCheckouts,
   startPluginDriftCheck,
   handlePluginRefreshEvent,
@@ -1411,5 +1412,127 @@ describe("refreshPluginCheckout — bunInstallFn seam (CTL-1223)", () => {
     expect(updEv).toBeDefined();
     expect(Array.isArray(updEv.detail.deps_installed)).toBe(true);
     expect(updEv.detail.deps_installed).toContain("/repo/plugins/dev/scripts/orch-monitor/ui");
+  });
+});
+
+// ─── clearStaleIndexLock (CTL-1415) ──────────────────────────────────────────
+//
+// A crashed git op leaves .git/index.lock behind and every later reset --hard
+// then fails forever (the ~8.5h laptop freeze in CTL-1401). The pull path
+// age-gate clears ONLY a lock older than the safe threshold (a live op is never
+// disturbed), emits a WARN when it clears, and never throws.
+
+const LOCK_NOW = 1_750_000_000_000;
+const LOCK_ROOT = "/co/plugin-source";
+const LOCK_PATH = "/co/plugin-source/.git/index.lock";
+
+// statFn seam: returns a fixed mtime for the lock path, null (absent) otherwise.
+function makeLockStatFn(mtimeMs) {
+  return (path) => (path === LOCK_PATH && mtimeMs != null ? mtimeMs : null);
+}
+
+describe("clearStaleIndexLock", () => {
+  test("no lock → no removal, no event", () => {
+    const emitted = [];
+    const removed = [];
+    const res = clearStaleIndexLock({
+      root: LOCK_ROOT, now: LOCK_NOW,
+      emitFn: (e) => emitted.push(e),
+      statFn: makeLockStatFn(null),
+      rmFn: (p) => removed.push(p),
+    });
+    expect(res.present).toBe(false);
+    expect(res.cleared).toBe(false);
+    expect(removed).toEqual([]);
+    expect(emitted).toEqual([]);
+  });
+
+  test("fresh lock (live git op) → NOT removed, no event", () => {
+    const emitted = [];
+    const removed = [];
+    const res = clearStaleIndexLock({
+      root: LOCK_ROOT, now: LOCK_NOW, thresholdMs: 600_000,
+      emitFn: (e) => emitted.push(e),
+      statFn: makeLockStatFn(LOCK_NOW - 5_000), // 5s old
+      rmFn: (p) => removed.push(p),
+    });
+    expect(res.present).toBe(true);
+    expect(res.stale).toBe(false);
+    expect(res.cleared).toBe(false);
+    expect(removed).toEqual([]);
+    expect(emitted).toEqual([]);
+  });
+
+  test("stale lock → removed + plugin.checkout.stale_lock_cleared (WARN)", () => {
+    const emitted = [];
+    const removed = [];
+    const res = clearStaleIndexLock({
+      root: LOCK_ROOT, now: LOCK_NOW, thresholdMs: 600_000,
+      emitFn: (e) => emitted.push(e),
+      statFn: makeLockStatFn(LOCK_NOW - 8.5 * 60 * 60 * 1000), // 8.5h old
+      rmFn: (p) => removed.push(p),
+    });
+    expect(res.cleared).toBe(true);
+    expect(removed).toEqual([LOCK_PATH]);
+    const ev = emitted.find((e) => e.event === "plugin.checkout.stale_lock_cleared");
+    expect(ev).toBeDefined();
+    expect(ev.severity).toBe("WARN");
+    expect(ev.detail.checkout).toBe(LOCK_ROOT);
+    expect(ev.detail.lock_age_ms).toBeGreaterThanOrEqual(600_000);
+    expect(ev.detail.threshold_ms).toBe(600_000);
+  });
+
+  test("removal failure → stale_lock_clear_failed (WARN), never throws", () => {
+    const emitted = [];
+    const res = clearStaleIndexLock({
+      root: LOCK_ROOT, now: LOCK_NOW, thresholdMs: 600_000,
+      emitFn: (e) => emitted.push(e),
+      statFn: makeLockStatFn(LOCK_NOW - 3_600_000), // 1h old → stale
+      rmFn: () => { throw new Error("EACCES"); },
+    });
+    expect(res.cleared).toBe(false);
+    expect(res.error).toContain("EACCES");
+    const ev = emitted.find((e) => e.event === "plugin.checkout.stale_lock_clear_failed");
+    expect(ev).toBeDefined();
+    expect(ev.severity).toBe("WARN");
+  });
+});
+
+describe("refreshPluginCheckout — stale-lock pre-pull clear (CTL-1415)", () => {
+  beforeEach(() => __clearThrottleForTest());
+
+  test("clears a stale lock before fetch/reset, then pulls", () => {
+    const emitted = [];
+    const removed = [];
+    const gitFn = makeGitFn({ before: "old111", after: "new222" });
+    const res = refreshPluginCheckout({
+      root: LOCK_ROOT, now: LOCK_NOW, gitFn,
+      emitFn: (e) => emitted.push(e),
+      statFn: makeLockStatFn(LOCK_NOW - 3_600_000), // 1h stale
+      rmFn: (p) => removed.push(p),
+      bunInstallFn: () => {},
+    });
+    // Lock cleared, and the pull proceeded to a real reset + updated event.
+    expect(removed).toEqual([LOCK_PATH]);
+    expect(emitted.some((e) => e.event === "plugin.checkout.stale_lock_cleared")).toBe(true);
+    expect(gitFn.calls.some((c) => c.args[0] === "reset")).toBe(true);
+    expect(res.pulled).toBe(true);
+    expect(res.changed).toBe(true);
+  });
+
+  test("does NOT touch a fresh lock (live op), still attempts the pull", () => {
+    const emitted = [];
+    const removed = [];
+    const gitFn = makeGitFn({ before: "old111", after: "new222" });
+    refreshPluginCheckout({
+      root: LOCK_ROOT, now: LOCK_NOW, gitFn,
+      emitFn: (e) => emitted.push(e),
+      statFn: makeLockStatFn(LOCK_NOW - 3_000), // 3s fresh
+      rmFn: (p) => removed.push(p),
+      bunInstallFn: () => {},
+    });
+    expect(removed).toEqual([]);
+    expect(emitted.some((e) => e.event === "plugin.checkout.stale_lock_cleared")).toBe(false);
+    expect(gitFn.calls.some((c) => c.args[0] === "fetch")).toBe(true);
   });
 });

--- a/plugins/dev/scripts/broker/plugin-refresh.test.mjs
+++ b/plugins/dev/scripts/broker/plugin-refresh.test.mjs
@@ -25,6 +25,7 @@ import {
   isThisRepoMergeEvent,
   isDaemonLocalMergeSignal,
   refreshPluginCheckout,
+  clearStaleIndexLock,
   refreshAllPluginCheckouts,
   startPluginDriftCheck,
   handlePluginRefreshEvent,
@@ -1578,5 +1579,127 @@ describe("refreshPluginCheckout — stale node_modules pruning", () => {
     expect(warn.detail.node_modules_dir).toBe("/co/x/node_modules");
     expect(warn.detail.error).toContain("EPERM");
     expect(installed).toEqual(["/co"]); // the checkout still converges as far as it can
+  });
+});
+
+// ─── clearStaleIndexLock (CTL-1415) ──────────────────────────────────────────
+//
+// A crashed git op leaves .git/index.lock behind and every later reset --hard
+// then fails forever (the ~8.5h laptop freeze in CTL-1401). The pull path
+// age-gate clears ONLY a lock older than the safe threshold (a live op is never
+// disturbed), emits a WARN when it clears, and never throws.
+
+const LOCK_NOW = 1_750_000_000_000;
+const LOCK_ROOT = "/co/plugin-source";
+const LOCK_PATH = "/co/plugin-source/.git/index.lock";
+
+// statFn seam: returns a fixed mtime for the lock path, null (absent) otherwise.
+function makeLockStatFn(mtimeMs) {
+  return (path) => (path === LOCK_PATH && mtimeMs != null ? mtimeMs : null);
+}
+
+describe("clearStaleIndexLock", () => {
+  test("no lock → no removal, no event", () => {
+    const emitted = [];
+    const removed = [];
+    const res = clearStaleIndexLock({
+      root: LOCK_ROOT, now: LOCK_NOW,
+      emitFn: (e) => emitted.push(e),
+      statFn: makeLockStatFn(null),
+      rmFn: (p) => removed.push(p),
+    });
+    expect(res.present).toBe(false);
+    expect(res.cleared).toBe(false);
+    expect(removed).toEqual([]);
+    expect(emitted).toEqual([]);
+  });
+
+  test("fresh lock (live git op) → NOT removed, no event", () => {
+    const emitted = [];
+    const removed = [];
+    const res = clearStaleIndexLock({
+      root: LOCK_ROOT, now: LOCK_NOW, thresholdMs: 600_000,
+      emitFn: (e) => emitted.push(e),
+      statFn: makeLockStatFn(LOCK_NOW - 5_000), // 5s old
+      rmFn: (p) => removed.push(p),
+    });
+    expect(res.present).toBe(true);
+    expect(res.stale).toBe(false);
+    expect(res.cleared).toBe(false);
+    expect(removed).toEqual([]);
+    expect(emitted).toEqual([]);
+  });
+
+  test("stale lock → removed + plugin.checkout.stale_lock_cleared (WARN)", () => {
+    const emitted = [];
+    const removed = [];
+    const res = clearStaleIndexLock({
+      root: LOCK_ROOT, now: LOCK_NOW, thresholdMs: 600_000,
+      emitFn: (e) => emitted.push(e),
+      statFn: makeLockStatFn(LOCK_NOW - 8.5 * 60 * 60 * 1000), // 8.5h old
+      rmFn: (p) => removed.push(p),
+    });
+    expect(res.cleared).toBe(true);
+    expect(removed).toEqual([LOCK_PATH]);
+    const ev = emitted.find((e) => e.event === "plugin.checkout.stale_lock_cleared");
+    expect(ev).toBeDefined();
+    expect(ev.severity).toBe("WARN");
+    expect(ev.detail.checkout).toBe(LOCK_ROOT);
+    expect(ev.detail.lock_age_ms).toBeGreaterThanOrEqual(600_000);
+    expect(ev.detail.threshold_ms).toBe(600_000);
+  });
+
+  test("removal failure → stale_lock_clear_failed (WARN), never throws", () => {
+    const emitted = [];
+    const res = clearStaleIndexLock({
+      root: LOCK_ROOT, now: LOCK_NOW, thresholdMs: 600_000,
+      emitFn: (e) => emitted.push(e),
+      statFn: makeLockStatFn(LOCK_NOW - 3_600_000), // 1h old → stale
+      rmFn: () => { throw new Error("EACCES"); },
+    });
+    expect(res.cleared).toBe(false);
+    expect(res.error).toContain("EACCES");
+    const ev = emitted.find((e) => e.event === "plugin.checkout.stale_lock_clear_failed");
+    expect(ev).toBeDefined();
+    expect(ev.severity).toBe("WARN");
+  });
+});
+
+describe("refreshPluginCheckout — stale-lock pre-pull clear (CTL-1415)", () => {
+  beforeEach(() => __clearThrottleForTest());
+
+  test("clears a stale lock before fetch/reset, then pulls", () => {
+    const emitted = [];
+    const removed = [];
+    const gitFn = makeGitFn({ before: "old111", after: "new222" });
+    const res = refreshPluginCheckout({
+      root: LOCK_ROOT, now: LOCK_NOW, gitFn,
+      emitFn: (e) => emitted.push(e),
+      statFn: makeLockStatFn(LOCK_NOW - 3_600_000), // 1h stale
+      rmFn: (p) => removed.push(p),
+      bunInstallFn: () => {},
+    });
+    // Lock cleared, and the pull proceeded to a real reset + updated event.
+    expect(removed).toEqual([LOCK_PATH]);
+    expect(emitted.some((e) => e.event === "plugin.checkout.stale_lock_cleared")).toBe(true);
+    expect(gitFn.calls.some((c) => c.args[0] === "reset")).toBe(true);
+    expect(res.pulled).toBe(true);
+    expect(res.changed).toBe(true);
+  });
+
+  test("does NOT touch a fresh lock (live op), still attempts the pull", () => {
+    const emitted = [];
+    const removed = [];
+    const gitFn = makeGitFn({ before: "old111", after: "new222" });
+    refreshPluginCheckout({
+      root: LOCK_ROOT, now: LOCK_NOW, gitFn,
+      emitFn: (e) => emitted.push(e),
+      statFn: makeLockStatFn(LOCK_NOW - 3_000), // 3s fresh
+      rmFn: (p) => removed.push(p),
+      bunInstallFn: () => {},
+    });
+    expect(removed).toEqual([]);
+    expect(emitted.some((e) => e.event === "plugin.checkout.stale_lock_cleared")).toBe(false);
+    expect(gitFn.calls.some((c) => c.args[0] === "fetch")).toBe(true);
   });
 });

--- a/plugins/dev/scripts/broker/plugin-refresh.test.mjs
+++ b/plugins/dev/scripts/broker/plugin-refresh.test.mjs
@@ -1663,6 +1663,55 @@ describe("clearStaleIndexLock", () => {
     expect(ev).toBeDefined();
     expect(ev.severity).toBe("WARN");
   });
+
+  // Codex P1 (#2530): a concurrent cleanup attempt could classify the SAME old
+  // lock as stale, then lose a race to a different attempt that already cleared
+  // it and started a new git op (a fresh index.lock). The re-check right before
+  // removal must see that the lock is no longer present-and-stale and bail out
+  // — never unlinking a lock a live git op now holds.
+  test("re-check race: lock no longer stale by removal time → NOT removed, no event", () => {
+    const emitted = [];
+    const removed = [];
+    let calls = 0;
+    // First staleLockStatus call (classification) sees the old stale lock;
+    // second call (the pre-removal re-check) sees a brand-new fresh lock —
+    // simulating another process having cleared+restarted git in between.
+    const statFn = (path) => {
+      calls += 1;
+      if (path !== LOCK_PATH) return null;
+      return calls === 1 ? LOCK_NOW - 3_600_000 : LOCK_NOW; // 1h stale, then 0s fresh
+    };
+    const res = clearStaleIndexLock({
+      root: LOCK_ROOT, now: LOCK_NOW, thresholdMs: 600_000,
+      emitFn: (e) => emitted.push(e),
+      statFn,
+      rmFn: (p) => removed.push(p),
+    });
+    expect(res.cleared).toBe(false);
+    expect(removed).toEqual([]);
+    expect(emitted).toEqual([]);
+    expect(calls).toBeGreaterThanOrEqual(2); // both the classification and the re-check ran
+  });
+
+  test("re-check race: lock disappears entirely by removal time (already cleared) → NOT removed, no event", () => {
+    const emitted = [];
+    const removed = [];
+    let calls = 0;
+    const statFn = (path) => {
+      calls += 1;
+      if (path !== LOCK_PATH) return null;
+      return calls === 1 ? LOCK_NOW - 3_600_000 : null; // stale, then gone
+    };
+    const res = clearStaleIndexLock({
+      root: LOCK_ROOT, now: LOCK_NOW, thresholdMs: 600_000,
+      emitFn: (e) => emitted.push(e),
+      statFn,
+      rmFn: (p) => removed.push(p),
+    });
+    expect(res.cleared).toBe(false);
+    expect(removed).toEqual([]);
+    expect(emitted).toEqual([]);
+  });
 });
 
 describe("refreshPluginCheckout — stale-lock pre-pull clear (CTL-1415)", () => {

--- a/plugins/dev/scripts/execution-core/doctor.mjs
+++ b/plugins/dev/scripts/execution-core/doctor.mjs
@@ -68,6 +68,7 @@ import { assertSdkAuth } from "./sdk-run-phase-agent.mjs";
 // (pure, no-I/O) shared with the Phase-1 config-schema tests. Lives in
 // plugins/dev/scripts/lib/ (sibling of execution-core/).
 import { validateLayer1Config, RELOCATED_LAYER1_KEYS } from "../lib/validate-catalyst-config.mjs";
+import { staleLockStatus, indexLockPath, STALE_LOCK_THRESHOLD_MS } from "../lib/stale-lock.mjs"; // CTL-1415
 
 // readLinearBotUserIds — inlined from daemon.mjs to avoid pulling in the full
 // daemon dependency chain (which includes bun: protocol imports incompatible
@@ -2953,6 +2954,36 @@ export function checkPluginPullOwner(deps = {}) {
   ];
 }
 
+// checkStaleLock — CTL-1415: a stale `.git/index.lock` in the node's plugin-source
+// checkout silently freezes every plugin pull (a crashed git op leaves the lock;
+// each later `git reset --hard` then fails forever — the ~8.5h laptop freeze in
+// CTL-1401). doctor REPORTS the frozen state so the node isn't silently stuck on
+// stale plugins; the updater/broker pull path (broker/plugin-refresh.mjs) is what
+// auto-clears it. Age-gated via the SHARED lib/stale-lock.mjs classifier, so the
+// "safe age" can't drift from what the pull path clears, and a live git op (a
+// fresh lock) is reported as in-progress, never flagged.
+export function checkStaleLock(deps = {}) {
+  const {
+    root = process.env.CATALYST_PLUGIN_SOURCE || resolve(homedir(), "catalyst", "plugin-source"),
+    now = Date.now(),
+    thresholdMs = STALE_LOCK_THRESHOLD_MS,
+    statFn,
+  } = deps;
+  const s = staleLockStatus({ root, now, thresholdMs, statFn });
+  if (!s.present) {
+    return [mkCheck("stale-plugin-lock", STATUS.PASS, `no stale git index.lock in plugin-source (${root})`)];
+  }
+  if (!s.stale) {
+    const secs = Math.round(s.ageMs / 1000);
+    const thSecs = Math.round(thresholdMs / 1000);
+    return [mkCheck("stale-plugin-lock", STATUS.PASS, `a git operation is in progress in plugin-source (index.lock ${secs}s old < ${thSecs}s threshold) — not stale`)];
+  }
+  const mins = Math.round(s.ageMs / 60000);
+  const thMins = Math.round(thresholdMs / 60000);
+  return [mkCheck("stale-plugin-lock", STATUS.WARN,
+    `stale .git/index.lock in plugin-source (age ~${mins}m ≥ ${thMins}m threshold) — plugin pulls are FROZEN until it clears; the updater/broker auto-clears it on its next pull (CTL-1415), or remove ${indexLockPath(root)} by hand`)];
+}
+
 // ─── Suite selection ─────────────────────────────────────────────────────────
 
 // checksForClass — build the check-thunk suite for a resolved node class. This is
@@ -2996,6 +3027,8 @@ export function checksForClass(nc, opts = {}) {
   // post-install verification (fail-closed). Seams (undefined in production) fall through to defaults.
   const agentsThunk = () => checkAgentsForClass({ nodeClass: nc.class, strict, hasStackAgent, hasUpdaterAgent });
   const pullOwnerThunk = () => checkPluginPullOwner({ nodeClass: nc.class, strict, owner: pluginPullOwner });
+  // CTL-1415: a stale plugin-source .git/index.lock freezes pulls on ANY node class.
+  const staleLockThunk = () => checkStaleLock();
 
   const replicaThunk = () => checkReadReplicaReachable({ baseUrl: readReplicaBaseUrl, fetch: _fetch });
   const wontOwnThunk = () =>
@@ -3045,6 +3078,7 @@ export function checksForClass(nc, opts = {}) {
       () => checkDaemonlessLocal({ nodeClass: nc.class, runVerifyNode }), // broker/exec-core down + plugins fresh
       agentsThunk, // CTL-1369 PR4: updater agent installed, no worker stack (correct class agent set)
       pullOwnerThunk, // CTL-1369 PR4: pluginPullOwner=updater (a developer runs no broker)
+      staleLockThunk, // CTL-1415: a stale plugin-source index.lock silently freezes the updater's pulls
       replicaThunk,
       wontOwnThunk,
       () => checkReaper(), // advisory (never FAIL), class-agnostic
@@ -3069,6 +3103,7 @@ export function checksForClass(nc, opts = {}) {
       () => checkHrwPartition(), // would-own count (visibility)
       agentsThunk, // CTL-1369 PR4: updater agent installed, no worker stack (monitor is adopt-updater-shaped)
       pullOwnerThunk, // CTL-1369 PR4: pluginPullOwner=updater
+      staleLockThunk, // CTL-1415: a stale plugin-source index.lock silently freezes the updater's pulls
       replicaThunk,
       wontOwnThunk,
       () => [
@@ -3096,6 +3131,7 @@ export function checksForClass(nc, opts = {}) {
     () => checkDaemonToolPath(), // CTL-1289: daemon launchd PATH resolves linearis/node/claude
     agentsThunk, // CTL-1369 PR4: worker work-stack agent installed, no updater agent (correct class agent set)
     pullOwnerThunk, // CTL-1369 PR4: pluginPullOwner=broker (the worker's broker owns the pull)
+    staleLockThunk, // CTL-1415: a stale plugin-source index.lock silently freezes the broker's pulls
     () => checkWebhookIngestion(), // CTL-1284: multiHost member ingests webhooks; single-host does not
     () => checkThoughts(), // CTL-1293: member thoughts repo provisioned + non-foreign primary
     () => checkClaudeSettings(), // CTL-1231: member settings.json pins host identity + OTLP endpoint

--- a/plugins/dev/scripts/execution-core/doctor.mjs
+++ b/plugins/dev/scripts/execution-core/doctor.mjs
@@ -4469,26 +4469,48 @@ export function checkPluginSourceFreshness(deps = {}) {
 // auto-clears it. Age-gated via the SHARED lib/stale-lock.mjs classifier, so the
 // "safe age" can't drift from what the pull path clears, and a live git op (a
 // fresh lock) is reported as in-progress, never flagged.
+//
+// Codex P2 (#2530): a checkout provisioned via `setup-plugin-source.sh --path`
+// only persists the custom root through catalyst.orchestration.pluginDirs — it
+// does NOT guarantee CATALYST_PLUGIN_SOURCE is set in doctor's environment. The
+// old hardcoded ~/catalyst/plugin-source default could report "no stale lock"
+// while the ACTUAL configured checkout sat frozen. Resolve the same
+// resolvePluginCheckoutRoots() the adjacent freshness check and the real pull
+// path use (CTL-1421), so this check inspects the checkout(s) that are actually
+// live rather than an unconditional guess. An explicit `root` still wins (tests /
+// single-checkout callers); the historical env/default guess is the last-resort
+// fallback only when nothing resolves at all (no pluginDirs configured).
 export function checkStaleLock(deps = {}) {
   const {
-    root = process.env.CATALYST_PLUGIN_SOURCE || resolve(homedir(), "catalyst", "plugin-source"),
+    root,
+    resolveRootsFn = () => resolvePluginCheckoutRoots({}),
     now = Date.now(),
     thresholdMs = STALE_LOCK_THRESHOLD_MS,
     statFn,
   } = deps;
-  const s = staleLockStatus({ root, now, thresholdMs, statFn });
-  if (!s.present) {
-    return [mkCheck("stale-plugin-lock", STATUS.PASS, `no stale git index.lock in plugin-source (${root})`)];
+  const resolved = root ? [root] : resolveRootsFn();
+  const roots =
+    resolved.length > 0
+      ? resolved
+      : [process.env.CATALYST_PLUGIN_SOURCE || resolve(homedir(), "catalyst", "plugin-source")];
+
+  const statuses = roots.map((r) => ({ r, s: staleLockStatus({ root: r, now, thresholdMs, statFn }) }));
+  const stale = statuses.filter(({ s }) => s.present && s.stale);
+  if (stale.length > 0) {
+    const thMins = Math.round(thresholdMs / 60000);
+    const details = stale
+      .map(({ r, s }) => `${indexLockPath(r)} (~${Math.round(s.ageMs / 60000)}m old)`)
+      .join("; ");
+    return [mkCheck("stale-plugin-lock", STATUS.WARN,
+      `stale .git/index.lock (age ≥ ${thMins}m threshold) — plugin pulls are FROZEN until it clears; the updater/broker auto-clears it on its next pull (CTL-1415), or remove by hand: ${details}`)];
   }
-  if (!s.stale) {
-    const secs = Math.round(s.ageMs / 1000);
+  const inProgress = statuses.find(({ s }) => s.present && !s.stale);
+  if (inProgress) {
+    const secs = Math.round(inProgress.s.ageMs / 1000);
     const thSecs = Math.round(thresholdMs / 1000);
     return [mkCheck("stale-plugin-lock", STATUS.PASS, `a git operation is in progress in plugin-source (index.lock ${secs}s old < ${thSecs}s threshold) — not stale`)];
   }
-  const mins = Math.round(s.ageMs / 60000);
-  const thMins = Math.round(thresholdMs / 60000);
-  return [mkCheck("stale-plugin-lock", STATUS.WARN,
-    `stale .git/index.lock in plugin-source (age ~${mins}m ≥ ${thMins}m threshold) — plugin pulls are FROZEN until it clears; the updater/broker auto-clears it on its next pull (CTL-1415), or remove ${indexLockPath(root)} by hand`)];
+  return [mkCheck("stale-plugin-lock", STATUS.PASS, `no stale git index.lock in plugin-source (${roots.join(", ")})`)];
 }
 
 // ─── Suite selection ─────────────────────────────────────────────────────────

--- a/plugins/dev/scripts/execution-core/doctor.mjs
+++ b/plugins/dev/scripts/execution-core/doctor.mjs
@@ -88,6 +88,7 @@ import { assertSdkAuth } from "./sdk-run-phase-agent.mjs";
 // plugins/dev/scripts/lib/ (sibling of execution-core/).
 import { validateLayer1Config, RELOCATED_LAYER1_KEYS } from "../lib/validate-catalyst-config.mjs";
 import { resolvePluginCheckoutRoots } from "../broker/plugin-refresh.mjs"; // CTL-1421: same resolver the workers use
+import { staleLockStatus, indexLockPath, STALE_LOCK_THRESHOLD_MS } from "../lib/stale-lock.mjs"; // CTL-1415
 
 // readLinearBotUserIds — inlined from daemon.mjs to avoid pulling in the full
 // daemon dependency chain (which includes bun: protocol imports incompatible
@@ -4460,6 +4461,36 @@ export function checkPluginSourceFreshness(deps = {}) {
   return [classifyPluginSourceFreshness({ roots, healthByRoot, nodeClass })];
 }
 
+// checkStaleLock — CTL-1415: a stale `.git/index.lock` in the node's plugin-source
+// checkout silently freezes every plugin pull (a crashed git op leaves the lock;
+// each later `git reset --hard` then fails forever — the ~8.5h laptop freeze in
+// CTL-1401). doctor REPORTS the frozen state so the node isn't silently stuck on
+// stale plugins; the updater/broker pull path (broker/plugin-refresh.mjs) is what
+// auto-clears it. Age-gated via the SHARED lib/stale-lock.mjs classifier, so the
+// "safe age" can't drift from what the pull path clears, and a live git op (a
+// fresh lock) is reported as in-progress, never flagged.
+export function checkStaleLock(deps = {}) {
+  const {
+    root = process.env.CATALYST_PLUGIN_SOURCE || resolve(homedir(), "catalyst", "plugin-source"),
+    now = Date.now(),
+    thresholdMs = STALE_LOCK_THRESHOLD_MS,
+    statFn,
+  } = deps;
+  const s = staleLockStatus({ root, now, thresholdMs, statFn });
+  if (!s.present) {
+    return [mkCheck("stale-plugin-lock", STATUS.PASS, `no stale git index.lock in plugin-source (${root})`)];
+  }
+  if (!s.stale) {
+    const secs = Math.round(s.ageMs / 1000);
+    const thSecs = Math.round(thresholdMs / 1000);
+    return [mkCheck("stale-plugin-lock", STATUS.PASS, `a git operation is in progress in plugin-source (index.lock ${secs}s old < ${thSecs}s threshold) — not stale`)];
+  }
+  const mins = Math.round(s.ageMs / 60000);
+  const thMins = Math.round(thresholdMs / 60000);
+  return [mkCheck("stale-plugin-lock", STATUS.WARN,
+    `stale .git/index.lock in plugin-source (age ~${mins}m ≥ ${thMins}m threshold) — plugin pulls are FROZEN until it clears; the updater/broker auto-clears it on its next pull (CTL-1415), or remove ${indexLockPath(root)} by hand`)];
+}
+
 // ─── Suite selection ─────────────────────────────────────────────────────────
 
 // checksForClass — build the check-thunk suite for a resolved node class. This is
@@ -4523,6 +4554,8 @@ export function checksForClass(nc, opts = {}) {
   // CTL-1421: assert the worker plugin path resolves to a healthy pristine plugin-source
   // (else workers silently serve stale marketplace-cache code). worker=FAIL, dev/monitor=WARN.
   const pluginSourceFreshThunk = () => checkPluginSourceFreshness({ nodeClass: nc.class });
+  // CTL-1415: a stale plugin-source .git/index.lock freezes pulls on ANY node class.
+  const staleLockThunk = () => checkStaleLock();
 
   const replicaThunk = () => checkReadReplicaReachable({ baseUrl: readReplicaBaseUrl, fetch: _fetch });
   const wontOwnThunk = () =>
@@ -4581,6 +4614,7 @@ export function checksForClass(nc, opts = {}) {
       agentsThunk, // CTL-1369 PR4: updater agent installed, no worker stack (correct class agent set)
       pullOwnerThunk, // CTL-1369 PR4: pluginPullOwner=updater (a developer runs no broker)
       pluginSourceFreshThunk, // CTL-1421: worker plugin path resolves to a fresh pristine plugin-source (WARN on a developer)
+      staleLockThunk, // CTL-1415: a stale plugin-source index.lock silently freezes the updater's pulls
       replicaThunk,
       wontOwnThunk,
       () => checkReaper(), // advisory (never FAIL), class-agnostic
@@ -4612,6 +4646,7 @@ export function checksForClass(nc, opts = {}) {
       agentsThunk, // CTL-1369 PR4: updater agent installed, no worker stack (monitor is adopt-updater-shaped)
       pullOwnerThunk, // CTL-1369 PR4: pluginPullOwner=updater
       pluginSourceFreshThunk, // CTL-1421: worker plugin path resolves to a fresh pristine plugin-source (WARN on a monitor)
+      staleLockThunk, // CTL-1415: a stale plugin-source index.lock silently freezes the updater's pulls
       replicaThunk,
       wontOwnThunk,
       () => [
@@ -4643,6 +4678,7 @@ export function checksForClass(nc, opts = {}) {
     agentsThunk, // CTL-1369 PR4: worker work-stack agent installed, no updater agent (correct class agent set)
     pullOwnerThunk, // CTL-1369 PR4: pluginPullOwner=broker (the worker's broker owns the pull)
     pluginSourceFreshThunk, // CTL-1421: worker plugin path resolves to a fresh pristine plugin-source (FAIL — the CI/CD executor)
+    staleLockThunk, // CTL-1415: a stale plugin-source index.lock silently freezes the broker's pulls
     () => checkWebhookIngestion(), // CTL-1284: multiHost member ingests webhooks; single-host does not
     () => checkThoughts(), // CTL-1293: member thoughts repo provisioned + non-foreign primary
     () => checkClaudeSettings(), // CTL-1231: member settings.json pins host identity + OTLP endpoint

--- a/plugins/dev/scripts/execution-core/doctor.test.mjs
+++ b/plugins/dev/scripts/execution-core/doctor.test.mjs
@@ -35,6 +35,7 @@ import {
   checkDaemonlessLocal,
   checkAgentsForClass,
   checkPluginPullOwner,
+  checkStaleLock,
   checksForClass,
   installChecksForClass,
   summarize,
@@ -2723,4 +2724,50 @@ describe("checkClusterSecretFreshness", () => {
     });
     expect(code).toBe(0); // WARN, not FAIL
   });
+});
+
+// ─── checkStaleLock (CTL-1415) ───────────────────────────────────────────────
+//
+// A stale plugin-source .git/index.lock silently freezes plugin pulls. doctor
+// REPORTS it (WARN) — age-gated via the shared lib/stale-lock.mjs classifier, so
+// a live git op (fresh lock) reads as in-progress, not a problem.
+describe("checkStaleLock (CTL-1415)", () => {
+  const ROOT = "/co/plugin-source";
+  const LOCK = "/co/plugin-source/.git/index.lock";
+  const NOW = 1_750_000_000_000;
+  const statFor = (mtimeMs) => (path) => (path === LOCK && mtimeMs != null ? mtimeMs : null);
+
+  it("no lock → PASS", () => {
+    const [c] = checkStaleLock({ root: ROOT, now: NOW, statFn: statFor(null) });
+    expect(c.name).toBe("stale-plugin-lock");
+    expect(c.status).toBe(STATUS.PASS);
+    expect(c.detail).toContain("no stale git index.lock");
+  });
+
+  it("fresh lock (live git op) → PASS (in progress, not stale)", () => {
+    const [c] = checkStaleLock({ root: ROOT, now: NOW, thresholdMs: 600_000, statFn: statFor(NOW - 4_000) });
+    expect(c.status).toBe(STATUS.PASS);
+    expect(c.detail).toContain("git operation is in progress");
+  });
+
+  it("stale lock (older than threshold) → WARN with the frozen-pulls guidance", () => {
+    const [c] = checkStaleLock({ root: ROOT, now: NOW, thresholdMs: 600_000, statFn: statFor(NOW - 8.5 * 60 * 60 * 1000) });
+    expect(c.status).toBe(STATUS.WARN);
+    expect(c.detail).toContain("FROZEN");
+    expect(c.detail).toContain(LOCK);
+  });
+
+  it("stale lock is a WARN, never a FAIL (never blocks doctor exit)", () => {
+    const [c] = checkStaleLock({ root: ROOT, now: NOW, thresholdMs: 600_000, statFn: statFor(NOW - 3_600_000) });
+    expect(c.status).not.toBe(STATUS.FAIL);
+  });
+});
+
+describe("checksForClass — checkStaleLock registration (CTL-1415)", () => {
+  const src = (nc, opts = {}) => checksForClass(nc, opts).map((f) => f.toString()).join("\n");
+  for (const cls of ["worker", "developer", "monitor"]) {
+    it(`wires checkStaleLock into the ${cls} suite`, () => {
+      expect(src({ recognized: true, class: cls })).toContain("checkStaleLock()");
+    });
+  }
 });

--- a/plugins/dev/scripts/execution-core/doctor.test.mjs
+++ b/plugins/dev/scripts/execution-core/doctor.test.mjs
@@ -42,6 +42,7 @@ import {
   checkPluginPullOwner,
   checkPluginSourceFreshness,
   classifyPluginSourceFreshness,
+  checkStaleLock,
   checksForClass,
   installChecksForClass,
   summarize,
@@ -4943,6 +4944,52 @@ describe("checksForClass — checkPluginSourceFreshness registration (CTL-1421)"
   for (const cls of ["worker", "developer", "monitor"]) {
     it(`wires checkPluginSourceFreshness into the ${cls} suite`, () => {
       expect(src({ recognized: true, class: cls })).toContain("checkPluginSourceFreshness");
+    });
+  }
+});
+
+// ─── checkStaleLock (CTL-1415) ───────────────────────────────────────────────
+//
+// A stale plugin-source .git/index.lock silently freezes plugin pulls. doctor
+// REPORTS it (WARN) — age-gated via the shared lib/stale-lock.mjs classifier, so
+// a live git op (fresh lock) reads as in-progress, not a problem.
+describe("checkStaleLock (CTL-1415)", () => {
+  const ROOT = "/co/plugin-source";
+  const LOCK = "/co/plugin-source/.git/index.lock";
+  const NOW = 1_750_000_000_000;
+  const statFor = (mtimeMs) => (path) => (path === LOCK && mtimeMs != null ? mtimeMs : null);
+
+  it("no lock → PASS", () => {
+    const [c] = checkStaleLock({ root: ROOT, now: NOW, statFn: statFor(null) });
+    expect(c.name).toBe("stale-plugin-lock");
+    expect(c.status).toBe(STATUS.PASS);
+    expect(c.detail).toContain("no stale git index.lock");
+  });
+
+  it("fresh lock (live git op) → PASS (in progress, not stale)", () => {
+    const [c] = checkStaleLock({ root: ROOT, now: NOW, thresholdMs: 600_000, statFn: statFor(NOW - 4_000) });
+    expect(c.status).toBe(STATUS.PASS);
+    expect(c.detail).toContain("git operation is in progress");
+  });
+
+  it("stale lock (older than threshold) → WARN with the frozen-pulls guidance", () => {
+    const [c] = checkStaleLock({ root: ROOT, now: NOW, thresholdMs: 600_000, statFn: statFor(NOW - 8.5 * 60 * 60 * 1000) });
+    expect(c.status).toBe(STATUS.WARN);
+    expect(c.detail).toContain("FROZEN");
+    expect(c.detail).toContain(LOCK);
+  });
+
+  it("stale lock is a WARN, never a FAIL (never blocks doctor exit)", () => {
+    const [c] = checkStaleLock({ root: ROOT, now: NOW, thresholdMs: 600_000, statFn: statFor(NOW - 3_600_000) });
+    expect(c.status).not.toBe(STATUS.FAIL);
+  });
+});
+
+describe("checksForClass — checkStaleLock registration (CTL-1415)", () => {
+  const src = (nc, opts = {}) => checksForClass(nc, opts).map((f) => f.toString()).join("\n");
+  for (const cls of ["worker", "developer", "monitor"]) {
+    it(`wires checkStaleLock into the ${cls} suite`, () => {
+      expect(src({ recognized: true, class: cls })).toContain("checkStaleLock()");
     });
   }
 });

--- a/plugins/dev/scripts/execution-core/doctor.test.mjs
+++ b/plugins/dev/scripts/execution-core/doctor.test.mjs
@@ -4993,3 +4993,76 @@ describe("checksForClass — checkStaleLock registration (CTL-1415)", () => {
     });
   }
 });
+
+// Codex P2 (#2530): a checkout provisioned via `setup-plugin-source.sh --path`
+// only persists the custom root through pluginDirs config, not
+// CATALYST_PLUGIN_SOURCE — the old hardcoded ~/catalyst/plugin-source default
+// could report "no stale lock" while the ACTUAL configured checkout was frozen.
+// checkStaleLock must resolve the same configured root(s) the adjacent
+// freshness check and the real pull path use.
+describe("checkStaleLock — resolves configured pluginDirs roots (Codex P2, #2530)", () => {
+  const NOW = 1_750_000_000_000;
+
+  it("inspects a resolveRootsFn-provided custom root, not the hardcoded default", () => {
+    const CUSTOM = "/custom/plugin-source";
+    const LOCK = `${CUSTOM}/.git/index.lock`;
+    const [c] = checkStaleLock({
+      now: NOW,
+      thresholdMs: 600_000,
+      resolveRootsFn: () => [CUSTOM],
+      statFn: (path) => (path === LOCK ? NOW - 3_600_000 : null), // 1h stale
+    });
+    expect(c.status).toBe(STATUS.WARN);
+    expect(c.detail).toContain(LOCK);
+  });
+
+  it("no stale lock across multiple resolved roots → PASS listing all roots", () => {
+    const A = "/co/a";
+    const B = "/co/b";
+    const [c] = checkStaleLock({
+      now: NOW,
+      resolveRootsFn: () => [A, B],
+      statFn: () => null,
+    });
+    expect(c.status).toBe(STATUS.PASS);
+    expect(c.detail).toContain(A);
+    expect(c.detail).toContain(B);
+  });
+
+  it("one of several resolved roots is stale → WARN naming that root", () => {
+    const A = "/co/a";
+    const B = "/co/b";
+    const staleLock = `${B}/.git/index.lock`;
+    const [c] = checkStaleLock({
+      now: NOW,
+      thresholdMs: 600_000,
+      resolveRootsFn: () => [A, B],
+      statFn: (path) => (path === staleLock ? NOW - 3_600_000 : null),
+    });
+    expect(c.status).toBe(STATUS.WARN);
+    expect(c.detail).toContain(staleLock);
+  });
+
+  it("an explicit root still overrides resolveRootsFn (single-checkout callers/tests)", () => {
+    const EXPLICIT = "/explicit/root";
+    const IGNORED = "/should/not/be/checked";
+    const [c] = checkStaleLock({
+      root: EXPLICIT,
+      now: NOW,
+      resolveRootsFn: () => [IGNORED],
+      statFn: () => null,
+    });
+    expect(c.detail).toContain(EXPLICIT);
+    expect(c.detail).not.toContain(IGNORED);
+  });
+
+  it("no pluginDirs configured (resolveRootsFn returns []) → falls back to the historical default", () => {
+    const [c] = checkStaleLock({
+      now: NOW,
+      resolveRootsFn: () => [],
+      statFn: () => null,
+    });
+    expect(c.status).toBe(STATUS.PASS);
+    expect(c.detail).toContain("plugin-source");
+  });
+});

--- a/plugins/dev/scripts/lib/stale-lock.mjs
+++ b/plugins/dev/scripts/lib/stale-lock.mjs
@@ -1,0 +1,67 @@
+// stale-lock.mjs — age-gated detection of a stale git index.lock in a plugin
+// checkout (CTL-1415).
+//
+// A git operation that crashes mid-write leaves `.git/index.lock` behind. Every
+// later `git reset --hard` in that checkout then fails with
+// "Unable to create '.../index.lock': File exists" — silently freezing plugin
+// pulls, so the node quietly stays on stale plugins with no signal. During
+// CTL-1401 the laptop sat ~8.5h behind origin/main on exactly this.
+//
+// This module is the ONE age-gate that both consumers share:
+//   - broker/plugin-refresh.mjs   CLEARS the stale lock before it pulls
+//   - execution-core/doctor.mjs   REPORTS the stale-lock condition
+// so the "safe age" threshold can never drift between what the updater clears
+// and what doctor flags.
+//
+// Pure + seam-injected (statFn, now): no real fs/clock is needed to unit-test
+// the classification. Mirrors the ingestion-recency.mjs / plugin-refresh.mjs
+// seam-injection convention.
+
+import { statSync } from "node:fs";
+import { resolve } from "node:path";
+
+// Safe-age threshold. A git op holding index.lock completes in seconds (this
+// repo hard-caps every git call at 20s — CTL-990); a lock older than this was
+// orphaned by a crashed process. 10 min stays well clear of any legitimate op
+// (including a human running git by hand in the checkout) while capping the
+// self-heal latency to roughly one updater poll past the threshold. Far below
+// the multi-hour freeze it heals. Env-overridable.
+export const STALE_LOCK_THRESHOLD_MS =
+  Number(process.env.CATALYST_PLUGIN_STALE_LOCK_MS) || 600_000;
+
+// indexLockPath — the git index lock inside a checkout root.
+export function indexLockPath(root) {
+  return resolve(root, ".git", "index.lock");
+}
+
+// defaultStatFn — mtime epoch-ms of a path, or null when absent/unstattable.
+// Swallows ENOENT (the common "no lock" case) and any other stat error so the
+// classifier is total (never throws).
+function defaultStatFn(path) {
+  try {
+    return statSync(path).mtimeMs;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * staleLockStatus — classify a checkout's index.lock WITHOUT touching it.
+ *
+ * @returns {{present: boolean, ageMs: number|null, stale: boolean}}
+ *   present: a lock file exists
+ *   ageMs:   now - lock mtime, clamped ≥0 for clock skew (null when absent)
+ *   stale:   present AND ageMs >= thresholdMs (safe to clear / worth flagging)
+ */
+export function staleLockStatus({
+  root,
+  now = Date.now(),
+  thresholdMs = STALE_LOCK_THRESHOLD_MS,
+  statFn = defaultStatFn,
+} = {}) {
+  if (!root) return { present: false, ageMs: null, stale: false };
+  const mtimeMs = statFn(indexLockPath(root));
+  if (mtimeMs == null) return { present: false, ageMs: null, stale: false };
+  const ageMs = Math.max(0, now - mtimeMs);
+  return { present: true, ageMs, stale: ageMs >= thresholdMs };
+}

--- a/plugins/dev/scripts/lib/stale-lock.test.mjs
+++ b/plugins/dev/scripts/lib/stale-lock.test.mjs
@@ -1,0 +1,64 @@
+// Tests for stale-lock.mjs (CTL-1415). Run: bun test plugins/dev/scripts/lib/stale-lock.test.mjs
+
+import { describe, test, expect } from "bun:test";
+import { staleLockStatus, indexLockPath, STALE_LOCK_THRESHOLD_MS } from "./stale-lock.mjs";
+
+const NOW = 1_750_000_000_000; // fixed epoch ms
+const ROOT = "/co/plugin-source";
+
+// makeStatFn — a statFn seam returning a fixed mtime for the index.lock path and
+// null (absent) for anything else, mirroring defaultStatFn's ENOENT→null contract.
+function makeStatFn(mtimeMs) {
+  const lock = indexLockPath(ROOT);
+  return (path) => (path === lock && mtimeMs != null ? mtimeMs : null);
+}
+
+describe("indexLockPath", () => {
+  test("resolves <root>/.git/index.lock", () => {
+    expect(indexLockPath(ROOT)).toBe("/co/plugin-source/.git/index.lock");
+  });
+});
+
+describe("staleLockStatus", () => {
+  test("no lock file → not present, not stale", () => {
+    const s = staleLockStatus({ root: ROOT, now: NOW, statFn: makeStatFn(null) });
+    expect(s).toEqual({ present: false, ageMs: null, stale: false });
+  });
+
+  test("fresh lock (younger than threshold) → present but NOT stale (a live git op)", () => {
+    const mtime = NOW - 5_000; // 5s old
+    const s = staleLockStatus({ root: ROOT, now: NOW, thresholdMs: 600_000, statFn: makeStatFn(mtime) });
+    expect(s.present).toBe(true);
+    expect(s.ageMs).toBe(5_000);
+    expect(s.stale).toBe(false);
+  });
+
+  test("lock exactly at the threshold → stale (>= is inclusive)", () => {
+    const mtime = NOW - 600_000;
+    const s = staleLockStatus({ root: ROOT, now: NOW, thresholdMs: 600_000, statFn: makeStatFn(mtime) });
+    expect(s.stale).toBe(true);
+    expect(s.ageMs).toBe(600_000);
+  });
+
+  test("old lock (older than threshold) → stale", () => {
+    const mtime = NOW - 8.5 * 60 * 60 * 1000; // the 8.5h CTL-1401 freeze
+    const s = staleLockStatus({ root: ROOT, now: NOW, thresholdMs: 600_000, statFn: makeStatFn(mtime) });
+    expect(s.present).toBe(true);
+    expect(s.stale).toBe(true);
+  });
+
+  test("future mtime (clock skew) clamps age to 0, never stale/negative", () => {
+    const s = staleLockStatus({ root: ROOT, now: NOW, thresholdMs: 600_000, statFn: makeStatFn(NOW + 10_000) });
+    expect(s.ageMs).toBe(0);
+    expect(s.stale).toBe(false);
+  });
+
+  test("empty/missing root → not present (no throw)", () => {
+    expect(staleLockStatus({ root: "", now: NOW })).toEqual({ present: false, ageMs: null, stale: false });
+    expect(staleLockStatus({ now: NOW })).toEqual({ present: false, ageMs: null, stale: false });
+  });
+
+  test("default threshold is 10 minutes", () => {
+    expect(STALE_LOCK_THRESHOLD_MS).toBe(600_000);
+  });
+});


### PR DESCRIPTION
## What & why

A git operation that crashes mid-write leaves `.git/index.lock` behind. Every later `git reset --hard` in that checkout then fails forever with `Unable to create '.../index.lock': File exists` — **silently freezing the node's plugin pulls**, so it quietly stays on stale plugins with no signal. During CTL-1401 the laptop sat **~8.5h** behind `origin/main` on exactly this.

This is mechanism **(b)** of the deploy-staleness pair from the CTL-1401 handoff. Mechanism (a) — member nodes falling to slow-poll because the auto-pull fast-path never fires without local webhook ingestion — is a downstream consequence of **CTL-1284** and is left there, not duplicated here.

## Approach

One **shared age-gate** so the "safe age" can never drift between the clearer and the reporter:

- **`lib/stale-lock.mjs` (new)** — pure, seam-injected classifier. `staleLockStatus()` → `{present, ageMs, stale}`. Threshold **10 min** (`env CATALYST_PLUGIN_STALE_LOCK_MS`): far above any legitimate git op (this repo hard-caps git calls at 20s, CTL-990) so a live operation is never disturbed, far below the multi-hour freeze it heals.
- **`broker/plugin-refresh.mjs`** — the real-pull path (traversed by **both** the standalone `catalyst-updater` on dev/monitor nodes **and** the broker on workers) calls `clearStaleIndexLock()` before `fetch`/`reset --hard`. Age-gated; emits `plugin.checkout.stale_lock_cleared` (WARN) on removal; **never throws** — a removal failure emits `stale_lock_clear_failed` and the pull still proceeds (failing loudly via `refresh_failed` rather than being masked).
- **`execution-core/doctor.mjs`** — new `checkStaleLock()` registered in all three class suites (worker/developer/monitor) that **REPORTS** a stale lock as WARN, so the frozen state is visible.

## Design decision (flagging for review)

The ticket's technical note says "the updater **and** doctor should age-gate and auto-clear," but the authoritative **Gherkin** assigns the two roles distinctly: the updater *clears the lock and pulls*, and *doctor reports the condition*. I implemented it that way — **updater/pull-path clears, doctor reports** — keeping doctor read-only (consistent with every other doctor check). If you'd prefer doctor to also clear, it's a one-line follow-up (call `clearStaleIndexLock` from the check).

## Tests

- `lib/stale-lock.test.mjs` — 8 tests (absent / fresh / at-threshold / old / clock-skew / empty-root / default threshold).
- `broker/plugin-refresh.test.mjs` — +6 tests (helper: no-lock/fresh/stale/rm-failure; wiring: clears-then-pulls / leaves-fresh-lock).
- `execution-core/doctor.test.mjs` — `checkStaleLock` behavior (PASS/in-progress/WARN, never FAIL) + registration in all 3 class suites.

All new tests pass. One **pre-existing, unrelated** failure remains in `plugin-refresh.test.mjs` (`Cannot find package 'pino'` from `broker/config.mjs`) — confirmed identical with this change stashed; it's a local `node_modules` gap, resolved in CI.

Closes CTL-1415.

🤖 Generated with [Claude Code](https://claude.com/claude-code)