### PR TITLE
fix(dev): CTL-764 follow-up — Codex round-3 emission gating + gitleaks allowlist (greens main)

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -46,4 +46,7 @@ regexes = [
   # Public OAuth client identifier in catalyst-agent/accounts.mjs — a public
   # client_id (not a secret); exact value only.
   '''^9d1c250a-e61b-44d9-88ed-5944d1962f5e$''',
+  # doctor.mjs comment "token present, CATALYST_EXECUTOR=sdk → PASS" — generic-api-key
+  # false-positives the env assignment as a key (main gitleaks red since 4f7aac4b).
+  '''^CATALYST_EXECUTOR=sdk$''',
 ]

--- a/plugins/dev/scripts/__tests__/check-setup-worker-status-labels.test.sh
+++ b/plugins/dev/scripts/__tests__/check-setup-worker-status-labels.test.sh
@@ -211,6 +211,39 @@ else
 	fail "group missing: exit 0 (got rc=$RC5)"
 fi
 
+# ─── Test 6 (CTL-764 finding G): supported .catalyst.linear.apiToken shape ─────
+# An install using the supported nested shape must NOT be skipped — before the fix
+# the check read only the legacy .linear.apiToken, leaving `token` empty so the
+# worker-status section silently soft-skipped. Confirm the live query IS issued and
+# the members are checked.
+make_secrets_supported() {
+	local xdg="$1"
+	mkdir -p "${xdg}/catalyst"
+	cat >"${xdg}/catalyst/config-test.json" <<'EOF'
+{ "catalyst": { "linear": { "apiToken": "lin_api_fake_ws_token" } } }
+EOF
+	echo '{"catalyst":{}}' >"${xdg}/catalyst/config.json"
+}
+
+P6="${SCRATCH}/p6" X6="${SCRATCH}/x6" B6="${SCRATCH}/b6" L6="${SCRATCH}/l6.log"
+make_project "$P6"
+make_secrets_supported "$X6"
+install_ws_curl "$B6" "$L6" "full"
+: >"$L6"
+mkdir -p "${X6}/catalyst"
+OUT6="$(run_check_setup "$P6" "$X6" "$B6")"
+if grep -q "issueLabels" "$L6" 2>/dev/null; then
+	pass "supported token shape: live issueLabels query IS issued (not soft-skipped)"
+else
+	fail "supported token shape: live issueLabels query IS issued (not soft-skipped)"
+fi
+if ! grep -qiE "Skipping worker-status label check" <<<"$OUT6"; then
+	pass "supported token shape: no soft-skip message"
+else
+	fail "supported token shape: no soft-skip message"
+	echo "$OUT6" | grep -i "worker\|skip" | sed 's/^/    /'
+fi
+
 echo ""
 echo "Results: ${PASSES} passed, ${FAILURES} failed"
 [ "$FAILURES" = "0" ]

--- a/plugins/dev/scripts/__tests__/setup-execution-core-states.test.sh
+++ b/plugins/dev/scripts/__tests__/setup-execution-core-states.test.sh
@@ -570,8 +570,10 @@ WS_GRP_MUT_VAL="$(source "$SCRIPT" && build_issue_label_group_create_mutation 'w
 run "build_issue_label_group_create_mutation: contains issueLabelCreate" \
 	bash -c "echo '$WS_GRP_MUT_VAL' | grep -q 'issueLabelCreate'"
 
-run "build_issue_label_group_create_mutation: contains isGroup" \
-	bash -c "echo '$WS_GRP_MUT_VAL' | grep -q 'isGroup'"
+# CTL-764 finding A: the group is created as a plain workspace label — sending isGroup:true
+# is rejected by IssueLabelCreateInput and aborts the reconcile before any child is created.
+run "build_issue_label_group_create_mutation: omits isGroup (rejected by IssueLabelCreateInput)" \
+	bash -c "! echo '$WS_GRP_MUT_VAL' | grep -q 'isGroup'"
 
 run "build_issue_label_group_create_mutation: omits teamId (workspace scope)" \
 	bash -c "! echo '$WS_GRP_MUT_VAL' | grep -q 'teamId'"
