### PR TITLE
feat(dev): CTL-1436 (WS-A A4) — negative-cache fetchTicketState replica-MISS live reads (stop the issues-read breaker flap)

### DIFF
--- a/plugins/dev/scripts/execution-core/dispatch-alert.mjs
+++ b/plugins/dev/scripts/execution-core/dispatch-alert.mjs
@@ -24,6 +24,16 @@ export const ALERT_ELIGIBLE_SOURCE_UNAVAILABLE = "catalyst.alert.eligible_source
 
 export const ALERT_KIND_ELIGIBLE_SOURCE_UNAVAILABLE = "eligible_source_unavailable";
 
+// CTL-1436 (A4): a terminal-probe / GC-census ticket-state read MISSED the replica
+// and its LIVE `linearis issues read` fallback FAILED (429 / timeout / unparseable).
+// This is the "reads-via-replica must be LOUD on fail-open" signal — the silent
+// MISS→live fallthrough is now visible, and the negative cache backs the ticket off
+// so the breaker stops flapping. Throttled per-kind (one line/window) since the
+// negative cache already rate-limits the underlying reads.
+export const ALERT_TICKET_STATE_LIVE_FALLBACK = "catalyst.alert.ticket_state_live_fallback";
+
+export const ALERT_KIND_TICKET_STATE_LIVE_FALLBACK = "ticket_state_live_fallback";
+
 // Per-kind throttle so a per-tick hot path (runEligibleQuery inside the reconcile
 // timer) cannot spam the event log during a sustained storm. The alert is a LOUD
 // "something is wrong"
