### PR TITLE
feat(dev): CTL-1500 reap leaked agent-browser Chrome + idle-timeout + setup-tooling ownership

### DIFF
--- a/docs/orphan-sweep.md
+++ b/docs/orphan-sweep.md
@@ -12,7 +12,7 @@ orphaned resources on unattended hosts. It complements the execution-core real-t
 | 2 | Done-ticket worktrees | Worktrees for Linear "Done" tickets not cleaned by `/teardown` | `worktree-presweep.sh` stops sessions first; `git status --porcelain` must be clean; NEVER removes dirty worktrees |
 | 3 | Stale phase signals | `status=running` signals whose `bg_job_id` is dead and >30 min old | Flip ONLY if `bg_job_id` absent from `claude agents --json`; never touch interactive-kind or terminal statuses |
 | 4 | Trunk repo cache dirs | `~/.cache/trunk/repos` entries with mtime >30 days | mtime only; no live-process guard needed |
-| 5 | Leaked agent-browser browsers | agent-browser's persistent daemon + its "Chrome for Testing" / `chrome-headless-shell` browser that outlived the CLI — reaped when a browser subtree is CPU-pegged (runaway) or older than a TTL, plus stale `~/.agent-browser/<session>.sock\|.pid` housekeeping (CTL-1500) | Target ONLY the Playwright browser under `ms-playwright/` (bundle `com.google.chrome.for.testing`) validated against the `agent-browser …/daemon.js` owner; any command under `/Applications/` is HARD-EXCLUDED so the user's personal `/Applications/Google Chrome.app` is NEVER touched |
+| 5 | Leaked agent-browser browsers | agent-browser's persistent daemon + its "Chrome for Testing" / `chrome-headless-shell` browser that outlived the CLI — reaped when a browser subtree is CPU-pegged (runaway) or older than a TTL, plus stale `~/.agent-browser/<session>.sock\|.pid` housekeeping (CTL-1500) | Every command under `/Applications/` is HARD-EXCLUDED so the personal `/Applications/Google Chrome.app` is NEVER touched. A browser with an agent-browser-SPECIFIC anchor (`~/.agent-browser/`, `agent-browser-chrome-`) is reaped on its own; a browser matched only by the SHARED Playwright markers (`ms-playwright/`, `playwright_chromiumdev_profile`) is reaped ONLY when a live agent-browser daemon (`…/node_modules/agent-browser/{bin,dist}/…`) owns it, so an unrelated Playwright job is never killed |
 
 Telemetry: one `emit-otel-event.sh` call per reclaimed resource (`catalyst.sweep.reclaim`, vector `agent_browser` for #5), fail-open.
 
@@ -29,10 +29,12 @@ idle timeout). Knobs (env, all with production defaults):
 | `SWEEP_AB_TTL_SECS` | `14400` | absolute leaked-browser age cap (4h) |
 | `SWEEP_AB_SOCKET_DIR` | `$AGENT_BROWSER_SOCKET_DIR` → `$XDG_RUNTIME_DIR/agent-browser` → `~/.agent-browser` | sock/pid dir |
 
-Reap = graceful `kill` of the daemon (its `SIGTERM` handler closes the browser) plus
-the root browser process (cascades helper children), then removal of that session's
-`.sock`/`.pid`. Complements the forward fix: phase workers now launch with
-`AGENT_BROWSER_IDLE_TIMEOUT_MS` set so newer agent-browser self-shuts-down when idle.
+Reap = graceful `kill` of the owning daemon (its `SIGTERM` handler closes the browser)
+plus the root browser process (cascades helper children), then removal of that
+session's `.sock`/`.pid`. A shared-Playwright-marker browser with no live agent-browser
+daemon owner is left alone (it may be an unrelated Playwright job). Complements the
+forward fix: phase workers now launch with `AGENT_BROWSER_IDLE_TIMEOUT_MS` set so newer
+agent-browser self-shuts-down when idle.
 
 ## Installation
 

--- a/docs/orphan-sweep.md
+++ b/docs/orphan-sweep.md
@@ -4,7 +4,7 @@
 orphaned resources on unattended hosts. It complements the execution-core real-time reaper
 (CTL-657) — it acts whether or not the orchestrator daemon is alive.
 
-## What It Reclaims (Four Vectors)
+## What It Reclaims (Five Vectors)
 
 | # | Vector | What | Safety gate |
 |---|--------|------|-------------|
@@ -12,8 +12,27 @@ orphaned resources on unattended hosts. It complements the execution-core real-t
 | 2 | Done-ticket worktrees | Worktrees for Linear "Done" tickets not cleaned by `/teardown` | `worktree-presweep.sh` stops sessions first; `git status --porcelain` must be clean; NEVER removes dirty worktrees |
 | 3 | Stale phase signals | `status=running` signals whose `bg_job_id` is dead and >30 min old | Flip ONLY if `bg_job_id` absent from `claude agents --json`; never touch interactive-kind or terminal statuses |
 | 4 | Trunk repo cache dirs | `~/.cache/trunk/repos` entries with mtime >30 days | mtime only; no live-process guard needed |
+| 5 | Leaked agent-browser browsers | agent-browser's persistent daemon + its "Chrome for Testing" / `chrome-headless-shell` browser that outlived the CLI — reaped when a browser subtree is CPU-pegged (runaway) or older than a TTL, plus stale `~/.agent-browser/<session>.sock\|.pid` housekeeping (CTL-1500) | Target ONLY the Playwright browser under `ms-playwright/` (bundle `com.google.chrome.for.testing`) validated against the `agent-browser …/daemon.js` owner; any command under `/Applications/` is HARD-EXCLUDED so the user's personal `/Applications/Google Chrome.app` is NEVER touched |
 
