### PR TITLE
fix(dev): CTL-863 — interim in-process TTL cache for fence ReadFence to unfreeze the shared Linear bucket

### DIFF
--- a/plugins/dev/scripts/execution-core/cluster-claim-sync.mjs
+++ b/plugins/dev/scripts/execution-core/cluster-claim-sync.mjs
@@ -124,3 +124,82 @@ export function fenceCheckSync(
     return { current: false, stale: false };
   }
 }
+
+// ─── in-process TTL cache around the fence read (CTL-863 fleet-unfreeze, urgent interim) ──
+//
+// The CTL-863 fence guards (fenceGuard, fence-guard.mjs) call fenceCheckSync
+// before EVERY external-write site — ~11 call sites across scheduler.mjs,
+// recovery.mjs, and stale-pr-rescue-timer.mjs. Each call spawns a FRESH `node
+// cluster-claim.mjs fence-check <ticket> <gen>` subprocess (a new process, so
+// caching INSIDE cluster-claim.mjs would be cold every time) that issues
+// Linear's `query ReadFence` (an attachment read). Live-proxy-confirmed at
+// ~5,000/hr — 62% of ALL Linear traffic on the shared app-actor bucket —
+// saturating it and tripping the CTL-679 rate-limit breaker open, which
+// freezes fleet dispatch entirely.
+//
+// fenceCheckSyncCached wraps fenceCheckSync with an in-process TTL cache that
+// lives in THIS module (imported once by the long-running daemon process —
+// scheduler.mjs / recovery.mjs / stale-pr-rescue-timer.mjs — so the Map
+// persists across calls, unlike the per-call subprocess). Keyed by
+// `${ticket}::${generation}`, NOT ticket alone: isFenceCurrent's answer is a
+// function of BOTH — a takeover can leave the same ticket at a different
+// current generation, so two different generations asked about the same
+// ticket are NOT interchangeable answers.
+//
+// The underlying fence only changes on the heartbeat cadence (~2 min,
+// cluster-heartbeat.mjs), so caching a read for up to 45s cannot observe a
+// staler fence than genuinely existed at write time — safe by construction,
+// not a race. This is the INTERIM stopgap; the durable fix replaces the
+// read-per-check pattern with an event-log-derived fence (see
+// thoughts/shared/plans/2026-07-03-fence-to-eventlog.md).
+//
+// Only a DETERMINATE read is cached: {current:true} or {current:false,
+// stale:true} (a confirmed non-current generation). The indeterminate bucket —
+// {current:false, stale:false}, i.e. a spawn error/timeout/other exit — is a
+// FAILURE, not an answer. fenceGuard fail-closes on it (suppresses the write),
+// so caching a transient hiccup would extend a false "not current" verdict for
+// the full TTL instead of retrying on the very next call. Never cached.
+//
+// CATALYST_FENCE_READ_CACHE_MS — TTL override in ms, read from the same `env`
+// seam fenceCheckSync already threads through to the spawned subprocess. 0
+// disables the cache entirely (every call falls through to a real
+// fenceCheckSync) — an escape hatch for debugging/verification. Unset/invalid
+// → the 45s default.
+const FENCE_READ_CACHE_MS_DEFAULT = 45_000;
+
+// fenceReadCache — module-scope Map(`${ticket}::${generation}` -> {result, ts}).
+const fenceReadCache = new Map();
+
+// clearFenceReadCache — test-only reset of the module-scope cache between cases.
+export function clearFenceReadCache() {
+  fenceReadCache.clear();
+}
+
+function resolveFenceReadCacheMs(env) {
+  const raw = Number(env?.CATALYST_FENCE_READ_CACHE_MS);
+  return Number.isFinite(raw) && raw >= 0 ? raw : FENCE_READ_CACHE_MS_DEFAULT;
+}
+
+// fenceCheckSyncCached — the cached entry point. fence-guard.mjs's default
+// `check` seam points here so every real external-write-site fence check
+// benefits without any change to fenceGuard's decision logic or fail-closed
+// semantics — this only decides whether to skip the underlying read, never
+// what the read means. `now`/`env` are injectable for tests; every other
+// option (`spawn`/`nodeBin`/`cli`/`timeout`) passes straight through to
+// fenceCheckSync unchanged on a cache miss.
+export function fenceCheckSyncCached({ ticket, generation }, { now = Date.now, env = process.env, ...rest } = {}) {
+  const ttlMs = resolveFenceReadCacheMs(env);
+  const key = `${ticket}::${generation}`;
+  if (ttlMs > 0) {
+    const cached = fenceReadCache.get(key);
+    if (cached && now() - cached.ts < ttlMs) {
+      return cached.result;
+    }
+  }
+  const result = fenceCheckSync({ ticket, generation }, { env, ...rest });
+  // Cache only a determinate read (never the indeterminate/error bucket).
+  if (ttlMs > 0 && (result.current === true || result.stale === true)) {
+    fenceReadCache.set(key, { result, ts: now() });
+  }
+  return result;
+}

