### PR TITLE
fix(dev): CTL-1420 (#17) follow-up — loki-liveness reader: newest-across-streams + two-query tickets

### DIFF
--- a/plugins/dev/scripts/execution-core/loki-liveness.mjs
+++ b/plugins/dev/scripts/execution-core/loki-liveness.mjs
@@ -54,35 +54,64 @@ export function parseLokiLivenessResponse(body) {
   const out = {};
   const results = body?.data?.result;
   if (!Array.isArray(results)) return out;
+  // Track the newest ts per host ACROSS ALL streams. Real Loki returns ONE
+  // single-value stream PER heartbeat line (the changing catalyst_node_in_flight_count
+  // label splits every beat into its own stream), so "newest per host" MUST be a
+  // cross-stream reduction — a per-stream `newest` that overwrites out[host] each
+  // stream would let the LAST-listed stream win (a stale beat), which is exactly the
+  // bug that made a live peer read ~20 min stale and risked a false reclaim.
+  const newestMs = {};
   for (const stream of results) {
     const labels = (stream && stream.stream) || {};
     const host = labels.host_name;
     if (typeof host !== "string" || host.length === 0) continue;
     const values = Array.isArray(stream.values) ? stream.values : [];
-    // Pick the NEWEST entry by ts (don't assume Loki's ordering) so last_seen and
-    // in_flight reflect the most recent heartbeat.
-    let newest = null;
     for (const v of values) {
       const tsMs = nsToMs(v && v[0]);
       if (!Number.isFinite(tsMs)) continue;
-      if (!newest || tsMs > newest.tsMs) newest = { tsMs, meta: (v && v[2]) || null };
+      if (host in newestMs && tsMs <= newestMs[host]) continue; // not strictly newer → skip
+      newestMs[host] = tsMs;
+      const meta = (v && v[2]) || null;
+      const rawTickets =
+        (meta && meta.catalyst_node_in_flight_tickets) ??
+        labels.catalyst_node_in_flight_tickets ??
+        "";
+      out[host] = {
+        last_seen: new Date(tsMs).toISOString(),
+        in_flight_tickets: parseInFlight(rawTickets),
+      };
     }
-    if (!newest) continue;
-    const rawTickets =
-      (newest.meta && newest.meta.catalyst_node_in_flight_tickets) ??
-      labels.catalyst_node_in_flight_tickets ??
-      "";
-    out[host] = {
-      last_seen: new Date(newest.tsMs).toISOString(),
-      in_flight_tickets: parseInFlight(rawTickets),
-    };
   }
   return out;
 }
 
-// readClusterLivenessFromLoki — query Loki for every host's most-recent
-// node.heartbeat over `windowMs`, returning the peer-liveness map. FAIL-OPEN → {}.
-// `fetcher`/`nowMs` are injectable seams for unit tests (no network, no clock).
+// queryLokiStreams — one fail-open query_range → the parsed success body, or null on
+// ANY failure (unreachable / timeout / non-200 / non-success). Injectable fetcher.
+async function queryLokiStreams(url, timeoutMs, fetcher) {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  let res;
+  try {
+    res = await fetcher(url, { signal: controller.signal });
+  } finally {
+    clearTimeout(timer);
+  }
+  if (!res || !res.ok) return null;
+  const body = await res.json();
+  if (!body || body.status !== "success") return null;
+  return body;
+}
+
+// readClusterLivenessFromLoki — TWO fail-open queries → the peer-liveness map:
+//   A (liveness): newest node.heartbeat per host → last_seen. NO dependency on the
+//     in-flight structured-metadata field, so it returns EVERY host regardless of code
+//     version — the load-bearing dead-host-detection read.
+//   B (tickets enrichment, best-effort): Loki only surfaces the in_flight_tickets
+//     structured metadata when a query REFERENCES it, so a second query filters to
+//     hosts with a non-empty set and merges the ticket list onto A. A failure here
+//     leaves ownership to the local-scan/board-sweep backstop — liveness (A) is already
+//     set, so dead-host DETECTION is never affected.
+// FAIL-OPEN → {}. `fetcher`/`nowMs` are injectable seams for unit tests.
 export async function readClusterLivenessFromLoki({
   lokiUrl,
   nowMs = Date.now(),
@@ -95,28 +124,31 @@ export async function readClusterLivenessFromLoki({
   const base = lokiUrl.replace(/\/+$/, "");
   const startNs = String((nowMs - windowMs) * 1_000_000);
   const endNs = String(nowMs * 1_000_000);
-  const query = `{service_name="catalyst.execution-core"} | event_name=\`${HEARTBEAT_EVENT}\``;
-  const params = new URLSearchParams({
-    query,
-    start: startNs,
-    end: endNs,
-    limit: "1000",
-    direction: "backward",
-  });
-  const url = `${base}/loki/api/v1/query_range?${params.toString()}`;
+  const sel = `{service_name="catalyst.execution-core"} | event_name=\`${HEARTBEAT_EVENT}\``;
+  const mkUrl = (q) =>
+    `${base}/loki/api/v1/query_range?` +
+    new URLSearchParams({ query: q, start: startNs, end: endNs, limit: "1000", direction: "backward" }).toString();
   try {
-    const controller = new AbortController();
-    const timer = setTimeout(() => controller.abort(), timeoutMs);
-    let res;
+    const aBody = await queryLokiStreams(mkUrl(sel), timeoutMs, fetcher);
+    if (!aBody) return {};
+    const out = parseLokiLivenessResponse(aBody);
+    if (Object.keys(out).length === 0) return {};
     try {
-      res = await fetcher(url, { signal: controller.signal });
-    } finally {
-      clearTimeout(timer);
+      const bBody = await queryLokiStreams(
+        mkUrl(`${sel} | catalyst_node_in_flight_tickets=~\`.+\``),
+        timeoutMs,
+        fetcher,
+      );
+      const enriched = bBody ? parseLokiLivenessResponse(bBody) : {};
+      for (const [host, rec] of Object.entries(enriched)) {
+        if (out[host] && Array.isArray(rec.in_flight_tickets) && rec.in_flight_tickets.length > 0) {
+          out[host].in_flight_tickets = rec.in_flight_tickets;
+        }
+      }
+    } catch (err) {
+      logger?.warn?.({ err: err?.message }, "loki-liveness: tickets enrichment failed (ownership → local fallback)");
     }
-    if (!res || !res.ok) return {};
-    const body = await res.json();
-    if (!body || body.status !== "success") return {};
-    return parseLokiLivenessResponse(body);
+    return out;
   } catch (err) {
     // Fail-open: never let a Loki hiccup break liveness. An empty map = "no peers
     // seen" = deadHosts treats all as alive = no false reclaim.

--- a/plugins/dev/scripts/execution-core/loki-liveness.test.mjs
+++ b/plugins/dev/scripts/execution-core/loki-liveness.test.mjs
@@ -79,6 +79,25 @@ describe("parseLokiLivenessResponse (CTL-1420 #17)", () => {
     expect(out.mini.in_flight_tickets).toEqual(["NEW"]);
   });
 
+  test("newest ts tracked ACROSS streams — real Loki = one single-value stream per beat (regression)", () => {
+    // Real Loki splits EVERY heartbeat into its own stream (the changing in_flight_count
+    // label), and lists them in arbitrary order. A per-stream `newest` that overwrote
+    // out[host] each stream would let the LAST-listed (stale) stream win — the live bug
+    // that read a peer ~20 min stale and risked a false reclaim. The newest must win
+    // regardless of stream ORDER in the result array.
+    const body = {
+      data: {
+        result: [
+          stream("mini", [{ tsNs: "1783451090000000000" }]), // NEWEST, listed FIRST
+          stream("mini", [{ tsNs: "1783451000000000000" }]), // older, listed AFTER
+          stream("mini", [{ tsNs: "1783451030000000000" }]), // middle, listed LAST
+        ],
+      },
+    };
+    const out = parseLokiLivenessResponse(body);
+    expect(out.mini.last_seen).toBe("2026-07-07T19:04:50.000Z"); // 1783451090000 ms = newest
+  });
+
   test("skips streams with no host_name / no parseable ts; returns {} on garbage", () => {
     expect(parseLokiLivenessResponse({ data: { result: [{ stream: {}, values: [["1", "x"]] }] } })).toEqual({});
     expect(parseLokiLivenessResponse({ data: { result: [stream("mini", [{ tsNs: "zzz" }])] } })).toEqual({});
@@ -125,5 +144,32 @@ describe("readClusterLivenessFromLoki (CTL-1420 #17) — fail-open", () => {
   test("status != success → {}", async () => {
     const fetcher = async () => ({ ok: true, json: async () => ({ status: "error", data: null }) });
     expect(await readClusterLivenessFromLoki({ lokiUrl: "http://loki:3100", fetcher })).toEqual({});
+  });
+
+  test("two-query: liveness from A (all hosts) + tickets enriched from B (per host)", async () => {
+    // Query A (no tickets filter) → host+ts for BOTH; Query B (tickets filter) → only the
+    // host WITH a non-empty set. The reader merges B's tickets onto A without dropping the
+    // empty-set host from liveness.
+    const fetcher = async (url) =>
+      url.includes("in_flight_tickets")
+        ? ok([stream("mini", [{ tsNs: "1783451090000000000", metaTickets: "CTL-1,CTL-2" }])])
+        : ok([
+            stream("mini", [{ tsNs: "1783451090000000000" }]),
+            stream("mini-2", [{ tsNs: "1783451092000000000" }]),
+          ]);
+    const out = await readClusterLivenessFromLoki({ lokiUrl: "http://loki:3100", fetcher, nowMs: 1783451100000 });
+    expect(Object.keys(out).sort()).toEqual(["mini", "mini-2"]);
+    expect(out.mini.in_flight_tickets).toEqual(["CTL-1", "CTL-2"]);
+    expect(out["mini-2"].in_flight_tickets).toEqual([]);
+  });
+
+  test("tickets-enrichment (query B) failure does NOT break liveness (query A stands)", async () => {
+    const fetcher = async (url) => {
+      if (url.includes("in_flight_tickets")) throw new Error("loki blip on B");
+      return ok([stream("mini", [{ tsNs: "1783451090000000000" }])]);
+    };
+    const out = await readClusterLivenessFromLoki({ lokiUrl: "http://loki:3100", fetcher });
+    expect(out.mini).toBeDefined();
+    expect(out.mini.in_flight_tickets).toEqual([]);
   });
 });


### PR DESCRIPTION
## Two live-verification bugs in the merged loki-liveness reader (PR1b #2604)

Found while **deploying PR1b** to the fleet — I reverted both minis to `linear` (known-good) while fixing. This is why deploying and *observing* matters: unit tests passed on synthetic single-stream responses, but **real Loki behaves differently**.

### 1. Stale peer → false-reclaim risk (the serious one)
Real Loki returns **one single-value stream per heartbeat** (the changing `catalyst_node_in_flight_count` label splits every beat into its own stream). `parseLokiLivenessResponse` computed "newest" **per stream** and overwrote `out[host]` each stream, so the **last-listed (arbitrary, often stale) stream won** → a live peer read **~20 min stale** → past the 10-min grace → the daemon would false-flag it dead and reclaim its in-flight work. **Fix: track newest ts per host ACROSS all streams.**

### 2. Empty tickets
Loki only surfaces the `in_flight_tickets` structured metadata when a query **references** it, so the single query returned `in_flight_tickets:[]` for every host. **Fix: two fail-open queries** — A (liveness, robust, all hosts) + B (tickets enrichment via `| catalyst_node_in_flight_tickets=~`.+``, best-effort). A B-failure leaves ownership to the local/board-sweep backstop; liveness (A) is unaffected.

## Verification
- Regression tests: multi-stream-per-host newest-across-streams (**order-independent**) + two-query enrichment + B-failure-doesn't-break-liveness. loki 15, loki-sync 9, config 6 — all pass.
- **Live**: the reader now returns fresh `last_seen` (mini 30s / mini-2 28s, was 20min stale) + mini's 6 in-flight tickets.

## Rollout
Fleet is on `linear` (reverted) until this merges + deploys, then I re-flip `CATALYST_LIVENESS_READ_SOURCE=loki` and re-verify no false-reclaim.

🤖 Generated with [Claude Code](https://claude.com/claude-code)