-Telemetry: one `emit-otel-event.sh` call per reclaimed resource (`catalyst.sweep.reclaim`), fail-open.
+Telemetry: one `emit-otel-event.sh` call per reclaimed resource (`catalyst.sweep.reclaim`, vector `agent_browser` for #5), fail-open.
+
+### Vector 5 tuning (agent-browser reaper)
+
+Version-agnostic backstop for the CTL-1500 leak (old agent-browser builds have no
+idle timeout). Knobs (env, all with production defaults):
+
+| Env | Default | Meaning |
+|-----|---------|---------|
+| `SWEEP_AB_ENABLED` | `1` | reaper on/off |
+| `SWEEP_AB_CPU_THRESHOLD` | `30` | runaway browser %CPU threshold |
+| `SWEEP_AB_MIN_AGE_SECS` | `600` | min browser age for the runaway rule (guards short automation bursts) |
+| `SWEEP_AB_TTL_SECS` | `14400` | absolute leaked-browser age cap (4h) |
+| `SWEEP_AB_SOCKET_DIR` | `$AGENT_BROWSER_SOCKET_DIR` → `$XDG_RUNTIME_DIR/agent-browser` → `~/.agent-browser` | sock/pid dir |
+
+Reap = graceful `kill` of the daemon (its `SIGTERM` handler closes the browser) plus
+the root browser process (cascades helper children), then removal of that session's
+`.sock`/`.pid`. Complements the forward fix: phase workers now launch with
+`AGENT_BROWSER_IDLE_TIMEOUT_MS` set so newer agent-browser self-shuts-down when idle.
 
 ## Installation
 

--- a/plugins/dev/scripts/__tests__/orphan-sweep.test.sh
+++ b/plugins/dev/scripts/__tests__/orphan-sweep.test.sh
@@ -1483,18 +1483,35 @@ run "T68a: young browser NOT killed (5100/5101 absent from kill log)" \
 run "T68b: keep logged for young browser" \
   bash -c "bash '$SWEEP' 2>&1 | grep -qi 'keep agent-browser'"
 
-# ── T69: orphaned old idle browser (daemon dead, low CPU, age>=TTL) → TTL reap ─
-# 0.9.x ms-playwright root, reparented to init (ppid=1) → reap root only, no daemon.
+# ── T69: 0.9.x leak WITH a live daemon (dist/ topology) → daemon+root reaped ──
+# The 0.9.x ms-playwright browser matches only the SHARED Playwright markers, so it
+# is reaped BECAUSE a live agent-browser daemon owns it. That daemon lives under
+# dist/ (not bin/) — this also proves _is_agent_browser_daemon_cmd matches the 0.9.x
+# `dist/daemon.js` topology (CTL-1500 review P2).
 _ab_clear
+AB_DAEMON_09X_CMD="/opt/homebrew/opt/node/bin/node /Users/x/.npm-global/lib/node_modules/agent-browser/dist/daemon.js"
 export AB_CFT="5201"
-export AB_CMD_5201="$AB_PLAYWRIGHT_ROOT_CMD"; export AB_CPU_5201="0"; export AB_ETIME_5201="05-00:00:00"; export AB_PPID_5201="1"
+export AB_CMD_5201="$AB_PLAYWRIGHT_ROOT_CMD"; export AB_CPU_5201="0"; export AB_ETIME_5201="05-00:00:00"; export AB_PPID_5201="5200"
+export AB_CMD_5200="$AB_DAEMON_09X_CMD"; export AB_PPID_5200="1"
+rm -f "$KILL_LOG"
+run "T69: 0.9.x leak-with-daemon sweep exits 0" bash "$SWEEP"
+run "T69a: TTL reap kills root 5201" bash -c "grep -q '5201' '${KILL_LOG}'"
+run "T69b: 0.9.x dist/ daemon 5200 recognized + killed (P2)" bash -c "grep -q '5200' '${KILL_LOG}'"
+
+# ── T69safety: orphaned SHARED-Playwright browser, NO agent-browser daemon → KEPT ─
+# A ms-playwright / playwright_chromiumdev_profile browser reparented to init with no
+# agent-browser-specific anchor could be an UNRELATED Playwright job — never reap it
+# (CTL-1500 review P1). CPU-pegged + ancient so only the ownership gate spares it.
+_ab_clear
+export AB_CFT="5211"
+export AB_CMD_5211="$AB_PLAYWRIGHT_ROOT_CMD"; export AB_CPU_5211="99"; export AB_ETIME_5211="05-00:00:00"; export AB_PPID_5211="1"
 export AB_CMD_1=""   # init has no agent-browser-daemon command
 rm -f "$KILL_LOG"
-run "T69: orphaned old browser sweep exits 0" bash "$SWEEP"
-run "T69a: TTL reap kills orphaned root 5201" bash -c "grep -q '5201' '${KILL_LOG}'"
-run "T69b: no daemon (init pid 1) killed" bash -c "! grep -qx '1' '${KILL_LOG}' 2>/dev/null; true"
-run "T69c: orphan reason logged" \
-  bash -c "bash '$SWEEP' 2>&1 | grep -qi 'orphaned'"
+run "T69safety: shared-playwright-no-owner sweep exits 0" bash "$SWEEP"
+run "T69safety-a: unowned shared-playwright root 5211 NEVER killed (P1)" \
+  bash -c "! grep -q '5211' '${KILL_LOG}' 2>/dev/null; true"
+run "T69safety-b: 'no agent-browser owner' keep logged" \
+  bash -c "bash '$SWEEP' 2>&1 | grep -qi 'no agent-browser owner'"
 
 # ── T70: SAFETY — /Applications personal Chrome & unowned CfT are NEVER targets ─
 # 5302: personal Chrome root (no 'for Testing') → rejected by browser-sig.

--- a/plugins/dev/scripts/__tests__/orphan-sweep.test.sh
+++ b/plugins/dev/scripts/__tests__/orphan-sweep.test.sh
@@ -21,6 +21,10 @@ MOCKBIN="${SCRATCH}/bin"
 mkdir -p "$MOCKBIN"
 export PATH="${MOCKBIN}:${PATH}"
 export SWEEP_RUN_ID="testrun"
+# CTL-1500: keep the agent-browser reaper (vector 5) inert for all pre-existing
+# phases so their fixed pgrep/ps mocks (or the real host) can't trip it. The
+# dedicated Phase 10 turns it back on with fully-mocked pgrep/ps/kill.
+export SWEEP_AB_ENABLED=0
 
 # ─── harness ────────────────────────────────────────────────────────────────
 
@@ -1352,6 +1356,213 @@ run "T66: worktree.sweep.completed emitted exactly once" \
 rm -f "$MOCKBIN/git"
 rm -f "$MOCKBIN/pmset"
 rm -f "$MOCKBIN/worktree-presweep.sh"
+
+# ─── Phase 10: vector 5 — leaked agent-browser reaper (CTL-1500, T67-T74) ────
+#
+# Hermetic: pgrep/ps/kill are mocked so NO real process is ever signalled. The
+# agent-browser browser/daemon topology is described entirely via AB_* env vars.
+# The reaper is browser-centric and version-agnostic: it enumerates browser roots
+# via `pgrep -f "Chrome for Testing"` / `pgrep -f "chrome-headless-shell"`, so the
+# mock returns those matches (root + helpers) and the reaper's own validation must
+# filter to true roots and reject helpers / crashpad / personal /Applications Chrome.
+
+# Dispatching pgrep mock: browser-sig patterns → $AB_CFT / $AB_HS; -P → children.
+cat > "$MOCKBIN/pgrep" <<'EOF'
+#!/usr/bin/env bash
+if [[ "${1:-}" == "-f" ]]; then
+  case "${2:-}" in
+    *"Chrome for Testing"*)     printf '%s\n' ${AB_CFT:-} ;;
+    *"chrome-headless-shell"*)  printf '%s\n' ${AB_HS:-} ;;
+    *) : ;;   # bun run|turbo|node etc → no match
+  esac
+elif [[ "${1:-}" == "-P" ]]; then
+  eval "printf '%s\n' \${AB_CHILDREN_${2}:-}"
+fi
+exit 0
+EOF
+chmod +x "$MOCKBIN/pgrep"
+
+# ps mock: `-o <fmt>= -p <pid>` for command=/pcpu=/etime=/ppid= via AB_<F>_<pid>.
+cat > "$MOCKBIN/ps" <<'EOF'
+#!/usr/bin/env bash
+fmt=""; pid=""
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -o) fmt="$2"; shift 2 ;;
+    -p) pid="$2"; shift 2 ;;
+    *)  shift ;;
+  esac
+done
+case "$fmt" in
+  command=) eval "printf '%s\n' \"\${AB_CMD_${pid}:-}\"" ;;
+  pcpu=)    eval "printf '%s\n' \"\${AB_CPU_${pid}:-}\"" ;;
+  etime=)   eval "printf '%s\n' \"\${AB_ETIME_${pid}:-}\"" ;;
+  ppid=)    eval "printf '%s\n' \"\${AB_PPID_${pid}:-}\"" ;;
+esac
+exit 0
+EOF
+chmod +x "$MOCKBIN/ps"
+
+# kill mock records signalled pids (env kill resolves to PATH; kill -0 stays builtin).
+cat > "$MOCKBIN/kill" <<'EOF'
+#!/usr/bin/env bash
+echo "$@" >> "${KILL_LOG}"
+EOF
+chmod +x "$MOCKBIN/kill"
+
+# claude mock: no active agents (worktree/signal vectors stay inert).
+cat > "$MOCKBIN/claude" <<'EOF'
+#!/usr/bin/env bash
+if [[ "${1:-}" == "agents" ]]; then echo "[]"; fi
+EOF
+chmod +x "$MOCKBIN/claude"
+
+AB_SOCKDIR="${SCRATCH}/ab-sock"
+mkdir -p "$AB_SOCKDIR"
+
+# Phase-wide env: reaper ON, all other vectors pointed at empty/nonexistent roots.
+export SWEEP_AB_ENABLED=1
+export SWEEP_AB_SOCKET_DIR="$AB_SOCKDIR"
+export SWEEP_TRUNK_CACHE_DIR="${SCRATCH}/none-trunk"
+export SWEEP_WORKERS_GLOB_ROOT="/nonexistent-ab"
+export SWEEP_WT_ROOT="/nonexistent-ab"
+export SWEEP_PROJECT_CLAUDE_WT="/nonexistent-ab"
+export SWEEP_INCLUDE_GLOBAL_CLAUDE_WT=0
+export SWEEP_FORCE_POWER=ac
+# defaults: CPU_THRESHOLD=30 MIN_AGE=600 TTL=14400
+
+# Ground-truth-derived command lines. 0.3x-style root browser (~/.agent-browser +
+# agent-browser-chrome- user-data-dir) and a helper renderer; a 0.9.x-style
+# ms-playwright root; the compiled-daemon command; and personal /Applications Chrome.
+AB_ROOT_CMD="/Users/x/.agent-browser/browsers/chrome-151/Google Chrome for Testing.app/Contents/MacOS/Google Chrome for Testing --headless=new --user-data-dir=/var/folders/T/agent-browser-chrome-uuid --window-size=1280,720"
+AB_RENDERER_CMD="/Users/x/.agent-browser/browsers/chrome-151/Google Chrome for Testing.app/Contents/Frameworks/Google Chrome for Testing Framework.framework/Versions/151/Helpers/Google Chrome for Testing Helper (Renderer).app/Contents/MacOS/Google Chrome for Testing Helper (Renderer) --type=renderer --user-data-dir=/var/folders/T/agent-browser-chrome-uuid"
+AB_CRASHPAD_CMD="/Users/x/.agent-browser/browsers/chrome-151/Google Chrome for Testing.app/Contents/Frameworks/Google Chrome for Testing Framework.framework/Versions/151/Helpers/chrome_crashpad_handler --monitor-self --database=/Users/x/Library/Application Support/Google/Chrome for Testing/Crashpad"
+AB_PLAYWRIGHT_ROOT_CMD="/Users/x/Library/Caches/ms-playwright/chromium-1208/chrome-mac-arm64/Google Chrome for Testing.app/Contents/MacOS/Google Chrome for Testing --user-data-dir=/var/folders/T/playwright_chromiumdev_profile-a"
+AB_DAEMON_CMD="/opt/homebrew/Cellar/agent-browser/0.32.4/libexec/lib/node_modules/agent-browser/bin/agent-browser-darwin-arm64"
+PERSONAL_CHROME_ROOT_CMD="/Applications/Google Chrome.app/Contents/MacOS/Google Chrome"
+PERSONAL_CHROME_HELPER_CMD="/Applications/Google Chrome.app/Contents/Frameworks/Google Chrome Framework.framework/Versions/149/Helpers/Google Chrome Helper (Renderer).app/Contents/MacOS/Google Chrome Helper (Renderer) --type=renderer"
+
+_ab_clear() {
+  # unset all AB_* topology vars so scenarios don't leak into each other
+  unset "${!AB_CFT@}" "${!AB_HS@}" "${!AB_CMD_@}" "${!AB_CPU_@}" "${!AB_ETIME_@}" "${!AB_PPID_@}" "${!AB_CHILDREN_@}" 2>/dev/null || true
+  unset AB_CFT AB_HS 2>/dev/null || true
+}
+
+# ── T67: runaway browser (renderer CPU-pegged, age>min) → daemon+root reaped ──
+# pgrep 'Chrome for Testing' returns root(5001)+helper(5002); only 5001 is a root.
+_ab_clear
+export AB_CFT="5001 5002"
+export AB_CMD_5001="$AB_ROOT_CMD"; export AB_CPU_5001="1"; export AB_ETIME_5001="20:00"; export AB_PPID_5001="5000"
+export AB_CHILDREN_5001="5002"
+export AB_CMD_5002="$AB_RENDERER_CMD"; export AB_CPU_5002="96"; export AB_ETIME_5002="19:50"; export AB_PPID_5002="5001"
+export AB_CMD_5000="$AB_DAEMON_CMD"; export AB_PPID_5000="1"
+rm -f "$KILL_LOG" "$SCRATCH_OTEL_LOG"
+echo "5000" > "$AB_SOCKDIR/probe.pid"; : > "$AB_SOCKDIR/probe.sock"
+
+run "T67: runaway browser sweep exits 0" bash "$SWEEP"
+run "T67a: owning daemon pid 5000 killed" bash -c "grep -q '5000' '${KILL_LOG}'"
+run "T67b: root browser pid 5001 killed" bash -c "grep -q '5001' '${KILL_LOG}'"
+run "T67c: helper 5002 NOT killed directly (cascades; not a root)" \
+  bash -c "! grep -q '5002' '${KILL_LOG}' 2>/dev/null; true"
+run "T67d: emits agent_browser reclaim vector" \
+  bash -c "grep -q 'agent_browser' '${SCRATCH_OTEL_LOG}'"
+run "T67e: reaped session sock/pid removed" \
+  bash -c "! test -e '${AB_SOCKDIR}/probe.pid' && ! test -e '${AB_SOCKDIR}/probe.sock'"
+
+# ── T68: young browser, even CPU-pegged → KEPT (min-age guards short bursts) ──
+_ab_clear
+export AB_CFT="5101 5102"
+export AB_CMD_5101="$AB_ROOT_CMD"; export AB_CPU_5101="1"; export AB_ETIME_5101="00:30"; export AB_PPID_5101="5100"
+export AB_CHILDREN_5101="5102"
+export AB_CMD_5102="$AB_RENDERER_CMD"; export AB_CPU_5102="99"; export AB_ETIME_5102="00:20"; export AB_PPID_5102="5101"
+export AB_CMD_5100="$AB_DAEMON_CMD"; export AB_PPID_5100="1"
+rm -f "$KILL_LOG"
+run "T68: young pegged browser sweep exits 0" bash "$SWEEP"
+run "T68a: young browser NOT killed (5100/5101 absent from kill log)" \
+  bash -c "! grep -qE '5100|5101' '${KILL_LOG}' 2>/dev/null; true"
+run "T68b: keep logged for young browser" \
+  bash -c "bash '$SWEEP' 2>&1 | grep -qi 'keep agent-browser'"
+
+# ── T69: orphaned old idle browser (daemon dead, low CPU, age>=TTL) → TTL reap ─
+# 0.9.x ms-playwright root, reparented to init (ppid=1) → reap root only, no daemon.
+_ab_clear
+export AB_CFT="5201"
+export AB_CMD_5201="$AB_PLAYWRIGHT_ROOT_CMD"; export AB_CPU_5201="0"; export AB_ETIME_5201="05-00:00:00"; export AB_PPID_5201="1"
+export AB_CMD_1=""   # init has no agent-browser-daemon command
+rm -f "$KILL_LOG"
+run "T69: orphaned old browser sweep exits 0" bash "$SWEEP"
+run "T69a: TTL reap kills orphaned root 5201" bash -c "grep -q '5201' '${KILL_LOG}'"
+run "T69b: no daemon (init pid 1) killed" bash -c "! grep -qx '1' '${KILL_LOG}' 2>/dev/null; true"
+run "T69c: orphan reason logged" \
+  bash -c "bash '$SWEEP' 2>&1 | grep -qi 'orphaned'"
+
+# ── T70: SAFETY — /Applications personal Chrome & unowned CfT are NEVER targets ─
+# 5302: personal Chrome root (no 'for Testing') → rejected by browser-sig.
+# 5303: personal Chrome renderer under /Applications WITH 'for Testing' forced in →
+#       rejected by the /Applications hard-exclude.
+# 5304: a "Chrome for Testing" root with NO agent-browser/Playwright ownership
+#       anchor (a human's manual run) → rejected by the ownership requirement.
+# All CPU-pegged + ancient so ONLY the safety gates keep them alive.
+_ab_clear
+export AB_CFT="5302 5303 5304"
+export AB_CMD_5302="$PERSONAL_CHROME_ROOT_CMD"; export AB_CPU_5302="99"; export AB_ETIME_5302="38-00:00:00"; export AB_PPID_5302="1"
+export AB_CMD_5303="/Applications/Google Chrome.app/Contents/MacOS/Google Chrome for Testing Helper (Renderer) --type=renderer"; export AB_CPU_5303="99"; export AB_ETIME_5303="38-00:00:00"; export AB_PPID_5303="1"
+export AB_CMD_5304="/opt/local/Google Chrome for Testing.app/Contents/MacOS/Google Chrome for Testing --user-data-dir=/tmp/manual"; export AB_CPU_5304="99"; export AB_ETIME_5304="38-00:00:00"; export AB_PPID_5304="1"
+rm -f "$KILL_LOG"
+run "T70: safety-scenario sweep exits 0" bash "$SWEEP"
+run "T70a: personal Chrome root 5302 NEVER killed (no 'for Testing')" \
+  bash -c "! grep -q '5302' '${KILL_LOG}' 2>/dev/null; true"
+run "T70b: /Applications 'for Testing' 5303 NEVER killed (app-bundle hard-exclude)" \
+  bash -c "! grep -q '5303' '${KILL_LOG}' 2>/dev/null; true"
+run "T70c: unowned manual CfT 5304 NEVER killed (no ownership anchor)" \
+  bash -c "! grep -q '5304' '${KILL_LOG}' 2>/dev/null; true"
+
+# ── T71: --dry-run reaps nothing (runaway fixture) ───────────────────────────
+_ab_clear
+export AB_CFT="5401 5402"
+export AB_CMD_5401="$AB_ROOT_CMD"; export AB_CPU_5401="1"; export AB_ETIME_5401="30:00"; export AB_PPID_5401="5400"
+export AB_CHILDREN_5401="5402"
+export AB_CMD_5402="$AB_RENDERER_CMD"; export AB_CPU_5402="88"; export AB_ETIME_5402="29:50"; export AB_PPID_5402="5401"
+export AB_CMD_5400="$AB_DAEMON_CMD"; export AB_PPID_5400="1"
+rm -f "$KILL_LOG"
+run "T71: dry-run kills nothing" \
+  bash -c "bash '$SWEEP' --dry-run && ! test -s '${KILL_LOG}'"
+run "T71b: dry-run logs would-reap" \
+  bash -c "bash '$SWEEP' --dry-run 2>&1 | grep -qi 'would reap agent-browser'"
+
+# ── T72: crashpad handler is never treated as a root (harmless leftover) ──────
+_ab_clear
+export AB_CFT="5601"
+export AB_CMD_5601="$AB_CRASHPAD_CMD"; export AB_CPU_5601="0"; export AB_ETIME_5601="10-00:00:00"; export AB_PPID_5601="1"
+rm -f "$KILL_LOG"
+run "T72: crashpad handler not reaped (excluded from roots)" \
+  bash -c "bash '$SWEEP' && ! grep -q '5601' '${KILL_LOG}' 2>/dev/null; true"
+
+# ── T73: stale sock/pid housekeeping (dead pid removed, live pid kept) ────────
+_ab_clear
+rm -rf "$AB_SOCKDIR"; mkdir -p "$AB_SOCKDIR"
+run "T73: stale sock/pid housekeeping" bash -c '
+  echo 999999 > "'"$AB_SOCKDIR"'/dead.pid"; : > "'"$AB_SOCKDIR"'/dead.sock"
+  echo $$ > "'"$AB_SOCKDIR"'/alive.pid"; : > "'"$AB_SOCKDIR"'/alive.sock"
+  bash "'"$SWEEP"'" >/dev/null 2>&1
+  ! test -e "'"$AB_SOCKDIR"'/dead.pid" && ! test -e "'"$AB_SOCKDIR"'/dead.sock" \
+    && test -e "'"$AB_SOCKDIR"'/alive.pid" && test -e "'"$AB_SOCKDIR"'/alive.sock"
+'
+
+# ── T74: kill-switch — SWEEP_AB_ENABLED=0 disables the whole vector ──────────
+_ab_clear
+export AB_CFT="5501 5502"
+export AB_CMD_5501="$AB_ROOT_CMD"; export AB_CPU_5501="99"; export AB_ETIME_5501="99:00"; export AB_PPID_5501="5500"
+export AB_CHILDREN_5501="5502"
+export AB_CMD_5502="$AB_RENDERER_CMD"; export AB_CPU_5502="99"; export AB_ETIME_5502="98:00"; export AB_PPID_5502="5501"
+export AB_CMD_5500="$AB_DAEMON_CMD"; export AB_PPID_5500="1"
+rm -f "$KILL_LOG"
+run "T74: SWEEP_AB_ENABLED=0 reaps nothing" \
+  bash -c "SWEEP_AB_ENABLED=0 bash '$SWEEP' && ! test -s '${KILL_LOG}'"
+
+_ab_clear
+unset SWEEP_AB_ENABLED SWEEP_AB_SOCKET_DIR
+rm -f "$MOCKBIN/pgrep" "$MOCKBIN/ps"
 
 # ─── results ────────────────────────────────────────────────────────────────
 

