### PR TITLE
fix(dev): CTL-1515 bound orch-monitor readBacklog/readTunnelEventStats fallbacks (chunked scan)

### DIFF
--- a/plugins/dev/scripts/orch-monitor/__tests__/event-filter.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/event-filter.test.ts
@@ -97,4 +97,24 @@ describe("createFilterStream", () => {
     f.close();
     expect(() => f.close()).not.toThrow();
   });
+
+  it("write returns a boolean and drain() resolves (backpressure contract, CTL-1515)", async () => {
+    const f = createFilterStream(".a == 1");
+    // The chunked predicate scan relies on write's return value + drain() to stay
+    // memory-bounded: await drain() only when write returns false.
+    expect(typeof f.write('{"a":1}')).toBe("boolean");
+    await f.drain(); // resolves immediately when not backpressured — must not hang
+    expect(typeof f.write('{"a":2}')).toBe("boolean");
+    f.close();
+    // After close, write is a no-op returning true (never asks the caller to wait).
+    expect(f.write('{"a":3}')).toBe(true);
+    await f.drain();
+  });
+
+  it("passthrough (empty predicate) write returns true and drain resolves", async () => {
+    const f = createFilterStream("");
+    expect(f.write('{"a":1}')).toBe(true);
+    await f.drain();
+    f.close();
+  });
 });

--- a/plugins/dev/scripts/orch-monitor/__tests__/event-log-reader.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/event-log-reader.test.ts
@@ -697,6 +697,26 @@ describe("readBacklog / readTunnelEventStats fallback: chunked scan, never readF
     }
   });
 
