### PR TITLE
feat(dev): CTL-1433 (WS-A A2) — raise the eligible empty-reconfirm TTL above the reconcile interval (cut the top breaker driver, keep drift validation)

### DIFF
--- a/plugins/dev/scripts/execution-core/linear-query.mjs
+++ b/plugins/dev/scripts/execution-core/linear-query.mjs
@@ -911,21 +911,11 @@ export function fetchTicketsDelegateBatch(team, identifiers, { exec = defaultDel
   return result;
 }
 
-// CTL-1397 (3/n) — confirmed-empty trust window. A SEED-COMPLETE replica-empty is
-// trusted locally ONLY within this window of a SUCCESSFUL EMPTY linearis
-// confirmation, so empty Todo boards (the steady state) don't shell out to the
-// rate-limited `linearis issues list` every tick and pin the CTL-679 breaker,
-// while a feed-hole (CTL-139: cursor present but a team's rows dropped) is never
-// trusted as empty — it keeps falling through to linearis until the replica
-// catches up. Empty confirms are thereby bounded to ≤1 linearis call/team/window.
-// Env-overridable; default 5 min (matches the replica staleness window).
-const EMPTY_RECONFIRM_MS = Number(process.env.CATALYST_ELIGIBLE_EMPTY_RECONFIRM_MS) || 300_000;
-// team → epoch-ms of the last SUCCESSFUL EMPTY linearis confirmation. Module-scoped
-// (the daemon is long-lived; bounded by team count). Reset in tests via the export.
-const _eligibleEmptyConfirmAt = new Map();
-export function __resetEligibleEmptyConfirm() {
-  _eligibleEmptyConfirmAt.clear();
-}
+// CTL-1433 (A2): the confirmed-empty trust window (EMPTY_RECONFIRM_MS +
+// _eligibleEmptyConfirmAt + __resetEligibleEmptyConfirm) was removed. A DEFINED
+// replica-empty is now always trusted directly (it has already passed the reader's
+// CTL-1397 freshness gates), so the per-team `linearis issues list` reconfirm — the
+// dominant CTL-679 breaker driver — is gone entirely. See runEligibleQuery below.
 
 // runEligibleQuery — run the query, parse + normalize, apply the priority
 // floor. A non-zero linearis exit THROWS (never a silent []): a silent empty
@@ -984,58 +974,26 @@ export function runEligibleQuery(
         onSource?.("replica", tickets.length);
         return tickets;
       }
-      // CTL-1397 (3/n) — a SEED-COMPLETE replica-empty. The reader only returns a
-      // defined { nodes } when the replica is fresh AND the sync_meta cursor is
-      // present (seed complete; the snapshot-consistent gate rules out a mid-reseed
-      // truncation), so this empty is a real "0 eligible", NOT a truncation
-      // artifact. Empty Todo boards are the STEADY STATE, so confirming EVERY empty
-      // via `linearis issues list` made discovery hit the rate-limited API every
-      // tick — defeating the breaker-immunity this tier exists for and pinning the
-      // CTL-679 breaker (the live freeze: 100% eligible_source=linearis).
-      //
-      // So TRUST the replica-empty — but ONLY when linearis has RECENTLY CONFIRMED
-      // this team's board empty (a successful, empty confirmation cached within
-      // EMPTY_RECONFIRM_MS; the marker is set at the END of the linearis path
-      // below, and ONLY on a successful empty result). This keeps steady-state
-      // empty boards breaker-immune (≤1 linearis confirm/team/window) while never
-      // zeroing on a feed-hole:
-      //   - a FAILED confirm (breaker trip, auth/network, bad stdout) throws before
-      //     the marker is set → reconcileProject preserves the prior set, and the
-      //     next reconcile re-confirms (not suppressed by a doomed attempt);
-      //   - a NON-EMPTY confirm (the CTL-139 feed-hole: cursor present but rows
-      //     dropped) serves the real board and does NOT set the marker → the next
-      //     reconcile keeps confirming until the replica catches up;
-      //   - a breaker-OPEN reconcile with no recent confirmation falls through so
-      //     the exec short-circuits (circuit-open) → throw → preserve prior (never
-      //     trusts an unconfirmed empty as authoritative during a storm).
-      if (now() - (_eligibleEmptyConfirmAt.get(query.team) ?? 0) < EMPTY_RECONFIRM_MS) {
-        onSource?.("replica", 0);
-        return tickets; // [] — a recently linearis-confirmed empty, trusted (breaker-immune)
-      }
-      // CTL-1420 (freeze-avoidance): when the CTL-679 breaker is OPEN, the
-      // linearis reconfirm below can only short-circuit (circuit-open) → throw →
-      // reconcileProject preserves the (empty) prior set = a fleet-wide admission
-      // FREEZE for the breaker's entire open window (the observed 4h+ boot freeze:
-      // fresh process, empty marker map, breaker pinned → nothing ever admitted).
-      // A DEFINED replica-empty has already cleared the reader's writer-liveness +
-      // seed-complete cursor + snapshot-consistent gates, so it is a provably-real
-      // "0 eligible" (NOT a mid-reseed truncation). During breaker-open we TRUST it
-      // rather than freeze. The only residual risk is a CTL-139 feed-hole (a team's
-      // rows silently dropped while the writer stays alive) — strictly less bad than
-      // freezing ALL admission fleet-wide, and self-healing: the moment the breaker
-      // closes, the reconfirm path below resumes and re-validates every empty. A
-      // NON-EMPTY replica is always served (above), even during a storm — so this
-      // only ever trusts a genuinely-empty board; real Todo work still dispatches.
-      if (breakerIsOpen()) {
-        onSource?.("replica-empty-breaker-open", 0);
-        return tickets; // [] — trusted under quota exhaustion (freeze-avoidance)
-      }
-      // No recent confirmation AND breaker closed → fall through to the linearis
-      // confirm/preserve-prior path below (cheap: ≤1 confirm/team/window; sets the
-      // marker on a successful empty). Do NOT set the marker here.
+      // CTL-1397 / CTL-1433 (A2) — a DEFINED replica-empty is ALWAYS trusted, with
+      // ZERO live Linear reads. The reader only returns a defined { nodes } when the
+      // replica is fresh (writer-liveness) AND the sync_meta cursor is present (seed
+      // complete; the snapshot-consistent gate rules out a mid-reseed truncation) —
+      // the CTL-1397 2-gate freshness rule — so this empty is a provably-real "0
+      // eligible", not a truncation artifact. Empty Todo boards are the STEADY STATE,
+      // so the old per-tick `linearis issues list` reconfirm (gated on a marker cached
+      // within EMPTY_RECONFIRM_MS 5min, which was < the 10-min reconcile interval → the
+      // confirm was ALWAYS stale) was the DOMINANT CTL-679 breaker driver:
+      // eligible_source:linearis 597 on mini, #1 attributed trip caller:"linearis:issues-list".
+      // Residual risk is a CTL-139 feed-hole (a team's rows silently dropped while the
+      // writer stays alive) — self-healing on the next sync, and strictly better than
+      // pinning the breaker every quiet tick (previously it also froze admission fleet-
+      // wide during a storm). A NON-EMPTY replica is always served above, so this only
+      // ever trusts a genuinely-empty board. Source distinguishes breaker state for
+      // observability.
+      onSource?.(breakerIsOpen() ? "replica-empty-breaker-open" : "replica-empty-fresh", 0);
+      return tickets; // [] — provably-real empty per the reader's own freshness gates
     }
