### PR TITLE
fix(dev): CTL-1481 follow-up — worker group create needs isGroup:true (live API drift)

### DIFF
--- a/plugins/dev/scripts/__tests__/setup-execution-core-states.test.sh
+++ b/plugins/dev/scripts/__tests__/setup-execution-core-states.test.sh
@@ -1077,6 +1077,88 @@ run "child create-failure: worker:host-a is attempted" \
 run "child create-failure: worker:host-b is attempted" \
 	bash -c "grep 'issueLabelCreate' '$WH_T8_LOG' | grep -q 'worker:host-b'"
 
+# Test 9: adopted PLAIN parent (isGroup:false) is upgraded via issueLabelUpdate
+# before children attach — the live API rejects child creates against a
+# non-group parent ("parent label is not a group", observed 2026-07-15).
+WH_T9_BIN="${SCRATCH}/wh-t9/bin"
+WH_T9_LOG="${SCRATCH}/wh-t9/req.log"
+mkdir -p "${SCRATCH}/wh-t9" "$WH_T9_BIN"
+: >"$WH_T9_LOG"
+WH_T9_NODES='[{"id":"grp-plain","name":"worker","isGroup":false,"parent":null}]'
+cat >"${WH_T9_BIN}/curl" <<SCRIPT
+#!/usr/bin/env bash
+body=""
+for a in "\$@"; do case "\$a" in {*) body="\$a";; esac; done
+if [ -z "\$body" ]; then body="\$(cat 2>/dev/null)"; fi
+echo "\$body" >> "${WH_T9_LOG}"
+case "\$body" in
+  *issueLabelUpdate*) echo '{"data":{"issueLabelUpdate":{"success":true,"issueLabel":{"id":"grp-plain","isGroup":true}}}}' ;;
+  *issueLabelCreate*) echo '{"data":{"issueLabelCreate":{"success":true,"issueLabel":{"id":"new-lbl-id","name":"x"}}}}' ;;
+  *) echo '{"data":{"issueLabels":{"nodes":${WH_T9_NODES}}}}' ;;
+esac
+exit 0
+SCRIPT
+chmod +x "${WH_T9_BIN}/curl"
+(
+	# shellcheck source=/dev/null
+	source "$SCRIPT"
+	PATH="$WH_T9_BIN:$PATH"
+	CATALYST_HOST_NAME="testhost"
+	CATALYST_CLUSTER_DIR="${SCRATCH}/wh-t9-nocluster"
+	dry_run=0
+	reconcile_worker_host_labels "fake-token"
+) >"${SCRATCH}/wh-t9-out" 2>&1
+WH_T9_RC=$?
+
+run "plain-parent upgrade: issues exactly one issueLabelUpdate with isGroup" \
+	bash -c "count=\$(grep -c 'issueLabelUpdate' '$WH_T9_LOG' 2>/dev/null || echo 0); [ \"\$count\" = '1' ] && grep 'issueLabelUpdate' '$WH_T9_LOG' | grep -q 'isGroup'"
+
+run "plain-parent upgrade: child create still attempted after the upgrade" \
+	bash -c "grep 'issueLabelCreate' '$WH_T9_LOG' | grep -q 'worker:testhost'"
+
+run "plain-parent upgrade: returns 0" \
+	bash -c "[ '$WH_T9_RC' = '0' ]"
+
+# Test 10: an API generation that REJECTS the isGroup input field (the
+# CTL-764 #2631-era behavior) gets the plain-create fallback.
+WH_T10_BIN="${SCRATCH}/wh-t10/bin"
+WH_T10_LOG="${SCRATCH}/wh-t10/req.log"
+mkdir -p "${SCRATCH}/wh-t10" "$WH_T10_BIN"
+: >"$WH_T10_LOG"
+cat >"${WH_T10_BIN}/curl" <<SCRIPT
+#!/usr/bin/env bash
+body=""
+for a in "\$@"; do case "\$a" in {*) body="\$a";; esac; done
+if [ -z "\$body" ]; then body="\$(cat 2>/dev/null)"; fi
+echo "\$body" >> "${WH_T10_LOG}"
+case "\$body" in
+  *issueLabelCreate*isGroup*) echo '{"errors":[{"message":"Field \\"isGroup\\" is not defined by type IssueLabelCreateInput"}]}' ;;
+  *issueLabelCreate*) echo '{"data":{"issueLabelCreate":{"success":true,"issueLabel":{"id":"new-lbl-id","name":"x"}}}}' ;;
+  *) echo '{"data":{"issueLabels":{"nodes":[]}}}' ;;
+esac
+exit 0
+SCRIPT
+chmod +x "${WH_T10_BIN}/curl"
+(
+	# shellcheck source=/dev/null
+	source "$SCRIPT"
+	PATH="$WH_T10_BIN:$PATH"
+	CATALYST_HOST_NAME="testhost"
+	CATALYST_CLUSTER_DIR="${SCRATCH}/wh-t10-nocluster"
+	dry_run=0
+	reconcile_worker_host_labels "fake-token"
+) >"${SCRATCH}/wh-t10-out" 2>&1
+WH_T10_RC=$?
+
+run "isGroup-rejected fallback: 3 issueLabelCreate calls (isGroup attempt + plain retry + child)" \
+	bash -c "count=\$(grep -c 'issueLabelCreate' '$WH_T10_LOG' 2>/dev/null || echo 0); [ \"\$count\" = '3' ]"
+
+run "isGroup-rejected fallback: the child create still lands (worker:testhost)" \
+	bash -c "grep 'issueLabelCreate' '$WH_T10_LOG' | grep -q 'worker:testhost'"
+
+run "isGroup-rejected fallback: returns 0" \
+	bash -c "[ '$WH_T10_RC' = '0' ]"
+
 echo ""
 echo "Results: ${PASSES} passed, ${FAILURES} failed"
 [ "$FAILURES" = "0" ]