--- a/plugins/dev/scripts/execution-core/cluster-claim-sync.test.mjs
+++ b/plugins/dev/scripts/execution-core/cluster-claim-sync.test.mjs
@@ -2,9 +2,14 @@
 // cluster-claim CLI (CTL-850). Every test injects a fake `spawn` so nothing
 // actually forks a process; the focus is argv construction + stdout parsing +
 // the FAIL-CLOSED contract (won:false on any failure).
-import { describe, it, expect } from "bun:test";
+import { describe, it, expect, beforeEach } from "bun:test";
 
-import { claimDispatchSync, fenceCheckSync } from "./cluster-claim-sync.mjs";
+import {
+  claimDispatchSync,
+  fenceCheckSync,
+  fenceCheckSyncCached,
+  clearFenceReadCache,
+} from "./cluster-claim-sync.mjs";
 
 describe("claimDispatchSync — argv + parsing", () => {
   it("builds the right argv: node <cli> claim <ticket> <host> <phase>", () => {
@@ -167,5 +172,109 @@ describe("fenceCheckSync — FAIL-CLOSED on every indeterminate failure", () => 
       current: false,
       stale: false,
     });
+  });
+});
+
+describe("fenceCheckSyncCached — in-process TTL cache around the fence read (CTL-863 fleet-unfreeze)", () => {
+  beforeEach(() => {
+    // The cache is module-scope (persists for the daemon process's lifetime by
+    // design) — reset it between cases so tests don't pollute each other via a
+    // shared ticket::generation key.
+    clearFenceReadCache();
+  });
+
+  it("(a) two reads within TTL for the same ticket+generation → ONE underlying spawn call", () => {
+    let calls = 0;
+    const spawn = () => {
+      calls += 1;
+      return { status: 0, stdout: '{"current":true}\n' };
+    };
+    let now = 1_000_000;
+    const first = fenceCheckSyncCached({ ticket: "CTL-1", generation: 5 }, { spawn, now: () => now });
+    now += 1_000; // 1s later — well within the 45s default TTL
+    const second = fenceCheckSyncCached({ ticket: "CTL-1", generation: 5 }, { spawn, now: () => now });
+    expect(first).toEqual({ current: true, stale: false });
+    expect(second).toEqual({ current: true, stale: false });
+    expect(calls).toBe(1); // second call served from cache, no spawn
+  });
+
+  it("(b) after TTL expiry → a fresh read (spawn called again)", () => {
+    let calls = 0;
+    const spawn = () => {
+      calls += 1;
+      return { status: 0, stdout: '{"current":true}\n' };
+    };
+    let now = 1_000_000;
+    fenceCheckSyncCached({ ticket: "CTL-2", generation: 3 }, { spawn, now: () => now, env: { CATALYST_FENCE_READ_CACHE_MS: "45000" } });
+    now += 45_001; // just past the 45s TTL
+    fenceCheckSyncCached({ ticket: "CTL-2", generation: 3 }, { spawn, now: () => now, env: { CATALYST_FENCE_READ_CACHE_MS: "45000" } });
+    expect(calls).toBe(2); // TTL expired → the second call re-spawned
+  });
+
+  it("(c) CATALYST_FENCE_READ_CACHE_MS=0 disables the cache — every read hits through", () => {
+    let calls = 0;
+    const spawn = () => {
+      calls += 1;
+      return { status: 0, stdout: '{"current":true}\n' };
+    };
+    const env = { CATALYST_FENCE_READ_CACHE_MS: "0" };
+    const now = () => 1_000_000; // frozen clock — proves it's the env flag, not elapsed time
+    fenceCheckSyncCached({ ticket: "CTL-3", generation: 1 }, { spawn, env, now });
+    fenceCheckSyncCached({ ticket: "CTL-3", generation: 1 }, { spawn, env, now });
+    fenceCheckSyncCached({ ticket: "CTL-3", generation: 1 }, { spawn, env, now });
+    expect(calls).toBe(3); // cache fully disabled — no memoization at all
+  });
+
+  it("(d) an indeterminate/error result is NEVER cached — the next call retries the real read", () => {
+    let calls = 0;
+    const spawn = () => {
+      calls += 1;
+      return { status: 1, stdout: "" }; // non-zero, non-FENCE_STALE_EXIT → indeterminate/error
+    };
+    const now = () => 1_000_000; // frozen clock — within TTL, so only caching (not expiry) explains a re-spawn
+    const first = fenceCheckSyncCached({ ticket: "CTL-4", generation: 2 }, { spawn, now });
+    const second = fenceCheckSyncCached({ ticket: "CTL-4", generation: 2 }, { spawn, now });
+    expect(first).toEqual({ current: false, stale: false });
+    expect(second).toEqual({ current: false, stale: false });
+    expect(calls).toBe(2); // NOT cached — both calls spawned
+  });
+
+  it("a confirmed-stale determinate result (current:false, stale:true) IS cached", () => {
+    let calls = 0;
+    const spawn = () => {
+      calls += 1;
+      return { status: 10, stdout: '{"current":false}\n' }; // FENCE_STALE_EXIT
+    };
+    const now = () => 1_000_000;
+    fenceCheckSyncCached({ ticket: "CTL-5", generation: 1 }, { spawn, now });
+    fenceCheckSyncCached({ ticket: "CTL-5", generation: 1 }, { spawn, now });
+    expect(calls).toBe(1); // confirmed-stale is a determinate answer — cached
+  });
+
+  it("different generations for the SAME ticket are NOT interchangeable — each gets its own read", () => {
+    const seen = [];
+    const spawn = (bin, args) => {
+      seen.push(args[3]); // the generation argv
+      return { status: 0, stdout: '{"current":true}\n' };
+    };
+    const now = () => 1_000_000;
+    fenceCheckSyncCached({ ticket: "CTL-6", generation: 1 }, { spawn, now });
+    fenceCheckSyncCached({ ticket: "CTL-6", generation: 2 }, { spawn, now });
+    expect(seen).toEqual(["1", "2"]); // both spawned — distinct cache keys
+  });
+
+  it("falls through to a real fenceCheckSync on a cache miss (argv unchanged)", () => {
+    let captured;
+    const spawn = (bin, args) => {
+      captured = { bin, args };
+      return { status: 0, stdout: '{"current":true}\n' };
+    };
+    const now = () => 1_000_000;
+    fenceCheckSyncCached(
+      { ticket: "CTL-7", generation: 4 },
+      { spawn, now, nodeBin: "/usr/bin/node", cli: "/x/cluster-claim.mjs" },
+    );
+    expect(captured.bin).toBe("/usr/bin/node");
+    expect(captured.args).toEqual(["/x/cluster-claim.mjs", "fence-check", "CTL-7", "4"]);
   });
 });

