### PR TITLE
fix(dev): CTL-1420 replica-read detector was blind to the `linear` alias + wrapper prefixes

### DIFF
--- a/plugins/dev/hooks/detect-bare-linear-read.sh
+++ b/plugins/dev/hooks/detect-bare-linear-read.sh
@@ -1,12 +1,23 @@
 #!/usr/bin/env bash
-# PreToolUse/Bash hook: detect a bare single-ticket `linearis issues read <arg>`
-# that bypasses the replica — for LITERAL ids AND shell-variable forms ($T, "$T",
+# PreToolUse/Bash hook: detect a bare single-ticket Linear `issues read` that
+# bypasses the replica — for LITERAL ids AND shell-variable forms ($T, "$T",
 # ${T}, $(...)). Flag-order independent. EXEMPT the one sanctioned linearis read the
 # replica can't serve: --with-attachments. Comments are fetched via `linearis
 # comments list` (structurally outside `issues read`), so no comment exemption is
 # needed. Mode: CATALYST_LINEAR_READ_DETECT_MODE (observe|enforce; default observe).
+#
+# CTL-1420: detection is a TOKEN WALK, not a single anchored regex. The regex form
+# had two blind spots that let a session exhaust the shared 2500/hr Linear quota:
+#   1. the `linear` ALIAS — the linearis package installs BOTH `linear` and
+#      `linearis` symlinks to the same dist/main.js;
+#   2. WRAPPER PREFIXES — `direnv exec . linearis …` is a command prefix, not a
+#      VAR=val assignment, so the command-word anchor failed. Every Linear call in
+#      a direnv-managed repo carries that prefix, so the hook was structurally
+#      blind in those repos.
+# The walk resolves the real command word past env-assignments and wrappers, so
+# both forms are caught. Tests: scripts/__tests__/detect-bare-linear-read.test.sh.
 set -uo pipefail
-input="$(cat)"                                   # Claude Code pipes the tool call as JSON on stdin
+input="$(cat)" # Claude Code pipes the tool call as JSON on stdin
 cmd="$(printf '%s' "$input" | jq -r '.tool_input.command // empty' 2>/dev/null)"
 [[ -n "$cmd" ]] || exit 0
 # Collapse shell line-continuations (`\<newline>`) to a space so a wrapped
@@ -14,19 +25,90 @@ cmd="$(printf '%s' "$input" | jq -r '.tool_input.command // empty' 2>/dev/null)"
 # non-matching segments below.
 cmd="${cmd//$'\\\n'/ }"
 
