### PR TITLE
feat(dev): CTL-1431 (WS-B B1) — TTL on terminal recovery-intents + one-time June sweep

### DIFF
--- a/.github/workflows/execution-core-tests.yml
+++ b/.github/workflows/execution-core-tests.yml
@@ -299,6 +299,7 @@ jobs:
             worktree-safety.test.mjs \
             worktree.test.mjs \
             recovery-reasoning.test.mjs \
+            sweep-stale-recovery-intents.test.mjs \
             recovery-evidence.test.mjs \
             unstuck-act-seams.test.mjs \
             lib/catalyst-resource.test.mjs \

--- a/plugins/dev/scripts/execution-core/recovery-reasoning.mjs
+++ b/plugins/dev/scripts/execution-core/recovery-reasoning.mjs
@@ -1708,8 +1708,20 @@ export function defaultRecordIntent(ticket, intent, opts = {}) {
     prior = {}; // absent / malformed → start fresh
   }
 
+  // CTL-1431 Codex F2: a prior escalated latch is preserved UNLESS it has aged past
+  // the terminal TTL. Once expired, the ticket has re-entered triage (see
+  // defaultShouldSkipItem) — recording a follow-up fix must NOT silently re-latch it
+  // for another 7 days with a refreshed lastTs, or the re-entry accomplishes nothing.
+  // A timestamp-less latch has no age and stays latched (matches F3 / the read path).
+  // Re-escalating explicitly (intent.escalated / decision "escalate") still latches
+  // afresh — a genuine new escalation with a new timestamp, so it TTLs again in 7d.
+  const priorLast = typeof prior.lastTs === "number" ? prior.lastTs : prior.ts;
+  const priorEscalationExpired =
+    Boolean(prior.escalated) &&
+    typeof priorLast === "number" &&
+    ts - priorLast >= RECOVERY_TERMINAL_INTENT_TTL_MS;
   const escalated =
-    Boolean(prior.escalated) ||
+    (Boolean(prior.escalated) && !priorEscalationExpired) ||
     Boolean(intent.escalated) ||
     intent.decision === "escalate"; // an escalate-pass latches escalated
 
