### PR TITLE
fix(dev): CTL-1505 retry rebase against fresh origin/<base> before parking a source conflict

### DIFF
--- a/plugins/dev/scripts/lib/__tests__/worktree-rebase.test.sh
+++ b/plugins/dev/scripts/lib/__tests__/worktree-rebase.test.sh
@@ -768,6 +768,100 @@ else
   echo "  SKIP: escalation-explain.mjs or node not available"
 fi
 
+# ─── CTL-1505: transient source conflict cleared by a re-fetch retry ─────────
+# A source conflict is judged against origin/<base> as fetched at the top of
+# rebase_onto_base_classified. When main has since moved, that judgement is
+# STALE: rebasing onto a freshly-fetched base often applies cleanly. Before the
+# terminal rc=2 park, the classifier must abort, RE-FETCH origin/<base>, and
+# retry the rebase exactly once. This is the CTL-1504 regression.
+
+# ── 28. transient source conflict → re-fetch retry clears it → rc 0 ─────────
+echo "28. rebase_onto_base_classified transient source conflict → retry → rc 0"
+new_fixture t28
+advance_origin_main_conflict   # origin/main tip: shared.txt='upstream-edit' (conflicts)
+# git shim: on the 2nd `git fetch … main` (the CTL-1505 retry fetch), first push
+# a RESOLVING commit to origin (reverting shared.txt to base-line) with the REAL
+# git, then delegate. Simulates origin/main advancing between the initial fetch
+# (conflict) and the retry fetch (clean) inside one function call.
+mkdir -p "$SCRATCH/t28/shimbin"
+cat >"$SCRATCH/t28/shimbin/git" <<'SHIM'
+#!/usr/bin/env bash
+if [[ "$1" == "fetch" && "$*" == *main* ]]; then
+  __n=$(( $(cat "$T28_COUNTER" 2>/dev/null || echo 0) + 1 ))
+  echo "$__n" >"$T28_COUNTER"
+  if [[ "$__n" -ge 2 ]]; then
+    (
+      cd "$T28_UP" || exit 0
+      "$T28_REAL_GIT" checkout --quiet main
+      printf 'base-line\n' >shared.txt
+      "$T28_REAL_GIT" add -A
+      "$T28_REAL_GIT" commit --quiet -m "upstream resolves conflict (main advanced)"
+      "$T28_REAL_GIT" push --quiet origin main
+    ) >/dev/null 2>&1
+  fi
+fi
+exec "$T28_REAL_GIT" "$@"
+SHIM
+chmod +x "$SCRATCH/t28/shimbin/git"
+(
+  cd "$WORK"
+  printf 'local-edit\n' >shared.txt
+  git add -A && git commit --quiet -m "local conflicting edit"
+  ORIG_HEAD="$(git rev-parse HEAD)"
+  echo "$ORIG_HEAD" >"$SCRATCH/t28.orig"
+  # Capture REAL git BEFORE the shim shadows it on PATH.
+  export T28_REAL_GIT="$(command -v git)"
+  export T28_UP="$UP" T28_COUNTER="$SCRATCH/t28/fetchcount"
+  export PATH="$SCRATCH/t28/shimbin:$PATH"
+  hash -r 2>/dev/null || true
+  rebase_onto_base_classified "main"
+  echo "$?" >"$SCRATCH/t28.rc"
+  git log --oneline >"$SCRATCH/t28.log"
+  cat shared.txt >"$SCRATCH/t28.shared"
+  [[ -d .git/rebase-merge ]] && echo leftover >"$SCRATCH/t28.rebasedir" || echo clean >"$SCRATCH/t28.rebasedir"
+  git status --porcelain >"$SCRATCH/t28.status"
+)
+assert_eq "0" "$(cat "$SCRATCH/t28.rc")" "transient source conflict cleared by re-fetch retry → rc 0"
+assert_eq "clean" "$(cat "$SCRATCH/t28.rebasedir")" "retry-clean: no rebase-merge leftover"
+assert_eq "" "$(cat "$SCRATCH/t28.status")" "retry-clean: working tree clean (noise stash popped)"
+assert_eq "local-edit" "$(cat "$SCRATCH/t28.shared")" "retry-clean: local edit applied onto advanced base"
+T28_WORK_IN_LOG="no"; grep -q "local conflicting edit" "$SCRATCH/t28.log" && T28_WORK_IN_LOG="yes"
+assert_eq "yes" "$T28_WORK_IN_LOG" "retry-clean: local work commit retained"
+# The auto-rebased(refetch-retry) event is the distinct, observable retry signal.
+assert_eq "refetch-retry" \
+  "$(jq -r '.body.payload.strategy' <<<"$(last_telem_line)")" \
+  "retry-clean: auto-rebased(refetch-retry) event emitted"
+
+# ── 29. persistent source conflict → retry still conflicts → rc 2, HEAD restored
+# Guards boundedness (one retry, no loop) and that the terminal reason stays the
+# routing-recognized source_conflict_ctl708_unavailable (downstream recovery
+# keys EXACTLY on it — see catB-force-with-lease.mjs / STALL_CATEGORY_MAP).
+echo "29. persistent source conflict → retry still conflicts → rc 2 (bounded)"
+new_fixture t29
+advance_origin_main_conflict
+(
+  cd "$WORK"
+  printf 'local-edit\n' >shared.txt
+  git add -A && git commit --quiet -m "local conflicting edit"
+  ORIG_HEAD="$(git rev-parse HEAD)"
+  echo "$ORIG_HEAD" >"$SCRATCH/t29.orig"
+  rebase_onto_base_classified "main"
+  echo "$?" >"$SCRATCH/t29.rc"
+  echo "${REBASE_LAST_STALL_REASON:-}" >"$SCRATCH/t29.reason"
+  git rev-parse HEAD >"$SCRATCH/t29.head"
+  [[ -d .git/rebase-merge ]] && echo leftover >"$SCRATCH/t29.rebasedir" || echo clean >"$SCRATCH/t29.rebasedir"
+  git status --porcelain >"$SCRATCH/t29.status"
+)
+assert_eq "2" "$(cat "$SCRATCH/t29.rc")" "persistent source conflict survives retry → rc 2"
+assert_eq "source_conflict_ctl708_unavailable" "$(cat "$SCRATCH/t29.reason")" \
+  "persistent: terminal reason stays routing-recognized (not renamed)"
+assert_eq "$(cat "$SCRATCH/t29.orig")" "$(cat "$SCRATCH/t29.head")" "persistent: HEAD restored after retry+abort"
+assert_eq "clean" "$(cat "$SCRATCH/t29.rebasedir")" "persistent: no rebase-merge leftover after retry"
+assert_eq "" "$(cat "$SCRATCH/t29.status")" "persistent: working tree clean after retry+abort"
+STALL29="$(last_telem_line)"
+assert_eq "source_conflict_ctl708_unavailable" "$(jq -r '.body.payload.reason' <<<"$STALL29")" \
+  "persistent: stalled event reason recorded (observable park)"
+
 echo
 echo "results: $PASSES passed, $FAILURES failed"
 [ $FAILURES -eq 0 ]

