### PR TITLE
feat(dev): CTL-1496 recovery-pass drives blocked PR to merge instead of escalating

### DIFF
--- a/.claude/rules/skill-references.md
+++ b/.claude/rules/skill-references.md
@@ -1,0 +1,15 @@
+# Skill Reference Naming
+
+Plugin skills always require the fully-qualified `plugin-name:skill-name` form for invocation.
+
+When outputting skill invocation instructions to the user (in templates, error messages, "next steps" suggestions), always use the full prefix:
+
+- catalyst-dev skills: `/catalyst-dev:skill-name`
+- catalyst-pm skills: `/catalyst-pm:skill-name`
+- catalyst-meta skills: `/catalyst-meta:skill-name`
+- catalyst-debugging skills: `/catalyst-debugging:skill-name`
+- catalyst-analytics skills: `/catalyst-analytics:skill-name`
+
+In explanatory prose describing workflow relationships (e.g., "Called by /implement-plan as part of quality gates"), bare names are acceptable for readability since nobody types those.
+
+Agent `subagent_type` references always use the full `plugin-name:agent-name` format.

--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,1 +1,0 @@
-{"sessionId":"966d6785-620b-44b3-b060-aea1d1ff8732","pid":84354,"procStart":"Sat Apr 25 03:35:01 2026","acquiredAt":1777089037648}

--- a/.github/workflows/execution-core-tests.yml
+++ b/.github/workflows/execution-core-tests.yml
@@ -164,6 +164,20 @@ jobs:
         working-directory: plugins/dev/scripts
         run: bash __tests__/canonical-event.test.sh
 
+      - name: gh-pr-comment helper test (CTL-1496)
+        # Covers PR_NUMBER numeric validation + the idempotent existing-comment
+        # guard (skip on match, fail-closed on fetch failure).
+        working-directory: plugins/dev/scripts
+        run: bash __tests__/gh-pr-comment.test.sh
+
+      - name: recovery-pass pr_not_merged remediation test (CTL-1496)
+        working-directory: plugins/dev/scripts
+        run: bash __tests__/recovery-pass-pr-not-merged.test.sh
+
+      - name: review-comments headless resolution test (CTL-1496)
+        working-directory: plugins/dev/scripts
+        run: bash __tests__/review-comments-headless.test.sh
+
       - name: Run stable unit tests
         # EXCLUDED SUITES — do NOT add these back without fixing the underlying
         # timing / sandbox incompatibility:
@@ -317,6 +331,7 @@ jobs:
             worktree-safety.test.mjs \
             worktree.test.mjs \
             recovery-reasoning.test.mjs \
+            pr-block-probe.test.mjs \
             recovery-emit.test.mjs \
             sweep-stale-recovery-intents.test.mjs \
             triage-redispatch-guard.test.mjs \

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -218,6 +218,26 @@ active work:
 - **Deferred**: reading `.draftPr` draft-state as a secondary advancement signal (advancement
   currently driven by signal `status === "done"` only).
 
+### Recovery-pass `pr_not_merged` remediation (CTL-1496)
+
+When `phase-teardown` emits `failed(reason: "pr_not_merged")`, the scheduler's **Pass 0r** sweeps
+it as a recovery item. Previously the classifier blindly escalated it to a human. With CTL-1496
+(`CATALYST_RECOVERY_PASS=shadow|enforce`), the classifier instead probes live GitHub state
+(`pr-block-probe.mjs` → one `gh pr view` + GraphQL `reviewThreads` + `gh pr view --json reviews`):
+
+- **Failing required checks or unresolved bot (Codex) threads, no human `CHANGES_REQUESTED`** →
+  `{ decision: "fix", fix_class: "bounded-llm" }` with a `"pr-not-merged"` brief embedding the
+  concrete failing-check names and thread ids. The recovery-pass worker fixes the CI, addresses the
+  review findings, resolves the threads, and posts `@codex review` via `gh-pr-comment.sh
+  --idempotent` to re-trigger the automated reviewer, then merges when `CLEAN`.
+- **Human `CHANGES_REQUESTED`** → `escalate` with the specific reviewer ask (PR and thread linked),
+  never the opaque `"Failure reason: pr_not_merged"` string.
+- **Probe throws** → `defer` (transient GitHub outage — retry next tick).
+- **No open PR found** → `escalate`.
+
+The behavior is gated by `CATALYST_RECOVERY_PASS` (off by default); shadow mode logs a
+`recovery.would-fix` event without dispatching; enforce dispatches the recovery-pass worker.
+
 ### Runaway-loop guards (CTL-671)
 
 `schedulerTick` is hardened against runaway dispatch/reclaim loops on phantom/non-resolving tickets