-    // MISS (undefined) / unconfirmed replica-empty → fall through to the UNCHANGED
-    // linearis path below.
+    // MISS (undefined) → fall through to the UNCHANGED linearis path below.
   }
   // D2 (Stage 0): breaker-open-aware replica MISS. Gated on `replica?.eligible` so it
   // fires ONLY when the replica tier was actually consulted and MISSED (undefined) —
@@ -1096,15 +1054,6 @@ export function runEligibleQuery(
     } catch {
       /* best-effort: a delegate hiccup never blocks the state/priority/relations refresh */
     }
-  }
-  // CTL-1397 (3/n): cache a SUCCESSFUL EMPTY confirmation so the replica-empty
-  // branch above can trust this team's empty board for EMPTY_RECONFIRM_MS without
-  // re-shelling to linearis. ONLY an empty result caches — a non-empty (feed-hole)
-  // result must keep serving the real board + re-confirming, and a throw never
-  // reaches here (→ reconcileProject preserves the prior set). This is what makes
-  // "a failed or non-empty confirm never suppresses the next confirm" true.
-  if (tickets.length === 0) {
-    _eligibleEmptyConfirmAt.set(query.team, now());
   }
   // CTL-1397: mark the source (linearis) for the same verification seam as the
   // replica HIT above, so the daemon can log eligible_source for both paths.

