### PR TITLE
fix(dev): CTL-1483 mirror isGroup:true fix to reconcile_worker_status_labels

### DIFF
--- a/plugins/dev/scripts/__tests__/setup-execution-core-states.test.sh
+++ b/plugins/dev/scripts/__tests__/setup-execution-core-states.test.sh
@@ -570,10 +570,10 @@ WS_GRP_MUT_VAL="$(source "$SCRIPT" && build_issue_label_group_create_mutation 'w
 run "build_issue_label_group_create_mutation: contains issueLabelCreate" \
 	bash -c "echo '$WS_GRP_MUT_VAL' | grep -q 'issueLabelCreate'"
 
-# CTL-764 finding A: the group is created as a plain workspace label — sending isGroup:true
-# is rejected by IssueLabelCreateInput and aborts the reconcile before any child is created.
-run "build_issue_label_group_create_mutation: omits isGroup (rejected by IssueLabelCreateInput)" \
-	bash -c "! echo '$WS_GRP_MUT_VAL' | grep -q 'isGroup'"
+# CTL-1483: the live API now REQUIRES isGroup:true on the parent create — a plain
+# parent rejects child attaches ("parent label is not a group"). Inverts the #2631 shape.
+run "build_issue_label_group_create_mutation: sets isGroup:true (required by the live API)" \
+	bash -c "echo '$WS_GRP_MUT_VAL' | grep -q 'isGroup'"
 
 run "build_issue_label_group_create_mutation: omits teamId (workspace scope)" \
 	bash -c "! echo '$WS_GRP_MUT_VAL' | grep -q 'teamId'"
@@ -635,6 +635,7 @@ for a in "\$@"; do case "\$a" in {*) body="\$a";; esac; done
 if [ -z "\$body" ]; then body="\$(cat 2>/dev/null)"; fi
 echo "\$body" >> "${log}"
 case "\$body" in
+  *issueLabelUpdate*) echo '{"data":{"issueLabelUpdate":{"success":true,"issueLabel":{"id":"grp-ws","isGroup":true}}}}' ;;
   *issueLabelCreate*) echo '${create_resp}' ;;
   *) echo '${query_resp}' ;;
 esac
@@ -766,6 +767,84 @@ run "plain-label parent: found by name+parent==null, creates the 4 children (4 i
 
 run "plain-label parent: never re-creates the group (every create carries parentId)" \
 	bash -c "! grep 'issueLabelCreate' '$WS_T6_LOG' | grep -qv 'parentId'"
