### PR TITLE
fix(dev): CTL-1420 — unfreeze fleet admission during a Linear quota storm

### DIFF
--- a/plugins/dev/scripts/execution-core/fleet-freeze-alert.mjs
+++ b/plugins/dev/scripts/execution-core/fleet-freeze-alert.mjs
@@ -1,0 +1,132 @@
+// fleet-freeze-alert.mjs — CTL-1420. A fleet-frozen-for-admission alert.
+//
+// When EVERY registered team's reconcile is in a persistent-failure (alerting)
+// state at once, the eligible projection cannot be refreshed from either source:
+// the local Linear replica is unavailable (stale/absent → the reader returns
+// undefined) AND the live Linear API is unreachable (the CTL-679 breaker is
+// pinned open). New work then cannot be admitted fleet-wide until one source
+// recovers. The CTL-1420 surface-(a) fix keeps a FRESH replica serving during a
+// quota storm, so this alert fires only for the residual DOUBLE outage (no fresh
+// replica AND no quota) — which used to fail silently (reconcileProject just
+// preserves the empty prior set). This makes it LOUD.
+//
+// Emits, mirroring reconcile-health-event.mjs (OTel envelope, appendFileSync,
+// never throws), onto the SAME catalyst.alert.* topic the broker uses for its own
+// alerts (broker/alert-emit.mjs), so the existing alert consumer picks it up:
+//   catalyst.alert.raised   (event.label=fleet_frozen_admission, WARN)
+//   catalyst.alert.cleared  (INFO)
+// Attribution is catalyst.execution-core (the monitor observed the freeze),
+// consistent with the "alerting decoupled via Loki" design and the established
+// execution-core precedent (reconcile-health-event.mjs): emit intent to the
+// unified event log; a separate consumer delivers. A distinct service.name (not
+// catalyst.broker) also means the broker's own self-filter does not drop it.
+import { randomBytes } from "node:crypto";
+import { appendFileSync, mkdirSync } from "node:fs";
+import { dirname } from "node:path";
+import { getEventLogPath, log } from "./config.mjs";
+import { buildCatalystResource } from "./lib/catalyst-resource.mjs";
+
+// Same topic + kind taxonomy as broker/alert-emit.mjs (event.name is the fixed
+// raised/cleared topic; the kind differentiator lives in event.label).
+export const ALERT_RAISED = "catalyst.alert.raised";
+export const ALERT_CLEARED = "catalyst.alert.cleared";
+export const ALERT_KIND_FLEET_FROZEN_ADMISSION = "fleet_frozen_admission";
+
+// Module-scoped latch so the alert fires exactly once per raised→cleared
+// transition (mirrors reconcile-health's per-team `alerting` latch, fleet-wide).
+let _fleetFrozenRaised = false;
+
+// __resetFleetFreezeLatch — test seam so latch state never leaks across tests.
+export function __resetFleetFreezeLatch() {
+  _fleetFrozenRaised = false;
+}
+
+// isFleetFrozenRaised — introspection (test/telemetry only).
+export function isFleetFrozenRaised() {
+  return _fleetFrozenRaised;
+}
+
+// defaultAppend — writes a JSONL line to the canonical event log (same path the
+// broker + every other execution-core emitter appends to).
+function defaultAppend(line) {
+  const logPath = getEventLogPath();
+  mkdirSync(dirname(logPath), { recursive: true });
+  appendFileSync(logPath, line);
+}
+
+// buildFleetFreezeAlertEvent — canonical JSONL line (string + "\n") for the
+// fleet-frozen-admission alert. `action` is "raised" (WARN) or "cleared" (INFO).
+export function buildFleetFreezeAlertEvent({ action, teams = [], reason = null } = {}) {
+  const ts = new Date().toISOString().replace(/\.\d{3}Z$/, "Z");
+  const raised = action === "raised";
+  return (
+    JSON.stringify({
+      ts,
+      id: randomBytes(8).toString("hex"),
+      observedTs: ts,
+      severityText: raised ? "WARN" : "INFO",
+      severityNumber: raised ? 13 : 9,
+      traceId: randomBytes(16).toString("hex"),
+      spanId: randomBytes(8).toString("hex"),
+      resource: buildCatalystResource({ serviceName: "catalyst.execution-core" }),
+      attributes: {
+        "event.name": raised ? ALERT_RAISED : ALERT_CLEARED,
+        "event.entity": "alert",
+        "event.action": action,
+        "event.label": ALERT_KIND_FLEET_FROZEN_ADMISSION,
+      },
+      body: {
+        payload: {
+          kind: ALERT_KIND_FLEET_FROZEN_ADMISSION,
+          reason,
+          source: "catalyst.execution-core",
+          count: teams.length,
+          teams,
+        },
+      },
+    }) + "\n"
+  );
+}
+
+// checkFleetFreeze — evaluate the fleet-frozen-for-admission condition and emit a
+// raised/cleared alert ON A STATE TRANSITION only (latched; idempotent within a
+// state). The fleet is frozen when there is ≥1 registered team AND EVERY team's
+// reconcile is in a persistent-failure state (isTeamFrozen). Best-effort: any
+// emit error is swallowed so a failed alert never crashes the reconcile timer.
+//
+//   teams        — every registered team (e.g. listProjects().map(p => p.team))
+//   isTeamFrozen  — (team) => boolean; true when that team can't refresh eligible
+//   append        — injectable JSONL sink (defaults to the canonical event log)
+//
+// Returns { frozen, emitted } where emitted ∈ {"raised","cleared",null}.
+export function checkFleetFreeze({ teams = [], isTeamFrozen = () => false, append = defaultAppend } = {}) {
+  const frozen = teams.length > 0 && teams.every((t) => isTeamFrozen(t));
+  let emitted = null;
+  try {
+    if (frozen && !_fleetFrozenRaised) {
+      // Append FIRST; flip the latch only on a successful write, so a transient
+      // append failure (disk full) retries next tick instead of silently latching
+      // "raised" with no event ever emitted.
+      append(
+        buildFleetFreezeAlertEvent({
+          action: "raised",
+          teams,
+          reason:
+            "every registered team's reconcile is failing — the eligible projection cannot refresh from the replica or linearis (fleet admission is frozen)",
+        })
+      );
+      _fleetFrozenRaised = true;
+      emitted = "raised";
+      log.error({ teams }, "CTL-1420: fleet FROZEN for admission — all teams' reconcile failing");
+    } else if (!frozen && _fleetFrozenRaised) {
+      append(buildFleetFreezeAlertEvent({ action: "cleared", teams }));
+      _fleetFrozenRaised = false;
+      emitted = "cleared";
+      log.info({ teams }, "CTL-1420: fleet admission UNFROZEN — a team's reconcile recovered");
+    }
+  } catch (err) {
+    // Never throw out of the reconcile timer.
+    log.error?.({ err: err.message }, "CTL-1420: fleet-freeze alert emit failed (continuing)");
+  }
+  return { frozen, emitted };
+}