+# Command words that RUN another command: skip them (and their own operands) to
+# reach the real command word. `direnv exec .` is the load-bearing case.
+is_wrapper() {
+	case "$1" in
+	env | command | exec | direnv | nice | nohup | stdbuf | time | timeout | sudo) return 0 ;;
+	*) return 1 ;;
+	esac
+}
+
+# The linearis CLI, by either name the package installs (both symlink main.js).
+is_linearis() {
+	case "$1" in
+	linearis | linear) return 0 ;;
+	*) return 1 ;;
+	esac
+}
+
+# Shell keywords that can PRECEDE a command word inside a compound statement. After
+# splitting on `;`, a loop body arrives as `do <cmd> …` — the shape that actually
+# burned the quota (`for t in 198 199 200; do direnv exec . linear issues read CTC-$t; done`).
+# These are skipped WITHOUT setting saw_wrapper, so the next token is still judged
+# strictly as a command word rather than loosening the walk.
+is_shell_keyword() {
+	case "$1" in
+	do | then | else | elif | '{' | '(' | '!') return 0 ;;
+	*) return 1 ;;
+	esac
+}
+
+# True iff SEGMENT invokes `<linearis|linear> [flags] issues [flags] read`.
+# Matching the command word EXACTLY (after stripping a leading path) is what keeps
+# `rg 'linearis issues read'` / `echo '…'` / `mylinearis` / `linearisctl` from
+# matching: a quoted or substring occurrence is never a bare token.
+is_bare_issues_read() {
+	local seg="$1"
+	local -a toks
+	read -r -a toks <<<"$seg" || return 1
+	local n=${#toks[@]} i=0 saw_wrapper=0 base
+	# Phase 1 — resolve the command word past env-assignments and wrappers.
+	while ((i < n)); do
+		if [[ ${toks[i]} == [A-Za-z_]*=* ]]; then # VAR=val prefix
+			i=$((i + 1))
+			continue
+		fi
+		base="${toks[i]##*/}" # strip a path invocation (/opt/homebrew/bin/linear)
+		is_linearis "$base" && break
+		if is_shell_keyword "${toks[i]}"; then
+			i=$((i + 1))
+			continue
+		fi
+		if is_wrapper "$base"; then
+			saw_wrapper=1
+			i=$((i + 1))
+			continue
+		fi
+		# A wrapper's own operands (`.` in `direnv exec .`, `-u FOO` in `env -u FOO`)
+		# sit between the wrapper and the command word — skip them. With no wrapper in
+		# front, any other command word means this is not a linearis invocation.
+		((saw_wrapper)) || return 1
+		i=$((i + 1))
+	done
+	((i < n)) || return 1 # ran out of tokens — no linearis command word
+
+	# Phase 2 — the verb path: `issues` then `read` as the first two positionals
+	# (flags anywhere). Verb `read` excludes list/search/create/update/comments/usage.
+	i=$((i + 1))
+	local -a rest=()
+	while ((i < n)); do
+		[[ ${toks[i]} == -* ]] || rest+=("${toks[i]}") # drop flags; keep positionals
+		i=$((i + 1))
+	done
+	[[ ${#rest[@]} -ge 2 && ${rest[0]} == "issues" && ${rest[1]} == "read" ]]
+}
+
 # Detect per COMMAND SEGMENT, not payload-wide, so a sanctioned `--with-attachments`
 # read in the same tool call can't shield a sibling bare read
-# (e.g. `linearis issues read A; linearis issues read B --with-attachments`). Split on
+# (e.g. `linearis issues read A --with-attachments; linear issues read B`). Split on
 # shell separators (;, &, |, newline) — sufficient for the payload shapes agents emit.
-# A segment is a BARE read iff `linearis` is the COMMAND WORD (anchored — after optional
-# leading whitespace + VAR=val env-assignments; so `rg "linearis issues read"` / `echo …`
-# do NOT match) running an `issues read` (verb `read` excludes list/search/create/update/
-# comments/usage/auth) WITHOUT --with-attachments (the one replica-less read).
 bare=""
 while IFS= read -r seg; do
-  printf '%s' "$seg" | grep -Eq '^[[:space:]]*([A-Za-z_][A-Za-z0-9_]*=[^[:space:]]*[[:space:]]+)*linearis([[:space:]]+[^[:space:]]+)*[[:space:]]+issues[[:space:]]+read([[:space:]]|$)' || continue
-  printf '%s' "$seg" | grep -Eq -- '--with-attachments' && continue   # sanctioned attachment read — exempt
-  bare="$seg"; break
+	is_bare_issues_read "$seg" || continue
+	printf '%s' "$seg" | grep -Eq -- '--with-attachments' && continue # sanctioned attachment read — exempt
+	bare="$seg"
+	break
 done < <(printf '%s\n' "$cmd" | tr ';&|' '\n')
 [[ -n "$bare" ]] || exit 0
 
@@ -34,13 +116,20 @@ done < <(printf '%s\n' "$cmd" | tr ';&|' '\n')
 id="$(printf '%s' "$bare" | grep -Eo '[A-Za-z][A-Za-z0-9]*-[0-9]+' | head -1)"
 id="${id:-unknown}"
 
+# Resolve the helper's REAL location — used both to emit telemetry and to quote a
+# runnable remedy. It must be ABSOLUTE: this hook is global, so it fires in repos
+# that have no `plugins/dev/…` path of their own (a direnv-managed repo like
+# catalyst-cloud is exactly where the wrapper-prefix blind spot lived), and a
+# repo-relative remedy would be un-sourceable precisely where it's needed most.
+LIB="$(cd "$(dirname "$0")/../scripts/lib" 2>/dev/null && pwd)/linear-read-replica.sh"
+
 # Count it in Loki (same event as E1; source=raw-cli-hook, reason=no-gate).
-LIB="$(dirname "$0")/../scripts/lib/linear-read-replica.sh"
+# shellcheck source=../scripts/lib/linear-read-replica.sh disable=SC1090,SC1091
 [[ -r "$LIB" ]] && { source "$LIB"; _lrr_emit_fallback_event "$id" no-gate raw-cli-hook; }
 
 if [[ "${CATALYST_LINEAR_READ_DETECT_MODE:-observe}" == "enforce" ]]; then
-  echo "Blocked: '$bare' hits the rate-limited Linear API. Use the replica: source plugins/dev/scripts/lib/linear-read-replica.sh && linear_read_ticket ${id/unknown/<ID>} (or gate + sqlite3 the replica). Attachments? add --with-attachments (exempt). See the linearis skill 'Reading Linear'." >&2
-  exit 2                                          # exit 2 = block the tool call, feed stderr to the model
+	echo "Blocked: '$bare' hits the rate-limited Linear API. Use the replica: source $LIB && linear_read_ticket ${id/unknown/<ID>} (or gate + sqlite3 the replica). Attachments? add --with-attachments (exempt). See the linearis skill 'Reading Linear'." >&2
+	exit 2 # exit 2 = block the tool call, feed stderr to the model
 fi
 # observe mode: warn + allow (does NOT hard-stop the read — see deploy plan).
 echo "note: this bypassed the replica — prefer linear_read_ticket ${id/unknown/<ID>} (linearis skill 'Reading Linear')." >&2

--- a/plugins/dev/hooks/detect-bare-linear-read.sh
+++ b/plugins/dev/hooks/detect-bare-linear-read.sh
@@ -55,36 +55,59 @@ is_shell_keyword() {
 }
 
 # True iff SEGMENT invokes `<linearis|linear> [flags] issues [flags] read`.
+# On success sets DETECTED_TICKET to the READ TARGET (the positional after `read`),
+# or "" when the id is a shell variable.
+#
 # Matching the command word EXACTLY (after stripping a leading path) is what keeps
 # `rg 'linearis issues read'` / `echo '…'` / `mylinearis` / `linearisctl` from
 # matching: a quoted or substring occurrence is never a bare token.
+#
+# A wrapper does NOT license skipping ahead to any later `linear` token — the command
+# it runs is whatever lands in command position after its own known operands. Skipping
+# arbitrarily would flag `env echo linear issues read X`, which touches no API, and
+# under enforce that BLOCKS a legitimate command.
 is_bare_issues_read() {
 	local seg="$1"
+	DETECTED_TICKET=""
 	local -a toks
 	read -r -a toks <<<"$seg" || return 1
-	local n=${#toks[@]} i=0 saw_wrapper=0 base
-	# Phase 1 — resolve the command word past env-assignments and wrappers.
+	local n=${#toks[@]} i=0 base
+	# Phase 1 — resolve the command word past env-assignments, flags and wrappers.
 	while ((i < n)); do
 		if [[ ${toks[i]} == [A-Za-z_]*=* ]]; then # VAR=val prefix
 			i=$((i + 1))
 			continue
 		fi
-		base="${toks[i]##*/}" # strip a path invocation (/opt/homebrew/bin/linear)
-		is_linearis "$base" && break
+		if [[ ${toks[i]} == -* ]]; then # a wrapper's own flag
+			i=$((i + 1))
+			continue
+		fi
 		if is_shell_keyword "${toks[i]}"; then
 			i=$((i + 1))
 			continue
 		fi
+		base="${toks[i]##*/}" # strip a path invocation (/opt/homebrew/bin/linear)
+		is_linearis "$base" && break
 		if is_wrapper "$base"; then
-			saw_wrapper=1
 			i=$((i + 1))
+			# Consume only the operands this wrapper's grammar puts before the command:
+			# `direnv exec <DIR> CMD`, `timeout <DURATION> CMD`, `env -u <NAME> CMD`.
+			# Everything else takes the command word next.
+			case "$base" in
+			direnv)
+				[[ ${toks[i]:-} == exec ]] && i=$((i + 1))
+				[[ -n ${toks[i]:-} && ${toks[i]} != -* ]] && i=$((i + 1)) # DIR
+				;;
+			timeout)
+				[[ -n ${toks[i]:-} && ${toks[i]} != -* ]] && i=$((i + 1)) # DURATION
+				;;
+			env)
+				while [[ ${toks[i]:-} == -u ]]; do i=$((i + 2)); done # -u NAME pairs
+				;;
+			esac
 			continue
 		fi
-		# A wrapper's own operands (`.` in `direnv exec .`, `-u FOO` in `env -u FOO`)
-		# sit between the wrapper and the command word — skip them. With no wrapper in
-		# front, any other command word means this is not a linearis invocation.
-		((saw_wrapper)) || return 1
-		i=$((i + 1))
+		return 1 # a real command word that is not linearis → not a linearis invocation
 	done
 	((i < n)) || return 1 # ran out of tokens — no linearis command word
 
@@ -96,7 +119,12 @@ is_bare_issues_read() {
 		[[ ${toks[i]} == -* ]] || rest+=("${toks[i]}") # drop flags; keep positionals
 		i=$((i + 1))
 	done
-	[[ ${#rest[@]} -ge 2 && ${rest[0]} == "issues" && ${rest[1]} == "read" ]]
+	[[ ${#rest[@]} -ge 2 && ${rest[0]} == "issues" && ${rest[1]} == "read" ]] || return 1
+	# The read target is the positional after `read` — NOT any ticket-shaped token
+	# elsewhere in the segment (a wrapper's `direnv exec /tmp/CTC-111` operand would
+	# otherwise misname the remedy and misattribute the Loki event).
+	DETECTED_TICKET="${rest[2]:-}"
+	return 0
 }
 
 # Detect per COMMAND SEGMENT, not payload-wide, so a sanctioned `--with-attachments`
@@ -104,16 +132,19 @@ is_bare_issues_read() {
 # (e.g. `linearis issues read A --with-attachments; linear issues read B`). Split on
 # shell separators (;, &, |, newline) — sufficient for the payload shapes agents emit.
 bare=""
+ticket=""
 while IFS= read -r seg; do
 	is_bare_issues_read "$seg" || continue
 	printf '%s' "$seg" | grep -Eq -- '--with-attachments' && continue # sanctioned attachment read — exempt
 	bare="$seg"
+	ticket="$DETECTED_TICKET"
 	break
 done < <(printf '%s\n' "$cmd" | tr ';&|' '\n')
 [[ -n "$bare" ]] || exit 0
 
-# Literal id in the OFFENDING segment if present; else variable-form → unknown (still counted/blocked).
-id="$(printf '%s' "$bare" | grep -Eo '[A-Za-z][A-Za-z0-9]*-[0-9]+' | head -1)"
+# Literal id of the READ TARGET if present; else variable-form → unknown (still
+# counted/blocked). Scoped to the target token, never the whole segment.
+id="$(printf '%s' "$ticket" | grep -Eo '[A-Za-z][A-Za-z0-9]*-[0-9]+' | head -1)"
 id="${id:-unknown}"
 
 # Resolve the helper's REAL location — used both to emit telemetry and to quote a
@@ -128,7 +159,9 @@ LIB="$(cd "$(dirname "$0")/../scripts/lib" 2>/dev/null && pwd)/linear-read-repli
 [[ -r "$LIB" ]] && { source "$LIB"; _lrr_emit_fallback_event "$id" no-gate raw-cli-hook; }
 
 if [[ "${CATALYST_LINEAR_READ_DETECT_MODE:-observe}" == "enforce" ]]; then
-	echo "Blocked: '$bare' hits the rate-limited Linear API. Use the replica: source $LIB && linear_read_ticket ${id/unknown/<ID>} (or gate + sqlite3 the replica). Attachments? add --with-attachments (exempt). See the linearis skill 'Reading Linear'." >&2
+	# The path is SHELL-QUOTED: the agent copy-pastes this, and a plugin root
+	# containing spaces would otherwise emit a broken `source /a b/c.sh`.
+	echo "Blocked: '$bare' hits the rate-limited Linear API. Use the replica: source '$LIB' && linear_read_ticket ${id/unknown/<ID>} (or gate + sqlite3 the replica). Attachments? add --with-attachments (exempt). See the linearis skill 'Reading Linear'." >&2
 	exit 2 # exit 2 = block the tool call, feed stderr to the model
 fi
 # observe mode: warn + allow (does NOT hard-stop the read — see deploy plan).

--- a/plugins/dev/scripts/__tests__/detect-bare-linear-read.test.sh
+++ b/plugins/dev/scripts/__tests__/detect-bare-linear-read.test.sh
@@ -112,6 +112,13 @@ assert_pass "echo of the string is not a call" "echo 'linear issues read CTC-198
 assert_pass "a substring binary is not linearis" "mylinearis issues read CTC-198"
 assert_pass "linear-adjacent binary is not linearis" "linearisctl issues read CTC-198"
 assert_pass "unrelated command" "ls -la"
+# A wrapper must not license skipping to ANY later `linear` token: the command a
+# wrapper runs is the first thing in command position after its own operands.
+# Here the command is `echo`, so nothing hits the API. Detecting it would BLOCK a
+# legitimate command under enforce. (Codex P2, PR #2658.)
+assert_pass "wrapper running a different command" "env echo linear issues read CTC-198"
+assert_pass "wrapper running a different command (direnv)" "direnv exec . echo linear issues read CTC-198"
+assert_pass "printf of the string under a wrapper" "env printf '%s' 'linear issues read CTC-198'"
 
 echo
 echo "detect-bare-linear-read: enforce mode blocks"
@@ -140,13 +147,38 @@ out="$(printf '{"tool_input":{"command":"linear issues read CTC-198"}}' |
 	CATALYST_LINEAR_READ_DETECT_MODE=enforce CATALYST_EVENTS_DIR="$TMPDIR_T/events" \
 		bash "$HOOK" 2>&1)"
 case "$out" in
-*"source plugins/dev/scripts/lib"*) fail "enforce remedy is an absolute path" "message quotes a repo-relative path that does not exist outside the catalyst checkout" ;;
-*"source /"*) ok "enforce remedy is an absolute path" ;;
+*"source plugins/dev/scripts/lib"* | *"source 'plugins/"*)
+	fail "enforce remedy is an absolute path" "message quotes a repo-relative path that does not exist outside the catalyst checkout" ;;
+*"source '/"* | *"source /"*) ok "enforce remedy is an absolute path" ;;
 *) fail "enforce remedy is an absolute path" "no sourceable path in: $out" ;;
 esac
 if printf '%s' "$out" | grep -q "linear_read_ticket CTC-198"; then
 	ok "enforce remedy names the ticket"
 else fail "enforce remedy names the ticket" "got: $out"; fi
+
+# The remedy is copy-pasted by an agent, so the path must survive a plugin root
+# containing spaces — an unquoted `source /a b/c.sh` is a broken command.
+# (Codex P2, PR #2658.)
+SPACED="$TMPDIR_T/plugin root/hooks"
+mkdir -p "$SPACED" "$TMPDIR_T/plugin root/scripts/lib"
+cp "$HOOK" "$SPACED/detect-bare-linear-read.sh"
+: >"$TMPDIR_T/plugin root/scripts/lib/linear-read-replica.sh"
+out="$(printf '{"tool_input":{"command":"linear issues read CTC-198"}}' |
+	CATALYST_LINEAR_READ_DETECT_MODE=enforce CATALYST_EVENTS_DIR="$TMPDIR_T/events" \
+		bash "$SPACED/detect-bare-linear-read.sh" 2>&1)"
+if printf '%s' "$out" | grep -qE "source ('[^']*'|\"[^\"]*\")"; then
+	ok "enforce remedy quotes a path containing spaces"
+else fail "enforce remedy quotes a path containing spaces" "unquoted/invalid in: $out"; fi
+
+# The reported id must be the READ TARGET, not a wrapper operand that merely looks
+# like a ticket — otherwise the remedy tells the agent to read the wrong ticket and
+# the Loki event is misattributed. (Codex P2, PR #2658.)
+out="$(printf '{"tool_input":{"command":"direnv exec /tmp/CTC-111 linear issues read CTC-198"}}' |
+	CATALYST_LINEAR_READ_DETECT_MODE=enforce CATALYST_EVENTS_DIR="$TMPDIR_T/events" \
+		bash "$HOOK" 2>&1)"
+if printf '%s' "$out" | grep -q "linear_read_ticket CTC-198"; then
+	ok "id comes from the read target, not a wrapper operand"
+else fail "id comes from the read target, not a wrapper operand" "got: $out"; fi
 
 echo
 printf 'detect-bare-linear-read: %d passed, %d failed\n' "$PASS" "$FAIL"

--- a/plugins/dev/scripts/__tests__/detect-bare-linear-read.test.sh
+++ b/plugins/dev/scripts/__tests__/detect-bare-linear-read.test.sh
@@ -1,0 +1,153 @@
+#!/usr/bin/env bash
+# detect-bare-linear-read.test.sh — CTL-1420: unit tests for the PreToolUse hook
+# that detects a bare single-ticket Linear read bypassing the replica.
+#
+# WHY THIS FILE EXISTS: the hook shipped (CTL-1397 / #2543) with smoke cases run
+# by hand but never committed. Two blind spots survived into production and cost a
+# 2500/hr quota exhaustion:
+#   1. the `linear` alias — the linearis package installs BOTH `linear` and
+#      `linearis` symlinks to the same dist/main.js, and the matcher anchored on
+#      `linearis` only;
+#   2. wrapper prefixes — `direnv exec . linearis issues read X` failed the
+#      command-word anchor. Every Linear call in a direnv repo carries that
+#      prefix, so the hook was structurally blind in those repos.
+# These are locked in below as MUST-DETECT cases.
+#
+# Single-quoted `$VAR` / `$(…)` in the cases below are DELIBERATE: the hook is fed
+# the unexpanded command text, so the literal is the fixture.
+# shellcheck disable=SC2016
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+HOOK="${SCRIPT_DIR}/../../hooks/detect-bare-linear-read.sh"
+
+PASS=0
+FAIL=0
+ok() {
+	PASS=$((PASS + 1))
+	printf '  PASS: %s\n' "$1"
+}
+fail() {
+	FAIL=$((FAIL + 1))
+	printf '  FAIL: %s\n    %s\n' "$1" "$2"
+}
+
+command -v jq >/dev/null 2>&1 || {
+	echo "SKIP: jq not available"
+	exit 0
+}
+[ -r "$HOOK" ] || {
+	echo "FAIL: hook not found at $HOOK"
+	exit 1
+}
+
+# Run the hook against a command string. Echoes "DETECT" or "PASS-THROUGH".
+# CATALYST_LINEAR_READ_DETECT_MODE is forced to observe so a detection is a
+# warn-on-stderr + exit 0 (we assert on the stderr, not the exit code).
+# CATALYST_EVENTS_DIR is redirected so the telemetry emit can never touch the
+# real event log from a test run.
+run_hook() {
+	local cmd="$1" mode="${2:-observe}" out
+	out="$(printf '{"tool_input":{"command":%s}}' "$(printf '%s' "$cmd" | jq -Rs .)" |
+		CATALYST_LINEAR_READ_DETECT_MODE="$mode" \
+			CATALYST_EVENTS_DIR="$TMPDIR_T/events" \
+			bash "$HOOK" 2>&1)"
+	if [ -n "$out" ]; then printf 'DETECT'; else printf 'PASS-THROUGH'; fi
+}
+
+assert_detect() {
+	local got
+	got="$(run_hook "$2")"
+	if [ "$got" = "DETECT" ]; then ok "$1"; else fail "$1" "expected DETECT, got $got — '$2'"; fi
+}
+assert_pass() {
+	local got
+	got="$(run_hook "$2")"
+	if [ "$got" = "PASS-THROUGH" ]; then ok "$1"; else fail "$1" "expected PASS-THROUGH, got $got — '$2'"; fi
+}
+
+TMPDIR_T="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR_T"' EXIT
+
+echo "detect-bare-linear-read: MUST DETECT (bare replica-bypassing reads)"
+assert_detect "canonical linearis read" "linearis issues read CTC-198"
+assert_detect "the \`linear\` alias (regression: CTL-1420)" "linear issues read CTC-198"
+assert_detect "direnv wrapper + linearis (regression: CTL-1420)" "direnv exec . linearis issues read CTC-198"
+assert_detect "direnv wrapper + linear alias (regression: CTL-1420)" "direnv exec . linear issues read CTC-198"
+assert_detect "env-assignment prefix" "FOO=1 linearis issues read CTC-198"
+assert_detect "env wrapper" "env linearis issues read CTC-198"
+assert_detect "command wrapper" "command linear issues read CTC-198"
+assert_detect "nested wrappers" "env FOO=1 direnv exec . linear issues read CTC-198"
+assert_detect "variable ticket id" 'linear issues read "$TICKET"'
+assert_detect "braced variable id" 'linearis issues read ${T}'
+assert_detect "command-substitution id" 'linear issues read $(cat /tmp/t)'
+assert_detect "flags before verb" "linearis --json issues read CTC-198"
+assert_detect "sibling bare read after a sanctioned one" \
+	"linearis issues read A --with-attachments; linear issues read B"
+assert_detect "line-continuation split" "linear issues \\
+read CTC-198"
+# The shape that actually burned the quota: a for-loop over a ticket range. Splitting
+# on `;` leaves a segment starting with the shell keyword `do`, so the command word
+# is not the first token.
+assert_detect "for-loop body (regression: CTL-1420)" \
+	'for t in 198 199 200; do direnv exec . linear issues read CTC-$t; done'
+assert_detect "while-loop body" 'while read t; do linear issues read $t; done < ids.txt'
+assert_detect "then-branch" 'if [ -n "$T" ]; then linear issues read $T; fi'
+assert_detect "&& chain" "cd /tmp && linear issues read CTC-198"
+assert_detect "brace group" "{ linear issues read CTC-198; }"
+
+echo
+echo "detect-bare-linear-read: MUST NOT DETECT (sanctioned / not-a-read)"
+assert_pass "sanctioned attachments read" "linearis issues read CTC-198 --with-attachments"
+assert_pass "attachments read via alias" "linear issues read CTC-198 --with-attachments"
+assert_pass "issues list (documented carve-out)" "linearis issues list --team CTC"
+assert_pass "issues search (documented carve-out)" "linear issues search foo"
+assert_pass "comments list (documented carve-out)" "linearis comments list CTC-198"
+assert_pass "writes are never a bypass" "linearis issues update CTC-198 --status Done"
+assert_pass "creates are never a bypass" "linear issues create --title x"
+assert_pass "usage lookup" "linearis issues usage"
+assert_pass "the replica helper itself" "linear_read_ticket CTC-198"
+assert_pass "grep for the string is not a call" "rg 'linearis issues read' plugins/"
+assert_pass "echo of the string is not a call" "echo 'linear issues read CTC-198'"
+assert_pass "a substring binary is not linearis" "mylinearis issues read CTC-198"
+assert_pass "linear-adjacent binary is not linearis" "linearisctl issues read CTC-198"
+assert_pass "unrelated command" "ls -la"
+
+echo
+echo "detect-bare-linear-read: enforce mode blocks"
+out="$(printf '{"tool_input":{"command":"linear issues read CTC-198"}}' |
+	CATALYST_LINEAR_READ_DETECT_MODE=enforce CATALYST_EVENTS_DIR="$TMPDIR_T/events" \
+		bash "$HOOK" 2>&1)"
+rc=$?
+if [ "$rc" -eq 2 ]; then ok "enforce exits 2 (blocks the tool call)"; else fail "enforce exits 2" "got rc=$rc"; fi
+case "$out" in
+*Blocked*) ok "enforce message says Blocked" ;;
+*) fail "enforce message says Blocked" "got: $out" ;;
+esac
+
+out="$(printf '{"tool_input":{"command":"linearis issues list --team CTC"}}' |
+	CATALYST_LINEAR_READ_DETECT_MODE=enforce CATALYST_EVENTS_DIR="$TMPDIR_T/events" \
+		bash "$HOOK" 2>&1)"
+rc=$?
+if [ "$rc" -eq 0 ]; then ok "enforce does not block a carve-out"; else fail "enforce does not block a carve-out" "got rc=$rc"; fi
+
+# The remedy must be actionable from ANY repo. A relative `plugins/dev/...` path
+# resolves only inside the catalyst checkout — and the repos where this hook newly
+# fires (direnv-managed ones like catalyst-cloud) do not have that path. The hook
+# already resolves the helper's real location for its own telemetry; the message
+# must quote that same absolute path.
+out="$(printf '{"tool_input":{"command":"linear issues read CTC-198"}}' |
+	CATALYST_LINEAR_READ_DETECT_MODE=enforce CATALYST_EVENTS_DIR="$TMPDIR_T/events" \
+		bash "$HOOK" 2>&1)"
+case "$out" in
+*"source plugins/dev/scripts/lib"*) fail "enforce remedy is an absolute path" "message quotes a repo-relative path that does not exist outside the catalyst checkout" ;;
+*"source /"*) ok "enforce remedy is an absolute path" ;;
+*) fail "enforce remedy is an absolute path" "no sourceable path in: $out" ;;
+esac
+if printf '%s' "$out" | grep -q "linear_read_ticket CTC-198"; then
+	ok "enforce remedy names the ticket"
+else fail "enforce remedy names the ticket" "got: $out"; fi
+
+echo
+printf 'detect-bare-linear-read: %d passed, %d failed\n' "$PASS" "$FAIL"
+[ "$FAIL" -eq 0 ]