+
+run "plain-label parent: issues exactly one issueLabelUpdate to upgrade the group" \
+	bash -c "count=\$(grep -c 'issueLabelUpdate' '$WS_T6_LOG' 2>/dev/null || echo 0); [ \"\$count\" = '1' ]"
+
+# Test 9 (CTL-1483): adopted PLAIN parent (isGroup:false) is upgraded via issueLabelUpdate
+# before children attach — mirrors WH_T9, but for the worker-status reconciler.
+WS_T9_BIN="${SCRATCH}/ws-t9/bin"
+WS_T9_LOG="${SCRATCH}/ws-t9/req.log"
+mkdir -p "${SCRATCH}/ws-t9" "$WS_T9_BIN"
+: >"$WS_T9_LOG"
+WS_T9_NODES='[{"id":"grp-plain","name":"worker-status","isGroup":false,"parent":null}]'
+cat >"${WS_T9_BIN}/curl" <<SCRIPT
+#!/usr/bin/env bash
+body=""
+for a in "\$@"; do case "\$a" in {*) body="\$a";; esac; done
+if [ -z "\$body" ]; then body="\$(cat 2>/dev/null)"; fi
+echo "\$body" >> "${WS_T9_LOG}"
+case "\$body" in
+  *issueLabelUpdate*) echo '{"data":{"issueLabelUpdate":{"success":true,"issueLabel":{"id":"grp-plain","isGroup":true}}}}' ;;
+  *issueLabelCreate*) echo '{"data":{"issueLabelCreate":{"success":true,"issueLabel":{"id":"new-lbl-id","name":"x"}}}}' ;;
+  *) echo '{"data":{"issueLabels":{"nodes":${WS_T9_NODES}}}}' ;;
+esac
+exit 0
+SCRIPT
+chmod +x "${WS_T9_BIN}/curl"
+(
+	# shellcheck source=/dev/null
+	source "$SCRIPT"
+	PATH="$WS_T9_BIN:$PATH"
+	dry_run=0
+	reconcile_worker_status_labels "fake-token"
+) >"${SCRATCH}/ws-t9-out" 2>&1
+WS_T9_RC=$?
+
+run "WS plain-parent upgrade: issues exactly one issueLabelUpdate with isGroup" \
+	bash -c "count=\$(grep -c 'issueLabelUpdate' '$WS_T9_LOG' 2>/dev/null || echo 0); [ \"\$count\" = '1' ] && grep 'issueLabelUpdate' '$WS_T9_LOG' | grep -q 'isGroup'"
+
+run "WS plain-parent upgrade: 4 child creates still attempted after the upgrade" \
+	bash -c "count=\$(grep -c 'issueLabelCreate' '$WS_T9_LOG' 2>/dev/null || echo 0); [ \"\$count\" = '4' ]"
+
+run "WS plain-parent upgrade: returns 0" bash -c "[ '$WS_T9_RC' = '0' ]"
+
+# Test 10 (CTL-1483): an API generation that REJECTS the isGroup input field gets the
+# plain-create fallback — mirrors WH_T10, but 4 children vs 1.
+WS_T10_BIN="${SCRATCH}/ws-t10/bin"
+WS_T10_LOG="${SCRATCH}/ws-t10/req.log"
+mkdir -p "${SCRATCH}/ws-t10" "$WS_T10_BIN"
+: >"$WS_T10_LOG"
+cat >"${WS_T10_BIN}/curl" <<SCRIPT
+#!/usr/bin/env bash
+body=""
+for a in "\$@"; do case "\$a" in {*) body="\$a";; esac; done
+if [ -z "\$body" ]; then body="\$(cat 2>/dev/null)"; fi
+echo "\$body" >> "${WS_T10_LOG}"
+case "\$body" in
+  *issueLabelCreate*isGroup*) echo '{"errors":[{"message":"Field \"isGroup\" is not defined by type IssueLabelCreateInput"}]}' ;;
+  *issueLabelCreate*) echo '{"data":{"issueLabelCreate":{"success":true,"issueLabel":{"id":"new-lbl-id","name":"x"}}}}' ;;
+  *) echo '{"data":{"issueLabels":{"nodes":[]}}}' ;;
+esac
+exit 0
+SCRIPT
+chmod +x "${WS_T10_BIN}/curl"
+(
+	# shellcheck source=/dev/null
+	source "$SCRIPT"
+	PATH="$WS_T10_BIN:$PATH"
+	dry_run=0
+	reconcile_worker_status_labels "fake-token"
+) >"${SCRATCH}/ws-t10-out" 2>&1
+WS_T10_RC=$?
+
+run "WS isGroup-rejected fallback: 6 issueLabelCreate calls (isGroup attempt + plain retry + 4 children)" \
+	bash -c "count=\$(grep -c 'issueLabelCreate' '$WS_T10_LOG' 2>/dev/null || echo 0); [ \"\$count\" = '6' ]"
+
+run "WS isGroup-rejected fallback: a child create lands (queued)" \
+	bash -c "grep 'issueLabelCreate' '$WS_T10_LOG' | grep -q 'queued'"
+
+run "WS isGroup-rejected fallback: returns 0" bash -c "[ '$WS_T10_RC' = '0' ]"
 
 # ─── Phase 2 (CTL-1481): worker:<host> label group ───────────────────────────
 # Unit tests for pure helpers (script already sourced above).