@@ -1771,8 +1783,11 @@ export function defaultShouldSkipItem(ticket, opts = {}) {
   // the non-mutating defer precedent above).
   if (data?.escalated === true) {
     const last = typeof data?.lastTs === "number" ? data.lastTs : data?.ts;
-    if (typeof last === "number" && now() - last < RECOVERY_TERMINAL_INTENT_TTL_MS) return true;
-    return false;
+    // A timestamp-less escalation (defaultClearIntentCooldown deletes both ts fields
+    // while KEEPING escalated as a deliberately-terminal latch) cannot be aged out —
+    // it stays terminal. (CTL-1431 Codex F3.)
+    if (typeof last !== "number") return true;
+    return now() - last < RECOVERY_TERMINAL_INTENT_TTL_MS;
   }
 
   // (b) attempts exhausted → stop self-healing.

--- a/plugins/dev/scripts/execution-core/recovery-reasoning.mjs
+++ b/plugins/dev/scripts/execution-core/recovery-reasoning.mjs
@@ -1678,6 +1678,14 @@ export const RECOVERY_COOLDOWN_MS =
 export const RECOVERY_MAX_ATTEMPTS =
   Number(process.env.CATALYST_RECOVERY_MAX_ATTEMPTS) || 2;
 
+// CTL-1431: TTL on a terminal (escalated) recovery-intent. An escalated latch is
+// no longer permanent — after this window the intent goes stale and the ticket
+// re-enters the recovery triage funnel, so a months-old escalate cannot pin a
+// ticket forever once the underlying blocker has cleared. Env-only, matching its
+// siblings (NaN*x and 0*x are both falsy → fall through to the 7-day default).
+export const RECOVERY_TERMINAL_INTENT_TTL_MS =
+  Number(process.env.CATALYST_RECOVERY_TERMINAL_TTL_DAYS) * 864e5 || 7 * 864e5;
+
 function recoveryIntentPath(orchDir, ticket) {
   return join(orchDir, ".recovery-intents", `${ticket}.json`);
 }
@@ -1753,8 +1761,19 @@ export function defaultShouldSkipItem(ticket, opts = {}) {
     return typeof last === "number" && now() - last < RECOVERY_COOLDOWN_MS;
   }
 
-  // (c) already escalated → terminal, hand off to human, stop acting.
-  if (data?.escalated === true) return true;
+  // (c) already escalated → terminal latch, but TTL-bounded (CTL-1431). Within the
+  // TTL it still skips (the ticket is handed off to a human); once the intent ages
+  // past RECOVERY_TERMINAL_INTENT_TTL_MS it goes stale and the ticket RE-ENTERS the
+  // recovery triage funnel. Return false DIRECTLY on expiry — do NOT fall through to
+  // the attempts-exhausted branch below: an escalated intent already has attempts ≥
+  // 2, so a fall-through would instantly re-latch there (that branch has no age
+  // gate). Derived purely from timestamps, so NO file mutation on expiry (mirrors
+  // the non-mutating defer precedent above).
+  if (data?.escalated === true) {
+    const last = typeof data?.lastTs === "number" ? data.lastTs : data?.ts;
+    if (typeof last === "number" && now() - last < RECOVERY_TERMINAL_INTENT_TTL_MS) return true;
+    return false;
+  }
 
   // (b) attempts exhausted → stop self-healing.
   if (typeof data?.attempts === "number" && data.attempts >= RECOVERY_MAX_ATTEMPTS) return true;

--- a/plugins/dev/scripts/execution-core/recovery-reasoning.test.mjs
+++ b/plugins/dev/scripts/execution-core/recovery-reasoning.test.mjs
@@ -1167,6 +1167,45 @@ describe("recovery-intent terminal TTL (CTL-1431)", () => {
     const nowT = t1 + TTL / 2;
     expect(defaultShouldSkipItem("CTL-1431-D", { orchDir, now: () => nowT })).toBe(true);
   });
+
+  test("(F3) escalated with NO timestamp stays terminal (clear-cooldown case, returns true)", () => {
+    const t0 = 1_000_000_000_000;
+    defaultRecordIntent("CTL-1431-F3", { decision: "escalate" }, { orchDir, now: () => t0 });
+    // Delete both timestamps, mimicking defaultClearIntentCooldown (which keeps
+    // `escalated` as a deliberate terminal latch). Such an entry can't be aged out.
+    const p = pathJoin(orchDir, ".recovery-intents", "CTL-1431-F3.json");
+    const data = JSON.parse(readFileSync(p, "utf8"));
+    delete data.ts;
+    delete data.lastTs;
+    writeFileSync(p, JSON.stringify(data));
+    expect(defaultShouldSkipItem("CTL-1431-F3", { orchDir, now: () => t0 + 1 })).toBe(true);
+  });
+
+  test("(F2) a fix recorded AFTER TTL expiry drops the escalated latch (no silent re-latch)", () => {
+    const t0 = 1_000_000_000_000;
+    defaultRecordIntent("CTL-1431-F2", { decision: "escalate" }, { orchDir, now: () => t0 });
+    const past = t0 + RECOVERY_TERMINAL_INTENT_TTL_MS + 1;
+    const entry = defaultRecordIntent(
+      "CTL-1431-F2",
+      { decision: "fix", fix_class: "x" },
+      { orchDir, now: () => past },
+    );
+    // The ticket has re-entered triage; a follow-up fix must NOT re-latch it for
+    // another 7 days. escalated is cleared → the entry is governed by attempts/cooldown.
+    expect(entry.escalated).toBe(false);
+  });
+
+  test("(F2) a fix recorded WITHIN the TTL preserves the escalated latch", () => {
+    const t0 = 1_000_000_000_000;
+    defaultRecordIntent("CTL-1431-F2b", { decision: "escalate" }, { orchDir, now: () => t0 });
+    const within = t0 + RECOVERY_TERMINAL_INTENT_TTL_MS - 1;
+    const entry = defaultRecordIntent(
+      "CTL-1431-F2b",
+      { decision: "fix", fix_class: "x" },
+      { orchDir, now: () => within },
+    );
+    expect(entry.escalated).toBe(true);
+  });
 });
 
 // ─── CTL-1176: capped remediate dispatch (cap enforcement) ──────────────────

