### PR TITLE
fix(dev): CTL-682 — wait-watcher skips background agents; pin scheduler test live-count seam

### DIFF
--- a/plugins/dev/scripts/execution-core/scheduler.test.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.test.mjs
@@ -4196,6 +4196,7 @@ describe("CTL-539 — idempotent dispatch across a crash", () => {
       readEligible: () => eligible,
       dispatch,
       verifyDispatched: verifyOk,
+      liveBackgroundCount: () => 0, // CTL-682: deterministic in-flight count (matches r1)
     });
 
     // CTL-9 now has a worker dir → excluded from the pull. research:dispatched

--- a/plugins/dev/scripts/execution-core/wait-watcher.mjs
+++ b/plugins/dev/scripts/execution-core/wait-watcher.mjs
@@ -70,6 +70,14 @@ export function startWaitWatcher({
     const live = new Set();
     for (const a of agents) {
       if (!a || !a.sessionId) continue;
+      // CTL-682: background phase agents post a closing text summary and exit
+      // with stopReason==="end_turn", which classifyWaitState() reads as
+      // WAITING_USER — a false "waiting on user" for a finished agent. The only
+      // consumer (`sessions waiting`) is about interactive sessions blocked on a
+      // human, so skip background agents entirely (matches reaper._isBackground /
+      // countBackgroundAgents). Absent kind (older claude builds) is treated as
+      // non-background and processed as before.
+      if (a.kind === "background") continue;
       live.add(a.sessionId);
 
       const path = findTranscriptFn(a.sessionId, projectsDir);

--- a/plugins/dev/scripts/execution-core/wait-watcher.test.mjs
+++ b/plugins/dev/scripts/execution-core/wait-watcher.test.mjs
@@ -157,3 +157,29 @@ test("stop() clears the interval", () => {
   w.stop();
   expect(clock.wasCleared()).toBe(true);
 });
+
+test("background agent with end_turn snapshot emits nothing (CTL-682)", () => {
+  // Same WAITING_USER snapshot, but kind:"background" → the loop must skip it
+  // before classify/emit, so no agent.waiting_on_user is produced.
+  const agentsRef = {
+    current: [{ sessionId: SID, status: "idle", kind: "background", cwd: "/wt" }],
+  };
+  const snapRef = { current: WAITING_USER_SNAP };
+  const { w, emitted } = harness({ agentsRef, snapRef });
+
+  w.tick();
+  expect(emitted).toEqual([]);
+  w.stop();
+});
+
+test("interactive agent still emits agent.waiting_on_user (CTL-682 guard is background-only)", () => {
+  const agentsRef = {
+    current: [{ sessionId: SID, status: "idle", kind: "interactive", cwd: "/wt" }],
+  };
+  const snapRef = { current: WAITING_USER_SNAP };
+  const { w, emitted } = harness({ agentsRef, snapRef });
+
+  w.tick();
+  expect(emitted.map((e) => e.name)).toEqual(["agent.waiting_on_user"]);
+  w.stop();
+});


### PR DESCRIPTION
<!-- Auto-generated: 2026-07-21T06:22:33Z -->
<!-- Last updated: 2026-07-21T06:22:33Z -->
<!-- PR: #2670 -->
<!-- Previous commits: 75978c12edceeb07b6c0cea0f1a13d0debabbf54 -->

## Summary

Two small, independent execution-core fixes bundled under CTL-682 to amortize
overhead. Both are isolated to the observability/test layers — the only production
runtime change is a one-line input guard in the wait-watcher.

1. **Wait-watcher no longer fires spurious `agent.waiting_on_user` events for
   completed background phase agents.** A cleanly-exited background agent posts a
   closing text summary and ends its final turn with `stopReason === "end_turn"`,
   which `classifyWaitState()` reads as `WAITING_USER` — a false "waiting on a
   human" for an agent that is actually done. Since the only consumer
   (`sessions waiting`) is about interactive sessions blocked on a human, the
   watcher now skips background agents entirely.

2. **Scheduler dispatch tests are pinned to a deterministic live-worker count.**
   `schedulerTick()` computes free slots from the host's live background agents,
   so a test that omits the `liveBackgroundCount` injection sees `freeSlots = 0`
   whenever real workers are running on the host and silently skips dispatch. One
   `schedulerTick(...)` call in the CTL-539 crash-idempotency test was missing the
   seam; it now injects `liveBackgroundCount: () => 0` like the sibling cases in
   the same file.

## Changes Made

### `plugins/dev/scripts/execution-core/wait-watcher.mjs` (+8)

- Added an early `continue` for `a.kind === "background"` in the agent-enumeration
  loop, before classify/emit. This matches the reaper's `_isBackground` /
  `countBackgroundAgents` convention. Absent `kind` (older `claude` builds) is
  treated as non-background and processed as before, so behavior is unchanged for
  interactive agents.

### `plugins/dev/scripts/execution-core/wait-watcher.test.mjs` (+26)

- `background agent with end_turn snapshot emits nothing (CTL-682)` — a
  `kind:"background"` agent with the same `WAITING_USER` snapshot is skipped
  before classify/emit, so no event is produced.
- `interactive agent still emits agent.waiting_on_user (CTL-682 guard is
  background-only)` — asserts the guard is background-scoped and interactive
  waiting still emits.

### `plugins/dev/scripts/execution-core/scheduler.test.mjs` (+1)

- Added `liveBackgroundCount: () => 0` to the `schedulerTick(...)` call in the
  CTL-539 idempotent-dispatch-across-a-crash test so the run is deterministic
  regardless of live workers on the host.

## How to Verify It

- [x] Wait-watcher CTL-682 tests pass: `bun test wait-watcher.test.mjs -t "CTL-682"` — 2 pass / 0 fail
- [x] CTL-539 idempotent-dispatch tests pass: `bun test scheduler.test.mjs -t "CTL-539"` — 2 pass / 0 fail
- [x] Full run of the two touched files: `bun test wait-watcher.test.mjs scheduler.test.mjs` — 569 pass, 6 fail (the 6 failures are pre-existing CTL-781/CTL-1174 respect-assignment tests, untouched by this PR)

## Changelog Entry

`fix(dev)`: wait-watcher skips completed background phase agents (no more spurious
`agent.waiting_on_user` noise in the event log); scheduler CTL-539 test pinned to a
deterministic live-worker count.

## Related Issues/PRs

- Fixes https://linear.app/rozich/issue/CTL-682

## Reviewer Notes

- The shipped guard is `if (a.kind === "background") continue;` (skip
  background), not the `kind !== "interactive"` phrasing in the original ticket
  notes — the shipped form intentionally treats an absent `kind` from older
  `claude` builds as non-background so nothing regresses for legacy agents.
- Impact of Fix 1 today is noise-only: no automated consumer reads
  `agent.waiting_on_user`; `sessions waiting` is human-facing. The value is
  restoring dashboard/event-log signal.
- Out of scope (tracked separately): the `catalyst-monitor.sh` shell tests, the
  Linearis cross-team label-UUID fix, and removing the now-unused
  `_exec`/`_debounceMs` params from `handleStateChangedEvent`.

<!-- Linear automation guard (CTL-623/CTL-633): unlink sibling tickets so this PR does not drag their workflow status. -->
skip CTL-1174
skip CTL-539
skip CTL-781