### PR TITLE
fix(dev): CTL-1523 stop the broker reporting daemon-degraded on an idle fleet

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -384,12 +384,22 @@ strings.
 
 That degraded/recovered pair is an EDGE-TRIGGERED episode with a **durable latch** (marker
 `~/catalyst/broker-degraded-latch.json`), and it is **OPT-IN and dormant by default** — it evaluates
-nothing unless `FILTER_BROKER_DEGRADED_ENABLED=1`. In `phase-agents` mode its `interests.size === 0`
-conjunct is permanently true (interest registration is legacy-only, dormant since the 2026-06-07
-cutover), so the gate carries no information; it is retained for legacy wave-orchestration hosts,
-where interests are registered. **The real silently-dead-broker detector is CTL-1122's
-`checkSourceRecency`** (`catalyst.ingestion.stale` + `catalyst.alert.raised(system_down)`), which
-watches actual ingestion recency and is unaffected by this knob.
+nothing unless `FILTER_BROKER_DEGRADED_ENABLED=1`. Under **execution-core dispatch** its
+`interests.size === 0` conjunct is permanently true (the daemon runs no `filter.register` producer),
+so the gate carries no information there. That is a property of execution-core, **not** of every
+configuration named `phase-agents`: a **legacy-wave** host — one driving
+`/catalyst-legacy:orchestrate`, which invokes `plugins/dev/scripts/orchestrate-register-interests.sh`
+— does register interests (pr/ticket/comms unconditionally, plus a per-ticket `phase_lifecycle` when
+`dispatchMode` is `phase-agents`), so there an empty table IS anomalous and enabling the knob is
+appropriate.
+
+**Neither this detector nor CTL-1122's `checkSourceRecency` can detect a fully-dead broker** — both
+execute inside the broker process, so a dead broker emits neither. `checkSourceRecency` detects an
+ingestion **stall** (an upstream source gone silent) while the broker is **alive**, via
+`catalyst.ingestion.stale` + `catalyst.alert.raised(system_down)`. Proving the process itself is gone
+requires an **external absence-based check** on the broker's own heartbeat/log series — a Loki
+`absent_over_time` alert on `broker.daemon.heartbeat` or the broker `.log` stream (absence, because a
+fully-dead daemon is a *missing series*, which `count_over_time == 0` cannot assert).
 
 **`KNOWN_PHASES`** (canonical 10, in order): `triage`, `research`, `plan`, `implement`, `verify`,
 `review`, `pr`, `monitor-merge`, `monitor-deploy`, `teardown`.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -373,9 +373,23 @@ strings.
 | Space                                                                   | Rule                                                                                                                           |
 | ----------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------ |
 | `filter.*`                                                              | Broker interest-management only (else filter-wake loop).                                                                       |
-| `broker.daemon.*`                                                       | Broker heartbeats/startup/shutdown only.                                                                                       |
+| `broker.daemon.*`                                                       | Broker lifecycle/health only (see the member list below).                                                                      |
 | `session.heartbeat`                                                     | Exact match; broker liveness pings only (CTL-401).                                                                             |
 | `phase.<name>.(complete\|failed\|turn-cap-exhausted\|skipped).<ticket>` | Routing namespace matched by `PHASE_EVENT_PATTERN`; `<name>` must be in `KNOWN_PHASES` or `INTENTIONAL_PHASE_SLOT_EXCEPTIONS`. |
+
+**`broker.daemon.*` members** (the complete emitted set, verified): `broker.daemon.startup` and
+`broker.daemon.shutdown` (`index.mjs`), `broker.daemon.heartbeat` (`index.mjs`), `broker.daemon.gc`
+(`gc-startup.mjs`), `broker.daemon.prose_disabled` (`router.mjs`), and the CTL-1523
+`broker.daemon.degraded` / `broker.daemon.recovered` pair (`broker-degraded.mjs`).
+
+That degraded/recovered pair is an EDGE-TRIGGERED episode with a **durable latch** (marker
+`~/catalyst/broker-degraded-latch.json`), and it is **OPT-IN and dormant by default** — it evaluates
+nothing unless `FILTER_BROKER_DEGRADED_ENABLED=1`. In `phase-agents` mode its `interests.size === 0`
+conjunct is permanently true (interest registration is legacy-only, dormant since the 2026-06-07
+cutover), so the gate carries no information; it is retained for legacy wave-orchestration hosts,
+where interests are registered. **The real silently-dead-broker detector is CTL-1122's
+`checkSourceRecency`** (`catalyst.ingestion.stale` + `catalyst.alert.raised(system_down)`), which
+watches actual ingestion recency and is unaffected by this knob.
 
 **`KNOWN_PHASES`** (canonical 10, in order): `triage`, `research`, `plan`, `implement`, `verify`,
 `review`, `pr`, `monitor-merge`, `monitor-deploy`, `teardown`.

--- a/plugins/dev/scripts/broker/barrel-exports.test.mjs
+++ b/plugins/dev/scripts/broker/barrel-exports.test.mjs
@@ -12,7 +12,11 @@
 // parseBootHandoff boot seam; CTL-1161 added 6 — isDaemonLocalMergeSignal,
 // refreshAllPluginCheckouts, startPluginDriftCheck, PLUGIN_DRIFT_CHECK_INTERVAL_MS
 // from plugin-refresh.mjs, and startDriftCheckWatcher from router.mjs; CTL-1171
-// added 2 — BROKER_HEARTBEAT_INTERVAL_MS and buildBrokerHeartbeatEvent).
+// added 2 — BROKER_HEARTBEAT_INTERVAL_MS and buildBrokerHeartbeatEvent; CTL-1523
+// added 4 broker-degraded symbols — the driver, the two event-name constants, and
+// the durable-latch reset seam. The pure classifiers/counters stay module-private
+// by design: the barrel rule for broker-degraded.mjs is DRIVER + EVENT NAMES +
+// RESET SEAM only, so their unit tests import them directly from the leaf module).
 // The count is the length of the enumerated REQUIRED_EXPORTS list below —
 // `grep -cE '^export '` undercounts because most re-exports are multi-name
 // `export { … } from` blocks.
