### PR TITLE
fix(dev): CTL-1497 — repair thoughts/shared on the worktree reuse path; guards test -L not -d

### DIFF
--- a/plugins/dev/scripts/create-worktree.sh
+++ b/plugins/dev/scripts/create-worktree.sh
@@ -139,24 +139,34 @@ if [ -d "$WORKTREE_PATH" ]; then
 		# CTL-1497: the reuse path short-circuits BEFORE the setup block below, so a worktree first
 		# created with a broken thoughts/shared — a plain directory, OR a dangling symlink whose target is
 		# gone — is never repaired on later dispatches, and thoughts written there strand and never sync.
-		# A HEALTHY thoughts/shared is a symlink that resolves to a directory (-L AND -d); repair anything
-		# else. init-or-repair refuses to clobber an existing plain-dir/dangling thoughts/ (it will not risk
-		# data loss), so move it aside first — stranded content is preserved under .orphaned-* — then
-		# rebuild. If the repair does not leave a healthy symlink, FAIL LOUD: never report a successful
-		# reuse of a worktree that would still strand thoughts.
+		# A HEALTHY thoughts/shared is a symlink that resolves to a directory (-L AND -d).
 		if [ ! -L "$WORKTREE_PATH/thoughts/shared" ] || [ ! -d "$WORKTREE_PATH/thoughts/shared" ]; then
-			_CW_SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-			echo -e "${YELLOW}  ⚠️  thoughts/shared is not a healthy symlink — repairing (CTL-1497)${NC}"
-			if [ -e "$WORKTREE_PATH/thoughts" ] || [ -L "$WORKTREE_PATH/thoughts" ]; then
-				mv "$WORKTREE_PATH/thoughts" "$WORKTREE_PATH/thoughts.orphaned-$(date +%Y%m%d-%H%M%S)" \
-					|| { echo -e "${RED}❌ create-worktree: could not move aside broken thoughts/ in ${WORKTREE_PATH} (CTL-1497)${NC}" >&2; exit 65; }
+			# ...but only when this project actually USES shared thoughts. An unconfigured project (no
+			# thoughts profile in config, no HumanLayer) legitimately has no thoughts/shared and must still
+			# reuse — never block phases 2-9 for those. Resolve the profile exactly as the setup block does.
+			_CW_THOUGHTS_PROFILE=""
+			[ -n "$CONFIG_FILE" ] && _CW_THOUGHTS_PROFILE=$(jq -r '.catalyst.thoughts.profile // empty' "$CONFIG_FILE" 2>/dev/null)
+			if [ -z "$_CW_THOUGHTS_PROFILE" ] && command -v humanlayer >/dev/null 2>&1; then
+				_CW_THOUGHTS_PROFILE=$(humanlayer thoughts status 2>/dev/null | grep -i "Profile:" | head -1 | awk '{print $2}')
 			fi