--- a/plugins/dev/scripts/__tests__/gh-pr-comment.test.sh
+++ b/plugins/dev/scripts/__tests__/gh-pr-comment.test.sh
@@ -1,0 +1,146 @@
+#!/usr/bin/env bash
+# gh-pr-comment.test.sh — tests for plugins/dev/scripts/lib/gh-pr-comment.sh (CTL-1496).
+# Run: bash plugins/dev/scripts/__tests__/gh-pr-comment.test.sh
+#
+# Pattern: routed `gh` stub + pass()/fail() counters, modelled after
+# orchestrate-resolve-fixed-threads.test.sh.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../../.." && pwd)"
+HELPER="${REPO_ROOT}/plugins/dev/scripts/lib/gh-pr-comment.sh"
+
+FAILURES=0
+PASSES=0
+
+pass() { PASSES=$((PASSES+1)); echo "  PASS: $1"; }
+fail() { FAILURES=$((FAILURES+1)); echo "  FAIL: $1"; [ $# -ge 2 ] && echo "    $2"; return 0; }
+
+scratch_setup() {
+  SCRATCH="$(mktemp -d)"
+  mkdir -p "${SCRATCH}/bin"
+
+  COMMENT_LOG="${SCRATCH}/comment.log"
+  : > "$COMMENT_LOG"
+  export COMMENT_LOG
+
+  # Stubbed gh: routes by command shape; logs `pr comment` calls.
+  cat > "${SCRATCH}/bin/gh" <<'STUB'
+#!/usr/bin/env bash
+ARGS="$*"
+if [[ "$ARGS" == *"repo view"* ]]; then
+  echo '{"nameWithOwner":"test-org/test-repo"}'
+elif [[ "$ARGS" == *"pr comment"* ]]; then
+  echo "COMMENT_CALLED $ARGS" >> "$COMMENT_LOG"
+  exit 0
+elif [[ "$ARGS" == *"issues/"*"/comments"* || "$ARGS" == *"issue"*"comments"* ]]; then
+  # Return existing comments fixture (default: empty).
+  if [[ -n "${GH_EXISTING_COMMENTS_FIXTURE:-}" && -f "${GH_EXISTING_COMMENTS_FIXTURE}" ]]; then
+    cat "${GH_EXISTING_COMMENTS_FIXTURE}"
+  else
+    echo "[]"
+  fi
+elif [[ "$ARGS" == *"pr view"* || "$ARGS" == *"issue view"* ]]; then
+  echo '{"number":42}'
+else
+  echo "stub gh: unexpected: $ARGS" >&2
+  exit 99
+fi
+STUB
+  chmod +x "${SCRATCH}/bin/gh"
+  export CATALYST_GH_PR_COMMENT_GH_BIN="${SCRATCH}/bin/gh"
+}
+
+scratch_teardown() {
+  rm -rf "${SCRATCH:-}"
+  unset COMMENT_LOG CATALYST_GH_PR_COMMENT_GH_BIN GH_EXISTING_COMMENTS_FIXTURE SCRATCH
+}
+
+# ── Test 1: posts comment body and exits 0 ────────────────────────────────────
+scratch_setup
+
+if bash "$HELPER" 42 "hello from catalyst" 2>/dev/null; then
+  if grep -q "COMMENT_CALLED" "$COMMENT_LOG"; then
+    pass "posts comment body via gh pr comment and exits 0"
+  else
+    fail "posts comment body via gh pr comment and exits 0" "gh pr comment not called"
+  fi
+else
+  fail "posts comment body via gh pr comment and exits 0" "exited non-zero"
+fi
+
+scratch_teardown
+
+# ── Test 2: --idempotent skips re-post when body already present ──────────────
+scratch_setup
+
+EXISTING_FIXTURE="${SCRATCH}/existing-comments.json"
+printf '[{"body":"@codex review","user":{"login":"catalyst[bot]"}}]' > "$EXISTING_FIXTURE"
+export GH_EXISTING_COMMENTS_FIXTURE="$EXISTING_FIXTURE"
+
+if bash "$HELPER" 42 "@codex review" --idempotent 2>/dev/null; then
+  if ! grep -q "COMMENT_CALLED" "$COMMENT_LOG"; then
+    pass "--idempotent: skips posting when body already in last comments"
+  else
+    fail "--idempotent: skips posting when body already in last comments" "gh pr comment was called anyway"
+  fi
+else
+  fail "--idempotent: skips posting when body already in last comments" "exited non-zero"
+fi
+
+scratch_teardown
+
+# ── Test 3: --idempotent posts when body is NOT in existing comments ──────────
+scratch_setup
+
+EXISTING_FIXTURE="${SCRATCH}/existing-comments.json"
+printf '[{"body":"some other comment","user":{"login":"ryan"}}]' > "$EXISTING_FIXTURE"
+export GH_EXISTING_COMMENTS_FIXTURE="$EXISTING_FIXTURE"
+
+if bash "$HELPER" 42 "@codex review" --idempotent 2>/dev/null; then
+  if grep -q "COMMENT_CALLED" "$COMMENT_LOG"; then
+    pass "--idempotent: posts when body not already present"
+  else
+    fail "--idempotent: posts when body not already present" "gh pr comment not called"
+  fi
+else
+  fail "--idempotent: posts when body not already present" "exited non-zero"
+fi
+
+scratch_teardown
+
+# ── Test 4: gh failure → non-zero exit, message on stderr ────────────────────
+scratch_setup
+
+cat > "${SCRATCH}/bin/gh" <<'STUB'
+#!/usr/bin/env bash
+echo "gh: network error" >&2
+exit 1
+STUB
+chmod +x "${SCRATCH}/bin/gh"
+
+STDERR_OUT="$(bash "$HELPER" 42 "hello" 2>&1 >/dev/null)" || EXIT=$?
+if [[ "${EXIT:-0}" -ne 0 ]]; then
+  pass "gh failure → non-zero exit"
+else
+  fail "gh failure → non-zero exit" "exited 0 despite gh error"
+fi
+
+scratch_teardown
+
+# ── Test 5: missing PR number arg → usage error (non-zero) ───────────────────
+scratch_setup
+
+if bash "$HELPER" 2>/dev/null; then
+  fail "missing PR number arg → usage error" "exited 0"
+else
+  pass "missing PR number arg → usage error"
+fi
+
+scratch_teardown
+
+# ── Summary ───────────────────────────────────────────────────────────────────
+echo ""
+echo "Results: ${PASSES} passed, ${FAILURES} failed"
+[[ "$FAILURES" -eq 0 ]] || exit 1

--- a/plugins/dev/scripts/__tests__/gh-pr-comment.test.sh
+++ b/plugins/dev/scripts/__tests__/gh-pr-comment.test.sh
@@ -140,6 +140,51 @@ fi
 
 scratch_teardown
 
+# ── Test 6: --idempotent existing-comment fetch failure → fail-closed ─────────
+# A transient gh api hiccup must NOT fall through to a post (double-comment
+# spam) — it fails closed (no post) and exits non-zero (CTL-1496).
+scratch_setup
+
+cat > "${SCRATCH}/bin/gh" <<'STUB'
+#!/usr/bin/env bash
+ARGS="$*"
+if [[ "$ARGS" == *"repo view"* ]]; then
+  echo '{"nameWithOwner":"test-org/test-repo"}'
+elif [[ "$ARGS" == *"pr comment"* ]]; then
+  echo "COMMENT_CALLED $ARGS" >> "$COMMENT_LOG"
+  exit 0
+elif [[ "$ARGS" == *"issues/"*"/comments"* ]]; then
+  echo "gh api: 502 Bad Gateway" >&2
+  exit 1
+else
+  echo "stub gh: unexpected: $ARGS" >&2
+  exit 99
+fi
+STUB
+chmod +x "${SCRATCH}/bin/gh"
+
+EXIT=0
+bash "$HELPER" 42 "@codex review" --idempotent 2>/dev/null || EXIT=$?
+if [[ "$EXIT" -ne 0 ]] && ! grep -q "COMMENT_CALLED" "$COMMENT_LOG"; then
+  pass "--idempotent: fetch failure fails closed (no post, non-zero exit)"
+else
+  fail "--idempotent: fetch failure fails closed (no post, non-zero exit)" \
+    "exit=${EXIT}, comment_log=$(cat "$COMMENT_LOG")"
+fi
+
+scratch_teardown
+
+# ── Test 7: non-numeric PR number → rejected (non-zero) ──────────────────────
+scratch_setup
+
+if bash "$HELPER" "42; rm -rf /" "body" 2>/dev/null; then
+  fail "non-numeric PR number → rejected" "exited 0 on non-numeric PR arg"
+else
+  pass "non-numeric PR number → rejected"
+fi
+
+scratch_teardown
+
 # ── Summary ───────────────────────────────────────────────────────────────────
 echo ""
 echo "Results: ${PASSES} passed, ${FAILURES} failed"

--- a/plugins/dev/scripts/__tests__/gh-pr-comment.test.sh
+++ b/plugins/dev/scripts/__tests__/gh-pr-comment.test.sh
@@ -185,6 +185,44 @@ fi
 
 scratch_teardown
 
+# ── Test 8: --idempotent dedups only within the recent window ────────────────
+# The fetch uses the API `since` param; a duplicate OLDER than the window is
+# filtered server-side (stub returns [] when `since` is present), so a fresh
+# re-review request is NOT suppressed forever by an old identical comment
+# (CTL-1496 round-2 fix).
+scratch_setup
+
+cat > "${SCRATCH}/bin/gh" <<'STUB'
+#!/usr/bin/env bash
+ARGS="$*"
+if [[ "$ARGS" == *"repo view"* ]]; then
+  echo '{"nameWithOwner":"test-org/test-repo"}'
+elif [[ "$ARGS" == *"pr comment"* ]]; then
+  echo "COMMENT_CALLED $ARGS" >> "$COMMENT_LOG"
+  exit 0
+elif [[ "$ARGS" == *"issues/"*"/comments"* ]]; then
+  # Windowed fetch (since=) returns nothing → old dupe is outside the window.
+  if [[ "$ARGS" == *"since="* ]]; then echo "[]"; else
+    echo '[{"body":"@codex review","created_at":"2000-01-01T00:00:00Z"}]'
+  fi
+else
+  echo "stub gh: unexpected: $ARGS" >&2; exit 99
+fi
+STUB
+chmod +x "${SCRATCH}/bin/gh"
+
+if bash "$HELPER" 42 "@codex review" --idempotent 2>/dev/null; then
+  if grep -q "COMMENT_CALLED" "$COMMENT_LOG"; then
+    pass "--idempotent: an out-of-window duplicate does not suppress a fresh post"
+  else
+    fail "--idempotent: an out-of-window duplicate does not suppress a fresh post" "post was suppressed"
+  fi
+else
+  fail "--idempotent: an out-of-window duplicate does not suppress a fresh post" "exited non-zero"
+fi
+
+scratch_teardown
+
 # ── Summary ───────────────────────────────────────────────────────────────────
 echo ""
 echo "Results: ${PASSES} passed, ${FAILURES} failed"

--- a/plugins/dev/scripts/__tests__/recovery-pass-pr-not-merged.test.sh
+++ b/plugins/dev/scripts/__tests__/recovery-pass-pr-not-merged.test.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# recovery-pass-pr-not-merged.test.sh — doc-drift guards for the PR-not-merged
+# remediation playbook added to recovery-pass/SKILL.md in CTL-1496.
+# Run: bash plugins/dev/scripts/__tests__/recovery-pass-pr-not-merged.test.sh
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../../.." && pwd)"
+SKILL_MD="${REPO_ROOT}/plugins/dev/skills/recovery-pass/SKILL.md"
+
+FAILURES=0
+PASSES=0
+
+pass() { PASSES=$((PASSES+1)); echo "  PASS: $1"; }
+fail() { FAILURES=$((FAILURES+1)); echo "  FAIL: $1"; [ $# -ge 2 ] && echo "    $2"; return 0; }
+
+# 1. SKILL.md has a PR-not-merged remediation section
+if grep -q "PR-not-merged\|pr-not-merged\|PR not merged\|pr_not_merged" "$SKILL_MD" 2>/dev/null; then
+  pass "recovery-pass/SKILL.md has a PR-not-merged remediation section"
+else
+  fail "recovery-pass/SKILL.md has a PR-not-merged remediation section" \
+    "no PR-not-merged section found in ${SKILL_MD}"
+fi
+
+# 2. References reading the recovery-pass.json brief and/or probing live PR state
+if grep -q "recovery-pass.json\|probe\|gh pr view" "$SKILL_MD" 2>/dev/null; then
+  pass "SKILL.md references reading brief / probing live PR state"
+else
+  fail "SKILL.md references reading brief / probing live PR state" \
+    "no reference to recovery-pass.json, probe, or gh pr view"
+fi
+
+# 3. CI branch mentions gh run view --log-failed
+if grep -q "gh run view.*--log-failed\|--log-failed" "$SKILL_MD" 2>/dev/null; then
+  pass "SKILL.md CI branch mentions gh run view --log-failed"
+else
+  fail "SKILL.md CI branch mentions gh run view --log-failed" \
+    "no --log-failed reference found"
+fi
+
+# 4. Review branch mentions resolving thread and posting @codex review
+if grep -q "@codex review\|codex review" "$SKILL_MD" 2>/dev/null; then
+  pass "SKILL.md review branch mentions posting @codex review"
+else
+  fail "SKILL.md review branch mentions posting @codex review" \
+    "no @codex review mention in ${SKILL_MD}"
+fi
+
+# 5. SKILL.md forbids --admin / force-merge
+if grep -q "\-\-admin\|force.merge\|force-merge" "$SKILL_MD" 2>/dev/null; then
+  pass "SKILL.md explicitly forbids --admin / force-merge past failing checks"
+else
+  fail "SKILL.md explicitly forbids --admin / force-merge past failing checks" \
+    "no --admin / force-merge prohibition found"
+fi
+
+echo ""
+echo "Results: ${PASSES} passed, ${FAILURES} failed"
+[[ "$FAILURES" -eq 0 ]] || exit 1

--- a/plugins/dev/scripts/__tests__/review-comments-headless.test.sh
+++ b/plugins/dev/scripts/__tests__/review-comments-headless.test.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# review-comments-headless.test.sh — doc-drift guards for the headless mode
+# added to review-comments/SKILL.md in CTL-1496.
+# Run: bash plugins/dev/scripts/__tests__/review-comments-headless.test.sh
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../../.." && pwd)"
+SKILL_MD="${REPO_ROOT}/plugins/dev/skills/review-comments/SKILL.md"
+
+FAILURES=0
+PASSES=0
+
+pass() { PASSES=$((PASSES+1)); echo "  PASS: $1"; }
+fail() { FAILURES=$((FAILURES+1)); echo "  FAIL: $1"; [ $# -ge 2 ] && echo "    $2"; return 0; }
+
+# 1. SKILL.md must have a headless / non-interactive section gated on CATALYST_PHASE or --headless
+if grep -q "Non-interactive\|headless\|CATALYST_PHASE" "$SKILL_MD" 2>/dev/null; then
+  pass "SKILL.md contains a Non-interactive/headless section keyed on CATALYST_PHASE or --headless"
+else
+  fail "SKILL.md contains a Non-interactive/headless section keyed on CATALYST_PHASE or --headless" \
+    "grep: no match for Non-interactive/headless/CATALYST_PHASE in ${SKILL_MD}"
+fi
+
+# 2. SKILL.md must state the y/N prompt is skipped in headless mode
+if grep -q "y/N.*skip\|skip.*y/N\|not.*prompt\|never.*prompt\|prompt.*skipped\|skipped.*prompt" \
+     "$SKILL_MD" 2>/dev/null; then
+  pass "SKILL.md states y/N prompt is SKIPPED in headless mode"
+else
+  fail "SKILL.md states y/N prompt is SKIPPED in headless mode" \
+    "no sentence about skipping the y/N prompt in headless mode"
+fi
+
+# 3. SKILL.md must state judgment-call findings go to a structured escalation list
+if grep -q "escalation\|review-escalations\|escalation list\|escalate" "$SKILL_MD" 2>/dev/null; then
+  pass "SKILL.md states judgment-call findings are recorded to an escalation list"
+else
+  fail "SKILL.md states judgment-call findings are recorded to an escalation list" \
+    "no reference to escalation list for judgment-call findings"
+fi
+
+# 4. The interactive y/N wording must still exist for the non-headless path
+if grep -q "y/N\|Y/n\|\[y/N\]\|\[Y/n\]" "$SKILL_MD" 2>/dev/null; then
+  pass "SKILL.md still contains the interactive y/N wording (not deleted)"
+else
+  fail "SKILL.md still contains the interactive y/N wording (not deleted)" \
+    "interactive y/N prompt wording not found — may have been removed by headless additions"
+fi
+
+echo ""
+echo "Results: ${PASSES} passed, ${FAILURES} failed"
+[[ "$FAILURES" -eq 0 ]] || exit 1

--- a/plugins/dev/scripts/__tests__/review-comments-headless.test.sh
+++ b/plugins/dev/scripts/__tests__/review-comments-headless.test.sh
@@ -24,7 +24,7 @@ else
 fi
 
 # 2. SKILL.md must state the y/N prompt is skipped in headless mode
-if grep -q "y/N.*skip\|skip.*y/N\|not.*prompt\|never.*prompt\|prompt.*skipped\|skipped.*prompt" \
+if grep -qi "y/N.*skip\|skip.*y/N\|not.*prompt\|never.*prompt\|prompt.*skipped\|skipped.*prompt" \
      "$SKILL_MD" 2>/dev/null; then
   pass "SKILL.md states y/N prompt is SKIPPED in headless mode"
 else

--- a/plugins/dev/scripts/execution-core/pr-block-probe.mjs
+++ b/plugins/dev/scripts/execution-core/pr-block-probe.mjs
@@ -6,19 +6,56 @@
 
 import { spawnSync } from "node:child_process";
 
-export const REVIEW_THREADS_QUERY = `query($owner:String!,$name:String!,$pr:Int!){
+// Paginated: `after:$after` (nullable String → first page passes it unbound =
+// null = start from the beginning). pageInfo lets the caller walk every page so
+// a review thread beyond the first 100 is never silently dropped (CTL-1496 P2).
+export const REVIEW_THREADS_QUERY = `query($owner:String!,$name:String!,$pr:Int!,$after:String){
   repository(owner:$owner,name:$name){ pullRequest(number:$pr){
-    reviewThreads(first:100){ nodes { id isResolved
+    reviewThreads(first:100, after:$after){
+      pageInfo { hasNextPage endCursor }
+      nodes { id isResolved
       comments(first:1){ nodes { body path line author { login __typename } } } } } } } }`;
 
+// This probe runs SYNCHRONOUSLY from reasoningRecoveryPass on the scheduler
+// tick, so an unbounded `gh` (hung network / auth / keychain prompt) would
+// wedge the whole daemon event loop. Bound every spawn; a timeout surfaces as
+// r.error (ETIMEDOUT) → throw → classifyPrNotMerged defers to the next tick
+// (CTL-1496 P1).
+const GH_PROBE_TIMEOUT_MS = Number(process.env.CATALYST_GH_PROBE_TIMEOUT_MS || 20000);
+
+// Hard cap on review-thread pages walked (100 threads/page). Far above any real
+// PR; hitting it means something is wrong, so we refuse rather than proceed on a
+// partial set (CTL-1496 P2).
+const MAX_THREAD_PAGES = 25;
+
 function realGh(args) {
-  const r = spawnSync("gh", args, { encoding: "utf8" });
+  const r = spawnSync("gh", args, { encoding: "utf8", timeout: GH_PROBE_TIMEOUT_MS });
+  // A timeout (or spawn failure) sets r.error and leaves status null — surface
+  // it as a throw so the caller treats it as transient rather than the daemon
+  // hanging on a wedged child.
+  if (r.error) {
+    const timedOut = r.error.code === "ETIMEDOUT" || r.signal === "SIGTERM";
+    throw new Error(
+      `gh ${args.join(" ")} ${timedOut ? `timed out after ${GH_PROBE_TIMEOUT_MS}ms` : `errored: ${r.error.message}`}`,
+    );
+  }
   if (r.status !== 0) throw new Error(`gh ${args.join(" ")} failed: ${r.stderr || r.status}`);
   return r.stdout;
 }
 
 export function isFailingState(s) {
-  return ["FAILURE", "ERROR", "TIMED_OUT", "CANCELLED"].includes(s);
+  return [
+    "FAILURE",
+    "ERROR",
+    "TIMED_OUT",
+    "CANCELLED",
+    // ACTION_REQUIRED / STARTUP_FAILURE are genuine CI failure states the
+    // existing orchestrate-auto-fixup classifier already treats as failing;
+    // omitting them here regressed the autonomous remediation path to a human
+    // escalation for those conclusions (CTL-1496 P2).
+    "ACTION_REQUIRED",
+    "STARTUP_FAILURE",
+  ].includes(s);
 }
 
 export function isBotAuthor(a) {
@@ -67,12 +104,18 @@ const PR_VIEW_FIELDS =
 // always resolving the wrong PR → always escalating). We resolve by the ticket's
 // head branch when the caller threads it, else by the ticket id in the PR title
 // (draft_pr_title injects `<type>(<scope>): <TICKET> …`), taking the single open
-// PR. Returns the parsed PR object or null.
-function resolveTicketPr(gh, ticket, branch) {
+// PR. Scoped to owner/name with `-R` so the lookup targets the TICKET's repo —
+// the same repo used for the GraphQL threads query below — not whatever repo the
+// daemon's cwd points at (CTL-1496 P1: without `-R`/cwd it resolved the daemon
+// repo → false "no open PR" escalation or an unrelated same-ticket PR).
+// Returns the parsed PR object or null.
+function resolveTicketPr(gh, ticket, branch, owner, name) {
   const selector = branch ? ["--head", branch] : ["--search", `${ticket} in:title`];
+  const repoArgs = owner && name ? ["-R", `${owner}/${name}`] : [];
   const listRaw = gh([
     "pr",
     "list",
+    ...repoArgs,
     ...selector,
     "--state",
     "open",
@@ -86,6 +129,52 @@ function resolveTicketPr(gh, ticket, branch) {
   return list[0];
 }
 
+// Fetch all review threads across pages, accumulating nodes. Each page's
+// partial/errored body is a probe failure (throw → caller defers) rather than a
+// silently-empty set. Refuse past MAX_THREAD_PAGES with more pages remaining so
+// a genuinely enormous (or looping) thread set never yields a partial view that
+// hides an unresolved human thread (CTL-1496 P2).
+function fetchAllReviewThreads(gh, owner, name, prNumber) {
+  const nodes = [];
+  let after = null;
+  for (let page = 0; page < MAX_THREAD_PAGES; page++) {
+    const args = [
+      "api",
+      "graphql",
+      "-f",
+      `query=${REVIEW_THREADS_QUERY}`,
+      // owner/name are String! — pass with -f (raw string) so a purely-numeric
+      // owner or repo name is not coerced to an Int and rejected. pr is Int! → -F.
+      "-f",
+      `owner=${owner}`,
+      "-f",
+      `name=${name}`,
+      "-F",
+      `pr=${prNumber}`,
+    ];
+    // First page leaves $after unbound (nullable → null → from the beginning).
+    if (after) args.push("-f", `after=${after}`);
+    const json = safeJson(gh(args));
+    // `gh api graphql` can exit 0 with a partial/field-errored body (HTTP 200,
+    // data.repository.pullRequest === null, or a top-level `errors` array).
+    // Coercing that to [] would silently hide an unresolved HUMAN thread and
+    // route a human-blocked PR to the autonomous fix path.
+    if (json === null || json.errors || !json?.data?.repository?.pullRequest) {
+      throw new Error(
+        "review-threads GraphQL returned no usable data (partial/errored response)",
+      );
+    }
+    const rt = json.data.repository.pullRequest.reviewThreads;
+    for (const n of rt?.nodes || []) nodes.push(n);
+    const pageInfo = rt?.pageInfo;
+    if (!pageInfo?.hasNextPage || !pageInfo?.endCursor) return nodes;
+    after = pageInfo.endCursor;
+  }
+  throw new Error(
+    `review-threads exceeded ${MAX_THREAD_PAGES} pages; refusing partial thread set`,
+  );
+}
+
 export function defaultProbePrBlock(ticket, { gh = realGh, repo, branch } = {}) {
   const [owner, name] = (
     repo ||
@@ -94,45 +183,20 @@ export function defaultProbePrBlock(ticket, { gh = realGh, repo, branch } = {}) 
   ).split("/");
 
   // Resolve the ticket's PR by head branch (when threaded) or ticket-in-title
-  // search — independent of the daemon's cwd/current branch.
-  const view = resolveTicketPr(gh, ticket, branch);
+  // search — independent of the daemon's cwd/current branch, scoped to the
+  // resolved owner/name.
+  const view = resolveTicketPr(gh, ticket, branch, owner, name);
   if (!view || !view.number) return emptyProbe();
 
   const failingChecks = (view.statusCheckRollup || [])
     .filter((c) => isFailingState(c.state || c.conclusion))
     .map((c) => ({ name: c.name || c.context, detailsUrl: c.detailsUrl || null }));
 
-  const threadsRaw = gh([
-    "api",
-    "graphql",
-    "-f",
-    `query=${REVIEW_THREADS_QUERY}`,
-    // owner/name are String! — pass with -f (raw string) so a purely-numeric
-    // owner or repo name is not coerced to an Int and rejected. pr is Int! → -F.
-    "-f",
-    `owner=${owner}`,
-    "-f",
-    `name=${name}`,
-    "-F",
-    `pr=${view.number}`,
-  ]);
-  const threadsJson = safeJson(threadsRaw);
-  // `gh api graphql` can exit 0 with a partial/field-errored body (HTTP 200,
-  // data.repository.pullRequest === null, or a top-level `errors` array). Coercing
-  // that to [] would silently hide an unresolved HUMAN thread and route a
-  // human-blocked PR to the autonomous fix path. Treat an unparseable or partial
-  // response as a probe failure → classifyPrNotMerged defers (retry next tick).
-  if (
-    threadsJson === null ||
-    threadsJson.errors ||
-    !threadsJson?.data?.repository?.pullRequest
-  ) {
-    throw new Error(
-      "review-threads GraphQL returned no usable data (partial/errored response)",
-    );
-  }
-  const nodes =
-    threadsJson.data.repository.pullRequest.reviewThreads?.nodes || [];
+  // Walk EVERY review-thread page. A single first:100 page silently omits later
+  // threads; if an omitted one is an unresolved human conversation while
+  // reviewDecision !== CHANGES_REQUESTED, the classifier would take the
+  // autonomous fix/merge path despite an unresolved human review (CTL-1496 P2).
+  const nodes = fetchAllReviewThreads(gh, owner, name, view.number);
   // A thread with no first comment cannot be attributed to bot vs human; skip it
   // rather than defaulting it into unresolvedHumanThreads (spurious escalate).
   const unresolved = nodes.filter((n) => !n.isResolved && n.comments?.nodes?.[0]);

--- a/plugins/dev/scripts/execution-core/pr-block-probe.mjs
+++ b/plugins/dev/scripts/execution-core/pr-block-probe.mjs
@@ -53,8 +53,12 @@ function emptyProbe() {
   };
 }
 
-// Fields the classifier reads off the resolved PR.
-const PR_VIEW_FIELDS = "number,state,mergeStateStatus,mergeable,statusCheckRollup";
+// Fields the classifier reads off the resolved PR. `reviewDecision` is the
+// aggregate GitHub verdict (latest review per required reviewer) — used instead
+// of scanning the raw reviews history so a PR that was CHANGES_REQUESTED then
+// re-APPROVED is not false-flagged by a stale entry (CTL-1496 verify finding).
+const PR_VIEW_FIELDS =
+  "number,state,mergeStateStatus,mergeable,statusCheckRollup,reviewDecision";
 
 // Resolve the ticket's PR EXPLICITLY — never by the daemon's current branch.
 // classifyPrNotMerged runs inside the daemon process (daemon cwd), so a bare
@@ -103,17 +107,35 @@ export function defaultProbePrBlock(ticket, { gh = realGh, repo, branch } = {}) 
     "graphql",
     "-f",
     `query=${REVIEW_THREADS_QUERY}`,
-    "-F",
+    // owner/name are String! — pass with -f (raw string) so a purely-numeric
+    // owner or repo name is not coerced to an Int and rejected. pr is Int! → -F.
+    "-f",
     `owner=${owner}`,
-    "-F",
+    "-f",
     `name=${name}`,
     "-F",
     `pr=${view.number}`,
   ]);
   const threadsJson = safeJson(threadsRaw);
+  // `gh api graphql` can exit 0 with a partial/field-errored body (HTTP 200,
+  // data.repository.pullRequest === null, or a top-level `errors` array). Coercing
+  // that to [] would silently hide an unresolved HUMAN thread and route a
+  // human-blocked PR to the autonomous fix path. Treat an unparseable or partial
+  // response as a probe failure → classifyPrNotMerged defers (retry next tick).
+  if (
+    threadsJson === null ||
+    threadsJson.errors ||
+    !threadsJson?.data?.repository?.pullRequest
+  ) {
+    throw new Error(
+      "review-threads GraphQL returned no usable data (partial/errored response)",
+    );
+  }
   const nodes =
-    threadsJson?.data?.repository?.pullRequest?.reviewThreads?.nodes || [];
-  const unresolved = nodes.filter((n) => !n.isResolved);
+    threadsJson.data.repository.pullRequest.reviewThreads?.nodes || [];
+  // A thread with no first comment cannot be attributed to bot vs human; skip it
+  // rather than defaulting it into unresolvedHumanThreads (spurious escalate).
+  const unresolved = nodes.filter((n) => !n.isResolved && n.comments?.nodes?.[0]);
   const shape = (n) => ({
     id: n.id,
     ...pick(n.comments?.nodes?.[0], ["body", "path", "line"]),
@@ -125,9 +147,11 @@ export function defaultProbePrBlock(ticket, { gh = realGh, repo, branch } = {}) 
     .filter((n) => !isBotAuthor(n.comments?.nodes?.[0]?.author))
     .map(shape);
 
-  const reviewsRaw = gh(["pr", "view", String(view.number), "--json", "reviews"]);
-  const reviews = safeJson(reviewsRaw)?.reviews || [];
-  const hasChangesRequested = reviews.some((r) => r.state === "CHANGES_REQUESTED");
+  // Aggregate verdict, not raw history: reviewDecision reflects the latest
+  // review per required reviewer, so a re-APPROVED PR reads APPROVED (not the
+  // stale CHANGES_REQUESTED it once carried). An un-required CHANGES_REQUESTED
+  // that reviewDecision omits is still caught by unresolvedHumanThreads.
+  const hasChangesRequested = view.reviewDecision === "CHANGES_REQUESTED";
 
   return {
     prNumber: view.number,

--- a/plugins/dev/scripts/execution-core/pr-block-probe.mjs
+++ b/plugins/dev/scripts/execution-core/pr-block-probe.mjs
@@ -53,34 +53,45 @@ function emptyProbe() {
   };
 }
 
-// Resolve the ticket's PR by branch name or by listing open PRs.
-// gh pr view with no selector looks up the current branch — we pass the ticket
-// as a head-branch hint instead; tests inject a fake gh that routes on "pr view".
-function prSelector(ticket) {
-  // Use the ticket as a search term for the branch name the dispatcher would have created.
-  // In practice the fake gh in tests routes on "pr view" regardless of the extra args,
-  // and in production `gh pr view` against the current branch (no extra args) works
-  // because phase agents run inside the ticket's worktree on the ticket branch.
-  return [];
+// Fields the classifier reads off the resolved PR.
+const PR_VIEW_FIELDS = "number,state,mergeStateStatus,mergeable,statusCheckRollup";
+
+// Resolve the ticket's PR EXPLICITLY — never by the daemon's current branch.
+// classifyPrNotMerged runs inside the daemon process (daemon cwd), so a bare
+// `gh pr view` would resolve whatever branch the daemon happens to be on, not
+// the ticket's PR (CTL-1496 verify finding: the probe was inert in production,
+// always resolving the wrong PR → always escalating). We resolve by the ticket's
+// head branch when the caller threads it, else by the ticket id in the PR title
+// (draft_pr_title injects `<type>(<scope>): <TICKET> …`), taking the single open
+// PR. Returns the parsed PR object or null.
+function resolveTicketPr(gh, ticket, branch) {
+  const selector = branch ? ["--head", branch] : ["--search", `${ticket} in:title`];
+  const listRaw = gh([
+    "pr",
+    "list",
+    ...selector,
+    "--state",
+    "open",
+    "--json",
+    PR_VIEW_FIELDS,
+    "--limit",
+    "1",
+  ]);
+  const list = safeJson(listRaw);
+  if (!Array.isArray(list) || list.length === 0) return null;
+  return list[0];
 }
 
-export function defaultProbePrBlock(ticket, { gh = realGh, repo } = {}) {
+export function defaultProbePrBlock(ticket, { gh = realGh, repo, branch } = {}) {
   const [owner, name] = (
     repo ||
     safeJson(gh(["repo", "view", "--json", "nameWithOwner"]))?.nameWithOwner ||
     "/"
   ).split("/");
 
-  // Resolve PR: the fake gh in tests routes any "pr view" call; production gh
-  // runs in the ticket's worktree on the ticket branch and resolves by current branch.
-  const viewRaw = gh([
-    "pr",
-    "view",
-    ...prSelector(ticket),
-    "--json",
-    "number,state,mergeStateStatus,mergeable,statusCheckRollup",
-  ]);
-  const view = safeJson(viewRaw);
+  // Resolve the ticket's PR by head branch (when threaded) or ticket-in-title
+  // search — independent of the daemon's cwd/current branch.
+  const view = resolveTicketPr(gh, ticket, branch);
   if (!view || !view.number) return emptyProbe();
 
   const failingChecks = (view.statusCheckRollup || [])

--- a/plugins/dev/scripts/execution-core/pr-block-probe.mjs
+++ b/plugins/dev/scripts/execution-core/pr-block-probe.mjs
@@ -1,0 +1,131 @@
+// pr-block-probe.mjs — read-only "why is this PR blocked?" probe (CTL-1496).
+//
+// Exports defaultProbePrBlock(ticket, { gh, repo }) — injectable seam so the
+// classifier (recovery-reasoning.mjs) stays pure and testable.  The real gh
+// default wraps spawnSync; tests inject a fake routed by argv shape.
+
+import { spawnSync } from "node:child_process";
+
+export const REVIEW_THREADS_QUERY = `query($owner:String!,$name:String!,$pr:Int!){
+  repository(owner:$owner,name:$name){ pullRequest(number:$pr){
+    reviewThreads(first:100){ nodes { id isResolved
+      comments(first:1){ nodes { body path line author { login __typename } } } } } } } }`;
+
+function realGh(args) {
+  const r = spawnSync("gh", args, { encoding: "utf8" });
+  if (r.status !== 0) throw new Error(`gh ${args.join(" ")} failed: ${r.stderr || r.status}`);
+  return r.stdout;
+}
+
+export function isFailingState(s) {
+  return ["FAILURE", "ERROR", "TIMED_OUT", "CANCELLED"].includes(s);
+}
+
+export function isBotAuthor(a) {
+  return a?.__typename === "Bot" || /\[bot\]$/.test(a?.login || "");
+}
+
+function safeJson(s) {
+  try {
+    return JSON.parse(s);
+  } catch {
+    return null;
+  }
+}
+
+function pick(obj, keys) {
+  if (!obj) return {};
+  const out = {};
+  for (const k of keys) if (k in obj) out[k] = obj[k];
+  return out;
+}
+
+function emptyProbe() {
+  return {
+    prNumber: null,
+    state: null,
+    mergeStateStatus: null,
+    mergeable: null,
+    failingChecks: [],
+    unresolvedBotThreads: [],
+    unresolvedHumanThreads: [],
+    hasChangesRequested: false,
+  };
+}
+
+// Resolve the ticket's PR by branch name or by listing open PRs.
+// gh pr view with no selector looks up the current branch — we pass the ticket
+// as a head-branch hint instead; tests inject a fake gh that routes on "pr view".
+function prSelector(ticket) {
+  // Use the ticket as a search term for the branch name the dispatcher would have created.
+  // In practice the fake gh in tests routes on "pr view" regardless of the extra args,
+  // and in production `gh pr view` against the current branch (no extra args) works
+  // because phase agents run inside the ticket's worktree on the ticket branch.
+  return [];
+}
+
+export function defaultProbePrBlock(ticket, { gh = realGh, repo } = {}) {
+  const [owner, name] = (
+    repo ||
+    safeJson(gh(["repo", "view", "--json", "nameWithOwner"]))?.nameWithOwner ||
+    "/"
+  ).split("/");
+
+  // Resolve PR: the fake gh in tests routes any "pr view" call; production gh
+  // runs in the ticket's worktree on the ticket branch and resolves by current branch.
+  const viewRaw = gh([
+    "pr",
+    "view",
+    ...prSelector(ticket),
+    "--json",
+    "number,state,mergeStateStatus,mergeable,statusCheckRollup",
+  ]);
+  const view = safeJson(viewRaw);
+  if (!view || !view.number) return emptyProbe();
+
+  const failingChecks = (view.statusCheckRollup || [])
+    .filter((c) => isFailingState(c.state || c.conclusion))
+    .map((c) => ({ name: c.name || c.context, detailsUrl: c.detailsUrl || null }));
+
+  const threadsRaw = gh([
+    "api",
+    "graphql",
+    "-f",
+    `query=${REVIEW_THREADS_QUERY}`,
+    "-F",
+    `owner=${owner}`,
+    "-F",
+    `name=${name}`,
+    "-F",
+    `pr=${view.number}`,
+  ]);
+  const threadsJson = safeJson(threadsRaw);
+  const nodes =
+    threadsJson?.data?.repository?.pullRequest?.reviewThreads?.nodes || [];
+  const unresolved = nodes.filter((n) => !n.isResolved);
+  const shape = (n) => ({
+    id: n.id,
+    ...pick(n.comments?.nodes?.[0], ["body", "path", "line"]),
+  });
+  const unresolvedBotThreads = unresolved
+    .filter((n) => isBotAuthor(n.comments?.nodes?.[0]?.author))
+    .map(shape);
+  const unresolvedHumanThreads = unresolved
+    .filter((n) => !isBotAuthor(n.comments?.nodes?.[0]?.author))
+    .map(shape);
+
+  const reviewsRaw = gh(["pr", "view", String(view.number), "--json", "reviews"]);
+  const reviews = safeJson(reviewsRaw)?.reviews || [];
+  const hasChangesRequested = reviews.some((r) => r.state === "CHANGES_REQUESTED");
+
+  return {
+    prNumber: view.number,
+    state: view.state,
+    mergeStateStatus: view.mergeStateStatus,
+    mergeable: view.mergeable,
+    failingChecks,
+    unresolvedBotThreads,
+    unresolvedHumanThreads,
+    hasChangesRequested,
+  };
+}

--- a/plugins/dev/scripts/execution-core/pr-block-probe.mjs
+++ b/plugins/dev/scripts/execution-core/pr-block-probe.mjs
@@ -28,8 +28,11 @@ const GH_PROBE_TIMEOUT_MS = Number(process.env.CATALYST_GH_PROBE_TIMEOUT_MS || 2
 // partial set (CTL-1496 P2).
 const MAX_THREAD_PAGES = 25;
 
-function realGh(args) {
-  const r = spawnSync("gh", args, { encoding: "utf8", timeout: GH_PROBE_TIMEOUT_MS });
+// opts.cwd lets the caller resolve `gh repo view` against the TICKET's worktree
+// so the probe targets the ticket's repository, not the daemon's checkout
+// (CTL-1496 P1).
+function realGh(args, { cwd } = {}) {
+  const r = spawnSync("gh", args, { encoding: "utf8", timeout: GH_PROBE_TIMEOUT_MS, cwd });
   // A timeout (or spawn failure) sets r.error and leaves status null — surface
   // it as a throw so the caller treats it as transient rather than the daemon
   // hanging on a wedged child.
@@ -55,6 +58,22 @@ export function isFailingState(s) {
     // escalation for those conclusions (CTL-1496 P2).
     "ACTION_REQUIRED",
     "STARTUP_FAILURE",
+  ].includes(s);
+}
+
+// A required check that is still queued/running is NOT a failure — the PR is
+// simply not ready yet. The classifier must DEFER on these (retry next tick)
+// rather than escalate a "no remediable cause" latch on a PR whose CI just
+// hasn't finished (CTL-1496 P2). check-runs report progress via `.status`
+// (QUEUED/IN_PROGRESS), legacy statuses via `.state` (PENDING/EXPECTED).
+export function isPendingState(s) {
+  return [
+    "QUEUED",
+    "IN_PROGRESS",
+    "PENDING",
+    "WAITING",
+    "REQUESTED",
+    "EXPECTED",
   ].includes(s);
 }
 
@@ -84,6 +103,7 @@ function emptyProbe() {
     mergeStateStatus: null,
     mergeable: null,
     failingChecks: [],
+    pendingChecks: [],
     unresolvedBotThreads: [],
     unresolvedHumanThreads: [],
     hasChangesRequested: false,
@@ -175,10 +195,19 @@ function fetchAllReviewThreads(gh, owner, name, prNumber) {
   );
 }
 
-export function defaultProbePrBlock(ticket, { gh = realGh, repo, branch } = {}) {
+export function defaultProbePrBlock(ticket, { gh = realGh, repo, branch, worktreePath } = {}) {
+  // Resolve owner/name: prefer an explicitly-threaded `repo`, else `gh repo
+  // view` run IN THE TICKET'S WORKTREE (cwd) so it reports the ticket's repo,
+  // not the daemon's checkout. Falls back to the daemon cwd only when neither is
+  // available (CTL-1496 P1).
   const [owner, name] = (
     repo ||
-    safeJson(gh(["repo", "view", "--json", "nameWithOwner"]))?.nameWithOwner ||
+    safeJson(
+      gh(
+        ["repo", "view", "--json", "nameWithOwner"],
+        worktreePath ? { cwd: worktreePath } : undefined,
+      ),
+    )?.nameWithOwner ||
     "/"
   ).split("/");
 
@@ -188,8 +217,17 @@ export function defaultProbePrBlock(ticket, { gh = realGh, repo, branch } = {}) 
   const view = resolveTicketPr(gh, ticket, branch, owner, name);
   if (!view || !view.number) return emptyProbe();
 
-  const failingChecks = (view.statusCheckRollup || [])
+  const rollup = view.statusCheckRollup || [];
+  const failingChecks = rollup
     .filter((c) => isFailingState(c.state || c.conclusion))
+    .map((c) => ({ name: c.name || c.context, detailsUrl: c.detailsUrl || null }));
+  // Queued/in-progress required checks: not failing, not done. Surfaced so the
+  // classifier can DEFER (retry next tick) instead of latching a "no remediable
+  // cause" escalation on a PR whose CI simply hasn't finished (CTL-1496 P2). A
+  // check that is both failing and (somehow) pending is counted as failing only.
+  const pendingChecks = rollup
+    .filter((c) => !isFailingState(c.state || c.conclusion))
+    .filter((c) => isPendingState(c.status) || isPendingState(c.state))
     .map((c) => ({ name: c.name || c.context, detailsUrl: c.detailsUrl || null }));
 
   // Walk EVERY review-thread page. A single first:100 page silently omits later
@@ -223,6 +261,7 @@ export function defaultProbePrBlock(ticket, { gh = realGh, repo, branch } = {}) 
     mergeStateStatus: view.mergeStateStatus,
     mergeable: view.mergeable,
     failingChecks,
+    pendingChecks,
     unresolvedBotThreads,
     unresolvedHumanThreads,
     hasChangesRequested,

--- a/plugins/dev/scripts/execution-core/pr-block-probe.test.mjs
+++ b/plugins/dev/scripts/execution-core/pr-block-probe.test.mjs
@@ -3,7 +3,7 @@
 // Run: cd plugins/dev/scripts/execution-core && bun test pr-block-probe.test.mjs
 
 import { describe, test, expect } from "bun:test";
-import { defaultProbePrBlock } from "./pr-block-probe.mjs";
+import { defaultProbePrBlock, isFailingState } from "./pr-block-probe.mjs";
 
 // fakeGh routes by longest matching pattern first so specific patterns
 // (e.g. "pr view 42 --json reviews") win over generic ones ("pr list").
@@ -423,5 +423,123 @@ describe("defaultProbePrBlock", () => {
     const r = defaultProbePrBlock("CTL-1", { gh, repo: "o/r" });
     expect(r.unresolvedBotThreads).toHaveLength(0);
     expect(r.unresolvedHumanThreads).toHaveLength(0);
+  });
+});
+
+describe("CTL-1496 remediation — probe hardening (Codex review)", () => {
+  // P1: the PR lookup must be scoped to the ticket's repo (-R owner/name), not
+  // resolved against the daemon's cwd/current branch.
+  test("gh pr list is scoped with -R <owner>/<name>", () => {
+    const calls = [];
+    const gh = (args) => {
+      calls.push(args.join(" "));
+      const key = args.join(" ");
+      if (key.startsWith("pr list"))
+        return JSON.stringify([
+          { number: 61, state: "OPEN", mergeStateStatus: "CLEAN", mergeable: "MERGEABLE", statusCheckRollup: [] },
+        ]);
+      if (key.includes("api graphql")) return JSON.stringify(EMPTY_THREADS);
+      throw new Error(`unrouted gh: ${key}`);
+    };
+    const r = defaultProbePrBlock("CTL-9", { gh, repo: "acme/widgets" });
+    expect(r.prNumber).toBe(61);
+    const resolveCall = calls.find((c) => c.startsWith("pr list"));
+    expect(resolveCall).toContain("-R acme/widgets");
+  });
+
+  // P2: ACTION_REQUIRED and STARTUP_FAILURE are genuine CI failure states.
+  test("isFailingState treats ACTION_REQUIRED and STARTUP_FAILURE as failing", () => {
+    expect(isFailingState("ACTION_REQUIRED")).toBe(true);
+    expect(isFailingState("STARTUP_FAILURE")).toBe(true);
+    // sanity: still passes the previously-covered states and excludes success
+    expect(isFailingState("FAILURE")).toBe(true);
+    expect(isFailingState("SUCCESS")).toBe(false);
+    expect(isFailingState("PENDING")).toBe(false);
+  });
+
+  test("ACTION_REQUIRED check surfaces in failingChecks", () => {
+    const gh = makeGh([
+      [
+        "pr list",
+        [
+          {
+            number: 62,
+            state: "OPEN",
+            mergeStateStatus: "BLOCKED",
+            mergeable: "MERGEABLE",
+            statusCheckRollup: [
+              { name: "deploy-gate", state: "ACTION_REQUIRED", detailsUrl: "u" },
+              { name: "unit", state: "SUCCESS" },
+            ],
+          },
+        ],
+      ],
+      ["api graphql", EMPTY_THREADS],
+    ]);
+    const r = defaultProbePrBlock("CTL-1", { gh, repo: "o/r" });
+    expect(r.failingChecks.map((c) => c.name)).toEqual(["deploy-gate"]);
+  });
+
+  // P2: walk every review-thread page — a thread beyond the first page is not
+  // silently dropped. Here page 2 carries an unresolved HUMAN thread.
+  test("paginates review threads across pages (page-2 human thread captured)", () => {
+    const gh = (args) => {
+      const key = args.join(" ");
+      if (key.startsWith("pr list"))
+        return JSON.stringify([
+          { number: 63, state: "OPEN", mergeStateStatus: "BLOCKED", mergeable: "MERGEABLE", statusCheckRollup: [] },
+        ]);
+      if (key.includes("api graphql")) {
+        const onPage2 = key.includes("after=CURSOR1");
+        if (!onPage2) {
+          return JSON.stringify({
+            data: { repository: { pullRequest: { reviewThreads: {
+              pageInfo: { hasNextPage: true, endCursor: "CURSOR1" },
+              nodes: [
+                { id: "BOT1", isResolved: false, comments: { nodes: [
+                  { body: "[P3] nit", path: "a.ts", line: 1, author: { login: "codex[bot]", __typename: "Bot" } },
+                ] } },
+              ],
+            } } } },
+          });
+        }
+        return JSON.stringify({
+          data: { repository: { pullRequest: { reviewThreads: {
+            pageInfo: { hasNextPage: false, endCursor: null },
+            nodes: [
+              { id: "HUMAN1", isResolved: false, comments: { nodes: [
+                { body: "please rethink", path: "z.ts", line: 9, author: { login: "ryan", __typename: "User" } },
+              ] } },
+            ],
+          } } } },
+        });
+      }
+      throw new Error(`unrouted gh: ${key}`);
+    };
+    const r = defaultProbePrBlock("CTL-1", { gh, repo: "o/r" });
+    expect(r.unresolvedBotThreads.map((t) => t.id)).toEqual(["BOT1"]);
+    expect(r.unresolvedHumanThreads.map((t) => t.id)).toEqual(["HUMAN1"]);
+  });
+
+  // P2: an endlessly-paging response is refused rather than yielding a partial
+  // (possibly human-thread-omitting) set.
+  test("refuses when review threads exceed the page cap", () => {
+    const gh = (args) => {
+      const key = args.join(" ");
+      if (key.startsWith("pr list"))
+        return JSON.stringify([
+          { number: 64, state: "OPEN", mergeStateStatus: "BLOCKED", mergeable: "MERGEABLE", statusCheckRollup: [] },
+        ]);
+      if (key.includes("api graphql"))
+        // Always claims another page → drives the cap.
+        return JSON.stringify({
+          data: { repository: { pullRequest: { reviewThreads: {
+            pageInfo: { hasNextPage: true, endCursor: "C" },
+            nodes: [],
+          } } } },
+        });
+      throw new Error(`unrouted gh: ${key}`);
+    };
+    expect(() => defaultProbePrBlock("CTL-1", { gh, repo: "o/r" })).toThrow(/page/);
   });
 });

--- a/plugins/dev/scripts/execution-core/pr-block-probe.test.mjs
+++ b/plugins/dev/scripts/execution-core/pr-block-probe.test.mjs
@@ -3,7 +3,7 @@
 // Run: cd plugins/dev/scripts/execution-core && bun test pr-block-probe.test.mjs
 
 import { describe, test, expect } from "bun:test";
-import { defaultProbePrBlock, isFailingState } from "./pr-block-probe.mjs";
+import { defaultProbePrBlock, isFailingState, isPendingState } from "./pr-block-probe.mjs";
 
 // fakeGh routes by longest matching pattern first so specific patterns
 // (e.g. "pr view 42 --json reviews") win over generic ones ("pr list").
@@ -541,5 +541,63 @@ describe("CTL-1496 remediation — probe hardening (Codex review)", () => {
       throw new Error(`unrouted gh: ${key}`);
     };
     expect(() => defaultProbePrBlock("CTL-1", { gh, repo: "o/r" })).toThrow(/page/);
+  });
+
+  // P2 (round 2): queued/in-progress checks are surfaced as pendingChecks (not
+  // failingChecks) so the classifier can defer instead of escalating.
+  test("isPendingState covers queued/in-progress/pending states", () => {
+    expect(isPendingState("QUEUED")).toBe(true);
+    expect(isPendingState("IN_PROGRESS")).toBe(true);
+    expect(isPendingState("PENDING")).toBe(true);
+    expect(isPendingState("SUCCESS")).toBe(false);
+    expect(isPendingState("FAILURE")).toBe(false);
+  });
+
+  test("in-progress check → pendingChecks, not failingChecks", () => {
+    const gh = makeGh([
+      [
+        "pr list",
+        [
+          {
+            number: 71,
+            state: "OPEN",
+            mergeStateStatus: "BLOCKED",
+            mergeable: "MERGEABLE",
+            statusCheckRollup: [
+              { name: "e2e", status: "IN_PROGRESS", conclusion: null },
+              { name: "queued-gate", status: "QUEUED", conclusion: null },
+              { name: "unit", status: "COMPLETED", conclusion: "SUCCESS" },
+            ],
+          },
+        ],
+      ],
+      ["api graphql", EMPTY_THREADS],
+    ]);
+    const r = defaultProbePrBlock("CTL-1", { gh, repo: "o/r" });
+    expect(r.failingChecks).toHaveLength(0);
+    expect(r.pendingChecks.map((c) => c.name).sort()).toEqual(["e2e", "queued-gate"]);
+  });
+
+  // P1 (round 2): with no explicit repo, owner/name are resolved via `gh repo
+  // view` run in the ticket's worktree (cwd), then the PR lookup is scoped to it.
+  test("resolves repo from worktree cwd when no repo is threaded, scopes -R", () => {
+    const calls = [];
+    const gh = (args, opts) => {
+      calls.push({ key: args.join(" "), cwd: opts?.cwd });
+      const key = args.join(" ");
+      if (key.startsWith("repo view")) return JSON.stringify({ nameWithOwner: "acme/from-worktree" });
+      if (key.startsWith("pr list"))
+        return JSON.stringify([
+          { number: 72, state: "OPEN", mergeStateStatus: "CLEAN", mergeable: "MERGEABLE", statusCheckRollup: [] },
+        ]);
+      if (key.includes("api graphql")) return JSON.stringify(EMPTY_THREADS);
+      throw new Error(`unrouted gh: ${key}`);
+    };
+    const r = defaultProbePrBlock("CTL-9", { gh, worktreePath: "/wt/CTL-9" });
+    expect(r.prNumber).toBe(72);
+    const repoView = calls.find((c) => c.key.startsWith("repo view"));
+    expect(repoView.cwd).toBe("/wt/CTL-9");
+    const prList = calls.find((c) => c.key.startsWith("pr list"));
+    expect(prList.key).toContain("-R acme/from-worktree");
   });
 });

--- a/plugins/dev/scripts/execution-core/pr-block-probe.test.mjs
+++ b/plugins/dev/scripts/execution-core/pr-block-probe.test.mjs
@@ -171,6 +171,7 @@ describe("defaultProbePrBlock", () => {
             mergeStateStatus: "BLOCKED",
             mergeable: "MERGEABLE",
             statusCheckRollup: [],
+            reviewDecision: "CHANGES_REQUESTED",
           },
         ],
       ],
@@ -340,6 +341,84 @@ describe("defaultProbePrBlock", () => {
         },
       ],
       ["pr view 47 --json reviews", { reviews: [] }],
+    ]);
+    const r = defaultProbePrBlock("CTL-1", { gh, repo: "o/r" });
+    expect(r.unresolvedBotThreads).toHaveLength(0);
+    expect(r.unresolvedHumanThreads).toHaveLength(0);
+  });
+
+  test("re-APPROVED PR (reviewDecision APPROVED) → hasChangesRequested false despite past CHANGES_REQUESTED", () => {
+    // CTL-1496 high finding: the aggregate reviewDecision, not raw review
+    // history, drives hasChangesRequested — so a fixed-then-re-approved PR is
+    // not stale-flagged and false-escalated to a human.
+    const gh = makeGh([
+      [
+        "pr list",
+        [
+          {
+            number: 48,
+            state: "OPEN",
+            mergeStateStatus: "CLEAN",
+            mergeable: "MERGEABLE",
+            statusCheckRollup: [],
+            reviewDecision: "APPROVED",
+          },
+        ],
+      ],
+      ["api graphql", EMPTY_THREADS],
+    ]);
+    const r = defaultProbePrBlock("CTL-1", { gh, repo: "o/r" });
+    expect(r.hasChangesRequested).toBe(false);
+  });
+
+  test("partial/errored review-threads GraphQL (pullRequest null) → throws (caller defers)", () => {
+    const gh = makeGh([
+      [
+        "pr list",
+        [
+          {
+            number: 49,
+            state: "OPEN",
+            mergeStateStatus: "BLOCKED",
+            mergeable: "MERGEABLE",
+            statusCheckRollup: [],
+          },
+        ],
+      ],
+      // HTTP-200 body with a field-level error: data present but pullRequest null.
+      ["api graphql", { data: { repository: { pullRequest: null } }, errors: [{ message: "x" }] }],
+    ]);
+    expect(() => defaultProbePrBlock("CTL-1", { gh, repo: "o/r" })).toThrow();
+  });
+
+  test("unresolved thread with no first comment → counted as neither bot nor human", () => {
+    const gh = makeGh([
+      [
+        "pr list",
+        [
+          {
+            number: 50,
+            state: "OPEN",
+            mergeStateStatus: "BLOCKED",
+            mergeable: "MERGEABLE",
+            statusCheckRollup: [],
+          },
+        ],
+      ],
+      [
+        "api graphql",
+        {
+          data: {
+            repository: {
+              pullRequest: {
+                reviewThreads: {
+                  nodes: [{ id: "X1", isResolved: false, comments: { nodes: [] } }],
+                },
+              },
+            },
+          },
+        },
+      ],
     ]);
     const r = defaultProbePrBlock("CTL-1", { gh, repo: "o/r" });
     expect(r.unresolvedBotThreads).toHaveLength(0);

--- a/plugins/dev/scripts/execution-core/pr-block-probe.test.mjs
+++ b/plugins/dev/scripts/execution-core/pr-block-probe.test.mjs
@@ -1,0 +1,291 @@
+// pr-block-probe.test.mjs — Unit tests for CTL-1496 PR-block probe.
+//
+// Run: cd plugins/dev/scripts/execution-core && bun test pr-block-probe.test.mjs
+
+import { describe, test, expect } from "bun:test";
+import { defaultProbePrBlock } from "./pr-block-probe.mjs";
+
+// fakeGh routes by longest matching pattern first so specific patterns
+// (e.g. "pr view 42 --json reviews") win over generic ones ("pr view").
+function makeGh(routes) {
+  const sorted = [...routes].sort((a, b) => b[0].length - a[0].length);
+  return (args) => {
+    const key = args.join(" ");
+    for (const [pat, out] of sorted) {
+      if (key.includes(pat)) {
+        if (out instanceof Error) throw out;
+        return typeof out === "string" ? out : JSON.stringify(out);
+      }
+    }
+    throw new Error(`unrouted gh: ${key}`);
+  };
+}
+
+const EMPTY_THREADS = {
+  data: { repository: { pullRequest: { reviewThreads: { nodes: [] } } } },
+};
+
+describe("defaultProbePrBlock", () => {
+  test("no PR for ticket → { prNumber: null }", () => {
+    const gh = makeGh([
+      ["pr view", {}],
+    ]);
+    const r = defaultProbePrBlock("CTL-1", { gh, repo: "o/r" });
+    expect(r.prNumber).toBeNull();
+  });
+
+  test("BLOCKED PR with one failing required check → failingChecks length 1", () => {
+    const gh = makeGh([
+      [
+        "pr view",
+        {
+          number: 42,
+          state: "OPEN",
+          mergeStateStatus: "BLOCKED",
+          mergeable: "MERGEABLE",
+          statusCheckRollup: [
+            { name: "quality", state: "FAILURE", detailsUrl: "u" },
+            { name: "unit", state: "SUCCESS" },
+          ],
+        },
+      ],
+      ["api graphql", EMPTY_THREADS],
+      ["pr view 42 --json reviews", { reviews: [] }],
+    ]);
+    const r = defaultProbePrBlock("CTL-1", { gh, repo: "o/r" });
+    expect(r.prNumber).toBe(42);
+    expect(r.failingChecks.map((c) => c.name)).toEqual(["quality"]);
+    expect(r.unresolvedBotThreads).toHaveLength(0);
+    expect(r.hasChangesRequested).toBe(false);
+  });
+
+  test("green PR with one unresolved bot thread → unresolvedBotThreads length 1", () => {
+    const gh = makeGh([
+      [
+        "pr view",
+        {
+          number: 43,
+          state: "OPEN",
+          mergeStateStatus: "BLOCKED",
+          mergeable: "MERGEABLE",
+          statusCheckRollup: [{ name: "quality", state: "SUCCESS" }],
+        },
+      ],
+      [
+        "api graphql",
+        {
+          data: {
+            repository: {
+              pullRequest: {
+                reviewThreads: {
+                  nodes: [
+                    {
+                      id: "T1",
+                      isResolved: false,
+                      comments: {
+                        nodes: [
+                          {
+                            body: "[P2] tighten this",
+                            path: "a.ts",
+                            line: 3,
+                            author: {
+                              login: "chatgpt-codex-connector[bot]",
+                              __typename: "Bot",
+                            },
+                          },
+                        ],
+                      },
+                    },
+                  ],
+                },
+              },
+            },
+          },
+        },
+      ],
+      ["pr view 43 --json reviews", { reviews: [] }],
+    ]);
+    const r = defaultProbePrBlock("CTL-1", { gh, repo: "o/r" });
+    expect(r.unresolvedBotThreads).toHaveLength(1);
+    expect(r.unresolvedBotThreads[0].id).toBe("T1");
+    expect(r.unresolvedHumanThreads).toHaveLength(0);
+  });
+
+  test("human CHANGES_REQUESTED → hasChangesRequested true + human thread captured", () => {
+    const gh = makeGh([
+      [
+        "pr view",
+        {
+          number: 44,
+          state: "OPEN",
+          mergeStateStatus: "BLOCKED",
+          mergeable: "MERGEABLE",
+          statusCheckRollup: [],
+        },
+      ],
+      [
+        "api graphql",
+        {
+          data: {
+            repository: {
+              pullRequest: {
+                reviewThreads: {
+                  nodes: [
+                    {
+                      id: "H1",
+                      isResolved: false,
+                      comments: {
+                        nodes: [
+                          {
+                            body: "please redesign",
+                            path: "b.ts",
+                            line: 9,
+                            author: { login: "ryan", __typename: "User" },
+                          },
+                        ],
+                      },
+                    },
+                  ],
+                },
+              },
+            },
+          },
+        },
+      ],
+      [
+        "pr view 44 --json reviews",
+        {
+          reviews: [{ author: { login: "ryan" }, state: "CHANGES_REQUESTED" }],
+        },
+      ],
+    ]);
+    const r = defaultProbePrBlock("CTL-1", { gh, repo: "o/r" });
+    expect(r.hasChangesRequested).toBe(true);
+    expect(r.unresolvedHumanThreads).toHaveLength(1);
+  });
+
+  test("already merged / clean → mergeStateStatus reflects it, no blockers", () => {
+    const gh = makeGh([
+      [
+        "pr view",
+        {
+          number: 45,
+          state: "OPEN",
+          mergeStateStatus: "CLEAN",
+          mergeable: "MERGEABLE",
+          statusCheckRollup: [{ name: "quality", state: "SUCCESS" }],
+        },
+      ],
+      ["api graphql", EMPTY_THREADS],
+      ["pr view 45 --json reviews", { reviews: [] }],
+    ]);
+    const r = defaultProbePrBlock("CTL-1", { gh, repo: "o/r" });
+    expect(r.mergeStateStatus).toBe("CLEAN");
+    expect(r.failingChecks).toHaveLength(0);
+    expect(r.unresolvedBotThreads).toHaveLength(0);
+  });
+
+  test("gh failure → throws (caller treats as transient)", () => {
+    const gh = makeGh([["pr view", new Error("gh: network")]]);
+    expect(() => defaultProbePrBlock("CTL-1", { gh, repo: "o/r" })).toThrow();
+  });
+
+  test("bot author detected by [bot] suffix (not just __typename)", () => {
+    const gh = makeGh([
+      [
+        "pr view",
+        {
+          number: 46,
+          state: "OPEN",
+          mergeStateStatus: "BLOCKED",
+          mergeable: "MERGEABLE",
+          statusCheckRollup: [],
+        },
+      ],
+      [
+        "api graphql",
+        {
+          data: {
+            repository: {
+              pullRequest: {
+                reviewThreads: {
+                  nodes: [
+                    {
+                      id: "B1",
+                      isResolved: false,
+                      comments: {
+                        nodes: [
+                          {
+                            body: "fix this",
+                            path: "c.ts",
+                            line: 5,
+                            author: { login: "some-bot[bot]", __typename: "User" },
+                          },
+                        ],
+                      },
+                    },
+                  ],
+                },
+              },
+            },
+          },
+        },
+      ],
+      ["pr view 46 --json reviews", { reviews: [] }],
+    ]);
+    const r = defaultProbePrBlock("CTL-1", { gh, repo: "o/r" });
+    expect(r.unresolvedBotThreads).toHaveLength(1);
+    expect(r.unresolvedHumanThreads).toHaveLength(0);
+  });
+
+  test("already-resolved threads are excluded", () => {
+    const gh = makeGh([
+      [
+        "pr view",
+        {
+          number: 47,
+          state: "OPEN",
+          mergeStateStatus: "BLOCKED",
+          mergeable: "MERGEABLE",
+          statusCheckRollup: [],
+        },
+      ],
+      [
+        "api graphql",
+        {
+          data: {
+            repository: {
+              pullRequest: {
+                reviewThreads: {
+                  nodes: [
+                    {
+                      id: "R1",
+                      isResolved: true,
+                      comments: {
+                        nodes: [
+                          {
+                            body: "already resolved",
+                            path: "d.ts",
+                            line: 1,
+                            author: {
+                              login: "chatgpt-codex-connector[bot]",
+                              __typename: "Bot",
+                            },
+                          },
+                        ],
+                      },
+                    },
+                  ],
+                },
+              },
+            },
+          },
+        },
+      ],
+      ["pr view 47 --json reviews", { reviews: [] }],
+    ]);
+    const r = defaultProbePrBlock("CTL-1", { gh, repo: "o/r" });
+    expect(r.unresolvedBotThreads).toHaveLength(0);
+    expect(r.unresolvedHumanThreads).toHaveLength(0);
+  });
+});

--- a/plugins/dev/scripts/execution-core/pr-block-probe.test.mjs
+++ b/plugins/dev/scripts/execution-core/pr-block-probe.test.mjs
@@ -6,7 +6,9 @@ import { describe, test, expect } from "bun:test";
 import { defaultProbePrBlock } from "./pr-block-probe.mjs";
 
 // fakeGh routes by longest matching pattern first so specific patterns
-// (e.g. "pr view 42 --json reviews") win over generic ones ("pr view").
+// (e.g. "pr view 42 --json reviews") win over generic ones ("pr list").
+// The PR is resolved via `gh pr list` (head branch or ticket-in-title search) —
+// never a bare `gh pr view` on the daemon's current branch (CTL-1496).
 function makeGh(routes) {
   const sorted = [...routes].sort((a, b) => b[0].length - a[0].length);
   return (args) => {
@@ -25,11 +27,54 @@ const EMPTY_THREADS = {
   data: { repository: { pullRequest: { reviewThreads: { nodes: [] } } } },
 };
 
+describe("defaultProbePrBlock — PR resolution contract (CTL-1496)", () => {
+  test("resolves by ticket-in-title search when no branch is threaded", () => {
+    const calls = [];
+    const gh = (args) => {
+      calls.push(args.join(" "));
+      const key = args.join(" ");
+      if (key.startsWith("pr list"))
+        return JSON.stringify([
+          { number: 42, state: "OPEN", mergeStateStatus: "CLEAN", mergeable: "MERGEABLE", statusCheckRollup: [] },
+        ]);
+      if (key.includes("api graphql")) return JSON.stringify(EMPTY_THREADS);
+      if (key.includes("pr view 42 --json reviews")) return JSON.stringify({ reviews: [] });
+      throw new Error(`unrouted gh: ${key}`);
+    };
+    const r = defaultProbePrBlock("CTL-99", { gh, repo: "o/r" });
+    expect(r.prNumber).toBe(42);
+    // The resolution call must NOT be a bare `pr view` (daemon current branch);
+    // it must select by the ticket id in the PR title.
+    const resolveCall = calls.find((c) => c.startsWith("pr list"));
+    expect(resolveCall).toContain("--search");
+    expect(resolveCall).toContain("CTL-99 in:title");
+    expect(resolveCall).not.toMatch(/^pr view/);
+  });
+
+  test("resolves by --head <branch> when the branch is threaded", () => {
+    const calls = [];
+    const gh = (args) => {
+      calls.push(args.join(" "));
+      const key = args.join(" ");
+      if (key.startsWith("pr list"))
+        return JSON.stringify([
+          { number: 7, state: "OPEN", mergeStateStatus: "BLOCKED", mergeable: "MERGEABLE", statusCheckRollup: [] },
+        ]);
+      if (key.includes("api graphql")) return JSON.stringify(EMPTY_THREADS);
+      if (key.includes("pr view 7 --json reviews")) return JSON.stringify({ reviews: [] });
+      throw new Error(`unrouted gh: ${key}`);
+    };
+    const r = defaultProbePrBlock("CTL-99", { gh, repo: "o/r", branch: "ryan/ctl-99-slug" });
+    expect(r.prNumber).toBe(7);
+    const resolveCall = calls.find((c) => c.startsWith("pr list"));
+    expect(resolveCall).toContain("--head ryan/ctl-99-slug");
+    expect(resolveCall).not.toContain("--search");
+  });
+});
+
 describe("defaultProbePrBlock", () => {
   test("no PR for ticket → { prNumber: null }", () => {
-    const gh = makeGh([
-      ["pr view", {}],
-    ]);
+    const gh = makeGh([["pr list", []]]);
     const r = defaultProbePrBlock("CTL-1", { gh, repo: "o/r" });
     expect(r.prNumber).toBeNull();
   });
@@ -37,17 +82,19 @@ describe("defaultProbePrBlock", () => {
   test("BLOCKED PR with one failing required check → failingChecks length 1", () => {
     const gh = makeGh([
       [
-        "pr view",
-        {
-          number: 42,
-          state: "OPEN",
-          mergeStateStatus: "BLOCKED",
-          mergeable: "MERGEABLE",
-          statusCheckRollup: [
-            { name: "quality", state: "FAILURE", detailsUrl: "u" },
-            { name: "unit", state: "SUCCESS" },
-          ],
-        },
+        "pr list",
+        [
+          {
+            number: 42,
+            state: "OPEN",
+            mergeStateStatus: "BLOCKED",
+            mergeable: "MERGEABLE",
+            statusCheckRollup: [
+              { name: "quality", state: "FAILURE", detailsUrl: "u" },
+              { name: "unit", state: "SUCCESS" },
+            ],
+          },
+        ],
       ],
       ["api graphql", EMPTY_THREADS],
       ["pr view 42 --json reviews", { reviews: [] }],
@@ -62,14 +109,16 @@ describe("defaultProbePrBlock", () => {
   test("green PR with one unresolved bot thread → unresolvedBotThreads length 1", () => {
     const gh = makeGh([
       [
-        "pr view",
-        {
-          number: 43,
-          state: "OPEN",
-          mergeStateStatus: "BLOCKED",
-          mergeable: "MERGEABLE",
-          statusCheckRollup: [{ name: "quality", state: "SUCCESS" }],
-        },
+        "pr list",
+        [
+          {
+            number: 43,
+            state: "OPEN",
+            mergeStateStatus: "BLOCKED",
+            mergeable: "MERGEABLE",
+            statusCheckRollup: [{ name: "quality", state: "SUCCESS" }],
+          },
+        ],
       ],
       [
         "api graphql",
@@ -114,14 +163,16 @@ describe("defaultProbePrBlock", () => {
   test("human CHANGES_REQUESTED → hasChangesRequested true + human thread captured", () => {
     const gh = makeGh([
       [
-        "pr view",
-        {
-          number: 44,
-          state: "OPEN",
-          mergeStateStatus: "BLOCKED",
-          mergeable: "MERGEABLE",
-          statusCheckRollup: [],
-        },
+        "pr list",
+        [
+          {
+            number: 44,
+            state: "OPEN",
+            mergeStateStatus: "BLOCKED",
+            mergeable: "MERGEABLE",
+            statusCheckRollup: [],
+          },
+        ],
       ],
       [
         "api graphql",
@@ -167,14 +218,16 @@ describe("defaultProbePrBlock", () => {
   test("already merged / clean → mergeStateStatus reflects it, no blockers", () => {
     const gh = makeGh([
       [
-        "pr view",
-        {
-          number: 45,
-          state: "OPEN",
-          mergeStateStatus: "CLEAN",
-          mergeable: "MERGEABLE",
-          statusCheckRollup: [{ name: "quality", state: "SUCCESS" }],
-        },
+        "pr list",
+        [
+          {
+            number: 45,
+            state: "OPEN",
+            mergeStateStatus: "CLEAN",
+            mergeable: "MERGEABLE",
+            statusCheckRollup: [{ name: "quality", state: "SUCCESS" }],
+          },
+        ],
       ],
       ["api graphql", EMPTY_THREADS],
       ["pr view 45 --json reviews", { reviews: [] }],
@@ -186,21 +239,23 @@ describe("defaultProbePrBlock", () => {
   });
 
   test("gh failure → throws (caller treats as transient)", () => {
-    const gh = makeGh([["pr view", new Error("gh: network")]]);
+    const gh = makeGh([["pr list", new Error("gh: network")]]);
     expect(() => defaultProbePrBlock("CTL-1", { gh, repo: "o/r" })).toThrow();
   });
 
   test("bot author detected by [bot] suffix (not just __typename)", () => {
     const gh = makeGh([
       [
-        "pr view",
-        {
-          number: 46,
-          state: "OPEN",
-          mergeStateStatus: "BLOCKED",
-          mergeable: "MERGEABLE",
-          statusCheckRollup: [],
-        },
+        "pr list",
+        [
+          {
+            number: 46,
+            state: "OPEN",
+            mergeStateStatus: "BLOCKED",
+            mergeable: "MERGEABLE",
+            statusCheckRollup: [],
+          },
+        ],
       ],
       [
         "api graphql",
@@ -241,14 +296,16 @@ describe("defaultProbePrBlock", () => {
   test("already-resolved threads are excluded", () => {
     const gh = makeGh([
       [
-        "pr view",
-        {
-          number: 47,
-          state: "OPEN",
-          mergeStateStatus: "BLOCKED",
-          mergeable: "MERGEABLE",
-          statusCheckRollup: [],
-        },
+        "pr list",
+        [
+          {
+            number: 47,
+            state: "OPEN",
+            mergeStateStatus: "BLOCKED",
+            mergeable: "MERGEABLE",
+            statusCheckRollup: [],
+          },
+        ],
       ],
       [
         "api graphql",

--- a/plugins/dev/scripts/execution-core/recovery-reasoning.mjs
+++ b/plugins/dev/scripts/execution-core/recovery-reasoning.mjs
@@ -536,12 +536,15 @@ export function classifyPrNotMerged(evidence, { probePrBlock = defaultProbePrBlo
     };
   }
 
-  // Remediable: failing checks, unresolved bot threads, or simply ready to merge.
+  // Remediable when there is a concrete LLM-actionable cause (failing checks or
+  // unresolved bot threads), or the PR is already CLEAN and just needs merging.
+  // A BLOCKED PR with NO actionable cause (awaiting a required approving review
+  // or a still-pending required check) is not LLM-fixable — falling through to
+  // escalate avoids burning the recovery-attempt budget re-entering as 'fix'.
   const remediable =
     probe.failingChecks.length > 0 ||
     probe.unresolvedBotThreads.length > 0 ||
-    probe.mergeStateStatus === "CLEAN" ||
-    probe.mergeStateStatus === "BLOCKED";
+    probe.mergeStateStatus === "CLEAN";
   if (remediable) {
     return {
       decision: "fix",

--- a/plugins/dev/scripts/execution-core/recovery-reasoning.mjs
+++ b/plugins/dev/scripts/execution-core/recovery-reasoning.mjs
@@ -45,6 +45,7 @@ import {
   getEventLogPath,
 } from "./config.mjs";
 import { buildCatalystResource } from "./lib/catalyst-resource.mjs";
+import { defaultProbePrBlock } from "./pr-block-probe.mjs";
 import { captureEvidence } from "./diagnostician.mjs";
 
 // Wrap defaultLog to ensure it's a function (config.mjs may export an object)
@@ -483,11 +484,105 @@ export function reasoningRecoveryPass(items, opts = {}) {
 
 // ─── Classification logic (pure, injectable) ────────────────────────────────
 
+// CTL-1496: the failureReason value emitted by phase-teardown's pr_not_merged gate.
+export const PR_NOT_MERGED_REASON = "pr_not_merged";
+
+// CTL-1496: classify a pr_not_merged recovery item by probing live PR state.
+// All GitHub calls are behind the injectable probePrBlock seam so this function
+// stays pure and unit-testable with a fake probe.
+export function classifyPrNotMerged(evidence, { probePrBlock = defaultProbePrBlock, log } = {}) {
+  const ticket = evidence.ticket ?? evidence.signal?.ticket;
+  let probe;
+  try {
+    probe = probePrBlock(ticket);
+  } catch (e) {
+    log?.(`pr-block probe failed: ${e.message}`);
+    return {
+      decision: "defer",
+      fix_class: "board-health",
+      details: {
+        reason: `pr_not_merged: PR-state probe failed (${e.message}); retry next tick`,
+      },
+    };
+  }
+
+  if (!probe || !probe.prNumber) {
+    return {
+      decision: "escalate",
+      fix_class: "human",
+      details: { reason: `pr_not_merged: no open PR found for ${ticket}` },
+    };
+  }
+
+  // Human decision required → escalate with the SPECIFIC ask.
+  if (probe.hasChangesRequested || probe.unresolvedHumanThreads.length > 0) {
+    const t = probe.unresolvedHumanThreads[0];
+    return {
+      decision: "escalate",
+      fix_class: "human",
+      details: {
+        reason:
+          `PR #${probe.prNumber} blocked by human review` +
+          (t
+            ? ` — "${(t.body || "").slice(0, 120)}" (${t.path}:${t.line})`
+            : " (CHANGES_REQUESTED)"),
+      },
+    };
+  }
+
+  // Remediable: failing checks, unresolved bot threads, or simply ready to merge.
+  const remediable =
+    probe.failingChecks.length > 0 ||
+    probe.unresolvedBotThreads.length > 0 ||
+    probe.mergeStateStatus === "CLEAN" ||
+    probe.mergeStateStatus === "BLOCKED";
+  if (remediable) {
+    return {
+      decision: "fix",
+      fix_class: "bounded-llm",
+      details: {
+        reason: _prNotMergedReasonText(probe),
+        brief: generateRemediateBrief("pr-not-merged", probe),
+      },
+    };
+  }
+
+  // Genuinely stuck with no actionable cause.
+  return {
+    decision: "escalate",
+    fix_class: "human",
+    details: {
+      reason: `PR #${probe.prNumber} not merged; mergeState=${probe.mergeStateStatus}, no remediable cause`,
+    },
+  };
+}
+
+function _prNotMergedReasonText(probe) {
+  const parts = [];
+  if (probe.failingChecks.length > 0) {
+    parts.push(`failing checks: ${probe.failingChecks.map((c) => c.name).join(", ")}`);
+  }
+  if (probe.unresolvedBotThreads.length > 0) {
+    parts.push(`${probe.unresolvedBotThreads.length} unresolved bot review thread(s)`);
+  }
+  if (parts.length === 0) {
+    parts.push(`mergeState=${probe.mergeStateStatus}`);
+  }
+  return `PR #${probe.prNumber} not merged — ${parts.join("; ")}`;
+}
+
 export function defaultClassifyTicket(evidence, opts = {}) {
-  const { log = defaultLogFn } = opts;
+  const { log = defaultLogFn, probePrBlock } = opts;
 
   // Extract evidence fields
   const { logsOutput, jobState, signal, beliefState, failureReason } = evidence;
+
+  // CTL-1496: pr_not_merged gets a live PR-state probe before any generic rules.
+  // Only fires for this specific failureReason; all other paths are untouched.
+  const effectiveFailureReason = failureReason ?? signal?.failureReason;
+  if (effectiveFailureReason === PR_NOT_MERGED_REASON) {
+    return classifyPrNotMerged(evidence, { probePrBlock: probePrBlock ?? defaultProbePrBlock, log });
+  }
 
   // Rule 1: Check for deterministic errors in logs
   const deterministic = checkDeterministicErrors(logsOutput, failureReason);
@@ -687,9 +782,11 @@ export function checkBoundedLlmFixes(logsOutput, jobState, signal) {
   return null;
 }
 
-// Generate a structured brief for phase-remediate that includes explicit instruction
-// on escalation bar: only return HUMAN if the fix would delete another ticket's merged feature.
-export function generateRemediateBrief(category) {
+// Generate a structured brief for phase-remediate / recovery-pass that includes
+// explicit instruction on escalation bar.  For the "pr-not-merged" category an
+// optional `probe` object embeds the concrete blockers so the worker has them
+// without re-probing at act-time.
+export function generateRemediateBrief(category, probe = null) {
   const briefs = {
     "merge-conflict": [
       "Read both sides of every conflicting hunk (git diff HEAD...MERGE_HEAD or git log --merge).",
@@ -713,6 +810,30 @@ export function generateRemediateBrief(category) {
     ].join(" "),
     "bun-install": "Run bun install in affected packages and retry the phase.",
     "typescript-error": "Review and fix type errors reported by the compiler, then retry the phase.",
+    // CTL-1496: pr-not-merged remediation brief (embeds concrete blockers from the probe).
+    "pr-not-merged": [
+      probe
+        ? `PR #${probe.prNumber} is OPEN (mergeState=${probe.mergeStateStatus}).`
+        : "A PR for this ticket is open but not merged.",
+      probe?.failingChecks?.length
+        ? `Failing checks: ${probe.failingChecks.map((c) => c.name).join(", ")}. ` +
+          "For each, run `gh run view --log-failed`, fix the root cause, commit and push to re-run it."
+        : "",
+      probe?.unresolvedBotThreads?.length
+        ? `Unresolved automated-review threads: ` +
+          `${probe.unresolvedBotThreads.map((t) => `${t.path}:${t.line}`).join(", ")}. ` +
+          "Address each actionable finding in code, resolve the thread via resolveReviewThread, " +
+          "then post `@codex review` via gh-pr-comment.sh to re-trigger the reviewer."
+        : "",
+      "When the PR is CLEAN, run `gh pr view <n> --json mergeable,mergeStateStatus` to confirm, " +
+        "then merge with `gh pr merge --squash --delete-branch`. " +
+        "After addressing any review finding, post `@codex review` via gh-pr-comment.sh to re-trigger the reviewer.",
+      "Never --admin or force-merge past a failing or pending check. " +
+        "Escalate ONLY a finding that genuinely requires a human decision, " +
+        "with the PR number and thread linked.",
+    ]
+      .filter(Boolean)
+      .join(" "),
   };
   return briefs[category] ?? `Resolve the ${category} issue and retry the phase.`;
 }

--- a/plugins/dev/scripts/execution-core/recovery-reasoning.mjs
+++ b/plugins/dev/scripts/execution-core/recovery-reasoning.mjs
@@ -492,9 +492,15 @@ export const PR_NOT_MERGED_REASON = "pr_not_merged";
 // stays pure and unit-testable with a fake probe.
 export function classifyPrNotMerged(evidence, { probePrBlock = defaultProbePrBlock, log } = {}) {
   const ticket = evidence.ticket ?? evidence.signal?.ticket;
+  // CTL-1496: thread the ticket's head branch to the probe when the evidence
+  // carries it, so the probe resolves the ticket's PR by `--head <branch>`
+  // rather than the daemon's current branch. Falls back to ticket-in-title
+  // search inside the probe when branch is absent.
+  const branch =
+    evidence.branch ?? evidence.signal?.branch ?? evidence.signal?.branchName ?? undefined;
   let probe;
   try {
-    probe = probePrBlock(ticket);
+    probe = probePrBlock(ticket, { branch });
   } catch (e) {
     log?.(`pr-block probe failed: ${e.message}`);
     return {

--- a/plugins/dev/scripts/execution-core/recovery-reasoning.mjs
+++ b/plugins/dev/scripts/execution-core/recovery-reasoning.mjs
@@ -498,9 +498,18 @@ export function classifyPrNotMerged(evidence, { probePrBlock = defaultProbePrBlo
   // search inside the probe when branch is absent.
   const branch =
     evidence.branch ?? evidence.signal?.branch ?? evidence.signal?.branchName ?? undefined;
+  // CTL-1496 P1: thread the ticket's repository into the probe so it resolves
+  // the ticket's PR, not a same-ticket PR in the daemon's own checkout. `repo`
+  // (owner/name) is used directly; `worktreePath` lets the probe derive the repo
+  // from the ticket's worktree when `repo` isn't pre-resolved. Both come off the
+  // worker signal the scheduler already carries — without them an external-repo
+  // ticket falls back to the daemon cwd and is misclassified as having no PR.
+  const repo = evidence.repo ?? evidence.signal?.repo ?? undefined;
+  const worktreePath =
+    evidence.worktreePath ?? evidence.signal?.worktreePath ?? undefined;
   let probe;
   try {
-    probe = probePrBlock(ticket, { branch });
+    probe = probePrBlock(ticket, { branch, repo, worktreePath });
   } catch (e) {
     log?.(`pr-block probe failed: ${e.message}`);
     return {
@@ -520,8 +529,14 @@ export function classifyPrNotMerged(evidence, { probePrBlock = defaultProbePrBlo
     };
   }
 
-  // Human decision required → escalate with the SPECIFIC ask.
-  if (probe.hasChangesRequested || probe.unresolvedHumanThreads.length > 0) {
+  // Human decision required → escalate with the SPECIFIC ask. The escalation
+  // condition is the aggregate CHANGES_REQUESTED verdict ONLY (CTL-1496 P2): a
+  // merely-open human discussion thread or question — with reviewDecision not
+  // CHANGES_REQUESTED — is not a change request, so it must NOT short-circuit to
+  // a terminal human-escalation latch while the PR has a fixable failing check
+  // or bot finding. Such non-requesting threads fall through to the actionable
+  // path below (and, if nothing is fixable, the generic escalate at the end).
+  if (probe.hasChangesRequested) {
     const t = probe.unresolvedHumanThreads[0];
     return {
       decision: "escalate",
@@ -552,6 +567,23 @@ export function classifyPrNotMerged(evidence, { probePrBlock = defaultProbePrBlo
       details: {
         reason: _prNotMergedReasonText(probe),
         brief: generateRemediateBrief("pr-not-merged", probe),
+      },
+    };
+  }
+
+  // CTL-1496 P2: a PR blocked only by queued/in-progress required checks has no
+  // fixable cause YET — but it is not stuck. Escalating here would latch a
+  // "no remediable cause" record for days and never revisit a CI run that
+  // later turns green. Defer instead so the next tick re-probes once checks
+  // settle.
+  if (probe.pendingChecks?.length > 0) {
+    return {
+      decision: "defer",
+      fix_class: "board-health",
+      details: {
+        reason:
+          `PR #${probe.prNumber} awaiting checks: ` +
+          `${probe.pendingChecks.map((c) => c.name).join(", ")}; retry next tick`,
       },
     };
   }

--- a/plugins/dev/scripts/execution-core/recovery-reasoning.test.mjs
+++ b/plugins/dev/scripts/execution-core/recovery-reasoning.test.mjs
@@ -27,6 +27,8 @@ import {
   recordVerdict,
   defaultSkipReason,
   escalateExhaustedIntents,
+  classifyPrNotMerged,
+  PR_NOT_MERGED_REASON,
 } from "./recovery-reasoning.mjs";
 import { mkdtempSync, rmSync, existsSync, readFileSync, mkdirSync, writeFileSync } from "node:fs";
 import { join as pathJoin } from "node:path";
@@ -2162,5 +2164,148 @@ describe("defaultSkipReason + escalateExhaustedIntents (CTL-1440 P0b)", () => {
     expect(defaultSkipReason("CTL-Y", { orchDir, now: () => t0 + 2 })).toBe("escalated");
     // …and B1's terminal TTL ages it back into triage.
     expect(defaultSkipReason("CTL-Y", { orchDir, now: () => t0 + 2 + RECOVERY_TERMINAL_INTENT_TTL_MS })).toBeNull();
+  });
+});
+
+// ─── CTL-1496: pr_not_merged classification ─────────────────────────────────
+
+describe("classifyPrNotMerged (CTL-1496)", () => {
+  const mkEvidence = () => ({
+    logsOutput: null,
+    signal: { failureReason: PR_NOT_MERGED_REASON },
+    failureReason: PR_NOT_MERGED_REASON,
+    ticket: "CTL-1",
+  });
+  const probeReturning = (o) => () => o;
+
+  test("failing check → bounded-llm fix, brief names the check", () => {
+    const r = defaultClassifyTicket(mkEvidence(), {
+      probePrBlock: probeReturning({
+        prNumber: 42,
+        mergeStateStatus: "BLOCKED",
+        failingChecks: [{ name: "quality", detailsUrl: null }],
+        unresolvedBotThreads: [],
+        unresolvedHumanThreads: [],
+        hasChangesRequested: false,
+      }),
+    });
+    expect(r.decision).toBe("fix");
+    expect(r.fix_class).toBe("bounded-llm");
+    expect(r.details.brief).toContain("quality");
+  });
+
+  test("unresolved bot thread only → bounded-llm fix (review sub-mode)", () => {
+    const r = defaultClassifyTicket(mkEvidence(), {
+      probePrBlock: probeReturning({
+        prNumber: 43,
+        mergeStateStatus: "BLOCKED",
+        failingChecks: [],
+        unresolvedBotThreads: [{ id: "T1", path: "a.ts", line: 3, body: "fix this" }],
+        unresolvedHumanThreads: [],
+        hasChangesRequested: false,
+      }),
+    });
+    expect(r.decision).toBe("fix");
+    expect(r.fix_class).toBe("bounded-llm");
+    expect(r.details.brief).toContain("review");
+  });
+
+  test("human CHANGES_REQUESTED → escalate with PR number in reason, not opaque pr_not_merged", () => {
+    const r = defaultClassifyTicket(mkEvidence(), {
+      probePrBlock: probeReturning({
+        prNumber: 44,
+        mergeStateStatus: "BLOCKED",
+        failingChecks: [],
+        unresolvedBotThreads: [],
+        unresolvedHumanThreads: [{ id: "H1", body: "redesign", path: "b.ts", line: 9 }],
+        hasChangesRequested: true,
+      }),
+    });
+    expect(r.decision).toBe("escalate");
+    expect(r.fix_class).toBe("human");
+    expect(r.details.reason).toContain("44");
+    expect(r.details.reason).not.toBe("Failure reason: pr_not_merged");
+  });
+
+  test("no blockers / CLEAN → bounded-llm fix (finish the merge)", () => {
+    const r = defaultClassifyTicket(mkEvidence(), {
+      probePrBlock: probeReturning({
+        prNumber: 45,
+        mergeStateStatus: "CLEAN",
+        failingChecks: [],
+        unresolvedBotThreads: [],
+        unresolvedHumanThreads: [],
+        hasChangesRequested: false,
+      }),
+    });
+    expect(r.decision).toBe("fix");
+  });
+
+  test("probe throws → defer (transient), NOT escalate", () => {
+    const r = defaultClassifyTicket(mkEvidence(), {
+      probePrBlock: () => { throw new Error("gh down"); },
+    });
+    expect(r.decision).toBe("defer");
+  });
+
+  test("no PR found (prNumber null) → escalate with 'no open PR' reason", () => {
+    const r = defaultClassifyTicket(mkEvidence(), {
+      probePrBlock: probeReturning({ prNumber: null }),
+    });
+    expect(r.decision).toBe("escalate");
+    expect(r.details.reason).toContain("no open PR");
+  });
+
+  test("generateRemediateBrief('pr-not-merged') mentions gh pr view, @codex review", () => {
+    const b = generateRemediateBrief("pr-not-merged");
+    expect(b).toContain("gh pr view");
+    expect(b).toContain("@codex review");
+  });
+
+  test("generateRemediateBrief('pr-not-merged', probe) embeds check names and thread paths", () => {
+    const probe = {
+      prNumber: 42,
+      mergeStateStatus: "BLOCKED",
+      failingChecks: [{ name: "quality-gate", detailsUrl: null }],
+      unresolvedBotThreads: [{ id: "T1", path: "src/foo.ts", line: 5, body: "fix this" }],
+    };
+    const b = generateRemediateBrief("pr-not-merged", probe);
+    expect(b).toContain("quality-gate");
+    expect(b).toContain("src/foo.ts");
+    expect(b).toContain("@codex review");
+  });
+
+  // REGRESSION GUARD: probe is never called for non-pr_not_merged reasons.
+  test("merge-conflict still bounded-llm without touching the probe", () => {
+    let called = false;
+    const r = defaultClassifyTicket(
+      { logsOutput: null, signal: { failureReason: "merge-conflict" } },
+      { probePrBlock: () => { called = true; return {}; } },
+    );
+    expect(r.fix_class).toBe("bounded-llm");
+    expect(called).toBe(false);
+  });
+
+  test("unknown failure without pr_not_merged — probe never called", () => {
+    let called = false;
+    defaultClassifyTicket(
+      { logsOutput: null, signal: { failureReason: "some-other-reason" } },
+      { probePrBlock: () => { called = true; return {}; } },
+    );
+    expect(called).toBe(false);
+  });
+
+  test("classifyPrNotMerged exported + produces same result as via defaultClassifyTicket", () => {
+    const probe = probeReturning({
+      prNumber: 50,
+      mergeStateStatus: "BLOCKED",
+      failingChecks: [{ name: "lint", detailsUrl: null }],
+      unresolvedBotThreads: [],
+      unresolvedHumanThreads: [],
+      hasChangesRequested: false,
+    });
+    const via1 = defaultClassifyTicket(mkEvidence(), { probePrBlock: probe });
+    const via2 = classifyPrNotMerged(mkEvidence(), { probePrBlock: probe });
+    expect(via1).toEqual(via2);
   });
 });

--- a/plugins/dev/scripts/execution-core/recovery-reasoning.test.mjs
+++ b/plugins/dev/scripts/execution-core/recovery-reasoning.test.mjs
@@ -2241,6 +2241,36 @@ describe("classifyPrNotMerged (CTL-1496)", () => {
     expect(r.decision).toBe("fix");
   });
 
+  test("BLOCKED with no actionable cause → escalate (awaiting required approval, not LLM-fixable)", () => {
+    const r = defaultClassifyTicket(mkEvidence(), {
+      probePrBlock: probeReturning({
+        prNumber: 46,
+        mergeStateStatus: "BLOCKED",
+        failingChecks: [],
+        unresolvedBotThreads: [],
+        unresolvedHumanThreads: [],
+        hasChangesRequested: false,
+      }),
+    });
+    expect(r.decision).toBe("escalate");
+    expect(r.details.reason).toContain("no remediable cause");
+  });
+
+  test("DIRTY with no actionable cause → escalate 'no remediable cause' (fallthrough coverage)", () => {
+    const r = defaultClassifyTicket(mkEvidence(), {
+      probePrBlock: probeReturning({
+        prNumber: 47,
+        mergeStateStatus: "DIRTY",
+        failingChecks: [],
+        unresolvedBotThreads: [],
+        unresolvedHumanThreads: [],
+        hasChangesRequested: false,
+      }),
+    });
+    expect(r.decision).toBe("escalate");
+    expect(r.details.reason).toContain("no remediable cause");
+  });
+
   test("probe throws → defer (transient), NOT escalate", () => {
     const r = defaultClassifyTicket(mkEvidence(), {
       probePrBlock: () => { throw new Error("gh down"); },

--- a/plugins/dev/scripts/execution-core/recovery-reasoning.test.mjs
+++ b/plugins/dev/scripts/execution-core/recovery-reasoning.test.mjs
@@ -2338,6 +2338,88 @@ describe("classifyPrNotMerged (CTL-1496)", () => {
     const via2 = classifyPrNotMerged(mkEvidence(), { probePrBlock: probe });
     expect(via1).toEqual(via2);
   });
+
+  // ── CTL-1496 remediation (Codex re-review round 2) ──
+
+  // P2: a merely-open human discussion thread (reviewDecision NOT
+  // CHANGES_REQUESTED) must NOT short-circuit to a human-escalation latch when
+  // there is a fixable cause — it follows the actionable path.
+  test("open human thread w/o CHANGES_REQUESTED + failing check → fix (not escalate)", () => {
+    const r = classifyPrNotMerged(mkEvidence(), {
+      probePrBlock: probeReturning({
+        prNumber: 51,
+        mergeStateStatus: "BLOCKED",
+        failingChecks: [{ name: "quality", detailsUrl: null }],
+        unresolvedBotThreads: [],
+        unresolvedHumanThreads: [{ id: "H9", body: "just a question", path: "x.ts", line: 2 }],
+        hasChangesRequested: false,
+      }),
+    });
+    expect(r.decision).toBe("fix");
+    expect(r.fix_class).toBe("bounded-llm");
+  });
+
+  // P2: pending required checks (queued/in-progress) are not a failure and not
+  // stuck — defer instead of latching a "no remediable cause" escalation.
+  test("only pending checks, no other cause → defer (retry next tick)", () => {
+    const r = classifyPrNotMerged(mkEvidence(), {
+      probePrBlock: probeReturning({
+        prNumber: 52,
+        mergeStateStatus: "BLOCKED",
+        failingChecks: [],
+        pendingChecks: [{ name: "e2e", detailsUrl: null }],
+        unresolvedBotThreads: [],
+        unresolvedHumanThreads: [],
+        hasChangesRequested: false,
+      }),
+    });
+    expect(r.decision).toBe("defer");
+    expect(r.details.reason).toContain("e2e");
+  });
+
+  // P2: a failing check still wins over pending — fix, don't defer.
+  test("failing check alongside a pending check → fix (failing wins)", () => {
+    const r = classifyPrNotMerged(mkEvidence(), {
+      probePrBlock: probeReturning({
+        prNumber: 53,
+        mergeStateStatus: "BLOCKED",
+        failingChecks: [{ name: "unit", detailsUrl: null }],
+        pendingChecks: [{ name: "e2e", detailsUrl: null }],
+        unresolvedBotThreads: [],
+        unresolvedHumanThreads: [],
+        hasChangesRequested: false,
+      }),
+    });
+    expect(r.decision).toBe("fix");
+  });
+
+  // P1: the ticket's repo + worktreePath are threaded from the worker signal
+  // into the probe so it resolves the ticket's repository, not the daemon's.
+  test("threads repo + worktreePath from the worker signal into the probe", () => {
+    let seen = null;
+    classifyPrNotMerged(
+      {
+        failureReason: PR_NOT_MERGED_REASON,
+        ticket: "CTL-77",
+        signal: {
+          failureReason: PR_NOT_MERGED_REASON,
+          branchName: "ryan/ctl-77-x",
+          repo: "acme/widgets",
+          worktreePath: "/wt/CTL-77",
+        },
+      },
+      {
+        probePrBlock: (ticket, opts) => {
+          seen = { ticket, ...opts };
+          return { prNumber: 77, mergeStateStatus: "CLEAN", failingChecks: [], unresolvedBotThreads: [], unresolvedHumanThreads: [], hasChangesRequested: false };
+        },
+      },
+    );
+    expect(seen.ticket).toBe("CTL-77");
+    expect(seen.repo).toBe("acme/widgets");
+    expect(seen.worktreePath).toBe("/wt/CTL-77");
+    expect(seen.branch).toBe("ryan/ctl-77-x");
+  });
 });
 
 // ─── CTL-1496 Phase 4: reasoningRecoveryPass end-to-end (enforce + shadow) ──

--- a/plugins/dev/scripts/execution-core/recovery-reasoning.test.mjs
+++ b/plugins/dev/scripts/execution-core/recovery-reasoning.test.mjs
@@ -2309,3 +2309,110 @@ describe("classifyPrNotMerged (CTL-1496)", () => {
     expect(via1).toEqual(via2);
   });
 });
+
+// ─── CTL-1496 Phase 4: reasoningRecoveryPass end-to-end (enforce + shadow) ──
+
+describe("reasoningRecoveryPass — pr_not_merged end-to-end (CTL-1496 Phase 4)", () => {
+  const mkPrNotMergedItem = () => ({
+    ticket: "CTL-PRNM",
+    evidence: {
+      failureReason: "pr_not_merged",
+      signal: { failureReason: "pr_not_merged" },
+      ticket: "CTL-PRNM",
+      logsOutput: null,
+      jobState: null,
+    },
+  });
+
+  test("enforce: pr_not_merged + failing check → dispatches recovery-pass (fix intent recorded)", () => {
+    const intents = [];
+    const events = [];
+    const items = [mkPrNotMergedItem()];
+    reasoningRecoveryPass(items, {
+      mode: "enforce",
+      classifyTicket: () => ({
+        decision: "fix",
+        fix_class: "bounded-llm",
+        details: {
+          reason: "PR #42 failing quality",
+          brief: "…@codex review…",
+        },
+      }),
+      invokeRecoveryPass: (_ticket, _o) => ({
+        success: true,
+        dispatched: true,
+        details: {},
+      }),
+      recordIntent: (t, i) => intents.push({ t, i }),
+      emitEvent: (e) => events.push(e),
+      postComment: () => {},
+      shouldSkipItem: () => null,
+    });
+    expect(intents.length).toBeGreaterThan(0);
+    const fixIntent = intents.find((i) => i.i.decision === "fix" || i.i.type === "recovery-pass");
+    expect(fixIntent).toBeDefined();
+    expect(events.some((e) => e.type === "recovery.fixed" || e.type === "recovery.decision")).toBe(true);
+  });
+
+  test("shadow: pr_not_merged + failing check → emits would-fix event, dispatches NOTHING", () => {
+    const events = [];
+    const items = [mkPrNotMergedItem()];
+    reasoningRecoveryPass(items, {
+      mode: "shadow",
+      classifyTicket: () => ({
+        decision: "fix",
+        fix_class: "bounded-llm",
+        details: { reason: "PR #42", brief: "…" },
+      }),
+      invokeRecoveryPass: () => {
+        throw new Error("must not dispatch in shadow mode");
+      },
+      recordIntent: () => {},
+      emitEvent: (e) => events.push(e),
+      postComment: () => {},
+      shouldSkipItem: () => null,
+    });
+    expect(events.some((e) => String(e.type).includes("would"))).toBe(true);
+    expect(events.some((e) => e.type === "recovery.fixed")).toBe(false);
+  });
+
+  test("shadow: human CHANGES_REQUESTED → emits would-escalate, dispatches NOTHING", () => {
+    const events = [];
+    reasoningRecoveryPass([mkPrNotMergedItem()], {
+      mode: "shadow",
+      classifyTicket: () => ({
+        decision: "escalate",
+        fix_class: "human",
+        details: { reason: "PR #44 blocked by human review — 'redesign' (b.ts:9)" },
+      }),
+      invokeRecoveryPass: () => { throw new Error("must not dispatch in shadow"); },
+      recordIntent: () => {},
+      emitEvent: (e) => events.push(e),
+      postComment: () => {},
+      shouldSkipItem: () => null,
+    });
+    expect(events.some((e) => String(e.type).includes("would-escalate") || String(e.type).includes("would"))).toBe(true);
+  });
+
+  test("probe throws in enforce → defer outcome (no dispatch, no escalation latch)", () => {
+    const events = [];
+    const intents = [];
+    reasoningRecoveryPass([mkPrNotMergedItem()], {
+      mode: "enforce",
+      classifyTicket: () => ({
+        decision: "defer",
+        fix_class: "board-health",
+        details: { reason: "pr_not_merged: probe failed (gh down); retry next tick" },
+      }),
+      invokeRecoveryPass: () => { throw new Error("must not dispatch on defer"); },
+      recordIntent: (t, i) => intents.push({ t, i }),
+      emitEvent: (e) => events.push(e),
+      postComment: () => {},
+      shouldSkipItem: () => null,
+    });
+    const deferIntent = intents.find((i) => i.i.decision === "defer");
+    expect(deferIntent).toBeDefined();
+    expect(events.some((e) => e.type === "recovery.fixed")).toBe(false);
+    expect(events.some((e) => e.type === "recovery.escalated")).toBe(false);
+  });
+});

--- a/plugins/dev/scripts/lib/gh-pr-comment.sh
+++ b/plugins/dev/scripts/lib/gh-pr-comment.sh
@@ -18,6 +18,13 @@ if [[ "${3:-}" == "--idempotent" ]]; then
   IDEMPOTENT=true
 fi
 
+# CTL-1496: PR_NUMBER is interpolated into a REST path below — reject anything
+# non-numeric so a bad arg can't build a malformed/traversable endpoint.
+if [[ ! "$PR_NUMBER" =~ ^[0-9]+$ ]]; then
+  echo "gh-pr-comment: PR number must be a positive integer (got '${PR_NUMBER}')" >&2
+  exit 2
+fi
+
 GH="${CATALYST_GH_PR_COMMENT_GH_BIN:-gh}"
 
 # Resolve repo (needed for the REST comments endpoint in idempotent mode).
@@ -28,8 +35,17 @@ REPO="$("$GH" repo view --json nameWithOwner --jq '.nameWithOwner' 2>/dev/null)"
 
 if [[ "$IDEMPOTENT" == "true" ]]; then
   # Fetch the last 20 issue comments and check for an exact body match.
-  EXISTING="$("$GH" api "repos/${REPO}/issues/${PR_NUMBER}/comments?per_page=20" 2>/dev/null \
-    | jq -r '.[].body' 2>/dev/null)" || true
+  # CTL-1496: distinguish a genuine "no matching comment" from a transient
+  # fetch failure. The old `... 2>/dev/null | jq ... || true` swallowed a gh
+  # api error and treated the empty result as "not present", then posted — so
+  # a transient hiccup could double-post `@codex review`, the exact spam this
+  # guard exists to prevent. On a non-zero gh api exit we now fail-closed (skip
+  # the post) and exit non-zero so the caller can retry next cycle.
+  if ! RAW_COMMENTS="$("$GH" api "repos/${REPO}/issues/${PR_NUMBER}/comments?per_page=20" 2>/dev/null)"; then
+    echo "gh-pr-comment: existing-comment fetch failed — skipping post to avoid a double-comment (idempotent, CTL-1496)" >&2
+    exit 3
+  fi
+  EXISTING="$(printf '%s' "$RAW_COMMENTS" | jq -r '.[].body' 2>/dev/null)" || EXISTING=""
   while IFS= read -r existing_body; do
     if [[ "$existing_body" == "$BODY" ]]; then
       echo "gh-pr-comment: body already present — skipping (idempotent)" >&2

--- a/plugins/dev/scripts/lib/gh-pr-comment.sh
+++ b/plugins/dev/scripts/lib/gh-pr-comment.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# gh-pr-comment.sh — Post a GitHub PR comment (CTL-1496).
+#
+# Usage: gh-pr-comment.sh <PR_NUMBER> <BODY> [--idempotent]
+#
+# With --idempotent: checks the last ~20 issue comments for an exact body
+# match and skips posting if already present (prevents @codex spam on
+# repeated recovery cycles).
+#
+# The gh binary can be overridden via CATALYST_GH_PR_COMMENT_GH_BIN (for
+# tests), matching the convention in orchestrate-resolve-fixed-threads.
+set -euo pipefail
+
+PR_NUMBER="${1:?PR number required (e.g. 42)}"
+BODY="${2:?comment body required}"
+IDEMPOTENT=false
+if [[ "${3:-}" == "--idempotent" ]]; then
+  IDEMPOTENT=true
+fi
+
+GH="${CATALYST_GH_PR_COMMENT_GH_BIN:-gh}"
+
+# Resolve repo (needed for the REST comments endpoint in idempotent mode).
+REPO="$("$GH" repo view --json nameWithOwner --jq '.nameWithOwner' 2>/dev/null)" || {
+  echo "gh-pr-comment: could not resolve repo" >&2
+  exit 1
+}
+
+if [[ "$IDEMPOTENT" == "true" ]]; then
+  # Fetch the last 20 issue comments and check for an exact body match.
+  EXISTING="$("$GH" api "repos/${REPO}/issues/${PR_NUMBER}/comments?per_page=20" 2>/dev/null \
+    | jq -r '.[].body' 2>/dev/null)" || true
+  while IFS= read -r existing_body; do
+    if [[ "$existing_body" == "$BODY" ]]; then
+      echo "gh-pr-comment: body already present — skipping (idempotent)" >&2
+      exit 0
+    fi
+  done <<< "$EXISTING"
+fi
+
+"$GH" pr comment "$PR_NUMBER" -R "$REPO" --body "$BODY"

--- a/plugins/dev/scripts/lib/gh-pr-comment.sh
+++ b/plugins/dev/scripts/lib/gh-pr-comment.sh
@@ -3,9 +3,14 @@
 #
 # Usage: gh-pr-comment.sh <PR_NUMBER> <BODY> [--idempotent]
 #
-# With --idempotent: checks the last ~20 issue comments for an exact body
-# match and skips posting if already present (prevents @codex spam on
-# repeated recovery cycles).
+# With --idempotent: checks issue comments posted within a RECENT time window
+# (CATALYST_GH_COMMENT_DEDUP_WINDOW_SEC, default 600s) for an exact body match
+# and skips posting if already present — this prevents @codex spam within a
+# single recovery cycle WITHOUT suppressing a fresh re-review request forever
+# (CTL-1496: an unbounded "last 20 comments" match let the very first
+# `@codex review` block every later cycle's re-review; the fetch also returned
+# the OLDEST comments, not the newest). The window is fetched correctly via the
+# API `since` parameter.
 #
 # The gh binary can be overridden via CATALYST_GH_PR_COMMENT_GH_BIN (for
 # tests), matching the convention in orchestrate-resolve-fixed-threads.
@@ -34,24 +39,36 @@ REPO="$("$GH" repo view --json nameWithOwner --jq '.nameWithOwner' 2>/dev/null)"
 }
 
 if [[ "$IDEMPOTENT" == "true" ]]; then
-  # Fetch the last 20 issue comments and check for an exact body match.
+  # Only dedup against comments from a RECENT window, fetched correctly via the
+  # `since` parameter (the plain `?per_page=20` returns the OLDEST comments in
+  # ascending order, so on a busy PR a fresh duplicate wouldn't even be in the
+  # set — and an old identical comment would suppress every future post). A
+  # match only counts as a duplicate when it was posted inside the window, so an
+  # earlier cycle's `@codex review` no longer blocks a re-review after a new fix.
+  WINDOW_SEC="${CATALYST_GH_COMMENT_DEDUP_WINDOW_SEC:-600}"
+  NOW_EPOCH="$(date -u +%s)"
+  SINCE_EPOCH=$(( NOW_EPOCH - WINDOW_SEC ))
+  # BSD (`-r`) and GNU (`-d @`) date both covered.
+  SINCE_ISO="$(date -u -r "$SINCE_EPOCH" +%Y-%m-%dT%H:%M:%SZ 2>/dev/null \
+    || date -u -d "@${SINCE_EPOCH}" +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || echo "")"
+  COMMENTS_PATH="repos/${REPO}/issues/${PR_NUMBER}/comments?per_page=100"
+  [[ -n "$SINCE_ISO" ]] && COMMENTS_PATH="${COMMENTS_PATH}&since=${SINCE_ISO}"
   # CTL-1496: distinguish a genuine "no matching comment" from a transient
-  # fetch failure. The old `... 2>/dev/null | jq ... || true` swallowed a gh
-  # api error and treated the empty result as "not present", then posted — so
-  # a transient hiccup could double-post `@codex review`, the exact spam this
-  # guard exists to prevent. On a non-zero gh api exit we now fail-closed (skip
-  # the post) and exit non-zero so the caller can retry next cycle.
-  if ! RAW_COMMENTS="$("$GH" api "repos/${REPO}/issues/${PR_NUMBER}/comments?per_page=20" 2>/dev/null)"; then
+  # fetch failure. A swallowed gh api error treated as "not present" would
+  # double-post `@codex review`, the exact spam this guard exists to prevent.
+  # On a non-zero gh api exit we fail-closed (skip the post) and exit non-zero
+  # so the caller can retry next cycle.
+  if ! RAW_COMMENTS="$("$GH" api "$COMMENTS_PATH" 2>/dev/null)"; then
     echo "gh-pr-comment: existing-comment fetch failed — skipping post to avoid a double-comment (idempotent, CTL-1496)" >&2
     exit 3
   fi
-  EXISTING="$(printf '%s' "$RAW_COMMENTS" | jq -r '.[].body' 2>/dev/null)" || EXISTING=""
-  while IFS= read -r existing_body; do
-    if [[ "$existing_body" == "$BODY" ]]; then
-      echo "gh-pr-comment: body already present — skipping (idempotent)" >&2
-      exit 0
-    fi
-  done <<< "$EXISTING"
+  # Count exact-body matches within the fetched (recent) window.
+  MATCH_COUNT="$(printf '%s' "$RAW_COMMENTS" \
+    | jq -r --arg body "$BODY" '[ .[] | select(.body == $body) ] | length' 2>/dev/null)" || MATCH_COUNT=""
+  if [[ "$MATCH_COUNT" =~ ^[0-9]+$ && "$MATCH_COUNT" -gt 0 ]]; then
+    echo "gh-pr-comment: identical comment already posted within ${WINDOW_SEC}s — skipping (idempotent)" >&2
+    exit 0
+  fi
 fi
 
 "$GH" pr comment "$PR_NUMBER" -R "$REPO" --body "$BODY"

--- a/plugins/dev/skills/recovery-pass/SKILL.md
+++ b/plugins/dev/skills/recovery-pass/SKILL.md
@@ -580,6 +580,49 @@ governs deciding a human is genuinely needed and authoring the brief for them.
 > red-CI open PR with a deterministic fix (fix it, push, re-check), an abandoned/superseded open PR
 > (close it). Mechanically-resolvable ⇒ FIX; genuine-judgment ⇒ escalate.
 
+### PR-not-merged remediation playbook (CTL-1496)
+
+When the recovery-pass brief category is `pr-not-merged` (set by the Phase-2 classifier when
+`phase-teardown` failed with `failureReason: "pr_not_merged"`), follow this sub-playbook before
+the general Rubric Two logic. The brief already embeds the concrete blockers from the classify-time
+probe; re-probe live state at act-time to get the current picture:
+
+```bash
+# Re-probe live PR state (read-only; same seam as classifier)
+gh pr view --json number,state,mergeStateStatus,mergeable,statusCheckRollup
+```
+
+**Step 1 — CI branch** (failing required checks): for each failing check named in the brief:
+1. `gh run view --log-failed` to read the failure log.
+2. Fix the root cause in code (bounded by the existing attempts cap — see Rubric Two).
+3. `git add … && git commit && git push` to re-trigger CI.
+4. Re-probe after CI completes; if CLEAN, proceed to Step 3 (merge).
+
+**Step 2 — Review branch** (unresolved bot-review threads): for each unresolved bot thread:
+1. Read the thread body — understand the specific finding (file, line, concern).
+2. Address the actionable finding in code; commit.
+3. Resolve the thread via the `resolveReviewThread` GraphQL mutation (reuse
+   `orchestrate-resolve-fixed-threads`'s mutation or call
+   `/catalyst-dev:review-comments <PR> --headless`).
+4. Post `@codex review` via `plugins/dev/scripts/lib/gh-pr-comment.sh <PR> "@codex review" --idempotent`
+   to re-trigger the automated reviewer. Wait bounded (`catalyst-events wait-for`) for re-review.
+5. Escalate ONLY a finding that is a genuine judgment call (human `CHANGES_REQUESTED` or a design
+   decision you cannot resolve) — write the finding to `.review-escalations.jsonl` and use it as
+   the curated escalation brief (PR + thread linked, never the opaque `pr_not_merged` string).
+
+**Step 3 — Merge** (when the probe returns `mergeStateStatus: "CLEAN"`):
+- Run `gh pr view <n> --json mergeable,mergeStateStatus` to confirm.
+- Run the cluster fence guard: `"${PLUGIN_ROOT}/scripts/lib/cluster-fence-guard.sh" --phase recovery-pass --ticket <T>`.
+- Merge: `gh pr merge <n> --squash --delete-branch`. **NEVER `--admin` or force-merge past a
+  failing or pending check** — this is the load-bearing safety property (Rubric Two invariant).
+
+**Step 4 — Escalate** only when:
+- A human reviewer (not a bot) left `CHANGES_REQUESTED` → escalate with the reviewer's SPECIFIC
+  ask (file, line, and body), PR number linked. Never "Failure reason: pr_not_merged".
+- CI persistently red after 3 honest attempts at a genuine design incompatibility → decision
+  escalate naming the failing check and the incompatibility.
+- The PR was not found (no open PR for the ticket) → escalate with the specific reason.
+
 ### RUBRIC TWO — Finish-the-PR vs. escalate
 
 > When you anchor on a stuck PR, you are the senior engineer who unsticks it. Default to FINISHING it.

--- a/plugins/dev/skills/review-comments/SKILL.md
+++ b/plugins/dev/skills/review-comments/SKILL.md
@@ -84,38 +84,13 @@ Post this reply? [y/N]
 
 ## Non-interactive / headless mode (CTL-1496)
 
-When `CATALYST_PHASE` is set in the environment **or** the argument `--headless` is passed, this
-skill runs non-interactively — no stdin is available (e.g. a `claude --bg` recovery-pass worker).
-
-In headless mode:
-
-- **Addressable findings** (code change requested) → address in code + resolve the thread (same
-  GraphQL path as interactive mode). Unchanged.
-- **Disagreement / judgment-call findings** → the `Post this reply? [y/N]` prompt is **skipped**.
-  The thread is left unresolved and a structured record is appended to
-  `${ORCH_DIR:-.}/workers/${CATALYST_TICKET}/.review-escalations.jsonl`:
-  ```json
-  {"prNumber": 42, "threadId": "T_id", "path": "a.ts", "line": 5,
-   "finding": "…reviewer's body…", "why": "…why this is a judgment call…"}
-  ```
-  The caller (recovery-pass) reads `.review-escalations.jsonl` and escalates with these specific
-  findings linked — never the opaque `pr_not_merged` string.
-- **Approval / praise** → same as interactive (skip, no action).
-
-The interactive `[y/N]` path is preserved unchanged for sessions where `CATALYST_PHASE` is unset
-and `--headless` is not passed.
-
-Group related comments that affect the same file — make all changes to a file before moving on.
-
-## Non-interactive / headless mode (CTL-1496)
-
 When `CATALYST_PHASE` is set **or** `--headless` is passed as an argument, this skill runs in a
 mode safe for `claude --bg` workers (no stdin available):
 
 - **Addressable findings** (code change requested, clear fix) → address in code + resolve the
   thread via `resolveReviewThread` mutation (same as the interactive path). Unchanged.
-- **Disagreement / judgment-call findings** → the `Post this reply? [y/N]` prompt is
-  **SKIPPED**. Instead the thread is left unresolved and a structured record is appended to
+- **Disagreement / judgment-call findings** → the `Post this reply? [y/N]` prompt is **SKIPPED** in headless mode.
+  Instead, the thread is left unresolved and a structured record is appended to
   `${ORCH_DIR:-./workers/${CATALYST_TICKET:-unknown}}/.review-escalations.jsonl`:
   ```json
   {"prNumber":42,"threadId":"T1","path":"a.ts","line":5,"finding":"…","why":"…"}

--- a/plugins/dev/skills/review-comments/SKILL.md
+++ b/plugins/dev/skills/review-comments/SKILL.md
@@ -82,7 +82,49 @@ I think this would [concern]. Draft reply:
 Post this reply? [y/N]
 ```
 
+## Non-interactive / headless mode (CTL-1496)
+
+When `CATALYST_PHASE` is set in the environment **or** the argument `--headless` is passed, this
+skill runs non-interactively — no stdin is available (e.g. a `claude --bg` recovery-pass worker).
+
+In headless mode:
+
+- **Addressable findings** (code change requested) → address in code + resolve the thread (same
+  GraphQL path as interactive mode). Unchanged.
+- **Disagreement / judgment-call findings** → the `Post this reply? [y/N]` prompt is **skipped**.
+  The thread is left unresolved and a structured record is appended to
+  `${ORCH_DIR:-.}/workers/${CATALYST_TICKET}/.review-escalations.jsonl`:
+  ```json
+  {"prNumber": 42, "threadId": "T_id", "path": "a.ts", "line": 5,
+   "finding": "…reviewer's body…", "why": "…why this is a judgment call…"}
+  ```
+  The caller (recovery-pass) reads `.review-escalations.jsonl` and escalates with these specific
+  findings linked — never the opaque `pr_not_merged` string.
+- **Approval / praise** → same as interactive (skip, no action).
+
+The interactive `[y/N]` path is preserved unchanged for sessions where `CATALYST_PHASE` is unset
+and `--headless` is not passed.
+
 Group related comments that affect the same file — make all changes to a file before moving on.
+
+## Non-interactive / headless mode (CTL-1496)
+
+When `CATALYST_PHASE` is set **or** `--headless` is passed as an argument, this skill runs in a
+mode safe for `claude --bg` workers (no stdin available):
+
+- **Addressable findings** (code change requested, clear fix) → address in code + resolve the
+  thread via `resolveReviewThread` mutation (same as the interactive path). Unchanged.
+- **Disagreement / judgment-call findings** → the `Post this reply? [y/N]` prompt is
+  **SKIPPED**. Instead the thread is left unresolved and a structured record is appended to
+  `${ORCH_DIR:-./workers/${CATALYST_TICKET:-unknown}}/.review-escalations.jsonl`:
+  ```json
+  {"prNumber":42,"threadId":"T1","path":"a.ts","line":5,"finding":"…","why":"…"}
+  ```
+  The caller (recovery-pass worker) reads `.review-escalations.jsonl` to author a curated
+  escalation brief — one line per genuine judgment call — and escalates only those, with the
+  PR number and thread linked.
+- **Interactive path preserved** — when neither `CATALYST_PHASE` is set nor `--headless` is
+  passed, the existing `[y/N]` prompt behaviour is unchanged.
 
 ## Step 4: Commit and Push
 

--- a/plugins/dev/skills/review-comments/SKILL.md
+++ b/plugins/dev/skills/review-comments/SKILL.md
@@ -90,14 +90,18 @@ mode safe for `claude --bg` workers (no stdin available):
 - **Addressable findings** (code change requested, clear fix) → address in code + resolve the
   thread via `resolveReviewThread` mutation (same as the interactive path). Unchanged.
 - **Disagreement / judgment-call findings** → the `Post this reply? [y/N]` prompt is **SKIPPED** in headless mode.
-  Instead, the thread is left unresolved and a structured record is appended to
-  `${ORCH_DIR:-./workers/${CATALYST_TICKET:-unknown}}/.review-escalations.jsonl`:
+  Instead, the thread is left unresolved and a structured record is appended to the ticket's
+  worker directory under the orchestrator dir:
+  `${CATALYST_ORCHESTRATOR_DIR:-${ORCH_DIR:-.}}/workers/${CATALYST_TICKET:-unknown}/.review-escalations.jsonl`:
   ```json
   {"prNumber":42,"threadId":"T1","path":"a.ts","line":5,"finding":"…","why":"…"}
   ```
-  The caller (recovery-pass worker) reads `.review-escalations.jsonl` to author a curated
-  escalation brief — one line per genuine judgment call — and escalates only those, with the
-  PR number and thread linked.
+  (Resolve `CATALYST_ORCHESTRATOR_DIR` **first** — a `claude --bg` worker receives that var, not
+  `ORCH_DIR`, which is only exported inside the recovery-pass skill's own prelude. Keying off
+  `ORCH_DIR` alone wrote the record to `./workers/<ticket>` in the worktree, where the recovery-pass
+  caller could never find it — CTL-1496.) The caller (recovery-pass worker) reads
+  `.review-escalations.jsonl` from that same path to author a curated escalation brief — one line per
+  genuine judgment call — and escalates only those, with the PR number and thread linked.
 - **Interactive path preserved** — when neither `CATALYST_PHASE` is set nor `--headless` is
   passed, the existing `[y/N]` prompt behaviour is unchanged.
 


### PR DESCRIPTION
<!-- Auto-generated: 2026-07-22T09:42:00Z -->
<!-- Last updated: 2026-07-22T09:42:00Z -->
<!-- PR: #2689 -->
<!-- Previous commits: 5dec487ab,c3c5ab0a,3a8ac31b,5ea20f64,4af159cb,73a18f53,c364fcf7 -->

## Summary

When `phase-teardown` reports `pr_not_merged`, the scheduler's recovery pass (Pass 0r) previously
escalated every such failure to a human with an opaque "Failure reason: pr_not_merged" message —
regardless of whether the block was actually remediable by the fleet.

This PR adds a **live-state probe + classifier routing layer** (`CATALYST_RECOVERY_PASS=shadow|enforce`) so the fleet
autonomously fixes remediable blocks (failing CI checks, unresolved bot review threads) and escalates
only for genuine human gates (CHANGES_REQUESTED from a person, no open PR found).

### What changed

| Component | Change |
|---|---|
| `pr-block-probe.mjs` | New read-only probe: `gh pr list --head` + GraphQL `reviewThreads` + `reviewDecision` |
| `recovery-reasoning.mjs` | New `classifyPrNotMerged()` routing: fix / escalate / defer |
| `gh-pr-comment.sh` | New `--idempotent` flag — posts a re-review comment without duplicate spam |
| `recovery-pass/SKILL.md` | Updated classifier doc + `@codex review` re-trigger step |
| `review-comments/SKILL.md` | Headless operation (no interactive prompts when `CATALYST_PHASE` set) |
| `docs/architecture.md` | CTL-1496 architecture section (probe → classifier → worker dispatch) |
| `execution-core-tests.yml` | CI covers the new probe + reasoning test files |

## Changes Made

### `pr-block-probe.mjs` — read-only PR block probe (new file)

Exported `defaultProbePrBlock(ticket, { gh, repo, branch })` — injectable seam so the classifier
stays pure and testable. The real `gh` default wraps `spawnSync`; tests inject a fake routed by
argv shape.

**Key design decisions:**

- **Resolves the ticket's PR explicitly** — never by the daemon's cwd/current branch. The probe was
  previously inert in production: a bare `gh pr view` resolved whatever branch the daemon was on,
  not the ticket's PR → always escalating. Fixed by resolving via `--head <branch>` or
  `--search "<TICKET> in:title"`.
- **`reviewDecision` aggregate** — uses GitHub's aggregate verdict (latest review per required
  reviewer) instead of scanning raw review history, so a PR that was CHANGES_REQUESTED then
  re-APPROVED is not false-flagged by a stale entry.
- **Fail-closed GraphQL partial responses** — treats an unparseable or partial `reviewThreads`
  response as a probe failure → classifier defers (retry next tick), rather than silently hiding an
  unresolved human thread and routing to the autonomous fix path.
- **Bot attribution** — `isBotAuthor()` checks `__typename === "Bot"` or login ending in `[bot]`.

### `recovery-reasoning.mjs` — `classifyPrNotMerged` classifier (new export)

`classifyPrNotMerged(ticket, { probe, branch })` routes to one of three decisions:

| Condition | Decision |
|---|---|
| Probe throws | `defer` — transient GitHub outage, retry next tick |
| No open PR found | `escalate` — can't fix what isn't there |
| Human `CHANGES_REQUESTED` | `escalate` with specific reviewer ask |
| Failing required checks OR unresolved bot threads, no human CHANGES_REQUESTED | `fix` with `fix_class: "bounded-llm"` |

When `fix`: the brief embeds the concrete failing-check names and thread IDs so the recovery-pass
worker has a surgical, bounded brief — not a vague "something is blocking" signal.

### `gh-pr-comment.sh` — idempotent re-review request helper

`--idempotent` flag: posts a `@codex review` comment (or any `--body TEXT`) but checks for a
recent duplicate (within `--dedup-window-hrs`, default 24h) before posting, so re-dispatch after a
fix push doesn't spam the review thread.

- Explicitly fails CLOSED (non-zero exit) on `gh` fetch failure so callers know the comment was not
  posted — no silent swallow.

### E2E integration tests

- `recovery-pass-pr-not-merged.test.sh` — 5 scenarios covering the fix/escalate/defer/probe-throw
  paths with shell-injected `gh` fakes.
- `review-comments-headless.test.sh` — 4 scenarios exercising headless mode (no interactive
  prompts) when `CATALYST_PHASE` is set.
- `gh-pr-comment.test.sh` — 7 tests covering `--idempotent` dedup, normal post, and closed-on-failure.
- `pr-block-probe.test.mjs` — 13 unit tests (happy path, failing checks, bot threads, human threads,
  partial GraphQL, no PR found).
- `recovery-reasoning.test.mjs` — 162 tests across the full classifier matrix.

## How to Verify It

- [x] All CI checks pass (10/10 green at time of PR promotion)
- [x] `pr-block-probe.test.mjs` — 13/13 pass
- [x] `recovery-reasoning.test.mjs` — 162/162 pass (with `CATALYST_ORCHESTRATOR_DIR` unset)
- [x] `gh-pr-comment.test.sh` — 7/7 pass
- [x] `recovery-pass-pr-not-merged.test.sh` — 5/5 pass
- [x] `review-comments-headless.test.sh` — 4/4 pass
- [x] Regression risk score: 1/10 (verify phase verdict)
- [x] Shipped behind `CATALYST_RECOVERY_PASS` flag (off by default — no live behavior change)
- [ ] Shadow mode smoke test: set `CATALYST_RECOVERY_PASS=shadow`, let scheduler tick on a
      `pr_not_merged` recovery item, verify `recovery.would-fix` event emitted to event log

## Gating / Safety

The entire feature is gated behind `CATALYST_RECOVERY_PASS`:
- **unset / `off`** — current behavior, no change
- **`shadow`** — logs `recovery.would-fix` event but does NOT dispatch a worker
- **`enforce`** — dispatches the recovery-pass worker for `fix` decisions

## Related Issues

- Fixes https://linear.app/coalesce-labs/issue/CTL-1496
