### PR TITLE
feat(dev): CTL-1518 health-responder supervises com.catalyst.agent sampler (self-heal backstop)

### DIFF
--- a/plugins/dev/scripts/__tests__/health-responder.test.sh
+++ b/plugins/dev/scripts/__tests__/health-responder.test.sh
@@ -954,6 +954,130 @@ run "T64: the full script runs clean under real /bin/bash with a provisioned tok
 rm -f "${HOME}/.config/catalyst/cloud-sync.env"
 unset MOCK_LAST_EXIT
 
+# ─── Phase 14: CTL-1518 agent supervision (T65–T74) ─────────────────────────
+#
+# Second supervised target: the com.catalyst.agent host-metrics sampler. Its
+# block runs BEFORE the cloud-sync detect (the cloud-sync act path `exit 0`s, so
+# a block after it would be unreachable) and is INERT without the agent plist.
+# Same PATH-shadowed launchctl/pgrep mocks — the agent kickstart lands in
+# KICKSTART_LOG as `kickstart -k gui/<uid>/com.catalyst.agent`. Staleness is the
+# breadcrumb mtime, falling back to the plist install-mtime when it is absent.
+
+export AGENT_HEARTBEAT_FILE="${SCRATCH}/catalyst-agent.heartbeat"
+AGENT_PLIST_FILE="${CATALYST_LAUNCHAGENTS_DIR}/com.catalyst.agent.plist"
+AGENT_KICK="kickstart -k gui/$(id -u)/com.catalyst.agent"
+
+# _agent_reset: the cloud-sync _reset PLUS the agent plist + breadcrumb (the
+# state dir removal in _reset already drops any agent-attempt.*/ESCALATED marker).
+_agent_reset() {
+  _reset
+  rm -f "$AGENT_PLIST_FILE" "$AGENT_HEARTBEAT_FILE"
+}
+
+# T65 (inert): no agent plist → no target=catalyst-agent line at all (this is
+# what keeps the whole T1–T64 suite above inert — none of them install it).
+_agent_reset
+touch "$PLIST"; touch "$MOCK_ALIVE_FILE"; _fresh_lock  # cloud-sync healthy
+run "T65: no agent plist is inert — no target=catalyst-agent line" \
+  bash -c "bash '$RESPONDER' | { ! grep -q 'target=catalyst-agent'; }"
+
+# T66 (fresh): agent plist + fresh breadcrumb → healthy, no kickstart.
+_agent_reset
+touch "$AGENT_PLIST_FILE"; touch "$AGENT_HEARTBEAT_FILE"
+run "T66: fresh agent breadcrumb is healthy (no kickstart)" \
+  bash -c "bash '$RESPONDER' | grep -q 'heartbeat status=healthy target=catalyst-agent' && ! test -s '${KICKSTART_LOG}'"
+
+# T67 (stale): agent plist + old breadcrumb → kickstart com.catalyst.agent, with
+# its OWN attempt marker (never the cloud-sync attempt.* namespace).
+_agent_reset
+touch "$AGENT_PLIST_FILE"; touch -t 202501010000 "$AGENT_HEARTBEAT_FILE"
+RESPONDER_KICKSTART_WAIT_SECS=0 bash "$RESPONDER" > "${SCRATCH}/agent-out" 2>&1 || true
+run "T67: stale agent breadcrumb kickstarts com.catalyst.agent" \
+  expect_contains "$KICKSTART_LOG" "$AGENT_KICK"
+run "T67b: stale agent emits its own target=catalyst-agent heartbeat" \
+  expect_contains "${SCRATCH}/agent-out" "target=catalyst-agent"
+run "T67c: stale agent records an agent-scoped attempt marker" \
+  bash -c "ls '${RESPONDER_STATE_DIR}'/agent-attempt.* >/dev/null"
+run "T67d: the agent path did NOT touch the cloud-sync attempt.* namespace" \
+  bash -c "! ls '${RESPONDER_STATE_DIR}'/attempt.* >/dev/null 2>&1"
+
+# T68 (absent breadcrumb, OLD plist): never ticked but installed long ago →
+# plist-mtime fallback is stale → kickstart.
+_agent_reset
+touch -t 202501010000 "$AGENT_PLIST_FILE"
+run "T68: absent breadcrumb + old plist mtime is stale (kickstart)" \
+  bash -c "RESPONDER_KICKSTART_WAIT_SECS=0 bash '$RESPONDER' >/dev/null; grep -qF '$AGENT_KICK' '${KICKSTART_LOG}'"
+
+# T69 (absent breadcrumb, FRESH plist): freshly installed, not yet ticked →
+# plist-mtime fallback is fresh → NOT stale → no kickstart (give it time to tick).
+_agent_reset
+touch "$AGENT_PLIST_FILE"
+run "T69: absent breadcrumb + fresh plist mtime is NOT stale (no kickstart)" \
+  bash -c "bash '$RESPONDER' | grep -q 'heartbeat status=healthy target=catalyst-agent' && ! test -s '${KICKSTART_LOG}'"
+
+# T70 (sub-kill-switch): RESPONDER_AGENT_ENABLED=0 disables the agent block even
+# when stale.
+_agent_reset
+touch "$AGENT_PLIST_FILE"; touch -t 202501010000 "$AGENT_HEARTBEAT_FILE"
+run "T70: RESPONDER_AGENT_ENABLED=0 disables the agent block (no kickstart)" \
+  bash -c "RESPONDER_AGENT_ENABLED=0 bash '$RESPONDER' | grep -q 'heartbeat status=disabled target=catalyst-agent' && ! test -s '${KICKSTART_LOG}'"
+
+# T71 (cap → escalate): repeated stale → after MAX_ATTEMPTS, escalate with its
+# own one-shot marker + fail-open otel, no further kickstart. MAX=2: kick, kick, escalate.
+_agent_reset
+touch "$AGENT_PLIST_FILE"; touch -t 202501010000 "$AGENT_HEARTBEAT_FILE"
+export RESPONDER_MAX_ATTEMPTS=2
+run "T71: agent strike 1 kickstarts (1 total)" \
+  bash -c "RESPONDER_KICKSTART_WAIT_SECS=0 bash '$RESPONDER' >/dev/null; [ \"\$(grep -cF '$AGENT_KICK' '${KICKSTART_LOG}')\" -eq 1 ]"
+run "T71b: agent strike 2 kickstarts (2 total)" \
+  bash -c "RESPONDER_KICKSTART_WAIT_SECS=0 bash '$RESPONDER' >/dev/null; [ \"\$(grep -cF '$AGENT_KICK' '${KICKSTART_LOG}')\" -eq 2 ]"
+run "T71c: agent third strike escalates (heartbeat + no third kickstart)" \
+  bash -c "out=\$(RESPONDER_KICKSTART_WAIT_SECS=0 bash '$RESPONDER'); printf '%s' \"\$out\" | grep -q 'heartbeat status=escalated target=catalyst-agent' && [ \"\$(grep -cF '$AGENT_KICK' '${KICKSTART_LOG}')\" -eq 2 ]"
+run "T71d: agent ESCALATED.catalyst-agent one-shot marker written" \
+  test -f "${RESPONDER_STATE_DIR}/ESCALATED.catalyst-agent"
+run "T71e: agent escalation emitted fail-open otel with target=catalyst-agent" \
+  expect_contains "$SCRATCH_OTEL_LOG" "target=catalyst-agent"
+run "T71f: escalated hold — no re-emit (one-shot), no further kickstart" \
+  bash -c "out=\$(bash '$RESPONDER'); printf '%s' \"\$out\" | grep -q 'heartbeat status=escalated target=catalyst-agent' && [ \"\$(grep -c 'target=catalyst-agent' '${SCRATCH_OTEL_LOG}')\" -eq 1 ]"
+unset RESPONDER_MAX_ATTEMPTS
+
+# T72 (re-arm): a fresh breadcrumb after escalation clears the markers + re-arms.
+_agent_reset
+touch "$AGENT_PLIST_FILE"; touch "$AGENT_HEARTBEAT_FILE"
+mkdir -p "$RESPONDER_STATE_DIR"
+touch "${RESPONDER_STATE_DIR}/ESCALATED.catalyst-agent"
+touch "${RESPONDER_STATE_DIR}/agent-attempt.$(date +%s).1"
+run "T72: agent condition clears → re-arm" \
+  bash -c "bash '$RESPONDER' | grep -q 're-armed'"
+run "T72b: agent ESCALATED marker removed on re-arm" \
+  bash -c "! test -f '${RESPONDER_STATE_DIR}/ESCALATED.catalyst-agent'"
+run "T72c: agent attempt markers removed on re-arm" \
+  bash -c "! ls '${RESPONDER_STATE_DIR}'/agent-attempt.* >/dev/null 2>&1"
+
+# T73 (two plists): cloud-sync healthy + agent stale — the agent kickstart fires
+# AND the sweep STILL ends with a completed cloud-sync `heartbeat status=` line
+# (the doctor-freshness contract survives the second target running first).
+_agent_reset
+touch "$PLIST"; touch "$MOCK_ALIVE_FILE"; _fresh_lock
+touch "$AGENT_PLIST_FILE"; touch -t 202501010000 "$AGENT_HEARTBEAT_FILE"
+RESPONDER_KICKSTART_WAIT_SECS=0 bash "$RESPONDER" > "${SCRATCH}/two-out" 2>&1 || true
+run "T73: two plists — the agent kickstart fires" \
+  expect_contains "$KICKSTART_LOG" "$AGENT_KICK"
+run "T73b: two plists — the agent emitted its own target=catalyst-agent heartbeat" \
+  expect_contains "${SCRATCH}/two-out" "target=catalyst-agent"
+run "T73c: two plists — the sweep still ENDS with a completed cloud-sync heartbeat (doctor freshness)" \
+  bash -c "tail -1 '${SCRATCH}/two-out' | grep -q 'heartbeat status=healthy' && tail -1 '${SCRATCH}/two-out' | { ! grep -q 'target=catalyst-agent'; }"
+run "T73d: two plists — the healthy cloud-sync writer was NOT kickstarted" \
+  bash -c "! grep -q 'ai.coalesce.catalyst-cloud-sync' '${KICKSTART_LOG}'"
+
+# T74 (bash 3.2): the FULL script with the agent block active runs clean under
+# real /bin/bash (3.2 on Darwin — the production interpreter; same idiom as T64).
+# No `unbound variable`, and the agent kickstart still fires.
+_agent_reset
+touch "$AGENT_PLIST_FILE"; touch -t 202501010000 "$AGENT_HEARTBEAT_FILE"
+run "T74: the agent block runs clean under real /bin/bash (production interpreter)" \
+  bash -c "out=\$(RESPONDER_KICKSTART_WAIT_SECS=0 /bin/bash '$RESPONDER' 2>&1); printf '%s' \"\$out\" | grep -q 'unbound variable' && exit 1; grep -qF '$AGENT_KICK' '${KICKSTART_LOG}'"
+
 # ─── results ────────────────────────────────────────────────────────────────
 
 echo ""