--- a/plugins/dev/scripts/setup-execution-core-states.sh
+++ b/plugins/dev/scripts/setup-execution-core-states.sh
@@ -198,11 +198,31 @@ worker_status_members() {
 # build_issue_label_group_create_mutation <name> <color>
 # Workspace-scoped: omits teamId so Linear assigns the label to the workspace,
 # not a specific team (the daemon applies via linearis which lists workspace labels).
-# CTL-764 finding A: creates the parent as a PLAIN workspace label — IssueLabelCreateInput
-# accepts only id/name/description/color/parentId/teamId, so sending isGroup:true is
-# rejected and the whole reconcile aborts before any child is created. A Linear label
-# becomes a group implicitly the moment a child is created with its parentId (below).
+# CTL-1483: the live API now REQUIRES isGroup:true on the parent create — a plain parent
+# rejects child attaches ("parent label is not a group", observed 2026-07-15). Inverts
+# the CTL-764 #2631-era shape. See build_worker_host_group_create_payload for the
+# variable-form twin (used where name/color are host-derived untrusted input).
 build_issue_label_group_create_mutation() {
+	local name="$1" color="$2"
+	cat <<MUTATION
+mutation {
+  issueLabelCreate(input: {
+    name: "${name}",
+    color: "${color}",
+    isGroup: true
+  }) {
+    success
+    issueLabel { id name }
+  }
+}
+MUTATION
+}
+
+# build_issue_label_group_create_mutation_plain <name> <color>
+# The pre-drift shape (no isGroup) — fallback when the API generation rejects the
+# isGroup input field (the CTL-764 #2631-era behavior). See build_worker_host_group_create_payload_plain
+# for the variable-form twin.
+build_issue_label_group_create_mutation_plain() {
 	local name="$1" color="$2"
 	cat <<MUTATION
 mutation {
@@ -215,6 +235,18 @@ mutation {
   }
 }
 MUTATION
+}
+
+# build_issue_label_group_upgrade_mutation <labelId>
+# issueLabelUpdate isGroup:true — upgrades an adopted plain parent so children can attach.
+# Returns a wrapped {query,variables} JSON envelope (pass directly to linear_graphql_post,
+# do NOT re-wrap). See build_worker_host_group_upgrade_payload for the variable-form twin.
+build_issue_label_group_upgrade_mutation() {
+	local label_id="$1"
+	jq -nc --arg id "$label_id" '{
+    query: "mutation($id: String!) { issueLabelUpdate(id: $id, input: { isGroup: true }) { success issueLabel { id isGroup } } }",
+    variables: { id: $id }
+  }'
 }
 
 # build_issue_label_child_create_mutation <name> <color> <parentId>
