### PR TITLE
fix(dev): CTL-1524 unblock the daemon event loop in wt-cleanup-drain (free provenance gate first + bounded burst)

### DIFF
--- a/plugins/dev/scripts/execution-core/board-health.mjs
+++ b/plugins/dev/scripts/execution-core/board-health.mjs
@@ -307,6 +307,21 @@ function deriveRing(events, nowMs) {
 }
 
 // ── (1) assembleBoardState — the ONE impure reader (reads only, never writes) ─
+// resolveDeadHosts — CTL-1524 (C4b). Accept EITHER a resolved array (the historical
+// contract, still used by bare ticks and unit tests) OR a zero-arg thunk the caller
+// wants evaluated lazily. The daemon binds a thunk because resolving it costs a
+// whole-log heartbeat read; every consumer below wants a plain array. Never throws —
+// a failed liveness read degrades to "no provably-dead hosts", which is the same
+// fail-safe computeSurvivingRoster already applies (no failover, never a double-act).
+export function resolveDeadHosts(deadHosts) {
+  try {
+    const v = typeof deadHosts === "function" ? deadHosts() : deadHosts;
+    return Array.isArray(v) ? v : [];
+  } catch {
+    return [];
+  }
+}
+
 export function assembleBoardState({
   orchDir,
   getBoard = () => [],
@@ -398,7 +413,9 @@ export function assembleBoardState({
     signals,
     eligible,
     roster: Array.isArray(roster) ? roster : [],
-    deadHosts: Array.isArray(deadHosts) ? deadHosts : [],
+    // CTL-1524 (C4b): resolve here too, so a direct assembleBoardState caller may
+    // also pass a thunk. Already-resolved arrays pass through untouched.
+    deadHosts: resolveDeadHosts(deadHosts),
     self: self ?? "",
     multiHost: !!multiHost,
     // CTL-1157 off-gate: carried so evaluateInvariants can skip the cohort checks
@@ -1254,13 +1271,17 @@ export function boardHealthPass({
   if (mode === "off") return { ran: false, reason: "off" }; // strict no-op
   const nowMs = now();
   if (isThrottledFn(lastRunMs, intervalMs, nowMs)) {
-    return { ran: false, reason: "throttled" }; // no emit, no act
+    return { ran: false, reason: "throttled" }; // no emit, no act, NO deadHosts read
   }
 
   const board = assembleBoardState({
     orchDir, getBoard, getWorkerSignals, getEligible,
     roster, self, multiHost, capacity, readEventRing, ownerForTicket, repoForTicket, getReconcileMarkers,
-    getPrStatusMap, deadHosts, mode, now,
+    // CTL-1524 (C4b): resolved HERE — past the `off` branch and past the throttle —
+    // so the expensive whole-log heartbeat read behind the daemon's thunk is paid
+    // only on a tick that actually proceeds, not on all ~59 throttled ticks between
+    // 5-minute passes. Arrays still work unchanged (resolveDeadHosts is a no-op).
+    getPrStatusMap, deadHosts: resolveDeadHosts(deadHosts), mode, now,
     getDeferredBoardHealthTickets, sanctionedNeedsHuman, // CTL-1432 (B2/B3)
   });
   const invariants = evaluateInvariants(board, { mode });

--- a/plugins/dev/scripts/execution-core/board-health.test.mjs
+++ b/plugins/dev/scripts/execution-core/board-health.test.mjs
@@ -19,6 +19,8 @@ import {
   buildBoardContext,
   buildBoardScanEvent,
   boardHealthPass,
+  // CTL-1524 (C4b): lazy deadHosts resolution (array OR thunk)
+  resolveDeadHosts,
 } from "./board-health.mjs";
 // CTL-1435 (Codex P1/P2): round-trip the REAL emit envelope so the ring test
 // exercises the production body.payload.details nesting + attribute promotion.
@@ -1428,5 +1430,109 @@ describe("buildRecoveryEnvelope — recovery.act_dispatched promotion (CTL-1435)
   test("non-dispatch scan → attributes['recovery.act_dispatched'] === 0", () => {
     const env = buildRecoveryEnvelope(mkEvent({ dispatched: false, anchor: null, skippedReason: "all-candidates-cooldown" }));
     expect(env.attributes["recovery.act_dispatched"]).toBe(0);
+  });
+});
+
+// ─── CTL-1524 (C4b) — deadHosts is resolved LAZILY, past the throttle ─────────
+// The scheduler used to evaluate `_boardHealth.deadHosts(roster)` EAGERLY at the
+// call site, so boardHealthPass's 5-minute internal throttle could never protect it:
+// the whole-log heartbeat read behind it was paid on every tick, ~59 of every 60 of
+// which the throttle then discarded. The seam now accepts a THUNK (and still an
+// array), and boardHealthPass calls it only once it has decided to proceed.
+describe("boardHealthPass — CTL-1524 C4b lazy deadHosts", () => {
+  test("THROTTLED pass → the thunk is NEVER invoked", () => {
+    let calls = 0;
+    const r = boardHealthPass(
+      flaggedDeps({
+        mode: "shadow",
+        lastRunMs: NOW, // just ran
+        intervalMs: 5 * MIN, // → throttled
+        deadHosts: () => {
+          calls++;
+          return ["mini-2"];
+        },
+      })
+    );
+    expect(r).toEqual({ ran: false, reason: "throttled" });
+    expect(calls).toBe(0); // the expensive read was not paid on a discarded tick
+  });
+
+  test("mode:off → the thunk is NEVER invoked either (strict no-op)", () => {
+    let calls = 0;
+    const r = boardHealthPass(
+      flaggedDeps({
+        mode: "off",
+        deadHosts: () => {
+          calls++;
+          return ["mini-2"];
+        },
+      })
+    );
+    expect(r).toEqual({ ran: false, reason: "off" });
+    expect(calls).toBe(0);
+  });
+
+  test("PROCEEDING pass → the thunk is invoked EXACTLY ONCE", () => {
+    let calls = 0;
+    const r = boardHealthPass(
+      flaggedDeps({
+        mode: "shadow",
+        deadHosts: () => {
+          calls++;
+          return ["mini-2"];
+        },
+      })
+    );
+    expect(r.ran).toBe(true);
+    expect(calls).toBe(1);
+  });
+
+  test("BACKWARD COMPATIBLE: a plain ARRAY still works exactly as before", () => {
+    const emits = [];
+    const r = boardHealthPass(
+      flaggedDeps({ mode: "shadow", deadHosts: ["mini-2"], emit: (e) => emits.push(e) })
+    );
+    expect(r.ran).toBe(true);
+    expect(emits.length).toBe(1); // the pass ran to completion on an array seam
+  });
+
+  test("a thunk and the equivalent array produce the SAME board state", () => {
+    const fromArray = assembleBoardState({ roster: ["mini", "mini-2"], deadHosts: ["mini-2"] });
+    const fromThunk = assembleBoardState({ roster: ["mini", "mini-2"], deadHosts: () => ["mini-2"] });
+    expect(fromThunk.deadHosts).toEqual(fromArray.deadHosts);
+    expect(fromThunk.deadHosts).toEqual(["mini-2"]);
+  });
+});
+
+describe("resolveDeadHosts (CTL-1524 C4b)", () => {
+  test("passes an array through untouched", () => {
+    expect(resolveDeadHosts(["a", "b"])).toEqual(["a", "b"]);
+    expect(resolveDeadHosts([])).toEqual([]);
+  });
+
+  test("invokes a thunk exactly once and returns its array", () => {
+    let calls = 0;
+    const out = resolveDeadHosts(() => {
+      calls++;
+      return ["dead-1"];
+    });
+    expect(calls).toBe(1);
+    expect(out).toEqual(["dead-1"]);
+  });
+
+  test("NEVER throws: a throwing thunk degrades to an empty dead set", () => {
+    expect(
+      resolveDeadHosts(() => {
+        throw new Error("heartbeat read blew up");
+      })
+    ).toEqual([]);
+  });
+
+  test("non-array inputs / non-array thunk returns degrade to []", () => {
+    expect(resolveDeadHosts(undefined)).toEqual([]);
+    expect(resolveDeadHosts(null)).toEqual([]);
+    expect(resolveDeadHosts("mini-2")).toEqual([]);
+    expect(resolveDeadHosts(() => null)).toEqual([]);
+    expect(resolveDeadHosts(() => "nope")).toEqual([]);
   });
 });

--- a/plugins/dev/scripts/execution-core/scheduler.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.mjs
@@ -424,6 +424,46 @@ export function computeSurvivingRoster(
   }
 }
 
+// CTL-1524 (C4a): computeDeadHosts — the roster minus the surviving set, computed
+// with EXACTLY ONE computeSurvivingRoster call regardless of roster size.
+//
+// The daemon's board-health binding previously read
+//   roster.filter((h) => !computeSurvivingRoster(roster).includes(h))
+// which re-ran the ENTIRE surviving computation once PER HOST. computeSurvivingRoster's
+// default readHeartbeats is readClusterHeartbeats — a whole-file read of the event log
+// (883MB on mini, ~305ms under bun), so at N=2 a single deadHosts evaluation cost two
+// full-log reads (~610ms) on every tick. Hoisting the call and testing membership
+// against a Set makes that one read, and C4b below makes even that one lazy.
+//
+// NOTE: the read itself is NOT dead code. A claim that readClusterHeartbeats always
+// throws ERR_STRING_TOO_LONG (883MB > node's 512MB MAX_STRING_LENGTH) does not hold
+// here — the daemon runs under BUN, where the read completes (verified: 883MB in
+// ~1.4s). C4 removes only the REDUNDANT calls, never the read.
+//
+// Semantics are preserved exactly: computeSurvivingRoster returns the roster unchanged
+// for length <= 1 and degrades to the FULL roster on a failed/garbled heartbeat read,
+// so both cases still yield an EMPTY dead set (no failover, never a double-act).
+// FAIL-SAFE on a degenerate survivor set: computeSurvivingRoster NEVER returns empty
+// (`alive.length > 0 ? alive : roster`), so an empty/non-array/thrown result means the
+// computation itself misbehaved — not that the whole fleet died. Degrade to an EMPTY
+// dead set (forgo failover this tick) rather than declaring every host dead, which
+// would be the destructive direction.
+export function computeDeadHosts(
+  roster,
+  { computeSurviving = computeSurvivingRoster } = {}
+) {
+  if (!Array.isArray(roster) || roster.length <= 1) return [];
+  let alive;
+  try {
+    alive = computeSurviving(roster);
+  } catch {
+    return [];
+  }
+  if (!Array.isArray(alive) || alive.length === 0) return [];
+  const surviving = new Set(alive);
+  return roster.filter((h) => !surviving.has(h));
+}
+
 // CTL-1091 Phase 3: the RAW positively-live host set. Dispatch ownership requires
 // POSITIVE liveness — a host must have been SEEN within grace to own new work —
 // unlike computeSurvivingRoster's fail-OPEN deadHosts (an unseen host is "not
@@ -5138,7 +5178,16 @@ export function schedulerTick(
           // → empty-Map / empty-array defaults keep the new invariants
           // observable:false and the holistic failover unreachable (shadow-safe).
           getPrStatusMap: _boardHealth.getPrStatusMap,
-          deadHosts: _boardHealth.deadHosts ? _boardHealth.deadHosts(roster) : [],
+          // CTL-1524 (C4b): pass a THUNK, not a resolved array. Evaluating it here
+          // ran the heartbeat read on EVERY tick, so boardHealthPass's 5-minute
+          // internal throttle could never protect it — the cost was paid before the
+          // throttle was consulted. boardHealthPass now calls this only once it has
+          // decided to proceed. Backward-compatible: a plain ARRAY is still accepted
+          // (bare ticks / tests that pass one directly).
+          deadHosts:
+            typeof _boardHealth.deadHosts === "function"
+              ? () => _boardHealth.deadHosts(roster)
+              : (_boardHealth.deadHosts ?? []),
           lastRunMs: _boardHealthLastRunMs,
           // emit defaults to defaultEmitEvent. CTL-1300: thread the optional `act`
           // seam — supplied ONLY by the daemon binding (the holistic recovery-pass
@@ -7575,7 +7624,9 @@ function runTick() {
             return null;
           }
         },
-        deadHosts: (roster) => roster.filter((h) => !computeSurvivingRoster(roster).includes(h)),
+        // CTL-1524 (C4a): ONE computeSurvivingRoster call (⇒ one whole-log heartbeat
+        // read), not one per host. See computeDeadHosts above.
+        deadHosts: (roster) => computeDeadHosts(roster),
         // CTL-1157 (MUST-FIX 2): iterate the ordered candidate list and dispatch
         // the FIRST actionable (non-cooldown/non-latched) candidate — instead of
         // returning {dispatched:false} on the first skip, which wedged the whole

--- a/plugins/dev/scripts/execution-core/scheduler.test.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.test.mjs
@@ -86,6 +86,8 @@ import {
   convergeDispositionLabel,
   HELD_LABEL_WAITING,
   HELD_LABEL_NEEDS_INPUT,
+  // CTL-1524 (C4a): hoisted dead-host computation (one surviving-roster read)
+  computeDeadHosts,
 } from "./scheduler.mjs";
 import { createTicketStateCache } from "./linear-cache.mjs";
 import { fetchTicketsBatch } from "./linear-query.mjs"; // CTL-784: cache-reuse tests drive the real batch
@@ -12440,5 +12442,86 @@ describe("CTL-764 Phase 5 — schedulerTick emits worker.transition events", () 
       (e) => e.ticket === "CTL-R53" && e.toDisposition === null && e.source === "scheduler-admission"
     );
     expect(cleared).toBeUndefined();
+  });
+});
+
+// ─── CTL-1524 (C4a) — computeDeadHosts calls computeSurvivingRoster ONCE ──────
+// The daemon's board-health binding used to read
+//   roster.filter((h) => !computeSurvivingRoster(roster).includes(h))
+// which re-ran the whole surviving computation once PER HOST. computeSurvivingRoster's
+// default readHeartbeats is readClusterHeartbeats — a whole-file read of the event log
+// (883MB on mini, ~305ms under bun), so at N=2 one deadHosts evaluation cost TWO full-log
+// reads (~610ms), which is exactly the measured 609.6ms "board-health" lap floor.
+describe("computeDeadHosts (CTL-1524 C4a)", () => {
+  test("invokes computeSurvivingRoster EXACTLY ONCE regardless of roster size", () => {
+    for (const size of [2, 3, 8, 25]) {
+      const roster = Array.from({ length: size }, (_, i) => `host-${i}`);
+      let calls = 0;
+      computeDeadHosts(roster, {
+        computeSurviving: (r) => {
+          calls++;
+          return r.slice(0, 1); // only the first host survives
+        },
+      });
+      expect(calls).toBe(1); // NOT `size` — the pre-CTL-1524 binding scaled with N
+    }
+  });
+
+  test("returns exactly the roster minus the surviving set", () => {
+    const roster = ["mini", "mini-2", "laptop"];
+    const dead = computeDeadHosts(roster, { computeSurviving: () => ["mini"] });
+    expect(dead.sort()).toEqual(["laptop", "mini-2"]);
+  });
+
+  test("byte-identical to the old per-host filter for every REACHABLE survivor subset", () => {
+    const roster = ["a", "b", "c", "d"];
+    // Every NON-EMPTY subset — the full reachable range of computeSurvivingRoster,
+    // which guarantees `alive.length > 0 ? alive : roster` and so can never return
+    // []. (The unreachable empty case is deliberately NOT byte-identical: see the
+    // degenerate-survivor-set test below, where the old filter would have called the
+    // entire fleet dead and the new one fails safe to no failover.)
+    const subsets = [["a"], ["b", "d"], ["a", "b", "c", "d"], ["a", "c"], ["d"]];
+    for (const surviving of subsets) {
+      const oldWay = roster.filter((h) => !surviving.includes(h));
+      const newWay = computeDeadHosts(roster, { computeSurviving: () => surviving });
+      expect(newWay).toEqual(oldWay);
+    }
+  });
+
+  test("single-host / empty / non-array roster → EMPTY dead set with NO read at all", () => {
+    let calls = 0;
+    const spy = (r) => {
+      calls++;
+      return r;
+    };
+    expect(computeDeadHosts(["solo"], { computeSurviving: spy })).toEqual([]);
+    expect(computeDeadHosts([], { computeSurviving: spy })).toEqual([]);
+    expect(computeDeadHosts(null, { computeSurviving: spy })).toEqual([]);
+    expect(computeDeadHosts(undefined, { computeSurviving: spy })).toEqual([]);
+    expect(calls).toBe(0); // N<=1 short-circuits before the heartbeat read
+  });
+
+  test("FAIL-SAFE preserved: a degrade-to-full-roster survivor set yields NO dead hosts", () => {
+    // computeSurvivingRoster returns the FULL roster when the heartbeat read throws or
+    // everyone looks dead. That must mean "no failover this tick", never "all dead".
+    const roster = ["mini", "mini-2"];
+    expect(computeDeadHosts(roster, { computeSurviving: (r) => r })).toEqual([]);
+  });
+
+  test("a degenerate survivor set (empty/non-array/throw) yields NO dead hosts, never 'all dead'", () => {
+    const roster = ["mini", "mini-2"];
+    // computeSurvivingRoster never returns empty (`alive.length > 0 ? alive : roster`),
+    // so these mean the computation misbehaved — not that the fleet died. Declaring
+    // every host dead here would hand the whole board to a foreign failover.
+    expect(computeDeadHosts(roster, { computeSurviving: () => [] })).toEqual([]);
+    expect(computeDeadHosts(roster, { computeSurviving: () => null })).toEqual([]);
+    expect(computeDeadHosts(roster, { computeSurviving: () => undefined })).toEqual([]);
+    expect(
+      computeDeadHosts(roster, {
+        computeSurviving: () => {
+          throw new Error("heartbeat read blew up");
+        },
+      })
+    ).toEqual([]);
   });
 });

