### PR TITLE
feat(dev): CTL-1432 (WS-B B2+B3) — dispatch deferred board-health intents + suppress sanctioned needs-human latches

### DIFF
--- a/plugins/dev/scripts/execution-core/board-health.mjs
+++ b/plugins/dev/scripts/execution-core/board-health.mjs
@@ -299,6 +299,14 @@ export function assembleBoardState({
   // (N=1 byte-identical; a true collision with no repo stays the ambiguous skip).
   repoForTicket = null,
   getReconcileMarkers = () => ({}),
+  // CTL-1432 (B2): live query for tickets carrying a deferred board-health
+  // recovery-intent (defer→fix_class=board-health) — folded into the anchor
+  // candidates so the holistic pass actuates them. Empty default keeps a bare unit
+  // call byte-identical.
+  getDeferredBoardHealthTickets = () => [],
+  // CTL-1432 (B3): operator-sanctioned needs-human latch allowlist (a static array,
+  // not a live query). Suppressed from proposeMoves; stays visible in frozenNeedsHuman.
+  sanctionedNeedsHuman = [],
   // CTL-1157: PR-lifecycle status map (filter_state). Empty Map default ⇒ the
   // phantom-merged-PR / orphaned-open-PR invariants stay observable:false (the
   // shadow-first seam: wiring lands before the invariants begin observing).
@@ -370,6 +378,12 @@ export function assembleBoardState({
       freeSlots: capacity?.freeSlots ?? 0,
     },
     reconcileMarkers: safe(() => getReconcileMarkers(), {}),
+    // CTL-1432 (B2/B3): deferred board-health anchor candidates + the sanctioned
+    // needs-human allowlist, carried on the frozen board for the pure consumers
+    // (selectAnchorCandidates reads deferredBoardHealth; proposeMoves reads
+    // sanctionedNeedsHuman).
+    deferredBoardHealth: safe(() => getDeferredBoardHealthTickets(), []),
+    sanctionedNeedsHuman: Array.isArray(sanctionedNeedsHuman) ? sanctionedNeedsHuman : [],
     // CTL-1157 off-gate: in off the filter_state PR-status SELECT must NOT run —
     // skip getPrStatusMap() entirely so off is byte-identical to origin/main (the
     // phantom/orphaned-PR invariants also stay out of evaluateInvariants in off).
@@ -810,7 +824,13 @@ export function proposeMoves(invariants, _b) {
   }
   // CTL-1157: a needs-human-LABELLED ticket frozen past 48h has already been
   // escalated once → tier2 (review, lower urgency than the actionable PR work).
+  // CTL-1432 (B3): operator-sanctioned needs-human latches stay VISIBLE in
+  // frozenNeedsHuman / boardContext but are never re-proposed as moves — else the
+  // sanctioned tickets drown the genuinely-stuck ones every 5-min scan (making
+  // proposedTier2 a constant). Suppression is HERE only, never in checkFrozenNeedsHuman.
+  const sanctioned = new Set(_b?.sanctionedNeedsHuman ?? []);
   for (const t of invariants.frozenNeedsHuman?.flagged ?? []) {
+    if (sanctioned.has(t)) continue;
     if (!invariants.frozenNeedsHuman.ok) tier2.push({ ticket: t, move: "review-needs-human", rationale: "needs-human label frozen past threshold" });
   }
   for (const h of invariants.strandedNode?.flagged ?? []) {
@@ -878,6 +898,11 @@ export function selectAnchorCandidates(moves, board, { holistic = false, strande
   for (const t of ticketsOf(moves?.tier1).filter(owns)) add(t);
   for (const t of ticketsOf(moves?.tier2).filter(owns)) add(t);
   for (const e of (board?.eligible ?? []).map((x) => x && x.id).filter(Boolean).filter(owns)) add(e);
+  // CTL-1432 (B2): deferred board-health intents are self-owned anchor candidates —
+  // ranked AFTER flagged work + the eligible queue, but still actuated when a slot is
+  // free, so "the holistic delegate will triage" dispatches a recovery-pass instead of
+  // the deferred intent rotting. Self-owned filtered like every other candidate.
+  for (const t of (board?.deferredBoardHealth ?? []).filter(owns)) add(t);
   // holistic foreign-failover: a flagged tier1/tier2 ticket this host does NOT own,
   // ONLY when its owner is provably dead/stranded. Appended AFTER all self-owned.
   if (holistic && multiHost) {
@@ -1007,6 +1032,8 @@ export function boardHealthPass({
   ownerForTicket,
   repoForTicket, // CTL-1157 (Codex #4): ticket→owner/repo resolver (daemon-bound)
   getReconcileMarkers,
+  getDeferredBoardHealthTickets, // CTL-1432 (B2): deferred board-health anchor candidates
+  sanctionedNeedsHuman, // CTL-1432 (B3): sanctioned needs-human latch allowlist
   getPrStatusMap, // CTL-1157: filter_state PR-status reader (daemon-bound)
   deadHosts, // CTL-1157: provably-dead host set (daemon-computed)
   lastRunMs = _lastRunMs,
@@ -1027,6 +1054,7 @@ export function boardHealthPass({
     orchDir, getBoard, getWorkerSignals, getEligible,
     roster, self, multiHost, capacity, readEventRing, ownerForTicket, repoForTicket, getReconcileMarkers,
     getPrStatusMap, deadHosts, mode, now,
+    getDeferredBoardHealthTickets, sanctionedNeedsHuman, // CTL-1432 (B2/B3)
   });
   const invariants = evaluateInvariants(board, { mode });
   const dec = decideBoardHealth(invariants, board);

--- a/plugins/dev/scripts/execution-core/board-health.mjs
+++ b/plugins/dev/scripts/execution-core/board-health.mjs
@@ -762,6 +762,26 @@ function checkNeedsHumanPile(b) {
 }
 
 // ── (3) decideBoardHealth — PURE. The cheap-gate funnel. First match wins. ───
+// CTL-1432 (Codex P1): the deferred board-health set must pass the SAME acceptance a
+// normal anchor does before it counts as actionable / gets ranked — not an operator-
+// sanctioned latch (else a sanctioned ticket that ALSO has a defer intent bypasses the
+// proposeMoves suppression via the deferred path), and still a LIVE non-terminal ticket
+// on the board. getBoard = getAllTicketDescriptors({includeRemoved:false}) still includes
+// Done/Canceled descriptors, so a board-presence check alone isn't enough — check
+// isTerminalLinearState too. (The 30-min defer cooldown is applied upstream in
+// readDeferredBoardHealthIntents.) Shared by decideBoardHealth (gate count) AND
+// selectAnchorCandidates (ranking) so the two never disagree.
+function eligibleDeferredAnchors(board) {
+  const sanctioned = new Set(board?.sanctionedNeedsHuman ?? []);
+  const byId = board?.ticketsById;
+  return (board?.deferredBoardHealth ?? []).filter((t) => {
+    if (sanctioned.has(t)) return false;
+    const d = byId && typeof byId.get === "function" ? byId.get(t) : undefined;
+    if (!d) return false;
+    return !isTerminalLinearState(d);
+  });
+}
+
 export function decideBoardHealth(invariants, boardState) {
   const observableFailed = Object.values(invariants).filter((v) => v.observable && !v.ok);
   const invariantsFailed = observableFailed.reduce((n, v) => n + (Number(v.failed) || 0), 0);
@@ -776,14 +796,10 @@ export function decideBoardHealth(invariants, boardState) {
   // trips the gate is inert). tier3 moves are escalate-only (never anchorable by
   // selectAnchorCandidates), so they alone do not justify a holistic pass.
   const moves = proposeMoves(invariants, boardState);
-  // CTL-1432 (Codex P1): count only deferred intents whose ticket is still on the live
-  // board (ticketsById excludes Done/removed) — a since-terminal defer marker must not
-  // make the gate proceed (it would proceed then no-anchor). Mirrors selectAnchorCandidates.
-  const deferred = (boardState?.deferredBoardHealth ?? []).filter((t) =>
-    boardState?.ticketsById && typeof boardState.ticketsById.has === "function"
-      ? boardState.ticketsById.has(t)
-      : true,
-  );
+  // CTL-1432 (Codex P1): count only deferred intents that pass full acceptance
+  // (not sanctioned, live + non-terminal) — a since-terminal / sanctioned defer must not
+  // make the gate proceed (it would proceed then no-anchor). Same helper selectAnchorCandidates uses.
+  const deferred = eligibleDeferredAnchors(boardState);
   const hasActionableWork =
     moves.tier1.length > 0 || moves.tier2.length > 0 || deferred.length > 0;
 
@@ -937,9 +953,7 @@ export function selectAnchorCandidates(moves, board, { holistic = false, strande
   // eligible-queue ticket. Cross-checked against the live board (ticketsById already
   // excludes Done/removed via getBoard's includeRemoved:false), so a stale defer marker
   // whose ticket has since gone terminal is dropped rather than re-anchored.
-  const onBoard = (t) =>
-    board?.ticketsById && typeof board.ticketsById.has === "function" ? board.ticketsById.has(t) : true;
-  for (const t of (board?.deferredBoardHealth ?? []).filter(owns).filter(onBoard)) add(t);
+  for (const t of eligibleDeferredAnchors(board).filter(owns)) add(t);
   for (const e of (board?.eligible ?? []).map((x) => x && x.id).filter(Boolean).filter(owns)) add(e);
   // holistic foreign-failover: a flagged tier1/tier2 ticket this host does NOT own,
   // ONLY when its owner is provably dead/stranded. Appended AFTER all self-owned.

--- a/plugins/dev/scripts/execution-core/board-health.mjs
+++ b/plugins/dev/scripts/execution-core/board-health.mjs
@@ -774,8 +774,21 @@ function checkNeedsHumanPile(b) {
 function eligibleDeferredAnchors(board) {
   const sanctioned = new Set(board?.sanctionedNeedsHuman ?? []);
   const byId = board?.ticketsById;
+  // CTL-1432 (Codex P2): HRW-ownership filter, mirroring selectAnchorCandidates — a
+  // foreign-owned deferred marker must not make the gate proceed (this host would then
+  // no-anchor it). N=1 / no roster / no ownerForTicket ⇒ owns everything ⇒ unchanged.
+  const multiHost = !!(board?.multiHost && typeof board?.ownerForTicket === "function");
+  const owns = (t) => {
+    if (!multiHost) return true;
+    try {
+      return board.ownerForTicket(t, board.roster) === board.self;
+    } catch {
+      return true; // fail-open: a broken HRW read must not block self-owned actuation
+    }
+  };
   return (board?.deferredBoardHealth ?? []).filter((t) => {
     if (sanctioned.has(t)) return false;
+    if (!owns(t)) return false;
     const d = byId && typeof byId.get === "function" ? byId.get(t) : undefined;
     if (!d) return false;
     return !isTerminalLinearState(d);
@@ -804,13 +817,16 @@ export function decideBoardHealth(invariants, boardState) {
     moves.tier1.length > 0 || moves.tier2.length > 0 || deferred.length > 0;
 
   // Gate 1 — nothing actionable (all green, or every failure suppressed/escalate-only,
-  // and no deferred work) → skip (no LLM thrash).
+  // and no deferred work) → skip the holistic DISPATCH (no LLM thrash). CTL-1432 (Codex
+  // P2): still return the proposed `moves` (not emptyMoves) so an escalate-only board —
+  // tier3 stranded-node / project-silence — keeps surfacing those proposals in the
+  // recovery.board-scan event (a human should see them); we just don't dispatch.
   if (!hasActionableWork) {
     return decision(
       "skip",
       observableFailed.length === 0 ? "all-green" : "no-actionable-moves",
       invariantsFailed,
-      emptyMoves(),
+      moves,
     );
   }
   // Gate 2 — actionable work but no free slot to dispatch a fix → skip.
@@ -953,7 +969,7 @@ export function selectAnchorCandidates(moves, board, { holistic = false, strande
   // eligible-queue ticket. Cross-checked against the live board (ticketsById already
   // excludes Done/removed via getBoard's includeRemoved:false), so a stale defer marker
   // whose ticket has since gone terminal is dropped rather than re-anchored.
-  for (const t of eligibleDeferredAnchors(board).filter(owns)) add(t);
+  for (const t of eligibleDeferredAnchors(board)) add(t); // already HRW-owns-filtered
   for (const e of (board?.eligible ?? []).map((x) => x && x.id).filter(Boolean).filter(owns)) add(e);
   // holistic foreign-failover: a flagged tier1/tier2 ticket this host does NOT own,
   // ONLY when its owner is provably dead/stranded. Appended AFTER all self-owned.

--- a/plugins/dev/scripts/execution-core/board-health.mjs
+++ b/plugins/dev/scripts/execution-core/board-health.mjs
@@ -776,7 +776,14 @@ export function decideBoardHealth(invariants, boardState) {
   // trips the gate is inert). tier3 moves are escalate-only (never anchorable by
   // selectAnchorCandidates), so they alone do not justify a holistic pass.
   const moves = proposeMoves(invariants, boardState);
-  const deferred = boardState?.deferredBoardHealth ?? [];
+  // CTL-1432 (Codex P1): count only deferred intents whose ticket is still on the live
+  // board (ticketsById excludes Done/removed) — a since-terminal defer marker must not
+  // make the gate proceed (it would proceed then no-anchor). Mirrors selectAnchorCandidates.
+  const deferred = (boardState?.deferredBoardHealth ?? []).filter((t) =>
+    boardState?.ticketsById && typeof boardState.ticketsById.has === "function"
+      ? boardState.ticketsById.has(t)
+      : true,
+  );
   const hasActionableWork =
     moves.tier1.length > 0 || moves.tier2.length > 0 || deferred.length > 0;
 
@@ -822,11 +829,20 @@ export function proposeMoves(invariants, _b) {
   const tier1 = [];
   const tier2 = [];
   const tier3 = [];
+  // CTL-1432 (B3 + Codex P1): operator-sanctioned needs-human latches are never
+  // re-proposed as ANY per-ticket move — not just the frozenNeedsHuman tier2, but also
+  // the needsHumanPile tier1 (a sanctioned ticket with a live needs-human/stalled
+  // worker signal), workerAge, and the PR cohorts. They stay VISIBLE in
+  // frozenNeedsHuman / boardContext (suppression is HERE only, never in
+  // checkFrozenNeedsHuman) so a human still sees them; they just stop drowning the
+  // genuinely-stuck tickets every 5-min scan (making proposedTier1/2 a constant).
+  const sanctioned = new Set(_b?.sanctionedNeedsHuman ?? []);
+  const sanction = (t) => sanctioned.has(t);
   if (invariants.dispatchLiveness && !invariants.dispatchLiveness.ok) {
     tier1.push({ move: "kick-dispatch", rationale: invariants.dispatchLiveness.note });
   }
   for (const t of invariants.workerAge?.flagged ?? []) {
-    if (!invariants.workerAge.ok) tier1.push({ ticket: t, move: "nudge", rationale: "worker past phase-normal age" });
+    if (!invariants.workerAge.ok && !sanction(t)) tier1.push({ ticket: t, move: "nudge", rationale: "worker past phase-normal age" });
   }
   if (invariants.cacheCoherence && invariants.cacheCoherence.observable && !invariants.cacheCoherence.ok) {
     tier1.push({ move: "note-cache-drift", rationale: invariants.cacheCoherence.note });
@@ -835,27 +851,21 @@ export function proposeMoves(invariants, _b) {
   // Done vs reopen) and orphaned open PRs (finish or close) — is tier1 (highest
   // anchor priority); the status-based needs-human pile is the untyped catch-all.
   for (const t of invariants.phantomMergedPr?.flagged ?? []) {
-    if (!invariants.phantomMergedPr.ok) tier1.push({ ticket: t, move: "judge-done-or-reopen", rationale: "PR merged/deployed but ticket still in a PR/in-review state" });
+    if (!invariants.phantomMergedPr.ok && !sanction(t)) tier1.push({ ticket: t, move: "judge-done-or-reopen", rationale: "PR merged/deployed but ticket still in a PR/in-review state" });
   }
   for (const t of invariants.orphanedOpenPr?.flagged ?? []) {
-    if (!invariants.orphanedOpenPr.ok) tier1.push({ ticket: t, move: "finish-or-close-pr", rationale: "open PR with no live worker past age" });
+    if (!invariants.orphanedOpenPr.ok && !sanction(t)) tier1.push({ ticket: t, move: "finish-or-close-pr", rationale: "open PR with no live worker past age" });
   }
   for (const t of invariants.needsHumanPile?.flagged ?? []) {
-    if (!invariants.needsHumanPile.ok) tier1.push({ ticket: t, move: "holistic-triage", rationale: "worker parked at needs-human/stalled" });
+    if (!invariants.needsHumanPile.ok && !sanction(t)) tier1.push({ ticket: t, move: "holistic-triage", rationale: "worker parked at needs-human/stalled" });
   }
   for (const t of invariants.blockedTree?.flagged ?? []) {
-    if (!invariants.blockedTree.ok) tier2.push({ ticket: t, move: "re-dispatch-blocker", rationale: "blocked by unscheduled/stuck blocker" });
+    if (!invariants.blockedTree.ok && !sanction(t)) tier2.push({ ticket: t, move: "re-dispatch-blocker", rationale: "blocked by unscheduled/stuck blocker" });
   }
   // CTL-1157: a needs-human-LABELLED ticket frozen past 48h has already been
   // escalated once → tier2 (review, lower urgency than the actionable PR work).
-  // CTL-1432 (B3): operator-sanctioned needs-human latches stay VISIBLE in
-  // frozenNeedsHuman / boardContext but are never re-proposed as moves — else the
-  // sanctioned tickets drown the genuinely-stuck ones every 5-min scan (making
-  // proposedTier2 a constant). Suppression is HERE only, never in checkFrozenNeedsHuman.
-  const sanctioned = new Set(_b?.sanctionedNeedsHuman ?? []);
   for (const t of invariants.frozenNeedsHuman?.flagged ?? []) {
-    if (sanctioned.has(t)) continue;
-    if (!invariants.frozenNeedsHuman.ok) tier2.push({ ticket: t, move: "review-needs-human", rationale: "needs-human label frozen past threshold" });
+    if (!invariants.frozenNeedsHuman.ok && !sanction(t)) tier2.push({ ticket: t, move: "review-needs-human", rationale: "needs-human label frozen past threshold" });
   }
   for (const h of invariants.strandedNode?.flagged ?? []) {
     if (!invariants.strandedNode.ok) tier3.push({ host: h, move: "escalate-stranded-node", rationale: "rostered node owns work but reconcile is failing" });
@@ -918,15 +928,19 @@ export function selectAnchorCandidates(moves, board, { holistic = false, strande
     }
   };
   const ticketsOf = (arr) => (arr ?? []).map((m) => m && m.ticket).filter(Boolean);
-  // self-owned chain first (unchanged tier1 > tier2 > eligible ordering).
+  // self-owned chain first (unchanged tier1 > tier2 ordering).
   for (const t of ticketsOf(moves?.tier1).filter(owns)) add(t);
   for (const t of ticketsOf(moves?.tier2).filter(owns)) add(t);
+  // CTL-1432 (B2, Codex P1): deferred board-health intents rank AFTER flagged work but
+  // BEFORE the eligible fallback — when a scan proceeds SOLELY for a deferred intent
+  // (empty moves), the deferred ticket MUST be the anchor, not an unrelated top-of-
+  // eligible-queue ticket. Cross-checked against the live board (ticketsById already
+  // excludes Done/removed via getBoard's includeRemoved:false), so a stale defer marker
+  // whose ticket has since gone terminal is dropped rather than re-anchored.
+  const onBoard = (t) =>
+    board?.ticketsById && typeof board.ticketsById.has === "function" ? board.ticketsById.has(t) : true;
+  for (const t of (board?.deferredBoardHealth ?? []).filter(owns).filter(onBoard)) add(t);
   for (const e of (board?.eligible ?? []).map((x) => x && x.id).filter(Boolean).filter(owns)) add(e);
-  // CTL-1432 (B2): deferred board-health intents are self-owned anchor candidates —
-  // ranked AFTER flagged work + the eligible queue, but still actuated when a slot is
-  // free, so "the holistic delegate will triage" dispatches a recovery-pass instead of
-  // the deferred intent rotting. Self-owned filtered like every other candidate.
-  for (const t of (board?.deferredBoardHealth ?? []).filter(owns)) add(t);
   // holistic foreign-failover: a flagged tier1/tier2 ticket this host does NOT own,
   // ONLY when its owner is provably dead/stranded. Appended AFTER all self-owned.
   if (holistic && multiHost) {

--- a/plugins/dev/scripts/execution-core/board-health.mjs
+++ b/plugins/dev/scripts/execution-core/board-health.mjs
@@ -766,11 +766,31 @@ export function decideBoardHealth(invariants, boardState) {
   const observableFailed = Object.values(invariants).filter((v) => v.observable && !v.ok);
   const invariantsFailed = observableFailed.reduce((n, v) => n + (Number(v.failed) || 0), 0);
 
-  // Gate 1 — all observable invariants green → skip (no LLM thrash).
-  if (observableFailed.length === 0) {
-    return decision("skip", "all-green", invariantsFailed, emptyMoves());
+  // CTL-1432 (B2/B3 — Codex P1): gate on ACTIONABLE work, not merely a failed
+  // invariant. proposeMoves already suppresses the sanctioned needs-human latches
+  // (B3), so a scan whose ONLY failure is an all-sanctioned frozenNeedsHuman produces
+  // no tier1/tier2 moves → it must NOT proceed (F2: else enforce dispatches a holistic
+  // pass with nothing real to do). Conversely, a deferred board-health intent (B2) is
+  // actionable even when NO invariant failed → it MUST proceed (F1: boardHealthPass
+  // calls selectAnchorCandidates only after "proceed", so a deferred intent that never
+  // trips the gate is inert). tier3 moves are escalate-only (never anchorable by
+  // selectAnchorCandidates), so they alone do not justify a holistic pass.
+  const moves = proposeMoves(invariants, boardState);
+  const deferred = boardState?.deferredBoardHealth ?? [];
+  const hasActionableWork =
+    moves.tier1.length > 0 || moves.tier2.length > 0 || deferred.length > 0;
+
+  // Gate 1 — nothing actionable (all green, or every failure suppressed/escalate-only,
+  // and no deferred work) → skip (no LLM thrash).
+  if (!hasActionableWork) {
+    return decision(
+      "skip",
+      observableFailed.length === 0 ? "all-green" : "no-actionable-moves",
+      invariantsFailed,
+      emptyMoves(),
+    );
   }
-  // Gate 2 — failures exist but no free slot to dispatch a fix → skip.
+  // Gate 2 — actionable work but no free slot to dispatch a fix → skip.
   if ((boardState.capacity?.freeSlots ?? 0) <= 0) {
     return decision("skip", "no-free-slots", invariantsFailed, emptyMoves());
   }
@@ -779,8 +799,12 @@ export function decideBoardHealth(invariants, boardState) {
   if (rl && rl.observable && !rl.ok) {
     return decision("skip", "rate-limit-cliff", invariantsFailed, emptyMoves());
   }
-  // Gate 4 — real failures + headroom → proceed; compute proposed moves.
-  return decision("proceed", `${observableFailed.length} invariant(s) flagged`, invariantsFailed, proposeMoves(invariants, boardState));
+  // Gate 4 — actionable work + headroom → proceed.
+  const reason =
+    observableFailed.length > 0
+      ? `${observableFailed.length} invariant(s) flagged`
+      : `${deferred.length} deferred board-health intent(s)`;
+  return decision("proceed", reason, invariantsFailed, moves);
 }
 
 function decision(gateDecision, reason, invariantsFailed, moves) {

--- a/plugins/dev/scripts/execution-core/board-health.test.mjs
+++ b/plugins/dev/scripts/execution-core/board-health.test.mjs
@@ -673,6 +673,35 @@ describe("selectAnchorCandidates — CTL-1432 deferred board-health (B2)", () =>
   });
 });
 
+// ─── CTL-1432 (B2/B3 — Codex P1): the gate accounts for deferred work + suppression ─
+describe("decideBoardHealth — CTL-1432 gate (deferred proceed / all-sanctioned skip)", () => {
+  test("(F1) a deferred board-health intent makes the gate PROCEED even when all invariants are green", () => {
+    const board = mkBoard({ deferredBoardHealth: ["ADV-1403"], capacity: { freeSlots: 4 } });
+    const d = decideBoardHealth(allGreen(), board);
+    expect(d.gate.decision).toBe("proceed");
+    expect(d.gate.reason).toMatch(/deferred/);
+  });
+
+  test("(F2) an all-sanctioned frozenNeedsHuman as the ONLY failure → gate SKIPS (no actionable moves)", () => {
+    const invs = { ...allGreen(), frozenNeedsHuman: inv(false, 2, true, ["CTL-SANCT-1", "CTL-SANCT-2"]) };
+    const board = mkBoard({
+      sanctionedNeedsHuman: ["CTL-SANCT-1", "CTL-SANCT-2"],
+      capacity: { freeSlots: 4 },
+    });
+    const d = decideBoardHealth(invs, board);
+    expect(d.gate.decision).toBe("skip");
+    expect(d.gate.reason).toBe("no-actionable-moves");
+  });
+
+  test("a partially-sanctioned frozenNeedsHuman still PROCEEDS on the non-sanctioned ticket", () => {
+    const invs = { ...allGreen(), frozenNeedsHuman: inv(false, 2, true, ["CTL-SANCT", "CTL-REAL"]) };
+    const board = mkBoard({ sanctionedNeedsHuman: ["CTL-SANCT"], capacity: { freeSlots: 4 } });
+    const d = decideBoardHealth(invs, board);
+    expect(d.gate.decision).toBe("proceed");
+    expect(d.moves.tier2.map((x) => x.ticket)).toEqual(["CTL-REAL"]);
+  });
+});
+
 // ─── buildBoardScanEvent — the flat event the emit envelope rides ───────────
 describe("buildBoardScanEvent", () => {
   test("type/ticket/scalars at top of details; rosters as arrays; mode echoed", () => {

--- a/plugins/dev/scripts/execution-core/board-health.test.mjs
+++ b/plugins/dev/scripts/execution-core/board-health.test.mjs
@@ -703,6 +703,19 @@ describe("selectAnchorCandidates — CTL-1432 deferred board-health (B2)", () =>
     const out = selectAnchorCandidates({ tier1: [], tier2: [], tier3: [] }, board);
     expect(out).not.toContain("CTL-SANCT");
   });
+
+  test("(Codex P2 r4) a FOREIGN-owned deferred marker is dropped (multi-host HRW)", () => {
+    const board = mkBoard({
+      deferredBoardHealth: ["ADV-FOREIGN"],
+      ticketsById: new Map([["ADV-FOREIGN", {}]]),
+      multiHost: true,
+      self: "mini",
+      roster: ["mini", "mini-2"],
+      ownerForTicket: () => "mini-2", // owned by the OTHER host
+    });
+    const out = selectAnchorCandidates({ tier1: [], tier2: [], tier3: [] }, board);
+    expect(out).not.toContain("ADV-FOREIGN");
+  });
 });
 
 // ─── CTL-1432 (B2/B3 — Codex P1): the gate accounts for deferred work + suppression ─
@@ -722,6 +735,13 @@ describe("decideBoardHealth — CTL-1432 gate (deferred proceed / all-sanctioned
     const board = mkBoard({ deferredBoardHealth: ["ADV-DONE"], ticketsById: new Map(), capacity: { freeSlots: 4 } });
     const d = decideBoardHealth(allGreen(), board);
     expect(d.gate.decision).toBe("skip");
+  });
+
+  test("(Codex P2 r4) a tier3-only board SKIPS dispatch but still SURFACES the tier3 proposals in decision.moves", () => {
+    const invs = { ...allGreen(), strandedNode: inv(false, 1, true, ["mini-2"]) };
+    const d = decideBoardHealth(invs, mkBoard({ capacity: { freeSlots: 4 } }));
+    expect(d.gate.decision).toBe("skip"); // escalate-only → no holistic dispatch
+    expect(d.moves.tier3.map((x) => x.move)).toContain("escalate-stranded-node"); // …but surfaced
   });
 
   test("(F2) an all-sanctioned frozenNeedsHuman as the ONLY failure → gate SKIPS (no actionable moves)", () => {

--- a/plugins/dev/scripts/execution-core/board-health.test.mjs
+++ b/plugins/dev/scripts/execution-core/board-health.test.mjs
@@ -655,31 +655,57 @@ describe("proposeMoves — CTL-1432 sanctioned-latch suppression (B3)", () => {
     const m = proposeMoves(invs, mkBoard());
     expect(m.tier2.map((x) => x.ticket)).toContain("CTL-REAL");
   });
+
+  test("(Codex P1) a sanctioned ticket in the needs-human PILE is not proposed as a tier1 holistic-triage", () => {
+    const invs = { ...allGreen(), needsHumanPile: inv(false, 1, true, ["CTL-SANCT"]) };
+    const m = proposeMoves(invs, mkBoard({ sanctionedNeedsHuman: ["CTL-SANCT"] }));
+    expect(m.tier1.map((x) => x.ticket)).not.toContain("CTL-SANCT");
+  });
 });
 
 // ─── CTL-1432 (B2): deferred board-health intents become anchor candidates ──────
 describe("selectAnchorCandidates — CTL-1432 deferred board-health (B2)", () => {
-  test("a deferred board-health ticket with NO invariant flag is a self-owned anchor candidate", () => {
-    const board = mkBoard({ deferredBoardHealth: ["ADV-1403"] });
+  test("a deferred board-health ticket (on the live board) with NO invariant flag is a self-owned anchor candidate", () => {
+    const board = mkBoard({ deferredBoardHealth: ["ADV-1403"], ticketsById: new Map([["ADV-1403", {}]]) });
     const out = selectAnchorCandidates({ tier1: [], tier2: [], tier3: [] }, board);
     expect(out).toContain("ADV-1403");
   });
 
-  test("deferred candidates rank AFTER flagged work + the eligible queue", () => {
-    const board = mkBoard({ deferredBoardHealth: ["ADV-1403"], eligible: [{ id: "CTL-ELIG" }] });
+  test("(Codex P1) deferred candidates rank AFTER flagged work but BEFORE the eligible queue", () => {
+    const board = mkBoard({
+      deferredBoardHealth: ["ADV-1403"],
+      eligible: [{ id: "CTL-ELIG" }],
+      ticketsById: new Map([["ADV-1403", {}]]),
+    });
     const moves = { tier1: [{ ticket: "CTL-FLAG" }], tier2: [], tier3: [] };
     const out = selectAnchorCandidates(moves, board);
-    expect(out).toEqual(["CTL-FLAG", "CTL-ELIG", "ADV-1403"]);
+    expect(out).toEqual(["CTL-FLAG", "ADV-1403", "CTL-ELIG"]);
+  });
+
+  test("(Codex P1) a deferred ticket NOT on the live board (since terminal) is dropped", () => {
+    const board = mkBoard({ deferredBoardHealth: ["ADV-DONE"], ticketsById: new Map() });
+    const out = selectAnchorCandidates({ tier1: [], tier2: [], tier3: [] }, board);
+    expect(out).not.toContain("ADV-DONE");
   });
 });
 
 // ─── CTL-1432 (B2/B3 — Codex P1): the gate accounts for deferred work + suppression ─
 describe("decideBoardHealth — CTL-1432 gate (deferred proceed / all-sanctioned skip)", () => {
-  test("(F1) a deferred board-health intent makes the gate PROCEED even when all invariants are green", () => {
-    const board = mkBoard({ deferredBoardHealth: ["ADV-1403"], capacity: { freeSlots: 4 } });
+  test("(F1) a deferred board-health intent (on the live board) makes the gate PROCEED even when all invariants are green", () => {
+    const board = mkBoard({
+      deferredBoardHealth: ["ADV-1403"],
+      ticketsById: new Map([["ADV-1403", {}]]),
+      capacity: { freeSlots: 4 },
+    });
     const d = decideBoardHealth(allGreen(), board);
     expect(d.gate.decision).toBe("proceed");
     expect(d.gate.reason).toMatch(/deferred/);
+  });
+
+  test("(Codex P1) a deferred intent whose ticket is terminal (not on the board) does NOT proceed", () => {
+    const board = mkBoard({ deferredBoardHealth: ["ADV-DONE"], ticketsById: new Map(), capacity: { freeSlots: 4 } });
+    const d = decideBoardHealth(allGreen(), board);
+    expect(d.gate.decision).toBe("skip");
   });
 
   test("(F2) an all-sanctioned frozenNeedsHuman as the ONLY failure → gate SKIPS (no actionable moves)", () => {

--- a/plugins/dev/scripts/execution-core/board-health.test.mjs
+++ b/plugins/dev/scripts/execution-core/board-health.test.mjs
@@ -682,10 +682,26 @@ describe("selectAnchorCandidates — CTL-1432 deferred board-health (B2)", () =>
     expect(out).toEqual(["CTL-FLAG", "ADV-1403", "CTL-ELIG"]);
   });
 
-  test("(Codex P1) a deferred ticket NOT on the live board (since terminal) is dropped", () => {
+  test("(Codex P1) a deferred ticket NOT on the live board (removed) is dropped", () => {
     const board = mkBoard({ deferredBoardHealth: ["ADV-DONE"], ticketsById: new Map() });
     const out = selectAnchorCandidates({ tier1: [], tier2: [], tier3: [] }, board);
     expect(out).not.toContain("ADV-DONE");
+  });
+
+  test("(Codex P1 r3) a deferred ticket in a TERMINAL Linear state is dropped (getBoard keeps Done descriptors)", () => {
+    const board = mkBoard({ deferredBoardHealth: ["CTL-DONE"], ticketsById: new Map([["CTL-DONE", { state: "Done" }]]) });
+    const out = selectAnchorCandidates({ tier1: [], tier2: [], tier3: [] }, board);
+    expect(out).not.toContain("CTL-DONE");
+  });
+
+  test("(Codex P1 r3) a deferred ticket that is ALSO sanctioned is dropped from the deferred anchors", () => {
+    const board = mkBoard({
+      deferredBoardHealth: ["CTL-SANCT"],
+      sanctionedNeedsHuman: ["CTL-SANCT"],
+      ticketsById: new Map([["CTL-SANCT", {}]]),
+    });
+    const out = selectAnchorCandidates({ tier1: [], tier2: [], tier3: [] }, board);
+    expect(out).not.toContain("CTL-SANCT");
   });
 });
 

--- a/plugins/dev/scripts/execution-core/board-health.test.mjs
+++ b/plugins/dev/scripts/execution-core/board-health.test.mjs
@@ -15,6 +15,7 @@ import {
   decideBoardHealth,
   proposeMoves,
   selectAnchor,
+  selectAnchorCandidates,
   buildBoardContext,
   buildBoardScanEvent,
   boardHealthPass,
@@ -73,6 +74,9 @@ function mkBoard(o = {}) {
     ownerForTicket: o.ownerForTicket ?? null,
     // CTL-1157 (Codex #4): ticket→owner/repo resolver for the composite lookup.
     repoForTicket: o.repoForTicket ?? null,
+    // CTL-1432 (B2/B3): deferred board-health anchor candidates + sanctioned latch allowlist.
+    deferredBoardHealth: o.deferredBoardHealth ?? [],
+    sanctionedNeedsHuman: o.sanctionedNeedsHuman ?? [],
     now: o.now ?? NOW,
   };
 }
@@ -633,6 +637,39 @@ describe("proposeMoves — tiering", () => {
     expect(d.proposed.tier1).toBe(d.moves.tier1.length);
     expect(d.proposed.tier2).toBe(d.moves.tier2.length);
     expect(d.proposed.tier3).toBe(d.moves.tier3.length);
+  });
+});
+
+// ─── CTL-1432 (B3): sanctioned needs-human latches suppressed from proposeMoves ─
+describe("proposeMoves — CTL-1432 sanctioned-latch suppression (B3)", () => {
+  test("a sanctioned frozen ticket is NOT re-proposed; a non-sanctioned one still is", () => {
+    const invs = { ...allGreen(), frozenNeedsHuman: inv(false, 2, true, ["CTL-SANCT", "CTL-REAL"]) };
+    const m = proposeMoves(invs, mkBoard({ sanctionedNeedsHuman: ["CTL-SANCT"] }));
+    const t2 = m.tier2.filter((x) => x.move === "review-needs-human").map((x) => x.ticket);
+    expect(t2).toContain("CTL-REAL");
+    expect(t2).not.toContain("CTL-SANCT");
+  });
+
+  test("empty allowlist → every frozen ticket still proposed (default behavior unchanged)", () => {
+    const invs = { ...allGreen(), frozenNeedsHuman: inv(false, 1, true, ["CTL-REAL"]) };
+    const m = proposeMoves(invs, mkBoard());
+    expect(m.tier2.map((x) => x.ticket)).toContain("CTL-REAL");
+  });
+});
+
+// ─── CTL-1432 (B2): deferred board-health intents become anchor candidates ──────
+describe("selectAnchorCandidates — CTL-1432 deferred board-health (B2)", () => {
+  test("a deferred board-health ticket with NO invariant flag is a self-owned anchor candidate", () => {
+    const board = mkBoard({ deferredBoardHealth: ["ADV-1403"] });
+    const out = selectAnchorCandidates({ tier1: [], tier2: [], tier3: [] }, board);
+    expect(out).toContain("ADV-1403");
+  });
+
+  test("deferred candidates rank AFTER flagged work + the eligible queue", () => {
+    const board = mkBoard({ deferredBoardHealth: ["ADV-1403"], eligible: [{ id: "CTL-ELIG" }] });
+    const moves = { tier1: [{ ticket: "CTL-FLAG" }], tier2: [], tier3: [] };
+    const out = selectAnchorCandidates(moves, board);
+    expect(out).toEqual(["CTL-FLAG", "CTL-ELIG", "ADV-1403"]);
   });
 });
 

--- a/plugins/dev/scripts/execution-core/config.mjs
+++ b/plugins/dev/scripts/execution-core/config.mjs
@@ -1325,7 +1325,10 @@ export const BOARD_HEALTH_MODES = new Set(["off", "shadow", "enforce"]);
 // sanctionedNeedsHuman; default empty (suppress nothing).
 export function readSanctionedNeedsHuman(env = process.env) {
   const raw = env.CATALYST_BH_SANCTIONED_LATCHES;
-  if (typeof raw === "string" && raw.trim()) {
+  // CTL-1432 (Codex P2): a DEFINED env var — even empty — is an explicit override, so
+  // `CATALYST_BH_SANCTIONED_LATCHES=` clears the allowlist (empty → []). Only fall
+  // through to Layer-2 when the env var is UNSET (undefined).
+  if (typeof raw === "string") {
     return raw.split(",").map((s) => s.trim()).filter(Boolean);
   }
   const l2 = readLayer2BoardHealth();

--- a/plugins/dev/scripts/execution-core/config.mjs
+++ b/plugins/dev/scripts/execution-core/config.mjs
@@ -1316,6 +1316,23 @@ export function readDeadDocWorkerConfig() {
 //             carrying the whole-board context. Operator-gated — never auto-enabled.
 export const BOARD_HEALTH_MODES = new Set(["off", "shadow", "enforce"]);
 
+// readSanctionedNeedsHuman — CTL-1432 (B3). The operator-sanctioned needs-human
+// latch allowlist: tickets a human has deliberately parked at needs-human that the
+// delegate must NOT re-propose as moves every scan (they drown the genuinely-stuck
+// tickets). They STAY visible in boardContext.frozenNeedsHuman — this only
+// suppresses them from proposeMoves. Env CATALYST_BH_SANCTIONED_LATCHES
+// (comma-separated ticket ids) overrides Layer-2 catalyst.boardHealth.
+// sanctionedNeedsHuman; default empty (suppress nothing).
+export function readSanctionedNeedsHuman(env = process.env) {
+  const raw = env.CATALYST_BH_SANCTIONED_LATCHES;
+  if (typeof raw === "string" && raw.trim()) {
+    return raw.split(",").map((s) => s.trim()).filter(Boolean);
+  }
+  const l2 = readLayer2BoardHealth();
+  const list = l2?.sanctionedNeedsHuman;
+  return Array.isArray(list) ? list.filter((x) => typeof x === "string") : [];
+}
+
 function readLayer2BoardHealth() {
   try {
     const b = JSON.parse(readFileSync(getLayer2ConfigPath(), "utf8"))?.catalyst?.boardHealth;

--- a/plugins/dev/scripts/execution-core/config.test.mjs
+++ b/plugins/dev/scripts/execution-core/config.test.mjs
@@ -37,6 +37,7 @@ import {
   CLUSTER_SYNC_INTERVAL_MS,
   readDeadDocWorkerConfig,
   readBoardHealthConfig,
+  readSanctionedNeedsHuman,
   DEAD_DOC_WORKER_TRANSCRIPT_SILENCE_MS,
   readLinearReplica,
   getReplicaDbPath,
@@ -1049,6 +1050,22 @@ describe("readDeadDocWorkerConfig (CTL-1245)", () => {
   });
   test("transcript-silence floor defaults to 30 minutes", () => {
     expect(DEAD_DOC_WORKER_TRANSCRIPT_SILENCE_MS).toBe(30 * 60_000);
+  });
+});
+
+describe("readSanctionedNeedsHuman (CTL-1432 B3)", () => {
+  const saved = process.env.CATALYST_BH_SANCTIONED_LATCHES;
+  afterEach(() => {
+    if (saved === undefined) delete process.env.CATALYST_BH_SANCTIONED_LATCHES;
+    else process.env.CATALYST_BH_SANCTIONED_LATCHES = saved;
+  });
+  test("env list → parsed, trimmed, empties dropped", () => {
+    process.env.CATALYST_BH_SANCTIONED_LATCHES = "CTL-1, CTL-2 ,, CTL-3";
+    expect(readSanctionedNeedsHuman()).toEqual(["CTL-1", "CTL-2", "CTL-3"]);
+  });
+  test("(Codex P2) an EMPTY env var explicitly clears the allowlist → [] (does not fall through to Layer-2)", () => {
+    process.env.CATALYST_BH_SANCTIONED_LATCHES = "";
+    expect(readSanctionedNeedsHuman()).toEqual([]);
   });
 });
 

--- a/plugins/dev/scripts/execution-core/recovery-reasoning.mjs
+++ b/plugins/dev/scripts/execution-core/recovery-reasoning.mjs
@@ -29,6 +29,7 @@ import {
   mkdirSync,
   appendFileSync,
   readFileSync,
+  readdirSync,
   writeFileSync,
   existsSync,
   renameSync,
@@ -1680,6 +1681,39 @@ export const RECOVERY_MAX_ATTEMPTS =
 
 function recoveryIntentPath(orchDir, ticket) {
   return join(orchDir, ".recovery-intents", `${ticket}.json`);
+}
+
+// readDeferredBoardHealthIntents — CTL-1432 (B2). Enumerate the tickets whose
+// recovery-intent is a DEFERRAL to the holistic board-health delegate
+// (decision:"defer" + fix_class:"board-health" — the classifier's "no typed
+// failure signature; the holistic board-health delegate will triage" path). Until
+// now nothing consumed these, so a deferred ticket rotted (the delegate-mini
+// session it implicitly routed to has been dormant since Jun 19). board-health's
+// selectAnchorCandidates now folds these in as first-class self-owned anchors so
+// the holistic pass actually dispatches a recovery-pass for them. Pure read,
+// fail-open: absent dir / malformed entries → [].
+export function readDeferredBoardHealthIntents(orchDir) {
+  if (!orchDir) return [];
+  const dir = join(orchDir, ".recovery-intents");
+  let files;
+  try {
+    files = readdirSync(dir);
+  } catch {
+    return [];
+  }
+  const out = [];
+  for (const f of files) {
+    if (!f.endsWith(".json")) continue;
+    try {
+      const data = JSON.parse(readFileSync(join(dir, f), "utf8"));
+      if (data?.decision === "defer" && data?.fix_class === "board-health") {
+        out.push(f.replace(/\.json$/, ""));
+      }
+    } catch {
+      /* malformed → skip */
+    }
+  }
+  return out;
 }
 
 // defaultRecordIntent — append/upgrade a recovery-intent ledger entry.

--- a/plugins/dev/scripts/execution-core/recovery-reasoning.mjs
+++ b/plugins/dev/scripts/execution-core/recovery-reasoning.mjs
@@ -1765,10 +1765,21 @@ export function defaultRecordIntent(ticket, intent, opts = {}) {
     Boolean(intent.escalated) ||
     intent.decision === "escalate"; // an escalate-pass latches escalated
 
+  // CTL-1432 (Codex P1): a REPEATED defer→board-health is a no-op handoff — the ticket
+  // is already handed to the board-health delegate, so re-deferring must NOT refresh
+  // lastTs. Otherwise the per-item recovery pass (which runs BEFORE boardHealthPass in
+  // the same tick) re-defers the marker back under the 30-min cooldown every cycle, and
+  // the board-health consumer — which gates on lastTs — is starved forever. Freezing
+  // lastTs lets the marker AGE OUT so board-health finally consumes + dispatches it.
+  const isRepeatedBoardHealthDefer =
+    intent.decision === "defer" &&
+    (intent.fix_class ?? prior.fix_class) === "board-health" &&
+    prior.decision === "defer" &&
+    typeof prior.lastTs === "number";
   const entry = {
     ticket,
     ts: typeof prior.ts === "number" ? prior.ts : ts, // first-action timestamp
-    lastTs: ts, // most-recent action timestamp (drives the cooldown window)
+    lastTs: isRepeatedBoardHealthDefer ? prior.lastTs : ts, // most-recent action ts (drives cooldown)
     decision: intent.decision,
     fix_class: intent.fix_class ?? prior.fix_class ?? null,
     attempts:

--- a/plugins/dev/scripts/execution-core/recovery-reasoning.mjs
+++ b/plugins/dev/scripts/execution-core/recovery-reasoning.mjs
@@ -1700,7 +1700,7 @@ function recoveryIntentPath(orchDir, ticket) {
 // selectAnchorCandidates now folds these in as first-class self-owned anchors so
 // the holistic pass actually dispatches a recovery-pass for them. Pure read,
 // fail-open: absent dir / malformed entries → [].
-export function readDeferredBoardHealthIntents(orchDir) {
+export function readDeferredBoardHealthIntents(orchDir, { now = () => Date.now(), cooldownMs = RECOVERY_COOLDOWN_MS } = {}) {
   if (!orchDir) return [];
   const dir = join(orchDir, ".recovery-intents");
   let files;
@@ -1715,6 +1715,12 @@ export function readDeferredBoardHealthIntents(orchDir) {
     try {
       const data = JSON.parse(readFileSync(join(dir, f), "utf8"));
       if (data?.decision === "defer" && data?.fix_class === "board-health") {
+        // CTL-1432 (Codex P1): honor the 30-min defer cooldown — defaultShouldSkipItem
+        // treats a defer marker as cooldown-only, so a deferred intent still inside its
+        // window is not yet an actionable anchor (else the gate proceeds and then the
+        // act site skips it → a wasted proceed).
+        const last = typeof data?.lastTs === "number" ? data.lastTs : data?.ts;
+        if (typeof last === "number" && now() - last < cooldownMs) continue;
         out.push(f.replace(/\.json$/, ""));
       }
     } catch {

--- a/plugins/dev/scripts/execution-core/recovery-reasoning.test.mjs
+++ b/plugins/dev/scripts/execution-core/recovery-reasoning.test.mjs
@@ -12,6 +12,7 @@ import {
   generateRemediateBrief,
   buildRecoveryEnvelope,
   defaultRecordIntent,
+  readDeferredBoardHealthIntents,
   defaultShouldSkipItem,
   defaultForgetIntent,
   defaultInvokeRemediateCapped,
@@ -1104,6 +1105,38 @@ describe("recovery-intent ledger (cooldown + max-attempts + escalated)", () => {
   test("forgetIntent with no orchDir / no ticket → false (fail-soft)", () => {
     expect(defaultForgetIntent("CTL-309", { orchDir: null })).toBe(false);
     expect(defaultForgetIntent("", { orchDir })).toBe(false);
+  });
+});
+
+// ─── CTL-1432 (B2): readDeferredBoardHealthIntents ──────────────────────────
+describe("readDeferredBoardHealthIntents (CTL-1432 B2)", () => {
+  let orchDir;
+  beforeEach(() => {
+    orchDir = mkdtempSync(pathJoin(tmpdir(), "rec-defer-"));
+  });
+  afterEach(() => {
+    try {
+      rmSync(orchDir, { recursive: true, force: true });
+    } catch {
+      /* best-effort */
+    }
+  });
+
+  test("returns ONLY defer + fix_class=board-health tickets", () => {
+    const t0 = 1_000_000_000_000;
+    // a deferred board-health intent → included
+    defaultRecordIntent("ADV-1403", { decision: "defer", fix_class: "board-health" }, { orchDir, now: () => t0 });
+    // a deferred intent with a DIFFERENT fix_class → excluded
+    defaultRecordIntent("CTL-900", { decision: "defer", fix_class: "bounded-llm" }, { orchDir, now: () => t0 });
+    // a non-defer (fix) board-health-ish intent → excluded (decision must be defer)
+    defaultRecordIntent("CTL-901", { decision: "fix", fix_class: "board-health" }, { orchDir, now: () => t0 });
+    const out = readDeferredBoardHealthIntents(orchDir);
+    expect(out).toEqual(["ADV-1403"]);
+  });
+
+  test("fail-open: absent dir / no orchDir → []", () => {
+    expect(readDeferredBoardHealthIntents(pathJoin(orchDir, "does-not-exist"))).toEqual([]);
+    expect(readDeferredBoardHealthIntents(null)).toEqual([]);
   });
 });
 

--- a/plugins/dev/scripts/execution-core/recovery-reasoning.test.mjs
+++ b/plugins/dev/scripts/execution-core/recovery-reasoning.test.mjs
@@ -1236,6 +1236,15 @@ describe("readDeferredBoardHealthIntents (CTL-1432 B2)", () => {
     expect(readDeferredBoardHealthIntents(pathJoin(orchDir, "does-not-exist"))).toEqual([]);
     expect(readDeferredBoardHealthIntents(null)).toEqual([]);
   });
+
+  test("(Codex P1 r3) a deferred intent still inside its 30-min cooldown is NOT returned", () => {
+    const t0 = 1_000_000_000_000;
+    defaultRecordIntent("ADV-COOL", { decision: "defer", fix_class: "board-health" }, { orchDir, now: () => t0 });
+    // within cooldown → excluded (it would proceed the gate then be skipped at the act site)
+    expect(readDeferredBoardHealthIntents(orchDir, { now: () => t0 + 1_000 })).toEqual([]);
+    // past cooldown → included
+    expect(readDeferredBoardHealthIntents(orchDir, { now: () => t0 + RECOVERY_COOLDOWN_MS + 1 })).toContain("ADV-COOL");
+  });
 });
 
 // ─── CTL-1176: capped remediate dispatch (cap enforcement) ──────────────────

--- a/plugins/dev/scripts/execution-core/recovery-reasoning.test.mjs
+++ b/plugins/dev/scripts/execution-core/recovery-reasoning.test.mjs
@@ -1245,6 +1245,28 @@ describe("readDeferredBoardHealthIntents (CTL-1432 B2)", () => {
     // past cooldown → included
     expect(readDeferredBoardHealthIntents(orchDir, { now: () => t0 + RECOVERY_COOLDOWN_MS + 1 })).toContain("ADV-COOL");
   });
+
+  test("(Codex P1 r4) a REPEATED defer→board-health FREEZES lastTs so the marker ages out for board-health", () => {
+    const t0 = 1_000_000_000_000;
+    defaultRecordIntent("CTL-BHD", { decision: "defer", fix_class: "board-health" }, { orchDir, now: () => t0 });
+    // the per-item pass re-defers 40 min later (past cooldown) — lastTs must NOT refresh,
+    // else it stays perpetually under cooldown and starves the board-health consumer.
+    const e2 = defaultRecordIntent(
+      "CTL-BHD",
+      { decision: "defer", fix_class: "board-health" },
+      { orchDir, now: () => t0 + 40 * 60_000 },
+    );
+    expect(e2.lastTs).toBe(t0); // frozen at the first defer
+    // and the reader now sees it (past cooldown from the frozen lastTs):
+    expect(readDeferredBoardHealthIntents(orchDir, { now: () => t0 + 40 * 60_000 })).toContain("CTL-BHD");
+  });
+
+  test("a repeated NON-board-health defer still refreshes lastTs (unchanged)", () => {
+    const t0 = 1_000_000_000_000;
+    defaultRecordIntent("CTL-D", { decision: "defer", fix_class: "bounded-llm" }, { orchDir, now: () => t0 });
+    const e2 = defaultRecordIntent("CTL-D", { decision: "defer", fix_class: "bounded-llm" }, { orchDir, now: () => t0 + 1000 });
+    expect(e2.lastTs).toBe(t0 + 1000);
+  });
 });
 
 // ─── CTL-1176: capped remediate dispatch (cap enforcement) ──────────────────

--- a/plugins/dev/scripts/execution-core/scheduler.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.mjs
@@ -233,6 +233,7 @@ import {
 import {
   reasoningRecoveryPass,
   defaultShouldSkipItem as recoveryShouldSkipItem,
+  readDeferredBoardHealthIntents, // CTL-1432 (B2): deferred board-health anchor candidates
   defaultRecordIntent as recoveryRecordIntent,
   // CTL-1242 (corrected scope): forget the host-local recovery-intent latch when
   // a ticket goes terminal so the ledger doesn't accumulate stale finished-ticket
@@ -266,7 +267,7 @@ import {
 // to production deps at the unstuckSweep wiring point below. Wiring this does NOT
 // flip enforce on — the mode gate stays at its safe 'off' default (ADR-023).
 import { buildUnstuckActSeams } from "./unstuck-act-seams.mjs";
-import { readUnstuckSweepConfig, readRecoveryPassConfig, readBoardHealthConfig, readReclaimGatewayFreshMs, isThrottled } from "./config.mjs";
+import { readUnstuckSweepConfig, readRecoveryPassConfig, readBoardHealthConfig, readSanctionedNeedsHuman, readReclaimGatewayFreshMs, isThrottled } from "./config.mjs";
 // CTL-558: the deterministic Linear status/label write seam. The whole module
 // is injected as `writeStatus` so tests pass fakes; production uses the real
 // module (best-effort — every write swallows its own failures).
@@ -4573,6 +4574,8 @@ export function schedulerTick(
           // passes none → null → number-only fallback (N=1 byte-identical).
           repoForTicket: _boardHealth.repoForTicket,
           getReconcileMarkers: _boardHealth.getReconcileMarkers,
+          getDeferredBoardHealthTickets: _boardHealth.getDeferredBoardHealthTickets, // CTL-1432 (B2)
+          sanctionedNeedsHuman: _boardHealth.sanctionedNeedsHuman, // CTL-1432 (B3)
           // CTL-1157: thread the PR-status reader + the provably-dead host set.
           // Both are daemon-bound (the binding below); a bare tick passes neither
           // → empty-Map / empty-array defaults keep the new invariants
@@ -6721,6 +6724,12 @@ function runTick() {
         },
         readEventRing: () => readBoardHealthEventTail(),
         getReconcileMarkers: () => readReconcileHealthMarkers({}),
+        // CTL-1432 (B2): deferred board-health intents → first-class anchor candidates
+        // (retires the dormant delegate-mini session). (B3): the sanctioned needs-human
+        // allowlist (env CATALYST_BH_SANCTIONED_LATCHES / Layer-2 config), suppressed
+        // from proposeMoves so the genuinely-stuck tickets stop being drowned each scan.
+        getDeferredBoardHealthTickets: () => readDeferredBoardHealthIntents(runningOpts.orchDir),
+        sanctionedNeedsHuman: readSanctionedNeedsHuman(),
         // CTL-1157 (A11): the filter_state PR-status reader (phantom/orphaned-PR
         // invariants) + the provably-dead host set for the HRW-safe holistic
         // failover. computeSurvivingRoster already exists (scheduler.mjs) and

--- a/website/src/content/docs/reference/configuration.md
+++ b/website/src/content/docs/reference/configuration.md
@@ -407,6 +407,8 @@ Mode resolves from the env var (a single operator knob) over Layer-2 over the de
 |---|---|---|
 | `CATALYST_BOARD_HEALTH` _(env var)_ | `shadow` | `off` / `0` (kill-switch — strict no-op), `shadow` (scan + emit `recovery.board-scan`, take no action), `enforce` (CTL-1300 — on a proceeding scan, dispatch **one holistic recovery-pass delegate** anchored to a flagged ticket and carrying the whole-board context; reuses the capped + cooldown'd recovery-pass actuator. **Operator-gated — never auto-enabled**). Garbage values fall back to `shadow`. Overrides Layer-2. |
 | `catalyst.boardHealth.mode` _(Layer-2)_ | `shadow` | Same three values; honored when the env var is unset. |
+| `CATALYST_BH_SANCTIONED_LATCHES` _(env var)_ | _(empty)_ | Comma-separated ticket ids a human has **deliberately parked** at needs-human (CTL-1432 B3). They stay visible in the board context's `frozenNeedsHuman` but are suppressed from `proposeMoves`, so the delegate stops re-proposing them every scan (which otherwise drowns the genuinely-stuck tickets). Overrides Layer-2. |
+| `catalyst.boardHealth.sanctionedNeedsHuman` _(Layer-2)_ | `[]` | Array form of the sanctioned needs-human latch allowlist; honored when the env var is unset. |
 | `CATALYST_BH_INTERVAL_MS` | `300000` (5 min) | Cadence floor — the scan runs at most once per interval per host. |
 | `CATALYST_BH_DISPATCH_STALL_MS` | `600000` (10 min) | Dispatch-liveness threshold: free slots + a queue + no dispatch within this window flags a wedge. |
 | `CATALYST_BH_WORKER_AGE_MS` | `14400000` (4 h) | Fallback worker-age threshold (per-phase normals override it). |


### PR DESCRIPTION
## What

WS-B B2+B3 of the delegate-operational plan. The delegate detects faithfully but actuates never — board-scan proposes ~15 moves every 5 min with ~zero executions. Two of the latches:

**B2 — deferred board-health intents get a live consumer.** A `defer → fix_class=board-health` recovery-intent (the classifier's "no typed failure signature; the holistic board-health delegate will triage" path) routed to a `delegate-mini` session dormant since Jun 19, so those tickets rot. New `readDeferredBoardHealthIntents(orchDir)` enumerates them; board-health threads them through `assembleBoardState`/`boardHealthPass` as `deferredBoardHealth`, and `selectAnchorCandidates` folds them in as first-class **self-owned** anchor candidates (ranked after flagged work + the eligible queue) — so the holistic pass actually dispatches a recovery-pass for them. The dormant `delegate-mini` session is retired **operationally** (no code).

**B3 — sanctioned needs-human latches stop being re-proposed.** The 5 operator-sanctioned latches get re-proposed as `review-needs-human` every scan, drowning the genuinely-stuck tickets (making `proposedTier2` a constant). `proposeMoves` now suppresses any ticket in the sanctioned allowlist. They **stay visible** in `boardContext.frozenNeedsHuman` — suppression is in `proposeMoves` only, never `checkFrozenNeedsHuman`.

## Config (B3)

New `readSanctionedNeedsHuman`: env `CATALYST_BH_SANCTIONED_LATCHES` (comma-separated) overrides Layer-2 `catalyst.boardHealth.sanctionedNeedsHuman`; default empty. **Operator sets** `CATALYST_BH_SANCTIONED_LATCHES=CTL-1047,CTL-1091,CTL-1214,CTL-682,SLI-17` on the minis at deploy.

## Wiring

Seam-threaded end to end (config.mjs reader → scheduler `_boardHealth` seam → `boardHealthPass` → `assembleBoardState` → `selectAnchorCandidates`/`proposeMoves`). All defaults empty → a bare tick / N=1 is byte-identical.

## Tests (189 pass)

`proposeMoves` suppression (sanctioned absent from tier2, non-sanctioned present, empty-allowlist unchanged); `selectAnchorCandidates` deferred ordering (after flagged + eligible); `readDeferredBoardHealthIntents` filtering + fail-open. Daemon import graph resolves. Merged with main (A1+B1); recovery-reasoning.mjs combines B1's age-gate + B2's reader cleanly.

Part of CTL-1157.