--- a/plugins/dev/scripts/catalyst-join.sh
+++ b/plugins/dev/scripts/catalyst-join.sh
@@ -425,6 +425,13 @@ do_install_cli() {
   if ! command -v alloy >/dev/null 2>&1; then
     warn "alloy not installed by install-cli — log-shipper will not start on this node (install Grafana Alloy manually, then 'catalyst-stack start')"
   fi
+  # CTL-1500: install-cli.sh's ensure_agent_browser provisions agent-browser
+  # (>= min) + Chrome for Testing on this node. Surface a LOUD but NON-FATAL
+  # warning if it did not land (e.g. a headless box with no brew) — browser-
+  # testing skills degrade, but the join must not hard-fail on optional infra.
+  if ! command -v agent-browser >/dev/null 2>&1; then
+    warn "agent-browser not installed by install-cli — browser-testing skills will not run on this node (install: brew install agent-browser && agent-browser install)"
+  fi
   return 0
 }
 

--- a/plugins/dev/scripts/check-setup.sh
+++ b/plugins/dev/scripts/check-setup.sh
@@ -104,7 +104,10 @@ done
 
 header "Browser Testing (agent-browser)"
 if command -v agent-browser &>/dev/null; then
-	ab_ver=$(agent-browser --version 2>/dev/null | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1)
+	# `|| true`: under `set -euo pipefail` an unparseable/failed --version makes the
+	# grep pipeline return nonzero and would abort the whole check before the
+	# `[[ -z $ab_ver ]]` branch can warn (CTL-1500 review). Swallow it → empty ab_ver.
+	ab_ver=$(agent-browser --version 2>/dev/null | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1 || true)
 	if [[ -z $ab_ver ]]; then
 		warn "agent-browser present but --version unparseable — need >= $AGENT_BROWSER_MIN_VERSION"
 	elif version_ge "$ab_ver" "$AGENT_BROWSER_MIN_VERSION"; then

--- a/plugins/dev/scripts/check-setup.sh
+++ b/plugins/dev/scripts/check-setup.sh
@@ -16,6 +16,10 @@ CATALYST_DIR="${CATALYST_DIR:-$HOME/catalyst}"
 DIRENV_CONFIG="${XDG_CONFIG_HOME:-$HOME/.config}/direnv"
 CATALYST_CONFIG="${XDG_CONFIG_HOME:-$HOME/.config}/catalyst"
 
+# Minimum agent-browser that honors AGENT_BROWSER_IDLE_TIMEOUT_MS (CTL-1500).
+# Keep in sync with install-cli.sh and execution-core/doctor.mjs.
+AGENT_BROWSER_MIN_VERSION="0.27.0"
+
 pass_count=0
 warn_count=0
 fail_count=0