--- a/plugins/dev/scripts/setup-execution-core-states.sh
+++ b/plugins/dev/scripts/setup-execution-core-states.sh
@@ -435,8 +435,33 @@ worker_host_list() {
 build_worker_host_group_create_payload() {
 	local name="$1" color="$2"
 	jq -nc --arg name "$name" --arg color "$color" '{
+    query: "mutation($name: String!, $color: String!) { issueLabelCreate(input: { name: $name, color: $color, isGroup: true }) { success issueLabel { id name } } }",
+    variables: { name: $name, color: $color }
+  }'
+}
+
+# build_worker_host_group_create_payload_plain <name> <color>
+# The pre-drift shape (no isGroup) — the fallback when the API generation
+# rejects the isGroup input field (the CTL-764 #2631-era behavior). See the
+# group-create fallback in reconcile_worker_host_labels.
+build_worker_host_group_create_payload_plain() {
+	local name="$1" color="$2"
+	jq -nc --arg name "$name" --arg color "$color" '{
     query: "mutation($name: String!, $color: String!) { issueLabelCreate(input: { name: $name, color: $color }) { success issueLabel { id name } } }",
     variables: { name: $name, color: $color }
+  }'
+}
+
+# build_worker_host_group_upgrade_payload <labelId>
+# issueLabelUpdate isGroup:true — upgrades an adopted plain parent (a
+# pre-drift partial run, or a customer label adopted by name) so children can
+# attach: the live API now REJECTS issueLabelCreate(parentId:) against a
+# non-group parent ("parent label is not a group", observed 2026-07-15).
+build_worker_host_group_upgrade_payload() {
+	local label_id="$1"
+	jq -nc --arg id "$label_id" '{
+    query: "mutation($id: String!) { issueLabelUpdate(id: $id, input: { isGroup: true }) { success issueLabel { id isGroup } } }",
+    variables: { id: $id }
   }'
 }
 
