### PR TITLE
feat(dev): CTL-1439 (P0a) — recovery-pass verdict persistence + surfacing (stop act-and-discard)

### DIFF
--- a/.github/workflows/execution-core-tests.yml
+++ b/.github/workflows/execution-core-tests.yml
@@ -313,6 +313,7 @@ jobs:
             worktree-safety.test.mjs \
             worktree.test.mjs \
             recovery-reasoning.test.mjs \
+            recovery-emit.test.mjs \
             sweep-stale-recovery-intents.test.mjs \
             recovery-evidence.test.mjs \
             unstuck-act-seams.test.mjs \

--- a/plugins/dev/scripts/execution-core/board-health-seam.test.mjs
+++ b/plugins/dev/scripts/execution-core/board-health-seam.test.mjs
@@ -128,6 +128,9 @@ describe("holisticBoardHealthAct — one real dispatch per scan, skip non-dispat
     expect(invoked).toEqual(["CTL-1"]); // stopped after the first real dispatch
     expect(recorded).toHaveLength(1);
     expect(recorded[0].intent.outcome).toBe(true);
+    // CTL-1439 (P0a): the dispatch-time ledger write is a DISPATCH marker, not a
+    // verdict — the session's actual conclusion arrives later via recordVerdict.
+    expect(recorded[0].intent.decision).toBe("dispatched");
   });
 
   test("a ledger-latched candidate (shouldSkipItem) is skipped without invoking (MUST-FIX 2)", () => {

--- a/plugins/dev/scripts/execution-core/recovery-emit.mjs
+++ b/plugins/dev/scripts/execution-core/recovery-emit.mjs
@@ -9,15 +9,28 @@
 // deriveAttention) surfaces it identically whether the daemon dispatched the
 // skill or Ryan invoked it by hand.
 //
-// Two subcommands:
+// Three subcommands (CTL-1439 P0a: every terminal conclusion of a recovery-pass
+// session — fixed / leave-alone / escalated — persists a verdict to the intent
+// ledger and a ticket-tagged event, so "correctly diagnosed" is never again
+// indistinguishable from "nothing happened"):
 //
-//   fixed   --ticket CTL-N --reason "<plain past-tense changelog>" [--details JSON]
+//   fixed   --ticket CTL-N --reason "<plain past-tense changelog>" [--details JSON] [--orch-dir D]
 //     Emits recovery.fixed (INFO). board-data folds it into autoFixed:true — the
 //     recovered lane, NOT a needs-you row. No push. (Use this when the skill
 //     resolved the item autonomously: rebased / merged / resolved a conflict /
-//     re-dispatched a phase.)
+//     re-dispatched a phase.) Also records the ledger verdict decision:"fixed"
+//     with attempts PINNED (the dispatch-time marker already counted the attempt).
 //
-//   escalated --ticket CTL-N --escalation <EscalationPayload JSON> [--orch-dir D] [--phase P]
+//   leave-alone --ticket CTL-N --reason "<why no action is needed>" [--details JSON]
+//               [--orch-dir D] [--no-comment]
+//     The reviewed-healthy verdict (stale flag / actively human-driven / false
+//     positive). Emits recovery.verdict (INFO), records the ledger verdict
+//     decision:"leave-alone" with the dispatch attempt REFUNDED (a leave-alone
+//     must not burn a fix attempt), and posts a ticket-visible app-actor comment
+//     (enforce-only, best-effort). defaultShouldSkipItem then suppresses
+//     re-review for RECOVERY_LEAVE_ALONE_TTL_MS.
+//
+//   escalated --ticket CTL-N --escalation <EscalationPayload JSON> [--orch-dir D] [--phase P] [--no-comment]
 //     The ONLY path that pages Ryan. It does THREE things, in order:
 //       1. Emits recovery.escalated (WARN, severityNumber 13) carrying the rich
 //          EscalationPayload (the composer-ready tagged union — manual /
@@ -46,10 +59,13 @@ import {
   existsSync,
 } from "node:fs";
 import { dirname, join } from "node:path";
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
 import {
   buildRecoveryEnvelope,
   defaultEmitEvent,
   defaultRecordIntent,
+  recordVerdict,
 } from "./recovery-reasoning.mjs";
 
 const argv = process.argv.slice(2);
@@ -71,6 +87,39 @@ function getJson(flag, fallback) {
 
 function resolveOrchDir() {
   return get("--orch-dir") ?? process.env.CATALYST_ORCHESTRATOR_DIR ?? null;
+}
+
+// ── Ticket-visible comment (CTL-1439 P0a) ────────────────────────────────────
+// The audit found 0/7 recovery-pass sessions posted a Linear comment even where
+// the skill prompt instructed one — prompt-side discipline is not a guarantee.
+// The shim therefore posts the verdict comment ITSELF (belt-and-braces): the
+// same app-actor helper the router uses, gated enforce-only (mirrors the skill's
+// _rp_comment gate; shadow must never write to Linear), suppressible with
+// --no-comment, and best-effort (a comment failure never fails the emit — the
+// ledger + event verdicts have already landed by the time this runs).
+const RECOVERY_MODE = process.env.CATALYST_RECOVERY_PASS ?? "enforce";
+const COMMENT_HELPER =
+  process.env.CATALYST_COMMENT_POST_HELPER ??
+  fileURLToPath(new URL("../lib/linear-comment-post.sh", import.meta.url));
+
+function postTicketComment(ticket, body) {
+  if (argv.includes("--no-comment")) return false;
+  if (RECOVERY_MODE !== "enforce") return false;
+  try {
+    const res = spawnSync(COMMENT_HELPER, [ticket, body], {
+      encoding: "utf8",
+      maxBuffer: 10 * 1024 * 1024,
+    });
+    if (res.status === 0) return true;
+    process.stderr.write(
+      `recovery-emit: comment post failed on ${ticket} (status ${res.status ?? res.error?.message}) — continuing\n`,
+    );
+  } catch (err) {
+    process.stderr.write(
+      `recovery-emit: comment post threw on ${ticket}: ${err.message} — continuing\n`,
+    );
+  }
+  return false;
 }
 
 // mergeExplanationIntoSignal — write the EscalationPayload as the signal's
@@ -110,7 +159,53 @@ if (sub === "fixed") {
     process.exit(2);
   }
   defaultEmitEvent({ type: "recovery.fixed", ticket, reason, details });
+  // CTL-1439 (P0a): persist the verdict — without this the ledger keeps the
+  // dispatch-time "dispatched" marker forever and the session's conclusion has
+  // no durable trace. attempts stays PINNED inside recordVerdict (no double
+  // count). Best-effort: a missing orchDir (bare operator sweep) skips the
+  // ledger, the event above is still the record.
+  try {
+    recordVerdict(ticket, { verdict: "fixed", reason }, { orchDir: resolveOrchDir() });
+  } catch (err) {
+    process.stderr.write(`recovery-emit: verdict ledger write failed: ${err.message}\n`);
+  }
   process.stdout.write(`recovery.fixed emitted for ${ticket}\n`);
+  process.exit(0);
+}
+
+if (sub === "leave-alone") {
+  const ticket = get("--ticket");
+  const reason = get("--reason");
+  const details = getJson("--details", {});
+  if (!ticket || !reason) {
+    process.stderr.write("recovery-emit leave-alone: --ticket and --reason required\n");
+    process.exit(2);
+  }
+
+  // (1) Ticket-tagged verdict event — the durable log record (audit RC2 (c)).
+  defaultEmitEvent({
+    type: "recovery.verdict",
+    ticket,
+    reason,
+    details: { verdict: "leave-alone", ...details },
+  });
+
+  // (2) The ACTUAL verdict into the ledger, refunding the dispatch attempt
+  //     (audit RC2 (b) + (d)). defaultShouldSkipItem now suppresses re-review
+  //     for RECOVERY_LEAVE_ALONE_TTL_MS instead of burning toward the 2-strike latch.
+  try {
+    recordVerdict(ticket, { verdict: "leave-alone", reason }, { orchDir: resolveOrchDir() });
+  } catch (err) {
+    process.stderr.write(`recovery-emit: verdict ledger write failed: ${err.message}\n`);
+  }
+
+  // (3) Ticket-visible comment (audit RC2 (a)) — enforce-only, best-effort.
+  postTicketComment(
+    ticket,
+    `🔍 **recovery-pass** reviewed this — ${reason}. No action needed; leaving as-is (re-checks automatically if still flagged after the leave-alone window).`,
+  );
+
+  process.stdout.write(`recovery.verdict (leave-alone) emitted for ${ticket}\n`);
   process.exit(0);
 }
 
@@ -135,15 +230,32 @@ if (sub === "escalated") {
   mergeExplanationIntoSignal(orchDir, ticket, phase, escalation);
 
   // (3) Latch the escalated intent (terminal — router stops re-acting).
+  //     CTL-1439 (P0a): carries the verdict fields so the ledger records the
+  //     session's actual conclusion, not just the latch.
   try {
     defaultRecordIntent(
       ticket,
-      { type: "recovery-pass", decision: "escalate", escalated: true, escalation },
+      {
+        type: "recovery-pass",
+        decision: "escalate",
+        escalated: true,
+        escalation,
+        verdict: "escalate",
+        verdictReason: reason,
+      },
       { orchDir },
     );
   } catch (err) {
     process.stderr.write(`recovery-emit: intent latch failed: ${err.message}\n`);
   }
+
+  // (4) CTL-1439 (P0a): ticket-visible escalation comment — the audit found the
+  //     skill-side comment discipline failed in practice (0/7 posted), so the
+  //     shim posts it itself. One line; the full briefing lives in the inbox.
+  postTicketComment(
+    ticket,
+    `🔼 **recovery-pass** escalated this to the operator — ${escalation.call_to_action ?? reason}. (See your inbox.)`,
+  );
 
   process.stdout.write(
     `recovery.escalated emitted for ${ticket} (type=${escalation.escalation_type})\n`,
@@ -152,6 +264,6 @@ if (sub === "escalated") {
 }
 
 process.stderr.write(
-  "recovery-emit: usage: recovery-emit.mjs <fixed|escalated> --ticket CTL-N ...\n",
+  "recovery-emit: usage: recovery-emit.mjs <fixed|leave-alone|escalated> --ticket CTL-N ...\n",
 );
 process.exit(2);

--- a/plugins/dev/scripts/execution-core/recovery-emit.mjs
+++ b/plugins/dev/scripts/execution-core/recovery-emit.mjs
@@ -111,8 +111,16 @@ function postTicketComment(ticket, body) {
       maxBuffer: 10 * 1024 * 1024,
     });
     if (res.status === 0) return true;
+    // Codex P3: surface the helper's own diagnostic (its last stderr line names
+    // the actual cause — token mint / issue resolution / mutation) instead of a
+    // bare status code; the silent-failure class is exactly what CTL-1439 fixes.
+    const helperErr = (res.stderr || res.error?.message || "")
+      .toString()
+      .trim()
+      .split("\n")
+      .pop();
     process.stderr.write(
-      `recovery-emit: comment post failed on ${ticket} (status ${res.status ?? res.error?.message}) — continuing\n`,
+      `recovery-emit: comment post failed on ${ticket} (status ${res.status ?? "spawn-error"}${helperErr ? `; ${helperErr}` : ""}) — continuing\n`,
     );
   } catch (err) {
     process.stderr.write(
@@ -183,11 +191,13 @@ if (sub === "leave-alone") {
   }
 
   // (1) Ticket-tagged verdict event — the durable log record (audit RC2 (c)).
+  //     Caller details first: the verdict field is RESERVED (Codex P3 — a
+  //     details.verdict must never contradict the ledger/comment).
   defaultEmitEvent({
     type: "recovery.verdict",
     ticket,
     reason,
-    details: { verdict: "leave-alone", ...details },
+    details: { ...details, verdict: "leave-alone" },
   });
 
   // (2) The ACTUAL verdict into the ledger, refunding the dispatch attempt

--- a/plugins/dev/scripts/execution-core/recovery-emit.test.mjs
+++ b/plugins/dev/scripts/execution-core/recovery-emit.test.mjs
@@ -1,0 +1,226 @@
+// recovery-emit.test.mjs — CTL-1439 (P0a): the recovery-pass CLI shim persists
+// the session's ACTUAL verdict (fixed / leave-alone / escalated) to all three
+// surfaces — the unified event log, the recovery-intent ledger, and (for
+// leave-alone/escalated) a ticket-visible Linear comment — instead of the
+// pre-dispatch placeholder being the only durable trace.
+//
+// Run: cd plugins/dev/scripts/execution-core && bun test recovery-emit.test.mjs
+
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { spawnSync } from "node:child_process";
+import {
+  mkdtempSync,
+  rmSync,
+  mkdirSync,
+  writeFileSync,
+  readFileSync,
+  existsSync,
+  chmodSync,
+} from "node:fs";
+import { join as pathJoin } from "node:path";
+import { tmpdir } from "node:os";
+import { fileURLToPath } from "node:url";
+
+const CLI = fileURLToPath(new URL("./recovery-emit.mjs", import.meta.url));
+
+let catalystDir; // CATALYST_DIR → events land at <catalystDir>/events/YYYY-MM.jsonl
+let orchDir; // --orch-dir → ledger at <orchDir>/.recovery-intents/<ticket>.json
+let captureFile; // the stub comment helper appends "<ticket>\n---\n<body>" here
+
+function eventLogPath() {
+  const now = new Date();
+  const ym = `${now.getUTCFullYear()}-${String(now.getUTCMonth() + 1).padStart(2, "0")}`;
+  return pathJoin(catalystDir, "events", `${ym}.jsonl`);
+}
+
+function readEvents() {
+  if (!existsSync(eventLogPath())) return [];
+  return readFileSync(eventLogPath(), "utf8")
+    .trim()
+    .split("\n")
+    .filter(Boolean)
+    .map((l) => JSON.parse(l));
+}
+
+function readLedger(ticket) {
+  return JSON.parse(
+    readFileSync(pathJoin(orchDir, ".recovery-intents", `${ticket}.json`), "utf8"),
+  );
+}
+
+function seedLedger(ticket, entry) {
+  const dir = pathJoin(orchDir, ".recovery-intents");
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(pathJoin(dir, `${ticket}.json`), JSON.stringify(entry));
+}
+
+function runCli(args, envOverride = {}) {
+  return spawnSync(process.execPath, [CLI, ...args], {
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      CATALYST_DIR: catalystDir,
+      CATALYST_COMMENT_POST_HELPER: pathJoin(catalystDir, "stub-comment-post.sh"),
+      CATALYST_RECOVERY_PASS: "enforce",
+      ...envOverride,
+    },
+  });
+}
+
+beforeEach(() => {
+  catalystDir = mkdtempSync(pathJoin(tmpdir(), "rec-emit-"));
+  orchDir = pathJoin(catalystDir, "execution-core");
+  mkdirSync(orchDir, { recursive: true });
+  captureFile = pathJoin(catalystDir, "comment-capture.txt");
+  const stub = pathJoin(catalystDir, "stub-comment-post.sh");
+  writeFileSync(stub, `#!/bin/bash\nprintf '%s\\n---\\n%s\\n' "$1" "$2" >> "${captureFile}"\n`);
+  chmodSync(stub, 0o755);
+});
+
+afterEach(() => {
+  try {
+    rmSync(catalystDir, { recursive: true, force: true });
+  } catch {
+    /* best-effort */
+  }
+});
+
+describe("recovery-emit leave-alone (CTL-1439 P0a)", () => {
+  test("happy path: recovery.verdict event + ledger leave-alone (attempt refunded) + Linear comment", () => {
+    seedLedger("CTL-500", { ticket: "CTL-500", ts: 1, lastTs: 1, decision: "dispatched", fix_class: "board-health", attempts: 2, escalated: false });
+    const res = runCli([
+      "leave-alone",
+      "--ticket", "CTL-500",
+      "--orch-dir", orchDir,
+      "--reason", "needs-human label is stale; the human is actively driving this worktree",
+    ]);
+    expect(res.status).toBe(0);
+
+    // (c) ticket-tagged verdict event in the unified log
+    const events = readEvents();
+    const verdict = events.find((e) => e.attributes?.["event.name"] === "recovery.verdict");
+    expect(verdict).toBeDefined();
+    expect(verdict.attributes["event.label"]).toBe("CTL-500");
+    expect(verdict.severityText).toBe("INFO");
+    expect(verdict.body.payload.details.verdict).toBe("leave-alone");
+    expect(verdict.body.payload.reason).toContain("stale");
+
+    // (b) the ACTUAL verdict in the ledger, (d) attempt refunded
+    const ledger = readLedger("CTL-500");
+    expect(ledger.decision).toBe("leave-alone");
+    expect(ledger.verdict).toBe("leave-alone");
+    expect(ledger.attempts).toBe(1);
+
+    // (a) ticket-visible comment through the app-actor helper
+    const captured = readFileSync(captureFile, "utf8");
+    expect(captured).toContain("CTL-500");
+    expect(captured).toContain("recovery-pass");
+    expect(captured).toContain("stale");
+  });
+
+  test("missing --reason → exit 2, nothing written", () => {
+    const res = runCli(["leave-alone", "--ticket", "CTL-501", "--orch-dir", orchDir]);
+    expect(res.status).toBe(2);
+    expect(readEvents()).toHaveLength(0);
+    expect(existsSync(pathJoin(orchDir, ".recovery-intents", "CTL-501.json"))).toBe(false);
+  });
+
+  test("missing --ticket → exit 2", () => {
+    const res = runCli(["leave-alone", "--reason", "x", "--orch-dir", orchDir]);
+    expect(res.status).toBe(2);
+  });
+
+  test("--no-comment suppresses the comment but keeps event + ledger", () => {
+    const res = runCli([
+      "leave-alone", "--ticket", "CTL-502", "--orch-dir", orchDir,
+      "--reason", "flag is a false positive", "--no-comment",
+    ]);
+    expect(res.status).toBe(0);
+    expect(existsSync(captureFile)).toBe(false);
+    expect(readEvents().some((e) => e.attributes?.["event.name"] === "recovery.verdict")).toBe(true);
+    expect(readLedger("CTL-502").decision).toBe("leave-alone");
+  });
+
+  test("shadow mode never posts a comment (event + ledger still land)", () => {
+    const res = runCli(
+      ["leave-alone", "--ticket", "CTL-503", "--orch-dir", orchDir, "--reason", "healthy"],
+      { CATALYST_RECOVERY_PASS: "shadow" },
+    );
+    expect(res.status).toBe(0);
+    expect(existsSync(captureFile)).toBe(false);
+    expect(readLedger("CTL-503").decision).toBe("leave-alone");
+  });
+
+  test("a failing comment helper never fails the emit (exit 0, verdict persisted)", () => {
+    const badStub = pathJoin(catalystDir, "bad-stub.sh");
+    writeFileSync(badStub, "#!/bin/bash\nexit 1\n");
+    chmodSync(badStub, 0o755);
+    const res = runCli(
+      ["leave-alone", "--ticket", "CTL-504", "--orch-dir", orchDir, "--reason", "healthy"],
+      { CATALYST_COMMENT_POST_HELPER: badStub },
+    );
+    expect(res.status).toBe(0);
+    expect(readLedger("CTL-504").decision).toBe("leave-alone");
+  });
+});
+
+describe("recovery-emit fixed — ledger verdict write (CTL-1439 P0a)", () => {
+  test("fixed records decision:fixed with attempts PINNED (dispatch already counted)", () => {
+    seedLedger("CTL-510", { ticket: "CTL-510", ts: 1, lastTs: 1, decision: "dispatched", fix_class: "board-health", attempts: 1, escalated: false });
+    const res = runCli([
+      "fixed", "--ticket", "CTL-510", "--orch-dir", orchDir,
+      "--reason", "Resolved the rebase conflict; merged #2163.",
+    ]);
+    expect(res.status).toBe(0);
+    const events = readEvents();
+    expect(events.some((e) => e.attributes?.["event.name"] === "recovery.fixed" && e.attributes?.["event.label"] === "CTL-510")).toBe(true);
+    const ledger = readLedger("CTL-510");
+    expect(ledger.decision).toBe("fixed");
+    expect(ledger.verdict).toBe("fixed");
+    expect(ledger.attempts).toBe(1); // pinned, not double-counted
+  });
+
+  test("fixed without any orch dir still emits the event (ledger skipped, fail-open)", () => {
+    const res = runCli(["fixed", "--ticket", "CTL-511", "--reason", "merged"], {
+      CATALYST_ORCHESTRATOR_DIR: "",
+    });
+    expect(res.status).toBe(0);
+    expect(readEvents().some((e) => e.attributes?.["event.name"] === "recovery.fixed")).toBe(true);
+  });
+});
+
+describe("recovery-emit escalated — comment surfacing (CTL-1439 P0a)", () => {
+  const escalation = JSON.stringify({
+    escalation_type: "decision",
+    problem: "two valid dispatch shapes collide",
+    call_to_action: "pick per-host pinning or quota-aware",
+  });
+
+  test("escalated posts the ticket comment AND keeps event + signal + latch", () => {
+    const res = runCli([
+      "escalated", "--ticket", "CTL-520", "--orch-dir", orchDir,
+      "--phase", "recovery-pass", "--escalation", escalation,
+    ]);
+    expect(res.status).toBe(0);
+    // existing three surfaces intact
+    expect(readEvents().some((e) => e.attributes?.["event.name"] === "recovery.escalated")).toBe(true);
+    const sig = JSON.parse(readFileSync(pathJoin(orchDir, "workers", "CTL-520", "phase-recovery-pass.json"), "utf8"));
+    expect(sig.status).toBe("needs-human");
+    expect(readLedger("CTL-520").escalated).toBe(true);
+    expect(readLedger("CTL-520").verdict).toBe("escalate");
+    // NEW: the ticket-visible escalation comment is posted by the shim itself
+    const captured = readFileSync(captureFile, "utf8");
+    expect(captured).toContain("CTL-520");
+    expect(captured).toContain("pick per-host pinning or quota-aware");
+  });
+
+  test("escalated --no-comment suppresses only the comment", () => {
+    const res = runCli([
+      "escalated", "--ticket", "CTL-521", "--orch-dir", orchDir,
+      "--escalation", escalation, "--no-comment",
+    ]);
+    expect(res.status).toBe(0);
+    expect(existsSync(captureFile)).toBe(false);
+    expect(readLedger("CTL-521").escalated).toBe(true);
+  });
+});

--- a/plugins/dev/scripts/execution-core/recovery-reasoning.mjs
+++ b/plugins/dev/scripts/execution-core/recovery-reasoning.mjs
@@ -1691,6 +1691,15 @@ export const RECOVERY_MAX_ATTEMPTS =
 export const RECOVERY_TERMINAL_INTENT_TTL_MS =
   Number(process.env.CATALYST_RECOVERY_TERMINAL_TTL_DAYS) * 864e5 || 7 * 864e5;
 
+// CTL-1439 (P0a): TTL on a leave-alone verdict. A recovery-pass that reviewed the
+// ticket and concluded "no action needed" (stale flag / actively human-driven /
+// false positive) suppresses re-review for this window, then the ticket re-enters
+// (conditions change). Deliberately much longer than the 30-min action cooldown —
+// re-reviewing a verified-healthy ticket every half hour is the RC2 waste loop.
+// Env-only, matching its siblings (NaN*x and 0*x are falsy → 24h default).
+export const RECOVERY_LEAVE_ALONE_TTL_MS =
+  Number(process.env.CATALYST_RECOVERY_LEAVE_ALONE_TTL_HOURS) * 3600e3 || 24 * 3600e3;
+
 function recoveryIntentPath(orchDir, ticket) {
   return join(orchDir, ".recovery-intents", `${ticket}.json`);
 }
@@ -1780,6 +1789,10 @@ export function defaultRecordIntent(ticket, intent, opts = {}) {
     (intent.fix_class ?? prior.fix_class) === "board-health" &&
     prior.decision === "defer" &&
     typeof prior.lastTs === "number";
+  // CTL-1439 (P0a): the session's ACTUAL verdict rides in the ledger. A write that
+  // carries a verdict stamps all three fields afresh; a verdict-less write (e.g.
+  // the next dispatch marker) PRESERVES the prior verdict trail for observability.
+  const hasVerdict = typeof intent.verdict === "string";
   const entry = {
     ticket,
     ts: typeof prior.ts === "number" ? prior.ts : ts, // first-action timestamp
@@ -1791,6 +1804,13 @@ export function defaultRecordIntent(ticket, intent, opts = {}) {
         ? intent.attempts
         : (typeof prior.attempts === "number" ? prior.attempts : 0) + 1,
     escalated,
+    ...(hasVerdict || typeof prior.verdict === "string"
+      ? {
+          verdict: hasVerdict ? intent.verdict : prior.verdict,
+          verdictReason: hasVerdict ? (intent.verdictReason ?? null) : (prior.verdictReason ?? null),
+          verdictTs: hasVerdict ? ts : (prior.verdictTs ?? null),
+        }
+      : {}),
   };
 
   try {
@@ -1803,9 +1823,67 @@ export function defaultRecordIntent(ticket, intent, opts = {}) {
   return entry;
 }
 
+// recordVerdict — CTL-1439 (P0a). Persist a recovery-pass session's ACTUAL
+// conclusion into the intent ledger (the dispatch-time write is only a
+// "dispatched" marker — see holisticBoardHealthAct). Three verdicts:
+//   fixed       → decision:"fixed", attempts PINNED (the dispatch already counted
+//                 this attempt; a verdict write must not double-count it).
+//   leave-alone → decision:"leave-alone", attempts REFUNDED by one (a reviewed-
+//                 healthy pass must not burn a fix attempt — audit RC1/RC2 (d));
+//                 defaultShouldSkipItem then suppresses re-review for
+//                 RECOVERY_LEAVE_ALONE_TTL_MS.
+//   escalate    → decision:"escalate" (latches escalated:true — existing terminal
+//                 semantics; the escalated TTL governs from here).
+// Returns the written entry, or null on an unknown verdict / no orchDir.
+export function recordVerdict(ticket, { verdict, reason = null } = {}, opts = {}) {
+  if (verdict === "leave-alone") {
+    const priorAttempts = defaultReadIntentAttempts(ticket, opts);
+    return defaultRecordIntent(
+      ticket,
+      {
+        type: "recovery-pass",
+        decision: "leave-alone",
+        attempts: Math.max(priorAttempts - 1, 0),
+        verdict,
+        verdictReason: reason,
+      },
+      opts,
+    );
+  }
+  if (verdict === "fixed") {
+    const priorAttempts = defaultReadIntentAttempts(ticket, opts);
+    return defaultRecordIntent(
+      ticket,
+      {
+        type: "recovery-pass",
+        decision: "fixed",
+        attempts: priorAttempts,
+        verdict,
+        verdictReason: reason,
+      },
+      opts,
+    );
+  }
+  if (verdict === "escalate") {
+    return defaultRecordIntent(
+      ticket,
+      {
+        type: "recovery-pass",
+        decision: "escalate",
+        escalated: true,
+        verdict,
+        verdictReason: reason,
+      },
+      opts,
+    );
+  }
+  return null;
+}
+
 // defaultShouldSkipItem — true when recovery should NOT act this pass. Fail-OPEN
 // on absent/malformed ledger (returns false → recovery proceeds). Evaluation
-// order: escalated (terminal) → attempts (terminal) → cooldown (transient).
+// order: defer (cooldown-only) → escalated (terminal, TTL) → leave-alone
+// (verdict, TTL) → attempts (terminal) → cooldown (transient).
 export function defaultShouldSkipItem(ticket, opts = {}) {
   const orchDir = opts.orchDir ?? resolveOrchDir();
   if (!orchDir) return false;
@@ -1843,6 +1921,17 @@ export function defaultShouldSkipItem(ticket, opts = {}) {
     // it stays terminal. (CTL-1431 Codex F3.)
     if (typeof last !== "number") return true;
     return now() - last < RECOVERY_TERMINAL_INTENT_TTL_MS;
+  }
+
+  // (CTL-1439 P0a) a LEAVE-ALONE verdict — the pass reviewed this ticket and
+  // concluded no action is needed (stale flag / actively human-driven / false
+  // positive). Skip re-review for the leave-alone TTL, then RE-ENTER with a
+  // direct false (mirrors the escalated short-circuit above — never fall through
+  // to the attempts latch: a reviewed-healthy ticket must not dead-end there).
+  if (data?.decision === "leave-alone") {
+    const last = typeof data?.lastTs === "number" ? data.lastTs : data?.ts;
+    if (typeof last !== "number") return false; // timestamp-less verdict → fail-open, re-enter
+    return now() - last < RECOVERY_LEAVE_ALONE_TTL_MS;
   }
 
   // (b) attempts exhausted → stop self-healing.

--- a/plugins/dev/scripts/execution-core/recovery-reasoning.mjs
+++ b/plugins/dev/scripts/execution-core/recovery-reasoning.mjs
@@ -424,6 +424,10 @@ export function reasoningRecoveryPass(items, opts = {}) {
             decision: "escalate",
             reason: classification.details.reason,
             escalation: escalationPayload,
+            // CTL-1439: a genuine escalation IS the verdict — stamp it so the
+            // ledger's verdict fields always agree with the decision.
+            verdict: "escalate",
+            verdictReason: classification.details.reason ?? null,
           });
           actionLog.push("recorded escalation intent");
         } catch (err) {
@@ -1790,9 +1794,14 @@ export function defaultRecordIntent(ticket, intent, opts = {}) {
     prior.decision === "defer" &&
     typeof prior.lastTs === "number";
   // CTL-1439 (P0a): the session's ACTUAL verdict rides in the ledger. A write that
-  // carries a verdict stamps all three fields afresh; a verdict-less write (e.g.
-  // the next dispatch marker) PRESERVES the prior verdict trail for observability.
+  // carries a verdict stamps all three fields afresh. A verdict-less MARKER write
+  // (the "dispatched" dispatch marker / a "defer" hand-off) PRESERVES the prior
+  // verdict trail for observability — but a verdict-less TERMINAL/classifier write
+  // (fix / escalate / shadow) CLEARS it (Codex P2 on #2586: preserving there let
+  // a decision:"escalate" entry carry verdict:"leave-alone", corrupting the audit
+  // surface — the verdict fields must never contradict the decision).
   const hasVerdict = typeof intent.verdict === "string";
+  const isMarkerWrite = intent.decision === "dispatched" || intent.decision === "defer";
   const entry = {
     ticket,
     ts: typeof prior.ts === "number" ? prior.ts : ts, // first-action timestamp
@@ -1804,13 +1813,15 @@ export function defaultRecordIntent(ticket, intent, opts = {}) {
         ? intent.attempts
         : (typeof prior.attempts === "number" ? prior.attempts : 0) + 1,
     escalated,
-    ...(hasVerdict || typeof prior.verdict === "string"
-      ? {
-          verdict: hasVerdict ? intent.verdict : prior.verdict,
-          verdictReason: hasVerdict ? (intent.verdictReason ?? null) : (prior.verdictReason ?? null),
-          verdictTs: hasVerdict ? ts : (prior.verdictTs ?? null),
-        }
-      : {}),
+    ...(hasVerdict
+      ? { verdict: intent.verdict, verdictReason: intent.verdictReason ?? null, verdictTs: ts }
+      : isMarkerWrite && typeof prior.verdict === "string"
+        ? {
+            verdict: prior.verdict,
+            verdictReason: prior.verdictReason ?? null,
+            verdictTs: prior.verdictTs ?? null,
+          }
+        : {}),
   };
 
   try {

--- a/plugins/dev/scripts/execution-core/recovery-reasoning.test.mjs
+++ b/plugins/dev/scripts/execution-core/recovery-reasoning.test.mjs
@@ -1345,6 +1345,41 @@ describe("recordVerdict + leave-alone TTL (CTL-1439 P0a)", () => {
     expect(entry.verdictReason).toBe("merged the green PR");
     expect(entry.verdictTs).toBe(t0 + 5);
   });
+
+  test("a TERMINAL verdict-less write (fix / escalate) CLEARS stale verdict fields — the ledger never contradicts itself", () => {
+    // Codex P2 (#2586): a leave-alone verdict that ages out and then genuinely
+    // escalates must NOT carry verdict:"leave-alone" on the escalate entry.
+    const t0 = 1_000_000_000_000;
+    recordVerdict("CTL-410", { verdict: "leave-alone", reason: "healthy" }, { orchDir, now: () => t0 });
+    const escalated = defaultRecordIntent(
+      "CTL-410",
+      { decision: "escalate", reason: "now genuinely stuck" },
+      { orchDir, now: () => t0 + RECOVERY_LEAVE_ALONE_TTL_MS + 5 },
+    );
+    expect(escalated.decision).toBe("escalate");
+    expect(escalated.verdict).toBeUndefined();
+    expect(escalated.verdictReason).toBeUndefined();
+
+    recordVerdict("CTL-411", { verdict: "leave-alone", reason: "healthy" }, { orchDir, now: () => t0 });
+    const fixed = defaultRecordIntent(
+      "CTL-411",
+      { decision: "fix", fix_class: "bounded-llm" },
+      { orchDir, now: () => t0 + RECOVERY_LEAVE_ALONE_TTL_MS + 5 },
+    );
+    expect(fixed.decision).toBe("fix");
+    expect(fixed.verdict).toBeUndefined();
+  });
+
+  test("a defer MARKER write still preserves the verdict trail", () => {
+    const t0 = 1_000_000_000_000;
+    recordVerdict("CTL-412", { verdict: "leave-alone", reason: "healthy" }, { orchDir, now: () => t0 });
+    const deferred = defaultRecordIntent(
+      "CTL-412",
+      { decision: "defer", fix_class: "board-health", attempts: 0 },
+      { orchDir, now: () => t0 + 5 },
+    );
+    expect(deferred.verdict).toBe("leave-alone"); // marker writes keep the trail
+  });
 });
 
 // ─── CTL-1432 (B2): readDeferredBoardHealthIntents ──────────────────────────

--- a/plugins/dev/scripts/execution-core/recovery-reasoning.test.mjs
+++ b/plugins/dev/scripts/execution-core/recovery-reasoning.test.mjs
@@ -23,6 +23,8 @@ import {
   RECOVERY_MAX_ATTEMPTS,
   RECOVERY_COOLDOWN_MS,
   RECOVERY_TERMINAL_INTENT_TTL_MS,
+  RECOVERY_LEAVE_ALONE_TTL_MS,
+  recordVerdict,
 } from "./recovery-reasoning.mjs";
 import { mkdtempSync, rmSync, existsSync, readFileSync, mkdirSync, writeFileSync } from "node:fs";
 import { join as pathJoin } from "node:path";
@@ -1206,6 +1208,142 @@ describe("recovery-intent terminal TTL (CTL-1431)", () => {
       { orchDir, now: () => within },
     );
     expect(entry.escalated).toBe(true);
+  });
+});
+
+// ─── CTL-1439 (P0a): verdict persistence — recordVerdict + leave-alone ──────
+// A recovery-pass session's ACTUAL conclusion (fixed / leave-alone / escalate)
+// must land in the ledger instead of the dispatch-time placeholder, and a
+// leave-alone verdict must not burn a fix attempt (RC2/RC1 of the 2026-07-08
+// root-cause audit).
+describe("recordVerdict + leave-alone TTL (CTL-1439 P0a)", () => {
+  let orchDir;
+  beforeEach(() => {
+    orchDir = mkdtempSync(pathJoin(tmpdir(), "rec-verdict-"));
+  });
+  afterEach(() => {
+    try {
+      rmSync(orchDir, { recursive: true, force: true });
+    } catch {
+      /* best-effort */
+    }
+  });
+
+  const readLedger = (ticket) =>
+    JSON.parse(readFileSync(pathJoin(orchDir, ".recovery-intents", `${ticket}.json`), "utf8"));
+
+  test("leave-alone REFUNDS the dispatch attempt (attempts 2 → 1) and records the verdict", () => {
+    const t0 = 1_000_000_000_000;
+    // Two dispatch-time writes (the holistic act's auto-increment) → attempts 2.
+    defaultRecordIntent("CTL-400", { decision: "dispatched", fix_class: "board-health" }, { orchDir, now: () => t0 });
+    defaultRecordIntent("CTL-400", { decision: "dispatched", fix_class: "board-health" }, { orchDir, now: () => t0 + 1 });
+    expect(readLedger("CTL-400").attempts).toBe(2);
+
+    const entry = recordVerdict(
+      "CTL-400",
+      { verdict: "leave-alone", reason: "needs-human label is stale; human actively driving" },
+      { orchDir, now: () => t0 + 2 },
+    );
+    expect(entry.decision).toBe("leave-alone");
+    expect(entry.attempts).toBe(1); // refunded — a reviewed-healthy pass must not burn an attempt
+    expect(entry.verdict).toBe("leave-alone");
+    expect(entry.verdictReason).toBe("needs-human label is stale; human actively driving");
+    expect(typeof entry.verdictTs).toBe("number");
+  });
+
+  test("leave-alone on an absent ledger → attempts floors at 0 (never negative)", () => {
+    const entry = recordVerdict(
+      "CTL-401",
+      { verdict: "leave-alone", reason: "false positive" },
+      { orchDir, now: () => 1_000_000_000_000 },
+    );
+    expect(entry.attempts).toBe(0);
+    expect(entry.decision).toBe("leave-alone");
+  });
+
+  test("fixed PINS attempts (no double count for the same dispatch) and records the verdict", () => {
+    const t0 = 1_000_000_000_000;
+    defaultRecordIntent("CTL-402", { decision: "dispatched", fix_class: "board-health" }, { orchDir, now: () => t0 });
+    const entry = recordVerdict(
+      "CTL-402",
+      { verdict: "fixed", reason: "rebased + merged #9999" },
+      { orchDir, now: () => t0 + 1 },
+    );
+    expect(entry.decision).toBe("fixed");
+    expect(entry.attempts).toBe(1); // pinned — the dispatch already counted this attempt
+    expect(entry.verdict).toBe("fixed");
+  });
+
+  test("escalate verdict latches escalated:true (existing terminal semantics)", () => {
+    const t0 = 1_000_000_000_000;
+    const entry = recordVerdict(
+      "CTL-403",
+      { verdict: "escalate", reason: "value judgment on two valid shapes" },
+      { orchDir, now: () => t0 },
+    );
+    expect(entry.decision).toBe("escalate");
+    expect(entry.escalated).toBe(true);
+    expect(defaultShouldSkipItem("CTL-403", { orchDir, now: () => t0 + 1 })).toBe(true);
+  });
+
+  test("unknown verdict → null (no ledger write)", () => {
+    expect(recordVerdict("CTL-404", { verdict: "wat" }, { orchDir })).toBeNull();
+    expect(existsSync(pathJoin(orchDir, ".recovery-intents", "CTL-404.json"))).toBe(false);
+  });
+
+  test("shouldSkipItem: leave-alone WITHIN the TTL → skip (no re-review thrash)", () => {
+    const t0 = 1_000_000_000_000;
+    recordVerdict("CTL-405", { verdict: "leave-alone", reason: "healthy" }, { orchDir, now: () => t0 });
+    expect(
+      defaultShouldSkipItem("CTL-405", { orchDir, now: () => t0 + RECOVERY_LEAVE_ALONE_TTL_MS - 1 }),
+    ).toBe(true);
+  });
+
+  test("shouldSkipItem: leave-alone PAST the TTL → re-enters DIRECTLY, even at attempts >= max", () => {
+    const t0 = 1_000_000_000_000;
+    // Force attempts to the cap, then a leave-alone verdict (no refund path used —
+    // attempts pinned high deliberately to prove the direct-return short-circuit).
+    defaultRecordIntent("CTL-406", { decision: "dispatched", attempts: RECOVERY_MAX_ATTEMPTS }, { orchDir, now: () => t0 });
+    recordVerdict("CTL-406", { verdict: "leave-alone", reason: "healthy" }, { orchDir, now: () => t0 + 1 });
+    // Past the leave-alone TTL: must return false DIRECTLY (re-enter), not fall
+    // through to the attempts latch (mirrors the CTL-1431 escalated short-circuit).
+    expect(
+      defaultShouldSkipItem("CTL-406", { orchDir, now: () => t0 + 1 + RECOVERY_LEAVE_ALONE_TTL_MS + 1 }),
+    ).toBe(false);
+  });
+
+  test("shouldSkipItem: escalated latch takes precedence over a later leave-alone decision", () => {
+    const t0 = 1_000_000_000_000;
+    defaultRecordIntent("CTL-407", { decision: "escalate" }, { orchDir, now: () => t0 });
+    // A later leave-alone write preserves the sticky escalated latch (human-owned;
+    // only the terminal TTL or a human ages it out).
+    const entry = recordVerdict("CTL-407", { verdict: "leave-alone", reason: "looks fine" }, { orchDir, now: () => t0 + 2 });
+    expect(entry.escalated).toBe(true);
+    expect(
+      defaultShouldSkipItem("CTL-407", { orchDir, now: () => t0 + 3 + RECOVERY_LEAVE_ALONE_TTL_MS }),
+    ).toBe(true); // escalated branch (7d TTL) governs, not the shorter leave-alone TTL
+  });
+
+  test("verdict fields survive a SUBSEQUENT dispatch-time write (observability trail)", () => {
+    const t0 = 1_000_000_000_000;
+    recordVerdict("CTL-408", { verdict: "leave-alone", reason: "healthy" }, { orchDir, now: () => t0 });
+    const entry = defaultRecordIntent(
+      "CTL-408",
+      { decision: "dispatched", fix_class: "board-health" },
+      { orchDir, now: () => t0 + RECOVERY_LEAVE_ALONE_TTL_MS + 5 },
+    );
+    expect(entry.decision).toBe("dispatched");
+    expect(entry.verdict).toBe("leave-alone"); // last verdict preserved until superseded
+    expect(entry.verdictReason).toBe("healthy");
+  });
+
+  test("a NEW verdict overwrites the preserved prior verdict fields", () => {
+    const t0 = 1_000_000_000_000;
+    recordVerdict("CTL-409", { verdict: "leave-alone", reason: "healthy" }, { orchDir, now: () => t0 });
+    const entry = recordVerdict("CTL-409", { verdict: "fixed", reason: "merged the green PR" }, { orchDir, now: () => t0 + 5 });
+    expect(entry.verdict).toBe("fixed");
+    expect(entry.verdictReason).toBe("merged the green PR");
+    expect(entry.verdictTs).toBe(t0 + 5);
   });
 });
 

--- a/plugins/dev/scripts/execution-core/scheduler.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.mjs
@@ -6892,10 +6892,14 @@ export function holisticBoardHealthAct(
       reason: `board-health: ${decision?.gate?.reason ?? "board anomaly"} — holistic recovery-pass delegate`,
     });
     // Start the cooldown window on a dispatch attempt (success OR failure).
+    // CTL-1439 (P0a): this is a DISPATCH marker, not a verdict — the session's
+    // actual conclusion (fixed / leave-alone / escalate) arrives later via
+    // recovery-emit.mjs → recordVerdict. Hardcoding decision:"fix" here was RC2's
+    // "act-and-discard": the ledger claimed a fix verdict before the pass ran.
     try {
       recordIntent(cand, {
         type: "recovery-pass",
-        decision: "fix",
+        decision: "dispatched",
         fix_class: "board-health",
         outcome: !!r?.dispatched,
         source: "board-health",

--- a/plugins/dev/scripts/lib/linear-comment-post.sh
+++ b/plugins/dev/scripts/lib/linear-comment-post.sh
@@ -133,8 +133,11 @@ ISSUE_HTTP=$(curl -s -w '\n%{http_code}' -X POST "${LINEAR_API}/graphql" \
 }
 ISSUE_CODE="${ISSUE_HTTP##*$'\n'}"
 ISSUE_RESPONSE="${ISSUE_HTTP%$'\n'*}"
-if [[ "$ISSUE_CODE" != "200" ]]; then
-  ERR_DETAIL=$(printf '%s' "$ISSUE_RESPONSE" | jq -r '.errors[0].message // empty' 2>/dev/null)
+# Linear returns GraphQL errors in an `errors` array even on HTTP 200 (schema/
+# authorization failures) — check it regardless of status so the real cause is
+# named instead of collapsing into "no issue found" (Codex P3, CTL-1439).
+ERR_DETAIL=$(printf '%s' "$ISSUE_RESPONSE" | jq -r '.errors[0].message // empty' 2>/dev/null)
+if [[ "$ISSUE_CODE" != "200" || -n "$ERR_DETAIL" ]]; then
   echo "linear-comment-post: issue identifier resolution failed (HTTP ${ISSUE_CODE}${ERR_DETAIL:+; }${ERR_DETAIL})" >&2
   exit 1
 fi

--- a/plugins/dev/scripts/lib/linear-comment-post.sh
+++ b/plugins/dev/scripts/lib/linear-comment-post.sh
@@ -113,18 +113,32 @@ if [[ -z "$ACCESS_TOKEN" ]]; then
 fi
 
 # 2. Resolve ticket identifier → issue UUID.
+#    CTL-1439: `issues(filter:{identifier:{eq:...}})` no longer validates — Linear
+#    removed the `identifier` field from IssueFilter, so the old query 400s
+#    (GRAPHQL_VALIDATION_FAILED) and EVERY comment post fleet-wide silently died
+#    at this step (a root cause of the audit's "0/7 recovery-pass comments"
+#    finding). `issue(id:)` accepts the human identifier directly. Captured
+#    WITHOUT -f (mirrors the mint above) so a schema/HTTP failure surfaces its
+#    actual cause instead of a generic curl error.
 ISSUE_QUERY=$(jq -nc \
-  --arg q 'query($id:String!){issues(filter:{identifier:{eq:$id}}){nodes{id}}}' \
+  --arg q 'query($id:String!){issue(id:$id){id}}' \
   --arg id "$TICKET" \
   '{query: $q, variables: {id: $id}}')
-ISSUE_RESPONSE=$(curl -sf -X POST "${LINEAR_API}/graphql" \
+ISSUE_HTTP=$(curl -s -w '\n%{http_code}' -X POST "${LINEAR_API}/graphql" \
   -H "Content-Type: application/json" \
   -H "Authorization: Bearer ${ACCESS_TOKEN}" \
   -d "$ISSUE_QUERY" 2>/dev/null) || {
-  echo "linear-comment-post: issue identifier resolution failed" >&2
+  echo "linear-comment-post: issue identifier resolution failed (curl error)" >&2
   exit 1
 }
-ISSUE_UUID=$(printf '%s' "$ISSUE_RESPONSE" | jq -r '.data.issues.nodes[0].id // empty' 2>/dev/null)
+ISSUE_CODE="${ISSUE_HTTP##*$'\n'}"
+ISSUE_RESPONSE="${ISSUE_HTTP%$'\n'*}"
+if [[ "$ISSUE_CODE" != "200" ]]; then
+  ERR_DETAIL=$(printf '%s' "$ISSUE_RESPONSE" | jq -r '.errors[0].message // empty' 2>/dev/null)
+  echo "linear-comment-post: issue identifier resolution failed (HTTP ${ISSUE_CODE}${ERR_DETAIL:+; }${ERR_DETAIL})" >&2
+  exit 1
+fi
+ISSUE_UUID=$(printf '%s' "$ISSUE_RESPONSE" | jq -r '.data.issue.id // empty' 2>/dev/null)
 if [[ -z "$ISSUE_UUID" ]]; then
   echo "linear-comment-post: no issue found for identifier $TICKET" >&2
   exit 1

--- a/plugins/dev/skills/recovery-pass/SKILL.md
+++ b/plugins/dev/skills/recovery-pass/SKILL.md
@@ -264,7 +264,9 @@ daemon-side.
        (2) ITEMS — every item the deterministic eyes+hands flagged as YOURS (HRW-
            owned) is now UNSTUCK (resolved autonomously — rebased / resolved the
            conflict / merged the green PR / re-dispatched the dead phase / reconciled
-           the orphan PR) or ESCALATED. Before I ACT on any item I VERIFIED its LIVE
+           the orphan PR), LEAVE-ALONE-verdicted (reviewed healthy — the verdict
+           EMITTED via recovery-emit, never just concluded), or ESCALATED. Before
+           I ACT on any item I VERIFIED its LIVE
            Linear state (verify-before-act) — never the stale board cache. CONTEXT
            (another host's HRW-owned) items I read for awareness, never act on.
 
@@ -680,6 +682,15 @@ Default to ACTING. For each stuck item, walk the decision checklist top-to-botto
 first match wins. Print a per-item resolution line for every item (your own
 self-checked record of the goal — see the /goal condition section).
 
+**Every item ends in exactly ONE of three verdicts, and every verdict is EMITTED
+(CTL-1439):** `FIX` (`recovery-emit.mjs fixed`), `LEAVE-ALONE`
+(`recovery-emit.mjs leave-alone` — Step 2.5), or `ESCALATE`
+(`recovery-emit.mjs escalated` — Step 4). A conclusion that lives only in your
+transcript does not exist: the audit found 7/7 sessions reached correct verdicts
+and discarded them. Emit the verdict for the ticket you were DISPATCHED for
+(`CATALYST_TICKET`); if you also acted on other tickets along the way, emit a
+verdict for each of those separately — never tag ticket A's verdict onto ticket B.
+
 ### Step 0 — Consume the eyes + hands output (do NOT redo it)
 
 Read the brief's `diagnosis` (the diagnostician evidence) and
@@ -782,6 +793,32 @@ _rp_comment "$TICKET" "✅ **recovery-pass** unstuck this — <what I did, plain
 
 (Pairs with the INFO `recovery-emit.mjs fixed` audit event below — the comment is
 the ticket-visible signal, the event is the log record.)
+
+### Step 2.5 — Nothing is actually wrong? LEAVE ALONE (a verdict, not a skip)
+
+Sometimes the honest conclusion is that **no action is needed**: the flag is
+stale (the label survived a state the ticket has left), a false positive, or the
+ticket is **actively human-driven** (clearing the label or "fixing" the branch
+would be actively harmful — the human is hand-driving that worktree). That is a
+real verdict, not a reason to silently move on. Record it:
+
+```bash
+node "${EXEC_CORE}/recovery-emit.mjs" leave-alone \
+  --ticket "$TICKET" --orch-dir "$ORCH_DIR" \
+  --reason "<one line: why no action is needed — e.g. 'needs-human label is stale; the human is actively driving this worktree'>"
+```
+
+One call writes all three surfaces: the `recovery.verdict` event (the log
+record), the ledger verdict `decision:"leave-alone"` — which **refunds the
+dispatch attempt** (a reviewed-healthy pass must not burn a fix attempt) and
+suppresses re-review for the leave-alone window (default 24h) — and the
+ticket-visible 🔍 comment (do NOT post a separate `_rp_comment` for this; the
+shim posts it). Without this call the router re-dispatches the same review every
+cooldown until the 2-strike latch silently freezes the ticket — the exact
+act-and-discard failure this verdict exists to close.
+
+LEAVE-ALONE is for "the SYSTEM is wrong about this ticket," never for "I
+couldn't figure it out" — that is Step 2 (keep trying) or Step 3 (escalate).
 
 ### Step 3 — Escalate ONLY IF one of these is genuinely true
 
@@ -893,17 +930,11 @@ app is a thin transport over that same shared filter; there is no second filter 
 satisfy. Print that both the event and the signal explanation were written — that
 printed line is your record that the escalation landed (the goal's branch (b)).
 
-**ESCALATE comment (enforce-only, once per item).** Alongside the inbox/push
-authoring above, post a ticket-visible comment so agents see it's awaiting a human
-decision and stop re-grabbing it:
-
-```bash
-_rp_comment "$TICKET" "🔼 **recovery-pass** escalated this to the operator — <the decision needed, one line>. (See your inbox.)"
-```
-
-This is the ticket-surface counterpart to the inbox row + push (which the
-`recovery-emit.mjs escalated` curation layer authors). Keep it to one line — the
-full briefing lives in the inbox, not the comment.
+**ESCALATE comment — posted by the shim (CTL-1439).** `recovery-emit.mjs
+escalated` posts the one-line 🔼 ticket comment itself (from the payload's
+`call_to_action`), so agents see the item is awaiting a human decision and stop
+re-grabbing it. Do NOT post a separate `_rp_comment` for the escalation — that
+would double-comment. The full briefing lives in the inbox, not the comment.
 
 **On an autonomous FIX, record the win for the audit trail** (INFO, no push — the
 recovered lane, not a needs-you row). Write a plain past-tense changelog, NOT
@@ -911,9 +942,12 @@ engineer chatter:
 
 ```bash
 node "${EXEC_CORE}/recovery-emit.mjs" fixed \
-  --ticket "$TICKET" \
+  --ticket "$TICKET" --orch-dir "$ORCH_DIR" \
   --reason "Resolved the rebase conflict in eligible-set.mjs by keeping both additions; force-pushed; CI green; merged #2163."
 ```
+
+(`--orch-dir` lets the shim record the ledger verdict `decision:"fixed"` —
+CTL-1439; without it only the event is written.)
 
 ### Iterate
 
@@ -926,8 +960,8 @@ sweep) and re-resolve `SIGNAL_FILE` /the per-item brief from it, so Step 4's
 --ticket "$TICKET"` carry the real ticket — an empty `--ticket` is rejected (exit
 2) and would leave the item neither FIXED nor ESCALATED, so the goal would never
 go TRUE. The goal stays FALSE while any YOURS item is "still stuck, not yet
-escalated", so keep going. Stop only when every YOURS item is UNSTUCK or
-legitimately ESCALATED.
+escalated", so keep going. Stop only when every YOURS item is UNSTUCK,
+LEAVE-ALONE-verdicted, or legitimately ESCALATED.
 
 ## Mid-flight inbox check (CTL-749)
 
@@ -945,11 +979,12 @@ the printed per-item resolution lines are the record.)
 ```bash
 if [[ -n "$TICKET" ]]; then
   EMIT="${PLUGIN_ROOT}/scripts/phase-agent-emit-complete"
-  # complete = "I finished the recovery pass on this item" (unstuck OR escalated
-  # with the inbox+push authored). The OUTCOME (fixed vs escalated) lives in the
-  # recovery.* event + the signal explanation, not in the phase status — mirroring
-  # phase-remediate's always-complete-on-a-normal-run semantics. Reserve
-  # --status failed for the pass ITSELF breaking (the failure block below).
+  # complete = "I finished the recovery pass on this item" (unstuck, leave-alone-
+  # verdicted, OR escalated with the inbox+push authored). The OUTCOME (fixed vs
+  # leave-alone vs escalated) lives in the recovery.* event + the ledger verdict +
+  # the signal explanation, not in the phase status — mirroring phase-remediate's
+  # always-complete-on-a-normal-run semantics. Reserve --status failed for the
+  # pass ITSELF breaking (the failure block below).
   if [[ -x "$EMIT" ]]; then
     "$EMIT" --phase "recovery-pass" --ticket "$TICKET" --status complete
   fi
@@ -1006,9 +1041,11 @@ this skill plugs in beneath them — exactly where the phase-remediate dispatch 
   event-counted per-target recovery-pass cycle cap
   (`countRecoveryPassCycles ≥ RECOVERY_PASS_CYCLE_CAP`, default 3) both live in the
   router; you are not re-dispatched past them.
-- **Cooldown + escalated-latch** — the host-local intent ledger
+- **Cooldown + escalated-latch + leave-alone TTL** — the host-local intent ledger
   (`shouldSkipItem` / `recordIntent`, 30-min cooldown, max-attempts 2, escalated
-  terminal). Your Step-4 escalation latches it via `recovery-emit.mjs`.
+  terminal; a leave-alone verdict suppresses re-review for
+  `RECOVERY_LEAVE_ALONE_TTL_MS`, default 24h, and refunds the dispatch attempt).
+  Your Step-4 escalation and Step-2.5 leave-alone both latch it via `recovery-emit.mjs`.
 - **Decide/act bright line (ADR-022/023/025)** — the router DERIVES the
   classification and owns the cooldown/cap; you ACT (resolve/rebase/merge/
   re-dispatch) and emit the result back to the log. You select among real moves;


### PR DESCRIPTION
## What

Closes the **act-and-discard** gap (RC2 of the [2026-07-08 root-cause audit](../blob/main/thoughts/shared/research/2026-07-08_delegate-root-cause-audit.md)): recovery-pass sessions reached correct verdicts — "stale label, leave alone", a 3-option decision brief — and every surface discarded them (0/7 Linear comments, 4/7 no ticket-tagged event, ledger hardcoded `decision:"fix"` before the session even ran).

Every recovery-pass session now ends in exactly one **emitted verdict** — `fixed` / `leave-alone` / `escalate` — persisted to three surfaces: the unified event log (ticket-tagged), the recovery-intent ledger (the ACTUAL decision + `verdict`/`verdictReason`/`verdictTs`), and a ticket-visible app-actor Linear comment.

## Changes

- **`recovery-emit.mjs`** — new `leave-alone` subcommand (event `recovery.verdict` + ledger write + 🔍 comment, one call). `fixed` gains the ledger verdict write (attempts **pinned**). `escalated` gains verdict fields + posts the 🔼 one-line comment itself (the audit proved prompt-side comment discipline fails in practice — belt-and-braces). Comments are enforce-only (mirrors `_rp_comment`), best-effort, `--no-comment` to suppress, helper overridable via `CATALYST_COMMENT_POST_HELPER`.
- **`recovery-reasoning.mjs`** — `recordVerdict()` helper; verdict fields ride `defaultRecordIntent` (preserved across later dispatch writes, overwritten by a new verdict); `defaultShouldSkipItem` gains a **leave-alone branch**: TTL-bounded re-review suppression (`RECOVERY_LEAVE_ALONE_TTL_MS`, default 24h, env `CATALYST_RECOVERY_LEAVE_ALONE_TTL_HOURS`), **direct return on expiry** so a reviewed-healthy ticket never falls through to the attempts latch (mirrors the CTL-1431 escalated short-circuit).
- **Attempt economy (audit requirement (d))** — a `leave-alone` verdict **refunds** the dispatch attempt (`max(prior-1, 0)`); `fixed` pins (no double count); a session that crashes without a verdict leaves `decision:"dispatched"` + accrued attempts, so the 2-strike crash-loop bound is preserved (P0b/CTL-1440 makes that exhaustion loud instead of silent).
- **`scheduler.mjs` `holisticBoardHealthAct`** — dispatch-time ledger write becomes a truthful `decision:"dispatched"` marker (was the hardcoded `"fix"` that poisoned the ledger). Verified no consumer keys on the old value.
- **`recovery-pass/SKILL.md`** — LEAVE-ALONE is a first-class Step-2.5 outcome ("a verdict, not a skip"); every item ends in an emitted verdict **tagged to the dispatched ticket** (fixes the CTL-1154-verdict-on-CTL-1424 class); escalate comment moved into the shim (no double-comment).

## Tests

- `recovery-reasoning.test.mjs` **135 pass** (+10 new: refund/pin/floor semantics, TTL skip + direct-return expiry, escalated-precedence, verdict-trail preservation/overwrite)
- new `recovery-emit.test.mjs` **10 pass** (CLI-level: all three subcommands × event/ledger/comment surfaces, shadow gate, `--no-comment`, failing-helper fail-open) — registered in the CI allowlist
- `board-health-seam.test.mjs` 9 pass (+ truthful-marker assertion), `board-health.test.mjs` 102 pass, `sweep-stale-recovery-intents` 7 pass
- `bun build daemon.mjs` import graph resolves

## Namespace safety

`recovery.verdict` checked against `broker/namespace-contract.mjs`: outside `FORBIDDEN_PREFIXES`/`PROTECTED_EXACT_NAMES`, doesn't match `PHASE_EVENT_PATTERN` — no parity-test changes needed.

Part of **CTL-1157** (P0a). Next: CTL-1440 (P0b — attempts-exhausted → escalate + needs-human, never silent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)