@@ -36,6 +40,12 @@ info() { echo -e "  ${BLUE}ℹ   ${NC}$1"; }
 header() {
 	echo ""
 	echo -e "${BOLD}$1${NC}"
+}
+
+# version_ge <have> <min> — true iff semver <have> >= <min> (sort -V handles
+# 0.9.1 < 0.27.0 correctly; lexical sort does not).
+version_ge() {
+	[[ "$(printf '%s\n%s\n' "$2" "$1" | sort -V | head -n1)" == "$2" ]]
 }
 
 # ─── 1. Platform ────────────────────────────────────────────────────────────
@@ -76,7 +86,6 @@ done
 header "Optional Tools"
 
 OPT_TOOLS=(
-	"agent-browser:agent-browser"
 	"sentry-cli:Sentry CLI"
 	"direnv:direnv"
 	"smee:smee-client (webhook tunnel)"
@@ -92,6 +101,22 @@ for spec in "${OPT_TOOLS[@]}"; do
 		warn "$name not found (optional)"
 	fi
 done
+
+header "Browser Testing (agent-browser)"
+if command -v agent-browser &>/dev/null; then
+	ab_ver=$(agent-browser --version 2>/dev/null | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1)
+	if [[ -z $ab_ver ]]; then
+		warn "agent-browser present but --version unparseable — need >= $AGENT_BROWSER_MIN_VERSION"
+	elif version_ge "$ab_ver" "$AGENT_BROWSER_MIN_VERSION"; then
+		pass "agent-browser $ab_ver (>= $AGENT_BROWSER_MIN_VERSION)"
+	else
+		fail "agent-browser $ab_ver < $AGENT_BROWSER_MIN_VERSION — AGENT_BROWSER_IDLE_TIMEOUT_MS ignored (daemon leak, CTL-1500)"
+		info "Upgrade: brew upgrade agent-browser"
+	fi
+else
+	warn "agent-browser not found — required for browser-testing skills (catalyst-dev:agent-browser)"
+	info "Install: brew install agent-browser && agent-browser install"
+fi
 
 # ─── 2b. Catalyst CLI Install ───────────────────────────────────────────────
 

--- a/plugins/dev/scripts/execution-core/doctor.mjs
+++ b/plugins/dev/scripts/execution-core/doctor.mjs
@@ -1747,6 +1747,142 @@ export function checkReaper(deps = {}) {
   return checks;
 }
 
+// ─── Phase 5f: agent-browser worker browser tool (CTL-1500) ──────────────────
+// Phase workers run browser tests (screenshots, live-UI verification) via the
+// `agent-browser` CLI (catalyst-dev:agent-browser skill). Hosts drifted badly:
+// mini ran 0.9.1 (IGNORES the idle-timeout knob), laptop 0.27.2, mini-2 had it
+// NOT INSTALLED. AGENT_BROWSER_IDLE_TIMEOUT_MS auto-shuts-down the per-session
+// daemon (the fix for the headed-Chrome core leak); honored only by >= 0.27.0.
+// Every non-healthy condition is WARN/INFO, never FAIL — same rationale as
+// checkReaper: doctor's exit code is the catalyst-join activation gate, and a
+// missing browser tool must not block owning/dispatching or self-healing.
+
+// Floor at which AGENT_BROWSER_IDLE_TIMEOUT_MS is honored (older builds ignore
+// it). Keep in sync with the bash floor in install-cli.sh / check-setup.sh.
+export const AGENT_BROWSER_MIN_VERSION = "0.27.0";
+
+// parseSemver — "agent-browser 0.32.4" | "0.32.4" → [0,32,4] (or null).
+export function parseSemver(s) {
+  const m = String(s ?? "").match(/(\d+)\.(\d+)\.(\d+)/);
+  return m ? [Number(m[1]), Number(m[2]), Number(m[3])] : null;
+}
+
+// versionGte — dotted `a` >= `b`? Unparseable a → false.
+export function versionGte(a, b) {
+  const va = parseSemver(a), vb = parseSemver(b);
+  if (!va || !vb) return false;
+  for (let i = 0; i < 3; i++) {
+    if (va[i] > vb[i]) return true;
+    if (va[i] < vb[i]) return false;
+  }
+  return true;
+}
+
+function defaultAbVersion() {
+  const r = spawnSync("agent-browser", ["--version"], { encoding: "utf8", timeout: 10_000 });
+  if (r.error || r.status !== 0 || !r.stdout) return null; // ENOENT → error set / status null
+  return r.stdout.trim(); // "agent-browser 0.32.4"
+}
+
+// Fast + network-free: --quick skips the live launch, --offline skips CDN probes.
+function defaultAbDoctor() {
+  const r = spawnSync("agent-browser", ["doctor", "--quick", "--offline", "--json"],
+    { encoding: "utf8", timeout: 20_000 });
+  if (r.error || !r.stdout) return null;
+  try { return JSON.parse(r.stdout); } catch { return null; }
+}
+
+// phase-agent-dispatch (one dir up from execution-core/) bakes
+// AGENT_BROWSER_IDLE_TIMEOUT_MS into the dispatched worker env block (CTL-1500).
+function defaultDispatchWiresIdleTimeout() {
+  try {
+    const p = resolve(dirname(fileURLToPath(import.meta.url)), "..", "phase-agent-dispatch");
+    return /AGENT_BROWSER_IDLE_TIMEOUT_MS/.test(readFileSync(p, "utf8"));
+  } catch { return false; }
+}
+
+// Does the INSTALLED orphan-sweep.sh (the one launchd runs) carry the CTL-1500
+// vector-5 agent-browser reaper? Resolve its baked path from the same plist
+// checkReaper reads, grep for the SWEEP_AB_ENABLED / _ab_browser_roots marker.
+// null = reaper LaunchAgent not installed at all (checkReaper covers that).
+function defaultReaperHasAbVector() {
+  try {
+    const plist = resolve(homedir(), "Library", "LaunchAgents", "ai.coalesce.catalyst-orphan-sweep.plist");
+    const m = readFileSync(plist, "utf8").match(/<string>([^<]*orphan-sweep\.sh)<\/string>/);
+    if (!m) return null;
+    return /SWEEP_AB_ENABLED|_ab_browser_roots/.test(readFileSync(m[1], "utf8"));
+  } catch { return null; }
+}
+
+// checkAgentBrowser — CTL-1500. present + >= min + idle-timeout wired + doctor
+// green + CTL-1500 reaper present. All advisory (WARN/INFO/PASS) — never FAILs.
+export function checkAgentBrowser(deps = {}) {
+  const {
+    abVersion = defaultAbVersion,
+    abDoctor = defaultAbDoctor,
+    dispatchWiresIdleTimeout = defaultDispatchWiresIdleTimeout,
+    reaperHasAbVector = defaultReaperHasAbVector,
+    minVersion = AGENT_BROWSER_MIN_VERSION,
+  } = deps;
+  const checks = [];
+
+  // (a) present on PATH
+  const raw = abVersion();
+  if (!raw) {
+    checks.push(mkCheck("agent-browser-installed", STATUS.WARN,
+      "agent-browser not found on PATH — worker browser tests (screenshots / live-UI " +
+        "verification) unavailable; `brew install agent-browser` then `agent-browser install`"));
+    return checks;
+  }
+  const version = (parseSemver(raw) ?? []).join(".") || raw;
+  checks.push(mkCheck("agent-browser-installed", STATUS.PASS, `agent-browser present (${raw})`));
+
+  // (b) version >= min (older builds silently IGNORE AGENT_BROWSER_IDLE_TIMEOUT_MS)
+  checks.push(versionGte(raw, minVersion)
+    ? mkCheck("agent-browser-version", STATUS.PASS,
+        `agent-browser ${version} >= ${minVersion} (honors AGENT_BROWSER_IDLE_TIMEOUT_MS)`)
+    : mkCheck("agent-browser-version", STATUS.WARN,
+        `agent-browser ${version} is below the ${minVersion} floor — it IGNORES ` +
+          `AGENT_BROWSER_IDLE_TIMEOUT_MS (the daemon idle-shutdown that stops the ` +
+          `headed-Chrome core leak); \`brew upgrade agent-browser\``));
+
+  // (c) idle-timeout wired into dispatched workers
+  checks.push(dispatchWiresIdleTimeout()
+    ? mkCheck("agent-browser-idle-timeout", STATUS.PASS,
+        "AGENT_BROWSER_IDLE_TIMEOUT_MS is wired into dispatched workers (phase-agent-dispatch)")
+    : mkCheck("agent-browser-idle-timeout", STATUS.WARN,
+        "phase-agent-dispatch does not inject AGENT_BROWSER_IDLE_TIMEOUT_MS — a leaked " +
+          "agent-browser daemon will not self-shutdown (CTL-1500 wiring missing)"));
+
+  // (d) optional: agent-browser's own doctor (fast, offline)
+  const d = abDoctor();
+  if (d && typeof d === "object") {
+    const s = d.summary ?? {};
+    checks.push(d.success
+      ? mkCheck("agent-browser-doctor", STATUS.PASS,
+          `agent-browser doctor: pass (${s.pass ?? "?"} pass, ${s.warn ?? 0} warn, ${s.fail ?? 0} fail)`)
+      : mkCheck("agent-browser-doctor", STATUS.WARN,
+          `agent-browser doctor reports ${s.fail ?? "?"} failing check(s) — run \`agent-browser doctor\``));
+  } else {
+    checks.push(mkCheck("agent-browser-doctor", STATUS.INFO,
+      "agent-browser doctor probe unavailable (older build without `doctor`, or probe failed)"));
+  }
+
+  // (e) CTL-1500 reaper present in the INSTALLED orphan-sweep.sh (checkReaper covers the LaunchAgent)
+  const hasVector = reaperHasAbVector();
+  checks.push(hasVector === true
+    ? mkCheck("agent-browser-reaper", STATUS.PASS,
+        "orphan-sweep.sh carries the CTL-1500 agent-browser leaked-browser reaper (vector 5)")
+    : hasVector === false
+      ? mkCheck("agent-browser-reaper", STATUS.WARN,
+          "installed orphan-sweep.sh predates CTL-1500 (no agent-browser vector-5 reaper) — " +
+            "reinstall from the pristine clone (`catalyst-stack install-services`)")
+      : mkCheck("agent-browser-reaper", STATUS.INFO,
+          "orphan-sweep reaper not installed — see the reaper-* checks"));
+
+  return checks;
+}
+
 // checkCloudTokenEnv — CTL-1307. ADVISORY ONLY (never FAIL): the cluster-shared
 // CATALYST_CLOUD_TOKEN is an OPTIONAL extension — a node stays fully local-only
 // without it, so its absence must NEVER block activation. WARN only on DRIFT: the
@@ -3230,6 +3366,7 @@ export function checksForClass(nc, opts = {}) {
       replicaThunk,
       wontOwnThunk,
       () => checkReaper(), // advisory (never FAIL), class-agnostic
+      () => checkAgentBrowser(), // CTL-1500: developers run the mini live-test browser loop too (advisory)
       () => checkMonitorProductionBuild({ fetch: _fetch }), // CTL-1372: warn on a dev-build monitor (advisory)
       () => checkCloudTokenEnv(), // advisory
       () => checkClusterSecretFreshness(), // CTL-1393: warn if running on stale rotated secrets (advisory)
@@ -3285,6 +3422,7 @@ export function checksForClass(nc, opts = {}) {
     () => checkThoughts(), // CTL-1293: member thoughts repo provisioned + non-foreign primary
     () => checkClaudeSettings(), // CTL-1231: member settings.json pins host identity + OTLP endpoint
     () => checkReaper(), // CTL-1306: orphan-sweep reaper installed + baked path still exists (not dead-127)
+    () => checkAgentBrowser(), // CTL-1500: worker browser tool present + >= min + idle-timeout wired + reaper (advisory, never FAIL)
     () => checkCloudTokenEnv(), // CTL-1307: cluster cloud token decrypted → projected to machine-level env (advisory)
     () => checkClusterSecretFreshness(), // CTL-1393: warn if the node is running on stale rotated secrets (advisory)
     () => checkCloudSync(), // CTL-1394: supervised cloud-sync daemon + read tier on the worker hot path (advisory)

--- a/plugins/dev/scripts/execution-core/doctor.test.mjs
+++ b/plugins/dev/scripts/execution-core/doctor.test.mjs
@@ -21,6 +21,7 @@ import {
   checkThoughts,
   checkClaudeSettings,
   checkReaper,
+  checkAgentBrowser,
   checkCloudTokenEnv,
   checkClusterSecretFreshness,
   checkSdkExecutorAuth,
@@ -1102,6 +1103,60 @@ describe("checkReaper", () => {
     });
     expect(checks[0].name).toBe("reaper-health");
     expect(checks[0].status).toBe(STATUS.PASS);
+  });
+});
+
+// ─── checkAgentBrowser (CTL-1500) ────────────────────────────────────────────
+describe("checkAgentBrowser", () => {
+  const healthyDeps = {
+    abVersion: () => "agent-browser 0.32.4",
+    abDoctor: () => ({ success: true, summary: { pass: 8, warn: 0, fail: 0 } }),
+    dispatchWiresIdleTimeout: () => true,
+    reaperHasAbVector: () => true,
+  };
+
+  it("WARNs and short-circuits when agent-browser is not on PATH", () => {
+    const checks = checkAgentBrowser({ ...healthyDeps, abVersion: () => null });
+    expect(checks).toHaveLength(1);
+    expect(checks[0].name).toBe("agent-browser-installed");
+    expect(checks[0].status).toBe(STATUS.WARN);
+  });
+
+  it("WARNs on a below-floor version (idle-timeout ignored)", () => {
+    const checks = checkAgentBrowser({ ...healthyDeps, abVersion: () => "agent-browser 0.9.1" });
+    const v = checks.find((c) => c.name === "agent-browser-version");
+    expect(v.status).toBe(STATUS.WARN);
+  });
+
+  it("PASSes the version check at exactly the floor", () => {
+    const checks = checkAgentBrowser({ ...healthyDeps, abVersion: () => "agent-browser 0.27.0" });
+    const v = checks.find((c) => c.name === "agent-browser-version");
+    expect(v.status).toBe(STATUS.PASS);
+  });
+
+  it("WARNs when phase-agent-dispatch does not wire the idle timeout", () => {
+    const checks = checkAgentBrowser({ ...healthyDeps, dispatchWiresIdleTimeout: () => false });
+    const t = checks.find((c) => c.name === "agent-browser-idle-timeout");
+    expect(t.status).toBe(STATUS.WARN);
+  });
+
+  it("INFOs (not WARN/FAIL) when the doctor probe is unavailable (older build)", () => {
+    const checks = checkAgentBrowser({ ...healthyDeps, abDoctor: () => null });
+    const d = checks.find((c) => c.name === "agent-browser-doctor");
+    expect(d.status).toBe(STATUS.INFO);
+  });
+
+  it("WARNs when the installed orphan-sweep predates the CTL-1500 reaper vector", () => {
+    const checks = checkAgentBrowser({ ...healthyDeps, reaperHasAbVector: () => false });
+    const r = checks.find((c) => c.name === "agent-browser-reaper");
+    expect(r.status).toBe(STATUS.WARN);
+  });
+
+  it("is all-advisory on a fully healthy host (no FAIL records)", () => {
+    const checks = checkAgentBrowser(healthyDeps);
+    expect(checks.every((c) => c.status !== STATUS.FAIL)).toBe(true);
+    expect(checks.find((c) => c.name === "agent-browser-version").status).toBe(STATUS.PASS);
+    expect(checks.find((c) => c.name === "agent-browser-doctor").status).toBe(STATUS.PASS);
   });
 });
 

