### PR TITLE
fix(dev): CTL-1457 follow-up — CATALYST_EXECUTOR_BY_PHASE env override (durable per-node routing)

### DIFF
--- a/plugins/dev/scripts/execution-core/config.mjs
+++ b/plugins/dev/scripts/execution-core/config.mjs
@@ -557,12 +557,54 @@ export function getExecutor(configPath) {
 
 // --- CTL-1457: per-phase executor routing + codex-exec runtime settings ---
 
-// readExecutorByPhaseLayer1 — pull catalyst.orchestration.executorByPhase (a
-// phase→executor map) out of a project's Layer-1 .catalyst/config.json. Returns
-// {} for a null/missing/unparseable file or an absent/non-object key so callers
-// fall back to the daemon executor. Never throws — mirrors
-// readFleetHealthConfigLayer1's ENOENT-tolerant shape.
-export function readExecutorByPhaseLayer1(configPath) {
+// readExecutorByPhaseLayer1 — resolve the executorByPhase (phase→executor) map.
+// Precedence: env CATALYST_EXECUTOR_BY_PHASE (a JSON map) OVER Layer-1
+// catalyst.orchestration.executorByPhase — mirroring resolveExecutor's
+// env-over-Layer-1 precedence. Returns {} for a null/missing/unparseable file or an
+// absent/non-object key so callers fall back to the daemon executor. Never throws —
+// mirrors readFleetHealthConfigLayer1's ENOENT-tolerant shape.
+//
+// CTL-1457 follow-up (Gap 1): the env override is the DURABLE, clobber-safe home for
+// a routing pin. On worker nodes the per-node Layer-1 .catalyst/config.json is
+// git-reset every few minutes, so a routing pin written to the file cannot persist;
+// CATALYST_EXECUTOR_BY_PHASE (set in the daemon launch env) survives that reset. When
+// set to a plain-object JSON map it REPLACES the file (env-over-Layer-1). When set but
+// malformed (invalid JSON, or JSON that is not a plain object) it WARN-logs actionably
+// and FALLS THROUGH to the Layer-1 file — a routing pin never silently vanishes AND a
+// typo never silently routes. Example: {"triage":"codex-exec"}.
+export function readExecutorByPhaseLayer1(configPath, env = process.env) {
+  const rawEnv = env?.CATALYST_EXECUTOR_BY_PHASE;
+  if (typeof rawEnv === "string" && rawEnv.trim() !== "") {
+    let parsedEnv;
+    let parseErr = null;
+    try {
+      parsedEnv = JSON.parse(rawEnv);
+    } catch (err) {
+      parseErr = err;
+    }
+    const isPlainObject =
+      !parseErr && parsedEnv && typeof parsedEnv === "object" && !Array.isArray(parsedEnv);
+    // Every route VALUE must be a string. A non-string (e.g. {"triage":false} /
+    // {"triage":null}) would make resolveExecutorForPhase treat that phase as unrouted
+    // AND hide a valid Layer-1 route — silently losing the durable pin this override adds.
+    const badPhase = isPlainObject
+      ? Object.entries(parsedEnv).find(([, v]) => typeof v !== "string")?.[0]
+      : undefined;
+    if (isPlainObject && badPhase === undefined) {
+      // A well-formed phase→executor string map → env REPLACES the Layer-1 file.
+      return parsedEnv;
+    }
+    // Any malformed shape (JSON parse error, non-object, or a non-string route value) →
+    // WARN + fall through to the Layer-1 file. Never throw, never silently route.
+    log.warn(
+      { value: rawEnv, err: parseErr?.message, badPhase },
+      parseErr
+        ? "CATALYST_EXECUTOR_BY_PHASE is set but is not valid JSON — ignoring the env override and falling back to the Layer-1 executorByPhase map"
+        : badPhase !== undefined
+          ? `CATALYST_EXECUTOR_BY_PHASE has a non-string value for phase "${badPhase}" — ignoring the env override and falling back to the Layer-1 executorByPhase map`
+          : "CATALYST_EXECUTOR_BY_PHASE is set but did not parse to a JSON object (a phase→executor map) — ignoring the env override and falling back to the Layer-1 executorByPhase map"
+    );
+  }
   if (!configPath) return {};
   try {
     const parsed = JSON.parse(readFileSync(configPath, "utf8"));
@@ -591,11 +633,11 @@ export function readExecutorByPhaseLayer1(configPath) {
 //     today (zero behavior change when executorByPhase is empty).
 // Returns { executor, source } — source is "executorByPhase" for a routed phase,
 // else resolveExecutor's source ("env" | "layer1" | "default"). The `env` bag is
-// accepted for signature symmetry with the other injected-env-bag readers; routing
-// itself is Layer-1-file-only today (there is no env override for the map).
+// threaded into readExecutorByPhaseLayer1 so the CTL-1457-followup env override
+// (CATALYST_EXECUTOR_BY_PHASE, env-over-Layer-1) is honored here too — a phase routed
+// via the durable env map resolves exactly as one routed via the Layer-1 file.
 export function resolveExecutorForPhase(phase, { configPath, env = process.env } = {}) {
-  void env; // reserved for signature symmetry; per-phase routing is Layer-1-file-only.
-  const map = readExecutorByPhaseLayer1(configPath);
+  const map = readExecutorByPhaseLayer1(configPath, env);
   const raw = phase != null ? map[phase] : undefined;
   if (typeof raw === "string" && raw.trim() !== "") {
     const normalized = raw.trim().toLowerCase();

--- a/plugins/dev/scripts/execution-core/config.test.mjs
+++ b/plugins/dev/scripts/execution-core/config.test.mjs
@@ -50,6 +50,7 @@ import {
   getExecutor,
   dispatchModeForExecutor,
   resolveExecutorForPhase,
+  readExecutorByPhaseLayer1,
   hasInProcessExecutorRoute,
   codexConfig,
 } from "./config.mjs";
@@ -429,7 +430,15 @@ describe("executor flag + resolver (CTL-1365a)", () => {
   // CATALYST_NODE_CLASS + a temp Layer-2 file keep the node-class default
   // deterministic (worker → "bg" in Phase 1) so the precedence assertions don't
   // depend on the host's real Layer-2 config.
-  const ENVS = ["CATALYST_EXECUTOR", "CATALYST_NODE_CLASS", "CATALYST_LAYER2_CONFIG_FILE"];
+  const ENVS = [
+    "CATALYST_EXECUTOR",
+    "CATALYST_NODE_CLASS",
+    "CATALYST_LAYER2_CONFIG_FILE",
+    // CTL-1457 follow-up (Gap 1): scrub the env override so an ambient value on the
+    // host running the suite can never perturb the existing resolveExecutorForPhase /
+    // executorByPhase tests (which pass no env bag → default process.env).
+    "CATALYST_EXECUTOR_BY_PHASE",
+  ];
   let saved = {};
   let tmp, l1, l2;
 
@@ -624,6 +633,73 @@ describe("executor flag + resolver (CTL-1365a)", () => {
     writeExecutorByPhase({ triage: "gpt-9000" });
     expect(() => resolveExecutorForPhase("triage", { configPath: l1 })).toThrow(/gpt-9000/);
     expect(() => resolveExecutorForPhase("triage", { configPath: l1 })).toThrow(/triage/);
+  });
+
+  // --- CTL-1457 follow-up (Gap 1): CATALYST_EXECUTOR_BY_PHASE env override ---
+  // The env map is the DURABLE, clobber-safe routing home (the per-node Layer-1 file is
+  // git-reset every few minutes). Precedence mirrors resolveExecutor's env-over-Layer-1.
+  // Uses the injected {env} bag pattern (like readBoardHealthConfig({env})).
+
+  test("CATALYST_EXECUTOR_BY_PHASE env map REPLACES the Layer-1 file (env > Layer-1)", () => {
+    writeExecutorByPhase({ triage: "bg" }); // Layer-1 file says bg
+    const env = { CATALYST_EXECUTOR_BY_PHASE: '{"triage":"codex-exec"}' };
+    // readExecutorByPhaseLayer1 returns the ENV map, not the file map.
+    expect(readExecutorByPhaseLayer1(l1, env)).toEqual({ triage: "codex-exec" });
+    // resolveExecutorForPhase threads env → routes to the env value.
+    const r = resolveExecutorForPhase("triage", { configPath: l1, env });
+    expect(r.executor).toBe("codex-exec");
+    expect(r.source).toBe("executorByPhase");
+  });
+
+  test("the env override works even with NO Layer-1 file present (durable routing pin)", () => {
+    // No writeExecutorByPhase — l1 does not exist. The env map still routes.
+    const env = { CATALYST_EXECUTOR_BY_PHASE: '{"triage":"codex-exec"}' };
+    expect(readExecutorByPhaseLayer1(l1, env)).toEqual({ triage: "codex-exec" });
+    expect(resolveExecutorForPhase("triage", { configPath: l1, env }).executor).toBe("codex-exec");
+  });
+
+  test("malformed CATALYST_EXECUTOR_BY_PHASE JSON → warn + fall through to the Layer-1 file (NOT a throw)", () => {
+    writeExecutorByPhase({ triage: "sdk" });
+    const env = { CATALYST_EXECUTOR_BY_PHASE: "{not valid json" };
+    expect(() => readExecutorByPhaseLayer1(l1, env)).not.toThrow();
+    // Fell through to the Layer-1 file.
+    expect(readExecutorByPhaseLayer1(l1, env)).toEqual({ triage: "sdk" });
+    expect(resolveExecutorForPhase("triage", { configPath: l1, env }).executor).toBe("sdk");
+  });
+
+  test("CATALYST_EXECUTOR_BY_PHASE that parses to a NON-object (array) → warn + fall through", () => {
+    writeExecutorByPhase({ triage: "sdk" });
+    const env = { CATALYST_EXECUTOR_BY_PHASE: '["triage","codex-exec"]' };
+    expect(() => readExecutorByPhaseLayer1(l1, env)).not.toThrow();
+    expect(readExecutorByPhaseLayer1(l1, env)).toEqual({ triage: "sdk" }); // file wins
+  });
+
+  test("CATALYST_EXECUTOR_BY_PHASE with a NON-STRING route value → warn + fall through (Codex #2655)", () => {
+    // A valid object whose value isn't a string ({"triage":false}/{"triage":null}) must
+    // NOT be accepted — it would make triage look unrouted AND hide the Layer-1 route.
+    writeExecutorByPhase({ triage: "codex-exec" });
+    for (const bad of ['{"triage":false}', '{"triage":null}', '{"triage":123}', '{"triage":{"nested":"x"}}']) {
+      const env = { CATALYST_EXECUTOR_BY_PHASE: bad };
+      expect(() => readExecutorByPhaseLayer1(l1, env)).not.toThrow();
+      // Falls through to the Layer-1 file — the durable route is preserved, not lost.
+      expect(readExecutorByPhaseLayer1(l1, env)).toEqual({ triage: "codex-exec" });
+      expect(resolveExecutorForPhase("triage", { configPath: l1, env }).executor).toBe("codex-exec");
+    }
+  });
+
+  test("empty / whitespace / unset CATALYST_EXECUTOR_BY_PHASE → Layer-1 file behavior unchanged", () => {
+    writeExecutorByPhase({ triage: "codex-exec" });
+    expect(readExecutorByPhaseLayer1(l1, {})).toEqual({ triage: "codex-exec" });
+    expect(readExecutorByPhaseLayer1(l1, { CATALYST_EXECUTOR_BY_PHASE: "   " })).toEqual({
+      triage: "codex-exec",
+    });
+    // The default-arg (process.env) form is unchanged too (env is scrubbed by ENVS).
+    expect(readExecutorByPhaseLayer1(l1)).toEqual({ triage: "codex-exec" });
+  });
+
+  test("hasInProcessExecutorRoute over the env-override map arms the in-process gate", () => {
+    const env = { CATALYST_EXECUTOR_BY_PHASE: '{"triage":"codex-exec"}' };
+    expect(hasInProcessExecutorRoute(readExecutorByPhaseLayer1(l1, env))).toBe(true);
   });
 
   // CTL-1457 (N1): hasInProcessExecutorRoute — does the map route ANY phase in-process?


### PR DESCRIPTION
## Summary

Follow-up to #2639 (codex-exec executor). The **Phase 5 live test on mini-2** exposed that per-phase codex routing never took effect. Root cause: the daemon reads `executorByPhase` only from the Layer-1 config file (`~/catalyst/plugin-source/.catalyst/config.json`), which is git-tracked and **`git reset --hard origin/main` on a ~5-minute timer** (the broker/updater pins the pristine checkout). A local per-node `executorByPhase` edit is wiped within 5 min — in the test, 21s before triage dispatched, so the monitor's one-shot dispatch (which *does* honor per-phase routing via `makePhaseAwareDispatchFn`) read an empty map and used the node executor.

**Fix:** add a **`CATALYST_EXECUTOR_BY_PHASE`** (JSON) env override read by `readExecutorByPhaseLayer1` / `resolveExecutorForPhase`, with precedence **over** the Layer-1 file (mirrors how `CATALYST_EXECUTOR` overrides Layer-1) — a clobber-safe home settable durably in `execution-core.env`. All daemon callers pick it up automatically (`env` defaults to `process.env`). Follows CTL-1458 (routing UX).

Validation is strict-but-fail-open: a malformed value — JSON parse error, non-object, **or a non-string route value** (e.g. `{"triage":false}`, which would otherwise make `triage` look unrouted *and* hide the Layer-1 route) — **warns and falls through to the Layer-1 file**. Never throws, never silently routes.

## Not in this PR (scope correction)

The first revision also tried to wire per-phase routing into the delegate-runner (`resolveEffectiveDelegateExecutor`). **Dropped** — Codex correctly showed the delegate/recovery-pass path dispatches under a synthetic `"recovery-pass"` meta-phase, so per-pipeline-phase routing can't be applied there, and (more importantly) it's **not the fresh-admission path**: fresh Todo triage is dispatched by the monitor's one-shot via `makePhaseAwareDispatchFn`, which already honors routing (daemon.mjs `dispatch: dispatchFn`). So the env override alone makes fresh-admission triage route to codex. (Routing the recovery-pass re-dispatch of a *stalled* phase is a separate, lower-priority concern for later.)

## Context

The codex adapter *core* was validated end-to-end on real mini-2 hardware during Phase 5: `codexRunPhaseAgent` driving the real `codex exec --json` binary → correct usage extraction, `thread_id`→sessionId capture, `success` classification, full event lifecycle, `dispatched`→`done` signal flip.

## Tests

`config.test.mjs` (+7): env map replaces the Layer-1 file; works with no file present (durable pin); malformed JSON / non-object / **non-string route value** → warn + fall-through; unset → Layer-1 unchanged; `hasInProcessExecutorRoute` sees the env override. All green; `bun build daemon.mjs --target=node` resolves.

## After merge

Deploy to mini-2, set `CATALYST_EXECUTOR_BY_PHASE={"triage":"codex-exec"}` in `execution-core.env`, restart exec-core, re-run the Phase 5 autonomous triage-routing test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