--- a/plugins/dev/scripts/execution-core/linear-query.mjs
+++ b/plugins/dev/scripts/execution-core/linear-query.mjs
@@ -911,11 +911,32 @@ export function fetchTicketsDelegateBatch(team, identifiers, { exec = defaultDel
   return result;
 }
 
-// CTL-1433 (A2): the confirmed-empty trust window (EMPTY_RECONFIRM_MS +
-// _eligibleEmptyConfirmAt + __resetEligibleEmptyConfirm) was removed. A DEFINED
-// replica-empty is now always trusted directly (it has already passed the reader's
-// CTL-1397 freshness gates), so the per-team `linearis issues list` reconfirm — the
-// dominant CTL-679 breaker driver — is gone entirely. See runEligibleQuery below.
+// CTL-1397 (3/n) — confirmed-empty trust window. A SEED-COMPLETE replica-empty is
+// trusted locally ONLY within this window of a SUCCESSFUL EMPTY linearis
+// confirmation, so empty Todo boards (the steady state) don't shell out to the
+// rate-limited `linearis issues list` every tick and pin the CTL-679 breaker,
+// while a feed-hole (CTL-139: cursor present but a team's rows dropped) is never
+// trusted as empty — it keeps falling through to linearis until the replica
+// catches up. Empty confirms are thereby bounded to ≤1 linearis call/team/window.
+// CTL-1433 (A2): default RAISED from 5 min to 30 min — ABOVE the 10-min reconcile
+// interval (RECONCILE_INTERVAL_MS, config.mjs). At 5 min the confirm was ALWAYS stale by
+// the next reconcile, so every quiet-board reconcile re-shelled `linearis issues list`
+// per team — the dominant CTL-679 breaker driver (the #1 attributed trip after A1
+// shipped: caller:"linearis:issues-list", eligible_source:linearis 597 vs replica 1 on
+// mini). At 30 min the marker stays fresh across ~2-3 reconciles, so a steady-empty team
+// re-validates at most ~once per 30 min (a ~4-6× cut) — while STILL doing a low-rate LIVE
+// validation. That live validation is load-bearing: if the configured Linear status is
+// renamed/removed, the replica filter (i.state = ?) returns a FALSE empty, and a full
+// removal of the reconfirm would silently freeze that team's admission; the periodic
+// linearis confirm (which queries the real status) catches the drift within ~30 min.
+// Env-overridable (CATALYST_ELIGIBLE_EMPTY_RECONFIRM_MS) — keep it above the reconcile interval.
+const EMPTY_RECONFIRM_MS = Number(process.env.CATALYST_ELIGIBLE_EMPTY_RECONFIRM_MS) || 1_800_000;
+// team → epoch-ms of the last SUCCESSFUL EMPTY linearis confirmation. Module-scoped
+// (the daemon is long-lived; bounded by team count). Reset in tests via the export.
+const _eligibleEmptyConfirmAt = new Map();
+export function __resetEligibleEmptyConfirm() {
+  _eligibleEmptyConfirmAt.clear();
+}
 
 // runEligibleQuery — run the query, parse + normalize, apply the priority
 // floor. A non-zero linearis exit THROWS (never a silent []): a silent empty
@@ -951,6 +972,9 @@ export function runEligibleQuery(
     // DEFINED replica-empty is trusted instead of freezing admission (see the
     // empty-path branch). Defaults to the production process-wide breaker.
     breakerIsOpen = () => linearBreaker.isOpen(),
+    // CTL-1433 (A2): the confirmed-empty trust window, injectable so the cadence tests
+    // pin a deterministic value independent of the (raised-to-30-min) module default.
+    reconfirmMs = EMPTY_RECONFIRM_MS,
   } = {}
 ) {
   // CTL-1397: replica-backed board-list tier. Fail-open: a throw out of
@@ -974,26 +998,58 @@ export function runEligibleQuery(
         onSource?.("replica", tickets.length);
         return tickets;
       }
-      // CTL-1397 / CTL-1433 (A2) — a DEFINED replica-empty is ALWAYS trusted, with
-      // ZERO live Linear reads. The reader only returns a defined { nodes } when the
-      // replica is fresh (writer-liveness) AND the sync_meta cursor is present (seed
-      // complete; the snapshot-consistent gate rules out a mid-reseed truncation) —
-      // the CTL-1397 2-gate freshness rule — so this empty is a provably-real "0
-      // eligible", not a truncation artifact. Empty Todo boards are the STEADY STATE,
-      // so the old per-tick `linearis issues list` reconfirm (gated on a marker cached
-      // within EMPTY_RECONFIRM_MS 5min, which was < the 10-min reconcile interval → the
-      // confirm was ALWAYS stale) was the DOMINANT CTL-679 breaker driver:
-      // eligible_source:linearis 597 on mini, #1 attributed trip caller:"linearis:issues-list".
-      // Residual risk is a CTL-139 feed-hole (a team's rows silently dropped while the
-      // writer stays alive) — self-healing on the next sync, and strictly better than
-      // pinning the breaker every quiet tick (previously it also froze admission fleet-
-      // wide during a storm). A NON-EMPTY replica is always served above, so this only
-      // ever trusts a genuinely-empty board. Source distinguishes breaker state for
-      // observability.
-      onSource?.(breakerIsOpen() ? "replica-empty-breaker-open" : "replica-empty-fresh", 0);
-      return tickets; // [] — provably-real empty per the reader's own freshness gates
+      // CTL-1397 (3/n) — a SEED-COMPLETE replica-empty. The reader only returns a
+      // defined { nodes } when the replica is fresh AND the sync_meta cursor is
+      // present (seed complete; the snapshot-consistent gate rules out a mid-reseed
+      // truncation), so this empty is a real "0 eligible", NOT a truncation
+      // artifact. Empty Todo boards are the STEADY STATE, so confirming EVERY empty
+      // via `linearis issues list` made discovery hit the rate-limited API every
+      // tick — defeating the breaker-immunity this tier exists for and pinning the
+      // CTL-679 breaker (the live freeze: 100% eligible_source=linearis).
+      //
+      // So TRUST the replica-empty — but ONLY when linearis has RECENTLY CONFIRMED
+      // this team's board empty (a successful, empty confirmation cached within
+      // EMPTY_RECONFIRM_MS; the marker is set at the END of the linearis path
+      // below, and ONLY on a successful empty result). This keeps steady-state
+      // empty boards breaker-immune (≤1 linearis confirm/team/window) while never
+      // zeroing on a feed-hole:
+      //   - a FAILED confirm (breaker trip, auth/network, bad stdout) throws before
+      //     the marker is set → reconcileProject preserves the prior set, and the
+      //     next reconcile re-confirms (not suppressed by a doomed attempt);
+      //   - a NON-EMPTY confirm (the CTL-139 feed-hole: cursor present but rows
+      //     dropped) serves the real board and does NOT set the marker → the next
+      //     reconcile keeps confirming until the replica catches up;
+      //   - a breaker-OPEN reconcile with no recent confirmation falls through so
+      //     the exec short-circuits (circuit-open) → throw → preserve prior (never
+      //     trusts an unconfirmed empty as authoritative during a storm).
+      if (now() - (_eligibleEmptyConfirmAt.get(query.team) ?? 0) < reconfirmMs) {
+        onSource?.("replica", 0);
+        return tickets; // [] — a recently linearis-confirmed empty, trusted (breaker-immune)
+      }
+      // CTL-1420 (freeze-avoidance): when the CTL-679 breaker is OPEN, the
+      // linearis reconfirm below can only short-circuit (circuit-open) → throw →
+      // reconcileProject preserves the (empty) prior set = a fleet-wide admission
+      // FREEZE for the breaker's entire open window (the observed 4h+ boot freeze:
+      // fresh process, empty marker map, breaker pinned → nothing ever admitted).
+      // A DEFINED replica-empty has already cleared the reader's writer-liveness +
+      // seed-complete cursor + snapshot-consistent gates, so it is a provably-real
+      // "0 eligible" (NOT a mid-reseed truncation). During breaker-open we TRUST it
+      // rather than freeze. The only residual risk is a CTL-139 feed-hole (a team's
+      // rows silently dropped while the writer stays alive) — strictly less bad than
+      // freezing ALL admission fleet-wide, and self-healing: the moment the breaker
+      // closes, the reconfirm path below resumes and re-validates every empty. A
+      // NON-EMPTY replica is always served (above), even during a storm — so this
+      // only ever trusts a genuinely-empty board; real Todo work still dispatches.
+      if (breakerIsOpen()) {
+        onSource?.("replica-empty-breaker-open", 0);
+        return tickets; // [] — trusted under quota exhaustion (freeze-avoidance)
+      }
+      // No recent confirmation AND breaker closed → fall through to the linearis
+      // confirm/preserve-prior path below (cheap: ≤1 confirm/team/window; sets the
+      // marker on a successful empty). Do NOT set the marker here.
     }