--- a/plugins/dev/scripts/install-cli.sh
+++ b/plugins/dev/scripts/install-cli.sh
@@ -226,6 +226,73 @@ ensure_alloy() {
   return 0
 }
 
+# Minimum agent-browser version that honors AGENT_BROWSER_IDLE_TIMEOUT_MS — the
+# idle-daemon-shutdown knob workers set so a leaked headed "Chrome for Testing"
+# can't re-render the auto-refresh SPA and peg a core (CTL-1500). 0.9.1 IGNORES
+# the env var; 0.27.x+ honors it (verified: `agent-browser --help` lists it).
+# Keep in sync with check-setup.sh and doctor.mjs (AGENT_BROWSER_MIN_VERSION).
+AGENT_BROWSER_MIN_VERSION="0.27.0"
+
+# _ab_version_ge <have> <min> — true iff semver <have> >= <min> (sort -V; the
+# repo's established version-ordering idiom, e.g. catalyst-stack:490).
+_ab_version_ge() {
+  [[ "$(printf '%s\n%s\n' "$2" "$1" | sort -V | head -n1)" == "$2" ]]
+}
+
+# ensure_agent_browser — install/upgrade agent-browser to >= AGENT_BROWSER_MIN_VERSION
+# and provision its Chrome-for-Testing browser (CTL-1500). agent-browser is a
+# homebrew-core formula (`brew install agent-browser` — no tap); after install/
+# upgrade `agent-browser install` downloads Chrome for Testing (idempotent).
+#
+# DETECT-DON'T-CLOBBER: an existing install (npm OR brew) that already satisfies
+# the floor is LEFT ALONE; brew is only used when the binary is ABSENT or too old.
+# IDEMPOTENT + WARN+CONTINUE (never returns non-zero): a headless box without brew
+# must not make install-cli exit non-zero over the optional browser-testing dep —
+# the orphan-sweep vector-5 reaper and the dispatch idle-timeout are the backstops.
+# Mirrors ensure_alloy's contract exactly.
+ensure_agent_browser() {
+  local have=""
+  if command -v agent-browser >/dev/null 2>&1; then
+    have="$(agent-browser --version 2>/dev/null | head -n1 | awk '{print $NF}')"
+    if [[ -n "$have" ]] && _ab_version_ge "$have" "$AGENT_BROWSER_MIN_VERSION"; then
+      # Satisfies the floor (brew OR npm) — don't clobber; just ensure the
+      # Chrome-for-Testing browser is present.
+      agent-browser install >/dev/null 2>&1 \
+        || echo "  warning: 'agent-browser install' (Chrome for Testing) failed — browser tests may not run until it completes" >&2
+      echo "  agent-browser ${have} present (>= ${AGENT_BROWSER_MIN_VERSION})"
+      return 0
+    fi
+    echo "  agent-browser ${have:-unknown} is older than ${AGENT_BROWSER_MIN_VERSION} (idle-timeout unsupported) — upgrading…"
+  fi
+
+  if ! command -v brew >/dev/null 2>&1; then
+    echo "  warning: agent-browser missing/old and brew unavailable — install manually (brew install agent-browser OR npm i -g 'agent-browser@>=${AGENT_BROWSER_MIN_VERSION}'), then 'agent-browser install'" >&2
+    return 0
+  fi
+
+  echo "  Installing/upgrading agent-browser via brew (homebrew-core, CTL-1500)…"
+  if [[ -n "$have" ]]; then
+    brew upgrade agent-browser >/dev/null 2>&1 || brew install agent-browser >/dev/null 2>&1 || true
+  else
+    brew install agent-browser >/dev/null 2>&1 || true
+  fi
+  hash -r 2>/dev/null || true
+
+  if command -v agent-browser >/dev/null 2>&1; then
+    have="$(agent-browser --version 2>/dev/null | head -n1 | awk '{print $NF}')"
+    if [[ -n "$have" ]] && _ab_version_ge "$have" "$AGENT_BROWSER_MIN_VERSION"; then
+      echo "  Installed agent-browser ${have} ($(command -v agent-browser))"
+      agent-browser install >/dev/null 2>&1 \
+        || echo "  warning: 'agent-browser install' (Chrome for Testing) failed — browser tests may not run until it completes" >&2
+    else
+      echo "  warning: agent-browser is ${have:-still absent} after brew (< ${AGENT_BROWSER_MIN_VERSION}) — idle-timeout unsupported" >&2
+    fi
+  else
+    echo "  warning: agent-browser install via brew failed — browser tests will not run until it is installed" >&2
+  fi
+  return 0
+}
+
 if [[ "$mode" = "uninstall" ]]; then
   if [[ -d "$BIN_DIR" ]]; then
     for entry in "${CLI_ENTRIES[@]}"; do
@@ -517,6 +584,11 @@ detect_stale_aliases
 # exit non-zero, since the shipper is optional infra and catalyst-stack's
 # start_shipper degrades loudly-but-gracefully when alloy is absent.
 ensure_alloy || true
