### PR TITLE
fix(dev): CTL-764 follow-up — Codex round-4 emission/fallback edge cases

### DIFF
--- a/plugins/dev/scripts/__tests__/check-setup-worker-status-labels.test.sh
+++ b/plugins/dev/scripts/__tests__/check-setup-worker-status-labels.test.sh
@@ -244,6 +244,39 @@ else
 	echo "$OUT6" | grep -i "worker\|skip" | sed 's/^/    /'
 fi
 
+# ─── Test 7 (CTL-764 r4): "[NEEDS_SETUP]" placeholder must not stop the fallback ───
+# A migrated secrets file can carry the sentinel in the supported shape while the
+# legacy .linear.apiToken still holds the usable token — the // fallback must skip
+# the placeholder and reach the legacy value (before the fix it stopped on the
+# sentinel, reported no token, and soft-skipped the worker-status check).
+make_secrets_placeholder() {
+	local xdg="$1"
+	mkdir -p "${xdg}/catalyst"
+	cat >"${xdg}/catalyst/config-test.json" <<'EOF'
+{ "catalyst": { "linear": { "apiToken": "[NEEDS_SETUP]" } }, "linear": { "apiToken": "lin_api_fake_ws_token" } }
+EOF
+	echo '{"catalyst":{}}' >"${xdg}/catalyst/config.json"
+}
+
+P7="${SCRATCH}/p7" X7="${SCRATCH}/x7" B7="${SCRATCH}/b7" L7="${SCRATCH}/l7.log"
+make_project "$P7"
+make_secrets_placeholder "$X7"
+install_ws_curl "$B7" "$L7" "full"
+: >"$L7"
+mkdir -p "${X7}/catalyst"
+OUT7="$(run_check_setup "$P7" "$X7" "$B7")"
+if grep -q "issueLabels" "$L7" 2>/dev/null; then
+	pass "placeholder fallback: live issueLabels query IS issued (legacy token used)"
+else
+	fail "placeholder fallback: live issueLabels query IS issued (legacy token used)"
+fi
+if grep -q "Linear API token configured" <<<"$OUT7"; then
+	pass "placeholder fallback: token reported configured from the legacy path"
+else
+	fail "placeholder fallback: token reported configured from the legacy path"
+	echo "$OUT7" | grep -i "token" | sed 's/^/    /'
+fi
+
 echo ""
 echo "Results: ${PASSES} passed, ${FAILURES} failed"
 [ "$FAILURES" = "0" ]

--- a/plugins/dev/scripts/check-setup.sh
+++ b/plugins/dev/scripts/check-setup.sh
@@ -263,7 +263,10 @@ if [[ -n ${PROJECT_KEY-} ]]; then
 		# and check-project-setup.sh. Reading only the legacy path left installs on the
 		# supported shape with an empty token, silently skipping the worker-status label
 		# check (and mis-reporting the token below).
-		token=$(jq -r '.catalyst.linear.apiToken // .linear.apiToken // empty' "$SECRETS_FILE" 2>/dev/null)
+		# r4: a "[NEEDS_SETUP]" placeholder in the supported shape must not stop the
+		# fallback — a migrated file can carry the sentinel there while the legacy
+		# path still holds the usable token.
+		token=$(jq -r '(.catalyst.linear.apiToken | select(. != null and . != "" and . != "[NEEDS_SETUP]")) // .linear.apiToken // empty' "$SECRETS_FILE" 2>/dev/null)
 		if [[ -n $token && $token != "[NEEDS_SETUP]" ]]; then
 			pass "Linear API token configured"
 		else

