### PR TITLE
fix(dev): CTL-1452 — parity test exempts action:skip STALL_CATEGORY_MAP entries (restores exec-core CI on main)

### DIFF
--- a/plugins/dev/scripts/execution-core/unstuck-act-seams.test.mjs
+++ b/plugins/dev/scripts/execution-core/unstuck-act-seams.test.mjs
@@ -661,6 +661,11 @@ describe("buildUnstuckActSeams — registry factory (CTL-1219)", () => {
     const seams = buildUnstuckActSeams(makeStubDeps());
     for (const { category, action } of Object.values(STALL_CATEGORY_MAP)) {
       if (action === "escalate") continue; // remediate-cap/unknown route to escalate, NOT the registry
+      // CTL-1442/CTL-1443: skip-typed entries (escalation-ask-cap, boot-resume-
+      // gate-expired) route to the sweep's own skip path (unstuck-sweep.mjs
+      // action === "skip" — the same branch classifyStalledTicket's live-session/
+      // linear-terminal returns use), NOT the seam registry.
+      if (action === "skip") continue;
       expect(Object.keys(seams)).toContain(category);
     }
   });


### PR DESCRIPTION
Main's `execution-core-unit-tests` job has been red since #2590 merged: the `unstuck-act-seams` parity test ("keys cover every non-escalate category in STALL_CATEGORY_MAP") predates skip-typed entries, and CTL-1442/CTL-1443 added `{category:"skip", action:"skip"}` routes (escalation-ask-cap, boot-resume-gate-expired). Runtime is unaffected — the sweep's `action === "skip"` branch predates these entries (it's how `classifyStalledTicket`'s live-session/linear-terminal returns are handled). The job isn't ruleset-required, so the auto-merges proceeded past it.

Test-only: exempt `action === "skip"` alongside the existing `escalate` exemption. Suite: 29 pass.

Part of **CTL-1157** (loop-1/loop-3 follow-up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)