### PR TITLE
feat(dev): CTL-1091 Phase 1 — route dispatch gates through the surviving roster

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -76,6 +76,28 @@ per-orchestrator local state in worktrees stays the source of truth for crash re
 - **Heartbeat** — orchestrators write `lastHeartbeat` every 2–3 min; entries stale >10 min are GC'd
   as `abandoned`.
 
+**Cross-host ticket ownership (HRW + liveness, CTL-859 → CTL-1091).** In a multi-host cluster,
+ticket ownership is partitioned by Highest-Random-Weight (rendezvous) hashing (`hrw.mjs` `ownedBy`):
+each daemon acts only on the tickets it owns, so one ticket is considered by exactly one host. Two
+gates evaluate ownership, and — since CTL-1091 — **both hash over a liveness-filtered roster**, so an
+offline owner's slice fails over to a live host instead of stranding in Todo forever:
+
+- **Dispatch gates** (new-work `ready` filter in `scheduler.mjs`; triage predicate in `monitor.mjs`)
+  hash over the **dispatch roster** = `computeDispatchSurvivingRoster(roster)` (POSITIVE liveness —
+  a host must have heartbeated within `HEARTBEAT_GRACE_MS`, so a *never-live* rostered host is shed;
+  CTL-1057) with a restore-side **deflap** on top (`liveness-deflap.mjs` `computeDispatchRoster` —
+  a dead→live host is held out for `HEARTBEAT_RESTORE_HOLD_MS` so a flapping laptop can't
+  grab-then-strand work; scheduler is the sole writer of `.liveness-deflap.json`, monitor reads it).
+- **Recovery gates** (`ownsForRecovery`, `reclaimDeadHostWork`) hash over the **surviving roster** =
+  `computeSurvivingRoster(roster)` (fail-OPEN `deadHosts` — an unseen host is "not proven dead" and
+  is NOT reclaimed, since a never-seen host has no work to reclaim). The asymmetry is deliberate:
+  dispatch fails an unseen owner's slice **over**; recovery must not reclaim a host's non-existent work.
+
+Both altitudes preserve the same fail-safes: single-host is a strict no-op, and a total liveness
+outage (heartbeat read throws / everyone looks dead) degrades to the **full roster** (each node owns
+only its own HRW slice — never double-acts). The Linear-CAS claim (`cluster-claim.mjs` soft-CAS on
+`catalyst://fence/<TICKET>`, applied HRW-first/claim-second) remains the transition-race serializer.
+
 **Worker signal projection (in migration, ADR-018, CTL-483).** Per-worker `workers/<TICKET>.json`
 files are currently written by ~7 scripts with no inter-process locking. CTL-483 moves these
 mutations to a `worker.state_changed` command event consumed by the broker, which projects to a

--- a/plugins/dev/scripts/execution-core/cluster-heartbeat-sync.mjs
+++ b/plugins/dev/scripts/execution-core/cluster-heartbeat-sync.mjs
@@ -191,6 +191,15 @@ export function readPeerHeartbeatsSync(
     cli = CLUSTER_HEARTBEAT_CLI,
     env = process.env,
     timeout = LIVENESS_TIMEOUT_MS,
+    // CTL-1091 (Codex P1 follow-up): when TRUE, a DETERMINATE read FAILURE (spawn
+    // error, timeout, nonzero exit, non-string/unparseable/non-object stdout) THROWS
+    // instead of collapsing to `{}`. This lets the strict DISPATCH liveness path
+    // (readClusterHeartbeats requirePeerView → readPositiveLive → resolveDispatchRoster)
+    // tell a FAILED peer read (→ full-roster outage fallback) apart from a genuinely
+    // EMPTY but SUCCESSFUL read (status 0, no peers published yet → legitimate [self]).
+    // Default false preserves the historical fail-open behavior recovery relies on:
+    // every failure → `{}` (unseen ≠ dead → never reclaim).
+    strict = false,
   } = {},
 ) {
   try {
@@ -199,13 +208,23 @@ export function readPeerHeartbeatsSync(
       env,
       timeout,
     });
-    if (!res || res.status !== 0 || typeof res.stdout !== "string") return {};
+    if (!res || res.status !== 0 || typeof res.stdout !== "string") {
+      if (strict)
+        throw new Error(
+          `ctl-1091: peer heartbeat read failed (status=${res?.status ?? "none"}) — indeterminate peer view`,
+        );
+      return {};
+    }
     const line = res.stdout.trim().split("\n").filter(Boolean).pop();
-    if (!line) return {};
+    if (!line) return {}; // status 0, no data → genuinely empty (a determinate success)
     const parsed = JSON.parse(line);
-    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return {};
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+      if (strict) throw new Error("ctl-1091: peer heartbeat read returned a malformed payload");
+      return {};
+    }
     return parsed;
-  } catch {
+  } catch (err) {
+    if (strict) throw err; // preserve the failure for the strict dispatch path
     return {};
   }
 }

--- a/plugins/dev/scripts/execution-core/cluster-heartbeat-sync.test.mjs
+++ b/plugins/dev/scripts/execution-core/cluster-heartbeat-sync.test.mjs
@@ -245,6 +245,64 @@ describe("readPeerHeartbeatsSync — parsing + fail-open contract", () => {
       ),
     ).toEqual({});
   });
+
+  // CTL-1091 (Codex P1 follow-up): strict mode must THROW on a determinate read
+  // FAILURE (so the dispatch liveness path degrades to the full roster) but still
+  // return {} on a genuinely-EMPTY successful read (so legitimate all-peers-absent
+  // failover is preserved). The default (non-strict) fail-open above is unchanged.
+  describe("strict mode (CTL-1091 P1 follow-up)", () => {
+    test("strict + non-zero exit → THROWS", () => {
+      expect(() =>
+        readPeerHeartbeatsSync({ anchorIssue: "CTL-9" }, { spawn: () => ({ status: 1, stdout: "" }), strict: true }),
+      ).toThrow(/indeterminate peer view/i);
+    });
+
+    test("strict + timeout (status null) → THROWS", () => {
+      expect(() =>
+        readPeerHeartbeatsSync(
+          { anchorIssue: "CTL-9" },
+          { spawn: () => ({ status: null, error: new Error("ETIMEDOUT"), stdout: null }), strict: true },
+        ),
+      ).toThrow(/indeterminate peer view/i);
+    });
+
+    test("strict + spawn throws → THROWS (original error preserved)", () => {
+      expect(() =>
+        readPeerHeartbeatsSync(
+          { anchorIssue: "CTL-9" },
+          { spawn: () => { throw new Error("ENOENT"); }, strict: true },
+        ),
+      ).toThrow(/ENOENT/);
+    });
+
+    test("strict + unparseable stdout → THROWS", () => {
+      expect(() =>
+        readPeerHeartbeatsSync({ anchorIssue: "CTL-9" }, { spawn: () => ({ status: 0, stdout: "not json" }), strict: true }),
+      ).toThrow();
+    });
+
+    test("strict + non-object payload → THROWS", () => {
+      expect(() =>
+        readPeerHeartbeatsSync({ anchorIssue: "CTL-9" }, { spawn: () => ({ status: 0, stdout: "[]\n" }), strict: true }),
+      ).toThrow(/malformed payload/i);
+    });
+
+    test("strict + status 0 empty stdout → {} (genuine empty, NOT a failure)", () => {
+      expect(
+        readPeerHeartbeatsSync({ anchorIssue: "CTL-9" }, { spawn: () => ({ status: 0, stdout: "" }), strict: true }),
+      ).toEqual({});
+    });
+
+    test("strict + status 0 valid peers → returns peers (happy path unaffected)", () => {
+      const map = { mini: { host: "mini", last_seen: "t", in_flight_tickets: [] } };
+      expect(
+        readPeerHeartbeatsSync(
+          { anchorIssue: "CTL-9" },
+          { spawn: () => ({ status: 0, stdout: JSON.stringify(map) + "\n" }), strict: true },
+        ),
+      ).toEqual(map);
+    });
+  });
 });
 
 describe("resolveAnchorIssueIdSync — argv + parsing (CTL-863 entourage follow-up)", () => {

--- a/plugins/dev/scripts/execution-core/config.mjs
+++ b/plugins/dev/scripts/execution-core/config.mjs
@@ -872,6 +872,16 @@ export const HEARTBEAT_INTERVAL_MS =
 export const HEARTBEAT_GRACE_MS =
   Number(process.env.EXECUTION_CORE_HEARTBEAT_GRACE_MS) || 600_000;
 
+// HEARTBEAT_RESTORE_HOLD_MS — CTL-1091 restore-side deflap. A host that
+// transitioned dead→live must be observed continuously live for this window
+// before it re-enters the DISPATCH ownership roster, so a flapping laptop (lid
+// open/close) does not grab-then-strand new work. Default = one grace window
+// (symmetric with the shed side). During the hold the surviving peer keeps
+// covering the slice, so there is no starvation gap. Env-overridable for
+// tests/tuning; also settable via Layer-2 catalyst.cluster.heartbeatRestoreHoldMs.
+export const HEARTBEAT_RESTORE_HOLD_MS =
+  Number(process.env.EXECUTION_CORE_HEARTBEAT_RESTORE_HOLD_MS) || HEARTBEAT_GRACE_MS;
+
 // CLUSTER_SYNC_INTERVAL_MS — how often the daemon git-pulls the catalyst-cluster
 // clone so a roster change committed on one node (CTL-1274 cluster cli) reaches
 // every running daemon without a restart. 5 min keeps the pull cheap while

--- a/plugins/dev/scripts/execution-core/config.mjs
+++ b/plugins/dev/scripts/execution-core/config.mjs
@@ -872,20 +872,32 @@ export const HEARTBEAT_INTERVAL_MS =
 export const HEARTBEAT_GRACE_MS =
   Number(process.env.EXECUTION_CORE_HEARTBEAT_GRACE_MS) || 600_000;
 
+// resolveRestoreHoldMs — parse the CTL-1091 restore-hold override with the
+// documented fallback semantics. Valid: a finite value >= 0, INCLUDING an explicit
+// 0 (opt-out: disables the hold, admitting a restored host immediately). Invalid →
+// fall back to `defaultMs`: unset, empty/whitespace, non-numeric, OR negative.
+// CTL-1091 (Codex P2): a bare `Number(env)` coerced an EMPTY value ("") to 0 and
+// accepted NEGATIVE values, either of which silently disabled the deflap (a flapping
+// host would immediately reclaim its HRW slice) — contradicting the "unset/garbled →
+// default" contract. Exported for unit tests.
+export function resolveRestoreHoldMs(rawStr, defaultMs) {
+  if (typeof rawStr !== "string" || rawStr.trim() === "") return defaultMs;
+  const n = Number(rawStr);
+  return Number.isFinite(n) && n >= 0 ? n : defaultMs;
+}
+
 // HEARTBEAT_RESTORE_HOLD_MS — CTL-1091 restore-side deflap. A host that
 // transitioned dead→live must be observed continuously live for this window
 // before it re-enters the DISPATCH ownership roster, so a flapping laptop (lid
 // open/close) does not grab-then-strand new work. Default = one grace window
 // (symmetric with the shed side). During the hold the surviving peer keeps
 // covering the slice, so there is no starvation gap. Env-overridable via
-// EXECUTION_CORE_HEARTBEAT_RESTORE_HOLD_MS for tests/tuning. A finite value of 0
-// is honored (disables the hold — a restored host is admitted immediately);
-// Number.isFinite gates so an unset/garbled env falls back to the default rather
-// than being swallowed by the falsy-zero of a bare `|| HEARTBEAT_GRACE_MS`.
-export const HEARTBEAT_RESTORE_HOLD_MS = (() => {
-  const raw = Number(process.env.EXECUTION_CORE_HEARTBEAT_RESTORE_HOLD_MS);
-  return Number.isFinite(raw) ? raw : HEARTBEAT_GRACE_MS;
-})();
+// EXECUTION_CORE_HEARTBEAT_RESTORE_HOLD_MS for tests/tuning (see resolveRestoreHoldMs
+// for the validation contract — explicit 0 opt-out honored; empty/negative → default).
+export const HEARTBEAT_RESTORE_HOLD_MS = resolveRestoreHoldMs(
+  process.env.EXECUTION_CORE_HEARTBEAT_RESTORE_HOLD_MS,
+  HEARTBEAT_GRACE_MS,
+);
 
 // CLUSTER_SYNC_INTERVAL_MS — how often the daemon git-pulls the catalyst-cluster
 // clone so a roster change committed on one node (CTL-1274 cluster cli) reaches

--- a/plugins/dev/scripts/execution-core/config.mjs
+++ b/plugins/dev/scripts/execution-core/config.mjs
@@ -877,10 +877,15 @@ export const HEARTBEAT_GRACE_MS =
 // before it re-enters the DISPATCH ownership roster, so a flapping laptop (lid
 // open/close) does not grab-then-strand new work. Default = one grace window
 // (symmetric with the shed side). During the hold the surviving peer keeps
-// covering the slice, so there is no starvation gap. Env-overridable for
-// tests/tuning; also settable via Layer-2 catalyst.cluster.heartbeatRestoreHoldMs.
-export const HEARTBEAT_RESTORE_HOLD_MS =
-  Number(process.env.EXECUTION_CORE_HEARTBEAT_RESTORE_HOLD_MS) || HEARTBEAT_GRACE_MS;
+// covering the slice, so there is no starvation gap. Env-overridable via
+// EXECUTION_CORE_HEARTBEAT_RESTORE_HOLD_MS for tests/tuning. A finite value of 0
+// is honored (disables the hold — a restored host is admitted immediately);
+// Number.isFinite gates so an unset/garbled env falls back to the default rather
+// than being swallowed by the falsy-zero of a bare `|| HEARTBEAT_GRACE_MS`.
+export const HEARTBEAT_RESTORE_HOLD_MS = (() => {
+  const raw = Number(process.env.EXECUTION_CORE_HEARTBEAT_RESTORE_HOLD_MS);
+  return Number.isFinite(raw) ? raw : HEARTBEAT_GRACE_MS;
+})();
 
 // CLUSTER_SYNC_INTERVAL_MS — how often the daemon git-pulls the catalyst-cluster
 // clone so a roster change committed on one node (CTL-1274 cluster cli) reaches

--- a/plugins/dev/scripts/execution-core/config.test.mjs
+++ b/plugins/dev/scripts/execution-core/config.test.mjs
@@ -1364,3 +1364,42 @@ describe("getReplicaDbPath (CTL-1340)", () => {
     expect(getReplicaDbPath()).toBe("/tmp/b/catalyst-replica.db");
   });
 });
+
+// ─── CTL-1091 (Codex P2): resolveRestoreHoldMs validation contract ───────────
+import { resolveRestoreHoldMs } from "./config.mjs";
+
+describe("resolveRestoreHoldMs — restore-hold override validation (CTL-1091 P2)", () => {
+  const DEF = 600_000;
+
+  test("unset (undefined) → default", () => {
+    expect(resolveRestoreHoldMs(undefined, DEF)).toBe(DEF);
+  });
+
+  test("empty string → default (NOT 0 — closes the Number(\"\")===0 bug)", () => {
+    expect(resolveRestoreHoldMs("", DEF)).toBe(DEF);
+    expect(resolveRestoreHoldMs("   ", DEF)).toBe(DEF);
+  });
+
+  test("explicit \"0\" → 0 (opt-out preserved, disables the hold)", () => {
+    expect(resolveRestoreHoldMs("0", DEF)).toBe(0);
+  });
+
+  test("negative → default (invalid)", () => {
+    expect(resolveRestoreHoldMs("-5", DEF)).toBe(DEF);
+    expect(resolveRestoreHoldMs("-1", DEF)).toBe(DEF);
+  });
+
+  test("non-numeric → default", () => {
+    expect(resolveRestoreHoldMs("abc", DEF)).toBe(DEF);
+    expect(resolveRestoreHoldMs("NaN", DEF)).toBe(DEF);
+  });
+
+  test("valid positive → honored", () => {
+    expect(resolveRestoreHoldMs("120000", DEF)).toBe(120_000);
+  });
+
+  test("non-string (defensive) → default", () => {
+    expect(resolveRestoreHoldMs(null, DEF)).toBe(DEF);
+    expect(resolveRestoreHoldMs(5000, DEF)).toBe(DEF);
+  });
+});

--- a/plugins/dev/scripts/execution-core/liveness-deflap.mjs
+++ b/plugins/dev/scripts/execution-core/liveness-deflap.mjs
@@ -38,7 +38,11 @@ export const DEFLAP_STATE_FILE = ".liveness-deflap.json";
 // A host ABSENT from `survivingRoster` (shed/dead) resets its liveSince to null,
 // so a later re-join restarts the whole hold (deflap).
 //
-// `self` is never held — a host never defers taking its OWN work.
+// `self` is never held AND never shed — a host always owns its OWN work, even
+// when it is absent from `survivingRoster` (a not-yet-heartbeated fresh start or
+// a stale/laggy self-heartbeat read). The self guard is hoisted above the
+// shed branch so it is reached regardless of self's observed liveness (CTL-1091
+// correctness review #1).
 //
 // FAIL-SAFE: if the filter would empty the dispatch roster (e.g. a total liveness
 // outage degraded survivingRoster to the full roster on a cold start where every
