### PR TITLE
fix(dev): CTL-764 follow-up — declare synthesizeOrphanTickets in board-data.d.mts (greens main quality gate)

### DIFF
--- a/plugins/dev/scripts/orch-monitor/lib/board-data.d.mts
+++ b/plugins/dev/scripts/orch-monitor/lib/board-data.d.mts
@@ -479,6 +479,13 @@ export function synthesizeQueuedTicket(
   teamRepoMap?: Record<string, string>,
   replicaTitles?: Record<string, string>
 ): BoardTicket;
+/** One BoardTicket-shaped card (type:"orphan-pr", attention:"needs-human") per notified
+ *  orphan in the orphan-PR state file — no capacity/queue impact (deriveStatusCounts
+ *  skips them). */
+export function synthesizeOrphanTickets(
+  orphanState: Record<string, unknown> | null | undefined,
+  now?: number
+): BoardTicket[];
 /** CTL-1378 (#2421 edge): the replica-first title chain shared by synthesizeQueuedTicket
  *  (the Todo card) AND the dispatch-queue payload, so the two never disagree. CTC replica
  *  title → eligible-projection title → bare id. */


### PR DESCRIPTION
#2597 auto-merged at d6e3bf27 (Cloudflare Pages + thread-resolution are the only ruleset-required gates) before this typecheck fix landed on the branch, leaving main's **quality** job red: `board-data-capacity.test.ts` imports `synthesizeOrphanTickets`, and tsc resolves `lib/board-data.mjs` to the hand-written `lib/board-data.d.mts`, which lacked the declaration. Cherry-pick of 38ad00bf. Verified locally: `bunx tsc --noEmit` clean + the capacity suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)