### PR TITLE
fix(dev): CTL-1513 bash-3.2 comment-parsing crash in _token_provisioned (production hotfix)

### DIFF
--- a/plugins/dev/scripts/__tests__/health-responder.test.sh
+++ b/plugins/dev/scripts/__tests__/health-responder.test.sh
@@ -930,6 +930,30 @@ run "T62: a future-dated lock is treated as stale-eligible, not blocked forever"
 run "T63: sweep-lock floor formula includes the token-resolve timeout" \
   bash -c "grep -q 'RESPONDER_LIST_TIMEOUT_SECS + RESPONDER_TOKEN_RESOLVE_TIMEOUT_SECS + RESPONDER_KICKSTART_TIMEOUT_SECS' '$RESPONDER'"
 
+# T64 (CTL-1510 hotfix, own discovery — NOT a Codex round): the ENTIRE
+# script, run under /bin/bash (3.2 on Darwin — the actual interpreter
+# launchd/cron invoke via the plist's/cron line's hardcoded path; every
+# OTHER test in this suite invokes `bash "$RESPONDER"`, which resolves
+# through PATH to a newer Homebrew bash and never exercises 3.2's parser).
+# Found live on mini-2 in production: bash 3.2 has a defect where multi-line
+# comments containing an unbalanced paren/quote/colon INSIDE a `$(...)`
+# command substitution corrupt its paren-matching, surfacing as a bogus
+# "unbound variable" for a variable that IS assigned. This exact scenario
+# (a provisioned real token + a failed-bounce writer) crash-looped the
+# responder every cron cycle for hours before being caught — the writer
+# itself stayed down the whole time since the responder never completed a
+# sweep to kickstart it. Same idiom as T52c (unconditional /bin/bash — exists
+# everywhere; harmlessly passes trivially on a newer Linux /bin/bash).
+_reset
+touch "$PLIST"
+export MOCK_LAST_EXIT=0
+mkdir -p "${HOME}/.config/catalyst"
+printf 'export CATALYST_CLOUD_TOKEN=real-value\n' > "${HOME}/.config/catalyst/cloud-sync.env"
+run "T64: the full script runs clean under real /bin/bash with a provisioned token (production interpreter)" \
+  bash -c "out=\$(RESPONDER_KICKSTART_WAIT_SECS=0 /bin/bash '$RESPONDER' 2>&1); printf '%s' \"\$out\" | grep -q 'unbound variable' && exit 1; printf '%s' \"\$out\" | grep -q 'failed-bounce signature' && test -s '${KICKSTART_LOG}'"
+rm -f "${HOME}/.config/catalyst/cloud-sync.env"
+unset MOCK_LAST_EXIT
+
 # ─── results ────────────────────────────────────────────────────────────────
 
 echo ""

--- a/plugins/dev/scripts/health-responder.sh
+++ b/plugins/dev/scripts/health-responder.sh
@@ -250,31 +250,44 @@ _resolve_token_env_via_bun() {
   printf '%s' "$out"
 }
 
