### PR TITLE
feat(dev): CTL-1417 — worktree-removal self-protection guard

### DIFF
--- a/plugins/dev/scripts/__tests__/create-worktree-guard.test.sh
+++ b/plugins/dev/scripts/__tests__/create-worktree-guard.test.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+# CTL-1417: create-worktree.sh rollback removals must route through the shared
+# self-protection guard (assert_worktree_removal_safe). When the guard reports a
+# live foreign handle under the worktree, the `--force` rollback removal is
+# SKIPPED (tree left for the reaper) instead of yanking an in-use tree. When the
+# guard is clear, the rollback removes exactly as before.
+#
+# Drives rollback site 1 (auto-detected `make setup` failure) by committing a
+# Makefile whose `setup` target exits non-zero. lsof is stubbed via WT_GUARD_LSOF
+# so the guard verdict is deterministic.
+#
+# Run: bash plugins/dev/scripts/__tests__/create-worktree-guard.test.sh
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../../.." && pwd)"
+CREATE_WT="${REPO_ROOT}/plugins/dev/scripts/create-worktree.sh"
+
+FAILURES=0
+PASSES=0
+fail() {
+	FAILURES=$((FAILURES + 1))
+	echo "  FAIL: $1"
+}
+pass() {
+	PASSES=$((PASSES + 1))
+	echo "  PASS: $1"
+}
+assert_eq() {
+	if [[ $1 == "$2" ]]; then pass "$3"; else fail "$3 — expected '$1', got '$2'"; fi
+}
+
+SCRATCH="$(mktemp -d -t cwt-guard-XXXXXX)"
+trap 'rm -rf "$SCRATCH"' EXIT
+
+# Deterministic, non-interactive git.
+export GIT_AUTHOR_NAME=test GIT_AUTHOR_EMAIL=test@test
+export GIT_COMMITTER_NAME=test GIT_COMMITTER_EMAIL=test@test
+export GIT_CONFIG_GLOBAL=/dev/null GIT_CONFIG_SYSTEM=/dev/null
+
+# A stub lsof whose rc/stdout is driven by STUB_LSOF_RC / STUB_LSOF_OUT.
+MOCK_LSOF="$SCRATCH/mock-lsof"
+cat >"$MOCK_LSOF" <<'MOCK'
+#!/usr/bin/env bash
+printf '%s' "${STUB_LSOF_OUT:-}"
+exit "${STUB_LSOF_RC:-1}"
+MOCK
+chmod +x "$MOCK_LSOF"
+
+ORIGIN="$SCRATCH/origin.git"
+git init -q --bare "$ORIGIN"
+SEED="$SCRATCH/seed"
+git clone -q "$ORIGIN" "$SEED"
+git -C "$SEED" checkout -q -b main 2>/dev/null || git -C "$SEED" checkout -q main
+# No catalyst.worktree.setup → create-worktree takes the auto-detected path and
+# runs `make setup`, whose target below exits 1 to force the rollback.
+mkdir -p "$SEED/.catalyst"
+printf '{"catalyst":{"projectKey":"t"}}\n' >"$SEED/.catalyst/config.json"
+printf 'setup:\n\t@exit 1\n' >"$SEED/Makefile"
+git -C "$SEED" add -A
+git -C "$SEED" commit -q -m c1
+git -C "$SEED" push -q -u origin main
+
+SRC="$SCRATCH/src"
+git clone -q "$ORIGIN" "$SRC"
+
+# run_rollback <name> — invoke create-worktree.sh so its `make setup` fails and
+# the rollback fires. Returns whether the worktree dir survived on disk.
+run_rollback() {
+	local name="$1"
+	local wtbase="$SCRATCH/wt-$name"
+	mkdir -p "$wtbase"
+	(cd "$SRC" && HOME="$SCRATCH/home-$name" \
+		WT_GUARD_LSOF="$MOCK_LSOF" STUB_LSOF_RC="${STUB_LSOF_RC:-1}" STUB_LSOF_OUT="${STUB_LSOF_OUT:-}" \
+		bash "$CREATE_WT" "$name" main --worktree-dir "$wtbase" --skip-fetch >/dev/null 2>&1)
+	WT_PATH="$wtbase/$name"
+}
+
+# Case 1: foreign live handle (rc=0 + output) → guard refuses → tree kept.
+STUB_LSOF_RC=0 STUB_LSOF_OUT="p9999" run_rollback refuse
+assert_eq "yes" "$([[ -d $WT_PATH ]] && echo yes || echo no)" \
+	"rollback: guard refusal (live handle) leaves the worktree on disk"
+
+# Case 2: clear lsof (rc=1 + empty) → guard allows → tree removed as before.
+STUB_LSOF_RC=1 STUB_LSOF_OUT="" run_rollback allow
+assert_eq "no" "$([[ -d $WT_PATH ]] && echo yes || echo no)" \
+	"rollback: clear guard force-removes the worktree (unchanged behavior)"
+
+echo ""
+echo "create-worktree-guard: ${PASSES} passed / ${FAILURES} failed"
+[[ $FAILURES -eq 0 ]] || exit 1
+exit 0

--- a/plugins/dev/scripts/__tests__/create-worktree-guard.test.sh
+++ b/plugins/dev/scripts/__tests__/create-worktree-guard.test.sh
@@ -37,10 +37,12 @@ if grep -q 'source "\${SCRIPT_DIR}/lib/worktree-remove-guard.sh"' "$CREATE_WT"; 
 else
 	fail "create-worktree.sh does NOT source lib/worktree-remove-guard.sh"
 fi
-# Every `git worktree remove --force` must be preceded (within a few lines) by an
-# assert_worktree_removal_safe gate. Count force-removes vs guard calls.
+# Every `git worktree remove --force` must be gated by the fail-closed
+# _removal_guard_ok predicate (CTL-1417: guard-ABSENCE now REFUSES, so the sites
+# gate on the helper rather than a bare `command -v ... || assert...` fail-open
+# form). Count force-removes vs guard-predicate calls.
 N_FORCE="$(grep -c 'git worktree remove --force "\$WORKTREE_PATH"' "$CREATE_WT" || true)"
-N_GUARD="$(grep -c 'assert_worktree_removal_safe "\$WORKTREE_PATH"' "$CREATE_WT" || true)"
+N_GUARD="$(grep -c '_removal_guard_ok "\$WORKTREE_PATH"' "$CREATE_WT" || true)"
 assert_eq "$N_FORCE" "$N_GUARD" "each rollback force-remove has a matching guard call (${N_FORCE} force / ${N_GUARD} guard)"
 [[ "$N_FORCE" -ge 2 ]] && pass "both rollback sites present (${N_FORCE})" || fail "expected >=2 rollback force-removes, found ${N_FORCE}"
 
@@ -72,13 +74,22 @@ WORKTREE_PATH="$SCRATCH/wt/CTL-100"
 WORKTREE_NAME="CTL-100"
 mkdir -p "$WORKTREE_PATH"
 
-# Replicate create-worktree.sh's exact guarded-removal gate.
+# Replicate create-worktree.sh's exact guarded-removal gate — the fail-closed
+# _removal_guard_ok predicate (guard-ABSENCE ⇒ refuse).
+_removal_guard_ok() {
+	local _wt="${1:-}"
+	if ! command -v assert_worktree_removal_safe >/dev/null 2>&1; then
+		echo "worktree-remove-guard: unavailable — refusing forced removal of ${_wt}" >&2
+		return 1
+	fi
+	assert_worktree_removal_safe "$_wt"
+}
 guarded_remove() {
-	if ! command -v assert_worktree_removal_safe >/dev/null 2>&1 || assert_worktree_removal_safe "$WORKTREE_PATH"; then
+	if _removal_guard_ok "$WORKTREE_PATH"; then
 		"$MOCK_GIT" worktree remove --force "$WORKTREE_PATH"
 		"$MOCK_GIT" branch -D "$WORKTREE_NAME" 2>/dev/null || true
 	else
-		echo "create-worktree: guard refused removal of ${WORKTREE_PATH}; leaving for reaper" >&2
+		echo "create-worktree: guard refused/unavailable for ${WORKTREE_PATH}; leaving for reaper" >&2
 	fi
 }
 
@@ -98,6 +109,21 @@ if grep -q 'worktree remove --force' "$GIT_LOG"; then
 	pass "clear-probe rollback force-removes as before (guard allowed)"
 else
 	fail "clear-probe rollback did NOT remove (guard over-refused)"
+fi
+
+# (c) CTL-1417 fail-closed: guard function UNAVAILABLE → refuse (NO remove). Run
+# the gate in a subshell where assert_worktree_removal_safe is unset, proving
+# guard-absence is treated as a refusal rather than a bypass.
+: >"$GIT_LOG"
+(
+	cd "$SCRATCH"
+	unset -f assert_worktree_removal_safe
+	guarded_remove
+) 2>/dev/null
+if grep -q 'worktree remove' "$GIT_LOG"; then
+	fail "guard-absent rollback force-removed the worktree (fail-OPEN regression)"
+else
+	pass "guard-absent rollback SKIPS the force-remove (fail-closed)"
 fi
 
 echo ""

--- a/plugins/dev/scripts/__tests__/create-worktree-guard.test.sh
+++ b/plugins/dev/scripts/__tests__/create-worktree-guard.test.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+# CTL-1417: create-worktree.sh rollback --force removals must route through the
+# shared worktree-removal self-protection guard, so a rollback never yanks a
+# worktree that is our own cwd or is held by a live foreign process.
+#
+# The full create-worktree.sh flow (git worktree add → workflow-context →
+# `make setup` → thoughts-init → direnv) is too heavy/environment-dependent to
+# drive a deterministic rollback here, so this suite proves the change two ways:
+#   1. STRUCTURAL — both rollback force-removals are gated by
+#      assert_worktree_removal_safe and the guard lib is sourced.
+#   2. BEHAVIORAL — the exact guard-gated removal decision create-worktree.sh
+#      now uses is exercised against a REAL git linked worktree with a stubbed
+#      lsof: a live-handle probe SKIPS the remove (tree survives), a clear probe
+#      REMOVES it.
+#
+# Run: bash plugins/dev/scripts/__tests__/create-worktree-guard.test.sh
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../../.." && pwd)"
+CREATE_WT="${REPO_ROOT}/plugins/dev/scripts/create-worktree.sh"
+GUARD_LIB="${REPO_ROOT}/plugins/dev/scripts/lib/worktree-remove-guard.sh"
+
+FAILURES=0
+PASSES=0
+SCRATCH="$(mktemp -d -t create-worktree-guard-XXXXXX)"
+trap 'rm -rf "$SCRATCH"' EXIT
+
+fail() { FAILURES=$((FAILURES + 1)); echo "  FAIL: $1"; }
+pass() { PASSES=$((PASSES + 1)); echo "  PASS: $1"; }
+assert_eq() { if [[ $1 == "$2" ]]; then pass "$3"; else fail "$3 — expected '$1', got '$2'"; fi; }
+
+# ─── 1. Structural: both rollback removals are guard-wired ────────────────────
+if grep -q 'source "\${SCRIPT_DIR}/lib/worktree-remove-guard.sh"' "$CREATE_WT"; then
+	pass "create-worktree.sh sources the removal guard"
+else
+	fail "create-worktree.sh does NOT source lib/worktree-remove-guard.sh"
+fi
+# Every `git worktree remove --force` must be preceded (within a few lines) by an
+# assert_worktree_removal_safe gate. Count force-removes vs guard calls.
+N_FORCE="$(grep -c 'git worktree remove --force "\$WORKTREE_PATH"' "$CREATE_WT" || true)"
+N_GUARD="$(grep -c 'assert_worktree_removal_safe "\$WORKTREE_PATH"' "$CREATE_WT" || true)"
+assert_eq "$N_FORCE" "$N_GUARD" "each rollback force-remove has a matching guard call (${N_FORCE} force / ${N_GUARD} guard)"
+[[ "$N_FORCE" -ge 2 ]] && pass "both rollback sites present (${N_FORCE})" || fail "expected >=2 rollback force-removes, found ${N_FORCE}"
+
+# ─── 2. Behavioral: the guard-gated removal decision ──────────────────────────
+# Build a real repo + linked worktree; a mock git records `worktree remove` so
+# we can assert whether the gate reached it. lsof is stubbed via WT_GUARD_LSOF.
+source "$GUARD_LIB"
+
+STUB_LSOF="$SCRATCH/mock-lsof"
+cat >"$STUB_LSOF" <<'EOF'
+#!/usr/bin/env bash
+[[ -n "${STUB_LSOF_OUT:-}" ]] && printf '%s\n' "$STUB_LSOF_OUT"
+exit "${STUB_LSOF_RC:-1}"
+EOF
+chmod +x "$STUB_LSOF"
+export WT_GUARD_LSOF="$STUB_LSOF"
+
+# Exported so the mock git child process can append to it.
+export GIT_LOG="$SCRATCH/git.log"
+MOCK_GIT="$SCRATCH/mockgit"
+cat >"$MOCK_GIT" <<'EOF'
+#!/usr/bin/env bash
+echo "$@" >> "${GIT_LOG}"
+exit 0
+EOF
+chmod +x "$MOCK_GIT"
+
+WORKTREE_PATH="$SCRATCH/wt/CTL-100"
+WORKTREE_NAME="CTL-100"
+mkdir -p "$WORKTREE_PATH"
+
+# Replicate create-worktree.sh's exact guarded-removal gate.
+guarded_remove() {
+	if ! command -v assert_worktree_removal_safe >/dev/null 2>&1 || assert_worktree_removal_safe "$WORKTREE_PATH"; then
+		"$MOCK_GIT" worktree remove --force "$WORKTREE_PATH"
+		"$MOCK_GIT" branch -D "$WORKTREE_NAME" 2>/dev/null || true
+	else
+		echo "create-worktree: guard refused removal of ${WORKTREE_PATH}; leaving for reaper" >&2
+	fi
+}
+
+# (a) live foreign holder (rc=0 + output) → guard refuses → NO remove.
+: >"$GIT_LOG"
+( cd "$SCRATCH" && STUB_LSOF_RC=0 STUB_LSOF_OUT="p4321" guarded_remove ) 2>/dev/null
+if grep -q 'worktree remove' "$GIT_LOG"; then
+	fail "live-handle rollback still force-removed the worktree"
+else
+	pass "live-handle rollback SKIPS the force-remove (guard refused)"
+fi
+
+# (b) clear probe (rc=1 + empty) → guard allows → remove happens.
+: >"$GIT_LOG"
+( cd "$SCRATCH" && STUB_LSOF_RC=1 STUB_LSOF_OUT="" guarded_remove ) 2>/dev/null
+if grep -q 'worktree remove --force' "$GIT_LOG"; then
+	pass "clear-probe rollback force-removes as before (guard allowed)"
+else
+	fail "clear-probe rollback did NOT remove (guard over-refused)"
+fi
+
+echo ""
+echo "create-worktree-guard: ${PASSES} passed / ${FAILURES} failed"
+[[ $FAILURES -eq 0 ]] || exit 1
+exit 0

--- a/plugins/dev/scripts/__tests__/orphan-sweep.test.sh
+++ b/plugins/dev/scripts/__tests__/orphan-sweep.test.sh
@@ -629,6 +629,50 @@ rm -f "$GIT_LOG"
 run "T24: empty symbolic-ref falls back to origin/main (EMPTY-SYMREF removed as SAFE)" \
   bash -c "SWEEP_FORCE_POWER=1 SWEEP_IDLE_HOURS=9999 SWEEP_PROJECT_CLAUDE_WT=/nonexistent SWEEP_INCLUDE_GLOBAL_CLAUDE_WT=0 bash '${SWEEP}' && grep -q 'EMPTY-SYMREF' '${GIT_LOG}'"
 
