### PR TITLE
feat(dev): CTL-1440 (P0b) — attempts-exhausted → loud escalation, RC3 defer-storm decoupling, truthful skip reasons

### DIFF
--- a/plugins/dev/scripts/execution-core/board-health-seam.test.mjs
+++ b/plugins/dev/scripts/execution-core/board-health-seam.test.mjs
@@ -173,6 +173,33 @@ describe("holisticBoardHealthAct — one real dispatch per scan, skip non-dispat
     expect(recorded[0].intent.outcome).toBe(false);
   });
 
+  test("ALL candidates ledger-skipped as attempts-exhausted → reason 'all-candidates-exhausted' (CTL-1440 truth)", () => {
+    const r = holisticBoardHealthAct(
+      { ...ctx, candidates: ["CTL-1", "CTL-2"] },
+      {
+        shouldSkipItem: () => true,
+        skipReason: () => "attempts-exhausted",
+        invokeRecoveryPass: () => { throw new Error("must not invoke"); },
+        recordIntent: () => {},
+      },
+    );
+    expect(r.dispatched).toBe(false);
+    expect(r.reason).toBe("all-candidates-exhausted");
+  });
+
+  test("MIXED ledger skips (exhausted + cooldown) → stays 'all-candidates-cooldown' (retryable)", () => {
+    const r = holisticBoardHealthAct(
+      { ...ctx, candidates: ["CTL-1", "CTL-2"] },
+      {
+        shouldSkipItem: () => true,
+        skipReason: (c) => (c === "CTL-1" ? "attempts-exhausted" : "cooldown"),
+        invokeRecoveryPass: () => { throw new Error("must not invoke"); },
+        recordIntent: () => {},
+      },
+    );
+    expect(r.reason).toBe("all-candidates-cooldown");
+  });
+
   test("ALL candidates non-dispatch → {dispatched:false, all-candidates-cooldown} (no starvation, no false dispatch)", () => {
     const r = holisticBoardHealthAct(
       { ...ctx, candidates: ["CTL-1", "CTL-2"] },

--- a/plugins/dev/scripts/execution-core/board-health-seam.test.mjs
+++ b/plugins/dev/scripts/execution-core/board-health-seam.test.mjs
@@ -187,6 +187,32 @@ describe("holisticBoardHealthAct — one real dispatch per scan, skip non-dispat
     expect(r.reason).toBe("all-candidates-exhausted");
   });
 
+  test("a SWEPT cohort (escalated) + a leave-alone verdict still reads 'all-candidates-exhausted' (terminal set, Codex R1)", () => {
+    const r = holisticBoardHealthAct(
+      { ...ctx, candidates: ["CTL-1", "CTL-2"] },
+      {
+        shouldSkipItem: () => true,
+        skipReason: (c) => (c === "CTL-1" ? "escalated" : "leave-alone"),
+        invokeRecoveryPass: () => { throw new Error("must not invoke"); },
+        recordIntent: () => {},
+      },
+    );
+    expect(r.reason).toBe("all-candidates-exhausted");
+  });
+
+  test("an INVOKED non-dispatch candidate forces 'all-candidates-cooldown' even beside exhausted skips (Codex R1)", () => {
+    const r = holisticBoardHealthAct(
+      { ...ctx, candidates: ["CTL-1", "CTL-2"] },
+      {
+        shouldSkipItem: (c) => c === "CTL-1",
+        skipReason: () => "attempts-exhausted",
+        invokeRecoveryPass: () => ({ dispatched: false, reason: "recovery-pass-cycle-cap-exhausted" }),
+        recordIntent: () => {},
+      },
+    );
+    expect(r.reason).toBe("all-candidates-cooldown"); // CTL-2 was actionable, just capped
+  });
+
   test("MIXED ledger skips (exhausted + cooldown) → stays 'all-candidates-cooldown' (retryable)", () => {
     const r = holisticBoardHealthAct(
       { ...ctx, candidates: ["CTL-1", "CTL-2"] },

--- a/plugins/dev/scripts/execution-core/board-health.mjs
+++ b/plugins/dev/scripts/execution-core/board-health.mjs
@@ -643,6 +643,10 @@ function checkStrandedNode(b) {
 // host that simply has no owned work.
 // Codex round-2: "no-actuator" (an enforce pass with no `act` seam wired — a
 // miswired daemon that proposes but structurally cannot dispatch) is a wedge too.
+// CTL-1440 (P0b): "all-candidates-exhausted" is deliberately EXCLUDED — every
+// candidate is terminally attempts-exhausted AND the exhaustion sweep has
+// escalated each to a human (needs-human + brief + comment), so the delegate is
+// truthfully done, not wedged.
 const WEDGE_SKIP_REASONS = new Set(["all-candidates-cooldown", "act-error", "no-actuator"]);
 
 // #7 — actuation liveness (CTL-1435 C2): the delegate's OWN wedge. Over the last

--- a/plugins/dev/scripts/execution-core/recovery-reasoning.mjs
+++ b/plugins/dev/scripts/execution-core/recovery-reasoning.mjs
@@ -1934,7 +1934,19 @@ export function defaultSkipReason(ticket, opts = {}) {
   // BOTH the per-item path AND board-health's holistic pass can reconsider the
   // untyped stuck item (it never dead-ends at a permanent latch).
   if (data?.decision === "defer") {
-    const last = typeof data?.lastTs === "number" ? data.lastTs : data?.ts;
+    // CTL-1440 (Codex R1): TWO gates for a board-health defer. The per-item
+    // pass throttles on lastTs (the last touch — a re-defer refreshes it, so
+    // re-processing is once per window). The HOLISTIC act (opts.holistic) gates
+    // on the FROZEN aging anchor deferredSince: the per-item pass re-deferring
+    // seconds before board-health reads is a no-op handoff and must not push
+    // the aged candidate back under cooldown (the residual starvation half of
+    // the RC3 collision). Non-board-health defers keep the lastTs gate.
+    const holisticAnchor =
+      opts.holistic && data?.fix_class === "board-health" && typeof data?.deferredSince === "number"
+        ? data.deferredSince
+        : null;
+    const last =
+      holisticAnchor ?? (typeof data?.lastTs === "number" ? data.lastTs : data?.ts);
     return typeof last === "number" && now() - last < RECOVERY_COOLDOWN_MS
       ? "defer-cooldown"
       : null;
@@ -2008,6 +2020,11 @@ export function escalateExhaustedIntents(orchDir, opts = {}) {
     emitEvent = defaultEmitEvent,
     labelNeedsHuman = null, // (orchDir, ticket) => void — scheduler wires label-guard
     writeSignal = (t, payload) => defaultWriteEscalationSignal(t, payload, { orchDir }),
+    // Codex R1: a finished ticket can hold a stale exhausted ledger until the
+    // terminal cleanup (recoveryForgetIntent) runs LATER in the tick — the sweep
+    // must not page a human about a Done ticket. The scheduler wires this to the
+    // cached terminal/merged check; default keeps the function pure/hermetic.
+    isActive = () => true,
     log = defaultLogFn,
   } = opts;
   if (!orchDir) return [];
@@ -2030,6 +2047,16 @@ export function escalateExhaustedIntents(orchDir, opts = {}) {
     if (!sweepable || data?.escalated === true) continue;
     if (!(typeof data?.attempts === "number" && data.attempts >= maxAttempts)) continue;
     const ticket = f.replace(/\.json$/, "");
+    // Codex R1: never escalate a finished ticket (fail toward ACTIVE — a wrongly
+    // skipped live ticket just waits a tick; the ledger is forgotten by the
+    // terminal cleanup once the ticket is confirmed done).
+    let active = true;
+    try {
+      active = isActive(ticket) !== false;
+    } catch {
+      active = true;
+    }
+    if (!active) continue;
     const reason = `self-heal attempts exhausted (${data.attempts} dispatches without a recorded verdict)`;
     const escalation = {
       escalation_type: "authorization",
@@ -2057,6 +2084,21 @@ export function escalateExhaustedIntents(orchDir, opts = {}) {
     } catch (err) {
       log(`recovery-reasoning: ${ticket} exhausted-escalate ledger write failed: ${err.message}`);
       continue; // without the latch the sweep would re-fire every tick — try again next tick
+    }
+    // Codex R1: defaultRecordIntent swallows write failures (best-effort by
+    // design) — VERIFY the latch actually landed before any human-facing side
+    // effect, or a disk-full/permission failure would re-post the signal/
+    // comment/label/event every tick.
+    let latched = false;
+    try {
+      latched =
+        JSON.parse(readFileSync(join(orchDir, ".recovery-intents", f), "utf8"))?.escalated === true;
+    } catch {
+      latched = false;
+    }
+    if (!latched) {
+      log(`recovery-reasoning: ${ticket} exhausted-escalate latch did not persist — deferring side effects to the next tick`);
+      continue;
     }
     try {
       writeSignal(ticket, escalation);

--- a/plugins/dev/scripts/execution-core/recovery-reasoning.mjs
+++ b/plugins/dev/scripts/execution-core/recovery-reasoning.mjs
@@ -1732,12 +1732,18 @@ export function readDeferredBoardHealthIntents(orchDir, { now = () => Date.now()
     try {
       const data = JSON.parse(readFileSync(join(dir, f), "utf8"));
       if (data?.decision === "defer" && data?.fix_class === "board-health") {
-        // CTL-1432 (Codex P1): honor the 30-min defer cooldown — defaultShouldSkipItem
-        // treats a defer marker as cooldown-only, so a deferred intent still inside its
-        // window is not yet an actionable anchor (else the gate proceeds and then the
-        // act site skips it → a wasted proceed).
-        const last = typeof data?.lastTs === "number" ? data.lastTs : data?.ts;
-        if (typeof last === "number" && now() - last < cooldownMs) continue;
+        // CTL-1440 (P0b): age off the FROZEN anchor `deferredSince` (set on the
+        // first board-health defer, preserved across re-defers) — lastTs now
+        // refreshes on every write, so keying it here would starve the consumer
+        // (the pre-CTL-1432 bug). Legacy entries without the field fall back to
+        // lastTs ?? ts (their lastTs was frozen, so it IS the anchor).
+        const anchor =
+          typeof data?.deferredSince === "number"
+            ? data.deferredSince
+            : typeof data?.lastTs === "number"
+              ? data.lastTs
+              : data?.ts;
+        if (typeof anchor === "number" && now() - anchor < cooldownMs) continue;
         out.push(f.replace(/\.json$/, ""));
       }
     } catch {
@@ -1782,17 +1788,27 @@ export function defaultRecordIntent(ticket, intent, opts = {}) {
     Boolean(intent.escalated) ||
     intent.decision === "escalate"; // an escalate-pass latches escalated
 
-  // CTL-1432 (Codex P1): a REPEATED defer→board-health is a no-op handoff — the ticket
-  // is already handed to the board-health delegate, so re-deferring must NOT refresh
-  // lastTs. Otherwise the per-item recovery pass (which runs BEFORE boardHealthPass in
-  // the same tick) re-defers the marker back under the 30-min cooldown every cycle, and
-  // the board-health consumer — which gates on lastTs — is starved forever. Freezing
-  // lastTs lets the marker AGE OUT so board-health finally consumes + dispatches it.
-  const isRepeatedBoardHealthDefer =
-    intent.decision === "defer" &&
-    (intent.fix_class ?? prior.fix_class) === "board-health" &&
-    prior.decision === "defer" &&
-    typeof prior.lastTs === "number";
+  // CTL-1440 (P0b, replaces the CTL-1432 lastTs FREEZE): the freeze shared one
+  // field between two consumers wanting OPPOSITE semantics — the board-health
+  // consumer needs the defer to AGE (a frozen anchor), while the per-item pass's
+  // cooldown gate needs the LAST touch (refreshing) — and that collision drove
+  // the RC3 defer storm (a frozen lastTs is permanently past-cooldown, so the
+  // per-item pass re-processed + re-emitted every ~2-3s fs.watch tick for 71 min
+  // on OTL-13). Decoupled: `deferredSince` is the frozen aging anchor (set on
+  // the FIRST board-health defer, preserved across re-defers, consumed by
+  // readDeferredBoardHealthIntents); `lastTs` now ALWAYS refreshes (drives the
+  // cooldown gates), so a re-defer is throttled to once per cooldown window and
+  // the consumer is still never starved. Legacy frozen entries fall back to
+  // prior.lastTs as their anchor.
+  const isBoardHealthDefer =
+    intent.decision === "defer" && (intent.fix_class ?? prior.fix_class) === "board-health";
+  const deferredSince = isBoardHealthDefer
+    ? typeof prior.deferredSince === "number"
+      ? prior.deferredSince
+      : prior.decision === "defer" && typeof prior.lastTs === "number"
+        ? prior.lastTs // legacy frozen entry — its lastTs WAS the anchor
+        : ts
+    : null;
   // CTL-1439 (P0a): the session's ACTUAL verdict rides in the ledger. A write that
   // carries a verdict stamps all three fields afresh. A verdict-less MARKER write
   // (the "dispatched" dispatch marker / a "defer" hand-off) PRESERVES the prior
@@ -1805,7 +1821,8 @@ export function defaultRecordIntent(ticket, intent, opts = {}) {
   const entry = {
     ticket,
     ts: typeof prior.ts === "number" ? prior.ts : ts, // first-action timestamp
-    lastTs: isRepeatedBoardHealthDefer ? prior.lastTs : ts, // most-recent action ts (drives cooldown)
+    lastTs: ts, // most-recent action ts (drives cooldown; CTL-1440 always refreshes)
+    ...(deferredSince != null ? { deferredSince } : {}),
     decision: intent.decision,
     fix_class: intent.fix_class ?? prior.fix_class ?? null,
     attempts:
@@ -1891,13 +1908,17 @@ export function recordVerdict(ticket, { verdict, reason = null } = {}, opts = {}
   return null;
 }
 
-// defaultShouldSkipItem — true when recovery should NOT act this pass. Fail-OPEN
-// on absent/malformed ledger (returns false → recovery proceeds). Evaluation
-// order: defer (cooldown-only) → escalated (terminal, TTL) → leave-alone
-// (verdict, TTL) → attempts (terminal) → cooldown (transient).
-export function defaultShouldSkipItem(ticket, opts = {}) {
+// defaultSkipReason — CTL-1440 (P0b): the reason-bearing form of the skip gate.
+// null → recovery may act; otherwise WHY it must not, one of:
+//   "defer-cooldown" | "escalated" | "leave-alone" | "attempts-exhausted" | "cooldown".
+// Lets the holistic act distinguish a RETRYABLE cooldown skip from a TERMINAL
+// attempts-exhausted one (the "all-candidates-cooldown" misnomer, audit RC1) so
+// C1's skippedReason and C2's wedge predicate tell the truth. Fail-OPEN on
+// absent/malformed ledger. Evaluation order: defer (cooldown-only) → escalated
+// (terminal, TTL) → leave-alone (verdict, TTL) → attempts (terminal) → cooldown.
+export function defaultSkipReason(ticket, opts = {}) {
   const orchDir = opts.orchDir ?? resolveOrchDir();
-  if (!orchDir) return false;
+  if (!orchDir) return null;
   const now = opts.now ?? (() => Date.now());
   const p = recoveryIntentPath(orchDir, ticket);
 
@@ -1905,7 +1926,7 @@ export function defaultShouldSkipItem(ticket, opts = {}) {
   try {
     data = JSON.parse(readFileSync(p, "utf8"));
   } catch {
-    return false; // no ledger / malformed → never acted → don't skip
+    return null; // no ledger / malformed → never acted → don't skip
   }
 
   // CTL-1157 Workstream B: a DEFER marker is cooldown-ONLY — never attempts-
@@ -1914,13 +1935,15 @@ export function defaultShouldSkipItem(ticket, opts = {}) {
   // untyped stuck item (it never dead-ends at a permanent latch).
   if (data?.decision === "defer") {
     const last = typeof data?.lastTs === "number" ? data.lastTs : data?.ts;
-    return typeof last === "number" && now() - last < RECOVERY_COOLDOWN_MS;
+    return typeof last === "number" && now() - last < RECOVERY_COOLDOWN_MS
+      ? "defer-cooldown"
+      : null;
   }
 
   // (c) already escalated → terminal latch, but TTL-bounded (CTL-1431). Within the
   // TTL it still skips (the ticket is handed off to a human); once the intent ages
   // past RECOVERY_TERMINAL_INTENT_TTL_MS it goes stale and the ticket RE-ENTERS the
-  // recovery triage funnel. Return false DIRECTLY on expiry — do NOT fall through to
+  // recovery triage funnel. Return null DIRECTLY on expiry — do NOT fall through to
   // the attempts-exhausted branch below: an escalated intent already has attempts ≥
   // 2, so a fall-through would instantly re-latch there (that branch has no age
   // gate). Derived purely from timestamps, so NO file mutation on expiry (mirrors
@@ -1930,29 +1953,134 @@ export function defaultShouldSkipItem(ticket, opts = {}) {
     // A timestamp-less escalation (defaultClearIntentCooldown deletes both ts fields
     // while KEEPING escalated as a deliberately-terminal latch) cannot be aged out —
     // it stays terminal. (CTL-1431 Codex F3.)
-    if (typeof last !== "number") return true;
-    return now() - last < RECOVERY_TERMINAL_INTENT_TTL_MS;
+    if (typeof last !== "number") return "escalated";
+    return now() - last < RECOVERY_TERMINAL_INTENT_TTL_MS ? "escalated" : null;
   }
 
   // (CTL-1439 P0a) a LEAVE-ALONE verdict — the pass reviewed this ticket and
   // concluded no action is needed (stale flag / actively human-driven / false
   // positive). Skip re-review for the leave-alone TTL, then RE-ENTER with a
-  // direct false (mirrors the escalated short-circuit above — never fall through
+  // direct null (mirrors the escalated short-circuit above — never fall through
   // to the attempts latch: a reviewed-healthy ticket must not dead-end there).
   if (data?.decision === "leave-alone") {
     const last = typeof data?.lastTs === "number" ? data.lastTs : data?.ts;
-    if (typeof last !== "number") return false; // timestamp-less verdict → fail-open, re-enter
-    return now() - last < RECOVERY_LEAVE_ALONE_TTL_MS;
+    if (typeof last !== "number") return null; // timestamp-less verdict → fail-open, re-enter
+    return now() - last < RECOVERY_LEAVE_ALONE_TTL_MS ? "leave-alone" : null;
   }
 
-  // (b) attempts exhausted → stop self-healing.
-  if (typeof data?.attempts === "number" && data.attempts >= RECOVERY_MAX_ATTEMPTS) return true;
+  // (b) attempts exhausted → stop self-healing (escalateExhaustedIntents turns
+  // this into a LOUD escalation on the next sweep — CTL-1440).
+  if (typeof data?.attempts === "number" && data.attempts >= RECOVERY_MAX_ATTEMPTS) {
+    return "attempts-exhausted";
+  }
 
   // (a) acted within the cooldown window → too soon, skip this pass.
   const last = typeof data?.lastTs === "number" ? data.lastTs : data?.ts;
-  if (typeof last === "number" && now() - last < RECOVERY_COOLDOWN_MS) return true;
+  if (typeof last === "number" && now() - last < RECOVERY_COOLDOWN_MS) return "cooldown";
 
-  return false;
+  return null;
+}
+
+// defaultShouldSkipItem — true when recovery should NOT act this pass. The
+// boolean view over defaultSkipReason (same branches, same order — see above).
+export function defaultShouldSkipItem(ticket, opts = {}) {
+  return defaultSkipReason(ticket, opts) !== null;
+}
+
+// escalateExhaustedIntents — CTL-1440 (P0b): the terminal-state policy sweep.
+// An intent whose fix attempts are exhausted (attempts >= max) WITHOUT a verdict
+// must escalate LOUDLY — ledger escalated:true (B1's 7-day TTL then ages it out
+// for re-entry), needs-human label (via the injected label-guard path), a
+// curated brief on the recovery-pass signal (→ the monitor Needs-You inbox), an
+// app-actor ticket comment, and a ticket-tagged recovery.escalated event —
+// never a silent permanent latch (audit RC1: NOTHING un-latched an
+// attempts-exhausted open ticket; they rotted for weeks). Idempotent: the
+// escalated:true it writes excludes the entry from every later scan. Only the
+// no-verdict decisions ("dispatched" dispatch markers and "fix" classifier
+// writes) are swept — leave-alone / escalate / defer / fixed carry their own
+// terminal policies. Never throws; returns the tickets it escalated.
+export function escalateExhaustedIntents(orchDir, opts = {}) {
+  const {
+    now = () => Date.now(),
+    maxAttempts = RECOVERY_MAX_ATTEMPTS,
+    recordIntent = (t, i) => defaultRecordIntent(t, i, { orchDir, now }),
+    postComment = defaultPostComment,
+    emitEvent = defaultEmitEvent,
+    labelNeedsHuman = null, // (orchDir, ticket) => void — scheduler wires label-guard
+    writeSignal = (t, payload) => defaultWriteEscalationSignal(t, payload, { orchDir }),
+    log = defaultLogFn,
+  } = opts;
+  if (!orchDir) return [];
+  let files;
+  try {
+    files = readdirSync(join(orchDir, ".recovery-intents"));
+  } catch {
+    return [];
+  }
+  const escalatedTickets = [];
+  for (const f of files) {
+    if (!f.endsWith(".json")) continue;
+    let data;
+    try {
+      data = JSON.parse(readFileSync(join(orchDir, ".recovery-intents", f), "utf8"));
+    } catch {
+      continue; // malformed → skip (fail-open)
+    }
+    const sweepable = data?.decision === "dispatched" || data?.decision === "fix";
+    if (!sweepable || data?.escalated === true) continue;
+    if (!(typeof data?.attempts === "number" && data.attempts >= maxAttempts)) continue;
+    const ticket = f.replace(/\.json$/, "");
+    const reason = `self-heal attempts exhausted (${data.attempts} dispatches without a recorded verdict)`;
+    const escalation = {
+      escalation_type: "authorization",
+      problem: `${ticket} consumed ${data.attempts} recovery attempts (last decision "${data.decision}") without any recorded verdict — the self-heal loop is not resolving it.`,
+      call_to_action: `look at ${ticket}: authorize another recovery cycle (clear its ledger latch), or take it over?`,
+      recommendation: `inspect the last recovery-pass session for ${ticket}; repeated verdict-less deaths usually mean the ticket needs a human decision`,
+      risk: `left latched it rots silently — the audit RC1 failure this sweep exists to prevent`,
+      why_asking: reason,
+      observed: {
+        attempts: data.attempts,
+        decision: data.decision ?? null,
+        fix_class: data.fix_class ?? null,
+      },
+      attempts: [],
+    };
+    try {
+      recordIntent(ticket, {
+        type: "recovery-pass",
+        decision: "escalate",
+        escalated: true,
+        attempts: data.attempts, // pin — exhaustion is the finding, not a new attempt
+        verdict: "escalate",
+        verdictReason: reason,
+      });
+    } catch (err) {
+      log(`recovery-reasoning: ${ticket} exhausted-escalate ledger write failed: ${err.message}`);
+      continue; // without the latch the sweep would re-fire every tick — try again next tick
+    }
+    try {
+      writeSignal(ticket, escalation);
+    } catch (err) {
+      log(`recovery-reasoning: ${ticket} exhausted-escalate signal write failed: ${err.message}`);
+    }
+    try {
+      labelNeedsHuman?.(orchDir, ticket);
+    } catch (err) {
+      log(`recovery-reasoning: ${ticket} exhausted-escalate label failed: ${err.message}`);
+    }
+    emitEvent({ type: "recovery.escalated", ticket, reason, escalation });
+    try {
+      postComment(
+        ticket,
+        `🔼 **recovery-pass** self-heal attempts exhausted on this ticket — escalated to the operator. ${reason}. (See your inbox.)`,
+      );
+    } catch {
+      /* comment is best-effort; the signal + event are the durable surfaces */
+    }
+    escalatedTickets.push(ticket);
+    log(`recovery-reasoning: ${ticket} attempts-exhausted → escalated loudly (CTL-1440)`);
+  }
+  return escalatedTickets;
 }
 
 // defaultForgetIntent — delete a ticket's recovery-intent ledger entry. The

--- a/plugins/dev/scripts/execution-core/recovery-reasoning.test.mjs
+++ b/plugins/dev/scripts/execution-core/recovery-reasoning.test.mjs
@@ -2105,6 +2105,55 @@ describe("defaultSkipReason + escalateExhaustedIntents (CTL-1440 P0b)", () => {
     expect(out).toEqual([]);
   });
 
+  test("(Codex R1) a terminal/finished ticket is NEVER swept (isActive gate; fail-open toward active)", () => {
+    const t0 = 1_000_000_000_000;
+    defaultRecordIntent("CTL-DONE", { decision: "fix", attempts: RECOVERY_MAX_ATTEMPTS }, { orchDir, now: () => t0 });
+    defaultRecordIntent("CTL-LIVE", { decision: "fix", attempts: RECOVERY_MAX_ATTEMPTS }, { orchDir, now: () => t0 });
+    const out = escalateExhaustedIntents(orchDir, {
+      now: () => t0 + 1,
+      isActive: (t) => t !== "CTL-DONE",
+      emitEvent: () => {}, postComment: () => {}, labelNeedsHuman: () => {}, writeSignal: () => {},
+    });
+    expect(out).toEqual(["CTL-LIVE"]);
+    expect(readLedger("CTL-DONE").escalated).toBe(false); // untouched — terminal cleanup owns it
+    // a THROWING isActive fails open toward active:
+    defaultRecordIntent("CTL-THROW", { decision: "fix", attempts: RECOVERY_MAX_ATTEMPTS }, { orchDir, now: () => t0 });
+    const out2 = escalateExhaustedIntents(orchDir, {
+      now: () => t0 + 2,
+      isActive: (t) => { if (t === "CTL-THROW") throw new Error("read failed"); return true; },
+      emitEvent: () => {}, postComment: () => {}, labelNeedsHuman: () => {}, writeSignal: () => {},
+    });
+    expect(out2).toContain("CTL-THROW");
+  });
+
+  test("(Codex R1) side effects are WITHHELD when the escalated latch did not persist (read-back gate)", () => {
+    const t0 = 1_000_000_000_000;
+    defaultRecordIntent("CTL-RO", { decision: "dispatched", attempts: RECOVERY_MAX_ATTEMPTS }, { orchDir, now: () => t0 });
+    const events = [];
+    const out = escalateExhaustedIntents(orchDir, {
+      now: () => t0 + 1,
+      recordIntent: () => ({ escalated: true }), // LIES: never writes the file
+      emitEvent: (e) => events.push(e),
+      postComment: () => { throw new Error("must not comment"); },
+      labelNeedsHuman: () => { throw new Error("must not label"); },
+      writeSignal: () => { throw new Error("must not write signal"); },
+    });
+    expect(out).toEqual([]); // latch verification failed → no side effects, retry next tick
+    expect(events).toEqual([]);
+  });
+
+  test("(Codex R1) the HOLISTIC gate keys a board-health defer on the frozen deferredSince anchor", () => {
+    const t0 = 1_000_000_000_000;
+    defaultRecordIntent("CTL-HD", { decision: "defer", fix_class: "board-health", attempts: 0 }, { orchDir, now: () => t0 });
+    // the per-item pass re-defers 31 min later — lastTs refreshes
+    defaultRecordIntent("CTL-HD", { decision: "defer", fix_class: "board-health", attempts: 0 }, { orchDir, now: () => t0 + 31 * 60_000 });
+    const shortly = t0 + 31 * 60_000 + 5_000; // 5s after the re-defer
+    // per-item view: throttled by the fresh lastTs
+    expect(defaultSkipReason("CTL-HD", { orchDir, now: () => shortly })).toBe("defer-cooldown");
+    // holistic view: the FROZEN anchor is aged → actionable NOW
+    expect(defaultSkipReason("CTL-HD", { orchDir, now: () => shortly, holistic: true })).toBeNull();
+  });
+
   test("after the sweep, skipReason flips from attempts-exhausted to escalated (TTL-governed re-entry)", () => {
     const t0 = 1_000_000_000_000;
     defaultRecordIntent("CTL-Y", { decision: "fix", fix_class: "bounded-llm", attempts: RECOVERY_MAX_ATTEMPTS }, { orchDir, now: () => t0 });

--- a/plugins/dev/scripts/execution-core/recovery-reasoning.test.mjs
+++ b/plugins/dev/scripts/execution-core/recovery-reasoning.test.mjs
@@ -25,6 +25,8 @@ import {
   RECOVERY_TERMINAL_INTENT_TTL_MS,
   RECOVERY_LEAVE_ALONE_TTL_MS,
   recordVerdict,
+  defaultSkipReason,
+  escalateExhaustedIntents,
 } from "./recovery-reasoning.mjs";
 import { mkdtempSync, rmSync, existsSync, readFileSync, mkdirSync, writeFileSync } from "node:fs";
 import { join as pathJoin } from "node:path";
@@ -1419,19 +1421,40 @@ describe("readDeferredBoardHealthIntents (CTL-1432 B2)", () => {
     expect(readDeferredBoardHealthIntents(orchDir, { now: () => t0 + RECOVERY_COOLDOWN_MS + 1 })).toContain("ADV-COOL");
   });
 
-  test("(Codex P1 r4) a REPEATED defer→board-health FREEZES lastTs so the marker ages out for board-health", () => {
+  test("(CTL-1440 P0b, replaces the r4 FREEZE) re-defer refreshes lastTs; the FROZEN deferredSince anchor keeps the consumer fed", () => {
     const t0 = 1_000_000_000_000;
-    defaultRecordIntent("CTL-BHD", { decision: "defer", fix_class: "board-health" }, { orchDir, now: () => t0 });
-    // the per-item pass re-defers 40 min later (past cooldown) — lastTs must NOT refresh,
-    // else it stays perpetually under cooldown and starves the board-health consumer.
+    const e1 = defaultRecordIntent("CTL-BHD", { decision: "defer", fix_class: "board-health" }, { orchDir, now: () => t0 });
+    expect(e1.deferredSince).toBe(t0);
+    // the per-item pass re-defers 40 min later (past cooldown) — lastTs REFRESHES
+    // (so its cooldown gate throttles the next re-process: no RC3 every-2s storm)
+    // while deferredSince stays frozen (so the board-health consumer still sees
+    // the marker as aged — never starved, the r4 guarantee preserved).
     const e2 = defaultRecordIntent(
       "CTL-BHD",
       { decision: "defer", fix_class: "board-health" },
       { orchDir, now: () => t0 + 40 * 60_000 },
     );
-    expect(e2.lastTs).toBe(t0); // frozen at the first defer
-    // and the reader now sees it (past cooldown from the frozen lastTs):
-    expect(readDeferredBoardHealthIntents(orchDir, { now: () => t0 + 40 * 60_000 })).toContain("CTL-BHD");
+    expect(e2.lastTs).toBe(t0 + 40 * 60_000); // refreshed → cooldown gate is real again
+    expect(e2.deferredSince).toBe(t0); // frozen aging anchor
+    expect(readDeferredBoardHealthIntents(orchDir, { now: () => t0 + 40 * 60_000 + 1 })).toContain("CTL-BHD");
+  });
+
+  test("(CTL-1440) a LEGACY frozen entry (no deferredSince) falls back to its frozen lastTs as the anchor", () => {
+    const t0 = 1_000_000_000_000;
+    mkdirSync(pathJoin(orchDir, ".recovery-intents"), { recursive: true });
+    writeFileSync(
+      pathJoin(orchDir, ".recovery-intents", "CTL-LEG.json"),
+      JSON.stringify({ ticket: "CTL-LEG", ts: t0, lastTs: t0, decision: "defer", fix_class: "board-health", attempts: 0, escalated: false }),
+    );
+    // reader: legacy anchor = lastTs -> aged after cooldown
+    expect(readDeferredBoardHealthIntents(orchDir, { now: () => t0 + 31 * 60_000 })).toContain("CTL-LEG");
+    // a re-defer upgrades it: deferredSince inherits the legacy frozen lastTs
+    const e2 = defaultRecordIntent(
+      "CTL-LEG",
+      { decision: "defer", fix_class: "board-health" },
+      { orchDir, now: () => t0 + 31 * 60_000 },
+    );
+    expect(e2.deferredSince).toBe(t0);
   });
 
   test("a repeated NON-board-health defer still refreshes lastTs (unchanged)", () => {
@@ -1990,5 +2013,105 @@ describe("defaultWriteEscalationSignal (CTL-1157 F #6)", () => {
     } finally {
       rmSync(orchDir, { recursive: true, force: true });
     }
+  });
+});
+
+// ─── CTL-1440 (P0b): skip-reason vocabulary + the exhausted-intent sweep ─────
+describe("defaultSkipReason + escalateExhaustedIntents (CTL-1440 P0b)", () => {
+  let orchDir;
+  beforeEach(() => {
+    orchDir = mkdtempSync(pathJoin(tmpdir(), "rec-p0b-"));
+  });
+  afterEach(() => {
+    try {
+      rmSync(orchDir, { recursive: true, force: true });
+    } catch {
+      /* best-effort */
+    }
+  });
+
+  const readLedger = (t) =>
+    JSON.parse(readFileSync(pathJoin(orchDir, ".recovery-intents", `${t}.json`), "utf8"));
+
+  test("skipReason names each branch (and mirrors shouldSkipItem exactly)", () => {
+    const t0 = 1_000_000_000_000;
+    // cooldown
+    defaultRecordIntent("CTL-A", { decision: "dispatched" }, { orchDir, now: () => t0 });
+    expect(defaultSkipReason("CTL-A", { orchDir, now: () => t0 + 1 })).toBe("cooldown");
+    // attempts-exhausted
+    defaultRecordIntent("CTL-B", { decision: "dispatched", attempts: RECOVERY_MAX_ATTEMPTS }, { orchDir, now: () => t0 });
+    expect(defaultSkipReason("CTL-B", { orchDir, now: () => t0 + RECOVERY_COOLDOWN_MS * 10 })).toBe("attempts-exhausted");
+    // escalated
+    defaultRecordIntent("CTL-C", { decision: "escalate" }, { orchDir, now: () => t0 });
+    expect(defaultSkipReason("CTL-C", { orchDir, now: () => t0 + 1 })).toBe("escalated");
+    // leave-alone
+    recordVerdict("CTL-D", { verdict: "leave-alone", reason: "healthy" }, { orchDir, now: () => t0 });
+    expect(defaultSkipReason("CTL-D", { orchDir, now: () => t0 + 1 })).toBe("leave-alone");
+    // defer-cooldown
+    defaultRecordIntent("CTL-E", { decision: "defer", fix_class: "board-health", attempts: 0 }, { orchDir, now: () => t0 });
+    expect(defaultSkipReason("CTL-E", { orchDir, now: () => t0 + 1 })).toBe("defer-cooldown");
+    // absent → null; boolean view agrees everywhere
+    expect(defaultSkipReason("CTL-none", { orchDir })).toBeNull();
+    for (const t of ["CTL-A", "CTL-B", "CTL-C", "CTL-D", "CTL-E", "CTL-none"]) {
+      expect(defaultShouldSkipItem(t, { orchDir, now: () => t0 + 1 })).toBe(
+        defaultSkipReason(t, { orchDir, now: () => t0 + 1 }) !== null,
+      );
+    }
+  });
+
+  test("the sweep escalates an exhausted no-verdict intent LOUDLY (ledger + signal + label + event + comment)", () => {
+    const t0 = 1_000_000_000_000;
+    defaultRecordIntent("CTL-X", { decision: "dispatched", fix_class: "board-health", attempts: RECOVERY_MAX_ATTEMPTS }, { orchDir, now: () => t0 });
+    const events = [];
+    const comments = [];
+    const labels = [];
+    const signals = [];
+    const out = escalateExhaustedIntents(orchDir, {
+      now: () => t0 + 1,
+      emitEvent: (e) => events.push(e),
+      postComment: (t, body) => comments.push({ t, body }),
+      labelNeedsHuman: (dir, t) => labels.push(t),
+      writeSignal: (t, payload) => signals.push({ t, payload }),
+    });
+    expect(out).toEqual(["CTL-X"]);
+    const led = readLedger("CTL-X");
+    expect(led.escalated).toBe(true);
+    expect(led.decision).toBe("escalate");
+    expect(led.verdict).toBe("escalate");
+    expect(led.attempts).toBe(RECOVERY_MAX_ATTEMPTS); // pinned — the finding, not a new attempt
+    expect(events[0].type).toBe("recovery.escalated");
+    expect(events[0].ticket).toBe("CTL-X");
+    expect(comments[0].t).toBe("CTL-X");
+    expect(labels).toEqual([orchDir + ":CTL-X"] .map(() => "CTL-X")); // label called with the ticket
+    expect(signals[0].payload.escalation_type).toBe("authorization");
+    // Idempotent: escalated:true excludes it from the next scan.
+    expect(escalateExhaustedIntents(orchDir, { now: () => t0 + 2, emitEvent: (e) => events.push(e), postComment: () => {}, labelNeedsHuman: () => {}, writeSignal: () => {} })).toEqual([]);
+    expect(events.length).toBe(1);
+  });
+
+  test("the sweep excludes verdicts and non-exhausted intents", () => {
+    const t0 = 1_000_000_000_000;
+    recordVerdict("CTL-LA", { verdict: "leave-alone", reason: "healthy" }, { orchDir, now: () => t0 });
+    defaultRecordIntent("CTL-DEF", { decision: "defer", fix_class: "board-health", attempts: 5 }, { orchDir, now: () => t0 });
+    defaultRecordIntent("CTL-ONE", { decision: "dispatched" }, { orchDir, now: () => t0 }); // attempts 1 < cap
+    recordVerdict("CTL-ESC", { verdict: "escalate", reason: "already escalated" }, { orchDir, now: () => t0 });
+    const out = escalateExhaustedIntents(orchDir, {
+      now: () => t0 + 1,
+      emitEvent: () => {},
+      postComment: () => {},
+      labelNeedsHuman: () => {},
+      writeSignal: () => {},
+    });
+    expect(out).toEqual([]);
+  });
+
+  test("after the sweep, skipReason flips from attempts-exhausted to escalated (TTL-governed re-entry)", () => {
+    const t0 = 1_000_000_000_000;
+    defaultRecordIntent("CTL-Y", { decision: "fix", fix_class: "bounded-llm", attempts: RECOVERY_MAX_ATTEMPTS }, { orchDir, now: () => t0 });
+    expect(defaultSkipReason("CTL-Y", { orchDir, now: () => t0 + RECOVERY_COOLDOWN_MS * 10 })).toBe("attempts-exhausted");
+    escalateExhaustedIntents(orchDir, { now: () => t0 + 1, emitEvent: () => {}, postComment: () => {}, labelNeedsHuman: () => {}, writeSignal: () => {} });
+    expect(defaultSkipReason("CTL-Y", { orchDir, now: () => t0 + 2 })).toBe("escalated");
+    // …and B1's terminal TTL ages it back into triage.
+    expect(defaultSkipReason("CTL-Y", { orchDir, now: () => t0 + 2 + RECOVERY_TERMINAL_INTENT_TTL_MS })).toBeNull();
   });
 });

--- a/plugins/dev/scripts/execution-core/scheduler.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.mjs
@@ -233,6 +233,8 @@ import {
 import {
   reasoningRecoveryPass,
   defaultShouldSkipItem as recoveryShouldSkipItem,
+  defaultSkipReason as recoverySkipReason, // CTL-1440 (P0b): exhausted-vs-cooldown truth
+  escalateExhaustedIntents, // CTL-1440 (P0b): attempts-exhausted → loud escalation
   readDeferredBoardHealthIntents, // CTL-1432 (B2): deferred board-health anchor candidates
   defaultRecordIntent as recoveryRecordIntent,
   // CTL-1242 (corrected scope): forget the host-local recovery-intent latch when
@@ -4149,6 +4151,26 @@ export function schedulerTick(
           db: getBeliefsDb(),
           getBeliefs: getEscalateHumanBelief,
         });
+        // CTL-1440 (P0b): terminal-state policy — attempts-exhausted intents
+        // escalate LOUDLY (ledger escalated:true + needs-human + curated brief +
+        // app-actor comment + recovery.escalated event) instead of silently
+        // latching forever (audit RC1: nothing un-latched an attempts-exhausted
+        // open ticket). Runs BEFORE the per-item pass so a freshly-escalated
+        // ticket is skipped as "escalated" (B1's TTL governs re-entry) rather
+        // than "attempts-exhausted". Enforce-only — shadow must not write
+        // labels/comments. Idempotent: escalated:true excludes future scans.
+        if (rMode === "enforce") {
+          try {
+            escalateExhaustedIntents(orchDir, {
+              labelNeedsHuman: (dir, t) =>
+                labelNeedsHumanUnlessBeliefOwner(dir, t, writeStatus, {
+                  site: "attempts-exhausted",
+                }),
+            });
+          } catch (err) {
+            log.warn({ err: err?.message }, "ctl-1440: exhausted-intent sweep threw — continuing tick");
+          }
+        }
         if (rItems.length > 0) {
           // CTL-1176: BIND the host-local ledger + act-seams to THIS tick's real
           // orchDir. Without this the defaults call resolveOrchDir() →
@@ -6785,6 +6807,7 @@ function runTick() {
             { anchor, candidates, boardContext, decision },
             {
               shouldSkipItem: (cand) => recoveryShouldSkipItem(cand, deps),
+              skipReason: (cand) => recoverySkipReason(cand, deps), // CTL-1440 (P0b)
               invokeRecoveryPass: (cand, ctx) => recoveryInvokeRecoveryPass(cand, ctx, deps),
               recordIntent: (cand, intent) => recoveryRecordIntent(cand, intent, deps),
             },
@@ -6881,12 +6904,23 @@ function scheduleDebouncedTick(debounceMs) {
 // result, or {dispatched:false, reason:"all-candidates-cooldown"} when none dispatched.
 export function holisticBoardHealthAct(
   { anchor = null, candidates = [], boardContext, decision } = {},
-  { shouldSkipItem, invokeRecoveryPass, recordIntent } = {}
+  { shouldSkipItem, invokeRecoveryPass, recordIntent, skipReason = null } = {}
 ) {
   const ordered = candidates.length ? candidates : (anchor ? [anchor] : []);
+  // CTL-1440 (P0b): track WHY candidates were ledger-skipped so the no-dispatch
+  // return distinguishes "everything is terminally attempts-exhausted" (a
+  // truthful non-wedge — the exhaustion sweep has escalated them to a human)
+  // from a genuine retryable cooldown (the old blanket "all-candidates-cooldown"
+  // misnomer that made C1/C2 lie — audit RC1).
+  let ledgerSkips = 0;
+  let exhaustedSkips = 0;
   for (const cand of ordered) {
     // (a) cooldown/attempts-latched → try the next candidate (MUST-FIX 2).
-    if (shouldSkipItem(cand)) continue;
+    if (shouldSkipItem(cand)) {
+      ledgerSkips += 1;
+      if (skipReason?.(cand) === "attempts-exhausted") exhaustedSkips += 1;
+      continue;
+    }
     const r = invokeRecoveryPass(cand, {
       boardContext,
       reason: `board-health: ${decision?.gate?.reason ?? "board anomaly"} — holistic recovery-pass delegate`,
@@ -6912,7 +6946,15 @@ export function holisticBoardHealthAct(
     // event's act.anchor records the real dispatch handle.
     return { ...r, candidate: cand }; // exactly ONE real dispatch per scan
   }
-  return { dispatched: false, reason: "all-candidates-cooldown" };
+  // Every ledger skip was terminal exhaustion → say so (C2 treats it as a
+  // truthful non-wedge); any retryable/mixed skip keeps the cooldown reason.
+  return {
+    dispatched: false,
+    reason:
+      ledgerSkips > 0 && exhaustedSkips === ledgerSkips
+        ? "all-candidates-exhausted"
+        : "all-candidates-cooldown",
+  };
 }
 
 // startScheduler — immediate authoritative tick, arm the periodic timer, then

--- a/plugins/dev/scripts/execution-core/scheduler.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.mjs
@@ -4159,13 +4159,29 @@ export function schedulerTick(
         // ticket is skipped as "escalated" (B1's TTL governs re-entry) rather
         // than "attempts-exhausted". Enforce-only — shadow must not write
         // labels/comments. Idempotent: escalated:true excludes future scans.
-        if (rMode === "enforce") {
+        // Codex R1: board-health is independently operator-gated — an exhausted
+        // board-health candidate must escalate loudly even when the per-item
+        // recovery pass is off (the new all-candidates-exhausted reason is
+        // excluded from C2's wedge set, so WITHOUT this sweep nothing would
+        // ever surface those tickets).
+        const _bhModeForSweep = readBoardHealthConfig().mode;
+        if (rMode === "enforce" || _bhModeForSweep === "enforce") {
           try {
             escalateExhaustedIntents(orchDir, {
               labelNeedsHuman: (dir, t) =>
                 labelNeedsHumanUnlessBeliefOwner(dir, t, writeStatus, {
                   site: "attempts-exhausted",
                 }),
+              // Codex R1: a finished ticket's stale ledger is forgotten by the
+              // terminal cleanup LATER in the tick — never page a human for it.
+              // Cached/replica-first read; fail-open toward active.
+              isActive: (t) =>
+                !isTicketTerminalOrMerged({
+                  ticket: t,
+                  cache,
+                  fetchState: (id, o = {}) =>
+                    fetchTicketState(id, { ...o, cache, gateway, replica, probeBackoff: true }),
+                })?.terminal,
             });
           } catch (err) {
             log.warn({ err: err?.message }, "ctl-1440: exhausted-intent sweep threw — continuing tick");
@@ -6806,8 +6822,12 @@ function runTick() {
           return holisticBoardHealthAct(
             { anchor, candidates, boardContext, decision },
             {
-              shouldSkipItem: (cand) => recoveryShouldSkipItem(cand, deps),
-              skipReason: (cand) => recoverySkipReason(cand, deps), // CTL-1440 (P0b)
+              // CTL-1440 (Codex R1): holistic:true — a board-health defer is
+              // gated on its FROZEN deferredSince anchor here (an aged deferred
+              // anchor stays actionable even when the per-item pass re-deferred
+              // it moments ago); the per-item pass keeps the lastTs throttle.
+              shouldSkipItem: (cand) => recoveryShouldSkipItem(cand, { ...deps, holistic: true }),
+              skipReason: (cand) => recoverySkipReason(cand, { ...deps, holistic: true }), // CTL-1440 (P0b)
               invokeRecoveryPass: (cand, ctx) => recoveryInvokeRecoveryPass(cand, ctx, deps),
               recordIntent: (cand, intent) => recoveryRecordIntent(cand, intent, deps),
             },
@@ -6913,14 +6933,21 @@ export function holisticBoardHealthAct(
   // from a genuine retryable cooldown (the old blanket "all-candidates-cooldown"
   // misnomer that made C1/C2 lie — audit RC1).
   let ledgerSkips = 0;
-  let exhaustedSkips = 0;
+  let terminalSkips = 0;
+  let invoked = 0;
+  // Codex R1: the terminal set includes "escalated" (the exhaustion sweep runs
+  // BEFORE this act and rewrites exhausted ledgers to escalated — the cohort is
+  // human-owned either way) and "leave-alone" (verified healthy). All three are
+  // truthful non-wedges; only genuine cooldown/defer skips stay retryable.
+  const TERMINAL_SKIPS = new Set(["attempts-exhausted", "escalated", "leave-alone"]);
   for (const cand of ordered) {
     // (a) cooldown/attempts-latched → try the next candidate (MUST-FIX 2).
     if (shouldSkipItem(cand)) {
       ledgerSkips += 1;
-      if (skipReason?.(cand) === "attempts-exhausted") exhaustedSkips += 1;
+      if (TERMINAL_SKIPS.has(skipReason?.(cand))) terminalSkips += 1;
       continue;
     }
+    invoked += 1;
     const r = invokeRecoveryPass(cand, {
       boardContext,
       reason: `board-health: ${decision?.gate?.reason ?? "board anomaly"} — holistic recovery-pass delegate`,
@@ -6946,12 +6973,15 @@ export function holisticBoardHealthAct(
     // event's act.anchor records the real dispatch handle.
     return { ...r, candidate: cand }; // exactly ONE real dispatch per scan
   }
-  // Every ledger skip was terminal exhaustion → say so (C2 treats it as a
-  // truthful non-wedge); any retryable/mixed skip keeps the cooldown reason.
+  // EVERY candidate was a terminal ledger skip (exhausted / escalated /
+  // leave-alone) and NONE was invoked → the cohort is truthfully done (C2
+  // non-wedge). Any invoke (even a non-dispatch result — cycle cap, latched)
+  // or any retryable skip keeps the cooldown reason (Codex R1: an actionable
+  // candidate that merely failed to dispatch is NOT a terminal cohort).
   return {
     dispatched: false,
     reason:
-      ledgerSkips > 0 && exhaustedSkips === ledgerSkips
+      invoked === 0 && ledgerSkips > 0 && terminalSkips === ledgerSkips
         ? "all-candidates-exhausted"
         : "all-candidates-cooldown",
   };


### PR DESCRIPTION
## What

Closes **RC1** (the 2-strike permanent silent latch) and **RC3** (the lastTs field collision behind the every-2-3s defer storm) from the 2026-07-08 root-cause audit. Builds on P0a (#2586).

## Changes

- **`escalateExhaustedIntents`** — per-tick, enforce-only, idempotent sweep: an exhausted no-verdict intent (`dispatched`/`fix`, `attempts >= RECOVERY_MAX_ATTEMPTS`, `!escalated`) escalates **loudly**: ledger `escalated:true` (B1's 7-day TTL then ages it back into triage — the latch is no longer permanent), attempts pinned, needs-human via the label-guard path, a curated `authorization` brief on the recovery-pass signal (renders in the existing monitor Needs-You inbox), an app-actor comment, and a ticket-tagged `recovery.escalated` event. Wired into `schedulerTick` before the per-item pass.
- **`defaultSkipReason`** — the reason-bearing skip gate (`defer-cooldown | escalated | leave-alone | attempts-exhausted | cooldown`); `defaultShouldSkipItem` is now its boolean view (byte-identical semantics, asserted by a mirror test). `holisticBoardHealthAct` gains a `skipReason` seam and returns **`all-candidates-exhausted`** when every ledger skip was terminal exhaustion — `WEDGE_SKIP_REASONS` deliberately excludes it (a fully-escalated cohort is the delegate being truthfully done, not wedged), fixing the C1/C2 misnomer.
- **RC3 decoupling** (replaces the CTL-1432 freeze): `deferredSince` = the frozen aging anchor (consumer key, legacy frozen entries fall back to `lastTs`); `lastTs` always refreshes (cooldown gates are real again). Re-defers throttle to once per window; the board-health consumer is never starved (the r4 guarantee holds — test updated to the new semantics with an explicit legacy-fallback test).

## Tests

recovery-reasoning **142 pass** (+5), board-health-seam **11 pass** (+2), board-health **102 pass**, import graph resolves. All suites CI-registered.

## Expected live effect

The 7-ticket frozen set stops dead-ending silently: exhausted intents surface as needs-human + brief + comment within one tick, C2 stops flagging (or flags truthfully), and OTL-13's defer-storm class cannot recur. Mission-test items 1–3 for CTL-1157.

Part of **CTL-1157** (P0b).

🤖 Generated with [Claude Code](https://claude.com/claude-code)