### PR TITLE
fix(dev): standard plugin-source loading for interactive sessions + drop marketplace guidance

### DIFF
--- a/node_modules
+++ b/node_modules
@@ -1,1 +1,0 @@
-/Users/ryan/code-repos/github/coalesce-labs/catalyst/node_modules

--- a/node_modules
+++ b/node_modules
@@ -1,0 +1,1 @@
+/Users/ryan/code-repos/github/coalesce-labs/catalyst/node_modules

--- a/plugins/dev/scripts/__tests__/setup-plugin-source.test.sh
+++ b/plugins/dev/scripts/__tests__/setup-plugin-source.test.sh
@@ -57,9 +57,22 @@ advance_origin() {
 }
 
 # run_setup MACHINE_CFG PATH_ARG REPO_URL [extra args...]
+# Passes --no-interactive-wrapper so the pluginDirs-registration tests never touch
+# the tester's real shell rc files. The wrapper behavior is covered separately by
+# the wrapper_* cases below (which invoke the script with an isolated $HOME).
 run_setup() {
   local mcfg="$1" path_arg="$2" url="$3"; shift 3
   env PATH="$REAL_PATH" CATALYST_MACHINE_CONFIG="$mcfg" GIT_TERMINAL_PROMPT=0 \
+    bash "$SETUP" --path "$path_arg" --repo-url "$url" --no-interactive-wrapper "$@"
+}
+
+# run_setup_hb — like run_setup but with an isolated HOME/ZDOTDIR/SHELL and WITHOUT
+# --no-interactive-wrapper, so the interactive `claude` wrapper install is exercised
+# against a throwaway home dir instead of the tester's real rc files.
+run_setup_hb() {
+  local home="$1" shell="$2" mcfg="$3" path_arg="$4" url="$5"; shift 5
+  env PATH="$REAL_PATH" CATALYST_MACHINE_CONFIG="$mcfg" GIT_TERMINAL_PROMPT=0 \
+    HOME="$home" ZDOTDIR="$home" SHELL="$shell" \
     bash "$SETUP" --path "$path_arg" --repo-url "$url" "$@"
 }
 
@@ -170,6 +183,75 @@ t8() {
   [[ "$(jq -r '.catalyst.orchestration.pluginDirs' "$MCFG8")" == "${CO8}/plugins/dev" ]]
 }
 check "creates the machine config (and parent dir) when absent" t8
