### PR TITLE
fix(dev): CTL-1418 — quiet catalyst-agent's pino-unavailable shim notice

### DIFF
--- a/plugins/dev/scripts/catalyst-agent/config.mjs
+++ b/plugins/dev/scripts/catalyst-agent/config.mjs
@@ -19,6 +19,17 @@ import { resolve } from "node:path";
 // import in try/catch and substitute a console-shim with the same
 // pino-compatible surface so the agent degrades gracefully instead of aborting
 // at module-load.
+
+// shimNoticeEnabled — CTL-1418: the console-shim IS the expected steady state
+// for the standalone agent (no node_modules → pino unresolvable), so falling
+// back is normal operation, not a fault. The agent is a short-lived one-shot
+// emitter spawned constantly, so emitting the "pino unavailable" notice on every
+// spawn floods the log (6.2k identical lines observed). Only surface it when
+// debug logging is explicitly requested. Pure + exported for unit testing.
+export function shimNoticeEnabled(logLevel = process.env.LOG_LEVEL) {
+  return /^(debug|trace)$/i.test(logLevel ?? "");
+}
+
 let log;
 try {
   const { default: pino } = await import("pino");
@@ -46,9 +57,13 @@ try {
     trace: emit("trace"),
     child: () => log,
   };
-  process.stderr.write(
-    `[catalyst-agent] WARN: pino unavailable (${err?.message ?? err}); using console shim\n`,
-  );
+  // Expected path for the standalone agent — only surface it under debug/trace,
+  // else it floods the log once per spawn (CTL-1418).
+  if (shimNoticeEnabled()) {
+    process.stderr.write(
+      `[catalyst-agent] pino unavailable (${err?.message ?? err}); using console shim\n`,
+    );
+  }
 }
 export { log };
 

--- a/plugins/dev/scripts/catalyst-agent/config.test.mjs
+++ b/plugins/dev/scripts/catalyst-agent/config.test.mjs
@@ -8,7 +8,7 @@
 import { describe, test, expect, beforeEach, afterEach } from "bun:test";
 import { homedir } from "node:os";
 import { resolve } from "node:path";
-import { readAgentConfig, getEventLogPath } from "./config.mjs";
+import { readAgentConfig, getEventLogPath, shimNoticeEnabled } from "./config.mjs";
 
 const ENVS = [
   "CATALYST_AGENT_EMIT",
@@ -177,5 +177,41 @@ describe("getEventLogPath", () => {
     const now = new Date();
     const ym = `${now.getUTCFullYear()}-${String(now.getUTCMonth() + 1).padStart(2, "0")}`;
     expect(p).toBe(resolve("/tmp/ctl812-fake-catalyst", "events", `${ym}.jsonl`));
+  });
+});
+
+// CTL-1418: the pino-unavailable console-shim notice is gated to debug/trace so
+// the standalone agent's expected fallback path doesn't flood the log per spawn.
+describe("shimNoticeEnabled — CTL-1418 log-spam gate", () => {
+  test("debug / trace → notice enabled (case-insensitive)", () => {
+    expect(shimNoticeEnabled("debug")).toBe(true);
+    expect(shimNoticeEnabled("trace")).toBe(true);
+    expect(shimNoticeEnabled("DEBUG")).toBe(true);
+    expect(shimNoticeEnabled("Trace")).toBe(true);
+  });
+  test("info / warn / error / unknown → notice suppressed (the steady state)", () => {
+    expect(shimNoticeEnabled("info")).toBe(false);
+    expect(shimNoticeEnabled("warn")).toBe(false);
+    expect(shimNoticeEnabled("error")).toBe(false);
+    expect(shimNoticeEnabled("verbose")).toBe(false);
+  });
+  test("unset / empty → suppressed (default operation is quiet)", () => {
+    expect(shimNoticeEnabled(undefined)).toBe(false);
+    expect(shimNoticeEnabled("")).toBe(false);
+    expect(shimNoticeEnabled(null)).toBe(false);
+  });
+  test("reads process.env.LOG_LEVEL when no arg passed", () => {
+    const saved = process.env.LOG_LEVEL;
+    try {
+      process.env.LOG_LEVEL = "debug";
+      expect(shimNoticeEnabled()).toBe(true);
+      process.env.LOG_LEVEL = "info";
+      expect(shimNoticeEnabled()).toBe(false);
+      delete process.env.LOG_LEVEL;
+      expect(shimNoticeEnabled()).toBe(false);
+    } finally {
+      if (saved === undefined) delete process.env.LOG_LEVEL;
+      else process.env.LOG_LEVEL = saved;
+    }
   });
 });


### PR DESCRIPTION
## What & why

The standalone `catalyst-agent` ships with no `node_modules`, so `import pino` is unresolvable and `config.mjs` falls back to a console-shim logger (CTL-578, **by design** — graceful degradation). But the catch block wrote `[catalyst-agent] WARN: pino unavailable … using console shim` to stderr on **every process start**, and the agent is a short-lived one-shot emitter spawned constantly — so the *expected* path floods the log: **6,219 identical lines** in one laptop's `catalyst-agent.log`, and present fleet-wide (both minis).

Functionally benign — OTLP telemetry emission is a separate path and is unaffected; this governs only the agent's own logger. Pure logging-hygiene noise, not a runtime error.

## Fix

Gate the shim notice behind `LOG_LEVEL=debug|trace` via a new exported pure helper `shimNoticeEnabled()`, since the console-shim IS the expected steady state for the standalone agent. Default operation is now quiet; the notice is still discoverable when debugging.

```gherkin
Scenario: The standalone agent uses its console-shim quietly
  Given catalyst-agent runs standalone with no node_modules (pino unresolvable — the expected path)
  When the agent starts and falls back to the console-shim logger
  Then it does NOT emit a notice line unless debug logging is enabled (LOG_LEVEL=debug|trace)
```

## Tests

`config.test.mjs` +4 tests on `shimNoticeEnabled`: debug/trace→on (case-insensitive); info/warn/error/verbose→off; unset/empty/null→off; reads `process.env.LOG_LEVEL`. Full `catalyst-agent` config suite green (23 pass).

Closes CTL-1418.

🤖 Generated with [Claude Code](https://claude.com/claude-code)