### PR TITLE
fix(dev): CTL-1451 (A4 final widening) — probeBackoff on the recovery-filter + reclaim terminal reads (kills the ADV-1433 read-storm)

### DIFF
--- a/plugins/dev/scripts/execution-core/scheduler.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.mjs
@@ -4138,6 +4138,14 @@ export function schedulerTick(
                   cache,
                   gateway,
                   replica,
+                  // CTL-1451 (A4 "then widen", final site): the recovery backlog
+                  // re-reads its stuck cohort EVERY tick — a replica-hole ticket
+                  // whose live read fails (ADV-1433: ~700 failed reads/hr) must
+                  // back off like the terminal-sweep/census callers, not retry
+                  // per tick. Fail-open toward not-terminal, retried after the
+                  // negative-cache TTL (never-cache-null preserved for
+                  // blocker-hydration callers — this flag is per-site).
+                  probeBackoff: true,
                   onExec: done
                     ? ({ source, execMs, result: r, timedOut }) =>
                         done({
@@ -4410,6 +4418,11 @@ export function schedulerTick(
             ...o,
             gateway,
             replica,
+            // CTL-1451: same per-tick class as the recovery filter above — the
+            // reclaim terminal short-circuit runs per stuck signal per tick;
+            // fail toward not-terminal and back off (matches the terminal-Done
+            // sweep's flag).
+            probeBackoff: true,
             gatewayFreshMs: reclaimGatewayFreshMs,
             onExec: reclaimOpDone
               ? ({ execMs, timedOut }) => {


### PR DESCRIPTION
## What

Post-PR1b **reads-by-source attribution** (the #2582 diagnostic, exactly what it was built for) pinned the entire residual breaker pressure — ~24 opens/hr, **100% `linearis:issues-read`** — to **one ticket**: ADV-1433, which is absent from mini's replica (outage-hole class) and holds a needs-human recovery-pass signal, so the recovery backlog's terminal filter live-read it **every ~5s tick** (415 `linearis_miss|failed` reads in 35 minutes).

The rSigs recovery-filter (scheduler ~4131) and the reclaim terminal short-circuit (~4409) were the two `fetchTicketState` sites the CTL-1436 A4 checklist explicitly listed as *"then widen"* that never got `probeBackoff: true` — the terminal-Done sweeps and all three censuses already have it.

## Change

Two one-flag additions (pure wiring of the tested CTL-1436 mechanism, the CTL-1437 precedent). Failure semantics: fail toward not-terminal, retry after the 5-min negative-cache TTL. The CTL-634 never-cache-null invariant for blocker-hydration callers is untouched (per-site flag).

## Acceptance (live, post-deploy)

ADV-1433's failed-read rate: ~700/hr → ≤12/hr; mini breaker opens reach the near-zero daemon-path end-state projected in the CTL-1420 PR1b before/after table. (The replica hole itself is writer-side — a forced full re-seed heals it wholesale; noted on CTL-1451.)

Tests: linear-query 209 pass, linear-cache 23 pass; import graph resolves.

Part of **CTL-1157** (A4 follow-up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)