### PR TITLE
fix(dev): CTL-1508 exit-safe cloud-sync self-heal + selfheal breadcrumb + lastFrameAt stall classifier

### DIFF
--- a/plugins/dev/scripts/execution-core/__tests__/cloud-sync-telemetry.test.mjs
+++ b/plugins/dev/scripts/execution-core/__tests__/cloud-sync-telemetry.test.mjs
@@ -1,6 +1,15 @@
 // cloud-sync-telemetry.test.mjs — CTL-1395. Tests the pure freshness-telemetry helpers.
+// CTL-1508 adds: exitAfterClose (bounded exit paths), the frame-silence classifier arm,
+// and the self-heal breadcrumb helpers.
 import { describe, test, expect } from "bun:test";
-import { classifyStall, freshnessFields, readReplicaCounts } from "../cloud-sync-telemetry.mjs";
+import {
+  classifyStall,
+  clearSelfHealBreadcrumb,
+  exitAfterClose,
+  freshnessFields,
+  readReplicaCounts,
+  writeSelfHealBreadcrumb,
+} from "../cloud-sync-telemetry.mjs";
 
 const NOW = 1_800_000_000_000;
 
@@ -40,6 +49,17 @@ describe("freshnessFields", () => {
   test("carries no secret-shaped keys/values (NAME-only telemetry)", () => {
     const f = freshnessFields({ rows: 1, maxUpdatedMs: NOW, status: "live", cursor: 1, hostName: "mini", now: NOW });
     expect(JSON.stringify(f)).not.toMatch(/token|secret|lin_|Bearer/i);
+  });
+
+  test("frame_staleness = whole seconds since lastFrameAt (CTL-1508)", () => {
+    const f = freshnessFields({ lastFrameAt: NOW - 45_000, now: NOW });
+    expect(f["catalyst.linear.replica.frame_staleness"]).toBe(45);
+  });
+
+  test("frame_staleness is null (never a bogus number) when lastFrameAt is absent — older SDK / pre-first-frame", () => {
+    for (const lf of [null, undefined, 0, NaN, "nope"]) {
+      expect(freshnessFields({ lastFrameAt: lf, now: NOW })["catalyst.linear.replica.frame_staleness"]).toBeNull();
+    }
   });
 });
 
@@ -100,6 +120,80 @@ describe("classifyStall", () => {
     expect(c.restart).toBe(false);
     expect(c.displayStatus).toBe("live");
   });
