### PR TITLE
feat(dev): CTL-1420 (#17) — read cross-host liveness from Loki + retire the Linear heartbeat publish (PR1b)

### DIFF
--- a/plugins/dev/scripts/execution-core/__tests__/config-liveness-source.test.mjs
+++ b/plugins/dev/scripts/execution-core/__tests__/config-liveness-source.test.mjs
@@ -1,0 +1,42 @@
+// config-liveness-source.test.mjs — CTL-1420 (#17). getLivenessReadSource +
+// getLokiQueryUrl resolution (env-driven; safe-rollout default; port swap).
+
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { getLivenessReadSource, getLokiQueryUrl } from "../config.mjs";
+
+const ENVS = ["CATALYST_LIVENESS_READ_SOURCE", "CATALYST_LOKI_QUERY_URL", "OTEL_EXPORTER_OTLP_ENDPOINT"];
+let saved = {};
+beforeEach(() => { for (const k of ENVS) { saved[k] = process.env[k]; delete process.env[k]; } });
+afterEach(() => { for (const k of ENVS) { if (saved[k] === undefined) delete process.env[k]; else process.env[k] = saved[k]; } saved = {}; });
+
+describe("getLivenessReadSource (CTL-1420 #17)", () => {
+  test("defaults to 'linear' (safe rollout — opt-in loki)", () => {
+    expect(getLivenessReadSource()).toBe("linear");
+  });
+  test("'loki' (any case / whitespace) selects loki; anything else → linear", () => {
+    process.env.CATALYST_LIVENESS_READ_SOURCE = "  LOKI ";
+    expect(getLivenessReadSource()).toBe("loki");
+    process.env.CATALYST_LIVENESS_READ_SOURCE = "linear";
+    expect(getLivenessReadSource()).toBe("linear");
+    process.env.CATALYST_LIVENESS_READ_SOURCE = "garbage";
+    expect(getLivenessReadSource()).toBe("linear");
+  });
+});
+
+describe("getLokiQueryUrl (CTL-1420 #17)", () => {
+  test("explicit CATALYST_LOKI_QUERY_URL wins (trailing slash stripped)", () => {
+    process.env.CATALYST_LOKI_QUERY_URL = "http://loki.example:3100/";
+    expect(getLokiQueryUrl()).toBe("http://loki.example:3100");
+  });
+  test("derives :3100 from the OTLP :4318 endpoint (same host)", () => {
+    process.env.OTEL_EXPORTER_OTLP_ENDPOINT = "http://100.65.193.30:4318";
+    expect(getLokiQueryUrl()).toBe("http://100.65.193.30:3100");
+  });
+  test("strips any OTLP path when deriving", () => {
+    process.env.OTEL_EXPORTER_OTLP_ENDPOINT = "http://collector:4318/v1/logs";
+    expect(getLokiQueryUrl()).toBe("http://collector:3100");
+  });
+  test("no env → null (caller fails open)", () => {
+    expect(getLokiQueryUrl()).toBe(null);
+  });
+});

--- a/plugins/dev/scripts/execution-core/cluster-heartbeat-publisher.mjs
+++ b/plugins/dev/scripts/execution-core/cluster-heartbeat-publisher.mjs
@@ -18,6 +18,7 @@ import {
   getClusterHosts,
   getHostName,
   getLivenessAnchorIssue,
+  getLivenessReadSource, // CTL-1420 (#17): gate the Linear anchor publish on the active source
   LIVENESS_PUBLISH_INTERVAL_MS,
   log,
 } from "./config.mjs";
@@ -113,6 +114,9 @@ export function startLivenessPublisher({
   // SKIP publishing while the breaker is open (don't add to a storm), and (2)
   // FEED the breaker on a rate-class rejection. Injectable for tests.
   breaker = linearBreaker,
+  // CTL-1420 (#17): the active cross-host liveness source. Injectable seam so tests
+  // can force loki|linear; defaults to the env-driven getLivenessReadSource().
+  readSource = getLivenessReadSource,
 } = {}) {
   // Single-host no-op (no network, no publish, zero cost).
   if (!Array.isArray(roster) || roster.length <= 1) {
@@ -157,6 +161,13 @@ export function startLivenessPublisher({
     } catch {
       /* fence re-emit is best-effort; never blocks or crashes the liveness tick */
     }
+    // CTL-1420 (#17): in "loki" mode the cross-host liveness READ comes from Loki
+    // (node.heartbeat → event log → Loki), so the Linear anchor publish is RETIRED —
+    // skip it entirely. This is the ~120/hr shared-app-actor-bucket write that flaps
+    // the CTL-679 breaker; removing it is the burn win. The Linear-FREE fence re-emit
+    // above still runs every tick. "linear" mode keeps the legacy publish (safe-rollout
+    // default; the fleet sets CATALYST_LIVENESS_READ_SOURCE=loki after validation).
+    if (readSource() !== "linear") return;
     try {
       // CTL-1420 follow-up: if the shared CTL-679 breaker is OPEN (a rate-class
       // 429/RATELIMITED from ANY daemon Linear path tripped it), SKIP this publish

--- a/plugins/dev/scripts/execution-core/cluster-heartbeat-publisher.test.mjs
+++ b/plugins/dev/scripts/execution-core/cluster-heartbeat-publisher.test.mjs
@@ -337,3 +337,44 @@ describe("startLivenessPublisher (CTL-1090)", () => {
     });
   });
 });
+
+describe("startLivenessPublisher — loki-mode retires the Linear publish (CTL-1420 #17)", () => {
+  beforeEach(() => linearBreaker.recordSuccess());
+
+  test("readSource=loki: NO Linear publish, but the Linear-free fence re-emit STILL runs", () => {
+    const publishCalls = [];
+    const fenceCalls = [];
+    const h = startLivenessPublisher({
+      roster: ["mini", "mini-2"],
+      anchorIssue: "CTL-9",
+      self: "mini",
+      ownedTickets: () => ["CTL-1"],
+      readGeneration: () => 7, // finite → fence re-emit fires
+      emitFence: (args) => fenceCalls.push(args),
+      publish: () => { throw new Error("must NOT publish to Linear in loki mode"); },
+      readSource: () => "loki",
+      intervalMs: 60_000,
+    });
+    h.stop();
+    // The ~120/hr Linear anchor write is gone…
+    expect(publishCalls.length).toBe(0);
+    // …but the #2553 fence projection is still kept fresh (Linear-free event-log append).
+    expect(fenceCalls).toEqual([{ ticket: "CTL-1", owner_host: "mini", generation: 7 }]);
+  });
+
+  test("readSource=linear: publishes as before (no regression)", () => {
+    const publishCalls = [];
+    const h = startLivenessPublisher({
+      roster: ["mini", "mini-2"],
+      anchorIssue: "CTL-9",
+      self: "mini",
+      ownedTickets: () => ["CTL-1"],
+      publish: (args) => publishCalls.push(args),
+      readSource: () => "linear",
+      intervalMs: 60_000,
+    });
+    h.stop();
+    expect(publishCalls.length).toBeGreaterThanOrEqual(1);
+    expect(publishCalls[0]).toMatchObject({ host: "mini", inFlightTickets: ["CTL-1"] });
+  });
+});

--- a/plugins/dev/scripts/execution-core/config.mjs
+++ b/plugins/dev/scripts/execution-core/config.mjs
@@ -657,6 +657,41 @@ export function getLivenessAnchorIssue() {
   return null;
 }
 
+// CTL-1420 (#17): getLivenessReadSource — WHERE the daemon reads CROSS-HOST peer
+// liveness for dead-host detection. "loki" reads the unified event log via Loki
+// (host + freshness + in_flight, fail-open — Loki is already the central cross-host
+// log store, so no mesh/new-store needed); "linear" is the legacy anchor-attachment
+// read. Defaults to "linear" for a SAFE rollout (opt-in "loki" via env, mirroring
+// CTL-863's CATALYST_FENCE_READ_SOURCE) — the fleet sets =loki once validated, with
+// an instant one-var revert. Single-host (roster ≤ 1) is a no-op under either source.
+export function getLivenessReadSource() {
+  const v = (process.env.CATALYST_LIVENESS_READ_SOURCE || "").trim().toLowerCase();
+  return v === "loki" ? "loki" : "linear";
+}
+
+// CTL-1420 (#17): getLokiQueryUrl — the Loki base URL the daemon QUERIES for peer
+// liveness (read path; distinct from the OTLP push endpoint the daemon writes to).
+// Resolution: (1) CATALYST_LOKI_QUERY_URL explicit override; (2) OTEL_EXPORTER_OTLP_ENDPOINT
+// with its port swapped to Loki's 3100 (same collector host); (3) null → the caller
+// fails open (no Loki read → peers look absent → deadHosts treats them alive → no
+// false reclaim). Never hardcodes an address (endpoints are environment-specific).
+export function getLokiQueryUrl() {
+  const explicit = process.env.CATALYST_LOKI_QUERY_URL;
+  if (typeof explicit === "string" && explicit.length > 0) return explicit.replace(/\/+$/, "");
+  const otlp = process.env.OTEL_EXPORTER_OTLP_ENDPOINT;
+  if (typeof otlp === "string" && otlp.length > 0) {
+    try {
+      const u = new URL(otlp);
+      u.port = "3100";
+      u.pathname = "/";
+      return u.toString().replace(/\/+$/, "");
+    } catch {
+      return null; // unparseable → fail-open
+    }
+  }
+  return null;
+}
+
 // LIVENESS_PUBLISH_INTERVAL_MS — cross-host liveness publish cadence (CTL-1090).
 // Coarser than the local heartbeat (30s) because the takeover grace is 10 min;
 // ~2 min keeps Linear quota bounded while giving 5 intervals of resolution inside

--- a/plugins/dev/scripts/execution-core/loki-liveness-sync.mjs
+++ b/plugins/dev/scripts/execution-core/loki-liveness-sync.mjs
@@ -1,0 +1,84 @@
+#!/usr/bin/env node
+// loki-liveness-sync.mjs — synchronous bridge over the async loki-liveness CLI
+// (CTL-1420 #17). recovery.mjs's dead-host detection (readClusterHeartbeats,
+// defaultOwnedTicketsForHost) is synchronous; the Loki read is async (fetch), so we
+// drive it through spawnSync of `node loki-liveness.mjs read <lokiUrl>` — the same
+// sync-subprocess convention cluster-heartbeat-sync.mjs uses for the Linear read.
+//
+// FAIL-OPEN contract: ANY failure — spawn error, timeout, non-zero exit, or
+// unparseable stdout — is reported as {}. A Loki hiccup must NEVER break liveness:
+// an empty map makes deadHosts treat every peer as "never seen ⇒ alive" (no false
+// reclaim), and the 10-min grace absorbs a brief blip.
+
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+
+const LOKI_LIVENESS_CLI = fileURLToPath(new URL("./loki-liveness.mjs", import.meta.url));
+
+// Hard cap on the read subprocess. 8s is generous for a healthy Loki query (~70ms
+// measured) and bounds a hung call well inside the 10-min dead-host grace.
+const LOKI_LIVENESS_TIMEOUT_MS =
+  Number(process.env.EXECUTION_CORE_LOKI_LIVENESS_TIMEOUT_MS) || 8_000;
+
+// readClusterLivenessFromLokiSync — spawn `node loki-liveness.mjs read <lokiUrl>` and
+// return the peer-liveness map { [host]: {last_seen, in_flight_tickets} }, or {} on
+// ANY failure (fail-open). No lokiUrl → {} with zero spawn.
+// `spawn`/`nodeBin`/`cli`/`env`/`timeout` are injectable for unit tests.
+export function readClusterLivenessFromLokiSync(
+  { lokiUrl },
+  {
+    spawn = spawnSync,
+    nodeBin = process.execPath,
+    cli = LOKI_LIVENESS_CLI,
+    env = process.env,
+    timeout = LOKI_LIVENESS_TIMEOUT_MS,
+  } = {},
+) {
+  if (typeof lokiUrl !== "string" || lokiUrl.length === 0) return {};
+  try {
+    const res = spawn(nodeBin, [cli, "read", lokiUrl], { encoding: "utf8", env, timeout });
+    if (!res || res.status !== 0 || typeof res.stdout !== "string") return {};
+    const line = res.stdout.trim().split("\n").filter(Boolean).pop();
+    if (!line) return {};
+    const parsed = JSON.parse(line);
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return {};
+    return parsed;
+  } catch {
+    return {};
+  }
+}
+
+// ─── short TTL cache (mirrors readPeerHeartbeatsSyncCached) ──
+// recovery reads liveness once per pass; a short cache avoids a subprocess spawn every
+// pass. The heartbeat data changes on the 30s emit cadence and dead-host detection
+// tolerates a 10-min grace, so a 20s cache can't make a live host look staler than
+// already tolerated. EXECUTION_CORE_LOKI_LIVENESS_CACHE_MS overrides; 0 disables.
+const LOKI_LIVENESS_CACHE_MS_DEFAULT = 20_000;
+const livenessCache = new Map();
+
+// clearLokiLivenessCache — test-only reset of the module-scope cache between cases.
+export function clearLokiLivenessCache() {
+  livenessCache.clear();
+}
+
+function resolveCacheMs(env) {
+  const raw = Number(env?.EXECUTION_CORE_LOKI_LIVENESS_CACHE_MS);
+  return Number.isFinite(raw) && raw >= 0 ? raw : LOKI_LIVENESS_CACHE_MS_DEFAULT;
+}
+
+// readClusterLivenessFromLokiSyncCached — cached entry point. A hit within the TTL
+// returns immediately with ZERO subprocess spawn. Only a NON-EMPTY result is cached:
+// an empty {} is indistinguishable from a failed read, so it is never latched (the
+// next call retries for real). `now`/`env` are injectable test seams.
+export function readClusterLivenessFromLokiSyncCached({ lokiUrl }, { now = Date.now, env = process.env, ...rest } = {}) {
+  const ttlMs = resolveCacheMs(env);
+  if (ttlMs > 0) {
+    const cached = livenessCache.get(lokiUrl);
+    if (cached && now() - cached.ts < ttlMs) return cached.peers;
+  }
+  const peers = readClusterLivenessFromLokiSync({ lokiUrl }, { env, ...rest });
+  if (ttlMs > 0 && peers && Object.keys(peers).length > 0) {
+    livenessCache.set(lokiUrl, { peers, ts: now() });
+  }
+  return peers;
+}

--- a/plugins/dev/scripts/execution-core/loki-liveness-sync.test.mjs
+++ b/plugins/dev/scripts/execution-core/loki-liveness-sync.test.mjs
@@ -1,0 +1,82 @@
+// loki-liveness-sync.test.mjs — CTL-1420 (#17). The synchronous spawnSync bridge
+// over the loki-liveness CLI, with an injected `spawn` (no real subprocess).
+//
+// Run: cd plugins/dev/scripts/execution-core && bun test loki-liveness-sync.test.mjs
+
+import { describe, test, expect, beforeEach } from "bun:test";
+import {
+  readClusterLivenessFromLokiSync,
+  readClusterLivenessFromLokiSyncCached,
+  clearLokiLivenessCache,
+} from "./loki-liveness-sync.mjs";
+
+const okSpawn = (map) => () => ({ status: 0, stdout: JSON.stringify(map) + "\n", stderr: "" });
+
+describe("readClusterLivenessFromLokiSync (CTL-1420 #17) — fail-open", () => {
+  test("no lokiUrl → {} with ZERO spawn", () => {
+    let spawned = false;
+    const spawn = () => { spawned = true; return { status: 0, stdout: "{}" }; };
+    expect(readClusterLivenessFromLokiSync({ lokiUrl: "" }, { spawn })).toEqual({});
+    expect(spawned).toBe(false);
+  });
+
+  test("successful subprocess → parsed peer map", () => {
+    const map = { mini: { last_seen: "2026-07-07T19:04:50.000Z", in_flight_tickets: ["CTL-1"] } };
+    const out = readClusterLivenessFromLokiSync({ lokiUrl: "http://loki:3100" }, { spawn: okSpawn(map) });
+    expect(out).toEqual(map);
+  });
+
+  test("non-zero exit → {}", () => {
+    const spawn = () => ({ status: 1, stdout: "", stderr: "boom" });
+    expect(readClusterLivenessFromLokiSync({ lokiUrl: "http://loki:3100" }, { spawn })).toEqual({});
+  });
+
+  test("unparseable stdout → {}", () => {
+    const spawn = () => ({ status: 0, stdout: "not json\n" });
+    expect(readClusterLivenessFromLokiSync({ lokiUrl: "http://loki:3100" }, { spawn })).toEqual({});
+  });
+
+  test("array stdout (not an object map) → {}", () => {
+    const spawn = () => ({ status: 0, stdout: "[1,2,3]\n" });
+    expect(readClusterLivenessFromLokiSync({ lokiUrl: "http://loki:3100" }, { spawn })).toEqual({});
+  });
+
+  test("spawn throws (e.g. ENOENT) → {}", () => {
+    const spawn = () => { throw new Error("ENOENT"); };
+    expect(readClusterLivenessFromLokiSync({ lokiUrl: "http://loki:3100" }, { spawn })).toEqual({});
+  });
+});
+
+describe("readClusterLivenessFromLokiSyncCached (CTL-1420 #17)", () => {
+  beforeEach(() => clearLokiLivenessCache());
+
+  test("caches a non-empty result within the TTL (second call does not spawn)", () => {
+    let spawnCount = 0;
+    const map = { mini: { last_seen: "2026-07-07T19:04:50.000Z", in_flight_tickets: [] } };
+    const spawn = () => { spawnCount += 1; return { status: 0, stdout: JSON.stringify(map) + "\n" }; };
+    const t = 1_000_000;
+    const a = readClusterLivenessFromLokiSyncCached({ lokiUrl: "u" }, { spawn, now: () => t });
+    const b = readClusterLivenessFromLokiSyncCached({ lokiUrl: "u" }, { spawn, now: () => t + 5_000 });
+    expect(a).toEqual(map);
+    expect(b).toEqual(map);
+    expect(spawnCount).toBe(1); // second call served from cache
+  });
+
+  test("does NOT cache an empty {} (a failed read must retry, not latch)", () => {
+    let spawnCount = 0;
+    const spawn = () => { spawnCount += 1; return { status: 1, stdout: "" }; };
+    readClusterLivenessFromLokiSyncCached({ lokiUrl: "u" }, { spawn, now: () => 1 });
+    readClusterLivenessFromLokiSyncCached({ lokiUrl: "u" }, { spawn, now: () => 2 });
+    expect(spawnCount).toBe(2); // no latch — each call retries
+  });
+
+  test("cache disabled (EXECUTION_CORE_LOKI_LIVENESS_CACHE_MS=0) always spawns", () => {
+    let spawnCount = 0;
+    const map = { mini: { last_seen: "x", in_flight_tickets: [] } };
+    const spawn = () => { spawnCount += 1; return { status: 0, stdout: JSON.stringify(map) + "\n" }; };
+    const env = { EXECUTION_CORE_LOKI_LIVENESS_CACHE_MS: "0" };
+    readClusterLivenessFromLokiSyncCached({ lokiUrl: "u" }, { spawn, env, now: () => 1 });
+    readClusterLivenessFromLokiSyncCached({ lokiUrl: "u" }, { spawn, env, now: () => 1 });
+    expect(spawnCount).toBe(2);
+  });
+});

--- a/plugins/dev/scripts/execution-core/loki-liveness.mjs
+++ b/plugins/dev/scripts/execution-core/loki-liveness.mjs
@@ -1,0 +1,171 @@
+// loki-liveness.mjs — CTL-1420 (#17). Cross-host peer LIVENESS read via Loki,
+// the replacement for the Linear heartbeat-attachment read (readPeerHeartbeatsSync).
+//
+// Loki is already the central place every host pushes node.heartbeat to, so it IS
+// the cross-host transport we need — no mesh, no direct host-to-host connectivity,
+// no new shared store (Ryan, 2026-07-07). LIVENESS ONLY: this is a broadcast,
+// read-mostly, FAIL-OPEN signal (a wrong "alive" is caught by fencing; a wrong
+// "dead" merely declines to reclaim). It is NEVER used for claim/fence CAS — that
+// needs a fail-closed arbiter, and Loki is append-only / eventually-consistent.
+//
+// Returns { [host]: { last_seen, in_flight_tickets } } — the SAME shape as the
+// legacy readPeerHeartbeatsSync peer map, so readClusterHeartbeats /
+// defaultOwnedTicketsForHost are drop-in (recovery.mjs).
+//
+// FAIL-OPEN everywhere: no lokiUrl, probe/timeout/non-200/parse error → {}. An
+// empty map makes deadHosts treat every peer as "never seen ⇒ alive"
+// (recovery.mjs:deadHosts), so a Loki outage can NEVER cause a false reclaim.
+
+const HEARTBEAT_EVENT = "node.heartbeat";
+const DEFAULT_TIMEOUT_MS = 2000;
+// Window must comfortably exceed the dead-host grace (HEARTBEAT_GRACE_MS = 10 min):
+// detection fires at grace-expiry when the last beat is ~grace old, so a window a
+// few× grace guarantees that last beat is still in range. 60 min = 6× grace.
+const DEFAULT_WINDOW_MS = 60 * 60_000;
+
+// nsToMs — Loki entry timestamps are NANOSECOND strings (e.g. "1783451090000000000").
+// Number() of a ns value overflows Number.MAX_SAFE_INTEGER (~9.0e15) and loses
+// precision, so convert ns→ms by dropping the last 6 digits on the STRING first,
+// then Number() (ms fits safely). Non-numeric input → NaN (caller skips it).
+export function nsToMs(ns) {
+  const s = String(ns ?? "");
+  if (!/^\d+$/.test(s)) return NaN;
+  const ms = s.length > 6 ? s.slice(0, -6) : "0";
+  const n = Number(ms);
+  return Number.isFinite(n) ? n : NaN;
+}
+
+// parseInFlight — normalize an in-flight-tickets value (comma-joined string, from
+// heartbeat-event.mjs's catalyst.node.in_flight_tickets attribute) into a string[].
+function parseInFlight(raw) {
+  if (typeof raw !== "string" || raw.length === 0) return [];
+  return raw
+    .split(",")
+    .map((t) => t.trim())
+    .filter(Boolean);
+}
+
+// parseLokiLivenessResponse — PURE. Fold a Loki query_range `streams` response into
+// { host: { last_seen, in_flight_tickets } }. Defensive across the two shapes the
+// in_flight attribute could take: per-entry STRUCTURED METADATA (the 3rd element of
+// a values tuple [tsNs, line, {meta}]) OR a promoted STREAM LABEL
+// (result[].stream.catalyst_node_in_flight_tickets). Exported for unit coverage.
+export function parseLokiLivenessResponse(body) {
+  const out = {};
+  const results = body?.data?.result;
+  if (!Array.isArray(results)) return out;
+  for (const stream of results) {
+    const labels = (stream && stream.stream) || {};
+    const host = labels.host_name;
+    if (typeof host !== "string" || host.length === 0) continue;
+    const values = Array.isArray(stream.values) ? stream.values : [];
+    // Pick the NEWEST entry by ts (don't assume Loki's ordering) so last_seen and
+    // in_flight reflect the most recent heartbeat.
+    let newest = null;
+    for (const v of values) {
+      const tsMs = nsToMs(v && v[0]);
+      if (!Number.isFinite(tsMs)) continue;
+      if (!newest || tsMs > newest.tsMs) newest = { tsMs, meta: (v && v[2]) || null };
+    }
+    if (!newest) continue;
+    const rawTickets =
+      (newest.meta && newest.meta.catalyst_node_in_flight_tickets) ??
+      labels.catalyst_node_in_flight_tickets ??
+      "";
+    out[host] = {
+      last_seen: new Date(newest.tsMs).toISOString(),
+      in_flight_tickets: parseInFlight(rawTickets),
+    };
+  }
+  return out;
+}
+
+// readClusterLivenessFromLoki — query Loki for every host's most-recent
+// node.heartbeat over `windowMs`, returning the peer-liveness map. FAIL-OPEN → {}.
+// `fetcher`/`nowMs` are injectable seams for unit tests (no network, no clock).
+export async function readClusterLivenessFromLoki({
+  lokiUrl,
+  nowMs = Date.now(),
+  windowMs = DEFAULT_WINDOW_MS,
+  timeoutMs = DEFAULT_TIMEOUT_MS,
+  fetcher = globalThis.fetch,
+  logger,
+} = {}) {
+  if (typeof lokiUrl !== "string" || lokiUrl.length === 0) return {};
+  const base = lokiUrl.replace(/\/+$/, "");
+  const startNs = String((nowMs - windowMs) * 1_000_000);
+  const endNs = String(nowMs * 1_000_000);
+  const query = `{service_name="catalyst.execution-core"} | event_name=\`${HEARTBEAT_EVENT}\``;
+  const params = new URLSearchParams({
+    query,
+    start: startNs,
+    end: endNs,
+    limit: "1000",
+    direction: "backward",
+  });
+  const url = `${base}/loki/api/v1/query_range?${params.toString()}`;
+  try {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), timeoutMs);
+    let res;
+    try {
+      res = await fetcher(url, { signal: controller.signal });
+    } finally {
+      clearTimeout(timer);
+    }
+    if (!res || !res.ok) return {};
+    const body = await res.json();
+    if (!body || body.status !== "success") return {};
+    return parseLokiLivenessResponse(body);
+  } catch (err) {
+    // Fail-open: never let a Loki hiccup break liveness. An empty map = "no peers
+    // seen" = deadHosts treats all as alive = no false reclaim.
+    logger?.warn?.({ err: err?.message }, "loki-liveness: read failed (fail-open → {})");
+    return {};
+  }
+}
+
+// ─── CLI ─────────────────────────────────────────────────────────────────────
+// Thin argv shim so the SYNCHRONOUS daemon (recovery.mjs dead-host detection) can
+// drive this async reader through spawnSync — the same sync-subprocess convention
+// cluster-heartbeat.mjs uses. loki-liveness-sync.mjs is the in-process wrapper that
+// spawnSync's `node loki-liveness.mjs read <lokiUrl> [windowMs]`.
+//
+//   read <lokiUrl> [windowMs]  → stdout JSON { [host]: {last_seen, in_flight_tickets} }; exit 0
+export async function runCli(argv, { fetcher } = {}) {
+  const [cmd, lokiUrl, windowMsRaw] = argv;
+  switch (cmd) {
+    case "read": {
+      const windowMs = windowMsRaw ? Number(windowMsRaw) : undefined;
+      const map = await readClusterLivenessFromLoki({
+        lokiUrl,
+        windowMs: Number.isFinite(windowMs) && windowMs > 0 ? windowMs : undefined,
+        fetcher,
+      });
+      process.stdout.write(JSON.stringify(map) + "\n");
+      return 0;
+    }
+    default:
+      process.stderr.write(
+        `loki-liveness.mjs: unknown subcommand: ${cmd ?? "(none)"}\n` +
+          "usage: loki-liveness.mjs read <lokiUrl> [windowMs]\n",
+      );
+      return 1;
+  }
+}
+
+function isMain() {
+  return (
+    process.argv[1] &&
+    (process.argv[1].endsWith("/loki-liveness.mjs") || process.argv[1].endsWith("loki-liveness.mjs"))
+  );
+}
+
+if (isMain()) {
+  runCli(process.argv.slice(2))
+    .then((code) => process.exit(code))
+    .catch((err) => {
+      process.stderr.write(`loki-liveness.mjs: ${err?.message ?? err}\n`);
+      process.exit(1);
+    });
+}

