### PR TITLE
chore(execution-core): bump @catalyst-cloud/sdk ^0.6.0 → ^0.7.0 (CTC-281)

### DIFF
--- a/plugins/dev/scripts/execution-core/bun.lock
+++ b/plugins/dev/scripts/execution-core/bun.lock
@@ -6,7 +6,7 @@
       "name": "catalyst-execution-core",
       "dependencies": {
         "@catalyst-cloud/read-model": "^0.1.0",
-        "@catalyst-cloud/sdk": "^0.6.0",
+        "@catalyst-cloud/sdk": "^0.7.0",
         "@opentelemetry/api": "^1.9.1",
         "@opentelemetry/exporter-trace-otlp-http": "^0.219.0",
         "@opentelemetry/resources": "^2.8.0",
@@ -51,7 +51,7 @@
 
     "@catalyst-cloud/schema": ["@catalyst-cloud/schema@0.1.3", "", { "dependencies": { "drizzle-orm": "0.44.7" } }, "sha512-qZGbGvJuvputQlX2TCH5IYAGGVJjunh7tZc9tsp4YxoE82Bj34F+zjqgtCuMTAc6yzR7rNJv90ZjZBLDNoKYwg=="],
 
-    "@catalyst-cloud/sdk": ["@catalyst-cloud/sdk@0.6.0", "", { "dependencies": { "@catalyst-cloud/read-model": "^0.1.0", "@catalyst-cloud/replicate": "^0.1.3", "@catalyst-cloud/schema": "^0.1.3" }, "peerDependencies": { "@opentelemetry/api": ">=1.3.0 <2", "@sqlite.org/sqlite-wasm": "*", "better-sqlite3": "*" }, "optionalPeers": ["@opentelemetry/api", "@sqlite.org/sqlite-wasm", "better-sqlite3"] }, "sha512-gdgTuiYtzwiFrvu98wlb4IzwqKZzcmi63Fv2eiIi5rfT2zVpNr8Q7LHfOCuUlxQtpqKuz2469kq8pNeRUiwOBw=="],
+    "@catalyst-cloud/sdk": ["@catalyst-cloud/sdk@0.7.0", "", { "dependencies": { "@catalyst-cloud/read-model": "^0.1.0", "@catalyst-cloud/replicate": "^0.1.3", "@catalyst-cloud/schema": "^0.1.3" }, "peerDependencies": { "@opentelemetry/api": ">=1.3.0 <2", "@sqlite.org/sqlite-wasm": "*", "better-sqlite3": "*" }, "optionalPeers": ["@opentelemetry/api", "@sqlite.org/sqlite-wasm", "better-sqlite3"] }, "sha512-duwFyC67upHCDbxUQkiKU4mFIbSslEEezx/s4/UO/mIkKdRUIix63oMIerWh6r21SwtrsFvWaheLCDr3Ys4SqQ=="],
 
     "@hono/node-server": ["@hono/node-server@1.19.14", "", { "peerDependencies": { "hono": "^4" } }, "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw=="],
 

--- a/plugins/dev/scripts/execution-core/package.json
+++ b/plugins/dev/scripts/execution-core/package.json
@@ -7,7 +7,7 @@
   },
   "dependencies": {
     "@catalyst-cloud/read-model": "^0.1.0",
-    "@catalyst-cloud/sdk": "^0.6.0",
+    "@catalyst-cloud/sdk": "^0.7.0",
     "@opentelemetry/api": "^1.9.1",
     "@opentelemetry/exporter-trace-otlp-http": "^0.219.0",
     "@opentelemetry/resources": "^2.8.0",


### PR DESCRIPTION
## Summary

Picks up `@catalyst-cloud/sdk@0.7.0` (published 2026-07-25), which ships the mirror-side remedy for
**CTC-281** — the fleet-wide live-sync push-feed half-opens (6 incidents Jul 17–23) that drove the
CTL-1508/1509 writer-recovery workstream. Bump + `bun.lock` refresh only; the writer already
feature-detects the SDK surface (`lastFrameAt`, CTL-1508).

## Testing

- Full execution-core suite with 0.7.0 installed: **6608 pass / 19 fail** vs main baseline
  **6607 pass / 20 fail** — the failing set is the documented pre-existing local-env flake class,
  unchanged within variance.
- Deploy plan: after merge, writer kickstart on both minis (`cloud-sync.mjs` loads the SDK at
  process start), then verify `frame_staleness` telemetry stays live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JjWhWmAg9SpQbhgicT4Lo5