### PR TITLE
chore(execution-core): bump @catalyst-cloud/sdk ^0.5.0 → ^0.6.0 (CTC-222)

### DIFF
--- a/plugins/dev/scripts/execution-core/bun.lock
+++ b/plugins/dev/scripts/execution-core/bun.lock
@@ -6,7 +6,7 @@
       "name": "catalyst-execution-core",
       "dependencies": {
         "@catalyst-cloud/read-model": "^0.1.0",
-        "@catalyst-cloud/sdk": "^0.5.0",
+        "@catalyst-cloud/sdk": "^0.6.0",
         "@opentelemetry/api": "^1.9.1",
         "@opentelemetry/exporter-trace-otlp-http": "^0.219.0",
         "@opentelemetry/resources": "^2.8.0",
@@ -51,7 +51,7 @@
 
     "@catalyst-cloud/schema": ["@catalyst-cloud/schema@0.1.3", "", { "dependencies": { "drizzle-orm": "0.44.7" } }, "sha512-qZGbGvJuvputQlX2TCH5IYAGGVJjunh7tZc9tsp4YxoE82Bj34F+zjqgtCuMTAc6yzR7rNJv90ZjZBLDNoKYwg=="],
 
-    "@catalyst-cloud/sdk": ["@catalyst-cloud/sdk@0.5.0", "", { "dependencies": { "@catalyst-cloud/read-model": "^0.1.0", "@catalyst-cloud/replicate": "^0.1.3", "@catalyst-cloud/schema": "^0.1.3" }, "peerDependencies": { "@opentelemetry/api": ">=1.3.0 <2", "@sqlite.org/sqlite-wasm": "*", "better-sqlite3": "*" }, "optionalPeers": ["@opentelemetry/api", "@sqlite.org/sqlite-wasm", "better-sqlite3"] }, "sha512-C+T+lvD/jUfo3qmrW6k10s/2KLRjeK28PsRT3r5ysjh22s+k3UyY55O29Ac+zTgDs2oRH3/Pd5O1MWfWbjc1bg=="],
+    "@catalyst-cloud/sdk": ["@catalyst-cloud/sdk@0.6.0", "", { "dependencies": { "@catalyst-cloud/read-model": "^0.1.0", "@catalyst-cloud/replicate": "^0.1.3", "@catalyst-cloud/schema": "^0.1.3" }, "peerDependencies": { "@opentelemetry/api": ">=1.3.0 <2", "@sqlite.org/sqlite-wasm": "*", "better-sqlite3": "*" }, "optionalPeers": ["@opentelemetry/api", "@sqlite.org/sqlite-wasm", "better-sqlite3"] }, "sha512-gdgTuiYtzwiFrvu98wlb4IzwqKZzcmi63Fv2eiIi5rfT2zVpNr8Q7LHfOCuUlxQtpqKuz2469kq8pNeRUiwOBw=="],
 
     "@hono/node-server": ["@hono/node-server@1.19.14", "", { "peerDependencies": { "hono": "^4" } }, "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw=="],
 

--- a/plugins/dev/scripts/execution-core/package.json
+++ b/plugins/dev/scripts/execution-core/package.json
@@ -7,7 +7,7 @@
   },
   "dependencies": {
     "@catalyst-cloud/read-model": "^0.1.0",
-    "@catalyst-cloud/sdk": "^0.5.0",
+    "@catalyst-cloud/sdk": "^0.6.0",
     "@opentelemetry/api": "^1.9.1",
     "@opentelemetry/exporter-trace-otlp-http": "^0.219.0",
     "@opentelemetry/resources": "^2.8.0",


### PR DESCRIPTION
## CTC-222 — cloud-sync daemon SDK bump to `^0.6.0`

Bumps `plugins/dev/scripts/execution-core`'s `@catalyst-cloud/sdk` pin `^0.5.0` → `^0.6.0` so the **cloud-sync daemon** picks up **gap detection + the self-healing `{type:"sync"}` re-request** (catalyst-cloud CTC-222 / SDK [v0.6.0](https://github.com/coalesce-labs/catalyst-cloud-sdk/releases/tag/v0.6.0)).

This is the **healer half** of the fix for the 2026-07-16 replica-loss incident — the root cause behind the long-standing board-drift complaint, and the reason the scheduler was gating dispatch on `relations` that were **29.7h stale**.

### What was broken

The mirror has two `change_log` append paths and only one broadcasts: webhook ingest goes through `appendAndBroadcast`, while **every reconcile / bootstrap / identity write uses bare `appendChange`** — a durable INSERT that is never pushed. The daemon's high-water cursor then advanced past those unpushed seqs on the next webhook-origin frame, **sealing the hole permanently**.

Observed live on this workstation's replica while preparing the fix:

```
cursor: 799022 → 799309 → 799311 → 799361 → 799367 → 799384   (+362 seqs)
relations rows:  1744 → 1744        (ZERO arrived)
relations max updated_at: unchanged (2026-07-16T20:25:53Z)
```

Webhook frames for other entities dragged the cursor **past** 8 un-broadcast `relations` rows — which now sit *below* the cursor, permanently orphaned. Throughout, the daemon reported `cursor == changeLogMax` and `status:"live"`: **indistinguishable from perfect health while silently missing data.**

### What 0.6.0 changes

- A frame arriving beyond `deliveredSeq + 1` is **not applied** and the baseline is **not advanced past the hole** — the daemon re-requests the range with the same `{type:"sync", after}` control frame it already sends on every reconnect, and the mirror replays the missing rows through the same apply path.
- Handles the mirror's new end-of-pass `{type:"head", seq}` nudge (catalyst-cloud CTC-220 — the **trigger** half). Both halves are required: gap detection alone can't fire in a webhook-quiet window, because no later frame arrives to detect a gap *from*.
- New telemetry: `catalyst.replica.gap` with `detected` / `healed` at INFO (a gap is the steady-state path here) and `escalated` at ERROR. **Alert on `escalated` only.**

### Notes

- 0.x caret ranges don't cross minors, so the `^0.5.0` pin needs an explicit bump (same as the `^0.4.0 → ^0.5.0` bump in #2654).
- `bun.lock` updated minimally — sdk `0.5.0` → `0.6.0`, 2 lines, no transitive churn.
- Ships to hosts via the updater's plugin-source pull + `bun install`, then a `launchctl kickstart -k gui/501/ai.coalesce.catalyst-cloud-sync`.
- **Deploy order vs the mirror is free** (verified both directions): 0.6.0 against a mirror without the nudge simply never sees a head frame and behaves exactly as 0.5.0 does; the nudge against an un-upgraded 0.5.0 client is dropped in `parseFrame` before any cursor logic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L4EiqwZGRnbwBwypJb6RYm