--- a/plugins/dev/scripts/__tests__/health-responder.test.sh
+++ b/plugins/dev/scripts/__tests__/health-responder.test.sh
@@ -985,7 +985,16 @@ run "T65: no agent plist is inert — no target=catalyst-agent line" \
 _agent_reset
 touch "$AGENT_PLIST_FILE"; touch "$AGENT_HEARTBEAT_FILE"
 run "T66: fresh agent breadcrumb is healthy (no kickstart)" \
-  bash -c "bash '$RESPONDER' | grep -q 'heartbeat status=healthy target=catalyst-agent' && ! test -s '${KICKSTART_LOG}'"
+  bash -c "bash '$RESPONDER' | grep -q 'agent-supervision status=healthy target=catalyst-agent' && ! test -s '${KICKSTART_LOG}'"
+
+# T66b (Codex P2): the agent line uses the distinct 'agent-supervision status='
+# prefix, NOT 'heartbeat status=', so it can never be the terminal line doctor's
+# `\bheartbeat status=` freshness anchor keys on — a partial sweep that dies after
+# the agent block but before cloud-sync's heartbeat can't fool doctor.
+_agent_reset
+touch "$AGENT_PLIST_FILE"; touch "$AGENT_HEARTBEAT_FILE"
+run "T66b: the agent supervision line does NOT match doctor's 'heartbeat status=' anchor" \
+  bash -c "bash '$RESPONDER' | grep 'target=catalyst-agent' | { ! grep -q 'heartbeat status='; }"
 
 # T67 (stale): agent plist + old breadcrumb → kickstart com.catalyst.agent, with
 # its OWN attempt marker (never the cloud-sync attempt.* namespace).
@@ -1013,14 +1022,14 @@ run "T68: absent breadcrumb + old plist mtime is stale (kickstart)" \
 _agent_reset
 touch "$AGENT_PLIST_FILE"
 run "T69: absent breadcrumb + fresh plist mtime is NOT stale (no kickstart)" \
-  bash -c "bash '$RESPONDER' | grep -q 'heartbeat status=healthy target=catalyst-agent' && ! test -s '${KICKSTART_LOG}'"
+  bash -c "bash '$RESPONDER' | grep -q 'agent-supervision status=healthy target=catalyst-agent' && ! test -s '${KICKSTART_LOG}'"
 
 # T70 (sub-kill-switch): RESPONDER_AGENT_ENABLED=0 disables the agent block even
 # when stale.
 _agent_reset
 touch "$AGENT_PLIST_FILE"; touch -t 202501010000 "$AGENT_HEARTBEAT_FILE"
 run "T70: RESPONDER_AGENT_ENABLED=0 disables the agent block (no kickstart)" \
-  bash -c "RESPONDER_AGENT_ENABLED=0 bash '$RESPONDER' | grep -q 'heartbeat status=disabled target=catalyst-agent' && ! test -s '${KICKSTART_LOG}'"
+  bash -c "RESPONDER_AGENT_ENABLED=0 bash '$RESPONDER' | grep -q 'agent-supervision status=disabled target=catalyst-agent' && ! test -s '${KICKSTART_LOG}'"
 
 # T71 (cap → escalate): repeated stale → after MAX_ATTEMPTS, escalate with its
 # own one-shot marker + fail-open otel, no further kickstart. MAX=2: kick, kick, escalate.
@@ -1032,13 +1041,13 @@ run "T71: agent strike 1 kickstarts (1 total)" \
 run "T71b: agent strike 2 kickstarts (2 total)" \
   bash -c "RESPONDER_KICKSTART_WAIT_SECS=0 bash '$RESPONDER' >/dev/null; [ \"\$(grep -cF '$AGENT_KICK' '${KICKSTART_LOG}')\" -eq 2 ]"
 run "T71c: agent third strike escalates (heartbeat + no third kickstart)" \
