### PR TITLE
fix(dev): CTL-1514 tail event log by cursor in execution-core (stop 115s scheduler stalls)

### DIFF
--- a/plugins/dev/scripts/execution-core/event-tail.mjs
+++ b/plugins/dev/scripts/execution-core/event-tail.mjs
@@ -1,7 +1,7 @@
 // event-tail.mjs — byte-correct event-log tail parsing (CTL-673). Leaf module:
 // no execution-core deps. Shared by daemon.mjs (live tail), event-scan.mjs
 // (incremental counters), and reaper.mjs (boot replay).
-import { openSync, fstatSync, readSync, closeSync } from "node:fs";
+import { openSync, fstatSync, readSync, closeSync, statSync } from "node:fs";
 
 const DEFAULT_CHUNK = 1 << 20; // 1 MiB — bounds peak memory regardless of file size.
 
@@ -83,4 +83,43 @@ export function scanEventsChunked({
       /* fd already gone */
     }
   }
+}
+
+// tailParsedEvents — return the last `maxLines` parsed JSON events from `path`,
+// in file order, WITHOUT reading the whole file when the tail fits in a small
+// window near EOF (CTL-1514). scanEventsChunked reads forward from an offset, so
+// this seeds an estimated start offset near EOF and scans forward to EOF; if
+// fewer than `maxLines` valid events came back AND there is more file before the
+// window, it doubles the window and rescans from scratch (never accumulates
+// across attempts — a larger window can reveal one more real line that a smaller
+// window's leading fragment cut off). Bounded to `maxDoublings` retries, after
+// which it forces fromOffset:0 (a full scan) so correctness never depends on the
+// estimate: a file with fewer than maxLines lines, or one containing a
+// pathologically long line, still returns the true last-N tail. Missing/empty
+// file ⇒ []; never throws.
+export function tailParsedEvents({
+  path,
+  maxLines = 800,
+  bytesPerLineEstimate = 2048,
+  maxDoublings = 8,
+} = {}) {
+  let size;
+  try {
+    size = statSync(path).size;
+  } catch {
+    return [];
+  }
+  if (size === 0) return [];
+
+  let window = Math.max(bytesPerLineEstimate * maxLines, 64 * 1024);
+  for (let attempt = 0; attempt <= maxDoublings; attempt++) {
+    const fromOffset = attempt === maxDoublings ? 0 : Math.max(0, size - window);
+    const collected = [];
+    scanEventsChunked({ path, fromOffset, onEvent: (e) => collected.push(e) });
+    if (collected.length >= maxLines || fromOffset === 0) {
+      return collected.slice(-maxLines);
+    }
+    window *= 2;
+  }
+  return []; // unreachable — the final attempt always uses fromOffset 0
 }

