### PR TITLE
feat(dev): CTL-1397 enforcement — replica-first Linear reads as a standard prerequisite reflex

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,12 +43,13 @@ No build process — this is markdown files and bash scripts.
 - **Wait for all agents before synthesizing** — Don't proceed until research completes
 - **Config drives behavior** — No hardcoded values
 - **Single source of truth** — Don't duplicate information across files:
-  - CLI syntax lives in skills (e.g., the `linearis` skill, which also defines the direct-SQLite read rule for agent Linear reads — reads → the local replica, writes → `linearis`) — reference it, don't copy
+  - CLI syntax lives in skills (e.g., the `linearis` skill) — reference it, don't copy
   - Workflow logic lives in skills — each skill owns its own state transitions
   - Config schema lives in `website/src/content/docs/reference/configuration.md`
 - **Spawn parallel agents** — Maximize efficiency
 - **Agents are documentarians** — Never suggest improvements unless asked
 - **Preserve context** — Save to thoughts/, not just memory
+- **Linear reads → local replica** — for a single-ticket read call `linear_read_ticket <ID>` (it gates freshness and falls back loudly); never a bare `linearis issues read <ID>` (it 429s the shared-quota fleet). Writes and list/search stay on `linearis`. See the `linearis` skill's "Reading Linear".
 
 ## Skill & Agent References
 

--- a/plugins/dev/hooks.toml
+++ b/plugins/dev/hooks.toml
@@ -139,3 +139,21 @@ description = "Provide Catalyst plan structure guidance when in plan mode"
 command = "bash"
 args = ["${CLAUDE_PLUGIN_ROOT}/hooks/inject-plan-template.sh"]
 run_in_background = false
+
+# CTL-1397/CTL-1420: replica-first Linear reads. Warn on (observe, default) or block
+# (enforce) a bare `linearis issues read <ID>` that bypasses the local replica and 429s
+# the shared Linear quota, and emit a catalyst.replica.read_fallback event so the burn-down
+# is measurable in Loki. Mode via CATALYST_LINEAR_READ_DETECT_MODE (observe|enforce). This
+# is what makes the detector actually FIRE (no manual settings.json install).
+[[hooks]]
+name = "Detect bare Linear reads (replica-first)"
+event = "PreToolUse"
+description = "Observe/enforce bare `linearis issues read` that bypasses the replica (CTL-1397/CTL-1420)"
+
+[hooks.matcher]
+tool_name = "Bash"
+
+[hooks.command]
+command = "bash"
+args = ["${CLAUDE_PLUGIN_ROOT}/hooks/detect-bare-linear-read.sh"]
+run_in_background = false

--- a/plugins/dev/hooks/detect-bare-linear-read.sh
+++ b/plugins/dev/hooks/detect-bare-linear-read.sh
@@ -10,14 +10,22 @@ input="$(cat)"                                   # Claude Code pipes the tool ca
 cmd="$(printf '%s' "$input" | jq -r '.tool_input.command // empty' 2>/dev/null)"
 [[ -n "$cmd" ]] || exit 0
 
-# Is this an `issues read` at all? (verb `read` excludes list/search/create/update/
-# comments/usage/auth). Allow arbitrary flags/tokens between `linearis` and `issues`.
-printf '%s' "$cmd" | grep -Eq 'linearis([[:space:]]+[^[:space:]]+)*[[:space:]]+issues[[:space:]]+read([[:space:]]|$)' || exit 0
-# Sanctioned exemption: attachments have no replica form.
-printf '%s' "$cmd" | grep -Eq -- '--with-attachments' && exit 0
+# Detect per COMMAND SEGMENT, not payload-wide, so a sanctioned `--with-attachments`
+# read in the same tool call can't shield a sibling bare read
+# (e.g. `linearis issues read A; linearis issues read B --with-attachments`). Split on
+# shell separators (;, &, |, newline) — sufficient for the payload shapes agents emit.
+# A segment is a BARE read iff it is an `issues read` (verb `read` excludes list/search/
+# create/update/comments/usage/auth) WITHOUT --with-attachments (the one replica-less read).
+bare=""
+while IFS= read -r seg; do
+  printf '%s' "$seg" | grep -Eq 'linearis([[:space:]]+[^[:space:]]+)*[[:space:]]+issues[[:space:]]+read([[:space:]]|$)' || continue
+  printf '%s' "$seg" | grep -Eq -- '--with-attachments' && continue   # sanctioned attachment read — exempt
+  bare="$seg"; break
+done < <(printf '%s\n' "$cmd" | tr ';&|' '\n')
+[[ -n "$bare" ]] || exit 0
 
-# Literal id if present; else variable-form → unknown (still counted/blocked).
-id="$(printf '%s' "$cmd" | grep -Eo '[A-Za-z][A-Za-z0-9]*-[0-9]+' | head -1)"
+# Literal id in the OFFENDING segment if present; else variable-form → unknown (still counted/blocked).
+id="$(printf '%s' "$bare" | grep -Eo '[A-Za-z][A-Za-z0-9]*-[0-9]+' | head -1)"
 id="${id:-unknown}"
 
 # Count it in Loki (same event as E1; source=raw-cli-hook, reason=no-gate).
@@ -25,7 +33,7 @@ LIB="$(dirname "$0")/../scripts/lib/linear-read-replica.sh"
 [[ -r "$LIB" ]] && { source "$LIB"; _lrr_emit_fallback_event "$id" no-gate raw-cli-hook; }
 
 if [[ "${CATALYST_LINEAR_READ_DETECT_MODE:-observe}" == "enforce" ]]; then