@@ -599,6 +601,11 @@ make_label_curl() {
 		;;
 	group_only)
 		labels_nodes='[{"id":"grp-ws","name":"worker-status","isGroup":true,"parent":null}]'
+		;;
+	group_only_plain)
+		# CTL-764 finding A: the parent exists but is still a PLAIN label (isGroup false)
+		# — a partial-failure re-run where the parent was created but no child attached.
+		labels_nodes='[{"id":"grp-ws","name":"worker-status","isGroup":false,"parent":null}]'
 		;;
 	partial)
 		labels_nodes='[{"id":"grp-ws","name":"worker-status","isGroup":true,"parent":null},{"id":"lbl-q","name":"queued","isGroup":false,"parent":{"id":"grp-ws"}},{"id":"lbl-b","name":"blocked","isGroup":false,"parent":{"id":"grp-ws"}},{"id":"lbl-nh","name":"needs-human","isGroup":false,"parent":{"id":"grp-ws"}}]'
@@ -737,6 +744,28 @@ run "--dry-run: no issueLabelCreate mutations issued" \
 
 run "--dry-run: reports intent (mentions worker-status or dry-run)" \
 	bash -c "grep -qiE 'dry.run|DRY|worker.status' '${SCRATCH}/ws-t5-out'"
+
+# Test 6 (CTL-764 finding A): the parent exists as a plain label (isGroup false, no
+# children yet). The lookup must FIND it by name+parent==null — NOT re-create it — and
+# create the 4 missing children → 4 issueLabelCreate calls, none of them a group create.
+WS_T6_BIN="${SCRATCH}/ws-t6/bin"
+WS_T6_LOG="${SCRATCH}/ws-t6/req.log"
+mkdir -p "${SCRATCH}/ws-t6"
+: >"$WS_T6_LOG"
+make_label_curl "$WS_T6_BIN" "group_only_plain" "true" "$WS_T6_LOG"
+(
+	# shellcheck source=/dev/null
+	source "$SCRIPT"
+	PATH="$WS_T6_BIN:$PATH"
+	dry_run=0
+	reconcile_worker_status_labels "fake-token"
+) >"${SCRATCH}/ws-t6-out" 2>&1
+
+run "plain-label parent: found by name+parent==null, creates the 4 children (4 issueLabelCreate)" \
+	bash -c "count=\$(grep -c 'issueLabelCreate' '$WS_T6_LOG' 2>/dev/null || echo 0); [ \"\$count\" = '4' ]"
+
+run "plain-label parent: never re-creates the group (every create carries parentId)" \
+	bash -c "! grep 'issueLabelCreate' '$WS_T6_LOG' | grep -qv 'parentId'"
 
 echo ""
 echo "Results: ${PASSES} passed, ${FAILURES} failed"

--- a/plugins/dev/scripts/check-setup.sh
+++ b/plugins/dev/scripts/check-setup.sh
@@ -258,7 +258,12 @@ if [[ -n ${PROJECT_KEY-} ]]; then
 	if [[ -f $SECRETS_FILE ]]; then
 		pass "Secrets file exists: config-${PROJECT_KEY}.json"
 
-		token=$(jq -r '.linear.apiToken // empty' "$SECRETS_FILE" 2>/dev/null)
+		# CTL-764 finding G: read the supported .catalyst.linear.apiToken shape first,
+		# falling back to the legacy .linear.apiToken — matching setup-execution-core-states.sh
+		# and check-project-setup.sh. Reading only the legacy path left installs on the
+		# supported shape with an empty token, silently skipping the worker-status label
+		# check (and mis-reporting the token below).
+		token=$(jq -r '.catalyst.linear.apiToken // .linear.apiToken // empty' "$SECRETS_FILE" 2>/dev/null)
 		if [[ -n $token && $token != "[NEEDS_SETUP]" ]]; then
 			pass "Linear API token configured"
 		else

