### PR TITLE
chore(execution-core): bump @catalyst-cloud/sdk ^0.4.0 → ^0.5.0 (CTC-135)

### DIFF
--- a/plugins/dev/scripts/execution-core/bun.lock
+++ b/plugins/dev/scripts/execution-core/bun.lock
@@ -6,7 +6,7 @@
       "name": "catalyst-execution-core",
       "dependencies": {
         "@catalyst-cloud/read-model": "^0.1.0",
-        "@catalyst-cloud/sdk": "^0.4.0",
+        "@catalyst-cloud/sdk": "^0.5.0",
         "@opentelemetry/api": "^1.9.1",
         "@opentelemetry/exporter-trace-otlp-http": "^0.219.0",
         "@opentelemetry/resources": "^2.8.0",
@@ -51,7 +51,7 @@
 
     "@catalyst-cloud/schema": ["@catalyst-cloud/schema@0.1.3", "", { "dependencies": { "drizzle-orm": "0.44.7" } }, "sha512-qZGbGvJuvputQlX2TCH5IYAGGVJjunh7tZc9tsp4YxoE82Bj34F+zjqgtCuMTAc6yzR7rNJv90ZjZBLDNoKYwg=="],
 
-    "@catalyst-cloud/sdk": ["@catalyst-cloud/sdk@0.4.0", "", { "dependencies": { "@catalyst-cloud/read-model": "^0.1.0", "@catalyst-cloud/replicate": "^0.1.3", "@catalyst-cloud/schema": "^0.1.3" }, "peerDependencies": { "@opentelemetry/api": ">=1.3.0 <2", "@sqlite.org/sqlite-wasm": "*", "better-sqlite3": "*" }, "optionalPeers": ["@opentelemetry/api", "@sqlite.org/sqlite-wasm", "better-sqlite3"] }, "sha512-jRqjHH9KJ7/BBOpGxMRwj+aLyrVqOr1CFOU5/q+eUEL5VPt3iFz+YKfY6GNgOd81g0G0Q+DAQ0+tH4cRl/Htfw=="],
+    "@catalyst-cloud/sdk": ["@catalyst-cloud/sdk@0.5.0", "", { "dependencies": { "@catalyst-cloud/read-model": "^0.1.0", "@catalyst-cloud/replicate": "^0.1.3", "@catalyst-cloud/schema": "^0.1.3" }, "peerDependencies": { "@opentelemetry/api": ">=1.3.0 <2", "@sqlite.org/sqlite-wasm": "*", "better-sqlite3": "*" }, "optionalPeers": ["@opentelemetry/api", "@sqlite.org/sqlite-wasm", "better-sqlite3"] }, "sha512-C+T+lvD/jUfo3qmrW6k10s/2KLRjeK28PsRT3r5ysjh22s+k3UyY55O29Ac+zTgDs2oRH3/Pd5O1MWfWbjc1bg=="],
 
     "@hono/node-server": ["@hono/node-server@1.19.14", "", { "peerDependencies": { "hono": "^4" } }, "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw=="],
 

--- a/plugins/dev/scripts/execution-core/package.json
+++ b/plugins/dev/scripts/execution-core/package.json
@@ -7,7 +7,7 @@
   },
   "dependencies": {
     "@catalyst-cloud/read-model": "^0.1.0",
-    "@catalyst-cloud/sdk": "^0.4.0",
+    "@catalyst-cloud/sdk": "^0.5.0",
     "@opentelemetry/api": "^1.9.1",
     "@opentelemetry/exporter-trace-otlp-http": "^0.219.0",
     "@opentelemetry/resources": "^2.8.0",


### PR DESCRIPTION
## CTC-135 Phase 3 — cloud-sync daemon SDK bump to `^0.5.0`

Bumps `plugins/dev/scripts/execution-core`'s `@catalyst-cloud/sdk` pin `^0.4.0` → `^0.5.0` so the **cloud-sync daemon** picks up the app-level ping/pong liveness watchdog (catalyst-cloud CTC-135).

This is the fix for the half-open-socket zombies that required manual `launchctl kickstart` — the laptop ran **6.8 days** frozen at one cursor while self-reporting `live`, a mini 3+ days. The watchdog pings the mirror after 90s of inbound silence and force-reconnects if no pong arrives; the mirror's auto-pong is **already deployed to prod** and live-verified.

- 0.x caret ranges don't cross minors, so the `^0.4.0` pin needs an explicit bump.
- Ships to hosts via the updater's plugin-source pull + `bun install`, then a `launchctl kickstart` of `ai.coalesce.catalyst-cloud-sync`.
- `bun.lock` updated minimally (sdk `0.4.0` → `0.5.0`). Additive SDK release — the daemon's usage is unchanged; the 19 local test failures are pre-existing hostname-derivation / scheduler-integration tests unrelated to this dep (no SDK/replica/cloud-sync test touched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