--- a/plugins/dev/scripts/execution-core/recovery-reasoning.test.mjs
+++ b/plugins/dev/scripts/execution-core/recovery-reasoning.test.mjs
@@ -21,6 +21,7 @@ import {
   RECOVERY_PASS_PHASE,
   RECOVERY_MAX_ATTEMPTS,
   RECOVERY_COOLDOWN_MS,
+  RECOVERY_TERMINAL_INTENT_TTL_MS,
 } from "./recovery-reasoning.mjs";
 import { mkdtempSync, rmSync, existsSync, readFileSync, mkdirSync, writeFileSync } from "node:fs";
 import { join as pathJoin } from "node:path";
@@ -1104,6 +1105,67 @@ describe("recovery-intent ledger (cooldown + max-attempts + escalated)", () => {
   test("forgetIntent with no orchDir / no ticket → false (fail-soft)", () => {
     expect(defaultForgetIntent("CTL-309", { orchDir: null })).toBe(false);
     expect(defaultForgetIntent("", { orchDir })).toBe(false);
+  });
+});
+
+// CTL-1431: the escalated latch is TTL-bounded. Within the terminal TTL it still
+// skips (hand off to human); once it ages past RECOVERY_TERMINAL_INTENT_TTL_MS the
+// ticket re-enters the recovery triage funnel. The critical invariant is the DIRECT
+// return false on expiry — the escalated branch must short-circuit, never fall
+// through to the attempts-exhausted branch (which has no age gate and would re-latch).
+describe("recovery-intent terminal TTL (CTL-1431)", () => {
+  let orchDir;
+  beforeEach(() => {
+    orchDir = mkdtempSync(pathJoin(tmpdir(), "rec-ttl-"));
+  });
+  afterEach(() => {
+    try {
+      rmSync(orchDir, { recursive: true, force: true });
+    } catch {
+      /* best-effort */
+    }
+  });
+
+  test("(a) escalated intent younger than TTL still skips (returns true)", () => {
+    const t0 = 1_000_000_000_000;
+    defaultRecordIntent("CTL-1431-A", { decision: "escalate" }, { orchDir, now: () => t0 });
+    const within = t0 + RECOVERY_TERMINAL_INTENT_TTL_MS - 1;
+    expect(defaultShouldSkipItem("CTL-1431-A", { orchDir, now: () => within })).toBe(true);
+  });
+
+  test("(b) escalated intent older than TTL re-enters triage (returns false)", () => {
+    const t0 = 1_000_000_000_000;
+    defaultRecordIntent("CTL-1431-B", { decision: "escalate" }, { orchDir, now: () => t0 });
+    const past = t0 + RECOVERY_TERMINAL_INTENT_TTL_MS + 1;
+    expect(defaultShouldSkipItem("CTL-1431-B", { orchDir, now: () => past })).toBe(false);
+  });
+
+  test("(c) escalated + attempts ≥ MAX but older than TTL still returns false (short-circuit, not fall-through)", () => {
+    const t0 = 1_000_000_000_000;
+    // attempts pinned well above RECOVERY_MAX_ATTEMPTS: if the escalated branch fell
+    // THROUGH to the attempts-exhausted branch (which has no age gate), this expired
+    // intent would skip (true). It must short-circuit to false instead.
+    defaultRecordIntent(
+      "CTL-1431-C",
+      { decision: "escalate", attempts: RECOVERY_MAX_ATTEMPTS + 3 },
+      { orchDir, now: () => t0 },
+    );
+    const past = t0 + RECOVERY_TERMINAL_INTENT_TTL_MS + 1;
+    expect(defaultShouldSkipItem("CTL-1431-C", { orchDir, now: () => past })).toBe(false);
+  });
+
+  test("(d) keys off lastTs not ts: fresh lastTs with a stale ts is NOT expired (returns true)", () => {
+    const t0 = 1_000_000_000_000;
+    const TTL = RECOVERY_TERMINAL_INTENT_TTL_MS;
+    // First escalate sets ts = lastTs = t0.
+    defaultRecordIntent("CTL-1431-D", { decision: "escalate" }, { orchDir, now: () => t0 });
+    // A later write advances lastTs to t1 but PRESERVES the first-action ts at t0.
+    const t1 = t0 + TTL;
+    defaultRecordIntent("CTL-1431-D", { decision: "fix", fix_class: "x" }, { orchDir, now: () => t1 });
+    // Evaluate at t1 + TTL/2: age off lastTs is TTL/2 (< TTL → skip), but age off the
+    // stale ts would be 1.5·TTL (> TTL → would re-enter). Keying off lastTs → true.
+    const nowT = t1 + TTL / 2;
+    expect(defaultShouldSkipItem("CTL-1431-D", { orchDir, now: () => nowT })).toBe(true);
   });
 });
 