--- a/plugins/dev/scripts/execution-core/daemon.mjs
+++ b/plugins/dev/scripts/execution-core/daemon.mjs
@@ -425,8 +425,16 @@ export async function handleCommentWake(
     } catch {
       /* fail-open */
     }
+    // CTL-764 finding E: gate the needs-input→cleared emission on a CONFIRMED removal.
+    // removeLabel reports a failed read/write as {removed:false} WITHOUT throwing, so the
+    // try/catch alone never suppresses the event — a bare emit would record a clear the
+    // durable label never got. removed:true covers both a real removal AND the idempotent
+    // already-absent case (linear-write.mjs:289-291); an undefined return from a test stub
+    // is treated as success to keep the wake path testable.
+    let needsInputRemoved = false;
     try {
-      await removeLabel(ticket, "needs-input"); // CTL-764 Phase 4: durable needs-input cleared on genuine resolution
+      const res = await removeLabel(ticket, "needs-input"); // CTL-764 Phase 4: durable needs-input cleared on genuine resolution
+      needsInputRemoved = res === undefined || res?.removed === true;
     } catch {
       /* fail-open */
     }
@@ -435,15 +443,17 @@ export async function handleCommentWake(
     // is emitted here (the daemon removes the durable label out-of-band and redispatches
     // — the scheduler never observes this edge). toDisposition:null is encoded as the
     // "cleared" sentinel in the event builder (finding 12). Fail-open — never blocks the
-    // wake.
-    appendWorkerTransitionEvent({
-      ticket,
-      orchId: ticket,
-      fromDisposition: "needs-input",
-      toDisposition: null,
-      reason: "comment-wake",
-      source: "comment-wake-clear",
-    });
+    // wake. finding E: only emitted on a confirmed removal.
+    if (needsInputRemoved) {
+      appendWorkerTransitionEvent({
+        ticket,
+        orchId: ticket,
+        fromDisposition: "needs-input",
+        toDisposition: null,
+        reason: "comment-wake",
+        source: "comment-wake-clear",
+      });
+    }
 
     dispatch(orchDir, ticket, parkedPhase, { handoffPath, resumeSession });
   }

--- a/plugins/dev/scripts/execution-core/daemon.test.mjs
+++ b/plugins/dev/scripts/execution-core/daemon.test.mjs
@@ -1408,6 +1408,56 @@ describe("handleCommentWake (CTL-549)", () => {
     expect(cleared.source).toBe("comment-wake-clear");
   });
 