--- a/plugins/dev/scripts/execution-core/loki-liveness.test.mjs
+++ b/plugins/dev/scripts/execution-core/loki-liveness.test.mjs
@@ -1,0 +1,129 @@
+// loki-liveness.test.mjs — CTL-1420 (#17). Cross-host peer liveness read via Loki.
+// Pure parser + fail-open reader are exercised with an injected fetcher (no network).
+//
+// Run: cd plugins/dev/scripts/execution-core && bun test loki-liveness.test.mjs
+
+import { describe, test, expect } from "bun:test";
+import {
+  parseLokiLivenessResponse,
+  readClusterLivenessFromLoki,
+  nsToMs,
+} from "./loki-liveness.mjs";
+
+// A Loki query_range "streams" response with one stream per host. `metaTickets`
+// (3rd values element) simulates the structured-metadata shape; `labelTickets`
+// simulates the promoted-stream-label shape. tsNs is a nanosecond string.
+function stream(host, entries, { labelTickets } = {}) {
+  const s = { host_name: host, event_name: "node.heartbeat" };
+  if (labelTickets !== undefined) s.catalyst_node_in_flight_tickets = labelTickets;
+  return {
+    stream: s,
+    values: entries.map((e) =>
+      e.metaTickets !== undefined
+        ? [e.tsNs, "node.heartbeat", { catalyst_node_in_flight_tickets: e.metaTickets }]
+        : [e.tsNs, "node.heartbeat"],
+    ),
+  };
+}
+const ok = (result) => ({ ok: true, json: async () => ({ status: "success", data: { resultType: "streams", result } }) });
+
+describe("nsToMs (CTL-1420 #17) — no precision loss on nanosecond timestamps", () => {
+  test("converts a ns string to ms without Number overflow", () => {
+    // 1783451090000000000 ns → 1783451090000 ms (Number-safe). Direct Number(ns) would lose precision.
+    expect(nsToMs("1783451090000000000")).toBe(1783451090000);
+    expect(new Date(nsToMs("1783451090000000000")).toISOString()).toBe("2026-07-07T19:04:50.000Z");
+  });
+  test("non-numeric / empty → NaN", () => {
+    expect(Number.isNaN(nsToMs("zzz"))).toBe(true);
+    expect(Number.isNaN(nsToMs(""))).toBe(true);
+    expect(Number.isNaN(nsToMs(null))).toBe(true);
+  });
+});
+
+describe("parseLokiLivenessResponse (CTL-1420 #17)", () => {
+  test("newest ts per host + in_flight from structured metadata (3rd element)", () => {
+    const body = {
+      data: {
+        result: [
+          stream("mini", [
+            { tsNs: "1783451060000000000", metaTickets: "CTL-1" },
+            { tsNs: "1783451090000000000", metaTickets: "CTL-1,CTL-2" }, // newest
+          ]),
+          stream("mini-2", [{ tsNs: "1783451092000000000", metaTickets: "" }]),
+        ],
+      },
+    };
+    const out = parseLokiLivenessResponse(body);
+    expect(out.mini.last_seen).toBe("2026-07-07T19:04:50.000Z");
+    expect(out.mini.in_flight_tickets).toEqual(["CTL-1", "CTL-2"]);
+    expect(out["mini-2"].in_flight_tickets).toEqual([]);
+  });
+
+  test("reads in_flight from the stream-label shape when metadata is absent", () => {
+    const body = { data: { result: [stream("mini", [{ tsNs: "1783451090000000000" }], { labelTickets: "CTL-9,CTL-8" })] } };
+    expect(parseLokiLivenessResponse(body).mini.in_flight_tickets).toEqual(["CTL-9", "CTL-8"]);
+  });
+
+  test("picks the max ts even when values are unordered", () => {
+    const body = {
+      data: {
+        result: [
+          stream("mini", [
+            { tsNs: "1783451090000000000", metaTickets: "NEW" },
+            { tsNs: "1783451000000000000", metaTickets: "OLD" },
+          ]),
+        ],
+      },
+    };
+    const out = parseLokiLivenessResponse(body);
+    expect(out.mini.in_flight_tickets).toEqual(["NEW"]);
+  });
+
+  test("skips streams with no host_name / no parseable ts; returns {} on garbage", () => {
+    expect(parseLokiLivenessResponse({ data: { result: [{ stream: {}, values: [["1", "x"]] }] } })).toEqual({});
+    expect(parseLokiLivenessResponse({ data: { result: [stream("mini", [{ tsNs: "zzz" }])] } })).toEqual({});
+    expect(parseLokiLivenessResponse(null)).toEqual({});
+    expect(parseLokiLivenessResponse({ data: {} })).toEqual({});
+  });
+});
+
+describe("readClusterLivenessFromLoki (CTL-1420 #17) — fail-open", () => {
+  test("parses a successful response via the injected fetcher", async () => {
+    const fetcher = async () => ok([stream("mini", [{ tsNs: "1783451090000000000", metaTickets: "CTL-5" }])]);
+    const out = await readClusterLivenessFromLoki({ lokiUrl: "http://loki:3100", fetcher, nowMs: 1783451100000 });
+    expect(out.mini.in_flight_tickets).toEqual(["CTL-5"]);
+    expect(typeof out.mini.last_seen).toBe("string");
+  });
+
+  test("builds a bounded query window around nowMs (start < end, ns)", async () => {
+    let captured;
+    const fetcher = async (url) => { captured = url; return ok([]); };
+    await readClusterLivenessFromLoki({ lokiUrl: "http://loki:3100", fetcher, nowMs: 1783451100000, windowMs: 600000 });
+    const u = new URL(captured);
+    expect(Number(u.searchParams.get("start"))).toBe((1783451100000 - 600000) * 1_000_000);
+    expect(Number(u.searchParams.get("end"))).toBe(1783451100000 * 1_000_000);
+    expect(u.searchParams.get("query")).toContain("node.heartbeat");
+  });
+
+  test("no lokiUrl → {} (no fetch attempted)", async () => {
+    let called = false;
+    const fetcher = async () => { called = true; return ok([]); };
+    expect(await readClusterLivenessFromLoki({ fetcher })).toEqual({});
+    expect(called).toBe(false);
+  });
+
+  test("fetcher throws (e.g. abort/timeout/unreachable) → {}", async () => {
+    const fetcher = async () => { throw new Error("ECONNREFUSED"); };
+    expect(await readClusterLivenessFromLoki({ lokiUrl: "http://loki:3100", fetcher })).toEqual({});
+  });
+
+  test("non-200 → {}", async () => {
+    const fetcher = async () => ({ ok: false, status: 503, json: async () => ({}) });
+    expect(await readClusterLivenessFromLoki({ lokiUrl: "http://loki:3100", fetcher })).toEqual({});
+  });
+
+  test("status != success → {}", async () => {
+    const fetcher = async () => ({ ok: true, json: async () => ({ status: "error", data: null }) });
+    expect(await readClusterLivenessFromLoki({ lokiUrl: "http://loki:3100", fetcher })).toEqual({});
+  });
+});