+  it("predicate fallback returns only the last `limit` matches for a broad predicate — bounded + waits for jq (CTL-1515)", async () => {
+    const dir = eventsDir();
+    const now = new Date("2026-05-04T00:00:00Z");
+    // 50 matching records; a broad predicate matches them all. The rolling buffer
+    // must retain only the last `limit`, and stream.end() must wait for jq to emit
+    // every match so the newest ones aren't cut off by a fixed-delay flush.
+    const lines = Array.from({ length: 50 }, (_, i) => makeLine("github.pr.opened", { i }));
+    writeFileSync(join(dir, "2026-05.jsonl"), lines.join("\n") + "\n");
+    const r = await readBacklog({
+      catalystDir: workdir,
+      predicate: '.event | startswith("github.")',
+      limit: 5,
+      ring: null,
+      now: () => now,
+    });
+    expect(r.length).toBe(5); // bounded to `limit`, not all 50
+    // the newest 5 (i = 45..49), proving end() waited for jq's full output
+    expect(r.map((l) => (JSON.parse(l) as { i: number }).i)).toEqual([45, 46, 47, 48, 49]);
+  });
+
   it("readTunnelEventStats file fallback (no ring) uses readSync, never readFileSync — counts unchanged", () => {
     eventsDir();
     const lines = [

--- a/plugins/dev/scripts/orch-monitor/__tests__/event-log-reader.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/event-log-reader.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach } from "bun:test";
+import { describe, it, expect, beforeEach, afterEach, spyOn } from "bun:test";
 import {
   mkdtempSync,
   mkdirSync,
@@ -6,12 +6,14 @@ import {
   appendFileSync,
   rmSync,
 } from "node:fs";
+import * as fs from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import {
   readBacklog,
   tailEventLog,
   readTunnelEventStats,
+  scanFileLines,
   fullReadMetrics,
   recordFullRead,
 } from "../lib/event-log-reader";
@@ -572,6 +574,151 @@ describe("full-read counters (CTL-1232)", () => {
       expect(fullReadMetrics.tunnelStats?.count ?? 0).toBe(before);
     } finally {
       ring.stop();
+    }
+  });
+});
+
+// CTL-1515: the ring-underflow fallbacks must scan the current-month log in
+// bounded CHUNKS (openSync/readSync) — never a single whole-file readFileSync
+// (a ~1.7 GB contiguous transient bun/mimalloc never returns). These tests are
+// a REINTRODUCTION GUARD: they count node:fs readSync/readFileSync so a revert
+// to readFileSync fails CI. Spying the shared `fs` namespace is observed inside
+// event-log-reader.ts even though it destructures its fs imports (Bun's node:fs
+// is a singleton). NOTE: Bun's `mockRestore()` clears the recorded calls, so
+// every count/assertion is captured into a plain variable BEFORE the spy is
+// restored in `finally`.
+describe("scanFileLines (CTL-1515)", () => {
+  it("chunks a file larger than chunkBytes (>1 readSync, no readFileSync) and stitches a multibyte char split across a chunk boundary", () => {
+    const dir = eventsDir();
+    const file = join(dir, "scan.jsonl");
+    // Deterministic byte layout so a chunk boundary provably bisects a 4-byte
+    // emoji. "ab🚀cd" = 61 62 | F0 9F 9A 80 | 63 64 (🚀 occupies bytes 2..5).
+    // With chunkBytes = 4 the first boundary at byte 4 falls INSIDE 🚀
+    // (bytes 2,3 in chunk 1; bytes 4,5 in chunk 2) → the StringDecoder must
+    // carry the partial sequence across the read.
+    const lines = ["ab🚀cd", "second-é-line", "third"];
+    const text = lines.join("\n") + "\n";
+    writeFileSync(file, text);
+    expect(Buffer.byteLength("🚀")).toBe(4); // 4-byte sequence, straddles byte 4
+
+    const readSyncSpy = spyOn(fs, "readSync");
+    const readFileSyncSpy = spyOn(fs, "readFileSync");
+    // Assert INSIDE the try: Bun's mockRestore() clears the recorded calls, so
+    // counts must be read while the spy is live. finally still restores the spy
+    // even if an assertion throws.
+    try {
+      const got: string[] = [];
+      const bytes = scanFileLines(file, (l) => got.push(l), 4);
+      // (a) chunked: many readSync calls for a file far larger than the 4-byte chunk
+      expect(readSyncSpy.mock.calls.length).toBeGreaterThan(1);
+      // (b) NEVER a whole-file readFileSync
+      expect(readFileSyncSpy.mock.calls.length).toBe(0);
+      // Returns bytes scanned = file byte length
+      expect(bytes).toBe(Buffer.byteLength(text));
+      // Parity: same lines as split (scanFileLines omits the trailing empty of a
+      // newline-terminated file, hence the .filter(l => l.length > 0)).
+      expect(got).toEqual(text.split("\n").filter((l) => l.length > 0));
+      // The multibyte line survived byte-exact (no dropped/corrupted char).
+      expect(got[0]).toBe("ab🚀cd");
+      expect(got[1]).toBe("second-é-line");
+    } finally {
+      readSyncSpy.mockRestore();
+      readFileSyncSpy.mockRestore();
+    }
+  });
+
+  it("emits a final line that lacks a trailing newline", () => {
+    const dir = eventsDir();
+    const file = join(dir, "no-trailing-nl.jsonl");
+    writeFileSync(file, "one\ntwo\nthree"); // no trailing "\n"
+    const got: string[] = [];
+    scanFileLines(file, (l) => got.push(l), 3);
+    expect(got).toEqual(["one", "two", "three"]);
+  });
+});
+
+describe("readBacklog / readTunnelEventStats fallback: chunked scan, never readFileSync (CTL-1515)", () => {
+  it("readBacklog empty-predicate fallback (no ring) uses readSync, never readFileSync", async () => {
+    const dir = eventsDir();
+    const now = new Date("2026-05-04T00:00:00Z");
+    const lines = Array.from({ length: 8 }, (_, i) => makeLine(`evt-${i}`));
+    writeFileSync(join(dir, "2026-05.jsonl"), lines.join("\n") + "\n");
+
+    const readSyncSpy = spyOn(fs, "readSync");
+    const readFileSyncSpy = spyOn(fs, "readFileSync");
+    try {
+      const r = await readBacklog({
+        catalystDir: workdir,
+        predicate: "",
+        limit: 3,
+        ring: null,
+        now: () => now,
+      });
+      // Behavioral parity with the old readFileSync path: last 3 non-empty lines.
+      expect(r.length).toBe(3);
+      expect(JSON.parse(r[0]).event).toBe("evt-5");
+      expect(JSON.parse(r[2]).event).toBe("evt-7");
+      // Reintroduction guard: chunked scan ran, no whole-file read.
+      expect(readSyncSpy.mock.calls.length).toBeGreaterThan(0);
+      expect(readFileSyncSpy.mock.calls.length).toBe(0);
+    } finally {
+      readSyncSpy.mockRestore();
+      readFileSyncSpy.mockRestore();
+    }
+  });
+
+  it("readBacklog predicate fallback (no ring) uses readSync, never readFileSync", async () => {
+    const dir = eventsDir();
+    const now = new Date("2026-05-04T00:00:00Z");
+    const lines = [
+      makeLine("github.pr.merged", { i: 0 }),
+      makeLine("linear.issue.created"),
+      makeLine("github.pr.opened", { i: 1 }),
+    ];
+    writeFileSync(join(dir, "2026-05.jsonl"), lines.join("\n") + "\n");
+
+    const readSyncSpy = spyOn(fs, "readSync");
+    const readFileSyncSpy = spyOn(fs, "readFileSync");
+    try {
+      const r = await readBacklog({
+        catalystDir: workdir,
+        predicate: '.event | startswith("github.")',
+        limit: 100,
+        ring: null,
+        now: () => now,
+      });
+      expect(r.length).toBe(2);
+      expect(r.every((l) => (JSON.parse(l) as { event: string }).event.startsWith("github."))).toBe(true);
+      expect(readSyncSpy.mock.calls.length).toBeGreaterThan(0);
+      expect(readFileSyncSpy.mock.calls.length).toBe(0);
+    } finally {
+      readSyncSpy.mockRestore();
+      readFileSyncSpy.mockRestore();
+    }
+  });
+
+  it("readTunnelEventStats file fallback (no ring) uses readSync, never readFileSync — counts unchanged", () => {
+    eventsDir();
+    const lines = [
+      makeGithubLine("org/a", "2026-05-04T10:00:00Z"),
+      makeGithubLine("org/a", "2026-05-04T10:30:00Z"),
+      makeGithubLine("org/b", "2026-05-04T11:00:00Z"),
+    ];
+    writeFileSync(join(workdir, "events", "2026-05.jsonl"), lines.join("\n") + "\n");
+
+    const readSyncSpy = spyOn(fs, "readSync");
+    const readFileSyncSpy = spyOn(fs, "readFileSync");
+    try {
+      const r = readTunnelEventStats(workdir, undefined, () => new Date("2026-05-04T12:00:00Z"));
+      // Byte-identical counts to the old split-based path.
+      expect(r.eventCount24h).toBe(3);
+      expect(r.eventCount24hByRepo).toEqual({ "org/a": 2, "org/b": 1 });
+      // Reintroduction guard.
+      expect(readSyncSpy.mock.calls.length).toBeGreaterThan(0);
+      expect(readFileSyncSpy.mock.calls.length).toBe(0);
+    } finally {
+      readSyncSpy.mockRestore();
+      readFileSyncSpy.mockRestore();
     }
   });
 });