-  bash -c "out=\$(RESPONDER_KICKSTART_WAIT_SECS=0 bash '$RESPONDER'); printf '%s' \"\$out\" | grep -q 'heartbeat status=escalated target=catalyst-agent' && [ \"\$(grep -cF '$AGENT_KICK' '${KICKSTART_LOG}')\" -eq 2 ]"
+  bash -c "out=\$(RESPONDER_KICKSTART_WAIT_SECS=0 bash '$RESPONDER'); printf '%s' \"\$out\" | grep -q 'agent-supervision status=escalated target=catalyst-agent' && [ \"\$(grep -cF '$AGENT_KICK' '${KICKSTART_LOG}')\" -eq 2 ]"
 run "T71d: agent ESCALATED.catalyst-agent one-shot marker written" \
   test -f "${RESPONDER_STATE_DIR}/ESCALATED.catalyst-agent"
 run "T71e: agent escalation emitted fail-open otel with target=catalyst-agent" \
   expect_contains "$SCRATCH_OTEL_LOG" "target=catalyst-agent"
 run "T71f: escalated hold — no re-emit (one-shot), no further kickstart" \
-  bash -c "out=\$(bash '$RESPONDER'); printf '%s' \"\$out\" | grep -q 'heartbeat status=escalated target=catalyst-agent' && [ \"\$(grep -c 'target=catalyst-agent' '${SCRATCH_OTEL_LOG}')\" -eq 1 ]"
+  bash -c "out=\$(bash '$RESPONDER'); printf '%s' \"\$out\" | grep -q 'agent-supervision status=escalated target=catalyst-agent' && [ \"\$(grep -c 'target=catalyst-agent' '${SCRATCH_OTEL_LOG}')\" -eq 1 ]"
 unset RESPONDER_MAX_ATTEMPTS
 
 # T72 (re-arm): a fresh breadcrumb after escalation clears the markers + re-arms.

--- a/plugins/dev/scripts/catalyst-agent/catalyst-agent.mjs
+++ b/plugins/dev/scripts/catalyst-agent/catalyst-agent.mjs
@@ -22,8 +22,11 @@
 // it keeps `importers` injectable so tests drive runDomain/runOnce with stubs and
 // touch no real network, ps, or keychain.
 
-import { readAgentConfig, log } from "./config.mjs";
+import { readAgentConfig, log, getHeartbeatPath } from "./config.mjs";
 import { makeBuilderEmit, drainPending } from "./emit.mjs";