--- a/plugins/dev/scripts/execution-core/sweep-stale-recovery-intents.mjs
+++ b/plugins/dev/scripts/execution-core/sweep-stale-recovery-intents.mjs
@@ -1,0 +1,133 @@
+#!/usr/bin/env bun
+// sweep-stale-recovery-intents.mjs — CTL-1431 one-time operator hygiene tool.
+//
+// Lists (and, with --execute, DELETES) escalated recovery-intent ledger entries
+// under <orchDir>/.recovery-intents/ that have aged past
+// RECOVERY_TERMINAL_INTENT_TTL_MS. Dry-run by default; pass --execute to delete.
+//
+// This is HYGIENE, not a functional gate. Once the CTL-1431 age-gate in
+// defaultShouldSkipItem ships, a June (>7-day-old) escalated intent auto-becomes
+// non-terminal on the next scheduler tick — the ticket re-enters triage with the
+// stale `.recovery-intents/<ticket>.json` still on disk. This tool just clears
+// that leftover file so the ledger dir doesn't accumulate dead terminal markers;
+// nothing depends on it running.
+//
+// Usage:
+//   bun sweep-stale-recovery-intents.mjs [--execute] [--orch-dir <path>] [--ttl-days <n>]
+//
+// Selector: entry.escalated === true AND (now - last) >= ttlMs, where
+//   last = typeof lastTs === "number" ? lastTs : ts   (mirrors defaultShouldSkipItem)
+
+import { readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { homedir } from "node:os";
+import {
+  RECOVERY_TERMINAL_INTENT_TTL_MS,
+  defaultForgetIntent,
+} from "./recovery-reasoning.mjs";
+
+/**
+ * Scan <orchDir>/.recovery-intents/ and return the escalated entries older than
+ * the TTL. Pure read: never mutates. Malformed / non-.json files are skipped.
+ *
+ * @param {{ orchDir: string, now?: () => number, ttlMs?: number }} opts
+ * @returns {{ ticket: string, ageMs: number, last: number }[]}
+ */
+export function selectStaleRecoveryIntents({
+  orchDir,
+  now = () => Date.now(),
+  ttlMs = RECOVERY_TERMINAL_INTENT_TTL_MS,
+} = {}) {
+  if (!orchDir) return [];
+  const dir = join(orchDir, ".recovery-intents");
+  let files;
+  try {
+    files = readdirSync(dir);
+  } catch {
+    return []; // absent dir → nothing to sweep
+  }
+
+  const stale = [];
+  const t = now();
+  for (const f of files) {
+    if (!f.endsWith(".json")) continue;
+    let data;
+    try {
+      data = JSON.parse(readFileSync(join(dir, f), "utf8"));
+    } catch {
+      continue; // malformed → skip
+    }
+    if (data?.escalated !== true) continue;
+    const last = typeof data?.lastTs === "number" ? data.lastTs : data?.ts;
+    if (typeof last !== "number") continue; // no timestamp → cannot age it out
+    const ageMs = t - last;
+    if (ageMs < ttlMs) continue; // still within the terminal TTL
+    // Derive the ticket from the filename so the delete path is guaranteed to
+    // target this exact file (recoveryIntentPath joins ticket + ".json").
+    stale.push({ ticket: f.replace(/\.json$/, ""), ageMs, last });
+  }
+  return stale;
+}
+
+/**
+ * Dry-run (execute=false): return the stale intents without deleting.
+ * Execute (execute=true): defaultForgetIntent each stale entry.
+ *
+ * @param {{ orchDir: string, now?: () => number, ttlMs?: number, execute?: boolean,
+ *           forgetIntent?: (ticket: string, opts: object) => boolean, quiet?: boolean }} opts
+ * @returns {{ swept: string[], skipped: string[], stale: {ticket:string,ageMs:number}[] }}
+ */
+export function sweepStaleRecoveryIntents({
+  orchDir,
+  now = () => Date.now(),
+  ttlMs = RECOVERY_TERMINAL_INTENT_TTL_MS,
+  execute = false,
+  forgetIntent = defaultForgetIntent,
+  quiet = false,
+} = {}) {
+  const stale = selectStaleRecoveryIntents({ orchDir, now, ttlMs });
+  const swept = [];
+  const skipped = [];
+
+  for (const { ticket, ageMs } of stale) {
+    const ageDays = (ageMs / 864e5).toFixed(1);
+    if (!execute) {
+      if (!quiet) console.log(`[dry-run] would sweep ${ticket} (escalated, ${ageDays}d old)`);
+      swept.push(ticket);
+      continue;
+    }
+    if (forgetIntent(ticket, { orchDir })) {
+      if (!quiet) console.log(`swept ${ticket} (escalated, ${ageDays}d old)`);
+      swept.push(ticket);
+    } else {
+      if (!quiet) console.error(`failed to sweep ${ticket}`);
+      skipped.push(ticket);
+    }
+  }
+  return { swept, skipped, stale };
+}
+
+// CLI entrypoint when run directly.
+if (import.meta.main) {
+  const args = process.argv.slice(2);
+  const execute = args.includes("--execute");
+  const orchIdx = args.indexOf("--orch-dir");
+  const orchDir =
+    orchIdx !== -1
+      ? args[orchIdx + 1]
+      : process.env.CATALYST_ORCHESTRATOR_DIR ?? join(homedir(), "catalyst", "execution-core");
+  const ttlIdx = args.indexOf("--ttl-days");
+  const ttlMs = ttlIdx !== -1 ? Number(args[ttlIdx + 1]) * 864e5 : RECOVERY_TERMINAL_INTENT_TTL_MS;
+
+  console.log(`orch dir: ${orchDir}`);
+  console.log(`ttl: ${(ttlMs / 864e5).toFixed(1)}d`);
+  console.log(execute ? "mode: EXECUTE" : "mode: dry-run (pass --execute to delete)");
+  console.log("");
+
+  const { swept, skipped } = sweepStaleRecoveryIntents({ orchDir, ttlMs, execute });
+
+  console.log(`\nSummary: ${swept.length} ${execute ? "swept" : "would-sweep"}, ${skipped.length} skipped`);
+  if (!execute && swept.length > 0) {
+    console.log("Re-run with --execute to delete these stale terminal intents.");
+  }
+}

--- a/plugins/dev/scripts/execution-core/sweep-stale-recovery-intents.mjs
+++ b/plugins/dev/scripts/execution-core/sweep-stale-recovery-intents.mjs
@@ -39,6 +39,12 @@ export function selectStaleRecoveryIntents({
   ttlMs = RECOVERY_TERMINAL_INTENT_TTL_MS,
 } = {}) {
   if (!orchDir) return [];
+  // CTL-1431 Codex F1: a non-finite / non-positive ttl (e.g. a mistyped `--ttl-days
+  // foo` → NaN) would make `ageMs < ttlMs` always false, marking EVERY escalated
+  // intent stale and sweeping the whole ledger. Fail loud instead of silently deleting.
+  if (!Number.isFinite(ttlMs) || ttlMs <= 0) {
+    throw new RangeError(`selectStaleRecoveryIntents: ttlMs must be a positive finite number (got ${ttlMs})`);
+  }
   const dir = join(orchDir, ".recovery-intents");
   let files;
   try {
@@ -117,7 +123,17 @@ if (import.meta.main) {
       ? args[orchIdx + 1]
       : process.env.CATALYST_ORCHESTRATOR_DIR ?? join(homedir(), "catalyst", "execution-core");
   const ttlIdx = args.indexOf("--ttl-days");
-  const ttlMs = ttlIdx !== -1 ? Number(args[ttlIdx + 1]) * 864e5 : RECOVERY_TERMINAL_INTENT_TTL_MS;
+  let ttlMs = RECOVERY_TERMINAL_INTENT_TTL_MS;
+  if (ttlIdx !== -1) {
+    // CTL-1431 Codex F1: validate before it can reach the selector as NaN and sweep
+    // the whole ledger. A mistyped/omitted value is a hard error, not a silent delete.
+    const days = Number(args[ttlIdx + 1]);
+    if (!Number.isFinite(days) || days <= 0) {
+      console.error(`error: --ttl-days requires a positive number (got: ${args[ttlIdx + 1] ?? "<missing>"})`);
+      process.exit(2);
+    }
+    ttlMs = days * 864e5;
+  }
 
   console.log(`orch dir: ${orchDir}`);
   console.log(`ttl: ${(ttlMs / 864e5).toFixed(1)}d`);

--- a/plugins/dev/scripts/execution-core/sweep-stale-recovery-intents.test.mjs
+++ b/plugins/dev/scripts/execution-core/sweep-stale-recovery-intents.test.mjs
@@ -1,0 +1,113 @@
+// sweep-stale-recovery-intents.test.mjs — CTL-1431. Tests for the one-time
+// operator hygiene tool that lists / deletes escalated recovery-intents aged past
+// RECOVERY_TERMINAL_INTENT_TTL_MS.
+//
+// Run: cd plugins/dev/scripts/execution-core && bun test sweep-stale-recovery-intents.test.mjs
+
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, rmSync, existsSync } from "node:fs";
+import { join as pathJoin } from "node:path";
+import { tmpdir } from "node:os";
+import {
+  selectStaleRecoveryIntents,
+  sweepStaleRecoveryIntents,
+} from "./sweep-stale-recovery-intents.mjs";
+import {
+  defaultRecordIntent,
+  RECOVERY_TERMINAL_INTENT_TTL_MS,
+} from "./recovery-reasoning.mjs";
+
+const intentPath = (orchDir, ticket) =>
+  pathJoin(orchDir, ".recovery-intents", `${ticket}.json`);
+
+describe("sweep-stale-recovery-intents (CTL-1431)", () => {
+  let orchDir;
+  const t0 = 1_000_000_000_000;
+  const TTL = RECOVERY_TERMINAL_INTENT_TTL_MS;
+  const tNow = t0 + TTL + 1; // just past the TTL for a t0-aged intent
+
+  beforeEach(() => {
+    orchDir = mkdtempSync(pathJoin(tmpdir(), "rec-sweep-"));
+    // A stale escalated intent (recorded at t0 → aged past the TTL by tNow).
+    defaultRecordIntent("STALE-ESC", { decision: "escalate" }, { orchDir, now: () => t0 });
+    // A stale but NON-escalated (fix) intent — must never be swept.
+    defaultRecordIntent("STALE-FIX", { decision: "fix", fix_class: "x" }, { orchDir, now: () => t0 });
+    // A fresh escalated intent (recorded at tNow → age 0) — must never be swept.
+    defaultRecordIntent("FRESH-ESC", { decision: "escalate" }, { orchDir, now: () => tNow });
+  });
+  afterEach(() => {
+    try {
+      rmSync(orchDir, { recursive: true, force: true });
+    } catch {
+      /* best-effort */
+    }
+  });
+
+  test("selectStaleRecoveryIntents returns only the stale escalated entry", () => {
+    const stale = selectStaleRecoveryIntents({ orchDir, now: () => tNow });
+    expect(stale.map((s) => s.ticket).sort()).toEqual(["STALE-ESC"]);
+  });
+
+  test("dry-run lists stale intents without deleting", () => {
+    const { swept, skipped } = sweepStaleRecoveryIntents({
+      orchDir,
+      now: () => tNow,
+      execute: false,
+      quiet: true,
+    });
+    expect(swept).toEqual(["STALE-ESC"]);
+    expect(skipped).toEqual([]);
+    // Nothing deleted — every seeded file still on disk.
+    expect(existsSync(intentPath(orchDir, "STALE-ESC"))).toBe(true);
+    expect(existsSync(intentPath(orchDir, "STALE-FIX"))).toBe(true);
+    expect(existsSync(intentPath(orchDir, "FRESH-ESC"))).toBe(true);
+  });
+
+  test("--execute deletes only the stale escalated intent", () => {
+    const { swept, skipped } = sweepStaleRecoveryIntents({
+      orchDir,
+      now: () => tNow,
+      execute: true,
+      quiet: true,
+    });
+    expect(swept).toEqual(["STALE-ESC"]);
+    expect(skipped).toEqual([]);
+    // Only the stale escalated file is gone.
+    expect(existsSync(intentPath(orchDir, "STALE-ESC"))).toBe(false);
+    // The fresh escalated + the stale non-escalated survive untouched.
+    expect(existsSync(intentPath(orchDir, "FRESH-ESC"))).toBe(true);
+    expect(existsSync(intentPath(orchDir, "STALE-FIX"))).toBe(true);
+  });
+
+  test("--execute never touches a fresh escalated intent (age < TTL)", () => {
+    sweepStaleRecoveryIntents({ orchDir, now: () => tNow, execute: true, quiet: true });
+    expect(existsSync(intentPath(orchDir, "FRESH-ESC"))).toBe(true);
+  });
+
+  test("forgetIntent is invoked only for stale entries under --execute", () => {
+    const forgotten = [];
+    const { swept } = sweepStaleRecoveryIntents({
+      orchDir,
+      now: () => tNow,
+      execute: true,
+      quiet: true,
+      forgetIntent: (ticket) => {
+        forgotten.push(ticket);
+        return true;
+      },
+    });
+    expect(forgotten).toEqual(["STALE-ESC"]);
+    expect(swept).toEqual(["STALE-ESC"]);
+  });
+
+  test("absent .recovery-intents dir → empty sweep, no throw", () => {
+    const empty = mkdtempSync(pathJoin(tmpdir(), "rec-sweep-empty-"));
+    try {
+      const { swept } = sweepStaleRecoveryIntents({ orchDir: empty, now: () => tNow, quiet: true });
+      expect(swept).toEqual([]);
+      expect(selectStaleRecoveryIntents({ orchDir: empty, now: () => tNow })).toEqual([]);
+    } finally {
+      rmSync(empty, { recursive: true, force: true });
+    }
+  });
+});

--- a/plugins/dev/scripts/execution-core/sweep-stale-recovery-intents.test.mjs
+++ b/plugins/dev/scripts/execution-core/sweep-stale-recovery-intents.test.mjs
@@ -110,4 +110,12 @@ describe("sweep-stale-recovery-intents (CTL-1431)", () => {
       rmSync(empty, { recursive: true, force: true });
     }
   });
+
+  test("(F1) selectStaleRecoveryIntents throws on a non-finite/non-positive ttl (never sweeps the whole ledger)", () => {
+    // A mistyped `--ttl-days foo` → NaN would otherwise make `ageMs < ttlMs` always
+    // false and mark EVERY escalated intent stale. Guard rejects it loudly instead.
+    expect(() => selectStaleRecoveryIntents({ orchDir, ttlMs: NaN, now: () => tNow })).toThrow();
+    expect(() => selectStaleRecoveryIntents({ orchDir, ttlMs: 0, now: () => tNow })).toThrow();
+    expect(() => selectStaleRecoveryIntents({ orchDir, ttlMs: -5, now: () => tNow })).toThrow();
+  });
 });