@@ -504,15 +529,21 @@ reconcile_worker_host_labels() {
 	labels_json=$(echo "$resp" | jq -c '.data.issueLabels.nodes // []')
 
 	# Find the existing workspace parent by name at the top level (parent == null).
-	# Same #2631 rationale as reconcile_worker_status_labels: match on parent==null,
-	# NOT isGroup==true, so a partial-failure re-run (parent created, no child
-	# attached yet) is found rather than re-created.
-	local group_id
+	# Same #2631 rationale as reconcile_worker_status_labels: match on parent==null
+	# (not isGroup==true) so a partial-failure prior run — or a customer's plain
+	# label adopted by name — is found rather than re-created.
+	local group_id group_is_group
 	group_id=$(echo "$labels_json" | jq -r --arg n "$group_name" \
 		'.[] | select(.name == $n and .parent == null) | .id // empty' | head -1)
+	group_is_group=$(echo "$labels_json" | jq -r --arg n "$group_name" \
+		'.[] | select(.name == $n and .parent == null) | .isGroup // false' | head -1)
 
 	if [[ -z $group_id ]]; then
-		# Create the group (workspace-scoped, plain label — no isGroup, no teamId).
+		# Create the group with isGroup:true — the live API REJECTS attaching a
+		# child to a non-group parent ("parent label is not a group", observed
+		# 2026-07-15; inverts the CTL-764 #2631-era behavior where isGroup was
+		# itself rejected). If THIS API generation rejects the isGroup field,
+		# fall back to the pre-drift plain create.
 		local group_payload group_resp
 		group_payload=$(build_worker_host_group_create_payload "$group_name" "$(worker_host_color)")
 		group_resp=$(linear_graphql_post "$token" "$group_payload")
@@ -523,13 +554,39 @@ reconcile_worker_host_labels() {
 		if echo "$group_resp" | jq -e '.errors' >/dev/null 2>&1; then
 			local group_err
 			group_err=$(echo "$group_resp" | jq -r '.errors[0].message // "unknown error"')
-			echo "WARNING: reconcile_worker_host_labels: could not create group '${group_name}': ${group_err}" >&2
-			return 0
+			if [[ $group_err == *isGroup* ]]; then
+				echo "reconcile_worker_host_labels: isGroup rejected by this API generation — retrying plain create" >&2
+				group_payload=$(build_worker_host_group_create_payload_plain "$group_name" "$(worker_host_color)")
+				group_resp=$(linear_graphql_post "$token" "$group_payload")
+				if ! jq -e . >/dev/null 2>&1 <<<"$group_resp" || echo "$group_resp" | jq -e '.errors' >/dev/null 2>&1; then
+					group_err=$(echo "$group_resp" | jq -r '.errors[0].message // "transport/non-JSON"' 2>/dev/null)
+					echo "WARNING: reconcile_worker_host_labels: could not create group '${group_name}': ${group_err}" >&2
+					return 0
+				fi
+			else
+				echo "WARNING: reconcile_worker_host_labels: could not create group '${group_name}': ${group_err}" >&2
+				return 0
+			fi
 		fi
 		group_id=$(echo "$group_resp" | jq -r '.data.issueLabelCreate.issueLabel.id // empty')
 		echo "reconcile_worker_host_labels: created group '${group_name}' (id: ${group_id})"
 	else
 		echo "reconcile_worker_host_labels: group '${group_name}' already present (id: ${group_id})"
+		if [[ $group_is_group != "true" ]]; then
+			# Adopted plain parent (pre-drift partial run or a same-name customer
+			# label): upgrade it to a group so the child creates below can attach.
+			# WARN-and-continue on failure — the per-child WARNs then surface it.
+			local upgrade_payload upgrade_resp
+			upgrade_payload=$(build_worker_host_group_upgrade_payload "$group_id")
+			upgrade_resp=$(linear_graphql_post "$token" "$upgrade_payload")
+			if ! jq -e . >/dev/null 2>&1 <<<"$upgrade_resp" || echo "$upgrade_resp" | jq -e '.errors' >/dev/null 2>&1; then
+				local upgrade_err
+				upgrade_err=$(echo "$upgrade_resp" | jq -r '.errors[0].message // "transport/non-JSON"' 2>/dev/null)
+				echo "WARNING: reconcile_worker_host_labels: could not upgrade '${group_name}' to a group: ${upgrade_err}" >&2
+			else
+				echo "reconcile_worker_host_labels: upgraded plain '${group_name}' to a group (isGroup:true)"
+			fi
+		fi
 	fi
 
 	# Create only missing children (one per host, name "worker:<host>").


### PR DESCRIPTION
## Summary

Deploy-and-observe of #2650 caught a **second live Linear API drift** the units couldn't: `issueLabelCreate` with `parentId` against a non-group parent is now **rejected** (`"parent label is not a group"`), inverting the CTL-764 / #2631-era behavior where `isGroup` itself was the rejected input field. The fresh-workspace provisioning path created a plain `worker` label whose children could never attach.

## Fix (drift-proof in both directions)

- Group create sends `isGroup: true`; if the API generation rejects that field (the pre-drift behavior), retry with the plain create.
- An adopted plain parent (pre-drift partial run, or a same-name customer label) is upgraded to a group via `issueLabelUpdate` before children attach — WARN-and-continue on failure, exit-code contract untouched.

## Live state

Workspace provisioning was completed manually during the deploy: group `worker` (isGroup:true) + `worker:laptop` / `worker:mini` / `worker:mini-2` all verified present in Linear. (En route, the colliding CTC team component label was renamed `worker` → `cloud-worker`; label ID and ticket attachments preserved.) This fix makes fresh installs and new-node joins do the same unattended.

Note: `reconcile_worker_status_labels` (the CTL-764 sibling) has the same latent fresh-workspace break under the new API generation — tracked separately, since its behavior is pinned by its own test set and every existing workspace already has the group.

## Testing

- New T9: adopted plain parent → exactly one `issueLabelUpdate` with `isGroup`, children still attach, rc=0.
- New T10: `isGroup`-rejecting API generation → plain-create fallback (3 creates: rejected attempt + plain retry + child), rc=0.
- Full suite: **120 passed / 2 failed** — the 2 are the pre-existing `missing-pino` failures, byte-identical on main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LGxuk8b38n7yDXv1UoSkSD