-  echo "Blocked: '$cmd' hits the rate-limited Linear API. Use the replica: source plugins/dev/scripts/lib/linear-read-replica.sh && linear_read_ticket ${id/unknown/<ID>} (or gate + sqlite3 the replica). Attachments? add --with-attachments (exempt). See the linearis skill 'Reading Linear'." >&2
+  echo "Blocked: '$bare' hits the rate-limited Linear API. Use the replica: source plugins/dev/scripts/lib/linear-read-replica.sh && linear_read_ticket ${id/unknown/<ID>} (or gate + sqlite3 the replica). Attachments? add --with-attachments (exempt). See the linearis skill 'Reading Linear'." >&2
   exit 2                                          # exit 2 = block the tool call, feed stderr to the model
 fi
 # observe mode: warn + allow (does NOT hard-stop the read — see deploy plan).

--- a/plugins/dev/hooks/detect-bare-linear-read.sh
+++ b/plugins/dev/hooks/detect-bare-linear-read.sh
@@ -9,16 +9,22 @@ set -uo pipefail
 input="$(cat)"                                   # Claude Code pipes the tool call as JSON on stdin
 cmd="$(printf '%s' "$input" | jq -r '.tool_input.command // empty' 2>/dev/null)"
 [[ -n "$cmd" ]] || exit 0
+# Collapse shell line-continuations (`\<newline>`) to a space so a wrapped
+# `linearis issues \<NL> read CTL-1` (one command to bash) isn't split into two
+# non-matching segments below.
+cmd="${cmd//$'\\\n'/ }"
 
 # Detect per COMMAND SEGMENT, not payload-wide, so a sanctioned `--with-attachments`
 # read in the same tool call can't shield a sibling bare read
 # (e.g. `linearis issues read A; linearis issues read B --with-attachments`). Split on
 # shell separators (;, &, |, newline) — sufficient for the payload shapes agents emit.
-# A segment is a BARE read iff it is an `issues read` (verb `read` excludes list/search/
-# create/update/comments/usage/auth) WITHOUT --with-attachments (the one replica-less read).
+# A segment is a BARE read iff `linearis` is the COMMAND WORD (anchored — after optional
+# leading whitespace + VAR=val env-assignments; so `rg "linearis issues read"` / `echo …`
+# do NOT match) running an `issues read` (verb `read` excludes list/search/create/update/
+# comments/usage/auth) WITHOUT --with-attachments (the one replica-less read).
 bare=""
 while IFS= read -r seg; do
-  printf '%s' "$seg" | grep -Eq 'linearis([[:space:]]+[^[:space:]]+)*[[:space:]]+issues[[:space:]]+read([[:space:]]|$)' || continue
+  printf '%s' "$seg" | grep -Eq '^[[:space:]]*([A-Za-z_][A-Za-z0-9_]*=[^[:space:]]*[[:space:]]+)*linearis([[:space:]]+[^[:space:]]+)*[[:space:]]+issues[[:space:]]+read([[:space:]]|$)' || continue
   printf '%s' "$seg" | grep -Eq -- '--with-attachments' && continue   # sanctioned attachment read — exempt
   bare="$seg"; break
 done < <(printf '%s\n' "$cmd" | tr ';&|' '\n')

--- a/plugins/dev/hooks/detect-bare-linear-read.sh
+++ b/plugins/dev/hooks/detect-bare-linear-read.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# PreToolUse/Bash hook: detect a bare single-ticket `linearis issues read <arg>`
+# that bypasses the replica — for LITERAL ids AND shell-variable forms ($T, "$T",
+# ${T}, $(...)). Flag-order independent. EXEMPT the one sanctioned linearis read the
+# replica can't serve: --with-attachments. Comments are fetched via `linearis
+# comments list` (structurally outside `issues read`), so no comment exemption is
+# needed. Mode: CATALYST_LINEAR_READ_DETECT_MODE (observe|enforce; default observe).
+set -uo pipefail
+input="$(cat)"                                   # Claude Code pipes the tool call as JSON on stdin
+cmd="$(printf '%s' "$input" | jq -r '.tool_input.command // empty' 2>/dev/null)"
+[[ -n "$cmd" ]] || exit 0
+
+# Is this an `issues read` at all? (verb `read` excludes list/search/create/update/
+# comments/usage/auth). Allow arbitrary flags/tokens between `linearis` and `issues`.
+printf '%s' "$cmd" | grep -Eq 'linearis([[:space:]]+[^[:space:]]+)*[[:space:]]+issues[[:space:]]+read([[:space:]]|$)' || exit 0
+# Sanctioned exemption: attachments have no replica form.
+printf '%s' "$cmd" | grep -Eq -- '--with-attachments' && exit 0
+
+# Literal id if present; else variable-form → unknown (still counted/blocked).
+id="$(printf '%s' "$cmd" | grep -Eo '[A-Za-z][A-Za-z0-9]*-[0-9]+' | head -1)"
+id="${id:-unknown}"
+
+# Count it in Loki (same event as E1; source=raw-cli-hook, reason=no-gate).
+LIB="$(dirname "$0")/../scripts/lib/linear-read-replica.sh"
+[[ -r "$LIB" ]] && { source "$LIB"; _lrr_emit_fallback_event "$id" no-gate raw-cli-hook; }
+
+if [[ "${CATALYST_LINEAR_READ_DETECT_MODE:-observe}" == "enforce" ]]; then
+  echo "Blocked: '$cmd' hits the rate-limited Linear API. Use the replica: source plugins/dev/scripts/lib/linear-read-replica.sh && linear_read_ticket ${id/unknown/<ID>} (or gate + sqlite3 the replica). Attachments? add --with-attachments (exempt). See the linearis skill 'Reading Linear'." >&2
+  exit 2                                          # exit 2 = block the tool call, feed stderr to the model
+fi
+# observe mode: warn + allow (does NOT hard-stop the read — see deploy plan).
+echo "note: this bypassed the replica — prefer linear_read_ticket ${id/unknown/<ID>} (linearis skill 'Reading Linear')." >&2
+exit 0