-    // MISS (undefined) → fall through to the UNCHANGED linearis path below.
+    // MISS (undefined) / unconfirmed replica-empty → fall through to the UNCHANGED
+    // linearis path below.
   }
   // D2 (Stage 0): breaker-open-aware replica MISS. Gated on `replica?.eligible` so it
   // fires ONLY when the replica tier was actually consulted and MISSED (undefined) —
@@ -1054,6 +1110,15 @@ export function runEligibleQuery(
     } catch {
       /* best-effort: a delegate hiccup never blocks the state/priority/relations refresh */
     }
+  }
+  // CTL-1397 (3/n): cache a SUCCESSFUL EMPTY confirmation so the replica-empty
+  // branch above can trust this team's empty board for EMPTY_RECONFIRM_MS without
+  // re-shelling to linearis. ONLY an empty result caches — a non-empty (feed-hole)
+  // result must keep serving the real board + re-confirming, and a throw never
+  // reaches here (→ reconcileProject preserves the prior set). This is what makes
+  // "a failed or non-empty confirm never suppresses the next confirm" true.
+  if (tickets.length === 0) {
+    _eligibleEmptyConfirmAt.set(query.team, now());
   }
   // CTL-1397: mark the source (linearis) for the same verification seam as the
   // replica HIT above, so the daemon can log eligible_source for both paths.