--- a/plugins/dev/scripts/execution-core/scheduler.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.mjs
@@ -1709,7 +1709,7 @@ export function convergeHeldLabel(
   current,
   desired,
   writeStatus,
-  { orchDir, now = Date.now } = {}
+  { orchDir, now = Date.now, onRemoveResult } = {}
 ) {
   // CTL-834: back off if a recent apply of `desired` failed unrecoverably.
   if (orchDir && desired && inLabelCooldown(orchDir, ticket, desired, now())) {
@@ -1719,9 +1719,24 @@ export function convergeHeldLabel(
   let writes = 0;
   // Remove any held label that is present but not desired. CTL-764 finding 1: the
   // removable set includes the legacy "waiting" so it is drained on clear-on-pickup.
+  // CTL-764 r4: the removal result is captured directly (safeWrite discards it) and
+  // surfaced via the optional onRemoveResult(label, removed) seam — removeLabel
+  // reports failures as {removed:false} WITHOUT throwing, and clear emissions must
+  // gate on a CONFIRMED removal. An undefined result (legacy/test stubs) counts as
+  // success; a throw counts as failure.
   for (const label of HELD_LABELS_REMOVABLE) {
     if (label !== desired && have.has(label)) {
-      safeWrite(() => writeStatus.removeLabel(ticket, label), { ticket, phase: "admission" });
+      let removed = false;
+      try {
+        const res = writeStatus.removeLabel(ticket, label);
+        removed = res?.removed !== false;
+      } catch (err) {
+        log.warn(
+          { ticket, phase: "admission", err: err.message },
+          "scheduler: Linear write-back threw — continuing tick"
+        );
+      }
+      onRemoveResult?.(label, removed);
       writes++;
     }
   }
@@ -5112,9 +5127,16 @@ export function schedulerTick(
         }
         // else: admitted → desired null → clear-on-pickup (both labels removed).
 
+        // CTL-764 r4 finding 1: collect which held labels this convergence CONFIRMED
+        // removed — the clear emission below must not outrun a failed removeLabel
+        // (Linear would still carry the label while the stream says cleared).
+        const confirmedRemoved = [];
         convergeHeldLabel(ticket, labelsByTicket.get(ticket), desired, writeStatus, {
           orchDir,
           now,
+          onRemoveResult: (label, removed) => {
+            if (removed) confirmedRemoved.push(label);
+          },
         });
 
         // CTL-764 findings B + F: the worker.transition emission must reflect the
@@ -5154,19 +5176,33 @@ export function schedulerTick(
           // Admitted (or no longer held) → reset so a future re-hold re-emits.
           lastHeldEmitState.delete(ticket);
           // CTL-764 Phase 5: emit worker.transition for admission (clear-on-pickup) —
-          // finding F passes the held label currently on the ticket as fromDisposition so
-          // the clear emits even after a restart; suppressed when needs-human is present.
+          // finding F passes the held label as fromDisposition so the clear emits even
+          // after a restart; suppressed when needs-human is present. CTL-764 r4:
+          //   finding 1 — the proven prior must come from a CONFIRMED removal, not the
+          //   pre-convergence snapshot: on a transient removeLabel failure Linear still
+          //   wears the label, so the emission is skipped and a later tick re-converges
+          //   and emits. A ticket that wore no held label stays a from:null no-op
+          //   (dropped by recordTransition's only-on-change guard).
+          //   finding 2 — legacy "waiting" normalizes to the canonical "queued" so the
+          //   transition stream never carries a fifth disposition value.
           if (!hasNeedsHuman) {
-            const currentHeld =
+            const woreHeld = [HELD_LABEL_BLOCKED, HELD_LABEL_WAITING, LEGACY_HELD_LABEL_WAITING].some(
+              (l) => currentLabelSet.has(l)
+            );
+            const removedHeld =
               [HELD_LABEL_BLOCKED, HELD_LABEL_WAITING, LEGACY_HELD_LABEL_WAITING].find((l) =>
-                currentLabelSet.has(l)
+                confirmedRemoved.includes(l)
               ) ?? null;
-            recordTransition({
-              ticket,
-              fromDisposition: currentHeld,
-              toDisposition: null,
-              source: "scheduler-admission",
-            });
+            const fromHeld =
+              removedHeld === LEGACY_HELD_LABEL_WAITING ? HELD_LABEL_WAITING : removedHeld;
+            if (!woreHeld || fromHeld) {
+              recordTransition({
+                ticket,
+                fromDisposition: fromHeld,
+                toDisposition: null,
+                source: "scheduler-admission",
+              });
+            }
           }
         }
       }

--- a/plugins/dev/scripts/execution-core/scheduler.test.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.test.mjs
@@ -11611,4 +11611,52 @@ describe("CTL-764 Phase 5 — schedulerTick emits worker.transition events", () 
     expect(cleared).toBeDefined();
     expect(cleared.source).toBe("scheduler-admission");
   });
+
+  // CTL-764 r4 finding 1: the restart clear must gate on a CONFIRMED removal.
+  // removeLabel reports transient failures as {removed:false} without throwing —
+  // Linear still wears the label, so emitting cleared would fork the stream from
+  // Linear. The emission is skipped; a later tick re-converges and emits then.
+  test("r4 finding 1 — a failed removeLabel suppresses the restart clear emission", () => {
+    writeFileSync(join(orchDir, "state.json"), JSON.stringify({ maxParallel: 2 }));
+    writeSignal("CTL-R41", "triage", "done"); // triaged-waiting, unblocked → admitted
+    const transitions = [];
+    schedulerTick(orchDir, {
+      readEligible: () => [],
+      dispatch: fakeDispatch(),
+      verifyDispatched: verifyOk,
+      liveBackgroundCount: () => 0,
+      fetchBatch: mkBatch(() => relUnblocked({ labels: ["blocked"] })),
+      hasTriageArtifact: () => true,
+      writeStatus: { ...noWrites(), removeLabel: () => ({ removed: false }) },
+      appendWorkerTransitionEvent: (ev) => transitions.push(ev),
+    });
+    const cleared = transitions.find(
+      (e) => e.ticket === "CTL-R41" && e.toDisposition === null && e.source === "scheduler-admission"
+    );
+    expect(cleared).toBeUndefined();
+  });
+
+  // CTL-764 r4 finding 2: a pre-migration "waiting" label is only a removable alias of
+  // "queued" — the restart clear must emit the canonical queued→cleared, never a fifth
+  // disposition value the two-axis vocabulary doesn't define.
+  test("r4 finding 2 — legacy waiting normalizes to queued on the restart clear", () => {
+    writeFileSync(join(orchDir, "state.json"), JSON.stringify({ maxParallel: 2 }));
+    writeSignal("CTL-R42", "triage", "done"); // triaged-waiting, unblocked → admitted
+    const transitions = [];
+    schedulerTick(orchDir, {
+      readEligible: () => [],
+      dispatch: fakeDispatch(),
+      verifyDispatched: verifyOk,
+      liveBackgroundCount: () => 0,
+      fetchBatch: mkBatch(() => relUnblocked({ labels: ["waiting"] })),
+      hasTriageArtifact: () => true,
+      writeStatus: { ...noWrites(), removeLabel: () => ({ removed: true }) },
+      appendWorkerTransitionEvent: (ev) => transitions.push(ev),
+    });
+    const cleared = transitions.find(
+      (e) => e.ticket === "CTL-R42" && e.toDisposition === null && e.source === "scheduler-admission"
+    );
+    expect(cleared).toBeDefined();
+    expect(cleared.fromDisposition).toBe("queued");
+  });
 });


### PR DESCRIPTION
Round-4 findings on the merged #2631 (three narrow edges of the confirmed-write invariant):

- **scheduler.mjs** — `convergeHeldLabel` gains an `onRemoveResult(label, removed)` seam (removal results were discarded by `safeWrite`; `removeLabel` reports failures as `{removed:false}` without throwing). The admission restart-clear now emits only from a **confirmed** removal — a transient failure leaves Linear wearing the label, so the emission defers to a later converging tick. A ticket that wore no held label remains a from:null no-op.
- **scheduler.mjs** — legacy `waiting` normalizes to the canonical `queued` in the clear's `fromDisposition`, so the transition stream never carries a fifth disposition value.
- **check-setup.sh** — the token fallback skips a `[NEEDS_SETUP]` placeholder in the supported shape so a migrated file with a usable legacy token doesn't soft-skip the worker-status check.

Tests: scheduler Phase-5 describe +2 (failed-removal suppression; waiting→queued), check-setup +Test 7 (placeholder fallback) — 13/0 bash, 14/0 scheduler finding tests, adjacent suites 113/0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)