### PR TITLE
feat(dev): CTL-1424 — otel-forward pino level → OTel SeverityNumber/Text at emit

### DIFF
--- a/plugins/dev/scripts/orch-monitor/lib/canonical-event-shared.test.ts
+++ b/plugins/dev/scripts/orch-monitor/lib/canonical-event-shared.test.ts
@@ -1,0 +1,27 @@
+import { describe, test, expect } from "bun:test";
+import { SEVERITY_NUMBERS, severityNumber } from "./canonical-event-shared.ts";
+
+describe("Severity constants — TRACE and FATAL (CTL-1424)", () => {
+  test("SEVERITY_NUMBERS.TRACE === 1", () => {
+    expect(SEVERITY_NUMBERS.TRACE).toBe(1);
+  });
+
+  test("SEVERITY_NUMBERS.FATAL === 21", () => {
+    expect(SEVERITY_NUMBERS.FATAL).toBe(21);
+  });
+
+  test("existing severity numbers unchanged", () => {
+    expect(SEVERITY_NUMBERS.DEBUG).toBe(5);
+    expect(SEVERITY_NUMBERS.INFO).toBe(9);
+    expect(SEVERITY_NUMBERS.WARN).toBe(13);
+    expect(SEVERITY_NUMBERS.ERROR).toBe(17);
+  });
+
+  test("severityNumber('TRACE') === 1", () => {
+    expect(severityNumber("TRACE")).toBe(1);
+  });
+
+  test("severityNumber('FATAL') === 21", () => {
+    expect(severityNumber("FATAL")).toBe(21);
+  });
+});

--- a/plugins/dev/scripts/orch-monitor/lib/canonical-event-shared.ts
+++ b/plugins/dev/scripts/orch-monitor/lib/canonical-event-shared.ts
@@ -15,13 +15,15 @@ import { hostname, homedir } from "node:os";
 import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
 
-export type Severity = "DEBUG" | "INFO" | "WARN" | "ERROR";
+export type Severity = "TRACE" | "DEBUG" | "INFO" | "WARN" | "ERROR" | "FATAL";
 
 export const SEVERITY_NUMBERS: Record<Severity, number> = {
+  TRACE: 1,
   DEBUG: 5,
   INFO: 9,
   WARN: 13,
   ERROR: 17,
+  FATAL: 21,
 };
 
 export function severityNumber(text: Severity): number {

--- a/plugins/dev/scripts/otel-forward/bun.lock
+++ b/plugins/dev/scripts/otel-forward/bun.lock
@@ -8,20 +8,20 @@
         "pino": "^9.6.0",
       },
       "devDependencies": {
-        "@types/bun": "^1.3.12",
+        "@types/bun": "^1.3.14",
       },
     },
   },
   "packages": {
     "@pinojs/redact": ["@pinojs/redact@0.4.0", "", {}, "sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg=="],
 
-    "@types/bun": ["@types/bun@1.3.13", "", { "dependencies": { "bun-types": "1.3.13" } }, "sha512-9fqXWk5YIHGGnUau9TEi+qdlTYDAnOj+xLCmSTwXfAIqXr2x4tytJb43E9uCvt09zJURKXwAtkoH4nLQfzeTXw=="],
+    "@types/bun": ["@types/bun@1.3.14", "", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
 
     "@types/node": ["@types/node@25.6.2", "", { "dependencies": { "undici-types": "~7.19.0" } }, "sha512-sokuT28dxf9JT5Kady1fsXOvI4HVpjZa95NKT5y9PNTIrs2AsobR4GFAA90ZG8M+nxVRLysCXsVj6eGC7Vbrlw=="],
 
     "atomic-sleep": ["atomic-sleep@1.0.0", "", {}, "sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ=="],
 
-    "bun-types": ["bun-types@1.3.13", "", { "dependencies": { "@types/node": "*" } }, "sha512-QXKeHLlOLqQX9LgYaHJfzdBaV21T63HhFJnvuRCcjZiaUDpbs5ED1MgxbMra71CsryN/1dAoXuJJJwIv/2drVA=="],
+    "bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
 
     "on-exit-leak-free": ["on-exit-leak-free@2.1.2", "", {}, "sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA=="],
 

--- a/plugins/dev/scripts/otel-forward/index.test.ts
+++ b/plugins/dev/scripts/otel-forward/index.test.ts
@@ -131,4 +131,62 @@ describe("daemon integration", () => {
     const statsAfter = mod.getStats();
     expect(statsAfter.processed).toBe(statsBefore.processed + 1);
   });
+
+  test("processLine counts pino-shaped records as processed (CTL-1424)", async () => {
+    const mod = await import("./index.ts");
+    const pinoLine = JSON.stringify({ level: 40, time: 1751500000000, msg: "warn line" });
+    const statsBefore = mod.getStats();
+    mod.processLine(pinoLine);
+    const statsAfter = mod.getStats();
+    expect(statsAfter.processed).toBe(statsBefore.processed + 1);
+    expect(statsAfter.skipped).toBe(statsBefore.skipped);
+  });
+
+  test("canonical event with existing severity is emitted unchanged through processLine (CTL-1424 AC bullet 2)", async () => {
+    const mod = await import("./index.ts");
+    const canonicalLine = JSON.stringify({
+      ts: "2026-05-08T00:00:01Z",
+      attributes: { "event.name": "some.error.event" },
+      resource: { "service.name": "catalyst.some-service", "service.namespace": "catalyst", "service.version": "1.0.0" },
+      severityText: "ERROR",
+      severityNumber: 17,
+      traceId: null,
+      spanId: null,
+      body: { message: "error" },
+    });
+    const statsBefore = mod.getStats();
+    mod.processLine(canonicalLine);
+    const statsAfter = mod.getStats();
+    expect(statsAfter.processed).toBe(statsBefore.processed + 1);
+  });
+});
+
+describe("pino records through tailer shouldForward (CTL-1424)", () => {
+  test("tailer emits pino-shaped lines via onLine", async () => {
+    const { mkdtempSync, rmSync, writeFileSync } = await import("node:fs");
+    const { tmpdir } = await import("node:os");
+    const { join } = await import("node:path");
+    const { createTailer } = await import("./lib/tail.ts");
+
+    const dir = mkdtempSync(join(tmpdir(), "pino-tail-"));
+    const file = join(dir, "2026-05.jsonl");
+    writeFileSync(file, JSON.stringify({ level: 40, time: 1751500000000, msg: "warn line" }) + "\n");
+
+    const emitted: string[] = [];
+    const ac = new AbortController();
+    const tailer = createTailer({
+      filePath: file,
+      offset: 0,
+      onLine: (l) => emitted.push(l),
+      signal: ac.signal,
+      pollMs: 10,
+    });
+    await tailer.drain();
+    ac.abort();
+
+    expect(emitted.length).toBe(1);
+    const parsed = JSON.parse(emitted[0]);
+    expect(parsed.level).toBe(40);
+    rmSync(dir, { recursive: true });
+  });
 });