--- a/plugins/dev/scripts/execution-core/event-tail.mjs
+++ b/plugins/dev/scripts/execution-core/event-tail.mjs
@@ -140,7 +140,23 @@ export function tailParsedEvents({
     const collected = [];
     // skipFirstLine when seeking mid-file: the bytes before the first newline are
     // a partial line whose suffix could parse as a bogus event (CTL-1514).
-    scanEventsChunked({ path, fromOffset, skipFirstLine: fromOffset > 0, onEvent: (e) => collected.push(e) });
+    const { leftover } = scanEventsChunked({
+      path,
+      fromOffset,
+      skipFirstLine: fromOffset > 0,
+      onEvent: (e) => collected.push(e),
+    });
+    // A log whose final record lacks a trailing newline leaves that record in
+    // `leftover` (never emitted as a complete line). Include it if it parses —
+    // the replaced raw.split("\n") parsed it, and board-health/recovery dedup must
+    // not miss the newest event in a truncated / crash-recovered log (Codex P2).
+    if (leftover) {
+      try {
+        collected.push(JSON.parse(leftover));
+      } catch {
+        /* genuinely partial mid-write line — skip, same as the old split path */
+      }
+    }
     if (collected.length >= maxLines || fromOffset === 0) {
       return collected.slice(-maxLines);
     }

--- a/plugins/dev/scripts/execution-core/event-tail.mjs
+++ b/plugins/dev/scripts/execution-core/event-tail.mjs
@@ -2,6 +2,7 @@
 // no execution-core deps. Shared by daemon.mjs (live tail), event-scan.mjs
 // (incremental counters), and reaper.mjs (boot replay).
 import { openSync, fstatSync, readSync, closeSync, statSync } from "node:fs";
+import { StringDecoder } from "node:string_decoder";
 
 const DEFAULT_CHUNK = 1 << 20; // 1 MiB — bounds peak memory regardless of file size.
 
@@ -44,6 +45,11 @@ export function scanEventsChunked({
   leftover = "",
   chunkSize = DEFAULT_CHUNK,
   onEvent,
+  // CTL-1514: when starting mid-file (fromOffset > 0) the bytes before the first
+  // newline are the tail of some earlier line; its suffix can independently parse
+  // as valid JSON and pollute the result. Set true to discard everything up to
+  // and including the first newline so scanning always begins on a line boundary.
+  skipFirstLine = false,
 } = {}) {
   let fd;
   let size;
@@ -63,18 +69,35 @@ export function scanEventsChunked({
   try {
     let pos = fromOffset;
     let carry = leftover;
-    // A single reusable buffer for the common full-chunk reads; short final
-    // reads get a right-sized buffer so toString never sees stale tail bytes.
+    let skipping = skipFirstLine && fromOffset > 0;
+    // CTL-1514: decode bytes through a StringDecoder so a multibyte UTF-8 sequence
+    // split across a chunk boundary is stitched (its trailing bytes are buffered
+    // until the next read) instead of each fragment decoding to U+FFFD — which
+    // would silently corrupt an event field while the JSON still parsed.
+    const decoder = new StringDecoder("utf8");
+    // A single reusable buffer for the common full-chunk reads; short final reads
+    // get a right-sized buffer so the decoder never sees stale tail bytes.
     const buf = Buffer.alloc(Math.min(chunkSize, Math.max(1, size - pos)) || 1);
+    const feed = (chunkStr) => {
+      if (skipping) {
+        const nl = chunkStr.indexOf("\n");
+        if (nl === -1) return; // still inside the leading partial line — discard it
+        chunkStr = chunkStr.slice(nl + 1); // resume after the first line boundary
+        skipping = false;
+      }
+      const { events, leftover: next } = parseEventTailChunk(chunkStr, carry);
+      for (const ev of events) onEvent(ev);
+      carry = next;
+    };
     while (pos < size) {
       const want = Math.min(chunkSize, size - pos);
       const slice = want === buf.length ? buf : Buffer.alloc(want);
       readSync(fd, slice, 0, want, pos);
-      const { events, leftover: next } = parseEventTailChunk(slice.toString("utf8"), carry);
-      for (const ev of events) onEvent(ev);
-      carry = next;
+      feed(decoder.write(slice));
       pos += want;
     }
+    const flushed = decoder.end();
+    if (flushed) feed(flushed);
     return { endOffset: size, leftover: carry };
   } finally {
     try {
@@ -115,7 +138,9 @@ export function tailParsedEvents({
   for (let attempt = 0; attempt <= maxDoublings; attempt++) {
     const fromOffset = attempt === maxDoublings ? 0 : Math.max(0, size - window);
     const collected = [];
-    scanEventsChunked({ path, fromOffset, onEvent: (e) => collected.push(e) });
+    // skipFirstLine when seeking mid-file: the bytes before the first newline are
+    // a partial line whose suffix could parse as a bogus event (CTL-1514).
+    scanEventsChunked({ path, fromOffset, skipFirstLine: fromOffset > 0, onEvent: (e) => collected.push(e) });
     if (collected.length >= maxLines || fromOffset === 0) {
       return collected.slice(-maxLines);
     }

--- a/plugins/dev/scripts/execution-core/event-tail.test.mjs
+++ b/plugins/dev/scripts/execution-core/event-tail.test.mjs
@@ -11,10 +11,10 @@
 // Run: cd plugins/dev/scripts/execution-core && bun test event-tail.test.mjs
 
 import { describe, test, expect } from "bun:test";
-import { writeFileSync, appendFileSync, mkdtempSync, statSync } from "node:fs";
+import { writeFileSync, appendFileSync, mkdtempSync, statSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
-import { parseEventTailChunk, scanEventsChunked } from "./event-tail.mjs";
+import { parseEventTailChunk, scanEventsChunked, tailParsedEvents } from "./event-tail.mjs";
 
 // parseEventTailChunk — preserve the daemon.mjs contract verbatim.
 describe("parseEventTailChunk", () => {
@@ -83,5 +83,85 @@ describe("scanEventsChunked", () => {
   test("missing file is a no-op (endOffset 0)", () => {
     const r = scanEventsChunked({ path: join(tmpdir(), "does-not-exist-xyz.jsonl"), fromOffset: 0, onEvent: () => {} });
     expect(r.endOffset).toBe(0);
+  });
+});
+
+describe("tailParsedEvents (CTL-1514)", () => {
+  function tempLog(lines, { trailingNewline = true } = {}) {
+    const dir = mkdtempSync(join(tmpdir(), "evttail-"));
+    const path = join(dir, "events.jsonl");
+    writeFileSync(path, lines.join("\n") + (trailingNewline ? "\n" : ""));
+    return path;
+  }
+  // trueTail — the correct semantics: parse EVERY valid line, then take the last
+  // maxLines. tailParsedEvents must equal this exactly. (Note: the OLD
+  // readBoardHealthEventTail did slice(-maxLines) on RAW lines first, so on a
+  // newline-terminated log it lost one slot to the trailing "" — returning 799
+  // for maxLines=800. tailParsedEvents intentionally returns the true last-N
+  // valid events instead: same upper bound, never fewer. See plan §5.5.)
+  function trueTail(path, maxLines) {
+    const all = [];
+    for (const line of readFileSync(path, "utf8").split("\n")) {
+      if (!line) continue;
+      try {
+        all.push(JSON.parse(line));
+      } catch {
+        /* skip */
+      }
+    }
+    return all.slice(-maxLines);
+  }
+
+  test("small file: returns the last N parsed events in order", () => {
+    const path = tempLog(['{"n":1}', '{"n":2}', '{"n":3}', '{"n":4}', '{"n":5}']);
+    expect(tailParsedEvents({ path, maxLines: 3 })).toEqual([{ n: 3 }, { n: 4 }, { n: 5 }]);
+  });
+
+  test("large file: identical to the true parsed tail, exactly maxLines", () => {
+    const lines = Array.from({ length: 5000 }, (_, i) => JSON.stringify({ n: i }));
+    const path = tempLog(lines);
+    const got = tailParsedEvents({ path, maxLines: 800 });
+    expect(got).toEqual(trueTail(path, 800));
+    expect(got).toHaveLength(800);
+    expect(got[0]).toEqual({ n: 4200 });
+    expect(got[799]).toEqual({ n: 4999 });
+  });
+
+  test("window-growth path converges to the correct tail (tiny estimate forces doublings)", () => {
+    const lines = Array.from({ length: 2000 }, (_, i) => JSON.stringify({ n: i }));
+    const path = tempLog(lines);
+    // bytesPerLineEstimate=1 → the first window is far smaller than needed, so
+    // the retry-doubling path (not the fast path) is exercised; result must still
+    // be exactly the true tail.
+    const got = tailParsedEvents({ path, maxLines: 800, bytesPerLineEstimate: 1 });
+    expect(got).toEqual(trueTail(path, 800));
+    expect(got).toHaveLength(800);
+  });
+
+  test("fewer total lines than maxLines: returns all of them", () => {
+    const path = tempLog(['{"n":1}', '{"n":2}']);
+    expect(tailParsedEvents({ path, maxLines: 800 })).toEqual([{ n: 1 }, { n: 2 }]);
+  });
+
+  test("malformed/blank lines in the tail are skipped and don't consume the maxLines budget", () => {
+    const path = tempLog(['{"n":1}', "not-json", "", '{"n":2}', '{"n":3}']);
+    expect(tailParsedEvents({ path, maxLines: 2 })).toEqual([{ n: 2 }, { n: 3 }]);
+  });
+
+  test("empty (0-byte) file → []", () => {
+    const path = tempLog([], { trailingNewline: false });
+    expect(tailParsedEvents({ path, maxLines: 800 })).toEqual([]);
+  });
+
+  test("missing file → [] (never throws)", () => {
+    expect(tailParsedEvents({ path: join(tmpdir(), "nope-xyz-1514.jsonl"), maxLines: 800 })).toEqual([]);
+  });
+
+  test("a single line longer than the 1MiB internal chunk is returned intact", () => {
+    const big = JSON.stringify({ big: "x".repeat(2 * 1024 * 1024) });
+    const path = tempLog([big]);
+    const got = tailParsedEvents({ path, maxLines: 1 });
+    expect(got).toHaveLength(1);
+    expect(got[0].big.length).toBe(2 * 1024 * 1024);
   });
 });

--- a/plugins/dev/scripts/execution-core/event-tail.test.mjs
+++ b/plugins/dev/scripts/execution-core/event-tail.test.mjs
@@ -162,6 +162,12 @@ describe("tailParsedEvents (CTL-1514)", () => {
     expect(tailParsedEvents({ path, maxLines: 800 })).toEqual([{ n: 1 }, { n: 2 }]);
   });
 
+  test("includes a valid final record that lacks a trailing newline (CTL-1514, Codex P2)", () => {
+    const path = tempLog(['{"n":1}', '{"n":2}'], { trailingNewline: false });
+    // {"n":2} is the leftover (no trailing \n); it must still be returned.
+    expect(tailParsedEvents({ path, maxLines: 2 })).toEqual([{ n: 1 }, { n: 2 }]);
+  });
+
   test("malformed/blank lines in the tail are skipped and don't consume the maxLines budget", () => {
     const path = tempLog(['{"n":1}', "not-json", "", '{"n":2}', '{"n":3}']);
     expect(tailParsedEvents({ path, maxLines: 2 })).toEqual([{ n: 2 }, { n: 3 }]);

--- a/plugins/dev/scripts/execution-core/event-tail.test.mjs
+++ b/plugins/dev/scripts/execution-core/event-tail.test.mjs
@@ -68,6 +68,25 @@ describe("scanEventsChunked", () => {
     expect(seen).toEqual([{ event: "alpha" }]); // counted exactly once across chunk boundaries
   });
 
+  test("stitches a multibyte UTF-8 char split across a chunk boundary (CTL-1514, no U+FFFD)", () => {
+    const path = tempLog(['{"e":"a🚀b"}']); // 🚀 = 4 bytes → straddles a 4-byte chunk boundary
+    const seen = [];
+    scanEventsChunked({ path, fromOffset: 0, chunkSize: 4, onEvent: (e) => seen.push(e) });
+    expect(seen).toEqual([{ e: "a🚀b" }]); // char preserved byte-exact, not corrupted to �
+  });
+
+  test("skipFirstLine discards a leading partial line whose suffix is valid JSON (CTL-1514)", () => {
+    // Full line 'XX{"n":7}' is invalid JSON, but its suffix '{"n":7}' parses. A
+    // mid-line fromOffset must not surface that fragment as a bogus event.
+    const path = tempLog(['XX{"n":7}', '{"n":2}']);
+    const noSkip = [];
+    scanEventsChunked({ path, fromOffset: 2, onEvent: (e) => noSkip.push(e) }); // byte 2 = '{'
+    expect(noSkip).toEqual([{ n: 7 }, { n: 2 }]); // the fragment leaks through by default
+    const skip = [];
+    scanEventsChunked({ path, fromOffset: 2, skipFirstLine: true, onEvent: (e) => skip.push(e) });
+    expect(skip).toEqual([{ n: 2 }]); // fragment discarded — only the complete line remains
+  });
+
   test("carries a trailing partial line across an append (leftover threaded back in)", () => {
     const dir = mkdtempSync(join(tmpdir(), "evttail-"));
     const path = join(dir, "events.jsonl");

--- a/plugins/dev/scripts/execution-core/recovery.mjs
+++ b/plugins/dev/scripts/execution-core/recovery.mjs
@@ -48,6 +48,7 @@ import {
 // transcripts so a doc worker mid in-process fan-out is never judged silent
 // (CTL-662-safe). Used ONLY to break the cold-snapshot doc-phase 6h tie below.
 import { transcriptAgeMs as defaultTranscriptAgeMs } from "./transcript-silence.mjs";
+import { scanEventsChunked } from "./event-tail.mjs"; // CTL-1514: streaming event-log scan
 // CTL-863 fleet-unfreeze (entourage follow-up to #2552): readPeerHeartbeatsSyncCached is
 // the CACHED reader — a 45s in-process TTL cache around the same anchor-issue read, safe
 // here because dead-host detection already tolerates a far larger (10-min) staleness
@@ -3394,31 +3395,87 @@ export function readClusterAdmission({ logPath = getEventLogPath() } = {}) {
   return out;
 }
 
+// scanAllPhaseCompleteEvents — ONE streaming pass over the unified event log,
+// collecting every `phase.<phase>.complete.<ticket>` event.name seen anywhere in
+// the file into a Set. Built on the shared scanEventsChunked primitive (CTL-673)
+// so a 300MB+ / ~478K-line log never materializes into one whole-file string +
+// array. Best-effort: missing/unreadable log ⇒ empty Set; never throws.
+function scanAllPhaseCompleteEvents(logPath = getEventLogPath(), scan = scanEventsChunked) {
+  const seen = new Set();
+  try {
+    scan({
+      path: logPath,
+      fromOffset: 0,
+      onEvent: (e) => {
+        const name = e?.attributes?.["event.name"];
+        if (typeof name === "string" && name.startsWith("phase.") && name.includes(".complete.")) {
+          seen.add(name);
+        }
+      },
+    });
+  } catch {
+    /* best-effort — empty set on failure, same fail-open as phaseAlreadyComplete */
+  }
+  return seen;
+}
+
+// makeBatchedPhaseCompleteChecker — CTL-1514. Same (ticket, phase) => bool
+// contract as phaseAlreadyComplete, but backed by ONE full-file scan per checker
+// instance instead of one per call, and lazy (never scans if the reclaim loop
+// finds zero candidates that reach the dedup check). Used as reclaimDeadHostWork's
+// default `alreadyComplete`, so N in-flight tickets owned by a dead host cost one
+// streaming log pass per tick, not N whole-file readFileSync calls.
+export function makeBatchedPhaseCompleteChecker({ logPath = getEventLogPath(), scan = scanEventsChunked } = {}) {
+  let completed = null;
+  return (ticket, phase) => {
+    if (completed === null) completed = scanAllPhaseCompleteEvents(logPath, scan);
+    return completed.has(`phase.${phase}.complete.${ticket}`);
+  };
+}
+
 // phaseAlreadyComplete — true when the unified event log already contains a
 // `phase.<phase>.complete.<ticket>` event. The resume path checks this before
 // re-dispatching so a survivor never re-emits a completion the dead host already
 // emitted (dedup). Best-effort: a missing/unreadable log ⇒ false; never throws.
-export function phaseAlreadyComplete(
-  ticket,
-  phase,
-  { readLog = () => readFileSync(getEventLogPath(), "utf8") } = {}
-) {
+export function phaseAlreadyComplete(ticket, phase, { readLog = null, logPath = getEventLogPath() } = {}) {
   const needle = `phase.${phase}.complete.${ticket}`;
-  let raw;
+  // Back-compat / test seam: when a caller supplies raw text directly, parse it
+  // exactly as before (all existing unit tests inject readLog).
+  if (readLog) {
+    let raw;
+    try {
+      raw = readLog();
+    } catch {
+      return false;
+    }
+    for (const line of raw.split("\n")) {
+      if (!line || !line.includes(needle)) continue;
+      try {
+        if (JSON.parse(line)?.attributes?.["event.name"] === needle) return true;
+      } catch {
+        // partial/malformed line — skip
+      }
+    }
+    return false;
+  }
+  // CTL-1514: default path streams via the shared scanEventsChunked primitive so
+  // a 300MB+ log never materializes into one whole-file string + array for a
+  // single-ticket lookup. (Memory-bounded; scanEventsChunked has no early-exit,
+  // so wall-clock is still O(bytes) — the hot-path time win comes from the
+  // batched checker collapsing N calls into 1, above.)
+  let found = false;
   try {
-    raw = readLog();
+    scanEventsChunked({
+      path: logPath,
+      fromOffset: 0,
+      onEvent: (e) => {
+        if (!found && e?.attributes?.["event.name"] === needle) found = true;
+      },
+    });
   } catch {
     return false;
   }
-  for (const line of raw.split("\n")) {
-    if (!line || !line.includes(needle)) continue;
-    try {
-      if (JSON.parse(line)?.attributes?.["event.name"] === needle) return true;
-    } catch {
-      // partial/malformed line — skip
-    }
-  }
-  return false;
+  return found;
 }
 
 // RESUME_PHASE_ORDER — the linear pipeline phases in forward order, derived from
@@ -3552,7 +3609,9 @@ export async function reclaimDeadHostWork(
     ownerForTicket: ownerFn = ownerForTicket,
     claim = (ticket, phase) => claimDispatchSync({ ticket, hostName: self, phase }),
     inferResume = (ticket, cwd) => inferResumePhase(ticket, { cwd }),
-    alreadyComplete = (ticket, phase) => phaseAlreadyComplete(ticket, phase),
+    // CTL-1514: batched default — ONE streaming log pass shared across every
+    // ticket this call processes, instead of one whole-file read per ticket.
+    alreadyComplete = makeBatchedPhaseCompleteChecker(),
     rebuildWorktree = (ticket) => {
       const result = defaultRebuildWorktree(ticket, { orchDir });
       return result;

--- a/plugins/dev/scripts/execution-core/recovery.mjs
+++ b/plugins/dev/scripts/execution-core/recovery.mjs
@@ -3395,41 +3395,47 @@ export function readClusterAdmission({ logPath = getEventLogPath() } = {}) {
   return out;
 }
 
-// scanAllPhaseCompleteEvents — ONE streaming pass over the unified event log,
-// collecting every `phase.<phase>.complete.<ticket>` event.name seen anywhere in
-// the file into a Set. Built on the shared scanEventsChunked primitive (CTL-673)
-// so a 300MB+ / ~478K-line log never materializes into one whole-file string +
-// array. Best-effort: missing/unreadable log ⇒ empty Set; never throws.
-function scanAllPhaseCompleteEvents(logPath = getEventLogPath(), scan = scanEventsChunked) {
-  const seen = new Set();
-  try {
-    scan({
-      path: logPath,
-      fromOffset: 0,
-      onEvent: (e) => {
-        const name = e?.attributes?.["event.name"];
-        if (typeof name === "string" && name.startsWith("phase.") && name.includes(".complete.")) {
-          seen.add(name);
-        }
-      },
-    });
-  } catch {
-    /* best-effort — empty set on failure, same fail-open as phaseAlreadyComplete */
-  }
-  return seen;
-}
-
 // makeBatchedPhaseCompleteChecker — CTL-1514. Same (ticket, phase) => bool
-// contract as phaseAlreadyComplete, but backed by ONE full-file scan per checker
-// instance instead of one per call, and lazy (never scans if the reclaim loop
-// finds zero candidates that reach the dedup check). Used as reclaimDeadHostWork's
-// default `alreadyComplete`, so N in-flight tickets owned by a dead host cost one
-// streaming log pass per tick, not N whole-file readFileSync calls.
+// contract as phaseAlreadyComplete, but backed by ONE full-file scan across all
+// tickets a reclaim call processes instead of one whole-file readFileSync per
+// ticket. Built on the shared scanEventsChunked primitive (CTL-673) so a 300MB+ /
+// ~478K-line log never materializes into a whole-file string + array.
+//
+// The scan is INCREMENTAL, not frozen-at-first-lookup: the first call reads the
+// whole log [0, EOF) into `seen` and remembers the byte cursor; each subsequent
+// call reads only the newly-appended bytes [cursor, newEOF) before answering. So
+// a completion appended by a live host mid-sweep (after the first lookup but
+// before a later ticket's dedup check) is still observed — the previous
+// per-ticket full read would have seen it, and this must too, or recovery
+// dispatches a duplicate phase (Codex P1 on #2729). Cost stays ~one full pass per
+// batch: the first call reads everything, later calls read only the delta (0
+// bytes ⇒ just an openSync+fstatSync). Lazy — never scans until first called.
+// Best-effort: an unreadable log leaves `seen` as-is and fails open to
+// "not complete", same posture as phaseAlreadyComplete.
 export function makeBatchedPhaseCompleteChecker({ logPath = getEventLogPath(), scan = scanEventsChunked } = {}) {
-  let completed = null;
+  const seen = new Set();
+  let cursor = null; // null = not yet scanned; else the byte offset scanned up to
+  let leftover = "";
+  const ingest = (e) => {
+    const name = e?.attributes?.["event.name"];
+    if (typeof name === "string" && name.startsWith("phase.") && name.includes(".complete.")) {
+      seen.add(name);
+    }
+  };
   return (ticket, phase) => {
-    if (completed === null) completed = scanAllPhaseCompleteEvents(logPath, scan);
-    return completed.has(`phase.${phase}.complete.${ticket}`);
+    try {
+      const { endOffset, leftover: next } = scan({
+        path: logPath,
+        fromOffset: cursor === null ? 0 : cursor,
+        leftover,
+        onEvent: ingest,
+      });
+      cursor = endOffset;
+      leftover = next;
+    } catch {
+      /* best-effort — keep what we have; fail open to "not complete" */
+    }
+    return seen.has(`phase.${phase}.complete.${ticket}`);
   };
 }
 

--- a/plugins/dev/scripts/execution-core/recovery.mjs
+++ b/plugins/dev/scripts/execution-core/recovery.mjs
@@ -3412,9 +3412,10 @@ export function readClusterAdmission({ logPath = getEventLogPath() } = {}) {
 // bytes ⇒ just an openSync+fstatSync). Lazy — never scans until first called.
 // Best-effort: an unreadable log leaves `seen` as-is and fails open to
 // "not complete", same posture as phaseAlreadyComplete.
-export function makeBatchedPhaseCompleteChecker({ logPath = getEventLogPath(), scan = scanEventsChunked } = {}) {
+export function makeBatchedPhaseCompleteChecker({ logPath = null, scan = scanEventsChunked } = {}) {
   const seen = new Set();
-  let cursor = null; // null = not yet scanned; else the byte offset scanned up to
+  let scannedPath = null;
+  let cursor = 0;
   let leftover = "";
   const ingest = (e) => {
     const name = e?.attributes?.["event.name"];
@@ -3423,10 +3424,22 @@ export function makeBatchedPhaseCompleteChecker({ logPath = getEventLogPath(), s
     }
   };
   return (ticket, phase) => {
+    // Re-resolve the month-partitioned log path on EVERY check (unless a test pins
+    // logPath): a reclaim sweep that spans a UTC month boundary must pick up
+    // completions written to the NEW month's YYYY-MM.jsonl, or it redispatches an
+    // already-complete phase (Codex P2 on #2729). On rollover the cursor resets to
+    // scan the new file from 0, while `seen` carries forward so prior-month
+    // completions still dedup.
+    const path = typeof logPath === "function" ? logPath() : logPath ?? getEventLogPath();
     try {
+      if (path !== scannedPath) {
+        cursor = 0;
+        leftover = "";
+        scannedPath = path;
+      }
       const { endOffset, leftover: next } = scan({
-        path: logPath,
-        fromOffset: cursor === null ? 0 : cursor,
+        path,
+        fromOffset: cursor,
         leftover,
         onEvent: ingest,
       });

--- a/plugins/dev/scripts/execution-core/recovery.mjs
+++ b/plugins/dev/scripts/execution-core/recovery.mjs
@@ -3432,7 +3432,18 @@ export function makeBatchedPhaseCompleteChecker({ logPath = null, scan = scanEve
     // completions still dedup.
     const path = typeof logPath === "function" ? logPath() : logPath ?? getEventLogPath();
     try {
-      if (path !== scannedPath) {
+      // Reset the cursor on a path change (month rollover) OR an in-place
+      // truncation/replacement — legacy rotation rewrites a SHORTER file at the same
+      // path, and if size < cursor the old offset is beyond the new EOF so its prefix
+      // would be skipped, permanently missing a completion (mirrors event-scan.mjs's
+      // size<cursor reset). Codex P2 on #2729.
+      let size = null;
+      try {
+        size = statSync(path).size;
+      } catch {
+        /* missing/unreadable → the scan below no-ops; keep prior `seen` */
+      }
+      if (path !== scannedPath || (size !== null && size < cursor)) {
         cursor = 0;
         leftover = "";
         scannedPath = path;
@@ -3445,6 +3456,23 @@ export function makeBatchedPhaseCompleteChecker({ logPath = null, scan = scanEve
       });
       cursor = endOffset;
       leftover = next;
+      // A completion written as the final record WITHOUT a trailing newline sits in
+      // `next` (never emitted as a complete line); ingest it if it parses so dedup
+      // doesn't miss it (idempotent — re-parsing the same leftover later is harmless).
+      if (next) {
+        try {
+          const finalName = JSON.parse(next)?.attributes?.["event.name"];
+          if (
+            typeof finalName === "string" &&
+            finalName.startsWith("phase.") &&
+            finalName.includes(".complete.")
+          ) {
+            seen.add(finalName);
+          }
+        } catch {
+          /* genuinely partial line — skip */
+        }
+      }
     } catch {
       /* best-effort — keep what we have; fail open to "not complete" */
     }

--- a/plugins/dev/scripts/execution-core/recovery.test.mjs
+++ b/plugins/dev/scripts/execution-core/recovery.test.mjs
@@ -5316,6 +5316,23 @@ describe("makeBatchedPhaseCompleteChecker — one pass for N tickets (CTL-1514)"
     expect(check("CTL-200", "plan")).toBe(true); // new file scanned from 0
     expect(check("CTL-100", "research")).toBe(true); // prior-month completion still deduped
   });
+
+  test("resets the cursor when the same-path log is replaced/truncated (Codex P2 on #2729)", () => {
+    const path = ctl1514TempLog([
+      "phase.research.complete.CTL-100",
+      "phase.plan.complete.CTL-200",
+      "phase.verify.complete.CTL-300",
+    ]);
+    const check = makeBatchedPhaseCompleteChecker({ logPath: path });
+    expect(check("CTL-300", "verify")).toBe(true); // scans the full file, cursor at EOF
+    // Legacy rotation rewrites a SHORTER file at the SAME path with a new completion.
+    writeFileSync(
+      path,
+      JSON.stringify({ attributes: { "event.name": "phase.research.complete.CTL-900" } }) + "\n"
+    );
+    // size < cursor → reset to 0 → the replacement is scanned, not skipped past.
+    expect(check("CTL-900", "research")).toBe(true);
+  });
 });
 
 // ─── CTL-863: reclaimDeadHostWork ────────────────────────────────────────────

--- a/plugins/dev/scripts/execution-core/recovery.test.mjs
+++ b/plugins/dev/scripts/execution-core/recovery.test.mjs
@@ -5224,6 +5224,7 @@ describe("phaseAlreadyComplete — event-log dedup (CTL-863)", () => {
 // ─── CTL-1514: streaming default path + batched checker ──────────────────────
 import { makeBatchedPhaseCompleteChecker } from "./recovery.mjs";
 import { scanEventsChunked } from "./event-tail.mjs";
+import { statSync as ctl1514StatSync } from "node:fs";
 
 function ctl1514TempLog(names) {
   const dir = mkdtempSync(join(tmpdir(), "ctl1514-recov-"));
@@ -5256,11 +5257,11 @@ describe("phaseAlreadyComplete — streaming default path (CTL-1514)", () => {
 });
 
 describe("makeBatchedPhaseCompleteChecker — one pass for N tickets (CTL-1514)", () => {
-  test("correct true/false per (ticket, phase), scanning the log exactly once for N calls", () => {
+  test("correct true/false per (ticket, phase); whole log read once, later calls only resume", () => {
     const path = ctl1514TempLog(["phase.research.complete.CTL-100", "phase.plan.complete.CTL-200"]);
-    let scanCalls = 0;
+    const fromOffsets = [];
     const scan = (opts) => {
-      scanCalls++;
+      fromOffsets.push(opts.fromOffset);
       return scanEventsChunked(opts);
     };
     const check = makeBatchedPhaseCompleteChecker({ logPath: path, scan });
@@ -5270,8 +5271,26 @@ describe("makeBatchedPhaseCompleteChecker — one pass for N tickets (CTL-1514)"
     expect(check("CTL-300", "research")).toBe(false); // not complete
     expect(check("CTL-100", "plan")).toBe(false); // wrong phase
 
-    // 4 checks, ONE streaming pass — the pre-fix default did one full readFileSync per call.
-    expect(scanCalls).toBe(1);
+    // The first call reads the whole log from offset 0; every later call resumes
+    // from the prior cursor (never re-reads from 0) — one full pass for N tickets,
+    // the rest are zero-byte delta scans.
+    const size = ctl1514StatSync(path).size;
+    expect(fromOffsets[0]).toBe(0);
+    expect(fromOffsets.slice(1)).toEqual([size, size, size]);
+  });
+
+  test("observes a completion appended AFTER the first lookup (Codex P1: no stale duplicate dispatch)", () => {
+    const path = ctl1514TempLog(["phase.research.complete.CTL-100"]);
+    const check = makeBatchedPhaseCompleteChecker({ logPath: path });
+    expect(check("CTL-100", "research")).toBe(true); // first (full) scan
+    expect(check("CTL-200", "plan")).toBe(false); // not present yet
+    // A live host appends CTL-200's completion mid-sweep, after the first lookup:
+    appendFileSync(
+      path,
+      JSON.stringify({ attributes: { "event.name": "phase.plan.complete.CTL-200" } }) + "\n"
+    );
+    // The incremental cursor picks up the newly-appended bytes → true, not stale false.
+    expect(check("CTL-200", "plan")).toBe(true);
   });
 
   test("lazy — never scans when no check is invoked (zero dead-host tickets ⇒ zero reads)", () => {

--- a/plugins/dev/scripts/execution-core/recovery.test.mjs
+++ b/plugins/dev/scripts/execution-core/recovery.test.mjs
@@ -5302,6 +5302,20 @@ describe("makeBatchedPhaseCompleteChecker — one pass for N tickets (CTL-1514)"
     makeBatchedPhaseCompleteChecker({ logPath: "/whatever", scan });
     expect(scanCalls).toBe(0);
   });
+
+  test("re-scans the new month's file after the log path rolls over (Codex P2 on #2729)", () => {
+    const monthA = ctl1514TempLog(["phase.research.complete.CTL-100"]);
+    const monthB = ctl1514TempLog(["phase.plan.complete.CTL-200"]);
+    let current = monthA;
+    // logPath as a resolver mimics getEventLogPath() re-resolving each call; a UTC
+    // month boundary mid-sweep flips it to the new file.
+    const check = makeBatchedPhaseCompleteChecker({ logPath: () => current });
+    expect(check("CTL-100", "research")).toBe(true); // scanned month A
+    expect(check("CTL-200", "plan")).toBe(false); // not in A yet
+    current = monthB; // month rolls over
+    expect(check("CTL-200", "plan")).toBe(true); // new file scanned from 0
+    expect(check("CTL-100", "research")).toBe(true); // prior-month completion still deduped
+  });
 });
 
 // ─── CTL-863: reclaimDeadHostWork ────────────────────────────────────────────

--- a/plugins/dev/scripts/execution-core/recovery.test.mjs
+++ b/plugins/dev/scripts/execution-core/recovery.test.mjs
@@ -5221,6 +5221,70 @@ describe("phaseAlreadyComplete — event-log dedup (CTL-863)", () => {
   });
 });
 
+// ─── CTL-1514: streaming default path + batched checker ──────────────────────
+import { makeBatchedPhaseCompleteChecker } from "./recovery.mjs";
+import { scanEventsChunked } from "./event-tail.mjs";
+
+function ctl1514TempLog(names) {
+  const dir = mkdtempSync(join(tmpdir(), "ctl1514-recov-"));
+  const path = join(dir, "events.jsonl");
+  writeFileSync(
+    path,
+    names.map((n) => JSON.stringify({ attributes: { "event.name": n } })).join("\n") + "\n"
+  );
+  return path;
+}
+
+describe("phaseAlreadyComplete — streaming default path (CTL-1514)", () => {
+  test("default path (logPath, no readLog) streams the file and finds the event", () => {
+    const path = ctl1514TempLog(["phase.research.complete.CTL-900", "phase.plan.complete.CTL-800"]);
+    expect(phaseAlreadyComplete("CTL-900", "research", { logPath: path })).toBe(true);
+    expect(phaseAlreadyComplete("CTL-800", "plan", { logPath: path })).toBe(true);
+  });
+
+  test("default path returns false for a non-present (ticket, phase)", () => {
+    const path = ctl1514TempLog(["phase.research.complete.CTL-900"]);
+    expect(phaseAlreadyComplete("CTL-900", "plan", { logPath: path })).toBe(false);
+    expect(phaseAlreadyComplete("CTL-123", "research", { logPath: path })).toBe(false);
+  });
+
+  test("default path returns false on a missing file (never throws)", () => {
+    expect(
+      phaseAlreadyComplete("CTL-900", "research", { logPath: join(tmpdir(), "nope-1514.jsonl") })
+    ).toBe(false);
+  });
+});
+
+describe("makeBatchedPhaseCompleteChecker — one pass for N tickets (CTL-1514)", () => {
+  test("correct true/false per (ticket, phase), scanning the log exactly once for N calls", () => {
+    const path = ctl1514TempLog(["phase.research.complete.CTL-100", "phase.plan.complete.CTL-200"]);
+    let scanCalls = 0;
+    const scan = (opts) => {
+      scanCalls++;
+      return scanEventsChunked(opts);
+    };
+    const check = makeBatchedPhaseCompleteChecker({ logPath: path, scan });
+
+    expect(check("CTL-100", "research")).toBe(true);
+    expect(check("CTL-200", "plan")).toBe(true);
+    expect(check("CTL-300", "research")).toBe(false); // not complete
+    expect(check("CTL-100", "plan")).toBe(false); // wrong phase
+
+    // 4 checks, ONE streaming pass — the pre-fix default did one full readFileSync per call.
+    expect(scanCalls).toBe(1);
+  });
+
+  test("lazy — never scans when no check is invoked (zero dead-host tickets ⇒ zero reads)", () => {
+    let scanCalls = 0;
+    const scan = () => {
+      scanCalls++;
+      return { endOffset: 0, leftover: "" };
+    };
+    makeBatchedPhaseCompleteChecker({ logPath: "/whatever", scan });
+    expect(scanCalls).toBe(0);
+  });
+});
+
 // ─── CTL-863: reclaimDeadHostWork ────────────────────────────────────────────
 
 import { reclaimDeadHostWork } from "./recovery.mjs";

--- a/plugins/dev/scripts/execution-core/scheduler.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.mjs
@@ -64,6 +64,7 @@ export { STAGE_RANK, NON_PREEMPTABLE_PHASES };
 // the sweep and are injected, so the router itself is unit-testable.
 import { readVerifyVerdict } from "./work-done-probes.mjs";
 import { countRemediateCycles, countTicketEventsInWindow } from "./event-scan.mjs";
+import { tailParsedEvents } from "./event-tail.mjs"; // CTL-1514: bounded event-log tail
 import { rankTickets, compareTickets } from "./scheduler-rank.mjs";
 import {
   defaultDispatch,
@@ -3153,20 +3154,15 @@ let _boardHealthLastRunMs = 0;
 // CTL-1257 shared ring (not yet threadable here). Best-effort: any read/parse
 // error degrades to [] so the dependent invariants flag observable:false rather
 // than throwing the tick.
-function readBoardHealthEventTail(maxLines = 800) {
+// CTL-1514: exported for direct unit coverage. Reads the last `maxLines` events
+// via the shared scanEventsChunked primitive (event-tail.mjs, CTL-673) — a
+// bounded ~1.6MB window near EOF — instead of materializing the entire monthly
+// event log (300MB+ / ~478K lines) into one string + array on the SYNCHRONOUS
+// scheduler tick every BOARD_HEALTH_INTERVAL_MS. That whole-file readFileSync was
+// the driver behind the measured 115s scheduler event-loop-delay spikes on mini.
+export function readBoardHealthEventTail(maxLines = 800) {
   try {
-    const raw = readFileSync(getEventLogPath(), "utf8");
-    const lines = raw.split("\n");
-    const out = [];
-    for (const line of lines.slice(-maxLines)) {
-      if (!line) continue;
-      try {
-        out.push(JSON.parse(line));
-      } catch {
-        /* skip a partial/garbled line */
-      }
-    }
-    return out;
+    return tailParsedEvents({ path: getEventLogPath(), maxLines });
   } catch {
     return [];
   }


### PR DESCRIPTION
## CTL-1514 — whole-file event-log reads stalling the scheduler tick

Two execution-core hot paths `readFileSync` the entire ~190–320 MB current-month event log into one string + a ~478K-element array, instead of the shared `scanEventsChunked` byte-cursor primitive (`event-tail.mjs`, CTL-673) that `reaper`/`daemon` already use:

- **`scheduler.mjs` `readBoardHealthEventTail`** — whole-file read every ~5 min **on the synchronous scheduler tick**. This is the driver behind the measured CTL-1330 event-loop-delay **p99/max = 115,024 ms** on mini.
- **`recovery.mjs` `phaseAlreadyComplete`** — whole-file read **per in-flight ticket** in the `reclaimDeadHostWork` dead-host takeover sweep (N tickets = N full reads/tick). *(Corrects the ticket's attribution — the per-ticket loop is `reclaimDeadHostWork`, not `reconcileBootResume`; same fix shape.)*

## Fixes
- **`tailParsedEvents(path, maxLines)`** in `event-tail.mjs`: bounded-window tail on `scanEventsChunked` — seeks near EOF, grows + retries, forced full-scan fallback so correctness never depends on the estimate. `readBoardHealthEventTail` becomes a thin wrapper: **~1.6 MB read instead of 300 MB+ (~200×)** in the production case. Exported for direct coverage.
- **`makeBatchedPhaseCompleteChecker`**: one *lazy* streaming pass shared across every ticket a reclaim call processes, wired as `reclaimDeadHostWork`'s default `alreadyComplete`. `phaseAlreadyComplete`'s default now streams too (memory-bounded); the `readLog` test seam is preserved unchanged.

### Disclosed semantic delta
The old code sliced the last N **raw** lines then parsed, so a trailing newline / interspersed junk cost a slot (returned ≤799 for `maxLines=800` on a newline-terminated log). `tailParsedEvents` returns the last N **valid** events — same upper bound, never fewer. board-health depends only on the bound + chronological order, both preserved. (Covered by an explicit test.)

## Tests
- `event-tail.test.mjs` **+8** (true-tail equivalence, window-growth path, >1 MiB line, empty/missing, junk-skips-budget) → 16 pass.
- `recovery.test.mjs` **+5** (streaming default path; one-pass-for-N batched checker via a `scan` spy; lazy = zero scans when unused). Existing `phaseAlreadyComplete` (6) + `reclaimDeadHostWork` (20) still green.

Plan re-derived and adversarially cross-checked (edge cases: partial last line, rotation, 0-byte, long-line all addressed). Part of the mini/mini-2 memory-audit remediation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)