### PR DESCRIPTION
## What

WS-B B1 of the delegate-operational master plan. An escalation nobody acted on is not a resolution. Today `escalated:true` in a recovery-intent is a **permanent latch** (`defaultShouldSkipItem`: `if (data?.escalated === true) return true`), so a months-old escalate pins a ticket in needs-human forever even after the blocker clears. The fleet is carrying **16 (mini) / 14 (mini-2)** such June-era escalated intents, and the delegate's actuation is latched behind them.

## Changes

- **`recovery-reasoning.mjs`** — the escalated check becomes **TTL-bounded**. Within `RECOVERY_TERMINAL_INTENT_TTL_MS` (env `CATALYST_RECOVERY_TERMINAL_TTL_DAYS`, default 7d) it still skips; past the TTL it returns `false` **directly** — the ticket re-enters the recovery triage funnel. It does **not** fall through to the attempts-exhausted branch (no age gate there → would instantly re-latch) and mutates **no file** (derived purely from the intent timestamps, mirroring the non-mutating defer precedent). `last = lastTs ?? ts`, mirroring the cooldown branch.
- **`sweep-stale-recovery-intents.mjs`** (new) — one-time operator hygiene tool. **Dry-run by default**; `--execute` deletes only escalated intents aged past the TTL (reusing `defaultForgetIntent`), ticket derived from filename. Not a functional gate (the age-gate already re-enables the ticket); this just clears the dead ledger file.

## Tests (123 pass)

younger<TTL skips; older>TTL re-enters; **escalated + attempts≥MAX past TTL still re-enters** (proves the short-circuit, not fall-through); `lastTs`-vs-`ts` boundary; sweep select/dry-run/execute isolation (fresh-escalated + stale-non-escalated survive). Sweep test **registered** in the CI allowlist. `bun build daemon.mjs` + the standalone sweep both resolve.

## Operational follow-up (post-deploy)

Run `bun sweep-stale-recovery-intents.mjs` (dry-run) then `--execute` on both minis to clear the June-era dead ledger files. The age-gate itself needs no sweep — it re-enables the tickets on the next tick.

Part of CTL-1157.