### PR TITLE
fix(dev): CTL-1519 close delegate-runner log fd after detached spawn (fd leak → EMFILE)

### DIFF
--- a/plugins/dev/scripts/execution-core/delegate-runner.mjs
+++ b/plugins/dev/scripts/execution-core/delegate-runner.mjs
@@ -27,7 +27,7 @@
 // NAMESPACE: this module emits NO events. Dispatch lifecycle events
 // (phase.dispatch.*) are emitted by the detached drainer (delegate-runner-entry.mjs).
 
-import { openSync, mkdirSync } from "node:fs";
+import { openSync, closeSync, mkdirSync } from "node:fs";
 import { spawn as nodeSpawn } from "node:child_process";
 import { join, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -54,6 +54,18 @@ function realClock() {
 function defaultOpenLogFd(logPath) {
   mkdirSync(dirname(logPath), { recursive: true });
   return openSync(logPath, "a");
+}
+
+// defaultCloseLogFd — close the PARENT's copy of the child log fd after the
+// detached spawn has inherited (dup'd) it. CTL-1519: omitting this close leaked
+// exactly one fd per tick (POSIX spawn() forks synchronously and dup's the fd
+// into the child before returning, so the parent's copy is redundant). At the
+// 15s cadence that is ~240 fds/hr, all pointing at delegate-runner.log, marching
+// the long-lived daemon toward EMFILE. Injectable so tests assert the close
+// without operating on a real fd (the fake fds tests inject, e.g. 5/77, must
+// never reach the real closeSync).
+function defaultCloseLogFd(fd) {
+  closeSync(fd);
 }
 
 // defaultIsRunnerRunning — the single-instance guard the timer consults BEFORE
@@ -91,6 +103,7 @@ function defaultIsRunnerRunning(orchDir) {
  * @param {string}   [opts.entryPath]          detached entrypoint (injectable for tests)
  * @param {Function} [opts.spawn]              injectable async spawn (NEVER spawnSync)
  * @param {Function} [opts.openLogFd]          injectable fd opener for the child log
+ * @param {Function} [opts.closeLogFd]         injectable fd closer (CTL-1519: closes the parent copy post-spawn)
  * @param {Function} [opts.isRunnerRunning]    injectable single-instance probe
  * @param {object}   [opts.clock]              fake-clock seam for tests
  */
@@ -101,6 +114,7 @@ export function startDelegateRunnerTimer({
   entryPath = DELEGATE_RUNNER_ENTRY,
   spawn = nodeSpawn,
   openLogFd = defaultOpenLogFd,
+  closeLogFd = defaultCloseLogFd,
   isRunnerRunning = defaultIsRunnerRunning,
   clock = realClock(),
 } = {}) {
@@ -130,15 +144,30 @@ export function startDelegateRunnerTimer({
       // (3) DETACHED spawn + unref. stdin ignored; stdout/stderr → the log fd.
       //     spawn (async) ONLY — never spawnSync (which would block the daemon
       //     loop, the exact thing this whole design moves work OFF of).
-      const child = spawn(process.execPath, [entryPath], {
-        detached: true,
-        stdio: ["ignore", logFd, logFd],
-        // CTL-1331 FU-1: the detached entry resolves its orchDir from
-        // CATALYST_EXECUTION_CORE_DIR — pass it explicitly so the child drains the
-        // correct queue even when the daemon's own env doesn't carry it.
-        env: { ...process.env, CATALYST_EXECUTION_CORE_DIR: orchDir },
-      });
-      if (child && typeof child.unref === "function") child.unref();
+      try {
+        const child = spawn(process.execPath, [entryPath], {
+          detached: true,
+          stdio: ["ignore", logFd, logFd],
+          // CTL-1331 FU-1: the detached entry resolves its orchDir from
+          // CATALYST_EXECUTION_CORE_DIR — pass it explicitly so the child drains the
+          // correct queue even when the daemon's own env doesn't carry it.
+          env: { ...process.env, CATALYST_EXECUTION_CORE_DIR: orchDir },
+        });
+        if (child && typeof child.unref === "function") child.unref();
+      } finally {
+        // (4) CTL-1519: close the PARENT's copy of the log fd. The detached
+        //     child inherited its own dup of this fd (its stdout/stderr) during
+        //     the synchronous POSIX fork, so the parent copy is redundant the
+        //     instant spawn() returns. In `finally` so it also closes if spawn()
+        //     throws (e.g. EAGAIN/EMFILE) — the very error path where leaking the
+        //     just-opened fd would compound exhaustion. Append mode means the
+        //     child's writes are unaffected for its whole lifetime.
+        try {
+          closeLogFd(logFd);
+        } catch (err) {
+          log.warn({ err: err?.message }, "delegate-runner: log fd close failed");
+        }
+      }
     } catch (err) {
       log.warn({ err: err?.message }, "delegate-runner: kick error");
     }

--- a/plugins/dev/scripts/execution-core/delegate-runner.test.mjs
+++ b/plugins/dev/scripts/execution-core/delegate-runner.test.mjs
@@ -703,6 +703,7 @@ describe("startDelegateRunnerTimer — detached spawn().unref() kick", () => {
     const clock = fakeClock();
     const spy = makeSpawnSpy();
     let openedLogPath = null;
+    let closedFd = null;
     startDelegateRunnerTimer({
       enabled: true,
       intervalMs: 15000,
@@ -715,6 +716,12 @@ describe("startDelegateRunnerTimer — detached spawn().unref() kick", () => {
       openLogFd: (p) => {
         openedLogPath = p;
         return 77; // a fake fd
+      },
+      // CTL-1519: inject the closer so the real closeSync(77) is NEVER called on
+      // an unrelated live descriptor — and assert the fd handed to the child is
+      // the exact one closed afterward.
+      closeLogFd: (fd) => {
+        closedFd = fd;
       },
     });
     clock.advance(15000);
@@ -729,6 +736,8 @@ describe("startDelegateRunnerTimer — detached spawn().unref() kick", () => {
     // the log target is under <orchDir>/logs/delegate-runner.log
     expect(openedLogPath).toContain(join(orchDir, "logs"));
     expect(openedLogPath).toContain("delegate-runner.log");
+    // CTL-1519: the parent's copy of that exact fd is closed post-spawn.
+    expect(closedFd).toBe(77);
   });
 
   test("DETACHED INVARIANT — the spawn fn is the injectable async spawn, NEVER spawnSync", () => {
@@ -747,6 +756,9 @@ describe("startDelegateRunnerTimer — detached spawn().unref() kick", () => {
       clock,
       isRunnerRunning: () => false,
       openLogFd: () => 5,
+      // CTL-1519: inject the closer so the default closeSync(5) never touches a
+      // real (possibly bun-internal) descriptor in the test process.
+      closeLogFd: () => {},
     });
     clock.advance(15000);
     // Exactly one async spawn; no third positional that smells synchronous.
@@ -836,6 +848,78 @@ describe("startDelegateRunnerTimer — detached spawn().unref() kick", () => {
       openLogFd: () => 5,
     });
     expect(unrefed).toBe(true);
+  });
+
+  // CTL-1519: the parent's log fd is closed on EVERY kick, so open/close stay
+  // balanced and the daemon's live fd count is bounded (not growing with uptime).
+  // This is the guard that goes RED on the pre-fix code (nothing closed) and
+  // GREEN after — it directly encodes the fd-leak-regression contract that the
+  // live lsof on mini-2 exposed (1319 handles to one delegate-runner.log).
+  test("CTL-1519 — closes the parent log fd every kick; open/close balanced across N ticks (no fd leak)", () => {
+    const clock = fakeClock();
+    const opened = [];
+    const closed = [];
+    let nextFd = 100;
+    // spawn spy that ALSO pins ordering: closeLogFd must NOT have fired yet at
+    // the moment spawn() is invoked (the parent must close strictly AFTER the
+    // detached child has inherited its dup — else the child logs to a dead fd).
+    const spawn = () => {
+      expect(closed).toHaveLength(opened.length - 1); // this kick's fd not closed yet
+      return { unref() {}, pid: 1234 };
+    };
+    startDelegateRunnerTimer({
+      enabled: true,
+      intervalMs: 15000,
+      orchDir,
+      entryPath: "/fake/entry.mjs",
+      spawn,
+      clock,
+      isRunnerRunning: () => false,
+      openLogFd: () => {
+        const fd = nextFd++;
+        opened.push(fd);
+        return fd;
+      },
+      closeLogFd: (fd) => {
+        closed.push(fd);
+      },
+    });
+    const N = 50;
+    clock.advance(15000 * N);
+
+    expect(opened).toHaveLength(N);
+    // every opened fd is closed, in open order → net live parent fds after N ticks = 0.
+    expect(closed).toEqual(opened);
+    expect(opened.filter((fd) => !closed.includes(fd))).toHaveLength(0);
+  });
+
+  // CTL-1519: the close lives in a `finally`, so the just-opened fd is released
+  // even when spawn() itself throws (EAGAIN/EMFILE) — the very error path where
+  // leaking it would compound descriptor exhaustion. The throw stays swallowed
+  // by the callback's outer guard (no kick ever escalates out of the timer).
+  test("CTL-1519 — closes the log fd even when spawn throws (finally); no leak on the error path", () => {
+    const clock = fakeClock();
+    const closed = [];
+    expect(() => {
+      startDelegateRunnerTimer({
+        enabled: true,
+        intervalMs: 15000,
+        orchDir,
+        entryPath: "/fake/entry.mjs",
+        spawn: () => {
+          throw new Error("EAGAIN");
+        },
+        clock,
+        isRunnerRunning: () => false,
+        openLogFd: () => 9,
+        closeLogFd: (fd) => {
+          closed.push(fd);
+        },
+      });
+      clock.advance(15000);
+    }).not.toThrow();
+    // the fd opened for the failed spawn is still released in the finally.
+    expect(closed).toEqual([9]);
   });
 });
 


### PR DESCRIPTION
## CTL-1519 — file-descriptor leak in execution-core delegate-runner

**Root cause (found via live `lsof` on mini-2):** the in-daemon delegate-runner timer (`delegate-runner.mjs`) opens a fresh append fd on `<orchDir>/logs/delegate-runner.log` **every 15s tick** for the detached child's stdout/stderr, and never closes the parent's copy. POSIX `spawn()` forks synchronously and dup's the fd into the child before returning, so the parent copy is redundant — leaving it open leaks **one fd per tick (~240/hr)**.

On mini-2's execution-core daemon, **1319 of 1341 open fds were that single file**. Trajectory: EMFILE → daemon crash, masked today only by the merge-restart cadence.

## Fix
Close the parent's copy in a `finally` after the detached spawn inherits it — closes even when `spawn()` throws EAGAIN/EMFILE (the error path where leaking would compound exhaustion). Append mode means the child's writes are unaffected for its whole lifetime. Adds an injectable `closeLogFd` seam (default `closeSync`) mirroring the existing `openLogFd`.

## Tests (`delegate-runner.test.mjs`, 38/38 pass)
- Two existing fake-fd kick tests now inject `closeLogFd` so the default `closeSync(5/77)` never touches an unrelated live descriptor (mandatory, same commit).
- **New:** open/close balanced across N=50 ticks (net live parent fds = 0) with an ordering pin asserting close fires strictly *after* spawn.
- **New:** close still fires when `spawn()` throws (the `finally`), no leak on the error path.

## Deploy note
The leak is live in the running daemons on mini + mini-2 (they keep their ~1319 leaked fds until restart). After merge → deploy to both + restart execution-core, then confirm via `lsof` that the count to `delegate-runner.log` stays bounded.

Plan adversarially verified (SOUND). Part of the mini/mini-2 memory-audit remediation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)