+
+# Provision agent-browser + its Chrome-for-Testing browser (CTL-1500). Same
+# warn+continue contract as ensure_alloy — optional browser-testing infra must
+# never make install-cli exit non-zero.
+ensure_agent_browser || true
 
 # PATH bootstrap — if BIN_DIR is not on PATH, append an export line to the
 # user's shell rc file. Idempotent: a marker comment guards against duplicate

--- a/plugins/dev/scripts/orphan-sweep.sh
+++ b/plugins/dev/scripts/orphan-sweep.sh
@@ -7,6 +7,12 @@
 #   2. Orphaned/idle worktrees (multi-signal classifier, CTL-1030)
 #   3. Stale phase signals: status=running + dead bg_job_id >30 min
 #   4. Trunk repo cache dirs, mtime >30 days
+#   5. Leaked agent-browser browsers/daemons (CTL-1500): a per-session daemon owns
+#      a real "Chrome for Testing" / chrome-headless-shell browser (Playwright,
+#      under ms-playwright) that OUTLIVES the CLI and has no idle timeout in old
+#      versions. Reap when a browser subtree is CPU-pegged (runaway) or older than
+#      a TTL. Targets ONLY the ms-playwright browser — NEVER /Applications personal
+#      Chrome.
 #
 # Usage:
 #   orphan-sweep.sh [--dry-run] [--print-config] [--count-dirty]
@@ -18,6 +24,12 @@
 #   SWEEP_WT_ROOT               — default: $HOME/catalyst/wt
 #   SWEEP_STALE_SECS            — default: 1800 (30 min)
 #   SWEEP_CACHE_MTIME_DAYS      — default: 30
+#   SWEEP_AB_ENABLED            — agent-browser reaper on/off (default 1)
+#   SWEEP_AB_CPU_THRESHOLD      — runaway browser %CPU threshold (default 30)
+#   SWEEP_AB_MIN_AGE_SECS       — min browser age for the runaway rule (default 600)
+#   SWEEP_AB_TTL_SECS           — absolute leaked-browser age cap (default 14400 / 4h)
+#   SWEEP_AB_SOCKET_DIR         — agent-browser sock/pid dir (default: $AGENT_BROWSER_SOCKET_DIR
+#                                 else $XDG_RUNTIME_DIR/agent-browser else ~/.agent-browser)
 #   SWEEP_IDLE_HOURS            — idle window before a worktree qualifies (default from config / 48)
 #   SWEEP_MAX_REMOVALS          — per-run deletion cap (default from config / 20)
 #   SWEEP_SALVAGE_PUSH          — 1 to push salvage branch before remove (default from config / 0)
@@ -152,6 +164,11 @@ _init_roots() {
   SWEEP_INCLUDE_GLOBAL_CLAUDE_WT="${SWEEP_INCLUDE_GLOBAL_CLAUDE_WT:-1}"
   SWEEP_PROJECT_CLAUDE_WT="${SWEEP_PROJECT_CLAUDE_WT:-${SCRIPT_DIR%/plugins/dev/scripts}/.claude/worktrees}"
   SWEEP_CONFIG_PATH="${SWEEP_CONFIG_PATH:-$(_resolve_sweep_config_path)}"
+  # CTL-1500: agent-browser reaper knobs (production defaults; all overridable).
+  SWEEP_AB_ENABLED="${SWEEP_AB_ENABLED:-1}"
+  SWEEP_AB_CPU_THRESHOLD="${SWEEP_AB_CPU_THRESHOLD:-30}"
+  SWEEP_AB_MIN_AGE_SECS="${SWEEP_AB_MIN_AGE_SECS:-600}"
+  SWEEP_AB_TTL_SECS="${SWEEP_AB_TTL_SECS:-14400}"
   _load_sweep_config
 }
 
@@ -613,6 +630,199 @@ sweep_worktrees() {
   # SWEEP_LINEAR_TEAMS deprecated — Linear Done query removed (CTL-1030)
 }
 