+  // CTL-764 finding E: removeLabel reports a failed read/write as {removed:false} without
+  // throwing, so the needs-input→cleared emission must be gated on a CONFIRMED removal —
+  // otherwise the event log says "cleared" while the durable label is still on Linear.
+  test("finding E — does NOT emit the clear when removeLabel reports {removed:false}", async () => {
+    const orch = tmpOrcDir();
+    writeSignal(orch, "CTL-1", "implement", {
+      status: "needs-input",
+      parkedFrom: "implement",
+    });
+    const transitions = [];
+    await handleCommentWake(
+      { ticket: "CTL-1", body: "answer" },
+      {
+        orchDir: orch,
+        dispatch: () => ({ code: 0 }),
+        // needs-human removes fine; needs-input removal FAILS (fail-open, no throw).
+        removeLabel: async (_t, label) =>
+          label === "needs-input" ? { removed: false, reason: "transient" } : { removed: true },
+        appendWorkerTransitionEvent: (ev) => transitions.push(ev),
+      }
+    );
+    const cleared = transitions.find(
+      (e) => e.ticket === "CTL-1" && e.fromDisposition === "needs-input" && e.toDisposition === null
+    );
+    expect(cleared).toBeUndefined();
+  });
+
+  test("finding E — emits the clear on a confirmed {removed:true}", async () => {
+    const orch = tmpOrcDir();
+    writeSignal(orch, "CTL-1", "implement", {
+      status: "needs-input",
+      parkedFrom: "implement",
+    });
+    const transitions = [];
+    await handleCommentWake(
+      { ticket: "CTL-1", body: "answer" },
+      {
+        orchDir: orch,
+        dispatch: () => ({ code: 0 }),
+        removeLabel: async () => ({ removed: true }),
+        appendWorkerTransitionEvent: (ev) => transitions.push(ev),
+      }
+    );
+    const cleared = transitions.find(
+      (e) => e.ticket === "CTL-1" && e.fromDisposition === "needs-input" && e.toDisposition === null
+    );
+    expect(cleared).toBeDefined();
+    expect(cleared.source).toBe("comment-wake-clear");
+  });
+
   test("no-ops when ticket has no worker dir", async () => {
     const orch = tmpOrcDir();
     const dispatched = [];

--- a/plugins/dev/scripts/execution-core/label-guard.mjs
+++ b/plugins/dev/scripts/execution-core/label-guard.mjs
@@ -74,7 +74,7 @@ export function labelOnce(
   ticket,
   label,
   writeStatus,
-  { appendEvent = null, env = process.env } = {}
+  { appendEvent = null, env = process.env, onApplyResult = null } = {}
 ) {
   const base = labelMarkerBase(orchDir, ticket, label);
   if (existsSync(`${base}.applied`) || existsSync(`${base}.skipped`)) return false;
@@ -82,7 +82,16 @@ export function labelOnce(
     const res = writeStatus.applyLabel({ ticket, label });
     // A fake that returns undefined (test stubs) is treated as success so
     // the once-semantics stay testable without a real result.
-    if (res === undefined || res?.applied) {
+    const applied = res === undefined || res?.applied === true;
+    // CTL-764 finding C: surface the CONFIRMED apply outcome to callers that must
+    // gate a side-effect (labelNeedsHumanUnlessBeliefOwner → the worker.transition
+    // emission) on a real application, not merely on this being the first write
+    // attempt. Only fires when applyLabel actually ran — never on a throw or on the
+    // marker-guarded early return above.
+    if (typeof onApplyResult === "function") {
+      onApplyResult({ applied, reason: res?.reason ?? null });
+    }
+    if (applied) {
       writeFileSync(`${base}.applied`, "");
     } else if (UNRECOVERABLE_LABEL_REASONS.has(res?.reason)) {
       writeFileSync(`${base}.skipped`, "");
@@ -369,12 +378,13 @@ export function beliefOwnsNeedsHuman(env = process.env) {
 //     log   : { info }              (the module's log instance)
 //   }
 //
-// CTL-764 finding 8: returns whether THIS call performed a label write attempt —
-// `false` when it deferred to the belief owner OR labelOnce found a terminal marker
-// (a persisted needs-human after a daemon restart), `true` when labelOnce performed
-// the once-application. Callers gate their worker.transition emission on this so a
-// no-op re-application (no label changed) never records a fresh escalation. Existing
-// callers ignore the return, so this stays backward-compatible.
+// CTL-764 finding 8 + finding C: returns whether the needs-human label was CONFIRMED
+// applied on THIS call — `false` when it deferred to the belief owner, when labelOnce
+// found a terminal marker (a persisted needs-human after a daemon restart), OR when the
+// apply was attempted but did not land (rate-limited / exclusive-conflict / missing-label);
+// `true` ONLY when applyLabel reported applied:true. Callers gate their worker.transition
+// emission on this so neither a no-op re-application nor a failed attempt records a fresh
+// escalation. Existing callers ignore the return, so this stays backward-compatible.
 export function labelNeedsHumanUnlessBeliefOwner(
   orchDir,
   ticket,
@@ -387,8 +397,18 @@ export function labelNeedsHumanUnlessBeliefOwner(
     logger.info({ ticket, site }, "needs-human deferred to belief owner (CTL-1241)");
     return false;
   }
-  // Enforcement OFF (default): call labelOnce exactly as before.
-  return labelOnce(orchDir, ticket, "needs-human", writeStatus);
+  // Enforcement OFF (default): call labelOnce exactly as before. CTL-764 finding C:
+  // return whether the label was CONFIRMED applied, not merely attempted — labelOnce's
+  // boolean is true for any first write attempt (including outcomes where the label never
+  // landed). Capture applyLabel's applied result via onApplyResult; a marker-guarded no-op
+  // (labelOnce early-returns, onApplyResult never fires) correctly stays false.
+  let applied = false;
+  labelOnce(orchDir, ticket, "needs-human", writeStatus, {
+    onApplyResult: (r) => {
+      applied = r.applied === true;
+    },
+  });
+  return applied;
 }
 
 export function recordEscalation(orchDir, ticket, phase, reason, now) {

--- a/plugins/dev/scripts/execution-core/label-guard.test.mjs
+++ b/plugins/dev/scripts/execution-core/label-guard.test.mjs
@@ -846,4 +846,51 @@ describe("labelNeedsHumanUnlessBeliefOwner (CTL-1241)", () => {
     });
     expect(wrote).toBe(false);
   });
+
+  // CTL-764 finding C: the return must reflect a CONFIRMED apply, not a bare first
+  // attempt. labelOnce returns true for any first write attempt — including outcomes
+  // where applyLabel reported applied:false — so gating a worker.transition on the raw
+  // labelOnce boolean records a needs-human escalation that never actually landed.
+  test("finding C — returns false when applyLabel is attempted but not applied (rate-limited)", () => {
+    const calls = [];
+    const ws = {
+      applyLabel: (args) => {
+        calls.push(args);
+        return { applied: false, reason: "rate-limited" };
+      },
+    };
+    mkdirSync(join(orchDir, "workers", "CTL-C1"), { recursive: true });
+    const wrote = labelNeedsHumanUnlessBeliefOwner(orchDir, "CTL-C1", ws, {
+      env: { CATALYST_INTENTS_ENFORCE: "0" },
+      log: { info: () => {} },
+    });
+    // The attempt happened (transient → no marker, retries next tick) but the label
+    // did not land, so no transition should be recorded.
+    expect(calls.length).toBe(1);
+    expect(wrote).toBe(false);
+  });
+
+  test("finding C — returns false on an unrecoverable failure (exclusive-conflict, .skipped written)", () => {
+    const ws = { applyLabel: () => ({ applied: false, reason: "exclusive-conflict" }) };
+    mkdirSync(join(orchDir, "workers", "CTL-C2"), { recursive: true });
+    const wrote = labelNeedsHumanUnlessBeliefOwner(orchDir, "CTL-C2", ws, {
+      env: { CATALYST_INTENTS_ENFORCE: "0" },
+      log: { info: () => {} },
+    });
+    expect(wrote).toBe(false);
+    // The .skipped marker is still written (storm-break) even though nothing applied.
+    expect(
+      existsSync(join(orchDir, "workers", "CTL-C2", ".linear-label-needs-human.skipped"))
+    ).toBe(true);
+  });
+
+  test("finding C — returns true ONLY on a confirmed applied:true", () => {
+    const ws = { applyLabel: () => ({ applied: true }) };
+    mkdirSync(join(orchDir, "workers", "CTL-C3"), { recursive: true });
+    const wrote = labelNeedsHumanUnlessBeliefOwner(orchDir, "CTL-C3", ws, {
+      env: { CATALYST_INTENTS_ENFORCE: "0" },
+      log: { info: () => {} },
+    });
+    expect(wrote).toBe(true);
+  });
 });

--- a/plugins/dev/scripts/execution-core/scheduler.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.mjs
@@ -5117,6 +5117,18 @@ export function schedulerTick(
           now,
         });
 
+        // CTL-764 findings B + F: the worker.transition emission must reflect the
+        // ticket's TRUE disposition. needs-human is sticky + exclusive, so when it is
+        // already on the ticket the lower held dispositions (blocked/queued) cannot
+        // apply — recording one would falsely downgrade the two-axis stream (finding B).
+        // On a clear, pass the held label the ticket currently wears as fromDisposition
+        // so a genuine blocked/queued→cleared still emits after a daemon restart, where
+        // lastDispositionEmit is empty and recordTransition's first-seen-clear allowance
+        // needs a proven prior (finding F). needs-human clears are owned by
+        // clearStalledLabel, so the admission loop never emits them.
+        const currentLabelSet = new Set(labelsByTicket.get(ticket) ?? []);
+        const hasNeedsHuman = currentLabelSet.has(HELD_LABEL_NEEDS_HUMAN);
+
         if (desired) {
           // Only-on-state-change emission: skip if the same held class already
           // emitted for this ticket since it was last cleared/admitted.
@@ -5128,18 +5140,34 @@ export function schedulerTick(
               { ticket, phase: "advance" }
             );
           }
-          // CTL-764 Phase 5: emit worker.transition for disposition hold.
-          recordTransition({
-            ticket,
-            toDisposition: desired,
-            reason,
-            source: "scheduler-admission",
-          });
+          // CTL-764 Phase 5: emit worker.transition for disposition hold — finding B
+          // suppresses it while needs-human is present (the lower disposition never lands).
+          if (!hasNeedsHuman) {
+            recordTransition({
+              ticket,
+              toDisposition: desired,
+              reason,
+              source: "scheduler-admission",
+            });
+          }
         } else {
           // Admitted (or no longer held) → reset so a future re-hold re-emits.
           lastHeldEmitState.delete(ticket);
-          // CTL-764 Phase 5: emit worker.transition for admission (clear-on-pickup).
-          recordTransition({ ticket, toDisposition: null, source: "scheduler-admission" });
+          // CTL-764 Phase 5: emit worker.transition for admission (clear-on-pickup) —
+          // finding F passes the held label currently on the ticket as fromDisposition so
+          // the clear emits even after a restart; suppressed when needs-human is present.
+          if (!hasNeedsHuman) {
+            const currentHeld =
+              [HELD_LABEL_BLOCKED, HELD_LABEL_WAITING, LEGACY_HELD_LABEL_WAITING].find((l) =>
+                currentLabelSet.has(l)
+              ) ?? null;
+            recordTransition({
+              ticket,
+              fromDisposition: currentHeld,
+              toDisposition: null,
+              source: "scheduler-admission",
+            });
+          }
         }
       }
 

--- a/plugins/dev/scripts/execution-core/scheduler.test.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.test.mjs
@@ -11557,4 +11557,58 @@ describe("CTL-764 Phase 5 — schedulerTick emits worker.transition events", () 
     expect(park).toBeDefined();
     expect(park.source).toBe("needs-input-park");
   });