--- a/plugins/dev/scripts/execution-core/wt-cleanup-drain.mjs
+++ b/plugins/dev/scripts/execution-core/wt-cleanup-drain.mjs
@@ -47,13 +47,33 @@ const DEFAULT_QUEUE_DIR = join(homedir(), "catalyst", "wt-cleanup-queue");
 // Override with CATALYST_WT_DRAIN_BATCH_CAP (existing env idiom).
 const DEFAULT_BATCH_CAP = 2;
 
+// Per-fire bound on short-circuit marker WRITES. The refresh below is idempotent,
+// so steady state is zero writes; this only paces the one-time backfill when a
+// large pre-existing queue is swept for the first time. Override with
+// CATALYST_WT_DRAIN_SC_WRITE_CAP.
+const DEFAULT_SHORT_CIRCUIT_WRITE_CAP = 100;
+
+// DEFAULT_ATTEMPT_MEMO — in-process rotation clock, keyed by marker file path.
+// stampAttempt records the attempt here REGARDLESS of whether persisting
+// `lastAttemptAt` to disk succeeded. Without it, a marker the daemon cannot rewrite
+// (read-only/full queue dir, bad perms) keeps the oldest sort key forever, sorts
+// first on every fire, and — once batchCap such markers exist — consumes the whole
+// batch budget in perpetuity so no other worktree ever gets an expensive attempt.
+// The daemon is long-lived and sweeps run in-process, so this survives across fires.
+// Pruned to the live marker set each sweep, so it cannot outgrow the queue.
+const DEFAULT_ATTEMPT_MEMO = new Map();
+
 // attemptOrderMs — the marker's last EXPENSIVE attempt as an epoch-ms sort key.
 // Never-attempted (and unparseable) sorts to 0 ⇒ picked first. Used to rotate the
 // bounded batch least-recently-attempted-first so a stable readdir order cannot
