### PR TITLE
feat(dev): CTL-1481 worker:<host> label ownership — Linear board shows which node owns each ticket

### DIFF
--- a/plugins/dev/scripts/__tests__/setup-execution-core-states.test.sh
+++ b/plugins/dev/scripts/__tests__/setup-execution-core-states.test.sh
@@ -767,6 +767,316 @@ run "plain-label parent: found by name+parent==null, creates the 4 children (4 i
 run "plain-label parent: never re-creates the group (every create carries parentId)" \
 	bash -c "! grep 'issueLabelCreate' '$WS_T6_LOG' | grep -qv 'parentId'"
 
+# ─── Phase 2 (CTL-1481): worker:<host> label group ───────────────────────────
+# Unit tests for pure helpers (script already sourced above).
+
+run "worker_host_group_name is 'worker'" \
+	bash -c "source '$SCRIPT'; [ \"\$(worker_host_group_name)\" = 'worker' ]"
+
+run "worker_host_color: returns a single hex color" \
+	bash -c "source '$SCRIPT'; echo \"\$(worker_host_color)\" | grep -qE '^#[0-9a-fA-F]{6}\$'"
+
+run "worker_host_self_name: CATALYST_HOST_NAME env wins" \
+	bash -c "source '$SCRIPT'; [ \"\$(CATALYST_HOST_NAME=envhost worker_host_self_name)\" = 'envhost' ]"
+
+WH_LAYER2_DIR="${SCRATCH}/wh-layer2"
+mkdir -p "$WH_LAYER2_DIR"
+cat >"${WH_LAYER2_DIR}/config.json" <<'EOF'
+{"catalyst":{"host":{"name":"layer2host"}}}
+EOF
+
+run "worker_host_self_name: Layer-2 catalyst.host.name used when env unset" \
+	bash -c "source '$SCRIPT'; unset CATALYST_HOST_NAME; [ \"\$(CATALYST_LAYER2_CONFIG_FILE='${WH_LAYER2_DIR}/config.json' worker_host_self_name)\" = 'layer2host' ]"
+
+run "worker_host_self_name: falls back to hostname when env+layer2 absent" \
+	bash -c "source '$SCRIPT'; unset CATALYST_HOST_NAME; out=\$(CATALYST_LAYER2_CONFIG_FILE='${WH_LAYER2_DIR}/missing.json' worker_host_self_name); [ -n \"\$out\" ]"
+
+run "worker_host_roster: missing cluster.json -> empty" \
+	bash -c "source '$SCRIPT'; [ -z \"\$(CATALYST_CLUSTER_DIR='${SCRATCH}/wh-missing-cluster' worker_host_roster)\" ]"
+
+WH_MALFORMED_DIR="${SCRATCH}/wh-malformed-cluster"
+mkdir -p "$WH_MALFORMED_DIR"
+echo '{not valid json' >"${WH_MALFORMED_DIR}/cluster.json"
+
+run "worker_host_roster: malformed cluster.json -> empty (fail-soft)" \
+	bash -c "source '$SCRIPT'; [ -z \"\$(CATALYST_CLUSTER_DIR='${WH_MALFORMED_DIR}' worker_host_roster)\" ]"
+
+WH_ROSTER_DIR="${SCRATCH}/wh-roster"
+mkdir -p "$WH_ROSTER_DIR"
+cat >"${WH_ROSTER_DIR}/cluster.json" <<'EOF'
+{"roster": ["mini", "mini-2"]}
+EOF
+
+run "worker_host_roster: reads roster array" \
+	bash -c "source '$SCRIPT'; names=\$(CATALYST_CLUSTER_DIR='${WH_ROSTER_DIR}' worker_host_roster | sort | tr '\n' ' '); [ \"\$names\" = 'mini mini-2 ' ]"
+
+run "worker_host_list: dedupes roster + self when self is already in the roster" \
+	bash -c "source '$SCRIPT'; names=\$(CATALYST_CLUSTER_DIR='${WH_ROSTER_DIR}' CATALYST_HOST_NAME='mini' worker_host_list | sort | tr '\n' ' '); [ \"\$names\" = 'mini mini-2 ' ]"
+
+run "worker_host_list: unions roster + a distinct self host" \
+	bash -c "source '$SCRIPT'; names=\$(CATALYST_CLUSTER_DIR='${WH_ROSTER_DIR}' CATALYST_HOST_NAME='laptop' worker_host_list | sort | tr '\n' ' '); [ \"\$names\" = 'laptop mini mini-2 ' ]"
+
+# make_worker_host_curl <bin_dir> <labels_nodes_json|ERROR> <create_ok> <log_file>
+# Generic label-list fixture (labels_nodes_json is the raw `nodes` array
+# content, or the literal string ERROR to make the initial query fail).
+make_worker_host_curl() {
+	local bin_dir="$1" labels_nodes="$2" create_ok="${3:-true}" log="${4:-/dev/null}"
+	mkdir -p "$bin_dir"
+	local create_resp query_resp
+	if [ "$create_ok" = "true" ]; then
+		create_resp='{"data":{"issueLabelCreate":{"success":true,"issueLabel":{"id":"new-lbl-id","name":"x"}}}}'
+	else
+		create_resp='{"errors":[{"message":"insufficient permissions"}]}'
+	fi
+	if [ "$labels_nodes" = "ERROR" ]; then
+		query_resp='{"errors":[{"message":"api error"}]}'
+	else
+		query_resp="{\"data\":{\"issueLabels\":{\"nodes\":${labels_nodes}}}}"
+	fi
+	cat >"${bin_dir}/curl" <<SCRIPT
+#!/usr/bin/env bash
+body=""
+for a in "\$@"; do case "\$a" in {*) body="\$a";; esac; done
+if [ -z "\$body" ]; then body="\$(cat 2>/dev/null)"; fi
+echo "\$body" >> "${log}"
+case "\$body" in
+  *issueLabelCreate*) echo '${create_resp}' ;;
+  *) echo '${query_resp}' ;;
+esac
+exit 0
+SCRIPT
+	chmod +x "${bin_dir}/curl"
+}
+
+# Test 1: fresh workspace (empty) + single host (self only) -> 1 group create + 1 child create = 2
+WH_T1_BIN="${SCRATCH}/wh-t1/bin"
+WH_T1_LOG="${SCRATCH}/wh-t1/req.log"
+mkdir -p "${SCRATCH}/wh-t1"
+: >"$WH_T1_LOG"
+make_worker_host_curl "$WH_T1_BIN" "[]" "true" "$WH_T1_LOG"
+(
+	# shellcheck source=/dev/null
+	source "$SCRIPT"
+	PATH="$WH_T1_BIN:$PATH"
+	CATALYST_HOST_NAME="testhost"
+	CATALYST_CLUSTER_DIR="${SCRATCH}/wh-t1-nocluster"
+	dry_run=0
+	reconcile_worker_host_labels "fake-token"
+) >"${SCRATCH}/wh-t1-out" 2>&1
+WH_T1_RC=$?
+
+run "fresh workspace: issues exactly 2 issueLabelCreate calls (1 group + 1 child)" \
+	bash -c "count=\$(grep -c 'issueLabelCreate' '$WH_T1_LOG' 2>/dev/null || echo 0); [ \"\$count\" = '2' ]"
+
+run "fresh workspace: the child create is for worker:testhost" \
+	bash -c "grep 'issueLabelCreate' '$WH_T1_LOG' | grep -q 'worker:testhost'"
+
+run "fresh workspace: returns 0" \
+	bash -c "[ '$WH_T1_RC' = '0' ]"
+
+# Test 2: idempotent (group + the self child already present) -> 0 issueLabelCreate calls
+WH_T2_BIN="${SCRATCH}/wh-t2/bin"
+WH_T2_LOG="${SCRATCH}/wh-t2/req.log"
+mkdir -p "${SCRATCH}/wh-t2"
+: >"$WH_T2_LOG"
+WH_T2_NODES='[{"id":"grp-w","name":"worker","isGroup":true,"parent":null},{"id":"lbl-th","name":"worker:testhost","isGroup":false,"parent":{"id":"grp-w"}}]'
+make_worker_host_curl "$WH_T2_BIN" "$WH_T2_NODES" "true" "$WH_T2_LOG"
+(
+	# shellcheck source=/dev/null
+	source "$SCRIPT"
+	PATH="$WH_T2_BIN:$PATH"
+	CATALYST_HOST_NAME="testhost"
+	CATALYST_CLUSTER_DIR="${SCRATCH}/wh-t2-nocluster"
+	dry_run=0
+	reconcile_worker_host_labels "fake-token"
+) >"${SCRATCH}/wh-t2-out" 2>&1
+WH_T2_RC=$?
+
+run "idempotent: zero issueLabelCreate calls when all present" \
+	bash -c "! grep -q 'issueLabelCreate' '$WH_T2_LOG'"
+
+run "idempotent: returns 0" \
+	bash -c "[ '$WH_T2_RC' = '0' ]"
+
+# Test 3: partial — 2 hosts (self + 1 roster host); group + self child present,
+# roster host's child missing -> exactly 1 issueLabelCreate (the missing child)
+WH_T3_BIN="${SCRATCH}/wh-t3/bin"
+WH_T3_LOG="${SCRATCH}/wh-t3/req.log"
+mkdir -p "${SCRATCH}/wh-t3"
+: >"$WH_T3_LOG"
+WH_T3_CLUSTER="${SCRATCH}/wh-t3-cluster"
+mkdir -p "$WH_T3_CLUSTER"
+cat >"${WH_T3_CLUSTER}/cluster.json" <<'EOF'
+{"roster": ["host-b"]}
+EOF
+WH_T3_NODES='[{"id":"grp-w","name":"worker","isGroup":true,"parent":null},{"id":"lbl-a","name":"worker:host-a","isGroup":false,"parent":{"id":"grp-w"}}]'
+make_worker_host_curl "$WH_T3_BIN" "$WH_T3_NODES" "true" "$WH_T3_LOG"
+(
+	# shellcheck source=/dev/null
+	source "$SCRIPT"
+	PATH="$WH_T3_BIN:$PATH"
+	CATALYST_HOST_NAME="host-a"
+	CATALYST_CLUSTER_DIR="$WH_T3_CLUSTER"
+	dry_run=0
+	reconcile_worker_host_labels "fake-token"
+) >"${SCRATCH}/wh-t3-out" 2>&1
+
+run "partial: creates only the missing child (1 issueLabelCreate)" \
+	bash -c "count=\$(grep -c 'issueLabelCreate' '$WH_T3_LOG' 2>/dev/null || echo 0); [ \"\$count\" = '1' ]"
+
+run "partial: the one create is for worker:host-b" \
+	bash -c "grep 'issueLabelCreate' '$WH_T3_LOG' | grep -q 'worker:host-b'"
+
+# Test 4: Linear error on the labels query -> WARNING printed, returns 0
+WH_T4_BIN="${SCRATCH}/wh-t4/bin"
+WH_T4_LOG="${SCRATCH}/wh-t4/req.log"
+mkdir -p "${SCRATCH}/wh-t4"
+: >"$WH_T4_LOG"
+make_worker_host_curl "$WH_T4_BIN" "ERROR" "true" "$WH_T4_LOG"
+WH_T4_OUT="${SCRATCH}/wh-t4-out"
+(
+	# shellcheck source=/dev/null
+	source "$SCRIPT"
+	PATH="$WH_T4_BIN:$PATH"
+	CATALYST_HOST_NAME="testhost"
+	CATALYST_CLUSTER_DIR="${SCRATCH}/wh-t4-nocluster"
+	dry_run=0
+	reconcile_worker_host_labels "fake-token"
+) >"$WH_T4_OUT" 2>&1
+WH_T4_RC=$?
+
+run "query error: WARNING is printed" \
+	bash -c "grep -qi 'warning' '$WH_T4_OUT'"
+
+run "query error: returns 0 (never alters exit codes)" \
+	bash -c "[ '$WH_T4_RC' = '0' ]"
+
+# Test 5: --dry-run (dry_run=1) -> no issueLabelCreate mutations, reports intent
+WH_T5_BIN="${SCRATCH}/wh-t5/bin"
+WH_T5_LOG="${SCRATCH}/wh-t5/req.log"
+mkdir -p "${SCRATCH}/wh-t5"
+: >"$WH_T5_LOG"
+make_worker_host_curl "$WH_T5_BIN" "[]" "true" "$WH_T5_LOG"
+(
+	# shellcheck source=/dev/null
+	source "$SCRIPT"
+	PATH="$WH_T5_BIN:$PATH"
+	CATALYST_HOST_NAME="testhost"
+	CATALYST_CLUSTER_DIR="${SCRATCH}/wh-t5-nocluster"
+	dry_run=1
+	reconcile_worker_host_labels "fake-token"
+) >"${SCRATCH}/wh-t5-out" 2>&1
+
+run "--dry-run: no issueLabelCreate mutations issued" \
+	bash -c "! grep -q 'issueLabelCreate' '$WH_T5_LOG'"
+
+run "--dry-run: reports intent (mentions worker or dry-run)" \
+	bash -c "grep -qiE 'dry.run|DRY|worker' '${SCRATCH}/wh-t5-out'"
+
+# Test 6 (plain-parent adoption): the 'worker' parent exists as a plain label
+# (isGroup false, no children yet). Must be found by name+parent==null — not
+# re-created — and only the missing self child gets created.
+WH_T6_BIN="${SCRATCH}/wh-t6/bin"
+WH_T6_LOG="${SCRATCH}/wh-t6/req.log"
+mkdir -p "${SCRATCH}/wh-t6"
+: >"$WH_T6_LOG"
+WH_T6_NODES='[{"id":"grp-w","name":"worker","isGroup":false,"parent":null}]'
+make_worker_host_curl "$WH_T6_BIN" "$WH_T6_NODES" "true" "$WH_T6_LOG"
+(
+	# shellcheck source=/dev/null
+	source "$SCRIPT"
+	PATH="$WH_T6_BIN:$PATH"
+	CATALYST_HOST_NAME="testhost"
+	CATALYST_CLUSTER_DIR="${SCRATCH}/wh-t6-nocluster"
+	dry_run=0
+	reconcile_worker_host_labels "fake-token"
+) >"${SCRATCH}/wh-t6-out" 2>&1
+
+run "plain-label parent: found by name+parent==null, creates only the 1 missing child" \
+	bash -c "count=\$(grep -c 'issueLabelCreate' '$WH_T6_LOG' 2>/dev/null || echo 0); [ \"\$count\" = '1' ]"
+
+run "plain-label parent: never re-creates the group (the one create carries parentId)" \
+	bash -c "grep 'issueLabelCreate' '$WH_T6_LOG' | grep -q 'parentId'"
+
+# Test 7 (roster-source coverage): CATALYST_CLUSTER_DIR fixture roster
+# ["mini","mini-2"] + CATALYST_HOST_NAME=laptop -> children worker:mini,
+# worker:mini-2, worker:laptop (1 group + 3 children = 4 issueLabelCreate).
+WH_T7_BIN="${SCRATCH}/wh-t7/bin"
+WH_T7_LOG="${SCRATCH}/wh-t7/req.log"
+mkdir -p "${SCRATCH}/wh-t7"
+: >"$WH_T7_LOG"
+WH_T7_CLUSTER="${SCRATCH}/wh-t7-cluster"
+mkdir -p "$WH_T7_CLUSTER"
+cat >"${WH_T7_CLUSTER}/cluster.json" <<'EOF'
+{"roster": ["mini", "mini-2"]}
+EOF
+make_worker_host_curl "$WH_T7_BIN" "[]" "true" "$WH_T7_LOG"
+(
+	# shellcheck source=/dev/null
+	source "$SCRIPT"
+	PATH="$WH_T7_BIN:$PATH"
+	CATALYST_HOST_NAME="laptop"
+	CATALYST_CLUSTER_DIR="$WH_T7_CLUSTER"
+	dry_run=0
+	reconcile_worker_host_labels "fake-token"
+) >"${SCRATCH}/wh-t7-out" 2>&1
+
+run "roster fixture: issues 4 issueLabelCreate (1 group + 3 children)" \
+	bash -c "count=\$(grep -c 'issueLabelCreate' '$WH_T7_LOG' 2>/dev/null || echo 0); [ \"\$count\" = '4' ]"
+
+run "roster fixture: creates worker:mini (distinct from worker:mini-2)" \
+	bash -c "grep 'issueLabelCreate' '$WH_T7_LOG' | grep 'worker:mini' | grep -qv 'mini-2'"
+
+run "roster fixture: creates worker:mini-2" \
+	bash -c "grep 'issueLabelCreate' '$WH_T7_LOG' | grep -q 'worker:mini-2'"
+
+run "roster fixture: creates worker:laptop" \
+	bash -c "grep 'issueLabelCreate' '$WH_T7_LOG' | grep -q 'worker:laptop'"
+
+# Test 8 (CTL-1481 finding 4: dead failure fixtures) — group already present (so
+# group-create is never attempted, ruling out the early-return-on-group-failure
+# path), 2 hosts (self + 1 roster host), BOTH children missing, and
+# create_ok=false so every issueLabelCreate the loop attempts errors out.
+# Asserts the per-child failure never aborts the loop: both children are still
+# attempted, a WARNING is printed for each, and the function still returns 0.
+WH_T8_BIN="${SCRATCH}/wh-t8/bin"
+WH_T8_LOG="${SCRATCH}/wh-t8/req.log"
+mkdir -p "${SCRATCH}/wh-t8"
+: >"$WH_T8_LOG"
+WH_T8_CLUSTER="${SCRATCH}/wh-t8-cluster"
+mkdir -p "$WH_T8_CLUSTER"
+cat >"${WH_T8_CLUSTER}/cluster.json" <<'EOF'
+{"roster": ["host-b"]}
+EOF
+WH_T8_NODES='[{"id":"grp-w","name":"worker","isGroup":true,"parent":null}]'
+make_worker_host_curl "$WH_T8_BIN" "$WH_T8_NODES" "false" "$WH_T8_LOG"
+WH_T8_OUT="${SCRATCH}/wh-t8-out"
+(
+	# shellcheck source=/dev/null
+	source "$SCRIPT"
+	PATH="$WH_T8_BIN:$PATH"
+	CATALYST_HOST_NAME="host-a"
+	CATALYST_CLUSTER_DIR="$WH_T8_CLUSTER"
+	dry_run=0
+	reconcile_worker_host_labels "fake-token"
+) >"$WH_T8_OUT" 2>&1
+WH_T8_RC=$?
+
+run "child create-failure: returns 0 (never alters exit codes)" \
+	bash -c "[ '$WH_T8_RC' = '0' ]"
+
+run "child create-failure: at least one WARNING is printed" \
+	bash -c "grep -qi 'warning' '$WH_T8_OUT'"
+
+run "child create-failure: both children are attempted despite the per-child error (2 issueLabelCreate)" \
+	bash -c "count=\$(grep -c 'issueLabelCreate' '$WH_T8_LOG' 2>/dev/null || echo 0); [ \"\$count\" = '2' ]"
+
+run "child create-failure: worker:host-a is attempted" \
+	bash -c "grep 'issueLabelCreate' '$WH_T8_LOG' | grep -q 'worker:host-a'"
+
+run "child create-failure: worker:host-b is attempted" \
+	bash -c "grep 'issueLabelCreate' '$WH_T8_LOG' | grep -q 'worker:host-b'"
+
 echo ""
 echo "Results: ${PASSES} passed, ${FAILURES} failed"
 [ "$FAILURES" = "0" ]