+
+  // CTL-764 finding B: a triaged-waiting ticket already wearing the sticky needs-human
+  // label (e.g. a dependency-cycle escalation persisted across restart) stays held, but
+  // convergeHeldLabel can't apply the lower disposition (exclusive worker-status group).
+  // The lower-disposition worker.transition must be SUPPRESSED so the two-axis stream is
+  // not falsely downgraded below needs-human.
+  test("finding B — a held ticket wearing needs-human suppresses the lower-disposition emit", () => {
+    writeFileSync(join(orchDir, "state.json"), JSON.stringify({ maxParallel: 0 })); // no slot → held
+    writeSignal("CTL-B", "triage", "done"); // triaged-waiting
+    const transitions = [];
+    schedulerTick(orchDir, {
+      readEligible: () => [],
+      dispatch: fakeDispatch(),
+      verifyDispatched: verifyOk,
+      liveBackgroundCount: () => 0,
+      // Held by a non-terminal blocker AND already wearing needs-human on Linear.
+      fetchBatch: mkBatch({
+        "CTL-B": relBlockedBy("CTL-BLK", { labels: ["needs-human"] }),
+        "CTL-BLK": descOf("Triage"),
+      }),
+      hasTriageArtifact: () => true,
+      writeStatus: noWrites(),
+      appendWorkerTransitionEvent: (ev) => transitions.push(ev),
+    });
+    const lowered = transitions.find(
+      (e) => e.ticket === "CTL-B" && (e.toDisposition === "blocked" || e.toDisposition === "queued")
+    );
+    expect(lowered).toBeUndefined();
+  });
+
+  // CTL-764 finding F: after a daemon restart lastDispositionEmit is empty. A ticket still
+  // wearing "blocked" on Linear that is admitted this tick (desired=null) must still emit
+  // the genuine blocked→cleared transition — the fix passes the current held label as
+  // fromDisposition so recordTransition's first-seen-clear allowance fires.
+  test("finding F — an admitted held ticket emits blocked→cleared after a restart (fromDisposition proven)", () => {
+    writeFileSync(join(orchDir, "state.json"), JSON.stringify({ maxParallel: 2 }));
+    writeSignal("CTL-F", "triage", "done"); // triaged-waiting, unblocked → admitted
+    const transitions = [];
+    schedulerTick(orchDir, {
+      readEligible: () => [],
+      dispatch: fakeDispatch(),
+      verifyDispatched: verifyOk,
+      liveBackgroundCount: () => 0,
+      fetchBatch: mkBatch(() => relUnblocked({ labels: ["blocked"] })),
+      hasTriageArtifact: () => true,
+      writeStatus: { ...noWrites(), removeLabel: () => ({ removed: true }) },
+      appendWorkerTransitionEvent: (ev) => transitions.push(ev),
+    });
+    const cleared = transitions.find(
+      (e) => e.ticket === "CTL-F" && e.fromDisposition === "blocked" && e.toDisposition === null
+    );
+    expect(cleared).toBeDefined();
+    expect(cleared.source).toBe("scheduler-admission");
+  });
 });