### PR DESCRIPTION
## Why

The CTL-1397 detector (#2543) shipped to stop agents burning the shared **2500/hr Linear quota** on reads the replica already holds. **It never fired.** A session exhausted the quota on ~60 replica-servable reads, and the event log shows the tell: **358** fallback events Jul 14, **98** Jul 15, **0** on Jul 16 — during the burn.

Two blind spots in the command-word anchor, both reproduced against the real hook:

```
[MATCH]  linearis issues read CTC-198
[MISS]   linear issues read CTC-198                   <- the alias
[MISS]   direnv exec . linearis issues read CTC-198   <- wrapper prefix
[MISS]   direnv exec . linear issues read CTC-198     <- what was actually run
```

1. **The `linear` alias** — the package installs BOTH `/opt/homebrew/bin/linear` and `/opt/homebrew/bin/linearis`, symlinks to the same `dist/main.js` (since May 4). The regex anchored on `linearis` only.
2. **Wrapper prefixes** — the anchor tolerated `VAR=val` but not a command prefix. `direnv exec .` is required for every Linear call in a direnv-managed repo (catalyst-cloud), so the hook was **structurally blind in exactly those repos**.

**Consequence:** flipping `CATALYST_LINEAR_READ_DETECT_MODE=enforce` — the documented post-merge follow-up from #2543 — **would have blocked nothing.** Enforce only escalates a match, and there was no match.

A third shape surfaced while testing: the `for t in …; do <cmd>; done` loop the burning session actually ran. Splitting on `;` leaves a segment starting with the shell keyword `do`.

## Change

- **Token walk, not one anchored regex** — resolves the real command word past env-assignments, wrappers (`direnv`/`env`/`command`/`nice`/…), and shell keywords (`do`/`then`/`{`/…); accepts both CLI names.
- **Enforce remedy is now an absolute path.** It quoted a repo-relative `plugins/dev/scripts/lib/…` that doesn't exist outside the catalyst checkout — un-sourceable in precisely the repos where the hook newly fires. The hook already resolved the helper's real location for telemetry; the message reuses it.
- **Committed the tests.** #2543 ran "10/10 smoke cases" by hand and committed none — which is how these survived.

## Verification

| check | result |
| --- | --- |
| new suite | **38/38** (RED first: 19 passed / **12 failed** against the old matcher) |
| negative cases | **14**, zero regressions — carve-outs (`issues list`/`search`/`comments list`), writes, `--with-attachments`, and quoted/substring forms (`rg 'linearis issues read'`, `echo`, `mylinearis`, `linearisctl`) |
| existing `linear-read-replica.test.sh` | **36/36** — no regression |
| `shellcheck` / `bash -n` | clean |

The exact command that burned the quota now blocks under enforce:
```
$ direnv exec . linear issues read CTC-198
Blocked: … Use the replica: source /…/lib/linear-read-replica.sh && linear_read_ticket CTC-198
rc=2
```

## Not in this change

- **Mode still defaults to `observe`.** The hook now actually *detects*, so observe finally produces the burn-down signal #2543 wanted. Flipping to enforce is a host-env decision — recommend a short bake on the new signal first.
- **The freshness gate still asserts writer *liveness*, not cursor *progress***, so a stalled writer serves stale data reporting FRESH (observed: a 58-min stall passing both gates). Deliberately **not** fixed here: a quiet feed and a stalled feed are indistinguishable from the replica alone today — `writer.lock` carries only `pid`/`owner`/`heartbeat`, and `lastChangeFrameAt` is not in the installed SDK 0.5.0 — so a restrictive gate would false-stale during quiet periods and fall back to `linearis`, **causing the very burn this fixes**. It unblocks when `catalyst-cloud-sdk` lands the head-nudge + `lastChangeFrameAt`.

Full investigation: `thoughts/shared/research/2026-07-16-agent-linear-reads-bypass-replica.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TxKbXMJHakfeXLXwh5geeK