@@ -111,6 +121,24 @@ export function emitEligibleSourceUnavailable({ team = null, append, now, thrott
       reason ??
       "eligible discovery missed the replica AND the Linear breaker is OPEN — preserved the prior eligible set without spawning linearis (no bucket consumed)",
     detail: team ? { "linear.team.key": team } : {},
+    append,
+    now,
+    throttleMs,
+  });
+}
+
+// emitTicketStateLiveFallback — CTL-1436 (A4). A probeBackoff terminal-state read
+// missed the replica and its live linearis fallback failed; the ticket is now
+// negative-cached (backed off). `identifier` rides in the payload; `reason` is the
+// failure mode (timeout | error | unparseable).
+export function emitTicketStateLiveFallback({ identifier = null, reason = null, append, now, throttleMs } = {}) {
+  return emitThrottled({
+    eventName: ALERT_TICKET_STATE_LIVE_FALLBACK,
+    kind: ALERT_KIND_TICKET_STATE_LIVE_FALLBACK,
+    reason:
+      reason ??
+      "a terminal-probe ticket-state read missed the replica and its live linearis fallback failed — backed off (breaker-flap mitigation)",
+    detail: identifier ? { "linear.ticket": identifier } : {},
     append,
     now,
     throttleMs,

--- a/plugins/dev/scripts/execution-core/linear-cache.mjs
+++ b/plugins/dev/scripts/execution-core/linear-cache.mjs
@@ -32,10 +32,19 @@
 
 // Default 60 s TTL; env-overridable to match the SCHEDULER_*_MS env idiom.
 const DEFAULT_TTL_MS = Number(process.env.LINEAR_STATE_CACHE_TTL_MS) || 60_000;
+// CTL-1436 (A4): the NEGATIVE-cache TTL — how long a probeBackoff caller (the
+// terminal-probe / GC census) backs off from re-reading a ticket live after a
+// FAILED live read (429 / timeout / unparseable). Longer than the positive TTL:
+// these are old parked tickets the replica doesn't track, so a failed live probe
+// need not retry every tick. This store is CONSULTED ONLY on probeBackoff calls,
+// so the blocker-hydration path keeps the CTL-634 "a null read re-reads promptly"
+// invariant untouched.
+const DEFAULT_NEG_TTL_MS = Number(process.env.LINEAR_STATE_NEG_TTL_MS) || 5 * 60_000;
 
-export function createTicketStateCache({ now = Date.now, ttlMs = DEFAULT_TTL_MS } = {}) {
+export function createTicketStateCache({ now = Date.now, ttlMs = DEFAULT_TTL_MS, negTtlMs = DEFAULT_NEG_TTL_MS } = {}) {
   const entries = new Map(); // identifier -> { state, expiresAt }
   const relationsEntries = new Map(); // identifier -> { desc, expiresAt } (CTL-784)
+  const negativeEntries = new Map(); // identifier -> expiresAt (CTL-1436 A4)
   let hits = 0;
   let misses = 0;
   let relHits = 0;
@@ -56,6 +65,23 @@ export function createTicketStateCache({ now = Date.now, ttlMs = DEFAULT_TTL_MS 
     // Fail-safe: never cache a missing state. A null fetch must re-read.
     if (state == null) return;
     entries.set(identifier, { state, expiresAt: now() + ttlMs });
+    negativeEntries.delete(identifier); // CTL-1436: a fresh success clears any backoff
+  }
+
+  // CTL-1436 (A4): negative-cache read/write — a SHORT backoff for probeBackoff
+  // callers (terminal-probe / GC census) so a ticket whose live read just FAILED
+  // (or found nothing) is not re-hammered against live Linear every tick. Kept
+  // entirely separate from the positive `entries` store and consulted ONLY when a
+  // caller opts in via fetchTicketState({ probeBackoff:true }), so the CTL-634
+  // never-cache-null invariant for blocker hydration is preserved.
+  function isNegativelyCached(identifier) {
+    const exp = negativeEntries.get(identifier);
+    if (exp && exp > now()) return true;
+    if (exp) negativeEntries.delete(identifier); // expired — drop eagerly
+    return false;
+  }
+  function setNegative(identifier) {
+    negativeEntries.set(identifier, now() + negTtlMs);
   }
 
   // getRelations — CTL-784 read-through for the full relation descriptor. TTL is
@@ -91,6 +117,7 @@ export function createTicketStateCache({ now = Date.now, ttlMs = DEFAULT_TTL_MS 
   function invalidate(identifier) {
     entries.delete(identifier);
     relationsEntries.delete(identifier);
+    negativeEntries.delete(identifier); // CTL-1436: clear backoff on explicit invalidation
   }
 
   function stats() {
@@ -106,5 +133,5 @@ export function createTicketStateCache({ now = Date.now, ttlMs = DEFAULT_TTL_MS 
     return { hits: relHits, misses: relMisses, hitRate: total === 0 ? 0 : relHits / total };
   }
 
-  return { get, set, getRelations, setRelations, invalidate, stats, relationsStats };
+  return { get, set, isNegativelyCached, setNegative, getRelations, setRelations, invalidate, stats, relationsStats };
 }

--- a/plugins/dev/scripts/execution-core/linear-cache.test.mjs
+++ b/plugins/dev/scripts/execution-core/linear-cache.test.mjs
@@ -176,4 +176,45 @@ describe("createTicketStateCache — relations store (CTL-784)", () => {
     // state-store stats untouched by relation lookups (only the setRelations prime)
     expect(c.stats().hits).toBe(0);
   });
+
+  // CTL-1436 (A4): the negative cache — a short backoff for probeBackoff callers.
+  it("isNegativelyCached is false on a cold ticket; true within negTtlMs of setNegative", () => {
+    let t = 1000;
+    const c = createTicketStateCache({ now: () => t, negTtlMs: 300_000 });
+    expect(c.isNegativelyCached("CTL-1")).toBe(false);
+    c.setNegative("CTL-1");
+    t = 1000 + 299_000;
+    expect(c.isNegativelyCached("CTL-1")).toBe(true);
+  });
+
+  it("negative entry expires past negTtlMs", () => {
+    let t = 1000;
+    const c = createTicketStateCache({ now: () => t, negTtlMs: 300_000 });
+    c.setNegative("CTL-1");
+    t = 1000 + 300_001;
+    expect(c.isNegativelyCached("CTL-1")).toBe(false);
+  });
+
+  it("a fresh success (set) clears the negative backoff", () => {
+    const c = createTicketStateCache({ now: () => 0 });
+    c.setNegative("CTL-1");
+    expect(c.isNegativelyCached("CTL-1")).toBe(true);
+    c.set("CTL-1", "Done"); // the ticket came back → drop the backoff
+    expect(c.isNegativelyCached("CTL-1")).toBe(false);
+  });
+
+  it("invalidate clears the negative backoff too", () => {
+    const c = createTicketStateCache({ now: () => 0 });
+    c.setNegative("CTL-1");
+    c.invalidate("CTL-1");
+    expect(c.isNegativelyCached("CTL-1")).toBe(false);
+  });
+
+  it("negTtlMs is independent of the positive ttlMs", () => {
+    let t = 0;
+    const c = createTicketStateCache({ now: () => t, ttlMs: 60_000, negTtlMs: 300_000 });
+    c.setNegative("CTL-1");
+    t = 120_000; // past the 60s positive TTL, well within the 300s negative TTL
+    expect(c.isNegativelyCached("CTL-1")).toBe(true);
+  });
 });

--- a/plugins/dev/scripts/execution-core/linear-query.mjs
+++ b/plugins/dev/scripts/execution-core/linear-query.mjs
@@ -318,6 +318,15 @@ export function fetchTicketState(
     const node = JSON.parse(stdout);
     const state = node?.state?.name ?? node?.state ?? null;
     if (cache && state != null) cache.set(identifier, state); // populate on success only
+    else if (state == null && probeBackoff && cache?.setNegative) {
+      // A4 (Codex #2579): a `linearis issues read` that parses fine but carries NO
+      // state — a deleted/missing ticket returns code:0 + an error body — still
+      // shells out live every tick otherwise (it's exactly the stale-worker-dir
+      // class driving the flap). Back it off too, so the negative cache actually
+      // bounds the no-state live-read loop.
+      cache.setNegative(identifier);
+      emitTicketStateLiveFallback({ identifier, reason: "no-state" });
+    }
     if (onExec) {
       try {
         onExec({ source: "live", execMs: Date.now() - execStart, code, result: state, timedOut: timedOut === true });

--- a/plugins/dev/scripts/execution-core/linear-query.mjs
+++ b/plugins/dev/scripts/execution-core/linear-query.mjs
@@ -9,7 +9,7 @@ import { spawnSync } from "node:child_process";
 import { existsSync } from "node:fs";
 import { withBreaker, linearBreaker, isRateLimitError } from "./linear-breaker.mjs";
 import { withAuthRemint, linearReminter, isBatchAuthError } from "./linear-remint.mjs";
-import { emitEligibleSourceUnavailable } from "./dispatch-alert.mjs";
+import { emitEligibleSourceUnavailable, emitTicketStateLiveFallback } from "./dispatch-alert.mjs";
 
 // linearis caps a single page; 200 comfortably covers a project's pickable
 // set without pagination (the reconcile poll runs every 10 min anyway).
@@ -252,7 +252,7 @@ const GATEWAY_STATE_FRESH_MS = 60_000;
 // Default undefined → zero added cost (no callback). Never throws out (best-effort).
 export function fetchTicketState(
   identifier,
-  { exec = defaultExec, cache, gateway, replica, gatewayFreshMs = GATEWAY_STATE_FRESH_MS, onExec } = {}
+  { exec = defaultExec, cache, gateway, replica, gatewayFreshMs = GATEWAY_STATE_FRESH_MS, onExec, probeBackoff = false } = {}
 ) {
   if (cache) {
     const cached = cache.get(identifier);
@@ -285,6 +285,15 @@ export function fetchTicketState(
       return d.state;
     }
   }
+  // CTL-1436 (A4): probeBackoff callers (terminal-probe / GC census) back off from
+  // re-reading a ticket live for negTtlMs after its last live read FAILED. This is
+  // the cache+gateway+replica MISS path — the ONLY live shell-out — so a MISS ticket
+  // whose live read keeps 429-ing would otherwise be re-probed EVERY tick and keep
+  // the CTL-679 breaker flapping. Scoped to probeBackoff only → the blocker-hydration
+  // path keeps its prompt-null-re-read (CTL-634) behavior untouched.
+  if (probeBackoff && cache?.isNegativelyCached?.(identifier)) {
+    return null;
+  }
   // CTL-1339: hot per-signal terminal read — cap the wall-clock so a 429-stalled
   // linearis can't block the synchronous tier-3 reclaim/recovery read its full ~30s.
   // CTL-1364: this is the cache+gateway+replica MISS path — the ONLY place this fn
@@ -294,6 +303,10 @@ export function fetchTicketState(
     timeoutMs: LINEARIS_TERMINAL_READ_TIMEOUT_MS,
   });
   if (code !== 0) {
+    if (probeBackoff && cache?.setNegative) {
+      cache.setNegative(identifier); // A4: back off — don't re-hammer this live read every tick
+      emitTicketStateLiveFallback({ identifier, reason: timedOut === true ? "timeout" : "error" });
+    }
     if (onExec) {
       try {
         onExec({ source: "live", execMs: Date.now() - execStart, code, result: null, timedOut: timedOut === true });
@@ -312,6 +325,10 @@ export function fetchTicketState(
     }
     return state;
   } catch {
+    if (probeBackoff && cache?.setNegative) {
+      cache.setNegative(identifier); // A4: unparseable live read → back off too
+      emitTicketStateLiveFallback({ identifier, reason: "unparseable" });
+    }
     if (onExec) {
       try {
         onExec({ source: "live", execMs: Date.now() - execStart, code, result: null, timedOut: timedOut === true });

--- a/plugins/dev/scripts/execution-core/linear-query.test.mjs
+++ b/plugins/dev/scripts/execution-core/linear-query.test.mjs
@@ -766,6 +766,90 @@ describe("fetchTicketState — cache (CTL-634)", () => {
   });
 });
 
+// CTL-1436 (A4): probeBackoff — the terminal-probe / GC census backs off from
+// re-reading a replica-MISS ticket live after its live read FAILS, so a ticket that
+// keeps 429-ing isn't re-hammered every tick (CTL-679 breaker-flap mitigation).
+// Scoped to probeBackoff callers → the CTL-634 blocker-hydration path
+// (never-cache-null, re-read promptly) is untouched — proven by the "does NOT cache
+// a failed read" test above, which uses the default probeBackoff:false.
+describe("fetchTicketState — probeBackoff negative cache (CTL-1436 A4)", () => {
+  let tmpDir;
+  let prevDir;
+  beforeEach(() => {
+    __resetDispatchAlertThrottle();
+    prevDir = process.env.CATALYST_DIR;
+    tmpDir = mkdtempSync(join(tmpdir(), "a4-backoff-"));
+    process.env.CATALYST_DIR = tmpDir; // redirect the event log the fallback alert appends to
+  });
+  afterEach(() => {
+    if (prevDir === undefined) delete process.env.CATALYST_DIR;
+    else process.env.CATALYST_DIR = prevDir;
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+  const fail429 = () => ({ code: 1, stdout: "", stderr: "429" });
+  function eventLogBody() {
+    const dir = join(tmpDir, "events");
+    let files = [];
+    try { files = readdirSync(dir); } catch { return ""; }
+    return files.map((f) => readFileSync(join(dir, f), "utf8")).join("");
+  }
+
+  test("a failed live read backs the ticket off → the second call SKIPS exec (returns null)", () => {
+    const cache = createTicketStateCache({ now: () => 0 });
+    let calls = 0;
+    const exec = () => { calls += 1; return fail429(); };
+    expect(fetchTicketState("CTL-1", { exec, cache, probeBackoff: true })).toBeNull();
+    expect(fetchTicketState("CTL-1", { exec, cache, probeBackoff: true })).toBeNull();
+    expect(calls).toBe(1); // second call short-circuited on the negative cache
+  });
+
+  test("WITHOUT probeBackoff (blocker-hydration default) a failed read re-execs — CTL-634 invariant preserved", () => {
+    const cache = createTicketStateCache({ now: () => 0 });
+    let calls = 0;
+    const exec = () => { calls += 1; return fail429(); };
+    fetchTicketState("CTL-1", { exec, cache }); // probeBackoff defaults false
+    fetchTicketState("CTL-1", { exec, cache });
+    expect(calls).toBe(2);
+  });
+
+  test("the backoff expires past negTtlMs → re-execs", () => {
+    let t = 0;
+    const cache = createTicketStateCache({ now: () => t, negTtlMs: 300_000 });
+    let calls = 0;
+    const exec = () => { calls += 1; return fail429(); };
+    fetchTicketState("CTL-1", { exec, cache, probeBackoff: true });
+    t = 300_001;
+    fetchTicketState("CTL-1", { exec, cache, probeBackoff: true });
+    expect(calls).toBe(2);
+  });
+
+  test("a SUCCESS sets no backoff and is positively cached", () => {
+    const cache = createTicketStateCache({ now: () => 0 });
+    let calls = 0;
+    const exec = () => { calls += 1; return { code: 0, stdout: JSON.stringify({ state: { name: "Done" } }), stderr: "" }; };
+    expect(fetchTicketState("CTL-1", { exec, cache, probeBackoff: true })).toBe("Done");
+    expect(cache.isNegativelyCached("CTL-1")).toBe(false);
+    expect(fetchTicketState("CTL-1", { exec, cache, probeBackoff: true })).toBe("Done");
+    expect(calls).toBe(1); // positive cache hit
+  });
+
+  test("probeBackoff with NO cache is a safe no-op (every call execs, never throws)", () => {
+    let calls = 0;
+    const exec = () => { calls += 1; return fail429(); };
+    expect(fetchTicketState("CTL-1", { exec, probeBackoff: true })).toBeNull();
+    expect(fetchTicketState("CTL-1", { exec, probeBackoff: true })).toBeNull();
+    expect(calls).toBe(2);
+  });
+
+  test("a failed probeBackoff read emits the loud ticket_state_live_fallback alert", () => {
+    const cache = createTicketStateCache({ now: () => 0 });
+    fetchTicketState("CTL-77", { exec: fail429, cache, probeBackoff: true });
+    const body = eventLogBody();
+    expect(body).toContain("catalyst.alert.ticket_state_live_fallback");
+    expect(body).toContain("CTL-77");
+  });
+});
+
 // CTL-755 — fetchTicketRelations is the admission gate's single-read hydration
 // of a triaged-waiting candidate: state + relations + inverseRelations +
 // priority + labels in one `linearis issues read <id>`. The descriptor it

--- a/plugins/dev/scripts/execution-core/linear-query.test.mjs
+++ b/plugins/dev/scripts/execution-core/linear-query.test.mjs
@@ -841,6 +841,17 @@ describe("fetchTicketState — probeBackoff negative cache (CTL-1436 A4)", () =>
     expect(calls).toBe(2);
   });
 
+  test("a successful-but-STATELESS read (deleted/missing ticket: code:0, no state) also backs off (Codex #2579)", () => {
+    const cache = createTicketStateCache({ now: () => 0 });
+    let calls = 0;
+    // Linear returns a missing ticket as code:0 with an error body (parses fine, no state).
+    const exec = () => { calls += 1; return { code: 0, stdout: JSON.stringify({ error: "Entity not found" }), stderr: "" }; };
+    expect(fetchTicketState("CTL-1", { exec, cache, probeBackoff: true })).toBeNull();
+    expect(cache.isNegativelyCached("CTL-1")).toBe(true); // no-state → backed off
+    expect(fetchTicketState("CTL-1", { exec, cache, probeBackoff: true })).toBeNull();
+    expect(calls).toBe(1); // second call short-circuited on the negative cache
+  });
+
   test("a failed probeBackoff read emits the loud ticket_state_live_fallback alert", () => {
     const cache = createTicketStateCache({ now: () => 0 });
     fetchTicketState("CTL-77", { exec: fail429, cache, probeBackoff: true });

--- a/plugins/dev/scripts/execution-core/scheduler.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.mjs
@@ -6521,6 +6521,7 @@ function runTick() {
                 cache: runningOpts.cache,
                 gateway: runningOpts.gateway,
                 replica: runningOpts.replica,
+                probeBackoff: true, // CTL-1436 (A4): a replica-MISS ticket whose live read fails backs off (breaker-flap mitigation)
               });
               return state != null && isLinearTerminal(state);
             },
@@ -6555,6 +6556,7 @@ function runTick() {
                 cache: runningOpts.cache,
                 gateway: runningOpts.gateway,
                 replica: runningOpts.replica,
+                probeBackoff: true, // CTL-1436 (A4): a replica-MISS ticket whose live read fails backs off (breaker-flap mitigation)
               });
               return state != null && isLinearTerminal(state);
             },
@@ -6594,6 +6596,7 @@ function runTick() {
                 cache: runningOpts.cache,
                 gateway: runningOpts.gateway,
                 replica: runningOpts.replica,
+                probeBackoff: true, // CTL-1436 (A4): a replica-MISS ticket whose live read fails backs off (breaker-flap mitigation)
               });
               return state != null && isLinearTerminal(state);
             },


### PR DESCRIPTION
## What & why

Part of the delegate-operational plan (umbrella **CTL-1157**, WS-A). Post-A2, the **#1 CTL-679 Linear breaker driver is `caller:linearis:issues-read`** (mini 19/19 opens, ~79% 429-class; mini-2 7/7) — surfaced by A1's breaker instrumentation.

**The reframe (research + live mini diagnosis):** these census/terminal-probe reads are **already replica-routed** (CTL-1240 cache/gateway + CTL-1340 replica tier), and the tier is **armed on both minis** with a fresh replica. The flap is `fetchTicketState`'s **live fallback firing on replica MISS**: ~7 old parked tickets (ADV-1374/1376/1403, CTL-1154/764, OTL-13/41) aren't in the replica's bounded working set (proven — replica max is ADV-1528/CTL-1435, *newer* than the missing ones → a sync **filter**, not a recency hole). The GC/stall/unstuck census reads them by on-disk signal **every tick** → MISS → live `linearis issues read` → 429. And on failure the result is **not cached** (the CTL-634 never-cache-null invariant) → re-probed every tick.

## Fix — a `probeBackoff`-scoped negative cache

Scoped to the terminal-probe/census path so the **CTL-634 blocker-hydration never-cache-null invariant is untouched** (a blocker still re-reads promptly for recovery):

- **`linear-cache.mjs`** — a negative-cache store (`isNegativelyCached`/`setNegative`) with its own short TTL (`LINEAR_STATE_NEG_TTL_MS`, default 5m). A success (`set`) or `invalidate` clears the backoff.
- **`linear-query.mjs` `fetchTicketState`** — new `probeBackoff` opt. On a MISS→live **failure**, set the backoff + emit a loud alert; **before** the live shell-out, short-circuit on a fresh backoff (return null). Bounds the live-read rate from ~7/tick to ~7/negTTL.
- **`dispatch-alert.mjs`** — `catalyst.alert.ticket_state_live_fallback` (WARN, per-kind throttled, never-throws) — the *"reads-via-replica must be LOUD on fail-open"* signal (parity with `emitEligibleSourceUnavailable`).
- **`scheduler.mjs`** — `probeBackoff:true` on the **3 census closures** (stall-clear J3, terminal-signal-GC J4, unstuck-sweep). **NOT** the blocker-hydration read at 6425.

## Scope notes
- **Site 3 (open-pr-gate `--with-attachments`)** is *outside* the CTL-679 breaker (separate `runLinearis` path) and has **no replica schema** → deferred.
- The **fence CAS read-back** stays on live Linear (CTL-1420's domain — a fail-closed arbitration read the replica can't serve).
- **Why active tickets miss the replica** (the sync filter) is a **writer-side follow-up**, not this daemon fix.

## Tests — +12
`linear-cache` negative methods (set/expire/success-clears/invalidate/independent-TTL); `fetchTicketState` probeBackoff (failed read backs off → skips exec; expiry re-execs; success no-backoff; no-cache no-op; **alert emitted**); and an explicit **CTL-634 invariant preserved** test (default `probeBackoff:false` → failed reads still re-exec).

- `linear-cache.test.mjs` → **23 pass**
- `linear-query.test.mjs` → **202 pass**
- census/stall-janitor tests pass in isolation; the full `scheduler.test.mjs` suite's 2 fails are the **pre-existing CTL-1174 `botWriteId` env flakes** (identical on untouched main — this suite has known order-dependent pollution).

🤖 Generated with [Claude Code](https://claude.com/claude-code)