--- a/plugins/dev/scripts/__tests__/linear-read-replica.test.sh
+++ b/plugins/dev/scripts/__tests__/linear-read-replica.test.sh
@@ -54,6 +54,10 @@ fresh_lock() { : >"$DB.writer.lock"; } # heartbeat = now
 fresh_lock
 
 export CATALYST_REPLICA_DB="$DB"
+# Isolate any fallback events (MISS/stale) to a scratch dir so the test's synthetic
+# TST-* reads never append to the LIVE ~/catalyst/events log otel-forward ships —
+# which would contaminate the very catalyst.replica.read_fallback burn-down metric.
+export CATALYST_EVENTS_DIR="$TMP/events"
 # shellcheck source=/dev/null
 source "$HELPER"
 

--- a/plugins/dev/scripts/check-project-setup.sh
+++ b/plugins/dev/scripts/check-project-setup.sh
@@ -457,6 +457,39 @@ if [[ -n $CONFIG_PATH ]]; then
 	fi
 fi
 
+# 8. Linear read path — replica-first reflex (CTL-1397 / CTL-1420 follow-up)
+#    CTL-1397 pivoted agent Linear READS to direct SQLite against the local
+#    catalyst-replica.db (writer-fed from Catalyst Cloud). Bare `linearis issues
+#    read <ID>` instead hits the personal ~2500/hr Linear key and 429s under load.
+#    Affirm "reads → replica" when the replica is FRESH; WARN (advisory, NEVER fatal)
+#    only when the operator has OPTED IN (CATALYST_LINEAR_REPLICA=on) but the replica
+#    is STALE/missing — so a downstream/non-fleet host that never runs the replica is
+#    NOT nagged and is NOT flipped out of "Project setup OK". Freshness is the SAME
+#    two-gate check the read helper enforces (writer.lock < 5min AND a sync_meta
+#    cursor) — sourced, not duplicated, so the gate can't drift from read behavior.
+REPLICA_LIB=""
+if [[ -f "${SCRIPT_DIR}/lib/linear-read-replica.sh" ]]; then
+	REPLICA_LIB="${SCRIPT_DIR}/lib/linear-read-replica.sh"
+elif [[ -n ${CLAUDE_PLUGIN_ROOT-} && -f "${CLAUDE_PLUGIN_ROOT}/scripts/lib/linear-read-replica.sh" ]]; then
+	REPLICA_LIB="${CLAUDE_PLUGIN_ROOT}/scripts/lib/linear-read-replica.sh"
+fi
+if [[ -n $REPLICA_LIB ]]; then
+	# Defines replica_fresh() (print-free, rc-only) + CATALYST_REPLICA_DB /
+	# CATALYST_LINEAR_REPLICA_STALE_MS defaults. Idempotent; safe under set -e.
+	# shellcheck source=lib/linear-read-replica.sh disable=SC1090,SC1091
+	source "$REPLICA_LIB"
+	_replica_stale_s=$(( ${CATALYST_LINEAR_REPLICA_STALE_MS:-300000} / 1000 ))
+	if replica_fresh; then
+		echo -e "${GREEN}Linear reads → local replica${NC} (${CATALYST_REPLICA_DB}) — do NOT use bare 'linearis issues read <ID>' for single-ticket reads (it hits the personal Linear key and 429s under load)."
+	elif [[ -f "$CATALYST_REPLICA_DB" ]]; then
+		warnings+=("Linear replica STALE (writer heartbeat >${_replica_stale_s}s or seed incomplete) — single-ticket reads fall back to the personal Linear key (rate-limited, 429-prone). Check the cloud-sync writer: bash plugins/dev/scripts/check-setup.sh")
+	elif [[ ${CATALYST_LINEAR_REPLICA:-} == on ]]; then
+		warnings+=("CATALYST_LINEAR_REPLICA=on but no replica at $CATALYST_REPLICA_DB — single-ticket reads fall back to the personal Linear key (rate-limited, 429-prone). Start the cloud-sync writer: catalyst-stack adopt-cloud-sync")
+	fi
+	# else (no replica, not opted in): silent — the replica is fleet-internal infra a
+	# downstream install never runs; nagging it would be a permanent false alarm.
+fi
+
 # Report errors (fatal)
 if [[ ${#errors[@]} -gt 0 ]]; then
 	echo -e "${RED}ERROR: Project setup incomplete${NC}"

--- a/plugins/dev/scripts/lib/linear-read-replica.sh
+++ b/plugins/dev/scripts/lib/linear-read-replica.sh
@@ -39,6 +39,35 @@ _CATALYST_LINEAR_READ_REPLICA_SH=1
 # Live-read fallback cap in ms (matches catalyst-linear's runLinearis); default 8s.
 : "${CATALYST_LINEARIS_TIMEOUT_MS:=8000}"
 
+# _lrr_emit_fallback_event <ID> <reason> <source> — best-effort: append a WARN
+# `catalyst.replica.read_fallback` event to the unified log so every replica
+# miss/stale fallback is measurable in Loki (otel-forward ships this log; agent
+# Bash stderr is NOT). NEVER fails the caller. No dedup — WARN log-only, not
+# paging; the alerting story owns latching/rate-limiting (a writer outage can
+# burst this at read-rate × outage-duration).
+_lrr_emit_fallback_event() {
+  local id="$1" reason="$2" source="${3:-helper}"
+  local lib; lib="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/canonical-event.sh"
+  [[ -r "$lib" ]] || return 0
+  command -v jq >/dev/null 2>&1 || return 0
+  # shellcheck disable=SC1090
+  . "$lib" 2>/dev/null || return 0
+  local events_dir="${CATALYST_EVENTS_DIR:-${CATALYST_DIR:-$HOME/catalyst}/events}"
+  local ts; ts="$(date -u +%Y-%m-%dT%H:%M:%S.000Z)"
+  local line
+  line="$(build_canonical_line \
+    --ts "$ts" --severity WARN \
+    --service "catalyst.linear-read" \
+    --event-name "catalyst.replica.read_fallback" \
+    --entity "linear-read" --action "fallback" \
+    --label "$reason" \
+    --linear-ticket "$id" \
+    --session "${CATALYST_SESSION_ID:-}" \
+    --message "Linear single-ticket read fell back to linearis ($reason) for $id" \
+    --payload-json "$(jq -nc --arg s "$source" '{source:$s}')" 2>/dev/null)" || return 0
+  canonical_jsonl_append "$events_dir" "$line" 2>/dev/null || true
+}
+
 # _lrr_live_read <ID> → run the linearis fallback, CAPPED so a 429-stalled / hung
 # linearis can't block the caller forever (parity with catalyst-linear's runLinearis
 # 8s cap). Uses `timeout` when present (GNU coreutils on the fleet); on timeout the
@@ -110,8 +139,10 @@ linear_read_ticket() {
     fi
     # Fresh replica, but the row is absent (not yet mirrored / tombstoned).
     printf '[linear-read-replica] MISS for %s (replica fresh, row absent) — falling back to linearis; file a ticket if this recurs.\n' "$id" >&2
+    _lrr_emit_fallback_event "$id" miss helper
   else
     printf '[linear-read-replica] replica STALE/ABSENT (writer heartbeat >%ds or seed incomplete) — falling back to linearis for %s; this is a writer/mirror gap to fix, not a retry.\n' "$(( ${CATALYST_LINEAR_REPLICA_STALE_MS:-300000} / 1000 ))" "$id" >&2
+    _lrr_emit_fallback_event "$id" stale-absent helper
   fi
   # Loud fallback — one un-accelerated, timeout-capped live read. Writes stay on
   # linearis elsewhere.

--- a/plugins/dev/scripts/lib/workflow-rules.mjs
+++ b/plugins/dev/scripts/lib/workflow-rules.mjs
@@ -212,12 +212,19 @@ if (import.meta.main) {
     // diagnosis; the dispatcher still launches with today's defaults.
     process.stderr.write(`workflow-rules resolve: ${e.message}\n`);
   }
-  const lines = [...(resolved.preamble ?? []), ...(resolved.postamble ?? [])];
+  // CTL-1420 follow-up: every phase worker inherits the replica-first read reflex
+  // at runtime. Prepended (not appended) so it leads, and composes with any
+  // per-phase preamble/postamble rather than being clobbered at the spawn site.
+  const REPLICA_FIRST =
+    "Linear reads → local replica: for a single-ticket read call `linear_read_ticket <ID>` " +
+    "(never a bare `linearis issues read <ID>` — it 429s the shared quota); writes and list/search " +
+    "stay on `linearis`. See the `linearis` skill's \"Reading Linear\".";
+  const lines = [REPLICA_FIRST, ...(resolved.preamble ?? []), ...(resolved.postamble ?? [])];
   process.stdout.write(
     JSON.stringify({
       model: resolved.model ?? null,
       effort: resolved.effort ?? null,
-      appendSystemPrompt: lines.length ? lines.join("\n") : null,
+      appendSystemPrompt: lines.join("\n"),
     })
   );
 }

--- a/plugins/dev/scripts/lib/workflow-rules.mjs
+++ b/plugins/dev/scripts/lib/workflow-rules.mjs
@@ -216,9 +216,12 @@ if (import.meta.main) {
   // at runtime. Prepended (not appended) so it leads, and composes with any
   // per-phase preamble/postamble rather than being clobbered at the spawn site.
   const REPLICA_FIRST =
-    "Linear reads → local replica: for a single-ticket read call `linear_read_ticket <ID>` " +
-    "(never a bare `linearis issues read <ID>` — it 429s the shared quota); writes and list/search " +
-    "stay on `linearis`. See the `linearis` skill's \"Reading Linear\".";
+    "Linear reads → local replica: read a single ticket from the Catalyst replica per the " +
+    "`linearis` skill's \"Reading Linear\" rule — source " +
+    "`${CLAUDE_PLUGIN_ROOT}/scripts/lib/linear-read-replica.sh` then `linear_read_ticket <ID>` " +
+    "(it is a shell FUNCTION, not an executable — you must source the helper first), or inline " +
+    "`sqlite3` on `catalyst-replica.db`. Never a bare `linearis issues read <ID>` (it 429s the " +
+    "shared quota). Writes and list/search stay on `linearis`.";
   const lines = [REPLICA_FIRST, ...(resolved.preamble ?? []), ...(resolved.postamble ?? [])];
   process.stdout.write(
     JSON.stringify({

--- a/plugins/dev/skills/_phase-agent-template/SKILL.md
+++ b/plugins/dev/skills/_phase-agent-template/SKILL.md
@@ -47,6 +47,11 @@ Every phase agent:
    - Updates `${ORCH_DIR}/workers/<TICKET>/phase-<name>.json`.
    - Calls `catalyst-session.sh end`.
 
+6. **Linear reads → local replica.** For a single-ticket read call
+   `linear_read_ticket <ID>` (never a bare `linearis issues read <ID>` — it 429s
+   the shared quota); writes and list/search stay on `linearis`. See the `linearis`
+   skill's "Reading Linear".
+
 ## Required env vars
 
 The dispatcher (`plugins/dev/scripts/phase-agent-dispatch`) sets these on

--- a/plugins/dev/skills/gherkin-ticket/SKILL.md
+++ b/plugins/dev/skills/gherkin-ticket/SKILL.md
@@ -8,7 +8,7 @@ description:
   plus tiered Gherkin (Given/When/Then) acceptance criteria — even for backend bugs and chores."
 disable-model-invocation: false
 user-invocable: true
-allowed-tools: Read, Write, Edit, Grep, Glob, Bash(linearis *), Bash(jq *), Bash(linear_read_ticket *)
+allowed-tools: Read, Write, Edit, Grep, Glob, Bash(linearis *), Bash(jq *), Bash(source *), Bash(linear_read_ticket *)
 version: 1.0.0
 ---
 

--- a/plugins/dev/skills/gherkin-ticket/SKILL.md
+++ b/plugins/dev/skills/gherkin-ticket/SKILL.md
@@ -239,9 +239,11 @@ Scenario: Dispatch still waits for completion before returning  # invariant
    command (the helper's function is only defined in the shell that sourced it):
    `source "${CLAUDE_PLUGIN_ROOT}/scripts/lib/linear-read-replica.sh" && linear_read_ticket "$TICKET"`
    (freshness gate → SQL → loud linearis fallback). **Comments are not mirrored** —
-   fetch them via `linearis comments list "$TICKET"` (see `/catalyst-dev:linearis`);
-   this stays on `linearis` and is
-   structurally outside the `issues read` detector.
+   fetch them via `linearis comments list "$TICKET"`, and for any comment with a
+   discussion thread also fetch its replies (`linearis issues replies <thread>`) so
+   technical detail in replies isn't dropped when you rewrite (see
+   `/catalyst-dev:linearis`); this stays on `linearis` and is structurally outside
+   the `issues read` detector.
 2. **Preserve all technical content** (file refs, repro steps, root-cause notes, SHAs). You are
    restructuring, not deleting. Move technical detail under a `## Technical notes` section below the
    Gherkin so it stays but doesn't lead.

--- a/plugins/dev/skills/gherkin-ticket/SKILL.md
+++ b/plugins/dev/skills/gherkin-ticket/SKILL.md
@@ -8,7 +8,7 @@ description:
   plus tiered Gherkin (Given/When/Then) acceptance criteria — even for backend bugs and chores."
 disable-model-invocation: false
 user-invocable: true
-allowed-tools: Read, Write, Edit, Grep, Glob, Bash(linearis *), Bash(jq *)
+allowed-tools: Read, Write, Edit, Grep, Glob, Bash(linearis *), Bash(jq *), Bash(linear_read_ticket *)
 version: 1.0.0
 ---
 
@@ -234,7 +234,14 @@ Scenario: Dispatch still waits for completion before returning  # invariant
    estimate, priority there (see `feedback_linear_ticket_hygiene`).
 
 ### REWRITE (existing ticket)
-1. Read the **full** existing ticket (title + description + comments) — never partial.
+1. Read the **full** existing ticket — never partial. Title + description come from
+   the replica (per the `linearis` skill's "Reading Linear" rule) — read it in ONE
+   command (the helper's function is only defined in the shell that sourced it):
+   `source "${CLAUDE_PLUGIN_ROOT}/scripts/lib/linear-read-replica.sh" && linear_read_ticket "$TICKET"`
+   (freshness gate → SQL → loud linearis fallback). **Comments are not mirrored** —
+   fetch them via `linearis comments list "$TICKET"` (see `/catalyst-dev:linearis`);
+   this stays on `linearis` and is
+   structurally outside the `issues read` detector.
 2. **Preserve all technical content** (file refs, repro steps, root-cause notes, SHAs). You are
    restructuring, not deleting. Move technical detail under a `## Technical notes` section below the
    Gherkin so it stays but doesn't lead.

--- a/plugins/dev/skills/linear/SKILL.md
+++ b/plugins/dev/skills/linear/SKILL.md
@@ -5,7 +5,7 @@ description:
   ticket', 'update the ticket', 'move ticket to', 'search Linear', or wants to create tickets from
   thoughts documents, update ticket status, or manage the Linear workflow. Uses Linearis CLI."
 disable-model-invocation: false
-allowed-tools: Bash(linearis *), Bash(linear_read_ticket *), Read, Write, Edit, Grep
+allowed-tools: Bash(linearis *), Bash(source *), Bash(linear_read_ticket *), Read, Write, Edit, Grep
 version: 1.0.0
 ---
 

--- a/plugins/dev/skills/linear/SKILL.md
+++ b/plugins/dev/skills/linear/SKILL.md
@@ -5,7 +5,7 @@ description:
   ticket', 'update the ticket', 'move ticket to', 'search Linear', or wants to create tickets from
   thoughts documents, update ticket status, or manage the Linear workflow. Uses Linearis CLI."
 disable-model-invocation: false
-allowed-tools: Bash(linearis *), Read, Write, Edit, Grep
+allowed-tools: Bash(linearis *), Bash(linear_read_ticket *), Read, Write, Edit, Grep
 version: 1.0.0
 ---
 
@@ -268,7 +268,9 @@ When user wants to add a comment to a ticket:
 
 1. **Determine which ticket:**
    - Use context from the current conversation to identify the relevant ticket
-   - If uncertain, read the ticket to show details and confirm (see `linearis issues usage`)
+   - If uncertain, read the ticket to show details and confirm — read via the replica
+     (`source "${CLAUDE_PLUGIN_ROOT}/scripts/lib/linear-read-replica.sh"; linear_read_ticket "$TICKET"`),
+     per the `linearis` skill's "Reading Linear" rule; see also `linearis issues usage`.
 
 2. **Format comments for clarity:**
    - Keep concise (~10 lines) unless more detail needed

--- a/plugins/dev/skills/linearis/SKILL.md
+++ b/plugins/dev/skills/linearis/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: linearis-cli
 description:
-  Reference for Linearis CLI commands to interact with Linear project management. Use when working
+  Linear access rule + Linearis CLI reference. READS → query the local replica by direct SQL
+  (`~/catalyst/catalyst-replica.db`); WRITES and list/search → the `linearis` CLI. Use when working
   with Linear tickets, cycles, projects, milestones, or when the user mentions ticket IDs like
   TEAM-123, ENG-456, PROJ-789.
 ---
@@ -10,22 +11,16 @@ description:
 
 > Verified against Linearis v2026.4.9 on 2026-05-31.
 
+> ⚠️ **READ vs WRITE — the rule that governs everything below.** Linear **READS** → query the local
+> replica by direct SQL (`~/catalyst/catalyst-replica.db`), or call `linear_read_ticket <ID>`.
+> **Never** shell `linearis issues read` for a routine read — that hits the rate-limited API and 429s
+> the shared quota. **WRITES** (create/update/state/comment/estimate/label) and **list/search/non-issue
+> domains** → the `linearis` CLI. Full rule + freshness gate: **[Reading Linear](#reading-linear)**.
+
 **CRITICAL: Always use these exact patterns. Do NOT guess or improvise syntax.**
 
 > ⚠️ **Read the [Gotchas & Traps](#gotchas--traps) section before scripting** — `issues list` silently
 > hides Done tickets, `linearis` eats stdin in loops, and there is no `--json` flag. These bite hard.
-
-## Looking Up Syntax
-
-For full flag details, run `linearis usage` (all domains) or `linearis <domain> usage` (one domain).
-The `usage` output is authoritative and always current — prefer it over memorizing flags.
-
-```bash
-linearis usage                # Full overview of every domain and flag
-linearis issues usage         # Just issue operations
-linearis milestones usage     # Just milestone operations
-linearis cycles usage         # Just cycle operations
-```
 
 ## Reading Linear
 
@@ -140,6 +135,18 @@ agent/skill reads and retained only as a fail-open compatibility shim. Prefer di
 additive `_meta` field + duplicate-flag collapsing broke bare-`linearis` jq pipelines.) The
 daemon's own read paths use `replica-read.mjs` directly and are unaffected by this deprecation.
 
+## Looking Up Syntax
+
+For full flag details, run `linearis usage` (all domains) or `linearis <domain> usage` (one domain).
+The `usage` output is authoritative and always current — prefer it over memorizing flags.
+
+```bash
+linearis usage                # Full overview of every domain and flag
+linearis issues usage         # Just issue operations
+linearis milestones usage     # Just milestone operations
+linearis cycles usage         # Just cycle operations
+```
+
 ## Gotchas & Traps
 
 These are non-obvious behaviors that silently produce wrong results. Verified empirically against
@@ -194,13 +201,19 @@ v2026.4.9.
 ### Read a ticket
 
 ```bash
-# Preferred — direct SQL (gate on freshness first; see Reading Linear)
-sqlite3 -json "${CATALYST_REPLICA_DB:-${CATALYST_DIR:-$HOME/catalyst}/catalyst-replica.db}" \
-  "SELECT identifier, title, state, estimate FROM issues WHERE identifier='ENG-123' AND removed_at IS NULL;"
+# Preferred — the shared helper: freshness gate → replica SQL → loud linearis fallback, one call.
+source "${SCRIPT_DIR}/lib/linear-read-replica.sh"   # plugins/dev/scripts/lib/linear-read-replica.sh
+json=$(linear_read_ticket ENG-123) || return 1      # linearis-shaped JSON (state.name, estimate, labels.nodes[]…)
+title=$(printf '%s' "$json" | jq -r '.title // empty')
 
-# Fallback only (replica stale/absent) — and surface it as an anomaly + file a ticket
-linearis issues read ENG-123
+# No helper on hand? Inline SQL — gate on freshness first (see Reading Linear):
+DB="${CATALYST_REPLICA_DB:-${CATALYST_DIR:-$HOME/catalyst}/catalyst-replica.db}"
+sqlite3 -json "$DB" \
+  "SELECT identifier, title, state, estimate FROM issues WHERE identifier='ENG-123' AND removed_at IS NULL;"
 ```
+
+> `linearis issues read ENG-123` is the STALE/ABSENT **fallback only**. `linear_read_ticket` runs it
+> for you and surfaces the fallback loudly — do **not** shell it directly for a routine read.
 
 ### Search tickets
 

--- a/plugins/dev/skills/linearis/SKILL.md
+++ b/plugins/dev/skills/linearis/SKILL.md
@@ -201,15 +201,19 @@ v2026.4.9.
 ### Read a ticket
 
 ```bash
-# Preferred — the shared helper: freshness gate → replica SQL → loud linearis fallback, one call.
-source "${SCRIPT_DIR}/lib/linear-read-replica.sh"   # plugins/dev/scripts/lib/linear-read-replica.sh
-json=$(linear_read_ticket ENG-123) || return 1      # linearis-shaped JSON (state.name, estimate, labels.nodes[]…)
-title=$(printf '%s' "$json" | jq -r '.title // empty')
-
-# No helper on hand? Inline SQL — gate on freshness first (see Reading Linear):
+# Preferred — self-contained inline replica SQL. No source, no $SCRIPT_DIR — works in any
+# shell. Resolves the DB path the same way the daemon does (gate on freshness first; see
+# Reading Linear):
 DB="${CATALYST_REPLICA_DB:-${CATALYST_DIR:-$HOME/catalyst}/catalyst-replica.db}"
 sqlite3 -json "$DB" \
   "SELECT identifier, title, state, estimate FROM issues WHERE identifier='ENG-123' AND removed_at IS NULL;"
+
+# Inside a skill/script, the shared helper does freshness-gate → replica SQL → loud linearis
+# fallback in ONE call. Source it by a RESOLVABLE root — there is NO $SCRIPT_DIR in a bare
+# shell; in a catalyst-dev skill use $CLAUDE_PLUGIN_ROOT:
+source "${CLAUDE_PLUGIN_ROOT:?source in a catalyst-dev skill}/scripts/lib/linear-read-replica.sh"
+json=$(linear_read_ticket ENG-123) || return 1      # linearis-shaped JSON (state.name, estimate, labels.nodes[]…)
+title=$(printf '%s' "$json" | jq -r '.title // empty')
 ```
 
 > `linearis issues read ENG-123` is the STALE/ABSENT **fallback only**. `linear_read_ticket` runs it

--- a/plugins/dev/skills/phase-research/SKILL.md
+++ b/plugins/dev/skills/phase-research/SKILL.md
@@ -125,8 +125,24 @@ Conduct the research by **invoking the canonical skill** rather than reimplement
 it. The body of [[research-codebase]] is the single source of truth for how research
 is performed.
 
-1. Read the Linear ticket via `linearis issues read $TICKET --with-attachments` to
-   get the title, description, and any linked plan reference.
+1. Read the Linear ticket from the **replica** (per the `linearis` skill's "Reading
+   Linear" rule; NEVER a bare `linearis issues read`, which burns the shared API
+   quota). Use the shared helper:
+   ```bash
+   source "${PLUGIN_ROOT}/scripts/lib/linear-read-replica.sh"
+   TICKET_JSON=$(linear_read_ticket "$TICKET")   # freshness gate → replica SQL → loud linearis fallback
+   TITLE=$(printf '%s' "$TICKET_JSON" | jq -r '.title // empty')
+   DESC=$(printf '%s'  "$TICKET_JSON" | jq -r '.description // empty')
+   ```
+   Take the title and description from `$TICKET_JSON`. **Linked plan reference:**
+   most plan pointers are inline links in the description — scan `$DESC` first. If
+   `$DESC` contains no plan reference, the pointer may be stored as a Linear
+   link-attachment (NOT mirrored in the replica) — only then fetch it explicitly:
+   `linearis issues read "$TICKET" --with-attachments </dev/null` and read
+   `.attachments`. Do not conclude "no plan" from `$DESC` alone.
+   **Attachments are the one field the replica does not mirror**; skip the
+   `--with-attachments` fetch entirely when the description already yields what
+   research needs (the common case).
 2. Read the triage summary from `$TRIAGE_FILE` to understand classification and
    surfaced dependencies.
 3. **Pull-before-read (CTL-1236).** Fast-forward all thoughts checkouts so reads

--- a/plugins/dev/templates/CLAUDE_SNIPPET.md
+++ b/plugins/dev/templates/CLAUDE_SNIPPET.md
@@ -39,6 +39,8 @@ This project uses [Catalyst](https://github.com/coalesce-labs/catalyst) for AI-a
 /catalyst-filter      # Register semantic event interests (orchestrators only)
 ```
 
+**Linear reads → local replica:** for a single-ticket read call `linear_read_ticket <ID>` (never a bare `linearis issues read <ID>` — it 429s the shared quota); writes and list/search stay on `linearis`. See the `linearis` skill's "Reading Linear".
+
 ### Agent Teams
 
 For complex implementations spanning multiple domains (frontend + backend + tests),

--- a/plugins/legacy/skills/orchestrate/SKILL.md
+++ b/plugins/legacy/skills/orchestrate/SKILL.md
@@ -468,10 +468,12 @@ if [ -z "$COMMS_BIN" ] || [ ! -x "$COMMS_BIN" ]; then
 fi
 
 # Build the registration JSON with all workers from all waves
-# Use linearis CLI to read ticket titles (run `linearis issues usage` for syntax)
+# Read ticket titles via the replica (per the `linearis` skill's "Reading Linear"
+# rule). A bare linearis loop also burns shared quota AND eats stdin without </dev/null.
+source "${CATALYST_DEV_SCRIPTS}/lib/linear-read-replica.sh"
 WORKERS_JSON="{}"
 for TICKET_ID in "${ALL_TICKETS[@]}"; do
-  TITLE=$(linearis issues read "$TICKET_ID" | jq -r '.title')  # see `linearis issues usage`
+  TITLE=$(linear_read_ticket "$TICKET_ID" | jq -r '.title')
   WORKERS_JSON=$(echo "$WORKERS_JSON" | jq \
     --arg tid "$TICKET_ID" --arg title "$TITLE" \
     '. + {($tid): {ticketId: $tid, title: $title, status: "dispatched", phase: 0, branch: null, pr: null, updatedAt: "'$(date -u +%Y-%m-%dT%H:%M:%SZ)'", needsAttention: false, attentionReason: null}}')


### PR DESCRIPTION
## Why

CTL-1397 (#2514) pivoted agent Linear **reads** to direct SQLite against the local `catalyst-replica.db`, but wrote the rule into exactly **one on-demand file** — the `linearis` skill. Nothing landed in **always-loaded core context** or the **startup prerequisite gate**, so a habit-driven / interactive session that shells `linearis issues read <ID>` never loads the file with the rule and never sees it. That's why **~52 laptop agent sessions keep 429-ing the personal 2500/hr Linear key**. This PR makes replica-first a **standard prerequisite reflex** across every path an agent takes to a Linear read, adds a **detector** so 52→0 is measurable, and **preserves every legitimate `linearis` use**.

Adversarially reviewed **twice** — the design spec (4 spec agents → synthesis → 4 skeptic lenses → revision) and the implemented diff (5 independent lenses → GO-with-fixes, zero blockers).

## Change set

**Always-loaded reflex (the root-cause hole)**
- `AGENTS.md` — buried DRY footnote → a Key Principles **imperative** bullet.
- `CLAUDE_SNIPPET.md` — one-line imperative+pointer (injected into every project `CLAUDE.md`).
- `_phase-agent-template` — Contract item 6, so every phase worker inherits it.
- `workflow-rules.mjs` — prepend a constant replica-first line to every resolved `--bg` phase-worker preamble (fail-open; composes with per-phase preambles).

**Prerequisite gate**
- `check-project-setup.sh` — new §8: source the read helper; **FRESH** → green affirmative; **STALE / opted-in-but-missing** → advisory WARN (never fatal); **non-fleet host** → silent (no false alarm). Only appends to `warnings`, never `errors` — exit-1 contract untouched (**test 21/21 pass**).

**Contradictions closed + allowlists unblocked**
- `phase-research` — convert the busiest orchestrated read; keep the `--with-attachments` link-attachment plan-pointer fallback (no silent drop).
- legacy `orchestrate` — convert the title-read loop (also fixes the stdin-eating trap).
- `gherkin-ticket` / `linear` — grant `Bash(linear_read_ticket *)` + route the read via the helper as a single compound command.

**Skill reframe** (`linearis` skill) — description leads with the read/write split; a READ-vs-WRITE banner + the `## Reading Linear` rule now sit first; the "Read a ticket" example leads with the helper and **demotes** bare `linearis issues read` to a fallback note.

**Detector (how we verify 52→0)**
- `lib/linear-read-replica.sh` — emit a WARN `catalyst.replica.read_fallback` event on every helper fallback (canonical event, survives `shouldSkipEvent` → Loki).
- **NEW** `plugins/dev/hooks/detect-bare-linear-read.sh` — PreToolUse/Bash hook catching bare single-ticket `linearis issues read` (literal **and** `$VAR`/`${V}`/`$(…)` forms, flag-order-independent), **exempts** `--with-attachments`, structurally ignores list/search/create/comments; **observe** (warn+count) by default, **enforce** (block, exit 2) via `CATALYST_LINEAR_READ_DETECT_MODE`. Committed script only.

## Preserved carve-outs (correctly STAY on `linearis`)
Writes · list/search · unmirrored fields (`relation.id`, `cycle.name`, `state.id`, `team.key`, `children`, `parent.title`) · attachments · comments.

## Verification
- Detector **10/10** smoke cases (read/list/create/comments/attachments/enforce).
- `canonical-event.sh` interface confirmed + **live emit** produces a Loki-valid line.
- `linearis` skill reorder verbatim-intact, all intra-doc anchors resolve.
- `check-project-setup.sh` **21/21**; `bash -n` + `node --check` clean on all changed scripts.
- Baseline: prompting/markdown only — no execution-core test surface beyond the two above.

## Deploy + verify (post-merge)
Ships via merge → broker plugin-source pull (no daemon restart). **Then**: install the PreToolUse hook in the laptop's `~/.claude/settings.json` (observe first), watch the `catalyst.replica.read_fallback` burn-down in Loki, and flip the laptop to `enforce` once residual is legitimate carve-outs only.

## Follow-ups (documented, not blockers)
- Install the hook + flip to enforce (deploy step).
- CH-6: confirm `claude --bg --settings` vs global `hooks.PreToolUse` merge for phase workers.
- oneshot legacy prose reference.

🤖 Generated with [Claude Code](https://claude.com/claude-code)