+import { writeFileSync, renameSync, mkdirSync } from "node:fs";
+import { dirname } from "node:path";
+import { hostname } from "node:os";
 
 const HELP = `catalyst-agent — standalone host telemetry agent (CTL-812)
 
@@ -204,6 +207,31 @@ export async function runOnce({ config = readAgentConfig(), importers } = {}) {
   return results;
 }
 
+/**
+ * writeHeartbeat — refresh the CTL-1518 liveness breadcrumb the health-responder
+ * reads to decide whether this launchd-managed sampler has silently died (it did
+ * on mini-2, dead for 10 days). Written ATOMICALLY (tmp + rename) so a concurrent
+ * reader never stat/reads a torn file, and BEST-EFFORT: any failure is logged at
+ * warn and swallowed — a breadcrumb write must NEVER be what turns a healthy tick
+ * into a crash. `path` / `now` / `host` are injectable so a unit test points it at
+ * a scratch dir and asserts content without touching the real CATALYST_DIR.
+ *
+ * @param {object} [opts]
+ * @param {string} [opts.path=getHeartbeatPath()]  breadcrumb path (CATALYST_DIR-resolved)
+ * @param {number} [opts.now=Date.now()]           epoch-ms timestamp written as `ts`
+ * @param {string} [opts.host=hostname()]          host label written as `host`
+ */
+export function writeHeartbeat({ path = getHeartbeatPath(), now = Date.now(), host = hostname() } = {}) {
+  try {
+    mkdirSync(dirname(path), { recursive: true });
+    const tmp = `${path}.tmp.${process.pid}`;
+    writeFileSync(tmp, `${JSON.stringify({ ts: now, host })}\n`);
+    renameSync(tmp, path);
+  } catch (err) {
+    log.warn({ err: err?.message }, "catalyst-agent: heartbeat breadcrumb write failed (non-fatal)");
+  }
+}
+
 // --- CLI ---
 /**
  * main — parse the flag and dispatch. Exported (and fully seam-injected) so a
@@ -228,6 +256,9 @@ export async function runOnce({ config = readAgentConfig(), importers } = {}) {
 export async function main(argv = process.argv.slice(2), deps = {}) {
   const {
     runOnceImpl = runOnce,
+    // CTL-1518: refresh the liveness breadcrumb after the --once tick. Injectable
+    // so the flag-dispatch tests stay hermetic (no write to the real CATALYST_DIR).
+    writeHeartbeatImpl = writeHeartbeat,
     setIntervalImpl = setInterval,
     clearIntervalImpl = clearInterval,
     onSignal = (name, handler) => process.on(name, handler),
@@ -249,7 +280,16 @@ export async function main(argv = process.argv.slice(2), deps = {}) {
     return 0;
   }
   if (flag === "--once") {
-    await runOnceImpl();
+    // Refresh the breadcrumb in a `finally` so even a transient tick throw still
+    // records that THIS process ran (CTL-1518 reviewer point): the responder
+    // reads the breadcrumb MTIME to distinguish a silently-dead sampler from a
+    // healthy one, and a process that ticked — even partially before throwing —
+    // is not dead. The throw still propagates (unchanged --once error semantics).
+    try {
+      await runOnceImpl();
+    } finally {
+      writeHeartbeatImpl();
+    }
     return 0;
   }
   if (flag === "--loop") {

--- a/plugins/dev/scripts/catalyst-agent/catalyst-agent.test.mjs
+++ b/plugins/dev/scripts/catalyst-agent/catalyst-agent.test.mjs
@@ -6,11 +6,11 @@
 // Run: cd plugins/dev/scripts/catalyst-agent && bun test catalyst-agent.test.mjs
 
 import { describe, test, expect } from "bun:test";
-import { mkdtempSync, readFileSync, existsSync } from "node:fs";
+import { mkdtempSync, readFileSync, existsSync, writeFileSync, readdirSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { runDomain, runOnce, main, defaultImporters } from "./catalyst-agent.mjs";
-import { readAgentConfig } from "./config.mjs";
+import { runDomain, runOnce, main, defaultImporters, writeHeartbeat } from "./catalyst-agent.mjs";
+import { readAgentConfig, getHeartbeatPath } from "./config.mjs";
 
 const ALL_ON = {
   usageEnabled: true,
@@ -149,7 +149,9 @@ describe("main — flag dispatch & exit codes", () => {
   test("--once dispatches to the (injected) runOnce and returns 0", async () => {
     let called = 0;
     const { write } = captureWrites();
-    const code = await main(["--once"], { write, runOnceImpl: async () => { called++; } });
+    // writeHeartbeatImpl stubbed so the test stays hermetic (CTL-1518: the real
+    // impl would write to ~/catalyst under CATALYST_DIR).
+    const code = await main(["--once"], { write, runOnceImpl: async () => { called++; }, writeHeartbeatImpl: () => {} });
     expect(code).toBe(0);
     expect(called).toBe(1);
   });
@@ -164,8 +166,38 @@ describe("main — flag dispatch & exit codes", () => {
         await new Promise((r) => setTimeout(r, 5));
         done = true;
       },
+      writeHeartbeatImpl: () => {},
     });
     expect(done).toBe(true);
+  });
+
+  // ── CTL-1518: the liveness breadcrumb refresh on the --once path ──
+  test("--once refreshes the breadcrumb AFTER the tick", async () => {
+    const order = [];
+    const { write } = captureWrites();
+    const code = await main(["--once"], {
+      write,
+      runOnceImpl: async () => { order.push("tick"); },
+      writeHeartbeatImpl: () => { order.push("heartbeat"); },
+    });
+    expect(code).toBe(0);
+    expect(order).toEqual(["tick", "heartbeat"]);
+  });
+
+  test("--once refreshes the breadcrumb in a finally even when the tick throws (throw still propagates)", async () => {
+    let wrote = 0;
+    const { write } = captureWrites();
+    // A transient tick throw must NOT stop the breadcrumb refresh — the process
+    // ran, so it is not dead — but the throw still propagates (unchanged --once
+    // error semantics).
+    await expect(
+      main(["--once"], {
+        write,
+        runOnceImpl: async () => { throw new Error("tick boom"); },
+        writeHeartbeatImpl: () => { wrote++; },
+      }),
+    ).rejects.toThrow("tick boom");
+    expect(wrote).toBe(1);
   });
 
   test("an unknown flag returns 2 and writes the error to stderr", async () => {
@@ -400,5 +432,47 @@ describe("defaultImporters — real sampler composition (event-log emit)", () =>
       // can await it (the load-bearing property for the OTLP drain).
       expect(mod.runOnce.constructor.name).toBe("AsyncFunction");
     }
+  });
+});
+
+// ─── writeHeartbeat — the CTL-1518 liveness breadcrumb ─────────────────────────
+
+describe("writeHeartbeat — liveness breadcrumb (CTL-1518)", () => {
+  test("writes {ts,host} atomically to the injected path, leaving no temp file", () => {
+    const dir = mkdtempSync(join(tmpdir(), "ctl1518-hb-"));
+    const path = join(dir, "catalyst-agent.heartbeat");
+    writeHeartbeat({ path, now: 1234567890, host: "test-host" });
+    expect(existsSync(path)).toBe(true);
+    const parsed = JSON.parse(readFileSync(path, "utf8"));
+    expect(parsed).toEqual({ ts: 1234567890, host: "test-host" });
+    // Atomic rename leaves no `*.tmp.<pid>` sibling behind.
+    expect(readdirSync(dir).filter((f) => f.includes(".tmp."))).toEqual([]);
+  });
+
+  test("resolves the default path from CATALYST_DIR (getHeartbeatPath parity)", () => {
+    const dir = mkdtempSync(join(tmpdir(), "ctl1518-hb-env-"));
+    const saved = process.env.CATALYST_DIR;
+    process.env.CATALYST_DIR = dir;
+    try {
+      // The default path must equal getHeartbeatPath() under the same env — the
+      // exact path the responder resolves from its own CATALYST_DIR.
+      expect(getHeartbeatPath()).toBe(join(dir, "catalyst-agent.heartbeat"));
+      writeHeartbeat({ now: 42, host: "h" });
+      expect(JSON.parse(readFileSync(join(dir, "catalyst-agent.heartbeat"), "utf8"))).toEqual({ ts: 42, host: "h" });
+    } finally {
+      if (saved === undefined) delete process.env.CATALYST_DIR;
+      else process.env.CATALYST_DIR = saved;
+    }
+  });
+
+  test("is best-effort — an unwritable path is swallowed, never thrown", () => {
+    const dir = mkdtempSync(join(tmpdir(), "ctl1518-hb-fail-"));
+    const blocker = join(dir, "blocker");
+    writeFileSync(blocker, "x");
+    // Parent of the target is a FILE → mkdirSync throws ENOTDIR; writeHeartbeat
+    // must swallow it (a breadcrumb write can never crash a healthy tick).
+    const path = join(blocker, "sub", "catalyst-agent.heartbeat");
+    expect(() => writeHeartbeat({ path, now: 1, host: "h" })).not.toThrow();
+    expect(existsSync(path)).toBe(false);
   });
 });

--- a/plugins/dev/scripts/catalyst-agent/com.catalyst.agent.plist
+++ b/plugins/dev/scripts/catalyst-agent/com.catalyst.agent.plist
@@ -38,6 +38,13 @@
          event-log path; empty disables metric emission. -->
     <key>CATALYST_AGENT_METRICS_ENDPOINT</key>
     <string>REPLACE_WITH_METRICS_ENDPOINT</string>
+    <!-- CTL-1518: the CATALYST_DIR the agent resolves its heartbeat breadcrumb
+         under. Persisted so a node installed with a nondefault CATALYST_DIR writes
+         the breadcrumb to the SAME dir the health-responder (installed with the
+         same override) probes — otherwise the responder would false-kickstart a
+         healthy sampler and eventually escalate. -->
+    <key>CATALYST_DIR</key>
+    <string>REPLACE_WITH_CATALYST_DIR</string>
   </dict>
 
   <key>RunAtLoad</key>

--- a/plugins/dev/scripts/catalyst-agent/config.mjs
+++ b/plugins/dev/scripts/catalyst-agent/config.mjs
@@ -84,6 +84,16 @@ export function getEventLogPath() {
   return resolve(catalystDir(), "events", `${ym}.jsonl`);
 }
 
+// The liveness breadcrumb the standalone agent atomically refreshes after every
+// `--once` tick (CTL-1518). health-responder.sh reads its MTIME (not its body)
+// to tell a silently-dead launchd-managed sampler from a healthy one — the same
+// dead-on-mini-2-for-10-days failure the responder now backstops. Resolved from
+// the SAME CATALYST_DIR root as the event log so a CATALYST_DIR override moves
+// both together (the responder resolves the identical path).
+export function getHeartbeatPath() {
+  return resolve(catalystDir(), "catalyst-agent.heartbeat");
+}
+
 // --- Cadence floor ---
 // The launchd StartInterval and --loop cadence are both driven by intervalMs.
 // 3 min is the hard floor (matches the rate-limit poller floor) so a misset env

--- a/plugins/dev/scripts/catalyst-agent/install.sh
+++ b/plugins/dev/scripts/catalyst-agent/install.sh
@@ -61,16 +61,19 @@ fi
 CATALYST_DIR_VALUE="${CATALYST_DIR:-${HOME}/catalyst}"
 echo "install.sh: CATALYST_DIR → ${CATALYST_DIR_VALUE}"
 
-# CTL-1518: escape sed-replacement metacharacters in the substituted values so a
-# path containing `&`, `|`, or `\` (e.g. "/Volumes/Catalyst & Data") can't expand
-# into the matched placeholder and write mangled XML into the plist (Codex P2).
+# CTL-1518: each substituted value lands inside a plist <string>…</string>, so it
+# must be BOTH XML-escaped (so `&`/`<`/`>` don't produce invalid XML — e.g.
+# "/Volumes/Catalyst & Data") AND sed-replacement-escaped (so `&`/`|`/`\` don't
+# expand into the sed match). XML-escape FIRST, then sed-escape the result (Codex P2).
+_xml_escape() { printf '%s' "$1" | sed -e 's/&/\&amp;/g' -e 's/</\&lt;/g' -e 's/>/\&gt;/g'; }
 _sed_escape() { printf '%s' "$1" | sed -e 's/[\\&|]/\\&/g'; }
-NODE_BIN_E="$(_sed_escape "${NODE_BIN}")"
-AGENT_E="$(_sed_escape "${AGENT}")"
-HOME_E="$(_sed_escape "${HOME}")"
-INSTALL_PATH_E="$(_sed_escape "${INSTALL_PATH}")"
-METRICS_ENDPOINT_E="$(_sed_escape "${METRICS_ENDPOINT}")"
-CATALYST_DIR_VALUE_E="$(_sed_escape "${CATALYST_DIR_VALUE}")"
+_esc() { _sed_escape "$(_xml_escape "$1")"; }
+NODE_BIN_E="$(_esc "${NODE_BIN}")"
+AGENT_E="$(_esc "${AGENT}")"
+HOME_E="$(_esc "${HOME}")"
+INSTALL_PATH_E="$(_esc "${INSTALL_PATH}")"
+METRICS_ENDPOINT_E="$(_esc "${METRICS_ENDPOINT}")"
+CATALYST_DIR_VALUE_E="$(_esc "${CATALYST_DIR_VALUE}")"
 
 sed \
   -e "s|REPLACE_WITH_NODE|${NODE_BIN_E}|g" \

--- a/plugins/dev/scripts/catalyst-agent/install.sh
+++ b/plugins/dev/scripts/catalyst-agent/install.sh
@@ -61,13 +61,24 @@ fi
 CATALYST_DIR_VALUE="${CATALYST_DIR:-${HOME}/catalyst}"
 echo "install.sh: CATALYST_DIR → ${CATALYST_DIR_VALUE}"
 
+# CTL-1518: escape sed-replacement metacharacters in the substituted values so a
+# path containing `&`, `|`, or `\` (e.g. "/Volumes/Catalyst & Data") can't expand
+# into the matched placeholder and write mangled XML into the plist (Codex P2).
+_sed_escape() { printf '%s' "$1" | sed -e 's/[\\&|]/\\&/g'; }
+NODE_BIN_E="$(_sed_escape "${NODE_BIN}")"
+AGENT_E="$(_sed_escape "${AGENT}")"
+HOME_E="$(_sed_escape "${HOME}")"
+INSTALL_PATH_E="$(_sed_escape "${INSTALL_PATH}")"
+METRICS_ENDPOINT_E="$(_sed_escape "${METRICS_ENDPOINT}")"
+CATALYST_DIR_VALUE_E="$(_sed_escape "${CATALYST_DIR_VALUE}")"
+
 sed \
-  -e "s|REPLACE_WITH_NODE|${NODE_BIN}|g" \
-  -e "s|REPLACE_WITH_AGENT|${AGENT}|g" \
-  -e "s|REPLACE_WITH_HOME|${HOME}|g" \
-  -e "s|REPLACE_WITH_PATH|${INSTALL_PATH}|g" \
-  -e "s|REPLACE_WITH_METRICS_ENDPOINT|${METRICS_ENDPOINT}|g" \
-  -e "s|REPLACE_WITH_CATALYST_DIR|${CATALYST_DIR_VALUE}|g" \
+  -e "s|REPLACE_WITH_NODE|${NODE_BIN_E}|g" \
+  -e "s|REPLACE_WITH_AGENT|${AGENT_E}|g" \
+  -e "s|REPLACE_WITH_HOME|${HOME_E}|g" \
+  -e "s|REPLACE_WITH_PATH|${INSTALL_PATH_E}|g" \
+  -e "s|REPLACE_WITH_METRICS_ENDPOINT|${METRICS_ENDPOINT_E}|g" \
+  -e "s|REPLACE_WITH_CATALYST_DIR|${CATALYST_DIR_VALUE_E}|g" \
   "${TEMPLATE}" > "${TMP}"
 mv "${TMP}" "${DEST}"
 echo "install.sh: wrote ${DEST}"

--- a/plugins/dev/scripts/catalyst-agent/install.sh
+++ b/plugins/dev/scripts/catalyst-agent/install.sh
@@ -54,12 +54,20 @@ fi
 [ -n "${METRICS_ENDPOINT}" ] && echo "install.sh: metrics endpoint → ${METRICS_ENDPOINT}" \
   || echo "install.sh: no metrics endpoint resolved — metric emission disabled"
 
+# CTL-1518: persist the install-time CATALYST_DIR into the plist so the agent
+# resolves its heartbeat breadcrumb under the same dir the health-responder
+# (installed with the same override) probes. Defaults to ${HOME}/catalyst, which
+# is what catalystDir() already resolves when unset — so default nodes are unchanged.
+CATALYST_DIR_VALUE="${CATALYST_DIR:-${HOME}/catalyst}"
+echo "install.sh: CATALYST_DIR → ${CATALYST_DIR_VALUE}"
+
 sed \
   -e "s|REPLACE_WITH_NODE|${NODE_BIN}|g" \
   -e "s|REPLACE_WITH_AGENT|${AGENT}|g" \
   -e "s|REPLACE_WITH_HOME|${HOME}|g" \
   -e "s|REPLACE_WITH_PATH|${INSTALL_PATH}|g" \
   -e "s|REPLACE_WITH_METRICS_ENDPOINT|${METRICS_ENDPOINT}|g" \
+  -e "s|REPLACE_WITH_CATALYST_DIR|${CATALYST_DIR_VALUE}|g" \
   "${TEMPLATE}" > "${TMP}"
 mv "${TMP}" "${DEST}"
 echo "install.sh: wrote ${DEST}"

--- a/plugins/dev/scripts/health-responder.sh
+++ b/plugins/dev/scripts/health-responder.sh
@@ -51,8 +51,20 @@
 # Usage:
 #   health-responder.sh [--dry-run] [--help]
 #
+# A SECOND supervised target rides the same sweep (CTL-1518): the
+# com.catalyst.agent host-metrics sampler (it died on mini-2 and launchd left it
+# dead for 10 days). Its block runs BEFORE the cloud-sync detect — the cloud-sync
+# act path `exit 0`s at several points, so a block after it is unreachable — and
+# is fully inert on nodes without the agent plist. Staleness is the age of the
+# agent's breadcrumb (~/catalyst/catalyst-agent.heartbeat, refreshed each --once
+# tick), falling back to the plist install-mtime when the breadcrumb is absent.
+# Same bounded-kickstart + one-shot-escalation + re-arm contract, with its OWN
+# agent-scoped markers / heartbeat line / OTel escalate.
+#
 # Env overrides (all have production defaults):
 #   RESPONDER_ENABLED              — kill-switch, default 1 (0 = heartbeat-only no-op)
+#   RESPONDER_AGENT_ENABLED        — agent sub-kill-switch, default 1 (0 = agent block off)
+#   RESPONDER_AGENT_STALE_SECS     — agent breadcrumb/plist staleness threshold, default 900
 #   RESPONDER_LOCK_STALE_SECS      — stale-writer threshold, default 900 (15 min)
 #   RESPONDER_SELFHEAL_GRACE_SECS  — no-respawn grace after breadcrumb ts, default 120
 #   RESPONDER_MAX_ATTEMPTS         — kickstarts per window before escalating, default 3
@@ -146,6 +158,11 @@ RESPONDER_KICKSTART_WAIT_SECS="$(_num "$RESPONDER_KICKSTART_WAIT_SECS" 10 0)"
 RESPONDER_KICKSTART_TIMEOUT_SECS="$(_num "$RESPONDER_KICKSTART_TIMEOUT_SECS" 20 1)"
 RESPONDER_LOCK_STALE_SECS="$(_num "$RESPONDER_LOCK_STALE_SECS" 900 1)"
 RESPONDER_SELFHEAL_GRACE_SECS="$(_num "$RESPONDER_SELFHEAL_GRACE_SECS" 120 0)"
+# Second-target (com.catalyst.agent) knobs (CTL-1518). ENABLED is a string
+# compare; STALE_SECS goes through the same validate-then-floor helper as the
+# other thresholds so garbage/zero-padded overrides degrade to the default.
+RESPONDER_AGENT_ENABLED="${RESPONDER_AGENT_ENABLED:-1}"
+RESPONDER_AGENT_STALE_SECS="$(_num "${RESPONDER_AGENT_STALE_SECS:-900}" 900 1)"
 # Deadline for the `launchctl list` intentional-exit probe (Codex P2 round 4:
 # the same hung-launchctl class the kickstart deadline guards against).
 RESPONDER_LIST_TIMEOUT_SECS="$(_num "${RESPONDER_LIST_TIMEOUT_SECS:-5}" 5 1)"
@@ -162,7 +179,15 @@ RESPONDER_TOKEN_RESOLVE_TIMEOUT_SECS="$(_num "${RESPONDER_TOKEN_RESOLVE_TIMEOUT_
 # LIVE lock and reintroduce the concurrent-kickstart race this lock exists to
 # close).
 RESPONDER_SWEEP_LOCK_STALE_SECS="$(_num "${RESPONDER_SWEEP_LOCK_STALE_SECS:-300}" 300 1)"
-_SWEEP_MIN_STALE=$(( RESPONDER_LIST_TIMEOUT_SECS + RESPONDER_TOKEN_RESOLVE_TIMEOUT_SECS + RESPONDER_KICKSTART_TIMEOUT_SECS + RESPONDER_KICKSTART_WAIT_SECS + 60 ))
+# CTL-1518 widened the floor to cover BOTH kickstart budgets: a single sweep can
+# now kickstart the agent (its block reuses RESPONDER_KICKSTART_TIMEOUT/WAIT_SECS)
+# AND the cloud-sync writer, so the worst-case legitimate sweep spends the
+# kickstart timeout+wait TWICE — the second `+ RESPONDER_KICKSTART_TIMEOUT_SECS +
+# RESPONDER_KICKSTART_WAIT_SECS` term. Without it the stale-lock breaker could
+# break a still-live two-target sweep and reintroduce the concurrent-kickstart
+# race the sweep lock exists to close. (The first three terms are unchanged, so
+# the token-resolve-floor invariant test still matches.)
+_SWEEP_MIN_STALE=$(( RESPONDER_LIST_TIMEOUT_SECS + RESPONDER_TOKEN_RESOLVE_TIMEOUT_SECS + RESPONDER_KICKSTART_TIMEOUT_SECS + RESPONDER_KICKSTART_WAIT_SECS + RESPONDER_KICKSTART_TIMEOUT_SECS + RESPONDER_KICKSTART_WAIT_SECS + 60 ))
 (( RESPONDER_SWEEP_LOCK_STALE_SECS < _SWEEP_MIN_STALE )) && RESPONDER_SWEEP_LOCK_STALE_SECS="$_SWEEP_MIN_STALE"
 RESPONDER_RUN_ID="${RESPONDER_RUN_ID:-$(date -u +%Y%m%dT%H%M%SZ)-$$}"
 # Resolve every state/target path through CATALYST_DIR exactly like the