--- a/plugins/dev/scripts/execution-core/__tests__/doctor-worker-labels.test.mjs
+++ b/plugins/dev/scripts/execution-core/__tests__/doctor-worker-labels.test.mjs
@@ -1,0 +1,156 @@
+// doctor-worker-labels.test.mjs — CTL-1481. Tests for checkWorkerLabels() in doctor.mjs.
+// All deps are injected so the test touches no network. The load-bearing invariants:
+// NEVER emit a FAIL record (it would block the catalyst-join activation gate), and
+// NEVER leak a token VALUE. Run:
+//   cd plugins/dev/scripts/execution-core && bun test doctor-worker-labels
+import { describe, test, expect } from "bun:test";
+import { checkWorkerLabels, checksForClass } from "../doctor.mjs";
+
+const ROSTER = ["mini", "mini-2"];
+const GROUP = { id: "grp-1", name: "worker", parent: null };
+const CHILD = (host) => ({ id: `child-${host}`, name: `worker:${host}`, parent: { id: GROUP.id } });
+
+function healthyNodes() {
+  return [GROUP, ...ROSTER.map(CHILD)];
+}
+
+// "healthy" defaults; override per test.
+function deps(over = {}) {
+  return {
+    getRoster: () => ROSTER,
+    linearToken: () => "lin_api_test_token",
+    post: async () => ({ data: { issueLabels: { nodes: healthyNodes() } } }),
+    ...over,
+  };
+}
+
+const byName = (recs) => Object.fromEntries(recs.map((r) => [r.name, r]));
+const noFail = (recs) => recs.every((r) => r.status !== "fail");
+
+describe("checkWorkerLabels", () => {
+  test("single-host roster → single INFO, never queries Linear", async () => {
+    let called = false;
+    const recs = await checkWorkerLabels(
+      deps({
+        getRoster: () => ["mini"],
+        post: async () => {
+          called = true;
+          return { data: { issueLabels: { nodes: [] } } };
+        },
+      }),
+    );
+    expect(recs).toHaveLength(1);
+    expect(recs[0].name).toBe("worker-labels");
+    expect(recs[0].status).toBe("info");
+    expect(recs[0].detail).toMatch(/single-host/i);
+    expect(called).toBe(false);
+  });
+
+  test("empty roster → single INFO too", async () => {
+    const recs = await checkWorkerLabels(deps({ getRoster: () => [] }));
+    expect(recs).toHaveLength(1);
+    expect(recs[0].status).toBe("info");
+  });
+
+  test("no token → single INFO (skip, not warn)", async () => {
+    const recs = await checkWorkerLabels(deps({ linearToken: () => "" }));
+    expect(recs).toHaveLength(1);
+    expect(recs[0].name).toBe("worker-labels");
+    expect(recs[0].status).toBe("info");
+    expect(recs[0].detail).toMatch(/token/i);
+  });
+
+  test("healthy fleet: group + every host child present → all PASS", async () => {
+    const recs = await checkWorkerLabels(deps());
+    expect(recs).toHaveLength(ROSTER.length);
+    const m = byName(recs);
+    for (const host of ROSTER) {
+      expect(m[`worker-label:${host}`].status).toBe("pass");
+    }
+  });
+
+  test("missing group → single WARN naming the setup-script remediation", async () => {
+    const recs = await checkWorkerLabels(deps({ post: async () => ({ data: { issueLabels: { nodes: [] } } }) }));
+    expect(recs).toHaveLength(1);
+    expect(recs[0].name).toBe("worker-labels");
+    expect(recs[0].status).toBe("warn");
+    expect(recs[0].detail).toContain("setup-execution-core-states.sh");
+  });
+
+  test("group present, one host child missing → that host WARNs, other PASSes", async () => {
+    const nodes = [GROUP, CHILD(ROSTER[0])]; // ROSTER[1]'s child is missing
+    const recs = await checkWorkerLabels(deps({ post: async () => ({ data: { issueLabels: { nodes } } }) }));
+    const m = byName(recs);
+    expect(m[`worker-label:${ROSTER[0]}`].status).toBe("pass");
+    expect(m[`worker-label:${ROSTER[1]}`].status).toBe("warn");
+    expect(m[`worker-label:${ROSTER[1]}`].detail).toContain("setup-execution-core-states.sh");
+  });
+
+  test("GraphQL error response → single WARN, never throws", async () => {
+    const recs = await checkWorkerLabels(deps({ post: async () => ({ errors: [{ message: "boom" }] }) }));
+    expect(recs).toHaveLength(1);
+    expect(recs[0].name).toBe("worker-labels");
+    expect(recs[0].status).toBe("warn");
+  });
+
+  test("post() rejects (network unreachable) → single WARN, never throws", async () => {
+    const recs = await checkWorkerLabels(
+      deps({
+        post: async () => {
+          throw new Error("fetch failed");
+        },
+      }),
+    );
+    expect(recs).toHaveLength(1);
+    expect(recs[0].status).toBe("warn");
+    expect(recs[0].detail).toMatch(/unreachable|fetch failed/i);
+  });
+
+  test("unexpected response shape (no nodes array) → single WARN", async () => {
+    const recs = await checkWorkerLabels(deps({ post: async () => ({ data: {} }) }));
+    expect(recs).toHaveLength(1);
+    expect(recs[0].status).toBe("warn");
+  });
+
+  test("secret token value never leaks into check output", async () => {
+    const SECRET = "lin_api_should_never_appear_in_output";
+    const recs = await checkWorkerLabels(
+      deps({ linearToken: () => SECRET, post: async () => ({ errors: [{ message: "boom" }] }) }),
+    );
+    expect(JSON.stringify(recs)).not.toContain(SECRET);
+  });
+
+  test("INVARIANT: no permutation of roster-size/token/response ever yields a FAIL record", async () => {
+    const rosterFns = [() => [], () => ["mini"], () => ["mini", "mini-2"]];
+    const tokenFns = [() => "", () => "lin_api_x"];
+    const postFns = [
+      async () => ({ data: { issueLabels: { nodes: healthyNodes() } } }),
+      async () => ({ data: { issueLabels: { nodes: [] } } }),
+      async () => ({ errors: [{ message: "boom" }] }),
+      async () => {
+        throw new Error("network down");
+      },
+      async () => ({ data: {} }),
+    ];
+    for (const getRoster of rosterFns)
+      for (const linearToken of tokenFns)
+        for (const post of postFns) {
+          const recs = await checkWorkerLabels(deps({ getRoster, linearToken, post }));
+          expect(noFail(recs)).toBe(true);
+        }
+  });
+});
+
+describe("checksForClass — checkWorkerLabels registration (CTL-1481)", () => {
+  const src = (nc, opts = {}) => checksForClass(nc, opts).map((f) => f.toString()).join("\n");
+
+  for (const cls of ["worker", "developer"]) {
+    test(`wires checkWorkerLabels into the ${cls} suite`, () => {
+      expect(src({ recognized: true, class: cls })).toContain("checkWorkerLabels");
+    });
+  }
+
+  test("does NOT wire checkWorkerLabels into the monitor suite (rubric unimplemented)", () => {
+    expect(src({ recognized: true, class: "monitor" })).not.toContain("checkWorkerLabels");
+  });
+});

--- a/plugins/dev/scripts/execution-core/doctor.mjs
+++ b/plugins/dev/scripts/execution-core/doctor.mjs
@@ -2208,7 +2208,9 @@ export async function checkWorkerLabels(deps = {}) {
     ];
   }
 
-  const QUERY = `query { issueLabels(filter: {team: {null: true}}, first: 250) { nodes { id name parent { id } } } }`;
+  // Narrowed server-side to names starting "worker" so the group + children
+  // always fit one page regardless of workspace label count (Codex #2650 r3).
+  const QUERY = `query { issueLabels(filter: {team: {null: true}, name: {startsWith: "worker"}}, first: 250) { nodes { id name parent { id } } } }`;
   let nodes;
   try {
     const json = await post(QUERY, token);

--- a/plugins/dev/scripts/execution-core/doctor.mjs
+++ b/plugins/dev/scripts/execution-core/doctor.mjs
@@ -62,7 +62,10 @@ import { ownedBy } from "./hrw.mjs";
 import { readPeerHeartbeats } from "./cluster-heartbeat.mjs";
 // CTL-1481: the canonical worker-ownership label names — imported (not
 // re-hardcoded) so the doctor can never drift from what the stamper writes.
-import { WORKER_LABEL_GROUP, WORKER_LABEL_PREFIX } from "./worker-label.mjs";
+// From the zero-import names leaf, NOT worker-label.mjs: doctor runs under
+// bare Node, and worker-label.mjs's graph reaches gateway-read.mjs →
+// bun:sqlite, which fails Node's ESM loader at import time.
+import { WORKER_LABEL_GROUP, WORKER_LABEL_PREFIX } from "./worker-label-names.mjs";
 // CTL-1367 item 9: reuse the single-source-of-truth subscription-auth predicate
 // (sdk-run-phase-agent.mjs imports only node:* + config.mjs — no bun: protocol —
 // so it is safe to pull into this node-runnable doctor).

--- a/plugins/dev/scripts/execution-core/doctor.mjs
+++ b/plugins/dev/scripts/execution-core/doctor.mjs
@@ -60,6 +60,9 @@ import {
 } from "./config.mjs";
 import { ownedBy } from "./hrw.mjs";
 import { readPeerHeartbeats } from "./cluster-heartbeat.mjs";
+// CTL-1481: the canonical worker-ownership label names — imported (not
+// re-hardcoded) so the doctor can never drift from what the stamper writes.
+import { WORKER_LABEL_GROUP, WORKER_LABEL_PREFIX } from "./worker-label.mjs";
 // CTL-1367 item 9: reuse the single-source-of-truth subscription-auth predicate
 // (sdk-run-phase-agent.mjs imports only node:* + config.mjs — no bun: protocol —
 // so it is safe to pull into this node-runnable doctor).
@@ -2155,6 +2158,94 @@ export function checkConfigScopeLeak(deps = {}) {
   return checks;
 }
 
+// ─── CTL-1481: worker:<host> label ownership visibility advisory ────────────
+
+// defaultLinearGraphQLPost — minimal fetch-based Linear GraphQL POST, mirroring
+// checkBotCredentials' inline probe above. Injectable via deps.post so tests
+// never hit the network; throws on a non-2xx response (caught by the caller).
+async function defaultLinearGraphQLPost(query, token) {
+  const res = await fetch(LINEAR_GQL, {
+    method: "POST",
+    headers: { "Content-Type": "application/json", Authorization: token },
+    body: JSON.stringify({ query }),
+    signal: AbortSignal.timeout(5000),
+  });
+  if (!res.ok) throw new Error(`HTTP ${res.status}`);
+  return res.json();
+}
+
+// checkWorkerLabels — CTL-1481. Advisory health of the workspace `worker`
+// label group + its `worker:<host>` children (the best-effort claim-win
+// VISIBILITY PROJECTION stamped by worker-label.mjs — never the claim
+// arbiter; the fence CAS in cluster-claim.mjs stays the source of truth).
+// EVERY condition is WARN/INFO/PASS, NEVER FAIL: doctor's exit code is the
+// FAIL count and gates catalyst-join activation — a projection label that
+// hasn't been provisioned yet must never block a node. Doctor does NOT
+// mutate Linear here (repo convention: setup-execution-core-states.sh is the
+// sole writer); this check only reports drift and points at the remediation.
+export async function checkWorkerLabels(deps = {}) {
+  const {
+    getRoster = getClusterHosts,
+    linearToken = () => process.env.LINEAR_API_TOKEN ?? process.env.LINEAR_API_KEY ?? "",
+    post = defaultLinearGraphQLPost,
+  } = deps;
+
+  const REMEDIATION = "run plugins/dev/scripts/setup-execution-core-states.sh";
+
+  const roster = getRoster();
+  // Single-host (or empty roster): no ownership ambiguity to visualize.
+  if (!Array.isArray(roster) || roster.length <= 1) {
+    return [mkCheck("worker-labels", STATUS.INFO, "single-host — worker ownership labels not applicable")];
+  }
+
+  const token = linearToken();
+  if (!token) {
+    return [
+      mkCheck("worker-labels", STATUS.INFO, "no LINEAR_API_TOKEN / LINEAR_API_KEY — skipping worker-label check"),
+    ];
+  }
+
+  const QUERY = `query { issueLabels(filter: {team: {null: true}}, first: 250) { nodes { id name parent { id } } } }`;
+  let nodes;
+  try {
+    const json = await post(QUERY, token);
+    if (json?.errors?.length) {
+      return [mkCheck("worker-labels", STATUS.WARN, `Linear GraphQL error: ${JSON.stringify(json.errors)}`)];
+    }
+    nodes = json?.data?.issueLabels?.nodes;
+    if (!Array.isArray(nodes)) {
+      return [mkCheck("worker-labels", STATUS.WARN, "unexpected issueLabels response shape from Linear")];
+    }
+  } catch (err) {
+    return [mkCheck("worker-labels", STATUS.WARN, `Linear unreachable: ${err?.message ?? err}`)];
+  }
+
+  // #2631-safe match: the exclusive-group marker is parent==null + the group
+  // name, NOT isGroup (drift-prone — see the CTL-1481 write-test verdict).
+  const group = nodes.find((n) => n?.name === WORKER_LABEL_GROUP && n?.parent == null);
+  if (!group) {
+    return [
+      mkCheck(
+        "worker-labels",
+        STATUS.WARN,
+        `workspace label group "${WORKER_LABEL_GROUP}" not found — ${REMEDIATION}`,
+      ),
+    ];
+  }
+
+  const checks = [];
+  for (const host of roster) {
+    const childName = `${WORKER_LABEL_PREFIX}${host}`;
+    const child = nodes.find((n) => n?.name === childName && n?.parent?.id === group.id);
+    checks.push(
+      child
+        ? mkCheck(`worker-label:${host}`, STATUS.PASS, `label "${childName}" present under group "${WORKER_LABEL_GROUP}"`)
+        : mkCheck(`worker-label:${host}`, STATUS.WARN, `label "${childName}" missing — ${REMEDIATION}`),
+    );
+  }
+  return checks;
+}
+
 // ─── CTL-1375: repo-icon token-scope advisory ────────────────────────────────
 
 // _ownerRepoFromRepoRoot — extract "owner/repo" from a repoRoot filesystem path that
@@ -3139,6 +3230,7 @@ export function checksForClass(nc, opts = {}) {
       () => checkClusterSecretFreshness(), // CTL-1393: warn if running on stale rotated secrets (advisory)
       () => checkCloudSync(), // CTL-1394: developer nodes read Linear from the local replica too (advisory)
       () => checkConfigScopeLeak(), // advisory
+      () => checkWorkerLabels(), // CTL-1481: worker:<host> label is a best-effort visibility projection, never the claim arbiter — advisory only
     ];
   }
 
@@ -3196,6 +3288,7 @@ export function checksForClass(nc, opts = {}) {
     () => checkConfigScopeLeak(), // CTL-1214: committed Layer-1 .catalyst/config.json must not carry node/cluster scope (roster/orchestration/feedback/sweep/repoColors/hosts.json)
     () => checkRepoIconTokenScope(), // CTL-1375: monitor daemon's gh token can read configured private repos' contents (else favicons fall back to the org avatar) — advisory (never FAIL)
     () => checkMonitorProductionBuild(), // CTL-1372: warn if the local monitor serves a dev-build React bundle (leaks via performance.measure) — advisory (never FAIL)
+    () => checkWorkerLabels(), // CTL-1481: worker:<host> label is a best-effort visibility projection, never the claim arbiter — advisory only
   ];
 }
 