@@ -255,6 +287,13 @@ reconcile_worker_status_labels() {
 	payload=$(jq -nc --arg q "$query" '{query: $q}')
 	resp=$(linear_graphql_post "$token" "$payload")
 
+	# 4a: transport validation before .errors — a curl failure yields non-JSON text
+	# (mirrors reconcile_worker_host_labels :515-518).
+	if ! jq -e . >/dev/null 2>&1 <<<"$resp"; then
+		echo "WARNING: reconcile_worker_status_labels: non-JSON/transport response — skipping" >&2
+		return 0
+	fi
+
 	if echo "$resp" | jq -e '.errors' >/dev/null 2>&1; then
 		local err
 		err=$(echo "$resp" | jq -r '.errors[0].message // "unknown error"')
@@ -267,30 +306,64 @@ reconcile_worker_status_labels() {
 	labels_json=$(echo "$resp" | jq -c '.data.issueLabels.nodes // []')
 
 	# Find the existing workspace parent by name at the top level (parent == null).
-	# CTL-764 finding A: match on parent==null, NOT isGroup==true — a freshly-created
-	# parent is a plain label (isGroup false) until its first child attaches and Linear
-	# flips it to a group, so requiring isGroup would miss a parent whose child creation
-	# partially failed and wrongly re-issue a duplicate create.
-	local group_id
+	# Match on parent==null, NOT isGroup==true — a partial-failure prior run may have
+	# created the parent without isGroup (or without children), and requiring isGroup
+	# would wrongly re-create a duplicate.
+	# 4b: also extract group_is_group for the upgrade branch below (mirrors host :535-539).
+	local group_id group_is_group
 	group_id=$(echo "$labels_json" | jq -r --arg n "$group_name" \
 		'.[] | select(.name == $n and .parent == null) | .id // empty' | head -1)
+	group_is_group=$(echo "$labels_json" | jq -r --arg n "$group_name" \
+		'.[] | select(.name == $n and .parent == null) | .isGroup // false' | head -1)
 
 	if [[ -z $group_id ]]; then
-		# Create the group (workspace-scoped, isGroup:true, no teamId).
+		# 4c: Create the group with isGroup:true — the live API REJECTS attaching a child
+		# to a non-group parent ("parent label is not a group", observed 2026-07-15). If
+		# this API generation rejects the isGroup field, fall back to the pre-drift plain create.
 		local group_mutation group_payload group_resp
 		group_mutation=$(build_issue_label_group_create_mutation "$group_name" "#5e6ad2")
 		group_payload=$(jq -nc --arg q "$group_mutation" '{query: $q}')
 		group_resp=$(linear_graphql_post "$token" "$group_payload")
+		if ! jq -e . >/dev/null 2>&1 <<<"$group_resp"; then
+			echo "WARNING: reconcile_worker_status_labels: non-JSON/transport response — skipping" >&2
+			return 0
+		fi
 		if echo "$group_resp" | jq -e '.errors' >/dev/null 2>&1; then
 			local group_err
 			group_err=$(echo "$group_resp" | jq -r '.errors[0].message // "unknown error"')
-			echo "WARNING: reconcile_worker_status_labels: could not create group '${group_name}': ${group_err}" >&2
-			return 0
+			if [[ $group_err == *isGroup* ]]; then
+				echo "reconcile_worker_status_labels: isGroup rejected by this API generation — retrying plain create" >&2
+				group_mutation=$(build_issue_label_group_create_mutation_plain "$group_name" "#5e6ad2")
+				group_payload=$(jq -nc --arg q "$group_mutation" '{query: $q}')
+				group_resp=$(linear_graphql_post "$token" "$group_payload")
+				if ! jq -e . >/dev/null 2>&1 <<<"$group_resp" || echo "$group_resp" | jq -e '.errors' >/dev/null 2>&1; then
+					group_err=$(echo "$group_resp" | jq -r '.errors[0].message // "transport/non-JSON"' 2>/dev/null)
+					echo "WARNING: reconcile_worker_status_labels: could not create group '${group_name}': ${group_err}" >&2
+					return 0
+				fi
+			else
+				echo "WARNING: reconcile_worker_status_labels: could not create group '${group_name}': ${group_err}" >&2
+				return 0
+			fi
 		fi
 		group_id=$(echo "$group_resp" | jq -r '.data.issueLabelCreate.issueLabel.id // empty')
 		echo "reconcile_worker_status_labels: created group '${group_name}' (id: ${group_id})"
 	else
 		echo "reconcile_worker_status_labels: group '${group_name}' already present (id: ${group_id})"
+		if [[ $group_is_group != "true" ]]; then
+			# Adopted plain parent (pre-drift partial run): upgrade it to a group so
+			# child creates below can attach. WARN-and-continue on failure.
+			local upgrade_payload upgrade_resp
+			upgrade_payload=$(build_issue_label_group_upgrade_mutation "$group_id")
+			upgrade_resp=$(linear_graphql_post "$token" "$upgrade_payload")
+			if ! jq -e . >/dev/null 2>&1 <<<"$upgrade_resp" || echo "$upgrade_resp" | jq -e '.errors' >/dev/null 2>&1; then
+				local upgrade_err
+				upgrade_err=$(echo "$upgrade_resp" | jq -r '.errors[0].message // "transport/non-JSON"' 2>/dev/null)
+				echo "WARNING: reconcile_worker_status_labels: could not upgrade '${group_name}' to a group: ${upgrade_err}" >&2
+			else
+				echo "reconcile_worker_status_labels: upgraded plain '${group_name}' to a group (isGroup:true)"
+			fi
+		fi
 		# Note any pre-existing CTL-755 team-level labels now superseded by the workspace
 		# group (daemon applies by name). No API delete — avoids stripping historical tickets.
 		local stale
@@ -317,6 +390,11 @@ reconcile_worker_status_labels() {
 		child_mutation=$(build_issue_label_child_create_mutation "$member_name" "$member_color" "$group_id")
 		child_payload=$(jq -nc --arg q "$child_mutation" '{query: $q}')
 		child_resp=$(linear_graphql_post "$token" "$child_payload")
+		# 4d: transport validation before .errors (mirrors host :605-608).
+		if ! jq -e . >/dev/null 2>&1 <<<"$child_resp"; then
+			echo "WARNING: reconcile_worker_status_labels: non-JSON/transport response for '${member_name}' — skipping" >&2
+			continue
+		fi
 		if echo "$child_resp" | jq -e '.errors' >/dev/null 2>&1; then
 			local child_err
 			child_err=$(echo "$child_resp" | jq -r '.errors[0].message // "unknown error"')


### PR DESCRIPTION
<!-- Auto-generated: 2026-07-15T02:30:00Z -->
<!-- Last updated: 2026-07-15T02:30:00Z -->
<!-- PR: #2653 -->
<!-- Previous commits: cd415dd67a30b837f31c5571c0581c62b136ec63 -->

## Summary

Mirrors the `isGroup:true` drift fix from #2651 (`reconcile_worker_host_labels`) to its sibling `reconcile_worker_status_labels`. The live Linear API now **requires** `isGroup: true` on `issueLabelCreate` for parent labels, and rejects child attaches against non-group parents — inverting the CTL-764 / #2631-era behavior where `isGroup` was the rejected field. `reconcile_worker_status_labels` still used the pre-drift plain-parent shape, making fresh-workspace provisioning of the `worker-status` disposition group latently broken (4 children always rejected).

## Fix (drift-proof in both directions)

**New helpers in `setup-execution-core-states.sh`:**

- `build_issue_label_group_create_mutation`: now sends `isGroup: true`.
- `build_issue_label_group_create_mutation_plain`: pre-drift shape (no `isGroup`) — fallback when the API generation rejects the field.
- `build_issue_label_group_upgrade_mutation`: `issueLabelUpdate isGroup:true` — upgrades an adopted plain parent before children attach.

**`reconcile_worker_status_labels` changes:**

- **isGroup-first create**: sends `isGroup:true`; on rejection (field-not-accepted error), retries with the plain shape.
- **Plain-parent upgrade**: if an existing `worker-status` parent is found with `isGroup: false` (pre-drift partial run), upgrades it via `issueLabelUpdate` before child creates — WARN-and-continue on failure.
- **Per-response transport validation**: `jq -e .` guard before `.errors` checks on the list query, group create, and each child create response, matching the pattern introduced in #2651.

## Testing

- **Inverted T-a assertion**: `build_issue_label_group_create_mutation` now asserts `isGroup` IS present (previously asserted absent per CTL-764 #2631-era behavior).
- **New WS_T9**: adopted plain parent → exactly one `issueLabelUpdate` with `isGroup`, 4 child creates still land, rc=0.
- **New WS_T10**: `isGroup`-rejecting API generation → plain-create fallback (2 create calls: rejected + plain retry) then 4 children, rc=0.
- **Updated T6**: asserts exactly one `issueLabelUpdate` (the plain-parent upgrade path added here mirrors the host reconciler's same path).
- Full suite: **127 passed / 2 failed** — the 2 are the pre-existing `missing-pino` env-only failures, unchanged on main.

## Context

All CI checks pass (13/13). This change touches the same file as #2651 — it was started only after that PR merged to avoid conflicts.

## Related Issues/PRs

- Fixes https://linear.app/coalesce/issue/CTL-1483
- Related to #2651 (the host-reconciler fix this mirrors)
- Related to #2650 (original worker-host label feature)

<!-- Linear automation guard (CTL-623/CTL-633): unlink sibling tickets so this PR does not drag their workflow status. -->
skip CTL-764