--- a/plugins/dev/scripts/execution-core/recovery.mjs
+++ b/plugins/dev/scripts/execution-core/recovery.mjs
@@ -32,6 +32,8 @@ import {
   getClusterHosts,
   getHostName,
   getLivenessAnchorIssue,
+  getLivenessReadSource, // CTL-1420 (#17): loki|linear cross-host liveness source
+  getLokiQueryUrl, // CTL-1420 (#17): Loki base URL for the liveness read
   log,
   BUSY_CEILING_MS,
   REVIVE_MAX_AGE_MS,
@@ -53,6 +55,27 @@ import { transcriptAgeMs as defaultTranscriptAgeMs } from "./transcript-silence.
 // for callers that want the live read every time (e.g. cli/cluster.mjs's human-invoked
 // `status` verb).
 import { readPeerHeartbeatsSyncCached } from "./cluster-heartbeat-sync.mjs";
+import { readClusterLivenessFromLokiSyncCached } from "./loki-liveness-sync.mjs"; // CTL-1420 (#17): Loki liveness read
+
+// CTL-1420 (#17): source-aware cross-host peer-liveness read. "loki" reads the
+// unified event log via Loki (fail-open, Linear-free); "linear" is the legacy anchor
+// attachment. Both return the SAME { [host]: {last_seen, in_flight_tickets} } shape,
+// so readClusterHeartbeats / defaultOwnedTicketsForHost are unchanged below the seam.
+// The `anchorIssue` arg is only meaningful in linear mode (loki uses getLokiQueryUrl()).
+function defaultReadPeers(anchorIssue) {
+  if (getLivenessReadSource() === "loki") {
+    return readClusterLivenessFromLokiSyncCached({ lokiUrl: getLokiQueryUrl() });
+  }
+  return readPeerHeartbeatsSyncCached({ anchorIssue });
+}
+
+// peerLivenessConfigured — is the cross-host peer read wired for the ACTIVE source?
+// loki → a Loki query URL resolves; linear → the anchor issue is set. Gates the
+// multi-host merge so a source with no transport configured is an exact no-op
+// (local-map-only) instead of a wasted/failing read.
+function peerLivenessConfigured(anchorIssue) {
+  return getLivenessReadSource() === "loki" ? Boolean(getLokiQueryUrl()) : Boolean(anchorIssue);
+}
 import { HEARTBEAT_EVENT } from "./heartbeat-event.mjs"; // CTL-859: node.heartbeat reader
 import { resolveTicketType, UNKNOWN_TICKET_TYPE } from "./ticket-type.mjs"; // CTL-1023: work-type dimension
 import { phaseIndex, isKnownPhase } from "../lib/phase-fsm.mjs";
@@ -3203,7 +3226,7 @@ export function readClusterHeartbeats({
   logPath = getEventLogPath(),
   roster = getClusterHosts(),
   anchorIssue = getLivenessAnchorIssue(),
-  readPeers = (anchor) => readPeerHeartbeatsSyncCached({ anchorIssue: anchor }),
+  readPeers = defaultReadPeers, // CTL-1420 (#17): loki|linear source-aware peer read
 } = {}) {
   const lastSeen = {};
   let raw;
@@ -3233,12 +3256,14 @@ export function readClusterHeartbeats({
   }
 
   // CTL-1090: multi-host cross-host merge. Single-host (roster<=1) ⇒ exact no-op.
-  if (Array.isArray(roster) && roster.length > 1 && anchorIssue) {
+  // CTL-1420 (#17): gate on the ACTIVE source's transport (loki: Loki URL; linear:
+  // anchor issue) so a source with no transport is a clean local-map-only no-op.
+  if (Array.isArray(roster) && roster.length > 1 && peerLivenessConfigured(anchorIssue)) {
     let peers = {};
     try {
       peers = readPeers(anchorIssue) ?? {};
     } catch {
-      peers = {}; // fail-open: a Linear hiccup must never break liveness
+      peers = {}; // fail-open: a Loki/Linear hiccup must never break liveness
     }
     for (const [host, rec] of Object.entries(peers)) {
       const ts = rec?.last_seen;
@@ -3385,19 +3410,20 @@ export async function inferResumePhase(ticket, { probes = WORK_DONE_PROBES, cwd 
 
 // defaultOwnedTicketsForHost — return the in-flight tickets for a dead host.
 // Primary path (CTL-1090): read the dead host's published `in_flight_tickets`
-// from the cross-host liveness channel (one Linear read = liveness + tickets).
-// Fallback: scan the local worker signal directory for non-terminal signals
-// dispatched from the dead host (the original local-only behavior, unchanged).
+// from the cross-host liveness channel (one read = liveness + tickets). CTL-1420
+// (#17): that channel is now source-aware — Loki (default reader) or the legacy
+// Linear anchor. Fallback: scan the local worker signal directory for non-terminal
+// signals dispatched from the dead host (the original local-only behavior, unchanged).
 // `anchorIssue`/`readPeers` are injectable for unit tests.
 function defaultOwnedTicketsForHost(
   deadHost,
   {
     orchDir,
     anchorIssue = getLivenessAnchorIssue(),
-    readPeers = (anchor) => readPeerHeartbeatsSyncCached({ anchorIssue: anchor }),
+    readPeers = defaultReadPeers, // CTL-1420 (#17): loki|linear source-aware peer read
   } = {}
 ) {
-  if (anchorIssue) {
+  if (peerLivenessConfigured(anchorIssue)) {
     try {
       const peerMap = readPeers(anchorIssue);
       const rec = peerMap?.[deadHost];

--- a/plugins/dev/scripts/execution-core/recovery.test.mjs
+++ b/plugins/dev/scripts/execution-core/recovery.test.mjs
@@ -5481,3 +5481,43 @@ describe("CTL-1065: reclaimDeadWorkIfPossible escalated event carries explanatio
     expect(validateExplanation(expl).valid).toBe(true);
   });
 });
+
+// ─── CTL-1420 (#17): readClusterHeartbeats source-aware peer gate ─────────────
+// In "loki" mode the cross-host peer read is gated on a resolvable Loki URL (NOT the
+// Linear anchor); in "linear" mode (the default, covered above) it gates on the anchor.
+describe("readClusterHeartbeats — loki source gate (CTL-1420 #17)", () => {
+  const ENVS = ["CATALYST_LIVENESS_READ_SOURCE", "CATALYST_LOKI_QUERY_URL", "OTEL_EXPORTER_OTLP_ENDPOINT"];
+  const NO_LOG = "/nonexistent/ctl1420/events.jsonl"; // readFileSync throws → local map empty
+  let saved = {};
+  beforeEach(() => {
+    for (const k of ENVS) { saved[k] = process.env[k]; delete process.env[k]; }
+    process.env.CATALYST_LIVENESS_READ_SOURCE = "loki";
+  });
+  afterEach(() => {
+    for (const k of ENVS) { if (saved[k] === undefined) delete process.env[k]; else process.env[k] = saved[k]; }
+    saved = {};
+  });
+
+  test("loki + Loki URL configured → peer merge runs (and does NOT require the Linear anchor)", () => {
+    process.env.CATALYST_LOKI_QUERY_URL = "http://loki:3100";
+    const readPeers = () => ({ "mini-2": { last_seen: "2026-06-08T00:05:00Z", in_flight_tickets: [] } });
+    const result = readClusterHeartbeats({
+      logPath: NO_LOG,
+      roster: ["mini", "mini-2"],
+      anchorIssue: null, // loki mode must NOT depend on the Linear anchor
+      readPeers,
+    });
+    expect(result["mini-2"]).toBe("2026-06-08T00:05:00Z");
+  });
+
+  test("loki but NO Loki URL → peer read SKIPPED (local-map only), even with an anchor set", () => {
+    const readPeers = () => { throw new Error("must not read: no Loki URL configured"); };
+    const result = readClusterHeartbeats({
+      logPath: NO_LOG,
+      roster: ["mini", "mini-2"],
+      anchorIssue: "CTL-9", // loki mode gates on the Loki URL, not this anchor
+      readPeers,
+    });
+    expect(result).toEqual({});
+  });
+});


### PR DESCRIPTION
## What & why (the burn win)

Flips cross-host **dead-host detection** off the Linear heartbeat attachment — the ~120/hr write that flaps the CTL-679 breaker — onto the unified event log read via **Loki**, which is already the central place every host pushes `node.heartbeat` to (so it IS the cross-host transport; no mesh, no new store). LIVENESS ONLY — claim/fence CAS stays on its arbiter (Loki is append-only). Full design: `thoughts/shared/plans/2026-07-07-liveness-off-linear-impl.md`.

Builds on **PR1a #2575** (heartbeat carries `in_flight_tickets` to Loki). **Deploy PR1a first** (or both together), then flip the env — see rollout.

## Changes
- **`loki-liveness.mjs`** — fail-open Loki reader: newest `node.heartbeat` per host → `{host:{last_seen,in_flight_tickets}}`, defensive across the structured-metadata and stream-label shapes; `nsToMs` avoids Number-overflow on ns timestamps. `read` CLI for the sync bridge.
- **`loki-liveness-sync.mjs`** — spawnSync bridge (recovery.mjs is synchronous) + 20s TTL cache, mirroring `cluster-heartbeat-sync.mjs`. Fail-open → `{}`.
- **`config`** — `getLivenessReadSource()` (env `CATALYST_LIVENESS_READ_SOURCE`, default **`linear`** — safe rollout) + `getLokiQueryUrl()` (explicit env, else OTLP endpoint port-swapped to `:3100`, else `null` → fail-open).
- **`recovery.mjs`** — `readClusterHeartbeats` / `defaultOwnedTicketsForHost` read peers via a source-aware seam; the multi-host merge gate is `peerLivenessConfigured()` (loki: resolvable Loki URL; linear: anchor, unchanged). Fail-open: Loki down → peers absent → `deadHosts` treats them alive → **no false reclaim**.
- **`cluster-heartbeat-publisher.mjs`** — in loki mode the Linear anchor publish is skipped (burn retired); the Linear-free #2553 fence re-emit still runs.

## Rollout (safe, revertible)
Default `linear` = behavior identical (every existing test unchanged). After deploy, set `CATALYST_LIVENESS_READ_SOURCE=loki` on both minis and restart them **together** (no cross-host transition hazard). Instant revert: unset the var. A follow-up flips the code default to `loki` once fleet-proven.

## Verification
- Unit: loki 12, sync 9, config 6, publisher +2 (loki gate), recovery +2 (source gate); **full recovery suite 289/0**.
- **Live end-to-end**: `node loki-liveness.mjs read <loki>` returns both minis with fresh `last_seen` from real Loki.

🤖 Generated with [Claude Code](https://claude.com/claude-code)