### PR TITLE
fix(dev): CTL-1416 — bash-3.2-safe emit-complete session-end + hermetic thoughts fixture for its tests

### DIFF
--- a/plugins/dev/scripts/__tests__/phase-agent-emit-complete.test.sh
+++ b/plugins/dev/scripts/__tests__/phase-agent-emit-complete.test.sh
@@ -56,6 +56,30 @@ fresh_env() {
 	export CATALYST_SESSION_ID="sess_test_${tag}"
 }
 
+# CTL-1416: hermetic thoughts fixture. The CTL-1081 artifact self-check in
+# phase-agent-emit-complete downgrades research/plan `complete`→`failed` when no
+# gate-visible doc exists under thoughts/shared/<research|plans>. The six tests
+# that run research/CTL-100/complete below historically relied on the developer's
+# *wired* thoughts symlinks incidentally containing a CTL-100-matching doc, so they
+# failed in a bare `git worktree add`. This helper seeds a synthetic own-phase
+# artifact into a per-test scratch project dir and echoes that dir; callers run the
+# emit from inside it via `(cd "$dir" && …)`. Mirrors tests 39/40 (CTL-1081) and
+# 43/44 (CTL-1097). Bash-3.2 safe.
+seed_thoughts_project() {
+	local proj="$1" phase="$2" ticket="$3" sub lc
+	case "$phase" in
+	research) sub="thoughts/shared/research" ;;
+	plan) sub="thoughts/shared/plans" ;;
+	*) sub="" ;;
+	esac
+	if [[ -n $sub ]]; then
+		lc="$(printf '%s' "$ticket" | tr '[:upper:]' '[:lower:]')"
+		mkdir -p "${proj}/${sub}"
+		: >"${proj}/${sub}/2026-07-02-${lc}-fixture.md"
+	fi
+	printf '%s\n' "$proj"
+}
+
 # Read the phase event line from this test's event log. catalyst-session.sh end
 # (which the emit script also invokes) appends session.ended + agent.checkout
 # lines after, so we grep for the phase event prefix instead of tailing.