+
+  // --- CTL-1508: the frame-silence arm (SDK 0.6.0 lastFrameAt) ---
+
+  test("OLDER-SDK PARITY: lastFrameAt null/undefined is bit-identical to the status-only classifier across the whole matrix", () => {
+    const matrix = [
+      { rows: 2878, stalledMs: STALL + 5_000, stallMs: STALL, status: "live" },
+      { rows: 2878, stalledMs: STALL + 1, stallMs: STALL, status: "reconnecting" },
+      { rows: 2878, stalledMs: STALL + 1, stallMs: STALL, status: "error" },
+      { rows: 2878, stalledMs: STALL + 1, stallMs: STALL, status: "stopped" },
+      { rows: 2878, stalledMs: 5_000, stallMs: STALL, status: "reconnecting" },
+      { rows: 0, stalledMs: STALL + 60_000, stallMs: STALL, status: "error" },
+      { rows: null, stalledMs: STALL + 60_000, stallMs: STALL, status: "error" },
+      { rows: 2878, stalledMs: STALL + 1, stallMs: STALL, status: "connecting" },
+      { rows: 2878, stalledMs: STALL + 1, stallMs: STALL, status: "resyncing" },
+    ];
+    for (const args of matrix) {
+      // lastFrameAt omitted vs explicit null vs undefined (an older SDK's absent getter)
+      // must all produce the same result object — frame-silence never asserts.
+      const base = classifyStall({ ...args, now: NOW });
+      expect(base.frameSilent).toBe(false);
+      expect(classifyStall({ ...args, lastFrameAt: null, now: NOW })).toEqual(base);
+      expect(classifyStall({ ...args, lastFrameAt: undefined, now: NOW })).toEqual(base);
+    }
+  });
+
+  test("HALF-OPEN CAUGHT: cursor stalled + status latched 'live' + NO inbound frames for the window → GENUINE (the 18.5h RCA shape)", () => {
+    const c = classifyStall({ rows: 2878, stalledMs: STALL + 5_000, stallMs: STALL, status: "live", lastFrameAt: NOW - STALL - 5_000, now: NOW });
+    expect(c.cursorStalled).toBe(true);
+    expect(c.sdkUnhealthy).toBe(false); // status is lying ("live") — onclose never fired
+    expect(c.frameSilent).toBe(true); // but zero inbound bytes (not even pongs) proves it
+    expect(c.genuine).toBe(true);
+    expect(c.alert).toBe(true);
+    expect(c.restart).toBe(true);
+    expect(c.displayStatus).toBe("stalled");
+  });
+
+  test("QUIET-BUT-PONGING: cursor stalled + status live + lastFrameAt fresh (watchdog pongs arriving) → NOT a stall", () => {
+    // A healthy quiet feed receives pongs every ~90s, so lastFrameAt stays fresh even
+    // when the cursor is frozen — the false-kill guard now has a POSITIVE proof of life.
+    const c = classifyStall({ rows: 2878, stalledMs: STALL + 5_000, stallMs: STALL, status: "live", lastFrameAt: NOW - 60_000, now: NOW });
+    expect(c.cursorStalled).toBe(true);
+    expect(c.frameSilent).toBe(false);
+    expect(c.genuine).toBe(false);
+    expect(c.restart).toBe(false);
+    expect(c.displayStatus).toBe("live");
+  });
+
+  test("frameStallMs defaults to stallMs (boundary: exactly-stallMs-old frames assert; one ms fresher does not)", () => {
+    const at = (lastFrameAt, extra = {}) =>
+      classifyStall({ rows: 2878, stalledMs: STALL + 1, stallMs: STALL, status: "live", lastFrameAt, now: NOW, ...extra });
+    expect(at(NOW - STALL).frameSilent).toBe(true);
+    expect(at(NOW - STALL + 1).frameSilent).toBe(false);
+    // An explicit frameStallMs overrides the stallMs default.
+    expect(at(NOW - 100_000, { frameStallMs: 90_000 }).frameSilent).toBe(true);
+    expect(at(NOW - 100_000, { frameStallMs: 120_000 }).frameSilent).toBe(false);
+  });
+
+  test("frame-silence WITHOUT cursor-stall never asserts genuine — pre-seed (rows 0/null) and advancing-cursor stay guarded", () => {
+    for (const rows of [0, null]) {
+      const c = classifyStall({ rows, stalledMs: STALL + 60_000, stallMs: STALL, status: "live", lastFrameAt: NOW - STALL - 60_000, now: NOW });
+      expect(c.genuine).toBe(false);
+      expect(c.restart).toBe(false);
+    }
+    const advancing = classifyStall({ rows: 2878, stalledMs: 5_000, stallMs: STALL, status: "live", lastFrameAt: NOW - STALL - 60_000, now: NOW });
+    expect(advancing.genuine).toBe(false);
+  });
+
+  test("frame-silence AND unhealthy status together are still one genuine stall (both confirmations reported)", () => {
+    const c = classifyStall({ rows: 2878, stalledMs: STALL + 1, stallMs: STALL, status: "error", lastFrameAt: NOW - STALL - 1, now: NOW });
+    expect(c.sdkUnhealthy).toBe(true);
+    expect(c.frameSilent).toBe(true);
+    expect(c.genuine).toBe(true);
+    expect(c.displayStatus).toBe("stalled");
+  });
 });
 
 describe("readReplicaCounts", () => {
@@ -116,5 +210,106 @@ describe("readReplicaCounts", () => {
   test("FAIL-OPEN: a throwing executor (locked/mid-apply DB) → both null, never throws", () => {
     const sql = { exec: () => { throw new Error("database is locked"); } };
     expect(readReplicaCounts(sql)).toEqual({ rows: null, maxUpdatedMs: null });
+  });
+});
+
+describe("exitAfterClose (CTL-1508)", () => {
+  // Fake timer registry: captures {fn, ms, unrefd} without ever arming a real timer, so
+  // tests fire timers deterministically and NEVER wait wall-clock time.
+  const makeTimers = () => {
+    const scheduled = [];
+    const setTimeoutFn = (fn, ms) => {
+      const t = { fn, ms, unrefd: false, unref() { this.unrefd = true; return this; } };
+      scheduled.push(t);
+      return t;
+    };
+    return { scheduled, setTimeoutFn };
+  };
+  // Drain the microtask queue (the closePromise .then chain) via one real 0ms macrotask.
+  const flush = () => new Promise((r) => setTimeout(r, 0));
+
+  test("close resolves fast → exit(exitCode) exactly once; the later timers are no-ops (no double-fire)", async () => {
+    const calls = [];
+    const { scheduled, setTimeoutFn } = makeTimers();
+    exitAfterClose({ closePromise: Promise.resolve(), exitCode: 0, timeoutMs: 3_000, exit: (c) => calls.push(c), setTimeoutFn });
+    await flush();
+    expect(calls).toEqual([0]); // the SIGTERM contract: exit 0 (launchd must NOT restart)
+    for (const t of scheduled) t.fn(); // deadline + failsafe fire later → guarded no-ops
+    expect(calls).toEqual([0]);
+  });
+
+  test("close never settles → the deadline timer fires exit at timeoutMs (the hung-close strand fixed)", () => {
+    const calls = [];
+    const { scheduled, setTimeoutFn } = makeTimers();
+    exitAfterClose({ closePromise: new Promise(() => {}), exitCode: 1, timeoutMs: 3_000, exit: (c) => calls.push(c), setTimeoutFn });
+    expect(scheduled.map((t) => t.ms)).toEqual([3_000, 4_000]); // deadline + failsafe(+1s)
+    scheduled[0].fn();
+    expect(calls).toEqual([1]); // the stall contract: exit 1 (launchd restarts)
+    scheduled[1].fn(); // failsafe after the deadline already fired → no double-fire
+    expect(calls).toEqual([1]);
+  });
+
+  test("failsafe path: unref'd (never holds the process open) and still exits if only IT fires", () => {
+    const calls = [];
+    const { scheduled, setTimeoutFn } = makeTimers();
+    exitAfterClose({ closePromise: new Promise(() => {}), exitCode: 1, timeoutMs: 3_000, exit: (c) => calls.push(c), setTimeoutFn });
+    const [deadline, failsafe] = scheduled;
+    expect(failsafe.unrefd).toBe(true); // the belt-and-braces timer must not keep us alive
+    expect(deadline.unrefd).toBe(false); // the primary deadline stays ref'd on purpose
+    failsafe.fn(); // wedged-deadline scenario: the failsafe alone still exits
+    expect(calls).toEqual([1]);
+    deadline.fn();
+    expect(calls).toEqual([1]);
+  });
+
+  test("a REJECTING close still exits exactly once with the requested code (no unhandled rejection)", async () => {
+    const calls = [];
+    const { scheduled, setTimeoutFn } = makeTimers();
+    exitAfterClose({ closePromise: Promise.reject(new Error("socket already dead")), exitCode: 1, timeoutMs: 3_000, exit: (c) => calls.push(c), setTimeoutFn });
+    await flush();
+    expect(calls).toEqual([1]);
+    for (const t of scheduled) t.fn();
+    expect(calls).toEqual([1]);
+  });
+});
+
+describe("self-heal breadcrumb (CTL-1508)", () => {
+  const PATH = "/x/cloud-sync.selfheal.json";
+
+  test("writes {ts, cursor, stalledMs, sdkStatus, expectRestart:true} atomically via tmp+rename", () => {
+    const ops = [];
+    const ok = writeSelfHealBreadcrumb(
+      PATH,
+      { cursor: 311476, stalledMs: 601_000, sdkStatus: "live" },
+      {
+        writeFile: (p, data) => ops.push(["write", p, data]),
+        rename: (from, to) => ops.push(["rename", from, to]),
+        now: () => NOW,
+      },
+    );
+    expect(ok).toBe(true);
+    // tmp FIRST, then rename onto the final path — CTL-1509's responder reads this file
+    // from another process and must never observe a torn write.
+    expect(ops.map((o) => o[0])).toEqual(["write", "rename"]);
+    expect(ops[0][1]).toBe(`${PATH}.tmp`);
+    expect(JSON.parse(ops[0][2])).toEqual({ ts: NOW, cursor: 311476, stalledMs: 601_000, sdkStatus: "live", expectRestart: true });
+    expect(ops[1]).toEqual(["rename", `${PATH}.tmp`, PATH]);
+  });
+
+  test("FAIL-OPEN: a throwing fs never throws out — the breadcrumb must never block the self-heal exit", () => {
+    expect(
+      writeSelfHealBreadcrumb(PATH, { cursor: 1 }, { writeFile: () => { throw new Error("EROFS"); }, rename: () => {}, now: () => NOW }),
+    ).toBe(false);
+    expect(
+      writeSelfHealBreadcrumb(PATH, { cursor: 1 }, { writeFile: () => {}, rename: () => { throw new Error("EXDEV"); }, now: () => NOW }),
+    ).toBe(false);
+  });
+
+  test("clear-on-live unlinks the breadcrumb; a missing file (ENOENT) is the fail-open normal case", () => {
+    const unlinked = [];
+    expect(clearSelfHealBreadcrumb(PATH, { unlink: (p) => unlinked.push(p) })).toBe(true);
+    expect(unlinked).toEqual([PATH]);
+    const enoent = () => { const e = new Error("ENOENT"); e.code = "ENOENT"; throw e; };
+    expect(clearSelfHealBreadcrumb(PATH, { unlink: enoent })).toBe(false); // no throw
   });
 });

--- a/plugins/dev/scripts/execution-core/cloud-sync-telemetry.mjs
+++ b/plugins/dev/scripts/execution-core/cloud-sync-telemetry.mjs
@@ -1,20 +1,29 @@
 // cloud-sync-telemetry.mjs — CTL-1395. Pure helpers for the catalyst-cloud-sync writer's
 // freshness telemetry, factored out of the (script-shaped) cloud-sync.mjs so the staleness
-// math + field shape are unit-testable without running the writer.
+// math + field shape are unit-testable without running the writer. CTL-1508 adds the
+// exit-safety (`exitAfterClose`) and self-heal-breadcrumb helpers here for the same reason.
+import { renameSync, unlinkSync, writeFileSync } from "node:fs";
 
 // freshnessFields — build the structured log fields for one `cloud-sync: freshness` line.
 // Semconv-conformant dotted keys (the OTEL logs→metrics connector keys on these). NAME-only
 // data — no secrets. `maxUpdatedMs` is the newest mirrored issue `updated_at` (epoch-ms) or
 // null; staleness is whole seconds since then (null when unknown — never a bogus number).
-export function freshnessFields({ rows = null, maxUpdatedMs = null, status = null, cursor = null, hostName = null, now = Date.now() } = {}) {
+// `lastFrameAt` (CTL-1508, SDK 0.6.0 `replica.lastFrameAt`) is the epoch-ms of the last
+// inbound socket frame of ANY kind; frame_staleness mirrors the staleness idiom — whole
+// seconds since then, null when unknown (older SDK / pre-first-frame / reader mode).
+export function freshnessFields({ rows = null, maxUpdatedMs = null, status = null, cursor = null, hostName = null, lastFrameAt = null, now = Date.now() } = {}) {
   const mx = Number(maxUpdatedMs);
   const staleness =
     Number.isFinite(mx) && mx > 0 ? Math.max(0, Math.round((now - mx) / 1000)) : null;
+  const lf = Number(lastFrameAt);
+  const frameStaleness =
+    Number.isFinite(lf) && lf > 0 ? Math.max(0, Math.round((now - lf) / 1000)) : null;
   return {
     "catalyst.linear.replica.staleness": staleness,
     "catalyst.linear.replica.rows": rows == null ? null : Number(rows) || 0,
     "catalyst.linear.replica.status": status ?? null,
     "catalyst.linear.replica.cursor": cursor ?? null,
+    "catalyst.linear.replica.frame_staleness": frameStaleness,
     "host.name": hostName ?? null,
   };
 }
@@ -28,29 +37,46 @@ export function freshnessFields({ rows = null, maxUpdatedMs = null, status = nul
 export const UNHEALTHY_SDK_STATUSES = new Set(["reconnecting", "error", "stopped"]);
 
 // classifyStall — decide the cloud-sync writer's stall posture from cursor-advance AND
-// the SDK connection status. Cursor-silence ALONE is AMBIGUOUS: a healthy QUIET feed (no
-// Linear changes for the window) and a dead/half-open socket BOTH freeze `replica.cursor`
-// — replica-read.mjs:102-118 documents exactly this (the `-wal`/apply cadence goes stale
-// on a quiet feed, which is why writer liveness keys on the `.writer.lock` heartbeat, not
-// cursor movement). So we must NEVER page or self-heal (restart) on cursor-silence alone:
-// that false-kills a perfectly current idle node every quiet window (Codex P1/P2) and
-// re-seeds/pages needlessly. The SDK (0.4.0) exposes no per-frame keepalive/last-frame
-// timestamp, so we gate the destructive action on an ADDITIONAL independent liveness
-// failure the cursor can't fake — the SDK's own connection status:
+// an INDEPENDENT transport-liveness signal. Cursor-silence ALONE is AMBIGUOUS: a healthy
+// QUIET feed (no Linear changes for the window) and a dead/half-open socket BOTH freeze
+// `replica.cursor` — replica-read.mjs:102-118 documents exactly this (the `-wal`/apply
+// cadence goes stale on a quiet feed, which is why writer liveness keys on the
+// `.writer.lock` heartbeat, not cursor movement). So we must NEVER page or self-heal
+// (restart) on cursor-silence alone: that false-kills a perfectly current idle node every
+// quiet window (Codex P1/P2) and re-seeds/pages needlessly. Two independent confirmations
+// the cursor can't fake, EITHER of which upgrades cursor-silence to a genuine stall:
+//   (a) the SDK's own connection status is unhealthy (reconnecting/error/stopped) — the
+//       original CTL-1420 gate, derived from the WebSocket lifecycle; and
+//   (b) CTL-1508 (SDK 0.6.0): `lastFrameAt` — epoch-ms of the last inbound frame of ANY
+//       kind — has ALSO been frozen for the whole frameStallMs window. Crucially the
+//       CTC-135 watchdog's auto-pongs stamp lastFrameAt too (unlike lastChangeFrameAt,
+//       which ignores pongs), and the SDK pings after ~90s of idle silence — so a healthy
+//       quiet feed keeps lastFrameAt fresh via ping/pong and a lastFrameAt frozen across a
+//       10-minute window is something a healthy socket CANNOT produce. This catches the
+//       18.5h-RCA half-open socket whose `status` sat latched "live" (onclose never fired),
+//       which gate (a) alone was blind to.
+// Feature-detected: older SDKs (< 0.6.0) pass lastFrameAt null/undefined and the result is
+// BIT-IDENTICAL to the status-only classifier — frame-silence simply never asserts.
 //   • cursor advanced within the window                 → healthy (no alert, no restart)
-//   • cursor stalled, SDK status healthy ("live"/…)     → AMBIGUOUS quiet feed → NO alert,
+//   • cursor stalled, SDK status healthy, frames fresh  → AMBIGUOUS quiet feed → NO alert,
 //        NO restart (surface the cursor-stall only as observational freshness telemetry)
-//   • cursor stalled AND SDK status unhealthy           → GENUINE stall (independent
+//   • cursor stalled AND (unhealthy status OR frame-silence) → GENUINE stall (independent
 //        confirmation) → loud ERROR alert + self-heal restart
-export function classifyStall({ rows = null, stalledMs = 0, stallMs = 600_000, status = null } = {}) {
+export function classifyStall({ rows = null, stalledMs = 0, stallMs = 600_000, status = null, lastFrameAt = null, frameStallMs = stallMs, now = Date.now() } = {}) {
   const cursorStalled = (rows ?? 0) > 0 && stalledMs >= stallMs;
   const sdkUnhealthy = UNHEALTHY_SDK_STATUSES.has(String(status));
-  // A GENUINE stall needs BOTH signals — cursor-silence is only actionable when the SDK
-  // independently reports the transport is not healthy.
-  const genuine = cursorStalled && sdkUnhealthy;
+  // Frame-silence is only meaningful when the SDK actually surfaces lastFrameAt (finite
+  // number). null/undefined (older SDK, pre-first-frame, reader mode) must NEVER assert —
+  // that keeps the classifier bit-identical to CTL-1420 behavior for older SDKs.
+  const frameSilent = Number.isFinite(lastFrameAt) && now - lastFrameAt >= frameStallMs;
+  // A GENUINE stall needs cursor-silence PLUS at least one independent transport-liveness
+  // failure — either the SDK admits the socket is unhealthy, or the socket has produced NO
+  // inbound bytes (not even watchdog pongs) for the whole window while claiming health.
+  const genuine = cursorStalled && (sdkUnhealthy || frameSilent);
   return {
     cursorStalled,
     sdkUnhealthy,
+    frameSilent,
     genuine,
     alert: genuine, // page ONLY on a genuine stall — never on a quiet-but-healthy feed
     restart: genuine, // self-heal ONLY on a genuine stall — never false-kill an idle node
@@ -74,5 +100,72 @@ export function readReplicaCounts(sql) {
     return { rows, maxUpdatedMs: Number.isFinite(mx) ? mx : null };
   } catch {
     return { rows: null, maxUpdatedMs: null };
+  }
+}
+
+// exitAfterClose — CTL-1508: bound an exit-path `replica.close()` with a hard deadline.
+// RCA: both writer exit paths (`SIGTERM shutdown` and the genuine-stall self-heal) did
+// `void replica.close().finally(() => process.exit(N))` with NO timeout — but the stall
+// path's close() runs over the very dead/half-open socket that CAUSED the stall, the
+// close() most likely to never settle. A hung close() stranded the process half-dead
+// (hbTimer already cleared, so even heartbeats stopped) and launchd never re-spawned it
+// because it never exited. Races closePromise against a deadline timer and calls
+// exit(exitCode) EXACTLY ONCE, whichever settles first; a rejected close() also exits
+// (the exit code is the contract, the close outcome is best-effort). Additionally arms an
+// unref'd failsafe timer at timeoutMs+1000 — belt-and-braces so even a wedged microtask
+// queue (the promise callbacks never running) cannot strand the process: timer callbacks
+// are macrotasks and still fire. unref'd so the failsafe itself never holds an otherwise
+// finished process open. Injectable exit/setTimeoutFn so tests never call the real ones.
+export function exitAfterClose({ closePromise, exitCode, timeoutMs = 3_000, exit = process.exit, setTimeoutFn = setTimeout } = {}) {
+  let fired = false;
+  const fire = () => {
+    if (fired) return; // exactly-once: the losers of the race become no-ops
+    fired = true;
+    exit(exitCode);
+  };
+  const deadline = setTimeoutFn(fire, timeoutMs);
+  const failsafe = setTimeoutFn(fire, timeoutMs + 1_000);
+  // unref where supported (fake test timers may not implement it): the failsafe must not
+  // keep the process alive on its own; the primary deadline stays ref'd — it is the
+  // guarantee that the event loop cannot drain before the exit happens.
+  if (typeof failsafe?.unref === "function") failsafe.unref();
+  void deadline; // ref'd on purpose (see above)
+  // .then(fire, fire): exit on resolve AND on reject, without an unhandled-rejection.
+  Promise.resolve(closePromise).then(fire, fire);
+}
+
+// --- CTL-1508 self-heal breadcrumb ---------------------------------------------------
+// Cross-ticket contract (consumed by CTL-1509's external responder and doctor): when the
+// writer self-heals (genuine-stall exit 1), it drops `~/catalyst/cloud-sync.selfheal.json`
+// BEFORE initiating close, and the NEXT boot deletes it on reaching 'live'. Therefore:
+//   breadcrumb present + writer process ABSENT → launchd did NOT re-spawn the writer
+//     (the launchd-no-respawn signature an external responder pages on);
+//   breadcrumb present + writer alive          → restart in progress / re-seeding (normal);
+//   breadcrumb absent                          → no self-heal pending.
+// Shape: { ts, cursor, stalledMs, sdkStatus, expectRestart: true } (ts = epoch-ms of the
+// self-heal decision). Both helpers are FAIL-OPEN (return false, never throw): the
+// breadcrumb must never block the exit, and a missing file on clear is the normal case.
+
+// writeSelfHealBreadcrumb — atomic tmp+rename (the writeBootMarker idiom, recovery.mjs):
+// CTL-1509's responder reads this file from another process, so it must never observe a
+// torn write. fs deps injectable for tests.
+export function writeSelfHealBreadcrumb(path, { cursor = null, stalledMs = null, sdkStatus = null } = {}, { writeFile = writeFileSync, rename = renameSync, now = Date.now } = {}) {
+  try {
+    const tmp = `${path}.tmp`;
+    writeFile(tmp, JSON.stringify({ ts: now(), cursor, stalledMs, sdkStatus, expectRestart: true }));
+    rename(tmp, path);
+    return true;
+  } catch {
+    return false; // fail-open — the self-heal exit proceeds breadcrumb-less
+  }
+}
+
+// clearSelfHealBreadcrumb — consumed on the next boot's 'live' (restart proven to work).
+export function clearSelfHealBreadcrumb(path, { unlink = unlinkSync } = {}) {
+  try {
+    unlink(path);
+    return true;
+  } catch {
+    return false; // fail-open — ENOENT (no pending self-heal) is the normal case
   }
 }

--- a/plugins/dev/scripts/execution-core/cloud-sync.mjs
+++ b/plugins/dev/scripts/execution-core/cloud-sync.mjs
@@ -45,11 +45,15 @@
 //   • SIGTERM/SIGINT             → close() (releases the writer lock) + exit 0  (no restart)
 //   • start() throws / fatal     → exit 1  (launchd restarts with backoff; a stale
 //                                   self-lock auto-reclaims after ~15s)
+//   • genuine stall (watchdog)   → self-heal breadcrumb + close() + exit 1  (restart)
+// CTL-1508: BOTH close()-then-exit paths are bounded by CATALYST_CLOUD_SYNC_CLOSE_TIMEOUT_MS
+// (default 3s) via exitAfterClose — a close() wedged on a dead socket can no longer strand
+// the process in a half-dead never-exits state launchd cannot recover from.
 import { CatalystReplica } from "@catalyst-cloud/sdk/node";
-import { getHostName, getReplicaDbPath, resolveNodeCloudTokenEnv, HEARTBEAT_INTERVAL_MS } from "./config.mjs";
+import { getCloudSyncSelfHealPath, getHostName, getReplicaDbPath, resolveNodeCloudTokenEnv, HEARTBEAT_INTERVAL_MS } from "./config.mjs";
 import { logDaemonHeartbeat } from "../lib/daemon-heartbeat.mjs";
 import { sdkLogRecord } from "./cloud-sync-log.mjs";
-import { classifyStall, freshnessFields, readReplicaCounts } from "./cloud-sync-telemetry.mjs";
+import { classifyStall, clearSelfHealBreadcrumb, exitAfterClose, freshnessFields, readReplicaCounts, writeSelfHealBreadcrumb } from "./cloud-sync-telemetry.mjs";
 import { createRequire } from "node:module";
 
 const TAG = "[catalyst-cloud-sync]";
@@ -102,6 +106,12 @@ function resolveStartTimeoutMs(raw) {
   return Number.isFinite(n) && n > 0 ? n : 120_000;
 }
 const startTimeoutMs = resolveStartTimeoutMs(process.env.CATALYST_REPLICA_START_TIMEOUT_MS);
+// CTL-1508: hard deadline on the exit-path replica.close() (both SIGTERM/SIGINT and the
+// genuine-stall self-heal). close() over a dead/half-open socket — the stall path's most
+// likely socket — can hang forever; unbounded, that stranded a half-dead writer (hbTimer
+// already cleared, heartbeats stopped) that launchd could never replace because the
+// process never exited. See exitAfterClose in cloud-sync-telemetry.mjs.
+const CLOSE_TIMEOUT_MS = Number(process.env.CATALYST_CLOUD_SYNC_CLOSE_TIMEOUT_MS) || 3_000;
 const dbPath = getReplicaDbPath();
 const { envVar, source } = resolveNodeCloudTokenEnv();
 const token = process.env[envVar];
@@ -157,8 +167,11 @@ const shutdown = (sig) => {
   closing = true;
   if (hbTimer) clearInterval(hbTimer);
   console.log(`${TAG} ${sig} — closing (releasing writer lock)`);
-  // close() is idempotent: stops the socket, releases the lock, closes the DB.
-  void replica.close().finally(() => process.exit(0));
+  // close() is idempotent: stops the socket, releases the lock, closes the DB. CTL-1508:
+  // bounded — a close() wedged on a dead socket must not strand a manual stop forever.
+  // Still exit 0 whether close settles or times out: KeepAlive={SuccessfulExit:false}
+  // must NOT restart a deliberate stop.
+  exitAfterClose({ closePromise: replica.close(), exitCode: 0, timeoutMs: CLOSE_TIMEOUT_MS });
 };
 process.on("SIGTERM", () => shutdown("SIGTERM"));
 process.on("SIGINT", () => shutdown("SIGINT"));
@@ -176,6 +189,12 @@ try {
   process.exit(1);
 }
 console.log(`${TAG} live — replica seeded + tailing the change feed (cursor=${replica.cursor})`);
+
+// CTL-1508: reaching 'live' proves a prior self-heal restart WORKED, so consume the
+// breadcrumb the pre-restart run dropped (see the genuine-stall block below for the full
+// CTL-1509 contract). Best-effort — a missing file (no self-heal pending) is the normal
+// case and clearSelfHealBreadcrumb never throws.
+clearSelfHealBreadcrumb(getCloudSyncSelfHealPath());
 
 // CTL-1395: liveness + freshness telemetry. Every HEARTBEAT_INTERVAL_MS emit (a) the
 // CTL-1280 `daemon heartbeat` marker — feed-independent proof the writer is alive, → the
@@ -197,10 +216,20 @@ console.log(`${TAG} live — replica seeded + tailing the change feed (cursor=${
 // goes stale on a quiet feed, which is why writer liveness keys on the `.writer.lock`
 // heartbeat, not cursor movement). Keying "stalled" on cursor-silence alone therefore
 // false-classifies a perfectly current idle node and would re-seed/restart/page every quiet
-// window. The SDK (0.4.0) exposes no per-frame keepalive/last-frame timestamp, so we gate the
+// window. The SDK (0.4.0) exposed no per-frame keepalive/last-frame timestamp, so we gate the
 // destructive action on an ADDITIONAL independent liveness failure the cursor can't fake —
-// the SDK's own connection status (classifyStall). A GENUINE stall = cursor-silence AND an
-// unhealthy SDK status (reconnecting/error/stopped); only THEN do we:
+// the SDK's own connection status (classifyStall).
+// CTL-1508 (SDK 0.6.0): the SDK now DOES surface `replica.lastFrameAt` — epoch-ms of the
+// last inbound socket bytes of ANY kind, INCLUDING the CTC-135 watchdog's pong traffic
+// (unlike `lastChangeFrameAt`, which ignores pongs). A healthy quiet feed keeps lastFrameAt
+// fresh via ping/pong (the SDK pings after ~90s of idle), so a lastFrameAt frozen across
+// the whole stall window is something a healthy socket CANNOT produce — it independently
+// confirms the half-open case even while `status` sits latched "live" (exactly the 18.5h
+// RCA shape gate-by-status alone was blind to). classifyStall therefore accepts EITHER
+// confirmation; feature-detected via typeof so an older SDK (getter absent) degrades
+// bit-identically to the status-only classifier. A GENUINE stall = cursor-silence AND
+// (an unhealthy SDK status (reconnecting/error/stopped) OR whole-window frame-silence);
+// only THEN do we:
 //   (1) surface status="stalled" in the freshness line (a mere quiet feed keeps its real status);
 //   (2) emit the LOUD ERROR alert to Loki (the alarm Ryan asked for — now fires only on a
 //       PROVABLE stall, never on a quiet-but-healthy feed, so no false pages every quiet window);
@@ -222,22 +251,31 @@ const emitTelemetry = () => {
   if (cursor !== _lastCursor) { _lastCursor = cursor; _lastAdvanceMs = now; _stallAlerted = false; }
   const stalledMs = now - _lastAdvanceMs;
   const sdkStatus = replica.status ?? "live";
+  // CTL-1508: per-frame transport liveness (SDK 0.6.0). Feature-detect via typeof — an
+  // older SDK has no getter (undefined) and MUST degrade to the status-only classifier
+  // bit-identically, so anything non-number becomes null (which never asserts).
+  const lastFrameAt = typeof replica.lastFrameAt === "number" ? replica.lastFrameAt : null;
   // A stall is GENUINE (alert + self-heal) only when cursor-silence is CONFIRMED by an
-  // independent SDK connection-liveness failure — never on cursor-silence alone, which a
-  // healthy quiet feed produces identically (Codex P1/P2).
-  const { genuine, restart, displayStatus } = classifyStall({ rows, stalledMs, stallMs: STALL_MS, status: sdkStatus });
+  // independent transport-liveness failure — an unhealthy SDK status OR whole-window
+  // frame-silence (CTL-1508) — never on cursor-silence alone, which a healthy quiet feed
+  // produces identically (Codex P1/P2).
+  const { genuine, restart, displayStatus, sdkUnhealthy, frameSilent } = classifyStall({ rows, stalledMs, stallMs: STALL_MS, status: sdkStatus, lastFrameAt, now });
   if (!genuine) _stallAlerted = false; // re-arm the one-shot alert for the next genuine stall
   try {
     hlog.info(
-      freshnessFields({ rows, maxUpdatedMs, status: displayStatus, cursor, hostName: getHostName() }),
+      freshnessFields({ rows, maxUpdatedMs, status: displayStatus, cursor, hostName: getHostName(), lastFrameAt, now }),
       "cloud-sync: freshness",
     );
   } catch { /* best-effort — telemetry must never crash the writer */ }
   if (genuine && !_stallAlerted) {
     _stallAlerted = true;
     // The alarm that was missing for 18.5h — now gated on an independent liveness failure
-    // (unhealthy SDK status) so it never fires on a quiet-but-healthy feed. ERROR severity
-    // → ships via hlog→Alloy→Loki.
+    // (unhealthy SDK status, or CTL-1508 whole-window frame-silence) so it never fires on
+    // a quiet-but-healthy feed. ERROR severity → ships via hlog→Alloy→Loki. The reason
+    // clause names WHICH confirmation fired (frame-silence implies a finite lastFrameAt).
+    const reason = sdkUnhealthy
+      ? `unhealthy SDK status=${sdkStatus}`
+      : `NO inbound frames for ${Math.round((now - lastFrameAt) / 1000)}s (not even watchdog pongs) despite SDK status=${sdkStatus}`;
     try {
       hlog.error(
         {
@@ -247,16 +285,36 @@ const emitTelemetry = () => {
           stalledMs,
           rows,
           "sdk.status": sdkStatus,
+          // CTL-1508: which independent confirmation(s) upgraded cursor-silence to genuine,
+          // plus the raw frame timestamp (null on an older SDK) for the responder/RCA.
+          "sdk.unhealthy": sdkUnhealthy,
+          "sdk.frame_silent": frameSilent,
+          "sdk.last_frame_at": lastFrameAt,
           "host.name": getHostName(),
         },
-        `cloud-sync: replica cursor STALLED ${Math.round(stalledMs / 1000)}s (>${Math.round(STALL_MS / 1000)}s) with unhealthy SDK status=${sdkStatus} — reads are going stale; self-healing via restart`,
+        `cloud-sync: replica cursor STALLED ${Math.round(stalledMs / 1000)}s (>${Math.round(STALL_MS / 1000)}s) with ${reason} — reads are going stale; self-healing via restart`,
       );
     } catch { /* the alarm must never crash the writer */ }
     if (restart) {
       // Self-heal: stop the timer, close the replica, and exit non-zero so launchd
       // (KeepAlive={SuccessfulExit:false}) re-spawns with a fresh socket + re-seed.
+      //
+      // CTL-1508 SELF-HEAL BREADCRUMB — a cross-ticket contract consumed by CTL-1509's
+      // external responder and doctor. BEFORE initiating close, atomically drop
+      // ~/catalyst/cloud-sync.selfheal.json = {ts, cursor, stalledMs, sdkStatus,
+      // expectRestart: true}; the NEXT boot deletes it on reaching 'live' (above). So:
+      //   breadcrumb present + writer process ABSENT → launchd did NOT re-spawn us —
+      //     the launchd-no-respawn signature the responder pages on / doctor flags;
+      //   breadcrumb present + writer alive          → restart in progress (normal);
+      //   breadcrumb absent                          → no self-heal pending.
+      // Best-effort by construction (writeSelfHealBreadcrumb never throws) — the
+      // breadcrumb must never block the exit.
+      writeSelfHealBreadcrumb(getCloudSyncSelfHealPath(), { cursor, stalledMs, sdkStatus });
       try { if (hbTimer) clearInterval(hbTimer); } catch { /* best-effort */ }
-      void replica.close().catch(() => {}).finally(() => process.exit(1));
+      // CTL-1508: bounded exit — this close() runs over the very dead socket that CAUSED
+      // the stall (the close most likely to hang). Unbounded, a hung close stranded a
+      // half-dead writer (heartbeats stopped above) that launchd could never replace.
+      exitAfterClose({ closePromise: replica.close(), exitCode: 1, timeoutMs: CLOSE_TIMEOUT_MS });
     }
   }
 };

--- a/plugins/dev/scripts/execution-core/config.mjs
+++ b/plugins/dev/scripts/execution-core/config.mjs
@@ -1756,6 +1756,15 @@ export function getReplicaDbPath() {
   return process.env.CATALYST_REPLICA_DB || resolve(catalystDir(), "catalyst-replica.db");
 }
 
+// CTL-1508: path to the cloud-sync self-heal breadcrumb — dropped by the writer just
+// before a genuine-stall exit(1), cleared on the next boot's 'live'. Lives beside the
+// writer's log/DB under ~/catalyst so CTL-1509's external responder and doctor find it at
+// a stable path. Re-resolved per call (the catalystDir() idiom) so tests redirect via
+// CATALYST_DIR.
+export function getCloudSyncSelfHealPath() {
+  return resolve(catalystDir(), "cloud-sync.selfheal.json");
+}
+
 // --- Catalyst-Cloud token resolution (CTL-1394) ---
 // The supervised cloud-sync daemon reads its cloud token from a STANDARD env-var NAME —
 // `CATALYST_CLOUD_TOKEN` — on EVERY host (the same name cloud-token-env.mjs / CTL-1307


### PR DESCRIPTION
## Problem (CTL-1508)

Adversarially-reviewed RCA of the 2026-07-23 replica-writer incident (mini-2 down 13.5 h → all reads on the rate-limited per-user `linearis` path):

- **Both** exit paths in `cloud-sync.mjs` (genuine-stall self-heal and SIGTERM `shutdown()`) did `replica.close().finally(exit)` — a `close()` that never settles on a dead socket strands the process with its heartbeat already stopped.
- `classifyStall` could not tell a quiet feed from a half-open socket: both minis' cursors froze at the same cursor at ~14:05Z with status still reading healthy for **93 minutes** (mini alone logged ≥6 such multi-hour silent stalls Jul 17–23).
- After the self-heal `exit(1)`, launchd — with verified-correct loaded `KeepAlive={SuccessfulExit:false}` — **did not respawn** mini-2's writer (cause unexplained; unified log empty). The writer must not depend on that respawn.

## Fix (three parts)

1. **`exitAfterClose`** (`cloud-sync-telemetry.mjs`, exported + unit-tested): races `close()` against `CATALYST_CLOUD_SYNC_CLOSE_TIMEOUT_MS` (default 3000 ms) with a once-latch, plus an unref'd failsafe timer at timeout+1 s — the process exits within bound even if `close()` never settles or rejects. Wired to **both** paths; exit codes preserved (SIGTERM → 0 keeps the KeepAlive manual-stop contract, stall → 1).
2. **Self-heal breadcrumb** `~/catalyst/cloud-sync.selfheal.json` — `{ts, cursor, stalledMs, sdkStatus, expectRestart:true}`, atomic tmp+rename, fail-open, written before the stall exit and cleared at the next boot's `live`. This is the cross-ticket contract CTL-1509's out-of-process responder + doctor consume: **breadcrumb present + writer absent = the launchd-no-respawn signature** (previously invisible).
3. **`classifyStall` frame-silence arm** — SDK 0.6.0 exposes `lastFrameAt` (stamped by the CTC-135 watchdog's pongs, so a healthy quiet feed keeps it fresh while a half-open socket freezes it): `genuine = cursorStalled && (sdkUnhealthy || frameSilent)`. With `lastFrameAt` null (older SDK) behavior is **bit-identical** to the previous classifier — pinned by a 9-case parity matrix test. Detection of the half-open mode drops from 80+ min to ~2 ticks.

## Testing

- `cloud-sync-telemetry` + `cloud-sync-log`: **37 pass** (new: exitAfterClose fake-timer suite incl. never-settling close; parity matrix; 18.5h-RCA half-open case; quiet-but-ponging guard; breadcrumb atomicity/fail-open/clear).
- Adversarial verify agent re-ran the **full** execution-core suite in the worktree and against pristine main: the 18 failures are **byte-identical pre-existing** ones — zero caused by this diff. All three behavior contracts independently CONFIRMED by reading the final code.
- `node --check` clean on all 4 changed files.

## Notes

- `freshnessFields` gains `catalyst.linear.replica.frame_staleness` (additive) — catalyst-otel dashboards may adopt it later.
- Companion PRs/tickets: CTL-1509 (out-of-process health responder consuming the breadcrumb), CTC-281 (mirror-side RCA of the fleet-wide half-open windows).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JjWhWmAg9SpQbhgicT4Lo5