### PR TITLE
feat(dev): agent house-rules block + checkup (CTL general-instructions)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,6 +26,30 @@ All agents follow a **documentarian, not critic** approach:
 - NO architecture critiques or quality assessments
 - Focus on answering "WHERE is X?" and "HOW does X work?"
 
+## Working the Loop (every agent — interactive too, not just skills)
+
+These are house rules for anyone touching this repo's dev / PR / ticket workflow — whether you are
+running a slash-command skill **or** working interactively and ad-hoc. They are **default
+reflexes, not skill internals**: reach for them without being told, even on a one-off PR you opened
+by hand.
+
+- **Waiting on GitHub / CI / Linear state → subscribe to the event log, don't poll.** To block on a
+  state change (a PR merged, CI turning green, a review posted, a push to a branch, a ticket
+  transition), wait on the unified event log instead of re-querying in a loop. Reach for the
+  `catalyst-dev:wait-for-github` skill for GitHub events (broker `broker_claim_pr` + `filter.wake`,
+  falling back to `catalyst-events wait-for`) and `catalyst-dev:monitor-events` for the general
+  wait-for-a-state-change pattern. A `gh` / `linearis` poll loop burns shared-quota API budget and
+  silently misses reaction-only signals (next bullet). When the broker / webhook infra is down these
+  skills degrade to a bounded single-event wait — that degradation is the fallback, never your
+  opening move.
+- **Judging an automated code review → a clean pass is a reaction, not a review object.** The
+  automated reviewer signals "no issues" with a 👍 reaction (or a terse "no major issues" comment)
+  **instead of** opening review threads. Detect it via the PR's reactions and issue comments, not
+  only the reviews API — otherwise a review that already passed reads as silence and you wait on it
+  forever. See **Pull requests** below for the full contract.
+- **Reading one Linear ticket → the local replica, not bare `linearis`.** See **Key Principles**
+  below (`linear_read_ticket <ID>`); a bare `linearis issues read <ID>` 429s the shared fleet quota.
+
 ## Build & Test
 
 No build process — this is markdown files and bash scripts.
@@ -49,7 +73,7 @@ No build process — this is markdown files and bash scripts.
 - **Spawn parallel agents** — Maximize efficiency
 - **Agents are documentarians** — Never suggest improvements unless asked
 - **Preserve context** — Save to thoughts/, not just memory
-- **Linear reads → local replica** — read a single ticket with **`sqlite3 "${CATALYST_REPLICA_DB:-${CATALYST_DIR:-$HOME/catalyst}/catalyst-replica.db}"`** (the canonical path resolver — an install may set `CATALYST_REPLICA_DB`/`CATALYST_DIR`; don't hard-code the default; gate on freshness first, per the `linearis` skill's "Reading Linear"). This is the bg-safe form: it needs no plugin, resolves in any shell, and physically cannot 429. **Never a bare `linearis`/`linear issues read <ID>`** — that hits the rate-limited API and burns the shared-quota fleet. `linear_read_ticket <ID>` is a convenience wrapper for the *same* replica read, but it is a plugin **shell function** that is NOT on `PATH` in a background/daemon Bash — so an unattended agent that reaches for it gets "command not found" and silently falls through to bare `linearis`. Prefer the `sqlite3` form in scripts and bg agents; use `linear_read_ticket` only in an interactive session that has sourced the helper. Writes and `issues list`/`search` have no replica form — they stay on `linearis`. See the `linearis` skill's "Reading Linear".
+- **Linear reads → local replica** — for a single-ticket read call `linear_read_ticket <ID>` (it gates freshness and falls back loudly); never a bare `linearis issues read <ID>` (it 429s the shared-quota fleet). Writes and list/search stay on `linearis`. See the `linearis` skill's "Reading Linear".
 
 ## Skill & Agent References
 
@@ -210,7 +234,7 @@ A pull request is **not mergeable** until BOTH are true:
 - **All CI checks pass.** A failing or pending required check blocks the merge.
 - **Every review is resolved.** If the PR has any review (automated code review or human), each review thread/conversation must be addressed and marked resolved. An unresolved review blocks the merge even when checks are green.
 