-			if ! ( cd "$WORKTREE_PATH" && bash "${_CW_SCRIPT_DIR}/catalyst-thoughts.sh" init-or-repair ) \
-				|| [ ! -L "$WORKTREE_PATH/thoughts/shared" ] || [ ! -d "$WORKTREE_PATH/thoughts/shared" ]; then
-				echo -e "${RED}❌ create-worktree: thoughts repair FAILED on reuse path — ${WORKTREE_PATH} would strand thoughts; refusing to report success (CTL-1497)${NC}" >&2
-				exit 65
+			if [ -n "$_CW_THOUGHTS_PROFILE" ]; then
+				_CW_SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+				echo -e "${YELLOW}  ⚠️  thoughts/shared is not a healthy symlink — repairing (CTL-1497)${NC}"
+				# init-or-repair refuses to clobber an existing plain-dir/dangling thoughts/ (it will not
+				# risk data loss), so move it aside first — stranded content is preserved under .orphaned-*
+				# — then rebuild. If repair does not leave a healthy symlink, FAIL LOUD (exit 65): never
+				# report a successful reuse of a worktree that would still strand thoughts.
+				if [ -e "$WORKTREE_PATH/thoughts" ] || [ -L "$WORKTREE_PATH/thoughts" ]; then
+					mv "$WORKTREE_PATH/thoughts" "$WORKTREE_PATH/thoughts.orphaned-$(date +%Y%m%d-%H%M%S)" \
+						|| { echo -e "${RED}❌ create-worktree: could not move aside broken thoughts/ in ${WORKTREE_PATH} (CTL-1497)${NC}" >&2; exit 65; }
+				fi
+				if ! ( cd "$WORKTREE_PATH" && bash "${_CW_SCRIPT_DIR}/catalyst-thoughts.sh" init-or-repair ) \
+					|| [ ! -L "$WORKTREE_PATH/thoughts/shared" ] || [ ! -d "$WORKTREE_PATH/thoughts/shared" ]; then
+					echo -e "${RED}❌ create-worktree: thoughts repair FAILED on reuse path — ${WORKTREE_PATH} would strand thoughts; refusing to report success (CTL-1497)${NC}" >&2
+					exit 65
+				fi
+				echo -e "${GREEN}  ✅ thoughts/shared repaired${NC}"
 			fi
-			echo -e "${GREEN}  ✅ thoughts/shared repaired${NC}"
 		fi
 		echo -e "${GREEN}♻️  Reusing existing worktree: $WORKTREE_PATH${NC}"
 		echo "WORKTREE_PATH=${WORKTREE_PATH}"

--- a/plugins/dev/scripts/create-worktree.sh
+++ b/plugins/dev/scripts/create-worktree.sh
@@ -137,13 +137,26 @@ if [ -d "$WORKTREE_PATH" ]; then
 			fi
 		fi
 		# CTL-1497: the reuse path short-circuits BEFORE the setup block below, so a worktree first
-		# created with a broken (plain-dir, not symlink) thoughts/shared is never repaired on later
-		# dispatches — thoughts written there strand and never sync. Repair it here before returning.
-		if [ ! -L "$WORKTREE_PATH/thoughts/shared" ]; then
+		# created with a broken thoughts/shared — a plain directory, OR a dangling symlink whose target is
+		# gone — is never repaired on later dispatches, and thoughts written there strand and never sync.
+		# A HEALTHY thoughts/shared is a symlink that resolves to a directory (-L AND -d); repair anything
+		# else. init-or-repair refuses to clobber an existing plain-dir/dangling thoughts/ (it will not risk
+		# data loss), so move it aside first — stranded content is preserved under .orphaned-* — then
+		# rebuild. If the repair does not leave a healthy symlink, FAIL LOUD: never report a successful
+		# reuse of a worktree that would still strand thoughts.
+		if [ ! -L "$WORKTREE_PATH/thoughts/shared" ] || [ ! -d "$WORKTREE_PATH/thoughts/shared" ]; then
 			_CW_SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-			echo -e "${YELLOW}  ⚠️  thoughts/shared is not a symlink — repairing (CTL-1497)${NC}"