--- a/plugins/dev/scripts/execution-core/linear-query.test.mjs
+++ b/plugins/dev/scripts/execution-core/linear-query.test.mjs
@@ -9,7 +9,6 @@ import { __resetDispatchAlertThrottle } from "./dispatch-alert.mjs";
 import {
   buildLinearisArgs,
   runEligibleQuery,
-  __resetEligibleEmptyConfirm,
   fetchTicketState,
   fetchTicketLabels,
   readTicketLabels,
@@ -240,7 +239,6 @@ describe("runEligibleQuery — replica tier (CTL-1397)", () => {
   // to CLOSED here for a deterministic baseline. Tests that exercise the
   // breaker-open freeze-avoidance path inject breakerIsOpen:()=>true explicitly.
   beforeEach(() => {
-    __resetEligibleEmptyConfirm();
     linearBreaker.recordSuccess(); // → closed (no-op if already closed)
   });
 
@@ -264,6 +262,23 @@ describe("runEligibleQuery — replica tier (CTL-1397)", () => {
     };
     return fn;
   }
+
+  test("CTL-1433 (A2): a freshness-gated replica-EMPTY is trusted with NO exec even when the breaker is CLOSED + no recent confirm — onSource('replica-empty-fresh', 0)", () => {
+    // beforeEach resets the confirm marker AND closes the breaker — this is the exact
+    // case that used to fall through to a live `linearis issues list` reconfirm (the
+    // #1 breaker driver). A2 trusts the defined-empty directly: it already cleared the
+    // reader's writer-liveness + seed-complete cursor gates, so it is provably real.
+    const replica = replicaReturning([]);
+    const sources = [];
+    const tickets = runEligibleQuery(query, {
+      exec: execMustNotRun(),
+      replica,
+      breakerIsOpen: () => false,
+      onSource: (source, count) => sources.push([source, count]),
+    });
+    expect(tickets).toEqual([]);
+    expect(sources).toContainEqual(["replica-empty-fresh", 0]);
+  });
 
   test("HIT: serves from the replica, never calls exec, normalizes + records onSource('replica')", () => {
     const replica = replicaReturning([
@@ -316,71 +331,6 @@ describe("runEligibleQuery — replica tier (CTL-1397)", () => {
     expect(tickets.map((t) => t.identifier).sort()).toEqual(["CTL-1", "CTL-2"]);
   });
 
-  // CTL-1397 (3/n) — a SEED-COMPLETE replica-empty is TRUSTED locally, but ONLY
-  // within EMPTY_RECONFIRM_MS of a SUCCESSFUL EMPTY linearis confirmation. So empty
-  // Todo boards (the steady state) stay breaker-immune (≤1 confirm/team/window),
-  // yet a feed-hole (CTL-139: cursor present but a team's rows dropped, presenting
-  // as empty) is never trusted as empty. Only a SUCCESSFUL EMPTY confirm caches;
-  // a failed or non-empty confirm never suppresses the next one.
-
-  test("replica-EMPTY, no recent confirm → falls through; a NON-EMPTY confirm (feed-hole) serves the real board and does NOT cache", () => {
-    const replica = replicaReturning([]);
-    let clock = 1_000_000;
-    const now = () => clock;
-    const execCalls = [];
-    const mkExec = () => () => {
-      execCalls.push(clock);
-      return { code: 0, stdout: ticketsJson([{ identifier: "CTL-9", state: { name: "Todo" }, priority: 2 }]), stderr: "" };
-    };
-    // CTL-1420: pin the breaker CLOSED — this test exercises the closed-breaker
-    // reconfirm cadence. (The non-empty confirm's default delegate-batch spawn can
-    // 429 and trip the real breaker singleton; without pinning, the 2nd call would
-    // hit the breaker-open freeze-avoidance branch and trust the empty.) A stub
-    // delegateExec also keeps the unit test off the network.
-    const opts = { replica, now, breakerIsOpen: () => false, delegateExec: () => ({ code: 0, stdout: "{}", stderr: "" }) };
-    const t1 = runEligibleQuery(query, { exec: mkExec(), ...opts });
-    expect(t1.map((t) => t.identifier)).toEqual(["CTL-9"]); // real board served (hole)
-    // 1s later: the non-empty confirm did NOT cache → still falls through (no zeroing).
-    clock += 1_000;
-    const t2 = runEligibleQuery(query, { exec: mkExec(), ...opts });
-    expect(execCalls).toHaveLength(2); // linearis called BOTH times — never suppressed
-    expect(t2.map((t) => t.identifier)).toEqual(["CTL-9"]);
-  });
-
-  test("replica-EMPTY, a SUCCESSFUL EMPTY confirm caches → a subsequent empty within the window TRUSTS the replica (no exec), onSource('replica', 0)", () => {
-    const replica = replicaReturning([]);
-    let clock = 3_000_000;
-    const now = () => clock;
-    // Prime: a successful EMPTY linearis confirmation caches the agreement.
-    const primeExec = fakeExec({ stdout: ticketsJson([]) });
-    runEligibleQuery(query, { exec: primeExec, replica, now });
-    expect(primeExec.calls).toHaveLength(1);
-    // 1s later: trusted from the replica, NO linearis call.
-    clock += 1_000;
-    const sources = [];
-    const t = runEligibleQuery(query, {
-      exec: execMustNotRun(),
-      replica,
-      now,
-      onSource: (source, count) => sources.push([source, count]),
-    });
-    expect(t).toEqual([]);
-    expect(sources).toEqual([["replica", 0]]);
-  });
-
-  test("replica-EMPTY, a FAILED confirm does NOT cache → the next reconcile still confirms (not suppressed by a doomed attempt)", () => {
-    const replica = replicaReturning([]);
-    let clock = 2_000_000;
-    const now = () => clock;
-    // First confirm throws (non-breaker failure, e.g. auth) → propagates, no cache.
-    expect(() => runEligibleQuery(query, { exec: fakeExec({ code: 1, stderr: "auth" }), replica, now })).toThrow(/exit 1/);
-    // 1s later: no recent SUCCESSFUL empty confirm → falls through again (re-confirms).
-    clock += 1_000;
-    const exec2 = fakeExec({ stdout: ticketsJson([]) });
-    runEligibleQuery(query, { exec: exec2, replica, now });
-    expect(exec2.calls).toHaveLength(1);
-  });
-
   // CTL-1420 (freeze-avoidance): the pre-1420 behavior was to THROW here →
   // reconcileProject preserved the (empty) prior set → a fleet-wide admission
   // FREEZE for the breaker's whole open window. Now a DEFINED replica-empty
@@ -401,24 +351,6 @@ describe("runEligibleQuery — replica tier (CTL-1397)", () => {
     expect(replica.calls).toEqual([query]); // the replica WAS consulted
   });
 
-  // CTL-1420: the fix is breaker-GATED — a CLOSED breaker preserves the exact
-  // pre-1420 behavior (fall through to the linearis confirm so a feed-hole is
-  // never trusted as empty; the ≤1-confirm/team/window cadence is intact).
-  test("CTL-1420: replica-EMPTY, breaker CLOSED, no recent confirm → still falls through to the linearis confirm (unchanged)", () => {
-    const replica = replicaReturning([]);
-    const exec = fakeExec({ stdout: ticketsJson([]) });
-    const sources = [];
-    const tickets = runEligibleQuery(query, {
-      exec,
-      replica,
-      breakerIsOpen: () => false,
-      onSource: (source, count) => sources.push([source, count]),
-    });
-    expect(exec.calls).toHaveLength(1); // linearis WAS called (breaker closed)
-    expect(tickets).toEqual([]);
-    expect(sources).toEqual([["linearis", 0]]); // served + cached by the linearis path
-  });
-
   // CTL-1420: a breaker-open reconcile must NEVER fabricate work — a genuinely
   // NON-EMPTY replica is still served verbatim (the freeze-avoidance branch only
   // fires on an empty board), so real Todo work dispatches during a quota storm.
@@ -433,48 +365,6 @@ describe("runEligibleQuery — replica tier (CTL-1397)", () => {
     });
     expect(tickets.map((t) => t.identifier)).toEqual(["CTL-1416"]);
     expect(sources).toEqual([["replica", 1]]);
-  });
-
-  // CTL-1420 review finding (guard): the freeze-avoidance branch trusts the empty
-  // WITHOUT caching the empty-confirm marker. If it did cache it, the linearis
-  // reconfirm would be suppressed for EMPTY_RECONFIRM_MS after the breaker closes
-  // — trusting a CTL-139 feed-hole as a real empty board. This asserts the marker
-  // stays unset: once the breaker closes, an empty STILL reconfirms via linearis.
-  test("CTL-1420: breaker-open trust does NOT cache the empty-confirm marker → after the breaker closes the next empty still reconfirms via linearis", () => {
-    const replica = replicaReturning([]);
-    // Breaker OPEN: trust the empty, no exec, and (crucially) no marker cached.
-    const t1 = runEligibleQuery(query, { exec: execMustNotRun(), replica, breakerIsOpen: () => true });
-    expect(t1).toEqual([]);
-    // Breaker now CLOSED: if the open branch had cached the marker, this empty
-    // would be trusted with NO linearis call. It must reconfirm instead.
-    const exec = fakeExec({ stdout: ticketsJson([]) });
-    const sources = [];
-    const t2 = runEligibleQuery(query, {
-      exec,
-      replica,
-      breakerIsOpen: () => false,
-      onSource: (source, count) => sources.push([source, count]),
-    });
-    expect(exec.calls).toHaveLength(1); // reconfirmed — the open branch left the marker unset
-    expect(t2).toEqual([]);
-    expect(sources).toEqual([["linearis", 0]]);
-  });
-
-  test("cadence: after a successful empty confirm, empties trust the replica until the window elapses, then re-confirm once per team", () => {
-    const replica = replicaReturning([]);
-    let clock = 5_000_000;
-    const now = () => clock;
-    const execCalls = [];
-    const mkExec = () => () => {
-      execCalls.push(clock);
-      return { code: 0, stdout: ticketsJson([]), stderr: "" };
-    };
-    const call = () => runEligibleQuery(query, { exec: mkExec(), replica, now });
-    call(); // t0: cold → linearis confirms empty → caches
-    clock += 60_000; call(); // +1m: within window → trust replica (no exec)
-    clock += 60_000; call(); // +2m: within window → trust replica (no exec)
-    clock += 200_000; call(); // +5m20s (past window) → re-confirm via linearis
-    expect(execCalls).toEqual([5_000_000, 5_320_000]); // exactly two confirms
   });
 
   test("replica filtered EMPTY by the priority floor → same confirmed-empty gating (trusts only within the window)", () => {
@@ -1666,7 +1556,6 @@ describe("runEligibleQuery — D2 (breaker-open replica miss)", () => {
   let tmpDir;
   let prevDir;
   beforeEach(() => {
-    __resetEligibleEmptyConfirm();
     __resetDispatchAlertThrottle();
     prevDir = process.env.CATALYST_DIR;
     tmpDir = mkdtempSync(join(tmpdir(), "d2-alert-"));

--- a/plugins/dev/scripts/execution-core/linear-query.test.mjs
+++ b/plugins/dev/scripts/execution-core/linear-query.test.mjs
@@ -9,6 +9,7 @@ import { __resetDispatchAlertThrottle } from "./dispatch-alert.mjs";
 import {
   buildLinearisArgs,
   runEligibleQuery,
+  __resetEligibleEmptyConfirm,
   fetchTicketState,
   fetchTicketLabels,
   readTicketLabels,
@@ -239,6 +240,7 @@ describe("runEligibleQuery — replica tier (CTL-1397)", () => {
   // to CLOSED here for a deterministic baseline. Tests that exercise the
   // breaker-open freeze-avoidance path inject breakerIsOpen:()=>true explicitly.
   beforeEach(() => {
+    __resetEligibleEmptyConfirm();
     linearBreaker.recordSuccess(); // → closed (no-op if already closed)
   });
 
@@ -262,23 +264,6 @@ describe("runEligibleQuery — replica tier (CTL-1397)", () => {
     };
     return fn;
   }
-
-  test("CTL-1433 (A2): a freshness-gated replica-EMPTY is trusted with NO exec even when the breaker is CLOSED + no recent confirm — onSource('replica-empty-fresh', 0)", () => {
-    // beforeEach resets the confirm marker AND closes the breaker — this is the exact
-    // case that used to fall through to a live `linearis issues list` reconfirm (the
-    // #1 breaker driver). A2 trusts the defined-empty directly: it already cleared the
-    // reader's writer-liveness + seed-complete cursor gates, so it is provably real.
-    const replica = replicaReturning([]);
-    const sources = [];
-    const tickets = runEligibleQuery(query, {
-      exec: execMustNotRun(),
-      replica,
-      breakerIsOpen: () => false,
-      onSource: (source, count) => sources.push([source, count]),
-    });
-    expect(tickets).toEqual([]);
-    expect(sources).toContainEqual(["replica-empty-fresh", 0]);
-  });
 
   test("HIT: serves from the replica, never calls exec, normalizes + records onSource('replica')", () => {
     const replica = replicaReturning([
@@ -331,6 +316,71 @@ describe("runEligibleQuery — replica tier (CTL-1397)", () => {
     expect(tickets.map((t) => t.identifier).sort()).toEqual(["CTL-1", "CTL-2"]);
   });
 
+  // CTL-1397 (3/n) — a SEED-COMPLETE replica-empty is TRUSTED locally, but ONLY
+  // within EMPTY_RECONFIRM_MS of a SUCCESSFUL EMPTY linearis confirmation. So empty
+  // Todo boards (the steady state) stay breaker-immune (≤1 confirm/team/window),
+  // yet a feed-hole (CTL-139: cursor present but a team's rows dropped, presenting
+  // as empty) is never trusted as empty. Only a SUCCESSFUL EMPTY confirm caches;
+  // a failed or non-empty confirm never suppresses the next one.
+
+  test("replica-EMPTY, no recent confirm → falls through; a NON-EMPTY confirm (feed-hole) serves the real board and does NOT cache", () => {
+    const replica = replicaReturning([]);
+    let clock = 1_000_000;
+    const now = () => clock;
+    const execCalls = [];
+    const mkExec = () => () => {
+      execCalls.push(clock);
+      return { code: 0, stdout: ticketsJson([{ identifier: "CTL-9", state: { name: "Todo" }, priority: 2 }]), stderr: "" };
+    };
+    // CTL-1420: pin the breaker CLOSED — this test exercises the closed-breaker
+    // reconfirm cadence. (The non-empty confirm's default delegate-batch spawn can
+    // 429 and trip the real breaker singleton; without pinning, the 2nd call would
+    // hit the breaker-open freeze-avoidance branch and trust the empty.) A stub
+    // delegateExec also keeps the unit test off the network.
+    const opts = { replica, now, breakerIsOpen: () => false, reconfirmMs: 300_000, delegateExec: () => ({ code: 0, stdout: "{}", stderr: "" }) };
+    const t1 = runEligibleQuery(query, { exec: mkExec(), ...opts });
+    expect(t1.map((t) => t.identifier)).toEqual(["CTL-9"]); // real board served (hole)
+    // 1s later: the non-empty confirm did NOT cache → still falls through (no zeroing).
+    clock += 1_000;
+    const t2 = runEligibleQuery(query, { exec: mkExec(), ...opts });
+    expect(execCalls).toHaveLength(2); // linearis called BOTH times — never suppressed
+    expect(t2.map((t) => t.identifier)).toEqual(["CTL-9"]);
+  });
+
+  test("replica-EMPTY, a SUCCESSFUL EMPTY confirm caches → a subsequent empty within the window TRUSTS the replica (no exec), onSource('replica', 0)", () => {
+    const replica = replicaReturning([]);
+    let clock = 3_000_000;
+    const now = () => clock;
+    // Prime: a successful EMPTY linearis confirmation caches the agreement.
+    const primeExec = fakeExec({ stdout: ticketsJson([]) });
+    runEligibleQuery(query, { exec: primeExec, replica, now });
+    expect(primeExec.calls).toHaveLength(1);
+    // 1s later: trusted from the replica, NO linearis call.
+    clock += 1_000;
+    const sources = [];
+    const t = runEligibleQuery(query, {
+      exec: execMustNotRun(),
+      replica,
+      now,
+      onSource: (source, count) => sources.push([source, count]),
+    });
+    expect(t).toEqual([]);
+    expect(sources).toEqual([["replica", 0]]);
+  });
+
+  test("replica-EMPTY, a FAILED confirm does NOT cache → the next reconcile still confirms (not suppressed by a doomed attempt)", () => {
+    const replica = replicaReturning([]);
+    let clock = 2_000_000;
+    const now = () => clock;
+    // First confirm throws (non-breaker failure, e.g. auth) → propagates, no cache.
+    expect(() => runEligibleQuery(query, { exec: fakeExec({ code: 1, stderr: "auth" }), replica, now })).toThrow(/exit 1/);
+    // 1s later: no recent SUCCESSFUL empty confirm → falls through again (re-confirms).
+    clock += 1_000;
+    const exec2 = fakeExec({ stdout: ticketsJson([]) });
+    runEligibleQuery(query, { exec: exec2, replica, now });
+    expect(exec2.calls).toHaveLength(1);
+  });
+
   // CTL-1420 (freeze-avoidance): the pre-1420 behavior was to THROW here →
   // reconcileProject preserved the (empty) prior set → a fleet-wide admission
   // FREEZE for the breaker's whole open window. Now a DEFINED replica-empty
@@ -351,6 +401,24 @@ describe("runEligibleQuery — replica tier (CTL-1397)", () => {
     expect(replica.calls).toEqual([query]); // the replica WAS consulted
   });
 
+  // CTL-1420: the fix is breaker-GATED — a CLOSED breaker preserves the exact
+  // pre-1420 behavior (fall through to the linearis confirm so a feed-hole is
+  // never trusted as empty; the ≤1-confirm/team/window cadence is intact).
+  test("CTL-1420: replica-EMPTY, breaker CLOSED, no recent confirm → still falls through to the linearis confirm (unchanged)", () => {
+    const replica = replicaReturning([]);
+    const exec = fakeExec({ stdout: ticketsJson([]) });
+    const sources = [];
+    const tickets = runEligibleQuery(query, {
+      exec,
+      replica,
+      breakerIsOpen: () => false,
+      onSource: (source, count) => sources.push([source, count]),
+    });
+    expect(exec.calls).toHaveLength(1); // linearis WAS called (breaker closed)
+    expect(tickets).toEqual([]);
+    expect(sources).toEqual([["linearis", 0]]); // served + cached by the linearis path
+  });
+
   // CTL-1420: a breaker-open reconcile must NEVER fabricate work — a genuinely
   // NON-EMPTY replica is still served verbatim (the freeze-avoidance branch only
   // fires on an empty board), so real Todo work dispatches during a quota storm.
@@ -365,6 +433,48 @@ describe("runEligibleQuery — replica tier (CTL-1397)", () => {
     });
     expect(tickets.map((t) => t.identifier)).toEqual(["CTL-1416"]);
     expect(sources).toEqual([["replica", 1]]);
+  });
+
+  // CTL-1420 review finding (guard): the freeze-avoidance branch trusts the empty
+  // WITHOUT caching the empty-confirm marker. If it did cache it, the linearis
+  // reconfirm would be suppressed for EMPTY_RECONFIRM_MS after the breaker closes
+  // — trusting a CTL-139 feed-hole as a real empty board. This asserts the marker
+  // stays unset: once the breaker closes, an empty STILL reconfirms via linearis.
+  test("CTL-1420: breaker-open trust does NOT cache the empty-confirm marker → after the breaker closes the next empty still reconfirms via linearis", () => {
+    const replica = replicaReturning([]);
+    // Breaker OPEN: trust the empty, no exec, and (crucially) no marker cached.
+    const t1 = runEligibleQuery(query, { exec: execMustNotRun(), replica, breakerIsOpen: () => true });
+    expect(t1).toEqual([]);
+    // Breaker now CLOSED: if the open branch had cached the marker, this empty
+    // would be trusted with NO linearis call. It must reconfirm instead.
+    const exec = fakeExec({ stdout: ticketsJson([]) });
+    const sources = [];
+    const t2 = runEligibleQuery(query, {
+      exec,
+      replica,
+      breakerIsOpen: () => false,
+      onSource: (source, count) => sources.push([source, count]),
+    });
+    expect(exec.calls).toHaveLength(1); // reconfirmed — the open branch left the marker unset
+    expect(t2).toEqual([]);
+    expect(sources).toEqual([["linearis", 0]]);
+  });
+
+  test("cadence: after a successful empty confirm, empties trust the replica until the window elapses, then re-confirm once per team", () => {
+    const replica = replicaReturning([]);
+    let clock = 5_000_000;
+    const now = () => clock;
+    const execCalls = [];
+    const mkExec = () => () => {
+      execCalls.push(clock);
+      return { code: 0, stdout: ticketsJson([]), stderr: "" };
+    };
+    const call = () => runEligibleQuery(query, { exec: mkExec(), replica, now, reconfirmMs: 300_000 });
+    call(); // t0: cold → linearis confirms empty → caches
+    clock += 60_000; call(); // +1m: within window → trust replica (no exec)
+    clock += 60_000; call(); // +2m: within window → trust replica (no exec)
+    clock += 200_000; call(); // +5m20s (past window) → re-confirm via linearis
+    expect(execCalls).toEqual([5_000_000, 5_320_000]); // exactly two confirms
   });
 
   test("replica filtered EMPTY by the priority floor → same confirmed-empty gating (trusts only within the window)", () => {
@@ -1556,6 +1666,7 @@ describe("runEligibleQuery — D2 (breaker-open replica miss)", () => {
   let tmpDir;
   let prevDir;
   beforeEach(() => {
+    __resetEligibleEmptyConfirm();
     __resetDispatchAlertThrottle();
     prevDir = process.env.CATALYST_DIR;
     tmpDir = mkdtempSync(join(tmpdir(), "d2-alert-"));


### PR DESCRIPTION
## What

The **#1 attributed CTL-679 breaker trip** on mini after A1 shipped is `caller:"linearis:issues-list"` — the eligible empty-reconfirm. `runEligibleQuery` used to fall through to a live `linearis issues list` per team on every quiet-board cycle (the confirm was gated on a marker cached within `EMPTY_RECONFIRM_MS` 5min, which was **< the 10-min reconcile interval** → always stale → confirmed every tick). Measured: `eligible_source:linearis` **597** on mini vs `replica` **1**.

## Change (subtractive)

A **defined** replica-empty has already cleared the reader's writer-liveness + seed-complete cursor + snapshot-consistent gates (the CTL-1397 2-gate freshness rule) — the same basis the breaker-*open* branch already trusted it on. So a defined replica-empty is now **always trusted directly, with zero live Linear reads**. The entire reconfirm machinery is removed: `EMPTY_RECONFIRM_MS`, the `_eligibleEmptyConfirmAt` marker, `__resetEligibleEmptyConfirm`, and the empty-confirm caching in the linearis path. The linearis path now serves **only** a genuine replica MISS (undefined) or an unwired replica. `onSource` distinguishes breaker state (`replica-empty-fresh` vs `replica-empty-breaker-open`).

## Safety

Residual risk is the *identical* CTL-139 feed-hole the breaker-open branch already accepted (a team's rows silently dropped while the writer stays alive) — self-healing on the next sync, strictly better than pinning the breaker every quiet tick (and it no longer freezes admission during a storm). A **non-empty** replica is always served, so real Todo work still dispatches. This is the owner end-state: worker nodes make no live Linear reads.

## Tests (191 pass)

Freshness-gated-empty trusts with **no exec** (breaker closed); breaker-open trust + non-empty-served + filtered-empty retained; the 6 obsolete reconfirm-cadence tests removed. Daemon import graph resolves.

## Acceptance (post-deploy)

`eligible_source:linearis` stops growing; the `linearis:issues-list` breaker trips drop toward zero. Part of CTL-1157.