+
+# ── 9. zsh: interactive wrapper written to ~/.zshrc (isolated HOME) ──────────
+make_origin wrapzsh
+MCFG9="${SCRATCH}/mcfg9.json"
+HOME9="${SCRATCH}/home9"; mkdir -p "$HOME9"
+CO9="${SCRATCH}/co9"
+t9() {
+  run_setup_hb "$HOME9" "/bin/zsh" "$MCFG9" "$CO9" "$ORIGIN" >/dev/null 2>&1 || return 1
+  [[ -f "${HOME9}/.zshrc" ]] || return 1
+  grep -q ">>> catalyst plugin-source" "${HOME9}/.zshrc" || return 1
+  # rerun stays idempotent: exactly one managed block.
+  run_setup_hb "$HOME9" "/bin/zsh" "$MCFG9" "$CO9" "$ORIGIN" >/dev/null 2>&1 || return 1
+  [[ "$(grep -c '>>> catalyst plugin-source' "${HOME9}/.zshrc")" == "1" ]]
+}
+check "zsh: installs idempotent interactive wrapper in ~/.zshrc" t9
+
+# ── 10. bash: interactive wrapper written to ~/.bashrc (isolated HOME) ───────
+make_origin wrapbash
+MCFG10="${SCRATCH}/mcfg10.json"
+HOME10="${SCRATCH}/home10"; mkdir -p "$HOME10"
+CO10="${SCRATCH}/co10"
+t10() {
+  run_setup_hb "$HOME10" "/bin/bash" "$MCFG10" "$CO10" "$ORIGIN" >/dev/null 2>&1 || return 1
+  grep -q ">>> catalyst plugin-source" "${HOME10}/.bashrc" || return 1
+  [[ ! -e "${HOME10}/.zshrc" ]]
+}
+check "bash: installs interactive wrapper in ~/.bashrc (not ~/.zshrc)" t10
+
+# ── 11. --no-interactive-wrapper: leaves rc files untouched ──────────────────
+make_origin nowrap
+MCFG11="${SCRATCH}/mcfg11.json"
+HOME11="${SCRATCH}/home11"; mkdir -p "$HOME11"
+CO11="${SCRATCH}/co11"
+t11() {
+  run_setup_hb "$HOME11" "/bin/zsh" "$MCFG11" "$CO11" "$ORIGIN" --no-interactive-wrapper >/dev/null 2>&1 || return 1
+  [[ ! -e "${HOME11}/.zshrc" && ! -e "${HOME11}/.bashrc" ]] || return 1
+  # config write still happened.
+  [[ "$(jq -r '.catalyst.orchestration.pluginDirs' "$MCFG11")" == "${CO11}/plugins/dev" ]]
+}
+check "--no-interactive-wrapper skips rc edit but still registers pluginDirs" t11
+
+# ── 12. symlinked ~/.zshrc (dotfiles repo) preserved on rerun ────────────────
+make_origin wrapsymlink
+MCFG12="${SCRATCH}/mcfg12.json"
+HOME12="${SCRATCH}/home12"; mkdir -p "${HOME12}/dotfiles"
+printf '# managed by dotfiles\n' > "${HOME12}/dotfiles/zshrc"
+ln -s "${HOME12}/dotfiles/zshrc" "${HOME12}/.zshrc"
+CO12="${SCRATCH}/co12"
+t12() {
+  run_setup_hb "$HOME12" "/bin/zsh" "$MCFG12" "$CO12" "$ORIGIN" >/dev/null 2>&1 || return 1
+  run_setup_hb "$HOME12" "/bin/zsh" "$MCFG12" "$CO12" "$ORIGIN" >/dev/null 2>&1 || return 1
+  [[ -L "${HOME12}/.zshrc" ]] || return 1                       # still a symlink
+  [[ "$(grep -c '>>> catalyst plugin-source' "${HOME12}/.zshrc")" == "1" ]] || return 1
+  grep -q "managed by dotfiles" "${HOME12}/dotfiles/zshrc"      # wrote through the link
+}
+check "symlinked ~/.zshrc is preserved (not replaced by a regular file)" t12
+
+# ── 13. read-only ~/.zshrc: wrapper is best-effort, pluginDirs still set ─────
+make_origin wrapreadonly
+MCFG13="${SCRATCH}/mcfg13.json"
+HOME13="${SCRATCH}/home13"; mkdir -p "$HOME13"
+printf '# read only\n' > "${HOME13}/.zshrc"; chmod 0444 "${HOME13}/.zshrc"
+CO13="${SCRATCH}/co13"
+t13() {
+  # Under the script's set -e, a read-only rc must NOT abort before the config write.
+  run_setup_hb "$HOME13" "/bin/zsh" "$MCFG13" "$CO13" "$ORIGIN" >/dev/null 2>&1 || return 1
+  [[ "$(jq -r '.catalyst.orchestration.pluginDirs' "$MCFG13")" == "${CO13}/plugins/dev" ]]
+}
+check "read-only ~/.zshrc is non-fatal; pluginDirs still registered" t13
 
 echo ""
 TOTAL=$((PASSES + FAILURES))