--- a/plugins/dev/scripts/execution-core/fleet-freeze-alert.mjs
+++ b/plugins/dev/scripts/execution-core/fleet-freeze-alert.mjs
@@ -21,9 +21,9 @@
 // unified event log; a separate consumer delivers. A distinct service.name (not
 // catalyst.broker) also means the broker's own self-filter does not drop it.
 import { randomBytes } from "node:crypto";
-import { appendFileSync, mkdirSync } from "node:fs";
-import { dirname } from "node:path";
-import { getEventLogPath, log } from "./config.mjs";
+import { appendFileSync, mkdirSync, readFileSync, writeFileSync, renameSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { getEventLogPath, getReconcileHealthDir, log } from "./config.mjs";
 import { buildCatalystResource } from "./lib/catalyst-resource.mjs";
 
 // Same topic + kind taxonomy as broker/alert-emit.mjs (event.name is the fixed
@@ -34,11 +34,53 @@ export const ALERT_KIND_FLEET_FROZEN_ADMISSION = "fleet_frozen_admission";
 
 // Module-scoped latch so the alert fires exactly once per raised→cleared
 // transition (mirrors reconcile-health's per-team `alerting` latch, fleet-wide).
+// PERSISTED to disk + hydrated on first use so a daemon RESTART mid-freeze does
+// NOT re-emit `raised` with no intervening `cleared` — a fleet freeze is the
+// residual double-outage state (breaker pinned open + no fresh replica), exactly
+// when restarts (deploy/crash/recovery loop) are most likely. This matches
+// reconcile-health, which was made restart-durable for the same reason.
 let _fleetFrozenRaised = false;
+let _hydrated = false;
+
+// markerPath — the persisted latch marker, alongside the per-team reconcile-health
+// markers (same CATALYST_DIR-scoped dir, so tests isolate via CATALYST_DIR).
+function markerPath() {
+  return join(getReconcileHealthDir(), "fleet-freeze.json");
+}
+
+// hydrate — lazily load the persisted latch on the first check of this process so
+// a restart resumes the prior raised/cleared state. Best-effort: a missing or
+// unreadable marker leaves the latch closed (never throws).
+function hydrate() {
+  if (_hydrated) return;
+  _hydrated = true;
+  try {
+    const raw = readFileSync(markerPath(), "utf8");
+    _fleetFrozenRaised = JSON.parse(raw)?.raised === true;
+  } catch {
+    _fleetFrozenRaised = false; // absent/malformed → closed
+  }
+}
+
+// persist — atomically write the latch so a restart resumes it. Best-effort.
+function persist() {
+  try {
+    const dir = getReconcileHealthDir();
+    mkdirSync(dir, { recursive: true });
+    const tmp = join(dir, `.fleet-freeze.${randomBytes(4).toString("hex")}.tmp`);
+    writeFileSync(tmp, JSON.stringify({ raised: _fleetFrozenRaised, ts: Date.now() }));
+    renameSync(tmp, markerPath());
+  } catch (err) {
+    log.error?.({ err: err.message }, "CTL-1420: fleet-freeze latch persist failed (continuing)");
+  }
+}
 
 // __resetFleetFreezeLatch — test seam so latch state never leaks across tests.
+// Clears both the in-memory latch and the hydration flag so the next check
+// re-reads the (CATALYST_DIR-scoped) marker.
 export function __resetFleetFreezeLatch() {
   _fleetFrozenRaised = false;
+  _hydrated = false;
 }
 
 // isFleetFrozenRaised — introspection (test/telemetry only).
@@ -100,13 +142,22 @@ export function buildFleetFreezeAlertEvent({ action, teams = [], reason = null }
 //
 // Returns { frozen, emitted } where emitted ∈ {"raised","cleared",null}.
 export function checkFleetFreeze({ teams = [], isTeamFrozen = () => false, append = defaultAppend } = {}) {
-  const frozen = teams.length > 0 && teams.every((t) => isTeamFrozen(t));
+  hydrate();
+  // An EMPTY team list is NOT evidence of recovery — it means "no teams to
+  // evaluate", which also happens on a transient unreadable/malformed registry
+  // (listProjects() returns [] instead of throwing). Concluding "not frozen" here
+  // would flap a genuinely-raised latch to `cleared` and re-raise next tick. So an
+  // empty team set is a NO-TRANSITION: preserve the current latch, emit nothing.
+  if (teams.length === 0) {
+    return { frozen: _fleetFrozenRaised, emitted: null };
+  }
+  const frozen = teams.every((t) => isTeamFrozen(t));
   let emitted = null;
   try {
     if (frozen && !_fleetFrozenRaised) {
-      // Append FIRST; flip the latch only on a successful write, so a transient
-      // append failure (disk full) retries next tick instead of silently latching
-      // "raised" with no event ever emitted.
+      // Append FIRST; flip + persist the latch only on a successful write, so a
+      // transient append failure (disk full) retries next tick instead of silently
+      // latching "raised" with no event ever emitted.
       append(
         buildFleetFreezeAlertEvent({
           action: "raised",
@@ -116,11 +167,13 @@ export function checkFleetFreeze({ teams = [], isTeamFrozen = () => false, appen
         })
       );
       _fleetFrozenRaised = true;
+      persist();
       emitted = "raised";
       log.error({ teams }, "CTL-1420: fleet FROZEN for admission — all teams' reconcile failing");
     } else if (!frozen && _fleetFrozenRaised) {
       append(buildFleetFreezeAlertEvent({ action: "cleared", teams }));
       _fleetFrozenRaised = false;
+      persist();
       emitted = "cleared";
       log.info({ teams }, "CTL-1420: fleet admission UNFROZEN — a team's reconcile recovered");
     }

--- a/plugins/dev/scripts/execution-core/fleet-freeze-alert.test.mjs
+++ b/plugins/dev/scripts/execution-core/fleet-freeze-alert.test.mjs
@@ -1,0 +1,119 @@
+// Unit tests for the CTL-1420 fleet-frozen-for-admission alert.
+// Run: cd plugins/dev/scripts/execution-core && bun test fleet-freeze-alert.test.mjs
+
+import { describe, test, expect, beforeEach } from "bun:test";
+import {
+  buildFleetFreezeAlertEvent,
+  checkFleetFreeze,
+  isFleetFrozenRaised,
+  __resetFleetFreezeLatch,
+  ALERT_RAISED,
+  ALERT_CLEARED,
+  ALERT_KIND_FLEET_FROZEN_ADMISSION,
+} from "./fleet-freeze-alert.mjs";
+
+describe("buildFleetFreezeAlertEvent", () => {
+  test("raised: catalyst.alert.raised envelope, WARN, fleet_frozen_admission label, execution-core resource", () => {
+    const line = buildFleetFreezeAlertEvent({ action: "raised", teams: ["CTL", "ADV"], reason: "double outage" });
+    expect(line.endsWith("\n")).toBe(true);
+    const ev = JSON.parse(line);
+    expect(ev.attributes["event.name"]).toBe(ALERT_RAISED);
+    expect(ev.attributes["event.entity"]).toBe("alert");
+    expect(ev.attributes["event.action"]).toBe("raised");
+    expect(ev.attributes["event.label"]).toBe(ALERT_KIND_FLEET_FROZEN_ADMISSION);
+    expect(ev.severityText).toBe("WARN");
+    expect(ev.severityNumber).toBe(13);
+    expect(ev.resource["service.name"]).toBe("catalyst.execution-core");
+    expect(ev.body.payload).toMatchObject({
+      kind: ALERT_KIND_FLEET_FROZEN_ADMISSION,
+      reason: "double outage",
+      count: 2,
+      teams: ["CTL", "ADV"],
+    });
+  });
+
+  test("cleared: catalyst.alert.cleared envelope, INFO", () => {
+    const ev = JSON.parse(buildFleetFreezeAlertEvent({ action: "cleared", teams: ["CTL"] }));
+    expect(ev.attributes["event.name"]).toBe(ALERT_CLEARED);
+    expect(ev.attributes["event.action"]).toBe("cleared");
+    expect(ev.severityText).toBe("INFO");
+    expect(ev.severityNumber).toBe(9);
+  });
+});
+
+describe("checkFleetFreeze", () => {
+  beforeEach(() => __resetFleetFreezeLatch());
+
+  test("ALL teams frozen → raises exactly once (latched), then stays silent while frozen", () => {
+    const lines = [];
+    const append = (l) => lines.push(JSON.parse(l));
+    const opts = { teams: ["CTL", "ADV", "OTL"], isTeamFrozen: () => true, append };
+
+    const r1 = checkFleetFreeze(opts);
+    expect(r1).toEqual({ frozen: true, emitted: "raised" });
+    expect(isFleetFrozenRaised()).toBe(true);
+    expect(lines).toHaveLength(1);
+    expect(lines[0].attributes["event.name"]).toBe(ALERT_RAISED);
+    expect(lines[0].body.payload.teams).toEqual(["CTL", "ADV", "OTL"]);
+
+    // Still frozen next pass → no duplicate emit.
+    const r2 = checkFleetFreeze(opts);
+    expect(r2).toEqual({ frozen: true, emitted: null });
+    expect(lines).toHaveLength(1);
+  });
+
+  test("one team recovers → clears exactly once, then silent", () => {
+    const lines = [];
+    const append = (l) => lines.push(JSON.parse(l));
+    checkFleetFreeze({ teams: ["CTL", "ADV"], isTeamFrozen: () => true, append }); // raise
+    expect(lines).toHaveLength(1);
+
+    // ADV recovers → not all frozen → cleared.
+    const frozenSet = new Set(["CTL"]);
+    const r = checkFleetFreeze({ teams: ["CTL", "ADV"], isTeamFrozen: (t) => frozenSet.has(t), append });
+    expect(r).toEqual({ frozen: false, emitted: "cleared" });
+    expect(lines).toHaveLength(2);
+    expect(lines[1].attributes["event.name"]).toBe(ALERT_CLEARED);
+    expect(isFleetFrozenRaised()).toBe(false);
+
+    // Still not frozen → no duplicate clear.
+    const r2 = checkFleetFreeze({ teams: ["CTL", "ADV"], isTeamFrozen: (t) => frozenSet.has(t), append });
+    expect(r2.emitted).toBe(null);
+    expect(lines).toHaveLength(2);
+  });
+
+  test("partial freeze (some teams healthy) never raises", () => {
+    const lines = [];
+    const frozenSet = new Set(["CTL"]); // ADV healthy
+    const r = checkFleetFreeze({
+      teams: ["CTL", "ADV"],
+      isTeamFrozen: (t) => frozenSet.has(t),
+      append: (l) => lines.push(l),
+    });
+    expect(r).toEqual({ frozen: false, emitted: null });
+    expect(lines).toHaveLength(0);
+  });
+
+  test("empty registry never raises (no teams ⇒ not frozen)", () => {
+    const lines = [];
+    const r = checkFleetFreeze({ teams: [], isTeamFrozen: () => true, append: (l) => lines.push(l) });
+    expect(r).toEqual({ frozen: false, emitted: null });
+    expect(lines).toHaveLength(0);
+  });
+
+  test("a throwing append never propagates, and does NOT latch → the alert retries next tick", () => {
+    const boom = () => {
+      throw new Error("disk full");
+    };
+    expect(() =>
+      checkFleetFreeze({ teams: ["CTL"], isTeamFrozen: () => true, append: boom })
+    ).not.toThrow();
+    // The append failed before the latch flipped, so the freeze is NOT yet
+    // recorded as raised — the next successful pass emits it.
+    expect(isFleetFrozenRaised()).toBe(false);
+    const lines = [];
+    const r = checkFleetFreeze({ teams: ["CTL"], isTeamFrozen: () => true, append: (l) => lines.push(l) });
+    expect(r.emitted).toBe("raised");
+    expect(lines).toHaveLength(1);
+  });
+});

--- a/plugins/dev/scripts/execution-core/fleet-freeze-alert.test.mjs
+++ b/plugins/dev/scripts/execution-core/fleet-freeze-alert.test.mjs
@@ -1,7 +1,10 @@
 // Unit tests for the CTL-1420 fleet-frozen-for-admission alert.
 // Run: cd plugins/dev/scripts/execution-core && bun test fleet-freeze-alert.test.mjs
 
-import { describe, test, expect, beforeEach } from "bun:test";
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import {
   buildFleetFreezeAlertEvent,
   checkFleetFreeze,
@@ -11,6 +14,23 @@ import {
   ALERT_CLEARED,
   ALERT_KIND_FLEET_FROZEN_ADMISSION,
 } from "./fleet-freeze-alert.mjs";
+
+// The latch persists under getReconcileHealthDir() (CATALYST_DIR-scoped), so give
+// each test an isolated CATALYST_DIR — no cross-test marker leakage, no writes to
+// the real ~/catalyst tree.
+let catalystDir;
+let prevCatalystDir;
+beforeEach(() => {
+  prevCatalystDir = process.env.CATALYST_DIR;
+  catalystDir = mkdtempSync(join(tmpdir(), "fleet-freeze-"));
+  process.env.CATALYST_DIR = catalystDir;
+  __resetFleetFreezeLatch(); // clear in-memory latch + force re-hydrate from the fresh (empty) dir
+});
+afterEach(() => {
+  if (prevCatalystDir === undefined) delete process.env.CATALYST_DIR;
+  else process.env.CATALYST_DIR = prevCatalystDir;
+  rmSync(catalystDir, { recursive: true, force: true });
+});
 
 describe("buildFleetFreezeAlertEvent", () => {
   test("raised: catalyst.alert.raised envelope, WARN, fleet_frozen_admission label, execution-core resource", () => {
@@ -94,11 +114,61 @@ describe("checkFleetFreeze", () => {
     expect(lines).toHaveLength(0);
   });
 
-  test("empty registry never raises (no teams ⇒ not frozen)", () => {
+  test("empty registry from a CLOSED latch never raises (no teams to evaluate)", () => {
     const lines = [];
     const r = checkFleetFreeze({ teams: [], isTeamFrozen: () => true, append: (l) => lines.push(l) });
     expect(r).toEqual({ frozen: false, emitted: null });
     expect(lines).toHaveLength(0);
+  });
+
+  // CTL-1420 review finding: a transient empty listProjects() (registry.json
+  // momentarily unreadable/malformed — listProjects returns [] instead of
+  // throwing) must NOT flap a genuinely-raised latch to `cleared`. An empty team
+  // set is a NO-TRANSITION, not evidence of recovery.
+  test("empty team list is a NO-TRANSITION: a RAISED latch survives an empty read (no spurious clear, then re-raise)", () => {
+    const lines = [];
+    const append = (l) => lines.push(JSON.parse(l));
+    checkFleetFreeze({ teams: ["CTL", "ADV"], isTeamFrozen: () => true, append }); // raise
+    expect(lines).toHaveLength(1);
+    expect(isFleetFrozenRaised()).toBe(true);
+
+    // Registry momentarily unreadable → teams=[] → must NOT emit `cleared`.
+    const r = checkFleetFreeze({ teams: [], isTeamFrozen: () => true, append });
+    expect(r).toEqual({ frozen: true, emitted: null }); // latch preserved
+    expect(lines).toHaveLength(1); // no spurious cleared
+    expect(isFleetFrozenRaised()).toBe(true);
+
+    // Registry restored, still frozen → still no duplicate raise.
+    const r2 = checkFleetFreeze({ teams: ["CTL", "ADV"], isTeamFrozen: () => true, append });
+    expect(r2.emitted).toBe(null);
+    expect(lines).toHaveLength(1);
+  });
+
+  // CTL-1420 review finding: the latch is persisted + hydrated, so a daemon
+  // restart mid-freeze does NOT re-emit `raised` with no intervening `cleared`.
+  test("a daemon restart mid-freeze (in-memory reset, marker persists) does NOT re-emit raised", () => {
+    const lines = [];
+    const append = (l) => lines.push(JSON.parse(l));
+    const teams = ["CTL", "ADV"];
+    checkFleetFreeze({ teams, isTeamFrozen: () => true, append }); // raise + persist
+    expect(lines).toHaveLength(1);
+
+    // Simulate a RESTART: the in-memory latch + hydration flag reset, but the
+    // persisted marker (in this test's CATALYST_DIR) survives.
+    __resetFleetFreezeLatch();
+    expect(isFleetFrozenRaised()).toBe(false); // in-memory cleared
+
+    // First post-restart check, still frozen: hydrate reads the marker → already
+    // raised → NO second `raised` emitted.
+    const r = checkFleetFreeze({ teams, isTeamFrozen: () => true, append });
+    expect(r).toEqual({ frozen: true, emitted: null });
+    expect(lines).toHaveLength(1); // still exactly one raised, no duplicate
+    expect(isFleetFrozenRaised()).toBe(true); // hydrated from disk
+
+    // Recovery after restart still clears exactly once.
+    const r2 = checkFleetFreeze({ teams, isTeamFrozen: () => false, append });
+    expect(r2.emitted).toBe("cleared");
+    expect(lines).toHaveLength(2);
   });
 
   test("a throwing append never propagates, and does NOT latch → the alert retries next tick", () => {

--- a/plugins/dev/scripts/execution-core/linear-query.mjs
+++ b/plugins/dev/scripts/execution-core/linear-query.mjs
@@ -931,6 +931,11 @@ export function runEligibleQuery(
     // Injectable clock (defaults to production) so the empty-confirmation cadence
     // is deterministically testable.
     now = Date.now,
+    // CTL-1420: the CTL-679 breaker state, injectable for deterministic tests.
+    // When OPEN, the linearis reconfirm below can only short-circuit — so a
+    // DEFINED replica-empty is trusted instead of freezing admission (see the
+    // empty-path branch). Defaults to the production process-wide breaker.
+    breakerIsOpen = () => linearBreaker.isOpen(),
   } = {}
 ) {
   // CTL-1397: replica-backed board-list tier. Fail-open: a throw out of
@@ -982,8 +987,27 @@ export function runEligibleQuery(
         onSource?.("replica", 0);
         return tickets; // [] — a recently linearis-confirmed empty, trusted (breaker-immune)
       }
-      // No recent confirmation → fall through to the linearis confirm/preserve-prior
-      // path below. Do NOT set the marker here — only a successful EMPTY confirm does.
+      // CTL-1420 (freeze-avoidance): when the CTL-679 breaker is OPEN, the
+      // linearis reconfirm below can only short-circuit (circuit-open) → throw →
+      // reconcileProject preserves the (empty) prior set = a fleet-wide admission
+      // FREEZE for the breaker's entire open window (the observed 4h+ boot freeze:
+      // fresh process, empty marker map, breaker pinned → nothing ever admitted).
+      // A DEFINED replica-empty has already cleared the reader's writer-liveness +
+      // seed-complete cursor + snapshot-consistent gates, so it is a provably-real
+      // "0 eligible" (NOT a mid-reseed truncation). During breaker-open we TRUST it
+      // rather than freeze. The only residual risk is a CTL-139 feed-hole (a team's
+      // rows silently dropped while the writer stays alive) — strictly less bad than
+      // freezing ALL admission fleet-wide, and self-healing: the moment the breaker
+      // closes, the reconfirm path below resumes and re-validates every empty. A
+      // NON-EMPTY replica is always served (above), even during a storm — so this
+      // only ever trusts a genuinely-empty board; real Todo work still dispatches.
+      if (breakerIsOpen()) {
+        onSource?.("replica-empty-breaker-open", 0);
+        return tickets; // [] — trusted under quota exhaustion (freeze-avoidance)
+      }
+      // No recent confirmation AND breaker closed → fall through to the linearis
+      // confirm/preserve-prior path below (cheap: ≤1 confirm/team/window; sets the
+      // marker on a successful empty). Do NOT set the marker here.
     }
     // MISS (undefined) / unconfirmed replica-empty → fall through to the UNCHANGED
     // linearis path below.

--- a/plugins/dev/scripts/execution-core/linear-query.test.mjs
+++ b/plugins/dev/scripts/execution-core/linear-query.test.mjs
@@ -28,6 +28,7 @@ import {
 } from "./linear-query.mjs";
 import { createTicketStateCache } from "./linear-cache.mjs";
 import { isLinearTerminal } from "./terminal-state.mjs"; // CTL-1340: replica-tier terminal assertions
+import { linearBreaker } from "./linear-breaker.mjs"; // CTL-1420: reset the shared breaker singleton between empty-path tests
 
 // A fake exec returning a canned linearis result. `exec(cmd, args)` ->
 // { code, stdout, stderr } — the injectable seam runEligibleQuery uses so a
@@ -230,7 +231,14 @@ describe("runEligibleQuery — replica tier (CTL-1397)", () => {
   // CTL-1397 (3/n): the empty-board re-confirm cadence is module-scoped state —
   // clear it before each test so an empty result is always "due" for re-confirm
   // (the deterministic baseline), regardless of test order.
-  beforeEach(() => __resetEligibleEmptyConfirm());
+  // CTL-1420: the CTL-679 breaker is a process-wide singleton that a prior test
+  // in this file can leave OPEN; the default breakerIsOpen reads it, so reset it
+  // to CLOSED here for a deterministic baseline. Tests that exercise the
+  // breaker-open freeze-avoidance path inject breakerIsOpen:()=>true explicitly.
+  beforeEach(() => {
+    __resetEligibleEmptyConfirm();
+    linearBreaker.recordSuccess(); // → closed (no-op if already closed)
+  });
 
   // A replica stub whose eligible() returns a canned linearis-list-shaped result.
   function replicaReturning(nodes) {
@@ -320,11 +328,17 @@ describe("runEligibleQuery — replica tier (CTL-1397)", () => {
       execCalls.push(clock);
       return { code: 0, stdout: ticketsJson([{ identifier: "CTL-9", state: { name: "Todo" }, priority: 2 }]), stderr: "" };
     };
-    const t1 = runEligibleQuery(query, { exec: mkExec(), replica, now });
+    // CTL-1420: pin the breaker CLOSED — this test exercises the closed-breaker
+    // reconfirm cadence. (The non-empty confirm's default delegate-batch spawn can
+    // 429 and trip the real breaker singleton; without pinning, the 2nd call would
+    // hit the breaker-open freeze-avoidance branch and trust the empty.) A stub
+    // delegateExec also keeps the unit test off the network.
+    const opts = { replica, now, breakerIsOpen: () => false, delegateExec: () => ({ code: 0, stdout: "{}", stderr: "" }) };
+    const t1 = runEligibleQuery(query, { exec: mkExec(), ...opts });
     expect(t1.map((t) => t.identifier)).toEqual(["CTL-9"]); // real board served (hole)
     // 1s later: the non-empty confirm did NOT cache → still falls through (no zeroing).
     clock += 1_000;
-    const t2 = runEligibleQuery(query, { exec: mkExec(), replica, now });
+    const t2 = runEligibleQuery(query, { exec: mkExec(), ...opts });
     expect(execCalls).toHaveLength(2); // linearis called BOTH times — never suppressed
     expect(t2.map((t) => t.identifier)).toEqual(["CTL-9"]);
   });
@@ -363,13 +377,58 @@ describe("runEligibleQuery — replica tier (CTL-1397)", () => {
     expect(exec2.calls).toHaveLength(1);
   });
 
-  test("replica-EMPTY, breaker OPEN (exec short-circuits circuit-open) with no recent confirm → THROWS → preserve prior (never trusts the empty)", () => {
+  // CTL-1420 (freeze-avoidance): the pre-1420 behavior was to THROW here →
+  // reconcileProject preserved the (empty) prior set → a fleet-wide admission
+  // FREEZE for the breaker's whole open window. Now a DEFINED replica-empty
+  // (which already cleared the reader's writer-liveness + seed-complete +
+  // snapshot gates) is TRUSTED during breaker-open instead of freezing. The
+  // linearis reconfirm is never attempted (it could only short-circuit anyway).
+  test("CTL-1420: replica-EMPTY, breaker OPEN, no recent confirm → TRUSTS the fresh replica-empty (no linearis, no throw), onSource('replica-empty-breaker-open', 0)", () => {
     const replica = replicaReturning([]);
-    // A breaker-open exec short-circuits locally: code 1, 'circuit-open' (no quota
-    // spent). runEligibleQuery throws → reconcileProject preserves the prior set,
-    // rather than trusting an unconfirmed replica-empty as authoritative.
-    const exec = fakeExec({ code: 1, stderr: "circuit-open" });
-    expect(() => runEligibleQuery(query, { exec, replica })).toThrow(/exit 1/);
+    const sources = [];
+    const tickets = runEligibleQuery(query, {
+      exec: execMustNotRun(), // proves the doomed linearis reconfirm is skipped
+      replica,
+      breakerIsOpen: () => true,
+      onSource: (source, count) => sources.push([source, count]),
+    });
+    expect(tickets).toEqual([]);
+    expect(sources).toEqual([["replica-empty-breaker-open", 0]]);
+    expect(replica.calls).toEqual([query]); // the replica WAS consulted
+  });
+
+  // CTL-1420: the fix is breaker-GATED — a CLOSED breaker preserves the exact
+  // pre-1420 behavior (fall through to the linearis confirm so a feed-hole is
+  // never trusted as empty; the ≤1-confirm/team/window cadence is intact).
+  test("CTL-1420: replica-EMPTY, breaker CLOSED, no recent confirm → still falls through to the linearis confirm (unchanged)", () => {
+    const replica = replicaReturning([]);
+    const exec = fakeExec({ stdout: ticketsJson([]) });
+    const sources = [];
+    const tickets = runEligibleQuery(query, {
+      exec,
+      replica,
+      breakerIsOpen: () => false,
+      onSource: (source, count) => sources.push([source, count]),
+    });
+    expect(exec.calls).toHaveLength(1); // linearis WAS called (breaker closed)
+    expect(tickets).toEqual([]);
+    expect(sources).toEqual([["linearis", 0]]); // served + cached by the linearis path
+  });
+
+  // CTL-1420: a breaker-open reconcile must NEVER fabricate work — a genuinely
+  // NON-EMPTY replica is still served verbatim (the freeze-avoidance branch only
+  // fires on an empty board), so real Todo work dispatches during a quota storm.
+  test("CTL-1420: replica NON-EMPTY, breaker OPEN → serves the real board (freeze-avoidance never masks real work)", () => {
+    const replica = replicaReturning([{ identifier: "CTL-1416", state: "Todo", priority: 2 }]);
+    const sources = [];
+    const tickets = runEligibleQuery(query, {
+      exec: execMustNotRun(),
+      replica,
+      breakerIsOpen: () => true,
+      onSource: (source, count) => sources.push([source, count]),
+    });
+    expect(tickets.map((t) => t.identifier)).toEqual(["CTL-1416"]);
+    expect(sources).toEqual([["replica", 1]]);
   });
 
   test("cadence: after a successful empty confirm, empties trust the replica until the window elapses, then re-confirm once per team", () => {

--- a/plugins/dev/scripts/execution-core/linear-query.test.mjs
+++ b/plugins/dev/scripts/execution-core/linear-query.test.mjs
@@ -431,6 +431,31 @@ describe("runEligibleQuery — replica tier (CTL-1397)", () => {
     expect(sources).toEqual([["replica", 1]]);
   });
 
+  // CTL-1420 review finding (guard): the freeze-avoidance branch trusts the empty
+  // WITHOUT caching the empty-confirm marker. If it did cache it, the linearis
+  // reconfirm would be suppressed for EMPTY_RECONFIRM_MS after the breaker closes
+  // — trusting a CTL-139 feed-hole as a real empty board. This asserts the marker
+  // stays unset: once the breaker closes, an empty STILL reconfirms via linearis.
+  test("CTL-1420: breaker-open trust does NOT cache the empty-confirm marker → after the breaker closes the next empty still reconfirms via linearis", () => {
+    const replica = replicaReturning([]);
+    // Breaker OPEN: trust the empty, no exec, and (crucially) no marker cached.
+    const t1 = runEligibleQuery(query, { exec: execMustNotRun(), replica, breakerIsOpen: () => true });
+    expect(t1).toEqual([]);
+    // Breaker now CLOSED: if the open branch had cached the marker, this empty
+    // would be trusted with NO linearis call. It must reconfirm instead.
+    const exec = fakeExec({ stdout: ticketsJson([]) });
+    const sources = [];
+    const t2 = runEligibleQuery(query, {
+      exec,
+      replica,
+      breakerIsOpen: () => false,
+      onSource: (source, count) => sources.push([source, count]),
+    });
+    expect(exec.calls).toHaveLength(1); // reconfirmed — the open branch left the marker unset
+    expect(t2).toEqual([]);
+    expect(sources).toEqual([["linearis", 0]]);
+  });
+
   test("cadence: after a successful empty confirm, empties trust the replica until the window elapses, then re-confirm once per team", () => {
     const replica = replicaReturning([]);
     let clock = 5_000_000;

--- a/plugins/dev/scripts/execution-core/monitor.mjs
+++ b/plugins/dev/scripts/execution-core/monitor.mjs
@@ -77,8 +77,10 @@ import { countSdkInflight as defaultCountSdkInflight } from "./signal-reader.mjs
 import {
   recordReconcileSuccess,
   recordReconcileFailure,
+  getReconcileHealth,
   __resetReconcileHealthForTests,
 } from "./reconcile-health.mjs";
+import { checkFleetFreeze } from "./fleet-freeze-alert.mjs"; // CTL-1420: fleet-frozen-for-admission alert
 
 // DRAG_OUT_STATES — the Linear workflow states that signal "stop work on this
 // ticket". The monitor classifies these as a kill: remove the ticket from the
@@ -343,7 +345,7 @@ export function reconcileProject(team, { exec, delegateExec, appendHealthEvent, 
 // reconcileAll — full reconcile of every registered team (the missed-webhook
 // backstop). Re-reads registry.json each call so a team added to the registry
 // is picked up and one removed is dropped within one tick.
-export function reconcileAll({ exec, delegateExec, appendHealthEvent } = {}) {
+export function reconcileAll({ exec, delegateExec, appendHealthEvent, fleetFreezeAppend } = {}) {
   const projects = listProjects();
   const seen = new Set(projects.map((p) => p.team));
   for (const p of projects) reconcileProject(p.team, { exec, delegateExec, appendHealthEvent });
@@ -355,6 +357,17 @@ export function reconcileAll({ exec, delegateExec, appendHealthEvent } = {}) {
   }
   knownProjects.clear();
   for (const t of seen) knownProjects.add(t);
+  // CTL-1420: after every team reconciled this pass, roll the per-team reconcile
+  // health up into a fleet-frozen-for-admission alert. When EVERY registered team
+  // is in a persistent-failure state, the eligible projection can refresh from
+  // neither the replica nor linearis — new work is frozen fleet-wide, which used
+  // to be silent (reconcileProject just preserves the empty prior set). Latched +
+  // best-effort inside checkFleetFreeze; a team's recovery clears it.
+  checkFleetFreeze({
+    teams: [...seen],
+    isTeamFrozen: (t) => getReconcileHealth(t)?.alerting === true,
+    ...(fleetFreezeAppend ? { append: fleetFreezeAppend } : {}),
+  });
 }
 
 // --- Event-driven fast path ---------------------------------------------

--- a/plugins/dev/scripts/execution-core/monitor.test.mjs
+++ b/plugins/dev/scripts/execution-core/monitor.test.mjs
@@ -59,6 +59,7 @@ beforeEach(() => {
   process.env.CATALYST_DIR = catalystDir;
   mkdirSync(join(catalystDir, "execution-core"), { recursive: true });
   __resetForTests();
+  __resetFleetFreezeLatch(); // CTL-1420: the fleet-freeze latch is module-global + now persisted — reset per test
   enrolledTeams.clear();
   registryEntries.length = 0;
 });

--- a/plugins/dev/scripts/execution-core/monitor.test.mjs
+++ b/plugins/dev/scripts/execution-core/monitor.test.mjs
@@ -39,6 +39,12 @@ import {
   recordReconcileFailure,
   __resetReconcileHealthForTests,
 } from "./reconcile-health.mjs";
+import {
+  __resetFleetFreezeLatch,
+  ALERT_RAISED,
+  ALERT_CLEARED,
+  ALERT_KIND_FLEET_FROZEN_ADMISSION,
+} from "./fleet-freeze-alert.mjs"; // CTL-1420
 
 let catalystDir;
 let prevCatalystDir;
@@ -892,6 +898,50 @@ describe("lifecycle", () => {
     unenroll("ENG");
     reconcileAll({ exec });
     expect(getEligibleSet("ENG")).toEqual([]); // dropProject'd
+  });
+
+  // CTL-1420: when EVERY registered team's reconcile fails persistently (no fresh
+  // replica AND the CTL-679 breaker is pinned open), the eligible projection can't
+  // refresh from either source — the board is frozen for new work fleet-wide.
+  // reconcileAll rolls the per-team reconcile-health up into ONE catalyst.alert.*.
+  test("reconcileAll raises a fleet-frozen-admission alert when every team's reconcile is failing, and clears it when one recovers", () => {
+    __resetFleetFreezeLatch();
+    enroll("ENG", { status: "Ready" });
+    enroll("PLAT", { status: "Ready" });
+    // A breaker-open/removed-state exec: throws for every team, every pass.
+    const throwingExec = () => ({ code: 1, stdout: "", stderr: "circuit-open" });
+    const alerts = [];
+    const fleetFreezeAppend = (line) => alerts.push(JSON.parse(line));
+
+    // Drive both teams past the failure threshold (3). No alert until the LAST
+    // team crosses — the fleet is frozen only when ALL teams are failing.
+    reconcileAll({ exec: throwingExec, fleetFreezeAppend });
+    reconcileAll({ exec: throwingExec, fleetFreezeAppend });
+    expect(alerts).toHaveLength(0); // both teams at 2 failures — under threshold
+    reconcileAll({ exec: throwingExec, fleetFreezeAppend });
+
+    // Both teams now alerting → exactly one fleet-frozen RAISED alert.
+    expect(getReconcileHealth("ENG").alerting).toBe(true);
+    expect(getReconcileHealth("PLAT").alerting).toBe(true);
+    expect(alerts).toHaveLength(1);
+    expect(alerts[0].attributes["event.name"]).toBe(ALERT_RAISED);
+    expect(alerts[0].attributes["event.label"]).toBe(ALERT_KIND_FLEET_FROZEN_ADMISSION);
+    expect(alerts[0].body.payload.teams.sort()).toEqual(["ENG", "PLAT"]);
+
+    // A further all-failing pass does NOT re-fire (latched).
+    reconcileAll({ exec: throwingExec, fleetFreezeAppend });
+    expect(alerts).toHaveLength(1);
+
+    // ENG recovers → not ALL teams frozen → exactly one CLEARED alert.
+    const mixedExec = (_cmd, args) => {
+      const team = args[args.indexOf("--team") + 1];
+      if (team === "ENG") return { code: 0, stdout: JSON.stringify({ nodes: [node("ENG-1")] }), stderr: "" };
+      return { code: 1, stdout: "", stderr: "circuit-open" };
+    };
+    reconcileAll({ exec: mixedExec, fleetFreezeAppend });
+    expect(getReconcileHealth("ENG").alerting).toBe(false);
+    expect(alerts).toHaveLength(2);
+    expect(alerts[1].attributes["event.name"]).toBe(ALERT_CLEARED);
   });
 
   test("stopMonitor clears pending debounce timers (a queued reconcile never fires)", async () => {


### PR DESCRIPTION
## CTL-1420 — unfreeze fleet admission during a Linear quota storm

Fixes the fleet-wide new-work **admission freeze** SDK-ONLY hit overnight: on a fresh daemon boot into an open CTL-679 breaker, the monitor reconcile froze every team's eligible set to empty for the breaker's whole open window (4h+; canary CTL-1416 never admitted across 4 attempts).

### Root cause
`runEligibleQuery`'s replica-empty path trusts a seed-complete replica-empty **only** within `EMPTY_RECONFIRM_MS` of a *successful linearis empty-confirm* — and that marker is an **in-memory Map cleared on every process start**. Fresh boot ⇒ marker absent ⇒ every empty team falls through to a linearis reconfirm that can only short-circuit (breaker open) → throw → `reconcileProject` preserves the **empty** prior set ⇒ nothing admitted, forever, until the breaker closes. A failed confirm never seeds the marker, so the loop is self-sustaining.

### The fix — two surfaces

**Surface (a): freeze-avoidance** (`linear-query.mjs`) — when the breaker is **OPEN**, a *defined* replica-empty (already past the reader's writer-liveness + seed-complete cursor + snapshot-consistent gates = a provably-real `0 eligible`, not a mid-reseed truncation) is **trusted** instead of freezing. Breaker-**gated**: a CLOSED breaker keeps the exact pre-1420 reconfirm cadence (CTL-139 feed-hole protection intact); a **non-empty** replica is always served, so real Todo work still dispatches during a storm; self-healing when the breaker closes. New injectable `breakerIsOpen` seam; `onSource("replica-empty-breaker-open", 0)` for OTEL/Loki.

**Surface (c): the alert** (`fleet-freeze-alert.mjs`) — when **every** registered team's reconcile is persistently failing (the residual double-outage: no fresh replica **and** breaker open, which surface (a) can't serve), `reconcileAll` rolls per-team reconcile-health up into **one latched `catalyst.alert.{raised,cleared}`** (`kind=fleet_frozen_admission`) so a genuine fleet freeze is **loud, not silent**. Mirrors `reconcile-health-event.mjs` (execution-core-attributed OTel envelope, best-effort append, never throws).

### Explicitly out of scope (documented → separate ticket)
The board-health **~442ms/tick #2503 regression** is **local SQLite/fs I/O, not Linear** — code-verified zero per-tick Linear calls (getBoard/getPrStatusMap = broker SQLite; readEventRing = whole-file `readFileSync`). It does **not** burn the quota, so it's a *perf* fix, not part of this quota-freeze fix.

### Tests
- `linear-query.test.mjs` — breaker-open trust (no linearis, no throw) / breaker-closed unchanged / non-empty-still-served during a storm.
- `fleet-freeze-alert.test.mjs` — raise/clear/latch/partial-freeze/empty-registry/throwing-append-retries.
- `monitor.test.mjs` — `reconcileAll` raises the fleet-freeze alert when all teams fail, clears on recovery.
- **333 pass / 0 fail** across the three files. Full execution-core suite: the only failures are pre-existing environmental ones (hostname/token-dependent) that also fail on `main`; none touch changed code paths.

### Validation plan
SDK-ONLY's CTL-1416 canary is the live end-to-end deploy check (admission during/after a storm) — closes their CTL-1410 Phase A fleet-verify at the same time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017wxcxbWTFPumW9hqZVRcLk