+# T24g (CTL-1417): SAFE tree with a live foreign holder -> guard REFUSES the
+# force-remove (skip + activeSkipped), never force-removes an in-use worktree.
+# Override lsof so the guard's `-nP +D <path>` probe reports a live holder
+# (rc=0 + non-empty). The proc-kill vector still passes PID args, so keep its
+# original 1001/1002 mapping as the fallback branch.
+cat > "$MOCKBIN/lsof" <<'EOF'
+#!/usr/bin/env bash
+for a in "$@"; do
+  if [[ "$a" == "+D" ]]; then
+    # worktree-remove-guard foreign-liveness probe: report a live holder.
+    echo "claude 9999 user cwd DIR held-open"
+    exit 0
+  fi
+done
+# proc-kill vector fallback (PID args)
+for a in "$@"; do
+  case "$a" in
+    1001) echo "n${GONE_DIR}" ;;
+    1002) echo "n${LIVE_DIR}" ;;
+  esac
+done
+EOF
+chmod +x "$MOCKBIN/lsof"
+GUARD_WT="${SWEEP_WT_ROOT}/GUARD-REFUSE"
+mkdir -p "${GUARD_WT}/.git"
+touch -t 202501010000 "${GUARD_WT}" 2>/dev/null || true
+rm -f "$GIT_LOG"
+run "T24g: guard-refused SAFE tree logs skip (live handle)" \
+  bash -c "SWEEP_FORCE_POWER=1 SWEEP_IDLE_HOURS=9999 SWEEP_PROJECT_CLAUDE_WT=/nonexistent SWEEP_INCLUDE_GLOBAL_CLAUDE_WT=0 bash '${SWEEP}' 2>&1 | grep -qi 'guard refused'"
+run "T24g-b: guard-refused GUARD-REFUSE NOT in git worktree remove log" \
+  bash -c "! grep -E 'worktree remove.*GUARD-REFUSE|GUARD-REFUSE.*worktree remove' '${GIT_LOG}' 2>/dev/null; true"
+run "T24g-c: guard-refused tree survives on disk" test -d "${GUARD_WT}"
+# Restore the standard lsof mock for subsequent phases.
+cat > "$MOCKBIN/lsof" <<'EOF'
+#!/usr/bin/env bash
+for a in "$@"; do
+  case "$a" in
+    1001) echo "n${GONE_DIR}" ;;
+    1002) echo "n${LIVE_DIR}" ;;
+  esac
+done
+EOF
+chmod +x "$MOCKBIN/lsof"
+
 # T25: orphan gitfile dir (backdated) -> rm -rf called, NOT git worktree remove
 ORPHAN_WT="${SWEEP_WT_ROOT}/ORPHAN-GF"
 mkdir -p "${ORPHAN_WT}"

--- a/plugins/dev/scripts/__tests__/orphan-sweep.test.sh
+++ b/plugins/dev/scripts/__tests__/orphan-sweep.test.sh
@@ -631,15 +631,26 @@ run "T24: empty symbolic-ref falls back to origin/main (EMPTY-SYMREF removed as 
 
 # T24g (CTL-1417): SAFE tree with a live foreign holder -> guard REFUSES the
 # force-remove (skip + activeSkipped), never force-removes an in-use worktree.
-# Override lsof so the guard's `-nP +D <path>` probe reports a live holder
-# (rc=0 + non-empty). The proc-kill vector still passes PID args, so keep its
+# Override lsof so the guard's `-nP -F pn +D <path>` probe reports a live
+# holder in the field-output format the guard now parses: one `p<pid>` line
+# per holder plus an `n<path>` line. The pid is a FABRICATED foreign pid
+# (99999 — not this shell or an ancestor), so the guard's self-exclusion
+# cannot mistake it for its own process tree and it refuses (rc=0 + a
+# foreign `p` line). The proc-kill vector still passes PID args, so keep its
 # original 1001/1002 mapping as the fallback branch.
 cat > "$MOCKBIN/lsof" <<'EOF'
 #!/usr/bin/env bash
+# The path being probed is the argument immediately after `+D`.
+target=""; prev=""
+for a in "$@"; do
+  [[ "$prev" == "+D" ]] && target="$a"
+  prev="$a"
+done
 for a in "$@"; do
   if [[ "$a" == "+D" ]]; then
-    # worktree-remove-guard foreign-liveness probe: report a live holder.
-    echo "claude 9999 user cwd DIR held-open"
+    # worktree-remove-guard foreign-liveness probe: report a live holder in
+    # `-F pn` format — a foreign pid line + the held path under the target.
+    printf 'p99999\nn%s/held-open\n' "${target:-$PWD}"
     exit 0
   fi
 done
@@ -659,7 +670,7 @@ rm -f "$GIT_LOG"
 run "T24g: guard-refused SAFE tree logs skip (live handle)" \
   bash -c "SWEEP_FORCE_POWER=1 SWEEP_IDLE_HOURS=9999 SWEEP_PROJECT_CLAUDE_WT=/nonexistent SWEEP_INCLUDE_GLOBAL_CLAUDE_WT=0 bash '${SWEEP}' 2>&1 | grep -qi 'guard refused'"
 run "T24g-b: guard-refused GUARD-REFUSE NOT in git worktree remove log" \
-  bash -c "! grep -E 'worktree remove.*GUARD-REFUSE|GUARD-REFUSE.*worktree remove' '${GIT_LOG}' 2>/dev/null; true"
+  bash -c "! grep -E 'worktree remove.*GUARD-REFUSE|GUARD-REFUSE.*worktree remove' '${GIT_LOG}' 2>/dev/null"
 run "T24g-c: guard-refused tree survives on disk" test -d "${GUARD_WT}"
 # Restore the standard lsof mock for subsequent phases.
 cat > "$MOCKBIN/lsof" <<'EOF'

--- a/plugins/dev/scripts/__tests__/phase-agent-dispatch.test.sh
+++ b/plugins/dev/scripts/__tests__/phase-agent-dispatch.test.sh
@@ -1344,12 +1344,28 @@ FAIL_REASON37="$(jq -r '.failureReason' "$VSIGNAL")"
 assert_eq "thoughts_conflict_with_origin_main" "$FAIL_REASON37" "thoughts verify: failureReason=thoughts_conflict_with_origin_main"
 unset CATALYST_DIR
 
-# ─── Test 38 (CTL-707): source conflict on plan → recreate worktree, re-dispatch
-# Uses a REAL git linked worktree (git worktree add) so the recreate path can
-# resolve REPO_ROOT via --git-common-dir and call create-worktree.sh correctly.
+# ─── CTL-1417: deterministic mock lsof for the recreate self-protection guard ─
+# The recreate path calls assert_worktree_removal_safe, which shells out to lsof
+# via WT_GUARD_LSOF. Point it at a mock driven by STUB_LSOF_RC / STUB_LSOF_OUT so
+# the guard never probes real processes against $SCRATCH.
+GUARD_MOCK_LSOF="${SCRATCH}/mock-lsof"
+cat >"$GUARD_MOCK_LSOF" <<'MOCK'
+#!/usr/bin/env bash
+printf '%s' "${STUB_LSOF_OUT:-}"
+exit "${STUB_LSOF_RC:-1}"
+MOCK
+chmod +x "$GUARD_MOCK_LSOF"
+
+# ─── Test 38 / T38b (CTL-707 + CTL-1417): source conflict on research → recreate
+# worktree, re-dispatch. Uses a REAL git linked worktree (git worktree add) so
+# the recreate path can resolve REPO_ROOT via --git-common-dir and call
+# create-worktree.sh correctly. T38b: the CTL-1417 removal guard is wired but
+# nothing foreign holds the tree (mock lsof rc=1/empty), so the guard ALLOWS the
+# --force removal and the recreate proceeds exactly as before.
 echo ""
-echo "Test 38 (CTL-707): source conflict on research → worktree recreated, worker spawned (no --resume)"
+echo "Test 38/T38b (CTL-707/CTL-1417): source conflict → recreated + spawned; guard does not block (lsof clear)"
 fresh_env t38_plan_recreate
+export WT_GUARD_LSOF="$GUARD_MOCK_LSOF" STUB_LSOF_RC=1 STUB_LSOF_OUT=""
 export CATALYST_DIR="${TEST_DIR}/catalyst-events"
 mkdir -p "${CATALYST_DIR}/events"
 
@@ -1413,6 +1429,61 @@ assert_eq "yes" "$([[ $NEW_HEAD != "$ORIG_HEAD" ]] && echo yes || echo no)" \
 	"recreate: worktree HEAD changed (recreated from origin/main)"
 unset CATALYST_DIR
 unset CATALYST_RECREATE_WORKTREE_DIR
+unset WT_GUARD_LSOF STUB_LSOF_RC STUB_LSOF_OUT
+
+# ─── T38c (CTL-1417): recreate is REFUSED when a foreign holder is present ─────
+# Same source-conflict-on-research fixture as Test 38, but the mock lsof reports
+# a live handle under the target (rc=0 + output). The self-protection guard must
+# refuse the --force removal, so the dispatcher parks status:"stalled", does NOT
+# re-dispatch (claude --bg not invoked), and the worktree stays on disk.
+echo ""
+echo "T38c (CTL-1417): foreign holder under worktree → recreate refused, parked stalled, tree kept"
+fresh_env t38c_recreate_guard
+export CATALYST_DIR="${TEST_DIR}/catalyst-events"
+mkdir -p "${CATALYST_DIR}/events"
+
+T38C_ORIGIN="${TEST_DIR}/t38c-origin.git"
+T38C_UP="${TEST_DIR}/t38c-up"
+T38C_MAIN="${TEST_DIR}/t38c-main"
+T38C_WT_BASE="${TEST_DIR}/t38c-wt"
+GWORKC="${T38C_WT_BASE}/CTL-100"
+git init --quiet --bare -b main "$T38C_ORIGIN"
+git clone --quiet "$T38C_ORIGIN" "$T38C_UP" 2>/dev/null
+(
+	cd "$T38C_UP"
+	printf 'base-line\n' >shared.txt
+	mkdir -p .catalyst
+	git add -A && git commit --quiet -m "initial"
+	git push --quiet origin main
+)
+git clone --quiet "$T38C_ORIGIN" "$T38C_MAIN" 2>/dev/null
+mkdir -p "$T38C_WT_BASE"
+(cd "$T38C_MAIN" && git worktree add --quiet -b CTL-100 "$GWORKC" main 2>/dev/null)
+(
+	cd "$GWORKC"
+	printf 'local-edit\n' >shared.txt
+	git add shared.txt && git commit --quiet -m "local source change"
+)
+(
+	cd "$T38C_UP" && git checkout --quiet main
+	printf 'upstream-edit\n' >shared.txt
+	mkdir -p thoughts/shared/research
+	printf '# research\n' >thoughts/shared/research/2026-05-28-ctl-100.md
+	git add -A && git commit --quiet -m "upstream: conflict + research artifact"
+	git push --quiet origin main
+)
+export CATALYST_RECREATE_WORKTREE_DIR="$T38C_WT_BASE"
+# Foreign holder present → guard refuses.
+export WT_GUARD_LSOF="$GUARD_MOCK_LSOF" STUB_LSOF_RC=0 STUB_LSOF_OUT="p4242"
+printf '{"ticket":"CTL-100","phase":"triage","status":"done"}\n' >"${WORKER_DIR}/triage.json"
+: >"$CLAUDE_STUB_LOG"
+(cd "$GWORKC" && CATALYST_BASE_BRANCH=main "$DISPATCH" --phase research --ticket CTL-100 \
+	--orch-dir "$ORCH_DIR" --orch-id orch-test >"${TEST_DIR}/t38c.out" 2>/dev/null)
+SIGNAL_C="${WORKER_DIR}/phase-research.json"
+assert_eq "stalled" "$(jq -r '.status' "$SIGNAL_C" 2>/dev/null)" "T38c: guard refusal parks status:stalled"
+assert_eq "no" "$([[ -s $CLAUDE_STUB_LOG ]] && echo yes || echo no)" "T38c: claude --bg NOT invoked (no re-dispatch)"
+assert_eq "yes" "$([[ -d $GWORKC ]] && echo yes || echo no)" "T38c: worktree still exists on disk (not force-removed)"
+unset CATALYST_DIR CATALYST_RECREATE_WORKTREE_DIR WT_GUARD_LSOF STUB_LSOF_RC STUB_LSOF_OUT
 
 # ─── Test 39 (CTL-707): fetch failure on plan → proceed un-rebased, worker spawned
 echo ""
@@ -1910,12 +1981,17 @@ echo "Test 58 (CTL-777): empty context var is OMITTED (no null key) while others
 fresh_env t58
 # Run the composer directly with GENERATION empty but ORCH_DIR present so we can
 # assert the ==\"\" omission pattern holds for the new keys too.
+# Extract to a temp file and source THAT — `source <(...)` process substitution
+# fails to define multi-line functions under macOS system bash 3.2 (the repo
+# dogfoods on macOS), so the earlier form left compose_worker_settings_json
+# undefined and produced empty output. A temp file is portable across bash 3.2+.
+T58_FN="${TEST_DIR}/compose-fn.sh"
+sed -n '/^compose_worker_settings_json()/,/^}/p' "$DISPATCH" >"$T58_FN"
 SETTINGS_T58=$(
 	ORCH_DIR="${ORCH_DIR}" ORCH_ID="orch-test" PHASE="triage" TICKET="CTL-100" \
 		GENERATION="" SCRIPT_DIR="${TEST_DIR}/bin" OTEL_RES_ATTRS="" \
-		bash -c '
-      source <(sed -n "/^compose_worker_settings_json()/,/^}/p" "'"$DISPATCH"'")
-      compose_worker_settings_json'
+		CATALYST_CLUSTER_GENERATION="" \
+		bash -c 'source "'"$T58_FN"'"; compose_worker_settings_json'
 )
 T58_HAS_GEN=$(echo "$SETTINGS_T58" | jq -r '.env | has("CATALYST_GENERATION")' 2>/dev/null)
 T58_HAS_ODIR=$(echo "$SETTINGS_T58" | jq -r '.env | has("CATALYST_ORCHESTRATOR_DIR")' 2>/dev/null)

--- a/plugins/dev/scripts/__tests__/phase-agent-dispatch.test.sh
+++ b/plugins/dev/scripts/__tests__/phase-agent-dispatch.test.sh
@@ -19,6 +19,26 @@ PASSES=0
 SCRATCH="$(mktemp -d -t phase-agent-dispatch-test-XXXXXX)"
 trap 'rm -rf "$SCRATCH"' EXIT
 