--- a/plugins/dev/scripts/execution-core/fence-guard.mjs
+++ b/plugins/dev/scripts/execution-core/fence-guard.mjs
@@ -4,16 +4,24 @@
 // (Linear/GitHub writes). On a ≥2-host cluster, a paused/partitioned zombie that
 // wakes up after another host took over should NOT be allowed to corrupt Linear
 // state. The guard reads this ticket's claimed generation from its signal file and
-// asks fenceCheckSync if we're still the current owner. FAIL-CLOSED: any failure
-// (missing signal, spawn error, stale gen) returns false → suppress the write.
+// asks fenceCheckSyncCached if we're still the current owner. FAIL-CLOSED: any
+// failure (missing signal, spawn error, stale gen) returns false → suppress the write.
 //
 // SINGLE-HOST is a guaranteed no-op: multiHost:false → return true without calling
 // check. This is the common case (most installs are single-host), so the guard
 // adds zero cost in the steady state.
+//
+// fenceCheckSyncCached (not the raw fenceCheckSync) is the default `check` — an
+// in-process TTL cache (default 45s, CATALYST_FENCE_READ_CACHE_MS) around the
+// underlying `query ReadFence` read, added as an URGENT interim fix: on a
+// multi-host cluster this guard's own read volume (~5,000/hr across all sites)
+// was saturating the shared Linear app-actor bucket and freezing dispatch via
+// the CTL-679 breaker. See cluster-claim-sync.mjs for the full rationale; the
+// cache changes read volume only, never fenceGuard's fail-closed decision.
 
 import { readdirSync, readFileSync } from "node:fs";
 import { join } from "node:path";