@@ -183,6 +208,18 @@ CLOUD_SYNC_PLIST="${CATALYST_LAUNCHAGENTS_DIR:-${HOME}/Library/LaunchAgents}/${C
 REPLICA_DB="${CATALYST_REPLICA_DB:-${CATALYST_DIR}/catalyst-replica.db}"
 WRITER_LOCK="${REPLICA_DB}.writer.lock"
 ESCALATED_MARKER="${RESPONDER_STATE_DIR}/ESCALATED.cloud-sync"
+
+# Second supervised target (CTL-1518): the com.catalyst.agent host-metrics
+# sampler. Its plist lives in the SAME LaunchAgents dir as cloud-sync's; its
+# breadcrumb is written by catalyst-agent.mjs each --once tick, CATALYST_DIR-
+# resolved exactly like config.mjs getHeartbeatPath() so the two never disagree
+# about WHERE to look. AGENT_HEARTBEAT_FILE is overridable so tests can redirect
+# it into scratch. Agent markers use their own agent-attempt.* / ESCALATED.
+# catalyst-agent namespace — never sharing a budget with the cloud-sync markers.
+AGENT_LABEL="com.catalyst.agent"
+AGENT_PLIST="${CATALYST_LAUNCHAGENTS_DIR:-${HOME}/Library/LaunchAgents}/${AGENT_LABEL}.plist"
+AGENT_HEARTBEAT_FILE="${AGENT_HEARTBEAT_FILE:-${CATALYST_DIR}/catalyst-agent.heartbeat}"
+AGENT_ESCALATED_MARKER="${RESPONDER_STATE_DIR}/ESCALATED.catalyst-agent"
 # The operator-provisioned token files the cloud-sync launcher sources
 # (cloud-sync/launch.sh sources BOTH, in this order: cluster.env — the CTL-1307
 # shared-token projection — then the dedicated cloud-sync.env; Codex P1).