@@ -135,14 +139,21 @@ const REQUIRED_EXPORTS = [
   "INGESTION_STALE",
   "INGESTION_RECOVERED",
   "MONITOR_SERVICE_NAME",
+  // CTL-1523: broker-degraded detector (broker-degraded.mjs) — driver + event names
+  // + reset seam only. The legacy __resetDegradedEmittedForTest name above is now an
+  // alias over __resetBrokerDegradedLatchForTest — one chokepoint, two names.
+  "__resetBrokerDegradedLatchForTest",
+  "checkBrokerDegraded",
+  "BROKER_DEGRADED_EVENT",
+  "BROKER_RECOVERED_EVENT",
 ];
 
 describe("CTL-529 barrel contract", () => {
-  test("all 100 public symbols re-export from ./index.mjs", () => {
+  test("all 104 public symbols re-export from ./index.mjs", () => {
     for (const name of REQUIRED_EXPORTS) {
       expect(typeof barrel[name], `missing export: ${name}`).not.toBe("undefined");
     }
-    expect(REQUIRED_EXPORTS.length).toBe(100);
+    expect(REQUIRED_EXPORTS.length).toBe(104);
   });
 
   test("singleton getters return identity-stable live references", () => {

--- a/plugins/dev/scripts/broker/broker-degraded-wiring.test.mjs
+++ b/plugins/dev/scripts/broker/broker-degraded-wiring.test.mjs
@@ -17,7 +17,7 @@
 // Run: cd plugins/dev/scripts/broker && bun test broker-degraded-wiring.test.mjs
 
 import { describe, test, expect, beforeEach, afterEach } from "bun:test";
-import { mkdtempSync, rmSync, readFileSync, existsSync } from "node:fs";
+import { mkdtempSync, rmSync, readFileSync, writeFileSync, existsSync, mkdirSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { getEventLogPath, BROKER_DEGRADED_SUSTAINED_TICKS } from "./config.mjs";
@@ -35,6 +35,7 @@ import {
 } from "./broker-degraded.mjs";
 import { openBrokerStateDb, closeBrokerStateDb, upsertWorkerState } from "./broker-state.mjs";
 import {
+  getInterests,
   clearInterests,
   clearLastHeartbeat,
   __resetBrokerStartedAtForTest,
@@ -83,6 +84,9 @@ function closeActivityGate(ticket = "CTL-1523") {
     eventId: "e2",
     eventTs: new Date(Date.now() + 1000).toISOString(),
   });
+}
+function interestsSize() {
+  return getInterests().size;
 }
 function ticks(n) {
   for (let i = 0; i < n; i++) runWatchdogTick();
@@ -381,5 +385,43 @@ describe("an unavailable activity reading is UNKNOWN, not idle (end-to-end)", ()
     ticks(1);
     expect(recoveredEvents()).toHaveLength(1);
     expect(recoveredEvents()[0].attributes["event.name"]).toBe(BROKER_RECOVERED_EVENT);
+  });
+});
+
+// Codex P2 round 4 (#2740): the cross-tick registration edge is EVIDENCE, and the
+// only thing making the clear verdict true for a one-shot interest. Consuming it
+// before the append meant a FAILED `recovered` destroyed it — latch stranded open,
+// suppressing every later degraded until an unrelated registration or an idle fleet.
+describe("the interest edge survives a failed recovery append (round 4)", () => {
+  test("a failed recovered retries on the next tick instead of losing the edge", () => {
+    pastGrace();
+    openActivityGate();
+    ticks(SUSTAINED);
+    expect(degradedEvents()).toHaveLength(1);
+
+    // One-shot interest: registers and deregisters entirely between ticks.
+    handleRegister({
+      event: "filter.register",
+      orchestrator: "orch-round4",
+      detail: { interest_id: "r4", notify_event: "filter.wake.r4", prompt: "p" },
+    });
+    handleDeregister({ event: "filter.deregister", detail: { interest_id: "r4" } });
+    expect(interestsSize()).toBe(0); // live table is empty again
+
+    // Make the append fail for this tick by pointing the event log at a directory.
+    const logPath = getEventLogPath();
+    const saved = readFileSync(logPath, "utf8");
+    rmSync(logPath, { force: true });
+    mkdirSync(logPath, { recursive: true });
+    ticks(1);
+    // Append failed, so the episode is still open and owes a recovered.
+    rmSync(logPath, { recursive: true, force: true });
+    writeFileSync(logPath, saved);
+    expect(recoveredEvents()).toHaveLength(0);
+
+    // The edge must NOT have been spent: the next tick retries and lands it.
+    ticks(1);
+    expect(recoveredEvents()).toHaveLength(1);
+    expect(recoveredEvents()[0].body.payload.reason).toBe("interests registered");
   });
 });

--- a/plugins/dev/scripts/broker/broker-degraded-wiring.test.mjs
+++ b/plugins/dev/scripts/broker/broker-degraded-wiring.test.mjs
@@ -1,0 +1,300 @@
+// broker-degraded-wiring.test.mjs — CTL-1523. The runWatchdogTick wiring of the
+// broker-degraded detector: the fleet-activity discriminator that fixes the
+// idle-fleet false alarm, the sustained-tick debounce, the paired
+// broker.daemon.recovered, the DURABLE latch across a simulated restart, and the
+// opt-in gate. The pure machine and the checkBrokerDegraded driver's failure
+// semantics are covered in broker-degraded.test.mjs.
+//
+// NOTE (CTL-1523): the detector is OPT-IN — dormant unless
+// FILTER_BROKER_DEGRADED_ENABLED=1 — so the shared beforeEach arms it and the
+// "opt-in gate" block asserts the dormant default.
+//
+// Harness copied from alert-emit-wiring.test.mjs (mkdtempSync → CATALYST_DIR,
+// close/openBrokerStateDb, clearInterests, clearLastHeartbeat,
+// __resetBrokerStartedAtForTest) plus the new __resetBrokerDegradedLatchForTest
+// seam (mirrors __resetFleetHealthLatch).
+//
+// Run: cd plugins/dev/scripts/broker && bun test broker-degraded-wiring.test.mjs
+
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, rmSync, readFileSync, existsSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { getEventLogPath, BROKER_DEGRADED_SUSTAINED_TICKS } from "./config.mjs";
+import { runWatchdogTick, handleRegister, __clearIngestionRecencyForTest } from "./router.mjs";
+import {
+  __resetBrokerDegradedLatchForTest,
+  getBrokerDegradedLatchPath,
+  BROKER_DEGRADED_EVENT,
+  BROKER_RECOVERED_EVENT,
+} from "./broker-degraded.mjs";
+import { openBrokerStateDb, closeBrokerStateDb, upsertWorkerState } from "./broker-state.mjs";
+import {
+  clearInterests,
+  clearLastHeartbeat,
+  __resetBrokerStartedAtForTest,
+  __setBrokerStartedAtForTest,
+} from "./state.mjs";
+
+const SUSTAINED = BROKER_DEGRADED_SUSTAINED_TICKS;
+
+// Read the JSONL and keep only this detector's two events (mirrors
+// alert-emit-wiring.test.mjs's readAlertEvents).
+function readDegradedEvents(logPath) {
+  if (!existsSync(logPath)) return [];
+  return readFileSync(logPath, "utf8")
+    .trim()
+    .split("\n")
+    .filter(Boolean)
+    .map((l) => JSON.parse(l))
+    .filter((e) =>
+      [BROKER_DEGRADED_EVENT, BROKER_RECOVERED_EVENT].includes(e?.attributes?.["event.name"]),
+    );
+}
+const byName = (evs, name) => evs.filter((e) => e.attributes["event.name"] === name);
+const degradedEvents = () => byName(readDegradedEvents(getEventLogPath()), BROKER_DEGRADED_EVENT);
+const recoveredEvents = () => byName(readDegradedEvents(getEventLogPath()), BROKER_RECOVERED_EVENT);
+
+// Backdate the broker start so every tick is past the 5-minute startup grace.
+function pastGrace() {
+  __setBrokerStartedAtForTest(new Date(Date.now() - 6 * 60 * 1000).toISOString());
+}
+// Open the activity gate: one fresh, non-terminal worker row → hasActiveWorkers().
+function openActivityGate(ticket = "CTL-1523") {
+  upsertWorkerState({
+    orchestrator: "o",
+    ticket,
+    status: "implement",
+    eventId: "e1",
+    eventTs: new Date().toISOString(),
+  });
+}
+// Close it: the same worker reaches a terminal status.
+function closeActivityGate(ticket = "CTL-1523") {
+  upsertWorkerState({
+    orchestrator: "o",
+    ticket,
+    status: "done",
+    eventId: "e2",
+    eventTs: new Date(Date.now() + 1000).toISOString(),
+  });
+}
+function ticks(n) {
+  for (let i = 0; i < n; i++) runWatchdogTick();
+}
+
+let dir;
+let prevCatalystDir;
+let prevDegradedEnabled;
+beforeEach(() => {
+  prevCatalystDir = process.env.CATALYST_DIR;
+  dir = mkdtempSync(join(tmpdir(), "broker-degraded-wiring-"));
+  process.env.CATALYST_DIR = dir;
+  // CTL-1523: the detector is OPT-IN and dormant by default (in phase-agents mode the
+  // empty-interests conjunct is permanently true, so the gate carries no information
+  // — see isBrokerDegradedDetectorEnabled). Every wiring case below asserts the
+  // ARMED behaviour, so arm it here; the opt-in-gate block overrides locally.
+  prevDegradedEnabled = process.env.FILTER_BROKER_DEGRADED_ENABLED;
+  process.env.FILTER_BROKER_DEGRADED_ENABLED = "1";
+  closeBrokerStateDb();
+  openBrokerStateDb(join(dir, "broker-state.db"));
+  __clearIngestionRecencyForTest();
+  __resetBrokerDegradedLatchForTest();
+  clearInterests();
+  clearLastHeartbeat();
+  __resetBrokerStartedAtForTest();
+});
+afterEach(() => {
+  closeBrokerStateDb();
+  __resetBrokerDegradedLatchForTest();
+  if (prevCatalystDir === undefined) delete process.env.CATALYST_DIR;
+  else process.env.CATALYST_DIR = prevCatalystDir;
+  if (prevDegradedEnabled === undefined) delete process.env.FILTER_BROKER_DEGRADED_ENABLED;
+  else process.env.FILTER_BROKER_DEGRADED_ENABLED = prevDegradedEnabled;
+  rmSync(dir, { recursive: true, force: true });
+});
+
+describe("the idle-fleet regression (CTL-1523)", () => {
+  test("(a) idle fleet + empty interests + 6-min uptime + many ticks → ZERO degraded", () => {
+    pastGrace();
+    // no worker rows at all → hasActiveWorkers() false → the discriminator holds
+    ticks(SUSTAINED + 5);
+    expect(degradedEvents()).toHaveLength(0);
+    expect(recoveredEvents()).toHaveLength(0);
+    // and nothing was latched, so no marker was written
+    expect(existsSync(getBrokerDegradedLatchPath())).toBe(false);
+  });
+});
+
+describe("degraded fires only for a genuinely-anomalous broker (CTL-1523)", () => {
+  test("(b) active worker + empty interests + sustained ticks → exactly ONE degraded", () => {
+    pastGrace();
+    openActivityGate();
+    ticks(SUSTAINED);
+    const degraded = degradedEvents();
+    expect(degraded).toHaveLength(1);
+    expect(degraded[0].severityText).toBe("WARN");
+    expect(degraded[0].body.payload.reason).toBe("no registered interests while fleet is active");
+    expect(degraded[0].body.payload.activeWorkers).toBe(true);
+    expect(degraded[0].body.payload.sustainedTicks).toBe(SUSTAINED);
+    expect(typeof degraded[0].body.payload.uptimeMs).toBe("number");
+    // edge-triggered: further anomalous ticks do NOT re-emit
+    ticks(3);
+    expect(degradedEvents()).toHaveLength(1);
+  });
+
+  test("(c) below the sustained-tick threshold → no degraded yet", () => {
+    pastGrace();
+    openActivityGate();
+    ticks(SUSTAINED - 1);
+    expect(degradedEvents()).toHaveLength(0);
+    // the very next contiguous anomalous tick trips it
+    ticks(1);
+    expect(degradedEvents()).toHaveLength(1);
+  });
+
+  test("a non-anomalous tick in the middle resets the run (must be contiguous)", () => {
+    pastGrace();
+    openActivityGate();
+    ticks(SUSTAINED - 1);
+    closeActivityGate(); // gate closes → run resets
+    ticks(1);
+    openActivityGate("CTL-1524"); // gate re-opens with a fresh row
+    ticks(SUSTAINED - 1);
+    expect(degradedEvents()).toHaveLength(0);
+    ticks(1);
+    expect(degradedEvents()).toHaveLength(1);
+  });
+});
+
+describe("the paired recovery event (CTL-1523)", () => {
+  test("(d) an interest registers after degraded → exactly one recovered", () => {
+    pastGrace();
+    openActivityGate();
+    ticks(SUSTAINED);
+    expect(degradedEvents()).toHaveLength(1);
+
+    handleRegister({
+      event: "filter.register",
+      orchestrator: "orch-recover-1",
+      detail: { interest_id: "recover-1", notify_event: "filter.wake.recover-1", prompt: "p" },
+    });
+    ticks(1);
+
+    const recovered = recoveredEvents();
+    expect(recovered).toHaveLength(1);
+    expect(recovered[0].severityText).toBe("INFO");
+    expect(recovered[0].body.payload.reason).toBe("interests registered");
+    expect(recovered[0].body.payload.interestCount).toBe(1);
+    expect(typeof recovered[0].body.payload.degradedForMs).toBe("number");
+    // and it does not re-emit on subsequent ticks
+    ticks(2);
+    expect(recoveredEvents()).toHaveLength(1);
+  });
+
+  test("(e) the fleet goes idle after degraded → exactly one recovered (fleet idle)", () => {
+    pastGrace();
+    openActivityGate();
+    ticks(SUSTAINED);
+    expect(degradedEvents()).toHaveLength(1);
+
+    closeActivityGate(); // worker terminal → gate closes
+    ticks(1);
+
+    const recovered = recoveredEvents();
+    expect(recovered).toHaveLength(1);
+    expect(recovered[0].body.payload.reason).toBe("fleet idle");
+    expect(recovered[0].body.payload.interestCount).toBe(0);
+    ticks(3);
+    expect(recoveredEvents()).toHaveLength(1);
+  });
+
+  test("a re-armed episode after a recovery emits a SECOND degraded", () => {
+    pastGrace();
+    openActivityGate();
+    ticks(SUSTAINED); // degraded #1
+    closeActivityGate();
+    ticks(1); // recovered #1
+    openActivityGate("CTL-1525");
+    ticks(SUSTAINED); // degraded #2
+    expect(degradedEvents()).toHaveLength(2);
+    expect(recoveredEvents()).toHaveLength(1);
+  });
+});
+
+describe("the DURABLE latch (CTL-1523 — the restart-driven re-fire fix)", () => {
+  test("(f) the latch survives a simulated restart: no duplicate degraded", () => {
+    pastGrace();
+    openActivityGate();
+    ticks(SUSTAINED);
+    expect(degradedEvents()).toHaveLength(1);
+    expect(existsSync(getBrokerDegradedLatchPath())).toBe(true);
+    expect(JSON.parse(readFileSync(getBrokerDegradedLatchPath(), "utf8")).latched).toBe(true);
+
+    // Simulate a broker restart: only the IN-MEMORY latch is cleared, the on-disk
+    // marker survives — exactly the ~5/day merge-triggered stack reload that made
+    // the CTL-352 guard re-fire 104 times in July.
+    __resetBrokerDegradedLatchForTest();
+    pastGrace(); // a fresh process is past the grace again after 6 min
+    ticks(SUSTAINED + 3); // long enough to re-earn the debounce if the latch were lost
+
+    expect(degradedEvents()).toHaveLength(1);
+    expect(recoveredEvents()).toHaveLength(0);
+  });
+
+  test("a restart mid-episode still emits the recovery when the condition clears", () => {
+    pastGrace();
+    openActivityGate();
+    ticks(SUSTAINED);
+    __resetBrokerDegradedLatchForTest(); // restart
+    pastGrace();
+    closeActivityGate();
+    ticks(1);
+    expect(recoveredEvents()).toHaveLength(1);
+    expect(degradedEvents()).toHaveLength(1);
+  });
+});
+
+describe("the opt-in gate (CTL-1523)", () => {
+  // Run `fn` with FILTER_BROKER_DEGRADED_ENABLED forced to `value` (undefined =
+  // unset), restoring whatever the outer beforeEach installed. Same save/restore
+  // idiom as the rest of the file, scoped to one case.
+  const withDegradedEnv = (value, fn) => {
+    const prev = process.env.FILTER_BROKER_DEGRADED_ENABLED;
+    if (value === undefined) delete process.env.FILTER_BROKER_DEGRADED_ENABLED;
+    else process.env.FILTER_BROKER_DEGRADED_ENABLED = value;
+    try {
+      fn();
+    } finally {
+      if (prev === undefined) delete process.env.FILTER_BROKER_DEGRADED_ENABLED;
+      else process.env.FILTER_BROKER_DEGRADED_ENABLED = prev;
+    }
+  };
+
+  // (g) THE DEFAULT. Unset is the production state on every phase-agents host: the
+  // detector must be completely inert — no event, and no latch marker written.
+  for (const [label, value] of [
+    ["UNSET — the production default", undefined],
+    ["=0 — the explicit kill-switch", "0"],
+    ["=true — anything that is not exactly \"1\"", "true"],
+  ]) {
+    test(`${label} → ZERO emits despite a genuine anomaly`, () => {
+      withDegradedEnv(value, () => {
+        pastGrace();
+        openActivityGate();
+        ticks(SUSTAINED + 3);
+        expect(readDegradedEvents(getEventLogPath())).toHaveLength(0);
+        expect(existsSync(getBrokerDegradedLatchPath())).toBe(false);
+      });
+    });
+  }
+
+  test('=1 opts in → the same anomaly emits exactly one degraded', () => {
+    withDegradedEnv("1", () => {
+      pastGrace();
+      openActivityGate();
+      ticks(SUSTAINED);
+      expect(degradedEvents()).toHaveLength(1);
+    });
+  });
+});

--- a/plugins/dev/scripts/broker/broker-degraded-wiring.test.mjs
+++ b/plugins/dev/scripts/broker/broker-degraded-wiring.test.mjs
@@ -21,7 +21,12 @@ import { mkdtempSync, rmSync, readFileSync, existsSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { getEventLogPath, BROKER_DEGRADED_SUSTAINED_TICKS } from "./config.mjs";
-import { runWatchdogTick, handleRegister, __clearIngestionRecencyForTest } from "./router.mjs";
+import {
+  runWatchdogTick,
+  handleRegister,
+  handleDeregister,
+  __clearIngestionRecencyForTest,
+} from "./router.mjs";
 import {
   __resetBrokerDegradedLatchForTest,
   getBrokerDegradedLatchPath,
@@ -209,6 +214,43 @@ describe("the paired recovery event (CTL-1523)", () => {
     expect(recovered[0].body.payload.interestCount).toBe(0);
     ticks(3);
     expect(recoveredEvents()).toHaveLength(1);
+  });
+
+  // Codex round 3 (T4): the interest-return edge that falls BETWEEN two ticks.
+  // Replacing the CTL-352 synchronous re-arm with the watchdog's periodic
+  // `interests.size` sample lost the one-shot case entirely: an interest that
+  // registers AND deregisters inside the ~60 s tick interval was never observed, so
+  // the `recovered` never fired and the stale latch suppressed every later degraded
+  // episode until the fleet went idle.
+  test("(d') an interest registered AND deregistered BETWEEN ticks still recovers", () => {
+    pastGrace();
+    openActivityGate();
+    ticks(SUSTAINED);
+    expect(degradedEvents()).toHaveLength(1);
+
+    // A whole interest lifecycle with NO intervening watchdog tick.
+    handleRegister({
+      event: "filter.register",
+      orchestrator: "orch-oneshot",
+      detail: { interest_id: "oneshot-1", notify_event: "filter.wake.oneshot-1", prompt: "p" },
+    });
+    handleDeregister({
+      event: "filter.deregister",
+      orchestrator: "orch-oneshot",
+      detail: { interest_id: "oneshot-1" },
+    });
+
+    // The live table is empty again at sampling time — the sample alone sees nothing.
+    ticks(1);
+    const recovered = recoveredEvents();
+    expect(recovered).toHaveLength(1);
+    expect(recovered[0].body.payload.reason).toBe("interests registered");
+
+    // The edge is consumed by that one tick: it does not linger and re-clear later,
+    // and the still-anomalous condition has to re-earn the full debounce.
+    ticks(SUSTAINED - 2);
+    expect(recoveredEvents()).toHaveLength(1);
+    expect(degradedEvents()).toHaveLength(1);
   });
 
   test("a re-armed episode after a recovery emits a SECOND degraded", () => {

--- a/plugins/dev/scripts/broker/broker-degraded-wiring.test.mjs
+++ b/plugins/dev/scripts/broker/broker-degraded-wiring.test.mjs
@@ -90,10 +90,12 @@ beforeEach(() => {
   prevCatalystDir = process.env.CATALYST_DIR;
   dir = mkdtempSync(join(tmpdir(), "broker-degraded-wiring-"));
   process.env.CATALYST_DIR = dir;
-  // CTL-1523: the detector is OPT-IN and dormant by default (in phase-agents mode the
-  // empty-interests conjunct is permanently true, so the gate carries no information
-  // — see isBrokerDegradedDetectorEnabled). Every wiring case below asserts the
-  // ARMED behaviour, so arm it here; the opt-in-gate block overrides locally.
+  // CTL-1523: the detector is OPT-IN and dormant by default (under execution-core
+  // dispatch nothing registers interests, so the empty-interests conjunct is
+  // permanently true and the gate carries no information — see
+  // isBrokerDegradedDetectorEnabled; on a legacy-wave host, which DOES register
+  // interests, it discriminates). Every wiring case below asserts the ARMED
+  // behaviour, so arm it here; the opt-in-gate block overrides locally.
   prevDegradedEnabled = process.env.FILTER_BROKER_DEGRADED_ENABLED;
   process.env.FILTER_BROKER_DEGRADED_ENABLED = "1";
   closeBrokerStateDb();
@@ -271,7 +273,7 @@ describe("the opt-in gate (CTL-1523)", () => {
     }
   };
 
-  // (g) THE DEFAULT. Unset is the production state on every phase-agents host: the
+  // (g) THE DEFAULT. Unset is the production state on every execution-core host: the
   // detector must be completely inert — no event, and no latch marker written.
   for (const [label, value] of [
     ["UNSET — the production default", undefined],
@@ -296,5 +298,46 @@ describe("the opt-in gate (CTL-1523)", () => {
       ticks(SUSTAINED);
       expect(degradedEvents()).toHaveLength(1);
     });
+  });
+});
+
+// CTL-1523 (review): the ONLY site that actually PRODUCES the `null` (unknown)
+// activity reading is fleetActivity's catch in router.mjs. Every other F2 test
+// injects `fleetActive` straight into the pure classifiers or into
+// checkBrokerDegraded, so reverting that catch to `return false` left the whole
+// suite green — which de-fanged the fix. This pins it end-to-end: a real
+// broker-state read failure must be UNKNOWN (latch holds), never "proven idle"
+// (which would emit a false `recovered` and then a duplicate degraded edge once
+// the DB recovers).
+describe("an unavailable activity reading is UNKNOWN, not idle (end-to-end)", () => {
+  test("a broker-state read failure holds a latched episode instead of clearing it", () => {
+    pastGrace();
+    openActivityGate();
+    ticks(SUSTAINED);
+    expect(degradedEvents()).toHaveLength(1);
+    expect(recoveredEvents()).toHaveLength(0);
+
+    // Make the REAL read fail the way a transient SQLite error would: the
+    // handle is gone, so hasActiveWorkers throws and fleetActivity catches.
+    closeBrokerStateDb();
+
+    expect(() => ticks(10)).not.toThrow(); // runWatchdogTick must never throw
+    expect(recoveredEvents()).toHaveLength(0); // <- the guard: no false recovery
+    expect(degradedEvents()).toHaveLength(1); // and no duplicate degraded
+
+    // The durable latch is still open, so the owed recovery is still owed.
+    const latch = JSON.parse(readFileSync(getBrokerDegradedLatchPath(), "utf8"));
+    expect(latch.latched).toBe(true);
+
+    // Once the read works again AND the fleet is genuinely idle, it clears once.
+    // (Reopening alone is not enough: the worker row is still fresh, so activity
+    // reads `true` — which is itself the point, unknown never became idle.)
+    openBrokerStateDb(join(dir, "broker-state.db"));
+    ticks(1);
+    expect(recoveredEvents()).toHaveLength(0); // still active, still no recovery
+    closeActivityGate();
+    ticks(1);
+    expect(recoveredEvents()).toHaveLength(1);
+    expect(recoveredEvents()[0].attributes["event.name"]).toBe(BROKER_RECOVERED_EVENT);
   });
 });

--- a/plugins/dev/scripts/broker/broker-degraded.mjs
+++ b/plugins/dev/scripts/broker/broker-degraded.mjs
@@ -88,7 +88,7 @@
 // activity reading and the event append are INJECTED by the router, so the whole
 // machine is unit-testable with no DB, no clock, and no event log.
 
-import { mkdirSync, readFileSync, writeFileSync, renameSync } from "node:fs";
+import { mkdirSync, readFileSync, writeFileSync, renameSync, rmSync } from "node:fs";
 import { homedir } from "node:os";
 import { resolve, dirname, join } from "node:path";
 import { randomBytes } from "node:crypto";
@@ -224,16 +224,57 @@ export function getBrokerDegradedLatchPath() {
 }
 
 // hydrateLatch — lazily load the persisted episode on this process's first tick.
-// Absent/malformed marker → unlatched (never throws).
+// Never throws.
+//
+// THE FAILURE TAXONOMY MATTERS (Codex round 3). The original broad catch marked the
+// latch hydrated and treated EVERY failure as "no open episode", so a TRANSIENT read
+// error (EIO, a momentary permission loss, an obstructed path) on a restart
+// PERMANENTLY discarded a REAL open episode: the still-anomalous condition then
+// re-earned the debounce and emitted a DUPLICATE `degraded` — precisely the defect
+// the durable latch exists to prevent. Absence and corruption are CONFIRMATIONS;
+// an unreadable marker is not. So:
+//
+//   ENOENT (marker absent)   → CONFIRMED unlatched. Hydrated; never retried.
+//   read OK, body unparseable→ CONFIRMED unlatched (a marker we cannot trust is no
+//                              marker — the existing, tested corrupt-marker
+//                              behavior). Hydrated; never retried.
+//   ANY OTHER read error     → TRANSIENT / UNKNOWN. Warn, leave `_hydrated` false so
+//                              the NEXT tick re-reads, and leave the in-memory latch
+//                              untouched — we have learned nothing about the episode.
+//
+// The un-hydrated state deliberately does NOT gate the tick: a marker that is
+// unreadable forever must not disable the detector forever. The retry runs on every
+// tick, so with the sustained-tick debounce hydration gets several chances before any
+// edge can fire; and once an edge DOES advance the latch, checkBrokerDegraded pins
+// `_hydrated = true` so a later successful read cannot clobber authoritative memory.
 function hydrateLatch() {
   if (_hydrated) return;
+  let raw;
+  try {
+    raw = readFileSync(getBrokerDegradedLatchPath(), "utf8");
+  } catch (err) {
+    if (err?.code === "ENOENT") {
+      _hydrated = true; // CONFIRMED: there is no episode on disk
+      _latched = false;
+      _latchedAtMs = null;
+      return;
+    }
+    // Transient: stay un-hydrated so the next tick retries, and touch nothing.
+    log.warn?.(
+      { err: err?.message, code: err?.code },
+      "broker-degraded: latch hydrate failed (transient — will retry)"
+    );
+    return;
+  }
+  // The read succeeded, so whatever is on disk IS the marker — a body we cannot
+  // parse is a confirmed-unusable marker, not an unknown one.
   _hydrated = true;
   try {
-    const m = JSON.parse(readFileSync(getBrokerDegradedLatchPath(), "utf8"));
+    const m = JSON.parse(raw);
     _latched = m?.latched === true;
     _latchedAtMs = Number.isFinite(m?.latchedAtMs) ? m.latchedAtMs : null;
   } catch {
-    _latched = false; // absent/malformed → unlatched
+    _latched = false; // malformed → unlatched
     _latchedAtMs = null;
   }
 }
@@ -242,6 +283,12 @@ function hydrateLatch() {
 // failure is warned and the detector continues (the in-memory latch still holds
 // for this process's lifetime).
 function persistLatch({ latched, latchedAtMs }) {
+  // Hoisted out of the try so the catch can clean it up (Codex round 3). The tmp
+  // name is per-call random, so an orphan is never overwritten by the next attempt:
+  // with the round-2 retry re-calling this on EVERY watchdog tick, a PERSISTENT
+  // obstruction (a directory at the marker path, EPERM on the rename, …) leaked one
+  // hidden tmp file per minute forever → inode/disk exhaustion.
+  let tmp = null;
   try {
     const path = getBrokerDegradedLatchPath();
     const dir = dirname(path);
@@ -250,11 +297,21 @@ function persistLatch({ latched, latchedAtMs }) {
     // BASENAME is dot-prefixed (mirrors fleet-health-probe.mjs) so a crash landing
     // between write and rename leaves a HIDDEN orphan rather than a visible piece of
     // debris in the operator-facing ~/catalyst root.
-    const tmp = join(dir, `.broker-degraded-latch.${randomBytes(4).toString("hex")}.tmp`);
+    tmp = join(dir, `.broker-degraded-latch.${randomBytes(4).toString("hex")}.tmp`);
     writeFileSync(tmp, JSON.stringify({ latched, latchedAtMs, ts: Date.now() }));
     renameSync(tmp, path);
     return true;
   } catch (err) {
+    if (tmp !== null) {
+      // Nested + swallowed: cleanup must NEVER turn a best-effort persist failure
+      // into a throw that escapes runWatchdogTick. `force` already tolerates an
+      // absent file (the write itself may be what failed).
+      try {
+        rmSync(tmp, { force: true });
+      } catch {
+        /* nothing further to do — the retry next tick uses a fresh name */
+      }
+    }
     log.warn?.({ err: err?.message }, "broker-degraded: latch persist failed (will retry)");
     return false;
   }
@@ -382,6 +439,11 @@ export function checkBrokerDegraded({
 
   _latched = latched;
   _latchedAtMs = degraded ? nowMs : null;
+  // An edge has been emitted, so the IN-MEMORY episode is now authoritative. Pin
+  // hydration closed (it may still be un-hydrated after a transient read failure —
+  // see hydrateLatch) so a later successful read of a stale/absent marker can never
+  // clobber the state we just committed to the event log.
+  _hydrated = true;
   _persistPending = !persistLatch({ latched: _latched, latchedAtMs: _latchedAtMs });
   return edge;
 }

--- a/plugins/dev/scripts/broker/broker-degraded.mjs
+++ b/plugins/dev/scripts/broker/broker-degraded.mjs
@@ -1,14 +1,15 @@
-// broker-degraded.mjs — CTL-1523. The broker's own "am I silently dead?" detector:
-// the pure classifier/latch machine behind `broker.daemon.degraded` and its new
-// paired `broker.daemon.recovered`, plus the DURABLE latch that survives a restart.
+// broker-degraded.mjs — CTL-1523. The broker's own "is my interest table empty while
+// the fleet is working?" detector: the pure classifier/latch machine behind
+// `broker.daemon.degraded` and its new paired `broker.daemon.recovered`, plus the
+// DURABLE latch that survives a restart. (NOT a dead-broker detector — it runs inside
+// the broker; see "THIS IS NOT A DEAD-BROKER DETECTOR" below.)
 //
 // WHY THIS EXISTS (the bug it fixes). CTL-352's gate consulted only
 // `interests.size === 0` and uptime, so it could not distinguish a SILENTLY-DEAD
-// broker (its intent) from a GENUINELY-IDLE fleet. Since the 2026-06-07
-// phase-agents cutover, interest registration is legacy-only (every
-// `filter.register` producer lives in plugins/legacy/) and correctly dormant — so
-// an empty interest table is the CORRECT steady state and the gate fired on every
-// quiet fleet. Worse, the one-shot guard (`degradedEmittedAt`) lived only in module
+// broker (its intent) from a GENUINELY-IDLE fleet. On an EXECUTION-CORE host no
+// component registers interests at all (see the scoping note below), so an empty
+// interest table is the CORRECT steady state and the gate fired on every quiet
+// fleet. Worse, the one-shot guard (`degradedEmittedAt`) lived only in module
 // memory and was never persisted, so every broker restart (~5/day from
 // merge-triggered stack reloads) re-armed it: all 104 July emissions on mini fired
 // at uptimeMs ∈ [300s, 343s] — the FIRST watchdog tick past the 5-minute grace
@@ -17,11 +18,11 @@
 // THE FIX — two changes, mirroring the CTL-1503 fleet-health-probe idiom:
 //
 //  1. A DISCRIMINATOR. The trip now requires the fleet to be ACTIVE
-//     (hasActiveWorkers, via the router's fail-closed fleetIsActive wrapper): no
+//     (hasActiveWorkers, via the router's tri-state fleetActivity wrapper): no
 //     interests WHILE work is in flight is the anomaly; no interests while nothing
 //     is running is Tuesday. Plus a sustained-tick debounce. Deliberately NO second
-//     "is the broker ingesting" probe — a dead tailer already surfaces through the
-//     CTL-1122 checkSourceRecency path (catalyst.ingestion.stale →
+//     "is the broker ingesting" probe — a stalled tailer already surfaces through
+//     the CTL-1122 checkSourceRecency path (catalyst.ingestion.stale →
 //     catalyst.alert.raised(system_down)); duplicating it here would double-page.
 //
 //  2. An EDGE-TRIGGER + DURABLE LATCH. `degraded` fires ONCE on the healthy→anomalous
@@ -32,9 +33,16 @@
 //     latch only advances on a SUCCESSFUL append, so a transient log failure retries
 //     the same edge next tick instead of swallowing it.
 //
-// An IDLE fleet CLEARS a latched episode (paired `recovered`, reason "fleet idle")
-// rather than holding it — same ledger-balancing choice checkSourceRecency makes for
-// its gated sources, so every degraded has exactly one recovered.
+// A PROVEN-IDLE fleet CLEARS a latched episode (paired `recovered`, reason "fleet
+// idle") rather than holding it — same ledger-balancing choice checkSourceRecency
+// makes for its gated sources, so every degraded has exactly one recovered.
+//
+// UNKNOWN ACTIVITY HOLDS THE LATCH (review F2). The activity reading is TRI-STATE:
+// true / false (proven idle) / null (the worker-table read failed — we know nothing).
+// `null` neither trips nor clears. Collapsing it into `false` was a real defect: a
+// transient SQLite failure emitted a FALSE `recovered` (reason "fleet idle") and
+// persisted the cleared latch, so when the DB came back the still-anomalous condition
+// re-tripped after the debounce — one uninterrupted episode reported as two.
 //
 // READING A `recovered` — the two reasons are NOT equally informative:
 //
@@ -43,19 +51,38 @@
 //   • reason: "fleet idle" — INCONCLUSIVE. It means only that the DISCRIMINATOR went
 //     dark: with no work in flight there is nothing left to distinguish a dead broker
 //     from a correctly-quiet one, so the episode is closed to keep the ledger
-//     balanced. It is NOT evidence the broker recovered. In the legacy mode where
-//     this detector is enabled, hasActiveWorkers ages rows out at 30 minutes, so a
-//     genuinely DEAD broker will auto-"recover" this way once the fleet quiesces.
-//     Never treat a "fleet idle" recovered as an all-clear — for that, consult the
-//     CTL-1122 ingestion-recency signal (catalyst.ingestion.stale /
-//     catalyst.alert.raised(system_down)), which observes real ingestion.
+//     balanced. It is NOT evidence the broker recovered. On the legacy-wave hosts
+//     where this detector is enabled, hasActiveWorkers ages rows out at 30 minutes,
+//     so a genuinely DEAD broker will auto-"recover" this way once the fleet
+//     quiesces. Never treat a "fleet idle" recovered as an all-clear.
+//
+// THIS IS NOT A DEAD-BROKER DETECTOR, AND NEITHER IS checkSourceRecency. Both run
+// INSIDE the broker process, so neither can emit anything once that process is gone —
+// watching either as a death signal means watching a series that disappears with the
+// thing it was meant to report on. checkSourceRecency detects an ingestion STALL
+// (monitor/GitHub sources gone silent) while the broker is ALIVE. Detecting a fully
+// dead broker requires an EXTERNAL, absence-based check on the broker's own
+// heartbeat/log series — e.g. a Loki `absent_over_time` alert on
+// `broker.daemon.heartbeat` or the broker `.log` stream. (Absence, not
+// `count_over_time == 0`: a fully-dead daemon is a MISSING series, which a count
+// cannot assert — see AGENTS.md → Observability.)
 //
 // DORMANT BY DEFAULT (see isBrokerDegradedDetectorEnabled in config.mjs). The
 // detector is OPT-IN via FILTER_BROKER_DEGRADED_ENABLED=1 and evaluates nothing when
-// unset: in phase-agents mode the `interests.size === 0` conjunct is permanently true
-// (registration is legacy-only), so the gate would degenerate to "the fleet has been
-// busy for N ticks". It is retained for legacy wave-orchestration hosts, where
-// interests ARE registered and the conjunct genuinely discriminates.
+// unset.
+//
+// SCOPING — the permanently-empty interest table is a property of EXECUTION-CORE
+// DISPATCH, not of every configuration named `phase-agents` (review F5). The
+// execution-core daemon runs no `filter.register` producer at all, so on such a host
+// `interests.size === 0` can never be false and the gate degenerates to "the fleet
+// has been busy for N ticks". By contrast, a LEGACY-WAVE host — one running the
+// `/catalyst-legacy:orchestrate` skill, which invokes
+// plugins/dev/scripts/orchestrate-register-interests.sh — DOES register interests:
+// that script emits the three deterministic interests (pr_lifecycle,
+// ticket_lifecycle, comms_lifecycle) UNCONDITIONALLY, plus a per-ticket
+// phase_lifecycle interest when `dispatchMode` is `phase-agents`. On those hosts an
+// empty table IS anomalous and the conjunct genuinely discriminates — which is
+// exactly the deployment where FILTER_BROKER_DEGRADED_ENABLED=1 belongs.
 //
 // This module is a near-leaf: it imports only config.mjs (knobs + logger). The
 // activity reading and the event append are INJECTED by the router, so the whole
@@ -81,11 +108,12 @@ export const BROKER_RECOVERED_EVENT = "broker.daemon.recovered";
 /**
  * classifyBrokerDegraded — PURE per-tick trip classifier. `anomalous` is true only
  * when ALL of: the interest table is empty, the startup grace has elapsed, AND the
- * fleet is actively working. `fleetActive` is a strict-true check so an `undefined`
- * (reader unavailable) never trips — the no-false-alarm default, matching the
- * router's fail-closed fleetIsActive.
+ * fleet is actively working. `fleetActive` is TRI-STATE (true / false / null) and
+ * this is a strict-true check, so `null` (reader unavailable) and `undefined` never
+ * trip — the no-false-alarm default. Only a POSITIVE activity reading is evidence of
+ * an anomaly.
  *
- * @param {object} readings { interestCount, uptimeMs, fleetActive }
+ * @param {object} readings { interestCount, uptimeMs, fleetActive } fleetActive: true|false|null
  * @param {object} [thresholds] { graceMs }
  * @returns {{anomalous:boolean, emptyInterests:boolean, pastGrace:boolean, fleetActive:boolean}}
  */
@@ -106,17 +134,27 @@ export function classifyBrokerDegraded(
 
 /**
  * classifyBrokerDegradedClear — PURE clear-side verdict. The complement of the trip's
- * two live inputs: interests came back, OR the fleet went idle. Uptime plays no part
- * (it only ever grows). `reason` names WHICH condition cleared it, for the recovered
- * event's detail; interests-came-back wins when both hold, since it is the
+ * two live inputs: interests came back, OR the fleet is PROVEN idle. Uptime plays no
+ * part (it only ever grows). `reason` names WHICH condition cleared it, for the
+ * recovered event's detail; interests-came-back wins when both hold, since it is the
  * affirmative proof that the broker is not dead.
  *
- * @param {object} readings { interestCount, fleetActive }
+ * TRI-STATE CONTRACT (review F2). Both edges demand POSITIVE evidence, so an UNKNOWN
+ * activity reading (`null`/`undefined` — the worker-table read failed) can do neither:
+ *
+ *   fleetActive === true   → neither (the anomaly, if any, persists) — trip side owns it
+ *   fleetActive === false  → CLEAR, reason "fleet idle" (proven idle)
+ *   fleetActive == null    → NEITHER trip nor clear; a latched episode HOLDS
+ *
+ * The old `!== true` test collapsed unknown into idle, so one transient SQLite failure
+ * produced a false `recovered` and a duplicate degraded edge when the DB came back.
+ *
+ * @param {object} readings { interestCount, fleetActive } fleetActive: true|false|null
  * @returns {{clear:boolean, reason:("interests registered"|"fleet idle"|null)}}
  */
 export function classifyBrokerDegradedClear({ interestCount, fleetActive } = {}) {
   if (interestCount > 0) return { clear: true, reason: "interests registered" };
-  if (fleetActive !== true) return { clear: true, reason: "fleet idle" };
+  if (fleetActive === false) return { clear: true, reason: "fleet idle" };
   return { clear: false, reason: null };
 }
 
@@ -262,7 +300,20 @@ export function checkBrokerDegraded({
   graceMs = BROKER_DEGRADED_GRACE_MS,
   sustainedTicks = BROKER_DEGRADED_SUSTAINED_TICKS,
 } = {}) {
-  if (!isBrokerDegradedDetectorEnabled()) return null;
+  if (!isBrokerDegradedDetectorEnabled()) {
+    // Review F4: DISCARD any unfinished debounce run while disabled. The knob is
+    // read at call time, so it can flip mid-run; leaving the counters standing let
+    // pre-disable observations count toward a POST-re-enable alarm (4 anomalous
+    // ticks → disable → conditions clear → re-enable during a NEW anomaly → the
+    // first new tick crosses a threshold of 5 after ONE tick of the new condition).
+    // A debounce run must be contiguous AND wholly observed while armed.
+    _sustained = 0;
+    _tripRunLength = null;
+    // Deliberately NOT touched: the durable latch (_latched/_latchedAtMs) and the
+    // hydration flag. An OPEN episode must survive the switch so it can still be
+    // paired with its `recovered` — that is existing intended behavior.
+    return null;
+  }
 
   const { anomalous } = classifyBrokerDegraded({ interestCount, uptimeMs, fleetActive }, { graceMs });
   const { clear, reason: clearReason } = classifyBrokerDegradedClear({ interestCount, fleetActive });

--- a/plugins/dev/scripts/broker/broker-degraded.mjs
+++ b/plugins/dev/scripts/broker/broker-degraded.mjs
@@ -447,3 +447,19 @@ export function checkBrokerDegraded({
   _persistPending = !persistLatch({ latched: _latched, latchedAtMs: _latchedAtMs });
   return edge;
 }
+
+/**
+ * isBrokerDegradedLatchOpen — is there an OPEN episode owing a `recovered`?
+ *
+ * Codex P2 round 4 (#2740): the router's cross-tick interest-registration edge is
+ * the only evidence that makes the clear verdict true for a one-shot interest. If
+ * it is consumed unconditionally and the `recovered` append then FAILS, that
+ * evidence is gone: the latch stays open and no later active/empty tick can retry
+ * the recovery, so the episode suppresses every subsequent degraded until an
+ * unrelated registration or an idle fleet happens along. The router therefore
+ * retains the edge while an episode is still open — same emit-then-advance
+ * discipline the latch itself uses. Reads in-memory state only; never throws.
+ */
+export function isBrokerDegradedLatchOpen() {
+  return _latched === true;
+}

--- a/plugins/dev/scripts/broker/broker-degraded.mjs
+++ b/plugins/dev/scripts/broker/broker-degraded.mjs
@@ -1,0 +1,314 @@
+// broker-degraded.mjs — CTL-1523. The broker's own "am I silently dead?" detector:
+// the pure classifier/latch machine behind `broker.daemon.degraded` and its new
+// paired `broker.daemon.recovered`, plus the DURABLE latch that survives a restart.
+//
+// WHY THIS EXISTS (the bug it fixes). CTL-352's gate consulted only
+// `interests.size === 0` and uptime, so it could not distinguish a SILENTLY-DEAD
+// broker (its intent) from a GENUINELY-IDLE fleet. Since the 2026-06-07
+// phase-agents cutover, interest registration is legacy-only (every
+// `filter.register` producer lives in plugins/legacy/) and correctly dormant — so
+// an empty interest table is the CORRECT steady state and the gate fired on every
+// quiet fleet. Worse, the one-shot guard (`degradedEmittedAt`) lived only in module
+// memory and was never persisted, so every broker restart (~5/day from
+// merge-triggered stack reloads) re-armed it: all 104 July emissions on mini fired
+// at uptimeMs ∈ [300s, 343s] — the FIRST watchdog tick past the 5-minute grace
+// after a fresh start. Zero fired later. It was a restart counter, not a detector.
+//
+// THE FIX — two changes, mirroring the CTL-1503 fleet-health-probe idiom:
+//
+//  1. A DISCRIMINATOR. The trip now requires the fleet to be ACTIVE
+//     (hasActiveWorkers, via the router's fail-closed fleetIsActive wrapper): no
+//     interests WHILE work is in flight is the anomaly; no interests while nothing
+//     is running is Tuesday. Plus a sustained-tick debounce. Deliberately NO second
+//     "is the broker ingesting" probe — a dead tailer already surfaces through the
+//     CTL-1122 checkSourceRecency path (catalyst.ingestion.stale →
+//     catalyst.alert.raised(system_down)); duplicating it here would double-page.
+//
+//  2. An EDGE-TRIGGER + DURABLE LATCH. `degraded` fires ONCE on the healthy→anomalous
+//     edge; `recovered` fires ONCE on the way back. The latch is persisted to a
+//     DEDICATED marker (NOT broker.state.json, which persistBrokerState rewrites
+//     dozens of times per second) and hydrated lazily on the first tick, so a restart
+//     mid-episode resumes rather than re-emitting. Emission is EMIT-THEN-ADVANCE: the
+//     latch only advances on a SUCCESSFUL append, so a transient log failure retries
+//     the same edge next tick instead of swallowing it.
+//
+// An IDLE fleet CLEARS a latched episode (paired `recovered`, reason "fleet idle")
+// rather than holding it — same ledger-balancing choice checkSourceRecency makes for
+// its gated sources, so every degraded has exactly one recovered.
+//
+// READING A `recovered` — the two reasons are NOT equally informative:
+//
+//   • reason: "interests registered" — AFFIRMATIVE proof of life. The broker
+//     demonstrably processed a registration, so it is not silently dead.
+//   • reason: "fleet idle" — INCONCLUSIVE. It means only that the DISCRIMINATOR went
+//     dark: with no work in flight there is nothing left to distinguish a dead broker
+//     from a correctly-quiet one, so the episode is closed to keep the ledger
+//     balanced. It is NOT evidence the broker recovered. In the legacy mode where
+//     this detector is enabled, hasActiveWorkers ages rows out at 30 minutes, so a
+//     genuinely DEAD broker will auto-"recover" this way once the fleet quiesces.
+//     Never treat a "fleet idle" recovered as an all-clear — for that, consult the
+//     CTL-1122 ingestion-recency signal (catalyst.ingestion.stale /
+//     catalyst.alert.raised(system_down)), which observes real ingestion.
+//
+// DORMANT BY DEFAULT (see isBrokerDegradedDetectorEnabled in config.mjs). The
+// detector is OPT-IN via FILTER_BROKER_DEGRADED_ENABLED=1 and evaluates nothing when
+// unset: in phase-agents mode the `interests.size === 0` conjunct is permanently true
+// (registration is legacy-only), so the gate would degenerate to "the fleet has been
+// busy for N ticks". It is retained for legacy wave-orchestration hosts, where
+// interests ARE registered and the conjunct genuinely discriminates.
+//
+// This module is a near-leaf: it imports only config.mjs (knobs + logger). The
+// activity reading and the event append are INJECTED by the router, so the whole
+// machine is unit-testable with no DB, no clock, and no event log.
+
+import { mkdirSync, readFileSync, writeFileSync, renameSync } from "node:fs";
+import { homedir } from "node:os";
+import { resolve, dirname, join } from "node:path";
+import { randomBytes } from "node:crypto";
+import {
+  log,
+  BROKER_DEGRADED_GRACE_MS,
+  BROKER_DEGRADED_SUSTAINED_TICKS,
+  isBrokerDegradedDetectorEnabled,
+} from "./config.mjs";
+
+// The two event names this detector owns. Both sit inside the `broker.daemon`
+// FORBIDDEN_PREFIXES space (namespace-contract.mjs), so shouldSkipEvent already
+// drops them from re-ingestion — no filter-wake feedback loop.
+export const BROKER_DEGRADED_EVENT = "broker.daemon.degraded";
+export const BROKER_RECOVERED_EVENT = "broker.daemon.recovered";
+
+/**
+ * classifyBrokerDegraded — PURE per-tick trip classifier. `anomalous` is true only
+ * when ALL of: the interest table is empty, the startup grace has elapsed, AND the
+ * fleet is actively working. `fleetActive` is a strict-true check so an `undefined`
+ * (reader unavailable) never trips — the no-false-alarm default, matching the
+ * router's fail-closed fleetIsActive.
+ *
+ * @param {object} readings { interestCount, uptimeMs, fleetActive }
+ * @param {object} [thresholds] { graceMs }
+ * @returns {{anomalous:boolean, emptyInterests:boolean, pastGrace:boolean, fleetActive:boolean}}
+ */
+export function classifyBrokerDegraded(
+  { interestCount, uptimeMs, fleetActive } = {},
+  { graceMs = BROKER_DEGRADED_GRACE_MS } = {}
+) {
+  const emptyInterests = interestCount === 0;
+  const pastGrace = Number.isFinite(uptimeMs) && uptimeMs > graceMs;
+  const active = fleetActive === true;
+  return {
+    anomalous: emptyInterests && pastGrace && active,
+    emptyInterests,
+    pastGrace,
+    fleetActive: active,
+  };
+}
+
+/**
+ * classifyBrokerDegradedClear — PURE clear-side verdict. The complement of the trip's
+ * two live inputs: interests came back, OR the fleet went idle. Uptime plays no part
+ * (it only ever grows). `reason` names WHICH condition cleared it, for the recovered
+ * event's detail; interests-came-back wins when both hold, since it is the
+ * affirmative proof that the broker is not dead.
+ *
+ * @param {object} readings { interestCount, fleetActive }
+ * @returns {{clear:boolean, reason:("interests registered"|"fleet idle"|null)}}
+ */
+export function classifyBrokerDegradedClear({ interestCount, fleetActive } = {}) {
+  if (interestCount > 0) return { clear: true, reason: "interests registered" };
+  if (fleetActive !== true) return { clear: true, reason: "fleet idle" };
+  return { clear: false, reason: null };
+}
+
+/**
+ * nextBrokerDegradedSustained — PURE debounce counter. Counts consecutive anomalous
+ * ticks; any non-anomalous tick resets it to 0, so the required run must be
+ * contiguous.
+ *
+ * @param {number} prev
+ * @param {boolean} anomalous
+ * @returns {number}
+ */
+export function nextBrokerDegradedSustained(prev, anomalous) {
+  const n = Number.isFinite(prev) ? prev : 0;
+  return anomalous ? n + 1 : 0;
+}
+
+/**
+ * nextBrokerDegradedLatch — PURE edge state machine (mirrors nextFleetHealthLatch).
+ * `trip` is only consulted when NOT latched; once latched only `clear` releases it,
+ * so a sustained anomaly never re-emits.
+ *
+ * @param {boolean} prev  prior latch (true = an episode is open)
+ * @param {{trip:boolean, clear:boolean}} verdict
+ * @returns {{latched:boolean, emit:("degraded"|"recovered"|null)}}
+ */
+export function nextBrokerDegradedLatch(prev, { trip, clear } = {}) {
+  if (!prev && trip) return { latched: true, emit: "degraded" };
+  if (prev && clear) return { latched: false, emit: "recovered" };
+  return { latched: prev === true, emit: null };
+}
+
+// ─── Durable latch (mirrors fleet-health-probe.mjs) ──────────────────────────
+// Module-scoped so the episode persists across ticks; PERSISTED to disk + hydrated
+// on the first tick so a broker RESTART mid-episode does not re-emit `degraded`
+// with no intervening `recovered` (the exact defect CTL-1523 fixes). Best-effort —
+// a hydrate/persist failure never wedges the watchdog.
+let _latched = false;
+let _latchedAtMs = null; // when the open episode started (for degradedForMs)
+let _hydrated = false;
+let _sustained = 0; // in-memory only: a restart deliberately re-earns the debounce
+// The run length AT THE TICK THE GATE FIRST CROSSED, held across retries. The live
+// _sustained counter keeps incrementing while a failed append re-attempts the same
+// edge, so reporting it would inflate the degraded event's `sustainedTicks` (6, 8, …
+// for a threshold of 5) and misdescribe what actually tripped the gate. Captured on
+// the first tripping tick, cleared whenever the run breaks.
+let _tripRunLength = null;
+
+// Resolved per call (not a load-time const) so tests can redirect by setting
+// CATALYST_DIR — parity with getEventLogPath / getInterestsFile. Prefer
+// process.env.HOME over homedir() for the same reason config.mjs does: macOS's
+// homedir() ignores HOME, so a test (or a daemon launched with an overridden HOME)
+// would otherwise resolve a different root than every other path helper.
+export function getBrokerDegradedLatchPath() {
+  const home = process.env.HOME ?? homedir();
+  const catalystDir = process.env.CATALYST_DIR ?? `${home}/catalyst`;
+  return resolve(catalystDir, "broker-degraded-latch.json");
+}
+
+// hydrateLatch — lazily load the persisted episode on this process's first tick.
+// Absent/malformed marker → unlatched (never throws).
+function hydrateLatch() {
+  if (_hydrated) return;
+  _hydrated = true;
+  try {
+    const m = JSON.parse(readFileSync(getBrokerDegradedLatchPath(), "utf8"));
+    _latched = m?.latched === true;
+    _latchedAtMs = Number.isFinite(m?.latchedAtMs) ? m.latchedAtMs : null;
+  } catch {
+    _latched = false; // absent/malformed → unlatched
+    _latchedAtMs = null;
+  }
+}
+
+// persistLatch — atomic tmp + rename write of the episode state. Best-effort; a
+// failure is warned and the detector continues (the in-memory latch still holds
+// for this process's lifetime).
+function persistLatch({ latched, latchedAtMs }) {
+  try {
+    const path = getBrokerDegradedLatchPath();
+    const dir = dirname(path);
+    mkdirSync(dir, { recursive: true });
+    // Same directory as the marker (rename must stay intra-filesystem), but the tmp
+    // BASENAME is dot-prefixed (mirrors fleet-health-probe.mjs) so a crash landing
+    // between write and rename leaves a HIDDEN orphan rather than a visible piece of
+    // debris in the operator-facing ~/catalyst root.
+    const tmp = join(dir, `.broker-degraded-latch.${randomBytes(4).toString("hex")}.tmp`);
+    writeFileSync(tmp, JSON.stringify({ latched, latchedAtMs, ts: Date.now() }));
+    renameSync(tmp, path);
+  } catch (err) {
+    log.warn?.({ err: err?.message }, "broker-degraded: latch persist failed (continuing)");
+  }
+}
+
+// __resetBrokerDegradedLatchForTest — test seam (mirrors __resetFleetHealthLatch).
+// Clears ONLY the in-memory episode + the hydration flag, so the next tick
+// re-reads the CATALYST_DIR-scoped marker — which is exactly how a restart is
+// simulated.
+export function __resetBrokerDegradedLatchForTest() {
+  _latched = false;
+  _latchedAtMs = null;
+  _hydrated = false;
+  _sustained = 0;
+  _tripRunLength = null;
+}
+
+export function __getBrokerDegradedLatchForTest() {
+  return {
+    latched: _latched,
+    latchedAtMs: _latchedAtMs,
+    sustained: _sustained,
+    tripRunLength: _tripRunLength,
+    hydrated: _hydrated,
+  };
+}
+
+/**
+ * checkBrokerDegraded — one watchdog-tick evaluation. Returns the emitted edge
+ * ("degraded" | "recovered") or null. Kill-switched (isBrokerDegradedDetectorEnabled).
+ *
+ * `emit({action, detail})` MUST return true on a successful append and false
+ * otherwise (it must never throw) — the latch advances ONLY on true, so a transient
+ * event-log failure re-attempts the same edge next tick rather than swallowing it.
+ *
+ * @param {object} i
+ * @param {number} i.interestCount
+ * @param {number} i.uptimeMs
+ * @param {string|null} [i.brokerStartedAt]  ISO, forensic passthrough
+ * @param {boolean} i.fleetActive
+ * @param {number} [i.nowMs]
+ * @param {Function} i.emit
+ * @param {number} [i.graceMs]
+ * @param {number} [i.sustainedTicks]
+ * @returns {"degraded"|"recovered"|null}
+ */
+export function checkBrokerDegraded({
+  interestCount,
+  uptimeMs,
+  brokerStartedAt = null,
+  fleetActive,
+  nowMs = Date.now(),
+  emit,
+  graceMs = BROKER_DEGRADED_GRACE_MS,
+  sustainedTicks = BROKER_DEGRADED_SUSTAINED_TICKS,
+} = {}) {
+  if (!isBrokerDegradedDetectorEnabled()) return null;
+
+  const { anomalous } = classifyBrokerDegraded({ interestCount, uptimeMs, fleetActive }, { graceMs });
+  const { clear, reason: clearReason } = classifyBrokerDegradedClear({ interestCount, fleetActive });
+
+  hydrateLatch();
+  _sustained = nextBrokerDegradedSustained(_sustained, anomalous);
+
+  const trip = anomalous && _sustained >= sustainedTicks;
+  // Capture the run length that actually crossed the gate (see _tripRunLength).
+  if (!trip) _tripRunLength = null;
+  else if (_tripRunLength === null) _tripRunLength = _sustained;
+
+  const { latched, emit: edge } = nextBrokerDegradedLatch(_latched, { trip, clear });
+  if (!edge) return null;
+
+  const degraded = edge === "degraded";
+  const detail = degraded
+    ? {
+        reason: "no registered interests while fleet is active",
+        uptimeMs,
+        brokerStartedAt,
+        activeWorkers: true,
+        sustainedTicks: _tripRunLength ?? _sustained,
+      }
+    : {
+        reason: clearReason,
+        interestCount,
+        degradedForMs: _latchedAtMs != null ? Math.max(0, nowMs - _latchedAtMs) : null,
+      };
+
+  let ok = false;
+  try {
+    ok = emit({ action: edge, detail }) !== false;
+  } catch (err) {
+    // Defensive `?.` for parity with persistLatch: config.mjs's `log` is a real pino
+    // instance with no console shim, so a stripped/stubbed logger must never turn a
+    // failed emit into a throw that escapes runWatchdogTick.
+    log.warn?.({ err: err?.message }, "broker-degraded: emit failed");
+    ok = false;
+  }
+  // EMIT-THEN-ADVANCE: a failed append leaves the latch untouched so the next tick
+  // retries this edge (a real silent-death is never reduced to one lost log line).
+  if (!ok) return null;
+
+  _latched = latched;
+  _latchedAtMs = degraded ? nowMs : null;
+  persistLatch({ latched: _latched, latchedAtMs: _latchedAtMs });
+  return edge;
+}

--- a/plugins/dev/scripts/broker/broker-degraded.mjs
+++ b/plugins/dev/scripts/broker/broker-degraded.mjs
@@ -195,6 +195,15 @@ export function nextBrokerDegradedLatch(prev, { trip, clear } = {}) {
 let _latched = false;
 let _latchedAtMs = null; // when the open episode started (for degradedForMs)
 let _hydrated = false;
+// Codex P2 (#2740): the marker write can fail (e.g. a temporarily unwritable
+// CATALYST_DIR) AFTER the event append already succeeded and `_latched` advanced.
+// Swallowing that left memory and disk disagreeing with nothing to reconcile them,
+// so a later restart hydrated an absent/stale marker and re-emitted a duplicate
+// edge for the same episode — defeating the whole point of the durable latch.
+// When a write fails we remember it and retry on every subsequent tick until it
+// lands. In-memory state stays authoritative meanwhile, so the retry never changes
+// what is emitted; it only makes the on-disk copy catch up.
+let _persistPending = false;
 let _sustained = 0; // in-memory only: a restart deliberately re-earns the debounce
 // The run length AT THE TICK THE GATE FIRST CROSSED, held across retries. The live
 // _sustained counter keeps incrementing while a failed append re-attempts the same
@@ -244,8 +253,10 @@ function persistLatch({ latched, latchedAtMs }) {
     const tmp = join(dir, `.broker-degraded-latch.${randomBytes(4).toString("hex")}.tmp`);
     writeFileSync(tmp, JSON.stringify({ latched, latchedAtMs, ts: Date.now() }));
     renameSync(tmp, path);
+    return true;
   } catch (err) {
-    log.warn?.({ err: err?.message }, "broker-degraded: latch persist failed (continuing)");
+    log.warn?.({ err: err?.message }, "broker-degraded: latch persist failed (will retry)");
+    return false;
   }
 }
 
@@ -259,6 +270,7 @@ export function __resetBrokerDegradedLatchForTest() {
   _hydrated = false;
   _sustained = 0;
   _tripRunLength = null;
+  _persistPending = false;
 }
 
 export function __getBrokerDegradedLatchForTest() {
@@ -268,6 +280,7 @@ export function __getBrokerDegradedLatchForTest() {
     sustained: _sustained,
     tripRunLength: _tripRunLength,
     hydrated: _hydrated,
+    persistPending: _persistPending,
   };
 }
 
@@ -319,6 +332,15 @@ export function checkBrokerDegraded({
   const { clear, reason: clearReason } = classifyBrokerDegradedClear({ interestCount, fleetActive });
 
   hydrateLatch();
+
+  // Codex P2 (#2740): reconcile a previously-failed marker write before doing
+  // anything else. Until this lands, disk disagrees with memory and a restart
+  // would re-emit an edge we already emitted. Runs after hydrateLatch so it can
+  // never clobber the on-disk episode with un-hydrated defaults.
+  if (_persistPending) {
+    _persistPending = !persistLatch({ latched: _latched, latchedAtMs: _latchedAtMs });
+  }
+
   _sustained = nextBrokerDegradedSustained(_sustained, anomalous);
 
   const trip = anomalous && _sustained >= sustainedTicks;
@@ -360,6 +382,6 @@ export function checkBrokerDegraded({
 
   _latched = latched;
   _latchedAtMs = degraded ? nowMs : null;
-  persistLatch({ latched: _latched, latchedAtMs: _latchedAtMs });
+  _persistPending = !persistLatch({ latched: _latched, latchedAtMs: _latchedAtMs });
   return edge;
 }

--- a/plugins/dev/scripts/broker/broker-degraded.test.mjs
+++ b/plugins/dev/scripts/broker/broker-degraded.test.mjs
@@ -610,3 +610,73 @@ describe("event names (CTL-1523)", () => {
     }
   });
 });
+
+// Codex P2 (#2740): the marker write can fail AFTER the event append succeeded and
+// `_latched` advanced. Swallowing that left memory and disk disagreeing with nothing
+// to reconcile them, so a restart hydrated a stale/absent marker and re-emitted a
+// duplicate edge for the same episode — defeating the durable latch entirely.
+describe("checkBrokerDegraded — a failed latch persist is retried (review round 2)", () => {
+  let dir;
+  let prevCatalystDir;
+  let prevEnabled;
+  beforeEach(() => {
+    prevCatalystDir = process.env.CATALYST_DIR;
+    prevEnabled = process.env.FILTER_BROKER_DEGRADED_ENABLED;
+    dir = mkdtempSync(join(tmpdir(), "broker-degraded-persist-"));
+    process.env.CATALYST_DIR = dir;
+    process.env.FILTER_BROKER_DEGRADED_ENABLED = "1";
+    __resetBrokerDegradedLatchForTest();
+  });
+  afterEach(() => {
+    if (prevCatalystDir === undefined) delete process.env.CATALYST_DIR;
+    else process.env.CATALYST_DIR = prevCatalystDir;
+    if (prevEnabled === undefined) delete process.env.FILTER_BROKER_DEGRADED_ENABLED;
+    else process.env.FILTER_BROKER_DEGRADED_ENABLED = prevEnabled;
+    rmSync(dir, { recursive: true, force: true });
+    __resetBrokerDegradedLatchForTest();
+  });
+
+  const anomalousTick = (emit) =>
+    checkBrokerDegraded({
+      interestCount: 0,
+      uptimeMs: 6 * 60 * 1000,
+      fleetActive: true,
+      emit,
+      sustainedTicks: 1,
+    });
+
+  test("a persist failure is remembered and retried until it lands", () => {
+    // Make the marker directory unwritable by planting a DIRECTORY where the marker
+    // file must go — writeFileSync/renameSync then fail while the append succeeds.
+    const markerPath = getBrokerDegradedLatchPath();
+    mkdirSync(markerPath, { recursive: true });
+
+    const emitted = [];
+    expect(anomalousTick((e) => (emitted.push(e.action), true))).toBe("degraded");
+    expect(emitted).toEqual(["degraded"]);
+    // In-memory latch advanced (the edge really was emitted) but disk did NOT.
+    expect(__getBrokerDegradedLatchForTest().latched).toBe(true);
+    expect(__getBrokerDegradedLatchForTest().persistPending).toBe(true);
+
+    // Still failing → still pending, and no duplicate edge is emitted meanwhile.
+    expect(anomalousTick(() => true)).toBeNull();
+    expect(__getBrokerDegradedLatchForTest().persistPending).toBe(true);
+    expect(emitted).toEqual(["degraded"]);
+
+    // Clear the obstruction: the very next tick reconciles disk with memory.
+    rmSync(markerPath, { recursive: true, force: true });
+    expect(anomalousTick(() => true)).toBeNull();
+    expect(__getBrokerDegradedLatchForTest().persistPending).toBe(false);
+
+    // And the marker now reflects the OPEN episode, so a restart resumes it
+    // instead of re-emitting — which is the whole point.
+    const marker = JSON.parse(readFileSync(getBrokerDegradedLatchPath(), "utf8"));
+    expect(marker.latched).toBe(true);
+  });
+
+  test("a successful persist leaves nothing pending", () => {
+    expect(anomalousTick(() => true)).toBe("degraded");
+    expect(__getBrokerDegradedLatchForTest().persistPending).toBe(false);
+    expect(JSON.parse(readFileSync(getBrokerDegradedLatchPath(), "utf8")).latched).toBe(true);
+  });
+});

--- a/plugins/dev/scripts/broker/broker-degraded.test.mjs
+++ b/plugins/dev/scripts/broker/broker-degraded.test.mjs
@@ -10,7 +10,15 @@
 // Run: cd plugins/dev/scripts/broker && bun test broker-degraded.test.mjs
 
 import { describe, test, expect, beforeEach, afterEach } from "bun:test";
-import { mkdtempSync, rmSync, writeFileSync, readFileSync, existsSync, mkdirSync } from "node:fs";
+import {
+  mkdtempSync,
+  rmSync,
+  writeFileSync,
+  readFileSync,
+  existsSync,
+  mkdirSync,
+  readdirSync,
+} from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import {
@@ -678,5 +686,105 @@ describe("checkBrokerDegraded — a failed latch persist is retried (review roun
     expect(anomalousTick(() => true)).toBe("degraded");
     expect(__getBrokerDegradedLatchForTest().persistPending).toBe(false);
     expect(JSON.parse(readFileSync(getBrokerDegradedLatchPath(), "utf8")).latched).toBe(true);
+  });
+
+  // Codex round 3 (T1): persistLatch writes a UNIQUELY-NAMED tmp file and then
+  // renames it. If the rename throws, that tmp file is orphaned — and because the
+  // round-2 retry re-calls persistLatch on EVERY watchdog tick, a PERSISTENT
+  // obstruction leaked one hidden tmp file per minute forever (inode/disk
+  // exhaustion). The cleanup must run in the catch, and must never itself throw.
+  test("a persistently failing rename leaves NO orphan .tmp files (the inode leak)", () => {
+    const markerPath = getBrokerDegradedLatchPath();
+    mkdirSync(markerPath, { recursive: true }); // rename onto a DIRECTORY always fails
+
+    const emitted = [];
+    expect(() => anomalousTick((e) => (emitted.push(e.action), true))).not.toThrow();
+    expect(emitted).toEqual(["degraded"]);
+    expect(__getBrokerDegradedLatchForTest().persistPending).toBe(true);
+
+    // Several more ticks: each one retries the persist and fails the same way.
+    for (let i = 0; i < 5; i++) {
+      expect(() => anomalousTick(() => true)).not.toThrow();
+    }
+    expect(__getBrokerDegradedLatchForTest().persistPending).toBe(true);
+
+    const leftovers = readdirSync(dir).filter(
+      (f) => f.startsWith(".broker-degraded-latch.") && f.endsWith(".tmp"),
+    );
+    expect(leftovers, `orphaned tmp files: ${leftovers.join(", ")}`).toEqual([]);
+  });
+});
+
+// Codex round 3 (T3): hydrateLatch's failure taxonomy. A CONFIRMED unlatched state
+// (marker absent, or present-but-unparseable) is final; any OTHER read failure is
+// merely UNKNOWN and must stay retryable — the old broad catch turned one transient
+// EIO on a restart into the permanent loss of a real open episode, whose continuing
+// anomaly then re-earned the debounce and emitted a DUPLICATE degraded.
+describe("hydrateLatch — a TRANSIENT read failure stays retryable (Codex round 3)", () => {
+  let dir;
+  let prevCatalystDir;
+  let prevEnabled;
+
+  const IDLE = { interestCount: 0, uptimeMs: GRACE + 1, fleetActive: false };
+  const run = (readings, emit) =>
+    checkBrokerDegraded({ ...readings, graceMs: GRACE, sustainedTicks: 1, emit });
+
+  beforeEach(() => {
+    prevCatalystDir = process.env.CATALYST_DIR;
+    prevEnabled = process.env.FILTER_BROKER_DEGRADED_ENABLED;
+    dir = mkdtempSync(join(tmpdir(), "broker-degraded-hydrate-"));
+    process.env.CATALYST_DIR = dir;
+    process.env.FILTER_BROKER_DEGRADED_ENABLED = "1";
+    __resetBrokerDegradedLatchForTest();
+  });
+  afterEach(() => {
+    __resetBrokerDegradedLatchForTest();
+    if (prevCatalystDir === undefined) delete process.env.CATALYST_DIR;
+    else process.env.CATALYST_DIR = prevCatalystDir;
+    if (prevEnabled === undefined) delete process.env.FILTER_BROKER_DEGRADED_ENABLED;
+    else process.env.FILTER_BROKER_DEGRADED_ENABLED = prevEnabled;
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  test("EISDIR (marker path obstructed) is NOT confirmed-unlatched — and it retries", () => {
+    // A DIRECTORY at the marker path makes readFileSync throw EISDIR, not ENOENT:
+    // the same shape as a transient EIO / permission loss.
+    const markerPath = getBrokerDegradedLatchPath();
+    mkdirSync(markerPath, { recursive: true });
+
+    const calls = [];
+    const emit = (p) => (calls.push(p), true);
+    expect(() => run(IDLE, emit)).not.toThrow();
+    // Nothing was learned: hydration is NOT closed, so the next tick re-reads.
+    expect(__getBrokerDegradedLatchForTest().hydrated).toBe(false);
+    expect(__getBrokerDegradedLatchForTest().latched).toBe(false);
+    expect(calls).toHaveLength(0); // and no orphan `recovered` was invented
+
+    // The obstruction clears, revealing the REAL open episode that was behind it.
+    // With the old broad catch this episode was already permanently discarded.
+    rmSync(markerPath, { recursive: true, force: true });
+    writeFileSync(
+      markerPath,
+      JSON.stringify({ latched: true, latchedAtMs: Date.now() - 60_000, ts: Date.now() }),
+    );
+
+    expect(run(IDLE, emit)).toBe("recovered"); // the owed recovery still fires
+    expect(__getBrokerDegradedLatchForTest().hydrated).toBe(true);
+    expect(calls[0].detail.reason).toBe("fleet idle");
+    expect(typeof calls[0].detail.degradedForMs).toBe("number");
+  });
+
+  test("ENOENT (absent) and a malformed body stay CONFIRMED unlatched — no retry", () => {
+    // (a) absent
+    expect(existsSync(getBrokerDegradedLatchPath())).toBe(false);
+    expect(run(IDLE, () => true)).toBeNull();
+    expect(__getBrokerDegradedLatchForTest().hydrated).toBe(true);
+
+    // (b) present but unparseable — a marker we cannot trust is no marker
+    __resetBrokerDegradedLatchForTest();
+    writeFileSync(getBrokerDegradedLatchPath(), "{not json");
+    expect(run(IDLE, () => true)).toBeNull();
+    expect(__getBrokerDegradedLatchForTest().hydrated).toBe(true);
+    expect(__getBrokerDegradedLatchForTest().latched).toBe(false);
   });
 });

--- a/plugins/dev/scripts/broker/broker-degraded.test.mjs
+++ b/plugins/dev/scripts/broker/broker-degraded.test.mjs
@@ -1,0 +1,383 @@
+// broker-degraded.test.mjs — CTL-1523. The PURE core of the broker-degraded
+// detector: the trip classifier (with its fleet-activity discriminator), the
+// clear-side verdict, the sustained-tick debounce, and the edge state machine —
+// table-driven; no disk, no clock, no event log — PLUS direct coverage of the
+// `checkBrokerDegraded` driver (emit-then-advance retry semantics + hydrateLatch
+// tolerance) with an injected emit stub and a CATALYST_DIR-isolated marker.
+// The runWatchdogTick wiring is covered in broker-degraded-wiring.test.mjs.
+// Idiom model: execution-core/fleet-health-probe.test.mjs.
+//
+// Run: cd plugins/dev/scripts/broker && bun test broker-degraded.test.mjs
+
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, rmSync, writeFileSync, existsSync, mkdirSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import {
+  classifyBrokerDegraded,
+  classifyBrokerDegradedClear,
+  nextBrokerDegradedSustained,
+  nextBrokerDegradedLatch,
+  checkBrokerDegraded,
+  getBrokerDegradedLatchPath,
+  __resetBrokerDegradedLatchForTest,
+  __getBrokerDegradedLatchForTest,
+  BROKER_DEGRADED_EVENT,
+  BROKER_RECOVERED_EVENT,
+} from "./broker-degraded.mjs";
+
+const GRACE = 300_000;
+
+describe("classifyBrokerDegraded — the trip classifier (CTL-1523)", () => {
+  const cases = [
+    // [name, readings, expectedAnomalous]
+    [
+      "THE REGRESSION: empty interests + past grace but IDLE fleet → not anomalous",
+      { interestCount: 0, uptimeMs: GRACE + 60_000, fleetActive: false },
+      false,
+    ],
+    [
+      "empty interests + past grace + ACTIVE fleet → anomalous",
+      { interestCount: 0, uptimeMs: GRACE + 60_000, fleetActive: true },
+      true,
+    ],
+    [
+      "inside the startup grace → not anomalous even with an active fleet",
+      { interestCount: 0, uptimeMs: 60_000, fleetActive: true },
+      false,
+    ],
+    [
+      "boundary: uptime EXACTLY at the grace does not trip (strict >)",
+      { interestCount: 0, uptimeMs: GRACE, fleetActive: true },
+      false,
+    ],
+    [
+      "boundary: one ms past the grace trips",
+      { interestCount: 0, uptimeMs: GRACE + 1, fleetActive: true },
+      true,
+    ],
+    [
+      "interests present → not anomalous however active/old",
+      { interestCount: 3, uptimeMs: GRACE + 600_000, fleetActive: true },
+      false,
+    ],
+    [
+      "fleetActive undefined (reader unavailable) → NOT anomalous (fail closed)",
+      { interestCount: 0, uptimeMs: GRACE + 60_000, fleetActive: undefined },
+      false,
+    ],
+    [
+      "fleetActive truthy-but-not-true is not accepted (strict === true)",
+      { interestCount: 0, uptimeMs: GRACE + 60_000, fleetActive: 1 },
+      false,
+    ],
+    [
+      "non-finite uptime → not anomalous",
+      { interestCount: 0, uptimeMs: NaN, fleetActive: true },
+      false,
+    ],
+  ];
+
+  for (const [name, readings, expected] of cases) {
+    test(name, () => {
+      expect(classifyBrokerDegraded(readings, { graceMs: GRACE }).anomalous).toBe(expected);
+    });
+  }
+
+  test("reports the three component predicates for forensics", () => {
+    const v = classifyBrokerDegraded(
+      { interestCount: 0, uptimeMs: GRACE + 1, fleetActive: true },
+      { graceMs: GRACE },
+    );
+    expect(v).toEqual({
+      anomalous: true,
+      emptyInterests: true,
+      pastGrace: true,
+      fleetActive: true,
+    });
+  });
+
+  test("no-arg call is safe (never throws) and does not trip", () => {
+    expect(classifyBrokerDegraded().anomalous).toBe(false);
+  });
+});
+
+describe("classifyBrokerDegradedClear — the clear-side verdict (CTL-1523)", () => {
+  const cases = [
+    [
+      "interests came back → clear, reason 'interests registered'",
+      { interestCount: 2, fleetActive: true },
+      { clear: true, reason: "interests registered" },
+    ],
+    [
+      "fleet went idle → clear, reason 'fleet idle' (an idle fleet CLOSES an episode)",
+      { interestCount: 0, fleetActive: false },
+      { clear: true, reason: "fleet idle" },
+    ],
+    [
+      "both conditions → 'interests registered' wins (affirmative proof of life)",
+      { interestCount: 5, fleetActive: false },
+      { clear: true, reason: "interests registered" },
+    ],
+    [
+      "still empty AND still active → NOT clear (hold the episode)",
+      { interestCount: 0, fleetActive: true },
+      { clear: false, reason: null },
+    ],
+    [
+      "unknown activity with empty interests → clear (fail closed, same as trip side)",
+      { interestCount: 0, fleetActive: undefined },
+      { clear: true, reason: "fleet idle" },
+    ],
+  ];
+
+  for (const [name, readings, expected] of cases) {
+    test(name, () => {
+      expect(classifyBrokerDegradedClear(readings)).toEqual(expected);
+    });
+  }
+
+  test("trip and clear are mutually exclusive across the whole input grid", () => {
+    for (const interestCount of [0, 1]) {
+      for (const fleetActive of [true, false]) {
+        for (const uptimeMs of [0, GRACE + 1]) {
+          const { anomalous } = classifyBrokerDegraded(
+            { interestCount, uptimeMs, fleetActive },
+            { graceMs: GRACE },
+          );
+          const { clear } = classifyBrokerDegradedClear({ interestCount, fleetActive });
+          expect(anomalous && clear).toBe(false);
+        }
+      }
+    }
+  });
+});
+
+describe("nextBrokerDegradedSustained — the debounce counter (CTL-1523)", () => {
+  test("counts consecutive anomalous ticks", () => {
+    let n = 0;
+    for (const expected of [1, 2, 3]) {
+      n = nextBrokerDegradedSustained(n, true);
+      expect(n).toBe(expected);
+    }
+  });
+
+  test("any non-anomalous tick resets the run to 0 (must be contiguous)", () => {
+    let n = nextBrokerDegradedSustained(nextBrokerDegradedSustained(0, true), true);
+    expect(n).toBe(2);
+    n = nextBrokerDegradedSustained(n, false);
+    expect(n).toBe(0);
+    expect(nextBrokerDegradedSustained(n, true)).toBe(1);
+  });
+
+  test("a non-finite prior is treated as 0", () => {
+    expect(nextBrokerDegradedSustained(undefined, true)).toBe(1);
+    expect(nextBrokerDegradedSustained(NaN, false)).toBe(0);
+  });
+});
+
+describe("nextBrokerDegradedLatch — the edge state machine (CTL-1523)", () => {
+  const cases = [
+    ["unlatched + trip → degraded edge", false, { trip: true, clear: false }, { latched: true, emit: "degraded" }],
+    ["unlatched + nothing → no emit", false, { trip: false, clear: false }, { latched: false, emit: null }],
+    ["unlatched + clear → no emit (nothing to recover)", false, { trip: false, clear: true }, { latched: false, emit: null }],
+    ["latched + still tripping → NO re-emit", true, { trip: true, clear: false }, { latched: true, emit: null }],
+    ["latched + clear → recovered edge", true, { trip: false, clear: true }, { latched: false, emit: "recovered" }],
+    ["latched + neither → hold", true, { trip: false, clear: false }, { latched: true, emit: null }],
+  ];
+
+  for (const [name, prev, verdict, expected] of cases) {
+    test(name, () => {
+      expect(nextBrokerDegradedLatch(prev, verdict)).toEqual(expected);
+    });
+  }
+
+  test("a full episode emits exactly one degraded and one recovered", () => {
+    const emitted = [];
+    let latched = false;
+    // trip, hold ×3, then clear, then stay clear ×2
+    for (const v of [
+      { trip: true, clear: false },
+      { trip: true, clear: false },
+      { trip: true, clear: false },
+      { trip: false, clear: true },
+      { trip: false, clear: true },
+      { trip: false, clear: true },
+    ]) {
+      const r = nextBrokerDegradedLatch(latched, v);
+      latched = r.latched;
+      if (r.emit) emitted.push(r.emit);
+    }
+    expect(emitted).toEqual(["degraded", "recovered"]);
+  });
+
+  test("no-verdict call is safe and holds", () => {
+    expect(nextBrokerDegradedLatch(true)).toEqual({ latched: true, emit: null });
+  });
+});
+
+// ─── checkBrokerDegraded — the driver (CTL-1523) ─────────────────────────────
+// Direct coverage of the parts the pure-fn tables cannot reach: the EMIT-THEN-ADVANCE
+// contract (a failed or throwing append must NOT advance the latch, so the edge
+// retries next tick), the `if (!ok) return null` guard, and hydrateLatch()'s
+// tolerance of an absent/corrupt marker. No DB, no router, no event log — the emit
+// side effect is an injected stub and CATALYST_DIR points at an mkdtemp so the
+// durable marker is isolated. Idiom model: execution-core/fleet-health-probe.test.mjs
+// ("a failed emit (append returns false) does NOT advance the latch").
+describe("checkBrokerDegraded — the driver's failure semantics (CTL-1523)", () => {
+  let dir;
+  let prevCatalystDir;
+  let prevEnabled;
+
+  // Readings that trip the gate (empty interests, past grace, fleet working) and the
+  // readings that clear it (fleet went idle).
+  const ANOMALOUS = { interestCount: 0, uptimeMs: GRACE + 1, fleetActive: true };
+  const IDLE = { interestCount: 0, uptimeMs: GRACE + 1, fleetActive: false };
+  // Every call pins the two knobs so the run does not depend on the deployed defaults.
+  const run = (readings, emit, { sustainedTicks = 1 } = {}) =>
+    checkBrokerDegraded({ ...readings, graceMs: GRACE, sustainedTicks, emit });
+
+  beforeEach(() => {
+    prevCatalystDir = process.env.CATALYST_DIR;
+    prevEnabled = process.env.FILTER_BROKER_DEGRADED_ENABLED;
+    dir = mkdtempSync(join(tmpdir(), "broker-degraded-driver-"));
+    process.env.CATALYST_DIR = dir;
+    // The detector is OPT-IN and dormant by default — arm it for these cases.
+    process.env.FILTER_BROKER_DEGRADED_ENABLED = "1";
+    __resetBrokerDegradedLatchForTest();
+  });
+  afterEach(() => {
+    __resetBrokerDegradedLatchForTest();
+    if (prevCatalystDir === undefined) delete process.env.CATALYST_DIR;
+    else process.env.CATALYST_DIR = prevCatalystDir;
+    if (prevEnabled === undefined) delete process.env.FILTER_BROKER_DEGRADED_ENABLED;
+    else process.env.FILTER_BROKER_DEGRADED_ENABLED = prevEnabled;
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  test("dormant by default: with the env UNSET the driver evaluates nothing", () => {
+    delete process.env.FILTER_BROKER_DEGRADED_ENABLED;
+    const calls = [];
+    expect(run(ANOMALOUS, (a) => (calls.push(a), true))).toBeNull();
+    expect(calls).toHaveLength(0);
+    expect(existsSync(getBrokerDegradedLatchPath())).toBe(false);
+  });
+
+  test("(1) a degraded edge whose emit RETURNS FALSE does not advance the latch — it retries", () => {
+    let ok = false;
+    const calls = [];
+    const emit = (payload) => {
+      calls.push(payload);
+      return ok;
+    };
+    // sustainedTicks=2 so the retry tick has a LIVE counter of 3 while the run that
+    // actually crossed the gate was 2 — the honest-`sustainedTicks` regression.
+    expect(run(ANOMALOUS, emit, { sustainedTicks: 2 })).toBeNull(); // tick 1: below threshold
+    expect(calls).toHaveLength(0);
+
+    expect(run(ANOMALOUS, emit, { sustainedTicks: 2 })).toBeNull(); // tick 2: edge, append FAILS
+    expect(calls).toHaveLength(1);
+    expect(calls[0].action).toBe("degraded");
+    expect(__getBrokerDegradedLatchForTest().latched).toBe(false); // latch did NOT advance
+    expect(existsSync(getBrokerDegradedLatchPath())).toBe(false); // and nothing persisted
+
+    ok = true;
+    expect(run(ANOMALOUS, emit, { sustainedTicks: 2 })).toBe("degraded"); // tick 3: retried
+    expect(calls).toHaveLength(2);
+    expect(calls[1].action).toBe("degraded");
+    // The reported run length is the one that CROSSED the gate, not the live counter
+    // (which is 3 by now) — a retry must not inflate the forensic detail.
+    expect(calls[1].detail.sustainedTicks).toBe(2);
+    expect(__getBrokerDegradedLatchForTest().latched).toBe(true);
+    expect(existsSync(getBrokerDegradedLatchPath())).toBe(true);
+  });
+
+  test("(2) a degraded edge whose emit THROWS is swallowed — null, latch unchanged, retries", () => {
+    const calls = [];
+    const throwing = (payload) => {
+      calls.push(payload);
+      throw new Error("ENOSPC: event log append failed");
+    };
+    expect(() => run(ANOMALOUS, throwing)).not.toThrow();
+    expect(run(ANOMALOUS, throwing)).toBeNull();
+    expect(__getBrokerDegradedLatchForTest().latched).toBe(false);
+    expect(existsSync(getBrokerDegradedLatchPath())).toBe(false);
+    expect(calls.length).toBeGreaterThanOrEqual(2); // attempted on every tick
+
+    const good = [];
+    expect(run(ANOMALOUS, (p) => (good.push(p), true))).toBe("degraded");
+    expect(good).toHaveLength(1);
+    expect(__getBrokerDegradedLatchForTest().latched).toBe(true);
+  });
+
+  test("(3) the CLEAR edge retries too: a throwing recovered leaves the episode LATCHED", () => {
+    expect(run(ANOMALOUS, () => true)).toBe("degraded");
+    expect(__getBrokerDegradedLatchForTest().latched).toBe(true);
+
+    const thrown = [];
+    const throwing = (payload) => {
+      thrown.push(payload);
+      throw new Error("append failed");
+    };
+    expect(() => run(IDLE, throwing)).not.toThrow();
+    expect(run(IDLE, throwing)).toBeNull();
+    expect(thrown[0].action).toBe("recovered");
+    // Still latched → the recovered is owed and will be re-attempted next tick.
+    expect(__getBrokerDegradedLatchForTest().latched).toBe(true);
+
+    const good = [];
+    expect(run(IDLE, (p) => (good.push(p), true))).toBe("recovered");
+    expect(good[0].detail.reason).toBe("fleet idle");
+    expect(__getBrokerDegradedLatchForTest().latched).toBe(false);
+    // …and it does not emit a second time.
+    expect(run(IDLE, () => true)).toBeNull();
+  });
+
+  test("(4a) an ABSENT marker hydrates as unlatched and produces no orphan recovered", () => {
+    expect(existsSync(getBrokerDegradedLatchPath())).toBe(false);
+    const calls = [];
+    // Clear-side readings on a fresh process: nothing was latched, so nothing recovers.
+    expect(run(IDLE, (p) => (calls.push(p), true))).toBeNull();
+    expect(calls).toHaveLength(0);
+    expect(__getBrokerDegradedLatchForTest().latched).toBe(false);
+  });
+
+  test("(4b) a CORRUPT marker is tolerated: unlatched, never throws, no orphan recovered", () => {
+    for (const garbage of ["{not json", "", "null", '{"latched":"yes"}', "[1,2,3]"]) {
+      __resetBrokerDegradedLatchForTest();
+      const path = getBrokerDegradedLatchPath();
+      mkdirSync(join(path, ".."), { recursive: true });
+      writeFileSync(path, garbage);
+
+      const calls = [];
+      let result;
+      expect(() => {
+        result = run(IDLE, (p) => (calls.push(p), true));
+      }).not.toThrow();
+      expect(result, `garbage: ${garbage}`).toBeNull();
+      expect(calls, `garbage: ${garbage}`).toHaveLength(0); // NO orphan "recovered"
+      expect(__getBrokerDegradedLatchForTest().latched).toBe(false);
+    }
+  });
+
+  test("(4c) a VALID latched marker hydrates the open episode — the recovered still fires", () => {
+    writeFileSync(
+      getBrokerDegradedLatchPath(),
+      JSON.stringify({ latched: true, latchedAtMs: Date.now() - 60_000, ts: Date.now() }),
+    );
+    const calls = [];
+    expect(run(IDLE, (p) => (calls.push(p), true))).toBe("recovered");
+    expect(calls[0].detail.reason).toBe("fleet idle");
+    expect(typeof calls[0].detail.degradedForMs).toBe("number");
+  });
+});
+
+describe("event names (CTL-1523)", () => {
+  test("both live in the broker.daemon protected space", () => {
+    expect(BROKER_DEGRADED_EVENT).toBe("broker.daemon.degraded");
+    expect(BROKER_RECOVERED_EVENT).toBe("broker.daemon.recovered");
+    for (const n of [BROKER_DEGRADED_EVENT, BROKER_RECOVERED_EVENT]) {
+      expect(n.startsWith("broker.daemon")).toBe(true);
+    }
+  });
+});

--- a/plugins/dev/scripts/broker/broker-degraded.test.mjs
+++ b/plugins/dev/scripts/broker/broker-degraded.test.mjs
@@ -10,7 +10,7 @@
 // Run: cd plugins/dev/scripts/broker && bun test broker-degraded.test.mjs
 
 import { describe, test, expect, beforeEach, afterEach } from "bun:test";
-import { mkdtempSync, rmSync, writeFileSync, existsSync, mkdirSync } from "node:fs";
+import { mkdtempSync, rmSync, writeFileSync, readFileSync, existsSync, mkdirSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import {
@@ -64,6 +64,13 @@ describe("classifyBrokerDegraded — the trip classifier (CTL-1523)", () => {
     [
       "fleetActive undefined (reader unavailable) → NOT anomalous (fail closed)",
       { interestCount: 0, uptimeMs: GRACE + 60_000, fleetActive: undefined },
+      false,
+    ],
+    [
+      // Review F2: null is the router's explicit UNKNOWN. Only a POSITIVE activity
+      // reading is evidence of an anomaly — unknown must never trip.
+      "fleetActive null (UNKNOWN — the activity read failed) → NOT anomalous",
+      { interestCount: 0, uptimeMs: GRACE + 60_000, fleetActive: null },
       false,
     ],
     [
@@ -124,10 +131,23 @@ describe("classifyBrokerDegradedClear — the clear-side verdict (CTL-1523)", ()
       { interestCount: 0, fleetActive: true },
       { clear: false, reason: null },
     ],
+    // Review F2: UNKNOWN activity is not "idle". Both edges demand positive
+    // evidence, so null/undefined can neither trip nor clear — a latched episode
+    // holds until the reading is trustworthy again.
     [
-      "unknown activity with empty interests → clear (fail closed, same as trip side)",
+      "UNKNOWN activity (null) with empty interests → NOT clear (the latch holds)",
+      { interestCount: 0, fleetActive: null },
+      { clear: false, reason: null },
+    ],
+    [
+      "UNKNOWN activity (undefined) with empty interests → NOT clear",
       { interestCount: 0, fleetActive: undefined },
-      { clear: true, reason: "fleet idle" },
+      { clear: false, reason: null },
+    ],
+    [
+      "UNKNOWN activity but interests came back → still clear (affirmative proof of life)",
+      { interestCount: 4, fleetActive: null },
+      { clear: true, reason: "interests registered" },
     ],
   ];
 
@@ -137,9 +157,9 @@ describe("classifyBrokerDegradedClear — the clear-side verdict (CTL-1523)", ()
     });
   }
 
-  test("trip and clear are mutually exclusive across the whole input grid", () => {
+  test("trip and clear are mutually exclusive across the whole tri-state input grid", () => {
     for (const interestCount of [0, 1]) {
-      for (const fleetActive of [true, false]) {
+      for (const fleetActive of [true, false, null]) {
         for (const uptimeMs of [0, GRACE + 1]) {
           const { anomalous } = classifyBrokerDegraded(
             { interestCount, uptimeMs, fleetActive },
@@ -149,6 +169,21 @@ describe("classifyBrokerDegradedClear — the clear-side verdict (CTL-1523)", ()
           expect(anomalous && clear).toBe(false);
         }
       }
+    }
+  });
+
+  // Review F2: the tri-state contract as one explicit statement — UNKNOWN activity
+  // with an empty table is the ONE grid cell where NEITHER edge holds. (Every other
+  // cell resolves to a trip, a clear, or a below-grace hold.)
+  test("UNKNOWN activity + empty interests past grace → NEITHER trip NOR clear", () => {
+    for (const unknown of [null, undefined]) {
+      const { anomalous } = classifyBrokerDegraded(
+        { interestCount: 0, uptimeMs: GRACE + 1, fleetActive: unknown },
+        { graceMs: GRACE },
+      );
+      const { clear } = classifyBrokerDegradedClear({ interestCount: 0, fleetActive: unknown });
+      expect(anomalous, `unknown: ${String(unknown)}`).toBe(false);
+      expect(clear, `unknown: ${String(unknown)}`).toBe(false);
     }
   });
 });
@@ -369,6 +404,200 @@ describe("checkBrokerDegraded — the driver's failure semantics (CTL-1523)", ()
     expect(run(IDLE, (p) => (calls.push(p), true))).toBe("recovered");
     expect(calls[0].detail.reason).toBe("fleet idle");
     expect(typeof calls[0].detail.degradedForMs).toBe("number");
+  });
+});
+
+// ─── Review F2: UNKNOWN activity must not move the latch ─────────────────────
+// The defect: fleetActivity() collapsed a failed worker-table read into `false`, so a
+// transient SQLite outage looked exactly like a proven-idle fleet — the detector
+// emitted a FALSE `recovered` (reason "fleet idle"), PERSISTED the cleared latch, and
+// then re-tripped the same uninterrupted episode once the DB came back. Driven here
+// end-to-end through checkBrokerDegraded, latch marker and all.
+describe("checkBrokerDegraded — UNKNOWN activity holds the latch (CTL-1523 review F2)", () => {
+  let dir;
+  let prevCatalystDir;
+  let prevEnabled;
+
+  const ANOMALOUS = { interestCount: 0, uptimeMs: GRACE + 1, fleetActive: true };
+  const IDLE = { interestCount: 0, uptimeMs: GRACE + 1, fleetActive: false };
+  const UNKNOWN = { interestCount: 0, uptimeMs: GRACE + 1, fleetActive: null };
+  const run = (readings, emit, { sustainedTicks = 1 } = {}) =>
+    checkBrokerDegraded({ ...readings, graceMs: GRACE, sustainedTicks, emit });
+
+  beforeEach(() => {
+    prevCatalystDir = process.env.CATALYST_DIR;
+    prevEnabled = process.env.FILTER_BROKER_DEGRADED_ENABLED;
+    dir = mkdtempSync(join(tmpdir(), "broker-degraded-tristate-"));
+    process.env.CATALYST_DIR = dir;
+    process.env.FILTER_BROKER_DEGRADED_ENABLED = "1";
+    __resetBrokerDegradedLatchForTest();
+  });
+  afterEach(() => {
+    __resetBrokerDegradedLatchForTest();
+    if (prevCatalystDir === undefined) delete process.env.CATALYST_DIR;
+    else process.env.CATALYST_DIR = prevCatalystDir;
+    if (prevEnabled === undefined) delete process.env.FILTER_BROKER_DEGRADED_ENABLED;
+    else process.env.FILTER_BROKER_DEGRADED_ENABLED = prevEnabled;
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  test("(a) LATCHED + activity UNKNOWN → no event, and the episode stays latched", () => {
+    expect(run(ANOMALOUS, () => true)).toBe("degraded");
+    expect(__getBrokerDegradedLatchForTest().latched).toBe(true);
+
+    // The DB read starts failing. Many ticks of pure ignorance must change nothing.
+    const calls = [];
+    for (let i = 0; i < 10; i++) {
+      expect(run(UNKNOWN, (p) => (calls.push(p), true))).toBeNull();
+    }
+    expect(calls).toHaveLength(0); // NO false "recovered"
+    expect(__getBrokerDegradedLatchForTest().latched).toBe(true);
+    // …and the DURABLE marker still records the open episode, so a restart mid-outage
+    // resumes it rather than re-emitting a duplicate degraded.
+    expect(JSON.parse(readFileSync(getBrokerDegradedLatchPath(), "utf8")).latched).toBe(true);
+  });
+
+  test("(b) LATCHED + activity PROVEN idle → exactly one recovered", () => {
+    expect(run(ANOMALOUS, () => true)).toBe("degraded");
+
+    const calls = [];
+    const emit = (p) => (calls.push(p), true);
+    expect(run(IDLE, emit)).toBe("recovered");
+    expect(calls).toHaveLength(1);
+    expect(calls[0].detail.reason).toBe("fleet idle");
+    expect(__getBrokerDegradedLatchForTest().latched).toBe(false);
+    // Idempotent: further idle ticks do not re-emit.
+    for (let i = 0; i < 3; i++) expect(run(IDLE, emit)).toBeNull();
+    expect(calls).toHaveLength(1);
+  });
+
+  test("(b') the DB recovers to idle after an unknown window → ONE recovered, not two edges", () => {
+    expect(run(ANOMALOUS, () => true)).toBe("degraded");
+    const calls = [];
+    const emit = (p) => (calls.push(p), true);
+    for (let i = 0; i < 5; i++) run(UNKNOWN, emit); // outage
+    expect(calls).toHaveLength(0);
+    expect(run(IDLE, emit)).toBe("recovered"); // DB back, fleet genuinely idle
+    expect(calls.map((c) => c.action)).toEqual(["recovered"]);
+  });
+
+  test("(b'') the DB recovers to STILL-ANOMALOUS → no duplicate degraded (still latched)", () => {
+    expect(run(ANOMALOUS, () => true)).toBe("degraded");
+    const calls = [];
+    const emit = (p) => (calls.push(p), true);
+    for (let i = 0; i < 5; i++) run(UNKNOWN, emit);
+    // The condition never actually went away — the latch held through the blind
+    // window, so the reappearing anomaly is the SAME episode, not a new edge.
+    for (let i = 0; i < 5; i++) expect(run(ANOMALOUS, emit)).toBeNull();
+    expect(calls).toHaveLength(0);
+    expect(__getBrokerDegradedLatchForTest().latched).toBe(true);
+  });
+
+  test("(c) UNLATCHED + activity UNKNOWN + empty interests past grace → NEVER trips", () => {
+    const calls = [];
+    const emit = (p) => (calls.push(p), true);
+    // sustainedTicks=1 (the most trip-happy setting there is) and 50 ticks: unknown
+    // activity is not evidence, so no number of ticks can manufacture an alarm.
+    for (let i = 0; i < 50; i++) {
+      expect(run(UNKNOWN, emit, { sustainedTicks: 1 })).toBeNull();
+    }
+    expect(calls).toHaveLength(0);
+    expect(__getBrokerDegradedLatchForTest().latched).toBe(false);
+    expect(existsSync(getBrokerDegradedLatchPath())).toBe(false);
+  });
+});
+
+// ─── Review F4: the debounce must not survive a disabled interval ────────────
+describe("checkBrokerDegraded — disabling discards the debounce run (CTL-1523 review F4)", () => {
+  let dir;
+  let prevCatalystDir;
+  let prevEnabled;
+
+  const ANOMALOUS = { interestCount: 0, uptimeMs: GRACE + 1, fleetActive: true };
+  const IDLE = { interestCount: 0, uptimeMs: GRACE + 1, fleetActive: false };
+  const SUSTAINED = 5;
+  const run = (readings, emit) =>
+    checkBrokerDegraded({ ...readings, graceMs: GRACE, sustainedTicks: SUSTAINED, emit });
+
+  beforeEach(() => {
+    prevCatalystDir = process.env.CATALYST_DIR;
+    prevEnabled = process.env.FILTER_BROKER_DEGRADED_ENABLED;
+    dir = mkdtempSync(join(tmpdir(), "broker-degraded-f4-"));
+    process.env.CATALYST_DIR = dir;
+    process.env.FILTER_BROKER_DEGRADED_ENABLED = "1";
+    __resetBrokerDegradedLatchForTest();
+  });
+  afterEach(() => {
+    __resetBrokerDegradedLatchForTest();
+    if (prevCatalystDir === undefined) delete process.env.CATALYST_DIR;
+    else process.env.CATALYST_DIR = prevCatalystDir;
+    if (prevEnabled === undefined) delete process.env.FILTER_BROKER_DEGRADED_ENABLED;
+    else process.env.FILTER_BROKER_DEGRADED_ENABLED = prevEnabled;
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  // The exact reported sequence: 4 anomalous ticks (one short of the threshold) →
+  // DISABLE → conditions clear → RE-ENABLE during a NEW anomaly. Before the fix the
+  // stale counter carried over and the very first tick of the new condition emitted
+  // degraded after ONE observed tick instead of five.
+  test("4 anomalous ticks → disable → clear → re-enable: the new run re-earns all 5 ticks", () => {
+    const calls = [];
+    const emit = (p) => (calls.push(p), true);
+
+    for (let i = 0; i < SUSTAINED - 1; i++) expect(run(ANOMALOUS, emit)).toBeNull();
+    expect(__getBrokerDegradedLatchForTest().sustained).toBe(SUSTAINED - 1);
+
+    // Operator flips the detector off. The unfinished run is discarded on the spot.
+    process.env.FILTER_BROKER_DEGRADED_ENABLED = "0";
+    expect(run(ANOMALOUS, emit)).toBeNull();
+    expect(__getBrokerDegradedLatchForTest().sustained).toBe(0);
+    expect(__getBrokerDegradedLatchForTest().tripRunLength).toBeNull();
+
+    // Conditions clear while disabled, then a NEW anomaly begins and the detector is
+    // re-enabled part-way into it.
+    run(IDLE, emit);
+    process.env.FILTER_BROKER_DEGRADED_ENABLED = "1";
+
+    // The first four ticks of the NEW condition must stay silent…
+    for (let i = 0; i < SUSTAINED - 1; i++) expect(run(ANOMALOUS, emit)).toBeNull();
+    expect(calls).toHaveLength(0);
+    // …and only the fifth trips, reporting an honest run length of 5.
+    expect(run(ANOMALOUS, emit)).toBe("degraded");
+    expect(calls).toHaveLength(1);
+    expect(calls[0].detail.sustainedTicks).toBe(SUSTAINED);
+  });
+
+  test("a single disabled tick mid-run resets the counter (the run must be contiguous AND armed)", () => {
+    const emit = () => true;
+    for (let i = 0; i < SUSTAINED - 1; i++) run(ANOMALOUS, emit);
+    process.env.FILTER_BROKER_DEGRADED_ENABLED = "0";
+    run(ANOMALOUS, emit);
+    process.env.FILTER_BROKER_DEGRADED_ENABLED = "1";
+    // Immediately re-armed and still anomalous: this is tick 1 of a fresh run, so the
+    // next SUSTAINED-1 ticks must remain silent.
+    for (let i = 0; i < SUSTAINED - 1; i++) expect(run(ANOMALOUS, emit)).toBeNull();
+    expect(run(ANOMALOUS, emit)).toBe("degraded");
+  });
+
+  test("an OPEN episode SURVIVES a disabled interval — the durable latch is untouched", () => {
+    const emit = () => true;
+    for (let i = 0; i < SUSTAINED; i++) run(ANOMALOUS, emit);
+    expect(__getBrokerDegradedLatchForTest().latched).toBe(true);
+
+    process.env.FILTER_BROKER_DEGRADED_ENABLED = "0";
+    const whileOff = [];
+    for (let i = 0; i < 5; i++) {
+      expect(run(IDLE, (p) => (whileOff.push(p), true))).toBeNull();
+    }
+    expect(whileOff).toHaveLength(0); // inert while off
+    expect(__getBrokerDegradedLatchForTest().latched).toBe(true); // episode preserved
+    expect(JSON.parse(readFileSync(getBrokerDegradedLatchPath(), "utf8")).latched).toBe(true);
+
+    // Re-armed: the owed `recovered` still fires, so the ledger stays balanced.
+    process.env.FILTER_BROKER_DEGRADED_ENABLED = "1";
+    const calls = [];
+    expect(run(IDLE, (p) => (calls.push(p), true))).toBe("recovered");
+    expect(calls[0].detail.reason).toBe("fleet idle");
   });
 });
 

--- a/plugins/dev/scripts/broker/config.mjs
+++ b/plugins/dev/scripts/broker/config.mjs
@@ -163,31 +163,43 @@ export const PILEUP_COOLDOWN_MS = parseIntKnob(process.env.FILTER_PILEUP_COOLDOW
 // and then deliberately parked). OPT-IN: unset (the default) means the detector
 // evaluates nothing and emits nothing.
 //
-// WHY DORMANT BY DEFAULT. In `phase-agents` mode the trip condition carries no
-// information, because one of its two conjuncts is PERMANENTLY true:
-// `interests.size === 0` can never be false. Interest registration is legacy-only —
-// every `filter.register` producer lives in plugins/legacy/, dormant since the
-// 2026-06-07 cutover — and neither in-router auto-register path can break the tie:
-// `_autoRegisterPrLifecycle` only fires when an agent reports a claimed_pr, and
-// `_autoPrLifecycleFromTicket` only fires when an EXISTING interest already watches
-// the ticket, so an empty table stays empty. With that conjunct pinned true the gate
-// degenerates to "the fleet has been active for N contiguous ticks", which would emit
-// roughly one degraded/recovered pair per busy/idle cycle — trading the CTL-352
-// restart-driven false positive for a busy-window-driven one. Not a trade worth making.
+// WHY DORMANT BY DEFAULT. Under EXECUTION-CORE DISPATCH the trip condition carries
+// no information, because one of its two conjuncts is PERMANENTLY true:
+// `interests.size === 0` can never be false. The execution-core daemon runs no
+// `filter.register` producer at all, and neither in-router auto-register path can
+// break the tie: `_autoRegisterPrLifecycle` only fires when an agent reports a
+// claimed_pr, and `_autoPrLifecycleFromTicket` only fires when an EXISTING interest
+// already watches the ticket, so an empty table stays empty. With that conjunct
+// pinned true the gate degenerates to "the fleet has been active for N contiguous
+// ticks", which would emit roughly one degraded/recovered pair per busy/idle cycle —
+// trading the CTL-352 restart-driven false positive for a busy-window-driven one.
+// Not a trade worth making, and execution-core is what every current host runs.
 //
-// WHY IT IS KEPT. Legacy wave-orchestration mode (plugins/legacy, dispatchMode
-// `oneshot-legacy`) DOES register interests, so there the empty-table conjunct is
-// genuinely discriminating and the detector is meaningful — flip
-// FILTER_BROKER_DEGRADED_ENABLED=1 on such a host.
+// WHY IT IS KEPT — and where to enable it. The empty-table property belongs to
+// execution-core dispatch, NOT to every configuration named `phase-agents`. A
+// LEGACY-WAVE host (one driving `/catalyst-legacy:orchestrate`, which invokes
+// plugins/dev/scripts/orchestrate-register-interests.sh) DOES register interests:
+// that script emits pr_lifecycle + ticket_lifecycle + comms_lifecycle
+// UNCONDITIONALLY, plus a per-ticket phase_lifecycle interest when `dispatchMode` is
+// `phase-agents`. On such a host an empty interest table IS anomalous, the conjunct
+// genuinely discriminates, and FILTER_BROKER_DEGRADED_ENABLED=1 is appropriate.
 //
-// THE REAL DEAD-BROKER DETECTOR IS ELSEWHERE, and is unaffected by this knob:
-// CTL-1122's `checkSourceRecency` over RECENCY_SOURCES (router.mjs) watches actual
-// ingestion recency and emits `catalyst.ingestion.stale` +
-// `catalyst.alert.raised(system_down)` when ingestion really stops. That is the
-// signal to trust for "is the broker silently dead".
+// THIS IS NOT A DEAD-BROKER DETECTOR — and neither is CTL-1122's `checkSourceRecency`
+// over RECENCY_SOURCES (router.mjs), despite both living in this process. That is the
+// point: BOTH run INSIDE the broker, so once the broker dies neither can emit
+// anything. checkSourceRecency detects an ingestion STALL (an upstream source —
+// monitor/GitHub — gone silent) while the broker is ALIVE, emitting
+// `catalyst.ingestion.stale` + `catalyst.alert.raised(system_down)`; that is the
+// signal to trust for "has ingestion stopped". Detecting a FULLY DEAD broker requires
+// an EXTERNAL absence check on the broker's own heartbeat/log series — a Loki
+// `absent_over_time` alert on `broker.daemon.heartbeat` or the broker `.log` stream
+// (absence, because a dead daemon is a MISSING series that `count_over_time == 0`
+// cannot assert).
 //
 // The check is call-time (parity with isAlertEmitEnabled) so an operator can flip it
-// without a broker restart.
+// without a broker restart. Flipping it OFF discards any in-progress debounce run,
+// so a re-enable always re-earns the full sustained-tick threshold; an already-open
+// episode survives the switch and still emits its paired `recovered`.
 export function isBrokerDegradedDetectorEnabled() {
   return process.env.FILTER_BROKER_DEGRADED_ENABLED === "1";
 }

--- a/plugins/dev/scripts/broker/config.mjs
+++ b/plugins/dev/scripts/broker/config.mjs
@@ -159,6 +159,48 @@ export const PILEUP_THRESHOLD = parseIntKnob(process.env.FILTER_PILEUP_THRESHOLD
 export const PILEUP_PERSISTENCE_MS = parseIntKnob(process.env.FILTER_PILEUP_PERSISTENCE_MS, 300000, { min: 0 });
 export const PILEUP_COOLDOWN_MS = parseIntKnob(process.env.FILTER_PILEUP_COOLDOWN_MS, 3600000, { min: 0 });
 
+// CTL-1523: broker-degraded detector (the CTL-352 empty-interests signal, fixed —
+// and then deliberately parked). OPT-IN: unset (the default) means the detector
+// evaluates nothing and emits nothing.
+//
+// WHY DORMANT BY DEFAULT. In `phase-agents` mode the trip condition carries no
+// information, because one of its two conjuncts is PERMANENTLY true:
+// `interests.size === 0` can never be false. Interest registration is legacy-only —
+// every `filter.register` producer lives in plugins/legacy/, dormant since the
+// 2026-06-07 cutover — and neither in-router auto-register path can break the tie:
+// `_autoRegisterPrLifecycle` only fires when an agent reports a claimed_pr, and
+// `_autoPrLifecycleFromTicket` only fires when an EXISTING interest already watches
+// the ticket, so an empty table stays empty. With that conjunct pinned true the gate
+// degenerates to "the fleet has been active for N contiguous ticks", which would emit
+// roughly one degraded/recovered pair per busy/idle cycle — trading the CTL-352
+// restart-driven false positive for a busy-window-driven one. Not a trade worth making.
+//
+// WHY IT IS KEPT. Legacy wave-orchestration mode (plugins/legacy, dispatchMode
+// `oneshot-legacy`) DOES register interests, so there the empty-table conjunct is
+// genuinely discriminating and the detector is meaningful — flip
+// FILTER_BROKER_DEGRADED_ENABLED=1 on such a host.
+//
+// THE REAL DEAD-BROKER DETECTOR IS ELSEWHERE, and is unaffected by this knob:
+// CTL-1122's `checkSourceRecency` over RECENCY_SOURCES (router.mjs) watches actual
+// ingestion recency and emits `catalyst.ingestion.stale` +
+// `catalyst.alert.raised(system_down)` when ingestion really stops. That is the
+// signal to trust for "is the broker silently dead".
+//
+// The check is call-time (parity with isAlertEmitEnabled) so an operator can flip it
+// without a broker restart.
+export function isBrokerDegradedDetectorEnabled() {
+  return process.env.FILTER_BROKER_DEGRADED_ENABLED === "1";
+}
+// Startup grace before an empty interest table can be judged at all (unchanged
+// 5-minute default — it was the CTL-352 DEGRADED_THRESHOLD_MS).
+export const BROKER_DEGRADED_GRACE_MS = parseIntKnob(
+  process.env.FILTER_BROKER_DEGRADED_GRACE_MS, 300000, { min: 0 });
+// Consecutive anomalous watchdog ticks (~60s each) required before the degraded
+// edge fires — a single-tick blip (e.g. a worker row that just went fresh while
+// interests are mid-reload) must not page.
+export const BROKER_DEGRADED_SUSTAINED_TICKS = parseIntKnob(
+  process.env.FILTER_BROKER_DEGRADED_SUSTAINED_TICKS, 5, { min: 1 });
+
 // --- Event log ---
 export function getEventLogPath() {
   const now = new Date();

--- a/plugins/dev/scripts/broker/config.mjs
+++ b/plugins/dev/scripts/broker/config.mjs
@@ -196,8 +196,12 @@ export const PILEUP_COOLDOWN_MS = parseIntKnob(process.env.FILTER_PILEUP_COOLDOW
 // (absence, because a dead daemon is a MISSING series that `count_over_time == 0`
 // cannot assert).
 //
-// The check is call-time (parity with isAlertEmitEnabled) so an operator can flip it
-// without a broker restart. Flipping it OFF discards any in-progress debounce run,
+// The check is call-time (parity with isAlertEmitEnabled), so it takes effect without
+// a code reload — but changing it STILL REQUIRES A BROKER RESTART (Codex P2, #2740).
+// A running daemon's process.env is fixed at launch and nothing in this repo mutates
+// the flag at runtime, so editing the env file or exporting in a shell does not reach
+// a live broker; without the restart an operator can believe the detector is armed
+// while it is still dormant. Flipping it OFF discards any in-progress debounce run,
 // so a re-enable always re-earns the full sustained-tick threshold; an already-open
 // episode survives the switch and still emits its paired `recovered`.
 export function isBrokerDegradedDetectorEnabled() {

--- a/plugins/dev/scripts/broker/config.mjs
+++ b/plugins/dev/scripts/broker/config.mjs
@@ -143,9 +143,23 @@ export function isAlertEmitEnabled() {
 // FILTER_PILEUP_THRESHOLD=abc → NaN → `count >= NaN` is always false → the
 // detector silently never fires; =0 → always true → a spurious pile-up on an
 // empty board. A bad value falls back to the default and is logged loudly.
-function parseIntKnob(envVal, dflt, { min }) {
+//
+// WHOLE-STRING VALIDATION (Codex round 3). `parseInt` is PREFIX-lenient: "1.5" and
+// "1garbage" both parse as 1, so a partially-parsed value slipped through as a
+// plausible-looking number and the warn path never ran. For
+// FILTER_BROKER_DEGRADED_SUSTAINED_TICKS that silently ELIMINATED the debounce —
+// the detector fired after ONE anomalous tick instead of the documented 5, while
+// the operator read the env file and believed otherwise. Every knob routed through
+// this helper is a whole integer (a millisecond count or a tick count); none has a
+// unit suffix or a fractional form, so requiring the WHOLE (trimmed) string to be
+// an integer changes nothing for any realistic existing value and routes typos to
+// the warn + default path that already exists for NaN.
+export function parseIntKnob(envVal, dflt, { min = 0 } = {}) {
   if (envVal === undefined) return dflt;
-  const n = parseInt(envVal, 10);
+  const raw = typeof envVal === "string" ? envVal.trim() : envVal;
+  // Reject "" / "   " / "1.5" / "1garbage" / "abc" / "1e5" — anything that is not
+  // exactly an optionally-signed run of digits.
+  const n = /^[+-]?\d+$/.test(String(raw)) ? Number(raw) : NaN;
   if (!Number.isFinite(n) || n < min) {
     log.warn({ envVal, dflt, min }, "alert config: invalid knob value — using default");
     return dflt;

--- a/plugins/dev/scripts/broker/config.test.mjs
+++ b/plugins/dev/scripts/broker/config.test.mjs
@@ -1,6 +1,6 @@
 // config.test.mjs — CTL-1086 broker config unit tests.
 import { describe, expect, test } from "bun:test";
-import { getEventLogPath } from "./config.mjs";
+import { getEventLogPath, parseIntKnob } from "./config.mjs";
 
 describe("CTL-1086: broker config", () => {
   test("getEventLogPath uses UTC year-month (parity with execution-core/config.mjs)", () => {
@@ -13,5 +13,45 @@ describe("CTL-1086: broker config", () => {
     } finally {
       process.env.CATALYST_DIR = prev;
     }
+  });
+});
+
+// CTL-1523 / Codex round 3 (T7). parseIntKnob is the SHARED validator behind every
+// int env knob in this module (PILEUP_{THRESHOLD,PERSISTENCE_MS,COOLDOWN_MS} and
+// BROKER_DEGRADED_{GRACE_MS,SUSTAINED_TICKS}). It used `parseInt`, which is
+// PREFIX-lenient — "1.5" and "1garbage" both come back as 1 — so a partially-parsed
+// value sailed past the warn-and-default path. For
+// FILTER_BROKER_DEGRADED_SUSTAINED_TICKS that silently eliminated the debounce: the
+// detector fired after a single anomalous tick instead of the documented 5.
+describe("CTL-1523: parseIntKnob rejects partially-parsed values", () => {
+  test("a well-formed integer parses (the happy path is unchanged)", () => {
+    expect(parseIntKnob("7", 5, { min: 1 })).toBe(7);
+    expect(parseIntKnob("300000", 1, { min: 0 })).toBe(300000);
+    expect(parseIntKnob(" 7 ", 5, { min: 1 })).toBe(7); // surrounding whitespace is fine
+    expect(parseIntKnob("+7", 5, { min: 1 })).toBe(7);
+  });
+
+  test("an UNSET knob is the default (not a malformed value)", () => {
+    expect(parseIntKnob(undefined, 5, { min: 1 })).toBe(5);
+  });
+
+  for (const bad of ["1.5", "1garbage", "", "  ", "abc", "-1"]) {
+    test(`${JSON.stringify(bad)} falls back to the default`, () => {
+      expect(parseIntKnob(bad, 5, { min: 1 })).toBe(5);
+    });
+  }
+
+  test("THE REGRESSION: SUSTAINED_TICKS='1.5' no longer collapses the debounce to 1", () => {
+    // What parseInt did — the silent single-tick detector.
+    expect(parseInt("1.5", 10)).toBe(1);
+    expect(parseInt("1garbage", 10)).toBe(1);
+    // What the knob now does: keep the documented 5-tick debounce.
+    expect(parseIntKnob("1.5", 5, { min: 1 })).toBe(5);
+    expect(parseIntKnob("1garbage", 5, { min: 1 })).toBe(5);
+  });
+
+  test("'-1' is rejected by the BOUND, not by its sign — a negative min accepts it", () => {
+    expect(parseIntKnob("-1", 5, { min: 0 })).toBe(5);
+    expect(parseIntKnob("-1", 5, { min: -5 })).toBe(-1);
   });
 });

--- a/plugins/dev/scripts/broker/index.mjs
+++ b/plugins/dev/scripts/broker/index.mjs
@@ -110,10 +110,26 @@ export {
   clearOrchestratorStatusMap,
   __setBrokerStartedAtForTest,
   __resetBrokerStartedAtForTest,
-  __resetDegradedEmittedForTest,
   __setHeartbeatForTest,
   __resetBrokerLivenessForTest,
 } from "./state.mjs";
+// CTL-1523: broker-degraded detector. The barrel rule for this module is
+// DRIVER + EVENT NAMES + RESET SEAM only — the pure classifiers/counters
+// (classifyBrokerDegraded, classifyBrokerDegradedClear, nextBrokerDegradedSustained,
+// nextBrokerDegradedLatch) and the path/inspection helpers stay module-private and
+// are imported directly from ./broker-degraded.mjs by their unit tests. That keeps
+// the public surface of a detector that is dormant by default minimal and internally
+// consistent (the previous 3-of-4 split exported some classifiers and not others).
+// The legacy barrel name (__resetDegradedEmittedForTest, once state.mjs's one-shot
+// guard) is preserved as an ALIAS over the new seam so callers keep working against
+// ONE chokepoint.
+export {
+  __resetBrokerDegradedLatchForTest,
+  __resetBrokerDegradedLatchForTest as __resetDegradedEmittedForTest,
+  checkBrokerDegraded,
+  BROKER_DEGRADED_EVENT,
+  BROKER_RECOVERED_EVENT,
+} from "./broker-degraded.mjs";
 export {
   saveInterests,
   loadPersistedInterests,

--- a/plugins/dev/scripts/broker/index.test.mjs
+++ b/plugins/dev/scripts/broker/index.test.mjs
@@ -2823,8 +2823,9 @@ describe("CTL-352 broker state + degraded event", () => {
   const logPathNow = () => join(tmpDir, "events", `${new Date().toISOString().slice(0, 7)}.jsonl`);
 
   // CTL-1523: the detector is OPT-IN and dormant by default (an empty interest table
-  // carries no information in phase-agents mode — see config.mjs), so every test in
-  // this block that expects an emit must arm it explicitly.
+  // carries no information under execution-core dispatch, which registers no
+  // interests at all — see config.mjs), so every test in this block that expects an
+  // emit must arm it explicitly.
   let prevDegradedEnabled;
 
   beforeEach(async () => {

--- a/plugins/dev/scripts/broker/index.test.mjs
+++ b/plugins/dev/scripts/broker/index.test.mjs
@@ -45,6 +45,7 @@ import {
   getTicketState,
   getWaitingSession,
   getActiveWaitingSessions,
+  upsertWorkerState,
 } from "./broker-state.mjs";
 
 // ─── Shared DB setup ─────────────────────────────────────────────────────────
@@ -2779,15 +2780,71 @@ describe("CTL-352 saveInterests guards", () => {
 
 describe("CTL-352 broker state + degraded event", () => {
   const STATE_FILE = () => join(tmpDir, "broker.state.json");
+  // CTL-1523: degraded now requires an ACTIVE fleet (the discriminator that tells a
+  // silently-dead broker from a correctly-idle one) sustained over N ticks, and its
+  // latch is durable — so these tests seed a worker row, tick N times, and reset the
+  // latch between tests (it is no longer part of __resetBrokerLivenessForTest).
+  const seedActiveWorker = (ticket = "CTL-352") =>
+    upsertWorkerState({
+      orchestrator: "o",
+      ticket,
+      status: "implement",
+      eventId: `e-${ticket}`,
+      eventTs: new Date().toISOString(),
+    });
+  const degradedLinesIn = (logPath) => {
+    if (!existsSync(logPath)) return [];
+    return readFileSync(logPath, "utf8")
+      .trim()
+      .split("\n")
+      .filter(Boolean)
+      .filter((l) => {
+        try {
+          return JSON.parse(l).attributes?.["event.name"] === "broker.daemon.degraded";
+        } catch {
+          return false;
+        }
+      });
+  };
+  const recoveredLinesIn = (logPath) => {
+    if (!existsSync(logPath)) return [];
+    return readFileSync(logPath, "utf8")
+      .trim()
+      .split("\n")
+      .filter(Boolean)
+      .filter((l) => {
+        try {
+          return JSON.parse(l).attributes?.["event.name"] === "broker.daemon.recovered";
+        } catch {
+          return false;
+        }
+      });
+  };
+  const logPathNow = () => join(tmpDir, "events", `${new Date().toISOString().slice(0, 7)}.jsonl`);
+
+  // CTL-1523: the detector is OPT-IN and dormant by default (an empty interest table
+  // carries no information in phase-agents mode — see config.mjs), so every test in
+  // this block that expects an emit must arm it explicitly.
+  let prevDegradedEnabled;
 
   beforeEach(async () => {
-    const { __resetBrokerLivenessForTest } = await import("./index.mjs");
+    prevDegradedEnabled = process.env.FILTER_BROKER_DEGRADED_ENABLED;
+    process.env.FILTER_BROKER_DEGRADED_ENABLED = "1";
+    const { __resetBrokerLivenessForTest, __resetBrokerDegradedLatchForTest } = await import(
+      "./index.mjs"
+    );
     __resetBrokerLivenessForTest();
+    __resetBrokerDegradedLatchForTest();
   });
 
   afterEach(async () => {
-    const { __resetBrokerLivenessForTest } = await import("./index.mjs");
+    if (prevDegradedEnabled === undefined) delete process.env.FILTER_BROKER_DEGRADED_ENABLED;
+    else process.env.FILTER_BROKER_DEGRADED_ENABLED = prevDegradedEnabled;
+    const { __resetBrokerLivenessForTest, __resetBrokerDegradedLatchForTest } = await import(
+      "./index.mjs"
+    );
     __resetBrokerLivenessForTest();
+    __resetBrokerDegradedLatchForTest();
   });
 
   test("buildBrokerState includes interestCount, lastWakeAt, lastRegisterAt", async () => {
@@ -2852,94 +2909,81 @@ describe("CTL-352 broker state + degraded event", () => {
     expect(typeof after).toBe("string");
   });
 
-  test("broker.daemon.degraded emitted once when interests empty and uptime > 5 min", async () => {
+  test("broker.daemon.degraded emitted once when interests empty, fleet active, uptime > 5 min", async () => {
     const { runWatchdogTick, __setBrokerStartedAtForTest, getInterests } = await import(
       "./index.mjs"
     );
+    const { BROKER_DEGRADED_SUSTAINED_TICKS } = await import("./config.mjs");
     clearInterests();
+    seedActiveWorker(); // CTL-1523: the discriminator — a genuinely in-flight fleet
     const sixMinAgo = new Date(Date.now() - 6 * 60 * 1000).toISOString();
     __setBrokerStartedAtForTest(sixMinAgo);
 
-    runWatchdogTick();
-    runWatchdogTick();
-    runWatchdogTick();
+    for (let i = 0; i < BROKER_DEGRADED_SUSTAINED_TICKS + 2; i++) runWatchdogTick();
 
-    // Read the month event log; assert exactly one degraded event.
-    const ym = new Date().toISOString().slice(0, 7);
-    const logPath = join(tmpDir, "events", `${ym}.jsonl`);
+    // Read the month event log; assert exactly one degraded event (edge-triggered).
+    const logPath = logPathNow();
     expect(existsSync(logPath)).toBe(true);
-    const lines = readFileSync(logPath, "utf8").trim().split("\n").filter(Boolean);
-    const degradedLines = lines.filter((l) => {
-      try {
-        const evt = JSON.parse(l);
-        return evt.attributes?.["event.name"] === "broker.daemon.degraded";
-      } catch {
-        return false;
-      }
-    });
+    const degradedLines = degradedLinesIn(logPath);
     expect(degradedLines).toHaveLength(1);
     const evt = JSON.parse(degradedLines[0]);
     expect(evt.severityText).toBe("WARN");
-    expect(evt.body.payload.reason).toBe("no registered interests");
+    expect(evt.body.payload.reason).toBe("no registered interests while fleet is active");
+    expect(evt.body.payload.activeWorkers).toBe(true);
     expect(typeof evt.body.payload.uptimeMs).toBe("number");
     expect(getInterests().size).toBe(0);
   });
 
   test("degraded NOT emitted within the 5-minute startup grace", async () => {
     const { runWatchdogTick, __setBrokerStartedAtForTest } = await import("./index.mjs");
+    const { BROKER_DEGRADED_SUSTAINED_TICKS } = await import("./config.mjs");
     clearInterests();
+    seedActiveWorker(); // fleet IS active — only the grace holds the emit back
     const oneMinAgo = new Date(Date.now() - 60 * 1000).toISOString();
     __setBrokerStartedAtForTest(oneMinAgo);
 
-    runWatchdogTick();
+    for (let i = 0; i < BROKER_DEGRADED_SUSTAINED_TICKS + 2; i++) runWatchdogTick();
 
-    const ym = new Date().toISOString().slice(0, 7);
-    const logPath = join(tmpDir, "events", `${ym}.jsonl`);
-    if (!existsSync(logPath)) return; // no events at all — vacuously fine
-    const lines = readFileSync(logPath, "utf8").trim().split("\n").filter(Boolean);
-    const degradedLines = lines.filter((l) => {
-      try {
-        return JSON.parse(l).attributes?.["event.name"] === "broker.daemon.degraded";
-      } catch {
-        return false;
-      }
-    });
-    expect(degradedLines).toHaveLength(0);
+    expect(degradedLinesIn(logPathNow())).toHaveLength(0);
   });
 
-  test("degraded re-arms after interests come back and go empty again", async () => {
+  // CTL-1523: this was "degraded re-arms after interests come back and go empty
+  // again" asserting toHaveLength(2) off two bare ticks — which is exactly the
+  // silent re-arm the fix removes. Re-arming is still supported, but it now runs
+  // through the LEDGER: degraded → (interests return) recovered → (empty again,
+  // sustained) degraded. Interests returning is the CLEAR EDGE, not a mute button.
+  test("re-arm goes through the paired ledger: degraded → recovered → degraded", async () => {
     const { runWatchdogTick, __setBrokerStartedAtForTest, handleRegister, handleDeregister } =
       await import("./index.mjs");
+    const { BROKER_DEGRADED_SUSTAINED_TICKS } = await import("./config.mjs");
     clearInterests();
+    seedActiveWorker();
     const sixMinAgo = new Date(Date.now() - 6 * 60 * 1000).toISOString();
     __setBrokerStartedAtForTest(sixMinAgo);
 
-    runWatchdogTick(); // emits first degraded
+    for (let i = 0; i < BROKER_DEGRADED_SUSTAINED_TICKS; i++) runWatchdogTick(); // degraded #1
+    expect(degradedLinesIn(logPathNow())).toHaveLength(1);
 
     handleRegister({
       event: "filter.register",
       orchestrator: "orch-rearm-1",
       detail: { interest_id: "rearm-1", notify_event: "filter.wake.rearm-1", prompt: "p" },
     });
+    runWatchdogTick(); // interests present → the clear edge → recovered
+    expect(recoveredLinesIn(logPathNow())).toHaveLength(1);
+    expect(JSON.parse(recoveredLinesIn(logPathNow())[0]).body.payload.reason).toBe(
+      "interests registered",
+    );
+
     handleDeregister({
       event: "filter.deregister",
       orchestrator: "orch-rearm-1",
       detail: { interest_id: "rearm-1" },
     });
+    for (let i = 0; i < BROKER_DEGRADED_SUSTAINED_TICKS; i++) runWatchdogTick(); // degraded #2
 
-    runWatchdogTick(); // should re-emit (cleared on non-empty, then armed again on empty)
-
-    const ym = new Date().toISOString().slice(0, 7);
-    const logPath = join(tmpDir, "events", `${ym}.jsonl`);
-    const lines = readFileSync(logPath, "utf8").trim().split("\n").filter(Boolean);
-    const degradedLines = lines.filter((l) => {
-      try {
-        return JSON.parse(l).attributes?.["event.name"] === "broker.daemon.degraded";
-      } catch {
-        return false;
-      }
-    });
-    expect(degradedLines).toHaveLength(2);
+    expect(degradedLinesIn(logPathNow())).toHaveLength(2);
+    expect(recoveredLinesIn(logPathNow())).toHaveLength(1);
   });
 });
 

--- a/plugins/dev/scripts/broker/ingestion-recency-wiring.test.mjs
+++ b/plugins/dev/scripts/broker/ingestion-recency-wiring.test.mjs
@@ -375,6 +375,39 @@ describe("github/linear activity-gated recency (CTL-1122 PR2)", () => {
     runWatchdogTick();
     expect(readIngestionEvents(getEventLogPath())).toHaveLength(0);
   });
+
+  // (g) REGRESSION GUARD (CTL-1523 review F2). The shared activity reader became
+  // TRI-STATE (true / false / null-for-unknown) so the broker-degraded detector could
+  // stop treating an unreadable worker table as "proven idle". This CTL-1122 gate must
+  // NOT inherit that nuance: it stays FAIL-CLOSED, so an unavailable reading forces
+  // "up" exactly as the old catch-returns-false did. An unreadable worker table must
+  // never license a github-silence page.
+  test("(g) github stale but the ACTIVITY READ FAILS → gate stays closed, no alarm", () => {
+    dispatchActiveWorker(); // a row exists, but…
+    __setLastSeenForTest(GITHUB_SERVICE_NAME, { ts: Date.now() - staleGithubMs, id: "gh-old" });
+    closeBrokerStateDb(); // …the DB handle is gone → the read throws → activity unknown
+    expect(() => runWatchdogTick()).not.toThrow();
+    expect(readIngestionEvents(getEventLogPath())).toHaveLength(0);
+    expect(__getRecencyAlarmForTest(GITHUB_SERVICE_NAME).downEmitted).toBe(false);
+  });
+
+  test("(g') an OPEN github outage clears when the activity read fails (fail-closed → up)", () => {
+    dispatchActiveWorker();
+    __setLastSeenForTest(GITHUB_SERVICE_NAME, { ts: Date.now() - staleGithubMs, id: "gh-old" });
+    runWatchdogTick(); // → stale (gate open)
+    expect(__getRecencyAlarmForTest(GITHUB_SERVICE_NAME).downEmitted).toBe(true);
+
+    closeBrokerStateDb(); // activity now unknown
+    runWatchdogTick();
+    // Unchanged CTL-1122 semantics: unknown forces "up", which pairs the open outage
+    // with a recovered rather than holding it.
+    const rec = readIngestionEvents(getEventLogPath()).find(
+      (e) => e.attributes["event.name"] === "catalyst.ingestion.recovered",
+    );
+    expect(rec).toBeDefined();
+    expect(rec.attributes["event.label"]).toBe(GITHUB_SERVICE_NAME);
+    expect(__getRecencyAlarmForTest(GITHUB_SERVICE_NAME).downEmitted).toBe(false);
+  });
 });
 
 describe("kill-switch CATALYST_INGESTION_RECENCY=0 (CTL-1122)", () => {

--- a/plugins/dev/scripts/broker/namespace-contract.test.mjs
+++ b/plugins/dev/scripts/broker/namespace-contract.test.mjs
@@ -23,6 +23,9 @@ describe("isBrokerProtectedName", () => {
   test("returns true for broker.daemon.* prefix", () => {
     expect(isBrokerProtectedName("broker.daemon.start")).toBe(true);
     expect(isBrokerProtectedName("broker.daemon.degraded")).toBe(true);
+    // CTL-1523: the paired recovery event rides the same protected prefix, so
+    // shouldSkipEvent drops it from re-ingestion with no contract change.
+    expect(isBrokerProtectedName("broker.daemon.recovered")).toBe(true);
   });
 
   test("returns true for exact session.heartbeat", () => {

--- a/plugins/dev/scripts/broker/projection.mjs
+++ b/plugins/dev/scripts/broker/projection.mjs
@@ -194,8 +194,16 @@ export function buildBrokerState({ probe } = {}) {
     // CTL-447: enumerate the deterministic interest types this broker supports
     // so `catalyst-broker status --json` can advertise them to clients.
     supportedInterestTypes: [...DETERMINISTIC_INTEREST_TYPES],
-    // CTL-352: liveness fields so the HUD pill and operators can detect a
-    // silently-dead broker (interests.size === 0 with stale lastWakeAt).
+    // CTL-352: liveness fields for the HUD pill and operators.
+    // CTL-1523: the heuristic this comment used to advertise — "interests.size === 0
+    // with stale lastWakeAt ⇒ silently-dead broker" — is FALSE in phase-agents mode.
+    // Interest registration is legacy-only (dormant since the 2026-06-07 cutover), so
+    // an empty table with no wakes is the CORRECT steady state, not a death signal;
+    // acting on it produced 104 false broker.daemon.degraded emissions in one month.
+    // See broker-degraded.mjs for the full reasoning (that detector is now opt-in and
+    // dormant by default). The real silently-dead-broker signal is CTL-1122
+    // ingestion-recency: catalyst.ingestion.stale / catalyst.alert.raised(system_down).
+    // These fields remain useful as raw operator readouts — just not as a verdict.
     interestCount: interests.size,
     lastWakeAt: getLastWakeAt(),
     lastRegisterAt: getLastRegisterAt(),

--- a/plugins/dev/scripts/broker/projection.mjs
+++ b/plugins/dev/scripts/broker/projection.mjs
@@ -196,13 +196,20 @@ export function buildBrokerState({ probe } = {}) {
     supportedInterestTypes: [...DETERMINISTIC_INTEREST_TYPES],
     // CTL-352: liveness fields for the HUD pill and operators.
     // CTL-1523: the heuristic this comment used to advertise — "interests.size === 0
-    // with stale lastWakeAt ⇒ silently-dead broker" — is FALSE in phase-agents mode.
-    // Interest registration is legacy-only (dormant since the 2026-06-07 cutover), so
-    // an empty table with no wakes is the CORRECT steady state, not a death signal;
-    // acting on it produced 104 false broker.daemon.degraded emissions in one month.
-    // See broker-degraded.mjs for the full reasoning (that detector is now opt-in and
-    // dormant by default). The real silently-dead-broker signal is CTL-1122
-    // ingestion-recency: catalyst.ingestion.stale / catalyst.alert.raised(system_down).
+    // with stale lastWakeAt ⇒ silently-dead broker" — is FALSE under execution-core
+    // dispatch, where nothing registers interests at all: an empty table with no wakes
+    // is the CORRECT steady state, not a death signal, and acting on it produced 104
+    // false broker.daemon.degraded emissions in one month. (On a legacy-wave host,
+    // which DOES register interests via orchestrate-register-interests.sh, an empty
+    // table is genuinely anomalous.) See broker-degraded.mjs for the full reasoning —
+    // that detector is now opt-in and dormant by default.
+    //
+    // No in-process field can report a DEAD broker: these values are produced by the
+    // broker itself, so they simply stop being written. CTL-1122 ingestion-recency
+    // (catalyst.ingestion.stale / catalyst.alert.raised(system_down)) detects an
+    // ingestion STALL while the broker is alive; proving the process itself is gone
+    // takes an EXTERNAL absence check (Loki `absent_over_time` on
+    // `broker.daemon.heartbeat` / the broker `.log` stream).
     // These fields remain useful as raw operator readouts — just not as a verdict.
     interestCount: interests.size,
     lastWakeAt: getLastWakeAt(),

--- a/plugins/dev/scripts/broker/router.mjs
+++ b/plugins/dev/scripts/broker/router.mjs
@@ -59,6 +59,7 @@ import {
 // supplies the two side effects — the activity reading and the event append.
 import {
   checkBrokerDegraded,
+  isBrokerDegradedLatchOpen,
   BROKER_DEGRADED_EVENT,
   BROKER_RECOVERED_EVENT,
 } from "./broker-degraded.mjs";
@@ -2340,8 +2341,14 @@ export function runWatchdogTick({ liveness = sessionLiveness } = {}) {
   // clear an open episode — and must not trip a new one. Consume-and-clear: the
   // edge counts for exactly one tick, and is cleared unconditionally (even when the
   // detector is dormant) so a stale edge can never leak into a later interval.
+  // Codex round 4: the edge is EVIDENCE, so it is retained until it has actually
+  // been acted on. It is read here but cleared only AFTER the detector runs, and
+  // only if no episode is left open — mirroring the latch's own emit-then-advance
+  // discipline. Clearing it up front meant a failed `recovered` append destroyed
+  // the one thing that made the clear verdict true, stranding the latch open (and
+  // suppressing later degraded events) until an unrelated registration or an idle
+  // fleet came along.
   const sawInterestEdge = _sawInterestSinceLastTick;
-  _sawInterestSinceLastTick = false;
   // 1 = "at least one registration was observed this interval" when the live table
   // is empty again; otherwise the real size. The detector only ever asks
   // empty-vs-non-empty of this number.
@@ -2359,6 +2366,11 @@ export function runWatchdogTick({ liveness = sessionLiveness } = {}) {
     sustainedTicks: BROKER_DEGRADED_SUSTAINED_TICKS,
     emit: emitBrokerDegradedEvent,
   });
+  // Retire the edge only once it can no longer be needed: either it was acted on
+  // (the episode closed) or there was no open episode for it to close. If an
+  // episode is STILL open the recovery has not landed — keep the evidence so the
+  // next tick retries. Guarded so a detector throw can never strand the flag set.
+  if (sawInterestEdge && !isBrokerDegradedLatchOpen()) _sawInterestSinceLastTick = false;
 
   // CTL-1122: judge each ingestion source's liveness from its event recency —
   // the surviving-process observation the 11h silent outage proved we were

--- a/plugins/dev/scripts/broker/router.mjs
+++ b/plugins/dev/scripts/broker/router.mjs
@@ -590,9 +590,16 @@ function checkSourceRecency(source, now) {
     downAfterMs: source.downAfterMs,
   });
   let severity = ungatedSeverity;
-  if (source.gated && !fleetIsActive(now)) {
-    // Gate closed: the fleet isn't working, so webhook silence is expected, not
-    // a fault. Force "up" → no stale, and a clean clear of any open outage.
+  // CTL-1523 review F2: fleetActivity is now tri-state, but this CTL-1122 gate keeps
+  // its original FAIL-CLOSED semantics exactly — only a demonstrably-active fleet
+  // (=== true) holds the gate open, so both "proven idle" (false) and "unknown"
+  // (null, the old catch-returns-false case) force "up" as they always did. Do not
+  // relax this to `=== false`: an unreadable worker table must never license a
+  // github-silence page.
+  if (source.gated && fleetActivity(now) !== true) {
+    // Gate closed: the fleet isn't working (or we cannot tell), so webhook silence
+    // is expected, not a fault. Force "up" → no stale, and a clean clear of any
+    // open outage.
     severity = "up";
   }
   const { state, emit } = nextRecencyAlarmState(prevAlarm, {
@@ -750,17 +757,28 @@ function checkNeedsHumanPileup(now) {
   return emit;
 }
 
-// fleetIsActive — the activity-gate input for gated recency sources. Defensive
-// wrapper around hasActiveWorkers: a watchdog tick must NEVER throw, and the
-// broker-state DB read could fail (e.g. closed handle in an isolated unit test,
-// or a transient error). On failure, fail the gate CLOSED (treat as no active
-// work) — the no-false-alarm safe default, consistent with the detector's
-// fail-open-to-"up" philosophy.
-function fleetIsActive(now) {
+// fleetActivity — the activity reading shared by the gated recency sources and the
+// CTL-1523 broker-degraded detector. Defensive wrapper around hasActiveWorkers: a
+// watchdog tick must NEVER throw, and the broker-state DB read could fail (e.g. a
+// closed handle in an isolated unit test, or a transient error).
+//
+// TRI-STATE (CTL-1523 review F2). The reading is deliberately three-valued:
+//   true  — the fleet is demonstrably working
+//   false — PROVEN idle (the read succeeded and found no active worker)
+//   null  — UNKNOWN (the read failed; we know nothing either way)
+//
+// Collapsing null into false was the defect: a transient SQLite failure looked
+// identical to a proven-idle fleet, so the degraded detector cleared its latch and
+// emitted a FALSE `broker.daemon.recovered` (reason "fleet idle"); when the DB
+// recovered, the still-anomalous condition re-tripped after the debounce, producing a
+// duplicate degraded edge from one uninterrupted episode. Consumers must now decide
+// explicitly what "unknown" means for them (the detector HOLDS its latch; see
+// classifyBrokerDegradedClear).
+function fleetActivity(now) {
   try {
     return hasActiveWorkers(new Date(now).toISOString());
   } catch {
-    return false;
+    return null; // unknown — NOT proven idle
   }
 }
 
@@ -2258,27 +2276,40 @@ export function runWatchdogTick({ liveness = sessionLiveness } = {}) {
   emitProcessMemoryMetric({ serviceName: "catalyst.broker", log }).catch(() => {});
 
   // CTL-352 / CTL-1523: empty-interests observability. The signal is only an
-  // anomaly when the fleet is ACTIVELY WORKING — interest registration is
-  // legacy-only and correctly dormant in phase-agents mode, so an empty table on
-  // an idle fleet is the healthy steady state, not a silently-dead broker. The
-  // gate, the sustained-tick debounce, and the durable edge latch live in
-  // broker-degraded.mjs; this call supplies the two side effects.
+  // anomaly when the fleet is ACTIVELY WORKING — under execution-core dispatch no
+  // component registers interests at all, so an empty table on an idle fleet is the
+  // healthy steady state, not a silently-dead broker. The gate, the sustained-tick
+  // debounce, and the durable edge latch live in broker-degraded.mjs; this call
+  // supplies the two side effects.
   //
   // NOTE: the log-level split below is INDEPENDENT of the detector's opt-in knob —
   // it is plain broker.log hygiene and always applies. checkBrokerDegraded itself is
   // dormant unless FILTER_BROKER_DEGRADED_ENABLED=1 (it returns null on its first
-  // line), so on a normal phase-agents host this call is a no-op; the real
-  // silently-dead-broker detector is the CTL-1122 checkSourceRecency pass below.
+  // line), so on an execution-core host this call is a no-op.
+  //
+  // Neither this nor the CTL-1122 checkSourceRecency pass below can detect a FULLY
+  // DEAD broker: both execute inside this process. checkSourceRecency detects an
+  // ingestion STALL while the broker is alive; a dead broker is a MISSING series and
+  // needs an EXTERNAL absence check (Loki `absent_over_time` on
+  // `broker.daemon.heartbeat` / the broker `.log` stream).
   const brokerStartedAt = getBrokerStartedAt();
   const startedTs = brokerStartedAt ? new Date(brokerStartedAt).getTime() : now;
   const brokerUptimeMs = now - startedTs;
-  const fleetActive = fleetIsActive(now);
+  // Tri-state (CTL-1523 review F2): true | false (proven idle) | null (unknown).
+  const fleetActive = fleetActivity(now);
   if (interests.size === 0) {
     // CTL-1523: split by the same discriminator the detector uses. An empty table
-    // WHILE work is in flight is a real anomaly (warn); on an idle fleet it is
-    // expected and was drowning broker.log (~171 lines / 2.85h on mini) → debug.
-    if (fleetActive) log.warn({ uptimeMs: brokerUptimeMs }, "watchdog: no registered interests");
-    else log.debug({ uptimeMs: brokerUptimeMs }, "watchdog: no registered interests (fleet idle)");
+    // WHILE work is in flight is a real anomaly (warn); on an idle fleet — or when
+    // the activity read is unavailable, where we have no anomaly claim to make — it
+    // is expected and was drowning broker.log (~171 lines / 2.85h on mini) → debug.
+    if (fleetActive === true) {
+      log.warn({ uptimeMs: brokerUptimeMs }, "watchdog: no registered interests");
+    } else {
+      log.debug(
+        { uptimeMs: brokerUptimeMs, fleetActive },
+        "watchdog: no registered interests (fleet idle or activity unknown)",
+      );
+    }
   }
   checkBrokerDegraded({
     interestCount: interests.size,

--- a/plugins/dev/scripts/broker/router.mjs
+++ b/plugins/dev/scripts/broker/router.mjs
@@ -156,6 +156,21 @@ const orchestratorStatusMap = getOrchestratorStatusMap();
 // FILTER_BROKER_DEGRADED_GRACE_MS knob (was the hard-coded CTL-352
 // DEGRADED_THRESHOLD_MS).
 
+// CTL-1523 (Codex round 3): an interest-return EDGE that happens BETWEEN two
+// watchdog ticks. Replacing the CTL-352 synchronous re-arm with the watchdog's
+// periodic `interests.size` SAMPLE lost the one-shot case: an interest that
+// registers AND deregisters inside the ~60 s tick interval is never observed, so
+// the `recovered` never fires and the stale latch suppresses every later degraded
+// episode until the fleet goes idle. Record the EDGE instead of re-introducing an
+// out-of-band re-arm (which is what left a degraded unpaired in the ledger).
+// Set by the registration paths, consumed and cleared once per watchdog tick.
+let _sawInterestSinceLastTick = false;
+// Cannot throw: a bare boolean assignment, deliberately no I/O and no logging, so
+// it is safe to call from any hot registration path.
+function noteInterestRegistered() {
+  _sawInterestSinceLastTick = true;
+}
+
 // CTL-993: merge-to-main plugin-checkout refresh wiring. The broker module lives
 // at <repo>/plugins/dev/scripts/broker/router.mjs, so the repo .catalyst config
 // (which carries feedback.githubRepo) is four levels up. The machine config path
@@ -1002,7 +1017,10 @@ export function handleRegister(event) {
   // CTL-1523: the CTL-352 out-of-band re-arm (setDegradedEmittedAt(null)) is gone.
   // "Interests came back" is now the CLEAR EDGE and must be observed by the
   // watchdog so it emits the paired broker.daemon.recovered — a silent re-arm here
-  // would leave a degraded with no recovery in the ledger.
+  // would leave a degraded with no recovery in the ledger. We record only that the
+  // edge HAPPENED, so a registration that is gone again before the next tick is
+  // still counted (see _sawInterestSinceLastTick).
+  noteInterestRegistered();
   persistBrokerState();
 }
 
@@ -1125,7 +1143,9 @@ function _autoRegisterPrLifecycle(sessionId, prNumber, orchestrator, ticket, rep
   log.info({ sessionId, prNumber }, "auto-correlated pr_lifecycle for session");
   saveInterests();
   setLastRegisterAt(new Date().toISOString());
-  // CTL-1523: no out-of-band re-arm — the watchdog observes the clear edge.
+  // CTL-1523: no out-of-band re-arm — the watchdog observes the clear edge, and
+  // this records the edge so a between-tick registration is not missed.
+  noteInterestRegistered();
   persistBrokerState();
 }
 
@@ -1940,7 +1960,9 @@ function _autoPrLifecycleFromTicket(ticket, prNumber, interestsMap, repo) {
   if (changed) {
     saveInterests();
     setLastRegisterAt(new Date().toISOString());
-    // CTL-1523: no out-of-band re-arm — the watchdog observes the clear edge.
+    // CTL-1523: no out-of-band re-arm — the watchdog observes the clear edge, and
+    // this records the edge so a between-tick registration is not missed.
+    noteInterestRegistered();
     persistBrokerState();
   }
 }
@@ -2311,8 +2333,21 @@ export function runWatchdogTick({ liveness = sessionLiveness } = {}) {
       );
     }
   }
+  // CTL-1523 (Codex round 3): feed the detector the interest count AS OBSERVED OVER
+  // THE WHOLE TICK INTERVAL, not just at this instant. A one-shot interest that
+  // registered and deregistered since the last tick still PROVES the broker
+  // processed a registration (it is demonstrably not silently dead), so it must
+  // clear an open episode — and must not trip a new one. Consume-and-clear: the
+  // edge counts for exactly one tick, and is cleared unconditionally (even when the
+  // detector is dormant) so a stale edge can never leak into a later interval.
+  const sawInterestEdge = _sawInterestSinceLastTick;
+  _sawInterestSinceLastTick = false;
+  // 1 = "at least one registration was observed this interval" when the live table
+  // is empty again; otherwise the real size. The detector only ever asks
+  // empty-vs-non-empty of this number.
+  const observedInterestCount = interests.size > 0 ? interests.size : sawInterestEdge ? 1 : 0;
   checkBrokerDegraded({
-    interestCount: interests.size,
+    interestCount: observedInterestCount,
     uptimeMs: brokerUptimeMs,
     brokerStartedAt,
     fleetActive,

--- a/plugins/dev/scripts/broker/router.mjs
+++ b/plugins/dev/scripts/broker/router.mjs
@@ -41,6 +41,8 @@ import {
   INGESTION_RECENCY_HOLDDOWN_MS,
   INGESTION_SEED_BYTES,
   getPrevMonthEventLogPath,
+  BROKER_DEGRADED_GRACE_MS,
+  BROKER_DEGRADED_SUSTAINED_TICKS,
 } from "./config.mjs";
 import {
   getInterests,
@@ -51,9 +53,15 @@ import {
   getBrokerStartedAt,
   setLastWakeAt,
   setLastRegisterAt,
-  getDegradedEmittedAt,
-  setDegradedEmittedAt,
 } from "./state.mjs";
+// CTL-1523: the broker-degraded detector (fleet-activity-gated, sustained,
+// durably latched). The pure machine + latch live in the leaf module; the router
+// supplies the two side effects — the activity reading and the event append.
+import {
+  checkBrokerDegraded,
+  BROKER_DEGRADED_EVENT,
+  BROKER_RECOVERED_EVENT,
+} from "./broker-degraded.mjs";
 import {
   saveInterests,
   persistBrokerState,
@@ -144,8 +152,9 @@ const workerToOrchestrator = getWorkerToOrchestrator();
 const waitingSessions = getWaitingSessionsMap();
 const orchestratorStatusMap = getOrchestratorStatusMap();
 
-// CTL-352: empty-interests degraded threshold (5-minute startup grace).
-const DEGRADED_THRESHOLD_MS = 5 * 60 * 1000;
+// CTL-1523: the empty-interests startup grace moved to config.mjs as the
+// FILTER_BROKER_DEGRADED_GRACE_MS knob (was the hard-coded CTL-352
+// DEGRADED_THRESHOLD_MS).
 
 // CTL-993: merge-to-main plugin-checkout refresh wiring. The broker module lives
 // at <repo>/plugins/dev/scripts/broker/router.mjs, so the repo .catalyst config
@@ -755,6 +764,30 @@ function fleetIsActive(now) {
   }
 }
 
+// emitBrokerDegradedEvent — the append side effect the CTL-1523 detector injects.
+// Returns true on a successful append, false on any failure, and NEVER throws:
+// checkBrokerDegraded advances its durable latch only on true, so a transient
+// event-log failure re-attempts the same edge next tick instead of losing it.
+// (appendEvent itself is void and CAN throw — appendFileSync — hence the wrap.)
+function emitBrokerDegradedEvent({ action, detail }) {
+  const degraded = action === "degraded";
+  try {
+    appendEvent({
+      event: degraded ? BROKER_DEGRADED_EVENT : BROKER_RECOVERED_EVENT,
+      orchestrator: null,
+      worker: null,
+      severity: degraded ? "WARN" : "INFO",
+      detail,
+    });
+    return true;
+  } catch (err) {
+    // Optional-call for parity with the two sites in broker-degraded.mjs: this
+    // rides runWatchdogTick, which must NEVER throw.
+    log.warn?.({ err: err?.message, action }, "broker-degraded: event append failed");
+    return false;
+  }
+}
+
 // Test seams (CTL-1122) — mirror the _emittedWakeCache __…ForTest pattern.
 export function __clearIngestionRecencyForTest() {
   _lastSeenByService.clear();
@@ -948,8 +981,10 @@ export function handleRegister(event) {
   }
   saveInterests();
   setLastRegisterAt(new Date().toISOString());
-  // CTL-352: a fresh registration arms a future degraded event.
-  setDegradedEmittedAt(null);
+  // CTL-1523: the CTL-352 out-of-band re-arm (setDegradedEmittedAt(null)) is gone.
+  // "Interests came back" is now the CLEAR EDGE and must be observed by the
+  // watchdog so it emits the paired broker.daemon.recovered — a silent re-arm here
+  // would leave a degraded with no recovery in the ledger.
   persistBrokerState();
 }
 
@@ -1072,7 +1107,7 @@ function _autoRegisterPrLifecycle(sessionId, prNumber, orchestrator, ticket, rep
   log.info({ sessionId, prNumber }, "auto-correlated pr_lifecycle for session");
   saveInterests();
   setLastRegisterAt(new Date().toISOString());
-  setDegradedEmittedAt(null);
+  // CTL-1523: no out-of-band re-arm — the watchdog observes the clear edge.
   persistBrokerState();
 }
 
@@ -1887,7 +1922,7 @@ function _autoPrLifecycleFromTicket(ticket, prNumber, interestsMap, repo) {
   if (changed) {
     saveInterests();
     setLastRegisterAt(new Date().toISOString());
-    setDegradedEmittedAt(null);
+    // CTL-1523: no out-of-band re-arm — the watchdog observes the clear edge.
     persistBrokerState();
   }
 }
@@ -2222,33 +2257,42 @@ export function runWatchdogTick({ liveness = sessionLiveness } = {}) {
   // never throws, never blocks) so per-daemon memory becomes attributable in Prometheus.
   emitProcessMemoryMetric({ serviceName: "catalyst.broker", log }).catch(() => {});
 
-  // CTL-352: empty-interests observability. Warn on every tick when the table
-  // is empty so a silently-dead broker is loud in broker.log, and emit a
-  // one-shot broker.daemon.degraded event after the 5-minute startup grace so
-  // downstream consumers (HUD, alerts) can pair startup ↔ degraded.
+  // CTL-352 / CTL-1523: empty-interests observability. The signal is only an
+  // anomaly when the fleet is ACTIVELY WORKING — interest registration is
+  // legacy-only and correctly dormant in phase-agents mode, so an empty table on
+  // an idle fleet is the healthy steady state, not a silently-dead broker. The
+  // gate, the sustained-tick debounce, and the durable edge latch live in
+  // broker-degraded.mjs; this call supplies the two side effects.
+  //
+  // NOTE: the log-level split below is INDEPENDENT of the detector's opt-in knob —
+  // it is plain broker.log hygiene and always applies. checkBrokerDegraded itself is
+  // dormant unless FILTER_BROKER_DEGRADED_ENABLED=1 (it returns null on its first
+  // line), so on a normal phase-agents host this call is a no-op; the real
+  // silently-dead-broker detector is the CTL-1122 checkSourceRecency pass below.
+  const brokerStartedAt = getBrokerStartedAt();
+  const startedTs = brokerStartedAt ? new Date(brokerStartedAt).getTime() : now;
+  const brokerUptimeMs = now - startedTs;
+  const fleetActive = fleetIsActive(now);
   if (interests.size === 0) {
-    const brokerStartedAt = getBrokerStartedAt();
-    const startedTs = brokerStartedAt ? new Date(brokerStartedAt).getTime() : now;
-    const uptimeMs = now - startedTs;
-    log.warn({ uptimeMs }, "watchdog: no registered interests");
-    if (uptimeMs > DEGRADED_THRESHOLD_MS && getDegradedEmittedAt() === null) {
-      appendEvent({
-        event: "broker.daemon.degraded",
-        orchestrator: null,
-        worker: null,
-        severity: "WARN",
-        detail: {
-          reason: "no registered interests",
-          uptimeMs,
-          brokerStartedAt,
-        },
-      });
-      setDegradedEmittedAt(new Date().toISOString());
-      persistBrokerState();
-    }
-  } else if (getDegradedEmittedAt() !== null) {
-    setDegradedEmittedAt(null);
+    // CTL-1523: split by the same discriminator the detector uses. An empty table
+    // WHILE work is in flight is a real anomaly (warn); on an idle fleet it is
+    // expected and was drowning broker.log (~171 lines / 2.85h on mini) → debug.
+    if (fleetActive) log.warn({ uptimeMs: brokerUptimeMs }, "watchdog: no registered interests");
+    else log.debug({ uptimeMs: brokerUptimeMs }, "watchdog: no registered interests (fleet idle)");
   }
+  checkBrokerDegraded({
+    interestCount: interests.size,
+    uptimeMs: brokerUptimeMs,
+    brokerStartedAt,
+    fleetActive,
+    nowMs: now,
+    // Both knobs injected explicitly (they default to the same config constants
+    // inside the detector) so the wiring reads as one config surface rather than
+    // half-explicit / half-defaulted.
+    graceMs: BROKER_DEGRADED_GRACE_MS,
+    sustainedTicks: BROKER_DEGRADED_SUSTAINED_TICKS,
+    emit: emitBrokerDegradedEvent,
+  });
 
   // CTL-1122: judge each ingestion source's liveness from its event recency —
   // the surviving-process observation the 11h silent outage proved we were

--- a/plugins/dev/scripts/broker/state.mjs
+++ b/plugins/dev/scripts/broker/state.mjs
@@ -67,9 +67,12 @@ export function clearOrchestratorStatusMap() {
 let brokerStartedAt = null;
 let lastWakeAt = null;
 let lastRegisterAt = null;
-// One-shot guard for broker.daemon.degraded — set on emission, cleared whenever
-// interests.size > 0 so a future empty window re-arms.
-let degradedEmittedAt = null;
+// CTL-1523: the CTL-352 one-shot `degradedEmittedAt` guard is RETIRED. It lived
+// only here in module memory (never persisted — buildBrokerState has no such key),
+// so every broker restart re-armed it and re-fired broker.daemon.degraded: all 104
+// July emissions on mini landed on the first watchdog tick past the startup grace.
+// Its replacement is the DURABLE latch in broker-degraded.mjs — the single
+// chokepoint for that episode state.
 // CTL-643: boot-time GC pass result, surfaced in broker.state.json so operators
 // can see "the broker pruned N stale interests on its last start."
 let gcLastRunAt = null;
@@ -93,12 +96,6 @@ export function getLastRegisterAt() {
 export function setLastRegisterAt(value) {
   lastRegisterAt = value;
 }
-export function getDegradedEmittedAt() {
-  return degradedEmittedAt;
-}
-export function setDegradedEmittedAt(value) {
-  degradedEmittedAt = value;
-}
 export function getGcLastRunAt() {
   return gcLastRunAt;
 }
@@ -120,9 +117,6 @@ export function __setBrokerStartedAtForTest(iso) {
 export function __resetBrokerStartedAtForTest() {
   brokerStartedAt = null;
 }
-export function __resetDegradedEmittedForTest() {
-  degradedEmittedAt = null;
-}
 // CTL-419: backdate a session's heartbeat timestamp so tests can simulate staleness.
 export function __setHeartbeatForTest(sessionId, tsMs) {
   const existing = lastHeartbeat.get(sessionId);
@@ -132,7 +126,8 @@ export function __resetBrokerLivenessForTest() {
   brokerStartedAt = null;
   lastWakeAt = null;
   lastRegisterAt = null;
-  degradedEmittedAt = null;
+  // CTL-1523: the degraded episode is no longer part of this liveness block —
+  // reset it with __resetBrokerDegradedLatchForTest() (broker-degraded.mjs).
   gcLastRunAt = null;
   gcLastPrunedCount = null;
 }

--- a/website/src/content/docs/reference/configuration.md
+++ b/website/src/content/docs/reference/configuration.md
@@ -580,6 +580,48 @@ daemon. These knobs are env vars on the `catalyst-broker` process:
   - `FILTER_PILEUP_COOLDOWN_MS` (default `3600000`) — minimum gap after a clear before it can
     re-fire (flap guard).
 
+### Broker-degraded detector (CTL-1523)
+
+The broker's watchdog can edge-trigger a `broker.daemon.degraded` / `broker.daemon.recovered` pair
+when its **interest table is empty while the fleet is actively working** — an empty table on an idle
+fleet is the healthy steady state, so the fleet-activity reading is the discriminator. The episode is
+edge-triggered with a **durable latch** (`~/catalyst/broker-degraded-latch.json`), so a broker
+restart mid-episode resumes rather than re-emitting.
+
+**The detector is dormant by default and only meaningful on legacy-wave hosts.** Under
+**execution-core dispatch** nothing registers interests at all, so `interests.size === 0` is
+permanently true and the gate carries no information. That is a property of execution-core, **not**
+of every configuration named `phase-agents`: a **legacy-wave** host — one driving
+`/catalyst-legacy:orchestrate`, which invokes `plugins/dev/scripts/orchestrate-register-interests.sh`
+— does register interests (`pr_lifecycle` + `ticket_lifecycle` + `comms_lifecycle` unconditionally,
+plus a per-ticket `phase_lifecycle` when `dispatchMode` is `phase-agents`). There an empty interest
+table IS anomalous, and that is the deployment where enabling this is appropriate. These knobs are
+env vars on the `catalyst-broker` process:
+
+- `FILTER_BROKER_DEGRADED_ENABLED` (default **off**; set to exactly `1` to enable) — opt-in
+  kill-switch. Unset (or any other value) means the detector evaluates nothing and emits nothing.
+  Read at call time, so it toggles without a broker restart. Flipping it **off** discards any
+  in-progress debounce run, so a re-enable re-earns the full sustained-tick threshold; an
+  already-open episode survives the switch and still emits its paired `recovered`.
+- `FILTER_BROKER_DEGRADED_GRACE_MS` (default `300000`, 5 min) — startup grace. An empty interest
+  table is not judged at all until the broker has been up this long, so a still-warming process never
+  trips.
+- `FILTER_BROKER_DEGRADED_SUSTAINED_TICKS` (default `5`) — consecutive anomalous watchdog ticks
+  (~60s each) required before the degraded edge fires. The run must be contiguous: any non-anomalous
+  tick resets it, so a single-tick blip cannot page.
+
+The fleet-activity reading is **tri-state** — active, proven idle, or *unknown* (the worker-table read
+failed). Only a proven-idle fleet closes an open episode (`recovered`, reason `fleet idle`); an
+unknown reading neither trips nor clears, so a transient DB failure cannot manufacture a false
+recovery followed by a duplicate degraded edge.
+
+**This is not a dead-broker detector**, and neither is the ingestion-silence detector above: both run
+inside the broker process, so a dead broker emits neither. `checkSourceRecency` detects an ingestion
+**stall** while the broker is **alive**. Detecting a fully-dead broker requires an **external,
+absence-based** check on the broker's own heartbeat/log series — e.g. a Loki `absent_over_time` alert
+on `broker.daemon.heartbeat` or the broker `.log` stream (absence, because a fully-dead daemon is a
+*missing series*, which `count_over_time == 0` cannot assert).
+
 ### Node admission state on the heartbeat (CTL-1322)
 
 A daemon that is **alive but not accepting new work** (draining, or a liveness-cold hold) otherwise

--- a/website/src/content/docs/reference/configuration.md
+++ b/website/src/content/docs/reference/configuration.md
@@ -600,9 +600,13 @@ env vars on the `catalyst-broker` process:
 
 - `FILTER_BROKER_DEGRADED_ENABLED` (default **off**; set to exactly `1` to enable) — opt-in
   kill-switch. Unset (or any other value) means the detector evaluates nothing and emits nothing.
-  Read at call time, so it toggles without a broker restart. Flipping it **off** discards any
-  in-progress debounce run, so a re-enable re-earns the full sustained-tick threshold; an
-  already-open episode survives the switch and still emits its paired `recovered`.
+  **Changing this requires a broker restart.** The value is read at call time, so it takes effect
+  without a code reload — but a running daemon's `process.env` is fixed at launch and there is no
+  runtime control path that mutates it, so editing the env file (or exporting in a shell) does
+  **not** reach a live broker. Restart it, or you will believe the detector is armed while it is
+  still dormant. Flipping it **off** discards any in-progress debounce run, so a re-enable re-earns
+  the full sustained-tick threshold; an already-open episode survives the switch and still emits
+  its paired `recovered`.
 - `FILTER_BROKER_DEGRADED_GRACE_MS` (default `300000`, 5 min) — startup grace. An empty interest
   table is not judged at all until the broker has been up this long, so a still-warming process never
   trips.


### PR DESCRIPTION
## Why

`runWatchdogTick` treated "no registered interests" as degraded. The gate consulted only `interests.size` and uptime, so it could not tell a **silently-dead** broker from a **genuinely-idle** one — the same class of false positive CTL-1503 just fixed for fleet-health/swap.

This is the item the originating handoff called the *primary* cause of Ryan's "daemon degraded" phone pushes. **It isn't** — `broker.daemon.degraded` has zero consumers anywhere in the repo and cannot produce a push. That misdiagnosis is corrected in **CTL-1522 / #2739**, which fixes the actual notification path. This PR fixes the real-but-separate log-noise bug.

## Live evidence (mini, July)

104 `broker.daemon.degraded` events — **all 104** at `uptimeMs` between 300,339 and 342,975, i.e. the first watchdog tick past the 5-minute grace after a fresh start. **Zero** at any later uptime.

So it was **restart-driven, not oscillation-driven**: the `degradedEmittedAt` latch lived only in module memory and was never persisted to `broker.state.json`, so each of ~5 daily restarts (merge-triggered stack reloads) re-armed and re-fired it. Plus ~171 WARN lines per 2.85h flooding Alloy→Loki.

## What changed

- **A real discriminator.** Trip additionally requires `fleetIsActive(now)` (the existing fail-closed wrapper over `hasActiveWorkers`) and N contiguous ticks. An idle fleet **clears** a latched episode rather than holding it.
- **A durable latch** in a new leaf module `broker-degraded.mjs`, mirroring the CTL-1503 `fleet-health-probe` shape: pure classifiers + `nextBrokerDegradedLatch`, a dedicated on-disk marker written tmp+rename, lazy hydrate treating an absent/corrupt marker as unlatched without throwing, and **emit-then-advance** so a failed append retries the edge instead of swallowing it.
- **A paired `broker.daemon.recovered`** (INFO) so episodes balance.
- **Removed three** out-of-band `setDegradedEmittedAt(null)` re-arms and retired `degradedEmittedAt` from `state.mjs` — one chokepoint only.
- WARN split to `debug` when the fleet is idle.

## Shipped INERT — and why that is the honest outcome

Set `FILTER_BROKER_DEGRADED_ENABLED=1` to opt in. Default: emits nothing.

Three independent reviewers judged the state machine sound (one proved the discriminator load-bearing via a mutation test). But **two independently established that even the rebuilt gate would not discriminate in phase-agents mode**:

`interests.size === 0` is *permanently* true there. Interest registration is legacy-only — every `filter.register` producer lives in `plugins/legacy/`, dormant since the 2026-06-07 cutover — and neither in-router auto-register path can break the tie: `_autoRegisterPrLifecycle` only fires when an agent reports `claimed_pr`, and `_autoPrLifecycleFromTicket` only fires when an *existing* interest already watches the ticket, so an empty table stays empty.

With that conjunct pinned true, the gate degenerates to **"the fleet has been busy for N contiguous ticks"** — emitting roughly one degraded/recovered pair per busy/idle cycle. That trades a restart-driven false positive for a busy-window-driven one, which is not a fix.

There is no way to make `interests.size` informative in this architecture, and the genuine silently-dead-broker detector **already exists**: CTL-1122's `checkSourceRecency`, which emits `catalyst.ingestion.stale` + `catalyst.alert.raised(system_down)` when ingestion actually stops.

So the detector ships dormant, with machinery and tests retained for legacy wave-orchestration mode where interests really are registered. **Result on mini: 104 meaningless events/month → 0, with certainty.**

## Also

- Documents that a `recovered` carrying `reason: "fleet idle"` is **inconclusive** — the discriminator went dark, not the broker proven alive. `hasActiveWorkers` ages out at 30 min, so in legacy mode a genuinely dead broker would otherwise auto-"recover".
- Corrected two stale docs: `projection.mjs` still advertised the now-disproven "`interests.size === 0` + stale `lastWakeAt` ⇒ dead broker" heuristic, and `docs/architecture.md`'s `broker.daemon.*` member list omitted `gc`, `heartbeat` and `shutdown`. That file is `@`-imported in full every session, so an incomplete *closed* list is worse than none.

## Testing

**+49 tests.** 29 pure-machine (including an exhaustive trip/clear mutual-exclusion grid over interestCount × fleetActive × uptime), 10 wiring (idle / active / sustained / restart-survival / opt-in), and 10 driver tests pinning **emit-then-advance** and **hydrate tolerance** — the latter a known **Codex P1 on the sibling PR #2704**, added here pre-emptively.

**832 pass / 1 fail.** The single failure is pre-existing and unrelated: `fence-held-fold.test.mjs:222` asserts on `heldFor` in `orch-monitor/lib/board-data.mjs`, and neither file appears in this diff. Independently confirmed by a reviewer who verified the failure lives in an unmodified test asserting against an unmodified subject.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AhdmqZ26mKwBXyEtRnmtUL
