### PR TITLE
feat(dev): CTL-1443 (P1-loop-3) — operable boot-resume approval gate (approve CLI + 48h expiry into Needs-You + alert)

### DIFF
--- a/plugins/dev/scripts/check-setup.sh
+++ b/plugins/dev/scripts/check-setup.sh
@@ -86,7 +86,7 @@ done
 header "Catalyst CLI Install"
 
 CLI_BIN_DIR="${CATALYST_CLI_BIN_DIR:-$HOME/.catalyst/bin}"
-CLI_NAMES=(catalyst catalyst-backup catalyst-install catalyst-broker catalyst-comms catalyst-events catalyst-execution-core catalyst-filter catalyst-linear catalyst-linear-reconcile catalyst-otel-forward catalyst-transitions catalyst-why catalyst-session catalyst-state catalyst-statusline catalyst-db catalyst-monitor catalyst-thoughts catalyst-claude catalyst-stack)
+CLI_NAMES=(catalyst catalyst-backup catalyst-install catalyst-broker catalyst-comms catalyst-events catalyst-execution-core catalyst-filter catalyst-linear catalyst-linear-reconcile catalyst-otel-forward catalyst-transitions catalyst-why catalyst-session catalyst-state catalyst-statusline catalyst-db catalyst-monitor catalyst-thoughts catalyst-claude catalyst-stack boot-resume-approve)
 
 if [[ -d "$CLI_BIN_DIR" ]]; then
     pass "Bin dir exists: $CLI_BIN_DIR"

--- a/plugins/dev/scripts/execution-core/boot-resume-approval.test.mjs
+++ b/plugins/dev/scripts/execution-core/boot-resume-approval.test.mjs
@@ -291,7 +291,8 @@ describe("boot-resume approval surfacing (CTL-1443)", () => {
     const sig = JSON.parse(
       readFileSync(join(orchDir, "workers", "OTL-41", "phase-recovery-pass.json"), "utf8"),
     );
-    expect(sig.status).toBe("needs-human");
+    expect(sig.status).toBe("stalled"); // terminal-sweep-owned label lifecycle (Codex R2)
+    expect(sig.stalledReason).toBe("boot-resume-gate-expired");
     expect(sig.ticket).toBe("OTL-41");
     expect(sig.explanation.escalation_type).toBe("authorization");
     expect(sig.explanation.call_to_action).toContain("boot-resume-approve");
@@ -326,5 +327,15 @@ describe("boot-resume approval surfacing (CTL-1443)", () => {
     });
     expect(alerts.length).toBe(1);
     expect(alerts[0].identifier).toBe("CTL-4");
+  });
+});
+
+describe("boot-resume approval lifetime (CTL-1443 Codex R2)", () => {
+  test("classifyStalledTicket skips gate-expired parks (no unstuck re-ask loop)", async () => {
+    const { classifyStalledTicket } = await import("./unstuck-sweep.mjs");
+    expect(classifyStalledTicket({ reason: "boot-resume-gate-expired" })).toEqual({
+      category: "skip",
+      action: "skip",
+    });
   });
 });

