### PR TITLE
fix(dev): CTL-1532 stamp the provider delivery id on webhook envelopes

### DIFF
--- a/plugins/dev/scripts/orch-monitor/__tests__/linear-webhook-handler.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/linear-webhook-handler.test.ts
@@ -129,6 +129,27 @@ describe("createLinearWebhookHandler", () => {
     expect(res.status).toBe(400);
   });
 
+  // CTL-1532: the appended envelope must carry the provider's own delivery id.
+  // Verified event-scoped (not per-subscription) for Linear: the same
+  // `linear-delivery` value reaches both the workspace webhook (-> smee) and the
+  // catalyst-cloud OAuth app, so it is a sound join key for the parity harness.
+  it("stamps webhook.delivery.id from the linear-delivery header", async () => {
+    const handler = createLinearWebhookHandler({
+      linearSecrets: [{ key: "test", secret: SECRET }],
+      eventLog,
+    });
+    const res = await handler.handle(
+      makeReq(issueUpdatePayload(), {
+        "linear-delivery": "276ce46b-30fc-41bf-b77b-c6c0c82ec712",
+      })
+    );
+    expect(res.status).toBe(200);
+    expect(eventLog.appends.length).toBe(1);
+    expect(eventLog.appends[0]?.attributes["webhook.delivery.id"]).toBe(
+      "276ce46b-30fc-41bf-b77b-c6c0c82ec712"
+    );
+  });
+
   it("happy path → 200 + canonical envelope written to event log", async () => {
     const handler = createLinearWebhookHandler({
       linearSecrets: [{ key: "test", secret: SECRET }],

--- a/plugins/dev/scripts/orch-monitor/__tests__/webhook-handler.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/webhook-handler.test.ts
@@ -470,6 +470,38 @@ describe("createWebhookHandler", () => {
     expect(eventLog.appends[0]?.attributes["event.name"]).toBe("github.pr.labeled");
   });
 
+  // CTL-1532: the appended envelope must carry the provider's own delivery id.
+  // This is the join key for the smee/catalyst-cloud parity harness — the cloud
+  // feed carries the same value as `deliveryId`. Without it the join matches ZERO
+  // rows, and a mismatch-only harness cannot distinguish that from perfect parity.
+  it("stamps webhook.delivery.id from the x-github-delivery header", async () => {
+    const eventLog = new FakeEventLog();
+    const handler = createWebhookHandler({
+      secret: SECRET,
+      prFetcher: fetcher,
+      eventLog,
+    });
+    const res = await handler.handle(
+      makeReq(
+        {
+          ...REPO,
+          action: "labeled",
+          pull_request: {
+            number: 326,
+            merged: true,
+            merged_at: "2026-05-04T06:42:52Z",
+          },
+        },
+        { "x-github-delivery": "2b236380-8929-11f1-8d49-f40528cd5182" },
+      ),
+    );
+    expect(res.status).toBe(200);
+    expect(eventLog.appends.length).toBe(1);
+    expect(eventLog.appends[0]?.attributes["webhook.delivery.id"]).toBe(
+      "2b236380-8929-11f1-8d49-f40528cd5182",
+    );
+  });
+
   it("release.published is accepted (200) and logged", async () => {
     const eventLog = new FakeEventLog();
     const handler = createWebhookHandler({

--- a/plugins/dev/scripts/orch-monitor/docs/otel-attribute-audit.md
+++ b/plugins/dev/scripts/orch-monitor/docs/otel-attribute-audit.md
@@ -12,8 +12,8 @@ Do **not** edit this file directly.
 | --- | --- |
 | ✓ Conforming | 20 |
 | → Rename-to | 37 |
-| ● Legitimately Custom | 39 |
-| **Total** | 96 |
+| ● Legitimately Custom | 40 |
+| **Total** | 97 |
 
 ## Classification by Emitter
 
@@ -68,6 +68,7 @@ Do **not** edit this file directly.
 | `vcs.ref.name` | `canonical-event.ts:75` | ✓ conforming |  |  |  |
 | `vcs.repository.name` | `canonical-event.ts:73` | ✓ conforming |  |  |  |
 | `vcs.revision` | `canonical-event.ts:76` | → rename-to | → `vcs.ref.revision` | Cluster E |  |
+| `webhook.delivery.id` | `canonical-event.ts:100` | ● custom |  |  | CTL-1532 |
 
 ### Bash (`canonical-event.sh`)
 

--- a/plugins/dev/scripts/orch-monitor/lib/canonical-event.ts
+++ b/plugins/dev/scripts/orch-monitor/lib/canonical-event.ts
@@ -103,6 +103,17 @@ export interface Attributes {
   "linear.team.key"?: string;
   "linear.actor.id"?: string;
 
+  // Provider webhook delivery id (catalyst-defined; no OTel semconv yet).
+  // CTL-1532: the provider's OWN idempotency key — `x-github-delivery` /
+  // `linear-delivery` — verbatim. Both handlers already read it for in-process
+  // dedup; stamping it here makes it durable so the smee-produced event log can
+  // be JOINED against the catalyst-cloud `/events/stream` feed, which carries the
+  // same value as `deliveryId`. Verified event-scoped (not per-subscription) for
+  // BOTH providers: the identical id reaches the smee webhook and the cloud app.
+  // Without this the smee/cloud parity harness matches ZERO rows — and a
+  // mismatch-only harness cannot tell a zero-match join from perfect parity.
+  "webhook.delivery.id"?: string;
+
   // Deployment semconv (OTel published)
   "deployment.environment"?: string;
   "deployment.id"?: number;

--- a/plugins/dev/scripts/orch-monitor/lib/linear-webhook-handler.ts
+++ b/plugins/dev/scripts/orch-monitor/lib/linear-webhook-handler.ts
@@ -399,6 +399,12 @@ export function createLinearWebhookHandler(deps: LinearWebhookHandlerDeps): Line
     if (deps.eventLog && event.kind !== "ignored") {
       const envelope = buildLinearEventLogEnvelope(event, undefined, teamsMap);
       if (envelope !== null) {
+        // CTL-1532: stamp the provider's own delivery id so the event log can be
+        // joined against the catalyst-cloud feed, which carries the same value.
+        // Already validated non-empty above (missing header -> 400). Verified
+        // event-scoped, not per-subscription: the same `linear-delivery` reaches
+        // both the workspace webhook (-> smee) and the cloud OAuth app.
+        envelope.attributes["webhook.delivery.id"] = deliveryId;
         try {
           await deps.eventLog.append(envelope);
         } catch (err) {

--- a/plugins/dev/scripts/orch-monitor/lib/otel-attribute-audit.ts
+++ b/plugins/dev/scripts/orch-monitor/lib/otel-attribute-audit.ts
@@ -79,6 +79,12 @@ export const AUDIT_MANIFEST: AttributeAuditEntry[] = [
   { key: "linear.team.key",         emitter: "ts", source: "canonical-event.ts:87", classification: "legitimately-custom" },
   { key: "linear.actor.id",         emitter: "ts", source: "canonical-event.ts:88", classification: "legitimately-custom" },
 
+  // CTL-1532: provider webhook delivery id (x-github-delivery / linear-delivery),
+  // verbatim. No OTel semconv covers a provider idempotency key. Load-bearing as
+  // the join key between the smee-produced event log and the catalyst-cloud
+  // /events/stream feed, which carries the same value.
+  { key: "webhook.delivery.id",     emitter: "ts", source: "canonical-event.ts:100", classification: "legitimately-custom", note: "CTL-1532" },
+
   // §4f: Deployment semconv
   { key: "deployment.environment", emitter: "ts", source: "canonical-event.ts:91", classification: "rename-to", targetName: "deployment.environment.name", remediationCluster: "E", where: "emit" },
   { key: "deployment.id",          emitter: "ts", source: "canonical-event.ts:92", classification: "conforming", note: "type should be string per OTel semconv; currently number" },

--- a/plugins/dev/scripts/orch-monitor/lib/webhook-handler.ts
+++ b/plugins/dev/scripts/orch-monitor/lib/webhook-handler.ts
@@ -671,6 +671,10 @@ export function createWebhookHandler(
         cachedPrNumber !== undefined ? { cachedPrNumber } : undefined,
       );
       if (envelope !== null) {
+        // CTL-1532: stamp the provider's own delivery id so the event log can be
+        // joined against the catalyst-cloud feed, which carries the same value.
+        // Already validated non-empty above (missing header -> 400).
+        envelope.attributes["webhook.delivery.id"] = deliveryId;
         if (deps.resolveOrchestrator) {
           const attribInput = attributionInputFor(event);
           if (attribInput !== null) {


### PR DESCRIPTION
Closes CTL-1532.

## Why

Phase 3 of the smee → Catalyst Cloud event-delivery cutover (ADR-0008 leg 3) diffs the smee-produced local event log against the cloud `/events/stream` feed. The join key is the **provider's own delivery id**, which CTC verified is **event-scoped, not per-subscription**, for both providers — the identical `x-github-delivery` / `linear-delivery` value reaches the smee webhook *and* the catalyst-cloud app.

## The defect

Both handlers already **read** that header — and 400 a request without one — but used it only for an in-process dedup set. **Neither wrote it into the v2 envelope.** A `linear.comment.created` envelope carried:

```
event.action, event.channel, event.entity, event.label, event.name, event.stream_class,
linear.actor.id, linear.issue.id, linear.issue.identifier, linear.team.key, vcs.repository.name
```

…and no delivery id. Same for GitHub.

So a parity harness joining on delivery id would have matched **zero rows** — and a harness that only counts mismatches **cannot distinguish a zero-match join from perfect parity**. It would have reported seven clean days while joining nothing. This was caught during design review before the harness was written.

## What

| File | Change |
|---|---|
| `lib/canonical-event.ts` | add `"webhook.delivery.id"?: string` to `Attributes` |
| `lib/webhook-handler.ts` | stamp it on the envelope before append |
| `lib/linear-webhook-handler.ts` | stamp it on the envelope before append |
| `__tests__/webhook-handler.test.ts` | assert `x-github-delivery` reaches the envelope |
| `__tests__/linear-webhook-handler.test.ts` | assert `linear-delivery` reaches the envelope |

`deliveryId` was already in scope at both call sites and already validated non-empty, so this forwards a value we had rather than deriving a new one.

## Safety

- **Additive and attribute-only.** No event names change, so the CTL-1142 lifecycle namespace contract is untouched.
- No behaviour change to dedup, dispatch, signature verification, or the 400-on-missing-header path.
- `bun run typecheck` clean; the two touched suites pass **128/128**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PR7K8AWqV8xENidMuKx736