### PR TITLE
feat(dev): CTL-1420 (#17) — move cross-host liveness off Linear → event log + Loki (PR1a: heartbeat carries in-flight tickets)

### DIFF
--- a/plugins/dev/scripts/execution-core/cluster-heartbeat-publisher.mjs
+++ b/plugins/dev/scripts/execution-core/cluster-heartbeat-publisher.mjs
@@ -64,7 +64,7 @@ function readLocalMaxParallel(orchDir) {
 // in defaultOwnedTicketsForHost (recovery.mjs) — factored here so the publisher
 // and the recovery fallback share the logic without importing recovery.mjs (which
 // would create a circular dependency once recovery imports this module's outputs).
-function localInFlightTickets(hostName, { orchDir } = {}) {
+export function localInFlightTickets(hostName, { orchDir } = {}) {
   if (!orchDir) return [];
   try {
     const signals = readWorkerSignals(orchDir);

--- a/plugins/dev/scripts/execution-core/daemon.mjs
+++ b/plugins/dev/scripts/execution-core/daemon.mjs
@@ -68,7 +68,7 @@ import { startRatelimitPoller as realStartRatelimitPoller } from "./ratelimit-po
 import { listProjects as realListProjects } from "./registry.mjs"; // CTL-854: boot health check
 import { startHeartbeat as realStartHeartbeat } from "./heartbeat-event.mjs"; // CTL-859: node.heartbeat emitter
 import { readAdmissionState } from "./admission-state.mjs"; // CTL-1322: live admission block for the heartbeat
-import { startLivenessPublisher as realStartLivenessPublisher } from "./cluster-heartbeat-publisher.mjs"; // CTL-1090: cross-host liveness
+import { startLivenessPublisher as realStartLivenessPublisher, localInFlightTickets } from "./cluster-heartbeat-publisher.mjs"; // CTL-1090: cross-host liveness; CTL-1420 (#17): in-flight list for the Loki heartbeat
 import { emitBootEvent } from "./boot-event.mjs"; // CTL-1084: node.boot self-report
 import {
   recoverStartup,
@@ -865,6 +865,10 @@ export function startDaemon({
       // both in scope here). Fail-open: readAdmissionState never throws.
       _heartbeat = startHeartbeat({
         admissionFn: () => readAdmissionState({ orchDir, concurrency }),
+        // CTL-1420 (#17): carry this host's in-flight tickets on every node.heartbeat
+        // so a peer can read liveness + ownership from Loki (retiring the Linear
+        // heartbeat attachment). Same local signal-scan source the publisher uses.
+        inFlightTicketsFn: () => localInFlightTickets(getHostName(), { orchDir }),
       });
       // CTL-1090: cross-host liveness publisher (multi-host only; single-host no-op).
       // startLivenessPublisher self-gates on roster.length > 1, so this is always safe.

--- a/plugins/dev/scripts/execution-core/heartbeat-event.mjs
+++ b/plugins/dev/scripts/execution-core/heartbeat-event.mjs
@@ -43,9 +43,12 @@ export const HEARTBEAT_EVENT = "node.heartbeat";
  * @param {Function} [opts.governanceFn]  injectable governance snapshot fn (CTL-1062)
  * @param {Function} [opts.admissionFn]  injectable admission-state fn (CTL-1322); the
  *   daemon supplies a closure over orchDir + concurrency. null when not supplied.
+ * @param {Function} [opts.inFlightTicketsFn]  CTL-1420 (#17): injectable fn returning
+ *   this host's in-flight ticket IDs (string[]); the daemon supplies the local
+ *   signal-scan list. Defaults to [] for non-daemon callers/tests.
  * @returns {object} the envelope object
  */
-export function buildHeartbeatEnvelope({ now, epochFn, governanceFn, admissionFn } = {}) {
+export function buildHeartbeatEnvelope({ now, epochFn, governanceFn, admissionFn, inFlightTicketsFn } = {}) {
   const ts = now ? now() : new Date().toISOString().replace(/\.\d{3}Z$/, "Z");
   const epoch = epochFn ? epochFn() : Date.now();
   const host = getHostName();
@@ -55,6 +58,18 @@ export function buildHeartbeatEnvelope({ now, epochFn, governanceFn, admissionFn
   // instead of hidden behind a healthy heartbeat. Supplied by the daemon; null for
   // non-daemon callers/tests so the key is always present for consumers.
   const admission = admissionFn ? admissionFn() : null;
+  // CTL-1420 (#17): this host's in-flight ticket IDs, carried as top-level ATTRIBUTES
+  // (not body.payload — otlp.ts:51 strips payload; only attributes reach Loki). A
+  // dotted attr key becomes Loki STRUCTURED METADATA (catalyst_node_in_flight_tickets),
+  // NOT an indexed stream label (collector-config cardinality rule), so a changing
+  // per-line value is safe. This is the cross-host ownership signal that lets a peer
+  // reclaim a dead host's work by reading Loki instead of the Linear heartbeat
+  // attachment. Comma-joined so the OTLP string attribute survives verbatim; count is
+  // a low-card int for dashboards. Fail-safe: a non-array fn result → [].
+  const inFlightRaw = inFlightTicketsFn ? inFlightTicketsFn() : [];
+  const inFlightTickets = Array.isArray(inFlightRaw)
+    ? inFlightRaw.filter((t) => typeof t === "string" && t.length > 0)
+    : [];
 
   return {
     ts,
@@ -70,6 +85,9 @@ export function buildHeartbeatEnvelope({ now, epochFn, governanceFn, admissionFn
       "event.entity": "node",
       "event.action": "heartbeat",
       "event.label": host,
+      // CTL-1420 (#17): Loki-queryable cross-host liveness+ownership signal.
+      "catalyst.node.in_flight_tickets": inFlightTickets.join(","),
+      "catalyst.node.in_flight_count": inFlightTickets.length,
     },
     body: {
       payload: {
@@ -97,8 +115,9 @@ export async function emitHeartbeatEvent({
   // reached buildHeartbeatEnvelope from here; now both governanceFn + admissionFn flow.
   governanceFn,
   admissionFn,
+  inFlightTicketsFn, // CTL-1420 (#17): forward the in-flight-tickets seam to the builder
 } = {}) {
-  const line = `${JSON.stringify(buildHeartbeatEnvelope({ now, epochFn, governanceFn, admissionFn }))}\n`;
+  const line = `${JSON.stringify(buildHeartbeatEnvelope({ now, epochFn, governanceFn, admissionFn, inFlightTicketsFn }))}\n`;
   try {
     await mkdir(dirname(logPath), { recursive: true });
     await appendFile(logPath, line);
@@ -120,15 +139,16 @@ export async function emitHeartbeatEvent({
  * @param {string} [opts.logPath]     event-log path (injectable for tests)
  * @param {Function} [opts.admissionFn]  CTL-1322: live admission-state fn (daemon-supplied)
  * @param {Function} [opts.governanceFn] CTL-1062: live governance snapshot fn (optional override)
+ * @param {Function} [opts.inFlightTicketsFn] CTL-1420 (#17): live in-flight-tickets fn (daemon-supplied)
  */
-export function startHeartbeat({ intervalMs = HEARTBEAT_INTERVAL_MS, logPath, admissionFn, governanceFn } = {}) {
+export function startHeartbeat({ intervalMs = HEARTBEAT_INTERVAL_MS, logPath, admissionFn, governanceFn, inFlightTicketsFn } = {}) {
   const tick = () => {
     // CTL-1280: deterministic liveness heartbeat to daemon.log (Alloy→Loki),
     // riding the same cadence as the node.heartbeat event but on the .log stream
     // so a liveness check can watch the heartbeat marker independent of the
     // otel-forward event pipeline (a quiet-but-healthy daemon must still prove it).
     logDaemonHeartbeat(log, "execution-core");
-    return emitHeartbeatEvent({ logPath, admissionFn, governanceFn }).catch(() => {});
+    return emitHeartbeatEvent({ logPath, admissionFn, governanceFn, inFlightTicketsFn }).catch(() => {});
   };
   const started = tick(); // emit once at boot; Promise for callers that need to await it
   const timer = setInterval(tick, intervalMs);

--- a/plugins/dev/scripts/execution-core/heartbeat-event.test.mjs
+++ b/plugins/dev/scripts/execution-core/heartbeat-event.test.mjs
@@ -338,6 +338,50 @@ describe("heartbeat admission block (CTL-1322)", () => {
   });
 });
 
+describe("heartbeat in-flight-tickets attributes (CTL-1420 #17)", () => {
+  test("carries the injected in-flight tickets as a comma-joined attribute + count", () => {
+    const env = buildHeartbeatEnvelope({ inFlightTicketsFn: () => ["CTL-100", "CTL-101"] });
+    // Top-level ATTRIBUTES (not body.payload) so they survive otel-forward → Loki.
+    expect(env.attributes["catalyst.node.in_flight_tickets"]).toBe("CTL-100,CTL-101");
+    expect(env.attributes["catalyst.node.in_flight_count"]).toBe(2);
+  });
+
+  test("defaults to empty string + 0 count when no fn is injected (key always present)", () => {
+    const env = buildHeartbeatEnvelope();
+    expect(env.attributes["catalyst.node.in_flight_tickets"]).toBe("");
+    expect(env.attributes["catalyst.node.in_flight_count"]).toBe(0);
+  });
+
+  test("filters non-string / empty entries and a non-array result fails safe to []", () => {
+    const dirty = buildHeartbeatEnvelope({ inFlightTicketsFn: () => ["CTL-1", "", null, 7, "CTL-2"] });
+    expect(dirty.attributes["catalyst.node.in_flight_tickets"]).toBe("CTL-1,CTL-2");
+    expect(dirty.attributes["catalyst.node.in_flight_count"]).toBe(2);
+    const notArray = buildHeartbeatEnvelope({ inFlightTicketsFn: () => null });
+    expect(notArray.attributes["catalyst.node.in_flight_tickets"]).toBe("");
+    expect(notArray.attributes["catalyst.node.in_flight_count"]).toBe(0);
+  });
+
+  test("startHeartbeat forwards inFlightTicketsFn through the tick to the appended line", async () => {
+    process.env.CATALYST_HOST_NAME = "mini";
+    const tmp = mkdtempSync(join(tmpdir(), "ctl1420-hb-inflight-"));
+    const logPath = join(tmp, "events.jsonl");
+    const h = startHeartbeat({
+      intervalMs: 1_000_000,
+      logPath,
+      inFlightTicketsFn: () => ["CTL-500"],
+    });
+    try {
+      await h.started;
+      const line = JSON.parse(readFileSync(logPath, "utf8").trim().split("\n")[0]);
+      expect(line.attributes["catalyst.node.in_flight_tickets"]).toBe("CTL-500");
+      expect(line.attributes["catalyst.node.in_flight_count"]).toBe(1);
+    } finally {
+      h.stop();
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+});
+
 // CTL-1322: emitHeartbeatEvent previously dropped governanceFn (and had no way to
 // forward admissionFn), so an injected seam never reached buildHeartbeatEnvelope on
 // the production startHeartbeat path — only the builder's default reader ran. Assert


### PR DESCRIPTION
## What & why

Part of moving **process-state (heartbeats) off Linear** (Ryan's directive, 2026-07-07) — the execution-core daemon publishes a `catalyst://heartbeat/<host>` Linear **attachment** every 120s (the ~120/hr write that flaps the CTL-679 breaker on the shared app-actor bucket). That attachment is the **only** cross-host transport for a peer's `last_seen` *and* `in_flight_tickets`.

The replacement is the unified event log → **Loki** (already central + cross-host; liveness is fail-open, so no new store/mesh needed — see dossier). `node.heartbeat` already reaches Loki with host + freshness, but the in-flight list lived in `body.payload`, which `otel-forward` **strips** (`otlp.ts:51` forwards only `attributes`).

## This PR (PR1a — additive telemetry, no behavior change)

Promotes the in-flight ticket list to top-level **attributes** so it survives to Loki as **structured metadata** (not an indexed stream label — collector cardinality rule):
- `catalyst.node.in_flight_tickets` (comma-joined) + `catalyst.node.in_flight_count`
- Daemon supplies the list via `localInFlightTickets(self)` (the same local signal-scan the publisher uses; now exported)
- Fail-safe: non-array/empty → `[]`. Single-host unchanged.

**Nothing reads this yet** — safe to deploy standalone; it de-risks PR1b by getting the data flowing to Loki first.

## Follow-ups (separate PRs)
- **PR1b** — `loki-liveness.mjs` fail-open reader + rewire `readClusterHeartbeats`/`defaultOwnedTicketsForHost` to Loki behind `CATALYST_LIVENESS_READ_SOURCE` (default `loki`, escape-hatch `linear`) + retire the Linear heartbeat publish (keep the Linear-free fence re-emit). This is the burn win.
- **PR2** — claim ownership visibility (`worker:<host>` label; gated on a Linear label-API write-test — single-select server-enforcement is unproven).

## Verification
- `heartbeat-event.test.mjs` — 4 new tests pass (attributes carry the list + count; empty default; dirty-input filtering; `startHeartbeat` forwards the seam). One unrelated pre-existing failure (`host.name defaults to os.hostname()`) fails identically on the base — it asserts the raw machine hostname but this host has a Layer-2 config name.
- `cluster-heartbeat-publisher.test.mjs` — 19/0 (export change clean). `daemon.mjs` builds clean.

Design: `thoughts/shared/research/2026-07-07_liveness-off-linear-dossier.md` · `thoughts/shared/plans/2026-07-07-liveness-off-linear-impl.md`

Deploy coordination via CTL-DELEGATE (channel `ctl-delegate-operational-unblock`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)