+# _token_provisioned's env-isolation subshell below must stay COMMENT-FREE
+# inside the `probe="$( ... )"` body (CTL-1510 hotfix, found live on mini-2):
+# bash 3.2 — the ACTUAL interpreter macOS launchd/cron invoke via the
+# plist's/cron line's hardcoded /bin/bash, never caught by this repo's own
+# test suite because `bash script.sh` there resolves through `env` to a
+# newer Homebrew bash — has a parser defect where multi-line comments
+# containing an unbalanced paren or a stray quote/colon INSIDE a `$(...)`
+# command substitution corrupt its paren-matching. The visible symptom is
+# bizarre and misleading: a `set -u` "unbound variable" (or "bad
+# substitution") error for a variable that IS assigned, at a REPORTED line
+# number that is often a comment line nowhere near the real one. Reproduced
+# 100% with the original heavily-commented version of this function and
+# vanished completely once every comment moved outside the substitution,
+# confirmed under the real system bash (`/bin/bash`, not `env bash`). This is
+# the ONLY multi-statement `="$(...)"` capture in this file — keep the code
+# inside it, keep everything else out.
+#
+# Behavior: unsets CATALYST_CLOUD_TOKEN_ENV so an override can only come from
+# the sourced files (not an ambient value); does NOT unset
+# CATALYST_LAYER2_CONFIG_FILE (unlike catalyst-stack's install-time probe,
+# which strips both to simulate launchd's clean env from an interactive
+# shell) since this responder has no different context to simulate and both
+# the bun path and the bash fallback below need to see a real override.
+# _resolve_token_env_via_bun returning empty means bun was unavailable or its
+# import failed; the fallback then replicates resolveNodeCloudTokenEnv's own
+# precedence in pure bash — env override (from the sourced files) first, then
+# the Layer-2 catalyst.cloud.tokenEnv key, then the standard name — instead
+# of hardcoding the default, which would misclassify a node with a genuinely
+# custom-named token as tokenless whenever bun happens to be unavailable.
 _token_provisioned() {
   local probe
   probe="$(
     set +u
-    # Unset only CATALYST_CLOUD_TOKEN_ENV (require an override to come from
-    # the sourced files below, not some ambient value) — NOT
-    # CATALYST_LAYER2_CONFIG_FILE. Unlike catalyst-stack's install-time probe
-    # (which strips both to simulate launchd's clean env from an interactive
-    # shell), this responder has no "different context to simulate": it
-    # resolves the token using whatever environment it actually runs under —
-    # and both the bun-based primary path (config.mjs's own
-    # getLayer2ConfigPath honors this var) and the pure-bash fallback below
-    # need to see a real CATALYST_LAYER2_CONFIG_FILE override when one is set.
     unset CATALYST_CLOUD_TOKEN_ENV 2>/dev/null || true
     [[ -r "$RESPONDER_CLUSTER_ENV_FILE" ]] && . "$RESPONDER_CLUSTER_ENV_FILE"
     [[ -r "$RESPONDER_TOKEN_FILE" ]] && . "$RESPONDER_TOKEN_FILE"
     name="$(_resolve_token_env_via_bun)"
     if [[ -z "$name" ]]; then
-      # bun unavailable or the import failed — replicate
-      # resolveNodeCloudTokenEnv's own precedence in pure bash (Codex P2
-      # round 4) instead of hardcoding the default: env override (as set by
-      # one of the just-sourced files) wins, then the Layer-2
-      # catalyst.cloud.tokenEnv key, then the standard name. A silent
-      # hardcode here would classify a node with a genuinely custom-named
-      # token as tokenless whenever bun happens to be unavailable.
       if [[ -n "${CATALYST_CLOUD_TOKEN_ENV:-}" ]]; then
         name="$CATALYST_CLOUD_TOKEN_ENV"
       else


### PR DESCRIPTION
## Summary

**Live production incident.** mini-2's CTL-1510 health responder crash-looped on every launchd/cron invocation since deploy (~08:45Z) — a bogus `set -u` "unbound variable: name" error, never completing a sweep. This included never kickstarting the writer during a real failed-bounce window (the exact scenario CTL-1510 item 0 exists to recover). **Mitigated immediately** via manual `launchctl kickstart` of the writer (confirmed healthy); this PR fixes the responder itself.

**Root cause:** bash 3.2 (Apple's shipped system bash — the *actual* interpreter launchd/cron invoke via the plist's/cron line's hardcoded `/bin/bash`) has a parser defect: multi-line comments containing an unbalanced paren, stray quote, or colon **inside** a `$(...)` command substitution corrupt its paren-matching. `_token_provisioned()`'s `probe="$( ... )"` block (added in CTL-1510 round 3) had exactly this shape — several paragraphs of explanatory prose living inside the substitution. `bash -n` passes cleanly under both bash versions; only full *execution* under the real interpreter reproduces it.

This repo's own test suite never caught it: every existing test invokes the responder via a bare `bash "$RESPONDER"`, which resolves through PATH/`env` to Homebrew bash 5.x on a dev machine — never the hardcoded `/bin/bash` 3.2 production actually runs.

**Fix:** moved every comment out of the `probe="$( ... )"` block, keeping the subshell body as pure code — the only safe shape for a multi-statement `="$(...)"` capture under bash 3.2. Verified by reproducing the exact mini-2 scenario (a provisioned real token + a failed-bounce writer) under real `/bin/bash`, both before (crashes) and after (correctly kickstarts) the fix.

Closes **CTL-1513**.

## Testing

- **T64** (new): runs the full script under real `/bin/bash` (not `env bash`) with a provisioned token — the exact production scenario. Confirmed it **fails without the fix and passes with it** (same idiom as T52c, which pinned the earlier round-1 bash-3.2 escaping bug).
- `health-responder.test.sh`: 121 → 122, all green.
- `doctor.test.mjs`: unaffected, 264 pass.
- Stability-verified over 3 additional full-suite runs, zero flakes.

## Deploy plan

After merge: pull latest on both minis, no `adopt-cloud-sync` needed (plugin-source auto-pull suffices for a bash script — no install step changed), confirm the responder completes a real sweep without crashing on its next cron/launchd cycle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JjWhWmAg9SpQbhgicT4Lo5