--- a/plugins/dev/scripts/lib/rebase-telemetry.sh
+++ b/plugins/dev/scripts/lib/rebase-telemetry.sh
@@ -71,7 +71,10 @@ emit_stale_base_detected() {
 }
 
 # emit_auto_rebased — INFO: rebase succeeded (clean or additive auto-resolve).
-# --orch <id>  --ticket <key>  --phase <name>  --strategy <clean|additive|recreate>
+# --orch <id>  --ticket <key>  --phase <name>
+# --strategy <clean|additive|recreate|refetch-retry>
+#   refetch-retry (CTL-1505): a source conflict cleared after aborting and
+#   rebasing once more onto a freshly-fetched origin/<base>.
 emit_auto_rebased() {
   local orch="" ticket="" phase="" strategy="clean"
   while [[ $# -gt 0 ]]; do

--- a/plugins/dev/scripts/lib/worktree-rebase.sh
+++ b/plugins/dev/scripts/lib/worktree-rebase.sh
@@ -275,10 +275,16 @@ _stall_and_return() {
 # Like rebase_onto_base but, on a conflict, categorizes the conflicted files
 # and either auto-resolves (tests/noise only) or returns a typed sentinel.
 #
+# CTL-1505: a source conflict is judged against a base that may already be stale,
+# so before the terminal rc=2 park it aborts, RE-FETCHES origin/<base>, and
+# retries the rebase ONCE (bounded) — a fresh base often clears a transient
+# conflict; a clean retry returns 0 (strategy=refetch-retry).
+#
 # Return codes:
-#   0 — clean or additively auto-resolved
+#   0 — clean, additively auto-resolved, or cleared by the CTL-1505 re-fetch retry
 #   1 — fetch / other pre-rebase failure (proceed un-rebased)
-#   2 — terminal source conflict (CTL-708 unavailable) or continue failed
+#   2 — terminal source conflict (persists after the re-fetch retry; CTL-708
+#       arbitrary-conflict auto-merge still unavailable) or continue failed
 #   3 — thoughts/** conflict (symlink safety)
 rebase_onto_base_classified() {
   local base="$1" marker
@@ -343,9 +349,41 @@ rebase_onto_base_classified() {
     return
   fi
 
-  # Source files → try CTL-708; stub always returns unavailable → stall.
+  # Source files → try CTL-708; stub always returns unavailable.
   if [[ $sc -gt 0 ]]; then
     if ! ctl708_escalate "${RT_SOURCE[@]+"${RT_SOURCE[@]}"}"; then
+      # CTL-1505: the conflict above was judged ONCE against origin/<base> as
+      # fetched at the top of this function, which can already be stale — main
+      # frequently moves between dispatch and this point, so a "source conflict"
+      # is often TRANSIENT (the live CTL-1504 failure rebased cleanly minutes
+      # later, on a base that had since advanced). Before parking, abort this
+      # attempt, RE-FETCH origin/<base>, and retry the rebase EXACTLY ONCE. A
+      # fresh base that no longer conflicts → proceed as a normal (clean) rebase.
+      # Bounded: one retry, no loop, no recursion. Anything still conflicting —
+      # or a transient re-fetch failure — falls through to the unchanged terminal
+      # stall below. `git rebase --abort` drops the first attempt so the retry
+      # starts from the same clean, noise-stashed pre-rebase state.
+      git rebase --abort 2>/dev/null || true
+      if git fetch --quiet origin "$base" 2>/dev/null &&
+        git rebase --quiet "origin/${base}" 2>/dev/null; then
+        noise_stash_pop "$marker"
+        emit_auto_rebased \
+          --orch     "${ORCH_ID:-}" \
+          --ticket   "${TICKET:-}" \
+          --phase    "${PHASE:-}" \
+          --strategy refetch-retry 2>/dev/null || true
+        return 0
+      fi
+      # Retry did not clear it → a real, persistent source conflict (or the
+      # re-fetch failed). Park with the SAME routing-recognized reason: the
+      # downstream recovery machinery keys EXACTLY on this string
+      # (STALL_CATEGORY_MAP → force-push-if-clean, catB-force-with-lease, the
+      # source-conflict act seam), with no normalizer — renaming it here would
+      # silently route the park to unknown/escalate. _stall_and_return aborts any
+      # rebase the retry left mid-flight and pops the noise stash, restoring
+      # HEAD + the working tree either way, and persists+emits the typed reason
+      # (REBASE_LAST_STALL_REASON + rebase-conflict-stalled) so the park is
+      # observable, not silent.
       _stall_and_return "$marker" source_conflict_ctl708_unavailable 2
       return
     fi


### PR DESCRIPTION
Implements CTL-1505 — the delegate off-worker-rebase gap surfaced by CTL-1504.

## Problem
When a build phase's dispatch-time rebase (CTL-707) hits a source conflict, it's judged **once** against `origin/<base>` as fetched at function entry — already stale, since `main` moves between dispatch and the rebase. So a "real source conflict" is frequently **transient** (CTL-1504's verify-phase park rebased cleanly minutes later on an advanced base), yet CTL-708 auto-resolve is a permanent stub, so the ticket parks `needs-human` with no self-heal.

## Fix
In `worktree-rebase.sh:rebase_onto_base_classified`, before the terminal `rc=2` park: `git rebase --abort` → **re-fetch `origin/<base>`** → **retry the rebase exactly once**. A fresh base that no longer conflicts proceeds as a clean rebase (emits `auto-rebased strategy=refetch-retry`); a genuinely-persistent conflict falls through to the unchanged terminal stall. **Bounded — one retry, no loop**; `rc=1`/`rc=3` paths untouched.

Safety: the park reason `source_conflict_ctl708_unavailable` is **preserved** (≥5 recovery consumers exact-match it for routing — `STALL_CATEGORY_MAP` → force-push-if-clean, catB-force-with-lease, the source-conflict act seam — renaming would silently route the park to unknown/escalate).

## Tests
122 pass (worktree-rebase, incl. new transient-clears-on-retry + persistent-still-stalls cases) + 23 pass (rebase-telemetry). Full CTL-708 arbitrary-conflict auto-resolution stays a scoped follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JjWhWmAg9SpQbhgicT4Lo5