### PR TITLE
fix(dev): CTL-863 — cache the fence entourage (ResolveIssueId anchor-UUID + GetIssueByIdentifier) to fully clear the shared bucket

### DIFF
--- a/plugins/dev/scripts/execution-core/cluster-claim-sync.mjs
+++ b/plugins/dev/scripts/execution-core/cluster-claim-sync.mjs
@@ -36,12 +36,49 @@ const CLAIM_TIMEOUT_MS = Number(process.env.EXECUTION_CORE_CLAIM_TIMEOUT_MS) || 
 // via the env passthrough at the spawn call below. When set, overrides the
 // 300_000 ms (5 min) default stale-claim preemption threshold (CTL-1297).
 
-// claimDispatchSync — soft-CAS claim `ticket` for `hostName` at `phase`,
-// synchronously. Returns { won, generation }. won:false on any failure
-// (fail-closed). `spawn`/`nodeBin`/`cli`/`env`/`timeout` are injectable so the
-// unit tests never spawn a real process.
-export function claimDispatchSync(
-  { ticket, hostName, phase },
+// ─── permanent in-process cache: ticket identifier → issue UUID (CTL-863 fleet-unfreeze, entourage follow-up to #2552) ──
+//
+// #2552 cached the ReadFence read (82% of the fence traffic) below via
+// fenceCheckSyncCached, but left the "entourage" queries uncached: every claim
+// resolves the ticket's identifier → UUID via `query ResolveIssueId` inside writeClaim,
+// even though a ticket's issue UUID can never change once Linear assigns it. Unlike the
+// ReadFence read (a TTL cache, because the underlying claim/fence state genuinely
+// changes on a cadence), this is safe to cache PERMANENTLY — there is no staleness
+// window to reason about.
+//
+// resolveIssueId is bundled inside the `claim` CLI subcommand (one subprocess call does
+// read + resolve + write + read-back), so caching it here means: pre-resolve the UUID
+// via the small standalone `resolve-issue-id` subcommand (cached after the first
+// success), then pass the resolved UUID into `claim` so ITS internal resolveIssueId call
+// is skipped. A cache miss/disable falls back to the pre-follow-up behavior byte-for-byte
+// (claim resolves the ticket itself). Deliberately NOT applied to the CAS reads
+// (readClaim, inside claimTicket) — those are the actual fencing correctness check, not
+// an immutable mapping, so caching them would risk a false win/lose (see claimTicket's
+// own doc comment).
+//
+// CATALYST_ANCHOR_UUID_CACHE — shared with cluster-heartbeat-sync.mjs's identical anchor
+// cache (same env name, same semantics: one operator knob for "cache identifier→UUID
+// resolution permanently" across both entourage call sites). "0" disables; any other
+// value (including unset) keeps it on.
+const issueIdCache = new Map();
+
+// clearIssueIdCache — test-only reset of the module-scope cache between cases.
+export function clearIssueIdCache() {
+  issueIdCache.clear();
+}
+
+function issueIdCacheEnabled(env) {
+  return env?.CATALYST_ANCHOR_UUID_CACHE !== "0";
+}
+
+// resolveIssueIdSync — spawn `node cluster-claim.mjs resolve-issue-id <ticket>` and
+// return the resolved UUID, or null on ANY failure (spawn error, timeout, non-zero exit,
+// unparseable stdout, or a resolution miss) — fail-open: the caller treats null as
+// "could not pre-resolve" and falls back to letting `claim` resolve it inline, exactly as
+// before this follow-up. `spawn`/`nodeBin`/`cli`/`env`/`timeout` are injectable so unit
+// tests never spawn a real process.
+export function resolveIssueIdSync(
+  { ticket },
   {
     spawn = spawnSync,
     nodeBin = process.execPath,
@@ -51,7 +88,61 @@ export function claimDispatchSync(
   } = {},
 ) {
   try {
-    const res = spawn(nodeBin, [cli, "claim", ticket, hostName, phase], {
+    const res = spawn(nodeBin, [cli, "resolve-issue-id", ticket], {
+      encoding: "utf8",
+      env,
+      timeout,
+    });
+    if (!res || res.status !== 0 || typeof res.stdout !== "string") return null;
+    const line = res.stdout.trim().split("\n").filter(Boolean).pop();
+    const parsed = JSON.parse(line);
+    return typeof parsed?.issueId === "string" && parsed.issueId.length > 0 ? parsed.issueId : null;
+  } catch {
+    return null;
+  }
+}
+
+// resolveIssueIdSyncCached — the cached entry point. A hit returns immediately with
+// ZERO subprocess spawn. A miss spawns resolveIssueIdSync and caches ONLY a truthy
+// (successfully resolved) UUID — a null (any failure) is never cached, so the very next
+// call retries for real instead of latching a transient hiccup forever. `env` is the
+// test seam gating the cache; every other option passes straight through to
+// resolveIssueIdSync on a miss.
+export function resolveIssueIdSyncCached({ ticket }, { env = process.env, ...rest } = {}) {
+  if (!issueIdCacheEnabled(env)) {
+    return resolveIssueIdSync({ ticket }, { env, ...rest });
+  }
+  const cached = issueIdCache.get(ticket);
+  if (cached) return cached;
+  const issueId = resolveIssueIdSync({ ticket }, { env, ...rest });
+  if (issueId) issueIdCache.set(ticket, issueId);
+  return issueId;
+}
+
+// claimDispatchSync — soft-CAS claim `ticket` for `hostName` at `phase`,
+// synchronously. Returns { won, generation }. won:false on any failure
+// (fail-closed). `spawn`/`nodeBin`/`cli`/`env`/`timeout` are injectable so the
+// unit tests never spawn a real process.
+// CTL-863 follow-up: `resolveIssueId` is the injectable pre-resolve seam (defaults to
+// resolveIssueIdSyncCached) — a resolved UUID is threaded into the `claim` argv so that
+// subprocess skips its own ResolveIssueId call. A null (miss/disabled+failed) falls back
+// to the pre-follow-up 3-arg form untouched.
+export function claimDispatchSync(
+  { ticket, hostName, phase },
+  {
+    spawn = spawnSync,
+    nodeBin = process.execPath,
+    cli = CLUSTER_CLAIM_CLI,
+    env = process.env,
+    timeout = CLAIM_TIMEOUT_MS,
+    resolveIssueId = resolveIssueIdSyncCached,
+  } = {},
+) {
+  try {
+    const issueId = resolveIssueId({ ticket }, { spawn, nodeBin, cli, env, timeout });
+    const args = [cli, "claim", ticket, hostName, phase];
+    if (issueId) args.push(issueId);
+    const res = spawn(nodeBin, args, {
       encoding: "utf8",
       env,
       timeout,

--- a/plugins/dev/scripts/execution-core/cluster-claim-sync.test.mjs
+++ b/plugins/dev/scripts/execution-core/cluster-claim-sync.test.mjs
@@ -9,6 +9,9 @@ import {
   fenceCheckSync,
   fenceCheckSyncCached,
   clearFenceReadCache,
+  resolveIssueIdSync,
+  resolveIssueIdSyncCached,
+  clearIssueIdCache,
 } from "./cluster-claim-sync.mjs";
 
 describe("claimDispatchSync — argv + parsing", () => {
@@ -276,5 +279,145 @@ describe("fenceCheckSyncCached — in-process TTL cache around the fence read (C
     );
     expect(captured.bin).toBe("/usr/bin/node");
     expect(captured.args).toEqual(["/x/cluster-claim.mjs", "fence-check", "CTL-7", "4"]);
+  });
+});
+
+describe("resolveIssueIdSync — argv + parsing (CTL-863 entourage follow-up)", () => {
+  it("builds the right argv: node <cli> resolve-issue-id <ticket>", () => {
+    let captured;
+    const spawn = (bin, args) => {
+      captured = { bin, args };
+      return { status: 0, stdout: '{"issueId":"uuid-CTL-9"}\n' };
+    };
+    resolveIssueIdSync(
+      { ticket: "CTL-9" },
+      { spawn, nodeBin: "/usr/bin/node", cli: "/x/cluster-claim.mjs" },
+    );
+    expect(captured.bin).toBe("/usr/bin/node");
+    expect(captured.args).toEqual(["/x/cluster-claim.mjs", "resolve-issue-id", "CTL-9"]);
+  });
+
+  it("parses the resolved UUID from stdout", () => {
+    const spawn = () => ({ status: 0, stdout: '{"issueId":"uuid-CTL-9"}\n' });
+    expect(resolveIssueIdSync({ ticket: "CTL-9" }, { spawn })).toBe("uuid-CTL-9");
+  });
+
+  it("a null issueId (missing ticket) → null", () => {
+    const spawn = () => ({ status: 0, stdout: '{"issueId":null}\n' });
+    expect(resolveIssueIdSync({ ticket: "CTL-9" }, { spawn })).toBeNull();
+  });
+
+  it("non-zero exit / spawn error / unparseable stdout / throw → null (fail-open)", () => {
+    expect(resolveIssueIdSync({ ticket: "CTL-9" }, { spawn: () => ({ status: 1, stdout: "" }) })).toBeNull();
+    expect(
+      resolveIssueIdSync({ ticket: "CTL-9" }, { spawn: () => ({ status: null, error: new Error("ETIMEDOUT") }) }),
+    ).toBeNull();
+    expect(resolveIssueIdSync({ ticket: "CTL-9" }, { spawn: () => ({ status: 0, stdout: "not json" }) })).toBeNull();
+    expect(
+      resolveIssueIdSync({ ticket: "CTL-9" }, { spawn: () => { throw new Error("EACCES"); } }),
+    ).toBeNull();
+  });
+});
+
+describe("resolveIssueIdSyncCached — permanent identifier→UUID cache (CTL-863 entourage follow-up)", () => {
+  beforeEach(() => {
+    clearIssueIdCache();
+  });
+
+  it("(a) two resolves of the same ticket → ONE underlying spawn call", () => {
+    let calls = 0;
+    const spawn = () => {
+      calls += 1;
+      return { status: 0, stdout: '{"issueId":"uuid-CTL-1"}\n' };
+    };
+    const first = resolveIssueIdSyncCached({ ticket: "CTL-1" }, { spawn });
+    const second = resolveIssueIdSyncCached({ ticket: "CTL-1" }, { spawn });
+    expect(first).toBe("uuid-CTL-1");
+    expect(second).toBe("uuid-CTL-1");
+    expect(calls).toBe(1); // second call served from the permanent cache, no spawn
+  });
+
+  it("persists beyond any TTL window — no expiry, ever (permanent cache)", () => {
+    let calls = 0;
+    const spawn = () => {
+      calls += 1;
+      return { status: 0, stdout: '{"issueId":"uuid-CTL-2"}\n' };
+    };
+    let now = 1_000_000;
+    resolveIssueIdSyncCached({ ticket: "CTL-2" }, { spawn, now: () => now });
+    now += 10 * 24 * 60 * 60 * 1000; // 10 days later — far past any TTL a read cache would use
+    resolveIssueIdSyncCached({ ticket: "CTL-2" }, { spawn, now: () => now });
+    expect(calls).toBe(1); // still cached — this cache has no TTL at all
+  });
+
+  it("CATALYST_ANCHOR_UUID_CACHE=0 disables the cache — every resolve hits through", () => {
+    let calls = 0;
+    const spawn = () => {
+      calls += 1;
+      return { status: 0, stdout: '{"issueId":"uuid-CTL-3"}\n' };
+    };
+    const env = { CATALYST_ANCHOR_UUID_CACHE: "0" };
+    resolveIssueIdSyncCached({ ticket: "CTL-3" }, { spawn, env });
+    resolveIssueIdSyncCached({ ticket: "CTL-3" }, { spawn, env });
+    expect(calls).toBe(2); // cache fully disabled — no memoization at all
+  });
+
+  it("a failed/null resolution is NEVER cached — the next call retries for real", () => {
+    let calls = 0;
+    const spawn = () => {
+      calls += 1;
+      return { status: 1, stdout: "" }; // non-zero exit → resolution failure
+    };
+    const first = resolveIssueIdSyncCached({ ticket: "CTL-4" }, { spawn });
+    const second = resolveIssueIdSyncCached({ ticket: "CTL-4" }, { spawn });
+    expect(first).toBeNull();
+    expect(second).toBeNull();
+    expect(calls).toBe(2); // NOT cached — both calls spawned
+  });
+
+  it("different tickets are NOT interchangeable — each gets its own resolve + cache slot", () => {
+    const seen = [];
+    const spawn = (bin, args) => {
+      seen.push(args[2]); // the ticket argv
+      return { status: 0, stdout: JSON.stringify({ issueId: `uuid-${args[2]}` }) + "\n" };
+    };
+    expect(resolveIssueIdSyncCached({ ticket: "CTL-5" }, { spawn })).toBe("uuid-CTL-5");
+    expect(resolveIssueIdSyncCached({ ticket: "CTL-6" }, { spawn })).toBe("uuid-CTL-6");
+    expect(seen).toEqual(["CTL-5", "CTL-6"]); // both spawned — distinct cache keys
+  });
+});
+
+describe("claimDispatchSync — pre-resolved issueId is threaded into the claim argv (CTL-863 entourage follow-up)", () => {
+  beforeEach(() => {
+    clearIssueIdCache();
+  });
+
+  it("a successful pre-resolve appends the UUID as the claim CLI's 4th arg", () => {
+    let claimArgs;
+    const spawn = (bin, args) => {
+      if (args[1] === "resolve-issue-id") {
+        return { status: 0, stdout: '{"issueId":"uuid-CTL-9"}\n' };
+      }
+      claimArgs = args;
+      return { status: 0, stdout: JSON.stringify({ won: true, generation: 1 }) + "\n" };
+    };
+    claimDispatchSync({ ticket: "CTL-9", hostName: "mini", phase: "triage" }, { spawn });
+    expect(claimArgs[claimArgs.length - 1]).toBe("uuid-CTL-9");
+  });
+
+  it("a failed pre-resolve falls back to the plain 3-arg claim form (unchanged behavior)", () => {
+    let claimArgs;
+    const spawn = (bin, args) => {
+      if (args[1] === "resolve-issue-id") {
+        return { status: 1, stdout: "" }; // resolution fails
+      }
+      claimArgs = args;
+      return { status: 0, stdout: JSON.stringify({ won: true, generation: 1 }) + "\n" };
+    };
+    claimDispatchSync(
+      { ticket: "CTL-9", hostName: "mini", phase: "triage" },
+      { spawn, nodeBin: "/usr/bin/node", cli: "/x/cluster-claim.mjs" },
+    );
+    expect(claimArgs).toEqual(["/x/cluster-claim.mjs", "claim", "CTL-9", "mini", "triage"]);
   });
 });

--- a/plugins/dev/scripts/execution-core/cluster-claim.mjs
+++ b/plugins/dev/scripts/execution-core/cluster-claim.mjs
@@ -175,8 +175,19 @@ const WRITE_ATTACHMENT_MUTATION = `mutation UpsertFence($input: AttachmentCreate
 // metadata is written with the VERIFIED key names: owner_host,
 // catalyst_generation, phase, claimed_at. catalyst_generation is a Number on the
 // wire; Linear's metadata JSON round-trips it.
-export async function writeClaim(ticket, { owner_host, generation, phase }, { post = defaultPost } = {}) {
-  const issueId = await resolveIssueId(ticket, { post });
+//
+// CTL-863 fleet-unfreeze (entourage, follow-up to #2552): `issueId` is an OPTIONAL
+// pre-resolved UUID override. A ticket's issue UUID never changes once assigned, so
+// cluster-claim-sync.mjs's permanent resolveIssueIdSyncCached resolves it ONCE and
+// passes it here on every subsequent claim — skipping this call's own `query
+// ResolveIssueId` round-trip. A falsy override (cache miss/disabled) falls through to
+// the original resolveIssueId(ticket) call, so behavior is unchanged when omitted.
+export async function writeClaim(
+  ticket,
+  { owner_host, generation, phase },
+  { post = defaultPost, issueId: issueIdOverride = null } = {},
+) {
+  const issueId = issueIdOverride || (await resolveIssueId(ticket, { post }));
   if (!issueId) {
     throw new Error(`cluster-claim: no issue found for identifier ${ticket}`);
   }
@@ -216,11 +227,16 @@ export async function writeClaim(ticket, { owner_host, generation, phase }, { po
 // and PR-order-independent; the caller threads in catalyst.host.name).
 // Returns { won, generation } where generation is the gen we attempted to claim.
 // staleMs and now are injectable seams for unit testing (no Date.now() in tests).
+// CTL-863 fleet-unfreeze (entourage): `issueId` is an OPTIONAL pre-resolved UUID
+// override, threaded straight through to both writeClaim call sites below (see
+// writeClaim's own doc comment) — NOT applied to the readClaim CAS reads above/below,
+// which must stay live: they are the actual fencing correctness check, not an
+// immutable identifier→UUID mapping, so caching them would risk a false win/lose.
 export async function claimTicket(
   ticket,
   hostName,
   phase,
-  { post = defaultPost, staleMs = CLAIM_STALE_MS_DEFAULT, now = () => Date.now() } = {},
+  { post = defaultPost, staleMs = CLAIM_STALE_MS_DEFAULT, now = () => Date.now(), issueId = null } = {},
 ) {
   const current = await readClaim(ticket, { post });
   const nextGen = (current?.generation ?? 0) + 1;
@@ -234,14 +250,14 @@ export async function claimTicket(
   if (current && current.owner_host && current.owner_host !== hostName) {
     const claimedAtMs = current.claimed_at ? Date.parse(current.claimed_at) : NaN;
     if (Number.isFinite(claimedAtMs) && now() - claimedAtMs > staleMs) {
-      await writeClaim(ticket, { owner_host: hostName, generation: nextGen, phase }, { post });
+      await writeClaim(ticket, { owner_host: hostName, generation: nextGen, phase }, { post, issueId });
       return { won: true, generation: nextGen };
     }
   }
 
   // Normal soft-CAS (unchanged): write then read-back; a concurrent host that
   // wrote last wins the read-back and we back off.
-  await writeClaim(ticket, { owner_host: hostName, generation: nextGen, phase }, { post });
+  await writeClaim(ticket, { owner_host: hostName, generation: nextGen, phase }, { post, issueId });
   const readback = await readClaim(ticket, { post });
   const won = readback?.owner_host === hostName && readback?.generation === nextGen;
   return { won, generation: nextGen };
@@ -270,21 +286,30 @@ export async function isFenceCurrent(ticket, generation, { post = defaultPost } 
 // runCli is exported (with an injectable `post`) so the CLI surface is unit
 // tested without the network; the main-guard below calls it with the real post.
 //
-//   claim <ticket> <host> <phase>  → stdout JSON {won, generation}; exit 0 iff
+//   claim <ticket> <host> <phase> [issueId]  → stdout JSON {won, generation}; exit 0 iff
 //                                    the soft-CAS ran (read `won` from stdout —
 //                                    a non-zero exit means the operation threw,
-//                                    which the wrapper treats as won:false).
+//                                    which the wrapper treats as won:false). The
+//                                    optional 4th arg is a pre-resolved ticket UUID
+//                                    (CTL-863 follow-up — see claimTicket/writeClaim).
 //   fence-check <ticket> <gen>     → stdout JSON {current}; exit 0 when current,
 //                                    FENCE_STALE_EXIT (10) when stale — mirrors
 //                                    claim.mjs's host-local fence-check contract.
+//   resolve-issue-id <ticket>      → stdout JSON {issueId}; exit 0. Standalone
+//                                    identifier→UUID resolution (CTL-863 follow-up)
+//                                    so cluster-claim-sync.mjs's permanent cache can
+//                                    populate itself with one small subprocess call
+//                                    instead of the resolution being buried inside
+//                                    every `claim`.
 const FENCE_STALE_EXIT = 10;
 
 export async function runCli(argv, { post = defaultPost } = {}) {
   const [cmd, ...rest] = argv;
   switch (cmd) {
     case "claim": {
-      const [ticket, hostName, phase] = rest;
-      const res = await claimTicket(ticket, hostName, phase, { post });
+      const [ticket, hostName, phase, issueIdRaw] = rest;
+      const issueId = issueIdRaw != null && issueIdRaw !== "" ? issueIdRaw : null;
+      const res = await claimTicket(ticket, hostName, phase, { post, issueId });
       process.stdout.write(JSON.stringify(res) + "\n");
       return 0;
     }
@@ -294,10 +319,16 @@ export async function runCli(argv, { post = defaultPost } = {}) {
       process.stdout.write(JSON.stringify({ current }) + "\n");
       return current ? 0 : FENCE_STALE_EXIT;
     }
+    case "resolve-issue-id": {
+      const [ticket] = rest;
+      const issueId = await resolveIssueId(ticket, { post });
+      process.stdout.write(JSON.stringify({ issueId }) + "\n");
+      return 0;
+    }
     default:
       process.stderr.write(
         `cluster-claim.mjs: unknown subcommand: ${cmd ?? "(none)"}\n` +
-          "usage: cluster-claim.mjs <claim <ticket> <host> <phase> | fence-check <ticket> <gen>>\n",
+          "usage: cluster-claim.mjs <claim <ticket> <host> <phase> [issueId] | fence-check <ticket> <gen> | resolve-issue-id <ticket>>\n",
       );
       return 1;
   }

--- a/plugins/dev/scripts/execution-core/cluster-claim.test.mjs
+++ b/plugins/dev/scripts/execution-core/cluster-claim.test.mjs
@@ -235,6 +235,28 @@ describe("writeClaim — upsert the attachment", () => {
     }
     expect(err?.message).toMatch(/no issue found/);
   });
+
+  // CTL-863 fleet-unfreeze (entourage follow-up to #2552): a pre-resolved issueId
+  // override skips the ResolveIssueId round-trip entirely.
+  it("an issueId override SKIPS resolveIssueId — only UpsertFence is called", async () => {
+    const { post, store, calls } = makeFakeLinear();
+    const written = await writeClaim(
+      "CTL-842",
+      { owner_host: "mini", generation: 1, phase: "triage" },
+      { post, issueId: "uuid-CTL-842" },
+    );
+    expect(written.owner_host).toBe("mini");
+    expect(calls.length).toBe(1); // ONLY the UpsertFence write — no ResolveIssueId call
+    expect(calls[0].query).toContain("UpsertFence");
+    expect(store.get("CTL-842").owner_host).toBe("mini");
+  });
+
+  it("no issueId override → falls through to resolveIssueId unchanged", async () => {
+    const { post, calls } = makeFakeLinear();
+    await writeClaim("CTL-842", { owner_host: "mini", generation: 1, phase: "triage" }, { post, issueId: null });
+    expect(calls[0].query).toContain("ResolveIssueId");
+    expect(calls[1].query).toContain("UpsertFence");
+  });
 });
 
 describe("claimTicket — soft-CAS via read-back", () => {
@@ -514,6 +536,35 @@ describe("runCli — the spawnSync CLI surface (CTL-850)", () => {
     const { post } = makeFakeLinear();
     const { code } = await captureStdout(() => runCli(["bogus"], { post }));
     expect(code).toBe(1);
+  });
+
+  // CTL-863 fleet-unfreeze (entourage follow-up to #2552).
+  it("resolve-issue-id: prints {issueId} and exits 0", async () => {
+    const { post } = makeFakeLinear();
+    const { code, out } = await captureStdout(() =>
+      runCli(["resolve-issue-id", "CTL-842"], { post }),
+    );
+    expect(code).toBe(0);
+    expect(JSON.parse(out)).toEqual({ issueId: "uuid-CTL-842" });
+  });
+
+  it("resolve-issue-id: {issueId:null} on a missing ticket", async () => {
+    const { post } = makeFakeLinear({ missingIssues: new Set(["CTL-999"]) });
+    const { code, out } = await captureStdout(() =>
+      runCli(["resolve-issue-id", "CTL-999"], { post }),
+    );
+    expect(code).toBe(0);
+    expect(JSON.parse(out)).toEqual({ issueId: null });
+  });
+
+  it("claim: an optional 4th issueId arg skips ResolveIssueId (only ReadFence/UpsertFence calls)", async () => {
+    const { post, calls } = makeFakeLinear();
+    const { code, out } = await captureStdout(() =>
+      runCli(["claim", "CTL-842", "mini", "triage", "uuid-CTL-842"], { post }),
+    );
+    expect(code).toBe(0);
+    expect(JSON.parse(out)).toEqual({ won: true, generation: 1 });
+    expect(calls.some((c) => c.query.includes("ResolveIssueId"))).toBe(false);
   });
 
   it("claim: preempts a stale cross-host claim via the default threshold (CTL-1297)", async () => {

--- a/plugins/dev/scripts/execution-core/cluster-heartbeat-sync.mjs
+++ b/plugins/dev/scripts/execution-core/cluster-heartbeat-sync.mjs
@@ -29,16 +29,47 @@ const CLUSTER_HEARTBEAT_CLI = fileURLToPath(
 const LIVENESS_TIMEOUT_MS =
   Number(process.env.EXECUTION_CORE_LIVENESS_TIMEOUT_MS) || 15_000;
 
-// publishHeartbeatSync — publish this host's liveness record synchronously.
-// Returns { ok: true } on success, { ok: false, error } on any failure (fail-open).
-// CTL-1251: the failure path now carries a short `error` reason (exit code +
-// stderr tail / spawn error / timeout / unparseable) so the publisher tick can
-// LOG why a publish failed — previously every failure was a silent { ok: false }
-// and a post-restart non-publish was undiagnosable. Callers must still treat any
-// non-ok as fail-open and never throw.
-// `spawn`/`nodeBin`/`cli`/`env`/`timeout` are injectable for unit tests.
-export function publishHeartbeatSync(
-  { anchorIssue, host, inFlightTickets = [], maxParallel = null },
+// ─── permanent in-process cache: anchor identifier → issue UUID (CTL-863 fleet-unfreeze, entourage follow-up to #2552) ──
+//
+// #2552 cached the ReadFence read (82% of the fence traffic) in cluster-claim-sync.mjs
+// via fenceCheckSyncCached, but left the "entourage" queries uncached: every heartbeat
+// publish resolves the anchor issue's identifier → UUID via `query ResolveIssueId`, even
+// though the SAME anchor identifier is resolved on EVERY ~2min publish tick from EVERY
+// host in the cluster (LIVENESS_PUBLISH_INTERVAL_MS) — and that UUID can never change for
+// a given identifier once Linear assigns it. So unlike the ReadFence read (a TTL cache,
+// because the underlying claim/fence state genuinely changes on a cadence), this is safe
+// to cache PERMANENTLY — there is no staleness window to reason about at all.
+//
+// resolveIssueId is itself bundled inside the `publish` CLI subcommand (a single
+// subprocess call must still do both the resolve AND the attachmentCreate write), so
+// caching it in-process here means: pre-resolve the UUID via the small standalone
+// `resolve-anchor` subcommand (ONE tiny subprocess call, cached after the first success),
+// then pass the resolved UUID into `publish` so ITS internal resolveIssueId call is
+// skipped. A cache miss/disable falls back to the pre-follow-up behavior byte-for-byte
+// (publish resolves the anchor itself).
+//
+// CATALYST_ANCHOR_UUID_CACHE — "0" disables (every call re-resolves); any other value
+// (including unset) keeps the cache on. There is no TTL knob — the whole point is that
+// this mapping never goes stale.
+const anchorUuidCache = new Map();
+
+// clearAnchorUuidCache — test-only reset of the module-scope cache between cases.
+export function clearAnchorUuidCache() {
+  anchorUuidCache.clear();
+}
+
+function anchorUuidCacheEnabled(env) {
+  return env?.CATALYST_ANCHOR_UUID_CACHE !== "0";
+}
+
+// resolveAnchorIssueIdSync — spawn `node cluster-heartbeat.mjs resolve-anchor <anchor>`
+// and return the resolved UUID, or null on ANY failure (spawn error, timeout, non-zero
+// exit, unparseable stdout, or a resolution miss) — fail-open: the caller treats null as
+// "could not pre-resolve" and falls back to letting `publish` resolve it inline, exactly
+// as before this follow-up. `spawn`/`nodeBin`/`cli`/`env`/`timeout` are injectable so unit
+// tests never spawn a real process.
+export function resolveAnchorIssueIdSync(
+  { anchorIssue },
   {
     spawn = spawnSync,
     nodeBin = process.execPath,
@@ -48,12 +79,76 @@ export function publishHeartbeatSync(
   } = {},
 ) {
   try {
+    const res = spawn(nodeBin, [cli, "resolve-anchor", anchorIssue], {
+      encoding: "utf8",
+      env,
+      timeout,
+    });
+    if (!res || res.status !== 0 || typeof res.stdout !== "string") return null;
+    const line = res.stdout.trim().split("\n").filter(Boolean).pop();
+    const parsed = JSON.parse(line);
+    return typeof parsed?.issueId === "string" && parsed.issueId.length > 0 ? parsed.issueId : null;
+  } catch {
+    return null;
+  }
+}
+
+// resolveAnchorIssueIdSyncCached — the cached entry point. Checks the permanent Map
+// first; a hit returns immediately with ZERO subprocess spawn. A miss spawns
+// resolveAnchorIssueIdSync and caches ONLY a truthy (successfully resolved) UUID — a
+// null (any failure) is never cached, so the very next call retries for real instead of
+// latching a transient hiccup forever. `now`/`env` are the test seams (mirroring
+// fenceCheckSyncCached in cluster-claim-sync.mjs); every other option passes straight
+// through to resolveAnchorIssueIdSync on a miss.
+export function resolveAnchorIssueIdSyncCached({ anchorIssue }, { env = process.env, ...rest } = {}) {
+  if (!anchorUuidCacheEnabled(env)) {
+    return resolveAnchorIssueIdSync({ anchorIssue }, { env, ...rest });
+  }
+  const cached = anchorUuidCache.get(anchorIssue);
+  if (cached) return cached;
+  const issueId = resolveAnchorIssueIdSync({ anchorIssue }, { env, ...rest });
+  if (issueId) anchorUuidCache.set(anchorIssue, issueId);
+  return issueId;
+}
+
+// publishHeartbeatSync — publish this host's liveness record synchronously.
+// Returns { ok: true } on success, { ok: false, error } on any failure (fail-open).
+// CTL-1251: the failure path now carries a short `error` reason (exit code +
+// stderr tail / spawn error / timeout / unparseable) so the publisher tick can
+// LOG why a publish failed — previously every failure was a silent { ok: false }
+// and a post-restart non-publish was undiagnosable. Callers must still treat any
+// non-ok as fail-open and never throw.
+// `spawn`/`nodeBin`/`cli`/`env`/`timeout` are injectable for unit tests.
+// CTL-863 follow-up: `resolveIssueId` is the injectable pre-resolve seam (defaults to
+// resolveAnchorIssueIdSyncCached) — a resolved UUID is threaded into the `publish` argv
+// so that subprocess skips its own ResolveIssueId call. A null (cache miss that also
+// failed to resolve, or the cache disabled AND the resolve failing) falls back to the
+// pre-follow-up 4-arg form untouched.
+export function publishHeartbeatSync(
+  { anchorIssue, host, inFlightTickets = [], maxParallel = null },
+  {
+    spawn = spawnSync,
+    nodeBin = process.execPath,
+    cli = CLUSTER_HEARTBEAT_CLI,
+    env = process.env,
+    timeout = LIVENESS_TIMEOUT_MS,
+    resolveIssueId = resolveAnchorIssueIdSyncCached,
+  } = {},
+) {
+  try {
     const ticketsCsv = inFlightTickets.join(",");
+    const issueId = resolveIssueId({ anchorIssue }, { spawn, nodeBin, cli, env, timeout });
     // CTL-1092: append max_parallel as a 4th arg ONLY when it resolves to a
     // positive int. A host that can't resolve its slot count still publishes
     // liveness via the back-compat 3-arg form (the CLI reads it as null).
     const argv = [cli, "publish", anchorIssue, host, ticketsCsv];
-    if (Number.isInteger(maxParallel) && maxParallel > 0) argv.push(String(maxParallel));
+    if (Number.isInteger(maxParallel) && maxParallel > 0) {
+      argv.push(String(maxParallel));
+    } else if (issueId) {
+      // Keep the positional 5th slot for issueId even with no maxParallel to report.
+      argv.push("");
+    }
+    if (issueId) argv.push(issueId);
     const res = spawn(nodeBin, argv, {
       encoding: "utf8",
       env,
@@ -113,4 +208,71 @@ export function readPeerHeartbeatsSync(
   } catch {
     return {};
   }
+}
+
+// ─── 45s TTL cache: peer-heartbeat read (CTL-863 fleet-unfreeze, entourage follow-up to #2552) ──
+//
+// readPeerHeartbeatsSync's `read` subcommand issues the SAME anchor-issue lookup
+// (fetch the issue by identifier + its attachments) as the fence's ReadFence read that
+// fenceCheckSyncCached already caches in cluster-claim-sync.mjs — just against the
+// heartbeat anchor instead of a per-ticket fence, and via a completely separate
+// subprocess/cache scope (this file never imports cluster-claim-sync.mjs, matching the
+// existing PR-order-independent, no-cross-module-import convention the two cluster-*
+// modules already follow). recovery.mjs's dead-host detection (readClusterHeartbeats,
+// defaultOwnedTicketsForHost) calls this every recovery pass, so it re-reads the SAME
+// anchor issue on the SAME cadence the ReadFence traffic was flooding the shared
+// app-actor bucket at. The underlying heartbeat data only changes on the ~2min publish
+// cadence (LIVENESS_PUBLISH_INTERVAL_MS) and dead-host detection already tolerates a
+// generous 10-min grace window, so a 45s cache cannot make a live host look staler than
+// it already tolerates — safe by construction, exactly like the ReadFence cache's own
+// rationale.
+//
+// CATALYST_FENCE_READ_CACHE_MS — reused verbatim (same env var, same 45s default) rather
+// than a new sibling knob: both caches answer the identical question ("how fresh must an
+// anchor-issue attachment read be before we trust the last answer without re-asking
+// Linear?") for the SAME class of Linear traffic, so one shared TTL knob keeps the
+// operator model simple. 0 disables the cache entirely.
+const HEARTBEAT_READ_CACHE_MS_DEFAULT = 45_000;
+
+// heartbeatReadCache — module-scope Map(anchorIssue -> {peers, ts}).
+const heartbeatReadCache = new Map();
+
+// clearHeartbeatReadCache — test-only reset of the module-scope cache between cases.
+export function clearHeartbeatReadCache() {
+  heartbeatReadCache.clear();
+}
+
+function resolveHeartbeatReadCacheMs(env) {
+  const raw = Number(env?.CATALYST_FENCE_READ_CACHE_MS);
+  return Number.isFinite(raw) && raw >= 0 ? raw : HEARTBEAT_READ_CACHE_MS_DEFAULT;
+}
+
+// readPeerHeartbeatsSyncCached — the cached entry point. A hit within the TTL returns
+// immediately with ZERO subprocess spawn (mirrors fenceCheckSyncCached). `now`/`env` are
+// injectable test seams; every other option passes straight through to
+// readPeerHeartbeatsSync on a cache miss.
+//
+// What is cached: readPeerHeartbeatsSync collapses EVERY failure mode (spawn error,
+// timeout, non-zero exit, unparseable/non-object stdout) to the SAME `{}` it would also
+// return for a genuinely-empty anchor (no heartbeats published yet) — the two are
+// indistinguishable from the return value alone. So this only caches a NON-EMPTY result
+// (at least one peer record) — the closest available proxy for "a determinate, successful
+// read" given the wrapped function's shape. Since this whole liveness channel is an exact
+// no-op on a single-host install (startLivenessPublisher returns an inert handle), by the
+// time this cache is ever consulted the cluster has ≥2 hosts, each of which publishes its
+// OWN record — so a genuinely-empty `{}` is only possible in the brief window before the
+// first-ever publish, and is conservatively treated as "unknown, do not cache" (never an
+// error is cached; a false non-cache in that narrow bootstrap window self-heals on the
+// very next call).
+export function readPeerHeartbeatsSyncCached({ anchorIssue }, { now = Date.now, env = process.env, ...rest } = {}) {
+  const ttlMs = resolveHeartbeatReadCacheMs(env);
+  if (ttlMs > 0) {
+    const cached = heartbeatReadCache.get(anchorIssue);
+    if (cached && now() - cached.ts < ttlMs) return cached.peers;
+  }
+  const peers = readPeerHeartbeatsSync({ anchorIssue }, { env, ...rest });
+  if (ttlMs > 0 && peers && Object.keys(peers).length > 0) {
+    heartbeatReadCache.set(anchorIssue, { peers, ts: now() });
+  }
+  return peers;
 }

--- a/plugins/dev/scripts/execution-core/cluster-heartbeat-sync.test.mjs
+++ b/plugins/dev/scripts/execution-core/cluster-heartbeat-sync.test.mjs
@@ -1,8 +1,16 @@
 // cluster-heartbeat-sync.test.mjs — synchronous bridge over cluster-heartbeat CLI
 // (CTL-1090). Every test injects a fake `spawn` so nothing forks a process.
 // Mirrors cluster-claim-sync.test.mjs in structure and fail-open contract.
-import { describe, test, expect } from "bun:test";
-import { publishHeartbeatSync, readPeerHeartbeatsSync } from "./cluster-heartbeat-sync.mjs";
+import { describe, test, expect, beforeEach } from "bun:test";
+import {
+  publishHeartbeatSync,
+  readPeerHeartbeatsSync,
+  resolveAnchorIssueIdSync,
+  resolveAnchorIssueIdSyncCached,
+  clearAnchorUuidCache,
+  readPeerHeartbeatsSyncCached,
+  clearHeartbeatReadCache,
+} from "./cluster-heartbeat-sync.mjs";
 
 describe("publishHeartbeatSync — argv + fail-open contract", () => {
   test("returns ok:true and forwards anchor/host/tickets to the CLI", () => {
@@ -236,5 +244,233 @@ describe("readPeerHeartbeatsSync — parsing + fail-open contract", () => {
         { spawn: () => ({ status: 0, stdout: "[]\n" }) },
       ),
     ).toEqual({});
+  });
+});
+
+describe("resolveAnchorIssueIdSync — argv + parsing (CTL-863 entourage follow-up)", () => {
+  test("builds the right argv: <node> <cli> resolve-anchor <anchor>", () => {
+    let capturedBin, capturedArgs;
+    const spawn = (bin, args) => {
+      capturedBin = bin;
+      capturedArgs = args;
+      return { status: 0, stdout: '{"issueId":"uuid-anchor"}\n' };
+    };
+    resolveAnchorIssueIdSync(
+      { anchorIssue: "CTL-9999" },
+      { spawn, nodeBin: "/usr/bin/node", cli: "/x/cluster-heartbeat.mjs" },
+    );
+    expect(capturedBin).toBe("/usr/bin/node");
+    expect(capturedArgs).toEqual(["/x/cluster-heartbeat.mjs", "resolve-anchor", "CTL-9999"]);
+  });
+
+  test("parses the resolved UUID from stdout", () => {
+    const spawn = () => ({ status: 0, stdout: '{"issueId":"uuid-anchor"}\n' });
+    expect(resolveAnchorIssueIdSync({ anchorIssue: "CTL-9999" }, { spawn })).toBe("uuid-anchor");
+  });
+
+  test("a null issueId (unresolvable anchor) → null", () => {
+    const spawn = () => ({ status: 0, stdout: '{"issueId":null}\n' });
+    expect(resolveAnchorIssueIdSync({ anchorIssue: "CTL-9999" }, { spawn })).toBeNull();
+  });
+
+  test("non-zero exit / spawn error / unparseable stdout / throw → null (fail-open)", () => {
+    expect(resolveAnchorIssueIdSync({ anchorIssue: "CTL-9999" }, { spawn: () => ({ status: 1, stdout: "" }) })).toBeNull();
+    expect(
+      resolveAnchorIssueIdSync({ anchorIssue: "CTL-9999" }, { spawn: () => ({ status: null, error: new Error("ETIMEDOUT") }) }),
+    ).toBeNull();
+    expect(
+      resolveAnchorIssueIdSync({ anchorIssue: "CTL-9999" }, { spawn: () => ({ status: 0, stdout: "not json" }) }),
+    ).toBeNull();
+    expect(
+      resolveAnchorIssueIdSync({ anchorIssue: "CTL-9999" }, { spawn: () => { throw new Error("EACCES"); } }),
+    ).toBeNull();
+  });
+});
+
+describe("resolveAnchorIssueIdSyncCached — permanent identifier→UUID cache (CTL-863 entourage follow-up)", () => {
+  beforeEach(() => {
+    clearAnchorUuidCache();
+  });
+
+  test("(a) two resolves of the same anchor → ONE underlying spawn call", () => {
+    let calls = 0;
+    const spawn = () => {
+      calls += 1;
+      return { status: 0, stdout: '{"issueId":"uuid-anchor-1"}\n' };
+    };
+    const first = resolveAnchorIssueIdSyncCached({ anchorIssue: "CTL-1001" }, { spawn });
+    const second = resolveAnchorIssueIdSyncCached({ anchorIssue: "CTL-1001" }, { spawn });
+    expect(first).toBe("uuid-anchor-1");
+    expect(second).toBe("uuid-anchor-1");
+    expect(calls).toBe(1); // second call served from the permanent cache, no spawn
+  });
+
+  test("persists beyond any TTL window — no expiry, ever (permanent cache)", () => {
+    let calls = 0;
+    const spawn = () => {
+      calls += 1;
+      return { status: 0, stdout: '{"issueId":"uuid-anchor-2"}\n' };
+    };
+    let now = 1_000_000;
+    resolveAnchorIssueIdSyncCached({ anchorIssue: "CTL-1002" }, { spawn, now: () => now });
+    now += 10 * 24 * 60 * 60 * 1000; // 10 days later — far past any TTL a read cache would use
+    resolveAnchorIssueIdSyncCached({ anchorIssue: "CTL-1002" }, { spawn, now: () => now });
+    expect(calls).toBe(1); // still cached — this cache has no TTL at all
+  });
+
+  test("CATALYST_ANCHOR_UUID_CACHE=0 disables the cache — every resolve hits through", () => {
+    let calls = 0;
+    const spawn = () => {
+      calls += 1;
+      return { status: 0, stdout: '{"issueId":"uuid-anchor-3"}\n' };
+    };
+    const env = { CATALYST_ANCHOR_UUID_CACHE: "0" };
+    resolveAnchorIssueIdSyncCached({ anchorIssue: "CTL-1003" }, { spawn, env });
+    resolveAnchorIssueIdSyncCached({ anchorIssue: "CTL-1003" }, { spawn, env });
+    expect(calls).toBe(2); // cache fully disabled — no memoization at all
+  });
+
+  test("a failed/null resolution is NEVER cached — the next call retries for real", () => {
+    let calls = 0;
+    const spawn = () => {
+      calls += 1;
+      return { status: 1, stdout: "" }; // non-zero exit → resolution failure
+    };
+    const first = resolveAnchorIssueIdSyncCached({ anchorIssue: "CTL-1004" }, { spawn });
+    const second = resolveAnchorIssueIdSyncCached({ anchorIssue: "CTL-1004" }, { spawn });
+    expect(first).toBeNull();
+    expect(second).toBeNull();
+    expect(calls).toBe(2); // NOT cached — both calls spawned
+  });
+});
+
+describe("publishHeartbeatSync — pre-resolved issueId threaded into the publish argv (CTL-863 entourage follow-up)", () => {
+  beforeEach(() => {
+    clearAnchorUuidCache();
+  });
+
+  test("a successful pre-resolve appends the UUID as the publish CLI's 5th arg", () => {
+    let publishArgs;
+    const spawn = (bin, args) => {
+      if (args[1] === "resolve-anchor") {
+        return { status: 0, stdout: '{"issueId":"uuid-anchor-5"}\n' };
+      }
+      publishArgs = args;
+      return { status: 0, stdout: '{"host":"mini","last_seen":"t","in_flight_tickets":[]}\n' };
+    };
+    publishHeartbeatSync(
+      { anchorIssue: "CTL-1005", host: "mini" },
+      { spawn, nodeBin: "/usr/bin/node", cli: "/x/cluster-heartbeat.mjs" },
+    );
+    // argv: [cli, "publish", anchor, host, ticketsCsv, maxParallelPlaceholder, issueId] —
+    // the maxParallel slot is kept as an empty-string placeholder ahead of issueId.
+    expect(publishArgs).toEqual(["/x/cluster-heartbeat.mjs", "publish", "CTL-1005", "mini", "", "", "uuid-anchor-5"]);
+  });
+
+  test("a failed pre-resolve falls back to the plain 4-arg publish form (unchanged behavior)", () => {
+    let publishArgs;
+    const spawn = (bin, args) => {
+      if (args[1] === "resolve-anchor") {
+        return { status: 1, stdout: "" }; // resolution fails
+      }
+      publishArgs = args;
+      return { status: 0, stdout: '{"host":"mini","last_seen":"t","in_flight_tickets":[]}\n' };
+    };
+    publishHeartbeatSync(
+      { anchorIssue: "CTL-1006", host: "mini" },
+      { spawn, nodeBin: "/usr/bin/node", cli: "/x/cluster-heartbeat.mjs" },
+    );
+    expect(publishArgs).toEqual(["/x/cluster-heartbeat.mjs", "publish", "CTL-1006", "mini", ""]);
+  });
+});
+
+describe("readPeerHeartbeatsSyncCached — 45s TTL cache around the peer-liveness read (CTL-863 entourage follow-up)", () => {
+  beforeEach(() => {
+    clearHeartbeatReadCache();
+  });
+
+  const peerMap = { mini: { host: "mini", last_seen: "2026-06-13T01:00:00Z", in_flight_tickets: [] } };
+
+  test("(a) two reads within TTL for the same anchor → ONE underlying spawn call", () => {
+    let calls = 0;
+    const spawn = () => {
+      calls += 1;
+      return { status: 0, stdout: JSON.stringify(peerMap) + "\n" };
+    };
+    let now = 1_000_000;
+    const first = readPeerHeartbeatsSyncCached({ anchorIssue: "CTL-2001" }, { spawn, now: () => now });
+    now += 1_000; // 1s later — well within the 45s default TTL
+    const second = readPeerHeartbeatsSyncCached({ anchorIssue: "CTL-2001" }, { spawn, now: () => now });
+    expect(first).toEqual(peerMap);
+    expect(second).toEqual(peerMap);
+    expect(calls).toBe(1); // second call served from cache, no spawn
+  });
+
+  test("(b) after TTL expiry → a fresh read (spawn called again)", () => {
+    let calls = 0;
+    const spawn = () => {
+      calls += 1;
+      return { status: 0, stdout: JSON.stringify(peerMap) + "\n" };
+    };
+    let now = 1_000_000;
+    readPeerHeartbeatsSyncCached({ anchorIssue: "CTL-2002" }, { spawn, now: () => now, env: { CATALYST_FENCE_READ_CACHE_MS: "45000" } });
+    now += 45_001; // just past the 45s TTL
+    readPeerHeartbeatsSyncCached({ anchorIssue: "CTL-2002" }, { spawn, now: () => now, env: { CATALYST_FENCE_READ_CACHE_MS: "45000" } });
+    expect(calls).toBe(2); // TTL expired → the second call re-spawned
+  });
+
+  test("(c) CATALYST_FENCE_READ_CACHE_MS=0 disables the cache — every read hits through", () => {
+    let calls = 0;
+    const spawn = () => {
+      calls += 1;
+      return { status: 0, stdout: JSON.stringify(peerMap) + "\n" };
+    };
+    const env = { CATALYST_FENCE_READ_CACHE_MS: "0" };
+    const now = () => 1_000_000; // frozen clock — proves it's the env flag, not elapsed time
+    readPeerHeartbeatsSyncCached({ anchorIssue: "CTL-2003" }, { spawn, env, now });
+    readPeerHeartbeatsSyncCached({ anchorIssue: "CTL-2003" }, { spawn, env, now });
+    readPeerHeartbeatsSyncCached({ anchorIssue: "CTL-2003" }, { spawn, env, now });
+    expect(calls).toBe(3); // cache fully disabled — no memoization at all
+  });
+
+  test("(d) an empty/error result is NEVER cached — the next call retries the real read", () => {
+    let calls = 0;
+    const spawn = () => {
+      calls += 1;
+      return { status: 1, stdout: "" }; // non-zero exit → the {} fail-open shape
+    };
+    const now = () => 1_000_000; // frozen clock — within TTL, so only caching (not expiry) explains a re-spawn
+    const first = readPeerHeartbeatsSyncCached({ anchorIssue: "CTL-2004" }, { spawn, now });
+    const second = readPeerHeartbeatsSyncCached({ anchorIssue: "CTL-2004" }, { spawn, now });
+    expect(first).toEqual({});
+    expect(second).toEqual({});
+    expect(calls).toBe(2); // NOT cached — both calls spawned
+  });
+
+  test("different anchors are NOT interchangeable — each gets its own read + cache slot", () => {
+    const seen = [];
+    const spawn = (bin, args) => {
+      seen.push(args[2]); // the anchor argv
+      return { status: 0, stdout: JSON.stringify(peerMap) + "\n" };
+    };
+    const now = () => 1_000_000;
+    readPeerHeartbeatsSyncCached({ anchorIssue: "CTL-2005" }, { spawn, now });
+    readPeerHeartbeatsSyncCached({ anchorIssue: "CTL-2006" }, { spawn, now });
+    expect(seen).toEqual(["CTL-2005", "CTL-2006"]); // both spawned — distinct cache keys
+  });
+
+  test("falls through to a real readPeerHeartbeatsSync on a cache miss (argv unchanged)", () => {
+    let captured;
+    const spawn = (bin, args) => {
+      captured = { bin, args };
+      return { status: 0, stdout: JSON.stringify(peerMap) + "\n" };
+    };
+    const now = () => 1_000_000;
+    readPeerHeartbeatsSyncCached(
+      { anchorIssue: "CTL-2007" },
+      { spawn, now, nodeBin: "/usr/bin/node", cli: "/x/cluster-heartbeat.mjs" },
+    );
+    expect(captured.bin).toBe("/usr/bin/node");
+    expect(captured.args).toEqual(["/x/cluster-heartbeat.mjs", "read", "CTL-2007"]);
   });
 });

--- a/plugins/dev/scripts/execution-core/cluster-heartbeat.mjs
+++ b/plugins/dev/scripts/execution-core/cluster-heartbeat.mjs
@@ -158,11 +158,21 @@ const WRITE_ATTACHMENT_MUTATION = `mutation UpsertFence($input: AttachmentCreate
 // on the anchor issue. Single-writer-per-host ⇒ no CAS. Mirrors writeClaim
 // (resolve issue UUID, then attachmentCreate UPSERT). Returns the parsed
 // heartbeat record written, throwing on a resolution miss or success:false.
+//
+// CTL-863 fleet-unfreeze (entourage, follow-up to #2552): `issueId` is an
+// OPTIONAL pre-resolved UUID override. The anchor issue's UUID never changes
+// once resolved, so cluster-heartbeat-sync.mjs's resolveAnchorIssueIdSyncCached
+// resolves it ONCE (permanently cached, in-process) and passes it here on every
+// subsequent publish — skipping the redundant `query ResolveIssueId` round-trip
+// every ~2min publish tick would otherwise repeat forever. A falsy override
+// (the cache-miss / cache-disabled case) falls through to the original
+// resolveIssueId(anchorIssue) call, so behavior is UNCHANGED when no override
+// is supplied — this is purely additive.
 export async function publishHeartbeat(
   { anchorIssue, host, inFlightTickets = [], maxParallel = null },
-  { post = defaultPost, now } = {},
+  { post = defaultPost, now, issueId: issueIdOverride = null } = {},
 ) {
-  const issueId = await resolveIssueId(anchorIssue, { post });
+  const issueId = issueIdOverride || (await resolveIssueId(anchorIssue, { post }));
   if (!issueId) throw new Error(`cluster-heartbeat: no issue found for anchor ${anchorIssue}`);
   const last_seen = now ? now() : new Date().toISOString();
   const metadata = {
@@ -192,13 +202,20 @@ export async function publishHeartbeat(
 // cluster-heartbeat-sync.mjs is the in-process wrapper that spawnSync's
 // `node cluster-heartbeat.mjs <cmd> …`.
 //
-//   publish <anchor> <host> <ticketsCSV> [maxParallel]  → stdout JSON record; exit 0
-//   read <anchor>                                        → stdout JSON map; exit 0
+//   publish <anchor> <host> <ticketsCSV> [maxParallel] [issueId]  → stdout JSON record; exit 0
+//   read <anchor>                                                  → stdout JSON map; exit 0
+//   resolve-anchor <anchor>                                        → stdout JSON {issueId}; exit 0
+//
+// CTL-863 fleet-unfreeze (entourage): `resolve-anchor` is a standalone identifier→UUID
+// resolution, added so cluster-heartbeat-sync.mjs's permanent cache can populate itself
+// with ONE small subprocess call (instead of the resolution being buried inside every
+// `publish`), then pass the resolved UUID back into `publish`'s optional 5th arg on every
+// subsequent call — skipping that call's own ResolveIssueId round-trip.
 export async function runCli(argv, { post = defaultPost, now } = {}) {
   const [cmd, ...rest] = argv;
   switch (cmd) {
     case "publish": {
-      const [anchor, host, ticketsCsv, maxParallelRaw] = rest;
+      const [anchor, host, ticketsCsv, maxParallelRaw, issueIdRaw] = rest;
       const inFlightTickets =
         ticketsCsv
           ? ticketsCsv
@@ -211,9 +228,13 @@ export async function runCli(argv, { post = defaultPost, now } = {}) {
       // pass only 3 args, so the heartbeat still carries max_parallel: null).
       const mp = maxParallelRaw != null && maxParallelRaw !== "" ? Number(maxParallelRaw) : null;
       const maxParallel = Number.isInteger(mp) && mp > 0 ? mp : null;
+      // CTL-863 follow-up: optional 5th arg — a pre-resolved anchor UUID from the
+      // daemon-side permanent cache. Absent/blank → null (publishHeartbeat falls back
+      // to resolving it itself, byte-identical to pre-follow-up behavior).
+      const issueId = issueIdRaw != null && issueIdRaw !== "" ? issueIdRaw : null;
       const rec = await publishHeartbeat(
         { anchorIssue: anchor, host, inFlightTickets, maxParallel },
-        { post, now },
+        { post, now, issueId },
       );
       process.stdout.write(JSON.stringify(rec) + "\n");
       return 0;
@@ -224,10 +245,16 @@ export async function runCli(argv, { post = defaultPost, now } = {}) {
       process.stdout.write(JSON.stringify(map) + "\n");
       return 0;
     }
+    case "resolve-anchor": {
+      const [anchor] = rest;
+      const issueId = await resolveIssueId(anchor, { post });
+      process.stdout.write(JSON.stringify({ issueId }) + "\n");
+      return 0;
+    }
     default:
       process.stderr.write(
         `cluster-heartbeat.mjs: unknown subcommand: ${cmd ?? "(none)"}\n` +
-          "usage: cluster-heartbeat.mjs <publish <anchor> <host> <ticketsCSV> [maxParallel] | read <anchor>>\n",
+          "usage: cluster-heartbeat.mjs <publish <anchor> <host> <ticketsCSV> [maxParallel] [issueId] | read <anchor> | resolve-anchor <anchor>>\n",
       );
       return 1;
   }

--- a/plugins/dev/scripts/execution-core/cluster-heartbeat.test.mjs
+++ b/plugins/dev/scripts/execution-core/cluster-heartbeat.test.mjs
@@ -133,6 +133,34 @@ describe("publishHeartbeat", () => {
     );
     expect(rec.in_flight_tickets).toEqual([]);
   });
+
+  // CTL-863 fleet-unfreeze (entourage follow-up to #2552): a pre-resolved issueId
+  // override skips the ResolveIssueId round-trip entirely.
+  test("an issueId override SKIPS resolveIssueId — only attachmentCreate is called", async () => {
+    const calls = [];
+    const post = async (q, v) => {
+      calls.push(q);
+      return { attachmentCreate: { success: true, attachment: {} } };
+    };
+    const rec = await publishHeartbeat(
+      { anchorIssue: "CTL-9999", host: "mini" },
+      { post, now: () => "2026-06-13T01:00:00Z", issueId: "uuid-anchor" },
+    );
+    expect(rec.host).toBe("mini");
+    expect(calls.length).toBe(1); // ONLY attachmentCreate — no ResolveIssueId call
+    expect(calls[0]).toContain("attachmentCreate");
+  });
+
+  test("no issueId override → falls through to resolveIssueId unchanged", async () => {
+    const calls = [];
+    const post = async (q) => {
+      calls.push(q);
+      if (q.includes("ResolveIssue")) return { issue: { id: "uuid-x" } };
+      return { attachmentCreate: { success: true, attachment: {} } };
+    };
+    await publishHeartbeat({ anchorIssue: "CTL-9999", host: "mini" }, { post, issueId: null });
+    expect(calls.some((q) => q.includes("ResolveIssue"))).toBe(true);
+  });
 });
 
 describe("readPeerHeartbeats", () => {
@@ -263,6 +291,41 @@ describe("runCli", () => {
   test("unknown subcommand exits 1", async () => {
     const { code } = await captureStdout(() => runCli(["bogus"], {}));
     expect(code).toBe(1);
+  });
+
+  // CTL-863 fleet-unfreeze (entourage follow-up to #2552).
+  test("resolve-anchor: prints {issueId} and exits 0", async () => {
+    const post = async (q) => {
+      if (q.includes("ResolveIssue")) return { issue: { id: "uuid-anchor" } };
+      throw new Error("unexpected query");
+    };
+    const { code, out } = await captureStdout(() => runCli(["resolve-anchor", "CTL-9999"], { post }));
+    expect(code).toBe(0);
+    expect(JSON.parse(out)).toEqual({ issueId: "uuid-anchor" });
+  });
+
+  test("resolve-anchor: {issueId:null} when the anchor cannot be resolved", async () => {
+    const post = async () => ({ issue: null });
+    const { code, out } = await captureStdout(() => runCli(["resolve-anchor", "CTL-9999"], { post }));
+    expect(code).toBe(0);
+    expect(JSON.parse(out)).toEqual({ issueId: null });
+  });
+
+  test("publish: an optional 5th issueId arg skips ResolveIssueId (only attachmentCreate)", async () => {
+    const calls = [];
+    const post = async (q) => {
+      calls.push(q);
+      return { attachmentCreate: { success: true, attachment: {} } };
+    };
+    const { code, out } = await captureStdout(() =>
+      runCli(["publish", "CTL-9999", "mini", "CTL-1", "", "uuid-anchor"], {
+        post,
+        now: () => "2026-06-13T01:00:00Z",
+      }),
+    );
+    expect(code).toBe(0);
+    expect(JSON.parse(out).host).toBe("mini");
+    expect(calls.some((q) => q.includes("ResolveIssue"))).toBe(false);
   });
 });
 

--- a/plugins/dev/scripts/execution-core/recovery.mjs
+++ b/plugins/dev/scripts/execution-core/recovery.mjs
@@ -46,7 +46,13 @@ import {
 // transcripts so a doc worker mid in-process fan-out is never judged silent
 // (CTL-662-safe). Used ONLY to break the cold-snapshot doc-phase 6h tie below.
 import { transcriptAgeMs as defaultTranscriptAgeMs } from "./transcript-silence.mjs";
-import { readPeerHeartbeatsSync } from "./cluster-heartbeat-sync.mjs";
+// CTL-863 fleet-unfreeze (entourage follow-up to #2552): readPeerHeartbeatsSyncCached is
+// the CACHED reader — a 45s in-process TTL cache around the same anchor-issue read, safe
+// here because dead-host detection already tolerates a far larger (10-min) staleness
+// grace. The uncached readPeerHeartbeatsSync stays available in cluster-heartbeat-sync.mjs
+// for callers that want the live read every time (e.g. cli/cluster.mjs's human-invoked
+// `status` verb).
+import { readPeerHeartbeatsSyncCached } from "./cluster-heartbeat-sync.mjs";
 import { HEARTBEAT_EVENT } from "./heartbeat-event.mjs"; // CTL-859: node.heartbeat reader
 import { resolveTicketType, UNKNOWN_TICKET_TYPE } from "./ticket-type.mjs"; // CTL-1023: work-type dimension
 import { phaseIndex, isKnownPhase } from "../lib/phase-fsm.mjs";
@@ -3039,7 +3045,7 @@ export function readClusterHeartbeats({
   logPath = getEventLogPath(),
   roster = getClusterHosts(),
   anchorIssue = getLivenessAnchorIssue(),
-  readPeers = (anchor) => readPeerHeartbeatsSync({ anchorIssue: anchor }),
+  readPeers = (anchor) => readPeerHeartbeatsSyncCached({ anchorIssue: anchor }),
 } = {}) {
   const lastSeen = {};
   let raw;
@@ -3230,7 +3236,7 @@ function defaultOwnedTicketsForHost(
   {
     orchDir,
     anchorIssue = getLivenessAnchorIssue(),
-    readPeers = (anchor) => readPeerHeartbeatsSync({ anchorIssue: anchor }),
+    readPeers = (anchor) => readPeerHeartbeatsSyncCached({ anchorIssue: anchor }),
   } = {}
 ) {
   if (anchorIssue) {


### PR DESCRIPTION
## Summary

Urgent follow-up to #2552. That PR added a 45s TTL cache for the `ReadFence`
read (82% of Linear traffic on the shared app-actor bucket) and materially
cut the burn (breaker trips 18/3m → 1-2/3m per OTEL), but left the
**uncached entourage** still keeping the bucket at the 429 edge:

- `query ResolveIssueId` — resolves an identifier → issue UUID. Issued on
  every claim (`cluster-claim.mjs::writeClaim`) and every ~2min heartbeat
  publish (`cluster-heartbeat.mjs::publishHeartbeat`) — the anchor/ticket
  UUID never changes once resolved, so this is the highest-value, safest
  cache: **permanent, no TTL**.
- The peer-heartbeat "get issue by identifier" read
  (`cluster-heartbeat.mjs::readPeerHeartbeats`, consumed via
  `readPeerHeartbeatsSync` in `recovery.mjs`'s dead-host detection) — a
  read-only liveness check, safe to cache with the **same 45s TTL** pattern
  as the ReadFence cache (dead-host detection already tolerates a 10-min
  staleness grace).

## Changes

- **`cluster-claim.mjs` / `cluster-claim-sync.mjs`**: `writeClaim` /
  `claimTicket` / `claimDispatchSync` gain an optional pre-resolved
  `issueId` override. A new `resolve-issue-id` CLI subcommand +
  `resolveIssueIdSyncCached` (permanent in-process `Map`, env
  `CATALYST_ANCHOR_UUID_CACHE`, "0" disables) let the daemon-side sync
  wrapper resolve a ticket's UUID once and skip the redundant
  `ResolveIssueId` round-trip on every subsequent claim. The CAS reads
  (`readClaim`, inside `claimTicket`) are deliberately **left uncached** —
  they are the actual fencing correctness check, not an immutable mapping,
  so caching them would risk a false win/lose.
- **`cluster-heartbeat.mjs` / `cluster-heartbeat-sync.mjs`**: the same
  permanent-cache pattern for the anchor issue (`publishHeartbeat` gains an
  `issueId` override + a `resolve-anchor` subcommand), plus a 45s TTL cache
  (`readPeerHeartbeatsSyncCached`, reusing `CATALYST_FENCE_READ_CACHE_MS`)
  around the peer-liveness read.
- **`recovery.mjs`**: wires `readPeerHeartbeatsSyncCached` into
  `readClusterHeartbeats` / `defaultOwnedTicketsForHost`.

Both caches only ever cache a **determinate success** — never an
error/indeterminate result — matching #2552's Map+TTL+env+test-seam style
exactly. Fence/claim write semantics are untouched; this only avoids
redundant Linear round-trips.

## Test plan

- [x] `node --check` on all 9 touched files
- [x] `env -u CLAUDE_CODE_OAUTH_TOKEN -u ANTHROPIC_API_KEY -u LINEAR_API_TOKEN bun test` on the 4 directly-touched test files: **141 pass / 0 fail**
- [x] Same for `fence-guard.test.mjs` + `fence-guard-integration.test.mjs` (consumers of `cluster-claim-sync.mjs`): pass
- [x] `recovery.test.mjs` (consumer of the new heartbeat cache): pass in isolation. Note: this file has a **pre-existing, unrelated** flakiness — `recoverStartup`'s "rebuilds routing state" test makes a real unauthenticated network call to `api.linear.app` (no `delegateExec` mock) via `runEligibleQuery`'s delegate-batch enrichment; enough repeated real hits from this sandbox trip Linear's live rate limiter, which opens the shared `linearBreaker` singleton for 60s and cascades into unrelated `reclaimDeadWorkIfPossible` test failures. **Reproduced this with zero code changes** (clean checkout, repeated runs) — confirmed unrelated to this diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)