### PR TITLE
fix(dev): drop the Linear-API degraded escape (contradicted the absolute replica rule)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,9 +33,10 @@ These are house rules for anyone touching this repo's dev / PR / ticket workflow
 running a slash-command skill **or** working interactively and ad-hoc. They are **default
 reflexes, not skill internals**: reach for them without being told, even on a one-off PR you opened
 by hand. They defer their mechanism to the `catalyst-dev` plugin, available in every Catalyst-managed
-repo. If that plugin is somehow unavailable (a broken environment — fix it), degrade each reflex to a
-single **bounded** check as a last resort — a lone `catalyst-events wait-for` / `gh` poll, a `gh` API
-reaction read, or one `linearis issues read` — never a poll loop, and never your opening move.
+repo. If that plugin is somehow unavailable, that is a broken environment — repair it (reload the
+plugin) rather than routing around it. For GitHub state only, a single **bounded** `gh` check is an
+acceptable last resort while you do; never a poll loop, and never a raw Linear API read (the
+replica-read rule below is absolute).
 
 - **Waiting on GitHub / CI / Linear state → subscribe to the event log, don't poll.** To block on a
   state change (a PR merged, CI turning green, a review posted, a push to a branch, a ticket
@@ -56,9 +57,9 @@ reaction read, or one `linearis issues read` — never a poll loop, and never yo
   local replica behind a freshness gate (via its `linear_read_ticket` helper, run in the plugin's
   skill context) and does the loud stale/absent fallback for you. Don't hand-roll the read yourself:
   an **un-gated** `sqlite3` of the replica skips the freshness check (you may read stale data or
-  create an empty DB), and a bare `linearis issues read <ID>` loop 429s the shared fleet quota (the
-  ban is on un-gated and looped reads, not on reading at all — see the degraded-mode note above).
-  Writes and list/search go through `linearis`.
+  create an empty DB), and a bare `linearis issues read <ID>` hits the rate-limited API and 429s the
+  shared fleet quota — don't reach for it even as a fallback; the skill's helper owns the loud
+  stale/absent path. Writes and list/search go through `linearis`.
 <!-- catalyst-house-rules:end -->
 
 ## Build & Test

--- a/plugins/dev/templates/agents-house-rules.md
+++ b/plugins/dev/templates/agents-house-rules.md
@@ -19,9 +19,10 @@ These are house rules for anyone touching this repo's dev / PR / ticket workflow
 running a slash-command skill **or** working interactively and ad-hoc. They are **default
 reflexes, not skill internals**: reach for them without being told, even on a one-off PR you opened
 by hand. They defer their mechanism to the `catalyst-dev` plugin, available in every Catalyst-managed
-repo. If that plugin is somehow unavailable (a broken environment — fix it), degrade each reflex to a
-single **bounded** check as a last resort — a lone `catalyst-events wait-for` / `gh` poll, a `gh` API
-reaction read, or one `linearis issues read` — never a poll loop, and never your opening move.
+repo. If that plugin is somehow unavailable, that is a broken environment — repair it (reload the
+plugin) rather than routing around it. For GitHub state only, a single **bounded** `gh` check is an
+acceptable last resort while you do; never a poll loop, and never a raw Linear API read (the
+replica-read rule below is absolute).
 
 - **Waiting on GitHub / CI / Linear state → subscribe to the event log, don't poll.** To block on a
   state change (a PR merged, CI turning green, a review posted, a push to a branch, a ticket
@@ -42,6 +43,6 @@ reaction read, or one `linearis issues read` — never a poll loop, and never yo
   local replica behind a freshness gate (via its `linear_read_ticket` helper, run in the plugin's
   skill context) and does the loud stale/absent fallback for you. Don't hand-roll the read yourself:
   an **un-gated** `sqlite3` of the replica skips the freshness check (you may read stale data or
-  create an empty DB), and a bare `linearis issues read <ID>` loop 429s the shared fleet quota (the
-  ban is on un-gated and looped reads, not on reading at all — see the degraded-mode note above).
-  Writes and list/search go through `linearis`.
+  create an empty DB), and a bare `linearis issues read <ID>` hits the rate-limited API and 429s the
+  shared fleet quota — don't reach for it even as a fallback; the skill's helper owns the loud
+  stale/absent path. Writes and list/search go through `linearis`.


### PR DESCRIPTION
The final polish round added a degraded escape — *"if `catalyst-dev` is unavailable … one loud `linearis issues read`"*. Codex flagged on catalyst-cloud#183 that this **contradicts the repo-local rule**: both catalyst's Key Principles and catalyst-cloud's AGENTS.md state a single-ticket read must **never** hit the Linear API. A seeded block would then hand agents two conflicting directives for the same operation — exactly the failure mode this whole block exists to prevent — and could reintroduce the shared-quota burn.

Now: a broken plugin is an environment to **repair**, not route around. A single bounded `gh` check remains acceptable for GitHub state (no rule bans it); a raw Linear API read is never sanctioned — the skill's helper owns the loud stale/absent path.

80-case suite green; catalyst's own AGENTS.md re-synced via the seeder.

🤖 Generated with [Claude Code](https://claude.com/claude-code)