@@ -72,7 +96,8 @@ read_event_line() {
 
 echo "Test 1: phase-complete emitter writes the canonical event shape"
 fresh_env t1
-"$EMIT_SCRIPT" --phase research --ticket CTL-100 --status complete >/dev/null 2>&1
+PROJ_DIR="$(seed_thoughts_project "${TEST_DIR}/proj" research CTL-100)"
+(cd "$PROJ_DIR" && "$EMIT_SCRIPT" --phase research --ticket CTL-100 --status complete >/dev/null 2>&1)
 LINE=$(read_event_line)
 if [[ -z $LINE ]]; then
 	fail "Test 1: no event line emitted"
@@ -123,7 +148,8 @@ echo "Test 4 (bonus): signal file is updated to status=done on complete"
 fresh_env t4
 SIGNAL="${CATALYST_ORCHESTRATOR_DIR}/workers/CTL-100/phase-research.json"
 echo '{"status":"in-progress","ticket":"CTL-100","phase":"research"}' >"$SIGNAL"
-"$EMIT_SCRIPT" --phase research --ticket CTL-100 --status complete >/dev/null 2>&1
+PROJ_DIR="$(seed_thoughts_project "${TEST_DIR}/proj" research CTL-100)"
+(cd "$PROJ_DIR" && "$EMIT_SCRIPT" --phase research --ticket CTL-100 --status complete >/dev/null 2>&1)
 NEW_STATUS=$(jq -r '.status' "$SIGNAL")
 HAS_COMPLETED=$(jq -r 'has("completedAt")' "$SIGNAL")
 assert_eq "done" "$NEW_STATUS" "signal file status updated to done"
@@ -492,9 +518,10 @@ fresh_env t29
 SIGNAL="${CATALYST_ORCHESTRATOR_DIR}/workers/CTL-100/phase-research.json"
 echo '{"status":"running","ticket":"CTL-100","phase":"research"}' >"$SIGNAL"
 # Drop the env var to reproduce the dropped-prefix bg worker; supply --orch-dir.
-env -u CATALYST_ORCHESTRATOR_DIR "$EMIT_SCRIPT" \
+PROJ_DIR="$(seed_thoughts_project "${TEST_DIR}/proj" research CTL-100)"
+(cd "$PROJ_DIR" && env -u CATALYST_ORCHESTRATOR_DIR "$EMIT_SCRIPT" \
 	--phase research --ticket CTL-100 --status complete \
-	--orch-dir "${TEST_DIR}/orch" >/dev/null 2>&1
+	--orch-dir "${TEST_DIR}/orch" >/dev/null 2>&1)
 NEW_STATUS=$(jq -r '.status' "$SIGNAL" 2>/dev/null)
 HAS_COMPLETED=$(jq -r 'has("completedAt")' "$SIGNAL" 2>/dev/null)
 assert_eq "done" "$NEW_STATUS" "--orch-dir flips signal to done with env unset"
@@ -521,7 +548,8 @@ echo "Test 31 (CTL-700 D): event payload omits failure_reason on --status comple
 fresh_env t31
 SIGNAL="${CATALYST_ORCHESTRATOR_DIR}/workers/CTL-100/phase-research.json"
 echo '{"status":"running","ticket":"CTL-100","phase":"research"}' >"$SIGNAL"
-"$EMIT_SCRIPT" --phase research --ticket CTL-100 --status complete --reason "should be dropped" >/dev/null 2>&1
+PROJ_DIR="$(seed_thoughts_project "${TEST_DIR}/proj" research CTL-100)"
+(cd "$PROJ_DIR" && "$EMIT_SCRIPT" --phase research --ticket CTL-100 --status complete --reason "should be dropped" >/dev/null 2>&1)
 LINE=$(read_event_line)
 HAS_REASON=$(echo "$LINE" | jq -r '.body.payload | has("failure_reason")')
 assert_eq "false" "$HAS_REASON" "failure_reason absent from event payload on complete"
@@ -531,7 +559,8 @@ echo "Test 32 (CTL-700 D): signal file gets failureReason=null on --status compl
 fresh_env t32
 SIGNAL="${CATALYST_ORCHESTRATOR_DIR}/workers/CTL-100/phase-research.json"
 echo '{"status":"running","ticket":"CTL-100","phase":"research"}' >"$SIGNAL"
-"$EMIT_SCRIPT" --phase research --ticket CTL-100 --status complete --reason "should be dropped" >/dev/null 2>&1
+PROJ_DIR="$(seed_thoughts_project "${TEST_DIR}/proj" research CTL-100)"
+(cd "$PROJ_DIR" && "$EMIT_SCRIPT" --phase research --ticket CTL-100 --status complete --reason "should be dropped" >/dev/null 2>&1)
 FAILURE_REASON=$(jq -r '.failureReason' "$SIGNAL" 2>/dev/null)
 assert_eq "null" "$FAILURE_REASON" "signal .failureReason is null on complete"
 
@@ -540,7 +569,8 @@ echo "Test 33 (CTL-700 D): signal clears a stale failureReason on --status compl
 fresh_env t33
 SIGNAL="${CATALYST_ORCHESTRATOR_DIR}/workers/CTL-100/phase-research.json"
 echo '{"status":"running","ticket":"CTL-100","phase":"research","failureReason":"leftover_from_failed_attempt"}' >"$SIGNAL"
-"$EMIT_SCRIPT" --phase research --ticket CTL-100 --status complete >/dev/null 2>&1
+PROJ_DIR="$(seed_thoughts_project "${TEST_DIR}/proj" research CTL-100)"
+(cd "$PROJ_DIR" && "$EMIT_SCRIPT" --phase research --ticket CTL-100 --status complete >/dev/null 2>&1)
 FAILURE_REASON=$(jq -r '.failureReason' "$SIGNAL" 2>/dev/null)
 assert_eq "null" "$FAILURE_REASON" "stale failureReason cleared to null on complete"
 
@@ -729,7 +759,8 @@ fi
 echo ""
 echo "Test 47 (CTL-1410): absent --payload-json → byte-identical default payload (no phase_name)"
 fresh_env t47
-"$EMIT_SCRIPT" --phase research --ticket CTL-100 --status complete >/dev/null 2>&1
+PROJ_DIR="$(seed_thoughts_project "${TEST_DIR}/proj" research CTL-100)"
+(cd "$PROJ_DIR" && "$EMIT_SCRIPT" --phase research --ticket CTL-100 --status complete >/dev/null 2>&1)
 LINE=$(read_event_line)
 PAYLOAD_KEYS=$(echo "$LINE" | jq -cS '.body.payload | keys')
 assert_eq '["phase","status","ticket"]' "$PAYLOAD_KEYS" "default payload keys unchanged (no phase_name leak)"

--- a/plugins/dev/scripts/phase-agent-emit-complete
+++ b/plugins/dev/scripts/phase-agent-emit-complete
@@ -475,7 +475,7 @@ if [[ -n $SESSION_ID ]] && [[ -x "${SCRIPT_DIR}/catalyst-session.sh" ]]; then
 		REASON_FLAG=(--reason "turn-cap-exhausted")
 	fi
 	"${SCRIPT_DIR}/catalyst-session.sh" end "$SESSION_ID" \
-		--status "$SESSION_OUTCOME" "${REASON_FLAG[@]}" >/dev/null 2>&1 ||
+		--status "$SESSION_OUTCOME" "${REASON_FLAG[@]+"${REASON_FLAG[@]}"}" >/dev/null 2>&1 ||
 		warn "catalyst-session.sh end failed for $SESSION_ID"
 fi
 


### PR DESCRIPTION
<!-- Auto-generated: 2026-07-02T03:38:24Z -->
<!-- Last updated: 2026-07-02T03:38:24Z -->
<!-- PR: #2535 -->
<!-- Previous commits: 534e0fdb67d905c8f08d70a899b14801e9c58331,c0144dfdaf9c51808c0a8e33b31fa50ad67f34fe -->

## Summary

CTL-1416 hardens `phase-agent-emit-complete` against **bash 3.2** — the default shell on the phase-agent host (macOS `mini-2`). Two problems surface only on bash 3.2 and only in a clean checkout:

1. **rc=1 + skipped session-end on no-reason completions.** The session-end block expanded an empty `"${REASON_FLAG[@]}"` under `set -u`. On bash 3.2 that is an "unbound variable" abort, so `catalyst-session.sh end` was silently skipped and the script returned non-zero on every no-`--reason` complete/skipped/park/failed path.
2. **Non-deterministic test suite.** Seven emit tests ran `research/CTL-100/complete` from the process cwd and relied on the developer's *wired* `thoughts/` symlinks incidentally exposing a CTL-100-matching research doc. In a bare `git worktree add` (CI / fresh checkout) the CTL-1081 artifact self-check downgraded `complete`→`failed` (`reason=artifact_not_gate_visible`) and the tests failed.

## Changes Made

**Production fix** — `plugins/dev/scripts/phase-agent-emit-complete`
- Replaced `"${REASON_FLAG[@]}"` with the standard guarded expansion `"${REASON_FLAG[@]+"${REASON_FLAG[@]}"}"` in the `catalyst-session.sh end` call. Behavior-identical on bash ≥ 4; on bash 3.2 the empty array now expands to nothing instead of aborting. This was the sole `[@]` site in the script.

**Test hardening** — `plugins/dev/scripts/__tests__/phase-agent-emit-complete.test.sh`
- Added a bash-3.2-safe `seed_thoughts_project` helper that seeds a synthetic own-phase artifact under `thoughts/shared/<research|plans>/` in a per-test scratch dir and echoes that dir.
- Rewired the seven affected emit tests (1, 4, 29, 31, 32, 33, 47) to run from inside the scratch dir via `(cd "$dir" && …)`, so the CTL-1081 artifact self-check sees a gate-visible doc regardless of the developer's `thoughts/` symlinks. Mirrors the already-hermetic tests 39/40 (CTL-1081) and 43/44 (CTL-1097). Test-only; no production behavior change.

## How to Verify It

- [x] Full emit-complete suite passes on the target shell: `bash plugins/dev/scripts/__tests__/phase-agent-emit-complete.test.sh` → **98 passed, 0 failed** on GNU bash 3.2.57 (arm64-apple-darwin) — the exact phase-agent host condition. Test 17 (park) and tests 1/4/29/31/32/33/47 (previously flaky in a bare worktree) all pass.

## Related Issues/PRs

- Fixes https://linear.app/coalesce/issue/CTL-1416

## Changelog Entry

fix(dev): CTL-1416 — make `phase-agent-emit-complete` bash-3.2-safe (guarded empty-array expansion in the session-end block) and give its emit tests a hermetic thoughts fixture so they pass in a bare worktree.