@@ -686,6 +723,242 @@ _release_sweep_lock() {
   return 0
 }
 trap _release_sweep_lock EXIT
+
+# ─── agent supervision (CTL-1518) ───────────────────────────────────────────
+#
+# Second supervised target: the com.catalyst.agent host-metrics sampler. It died
+# on mini-2 and launchd left it dead for 10 days — this block is the code
+# backstop for that class of silent death. Same bounded-kickstart + one-shot-
+# escalation + re-arm contract as the cloud-sync path, but with its OWN agent-
+# scoped attempt markers (agent-attempt.*), escalation marker (ESCALATED.
+# catalyst-agent), heartbeat line (target=catalyst-agent), and OTel escalate — so
+# the two targets never share an attempt budget or clobber each other's state.
+#
+# PLACEMENT is load-bearing: this runs BEFORE the cloud-sync detect because the
+# cloud-sync ACT path terminates the script with `exit 0` at several points — a
+# block placed after it would be unreachable. Running first, this block MUST NOT
+# exit; it falls through to the cloud-sync detect, whose heartbeat stays the LAST
+# line of every sweep (the doctor-freshness contract). It runs only after the
+# sweep lock is held (this trap fires after acquisition), so the two targets
+# share the same single-sweep reservation.
+#
+# CRITICAL (CTL-1510 lineage): agent_heartbeat / emit_agent_escalated are
+# SELF-CONTAINED — they read ONLY agent-scoped vars plus globals set at the top
+# of the file. They deliberately do NOT call heartbeat() / emit_escalated(),
+# which reference cloud-sync globals (INSTALLED, ALIVE, C_DEAD, CONDITIONS_CSV,
+# ATTEMPTS, …) that are UNSET here under `set -u`; calling them would abort the
+# sweep before the EXIT trap runs and leak the sweep lock. And every `$(...)`
+# capture below is a single-line single command — NO comments inside a
+# command-substitution capture (the bash 3.2 parser defect that cost CTL-1513 a
+# production incident; the real interpreter is /bin/bash 3.2 via launchd/cron).
+
+agent_heartbeat() {
+  local status="$1"
+  log "heartbeat status=${status} target=catalyst-agent installed=${AGENT_INSTALLED} stale=${AGENT_STALE} attempts=${AGENT_ATTEMPTS}/${RESPONDER_MAX_ATTEMPTS} escalated=${AGENT_ESCALATED}"
+}
+
+# Fail-open agent-scoped escalate (mirrors emit_escalated; own attrs only).
+emit_agent_escalated() {
+  command -v emit-otel-event.sh >/dev/null 2>&1 || return 0
+  emit-otel-event.sh \
+    --event "catalyst.responder.escalated" \
+    --outcome fail \
+    --session-id "$RESPONDER_RUN_ID" \
+    --attr "target=catalyst-agent" \
+    --attr "conditions=agent-stale" \
+    --attr "attempts=${AGENT_ATTEMPTS}" \
+    --attr "windowSecs=${RESPONDER_ATTEMPT_WINDOW_SECS}" >/dev/null 2>&1 || true
+}
+
+# agent-attempt.* markers — a SEPARATE glob namespace from the cloud-sync
+# attempt.* markers (the `attempt.*` glob never matches `agent-attempt.*`), so
+# the two targets prune / count / clear independently.
+_agent_prune_attempts() {
+  is_dry && return 0
+  local f ts now
+  now="$(date +%s)"
+  for f in "${RESPONDER_STATE_DIR}"/agent-attempt.*; do
+    [[ -e "$f" ]] || continue
+    ts="${f##*/}"; ts="${ts#agent-attempt.}"; ts="${ts%%.*}"
+    if [[ ! "$ts" =~ ^[0-9]+$ ]]; then
+      rm -f "$f" 2>/dev/null
+      [[ -e "$f" ]] && AGENT_PRUNE_DEGRADED=1
+      continue
+    fi
+    if [[ $(( now - ts )) -gt "$RESPONDER_ATTEMPT_WINDOW_SECS" ]]; then
+      rm -f "$f" 2>/dev/null
+      [[ -e "$f" ]] && AGENT_PRUNE_DEGRADED=1
+    fi
+  done
+  return 0
+}
+
+_agent_attempt_count() {
+  local n=0 f
+  for f in "${RESPONDER_STATE_DIR}"/agent-attempt.*; do
+    [[ -e "$f" ]] && n=$((n+1))
+  done
+  echo "$n"
+}
+
+# Fail-SAFE like _record_attempt: a marker that cannot be written means the cap
+# cannot bound us, so the caller refuses to kickstart.
+_agent_record_attempt() {
+  : > "${RESPONDER_STATE_DIR}/agent-attempt.$(date +%s).$$" 2>/dev/null
+}
+
+# Returns non-zero when a durable marker SURVIVES the rm (read-only dir) so the
+# caller never reports a false re-arm (mirrors _clear_markers).
+_agent_clear_markers() {
+  rm -f "${RESPONDER_STATE_DIR}"/agent-attempt.* "$AGENT_ESCALATED_MARKER" 2>/dev/null || true
+  [[ -e "$AGENT_ESCALATED_MARKER" ]] && return 1
+  local f
+  for f in "${RESPONDER_STATE_DIR}"/agent-attempt.*; do
+    [[ -e "$f" ]] && return 1
+  done
+  return 0
+}
+
+# _agent_stale_age: seconds since the agent's last liveness signal — the
+# breadcrumb mtime when present, else the plist install mtime (a freshly-
+# installed-but-never-ticked sampler is NOT yet stale). "" when neither is
+# readable. A future mtime (clock skew) clamps to 0/fresh — the safe direction
+# here is to NEVER kickstart a healthy sampler.
+_agent_stale_age() {
+  local now m age
+  now="$(date +%s)"
+  m="$(_mtime "$AGENT_HEARTBEAT_FILE")"
+  [[ "$m" =~ ^[0-9]+$ ]] || m="$(_mtime "$AGENT_PLIST")"
+  [[ "$m" =~ ^[0-9]+$ ]] || { printf ''; return 0; }
+  age=$(( now - m ))
+  (( age < 0 )) && age=0
+  printf '%s' "$age"
+}
+
+# _agent_kickstart: a DUPLICATE of the CTL-1510-hardened cloud-sync deadline-
+# wrapped kickstart (CTL-1518 correction a — NOT a shared refactor; cloud-sync
+# stays literally untouched). Agent-prefixed locals so nothing clobbers the
+# cloud-sync path. Reuses RESPONDER_KICKSTART_TIMEOUT_SECS / _WAIT_SECS. Sets
+# AGENT_KICK_RESULT to recovered|still-down from a post-settle breadcrumb re-probe.
+_agent_kickstart() {
+  local out pid rc="" i uid new_age
+  uid="$(id -u)"
+  out="$(mktemp "${TMPDIR:-/tmp}/responder-agent-kick.XXXXXX")"
+  launchctl kickstart -k "gui/${uid}/${AGENT_LABEL}" > "$out" 2>&1 &
+  pid=$!
+  for (( i = 0; i < RESPONDER_KICKSTART_TIMEOUT_SECS; i++ )); do
+    if ! kill -0 "$pid" 2>/dev/null; then
+      wait "$pid"
+      rc=$?
+      break
+    fi
+    sleep 1
+  done
+  if [[ -z "$rc" ]]; then
+    kill -9 "$pid" 2>/dev/null || true
+    wait "$pid" 2>/dev/null || true
+    log "agent: kickstart TIMED OUT after ${RESPONDER_KICKSTART_TIMEOUT_SECS}s for gui/${uid}/${AGENT_LABEL} (attempt ${AGENT_ATTEMPTS}/${RESPONDER_MAX_ATTEMPTS} still counted)"
+  elif [[ "$rc" -eq 0 ]]; then
+    sed 's/^/  /' "$out"
+    log "agent: kickstarted gui/${uid}/${AGENT_LABEL} (attempt ${AGENT_ATTEMPTS}/${RESPONDER_MAX_ATTEMPTS})"
+  else
+    sed 's/^/  /' "$out"
+    log "agent: kickstart FAILED for gui/${uid}/${AGENT_LABEL} — label not loaded? (attempt ${AGENT_ATTEMPTS}/${RESPONDER_MAX_ATTEMPTS} still counted)"
+  fi
+  rm -f "$out"
+  [[ "$RESPONDER_KICKSTART_WAIT_SECS" -gt 0 ]] && sleep "$RESPONDER_KICKSTART_WAIT_SECS"
+  new_age="$(_agent_stale_age)"
+  if [[ -n "$new_age" && "$new_age" -le "$RESPONDER_AGENT_STALE_SECS" ]]; then
+    AGENT_KICK_RESULT="recovered"
+  else
+    AGENT_KICK_RESULT="still-down"
+  fi
+}
+
+# Inert on nodes without the agent plist (existing tests + non-sampler nodes stay
+# silent — no agent heartbeat line at all).
+if [[ -f "$AGENT_PLIST" ]]; then
+  AGENT_INSTALLED=1
+  AGENT_STALE=0
+  AGENT_ATTEMPTS=0
+  AGENT_ESCALATED=0
+  AGENT_PRUNE_DEGRADED=0
+  AGENT_KICK_RESULT=""
+
+  if [[ "$RESPONDER_AGENT_ENABLED" != "1" ]]; then
+    agent_heartbeat "disabled"
+  else
+    _AGENT_AGE="$(_agent_stale_age)"
+    if [[ -n "$_AGENT_AGE" && "$_AGENT_AGE" -gt "$RESPONDER_AGENT_STALE_SECS" ]]; then
+      AGENT_STALE=1
+      log "agent: host-metrics breadcrumb ${_AGENT_AGE}s old (> ${RESPONDER_AGENT_STALE_SECS}s) — com.catalyst.agent sampler stale/dead"
+    fi
+    [[ -f "$AGENT_ESCALATED_MARKER" ]] && AGENT_ESCALATED=1
+    _agent_prune_attempts
+    AGENT_ATTEMPTS="$(_agent_attempt_count)"
+    [[ "$AGENT_PRUNE_DEGRADED" -eq 1 ]] && log "agent: ERROR: expired attempt markers could not be pruned from ${RESPONDER_STATE_DIR} (read-only?) — agent attempt count over-counts; fix permissions"
+
+    if [[ "$AGENT_STALE" -eq 0 ]]; then
+      if [[ "$AGENT_ESCALATED" -eq 1 || "$AGENT_ATTEMPTS" -gt 0 ]]; then
+        if is_dry; then
+          log "agent: [dry-run] would re-arm: clear ${AGENT_ATTEMPTS} attempt marker(s) + escalated=${AGENT_ESCALATED}"
+          agent_heartbeat "healthy"
+        elif _agent_clear_markers; then
+          [[ "$AGENT_ESCALATED" -eq 1 ]] && log "agent: condition cleared — re-armed (ESCALATED.catalyst-agent + attempt markers removed)"
+          AGENT_ESCALATED=0
+          AGENT_ATTEMPTS=0
+          agent_heartbeat "healthy"
+        else
+          log "agent: ERROR: condition cleared but markers could not be removed from ${RESPONDER_STATE_DIR} (read-only?) — agent supervision remains ESCALATED on disk; fix permissions"
+          agent_heartbeat "degraded"
+        fi
+      else
+        agent_heartbeat "healthy"
+      fi
+    elif [[ "$AGENT_ESCALATED" -eq 1 ]]; then
+      log "agent: condition active: agent-stale (escalated hold)"
+      agent_heartbeat "escalated"
+    elif [[ "$AGENT_ATTEMPTS" -ge "$RESPONDER_MAX_ATTEMPTS" ]]; then
+      log "agent: condition active: agent-stale"
+      if [[ "$AGENT_PRUNE_DEGRADED" -eq 1 ]]; then
+        log "agent: ERROR: attempt cap reached but the count includes unprunable expired markers — refusing to escalate on unreliable state; fix ${RESPONDER_STATE_DIR} permissions"
+        agent_heartbeat "degraded"
+      elif is_dry; then
+        log "agent: [dry-run] would escalate: ${AGENT_ATTEMPTS}/${RESPONDER_MAX_ATTEMPTS} kickstarts in ${RESPONDER_ATTEMPT_WINDOW_SECS}s did not clear agent-stale"
+        agent_heartbeat "dry-run"
+      else
+        if : > "$AGENT_ESCALATED_MARKER" 2>/dev/null; then
+          AGENT_ESCALATED=1
+          emit_agent_escalated
+        else
+          AGENT_ESCALATED=1
+          log "agent: ERROR: cannot write ESCALATED.catalyst-agent marker under ${RESPONDER_STATE_DIR} — skipping the one-shot OTel emit; fix permissions"
+        fi
+        log "agent: ERROR: escalated — agent-stale persists after ${AGENT_ATTEMPTS}/${RESPONDER_MAX_ATTEMPTS} kickstarts in ${RESPONDER_ATTEMPT_WINDOW_SECS}s; kickstarting stopped until the condition clears (check ~/catalyst/catalyst-agent.log)"
+        agent_heartbeat "escalated"
+      fi
+    elif is_dry; then
+      log "agent: [dry-run] would kickstart gui/$(id -u)/${AGENT_LABEL} (agent-stale)"
+      agent_heartbeat "dry-run"
+    else
+      log "agent: condition active: agent-stale"
+      if ! _agent_record_attempt; then
+        log "agent: ERROR: cannot write attempt marker under ${RESPONDER_STATE_DIR} — refusing to kickstart (attempt cap unenforceable); fix permissions"
+        agent_heartbeat "degraded"
+      else
+        AGENT_ATTEMPTS=$((AGENT_ATTEMPTS+1))
+        _agent_kickstart
+        if [[ "$AGENT_KICK_RESULT" == "recovered" ]]; then
+          log "agent: recovered: com.catalyst.agent breadcrumb is fresh after kickstart"
+          agent_heartbeat "recovered"
+        else
+          log "agent: still-down: com.catalyst.agent breadcrumb still stale after kickstart + ${RESPONDER_KICKSTART_WAIT_SECS}s"
+          agent_heartbeat "still-down"
+        fi
+      fi
+    fi
+  fi
+fi
 
 # ─── detect ─────────────────────────────────────────────────────────────────
 