-// starve a marker at the tail of the queue forever (C3).
-function attemptOrderMs(marker) {
-  const v = Date.parse(marker?.lastAttemptAt ?? "");
-  return Number.isFinite(v) ? v : 0;
+// starve a marker at the tail of the queue forever (C3). Takes the LATER of the
+// on-disk stamp and the in-process memo: when the write succeeded they agree, and
+// when it failed the memo is the only truthful record.
+function attemptOrderMs(marker, file, memo) {
+  const disk = Date.parse(marker?.lastAttemptAt ?? "");
+  const diskMs = Number.isFinite(disk) ? disk : 0;
+  const memoMs = Number(memo?.get(file)) || 0;
+  return Math.max(diskMs, memoMs);
 }
 
 // defaultConfirmMerged — confirm a marker's PR is GitHub-merged, the SAME dual-field
@@ -106,6 +126,9 @@ export async function sweepWtCleanupQueue({
   // up-front with the SAME orchDirs. Injected so the unit test can drive both sides.
   hasProvenance = hasOrchProvenance,
   batchCap = Number(process.env.CATALYST_WT_DRAIN_BATCH_CAP) || DEFAULT_BATCH_CAP,
+  shortCircuitWriteCap = Number(process.env.CATALYST_WT_DRAIN_SC_WRITE_CAP) ||
+    DEFAULT_SHORT_CIRCUIT_WRITE_CAP,
+  attemptMemo = DEFAULT_ATTEMPT_MEMO,
   now = () => Date.now(),
   log = defaultLog,
 } = {}) {
@@ -117,8 +140,10 @@ export async function sweepWtCleanupQueue({
     removed: 0,
     stillDeferred: 0,
     shortCircuited: 0, // CTL-1524 (C2): resolved by the free provenance gate alone
+    shortCircuitWrites: 0, // marker refreshes actually written (idempotent ⇒ ~0 at rest)
     errors: 0,
     batchCapped: false,
+    shortCircuitWriteCapped: false,
     durationMs: 0,
   };
 
@@ -139,6 +164,8 @@ export async function sweepWtCleanupQueue({
           errors: result.errors,
           batchCapped: result.batchCapped,
           shortCircuited: result.shortCircuited,
+          shortCircuitWrites: result.shortCircuitWrites,
+          shortCircuitWriteCapped: result.shortCircuitWriteCapped,
         },
         "wt-cleanup-drain: sweep timing"
       );
@@ -186,9 +213,22 @@ export async function sweepWtCleanupQueue({
     entries.push({ file, marker, worktreePath });
   }
 
+  // Prune the rotation memo to the live marker set, so it is bounded by queue depth
+  // and cannot retain keys for markers that have been cleared.
+  try {
+    const live = new Set(entries.map((e) => e.file));
+    for (const k of attemptMemo.keys()) if (!live.has(k)) attemptMemo.delete(k);
+  } catch {
+    /* memo is an optimisation only — never let it break the sweep */
+  }
+
   // C3 — least-recently-attempted first. Array.prototype.sort is stable, so markers
   // that have never had an expensive attempt (key 0) keep their relative order.
-  entries.sort((a, b) => attemptOrderMs(a.marker) - attemptOrderMs(b.marker));
+  entries.sort(
+    (a, b) =>
+      attemptOrderMs(a.marker, a.file, attemptMemo) -
+      attemptOrderMs(b.marker, b.file, attemptMemo)
+  );
 
   for (const { file, marker, worktreePath } of entries) {
     // Already-gone worktree → just clear the stale marker (the post-removal bulk).
@@ -222,6 +262,22 @@ export async function sweepWtCleanupQueue({
     }
     if (!provenance) {
       result.shortCircuited++;
+      // The refresh is IDEMPOTENT. This cohort is strictly monotonic — once a
+      // worker dir is GC'd at teardown, provenance can never be re-established —
+      // so rewriting every retained marker on every 600s fire would make write
+      // volume scale with queue depth forever, writing content that never changes
+      // after the first time. Write only when the marker does not already record
+      // this short-circuit; at rest this cohort therefore costs ZERO writes and
+      // its per-marker work is one stat plus one existsSync. The cap paces the
+      // one-time backfill when a large pre-existing queue is first swept.
+      const alreadyRecorded =
+        marker.shortCircuit === "unknown-provenance" && marker.reasonsPartial === true;
+      if (alreadyRecorded) continue;
+      if (result.shortCircuitWrites >= shortCircuitWriteCap) {
+        result.shortCircuitWriteCapped = true;
+        continue;
+      }
+      result.shortCircuitWrites++;
       try {
         writeFileFn(
           file,
@@ -237,7 +293,9 @@ export async function sweepWtCleanupQueue({
             reasons: ["unknown-provenance"],
             shortCircuit: "unknown-provenance",
             reasonsPartial: true,
-            lastShortCircuitAt: new Date(now()).toISOString(),
+            // WRITE-ONCE, so this is when the short-circuit was FIRST recorded —
+            // not the latest sweep that observed it. Named accordingly.
+            shortCircuitSince: new Date(now()).toISOString(),
           })
         );
       } catch {
@@ -279,7 +337,7 @@ export async function sweepWtCleanupQueue({
     } catch (err) {
       log.warn({ worktreePath, err: err?.message }, "wt-cleanup-drain: safeTeardown threw");
       result.errors++;
-      stampAttempt({ file, marker, attemptedAt, readFileFn, writeFileFn, pathExists });
+      stampAttempt({ file, marker, attemptedAt, readFileFn, writeFileFn, pathExists, attemptMemo });
       continue;
     }
 
@@ -296,7 +354,7 @@ export async function sweepWtCleanupQueue({
       }
     } else {
       result.stillDeferred++;
-      stampAttempt({ file, marker, attemptedAt, readFileFn, writeFileFn, pathExists });
+      stampAttempt({ file, marker, attemptedAt, readFileFn, writeFileFn, pathExists, attemptMemo });
     }
   }
 
@@ -308,7 +366,26 @@ export async function sweepWtCleanupQueue({
 // deferWorktreeCleanup just wrote (its FULL reason set) rather than clobbering it
 // with the pre-attempt copy. Best-effort and never throws: a failed stamp costs at
 // most one unfair rotation, never correctness.
-function stampAttempt({ file, marker, attemptedAt, readFileFn, writeFileFn, pathExists }) {
+function stampAttempt({
+  file,
+  marker,
+  attemptedAt,
+  readFileFn,
+  writeFileFn,
+  pathExists,
+  attemptMemo,
+}) {
+  // Record the attempt in-process FIRST, before any fallible IO. This is what keeps
+  // rotation fair when the on-disk stamp cannot be persisted: a marker the daemon
+  // cannot rewrite would otherwise keep the oldest sort key, sort first on every
+  // fire, and permanently consume the batch budget (with batchCap=1, ONE unwritable
+  // marker is enough to starve every other worktree forever).
+  try {
+    const ms = Date.parse(attemptedAt);
+    if (Number.isFinite(ms)) attemptMemo?.set?.(file, ms);
+  } catch {
+    /* memo is an optimisation only */
+  }
   try {
     if (!pathExists(file)) return; // teardown cleared it mid-flight — never resurrect
   } catch {

--- a/plugins/dev/scripts/execution-core/wt-cleanup-drain.mjs
+++ b/plugins/dev/scripts/execution-core/wt-cleanup-drain.mjs
@@ -16,16 +16,45 @@
 // real disk, git, or gh. Wired into the existing 600s orphan-reaper timer
 // (orphan-reaper-timer.mjs) — no new daemon timer.
 
-import { readdirSync, readFileSync, existsSync, rmSync } from "node:fs";
+// CTL-1524: this sweep runs on the 600s orphan-reaper timer in the SAME process and
+// event loop as the daemon's heartbeat setInterval, and every probe it makes is
+// SYNCHRONOUS. Measured on mini: event-loop delay inside a drain burst had a median
+// of 77.5s (p90 88.6s, max 97.7s) against 6.1s outside one; 46 of 46 readings >60s
+// fell inside a burst and ZERO outside. With HEARTBEAT_INTERVAL_MS=30000 that
+// contiguous block IS the observed node.heartbeat starvation. The decisive detail:
+// 692 of 692 deferred markers failed on `unknown-provenance` alone — a free
+// existsSync — yet each one still paid TWO `gh` round-trips (confirmMerged) plus a
+// recursive `lsof -nP +D <worktree>` (1.85s on a 104,525-file tree) and a
+// `git status` before reaching a conclusion that was already available. Three fixes
+// below: C1 instruments the sweep, C2 evaluates the free deterministic gate FIRST,
+// C3 bounds the per-fire burst regardless of queue depth.
+
+import { readdirSync, readFileSync, existsSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { homedir } from "node:os";
-import { safeTeardownWorktree, listOrchDirs } from "./worktree-safety.mjs";
+import { safeTeardownWorktree, listOrchDirs, hasOrchProvenance } from "./worktree-safety.mjs";
 import { getExecutionCoreDir, log as defaultLog } from "./config.mjs";
 import { makePrView } from "./scan-adapters.mjs";
 import { defaultResolvePrForEvent } from "./reaper.mjs";
 
 const DEFAULT_QUEUE_DIR = join(homedir(), "catalyst", "wt-cleanup-queue");
-const DEFAULT_BATCH_CAP = 100;
+// CTL-1524 (C3): 2, not 100. The old cap could never trip at the observed n=15, so
+// the burst length was set by queue depth rather than by any bound. Each EXPENSIVE
+// re-attempt costs ~2 synchronous `gh` round-trips + a recursive lsof descent
+// (~1.85s measured) + a `git status`, so a cap of 2 keeps one fire to a couple of
+// seconds of event-loop occupancy. Throughput is unaffected in practice: 2 expensive
+// attempts x 144 fires/day = 288/day against a queue that has held ~15 markers.
+// Override with CATALYST_WT_DRAIN_BATCH_CAP (existing env idiom).
+const DEFAULT_BATCH_CAP = 2;
+
+// attemptOrderMs — the marker's last EXPENSIVE attempt as an epoch-ms sort key.
+// Never-attempted (and unparseable) sorts to 0 ⇒ picked first. Used to rotate the
+// bounded batch least-recently-attempted-first so a stable readdir order cannot
+// starve a marker at the tail of the queue forever (C3).
+function attemptOrderMs(marker) {
+  const v = Date.parse(marker?.lastAttemptAt ?? "");
+  return Number.isFinite(v) ? v : 0;
+}
 
 // defaultConfirmMerged — confirm a marker's PR is GitHub-merged, the SAME dual-field
 // check the gate uses (state === "MERGED" || mergedAt != null). Fail-CLOSED: any
@@ -50,7 +79,16 @@ function defaultConfirmMerged(marker, { prView, resolvePr } = {}) {
 /**
  * sweepWtCleanupQueue — drain ~/catalyst/wt-cleanup-queue/*.json once. Fail-soft,
  * bounded, idempotent. Returns a summary:
- *   { scanned, cleared, reattempted, removed, stillDeferred, errors, batchCapped }
+ *   { scanned, cleared, reattempted, removed, stillDeferred, shortCircuited,
+ *     errors, batchCapped, durationMs }
+ *
+ * Per-marker cost ladder, cheapest first (CTL-1524 C2) — the sweep never pays a
+ * rung it does not need:
+ *   1. pathExists   — one stat; gone ⇒ clear the marker.
+ *   2. provenance   — one existsSync per orchDir; absent ⇒ removal is IMPOSSIBLE
+ *                     this sweep, so refresh the marker and stop here.
+ *   3. confirmMerged (2 gh round-trips) + safeTeardown (lsof descent + git status),
+ *                     bounded by batchCap.
  *
  * @returns {Promise<object>}
  */
@@ -59,21 +97,55 @@ export async function sweepWtCleanupQueue({
   orchDir = getExecutionCoreDir(),
   readDir = (p) => readdirSync(p),
   readFileFn = (p) => readFileSync(p, "utf8"),
+  writeFileFn = (p, s) => writeFileSync(p, s),
   pathExists = (p) => existsSync(p),
   clearMarker = (file) => rmSync(file, { force: true }),
   safeTeardown = safeTeardownWorktree,
   confirmMerged = (marker) => defaultConfirmMerged(marker),
+  // CTL-1524 (C2): the SAME predicate safeTeardownWorktree resolves internally, run
+  // up-front with the SAME orchDirs. Injected so the unit test can drive both sides.
+  hasProvenance = hasOrchProvenance,
   batchCap = Number(process.env.CATALYST_WT_DRAIN_BATCH_CAP) || DEFAULT_BATCH_CAP,
+  now = () => Date.now(),
   log = defaultLog,
 } = {}) {
+  const startedMs = now();
   const result = {
     scanned: 0,
     cleared: 0,
     reattempted: 0,
     removed: 0,
     stillDeferred: 0,
+    shortCircuited: 0, // CTL-1524 (C2): resolved by the free provenance gate alone
     errors: 0,
     batchCapped: false,
+    durationMs: 0,
+  };
+
+  // finish — CTL-1524 (C1). ONE structured line per fire, including a no-op sweep,
+  // so `duration_ms` is the acceptance-criteria surface for the event-loop block.
+  // Cheap and never-throwing: instrumentation must not be able to break the sweep.
+  const finish = () => {
+    result.durationMs = Math.max(0, now() - startedMs);
+    try {
+      log?.info?.(
+        {
+          duration_ms: result.durationMs,
+          scanned: result.scanned,
+          cleared: result.cleared,
+          reattempted: result.reattempted,
+          removed: result.removed,
+          deferred: result.stillDeferred,
+          errors: result.errors,
+          batchCapped: result.batchCapped,
+          shortCircuited: result.shortCircuited,
+        },
+        "wt-cleanup-drain: sweep timing"
+      );
+    } catch {
+      /* never let instrumentation break the sweep */
+    }
+    return result;
   };
 
   let files;
@@ -86,11 +158,14 @@ export async function sweepWtCleanupQueue({
         "wt-cleanup-drain: queue dir unreadable; skipping sweep"
       );
     }
-    return result;
+    return finish();
   }
 
   const orchDirs = [orchDir, ...listOrchDirs()];
 
+  // Parse every marker up-front (JSON.parse of a few hundred bytes each) so the
+  // bounded batch below can rotate by last-attempt instead of readdir order (C3).
+  const entries = [];
   for (const f of files) {
     result.scanned++;
     const file = join(queueDir, f);
@@ -108,7 +183,14 @@ export async function sweepWtCleanupQueue({
       result.errors++;
       continue;
     }
+    entries.push({ file, marker, worktreePath });
+  }
 
+  // C3 — least-recently-attempted first. Array.prototype.sort is stable, so markers
+  // that have never had an expensive attempt (key 0) keep their relative order.
+  entries.sort((a, b) => attemptOrderMs(a.marker) - attemptOrderMs(b.marker));
+
+  for (const { file, marker, worktreePath } of entries) {
     // Already-gone worktree → just clear the stale marker (the post-removal bulk).
     let exists;
     try {
@@ -126,12 +208,53 @@ export async function sweepWtCleanupQueue({
       continue;
     }
 
-    // Surviving worktree → re-attempt the gated teardown, bounded.
+    // CTL-1524 (C2) — THE FIX. hasOrchProvenance is a pure existsSync over orchDirs
+    // (worktree-safety.mjs), and isSafeToRemoveWorktree pushes "unknown-provenance"
+    // unconditionally when it is false, so `safe` can NEVER be true for this marker
+    // this sweep. Learn that here, for free, instead of after two gh round-trips and
+    // a full-tree lsof descent. This ONLY skips work: the drain performs no removal
+    // on this path, so the set of things it removes can only shrink, never grow.
+    let provenance;
+    try {
+      provenance = hasProvenance(marker.ticket ?? null, { orchDirs }) === true;
+    } catch {
+      provenance = false; // fail-closed: unreadable provenance is not evidence
+    }
+    if (!provenance) {
+      result.shortCircuited++;
+      try {
+        writeFileFn(
+          file,
+          JSON.stringify({
+            ...marker,
+            // HONEST ABBREVIATION: unlike isSafeToRemoveWorktree — which deliberately
+            // collects ALL failing gates with no short-circuit so a defer record is
+            // diagnostically complete — this reason set is PARTIAL. The merge, dirty-
+            // tree and liveness probes were never run, so their absence here is NOT
+            // evidence that they would have passed. `shortCircuit`/`reasonsPartial`
+            // exist so nobody later misreads the marker as "provenance was the only
+            // failing gate".
+            reasons: ["unknown-provenance"],
+            shortCircuit: "unknown-provenance",
+            reasonsPartial: true,
+            lastShortCircuitAt: new Date(now()).toISOString(),
+          })
+        );
+      } catch {
+        /* best-effort refresh — the marker already on disk stays valid either way */
+      }
+      continue;
+    }
+
+    // Surviving worktree WITH provenance → the full, unchanged gated teardown.
+    // The cap counts ONLY these expensive attempts, and `continue` (not `break`)
+    // so the free paths above keep draining the rest of the queue this fire.
     if (result.reattempted >= batchCap) {
       result.batchCapped = true;
-      break;
+      continue;
     }
     result.reattempted++;
+    const attemptedAt = new Date(now()).toISOString();
 
     let prMerged = false;
     try {
@@ -156,6 +279,7 @@ export async function sweepWtCleanupQueue({
     } catch (err) {
       log.warn({ worktreePath, err: err?.message }, "wt-cleanup-drain: safeTeardown threw");
       result.errors++;
+      stampAttempt({ file, marker, attemptedAt, readFileFn, writeFileFn, pathExists });
       continue;
     }
 
@@ -172,8 +296,33 @@ export async function sweepWtCleanupQueue({
       }
     } else {
       result.stillDeferred++;
+      stampAttempt({ file, marker, attemptedAt, readFileFn, writeFileFn, pathExists });
     }
   }
 
-  return result;
+  return finish();
+}
+
+// stampAttempt — record the expensive attempt on the retained marker so the next
+// sweep's batch rotates past it (C3). Re-reads first so it merges onto whatever
+// deferWorktreeCleanup just wrote (its FULL reason set) rather than clobbering it
+// with the pre-attempt copy. Best-effort and never throws: a failed stamp costs at
+// most one unfair rotation, never correctness.
+function stampAttempt({ file, marker, attemptedAt, readFileFn, writeFileFn, pathExists }) {
+  try {
+    if (!pathExists(file)) return; // teardown cleared it mid-flight — never resurrect
+  } catch {
+    /* probe failed → fall through and attempt the stamp */
+  }
+  let current = marker;
+  try {
+    current = JSON.parse(readFileFn(file));
+  } catch {
+    /* unreadable → stamp onto the pre-attempt copy */
+  }
+  try {
+    writeFileFn(file, JSON.stringify({ ...current, lastAttemptAt: attemptedAt }));
+  } catch {
+    /* best-effort */
+  }
 }

--- a/plugins/dev/scripts/execution-core/wt-cleanup-drain.test.mjs
+++ b/plugins/dev/scripts/execution-core/wt-cleanup-drain.test.mjs
@@ -317,7 +317,7 @@ describe("sweepWtCleanupQueue — CTL-1524 C2 free-gate short-circuit", () => {
     expect(m.reasons).toEqual(["unknown-provenance"]);
     expect(m.shortCircuit).toBe("unknown-provenance");
     expect(m.reasonsPartial).toBe(true); // NOT "provenance was the only failing gate"
-    expect(m.lastShortCircuitAt).toBeTruthy();
+    expect(m.shortCircuitSince).toBeTruthy(); // write-once: FIRST short-circuit, not latest
     expect(m.worktreePath).toBe(alive); // identity preserved
   });
 
@@ -530,6 +530,130 @@ describe("sweepWtCleanupQueue — CTL-1524 C3 bounded, fair batch", () => {
     const m = JSON.parse(readFileSync(file, "utf8"));
     expect(m.reasons).toEqual(["not-merged", "dirty-worktree"]); // NOT clobbered
     expect(m.lastAttemptAt).toBeTruthy(); // stamp applied on top
+  });
+
+  // ── Codex review (PR #2747, P2 x2) ─────────────────────────────────────────
+  it("the short-circuit refresh is IDEMPOTENT — an already-recorded marker is never rewritten again", async () => {
+    // This cohort is strictly monotonic, so rewriting each retained marker on every
+    // 600s fire would make write volume grow with queue depth forever.
+    const wt = join(tmp, "wt", "IDEM-1");
+    const file = writeMarker(queueDir, { worktreePath: wt, ticket: "CTL-IDEM" });
+    const writes = [];
+    const opts = () => ({
+      queueDir,
+      pathExists: () => true,
+      hasProvenance: () => false, // always short-circuits
+      writeFileFn: (p, str) => {
+        writes.push(p);
+        writeFileSync(p, str);
+      },
+      confirmMerged: () => {
+        throw new Error("must not be reached");
+      },
+      safeTeardown: () => {
+        throw new Error("must not be reached");
+      },
+      log: silentLog(),
+    });
+
+    const first = await sweepWtCleanupQueue(opts());
+    expect(first.shortCircuited).toBe(1);
+    expect(first.shortCircuitWrites).toBe(1); // first sweep records it
+    expect(writes.length).toBe(1);
+
+    const m = JSON.parse(readFileSync(file, "utf8"));
+    expect(m.shortCircuit).toBe("unknown-provenance");
+    expect(m.reasonsPartial).toBe(true);
+    expect(m.shortCircuitSince).toBeTruthy();
+
+    // Steady state: still counted, but ZERO further writes across many fires.
+    for (let i = 0; i < 5; i++) {
+      const again = await sweepWtCleanupQueue(opts());
+      expect(again.shortCircuited).toBe(1); // still observed
+      expect(again.shortCircuitWrites).toBe(0); // but never rewritten
+    }
+    expect(writes.length).toBe(1);
+    // The first-recorded timestamp is preserved, not churned.
+    expect(JSON.parse(readFileSync(file, "utf8")).shortCircuitSince).toBe(m.shortCircuitSince);
+  });
+
+  it("the short-circuit WRITE budget is bounded per fire (paces a large first-time backfill)", async () => {
+    for (let i = 0; i < 10; i++) {
+      writeMarker(queueDir, { worktreePath: join(tmp, "wt", `SC-${i}`), ticket: `CTL-SC${i}` });
+    }
+    const r = await sweepWtCleanupQueue({
+      queueDir,
+      pathExists: () => true,
+      hasProvenance: () => false,
+      shortCircuitWriteCap: 3,
+      log: silentLog(),
+    });
+    expect(r.shortCircuited).toBe(10); // all still observed (free)
+    expect(r.shortCircuitWrites).toBe(3); // but writes bounded
+    expect(r.shortCircuitWriteCapped).toBe(true);
+  });
+
+  it("rotation still advances when the attempt stamp CANNOT be persisted (unwritable marker)", async () => {
+    // With batchCap=1, a single marker whose stamp write always fails would keep the
+    // oldest sort key, sort first every fire, and starve every other worktree forever.
+    const tickets = ["CTL-W1", "CTL-W2", "CTL-W3"];
+    for (const t of tickets) {
+      writeMarker(queueDir, { worktreePath: join(tmp, "wt", t), ticket: t });
+    }
+    const seen = [];
+    let clock = Date.parse("2026-07-25T00:00:00.000Z");
+    const memo = new Map(); // fresh per test — no cross-test leakage
+    const sweepOnce = () =>
+      sweepWtCleanupQueue({
+        queueDir,
+        pathExists: () => true,
+        hasProvenance: () => true,
+        confirmMerged: () => true,
+        // EVERY marker write fails — the on-disk lastAttemptAt can never land.
+        writeFileFn: () => {
+          throw new Error("EROFS: read-only file system");
+        },
+        safeTeardown: (args) => {
+          seen.push(args.ticket);
+          return { removed: false, deferred: true, reasons: ["x"] };
+        },
+        batchCap: 1,
+        attemptMemo: memo,
+        now: () => (clock += 60_000),
+        log: silentLog(),
+      });
+
+    await sweepOnce();
+    await sweepOnce();
+    await sweepOnce();
+
+    // No marker on disk carries a stamp...
+    for (const t of tickets) {
+      const m = JSON.parse(readFileSync(markerFile(queueDir, join(tmp, "wt", t)), "utf8"));
+      expect(m.lastAttemptAt).toBeUndefined();
+    }
+    // ...yet every ticket still got its turn: rotation came from the in-process memo.
+    expect(seen.length).toBe(3);
+    expect([...new Set(seen)].sort()).toEqual(tickets);
+    await sweepOnce();
+    expect(seen[3]).toBe(seen[0]); // and it cycles, rather than repeating a prefix
+  });
+
+  it("the rotation memo is pruned to the live marker set (cannot outgrow the queue)", async () => {
+    const memo = new Map();
+    memo.set(join(queueDir, "stale-marker-that-no-longer-exists.json"), 123);
+    writeMarker(queueDir, { worktreePath: join(tmp, "wt", "P1"), ticket: "CTL-P1" });
+    await sweepWtCleanupQueue({
+      queueDir,
+      pathExists: () => true,
+      hasProvenance: () => true,
+      confirmMerged: () => true,
+      safeTeardown: () => ({ removed: false, deferred: true, reasons: ["x"] }),
+      attemptMemo: memo,
+      log: silentLog(),
+    });
+    expect([...memo.keys()].some((k) => k.includes("stale-marker"))).toBe(false);
+    expect(memo.size).toBe(1); // exactly the one live marker
   });
 
   it("the default batch cap is small (2) — the old 100 could never trip at the observed n=15", async () => {

--- a/plugins/dev/scripts/execution-core/wt-cleanup-drain.test.mjs
+++ b/plugins/dev/scripts/execution-core/wt-cleanup-drain.test.mjs
@@ -6,7 +6,9 @@
 // merge first. Every IO/spawn seam is injected — no real disk, git, gh.
 
 import { describe, it, expect, beforeEach, afterEach } from "bun:test";
-import { mkdtempSync, mkdirSync, writeFileSync, rmSync, existsSync, readdirSync } from "node:fs";
+import {
+  mkdtempSync, mkdirSync, writeFileSync, readFileSync, rmSync, existsSync, readdirSync,
+} from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { createHash } from "node:crypto";
@@ -72,6 +74,7 @@ describe("sweepWtCleanupQueue (CTL-1218 Part C)", () => {
     const res = await sweepWtCleanupQueue({
       queueDir,
       pathExists: () => true,
+      hasProvenance: () => true, // CTL-1524: past the free gate → full expensive path
       confirmMerged: () => true,
       safeTeardown: (args) => {
         teardownArgs.push(args);
@@ -97,6 +100,7 @@ describe("sweepWtCleanupQueue (CTL-1218 Part C)", () => {
     const res = await sweepWtCleanupQueue({
       queueDir,
       pathExists: () => true,
+      hasProvenance: () => true, // CTL-1524: past the free gate → full expensive path
       confirmMerged: () => false, // not merged → gate will defer
       safeTeardown: () => ({ removed: false, deferred: true, reasons: ["not-merged"] }),
       log: silentLog(),
@@ -113,6 +117,7 @@ describe("sweepWtCleanupQueue (CTL-1218 Part C)", () => {
     await sweepWtCleanupQueue({
       queueDir,
       pathExists: () => true,
+      hasProvenance: () => true, // CTL-1524: past the free gate → full expensive path
       confirmMerged: () => false, // NOT merged
       safeTeardown: (args) => {
         seen.push(args.prMerged);
@@ -129,6 +134,7 @@ describe("sweepWtCleanupQueue (CTL-1218 Part C)", () => {
     const res = await sweepWtCleanupQueue({
       queueDir,
       pathExists: () => true,
+      hasProvenance: () => true, // CTL-1524: all 5 are EXPENSIVE candidates → cap bites
       confirmMerged: () => true,
       safeTeardown: () => {
         attempts++;
@@ -207,5 +213,343 @@ describe("sweepWtCleanupQueue (CTL-1218 Part C)", () => {
     });
     expect(removeArg).toBe(alive); // remover called with the PATH only — no --force
     expect(res.removed).toBeGreaterThanOrEqual(1);
+  });
+});
+
+// ─── CTL-1524 — the drain must not block the event loop ──────────────────────
+// Measured on mini: the 600s drain ran 72-97s of SYNCHRONOUS work in the daemon's
+// own event loop, starving node.heartbeat (median event-loop delay 77.5s inside a
+// burst vs 6.1s outside; 46/46 readings >60s inside, 0 outside). 692/692 deferred
+// markers failed on `unknown-provenance` — a free existsSync — yet each still paid
+// 2 gh round-trips + a recursive lsof descent (1.85s on a 104k-file tree) first.
+describe("sweepWtCleanupQueue — CTL-1524 C1 sweep instrumentation", () => {
+  let tmp, queueDir;
+  beforeEach(() => {
+    tmp = mkdtempSync(join(tmpdir(), "ctl1524-drain-"));
+    queueDir = join(tmp, "queue");
+  });
+  afterEach(() => rmSync(tmp, { recursive: true, force: true }));
+
+  function capturingLog() {
+    const lines = [];
+    return { lines, info: (o, m) => lines.push([o, m]), warn: () => {}, error: () => {} };
+  }
+
+  it("emits ONE 'sweep timing' line per fire carrying duration_ms + every counter", async () => {
+    writeMarker(queueDir, { worktreePath: join(tmp, "wt", "T-1"), ticket: "CTL-T1" });
+    const log = capturingLog();
+    let t = 1000;
+    const res = await sweepWtCleanupQueue({
+      queueDir,
+      pathExists: () => true,
+      hasProvenance: () => false, // short-circuit cohort
+      now: () => (t += 5), // deterministic clock: start → finish = 5ms elapsed
+      log,
+    });
+    const timing = log.lines.filter(([, m]) => m === "wt-cleanup-drain: sweep timing");
+    expect(timing.length).toBe(1);
+    const fields = timing[0][0];
+    for (const k of [
+      "duration_ms", "scanned", "cleared", "reattempted",
+      "removed", "deferred", "errors", "batchCapped", "shortCircuited",
+    ]) {
+      expect(fields[k]).toBeDefined();
+    }
+    expect(typeof fields.duration_ms).toBe("number");
+    expect(fields.shortCircuited).toBe(1);
+    expect(res.durationMs).toBe(fields.duration_ms);
+  });
+
+  it("emits the timing line even on a NO-OP sweep (ENOENT queue dir)", async () => {
+    const log = capturingLog();
+    await sweepWtCleanupQueue({ queueDir: join(tmp, "nope"), log });
+    const timing = log.lines.filter(([, m]) => m === "wt-cleanup-drain: sweep timing");
+    expect(timing.length).toBe(1);
+    expect(timing[0][0].scanned).toBe(0);
+  });
+
+  it("instrumentation NEVER throws: a log.info that throws does not break the sweep", async () => {
+    writeMarker(queueDir, { worktreePath: join(tmp, "wt", "T-2"), ticket: "CTL-T2" });
+    const res = await sweepWtCleanupQueue({
+      queueDir,
+      pathExists: () => true,
+      hasProvenance: () => false,
+      log: { info: () => { throw new Error("log boom"); }, warn: () => {}, error: () => {} },
+    });
+    expect(res.shortCircuited).toBe(1); // sweep completed and returned normally
+  });
+});
+
+describe("sweepWtCleanupQueue — CTL-1524 C2 free-gate short-circuit", () => {
+  let tmp, queueDir;
+  beforeEach(() => {
+    tmp = mkdtempSync(join(tmpdir(), "ctl1524-c2-"));
+    queueDir = join(tmp, "queue");
+  });
+  afterEach(() => rmSync(tmp, { recursive: true, force: true }));
+
+  it("no provenance ⇒ confirmMerged and safeTeardown are NEVER called; marker refreshed; shortCircuited++", async () => {
+    const alive = join(tmp, "wt", "NOPROV-1");
+    const file = writeMarker(queueDir, {
+      worktreePath: alive,
+      ticket: "CTL-NP",
+      reasons: ["not-merged", "unknown-provenance"],
+    });
+    let mergedCalls = 0;
+    let teardownCalls = 0;
+    const res = await sweepWtCleanupQueue({
+      queueDir,
+      pathExists: () => true,
+      hasProvenance: () => false, // the 692/692 production cohort
+      confirmMerged: () => { mergedCalls++; return true; },
+      safeTeardown: () => { teardownCalls++; return { removed: true }; },
+      log: silentLog(),
+    });
+    // THE FIX: zero network round-trips, zero lsof descents.
+    expect(mergedCalls).toBe(0);
+    expect(teardownCalls).toBe(0);
+    expect(res.shortCircuited).toBe(1);
+    expect(res.reattempted).toBe(0);
+    expect(res.removed).toBe(0);
+    // The marker survives, refreshed and HONEST about being abbreviated.
+    expect(existsSync(file)).toBe(true);
+    const m = JSON.parse(readFileSync(file, "utf8"));
+    expect(m.reasons).toEqual(["unknown-provenance"]);
+    expect(m.shortCircuit).toBe("unknown-provenance");
+    expect(m.reasonsPartial).toBe(true); // NOT "provenance was the only failing gate"
+    expect(m.lastShortCircuitAt).toBeTruthy();
+    expect(m.worktreePath).toBe(alive); // identity preserved
+  });
+
+  it("a marker WITH provenance still goes through the full gate exactly as before", async () => {
+    const alive = join(tmp, "wt", "PROV-1");
+    writeMarker(queueDir, { worktreePath: alive, ticket: "CTL-P", branch: "CTL-P" });
+    const provArgs = [];
+    let mergedCalls = 0;
+    const teardownArgs = [];
+    const res = await sweepWtCleanupQueue({
+      queueDir,
+      pathExists: () => true,
+      hasProvenance: (ticket, opts) => { provArgs.push([ticket, opts]); return true; },
+      confirmMerged: () => { mergedCalls++; return true; },
+      safeTeardown: (args, deps) => { teardownArgs.push([args, deps]); return { removed: true }; },
+      log: silentLog(),
+    });
+    expect(mergedCalls).toBe(1);
+    expect(teardownArgs.length).toBe(1);
+    expect(teardownArgs[0][0]).toMatchObject({
+      ticket: "CTL-P", worktreePath: alive, branch: "CTL-P", terminal: true, prMerged: true,
+    });
+    expect(res.removed).toBe(1);
+    expect(res.shortCircuited).toBe(0);
+    // The pre-check uses the SAME ticket and the SAME orchDirs the gate resolves with,
+    // so the two can never disagree about provenance.
+    expect(provArgs[0][0]).toBe("CTL-P");
+    expect(provArgs[0][1].orchDirs).toEqual(teardownArgs[0][1].orchDirs);
+  });
+
+  it("SAFETY INVARIANT: the short-circuit can only ever remove FEWER things, never more", async () => {
+    // Drive the identical inputs twice — once with the free gate reached (new path)
+    // and once forced down the old always-expensive path — and assert the new run's
+    // removals are a SUBSET. The short-circuit performs no removal at all, so for
+    // every no-provenance marker: old = defer (isSafeToRemoveWorktree pushes
+    // "unknown-provenance" ⇒ safe:false), new = defer. Same outcome, no probes.
+    const cases = [
+      { ticket: "CTL-A", prov: false, merged: true },
+      { ticket: "CTL-B", prov: true, merged: true },
+      { ticket: "CTL-C", prov: false, merged: false },
+      { ticket: "CTL-D", prov: true, merged: false },
+    ];
+    for (const c of cases) {
+      writeMarker(queueDir, { worktreePath: join(tmp, "wt", c.ticket), ticket: c.ticket });
+    }
+    const provOf = (t) => cases.find((c) => c.ticket === t).prov;
+    const mergedOf = (t) => cases.find((c) => c.ticket === t).merged;
+    // The REAL gate semantics: removal requires provenance AND merge (plus the
+    // clean/liveness gates, held passing here).
+    const realGate = (args) =>
+      provOf(args.ticket) && args.prMerged === true
+        ? { removed: true }
+        : { removed: false, deferred: true, reasons: ["gate"] };
+
+    const newRemoved = [];
+    await sweepWtCleanupQueue({
+      queueDir,
+      pathExists: () => true,
+      batchCap: 99,
+      hasProvenance: (t) => provOf(t),
+      confirmMerged: (m) => mergedOf(m.ticket),
+      safeTeardown: (args) => {
+        const o = realGate(args);
+        if (o.removed) newRemoved.push(args.ticket);
+        return o;
+      },
+      log: silentLog(),
+    });
+
+    const oldRemoved = [];
+    await sweepWtCleanupQueue({
+      queueDir,
+      pathExists: () => true,
+      batchCap: 99,
+      hasProvenance: () => true, // force EVERY marker down the pre-C2 expensive path
+      confirmMerged: (m) => mergedOf(m.ticket),
+      safeTeardown: (args) => {
+        const o = realGate(args); // gate still consults REAL provenance internally
+        if (o.removed) oldRemoved.push(args.ticket);
+        return o;
+      },
+      log: silentLog(),
+    });
+
+    // Subset in both directions of the claim: nothing new appeared...
+    for (const t of newRemoved) expect(oldRemoved).toContain(t);
+    // ...and the only things skipped were ones the old path also refused.
+    expect(newRemoved.sort()).toEqual(oldRemoved.sort());
+    expect(newRemoved).toEqual(["CTL-B"]); // provenance AND merged — the only removable one
+  });
+});
+
+describe("sweepWtCleanupQueue — CTL-1524 C3 bounded, fair batch", () => {
+  let tmp, queueDir;
+  beforeEach(() => {
+    tmp = mkdtempSync(join(tmpdir(), "ctl1524-c3-"));
+    queueDir = join(tmp, "queue");
+  });
+  afterEach(() => rmSync(tmp, { recursive: true, force: true }));
+
+  it("the cap counts ONLY expensive attempts — N short-circuits never consume the budget", async () => {
+    // 6 no-provenance markers (free) + 2 with provenance (expensive), cap = 2.
+    // The free cohort must ALL be processed and must not trip the cap.
+    const expensive = new Set(["CTL-E1", "CTL-E2"]);
+    for (let i = 0; i < 6; i++) {
+      writeMarker(queueDir, { worktreePath: join(tmp, "wt", `F-${i}`), ticket: `CTL-F${i}` });
+    }
+    for (const t of expensive) {
+      writeMarker(queueDir, { worktreePath: join(tmp, "wt", t), ticket: t });
+    }
+    let attempts = 0;
+    const res = await sweepWtCleanupQueue({
+      queueDir,
+      pathExists: () => true,
+      hasProvenance: (t) => expensive.has(t),
+      confirmMerged: () => true,
+      safeTeardown: () => {
+        attempts++;
+        return { removed: false, deferred: true, reasons: ["x"] };
+      },
+      batchCap: 2,
+      log: silentLog(),
+    });
+    expect(attempts).toBe(2); // both expensive ones ran — the cap was NOT eaten by the free cohort
+    expect(res.shortCircuited).toBe(6); // every free marker still processed this fire
+    expect(res.reattempted).toBe(2);
+    expect(res.batchCapped).toBe(false); // exactly at cap, nothing turned away
+  });
+
+  it("the free cohort keeps draining AFTER the cap is hit (continue, not break)", async () => {
+    for (let i = 0; i < 3; i++) {
+      writeMarker(queueDir, { worktreePath: join(tmp, "wt", `X-${i}`), ticket: `CTL-X${i}` });
+    }
+    for (let i = 0; i < 4; i++) {
+      writeMarker(queueDir, { worktreePath: join(tmp, "wt", `Y-${i}`), ticket: `CTL-Y${i}` });
+    }
+    const res = await sweepWtCleanupQueue({
+      queueDir,
+      pathExists: () => true,
+      hasProvenance: (t) => t.startsWith("CTL-Y"), // 4 expensive, cap 1 → 3 turned away
+      confirmMerged: () => true,
+      safeTeardown: () => ({ removed: false, deferred: true, reasons: ["x"] }),
+      batchCap: 1,
+      log: silentLog(),
+    });
+    expect(res.reattempted).toBe(1);
+    expect(res.batchCapped).toBe(true);
+    expect(res.shortCircuited).toBe(3); // all 3 free ones handled despite the cap tripping
+  });
+
+  it("fair rotation: the least-recently-attempted marker is picked next sweep", async () => {
+    const tickets = ["CTL-R1", "CTL-R2", "CTL-R3"];
+    for (const t of tickets) {
+      writeMarker(queueDir, { worktreePath: join(tmp, "wt", t), ticket: t });
+    }
+    const seen = [];
+    let clock = Date.parse("2026-07-25T00:00:00.000Z");
+    const sweepOnce = () =>
+      sweepWtCleanupQueue({
+        queueDir,
+        pathExists: () => true,
+        hasProvenance: () => true,
+        confirmMerged: () => true,
+        safeTeardown: (args) => {
+          seen.push(args.ticket);
+          return { removed: false, deferred: true, reasons: ["x"] };
+        },
+        batchCap: 1, // exactly one expensive attempt per fire
+        now: () => (clock += 60_000), // each sweep advances the clock
+        log: silentLog(),
+      });
+
+    await sweepOnce();
+    await sweepOnce();
+    await sweepOnce();
+    // Every ticket got a turn before any ticket got a second one — no starvation
+    // from a stable readdir order.
+    expect(seen.length).toBe(3);
+    expect([...new Set(seen)].sort()).toEqual(tickets);
+
+    // And the stamp is what drives it: the marker carries lastAttemptAt.
+    for (const t of tickets) {
+      const m = JSON.parse(readFileSync(markerFile(queueDir, join(tmp, "wt", t)), "utf8"));
+      expect(m.lastAttemptAt).toBeTruthy();
+    }
+
+    // A 4th sweep returns to the least-recently-attempted (the first one tried).
+    await sweepOnce();
+    expect(seen[3]).toBe(seen[0]);
+  });
+
+  it("the attempt stamp merges onto the marker the gate just rewrote (full reasons preserved)", async () => {
+    const alive = join(tmp, "wt", "STAMP-1");
+    const file = writeMarker(queueDir, { worktreePath: alive, ticket: "CTL-S" });
+    await sweepWtCleanupQueue({
+      queueDir,
+      pathExists: () => true,
+      hasProvenance: () => true,
+      confirmMerged: () => false,
+      safeTeardown: () => {
+        // stand in for deferWorktreeCleanup rewriting the marker with FULL reasons
+        writeFileSync(
+          file,
+          JSON.stringify({ worktreePath: alive, ticket: "CTL-S", reasons: ["not-merged", "dirty-worktree"] })
+        );
+        return { removed: false, deferred: true, reasons: ["not-merged", "dirty-worktree"] };
+      },
+      log: silentLog(),
+    });
+    const m = JSON.parse(readFileSync(file, "utf8"));
+    expect(m.reasons).toEqual(["not-merged", "dirty-worktree"]); // NOT clobbered
+    expect(m.lastAttemptAt).toBeTruthy(); // stamp applied on top
+  });
+
+  it("the default batch cap is small (2) — the old 100 could never trip at the observed n=15", async () => {
+    for (let i = 0; i < 15; i++) {
+      writeMarker(queueDir, { worktreePath: join(tmp, "wt", `D-${i}`), ticket: `CTL-D${i}` });
+    }
+    let attempts = 0;
+    const res = await sweepWtCleanupQueue({
+      queueDir,
+      pathExists: () => true,
+      hasProvenance: () => true,
+      confirmMerged: () => true,
+      safeTeardown: () => {
+        attempts++;
+        return { removed: false, deferred: true, reasons: ["x"] };
+      },
+      // no batchCap override → the module default
+      log: silentLog(),
+    });
+    expect(attempts).toBe(2);
+    expect(res.batchCapped).toBe(true);
   });
 });


### PR DESCRIPTION
## Problem

`wt-cleanup-drain` runs on the 600s orphan-reaper timer **in the same process and event loop** as the daemon's `node.heartbeat` `setInterval`, and every probe it makes is synchronous.

Measured on mini:

| event-loop delay | inside a drain burst | outside |
| --- | --- | --- |
| median | **77,513 ms** | 6,118 ms |
| p90 | **88,590 ms** | 10,848 ms |
| max | **97,734 ms** | — |

**46 of 46 readings >60s fall inside a drain burst; zero outside.** Burst span median 72.3s, 15 markers each, cadence 605s. mini-2 is a clean control: 0 markers, 0 stalls >60s. With `HEARTBEAT_INTERVAL_MS=30000`, a 72–97s contiguous block **is** the observed heartbeat starvation.

The scheduler tick was **not** the cause — no tick body ever exceeded 33s, so the tick alone could never explain a 268s gap. (The earlier "board-health = 46% of tick time" reading was lap-label misattribution: `pass_durations` keys are lap *suffix* labels.)

**Mechanism:** 692 of 692 deferred markers failed on `unknown-provenance` alone — a free `existsSync` — yet each still paid two `gh` round-trips (`confirmMerged`) plus a recursive `lsof -nP +D` (**1.85s** measured on a 104,525-file tree) and a `git status`, all *before* learning removal was already impossible. 15 markers ⇒ ~1,987,680 files walked every 600s.

## Changes

- **C1 — instrument.** One structured `wt-cleanup-drain: sweep timing` line per fire carrying `duration_ms` + every counter, emitted even on a no-op sweep. Never throws.
- **C2 — free gate first (the fix).** Evaluate `hasOrchProvenance` up front. It is the *same* predicate, with the *same* ticket and the *same* `orchDirs`, that `safeTeardownWorktree` resolves internally, and `isSafeToRemoveWorktree` pushes `"unknown-provenance"` unconditionally when it is false — so `safe` could never have been `true`.
- **C3 — bound the burst.** Batch cap 2 (was 100, unreachable at the observed n=15), counting **only expensive attempts**, with `continue` rather than `break` so the free cohort keeps draining, plus least-recently-attempted rotation so a stable `readdir` order cannot starve a marker.
- **C4 — stop paying the heartbeat read per host / per throttled tick.** Hoist `computeSurvivingRoster` out of the per-host `deadHosts` filter (one whole-log read per evaluation, not one per host), and pass `deadHosts` as a **thunk** so `boardHealthPass`'s 5-minute throttle is consulted *before* the read is paid.

## Safety

The load-bearing property: **the short-circuit can only ever remove FEWER worktrees, never more.**

1. **Structural** — the short-circuit path contains no removal call at all. It refreshes the marker and `continue`s, so the removal set can only shrink. This holds regardless of predicate agreement.
2. **Predicate parity** — identical function, identical ticket (`marker.ticket`), identical `orchDirs` array (the drain passes the same `orchDirs` to both the short-circuit and `safeTeardown`), so there is no throughput loss either.
3. **Fail-closed** — a throwing provenance probe sets `provenance = false` ⇒ skip ⇒ fewer removals.
4. **Post-cap** — with `continue`, the only paths still reachable past the cap are marker-file cleanup for already-gone worktrees and the short-circuit. Neither removes a worktree.

The refreshed marker records a **partial** reason set, so it carries `shortCircuit` / `reasonsPartial` to make clear that the merge, dirty-tree and liveness probes were never run. (The drain is the only reader of these markers, so nothing downstream can misread them.)

`computeDeadHosts` degrades a degenerate survivor set to an **empty** dead set — forgo failover — rather than declaring the whole fleet dead, which is the destructive direction.

## Tests

+535 lines, including an explicit `SAFETY INVARIANT` test that drives identical inputs down both the short-circuit and the always-expensive path and asserts the removal sets are **equal**, plus coverage for cap accounting, post-cap draining, fair rotation, and stamp-merge preservation of the gate's full reason set.

Verified against a clean baseline worktree at the branch base, each file run in **isolation** (batch runs proved unreliable — cross-file pollution):

- `wt-cleanup-drain` + `board-health`: **130 pass / 0 fail**
- `scheduler.test.mjs`: identical **2 pre-existing** failures (CTL-781 delegate-on-Todo) on both baseline and branch, 3/3 runs each side
- remaining affected suites: failures present in **both** sides; the rest were load-dependent flakes appearing in both directions

**Zero regressions attributable to this change.**

## Verify on production (post-deploy ACs)

- the new `sweep timing` line's `duration_ms` stays small (was a 72.3s median burst)
- event-loop readings >60s go to zero
- `min(pass_durations['board-health'])` drops from **609.6ms** to <5ms

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AhdmqZ26mKwBXyEtRnmtUL