### PR TITLE
fix(dev): CTL-1442 (P1-loop-1) — no-progress escalations go terminal after N asks (stop the every-10-min forever loop)

### DIFF
--- a/plugins/dev/scripts/execution-core/label-guard.mjs
+++ b/plugins/dev/scripts/execution-core/label-guard.mjs
@@ -299,8 +299,28 @@ export function inRemovalBackoff(orchDir, ticket, label, now) {
 export const ESCALATION_COOLDOWN_MS =
   Number(process.env.RECOVERY_ESCALATION_COOLDOWN_MS) || 10 * 60 * 1000;
 
+// CTL-1442: consecutive same-reason asks before an escalation goes TERMINAL.
+// The 10-min cooldown above only THROTTLES re-emission — with no cap, a
+// no-progress ticket asks "authorize retry?" every window forever (ADV-1374/
+// ADV-1376 fired for days; audit RC4) because nothing consumes the ask and
+// nothing ever transitions the ticket. After this many asks the escalation
+// site parks the ticket terminally instead of asking again.
+export const ESCALATION_ASK_CAP = Number(process.env.CATALYST_ESCALATION_ASK_CAP) || 3;
+
 export function escalationCooldownPath(orchDir, ticket, phase) {
   return join(orchDir, ".escalation-cooldowns", `${ticket}-${phase}.json`);
+}
+
+// readEscalationRecord — CTL-1442: the full cool-down marker (reason, askCount,
+// asks[] history), for the ask-cap gate + truthful `attempts` event payloads.
+// Absent/malformed → null (fail-open — the cap only ever under-counts).
+export function readEscalationRecord(orchDir, ticket, phase) {
+  try {
+    const data = JSON.parse(readFileSync(escalationCooldownPath(orchDir, ticket, phase), "utf8"));
+    return data && typeof data === "object" ? data : null;
+  } catch {
+    return null;
+  }
 }
 
 export function inEscalationCooldown(orchDir, ticket, phase, now) {
@@ -368,9 +388,16 @@ export function recordEscalation(orchDir, ticket, phase, reason, now) {
   const dir = join(orchDir, ".escalation-cooldowns");
   try {
     mkdirSync(dir, { recursive: true });
+    // CTL-1442: accrue the consecutive same-reason ask count (+ a bounded ask
+    // history for truthful event payloads). A DIFFERENT reason restarts the
+    // count — it is a new question to the operator, not a repeat of the last.
+    const prior = readEscalationRecord(orchDir, ticket, phase);
+    const sameReason = prior?.reason === reason;
+    const askCount = sameReason && typeof prior?.askCount === "number" ? prior.askCount + 1 : 1;
+    const asks = [...(sameReason && Array.isArray(prior?.asks) ? prior.asks : []).slice(-9), now];
     writeFileSync(
       escalationCooldownPath(orchDir, ticket, phase),
-      JSON.stringify({ ticket, phase, reason, escalatedAt: now })
+      JSON.stringify({ ticket, phase, reason, escalatedAt: now, askCount, asks })
     );
   } catch (err) {
     // Never let a marker write crash the tick — worst case is the next tick

--- a/plugins/dev/scripts/execution-core/label-guard.test.mjs
+++ b/plugins/dev/scripts/execution-core/label-guard.test.mjs
@@ -11,6 +11,7 @@ import {
   clearStalledLabel,
   inEscalationCooldown,
   recordEscalation,
+  readEscalationRecord,
   escalationCooldownPath,
   ESCALATION_COOLDOWN_MS,
   recordRemovalFailure,
@@ -251,7 +252,58 @@ describe("inEscalationCooldown / recordEscalation", () => {
       phase: "monitor-merge",
       reason: "revive-budget-exhausted",
       escalatedAt: 9_876_543,
+      // CTL-1442: the ask-cap fields ride the same marker.
+      askCount: 1,
+      asks: [9_876_543],
     });
+  });
+
+  // ─── CTL-1442: consecutive-ask counting on the cool-down marker ───
+
+  test("same-reason asks accrue askCount + a bounded ask history", () => {
+    recordEscalation(orchDir, "CTL-9", "pr", "no-progress", 1_000);
+    recordEscalation(orchDir, "CTL-9", "pr", "no-progress", 2_000);
+    recordEscalation(orchDir, "CTL-9", "pr", "no-progress", 3_000);
+    const rec = readEscalationRecord(orchDir, "CTL-9", "pr");
+    expect(rec.askCount).toBe(3);
+    expect(rec.asks).toEqual([1_000, 2_000, 3_000]);
+  });
+
+  test("a DIFFERENT reason restarts the count (a new question, not a repeat)", () => {
+    recordEscalation(orchDir, "CTL-9", "pr", "no-progress", 1_000);
+    recordEscalation(orchDir, "CTL-9", "pr", "no-progress", 2_000);
+    recordEscalation(orchDir, "CTL-9", "pr", "wedged-never-started", 3_000);
+    const rec = readEscalationRecord(orchDir, "CTL-9", "pr");
+    expect(rec.askCount).toBe(1);
+    expect(rec.asks).toEqual([3_000]);
+  });
+
+  test("the ask history is bounded to the last 10 entries", () => {
+    for (let i = 1; i <= 14; i++) {
+      recordEscalation(orchDir, "CTL-9", "pr", "no-progress", i * 1_000);
+    }
+    const rec = readEscalationRecord(orchDir, "CTL-9", "pr");
+    expect(rec.askCount).toBe(14);
+    expect(rec.asks.length).toBe(10);
+    expect(rec.asks[rec.asks.length - 1]).toBe(14_000);
+  });
+
+  test("readEscalationRecord: absent/malformed → null (fail-open)", () => {
+    expect(readEscalationRecord(orchDir, "CTL-none", "pr")).toBeNull();
+    mkdirSync(join(orchDir, ".escalation-cooldowns"), { recursive: true });
+    writeFileSync(escalationCooldownPath(orchDir, "CTL-bad", "pr"), "not json");
+    expect(readEscalationRecord(orchDir, "CTL-bad", "pr")).toBeNull();
+  });
+
+  test("a LEGACY marker (no askCount) counts as a fresh ask on the next record", () => {
+    mkdirSync(join(orchDir, ".escalation-cooldowns"), { recursive: true });
+    writeFileSync(
+      escalationCooldownPath(orchDir, "CTL-9", "pr"),
+      JSON.stringify({ ticket: "CTL-9", phase: "pr", reason: "no-progress", escalatedAt: 500 })
+    );
+    recordEscalation(orchDir, "CTL-9", "pr", "no-progress", 1_000);
+    const rec = readEscalationRecord(orchDir, "CTL-9", "pr");
+    expect(rec.askCount).toBe(1); // legacy marker had no count → restart at 1
   });
 
   test("recordEscalation swallows mkdir/writeFile failures (warn-only, no throw)", () => {

--- a/plugins/dev/scripts/execution-core/recovery.mjs
+++ b/plugins/dev/scripts/execution-core/recovery.mjs
@@ -2221,13 +2221,9 @@ export function reclaimDeadWorkIfPossible(
         ? priorEscRecord.askCount
         : 0;
     const capApplies = reason === "no-progress";
-    if (capApplies && priorAsks >= escalationAskCap) {
-      log.debug(
-        { ticket, phase, reason, priorAsks },
-        "ctl-1442: escalation ask-cap already reached — not re-asking"
-      );
-      return "escalation-capped";
-    }
+    // (the cap early-return lives AFTER the explanation build below, so a
+    // failed/interrupted terminal flip can be re-asserted with a fresh brief —
+    // Codex P2 on #2590.)
     // CTL-1130: build a typed-union explanation classified by the three gates.
     // push_rejected_no_workflow_scope → MANUAL (capability boundary, D-recovery);
     // all other reasons → AUTHORIZATION (agent can retry with authority).
@@ -2276,6 +2272,30 @@ export function reclaimDeadWorkIfPossible(
         phase,
         canExecute: escType !== "manual",
       });
+    }
+    // CTL-1442: the ask-cap is already spent. Normally the cap-consuming ask
+    // flipped the signal terminal below — but if that write failed (or the
+    // process died between the record and the flip), the dead running signal
+    // would occupy capacity FOREVER while events stay suppressed (Codex P2).
+    // Re-assert the flip idempotently (skip when already stalled), never
+    // re-emit the event/label.
+    if (capApplies && priorAsks >= escalationAskCap) {
+      let already = null;
+      try {
+        already = JSON.parse(
+          readFileSync(join(orchDir, "workers", ticket, `phase-${phase}.json`), "utf8"),
+        )?.status;
+      } catch {
+        /* absent/malformed → re-assert below */
+      }
+      if (already !== "stalled") {
+        markEscalationCapTerminal({ orchDir, ticket, phase, explanation });
+        log.warn(
+          { ticket, phase, reason, priorAsks },
+          "ctl-1442: ask-cap spent but the signal was not terminal — re-asserted the stalled flip"
+        );
+      }
+      return "escalation-capped";
     }
     const enrichedExtras = { ...(extras ?? {}), explanation };
     appendEscalatedEvent({

--- a/plugins/dev/scripts/execution-core/recovery.mjs
+++ b/plugins/dev/scripts/execution-core/recovery.mjs
@@ -93,6 +93,8 @@ import {
   labelOnce,
   inEscalationCooldown as defaultInEscalationCooldown,
   recordEscalation as defaultRecordEscalation,
+  readEscalationRecord as defaultReadEscalationRecord, // CTL-1442: ask-cap gate
+  ESCALATION_ASK_CAP, // CTL-1442
   labelNeedsHumanUnlessBeliefOwner,
 } from "./label-guard.mjs";
 import { countReviveEvents as defaultCountReviveEvents, hasCompleteEvent } from "./event-scan.mjs";
@@ -1837,6 +1839,37 @@ function defaultWriteProgressMark(orchDir, ticket, phase, value) {
 // (appendReviveEvent, appendEscalatedEvent, reviveDispatch, applyStalledLabel,
 // killBgJob, countReviveEvents, writeReviveMarker) + the CTL-638 cool-down +
 // CTL-679 breaker. All have real defaults for prod; tests override every one.
+// markEscalationCapTerminal — CTL-1442. Flip a phase signal to a TERMINAL
+// stalled state after the escalation ask-cap is consumed, persisting the
+// curated CTL-1130 explanation on the signal so the monitor's Needs-You inbox
+// (board-data deriveExplanation, newest-signal-first) renders the final brief.
+// A terminal signal drops the ticket from the reclaim sweep's working set, so
+// the every-cool-down re-ask loop (audit RC4) ends here. Read-modify-write,
+// atomic tmp+rename (mirrors defaultReviveDispatch's signal reset). Never
+// throws — a failed flip falls back to the escalateOnce ask-cap early-return.
+function markEscalationCapTerminal({ orchDir, ticket, phase, explanation }) {
+  const signalPath = join(orchDir, "workers", ticket, `phase-${phase}.json`);
+  try {
+    mkdirSync(dirname(signalPath), { recursive: true });
+    const sig = existsSync(signalPath) ? JSON.parse(readFileSync(signalPath, "utf8")) : {};
+    sig.status = "stalled";
+    sig.stalledReason = "escalation-ask-cap";
+    sig.explanation = explanation;
+    if (!sig.needsHumanSince) sig.needsHumanSince = new Date().toISOString();
+    sig.updatedAt = new Date().toISOString().replace(/\.\d{3}Z$/, "Z");
+    const tmp = `${signalPath}.tmp.${process.pid}`;
+    writeFileSync(tmp, JSON.stringify(sig, null, 2));
+    renameSync(tmp, signalPath);
+    return true;
+  } catch (err) {
+    log.warn(
+      { ticket, phase, err: err.message },
+      "ctl-1442: escalation-cap terminal signal write failed — the ask-cap early-return still suppresses re-asks"
+    );
+    return false;
+  }
+}
+
 export function reclaimDeadWorkIfPossible(
   orchDir,
   signal,
@@ -1877,6 +1910,15 @@ export function reclaimDeadWorkIfPossible(
     // I/O, or to drive the cool-down clock independently of `now`.
     inEscalationCooldownFn = defaultInEscalationCooldown,
     recordEscalationFn = defaultRecordEscalation,
+    // CTL-1442 — the ask-cap gate: after escalationAskCap consecutive same-reason
+    // no-progress asks (default 3, env CATALYST_ESCALATION_ASK_CAP) the
+    // escalation goes TERMINAL (stalled signal + persisted brief) instead of
+    // re-asking every cool-down window forever (ADV-1374/1376 fired for days;
+    // audit RC4). Scoped to reason "no-progress" — the alive busy-ceiling and
+    // no-probe asks keep their existing unbounded-but-throttled behavior (their
+    // signals belong to live workers a terminal flip could fight).
+    readEscalationRecordFn = defaultReadEscalationRecord,
+    escalationAskCap = ESCALATION_ASK_CAP,
     // CTL-606 — supersede guard. Returns the ticket's dispatched phase names so
     // the guard can detect a dead signal the pipeline has already advanced past.
     listTicketPhases = (t) => listDispatchedPhases(orchDir, t),
@@ -2168,6 +2210,24 @@ export function reclaimDeadWorkIfPossible(
     if (inEscalationCooldownFn(orchDir, ticket, phase, now())) {
       return "escalation-suppressed";
     }
+    // CTL-1442: the ask-cap gate (no-progress only). Consecutive same-reason
+    // asks are counted in the cool-down marker; once the ticket has already
+    // been parked terminal (askCount >= cap), never re-ask — belt for the case
+    // where the terminal signal flip below failed and the sweep still sees a
+    // reclaim-eligible signal.
+    const priorEscRecord = readEscalationRecordFn(orchDir, ticket, phase);
+    const priorAsks =
+      priorEscRecord?.reason === reason && typeof priorEscRecord?.askCount === "number"
+        ? priorEscRecord.askCount
+        : 0;
+    const capApplies = reason === "no-progress";
+    if (capApplies && priorAsks >= escalationAskCap) {
+      log.debug(
+        { ticket, phase, reason, priorAsks },
+        "ctl-1442: escalation ask-cap already reached — not re-asking"
+      );
+      return "escalation-capped";
+    }
     // CTL-1130: build a typed-union explanation classified by the three gates.
     // push_rejected_no_workflow_scope → MANUAL (capability boundary, D-recovery);
     // all other reasons → AUTHORIZATION (agent can retry with authority).
@@ -2201,7 +2261,10 @@ export function reclaimDeadWorkIfPossible(
             could_higher_tier_resolve: tierProducer(extras?.model ?? signal?.raw?.model),
             authorize_label: `retry ${ticket} ${phase}`,
             observed: { final_attempt_count: finalAttemptCount, ...(extras?.observed ?? {}) },
-            attempts: extras?.attempts ?? [],
+            // CTL-1442: truthful ask history — this call site historically passed
+            // no extras, so the payload showed attempts:[] forever while asking
+            // "authorize retry?" every window (audit RC4).
+            attempts: extras?.attempts ?? (Array.isArray(priorEscRecord?.asks) ? priorEscRecord.asks : []),
           };
     try {
       explanation = buildExplanation(explanationFields);
@@ -2225,6 +2288,19 @@ export function reclaimDeadWorkIfPossible(
     });
     applyStalledLabel({ orchDir, ticket });
     recordEscalationFn(orchDir, ticket, phase, reason, now());
+    // CTL-1442: this ask consumed the cap → go TERMINAL. Flip the phase signal
+    // to stalled with the curated explanation persisted on it (deriveExplanation
+    // renders it in the monitor's Needs-You inbox), so the reclaim sweep stops
+    // re-evaluating the ticket and the operator sees ONE final, complete ask
+    // instead of an endless every-10-min echo.
+    if (capApplies && priorAsks + 1 >= escalationAskCap) {
+      markEscalationCapTerminal({ orchDir, ticket, phase, explanation });
+      log.warn(
+        { ticket, phase, reason, asks: priorAsks + 1 },
+        "ctl-1442: escalation ask-cap reached — parked terminal (stalled + needs-human + brief); delete the .escalation-cooldowns marker to re-arm"
+      );
+      return "escalation-cap-terminal";
+    }
     log.warn({ ticket, phase, reason }, "ctl-587: escalated");
     return "escalated";
   }

--- a/plugins/dev/scripts/execution-core/recovery.mjs
+++ b/plugins/dev/scripts/execution-core/recovery.mjs
@@ -1851,7 +1851,17 @@ function markEscalationCapTerminal({ orchDir, ticket, phase, explanation }) {
   const signalPath = join(orchDir, "workers", ticket, `phase-${phase}.json`);
   try {
     mkdirSync(dirname(signalPath), { recursive: true });
-    const sig = existsSync(signalPath) ? JSON.parse(readFileSync(signalPath, "utf8")) : {};
+    // Codex R4: a truncated/malformed signal must be treated like a MISSING one
+    // (parse failure must not abort the rewrite — readWorkerSignals skips
+    // malformed files, so leaving it broken loses the inbox association).
+    let sig = {};
+    if (existsSync(signalPath)) {
+      try {
+        sig = JSON.parse(readFileSync(signalPath, "utf8")) ?? {};
+      } catch {
+        sig = {};
+      }
+    }
     // Codex R3: when re-creating a removed/unreadable signal, seed identity —
     // readWorkerSignals derives ticket/phase from the BODY, not the path, and a
     // ticket:null stalled row breaks the Needs-You association.
@@ -2208,16 +2218,13 @@ export function reclaimDeadWorkIfPossible(
     // Defer: skip the audit event + label write entirely (no cool-down record,
     // so a genuine escalation re-fires cleanly once the breaker closes). A
     // transient 429 is not a human-intervention condition.
-    if (breaker.isOpen(now())) {
-      log.warn({ ticket, phase, reason }, "ctl-679: escalation deferred — Linear breaker open");
-      return "rate-limited-deferred";
-    }
     // CTL-1442: the ask-cap state (no-progress only). Consecutive same-reason
     // asks are counted in the cool-down marker; a spent cap means the ticket was
     // parked terminal (or should have been — the flip can be lost to a crash).
-    // Read BEFORE the cooldown gate so a lost flip is re-asserted even inside
-    // the window (Codex R2: waiting out the cooldown leaves a dead running
-    // signal counted as in-flight, blocking slots at maxParallel=1).
+    // Read BEFORE the breaker AND cooldown gates (Codex R2/R4): the terminal
+    // rewrite is purely LOCAL, so neither an open Linear breaker nor the
+    // cool-down window may defer repairing a lost flip — a dead running signal
+    // would otherwise hold a slot for the whole outage/window.
     const priorEscRecord = readEscalationRecordFn(orchDir, ticket, phase);
     const priorAsks =
       priorEscRecord?.reason === reason && typeof priorEscRecord?.askCount === "number"
@@ -2241,6 +2248,11 @@ export function reclaimDeadWorkIfPossible(
         "ctl-1442: ask-cap spent but the signal was not terminal — re-asserted the stalled flip"
       );
     };
+    if (breaker.isOpen(now())) {
+      if (capSpent) reassertTerminalIfLost(); // local-only repair — no Linear I/O
+      log.warn({ ticket, phase, reason }, "ctl-679: escalation deferred — Linear breaker open");
+      return "rate-limited-deferred";
+    }
     if (inEscalationCooldownFn(orchDir, ticket, phase, now())) {
       if (capSpent) reassertTerminalIfLost();
       return "escalation-suppressed";

--- a/plugins/dev/scripts/execution-core/recovery.mjs
+++ b/plugins/dev/scripts/execution-core/recovery.mjs
@@ -2207,26 +2207,45 @@ export function reclaimDeadWorkIfPossible(
       log.warn({ ticket, phase, reason }, "ctl-679: escalation deferred — Linear breaker open");
       return "rate-limited-deferred";
     }
-    if (inEscalationCooldownFn(orchDir, ticket, phase, now())) {
-      return "escalation-suppressed";
-    }
-    // CTL-1442: the ask-cap gate (no-progress only). Consecutive same-reason
-    // asks are counted in the cool-down marker; once the ticket has already
-    // been parked terminal (askCount >= cap), never re-ask — belt for the case
-    // where the terminal signal flip below failed and the sweep still sees a
-    // reclaim-eligible signal.
+    // CTL-1442: the ask-cap state (no-progress only). Consecutive same-reason
+    // asks are counted in the cool-down marker; a spent cap means the ticket was
+    // parked terminal (or should have been — the flip can be lost to a crash).
+    // Read BEFORE the cooldown gate so a lost flip is re-asserted even inside
+    // the window (Codex R2: waiting out the cooldown leaves a dead running
+    // signal counted as in-flight, blocking slots at maxParallel=1).
     const priorEscRecord = readEscalationRecordFn(orchDir, ticket, phase);
     const priorAsks =
       priorEscRecord?.reason === reason && typeof priorEscRecord?.askCount === "number"
         ? priorEscRecord.askCount
         : 0;
     const capApplies = reason === "no-progress";
-    // (the cap early-return lives AFTER the explanation build below, so a
-    // failed/interrupted terminal flip can be re-asserted with a fresh brief —
-    // Codex P2 on #2590.)
+    const capSpent = capApplies && priorAsks >= escalationAskCap;
+    const reassertTerminalIfLost = () => {
+      let already = null;
+      try {
+        already = JSON.parse(
+          readFileSync(join(orchDir, "workers", ticket, `phase-${phase}.json`), "utf8"),
+        )?.status;
+      } catch {
+        /* absent/malformed → re-assert below */
+      }
+      if (already === "stalled") return;
+      markEscalationCapTerminal({ orchDir, ticket, phase, explanation: buildEscExplanation() });
+      log.warn(
+        { ticket, phase, reason, priorAsks },
+        "ctl-1442: ask-cap spent but the signal was not terminal — re-asserted the stalled flip"
+      );
+    };
+    if (inEscalationCooldownFn(orchDir, ticket, phase, now())) {
+      if (capSpent) reassertTerminalIfLost();
+      return "escalation-suppressed";
+    }
     // CTL-1130: build a typed-union explanation classified by the three gates.
     // push_rejected_no_workflow_scope → MANUAL (capability boundary, D-recovery);
     // all other reasons → AUTHORIZATION (agent can retry with authority).
+    // CTL-1442: wrapped as a (pure) builder so the spent-cap re-assert can
+    // produce a fresh brief lazily without duplicating the CTL-1130 logic.
+    function buildEscExplanation() {
     const escType = reasonToType(reason);
     const whyField = reasonToWhyField(reason, finalAttemptCount);
     let explanation;
@@ -2259,8 +2278,14 @@ export function reclaimDeadWorkIfPossible(
             observed: { final_attempt_count: finalAttemptCount, ...(extras?.observed ?? {}) },
             // CTL-1442: truthful ask history — this call site historically passed
             // no extras, so the payload showed attempts:[] forever while asking
-            // "authorize retry?" every window (audit RC4).
-            attempts: extras?.attempts ?? (Array.isArray(priorEscRecord?.asks) ? priorEscRecord.asks : []),
+            // "authorize retry?" every window (audit RC4). Scoped to the SAME
+            // reason (Codex R2): a fresh no-progress ask must not inherit an
+            // unrelated wedged-never-started history.
+            attempts:
+              extras?.attempts ??
+              (priorEscRecord?.reason === reason && Array.isArray(priorEscRecord?.asks)
+                ? priorEscRecord.asks
+                : []),
           };
     try {
       explanation = buildExplanation(explanationFields);
@@ -2273,30 +2298,16 @@ export function reclaimDeadWorkIfPossible(
         canExecute: escType !== "manual",
       });
     }
-    // CTL-1442: the ask-cap is already spent. Normally the cap-consuming ask
-    // flipped the signal terminal below — but if that write failed (or the
-    // process died between the record and the flip), the dead running signal
-    // would occupy capacity FOREVER while events stay suppressed (Codex P2).
-    // Re-assert the flip idempotently (skip when already stalled), never
-    // re-emit the event/label.
-    if (capApplies && priorAsks >= escalationAskCap) {
-      let already = null;
-      try {
-        already = JSON.parse(
-          readFileSync(join(orchDir, "workers", ticket, `phase-${phase}.json`), "utf8"),
-        )?.status;
-      } catch {
-        /* absent/malformed → re-assert below */
-      }
-      if (already !== "stalled") {
-        markEscalationCapTerminal({ orchDir, ticket, phase, explanation });
-        log.warn(
-          { ticket, phase, reason, priorAsks },
-          "ctl-1442: ask-cap spent but the signal was not terminal — re-asserted the stalled flip"
-        );
-      }
+    return explanation;
+    }
+    // CTL-1442: the ask-cap is already spent (and we are OUTSIDE the cooldown —
+    // the in-window case re-asserted above). Re-assert the flip idempotently,
+    // never re-emit the event/label.
+    if (capSpent) {
+      reassertTerminalIfLost();
       return "escalation-capped";
     }
+    const explanation = buildEscExplanation();
     const enrichedExtras = { ...(extras ?? {}), explanation };
     appendEscalatedEvent({
       phase,

--- a/plugins/dev/scripts/execution-core/recovery.mjs
+++ b/plugins/dev/scripts/execution-core/recovery.mjs
@@ -1852,6 +1852,11 @@ function markEscalationCapTerminal({ orchDir, ticket, phase, explanation }) {
   try {
     mkdirSync(dirname(signalPath), { recursive: true });
     const sig = existsSync(signalPath) ? JSON.parse(readFileSync(signalPath, "utf8")) : {};
+    // Codex R3: when re-creating a removed/unreadable signal, seed identity —
+    // readWorkerSignals derives ticket/phase from the BODY, not the path, and a
+    // ticket:null stalled row breaks the Needs-You association.
+    if (!sig.ticket) sig.ticket = ticket;
+    if (!sig.phase) sig.phase = phase;
     sig.status = "stalled";
     sig.stalledReason = "escalation-ask-cap";
     sig.explanation = explanation;

--- a/plugins/dev/scripts/execution-core/recovery.test.mjs
+++ b/plugins/dev/scripts/execution-core/recovery.test.mjs
@@ -48,6 +48,7 @@ import { saveCursor } from "./event-cursor.mjs";
 import { dropProject } from "./eligible-set.mjs";
 import { existsSync, appendFileSync, chmodSync } from "node:fs";
 import { recordEscalation } from "./label-guard.mjs"; // CTL-1442: seed reason-change scenarios
+import { defaultClearStall } from "./scheduler.mjs"; // CTL-1442: operator re-arm resets the ask budget
 import { WORK_DONE_PROBES } from "./work-done-probes.mjs";
 
 let orchDir;
@@ -2727,6 +2728,44 @@ describe("reclaimDeadWorkIfPossible — CTL-1442 escalation ask-cap", () => {
     const attempts = secondAsk.extras?.explanation?.attempts;
     expect(Array.isArray(attempts)).toBe(true);
     expect(attempts.length).toBeGreaterThanOrEqual(1);
+  });
+
+  test("a lost terminal flip is RE-ASSERTED on the next sweep (no silent capacity leak)", () => {
+    let clock = 20_000_000;
+    const s = setupAt(orchDir);
+    s.opts.now = () => clock;
+    for (let ask = 1; ask <= 3; ask++) {
+      reclaimDeadWorkIfPossible(s.orch, s.sig, s.opts);
+      clock += 10 * 60 * 1000 + 1;
+    }
+    const sigPath = join(orchDir, "workers", "CTL-9", "phase-pr.json");
+    expect(JSON.parse(readFileSync(sigPath, "utf8")).status).toBe("stalled");
+    // Simulate the flip being lost (crash between record and write / manual rm).
+    rmSync(sigPath, { force: true });
+    reclaimDeadWorkIfPossible(s.orch, s.sig, s.opts);
+    // Re-asserted terminal, but NO new event (the cap stays spent).
+    expect(JSON.parse(readFileSync(sigPath, "utf8")).status).toBe("stalled");
+    expect(s.opts.appendEscalatedEvent.calls.length).toBe(3);
+  });
+
+  test("defaultClearStall re-arms the ask budget (operator re-arm = fresh cycle)", () => {
+    let clock = 30_000_000;
+    const s = setupAt(orchDir);
+    s.opts.now = () => clock;
+    for (let ask = 1; ask <= 3; ask++) {
+      reclaimDeadWorkIfPossible(s.orch, s.sig, s.opts);
+      clock += 10 * 60 * 1000 + 1;
+    }
+    expect(s.opts.appendEscalatedEvent.calls.length).toBe(3); // cap spent
+    // Operator replies → the stall janitor clears the stall; it must also
+    // remove the escalation-cooldown marker so the retry gets fresh asks.
+    defaultClearStall(orchDir, {})({ ticket: "CTL-9", phase: "pr" });
+    expect(
+      existsSync(join(orchDir, ".escalation-cooldowns", "CTL-9-pr.json")),
+    ).toBe(false);
+    // The retried phase no-progresses again → a FRESH ask fires (count restarted).
+    reclaimDeadWorkIfPossible(s.orch, s.sig, s.opts);
+    expect(s.opts.appendEscalatedEvent.calls.length).toBe(4);
   });
 
   test("a DIFFERENT escalation reason does not consume the no-progress cap (reason change resets the count)", () => {

--- a/plugins/dev/scripts/execution-core/recovery.test.mjs
+++ b/plugins/dev/scripts/execution-core/recovery.test.mjs
@@ -2789,6 +2789,39 @@ describe("reclaimDeadWorkIfPossible — CTL-1442 escalation ask-cap", () => {
     expect(s.opts.appendEscalatedEvent.calls.length).toBe(3); // still no new events
   });
 
+  test("(R4) a lost flip is repaired even while the Linear breaker is OPEN (local-only rewrite)", () => {
+    let clock = 60_000_000;
+    const s = setupAt(orchDir);
+    s.opts.now = () => clock;
+    for (let ask = 1; ask <= 3; ask++) {
+      reclaimDeadWorkIfPossible(s.orch, s.sig, s.opts);
+      clock += 10 * 60 * 1000 + 1;
+    }
+    const sigPath = join(orchDir, "workers", "CTL-9", "phase-pr.json");
+    rmSync(sigPath, { force: true });
+    // breaker OPEN: the repair still lands (no Linear I/O involved)
+    s.opts.breaker = { isOpen: () => true, recordRateLimited: () => {} };
+    reclaimDeadWorkIfPossible(s.orch, s.sig, s.opts);
+    expect(JSON.parse(readFileSync(sigPath, "utf8")).status).toBe("stalled");
+    expect(s.opts.appendEscalatedEvent.calls.length).toBe(3); // no new events
+  });
+
+  test("(R4) a MALFORMED signal is rewritten like a missing one (parse failure cannot orphan the row)", () => {
+    let clock = 70_000_000;
+    const s = setupAt(orchDir);
+    s.opts.now = () => clock;
+    for (let ask = 1; ask <= 3; ask++) {
+      reclaimDeadWorkIfPossible(s.orch, s.sig, s.opts);
+      clock += 10 * 60 * 1000 + 1;
+    }
+    const sigPath = join(orchDir, "workers", "CTL-9", "phase-pr.json");
+    writeFileSync(sigPath, "{truncated"); // corrupt it
+    reclaimDeadWorkIfPossible(s.orch, s.sig, s.opts);
+    const repaired = JSON.parse(readFileSync(sigPath, "utf8"));
+    expect(repaired.status).toBe("stalled");
+    expect(repaired.ticket).toBe("CTL-9");
+  });
+
   test("(R2) the attempts history never inherits a DIFFERENT reason's asks", () => {
     let clock = 50_000_000;
     const s = setupAt(orchDir);

--- a/plugins/dev/scripts/execution-core/recovery.test.mjs
+++ b/plugins/dev/scripts/execution-core/recovery.test.mjs
@@ -2744,7 +2744,12 @@ describe("reclaimDeadWorkIfPossible — CTL-1442 escalation ask-cap", () => {
     rmSync(sigPath, { force: true });
     reclaimDeadWorkIfPossible(s.orch, s.sig, s.opts);
     // Re-asserted terminal, but NO new event (the cap stays spent).
-    expect(JSON.parse(readFileSync(sigPath, "utf8")).status).toBe("stalled");
+    const reasserted = JSON.parse(readFileSync(sigPath, "utf8"));
+    expect(reasserted.status).toBe("stalled");
+    // Codex R3: the re-created body carries identity — readWorkerSignals derives
+    // ticket/phase from the JSON, and a null-ticket stalled row breaks the inbox.
+    expect(reasserted.ticket).toBe("CTL-9");
+    expect(reasserted.phase).toBe("pr");
     expect(s.opts.appendEscalatedEvent.calls.length).toBe(3);
   });
 

--- a/plugins/dev/scripts/execution-core/recovery.test.mjs
+++ b/plugins/dev/scripts/execution-core/recovery.test.mjs
@@ -47,6 +47,7 @@ import {
 import { saveCursor } from "./event-cursor.mjs";
 import { dropProject } from "./eligible-set.mjs";
 import { existsSync, appendFileSync, chmodSync } from "node:fs";
+import { recordEscalation } from "./label-guard.mjs"; // CTL-1442: seed reason-change scenarios
 import { WORK_DONE_PROBES } from "./work-done-probes.mjs";
 
 let orchDir;
@@ -2627,6 +2628,122 @@ describe("reclaimDeadWorkIfPossible — CTL-638 escalation storm prevention", ()
       orchDir: s.orch,
       ticket: "CTL-9",
     });
+  });
+});
+
+// --- CTL-1442: no-progress escalation ask-cap → terminal, never re-ask forever
+//
+// ADV-1374/1376 fired `phase.triage.escalated` (`reason:"no-progress"`) every
+// cool-down window for DAYS (audit RC4): the 10-min cool-down only throttles,
+// nothing ever transitioned the ticket, and the broker cannot consume the
+// `escalated` action. After ESCALATION_ASK_CAP consecutive same-reason asks the
+// escalation now goes terminal: the phase signal flips to stalled with the
+// curated explanation persisted (→ the monitor Needs-You inbox), and further
+// sweeps stop emitting.
+describe("reclaimDeadWorkIfPossible — CTL-1442 escalation ask-cap", () => {
+  let orchDir;
+  beforeEach(() => {
+    orchDir = mkdtempSync(join(tmpdir(), "ctl1442-"));
+  });
+  afterEach(() => {
+    rmSync(orchDir, { recursive: true, force: true });
+  });
+
+  function setupAt(orchPath, overrides = {}) {
+    const sig = {
+      ...implementSignal({ ticket: "CTL-9", status: "running", bgJobId: "bg-9" }),
+      phase: overrides.phase ?? "pr",
+    };
+    sig.raw.phase = overrides.phase ?? "pr";
+    return {
+      orch: orchPath,
+      sig,
+      opts: {
+        repoRoot: "/repo",
+        statJob: () => ({ exists: true, mtimeMs: 1_000 }),
+        jobLifecycle: () => "dead-gone",
+        progressMark: () => 0, // zero forward progress → the no-progress STOP path
+        readProgressMark: () => 0,
+        writeProgressMark: recorder(undefined),
+        probes: { [overrides.phase ?? "pr"]: recorder(false) },
+        emitComplete: recorder({ code: 0 }),
+        appendEvent: recorder(undefined),
+        appendReviveEvent: recorder(undefined),
+        appendEscalatedEvent: recorder(undefined),
+        appendReviveSuppressedEvent: recorder(undefined),
+        reviveDispatch: recorder({ code: 0 }),
+        applyStalledLabel: recorder({ applied: true }),
+        killBgJob: recorder(undefined),
+        countReviveEvents: recorder(0),
+        writeReviveMarker: recorder(undefined),
+        now: () => 1_000 + 6 * 60 * 1000,
+        staleMs: 5 * 60 * 1000,
+        // real fs-backed cool-down + ask-cap primitives (defaults)
+      },
+    };
+  }
+
+  test("the cap-consuming ask flips the signal TERMINAL with the brief persisted; later sweeps never re-ask", () => {
+    let clock = 5_000_000;
+    const s = setupAt(orchDir);
+    s.opts.now = () => clock;
+
+    // Asks 1..3 (each past the 10-min cool-down window). Default cap = 3.
+    for (let ask = 1; ask <= 3; ask++) {
+      reclaimDeadWorkIfPossible(s.orch, s.sig, s.opts);
+      clock += 10 * 60 * 1000 + 1;
+    }
+    expect(s.opts.appendEscalatedEvent.calls.length).toBe(3);
+
+    // The 3rd (cap-consuming) ask parked the ticket terminal: stalled signal
+    // with the curated explanation persisted for the Needs-You inbox.
+    const sigPath = join(orchDir, "workers", "CTL-9", "phase-pr.json");
+    const written = JSON.parse(readFileSync(sigPath, "utf8"));
+    expect(written.status).toBe("stalled");
+    expect(written.stalledReason).toBe("escalation-ask-cap");
+    expect(written.explanation).toBeTruthy();
+    expect(typeof written.needsHumanSince).toBe("string");
+
+    // 50 more sweeps, each past the cool-down window: ZERO further events —
+    // the ask-cap early-return holds even though this test keeps feeding the
+    // same (now-stale) in-memory signal back in.
+    for (let i = 0; i < 50; i++) {
+      reclaimDeadWorkIfPossible(s.orch, s.sig, s.opts);
+      clock += 10 * 60 * 1000 + 1;
+    }
+    expect(s.opts.appendEscalatedEvent.calls.length).toBe(3); // NOT 53
+  });
+
+  test("the ask history rides the event payload (attempts is no longer [] forever)", () => {
+    let clock = 9_000_000;
+    const s = setupAt(orchDir);
+    s.opts.now = () => clock;
+
+    reclaimDeadWorkIfPossible(s.orch, s.sig, s.opts); // ask 1 — no prior history
+    clock += 10 * 60 * 1000 + 1;
+    reclaimDeadWorkIfPossible(s.orch, s.sig, s.opts); // ask 2 — carries ask-1's ts
+
+    const secondAsk = s.opts.appendEscalatedEvent.calls[1][0];
+    const attempts = secondAsk.extras?.explanation?.attempts;
+    expect(Array.isArray(attempts)).toBe(true);
+    expect(attempts.length).toBeGreaterThanOrEqual(1);
+  });
+
+  test("a DIFFERENT escalation reason does not consume the no-progress cap (reason change resets the count)", () => {
+    let clock = 12_000_000;
+    const s = setupAt(orchDir);
+    s.opts.now = () => clock;
+    // Seed three same-reason asks via the real recordEscalation primitive but
+    // for a DIFFERENT reason — the no-progress cap must not fire off them.
+    // (The last write is past the cool-down window so the sweep's ask proceeds.)
+    recordEscalation(orchDir, "CTL-9", "pr", "wedged-never-started", clock - 3);
+    recordEscalation(orchDir, "CTL-9", "pr", "wedged-never-started", clock - 2);
+    recordEscalation(orchDir, "CTL-9", "pr", "wedged-never-started", clock - 31 * 60 * 1000);
+
+    reclaimDeadWorkIfPossible(s.orch, s.sig, s.opts); // no-progress ask 1
+    expect(s.opts.appendEscalatedEvent.calls.length).toBe(1);
+    // Not terminal yet — the no-progress count restarted at 1.
+    expect(existsSync(join(orchDir, "workers", "CTL-9", "phase-pr.json"))).toBe(false);
   });
 });
 

--- a/plugins/dev/scripts/execution-core/recovery.test.mjs
+++ b/plugins/dev/scripts/execution-core/recovery.test.mjs
@@ -2768,6 +2768,35 @@ describe("reclaimDeadWorkIfPossible — CTL-1442 escalation ask-cap", () => {
     expect(s.opts.appendEscalatedEvent.calls.length).toBe(4);
   });
 
+  test("(R2) a lost flip is re-asserted even INSIDE the cooldown window (no slot held for 10 min)", () => {
+    let clock = 40_000_000;
+    const s = setupAt(orchDir);
+    s.opts.now = () => clock;
+    for (let ask = 1; ask <= 3; ask++) {
+      reclaimDeadWorkIfPossible(s.orch, s.sig, s.opts);
+      clock += 10 * 60 * 1000 + 1;
+    }
+    const sigPath = join(orchDir, "workers", "CTL-9", "phase-pr.json");
+    rmSync(sigPath, { force: true }); // flip lost right after the cap-consuming ask
+    clock += 30 * 1000; // only 30s later — WELL inside the fresh cooldown window
+    reclaimDeadWorkIfPossible(s.orch, s.sig, s.opts);
+    expect(JSON.parse(readFileSync(sigPath, "utf8")).status).toBe("stalled"); // re-asserted now, not after 10 min
+    expect(s.opts.appendEscalatedEvent.calls.length).toBe(3); // still no new events
+  });
+
+  test("(R2) the attempts history never inherits a DIFFERENT reason's asks", () => {
+    let clock = 50_000_000;
+    const s = setupAt(orchDir);
+    s.opts.now = () => clock;
+    // three unrelated wedged asks on the marker, the last outside the window
+    recordEscalation(orchDir, "CTL-9", "pr", "wedged-never-started", clock - 3);
+    recordEscalation(orchDir, "CTL-9", "pr", "wedged-never-started", clock - 2);
+    recordEscalation(orchDir, "CTL-9", "pr", "wedged-never-started", clock - 31 * 60 * 1000);
+    reclaimDeadWorkIfPossible(s.orch, s.sig, s.opts); // first no-progress ask
+    const firstAsk = s.opts.appendEscalatedEvent.calls[0][0];
+    expect(firstAsk.extras?.explanation?.attempts ?? []).toEqual([]); // fresh — no wedged history
+  });
+
   test("a DIFFERENT escalation reason does not consume the no-progress cap (reason change resets the count)", () => {
     let clock = 12_000_000;
     const s = setupAt(orchDir);

--- a/plugins/dev/scripts/execution-core/scheduler.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.mjs
@@ -2791,6 +2791,15 @@ export function defaultClearStall(orchDir, writeStatus) {
     } catch {
       /* best-effort */
     }
+    // 4. CTL-1442: re-arm the escalation ask budget. An operator re-arming a
+    //    stalled ticket starts a FRESH cycle — without this, a retried phase
+    //    that no-progresses again hits the spent ask-cap (askCount >= cap) and
+    //    is suppressed without a fresh ask or re-stall (Codex P2 on #2590).
+    try {
+      rmSync(join(orchDir, ".escalation-cooldowns", `${ticket}-${phase}.json`), { force: true });
+    } catch {
+      /* best-effort */
+    }
     return true;
   };
 }

--- a/plugins/dev/scripts/execution-core/unstuck-sweep.mjs
+++ b/plugins/dev/scripts/execution-core/unstuck-sweep.mjs
@@ -83,6 +83,11 @@ export const STALL_CATEGORY_MAP = Object.freeze({
   source_conflict_ctl708_unavailable: { category: "source-conflict", action: "force-push-if-clean" },
   "orphan-sweep-stale":               { category: "orphan-stale",   action: "emit-phase-complete-if-merged" },
   "remediate-cycle-cap-exhausted":    { category: "remediate-cap",  action: "escalate" },
+  // CTL-1442 (Codex R5): a ticket parked by the no-progress escalation ask-cap
+  // is ALREADY terminally escalated (needs-human + brief + final event) — the
+  // unstuck sweep must stay quiet, not re-escalate it every interval (that
+  // would recreate the ask loop through a different subsystem).
+  "escalation-ask-cap":               { category: "skip",           action: "skip" },
 });
 
 // classifyStalledTicket — PURE top-level router (Phase 1). No IO.

--- a/plugins/dev/scripts/execution-core/unstuck-sweep.test.mjs
+++ b/plugins/dev/scripts/execution-core/unstuck-sweep.test.mjs
@@ -21,6 +21,11 @@ import { buildUnstuckActSeams } from "./unstuck-act-seams.mjs";
 // classifyStalledTicket — pure top-level router (CTL-1064)
 // ---------------------------------------------------------------------------
 describe("classifyStalledTicket — pure top-level router (CTL-1064)", () => {
+  test("escalation-ask-cap stalls are SKIPPED — already terminally escalated by CTL-1442 (no re-ask loop)", () => {
+    const r = classifyStalledTicket({ reason: "escalation-ask-cap" });
+    expect(r).toEqual({ category: "skip", action: "skip" });
+  });
+
   test("rebase_refused_dirty_tree → dirty-tree/clear-noise-and-retry", () => {
     const r = classifyStalledTicket({ reason: "rebase_refused_dirty_tree" });
     expect(r.category).toBe("dirty-tree");


### PR DESCRIPTION
## What

Closes the **triage-authorization no-progress loop** (RC4): ADV-1374/ADV-1376 emitted `phase.triage.escalated` with `reason:"no-progress", attempts:[]` every ~10 minutes for **days**. Traced mechanics: the CTL-638 cool-down only throttles re-emission (never terminal), the broker's `PHASE_EVENT_PATTERN` excludes the `escalated` action so nothing can consume "authorize retry?", and the dispatch circuit breaker has no reach into this path (no dispatch ever happens).

## Changes

- **Ask counting on the existing cool-down marker** (`label-guard.mjs`): `recordEscalation` accrues a consecutive same-reason `askCount` + bounded `asks[]` history; a different reason restarts the count. New `readEscalationRecord` + `ESCALATION_ASK_CAP` (default 3, `CATALYST_ESCALATION_ASK_CAP`).
- **Terminal transition at the cap** (`recovery.mjs escalateOnce`): the cap-consuming **no-progress** ask flips the phase signal to `status:"stalled"`/`stalledReason:"escalation-ask-cap"` with the curated CTL-1130 explanation **persisted on the signal** — so the monitor's Needs-You inbox renders the final brief (`deriveExplanation` scans phase signals) and the reclaim sweep drops the ticket. Past the cap, `escalateOnce` early-returns (belt for a failed flip). Scoped to `no-progress` — the alive busy-ceiling/no-probe asks keep their throttled behavior (their signals belong to live workers a terminal flip could fight).
- **Truthful payloads**: the ask history now rides `attempts` in the event payload (it was an unwired `extras` arg at this call site — `attempts:[]` forever).

## Tests

- `label-guard.test.mjs` **61 pass** (+5; marker-shape test updated for the new fields)
- `recovery.test.mjs` **281 pass** (+3: cap→terminal with persisted brief then 50 further sweeps emit ZERO events; attempts history on the second ask; a different prior reason doesn't consume the no-progress cap)
- `bun build daemon.mjs` resolves. Both suites are CI-registered.

## Expected live effect

ADV-1374/1376 park loudly (stalled + needs-human + rendered brief) within ~30 min of deploy instead of echoing forever — mission-test item 2 for CTL-1157.

Part of **CTL-1157** (P1-loop-1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)