--- a/plugins/dev/scripts/execution-core/install-lifecycle.mjs
+++ b/plugins/dev/scripts/execution-core/install-lifecycle.mjs
@@ -239,7 +239,12 @@ export function planPhases({ operation, nodeClass, scripts, opts = {} }) {
   // readReplica, secrets, launchd agents, catalyst.db) is written AFTER backup and so is restorable.
   const acquire = () => ({
     phase: "acquire",
-    steps: [{ label: "plugin-source", kind: "run", argv: [scripts.pluginSrc] }],
+    // --no-interactive-wrapper: the acquire step runs pre-backup and non-interactively;
+    // it must only write the git-reconstructable pluginDirs config, never the user's
+    // shell rc files (~/.zshrc/~/.bashrc), which the backup phase does not capture and
+    // a rollback could not restore. The interactive `claude` wrapper is installed only
+    // by the documented manual `bash setup-plugin-source.sh` run.
+    steps: [{ label: "plugin-source", kind: "run", argv: [scripts.pluginSrc, "--no-interactive-wrapper"] }],
   });
 
   const backup = (label) => ({

--- a/plugins/dev/scripts/setup-plugin-source.sh
+++ b/plugins/dev/scripts/setup-plugin-source.sh
@@ -84,6 +84,50 @@ require_cmd() {
 require_cmd git
 require_cmd jq
 
+# install_interactive_claude_wrapper — the interactive counterpart of the worker
+# --plugin-dir wiring. Phase workers get plugin-source via phase-agent-dispatch's
+# --plugin-dir flags (resolved from the pluginDirs machine-config key); a plain
+# interactive `claude` session has NO such mechanism (Claude Code exposes no env/
+# settings key for live local-plugin loading — only the --plugin-dir CLI flag), so
+# it would silently fall back to the version-keyed marketplace cache (which lags
+# releases — the exact staleness this whole setup avoids). This appends a guarded,
+# idempotent zsh `claude` function to ~/.zshrc that injects --plugin-dir for every
+# plugin in the checkout. It goes in ~/.zshrc (interactive shells only) — NOT
+# ~/.zshenv — so it never leaks into non-interactive/daemon `claude --bg` spawns
+# (which already get --plugin-dir from the dispatcher) and double-inject.
+install_interactive_claude_wrapper() {
+	local checkout="$1" rc="${ZDOTDIR:-$HOME}/.zshrc"
+	local start="# >>> catalyst plugin-source (managed) >>>"
+	local end="# <<< catalyst plugin-source (managed) <<<"
+	# Idempotent: strip any prior managed block, then append the current one.
+	if [[ -f "$rc" ]] && grep -qF "$start" "$rc"; then
+		local tmp; tmp="$(mktemp "$(dirname "$rc")/.zshrc.XXXXXX")"
+		awk -v s="$start" -v e="$end" '$0==s{skip=1} !skip{print} $0==e{skip=0}' "$rc" >"$tmp" && mv "$tmp" "$rc"
+	fi
+	cat >>"$rc" <<WRAP
+${start}
+# Interactive \`claude\` loads catalyst plugins LIVE from the plugin-source checkout
+# (never the lagging marketplace cache). Phase workers get this via
+# phase-agent-dispatch's --plugin-dir; this is the interactive equivalent.
+claude() {
+  case "\${1:-}" in
+    plugin|mcp|config|update|doctor|install|migrate-installer|--help|-h|--version|-v)
+      command claude "\$@"; return ;;
+  esac
+  local base="${checkout}/plugins" d
+  local args=()
+  if [ -d "\$base" ]; then
+    for d in "\$base"/*/; do
+      [ -f "\${d}.claude-plugin/plugin.json" ] && args+=(--plugin-dir "\${d%/}")
+    done
+  fi
+  command claude "\${args[@]}" "\$@"
+}
+${end}
+WRAP
+	echo "Installed the interactive \`claude\` plugin-source wrapper in ${rc}."
+}
+
 CHECKOUT_PATH="${CHECKOUT_PATH:-$DEFAULT_PATH}"
 
 # Derive the repo URL from this repo's origin (https) when not supplied.
@@ -140,6 +184,11 @@ fi
 
 HEAD_SHA="$(git -C "$CHECKOUT_PATH" rev-parse HEAD)"
 TARGET_DIR="${CHECKOUT_PATH}/plugins/dev"
+
+# Interactive sessions: install the ~/.zshrc --plugin-dir wrapper (idempotent) so
+# plain `claude` also live-loads plugin-source, not the lagging cache. Runs on
+# every invocation, including the pluginDirs-already-registered fast path below.
+install_interactive_claude_wrapper "$CHECKOUT_PATH"
 
 # ─── 2. Register pluginDirs in the machine config ───────────────────────────
 MACHINE_CFG="$(plugin_dirs_machine_config_path)"

--- a/plugins/dev/scripts/setup-plugin-source.sh
+++ b/plugins/dev/scripts/setup-plugin-source.sh
@@ -37,6 +37,7 @@ DEFAULT_PATH="${CATALYST_PLUGIN_SOURCE:-$HOME/catalyst/plugin-source}"
 CHECKOUT_PATH=""
 REPO_URL=""
 FORCE=0
+INSTALL_WRAPPER=1
 
 usage() {
 	cat <<EOF
@@ -51,6 +52,10 @@ Options:
   --repo-url URL    Clone source. Defaults to this repo's origin (https).
   --force           Re-register even if pluginDirs is already set to a
                     different path.
+  --no-interactive-wrapper
+                    Skip installing the interactive \`claude\` shell wrapper
+                    (used by the non-interactive install-lifecycle acquire step,
+                    which must not touch the user's shell rc files).
   -h|--help         Show this message.
 EOF
 }
@@ -70,6 +75,7 @@ while [[ $# -gt 0 ]]; do
 			fi
 			REPO_URL="$2"; shift 2 ;;
 		--force) FORCE=1; shift ;;
+		--no-interactive-wrapper) INSTALL_WRAPPER=0; shift ;;
 		-h|--help) usage; exit 0 ;;
 		*) echo "Unknown option: $1" >&2; usage; exit 1 ;;
 	esac
@@ -84,6 +90,24 @@ require_cmd() {
 require_cmd git
 require_cmd jq
 
+# rc_files_for_interactive_shell — the interactive-shell rc file(s) to install the
+# `claude` wrapper into, picked by the login shell ($SHELL) — mirroring the
+# convention setup-catalyst.sh uses for its PATH lines. zsh → ~/.zshrc; bash →
+# ~/.bashrc (+ ~/.bash_profile when it already exists, for macOS login shells that
+# read it instead of ~/.bashrc); unknown → both zsh and bash so a supported
+# interactive shell is always covered. The wrapper body is bash/zsh-portable
+# (case/local/arrays), so the same block works in either rc file.
+rc_files_for_interactive_shell() {
+	case "${SHELL:-}" in
+		*zsh) printf '%s\n' "${ZDOTDIR:-$HOME}/.zshrc" ;;
+		*bash)
+			printf '%s\n' "$HOME/.bashrc"
+			if [[ -e "$HOME/.bash_profile" ]]; then printf '%s\n' "$HOME/.bash_profile"; fi
+			;;
+		*) printf '%s\n' "${ZDOTDIR:-$HOME}/.zshrc" "$HOME/.bashrc" ;;
+	esac
+}
+
 # install_interactive_claude_wrapper — the interactive counterpart of the worker
 # --plugin-dir wiring. Phase workers get plugin-source via phase-agent-dispatch's
 # --plugin-dir flags (resolved from the pluginDirs machine-config key); a plain
@@ -91,20 +115,24 @@ require_cmd jq
 # settings key for live local-plugin loading — only the --plugin-dir CLI flag), so
 # it would silently fall back to the version-keyed marketplace cache (which lags
 # releases — the exact staleness this whole setup avoids). This appends a guarded,
-# idempotent zsh `claude` function to ~/.zshrc that injects --plugin-dir for every
-# plugin in the checkout. It goes in ~/.zshrc (interactive shells only) — NOT
-# ~/.zshenv — so it never leaks into non-interactive/daemon `claude --bg` spawns
-# (which already get --plugin-dir from the dispatcher) and double-inject.
+# idempotent shell `claude` function that injects --plugin-dir for every plugin in
+# the checkout. It goes in the interactive rc (~/.zshrc / ~/.bashrc) — NOT ~/.zshenv
+# — so it never leaks into non-interactive/daemon `claude --bg` spawns (which
+# already get --plugin-dir from the dispatcher) and double-inject.
+#
+# BEST-EFFORT: this is a non-essential convenience — the essential pluginDirs config
+# write has already run by the time we are called. A missing rc directory, a
+# read-only rc, or any write failure must warn-and-continue, never abort the script
+# (the caller invokes us as `… || warn`, which also disables `set -e` inside here).
+# Symlinked rc files (dotfiles repos) are rewritten IN PLACE (truncate-through-the-
+# link) so a routine rerun updates the symlink target instead of replacing the
+# symlink with a regular file.
 install_interactive_claude_wrapper() {
-	local checkout="$1" rc="${ZDOTDIR:-$HOME}/.zshrc"
+	local checkout="$1" rc dir tmp
 	local start="# >>> catalyst plugin-source (managed) >>>"
 	local end="# <<< catalyst plugin-source (managed) <<<"
-	# Idempotent: strip any prior managed block, then append the current one.
-	if [[ -f "$rc" ]] && grep -qF "$start" "$rc"; then
-		local tmp; tmp="$(mktemp "$(dirname "$rc")/.zshrc.XXXXXX")"
-		awk -v s="$start" -v e="$end" '$0==s{skip=1} !skip{print} $0==e{skip=0}' "$rc" >"$tmp" && mv "$tmp" "$rc"
-	fi
-	cat >>"$rc" <<WRAP
+	local block
+	block="$(cat <<WRAP
 ${start}
 # Interactive \`claude\` loads catalyst plugins LIVE from the plugin-source checkout
 # (never the lagging marketplace cache). Phase workers get this via
@@ -125,7 +153,36 @@ claude() {
 }
 ${end}
 WRAP
-	echo "Installed the interactive \`claude\` plugin-source wrapper in ${rc}."
+	)"
+
+	while IFS= read -r rc; do
+		if [[ -z "$rc" ]]; then continue; fi
+		dir="$(dirname "$rc")"
+		if [[ ! -d "$dir" ]]; then
+			echo "WARN: skipping interactive wrapper in ${rc} — directory ${dir} does not exist." >&2
+			continue
+		fi
+		# Read-only rc file (or dir, for a not-yet-created rc): warn and skip.
+		if { [[ -e "$rc" && ! -w "$rc" ]]; } || { [[ ! -e "$rc" && ! -w "$dir" ]]; }; then
+			echo "WARN: skipping interactive wrapper in ${rc} — not writable." >&2
+			continue
+		fi
+		# Idempotent: strip any prior managed block, then append the current one.
+		# The strip rewrites the rc IN PLACE (cat >"$rc" truncates through a symlink,
+		# preserving a dotfiles-repo symlink instead of replacing it with a file).
+		if [[ -f "$rc" ]] && grep -qF "$start" "$rc"; then
+			tmp="$(mktemp "${TMPDIR:-/tmp}/.catalyst-rc.XXXXXX")" || { echo "WARN: mktemp failed for ${rc}" >&2; continue; }
+			if awk -v s="$start" -v e="$end" '$0==s{skip=1} !skip{print} $0==e{skip=0}' "$rc" >"$tmp"; then
+				cat "$tmp" >"$rc" || { echo "WARN: could not rewrite ${rc}" >&2; rm -f "$tmp"; continue; }
+			fi
+			rm -f "$tmp"
+		fi
+		if printf '%s\n' "$block" >>"$rc"; then
+			echo "Installed the interactive \`claude\` plugin-source wrapper in ${rc}."
+		else
+			echo "WARN: could not append interactive wrapper to ${rc}." >&2
+		fi
+	done < <(rc_files_for_interactive_shell)
 }
 
 CHECKOUT_PATH="${CHECKOUT_PATH:-$DEFAULT_PATH}"
@@ -185,11 +242,6 @@ fi
 HEAD_SHA="$(git -C "$CHECKOUT_PATH" rev-parse HEAD)"
 TARGET_DIR="${CHECKOUT_PATH}/plugins/dev"
 
-# Interactive sessions: install the ~/.zshrc --plugin-dir wrapper (idempotent) so
-# plain `claude` also live-loads plugin-source, not the lagging cache. Runs on
-# every invocation, including the pluginDirs-already-registered fast path below.
-install_interactive_claude_wrapper "$CHECKOUT_PATH"
-
 # ─── 2. Register pluginDirs in the machine config ───────────────────────────
 MACHINE_CFG="$(plugin_dirs_machine_config_path)"
 mkdir -p "$(dirname "$MACHINE_CFG")"
@@ -203,23 +255,33 @@ if [[ "$CURRENT" == "$TARGET_DIR" && $FORCE -eq 0 ]]; then
 	echo "pluginDirs already registered as ${TARGET_DIR} in ${MACHINE_CFG} — leaving as-is."
 	echo "  checkout: ${CHECKOUT_PATH}"
 	echo "  HEAD:     ${HEAD_SHA}"
-	exit 0
+else
+	# Same-directory tmp so the final mv is an atomic same-filesystem rename
+	# (a default mktemp lands on a different volume on macOS, making mv a
+	# non-atomic copy+unlink — a crash mid-write would corrupt the config).
+	tmp="$(mktemp "$(dirname "$MACHINE_CFG")/.config.json.XXXXXX")"
+	trap 'rm -f "$tmp"' EXIT
+	jq --arg pd "$TARGET_DIR" '
+		.catalyst //= {}
+		| .catalyst.orchestration //= {}
+		| .catalyst.orchestration.pluginDirs = $pd
+	' "$MACHINE_CFG" > "$tmp"
+	mv "$tmp" "$MACHINE_CFG"
+
+	echo "Registered pluginDirs in ${MACHINE_CFG}:"
+	echo "  old: ${CURRENT:-<unset>}"
+	echo "  new: ${TARGET_DIR}"
+	echo "  checkout: ${CHECKOUT_PATH}"
+	echo "  HEAD:     ${HEAD_SHA}"
 fi
 
-# Same-directory tmp so the final mv is an atomic same-filesystem rename
-# (a default mktemp lands on a different volume on macOS, making mv a
-# non-atomic copy+unlink — a crash mid-write would corrupt the config).
-tmp="$(mktemp "$(dirname "$MACHINE_CFG")/.config.json.XXXXXX")"
-trap 'rm -f "$tmp"' EXIT
-jq --arg pd "$TARGET_DIR" '
-	.catalyst //= {}
-	| .catalyst.orchestration //= {}
-	| .catalyst.orchestration.pluginDirs = $pd
-' "$MACHINE_CFG" > "$tmp"
-mv "$tmp" "$MACHINE_CFG"
-
-echo "Registered pluginDirs in ${MACHINE_CFG}:"
-echo "  old: ${CURRENT:-<unset>}"
-echo "  new: ${TARGET_DIR}"
-echo "  checkout: ${CHECKOUT_PATH}"
-echo "  HEAD:     ${HEAD_SHA}"
+# ─── 3. Interactive `claude` wrapper (best-effort, LAST) ────────────────────
+# Runs after the essential pluginDirs config write so a non-fatal rc-file failure
+# can never skip it. Skipped entirely (--no-interactive-wrapper) when invoked by
+# the non-interactive install-lifecycle acquire step, which must not touch the
+# user's shell rc files. The `|| warn` guard also disables `set -e` inside the
+# function so a read-only/managed-dotfiles rc warns instead of aborting.
+if [[ $INSTALL_WRAPPER -eq 1 ]]; then
+	install_interactive_claude_wrapper "$CHECKOUT_PATH" \
+		|| echo "WARN: interactive \`claude\` wrapper not installed (non-fatal) — pluginDirs config is set; plain \`claude\` will use the marketplace cache until you add the wrapper manually." >&2
+fi

--- a/setup-catalyst.sh
+++ b/setup-catalyst.sh
@@ -2323,12 +2323,27 @@ print_summary() {
 	print_header "Next Steps"
 	echo ""
 
+	# Resolve setup-plugin-source.sh next to THIS script. Via the `curl … | bash`
+	# flow (or when run from a non-catalyst target repo) BASH_SOURCE is empty/stdin
+	# and no such script exists locally, so print a runnable clone+run command
+	# instead of a relative path that would fail.
+	local _pss_dir _pss_script
+	_pss_dir="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" 2>/dev/null && pwd)" || _pss_dir=""
+	_pss_script="${_pss_dir}/plugins/dev/scripts/setup-plugin-source.sh"
+
 	echo "1. Provision plugin-source (live plugin loading — NOT the marketplace cache,"
 	echo "   which lags releases and drifts per node):"
-	echo "   bash plugins/dev/scripts/setup-plugin-source.sh"
+	if [ -n "$_pss_dir" ] && [ -f "$_pss_script" ]; then
+		echo "   bash ${_pss_script}"
+	else
+		echo "   # Run from a catalyst checkout (this setup script was not run from one):"
+		echo "   git clone https://github.com/coalesce-labs/catalyst.git ~/catalyst-src \\"
+		echo "     && bash ~/catalyst-src/plugins/dev/scripts/setup-plugin-source.sh"
+	fi
 	echo "   → sets the pluginDirs machine-config key (workers load plugin-source via"
 	echo "     phase-agent-dispatch --plugin-dir) AND installs the interactive \`claude\`"
-	echo "     --plugin-dir wrapper in ~/.zshrc. Open a new shell to pick it up."
+	echo "     --plugin-dir wrapper in your shell rc (~/.zshrc or ~/.bashrc). Open a new"
+	echo "     shell to pick it up."
 	echo ""
 
 	echo "2. Restart Claude Code to load configuration"

--- a/setup-catalyst.sh
+++ b/setup-catalyst.sh
@@ -2323,9 +2323,12 @@ print_summary() {
 	print_header "Next Steps"
 	echo ""
 
-	echo "1. Install Catalyst plugin in Claude Code:"
-	echo "   /plugin marketplace add coalesce-labs/catalyst"
-	echo "   /plugin install catalyst-dev"
+	echo "1. Provision plugin-source (live plugin loading — NOT the marketplace cache,"
+	echo "   which lags releases and drifts per node):"
+	echo "   bash plugins/dev/scripts/setup-plugin-source.sh"
+	echo "   → sets the pluginDirs machine-config key (workers load plugin-source via"
+	echo "     phase-agent-dispatch --plugin-dir) AND installs the interactive \`claude\`"
+	echo "     --plugin-dir wrapper in ~/.zshrc. Open a new shell to pick it up."
 	echo ""
 
 	echo "2. Restart Claude Code to load configuration"


### PR DESCRIPTION
## Why

Workers already load catalyst plugins **live from `~/catalyst/plugin-source`** via `phase-agent-dispatch`'s `--plugin-dir` (from the `pluginDirs` machine-config key). But **interactive `claude` sessions have no equivalent** — Claude Code exposes **no env var or settings key** for live local-plugin loading (only the `--plugin-dir` CLI flag), so a plain `claude` falls back to the **version-keyed marketplace cache**, which lags releases and drifts per node. That's why a merged fix (e.g. #2543 / v12.23.0) can look "not deployed" on a node whose *interactive* sessions read the stale cache — even though its *workers* are on the fix.

## Changes
- **`setup-plugin-source.sh`** — also install a guarded, idempotent zsh `claude` **wrapper in `~/.zshrc`** that injects `--plugin-dir` for every plugin in the checkout (the interactive counterpart of the worker wiring). In `~/.zshrc` (interactive only), **not** `~/.zshenv`, so it never leaks into daemon `claude --bg` spawns (which already get `--plugin-dir`) and double-inject. No-ops for `claude` subcommands and when the checkout is absent.
- **`setup-catalyst.sh`** — replace the `/plugin marketplace add` + `/plugin install` Next-Steps prose with "run `setup-plugin-source.sh`", so a freshly set-up node is never pointed back at the lagging marketplace cache.

## Verification
- `bash -n` clean on both; the wrapper block is valid zsh; idempotent install proven live on the laptop `~/.zshrc` (strips + re-appends the managed block, preserves user content, enumerates all 10 plugins). No test asserts the removed prose.

## Follow-ups
- Doctor assertion that the interactive wrapper is present (the worker `pluginDirs`-unset case already hard-FAILs via `checkPluginSourceFreshness`).
- Once verified fleet-wide, remove the marketplace registration + `~/.claude/plugins/cache/catalyst/` on each node.

🤖 Generated with [Claude Code](https://claude.com/claude-code)