### PR TITLE
fix(dev): CTL-1420 — dispatch reads via replica (Stage 0: ownership→replica, eligible breaker-aware)

### DIFF
--- a/plugins/dev/scripts/execution-core/dispatch-alert.mjs
+++ b/plugins/dev/scripts/execution-core/dispatch-alert.mjs
@@ -1,0 +1,118 @@
+// dispatch-alert.mjs — Stage 0 of "dispatch severed from live Linear"
+// (2026-07-02-dispatch-no-live-linear.md). One one-shot, best-effort
+// `catalyst.alert.*` emitter for the Stage-0 dispatch-hardening signal:
+//
+//   catalyst.alert.eligible_source_unavailable (WARN) — linear-query.mjs
+//     runEligibleQuery(): the eligible poll MISSED the replica AND the CTL-679
+//     breaker is OPEN, so we preserve the prior set WITHOUT spawning linearis into
+//     the open breaker (D2). The genuine no-source residual (fresh boot, no replica,
+//     no prior set) is now LOUD instead of a silent whole-window freeze.
+//
+// Emit path mirrors fleet-freeze-alert.mjs (the execution-core alert precedent):
+// buildCatalystResource envelope + appendFileSync to the canonical event log,
+// NEVER throws. Distinct event.name per signal (these are fire-and-forget
+// one-shots, not latched raised/cleared pairs), event.entity=alert so the same
+// catalyst.alert.* consumer picks them up. A per-kind time throttle keeps a
+// per-tick hot-path emit from spamming the log.
+import { randomBytes } from "node:crypto";
+import { appendFileSync, mkdirSync } from "node:fs";
+import { dirname } from "node:path";
+import { getEventLogPath, log } from "./config.mjs";
+import { buildCatalystResource } from "./lib/catalyst-resource.mjs";
+
+export const ALERT_ELIGIBLE_SOURCE_UNAVAILABLE = "catalyst.alert.eligible_source_unavailable";
+
+export const ALERT_KIND_ELIGIBLE_SOURCE_UNAVAILABLE = "eligible_source_unavailable";
+
+// Per-kind throttle so a per-tick hot path (runEligibleQuery inside the reconcile
+// timer) cannot spam the event log during a sustained storm. The alert is a LOUD
+// "something is wrong"
+// signal, not per-ticket accounting — one line per window per kind is enough.
+const DEFAULT_THROTTLE_MS = 60_000;
+const _lastEmitAt = new Map();
+
+// __resetDispatchAlertThrottle — test seam so throttle state never leaks across tests.
+export function __resetDispatchAlertThrottle() {
+  _lastEmitAt.clear();
+}
+
+// defaultAppend — write a JSONL line to the canonical monthly event log (same
+// path/shape every other execution-core emitter appends to).
+function defaultAppend(line) {
+  const logPath = getEventLogPath();
+  mkdirSync(dirname(logPath), { recursive: true });
+  appendFileSync(logPath, line);
+}
+
+// buildDispatchAlertEvent — canonical OTel-shaped JSONL line (string + "\n") for a
+// one-shot dispatch alert. WARN severity; event.action "raised"; event.label is the
+// stable KIND; body.payload carries the reason + any structured detail.
+export function buildDispatchAlertEvent({ eventName, kind, reason = null, detail = {} } = {}) {
+  const ts = new Date().toISOString().replace(/\.\d{3}Z$/, "Z");
+  return (
+    JSON.stringify({
+      ts,
+      id: randomBytes(8).toString("hex"),
+      observedTs: ts,
+      severityText: "WARN",
+      severityNumber: 13,
+      traceId: randomBytes(16).toString("hex"),
+      spanId: randomBytes(8).toString("hex"),
+      resource: buildCatalystResource({ serviceName: "catalyst.execution-core" }),
+      attributes: {
+        "event.name": eventName,
+        "event.entity": "alert",
+        "event.action": "raised",
+        "event.label": kind,
+      },
+      body: {
+        payload: {
+          kind,
+          reason,
+          source: "catalyst.execution-core",
+          ...detail,
+        },
+      },
+    }) + "\n"
+  );
+}
+
+// emitThrottled — the shared best-effort, throttled append. Returns true when a
+// line was written this call, false when throttled/failed. Never throws.
+function emitThrottled({
+  eventName,
+  kind,
+  reason,
+  detail = {},
+  append = defaultAppend,
+  now = Date.now,
+  throttleMs = DEFAULT_THROTTLE_MS,
+}) {
+  try {
+    const t = now();
+    const last = _lastEmitAt.get(kind) ?? 0;
+    if (t - last < throttleMs) return false; // throttled — a recent line already fired
+    _lastEmitAt.set(kind, t);
+    append(buildDispatchAlertEvent({ eventName, kind, reason, detail }));
+    return true;
+  } catch (err) {
+    // Never throw out of a read/dispatch hot path on an alert failure.
+    log?.error?.({ err: err?.message }, "dispatch-alert emit failed (continuing)");
+    return false;
+  }
+}
+
+// emitEligibleSourceUnavailable — runEligibleQuery replica-miss + breaker-open alert.
+export function emitEligibleSourceUnavailable({ team = null, append, now, throttleMs, reason } = {}) {
+  return emitThrottled({
+    eventName: ALERT_ELIGIBLE_SOURCE_UNAVAILABLE,
+    kind: ALERT_KIND_ELIGIBLE_SOURCE_UNAVAILABLE,
+    reason:
+      reason ??
+      "eligible discovery missed the replica AND the Linear breaker is OPEN — preserved the prior eligible set without spawning linearis (no bucket consumed)",
+    detail: team ? { "linear.team.key": team } : {},
+    append,
+    now,
+    throttleMs,
+  });
+}