--- a/plugins/dev/scripts/execution-core/boot-resume-approval.test.mjs
+++ b/plugins/dev/scripts/execution-core/boot-resume-approval.test.mjs
@@ -277,12 +277,17 @@ describe("boot-resume approval surfacing (CTL-1443)", () => {
     const now = Date.now();
     writeGate("OTL-41", "recovery-pass", now - BOOT_RESUME_PENDING_TTL_MS - 1000);
     const alerts = [];
+    const labels = [];
     const out = surfaceStalePendingApprovals({
       orchDir,
       now: () => now,
       emitAlert: (a) => alerts.push(a),
+      labelNeedsHuman: (dir, t) => labels.push(t),
     });
     expect(out).toEqual(["OTL-41"]);
+    // Codex P1: the needs-human LABEL is what deriveAttention keys on — the
+    // signal explanation alone never reaches the Needs-You bucket.
+    expect(labels).toEqual(["OTL-41"]);
     const sig = JSON.parse(
       readFileSync(join(orchDir, "workers", "OTL-41", "phase-recovery-pass.json"), "utf8"),
     );
@@ -290,9 +295,10 @@ describe("boot-resume approval surfacing (CTL-1443)", () => {
     expect(sig.ticket).toBe("OTL-41");
     expect(sig.explanation.escalation_type).toBe("authorization");
     expect(sig.explanation.call_to_action).toContain("boot-resume-approve");
+    expect(sig.worktreePath).toBe("/wt"); // Codex P2: preserved for the CTL-615 revive cross-check
     expect(alerts[0].identifier).toBe("OTL-41");
     // idempotent: the surfacedAt stamp suppresses a second surfacing
-    const out2 = surfaceStalePendingApprovals({ orchDir, now: () => now, emitAlert: (a) => alerts.push(a) });
+    const out2 = surfaceStalePendingApprovals({ orchDir, now: () => now, emitAlert: (a) => alerts.push(a), labelNeedsHuman: () => {} });
     expect(out2).toEqual([]);
     expect(alerts.length).toBe(1);
     // and approval still works after surfacing (marker retained)
@@ -304,7 +310,7 @@ describe("boot-resume approval surfacing (CTL-1443)", () => {
     writeGate("CTL-2", "implement", now - 1000); // fresh
     writeGate("CTL-3", "implement", now - BOOT_RESUME_PENDING_TTL_MS - 1000); // stale but approved
     writeFileSync(bootResumeApprovedPath(orchDir, "CTL-3"), "");
-    expect(surfaceStalePendingApprovals({ orchDir, now: () => now, emitAlert: () => {} })).toEqual([]);
+    expect(surfaceStalePendingApprovals({ orchDir, now: () => now, emitAlert: () => {}, labelNeedsHuman: () => {} })).toEqual([]);
   });
 
   test("processApprovedResumes runs the sweep (stale gate surfaces on the normal tick path)", () => {
@@ -316,6 +322,7 @@ describe("boot-resume approval surfacing (CTL-1443)", () => {
       reviveDispatch: () => ({ code: 0 }),
       appendEvent: () => {},
       emitStaleGateAlert: (a) => alerts.push(a),
+      staleGateLabelNeedsHuman: () => {},
     });
     expect(alerts.length).toBe(1);
     expect(alerts[0].identifier).toBe("CTL-4");

--- a/plugins/dev/scripts/execution-core/boot-resume-approval.test.mjs
+++ b/plugins/dev/scripts/execution-core/boot-resume-approval.test.mjs
@@ -11,7 +11,12 @@ import {
   processApprovedResumes,
   bootResumePendingPath,
   bootResumeApprovedPath,
+  listPendingApprovals,
+  approveBootResume,
+  surfaceStalePendingApprovals,
+  BOOT_RESUME_PENDING_TTL_MS,
 } from "./boot-resume.mjs";
+import { readFileSync } from "node:fs";
 import { defaultReviveDispatch } from "./recovery.mjs"; // CTL-1367 P1: real revive seam for the async-dispatch behavior test
 
 let orchDir;
@@ -235,5 +240,84 @@ describe("processApprovedResumes (CTL-644)", () => {
       appendEvent: () => true,
     });
     expect(res).toMatchObject({ dispatched: 0, failed: 0 });
+  });
+});
+
+// ─── CTL-1443 (P1-loop-3): the gate becomes operable — list / approve / expire ─
+describe("boot-resume approval surfacing (CTL-1443)", () => {
+  const writeGate = (ticket, phase, requestedAtMs) => {
+    mkdirSync(join(orchDir, "workers", ticket), { recursive: true });
+    writeFileSync(
+      bootResumePendingPath(orchDir, ticket),
+      JSON.stringify({ ticket, phase, worktreePath: "/wt", requestedAt: new Date(requestedAtMs).toISOString() }),
+    );
+  };
+
+  test("listPendingApprovals enumerates gates with age + approval state", () => {
+    const now = Date.now();
+    writeGate("OTL-41", "recovery-pass", now - 5 * 3600e3);
+    writeGate("CTL-1", "implement", now - 1000);
+    writeFileSync(bootResumeApprovedPath(orchDir, "CTL-1"), "");
+    const gates = listPendingApprovals(orchDir, { now: () => now });
+    const byTicket = Object.fromEntries(gates.map((g) => [g.ticket, g]));
+    expect(byTicket["OTL-41"].phase).toBe("recovery-pass");
+    expect(byTicket["OTL-41"].approved).toBe(false);
+    expect(byTicket["OTL-41"].ageMs).toBeGreaterThan(4 * 3600e3);
+    expect(byTicket["CTL-1"].approved).toBe(true);
+  });
+
+  test("approveBootResume writes the sentinel; refuses without a gate", () => {
+    writeGate("OTL-41", "recovery-pass", Date.now());
+    expect(approveBootResume(orchDir, "OTL-41")).toEqual({ approved: true });
+    expect(existsSync(bootResumeApprovedPath(orchDir, "OTL-41"))).toBe(true);
+    expect(approveBootResume(orchDir, "CTL-none").approved).toBe(false);
+  });
+
+  test("a stale gate surfaces ONCE: needs-human signal with a brief + alert + surfacedAt stamp", () => {
+    const now = Date.now();
+    writeGate("OTL-41", "recovery-pass", now - BOOT_RESUME_PENDING_TTL_MS - 1000);
+    const alerts = [];
+    const out = surfaceStalePendingApprovals({
+      orchDir,
+      now: () => now,
+      emitAlert: (a) => alerts.push(a),
+    });
+    expect(out).toEqual(["OTL-41"]);
+    const sig = JSON.parse(
+      readFileSync(join(orchDir, "workers", "OTL-41", "phase-recovery-pass.json"), "utf8"),
+    );
+    expect(sig.status).toBe("needs-human");
+    expect(sig.ticket).toBe("OTL-41");
+    expect(sig.explanation.escalation_type).toBe("authorization");
+    expect(sig.explanation.call_to_action).toContain("boot-resume-approve");
+    expect(alerts[0].identifier).toBe("OTL-41");
+    // idempotent: the surfacedAt stamp suppresses a second surfacing
+    const out2 = surfaceStalePendingApprovals({ orchDir, now: () => now, emitAlert: (a) => alerts.push(a) });
+    expect(out2).toEqual([]);
+    expect(alerts.length).toBe(1);
+    // and approval still works after surfacing (marker retained)
+    expect(approveBootResume(orchDir, "OTL-41")).toEqual({ approved: true });
+  });
+
+  test("fresh and approved gates are never surfaced", () => {
+    const now = Date.now();
+    writeGate("CTL-2", "implement", now - 1000); // fresh
+    writeGate("CTL-3", "implement", now - BOOT_RESUME_PENDING_TTL_MS - 1000); // stale but approved
+    writeFileSync(bootResumeApprovedPath(orchDir, "CTL-3"), "");
+    expect(surfaceStalePendingApprovals({ orchDir, now: () => now, emitAlert: () => {} })).toEqual([]);
+  });
+
+  test("processApprovedResumes runs the sweep (stale gate surfaces on the normal tick path)", () => {
+    const now = Date.now();
+    writeGate("CTL-4", "implement", now - BOOT_RESUME_PENDING_TTL_MS - 1000);
+    const alerts = [];
+    processApprovedResumes({
+      orchDir,
+      reviveDispatch: () => ({ code: 0 }),
+      appendEvent: () => {},
+      emitStaleGateAlert: (a) => alerts.push(a),
+    });
+    expect(alerts.length).toBe(1);
+    expect(alerts[0].identifier).toBe("CTL-4");
   });
 });

--- a/plugins/dev/scripts/execution-core/boot-resume-approve.mjs
+++ b/plugins/dev/scripts/execution-core/boot-resume-approve.mjs
@@ -1,0 +1,89 @@
+#!/usr/bin/env node
+// boot-resume-approve.mjs — CTL-1443: the operator tooling the CTL-644 approval
+// gate always referenced but never had ("empty sentinel written by the operator
+// (or a HUD button)" — nothing wrote it). List gated tickets; approve one.
+//
+//   boot-resume-approve.mjs --list [--orch-dir D]
+//   boot-resume-approve.mjs <ticket> [--orch-dir D]
+//
+// Approval writes the .boot-resume-approved sentinel; the daemon's every-tick
+// processApprovedResumes dispatches the gated phase (no restart needed).
+//
+// STANDALONE on purpose: boot-resume.mjs transitively imports bun-only modules
+// (scheduler → bun:sqlite), and this CLI must run under plain node. The two
+// marker paths are a stable contract (boot-resume.mjs bootResumePendingPath /
+// bootResumeApprovedPath — change them together).
+
+import { existsSync, readdirSync, readFileSync, writeFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+const argv = process.argv.slice(2);
+function get(flag) {
+  const i = argv.indexOf(flag);
+  return i >= 0 ? argv[i + 1] : undefined;
+}
+const orchDir =
+  get("--orch-dir") ??
+  process.env.CATALYST_ORCHESTRATOR_DIR ??
+  join(process.env.CATALYST_DIR ?? join(homedir(), "catalyst"), "execution-core");
+
+const pendingPath = (t) => join(orchDir, "workers", t, ".boot-resume-pending-approval");
+const approvedPath = (t) => join(orchDir, "workers", t, ".boot-resume-approved");
+
+if (argv.includes("--list")) {
+  let tickets = [];
+  try {
+    tickets = readdirSync(join(orchDir, "workers"), { withFileTypes: true })
+      .filter((e) => e.isDirectory())
+      .map((e) => e.name);
+  } catch {
+    /* no workers dir → empty */
+  }
+  const gates = [];
+  for (const t of tickets) {
+    if (!existsSync(pendingPath(t))) continue;
+    let pending = {};
+    try {
+      pending = JSON.parse(readFileSync(pendingPath(t), "utf8")) ?? {};
+    } catch {
+      /* unreadable marker still listed */
+    }
+    const requestedMs = Date.parse(pending.requestedAt ?? "") || null;
+    gates.push({
+      ticket: t,
+      phase: pending.phase ?? "?",
+      age: requestedMs ? `${Math.round((Date.now() - requestedMs) / 3600e3)}h` : "?",
+      approved: existsSync(approvedPath(t)),
+      surfaced: Boolean(pending.surfacedAt),
+    });
+  }
+  if (gates.length === 0) {
+    process.stdout.write("no pending boot-resume approval gates\n");
+    process.exit(0);
+  }
+  for (const g of gates) {
+    process.stdout.write(
+      `${g.ticket}\tphase=${g.phase}\tage=${g.age}\tapproved=${g.approved}\tsurfaced=${g.surfaced ? "yes" : "no"}\n`,
+    );
+  }
+  process.exit(0);
+}
+
+const orchDirFlagValue = get("--orch-dir");
+const ticket = argv.find((a) => !a.startsWith("--") && a !== orchDirFlagValue);
+if (!ticket) {
+  process.stderr.write("usage: boot-resume-approve.mjs <ticket> | --list [--orch-dir D]\n");
+  process.exit(2);
+}
+if (!existsSync(pendingPath(ticket))) {
+  process.stderr.write(`boot-resume-approve: ${ticket}: no-pending-gate\n`);
+  process.exit(1);
+}
+try {
+  writeFileSync(approvedPath(ticket), "");
+} catch (err) {
+  process.stderr.write(`boot-resume-approve: ${ticket}: ${err.message}\n`);
+  process.exit(1);
+}
+process.stdout.write(`${ticket} approved — the daemon's next tick dispatches the gated phase\n`);

--- a/plugins/dev/scripts/execution-core/boot-resume.mjs
+++ b/plugins/dev/scripts/execution-core/boot-resume.mjs
@@ -35,11 +35,13 @@ import {
   mkdirSync,
   readdirSync,
   readFileSync,
+  renameSync,
   rmSync,
   unlinkSync,
   writeFileSync,
 } from "node:fs";
 import { join } from "node:path";
+import { emitBootResumePending as defaultEmitBootResumePending } from "./dispatch-alert.mjs"; // CTL-1443
 import {
   readWorkerSignals,
   readAllPhaseSignals,
@@ -112,6 +114,133 @@ function readPendingMarker(orchDir, ticket) {
   } catch {
     return null;
   }
+}
+
+// ─── CTL-1443 (P1-loop-3): the approval gate becomes OPERABLE ───────────────
+//
+// The pending marker was written with a companion "operator (or a HUD button)"
+// approval sentinel that NOTHING ever wrote, no surface displayed, and no TTL
+// expired — a gated ticket sat invisible forever (OTL-41: 4+ days). Three
+// additions: a list/approve API (fronted by boot-resume-approve.mjs), and a
+// per-tick expiry sweep that surfaces a stale gate ONCE into the existing
+// Needs-You pipeline (explanation on the gated phase's signal) + a
+// catalyst.alert.boot_resume_pending event.
+
+export const BOOT_RESUME_PENDING_TTL_MS =
+  Number(process.env.CATALYST_BOOT_RESUME_PENDING_TTL_H) * 3600e3 || 48 * 3600e3;
+
+// listPendingApprovals — every gated ticket with its age + approval state.
+export function listPendingApprovals(orchDir, { now = () => Date.now() } = {}) {
+  const workersDir = join(orchDir, "workers");
+  let tickets;
+  try {
+    tickets = readdirSync(workersDir, { withFileTypes: true })
+      .filter((e) => e.isDirectory())
+      .map((e) => e.name);
+  } catch {
+    return [];
+  }
+  const out = [];
+  for (const ticket of tickets) {
+    if (!existsSync(bootResumePendingPath(orchDir, ticket))) continue;
+    const pending = readPendingMarker(orchDir, ticket) ?? {};
+    const requestedMs = Date.parse(pending.requestedAt ?? "") || null;
+    out.push({
+      ticket,
+      phase: pending.phase ?? null,
+      requestedAt: pending.requestedAt ?? null,
+      ageMs: requestedMs != null ? Math.max(0, now() - requestedMs) : null,
+      approved: existsSync(bootResumeApprovedPath(orchDir, ticket)),
+      surfacedAt: pending.surfacedAt ?? null,
+    });
+  }
+  return out;
+}
+
+// approveBootResume — write the approval sentinel; the every-tick
+// processApprovedResumes picks it up (no restart). Refuses when no gate exists.
+export function approveBootResume(orchDir, ticket) {
+  if (!existsSync(bootResumePendingPath(orchDir, ticket))) {
+    return { approved: false, reason: "no-pending-gate" };
+  }
+  try {
+    writeFileSync(bootResumeApprovedPath(orchDir, ticket), "");
+    return { approved: true };
+  } catch (err) {
+    return { approved: false, reason: err?.message ?? String(err) };
+  }
+}
+
+// surfaceStalePendingApprovals — a pending gate older than the TTL surfaces
+// ONCE: the gated phase's signal gains status:"needs-human" + a curated
+// explanation (the monitor's existing Needs-You inbox renders it via
+// deriveExplanation) and a catalyst.alert.boot_resume_pending event fires. The
+// marker itself stays (approval still works); surfacedAt on the marker is the
+// per-ticket dedupe. Never throws; returns the tickets surfaced.
+export function surfaceStalePendingApprovals({
+  orchDir,
+  now = () => Date.now(),
+  ttlMs = BOOT_RESUME_PENDING_TTL_MS,
+  emitAlert = null, // ({identifier, phase, ageHours}) => void — daemon wires emitBootResumePending
+} = {}) {
+  const surfaced = [];
+  for (const gate of listPendingApprovals(orchDir, { now })) {
+    if (gate.approved || gate.surfacedAt) continue;
+    if (gate.ageMs == null || gate.ageMs < ttlMs) continue;
+    const { ticket, phase } = gate;
+    const ageHours = Math.round(gate.ageMs / 3600e3);
+    // (1) explanation onto the GATED phase's signal → the Needs-You inbox.
+    const sigPath = join(orchDir, "workers", ticket, `phase-${phase}.json`);
+    try {
+      let sig = {};
+      try {
+        sig = JSON.parse(readFileSync(sigPath, "utf8")) ?? {};
+      } catch {
+        sig = {};
+      }
+      if (!sig.ticket) sig.ticket = ticket;
+      if (!sig.phase) sig.phase = phase;
+      sig.status = "needs-human";
+      if (!sig.needsHumanSince) sig.needsHumanSince = new Date(now()).toISOString();
+      sig.updatedAt = new Date(now()).toISOString();
+      sig.explanation = {
+        escalation_type: "authorization",
+        problem: `${ticket}'s ${phase} resume has been gated behind boot-resume approval for ${ageHours}h with no operator response — expensive phases require explicit approval after a cold start, and nothing was surfacing the ask.`,
+        call_to_action: `approve the ${phase} resume for ${ticket} (boot-resume-approve.mjs ${ticket}), or take the ticket over?`,
+        recommendation: `approve the resume — the gate exists to prevent silent expensive re-runs, not to park the ticket`,
+        risk: `left unapproved the ticket stays frozen invisibly (the OTL-41 failure mode)`,
+        why_asking: "the CTL-644 cold-start gate requires operator approval for expensive phases",
+        observed: { gate_age_hours: ageHours, phase },
+        attempts: [],
+      };
+      const tmp = `${sigPath}.tmp.${process.pid}`;
+      writeFileSync(tmp, JSON.stringify(sig, null, 2));
+      renameSync(tmp, sigPath);
+    } catch (err) {
+      log.warn({ ticket, phase, err: err?.message }, "ctl-1443: stale-gate signal surfacing failed — will retry next tick");
+      continue; // no surfacedAt stamp → retried next tick
+    }
+    // (2) the durable alert event (throttled per-kind inside the emitter).
+    try {
+      emitAlert?.({ identifier: ticket, phase, ageHours });
+    } catch {
+      /* alert is best-effort; the signal is the operator surface */
+    }
+    // (3) dedupe stamp on the marker (approval still works; marker retained).
+    try {
+      const pending = readPendingMarker(orchDir, ticket) ?? { ticket, phase };
+      pending.surfacedAt = new Date(now()).toISOString();
+      writeFileSync(bootResumePendingPath(orchDir, ticket), JSON.stringify(pending));
+    } catch (err) {
+      log.warn({ ticket, err: err?.message }, "ctl-1443: surfacedAt stamp failed — the gate may re-surface next tick");
+    }
+    log.warn(
+      { ticket, phase, ageHours },
+      "ctl-1443: boot-resume approval gate exceeded its TTL — surfaced to Needs-You (approve with boot-resume-approve.mjs)"
+    );
+    surfaced.push(ticket);
+  }
+  return surfaced;
 }
 
 // hasLiveBgWorker — does `agents` contain a live BACKGROUND session whose cwd is
@@ -582,7 +711,18 @@ export function processApprovedResumes({
   dispatch = defaultDispatch,
   appendEvent = defaultAppendBootResumeEvent,
   orchId = undefined,
+  // CTL-1443: the stale-gate expiry sweep rides the same every-tick call so no
+  // scheduler wiring is needed. Injectable for tests; emitAlert defaults to the
+  // real dispatch-alert emitter (lazy import avoided — passed by the caller or
+  // defaulted here at call time).
+  surfaceStaleGates = (o) => surfaceStalePendingApprovals(o),
+  emitStaleGateAlert = defaultEmitBootResumePending,
 } = {}) {
+  try {
+    surfaceStaleGates({ orchDir, emitAlert: emitStaleGateAlert });
+  } catch (err) {
+    log.warn({ err: err?.message }, "ctl-1443: stale-gate sweep threw — continuing");
+  }
   const workersDir = join(orchDir, "workers");
   let tickets;
   try {

--- a/plugins/dev/scripts/execution-core/boot-resume.mjs
+++ b/plugins/dev/scripts/execution-core/boot-resume.mjs
@@ -42,6 +42,8 @@ import {
 } from "node:fs";
 import { join } from "node:path";
 import { emitBootResumePending as defaultEmitBootResumePending } from "./dispatch-alert.mjs"; // CTL-1443
+import { labelNeedsHumanUnlessBeliefOwner } from "./label-guard.mjs"; // CTL-1443 (Codex P1)
+import { applyLabel as defaultApplyLabel } from "./linear-write.mjs"; // CTL-1443 (Codex P1)
 import {
   readWorkerSignals,
   readAllPhaseSignals,
@@ -148,6 +150,7 @@ export function listPendingApprovals(orchDir, { now = () => Date.now() } = {}) {
     out.push({
       ticket,
       phase: pending.phase ?? null,
+      worktreePath: pending.worktreePath ?? null,
       requestedAt: pending.requestedAt ?? null,
       ageMs: requestedMs != null ? Math.max(0, now() - requestedMs) : null,
       approved: existsSync(bootResumeApprovedPath(orchDir, ticket)),
@@ -182,6 +185,12 @@ export function surfaceStalePendingApprovals({
   now = () => Date.now(),
   ttlMs = BOOT_RESUME_PENDING_TTL_MS,
   emitAlert = null, // ({identifier, phase, ageHours}) => void — daemon wires emitBootResumePending
+  // Codex P1: the signal explanation alone does NOT enter the monitor's
+  // Needs-You bucket — deriveAttention keys on the needs-human LABEL/marker,
+  // not on a bare status flip. Route through the same label-guard path the
+  // P0b exhaustion sweep uses (labelOnce markers = idempotence).
+  labelNeedsHuman = (dir, t) =>
+    labelNeedsHumanUnlessBeliefOwner(dir, t, { applyLabel: defaultApplyLabel }, { site: "boot-resume-gate" }),
 } = {}) {
   const surfaced = [];
   for (const gate of listPendingApprovals(orchDir, { now })) {
@@ -200,13 +209,17 @@ export function surfaceStalePendingApprovals({
       }
       if (!sig.ticket) sig.ticket = ticket;
       if (!sig.phase) sig.phase = phase;
+      // Codex P2: preserve the gated worktree on a synthetic rewrite — later
+      // approval routes through defaultReviveDispatch, whose CTL-615 worktree
+      // cross-check needs sig.worktreePath.
+      if (!sig.worktreePath && gate.worktreePath) sig.worktreePath = gate.worktreePath;
       sig.status = "needs-human";
       if (!sig.needsHumanSince) sig.needsHumanSince = new Date(now()).toISOString();
       sig.updatedAt = new Date(now()).toISOString();
       sig.explanation = {
         escalation_type: "authorization",
         problem: `${ticket}'s ${phase} resume has been gated behind boot-resume approval for ${ageHours}h with no operator response — expensive phases require explicit approval after a cold start, and nothing was surfacing the ask.`,
-        call_to_action: `approve the ${phase} resume for ${ticket} (boot-resume-approve.mjs ${ticket}), or take the ticket over?`,
+        call_to_action: `approve the ${phase} resume for ${ticket} (run: boot-resume-approve ${ticket}), or take the ticket over?`,
         recommendation: `approve the resume — the gate exists to prevent silent expensive re-runs, not to park the ticket`,
         risk: `left unapproved the ticket stays frozen invisibly (the OTL-41 failure mode)`,
         why_asking: "the CTL-644 cold-start gate requires operator approval for expensive phases",
@@ -219,6 +232,17 @@ export function surfaceStalePendingApprovals({
     } catch (err) {
       log.warn({ ticket, phase, err: err?.message }, "ctl-1443: stale-gate signal surfacing failed — will retry next tick");
       continue; // no surfacedAt stamp → retried next tick
+    }
+    // (1b) Codex P1: the needs-human LABEL is what deriveAttention keys on —
+    // without it the brief never reaches the Needs-You bucket. labelOnce's
+    // markers dedupe; failures retry next tick (no surfacedAt stamp yet? —
+    // the label is retried by virtue of running before the stamp only on the
+    // first pass; subsequent passes are gated by surfacedAt, so a transient
+    // label failure here is retried via labelOnce on the APPROVAL path too).
+    try {
+      labelNeedsHuman?.(orchDir, ticket);
+    } catch (err) {
+      log.warn({ ticket, err: err?.message }, "ctl-1443: needs-human label on stale gate failed — continuing");
     }
     // (2) the durable alert event (throttled per-kind inside the emitter).
     try {
@@ -717,9 +741,14 @@ export function processApprovedResumes({
   // defaulted here at call time).
   surfaceStaleGates = (o) => surfaceStalePendingApprovals(o),
   emitStaleGateAlert = defaultEmitBootResumePending,
+  staleGateLabelNeedsHuman = undefined, // CTL-1443 Codex P1: test seam
 } = {}) {
   try {
-    surfaceStaleGates({ orchDir, emitAlert: emitStaleGateAlert });
+    surfaceStaleGates({
+      orchDir,
+      emitAlert: emitStaleGateAlert,
+      ...(staleGateLabelNeedsHuman ? { labelNeedsHuman: staleGateLabelNeedsHuman } : {}),
+    });
   } catch (err) {
     log.warn({ err: err?.message }, "ctl-1443: stale-gate sweep threw — continuing");
   }

--- a/plugins/dev/scripts/execution-core/boot-resume.mjs
+++ b/plugins/dev/scripts/execution-core/boot-resume.mjs
@@ -213,7 +213,14 @@ export function surfaceStalePendingApprovals({
       // approval routes through defaultReviveDispatch, whose CTL-615 worktree
       // cross-check needs sig.worktreePath.
       if (!sig.worktreePath && gate.worktreePath) sig.worktreePath = gate.worktreePath;
-      sig.status = "needs-human";
+      // Codex R2 (P1): park as STALLED, not a bare needs-human status — the
+      // terminal label sweep preserves/applies the needs-human label only for
+      // stalled/failed signals (and RETRIES it every tick, which also closes
+      // the transient-label-failure gap), and deriveAttention's phaseFailed
+      // predicate keys terminal stalled phases into the Needs-You bucket. The
+      // stalledReason is mapped to skip in the unstuck sweep (no re-ask loop).
+      sig.status = "stalled";
+      sig.stalledReason = "boot-resume-gate-expired";
       if (!sig.needsHumanSince) sig.needsHumanSince = new Date(now()).toISOString();
       sig.updatedAt = new Date(now()).toISOString();
       sig.explanation = {
@@ -680,6 +687,14 @@ export function reconcileBootResume({
     if (warmSession) {
       try {
         rmSync(bootResumePendingPath(orchDir, ticket), { force: true });
+      } catch {
+        /* best-effort */
+      }
+      // CTL-1443 (Codex R2): a superseded gate's APPROVAL must die with it — a
+      // stale ticket-level sentinel would silently auto-authorize the NEXT
+      // expensive-phase gate for the same ticket (approve-once semantics).
+      try {
+        rmSync(bootResumeApprovedPath(orchDir, ticket), { force: true });
       } catch {
         /* best-effort */
       }

--- a/plugins/dev/scripts/execution-core/dispatch-alert.mjs
+++ b/plugins/dev/scripts/execution-core/dispatch-alert.mjs
@@ -34,6 +34,15 @@ export const ALERT_TICKET_STATE_LIVE_FALLBACK = "catalyst.alert.ticket_state_liv
 
 export const ALERT_KIND_TICKET_STATE_LIVE_FALLBACK = "ticket_state_live_fallback";
 
+// CTL-1443 (P1-loop-3): a boot-resume approval gate has sat unapproved past its
+// TTL. The gate itself is invisible by design (a marker file under workers/),
+// so without this alert + the Needs-You surfacing a gated ticket waits forever
+// (OTL-41 sat 4+ days). One line per window per kind — the per-ticket dedupe is
+// the marker's surfacedAt field.
+export const ALERT_BOOT_RESUME_PENDING = "catalyst.alert.boot_resume_pending";
+
+export const ALERT_KIND_BOOT_RESUME_PENDING = "boot_resume_pending";
+
 // Per-kind throttle so a per-tick hot path (runEligibleQuery inside the reconcile
 // timer) cannot spam the event log during a sustained storm. The alert is a LOUD
 // "something is wrong"
@@ -131,6 +140,24 @@ export function emitEligibleSourceUnavailable({ team = null, append, now, thrott
 // missed the replica and its live linearis fallback failed; the ticket is now
 // negative-cached (backed off). `identifier` rides in the payload; `reason` is the
 // failure mode (timeout | error | unparseable).
+export function emitBootResumePending({ identifier = null, phase = null, ageHours = null, reason = null, append, now, throttleMs } = {}) {
+  return emitThrottled({
+    eventName: ALERT_BOOT_RESUME_PENDING,
+    kind: ALERT_KIND_BOOT_RESUME_PENDING,
+    reason:
+      reason ??
+      "a boot-resume approval gate exceeded its TTL with no operator response — surfaced to Needs-You (approve with boot-resume-approve.mjs)",
+    detail: {
+      ...(identifier ? { "linear.ticket": identifier } : {}),
+      ...(phase ? { "catalyst.phase": phase } : {}),
+      ...(ageHours != null ? { "catalyst.gate_age_hours": ageHours } : {}),
+    },
+    append,
+    now,
+    throttleMs,
+  });
+}
+
 export function emitTicketStateLiveFallback({ identifier = null, reason = null, append, now, throttleMs } = {}) {
   return emitThrottled({
     eventName: ALERT_TICKET_STATE_LIVE_FALLBACK,

--- a/plugins/dev/scripts/execution-core/recovery.mjs
+++ b/plugins/dev/scripts/execution-core/recovery.mjs
@@ -2298,11 +2298,17 @@ export function reclaimDeadWorkIfPossible(
             // "authorize retry?" every window (audit RC4). Scoped to the SAME
             // reason (Codex R2): a fresh no-progress ask must not inherit an
             // unrelated wedged-never-started history.
+            // Codex (post-merge #2590 P3): include the CURRENT ask — the marker
+            // is written after the emit, so the record alone is one ask behind
+            // (the terminal brief would show 2 of 3 timestamps).
             attempts:
               extras?.attempts ??
-              (priorEscRecord?.reason === reason && Array.isArray(priorEscRecord?.asks)
-                ? priorEscRecord.asks
-                : []),
+              [
+                ...(priorEscRecord?.reason === reason && Array.isArray(priorEscRecord?.asks)
+                  ? priorEscRecord.asks
+                  : []),
+                now(),
+              ],
           };
     try {
       explanation = buildExplanation(explanationFields);
@@ -2345,7 +2351,7 @@ export function reclaimDeadWorkIfPossible(
       markEscalationCapTerminal({ orchDir, ticket, phase, explanation });
       log.warn(
         { ticket, phase, reason, asks: priorAsks + 1 },
-        "ctl-1442: escalation ask-cap reached — parked terminal (stalled + needs-human + brief); delete the .escalation-cooldowns marker to re-arm"
+        "ctl-1442: escalation ask-cap reached — parked terminal (stalled + needs-human + brief); re-arm by deleting the .escalation-cooldowns marker AND the stalled phase signal (or reply on the ticket — the stall janitor clears both)"
       );
       return "escalation-cap-terminal";
     }

--- a/plugins/dev/scripts/execution-core/recovery.test.mjs
+++ b/plugins/dev/scripts/execution-core/recovery.test.mjs
@@ -2832,7 +2832,9 @@ describe("reclaimDeadWorkIfPossible — CTL-1442 escalation ask-cap", () => {
     recordEscalation(orchDir, "CTL-9", "pr", "wedged-never-started", clock - 31 * 60 * 1000);
     reclaimDeadWorkIfPossible(s.orch, s.sig, s.opts); // first no-progress ask
     const firstAsk = s.opts.appendEscalatedEvent.calls[0][0];
-    expect(firstAsk.extras?.explanation?.attempts ?? []).toEqual([]); // fresh — no wedged history
+    // fresh — no wedged history; exactly the CURRENT ask's timestamp (post-merge
+    // P3: the emitted history includes the ask being made).
+    expect(firstAsk.extras?.explanation?.attempts).toEqual([clock]);
   });
 
   test("a DIFFERENT escalation reason does not consume the no-progress cap (reason change resets the count)", () => {

--- a/plugins/dev/scripts/execution-core/unstuck-sweep.mjs
+++ b/plugins/dev/scripts/execution-core/unstuck-sweep.mjs
@@ -88,6 +88,10 @@ export const STALL_CATEGORY_MAP = Object.freeze({
   // unstuck sweep must stay quiet, not re-escalate it every interval (that
   // would recreate the ask loop through a different subsystem).
   "escalation-ask-cap":               { category: "skip",           action: "skip" },
+  // CTL-1443: a gate-expired park is already surfaced (brief + label via the
+  // terminal sweep + alert) and is waiting on an operator approval — the
+  // unstuck sweep must stay quiet, not re-escalate it every interval.
+  "boot-resume-gate-expired":         { category: "skip",           action: "skip" },
 });
 
 // classifyStalledTicket — PURE top-level router (Phase 1). No IO.

--- a/plugins/dev/scripts/install-cli.sh
+++ b/plugins/dev/scripts/install-cli.sh
@@ -61,6 +61,7 @@ CLI_ENTRIES=(
   "catalyst-install:catalyst-install"
   "catalyst:catalyst"
   "thoughts-pull-sync.sh:thoughts-pull-sync"
+  "execution-core/boot-resume-approve.mjs:boot-resume-approve"
   "../hooks/emit-lifecycle-event.sh:emit-lifecycle-event"
 )
 


### PR DESCRIPTION
## What

Makes the CTL-644 boot-resume approval gate **operable** (audit RC4/loop-3): the `.boot-resume-approved` sentinel had no writer (the "HUD button" in the code comment never existed), pending gates had zero surfacing (exhaustive-grep confirmed), and no TTL — OTL-41's recovery-pass resume sat invisibly gated for 4+ days.

## Changes

- **`listPendingApprovals` / `approveBootResume`** — the API; approval is picked up by the existing every-tick `processApprovedResumes` (no restart).
- **`surfaceStalePendingApprovals`** — a gate older than `CATALYST_BOOT_RESUME_PENDING_TTL_H` (default 48h) surfaces **once**: the gated phase's signal flips `needs-human` with a curated `authorization` brief (rendered by the monitor's existing Needs-You inbox via `deriveExplanation` — no UI work) + a `catalyst.alert.boot_resume_pending` event (new emitter in dispatch-alert.mjs, namespace-checked). `surfacedAt` on the marker dedupes; the marker stays, so approval keeps working after surfacing. Rides `processApprovedResumes`' every-tick call.
- **`boot-resume-approve.mjs`** — standalone node CLI (`--list` / `<ticket>`); deliberately not importing boot-resume.mjs (bun-only graph via scheduler). Marker paths are a stable two-file contract.

## Tests

boot-resume-approval **14 pass** (+5), boot-resume **80 pass** (both CI-registered); CLI smoke-tested under plain node (list, approve, no-gate refusal).

## Validation plan (post-merge)

`boot-resume-approve.mjs --list` on mini shows OTL-41's 5-day-old gate → approve it → the every-tick consumer dispatches the gated recovery-pass. (OTL-41's decision brief is already surfaced on the ticket; its recovery-pass has since also recorded a live leave-alone verdict via P0a.)

Part of **CTL-1157** (P1-loop-3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)