-So after opening a PR: watch the checks to green, then address every review comment (push fixes), reply, and resolve each thread before considering the PR done.
+So after opening a PR: wait for the checks to go green (subscribe to the event log — see **Working the Loop**, don't poll `gh` in a loop), then address every review comment (push fixes), reply, and resolve each thread before considering the PR done.
 
 **Reading the automated reviewer's signal.** When the automated code reviewer finds nothing, it
 signals a clean pass with a 👍 reaction (or a brief "no major issues" note) **instead of** opening

--- a/plugins/dev/scripts/check-project-setup.sh
+++ b/plugins/dev/scripts/check-project-setup.sh
@@ -564,6 +564,40 @@ if [[ -n $REPLICA_LIB ]]; then
 	# downstream install never runs; nagging it would be a permanent false alarm.
 fi
 
+# 9. Agent house rules present — the "Working the Loop" reflexes (CTL general-instructions).
+#    The agent-instructions doc is meant to teach EVERY agent (including an interactive,
+#    non-slash-command session) three default reflexes that are otherwise buried in
+#    skills: (a) subscribe to the event log instead of polling GitHub/CI/Linear,
+#    (b) read a single Linear ticket from the local replica, (c) recognize an
+#    automated reviewer's 👍-reaction clean pass. A recent interactive session polled
+#    GitHub for 99 min and missed a passed review because these were framed as
+#    skill-internal, not house rules. This checkup nags (WARN, never fatal) when a
+#    Catalyst-managed project's agent doc is missing any reflex.
+#
+#    The block must live in the file the driving agent actually LOADS: AGENTS.md when
+#    CLAUDE.md is a thin `@AGENTS.md` bridge (AGENTS.md is imported), otherwise the
+#    monolithic CLAUDE.md directly. So we accept a marker found in EITHER doc, and only
+#    run the check when at least one agent doc exists (a repo with neither is outside
+#    the framework — nagging it would be a false alarm). Canonical block to copy:
+#    plugins/dev/templates/agents-house-rules.md. Markers matched case-insensitively.
+AGENT_DOCS=()
+[[ -f AGENTS.md ]] && AGENT_DOCS+=("AGENTS.md")
+[[ -f CLAUDE.md ]] && AGENT_DOCS+=("CLAUDE.md")
+if [[ ${#AGENT_DOCS[@]} -gt 0 ]]; then
+	missing_reflex=()
+	grep -qiE 'subscribe to the event log|wait-for-github' "${AGENT_DOCS[@]}" ||
+		missing_reflex+=("event-log-over-polling (waiting on GitHub/CI/Linear state → catalyst-dev:wait-for-github / catalyst-dev:monitor-events, don't poll)")
+	grep -qE '👍' "${AGENT_DOCS[@]}" ||
+		missing_reflex+=("automated-review 👍-reaction clean pass (detect via reactions/comments, not only the reviews API)")
+	grep -qiE 'linear_read_ticket|local replica' "${AGENT_DOCS[@]}" ||
+		missing_reflex+=("single-ticket Linear reads → local replica (linear_read_ticket <ID>, not bare linearis)")
+	if [[ ${#missing_reflex[@]} -eq 0 ]]; then
+		echo -e "${GREEN}Agent house rules present${NC} — ${AGENT_DOCS[*]} teaches the event-log, 👍-review, and replica-read reflexes."
+	else
+		warnings+=("Agent doc (${AGENT_DOCS[*]}) is missing house rules (the 'Working the Loop' reflexes) — an interactive agent won't learn: ${missing_reflex[*]}. Seed the canonical block: plugins/dev/templates/agents-house-rules.md (into AGENTS.md if CLAUDE.md is an @AGENTS.md bridge, else into CLAUDE.md).")
+	fi
+fi
+
 # Report errors (fatal)
 if [[ ${#errors[@]} -gt 0 ]]; then
 	echo -e "${RED}ERROR: Project setup incomplete${NC}"

--- a/plugins/dev/templates/agents-house-rules.md
+++ b/plugins/dev/templates/agents-house-rules.md
@@ -1,0 +1,34 @@
+## Working the Loop (every agent — interactive too, not just skills)
+
+<!--
+  CANONICAL SOURCE for the Catalyst "agent house rules" block.
+  Seed this section verbatim into every Catalyst-managed repo's agent-instructions
+  doc — AGENTS.md when CLAUDE.md is a thin `@AGENTS.md` bridge, otherwise directly
+  into the monolithic CLAUDE.md (that is the file the driving agent actually loads).
+  `check-project-setup.sh` §9 verifies its presence via the three reflex markers
+  ("subscribe to the event log" / "👍" / "local replica"); keep those phrases intact
+  so the checkup keeps recognizing a correctly-set-up project. Delete this HTML
+  comment when you paste the block into a repo.
+-->
+
+These are house rules for anyone touching this repo's dev / PR / ticket workflow — whether you are
+running a slash-command skill **or** working interactively and ad-hoc. They are **default
+reflexes, not skill internals**: reach for them without being told, even on a one-off PR you opened
+by hand.
+
+- **Waiting on GitHub / CI / Linear state → subscribe to the event log, don't poll.** To block on a
+  state change (a PR merged, CI turning green, a review posted, a push to a branch, a ticket
+  transition), wait on the unified event log instead of re-querying in a loop. Reach for the
+  `catalyst-dev:wait-for-github` skill for GitHub events (broker `broker_claim_pr` + `filter.wake`,
+  falling back to `catalyst-events wait-for`) and `catalyst-dev:monitor-events` for the general
+  wait-for-a-state-change pattern. A `gh` / `linearis` poll loop burns shared-quota API budget and
+  silently misses reaction-only signals (next bullet). When the broker / webhook infra is down these
+  skills degrade to a bounded single-event wait — that degradation is the fallback, never your
+  opening move.
+- **Judging an automated code review → a clean pass is a reaction, not a review object.** The
+  automated reviewer signals "no issues" with a 👍 reaction (or a terse "no major issues" comment)
+  **instead of** opening review threads. Detect it via the PR's reactions and issue comments, not
+  only the reviews API — otherwise a review that already passed reads as silence and you wait on it
+  forever. See **Pull requests** below for the full contract.
+- **Reading one Linear ticket → the local replica, not bare `linearis`.** See **Key Principles**
+  below (`linear_read_ticket <ID>`); a bare `linearis issues read <ID>` 429s the shared fleet quota.


### PR DESCRIPTION
## What

Teach **every** agent — including an interactive, non-slash-command session — three default reflexes that were previously buried in skills. Motivated by a live session that polled GitHub for 99 min and missed a review that had already passed with a 👍 reaction.

The three reflexes:
- **Waiting on GitHub / CI / Linear state → subscribe to the unified event log** (`catalyst-dev:wait-for-github` / `catalyst-dev:monitor-events`), don't poll `gh`/`linearis` in a loop.
- **An automated review's clean pass is a 👍 reaction, not a review object** — detect via reactions/comments (a passed review otherwise reads as silence).
- **Single-ticket Linear reads → local replica** (`linear_read_ticket`), not bare `linearis` (429s the shared fleet quota).

## Changes

- `AGENTS.md`: new **"Working the Loop"** section (vendor-neutral — bridge lint green) + the *Pull requests* "watch checks to green" line now points at the event-log reflex instead of implying a poll.
- `plugins/dev/templates/agents-house-rules.md`: **canonical block** to seed into every Catalyst-managed repo (AGENTS.md when CLAUDE.md is an `@AGENTS.md` bridge, else the monolithic CLAUDE.md).
- `plugins/dev/scripts/check-project-setup.sh` §9: **checkup** that verifies the three reflex markers in AGENTS.md **or** CLAUDE.md (WARN, never fatal), so setup/orchestrate prerequisites flag any project missing the block.

## Systematization

This is the foundation PR. The same block is being seeded into every repo currently enrolled in the execution-core registry (Adva, catalyst-otel, slides, evergreen) as sibling PRs. The checkup then keeps every project honest going forward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QRoodbsoonZJNbNfyJetso