--- a/plugins/dev/scripts/execution-core/monitor.mjs
+++ b/plugins/dev/scripts/execution-core/monitor.mjs
@@ -917,7 +917,7 @@ function dispatchTriage(
   // and never blocks the triage dispatch.
   if (clusterGeneration != null) {
     try {
-      stampWorkerLabel({ ticket: identifier, hostName: self, applyLabel, removeLabel });
+      stampWorkerLabel({ ticket: identifier, hostName: self, replica, applyLabel, removeLabel, log });
     } catch (err) {
       log.warn({ identifier, err: err.message }, "monitor: stampWorkerLabel threw — continuing");
     }

--- a/plugins/dev/scripts/execution-core/monitor.mjs
+++ b/plugins/dev/scripts/execution-core/monitor.mjs
@@ -71,6 +71,7 @@ import {
   applyTriageStatus as defaultApplyTriageStatus,
   applyAssignee as defaultApplyAssignee,
   applyLabel, // CTL-1441: needs-human at the triage re-dispatch cap
+  removeLabel, // CTL-1481: worker:<host> swap (remove-before-add)
 } from "./linear-write.mjs";
 import { labelNeedsHumanUnlessBeliefOwner } from "./label-guard.mjs"; // CTL-1441
 import { appendTriageTransitionEvent as defaultAppendEvent } from "./triage-transition-event.mjs";
@@ -78,6 +79,9 @@ import { countBackgroundAgents, resetLivenessCache } from "./claude-agents.mjs";
 import { readMaxParallel, computeFreeSlots, writeClusterGeneration } from "./scheduler.mjs";
 // CTL-863: Linear-free fence event emitter (durable fence → event-log migration).
 import { emitFenceClaimed } from "./fence-event.mjs";
+// CTL-1481: best-effort worker:<host> label visibility-projection stamp on a
+// won cluster claim. Never the claim arbiter — see worker-label.mjs header.
+import { stampWorkerLabel as defaultStampWorkerLabel } from "./worker-label.mjs";
 import { countSdkInflight as defaultCountSdkInflight } from "./signal-reader.mjs"; // CTL-1367 P1: executor=sdk occupancy reader for the triage budget
 import {
   recordReconcileSuccess,
@@ -448,6 +452,9 @@ export function handleStateChangedEvent(
     // CTL-1367 P1: failed-terminal backstop for a rejected async (sdk) triage
     // dispatch — threaded through to dispatchTriage (undefined → real default).
     emitBackstop,
+    // CTL-1481: worker:<host> label-stamp seam — threaded through to
+    // dispatchTriage (undefined → real default; tests inject a fake).
+    stampWorkerLabel,
   } = {}
 ) {
   const parsed = parseStateChangedEvent(event);
@@ -493,6 +500,7 @@ export function handleStateChangedEvent(
           claimDispatch, // CTL-862
           isDraining, // CTL-1095
           emitBackstop, // CTL-1367 P1
+          stampWorkerLabel, // CTL-1481
         });
       }
     } else if (!parsed.toState || parsed.toState === query.status) {
@@ -549,6 +557,7 @@ export function handleStateChangedEvent(
           claimDispatch, // CTL-862
           isDraining, // CTL-1095
           emitBackstop, // CTL-1367 P1
+          stampWorkerLabel, // CTL-1481
         });
       } else {
         log.debug(
@@ -665,6 +674,10 @@ function dispatchTriage(
     hosts = undefined,
     hostName = undefined,
     claimDispatch = claimDispatchSync,
+    // CTL-1481: best-effort worker:<host> label stamp, fired right after a won
+    // multi-host triage claim (same gate as emitFenceClaimed). Injectable so
+    // tests drive/assert the stamp without touching Linear.
+    stampWorkerLabel = defaultStampWorkerLabel,
     // CTL-1095: drain gate — node-level refusal of new-triage admission.
     isDraining = (dir) => isDrainingDefault(dir),
     // CTL-1367 P1: failed-terminal backstop for a REJECTED async (sdk) triage
@@ -896,6 +909,19 @@ function dispatchTriage(
   } catch (err) {
     log.warn({ identifier, err: err.message }, "monitor: self-assign threw — continuing");
   }
+  // CTL-1481: best-effort worker:<host> label stamp — a visibility projection
+  // of the triage claim we just won, NEVER the claim arbiter itself. Multi-host
+  // only (same gate as emitFenceClaimed). Placed AFTER the triage-status +
+  // self-assign writes so a stamp-tripped breaker can never starve them. Own
+  // try/catch (mirrors the self-assign precedent above) so a throw only logs
+  // and never blocks the triage dispatch.
+  if (clusterGeneration != null) {
+    try {
+      stampWorkerLabel({ ticket: identifier, hostName: self, applyLabel, removeLabel });
+    } catch (err) {
+      log.warn({ identifier, err: err.message }, "monitor: stampWorkerLabel threw — continuing");
+    }
+  }
   return true;
 }
 
@@ -1047,6 +1073,9 @@ export function sweepMissingTriage({
   // CTL-1441: needs-human at the re-dispatch cap — threaded through to
   // dispatchTriage (undefined → real label-guard default; tests inject a spy).
   labelNeedsHuman,
+  // CTL-1481: worker:<host> label-stamp seam — threaded through to
+  // dispatchTriage (undefined → real default; tests inject a fake).
+  stampWorkerLabel,
 } = {}) {
   if (!orchDir) {
     log.debug("sweepMissingTriage: no orchDir wired — skipping triage sweep");
@@ -1090,6 +1119,7 @@ export function sweepMissingTriage({
         claimDispatch, // CTL-862
         emitBackstop, // CTL-1367 P1
         ...(labelNeedsHuman ? { labelNeedsHuman } : {}), // CTL-1441
+        stampWorkerLabel, // CTL-1481
       });
     }
   }

--- a/plugins/dev/scripts/execution-core/monitor.mjs
+++ b/plugins/dev/scripts/execution-core/monitor.mjs
@@ -917,7 +917,7 @@ function dispatchTriage(
   // and never blocks the triage dispatch.
   if (clusterGeneration != null) {
     try {
-      stampWorkerLabel({ ticket: identifier, hostName: self, replica, applyLabel, removeLabel, log });
+      stampWorkerLabel({ ticket: identifier, hostName: self, knownHosts: roster, replica, applyLabel, removeLabel, log });
     } catch (err) {
       log.warn({ identifier, err: err.message }, "monitor: stampWorkerLabel threw — continuing");
     }

--- a/plugins/dev/scripts/execution-core/monitor.test.mjs
+++ b/plugins/dev/scripts/execution-core/monitor.test.mjs
@@ -2375,6 +2375,9 @@ describe("CTL-862 — HRW ownership + claim-on-dispatch (monitor dispatchTriage)
       hosts: ROSTER,
       hostName: OWNER,
       claimDispatch,
+      // CTL-1481: stub the label-stamp seam — this test's subject is HRW/claim
+      // dispatch, not the label write, and a won multi-host claim now fires it.
+      stampWorkerLabel: () => ({ stamped: true }),
       applyTriageStatus: () => ({ applied: false, verified: false, from_state: null, to_state: null, reason: null }),
       appendEvent: () => {},
     });
@@ -2430,6 +2433,9 @@ describe("CTL-862 — HRW ownership + claim-on-dispatch (monitor dispatchTriage)
       hosts: ROSTER,
       hostName: OWNER,
       claimDispatch,
+      // CTL-1481: stub the label-stamp seam — this test's subject is HRW/claim
+      // dispatch, not the label write, and a won multi-host claim now fires it.
+      stampWorkerLabel: () => ({ stamped: true }),
       applyTriageStatus: () => ({ applied: false, verified: false, from_state: null, to_state: null, reason: null }),
       appendEvent: () => {},
       readMaxParallelFn: () => 5,
@@ -2474,6 +2480,9 @@ describe("CTL-1028 — triage forwards + persists cluster generation (monitor di
       hosts: ROSTER,
       hostName: OWNER,
       claimDispatch,
+      // CTL-1481: stub the label-stamp seam — this test's subject is
+      // clusterGeneration forwarding, not the label write.
+      stampWorkerLabel: () => ({ stamped: true }),
       applyTriageStatus: () => ({ applied: false, verified: false, from_state: null, to_state: null, reason: null }),
       appendEvent: () => {},
     });
@@ -2513,6 +2522,9 @@ describe("CTL-1028 — triage forwards + persists cluster generation (monitor di
         hosts: ROSTER,
         hostName: OWNER,
         claimDispatch,
+        // CTL-1481: stub the label-stamp seam — this test's subject is the
+        // cluster-generation persist, not the label write.
+        stampWorkerLabel: () => ({ stamped: true }),
         applyTriageStatus: () => ({ applied: false, verified: false, from_state: null, to_state: null, reason: null }),
         appendEvent: () => {},
       });

--- a/plugins/dev/scripts/execution-core/recovery.mjs
+++ b/plugins/dev/scripts/execution-core/recovery.mjs
@@ -3507,8 +3507,11 @@ export async function reclaimDeadHostWork(
       dispatchTicket(od, ticket, phase, { dispatch: defaultDispatch }),
     // CTL-1481: best-effort worker:<host> label stamp, fired right after a won
     // takeover claim (same gate as emitFenceClaimed). Injectable so tests
-    // drive/assert the stamp without touching Linear.
+    // drive/assert the stamp without touching Linear. `replica` is the daemon's
+    // createReplicaReader, threaded from the tick so the stamp's label read is
+    // replica-first (live fallback is loud inside the stamp).
     stampWorkerLabel = defaultStampWorkerLabel,
+    replica = undefined,
   } = {}
 ) {
   const taken = [];
@@ -3554,7 +3557,7 @@ export async function reclaimDeadHostWork(
       // projection of the takeover claim we just won, NEVER the claim arbiter
       // itself. Best-effort swallow (mirrors writeLocalClusterGeneration below).
       try {
-        stampWorkerLabel({ ticket, hostName: self, log });
+        stampWorkerLabel({ ticket, hostName: self, replica, log });
       } catch {
         // best-effort — a failed/thrown stamp never blocks the takeover.
       }

--- a/plugins/dev/scripts/execution-core/recovery.mjs
+++ b/plugins/dev/scripts/execution-core/recovery.mjs
@@ -3557,7 +3557,7 @@ export async function reclaimDeadHostWork(
       // projection of the takeover claim we just won, NEVER the claim arbiter
       // itself. Best-effort swallow (mirrors writeLocalClusterGeneration below).
       try {
-        stampWorkerLabel({ ticket, hostName: self, replica, log });
+        stampWorkerLabel({ ticket, hostName: self, knownHosts: roster, replica, log });
       } catch {
         // best-effort — a failed/thrown stamp never blocks the takeover.
       }

--- a/plugins/dev/scripts/execution-core/recovery.mjs
+++ b/plugins/dev/scripts/execution-core/recovery.mjs
@@ -102,6 +102,9 @@ import { fenceGuard } from "./fence-guard.mjs";
 // CTL-863: Linear-free fence event emitter (durable fence → event-log migration).
 import { emitFenceClaimed } from "./fence-event.mjs";
 import { applyLabel as defaultApplyLabel } from "./linear-write.mjs";
+// CTL-1481: best-effort worker:<host> label visibility-projection stamp on a
+// won cluster claim. Never the claim arbiter — see worker-label.mjs header.
+import { stampWorkerLabel as defaultStampWorkerLabel } from "./worker-label.mjs";
 import { linearBreaker } from "./linear-breaker.mjs";
 // CTL-642: the SHARED terminal-state predicate. The recovery short-circuit reuses
 // the scheduler's fetchTicketState + cache (threaded via reclaimOpts) so a
@@ -3502,6 +3505,10 @@ export async function reclaimDeadHostWork(
     thoughtsPull = (cwd) => defaultThoughtsPull(cwd),
     dispatch = (od, ticket, phase, cwd) =>
       dispatchTicket(od, ticket, phase, { dispatch: defaultDispatch }),
+    // CTL-1481: best-effort worker:<host> label stamp, fired right after a won
+    // takeover claim (same gate as emitFenceClaimed). Injectable so tests
+    // drive/assert the stamp without touching Linear.
+    stampWorkerLabel = defaultStampWorkerLabel,
   } = {}
 ) {
   const taken = [];
@@ -3542,6 +3549,14 @@ export async function reclaimDeadHostWork(
           generation: claimRes.generation,
           phase: NEW_WORK_ENTRY_PHASE,
         });
+      }
+      // CTL-1481: best-effort worker:<host> label stamp — a visibility
+      // projection of the takeover claim we just won, NEVER the claim arbiter
+      // itself. Best-effort swallow (mirrors writeLocalClusterGeneration below).
+      try {
+        stampWorkerLabel({ ticket, hostName: self, log });
+      } catch {
+        // best-effort — a failed/thrown stamp never blocks the takeover.
       }
 
       // Rebuild the worktree on the ticket branch.

--- a/plugins/dev/scripts/execution-core/recovery.test.mjs
+++ b/plugins/dev/scripts/execution-core/recovery.test.mjs
@@ -4935,6 +4935,10 @@ describe("reclaimDeadHostWork — peer in_flight_tickets seam (CTL-1090)", () =>
         rebuildWorktree: () => ({ ok: true, cwd: "/wt/CTL-7" }),
         thoughtsPull: () => ({ ok: true }),
         dispatch: (od, ticket) => { dispatched.push(ticket); return { code: 0 }; },
+        // CTL-1481: stub the label-stamp seam — this test's subject is the
+        // peer in_flight_tickets seam, not the label write, and a won claim
+        // now fires it (else this would hit the real network default).
+        stampWorkerLabel: () => ({ stamped: true }),
       },
     );
     expect(dispatched.sort()).toEqual(["CTL-7", "CTL-8"]);
@@ -5115,6 +5119,10 @@ const makeBaseDeps = (overrides = {}) => ({
   alreadyComplete: () => false,
   rebuildWorktree: () => ({ ok: true, cwd: "/wt/CTL-900" }),
   dispatch: () => ({ code: 0 }),
+  // CTL-1481: stub the label-stamp seam by default — this describe block's
+  // default `claim` always wins, so every test that doesn't override
+  // stampWorkerLabel would otherwise hit the real (network-touching) default.
+  stampWorkerLabel: () => ({ stamped: true }),
   ...overrides,
 });
 
@@ -5137,6 +5145,47 @@ describe("reclaimDeadHostWork — takeover sweep (CTL-863)", () => {
     );
     expect(dispatched).toBe(true);
     expect(r.taken).toEqual([{ ticket: "CTL-900", phase: "implement", generation: 5 }]);
+  });
+
+  // CTL-1481: the worker:<host> label visibility-projection stamp fires right
+  // after a won takeover claim, mirroring the emitFenceClaimed gate.
+  test("CTL-1481: a won takeover claim fires stampWorkerLabel with the ticket + host", async () => {
+    const calls = [];
+    const r = await reclaimDeadHostWork(
+      { orchDir: "/o" },
+      makeBaseDeps({
+        stampWorkerLabel: (arg) => { calls.push(arg); return { stamped: true }; },
+      }),
+    );
+    expect(calls).toHaveLength(1);
+    expect(calls[0]).toMatchObject({ ticket: "CTL-900", hostName: "mini" });
+    expect(r.taken).toHaveLength(1);
+  });
+
+  test("CTL-1481: a lost claim never fires stampWorkerLabel", async () => {
+    const calls = [];
+    const r = await reclaimDeadHostWork(
+      { orchDir: "/o" },
+      makeBaseDeps({
+        claim: () => ({ won: false, generation: null }),
+        stampWorkerLabel: (arg) => { calls.push(arg); return { stamped: true }; },
+      }),
+    );
+    expect(calls).toHaveLength(0);
+    expect(r.taken).toEqual([]);
+  });
+
+  test("CTL-1481: a thrown stampWorkerLabel never blocks the takeover dispatch", async () => {
+    let dispatched = false;
+    const r = await reclaimDeadHostWork(
+      { orchDir: "/o" },
+      makeBaseDeps({
+        stampWorkerLabel: () => { throw new Error("linearis exploded"); },
+        dispatch: () => { dispatched = true; return { code: 0 }; },
+      }),
+    );
+    expect(dispatched).toBe(true);
+    expect(r.taken).toHaveLength(1);
   });
 
   test("HRW says another survivor owns it → skip (no claim, no dispatch)", async () => {

--- a/plugins/dev/scripts/execution-core/replica-read.mjs
+++ b/plugins/dev/scripts/execution-core/replica-read.mjs
@@ -116,6 +116,20 @@ const OWNERSHIP_SELECT = `SELECT assignee_id, delegate_id, delegate_name FROM is
 const RELATIONS_FORWARD_SELECT = `SELECT type, related_identifier FROM relations WHERE issue_identifier = ?`;
 const RELATIONS_INVERSE_SELECT = `SELECT type, issue_identifier FROM relations WHERE related_identifier = ?`;
 
+// labels(identifier) SELECTs (CTL-1481 — the worker-label visibility projection's
+// replica-backed read). issue_labels keys off the issue's internal PK, not its
+// display identifier, so this resolves identifier → id first (same resolution
+// buildEligibleSelect's label-EXISTS join needs, just materialized as a row
+// instead of tested for existence).
+const LABELS_ISSUE_ID_SELECT = `SELECT id FROM issues WHERE identifier = ? AND removed_at IS NULL LIMIT 1`;
+// labels.removed_at IS filtered here — a deliberate NEW decision for this
+// accessor. No existing SELECT in this file filters labels.removed_at (the
+// EXISTS join in buildEligibleSelect only tests `l.name = ?`, tombstone-blind),
+// but a caller LISTING a ticket's labels must never see a removed one: a
+// tombstoned label name can be recycled/reused by a later live label, so
+// surfacing it here would misreport what's actually attached today.
+const LABELS_SELECT = `SELECT l.id, l.name FROM issue_labels il JOIN labels l ON l.id = il.label_id WHERE il.issue_id = ? AND l.removed_at IS NULL ORDER BY l.name`;
+
 // CTL-1397 (P1 fix) — the SEED-COMPLETENESS gate. The mtime gate
 // (isReplicaFresh) proves the cloud-sync writer is LIVE; it does NOT prove the
 // seed is COMPLETE. The writer's forced re-seed (the exact quota/outage-recovery
@@ -428,5 +442,48 @@ export function createReplicaReader({ dbPath = getReplicaDbPath() } = {}) {
     }
   };
 
-  return { lookup, freshness, titles, eligible, ownership, close: dropHandle };
+  // labels(id) → [{ id, name }] | undefined  (CTL-1481 — worker-label visibility
+  // projection read). The replica-backed accessor a `worker:<host>` label reader
+  // can consult instead of a live linearis label fetch. Gated IDENTICALLY to
+  // eligible()/ownership(): writer LIVENESS (isReplicaFresh) + the seed-completeness
+  // cursor, both resolved inside one deferred read snapshot. ANY gate-fail, a MISS
+  // (absent/removed issue), or any throw → undefined — the caller falls through to
+  // a live read, never trusts a stale/partial label list.
+  //
+  //   HIT (issue exists, ≥1 live label attached) → [{id, name}, ...], sorted by name.
+  //   HIT (issue exists, zero labels attached)    → [] — a DEFINED, authoritative
+  //     empty answer (not a miss); the caller must NOT treat it as "unknown".
+  //   MISS/gate-fail/throw                        → undefined.
+  //
+  //   Gate order:
+  //     1. !isReplicaFresh    → undefined  (dead/stale writer)
+  //     2. seed cursor absent → undefined  (mid-reseed)
+  //     3. no issue row       → undefined  (absent/removed; MISS)
+  //     4. HIT                → [{id, name}] (possibly empty)
+  const labels = (identifier) => {
+    if (!identifier) return undefined;
+    // 1. LIVENESS — a dead/stale writer must never serve a label list.
+    if (!isReplicaFresh(dbPath)) return undefined;
+    try {
+      const handle = open();
+      // 2+3+4 in ONE deferred read snapshot (same shape as ownership()): the
+      // seed-completeness cursor, the identifier→id resolution, and the label
+      // rows come from one consistent snapshot so a forced re-seed can't slip
+      // between the gate and the reads.
+      const rows = handle.transaction(() => {
+        if (!handle.prepare(SEED_COMPLETE_SELECT).get()) return undefined; // mid-reseed
+        const issue = handle.prepare(LABELS_ISSUE_ID_SELECT).get(identifier);
+        if (!issue) return undefined; // absent/removed → MISS
+        return handle.prepare(LABELS_SELECT).all(issue.id);
+      })();
+      if (!rows) return undefined; // seed-gate fail / absent / removed → MISS
+      return rows.map((row) => ({ id: row.id, name: row.name }));
+    } catch {
+      // Drop the handle so a later call re-opens fresh (DB may be re-seeded).
+      dropHandle();
+      return undefined;
+    }
+  };
+
+  return { lookup, freshness, titles, eligible, ownership, labels, close: dropHandle };
 }

--- a/plugins/dev/scripts/execution-core/replica-read.test.mjs
+++ b/plugins/dev/scripts/execution-core/replica-read.test.mjs
@@ -770,3 +770,109 @@ describe("createReplicaReader.ownership (Stage 0 / A0)", () => {
     expect(reader.ownership("CTL-300")).toEqual({ assignee: "user-1", delegate: "bot-9" });
   });
 });
+
+// labels() (CTL-1481 — worker-label visibility projection read). Same freshness +
+// seed-cursor gate as ownership(); any gate-fail/miss/throw → undefined (caller
+// falls through, never trusts a stale/partial label list). Resolves
+// identifier → internal id first (issue_labels keys off the PK, matching the
+// identifier→id resolution eligible()'s label-EXISTS join needs), then joins
+// issue_labels⋈labels for that id.
+function seedLabels() {
+  const db = new Database(dbPath, { create: true });
+  db.run(`CREATE TABLE issues (id TEXT, identifier TEXT, removed_at TEXT)`);
+  db.run(`CREATE INDEX idx_issues_identifier ON issues (identifier)`);
+  db.run(`CREATE TABLE labels (id TEXT, name TEXT, removed_at TEXT)`);
+  db.run(`CREATE TABLE issue_labels (issue_id TEXT, label_id TEXT)`);
+  db.run(`CREATE TABLE sync_meta (key TEXT PRIMARY KEY, value TEXT)`);
+  db.run(`INSERT INTO sync_meta VALUES ('cursor', '42')`);
+  db.run(`INSERT INTO labels VALUES ('lab-a', 'worker:mini', NULL)`);
+  db.run(`INSERT INTO labels VALUES ('lab-b', 'type:bug', NULL)`);
+  // CTL-400: two live labels attached — the sort-order + basic HIT case.
+  db.run(`INSERT INTO issues VALUES ('id-400', 'CTL-400', NULL)`);
+  db.run(`INSERT INTO issue_labels VALUES ('id-400', 'lab-a')`);
+  db.run(`INSERT INTO issue_labels VALUES ('id-400', 'lab-b')`);
+  // CTL-401: no labels attached at all — a defined, authoritative [].
+  db.run(`INSERT INTO issues VALUES ('id-401', 'CTL-401', NULL)`);
+  // CTL-402: tombstoned issue (removed_at set) — excluded by removed_at IS NULL.
+  db.run(`INSERT INTO issues VALUES ('id-402', 'CTL-402', '2026-06-03T00:00:00Z')`);
+  db.run(`INSERT INTO issue_labels VALUES ('id-402', 'lab-a')`);
+  // CTL-403: one live label ('lab-a') + one tombstoned label ('lab-c') attached —
+  // the tombstoned label must be filtered out of the returned list.
+  db.run(`INSERT INTO labels VALUES ('lab-c', 'worker:mini-2', '2026-06-03T00:00:00Z')`);
+  db.run(`INSERT INTO issues VALUES ('id-403', 'CTL-403', NULL)`);
+  db.run(`INSERT INTO issue_labels VALUES ('id-403', 'lab-a')`);
+  db.run(`INSERT INTO issue_labels VALUES ('id-403', 'lab-c')`);
+  db.close();
+  freshen();
+}
+
+describe("createReplicaReader.labels (CTL-1481 — worker-label visibility read)", () => {
+  test("fresh + seeded issue with 2 labels → sorted [{id,name}] pairs (ORDER BY l.name)", () => {
+    seedLabels();
+    reader = createReplicaReader({ dbPath });
+    expect(reader.labels("CTL-400")).toEqual([
+      { id: "lab-b", name: "type:bug" },
+      { id: "lab-a", name: "worker:mini" },
+    ]);
+  });
+
+  test("issue with zero labels → [] (a defined, authoritative empty answer)", () => {
+    seedLabels();
+    reader = createReplicaReader({ dbPath });
+    expect(reader.labels("CTL-401")).toEqual([]);
+  });
+
+  test("unknown identifier → undefined (MISS)", () => {
+    seedLabels();
+    reader = createReplicaReader({ dbPath });
+    expect(reader.labels("CTL-404")).toBeUndefined();
+  });
+
+  test("tombstoned issue (removed_at set) → undefined", () => {
+    seedLabels();
+    reader = createReplicaReader({ dbPath });
+    expect(reader.labels("CTL-402")).toBeUndefined();
+  });
+
+  test("a tombstoned label attached to a live issue is filtered out of the list", () => {
+    seedLabels();
+    reader = createReplicaReader({ dbPath });
+    // CTL-403 has lab-a (live) + lab-c (tombstoned) attached; only lab-a returns.
+    expect(reader.labels("CTL-403")).toEqual([{ id: "lab-a", name: "worker:mini" }]);
+  });
+
+  test("STALE .writer.lock (dead writer) → undefined (liveness gate fails)", () => {
+    seedLabels();
+    writeFileSync(dbPath + ".writer.lock", "");
+    backdate(dbPath + ".writer.lock", 10); // present-but-stale lock is authoritative
+    reader = createReplicaReader({ dbPath });
+    expect(reader.labels("CTL-400")).toBeUndefined();
+  });
+
+  test("mid-reseed (cursor row ABSENT) on a fresh DB → undefined (seed gate)", () => {
+    seedLabels();
+    const db = new Database(dbPath);
+    db.run(`DELETE FROM sync_meta WHERE key = 'cursor'`);
+    db.close();
+    freshen(); // the writer is STILL live; only the seed is incomplete
+    reader = createReplicaReader({ dbPath });
+    expect(reader.labels("CTL-400")).toBeUndefined();
+  });
+
+  test("mid-reseed (cursor present but EMPTY value) → undefined (seed gate)", () => {
+    seedLabels();
+    const db = new Database(dbPath);
+    db.run(`UPDATE sync_meta SET value = '' WHERE key = 'cursor'`);
+    db.close();
+    freshen();
+    reader = createReplicaReader({ dbPath });
+    expect(reader.labels("CTL-400")).toBeUndefined();
+  });
+
+  test("empty/falsy identifier → undefined without touching the DB", () => {
+    reader = createReplicaReader({ dbPath });
+    expect(reader.labels("")).toBeUndefined();
+    expect(reader.labels(null)).toBeUndefined();
+    expect(reader.labels(undefined)).toBeUndefined();
+  });
+});

--- a/plugins/dev/scripts/execution-core/scheduler.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.mjs
@@ -6284,6 +6284,7 @@ export function schedulerTick(
           stampWorkerLabel({
             ticket: t.identifier,
             hostName: self,
+            knownHosts: roster,
             replica,
             applyLabel: writeStatus.applyLabel,
             removeLabel: writeStatus.removeLabel,

--- a/plugins/dev/scripts/execution-core/scheduler.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.mjs
@@ -7474,9 +7474,10 @@ function runTick() {
     // Skip entirely on single-host installs (no-op inside the function, but the
     // pre-check avoids the call to stay zero-cost on the common case).
     if (getClusterHosts().length > 1) {
-      // CTL-1481: thread the replica so the takeover stamp's label read stays
-      // off live Linear (replica-first, loud live fallback inside the stamp).
-      reclaimDeadHostWork({ orchDir: runningOpts.orchDir, replica: runningOpts.replica }).catch((err) => {
+      // CTL-1481: thread the replica (second arg — the seams object) so the
+      // takeover stamp's label read stays off live Linear (replica-first, loud
+      // live fallback inside the stamp).
+      reclaimDeadHostWork({ orchDir: runningOpts.orchDir }, { replica: runningOpts.replica }).catch((err) => {
         log.warn({ err: err?.message }, "ctl-863: reclaimDeadHostWork tick failed — continuing");
       });
     }

--- a/plugins/dev/scripts/execution-core/scheduler.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.mjs
@@ -301,6 +301,9 @@ import * as linearWrite from "./linear-write.mjs";
 import { fenceGuard } from "./fence-guard.mjs";
 // CTL-863: Linear-free fence event emitter (durable fence → event-log migration).
 import { emitFenceClaimed } from "./fence-event.mjs";
+// CTL-1481: best-effort worker:<host> label visibility-projection stamp on a
+// won cluster claim. Never the claim arbiter — see worker-label.mjs header.
+import { stampWorkerLabel as defaultStampWorkerLabel } from "./worker-label.mjs";
 // CTL-757: the canonical linear.state.write audit emitter. CALLER-EMITS at each
 // scheduler write site (source/phase/reason known only here) — NEVER inside
 // runTransition (would double-audit the triage path, which keeps its own
@@ -3393,6 +3396,11 @@ export function schedulerTick(
     hosts = undefined,
     hostName = undefined,
     claimDispatch = claimDispatchSync,
+    // CTL-1481: best-effort worker:<host> label stamp, fired right after a won
+    // multi-host claim (same gate as emitFenceClaimed). Injectable so tests
+    // drive/assert the stamp without touching Linear; production defaults to
+    // the real linear-query/linear-write-backed implementation.
+    stampWorkerLabel = defaultStampWorkerLabel,
     // CTL-1191: injectable surviving-roster computation for the recovery-pass HRW
     // gate (ownsForRecovery). Default undefined → computeSurvivingRoster(roster),
     // which reads heartbeats from the (test-redirected) event log. Tests inject a
@@ -6264,6 +6272,29 @@ export function schedulerTick(
         ticket: t.identifier,
         phase: "assignment",
       });
+      // CTL-1481: best-effort worker:<host> label stamp — a visibility
+      // projection of the claim we just won, NEVER the claim arbiter itself.
+      // Multi-host only (same gate as emitFenceClaimed). Placed AFTER the
+      // applyPhaseStatus/applyAssignee writes so a stamp-tripped breaker can
+      // never starve the Axis-1 status write within the same tick. Own
+      // try/catch (mirrors convergeHeldLabel's applyLabel catch shape) so a
+      // throw only logs and never unwinds the dispatch success path.
+      if (clusterGeneration != null) {
+        try {
+          stampWorkerLabel({
+            ticket: t.identifier,
+            hostName: self,
+            applyLabel: writeStatus.applyLabel,
+            removeLabel: writeStatus.removeLabel,
+            log,
+          });
+        } catch (err) {
+          log.warn(
+            { ticket: t.identifier, err: err.message },
+            "scheduler: stampWorkerLabel threw — continuing tick"
+          );
+        }
+      }
     }
   }
 

--- a/plugins/dev/scripts/execution-core/scheduler.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.mjs
@@ -6284,6 +6284,7 @@ export function schedulerTick(
           stampWorkerLabel({
             ticket: t.identifier,
             hostName: self,
+            replica,
             applyLabel: writeStatus.applyLabel,
             removeLabel: writeStatus.removeLabel,
             log,
@@ -7473,7 +7474,9 @@ function runTick() {
     // Skip entirely on single-host installs (no-op inside the function, but the
     // pre-check avoids the call to stay zero-cost on the common case).
     if (getClusterHosts().length > 1) {
-      reclaimDeadHostWork({ orchDir: runningOpts.orchDir }).catch((err) => {
+      // CTL-1481: thread the replica so the takeover stamp's label read stays
+      // off live Linear (replica-first, loud live fallback inside the stamp).
+      reclaimDeadHostWork({ orchDir: runningOpts.orchDir, replica: runningOpts.replica }).catch((err) => {
         log.warn({ err: err?.message }, "ctl-863: reclaimDeadHostWork tick failed — continuing");
       });
     }

--- a/plugins/dev/scripts/execution-core/scheduler.test.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.test.mjs
@@ -9578,6 +9578,9 @@ describe("CTL-850 — HRW ownership + claim-on-dispatch (schedulerTick new-work)
       hosts: ROSTER,
       hostName: OWNER,
       claimDispatch,
+      // CTL-1481: stub the label-stamp seam — this test's subject is HRW/claim
+      // dispatch, not the label write, and a won multi-host claim now fires it.
+      stampWorkerLabel: () => ({ stamped: true }),
       verifyDispatched: verifyOk,
       liveBackgroundCount: () => 0,
       now: () => 1_000,
@@ -9640,6 +9643,9 @@ describe("CTL-850 — HRW ownership + claim-on-dispatch (schedulerTick new-work)
       hosts: ROSTER,
       hostName: OWNER,
       claimDispatch,
+      // CTL-1481: stub the label-stamp seam — this test's subject is
+      // clusterGeneration forwarding, not the label write.
+      stampWorkerLabel: () => ({ stamped: true }),
       verifyDispatched: verifyOk,
       liveBackgroundCount: () => 0,
       now: () => 1_000,
@@ -9705,6 +9711,9 @@ describe("CTL-850 — HRW ownership + claim-on-dispatch (schedulerTick new-work)
       hosts: ROSTER,
       hostName: OWNER,
       claimDispatch,
+      // CTL-1481: stub the label-stamp seam — this test's subject is the
+      // cluster-generation persist, not the label write.
+      stampWorkerLabel: () => ({ stamped: true }),
       verifyDispatched: verifyOk,
       liveBackgroundCount: () => 0,
       now: () => 1_000,
@@ -9727,6 +9736,79 @@ describe("CTL-850 — HRW ownership + claim-on-dispatch (schedulerTick new-work)
       now: () => 1_000,
     });
     expect(existsSync(join(orchDir, "workers", TICKET, "cluster-generation.json"))).toBe(false);
+  });
+
+  // CTL-1481: the worker:<host> label visibility-projection stamp fires right
+  // after a won multi-host claim, mirroring the emitFenceClaimed gate.
+  test("CTL-1481: a won multi-host claim fires stampWorkerLabel with the ticket + host", () => {
+    writeFileSync(join(orchDir, "state.json"), JSON.stringify({ maxParallel: 1 }));
+    const dispatch = dispatchCreatesDir();
+    const claimDispatch = recordClaim({ won: true, generation: 7 });
+    const calls = [];
+    const stampWorkerLabel = (arg) => {
+      calls.push(arg);
+      return { stamped: true };
+    };
+    schedulerTick(orchDir, {
+      readEligible: () => eligibleOne(),
+      dispatch,
+      hosts: ROSTER,
+      hostName: OWNER,
+      claimDispatch,
+      stampWorkerLabel,
+      verifyDispatched: verifyOk,
+      liveBackgroundCount: () => 0,
+      now: () => 1_000,
+      hasTriageArtifact: () => true, // CTL-1150: bypass triage gate, subject is the label stamp wiring
+    });
+    expect(calls).toHaveLength(1);
+    expect(calls[0]).toMatchObject({ ticket: TICKET, hostName: OWNER });
+  });
+
+  test("CTL-1481: single-host dispatch never fires stampWorkerLabel (multiHost gate)", () => {
+    writeFileSync(join(orchDir, "state.json"), JSON.stringify({ maxParallel: 1 }));
+    const dispatch = dispatchCreatesDir();
+    const calls = [];
+    const stampWorkerLabel = (arg) => {
+      calls.push(arg);
+      return { stamped: true };
+    };
+    schedulerTick(orchDir, {
+      readEligible: () => eligibleOne(),
+      dispatch,
+      hosts: ["solo"],
+      hostName: "solo",
+      claimDispatch: recordClaim({ won: false, generation: null }),
+      stampWorkerLabel,
+      verifyDispatched: verifyOk,
+      liveBackgroundCount: () => 0,
+      now: () => 1_000,
+      hasTriageArtifact: () => true,
+    });
+    expect(calls).toHaveLength(0);
+  });
+
+  test("CTL-1481: a thrown stampWorkerLabel never blocks the dispatch success path", () => {
+    writeFileSync(join(orchDir, "state.json"), JSON.stringify({ maxParallel: 1 }));
+    const dispatch = dispatchCreatesDir();
+    const claimDispatch = recordClaim({ won: true, generation: 7 });
+    const stampWorkerLabel = () => {
+      throw new Error("linearis exploded");
+    };
+    const result = schedulerTick(orchDir, {
+      readEligible: () => eligibleOne(),
+      dispatch,
+      hosts: ROSTER,
+      hostName: OWNER,
+      claimDispatch,
+      stampWorkerLabel,
+      verifyDispatched: verifyOk,
+      liveBackgroundCount: () => 0,
+      now: () => 1_000,
+      hasTriageArtifact: () => true,
+    });
+    expect(dispatch.calls).toHaveLength(1); // dispatch still succeeded
+    expect(result?.dispatched).toEqual([TICKET]);
   });
 });
 

--- a/plugins/dev/scripts/execution-core/worker-label-names.mjs
+++ b/plugins/dev/scripts/execution-core/worker-label-names.mjs
@@ -1,0 +1,15 @@
+// worker-label-names.mjs — CTL-1481: the canonical worker-ownership label
+// name constants, isolated in a ZERO-IMPORT leaf. doctor.mjs runs under bare
+// Node and must import these without pulling worker-label.mjs's module graph
+// (linear-query.mjs → gateway-read.mjs statically imports bun:sqlite, which
+// the Node ESM loader rejects at load time). Everything else should import
+// from worker-label.mjs, which re-exports both.
+
+// The workspace-level label group's own name (matched by name + parent==null,
+// per the #2631 isGroup gotcha). Provisioned by setup-execution-core-states.sh
+// (which necessarily duplicates the string — bash), asserted by doctor.mjs.
+export const WORKER_LABEL_GROUP = "worker";
+
+// The shared prefix for the per-host children of the workspace group. A
+// ticket's desired label is always `${WORKER_LABEL_PREFIX}${hostName}`.
+export const WORKER_LABEL_PREFIX = "worker:";

--- a/plugins/dev/scripts/execution-core/worker-label.mjs
+++ b/plugins/dev/scripts/execution-core/worker-label.mjs
@@ -1,0 +1,162 @@
+// worker-label.mjs — CTL-1481: best-effort `worker:<host>` label stamp on a
+// cluster claim-win.
+//
+// VISIBILITY PROJECTION, NEVER THE CLAIM ARBITER. The claim/fence soft-CAS +
+// generation stay entirely on cluster-claim.mjs / the #2553 event-log fence;
+// this module's only job is to make the winning host's ownership visible on
+// the Linear board via a single-select `worker` label group (sibling
+// convention to the `type`/`worker-status` groups), so a human scanning the
+// board can see which host is driving a ticket. A failure here (read, remove,
+// or apply) never blocks, retries, or reverses the claim — it only means the
+// board's label goes stale until the next claim-win re-stamps it.
+//
+// Linear enforces the `worker` group as an EXCLUSIVE single-select child set
+// server-side: applying a second child to an already-labeled ticket is
+// REJECTED ("labelIds not exclusive child labels" — write-tested 2026-07-14).
+// So a swap from one host's label to another's is never a single mutation —
+// it is always remove-old-then-add-new, exactly the two-step
+// convergeHeldLabel/convergeDispositionLabel already use for the sibling
+// worker-status group (scheduler.mjs).
+//
+// Steady state (the ticket already carries `worker:<hostName>` and no other
+// group member) costs exactly ONE live read and ZERO writes.
+
+import { readTicketLabelNodes } from "./linear-query.mjs";
+import {
+  applyLabel as defaultApplyLabel,
+  removeLabel as defaultRemoveLabel,
+} from "./linear-write.mjs";
+
+// WORKER_LABEL_GROUP — the workspace-level label group's own name (matched by
+// name + parent==null, per the #2631 isGroup gotcha). Provisioned by
+// setup-execution-core-states.sh (which necessarily duplicates the string —
+// bash), asserted by doctor.mjs checkWorkerLabels (which imports it from here).
+export const WORKER_LABEL_GROUP = "worker";
+
+// WORKER_LABEL_PREFIX — the shared prefix for the per-host children of the
+// workspace `worker` label group. A ticket's desired label is always
+// `${WORKER_LABEL_PREFIX}${hostName}`.
+export const WORKER_LABEL_PREFIX = "worker:";
+
+// stampWorkerLabel — apply `worker:<hostName>` to `ticket`, removing any OTHER
+// `worker:*` label first (remove-before-add: Linear rejects a second
+// exclusive-group child in one apply). The entire body is wrapped so this
+// function NEVER throws — a claim-win call site can invoke it bare, wrapping
+// only its own best-effort try/catch around the call (mirrors linear-write.mjs's
+// applyLabel/removeLabel swallow discipline).
+//
+// Returns { stamped: true } once `worker:<hostName>` is confirmed present
+// (already-present counts — zero writes at steady state), or
+// { stamped: false, reason } on a read failure ("read-failed"), a foreign-label
+// removal failure/throw ("remove-failed"), or an apply failure/throw
+// ("apply-threw" or applyLabel's own reason string).
+//
+// `readLabelNodes`/`applyLabel`/`removeLabel` are injectable (tests fake them);
+// production defaults to the real linear-query.mjs/linear-write.mjs functions —
+// `readLabelNodes` is a LIVE read (labels are not yet served by the replica).
+// `log` is an optional injectable logger (default null — no-op) so a bare test
+// call needs no logger stub.
+export function stampWorkerLabel({
+  ticket,
+  hostName,
+  readLabelNodes = readTicketLabelNodes,
+  applyLabel = defaultApplyLabel,
+  removeLabel = defaultRemoveLabel,
+  log = null,
+} = {}) {
+  try {
+    const desired = `${WORKER_LABEL_PREFIX}${hostName}`;
+    const read = readLabelNodes(ticket);
+    if (!read?.ok || !Array.isArray(read.nodes)) {
+      log?.warn?.(
+        { ticket, hostName },
+        "worker-label: label read failed — skipping stamp (no writes; cannot safely swap)"
+      );
+      return { stamped: false, reason: "read-failed" };
+    }
+    const nodes = read.nodes;
+    // Remove BEFORE add: Linear rejects a second exclusive-group child in one
+    // apply, so any foreign `worker:*` sibling must be cleared first.
+    const foreign = nodes.filter(
+      (n) =>
+        typeof n?.name === "string" &&
+        n.name.startsWith(WORKER_LABEL_PREFIX) &&
+        n.name !== desired
+    );
+    const applyIfAbsent = () => {
+      if (nodes.some((n) => n?.name === desired)) {
+        return { stamped: true };
+      }
+      let applyRes;
+      try {
+        applyRes = applyLabel({ ticket, label: desired });
+      } catch (err) {
+        log?.warn?.(
+          { ticket, label: desired, err: err.message },
+          "worker-label: applyLabel threw — swallowed"
+        );
+        return { stamped: false, reason: "apply-threw" };
+      }
+      if (applyRes?.applied) {
+        return { stamped: true };
+      }
+      log?.warn?.(
+        { ticket, label: desired, reason: applyRes?.reason },
+        "worker-label: applyLabel failed"
+      );
+      return { stamped: false, reason: applyRes?.reason ?? "apply-failed" };
+    };
+    // Sequential remove→confirm→next→apply chain. removeLabel (linear-write.mjs)
+    // is declared `async` with an entirely spawnSync-synchronous body — the
+    // mutation has already landed or failed by the time it returns; only the
+    // RESULT is promise-wrapped. Mirror clearStalledLabel's thenable-aware
+    // confirmation (CTL-764 round-5): a plain-object result (test fakes) is
+    // confirmed inline; a thenable result is confirmed on a microtask, so the
+    // apply still happens strictly AFTER a CONFIRMED remove and a failed remove
+    // aborts the stamp in production too (never leaves the exclusive group with
+    // an apply Linear would reject).
+    const removeThenContinue = (idx) => {
+      if (idx >= foreign.length) return applyIfAbsent();
+      const node = foreign[idx];
+      let res;
+      try {
+        res = removeLabel(ticket, node.name);
+      } catch (err) {
+        log?.warn?.(
+          { ticket, label: node.name, err: err.message },
+          "worker-label: removeLabel threw — stamp aborted (no apply)"
+        );
+        return { stamped: false, reason: "remove-failed" };
+      }
+      const confirm = (r) => {
+        if (r?.removed === false) {
+          log?.warn?.(
+            { ticket, label: node.name, reason: r.reason },
+            "worker-label: removeLabel failed — stamp aborted (no apply)"
+          );
+          return { stamped: false, reason: "remove-failed" };
+        }
+        return removeThenContinue(idx + 1);
+      };
+      if (res && typeof res.then === "function") {
+        res.then(confirm).catch((err) =>
+          log?.warn?.(
+            { ticket, label: node.name, err: err?.message },
+            "worker-label: removeLabel rejected — stamp aborted (no apply)"
+          )
+        );
+        // The swap completes on a microtask; the sync caller only learns it was
+        // deferred. Best-effort projection — the outcome is logged, not returned.
+        return { stamped: false, reason: "swap-deferred" };
+      }
+      return confirm(res);
+    };
+    return removeThenContinue(0);
+  } catch (err) {
+    log?.warn?.(
+      { ticket, hostName, err: err?.message },
+      "worker-label: stampWorkerLabel threw — swallowed"
+    );
+    return { stamped: false, reason: "threw" };
+  }
+}

--- a/plugins/dev/scripts/execution-core/worker-label.mjs
+++ b/plugins/dev/scripts/execution-core/worker-label.mjs
@@ -51,11 +51,16 @@ export { WORKER_LABEL_GROUP, WORKER_LABEL_PREFIX };
 // CTL-1481) — the PREFERRED read source per the repo's replica-first read rule
 // (a live single-ticket read burns the shared fleet quota). A replica miss
 // (gate-fail/absent/undefined) falls back LOUDLY to the live `readLabelNodes`.
+// `knownHosts` is the cluster roster (in scope at every call site): eager
+// sibling removal is limited to `worker:<roster-host>` names so an unrelated
+// same-prefix label from a workspace's own taxonomy is never touched outside
+// the conflict-proven retry.
 // `log` is an optional injectable logger (default null — no-op) so a bare test
 // call needs no logger stub.
 export function stampWorkerLabel({
   ticket,
   hostName,
+  knownHosts = null,
   replica = null,
   readLabelNodes = readTicketLabelNodes,
   applyLabel = defaultApplyLabel,
@@ -64,16 +69,27 @@ export function stampWorkerLabel({
 } = {}) {
   try {
     const desired = `${WORKER_LABEL_PREFIX}${hostName}`;
+    // A prefix-matched sibling that is NOT the desired label. Prefix alone
+    // cannot prove group membership (a workspace may carry an unrelated
+    // `worker:frontend` from its own taxonomy), so candidates are only
+    // removed EAGERLY when their host part is roster-known (certainly ours),
+    // and prefix-wide only inside the conflict-proven retry below.
+    const isCandidate = (n) =>
+      typeof n?.name === "string" &&
+      n.name.startsWith(WORKER_LABEL_PREFIX) &&
+      n.name !== desired;
+    const knownNames = new Set(
+      (Array.isArray(knownHosts) ? knownHosts : []).map((h) => `${WORKER_LABEL_PREFIX}${h}`)
+    );
+
     // Replica-first: labels ARE mirrored into catalyst-replica.db, and the
     // steady-state stamp (label already correct) should cost ZERO live calls.
     // replica.labels returns [] as an authoritative "no labels" answer and
     // undefined on any gate-fail/miss — only undefined falls through.
     let nodes = null;
-    let usedReplica = false;
     const replicaRows = typeof replica?.labels === "function" ? replica.labels(ticket) : undefined;
     if (Array.isArray(replicaRows)) {
       nodes = replicaRows;
-      usedReplica = true;
     } else {
       if (replica) {
         // Loud fallback per the replica-first convention — a silent live read
@@ -93,16 +109,18 @@ export function stampWorkerLabel({
       }
       nodes = read.nodes;
     }
-    // Remove BEFORE add: Linear rejects a second exclusive-group child in one
-    // apply, so any foreign `worker:*` sibling must be cleared first.
-    const foreign = nodes.filter(
-      (n) =>
-        typeof n?.name === "string" &&
-        n.name.startsWith(WORKER_LABEL_PREFIX) &&
-        n.name !== desired
-    );
-    const applyIfAbsent = () => {
-      if (nodes.some((n) => n?.name === desired)) {
+
+    // applyIfAbsent — the terminal apply step of a pass. On an
+    // exclusive-conflict rejection the server has PROVED a live same-group
+    // sibling our pass didn't remove (a stale replica snapshot, or a sibling
+    // outside the roster — e.g. a decommissioned host's label). One
+    // conflict-proven retry re-reads LIVE and removes candidates PREFIX-WIDE:
+    // at that point an unrelated same-prefix label coexisting with a genuine
+    // in-group conflict is vanishingly rare, and the alternative is an
+    // ownership label that can never converge. The retry pass itself never
+    // retries again.
+    const applyIfAbsent = (currentNodes, allowConflictRetry) => {
+      if (currentNodes.some((n) => n?.name === desired)) {
         return { stamped: true };
       }
       let applyRes;
@@ -118,25 +136,20 @@ export function stampWorkerLabel({
       if (applyRes?.applied) {
         return { stamped: true };
       }
-      // A replica that is fresh-gated but behind for THIS ticket can be missing
-      // a live foreign worker:* sibling — the apply then hits the server-side
-      // exclusive-group rejection. Retry ONCE from a LIVE read (replica
-      // disabled) so the stale sibling is actually removed before re-adding;
-      // the replica:null recursion cannot recurse again.
-      if (usedReplica && applyRes?.reason === "exclusive-conflict") {
+      if (allowConflictRetry && applyRes?.reason === "exclusive-conflict") {
         log?.warn?.(
           { ticket, label: desired },
-          "worker-label: exclusive-conflict off a replica-sourced read — retrying from a live read"
+          "worker-label: exclusive-conflict — retrying once from a live read (prefix-wide removal)"
         );
-        return stampWorkerLabel({
-          ticket,
-          hostName,
-          replica: null,
-          readLabelNodes,
-          applyLabel,
-          removeLabel,
-          log,
-        });
+        const read = readLabelNodes(ticket);
+        if (!read?.ok || !Array.isArray(read.nodes)) {
+          log?.warn?.(
+            { ticket, hostName },
+            "worker-label: conflict-retry live read failed — stamp aborted"
+          );
+          return { stamped: false, reason: "read-failed" };
+        }
+        return removeThenApply(read.nodes, read.nodes.filter(isCandidate), false);
       }
       log?.warn?.(
         { ticket, label: desired, reason: applyRes?.reason },
@@ -144,52 +157,64 @@ export function stampWorkerLabel({
       );
       return { stamped: false, reason: applyRes?.reason ?? "apply-failed" };
     };
-    // Sequential remove→confirm→next→apply chain. removeLabel (linear-write.mjs)
-    // is declared `async` with an entirely spawnSync-synchronous body — the
-    // mutation has already landed or failed by the time it returns; only the
-    // RESULT is promise-wrapped. Mirror clearStalledLabel's thenable-aware
-    // confirmation (CTL-764 round-5): a plain-object result (test fakes) is
-    // confirmed inline; a thenable result is confirmed on a microtask, so the
-    // apply still happens strictly AFTER a CONFIRMED remove and a failed remove
-    // aborts the stamp in production too (never leaves the exclusive group with
-    // an apply Linear would reject).
-    const removeThenContinue = (idx) => {
-      if (idx >= foreign.length) return applyIfAbsent();
-      const node = foreign[idx];
-      let res;
-      try {
-        res = removeLabel(ticket, node.name);
-      } catch (err) {
-        log?.warn?.(
-          { ticket, label: node.name, err: err.message },
-          "worker-label: removeLabel threw — stamp aborted (no apply)"
-        );
-        return { stamped: false, reason: "remove-failed" };
-      }
-      const confirm = (r) => {
-        if (r?.removed === false) {
+
+    // removeThenApply — sequential remove→confirm→next→apply chain.
+    // removeLabel (linear-write.mjs) is declared `async` with an entirely
+    // spawnSync-synchronous body — the mutation has already landed or failed
+    // by the time it returns; only the RESULT is promise-wrapped. Mirror
+    // clearStalledLabel's thenable-aware confirmation (CTL-764 round-5): a
+    // plain-object result (test fakes) is confirmed inline; a thenable result
+    // is confirmed on a microtask, so the apply still happens strictly AFTER a
+    // CONFIRMED remove and a failed remove aborts the stamp in production too
+    // (never leaves the exclusive group with an apply Linear would reject).
+    // removeLabel internally re-reads live before writing (read-modify-write),
+    // so every removal is checked against live truth even off a replica read.
+    const removeThenApply = (currentNodes, toRemove, allowConflictRetry) => {
+      const step = (idx) => {
+        if (idx >= toRemove.length) return applyIfAbsent(currentNodes, allowConflictRetry);
+        const node = toRemove[idx];
+        let res;
+        try {
+          res = removeLabel(ticket, node.name);
+        } catch (err) {
           log?.warn?.(
-            { ticket, label: node.name, reason: r.reason },
-            "worker-label: removeLabel failed — stamp aborted (no apply)"
+            { ticket, label: node.name, err: err.message },
+            "worker-label: removeLabel threw — stamp aborted (no apply)"
           );
           return { stamped: false, reason: "remove-failed" };
         }
-        return removeThenContinue(idx + 1);
+        const confirm = (r) => {
+          if (r?.removed === false) {
+            log?.warn?.(
+              { ticket, label: node.name, reason: r.reason },
+              "worker-label: removeLabel failed — stamp aborted (no apply)"
+            );
+            return { stamped: false, reason: "remove-failed" };
+          }
+          return step(idx + 1);
+        };
+        if (res && typeof res.then === "function") {
+          res.then(confirm).catch((err) =>
+            log?.warn?.(
+              { ticket, label: node.name, err: err?.message },
+              "worker-label: removeLabel rejected — stamp aborted (no apply)"
+            )
+          );
+          // The swap completes on a microtask; the sync caller only learns it
+          // was deferred. Best-effort projection — the outcome is logged, not
+          // returned.
+          return { stamped: false, reason: "swap-deferred" };
+        }
+        return confirm(res);
       };
-      if (res && typeof res.then === "function") {
-        res.then(confirm).catch((err) =>
-          log?.warn?.(
-            { ticket, label: node.name, err: err?.message },
-            "worker-label: removeLabel rejected — stamp aborted (no apply)"
-          )
-        );
-        // The swap completes on a microtask; the sync caller only learns it was
-        // deferred. Best-effort projection — the outcome is logged, not returned.
-        return { stamped: false, reason: "swap-deferred" };
-      }
-      return confirm(res);
+      return step(0);
     };
-    return removeThenContinue(0);
+
+    // First pass: eagerly remove only roster-known siblings, then apply; an
+    // exclusive-conflict on the apply escalates to the one live prefix-wide
+    // retry inside applyIfAbsent.
+    const eager = nodes.filter((n) => isCandidate(n) && knownNames.has(n.name));
+    return removeThenApply(nodes, eager, true);
   } catch (err) {
     log?.warn?.(
       { ticket, hostName, err: err?.message },

--- a/plugins/dev/scripts/execution-core/worker-label.mjs
+++ b/plugins/dev/scripts/execution-core/worker-label.mjs
@@ -89,7 +89,26 @@ export function stampWorkerLabel({
     let nodes = null;
     const replicaRows = typeof replica?.labels === "function" ? replica.labels(ticket) : undefined;
     if (Array.isArray(replicaRows)) {
-      nodes = replicaRows;
+      if (replicaRows.some((n) => n?.name === desired)) {
+        // The ONE replica answer that would terminate with NO write: a stale
+        // snapshot can still show OUR label after a peer swapped it live (we
+        // re-win within the replica lag), and since no later stamp fires, a
+        // wrong no-op here never converges. Every other replica answer leads
+        // to a write that self-verifies against live truth (removeLabel is
+        // read-modify-write; applyLabel is server-side conflict-checked), so
+        // only this already-present answer gets a live confirm.
+        const confirm = readLabelNodes(ticket);
+        if (!confirm?.ok || !Array.isArray(confirm.nodes)) {
+          log?.warn?.(
+            { ticket, hostName },
+            "worker-label: live confirm of replica already-present hit failed — skipping stamp"
+          );
+          return { stamped: false, reason: "read-failed" };
+        }
+        nodes = confirm.nodes;
+      } else {
+        nodes = replicaRows;
+      }
     } else {
       if (replica) {
         // Loud fallback per the replica-first convention — a silent live read

--- a/plugins/dev/scripts/execution-core/worker-label.mjs
+++ b/plugins/dev/scripts/execution-core/worker-label.mjs
@@ -26,17 +26,11 @@ import {
   applyLabel as defaultApplyLabel,
   removeLabel as defaultRemoveLabel,
 } from "./linear-write.mjs";
+// The name constants live in a zero-import leaf so bare-Node entrypoints
+// (doctor.mjs) can read them without loading this module's linearis graph.
+import { WORKER_LABEL_GROUP, WORKER_LABEL_PREFIX } from "./worker-label-names.mjs";
 
-// WORKER_LABEL_GROUP — the workspace-level label group's own name (matched by
-// name + parent==null, per the #2631 isGroup gotcha). Provisioned by
-// setup-execution-core-states.sh (which necessarily duplicates the string —
-// bash), asserted by doctor.mjs checkWorkerLabels (which imports it from here).
-export const WORKER_LABEL_GROUP = "worker";
-
-// WORKER_LABEL_PREFIX — the shared prefix for the per-host children of the
-// workspace `worker` label group. A ticket's desired label is always
-// `${WORKER_LABEL_PREFIX}${hostName}`.
-export const WORKER_LABEL_PREFIX = "worker:";
+export { WORKER_LABEL_GROUP, WORKER_LABEL_PREFIX };
 
 // stampWorkerLabel — apply `worker:<hostName>` to `ticket`, removing any OTHER
 // `worker:*` label first (remove-before-add: Linear rejects a second
@@ -52,13 +46,17 @@ export const WORKER_LABEL_PREFIX = "worker:";
 // ("apply-threw" or applyLabel's own reason string).
 //
 // `readLabelNodes`/`applyLabel`/`removeLabel` are injectable (tests fake them);
-// production defaults to the real linear-query.mjs/linear-write.mjs functions —
-// `readLabelNodes` is a LIVE read (labels are not yet served by the replica).
+// production defaults to the real linear-query.mjs/linear-write.mjs functions.
+// `replica` is the daemon's createReplicaReader instance (duck-typed .labels,
+// CTL-1481) — the PREFERRED read source per the repo's replica-first read rule
+// (a live single-ticket read burns the shared fleet quota). A replica miss
+// (gate-fail/absent/undefined) falls back LOUDLY to the live `readLabelNodes`.
 // `log` is an optional injectable logger (default null — no-op) so a bare test
 // call needs no logger stub.
 export function stampWorkerLabel({
   ticket,
   hostName,
+  replica = null,
   readLabelNodes = readTicketLabelNodes,
   applyLabel = defaultApplyLabel,
   removeLabel = defaultRemoveLabel,
@@ -66,15 +64,33 @@ export function stampWorkerLabel({
 } = {}) {
   try {
     const desired = `${WORKER_LABEL_PREFIX}${hostName}`;
-    const read = readLabelNodes(ticket);
-    if (!read?.ok || !Array.isArray(read.nodes)) {
-      log?.warn?.(
-        { ticket, hostName },
-        "worker-label: label read failed — skipping stamp (no writes; cannot safely swap)"
-      );
-      return { stamped: false, reason: "read-failed" };
+    // Replica-first: labels ARE mirrored into catalyst-replica.db, and the
+    // steady-state stamp (label already correct) should cost ZERO live calls.
+    // replica.labels returns [] as an authoritative "no labels" answer and
+    // undefined on any gate-fail/miss — only undefined falls through.
+    let nodes = null;
+    const replicaRows = typeof replica?.labels === "function" ? replica.labels(ticket) : undefined;
+    if (Array.isArray(replicaRows)) {
+      nodes = replicaRows;
+    } else {
+      if (replica) {
+        // Loud fallback per the replica-first convention — a silent live read
+        // here would hide replica-health regressions behind burned quota.
+        log?.warn?.(
+          { ticket, hostName },
+          "worker-label: replica label read missed — falling back to live read"
+        );
+      }
+      const read = readLabelNodes(ticket);
+      if (!read?.ok || !Array.isArray(read.nodes)) {
+        log?.warn?.(
+          { ticket, hostName },
+          "worker-label: label read failed — skipping stamp (no writes; cannot safely swap)"
+        );
+        return { stamped: false, reason: "read-failed" };
+      }
+      nodes = read.nodes;
     }
-    const nodes = read.nodes;
     // Remove BEFORE add: Linear rejects a second exclusive-group child in one
     // apply, so any foreign `worker:*` sibling must be cleared first.
     const foreign = nodes.filter(

--- a/plugins/dev/scripts/execution-core/worker-label.mjs
+++ b/plugins/dev/scripts/execution-core/worker-label.mjs
@@ -69,9 +69,11 @@ export function stampWorkerLabel({
     // replica.labels returns [] as an authoritative "no labels" answer and
     // undefined on any gate-fail/miss — only undefined falls through.
     let nodes = null;
+    let usedReplica = false;
     const replicaRows = typeof replica?.labels === "function" ? replica.labels(ticket) : undefined;
     if (Array.isArray(replicaRows)) {
       nodes = replicaRows;
+      usedReplica = true;
     } else {
       if (replica) {
         // Loud fallback per the replica-first convention — a silent live read
@@ -115,6 +117,26 @@ export function stampWorkerLabel({
       }
       if (applyRes?.applied) {
         return { stamped: true };
+      }
+      // A replica that is fresh-gated but behind for THIS ticket can be missing
+      // a live foreign worker:* sibling — the apply then hits the server-side
+      // exclusive-group rejection. Retry ONCE from a LIVE read (replica
+      // disabled) so the stale sibling is actually removed before re-adding;
+      // the replica:null recursion cannot recurse again.
+      if (usedReplica && applyRes?.reason === "exclusive-conflict") {
+        log?.warn?.(
+          { ticket, label: desired },
+          "worker-label: exclusive-conflict off a replica-sourced read — retrying from a live read"
+        );
+        return stampWorkerLabel({
+          ticket,
+          hostName,
+          replica: null,
+          readLabelNodes,
+          applyLabel,
+          removeLabel,
+          log,
+        });
       }
       log?.warn?.(
         { ticket, label: desired, reason: applyRes?.reason },

--- a/plugins/dev/scripts/execution-core/worker-label.test.mjs
+++ b/plugins/dev/scripts/execution-core/worker-label.test.mjs
@@ -224,9 +224,9 @@ describe("stampWorkerLabel — thenable removeLabel (the production async-declar
 });
 
 describe("stampWorkerLabel — replica-first read (Codex #2650 P2)", () => {
-  test("replica HIT (label already correct) — ZERO live reads, zero writes", () => {
+  test("replica already-present hit is LIVE-CONFIRMED — 1 read, zero writes when live agrees", () => {
     const replica = { labels: recorder([{ id: "l1", name: "worker:mini" }]) };
-    const readLabelNodes = recorder({ ok: true, nodes: [] });
+    const readLabelNodes = recorder({ ok: true, nodes: [{ id: "l1", name: "worker:mini" }] });
     const applyLabel = recorder({ applied: true });
     const removeLabel = recorder({ removed: true });
 
@@ -234,7 +234,36 @@ describe("stampWorkerLabel — replica-first read (Codex #2650 P2)", () => {
 
     expect(res).toEqual({ stamped: true });
     expect(replica.labels.calls.length).toBe(1);
-    expect(readLabelNodes.calls.length).toBe(0);
+    expect(readLabelNodes.calls.length).toBe(1); // the confirm — this is the one no-write replica answer
+    expect(applyLabel.calls.length).toBe(0);
+    expect(removeLabel.calls.length).toBe(0);
+  });
+
+  test("STALE replica already-present hit (peer swapped live) — live confirm disagrees, swap proceeds", () => {
+    // Replica still shows worker:mini from our previous stint; live truth is
+    // worker:mini-2 (a peer swapped it and we just re-won the claim).
+    const replica = { labels: recorder([{ id: "l1", name: "worker:mini" }]) };
+    const readLabelNodes = recorder({ ok: true, nodes: [{ id: "l2", name: "worker:mini-2" }] });
+    const removeLabel = recorder({ removed: true });
+    const applyLabel = recorder({ applied: true });
+
+    const res = stampWorkerLabel({ ticket: "CTL-1", hostName: "mini", knownHosts: ["mini", "mini-2"], replica, readLabelNodes, applyLabel, removeLabel });
+
+    expect(res).toEqual({ stamped: true });
+    expect(removeLabel.calls.length).toBe(1);
+    expect(removeLabel.calls[0][1]).toBe("worker:mini-2");
+    expect(applyLabel.calls.length).toBe(1);
+  });
+
+  test("live confirm of a replica already-present hit FAILING skips the stamp (no writes)", () => {
+    const replica = { labels: recorder([{ id: "l1", name: "worker:mini" }]) };
+    const readLabelNodes = recorder({ ok: false, nodes: null, code: 1, stderr: "boom" });
+    const applyLabel = recorder({ applied: true });
+    const removeLabel = recorder({ removed: true });
+
+    const res = stampWorkerLabel({ ticket: "CTL-1", hostName: "mini", replica, readLabelNodes, applyLabel, removeLabel });
+
+    expect(res).toEqual({ stamped: false, reason: "read-failed" });
     expect(applyLabel.calls.length).toBe(0);
     expect(removeLabel.calls.length).toBe(0);
   });

--- a/plugins/dev/scripts/execution-core/worker-label.test.mjs
+++ b/plugins/dev/scripts/execution-core/worker-label.test.mjs
@@ -293,3 +293,50 @@ describe("stampWorkerLabel — replica-first read (Codex #2650 P2)", () => {
     expect(warns.length).toBe(0);
   });
 });
+
+describe("stampWorkerLabel — stale-replica exclusive-conflict live retry (Codex #2650 round-2)", () => {
+  test("replica missed a live foreign sibling → apply conflicts → ONE live retry removes it and re-applies", () => {
+    // Replica says no labels; live truth has worker:other still attached.
+    const replica = { labels: recorder([]) };
+    const readLabelNodes = recorder({ ok: true, nodes: [{ id: "l1", name: "worker:other" }] });
+    const removeLabel = recorder({ removed: true });
+    let applyCalls = 0;
+    const applyLabel = recorder(() => {
+      applyCalls += 1;
+      // First apply (off the stale replica read) hits the server-side
+      // exclusive-group rejection; the live-retry apply succeeds.
+      return applyCalls === 1 ? { applied: false, reason: "exclusive-conflict" } : { applied: true };
+    });
+
+    const res = stampWorkerLabel({ ticket: "CTL-1", hostName: "mini", replica, readLabelNodes, applyLabel, removeLabel });
+
+    expect(res).toEqual({ stamped: true });
+    expect(readLabelNodes.calls.length).toBe(1); // the live retry read
+    expect(removeLabel.calls.length).toBe(1); // the stale sibling removed
+    expect(removeLabel.calls[0][1]).toBe("worker:other");
+    expect(applyLabel.calls.length).toBe(2);
+  });
+
+  test("live retry that STILL conflicts surfaces the failure — no infinite recursion", () => {
+    const replica = { labels: recorder([]) };
+    const readLabelNodes = recorder({ ok: true, nodes: [] });
+    const applyLabel = recorder({ applied: false, reason: "exclusive-conflict" });
+
+    const res = stampWorkerLabel({ ticket: "CTL-1", hostName: "mini", replica, readLabelNodes, applyLabel, removeLabel: recorder({ removed: true }) });
+
+    expect(res).toEqual({ stamped: false, reason: "exclusive-conflict" });
+    expect(readLabelNodes.calls.length).toBe(1); // exactly one live retry
+    expect(applyLabel.calls.length).toBe(2); // replica attempt + live attempt, then stop
+  });
+
+  test("exclusive-conflict off a LIVE read does not retry (no replica involved)", () => {
+    const readLabelNodes = recorder({ ok: true, nodes: [] });
+    const applyLabel = recorder({ applied: false, reason: "exclusive-conflict" });
+
+    const res = stampWorkerLabel({ ticket: "CTL-1", hostName: "mini", readLabelNodes, applyLabel, removeLabel: recorder({ removed: true }) });
+
+    expect(res).toEqual({ stamped: false, reason: "exclusive-conflict" });
+    expect(readLabelNodes.calls.length).toBe(1);
+    expect(applyLabel.calls.length).toBe(1);
+  });
+});

--- a/plugins/dev/scripts/execution-core/worker-label.test.mjs
+++ b/plugins/dev/scripts/execution-core/worker-label.test.mjs
@@ -222,3 +222,74 @@ describe("stampWorkerLabel — thenable removeLabel (the production async-declar
     expect(applyLabel.calls.length).toBe(0);
   });
 });
+
+describe("stampWorkerLabel — replica-first read (Codex #2650 P2)", () => {
+  test("replica HIT (label already correct) — ZERO live reads, zero writes", () => {
+    const replica = { labels: recorder([{ id: "l1", name: "worker:mini" }]) };
+    const readLabelNodes = recorder({ ok: true, nodes: [] });
+    const applyLabel = recorder({ applied: true });
+    const removeLabel = recorder({ removed: true });
+
+    const res = stampWorkerLabel({ ticket: "CTL-1", hostName: "mini", replica, readLabelNodes, applyLabel, removeLabel });
+
+    expect(res).toEqual({ stamped: true });
+    expect(replica.labels.calls.length).toBe(1);
+    expect(readLabelNodes.calls.length).toBe(0);
+    expect(applyLabel.calls.length).toBe(0);
+    expect(removeLabel.calls.length).toBe(0);
+  });
+
+  test("replica [] (authoritative empty) is trusted — no live read, one apply", () => {
+    const replica = { labels: recorder([]) };
+    const readLabelNodes = recorder({ ok: true, nodes: [{ id: "x", name: "worker:other" }] });
+    const applyLabel = recorder({ applied: true });
+    const removeLabel = recorder({ removed: true });
+
+    const res = stampWorkerLabel({ ticket: "CTL-1", hostName: "mini", replica, readLabelNodes, applyLabel, removeLabel });
+
+    expect(res).toEqual({ stamped: true });
+    expect(readLabelNodes.calls.length).toBe(0);
+    expect(removeLabel.calls.length).toBe(0);
+    expect(applyLabel.calls.length).toBe(1);
+  });
+
+  test("replica MISS (undefined) falls back LOUDLY to the live read", () => {
+    const replica = { labels: recorder(undefined) };
+    const readLabelNodes = recorder({ ok: true, nodes: [{ id: "l1", name: "worker:mini" }] });
+    const warns = [];
+    const log = { warn: (...a) => warns.push(a) };
+
+    const res = stampWorkerLabel({ ticket: "CTL-1", hostName: "mini", replica, readLabelNodes, applyLabel: recorder({ applied: true }), removeLabel: recorder({ removed: true }), log });
+
+    expect(res).toEqual({ stamped: true });
+    expect(readLabelNodes.calls.length).toBe(1);
+    expect(warns.some(([, msg]) => String(msg).includes("falling back to live read"))).toBe(true);
+  });
+
+  test("replica.labels throwing is swallowed by the outer guard — stamped:false, nothing propagates", () => {
+    const replica = { labels: () => { throw new Error("db exploded"); } };
+
+    let threw = false;
+    let res;
+    try {
+      res = stampWorkerLabel({ ticket: "CTL-1", hostName: "mini", replica, readLabelNodes: recorder({ ok: true, nodes: [] }), applyLabel: recorder({ applied: true }), removeLabel: recorder({ removed: true }) });
+    } catch {
+      threw = true;
+    }
+
+    expect(threw).toBe(false);
+    expect(res).toEqual({ stamped: false, reason: "threw" });
+  });
+
+  test("no replica (null) — live read path unchanged, no fallback warn", () => {
+    const readLabelNodes = recorder({ ok: true, nodes: [{ id: "l1", name: "worker:mini" }] });
+    const warns = [];
+    const log = { warn: (...a) => warns.push(a) };
+
+    const res = stampWorkerLabel({ ticket: "CTL-1", hostName: "mini", readLabelNodes, applyLabel: recorder({ applied: true }), removeLabel: recorder({ removed: true }), log });
+
+    expect(res).toEqual({ stamped: true });
+    expect(readLabelNodes.calls.length).toBe(1);
+    expect(warns.length).toBe(0);
+  });
+});

--- a/plugins/dev/scripts/execution-core/worker-label.test.mjs
+++ b/plugins/dev/scripts/execution-core/worker-label.test.mjs
@@ -1,0 +1,224 @@
+// worker-label.test.mjs — CTL-1481 stampWorkerLabel: the best-effort
+// `worker:<host>` visibility-projection stamp on a cluster claim-win. Every
+// test injects fakes for readLabelNodes/applyLabel/removeLabel so nothing
+// shells out to linearis. Run:
+//   cd plugins/dev/scripts/execution-core && bun test worker-label.test.mjs
+
+import { describe, test, expect } from "bun:test";
+import { WORKER_LABEL_PREFIX, stampWorkerLabel } from "./worker-label.mjs";
+
+// recorder — minimal call-collecting fake; mirrors label-guard.test.mjs's
+// recorder / recovery.test.mjs convention. `impl` may be a function (invoked
+// per call) or a plain value (returned every call).
+function recorder(impl) {
+  const fn = (...args) => {
+    fn.calls.push(args);
+    return typeof impl === "function" ? impl(...args) : impl;
+  };
+  fn.calls = [];
+  return fn;
+}
+
+describe("WORKER_LABEL_PREFIX", () => {
+  test("is the shared 'worker:' namespace prefix", () => {
+    expect(WORKER_LABEL_PREFIX).toBe("worker:");
+  });
+});
+
+describe("stampWorkerLabel — steady state", () => {
+  test("ticket already carries worker:<hostName> and nothing else — zero writes, stamped:true", () => {
+    const readLabelNodes = recorder({ ok: true, nodes: [{ id: "l1", name: "worker:mini" }] });
+    const applyLabel = recorder({ applied: true });
+    const removeLabel = recorder({ removed: true });
+
+    const res = stampWorkerLabel({ ticket: "CTL-1", hostName: "mini", readLabelNodes, applyLabel, removeLabel });
+
+    expect(res).toEqual({ stamped: true });
+    expect(readLabelNodes.calls.length).toBe(1);
+    expect(applyLabel.calls.length).toBe(0);
+    expect(removeLabel.calls.length).toBe(0);
+  });
+});
+
+describe("stampWorkerLabel — unlabeled ticket", () => {
+  test("no worker:* label present — exactly one apply, no removes", () => {
+    const readLabelNodes = recorder({ ok: true, nodes: [] });
+    const applyLabel = recorder({ applied: true });
+    const removeLabel = recorder({ removed: true });
+
+    const res = stampWorkerLabel({ ticket: "CTL-1", hostName: "mini", readLabelNodes, applyLabel, removeLabel });
+
+    expect(res).toEqual({ stamped: true });
+    expect(removeLabel.calls.length).toBe(0);
+    expect(applyLabel.calls.length).toBe(1);
+    expect(applyLabel.calls[0][0]).toEqual({ ticket: "CTL-1", label: "worker:mini" });
+  });
+});
+
+describe("stampWorkerLabel — swap from a foreign host", () => {
+  test("worker:other present — removes worker:other THEN applies worker:mini, in that order", () => {
+    const order = [];
+    const readLabelNodes = recorder({ ok: true, nodes: [{ id: "l1", name: "worker:other" }] });
+    const removeLabel = recorder((ticket, label) => {
+      order.push(`remove:${label}`);
+      return { removed: true };
+    });
+    const applyLabel = recorder(({ label }) => {
+      order.push(`apply:${label}`);
+      return { applied: true };
+    });
+
+    const res = stampWorkerLabel({ ticket: "CTL-1", hostName: "mini", readLabelNodes, applyLabel, removeLabel });
+
+    expect(res).toEqual({ stamped: true });
+    expect(order).toEqual(["remove:worker:other", "apply:worker:mini"]);
+    expect(removeLabel.calls[0]).toEqual(["CTL-1", "worker:other"]);
+  });
+
+  test("non-worker labels (e.g. a customer/component label) are never touched", () => {
+    const readLabelNodes = recorder({
+      ok: true,
+      nodes: [{ id: "l1", name: "worker:other" }, { id: "l2", name: "bug" }],
+    });
+    const removeLabel = recorder({ removed: true });
+    const applyLabel = recorder({ applied: true });
+
+    stampWorkerLabel({ ticket: "CTL-1", hostName: "mini", readLabelNodes, applyLabel, removeLabel });
+
+    expect(removeLabel.calls.length).toBe(1);
+    expect(removeLabel.calls[0][1]).toBe("worker:other");
+    expect(removeLabel.calls.some((c) => c[1] === "bug")).toBe(false);
+  });
+});
+
+describe("stampWorkerLabel — read failure", () => {
+  test("readLabelNodes reports !ok — no writes attempted, stamped:false", () => {
+    const readLabelNodes = recorder({ ok: false, nodes: null, code: 1, stderr: "boom" });
+    const applyLabel = recorder({ applied: true });
+    const removeLabel = recorder({ removed: true });
+
+    const res = stampWorkerLabel({ ticket: "CTL-1", hostName: "mini", readLabelNodes, applyLabel, removeLabel });
+
+    expect(res).toEqual({ stamped: false, reason: "read-failed" });
+    expect(applyLabel.calls.length).toBe(0);
+    expect(removeLabel.calls.length).toBe(0);
+  });
+});
+
+describe("stampWorkerLabel — applyLabel throws", () => {
+  test("throw is swallowed — stamped:false, no propagation", () => {
+    const readLabelNodes = recorder({ ok: true, nodes: [] });
+    const applyLabel = recorder(() => {
+      throw new Error("linearis exploded");
+    });
+    const removeLabel = recorder({ removed: true });
+
+    let threw = false;
+    let res;
+    try {
+      res = stampWorkerLabel({ ticket: "CTL-1", hostName: "mini", readLabelNodes, applyLabel, removeLabel });
+    } catch {
+      threw = true;
+    }
+
+    expect(threw).toBe(false);
+    expect(res).toEqual({ stamped: false, reason: "apply-threw" });
+  });
+});
+
+describe("stampWorkerLabel — removeLabel fails", () => {
+  test("a failed foreign-label removal aborts the stamp — apply is NEVER attempted", () => {
+    const readLabelNodes = recorder({ ok: true, nodes: [{ id: "l1", name: "worker:other" }] });
+    const removeLabel = recorder({ removed: false, reason: "transient" });
+    const applyLabel = recorder({ applied: true });
+
+    const res = stampWorkerLabel({ ticket: "CTL-1", hostName: "mini", readLabelNodes, applyLabel, removeLabel });
+
+    expect(res).toEqual({ stamped: false, reason: "remove-failed" });
+    expect(applyLabel.calls.length).toBe(0);
+  });
+
+  test("removeLabel throwing also aborts the stamp — apply is NEVER attempted, no propagation", () => {
+    const readLabelNodes = recorder({ ok: true, nodes: [{ id: "l1", name: "worker:other" }] });
+    const removeLabel = recorder(() => {
+      throw new Error("linearis exploded");
+    });
+    const applyLabel = recorder({ applied: true });
+
+    let threw = false;
+    let res;
+    try {
+      res = stampWorkerLabel({ ticket: "CTL-1", hostName: "mini", readLabelNodes, applyLabel, removeLabel });
+    } catch {
+      threw = true;
+    }
+
+    expect(threw).toBe(false);
+    expect(res).toEqual({ stamped: false, reason: "remove-failed" });
+    expect(applyLabel.calls.length).toBe(0);
+  });
+});
+
+describe("stampWorkerLabel — applyLabel reports a non-throw failure", () => {
+  test("applied:false with a reason is surfaced verbatim", () => {
+    const readLabelNodes = recorder({ ok: true, nodes: [] });
+    const applyLabel = recorder({ applied: false, reason: "exclusive-conflict" });
+    const removeLabel = recorder({ removed: true });
+
+    const res = stampWorkerLabel({ ticket: "CTL-1", hostName: "mini", readLabelNodes, applyLabel, removeLabel });
+
+    expect(res).toEqual({ stamped: false, reason: "exclusive-conflict" });
+  });
+});
+
+describe("stampWorkerLabel — thenable removeLabel (the production async-declared shape, CTL-764 round-5 discipline)", () => {
+  test("resolved {removed:true} — apply happens on a microtask, strictly AFTER the confirmed remove", async () => {
+    const readLabelNodes = recorder({ ok: true, nodes: [{ id: "l1", name: "worker:other" }] });
+    const order = [];
+    const removeLabel = recorder((ticket, name) => {
+      order.push(`remove:${name}`);
+      return Promise.resolve({ removed: true });
+    });
+    const applyLabel = recorder(({ label }) => {
+      order.push(`apply:${label}`);
+      return { applied: true };
+    });
+
+    const res = stampWorkerLabel({ ticket: "CTL-1", hostName: "mini", readLabelNodes, applyLabel, removeLabel });
+
+    // Sync caller only learns the swap was deferred; no apply yet.
+    expect(res).toEqual({ stamped: false, reason: "swap-deferred" });
+    expect(applyLabel.calls.length).toBe(0);
+
+    await Promise.resolve(); // drain the confirmation microtask
+    expect(order).toEqual(["remove:worker:other", "apply:worker:mini"]);
+  });
+
+  test("resolved {removed:false} — apply is NEVER attempted (abort survives the async boundary)", async () => {
+    const readLabelNodes = recorder({ ok: true, nodes: [{ id: "l1", name: "worker:other" }] });
+    const removeLabel = recorder(Promise.resolve({ removed: false, reason: "transient" }));
+    const applyLabel = recorder({ applied: true });
+
+    const res = stampWorkerLabel({ ticket: "CTL-1", hostName: "mini", readLabelNodes, applyLabel, removeLabel });
+    expect(res).toEqual({ stamped: false, reason: "swap-deferred" });
+
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(applyLabel.calls.length).toBe(0);
+  });
+
+  test("rejected promise — swallowed, apply is NEVER attempted, nothing propagates", async () => {
+    const readLabelNodes = recorder({ ok: true, nodes: [{ id: "l1", name: "worker:other" }] });
+    const rejection = Promise.reject(new Error("linearis exploded"));
+    rejection.catch(() => {}); // pre-observed so bun doesn't flag an unhandled rejection before stamp attaches its catch
+    const removeLabel = recorder(rejection);
+    const applyLabel = recorder({ applied: true });
+
+    const res = stampWorkerLabel({ ticket: "CTL-1", hostName: "mini", readLabelNodes, applyLabel, removeLabel });
+    expect(res).toEqual({ stamped: false, reason: "swap-deferred" });
+
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(applyLabel.calls.length).toBe(0);
+  });
+});

--- a/plugins/dev/scripts/execution-core/worker-label.test.mjs
+++ b/plugins/dev/scripts/execution-core/worker-label.test.mjs
@@ -68,7 +68,7 @@ describe("stampWorkerLabel — swap from a foreign host", () => {
       return { applied: true };
     });
 
-    const res = stampWorkerLabel({ ticket: "CTL-1", hostName: "mini", readLabelNodes, applyLabel, removeLabel });
+    const res = stampWorkerLabel({ ticket: "CTL-1", hostName: "mini", knownHosts: ["mini", "other"], readLabelNodes, applyLabel, removeLabel });
 
     expect(res).toEqual({ stamped: true });
     expect(order).toEqual(["remove:worker:other", "apply:worker:mini"]);
@@ -83,7 +83,7 @@ describe("stampWorkerLabel — swap from a foreign host", () => {
     const removeLabel = recorder({ removed: true });
     const applyLabel = recorder({ applied: true });
 
-    stampWorkerLabel({ ticket: "CTL-1", hostName: "mini", readLabelNodes, applyLabel, removeLabel });
+    stampWorkerLabel({ ticket: "CTL-1", hostName: "mini", knownHosts: ["other"], readLabelNodes, applyLabel, removeLabel });
 
     expect(removeLabel.calls.length).toBe(1);
     expect(removeLabel.calls[0][1]).toBe("worker:other");
@@ -132,7 +132,7 @@ describe("stampWorkerLabel — removeLabel fails", () => {
     const removeLabel = recorder({ removed: false, reason: "transient" });
     const applyLabel = recorder({ applied: true });
 
-    const res = stampWorkerLabel({ ticket: "CTL-1", hostName: "mini", readLabelNodes, applyLabel, removeLabel });
+    const res = stampWorkerLabel({ ticket: "CTL-1", hostName: "mini", knownHosts: ["other"], readLabelNodes, applyLabel, removeLabel });
 
     expect(res).toEqual({ stamped: false, reason: "remove-failed" });
     expect(applyLabel.calls.length).toBe(0);
@@ -148,7 +148,7 @@ describe("stampWorkerLabel — removeLabel fails", () => {
     let threw = false;
     let res;
     try {
-      res = stampWorkerLabel({ ticket: "CTL-1", hostName: "mini", readLabelNodes, applyLabel, removeLabel });
+      res = stampWorkerLabel({ ticket: "CTL-1", hostName: "mini", knownHosts: ["other"], readLabelNodes, applyLabel, removeLabel });
     } catch {
       threw = true;
     }
@@ -184,7 +184,7 @@ describe("stampWorkerLabel — thenable removeLabel (the production async-declar
       return { applied: true };
     });
 
-    const res = stampWorkerLabel({ ticket: "CTL-1", hostName: "mini", readLabelNodes, applyLabel, removeLabel });
+    const res = stampWorkerLabel({ ticket: "CTL-1", hostName: "mini", knownHosts: ["other"], readLabelNodes, applyLabel, removeLabel });
 
     // Sync caller only learns the swap was deferred; no apply yet.
     expect(res).toEqual({ stamped: false, reason: "swap-deferred" });
@@ -199,7 +199,7 @@ describe("stampWorkerLabel — thenable removeLabel (the production async-declar
     const removeLabel = recorder(Promise.resolve({ removed: false, reason: "transient" }));
     const applyLabel = recorder({ applied: true });
 
-    const res = stampWorkerLabel({ ticket: "CTL-1", hostName: "mini", readLabelNodes, applyLabel, removeLabel });
+    const res = stampWorkerLabel({ ticket: "CTL-1", hostName: "mini", knownHosts: ["other"], readLabelNodes, applyLabel, removeLabel });
     expect(res).toEqual({ stamped: false, reason: "swap-deferred" });
 
     await Promise.resolve();
@@ -214,7 +214,7 @@ describe("stampWorkerLabel — thenable removeLabel (the production async-declar
     const removeLabel = recorder(rejection);
     const applyLabel = recorder({ applied: true });
 
-    const res = stampWorkerLabel({ ticket: "CTL-1", hostName: "mini", readLabelNodes, applyLabel, removeLabel });
+    const res = stampWorkerLabel({ ticket: "CTL-1", hostName: "mini", knownHosts: ["other"], readLabelNodes, applyLabel, removeLabel });
     expect(res).toEqual({ stamped: false, reason: "swap-deferred" });
 
     await Promise.resolve();
@@ -329,14 +329,47 @@ describe("stampWorkerLabel — stale-replica exclusive-conflict live retry (Code
     expect(applyLabel.calls.length).toBe(2); // replica attempt + live attempt, then stop
   });
 
-  test("exclusive-conflict off a LIVE read does not retry (no replica involved)", () => {
+  test("exclusive-conflict retries once even off a LIVE read (roster-limited eager set can miss an in-group sibling)", () => {
     const readLabelNodes = recorder({ ok: true, nodes: [] });
     const applyLabel = recorder({ applied: false, reason: "exclusive-conflict" });
 
     const res = stampWorkerLabel({ ticket: "CTL-1", hostName: "mini", readLabelNodes, applyLabel, removeLabel: recorder({ removed: true }) });
 
     expect(res).toEqual({ stamped: false, reason: "exclusive-conflict" });
-    expect(readLabelNodes.calls.length).toBe(1);
+    expect(readLabelNodes.calls.length).toBe(2); // initial + the one conflict retry
+    expect(applyLabel.calls.length).toBe(2); // first attempt + retry attempt, then stop
+  });
+});
+
+describe("stampWorkerLabel — group-scoped sibling removal (Codex #2650 round-3)", () => {
+  test("an unrelated same-prefix label (worker:frontend, not roster-known) is NEVER removed when the apply succeeds", () => {
+    const readLabelNodes = recorder({ ok: true, nodes: [{ id: "l9", name: "worker:frontend" }] });
+    const removeLabel = recorder({ removed: true });
+    const applyLabel = recorder({ applied: true }); // different group — no exclusive conflict
+
+    const res = stampWorkerLabel({ ticket: "CTL-1", hostName: "mini", knownHosts: ["mini", "mini-2"], readLabelNodes, applyLabel, removeLabel });
+
+    expect(res).toEqual({ stamped: true });
+    expect(removeLabel.calls.length).toBe(0);
     expect(applyLabel.calls.length).toBe(1);
+  });
+
+  test("a decommissioned host's sibling (not in roster) swaps via the conflict-proven retry", () => {
+    // worker:oldhost is OUR group's child but its host left the roster —
+    // the eager pass skips it, the apply conflicts, the retry removes it.
+    const readLabelNodes = recorder({ ok: true, nodes: [{ id: "l1", name: "worker:oldhost" }] });
+    const removeLabel = recorder({ removed: true });
+    let applyCalls = 0;
+    const applyLabel = recorder(() => {
+      applyCalls += 1;
+      return applyCalls === 1 ? { applied: false, reason: "exclusive-conflict" } : { applied: true };
+    });
+
+    const res = stampWorkerLabel({ ticket: "CTL-1", hostName: "mini", knownHosts: ["mini", "mini-2"], readLabelNodes, applyLabel, removeLabel });
+
+    expect(res).toEqual({ stamped: true });
+    expect(removeLabel.calls.length).toBe(1);
+    expect(removeLabel.calls[0][1]).toBe("worker:oldhost");
+    expect(applyLabel.calls.length).toBe(2);
   });
 });

--- a/plugins/dev/scripts/setup-execution-core-states.sh
+++ b/plugins/dev/scripts/setup-execution-core-states.sh
@@ -376,7 +376,9 @@ worker_host_self_name() {
 # a missing or malformed cluster repo/file yields empty output, never an error.
 worker_host_roster() {
 	local cluster_dir cluster_file
-	cluster_dir="${CATALYST_CLUSTER_DIR:-$HOME/catalyst/catalyst-cluster}"
+	# Mirror config.mjs getClusterRepoDir: CATALYST_CLUSTER_DIR, else the
+	# catalyst data dir (CATALYST_DIR, default ~/catalyst) + /catalyst-cluster.
+	cluster_dir="${CATALYST_CLUSTER_DIR:-${CATALYST_DIR:-$HOME/catalyst}/catalyst-cluster}"
 	cluster_file="${cluster_dir}/cluster.json"
 	[[ -f $cluster_file ]] || return 0
 	jq -r '.roster[]?' "$cluster_file" 2>/dev/null || true

--- a/plugins/dev/scripts/setup-execution-core-states.sh
+++ b/plugins/dev/scripts/setup-execution-core-states.sh
@@ -329,6 +329,233 @@ reconcile_worker_status_labels() {
 	return 0
 }
 
+# --- worker:<host> label group reconcile (CTL-1481) -------------------------
+# Idempotently ensures a workspace-scoped exclusive 'worker' label group with
+# one 'worker:<host>' child per cluster host, via issueLabelCreate. Mirrors
+# reconcile_worker_status_labels above exactly in shape and tolerance — this is
+# a best-effort VISIBILITY PROJECTION of which host currently owns/last-claimed
+# a ticket, NEVER the claim arbiter (cluster-claim.mjs's Linear-attachment CAS
+# + generation stay authoritative).
+
+# worker_host_group_name — the workspace-scoped exclusive label group name.
+worker_host_group_name() { echo "worker"; }
+
+# worker_host_color — single hex color shared by every worker:<host> child. An
+# ownership stamp isn't a disposition palette (unlike worker_status_members'
+# 4 distinct colors), so one harmonious color suffices — picked to read
+# distinctly from the existing queued/blocked/needs-input/needs-human hues.
+worker_host_color() { echo "#26a69a"; }
+
+# worker_host_self_name — this host's coordination name. Bash mirror of
+# config.mjs getHostName()'s precedence:
+#   1. CATALYST_HOST_NAME env (test/alias override)
+#   2. catalyst.host.name in the Layer-2 (machine-local) config file
+#   3. hostname, reduced to its first DNS label (strips .local, .rozich, etc.)
+# Never fails — always echoes something.
+worker_host_self_name() {
+	if [[ -n ${CATALYST_HOST_NAME:-} ]]; then
+		echo "$CATALYST_HOST_NAME"
+		return 0
+	fi
+	local layer2 name
+	layer2="${CATALYST_LAYER2_CONFIG_FILE:-$HOME/.config/catalyst/config.json}"
+	if [[ -f $layer2 ]]; then
+		name=$(jq -r '.catalyst.host.name // empty' "$layer2" 2>/dev/null)
+		if [[ -n $name ]]; then
+			echo "$name"
+			return 0
+		fi
+	fi
+	local h
+	h=$(hostname -s 2>/dev/null)
+	[[ -z $h ]] && h=$(hostname 2>/dev/null)
+	echo "${h%%.*}"
+}
+
+# worker_host_roster — cluster.json roster hosts (newline-separated). Fail-soft:
+# a missing or malformed cluster repo/file yields empty output, never an error.
+worker_host_roster() {
+	local cluster_dir cluster_file
+	cluster_dir="${CATALYST_CLUSTER_DIR:-$HOME/catalyst/catalyst-cluster}"
+	cluster_file="${cluster_dir}/cluster.json"
+	[[ -f $cluster_file ]] || return 0
+	jq -r '.roster[]?' "$cluster_file" 2>/dev/null || true
+}
+
+# worker_host_static_roster_env — CATALYST_STATIC_ROSTER escape-hatch leg
+# (CTL-1481 finding 1). Comma-separated host list; mirrors config.mjs
+# getStaticRoster()'s env leg exactly (split, trim, drop blanks). Fail-soft:
+# unset/empty contributes nothing.
+worker_host_static_roster_env() {
+	local env="${CATALYST_STATIC_ROSTER:-}"
+	[[ -z $env ]] && return 0
+	tr ',' '\n' <<<"$env" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//' | awk 'NF'
+}
+
+# worker_host_static_roster_layer2 — catalyst.cluster.staticRoster escape-hatch
+# leg (CTL-1481 finding 1). Mirrors config.mjs getStaticRoster()'s file leg: a
+# JSON array of host-name strings at .catalyst.cluster.staticRoster in the
+# Layer-2 (machine-local) config. Fail-soft: a missing file, malformed JSON,
+# non-array value, or non-string/empty entries contribute nothing.
+worker_host_static_roster_layer2() {
+	local layer2
+	layer2="${CATALYST_LAYER2_CONFIG_FILE:-$HOME/.config/catalyst/config.json}"
+	[[ -f $layer2 ]] || return 0
+	jq -r '.catalyst.cluster.staticRoster // [] | .[] | select(type == "string" and length > 0)' \
+		"$layer2" 2>/dev/null || true
+}
+
+# worker_host_list — union of the cluster.json roster, the
+# CATALYST_STATIC_ROSTER env escape hatch, the Layer-2
+# catalyst.cluster.staticRoster escape hatch, and this host's own name, deduped
+# (newline-separated). CTL-1481 finding 1: unlike config.mjs's
+# resolveClusterHosts (which picks ONE source by precedence for roster
+# membership), label provisioning wants a child label for every host that
+# could ever claim a ticket, so all sources are unioned rather than
+# precedence-selected — over-provisioning a label is harmless and idempotent.
+# Each leg is independently fail-soft; never empty in practice —
+# worker_host_self_name always resolves to something.
+worker_host_list() {
+	{ worker_host_roster
+		worker_host_static_roster_env
+		worker_host_static_roster_layer2
+		worker_host_self_name
+	} | awk 'NF' | sort -u
+}
+
+# build_worker_host_group_create_payload <name> <color>
+# CTL-1481 finding 2: unlike build_issue_label_group_create_mutation above
+# (used only with the static worker-status group name/color literals), the
+# name here is a host-derived string (cluster.json roster / env / Layer-2
+# config) — untrusted input that could contain a double-quote or backslash and
+# break or inject into a spliced-in GraphQL query. So name/color travel as
+# GraphQL variables and the query text stays a fixed string.
+build_worker_host_group_create_payload() {
+	local name="$1" color="$2"
+	jq -nc --arg name "$name" --arg color "$color" '{
+    query: "mutation($name: String!, $color: String!) { issueLabelCreate(input: { name: $name, color: $color }) { success issueLabel { id name } } }",
+    variables: { name: $name, color: $color }
+  }'
+}
+
+# build_worker_host_child_create_payload <name> <color> <parentId>
+# Same variables treatment as build_worker_host_group_create_payload, plus
+# parentId (also untrusted-shaped — derived from the group's resolved id, but
+# kept as a variable for consistency and to avoid re-introducing splicing).
+build_worker_host_child_create_payload() {
+	local name="$1" color="$2" parent_id="$3"
+	jq -nc --arg name "$name" --arg color "$color" --arg parentId "$parent_id" '{
+    query: "mutation($name: String!, $color: String!, $parentId: String!) { issueLabelCreate(input: { name: $name, color: $color, parentId: $parentId }) { success issueLabel { id name } } }",
+    variables: { name: $name, color: $color, parentId: $parentId }
+  }'
+}
+
+# reconcile_worker_host_labels <token>
+# Ensures the workspace-scoped 'worker' group and one 'worker:<host>' child per
+# cluster host exist. Idempotent: re-runs issue zero mutations when all
+# present. Tolerant: any Linear failure WARNs and returns 0 — never alters
+# exit codes 0/2/3/4. CTL-1481 finding 3: every response is checked for valid
+# JSON before `.errors` is consulted — a curl transport failure (timeout, TLS
+# error, connection refused) yields non-JSON text on stdout, and `jq -e
+# '.errors'` on unparseable input silently evaluates falsy, which would read as
+# "no errors" and log a false success.
+reconcile_worker_host_labels() {
+	local token="$1"
+	local group_name
+	group_name=$(worker_host_group_name)
+
+	local hosts
+	hosts=$(worker_host_list)
+	if [[ -z $hosts ]]; then
+		echo "WARNING: reconcile_worker_host_labels: no hosts resolved (empty roster and self) — skipping" >&2
+		return 0
+	fi
+
+	if [[ ${dry_run:-0} -eq 1 ]]; then
+		echo "DRY-RUN: would ensure worker label group (${group_name}) with children: $(echo "$hosts" | tr '\n' ' ')"
+		return 0
+	fi
+
+	# Query workspace labels (team:null = workspace-scoped, not per-team).
+	local query payload resp
+	query='query { issueLabels(filter: {team: {null: true}}, first: 250) { nodes { id name isGroup parent { id } } } }'
+	payload=$(jq -nc --arg q "$query" '{query: $q}')
+	resp=$(linear_graphql_post "$token" "$payload")
+
+	if ! jq -e . >/dev/null 2>&1 <<<"$resp"; then
+		echo "WARNING: reconcile_worker_host_labels: non-JSON/transport response — skipping" >&2
+		return 0
+	fi
+
+	if echo "$resp" | jq -e '.errors' >/dev/null 2>&1; then
+		local err
+		err=$(echo "$resp" | jq -r '.errors[0].message // "unknown error"')
+		echo "WARNING: reconcile_worker_host_labels: could not query workspace labels: ${err}" >&2
+		return 0
+	fi
+
+	# Parse the response into a JSON array once; all subsequent lookups use jq over this.
+	local labels_json
+	labels_json=$(echo "$resp" | jq -c '.data.issueLabels.nodes // []')
+
+	# Find the existing workspace parent by name at the top level (parent == null).
+	# Same #2631 rationale as reconcile_worker_status_labels: match on parent==null,
+	# NOT isGroup==true, so a partial-failure re-run (parent created, no child
+	# attached yet) is found rather than re-created.
+	local group_id
+	group_id=$(echo "$labels_json" | jq -r --arg n "$group_name" \
+		'.[] | select(.name == $n and .parent == null) | .id // empty' | head -1)
+
+	if [[ -z $group_id ]]; then
+		# Create the group (workspace-scoped, plain label — no isGroup, no teamId).
+		local group_payload group_resp
+		group_payload=$(build_worker_host_group_create_payload "$group_name" "$(worker_host_color)")
+		group_resp=$(linear_graphql_post "$token" "$group_payload")
+		if ! jq -e . >/dev/null 2>&1 <<<"$group_resp"; then
+			echo "WARNING: reconcile_worker_host_labels: non-JSON/transport response — skipping" >&2
+			return 0
+		fi
+		if echo "$group_resp" | jq -e '.errors' >/dev/null 2>&1; then
+			local group_err
+			group_err=$(echo "$group_resp" | jq -r '.errors[0].message // "unknown error"')
+			echo "WARNING: reconcile_worker_host_labels: could not create group '${group_name}': ${group_err}" >&2
+			return 0
+		fi
+		group_id=$(echo "$group_resp" | jq -r '.data.issueLabelCreate.issueLabel.id // empty')
+		echo "reconcile_worker_host_labels: created group '${group_name}' (id: ${group_id})"
+	else
+		echo "reconcile_worker_host_labels: group '${group_name}' already present (id: ${group_id})"
+	fi
+
+	# Create only missing children (one per host, name "worker:<host>").
+	local host_name
+	while IFS= read -r host_name; do
+		[[ -z $host_name ]] && continue
+		local child_name already
+		child_name="worker:${host_name}"
+		already=$(echo "$labels_json" | jq -r --arg n "$child_name" --arg pid "$group_id" \
+			'.[] | select(.name == $n and .parent.id == $pid) | .name // empty' | head -1)
+		if [[ -n $already ]]; then continue; fi
+
+		local child_payload child_resp
+		child_payload=$(build_worker_host_child_create_payload "$child_name" "$(worker_host_color)" "$group_id")
+		child_resp=$(linear_graphql_post "$token" "$child_payload")
+		if ! jq -e . >/dev/null 2>&1 <<<"$child_resp"; then
+			echo "WARNING: reconcile_worker_host_labels: non-JSON/transport response for '${child_name}' — skipping" >&2
+			continue
+		fi
+		if echo "$child_resp" | jq -e '.errors' >/dev/null 2>&1; then
+			local child_err
+			child_err=$(echo "$child_resp" | jq -r '.errors[0].message // "unknown error"')
+			echo "WARNING: reconcile_worker_host_labels: could not create '${child_name}': ${child_err}" >&2
+		else
+			echo "reconcile_worker_host_labels: created child '${child_name}' under '${group_name}'"
+		fi
+	done <<<"$hosts"
+
+	return 0
+}
+
 # --- Linear git-automation reconcile (CTL-759) ------------------------------
 # reconcile_git_automation_states <team_id> <token> <fetched_states_json>
 #
@@ -731,6 +958,11 @@ main() {
 	# Must run before git automations so the group exists before the daemon starts
 	# applying labels. Best-effort — never alters exit codes 0/2/3/4.
 	reconcile_worker_status_labels "$token" || true
+
+	# --- reconcile worker:<host> label group (CTL-1481) ------------------------
+	# Best-effort visibility projection — never gates the exit code. Runs right
+	# after the worker-status reconcile (same install-time step, same tolerance).
+	reconcile_worker_host_labels "$token" || true
 
 	# --- reconcile Linear git automations (CTL-759) — the LAST Linear step ---
 	# Best-effort hardening: pins start→PR / merge→Done and removes any review

--- a/plugins/dev/scripts/setup-execution-core-states.sh
+++ b/plugins/dev/scripts/setup-execution-core-states.sh
@@ -480,7 +480,10 @@ reconcile_worker_host_labels() {
 
 	# Query workspace labels (team:null = workspace-scoped, not per-team).
 	local query payload resp
-	query='query { issueLabels(filter: {team: {null: true}}, first: 250) { nodes { id name isGroup parent { id } } } }'
+	# Narrowed server-side to names starting "worker" so the group + every
+	# worker:<host> child always fit one page — a >250-label workspace cannot
+	# push them past the first-page bound (Codex #2650 round-3).
+	query='query { issueLabels(filter: {team: {null: true}, name: {startsWith: "worker"}}, first: 250) { nodes { id name isGroup parent { id } } } }'
 	payload=$(jq -nc --arg q "$query" '{query: $q}')
 	resp=$(linear_graphql_post "$token" "$payload")
 


### PR DESCRIPTION
## Summary

Operators can now see **which worker node owns each in-flight ticket** directly on the Linear board: a host stamps a workspace-level single-select `worker:<host>` label (e.g. `worker:mini`) on a ticket the moment it wins the cluster claim. Ownership becomes board-filterable and replica-readable ("who owns X" = local SQLite read, no live Linear call).

**The hard constraint (by design):** the label is a best-effort **visibility projection, never the claim arbiter**. The claim/fence CAS + generation stay entirely on `cluster-claim.mjs` / the #2553 event-log fence. Every stamp is wrapped so a failure logs and the claim stands.

## Write-test verdict (live probe, 2026-07-14, auto-cleaned)

- Linear **server-enforces single-select as REJECT** (`"labelIds not exclusive child labels"`) — fail-closed; two hosts can never both appear as owner.
- Swaps therefore go **remove-old-then-add** through the existing linearis-based `applyLabel`/`removeLabel` machinery (the same production path the `worker-status` group uses), with **thenable-aware remove confirmation** (CTL-764 round-5 discipline) so a failed remove aborts the apply in production too.
- Duplicate label names are case-insensitively rejected; `isGroup` on IssueLabelCreateInput is accepted today (schema drift since CTL-764 finding A) but provisioning keeps the drift-proof plain-parent shape.

## The four pieces

1. **`worker-label.mjs` (new leaf module)** — `stampWorkerLabel`: never throws; steady state = 1 read, 0 writes. Wired at the three claim-win sites (scheduler new-work `claimDispatch`, monitor `dispatchTriage`, recovery `reclaimDeadHostWork` takeover), multi-host gated (single-host = exact no-op), placed **after** the Axis-1 `applyPhaseStatus`/self-assign writes so a stamp-tripped breaker can't starve them within the same tick.
2. **`setup-execution-core-states.sh`** — `reconcile_worker_host_labels`: idempotent workspace `worker` group + `worker:<host>` child per host. Host set = `cluster.json` roster ∪ `CATALYST_STATIC_ROSTER` ∪ Layer-2 `staticRoster` ∪ self (all legs fail-soft; union not precedence — over-provisioning a label is harmless). Host names travel as **GraphQL variables** (no query-text splicing); non-JSON transport responses are guarded; WARN-and-continue everywhere; the 0/2/3/4 exit-code contract is untouched.
3. **`doctor.mjs` `checkWorkerLabels`** — advisory (**never FAIL**; doctor exit gates activation), single-host/no-token INFO gates, asserts group + per-roster-host children, remediation points at the setup script. Names are **imported** from `worker-label.mjs` so doctor can't drift from the stamper. Doctor does not mutate Linear (repo convention — the setup script is the writer).
4. **`replica-read.mjs` `labels(identifier)`** — per-issue label list with `ownership()`'s dual gate (writer-liveness + seed-completeness in one snapshot): `[{id,name}]` sorted, `[]` = authoritative empty, `undefined` = miss/gate-fail. Tombstone-filtered on both `issues.removed_at` and `labels.removed_at` (deliberate new decision, documented + tested). This is the replica read CTL-DELEGATE's A4 read-burden win expects.

## Testing

- `worker-label.test.mjs` 13/13 (incl. thenable remove: confirmed-remove→apply order across the microtask boundary, failed/rejected remove never applies).
- Combined targeted run **523/523** (worker-label, replica-read, cluster-claim, doctor-replica, doctor-worker-labels, doctor, monitor).
- `setup-execution-core-states.test.sh` **114 passed / 2 failed** — the 2 are pre-existing `missing-pino` failures, byte-identical on pristine main.
- scheduler/recovery suites: failure sets byte-identical to pristine main (pre-existing CTL-781/CTL-736/CTL-587/CTL-638 flaky clusters; verified by running both suites on main).
- Pre-existing tests that reach claim-win branches were retrofitted with stamp stubs — they were otherwise making **live linearis calls** from unit tests once the stamp default existed.

## Deploy plan (post-merge)

Fleet hotpatch coordinated with CTL-DELEGATE on the ops channel; then **deploy-and-observe**: run the setup provisioning once, watch a real claim-win stamp `worker:<host>` in the Linear UI, and confirm the label lands in `catalyst-replica.db` (`issue_labels ⋈ labels`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LGxuk8b38n7yDXv1UoSkSD