--- a/plugins/dev/scripts/health-responder.sh
+++ b/plugins/dev/scripts/health-responder.sh
@@ -754,7 +754,7 @@ trap _release_sweep_lock EXIT
 
 agent_heartbeat() {
   local status="$1"
-  log "heartbeat status=${status} target=catalyst-agent installed=${AGENT_INSTALLED} stale=${AGENT_STALE} attempts=${AGENT_ATTEMPTS}/${RESPONDER_MAX_ATTEMPTS} escalated=${AGENT_ESCALATED}"
+  log "agent-supervision status=${status} target=catalyst-agent installed=${AGENT_INSTALLED} stale=${AGENT_STALE} attempts=${AGENT_ATTEMPTS}/${RESPONDER_MAX_ATTEMPTS} escalated=${AGENT_ESCALATED}"
 }
 
 # Fail-open agent-scoped escalate (mirrors emit_escalated; own attrs only).


### PR DESCRIPTION
## CTL-1518 — durable self-heal for the host-metrics sampler

`com.catalyst.agent` (the host-metrics sampler feeding `host.metrics.sampled` + `catalyst_host_mem_used_mb`) died on mini-2 and launchd left it **dead 10 days**, blinding mini-2's memory trends. The ops kickstart is already done live; this adds the **durable code backstop** — the stateless health-responder sweep now supervises a **second** launchd target.