-			( cd "$WORKTREE_PATH" && bash "${_CW_SCRIPT_DIR}/catalyst-thoughts.sh" init-or-repair ) \
-				|| echo -e "${YELLOW}  ⚠️  thoughts repair failed on reuse path (non-fatal); run: cd ${WORKTREE_PATH} && bash ${_CW_SCRIPT_DIR}/catalyst-thoughts.sh init-or-repair${NC}" >&2
+			echo -e "${YELLOW}  ⚠️  thoughts/shared is not a healthy symlink — repairing (CTL-1497)${NC}"
+			if [ -e "$WORKTREE_PATH/thoughts" ] || [ -L "$WORKTREE_PATH/thoughts" ]; then
+				mv "$WORKTREE_PATH/thoughts" "$WORKTREE_PATH/thoughts.orphaned-$(date +%Y%m%d-%H%M%S)" \
+					|| { echo -e "${RED}❌ create-worktree: could not move aside broken thoughts/ in ${WORKTREE_PATH} (CTL-1497)${NC}" >&2; exit 65; }
+			fi
+			if ! ( cd "$WORKTREE_PATH" && bash "${_CW_SCRIPT_DIR}/catalyst-thoughts.sh" init-or-repair ) \
+				|| [ ! -L "$WORKTREE_PATH/thoughts/shared" ] || [ ! -d "$WORKTREE_PATH/thoughts/shared" ]; then
+				echo -e "${RED}❌ create-worktree: thoughts repair FAILED on reuse path — ${WORKTREE_PATH} would strand thoughts; refusing to report success (CTL-1497)${NC}" >&2
+				exit 65
+			fi
+			echo -e "${GREEN}  ✅ thoughts/shared repaired${NC}"
 		fi
 		echo -e "${GREEN}♻️  Reusing existing worktree: $WORKTREE_PATH${NC}"
 		echo "WORKTREE_PATH=${WORKTREE_PATH}"
@@ -393,8 +406,8 @@ else
 			echo -e "${GREEN}  ✅ Thoughts initialized${NC}"
 			humanlayer thoughts sync >/dev/null 2>&1 || echo -e "${YELLOW}  ⚠️  Sync warning: run 'humanlayer thoughts sync' manually${NC}"
 			# Verify thoughts/shared/ exists after init+sync
-			if [ ! -L "thoughts/shared" ]; then
-				echo -e "${RED}❌ Error: thoughts/shared/ does not exist after init+sync${NC}"
+			if [ ! -L "thoughts/shared" ] || [ ! -d "thoughts/shared" ]; then
+				echo -e "${RED}❌ Error: thoughts/shared/ is not a healthy symlink (missing or dangling) after init+sync${NC}"
 				echo "  Working directory: $(pwd)"
 				echo "  Expected path: $(pwd)/thoughts/shared/"
 				echo "  This indicates a thoughts initialization failure."
@@ -426,7 +439,7 @@ fi
 # run_hook_array (or the auto-detected else-branch) and is otherwise silent;
 # the missing thoughts/shared then surfaces ~30 min later as a phase-plan
 # `prior_artifact_missing` failure. Catch it here, at creation time, instead.
-if [ "$THOUGHTS_INIT_EXPECTED" = true ] && [ ! -L "thoughts/shared" ]; then
+if [ "$THOUGHTS_INIT_EXPECTED" = true ] && { [ ! -L "thoughts/shared" ] || [ ! -d "thoughts/shared" ]; }; then
 	echo -e "${RED}❌ Error: thoughts/shared/ missing after setup hooks${NC}"
 	echo "  Working directory: $(pwd)"
 	echo "  Expected path: $(pwd)/thoughts/shared/"

--- a/plugins/dev/scripts/create-worktree.sh
+++ b/plugins/dev/scripts/create-worktree.sh
@@ -136,6 +136,15 @@ if [ -d "$WORKTREE_PATH" ]; then
 				exit 64
 			fi
 		fi
+		# CTL-1497: the reuse path short-circuits BEFORE the setup block below, so a worktree first
+		# created with a broken (plain-dir, not symlink) thoughts/shared is never repaired on later
+		# dispatches — thoughts written there strand and never sync. Repair it here before returning.
+		if [ ! -L "$WORKTREE_PATH/thoughts/shared" ]; then
+			_CW_SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+			echo -e "${YELLOW}  ⚠️  thoughts/shared is not a symlink — repairing (CTL-1497)${NC}"
+			( cd "$WORKTREE_PATH" && bash "${_CW_SCRIPT_DIR}/catalyst-thoughts.sh" init-or-repair ) \
+				|| echo -e "${YELLOW}  ⚠️  thoughts repair failed on reuse path (non-fatal); run: cd ${WORKTREE_PATH} && bash ${_CW_SCRIPT_DIR}/catalyst-thoughts.sh init-or-repair${NC}" >&2
+		fi
 		echo -e "${GREEN}♻️  Reusing existing worktree: $WORKTREE_PATH${NC}"
 		echo "WORKTREE_PATH=${WORKTREE_PATH}"
 		exit 0
