### PR TITLE
feat(dev): CTL-1422 — warm resume: a daemon restart continues in-flight SDK work

### DIFF
--- a/plugins/dev/scripts/execution-core/boot-resume.mjs
+++ b/plugins/dev/scripts/execution-core/boot-resume.mjs
@@ -392,6 +392,13 @@ export function reconcileBootResume({
   // CTL-1084: per-boot dispatch cap for cheap phases. Deferred items drain via
   // Sweep 1.5 on subsequent ticks. Default from BOOT_REWALK_MAX_PER_TICK const.
   maxRewalkPerTick = BOOT_REWALK_MAX_PER_TICK,
+  // CTL-1422: Map<ticket, sessionId> harvested from dead-pid SDK registry
+  // projections (reconcileSdkRegistryOnBoot) — interrupted in-process runs whose
+  // SDK session can be CONTINUED via options.resume. A warm candidate bypasses
+  // the CTL-644 expensive-phase gate AND the rewalk cap: continuation is cheap,
+  // and a deferred warm candidate would lose its UUID (the harvest lives only in
+  // this boot pass — Sweep 1.5 has no access to it).
+  sdkSessionHarvest = new Map(),
 } = {}) {
   // CTL-1006 Scenario 1: eligible on a cold start OR a daemon bounce. The old
   // `report.coldStart !== true` gate was a permanent production no-op because
@@ -417,12 +424,17 @@ export function reconcileBootResume({
   const planned = candidates.length;
   let dispatched = 0;
   let resumed = 0;
+  let warmResumed = 0; // CTL-1422: dispatches that continued a harvested SDK session
   let failed = 0;
   let gated = 0;
   let deferred = 0; // CTL-1084: cheap candidates held back by the per-boot cap
   for (const { ticket, phase, worktreePath, bgJobId } of candidates) {
+    // CTL-1422: a harvested SDK session makes this a warm CONTINUATION, not a
+    // cold re-run — skip the expensive gate and the rewalk cap (rationale in
+    // the option doc above).
+    const warmSession = sdkSessionHarvest.get?.(ticket) ?? null;
     // CTL-644: gate expensive phases behind operator approval; auto-dispatch cheap ones.
-    if (!isCheapPhase(phase)) {
+    if (!isCheapPhase(phase) && !warmSession) {
       const written = writePendingMarker(orchDir, ticket, phase, worktreePath);
       if (written) {
         gated++;
@@ -437,19 +449,23 @@ export function reconcileBootResume({
 
     // CTL-1084: per-boot cheap-dispatch cap — defer to Sweep 1.5 once reached.
     // Cooldown markers are never reset here; the cap is purely additive.
-    if (dispatched >= maxRewalkPerTick) {
+    // CTL-1422: warm candidates are exempt (see option doc).
+    if (!warmSession && dispatched >= maxRewalkPerTick) {
       deferred++;
       continue;
     }
 
     // Cheap path — existing resume/dispatch logic unchanged.
+    // CTL-1422: the harvested SDK session wins over bg-job-dir resolution (an
+    // sdk-run ticket has no bg job dir; a bg-run ticket has no projection —
+    // the two sources are disjoint in practice, precedence is belt-and-braces).
     // CTL-690: try to map the dead worker's bg_job_id → resume UUID. Null
     // result (no bg id, no state.json, no/!.jsonl transcript) falls through
     // to the today-default fresh-dispatch path. The downstream stderr
     // classifier in phase-agent-dispatch (CTL-658 launched/alive/failed)
     // handles a resume that's recorded on disk but fails to launch.
-    let resumeSession = null;
-    if (bgJobId) {
+    let resumeSession = warmSession;
+    if (!resumeSession && bgJobId) {
       try {
         resumeSession = resolveSession(bgJobId);
       } catch (err) {
@@ -470,6 +486,7 @@ export function reconcileBootResume({
     if (res?.code === 0) {
       dispatched++;
       if (resumeSession) resumed++;
+      if (warmSession) warmResumed++;
       appendEvent({ phase, ticket, orchId });
     } else {
       failed++;
@@ -481,10 +498,10 @@ export function reconcileBootResume({
   }
 
   log.info(
-    { dispatched, resumed, gated, failed, deferred, planned, candidates: candidates.length },
+    { dispatched, resumed, warmResumed, gated, failed, deferred, planned, candidates: candidates.length },
     "boot-resume: cold-start reconciliation complete"
   );
-  return { dispatched, resumed, gated, failed, deferred, planned, candidates: candidates.length };
+  return { dispatched, resumed, warmResumed, gated, failed, deferred, planned, candidates: candidates.length };
 }
 
 // processApprovedResumes — CTL-644. Dispatch gated tickets whose operator

--- a/plugins/dev/scripts/execution-core/boot-resume.mjs
+++ b/plugins/dev/scripts/execution-core/boot-resume.mjs
@@ -35,6 +35,7 @@ import {
   mkdirSync,
   readdirSync,
   readFileSync,
+  rmSync,
   unlinkSync,
   writeFileSync,
 } from "node:fs";
@@ -241,6 +242,12 @@ export function selectBootResumeCandidates({
   // supersedes its resume phase. reconcileBootResume threads a real callback that
   // routes the regression to the audit log.
   onPhaseRegression = () => {},
+  // CTL-1422 review fix (B): warm-harvested tickets are exempt from the
+  // free-slot slice — dropping one silently discards its session UUID (the
+  // in-memory harvest is the boot pass's only copy in use). Safe: they were
+  // occupying slots before the restart, and the runner's semaphore still caps
+  // real concurrency.
+  sdkSessionHarvest = new Map(),
 } = {}) {
   const inFlight = listInFlightTickets(orchDir);
   if (inFlight.size === 0) return [];
@@ -338,7 +345,11 @@ export function selectBootResumeCandidates({
 
   const free = computeFreeSlots(maxParallel, liveCount);
   needResume.sort((a, b) => a.ticket.localeCompare(b.ticket));
-  return needResume.slice(0, free);
+  // CTL-1422 (B): warm candidates always survive selection; the slice caps
+  // only cold candidates, against the slots warm did not consume.
+  const warm = needResume.filter((c) => sdkSessionHarvest.has?.(c.ticket));
+  const cold = needResume.filter((c) => !sdkSessionHarvest.has?.(c.ticket));
+  return [...warm, ...cold.slice(0, Math.max(0, free - warm.length))];
 }
 
 // resolveAgents — normalize the injectable `agents` seam to a concrete array.
@@ -367,6 +378,42 @@ function resolveAgents(agents) {
 // dispatch-cooldown markers — it never resets them.
 const BOOT_REWALK_MAX_PER_TICK =
   Number(process.env.CATALYST_BOOT_REWALK_MAX_PER_TICK) || 2;
+
+// CTL-1422 review fix (A): the warm-resume loop budget. A crash-looping daemon
+// would otherwise re-resume the SAME session on every boot forever — bypassing
+// the CTL-644 operator gate it is allowed to skip only because a continuation
+// is cheap ONCE. The budget is keyed by session UUID (a NEW session is a new
+// run, not a loop) and persisted per ticket so it survives the crash loop it
+// exists to stop. At the cap, the candidate falls back to the normal gated path.
+export const WARM_RESUME_MAX_PER_SESSION =
+  Number(process.env.CATALYST_WARM_RESUME_MAX_PER_SESSION) || 3;
+
+function warmBudgetPath(orchDir, ticket) {
+  return join(orchDir, "workers", ticket, ".warm-resume-budget");
+}
+
+// Returns true when the warm path may proceed (and records the attempt);
+// false when the session has exhausted its budget.
+function consumeWarmBudget(orchDir, ticket, sessionId) {
+  const p = warmBudgetPath(orchDir, ticket);
+  let rec = null;
+  try {
+    rec = JSON.parse(readFileSync(p, "utf8"));
+  } catch {
+    /* absent/corrupt → fresh budget */
+  }
+  const count = rec?.sessionId === sessionId ? Number(rec.count) || 0 : 0;
+  if (count >= WARM_RESUME_MAX_PER_SESSION) return false;
+  try {
+    writeFileSync(p, JSON.stringify({ sessionId, count: count + 1 }));
+  } catch (err) {
+    log.warn(
+      { ticket, err: err?.message },
+      "boot-resume: warm-budget write failed — allowing this resume, budget not durable"
+    );
+  }
+  return true;
+}
 
 export function reconcileBootResume({
   orchDir,
@@ -418,6 +465,7 @@ export function reconcileBootResume({
     // audit log instead of re-dispatching it behind a later terminal phase.
     onPhaseRegression: ({ ticket, phase, dominantPhase }) =>
       appendRegressionEvent({ phase, ticket, dominantPhase, orchId }),
+    sdkSessionHarvest, // CTL-1422 (B): warm candidates are slice-exempt
   });
 
   // CTL-1084: planned = total candidates found (before any cap or cooldown filter).
@@ -431,8 +479,17 @@ export function reconcileBootResume({
   for (const { ticket, phase, worktreePath, bgJobId } of candidates) {
     // CTL-1422: a harvested SDK session makes this a warm CONTINUATION, not a
     // cold re-run — skip the expensive gate and the rewalk cap (rationale in
-    // the option doc above).
-    const warmSession = sdkSessionHarvest.get?.(ticket) ?? null;
+    // the option doc above). Review fix (A): the skip is BUDGETED per session
+    // UUID — an exhausted budget demotes the candidate to the normal cold path
+    // (gate + cap apply), so a crash-looping daemon cannot re-resume forever.
+    let warmSession = sdkSessionHarvest.get?.(ticket) ?? null;
+    if (warmSession && !consumeWarmBudget(orchDir, ticket, warmSession)) {
+      log.warn(
+        { ticket, phase, sessionId: warmSession, max: WARM_RESUME_MAX_PER_SESSION },
+        "boot-resume: warm-resume budget exhausted for this session — demoting to the gated cold path"
+      );
+      warmSession = null;
+    }
     // CTL-644: gate expensive phases behind operator approval; auto-dispatch cheap ones.
     if (!isCheapPhase(phase) && !warmSession) {
       const written = writePendingMarker(orchDir, ticket, phase, worktreePath);
@@ -464,6 +521,16 @@ export function reconcileBootResume({
     // to the today-default fresh-dispatch path. The downstream stderr
     // classifier in phase-agent-dispatch (CTL-658 launched/alive/failed)
     // handles a resume that's recorded on disk but fails to launch.
+    // CTL-1422 review fix (C): a warm dispatch supersedes any pending-approval
+    // marker a PRIOR boot's cold gating left behind — otherwise a later operator
+    // approval (processApprovedResumes) double-dispatches the same ticket.
+    if (warmSession) {
+      try {
+        rmSync(bootResumePendingPath(orchDir, ticket), { force: true });
+      } catch {
+        /* best-effort */
+      }
+    }
     let resumeSession = warmSession;
     if (!resumeSession && bgJobId) {
       try {

--- a/plugins/dev/scripts/execution-core/boot-resume.test.mjs
+++ b/plugins/dev/scripts/execution-core/boot-resume.test.mjs
@@ -12,6 +12,7 @@ import { mkdtempSync, rmSync, mkdirSync, writeFileSync, readFileSync, existsSync
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
+  WARM_RESUME_MAX_PER_SESSION,
   hasLiveBgWorker,
   activePhaseForTicket,
   selectBootResumeCandidates,
@@ -1374,5 +1375,85 @@ describe("reconcileBootResume — CTL-1422 warm resume", () => {
     });
     expect(res.dispatched).toBe(1);
     expect(dispatched[0]).toMatchObject({ resumeSession: "sess-warm-5" });
+  });
+});
+
+// ── CTL-1422 review fixes: warm-resume loop budget + slice exemption + marker clear ──
+
+describe("reconcileBootResume — CTL-1422 review hardening", () => {
+  const warmDeps = (over = {}) => ({
+    orchDir,
+    report: { coldStart: true },
+    agents: [],
+    dispatch: () => {},
+    appendEvent: () => {},
+    appendGatedEvent: () => {},
+    resolveSession: () => null,
+    ...over,
+  });
+
+  test("the SAME session UUID warm-resumes at most WARM_RESUME_MAX_PER_SESSION times, then falls to the gated path", () => {
+    const dispatched = [];
+    const gated = [];
+    for (let boot = 0; boot < 5; boot++) {
+      rmSync(join(orchDir, "workers", "CTL-1", "phase-implement.json"), { force: true });
+      writeSignal(orchDir, "CTL-1", "implement", { worktreePath: "/wt/CTL-1", bg_job_id: null });
+      reconcileBootResume(warmDeps({
+        reviveDispatch: (a) => { dispatched.push(a); return { code: 0 }; },
+        appendGatedEvent: (e) => gated.push(e),
+        sdkSessionHarvest: new Map([["CTL-1", "sess-loop"]]),
+      }));
+    }
+    expect(dispatched.length).toBe(WARM_RESUME_MAX_PER_SESSION);
+    expect(gated.length).toBe(1); // the over-budget boot falls back to the CTL-644 gate exactly once (marker idempotent after)
+  });
+
+  test("a DIFFERENT session UUID resets the warm budget (new run, not a loop)", () => {
+    const dispatched = [];
+    for (let boot = 0; boot < 2; boot++) {
+      rmSync(join(orchDir, "workers", "CTL-2", "phase-implement.json"), { force: true });
+      rmSync(join(orchDir, "workers", "CTL-2", ".boot-resume-pending-approval"), { force: true });
+      writeSignal(orchDir, "CTL-2", "implement", { worktreePath: "/wt/CTL-2", bg_job_id: null });
+      for (let i = 0; i < WARM_RESUME_MAX_PER_SESSION; i++) {
+        reconcileBootResume(warmDeps({
+          reviveDispatch: (a) => { dispatched.push(a); return { code: 0 }; },
+          sdkSessionHarvest: new Map([["CTL-2", `sess-gen-${boot}`]]),
+        }));
+      }
+    }
+    expect(dispatched.length).toBe(2 * WARM_RESUME_MAX_PER_SESSION);
+  });
+
+  test("warm candidates are exempt from the free-slot slice (the UUID must not be silently dropped)", () => {
+    // maxParallel=1 with two candidates: the lexically-later warm ticket must
+    // still dispatch; the cold one takes the single free slot.
+    writeSignal(orchDir, "CTL-A", "plan", { worktreePath: "/wt/CTL-A", bg_job_id: null });
+    writeSignal(orchDir, "CTL-Z", "plan", { worktreePath: "/wt/CTL-Z", bg_job_id: null });
+    const dispatched = [];
+    reconcileBootResume(warmDeps({
+      reviveDispatch: (a) => { dispatched.push(a.ticket); return { code: 0 }; },
+      concurrency: { maxParallel: 1 },
+      maxRewalkPerTick: 100,
+      sdkSessionHarvest: new Map([["CTL-Z", "sess-z"]]),
+    }));
+    expect(dispatched).toContain("CTL-Z"); // warm — slice-exempt
+    expect(dispatched).toHaveLength(1); // cold CTL-A lost the single slot to nothing else… slice caps cold only
+  });
+
+  test("a warm dispatch clears a stale pending-approval marker (no later double-dispatch)", () => {
+    writeSignal(orchDir, "CTL-3", "implement", { worktreePath: "/wt/CTL-3", bg_job_id: null });
+    // simulate the marker left by a PRIOR boot's cold gating
+    mkdirSync(join(orchDir, "workers", "CTL-3"), { recursive: true });
+    writeFileSync(
+      join(orchDir, "workers", "CTL-3", ".boot-resume-pending-approval"),
+      JSON.stringify({ ticket: "CTL-3", phase: "implement" }),
+    );
+    const dispatched = [];
+    reconcileBootResume(warmDeps({
+      reviveDispatch: (a) => { dispatched.push(a); return { code: 0 }; },
+      sdkSessionHarvest: new Map([["CTL-3", "sess-3"]]),
+    }));
+    expect(dispatched).toHaveLength(1);
+    expect(existsSync(join(orchDir, "workers", "CTL-3", ".boot-resume-pending-approval"))).toBe(false);
   });
 });

--- a/plugins/dev/scripts/execution-core/boot-resume.test.mjs
+++ b/plugins/dev/scripts/execution-core/boot-resume.test.mjs
@@ -1253,3 +1253,126 @@ describe("boot re-walk damping (CTL-1084)", () => {
     expect(res.dispatched).toBe(0);
   });
 });
+
+// ── CTL-1422: warm resume from harvested SDK sessions ─────────────────────────
+// sdkSessionHarvest (Map<ticket, sessionId>, from reconcileSdkRegistryOnBoot's
+// dead-pid projection harvest) turns a boot re-dispatch into a session
+// CONTINUATION: resumeSession is the harvested UUID, the CTL-644 expensive-phase
+// approval gate is bypassed (continuing is cheap — the gate exists to stop
+// costly cold re-runs), and the rewalk cap does not defer it (a deferred warm
+// candidate would lose its UUID: the harvest lives only in this boot pass).
+
+describe("reconcileBootResume — CTL-1422 warm resume", () => {
+  test("a harvested session warm-resumes an EXPENSIVE phase immediately (gate + cap bypassed)", () => {
+    writeSignal(orchDir, "CTL-1", "implement", { worktreePath: "/wt/CTL-1", bg_job_id: null });
+    const dispatched = [];
+    const reviveDispatch = (a) => {
+      dispatched.push(a);
+      return { code: 0 };
+    };
+    const res = reconcileBootResume({
+      orchDir,
+      report: { coldStart: true },
+      agents: [],
+      reviveDispatch,
+      dispatch: () => {},
+      appendEvent: () => {},
+      appendGatedEvent: () => {},
+      resolveSession: () => null,
+      maxRewalkPerTick: 0, // even a zero cap must not defer a warm resume
+      sdkSessionHarvest: new Map([["CTL-1", "sess-warm-1"]]),
+    });
+    expect(res.gated).toBe(0);
+    expect(res.dispatched).toBe(1);
+    expect(res.warmResumed).toBe(1);
+    expect(dispatched).toHaveLength(1);
+    expect(dispatched[0]).toMatchObject({ ticket: "CTL-1", phase: "implement", resumeSession: "sess-warm-1" });
+  });
+
+  test("no harvested session → cold path unchanged (expensive phase still gated)", () => {
+    writeSignal(orchDir, "CTL-2", "implement", { worktreePath: "/wt/CTL-2", bg_job_id: null });
+    const dispatched = [];
+    const gatedEvents = [];
+    const res = reconcileBootResume({
+      orchDir,
+      report: { coldStart: true },
+      agents: [],
+      reviveDispatch: (a) => {
+        dispatched.push(a);
+        return { code: 0 };
+      },
+      dispatch: () => {},
+      appendEvent: () => {},
+      appendGatedEvent: (e) => gatedEvents.push(e),
+      resolveSession: () => null,
+      sdkSessionHarvest: new Map(),
+    });
+    expect(res.dispatched).toBe(0);
+    expect(res.gated).toBe(1);
+    expect(res.warmResumed ?? 0).toBe(0);
+    expect(gatedEvents).toHaveLength(1);
+    expect(dispatched).toHaveLength(0);
+  });
+
+  test("a warm session for a CHEAP phase also resumes with the UUID (not fresh)", () => {
+    writeSignal(orchDir, "CTL-3", "plan", { worktreePath: "/wt/CTL-3", bg_job_id: null });
+    const dispatched = [];
+    const res = reconcileBootResume({
+      orchDir,
+      report: { coldStart: true },
+      agents: [],
+      reviveDispatch: (a) => {
+        dispatched.push(a);
+        return { code: 0 };
+      },
+      dispatch: () => {},
+      appendEvent: () => {},
+      resolveSession: () => null,
+      sdkSessionHarvest: new Map([["CTL-3", "sess-warm-3"]]),
+    });
+    expect(res.dispatched).toBe(1);
+    expect(res.resumed).toBe(1);
+    expect(res.warmResumed).toBe(1);
+    expect(dispatched[0]).toMatchObject({ ticket: "CTL-3", resumeSession: "sess-warm-3" });
+  });
+
+  test("a terminal signal is never warm-resumed even with a harvested session", () => {
+    writeSignal(orchDir, "CTL-4", "implement", { worktreePath: "/wt/CTL-4", status: "done", bg_job_id: null });
+    const dispatched = [];
+    const res = reconcileBootResume({
+      orchDir,
+      report: { coldStart: true },
+      agents: [],
+      reviveDispatch: (a) => {
+        dispatched.push(a);
+        return { code: 0 };
+      },
+      dispatch: () => {},
+      appendEvent: () => {},
+      resolveSession: () => null,
+      sdkSessionHarvest: new Map([["CTL-4", "sess-dead"]]),
+    });
+    expect(res.dispatched).toBe(0);
+    expect(dispatched).toHaveLength(0);
+  });
+
+  test("warm resume prefers the harvest over bg-session resolution", () => {
+    writeSignal(orchDir, "CTL-5", "plan", { worktreePath: "/wt/CTL-5", bg_job_id: "deadbeef" });
+    const dispatched = [];
+    const res = reconcileBootResume({
+      orchDir,
+      report: { coldStart: true },
+      agents: [],
+      reviveDispatch: (a) => {
+        dispatched.push(a);
+        return { code: 0 };
+      },
+      dispatch: () => {},
+      appendEvent: () => {},
+      resolveSession: () => "sess-from-bg-jobdir",
+      sdkSessionHarvest: new Map([["CTL-5", "sess-warm-5"]]),
+    });
+    expect(res.dispatched).toBe(1);
+    expect(dispatched[0]).toMatchObject({ resumeSession: "sess-warm-5" });
+  });
+});

--- a/plugins/dev/scripts/execution-core/daemon.mjs
+++ b/plugins/dev/scripts/execution-core/daemon.mjs
@@ -634,10 +634,20 @@ export function startDaemon({
     const sdkRegistryBoot = reconcileSdkRegistryOnBoot(orchDir);
     if (sdkRegistryBoot.removed.length > 0) {
       log.info(
-        { removed: sdkRegistryBoot.removed, kept: sdkRegistryBoot.kept },
-        "boot: reaped stale sdk-worker projections (CTL-1410)"
+        {
+          removed: sdkRegistryBoot.removed,
+          kept: sdkRegistryBoot.kept,
+          harvested: sdkRegistryBoot.harvested.map((h) => h.ticket),
+        },
+        "boot: reaped stale sdk-worker projections (CTL-1410); harvested warm-resume sessions (CTL-1422)"
       );
     }
+    // CTL-1422: interrupted in-process runs (dead-pid projections that captured a
+    // session UUID) become warm-resume candidates — boot-resume CONTINUES their
+    // SDK session via options.resume instead of cold re-dispatching the phase.
+    const sdkSessionHarvest = new Map(
+      sdkRegistryBoot.harvested.map((h) => [h.ticket, h.sessionId])
+    );
     // CTL-1396 (Codex P2): under executor=sdk, inject the unified-event-log appender
     // into the dispatch path so sdkRunPhaseAgent's telemetry (execution-core.sdk.phase-turns
     // — the turn-cap calibration signal — plus .overloaded/.auth.misconfigured) lands in
@@ -668,7 +678,7 @@ export function startDaemon({
     // CTL-1365b: dispatch === dispatchFn so the crash-recovery re-dispatch honors
     // the executor flag (defaultDispatch under bg — reconcileBootResume's own
     // default — so byte-identical to today).
-    const bootResume = reconcileBoot({ orchDir, report, concurrency, dispatch: dispatchFn }); // CTL-665: config-first boot-resume ceiling
+    const bootResume = reconcileBoot({ orchDir, report, concurrency, dispatch: dispatchFn, sdkSessionHarvest }); // CTL-665: config-first ceiling; CTL-1422: warm-resume harvest
     _bootResume = bootResume;
     // CTL-644: dispatch any gated tickets that already have an approval sentinel on disk
     // (operator may have dropped the sentinel while the daemon was down).

--- a/plugins/dev/scripts/execution-core/sdk-run-phase-agent.mjs
+++ b/plugins/dev/scripts/execution-core/sdk-run-phase-agent.mjs
@@ -1034,6 +1034,13 @@ export async function sdkRunPhaseAgent(
   // workers are, by the scheduler's maxParallel admission gate upstream.
   const sem = semaphore ?? sharedSemaphore(maxParallel);
   const release = await sem.acquire();
+  // CTL-1422: the live SDK session UUID — the warm-resume key. Captured from the
+  // first streamed message that carries one (the init message; a 429-retry starts
+  // a NEW session, so a changed id re-captures). Persisted to the registry
+  // projection the moment it is known (a daemon crash must not lose it) and
+  // announced on the unified event log (worker.session.started|resumed) so the
+  // fleet view / orphan lookback can be built centrally (Loki ships the same log).
+  let sessionId = null;
   try {
     let lastOverload = null;
     for (let i = 0; i <= maxRetries; i++) {
@@ -1047,6 +1054,22 @@ export async function sdkRunPhaseAgent(
         const q = runQuery({ prompt: spec.prompt, options: { ...options, abortController: ac } });
         for await (const m of q) {
           reg.touch(); // registry heartbeat (internally throttled to disk)
+          if (typeof m?.session_id === "string" && m.session_id && m.session_id !== sessionId) {
+            // A 429-retry starts a NEW session: close the old id first so the
+            // log never carries a dangling started (the "interrupted" shape is
+            // reserved for real crashes/kills).
+            if (sessionId) {
+              emitEvent("worker.session.stopped", {
+                ticket, phase, session_id: sessionId, generation: spec.generation ?? null,
+              });
+            }
+            sessionId = m.session_id;
+            reg.setSessionId?.(sessionId); // optional-chained: Phase B test fakes lack it
+            emitEvent(
+              spec.resumeSession ? "worker.session.resumed" : "worker.session.started",
+              { ticket, phase, session_id: sessionId, generation: spec.generation ?? null },
+            );
+          }
           if (m?.type === "result") result = m; // exactly one terminal
         }
       } catch (err) {
@@ -1156,6 +1179,15 @@ export async function sdkRunPhaseAgent(
     // Unreachable (the loop always returns), but keep a defined shape.
     return { code: 1, stdout: "", stderr: "sdk: retry loop exhausted", signal: null };
   } finally {
+    // CTL-1422: the lifecycle close — "started/resumed without a stopped" is the
+    // boot-time (and Loki) definition of an interrupted session, so stopped must
+    // fire on EVERY post-capture exit path. A daemon crash/SIGKILL skips this by
+    // nature, which is exactly what makes the interrupted session harvestable.
+    if (sessionId) {
+      emitEvent("worker.session.stopped", {
+        ticket, phase, session_id: sessionId, generation: spec.generation ?? null,
+      });
+    }
     reg.deregister(); // every post-registration exit path, including throws
     release();
   }

--- a/plugins/dev/scripts/execution-core/sdk-run-phase-agent.mjs
+++ b/plugins/dev/scripts/execution-core/sdk-run-phase-agent.mjs
@@ -1019,6 +1019,10 @@ export async function sdkRunPhaseAgent(
     worktreePath: spec.worktreePath ?? worktreePath,
     generation: spec.generation,
     orchDir,
+    // CTL-1422 review fix (D): a warm resume knows its session UUID up front —
+    // seed the projection so a crash before the first streamed message doesn't
+    // break the warm chain (the init capture below overwrites/confirms it).
+    sessionId: spec.resumeSession ?? null,
   });
 
   // ── LAUNCH VERB: the in-process query() loop, under the concurrency cap ───

--- a/plugins/dev/scripts/execution-core/sdk-run-phase-agent.test.mjs
+++ b/plugins/dev/scripts/execution-core/sdk-run-phase-agent.test.mjs
@@ -1746,3 +1746,141 @@ describe("sdkRunPhaseAgent — CTL-1410 Phase B (worker registry wiring)", () =>
     expect(state.registered).toHaveLength(0);
   });
 });
+
+// ── CTL-1422: session capture + worker.session.* lifecycle events ─────────────
+// The init message's session_id is the warm-resume key: it must reach the
+// registry (durable projection) and the unified event log (fleet view) the
+// moment it is known. stopped fires on every post-capture exit path.
+
+describe("sdkRunPhaseAgent — CTL-1422 (session capture + lifecycle events)", () => {
+  const sessionRegistry = () => {
+    const state = { handles: [] };
+    const registerWorker = () => {
+      const h = { sessionIds: [], deregistered: 0 };
+      h.setAbortController = () => {};
+      h.touch = () => {};
+      h.setSessionId = (id) => h.sessionIds.push(id);
+      h.deregister = () => { h.deregistered += 1; };
+      state.handles.push(h);
+      return h;
+    };
+    return { registerWorker, state };
+  };
+  const initMsg = { type: "system", subtype: "init", session_id: "sess-abc" };
+
+  test("captures session_id from the init message → registry + started/stopped events", async () => {
+    const { spawn } = spawnReturningSpec();
+    const { registerWorker, state } = sessionRegistry();
+    const events = [];
+    const runQuery = fakeQuery([initMsg, resultMsg()]);
+    const r = await sdkRunPhaseAgent(ARGS, {
+      ...GOOD_AUTH, spawn, runQuery, registerWorker,
+      emitEvent: (n, p) => events.push([n, p]),
+    });
+    expect(r.code).toBe(0);
+    expect(state.handles[0].sessionIds).toEqual(["sess-abc"]);
+    const started = events.filter(([n]) => n === "worker.session.started");
+    expect(started).toHaveLength(1);
+    expect(started[0][1]).toMatchObject({
+      ticket: "CTL-100", phase: "implement", session_id: "sess-abc", generation: 1,
+    });
+    const stopped = events.filter(([n]) => n === "worker.session.stopped");
+    expect(stopped).toHaveLength(1);
+    expect(stopped[0][1]).toMatchObject({ ticket: "CTL-100", session_id: "sess-abc" });
+  });
+
+  test("a resume dispatch emits worker.session.resumed instead of started", async () => {
+    const spec = makeSpec({ resumeSession: "sess-prev" });
+    const { spawn } = spawnReturningSpec({ spec });
+    const { registerWorker } = sessionRegistry();
+    const events = [];
+    const runQuery = fakeQuery([{ ...initMsg, session_id: "sess-prev" }, resultMsg()]);
+    const r = await sdkRunPhaseAgent(ARGS, {
+      ...GOOD_AUTH, spawn, runQuery, registerWorker,
+      emitEvent: (n, p) => events.push([n, p]),
+    });
+    expect(r.code).toBe(0);
+    expect(events.filter(([n]) => n === "worker.session.resumed")).toHaveLength(1);
+    expect(events.filter(([n]) => n === "worker.session.started")).toHaveLength(0);
+  });
+
+  test("no init message → no session events, no registry call, no crash", async () => {
+    const { spawn } = spawnReturningSpec();
+    const { registerWorker, state } = sessionRegistry();
+    const events = [];
+    const runQuery = fakeQuery([resultMsg()]);
+    const r = await sdkRunPhaseAgent(ARGS, {
+      ...GOOD_AUTH, spawn, runQuery, registerWorker,
+      emitEvent: (n, p) => events.push([n, p]),
+    });
+    expect(r.code).toBe(0);
+    expect(state.handles[0].sessionIds).toEqual([]);
+    expect(events.filter(([n]) => String(n).startsWith("worker.session."))).toHaveLength(0);
+  });
+
+  test("stopped still fires when the query throws AFTER the init message", async () => {
+    const { spawn } = spawnReturningSpec();
+    const { registerWorker, state } = sessionRegistry();
+    const events = [];
+    const runQuery = () =>
+      (async function* () {
+        yield initMsg;
+        throw new Error("boom");
+      })();
+    const r = await sdkRunPhaseAgent(ARGS, {
+      ...GOOD_AUTH, spawn, runQuery, registerWorker,
+      emitEvent: (n, p) => events.push([n, p]),
+      emitBackstop: () => {},
+    });
+    expect(r.code).toBe(1);
+    expect(state.handles[0].sessionIds).toEqual(["sess-abc"]);
+    expect(events.filter(([n]) => n === "worker.session.stopped")).toHaveLength(1);
+  });
+
+  test("Phase B fakes without setSessionId do not crash (optional-chained)", async () => {
+    const { spawn } = spawnReturningSpec();
+    const legacyHandle = { setAbortController: () => {}, touch: () => {}, deregister: () => {} };
+    const runQuery = fakeQuery([initMsg, resultMsg()]);
+    const r = await sdkRunPhaseAgent(ARGS, {
+      ...GOOD_AUTH, spawn, runQuery,
+      registerWorker: () => legacyHandle,
+      emitEvent: () => {},
+    });
+    expect(r.code).toBe(0);
+  });
+});
+
+describe("sdkRunPhaseAgent — CTL-1422 session change across retries", () => {
+  test("an overload retry with a NEW session closes the old one (stopped) before starting the new", async () => {
+    const { spawn } = spawnReturningSpec();
+    const events = [];
+    let attempt = 0;
+    const runQuery = () =>
+      (async function* () {
+        attempt += 1;
+        yield { type: "system", subtype: "init", session_id: `sess-${attempt}` };
+        if (attempt === 1) {
+          yield resultMsg({ subtype: "error", is_error: true, api_error_status: 529 });
+        } else {
+          yield resultMsg();
+        }
+      })();
+    const r = await sdkRunPhaseAgent(ARGS, {
+      ...GOOD_AUTH, spawn, runQuery,
+      registerWorker: () => ({ setAbortController() {}, touch() {}, setSessionId() {}, deregister() {} }),
+      sleep: () => Promise.resolve(),
+      backoff: { baseMs: 1, capMs: 2 },
+      emitEvent: (n, p) => events.push([n, p]),
+    });
+    expect(r.code).toBe(0);
+    const lifecycle = events
+      .filter(([n]) => String(n).startsWith("worker.session."))
+      .map(([n, p]) => `${n.split(".").pop()}:${p.session_id}`);
+    expect(lifecycle).toEqual([
+      "started:sess-1",
+      "stopped:sess-1", // closed when the retry re-keyed the session
+      "started:sess-2",
+      "stopped:sess-2", // the finally close
+    ]);
+  });
+});

--- a/plugins/dev/scripts/execution-core/sdk-run-phase-agent.test.mjs
+++ b/plugins/dev/scripts/execution-core/sdk-run-phase-agent.test.mjs
@@ -1789,6 +1789,23 @@ describe("sdkRunPhaseAgent — CTL-1422 (session capture + lifecycle events)", (
     expect(stopped[0][1]).toMatchObject({ ticket: "CTL-100", session_id: "sess-abc" });
   });
 
+  test("a resume dispatch seeds registerWorker with the known UUID (crash-before-init safety)", async () => {
+    const spec = makeSpec({ resumeSession: "sess-prev" });
+    const { spawn } = spawnReturningSpec({ spec });
+    const registered = [];
+    const runQuery = fakeQuery([resultMsg()]);
+    const r = await sdkRunPhaseAgent(ARGS, {
+      ...GOOD_AUTH, spawn, runQuery,
+      registerWorker: (e) => {
+        registered.push(e);
+        return { setAbortController() {}, touch() {}, setSessionId() {}, deregister() {} };
+      },
+      emitEvent: () => {},
+    });
+    expect(r.code).toBe(0);
+    expect(registered[0]).toMatchObject({ ticket: "CTL-100", sessionId: "sess-prev" });
+  });
+
   test("a resume dispatch emits worker.session.resumed instead of started", async () => {
     const spec = makeSpec({ resumeSession: "sess-prev" });
     const { spawn } = spawnReturningSpec({ spec });

--- a/plugins/dev/scripts/execution-core/sdk-worker-registry.mjs
+++ b/plugins/dev/scripts/execution-core/sdk-worker-registry.mjs
@@ -70,6 +70,7 @@ function writeProjection(entry) {
         pid: entry.pid,
         startedAt: entry.startedAt,
         updatedAt: entry.updatedAt,
+        sessionId: entry.sessionId ?? null,
       }),
     );
     renameSync(tmp, file);
@@ -105,6 +106,7 @@ function publicView(entry) {
     pid: entry.pid,
     orchDir: entry.orchDir,
     aborted: entry.aborted,
+    sessionId: entry.sessionId,
   };
 }
 
@@ -144,6 +146,7 @@ export function registerSdkWorker({ ticket, phase, worktreePath, generation, orc
     abortController: null,
     abortReason: null,
     aborted: false,
+    sessionId: null,
     now,
   };
   _live.set(ticket, entry);
@@ -172,6 +175,16 @@ export function registerSdkWorker({ ticket, phase, worktreePath, generation, orc
       if (entry.updatedAt - entry.lastProjectionWriteAt >= PROJECTION_TOUCH_THROTTLE_MS) {
         writeProjection(entry);
       }
+    },
+    // CTL-1422: the live SDK session UUID (from the query's init message) — the
+    // warm-resume key. Written to the projection IMMEDIATELY (not touch-throttled):
+    // the projection outliving a daemon crash is the entire point, so the id must
+    // be durable the moment it is known. Token-fenced like touch/deregister.
+    setSessionId(sessionId) {
+      if (_live.get(ticket)?.token !== entry.token) return;
+      entry.sessionId = sessionId;
+      entry.updatedAt = entry.now();
+      writeProjection(entry);
     },
     deregister() {
       const current = _live.get(ticket);
@@ -293,11 +306,17 @@ export function isSdkWorkerLiveOnDisk(orchDir, ticket, { pidAlive = defaultPidAl
 export function reconcileSdkRegistryOnBoot(orchDir, { pidAlive = defaultPidAlive } = {}) {
   const removed = [];
   const kept = [];
+  // CTL-1422: dead-pid projections that carry a sessionId are the warm-resume
+  // inventory — no in-process worker survives a daemon restart, so each one is
+  // an interrupted run whose SDK session can be continued via options.resume.
+  // Harvested BEFORE the file is deleted; the caller (daemon boot) threads the
+  // list into boot-resume as its sdkSessionHarvest.
+  const harvested = [];
   let files;
   try {
     files = readdirSync(projectionDir(orchDir)).filter((f) => f.endsWith(".json"));
   } catch {
-    return { removed, kept };
+    return { removed, kept, harvested };
   }
   for (const f of files) {
     const ticket = f.slice(0, -".json".length);
@@ -312,6 +331,15 @@ export function reconcileSdkRegistryOnBoot(orchDir, { pidAlive = defaultPidAlive
       kept.push(ticket);
       continue;
     }
+    if (proj && typeof proj.sessionId === "string" && proj.sessionId) {
+      harvested.push({
+        ticket,
+        sessionId: proj.sessionId,
+        phase: proj.phase,
+        generation: proj.generation,
+        worktreePath: proj.worktreePath,
+      });
+    }
     try {
       rmSync(file, { force: true });
     } catch {
@@ -319,7 +347,7 @@ export function reconcileSdkRegistryOnBoot(orchDir, { pidAlive = defaultPidAlive
     }
     removed.push(ticket);
   }
-  return { removed, kept };
+  return { removed, kept, harvested };
 }
 
 /** Test seam: clear all in-memory state (projections are per-test tmp dirs). */

--- a/plugins/dev/scripts/execution-core/sdk-worker-registry.mjs
+++ b/plugins/dev/scripts/execution-core/sdk-worker-registry.mjs
@@ -126,7 +126,13 @@ function isPlainInt(v) {
  * @param {{now?: () => number}} [opts] injectable clock
  * @returns handle {setAbortController, touch, deregister, aborted}
  */
-export function registerSdkWorker({ ticket, phase, worktreePath, generation, orchDir }, { now = Date.now } = {}) {
+export function registerSdkWorker(
+  // CTL-1422 review fix (D): a warm resume KNOWS its session UUID at register
+  // time (spec.resumeSession) — seed it so a crash between register and the
+  // first streamed message doesn't lose the warm chain.
+  { ticket, phase, worktreePath, generation, orchDir, sessionId = null },
+  { now = Date.now } = {},
+) {
   if (!ticket) throw new TypeError("registerSdkWorker: ticket is required");
   const prev = _live.get(ticket);
   if (prev && _byWorktree.get(prev.worktreePath) === ticket) _byWorktree.delete(prev.worktreePath);
@@ -146,7 +152,7 @@ export function registerSdkWorker({ ticket, phase, worktreePath, generation, orc
     abortController: null,
     abortReason: null,
     aborted: false,
-    sessionId: null,
+    sessionId,
     now,
   };
   _live.set(ticket, entry);
@@ -303,14 +309,23 @@ export function isSdkWorkerLiveOnDisk(orchDir, ticket, { pidAlive = defaultPidAl
  * previous daemon and is deleted. Runs before any dispatch entry point.
  * @returns {{removed: string[], kept: string[]}}
  */
-export function reconcileSdkRegistryOnBoot(orchDir, { pidAlive = defaultPidAlive } = {}) {
+// CTL-1422: harvested sessions older than this are orphans, not resume
+// candidates — the lookback window that stops an ancient never-stopped
+// projection from resurrecting forever.
+export const WARM_HARVEST_MAX_AGE_MS = 48 * 60 * 60 * 1000;
+
+export function reconcileSdkRegistryOnBoot(orchDir, { pidAlive = defaultPidAlive, now = Date.now } = {}) {
   const removed = [];
   const kept = [];
-  // CTL-1422: dead-pid projections that carry a sessionId are the warm-resume
-  // inventory — no in-process worker survives a daemon restart, so each one is
-  // an interrupted run whose SDK session can be continued via options.resume.
-  // Harvested BEFORE the file is deleted; the caller (daemon boot) threads the
-  // list into boot-resume as its sdkSessionHarvest.
+  // CTL-1422: dead-pid projections that carry a FRESH sessionId are the
+  // warm-resume inventory — no in-process worker survives a daemon restart, so
+  // each one is an interrupted run whose SDK session can be continued via
+  // options.resume. Review fix (B): harvested projections are KEPT on disk
+  // (the file is the only durable copy of the UUID; a candidate dropped by a
+  // downstream selection guard must survive to the next boot). The file is
+  // superseded when the resumed run re-registers, or aged out here at
+  // WARM_HARVEST_MAX_AGE_MS. Only unharvestable dead projections (corrupt, no
+  // session, stale) are deleted.
   const harvested = [];
   let files;
   try {
@@ -331,7 +346,9 @@ export function reconcileSdkRegistryOnBoot(orchDir, { pidAlive = defaultPidAlive
       kept.push(ticket);
       continue;
     }
-    if (proj && typeof proj.sessionId === "string" && proj.sessionId) {
+    const updatedAt = Number(proj?.updatedAt);
+    const fresh = Number.isFinite(updatedAt) && now() - updatedAt <= WARM_HARVEST_MAX_AGE_MS;
+    if (proj && typeof proj.sessionId === "string" && proj.sessionId && fresh) {
       harvested.push({
         ticket,
         sessionId: proj.sessionId,
@@ -339,6 +356,7 @@ export function reconcileSdkRegistryOnBoot(orchDir, { pidAlive = defaultPidAlive
         generation: proj.generation,
         worktreePath: proj.worktreePath,
       });
+      continue; // keep the file — it is the durable copy of the UUID
     }
     try {
       rmSync(file, { force: true });

--- a/plugins/dev/scripts/execution-core/sdk-worker-registry.test.mjs
+++ b/plugins/dev/scripts/execution-core/sdk-worker-registry.test.mjs
@@ -376,3 +376,53 @@ describe("abort / cancel", () => {
     expect(isPreemptionAbort(undefined)).toBe(false);
   });
 });
+
+describe("session capture (CTL-1422)", () => {
+  test("setSessionId records the id, exposes it, and writes the projection immediately (bypasses throttle)", () => {
+    const dir = freshDir();
+    let t = T0;
+    const h = registerSdkWorker(entry(dir), { now: () => t });
+    t = T0 + 1_000; // INSIDE the touch throttle — the session write must not wait
+    h.setSessionId("sess-abc");
+    expect(sdkWorkerForTicket("CTL-1").sessionId).toBe("sess-abc");
+    expect(readProjection(dir, "CTL-1").sessionId).toBe("sess-abc");
+    h.deregister();
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  test("a superseded handle's setSessionId does not clobber the successor (token fence)", () => {
+    const dir = freshDir();
+    const hOld = registerSdkWorker(entry(dir, { generation: 1 }));
+    const hNew = registerSdkWorker(entry(dir, { generation: 2 }));
+    hNew.setSessionId("sess-new");
+    hOld.setSessionId("sess-stale"); // superseded — must be a no-op
+    expect(sdkWorkerForTicket("CTL-1").sessionId).toBe("sess-new");
+    expect(readProjection(dir, "CTL-1").sessionId).toBe("sess-new");
+    hNew.deregister();
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  test("reconcileSdkRegistryOnBoot harvests dead-pid projections that carry a sessionId", () => {
+    const dir = freshDir();
+    mkdirSync(join(dir, ".sdk-workers"), { recursive: true });
+    writeFileSync(
+      join(dir, ".sdk-workers", "CTL-1.json"),
+      JSON.stringify({ ticket: "CTL-1", phase: "implement", sessionId: "sess-1", generation: 3, worktreePath: "/wt/a", pid: 11111, updatedAt: T0 }),
+    );
+    writeFileSync(
+      join(dir, ".sdk-workers", "CTL-2.json"),
+      JSON.stringify({ ticket: "CTL-2", pid: 11111, updatedAt: T0 }), // dead, no session — removed, not harvested
+    );
+    writeFileSync(
+      join(dir, ".sdk-workers", "CTL-3.json"),
+      JSON.stringify({ ticket: "CTL-3", sessionId: "sess-3", pid: 22222, updatedAt: T0 }), // pid ALIVE — kept
+    );
+    const res = reconcileSdkRegistryOnBoot(dir, { pidAlive: (pid) => pid === 22222 });
+    expect(res.removed.sort()).toEqual(["CTL-1", "CTL-2"]);
+    expect(res.kept).toEqual(["CTL-3"]);
+    expect(res.harvested).toEqual([
+      { ticket: "CTL-1", sessionId: "sess-1", phase: "implement", generation: 3, worktreePath: "/wt/a" },
+    ]);
+    rmSync(dir, { recursive: true, force: true });
+  });
+});

--- a/plugins/dev/scripts/execution-core/sdk-worker-registry.test.mjs
+++ b/plugins/dev/scripts/execution-core/sdk-worker-registry.test.mjs
@@ -11,6 +11,7 @@ import { join } from "node:path";
 
 import {
   SDK_WORKER_FRESH_MS,
+  WARM_HARVEST_MAX_AGE_MS,
   PREEMPTION_ABORT_REASON,
   isPreemptionAbort,
   registerSdkWorker,
@@ -417,12 +418,42 @@ describe("session capture (CTL-1422)", () => {
       join(dir, ".sdk-workers", "CTL-3.json"),
       JSON.stringify({ ticket: "CTL-3", sessionId: "sess-3", pid: 22222, updatedAt: T0 }), // pid ALIVE — kept
     );
-    const res = reconcileSdkRegistryOnBoot(dir, { pidAlive: (pid) => pid === 22222 });
-    expect(res.removed.sort()).toEqual(["CTL-1", "CTL-2"]);
+    const res = reconcileSdkRegistryOnBoot(dir, { pidAlive: (pid) => pid === 22222, now: () => T0 + 1000 });
+    expect(res.removed).toEqual(["CTL-2"]); // unharvestable only
     expect(res.kept).toEqual(["CTL-3"]);
     expect(res.harvested).toEqual([
       { ticket: "CTL-1", sessionId: "sess-1", phase: "implement", generation: 3, worktreePath: "/wt/a" },
     ]);
+    // Review fix (B): the harvested projection is KEPT — it is the only durable
+    // copy of the UUID until the resumed run re-registers.
+    expect(existsSync(join(dir, ".sdk-workers", "CTL-1.json"))).toBe(true);
+    expect(existsSync(join(dir, ".sdk-workers", "CTL-2.json"))).toBe(false);
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  test("a stale harvested projection (past the 48h lookback) is removed, not harvested", () => {
+    const dir = freshDir();
+    mkdirSync(join(dir, ".sdk-workers"), { recursive: true });
+    writeFileSync(
+      join(dir, ".sdk-workers", "CTL-9.json"),
+      JSON.stringify({ ticket: "CTL-9", sessionId: "sess-old", pid: 11111, updatedAt: T0 }),
+    );
+    const res = reconcileSdkRegistryOnBoot(dir, {
+      pidAlive: () => false,
+      now: () => T0 + WARM_HARVEST_MAX_AGE_MS + 1,
+    });
+    expect(res.harvested).toEqual([]);
+    expect(res.removed).toEqual(["CTL-9"]);
+    expect(existsSync(join(dir, ".sdk-workers", "CTL-9.json"))).toBe(false);
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  test("register seeds the projection with a known resumeSession UUID (crash-before-init safety)", () => {
+    const dir = freshDir();
+    const h = registerSdkWorker(entry(dir, { sessionId: "sess-warm" }), { now: () => T0 });
+    expect(readProjection(dir, "CTL-1").sessionId).toBe("sess-warm");
+    expect(sdkWorkerForTicket("CTL-1").sessionId).toBe("sess-warm");
+    h.deregister();
     rmSync(dir, { recursive: true, force: true });
   });
 });


### PR DESCRIPTION
## Summary

A daemon restart now **continues** in-flight SDK work instead of cold-restarting it — the capability that makes fleet-wide stop/restart-all routine (Ryan's ask, 2026-07-02). Builds on CTL-1410 Phase B's registry.

### The loop

1. **Capture**: `sdk-run-phase-agent` reads the SDK session UUID off the streamed init message (previously discarded) and persists it to the registry disk projection immediately (crash-safe, not touch-throttled). A warm resume seeds the UUID at register time.
2. **Announce**: `worker.session.{started,resumed,stopped}` events (UUID, ticket, phase, generation) land on the unified event log — local file for boot, Loki (via otel-forward) for the fleet view and orphan lookback. A 429-retry that re-keys the session closes the old id first.
3. **Harvest**: `reconcileSdkRegistryOnBoot` collects dead-pid projections carrying a fresh (≤48h) sessionId — each is an interrupted run. Harvested projections stay on disk until the resumed run re-registers (the file is the durable copy of the UUID).
4. **Resume**: boot-resume passes the harvested UUID as `resumeSession` → the existing rail (`--resume-session` → `spec.resumeSession` → `options.resume`) continues the same conversation from its on-disk transcript.

### Policy (agreed design)

- Warm resumes **bypass the CTL-644 expensive-phase approval gate and the CTL-1084 rewalk cap** — continuation is cheap; cold re-dispatches keep both gates.
- **Budgeted per session UUID** (durable marker, default 3, `CATALYST_WARM_RESUME_MAX_PER_SESSION`): a crash-looping daemon demotes the candidate to the gated cold path instead of re-resuming forever.
- Warm candidates are **exempt from the free-slot slice** (dropping one destroys its UUID); the runner's semaphore still caps real concurrency.
- A warm dispatch **clears stale pending-approval markers** (no operator double-dispatch).
- Terminal/needs-input/needs-human guards apply to warm candidates unchanged.

## Review

12-agent adversarial workflow (3 lenses → per-finding refutation): 9 raw findings → 4 distinct defects (1 high: the infinite warm-resume loop), all fixed in the second commit; 0 refuted.

## Tests

+15 across registry (capture/fence/harvest/age-out/seed), runner (init capture, resumed-vs-started, retry re-key closes old session, throw-after-init, legacy-fake tolerance), boot-resume (warm-expensive bypass, budget cap + reset, slice exemption, marker clear, terminal guard, harvest precedence). 305 green across the six touched suites; daemon module-load smoke OK.

## Acceptance demo (post-merge)

Stop a daemon mid-run → restart → the same session continues from its transcript (`boot-resume: … warmResumed: 1`). Then: stop ALL daemons, restart all — fleet picks up where it left off. Pairs with the drain-aware stack-reload ticket to fully restore bg-era restart ergonomics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ArmgujXD5Kdx2HX4ZGNim6