--- a/plugins/dev/scripts/orch-monitor/lib/event-filter.ts
+++ b/plugins/dev/scripts/orch-monitor/lib/event-filter.ts
@@ -195,6 +195,10 @@ export function createFilterStream(predicate: string): FilterStream {
       // fixed 50ms flush happened to capture on a large log (CTL-1515). The stdout
       // 'data' handler above drains all output before 'close' fires.
       if (closed) return Promise.resolve();
+      // If jq already exited (e.g. a `halt`-style predicate terminated it before
+      // end() was called), its 'close' has already fired and won't fire again —
+      // resolve immediately instead of waiting forever (Codex P2 on #2730).
+      if (proc.exitCode !== null || proc.signalCode !== null) return Promise.resolve();
       return new Promise<void>((resolve) => {
         let done = false;
         const finish = () => {

--- a/plugins/dev/scripts/orch-monitor/lib/event-filter.ts
+++ b/plugins/dev/scripts/orch-monitor/lib/event-filter.ts
@@ -28,6 +28,10 @@ export interface FilterStream {
   drain(): Promise<void>;
   /** Wait briefly for any in-flight stdout to drain. */
   flush(): Promise<void>;
+  /** End input and resolve once the filter has emitted ALL output (jq exited) — so a
+   *  caller reading accumulated matches sees every one, not just what a fixed-delay
+   *  flush happened to capture (CTL-1515). */
+  end(): Promise<void>;
   close(): void;
   onMatch(cb: (line: string) => void): void;
 }
@@ -100,6 +104,9 @@ export function createFilterStream(predicate: string): FilterStream {
       },
       flush(): Promise<void> {
         return Promise.resolve();
+      },
+      end(): Promise<void> {
+        return Promise.resolve(); // synchronous passthrough — all output already emitted
       },
       close(): void {
         closed = true;
@@ -181,6 +188,28 @@ export function createFilterStream(predicate: string): FilterStream {
         }, 50);
       });
       return pendingFlush;
+    },
+    end(): Promise<void> {
+      // End jq's stdin and resolve once it has flushed all output and exited, so a
+      // caller reading accumulated matches sees EVERY match — not just what the
+      // fixed 50ms flush happened to capture on a large log (CTL-1515). The stdout
+      // 'data' handler above drains all output before 'close' fires.
+      if (closed) return Promise.resolve();
+      return new Promise<void>((resolve) => {
+        let done = false;
+        const finish = () => {
+          if (done) return;
+          done = true;
+          resolve();
+        };
+        proc.once("close", finish);
+        proc.once("error", finish); // never hang on a spawn/pipe error
+        try {
+          proc.stdin?.end();
+        } catch {
+          finish();
+        }
+      });
     },
     close(): void {
       if (closed) return;

--- a/plugins/dev/scripts/orch-monitor/lib/event-filter.ts
+++ b/plugins/dev/scripts/orch-monitor/lib/event-filter.ts
@@ -20,7 +20,12 @@ export interface ValidationResult {
 }
 
 export interface FilterStream {
-  write(line: string): void;
+  /** Feed one line. Returns false when the sink is backpressured (jq stdin buffer
+   *  full) — the caller should `await drain()` before writing more so a large
+   *  chunked scan stays memory-bounded (CTL-1515). */
+  write(line: string): boolean;
+  /** Resolve once the sink is writable again (or immediately if not backpressured). */
+  drain(): Promise<void>;
   /** Wait briefly for any in-flight stdout to drain. */
   flush(): Promise<void>;
   close(): void;
@@ -80,14 +85,18 @@ export function createFilterStream(predicate: string): FilterStream {
     let cb: ((line: string) => void) | null = null;
     let closed = false;
     return {
-      write(line: string): void {
-        if (closed || !cb) return;
+      write(line: string): boolean {
+        if (closed || !cb) return true;
         try {
           JSON.parse(line);
           cb(line);
         } catch {
           /* drop invalid JSON */
         }
+        return true; // synchronous passthrough — never backpressured
+      },
+      drain(): Promise<void> {
+        return Promise.resolve();
       },
       flush(): Promise<void> {
         return Promise.resolve();
@@ -131,20 +140,34 @@ export function createFilterStream(predicate: string): FilterStream {
   });
 
   return {
-    write(line: string): void {
-      if (closed) return;
+    write(line: string): boolean {
+      if (closed) return true;
       // Pre-validate JSON; jq dies on invalid input so we drop bad lines here
       // (matches the CLI's `2>/dev/null` behavior).
       try {
         JSON.parse(line);
       } catch {
-        return;
+        return true;
       }
       try {
-        proc.stdin?.write(line + "\n");
+        // Return jq stdin's backpressure signal so a chunked scan can await
+        // drain() and stay memory-bounded (CTL-1515).
+        return proc.stdin?.write(line + "\n") ?? true;
       } catch {
-        /* ignore broken pipe */
+        return true; // broken pipe — don't ask the caller to wait
       }
+    },
+    drain(): Promise<void> {
+      const s = proc.stdin;
+      if (closed || !s || !s.writableNeedDrain) return Promise.resolve();
+      return new Promise<void>((resolve) => {
+        const done = () => {
+          s.off("error", done);
+          resolve();
+        };
+        s.once("drain", done);
+        s.once("error", done); // never hang on a broken pipe
+      });
     },
     flush(): Promise<void> {
       if (pendingFlush) return pendingFlush;

--- a/plugins/dev/scripts/orch-monitor/lib/event-log-reader.ts
+++ b/plugins/dev/scripts/orch-monitor/lib/event-log-reader.ts
@@ -12,11 +12,11 @@
 import {
   existsSync,
   statSync,
-  readFileSync,
   openSync,
   readSync,
   closeSync,
 } from "node:fs";
+import { StringDecoder } from "node:string_decoder";
 import { join } from "node:path";
 import { createFilterStream } from "./event-filter";
 import type { EventRing } from "./event-ring";
@@ -55,6 +55,64 @@ function monthlyPath(catalystDir: string, d: Date): string {
   const y = d.getUTCFullYear();
   const m = String(d.getUTCMonth() + 1).padStart(2, "0");
   return join(catalystDir, "events", `${y}-${m}.jsonl`);
+}
+
+/**
+ * CTL-1515: chunk size for {@link scanFileLines}. The bounded forward scan's
+ * peak transient is one chunk, replacing the whole-file `readFileSync` that
+ * allocated a single ~1.7 GB contiguous string bun/mimalloc never returns to
+ * the OS.
+ */
+const SCAN_CHUNK_BYTES = 1 << 20; // 1 MiB
+
+/**
+ * CTL-1515: bounded forward line scan. Reads `path` in `chunkBytes`-sized
+ * chunks via `openSync`/`readSync` (peak transient = one chunk) and invokes
+ * `onLine` once per `\n`-delimited line, in file order. This is the bounded
+ * replacement for the ring-underflow `readFileSync` fallbacks in
+ * {@link readBacklog} and {@link readTunnelEventStats}: a whole-file read of the
+ * current-month log allocated one giant contiguous buffer that Bun/mimalloc
+ * rarely returns to the OS.
+ *
+ * A `node:string_decoder` {@link StringDecoder} carries the partial line across
+ * chunk edges, so a multibyte UTF-8 sequence split on a chunk boundary is
+ * decoded byte-exact (never dropped or mojibake'd). The trailing empty segment
+ * of a newline-terminated file is NOT emitted; a final line lacking a trailing
+ * newline IS emitted. The fd is always closed (try/finally). Returns the total
+ * number of bytes read.
+ */
+export function scanFileLines(
+  path: string,
+  onLine: (line: string) => void,
+  chunkBytes: number = SCAN_CHUNK_BYTES,
+): number {
+  const decoder = new StringDecoder("utf8");
+  const buf = Buffer.allocUnsafe(chunkBytes);
+  const fd = openSync(path, "r");
+  let totalBytes = 0;
+  let pending = "";
+  try {
+    let bytesRead = 0;
+    // `null` position → sequential reads advancing the fd's own cursor; the
+    // peak transient is one chunk (vs a whole-file readFileSync string).
+    while ((bytesRead = readSync(fd, buf, 0, chunkBytes, null)) > 0) {
+      totalBytes += bytesRead;
+      pending += decoder.write(buf.subarray(0, bytesRead));
+      let nl = pending.indexOf("\n");
+      while (nl !== -1) {
+        onLine(pending.slice(0, nl));
+        pending = pending.slice(nl + 1);
+        nl = pending.indexOf("\n");
+      }
+    }
+    // Flush any bytes the decoder was holding, then emit a final unterminated
+    // line (a file ending in "\n" leaves `pending` empty → nothing emitted).
+    pending += decoder.end();
+    if (pending.length > 0) onLine(pending);
+  } finally {
+    closeSync(fd);
+  }
+  return totalBytes;
 }
 
 const BACKOFF_BASE_MS = 200;
@@ -115,22 +173,35 @@ export async function readBacklog(opts: ReadBacklogOpts): Promise<string[]> {
   const path = monthlyPath(opts.catalystDir, now());
   if (!existsSync(path)) return [];
 
-  // Current monthly files are ~17MB at end-of-month; reading the whole file is
-  // fast enough. If files grow significantly we can switch to chunked reads
-  // from the end of the file.
+  // CTL-1515: ring-underflow fallback. Instead of a single whole-file
+  // `readFileSync` (a ~1.7 GB contiguous transient bun/mimalloc never returns),
+  // scan the current-month log in bounded chunks and feed each line to the same
+  // filter path — output is byte-for-byte identical to the old read+split, but
+  // the peak transient is one chunk.
   const _t0 = performance.now();
-  const text = readFileSync(path, "utf8");
-  recordFullRead("readBacklog", text.length, performance.now() - _t0);
-  const allLines = text.split("\n").filter((l) => l.length > 0);
 
   if (!opts.predicate.trim()) {
-    return allLines.slice(-opts.limit);
+    // Empty predicate: rolling last-`limit` non-empty lines (matches the old
+    // `allLines.slice(-limit)`, no JSON validation).
+    const rolling: string[] = [];
+    const bytes = scanFileLines(path, (l) => {
+      if (l.length === 0) return;
+      rolling.push(l);
+      if (rolling.length > opts.limit) rolling.shift();
+    });
+    recordFullRead("readBacklog", bytes, performance.now() - _t0);
+    return rolling;
   }
 
   const stream = createFilterStream(opts.predicate);
   const matches: string[] = [];
   stream.onMatch((l) => matches.push(l));
-  for (const l of allLines) stream.write(l);
+  // `scanFileLines` drives `stream.write` synchronously per line — the same
+  // feed the old `for (const l of allLines)` loop produced (empty/invalid-JSON
+  // lines are dropped inside the stream, just as `.filter(l => l.length > 0)`
+  // + jq did).
+  const bytes = scanFileLines(path, (l) => stream.write(l));
+  recordFullRead("readBacklog", bytes, performance.now() - _t0);
   // Flushing the jq subprocess is a wait-on-stdout. For a 50k-line file we
   // need a few flush cycles to ensure all output drains.
   await stream.flush();
@@ -291,7 +362,11 @@ export function readTunnelEventStats(
     return acc;
   }
 
-  // File fallback (no ring, or ring underflows the 24h window).
+  // File fallback (no ring, or ring underflows the 24h window). CTL-1515:
+  // bounded chunked scan instead of a whole-file `readFileSync` (a ~1.7 GB
+  // contiguous transient bun/mimalloc never returns). Counts are byte-identical
+  // to the old read + `split("\n")` — `accumulateGithubStat` already no-ops on
+  // blank lines.
   const _t0 = performance.now();
   let _fallbackBytes = 0;
   const currentPath = monthlyPath(catalystDir, nowDate);
@@ -300,15 +375,12 @@ export function readTunnelEventStats(
 
   for (const filePath of paths) {
     if (!existsSync(filePath)) continue;
-    let text: string;
     try {
-      text = readFileSync(filePath, "utf8");
+      _fallbackBytes += scanFileLines(filePath, (line) => {
+        accumulateGithubStat(line, cutoffIso, acc);
+      });
     } catch {
       continue;
-    }
-    _fallbackBytes += text.length;
-    for (const line of text.split("\n")) {
-      accumulateGithubStat(line, cutoffIso, acc);
     }
   }
   recordFullRead("tunnelStats", _fallbackBytes, performance.now() - _t0);

--- a/plugins/dev/scripts/orch-monitor/lib/event-log-reader.ts
+++ b/plugins/dev/scripts/orch-monitor/lib/event-log-reader.ts
@@ -115,6 +115,44 @@ export function scanFileLines(
   return totalBytes;
 }
 
+/**
+ * scanFileLinesAsync — CTL-1515. The async twin of {@link scanFileLines}: same
+ * bounded openSync/readSync chunk scan and StringDecoder line-carry, but it
+ * `await`s `onLine` per line so a consumer can apply backpressure (e.g. await a
+ * jq stdin `drain()`) and keep the whole scan memory-bounded. Kept separate from
+ * the sync `scanFileLines` because `readTunnelEventStats` needs the synchronous
+ * form. Returns the number of bytes scanned; the fd is always closed.
+ */
+export async function scanFileLinesAsync(
+  path: string,
+  onLine: (line: string) => Promise<void> | void,
+  chunkBytes: number = SCAN_CHUNK_BYTES,
+): Promise<number> {
+  const decoder = new StringDecoder("utf8");
+  const buf = Buffer.allocUnsafe(chunkBytes);
+  const fd = openSync(path, "r");
+  let totalBytes = 0;
+  let pending = "";
+  try {
+    let bytesRead = 0;
+    while ((bytesRead = readSync(fd, buf, 0, chunkBytes, null)) > 0) {
+      totalBytes += bytesRead;
+      pending += decoder.write(buf.subarray(0, bytesRead));
+      let nl = pending.indexOf("\n");
+      while (nl !== -1) {
+        await onLine(pending.slice(0, nl));
+        pending = pending.slice(nl + 1);
+        nl = pending.indexOf("\n");
+      }
+    }
+    pending += decoder.end();
+    if (pending.length > 0) await onLine(pending);
+  } finally {
+    closeSync(fd);
+  }
+  return totalBytes;
+}
+
 const BACKOFF_BASE_MS = 200;
 const BACKOFF_CAP_MS = 1600;
 
@@ -196,17 +234,26 @@ export async function readBacklog(opts: ReadBacklogOpts): Promise<string[]> {
   const stream = createFilterStream(opts.predicate);
   const matches: string[] = [];
   stream.onMatch((l) => matches.push(l));
-  // `scanFileLines` drives `stream.write` synchronously per line — the same
-  // feed the old `for (const l of allLines)` loop produced (empty/invalid-JSON
-  // lines are dropped inside the stream, just as `.filter(l => l.length > 0)`
-  // + jq did).
-  const bytes = scanFileLines(path, (l) => stream.write(l));
-  recordFullRead("readBacklog", bytes, performance.now() - _t0);
-  // Flushing the jq subprocess is a wait-on-stdout. For a 50k-line file we
-  // need a few flush cycles to ensure all output drains.
-  await stream.flush();
-  await stream.flush();
-  stream.close();
+  try {
+    // scanFileLinesAsync feeds each line to jq and awaits `drain()` whenever jq's
+    // stdin is backpressured — so a slow/stalled jq cannot let the whole ~1.7 GB
+    // log queue into stdin (that would defeat the bounded-transient goal). Same
+    // feed the old `for (const l of allLines)` loop produced; empty/invalid-JSON
+    // lines are dropped inside the stream (as `.filter(l => l.length > 0)` + jq did).
+    const bytes = await scanFileLinesAsync(path, async (l) => {
+      if (!stream.write(l)) await stream.drain();
+    });
+    recordFullRead("readBacklog", bytes, performance.now() - _t0);
+    // Flushing the jq subprocess is a wait-on-stdout. For a 50k-line file we need
+    // a few flush cycles to ensure all output drains.
+    await stream.flush();
+    await stream.flush();
+  } finally {
+    // Always reap the jq child + its pipes, even if the scan throws mid-stream
+    // (e.g. the file disappears between existsSync and openSync) — otherwise the
+    // SSE caller catches the error and leaves an orphaned subprocess (CTL-1515).
+    stream.close();
+  }
   return matches.slice(-opts.limit);
 }
 

--- a/plugins/dev/scripts/orch-monitor/lib/event-log-reader.ts
+++ b/plugins/dev/scripts/orch-monitor/lib/event-log-reader.ts
@@ -12,6 +12,7 @@
 import {
   existsSync,
   statSync,
+  fstatSync,
   openSync,
   readSync,
   closeSync,
@@ -89,13 +90,17 @@ export function scanFileLines(
   const decoder = new StringDecoder("utf8");
   const buf = Buffer.allocUnsafe(chunkBytes);
   const fd = openSync(path, "r");
+  // Snapshot the EOF at open so a file being appended to (a busy producer) can't
+  // keep extending this scan indefinitely — read exactly the bytes present now
+  // (Codex P2 on #2730).
+  const snapshotSize = fstatSync(fd).size;
   let totalBytes = 0;
   let pending = "";
   try {
     let bytesRead = 0;
     // `null` position → sequential reads advancing the fd's own cursor; the
     // peak transient is one chunk (vs a whole-file readFileSync string).
-    while ((bytesRead = readSync(fd, buf, 0, chunkBytes, null)) > 0) {
+    while (totalBytes < snapshotSize && (bytesRead = readSync(fd, buf, 0, Math.min(chunkBytes, snapshotSize - totalBytes), null)) > 0) {
       totalBytes += bytesRead;
       pending += decoder.write(buf.subarray(0, bytesRead));
       let nl = pending.indexOf("\n");
@@ -131,11 +136,15 @@ export async function scanFileLinesAsync(
   const decoder = new StringDecoder("utf8");
   const buf = Buffer.allocUnsafe(chunkBytes);
   const fd = openSync(path, "r");
+  // Snapshot the EOF at open so a file being appended to (a busy producer) can't
+  // keep extending this scan indefinitely — read exactly the bytes present now
+  // (Codex P2 on #2730).
+  const snapshotSize = fstatSync(fd).size;
   let totalBytes = 0;
   let pending = "";
   try {
     let bytesRead = 0;
-    while ((bytesRead = readSync(fd, buf, 0, chunkBytes, null)) > 0) {
+    while (totalBytes < snapshotSize && (bytesRead = readSync(fd, buf, 0, Math.min(chunkBytes, snapshotSize - totalBytes), null)) > 0) {
       totalBytes += bytesRead;
       pending += decoder.write(buf.subarray(0, bytesRead));
       let nl = pending.indexOf("\n");
@@ -232,8 +241,14 @@ export async function readBacklog(opts: ReadBacklogOpts): Promise<string[]> {
   }
 
   const stream = createFilterStream(opts.predicate);
+  // Rolling last-`limit` buffer: a broad predicate on a huge log retains only the
+  // most recent `limit` matches, never the whole file — otherwise the memory the
+  // bounded scan saved just moves into this array (Codex P1 on #2730).
   const matches: string[] = [];
-  stream.onMatch((l) => matches.push(l));
+  stream.onMatch((l) => {
+    matches.push(l);
+    if (matches.length > opts.limit) matches.shift();
+  });
   try {
     // scanFileLinesAsync feeds each line to jq and awaits `drain()` whenever jq's
     // stdin is backpressured — so a slow/stalled jq cannot let the whole ~1.7 GB
@@ -244,10 +259,10 @@ export async function readBacklog(opts: ReadBacklogOpts): Promise<string[]> {
       if (!stream.write(l)) await stream.drain();
     });
     recordFullRead("readBacklog", bytes, performance.now() - _t0);
-    // Flushing the jq subprocess is a wait-on-stdout. For a 50k-line file we need
-    // a few flush cycles to ensure all output drains.
-    await stream.flush();
-    await stream.flush();
+    // Wait for jq to emit EVERY match (it exits when stdin ends) before we return —
+    // the old fixed 50ms double-flush could expire while jq still had pending
+    // input/output on a large log, returning stale early matches (Codex P1 on #2730).
+    await stream.end();
   } finally {
     // Always reap the jq child + its pipes, even if the scan throws mid-stream
     // (e.g. the file disappears between existsSync and openSync) — otherwise the


### PR DESCRIPTION
## CTL-1515 — residual whole-file reads in orch-monitor

CTL-1257 left two `readFileSync` fallbacks in `event-log-reader.ts` that fire on event-ring underflow (`readBacklog`, `readTunnelEventStats`) — each a **~1.7 GB contiguous transient** bun/mimalloc never returns. **Currently latent** (live `/debug/memory` `fullReads:{}` empty), so this is defense-in-depth.

## Fix
One shared **`scanFileLines(path, onLine, chunkBytes)`** — bounded forward scan via `openSync`/`readSync`, peak transient = one 1 MiB chunk, partial line carried across chunk edges with a `StringDecoder` (multibyte UTF-8 split on a boundary decodes byte-exact), fd closed in `try/finally`. `readBacklog` empty-predicate → rolling last-`limit` buffer; predicate path → existing `createFilterStream` (byte-identical HUD output). `readTunnelEventStats` keeps the shared accumulator + `[prev,current]`-month loop + `recordFullRead`. Dropped the now-unused `readFileSync` import.

## Tests (+5 → 31 pass)
A **real reintroduction guard**: spies `node:fs` `readSync`/`readFileSync` and asserts the fallbacks issue >1 `readSync` and **never** `readFileSync`, driven with a 4-byte emoji straddling a chunk boundary (no dropped/corrupted line). Counts are read while the spy is live (Bun's `mockRestore` clears calls — a naive read-after-restore would make the guard vacuous). typecheck clean.

Implemented per the adversarially-verified plan + reviewer corrections. Follow-up: `loadRecoveryOutcomes` (board-data.mjs) has the same unbounded fallback (out of scope).

🤖 Generated with [Claude Code](https://claude.com/claude-code)