### PR TITLE
feat(dev): CTL-1430 (WS-A A1) — instrument the Linear breaker (reason+caller on OPEN + durable linear.ratelimit.breaker event)

### DIFF
--- a/.github/workflows/execution-core-tests.yml
+++ b/.github/workflows/execution-core-tests.yml
@@ -253,6 +253,7 @@ jobs:
             job-dir-gc.test.mjs \
             label-guard.test.mjs \
             linear-breaker.test.mjs \
+            linear-ratelimit-event.test.mjs \
             linear-cache.test.mjs \
             linear-estimation-method.test.mjs \
             linear-query.test.mjs \

--- a/plugins/dev/scripts/execution-core/cluster-heartbeat-publisher.mjs
+++ b/plugins/dev/scripts/execution-core/cluster-heartbeat-publisher.mjs
@@ -188,7 +188,16 @@ export function startLivenessPublisher({
         // bug surfaces rather than being masked as "rate limited". We never call
         // recordSuccess here: a light heartbeat success must not force-close the
         // breaker while heavier reads are still being rate-limited.
-        if (isRateClassLinearError(result.error)) breaker?.recordRateLimited?.();
+        // CTL-1430: attribute this trip to the heartbeat publisher (a rate-class
+        // failure = 429-class) so the durable linear.ratelimit.breaker event names
+        // the caller — the WS-A diagnosis needs to know how much of the flap is
+        // this ~2min anchor write vs. the read paths.
+        if (isRateClassLinearError(result.error)) {
+          breaker?.recordRateLimited?.(undefined, {
+            reason: "429",
+            caller: "cluster-heartbeat-publisher",
+          });
+        }
         if (consecutiveFailures === 0) {
           logger.warn(
             { host: self, anchorIssue, error: result.error },

--- a/plugins/dev/scripts/execution-core/linear-breaker.mjs
+++ b/plugins/dev/scripts/execution-core/linear-breaker.mjs
@@ -12,6 +12,7 @@
 // exponentially-backed-off cooldown — without spawning linearis at all — until
 // the cooldown elapses. A clean call CLOSES it and resets the backoff.
 import { log } from "./config.mjs";
+import { emitLinearBreakerEvent } from "./linear-ratelimit-event.mjs";
 
 // The 429 shape linearis surfaces on stderr: "Rate limit exceeded. Only 2500
 // requests are allowed per 1 hour". Matched case-insensitively and loosely so a
@@ -27,10 +28,16 @@ const MAX_COOLDOWN_MS = 15 * 60_000; // backoff ceiling
 // shared singleton (`linearBreaker`) that both exec wrappers consume so one 429
 // pauses the whole process; the factory exists so tests get an isolated breaker
 // and can drive its clock via the injected `now`.
+// CTL-1430: `emitEvent` is an injectable durable-event emitter. It defaults to a
+// NO-OP so unit-constructed breakers (and every existing behavior test) never
+// touch the real event log; the production singleton below wires the real
+// emitLinearBreakerEvent, and tests that assert emission inject a spy. This keeps
+// the pure control-flow tests hermetic while production emits observable events.
 export function createLinearBreaker({
   baseCooldownMs = BASE_COOLDOWN_MS,
   maxCooldownMs = MAX_COOLDOWN_MS,
   logger = log,
+  emitEvent = () => {},
 } = {}) {
   let openUntil = 0; // epoch ms the breaker stays open until (0 = closed)
   let consecutive = 0; // consecutive 429s with no intervening success → backoff exponent
@@ -42,32 +49,41 @@ export function createLinearBreaker({
       return now < openUntil;
     },
 
-    // recordRateLimited — a real spawn just returned a 429. Open (or re-arm) the
-    // breaker with exponential backoff (base × 2^(n-1), capped), honoring a
-    // larger Retry-After hint when present. Only ever called from a CLOSED state
-    // (an open breaker short-circuits before spawning), so each call is a
-    // closed→open transition and logs exactly one "circuit open" line.
-    recordRateLimited(now = Date.now(), { retryAfterMs } = {}) {
+    // recordRateLimited — a real spawn just returned a 429 or blew the CTL-1341
+    // wall-clock cap. Open (or re-arm) the breaker with exponential backoff
+    // (base × 2^(n-1), capped), honoring a larger Retry-After hint when present.
+    // Only ever called from a CLOSED state (an open breaker short-circuits before
+    // spawning), so each call is a closed→open transition and logs exactly one
+    // "circuit open" line + emits one durable open event.
+    // CTL-1430: `reason` ("429" | "timeout") and `caller` (which Linear path
+    // spawned the failing call) land on both the log line and the event so the
+    // steadily-flapping breaker is finally attributable.
+    recordRateLimited(now = Date.now(), { retryAfterMs, reason = null, caller = null } = {}) {
       consecutive += 1;
       const backoff = Math.min(baseCooldownMs * 2 ** (consecutive - 1), maxCooldownMs);
       const cooldownMs = Math.max(backoff, retryAfterMs ?? 0);
       openUntil = now + cooldownMs;
       logger.warn(
-        { consecutive, cooldownMs, openUntil },
+        { consecutive, cooldownMs, openUntil, reason, caller },
         "ctl-679: Linear circuit breaker OPEN — pausing all Linear calls"
       );
+      emitEvent({ state: "open", reason, caller, cooldownMs, consecutive });
     },
 
     // recordSuccess — a clean call landed; close the breaker and reset backoff.
-    // Logs a single "circuit closed" line only when transitioning out of a
-    // degraded state (so steady-state successes stay silent).
+    // Logs a single "circuit closed" line + emits one durable close event only
+    // when transitioning out of a degraded state (so steady-state successes stay
+    // silent). CTL-1430: the close event carries recoveredAfter (the consecutive
+    // failure count that preceded recovery) so a dashboard can pair open↔close.
     recordSuccess() {
       if (consecutive === 0 && openUntil === 0) return;
       const wasDegraded = consecutive > 0;
+      const recoveredAfter = consecutive;
       consecutive = 0;
       openUntil = 0;
       if (wasDegraded) {
         logger.info({}, "ctl-679: Linear circuit breaker CLOSED — calls resumed");
+        emitEvent({ state: "closed", recoveredAfter });
       }
     },
 
@@ -79,8 +95,25 @@ export function createLinearBreaker({
 }
 
 // The process-wide singleton both exec wrappers (linear-write.mjs,
-// linear-query.mjs) share so a 429 on any path pauses every path.
-export const linearBreaker = createLinearBreaker();
+// linear-query.mjs) share so a 429 on any path pauses every path. CTL-1430: it is
+// the ONE production instance wired to the real durable-event emitter (factory
+// default is a no-op so test breakers stay hermetic).
+export const linearBreaker = createLinearBreaker({ emitEvent: emitLinearBreakerEvent });
+
+// deriveCaller — a compact, allocation-free tag for WHICH Linear path spawned the
+// failing call, derived from the exec argv (e.g. "linearis" + ["issues","list"] →
+// "linearis:issues-list"). Used when the call site did not pass an explicit
+// `opts.caller`. Enough granularity to rank callers in the CTL-1430 diagnosis
+// (issues-list vs issues-read vs a transition script) without touching every site.
+export function deriveCaller(cmd, args) {
+  const base = String(cmd ?? "").split("/").pop() || "unknown";
+  const a = Array.isArray(args) ? args : [];
+  const sub = a
+    .filter((x) => typeof x === "string" && !x.startsWith("-"))
+    .slice(0, 2)
+    .join("-");
+  return sub ? `${base}:${sub}` : base;
+}
 
 // withBreaker — wrap a raw exec (the spawnSync normalizer) so it consults the
 // breaker before spawning and feeds the result back. When open it returns a
@@ -105,7 +138,11 @@ export function withBreaker(rawExec, { breaker = linearBreaker, now = Date.now }
     // per-call cap alone left recovery-pass at ~N×8s). A >8s linearis read is
     // genuinely abnormal (healthy reads are sub-second), so the backoff is right.
     if (res.code !== 0 && (res.timedOut || isRateLimitError(res.stderr))) {
-      breaker.recordRateLimited(t);
+      // CTL-1430: tag WHY (timeout vs 429) and WHO (explicit opts.caller, else the
+      // argv-derived tag) so the OPEN log line + durable event are attributable.
+      const reason = res.timedOut ? "timeout" : "429";
+      const caller = opts?.caller ?? deriveCaller(cmd, args);
+      breaker.recordRateLimited(t, { reason, caller });
     } else if (res.code === 0) {
       breaker.recordSuccess();
     }

--- a/plugins/dev/scripts/execution-core/linear-breaker.mjs
+++ b/plugins/dev/scripts/execution-core/linear-breaker.mjs
@@ -108,10 +108,21 @@ export const linearBreaker = createLinearBreaker({ emitEvent: emitLinearBreakerE
 export function deriveCaller(cmd, args) {
   const base = String(cmd ?? "").split("/").pop() || "unknown";
   const a = Array.isArray(args) ? args : [];
-  const sub = a
-    .filter((x) => typeof x === "string" && !x.startsWith("-"))
-    .slice(0, 2)
-    .join("-");
+  // Take only the positional subcommand tokens that appear BEFORE the first flag
+  // (`issues list` from `linearis issues list --team CTL`). Stopping at the first
+  // `-`-prefixed token avoids capturing flag VALUES: a status write
+  // `linear-transition.sh --ticket CTL-123 --transition research` yields just the
+  // basename, not a per-ticket high-cardinality `…:CTL-123-research` tag (CTL-1430
+  // Codex review). linearis reads put the subcommand first, so this keeps their
+  // granularity (`linearis:issues-list`, `linearis:issues-read`).
+  const positional = [];
+  for (const x of a) {
+    if (typeof x !== "string") continue;
+    if (x.startsWith("-")) break;
+    positional.push(x);
+    if (positional.length === 2) break;
+  }
+  const sub = positional.join("-");
   return sub ? `${base}:${sub}` : base;
 }
 

--- a/plugins/dev/scripts/execution-core/linear-breaker.test.mjs
+++ b/plugins/dev/scripts/execution-core/linear-breaker.test.mjs
@@ -1,7 +1,7 @@
 // linear-breaker.test.mjs — Linear rate-limit circuit breaker (CTL-679).
 // Run: cd plugins/dev/scripts/execution-core && bun test linear-breaker.test.mjs
 import { describe, test, expect } from "bun:test";
-import { createLinearBreaker, withBreaker, isRateLimitError } from "./linear-breaker.mjs";
+import { createLinearBreaker, withBreaker, isRateLimitError, deriveCaller } from "./linear-breaker.mjs";
 
 const silentLogger = { warn() {}, info() {}, error() {} };
 const RATE_LIMIT_STDERR = "Rate limit exceeded. Only 2500 requests are allowed per 1 hour";
@@ -209,5 +209,107 @@ describe("withBreaker", () => {
     const exec = withBreaker(raw, { breaker });
     exec("linearis", ["issues", "list"]);
     expect(calls[0][2]).toBeUndefined();
+  });
+});
+
+describe("deriveCaller (CTL-1430)", () => {
+  test("tags a linearis subcommand from the argv (basename + first two non-flag args)", () => {
+    expect(deriveCaller("linearis", ["issues", "list"])).toBe("linearis:issues-list");
+    expect(deriveCaller("/usr/local/bin/linearis", ["issues", "read", "CTL-1"])).toBe("linearis:issues-read");
+  });
+  test("skips leading flags when picking the subcommand tag", () => {
+    expect(deriveCaller("linearis", ["--json", "issues", "list"])).toBe("linearis:issues-list");
+  });
+  test("falls back to the bare basename when there are no positional args", () => {
+    expect(deriveCaller("linear-transition.sh", [])).toBe("linear-transition.sh");
+    expect(deriveCaller("/opt/bin/linear-transition.sh", ["--flag-only"])).toBe("linear-transition.sh");
+  });
+  test("never throws on missing/oddly-typed argv", () => {
+    expect(deriveCaller(undefined, undefined)).toBe("unknown");
+    expect(deriveCaller("linearis", null)).toBe("linearis");
+  });
+});
+
+describe("CTL-1430: breaker reason/caller + durable event", () => {
+  test("recordRateLimited puts reason+caller on the OPEN log line", () => {
+    const warned = [];
+    const logger = { warn: (o, _m) => warned.push(o), info() {} };
+    const b = createLinearBreaker({ logger, baseCooldownMs: 1000 });
+    b.recordRateLimited(0, { reason: "timeout", caller: "linearis:issues-read" });
+    expect(warned).toHaveLength(1);
+    expect(warned[0].reason).toBe("timeout");
+    expect(warned[0].caller).toBe("linearis:issues-read");
+  });
+
+  test("recordRateLimited emits one durable OPEN event with reason/caller/cooldown/consecutive", () => {
+    const events = [];
+    const b = createLinearBreaker({
+      logger: silentLogger,
+      baseCooldownMs: 1000,
+      emitEvent: (e) => events.push(e),
+    });
+    b.recordRateLimited(0, { reason: "429", caller: "cluster-heartbeat-publisher" });
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({
+      state: "open",
+      reason: "429",
+      caller: "cluster-heartbeat-publisher",
+      cooldownMs: 1000,
+      consecutive: 1,
+    });
+  });
+
+  test("recordSuccess emits one durable CLOSED event carrying recoveredAfter", () => {
+    const events = [];
+    const b = createLinearBreaker({
+      logger: silentLogger,
+      baseCooldownMs: 1000,
+      emitEvent: (e) => events.push(e),
+    });
+    b.recordRateLimited(0, { reason: "429", caller: "x" });
+    b.recordRateLimited(1000, { reason: "429", caller: "x" }); // consecutive → 2
+    b.recordSuccess();
+    const closed = events.filter((e) => e.state === "closed");
+    expect(closed).toHaveLength(1);
+    expect(closed[0].recoveredAfter).toBe(2);
+  });
+
+  test("a steady-state success (never degraded) emits NO event", () => {
+    const events = [];
+    const b = createLinearBreaker({ logger: silentLogger, emitEvent: (e) => events.push(e) });
+    b.recordSuccess();
+    expect(events).toHaveLength(0);
+  });
+
+  test("the factory default emitEvent is a no-op (hermetic — never touches the real log)", () => {
+    const b = createLinearBreaker({ logger: silentLogger });
+    expect(() => b.recordRateLimited(0, { reason: "429", caller: "x" })).not.toThrow();
+  });
+
+  test("withBreaker tags a 429 with reason='429' + the argv-derived caller", () => {
+    const events = [];
+    const breaker = createLinearBreaker({ logger: silentLogger, emitEvent: (e) => events.push(e) });
+    const raw = () => ({ code: 1, stdout: "", stderr: RATE_LIMIT_STDERR });
+    const exec = withBreaker(raw, { breaker, now: () => 0 });
+    exec("linearis", ["issues", "list"]);
+    expect(events[0]).toMatchObject({ state: "open", reason: "429", caller: "linearis:issues-list" });
+  });
+
+  test("withBreaker tags a timed-out read with reason='timeout'", () => {
+    const events = [];
+    const breaker = createLinearBreaker({ logger: silentLogger, emitEvent: (e) => events.push(e) });
+    const raw = () => ({ code: 1, timedOut: true, stdout: "", stderr: "" });
+    const exec = withBreaker(raw, { breaker, now: () => 0 });
+    exec("linearis", ["issues", "read", "CTL-9"]);
+    expect(events[0]).toMatchObject({ state: "open", reason: "timeout", caller: "linearis:issues-read" });
+  });
+
+  test("an explicit opts.caller overrides the argv-derived tag", () => {
+    const events = [];
+    const breaker = createLinearBreaker({ logger: silentLogger, emitEvent: (e) => events.push(e) });
+    const raw = () => ({ code: 1, stdout: "", stderr: RATE_LIMIT_STDERR });
+    const exec = withBreaker(raw, { breaker, now: () => 0 });
+    exec("linearis", ["issues", "list"], { caller: "open-pr-gate" });
+    expect(events[0].caller).toBe("open-pr-gate");
   });
 });

--- a/plugins/dev/scripts/execution-core/linear-breaker.test.mjs
+++ b/plugins/dev/scripts/execution-core/linear-breaker.test.mjs
@@ -217,8 +217,17 @@ describe("deriveCaller (CTL-1430)", () => {
     expect(deriveCaller("linearis", ["issues", "list"])).toBe("linearis:issues-list");
     expect(deriveCaller("/usr/local/bin/linearis", ["issues", "read", "CTL-1"])).toBe("linearis:issues-read");
   });
-  test("skips leading flags when picking the subcommand tag", () => {
-    expect(deriveCaller("linearis", ["--json", "issues", "list"])).toBe("linearis:issues-list");
+  test("stops at the first flag so flag VALUES never become caller tags (no ticket cardinality)", () => {
+    // A status write is flags-first (`--ticket CTL-123 …`) → just the basename, NOT
+    // a per-ticket `…:CTL-123-research` tag (the CTL-1430 Codex F2 finding).
+    expect(deriveCaller("linear-transition.sh", ["--ticket", "CTL-123", "--transition", "research"])).toBe(
+      "linear-transition.sh",
+    );
+    // Flags AFTER the subcommand are dropped; the subcommand is kept.
+    expect(deriveCaller("linearis", ["issues", "list", "--team", "CTL"])).toBe("linearis:issues-list");
+    // A leading global flag stops collection → basename (real linearis reads put the
+    // subcommand first, so this edge only costs granularity, never cardinality).
+    expect(deriveCaller("linearis", ["--api-token", "x", "issues", "list"])).toBe("linearis");
   });
   test("falls back to the bare basename when there are no positional args", () => {
     expect(deriveCaller("linear-transition.sh", [])).toBe("linear-transition.sh");

--- a/plugins/dev/scripts/execution-core/linear-query.mjs
+++ b/plugins/dev/scripts/execution-core/linear-query.mjs
@@ -499,7 +499,10 @@ function defaultBatchExec(ids) {
   if (linearBreaker.isOpen()) return null; // circuit-open → skip, no spawn
   let r = runBatchOnce(ids);
   if (r.auth && linearReminter.attempt()) r = runBatchOnce(ids);
-  if (r.ratelimit) { linearBreaker.recordRateLimited(); return null; }
+  // CTL-1430: the CTL-784 batched GraphQL POST is not wrapped by withBreaker, so
+  // tag its direct breaker trip (429/RATELIMITED) here — otherwise it lands
+  // unattributed (reason/caller null) on the new breaker log line + event.
+  if (r.ratelimit) { linearBreaker.recordRateLimited(undefined, { reason: "429", caller: "linear-query:fetchTicketsBatch" }); return null; }
   if (r.nodes == null) return null; // auth-after-retry, curlFailed, or unparseable
   linearBreaker.recordSuccess();
   return r.nodes;
@@ -879,7 +882,8 @@ function defaultDelegateBatchExec(team, identifiers) {
   if (linearBreaker.isOpen()) return null;
   let r = runDelegateBatchOnce(team, identifiers);
   if (r.auth && linearReminter.attempt()) r = runDelegateBatchOnce(team, identifiers);
-  if (r.ratelimit) { linearBreaker.recordRateLimited(); return null; }
+  // CTL-1430: same direct (un-withBreaker'd) trip as defaultBatchExec — attribute it.
+  if (r.ratelimit) { linearBreaker.recordRateLimited(undefined, { reason: "429", caller: "linear-query:fetchTicketsDelegateBatch" }); return null; }
   if (r.nodes == null) return null;
   linearBreaker.recordSuccess();
   return r.nodes;

--- a/plugins/dev/scripts/execution-core/linear-ratelimit-event.mjs
+++ b/plugins/dev/scripts/execution-core/linear-ratelimit-event.mjs
@@ -57,6 +57,17 @@ export function buildLinearBreakerEnvelope({
       "event.entity": "linear",
       "event.action": open ? "ratelimit.breaker.open" : "ratelimit.breaker.closed",
       "event.label": host,
+      // CTL-1430 (Codex F3): promote the discriminating fields to OTLP attributes so
+      // they survive the otel-forward→Loki path as structured metadata (body.payload
+      // is NOT forwarded — only attributes + body.message are). Kept in body.payload
+      // too for direct JSONL readers (board-health deriveRing / grep).
+      "catalyst.linear.breaker.state": open ? "open" : "closed",
+      ...(open
+        ? {
+            "catalyst.linear.breaker.reason": reason ?? "unknown",
+            "catalyst.linear.breaker.caller": caller ?? "unknown",
+          }
+        : {}),
     },
     body: {
       payload: {

--- a/plugins/dev/scripts/execution-core/linear-ratelimit-event.mjs
+++ b/plugins/dev/scripts/execution-core/linear-ratelimit-event.mjs
@@ -1,0 +1,101 @@
+// linear-ratelimit-event.mjs — CTL-1430 (WS-A A1). Durable open/close event for
+// the CTL-679 Linear rate-limit circuit breaker.
+//
+// Mirrors drain-event.mjs: OTel envelope, appendFileSync, never throws.
+// One event type, two states:
+//   linear.ratelimit.breaker (state:"open")   — a Linear call tripped the breaker
+//   linear.ratelimit.breaker (state:"closed") — a clean call closed it again
+//
+// The OPEN event carries WHY (`reason`: "429" | "timeout") and WHO (`caller`: a
+// compact tag derived from the linearis argv or passed explicitly), so the
+// steadily-flapping breaker (CTL-1430 diagnosis: 12–22 opens/hr on mini, trigger
+// invisible in logs) becomes attributable from the unified event log — and
+// board-health invariant #2 can consume it (`deriveRing`) so Linear degradation
+// is `observable:true` instead of Anthropic-only.
+//
+// `linear.*` is NOT a broker-protected namespace (FORBIDDEN_PREFIXES = filter.,
+// broker.daemon; PROTECTED_EXACT = session.heartbeat — see
+// broker/namespace-contract.mjs), so emitting it from execution-core is safe and
+// the broker will not self-filter or route it.
+
+import { mkdirSync, appendFileSync } from "node:fs";
+import { dirname } from "node:path";
+import { randomBytes } from "node:crypto";
+import { getEventLogPath, getHostName, log } from "./config.mjs";
+import { buildCatalystResource } from "./lib/catalyst-resource.mjs";
+
+export const LINEAR_BREAKER_EVENT = "linear.ratelimit.breaker";
+
+/**
+ * buildLinearBreakerEnvelope — pure OTel envelope for a breaker state change.
+ * `state` is "open" (a trip) or "closed" (recovery). OPEN carries reason+caller;
+ * CLOSED carries recoveredAfter (the consecutive-failure count that preceded it).
+ */
+export function buildLinearBreakerEnvelope({
+  state,
+  reason = null,
+  caller = null,
+  cooldownMs = 0,
+  consecutive = 0,
+  recoveredAfter = 0,
+  now,
+} = {}) {
+  const ts = now ? now() : new Date().toISOString().replace(/\.\d{3}Z$/, "Z");
+  const host = getHostName();
+  const open = state === "open";
+  return {
+    ts,
+    id: randomBytes(8).toString("hex"),
+    observedTs: ts,
+    severityText: open ? "WARN" : "INFO",
+    severityNumber: open ? 13 : 9,
+    traceId: null,
+    spanId: null,
+    resource: buildCatalystResource({ serviceName: "catalyst.execution-core" }),
+    attributes: {
+      "event.name": LINEAR_BREAKER_EVENT,
+      "event.entity": "linear",
+      "event.action": open ? "ratelimit.breaker.open" : "ratelimit.breaker.closed",
+      "event.label": host,
+    },
+    body: {
+      payload: {
+        "host.name": host,
+        state: open ? "open" : "closed",
+        reason: open ? reason : null,
+        caller: open ? caller : null,
+        cooldownMs: open ? cooldownMs : 0,
+        consecutive: open ? consecutive : 0,
+        recoveredAfter: open ? 0 : recoveredAfter,
+      },
+    },
+  };
+}
+
+/**
+ * emitLinearBreakerEvent — append one linear.ratelimit.breaker envelope line.
+ * Returns true on success, false on any failure (best-effort; never throws — a
+ * telemetry hiccup must never perturb the breaker's control flow).
+ */
+export function emitLinearBreakerEvent({
+  state,
+  reason = null,
+  caller = null,
+  cooldownMs = 0,
+  consecutive = 0,
+  recoveredAfter = 0,
+  logPath = getEventLogPath(),
+  now,
+} = {}) {
+  const line = `${JSON.stringify(
+    buildLinearBreakerEnvelope({ state, reason, caller, cooldownMs, consecutive, recoveredAfter, now }),
+  )}\n`;
+  try {
+    mkdirSync(dirname(logPath), { recursive: true });
+    appendFileSync(logPath, line);
+    return true;
+  } catch (err) {
+    log.warn({ err: err?.message }, "linear-ratelimit-event: event append failed");
+    return false;
+  }
+}

--- a/plugins/dev/scripts/execution-core/linear-ratelimit-event.test.mjs
+++ b/plugins/dev/scripts/execution-core/linear-ratelimit-event.test.mjs
@@ -52,6 +52,19 @@ describe("buildLinearBreakerEnvelope — OPEN (CTL-1430)", () => {
     expect(env.body.payload["host.name"]).toBeDefined();
   });
 
+  test("promotes reason/caller/state to OTLP attributes (CTL-1430 F3 — survive otel-forward→Loki)", () => {
+    const env = buildLinearBreakerEnvelope({
+      state: "open",
+      reason: "timeout",
+      caller: "linearis:issues-read",
+      cooldownMs: 60000,
+      consecutive: 1,
+    });
+    expect(env.attributes["catalyst.linear.breaker.state"]).toBe("open");
+    expect(env.attributes["catalyst.linear.breaker.reason"]).toBe("timeout");
+    expect(env.attributes["catalyst.linear.breaker.caller"]).toBe("linearis:issues-read");
+  });
+
   test("open is WARN severity (13)", () => {
     const env = buildLinearBreakerEnvelope({ state: "open", reason: "429", caller: "x" });
     expect(env.severityText).toBe("WARN");
@@ -85,6 +98,10 @@ describe("buildLinearBreakerEnvelope — CLOSED (CTL-1430)", () => {
     expect(env.body.payload.cooldownMs).toBe(0);
     expect(env.severityText).toBe("INFO");
     expect(env.severityNumber).toBe(9);
+    // closed carries only state in attributes; reason/caller are open-only.
+    expect(env.attributes["catalyst.linear.breaker.state"]).toBe("closed");
+    expect(env.attributes["catalyst.linear.breaker.reason"]).toBeUndefined();
+    expect(env.attributes["catalyst.linear.breaker.caller"]).toBeUndefined();
   });
 });
 

--- a/plugins/dev/scripts/execution-core/linear-ratelimit-event.test.mjs
+++ b/plugins/dev/scripts/execution-core/linear-ratelimit-event.test.mjs
@@ -1,0 +1,139 @@
+// linear-ratelimit-event.test.mjs — CTL-1430 (WS-A A1). linear.ratelimit.breaker
+// envelope builder + best-effort emitter.
+//
+// Run: cd plugins/dev/scripts/execution-core && bun test linear-ratelimit-event.test.mjs
+
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, readFileSync, appendFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  buildLinearBreakerEnvelope,
+  emitLinearBreakerEvent,
+  LINEAR_BREAKER_EVENT,
+} from "./linear-ratelimit-event.mjs";
+
+const HOST_ENVS = ["CATALYST_HOST_NAME", "CATALYST_LAYER2_CONFIG_FILE"];
+let savedEnv = {};
+
+beforeEach(() => {
+  for (const k of HOST_ENVS) {
+    savedEnv[k] = process.env[k];
+    delete process.env[k];
+  }
+});
+
+afterEach(() => {
+  for (const k of HOST_ENVS) {
+    if (savedEnv[k] === undefined) delete process.env[k];
+    else process.env[k] = savedEnv[k];
+  }
+  savedEnv = {};
+});
+
+describe("buildLinearBreakerEnvelope — OPEN (CTL-1430)", () => {
+  test("open envelope: name/entity/action + reason/caller/cooldown/consecutive payload", () => {
+    const env = buildLinearBreakerEnvelope({
+      state: "open",
+      reason: "timeout",
+      caller: "linearis:issues-read",
+      cooldownMs: 60000,
+      consecutive: 1,
+    });
+    expect(env.attributes["event.name"]).toBe("linear.ratelimit.breaker");
+    expect(LINEAR_BREAKER_EVENT).toBe("linear.ratelimit.breaker");
+    expect(env.attributes["event.entity"]).toBe("linear");
+    expect(env.attributes["event.action"]).toBe("ratelimit.breaker.open");
+    expect(env.body.payload.state).toBe("open");
+    expect(env.body.payload.reason).toBe("timeout");
+    expect(env.body.payload.caller).toBe("linearis:issues-read");
+    expect(env.body.payload.cooldownMs).toBe(60000);
+    expect(env.body.payload.consecutive).toBe(1);
+    expect(env.body.payload["host.name"]).toBeDefined();
+  });
+
+  test("open is WARN severity (13)", () => {
+    const env = buildLinearBreakerEnvelope({ state: "open", reason: "429", caller: "x" });
+    expect(env.severityText).toBe("WARN");
+    expect(env.severityNumber).toBe(13);
+  });
+
+  test("stamps host + service on the resource block", () => {
+    process.env.CATALYST_HOST_NAME = "mini";
+    const env = buildLinearBreakerEnvelope({ state: "open", reason: "429", caller: "x" });
+    expect(env.resource["service.name"]).toBe("catalyst.execution-core");
+    expect(env.resource["service.namespace"]).toBe("catalyst");
+    expect(env.resource["host.name"]).toBe("mini");
+    expect(env.body.payload["host.name"]).toBe("mini");
+  });
+
+  test("ts is a no-millisecond ISO string by default", () => {
+    const env = buildLinearBreakerEnvelope({ state: "open", reason: "429", caller: "x" });
+    expect(env.ts).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$/);
+  });
+});
+
+describe("buildLinearBreakerEnvelope — CLOSED (CTL-1430)", () => {
+  test("closed envelope: state closed, reason/caller null, recoveredAfter carried, INFO severity", () => {
+    const env = buildLinearBreakerEnvelope({ state: "closed", recoveredAfter: 3 });
+    expect(env.attributes["event.name"]).toBe("linear.ratelimit.breaker");
+    expect(env.attributes["event.action"]).toBe("ratelimit.breaker.closed");
+    expect(env.body.payload.state).toBe("closed");
+    expect(env.body.payload.reason).toBeNull();
+    expect(env.body.payload.caller).toBeNull();
+    expect(env.body.payload.recoveredAfter).toBe(3);
+    expect(env.body.payload.cooldownMs).toBe(0);
+    expect(env.severityText).toBe("INFO");
+    expect(env.severityNumber).toBe(9);
+  });
+});
+
+describe("emitLinearBreakerEvent (CTL-1430)", () => {
+  let tmp;
+  let logPath;
+
+  beforeEach(() => {
+    tmp = mkdtempSync(join(tmpdir(), "ctl1430-lrb-"));
+    logPath = join(tmp, "events.jsonl");
+  });
+
+  afterEach(() => {
+    rmSync(tmp, { recursive: true, force: true });
+  });
+
+  test("appends one parseable open line to the event log", () => {
+    process.env.CATALYST_HOST_NAME = "mini";
+    expect(
+      emitLinearBreakerEvent({
+        state: "open",
+        reason: "429",
+        caller: "cluster-heartbeat-publisher",
+        cooldownMs: 60000,
+        consecutive: 1,
+        logPath,
+      }),
+    ).toBe(true);
+    const lines = readFileSync(logPath, "utf8").trim().split("\n");
+    expect(lines).toHaveLength(1);
+    const evt = JSON.parse(lines[0]);
+    expect(evt.attributes["event.name"]).toBe("linear.ratelimit.breaker");
+    expect(evt.body.payload.state).toBe("open");
+    expect(evt.body.payload.reason).toBe("429");
+    expect(evt.body.payload.caller).toBe("cluster-heartbeat-publisher");
+    expect(evt.body.payload["host.name"]).toBe("mini");
+  });
+
+  test("appends a parseable closed line", () => {
+    expect(emitLinearBreakerEvent({ state: "closed", recoveredAfter: 2, logPath })).toBe(true);
+    const evt = JSON.parse(readFileSync(logPath, "utf8").trim());
+    expect(evt.body.payload.state).toBe("closed");
+    expect(evt.body.payload.recoveredAfter).toBe(2);
+  });
+
+  test("returns false (never throws) when the log path is unwriteable", () => {
+    const fileAsDir = join(tmp, "afile");
+    appendFileSync(fileAsDir, "x");
+    const bad = join(fileAsDir, "events.jsonl");
+    expect(emitLinearBreakerEvent({ state: "open", reason: "429", caller: "x", logPath: bad })).toBe(false);
+  });
+});


### PR DESCRIPTION
## What

Keystone (WS-A A1) of the delegate-operational master plan (`thoughts/shared/plans/2026-07-05-delegate-operational-master-plan.md`). Makes the ctl-679 Linear circuit-breaker flap **attributable**: today the OPEN log line records neither *why* (429 vs the CTL-1341 8s-timeout — both funnel through `recordRateLimited`) nor *who* spawned the failing call, so the 12–22 opens/hr on mini are unfalsifiable from logs.

## Changes

- **`linear-breaker.mjs`** — `recordRateLimited(now, { reason, caller })`; both fields land on the OPEN warn line and a new durable event. `withBreaker` derives `reason` (`res.timedOut ? "timeout" : "429"`) and `caller` (`opts.caller ?? deriveCaller(argv)` — no call-site churn). `recordSuccess` emits a CLOSED event with `recoveredAfter`. Factory `emitEvent` defaults to a **no-op** so unit breakers stay hermetic; the production singleton wires the real emitter.
- **`linear-ratelimit-event.mjs`** (new) — `linear.ratelimit.breaker` open/close OTel envelope + best-effort emitter, modeled on `drain-event.mjs`. `linear.*` is not a broker-protected namespace (verified vs `broker/namespace-contract.mjs`), so board-health invariant #2 can later consume it via `deriveRing`.
- **`cluster-heartbeat-publisher.mjs`** — tags its rate-class breaker feed with `caller="cluster-heartbeat-publisher"` so its share of the flap is measurable (the WS-A prime suspect).
- **Tests** — reason/caller threading, open/close emission, `deriveCaller`, full envelope+append suite. `linear-ratelimit-event.test.mjs` **registered** in the CI allowlist (the workflow is an explicit list — an unregistered test passes vacuously).

## No behavior change

Cooldown math, the CTL-1341 per-pass timeout bound, and the true-429 back-off are untouched. All existing breaker/heartbeat/write/query tests stay green (56 + 288 local).

## Verification plan (post-merge)

Deploy to both minis, collect 1–2h, then `grep "breaker OPEN" daemon.log | jq .reason,.caller | sort | uniq -c` per host → the WS-A Phase-2 caller/reason table that drives A5.

Part of CTL-1157.