-import { fenceCheckSync } from "./cluster-claim-sync.mjs";
+import { fenceCheckSyncCached } from "./cluster-claim-sync.mjs";
 
 // readSignalGeneration — read `generation` from the active phase signal file for
 // a ticket. Scans workers/<ticket>/phase-*.json, preferring running > newest.
@@ -61,7 +69,7 @@ export function fenceGuard(
   { ticket, orchDir, multiHost },
   {
     readGen = () => readSignalGeneration(orchDir, ticket),
-    check = fenceCheckSync,
+    check = fenceCheckSyncCached,
   } = {},
 ) {
   if (!multiHost) return true; // single-host: always the fence owner


### PR DESCRIPTION
## Summary

- The CTL-863 fence guards (`fenceGuard`, called before every daemon-side external-write site — ~11 sites across `scheduler.mjs`, `recovery.mjs`, `stale-pr-rescue-timer.mjs`) hit Linear's `query ReadFence` (an attachment read on the ticket's issue) before each write. Live-proxy-confirmed at **~5,000/hr — 62% of ALL Linear traffic** on the shared app-actor bucket, saturating it and tripping the **CTL-679 rate-limit breaker open**, which **freezes fleet dispatch entirely** (zero dispatches for hours).
- Adds `fenceCheckSyncCached` in `cluster-claim-sync.mjs`: an **in-process TTL cache** (default **45s**, override via `CATALYST_FENCE_READ_CACHE_MS`, `0` disables) keyed by `` `${ticket}::${generation}` `` — wired in as `fence-guard.mjs`'s default `check`. The underlying fence only changes on the ~**2min heartbeat cadence** (`cluster-heartbeat.mjs`), so a 45s cache can never observe a staler fence than genuinely exists at write time — safe by construction, not a race.
- Only a **determinate** read is cached (`current:true`, or a confirmed-stale `current:false,stale:true`). The **indeterminate/error** bucket (spawn error, timeout, other exit) is **never cached** — `fenceGuard` is fail-closed on it, so caching a transient hiccup would extend a false "not current" (write-suppressing) verdict for the full TTL instead of retrying on the very next call.
- `fenceGuard`'s decision logic and fail-closed semantics are **untouched** — this only reduces read volume, never changes what a check means. The `UpsertFence` write path is untouched (read-only caching).
- **This is the INTERIM unfreeze.** The durable fix replaces the read-per-check fence with an event-log-derived one: `thoughts/shared/plans/2026-07-03-fence-to-eventlog.md`.

**Expected effect**: CTL-679 breaker-opens → 0, dispatch resumes fleet-wide.

## Files changed

- `plugins/dev/scripts/execution-core/cluster-claim-sync.mjs` — new `fenceCheckSyncCached` + `clearFenceReadCache` (test seam), wrapping the existing (unchanged) `fenceCheckSync`.
- `plugins/dev/scripts/execution-core/fence-guard.mjs` — default `check` seam switched from `fenceCheckSync` to `fenceCheckSyncCached`; doc comment updated.
- `plugins/dev/scripts/execution-core/cluster-claim-sync.test.mjs` — new test coverage for the cache: TTL hit/miss, TTL expiry, env-disable, error-not-cached, generation-scoped keys, and argv passthrough on a cache miss.

## Test plan

- [x] `env -u CLAUDE_CODE_OAUTH_TOKEN -u ANTHROPIC_API_KEY -u LINEAR_API_TOKEN bun test cluster-claim-sync.test.mjs fence-guard.test.mjs fence-guard-integration.test.mjs cluster-claim.test.mjs` → **77 pass / 0 fail**
- [x] `node --check` on all three changed source files
- [x] Confirmed the 11 pre-existing failures in `scheduler.test.mjs`/`recovery.test.mjs`/`stale-pr-rescue-timer.test.mjs` are unchanged before/after this diff (824 pass / 11 fail both on `main` and on this branch) — this change introduces zero regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)