### PR TITLE
fix(dev): CTL-1443 follow-up — sync CLI reference for boot-resume-approve (unblocks CI)

### DIFF
--- a/plugins/dev/scripts/gen-cli-reference.sh
+++ b/plugins/dev/scripts/gen-cli-reference.sh
@@ -48,6 +48,7 @@ catalyst-why|Event & comms|1|Explain why the daemon believes a worker is alive, 
 catalyst-transitions|Event & comms|0|Live, human-readable Linear-state + phase transition log (tails the event stream — bare runs forever).
 catalyst-session|Session & state|1|Lifecycle CLI for Catalyst agent sessions (start/phase/metric/tool/pr → SQLite + event log).
 catalyst-state|Session & state|1|Manage global orchestrator state at ~/catalyst/state.json (flock-protected RMW + event log).
+boot-resume-approve|Session & state|0|List boot-resume-gated tickets and approve one — writes the .boot-resume-approved sentinel so the daemon dispatches the gated phase without a restart (CTL-1443).
 catalyst-db|Session & state|1|SQLite-backed durable session store for agent runs (init/migrate, sessions, events, metrics).
 workflow-context|Session & state|1|Workflow context management utilities (recent docs, orchestration pointers, skill chaining).
 catalyst-thoughts|Thoughts|1|Repair and verify the HumanLayer thoughts system for a Catalyst project.

--- a/website/src/content/docs/reference/catalyst-cli.md
+++ b/website/src/content/docs/reference/catalyst-cli.md
@@ -12,7 +12,7 @@ sidebar:
 
 Every `catalyst-*` CLI is installed onto your `PATH` by
 [`install-cli.sh`](https://github.com/coalesce-labs/catalyst/blob/main/plugins/dev/scripts/install-cli.sh) (into
-`~/.catalyst/bin` by default). This page lists all 29 of them — one line of
+`~/.catalyst/bin` by default). This page lists all 30 of them — one line of
 purpose plus the key subcommands — grouped by area. Run any tool with `--help`
 for full syntax. The richer tools have their own reference pages (e.g.
 [catalyst-stack](/reference/catalyst-stack/)).
@@ -108,6 +108,12 @@ Manage global orchestrator state at ~/catalyst/state.json (flock-protected RMW +
 **Key subcommands:** `init`, `register`, `update`, `worker`, `heartbeat`, `attention`, `resolve-attention`, `event`, `archive`, `gc`
 
 [Source](https://github.com/coalesce-labs/catalyst/blob/main/plugins/dev/scripts/catalyst-state.sh)
+
+### boot-resume-approve
+
+List boot-resume-gated tickets and approve one — writes the .boot-resume-approved sentinel so the daemon dispatches the gated phase without a restart (CTL-1443).
+
+[Source](https://github.com/coalesce-labs/catalyst/blob/main/plugins/dev/scripts/execution-core/boot-resume-approve.mjs)
 
 ### catalyst-db
 


### PR DESCRIPTION
## Why (fleet-wide CI unblock)

CTL-1443 (#2596) registered `boot-resume-approve` in `install-cli.sh`'s `CLI_ENTRIES` but did **not** add it to the CLI-reference generator's manifest or the committed reference page. The `cli-reference-drift` guard (part of `execution-core-unit-tests`) is a "cannot drift" invariant — so it now **fails on `main`**, and therefore on **every PR branched off main** (`FAIL: doc missing tool boot-resume-approve` / `manifest missing`).

## Fix (mechanical doc-sync)

- Add the `boot-resume-approve` row (category **Session & state**) to `gen-cli-reference.sh`'s manifest.
- Regenerate `website/src/content/docs/reference/catalyst-cli.md` via `bash plugins/dev/scripts/gen-cli-reference.sh --write`.

No code/behavior change. Verified: `cli-reference-drift.test.sh` 123/0, `gen-cli-reference.test.sh` 100/0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)