### PR TITLE
fix(dev): CTL-1437 (A4 follow-up) — widen probeBackoff to the every-tick terminal-Done sweep

### DIFF
--- a/plugins/dev/scripts/execution-core/scheduler.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.mjs
@@ -5874,7 +5874,10 @@ export function schedulerTick(
       {
         cache,
         prAdapter,
-        fetchState: (id, o = {}) => fetchTicketState(id, { ...o, gateway, replica }),
+        // CTL-1437 (A4 follow-up): the terminal-Done sweep runs EVERY tick per started
+        // ticket; probeBackoff backs off a replica-MISS ticket whose live terminal read
+        // fails so it isn't re-probed every tick (the CTL-1329 ~2x/sec flap driver).
+        fetchState: (id, o = {}) => fetchTicketState(id, { ...o, gateway, replica, probeBackoff: true }),
         multiHost,
         gateway,
         self,
@@ -5909,7 +5912,11 @@ export function schedulerTick(
         const term = isTicketTerminalOrMerged({
           ticket,
           signal: signalByTicket.get(ticket),
-          fetchState: (id, o = {}) => fetchTicketState(id, { ...o, cache, gateway, replica }),
+          // CTL-1437 (A4 follow-up): the cheap-first terminal probe on the stalled/failed
+          // set runs EVERY tick — CTL-1329's documented ~2x/sec `issues read` burn. probeBackoff
+          // backs a replica-MISS ticket off (5-min negTTL) after a failed live read instead of
+          // re-probing every tick, so the CTL-679 breaker stops flapping on it.
+          fetchState: (id, o = {}) => fetchTicketState(id, { ...o, cache, gateway, replica, probeBackoff: true }),
           cache,
           prAdapter,
         });


### PR DESCRIPTION
## What & why

**A4 (CTL-1436) scope completion.** CTL-1436 wired `probeBackoff` into the 3 GC/stall **censuses** — but those (J3/J4/unstuck) are git-heavy and **throttled to ~15-min cadence** (CTL-1324). The actual **every-tick** `issues-read` driver is the **terminal-Done sweep's terminal probe**:

- `isTicketTerminalOrMerged` (`scheduler.mjs:5912`) and `reconcileTerminalBackstop` fetchState (`5877`) run **every tick per stalled/failed-not-done started ticket**.
- **CTL-1329** documents this exact loop: *"five leftover ADV dirs looped ~2×/sec, draining the daemon's OAuth bucket until the CTL-679 breaker froze dispatch fleet-wide."*
- **Live post-A4 evidence:** the breaker kept flapping at ~24 opens/hr 8 min after the CTL-1436 deploy — because these per-tick reads weren't backed off.

## Fix
Add `probeBackoff: true` to both terminal-Done-sweep `fetchTicketState` calls. A replica-MISS ticket whose live terminal read fails now backs off (5-min `negTTL`) instead of re-probing every tick — reusing the **CTL-1436 negative-cache mechanism** (already merged, tested at the `fetchTicketState` level: negative-cache set/expire/success-clears, failure/stateless backoff, CTL-634 invariant preserved).

This is **pure wiring** of the flag into the per-tick sites (2 one-line changes). The 4125/4362 recovery-pass/reclaim reads are a possible further widening, but reclaim is fence-sensitive — scoped here to the documented terminal-Done-sweep driver.

## Tests
Terminal-Done-sweep tests (`scheduler.test.mjs -t terminal`): **51 pass**. The negative-cache behavior is covered by the CTL-1436 `linear-query`/`linear-cache` suites; this PR only threads the already-tested flag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)