1. **catalyst-agent breadcrumb** — `writeHeartbeat()` atomically writes `{ts,host}` to `catalyst-agent.heartbeat` after each `--once` tick (in a `try/finally` so a transient tick throw still refreshes it), best-effort/never-throws.
2. **health-responder agent-supervision block** — inserted after the sweep-lock trap and before the cloud-sync detect (the cloud-sync path `exit 0`s at several points → a later block is unreachable). Gated on the agent plist existing (inert without it); staleness from breadcrumb mtime (>900s) with plist-install-mtime fallback; on stale → bounded `launchctl kickstart` with agent-scoped attempt/escalate markers + `RESPONDER_AGENT_ENABLED` kill-switch.

### Reviewer corrections honored
(a) the CTL-1510-hardened cloud-sync kickstart is **duplicated** into `_agent_kickstart`, byte-for-byte untouched (only deletion is the `_SWEEP_MIN_STALE` widening); (b) agent helpers are **self-contained** (agent-scoped vars only — never touch cloud-sync globals unset under `set -u`, which would leak the sweep lock); (c) **bash-3.2-safe** (no comments in `$()` captures; T74 runs the full script under real `/bin/bash`); (d) `_SWEEP_MIN_STALE` widened to double the kickstart budget (first 3 terms verbatim so the T63 floor invariant matches).

## Tests
catalyst-agent **251 pass** (+5 breadcrumb); health-responder **145 pass under real /bin/bash 3.2.57** (+23: fresh/stale/absent/cap/re-arm/inert/two-plists/full-script-under-bash). New knob `FILTER`… documented; the Loki silence alert is a separate `catalyst-otel` follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)