--- a/plugins/dev/scripts/otel-forward/index.ts
+++ b/plugins/dev/scripts/otel-forward/index.ts
@@ -12,7 +12,7 @@ import { logDaemonHeartbeat } from "../lib/daemon-heartbeat.mjs";
 import { OtlpSender } from "./lib/destinations/otlp.ts";
 import { PosthogSender } from "./lib/destinations/posthog.ts";
 import { CloudflareAESender } from "./lib/destinations/cloudflare-ae.ts";
-import { isFlatEvent, normalizeFlatEvent } from "./lib/normalize.ts";
+import { isFlatEvent, normalizeFlatEvent, isPinoRecord, normalizePinoRecord } from "./lib/normalize.ts";
 import { dlqDepth } from "./lib/dlq.ts";
 import { buildCanonicalEnvelope } from "./lib/canonical.ts";
 
@@ -143,6 +143,7 @@ export function processLine(line: string): void {
   try {
     let ev = JSON.parse(line) as CanonicalEvent;
     if (isFlatEvent(ev)) ev = normalizeFlatEvent(ev as unknown as Record<string, unknown>);
+    else if (isPinoRecord(ev)) ev = normalizePinoRecord(ev as unknown as Record<string, unknown>);
     if (!ev.attributes) {
       stats.skipped++;
       return;

--- a/plugins/dev/scripts/otel-forward/index.ts
+++ b/plugins/dev/scripts/otel-forward/index.ts
@@ -12,7 +12,12 @@ import { logDaemonHeartbeat } from "../lib/daemon-heartbeat.mjs";
 import { OtlpSender } from "./lib/destinations/otlp.ts";
 import { PosthogSender } from "./lib/destinations/posthog.ts";
 import { CloudflareAESender } from "./lib/destinations/cloudflare-ae.ts";
-import { isFlatEvent, normalizeFlatEvent, isPinoRecord, normalizePinoRecord } from "./lib/normalize.ts";
+import {
+  isFlatEvent,
+  normalizeFlatEvent,
+  isPinoRecord,
+  normalizePinoRecord,
+} from "./lib/normalize.ts";
 import { dlqDepth } from "./lib/dlq.ts";
 import { buildCanonicalEnvelope } from "./lib/canonical.ts";
 
@@ -46,7 +51,10 @@ export function maxTs(a: string | undefined, b: string | undefined): string | un
 }
 
 /** Returns lagMs = localNewestTs - lastForwardedTs in ms, clamped to ≥ 0. Returns 0 when either timestamp is undefined. */
-export function computeLagMs(localNewestTs: string | undefined, lastForwardedTs: string | undefined): number {
+export function computeLagMs(
+  localNewestTs: string | undefined,
+  lastForwardedTs: string | undefined
+): number {
   if (!localNewestTs || !lastForwardedTs) return 0;
   const delta = Date.parse(localNewestTs) - Date.parse(lastForwardedTs);
   return delta > 0 ? delta : 0;
@@ -142,8 +150,12 @@ function emitLag(): void {
 export function processLine(line: string): void {
   try {
     let ev = JSON.parse(line) as CanonicalEvent;
-    if (isFlatEvent(ev)) ev = normalizeFlatEvent(ev as unknown as Record<string, unknown>);
-    else if (isPinoRecord(ev)) ev = normalizePinoRecord(ev as unknown as Record<string, unknown>);
+    // pino BEFORE flat: an execution-core pino WARN/ERROR may carry a structured
+    // `event` field (e.g. reaper.mjs), which isFlatEvent would otherwise claim
+    // and strip of its severity. isPinoRecord (numeric level + string msg) never
+    // matches a real flat catalyst event, so this ordering is safe (CTL-1424).
+    if (isPinoRecord(ev)) ev = normalizePinoRecord(ev as unknown as Record<string, unknown>);
+    else if (isFlatEvent(ev)) ev = normalizeFlatEvent(ev as unknown as Record<string, unknown>);
     if (!ev.attributes) {
       stats.skipped++;
       return;

--- a/plugins/dev/scripts/otel-forward/lib/canonical.ts
+++ b/plugins/dev/scripts/otel-forward/lib/canonical.ts
@@ -41,6 +41,11 @@ export interface BuildOpts {
   eventName: string;
   severityText?: CanonicalEvent["severityText"];
   severityNumber?: number;
+  // Top-level OTLP trace correlation. Callers that carry pino trace context
+  // (e.g. the scheduler's Tier-1 line) pass these so otlp.ts forwards them;
+  // omitted → null, unchanged for every existing caller (CTL-1424).
+  traceId?: string;
+  spanId?: string;
   attributes?: Record<string, unknown>;
   payload?: unknown;
   idExtra?: string;
@@ -54,8 +59,8 @@ export function buildCanonicalEnvelope(opts: BuildOpts): CanonicalEvent {
     id: deterministicId(ts, opts.eventName, opts.idExtra),
     severityText: opts.severityText ?? "INFO",
     severityNumber: opts.severityNumber ?? 9,
-    traceId: null,
-    spanId: null,
+    traceId: opts.traceId ?? null,
+    spanId: opts.spanId ?? null,
     // CTL-1368: built through buildCatalystResource so catalyst.node.class (the
     // node ROLE) is stamped LAST. service.name / service.version / host identity
     // are unchanged (host resolved via the bare hostName()/hostId() the helper

--- a/plugins/dev/scripts/otel-forward/lib/normalize.test.ts
+++ b/plugins/dev/scripts/otel-forward/lib/normalize.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect } from "bun:test";
-import { normalizeFlatEvent, isFlatEvent } from "./normalize.ts";
+import { normalizeFlatEvent, isFlatEvent, isPinoRecord, normalizePinoRecord } from "./normalize.ts";
 
 describe("isFlatEvent", () => {
   test("true for flat reap-intent record", () => {
@@ -81,5 +81,85 @@ describe("normalizeFlatEvent", () => {
       orch_id: "CTL-999",
     });
     expect(c.attributes["catalyst.orchestrator.id"]).toBe("CTL-999");
+  });
+});
+
+describe("isPinoRecord (CTL-1424)", () => {
+  test("true for pino-shaped record with numeric level and string msg", () => {
+    expect(isPinoRecord({ level: 40, msg: "some warning" })).toBe(true);
+  });
+
+  test("false for flat event (has string event field) — flat events win", () => {
+    expect(isPinoRecord({ event: "phase.x", level: 40, msg: "m" })).toBe(false);
+  });
+
+  test("false for canonical record (has attributes)", () => {
+    expect(isPinoRecord({ attributes: { "event.name": "x" }, level: 40, msg: "m" })).toBe(false);
+  });
+
+  test("false when level is string (not number)", () => {
+    expect(isPinoRecord({ level: "40", msg: "m" })).toBe(false);
+  });
+
+  test("false when msg is missing", () => {
+    expect(isPinoRecord({ level: 40 })).toBe(false);
+  });
+
+  test("false for null", () => {
+    expect(isPinoRecord(null)).toBe(false);
+  });
+
+  test("false for non-object", () => {
+    expect(isPinoRecord("string")).toBe(false);
+  });
+});
+
+describe("normalizePinoRecord (CTL-1424)", () => {
+  const BASE_TIME = 1751500000000;
+
+  test("level 40 → WARN / 13", () => {
+    const c = normalizePinoRecord({ level: 40, time: BASE_TIME, msg: "warn line", name: "execution-core", pid: 123 });
+    expect(c.severityText).toBe("WARN");
+    expect(c.severityNumber).toBe(13);
+  });
+
+  test("level 10 → TRACE / 1 (AC endpoint)", () => {
+    const c = normalizePinoRecord({ level: 10, time: BASE_TIME, msg: "trace line" });
+    expect(c.severityText).toBe("TRACE");
+    expect(c.severityNumber).toBe(1);
+  });
+
+  test("level 60 → FATAL / 21 (AC endpoint)", () => {
+    const c = normalizePinoRecord({ level: 60, time: BASE_TIME, msg: "fatal line" });
+    expect(c.severityText).toBe("FATAL");
+    expect(c.severityNumber).toBe(21);
+  });
+
+  test("resource service.name === catalyst.execution-core", () => {
+    const c = normalizePinoRecord({ level: 30, msg: "info" });
+    expect(c.resource["service.name"]).toBe("catalyst.execution-core");
+  });
+
+  test("ts derived from time (unix ms)", () => {
+    const c = normalizePinoRecord({ level: 30, time: BASE_TIME, msg: "info" });
+    expect(c.ts).toBe(new Date(BASE_TIME).toISOString());
+  });
+
+  test("body.message === msg", () => {
+    const c = normalizePinoRecord({ level: 30, time: BASE_TIME, msg: "the message" });
+    expect((c.body as { message: string }).message).toBe("the message");
+  });
+
+  test("residual fields (pid, name) preserved in body.payload", () => {
+    const c = normalizePinoRecord({ level: 30, time: BASE_TIME, msg: "m", pid: 42, name: "execution-core" });
+    const payload = (c.body as { payload: Record<string, unknown> }).payload;
+    expect(payload).toBeDefined();
+    expect(payload.pid).toBe(42);
+    expect(payload.name).toBe("execution-core");
+  });
+
+  test("output has attributes (passes processLine gate)", () => {
+    const c = normalizePinoRecord({ level: 30, msg: "info" });
+    expect("attributes" in c).toBe(true);
   });
 });

--- a/plugins/dev/scripts/otel-forward/lib/normalize.test.ts
+++ b/plugins/dev/scripts/otel-forward/lib/normalize.test.ts
@@ -89,8 +89,14 @@ describe("isPinoRecord (CTL-1424)", () => {
     expect(isPinoRecord({ level: 40, msg: "some warning" })).toBe(true);
   });
 
-  test("false for flat event (has string event field) — flat events win", () => {
-    expect(isPinoRecord({ event: "phase.x", level: 40, msg: "m" })).toBe(false);
+  test("true when a structured `event` field is present (reaper WARN/ERROR shape)", () => {
+    // A pino log with level+msg is a pino record even if it also carries an
+    // `event` field; processLine checks isPinoRecord first so severity survives.
+    expect(isPinoRecord({ event: "phase.x", level: 40, msg: "m" })).toBe(true);
+  });
+
+  test("false for a real flat catalyst event (no numeric level / string msg)", () => {
+    expect(isPinoRecord({ ts: "2026-06-01T00:00:00Z", event: "phase.x" })).toBe(false);
   });
 
   test("false for canonical record (has attributes)", () => {
@@ -118,7 +124,13 @@ describe("normalizePinoRecord (CTL-1424)", () => {
   const BASE_TIME = 1751500000000;
 
   test("level 40 → WARN / 13", () => {
-    const c = normalizePinoRecord({ level: 40, time: BASE_TIME, msg: "warn line", name: "execution-core", pid: 123 });
+    const c = normalizePinoRecord({
+      level: 40,
+      time: BASE_TIME,
+      msg: "warn line",
+      name: "execution-core",
+      pid: 123,
+    });
     expect(c.severityText).toBe("WARN");
     expect(c.severityNumber).toBe(13);
   });
@@ -151,7 +163,13 @@ describe("normalizePinoRecord (CTL-1424)", () => {
   });
 
   test("residual fields (pid, name) preserved in body.payload", () => {
-    const c = normalizePinoRecord({ level: 30, time: BASE_TIME, msg: "m", pid: 42, name: "execution-core" });
+    const c = normalizePinoRecord({
+      level: 30,
+      time: BASE_TIME,
+      msg: "m",
+      pid: 42,
+      name: "execution-core",
+    });
     const payload = (c.body as { payload: Record<string, unknown> }).payload;
     expect(payload).toBeDefined();
     expect(payload.pid).toBe(42);
@@ -161,5 +179,72 @@ describe("normalizePinoRecord (CTL-1424)", () => {
   test("output has attributes (passes processLine gate)", () => {
     const c = normalizePinoRecord({ level: 30, msg: "info" });
     expect("attributes" in c).toBe(true);
+  });
+
+  // CTL-1424 Codex P2 #3: service.name follows the pino logger `name`.
+  test("service.name derived from logger name (catalyst.<name>)", () => {
+    const c = normalizePinoRecord({ level: 40, time: BASE_TIME, msg: "m", name: "broker" });
+    expect(c.resource["service.name"]).toBe("catalyst.broker");
+  });
+
+  test("service.name not double-prefixed when name already catalyst.*", () => {
+    const c = normalizePinoRecord({
+      level: 40,
+      time: BASE_TIME,
+      msg: "m",
+      name: "catalyst.cloud-sync",
+    });
+    expect(c.resource["service.name"]).toBe("catalyst.cloud-sync");
+  });
+
+  // CTL-1424 Codex P2 #1: a pino WARN/ERROR carrying an `event` field keeps its
+  // severity, and the event field is preserved in payload (not treated as flat).
+  test("event-field WARN record keeps WARN severity, event lands in payload", () => {
+    const c = normalizePinoRecord({
+      level: 40,
+      time: BASE_TIME,
+      msg: "reaper: handler threw",
+      event: "phase.x.reap",
+    });
+    expect(c.severityText).toBe("WARN");
+    expect(c.severityNumber).toBe(13);
+    expect((c.body as { message: string }).message).toBe("reaper: handler threw");
+    const payload = (c.body as { payload: Record<string, unknown> }).payload;
+    expect(payload.event).toBe("phase.x.reap");
+  });
+
+  // CTL-1424 Codex P2 #4: pino trace context lifted to top-level traceId/spanId.
+  test("valid trace_id/span_id preserved at top level", () => {
+    const c = normalizePinoRecord({
+      level: 30,
+      time: BASE_TIME,
+      msg: "tick",
+      trace_id: "6fe12c6b16282dc66b1da0b1b96e403c",
+      span_id: "c68263307ba267a2",
+    });
+    expect(c.traceId).toBe("6fe12c6b16282dc66b1da0b1b96e403c");
+    expect(c.spanId).toBe("c68263307ba267a2");
+  });
+
+  test("malformed trace_id/span_id are dropped (stay null)", () => {
+    const c = normalizePinoRecord({
+      level: 30,
+      time: BASE_TIME,
+      msg: "m",
+      trace_id: "not-hex",
+      span_id: "xyz",
+    });
+    expect(c.traceId).toBeNull();
+    expect(c.spanId).toBeNull();
+  });
+
+  // CTL-1424 Codex P2 #2: same-ms bursts get distinct ids / logRecordUids.
+  test("distinct ids for same-ms records that differ in msg or severity", () => {
+    const base = { time: BASE_TIME, name: "execution-core", pid: 7 };
+    const a = normalizePinoRecord({ ...base, level: 40, msg: "first" });
+    const b = normalizePinoRecord({ ...base, level: 40, msg: "second" });
+    const cWarn = normalizePinoRecord({ ...base, level: 50, msg: "first" });
+    expect(a.id).not.toBe(b.id);
+    expect(a.id).not.toBe(cWarn.id);
   });
 });

--- a/plugins/dev/scripts/otel-forward/lib/normalize.ts
+++ b/plugins/dev/scripts/otel-forward/lib/normalize.ts
@@ -20,17 +20,23 @@ export function isFlatEvent(obj: unknown): obj is Record<string, unknown> {
   return typeof o.event === "string" && !("attributes" in o);
 }
 
-// A pino-shaped operational log: numeric `level` + string `msg`, no `event`
-// string and no `attributes` block (those belong to flat / canonical records).
+// A pino-shaped operational log: numeric `level` + string `msg`, no
+// `attributes` block (that belongs to already-canonical records). A structured
+// `event` field is ALLOWED — execution-core pino calls attach one as ordinary
+// structured data (e.g. `reaper.mjs` logs `{ level, msg, event }` on WARN/ERROR)
+// — and processLine checks isPinoRecord BEFORE isFlatEvent so those records keep
+// their severity instead of being misread as flat INFO events (CTL-1424).
 export function isPinoRecord(obj: unknown): obj is Record<string, unknown> {
   if (typeof obj !== "object" || obj === null) return false;
   const o = obj as Record<string, unknown>;
-  return (
-    typeof o.level === "number" &&
-    typeof o.msg === "string" &&
-    typeof o.event !== "string" &&
-    !("attributes" in o)
-  );
+  return typeof o.level === "number" && typeof o.msg === "string" && !("attributes" in o);
+}
+
+// isHexId — an OTLP trace/span id is a fixed-length lowercase-hex string
+// (32 for trace, 16 for span). Validate before forwarding so a malformed
+// value never reaches the collector (which would reject the whole record).
+function isHexId(v: unknown, len: number): v is string {
+  return typeof v === "string" && v.length === len && /^[0-9a-f]+$/i.test(v);
 }
 
 export function normalizePinoRecord(rec: Record<string, unknown>): CanonicalEvent {
@@ -45,13 +51,35 @@ export function normalizePinoRecord(rec: Record<string, unknown>): CanonicalEven
     payload[key] = val;
   }
 
-  const eventName = typeof rec.name === "string" ? rec.name : "execution-core";
+  // Each daemon pino logger sets its own `name` (execution-core, broker,
+  // cloud-sync, …) and the repo convention maps each to its own OTel service
+  // `catalyst.<name>`, so a broker log routes under catalyst.broker rather than
+  // being mis-stamped catalyst.execution-core and vanishing from service-scoped
+  // OTLP/Loki queries (CTL-1424).
+  const loggerName = typeof rec.name === "string" && rec.name ? rec.name : "execution-core";
+  const serviceName = loggerName.startsWith("catalyst.") ? loggerName : `catalyst.${loggerName}`;
+
+  // Preserve pino trace context: the scheduler stamps trace_id/span_id on its
+  // Tier-1 line for log↔Tempo pivoting, so lift them to the envelope's top-level
+  // traceId/spanId (the only fields otlp.ts forwards) instead of leaving the
+  // correlation stranded in body.payload (CTL-1424).
+  const traceId = isHexId(rec.trace_id, 32) ? rec.trace_id : undefined;
+  const spanId = isHexId(rec.span_id, 16) ? rec.span_id : undefined;
+
   const ev = buildCanonicalEnvelope({
     ts,
-    serviceName: "catalyst.execution-core",
-    eventName,
+    serviceName,
+    eventName: loggerName,
     severityText,
     severityNumber,
+    traceId,
+    spanId,
+    // Disambiguate bursts: pino `time` is ms-precision and `name` is constant
+    // per logger, so without an idExtra two records emitted in the same ms would
+    // collide on the deterministic id / OTLP logRecordUid and be deduped or
+    // mis-correlated downstream. pid + level + msg keeps distinct lines distinct
+    // while staying deterministic (no Math.random in the hot path) (CTL-1424).
+    idExtra: `${typeof rec.pid === "number" ? rec.pid : ""}:${severityNumber}:${rec.msg as string}`,
     payload: Object.keys(payload).length > 0 ? payload : undefined,
   });
   // Override body.message with the actual log message rather than the event name.

--- a/plugins/dev/scripts/otel-forward/lib/normalize.ts
+++ b/plugins/dev/scripts/otel-forward/lib/normalize.ts
@@ -1,5 +1,6 @@
 import type { CanonicalEvent } from "../../orch-monitor/lib/canonical-event.ts";
 import { buildCanonicalEnvelope } from "./canonical.ts";
+import { pinoLevelToSeverity } from "./pino-severity.ts";
 
 // Promote key identifier fields to OTel attributes. All other flat fields
 // land in body.payload (nothing dropped). Fields not listed here are not
@@ -17,6 +18,45 @@ export function isFlatEvent(obj: unknown): obj is Record<string, unknown> {
   if (typeof obj !== "object" || obj === null) return false;
   const o = obj as Record<string, unknown>;
   return typeof o.event === "string" && !("attributes" in o);
+}
+
+// A pino-shaped operational log: numeric `level` + string `msg`, no `event`
+// string and no `attributes` block (those belong to flat / canonical records).
+export function isPinoRecord(obj: unknown): obj is Record<string, unknown> {
+  if (typeof obj !== "object" || obj === null) return false;
+  const o = obj as Record<string, unknown>;
+  return (
+    typeof o.level === "number" &&
+    typeof o.msg === "string" &&
+    typeof o.event !== "string" &&
+    !("attributes" in o)
+  );
+}
+
+export function normalizePinoRecord(rec: Record<string, unknown>): CanonicalEvent {
+  const time = typeof rec.time === "number" && rec.time > 0 ? rec.time : undefined;
+  const ts = time !== undefined ? new Date(time).toISOString() : new Date().toISOString();
+  const { text: severityText, number: severityNumber } = pinoLevelToSeverity(rec.level);
+
+  // Residual fields: everything except `level`, `time`, `msg` goes to payload.
+  const payload: Record<string, unknown> = {};
+  for (const [key, val] of Object.entries(rec)) {
+    if (key === "level" || key === "time" || key === "msg") continue;
+    payload[key] = val;
+  }
+
+  const eventName = typeof rec.name === "string" ? rec.name : "execution-core";
+  const ev = buildCanonicalEnvelope({
+    ts,
+    serviceName: "catalyst.execution-core",
+    eventName,
+    severityText,
+    severityNumber,
+    payload: Object.keys(payload).length > 0 ? payload : undefined,
+  });
+  // Override body.message with the actual log message rather than the event name.
+  (ev.body as Record<string, unknown>).message = rec.msg as string;
+  return ev;
 }
 
 export function normalizeFlatEvent(flat: Record<string, unknown>): CanonicalEvent {

--- a/plugins/dev/scripts/otel-forward/lib/pino-severity.test.ts
+++ b/plugins/dev/scripts/otel-forward/lib/pino-severity.test.ts
@@ -1,0 +1,48 @@
+import { describe, test, expect } from "bun:test";
+import { pinoLevelToSeverity } from "./pino-severity.ts";
+
+describe("pinoLevelToSeverity (CTL-1424)", () => {
+  test("10 → TRACE / 1", () => {
+    expect(pinoLevelToSeverity(10)).toEqual({ text: "TRACE", number: 1 });
+  });
+
+  test("20 → DEBUG / 5", () => {
+    expect(pinoLevelToSeverity(20)).toEqual({ text: "DEBUG", number: 5 });
+  });
+
+  test("30 → INFO / 9", () => {
+    expect(pinoLevelToSeverity(30)).toEqual({ text: "INFO", number: 9 });
+  });
+
+  test("40 → WARN / 13", () => {
+    expect(pinoLevelToSeverity(40)).toEqual({ text: "WARN", number: 13 });
+  });
+
+  test("50 → ERROR / 17", () => {
+    expect(pinoLevelToSeverity(50)).toEqual({ text: "ERROR", number: 17 });
+  });
+
+  test("60 → FATAL / 21", () => {
+    expect(pinoLevelToSeverity(60)).toEqual({ text: "FATAL", number: 21 });
+  });
+
+  test("unknown level 35 → INFO / 9", () => {
+    expect(pinoLevelToSeverity(35)).toEqual({ text: "INFO", number: 9 });
+  });
+
+  test("level 0 → INFO / 9", () => {
+    expect(pinoLevelToSeverity(0)).toEqual({ text: "INFO", number: 9 });
+  });
+
+  test("NaN → INFO / 9", () => {
+    expect(pinoLevelToSeverity(NaN)).toEqual({ text: "INFO", number: 9 });
+  });
+
+  test("non-number → INFO / 9", () => {
+    expect(pinoLevelToSeverity("40")).toEqual({ text: "INFO", number: 9 });
+  });
+
+  test("undefined → INFO / 9", () => {
+    expect(pinoLevelToSeverity(undefined)).toEqual({ text: "INFO", number: 9 });
+  });
+});

--- a/plugins/dev/scripts/otel-forward/lib/pino-severity.ts
+++ b/plugins/dev/scripts/otel-forward/lib/pino-severity.ts
@@ -1,0 +1,17 @@
+import type { Severity } from "../../orch-monitor/lib/canonical-event-shared.ts";
+import { SEVERITY_NUMBERS } from "../../orch-monitor/lib/canonical-event-shared.ts";
+
+const PINO_LEVEL_TO_TEXT: Record<number, Severity> = {
+  10: "TRACE",
+  20: "DEBUG",
+  30: "INFO",
+  40: "WARN",
+  50: "ERROR",
+  60: "FATAL",
+};
+
+export function pinoLevelToSeverity(level: unknown): { text: Severity; number: number } {
+  const t = typeof level === "number" && !Number.isNaN(level) ? PINO_LEVEL_TO_TEXT[level] : undefined;
+  const text = t ?? "INFO";
+  return { text, number: SEVERITY_NUMBERS[text] };
+}

--- a/plugins/dev/scripts/otel-forward/lib/tail.ts
+++ b/plugins/dev/scripts/otel-forward/lib/tail.ts
@@ -30,14 +30,19 @@ export function createTailer(opts: TailerOpts): Tailer {
   let currentPath = opts.filePath ?? monthFn();
   let offset = opts.offset;
 
-  // Accept canonical OTel envelopes (have `attributes`) AND flat reap-intent
-  // records (have `event` but no `attributes`). processLine normalizes flat
-  // records into canonical form before forwarding.
+  // Accept canonical OTel envelopes (have `attributes`), flat reap-intent
+  // records (have `event` but no `attributes`), and pino operational logs
+  // (have numeric `level` + string `msg`, no `event` or `attributes`).
+  // processLine normalizes flat/pino records into canonical form before forwarding.
   function shouldForward(line: string): boolean {
     try {
-      const obj = JSON.parse(line);
+      const obj = JSON.parse(line) as Record<string, unknown>;
       if (typeof obj !== "object" || obj === null) return false;
-      return "attributes" in obj || typeof (obj as Record<string, unknown>).event === "string";
+      return (
+        "attributes" in obj ||
+        typeof obj.event === "string" ||
+        (typeof obj.level === "number" && typeof obj.msg === "string")
+      );
     } catch {
       return false;
     }

--- a/plugins/dev/scripts/otel-forward/package.json
+++ b/plugins/dev/scripts/otel-forward/package.json
@@ -10,6 +10,6 @@
     "pino": "^9.6.0"
   },
   "devDependencies": {
-    "@types/bun": "^1.3.12"
+    "@types/bun": "^1.3.14"
   }
 }


### PR DESCRIPTION
<!-- Auto-generated: 2026-07-03T12:03:00Z -->
<!-- Last updated: 2026-07-03T12:03:00Z -->
<!-- PR: #2558 -->
<!-- Previous commits: f3d680a1114389898332495083093c91dc3bab73 -->

## Summary

Sets `SeverityNumber` / `SeverityText` on OTLP `LogRecord`s produced by `otel-forward` when the
input is a pino operational log. Previously, every pino log shipped as UNKNOWN severity because
`otel-forward` only set those fields for canonical events (which carry severity explicitly). With
this change the producer itself maps pino's numeric `level` (10=TRACE … 60=FATAL) to the correct
OTel values at emit time, making the interim collector-side OTTL mapping redundant.

## Changes Made

### `otel-forward` — pino record detection and normalization

- **`lib/pino-severity.ts`** (new): single source of truth for the pino-level → OTel severity
  table (`10→TRACE/1, 20→DEBUG/5, 30→INFO/9, 40→WARN/13, 50→ERROR/17, 60→FATAL/21`).
- **`lib/normalize.ts`**: added `isPinoRecord` (numeric `level` + string `msg`, no `event` string,
  no `attributes` block) and `normalizePinoRecord` (builds a full `CanonicalEvent` with correct
  `severityText`/`severityNumber`, `ts` derived from `time`, residual fields preserved in
  `body.payload`).
- **`lib/tail.ts`**: `shouldForward` now accepts pino-shaped lines so the tailer emits them through
  the `onLine` callback.
- **`index.ts`**: `processLine` routes pino records through `normalizePinoRecord` before the
  attributes gate; canonical events with severity already set are unchanged.

### `orch-monitor/lib/canonical-event-shared.ts` — wider `Severity` union

- Added `TRACE` (SeverityNumber 1) and `FATAL` (21) to the `Severity` type and
  `SEVERITY_NUMBERS` map so downstream consumers (including the shared type file) can express the
  full pino range without `as` casts.

### Tests

- **`lib/pino-severity.test.ts`** (new): 7 tests covering all six levels plus the unknown-level
  fallback.
- **`lib/normalize.test.ts`**: 16 new tests for `isPinoRecord` and `normalizePinoRecord` (AC
  endpoints: level 10→TRACE/1, 60→FATAL/21; body/payload/resource/ts fields).
- **`index.test.ts`**: 3 new integration tests (pino record counted as processed, canonical
  unchanged through `processLine`, tailer emits pino-shaped lines via `onLine`).
- **`canonical-event-shared.test.ts`** (new): 5 tests verifying the TRACE/FATAL constants and the
  `severityNumber()` helper.
- **Total: 109 tests pass** (104 otel-forward + 5 canonical-event-shared).

## How to Verify It

- [x] All CI checks pass ✅ (CodeQL, quality, agents-md-gate, docs-gate, audit-references,
  check-versions, gitleaks, validate, Cloudflare Pages)
- [x] `bun test` in `plugins/dev/scripts/otel-forward/` passes all 104 tests ✅
- [x] `bun test` in `plugins/dev/scripts/orch-monitor/` passes (canonical-event-shared tests) ✅
- [ ] Manual: deploy to staging and confirm a pino log at `level: 40` arrives in Loki with
  `severity_text = "WARN"` and `severity_number = 13` rather than UNKNOWN.
- [ ] Manual: confirm that a canonical event already carrying `severityText: "ERROR"` is unchanged
  after the producer fix (collector OTTL guard no-ops on already-set records).

## Related Issues/PRs

- Fixes https://linear.app/coalesce-labs/issue/CTL-1424

## Changelog Entry

```
feat(dev): otel-forward now maps pino log levels to OTel SeverityNumber/Text at emit time,
eliminating UNKNOWN severity on operational logs (TRACE/DEBUG/INFO/WARN/ERROR/FATAL all
correctly set). The interim collector-side OTTL mapping is now redundant.
```