@@ -384,7 +393,7 @@ else
 			echo -e "${GREEN}  ✅ Thoughts initialized${NC}"
 			humanlayer thoughts sync >/dev/null 2>&1 || echo -e "${YELLOW}  ⚠️  Sync warning: run 'humanlayer thoughts sync' manually${NC}"
 			# Verify thoughts/shared/ exists after init+sync
-			if [ ! -d "thoughts/shared" ]; then
+			if [ ! -L "thoughts/shared" ]; then
 				echo -e "${RED}❌ Error: thoughts/shared/ does not exist after init+sync${NC}"
 				echo "  Working directory: $(pwd)"
 				echo "  Expected path: $(pwd)/thoughts/shared/"
@@ -417,7 +426,7 @@ fi
 # run_hook_array (or the auto-detected else-branch) and is otherwise silent;
 # the missing thoughts/shared then surfaces ~30 min later as a phase-plan
 # `prior_artifact_missing` failure. Catch it here, at creation time, instead.
-if [ "$THOUGHTS_INIT_EXPECTED" = true ] && [ ! -d "thoughts/shared" ]; then
+if [ "$THOUGHTS_INIT_EXPECTED" = true ] && [ ! -L "thoughts/shared" ]; then
 	echo -e "${RED}❌ Error: thoughts/shared/ missing after setup hooks${NC}"
 	echo "  Working directory: $(pwd)"
 	echo "  Expected path: $(pwd)/thoughts/shared/"


### PR DESCRIPTION
## Problem

The daemon always creates worktrees with `--reuse-existing` (`worktree.mjs:29`). In `create-worktree.sh`, the `--reuse-existing` block short-circuits with `exit 0` **before the thoughts-setup block ever runs**, so a worktree first created with a broken `thoughts/shared` (a plain directory instead of the humanlayer symlink — from an interrupted/failed init or a pre-existing dir) is **never repaired on any later dispatch**. Compounding it, the post-setup guards tested `-d`, not `-L`, so a plain-dir `thoughts/shared` *passed* — the guards only caught total absence, never the wrong-type state.

**Impact:** thoughts written into such a worktree (handoffs, research, plans) land in a local non-symlinked dir and never sync to the shared thoughts repo — silently stranded. Observed live: the CTC-263 dev-view handoff (catalyst-cloud) was written into a reused worktree whose `thoughts/shared` was a plain dir; it never synced, so `/resume-handoff` and `humanlayer thoughts sync` from the main checkout couldn't find it (recovered by hand).

This is the residual [CTL-513](https://linear.app/coalesce-labs/issue/CTL-513) did not close.

## Fix

- **Reuse path:** before the reuse-path `exit 0`, if `thoughts/shared` is not a symlink, repair it via the existing `catalyst-thoughts.sh init-or-repair` primitive (which moves a plain-dir aside and rebuilds the symlinks). Non-fatal on failure — prints the manual recovery command. `SCRIPT_DIR` isn't defined this early, so it's computed inline.
- **Harden guards:** both `[ ! -d "thoughts/shared" ]` checks → `[ ! -L "thoughts/shared" ]`, so a plain dir is caught, not just absence.

`bash -n` clean. No behavior change on the happy path (a valid symlink passes `-L`).

## Follow-up (same ticket)
Extend `plugins/dev/scripts/__tests__/create-worktree-thoughts-check.test.sh` with a case exercising the `--reuse-existing` path against a pre-existing plain-dir `thoughts/shared` (today only the CREATE path is covered). Optionally add a per-worktree `-L thoughts/shared` check to `execution-core/doctor.mjs` `checkThoughts()`.

Closes CTL-1497.

🤖 Generated with [Claude Code](https://claude.com/claude-code)