--- a/plugins/dev/scripts/execution-core/linear-query.mjs
+++ b/plugins/dev/scripts/execution-core/linear-query.mjs
@@ -9,6 +9,7 @@ import { spawnSync } from "node:child_process";
 import { existsSync } from "node:fs";
 import { withBreaker, linearBreaker, isRateLimitError } from "./linear-breaker.mjs";
 import { withAuthRemint, linearReminter, isBatchAuthError } from "./linear-remint.mjs";
+import { emitEligibleSourceUnavailable } from "./dispatch-alert.mjs";
 
 // linearis caps a single page; 200 comfortably covers a project's pickable
 // set without pagination (the reconcile poll runs every 10 min anyway).
@@ -650,8 +651,28 @@ export function classifyTicketResolution(
 // (back-compat for callers that do not wire the gateway, e.g. CLI tools).
 export function fetchTicketAssignee(
   identifier,
-  { exec = defaultExec, gateway, fetchDelegate = fetchTicketDelegate } = {}
+  { exec = defaultExec, gateway, fetchDelegate = fetchTicketDelegate, replica } = {}
 ) {
+  // Stage 0 / A1: consult the local replica FIRST — but with the SAME trust rule the
+  // gateway path applies below (confirm-null, trust-non-null). A HIT with a NON-NULL
+  // delegate is authoritative and served Linear-free: Issue.delegate is only ever set
+  // by an actor, so a non-null value is trustworthy regardless of replica age (the
+  // primary per-tick breaker-tripper — the live delegate confirm below — never runs).
+  // A HIT with a NULL delegate is NOT trusted: the replica proves the writer is LIVE,
+  // not that THIS ticket's delegation was applied, so a per-ticket-lagged row can read
+  // delegate=null while a just-applied human/actor delegation is still queued behind
+  // the writer's cursor — trusting that null would self-delegate over the real owner
+  // and claim (a stomp). So a null-delegate HIT (and any gate-fail / miss / unreadable)
+  // FALLS THROUGH to the gateway/live chain, which live-confirms every null delegate
+  // (the CTL-1174 latch fix) — never claim on unknown. NOTE (A1-partial): the live
+  // confirm at the gateway-null and gateway-miss paths is deliberately retained this
+  // stage; it is deleted only in Stage 2 once event-log claims exist.
+  if (replica && typeof replica.ownership === "function") {
+    const own = replica.ownership(identifier);
+    if (own && own.delegate != null) {
+      return { known: true, assignee: own.assignee ?? null, delegate: own.delegate };
+    }
+  }
   if (gateway) {
     const d = gateway.getDescriptor(identifier);
     if (d && !d.removed) {
@@ -1011,6 +1032,27 @@ export function runEligibleQuery(
     }
     // MISS (undefined) / unconfirmed replica-empty → fall through to the UNCHANGED
     // linearis path below.
+  }
+  // D2 (Stage 0): breaker-open-aware replica MISS. Gated on `replica?.eligible` so it
+  // fires ONLY when the replica tier was actually consulted and MISSED (undefined) —
+  // NOT when no replica is wired at all (that un-accelerated path stays byte-identical,
+  // its breaker gating handled by the real breaker-wrapped exec). Reaching here with
+  // `replica?.eligible` present means eligible() returned undefined (a true miss); a
+  // breaker-open replica-EMPTY was already trusted+returned above (CTL-1420), and the
+  // unconfirmed-empty reconfirm falls through only with the breaker CLOSED. So when the
+  // CTL-679 breaker is OPEN on a genuine replica miss, do NOT spawn into it: the spawn
+  // could only short-circuit (circuit-open → the throw below) AND fails SILENTLY
+  // (reconcileProject preserves the empty prior set for the whole open window = the
+  // residual freeze L0 found). Instead emit a LOUD alert and THROW so reconcileProject
+  // preserves the prior set EXACTLY as today (its catch logs + recordReconcileFailure +
+  // preserves prior — the same shape a circuit-open exec produces), without consuming
+  // the bucket.
+  if (replica?.eligible && breakerIsOpen()) {
+    onSource?.("eligible-source-unavailable-breaker-open", 0);
+    emitEligibleSourceUnavailable({ team: query.team });
+    throw new Error(
+      "eligible source unavailable: replica miss + Linear breaker open — preserving prior set (no linearis spawn)"
+    );
   }
   // CTL-1364 regression fix: the eligible-list poll MUST stay UNCAPPED. The
   // CTL-1364 default floor is for the hot per-signal terminal reads only; a

--- a/plugins/dev/scripts/execution-core/linear-query.test.mjs
+++ b/plugins/dev/scripts/execution-core/linear-query.test.mjs
@@ -1,7 +1,11 @@
 // Unit tests for the execution-core Linear eligible query (CTL-535 Phase 2).
 // Run: cd plugins/dev/scripts/execution-core && bun test linear-query.test.mjs
 
-import { describe, test, expect, mock, beforeEach } from "bun:test";
+import { describe, test, expect, mock, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, rmSync, readFileSync, readdirSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { __resetDispatchAlertThrottle } from "./dispatch-alert.mjs";
 import {
   buildLinearisArgs,
   runEligibleQuery,
@@ -1588,6 +1592,134 @@ describe("fetchTicketAssignee (CTL-781)", () => {
     const r = fetchTicketAssignee("CTL-8", { exec });
     expect(r).toEqual({ known: true, assignee: BOT });
     expect(exec.calls.length).toBe(1);
+  });
+});
+
+// ─── Stage 0 / A1: fetchTicketAssignee replica-ownership fast-path ───────────
+describe("fetchTicketAssignee — replica ownership (A1, Stage 0)", () => {
+  const BOT = "ff78d890-7906-4c22-b2f5-020bd150c790";
+  const HUMAN = "11111111-1111-1111-1111-111111111111";
+
+  test("replica HIT with a NON-NULL delegate → trusted, never consults gateway/exec/fetchDelegate", () => {
+    const replica = { ownership: mock(() => ({ assignee: HUMAN, delegate: BOT })) };
+    const gateway = {
+      getDescriptor: () => {
+        throw new Error("gateway must NOT be read on a trusted (non-null) replica HIT");
+      },
+    };
+    const exec = () => {
+      throw new Error("live exec must NOT run on a trusted replica HIT");
+    };
+    const fetchDelegate = () => {
+      throw new Error("live delegate must NOT run on a trusted replica HIT");
+    };
+    const r = fetchTicketAssignee("CTL-1", { replica, gateway, exec, fetchDelegate });
+    expect(r).toEqual({ known: true, assignee: HUMAN, delegate: BOT });
+    expect(replica.ownership).toHaveBeenCalledTimes(1);
+  });
+
+  // Regression (Stage-0 review, Lens 1): a NULL-delegate replica HIT must NOT be
+  // trusted. A per-ticket-lagged replica can read delegate=null while a just-applied
+  // human/actor delegation is still queued — trusting it would self-delegate over the
+  // real owner and claim (a stomp). So a null-delegate HIT falls through to the
+  // gateway/live chain, which live-confirms the delegate (CTL-1174 latch fix) and
+  // observes the human's real delegation.
+  test("replica HIT with a NULL delegate → NOT trusted, live-confirms via the gateway path", () => {
+    const replica = { ownership: () => ({ assignee: null, delegate: null }) };
+    // Gateway cached-null delegate → the CTL-1174 latch fix live-confirms it; the
+    // confirm returns the human's REAL delegation, so the null is never trusted.
+    const gateway = fakeGateway({ ticket: "CTL-1", assignee: HUMAN, delegate: null, removed: false, updatedAt: FRESH() });
+    const fetchDelegate = mock(() => ({ known: true, delegate: HUMAN }));
+    const r = fetchTicketAssignee("CTL-1", { replica, gateway, fetchDelegate });
+    expect(fetchDelegate).toHaveBeenCalledTimes(1); // fell through + live-confirmed the null
+    expect(r).toEqual({ known: true, assignee: HUMAN, delegate: HUMAN });
+  });
+
+  test("replica MISS (undefined) falls through to the existing gateway path UNCHANGED", () => {
+    const mkGateway = () =>
+      fakeGateway({ ticket: "CTL-1", assignee: HUMAN, delegate: BOT, removed: false, updatedAt: FRESH() });
+    const withMiss = fetchTicketAssignee("CTL-1", {
+      replica: { ownership: () => undefined },
+      gateway: mkGateway(),
+    });
+    const withoutReplica = fetchTicketAssignee("CTL-1", { gateway: mkGateway() });
+    expect(withMiss).toEqual({ known: true, assignee: HUMAN, delegate: BOT });
+    expect(withMiss).toEqual(withoutReplica); // byte-identical to today's behavior on a miss
+  });
+
+  test("replica MISS + gateway miss → today's live read chain (fetchDelegate injected)", () => {
+    const exec = fakeExec({ code: 0, stdout: JSON.stringify({ assignee: { id: BOT } }) });
+    const fetchDelegate = () => ({ known: true, delegate: null });
+    const r = fetchTicketAssignee("CTL-4", {
+      replica: { ownership: () => undefined },
+      gateway: fakeGateway(null),
+      exec,
+      fetchDelegate,
+    });
+    expect(r).toEqual({ known: true, assignee: BOT, delegate: null });
+    expect(exec.calls.length).toBe(1); // fell through to the live read
+  });
+});
+
+// ─── Stage 0 / D2: runEligibleQuery breaker-open replica-miss hardening ──────
+describe("runEligibleQuery — D2 (breaker-open replica miss)", () => {
+  let tmpDir;
+  let prevDir;
+  beforeEach(() => {
+    __resetEligibleEmptyConfirm();
+    __resetDispatchAlertThrottle();
+    prevDir = process.env.CATALYST_DIR;
+    tmpDir = mkdtempSync(join(tmpdir(), "d2-alert-"));
+    process.env.CATALYST_DIR = tmpDir; // redirect the event log the alert appends to
+  });
+  afterEach(() => {
+    if (prevDir === undefined) delete process.env.CATALYST_DIR;
+    else process.env.CATALYST_DIR = prevDir;
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  const missReplica = () => ({ eligible: () => undefined }); // a replica MISS (fall-through)
+
+  function eventLogBody() {
+    const dir = join(tmpDir, "events");
+    const files = readdirSync(dir);
+    return files.map((f) => readFileSync(join(dir, f), "utf8")).join("");
+  }
+
+  test("undefined-miss + breaker OPEN → throws (preserve-prior), NO linearis spawn, alert emitted", () => {
+    const exec = mock(() => ({ code: 0, stdout: ticketsJson([]), stderr: "" }));
+    const sources = [];
+    expect(() =>
+      runEligibleQuery(
+        { team: "CTL", status: "Todo" },
+        {
+          exec,
+          replica: missReplica(),
+          breakerIsOpen: () => true,
+          onSource: (s, n) => sources.push([s, n]),
+        },
+      ),
+    ).toThrow(/breaker open/);
+    expect(exec).not.toHaveBeenCalled(); // did NOT spawn into the open breaker
+    expect(sources).toEqual([["eligible-source-unavailable-breaker-open", 0]]);
+    const body = eventLogBody();
+    expect(body).toContain("catalyst.alert.eligible_source_unavailable");
+    expect(body).toContain("eligible_source_unavailable");
+  });
+
+  test("undefined-miss + breaker CLOSED → spawns linearis as before (no alert, no throw)", () => {
+    const exec = fakeExec({ code: 0, stdout: ticketsJson([]) });
+    const tickets = runEligibleQuery(
+      { team: "CTL", status: "Todo" },
+      {
+        exec,
+        replica: missReplica(),
+        breakerIsOpen: () => false,
+        delegateExec: () => ({ code: 0, stdout: "{}", stderr: "" }),
+      },
+    );
+    expect(tickets).toEqual([]);
+    expect(exec.calls.length).toBe(1); // fell through to the live linearis path
   });
 });
 

--- a/plugins/dev/scripts/execution-core/monitor.mjs
+++ b/plugins/dev/scripts/execution-core/monitor.mjs
@@ -637,6 +637,12 @@ function dispatchTriage(
     botWriteId,
     gateway,
     fetchAssignee = fetchTicketAssignee,
+    // Stage 0 / A1: the daemon-injected replica reader (createReplicaReader, with an
+    // ownership() method), so the CTL-1174 gate consults local ownership FIRST and
+    // only falls through to the live confirm on a replica miss. Defaults to the
+    // module singleton the daemon set (mirrors reconcileProject's replica default);
+    // undefined on the Node broker / mode-off → the live path, byte-identical to today.
+    replica = _injectedEligibleReplica,
     applyAssignee = defaultApplyAssignee,
     // CTL-862: cross-host coordination seams (left undefined → single-host fallback).
     hosts = undefined,
@@ -694,7 +700,7 @@ function dispatchTriage(
   // retries next reconcile). Empty/absent botUserIds disables the gate
   // (CTL-749 fail-open convention).
   if (botUserIds instanceof Set && botUserIds.size > 0) {
-    const a = fetchAssignee(identifier, { gateway });
+    const a = fetchAssignee(identifier, { gateway, replica });
     if (!a.known) {
       // Unreadable delegate → HOLD (sweepMissingTriage retries next reconcile).
       log.info({ identifier, known: false }, "monitor: triage dispatch held — delegate unreadable (CTL-1174)");

--- a/plugins/dev/scripts/execution-core/monitor.test.mjs
+++ b/plugins/dev/scripts/execution-core/monitor.test.mjs
@@ -33,6 +33,7 @@ import { setProjectEligible, getEligibleSet, dropProject } from "./eligible-set.
 import { loadCursor, saveCursor } from "./event-cursor.mjs";
 import { createTicketStateCache } from "./linear-cache.mjs";
 import { fetchTicketState } from "./linear-query.mjs";
+import { linearBreaker } from "./linear-breaker.mjs"; // close the shared breaker so the D2 replica-miss fall-through is deterministic
 import {
   getReconcileHealth,
   readReconcileHealthMarkers,
@@ -224,6 +225,15 @@ describe("reconcileProject", () => {
 // quota + trips the CTL-679 circuit breaker). A replica HIT must NOT shell out
 // to linearis; a MISS falls through unchanged.
 describe("reconcileProject — replica tier (CTL-1397)", () => {
+  // CTL-679/Stage-0 D2: the shared linearBreaker is a process-wide singleton a
+  // prior test FILE can leave OPEN. Stage-0 D2 makes a replica-MISS THROW (preserve
+  // prior, no spawn) when the breaker is open — so the replica-miss→linearis
+  // fall-through these tests assert is the CLOSED-breaker path. Close it per test
+  // for a deterministic baseline (mirrors linear-query.test.mjs's replica-tier block).
+  beforeEach(() => {
+    linearBreaker.recordSuccess(); // → closed (no-op if already closed)
+  });
+
   // A replica stub whose eligible() returns a canned eligible answer (or
   // undefined to fall through). Shaped so normalizeTicket consumes it directly.
   function replicaReturning(nodesOrUndefined) {

--- a/plugins/dev/scripts/execution-core/replica-read.mjs
+++ b/plugins/dev/scripts/execution-core/replica-read.mjs
@@ -79,8 +79,37 @@ function coerceMs(v) {
 // `identifier LIKE 'CTL-%'` selects exactly team CTL (the hyphen disambiguates
 // CTL- from CTC-). state is the workflow-state NAME string (matches query.status).
 // removed_at IS NULL drops tombstones. LIMIT 200 matches linear-query DEFAULT_LIMIT.
-const ELIGIBLE_SELECT = `SELECT i.identifier, i.title, i.state, i.priority, i.estimate, i.updated_at, i.created_at, i.parent_identifier, i.delegate_id, i.delegate_name, p.name AS project_name FROM issues i LEFT JOIN projects p ON p.id = i.project_id WHERE i.identifier LIKE ? AND i.state = ? AND i.removed_at IS NULL ORDER BY i.updated_at DESC LIMIT ?`;
+// The eligible board-list query, split HEAD/TAIL so D1 (project/label filters)
+// can inject extra WHERE clauses before the ORDER BY without a second SELECT.
+const ELIGIBLE_SELECT_HEAD = `SELECT i.identifier, i.title, i.state, i.priority, i.estimate, i.updated_at, i.created_at, i.parent_identifier, i.delegate_id, i.delegate_name, p.name AS project_name FROM issues i LEFT JOIN projects p ON p.id = i.project_id WHERE i.identifier LIKE ? AND i.state = ? AND i.removed_at IS NULL`;
+const ELIGIBLE_SELECT_TAIL = ` ORDER BY i.updated_at DESC LIMIT ?`;
 const ELIGIBLE_LIMIT = 200;
+
+// buildEligibleSelect — assemble the eligible SELECT with optional D1 project/label
+// filters. project → `AND p.name = ?` (the LEFT JOIN projects.name already in HEAD);
+// label → an EXISTS over issue_labels⋈labels keyed by the issue's own PK id, matching
+// the label NAME (issue_labels(issue_id,label_id) + labels(id,name); the identifier→id
+// resolution the cloud schema needs). Bind order MUST mirror the appended clauses:
+// [likePattern, status, (project?), (label?), LIMIT].
+function buildEligibleSelect({ project, label } = {}) {
+  let sql = ELIGIBLE_SELECT_HEAD;
+  if (project != null) sql += ` AND p.name = ?`;
+  if (label != null)
+    sql += ` AND EXISTS (SELECT 1 FROM issue_labels il JOIN labels l ON l.id = il.label_id WHERE il.issue_id = i.id AND l.name = ?)`;
+  return sql + ELIGIBLE_SELECT_TAIL;
+}
+
+// ownership(id) — the per-ticket claim-gate reader (Stage 0 / A0). One index-backed
+// row-read of the assignee + delegate the CTL-1174 gate needs, so the daemon can
+// decide human/tool ownership Linear-free. Gated (in ownership() below) by the SAME
+// freshness + seed-cursor gate as eligible() — a gate-fail/miss/unreadable returns
+// undefined so the caller HOLDs / falls through to the live confirm and NEVER claims
+// on unknown. There is deliberately NO per-ticket currency gate here: file mtime
+// proves the writer is LIVE, not that THIS ticket's delegate change was applied, so
+// a caller must never TRUST a null delegate from the replica — fetchTicketAssignee
+// live-confirms every null delegate and trusts only a non-null (actor-set) one,
+// matching the gateway path (see linear-query.mjs).
+const OWNERSHIP_SELECT = `SELECT assignee_id, delegate_id, delegate_name FROM issues WHERE identifier = ? AND removed_at IS NULL LIMIT 1`;
 // Relation enrichment, mirroring normalizeDetail in linear-cli.mjs. forward:
 // edges this issue OWNS (relatedIssue is the target); inverse: edges that point
 // AT this issue (the blocked-by edge the scheduler gates on).
@@ -141,6 +170,20 @@ function isReplicaFresh(dbPath) {
   }
   return Date.now() - newest <= thresholdMs;
 }
+
+// NOTE (Stage 0): there is intentionally NO coarse "currency" guard on ownership().
+// An earlier draft gated ownership() on the db/`-wal` mtimes being within a currency
+// window, on the theory that a live-but-lagging writer could leave a just-delegated
+// ticket reading `delegate=null` locally. But file mtime cannot detect PER-TICKET
+// lag: it only proves SOME apply happened recently, not that THIS ticket's change
+// was applied — so it gave false confidence in the dangerous direction (a fresh
+// mtime with a stale row) while FALSELY tripping in the safe direction (a genuinely
+// QUIET-but-current feed reads as "stale" and re-froze the claim gate on the exact
+// `-wal`-staleness antipattern CTL-1397 removed — see isReplicaFresh's rationale
+// above). The correct instrument lives at the trust boundary instead:
+// fetchTicketAssignee live-confirms every NULL delegate and trusts only a NON-NULL
+// (actor-set) delegate, so a stale null can never self-delegate + claim, and a quiet
+// feed still serves the authoritative non-null case Linear-free.
 
 export function createReplicaReader({ dbPath = getReplicaDbPath() } = {}) {
   let db = null;
@@ -247,18 +290,17 @@ export function createReplicaReader({ dbPath = getReplicaDbPath() } = {}) {
   //   caller must NOT fall through and re-run linearis for it).
   //   undefined = "fall through to linearis" — returned when:
   //     - the query is missing team or status (can't build the filter), OR
-  //     - query.project or query.label is set (v1 scope: filtered queries stay
-  //       on linearis — the replica filter is team+state only), OR
   //     - the replica file is absent OR STALE by mtime (writer-liveness gate), OR
   //     - any throw (→ dropHandle + undefined).
   //   Fail-open everywhere: this tier can only ACCELERATE; any doubt falls
   //   through to today's linearis behavior, never makes discovery WORSE.
   const eligible = (query) => {
-    // Guard: need both filter dimensions, and v1 does NOT serve project/label
-    // filtered queries (the SQL filters team+state only — a project/label query
-    // would silently over-return, so fall through to linearis instead).
+    // Guard: need both filter dimensions.
+    // D1 (Stage 0): project/label filtered queries ARE now served from the replica
+    // (the replica carries projects + issue_labels⋈labels), closing the permanent
+    // every-tick fall-through to `linearis issues list` for project/label-scoped
+    // teams — buildEligibleSelect appends the matching WHERE clauses below.
     if (!query || !query.team || !query.status) return undefined;
-    if (query.project != null || query.label != null) return undefined;
     // Freshness GATE (writer-liveness proxy) — a stale/absent replica falls
     // through so a dead writer can never freeze discovery on a stale board.
     if (!isReplicaFresh(dbPath)) return undefined;
@@ -286,9 +328,15 @@ export function createReplicaReader({ dbPath = getReplicaDbPath() } = {}) {
         // snapshot as the board below so a re-seed can't slip between the two.
         // undefined here = gate failed → fall through to linearis.
         if (!handle.prepare(SEED_COMPLETE_SELECT).get()) return undefined;
+        // D1: bind order mirrors buildEligibleSelect's appended clauses —
+        // [likePattern, status, (project?), (label?), LIMIT].
+        const params = [`${query.team}-%`, query.status];
+        if (query.project != null) params.push(query.project);
+        if (query.label != null) params.push(query.label);
+        params.push(ELIGIBLE_LIMIT);
         const rows = handle
-          .prepare(ELIGIBLE_SELECT)
-          .all(`${query.team}-%`, query.status, ELIGIBLE_LIMIT);
+          .prepare(buildEligibleSelect({ project: query.project, label: query.label }))
+          .all(...params);
         const fwdStmt = handle.prepare(RELATIONS_FORWARD_SELECT);
         const invStmt = handle.prepare(RELATIONS_INVERSE_SELECT);
         return rows.map((row) => {
@@ -341,5 +389,44 @@ export function createReplicaReader({ dbPath = getReplicaDbPath() } = {}) {
     }
   };
 
-  return { lookup, freshness, titles, eligible, close: dropHandle };
+  // ownership(id) → { assignee, delegate } | undefined  (Stage 0 / A0, A1)
+  //   The per-ticket claim-gate reader: the ticket's current assignee + delegate
+  //   UUIDs (each null when unset), read Linear-free from the local replica.
+  //   Gated IDENTICALLY to eligible() — writer LIVENESS (isReplicaFresh, on the
+  //   `.writer.lock` heartbeat) + the seed-completeness cursor (inside the read
+  //   snapshot). ANY gate-fail, a MISS (absent/removed row), or any throw →
+  //   undefined, so the caller HOLDs / falls through to the live confirm and NEVER
+  //   claims on unknown (L1-1 fail-safe). The per-ticket null-vs-non-null trust
+  //   decision lives at the caller (fetchTicketAssignee): a null delegate is always
+  //   live-confirmed, a non-null one is trusted — so ownership() needs no currency
+  //   gate of its own (see the isReplicaCurrent removal note above).
+  //
+  //   Gate order:
+  //     1. !isReplicaFresh   → undefined            (dead/stale writer)
+  //     2. seed cursor absent → undefined            (mid-reseed)
+  //     3. no row            → undefined            (absent/removed; MISS)
+  //     4. HIT               → { assignee, delegate }
+  const ownership = (identifier) => {
+    if (!identifier) return undefined;
+    // 1. LIVENESS — a dead/stale writer must never serve ownership.
+    if (!isReplicaFresh(dbPath)) return undefined;
+    try {
+      const handle = open();
+      // 2+3+4 in ONE deferred read snapshot (same shape as eligible()): the
+      // seed-completeness cursor and the ownership row come from one consistent
+      // snapshot so a forced re-seed can't slip between the gate and the read.
+      const row = handle.transaction(() => {
+        if (!handle.prepare(SEED_COMPLETE_SELECT).get()) return undefined; // mid-reseed
+        return handle.prepare(OWNERSHIP_SELECT).get(identifier);
+      })();
+      if (!row) return undefined; // seed-gate fail / absent / removed → MISS (HOLD)
+      return { assignee: row.assignee_id ?? null, delegate: row.delegate_id ?? null };
+    } catch {
+      // Drop the handle so a later call re-opens fresh (DB may be re-seeded).
+      dropHandle();
+      return undefined;
+    }
+  };
+
+  return { lookup, freshness, titles, eligible, ownership, close: dropHandle };
 }

--- a/plugins/dev/scripts/execution-core/replica-read.test.mjs
+++ b/plugins/dev/scripts/execution-core/replica-read.test.mjs
@@ -410,16 +410,24 @@ describe("createReplicaReader.eligible (CTL-1397 board-list)", () => {
     expect(reader.eligible({ team: "CTL" })).toBeUndefined();
   });
 
-  test("returns undefined (v1 scope) when query.project is set", () => {
+  // D1 (Stage 0): project-filtered queries are now SERVED from the replica (the
+  // permanent every-tick fall-through to `linearis issues list` for project-scoped
+  // teams is closed). The filter is an EXACT project-name match on the LEFT JOIN.
+  test("D1: serves a project-filtered query from the replica (exact project name)", () => {
     seedEligible();
     reader = createReplicaReader({ dbPath });
-    expect(reader.eligible({ team: "CTL", status: "Todo", project: "Harden" })).toBeUndefined();
+    const res = reader.eligible({ team: "CTL", status: "Todo", project: "Harden the core" });
+    // Only CTL-100 is in proj-1 ("Harden the core"); CTL-101 has no project.
+    expect(res.nodes.map((n) => n.identifier)).toEqual(["CTL-100"]);
   });
 
-  test("returns undefined (v1 scope) when query.label is set", () => {
+  test("D1: a project filter that matches nothing → { nodes: [] } (served, NOT undefined)", () => {
     seedEligible();
     reader = createReplicaReader({ dbPath });
-    expect(reader.eligible({ team: "CTL", status: "Todo", label: "bug" })).toBeUndefined();
+    // A defined empty answer — the caller must NOT re-run linearis for it.
+    expect(reader.eligible({ team: "CTL", status: "Todo", project: "Nonexistent" })).toEqual({
+      nodes: [],
+    });
   });
 
   test("returns undefined when the replica file is absent", () => {
@@ -574,5 +582,191 @@ describe("createReplicaReader.eligible (CTL-1397 board-list)", () => {
     expect(second.nodes[0].inverseRelations.nodes).toEqual([
       { type: "blocks", issue: { identifier: "CTL-7" } },
     ]);
+  });
+});
+
+// D1 (Stage 0) — label-filtered eligible(). Needs the issue_labels⋈labels join keyed
+// by the issue's own PK `id`, so this fixture carries the `id` column + the two label
+// tables the corrected join reads (issue_labels(issue_id,label_id) + labels(id,name)).
+function seedEligibleLabeled() {
+  const db = new Database(dbPath, { create: true });
+  db.run(`
+    CREATE TABLE issues (
+      id                TEXT,
+      identifier        TEXT,
+      title             TEXT,
+      state             TEXT,
+      priority          INTEGER,
+      estimate          INTEGER,
+      project_id        TEXT,
+      parent_identifier TEXT,
+      delegate_id       TEXT,
+      delegate_name     TEXT,
+      removed_at        TEXT,
+      updated_at        INTEGER,
+      created_at        INTEGER
+    )
+  `);
+  db.run(`CREATE INDEX idx_issues_identifier ON issues (identifier)`);
+  db.run(`CREATE TABLE relations (type TEXT, issue_identifier TEXT, related_identifier TEXT)`);
+  db.run(`CREATE TABLE projects (id TEXT, name TEXT)`);
+  db.run(`CREATE TABLE labels (id TEXT, name TEXT)`);
+  db.run(`CREATE TABLE issue_labels (issue_id TEXT, label_id TEXT)`);
+  db.run(`CREATE TABLE sync_meta (key TEXT PRIMARY KEY, value TEXT)`);
+  db.run(`INSERT INTO sync_meta VALUES ('cursor', '42')`);
+  db.run(`INSERT INTO labels VALUES ('lab-bug', 'bug')`);
+  db.run(`INSERT INTO labels VALUES ('lab-chore', 'chore')`);
+  // CTL-200 labeled 'bug'; CTL-201 labeled 'chore'; both Todo.
+  db.run(
+    `INSERT INTO issues VALUES ('id-200', 'CTL-200', 'Bug ticket', 'Todo', 2, NULL, NULL, NULL, NULL, NULL, NULL, 3000, 100)`,
+  );
+  db.run(
+    `INSERT INTO issues VALUES ('id-201', 'CTL-201', 'Chore ticket', 'Todo', 2, NULL, NULL, NULL, NULL, NULL, NULL, 2000, 90)`,
+  );
+  db.run(`INSERT INTO issue_labels VALUES ('id-200', 'lab-bug')`);
+  db.run(`INSERT INTO issue_labels VALUES ('id-201', 'lab-chore')`);
+  db.close();
+  freshen();
+}
+
+describe("createReplicaReader.eligible — D1 label filter (Stage 0)", () => {
+  test("serves a label-filtered query from the replica (issue_labels⋈labels by name)", () => {
+    seedEligibleLabeled();
+    reader = createReplicaReader({ dbPath });
+    const res = reader.eligible({ team: "CTL", status: "Todo", label: "bug" });
+    expect(res.nodes.map((n) => n.identifier)).toEqual(["CTL-200"]); // only the 'bug' ticket
+  });
+
+  test("a different label selects the other ticket (join resolves identifier→id correctly)", () => {
+    seedEligibleLabeled();
+    reader = createReplicaReader({ dbPath });
+    const res = reader.eligible({ team: "CTL", status: "Todo", label: "chore" });
+    expect(res.nodes.map((n) => n.identifier)).toEqual(["CTL-201"]);
+  });
+
+  test("a label matching nothing → { nodes: [] } (served, NOT undefined)", () => {
+    seedEligibleLabeled();
+    reader = createReplicaReader({ dbPath });
+    expect(reader.eligible({ team: "CTL", status: "Todo", label: "nonexistent" })).toEqual({
+      nodes: [],
+    });
+  });
+
+  test("project + label combined AND both filters", () => {
+    seedEligibleLabeled();
+    reader = createReplicaReader({ dbPath });
+    // No project set on these rows, so a project filter + label yields nothing.
+    expect(
+      reader.eligible({ team: "CTL", status: "Todo", label: "bug", project: "Harden the core" }),
+    ).toEqual({ nodes: [] });
+  });
+});
+
+// ownership() (Stage 0 / A0) — the per-ticket claim-gate reader. Same freshness +
+// seed-cursor gate as eligible() (NO per-ticket currency gate — the null-vs-non-null
+// trust decision lives in fetchTicketAssignee); any gate-fail / miss → undefined
+// (caller HOLDs / falls through, never claims on unknown).
+function seedOwnership() {
+  const db = new Database(dbPath, { create: true });
+  db.run(
+    `CREATE TABLE issues (identifier TEXT, assignee_id TEXT, delegate_id TEXT, delegate_name TEXT, removed_at TEXT)`,
+  );
+  db.run(`CREATE INDEX idx_issues_identifier ON issues (identifier)`);
+  db.run(`CREATE TABLE sync_meta (key TEXT PRIMARY KEY, value TEXT)`);
+  db.run(`INSERT INTO sync_meta VALUES ('cursor', '42')`);
+  db.run(`INSERT INTO issues VALUES ('CTL-300', 'user-1', 'bot-9', 'Bot', NULL)`); // assigned + delegated
+  db.run(`INSERT INTO issues VALUES ('CTL-301', NULL, NULL, NULL, NULL)`); // unassigned/undelegated
+  db.run(`INSERT INTO issues VALUES ('CTL-302', 'user-2', 'user-3', 'Human', NULL)`); // human delegate
+  db.run(`INSERT INTO issues VALUES ('CTL-303', 'user-1', 'bot-9', 'Bot', '2026-06-03T00:00:00Z')`); // removed
+  db.close();
+}
+
+// backdate — push a file's mtime N minutes into the past (liveness/currency fixtures).
+function backdate(path, minutes) {
+  const t = new Date(Date.now() - minutes * 60_000);
+  try {
+    utimesSync(path, t, t);
+  } catch {
+    /* absent */
+  }
+}
+
+describe("createReplicaReader.ownership (Stage 0 / A0)", () => {
+  test("fresh (liveness + seed pass) → HIT { assignee, delegate }", () => {
+    seedOwnership();
+    freshen();
+    reader = createReplicaReader({ dbPath });
+    expect(reader.ownership("CTL-300")).toEqual({ assignee: "user-1", delegate: "bot-9" });
+  });
+
+  test("HIT coerces unset assignee/delegate to null", () => {
+    seedOwnership();
+    freshen();
+    reader = createReplicaReader({ dbPath });
+    expect(reader.ownership("CTL-301")).toEqual({ assignee: null, delegate: null });
+  });
+
+  test("HIT reports a human delegate verbatim (the claim decision lives in the caller)", () => {
+    seedOwnership();
+    freshen();
+    reader = createReplicaReader({ dbPath });
+    expect(reader.ownership("CTL-302")).toEqual({ assignee: "user-2", delegate: "user-3" });
+  });
+
+  test("removed (tombstoned) row → undefined (MISS → caller HOLDs)", () => {
+    seedOwnership();
+    freshen();
+    reader = createReplicaReader({ dbPath });
+    expect(reader.ownership("CTL-303")).toBeUndefined();
+  });
+
+  test("absent ticket → undefined", () => {
+    seedOwnership();
+    freshen();
+    reader = createReplicaReader({ dbPath });
+    expect(reader.ownership("CTL-404")).toBeUndefined();
+  });
+
+  test("empty/falsy identifier → undefined without touching the DB", () => {
+    reader = createReplicaReader({ dbPath });
+    expect(reader.ownership("")).toBeUndefined();
+    expect(reader.ownership(null)).toBeUndefined();
+    expect(reader.ownership(undefined)).toBeUndefined();
+  });
+
+  test("STALE .writer.lock (dead writer) → undefined (liveness gate fails)", () => {
+    seedOwnership();
+    freshen(); // db/-wal fresh (a recent apply just before the writer died)
+    writeFileSync(dbPath + ".writer.lock", "");
+    backdate(dbPath + ".writer.lock", 10); // present-but-stale lock is authoritative → liveness fails
+    reader = createReplicaReader({ dbPath });
+    expect(reader.ownership("CTL-300")).toBeUndefined();
+  });
+
+  test("mid-reseed (cursor absent) on a fresh DB → undefined (seed gate)", () => {
+    seedOwnership();
+    const db = new Database(dbPath);
+    db.run(`DELETE FROM sync_meta WHERE key = 'cursor'`);
+    db.close();
+    freshen(); // liveness passes; only the seed is incomplete
+    reader = createReplicaReader({ dbPath });
+    expect(reader.ownership("CTL-300")).toBeUndefined();
+  });
+
+  // Regression (Stage-0 review): there is deliberately NO per-ticket currency gate.
+  // File mtime cannot detect PER-TICKET lag, and gating on it re-froze the claim gate
+  // on a genuinely QUIET-but-current feed (the CTL-1397 antipattern). As long as the
+  // writer is LIVE (fresh lock) and the seed is complete, ownership() serves the row
+  // even when the data-file mtimes are old — the null-vs-non-null trust decision is
+  // the caller's (fetchTicketAssignee live-confirms every null delegate).
+  test("STALE data files but LIVE writer + complete seed → HIT (no currency gate)", () => {
+    seedOwnership();
+    backdate(dbPath, 30); // data files stale far beyond any old currency window …
+    backdate(dbPath + "-wal", 30);
+    // … but the writer is alive: a just-heartbeated lock keeps liveness passing.
+    writeFileSync(dbPath + ".writer.lock", "");
+    utimesSync(dbPath + ".writer.lock", new Date(), new Date());
+    reader = createReplicaReader({ dbPath });
+    expect(reader.ownership("CTL-300")).toEqual({ assignee: "user-1", delegate: "bot-9" });
   });
 });

--- a/plugins/dev/scripts/execution-core/scheduler.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.mjs
@@ -5645,7 +5645,7 @@ export function schedulerTick(
     // cooldown marker, no failure event. Empty/absent botUserIds disables
     // the gate (CTL-749 fail-open convention).
     if (botUserIds instanceof Set && botUserIds.size > 0) {
-      const a = fetchAssignee(t.identifier, { gateway, exec });
+      const a = fetchAssignee(t.identifier, { gateway, exec, replica });
       if (!a.known) {
         log.debug(
           { ticket: t.identifier },


### PR DESCRIPTION
## Context
Stage 0 of severing the execution-core **dispatch path from live Linear** — the durable fix for the freeze class where the shared app-actor bucket saturates, the CTL-679 breaker opens, and dispatch (which read Linear live for ownership + eligibility) freezes. Design (adversarially vetted, 10-agent workflow): `thoughts/shared/plans/2026-07-02-dispatch-no-live-linear.md`.

**Root-cause note:** the fleet's live proxy capture named the dominant burner as `query ReadFence` (~80% of Linear traffic, CTL-863 fence guards) — owned separately (READ-SDK's ReadFence cache). **This PR is the complementary dispatch-read layer**, not the ReadFence fix.

## Changes (Stage 0 — keeps the live fallback; full elimination + event-log claims are Stage 1/2)
- **`replica-read.mjs`** — new `ownership(id)` reader (assignee+delegate), gated on writer-liveness + seed cursor **identically to `eligible()`**. `eligible()` now serves `project`/`label` filters inside the same snapshot (**D1**) instead of a live-linearis fall-through.
- **`linear-query.mjs`** — **A1 (confirm-null, trust-non-null):** `fetchTicketAssignee` consults `ownership()` first; a **non-null** delegate is actor-authoritative → trusted **Linear-free**; a **null** delegate falls through to the unchanged gateway/live confirm (no stomp on a stale null). **D2:** `runEligibleQuery` no longer spawns `linearis` into an **open** breaker on a replica miss — preserves the prior eligible set + emits `catalyst.alert.eligible_source_unavailable`.
- **`dispatch-alert.mjs`** (new) — one-shot best-effort `catalyst.alert.*` emitters to the event log.
- **`scheduler.mjs` / `monitor.mjs`** — thread the daemon's replica reader into the CTL-1174 gate.

## Design decision
**Rejects the breaker split** (an earlier idea): the daemon has a *single* shared app-actor token/bucket/breaker — there is nothing to split. Freeze-immunity comes from removing dispatch's *dependence* on the bucket (reads→replica), not from breaker surgery.

## Tests
replica-read **55**, linear-query **196**, monitor **137** pass; **zero net-new failures** in the full `execution-core/` suite; `node --check` clean. No breaker/claim files touched.

## Deploy
Merge only auto-reloads the broker; the exec-core change needs an explicit restart. **I'll defer that restart** until the fleet's ReadFence cache lands + unfreezes and the mini-2 audit-proxy window closes, then deploy + verify dispatch with a before/after proxy capture.

🤖 Generated with [Claude Code](https://claude.com/claude-code)