@@ -59,6 +63,24 @@ export function computeDispatchRoster({
   const dispatchRoster = [];
 
   for (const h of roster ?? []) {
+    // self is ALWAYS admitted to its OWN dispatch roster and never held — this
+    // guard is hoisted ABOVE the surviving.has() gate on purpose. A host must
+    // never defer or re-home its own HRW slice based on its own observed
+    // liveness: on a fresh daemon start (self has not emitted its first heartbeat
+    // yet) or a stale/laggy self-heartbeat read, self is absent from the live
+    // `survivingRoster` and would otherwise fall into the `!surviving.has(h)`
+    // shed branch below BEFORE this self guard was ever reached — silently
+    // re-homing self's slice to a peer during the warmup window (CTL-1091
+    // correctness review #1). Keeping the guard first makes the documented
+    // "self never held / never double-acts" invariant hold regardless of whether
+    // self appears in the live set this tick.
+    if (self !== undefined && h === self) {
+      const liveSince = nowMs - holdMs;
+      nextState[h] = { liveSince };
+      dispatchRoster.push(h);
+      continue;
+    }
+
     if (!surviving.has(h)) {
       // Shed / dead this tick → reset the restore hold; not dispatch-eligible.
       nextState[h] = { liveSince: null };
@@ -77,9 +99,6 @@ export function computeDispatchRoster({
       // Explicit null → was dead, now restored → start the hold now.
       liveSince = nowMs;
     }
-
-    // self never defers taking its own work.
-    if (self !== undefined && h === self) liveSince = nowMs - holdMs;
 
     nextState[h] = { liveSince };
     if (nowMs - liveSince >= holdMs) dispatchRoster.push(h);

--- a/plugins/dev/scripts/execution-core/liveness-deflap.mjs
+++ b/plugins/dev/scripts/execution-core/liveness-deflap.mjs
@@ -1,0 +1,123 @@
+// liveness-deflap.mjs — CTL-1091 Phase 2. Restore-side deflap (hysteresis) for
+// the DISPATCH ownership roster.
+//
+// The shed side already has hysteresis: computeSurvivingRoster only drops a host
+// after HEARTBEAT_GRACE_MS (~10 min ≈ 20 missed heartbeats). The restore side had
+// none — a host that flaps back (laptop lid re-opens) would immediately re-enter
+// the roster, grab its HRW slice, then strand it on the next lid-close. This
+// module adds a symmetric restore hold: a host that transitioned dead→live must
+// be observed continuously live for holdMs before it re-enters the dispatch
+// roster. During the hold the surviving peer keeps covering the slice, so there
+// is NO starvation gap — the recovering host merely defers RE-TAKING new work.
+//
+// Applies to the DISPATCH roster only (not recovery — see plan Phase 2 Overview):
+// recovery keeps its grace-only surviving roster.
+//
+// Per-host observation state is a tiny `{ <host>: { liveSince: <ms>|null } }` map
+// the caller persists (scheduler is the sole writer; monitor reads it read-only).
+
+import { readFileSync, writeFileSync, renameSync } from "node:fs";
+import { join } from "node:path";
+
+// The on-disk observation-state file, relative to an orchestrator dir.
+export const DEFLAP_STATE_FILE = ".liveness-deflap.json";
+
+// computeDispatchRoster — apply the restore-side deflap to the surviving roster.
+//
+// A host present in `survivingRoster` (currently live) is admitted to the
+// DISPATCH roster only once it has been continuously live for `holdMs`, tracked
+// via a per-host `liveSince` timestamp. Semantics of `prevState[h]`:
+//   • absent entry            → first observation / cold start. Treated as
+//                               already past the hold (admit) so a cold start
+//                               does NOT transiently shed every live host.
+//   • { liveSince: <number> } → continuously live. Keep the timestamp; admit
+//                               once nowMs - liveSince >= holdMs.
+//   • { liveSince: null }     → was explicitly dead last tick → newly restored.
+//                               Start the hold now (liveSince = nowMs); hold out
+//                               until the window elapses.
+// A host ABSENT from `survivingRoster` (shed/dead) resets its liveSince to null,
+// so a later re-join restarts the whole hold (deflap).
+//
+// `self` is never held — a host never defers taking its OWN work.
+//
+// FAIL-SAFE: if the filter would empty the dispatch roster (e.g. a total liveness
+// outage degraded survivingRoster to the full roster on a cold start where every
+// host looks newly-restored), degrade to the surviving roster unchanged — deflap
+// must never strand the whole board.
+//
+// Pure. Returns { dispatchRoster, nextState }; the caller persists nextState.
+export function computeDispatchRoster({
+  survivingRoster,
+  roster,
+  prevState = {},
+  holdMs,
+  nowMs,
+  self,
+} = {}) {
+  const surviving = new Set(survivingRoster ?? []);
+  const nextState = {};
+  const dispatchRoster = [];
+
+  for (const h of roster ?? []) {
+    if (!surviving.has(h)) {
+      // Shed / dead this tick → reset the restore hold; not dispatch-eligible.
+      nextState[h] = { liveSince: null };
+      continue;
+    }
+
+    // Host is currently live — resolve its continuous-live-since timestamp.
+    let liveSince;
+    const entry = prevState[h];
+    if (!entry || !Object.prototype.hasOwnProperty.call(entry, "liveSince")) {
+      // Cold start: treat as already past the hold (admit) — no transient shed.
+      liveSince = nowMs - holdMs;
+    } else if (typeof entry.liveSince === "number") {
+      liveSince = entry.liveSince; // continuously live — keep the running hold
+    } else {
+      // Explicit null → was dead, now restored → start the hold now.
+      liveSince = nowMs;
+    }
+
+    // self never defers taking its own work.
+    if (self !== undefined && h === self) liveSince = nowMs - holdMs;
+
+    nextState[h] = { liveSince };
+    if (nowMs - liveSince >= holdMs) dispatchRoster.push(h);
+  }
+
+  if (dispatchRoster.length === 0) {
+    // Never strand: degrade to the surviving roster (fail-safe).
+    return { dispatchRoster: [...surviving], nextState };
+  }
+  return { dispatchRoster, nextState };
+}
+
+// readDeflapState — the persisted per-host observation map for an orchestrator
+// dir. Absent file / parse failure → {} (no prior observations → cold start).
+// Never throws — a corrupt file must not wedge the tick.
+export function readDeflapState(orchDir) {
+  if (!orchDir) return {};
+  try {
+    const raw = readFileSync(join(orchDir, DEFLAP_STATE_FILE), "utf8");
+    const parsed = JSON.parse(raw);
+    return parsed && typeof parsed === "object" ? parsed : {};
+  } catch {
+    return {};
+  }
+}
+
+// writeDeflapState — atomically persist the observation map (tmp + rename), the
+// same pattern the fence-token / cluster-generation writes use. Best-effort: a
+// write failure is swallowed (the next tick recomputes from whatever survived).
+// The scheduler tick is the SOLE writer; monitor only reads.
+export function writeDeflapState(orchDir, nextState) {
+  if (!orchDir) return;
+  const dest = join(orchDir, DEFLAP_STATE_FILE);
+  const tmp = `${dest}.tmp.${process.pid}`;
+  try {
+    writeFileSync(tmp, JSON.stringify(nextState ?? {}));
+    renameSync(tmp, dest);
+  } catch {
+    // best-effort — leave whatever prior state exists.
+  }
+}

--- a/plugins/dev/scripts/execution-core/liveness-deflap.test.mjs
+++ b/plugins/dev/scripts/execution-core/liveness-deflap.test.mjs
@@ -5,7 +5,15 @@
 // grab-then-strand new work.
 
 import { describe, test, expect } from "bun:test";
-import { computeDispatchRoster } from "./liveness-deflap.mjs";
+import { mkdtempSync, writeFileSync, existsSync, readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  computeDispatchRoster,
+  readDeflapState,
+  writeDeflapState,
+  DEFLAP_STATE_FILE,
+} from "./liveness-deflap.mjs";
 
 describe("computeDispatchRoster — restore deflap (CTL-1091)", () => {
   const HOLD = 600_000; // HEARTBEAT_RESTORE_HOLD_MS
@@ -85,6 +93,40 @@ describe("computeDispatchRoster — restore deflap (CTL-1091)", () => {
     expect(dispatchRoster).toContain("mini");
   });
 
+  // CTL-1091 correctness review #1 (HIGH): self must be admitted to its OWN
+  // dispatch roster even when it is ABSENT from survivingRoster — a fresh daemon
+  // start (self has not heartbeated yet) or a stale/laggy self-heartbeat read
+  // leaves self out of the positive-liveness set. The self guard is hoisted above
+  // the shed branch so self never re-homes its own HRW slice to a peer.
+  test("admits SELF even when it is absent from the surviving (live) roster", () => {
+    const now = 5_000;
+    const { dispatchRoster, nextState } = computeDispatchRoster({
+      survivingRoster: ["laptop"], // self (mini) NOT observed live this tick
+      roster: ["mini", "laptop"],
+      prevState: {}, // cold: nothing known about self yet
+      holdMs: HOLD,
+      nowMs: now,
+      self: "mini",
+    });
+    expect(dispatchRoster).toContain("mini"); // self not shed despite absence
+    expect(nextState.mini.liveSince).toBe(now - HOLD); // recorded as past the hold
+  });
+
+  test("admits SELF absent-from-feed even when prevState marks it dead (null)", () => {
+    // The empirically-confirmed regression: roster=[A,B], self=A absent from the
+    // live feed with a prior dead marker, B live → A must still be in the roster.
+    const now = 9_000;
+    const { dispatchRoster } = computeDispatchRoster({
+      survivingRoster: ["B"], // A (self) absent
+      roster: ["A", "B"],
+      prevState: { A: { liveSince: null } }, // A looked dead last tick
+      holdMs: HOLD,
+      nowMs: now,
+      self: "A",
+    });
+    expect(dispatchRoster.slice().sort()).toEqual(["A", "B"]);
+  });
+
   test("cold start (no prior state) admits every live host — no transient shed", () => {
     // First run / absent .liveness-deflap.json: a live host with no prior
     // observation is treated as already past the hold, NOT newly-restored, so a
@@ -122,5 +164,81 @@ describe("computeDispatchRoster — restore deflap (CTL-1091)", () => {
       nowMs: 1_000,
     });
     expect(dispatchRoster).toEqual(["solo"]);
+  });
+
+  // CTL-1091 verify (phase-verify F3): pin the 3-host self-ordering so a future
+  // refactor can't regress the "self admitted immediately while a restored peer is
+  // held and a continuously-live peer is admitted" combination in one roster pass.
+  test("3-host: self admitted immediately, restored peer held, live peer admitted", () => {
+    const now = 10_000_000;
+    const { dispatchRoster, nextState } = computeDispatchRoster({
+      survivingRoster: ["mini", "laptop", "desktop"], // all currently live
+      roster: ["mini", "laptop", "desktop"],
+      prevState: {
+        // desktop was continuously live and already past the hold
+        desktop: { liveSince: now - HOLD - 1 },
+        // laptop just came back this tick (was dead) → must be held
+        laptop: { liveSince: null },
+        // mini (self) has no prior entry, but self is force-admitted regardless
+      },
+      holdMs: HOLD,
+      nowMs: now,
+      self: "mini",
+    });
+    expect(dispatchRoster.slice().sort()).toEqual(["desktop", "mini"]);
+    expect(dispatchRoster).not.toContain("laptop"); // restored peer still held
+    expect(nextState.laptop.liveSince).toBe(now); // hold started this tick
+    expect(nextState.mini.liveSince).toBe(now - HOLD); // self past the hold
+  });
+});
+
+// CTL-1091 verify (phase-verify F2): the persisted-state I/O helpers. These
+// defensive branches (corrupt/absent/non-object file → {}, unwritable → no throw)
+// are the fail-safes that keep a corrupt .liveness-deflap.json from wedging a tick;
+// they were only exercised incidentally by the scheduler scenarios before.
+describe("readDeflapState / writeDeflapState — persisted observation state (CTL-1091)", () => {
+  test("absent file → {} (cold start, no throw)", () => {
+    const dir = mkdtempSync(join(tmpdir(), "deflap-absent-"));
+    expect(readDeflapState(dir)).toEqual({});
+  });
+
+  test("corrupt (non-JSON) file → {} (no throw, does not wedge the tick)", () => {
+    const dir = mkdtempSync(join(tmpdir(), "deflap-corrupt-"));
+    writeFileSync(join(dir, DEFLAP_STATE_FILE), "{not valid json");
+    expect(readDeflapState(dir)).toEqual({});
+  });
+
+  // The guard is `parsed && typeof parsed === "object"`, so a JSON `null` or a
+  // bare primitive coerces to {}. (A top-level JSON array is technically typeof
+  // "object" and passes through, but it is harmless — it has no host-named keys,
+  // so every downstream prevState[host] lookup just cold-starts.)
+  test("non-object JSON (null / primitive) → {}", () => {
+    const dirNull = mkdtempSync(join(tmpdir(), "deflap-null-"));
+    writeFileSync(join(dirNull, DEFLAP_STATE_FILE), "null");
+    expect(readDeflapState(dirNull)).toEqual({});
+    const dirNum = mkdtempSync(join(tmpdir(), "deflap-num-"));
+    writeFileSync(join(dirNum, DEFLAP_STATE_FILE), "42");
+    expect(readDeflapState(dirNum)).toEqual({});
+  });
+
+  test("falsy orchDir → {} with no read", () => {
+    expect(readDeflapState(undefined)).toEqual({});
+    expect(readDeflapState("")).toEqual({});
+  });
+
+  test("round-trips a valid observation map atomically (no .tmp leftover)", () => {
+    const dir = mkdtempSync(join(tmpdir(), "deflap-rt-"));
+    const state = { mini: { liveSince: 123 }, laptop: { liveSince: null } };
+    writeDeflapState(dir, state);
+    expect(JSON.parse(readFileSync(join(dir, DEFLAP_STATE_FILE), "utf8"))).toEqual(state);
+    expect(readDeflapState(dir)).toEqual(state);
+    expect(existsSync(join(dir, `${DEFLAP_STATE_FILE}.tmp.${process.pid}`))).toBe(false);
+  });
+
+  test("writeDeflapState to an unwritable dir is swallowed (best-effort, no throw)", () => {
+    // A non-existent nested dir makes the tmp write fail; must NOT throw.
+    const bogus = join(tmpdir(), "deflap-nope-does-not-exist", "child");
+    expect(() => writeDeflapState(bogus, { mini: { liveSince: 1 } })).not.toThrow();
+    expect(() => writeDeflapState(undefined, {})).not.toThrow();
   });
 });

--- a/plugins/dev/scripts/execution-core/liveness-deflap.test.mjs
+++ b/plugins/dev/scripts/execution-core/liveness-deflap.test.mjs
@@ -1,0 +1,126 @@
+// liveness-deflap.test.mjs — CTL-1091 Phase 2. Unit tests for the pure
+// restore-side deflap that layers on top of the surviving roster: a host that
+// transitioned dead→live must be observed continuously live for holdMs before it
+// re-enters the DISPATCH roster, so a flapping laptop (lid open/close) does not
+// grab-then-strand new work.
+
+import { describe, test, expect } from "bun:test";
+import { computeDispatchRoster } from "./liveness-deflap.mjs";
+
+describe("computeDispatchRoster — restore deflap (CTL-1091)", () => {
+  const HOLD = 600_000; // HEARTBEAT_RESTORE_HOLD_MS
+
+  test("keeps a freshly-restored host OUT until continuously live for the hold", () => {
+    // prevState marks laptop as previously dead (liveSince:null). It is live now
+    // (in survivingRoster) → first live observation → liveSince=nowMs, elapsed
+    // 0 < HOLD → excluded from the dispatch roster.
+    const { dispatchRoster, nextState } = computeDispatchRoster({
+      survivingRoster: ["mini", "laptop"],
+      roster: ["mini", "laptop"],
+      prevState: { laptop: { liveSince: null } },
+      holdMs: HOLD,
+      nowMs: 1_000,
+    });
+    expect(dispatchRoster).toEqual(["mini"]);
+    expect(nextState.laptop.liveSince).toBe(1_000);
+  });
+
+  test("admits the host once liveSince is older than the hold", () => {
+    const { dispatchRoster } = computeDispatchRoster({
+      survivingRoster: ["mini", "laptop"],
+      roster: ["mini", "laptop"],
+      prevState: { laptop: { liveSince: 1_000 } },
+      holdMs: HOLD,
+      nowMs: 1_000 + HOLD + 1,
+    });
+    expect(dispatchRoster).toEqual(["mini", "laptop"]);
+  });
+
+  test("still holds the host the tick BEFORE the hold elapses (boundary)", () => {
+    const { dispatchRoster } = computeDispatchRoster({
+      survivingRoster: ["mini", "laptop"],
+      roster: ["mini", "laptop"],
+      prevState: { laptop: { liveSince: 1_000 } },
+      holdMs: HOLD,
+      nowMs: 1_000 + HOLD - 1,
+    });
+    expect(dispatchRoster).toEqual(["mini"]);
+  });
+
+  test("preserves a continuously-live host's liveSince across ticks", () => {
+    const { nextState } = computeDispatchRoster({
+      survivingRoster: ["mini", "laptop"],
+      roster: ["mini", "laptop"],
+      prevState: { laptop: { liveSince: 1_000 } },
+      holdMs: HOLD,
+      nowMs: 50_000,
+    });
+    expect(nextState.laptop.liveSince).toBe(1_000);
+  });
+
+  test("resets liveSince when the host drops out of the surviving roster (flap)", () => {
+    // laptop had a live-hold running, now it is NOT in survivingRoster (shed) →
+    // liveSince resets to null so a re-join restarts the whole hold.
+    const { nextState, dispatchRoster } = computeDispatchRoster({
+      survivingRoster: ["mini"],
+      roster: ["mini", "laptop"],
+      prevState: { laptop: { liveSince: 1_000 } },
+      holdMs: HOLD,
+      nowMs: 5_000,
+    });
+    expect(nextState.laptop.liveSince).toBeNull();
+    expect(dispatchRoster).toEqual(["mini"]);
+  });
+
+  test("never delays the SELF host, even if it looks freshly restored", () => {
+    // A host never defers taking its OWN work — self is admitted regardless of hold.
+    const { dispatchRoster } = computeDispatchRoster({
+      survivingRoster: ["mini", "laptop"],
+      roster: ["mini", "laptop"],
+      prevState: { mini: { liveSince: null } },
+      holdMs: HOLD,
+      nowMs: 1_000,
+      self: "mini",
+    });
+    expect(dispatchRoster).toContain("mini");
+  });
+
+  test("cold start (no prior state) admits every live host — no transient shed", () => {
+    // First run / absent .liveness-deflap.json: a live host with no prior
+    // observation is treated as already past the hold, NOT newly-restored, so a
+    // cold start does not transiently shed every host (migration note).
+    const { dispatchRoster } = computeDispatchRoster({
+      survivingRoster: ["mini", "laptop"],
+      roster: ["mini", "laptop"],
+      prevState: {},
+      holdMs: HOLD,
+      nowMs: 1_000,
+    });
+    expect(dispatchRoster.slice().sort()).toEqual(["laptop", "mini"]);
+  });
+
+  test("fail-safe: an all-newly-restored fleet degrades to the surviving roster (never strands)", () => {
+    // Pathological: every live host looks newly-restored → the naive filter would
+    // empty the dispatch roster. The backstop degrades to the surviving roster so
+    // dispatch never strands the whole board.
+    const { dispatchRoster } = computeDispatchRoster({
+      survivingRoster: ["mini", "laptop"],
+      roster: ["mini", "laptop"],
+      prevState: { mini: { liveSince: null }, laptop: { liveSince: null } },
+      holdMs: HOLD,
+      nowMs: 1_000,
+    });
+    expect(dispatchRoster.slice().sort()).toEqual(["laptop", "mini"]);
+  });
+
+  test("single-host roster admits the lone host unchanged", () => {
+    const { dispatchRoster } = computeDispatchRoster({
+      survivingRoster: ["solo"],
+      roster: ["solo"],
+      prevState: {},
+      holdMs: HOLD,
+      nowMs: 1_000,
+    });
+    expect(dispatchRoster).toEqual(["solo"]);
+  });
+});

--- a/plugins/dev/scripts/execution-core/loki-liveness-sync.mjs
+++ b/plugins/dev/scripts/execution-core/loki-liveness-sync.mjs
@@ -32,18 +32,38 @@ export function readClusterLivenessFromLokiSync(
     cli = LOKI_LIVENESS_CLI,
     env = process.env,
     timeout = LOKI_LIVENESS_TIMEOUT_MS,
+    // CTL-1091 (Codex P1 follow-up): mirror readPeerHeartbeatsSync — when TRUE, a
+    // DETERMINATE read FAILURE (missing Loki URL, spawn error, timeout, nonzero exit,
+    // non-string/unparseable/non-object stdout) THROWS instead of collapsing to `{}`,
+    // so the strict DISPATCH liveness path can tell a FAILED read (→ full-roster outage
+    // fallback) apart from a genuinely EMPTY successful read. Default false preserves
+    // the fail-open behavior recovery relies on.
+    strict = false,
   } = {},
 ) {
-  if (typeof lokiUrl !== "string" || lokiUrl.length === 0) return {};
+  if (typeof lokiUrl !== "string" || lokiUrl.length === 0) {
+    if (strict) throw new Error("ctl-1091: Loki liveness read has no query URL — indeterminate peer view");
+    return {};
+  }
   try {
     const res = spawn(nodeBin, [cli, "read", lokiUrl], { encoding: "utf8", env, timeout });
-    if (!res || res.status !== 0 || typeof res.stdout !== "string") return {};
+    if (!res || res.status !== 0 || typeof res.stdout !== "string") {
+      if (strict)
+        throw new Error(
+          `ctl-1091: Loki liveness read failed (status=${res?.status ?? "none"}) — indeterminate peer view`,
+        );
+      return {};
+    }
     const line = res.stdout.trim().split("\n").filter(Boolean).pop();
-    if (!line) return {};
+    if (!line) return {}; // status 0, no data → genuinely empty (a determinate success)
     const parsed = JSON.parse(line);
-    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return {};
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+      if (strict) throw new Error("ctl-1091: Loki liveness read returned a malformed payload");
+      return {};
+    }
     return parsed;
-  } catch {
+  } catch (err) {
+    if (strict) throw err; // preserve the failure for the strict dispatch path
     return {};
   }
 }

--- a/plugins/dev/scripts/execution-core/loki-liveness-sync.test.mjs
+++ b/plugins/dev/scripts/execution-core/loki-liveness-sync.test.mjs
@@ -45,6 +45,50 @@ describe("readClusterLivenessFromLokiSync (CTL-1420 #17) — fail-open", () => {
     const spawn = () => { throw new Error("ENOENT"); };
     expect(readClusterLivenessFromLokiSync({ lokiUrl: "http://loki:3100" }, { spawn })).toEqual({});
   });
+
+  // CTL-1091 (Codex P1 follow-up): strict mode surfaces a determinate FAILURE as a
+  // throw (dispatch → full-roster outage fallback) while still returning {} on a
+  // genuinely-empty successful read. Default (non-strict) fail-open above unchanged.
+  describe("strict mode (CTL-1091 P1 follow-up)", () => {
+    test("strict + missing lokiUrl → THROWS", () => {
+      expect(() => readClusterLivenessFromLokiSync({ lokiUrl: "" }, { spawn: () => ({}), strict: true })).toThrow(
+        /indeterminate peer view/i,
+      );
+    });
+
+    test("strict + non-zero exit → THROWS", () => {
+      const spawn = () => ({ status: 1, stdout: "", stderr: "boom" });
+      expect(() => readClusterLivenessFromLokiSync({ lokiUrl: "http://loki:3100" }, { spawn, strict: true })).toThrow(
+        /indeterminate peer view/i,
+      );
+    });
+
+    test("strict + spawn throws → THROWS (original error preserved)", () => {
+      const spawn = () => { throw new Error("ENOENT"); };
+      expect(() => readClusterLivenessFromLokiSync({ lokiUrl: "http://loki:3100" }, { spawn, strict: true })).toThrow(
+        /ENOENT/,
+      );
+    });
+
+    test("strict + array/non-object payload → THROWS", () => {
+      const spawn = () => ({ status: 0, stdout: "[1,2,3]\n" });
+      expect(() => readClusterLivenessFromLokiSync({ lokiUrl: "http://loki:3100" }, { spawn, strict: true })).toThrow(
+        /malformed payload/i,
+      );
+    });
+
+    test("strict + status 0 empty stdout → {} (genuine empty, NOT a failure)", () => {
+      const spawn = () => ({ status: 0, stdout: "" });
+      expect(readClusterLivenessFromLokiSync({ lokiUrl: "http://loki:3100" }, { spawn, strict: true })).toEqual({});
+    });
+
+    test("strict + valid peers → returns peers (happy path unaffected)", () => {
+      const map = { mini: { last_seen: "2026-07-07T19:04:50.000Z", in_flight_tickets: [] } };
+      expect(
+        readClusterLivenessFromLokiSync({ lokiUrl: "http://loki:3100" }, { spawn: okSpawn(map), strict: true }),
+      ).toEqual(map);
+    });
+  });
 });
 
 describe("readClusterLivenessFromLokiSyncCached (CTL-1420 #17)", () => {

--- a/plugins/dev/scripts/execution-core/monitor.mjs
+++ b/plugins/dev/scripts/execution-core/monitor.mjs
@@ -85,11 +85,12 @@ import {
   readMaxParallel,
   computeFreeSlots,
   writeClusterGeneration,
-  // CTL-1091: route the triage-dispatch HRW gate through the same surviving
-  // (live) roster the scheduler's new-work gate uses, so both dispatch sites
-  // fail an offline owner's slice over to a live host. This helper pulls in no
-  // bun:sqlite dependency, so it is safe to import here (CTL-1397 Node-loadability).
-  computeSurvivingRoster,
+  // CTL-1091: route the triage-dispatch HRW gate through the same live roster the
+  // scheduler's new-work gate uses (positive-liveness → sheds a never-live host),
+  // so both dispatch sites fail an offline owner's slice over to a live host. This
+  // helper pulls in no bun:sqlite dependency, so it is safe to import here
+  // (CTL-1397 Node-loadability).
+  computeDispatchSurvivingRoster,
 } from "./scheduler.mjs";
 // CTL-863: Linear-free fence event emitter (durable fence → event-log migration).
 import { emitFenceClaimed } from "./fence-event.mjs";
@@ -694,7 +695,7 @@ function dispatchTriage(
     hostName = undefined,
     // CTL-1091: injectable surviving-roster override for the ownership gate below,
     // mirroring the scheduler's dispatchSurvivingRoster. Default undefined →
-    // computeSurvivingRoster(roster) (reads the live heartbeat feed). Tests inject
+    // computeDispatchSurvivingRoster(roster) (positive-liveness heartbeat read). Tests inject
     // a fixed survivor set to drive the offline-owner failover deterministically.
     survivingRosterOverride = undefined,
     claimDispatch = claimDispatchSync,
@@ -742,7 +743,7 @@ function dispatchTriage(
   // whose HRW owner is offline is triaged by a live host instead of stranding.
   // Injectable for tests; defaults to the live heartbeat feed. The heartbeat
   // sync wrappers cache (Loki 20s / Linear 45s) so per-call reads coalesce.
-  // Fail-safe: computeSurvivingRoster degrades to the full roster on a
+  // Fail-safe: computeDispatchSurvivingRoster degrades to the full roster on a
   // read-throw / all-dead (today's raw-roster behavior). Only computed multi-host.
   //
   // Phase 2: layer the restore-side deflap on top of the surviving roster so
@@ -755,7 +756,9 @@ function dispatchTriage(
     // Test override bypasses both the heartbeat read and the deflap.
     dispatchRoster = survivingRosterOverride;
   } else {
-    const survivingRosterNow = computeSurvivingRoster(roster);
+    // Phase 3: positive-liveness surviving roster (sheds a never-live host), then
+    // Phase 2 restore deflap on top. READ-ONLY deflap state (scheduler is sole writer).
+    const survivingRosterNow = computeDispatchSurvivingRoster(roster);
     dispatchRoster = computeDispatchRoster({
       survivingRoster: survivingRosterNow,
       roster,

--- a/plugins/dev/scripts/execution-core/monitor.mjs
+++ b/plugins/dev/scripts/execution-core/monitor.mjs
@@ -38,7 +38,6 @@ import {
   hostMembershipWarning, // CTL-1057
   isDraining as isDrainingDefault, // CTL-1095: drain gate
   isInProcessDispatchMode, // CTL-1457 (T2): sdk|codex-exec occupancy gate predicate
-  HEARTBEAT_RESTORE_HOLD_MS, // CTL-1091: restore-side deflap hold for the dispatch roster
 } from "./config.mjs";
 // CTL-1397 (Node-loadability): monitor.mjs MUST NOT import replica-read.mjs — that
 // module statically imports `bun:sqlite`, which the Node ESM loader rejects at
@@ -49,10 +48,6 @@ import {
 // (linear-query.mjs never imports replica-read.mjs either; daemon.mjs:681 builds
 // the reader and passes it in). monitor.mjs stays Node-loadable.
 import { ownedBy } from "./hrw.mjs"; // CTL-862: HRW ownership filter
-// CTL-1091: restore-side deflap — READ-ONLY here (scheduler tick is the sole
-// writer of .liveness-deflap.json). Pure node:fs/node:path; no bun:sqlite dep,
-// so it is safe to import into the Node-loadable monitor.mjs (CTL-1397).
-import { computeDispatchRoster, readDeflapState } from "./liveness-deflap.mjs";
 import { claimDispatchSync } from "./cluster-claim-sync.mjs"; // CTL-862: cross-host claim soft-CAS
 import { listProjects, getProjectConfig, resolveEligibleQuery } from "./registry.mjs";
 import {
@@ -85,12 +80,12 @@ import {
   readMaxParallel,
   computeFreeSlots,
   writeClusterGeneration,
-  // CTL-1091: route the triage-dispatch HRW gate through the same live roster the
-  // scheduler's new-work gate uses (positive-liveness → sheds a never-live host),
-  // so both dispatch sites fail an offline owner's slice over to a live host. This
-  // helper pulls in no bun:sqlite dependency, so it is safe to import here
-  // (CTL-1397 Node-loadability).
-  computeDispatchSurvivingRoster,
+  // CTL-1091: route the triage-dispatch HRW gate through the SAME helper the
+  // scheduler's new-work gate uses (positive-liveness → restore-deflap → outage
+  // fail-safe), so both dispatch sites can never drift out of sync. This helper
+  // pulls in no bun:sqlite dependency, so it is safe to import here (CTL-1397
+  // Node-loadability).
+  resolveDispatchRoster,
 } from "./scheduler.mjs";
 // CTL-863: Linear-free fence event emitter (durable fence → event-log migration).
 import { emitFenceClaimed } from "./fence-event.mjs";
@@ -739,16 +734,13 @@ function dispatchTriage(
     globalThis.__ctl1057_monitor_warned = true;
     log.warn({ roster, self }, _mw);
   }
-  // CTL-1091: ownership over the LIVE (surviving) roster, so a →Triage ticket
-  // whose HRW owner is offline is triaged by a live host instead of stranding.
-  // Injectable for tests; defaults to the live heartbeat feed. The heartbeat
-  // sync wrappers cache (Loki 20s / Linear 45s) so per-call reads coalesce.
-  // Fail-safe: computeDispatchSurvivingRoster degrades to the full roster on a
-  // read-throw / all-dead (today's raw-roster behavior). Only computed multi-host.
-  //
-  // Phase 2: layer the restore-side deflap on top of the surviving roster so
-  // triage and new-work agree on the deflapped roster. READ-ONLY — the scheduler
-  // tick is the sole writer of .liveness-deflap.json; monitor discards nextState.
+  // CTL-1091: ownership over the LIVE roster (positive-liveness + restore-deflap +
+  // outage fail-safe), so a →Triage ticket whose HRW owner is offline is triaged by
+  // a live host instead of stranding. Computed via the SAME resolveDispatchRoster
+  // the scheduler's new-work gate uses, so the two dispatch sites can never drift
+  // out of sync. READ-ONLY here (persist:false) — the scheduler tick is the sole
+  // writer of .liveness-deflap.json. The heartbeat sync wrappers cache (Loki 20s /
+  // Linear 45s) so per-call reads coalesce. Only computed multi-host.
   let dispatchRoster;
   if (!multiHost) {
     dispatchRoster = roster;
@@ -756,17 +748,13 @@ function dispatchTriage(
     // Test override bypasses both the heartbeat read and the deflap.
     dispatchRoster = survivingRosterOverride;
   } else {
-    // Phase 3: positive-liveness surviving roster (sheds a never-live host), then
-    // Phase 2 restore deflap on top. READ-ONLY deflap state (scheduler is sole writer).
-    const survivingRosterNow = computeDispatchSurvivingRoster(roster);
-    dispatchRoster = computeDispatchRoster({
-      survivingRoster: survivingRosterNow,
+    dispatchRoster = resolveDispatchRoster({
       roster,
-      prevState: readDeflapState(orchDir),
-      holdMs: HEARTBEAT_RESTORE_HOLD_MS,
-      nowMs: Date.now(),
+      orchDir,
       self,
-    }).dispatchRoster;
+      nowMs: Date.now(),
+      persist: false,
+    });
   }
   if (multiHost && !ownedBy(identifier, dispatchRoster, self)) {
     log.debug(

--- a/plugins/dev/scripts/execution-core/monitor.mjs
+++ b/plugins/dev/scripts/execution-core/monitor.mjs
@@ -38,6 +38,7 @@ import {
   hostMembershipWarning, // CTL-1057
   isDraining as isDrainingDefault, // CTL-1095: drain gate
   isInProcessDispatchMode, // CTL-1457 (T2): sdk|codex-exec occupancy gate predicate
+  HEARTBEAT_RESTORE_HOLD_MS, // CTL-1091: restore-side deflap hold for the dispatch roster
 } from "./config.mjs";
 // CTL-1397 (Node-loadability): monitor.mjs MUST NOT import replica-read.mjs — that
 // module statically imports `bun:sqlite`, which the Node ESM loader rejects at
@@ -48,6 +49,10 @@ import {
 // (linear-query.mjs never imports replica-read.mjs either; daemon.mjs:681 builds
 // the reader and passes it in). monitor.mjs stays Node-loadable.
 import { ownedBy } from "./hrw.mjs"; // CTL-862: HRW ownership filter
+// CTL-1091: restore-side deflap — READ-ONLY here (scheduler tick is the sole
+// writer of .liveness-deflap.json). Pure node:fs/node:path; no bun:sqlite dep,
+// so it is safe to import into the Node-loadable monitor.mjs (CTL-1397).
+import { computeDispatchRoster, readDeflapState } from "./liveness-deflap.mjs";
 import { claimDispatchSync } from "./cluster-claim-sync.mjs"; // CTL-862: cross-host claim soft-CAS
 import { listProjects, getProjectConfig, resolveEligibleQuery } from "./registry.mjs";
 import {
@@ -739,11 +744,27 @@ function dispatchTriage(
   // sync wrappers cache (Loki 20s / Linear 45s) so per-call reads coalesce.
   // Fail-safe: computeSurvivingRoster degrades to the full roster on a
   // read-throw / all-dead (today's raw-roster behavior). Only computed multi-host.
-  const dispatchRoster = !multiHost
-    ? roster
-    : Array.isArray(survivingRosterOverride)
-      ? survivingRosterOverride
-      : computeSurvivingRoster(roster);
+  //
+  // Phase 2: layer the restore-side deflap on top of the surviving roster so
+  // triage and new-work agree on the deflapped roster. READ-ONLY — the scheduler
+  // tick is the sole writer of .liveness-deflap.json; monitor discards nextState.
+  let dispatchRoster;
+  if (!multiHost) {
+    dispatchRoster = roster;
+  } else if (Array.isArray(survivingRosterOverride)) {
+    // Test override bypasses both the heartbeat read and the deflap.
+    dispatchRoster = survivingRosterOverride;
+  } else {
+    const survivingRosterNow = computeSurvivingRoster(roster);
+    dispatchRoster = computeDispatchRoster({
+      survivingRoster: survivingRosterNow,
+      roster,
+      prevState: readDeflapState(orchDir),
+      holdMs: HEARTBEAT_RESTORE_HOLD_MS,
+      nowMs: Date.now(),
+      self,
+    }).dispatchRoster;
+  }
   if (multiHost && !ownedBy(identifier, dispatchRoster, self)) {
     log.debug(
       { identifier, self, roster, dispatchRoster },

--- a/plugins/dev/scripts/execution-core/monitor.mjs
+++ b/plugins/dev/scripts/execution-core/monitor.mjs
@@ -690,8 +690,12 @@ function dispatchTriage(
     hostName = undefined,
     // CTL-1091: injectable surviving-roster override for the ownership gate below,
     // mirroring the scheduler's dispatchSurvivingRoster. Default undefined →
-    // computeDispatchSurvivingRoster(roster) (positive-liveness heartbeat read). Tests inject
-    // a fixed survivor set to drive the offline-owner failover deterministically.
+    // resolveDispatchRoster (positive-liveness → restore-deflap → outage fail-safe),
+    // called read-only (persist:false) — the SAME gate the scheduler's new-work
+    // path uses, so the two dispatch sites can never drift. (computeDispatchSurvivingRoster
+    // is the positive-liveness-only sub-step, exported/unit-tested but NOT the live
+    // composition — the live path adds the deflap.) Tests inject a fixed survivor
+    // set to drive the offline-owner failover deterministically.
     survivingRosterOverride = undefined,
     claimDispatch = claimDispatchSync,
     // CTL-1481: best-effort worker:<host> label stamp, fired right after a won

--- a/plugins/dev/scripts/execution-core/monitor.mjs
+++ b/plugins/dev/scripts/execution-core/monitor.mjs
@@ -76,7 +76,16 @@ import {
 import { labelNeedsHumanUnlessBeliefOwner } from "./label-guard.mjs"; // CTL-1441
 import { appendTriageTransitionEvent as defaultAppendEvent } from "./triage-transition-event.mjs";
 import { countBackgroundAgents, resetLivenessCache } from "./claude-agents.mjs";
-import { readMaxParallel, computeFreeSlots, writeClusterGeneration } from "./scheduler.mjs";
+import {
+  readMaxParallel,
+  computeFreeSlots,
+  writeClusterGeneration,
+  // CTL-1091: route the triage-dispatch HRW gate through the same surviving
+  // (live) roster the scheduler's new-work gate uses, so both dispatch sites
+  // fail an offline owner's slice over to a live host. This helper pulls in no
+  // bun:sqlite dependency, so it is safe to import here (CTL-1397 Node-loadability).
+  computeSurvivingRoster,
+} from "./scheduler.mjs";
 // CTL-863: Linear-free fence event emitter (durable fence → event-log migration).
 import { emitFenceClaimed } from "./fence-event.mjs";
 // CTL-1481: best-effort worker:<host> label visibility-projection stamp on a
@@ -446,6 +455,9 @@ export function handleStateChangedEvent(
     // CTL-862: cross-host coordination seams.
     hosts = undefined,
     hostName = undefined,
+    // CTL-1091: surviving-roster override → threaded through to dispatchTriage's
+    // live-roster ownership gate (undefined → real heartbeat feed; tests inject).
+    survivingRosterOverride = undefined,
     claimDispatch = claimDispatchSync,
     // CTL-1095: drain gate seam — thread through to dispatchTriage.
     isDraining = (dir) => isDrainingDefault(dir),
@@ -497,6 +509,7 @@ export function handleStateChangedEvent(
           applyAssignee,
           hosts,
           hostName,
+          survivingRosterOverride, // CTL-1091
           claimDispatch, // CTL-862
           isDraining, // CTL-1095
           emitBackstop, // CTL-1367 P1
@@ -554,6 +567,7 @@ export function handleStateChangedEvent(
           applyAssignee,
           hosts,
           hostName,
+          survivingRosterOverride, // CTL-1091
           claimDispatch, // CTL-862
           isDraining, // CTL-1095
           emitBackstop, // CTL-1367 P1
@@ -673,6 +687,11 @@ function dispatchTriage(
     // CTL-862: cross-host coordination seams (left undefined → single-host fallback).
     hosts = undefined,
     hostName = undefined,
+    // CTL-1091: injectable surviving-roster override for the ownership gate below,
+    // mirroring the scheduler's dispatchSurvivingRoster. Default undefined →
+    // computeSurvivingRoster(roster) (reads the live heartbeat feed). Tests inject
+    // a fixed survivor set to drive the offline-owner failover deterministically.
+    survivingRosterOverride = undefined,
     claimDispatch = claimDispatchSync,
     // CTL-1481: best-effort worker:<host> label stamp, fired right after a won
     // multi-host triage claim (same gate as emitFenceClaimed). Injectable so
@@ -714,10 +733,21 @@ function dispatchTriage(
     globalThis.__ctl1057_monitor_warned = true;
     log.warn({ roster, self }, _mw);
   }
-  if (multiHost && !ownedBy(identifier, roster, self)) {
+  // CTL-1091: ownership over the LIVE (surviving) roster, so a →Triage ticket
+  // whose HRW owner is offline is triaged by a live host instead of stranding.
+  // Injectable for tests; defaults to the live heartbeat feed. The heartbeat
+  // sync wrappers cache (Loki 20s / Linear 45s) so per-call reads coalesce.
+  // Fail-safe: computeSurvivingRoster degrades to the full roster on a
+  // read-throw / all-dead (today's raw-roster behavior). Only computed multi-host.
+  const dispatchRoster = !multiHost
+    ? roster
+    : Array.isArray(survivingRosterOverride)
+      ? survivingRosterOverride
+      : computeSurvivingRoster(roster);
+  if (multiHost && !ownedBy(identifier, dispatchRoster, self)) {
     log.debug(
-      { identifier, self, roster },
-      "ctl-862: ticket not owned by this host under HRW — skipping triage dispatch"
+      { identifier, self, roster, dispatchRoster },
+      "ctl-1091: ticket not owned by this host under HRW over the live roster — skipping triage dispatch"
     );
     return false;
   }
@@ -1066,6 +1096,9 @@ export function sweepMissingTriage({
   // CTL-862: cross-host coordination seams.
   hosts = undefined,
   hostName = undefined,
+  // CTL-1091: surviving-roster override → threaded through to dispatchTriage's
+  // live-roster ownership gate (undefined → real heartbeat feed; tests inject).
+  survivingRosterOverride = undefined,
   claimDispatch = claimDispatchSync,
   // CTL-1367 P1: failed-terminal backstop for a rejected async (sdk) triage
   // dispatch — threaded through to dispatchTriage (undefined → real default).
@@ -1116,6 +1149,7 @@ export function sweepMissingTriage({
         applyAssignee,
         hosts,
         hostName,
+        survivingRosterOverride, // CTL-1091
         claimDispatch, // CTL-862
         emitBackstop, // CTL-1367 P1
         ...(labelNeedsHuman ? { labelNeedsHuman } : {}), // CTL-1441

--- a/plugins/dev/scripts/execution-core/monitor.mjs
+++ b/plugins/dev/scripts/execution-core/monitor.mjs
@@ -82,9 +82,22 @@ import {
   writeClusterGeneration,
   // CTL-1091: route the triage-dispatch HRW gate through the SAME helper the
   // scheduler's new-work gate uses (positive-liveness → restore-deflap → outage
-  // fail-safe), so both dispatch sites can never drift out of sync. This helper
-  // pulls in no bun:sqlite dependency, so it is safe to import here (CTL-1397
-  // Node-loadability).
+  // fail-safe), so both dispatch sites can never drift out of sync.
+  //
+  // NOTE (CTL-1091 Codex P1 #2 — correcting an earlier inaccurate comment):
+  // a STATIC import from ./scheduler.mjs loads that module's ENTIRE graph, which
+  // DOES transitively reach `bun:sqlite` (scheduler.mjs → broker/broker-state.mjs).
+  // So this line is NOT bun:sqlite-free, and monitor.mjs is not Node-loadable in
+  // isolation. This is a PRE-EXISTING property, not introduced here: monitor.mjs
+  // already imported readMaxParallel/computeFreeSlots/writeClusterGeneration from
+  // ./scheduler.mjs before this ticket, so the scheduler→broker-state→bun:sqlite
+  // edge was already in the graph; adding resolveDispatchRoster changes nothing
+  // about reachability. Every runtime that loads this path (exec-core daemon,
+  // broker) runs under Bun, where bun:sqlite resolves. Making monitor.mjs truly
+  // Node-loadable requires extracting ALL of these shared scheduler helpers into a
+  // Node-safe leaf module — an all-or-nothing refactor out of this ticket's scope
+  // (a partial extraction of just this symbol would leave the other three imports
+  // pulling the same edge, so it would buy nothing). Tracked separately.
   resolveDispatchRoster,
 } from "./scheduler.mjs";
 // CTL-863: Linear-free fence event emitter (durable fence → event-log migration).

--- a/plugins/dev/scripts/execution-core/monitor.test.mjs
+++ b/plugins/dev/scripts/execution-core/monitor.test.mjs
@@ -2447,6 +2447,88 @@ describe("CTL-862 — HRW ownership + claim-on-dispatch (monitor dispatchTriage)
   });
 });
 
+// ── CTL-1091: triage-dispatch ownership over the SURVIVING roster ─────────────
+//
+// The triage gate (dispatchTriage) must hash ownership over the LIVE roster too,
+// so a →Triage ticket whose HRW owner is offline is triaged by a live host
+// instead of stranding. An injectable survivingRosterOverride threaded through
+// handleStateChangedEvent drives the shed set deterministically (mirrors the
+// scheduler's dispatchSurvivingRoster).
+describe("CTL-1091 — triage ownership over the surviving roster (dispatchTriage)", () => {
+  const ROSTER = ["mini", "laptop"];
+  // ENG-1 hashes to "laptop" under [mini,laptop]; under [mini] alone → mini.
+  const TICKET = "ENG-1";
+  expect(ownerForTicket(TICKET, ROSTER)).toBe("laptop");
+  expect(ownerForTicket(TICKET, ["mini"])).toBe("mini");
+
+  const triageEvent = () => ({
+    event: "linear.issue.state_changed",
+    detail: { ticket: TICKET, teamKey: "ENG", toState: "Triage" },
+  });
+  const recordClaim = (verdict) => {
+    const calls = [];
+    const fn = (arg) => { calls.push(arg); return verdict; };
+    fn.calls = calls;
+    return fn;
+  };
+  const fakeOrchDir = "/fake-orch-1091";
+
+  test("mini triages a laptop-owned ticket when laptop is OFFLINE (shed)", () => {
+    enroll("ENG", { status: "Ready" });
+    const dispatch = mock(() => ({ code: 0 }));
+    const claimDispatch = recordClaim({ won: true, generation: 1 });
+    handleStateChangedEvent(triageEvent(), {
+      dispatch,
+      orchDir: fakeOrchDir,
+      hosts: ROSTER,
+      hostName: "mini",
+      survivingRosterOverride: ["mini"], // laptop shed → mini owns ENG-1
+      claimDispatch,
+      stampWorkerLabel: () => ({ stamped: true }),
+      applyTriageStatus: () => ({ applied: false, verified: false, from_state: null, to_state: null, reason: null }),
+      appendEvent: () => {},
+    });
+    // Won claim forwards its generation as clusterGeneration (CTL-864).
+    expect(dispatch).toHaveBeenCalledWith({ orchDir: fakeOrchDir, ticket: TICKET, phase: "triage", clusterGeneration: 1 });
+    expect(claimDispatch.calls[0]).toEqual({ ticket: TICKET, hostName: "mini", phase: "triage" });
+  });
+
+  test("mini does NOT triage a laptop-owned ticket when laptop is LIVE", () => {
+    enroll("ENG", { status: "Ready" });
+    const dispatch = mock(() => ({ code: 0 }));
+    const claimDispatch = recordClaim({ won: true, generation: 1 });
+    handleStateChangedEvent(triageEvent(), {
+      dispatch,
+      orchDir: fakeOrchDir,
+      hosts: ROSTER,
+      hostName: "mini",
+      survivingRosterOverride: ["mini", "laptop"], // laptop live → laptop owns it
+      claimDispatch,
+      applyTriageStatus: () => ({ applied: false, verified: false, from_state: null, to_state: null, reason: null }),
+      appendEvent: () => {},
+    });
+    expect(dispatch).not.toHaveBeenCalled();
+    expect(claimDispatch.calls).toHaveLength(0);
+  });
+
+  test("single-host: predicate is a strict no-op (dispatch proceeds, no claim)", () => {
+    enroll("ENG", { status: "Ready" });
+    const dispatch = mock(() => ({ code: 0 }));
+    const claimDispatch = recordClaim({ won: false, generation: null });
+    handleStateChangedEvent(triageEvent(), {
+      dispatch,
+      orchDir: fakeOrchDir,
+      hosts: ["mini"],
+      hostName: "mini",
+      claimDispatch,
+      applyTriageStatus: () => ({ applied: false, verified: false, from_state: null, to_state: null, reason: null }),
+      appendEvent: () => {},
+    });
+    expect(dispatch).toHaveBeenCalledWith({ orchDir: fakeOrchDir, ticket: TICKET, phase: "triage" });
+    expect(claimDispatch.calls).toHaveLength(0);
+  });
+});
+
 // ── CTL-1028: triage forwards + persists cluster generation (monitor dispatchTriage) ──
 //
 // Mirrors the CTL-864 scheduler tests but drives dispatchTriage through the

--- a/plugins/dev/scripts/execution-core/recovery.mjs
+++ b/plugins/dev/scripts/execution-core/recovery.mjs
@@ -62,11 +62,18 @@ import { readClusterLivenessFromLokiSyncCached } from "./loki-liveness-sync.mjs"
 // attachment. Both return the SAME { [host]: {last_seen, in_flight_tickets} } shape,
 // so readClusterHeartbeats / defaultOwnedTicketsForHost are unchanged below the seam.
 // The `anchorIssue` arg is only meaningful in linear mode (loki uses getLokiQueryUrl()).
-function defaultReadPeers(anchorIssue) {
+// CTL-1091 (Codex P1 follow-up): `strict` propagates to the underlying reader so a
+// DETERMINATE peer-read FAILURE throws (dispatch outage → full roster) rather than
+// fail-opening to `{}` (which is indistinguishable from a genuinely-empty success and
+// would let the strict path keep [self] and grab every peer's work). The cached
+// wrappers spread it straight through to the sync reader on a miss; a cache HIT (a
+// recent determinate success) legitimately skips the read. Default false = recovery's
+// fail-open.
+function defaultReadPeers(anchorIssue, { strict = false } = {}) {
   if (getLivenessReadSource() === "loki") {
-    return readClusterLivenessFromLokiSyncCached({ lokiUrl: getLokiQueryUrl() });
+    return readClusterLivenessFromLokiSyncCached({ lokiUrl: getLokiQueryUrl() }, { strict });
   }
-  return readPeerHeartbeatsSyncCached({ anchorIssue });
+  return readPeerHeartbeatsSyncCached({ anchorIssue }, { strict });
 }
 
 // peerLivenessConfigured — is the cross-host peer read wired for the ACTIVE source?
@@ -3291,7 +3298,13 @@ export function readClusterHeartbeats({
     } else {
       let peers = {};
       try {
-        peers = readPeers(anchorIssue) ?? {};
+        // strict:requirePeerView makes the reader THROW on a determinate failure
+        // (timeout/nonzero/unparseable) instead of collapsing it to `{}` — the default
+        // readers otherwise fail-open, so a failed peer read would look identical to a
+        // genuinely-empty one and the dispatch roster would silently shrink to [self]
+        // (Codex P1 follow-up). A genuinely-empty SUCCESSFUL read still returns `{}`
+        // (legitimate all-peers-absent → [self] failover).
+        peers = readPeers(anchorIssue, { strict: requirePeerView }) ?? {};
       } catch (err) {
         // CTL-1091 P1 #3: DISPATCH surfaces the read failure as an outage (→ full
         // roster). RECOVERY stays fail-open — a Loki/Linear hiccup must never break

--- a/plugins/dev/scripts/execution-core/recovery.mjs
+++ b/plugins/dev/scripts/execution-core/recovery.mjs
@@ -3230,6 +3230,21 @@ export function readClusterHeartbeats({
   roster = getClusterHosts(),
   anchorIssue = getLivenessAnchorIssue(),
   readPeers = defaultReadPeers, // CTL-1420 (#17): loki|linear source-aware peer read
+  // CTL-1091 (Codex P1 #3): when TRUE — the DISPATCH positive-liveness path — a
+  // multi-host roster with NO trustworthy cross-host view THROWS instead of
+  // returning a local-only map. "No trustworthy view" = the peer transport is
+  // unconfigured OR the peer read threw. Without this the local event log always
+  // carries self's own fresh heartbeat, so the positive-liveness filter would see
+  // live=[self] (nonempty, no throw), skip the resolver's outage branch, shrink the
+  // dispatch roster to [self], and make every live host own every ready ticket —
+  // contending for its peers' work instead of taking the documented
+  // outage → FULL-roster fallback (each node owns only its own HRW slice). The throw
+  // routes through readPositiveLive's catch → resolveDispatchRoster's outage degrade.
+  // RECOVERY keeps the default (false) fail-open: an unseen peer is "not proven dead"
+  // and must NOT be reclaimed, so a Loki/Linear hiccup there must never break
+  // liveness. This is the dispatch(positive) vs recovery(fail-open) asymmetry in
+  // docs/architecture.md.
+  requirePeerView = false,
 } = {}) {
   const lastSeen = {};
   let raw;
@@ -3261,30 +3276,47 @@ export function readClusterHeartbeats({
   // CTL-1090: multi-host cross-host merge. Single-host (roster<=1) ⇒ exact no-op.
   // CTL-1420 (#17): gate on the ACTIVE source's transport (loki: Loki URL; linear:
   // anchor issue) so a source with no transport is a clean local-map-only no-op.
-  if (Array.isArray(roster) && roster.length > 1 && peerLivenessConfigured(anchorIssue)) {
-    let peers = {};
-    try {
-      peers = readPeers(anchorIssue) ?? {};
-    } catch {
-      peers = {}; // fail-open: a Loki/Linear hiccup must never break liveness
-    }
-    for (const [host, rec] of Object.entries(peers)) {
-      const ts = rec?.last_seen;
-      if (typeof ts !== "string" || ts.length === 0) continue;
-      // CTL-1090 review hardening: a peer's last_seen is untrusted input. Reject
-      // anything Date.parse can't read so a garbage value (e.g. "zzz") — which
-      // would sort ABOVE real ISO strings lexicographically and then make the host
-      // look forever-alive once deadHosts does Date.parse(seen) (NaN < cutoff is
-      // false) — can never poison the merge.
-      const peerMs = Date.parse(ts);
-      if (!Number.isFinite(peerMs)) continue; // unparseable → drop (fail-open)
-      // Keep the freshest ts per host. Compare NUMERICALLY (Date.parse), not
-      // lexicographically: the local event log carries second-precision ts
-      // ("…02Z", heartbeat-event.mjs strips millis) while peers publish
-      // millisecond ISO ("…02.500Z"), and "…02.500Z" < "…02Z" as strings — a
-      // lexicographic compare would discard a genuinely newer peer ts.
-      const cur = lastSeen[host];
-      if (!cur || peerMs > Date.parse(cur)) lastSeen[host] = ts;
+  if (Array.isArray(roster) && roster.length > 1) {
+    if (!peerLivenessConfigured(anchorIssue)) {
+      // No cross-host transport. CTL-1091 P1 #3: for the DISPATCH path this is NOT a
+      // safe local-map-only no-op — self's own heartbeat alone would collapse the
+      // dispatch roster to [self]. Surface it as an outage so the resolver degrades
+      // to the FULL roster. Recovery (requirePeerView=false) keeps the local-map-only
+      // no-op (an unconfigured transport must not manufacture "dead" peers to reclaim).
+      if (requirePeerView) {
+        throw new Error(
+          "ctl-1091: dispatch requires a cross-host liveness view but no peer transport is configured (multi-host)",
+        );
+      }
+    } else {
+      let peers = {};
+      try {
+        peers = readPeers(anchorIssue) ?? {};
+      } catch (err) {
+        // CTL-1091 P1 #3: DISPATCH surfaces the read failure as an outage (→ full
+        // roster). RECOVERY stays fail-open — a Loki/Linear hiccup must never break
+        // liveness (unseen ≠ dead).
+        if (requirePeerView) throw err;
+        peers = {};
+      }
+      for (const [host, rec] of Object.entries(peers)) {
+        const ts = rec?.last_seen;
+        if (typeof ts !== "string" || ts.length === 0) continue;
+        // CTL-1090 review hardening: a peer's last_seen is untrusted input. Reject
+        // anything Date.parse can't read so a garbage value (e.g. "zzz") — which
+        // would sort ABOVE real ISO strings lexicographically and then make the host
+        // look forever-alive once deadHosts does Date.parse(seen) (NaN < cutoff is
+        // false) — can never poison the merge.
+        const peerMs = Date.parse(ts);
+        if (!Number.isFinite(peerMs)) continue; // unparseable → drop (fail-open)
+        // Keep the freshest ts per host. Compare NUMERICALLY (Date.parse), not
+        // lexicographically: the local event log carries second-precision ts
+        // ("…02Z", heartbeat-event.mjs strips millis) while peers publish
+        // millisecond ISO ("…02.500Z"), and "…02.500Z" < "…02Z" as strings — a
+        // lexicographic compare would discard a genuinely newer peer ts.
+        const cur = lastSeen[host];
+        if (!cur || peerMs > Date.parse(cur)) lastSeen[host] = ts;
+      }
     }
   }
 

--- a/plugins/dev/scripts/execution-core/recovery.test.mjs
+++ b/plugins/dev/scripts/execution-core/recovery.test.mjs
@@ -4948,6 +4948,23 @@ describe("readClusterHeartbeats — requirePeerView dispatch strict mode (CTL-10
     ).toThrow(/Linear down/);
   });
 
+  test("strict + multi-host + peer read returns EMPTY {} (genuine, no throw) → local map, NOT an outage", () => {
+    // A SUCCESSFUL-but-empty read (no peers heartbeating yet / all genuinely absent)
+    // must NOT be treated as an outage — the reader returns {} without throwing, so
+    // readClusterHeartbeats returns the local self-only map and the dispatch resolver
+    // legitimately fails over. Only a determinate FAILURE (which the strict readers now
+    // throw on) routes to the full-roster fallback. See the reader-level strict tests.
+    const result = readClusterHeartbeats({
+      logPath,
+      roster: ["mini", "laptop"],
+      anchorIssue: "CTL-9999",
+      readPeers: () => ({}), // genuine empty success (no throw)
+      requirePeerView: true,
+    });
+    expect(result.mini).toBe("2026-06-13T01:00:00Z");
+    expect(result.laptop).toBeUndefined();
+  });
+
   test("strict + multi-host + peer read OK → merges normally (happy path unaffected)", () => {
     const result = readClusterHeartbeats({
       logPath,

--- a/plugins/dev/scripts/execution-core/recovery.test.mjs
+++ b/plugins/dev/scripts/execution-core/recovery.test.mjs
@@ -4892,6 +4892,110 @@ describe("readClusterHeartbeats — cross-host peer merge (CTL-1090)", () => {
   });
 });
 
+// ─── CTL-1091 (Codex P1 #3): requirePeerView — dispatch must NOT fail-open ────
+// The DISPATCH positive-liveness path passes requirePeerView:true so that a
+// multi-host roster with no trustworthy cross-host view THROWS (→ readPositiveLive
+// catch → resolveDispatchRoster outage degrade → full roster) instead of returning
+// a local-only map (self's own heartbeat), which would collapse the dispatch roster
+// to [self] and make every live host grab every ready ticket. RECOVERY keeps the
+// default (false) fail-open so an unseen peer is never reclaimed on a transient
+// Loki/Linear hiccup. These tests pin the asymmetry.
+describe("readClusterHeartbeats — requirePeerView dispatch strict mode (CTL-1091 P1 #3)", () => {
+  let tmpDir;
+  let logPath;
+  let prevSource;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), "ctl1091-strict-hb-"));
+    logPath = join(tmpDir, "events.jsonl");
+    writeFileSync(logPath, makeHbLine("mini", "2026-06-13T01:00:00Z") + "\n");
+    // Pin the liveness source so peerLivenessConfigured() is driven by anchorIssue
+    // (linear source) and NOT by an ambient CATALYST_LIVENESS_READ_SOURCE=loki with
+    // no Loki URL — which would make peerLivenessConfigured always false and mask the
+    // configured-vs-unconfigured distinction these tests pin. (CI runs with a clean
+    // env; a dev machine may have the loki source exported.)
+    prevSource = process.env.CATALYST_LIVENESS_READ_SOURCE;
+    process.env.CATALYST_LIVENESS_READ_SOURCE = "linear";
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+    if (prevSource === undefined) delete process.env.CATALYST_LIVENESS_READ_SOURCE;
+    else process.env.CATALYST_LIVENESS_READ_SOURCE = prevSource;
+  });
+
+  test("strict + multi-host + peer transport UNCONFIGURED → THROWS (no silent local-only map)", () => {
+    expect(() =>
+      readClusterHeartbeats({
+        logPath,
+        roster: ["mini", "laptop"],
+        anchorIssue: null, // unconfigured (linear source) → no cross-host view
+        readPeers: () => ({}),
+        requirePeerView: true,
+      }),
+    ).toThrow(/cross-host liveness view/i);
+  });
+
+  test("strict + multi-host + peer read THROWS → propagates (not swallowed)", () => {
+    expect(() =>
+      readClusterHeartbeats({
+        logPath,
+        roster: ["mini", "laptop"],
+        anchorIssue: "CTL-9999",
+        readPeers: () => { throw new Error("Linear down"); },
+        requirePeerView: true,
+      }),
+    ).toThrow(/Linear down/);
+  });
+
+  test("strict + multi-host + peer read OK → merges normally (happy path unaffected)", () => {
+    const result = readClusterHeartbeats({
+      logPath,
+      roster: ["mini", "laptop"],
+      anchorIssue: "CTL-9999",
+      readPeers: () => ({
+        laptop: { host: "laptop", last_seen: "2026-06-13T00:55:00Z", in_flight_tickets: [] },
+      }),
+      requirePeerView: true,
+    });
+    expect(result.mini).toBe("2026-06-13T01:00:00Z");
+    expect(result.laptop).toBe("2026-06-13T00:55:00Z");
+  });
+
+  test("strict + SINGLE-host → peer reader never called, never throws (no-op)", () => {
+    expect(() =>
+      readClusterHeartbeats({
+        logPath,
+        roster: ["mini"],
+        anchorIssue: null,
+        readPeers: () => { throw new Error("must not be called single-host"); },
+        requirePeerView: true,
+      }),
+    ).not.toThrow();
+  });
+
+  test("recovery (default requirePeerView:false) stays FAIL-OPEN on the same conditions", () => {
+    // unconfigured transport
+    expect(() =>
+      readClusterHeartbeats({
+        logPath,
+        roster: ["mini", "laptop"],
+        anchorIssue: null,
+        readPeers: () => ({}),
+      }),
+    ).not.toThrow();
+    // peer read throws
+    const result = readClusterHeartbeats({
+      logPath,
+      roster: ["mini", "laptop"],
+      anchorIssue: "CTL-9999",
+      readPeers: () => { throw new Error("Linear down"); },
+    });
+    expect(result.mini).toBe("2026-06-13T01:00:00Z"); // local map preserved
+    expect(result.laptop).toBeUndefined();
+  });
+});
+
 // ─── CTL-1090: deadHosts flags a stale peer (pure function, no change needed) ─
 
 describe("deadHosts — flags a stale peer in merged lastSeen (CTL-1090)", () => {

--- a/plugins/dev/scripts/execution-core/scheduler.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.mjs
@@ -337,11 +337,13 @@ import {
   isDraining as isDrainingDefault,
   getDrainedMarkerPath, // CTL-1321: shared resolver for the drain.drained sentinel
   HEARTBEAT_GRACE_MS, // CTL-1191: dead-host grace for surviving-roster recovery gate
+  HEARTBEAT_RESTORE_HOLD_MS, // CTL-1091: restore-side deflap hold for the dispatch roster
   isInProcessDispatchMode, // CTL-1457 (T2): sdk|codex-exec occupancy gate predicate
 } from "./config.mjs";
 import { emitDrainedEvent as defaultEmitDrainedEvent } from "./drain-event.mjs"; // CTL-1095: drained sentinel
 import { defaultCheckSequencing } from "./sequencing.mjs"; // CTL-537
 import { ownedBy, ownerForTicket } from "./hrw.mjs"; // CTL-850: HRW ownership filter (CTL-1191 also uses it for the diagnostician gate); ownerForTicket: CTL-1290 board-health stranded-node + enforce HRW gate
+import { computeDispatchRoster, readDeflapState, writeDeflapState } from "./liveness-deflap.mjs"; // CTL-1091: restore-side deflap for the dispatch roster
 import { boardHealthPass } from "./board-health.mjs"; // CTL-1290: the whole-board health delegate (shadow-first)
 import {
   getAllTicketDescriptors,
@@ -3604,9 +3606,32 @@ export function schedulerTick(
   let _dispatchRosterMemo = null;
   const _dispatchRoster = () => {
     if (_dispatchRosterMemo) return _dispatchRosterMemo;
-    _dispatchRosterMemo = Array.isArray(dispatchSurvivingRoster)
-      ? dispatchSurvivingRoster
-      : computeSurvivingRoster(roster);
+    // Test override bypasses both the heartbeat read AND the deflap (tests
+    // exercise the deflap directly via the pure computeDispatchRoster).
+    if (Array.isArray(dispatchSurvivingRoster)) {
+      _dispatchRosterMemo = dispatchSurvivingRoster;
+      return _dispatchRosterMemo;
+    }
+    // CTL-1091 Phase 2: layer the restore-side deflap on top of the surviving
+    // roster. A dead→live host is held out of the dispatch roster until it has
+    // been continuously live for HEARTBEAT_RESTORE_HOLD_MS, so a flapping host
+    // doesn't grab-then-strand new work. Scheduler is the SOLE writer of
+    // .liveness-deflap.json (monitor reads it read-only).
+    const survivingRosterNow = computeSurvivingRoster(roster);
+    if (!multiHost) {
+      _dispatchRosterMemo = survivingRosterNow;
+      return _dispatchRosterMemo;
+    }
+    const { dispatchRoster: deflapped, nextState } = computeDispatchRoster({
+      survivingRoster: survivingRosterNow,
+      roster,
+      prevState: readDeflapState(orchDir),
+      holdMs: HEARTBEAT_RESTORE_HOLD_MS,
+      nowMs: now(),
+      self,
+    });
+    writeDeflapState(orchDir, nextState);
+    _dispatchRosterMemo = deflapped;
     return _dispatchRosterMemo;
   };
   // CTL-757: emitStateWrite — caller-emit the canonical linear.state.write audit

--- a/plugins/dev/scripts/execution-core/scheduler.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.mjs
@@ -423,26 +423,18 @@ export function computeSurvivingRoster(
   }
 }
 
-// CTL-1091 Phase 3: the DISPATCH-side surviving roster. Unlike computeSurvivingRoster
-// (which uses deadHosts's fail-OPEN semantics — an unseen host is "not proven dead"
-// and stays a survivor), dispatch ownership requires POSITIVE liveness: a host must
-// have been SEEN within grace to own new work. This sheds a NEVER-live rostered host
-// (absent from lastSeen — the CTL-1057 permanently-offline case) whose HRW slice would
-// otherwise strand, because deadHosts never flags a host it has never seen.
-//
-// The asymmetry is deliberate: recovery keeps the fail-open deadHosts (it must NOT
-// reclaim a never-seen host's non-existent work), while dispatch fails an unseen
-// owner's slice over to a live host. See plan Phase 3 / docs/architecture.md.
-//
-// Fail-safe preserved: if positive-liveness empties the roster (a TOTAL feed outage —
-// nobody has heartbeated at all), degrade to the FULL roster, exactly as
-// computeSurvivingRoster does — never strand the board on a dead feed. Single-host
-// (roster.length <= 1) is a no-op with no read.
-export function computeDispatchSurvivingRoster(
+// CTL-1091 Phase 3: the RAW positively-live host set. Dispatch ownership requires
+// POSITIVE liveness — a host must have been SEEN within grace to own new work —
+// unlike computeSurvivingRoster's fail-OPEN deadHosts (an unseen host is "not
+// proven dead" and stays a survivor). Returns `{ live }` where `live` is the
+// filtered array (possibly EMPTY when nobody is positively live), or `{ live: null }`
+// when the heartbeat read THREW. The empty/null distinction from "some hosts live"
+// is what lets callers tell a total feed outage apart from a partial one — the
+// fail-safe (degrade to the full roster) must fire only on a genuine outage.
+function readPositiveLive(
   roster,
   { readHeartbeats = readClusterHeartbeats, nowMs = Date.now(), graceMs = HEARTBEAT_GRACE_MS } = {}
 ) {
-  if (!Array.isArray(roster) || roster.length <= 1) return roster;
   try {
     const lastSeen = readHeartbeats({ roster });
     const cutoff = nowMs - graceMs;
@@ -450,10 +442,70 @@ export function computeDispatchSurvivingRoster(
       const seen = lastSeen[h];
       return typeof seen === "string" && seen.length > 0 && Date.parse(seen) >= cutoff;
     });
-    return live.length > 0 ? live : roster;
+    return { live };
   } catch {
+    return { live: null };
+  }
+}
+
+// computeDispatchSurvivingRoster — the positive-liveness dispatch roster with the
+// outage fail-safe folded in: sheds a NEVER-live rostered host (absent from
+// lastSeen — the CTL-1057 permanently-offline case) so its HRW slice fails over,
+// but degrades to the FULL roster when NOBODY is positively live (a total feed
+// outage) so the board is never stranded. Single-host (roster.length <= 1) is a
+// no-op with no read. The recovery side deliberately keeps the fail-open deadHosts
+// (it must NOT reclaim a never-seen host's non-existent work); see docs/architecture.md.
+export function computeDispatchSurvivingRoster(roster, opts = {}) {
+  if (!Array.isArray(roster) || roster.length <= 1) return roster;
+  const { live } = readPositiveLive(roster, opts);
+  return live && live.length > 0 ? live : roster;
+}
+
+// resolveDispatchRoster — the SINGLE source of truth for the dispatch-ownership
+// roster, shared by BOTH dispatch sites (scheduler new-work `_dispatchRoster` and
+// monitor `dispatchTriage`) so they can never drift into split-brain (CTL-1091
+// cleanup #1). Composes positive-liveness → restore deflap → outage fail-safe:
+//
+//  1. Read the raw positively-live set once.
+//  2. TOTAL OUTAGE (read threw, or NOBODY positively live) → degrade to the FULL
+//     roster and DO NOT mutate the deflap observation state (we learned nothing
+//     this tick). This preserves the "outage → full roster, never re-home" invariant
+//     that a naive deflap-on-fail-open-roster would violate: without this guard a
+//     just-departed host (prevState liveSince:null) would be held out and its slice
+//     re-homed to a peer during an outage (CTL-1091 correctness review #1).
+//  3. Otherwise apply the restore deflap (computeDispatchRoster) on the live set;
+//     `persist` writes the next observation state atomically (scheduler is the SOLE
+//     writer; monitor passes persist:false and reads the same file read-only).
+//
+// Single-host (roster.length <= 1) is a strict no-op with no read. Injectable
+// readHeartbeats/holdMs for tests.
+export function resolveDispatchRoster({
+  roster,
+  orchDir,
+  self,
+  nowMs = Date.now(),
+  persist = false,
+  readHeartbeats = readClusterHeartbeats,
+  holdMs = HEARTBEAT_RESTORE_HOLD_MS,
+} = {}) {
+  if (!Array.isArray(roster) || roster.length <= 1) return roster;
+  const prevState = readDeflapState(orchDir);
+  const { live } = readPositiveLive(roster, { readHeartbeats, nowMs });
+  if (!live || live.length === 0) {
+    // Total outage → full roster, observation state untouched.
+    if (persist) writeDeflapState(orchDir, prevState);
     return roster;
   }
+  const { dispatchRoster, nextState } = computeDispatchRoster({
+    survivingRoster: live,
+    roster,
+    prevState,
+    holdMs,
+    nowMs,
+    self,
+  });
+  if (persist) writeDeflapState(orchDir, nextState);
+  return dispatchRoster;
 }
 
 // CTL-1004/CTL-1056 Bug 2: dispatchFailureDiag — extract the diagnostic fields
@@ -3629,13 +3681,14 @@ export function schedulerTick(
   };
   const ownsForRecovery = (ticket) => !multiHost || ownedBy(ticket, _survivors(), self);
 
-  // CTL-1091: the DISPATCH-time ownership roster = the surviving (live) roster,
-  // so new eligible tickets whose HRW owner is OFFLINE fail over to a live host
-  // instead of stranding in Todo. Memoized once per tick; reuses the same
-  // heartbeat read as recovery (_survivors) so dispatch and recovery agree on
-  // who is alive. Injectable via dispatchSurvivingRoster for tests. Fail-safe:
-  // computeSurvivingRoster degrades to the full roster on a read-throw / all-dead
-  // (today's raw-roster behavior — never double-acts).
+  // CTL-1091: the DISPATCH-time ownership roster = the live (positive-liveness +
+  // restore-deflap) roster, so new eligible tickets whose HRW owner is OFFLINE
+  // fail over to a live host instead of stranding in Todo. Memoized once per tick.
+  // It performs its OWN positive-liveness heartbeat read (via resolveDispatchRoster)
+  // — independent of recovery's fail-open computeSurvivingRoster read (_survivors),
+  // by design: dispatch needs positive liveness, recovery needs fail-open. Both hit
+  // the same cached feed. Injectable via dispatchSurvivingRoster for tests; a total
+  // outage degrades to the full roster (never double-acts).
   let _dispatchRosterMemo = null;
   const _dispatchRoster = () => {
     if (_dispatchRosterMemo) return _dispatchRosterMemo;
@@ -3645,27 +3698,15 @@ export function schedulerTick(
       _dispatchRosterMemo = dispatchSurvivingRoster;
       return _dispatchRosterMemo;
     }
-    // CTL-1091 Phase 3: dispatch ownership uses POSITIVE liveness (seen within
-    // grace), so a never-live rostered host is shed and its slice fails over.
-    // Phase 2: layer the restore-side deflap on top, so a dead→live host is held
-    // out until continuously live for HEARTBEAT_RESTORE_HOLD_MS (no grab-then-
-    // strand on a flap). Scheduler is the SOLE writer of .liveness-deflap.json
-    // (monitor reads it read-only).
-    const survivingRosterNow = computeDispatchSurvivingRoster(roster);
-    if (!multiHost) {
-      _dispatchRosterMemo = survivingRosterNow;
-      return _dispatchRosterMemo;
-    }
-    const { dispatchRoster: deflapped, nextState } = computeDispatchRoster({
-      survivingRoster: survivingRosterNow,
-      roster,
-      prevState: readDeflapState(orchDir),
-      holdMs: HEARTBEAT_RESTORE_HOLD_MS,
-      nowMs: now(),
-      self,
-    });
-    writeDeflapState(orchDir, nextState);
-    _dispatchRosterMemo = deflapped;
+    // Single-host is a strict no-op with NO heartbeat read (cheap guard first);
+    // _dispatchRoster is only reached multiHost anyway (the ready filter short-
+    // circuits single-host), but this keeps it safe if ever called otherwise.
+    // Scheduler is the SOLE writer of .liveness-deflap.json (persist:true); monitor
+    // reads it read-only. Shared with the triage gate via resolveDispatchRoster so
+    // both dispatch sites can never drift out of sync.
+    _dispatchRosterMemo = multiHost
+      ? resolveDispatchRoster({ roster, orchDir, self, nowMs: now(), persist: true })
+      : roster;
     return _dispatchRosterMemo;
   };
   // CTL-757: emitStateWrite — caller-emit the canonical linear.state.write audit

--- a/plugins/dev/scripts/execution-core/scheduler.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.mjs
@@ -436,7 +436,14 @@ function readPositiveLive(
   { readHeartbeats = readClusterHeartbeats, nowMs = Date.now(), graceMs = HEARTBEAT_GRACE_MS } = {}
 ) {
   try {
-    const lastSeen = readHeartbeats({ roster });
+    // CTL-1091 (Codex P1 #3): DISPATCH liveness requires a trustworthy cross-host
+    // view. requirePeerView makes readClusterHeartbeats THROW (→ caught below →
+    // {live:null,error} → resolveDispatchRoster outage degrade → FULL roster) when
+    // the peer transport is unconfigured or the peer read fails, instead of quietly
+    // returning self's local-only heartbeat map (which would collapse the dispatch
+    // roster to [self] and make every host grab every ready ticket). A test-injected
+    // readHeartbeats simply ignores the extra option.
+    const lastSeen = readHeartbeats({ roster, requirePeerView: true });
     const cutoff = nowMs - graceMs;
     const live = roster.filter((h) => {
       const seen = lastSeen[h];
@@ -6074,6 +6081,18 @@ export function schedulerTick(
   // regardless of whether the lone roster entry string-matches the resolved
   // hostName (stale/aliased hosts.json). HRW filtering engages only when a 2nd
   // host actually joins (roster.length > 1).
+  // CTL-1091 (Codex P1 #1): refresh the dispatch-roster deflap observation state
+  // EVERY multi-host tick, even when there is no ready work. _dispatchRoster() is
+  // otherwise only reached lazily through the ready.filter() below, so on an idle
+  // board (ready empty) that path never runs — a peer that departs while the board
+  // is quiet never has its liveSince reset to null, and on return computeDispatchRoster
+  // would see a stale continuous timestamp and re-admit it immediately, skipping the
+  // restore hold (the exact flap this deflap exists to prevent). Forcing the
+  // (memoized) read+persist here keeps the deflap honest during idle periods; the
+  // ready.filter() below reuses the same memoized roster (no double read). During a
+  // liveness outage the resolver degrades to the full roster and intentionally leaves
+  // the observation state untouched (we learned nothing this tick).
+  if (multiHost) _dispatchRoster();
   const ready = computeReadyTickets(eligible, { blockerStates }).filter(
     // CTL-1091: hash ownership over the LIVE (surviving) roster, not the raw
     // roster, so an offline owner's slice fails over to a live host.

--- a/plugins/dev/scripts/execution-core/scheduler.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.mjs
@@ -443,8 +443,12 @@ function readPositiveLive(
       return typeof seen === "string" && seen.length > 0 && Date.parse(seen) >= cutoff;
     });
     return { live };
-  } catch {
-    return { live: null };
+  } catch (err) {
+    // CTL-1091 review F2: preserve the caught error so the outage→full-roster
+    // degrade can be told apart from a latent bug in the read path when it is
+    // surfaced (resolveDispatchRoster's onDegrade hook). Back-compat: existing
+    // callers destructure only `{ live }`.
+    return { live: null, error: err };
   }
 }
 
@@ -487,12 +491,31 @@ export function resolveDispatchRoster({
   persist = false,
   readHeartbeats = readClusterHeartbeats,
   holdMs = HEARTBEAT_RESTORE_HOLD_MS,
+  // CTL-1091 review F2: observability hook fired ONLY on the outage→full-roster
+  // degradation (below). Default no-op keeps the pure resolve silent for unit
+  // callers and the read-only monitor site; the scheduler's write path wires the
+  // rate-limited warn emitter so a genuine feed outage is not invisible.
+  onDegrade = () => {},
 } = {}) {
   if (!Array.isArray(roster) || roster.length <= 1) return roster;
   const prevState = readDeflapState(orchDir);
-  const { live } = readPositiveLive(roster, { readHeartbeats, nowMs });
+  const { live, error } = readPositiveLive(roster, { readHeartbeats, nowMs });
   if (!live || live.length === 0) {
-    // Total outage → full roster, observation state untouched.
+    // Total outage → full roster, observation state untouched. Surface the
+    // degradation (its silence was CTL-1091 verify F2): cross-host failover has
+    // effectively turned OFF this tick and every host has dropped back to owning
+    // only its own HRW slice. The fail-safe is correct; only its silence was the
+    // risk. Never let an observability throw break the roster resolve.
+    try {
+      onDegrade({
+        roster,
+        self,
+        reason: error ? "heartbeat-read-threw" : "nobody-positively-live",
+        error: error ? (error.message ?? String(error)) : null,
+      });
+    } catch {
+      /* observability is best-effort */
+    }
     if (persist) writeDeflapState(orchDir, prevState);
     return roster;
   }
@@ -506,6 +529,26 @@ export function resolveDispatchRoster({
   });
   if (persist) writeDeflapState(orchDir, nextState);
   return dispatchRoster;
+}
+
+// CTL-1091 review F2: rate-limited WARN for the dispatch-roster outage degrade.
+// The scheduler is a single long-lived daemon process, so a module-level
+// timestamp is enough to keep this to one warn per window (a partial feed outage
+// otherwise fires every tick). Alloy ships the Tier-1 daemon log to Loki, so this
+// gives an operator the "failover is OFF right now" signal — and the caught error
+// message rides along so a genuine feed outage is distinguishable from a latent
+// read-path bug. The read-only monitor site stays silent (no onDegrade), so the
+// scheduler is the sole emitter and there is no double-logging.
+const DISPATCH_ROSTER_OUTAGE_WARN_INTERVAL_MS = 60_000;
+let _lastDispatchRosterOutageWarnMs = 0;
+function warnDispatchRosterOutage({ roster, self, reason, error } = {}) {
+  const nowMs = Date.now();
+  if (nowMs - _lastDispatchRosterOutageWarnMs < DISPATCH_ROSTER_OUTAGE_WARN_INTERVAL_MS) return;
+  _lastDispatchRosterOutageWarnMs = nowMs;
+  log.warn(
+    { roster, self, reason, error, degradedTo: "full-roster" },
+    "ctl-1091: dispatch-roster liveness read degraded to the FULL roster — cross-host failover is OFF this tick (every host owns only its own HRW slice). This is the correct fail-safe; investigate the heartbeat/Loki feed if it persists.",
+  );
 }
 
 // CTL-1004/CTL-1056 Bug 2: dispatchFailureDiag — extract the diagnostic fields
@@ -3705,7 +3748,14 @@ export function schedulerTick(
     // reads it read-only. Shared with the triage gate via resolveDispatchRoster so
     // both dispatch sites can never drift out of sync.
     _dispatchRosterMemo = multiHost
-      ? resolveDispatchRoster({ roster, orchDir, self, nowMs: now(), persist: true })
+      ? resolveDispatchRoster({
+          roster,
+          orchDir,
+          self,
+          nowMs: now(),
+          persist: true,
+          onDegrade: warnDispatchRosterOutage, // CTL-1091 F2: surface outage→full-roster
+        })
       : roster;
     return _dispatchRosterMemo;
   };

--- a/plugins/dev/scripts/execution-core/scheduler.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.mjs
@@ -402,7 +402,11 @@ const TERMINAL_SIGNAL_STATUSES = new Set(["failed", "stalled", "aborted"]);
 // then owns only its own HRW slice (NEVER double-acts) and we merely forgo the
 // dead-owner failover for this tick (no worse than the pre-CTL-1191 strand).
 // Single-host (roster.length <= 1) returns the roster unchanged with no read.
-function computeSurvivingRoster(
+// CTL-1091: exported so monitor.mjs can route its triage-dispatch ownership gate
+// through the same surviving-roster read as the scheduler's new-work gate (both
+// dispatch sites then agree with recovery on who is alive). Safe to import from
+// monitor.mjs — this helper pulls in no bun:sqlite dependency (CTL-1397).
+export function computeSurvivingRoster(
   roster,
   { readHeartbeats = readClusterHeartbeats, nowMs = Date.now() } = {}
 ) {
@@ -3407,6 +3411,13 @@ export function schedulerTick(
     // fixed survivor set to drive the dead-owner-failover path deterministically
     // without writing heartbeat events. Single-host is still a no-op regardless.
     recoverySurvivingRoster = undefined,
+    // CTL-1091: injectable surviving-roster computation for the NEW-WORK dispatch
+    // HRW gate (the `ready` filter below), mirroring recoverySurvivingRoster.
+    // Default undefined → computeSurvivingRoster(roster) (reads the test-redirected
+    // event log). Tests inject a fixed survivor set to drive the offline-owner
+    // failover deterministically without writing heartbeat events. Single-host is
+    // still a no-op regardless (multiHost gate short-circuits before it is read).
+    dispatchSurvivingRoster = undefined,
     // CTL-729: progress-watchdog seams. Defaults keep every existing bare unit
     // tick inert (null silence probe → predicate no-ops via "no-transcript").
     watchdog: {
@@ -3582,6 +3593,22 @@ export function schedulerTick(
     return _survivorRoster;
   };
   const ownsForRecovery = (ticket) => !multiHost || ownedBy(ticket, _survivors(), self);
+
+  // CTL-1091: the DISPATCH-time ownership roster = the surviving (live) roster,
+  // so new eligible tickets whose HRW owner is OFFLINE fail over to a live host
+  // instead of stranding in Todo. Memoized once per tick; reuses the same
+  // heartbeat read as recovery (_survivors) so dispatch and recovery agree on
+  // who is alive. Injectable via dispatchSurvivingRoster for tests. Fail-safe:
+  // computeSurvivingRoster degrades to the full roster on a read-throw / all-dead
+  // (today's raw-roster behavior — never double-acts).
+  let _dispatchRosterMemo = null;
+  const _dispatchRoster = () => {
+    if (_dispatchRosterMemo) return _dispatchRosterMemo;
+    _dispatchRosterMemo = Array.isArray(dispatchSurvivingRoster)
+      ? dispatchSurvivingRoster
+      : computeSurvivingRoster(roster);
+    return _dispatchRosterMemo;
+  };
   // CTL-757: emitStateWrite — caller-emit the canonical linear.state.write audit
   // event for ONE scheduler write site. `writerResult` is the runTransition return
   // ({applied, reason, from_state, to_state, ...}) from applyPhaseStatus /
@@ -5898,7 +5925,9 @@ export function schedulerTick(
   // hostName (stale/aliased hosts.json). HRW filtering engages only when a 2nd
   // host actually joins (roster.length > 1).
   const ready = computeReadyTickets(eligible, { blockerStates }).filter(
-    (t) => !multiHost || ownedBy(t.identifier, roster, self)
+    // CTL-1091: hash ownership over the LIVE (surviving) roster, not the raw
+    // roster, so an offline owner's slice fails over to a live host.
+    (t) => !multiHost || ownedBy(t.identifier, _dispatchRoster(), self)
   );
   // CTL-657: the in-flight count is the live `background` claude-agents count,
   // not listInFlightTickets(orchDir).size. A worker that leaked (signal terminal

--- a/plugins/dev/scripts/execution-core/scheduler.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.mjs
@@ -423,6 +423,39 @@ export function computeSurvivingRoster(
   }
 }
 
+// CTL-1091 Phase 3: the DISPATCH-side surviving roster. Unlike computeSurvivingRoster
+// (which uses deadHosts's fail-OPEN semantics — an unseen host is "not proven dead"
+// and stays a survivor), dispatch ownership requires POSITIVE liveness: a host must
+// have been SEEN within grace to own new work. This sheds a NEVER-live rostered host
+// (absent from lastSeen — the CTL-1057 permanently-offline case) whose HRW slice would
+// otherwise strand, because deadHosts never flags a host it has never seen.
+//
+// The asymmetry is deliberate: recovery keeps the fail-open deadHosts (it must NOT
+// reclaim a never-seen host's non-existent work), while dispatch fails an unseen
+// owner's slice over to a live host. See plan Phase 3 / docs/architecture.md.
+//
+// Fail-safe preserved: if positive-liveness empties the roster (a TOTAL feed outage —
+// nobody has heartbeated at all), degrade to the FULL roster, exactly as
+// computeSurvivingRoster does — never strand the board on a dead feed. Single-host
+// (roster.length <= 1) is a no-op with no read.
+export function computeDispatchSurvivingRoster(
+  roster,
+  { readHeartbeats = readClusterHeartbeats, nowMs = Date.now(), graceMs = HEARTBEAT_GRACE_MS } = {}
+) {
+  if (!Array.isArray(roster) || roster.length <= 1) return roster;
+  try {
+    const lastSeen = readHeartbeats({ roster });
+    const cutoff = nowMs - graceMs;
+    const live = roster.filter((h) => {
+      const seen = lastSeen[h];
+      return typeof seen === "string" && seen.length > 0 && Date.parse(seen) >= cutoff;
+    });
+    return live.length > 0 ? live : roster;
+  } catch {
+    return roster;
+  }
+}
+
 // CTL-1004/CTL-1056 Bug 2: dispatchFailureDiag — extract the diagnostic fields
 // from a dispatch result (r = { code, stderr, spawnError, signal }) for the
 // "dispatch failed" log + the phase.dispatch.failed event. The scheduler used to
@@ -3612,12 +3645,13 @@ export function schedulerTick(
       _dispatchRosterMemo = dispatchSurvivingRoster;
       return _dispatchRosterMemo;
     }
-    // CTL-1091 Phase 2: layer the restore-side deflap on top of the surviving
-    // roster. A dead→live host is held out of the dispatch roster until it has
-    // been continuously live for HEARTBEAT_RESTORE_HOLD_MS, so a flapping host
-    // doesn't grab-then-strand new work. Scheduler is the SOLE writer of
-    // .liveness-deflap.json (monitor reads it read-only).
-    const survivingRosterNow = computeSurvivingRoster(roster);
+    // CTL-1091 Phase 3: dispatch ownership uses POSITIVE liveness (seen within
+    // grace), so a never-live rostered host is shed and its slice fails over.
+    // Phase 2: layer the restore-side deflap on top, so a dead→live host is held
+    // out until continuously live for HEARTBEAT_RESTORE_HOLD_MS (no grab-then-
+    // strand on a flap). Scheduler is the SOLE writer of .liveness-deflap.json
+    // (monitor reads it read-only).
+    const survivingRosterNow = computeDispatchSurvivingRoster(roster);
     if (!multiHost) {
       _dispatchRosterMemo = survivingRosterNow;
       return _dispatchRosterMemo;

--- a/plugins/dev/scripts/execution-core/scheduler.test.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.test.mjs
@@ -9953,6 +9953,33 @@ describe("schedulerTick — new-work dispatch fails over an offline HRW owner (C
     const leftoverTmp = readdirSync(orchDir).filter((f) => f.startsWith(".liveness-deflap.json.tmp"));
     expect(leftoverTmp).toEqual([]);
   });
+
+  // CTL-1091 (Codex P1 #1): the deflap observation state must refresh on EVERY
+  // multi-host tick, even with NO ready work. Before the fix, _dispatchRoster()
+  // (the sole persist:true / writeDeflapState path) ran only inside the ready
+  // filter, so an idle board (empty eligible → empty ready) never wrote the file —
+  // a peer that departed while the board was quiet kept a stale continuous liveSince
+  // and was re-admitted immediately on return, skipping the restore hold. Assert the
+  // file is written even when there is nothing to dispatch.
+  test("Phase 2 (P1 #1): a multi-host tick with NO ready work still refreshes .liveness-deflap.json", () => {
+    writeFileSync(join(orchDir, "state.json"), JSON.stringify({ maxParallel: 1 }));
+    const dispatch = fakeDispatch({ code: 0 });
+    expect(existsSync(join(orchDir, ".liveness-deflap.json"))).toBe(false);
+    schedulerTick(orchDir, {
+      readEligible: () => [], // EMPTY board → no ready tickets → ready.filter never runs
+      dispatch,
+      hosts: ROSTER,
+      hostName: "mini",
+      claimDispatch: () => ({ won: true, generation: 1 }),
+      stampWorkerLabel: () => ({ stamped: true }),
+      verifyDispatched: verifyOk,
+      liveBackgroundCount: () => 0,
+      now: () => 1_000,
+      hasTriageArtifact: () => true,
+    });
+    expect(dispatch.calls).toHaveLength(0); // nothing dispatched
+    expect(existsSync(join(orchDir, ".liveness-deflap.json"))).toBe(true); // …but deflap refreshed
+  });
 });
 
 // ── CTL-1091 / CTL-1057: computeDispatchSurvivingRoster positive-liveness ──────

--- a/plugins/dev/scripts/execution-core/scheduler.test.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.test.mjs
@@ -10134,6 +10134,97 @@ describe("resolveDispatchRoster — shared dispatch resolver (CTL-1091)", () => 
     });
     expect(existsSync(join(orchDir, ".liveness-deflap.json"))).toBe(false);
   });
+
+  // CTL-1091 verify F3 (coverage): pin the SOLE-WRITER invariant on the read-only
+  // (monitor) path even when the deflap actually mutates observation state — a
+  // freshly-restored host is held, so nextState differs from prevState, yet
+  // persist:false must still leave the file untouched. Guards a regression that
+  // made the monitor path (resolveDispatchRoster persist:false) write the file.
+  test("persist:false leaves the deflap file untouched even when the deflap holds a host", () => {
+    // Seed a restored host so the resolve computes fresh observation state.
+    const seeded = JSON.stringify({ laptop: { liveSince: null } });
+    writeFileSync(join(orchDir, ".liveness-deflap.json"), seeded);
+    const out = resolveDispatchRoster({
+      roster: ["mini", "laptop"],
+      orchDir,
+      self: "mini",
+      nowMs: NOW,
+      holdMs: HOLD,
+      readHeartbeats: () => ({ mini: recent, laptop: recent }), // both live now
+      persist: false,
+    });
+    expect(out).toEqual(["mini"]); // laptop held (deflap active → nextState differs)
+    // File byte-identical to the seed — read-only path wrote nothing.
+    expect(readFileSync(join(orchDir, ".liveness-deflap.json"), "utf8")).toBe(seeded);
+  });
+
+  // CTL-1091 verify F2 (silent-failure): the outage→full-roster degrade must fire
+  // the onDegrade observability hook so cross-host failover turning OFF is not
+  // invisible. Two outage shapes; the caught error rides along on a read-throw.
+  test("onDegrade fires on a read-throw outage with the caught error message", () => {
+    const calls = [];
+    const out = resolveDispatchRoster({
+      roster: ["mini", "laptop"],
+      orchDir,
+      self: "mini",
+      nowMs: NOW,
+      readHeartbeats: () => {
+        throw new Error("loki down");
+      },
+      persist: true,
+      onDegrade: (info) => calls.push(info),
+    });
+    expect(out.slice().sort()).toEqual(["laptop", "mini"]);
+    expect(calls.length).toBe(1);
+    expect(calls[0].reason).toBe("heartbeat-read-threw");
+    expect(calls[0].error).toBe("loki down");
+  });
+
+  test("onDegrade fires when NOBODY is positively live (reason nobody-positively-live)", () => {
+    const calls = [];
+    resolveDispatchRoster({
+      roster: ["mini", "laptop"],
+      orchDir,
+      self: "mini",
+      nowMs: NOW,
+      readHeartbeats: () => ({}), // empty feed → nobody live
+      persist: true,
+      onDegrade: (info) => calls.push(info),
+    });
+    expect(calls.length).toBe(1);
+    expect(calls[0].reason).toBe("nobody-positively-live");
+    expect(calls[0].error).toBe(null);
+  });
+
+  test("onDegrade does NOT fire on the happy (some-live) path", () => {
+    const calls = [];
+    resolveDispatchRoster({
+      roster: ["mini", "laptop"],
+      orchDir,
+      self: "mini",
+      nowMs: NOW,
+      holdMs: HOLD,
+      readHeartbeats: () => ({ mini: recent, laptop: recent }),
+      persist: true,
+      onDegrade: (info) => calls.push(info),
+    });
+    expect(calls.length).toBe(0);
+  });
+
+  test("an onDegrade that throws never breaks the roster resolve", () => {
+    const out = resolveDispatchRoster({
+      roster: ["mini", "laptop"],
+      orchDir,
+      self: "mini",
+      nowMs: NOW,
+      readHeartbeats: () => ({}),
+      persist: false,
+      onDegrade: () => {
+        throw new Error("observability blew up");
+      },
+    });
+    expect(out.slice().sort()).toEqual(["laptop", "mini"]);
+  });
 });
 
 // ── CTL-1091 ticket-Gherkin scenarios (end-to-end over schedulerTick) ──────────

--- a/plugins/dev/scripts/execution-core/scheduler.test.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.test.mjs
@@ -21,6 +21,7 @@ import {
   isTicketInFlight,
   listInFlightTickets,
   computeDispatchSurvivingRoster, // CTL-1091 Phase 3: positive-liveness dispatch roster
+  resolveDispatchRoster, // CTL-1091: shared dispatch-roster resolver (liveness + deflap + outage)
   readMaxParallel,
   readExecutionCoreConcurrency,
   readExecutionCoreConcurrencyLayer2,
@@ -10023,6 +10024,115 @@ describe("computeDispatchSurvivingRoster — positive liveness (CTL-1091/CTL-105
     });
     expect(out).toEqual(["solo"]);
     expect(read).toBe(false);
+  });
+});
+
+// ── CTL-1091: resolveDispatchRoster — the shared liveness+deflap+outage resolver ─
+//
+// The single source of truth both dispatch sites (scheduler new-work + monitor
+// triage) call, so they can never drift. Composes positive-liveness → restore
+// deflap → outage fail-safe. Uses a real temp orchDir for the .liveness-deflap.json
+// read/write and an injected readHeartbeats for the feed.
+describe("resolveDispatchRoster — shared dispatch resolver (CTL-1091)", () => {
+  const NOW = 10_000_000;
+  const recent = new Date(NOW - 1_000).toISOString();
+  const HOLD = 600_000;
+
+  test("single-host is a strict no-op", () => {
+    const out = resolveDispatchRoster({
+      roster: ["solo"],
+      orchDir,
+      self: "solo",
+      nowMs: NOW,
+      readHeartbeats: () => ({}),
+    });
+    expect(out).toEqual(["solo"]);
+  });
+
+  test("sheds a never-live host and dispatches over the live survivor", () => {
+    const out = resolveDispatchRoster({
+      roster: ["mini", "ghost"],
+      orchDir,
+      self: "mini",
+      nowMs: NOW,
+      holdMs: HOLD,
+      readHeartbeats: () => ({ mini: recent }), // ghost never live
+      persist: true,
+    });
+    expect(out).toEqual(["mini"]);
+  });
+
+  test("holds a freshly-restored host out for the deflap window", () => {
+    // Seed prevState: laptop was shed last tick (liveSince:null) → newly restored.
+    writeFileSync(
+      join(orchDir, ".liveness-deflap.json"),
+      JSON.stringify({ laptop: { liveSince: null } })
+    );
+    const out = resolveDispatchRoster({
+      roster: ["mini", "laptop"],
+      orchDir,
+      self: "mini",
+      nowMs: NOW,
+      holdMs: HOLD,
+      readHeartbeats: () => ({ mini: recent, laptop: recent }), // both live now
+      persist: true,
+    });
+    expect(out).toEqual(["mini"]); // laptop held out (restore hold)
+  });
+
+  // CTL-1091 correctness review #1: on a TOTAL feed outage the resolver must
+  // degrade to the FULL roster and NOT let the deflap partially re-shed a
+  // just-departed host (which would re-home its slice, violating the outage
+  // invariant). This is the exact reproduction from the review.
+  test("total outage → FULL roster even when prevState marks a host shed (no partial re-shed)", () => {
+    writeFileSync(
+      join(orchDir, ".liveness-deflap.json"),
+      JSON.stringify({ A: { liveSince: null }, C: { liveSince: 0 } })
+    );
+    const out = resolveDispatchRoster({
+      roster: ["A", "B", "C"],
+      orchDir,
+      self: "A",
+      nowMs: 700_000,
+      holdMs: HOLD,
+      readHeartbeats: () => ({}), // NOBODY positively live → total outage
+      persist: true,
+    });
+    // Must be the full roster, NOT the partial [B,C] the naive deflap produced.
+    expect(out.slice().sort()).toEqual(["A", "B", "C"]);
+  });
+
+  test("read-throw (outage) → full roster, observation state left intact", () => {
+    writeFileSync(
+      join(orchDir, ".liveness-deflap.json"),
+      JSON.stringify({ laptop: { liveSince: 1234 } })
+    );
+    const out = resolveDispatchRoster({
+      roster: ["mini", "laptop"],
+      orchDir,
+      self: "mini",
+      nowMs: NOW,
+      readHeartbeats: () => {
+        throw new Error("loki down");
+      },
+      persist: true,
+    });
+    expect(out.slice().sort()).toEqual(["laptop", "mini"]);
+    // prevState preserved (we learned nothing this tick).
+    const persisted = JSON.parse(readFileSync(join(orchDir, ".liveness-deflap.json"), "utf8"));
+    expect(persisted.laptop.liveSince).toBe(1234);
+  });
+
+  test("persist:false does NOT write the deflap file", () => {
+    resolveDispatchRoster({
+      roster: ["mini", "ghost"],
+      orchDir,
+      self: "mini",
+      nowMs: NOW,
+      readHeartbeats: () => ({ mini: recent }),
+      persist: false,
+    });
+    expect(existsSync(join(orchDir, ".liveness-deflap.json"))).toBe(false);
   });
 });
 

--- a/plugins/dev/scripts/execution-core/scheduler.test.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.test.mjs
@@ -12,6 +12,7 @@ import {
   appendFileSync,
   existsSync,
   readFileSync,
+  readdirSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -9920,6 +9921,32 @@ describe("schedulerTick — new-work dispatch fails over an offline HRW owner (C
       hasTriageArtifact: () => true,
     });
     expect(dispatch.calls).toHaveLength(0);
+  });
+
+  // CTL-1091 Phase 2: the deflap path (no dispatchSurvivingRoster override) must
+  // persist .liveness-deflap.json atomically — the file exists after a multi-host
+  // tick and no partial `.tmp` sibling is left behind.
+  test("Phase 2: a multi-host tick writes .liveness-deflap.json atomically (no .tmp left)", () => {
+    writeFileSync(join(orchDir, "state.json"), JSON.stringify({ maxParallel: 1 }));
+    const dispatch = fakeDispatch({ code: 0 });
+    schedulerTick(orchDir, {
+      // A mini-owned eligible ticket forces the ready filter (→ _dispatchRoster())
+      // to run without a dispatchSurvivingRoster override, so the real deflap
+      // read/compute/write path fires.
+      readEligible: () => eligibleOne("CTL-1"),
+      dispatch,
+      hosts: ROSTER,
+      hostName: "mini",
+      claimDispatch: () => ({ won: true, generation: 1 }),
+      stampWorkerLabel: () => ({ stamped: true }),
+      verifyDispatched: verifyOk,
+      liveBackgroundCount: () => 0,
+      now: () => 1_000,
+      hasTriageArtifact: () => true,
+    });
+    expect(existsSync(join(orchDir, ".liveness-deflap.json"))).toBe(true);
+    const leftoverTmp = readdirSync(orchDir).filter((f) => f.startsWith(".liveness-deflap.json.tmp"));
+    expect(leftoverTmp).toEqual([]);
   });
 });
 

--- a/plugins/dev/scripts/execution-core/scheduler.test.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.test.mjs
@@ -20,6 +20,7 @@ import {
   readPhaseSignals,
   isTicketInFlight,
   listInFlightTickets,
+  computeDispatchSurvivingRoster, // CTL-1091 Phase 3: positive-liveness dispatch roster
   readMaxParallel,
   readExecutionCoreConcurrency,
   readExecutionCoreConcurrencyLayer2,
@@ -9901,18 +9902,21 @@ describe("schedulerTick — new-work dispatch fails over an offline HRW owner (C
     expect(dispatch.calls.map((a) => a.ticket)).toContain(LAPTOP_OWNED_ID);
   });
 
-  test("fails open: total liveness outage degrades to the full roster (no override, no heartbeats)", () => {
+  test("fails open: total liveness outage degrades to the full roster (no override)", () => {
     writeFileSync(join(orchDir, "state.json"), JSON.stringify({ maxParallel: 1 }));
     const dispatch = fakeDispatch({ code: 0 });
-    // No dispatchSurvivingRoster override → computeSurvivingRoster(roster) runs.
-    // With no heartbeat event log under orchDir it sees no live hosts; the
-    // fail-safe degrades to the FULL roster [mini,laptop], so laptop still owns
-    // CTL-3 → mini does NOT dispatch it (today's raw-roster behavior preserved).
+    // No dispatchSurvivingRoster override → the real computeDispatchSurvivingRoster
+    // runs. Use fake hosts guaranteed ABSENT from the real heartbeat feed so
+    // positive-liveness sees NO live host → fail-safe degrades to the FULL roster
+    // [hosta,hostb]. CTL-1 hashes to hostb over that roster, so hosta does NOT
+    // dispatch it (today's raw-roster behavior preserved on a dead feed).
+    const OUTAGE_ROSTER = ["hosta", "hostb"];
+    expect(ownerForTicket("CTL-1", OUTAGE_ROSTER)).toBe("hostb");
     schedulerTick(orchDir, {
-      readEligible: () => eligibleOne(),
+      readEligible: () => eligibleOne("CTL-1"),
       dispatch,
-      hosts: ROSTER,
-      hostName: "mini",
+      hosts: OUTAGE_ROSTER,
+      hostName: "hosta",
       claimDispatch: () => ({ won: true, generation: 1 }),
       stampWorkerLabel: () => ({ stamped: true }),
       verifyDispatched: verifyOk,
@@ -9947,6 +9951,209 @@ describe("schedulerTick — new-work dispatch fails over an offline HRW owner (C
     expect(existsSync(join(orchDir, ".liveness-deflap.json"))).toBe(true);
     const leftoverTmp = readdirSync(orchDir).filter((f) => f.startsWith(".liveness-deflap.json.tmp"));
     expect(leftoverTmp).toEqual([]);
+  });
+});
+
+// ── CTL-1091 / CTL-1057: computeDispatchSurvivingRoster positive-liveness ──────
+//
+// Dispatch ownership requires POSITIVE liveness (seen within grace), unlike the
+// recovery-side computeSurvivingRoster (fail-open deadHosts). This sheds a host
+// that has NEVER heartbeated (absent from lastSeen) so its HRW slice fails over,
+// while a total feed outage still fail-safes to the full roster.
+describe("computeDispatchSurvivingRoster — positive liveness (CTL-1091/CTL-1057)", () => {
+  const NOW = 10_000_000;
+  const recent = new Date(NOW - 1_000).toISOString();
+  const stale = new Date(NOW - 700_000).toISOString(); // older than 10-min grace
+
+  test("sheds a NEVER-live host (absent from lastSeen) — the CTL-1057 case", () => {
+    const roster = ["mini", "ghost"];
+    const out = computeDispatchSurvivingRoster(roster, {
+      readHeartbeats: () => ({ mini: recent }), // ghost never heartbeated
+      nowMs: NOW,
+    });
+    expect(out).toEqual(["mini"]);
+  });
+
+  test("sheds a host whose last heartbeat is older than grace", () => {
+    const roster = ["mini", "laptop"];
+    const out = computeDispatchSurvivingRoster(roster, {
+      readHeartbeats: () => ({ mini: recent, laptop: stale }),
+      nowMs: NOW,
+    });
+    expect(out).toEqual(["mini"]);
+  });
+
+  test("keeps every host seen within grace", () => {
+    const roster = ["mini", "laptop"];
+    const out = computeDispatchSurvivingRoster(roster, {
+      readHeartbeats: () => ({ mini: recent, laptop: recent }),
+      nowMs: NOW,
+    });
+    expect(out.slice().sort()).toEqual(["laptop", "mini"]);
+  });
+
+  test("fail-safe: NObody live (total outage) → full roster, never strands", () => {
+    const roster = ["mini", "laptop"];
+    const out = computeDispatchSurvivingRoster(roster, {
+      readHeartbeats: () => ({}), // no host seen at all
+      nowMs: NOW,
+    });
+    expect(out.slice().sort()).toEqual(["laptop", "mini"]);
+  });
+
+  test("fail-safe: a heartbeat-read throw → full roster", () => {
+    const roster = ["mini", "laptop"];
+    const out = computeDispatchSurvivingRoster(roster, {
+      readHeartbeats: () => {
+        throw new Error("loki down");
+      },
+      nowMs: NOW,
+    });
+    expect(out).toEqual(roster);
+  });
+
+  test("single-host is a strict no-op (no read)", () => {
+    let read = false;
+    const out = computeDispatchSurvivingRoster(["solo"], {
+      readHeartbeats: () => {
+        read = true;
+        return {};
+      },
+      nowMs: NOW,
+    });
+    expect(out).toEqual(["solo"]);
+    expect(read).toBe(false);
+  });
+});
+
+// ── CTL-1091 ticket-Gherkin scenarios (end-to-end over schedulerTick) ──────────
+//
+// One describe per ticket scenario. Co-located here (not a standalone file) to
+// reuse the outer beforeEach's CATALYST_DIR redirect — otherwise the real event
+// log would leak into computeSurvivingRoster and make these non-deterministic.
+// Liveness is injected via dispatchSurvivingRoster; the soft-CAS via claimDispatch.
+describe("CTL-1091 ticket scenarios — offline-node ownership shedding", () => {
+  const ROSTER = ["mini", "laptop"];
+  const T_MINI = "CTL-1"; // HRW owner over [mini,laptop] === mini
+  const T_LAPTOP = "CTL-3"; // HRW owner over [mini,laptop] === laptop
+  // Anchor fixtures to the real HRW math.
+  expect(ownerForTicket(T_MINI, ROSTER)).toBe("mini");
+  expect(ownerForTicket(T_LAPTOP, ROSTER)).toBe("laptop");
+  expect(ownerForTicket(T_LAPTOP, ["mini"])).toBe("mini"); // fails over to survivor
+
+  const elig = (...ids) =>
+    ids.map((identifier) => ({
+      identifier,
+      priority: 1,
+      createdAt: "x",
+      state: "Todo",
+      relations: { nodes: [] },
+      inverseRelations: { nodes: [] },
+    }));
+
+  const dispatchedIds = (dispatch) => dispatch.calls.map((a) => a.ticket).sort();
+
+  test("scenario 1 — backlog flows while the laptop is OFF: mini dispatches ALL", () => {
+    writeFileSync(join(orchDir, "state.json"), JSON.stringify({ maxParallel: 5 }));
+    const dispatch = fakeDispatch({ code: 0 });
+    schedulerTick(orchDir, {
+      readEligible: () => elig(T_MINI, T_LAPTOP),
+      dispatch,
+      hosts: ROSTER,
+      hostName: "mini",
+      dispatchSurvivingRoster: ["mini"], // laptop shed
+      claimDispatch: () => ({ won: true, generation: 1 }),
+      stampWorkerLabel: () => ({ stamped: true }),
+      verifyDispatched: verifyOk,
+      liveBackgroundCount: () => 0,
+      now: () => 1_000,
+      hasTriageArtifact: () => true,
+    });
+    // Both the mini-hashed AND the laptop-hashed ticket dispatch from mini.
+    expect(dispatchedIds(dispatch)).toEqual([T_LAPTOP, T_MINI].sort());
+  });
+
+  test("scenario 2a — laptop rejoins and takes its OWN slice back", () => {
+    writeFileSync(join(orchDir, "state.json"), JSON.stringify({ maxParallel: 5 }));
+    const dispatch = fakeDispatch({ code: 0 });
+    schedulerTick(orchDir, {
+      readEligible: () => elig(T_LAPTOP),
+      dispatch,
+      hosts: ROSTER,
+      hostName: "laptop",
+      dispatchSurvivingRoster: ["mini", "laptop"], // both live (past hold)
+      claimDispatch: () => ({ won: true, generation: 1 }),
+      stampWorkerLabel: () => ({ stamped: true }),
+      verifyDispatched: verifyOk,
+      liveBackgroundCount: () => 0,
+      now: () => 1_000,
+      hasTriageArtifact: () => true,
+    });
+    expect(dispatchedIds(dispatch)).toEqual([T_LAPTOP]);
+  });
+
+  test("scenario 2b — NO mid-flight handback: a ticket mini already claimed stays with mini", () => {
+    writeFileSync(join(orchDir, "state.json"), JSON.stringify({ maxParallel: 5 }));
+    const dispatch = fakeDispatch({ code: 0 });
+    const claims = [];
+    schedulerTick(orchDir, {
+      readEligible: () => elig(T_LAPTOP),
+      dispatch,
+      hosts: ROSTER,
+      hostName: "laptop",
+      dispatchSurvivingRoster: ["mini", "laptop"],
+      // laptop owns T_LAPTOP by HRW and attempts the claim, but mini holds the
+      // fence → the soft-CAS is LOST → laptop does not re-dispatch (no handback).
+      claimDispatch: (arg) => {
+        claims.push(arg);
+        return { won: false, generation: 2 };
+      },
+      stampWorkerLabel: () => ({ stamped: true }),
+      verifyDispatched: verifyOk,
+      liveBackgroundCount: () => 0,
+      now: () => 1_000,
+      hasTriageArtifact: () => true,
+    });
+    expect(claims).toHaveLength(1); // the claim was ATTEMPTED (path unchanged)
+    expect(dispatch.calls).toHaveLength(0); // but LOST → not dispatched
+  });
+
+  test("scenario 3 — both hosts race a transition: the soft-CAS yields EXACTLY one dispatch", () => {
+    writeFileSync(join(orchDir, "state.json"), JSON.stringify({ maxParallel: 5 }));
+    // mini's tick: it believes laptop is dead → it owns T_LAPTOP → wins the CAS.
+    const dMini = fakeDispatch({ code: 0 });
+    schedulerTick(orchDir, {
+      readEligible: () => elig(T_LAPTOP),
+      dispatch: dMini,
+      hosts: ROSTER,
+      hostName: "mini",
+      dispatchSurvivingRoster: ["mini"],
+      claimDispatch: () => ({ won: true, generation: 5 }), // mini wins
+      stampWorkerLabel: () => ({ stamped: true }),
+      verifyDispatched: verifyOk,
+      liveBackgroundCount: () => 0,
+      now: () => 1_000,
+      hasTriageArtifact: () => true,
+    });
+    // laptop's concurrent tick: it believes it is live → it owns T_LAPTOP too, but
+    // the fence CAS is already held by mini → LOST.
+    const dLaptop = fakeDispatch({ code: 0 });
+    schedulerTick(orchDir, {
+      readEligible: () => elig(T_LAPTOP),
+      dispatch: dLaptop,
+      hosts: ROSTER,
+      hostName: "laptop",
+      dispatchSurvivingRoster: ["mini", "laptop"],
+      claimDispatch: () => ({ won: false, generation: 5 }), // laptop loses the CAS
+      stampWorkerLabel: () => ({ stamped: true }),
+      verifyDispatched: verifyOk,
+      liveBackgroundCount: () => 0,
+      now: () => 1_000,
+      hasTriageArtifact: () => true,
+    });
+    // Exactly one host dispatched the contested ticket.
+    expect(dMini.calls).toHaveLength(1);
+    expect(dLaptop.calls).toHaveLength(0);
   });
 });
 

--- a/plugins/dev/scripts/execution-core/scheduler.test.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.test.mjs
@@ -9813,6 +9813,116 @@ describe("CTL-850 — HRW ownership + claim-on-dispatch (schedulerTick new-work)
   });
 });
 
+// ── CTL-1091: new-work dispatch fails over an OFFLINE HRW owner ───────────────
+//
+// The new-work ready filter (scheduler.mjs) must hash ownership over the LIVE
+// (surviving) roster, not the raw roster, so a ticket whose HRW owner is offline
+// fails over to a live host instead of stranding in Todo forever. Mirrors the
+// CTL-1191 recovery-side seam: an injectable dispatchSurvivingRoster override
+// drives the shed set deterministically without writing heartbeat events.
+describe("schedulerTick — new-work dispatch fails over an offline HRW owner (CTL-1091)", () => {
+  const ROSTER = ["mini", "laptop"];
+  // CTL-3 hashes to "laptop" under [mini,laptop]; under [mini] alone it fails
+  // over to mini (survivor identity). Anchor the fixture to the real HRW math.
+  const LAPTOP_OWNED_ID = "CTL-3";
+  expect(ownerForTicket(LAPTOP_OWNED_ID, ROSTER)).toBe("laptop");
+  expect(ownerForTicket(LAPTOP_OWNED_ID, ["mini"])).toBe("mini");
+
+  const eligibleOne = (id = LAPTOP_OWNED_ID) => [
+    {
+      identifier: id,
+      priority: 1,
+      createdAt: "x",
+      state: "Todo",
+      relations: { nodes: [] },
+      inverseRelations: { nodes: [] },
+    },
+  ];
+
+  test("dispatches a laptop-owned ticket from mini when laptop is OFFLINE (shed)", () => {
+    writeFileSync(join(orchDir, "state.json"), JSON.stringify({ maxParallel: 1 }));
+    const dispatch = fakeDispatch({ code: 0 });
+    schedulerTick(orchDir, {
+      readEligible: () => eligibleOne(),
+      dispatch,
+      hosts: ROSTER,
+      hostName: "mini",
+      // laptop shed → survivors = [mini]; mini now owns CTL-3 → dispatched.
+      dispatchSurvivingRoster: ["mini"],
+      // won claim so the dispatch proceeds past the multi-host claim gate.
+      claimDispatch: () => ({ won: true, generation: 1 }),
+      stampWorkerLabel: () => ({ stamped: true }),
+      verifyDispatched: verifyOk,
+      liveBackgroundCount: () => 0,
+      now: () => 1_000,
+      hasTriageArtifact: () => true,
+    });
+    expect(dispatch.calls.map((a) => a.ticket)).toContain(LAPTOP_OWNED_ID);
+  });
+
+  test("does NOT dispatch a laptop-owned ticket from mini when laptop is LIVE", () => {
+    writeFileSync(join(orchDir, "state.json"), JSON.stringify({ maxParallel: 1 }));
+    const dispatch = fakeDispatch({ code: 0 });
+    schedulerTick(orchDir, {
+      readEligible: () => eligibleOne(),
+      dispatch,
+      hosts: ROSTER,
+      hostName: "mini",
+      // both live → laptop still owns CTL-3 → mini filters it out.
+      dispatchSurvivingRoster: ["mini", "laptop"],
+      claimDispatch: () => ({ won: true, generation: 1 }),
+      stampWorkerLabel: () => ({ stamped: true }),
+      verifyDispatched: verifyOk,
+      liveBackgroundCount: () => 0,
+      now: () => 1_000,
+      hasTriageArtifact: () => true,
+    });
+    expect(dispatch.calls).toHaveLength(0);
+  });
+
+  test("single-host is a strict no-op (dispatches, HRW identity)", () => {
+    writeFileSync(join(orchDir, "state.json"), JSON.stringify({ maxParallel: 1 }));
+    const dispatch = fakeDispatch({ code: 0 });
+    schedulerTick(orchDir, {
+      readEligible: () => eligibleOne(),
+      dispatch,
+      hosts: ["mini"],
+      hostName: "mini",
+      // multiHost=false short-circuits the ownership filter entirely; no
+      // surviving-roster read fires regardless of any override.
+      claimDispatch: () => ({ won: true, generation: 1 }),
+      stampWorkerLabel: () => ({ stamped: true }),
+      verifyDispatched: verifyOk,
+      liveBackgroundCount: () => 0,
+      now: () => 1_000,
+      hasTriageArtifact: () => true,
+    });
+    expect(dispatch.calls.map((a) => a.ticket)).toContain(LAPTOP_OWNED_ID);
+  });
+
+  test("fails open: total liveness outage degrades to the full roster (no override, no heartbeats)", () => {
+    writeFileSync(join(orchDir, "state.json"), JSON.stringify({ maxParallel: 1 }));
+    const dispatch = fakeDispatch({ code: 0 });
+    // No dispatchSurvivingRoster override → computeSurvivingRoster(roster) runs.
+    // With no heartbeat event log under orchDir it sees no live hosts; the
+    // fail-safe degrades to the FULL roster [mini,laptop], so laptop still owns
+    // CTL-3 → mini does NOT dispatch it (today's raw-roster behavior preserved).
+    schedulerTick(orchDir, {
+      readEligible: () => eligibleOne(),
+      dispatch,
+      hosts: ROSTER,
+      hostName: "mini",
+      claimDispatch: () => ({ won: true, generation: 1 }),
+      stampWorkerLabel: () => ({ stamped: true }),
+      verifyDispatched: verifyOk,
+      liveBackgroundCount: () => 0,
+      now: () => 1_000,
+      hasTriageArtifact: () => true,
+    });
+    expect(dispatch.calls).toHaveLength(0);
+  });
+});
+
 // ── CTL-1191: HRW-gate the recovery passes over the surviving roster ──────────
 //
 // The recovery passes (Pass 0u unstuck-sweep, Pass 0r reasoning, diagnostician)


### PR DESCRIPTION
<!-- Auto-generated: 2026-07-21T00:00:00Z -->
<!-- Last updated: 2026-07-21T00:00:00Z -->
<!-- PR: #2671 -->
<!-- Previous commits: 110f9461,235b737f,886329e5,9de3ef49,8a88ecd7 -->

## Summary

Make cross-host ticket ownership fail over when a *sometimes-on* node goes offline, so its share of the backlog is no longer stranded in Todo forever. Previously both cross-host ownership gates hashed over the **full** roster, so a laptop that had never heartbeated (or had gone offline) still "owned" its Highest-Random-Weight (HRW) slice — and no live host would pick it up. This PR routes the **dispatch** altitude through a liveness-filtered roster so an offline/never-live owner's slice fails over to a live host, while keeping the **recovery** altitude fail-open (an unseen host has no work to reclaim).

Refs: CTL-1091 — *"A sometimes-on node should shed its ticket ownership while offline so its share of the backlog never starves."*

## Changes Made

Landed in three phases plus review/verify remediation:

**Phase 1 — route dispatch gates through the surviving roster** (`110f9461`)
- The new-work `ready` filter (`scheduler.mjs`) and the triage predicate (`monitor.mjs`) now hash ownership over a liveness-filtered dispatch roster instead of the full roster, so an offline owner's HRW slice fails over to a live host.

**Phase 2 — restore-side deflap hysteresis** (`235b737f`)
- Adds `liveness-deflap.mjs` (`computeDispatchRoster`): a dead→live host is held out for `HEARTBEAT_RESTORE_HOLD_MS` before it can re-acquire ownership, so a flapping laptop can't grab-then-strand work. The scheduler is the sole writer of `.liveness-deflap.json`; the monitor reads it.

**Phase 3 — never-live shedding + scenario tests + docs** (`886329e5`)
- `computeDispatchSurvivingRoster` uses POSITIVE liveness: a host must have heartbeated within `HEARTBEAT_GRACE_MS`, so a *never-live* rostered host is shed (not just a previously-live one that went dark).
- Adds scenario tests and updates `docs/architecture.md` cross-host ownership section.

**Review + verify remediation** (`9de3ef49`, `8a88ecd7`)
- Extracts a shared dispatch-resolver so the scheduler and monitor agree on the same roster.
- Fixes the total-liveness-outage invariant (heartbeat read throws / everyone looks dead) to degrade to the **full roster** — each node owns only its own HRW slice, never double-acting.
- Remediates verify findings (regression_risk 5).

### Ownership-gate asymmetry (the core design point)

| Altitude | Roster | Liveness posture | Rationale |
| --- | --- | --- | --- |
| **Dispatch** (`ready` filter, triage predicate) | `computeDispatchSurvivingRoster` + restore deflap | POSITIVE — must have heartbeated within grace; never-live host is shed | Fail an unseen/offline owner's slice **over** to a live host |
| **Recovery** (`ownsForRecovery`, `reclaimDeadHostWork`) | `computeSurvivingRoster` | fail-OPEN `deadHosts` — unseen host is "not proven dead" | A never-seen host has no work to reclaim; do not reclaim non-existent work |

Preserved fail-safes (unchanged): single-host is a strict no-op; a total liveness outage degrades to the full roster; the Linear-CAS claim (`cluster-claim.mjs`) remains the transition-race serializer.

## Files Changed (8 files, +1285 / −6)

- `plugins/dev/scripts/execution-core/liveness-deflap.mjs` (new, +142) — restore-side deflap + `computeDispatchRoster`
- `plugins/dev/scripts/execution-core/liveness-deflap.test.mjs` (new, +244)
- `plugins/dev/scripts/execution-core/scheduler.mjs` (+181 / −2) — dispatch roster in the `ready` filter
- `plugins/dev/scripts/execution-core/scheduler.test.mjs` (new, +545)
- `plugins/dev/scripts/execution-core/monitor.mjs` (+54 / −4) — dispatch roster in the triage predicate
- `plugins/dev/scripts/execution-core/monitor.test.mjs` (new, +82)
- `plugins/dev/scripts/execution-core/config.mjs` (+15) — `HEARTBEAT_RESTORE_HOLD_MS` and related config
- `docs/architecture.md` (+22) — cross-host ownership (HRW + liveness) section updated

## How to Verify It

- [x] Touched unit + scenario tests pass: `bun test liveness-deflap.test.mjs monitor.test.mjs scheduler.test.mjs` — **760 pass, 0 fail** (1522 assertions) ✅

_Note: these are `bun:test` suites and must run under Bun, not `node --test`._

## Related Issues/PRs

- Fixes https://linear.app/issue/CTL-1091