+# ─── vector 5: leaked agent-browser browser/daemon reaper (CTL-1500) ─────────
+#
+# agent-browser runs a PERSISTENT per-session daemon that owns a real "Chrome for
+# Testing" (or chrome-headless-shell) browser. It has NO idle timeout in current
+# builds, so when the Claude worker that ran `agent-browser open` exits/crashes the
+# daemon + browser + its renderer children survive until reboot — and a leaked
+# browser left on the auto-refreshing orch-monitor SPA re-renders every 20-40s,
+# pegging ~1 core. This reaper kills those leaks.
+#
+# SAFETY (non-negotiable): every kill target is command-validated to be an
+# agent-browser process. Browsers are the automation-only "Google Chrome for
+# Testing" (bundle com.google.chrome.for.testing) / "chrome-headless-shell" binary,
+# owned by agent-browser/Playwright (path under `~/.agent-browser/`, `ms-playwright/`,
+# a `--user-data-dir=…/agent-browser-chrome-*` or `…/playwright_chromiumdev_profile-*`).
+# ANY command under `/Applications/` is HARD-EXCLUDED, so the user's personal
+# `/Applications/Google Chrome.app` (which is "Google Chrome", NEVER "for Testing")
+# can never be a target. Verified version-agnostic across agent-browser 0.9.x
+# (Playwright ms-playwright cache) and 0.3x (compiled daemon + ~/.agent-browser
+# browsers) on macOS.
+
+# _ab_socket_dir: mirror the daemon's app-dir resolution order.
+_ab_socket_dir() {
+  if [[ -n "${SWEEP_AB_SOCKET_DIR:-}" ]]; then printf '%s' "$SWEEP_AB_SOCKET_DIR"; return 0; fi
+  if [[ -n "${AGENT_BROWSER_SOCKET_DIR:-}" ]]; then printf '%s' "$AGENT_BROWSER_SOCKET_DIR"; return 0; fi
+  if [[ -n "${XDG_RUNTIME_DIR:-}" ]]; then printf '%s' "${XDG_RUNTIME_DIR}/agent-browser"; return 0; fi
+  printf '%s' "${HOME}/.agent-browser"
+}
+
+# _is_agent_browser_cmd <cmd>: true iff cmd is agent-browser's automation browser —
+# a "Chrome for Testing"/chrome-headless-shell process owned by agent-browser or
+# Playwright. Version-agnostic; HARD-EXCLUDES anything under /Applications, so the
+# personal desktop Chrome ("Google Chrome", never "for Testing") can never match.
+_is_agent_browser_cmd() {
+  local cmd="$1"
+  case "$cmd" in */Applications/*) return 1 ;; esac
+  case "$cmd" in
+    *"Chrome for Testing"*|*"chrome-headless-shell"*) ;;
+    *) return 1 ;;
+  esac
+  case "$cmd" in
+    *"/.agent-browser/"*|*"/ms-playwright/"*|*"agent-browser-chrome-"*|*"playwright_chromiumdev_profile"*) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+# _is_agent_browser_root_cmd <cmd>: true iff cmd is the TOP-LEVEL browser process
+# (not a `--type=` helper, not the crashpad handler) — killing it cascades the
+# whole browser subtree.
+_is_agent_browser_root_cmd() {
+  local cmd="$1"
+  _is_agent_browser_cmd "$cmd" || return 1
+  case "$cmd" in *"--type="*|*crashpad*) return 1 ;; esac
+  return 0
+}
+
+# _is_agent_browser_daemon_cmd <cmd>: true iff cmd is an agent-browser daemon binary.
+# Both the 0.9.x `node …/dist/daemon.js` and the 0.3x compiled
+# `…/bin/agent-browser-<platform>` live under node_modules/agent-browser/bin/.
+_is_agent_browser_daemon_cmd() {
+  local cmd="$1"
+  case "$cmd" in */Applications/*) return 1 ;; esac
+  case "$cmd" in *"/node_modules/agent-browser/bin/"*) return 0 ;; esac
+  return 1
+}
+
+# _etime_to_secs "<ps-etime>": parse macOS ps etime ([DD-]HH:MM:SS or MM:SS) → seconds.
+# (macOS ps has no `etimes` keyword, so we parse the human `etime`.)
+_etime_to_secs() {
+  local e="${1// /}" days=0 a b c
+  [[ -n "$e" ]] || { printf '0'; return 0; }
+  if [[ "$e" == *-* ]]; then days="${e%%-*}"; e="${e#*-}"; fi
+  local IFS=:
+  read -r a b c <<<"$e"
+  if [[ -n "$c" ]]; then
+    printf '%s' $(( 10#${days:-0}*86400 + 10#${a:-0}*3600 + 10#${b:-0}*60 + 10#${c:-0} ))
+  else
+    printf '%s' $(( 10#${days:-0}*86400 + 10#${a:-0}*60 + 10#${b:-0} ))
+  fi
+}
+
+_ab_children() { pgrep -P "$1" 2>/dev/null || true; }
+_ab_ppid()     { ps -o ppid= -p "$1" 2>/dev/null | tr -d ' '; }
+
+# Candidate browser-root pids: the union of the two automation-browser signatures.
+# pgrep excludes its own pid, and `Chrome for Testing`/`chrome-headless-shell` never
+# match the personal `/Applications/Google Chrome.app` — validation narrows further.
+_ab_browser_roots() {
+  { pgrep -f 'Chrome for Testing' 2>/dev/null; pgrep -f 'chrome-headless-shell' 2>/dev/null; } \
+    | sort -un
+}
+
+_ab_max_cpu() {
+  local pid maxc=0 c
+  for pid in "$@"; do
+    c="$(ps -o pcpu= -p "$pid" 2>/dev/null | awk 'NR==1{printf "%d", $1+0.5}')"
+    [[ -n "$c" ]] || continue
+    [[ "$c" -gt "$maxc" ]] && maxc="$c"
+  done
+  printf '%s' "$maxc"
+}
+
+# _ab_reap <daemon_pid|""> <root_browser_pid> <sockdir> <reason>
+_ab_reap() {
+  local dpid="$1" root="$2" sockdir="$3" reason="$4"
+  if is_dry; then
+    log "[dry-run] would reap agent-browser (${dpid:+daemon=$dpid }root=${root}): ${reason}"
+    return 0
+  fi
+  # TERM the owning daemon first (its SIGTERM handler closes the browser), then TERM
+  # the root browser (cascades its helper children). Both targets are command-
+  # validated agent-browser processes — never the personal Chrome.
+  [[ -n "$dpid" ]] && env kill "$dpid" 2>/dev/null || true
+  [[ -n "$root" ]] && env kill "$root" 2>/dev/null || true
+  log "reaped agent-browser (${dpid:+daemon=$dpid }root=${root}): ${reason}"
+  emit_reclaim agent_browser "${dpid:+daemon=$dpid,}root=${root}"
+  # Drop the sock/pid whose .pid content == this daemon pid.
+  [[ -n "$dpid" && -d "$sockdir" ]] || return 0
+  local pidf base cpid
+  for pidf in "$sockdir"/*.pid; do
+    [[ -e "$pidf" ]] || continue
+    cpid="$(tr -dc '0-9' < "$pidf" 2>/dev/null)"
+    [[ "$cpid" == "$dpid" ]] && { base="${pidf%.pid}"; rm -f "${base}.pid" "${base}.sock"; }
+  done
+}
+
+sweep_agent_browser() {
+  [[ "${SWEEP_AB_ENABLED:-1}" == "1" ]] || return 0
+  command -v pgrep >/dev/null 2>&1 || return 0
+  command -v ps    >/dev/null 2>&1 || return 0
+
+  local sockdir; sockdir="$(_ab_socket_dir)"
+
+  # (1) Reap runaway / leaked agent-browser browsers — whether the owning daemon is
+  #     still alive (the common leak: daemon outlives the CLI) or already dead (an
+  #     orphaned browser reparented to init). Browser-centric so it is agnostic to
+  #     the daemon-binary shape across agent-browser versions.
+  local root rcmd subtree helper root_age max_cpu reason ppid pcmd
+  while IFS= read -r root; do
+    [[ "$root" =~ ^[0-9]+$ ]] || continue
+    rcmd="$(ps -o command= -p "$root" 2>/dev/null)"
+    _is_agent_browser_root_cmd "$rcmd" || continue
+
+    subtree="$root"
+    while IFS= read -r helper; do
+      [[ "$helper" =~ ^[0-9]+$ ]] && subtree="$subtree $helper"
+    done < <(_ab_children "$root")
+
+    root_age="$(_etime_to_secs "$(ps -o etime= -p "$root" 2>/dev/null)")"
+    # shellcheck disable=SC2086
+    max_cpu="$(_ab_max_cpu $subtree)"
+
+    reason=""
+    if [[ "$root_age" -ge "$SWEEP_AB_TTL_SECS" ]]; then
+      reason="ttl age=${root_age}s>=${SWEEP_AB_TTL_SECS}s cpu=${max_cpu}%"
+    elif [[ "$root_age" -ge "$SWEEP_AB_MIN_AGE_SECS" && "$max_cpu" -ge "$SWEEP_AB_CPU_THRESHOLD" ]]; then
+      reason="runaway cpu=${max_cpu}%>=${SWEEP_AB_CPU_THRESHOLD}% age=${root_age}s"
+    fi
+    if [[ -z "$reason" ]]; then
+      log "keep agent-browser (root=${root} age=${root_age}s cpu=${max_cpu}%)"
+      continue
+    fi
+
+    # Also reap the owning daemon (and drop its sock/pid) when the parent is a
+    # validated agent-browser daemon; an orphaned browser (parent = init or gone)
+    # is reaped on its own.
+    ppid="$(_ab_ppid "$root")"
+    pcmd="$(ps -o command= -p "$ppid" 2>/dev/null)"
+    if [[ "$ppid" =~ ^[0-9]+$ ]] && _is_agent_browser_daemon_cmd "$pcmd"; then
+      _ab_reap "$ppid" "$root" "$sockdir" "$reason"
+    else
+      _ab_reap "" "$root" "$sockdir" "${reason} (orphaned, no live daemon)"
+    fi
+  done < <(_ab_browser_roots)
+
+  # (2) Housekeeping: drop stale sock/pid whose recorded daemon pid is dead.
+  #     Pure file cleanup — kill -0 (shell builtin) never signals a process.
+  [[ -d "$sockdir" ]] || return 0
+  local pidf pid base
+  for pidf in "$sockdir"/*.pid; do
+    [[ -e "$pidf" ]] || continue
+    pid="$(tr -dc '0-9' < "$pidf" 2>/dev/null)"
+    if [[ -z "$pid" ]] || ! kill -0 "$pid" 2>/dev/null; then
+      base="${pidf%.pid}"
+      if is_dry; then
+        log "[dry-run] would remove stale agent-browser sock/pid: $(basename "$base")"
+      else
+        rm -f "${base}.pid" "${base}.sock"
+        log "removed stale agent-browser sock/pid: $(basename "$base")"
+      fi
+    fi
+  done
+}
+
 # ─── main ───────────────────────────────────────────────────────────────────
 
 main() {
@@ -633,13 +843,14 @@ main() {
     log "=== DRY RUN — no changes will be made ==="
   fi
 
-  log "starting sweep (vectors: trunk_cache, signals, procs, worktrees)"
+  log "starting sweep (vectors: trunk_cache, signals, procs, worktrees, agent_browser)"
 
   _SWEEP_START_EPOCH="$(date -u +%s)"
   sweep_trunk_cache
   sweep_procs
   sweep_signals
   sweep_worktrees
+  sweep_agent_browser
   emit_sweep_completed
 
   log "sweep complete"

--- a/plugins/dev/scripts/orphan-sweep.sh
+++ b/plugins/dev/scripts/orphan-sweep.sh
@@ -685,13 +685,34 @@ _is_agent_browser_root_cmd() {
   return 0
 }
 
+# _is_agent_browser_owned_cmd <cmd>: true iff cmd carries an agent-browser-SPECIFIC
+# ownership anchor (~/.agent-browser/ or the agent-browser-chrome- user-data-dir),
+# proving it is agent-browser's OWN browser rather than one merely sharing the
+# generic Playwright cache/profile. The shared /ms-playwright/ and
+# playwright_chromiumdev_profile markers are NOT agent-browser-specific — an
+# unrelated Playwright job uses them too — so a browser matched only by those is
+# reaped only when a live agent-browser daemon owns it (see the safety gate in
+# sweep_agent_browser). CTL-1500 review P1.
+_is_agent_browser_owned_cmd() {
+  local cmd="$1"
+  case "$cmd" in
+    *"/.agent-browser/"*|*"agent-browser-chrome-"*) return 0 ;;
+  esac
+  return 1
+}
+
 # _is_agent_browser_daemon_cmd <cmd>: true iff cmd is an agent-browser daemon binary.
-# Both the 0.9.x `node …/dist/daemon.js` and the 0.3x compiled
-# `…/bin/agent-browser-<platform>` live under node_modules/agent-browser/bin/.
+# Covers BOTH the 0.3x compiled `…/node_modules/agent-browser/bin/agent-browser-<platform>`
+# AND the 0.9.x node daemon `node …/node_modules/agent-browser/dist/daemon.js` — the
+# 0.9.x daemon lives under dist/, not bin/, so a bin/-only match would reject the live
+# owning daemon of a 0.9.x leak, reap the browser alone, and leave the daemon +
+# .pid/.sock behind (CTL-1500 review P2).
 _is_agent_browser_daemon_cmd() {
   local cmd="$1"
   case "$cmd" in */Applications/*) return 1 ;; esac
-  case "$cmd" in *"/node_modules/agent-browser/bin/"*) return 0 ;; esac
+  case "$cmd" in
+    *"/node_modules/agent-browser/bin/"*|*"/node_modules/agent-browser/dist/"*) return 0 ;;
+  esac
   return 1
 }
 
@@ -766,7 +787,7 @@ sweep_agent_browser() {
   #     still alive (the common leak: daemon outlives the CLI) or already dead (an
   #     orphaned browser reparented to init). Browser-centric so it is agnostic to
   #     the daemon-binary shape across agent-browser versions.
-  local root rcmd subtree helper root_age max_cpu reason ppid pcmd
+  local root rcmd subtree helper root_age max_cpu reason ppid pcmd daemon_owner
   while IFS= read -r root; do
     [[ "$root" =~ ^[0-9]+$ ]] || continue
     rcmd="$(ps -o command= -p "$root" 2>/dev/null)"
@@ -792,13 +813,30 @@ sweep_agent_browser() {
       continue
     fi
 
-    # Also reap the owning daemon (and drop its sock/pid) when the parent is a
-    # validated agent-browser daemon; an orphaned browser (parent = init or gone)
-    # is reaped on its own.
+    # Resolve the owning daemon: the parent, when it validates as an agent-browser
+    # daemon binary (the common leak = the daemon outlives the CLI).
     ppid="$(_ab_ppid "$root")"
     pcmd="$(ps -o command= -p "$ppid" 2>/dev/null)"
+    daemon_owner=""
     if [[ "$ppid" =~ ^[0-9]+$ ]] && _is_agent_browser_daemon_cmd "$pcmd"; then
-      _ab_reap "$ppid" "$root" "$sockdir" "$reason"
+      daemon_owner="$ppid"
+    fi
+
+    # SHARED-PLAYWRIGHT SAFETY GATE (CTL-1500 review P1): a browser matched ONLY by
+    # the generic Playwright markers (ms-playwright cache / playwright_chromiumdev_profile)
+    # — with no agent-browser-specific anchor AND no live agent-browser daemon parent —
+    # may belong to an UNRELATED Playwright job, so it must NEVER be reaped. Reap a
+    # shared-marker browser only when a live agent-browser daemon owns it; a browser
+    # with an agent-browser-specific anchor is reaped regardless (incl. orphaned).
+    if [[ -z "$daemon_owner" ]] && ! _is_agent_browser_owned_cmd "$rcmd"; then
+      log "keep agent-browser (root=${root}): shared-playwright browser, no agent-browser owner (age=${root_age}s cpu=${max_cpu}%)"
+      continue
+    fi
+
+    # Reap the owning daemon (and drop its sock/pid) when present; an orphaned but
+    # agent-browser-owned browser (parent = init or gone) is reaped on its own.
+    if [[ -n "$daemon_owner" ]]; then
+      _ab_reap "$daemon_owner" "$root" "$sockdir" "$reason"
     else
       _ab_reap "" "$root" "$sockdir" "${reason} (orphaned, no live daemon)"
     fi

--- a/plugins/dev/scripts/phase-agent-dispatch
+++ b/plugins/dev/scripts/phase-agent-dispatch
@@ -854,6 +854,14 @@ compose_worker_settings_json() {
 	local cluster_generation_val="${CATALYST_CLUSTER_GENERATION-}" # CTL-864
 	local executor_val="${EXECUTOR-}"                             # CTL-1457
 
+	# CTL-1500: cap agent-browser daemon idle life so a worker that runs
+	# `agent-browser open` and then exits/crashes doesn't strand a headed
+	# "Chrome for Testing" browser that re-renders the auto-refresh SPA and pegs a
+	# core. Honored by agent-browser versions that support the env var; a harmless
+	# no-op on older builds (the orphan-sweep vector-5 reaper is the version-agnostic
+	# backstop). Default 5 min; override by exporting AGENT_BROWSER_IDLE_TIMEOUT_MS.
+	local ab_idle_timeout_ms="${AGENT_BROWSER_IDLE_TIMEOUT_MS:-300000}"
+
 	local statusline_script="${SCRIPT_DIR}/catalyst-statusline.sh"
 
 	jq -nc \
@@ -870,6 +878,7 @@ compose_worker_settings_json() {
 		--arg generation "$generation_val" \
 		--arg cluster_generation "$cluster_generation_val" \
 		--arg executor "$executor_val" \
+		--arg ab_idle_timeout_ms "$ab_idle_timeout_ms" \
 		--arg statusline_cmd "$statusline_script" \
 		--argjson have_statusline "$([[ -f $statusline_script ]] && echo true || echo false)" \
 		'{
@@ -877,7 +886,8 @@ compose_worker_settings_json() {
          {
            "CLAUDE_CODE_ENABLE_TELEMETRY": $enable_telemetry,
            "OTEL_METRICS_EXPORTER": $metrics_exporter,
-           "OTEL_LOGS_EXPORTER": $logs_exporter
+           "OTEL_LOGS_EXPORTER": $logs_exporter,
+           "AGENT_BROWSER_IDLE_TIMEOUT_MS": $ab_idle_timeout_ms
          }
          + (if $otlp_endpoint == "" then {} else { "OTEL_EXPORTER_OTLP_ENDPOINT": $otlp_endpoint } end)
          + (if $otlp_protocol == "" then {} else { "OTEL_EXPORTER_OTLP_PROTOCOL": $otlp_protocol } end)
@@ -924,6 +934,12 @@ DISPATCH_ENV=(
 	# prefix here (reaches sdk/codex spawns directly); ALSO threaded through
 	# settings.env below so it survives the `claude --bg` RPC that drops this prefix.
 	"CATALYST_EXECUTOR_ID=${EXECUTOR}"
+	# CTL-1500: agent-browser idle-shutdown cap. Mirrors the dual-channel pattern
+	# above: this plain-prefix copy reaches the codex executor (buildCodexEnv reads
+	# only spec.env, never settings.env) and the sdk executor; the settings.env copy
+	# in compose_worker_settings_json is the one that survives the `claude --bg` RPC
+	# for the bg executor (the host that actually leaks). Default 5 min.
+	"AGENT_BROWSER_IDLE_TIMEOUT_MS=${AGENT_BROWSER_IDLE_TIMEOUT_MS:-300000}"
 )
 [[ -n $OTEL_RES_ATTRS ]] &&
 	DISPATCH_ENV+=("OTEL_RESOURCE_ATTRIBUTES=${OTEL_RES_ATTRS}")

--- a/plugins/dev/skills/agent-browser/SKILL.md
+++ b/plugins/dev/skills/agent-browser/SKILL.md
@@ -15,9 +15,38 @@ description: Fast browser automation CLI for AI agents. **ALWAYS use instead of 
 
 **Do NOT use Playwright MCP tools.** If browser automation is needed, always use `agent-browser` CLI instead.
 
+## Session Hygiene (REQUIRED — prevents leaked browsers)
+
+agent-browser runs a **persistent per-session daemon** that owns a real "Chrome for
+Testing" browser. That daemon **outlives the CLI** — the browser keeps running (and,
+if left on an auto-refreshing page, keeps re-rendering and pegging a CPU core) until
+something closes it. On shared fleet/worker hosts a leaked browser starves the box
+(CTL-1500). So treat every session as something you **must** open with a name and
+**always close**:
+
+- **REQUIRED: always pass `--session <name>`.** Pick a short task-specific name
+  (e.g. `ctl-1500-verify`, `gh-review`). Never rely on the implicit `default`
+  session — a shared default collides across concurrent workers and is the hardest
+  leak to attribute and clean up.
+- **REQUIRED: always `close` when done.** End every task with
+  `agent-browser --session <name> close`. Do it in the same turn you finish the
+  browser work — do not leave a session open "in case". If you took a wrong turn,
+  close before starting over.
+- **BANNED: unnamed / shared-`default` sessions.** Every `open` must carry an
+  explicit `--session`. An un-named session on a worker host is a leak waiting to
+  happen.
+- **BANNED: abandoned open-loops.** Never write retry/wait loops that call
+  `agent-browser ... open` (e.g. `until agent-browser --session s open <url>; do
+  sleep …; done`) without a guaranteed matching `close`. Each failed `open` can
+  spawn/adopt a browser; a loop that exits without closing strands them. If you must
+  poll, `open` **once**, then use `wait`/`reload`, and `close` in a trap/`finally`.
+- **On a worker/CI host**, prefer the shortest-lived session possible and close it
+  immediately; a phase worker that exits without closing relies on the host reaper
+  (orphan-sweep vector 5) to clean up, which is a backstop, not a substitute.
+
 ## Starting a Browser Session
 
-**ALWAYS use `--headed` and a named session.** Headed mode shows a visible browser window so the user can watch. Sessions preserve browser state so they survive accidental closes and can be resumed.
+**ALWAYS use `--headed` and a named session.** Headed mode shows a visible browser window so the user can watch. Sessions preserve browser state so they survive accidental closes and can be resumed. **Always `close` the session when the task is done (see Session Hygiene above).**
 
 ```bash
 agent-browser --headed --session my-task open https://example.com
@@ -313,4 +342,4 @@ agent-browser connect <port|url>   # Connect to existing browser
 4. **Use snapshot -i -c** for AI-efficient page state
 5. **Use @refs** from snapshots for interactions, not CSS selectors
 6. **agent-browser, NOT Playwright MCP** — always prefer the CLI
-7. **Close when done**: `agent-browser --headed --session <name> close` to clean up
+7. **ALWAYS close when done** (REQUIRED): `agent-browser --session <name> close`. The daemon + browser outlive the CLI and leak a CPU-pegging browser on shared hosts if left open (CTL-1500). Never leave a session open; never use unnamed/shared-`default` sessions or abandoned `until … open` loops. See **Session Hygiene** above.


### PR DESCRIPTION
## Problem (CTL-1500)

`agent-browser` runs a **persistent per-session daemon** that owns a real headed
"Chrome for Testing" browser and **outlives the CLI** — with no idle timeout / TTL
/ reaper. A Claude worker that ran `agent-browser open` and then exited left the
browser re-rendering an auto-refresh SPA (the `:7400` orch-monitor) **forever**,
pegging a CPU core. mini had ~10 renderers at 24–96% CPU; it recurred twice in a day
and starved the fleet. Hosts had also drifted badly: mini ran 0.9.1 (ignores the
idle-timeout knob), laptop 0.27.2 (npm), mini-2 had it **not installed at all**.

## Fix (one PR, four parts + setup-tooling)

1. **Reaper (load-bearing).** A version-agnostic **vector 5** in `orphan-sweep.sh`
   (the hourly `ai.coalesce.catalyst-orphan-sweep` LaunchAgent) reaps leaked
   agent-browser browsers/daemons on **CPU-peg** (runaway) or **TTL** (idle), plus
   stale `~/.agent-browser/<session>.sock|.pid` housekeeping. **Three airtight safety
   gates**, all required to select a target: hard-exclude anything under
   `/Applications/`, require `Chrome for Testing`/`chrome-headless-shell`, require an
   ownership anchor (`/.agent-browser/`, `/ms-playwright/`, `agent-browser-chrome-`,
   `playwright_chromiumdev_profile`). **Personal `/Applications/Google Chrome.app` is
   never touched** (3 dedicated safety tests + a live mini dry-run naming it zero times).
2. **Idle-timeout env.** `AGENT_BROWSER_IDLE_TIMEOUT_MS` (default 300000 / 5 min)
   injected into **both** worker launch channels in `phase-agent-dispatch` —
   `settings.env` (survives the `claude --bg` RPC; covers the actually-leaking bg
   executor) and `DISPATCH_ENV` (reaches sdk/codex). Honored by builds ≥ 0.27.0.
3. **Setup-tooling ownership** so hosts stop drifting (shared floor
   `AGENT_BROWSER_MIN_VERSION=0.27.0`):
   - `doctor.mjs` — advisory `checkAgentBrowser` (present + ≥ min + idle-timeout wired
     + own-doctor + reaper-vector present). **All WARN/INFO, never FAIL** — same
     rationale as `checkReaper`: doctor's exit code is the catalyst-join activation
     gate, so a missing browser tool must not block owning/dispatching or self-healing.
   - `install-cli.sh` — `ensure_agent_browser` (detect-don't-clobber brew
     install/upgrade + `agent-browser install`; mirrors `ensure_alloy`, warn+continue).
     Reaches every provisioning path (catalyst-join + install-lifecycle) with no
     change to `install-lifecycle.mjs`.
   - `check-setup.sh` — agent-browser promoted from a presence-only optional entry to
     a version-gated block. `catalyst-join.sh` — join-time presence warn.
4. **Skill.** `agent-browser/SKILL.md` — Session Hygiene (mandatory named session +
   `close`; bans unnamed/shared-`default` sessions and abandoned open/reload loops =
   the phantom-reload pattern that starved the fleet). `docs/orphan-sweep.md` 4→5 vectors.

## Testing

- `orphan-sweep.test.sh` — **131 pass** (Phase 10, T67–T74, incl. 3 safety cases
  proving personal Chrome, an `/Applications` "for Testing" helper, and an unowned
  manual Chrome-for-Testing are all spared even at CPU=99%/age=38d).
- `doctor.test.mjs` — `checkAgentBrowser` **7 pass**; **full doctor suite 239 pass**.
- Live: `doctor --json` emits the 5 agent-browser records correctly (laptop 0.27.2 →
  4 PASS + the reaper-vector WARN, which is accurate pre-merge); `check-setup.sh` →
  `✅ agent-browser 0.27.2 (>= 0.27.0)`. `bash -n` clean on all touched scripts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JjWhWmAg9SpQbhgicT4Lo5