--- a/plugins/dev/scripts/gen-cli-reference.sh
+++ b/plugins/dev/scripts/gen-cli-reference.sh
@@ -66,7 +66,6 @@ catalyst-install|Umbrella & lifecycle|1|Provision or tear down this node for its
 catalyst-doctor|Umbrella & lifecycle|1|Fail-closed activation gate — class-aware health/activation grade (exit 0 ⇒ safe to activate).
 catalyst-backup|Umbrella & lifecycle|0|Capture / restore a node's restorable identity + state bundle (bare backup writes a secrets bundle).
 catalyst-claude|Umbrella & lifecycle|0|Wrapper that registers a Catalyst session around claude, then execs the interactive claude process.
-boot-resume-approve|Umbrella & lifecycle|0|Operator approval CLI for the boot-resume gate (CTL-1443) — --list shows pending gates; <ticket> writes the .boot-resume-approved sentinel the daemon polls each tick.
 emit-lifecycle-event|Hooks|0|Claude Code Stop/SubagentStop hook — fallback agent.checkout emitter for the broker.
 EOF
 }

--- a/plugins/dev/scripts/setup-execution-core-states.sh
+++ b/plugins/dev/scripts/setup-execution-core-states.sh
@@ -198,14 +198,17 @@ worker_status_members() {
 # build_issue_label_group_create_mutation <name> <color>
 # Workspace-scoped: omits teamId so Linear assigns the label to the workspace,
 # not a specific team (the daemon applies via linearis which lists workspace labels).
+# CTL-764 finding A: creates the parent as a PLAIN workspace label — IssueLabelCreateInput
+# accepts only id/name/description/color/parentId/teamId, so sending isGroup:true is
+# rejected and the whole reconcile aborts before any child is created. A Linear label
+# becomes a group implicitly the moment a child is created with its parentId (below).
 build_issue_label_group_create_mutation() {
 	local name="$1" color="$2"
 	cat <<MUTATION
 mutation {
   issueLabelCreate(input: {
     name: "${name}",
-    color: "${color}",
-    isGroup: true
+    color: "${color}"
   }) {
     success
     issueLabel { id name }
@@ -263,10 +266,14 @@ reconcile_worker_status_labels() {
 	local labels_json
 	labels_json=$(echo "$resp" | jq -c '.data.issueLabels.nodes // []')
 
-	# Find existing workspace group by name + isGroup:true.
+	# Find the existing workspace parent by name at the top level (parent == null).
+	# CTL-764 finding A: match on parent==null, NOT isGroup==true — a freshly-created
+	# parent is a plain label (isGroup false) until its first child attaches and Linear
+	# flips it to a group, so requiring isGroup would miss a parent whose child creation
+	# partially failed and wrongly re-issue a duplicate create.
 	local group_id
 	group_id=$(echo "$labels_json" | jq -r --arg n "$group_name" \
-		'.[] | select(.name == $n and .isGroup == true) | .id // empty' | head -1)
+		'.[] | select(.name == $n and .parent == null) | .id // empty' | head -1)
 
 	if [[ -z $group_id ]]; then
 		# Create the group (workspace-scoped, isGroup:true, no teamId).

--- a/website/src/content/docs/reference/catalyst-cli.md
+++ b/website/src/content/docs/reference/catalyst-cli.md
@@ -245,12 +245,6 @@ Wrapper that registers a Catalyst session around claude, then execs the interact
 
 [Source](https://github.com/coalesce-labs/catalyst/blob/main/plugins/dev/scripts/catalyst-claude.sh)
 
-### boot-resume-approve
-
-Operator approval CLI for the boot-resume gate (CTL-1443) — --list shows pending gates; <ticket> writes the .boot-resume-approved sentinel the daemon polls each tick.
-
-[Source](https://github.com/coalesce-labs/catalyst/blob/main/plugins/dev/scripts/execution-core/boot-resume-approve.mjs)
-
 ## Hooks
 
 ### emit-lifecycle-event


### PR DESCRIPTION
## What

Two standing-red repairs plus the Codex round-3 findings that landed after #2597 auto-merged:

**Codex round-3 (7 findings, same invariant as round 2 — emissions reflect CONFIRMED changes, not attempts):**
- `label-guard.mjs`: `labelNeedsHumanUnlessBeliefOwner` now returns applied-**confirmed** via a new `labelOnce` `onApplyResult` seam (rate-limited / exclusive-conflict / missing-label no longer record false needs-human transitions; `escalate.mjs`'s CTL-962 first-application semantics untouched).
- `daemon.mjs` comment-wake: needs-input→cleared emits only on `removed:true`.
- `scheduler.mjs` admission: lower-disposition hold emission suppressed while sticky needs-human is worn; admission clears pass the worn held label as `fromDisposition` so restart-window blocked/queued→cleared transitions emit (uses the round-2 first-seen-clear allowance).
- `setup-execution-core-states.sh`: drop unsupported `isGroup` from IssueLabelCreateInput (fresh-workspace group create was rejected → zero child labels created); parent found/created as a plain label, becomes a group when children attach via `parentId`.
- `gen-cli-reference.sh` + `catalyst-cli.md`: dedupe the `boot-resume-approve` manifest row/section.
- `check-setup.sh`: worker-status check reads `.catalyst.linear.apiToken // .linear.apiToken`.

**gitleaks (main red since 2026-07-09):** `generic-api-key` false-positives the doctor.mjs comment `token present, CATALYST_EXECUTOR=sdk → PASS` (the "secret" is literally `CATALYST_EXECUTOR=sdk`). Anchored allowlist regex added; full-history scan verified locally → **no leaks found** (3.25 GB, 2242 commits).

## Verification

Stable suite 4314 pass / 4 pre-existing local-env fails (hostname/linearis fixture class, untouched files); cli-reference-drift 123/0; label-guard 67/0; touched scheduler/daemon describes green in isolation; `bash -n` clean on all scripts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)