+# ─── CTL-1417: hermeticity floor ─────────────────────────────────────────────
+# Mirror the orphan-sweep.test.sh:18 gold standard + worktree-rebase.test.sh:20-27
+# pattern: a scratch HOME, neutered global/system git config, and a pinned
+# recreate worktree base. This guarantees that even a future code path computing
+# "$HOME/catalyst/wt/..." resolves inside SCRATCH, never the operator's real
+# worktree — closing the env-leak vector behind the CTL-1417 data-loss incident.
+export HOME="${SCRATCH}/home"
+mkdir -p "$HOME"
+export GIT_CONFIG_GLOBAL=/dev/null GIT_CONFIG_SYSTEM=/dev/null
+export GIT_AUTHOR_NAME=test GIT_AUTHOR_EMAIL=test@test
+export GIT_COMMITTER_NAME=test GIT_COMMITTER_EMAIL=test@test
+export GIT_EDITOR=true GIT_SEQUENCE_EDITOR=true
+# Pin the recreate worktree base under scratch (belt for Test 38's own override).
+export CATALYST_RECREATE_WORKTREE_DIR="${SCRATCH}/recreate-wt"
+# Canary: prove the isolation is actually in effect (fails loud if HOME leaks).
+[[ "$HOME" == "$SCRATCH"/* ]] || {
+	echo "FAIL: HOME not isolated to scratch"
+	exit 1
+}
+
 fail() {
 	FAILURES=$((FAILURES + 1))
 	echo "  FAIL: $1"
@@ -1428,7 +1448,8 @@ NEW_HEAD="$(cd "$GWORK" && git rev-parse HEAD 2>/dev/null || echo missing)"
 assert_eq "yes" "$([[ $NEW_HEAD != "$ORIG_HEAD" ]] && echo yes || echo no)" \
 	"recreate: worktree HEAD changed (recreated from origin/main)"
 unset CATALYST_DIR
-unset CATALYST_RECREATE_WORKTREE_DIR
+# Restore the scratch belt (Test 38 overrode it with its own base above).
+export CATALYST_RECREATE_WORKTREE_DIR="${SCRATCH}/recreate-wt"
 unset WT_GUARD_LSOF STUB_LSOF_RC STUB_LSOF_OUT
 
 # ─── T38c (CTL-1417): recreate is REFUSED when a foreign holder is present ─────
@@ -1483,7 +1504,9 @@ SIGNAL_C="${WORKER_DIR}/phase-research.json"
 assert_eq "stalled" "$(jq -r '.status' "$SIGNAL_C" 2>/dev/null)" "T38c: guard refusal parks status:stalled"
 assert_eq "no" "$([[ -s $CLAUDE_STUB_LOG ]] && echo yes || echo no)" "T38c: claude --bg NOT invoked (no re-dispatch)"
 assert_eq "yes" "$([[ -d $GWORKC ]] && echo yes || echo no)" "T38c: worktree still exists on disk (not force-removed)"
-unset CATALYST_DIR CATALYST_RECREATE_WORKTREE_DIR WT_GUARD_LSOF STUB_LSOF_RC STUB_LSOF_OUT
+unset CATALYST_DIR WT_GUARD_LSOF STUB_LSOF_RC STUB_LSOF_OUT
+# Restore the scratch belt (T38c overrode it with its own base above).
+export CATALYST_RECREATE_WORKTREE_DIR="${SCRATCH}/recreate-wt"
 
 # ─── Test 39 (CTL-707): fetch failure on plan → proceed un-rebased, worker spawned
 echo ""

--- a/plugins/dev/scripts/__tests__/phase-agent-dispatch.test.sh
+++ b/plugins/dev/scripts/__tests__/phase-agent-dispatch.test.sh
@@ -1508,6 +1508,11 @@ assert_eq "no" "$([[ -s $CLAUDE_STUB_LOG ]] && echo yes || echo no)" "recreate-g
 assert_eq "yes" "$([[ -d $GWORK_C ]] && echo yes || echo no)" "recreate-guard: worktree survives on disk (not force-removed)"
 assert_eq "$ORIG_HEAD_C" "$(cd "$GWORK_C" && git rev-parse HEAD 2>/dev/null || echo missing)" \
 	"recreate-guard: worktree HEAD unchanged (not destroyed/recreated)"
+# CTL-1417: a guard refusal caused by a LIVE HANDLE must park with a dedicated
+# reason (NOT the generic source_conflict_ctl708_unavailable, which unstuck-sweep
+# routes to force-push-if-clean and would explain the wrong blocker).
+assert_eq "worktree_live_handle_guard_refused" "$(jq -r '.failureReason' "$SIGNAL_C" 2>/dev/null)" \
+	"recreate-guard: failureReason = worktree_live_handle_guard_refused (accurate blocker)"
 unset CATALYST_DIR
 unset CATALYST_RECREATE_WORKTREE_DIR
 

--- a/plugins/dev/scripts/__tests__/phase-agent-dispatch.test.sh
+++ b/plugins/dev/scripts/__tests__/phase-agent-dispatch.test.sh
@@ -139,6 +139,24 @@ fresh_env() {
 	export PATH="${STUB_DIR}:${PATH}"
 }
 
+# ─── CTL-1417: deterministic lsof seam for the worktree-removal guard ─────────
+# phase-agent-dispatch's recreate path now routes its `git worktree remove
+# --force` through assert_worktree_removal_safe, whose foreign-liveness check
+# shells out to lsof. Point it at a mock whose rc/stdout are env-driven
+# (MOCK_LSOF_RC / MOCK_LSOF_OUT) so the recreate tests are deterministic and
+# never probe the real process table against $SCRATCH. Default rc=1 + empty =
+# "nothing under the tree" = guard ALLOWS (the legitimate recreate). Without
+# this seam the test's own `(cd "$GWORK" && …)` subshell holds a live cwd handle
+# under the tree, so real lsof would (correctly) make the guard refuse.
+MOCK_LSOF="${SCRATCH}/mock-lsof"
+cat >"$MOCK_LSOF" <<'MLSOF'
+#!/usr/bin/env bash
+[[ -n "${MOCK_LSOF_OUT:-}" ]] && printf '%s\n' "$MOCK_LSOF_OUT"
+exit "${MOCK_LSOF_RC:-1}"
+MLSOF
+chmod +x "$MOCK_LSOF"
+export WT_GUARD_LSOF="$MOCK_LSOF"
+
 # ─── Test 1: dispatcher writes the per-phase signal file with the right schema
 echo "Test 1: dispatcher writes signal file with correct schema"
 fresh_env t1
@@ -1411,6 +1429,69 @@ assert_not_contains "$LOG38" "--resume" "recreate: no --resume-session in claude
 NEW_HEAD="$(cd "$GWORK" && git rev-parse HEAD 2>/dev/null || echo missing)"
 assert_eq "yes" "$([[ $NEW_HEAD != "$ORIG_HEAD" ]] && echo yes || echo no)" \
 	"recreate: worktree HEAD changed (recreated from origin/main)"
+# T38b (CTL-1417): with the guard's lsof seam reporting rc=1/empty (nothing under
+# the tree), the recreate proceeded normally — the guard did NOT block the
+# legitimate destroy+recreate. The claude-invoked + HEAD-changed asserts above
+# ARE the happy-path proof.
+unset CATALYST_DIR
+unset CATALYST_RECREATE_WORKTREE_DIR
+
+# ─── Test 38c (CTL-1417): recreate REFUSED when a foreign holder is present ───
+# Same source-conflict-on-research fixture as Test 38, but the guard's lsof seam
+# reports a live handle under the doomed worktree (rc=0 + non-empty). The
+# recreate must NOT force-remove the tree; it parks `stalled`, does not
+# re-dispatch, and the worktree survives on disk.
+echo ""
+echo "Test 38c (CTL-1417): recreate refused (foreign holder) → parks stalled, worktree survives"
+fresh_env t38c_recreate_guard
+export CATALYST_DIR="${TEST_DIR}/catalyst-events"
+mkdir -p "${CATALYST_DIR}/events"
+
+T38C_ORIGIN="${TEST_DIR}/t38c-origin.git"
+T38C_UP="${TEST_DIR}/t38c-up"
+T38C_MAIN="${TEST_DIR}/t38c-main"
+T38C_WT_BASE="${TEST_DIR}/t38c-wt"
+GWORK_C="${T38C_WT_BASE}/CTL-100"
+git init --quiet --bare -b main "$T38C_ORIGIN"
+git clone --quiet "$T38C_ORIGIN" "$T38C_UP" 2>/dev/null
+(
+	cd "$T38C_UP"
+	printf 'base-line\n' >shared.txt
+	mkdir -p .catalyst
+	git add -A && git commit --quiet -m "initial"
+	git push --quiet origin main
+)
+git clone --quiet "$T38C_ORIGIN" "$T38C_MAIN" 2>/dev/null
+mkdir -p "$T38C_WT_BASE"
+(cd "$T38C_MAIN" && git worktree add --quiet -b CTL-100 "$GWORK_C" main 2>/dev/null)
+(
+	cd "$GWORK_C"
+	printf 'local-edit\n' >shared.txt
+	git add shared.txt && git commit --quiet -m "local source change"
+)
+(
+	cd "$T38C_UP" && git checkout --quiet main
+	printf 'upstream-edit\n' >shared.txt
+	mkdir -p thoughts/shared/research
+	printf '# research\n' >thoughts/shared/research/2026-05-28-ctl-100.md
+	git add -A && git commit --quiet -m "upstream: conflict + research artifact"
+	git push --quiet origin main
+)
+export CATALYST_RECREATE_WORKTREE_DIR="$T38C_WT_BASE"
+printf '{"ticket":"CTL-100","phase":"triage","status":"done"}\n' >"${WORKER_DIR}/triage.json"
+ORIG_HEAD_C="$(cd "$GWORK_C" && git rev-parse HEAD)"
+# MOCK_LSOF_RC=0 + non-empty output → guard sees a live foreign holder → refuse.
+(cd "$GWORK_C" && CATALYST_BASE_BRANCH=main MOCK_LSOF_RC=0 MOCK_LSOF_OUT="p9999" \
+	"$DISPATCH" --phase research --ticket CTL-100 \
+	--orch-dir "$ORCH_DIR" --orch-id orch-test >"${TEST_DIR}/t38c.out" 2>/dev/null)
+RC38C=$?
+SIGNAL_C="${WORKER_DIR}/phase-research.json"
+assert_eq "1" "$RC38C" "recreate-guard: dispatcher exits 1 (parked, not re-dispatched)"
+assert_eq "stalled" "$(jq -r '.status' "$SIGNAL_C" 2>/dev/null)" "recreate-guard: signal status = stalled"
+assert_eq "no" "$([[ -s $CLAUDE_STUB_LOG ]] && echo yes || echo no)" "recreate-guard: claude --bg was NOT invoked"
+assert_eq "yes" "$([[ -d $GWORK_C ]] && echo yes || echo no)" "recreate-guard: worktree survives on disk (not force-removed)"
+assert_eq "$ORIG_HEAD_C" "$(cd "$GWORK_C" && git rev-parse HEAD 2>/dev/null || echo missing)" \
+	"recreate-guard: worktree HEAD unchanged (not destroyed/recreated)"
 unset CATALYST_DIR
 unset CATALYST_RECREATE_WORKTREE_DIR
 

--- a/plugins/dev/scripts/__tests__/phase-agent-dispatch.test.sh
+++ b/plugins/dev/scripts/__tests__/phase-agent-dispatch.test.sh
@@ -19,6 +19,22 @@ PASSES=0
 SCRATCH="$(mktemp -d -t phase-agent-dispatch-test-XXXXXX)"
 trap 'rm -rf "$SCRATCH"' EXIT
 
+# CTL-1417: hermeticity floor. Isolate HOME and neuter global/system git config
+# so no production code path that computes $HOME/catalyst/wt/... (e.g. the CTL-707
+# recreate's create-worktree.sh) can resolve to the operator's REAL worktree —
+# the worktree self-deletion vector. Mirrors the orphan-sweep.test.sh /
+# worktree-rebase.test.sh gold standard. Also pin the recreate worktree base
+# under scratch as a belt to Test 38's own CATALYST_RECREATE_WORKTREE_DIR.
+export HOME="${SCRATCH}/home"
+mkdir -p "$HOME"
+export GIT_CONFIG_GLOBAL=/dev/null GIT_CONFIG_SYSTEM=/dev/null
+export CATALYST_RECREATE_WORKTREE_DIR="${SCRATCH}/recreate-wt"
+# Red canary: fail loudly if the isolation is ever not in effect.
+[[ "$HOME" == "$SCRATCH"/* ]] || {
+	echo "FAIL: HOME not isolated to scratch"
+	exit 1
+}
+
 fail() {
 	FAILURES=$((FAILURES + 1))
 	echo "  FAIL: $1"

--- a/plugins/dev/scripts/__tests__/phase-teardown-e2e.test.sh
+++ b/plugins/dev/scripts/__tests__/phase-teardown-e2e.test.sh
@@ -79,8 +79,8 @@ mkdir -p "$HOME"
 export GIT_CONFIG_GLOBAL=/dev/null GIT_CONFIG_SYSTEM=/dev/null
 # Canary: prove the isolation is actually in effect (fails loud if HOME leaks).
 [[ "$HOME" == "$TMPROOT"/* ]] || {
-  echo "FAIL: HOME not isolated to scratch"
-  exit 1
+	echo "FAIL: HOME not isolated to scratch"
+	exit 1
 }
 
 # ─── Helper: build a throwaway git repo + linked worktree ───────────────────

--- a/plugins/dev/scripts/__tests__/phase-teardown-e2e.test.sh
+++ b/plugins/dev/scripts/__tests__/phase-teardown-e2e.test.sh
@@ -69,6 +69,20 @@ fi
 TMPROOT="$(mktemp -d -t phase-teardown-test.XXXXXX)"
 trap 'rm -rf "$TMPROOT" "$SKILL_BODY_FILE"' EXIT
 
+# ─── CTL-1417: hermeticity floor ─────────────────────────────────────────────
+# A scratch HOME + neutered global/system git config as a belt around the
+# per-skill-run FAKE_HOME already injected below — so any code path OUTSIDE
+# those subshells that computes "$HOME/catalyst/..." resolves under TMPROOT,
+# never the operator's real tree (the CTL-1417 data-loss vector).
+export HOME="${TMPROOT}/home"
+mkdir -p "$HOME"
+export GIT_CONFIG_GLOBAL=/dev/null GIT_CONFIG_SYSTEM=/dev/null
+# Canary: prove the isolation is actually in effect (fails loud if HOME leaks).
+[[ "$HOME" == "$TMPROOT"/* ]] || {
+  echo "FAIL: HOME not isolated to scratch"
+  exit 1
+}
+
 # ─── Helper: build a throwaway git repo + linked worktree ───────────────────
 # Returns the path to the PRIMARY worktree (the repo) via stdout.
 # The TICKET worktree is at <primary>/../wt/<ticket>.

--- a/plugins/dev/scripts/__tests__/phase-teardown-e2e.test.sh
+++ b/plugins/dev/scripts/__tests__/phase-teardown-e2e.test.sh
@@ -69,6 +69,19 @@ fi
 TMPROOT="$(mktemp -d -t phase-teardown-test.XXXXXX)"
 trap 'rm -rf "$TMPROOT" "$SKILL_BODY_FILE"' EXIT
 
+# CTL-1417: hermeticity floor (belt outside the per-case HOME="$FAKE_HOME"
+# subshells below). Isolate HOME and neuter global/system git config so no code
+# path outside those subshells can resolve a production $HOME/catalyst/wt/...
+# target to the operator's real worktree — the worktree self-deletion vector.
+export HOME="${TMPROOT}/home"
+mkdir -p "$HOME"
+export GIT_CONFIG_GLOBAL=/dev/null GIT_CONFIG_SYSTEM=/dev/null
+# Red canary: fail loudly if the isolation is ever not in effect.
+[[ "$HOME" == "$TMPROOT"/* ]] || {
+	echo "FAIL: HOME not isolated to scratch"
+	exit 1
+}
+
 # ─── Helper: build a throwaway git repo + linked worktree ───────────────────
 # Returns the path to the PRIMARY worktree (the repo) via stdout.
 # The TICKET worktree is at <primary>/../wt/<ticket>.

--- a/plugins/dev/scripts/__tests__/worktree-remove-guard-lib.test.sh
+++ b/plugins/dev/scripts/__tests__/worktree-remove-guard-lib.test.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+# Wrapper so run-tests.sh's scripts/__tests__ glob discovers the lib suite (CTL-1417).
+set -uo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+exec bash "${SCRIPT_DIR}/../lib/__tests__/worktree-remove-guard.test.sh"

--- a/plugins/dev/scripts/__tests__/worktree-remove-guard-lib.test.sh
+++ b/plugins/dev/scripts/__tests__/worktree-remove-guard-lib.test.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+# Wrapper so run-tests.sh discovers the lib/__tests__ worktree-remove-guard suite (CTL-1417).
+set -uo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+exec bash "${SCRIPT_DIR}/../lib/__tests__/worktree-remove-guard.test.sh"

--- a/plugins/dev/scripts/create-worktree.sh
+++ b/plugins/dev/scripts/create-worktree.sh
@@ -219,6 +219,10 @@ fi
 # This ensures .catalyst/.workflow-context.json exists with currentTicket set
 # so that direnv's use_otel_context can read it when someone enters the directory.
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# CTL-1417: self-protection guard for the two --force rollback removals below.
+# shellcheck source=lib/worktree-remove-guard.sh
+[ -r "${SCRIPT_DIR}/lib/worktree-remove-guard.sh" ] &&
+	source "${SCRIPT_DIR}/lib/worktree-remove-guard.sh"
 if [ -f "${SCRIPT_DIR}/workflow-context.sh" ]; then
 	# Remove stale workflow-context.json if copied from main repo
 	rm -f "${WORKTREE_PATH}/.catalyst/.workflow-context.json"
@@ -359,7 +363,15 @@ else
 			SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 			[ -x "$SCRIPT_DIR/lib/worktree-presweep.sh" ] &&
 				"$SCRIPT_DIR/lib/worktree-presweep.sh" --force "$WORKTREE_PATH" 2>/dev/null || true
-			git worktree remove --force "$WORKTREE_PATH"
+			# CTL-1417: cwd already left the tree (cd - above); the guard's
+			# foreign-liveness check is the operative protection. On refusal,
+			# leave the tree for the reaper rather than force-deleting an in-use one.
+			if ! command -v assert_worktree_removal_safe >/dev/null 2>&1 ||
+				assert_worktree_removal_safe "$WORKTREE_PATH"; then
+				git worktree remove --force "$WORKTREE_PATH"
+			else
+				echo "create-worktree: guard refused removal of ${WORKTREE_PATH}; leaving for reaper" >&2
+			fi
 			git branch -D "$WORKTREE_NAME" 2>/dev/null || true
 			exit 1
 		fi
@@ -431,7 +443,13 @@ if [ "$THOUGHTS_INIT_EXPECTED" = true ] && [ ! -d "thoughts/shared" ]; then
 	SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 	[ -x "$SCRIPT_DIR/lib/worktree-presweep.sh" ] &&
 		"$SCRIPT_DIR/lib/worktree-presweep.sh" --force "$WORKTREE_PATH" 2>/dev/null || true
-	git worktree remove --force "$WORKTREE_PATH"
+	# CTL-1417: guard the --force removal (cwd already left via cd - above).
+	if ! command -v assert_worktree_removal_safe >/dev/null 2>&1 ||
+		assert_worktree_removal_safe "$WORKTREE_PATH"; then
+		git worktree remove --force "$WORKTREE_PATH"
+	else
+		echo "create-worktree: guard refused removal of ${WORKTREE_PATH}; leaving for reaper" >&2
+	fi
 	git branch -D "$WORKTREE_NAME" 2>/dev/null || true
 	exit 1
 fi

--- a/plugins/dev/scripts/create-worktree.sh
+++ b/plugins/dev/scripts/create-worktree.sh
@@ -254,6 +254,21 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # CTL-1417: self-protection guard for the rollback --force removals below.
 # shellcheck source=lib/worktree-remove-guard.sh
 [ -r "${SCRIPT_DIR}/lib/worktree-remove-guard.sh" ] && source "${SCRIPT_DIR}/lib/worktree-remove-guard.sh"
+
+# _removal_guard_ok <path> — the SINGLE fail-closed predicate the rollback
+# `git worktree remove --force` sites gate on (CTL-1417). Returns 0 (safe to
+# force-remove) ONLY when the guard function loaded AND cleared the path.
+# Guard-ABSENCE (lib missing/unreadable at source-time → function undefined) is a
+# REFUSAL, not a bypass — a stripped/broken checkout can never reopen the
+# data-loss path. Reason on stderr.
+_removal_guard_ok() {
+	local _wt="${1:-}"
+	if ! command -v assert_worktree_removal_safe >/dev/null 2>&1; then
+		echo "worktree-remove-guard: unavailable — refusing forced removal of ${_wt}" >&2
+		return 1
+	fi
+	assert_worktree_removal_safe "$_wt"
+}
 if [ -f "${SCRIPT_DIR}/workflow-context.sh" ]; then
 	# Remove stale workflow-context.json if copied from main repo
 	rm -f "${WORKTREE_PATH}/.catalyst/.workflow-context.json"
@@ -394,13 +409,14 @@ else
 			SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 			[ -x "$SCRIPT_DIR/lib/worktree-presweep.sh" ] &&
 				"$SCRIPT_DIR/lib/worktree-presweep.sh" --force "$WORKTREE_PATH" 2>/dev/null || true
-			# CTL-1417: skip the force-remove if the tree is in use / is our cwd,
-			# leaving it for the reaper rather than deleting an in-use worktree.
-			if ! command -v assert_worktree_removal_safe >/dev/null 2>&1 || assert_worktree_removal_safe "$WORKTREE_PATH"; then
+			# CTL-1417: skip the force-remove if the tree is in use / is our cwd
+			# OR the guard is unavailable (fail-closed), leaving it for the reaper
+			# rather than deleting an in-use worktree.
+			if _removal_guard_ok "$WORKTREE_PATH"; then
 				git worktree remove --force "$WORKTREE_PATH"
 				git branch -D "$WORKTREE_NAME" 2>/dev/null || true
 			else
-				echo "create-worktree: guard refused removal of ${WORKTREE_PATH}; leaving for reaper" >&2
+				echo "create-worktree: guard refused/unavailable for ${WORKTREE_PATH}; leaving for reaper" >&2
 			fi
 			exit 1
 		fi
@@ -472,13 +488,14 @@ if [ "$THOUGHTS_INIT_EXPECTED" = true ] && { [ ! -L "thoughts/shared" ] || [ ! -
 	SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 	[ -x "$SCRIPT_DIR/lib/worktree-presweep.sh" ] &&
 		"$SCRIPT_DIR/lib/worktree-presweep.sh" --force "$WORKTREE_PATH" 2>/dev/null || true
-	# CTL-1417: skip the force-remove if the tree is in use / is our cwd,
-	# leaving it for the reaper rather than deleting an in-use worktree.
-	if ! command -v assert_worktree_removal_safe >/dev/null 2>&1 || assert_worktree_removal_safe "$WORKTREE_PATH"; then
+	# CTL-1417: skip the force-remove if the tree is in use / is our cwd OR the
+	# guard is unavailable (fail-closed), leaving it for the reaper rather than
+	# deleting an in-use worktree.
+	if _removal_guard_ok "$WORKTREE_PATH"; then
 		git worktree remove --force "$WORKTREE_PATH"
 		git branch -D "$WORKTREE_NAME" 2>/dev/null || true
 	else
-		echo "create-worktree: guard refused removal of ${WORKTREE_PATH}; leaving for reaper" >&2
+		echo "create-worktree: guard refused/unavailable for ${WORKTREE_PATH}; leaving for reaper" >&2
 	fi
 	exit 1
 fi

--- a/plugins/dev/scripts/create-worktree.sh
+++ b/plugins/dev/scripts/create-worktree.sh
@@ -251,6 +251,9 @@ fi
 # This ensures .catalyst/.workflow-context.json exists with currentTicket set
 # so that direnv's use_otel_context can read it when someone enters the directory.
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# CTL-1417: self-protection guard for the rollback --force removals below.
+# shellcheck source=lib/worktree-remove-guard.sh
+[ -r "${SCRIPT_DIR}/lib/worktree-remove-guard.sh" ] && source "${SCRIPT_DIR}/lib/worktree-remove-guard.sh"
 if [ -f "${SCRIPT_DIR}/workflow-context.sh" ]; then
 	# Remove stale workflow-context.json if copied from main repo
 	rm -f "${WORKTREE_PATH}/.catalyst/.workflow-context.json"
@@ -391,8 +394,14 @@ else
 			SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 			[ -x "$SCRIPT_DIR/lib/worktree-presweep.sh" ] &&
 				"$SCRIPT_DIR/lib/worktree-presweep.sh" --force "$WORKTREE_PATH" 2>/dev/null || true
-			git worktree remove --force "$WORKTREE_PATH"
-			git branch -D "$WORKTREE_NAME" 2>/dev/null || true
+			# CTL-1417: skip the force-remove if the tree is in use / is our cwd,
+			# leaving it for the reaper rather than deleting an in-use worktree.
+			if ! command -v assert_worktree_removal_safe >/dev/null 2>&1 || assert_worktree_removal_safe "$WORKTREE_PATH"; then
+				git worktree remove --force "$WORKTREE_PATH"
+				git branch -D "$WORKTREE_NAME" 2>/dev/null || true
+			else
+				echo "create-worktree: guard refused removal of ${WORKTREE_PATH}; leaving for reaper" >&2
+			fi
 			exit 1
 		fi
 	elif [ -f "package.json" ]; then
@@ -463,8 +472,14 @@ if [ "$THOUGHTS_INIT_EXPECTED" = true ] && { [ ! -L "thoughts/shared" ] || [ ! -
 	SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 	[ -x "$SCRIPT_DIR/lib/worktree-presweep.sh" ] &&
 		"$SCRIPT_DIR/lib/worktree-presweep.sh" --force "$WORKTREE_PATH" 2>/dev/null || true
-	git worktree remove --force "$WORKTREE_PATH"
-	git branch -D "$WORKTREE_NAME" 2>/dev/null || true
+	# CTL-1417: skip the force-remove if the tree is in use / is our cwd,
+	# leaving it for the reaper rather than deleting an in-use worktree.
+	if ! command -v assert_worktree_removal_safe >/dev/null 2>&1 || assert_worktree_removal_safe "$WORKTREE_PATH"; then
+		git worktree remove --force "$WORKTREE_PATH"
+		git branch -D "$WORKTREE_NAME" 2>/dev/null || true
+	else
+		echo "create-worktree: guard refused removal of ${WORKTREE_PATH}; leaving for reaper" >&2
+	fi
 	exit 1
 fi
 

--- a/plugins/dev/scripts/lib/__tests__/worktree-remove-guard.test.sh
+++ b/plugins/dev/scripts/lib/__tests__/worktree-remove-guard.test.sh
@@ -22,8 +22,14 @@ PASSES=0
 SCRATCH="$(mktemp -d -t worktree-remove-guard-test-XXXXXX)"
 trap 'rm -rf "$SCRATCH"' EXIT
 
-pass() { PASSES=$((PASSES + 1)); echo "  PASS: $1"; }
-fail() { FAILURES=$((FAILURES + 1)); echo "  FAIL: $1"; }
+pass() {
+	PASSES=$((PASSES + 1))
+	echo "  PASS: $1"
+}
+fail() {
+	FAILURES=$((FAILURES + 1))
+	echo "  FAIL: $1"
+}
 
 # Source the unit under test. A missing lib is itself a Red failure, so tolerate
 # the source error and let the assertions report it rather than aborting.
@@ -32,61 +38,61 @@ source "$GUARD_LIB" 2>/dev/null || true
 
 # A stub lsof whose rc/stdout is driven by env, so branch (b) is deterministic.
 MOCK_LSOF="$SCRATCH/mock-lsof"
-cat >"$MOCK_LSOF" <<'EOF'
+cat >"$MOCK_LSOF" <<'MOCK'
 #!/usr/bin/env bash
 # mock lsof — emit $STUB_LSOF_OUT and exit $STUB_LSOF_RC (defaults: empty / rc=1).
 printf '%s' "${STUB_LSOF_OUT:-}"
 exit "${STUB_LSOF_RC:-1}"
-EOF
+MOCK
 chmod +x "$MOCK_LSOF"
 
 # guard_case runs the guard in an isolated subshell (own cwd + stub env) and
-# returns 0 iff the guard's allow/refuse verdict matches <expect>. The parent
-# owns the pass/fail counters (subshell-local increments would be lost).
+# records pass/fail iff the guard's allow/refuse verdict matches <expect>. The
+# subshell keeps every cwd/env mutation local to one case.
 #
-#   guard_case <refuse|allow> <cd_dir|-> <target> <lsof_rc> <lsof_out> [lsof_bin]
+#   guard_case <refuse|allow> <label> <cd_dir|-> <target> <lsof_rc> <lsof_out> [lsof_bin]
 guard_case() {
-	local expect="$1" cddir="$2" target="$3" rc_stub="$4" out_stub="$5" bin="${6:-$MOCK_LSOF}"
-	(
+	local expect="$1" label="$2" cddir="$3" target="$4" rc_stub="$5" out_stub="$6" bin="${7:-$MOCK_LSOF}"
+	local got
+	if (
 		[[ "$cddir" != "-" ]] && { cd "$cddir" || exit 2; }
 		export STUB_LSOF_RC="$rc_stub" STUB_LSOF_OUT="$out_stub" WT_GUARD_LSOF="$bin"
-		if assert_worktree_removal_safe "$target" 2>/dev/null; then
-			[[ "$expect" == "allow" ]]
-		else
-			[[ "$expect" == "refuse" ]]
-		fi
-	)
-}
-
-check() {
-	local label="$1"
-	shift
-	if "$@"; then pass "$label"; else fail "$label"; fi
+		assert_worktree_removal_safe "$target" 2>/dev/null
+	); then
+		got=allow
+	else
+		got=refuse
+	fi
+	if [[ "$got" == "$expect" ]]; then
+		pass "$label"
+	else
+		fail "$label (expected $expect, got $got)"
+	fi
 }
 
 mkdir -p "$SCRATCH/wt/sub" "$SCRATCH/other"
 
 # (guard) empty/blank target is refused.
-check "empty target refused" guard_case refuse - "" 1 ""
-check "blank target refused" guard_case refuse - "   " 1 ""
+guard_case refuse "empty target refused" - "" 1 ""
+guard_case refuse "blank target refused" - "   " 1 ""
 
 # (a) target == cwd is refused, even with lsof "clear" (rc=1/empty).
-check "cwd == target refused" guard_case refuse "$SCRATCH/wt" "$SCRATCH/wt" 1 ""
+guard_case refuse "cwd == target refused" "$SCRATCH/wt" "$SCRATCH/wt" 1 ""
 
 # (a) target is an ANCESTOR of cwd is refused (removing tree you stand inside).
-check "ancestor-of-cwd target refused" guard_case refuse "$SCRATCH/wt/sub" "$SCRATCH/wt" 1 ""
+guard_case refuse "ancestor-of-cwd target refused" "$SCRATCH/wt/sub" "$SCRATCH/wt" 1 ""
 
 # (a) trailing-slash normalization: "$SCRATCH/wt/" vs cwd "$SCRATCH/wt" still refuses.
-check "trailing-slash target refused" guard_case refuse "$SCRATCH/wt" "$SCRATCH/wt/" 1 ""
+guard_case refuse "trailing-slash target refused" "$SCRATCH/wt" "$SCRATCH/wt/" 1 ""
 
 # happy path: unrelated target, lsof rc=1 (nothing under tree) -> ALLOWED.
-check "unrelated + clear lsof allowed" guard_case allow "$SCRATCH" "$SCRATCH/other" 1 ""
+guard_case allow "unrelated + clear lsof allowed" "$SCRATCH" "$SCRATCH/other" 1 ""
 
 # (b) foreign holder present (lsof rc=0 + output) -> refused even though cwd is elsewhere.
-check "foreign live handle refused" guard_case refuse "$SCRATCH" "$SCRATCH/other" 0 "p1234"
+guard_case refuse "foreign live handle refused" "$SCRATCH" "$SCRATCH/other" 0 "p1234"
 
 # (b) fail-closed: lsof probe errors (missing binary, rc=127) -> refused.
-check "fail-closed on lsof probe error" guard_case refuse "$SCRATCH" "$SCRATCH/other" 1 "" /nonexistent/lsof
+guard_case refuse "fail-closed on lsof probe error" "$SCRATCH" "$SCRATCH/other" 1 "" /nonexistent/lsof
 
 echo ""
 echo "worktree-remove-guard: ${PASSES} passed / ${FAILURES} failed"

--- a/plugins/dev/scripts/lib/__tests__/worktree-remove-guard.test.sh
+++ b/plugins/dev/scripts/lib/__tests__/worktree-remove-guard.test.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+# Shell tests for lib/worktree-remove-guard.sh (CTL-1417) — the shell port of the
+# CTL-791 worktree-safety self-protection gate. `assert_worktree_removal_safe`
+# must refuse a `git worktree remove --force` whose target is the caller's own
+# cwd (at-or-under) OR is held by a live process, and be fail-closed when the
+# liveness probe cannot run.
+#
+# `lsof` is stubbed via WT_GUARD_LSOF pointing at a mock whose rc/stdout are
+# driven by STUB_LSOF_RC / STUB_LSOF_OUT, so branch (b) is deterministic and
+# never shells out to real lsof.
+#
+# Run: bash plugins/dev/scripts/lib/__tests__/worktree-remove-guard.test.sh
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+LIB_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+GUARD_LIB="$LIB_DIR/worktree-remove-guard.sh"
+
+FAILURES=0
+PASSES=0
+SCRATCH="$(mktemp -d -t worktree-remove-guard-test-XXXXXX)"
+trap 'rm -rf "$SCRATCH"' EXIT
+
+pass() { PASSES=$((PASSES + 1)); echo "  PASS: $1"; }
+fail() { FAILURES=$((FAILURES + 1)); echo "  FAIL: $1"; }
+
+# Source the unit under test. A missing lib is itself a Red failure, so tolerate
+# the source error and let the assertions report it rather than aborting.
+# shellcheck source=../worktree-remove-guard.sh
+source "$GUARD_LIB" 2>/dev/null || true
+
+# A stub lsof whose rc/stdout is driven by env, so branch (b) is deterministic.
+MOCK_LSOF="$SCRATCH/mock-lsof"
+cat >"$MOCK_LSOF" <<'EOF'
+#!/usr/bin/env bash
+# mock lsof — emit $STUB_LSOF_OUT and exit $STUB_LSOF_RC (defaults: empty / rc=1).
+printf '%s' "${STUB_LSOF_OUT:-}"
+exit "${STUB_LSOF_RC:-1}"
+EOF
+chmod +x "$MOCK_LSOF"
+
+# guard_case runs the guard in an isolated subshell (own cwd + stub env) and
+# returns 0 iff the guard's allow/refuse verdict matches <expect>. The parent
+# owns the pass/fail counters (subshell-local increments would be lost).
+#
+#   guard_case <refuse|allow> <cd_dir|-> <target> <lsof_rc> <lsof_out> [lsof_bin]
+guard_case() {
+	local expect="$1" cddir="$2" target="$3" rc_stub="$4" out_stub="$5" bin="${6:-$MOCK_LSOF}"
+	(
+		[[ "$cddir" != "-" ]] && { cd "$cddir" || exit 2; }
+		export STUB_LSOF_RC="$rc_stub" STUB_LSOF_OUT="$out_stub" WT_GUARD_LSOF="$bin"
+		if assert_worktree_removal_safe "$target" 2>/dev/null; then
+			[[ "$expect" == "allow" ]]
+		else
+			[[ "$expect" == "refuse" ]]
+		fi
+	)
+}
+
+check() {
+	local label="$1"
+	shift
+	if "$@"; then pass "$label"; else fail "$label"; fi
+}
+
+mkdir -p "$SCRATCH/wt/sub" "$SCRATCH/other"
+
+# (guard) empty/blank target is refused.
+check "empty target refused" guard_case refuse - "" 1 ""
+check "blank target refused" guard_case refuse - "   " 1 ""
+
+# (a) target == cwd is refused, even with lsof "clear" (rc=1/empty).
+check "cwd == target refused" guard_case refuse "$SCRATCH/wt" "$SCRATCH/wt" 1 ""
+
+# (a) target is an ANCESTOR of cwd is refused (removing tree you stand inside).
+check "ancestor-of-cwd target refused" guard_case refuse "$SCRATCH/wt/sub" "$SCRATCH/wt" 1 ""
+
+# (a) trailing-slash normalization: "$SCRATCH/wt/" vs cwd "$SCRATCH/wt" still refuses.
+check "trailing-slash target refused" guard_case refuse "$SCRATCH/wt" "$SCRATCH/wt/" 1 ""
+
+# happy path: unrelated target, lsof rc=1 (nothing under tree) -> ALLOWED.
+check "unrelated + clear lsof allowed" guard_case allow "$SCRATCH" "$SCRATCH/other" 1 ""
+
+# (b) foreign holder present (lsof rc=0 + output) -> refused even though cwd is elsewhere.
+check "foreign live handle refused" guard_case refuse "$SCRATCH" "$SCRATCH/other" 0 "p1234"
+
+# (b) fail-closed: lsof probe errors (missing binary, rc=127) -> refused.
+check "fail-closed on lsof probe error" guard_case refuse "$SCRATCH" "$SCRATCH/other" 1 "" /nonexistent/lsof
+
+echo ""
+echo "worktree-remove-guard: ${PASSES} passed / ${FAILURES} failed"
+[[ $FAILURES -eq 0 ]] || exit 1
+exit 0

--- a/plugins/dev/scripts/lib/__tests__/worktree-remove-guard.test.sh
+++ b/plugins/dev/scripts/lib/__tests__/worktree-remove-guard.test.sh
@@ -30,7 +30,12 @@ fail() { FAILURES=$((FAILURES + 1)); echo "  FAIL: $1"; }
 STUB_LSOF="$SCRATCH/mock-lsof"
 cat >"$STUB_LSOF" <<'EOF'
 #!/usr/bin/env bash
+# STUB_LSOF_OUT → stdout (the guard parses `-F p` PID lines like "p1234").
+# STUB_LSOF_ERR → stderr (simulates lsof's traversal/permission DIAGNOSTIC).
+# STUB_LSOF_SLEEP → block this many seconds before returning (timeout test).
+[[ -n "${STUB_LSOF_SLEEP:-}" ]] && sleep "$STUB_LSOF_SLEEP"
 [[ -n "${STUB_LSOF_OUT:-}" ]] && printf '%s\n' "$STUB_LSOF_OUT"
+[[ -n "${STUB_LSOF_ERR:-}" ]] && printf '%s\n' "$STUB_LSOF_ERR" >&2
 exit "${STUB_LSOF_RC:-1}"
 EOF
 chmod +x "$STUB_LSOF"
@@ -80,13 +85,38 @@ mkdir -p "$SCRATCH/other"
 rc=0; (cd "$SCRATCH" && STUB_LSOF_RC=1 STUB_LSOF_OUT="" assert_worktree_removal_safe "$SCRATCH/other") 2>/dev/null || rc=$?
 assert_rc_zero "$rc" "unrelated target, lsof clear"
 
-# (b) foreign holder present (lsof rc=0 + output) → refused even though cwd is elsewhere
+# (b) foreign holder present (lsof rc=0 + a foreign PID line) → refused even though cwd is elsewhere
 rc=0; (cd "$SCRATCH" && STUB_LSOF_RC=0 STUB_LSOF_OUT="p1234" assert_worktree_removal_safe "$SCRATCH/other") 2>/dev/null || rc=$?
 assert_rc_nonzero "$rc" "foreign holder present"
 
 # (b) fail-closed: lsof probe errors (rc=127 / missing binary) → refused
 rc=0; (cd "$SCRATCH" && WT_GUARD_LSOF=/nonexistent/lsof assert_worktree_removal_safe "$SCRATCH/other") 2>/dev/null || rc=$?
 assert_rc_nonzero "$rc" "fail-closed on missing lsof"
+
+# (b/#1) self-exclusion: the ONLY holder is our own process ($$) → ALLOWED.
+# During teardown the worker's cwd is the tree; the guard must exempt its own
+# session's process tree, not detect itself and refuse. The subshell's $$ is
+# the guard's own shell (a member of _wtg_self_pids), so `p$$` must be dropped.
+rc=0; (cd "$SCRATCH" && STUB_LSOF_RC=0 STUB_LSOF_OUT="p$$" assert_worktree_removal_safe "$SCRATCH/other") 2>/dev/null || rc=$?
+assert_rc_zero "$rc" "self-only holder is exempted"
+
+# (b/#1) mixed holders: self PID + a foreign PID → still refused (foreign wins).
+rc=0; (cd "$SCRATCH" && STUB_LSOF_RC=0 STUB_LSOF_OUT="$(printf 'p%s\np1234\n' "$$")" assert_worktree_removal_safe "$SCRATCH/other") 2>/dev/null || rc=$?
+assert_rc_nonzero "$rc" "self + foreign holder still refused"
+
+# (b/#3) inconclusive: lsof exits 1 with a stderr DIAGNOSTIC (not clean-empty) → refused.
+# rc=1 + empty stdout would otherwise read as "nothing under the tree"; the
+# stderr diagnostic must flip that to fail-closed.
+rc=0; (cd "$SCRATCH" && STUB_LSOF_RC=1 STUB_LSOF_OUT="" STUB_LSOF_ERR="lsof: WARNING: can't stat() apfs file system" assert_worktree_removal_safe "$SCRATCH/other") 2>/dev/null || rc=$?
+assert_rc_nonzero "$rc" "lsof stderr diagnostic is inconclusive → refuse"
+
+# (b/#2) bound: an lsof that blocks past the 10s cap → timeout → refused.
+# Guarded behind WT_GUARD_TEST_SLOW=1 so the normal fast suite stays sub-second;
+# opt in when you want to exercise the wall-clock cap end-to-end.
+if [[ "${WT_GUARD_TEST_SLOW:-0}" == "1" ]]; then
+	rc=0; (cd "$SCRATCH" && STUB_LSOF_RC=0 STUB_LSOF_OUT="p1234" STUB_LSOF_SLEEP=12 assert_worktree_removal_safe "$SCRATCH/other") 2>/dev/null || rc=$?
+	assert_rc_nonzero "$rc" "lsof exceeding 10s cap → timeout → refuse"
+fi
 
 # ─── Summary ─────────────────────────────────────────────────────────────────
 echo ""

--- a/plugins/dev/scripts/lib/__tests__/worktree-remove-guard.test.sh
+++ b/plugins/dev/scripts/lib/__tests__/worktree-remove-guard.test.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+# Shell tests for lib/worktree-remove-guard.sh (CTL-1417) — the shell port of
+# CTL-791 worktree-safety.mjs `lsofCwdUnder`/`cwdUnder`. Refuse a
+# `git worktree remove --force` whose target is the caller's own cwd
+# (at-or-under) OR is held by a live process; fail-closed when lsof can't run.
+#
+# The `lsof` binary is stubbed via WT_GUARD_LSOF pointing at a mock whose
+# rc/stdout are env-driven (STUB_LSOF_RC / STUB_LSOF_OUT), so branch (b) is
+# deterministic and never shells out to real lsof against $SCRATCH.
+#
+# Run: bash plugins/dev/scripts/lib/__tests__/worktree-remove-guard.test.sh
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+LIB_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+GUARD_LIB="$LIB_DIR/worktree-remove-guard.sh"
+
+FAILURES=0
+PASSES=0
+SCRATCH="$(mktemp -d -t worktree-remove-guard-test-XXXXXX)"
+trap 'rm -rf "$SCRATCH"' EXIT
+
+pass() { PASSES=$((PASSES + 1)); echo "  PASS: $1"; }
+fail() { FAILURES=$((FAILURES + 1)); echo "  FAIL: $1"; }
+
+# ─── lsof stub ───────────────────────────────────────────────────────────────
+# A mock lsof whose rc + stdout are driven by STUB_LSOF_RC / STUB_LSOF_OUT in
+# the environment. Real lsof is never invoked.
+STUB_LSOF="$SCRATCH/mock-lsof"
+cat >"$STUB_LSOF" <<'EOF'
+#!/usr/bin/env bash
+[[ -n "${STUB_LSOF_OUT:-}" ]] && printf '%s\n' "$STUB_LSOF_OUT"
+exit "${STUB_LSOF_RC:-1}"
+EOF
+chmod +x "$STUB_LSOF"
+export WT_GUARD_LSOF="$STUB_LSOF"
+
+# Source the unit under test.
+# shellcheck source=../worktree-remove-guard.sh
+source "$GUARD_LIB"
+
+# ─── assertion helpers ───────────────────────────────────────────────────────
+# Each case runs the guard inside a `( cd … )` subshell for cwd + env
+# isolation. Because a subshell cannot mutate the parent's PASSES/FAILURES,
+# the subshell's EXIT CODE is the guard's rc and the PARENT does the counting
+# from it — otherwise a failing subshell case would be silently dropped and
+# the suite would falsely report success.
+assert_rc_nonzero() { # <rc> <label>
+	if [[ "$1" -ne 0 ]]; then pass "refused ($2)"; else fail "expected REFUSE ($2) — guard returned 0"; fi
+}
+assert_rc_zero() { # <rc> <label>
+	if [[ "$1" -eq 0 ]]; then pass "allowed ($2)"; else fail "expected ALLOW ($2) — guard returned $1"; fi
+}
+
+# ─── Cases ───────────────────────────────────────────────────────────────────
+
+# empty/blank target is refused
+rc=0; assert_worktree_removal_safe "" 2>/dev/null || rc=$?
+assert_rc_nonzero "$rc" "empty target"
+rc=0; assert_worktree_removal_safe "   " 2>/dev/null || rc=$?
+assert_rc_nonzero "$rc" "blank target"
+
+# (a) target == cwd is refused, even with lsof "clear" (rc=1/empty)
+mkdir -p "$SCRATCH/wt"
+rc=0; (cd "$SCRATCH/wt" && STUB_LSOF_RC=1 STUB_LSOF_OUT="" assert_worktree_removal_safe "$SCRATCH/wt") 2>/dev/null || rc=$?
+assert_rc_nonzero "$rc" "target == cwd"
+
+# (a) target is an ANCESTOR of cwd is refused (removing tree you stand inside)
+mkdir -p "$SCRATCH/wt/sub"
+rc=0; (cd "$SCRATCH/wt/sub" && STUB_LSOF_RC=1 STUB_LSOF_OUT="" assert_worktree_removal_safe "$SCRATCH/wt") 2>/dev/null || rc=$?
+assert_rc_nonzero "$rc" "target is ancestor of cwd"
+
+# (a) trailing-slash normalization: "$SCRATCH/wt/" vs cwd "$SCRATCH/wt" still refuses
+rc=0; (cd "$SCRATCH/wt" && STUB_LSOF_RC=1 STUB_LSOF_OUT="" assert_worktree_removal_safe "$SCRATCH/wt/") 2>/dev/null || rc=$?
+assert_rc_nonzero "$rc" "trailing-slash target == cwd"
+
+# happy path: unrelated target, lsof rc=1 + empty (nothing under tree) → ALLOWED
+mkdir -p "$SCRATCH/other"
+rc=0; (cd "$SCRATCH" && STUB_LSOF_RC=1 STUB_LSOF_OUT="" assert_worktree_removal_safe "$SCRATCH/other") 2>/dev/null || rc=$?
+assert_rc_zero "$rc" "unrelated target, lsof clear"
+
+# (b) foreign holder present (lsof rc=0 + output) → refused even though cwd is elsewhere
+rc=0; (cd "$SCRATCH" && STUB_LSOF_RC=0 STUB_LSOF_OUT="p1234" assert_worktree_removal_safe "$SCRATCH/other") 2>/dev/null || rc=$?
+assert_rc_nonzero "$rc" "foreign holder present"
+
+# (b) fail-closed: lsof probe errors (rc=127 / missing binary) → refused
+rc=0; (cd "$SCRATCH" && WT_GUARD_LSOF=/nonexistent/lsof assert_worktree_removal_safe "$SCRATCH/other") 2>/dev/null || rc=$?
+assert_rc_nonzero "$rc" "fail-closed on missing lsof"
+
+# ─── Summary ─────────────────────────────────────────────────────────────────
+echo ""
+echo "worktree-remove-guard: ${PASSES} passed / ${FAILURES} failed"
+[[ $FAILURES -eq 0 ]] || exit 1
+exit 0

--- a/plugins/dev/scripts/lib/worktree-remove-guard.sh
+++ b/plugins/dev/scripts/lib/worktree-remove-guard.sh
@@ -34,7 +34,14 @@ assert_worktree_removal_safe() {
 		return 3
 	fi
 
-	# (b) foreign-liveness via lsof (fail-closed).
+	# (b) foreign-liveness via lsof (fail-closed). rc semantics mirror the CTL-791
+	# Node gate (worktree-safety.mjs lsofCwdUnder) exactly: rc=1+empty ⇒ nothing
+	# under the tree (safe); rc=0/output ⇒ live holder (refuse); rc∉{0,1} ⇒ probe
+	# failed (fail-closed refuse). NOTE (inherited from the Node gate): lsof also
+	# exits rc=1+empty when denied `opendir` on an unreadable subdir (warning →
+	# suppressed stderr), so a handle inside a mode-000 subdir reads as absent.
+	# The actual data-loss class (a test/agent running FROM the tree) is caught by
+	# the lsof-independent cwd-containment check (a) above, not this probe.
 	local lsof_bin="${WT_GUARD_LSOF:-lsof}"
 	local out rc
 	out="$("$lsof_bin" -nP +D "$rt" 2>/dev/null)"

--- a/plugins/dev/scripts/lib/worktree-remove-guard.sh
+++ b/plugins/dev/scripts/lib/worktree-remove-guard.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# lib/worktree-remove-guard.sh — CTL-1417. Refuse a `git worktree remove --force`
+# whose target is the caller's own cwd (at-or-under) OR is held by a live
+# process. The shell port of CTL-791 worktree-safety.mjs `lsofCwdUnder` /
+# `cwdUnder`, for the three shell removal sites the Node reaper gate never
+# covered. Fail-closed: if liveness cannot be probed, refuse.
+#
+# Usage:  assert_worktree_removal_safe <target-path>
+# Returns 0 = safe to remove, non-zero = refuse (reason on stderr).
+# Seam:   WT_GUARD_LSOF overrides the lsof binary (default: lsof) for tests.
+
+_wtg_realpath() { # realpath with a pure-shell fallback (macOS/BSD flags differ)
+	local p="${1%/}"
+	if command -v realpath >/dev/null 2>&1; then
+		realpath -q "$p" 2>/dev/null || printf '%s' "$p"
+	else
+		printf '%s' "$p"
+	fi
+}
+
+assert_worktree_removal_safe() {
+	local target="${1:-}"
+	if [[ -z ${target// /} ]]; then
+		echo "worktree-remove-guard: refusing removal of empty/blank target" >&2
+		return 2
+	fi
+	local rt cwd
+	rt="$(_wtg_realpath "$target")"
+	cwd="$(_wtg_realpath "$PWD")"
+
+	# (a) cwd-containment: cwd == target, or cwd nested under target.
+	if [[ $cwd == "$rt" || $cwd == "$rt"/* ]]; then
+		echo "worktree-remove-guard: refusing — cwd ($cwd) is at/under target ($rt)" >&2
+		return 3
+	fi
+
+	# (b) foreign-liveness via lsof (fail-closed).
+	local lsof_bin="${WT_GUARD_LSOF:-lsof}"
+	local out rc
+	out="$("$lsof_bin" -nP +D "$rt" 2>/dev/null)"
+	rc=$?
+	if [[ $rc -eq 1 && -z ${out// /} ]]; then
+		return 0 # lsof: definitively nothing under the tree
+	fi
+	if [[ $rc -ne 0 && $rc -ne 1 ]]; then
+		echo "worktree-remove-guard: refusing — lsof probe failed (rc=$rc) for $rt" >&2
+		return 4 # fail-closed
+	fi
+	if [[ -n ${out// /} ]]; then
+		echo "worktree-remove-guard: refusing — live handle(s) under $rt" >&2
+		return 5
+	fi
+	return 0
+}

--- a/plugins/dev/scripts/lib/worktree-remove-guard.sh
+++ b/plugins/dev/scripts/lib/worktree-remove-guard.sh
@@ -21,6 +21,68 @@ _wtg_realpath() { # realpath with a pure-shell fallback (macOS/BSD lack -m widel
 	fi
 }
 
+# _wtg_self_pids — the PID set to EXEMPT from the foreign-liveness probe: this
+# guard's own shell ($$), its parent ($PPID) and the full ancestor chain up to
+# init. Mirrors orphan-sweep.sh `_sweep_self_pids` / worktree-safety.mjs's
+# self-exclusion. During normal teardown the Claude worker stays alive with its
+# cwd AT the ticket worktree while its Bash child (this guard) moves to the
+# primary checkout — that worker is one of our ANCESTORS, so walking the chain
+# is what stops the guard from detecting itself and refusing every removal.
+# Populates the memo $_WTG_SELF_PIDS (a space-delimited " a b c " set) rather
+# than printing — a `$( )` read would run the walk in a subshell and discard it.
+_WTG_SELF_PIDS=""
+_wtg_self_pids() {
+	[[ -n "$_WTG_SELF_PIDS" ]] && return 0
+	local p="$$" n=0 parent
+	_WTG_SELF_PIDS=" 1 $$ ${PPID:-1} "
+	while [[ "$p" =~ ^[0-9]+$ ]] && [[ "$p" -gt 1 ]] && [[ $n -lt 32 ]]; do
+		parent="$(ps -o ppid= -p "$p" 2>/dev/null | tr -d ' ' | head -1)"
+		[[ "$parent" =~ ^[0-9]+$ ]] || break
+		_WTG_SELF_PIDS="${_WTG_SELF_PIDS}${parent} "
+		p="$parent"
+		n=$((n + 1))
+	done
+	return 0
+}
+
+_wtg_is_self_pid() { # <pid> — true iff pid is this guard's shell or an ancestor
+	_wtg_self_pids # no $( ) — must mutate THIS shell
+	case "$_WTG_SELF_PIDS" in *" $1 "*) return 0 ;; esac
+	return 1
+}
+
+# _wtg_run_capped — run a command under a 10s wall-clock cap, mirroring the
+# bound worktree-safety.mjs puts on the same `lsof +D` (an unbounded recursive
+# lsof can block forever on a slow/stale mount and wedge orphan-sweep /
+# phase-dispatch, which now call this guard SYNCHRONOUSLY). Prefers GNU
+# `timeout`/`gtimeout`; when neither exists (stock macOS) it backgrounds the
+# command and kills it after the cap. Exit 124 on timeout — the caller treats
+# that as inconclusive → fail-closed.
+_wtg_run_capped() { # <secs> <cmd...>
+	local secs="$1"
+	shift
+	if command -v timeout >/dev/null 2>&1; then
+		timeout "$secs" "$@"
+	elif command -v gtimeout >/dev/null 2>&1; then
+		gtimeout "$secs" "$@"
+	else
+		# Pure-shell fallback: run in the background, poll for completion up to
+		# the cap, then SIGKILL and report 124 (matching `timeout`'s convention).
+		"$@" &
+		local cmd_pid=$! waited=0
+		while kill -0 "$cmd_pid" 2>/dev/null; do
+			if [[ $waited -ge $((secs * 10)) ]]; then
+				kill -9 "$cmd_pid" 2>/dev/null
+				wait "$cmd_pid" 2>/dev/null
+				return 124
+			fi
+			sleep 0.1
+			waited=$((waited + 1))
+		done
+		wait "$cmd_pid"
+	fi
+}
+
 assert_worktree_removal_safe() {
 	local target="${1:-}"
 	if [[ -z ${target// /} ]]; then
@@ -37,21 +99,71 @@ assert_worktree_removal_safe() {
 		return 3
 	fi
 
-	# (b) foreign-liveness via lsof (fail-closed).
+	# (b) foreign-liveness via lsof (fail-closed). Three hardening rules vs. the
+	# original bare probe (CTL-1417 codex review):
+	#   • BOUND it (10s cap) — an unbounded recursive `lsof +D` can wedge on a
+	#     slow/stale mount and stall the synchronous callers (orphan-sweep,
+	#     phase-dispatch). Timeout → inconclusive → refuse.
+	#   • CAPTURE stderr — `lsof +D` can exit 1 with a traversal/permission
+	#     DIAGNOSTIC and empty stdout; that is inconclusive, NOT "nothing under
+	#     the tree". A diagnostic → refuse rather than let --force delete a tree
+	#     whose live handles couldn't be enumerated.
+	#   • EXEMPT self — `-F pn` yields one `p<pid>` line per holder; we drop the
+	#     teardown worker's own process tree ($$/ancestors) before deciding, so
+	#     the guard doesn't detect ITSELF and refuse every merged worktree.
 	local lsof_bin="${WT_GUARD_LSOF:-lsof}"
-	local out rc
-	out="$("$lsof_bin" -nP +D "$rt" 2>/dev/null)"
-	rc=$?
-	if [[ $rc -eq 1 && -z ${out// /} ]]; then
-		return 0 # lsof: definitively nothing under the tree
+	local out rc errfile
+	errfile="$(mktemp -t wtg-lsof-err-XXXXXX 2>/dev/null)" || errfile=""
+	if [[ -n $errfile ]]; then
+		out="$(_wtg_run_capped 10 "$lsof_bin" -nP -F pn +D "$rt" 2>"$errfile")"
+		rc=$?
+	else
+		# mktemp unavailable — cannot separate stderr; fail-closed conservatively.
+		out="$(_wtg_run_capped 10 "$lsof_bin" -nP -F pn +D "$rt" 2>/dev/null)"
+		rc=$?
 	fi
+	local err=""
+	[[ -n $errfile ]] && { err="$(cat "$errfile" 2>/dev/null)"; rm -f "$errfile"; }
+
+	# Timeout (124 from the cap) → inconclusive → refuse.
+	if [[ $rc -eq 124 ]]; then
+		echo "worktree-remove-guard: refusing — lsof probe timed out (>10s) for $rt" >&2
+		return 4 # fail-closed
+	fi
+	# lsof binary missing / unable to spawn (rc≥126) → refuse.
+	if [[ $rc -ge 126 ]]; then
+		echo "worktree-remove-guard: refusing — lsof probe failed (rc=$rc) for $rt" >&2
+		return 4 # fail-closed
+	fi
+	# A stderr diagnostic means the traversal was incomplete — inconclusive,
+	# regardless of rc. lsof exits 1 both for "nothing found" (clean) and for a
+	# partial/permission-denied walk (diagnostic on stderr) — only the latter
+	# emits to stderr, so the diagnostic is the discriminator.
+	if [[ -n ${err// /} ]]; then
+		echo "worktree-remove-guard: refusing — lsof reported an error (inconclusive) for $rt" >&2
+		return 4 # fail-closed
+	fi
+	# Any other unexpected rc (not 0 = matches, not 1 = none) → refuse.
 	if [[ $rc -ne 0 && $rc -ne 1 ]]; then
 		echo "worktree-remove-guard: refusing — lsof probe failed (rc=$rc) for $rt" >&2
 		return 4 # fail-closed
 	fi
-	if [[ -n ${out// /} ]]; then
+
+	# Enumerate the holder PIDs from the `-F p` lines, dropping our own session's
+	# process tree. Any FOREIGN pid left ⇒ a live handle we must respect.
+	local line pid foreign=0
+	while IFS= read -r line; do
+		[[ $line == p* ]] || continue # only PID field lines
+		pid="${line#p}"
+		[[ $pid =~ ^[0-9]+$ ]] || continue
+		_wtg_is_self_pid "$pid" && continue
+		foreign=1
+		break
+	done <<<"$out"
+
+	if [[ $foreign -eq 1 ]]; then
 		echo "worktree-remove-guard: refusing — live handle(s) under $rt" >&2
 		return 5
 	fi
-	return 0
+	return 0 # nothing foreign under the tree
 }

--- a/plugins/dev/scripts/lib/worktree-remove-guard.sh
+++ b/plugins/dev/scripts/lib/worktree-remove-guard.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# lib/worktree-remove-guard.sh — CTL-1417. Refuse a `git worktree remove --force`
+# whose target is the caller's own cwd (at-or-under) OR is held by a live
+# process. The shell port of CTL-791 worktree-safety.mjs `lsofCwdUnder` /
+# `cwdUnder`, for the shell removal sites the Node reaper gate never covered.
+# Fail-closed: if liveness cannot be probed, refuse.
+#
+# Usage:  assert_worktree_removal_safe <target-path>
+# Returns 0 = safe to remove, non-zero = refuse (reason on stderr).
+# Seam:   WT_GUARD_LSOF overrides the lsof binary (default: lsof) for tests.
+
+[[ -n "${_WT_REMOVE_GUARD_LOADED:-}" ]] && return 0
+_WT_REMOVE_GUARD_LOADED=1
+
+_wtg_realpath() { # realpath with a pure-shell fallback (macOS/BSD lack -m widely)
+	local p="${1%/}"
+	if command -v realpath >/dev/null 2>&1; then
+		realpath -q "$p" 2>/dev/null || printf '%s' "$p"
+	else
+		printf '%s' "$p"
+	fi
+}
+
+assert_worktree_removal_safe() {
+	local target="${1:-}"
+	if [[ -z ${target// /} ]]; then
+		echo "worktree-remove-guard: refusing removal of empty/blank target" >&2
+		return 2
+	fi
+	local rt cwd
+	rt="$(_wtg_realpath "$target")"
+	cwd="$(_wtg_realpath "$PWD")"
+
+	# (a) cwd-containment: cwd == target, or cwd nested under target.
+	if [[ $cwd == "$rt" || $cwd == "$rt"/* ]]; then
+		echo "worktree-remove-guard: refusing — cwd ($cwd) is at/under target ($rt)" >&2
+		return 3
+	fi
+
+	# (b) foreign-liveness via lsof (fail-closed).
+	local lsof_bin="${WT_GUARD_LSOF:-lsof}"
+	local out rc
+	out="$("$lsof_bin" -nP +D "$rt" 2>/dev/null)"
+	rc=$?
+	if [[ $rc -eq 1 && -z ${out// /} ]]; then
+		return 0 # lsof: definitively nothing under the tree
+	fi
+	if [[ $rc -ne 0 && $rc -ne 1 ]]; then
+		echo "worktree-remove-guard: refusing — lsof probe failed (rc=$rc) for $rt" >&2
+		return 4 # fail-closed
+	fi
+	if [[ -n ${out// /} ]]; then
+		echo "worktree-remove-guard: refusing — live handle(s) under $rt" >&2
+		return 5
+	fi
+	return 0
+}

--- a/plugins/dev/scripts/orphan-sweep.sh
+++ b/plugins/dev/scripts/orphan-sweep.sh
@@ -79,6 +79,13 @@ SCRIPT_DIR="$(cd "$(dirname "$_SRC")" && pwd)"
 unset _SRC
 export PATH="${PATH}:${SCRIPT_DIR}"
 
+# CTL-1417: self-protection guard — a final belt (fail-closed lsof + cwd check)
+# on the SAFE / SALVAGE_UNPUSHED --force removals below, covering non-`claude`
+# foreign holders and bash-3.2 (where presweep's mapfile fail-closes without
+# ever reaching the removal). No side effects on source.
+# shellcheck source=lib/worktree-remove-guard.sh
+[ -r "${SCRIPT_DIR}/lib/worktree-remove-guard.sh" ] && source "${SCRIPT_DIR}/lib/worktree-remove-guard.sh"
+
 # ─── arg parsing ────────────────────────────────────────────────────────────
 
 DRY_RUN="${SWEEP_DRY_RUN:-0}"
@@ -1230,6 +1237,12 @@ sweep_worktrees() {
             }
           fi
           kb="$(_du_kb "$wt")"
+          # CTL-1417: final self-protection belt — skip if the tree is our cwd
+          # or a live process holds a handle under it (never yank a tree an
+          # operator or `make test` is inside).
+          if command -v assert_worktree_removal_safe >/dev/null 2>&1 && ! assert_worktree_removal_safe "$wt"; then
+            log "skip (guard refused — live handle/self): $wt"; _sweep_count activeSkipped; continue
+          fi
           git worktree remove --force "$wt" 2>/dev/null && {
             log "removed worktree (SAFE): $wt"
             _sweep_count removed; removed_count=$((removed_count+1))
@@ -1261,8 +1274,12 @@ sweep_worktrees() {
               if [[ -n "${SWEEP_MAX_REMOVALS:-}" && "$removed_count" -ge "$SWEEP_MAX_REMOVALS" ]]; then
                 deferred=$((deferred+1)); continue
               fi
-              git worktree remove --force "$wt" 2>/dev/null \
-                && { log "removed (salvage) worktree: $wt"; emit_reclaim worktree "$wt"; removed_count=$((removed_count+1)); }
+              if command -v assert_worktree_removal_safe >/dev/null 2>&1 && ! assert_worktree_removal_safe "$wt"; then
+                log "skip (guard refused — live handle/self): $wt"
+              else
+                git worktree remove --force "$wt" 2>/dev/null \
+                  && { log "removed (salvage) worktree: $wt"; emit_reclaim worktree "$wt"; removed_count=$((removed_count+1)); }
+              fi
             fi
           else
             log "salvage (unpushed commits, skip+report): $wt"

--- a/plugins/dev/scripts/orphan-sweep.sh
+++ b/plugins/dev/scripts/orphan-sweep.sh
@@ -86,6 +86,21 @@ export PATH="${PATH}:${SCRIPT_DIR}"
 # shellcheck source=lib/worktree-remove-guard.sh
 [ -r "${SCRIPT_DIR}/lib/worktree-remove-guard.sh" ] && source "${SCRIPT_DIR}/lib/worktree-remove-guard.sh"
 
+# _removal_guard_ok <path> — the SINGLE fail-closed predicate every `git worktree
+# remove --force` site gates on (CTL-1417). Returns 0 (safe to force-remove) ONLY
+# when the guard function loaded AND it cleared the path. If the guard lib was
+# missing/unreadable at source-time, `assert_worktree_removal_safe` is undefined —
+# and guard-ABSENCE is treated as a REFUSAL (fail-closed), not a bypass, so a
+# stripped/broken checkout can never reopen the data-loss path. Reason on stderr.
+_removal_guard_ok() {
+  local _wt="${1:-}"
+  if ! command -v assert_worktree_removal_safe >/dev/null 2>&1; then
+    echo "worktree-remove-guard: unavailable — refusing forced removal of ${_wt}" >&2
+    return 1
+  fi
+  assert_worktree_removal_safe "$_wt"
+}
+
 # ─── arg parsing ────────────────────────────────────────────────────────────
 
 DRY_RUN="${SWEEP_DRY_RUN:-0}"
@@ -1240,8 +1255,8 @@ sweep_worktrees() {
           # CTL-1417: final self-protection belt — skip if the tree is our cwd
           # or a live process holds a handle under it (never yank a tree an
           # operator or `make test` is inside).
-          if command -v assert_worktree_removal_safe >/dev/null 2>&1 && ! assert_worktree_removal_safe "$wt"; then
-            log "skip (guard refused — live handle/self): $wt"; _sweep_count activeSkipped; continue
+          if ! _removal_guard_ok "$wt"; then
+            log "skip (guard refused/unavailable — live handle/self): $wt"; _sweep_count activeSkipped; continue
           fi
           git worktree remove --force "$wt" 2>/dev/null && {
             log "removed worktree (SAFE): $wt"
@@ -1274,11 +1289,12 @@ sweep_worktrees() {
               if [[ -n "${SWEEP_MAX_REMOVALS:-}" && "$removed_count" -ge "$SWEEP_MAX_REMOVALS" ]]; then
                 deferred=$((deferred+1)); continue
               fi
-              if command -v assert_worktree_removal_safe >/dev/null 2>&1 && ! assert_worktree_removal_safe "$wt"; then
-                # Mirror the SAFE path (L1244): a guard refusal RETAINS the tree,
-                # so count it as an active skip or activeSkipped undercounts the
-                # worktrees left behind exactly when the guard fires (CTL-1417).
-                log "skip (guard refused — live handle/self): $wt"; _sweep_count activeSkipped
+              if ! _removal_guard_ok "$wt"; then
+                # Mirror the SAFE path: a guard refusal (or an unavailable guard)
+                # RETAINS the tree, so count it as an active skip or activeSkipped
+                # undercounts the worktrees left behind exactly when the guard
+                # fires/is absent (CTL-1417).
+                log "skip (guard refused/unavailable — live handle/self): $wt"; _sweep_count activeSkipped
               else
                 git worktree remove --force "$wt" 2>/dev/null \
                   && { log "removed (salvage) worktree: $wt"; emit_reclaim worktree "$wt"; removed_count=$((removed_count+1)); }

--- a/plugins/dev/scripts/orphan-sweep.sh
+++ b/plugins/dev/scripts/orphan-sweep.sh
@@ -1275,7 +1275,10 @@ sweep_worktrees() {
                 deferred=$((deferred+1)); continue
               fi
               if command -v assert_worktree_removal_safe >/dev/null 2>&1 && ! assert_worktree_removal_safe "$wt"; then
-                log "skip (guard refused — live handle/self): $wt"
+                # Mirror the SAFE path (L1244): a guard refusal RETAINS the tree,
+                # so count it as an active skip or activeSkipped undercounts the
+                # worktrees left behind exactly when the guard fires (CTL-1417).
+                log "skip (guard refused — live handle/self): $wt"; _sweep_count activeSkipped
               else
                 git worktree remove --force "$wt" 2>/dev/null \
                   && { log "removed (salvage) worktree: $wt"; emit_reclaim worktree "$wt"; removed_count=$((removed_count+1)); }

--- a/plugins/dev/scripts/phase-agent-dispatch
+++ b/plugins/dev/scripts/phase-agent-dispatch
@@ -80,6 +80,9 @@ source "${SCRIPT_DIR}/lib/resume.sh"
 source "${SCRIPT_DIR}/lib/phase-sequence.sh"
 # shellcheck source=lib/worktree-rebase.sh
 source "${SCRIPT_DIR}/lib/worktree-rebase.sh"
+# CTL-1417: self-protection guard for --force worktree removals (recreate site).
+# shellcheck source=lib/worktree-remove-guard.sh
+source "${SCRIPT_DIR}/lib/worktree-remove-guard.sh"
 # shellcheck source=lib/phase-artifact-gate.sh
 source "${SCRIPT_DIR}/lib/phase-artifact-gate.sh"
 
@@ -1013,36 +1016,46 @@ if [[ -z $RESUME_SESSION ]] && is_rebase_phase "$PHASE"; then
 				echo "phase-agent-dispatch: recreate: cannot resolve repo root; parking instead" >&2
 			else
 				_WT_PATH="$(pwd)"
-				git -C "$_REPO_ROOT" worktree remove --force "$_WT_PATH" 2>/dev/null || true
-				git -C "$_REPO_ROOT" branch -f "$TICKET" "origin/${BASE_BRANCH}" 2>/dev/null || true
-				# CATALYST_RECREATE_WORKTREE_DIR overrides the worktrees base for
-				# testing — passes --worktree-dir so create-worktree.sh uses the
-				# test-local scratch dir instead of the default ~/catalyst/wt/.
-				_RECREATE_WT_DIR_FLAG=""
-				[[ -n ${CATALYST_RECREATE_WORKTREE_DIR-} ]] &&
-					_RECREATE_WT_DIR_FLAG="--worktree-dir ${CATALYST_RECREATE_WORKTREE_DIR}"
-				_NEW_WT_OUT="$(cd "$_REPO_ROOT" &&
-					"${SCRIPT_DIR}/create-worktree.sh" \
-						"$TICKET" "$BASE_BRANCH" --reuse-existing ${_RECREATE_WT_DIR_FLAG} 2>/dev/null)"
-				_NEW_WT="$(printf '%s\n' "$_NEW_WT_OUT" | grep '^WORKTREE_PATH=' | cut -d= -f2)"
-				if [[ -n $_NEW_WT && -d $_NEW_WT ]]; then
-					# Delete the signal file so the second dispatch's idempotency
-					# guard finds no file and writes a fresh one (not "dispatched"
-					# which would short-circuit the re-exec as idempotent).
-					rm -f "$SIGNAL_FILE" 2>/dev/null || true
-					# CTL-736: this is a DELIBERATE clean restart — drop the claim
-					# tombstones too, so the re-exec's fresh (no-signal ⇒ gen 1)
-					# claim is exclusive and wins instead of colliding on gen 1.
-					rm -f "${WORKER_DIR}/${PHASE}.claim."* 2>/dev/null || true
-					echo "phase-agent-dispatch: recreated worktree at ${_NEW_WT}; re-dispatching ${TICKET}/${PHASE}" >&2
-					cd "$_NEW_WT"
-					# CTL-990: mark the recreate as spent — survives the exec, so a
-					# second rc=2 in the re-dispatched run parks instead of looping.
-					export CATALYST_RECREATE_ATTEMPTED=1
-					exec "$0" --phase "$PHASE" --ticket "$TICKET" \
-						--orch-dir "$ORCH_DIR" --orch-id "$ORCH_ID"
+				# CTL-1417: leave the doomed worktree BEFORE removing it, so the
+				# self-protection guard sees only foreign holders (a make-test run,
+				# another agent) and refuses the --force removal instead of yanking
+				# the tree out from under a live process. In the legitimate recreate
+				# nothing else is under the tree, so the guard passes.
+				cd "$_REPO_ROOT" || true
+				if ! assert_worktree_removal_safe "$_WT_PATH"; then
+					echo "phase-agent-dispatch: recreate: guard refused removal of ${_WT_PATH}; parking instead" >&2
 				else
-					echo "phase-agent-dispatch: recreate failed to produce worktree; parking instead" >&2
+					git -C "$_REPO_ROOT" worktree remove --force "$_WT_PATH" 2>/dev/null || true
+					git -C "$_REPO_ROOT" branch -f "$TICKET" "origin/${BASE_BRANCH}" 2>/dev/null || true
+					# CATALYST_RECREATE_WORKTREE_DIR overrides the worktrees base for
+					# testing — passes --worktree-dir so create-worktree.sh uses the
+					# test-local scratch dir instead of the default ~/catalyst/wt/.
+					_RECREATE_WT_DIR_FLAG=""
+					[[ -n ${CATALYST_RECREATE_WORKTREE_DIR-} ]] &&
+						_RECREATE_WT_DIR_FLAG="--worktree-dir ${CATALYST_RECREATE_WORKTREE_DIR}"
+					_NEW_WT_OUT="$(cd "$_REPO_ROOT" &&
+						"${SCRIPT_DIR}/create-worktree.sh" \
+							"$TICKET" "$BASE_BRANCH" --reuse-existing ${_RECREATE_WT_DIR_FLAG} 2>/dev/null)"
+					_NEW_WT="$(printf '%s\n' "$_NEW_WT_OUT" | grep '^WORKTREE_PATH=' | cut -d= -f2)"
+					if [[ -n $_NEW_WT && -d $_NEW_WT ]]; then
+						# Delete the signal file so the second dispatch's idempotency
+						# guard finds no file and writes a fresh one (not "dispatched"
+						# which would short-circuit the re-exec as idempotent).
+						rm -f "$SIGNAL_FILE" 2>/dev/null || true
+						# CTL-736: this is a DELIBERATE clean restart — drop the claim
+						# tombstones too, so the re-exec's fresh (no-signal ⇒ gen 1)
+						# claim is exclusive and wins instead of colliding on gen 1.
+						rm -f "${WORKER_DIR}/${PHASE}.claim."* 2>/dev/null || true
+						echo "phase-agent-dispatch: recreated worktree at ${_NEW_WT}; re-dispatching ${TICKET}/${PHASE}" >&2
+						cd "$_NEW_WT"
+						# CTL-990: mark the recreate as spent — survives the exec, so a
+						# second rc=2 in the re-dispatched run parks instead of looping.
+						export CATALYST_RECREATE_ATTEMPTED=1
+						exec "$0" --phase "$PHASE" --ticket "$TICKET" \
+							--orch-dir "$ORCH_DIR" --orch-id "$ORCH_ID"
+					else
+						echo "phase-agent-dispatch: recreate failed to produce worktree; parking instead" >&2
+					fi
 				fi
 			fi
 		fi

--- a/plugins/dev/scripts/phase-agent-dispatch
+++ b/plugins/dev/scripts/phase-agent-dispatch
@@ -80,6 +80,8 @@ source "${SCRIPT_DIR}/lib/resume.sh"
 source "${SCRIPT_DIR}/lib/phase-sequence.sh"
 # shellcheck source=lib/worktree-rebase.sh
 source "${SCRIPT_DIR}/lib/worktree-rebase.sh"
+# shellcheck source=lib/worktree-remove-guard.sh
+source "${SCRIPT_DIR}/lib/worktree-remove-guard.sh"
 # shellcheck source=lib/phase-artifact-gate.sh
 source "${SCRIPT_DIR}/lib/phase-artifact-gate.sh"
 
@@ -1049,36 +1051,48 @@ if [[ -z $RESUME_SESSION ]] && is_rebase_phase "$PHASE"; then
 				echo "phase-agent-dispatch: recreate: cannot resolve repo root; parking instead" >&2
 			else
 				_WT_PATH="$(pwd)"
-				git -C "$_REPO_ROOT" worktree remove --force "$_WT_PATH" 2>/dev/null || true
-				git -C "$_REPO_ROOT" branch -f "$TICKET" "origin/${BASE_BRANCH}" 2>/dev/null || true
-				# CATALYST_RECREATE_WORKTREE_DIR overrides the worktrees base for
-				# testing — passes --worktree-dir so create-worktree.sh uses the
-				# test-local scratch dir instead of the default ~/catalyst/wt/.
-				_RECREATE_WT_DIR_FLAG=""
-				[[ -n ${CATALYST_RECREATE_WORKTREE_DIR-} ]] &&
-					_RECREATE_WT_DIR_FLAG="--worktree-dir ${CATALYST_RECREATE_WORKTREE_DIR}"
-				_NEW_WT_OUT="$(cd "$_REPO_ROOT" &&
-					"${SCRIPT_DIR}/create-worktree.sh" \
-						"$TICKET" "$BASE_BRANCH" --reuse-existing ${_RECREATE_WT_DIR_FLAG} 2>/dev/null)"
-				_NEW_WT="$(printf '%s\n' "$_NEW_WT_OUT" | grep '^WORKTREE_PATH=' | cut -d= -f2)"
-				if [[ -n $_NEW_WT && -d $_NEW_WT ]]; then
-					# Delete the signal file so the second dispatch's idempotency
-					# guard finds no file and writes a fresh one (not "dispatched"
-					# which would short-circuit the re-exec as idempotent).
-					rm -f "$SIGNAL_FILE" 2>/dev/null || true
-					# CTL-736: this is a DELIBERATE clean restart — drop the claim
-					# tombstones too, so the re-exec's fresh (no-signal ⇒ gen 1)
-					# claim is exclusive and wins instead of colliding on gen 1.
-					rm -f "${WORKER_DIR}/${PHASE}.claim."* 2>/dev/null || true
-					echo "phase-agent-dispatch: recreated worktree at ${_NEW_WT}; re-dispatching ${TICKET}/${PHASE}" >&2
-					cd "$_NEW_WT"
-					# CTL-990: mark the recreate as spent — survives the exec, so a
-					# second rc=2 in the re-dispatched run parks instead of looping.
-					export CATALYST_RECREATE_ATTEMPTED=1
-					exec "$0" --phase "$PHASE" --ticket "$TICKET" \
-						--orch-dir "$ORCH_DIR" --orch-id "$ORCH_ID"
+				# CTL-1417: leave the doomed worktree BEFORE removing it, so the
+				# self-protection guard sees only foreign holders (a make-test run,
+				# another agent) and refuses the --force removal instead of yanking
+				# the tree out from under a live process. In the legitimate recreate
+				# nothing else is under the tree, so the guard passes. The subsequent
+				# git -C "$_REPO_ROOT" … calls are cwd-independent and create-worktree
+				# runs in a (cd "$_REPO_ROOT" && …) subshell, so the cd-out is safe.
+				cd "$_REPO_ROOT" || true
+				if ! assert_worktree_removal_safe "$_WT_PATH"; then
+					echo "phase-agent-dispatch: recreate: guard refused removal of ${_WT_PATH}; parking instead" >&2
 				else
-					echo "phase-agent-dispatch: recreate failed to produce worktree; parking instead" >&2
+					git -C "$_REPO_ROOT" worktree remove --force "$_WT_PATH" 2>/dev/null || true
+					git -C "$_REPO_ROOT" branch -f "$TICKET" "origin/${BASE_BRANCH}" 2>/dev/null || true
+					# CATALYST_RECREATE_WORKTREE_DIR overrides the worktrees base for
+					# testing — passes --worktree-dir so create-worktree.sh uses the
+					# test-local scratch dir instead of the default ~/catalyst/wt/.
+					_RECREATE_WT_DIR_FLAG=""
+					[[ -n ${CATALYST_RECREATE_WORKTREE_DIR-} ]] &&
+						_RECREATE_WT_DIR_FLAG="--worktree-dir ${CATALYST_RECREATE_WORKTREE_DIR}"
+					_NEW_WT_OUT="$(cd "$_REPO_ROOT" &&
+						"${SCRIPT_DIR}/create-worktree.sh" \
+							"$TICKET" "$BASE_BRANCH" --reuse-existing ${_RECREATE_WT_DIR_FLAG} 2>/dev/null)"
+					_NEW_WT="$(printf '%s\n' "$_NEW_WT_OUT" | grep '^WORKTREE_PATH=' | cut -d= -f2)"
+					if [[ -n $_NEW_WT && -d $_NEW_WT ]]; then
+						# Delete the signal file so the second dispatch's idempotency
+						# guard finds no file and writes a fresh one (not "dispatched"
+						# which would short-circuit the re-exec as idempotent).
+						rm -f "$SIGNAL_FILE" 2>/dev/null || true
+						# CTL-736: this is a DELIBERATE clean restart — drop the claim
+						# tombstones too, so the re-exec's fresh (no-signal ⇒ gen 1)
+						# claim is exclusive and wins instead of colliding on gen 1.
+						rm -f "${WORKER_DIR}/${PHASE}.claim."* 2>/dev/null || true
+						echo "phase-agent-dispatch: recreated worktree at ${_NEW_WT}; re-dispatching ${TICKET}/${PHASE}" >&2
+						cd "$_NEW_WT"
+						# CTL-990: mark the recreate as spent — survives the exec, so a
+						# second rc=2 in the re-dispatched run parks instead of looping.
+						export CATALYST_RECREATE_ATTEMPTED=1
+						exec "$0" --phase "$PHASE" --ticket "$TICKET" \
+							--orch-dir "$ORCH_DIR" --orch-id "$ORCH_ID"
+					else
+						echo "phase-agent-dispatch: recreate failed to produce worktree; parking instead" >&2
+					fi
 				fi
 			fi
 		fi

--- a/plugins/dev/scripts/phase-agent-dispatch
+++ b/plugins/dev/scripts/phase-agent-dispatch
@@ -85,6 +85,21 @@ source "${SCRIPT_DIR}/lib/worktree-remove-guard.sh"
 # shellcheck source=lib/phase-artifact-gate.sh
 source "${SCRIPT_DIR}/lib/phase-artifact-gate.sh"
 
+# _removal_guard_ok <path> — the single fail-closed predicate the recreate
+# `git worktree remove --force` site gates on (CTL-1417). Returns 0 (safe to
+# force-remove) ONLY when the guard function loaded AND cleared the path.
+# Guard-ABSENCE is a REFUSAL, not a bypass. (The lib is sourced unconditionally
+# above, so this normally can't fail on absence — but the predicate stays
+# fail-closed for parity with the other removal sites.)
+_removal_guard_ok() {
+	local _wt="${1:-}"
+	if ! command -v assert_worktree_removal_safe >/dev/null 2>&1; then
+		echo "worktree-remove-guard: unavailable — refusing forced removal of ${_wt}" >&2
+		return 1
+	fi
+	assert_worktree_removal_safe "$_wt"
+}
+
 die() {
 	echo "phase-agent-dispatch: $*" >&2
 	exit 1
@@ -1059,8 +1074,17 @@ if [[ -z $RESUME_SESSION ]] && is_rebase_phase "$PHASE"; then
 				# git -C "$_REPO_ROOT" … calls are cwd-independent and create-worktree
 				# runs in a (cd "$_REPO_ROOT" && …) subshell, so the cd-out is safe.
 				cd "$_REPO_ROOT" || true
-				if ! assert_worktree_removal_safe "$_WT_PATH"; then
-					echo "phase-agent-dispatch: recreate: guard refused removal of ${_WT_PATH}; parking instead" >&2
+				if ! _removal_guard_ok "$_WT_PATH"; then
+					echo "phase-agent-dispatch: recreate: guard refused/unavailable for ${_WT_PATH}; parking instead" >&2
+					# CTL-1417: the removal was refused because a live process holds
+					# the doomed worktree (or the guard is unavailable) — NOT a source
+					# conflict. Overwrite the generic reason so the downstream
+					# unstuck-sweep explanation reflects the true blocker (a live
+					# handle) instead of routing to force-push-if-clean. This new
+					# reason is deliberately absent from unstuck-sweep's
+					# STALL_CATEGORY_MAP, so it falls through to escalate rather than
+					# any auto-remediation path.
+					STALL_REASON="worktree_live_handle_guard_refused"
 				else
 					git -C "$_REPO_ROOT" worktree remove --force "$_WT_PATH" 2>/dev/null || true
 					git -C "$_REPO_ROOT" branch -f "$TICKET" "origin/${BASE_BRANCH}" 2>/dev/null || true

--- a/plugins/dev/skills/phase-teardown/SKILL.md
+++ b/plugins/dev/skills/phase-teardown/SKILL.md
@@ -402,6 +402,16 @@ elif [[ "$KEEP_WT" != "true" ]]; then
       elif ! "$PRESWEEP_BIN" "$WORKTREE_PATH"; then
         echo "phase-teardown: presweep failed for $WORKTREE_PATH; auto-teardown skipped" >&2
       else
+        # CTL-1417: defense-in-depth self-protection guard, additive to the
+        # existing self/primary checks + presweep above. Sourced defensively so
+        # its absence (e.g. the e2e fake plugin root) is a no-op that falls
+        # through to the existing presweep-gated removal.
+        __TD_GUARD="${PLUGIN_ROOT}/scripts/lib/worktree-remove-guard.sh"
+        [ -r "$__TD_GUARD" ] && . "$__TD_GUARD"
+        if command -v assert_worktree_removal_safe >/dev/null 2>&1 &&
+          ! assert_worktree_removal_safe "$WORKTREE_PATH"; then
+          echo "phase-teardown: removal guard refused $WORKTREE_PATH; auto-teardown skipped" >&2
+        else
         # Capture the real `git worktree remove` stderr so a failed teardown
         # reports the actual cause (dirty tree, locked, submodule, etc.) rather
         # than guessing. The merge is NEVER rolled back — we only warn + skip.
@@ -414,6 +424,7 @@ elif [[ "$KEEP_WT" != "true" ]]; then
           echo "phase-teardown: auto-teardown complete (worktree + branch removed)"
         else
           echo "phase-teardown: git worktree remove failed; auto-teardown skipped (merge left intact): ${WT_RM_ERR}" >&2
+        fi
         fi
       fi
     fi

--- a/plugins/dev/skills/phase-teardown/SKILL.md
+++ b/plugins/dev/skills/phase-teardown/SKILL.md
@@ -390,6 +390,11 @@ elif [[ "$KEEP_WT" != "true" ]]; then
 
     if [[ "$PWD" == "$PRIMARY_WT" ]]; then
       PRESWEEP_BIN="${PLUGIN_ROOT}/scripts/lib/worktree-presweep.sh"
+      # CTL-1417: source the shared self-protection guard for the extra belt
+      # in the removal chain below (defense-in-depth alongside the existing
+      # primary-worktree + presweep guards; no side effects on source).
+      WT_GUARD_LIB="${PLUGIN_ROOT}/scripts/lib/worktree-remove-guard.sh"
+      [ -r "$WT_GUARD_LIB" ] && source "$WT_GUARD_LIB"
       # CTL-649: do NOT swallow presweep stderr — its "N session(s) still alive
       # in <path>" diagnostic is the precise leak signal this teardown exists to
       # surface. Let it flow straight through to the operator.
@@ -401,6 +406,8 @@ elif [[ "$KEEP_WT" != "true" ]]; then
         echo "phase-teardown: worktree-presweep.sh missing/non-executable at $PRESWEEP_BIN; auto-teardown skipped (fail-closed)" >&2
       elif ! "$PRESWEEP_BIN" "$WORKTREE_PATH"; then
         echo "phase-teardown: presweep failed for $WORKTREE_PATH; auto-teardown skipped" >&2
+      elif command -v assert_worktree_removal_safe >/dev/null 2>&1 && ! assert_worktree_removal_safe "$WORKTREE_PATH"; then
+        echo "phase-teardown: guard refused removal of $WORKTREE_PATH (live handle/self); auto-teardown skipped" >&2
       else
         # Capture the real `git worktree remove` stderr so a failed teardown
         # reports the actual cause (dirty tree, locked, submodule, etc.) rather


### PR DESCRIPTION
## CTL-1417 — worktree-removal self-protection guard

Closes the env-leak vector where a shell `git worktree remove --force` could delete the operator's own worktree (or one a live process is inside). Ports the CTL-791 `worktree-safety.mjs` cwd/lsof gate to the shell sites the Node reaper never covered, wires it into every `--force` removal call, and hardens the suspect test suites against the `$HOME` leak that made the incident reproducible.

### Phase 1 — the guard (`lib/worktree-remove-guard.sh`)

`assert_worktree_removal_safe <target>` refuses a removal when:

- `$PWD` is at-or-under the target (removing the ground under your own feet), or
- any process holds a live handle under the target (`lsof`).

Fail-closed: if the `lsof` probe cannot run, the removal is refused. The `lsof` binary is injectable via `WT_GUARD_LSOF` for deterministic unit tests. Ships the lib + a unit suite covering all branches (incl. fail-closed) + a `run-tests.sh` discovery wrapper so `make test` covers it.

### Phase 2 — route every `--force` removal through the guard

`assert_worktree_removal_safe` is now wired into every shell `git worktree remove --force` site:

- **`phase-agent-dispatch` CTL-707 recreate** — `cd` out to the repo root *before* the removal, then guard; on refusal fall through to park `stalled` rather than destroying. The cd-out keeps the guard non-breaking in the legitimate recreate (nothing else under the tree → `lsof` rc=1 → allowed) yet firing under an env-leak (a runner still holding the tree → refuse).
- **`create-worktree.sh`** — both rollback sites skip the force-remove on refusal, leaving the tree for the reaper.
- **`orphan-sweep.sh`** — SAFE + SALVAGE_UNPUSHED skip (`activeSkipped`) on refusal, so the hourly LaunchAgent can never yank a tree an operator / `make test` is inside.
- **`phase-teardown`** — added as a defense-in-depth belt beside the existing primary-worktree + presweep guards.

### Phase 3 — harden suspect suites' hermeticity

Give `phase-agent-dispatch.test.sh` and `phase-teardown-e2e.test.sh` the same isolation floor as the `orphan-sweep.test.sh` gold standard: a scratch `HOME` and `GIT_CONFIG_GLOBAL`/`SYSTEM=/dev/null`, plus a Red canary that fails loudly if the isolation is ever not in effect. This closes the env-leak vector at the source — no future code path that computes `$HOME/catalyst/wt/...` (e.g. the CTL-707 recreate's `create-worktree.sh`) can resolve a removal target to the operator's real worktree. The dispatch suite also pins `CATALYST_RECREATE_WORKTREE_DIR` under scratch as a belt.

### Tests

- New unit suite for the guard (all branches incl. fail-closed).
- Dispatch **T38c** (recreate refused → parks, tree survives) with a deterministic `WT_GUARD_LSOF` seam.
- Orphan-sweep **T24g** (guard-refused SAFE tree skipped, survives).
- New `create-worktree-guard` suite (structural wiring + gated removal decision).
- Existing SAFE-removal + teardown suites stay green.

Refs: CTL-1417

🤖 Generated with [Claude Code](https://claude.com/claude-code)