### PR TITLE
feat(dev): CTL-1534 phase-3 shadow consumer + smee/cloud parity harness

### DIFF
--- a/.github/workflows/execution-core-tests.yml
+++ b/.github/workflows/execution-core-tests.yml
@@ -420,6 +420,14 @@ jobs:
         # exit-127'd the reaper fleet-wide. Runs the REAL refusal paths.
         working-directory: plugins/dev/scripts
         run: bash __tests__/install-orphan-sweep-guard.test.sh
+      - name: CTL-1534 negative controls (shadow consumer + parity harness self-tests)
+        # Rule 8: the load-bearing control must run where it is most useful — a clean,
+        # secret-free CI checkout. Both binaries exit 0 ONLY when every seeded detector
+        # fired and the positive control stayed green; a detector that stops firing fails
+        # the gate here instead of on a developer's laptop.
+        run: |
+          bun cloud-event-consumer.mjs --self-test
+          bun parity-harness.mjs --self-test
 
       - name: Run stable unit tests
         # EXCLUDED SUITES — do NOT add these back without fixing the underlying
@@ -486,6 +494,8 @@ jobs:
             tick-timing.test.mjs \
             tracing.test.mjs \
             cloud-token-env.test.mjs \
+            cloud-event-consumer.test.mjs \
+            parity-harness.test.mjs \
             cluster-claim-sync.test.mjs \
             cluster-claim.test.mjs \
             comms-drain.test.mjs \

--- a/.github/workflows/execution-core-tests.yml
+++ b/.github/workflows/execution-core-tests.yml
@@ -429,6 +429,45 @@ jobs:
           bun cloud-event-consumer.mjs --self-test
           bun parity-harness.mjs --self-test
 
+      - name: Assert every `bun test` target below still exists (CTL-1534)
+        # `bun test <file>` on a path that does not exist matches ZERO tests and exits 0.
+        # So renaming or deleting any suite named in the allowlist below silently stops
+        # running it while this required check stays green — the exact "the check
+        # evaluated nothing and passed" shape the CTL-1534 tooling exists to prevent.
+        # The list is parsed out of this file rather than duplicated, so it cannot drift
+        # from the step it guards; a parse that yields nothing fails too (a guard that
+        # checks nothing is worse than no guard). Only the backslash-continued argument
+        # lines of the `bun test` invocation are read — the EXCLUDED-SUITES comment above
+        # it names suites that deliberately do NOT run.
+        #
+        # Resolution is by SUFFIX, not exact path: a `bun test` argument is a filename
+        # filter, so `config-node-class.test.mjs` legitimately matches
+        # `__tests__/config-node-class.test.mjs`. What must never happen is an argument
+        # that matches NOTHING.
+        working-directory: .
+        run: |
+          set -euo pipefail
+          targets="${RUNNER_TEMP:-/tmp}/bun-test-targets.txt"
+          awk '
+            index($0, "- name: Run stable unit tests") { f = 1; next }
+            f && /^      - name: / { f = 0 }
+            f && /^ +[A-Za-z0-9_.\/-]+\.test\.(mjs|ts) \\?$/ { gsub(/[ \\]/, "", $0); print }
+          ' .github/workflows/execution-core-tests.yml | sort -u > "$targets"
+          count=$(wc -l < "$targets" | tr -d ' ')
+          if [ "$count" -eq 0 ]; then
+            echo "GUARD BROKEN: parsed zero bun test targets from the workflow"
+            exit 1
+          fi
+          missing=0
+          while read -r t; do
+            if [ -z "$(find plugins/dev/scripts/execution-core -path "*/$t" -type f -print -quit)" ]; then
+              echo "MISSING bun test target: $t (renamed or deleted — bun test matches zero files and exits 0)"
+              missing=1
+            fi
+          done < "$targets"
+          echo "verified $count bun test target(s) resolve"
+          [ "$missing" -eq 0 ]
+
       - name: Run stable unit tests
         # EXCLUDED SUITES — do NOT add these back without fixing the underlying
         # timing / sandbox incompatibility:

--- a/plugins/dev/scripts/execution-core/cloud-event-consumer.mjs
+++ b/plugins/dev/scripts/execution-core/cloud-event-consumer.mjs
@@ -1,0 +1,1936 @@
+#!/usr/bin/env bun
+// cloud-event-consumer.mjs — CTL-1534: the phase-3 SHADOW consumer of the
+// catalyst-cloud event feed.
+//
+// WHAT
+// ----
+// Polls `GET <baseUrl>/events/stream?since=<seq>` (NDJSON, per-host bearer),
+// maps each RAW provider payload through the EXISTING, UNMODIFIED orch-monitor
+// webhook mappers, and appends the resulting v2 envelopes to a SHADOW event log
+// at `~/catalyst/events-shadow/YYYY-MM.jsonl`.
+//
+// It NEVER writes `~/catalyst/events/`. That is enforced by construction, not by
+// convention: the shadow directory name is a module constant, no caller can pass
+// a directory path, and `resolveShadowDir()` refuses any resolution that lands on
+// or inside the live events dir. Writing the live log would double-wake every
+// worker in the fleet.
+//
+// THE MAPPERS ARE REUSED, NEVER REIMPLEMENTED (project invariant 2). Both the
+// smee path and this path run identical mapping code, so any shadow-vs-live diff
+// is *transport or coverage* — never mapping. See the four imports below; if you
+// find yourself writing a `switch (eventType)` in this file, stop.
+//
+// THE JOIN KEY is `attributes["webhook.delivery.id"]` (CTL-1532), stamped here
+// from the feed's `deliveryId` exactly as the live handlers stamp it from
+// `x-github-delivery` / `linear-delivery`. Verified end-to-end: the same value
+// reaches both transports, for both providers.
+//
+// THE ORDERING KEY is `attributes[SEQ_ATTR]` (= "catalyst.cloud.event.seq"),
+// stamped here from the feed's `seq`. It is the ONLY input to parity-harness's
+// SEQ_WIRE_ORDER / SEQ_CONTIGUITY / SEQ_COVERAGE assertions: if this producer
+// stops stamping it, those three questions cannot be answered and the harness
+// hard-blocks (exit 2) rather than passing on an attribute nobody wrote. The
+// two halves of this deliverable agree on exactly one string, exported here and
+// asserted against the harness default in the test suite.
+//
+// THREE-WAY EXIT CONTRACT (non-negotiable; see HARNESS RULES below)
+//   0 = evaluated, healthy
+//   1 = evaluated, problem found
+//   2 = COULD NOT EVALUATE
+// "I could not check" must NEVER render as "healthy". A failed probe, an auth
+// error, a control record, a missing head header, or bad input is 2 — never 0.
+// When a run both fails to evaluate part of the range AND finds a problem in the
+// part it did evaluate, 2 wins (and both counts are printed, so neither hides).
+//
+// HARNESS RULES this file implements — every one comes from a real defect found
+// in catalyst-cloud's equivalent harness, each of which produced a confident green:
+//   1. three-way exit (above)
+//   2. COVERAGE != INTEGRITY, asserted SEPARATELY. A 200 that starts after
+//      since+1, ends before head, or is empty while head is ahead is internally
+//      contiguous and carries NO control record. Contiguity cannot see it at any
+//      level of rigour.
+//   3. a CONTROL RECORD invalidates the run -> exit 2 (the received prefix is
+//      contiguous, so a naive gap check passes a server-declared incomplete scan)
+//   4. adjacency is checked in WIRE ORDER. Nothing is ever sorted.
+//   5. per-source, per-type COUNTS (never presence); `--require-source` asserts
+//      non-zero per named source
+//   6. the evidence is NEVER normalised — no coercion, no defaulting, no sorting.
+//      Bad input is rejected with exit 2, never repaired.
+//   7. `--since` / a persisted cursor from day one (a hardcoded 0 409s forever
+//      once retention evicts)
+//   8. `--self-test` is the negative control: credential-free, offline, CI-runnable,
+//      and OBSERVED to go red on every seeded failure.
+//
+// SECRETS: the token is read from ~/.config/catalyst/cloud-sync.env
+// (CATALYST_CLOUD_TOKEN) or the environment, and is NEVER logged. Every log line
+// and every report string passes through a scrubber bound to the live token value.
+
+import { appendFileSync, existsSync, lstatSync, mkdirSync, readFileSync, realpathSync, renameSync, writeFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { basename, dirname, resolve, sep } from "node:path";
+
+// ---------------------------------------------------------------------------
+// THE MAPPERS — imported UNMODIFIED from orch-monitor. Do not fork these.
+// ---------------------------------------------------------------------------
+import { parseWebhookEvent } from "../orch-monitor/lib/webhook-events.ts";
+import { buildEventLogEnvelope } from "../orch-monitor/lib/webhook-handler.ts";
+import { parseLinearWebhookEvent } from "../orch-monitor/lib/linear-webhook-events.ts";
+import { buildLinearEventLogEnvelope } from "../orch-monitor/lib/linear-webhook-handler.ts";
+import { readClusterProjects } from "../orch-monitor/lib/cluster-roster.ts";
+
+export const TAG = "[cloud-event-consumer]";
+
+/** The ONLY directory this consumer may write. Hardcoded, never a parameter. */
+export const SHADOW_DIR_NAME = "events-shadow";
+/** The live log. Named here only so we can refuse to resolve onto it. */
+export const LIVE_DIR_NAME = "events";
+
+export const DEFAULT_BASE_URL = "https://staging.catalystcloud.dev";
+export const DEFAULT_STREAM_PATH = "/events/stream";
+export const DEFAULT_POLL_MS = 10_000;
+/** Bounded persisted dedup ring. Retains the most recent N delivery ids. */
+export const DEFAULT_DEDUP_MAX = 5000;
+export const DEFAULT_MAX_CONSECUTIVE_FAILURES = 5;
+export const STATE_FILE_NAME = ".cloud-event-consumer.cursor.json";
+export const STATE_VERSION = 1;
+
+/** Exit codes. 2 dominates 1 dominates 0 — "could not evaluate" never collapses. */
+export const EXIT_HEALTHY = 0;
+export const EXIT_PROBLEM = 1;
+export const EXIT_UNEVALUATED = 2;
+
+/** Marker names written into the shadow log. Never a CTL-1142 protected prefix. */
+export const MARKER_UNMAPPABLE = "catalyst.cloud_feed.unmappable_payload";
+export const MARKER_FEED_GAP = "catalyst.cloud_feed.gap";
+
+/**
+ * The transport-ordering attribute stamped on EVERY shadow envelope. This is the
+ * producer half of a two-party contract: parity-harness.mjs defaults --seq-attr
+ * to this exact string and its whole ordering/coverage subsystem reads it. Both
+ * halves are pinned together by a test (`SEQ_ATTR === parseArgs([]).opts.seqAttr`)
+ * so a rename on either side breaks the suite instead of silently disabling three
+ * assertions.
+ */
+export const SEQ_ATTR = "catalyst.cloud.event.seq";
+
+/** The cloud edge cap. A payloadOmitted record must be at least this large. */
+export const PAYLOAD_CAP_BYTES = 96 * 1024;
+
+/**
+ * The DECLARED per-source provider-type census (rule 9: classify against a
+ * declared expectation, never against presence).
+ *
+ *  - declared-mappable   — webhook-events.ts has a case for it. If records of
+ *                          this type arrive and NOTHING is appended for it, that
+ *                          is a mapper/schema regression, not "coverage data".
+ *  - declared-unmappable — no mapper on EITHER path (so the live log has no such
+ *                          envelope either). Structurally invisible, expected-zero.
+ *  - anything else       — UNDECLARED: a cloud-side schema/casing change. Loud.
+ *
+ * Mirrors parity-harness's UNMAPPABLE_PROVIDER_TYPES; the lists are asserted
+ * equal in the test suite so they cannot drift apart silently.
+ */
+export const DECLARED_MAPPABLE_TYPES = {
+  github: new Set([
+    "pull_request", "pull_request_review", "pull_request_review_thread", "check_suite",
+    "status", "push", "issue_comment", "pull_request_review_comment", "deployment",
+    "deployment_status", "release", "workflow_run",
+  ]),
+  linear: new Set([
+    "Issue", "Comment", "Cycle", "Reaction", "IssueLabel", "AgentSessionEvent",
+    "issueCommentMention",
+  ]),
+};
+export const DECLARED_UNMAPPABLE_TYPES = {
+  github: new Set(["workflow_job", "check_run"]),
+  linear: new Set(["Attachment"]),
+};
+
+/** "declared-mappable" | "declared-unmappable" | "undeclared" */
+export function classifyProviderType(source, eventType) {
+  if (DECLARED_MAPPABLE_TYPES[source]?.has(eventType)) return "declared-mappable";
+  if (DECLARED_UNMAPPABLE_TYPES[source]?.has(eventType)) return "declared-unmappable";
+  return "undeclared";
+}
+
+// ---------------------------------------------------------------------------
+// Strict parsing. Rule 6: reject, never repair.
+// ---------------------------------------------------------------------------
+
+/** Canonical non-negative integer, decimal, no sign, no whitespace, no exponent. */
+const INT_RE = /^(0|[1-9][0-9]*)$/;
+
+/**
+ * parseSinceArg — strict `--since` / cursor parse. Returns a number, or null for
+ * ANYTHING else. Deliberately NOT `Number()`: `Number("banana")` is NaN, which a
+ * server normalises to 0, which silently scans the whole feed and reports healthy
+ * about a range nobody asked for. That was a real defect.
+ */
+export function parseSinceArg(raw) {
+  if (typeof raw !== "string") return null;
+  if (!INT_RE.test(raw)) return null;
+  const n = Number(raw);
+  return Number.isSafeInteger(n) ? n : null;
+}
+
+/**
+ * strictSeq — a wire `seq` must already be a safe non-negative integer NUMBER.
+ * A string "12", a float, a NaN, or a missing value is bad input: return null and
+ * let the caller exit 2. We never coerce the evidence into something checkable.
+ */
+export function strictSeq(value) {
+  if (typeof value !== "number") return null;
+  if (!Number.isSafeInteger(value) || value < 0) return null;
+  return value;
+}
+
+/** strictHeader — parse `x-catalyst-event-head-seq`. null when absent/malformed. */
+export function parseHeadHeader(raw) {
+  if (typeof raw !== "string") return null;
+  return parseSinceArg(raw);
+}
+
+// ---------------------------------------------------------------------------
+// Paths. The shadow dir is impossible to point at the live log.
+// ---------------------------------------------------------------------------
+
+export function defaultCatalystDir(env = process.env) {
+  return env.CATALYST_DIR ?? resolve(homedir(), "catalyst");
+}
+
+/**
+ * resolveShadowDir — the ONLY way to obtain a write directory. Callers supply the
+ * catalyst root, never a directory: the last segment is the hardcoded
+ * SHADOW_DIR_NAME. Refuses any resolution that equals the live events dir or sits
+ * inside it (which a `CATALYST_DIR=.../events` would otherwise produce).
+ */
+export function resolveShadowDir(catalystDir) {
+  if (typeof catalystDir !== "string" || catalystDir.length === 0) {
+    throw new Error("resolveShadowDir: catalystDir must be a non-empty string");
+  }
+  const root = resolve(catalystDir);
+  const dir = resolve(root, SHADOW_DIR_NAME);
+  const live = resolve(root, LIVE_DIR_NAME);
+  if (basename(dir) !== SHADOW_DIR_NAME) {
+    throw new Error(`refusing shadow dir with unexpected basename: ${dir}`);
+  }
+  if (dir === live || dir.startsWith(live + sep)) {
+    throw new Error(`refusing shadow dir that resolves onto the LIVE event log: ${dir}`);
+  }
+  // Defence in depth: the resolved dir must not itself be named `events`, nor
+  // have `events` as its immediate parent.
+  if (basename(dirname(dir)) === LIVE_DIR_NAME) {
+    throw new Error(`refusing shadow dir nested under a live events dir: ${dir}`);
+  }
+  // CTL-1534 (M10): every check above is LEXICAL, and `resolve()` does not follow
+  // symlinks. If `<root>/events-shadow` is a symlink to `<root>/events`, all of
+  // them pass and we write straight into the LIVE event log — double-waking every
+  // worker, the single worst outcome this tool can produce. Re-check on REAL paths.
+  //
+  // A symlink at the shadow path is refused outright rather than resolved: there is
+  // no legitimate reason for it, and refusing is simpler to reason about than
+  // deciding which targets are acceptable.
+  if (existsSync(dir) && lstatSync(dir).isSymbolicLink()) {
+    throw new Error(`refusing shadow dir that is a symlink: ${dir}`);
+  }
+  const realOf = (p) => {
+    // realpath the deepest existing ancestor, so the guard works before mkdir.
+    let cur = p;
+    for (;;) {
+      if (existsSync(cur)) return resolve(realpathSync(cur), p.slice(cur.length));
+      const parent = dirname(cur);
+      if (parent === cur) return p;
+      cur = parent;
+    }
+  };
+  const realDir = realOf(dir);
+  const realLive = realOf(live);
+  if (realDir === realLive || realDir.startsWith(realLive + sep)) {
+    throw new Error(
+      `refusing shadow dir that RESOLVES onto the LIVE event log: ${dir} -> ${realDir}`,
+    );
+  }
+  return dir;
+}
+
+export function shadowFilePath(catalystDir, date = new Date()) {
+  const y = date.getUTCFullYear();
+  const m = String(date.getUTCMonth() + 1).padStart(2, "0");
+  // CTL-1534 (M10): distinct basename from the live log (`YYYY-MM.jsonl`). Even if
+  // every directory guard above were defeated, a shadow write can then never
+  // overwrite or be mistaken for a live event-log file.
+  return resolve(resolveShadowDir(catalystDir), `shadow-${y}-${m}.jsonl`);
+}
+
+export function statePath(catalystDir) {
+  return resolve(catalystDir, STATE_FILE_NAME);
+}
+
+// ---------------------------------------------------------------------------
+// Token. Never logged.
+// ---------------------------------------------------------------------------
+
+export function defaultCloudSyncEnvPath(env = process.env) {
+  const dir = env.CATALYST_CONFIG_DIR || resolve(homedir(), ".config", "catalyst");
+  return resolve(dir, "cloud-sync.env");
+}
+
+/**
+ * parseEnvFile — minimal `KEY=value` / `export KEY=value` reader. Strips one
+ * layer of matching single or double quotes. Comments and blanks ignored.
+ */
+export function parseEnvFile(text) {
+  const out = {};
+  for (const rawLine of String(text).split("\n")) {
+    const line = rawLine.trim();
+    if (line.length === 0 || line.startsWith("#")) continue;
+    const m = /^(?:export\s+)?([A-Za-z_][A-Za-z0-9_]*)=(.*)$/.exec(line);
+    if (m === null) continue;
+    let value = m[2].trim();
+    if (
+      value.length >= 2 &&
+      ((value.startsWith("'") && value.endsWith("'")) ||
+        (value.startsWith('"') && value.endsWith('"')))
+    ) {
+      value = value.slice(1, -1);
+    }
+    out[m[1]] = value;
+  }
+  return out;
+}
+
+/**
+ * readCloudToken — env var first (so a supervisor can inject), then the 0600
+ * cloud-sync.env. Returns "" when unresolvable. NEVER logs or returns a partial
+ * token in an error string.
+ */
+export function readCloudToken(opts = {}) {
+  const {
+    env = process.env,
+    envFilePath = defaultCloudSyncEnvPath(env),
+    readFile = (p) => readFileSync(p, "utf8"),
+  } = opts;
+  const fromEnv = env.CATALYST_CLOUD_TOKEN;
+  if (typeof fromEnv === "string" && fromEnv.length > 0) {
+    return { token: fromEnv, source: "env" };
+  }
+  let text;
+  try {
+    text = readFile(envFilePath);
+  } catch {
+    return { token: "", source: "absent" };
+  }
+  const parsed = parseEnvFile(text);
+  const t = parsed.CATALYST_CLOUD_TOKEN;
+  return typeof t === "string" && t.length > 0
+    ? { token: t, source: "file" }
+    : { token: "", source: "absent" };
+}
+
+/** makeScrubber — redact the live token (and any bearer/token-shaped substring). */
+export function makeScrubber(token) {
+  return (value) => {
+    let s = typeof value === "string" ? value : String(value);
+    if (typeof token === "string" && token.length >= 8) {
+      s = s.split(token).join("<redacted>");
+    }
+    return s
+      .replace(/(Bearer\s+)[A-Za-z0-9._~+/=-]+/gi, "$1<redacted>")
+      .replace(/([?&]token=)[^&\s]+/gi, "$1<redacted>");
+  };
+}
+
+// ---------------------------------------------------------------------------
+// State: cursor + bounded persisted dedup ring. Atomic tmp + rename.
+// ---------------------------------------------------------------------------
+
+export function emptyState() {
+  return { version: STATE_VERSION, cursor: null, updatedAt: null, seenDeliveryIds: [] };
+}
+
+/**
+ * readState — returns {state, ok, reason}. A CORRUPT state file is NOT silently
+ * replaced with a fresh one: `ok:false` so the caller exits 2. Silently resetting
+ * a cursor is exactly the "quietly repaired the input" defect class.
+ */
+export function readState(catalystDir, opts = {}) {
+  const { readFile = (p) => readFileSync(p, "utf8") } = opts;
+  let text;
+  try {
+    text = readFile(statePath(catalystDir));
+  } catch {
+    return { state: emptyState(), ok: true, reason: "absent" };
+  }
+  let parsed;
+  try {
+    parsed = JSON.parse(text);
+  } catch {
+    return { state: null, ok: false, reason: "unparseable-state-file" };
+  }
+  if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) {
+    return { state: null, ok: false, reason: "state-file-not-an-object" };
+  }
+  if (parsed.version !== STATE_VERSION) {
+    return { state: null, ok: false, reason: `unknown-state-version:${String(parsed.version)}` };
+  }
+  const cursor = parsed.cursor === null ? null : strictSeq(parsed.cursor);
+  if (parsed.cursor !== null && cursor === null) {
+    return { state: null, ok: false, reason: "state-cursor-not-a-safe-integer" };
+  }
+  const ids = parsed.seenDeliveryIds;
+  if (!Array.isArray(ids) || ids.some((v) => typeof v !== "string")) {
+    return { state: null, ok: false, reason: "state-seenDeliveryIds-malformed" };
+  }
+  return {
+    state: {
+      version: STATE_VERSION,
+      cursor,
+      updatedAt: typeof parsed.updatedAt === "string" ? parsed.updatedAt : null,
+      seenDeliveryIds: ids,
+    },
+    ok: true,
+    reason: "read",
+  };
+}
+
+/** writeState — atomic tmp + rename, so a crash can never leave a half cursor. */
+export function writeState(catalystDir, state, opts = {}) {
+  const {
+    dedupMax = DEFAULT_DEDUP_MAX,
+    now = () => new Date(),
+    mkdir = (d) => mkdirSync(d, { recursive: true }),
+    writeFile = (p, s) => writeFileSync(p, s),
+    rename = (a, b) => renameSync(a, b),
+  } = opts;
+  const dest = statePath(catalystDir);
+  const ids = state.seenDeliveryIds.slice(-dedupMax);
+  const body = JSON.stringify(
+    {
+      version: STATE_VERSION,
+      cursor: state.cursor,
+      updatedAt: now().toISOString(),
+      seenDeliveryIds: ids,
+    },
+    null,
+    2,
+  );
+  mkdir(dirname(dest));
+  const tmp = `${dest}.${process.pid}.tmp`;
+  writeFile(tmp, body + "\n");
+  rename(tmp, dest);
+  return { path: dest, cursor: state.cursor, retainedIds: ids.length };
+}
+
+// ---------------------------------------------------------------------------
+// Shadow appender. Hardcoded dir; the only write surface.
+// ---------------------------------------------------------------------------
+
+export function createShadowAppender(catalystDir, opts = {}) {
+  const {
+    now = () => new Date(),
+    mkdir = (d) => mkdirSync(d, { recursive: true }),
+    append = (p, s) => appendFileSync(p, s),
+  } = opts;
+  // Resolve (and validate) once at construction so a bad root fails loudly before
+  // a single line is written.
+  const dir = resolveShadowDir(catalystDir);
+  let lines = 0;
+  return {
+    dir,
+    get lines() {
+      return lines;
+    },
+    write(record) {
+      const path = shadowFilePath(catalystDir, now());
+      mkdir(dir);
+      append(path, JSON.stringify(record) + "\n");
+      lines += 1;
+      return path;
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Line classification. Invariant 8: EVERY event line has `seq`; NO control line
+// does. `!("seq" in line)` is the contract. `error` only appears at the envelope
+// top level — provider JSON is nested under `payload`, so a provider body with
+// its own `error` key surfaces at `line.payload.error` and cannot collide.
+// Ambiguous lines fail toward reconcile.
+// ---------------------------------------------------------------------------
+
+export function classifyLine(parsed) {
+  if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) {
+    return { kind: "invalid", reason: "line is not a JSON object" };
+  }
+  const hasSeq = "seq" in parsed;
+  const hasError = "error" in parsed;
+  if (hasError && !hasSeq) return { kind: "control", record: parsed };
+  if (!hasSeq) return { kind: "invalid", reason: "line has neither seq nor error" };
+  if (hasError && hasSeq) {
+    // Never seen in the wild and not in the contract. Fail toward reconcile.
+    return { kind: "control", record: parsed, ambiguous: true };
+  }
+  return { kind: "event", record: parsed };
+}
+
+/**
+ * isPayloadOmitted — TRUTHY test, never key-presence. On a normal event the field
+ * is ABSENT (not `false`); branching on `"payloadOmitted" in line` would classify
+ * every normal event as unmappable. Verified parser detail from the wire.
+ */
+export function isPayloadOmitted(record) {
+  return Boolean(record.payloadOmitted);
+}
+
+// ---------------------------------------------------------------------------
+// NDJSON reading. Streams when the response exposes a body; falls back to text().
+// Both paths are exercised by the test suite.
+// ---------------------------------------------------------------------------
+
+export async function* ndjsonLines(response) {
+  const body = response.body;
+  const getReader = body && typeof body.getReader === "function" ? body.getReader.bind(body) : null;
+  if (getReader === null) {
+    const text = await response.text();
+    for (const line of text.split("\n")) {
+      if (line.length > 0) yield line;
+    }
+    return;
+  }
+  const reader = getReader();
+  const decoder = new TextDecoder();
+  let buf = "";
+  for (;;) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    buf += decoder.decode(value, { stream: true });
+    let idx;
+    while ((idx = buf.indexOf("\n")) !== -1) {
+      const line = buf.slice(0, idx);
+      buf = buf.slice(idx + 1);
+      if (line.length > 0) yield line;
+    }
+  }
+  buf += decoder.decode();
+  if (buf.length > 0) yield buf;
+}
+
+// ---------------------------------------------------------------------------
+// Bot-actor suppression, mirroring the live Linear handler so the parity join is
+// not polluted by rows the live path deliberately never appends. This is HANDLER
+// policy, not mapping — the mapper stays untouched.
+// ---------------------------------------------------------------------------
+
+export function readLinearBotUserIds(opts = {}) {
+  const {
+    env = process.env,
+    readFile = (p) => readFileSync(p, "utf8"),
+    layer2Path = resolve(
+      env.CATALYST_CONFIG_DIR || resolve(homedir(), ".config", "catalyst"),
+      "config.json",
+    ),
+    layer1Path = resolve(env.CATALYST_PROJECT_DIR || process.cwd(), ".catalyst", "config.json"),
+  } = opts;
+  const ids = new Set();
+  const load = (p) => {
+    try {
+      const parsed = JSON.parse(readFile(p));
+      return parsed !== null && typeof parsed === "object" ? parsed : null;
+    } catch {
+      return null;
+    }
+  };
+  const l2 = load(layer2Path);
+  const bot = l2?.catalyst?.linear?.bot;
+  for (const slot of ["worker", "orchestrator"]) {
+    const id = bot?.[slot]?.botUserId;
+    if (typeof id === "string" && id.length > 0) ids.add(id);
+  }
+  const l1 = load(layer1Path);
+  const legacy = l1?.catalyst?.monitor?.linear?.botUserId ?? l1?.monitor?.linear?.botUserId;
+  if (typeof legacy === "string" && legacy.length > 0) ids.add(legacy);
+  return ids;
+}
+
+// ---------------------------------------------------------------------------
+// Mapping a single cloud record -> a v2 envelope, via the UNMODIFIED mappers.
+// ---------------------------------------------------------------------------
+
+/**
+ * mapCloudEvent — turn one feed record into a v2 envelope.
+ *
+ * Returns one of:
+ *   {outcome:"envelope", envelope}
+ *   {outcome:"unmappable", reason}          // payloadOmitted — a targeted GAP
+ *   {outcome:"ignored", reason}             // the mapper declined it (coverage data)
+ *   {outcome:"bot-suppressed"}              // live path suppresses it too
+ *   {outcome:"invalid", reason}             // malformed record -> caller exits 2
+ *
+ * `tsMode`:
+ *   "receivedAt" (default) — envelope.ts = the cloud's edge receipt time. Makes the
+ *      shadow log temporally comparable to the live one.
+ *   "now" — envelope.ts = wall clock at map time, matching what the live handler
+ *      does (it passes `undefined`). Replay then stamps replay-time, which is why
+ *      it is not the default.
+ * Either way `ts` is NOT a parity field; the join key is webhook.delivery.id.
+ */
+export function mapCloudEvent(record, opts = {}) {
+  const { teamsMap = new Map(), tsMode = "receivedAt", botUserIds = new Set(), now = () => new Date() } = opts;
+
+  const source = record.source;
+  if (source !== "github" && source !== "linear") {
+    return { outcome: "invalid", reason: `unknown source: ${JSON.stringify(source)}` };
+  }
+  const eventType = record.eventType;
+  if (typeof eventType !== "string" || eventType.length === 0) {
+    return { outcome: "invalid", reason: "missing eventType" };
+  }
+  const deliveryId = record.deliveryId;
+  if (typeof deliveryId !== "string" || deliveryId.length === 0) {
+    return { outcome: "invalid", reason: "missing deliveryId (the ONLY join key)" };
+  }
+  // The ordering key. Rejected, never defaulted: an envelope with no seq would
+  // silently disable the harness's entire ordering/coverage subsystem, which is
+  // exactly the "the check evaluated nothing and passed" class this file exists
+  // to prevent.
+  const seq = strictSeq(record.seq);
+  if (seq === null) {
+    return {
+      outcome: "invalid",
+      reason: `seq is not a safe non-negative integer: ${JSON.stringify(record.seq)} (the ONLY ordering key)`,
+    };
+  }
+
+  if (isPayloadOmitted(record)) {
+    return { outcome: "unmappable", reason: "payloadOmitted" };
+  }
+  if (record.payload === null || typeof record.payload !== "object") {
+    // Not the documented elision shape and not a mappable body. Do not guess.
+    return { outcome: "invalid", reason: "payload is absent but payloadOmitted is not truthy" };
+  }
+
+  let ts;
+  if (tsMode === "receivedAt") {
+    const parsedTs = toIsoOrNull(record.receivedAt);
+    if (parsedTs === null) return { outcome: "invalid", reason: "receivedAt is not a usable timestamp" };
+    ts = parsedTs;
+  } else if (tsMode === "now") {
+    ts = now().toISOString();
+  } else {
+    return { outcome: "invalid", reason: `unknown tsMode: ${String(tsMode)}` };
+  }
+
+  let envelope = null;
+  if (source === "github") {
+    const parsed = parseWebhookEvent(eventType, record.payload);
+    if (parsed.kind === "ignored") return { outcome: "ignored", reason: parsed.reason };
+    // NOTE: the live path may consult a SHA->PR cache here for check_suite /
+    // workflow_run with no inline pull_requests. The shadow has no such cache;
+    // those events are counted as `prCacheDependent` by the caller so the
+    // resulting attribute diff is a KNOWN coverage delta, not a mystery.
+    envelope = buildEventLogEnvelope(parsed, ts);
+  } else {
+    const parsed = parseLinearWebhookEvent(eventType, record.payload);
+    if (parsed.kind === "ignored") return { outcome: "ignored", reason: parsed.reason };
+    if (parsed.kind === "issue" && parsed.actorId !== null && botUserIds.has(parsed.actorId)) {
+      return { outcome: "bot-suppressed" };
+    }
+    envelope = buildLinearEventLogEnvelope(parsed, ts, teamsMap);
+  }
+  if (envelope === null) return { outcome: "ignored", reason: "builder returned null" };
+
+  // CTL-1532 join key, stamped exactly as the live handlers stamp it.
+  envelope.attributes["webhook.delivery.id"] = deliveryId;
+  // Transport ordering key (the harness's --seq-attr). The smee side structurally
+  // cannot carry it, so parity-harness excludes it from ENVELOPE_EQUIVALENCE by
+  // declaration (`ignoredAttrs`), not by accident.
+  envelope.attributes[SEQ_ATTR] = seq;
+  return { outcome: "envelope", envelope };
+}
+
+function toIsoOrNull(value) {
+  if (typeof value === "number" && Number.isFinite(value)) {
+    const d = new Date(value);
+    return Number.isNaN(d.getTime()) ? null : d.toISOString();
+  }
+  if (typeof value === "string" && value.length > 0) {
+    const d = new Date(value);
+    return Number.isNaN(d.getTime()) ? null : d.toISOString();
+  }
+  return null;
+}
+
+/** True when the live path would have consulted its SHA->PR cache for this event. */
+export function needsPrCache(source, eventType, payload) {
+  if (source !== "github") return false;
+  if (eventType !== "check_suite" && eventType !== "workflow_run") return false;
+  const parsed = parseWebhookEvent(eventType, payload);
+  if (parsed.kind !== "check_suite" && parsed.kind !== "workflow_run") return false;
+  return parsed.prNumbers.length === 0 && Boolean(parsed.headSha);
+}
+
+// ---------------------------------------------------------------------------
+// One poll pass.
+// ---------------------------------------------------------------------------
+
+export function newReport(since) {
+  return {
+    status: EXIT_HEALTHY,
+    since,
+    headSeq: null,
+    firstSeq: null,
+    lastSeq: null,
+    received: 0,
+    appended: 0,
+    deduped: 0,
+    // COVERAGE and INTEGRITY are SEPARATE. Requirement: a clean EOF is
+    // indistinguishable from a complete answer to any contiguity check.
+    coverage: { ok: null, problems: [] },
+    integrity: { ok: null, breaks: [] },
+    // WIRE census — what arrived. Seeded at zero for both sources so "linear
+    // delivered nothing" is a printed row, not an absent key (rule 9/10).
+    bySource: { github: 0, linear: 0 },
+    byType: {},
+    // APPENDED census — what actually reached the shadow log. Every non-zero
+    // assertion reads THESE, never the wire census: a record that arrived and was
+    // then declined, suppressed or deduped contributed nothing to parity.
+    appendedBySource: { github: 0, linear: 0 },
+    appendedByType: {},
+    unmappable: [],
+    ignoredByType: {},
+    undeclaredTypes: {},
+    markersWritten: 0,
+    prCacheDependent: 0,
+    botSuppressed: 0,
+    control: null,
+    unevaluated: [],
+    problems: [],
+    cursorAdvancedTo: null,
+  };
+}
+
+function bump(obj, key) {
+  obj[key] = (obj[key] ?? 0) + 1;
+}
+
+function markUnevaluated(report, reason) {
+  report.unevaluated.push(reason);
+  report.status = EXIT_UNEVALUATED;
+}
+
+function markProblem(report, reason) {
+  report.problems.push(reason);
+  // 2 dominates 1 — an unevaluated run must never be downgraded to "problem",
+  // and a problem must never be upgraded to healthy.
+  if (report.status !== EXIT_UNEVALUATED) report.status = EXIT_PROBLEM;
+}
+
+/**
+ * runOnce — a single poll pass. Never throws for an expected failure mode; every
+ * failure is folded into `report.status` per the three-way contract.
+ *
+ * ctx:
+ *   fetchImpl(url, init) -> Response-like
+ *   baseUrl, token, since
+ *   appender  ({write(record)})
+ *   teamsMap, botUserIds, tsMode
+ *   seen      (Set<string> of delivery ids; mutated)
+ *   log       ({info,warn,error})
+ */
+export async function runOnce(ctx) {
+  const {
+    fetchImpl,
+    baseUrl = DEFAULT_BASE_URL,
+    streamPath = DEFAULT_STREAM_PATH,
+    token,
+    since,
+    appender,
+    teamsMap = new Map(),
+    botUserIds = new Set(),
+    tsMode = "receivedAt",
+    seen,
+    log = console,
+    scrub = (s) => s,
+    requireSources = [],
+  } = ctx;
+
+  const report = newReport(since);
+
+  if (strictSeq(since) === null) {
+    markUnevaluated(report, `since is not a safe non-negative integer: ${JSON.stringify(since)}`);
+    return report;
+  }
+
+  const url = `${String(baseUrl).replace(/\/+$/, "")}${streamPath}?since=${since}`;
+
+  let res;
+  try {
+    res = await fetchImpl(url, {
+      method: "GET",
+      headers: {
+        authorization: `Bearer ${token}`,
+        accept: "application/x-ndjson",
+      },
+    });
+  } catch (err) {
+    markUnevaluated(report, `fetch threw: ${scrub(err?.message ?? String(err))}`);
+    return report;
+  }
+
+  const status = res.status;
+
+  if (status === 409) {
+    // BOTH 409s are LOUD and terminal. Neither is a transient to shrug off, and
+    // NEITHER auto-repairs the cursor: clamping to head would be normalising the
+    // evidence and would silently skip a real range.
+    let body = null;
+    try {
+      body = JSON.parse(await res.text());
+    } catch {
+      body = null;
+    }
+    const kind = body && typeof body.error === "string" ? body.error : "unknown-409";
+    if (kind === "cursor_underflow") {
+      markUnevaluated(report, "409 cursor_underflow — RECONCILE REQUIRED, not resume");
+      report.control = { source: "http-409", ...(body ?? {}) };
+      log.error?.(
+        scrub(
+          `${TAG} 409 cursor_underflow at since=${since}: retention has evicted our cursor. ` +
+            `This is a RECONCILE signal, NOT a resume. The cursor is left UNCHANGED. ` +
+            `Re-point it deliberately (--since <seq>) after reconciling the gap.`,
+        ),
+      );
+      appender?.write(
+        gapMarker({
+          reason: "cursor_underflow",
+          detail: "409 from /events/stream — cursor below oldest retained seq",
+          since,
+          body,
+        }),
+      );
+      report.markersWritten += 1;
+    } else if (kind === "cursor_ahead_of_head") {
+      markUnevaluated(report, "409 cursor_ahead_of_head — CROSSED CURSOR (a bug, not a transient)");
+      report.control = { source: "http-409", ...(body ?? {}) };
+      log.error?.(
+        scrub(
+          `${TAG} 409 cursor_ahead_of_head at since=${since} (feed head=${String(body?.head)}). ` +
+            `A cursor ahead of head means the cursor was crossed — most likely a change_log.seq ` +
+            `written into the event_log cursor. These are SEPARATE sequences. Not auto-clamped.`,
+        ),
+      );
+      appender?.write(
+        gapMarker({ reason: "cursor_ahead_of_head", detail: "409 from /events/stream", since, body }),
+      );
+      report.markersWritten += 1;
+    } else {
+      markUnevaluated(report, `409 with unrecognised error body: ${JSON.stringify(body)}`);
+    }
+    return report;
+  }
+
+  if (status === 401 || status === 403) {
+    markUnevaluated(report, `auth failed (HTTP ${status}) — credential rejected`);
+    log.error?.(scrub(`${TAG} HTTP ${status} from the feed — credential rejected. Nothing evaluated.`));
+    return report;
+  }
+
+  if (status < 200 || status >= 300) {
+    markUnevaluated(report, `unexpected HTTP ${status}`);
+    return report;
+  }
+
+  const headSeq = parseHeadHeader(res.headers?.get?.("x-catalyst-event-head-seq"));
+  if (headSeq === null) {
+    // Without the stamped head there is NO coverage assertion possible. Contiguity
+    // alone cannot see a short read, so reporting healthy here would be exactly
+    // the defect this contract exists to prevent.
+    markUnevaluated(report, "missing or malformed x-catalyst-event-head-seq — coverage unassertable");
+    return report;
+  }
+  report.headSeq = headSeq;
+
+  // ---- consume the stream in WIRE ORDER. Nothing is ever sorted. ----
+  let prevSeq = null;
+  let sawControl = false;
+
+  try {
+    for await (const line of ndjsonLines(res)) {
+      let parsed;
+      try {
+        parsed = JSON.parse(line);
+      } catch {
+        markUnevaluated(report, "unparseable NDJSON line");
+        return report;
+      }
+      const cls = classifyLine(parsed);
+
+      if (cls.kind === "invalid") {
+        markUnevaluated(report, `invalid stream line: ${cls.reason}`);
+        return report;
+      }
+
+      if (cls.kind === "control") {
+        // Rule 3: the prefix is internally contiguous, so a naive gap check would
+        // pass a SERVER-DECLARED INCOMPLETE SCAN. The run is not evaluable.
+        sawControl = true;
+        report.control = { source: "in-band", ...cls.record };
+        markUnevaluated(
+          report,
+          `in-band control record ended the stream: ${JSON.stringify(cls.record)}`,
+        );
+        log.error?.(
+          scrub(
+            `${TAG} CONTROL RECORD received — the server declared this replay INCOMPLETE. ` +
+              `Everything before it is real and was ingested; everything after is UNKNOWN. ` +
+              `Run status = 2 (could not evaluate). record=${JSON.stringify(cls.record)}`,
+          ),
+        );
+        appender?.write(
+          gapMarker({
+            reason: "control-record",
+            detail: "in-band control line terminated the NDJSON stream",
+            since,
+            body: cls.record,
+            lastSeq: report.lastSeq,
+          }),
+        );
+        report.markersWritten += 1;
+        break;
+      }
+
+      // ---- event line ----
+      const rec = cls.record;
+      const seq = strictSeq(rec.seq);
+      if (seq === null) {
+        markUnevaluated(report, `event line with a non-integer seq: ${JSON.stringify(rec.seq)}`);
+        return report;
+      }
+      report.received += 1;
+      if (report.firstSeq === null) report.firstSeq = seq;
+      // INTEGRITY (separate from coverage): strict +1 adjacency, wire order, unsorted.
+      if (prevSeq !== null && seq !== prevSeq + 1) {
+        report.integrity.breaks.push({ prev: prevSeq, next: seq });
+      }
+      prevSeq = seq;
+      report.lastSeq = seq;
+
+      const src = typeof rec.source === "string" ? rec.source : "<missing>";
+      const et = typeof rec.eventType === "string" ? rec.eventType : "<missing>";
+      bump(report.bySource, src);
+      bump(report.byType, `${src}:${et}`);
+
+      const mapped = mapCloudEvent(rec, { teamsMap, tsMode, botUserIds });
+      if (mapped.outcome === "invalid") {
+        markUnevaluated(report, `unmappable-by-malformation at seq=${seq}: ${mapped.reason}`);
+        return report;
+      }
+      if (mapped.outcome === "unmappable") {
+        // NEVER silently skipped. An attributable, explicit gap marker.
+        const marker = {
+          marker: "unmappable-payload",
+          ts: new Date().toISOString(),
+          attributes: {
+            "event.name": MARKER_UNMAPPABLE,
+            "webhook.delivery.id": rec.deliveryId,
+          },
+          seq,
+          deliveryId: rec.deliveryId,
+          source: rec.source,
+          eventType: rec.eventType,
+          action: rec.action ?? null,
+          payloadBytes: rec.payloadBytes ?? null,
+          reason: "payloadOmitted",
+          ...(rec.identity !== undefined ? { identity: rec.identity } : {}),
+        };
+        appender?.write(marker);
+        report.markersWritten += 1;
+        report.unmappable.push({
+          seq,
+          deliveryId: rec.deliveryId,
+          source: rec.source,
+          eventType: rec.eventType,
+          ...(rec.identity !== undefined ? { identity: rec.identity } : {}),
+        });
+        // An elided payload is a real, targeted gap that needs a scoped reconcile.
+        markProblem(report, `payloadOmitted at seq=${seq} (deliveryId=${rec.deliveryId})`);
+        continue;
+      }
+      if (mapped.outcome === "bot-suppressed") {
+        report.botSuppressed += 1;
+        continue;
+      }
+      if (mapped.outcome === "ignored") {
+        bump(report.ignoredByType, `${src}:${et}`);
+        // Rule 9: classify against the DECLARED census, never against presence.
+        // "the mapper ignored it" is only benign for a type we declared has no
+        // mapper on either path.
+        if (classifyProviderType(src, et) === "undeclared") bump(report.undeclaredTypes, `${src}:${et}`);
+        continue;
+      }
+
+      if (needsPrCache(rec.source, rec.eventType, rec.payload)) report.prCacheDependent += 1;
+
+      // Dedup on deliveryId (invariant 6) — the LOOKUP happens before the append,
+      // but the MARK happens strictly after it. Marking first meant a write that
+      // threw (EACCES / ENOSPC / a stale mount) left the id permanently poisoned
+      // in the persisted ring: every later retry silently "deduped" a delivery
+      // that was never written, and reported healthy. Write, then mark.
+      if (seen.has(rec.deliveryId)) {
+        report.deduped += 1;
+        continue;
+      }
+      appender?.write(mapped.envelope);
+      seen.add(rec.deliveryId);
+      report.appended += 1;
+      bump(report.appendedBySource, src);
+      bump(report.appendedByType, `${src}:${et}`);
+    }
+  } catch (err) {
+    markUnevaluated(report, `stream read failed: ${scrub(err?.message ?? String(err))}`);
+    return report;
+  }
+
+  // ---- INTEGRITY verdict (independent of coverage) ----
+  report.integrity.ok = report.integrity.breaks.length === 0;
+  if (!report.integrity.ok) {
+    markProblem(
+      report,
+      `internal gap(s)/inversion(s) in wire order: ${JSON.stringify(report.integrity.breaks)}`,
+    );
+  }
+
+  // ---- COVERAGE verdict (invisible to any amount of contiguity checking) ----
+  // Skipped when a control record already invalidated the run: the server told us
+  // the replay is short, so "coverage failed" would be a redundant second verdict
+  // on a run that is not evaluable at all.
+  let provenHole = null;
+  if (!sawControl) {
+    const cov = report.coverage;
+    if (report.received === 0) {
+      if (since === headSeq) {
+        cov.ok = true;
+      } else if (since < headSeq) {
+        cov.ok = false;
+        cov.problems.push(`empty 200 while head is ahead (since=${since}, head=${headSeq})`);
+      } else {
+        cov.ok = false;
+        cov.problems.push(`empty 200 with since(${since}) > head(${headSeq}) — crossed cursor`);
+      }
+    } else {
+      if (report.firstSeq !== since + 1) {
+        cov.ok = false;
+        cov.problems.push(`first seq ${report.firstSeq} != since+1 (${since + 1}) — replay starts late`);
+        // A PROVEN hole: seqs since+1..firstSeq-1 were never delivered and never
+        // will be if we advance past them. Recorded here so the cursor policy and
+        // the durable marker below both key on the same fact.
+        provenHole = {
+          reason: "coverage-late-start",
+          missingFrom: since + 1,
+          missingTo: report.firstSeq - 1,
+        };
+      }
+      if (report.lastSeq < headSeq) {
+        cov.ok = false;
+        cov.problems.push(`last seq ${report.lastSeq} < head ${headSeq} — SHORT READ (clean EOF, no control record)`);
+      }
+      if (cov.ok === null) cov.ok = true;
+      if (report.lastSeq > headSeq) {
+        // Not a fault: the feed advanced while we read. Recorded so a
+        // cross-consumer sample taken at the same cursor stays comparable.
+        cov.advancedDuringRead = report.lastSeq - headSeq;
+      }
+    }
+    if (cov.ok === false) markProblem(report, `coverage: ${cov.problems.join("; ")}`);
+    if (provenHole !== null) {
+      // DURABLE evidence. An in-memory report dies with the process; the poll loop
+      // never exits, so the exit code carrying this finding is never observed by
+      // anything. The marker is what parity-harness's FEED_GAP_DECLARED blocker
+      // consumes, so a later parity run over this window goes non-evaluable
+      // instead of confidently green over a hole.
+      appender?.write(
+        gapMarker({
+          reason: provenHole.reason,
+          detail:
+            `coverage assertion PROVED a hole: seqs ${provenHole.missingFrom}..${provenHole.missingTo} ` +
+            `were never delivered (first seq ${report.firstSeq} != since+1). The cursor is NOT advanced past them.`,
+          since,
+          body: {
+            missingFrom: provenHole.missingFrom,
+            missingTo: provenHole.missingTo,
+            firstSeq: report.firstSeq,
+            lastSeq: report.lastSeq,
+            headSeq: report.headSeq,
+            problems: cov.problems,
+          },
+          lastSeq: report.lastSeq,
+        }),
+      );
+      report.markersWritten += 1;
+      log.error?.(
+        scrub(
+          `${TAG} COVERAGE HOLE at since=${since}: seqs ${provenHole.missingFrom}..${provenHole.missingTo} ` +
+            `were never delivered. Cursor left UNCHANGED and a ${MARKER_FEED_GAP} marker written. ` +
+            `Reconcile that range, then re-point deliberately with --since.`,
+        ),
+      );
+    }
+  }
+
+  // ---- per-source non-zero assertion (rule 5), opt-in ----
+  // Reads the APPENDED census, never the wire census: a source whose records all
+  // arrived and were then declined by the mapper contributed nothing to the shadow
+  // log, and "one lucky wire record" must not satisfy a non-zero assertion.
+  for (const s of requireSources) {
+    if ((report.appendedBySource[s] ?? 0) === 0) {
+      markProblem(
+        report,
+        `required source "${s}" appended ZERO envelopes in this window ` +
+          `(wire records received: ${report.bySource[s] ?? 0})`,
+      );
+    }
+  }
+
+  // ---- productive-output assertions (rule 9: counts of what was APPENDED) ----
+  // An UNDECLARED provider type is a cloud-side schema/casing change, not a known
+  // drop: "Comment" -> "comment" makes 100% of Linear events `ignored` while every
+  // wire-level counter stays healthy.
+  for (const [key, n] of Object.entries(report.undeclaredTypes)) {
+    markProblem(
+      report,
+      `undeclared provider type ${key}: ${n} record(s) produced NO envelope. It is neither ` +
+        `declared-mappable nor declared-unmappable — classify it (DECLARED_*_TYPES) before trusting a green run`,
+    );
+  }
+  // A type the mapper DECLARES it handles that produced records and zero envelopes
+  // is a mapper/schema regression (the "Comment payload nests under `comment`"
+  // drift), not coverage data.
+  for (const [key, n] of Object.entries(report.ignoredByType)) {
+    const cut = key.indexOf(":");
+    const s = key.slice(0, cut);
+    const t = key.slice(cut + 1);
+    if (classifyProviderType(s, t) !== "declared-mappable") continue;
+    if ((report.appendedByType[key] ?? 0) > 0) continue;
+    markProblem(
+      report,
+      `${key}: ${n} record(s) declined by the mapper and ZERO envelopes appended for that type — ` +
+        `a declared-mappable type produced nothing`,
+    );
+  }
+
+  if (sawControl) {
+    // INVARIANT 7 — underflow means RECONCILE, not resume. Advancing the cursor
+    // past a server-declared incomplete scan is precisely "assume continuity
+    // across a gap": a later restart would silently resume beyond the hole and
+    // never mention it again. The cursor stays exactly where it was; the operator
+    // must re-point it deliberately (--since) after reconciling.
+    report.cursorAdvancedTo = null;
+    if (report.firstSeq !== null && report.firstSeq !== since + 1) {
+      report.unevaluated.push(
+        `replay also started late: first seq ${report.firstSeq} != since+1 (${since + 1}) — ` +
+          `seqs ${since + 1}..${report.firstSeq - 1} were never delivered`,
+      );
+    }
+    return report;
+  }
+
+  if (provenHole !== null) {
+    // Same rule as the control record: NEVER advance past a hole we have PROVEN.
+    // Advancing would burn seqs missingFrom..missingTo forever and every later
+    // pass would report healthy. The operator reconciles and re-points --since.
+    report.cursorAdvancedTo = null;
+    return report;
+  }
+
+  // NOTE on the OTHER coverage failure, the short read (lastSeq < head): advancing
+  // to lastSeq skips NOTHING — the undelivered tail is still ahead of the cursor
+  // and is re-fetched on the next pass — so it stays a loud exit-1 problem without
+  // a durable gap marker. Writing one would make routine catch-up paging
+  // permanently non-evaluable for the harness, which is its own false signal.
+  report.cursorAdvancedTo = report.lastSeq === null ? since : report.lastSeq;
+  return report;
+}
+
+function gapMarker({ reason, detail, since, body, lastSeq = null }) {
+  return {
+    marker: "feed-gap",
+    ts: new Date().toISOString(),
+    attributes: { "event.name": MARKER_FEED_GAP },
+    reason,
+    detail,
+    since,
+    lastSeq,
+    body: body ?? null,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// CLI
+// ---------------------------------------------------------------------------
+
+/** Flags that consume the NEXT token as their value. */
+export const VALUE_FLAGS = new Set([
+  "--since", "--base-url", "--interval-ms", "--poll-ms", "--ts-mode",
+  "--require-source", "--max-consecutive-failures", "--max-passes",
+]);
+
+export function parseArgv(argv) {
+  const out = {
+    once: false,
+    json: false,
+    selfTest: false,
+    since: undefined,
+    sinceRaw: undefined,
+    baseUrl: undefined,
+    pollMs: undefined,
+    tsMode: "receivedAt",
+    requireSources: [],
+    maxConsecutiveFailures: undefined,
+    errors: [],
+    help: false,
+  };
+  // Rule 6, reached through the door a wrapper script opens: a value-taking flag
+  // whose value was eaten (`--since $SEQ` with SEQ unset, or the flag in final
+  // position) MUST be an error. Falling through to `undefined` silently discarded
+  // the flag and resumed from the persisted cursor / the default base URL / an
+  // empty --require-source, and then reported healthy about a range nobody asked
+  // for. Mirrors parity-harness.mjs parseArgs.
+  const takeValue = (flag, i) => {
+    const v = argv[i + 1];
+    if (v === undefined || (typeof v === "string" && v.startsWith("--"))) {
+      out.errors.push(`${flag} requires a value (got ${v === undefined ? "end of arguments" : JSON.stringify(v)})`);
+      return null;
+    }
+    return v;
+  };
+  const takeInline = (flag, a, prefix) => {
+    const v = a.slice(prefix.length);
+    if (v.length === 0) {
+      out.errors.push(`${flag} requires a non-empty value`);
+      return null;
+    }
+    return v;
+  };
+
+  for (let i = 0; i < argv.length; i += 1) {
+    const a = argv[i];
+    if (a === "--once") out.once = true;
+    else if (a === "--json") out.json = true;
+    else if (a === "--self-test") out.selfTest = true;
+    else if (a === "-h" || a === "--help") out.help = true;
+    else if (VALUE_FLAGS.has(a)) {
+      const v = takeValue(a, i);
+      i += 1;
+      if (v === null) continue;
+      if (a === "--since") out.sinceRaw = v;
+      else if (a === "--base-url") out.baseUrlRaw = v;
+      else if (a === "--interval-ms" || a === "--poll-ms") out.pollRaw = v;
+      else if (a === "--ts-mode") out.tsModeRaw = v;
+      else if (a === "--require-source") out.requireRaw = v;
+      else if (a === "--max-consecutive-failures") out.maxFailRaw = v;
+      else if (a === "--max-passes") out.maxPassesRaw = v;
+    } else if (a.startsWith("--since=")) {
+      const v = takeInline("--since", a, "--since=");
+      if (v !== null) out.sinceRaw = v;
+    } else if (a.startsWith("--base-url=")) {
+      const v = takeInline("--base-url", a, "--base-url=");
+      if (v !== null) out.baseUrlRaw = v;
+    } else if (a.startsWith("--interval-ms=")) {
+      const v = takeInline("--interval-ms", a, "--interval-ms=");
+      if (v !== null) out.pollRaw = v;
+    } else if (a.startsWith("--ts-mode=")) {
+      const v = takeInline("--ts-mode", a, "--ts-mode=");
+      if (v !== null) out.tsModeRaw = v;
+    } else if (a.startsWith("--require-source=")) {
+      const v = takeInline("--require-source", a, "--require-source=");
+      if (v !== null) out.requireRaw = v;
+    } else if (a.startsWith("--max-consecutive-failures=")) {
+      const v = takeInline("--max-consecutive-failures", a, "--max-consecutive-failures=");
+      if (v !== null) out.maxFailRaw = v;
+    } else if (a.startsWith("--max-passes=")) {
+      const v = takeInline("--max-passes", a, "--max-passes=");
+      if (v !== null) out.maxPassesRaw = v;
+    } else out.errors.push(`unknown argument: ${a}`);
+  }
+
+  if (out.baseUrlRaw !== undefined) {
+    if (!/^https?:\/\/[^\s]+$/.test(out.baseUrlRaw)) {
+      out.errors.push(`--base-url must be an http(s) URL, got ${JSON.stringify(out.baseUrlRaw)}`);
+    } else out.baseUrl = out.baseUrlRaw;
+  }
+  if (out.tsModeRaw !== undefined) out.tsMode = out.tsModeRaw;
+
+  // Rule 6: reject, never repair.
+  if (out.sinceRaw !== undefined) {
+    const n = parseSinceArg(out.sinceRaw);
+    if (n === null) out.errors.push(`--since must be a non-negative integer, got ${JSON.stringify(out.sinceRaw)}`);
+    else out.since = n;
+  }
+  if (out.pollRaw !== undefined) {
+    const n = parseSinceArg(out.pollRaw);
+    if (n === null || n === 0) out.errors.push(`--interval-ms must be a positive integer, got ${JSON.stringify(out.pollRaw)}`);
+    else out.pollMs = n;
+  }
+  if (out.maxFailRaw !== undefined) {
+    const n = parseSinceArg(out.maxFailRaw);
+    if (n === null || n === 0) out.errors.push(`--max-consecutive-failures must be a positive integer`);
+    else out.maxConsecutiveFailures = n;
+  }
+  if (out.maxPassesRaw !== undefined) {
+    const n = parseSinceArg(out.maxPassesRaw);
+    if (n === null || n === 0) out.errors.push(`--max-passes must be a positive integer`);
+    else out.maxPasses = n;
+  }
+  if (out.requireRaw !== undefined) {
+    const parts = String(out.requireRaw).split(",").map((s) => s.trim()).filter((s) => s.length > 0);
+    // An empty list silently turns the ONLY dead-source detector into a no-op.
+    // `--require-source ""` / `--require-source ,` must be an error, not a waiver.
+    if (parts.length === 0) {
+      out.errors.push(`--require-source parses to ZERO sources (${JSON.stringify(out.requireRaw)}) — that would disable the non-zero assertion`);
+    }
+    for (const p of parts) {
+      if (p !== "github" && p !== "linear") out.errors.push(`--require-source: unknown source "${p}"`);
+    }
+    out.requireSources = parts;
+  }
+  if (out.tsMode !== "receivedAt" && out.tsMode !== "now") {
+    out.errors.push(`--ts-mode must be receivedAt|now, got ${JSON.stringify(out.tsMode)}`);
+  }
+  return out;
+}
+
+export const USAGE = `${TAG} CTL-1534 — shadow consumer of the catalyst-cloud event feed.
+
+  bun cloud-event-consumer.mjs [--once] [--json] [--since N] [--base-url URL]
+                               [--interval-ms N] [--ts-mode receivedAt|now]
+                               [--require-source github,linear]
+                               [--max-consecutive-failures N] [--max-passes N]
+  bun cloud-event-consumer.mjs --self-test     # credential-free, offline negative control
+
+EXIT: 0 evaluated-healthy · 1 evaluated-problem · 2 COULD NOT EVALUATE.
+Writes ONLY to <CATALYST_DIR>/${SHADOW_DIR_NAME}/YYYY-MM.jsonl — never the live event log.
+`;
+
+export async function main(argv = process.argv.slice(2), deps = {}) {
+  const {
+    env = process.env,
+    fetchImpl = globalThis.fetch,
+    stdout = (s) => process.stdout.write(s),
+    stderr = (s) => process.stderr.write(s),
+    sleep = (ms) => new Promise((r) => setTimeout(r, ms)),
+    now = () => new Date(),
+  } = deps;
+
+  const args = parseArgv(argv);
+  if (args.help) {
+    stdout(USAGE);
+    return EXIT_HEALTHY;
+  }
+  if (args.errors.length > 0) {
+    for (const e of args.errors) stderr(`${TAG} ${e}\n`);
+    stderr(`${TAG} refusing to run on un-normalised input (exit 2 = could not evaluate)\n`);
+    return EXIT_UNEVALUATED;
+  }
+
+  if (args.selfTest) return runSelfTest({ stdout, stderr });
+
+  const catalystDir = deps.catalystDir ?? defaultCatalystDir(env);
+
+  const { token, source: tokenSource } = deps.tokenOverride
+    ? { token: deps.tokenOverride, source: "injected" }
+    : readCloudToken({ env });
+  const scrub = makeScrubber(token);
+  const log = deps.log ?? {
+    info: (m) => stderr(`${scrub(m)}\n`),
+    warn: (m) => stderr(`${scrub(m)}\n`),
+    error: (m) => stderr(`${scrub(m)}\n`),
+  };
+
+  if (token.length === 0) {
+    log.error(`${TAG} no CATALYST_CLOUD_TOKEN resolvable (env or ${defaultCloudSyncEnvPath(env)}) — nothing evaluated`);
+    return EXIT_UNEVALUATED;
+  }
+  log.info(`${TAG} token resolved from ${tokenSource} (value never logged)`);
+
+  const { state, ok: stateOk, reason: stateReason } = readState(catalystDir);
+  if (!stateOk) {
+    log.error(`${TAG} cursor state file is unusable (${stateReason}) at ${statePath(catalystDir)} — refusing to guess a cursor`);
+    return EXIT_UNEVALUATED;
+  }
+
+  let cursor = args.since !== undefined ? args.since : state.cursor;
+  if (cursor === null) {
+    log.error(
+      `${TAG} no persisted cursor and no --since. Refusing to default to 0: once retention ` +
+        `evicts, since=0 409s forever. Pass --since <seq> explicitly for the first run.`,
+    );
+    return EXIT_UNEVALUATED;
+  }
+
+  let appender;
+  try {
+    appender = createShadowAppender(catalystDir, { now });
+  } catch (err) {
+    log.error(`${TAG} refusing to start: ${scrub(err?.message ?? String(err))}`);
+    return EXIT_UNEVALUATED;
+  }
+  log.info(`${TAG} shadow log: ${appender.dir} (the live event log is NEVER written)`);
+
+  const seen = new Set(state.seenDeliveryIds);
+  const teamsMap = new Map(
+    (deps.linearTeams ?? safeReadClusterProjects(log, scrub)).map((t) => [t.key, t.vcsRepo]),
+  );
+  const botUserIds = deps.botUserIds ?? safeReadBotIds(log, scrub);
+  // Both of these silently degrade the shadow envelope if they resolve empty
+  // (no vcs.repository.name on Linear events; no bot suppression -> shadow-only
+  // rows in the parity join). Say so out loud rather than let the harness
+  // discover it as an unexplained diff.
+  log.info(
+    `${TAG} config: ${teamsMap.size} team->repo entries, ${botUserIds.size} bot actor id(s)` +
+      (teamsMap.size === 0 ? " — WARN: no roster, Linear envelopes will lack vcs.repository.name" : "") +
+      (botUserIds.size === 0 ? " — WARN: no bot ids, bot-authored issue events will NOT be suppressed" : ""),
+  );
+
+  const baseUrl = args.baseUrl ?? env.CATALYST_CLOUD_EVENTS_BASE_URL ?? DEFAULT_BASE_URL;
+  // The env path is validated EXACTLY as the flag path is. Repairing a malformed
+  // value into the default meant the operator set a cadence, the tool discarded
+  // it, and every healthy report afterwards described a cadence nobody configured
+  // — and "0" survived `??` into an unthrottled poll loop the flag form rejects.
+  let pollMs = args.pollMs ?? DEFAULT_POLL_MS;
+  if (args.pollMs === undefined && typeof env.CATALYST_CLOUD_EVENT_POLL_MS === "string" && env.CATALYST_CLOUD_EVENT_POLL_MS.length > 0) {
+    const n = parseSinceArg(env.CATALYST_CLOUD_EVENT_POLL_MS);
+    if (n === null || n === 0) {
+      log.error(`${TAG} CATALYST_CLOUD_EVENT_POLL_MS must be a positive integer, got ${JSON.stringify(env.CATALYST_CLOUD_EVENT_POLL_MS)} — refusing to silently substitute the default`);
+      return EXIT_UNEVALUATED;
+    }
+    pollMs = n;
+  }
+  const maxFail = args.maxConsecutiveFailures ?? DEFAULT_MAX_CONSECUTIVE_FAILURES;
+
+  let worst = EXIT_HEALTHY;
+  let consecutiveFailures = 0;
+  const reports = [];
+
+  for (;;) {
+    const report = await runOnce({
+      fetchImpl,
+      baseUrl,
+      token,
+      since: cursor,
+      appender,
+      teamsMap,
+      botUserIds,
+      tsMode: args.tsMode,
+      seen,
+      log,
+      scrub,
+      requireSources: args.requireSources,
+    });
+    reports.push(report);
+    // 2 dominates 1 dominates 0 — worst-observed, never downgraded.
+    if (report.status === EXIT_UNEVALUATED) worst = EXIT_UNEVALUATED;
+    else if (report.status === EXIT_PROBLEM && worst !== EXIT_UNEVALUATED) worst = EXIT_PROBLEM;
+
+    // Persist whatever we genuinely ingested, even on a bad pass — those events
+    // were really delivered. The cursor is NEVER advanced past what we received,
+    // and is left completely untouched when nothing was received.
+    const cursorBefore = cursor;
+    if (report.cursorAdvancedTo !== null && report.cursorAdvancedTo !== cursor) {
+      cursor = report.cursorAdvancedTo;
+    }
+    const madeProgress = cursor !== cursorBefore;
+    try {
+      writeState(catalystDir, { cursor, seenDeliveryIds: Array.from(seen) });
+    } catch (err) {
+      log.error(`${TAG} cursor persist FAILED: ${scrub(err?.message ?? String(err))}`);
+      worst = EXIT_UNEVALUATED;
+      break;
+    }
+
+    if (!args.json) log.info(`${TAG} ${summarize(report)}`);
+
+    if (args.once) break;
+
+    // Hard upper bound on passes. A poll loop with no bound can HANG instead of
+    // failing when a status-classification bug makes every pass look retryable —
+    // and a hang is not a red, it is an absence of a verdict.
+    if (args.maxPasses !== undefined && reports.length >= args.maxPasses) {
+      log.warn?.(`${TAG} reached --max-passes ${args.maxPasses} — stopping`);
+      break;
+    }
+
+    if (isTerminal(report)) {
+      log.error(`${TAG} terminal condition — stopping the poll loop. ${report.unevaluated.join("; ")}`);
+      break;
+    }
+    // A non-healthy pass that ALSO made no progress is not a transient: the same
+    // cursor will produce the same verdict forever. Bounding only EXIT_UNEVALUATED
+    // let a permanent EXIT_PROBLEM (a proven coverage hole, an empty 200 while head
+    // is ahead) spin at one cursor indefinitely — and a process that never exits
+    // never reports its exit code, so "still running" read as healthy.
+    if (report.status !== EXIT_HEALTHY && !madeProgress) {
+      consecutiveFailures += 1;
+      if (consecutiveFailures >= maxFail) {
+        log.error(
+          `${TAG} ${consecutiveFailures} consecutive non-healthy passes with NO cursor progress ` +
+            `(cursor stuck at ${cursor}) — stopping rather than spinning. worst status so far = ${worst}`,
+        );
+        break;
+      }
+    } else {
+      consecutiveFailures = 0;
+    }
+    await sleep(pollMs);
+  }
+
+  if (args.json) {
+    stdout(JSON.stringify({ exit: worst, reports }, null, 2) + "\n");
+  } else {
+    stdout(`${TAG} exit=${worst} (0=healthy 1=problem 2=COULD-NOT-EVALUATE) passes=${reports.length}\n`);
+  }
+  return worst;
+}
+
+/** Terminal = a condition that cannot resolve by retrying the same cursor. */
+function isTerminal(report) {
+  if (report.control !== null) return true;
+  return report.unevaluated.some(
+    (r) =>
+      r.startsWith("409 ") ||
+      r.startsWith("auth failed") ||
+      r.startsWith("since is not") ||
+      r.startsWith("missing or malformed x-catalyst-event-head-seq"),
+  );
+}
+
+function summarize(r) {
+  const parts = [
+    `since=${r.since}`,
+    `head=${r.headSeq ?? "?"}`,
+    `recv=${r.received}`,
+    `appended=${r.appended}`,
+    `dedup=${r.deduped}`,
+    `coverage=${r.coverage.ok === null ? "n/a" : r.coverage.ok ? "ok" : "FAIL"}`,
+    `integrity=${r.integrity.ok === null ? "n/a" : r.integrity.ok ? "ok" : "FAIL"}`,
+    `unmappable=${r.unmappable.length}`,
+    `markers=${r.markersWritten}`,
+    `status=${r.status}`,
+  ];
+  // Printed UNCONDITIONALLY, with both sources seeded at zero: "linear delivered
+  // nothing" must not look identical to "linear was not part of this window".
+  const fmt = (obj) => Object.entries(obj).map(([k, v]) => `${k}:${v}`).join(",") || "-";
+  parts.push(`bySource=${fmt(r.bySource)}`);
+  parts.push(`appendedBySource=${fmt(r.appendedBySource)}`);
+  parts.push(`byType=${fmt(r.byType)}`);
+  parts.push(`ignoredByType=${fmt(r.ignoredByType)}`);
+  if (r.problems.length) parts.push(`problems=[${r.problems.join(" | ")}]`);
+  if (r.unevaluated.length) parts.push(`unevaluated=[${r.unevaluated.join(" | ")}]`);
+  return parts.join(" ");
+}
+
+function safeReadClusterProjects(log, scrub) {
+  try {
+    return readClusterProjects();
+  } catch (err) {
+    log.warn?.(`${TAG} team roster unreadable (${scrub(err?.message ?? String(err))}) — vcs.repository.name will be absent on Linear envelopes`);
+    return [];
+  }
+}
+
+function safeReadBotIds(log, scrub) {
+  try {
+    return readLinearBotUserIds();
+  } catch (err) {
+    log.warn?.(`${TAG} bot-actor ids unreadable (${scrub(err?.message ?? String(err))}) — bot-authored issue events will NOT be suppressed`);
+    return new Set();
+  }
+}
+
+// ---------------------------------------------------------------------------
+// NEGATIVE CONTROL — credential-free, offline, CI-runnable, and OBSERVED red.
+//
+// Rule 8: the load-bearing control must run where it is most useful (a clean
+// checkout, secret-free CI). It uses an in-memory fetch and an in-memory
+// appender: no token, no network, no filesystem writes.
+// ---------------------------------------------------------------------------
+
+function fakeResponse({ status = 200, head = null, lines = [], body = null }) {
+  const headers = new Map();
+  if (head !== null) headers.set("x-catalyst-event-head-seq", String(head));
+  return {
+    status,
+    headers: { get: (k) => headers.get(String(k).toLowerCase()) ?? null },
+    text: async () => (body !== null ? JSON.stringify(body) : lines.map((l) => JSON.stringify(l)).join("\n") + "\n"),
+  };
+}
+
+export function ghEvent(seq, deliveryId, extra = {}) {
+  return {
+    accountId: "tenant-0",
+    seq,
+    deliveryId,
+    source: "github",
+    eventType: "pull_request",
+    action: "opened",
+    receivedAt: "2026-07-26T20:00:00.000Z",
+    payload: {
+      action: "opened",
+      repository: { full_name: "coalesce-labs/catalyst" },
+      pull_request: { number: 2751, head: { ref: "ryan/x", sha: "abc123" } },
+    },
+    ...extra,
+  };
+}
+
+export function linearEvent(seq, deliveryId, extra = {}) {
+  return {
+    accountId: "tenant-0",
+    seq,
+    deliveryId,
+    source: "linear",
+    eventType: "Comment",
+    action: "create",
+    receivedAt: "2026-07-26T20:00:00.000Z",
+    payload: {
+      type: "Comment",
+      action: "create",
+      data: { id: "cmt-1", body: "hello", issue: { identifier: "CTL-1534" } },
+    },
+    ...extra,
+  };
+}
+
+function memAppender() {
+  const records = [];
+  return { records, write: (r) => records.push(r), dir: "<memory>" };
+}
+
+const SELF_TEST_CASES = [
+  {
+    name: "healthy: full replay, contiguous, spans since+1..head",
+    expect: EXIT_HEALTHY,
+    build: () => ({ since: 0, res: fakeResponse({ head: 3, lines: [ghEvent(1, "d1"), linearEvent(2, "d2"), ghEvent(3, "d3")] }) }),
+  },
+  {
+    name: "healthy: empty 200 with cursor exactly at head",
+    expect: EXIT_HEALTHY,
+    build: () => ({ since: 7, res: fakeResponse({ head: 7, lines: [] }) }),
+  },
+  {
+    name: "RED coverage: empty 200 while head is AHEAD (internally contiguous, no control record)",
+    expect: EXIT_PROBLEM,
+    build: () => ({ since: 3, res: fakeResponse({ head: 9, lines: [] }) }),
+  },
+  {
+    name: "RED coverage: replay STARTS LATE (first != since+1)",
+    expect: EXIT_PROBLEM,
+    build: () => ({ since: 0, res: fakeResponse({ head: 3, lines: [ghEvent(2, "d2"), ghEvent(3, "d3")] }) }),
+  },
+  {
+    name: "RED coverage: SHORT READ, clean EOF before head",
+    expect: EXIT_PROBLEM,
+    build: () => ({ since: 0, res: fakeResponse({ head: 9, lines: [ghEvent(1, "d1"), ghEvent(2, "d2")] }) }),
+  },
+  {
+    name: "RED integrity: internal gap 1,3",
+    expect: EXIT_PROBLEM,
+    build: () => ({ since: 0, res: fakeResponse({ head: 3, lines: [ghEvent(1, "d1"), ghEvent(3, "d3")] }) }),
+  },
+  {
+    name: "RED integrity: wire-order inversion 1,3,2 is NOT sorted away",
+    expect: EXIT_PROBLEM,
+    build: () => ({ since: 0, res: fakeResponse({ head: 3, lines: [ghEvent(1, "d1"), ghEvent(3, "d3"), ghEvent(2, "d2")] }) }),
+  },
+  {
+    name: "UNEVALUATED: in-band control record terminates a contiguous prefix",
+    expect: EXIT_UNEVALUATED,
+    build: () => ({
+      since: 0,
+      res: fakeResponse({ head: 9, lines: [ghEvent(1, "d1"), ghEvent(2, "d2"), { error: "cursor_underflow", resync: true }] }),
+    }),
+  },
+  {
+    name: "UNEVALUATED: 409 cursor_underflow",
+    expect: EXIT_UNEVALUATED,
+    build: () => ({ since: 1, res: fakeResponse({ status: 409, body: { error: "cursor_underflow", resync: true } }) }),
+  },
+  {
+    name: "UNEVALUATED: 409 cursor_ahead_of_head",
+    expect: EXIT_UNEVALUATED,
+    build: () => ({ since: 999999999, res: fakeResponse({ status: 409, body: { error: "cursor_ahead_of_head", resync: true, head: 113 } }) }),
+  },
+  {
+    name: "UNEVALUATED: missing x-catalyst-event-head-seq (coverage unassertable)",
+    expect: EXIT_UNEVALUATED,
+    build: () => ({ since: 0, res: fakeResponse({ head: null, lines: [ghEvent(1, "d1")] }) }),
+  },
+  {
+    name: "UNEVALUATED: HTTP 401 (credential rejected)",
+    expect: EXIT_UNEVALUATED,
+    build: () => ({ since: 0, res: fakeResponse({ status: 401 }) }),
+  },
+  {
+    name: "UNEVALUATED: fetch throws (probe failed -> never 'healthy')",
+    expect: EXIT_UNEVALUATED,
+    build: () => ({ since: 0, throws: new Error("ECONNREFUSED") }),
+  },
+  {
+    name: "UNEVALUATED: seq arrives as a STRING (evidence not coerced)",
+    expect: EXIT_UNEVALUATED,
+    build: () => ({ since: 0, res: fakeResponse({ head: 1, lines: [{ ...ghEvent(1, "d1"), seq: "1" }] }) }),
+  },
+  {
+    name: "PROBLEM: payloadOmitted produces an attributable gap marker, never a silent skip",
+    expect: EXIT_PROBLEM,
+    build: () => ({
+      since: 0,
+      res: fakeResponse({
+        head: 1,
+        lines: [
+          {
+            accountId: "tenant-0", seq: 1, deliveryId: "big-1", source: "linear",
+            eventType: "Comment", action: "create", receivedAt: "2026-07-26T20:00:00.000Z",
+            payload: null, payloadOmitted: true, payloadBytes: 120000,
+            identity: { id: "iss-1", identifier: "CTL-1534" },
+          },
+        ],
+      }),
+    }),
+  },
+  {
+    name: "HEALTHY: payloadOmitted ABSENT on a normal event (truthy test, not key-presence)",
+    expect: EXIT_HEALTHY,
+    build: () => ({ since: 0, res: fakeResponse({ head: 1, lines: [ghEvent(1, "d1")] }) }),
+  },
+  {
+    name: "RED per-source: --require-source linear with zero linear events",
+    expect: EXIT_PROBLEM,
+    requireSources: ["linear"],
+    build: () => ({ since: 0, res: fakeResponse({ head: 1, lines: [ghEvent(1, "d1")] }) }),
+  },
+  {
+    name: "HEALTHY: payloadOmitted:false still maps (key-presence would break this)",
+    expect: EXIT_HEALTHY,
+    build: () => ({ since: 0, res: fakeResponse({ head: 1, lines: [ghEvent(1, "d1", { payloadOmitted: false })] }) }),
+  },
+  {
+    name: "DEDUP: a repeated deliveryId in one stream is appended exactly once",
+    expect: EXIT_HEALTHY,
+    assertReport: (r) => r.appended === 1 && r.deduped === 1,
+    build: () => ({ since: 0, res: fakeResponse({ head: 2, lines: [ghEvent(1, "dup"), ghEvent(2, "dup")] }) }),
+  },
+  {
+    // Rule 8 applied to the PRODUCER/HARNESS contract: the ordering attribute the
+    // parity harness keys on must be present on a real envelope, with the wire seq.
+    name: "CONTRACT: every appended envelope carries the cloud seq the harness reads",
+    expect: EXIT_HEALTHY,
+    assertReport: (r, app) => {
+      const envelopes = app.records.filter((x) => x.attributes?.["event.name"]?.includes("."));
+      if (envelopes.length !== 2) return false;
+      return (
+        envelopes[0].attributes[SEQ_ATTR] === 1 &&
+        envelopes[1].attributes[SEQ_ATTR] === 2 &&
+        // and BOTH sources actually produced an envelope — a positive control that
+        // never inspects the output cannot see a per-source mapping regression
+        envelopes.some((e) => e.attributes["event.name"].startsWith("github.")) &&
+        envelopes.some((e) => e.attributes["event.name"].startsWith("linear."))
+      );
+    },
+    build: () => ({ since: 0, res: fakeResponse({ head: 2, lines: [ghEvent(1, "d1"), linearEvent(2, "d2")] }) }),
+  },
+  {
+    name: "PROBLEM: a PROVEN coverage hole writes a durable gap marker and does NOT advance the cursor",
+    expect: EXIT_PROBLEM,
+    assertReport: (r, app) => {
+      const gaps = app.records.filter((x) => x.attributes?.["event.name"] === MARKER_FEED_GAP);
+      return (
+        r.cursorAdvancedTo === null &&
+        gaps.length === 1 &&
+        gaps[0].reason === "coverage-late-start" &&
+        gaps[0].body?.missingFrom === 1 &&
+        gaps[0].body?.missingTo === 8
+      );
+    },
+    build: () => ({ since: 0, res: fakeResponse({ head: 10, lines: [ghEvent(9, "d9"), ghEvent(10, "d10")] }) }),
+  },
+  {
+    name: "DEDUP ORDERING: a failed append never marks the delivery seen (no permanent silent skip)",
+    expect: EXIT_UNEVALUATED,
+    direct: async () => {
+      const seen = new Set();
+      const report = await runOnce({
+        fetchImpl: async () => fakeResponse({ head: 1, lines: [ghEvent(1, "d1")] }),
+        token: "",
+        since: 0,
+        appender: { write: () => { throw new Error("EACCES"); }, dir: "<broken>" },
+        seen,
+        log: { info() {}, warn() {}, error() {} },
+      });
+      // The run must be unevaluated AND the id must NOT be poisoned into the ring.
+      return report.status === EXIT_UNEVALUATED && !seen.has("d1") ? EXIT_UNEVALUATED : EXIT_HEALTHY;
+    },
+  },
+  {
+    name: "RED per-source: --require-source counts APPENDED envelopes, not wire records",
+    expect: EXIT_PROBLEM,
+    requireSources: ["linear"],
+    build: () => ({
+      since: 0,
+      res: fakeResponse({
+        head: 1,
+        // A declared-unmappable Linear provider type: it arrives (bySource.linear = 1)
+        // but produces no envelope. Counting the wire record satisfied the assertion.
+        lines: [{ ...linearEvent(1, "att-1"), eventType: "Attachment", payload: { type: "Attachment", action: "create", data: {} } }],
+      }),
+    }),
+  },
+  {
+    name: "RED mapper regression: an UNDECLARED provider type (casing drift) is a problem, not coverage data",
+    expect: EXIT_PROBLEM,
+    build: () => ({
+      since: 0,
+      res: fakeResponse({ head: 1, lines: [{ ...linearEvent(1, "c1"), eventType: "comment" }] }),
+    }),
+  },
+  {
+    name: "RED mapper regression: a DECLARED-mappable type that appended nothing is a problem",
+    expect: EXIT_PROBLEM,
+    build: () => ({
+      since: 0,
+      // "Comment" IS declared-mappable; the payload nests under `comment` instead of
+      // `data` (the recorded Linear schema drift), so every record is ignored.
+      res: fakeResponse({
+        head: 2,
+        lines: [
+          { ...linearEvent(1, "c1"), payload: { type: "Comment", action: "create", comment: { id: "x" } } },
+          { ...linearEvent(2, "c2"), payload: { type: "Comment", action: "create", comment: { id: "y" } } },
+        ],
+      }),
+    }),
+  },
+  {
+    name: "HEALTHY: a DECLARED-unmappable provider type (workflow_job) is expected-zero, not a problem",
+    expect: EXIT_HEALTHY,
+    build: () => ({
+      since: 0,
+      res: fakeResponse({
+        head: 2,
+        lines: [
+          ghEvent(1, "wj-1", { eventType: "workflow_job", payload: { repository: { full_name: "a/b" } } }),
+          ghEvent(2, "d2"),
+        ],
+      }),
+    }),
+  },
+  {
+    name: "UNEVALUATED: a value-taking flag with its value EATEN is rejected, never silently dropped",
+    expect: EXIT_UNEVALUATED,
+    direct: async () => {
+      const dangling = [...VALUE_FLAGS].every((f) => parseArgv(["--once", f]).errors.length > 0);
+      const empties = ["--since=", "--require-source=", "--base-url=", "--ts-mode=", "--interval-ms="].every(
+        (f) => parseArgv(["--once", f]).errors.length > 0,
+      );
+      const flagShaped = parseArgv(["--since", "--json"]).errors.length > 0;
+      const emptyList = parseArgv(["--require-source", ","]).errors.length > 0;
+      const good = parseArgv(["--once", "--since", "42", "--require-source", "github"]).errors.length === 0;
+      return dangling && empties && flagShaped && emptyList && good ? EXIT_UNEVALUATED : EXIT_HEALTHY;
+    },
+  },
+  {
+    name: "UNEVALUATED: --since banana / 1e3 / -1 / ' 5' are all REJECTED, never coerced",
+    expect: EXIT_UNEVALUATED,
+    direct: async () => {
+      const bad = ["banana", "1e3", "-1", " 5", "1.0", "0x10", "+3"];
+      const allRejected = bad.every((v) => parseArgv(["--since", v]).errors.length > 0);
+      const goodAccepted = parseArgv(["--since", "42"]).errors.length === 0;
+      return allRejected && goodAccepted ? EXIT_UNEVALUATED : EXIT_HEALTHY;
+    },
+  },
+  {
+    name: "UNEVALUATED: the shadow dir constant is NOT the live events dir name",
+    expect: EXIT_UNEVALUATED,
+    direct: async () =>
+      SHADOW_DIR_NAME !== LIVE_DIR_NAME && resolveShadowDir("/tmp/fake-catalyst").endsWith(SHADOW_DIR_NAME)
+        ? EXIT_UNEVALUATED
+        : EXIT_HEALTHY,
+  },
+  {
+    name: "UNEVALUATED: shadow dir can NEVER resolve onto the live events dir",
+    expect: EXIT_UNEVALUATED,
+    direct: async () => {
+      try {
+        resolveShadowDir("/tmp/fake-catalyst/events");
+        return EXIT_HEALTHY; // detector FAILED to fire
+      } catch {
+        return EXIT_UNEVALUATED;
+      }
+    },
+  },
+];
+
+export async function runSelfTest({ stdout = (s) => process.stdout.write(s), stderr = (s) => process.stderr.write(s) } = {}) {
+  const rows = [];
+  let allOk = true;
+  for (const c of SELF_TEST_CASES) {
+    let got;
+    try {
+      if (c.direct) {
+        got = await c.direct();
+      } else {
+        const { since, res, throws } = c.build();
+        const app = memAppender();
+        const report = await runOnce({
+          fetchImpl: async () => {
+            if (throws) throw throws;
+            return res;
+          },
+          token: "", // credential-free by construction
+          since,
+          appender: app,
+          seen: new Set(),
+          log: { info() {}, warn() {}, error() {} },
+          requireSources: c.requireSources ?? [],
+        });
+        got = report.status;
+        // Some detectors assert on the REPORT and on what was actually WRITTEN, not
+        // just the exit code — a status check alone cannot see a removed dedup
+        // (still exit 0, silently double-appending), a missing seq stamp, or a
+        // whole source that produced no envelope.
+        if (c.assertReport && !c.assertReport(report, app)) {
+          got = `report-assertion-failed(status=${report.status})`;
+        }
+      }
+    } catch (err) {
+      got = `THREW: ${err?.message ?? String(err)}`;
+    }
+    const ok = got === c.expect;
+    if (!ok) allOk = false;
+    rows.push({ name: c.name, expect: c.expect, got, ok });
+  }
+  const red = rows.filter((r) => r.expect !== EXIT_HEALTHY).length;
+  stdout(`${TAG} --self-test (credential-free, offline)\n`);
+  for (const r of rows) {
+    stdout(`  ${r.ok ? "PASS" : "FAIL"}  expect=${r.expect} got=${r.got}  ${r.name}\n`);
+  }
+  stdout(`${TAG} ${rows.length} cases; ${red} detectors expected RED; ${rows.filter((r) => r.ok).length} correct\n`);
+  if (!allOk) {
+    stderr(`${TAG} SELF-TEST FAILED — a detector did not fire. The harness cannot be trusted.\n`);
+    return EXIT_PROBLEM;
+  }
+  return EXIT_HEALTHY;
+}
+
+// ---------------------------------------------------------------------------
+// Direct invocation
+// ---------------------------------------------------------------------------
+
+const _invokedDirectly =
+  typeof process !== "undefined" &&
+  Array.isArray(process.argv) &&
+  typeof process.argv[1] === "string" &&
+  process.argv[1].endsWith("cloud-event-consumer.mjs");
+
+if (_invokedDirectly) {
+  const code = await main();
+  process.exit(code);
+}

--- a/plugins/dev/scripts/execution-core/cloud-event-consumer.mjs
+++ b/plugins/dev/scripts/execution-core/cloud-event-consumer.mjs
@@ -190,6 +190,44 @@ export function parseHeadHeader(raw) {
   return parseSinceArg(raw);
 }
 
+/**
+ * computeMissingRanges — the seqs in (since, max(received)] the feed NEVER delivered.
+ *
+ * PRESENCE is a set question; ORDER is a separate one, checked unsorted in wire order by
+ * the integrity pass (rule 4). Deriving the hole from `firstSeq !== since + 1` conflates
+ * the two: an out-of-order page (2,1,3) delivers every seq in its range and has NO hole,
+ * yet the first-line test claims one and pins the cursor forever on healthy data. Sorting
+ * a COPY of the received set here is presentation of a set, not normalisation of the
+ * adjacency evidence — that evidence is untouched.
+ */
+export function computeMissingRanges(since, receivedSeqs) {
+  const sorted = [...new Set(receivedSeqs)].sort((a, b) => a - b);
+  const ranges = [];
+  let expect = since + 1;
+  for (const s of sorted) {
+    if (s > expect) ranges.push({ from: expect, to: s - 1 });
+    if (s >= expect) expect = s + 1;
+  }
+  return ranges;
+}
+
+/**
+ * classifyDecline — WHY the mapper declined a record.
+ *
+ *   "routine"    — the mapper handles the TYPE but not this ACTION (or the record is
+ *                  legitimately out of scope, e.g. a non-PR issue_comment). The live path
+ *                  declines it identically, so it is coverage data on both sides.
+ *   "structural" — the payload did not have the SHAPE the mapper requires ("missing X",
+ *                  "payload is not an object"). On a DECLARED-MAPPABLE type that is schema
+ *                  drift, and it is a regression at ANY ratio — which is precisely the
+ *                  partial regression a zero-appends test cannot see.
+ */
+export function classifyDecline(reason) {
+  const r = typeof reason === "string" ? reason : "";
+  if (/unknown action|unhandled event:|unhandled type:|not a PR comment/.test(r)) return "routine";
+  return "structural";
+}
+
 // ---------------------------------------------------------------------------
 // Paths. The shadow dir is impossible to point at the live log.
 // ---------------------------------------------------------------------------
@@ -532,13 +570,24 @@ export function readLinearBotUserIds(opts = {}) {
     layer1Path = resolve(env.CATALYST_PROJECT_DIR || process.cwd(), ".catalyst", "config.json"),
   } = opts;
   const ids = new Set();
+  // An ABSENT config file is a legitimate state (a host may have no Layer-2 at all). A
+  // file that exists but does not parse is NOT — swallowing it produced an empty bot set
+  // that silently stops suppressing bot-authored events, which the parity join then reads
+  // as unexplained shadow-only rows. Reject, never repair (rule 6).
   const load = (p) => {
+    let text;
     try {
-      const parsed = JSON.parse(readFile(p));
-      return parsed !== null && typeof parsed === "object" ? parsed : null;
+      text = readFile(p);
     } catch {
       return null;
     }
+    let parsed;
+    try {
+      parsed = JSON.parse(text);
+    } catch (err) {
+      throw new Error(`config file ${p} exists but is not parseable JSON: ${err?.message ?? String(err)}`);
+    }
+    return parsed !== null && typeof parsed === "object" ? parsed : null;
   };
   const l2 = load(layer2Path);
   const bot = l2?.catalyst?.linear?.bot;
@@ -698,7 +747,16 @@ export function newReport(since) {
     appendedByType: {},
     unmappable: [],
     ignoredByType: {},
+    // Declines with a STRUCTURAL reason, per `source:eventType`. Separate from
+    // ignoredByType because a routine action-level decline is coverage data while a
+    // structural one on a declared-mappable type is schema drift (H10).
+    structuralDeclines: {},
+    structuralDeclineReasons: {},
     undeclaredTypes: {},
+    // Proven seq holes (never-delivered ranges) that pinned the cursor.
+    holes: [],
+    // True when every record in the window was already in the dedup ring (M11).
+    dedupOnly: false,
     markersWritten: 0,
     prCacheDependent: 0,
     botSuppressed: 0,
@@ -752,9 +810,41 @@ export async function runOnce(ctx) {
     log = console,
     scrub = (s) => s,
     requireSources = [],
+    now = () => new Date(),
   } = ctx;
 
   const report = newReport(since);
+  const emittedAt = now().toISOString();
+
+  /**
+   * writeMarker — the ONLY way a durable marker reaches the shadow log.
+   *
+   * CTL-1534 (M): these writes used to sit OUTSIDE the try/catch that guards the stream
+   * loop, so an EACCES/ENOSPC on a gap marker escaped `runOnce` entirely — the process
+   * died with an unhandled rejection instead of the exit-2 the three-way contract owes a
+   * failed evaluation. And a gap marker that never lands is worse than loud: it is the
+   * record parity-harness's FEED_GAP_DECLARED blocker consumes, so a later parity run
+   * goes confidently green over a hole nobody can see.
+   */
+  const writeMarker = (record) => {
+    if (!appender) return;
+    try {
+      appender.write(record);
+      report.markersWritten += 1;
+    } catch (err) {
+      markUnevaluated(
+        report,
+        `durable marker write FAILED (${record?.reason ?? record?.marker ?? "marker"}): ` +
+          `${scrub(err?.message ?? String(err))} — this window's coverage declaration is NOT on disk`,
+      );
+      log.error?.(
+        scrub(
+          `${TAG} durable marker write FAILED — parity-harness will NOT see this window's ` +
+            `coverage declaration and would report green over it. Run status = 2.`,
+        ),
+      );
+    }
+  };
 
   if (strictSeq(since) === null) {
     markUnevaluated(report, `since is not a safe non-negative integer: ${JSON.stringify(since)}`);
@@ -800,15 +890,15 @@ export async function runOnce(ctx) {
             `Re-point it deliberately (--since <seq>) after reconciling the gap.`,
         ),
       );
-      appender?.write(
+      writeMarker(
         gapMarker({
           reason: "cursor_underflow",
           detail: "409 from /events/stream — cursor below oldest retained seq",
           since,
           body,
+          emittedAt,
         }),
       );
-      report.markersWritten += 1;
     } else if (kind === "cursor_ahead_of_head") {
       markUnevaluated(report, "409 cursor_ahead_of_head — CROSSED CURSOR (a bug, not a transient)");
       report.control = { source: "http-409", ...(body ?? {}) };
@@ -819,10 +909,9 @@ export async function runOnce(ctx) {
             `written into the event_log cursor. These are SEPARATE sequences. Not auto-clamped.`,
         ),
       );
-      appender?.write(
-        gapMarker({ reason: "cursor_ahead_of_head", detail: "409 from /events/stream", since, body }),
+      writeMarker(
+        gapMarker({ reason: "cursor_ahead_of_head", detail: "409 from /events/stream", since, body, emittedAt }),
       );
-      report.markersWritten += 1;
     } else {
       markUnevaluated(report, `409 with unrecognised error body: ${JSON.stringify(body)}`);
     }
@@ -853,6 +942,14 @@ export async function runOnce(ctx) {
   // ---- consume the stream in WIRE ORDER. Nothing is ever sorted. ----
   let prevSeq = null;
   let sawControl = false;
+  // PRESENCE evidence, kept alongside (never instead of) the wire-order evidence above.
+  const receivedSeqs = [];
+  let minSeq = null;
+  let maxSeq = null;
+  // Timestamp anchors for durable markers (H): the harness places a marker in the window
+  // by `ts`, and the envelopes it is compared against carry the cloud's `receivedAt`.
+  let firstReceivedAtIso = null;
+  let lastReceivedAtIso = null;
 
   try {
     for await (const line of ndjsonLines(res)) {
@@ -886,16 +983,18 @@ export async function runOnce(ctx) {
               `Run status = 2 (could not evaluate). record=${JSON.stringify(cls.record)}`,
           ),
         );
-        appender?.write(
+        writeMarker(
           gapMarker({
             reason: "control-record",
             detail: "in-band control line terminated the NDJSON stream",
             since,
             body: cls.record,
             lastSeq: report.lastSeq,
+            ts: lastReceivedAtIso,
+            tsSource: lastReceivedAtIso === null ? "wall-clock" : "receivedAt",
+            emittedAt,
           }),
         );
-        report.markersWritten += 1;
         break;
       }
 
@@ -914,6 +1013,14 @@ export async function runOnce(ctx) {
       }
       prevSeq = seq;
       report.lastSeq = seq;
+      receivedSeqs.push(seq);
+      if (minSeq === null || seq < minSeq) minSeq = seq;
+      if (maxSeq === null || seq > maxSeq) maxSeq = seq;
+      const recTsIso = toIsoOrNull(rec.receivedAt);
+      if (recTsIso !== null) {
+        if (firstReceivedAtIso === null) firstReceivedAtIso = recTsIso;
+        lastReceivedAtIso = recTsIso;
+      }
 
       const src = typeof rec.source === "string" ? rec.source : "<missing>";
       const et = typeof rec.eventType === "string" ? rec.eventType : "<missing>";
@@ -929,7 +1036,10 @@ export async function runOnce(ctx) {
         // NEVER silently skipped. An attributable, explicit gap marker.
         const marker = {
           marker: "unmappable-payload",
-          ts: new Date().toISOString(),
+          // Anchored on the delivery's own receipt time, not wall clock (H).
+          ts: recTsIso ?? emittedAt,
+          tsSource: recTsIso === null ? "wall-clock" : "receivedAt",
+          emittedAt,
           attributes: {
             "event.name": MARKER_UNMAPPABLE,
             "webhook.delivery.id": rec.deliveryId,
@@ -943,8 +1053,7 @@ export async function runOnce(ctx) {
           reason: "payloadOmitted",
           ...(rec.identity !== undefined ? { identity: rec.identity } : {}),
         };
-        appender?.write(marker);
-        report.markersWritten += 1;
+        writeMarker(marker);
         report.unmappable.push({
           seq,
           deliveryId: rec.deliveryId,
@@ -962,6 +1071,10 @@ export async function runOnce(ctx) {
       }
       if (mapped.outcome === "ignored") {
         bump(report.ignoredByType, `${src}:${et}`);
+        if (classifyDecline(mapped.reason) === "structural") {
+          bump(report.structuralDeclines, `${src}:${et}`);
+          report.structuralDeclineReasons[`${src}:${et}`] ??= mapped.reason;
+        }
         // Rule 9: classify against the DECLARED census, never against presence.
         // "the mapper ignored it" is only benign for a type we declared has no
         // mapper on either path.
@@ -1018,27 +1131,45 @@ export async function runOnce(ctx) {
         cov.problems.push(`empty 200 with since(${since}) > head(${headSeq}) — crossed cursor`);
       }
     } else {
-      if (report.firstSeq !== since + 1) {
+      // COVERAGE is a question about which seqs were DELIVERED, so it is answered from
+      // the received SET (min/max/holes), never from the first/last line of the wire.
+      // Keying it on `firstSeq` conflated presence with order: an out-of-order page
+      // (2,1,3) has no hole at all, yet the first-line test declared one, failed
+      // coverage, and pinned the cursor forever on perfectly healthy data.
+      const holes = computeMissingRanges(since, receivedSeqs);
+      if (minSeq !== since + 1) {
         cov.ok = false;
-        cov.problems.push(`first seq ${report.firstSeq} != since+1 (${since + 1}) — replay starts late`);
-        // A PROVEN hole: seqs since+1..firstSeq-1 were never delivered and never
-        // will be if we advance past them. Recorded here so the cursor policy and
-        // the durable marker below both key on the same fact.
-        provenHole = {
-          reason: "coverage-late-start",
-          missingFrom: since + 1,
-          missingTo: report.firstSeq - 1,
-        };
+        cov.problems.push(
+          `lowest delivered seq ${minSeq} != since+1 (${since + 1}) — replay starts late ` +
+            `(the first line carried seq ${report.firstSeq})`,
+        );
       }
-      if (report.lastSeq < headSeq) {
+      if (maxSeq < headSeq) {
         cov.ok = false;
-        cov.problems.push(`last seq ${report.lastSeq} < head ${headSeq} — SHORT READ (clean EOF, no control record)`);
+        cov.problems.push(`highest delivered seq ${maxSeq} < head ${headSeq} — SHORT READ (clean EOF, no control record)`);
+      }
+      if (holes.length > 0) {
+        cov.ok = false;
+        cov.problems.push(
+          `${holes.length} PROVEN hole(s): seq range(s) ${holes.map((h) => `${h.from}..${h.to}`).join(", ")} were never delivered`,
+        );
+        // A hole is PROVEN and permanent whether it sits at the start of the page or in
+        // its interior: advancing the cursor past either burns those seqs forever and
+        // every later pass reports healthy. Only the late-start shape used to pin the
+        // cursor, so an interior-page gap advanced straight over itself.
+        provenHole = {
+          reason: holes[0].from === since + 1 ? "coverage-late-start" : "coverage-interior-gap",
+          missingFrom: holes[0].from,
+          missingTo: holes[0].to,
+          ranges: holes,
+        };
+        report.holes = holes;
       }
       if (cov.ok === null) cov.ok = true;
-      if (report.lastSeq > headSeq) {
+      if (maxSeq > headSeq) {
         // Not a fault: the feed advanced while we read. Recorded so a
         // cross-consumer sample taken at the same cursor stays comparable.
-        cov.advancedDuringRead = report.lastSeq - headSeq;
+        cov.advancedDuringRead = maxSeq - headSeq;
       }
     }
     if (cov.ok === false) markProblem(report, `coverage: ${cov.problems.join("; ")}`);
@@ -1048,33 +1179,63 @@ export async function runOnce(ctx) {
       // anything. The marker is what parity-harness's FEED_GAP_DECLARED blocker
       // consumes, so a later parity run over this window goes non-evaluable
       // instead of confidently green over a hole.
-      appender?.write(
+      const rangeText = provenHole.ranges.map((h) => `${h.from}..${h.to}`).join(", ");
+      writeMarker(
         gapMarker({
           reason: provenHole.reason,
           detail:
-            `coverage assertion PROVED a hole: seqs ${provenHole.missingFrom}..${provenHole.missingTo} ` +
-            `were never delivered (first seq ${report.firstSeq} != since+1). The cursor is NOT advanced past them.`,
+            `coverage assertion PROVED ${provenHole.ranges.length} hole(s): seq range(s) ${rangeText} ` +
+            `were never delivered. The cursor is NOT advanced past them.`,
           since,
           body: {
             missingFrom: provenHole.missingFrom,
             missingTo: provenHole.missingTo,
+            missingRanges: provenHole.ranges,
             firstSeq: report.firstSeq,
+            minSeq,
+            maxSeq,
             lastSeq: report.lastSeq,
             headSeq: report.headSeq,
             problems: cov.problems,
           },
           lastSeq: report.lastSeq,
+          ts: firstReceivedAtIso,
+          tsSource: firstReceivedAtIso === null ? "wall-clock" : "receivedAt",
+          emittedAt,
         }),
       );
-      report.markersWritten += 1;
       log.error?.(
         scrub(
-          `${TAG} COVERAGE HOLE at since=${since}: seqs ${provenHole.missingFrom}..${provenHole.missingTo} ` +
+          `${TAG} COVERAGE HOLE at since=${since}: seq range(s) ${rangeText} ` +
             `were never delivered. Cursor left UNCHANGED and a ${MARKER_FEED_GAP} marker written. ` +
             `Reconcile that range, then re-point deliberately with --since.`,
         ),
       );
     }
+  }
+
+  // ---- dedup-only pass (M11) ----
+  // A pass that received records and appended NONE of them, because every single one was
+  // already in the dedup ring, evaluated nothing NEW. Exiting 0 renders it identical to
+  // "ran and confirmed parity" — and if dedup ever over-fires (a poisoned ring, a
+  // deliveryId collision), every subsequent pass looks exactly this healthy, forever.
+  //
+  // Gated on an otherwise-HEALTHY pass on purpose: when the same pass also proved a
+  // coverage hole it DID evaluate something and reached a verdict, so demoting it to
+  // "could not evaluate" would bury the finding behind a weaker one. A cursor pinned at a
+  // hole re-reads the same page every pass, which is exactly that shape.
+  if (
+    report.received > 0 &&
+    report.appended === 0 &&
+    report.deduped === report.received &&
+    report.status === EXIT_HEALTHY
+  ) {
+    report.dedupOnly = true;
+    markUnevaluated(
+      report,
+      `dedup-only pass: all ${report.received} record(s) in this window were already in the ` +
+        `dedup ring and ZERO envelopes were appended — this pass confirmed nothing`,
+    );
   }
 
   // ---- per-source non-zero assertion (rule 5), opt-in ----
@@ -1117,6 +1278,25 @@ export async function runOnce(ctx) {
         `a declared-mappable type produced nothing`,
     );
   }
+  // H10: the loop above only fires when a declared-mappable type appended NOTHING, so a
+  // PARTIAL regression was invisible — some records of the type map fine, others are
+  // declined because the payload lost a shape the mapper requires, and the type's non-zero
+  // append count made it skip the check entirely. A STRUCTURAL decline is schema drift at
+  // any ratio; a routine action-level decline (classifyDecline) stays coverage data.
+  for (const [key, n] of Object.entries(report.structuralDeclines)) {
+    const cut = key.indexOf(":");
+    const s = key.slice(0, cut);
+    const t = key.slice(cut + 1);
+    if (classifyProviderType(s, t) !== "declared-mappable") continue;
+    const appended = report.appendedByType[key] ?? 0;
+    if (appended === 0) continue; // the zero-append loop above already owns this shape
+    markProblem(
+      report,
+      `${key}: ${n} of ${appended + n} record(s) declined by the mapper for a STRUCTURAL reason ` +
+        `(${report.structuralDeclineReasons[key]}) while ${appended} mapped fine — a PARTIAL ` +
+        `mapper/schema regression on a declared-mappable type`,
+    );
+  }
 
   if (sawControl) {
     // INVARIANT 7 — underflow means RECONCILE, not resume. Advancing the cursor
@@ -1125,10 +1305,10 @@ export async function runOnce(ctx) {
     // never mention it again. The cursor stays exactly where it was; the operator
     // must re-point it deliberately (--since) after reconciling.
     report.cursorAdvancedTo = null;
-    if (report.firstSeq !== null && report.firstSeq !== since + 1) {
+    if (minSeq !== null && minSeq !== since + 1) {
       report.unevaluated.push(
-        `replay also started late: first seq ${report.firstSeq} != since+1 (${since + 1}) — ` +
-          `seqs ${since + 1}..${report.firstSeq - 1} were never delivered`,
+        `replay also started late: lowest delivered seq ${minSeq} != since+1 (${since + 1}) — ` +
+          `seqs ${since + 1}..${minSeq - 1} were never delivered`,
       );
     }
     return report;
@@ -1151,10 +1331,24 @@ export async function runOnce(ctx) {
   return report;
 }
 
-function gapMarker({ reason, detail, since, body, lastSeq = null }) {
+/**
+ * gapMarker — a durable coverage declaration in the shadow log.
+ *
+ * `ts` is the ANCHOR, not the emission time. parity-harness places a marker in the
+ * --from/--to window by `ts`, and the envelopes on both sides carry the cloud's
+ * `receivedAt`. Stamping wall clock here put markers outside the very window they anchor
+ * (the consumer emits a hole marker after reading the page that proved it, and a poll
+ * loop can be minutes behind the traffic), so a declared hole silently fell out of the
+ * window and the parity run went green over it. The wall clock is kept, separately, as
+ * `emittedAt` — the two are never conflated, and `tsSource` says which one `ts` is.
+ */
+function gapMarker({ reason, detail, since, body, lastSeq = null, ts = null, tsSource = "wall-clock", emittedAt }) {
+  const wall = emittedAt ?? new Date().toISOString();
   return {
     marker: "feed-gap",
-    ts: new Date().toISOString(),
+    ts: ts ?? wall,
+    tsSource: ts === null ? "wall-clock" : tsSource,
+    emittedAt: wall,
     attributes: { "event.name": MARKER_FEED_GAP },
     reason,
     detail,
@@ -1186,6 +1380,7 @@ export function parseArgv(argv) {
     tsMode: "receivedAt",
     requireSources: [],
     maxConsecutiveFailures: undefined,
+    allowEmptyConfig: false,
     errors: [],
     help: false,
   };
@@ -1217,6 +1412,7 @@ export function parseArgv(argv) {
     if (a === "--once") out.once = true;
     else if (a === "--json") out.json = true;
     else if (a === "--self-test") out.selfTest = true;
+    else if (a === "--allow-empty-config") out.allowEmptyConfig = true;
     else if (a === "-h" || a === "--help") out.help = true;
     else if (VALUE_FLAGS.has(a)) {
       const v = takeValue(a, i);
@@ -1305,6 +1501,7 @@ export const USAGE = `${TAG} CTL-1534 — shadow consumer of the catalyst-cloud 
                                [--interval-ms N] [--ts-mode receivedAt|now]
                                [--require-source github,linear]
                                [--max-consecutive-failures N] [--max-passes N]
+                               [--allow-empty-config]
   bun cloud-event-consumer.mjs --self-test     # credential-free, offline negative control
 
 EXIT: 0 evaluated-healthy · 1 evaluated-problem · 2 COULD NOT EVALUATE.
@@ -1377,18 +1574,44 @@ export async function main(argv = process.argv.slice(2), deps = {}) {
   log.info(`${TAG} shadow log: ${appender.dir} (the live event log is NEVER written)`);
 
   const seen = new Set(state.seenDeliveryIds);
-  const teamsMap = new Map(
-    (deps.linearTeams ?? safeReadClusterProjects(log, scrub)).map((t) => [t.key, t.vcsRepo]),
-  );
-  const botUserIds = deps.botUserIds ?? safeReadBotIds(log, scrub);
-  // Both of these silently degrade the shadow envelope if they resolve empty
-  // (no vcs.repository.name on Linear events; no bot suppression -> shadow-only
-  // rows in the parity join). Say so out loud rather than let the harness
-  // discover it as an unexplained diff.
+
+  // M1: BOTH of these silently change what the shadow log CONTAINS — an empty roster
+  // strips vcs.repository.name from every Linear envelope (which the harness then reads
+  // as a benign local-enrichment presence diff), and an empty bot set stops suppressing
+  // bot-authored events (which the harness reads as unexplained shadow-only rows). They
+  // used to fail OPEN: a read that threw, or a config that resolved to nothing, logged a
+  // WARN and the run carried on to report healthy about a shadow log built from a
+  // degraded config. A config problem must be exit 2, and a deliberate degradation must
+  // be DECLARED (--allow-empty-config), not inferred from silence.
+  let teamEntries;
+  try {
+    teamEntries = deps.linearTeams ?? readClusterProjects();
+  } catch (err) {
+    log.error(`${TAG} team roster read FAILED (${scrub(err?.message ?? String(err))}) — nothing evaluated`);
+    return EXIT_UNEVALUATED;
+  }
+  const teamsMap = new Map(teamEntries.map((t) => [t.key, t.vcsRepo]));
+  let botUserIds;
+  try {
+    botUserIds = deps.botUserIds ?? readLinearBotUserIds();
+  } catch (err) {
+    log.error(`${TAG} bot-actor id read FAILED (${scrub(err?.message ?? String(err))}) — nothing evaluated`);
+    return EXIT_UNEVALUATED;
+  }
+  const degraded = [];
+  if (teamsMap.size === 0) degraded.push("team->repo roster is EMPTY (Linear envelopes will lack vcs.repository.name)");
+  if (botUserIds.size === 0) degraded.push("bot actor id set is EMPTY (bot-authored issue events will NOT be suppressed)");
+  if (degraded.length > 0 && !args.allowEmptyConfig) {
+    log.error(
+      `${TAG} refusing to run on a degraded config: ${degraded.join("; ")}. ` +
+        `A parity verdict computed from a shadow log built this way is not evaluable. ` +
+        `Fix the config, or pass --allow-empty-config to declare the degradation deliberately.`,
+    );
+    return EXIT_UNEVALUATED;
+  }
   log.info(
     `${TAG} config: ${teamsMap.size} team->repo entries, ${botUserIds.size} bot actor id(s)` +
-      (teamsMap.size === 0 ? " — WARN: no roster, Linear envelopes will lack vcs.repository.name" : "") +
-      (botUserIds.size === 0 ? " — WARN: no bot ids, bot-authored issue events will NOT be suppressed" : ""),
+      (degraded.length > 0 ? ` — DEGRADED, waived by --allow-empty-config: ${degraded.join("; ")}` : ""),
   );
 
   const baseUrl = args.baseUrl ?? env.CATALYST_CLOUD_EVENTS_BASE_URL ?? DEFAULT_BASE_URL;
@@ -1526,24 +1749,6 @@ function summarize(r) {
   if (r.problems.length) parts.push(`problems=[${r.problems.join(" | ")}]`);
   if (r.unevaluated.length) parts.push(`unevaluated=[${r.unevaluated.join(" | ")}]`);
   return parts.join(" ");
-}
-
-function safeReadClusterProjects(log, scrub) {
-  try {
-    return readClusterProjects();
-  } catch (err) {
-    log.warn?.(`${TAG} team roster unreadable (${scrub(err?.message ?? String(err))}) — vcs.repository.name will be absent on Linear envelopes`);
-    return [];
-  }
-}
-
-function safeReadBotIds(log, scrub) {
-  try {
-    return readLinearBotUserIds();
-  } catch (err) {
-    log.warn?.(`${TAG} bot-actor ids unreadable (${scrub(err?.message ?? String(err))}) — bot-authored issue events will NOT be suppressed`);
-    return new Set();
-  }
 }
 
 // ---------------------------------------------------------------------------
@@ -1845,6 +2050,110 @@ const SELF_TEST_CASES = [
       const goodAccepted = parseArgv(["--since", "42"]).errors.length === 0;
       return allRejected && goodAccepted ? EXIT_UNEVALUATED : EXIT_HEALTHY;
     },
+  },
+  {
+    // CTL-1534 (H): only the LATE-START shape used to pin the cursor, so a hole in the
+    // interior of a page advanced straight over itself and was never seen again.
+    name: "PROBLEM: an INTERIOR-page hole also pins the cursor and writes a durable marker",
+    expect: EXIT_PROBLEM,
+    assertReport: (r, app) => {
+      const gaps = app.records.filter((x) => x.attributes?.["event.name"] === MARKER_FEED_GAP);
+      return (
+        r.cursorAdvancedTo === null &&
+        gaps.length === 1 &&
+        gaps[0].reason === "coverage-interior-gap" &&
+        gaps[0].body?.missingFrom === 2 &&
+        gaps[0].body?.missingTo === 3
+      );
+    },
+    build: () => ({ since: 0, res: fakeResponse({ head: 4, lines: [ghEvent(1, "d1"), ghEvent(4, "d4")] }) }),
+  },
+  {
+    // CTL-1534 (M): the mirror image — a wire-order INVERSION delivers every seq in the
+    // range, so there is no hole to pin on. Deriving the hole from the first line claimed
+    // one and stranded the cursor on healthy data.
+    name: "PROBLEM: a wire-order INVERSION is an ordering fault, NOT a proven hole (cursor still advances)",
+    expect: EXIT_PROBLEM,
+    assertReport: (r, app) =>
+      r.cursorAdvancedTo !== null &&
+      r.coverage.ok === true &&
+      r.integrity.ok === false &&
+      app.records.every((x) => x.attributes?.["event.name"] !== MARKER_FEED_GAP),
+    build: () => ({ since: 0, res: fakeResponse({ head: 3, lines: [ghEvent(2, "d2"), ghEvent(1, "d1"), ghEvent(3, "d3")] }) }),
+  },
+  {
+    // CTL-1534 (M11): every record already in the dedup ring => nothing was appended and
+    // nothing was confirmed. Exiting 0 made it indistinguishable from a verified window.
+    name: "UNEVALUATED: a dedup-only pass appended NOTHING and confirmed nothing",
+    expect: EXIT_UNEVALUATED,
+    direct: async () => {
+      const report = await runOnce({
+        fetchImpl: async () => fakeResponse({ head: 2, lines: [ghEvent(1, "d1"), ghEvent(2, "d2")] }),
+        token: "",
+        since: 0,
+        appender: memAppender(),
+        seen: new Set(["d1", "d2"]),
+        log: { info() {}, warn() {}, error() {} },
+      });
+      return report.status === EXIT_UNEVALUATED && report.dedupOnly === true ? EXIT_UNEVALUATED : EXIT_HEALTHY;
+    },
+  },
+  {
+    // CTL-1534 (H10): the zero-appends check cannot see a PARTIAL regression — one
+    // Comment maps fine, the next has drifted its payload shape, and the type's non-zero
+    // append count skipped the check entirely.
+    name: "PROBLEM: a PARTIAL structural mapper regression on a declared-mappable type",
+    expect: EXIT_PROBLEM,
+    assertReport: (r) => r.appended === 1 && Object.keys(r.structuralDeclines).length === 1,
+    build: () => ({
+      since: 0,
+      res: fakeResponse({
+        head: 2,
+        lines: [
+          linearEvent(1, "c1"),
+          { ...linearEvent(2, "c2"), payload: { type: "Comment", action: "create" } },
+        ],
+      }),
+    }),
+  },
+  {
+    // CTL-1534 (M): the durable marker write sat OUTSIDE the try/catch, so a write failure
+    // escaped runOnce entirely instead of producing the exit-2 a failed evaluation owes.
+    name: "UNEVALUATED: a failed durable marker write is exit 2, not an escaped throw",
+    expect: EXIT_UNEVALUATED,
+    direct: async () => {
+      const report = await runOnce({
+        fetchImpl: async () => fakeResponse({ status: 409, body: { error: "cursor_underflow", resync: true } }),
+        token: "",
+        since: 5,
+        appender: { write: () => { throw new Error("ENOSPC"); }, dir: "<broken>" },
+        seen: new Set(),
+        log: { info() {}, warn() {}, error() {} },
+      });
+      return report.status === EXIT_UNEVALUATED &&
+        report.markersWritten === 0 &&
+        report.unevaluated.some((u) => u.includes("durable marker write FAILED"))
+        ? EXIT_UNEVALUATED
+        : EXIT_HEALTHY;
+    },
+  },
+  {
+    // CTL-1534 (H): the harness places a marker in the window by `ts`, and both sides'
+    // envelopes carry the cloud's receivedAt. A wall-clock `ts` fell outside the very
+    // window the marker anchors.
+    name: "PROBLEM: a gap marker anchors its ts on receivedAt, not the wall clock",
+    expect: EXIT_PROBLEM,
+    assertReport: (r, app) => {
+      const gaps = app.records.filter((x) => x.attributes?.["event.name"] === MARKER_FEED_GAP);
+      return (
+        gaps.length === 1 &&
+        gaps[0].tsSource === "receivedAt" &&
+        gaps[0].ts === "2026-07-26T20:00:00.000Z" &&
+        typeof gaps[0].emittedAt === "string" &&
+        gaps[0].emittedAt !== gaps[0].ts
+      );
+    },
+    build: () => ({ since: 0, res: fakeResponse({ head: 10, lines: [ghEvent(9, "d9"), ghEvent(10, "d10")] }) }),
   },
   {
     name: "UNEVALUATED: the shadow dir constant is NOT the live events dir name",

--- a/plugins/dev/scripts/execution-core/cloud-event-consumer.test.mjs
+++ b/plugins/dev/scripts/execution-core/cloud-event-consumer.test.mjs
@@ -1,0 +1,1396 @@
+// cloud-event-consumer.test.mjs — CTL-1534.
+//
+// Hermetic by construction: every test points the consumer at a throwaway tmp
+// CATALYST_DIR and injects an in-memory `fetchImpl`, a token override, and the
+// team/bot config. No network, no credential, no real ~/catalyst is ever touched
+// — so this suite is exactly the credential-free CI negative control the phase-3
+// harness rules demand (rule 8).
+//
+// Run: cd plugins/dev/scripts/execution-core && bun test cloud-event-consumer.test.mjs
+
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, readdirSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { basename, join, resolve } from "node:path";
+
+import {
+  DECLARED_MAPPABLE_TYPES,
+  DECLARED_UNMAPPABLE_TYPES,
+  EXIT_HEALTHY,
+  EXIT_PROBLEM,
+  EXIT_UNEVALUATED,
+  LIVE_DIR_NAME,
+  MARKER_FEED_GAP,
+  MARKER_UNMAPPABLE,
+  SEQ_ATTR,
+  SHADOW_DIR_NAME,
+  VALUE_FLAGS,
+  classifyLine,
+  classifyProviderType,
+  createShadowAppender,
+  ghEvent,
+  isPayloadOmitted,
+  linearEvent,
+  main,
+  mapCloudEvent,
+  ndjsonLines,
+  parseArgv,
+  parseEnvFile,
+  parseSinceArg,
+  readCloudToken,
+  readState,
+  resolveShadowDir,
+  runOnce,
+  runSelfTest,
+  shadowFilePath,
+  statePath,
+  strictSeq,
+  writeState,
+} from "./cloud-event-consumer.mjs";
+
+const TOKEN = "cat_tok_SUPERSECRET_do_not_log_0123456789";
+
+let dir;
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), "cec-"));
+});
+afterEach(() => {
+  rmSync(dir, { recursive: true, force: true });
+});
+
+// --------------------------------------------------------------------------
+// helpers
+// --------------------------------------------------------------------------
+
+function res({ status = 200, head = null, lines = [], body = null, stream = false }) {
+  const headers = new Map();
+  if (head !== null) headers.set("x-catalyst-event-head-seq", String(head));
+  const text =
+    body !== null ? JSON.stringify(body) : lines.map((l) => JSON.stringify(l)).join("\n") + (lines.length ? "\n" : "");
+  const out = {
+    status,
+    headers: { get: (k) => headers.get(String(k).toLowerCase()) ?? null },
+    text: async () => text,
+  };
+  if (stream) {
+    out.body = new ReadableStream({
+      start(controller) {
+        // deliberately chunk mid-line so the line buffer is exercised
+        const bytes = new TextEncoder().encode(text);
+        const mid = Math.floor(bytes.length / 2);
+        controller.enqueue(bytes.slice(0, mid));
+        controller.enqueue(bytes.slice(mid));
+        controller.close();
+      },
+    });
+  }
+  return out;
+}
+
+function memAppender() {
+  const records = [];
+  return { records, dir: "<memory>", write: (r) => records.push(r) };
+}
+
+function collectLogs() {
+  const lines = [];
+  const push = (m) => lines.push(String(m));
+  return { lines, info: push, warn: push, error: push };
+}
+
+async function runMain(argv, responses, extra = {}) {
+  const queue = Array.isArray(responses) ? [...responses] : [responses];
+  const requested = [];
+  const out = [];
+  const err = [];
+  const code = await main(argv, {
+    catalystDir: dir,
+    tokenOverride: TOKEN,
+    linearTeams: [],
+    botUserIds: new Set(),
+    fetchImpl: async (url) => {
+      requested.push(url);
+      const next = queue.shift();
+      if (next === undefined) throw new Error("no more mocked responses");
+      if (next instanceof Error) throw next;
+      return next;
+    },
+    stdout: (s) => out.push(s),
+    stderr: (s) => err.push(s),
+    sleep: async () => {},
+    ...extra,
+  });
+  return { code, requested, stdout: out.join(""), stderr: err.join("") };
+}
+
+function shadowLines() {
+  const sdir = resolve(dir, SHADOW_DIR_NAME);
+  if (!existsSync(sdir)) return [];
+  return readdirSync(sdir)
+    .filter((f) => f.endsWith(".jsonl"))
+    .flatMap((f) =>
+      readFileSync(join(sdir, f), "utf8")
+        .split("\n")
+        .filter((l) => l.length > 0)
+        .map((l) => JSON.parse(l)),
+    );
+}
+
+// --------------------------------------------------------------------------
+// rule 6 — never normalise the evidence
+// --------------------------------------------------------------------------
+
+describe("strict input parsing (never coerce, never default)", () => {
+  test("parseSinceArg accepts only canonical non-negative integers", () => {
+    expect(parseSinceArg("0")).toBe(0);
+    expect(parseSinceArg("42")).toBe(42);
+    for (const bad of ["banana", "", " 5", "5 ", "-1", "1e3", "1.0", "0x10", "007", "+3", "NaN", "Infinity"]) {
+      expect(parseSinceArg(bad)).toBeNull();
+    }
+    expect(parseSinceArg(5)).toBeNull(); // not a string -> rejected, not coerced
+  });
+
+  test("--since banana is REJECTED with exit 2 (never coerced to 0 and rescanned)", async () => {
+    const { code, stderr } = await runMain(["--once", "--since", "banana"], []);
+    expect(code).toBe(EXIT_UNEVALUATED);
+    expect(stderr).toContain("--since must be a non-negative integer");
+  });
+
+  test("strictSeq rejects strings, floats and negatives from the wire", () => {
+    expect(strictSeq(3)).toBe(3);
+    expect(strictSeq(0)).toBe(0);
+    expect(strictSeq("3")).toBeNull();
+    expect(strictSeq(3.5)).toBeNull();
+    expect(strictSeq(-1)).toBeNull();
+    expect(strictSeq(NaN)).toBeNull();
+    expect(strictSeq(undefined)).toBeNull();
+  });
+
+  test("a wire seq that is a string makes the run UNEVALUATED, not repaired", async () => {
+    const r = await runOnce({
+      fetchImpl: async () => res({ head: 1, lines: [{ ...ghEvent(1, "d1"), seq: "1" }] }),
+      token: "",
+      since: 0,
+      appender: memAppender(),
+      seen: new Set(),
+      log: collectLogs(),
+    });
+    expect(r.status).toBe(EXIT_UNEVALUATED);
+    expect(r.unevaluated.join(" ")).toContain("non-integer seq");
+  });
+});
+
+// --------------------------------------------------------------------------
+// the shadow path can never be the live path
+// --------------------------------------------------------------------------
+
+describe("shadow path is impossible-by-construction (never the live event log)", () => {
+  test("resolveShadowDir always lands on <root>/events-shadow", () => {
+    expect(resolveShadowDir("/tmp/cat")).toBe(resolve("/tmp/cat", SHADOW_DIR_NAME));
+    expect(SHADOW_DIR_NAME).not.toBe(LIVE_DIR_NAME);
+  });
+
+  test("refuses a root that would nest the shadow dir inside the live events dir", () => {
+    expect(() => resolveShadowDir("/tmp/cat/events")).toThrow(/live events dir/);
+  });
+
+  test("refuses an empty/non-string root rather than defaulting", () => {
+    expect(() => resolveShadowDir("")).toThrow();
+    expect(() => resolveShadowDir(undefined)).toThrow();
+  });
+
+  test("there is NO parameter that names a write directory — only a catalyst root", () => {
+    // The appender takes the root; the last segment is a module constant.
+    const app = createShadowAppender(dir);
+    expect(app.dir).toBe(resolve(dir, SHADOW_DIR_NAME));
+    expect(shadowFilePath(dir, new Date(Date.UTC(2026, 6, 5)))).toBe(
+      resolve(dir, SHADOW_DIR_NAME, "shadow-2026-07.jsonl"),
+    );
+  });
+
+  test("a full ingest run never creates <root>/events", async () => {
+    const { code } = await runMain(["--once", "--since", "0"], [
+      res({ head: 2, lines: [ghEvent(1, "d1"), linearEvent(2, "d2")] }),
+    ]);
+    expect(code).toBe(EXIT_HEALTHY);
+    expect(existsSync(resolve(dir, SHADOW_DIR_NAME))).toBe(true);
+    expect(existsSync(resolve(dir, LIVE_DIR_NAME))).toBe(false);
+  });
+});
+
+// --------------------------------------------------------------------------
+// cursor persistence + resume
+// --------------------------------------------------------------------------
+
+describe("cursor persistence and resume", () => {
+  test("persists the cursor atomically and resumes from it on the next run", async () => {
+    const first = await runMain(["--once", "--since", "0"], [
+      res({ head: 3, lines: [ghEvent(1, "d1"), ghEvent(2, "d2"), ghEvent(3, "d3")] }),
+    ]);
+    expect(first.code).toBe(EXIT_HEALTHY);
+    expect(first.requested[0]).toContain("since=0");
+
+    const persisted = JSON.parse(readFileSync(statePath(dir), "utf8"));
+    expect(persisted.version).toBe(1);
+    expect(persisted.cursor).toBe(3);
+    expect(persisted.seenDeliveryIds).toEqual(["d1", "d2", "d3"]);
+    // atomic write leaves no tmp behind
+    expect(readdirSync(dir).filter((f) => f.endsWith(".tmp"))).toEqual([]);
+
+    // second run: no --since, resumes from the persisted cursor
+    const second = await runMain(["--once"], [res({ head: 3, lines: [] })]);
+    expect(second.code).toBe(EXIT_HEALTHY);
+    expect(second.requested[0]).toContain("since=3");
+  });
+
+  test("--since OVERRIDES the persisted cursor", async () => {
+    writeState(dir, { cursor: 99, seenDeliveryIds: [] });
+    const { requested } = await runMain(["--once", "--since", "5"], [res({ head: 5, lines: [] })]);
+    expect(requested[0]).toContain("since=5");
+  });
+
+  test("refuses to invent a cursor when there is neither state nor --since (since=0 409s forever)", async () => {
+    const { code, stderr } = await runMain(["--once"], []);
+    expect(code).toBe(EXIT_UNEVALUATED);
+    expect(stderr).toContain("Refusing to default to 0");
+  });
+
+  test("a corrupt state file is exit 2, NOT a silent reset to a fresh cursor", async () => {
+    writeFileSync(statePath(dir), "{not json");
+    const { code, stderr } = await runMain(["--once"], []);
+    expect(code).toBe(EXIT_UNEVALUATED);
+    expect(stderr).toContain("cursor state file is unusable");
+    expect(readState(dir).ok).toBe(false);
+  });
+
+  test("the persisted dedup ring is bounded", () => {
+    const ids = Array.from({ length: 20 }, (_, i) => `d${i}`);
+    writeState(dir, { cursor: 1, seenDeliveryIds: ids }, { dedupMax: 5 });
+    const p = JSON.parse(readFileSync(statePath(dir), "utf8"));
+    expect(p.seenDeliveryIds).toEqual(["d15", "d16", "d17", "d18", "d19"]);
+  });
+});
+
+// --------------------------------------------------------------------------
+// dedup on deliveryId
+// --------------------------------------------------------------------------
+
+describe("dedup on deliveryId before appending", () => {
+  test("a re-delivered deliveryId is counted, not appended twice", async () => {
+    await runMain(["--once", "--since", "0"], [res({ head: 2, lines: [ghEvent(1, "d1"), ghEvent(2, "d2")] })]);
+    expect(shadowLines().length).toBe(2);
+
+    // crash-and-rewind: the same events arrive again from an earlier cursor
+    const second = await runMain(["--once", "--since", "0"], [
+      res({ head: 3, lines: [ghEvent(1, "d1"), ghEvent(2, "d2"), ghEvent(3, "d3")] }),
+    ]);
+    expect(second.code).toBe(EXIT_HEALTHY);
+    const all = shadowLines();
+    expect(all.length).toBe(3); // only d3 was new
+    const ids = all.map((e) => e.attributes["webhook.delivery.id"]);
+    expect(ids).toEqual(["d1", "d2", "d3"]);
+  });
+
+  test("dedup survives a process restart (it is persisted, not in-memory only)", async () => {
+    await runMain(["--once", "--since", "0"], [res({ head: 1, lines: [ghEvent(1, "d1")] })]);
+    const r = await runOnce({
+      fetchImpl: async () => res({ head: 1, lines: [ghEvent(1, "d1")] }),
+      token: "",
+      since: 0,
+      appender: memAppender(),
+      seen: new Set(readState(dir).state.seenDeliveryIds),
+      log: collectLogs(),
+    });
+    expect(r.deduped).toBe(1);
+    expect(r.appended).toBe(0);
+  });
+});
+
+// --------------------------------------------------------------------------
+// control records (rule 3)
+// --------------------------------------------------------------------------
+
+describe("control records invalidate the run", () => {
+  test("a line with `error` and NO `seq` is a control record", () => {
+    expect(classifyLine({ error: "cursor_underflow", resync: true }).kind).toBe("control");
+    expect(classifyLine({ seq: 1, source: "github" }).kind).toBe("event");
+    // a provider body carrying its own `error` key nests under payload — no collision
+    expect(classifyLine({ seq: 1, source: "github", payload: { error: "boom" } }).kind).toBe("event");
+    expect(classifyLine(null).kind).toBe("invalid");
+    expect(classifyLine([]).kind).toBe("invalid");
+    expect(classifyLine({ hello: 1 }).kind).toBe("invalid");
+  });
+
+  test("a contiguous prefix terminated by a control record is exit 2, NOT a clean pass", async () => {
+    const { code } = await runMain(["--once", "--since", "0"], [
+      res({
+        head: 9,
+        lines: [ghEvent(1, "d1"), ghEvent(2, "d2"), { error: "cursor_underflow", resync: true }],
+      }),
+    ]);
+    expect(code).toBe(EXIT_UNEVALUATED);
+
+    const lines = shadowLines();
+    // the prefix is real and was ingested; the gap is recorded, never silent
+    expect(lines.filter((l) => l.marker === undefined).length).toBe(2);
+    const gap = lines.find((l) => l.marker === "feed-gap");
+    expect(gap).toBeDefined();
+    expect(gap.attributes["event.name"]).toBe(MARKER_FEED_GAP);
+    expect(gap.reason).toBe("control-record");
+    expect(gap.body.error).toBe("cursor_underflow");
+  });
+
+  test("the cursor is NOT advanced past a server-declared incomplete scan", async () => {
+    writeState(dir, { cursor: 0, seenDeliveryIds: [] });
+    const { code } = await runMain(["--once"], [
+      res({ head: 9, lines: [ghEvent(1, "d1"), ghEvent(2, "d2"), { error: "cursor_underflow", resync: true }] }),
+    ]);
+    expect(code).toBe(EXIT_UNEVALUATED);
+    // Advancing to 2 here would let a later restart silently resume PAST the hole.
+    expect(JSON.parse(readFileSync(statePath(dir), "utf8")).cursor).toBe(0);
+  });
+
+  test("a control record after a LATE start names the range that was never delivered", async () => {
+    const r = await runOnce({
+      fetchImpl: async () => res({ head: 99, lines: [ghEvent(50, "d50"), { error: "cursor_underflow" }] }),
+      token: "",
+      since: 0,
+      appender: memAppender(),
+      seen: new Set(),
+      log: collectLogs(),
+    });
+    expect(r.status).toBe(EXIT_UNEVALUATED);
+    expect(r.cursorAdvancedTo).toBeNull();
+    expect(r.unevaluated.join(" ")).toContain("seqs 1..49 were never delivered");
+  });
+
+  test("the control-record run does NOT report a coverage verdict it did not earn", async () => {
+    const r = await runOnce({
+      fetchImpl: async () => res({ head: 9, lines: [ghEvent(1, "d1"), { error: "cursor_underflow" }] }),
+      token: "",
+      since: 0,
+      appender: memAppender(),
+      seen: new Set(),
+      log: collectLogs(),
+    });
+    expect(r.status).toBe(EXIT_UNEVALUATED);
+    expect(r.coverage.ok).toBeNull();
+    expect(r.integrity.ok).toBe(true); // the PREFIX is contiguous — which is the trap
+  });
+
+  test("a control record stops the poll loop instead of spinning", async () => {
+    const { code, requested } = await runMain(["--since", "0", "--max-passes", "3"], [
+      res({ head: 9, lines: [{ error: "cursor_underflow", resync: true }] }),
+    ]);
+    expect(code).toBe(EXIT_UNEVALUATED);
+    expect(requested.length).toBe(1);
+  });
+});
+
+// --------------------------------------------------------------------------
+// 409 handling — both kinds, both LOUD, neither auto-repaired
+// --------------------------------------------------------------------------
+
+describe("409 handling", () => {
+  test("cursor_underflow is a RECONCILE signal, exits 2, and leaves the cursor UNCHANGED", async () => {
+    writeState(dir, { cursor: 7, seenDeliveryIds: [] });
+    const { code, stderr } = await runMain(["--once"], [
+      res({ status: 409, body: { error: "cursor_underflow", resync: true } }),
+    ]);
+    expect(code).toBe(EXIT_UNEVALUATED);
+    expect(stderr).toContain("RECONCILE");
+    expect(stderr).toContain("NOT a resume");
+    expect(JSON.parse(readFileSync(statePath(dir), "utf8")).cursor).toBe(7);
+    const gap = shadowLines().find((l) => l.marker === "feed-gap");
+    expect(gap.reason).toBe("cursor_underflow");
+  });
+
+  test("cursor_ahead_of_head exits 2 and is NOT clamped to the reported head", async () => {
+    writeState(dir, { cursor: 999999999, seenDeliveryIds: [] });
+    const { code, stderr } = await runMain(["--once"], [
+      res({ status: 409, body: { error: "cursor_ahead_of_head", resync: true, head: 113 } }),
+    ]);
+    expect(code).toBe(EXIT_UNEVALUATED);
+    expect(stderr).toContain("crossed");
+    expect(stderr).toContain("SEPARATE sequences");
+    // NOT clamped to 113 — clamping would silently skip a real range
+    expect(JSON.parse(readFileSync(statePath(dir), "utf8")).cursor).toBe(999999999);
+  });
+
+  test("an unrecognised 409 body is still exit 2, never 0", async () => {
+    const r = await runOnce({
+      fetchImpl: async () => res({ status: 409, body: { error: "something_new" } }),
+      token: "",
+      since: 1,
+      appender: memAppender(),
+      seen: new Set(),
+      log: collectLogs(),
+    });
+    expect(r.status).toBe(EXIT_UNEVALUATED);
+  });
+
+  test("401/403 and other non-2xx are exit 2, never 0", async () => {
+    for (const status of [401, 403, 500, 502]) {
+      const r = await runOnce({
+        fetchImpl: async () => res({ status }),
+        token: "",
+        since: 0,
+        appender: memAppender(),
+        seen: new Set(),
+        log: collectLogs(),
+      });
+      expect(r.status).toBe(EXIT_UNEVALUATED);
+    }
+  });
+
+  test("a thrown fetch is exit 2 (a failed probe is never 'healthy')", async () => {
+    const r = await runOnce({
+      fetchImpl: async () => {
+        throw new Error("ECONNREFUSED");
+      },
+      token: "",
+      since: 0,
+      appender: memAppender(),
+      seen: new Set(),
+      log: collectLogs(),
+    });
+    expect(r.status).toBe(EXIT_UNEVALUATED);
+  });
+});
+
+// --------------------------------------------------------------------------
+// payloadOmitted -> attributable gap marker
+// --------------------------------------------------------------------------
+
+describe("payloadOmitted is a targeted gap, never a silent skip", () => {
+  test("isPayloadOmitted is a TRUTHY test, not key-presence", () => {
+    expect(isPayloadOmitted({})).toBe(false); // absent on normal events
+    expect(isPayloadOmitted({ payloadOmitted: false })).toBe(false);
+    expect(isPayloadOmitted({ payloadOmitted: true })).toBe(true);
+  });
+
+  test("a normal event (key ABSENT) maps and appends — the key-presence bug would break this", async () => {
+    const { code } = await runMain(["--once", "--since", "0"], [res({ head: 1, lines: [ghEvent(1, "d1")] })]);
+    expect(code).toBe(EXIT_HEALTHY);
+    expect(shadowLines().filter((l) => l.marker === undefined).length).toBe(1);
+  });
+
+  test("an elided payload writes a marker carrying deliveryId/source/eventType/identity", async () => {
+    const elided = {
+      accountId: "tenant-0",
+      seq: 1,
+      deliveryId: "big-1",
+      source: "linear",
+      eventType: "Comment",
+      action: "create",
+      receivedAt: "2026-07-26T20:00:00.000Z",
+      payload: null,
+      payloadOmitted: true,
+      payloadBytes: 120000,
+      identity: { id: "iss-1", identifier: "CTL-1534", issueId: "iss-1" },
+    };
+    const { code } = await runMain(["--once", "--since", "0"], [res({ head: 1, lines: [elided] })]);
+    expect(code).toBe(EXIT_PROBLEM); // evaluated, and a real gap was found
+
+    const marker = shadowLines().find((l) => l.marker === "unmappable-payload");
+    expect(marker).toBeDefined();
+    expect(marker.attributes["event.name"]).toBe(MARKER_UNMAPPABLE);
+    expect(marker.attributes["webhook.delivery.id"]).toBe("big-1");
+    expect(marker.deliveryId).toBe("big-1");
+    expect(marker.source).toBe("linear");
+    expect(marker.eventType).toBe("Comment");
+    expect(marker.payloadBytes).toBe(120000);
+    expect(marker.identity).toEqual({ id: "iss-1", identifier: "CTL-1534", issueId: "iss-1" });
+    // and it was NOT appended as an event
+    expect(shadowLines().filter((l) => l.marker === undefined).length).toBe(0);
+  });
+
+  test("an elided payload with NO identity still produces an attributable marker", async () => {
+    const r = await runOnce({
+      fetchImpl: async () =>
+        res({
+          head: 1,
+          lines: [
+            {
+              seq: 1, deliveryId: "big-2", source: "github", eventType: "push",
+              receivedAt: "2026-07-26T20:00:00.000Z", payload: null, payloadOmitted: true, payloadBytes: 99999,
+            },
+          ],
+        }),
+      token: "",
+      since: 0,
+      appender: memAppender(),
+      seen: new Set(),
+      log: collectLogs(),
+    });
+    expect(r.status).toBe(EXIT_PROBLEM);
+    expect(r.unmappable).toEqual([{ seq: 1, deliveryId: "big-2", source: "github", eventType: "push" }]);
+  });
+
+  test("payload:null WITHOUT payloadOmitted is malformed input -> exit 2, not a guess", () => {
+    const out = mapCloudEvent({
+      seq: 1, deliveryId: "x", source: "github", eventType: "push",
+      receivedAt: "2026-07-26T20:00:00.000Z", payload: null,
+    });
+    expect(out.outcome).toBe("invalid");
+  });
+});
+
+// --------------------------------------------------------------------------
+// COVERAGE != INTEGRITY (rule 2 / defect 6)
+// --------------------------------------------------------------------------
+
+describe("coverage and integrity are asserted SEPARATELY", () => {
+  const run = (since, head, lines) =>
+    runOnce({
+      fetchImpl: async () => res({ head, lines }),
+      token: "",
+      since,
+      appender: memAppender(),
+      seen: new Set(),
+      log: collectLogs(),
+    });
+
+  test("a full replay spanning since+1..head is healthy on both axes", async () => {
+    const r = await run(0, 3, [ghEvent(1, "d1"), ghEvent(2, "d2"), ghEvent(3, "d3")]);
+    expect(r.coverage.ok).toBe(true);
+    expect(r.integrity.ok).toBe(true);
+    expect(r.status).toBe(EXIT_HEALTHY);
+  });
+
+  test("SHORT READ: internally contiguous, no control record — integrity passes, coverage FAILS", async () => {
+    const r = await run(0, 9, [ghEvent(1, "d1"), ghEvent(2, "d2")]);
+    expect(r.integrity.ok).toBe(true); // the trap: every gap check passes
+    expect(r.coverage.ok).toBe(false);
+    expect(r.coverage.problems.join(" ")).toContain("SHORT READ");
+    expect(r.status).toBe(EXIT_PROBLEM);
+  });
+
+  test("STARTS LATE: first != since+1 fails coverage while integrity passes", async () => {
+    const r = await run(0, 3, [ghEvent(2, "d2"), ghEvent(3, "d3")]);
+    expect(r.integrity.ok).toBe(true);
+    expect(r.coverage.ok).toBe(false);
+    expect(r.coverage.problems.join(" ")).toContain("starts late");
+    expect(r.status).toBe(EXIT_PROBLEM);
+  });
+
+  test("EMPTY while head is ahead fails coverage", async () => {
+    const r = await run(3, 9, []);
+    expect(r.coverage.ok).toBe(false);
+    expect(r.status).toBe(EXIT_PROBLEM);
+  });
+
+  test("EMPTY is healthy only when the cursor is exactly at head", async () => {
+    const r = await run(7, 7, []);
+    expect(r.coverage.ok).toBe(true);
+    expect(r.status).toBe(EXIT_HEALTHY);
+  });
+
+  test("EMPTY with since > head is a crossed cursor, flagged not shrugged", async () => {
+    const r = await run(9, 3, []);
+    expect(r.coverage.ok).toBe(false);
+    expect(r.coverage.problems.join(" ")).toContain("crossed cursor");
+  });
+
+  test("a feed that advances DURING the read is recorded, not treated as a fault", async () => {
+    const r = await run(0, 2, [ghEvent(1, "d1"), ghEvent(2, "d2"), ghEvent(3, "d3")]);
+    expect(r.coverage.ok).toBe(true);
+    expect(r.coverage.advancedDuringRead).toBe(1);
+    expect(r.status).toBe(EXIT_HEALTHY);
+  });
+
+  test("a missing head header makes coverage UNASSERTABLE -> exit 2, never 0", async () => {
+    const r = await runOnce({
+      fetchImpl: async () => res({ head: null, lines: [ghEvent(1, "d1")] }),
+      token: "",
+      since: 0,
+      appender: memAppender(),
+      seen: new Set(),
+      log: collectLogs(),
+    });
+    expect(r.status).toBe(EXIT_UNEVALUATED);
+    expect(r.coverage.ok).toBeNull();
+  });
+
+  test("integrity is checked in WIRE ORDER — 1,3,2 is a break, not a clean pass", async () => {
+    const r = await run(0, 3, [ghEvent(1, "d1"), ghEvent(3, "d3"), ghEvent(2, "d2")]);
+    expect(r.integrity.ok).toBe(false);
+    expect(r.integrity.breaks).toEqual([{ prev: 1, next: 3 }, { prev: 3, next: 2 }]);
+    expect(r.status).toBe(EXIT_PROBLEM);
+  });
+
+  test("an internal gap 1,3 is caught", async () => {
+    const r = await run(0, 3, [ghEvent(1, "d1"), ghEvent(3, "d3")]);
+    expect(r.integrity.ok).toBe(false);
+    expect(r.integrity.breaks).toEqual([{ prev: 1, next: 3 }]);
+  });
+});
+
+// --------------------------------------------------------------------------
+// per-source / per-type counts (rules 5 + 9)
+// --------------------------------------------------------------------------
+
+describe("per-source and per-type COUNTS, never presence", () => {
+  test("counts are per source and per type", async () => {
+    const r = await runOnce({
+      fetchImpl: async () =>
+        res({
+          head: 4,
+          lines: [
+            ghEvent(1, "d1"),
+            ghEvent(2, "d2", { eventType: "push", payload: { repository: { full_name: "a/b" }, ref: "refs/heads/main", before: "x", after: "y", commits: [] } }),
+            linearEvent(3, "d3"),
+            linearEvent(4, "d4"),
+          ],
+        }),
+      token: "",
+      since: 0,
+      appender: memAppender(),
+      seen: new Set(),
+      log: collectLogs(),
+    });
+    expect(r.bySource).toEqual({ github: 2, linear: 2 });
+    expect(r.byType["github:pull_request"]).toBe(1);
+    expect(r.byType["github:push"]).toBe(1);
+    expect(r.byType["linear:Comment"]).toBe(2);
+  });
+
+  test("--require-source goes RED when a named source contributes zero", async () => {
+    const r = await runOnce({
+      fetchImpl: async () => res({ head: 1, lines: [ghEvent(1, "d1")] }),
+      token: "",
+      since: 0,
+      appender: memAppender(),
+      seen: new Set(),
+      log: collectLogs(),
+      requireSources: ["github", "linear"],
+    });
+    expect(r.status).toBe(EXIT_PROBLEM);
+    expect(r.problems.join(" ")).toContain('required source "linear" appended ZERO envelopes');
+  });
+
+  // H2/H9: the assertion used to read the WIRE census (`bySource`), which is bumped
+  // before the mapper runs — so one arriving record of a source satisfied "non-zero"
+  // even when it produced no envelope at all.
+  test("--require-source is NOT satisfied by a wire record that produced no envelope", async () => {
+    const attachment = {
+      seq: 1, deliveryId: "att-1", source: "linear", eventType: "Attachment",
+      action: "create", receivedAt: "2026-07-26T20:00:00.000Z",
+      payload: { type: "Attachment", action: "create", data: { id: "a1" } },
+    };
+    const app = memAppender();
+    const r = await runOnce({
+      fetchImpl: async () => res({ head: 2, lines: [ghEvent(1, "d0"), { ...attachment, seq: 2 }] }),
+      token: "",
+      since: 0,
+      appender: app,
+      seen: new Set(),
+      log: collectLogs(),
+      requireSources: ["github", "linear"],
+    });
+    expect(r.bySource.linear).toBe(1); // it DID arrive
+    expect(r.appendedBySource.linear).toBe(0); // and produced nothing
+    expect(app.records.filter((x) => x.attributes?.["event.name"]?.startsWith("linear.")).length).toBe(0);
+    expect(r.status).toBe(EXIT_PROBLEM);
+    expect(r.problems.join(" ")).toContain('required source "linear" appended ZERO envelopes');
+  });
+
+  test("appendedBySource counts only envelopes that reached the shadow log", async () => {
+    const r = await runOnce({
+      fetchImpl: async () => res({ head: 3, lines: [ghEvent(1, "d1"), linearEvent(2, "d2"), ghEvent(3, "d1")] }),
+      token: "",
+      since: 0,
+      appender: memAppender(),
+      seen: new Set(),
+      log: collectLogs(),
+    });
+    expect(r.bySource).toEqual({ github: 2, linear: 1 });
+    expect(r.appendedBySource).toEqual({ github: 1, linear: 1 }); // d1 deduped
+    expect(r.deduped).toBe(1);
+  });
+
+  test("--require-source with an unknown source is rejected (exit 2), not ignored", async () => {
+    const args = parseArgv(["--require-source", "gitlab"]);
+    expect(args.errors.length).toBeGreaterThan(0);
+    const { code } = await runMain(["--once", "--since", "0", "--require-source", "gitlab"], []);
+    expect(code).toBe(EXIT_UNEVALUATED);
+  });
+});
+
+// --------------------------------------------------------------------------
+// mapping — reuse, and the join key
+// --------------------------------------------------------------------------
+
+describe("mapping via the UNMODIFIED orch-monitor mappers", () => {
+  test("a github payload becomes the same v2 envelope shape the live path writes", () => {
+    const out = mapCloudEvent(ghEvent(1, "gh-delivery-1"));
+    expect(out.outcome).toBe("envelope");
+    const e = out.envelope;
+    expect(e.attributes["event.name"]).toBe("github.pr.opened");
+    expect(e.attributes["vcs.repository.name"]).toBe("coalesce-labs/catalyst");
+    expect(e.attributes["vcs.pr.number"]).toBe(2751);
+    expect(e.attributes["webhook.delivery.id"]).toBe("gh-delivery-1");
+    expect(e.resource["service.namespace"]).toBe("catalyst");
+    expect(typeof e.id).toBe("string");
+  });
+
+  test("a linear payload becomes a linear.* envelope with the join key stamped", () => {
+    const out = mapCloudEvent(linearEvent(2, "lin-delivery-1"));
+    expect(out.outcome).toBe("envelope");
+    expect(out.envelope.attributes["event.name"]).toBe("linear.comment.created");
+    expect(out.envelope.attributes["linear.issue.identifier"]).toBe("CTL-1534");
+    expect(out.envelope.attributes["webhook.delivery.id"]).toBe("lin-delivery-1");
+  });
+
+  test("teamsMap flows into the Linear envelope exactly as the live handler does", () => {
+    const out = mapCloudEvent(linearEvent(2, "lin-2"), { teamsMap: new Map([["CTL", "coalesce-labs/catalyst"]]) });
+    expect(out.envelope.attributes["vcs.repository.name"]).toBe("coalesce-labs/catalyst");
+  });
+
+  test("tsMode=receivedAt stamps the cloud receipt time; tsMode=now stamps map time", () => {
+    const a = mapCloudEvent(ghEvent(1, "d1"), { tsMode: "receivedAt" });
+    expect(a.envelope.ts).toBe("2026-07-26T20:00:00.000Z");
+    const b = mapCloudEvent(ghEvent(1, "d1"), { tsMode: "now", now: () => new Date("2030-01-01T00:00:00.000Z") });
+    expect(b.envelope.ts).toBe("2030-01-01T00:00:00.000Z");
+  });
+
+  test("an unknown source / missing deliveryId is invalid input, not a best-effort map", () => {
+    expect(mapCloudEvent({ source: "gitlab", eventType: "x", deliveryId: "d", payload: {} }).outcome).toBe("invalid");
+    expect(mapCloudEvent({ source: "github", eventType: "push", payload: {}, receivedAt: "2026-01-01T00:00:00Z" }).outcome).toBe("invalid");
+  });
+
+  // H10: "the mapper ignores it" is benign ONLY for a type we DECLARED has no
+  // mapper on either path. Blanket-blessing every ignore made a total mapper
+  // failure indistinguishable from a healthy run.
+  test("a DECLARED-unmappable provider type is expected-zero coverage data, not a defect", async () => {
+    const r = await runOnce({
+      fetchImpl: async () =>
+        res({ head: 1, lines: [ghEvent(1, "d1", { eventType: "workflow_job", payload: { repository: { full_name: "a/b" } } })] }),
+      token: "",
+      since: 0,
+      appender: memAppender(),
+      seen: new Set(),
+      log: collectLogs(),
+    });
+    expect(r.appended).toBe(0);
+    expect(r.ignoredByType["github:workflow_job"]).toBe(1);
+    expect(classifyProviderType("github", "workflow_job")).toBe("declared-unmappable");
+    expect(r.status).toBe(EXIT_HEALTHY);
+  });
+
+  test("an UNDECLARED provider type is a PROBLEM, not silent coverage data", async () => {
+    const r = await runOnce({
+      fetchImpl: async () =>
+        res({ head: 1, lines: [ghEvent(1, "d1", { eventType: "ping", payload: { repository: { full_name: "a/b" } } })] }),
+      token: "",
+      since: 0,
+      appender: memAppender(),
+      seen: new Set(),
+      log: collectLogs(),
+    });
+    expect(r.appended).toBe(0);
+    expect(r.undeclaredTypes["github:ping"]).toBe(1);
+    expect(r.status).toBe(EXIT_PROBLEM);
+    expect(r.problems.join(" ")).toContain("undeclared provider type github:ping");
+  });
+
+  test("a DECLARED-mappable type that appends NOTHING is a problem (schema drift), not coverage data", async () => {
+    // The recorded Linear drift: the Comment body nests under `comment`, not `data`.
+    const drifted = (seq, id) => ({
+      seq, deliveryId: id, source: "linear", eventType: "Comment", action: "create",
+      receivedAt: "2026-07-26T20:00:00.000Z",
+      payload: { type: "Comment", action: "create", comment: { id: "c1", body: "x" } },
+    });
+    const r = await runOnce({
+      fetchImpl: async () => res({ head: 2, lines: [drifted(1, "c1"), drifted(2, "c2")] }),
+      token: "",
+      since: 0,
+      appender: memAppender(),
+      seen: new Set(),
+      log: collectLogs(),
+      requireSources: [],
+    });
+    expect(r.received).toBe(2);
+    expect(r.appended).toBe(0);
+    expect(r.status).toBe(EXIT_PROBLEM);
+    expect(r.problems.join(" ")).toContain("linear:Comment");
+  });
+
+  test("a mixed window where ONE source silently stops mapping is still a problem", async () => {
+    // github keeps flowing (so `received`, `appended` and every total look alive)
+    // while 100% of Linear Comments are declined.
+    const drifted = {
+      seq: 2, deliveryId: "c1", source: "linear", eventType: "Comment", action: "create",
+      receivedAt: "2026-07-26T20:00:00.000Z",
+      payload: { type: "Comment", action: "create", comment: { id: "c1" } },
+    };
+    const r = await runOnce({
+      fetchImpl: async () => res({ head: 3, lines: [ghEvent(1, "g1"), drifted, ghEvent(3, "g3")] }),
+      token: "",
+      since: 0,
+      appender: memAppender(),
+      seen: new Set(),
+      log: collectLogs(),
+    });
+    expect(r.appended).toBe(2); // both github events landed
+    expect(r.status).toBe(EXIT_PROBLEM);
+  });
+
+  test("bot-authored Linear issue events are suppressed, matching the live handler", async () => {
+    const botIssue = {
+      seq: 1, deliveryId: "bot-1", source: "linear", eventType: "Issue", action: "update",
+      receivedAt: "2026-07-26T20:00:00.000Z",
+      payload: {
+        type: "Issue", action: "update",
+        actor: { id: "bot-uuid", name: "Catalyst" },
+        data: { id: "i1", identifier: "CTL-1", team: { key: "CTL" } },
+        updatedFrom: { stateId: "s0" },
+      },
+    };
+    const r = await runOnce({
+      fetchImpl: async () => res({ head: 1, lines: [botIssue] }),
+      token: "",
+      since: 0,
+      appender: memAppender(),
+      seen: new Set(),
+      botUserIds: new Set(["bot-uuid"]),
+      log: collectLogs(),
+    });
+    expect(r.botSuppressed).toBe(1);
+    expect(r.appended).toBe(0);
+  });
+
+  test("check_suite with no inline PR numbers is flagged as a KNOWN pr-cache coverage delta", async () => {
+    const cs = {
+      seq: 1, deliveryId: "cs-1", source: "github", eventType: "check_suite", action: "completed",
+      receivedAt: "2026-07-26T20:00:00.000Z",
+      payload: {
+        repository: { full_name: "a/b" },
+        check_suite: { status: "completed", conclusion: "success", head_branch: "x", head_sha: "sha1", pull_requests: [] },
+      },
+    };
+    const r = await runOnce({
+      fetchImpl: async () => res({ head: 1, lines: [cs] }),
+      token: "",
+      since: 0,
+      appender: memAppender(),
+      seen: new Set(),
+      log: collectLogs(),
+    });
+    expect(r.prCacheDependent).toBe(1);
+  });
+});
+
+// --------------------------------------------------------------------------
+// transport plumbing
+// --------------------------------------------------------------------------
+
+describe("NDJSON transport", () => {
+  test("the streaming body path and the text() fallback path agree", async () => {
+    const lines = [ghEvent(1, "d1"), linearEvent(2, "d2"), ghEvent(3, "d3")];
+    const viaText = [];
+    for await (const l of ndjsonLines(res({ head: 3, lines }))) viaText.push(l);
+    const viaStream = [];
+    for await (const l of ndjsonLines(res({ head: 3, lines, stream: true }))) viaStream.push(l);
+    expect(viaStream).toEqual(viaText);
+    expect(viaStream.length).toBe(3);
+  });
+
+  test("a run over the streaming body produces the same verdict", async () => {
+    const r = await runOnce({
+      fetchImpl: async () => res({ head: 2, lines: [ghEvent(1, "d1"), ghEvent(2, "d2")], stream: true }),
+      token: "",
+      since: 0,
+      appender: memAppender(),
+      seen: new Set(),
+      log: collectLogs(),
+    });
+    expect(r.status).toBe(EXIT_HEALTHY);
+    expect(r.appended).toBe(2);
+  });
+
+  test("an unparseable NDJSON line is exit 2, not a skipped line", async () => {
+    const bad = {
+      status: 200,
+      headers: { get: () => "1" },
+      text: async () => "{not json}\n",
+    };
+    const r = await runOnce({
+      fetchImpl: async () => bad,
+      token: "",
+      since: 0,
+      appender: memAppender(),
+      seen: new Set(),
+      log: collectLogs(),
+    });
+    expect(r.status).toBe(EXIT_UNEVALUATED);
+  });
+
+  test("the request carries the bearer and the requested cursor", async () => {
+    let seenInit = null;
+    let seenUrl = null;
+    await runOnce({
+      fetchImpl: async (url, init) => {
+        seenUrl = url;
+        seenInit = init;
+        return res({ head: 4, lines: [] });
+      },
+      baseUrl: "https://example.test/",
+      token: TOKEN,
+      since: 4,
+      appender: memAppender(),
+      seen: new Set(),
+      log: collectLogs(),
+    });
+    expect(seenUrl).toBe("https://example.test/events/stream?since=4");
+    expect(seenInit.headers.authorization).toBe(`Bearer ${TOKEN}`);
+  });
+});
+
+// --------------------------------------------------------------------------
+// token handling
+// --------------------------------------------------------------------------
+
+describe("token handling", () => {
+  test("parses `export KEY=value` and quoted forms from cloud-sync.env", () => {
+    expect(parseEnvFile("export CATALYST_CLOUD_TOKEN=abc123\n").CATALYST_CLOUD_TOKEN).toBe("abc123");
+    expect(parseEnvFile('CATALYST_CLOUD_TOKEN="q u o"\n').CATALYST_CLOUD_TOKEN).toBe("q u o");
+    expect(parseEnvFile("# comment\n\nexport A='x'\n").A).toBe("x");
+  });
+
+  test("env var wins over the file; absent is reported, never guessed", () => {
+    const p = join(dir, "cloud-sync.env");
+    writeFileSync(p, "export CATALYST_CLOUD_TOKEN=from-file\n");
+    expect(readCloudToken({ env: {}, envFilePath: p }).token).toBe("from-file");
+    expect(readCloudToken({ env: { CATALYST_CLOUD_TOKEN: "from-env" }, envFilePath: p }).source).toBe("env");
+    expect(readCloudToken({ env: {}, envFilePath: join(dir, "nope.env") }).token).toBe("");
+  });
+
+  test("a missing token is exit 2 — never a 'healthy' no-op run", async () => {
+    const code = await main(["--once", "--since", "0"], {
+      catalystDir: dir,
+      env: { CATALYST_CONFIG_DIR: dir },
+      linearTeams: [],
+      botUserIds: new Set(),
+      fetchImpl: async () => {
+        throw new Error("must not be called");
+      },
+      stdout: () => {},
+      stderr: () => {},
+    });
+    expect(code).toBe(EXIT_UNEVALUATED);
+  });
+
+  test("the token NEVER appears in any log line or in stdout", async () => {
+    const { stdout, stderr } = await runMain(["--once", "--since", "0"], [
+      res({ head: 1, lines: [ghEvent(1, "d1")] }),
+    ]);
+    expect(stdout).not.toContain(TOKEN);
+    expect(stderr).not.toContain(TOKEN);
+    expect(stderr).toContain("value never logged");
+  });
+
+  test("a token echoed back inside an error message is scrubbed", async () => {
+    const { stderr } = await runMain(["--once", "--since", "0"], [new Error(`connect failed for Bearer ${TOKEN}`)]);
+    expect(stderr).not.toContain(TOKEN);
+    expect(stderr).toContain("<redacted>");
+  });
+});
+
+// --------------------------------------------------------------------------
+// exit contract at the process level
+// --------------------------------------------------------------------------
+
+describe("three-way exit contract end to end", () => {
+  test("healthy run exits 0", async () => {
+    const { code } = await runMain(["--once", "--since", "0"], [res({ head: 1, lines: [ghEvent(1, "d1")] })]);
+    expect(code).toBe(EXIT_HEALTHY);
+  });
+
+  test("evaluated-problem run exits 1", async () => {
+    const { code } = await runMain(["--once", "--since", "0"], [res({ head: 9, lines: [ghEvent(1, "d1")] })]);
+    expect(code).toBe(EXIT_PROBLEM);
+  });
+
+  test("could-not-evaluate run exits 2", async () => {
+    const { code } = await runMain(["--once", "--since", "0"], [res({ status: 500 })]);
+    expect(code).toBe(EXIT_UNEVALUATED);
+  });
+
+  test("a loop that saw BOTH a problem and an unevaluated pass exits 2 (2 dominates)", async () => {
+    const { code, stdout } = await runMain(
+      ["--since", "0", "--json", "--max-consecutive-failures", "1", "--max-passes", "4"],
+      [res({ head: 9, lines: [ghEvent(1, "d1")] }), res({ status: 500 })],
+    );
+    expect(code).toBe(EXIT_UNEVALUATED);
+    const parsed = JSON.parse(stdout);
+    expect(parsed.exit).toBe(EXIT_UNEVALUATED);
+    // both verdicts are printed — neither hides the other
+    expect(parsed.reports.map((r) => r.status)).toEqual([EXIT_PROBLEM, EXIT_UNEVALUATED]);
+  });
+
+  test("the poll loop advances the cursor between passes", async () => {
+    const { code, requested } = await runMain(
+      ["--since", "0", "--max-consecutive-failures", "1", "--max-passes", "4"],
+      [res({ head: 2, lines: [ghEvent(1, "d1"), ghEvent(2, "d2")] }), res({ status: 500 })],
+    );
+    expect(code).toBe(EXIT_UNEVALUATED);
+    expect(requested[0]).toContain("since=0");
+    expect(requested[1]).toContain("since=2");
+  });
+
+  test("--json emits a machine-readable report", async () => {
+    const { stdout } = await runMain(["--once", "--json", "--since", "0"], [
+      res({ head: 2, lines: [ghEvent(1, "d1"), linearEvent(2, "d2")] }),
+    ]);
+    const parsed = JSON.parse(stdout);
+    expect(parsed.exit).toBe(EXIT_HEALTHY);
+    expect(parsed.reports[0].bySource).toEqual({ github: 1, linear: 1 });
+    expect(parsed.reports[0].coverage.ok).toBe(true);
+    expect(parsed.reports[0].integrity.ok).toBe(true);
+  });
+
+  test("an unknown flag is exit 2, not silently ignored", async () => {
+    const { code } = await runMain(["--once", "--wat"], []);
+    expect(code).toBe(EXIT_UNEVALUATED);
+  });
+});
+
+// --------------------------------------------------------------------------
+// C1/C3/H15/M4 — the producer/harness ordering contract
+// --------------------------------------------------------------------------
+
+describe("the cloud seq is stamped on every shadow envelope (the harness's only ordering input)", () => {
+  test("mapCloudEvent stamps the wire seq under SEQ_ATTR", () => {
+    const gh = mapCloudEvent(ghEvent(41, "d1"));
+    expect(gh.envelope.attributes[SEQ_ATTR]).toBe(41);
+    const li = mapCloudEvent(linearEvent(42, "d2"));
+    expect(li.envelope.attributes[SEQ_ATTR]).toBe(42);
+  });
+
+  test("SEQ_ATTR is the string parity-harness defaults --seq-attr to (a rename breaks this test, not the checks)", async () => {
+    const { parseArgs } = await import("./parity-harness.mjs");
+    expect(SEQ_ATTR).toBe(parseArgs([]).opts.seqAttr);
+  });
+
+  test("every envelope written to the shadow log carries the seq, in wire order", async () => {
+    await runMain(["--once", "--since", "0"], [
+      res({ head: 3, lines: [ghEvent(1, "d1"), linearEvent(2, "d2"), ghEvent(3, "d3")] }),
+    ]);
+    const written = shadowLines();
+    expect(written.length).toBe(3);
+    expect(written.map((w) => w.attributes[SEQ_ATTR])).toEqual([1, 2, 3]);
+  });
+
+  test("a record with no usable seq is INVALID input, never an envelope with the attribute missing", () => {
+    const bad = mapCloudEvent({ ...ghEvent(1, "d1"), seq: "1" });
+    expect(bad.outcome).toBe("invalid");
+    expect(bad.reason).toContain("ordering key");
+    expect(mapCloudEvent({ ...ghEvent(1, "d1"), seq: undefined }).outcome).toBe("invalid");
+  });
+
+  test("consumer output feeds the harness's seq subsystem end to end (the two halves are wired)", async () => {
+    const { evaluate, ingestText, parseArgs } = await import("./parity-harness.mjs");
+    await runMain(["--once", "--since", "0"], [
+      res({
+        head: 3,
+        lines: [
+          ghEvent(1, "d1", { receivedAt: "2026-07-26T22:11:00.000Z" }),
+          linearEvent(2, "d2", { receivedAt: "2026-07-26T22:12:00.000Z" }),
+          ghEvent(3, "d3", { receivedAt: "2026-07-26T22:13:00.000Z" }),
+        ],
+      }),
+    ]);
+    const shadowText = shadowLines().map((l) => JSON.stringify(l)).join("\n");
+    // The live side is the same mapped envelopes minus the transport annotation.
+    const liveText = shadowLines()
+      .map((l) => {
+        const copy = JSON.parse(JSON.stringify(l));
+        delete copy.attributes[SEQ_ATTR];
+        return JSON.stringify(copy);
+      })
+      .join("\n");
+    const o = {
+      ...parseArgs([]).opts,
+      fromMs: Date.parse("2026-07-26T22:00:00Z"), fromIso: "2026-07-26T22:00:00Z",
+      toMs: Date.parse("2026-07-26T23:00:00Z"), toIso: "2026-07-26T23:00:00Z",
+      seqLedgerComplete: true, expectFirstSeq: 1, expectHeadSeq: 3,
+    };
+    const r = evaluate({
+      live: ingestText("live", liveText, o),
+      shadow: ingestText("shadow", shadowText, o),
+      opts: o,
+      generatedAt: "1970-01-01T00:00:00.000Z",
+    });
+    // The seq subsystem must have ACTUALLY RUN against real producer output.
+    expect(r.blockers.map((b) => b.id)).not.toContain("SEQ_ATTR_ABSENT");
+    expect(r.checks.find((c) => c.id === "SEQ_WIRE_ORDER").status).toBe("pass");
+    expect(r.checks.find((c) => c.id === "SEQ_CONTIGUITY").status).toBe("pass");
+    expect(r.checks.find((c) => c.id === "SEQ_COVERAGE").status).toBe("pass");
+    expect(r.exitCode).toBe(EXIT_HEALTHY);
+  });
+
+  test("the declared provider-type census matches the harness's structural-blind-spot list", async () => {
+    const { UNMAPPABLE_PROVIDER_TYPES } = await import("./parity-harness.mjs");
+    for (const u of UNMAPPABLE_PROVIDER_TYPES) {
+      expect(DECLARED_UNMAPPABLE_TYPES[u.source].has(u.type)).toBe(true);
+      expect(DECLARED_MAPPABLE_TYPES[u.source].has(u.type)).toBe(false);
+    }
+  });
+});
+
+// --------------------------------------------------------------------------
+// C5 — dedup ordering: mark seen only AFTER the write succeeded
+// --------------------------------------------------------------------------
+
+describe("a failed append never poisons the dedup ring", () => {
+  test("an append that throws leaves the delivery id UNSEEN", async () => {
+    const seen = new Set();
+    const r = await runOnce({
+      fetchImpl: async () => res({ head: 3, lines: [ghEvent(1, "d1"), ghEvent(2, "d2"), ghEvent(3, "d3")] }),
+      token: "",
+      since: 0,
+      appender: { dir: "<broken>", write: () => { throw new Error("EACCES: shadow dir is not writable"); } },
+      seen,
+      log: collectLogs(),
+    });
+    expect(r.status).toBe(EXIT_UNEVALUATED);
+    expect([...seen]).toEqual([]);
+    expect(r.cursorAdvancedTo).toBe(null);
+  });
+
+  test("the retry after a write failure re-appends the delivery instead of silently deduping it", async () => {
+    // Pass 1: the shadow directory is a regular FILE, so every append throws.
+    writeFileSync(resolve(dir, SHADOW_DIR_NAME), "not a directory");
+    const first = await runMain(["--once", "--since", "0"], [
+      res({ head: 3, lines: [ghEvent(1, "d1"), ghEvent(2, "d2"), ghEvent(3, "d3")] }),
+    ]);
+    expect(first.code).toBe(EXIT_UNEVALUATED);
+    const persisted = JSON.parse(readFileSync(statePath(dir), "utf8"));
+    expect(persisted.seenDeliveryIds).toEqual([]);
+    expect(persisted.cursor).toBe(0);
+
+    // The condition clears; the same range is refetched.
+    rmSync(resolve(dir, SHADOW_DIR_NAME), { force: true });
+    const second = await runMain(["--once", "--since", "0"], [
+      res({ head: 3, lines: [ghEvent(1, "d1"), ghEvent(2, "d2"), ghEvent(3, "d3")] }),
+    ]);
+    expect(second.code).toBe(EXIT_HEALTHY);
+    expect(shadowLines().map((l) => l.attributes["webhook.delivery.id"])).toEqual(["d1", "d2", "d3"]);
+  });
+});
+
+// --------------------------------------------------------------------------
+// C6/H4/H13 — a PROVEN coverage hole: durable marker, no cursor advance
+// --------------------------------------------------------------------------
+
+describe("a proven coverage hole leaves durable evidence and does not burn the cursor", () => {
+  test("a late-started replay writes a feed-gap marker naming the undelivered range", async () => {
+    const app = memAppender();
+    const r = await runOnce({
+      fetchImpl: async () => res({ head: 605, lines: [ghEvent(601, "d601"), ghEvent(602, "d602")] }),
+      token: "",
+      since: 500,
+      appender: app,
+      seen: new Set(),
+      log: collectLogs(),
+    });
+    expect(r.status).toBe(EXIT_PROBLEM);
+    expect(r.coverage.ok).toBe(false);
+    const gaps = app.records.filter((x) => x.attributes?.["event.name"] === MARKER_FEED_GAP);
+    expect(gaps.length).toBe(1);
+    expect(gaps[0].reason).toBe("coverage-late-start");
+    expect(gaps[0].body.missingFrom).toBe(501);
+    expect(gaps[0].body.missingTo).toBe(600);
+  });
+
+  test("the cursor is NOT advanced past a proven hole, in-process or across a restart", async () => {
+    const first = await runMain(["--once", "--since", "0"], [
+      res({ head: 10, lines: [ghEvent(9, "d9"), ghEvent(10, "d10")] }),
+    ]);
+    expect(first.code).toBe(EXIT_PROBLEM);
+    expect(JSON.parse(readFileSync(statePath(dir), "utf8")).cursor).toBe(0);
+
+    // A supervised restart must NOT resume beyond the hole.
+    const second = await runMain(["--once"], [res({ head: 10, lines: [ghEvent(9, "d9"), ghEvent(10, "d10")] })]);
+    expect(second.requested[0]).toContain("since=0");
+    expect(second.code).toBe(EXIT_PROBLEM);
+  });
+
+  test("the durable marker is what makes a later parity run non-evaluable instead of green", async () => {
+    const { evaluate, ingestText, parseArgs } = await import("./parity-harness.mjs");
+    await runMain(["--once", "--since", "0"], [
+      res({ head: 10, lines: [ghEvent(9, "d9", { receivedAt: "2026-07-26T22:11:00.000Z" })] }),
+    ]);
+    const written = shadowLines();
+    const shadowText = written.map((l) => JSON.stringify(l)).join("\n");
+    // The gap marker is stamped with the wall clock, so derive the window from the
+    // records themselves (edge margin 0 — this case is about the marker, not edges).
+    const stamps = written.map((l) => Date.parse(l.ts)).sort((a, b) => a - b);
+    const o = {
+      ...parseArgs([]).opts,
+      edgeMarginMs: 0,
+      fromMs: stamps[0], fromIso: new Date(stamps[0]).toISOString(),
+      toMs: stamps[stamps.length - 1], toIso: new Date(stamps[stamps.length - 1]).toISOString(),
+    };
+    const r = evaluate({
+      live: ingestText("live", shadowText, o),
+      shadow: ingestText("shadow", shadowText, o),
+      opts: o,
+      generatedAt: "1970-01-01T00:00:00.000Z",
+    });
+    expect(r.blockers.some((b) => b.id === "FEED_GAP_DECLARED")).toBe(true);
+    expect(r.exitCode).toBe(2);
+  });
+
+  test("a SHORT READ still advances (nothing was skipped) but stays a loud problem with no false gap marker", async () => {
+    const app = memAppender();
+    const r = await runOnce({
+      fetchImpl: async () => res({ head: 9, lines: [ghEvent(1, "d1"), ghEvent(2, "d2")] }),
+      token: "",
+      since: 0,
+      appender: app,
+      seen: new Set(),
+      log: collectLogs(),
+    });
+    expect(r.status).toBe(EXIT_PROBLEM);
+    expect(r.cursorAdvancedTo).toBe(2);
+    expect(app.records.filter((x) => x.attributes?.["event.name"] === MARKER_FEED_GAP).length).toBe(0);
+  });
+
+  test("a non-healthy pass that makes NO progress is bounded, not spun on forever", async () => {
+    const stuck = () => res({ head: 10, lines: [ghEvent(9, "d9"), ghEvent(10, "d10")] });
+    const { code, requested } = await runMain(
+      ["--since", "0", "--max-consecutive-failures", "3"],
+      [stuck(), stuck(), stuck(), stuck(), stuck()],
+    );
+    expect(code).toBe(EXIT_PROBLEM);
+    expect(requested.length).toBe(3);
+    expect(requested.every((u) => u.includes("since=0"))).toBe(true);
+  });
+});
+
+// --------------------------------------------------------------------------
+// H3/H5/H6/M9 — a flag whose value was eaten must never fall through
+// --------------------------------------------------------------------------
+
+describe("value-taking flags reject a missing/empty/flag-shaped value", () => {
+  test.each([...VALUE_FLAGS])("%s in final position is an error, not a silent drop", (flag) => {
+    const parsed = parseArgv(["--once", flag]);
+    expect(parsed.errors.length).toBeGreaterThan(0);
+  });
+
+  test.each(["--since=", "--base-url=", "--require-source=", "--ts-mode=", "--interval-ms=", "--max-passes="])(
+    "%s with an empty value is an error",
+    (flag) => {
+      expect(parseArgv(["--once", flag]).errors.length).toBeGreaterThan(0);
+    },
+  );
+
+  test("a flag-shaped value is rejected rather than consumed", () => {
+    expect(parseArgv(["--since", "--json"]).errors.length).toBeGreaterThan(0);
+  });
+
+  test("--since with the value eaten does NOT silently resume from the persisted cursor", async () => {
+    writeState(dir, { cursor: 900, seenDeliveryIds: [] });
+    const { code, requested } = await runMain(["--once", "--since"], []);
+    expect(code).toBe(EXIT_UNEVALUATED);
+    expect(requested.length).toBe(0); // nothing was scanned at all
+  });
+
+  test("--require-source with the value eaten does NOT disable the dead-source detector", async () => {
+    const { code } = await runMain(["--once", "--since", "0", "--require-source"], []);
+    expect(code).toBe(EXIT_UNEVALUATED);
+    // and an explicitly EMPTY list is equally rejected
+    expect(parseArgv(["--require-source", ","]).errors.length).toBeGreaterThan(0);
+  });
+
+  test("--base-url with the value eaten does NOT silently probe the default staging feed", async () => {
+    const { code, requested } = await runMain(["--once", "--since", "0", "--base-url"], []);
+    expect(code).toBe(EXIT_UNEVALUATED);
+    expect(requested.length).toBe(0);
+    expect(parseArgv(["--base-url", "not-a-url"]).errors.length).toBeGreaterThan(0);
+  });
+
+  test("a malformed or zero poll interval in the ENV is rejected exactly like the flag", async () => {
+    for (const bad of ["banana", "0"]) {
+      const code = await main(["--since", "0"], {
+        catalystDir: dir,
+        tokenOverride: TOKEN,
+        linearTeams: [],
+        botUserIds: new Set(),
+        env: { CATALYST_CLOUD_EVENT_POLL_MS: bad },
+        fetchImpl: async () => {
+          throw new Error("must not be called");
+        },
+        stdout: () => {},
+        stderr: () => {},
+        sleep: async () => {},
+      });
+      expect(code).toBe(EXIT_UNEVALUATED);
+    }
+  });
+});
+
+// --------------------------------------------------------------------------
+// the negative control itself
+// --------------------------------------------------------------------------
+
+describe("--self-test is the credential-free negative control", () => {
+  test("it runs with no token, no network, no filesystem and every detector fires", async () => {
+    const out = [];
+    const code = await runSelfTest({ stdout: (s) => out.push(s), stderr: (s) => out.push(s) });
+    const text = out.join("");
+    expect(code).toBe(EXIT_HEALTHY);
+    expect(text).not.toContain("FAIL");
+    // observed RED, not merely "runs"
+    expect(text).toMatch(/detectors expected RED/);
+    const reds = text.split("\n").filter((l) => /expect=[12] /.test(l));
+    expect(reds.length).toBeGreaterThanOrEqual(9);
+  });
+
+  test("main --self-test needs no credential and no CATALYST_DIR", async () => {
+    const code = await main(["--self-test"], {
+      env: {},
+      stdout: () => {},
+      stderr: () => {},
+      fetchImpl: async () => {
+        throw new Error("must not be called");
+      },
+    });
+    expect(code).toBe(EXIT_HEALTHY);
+  });
+});
+
+// CTL-1534 (M10): the shadow-dir guard was purely LEXICAL, and resolve() does not
+// follow symlinks. A symlinked <root>/events-shadow -> <root>/events passed every
+// lexical check and would have written the LIVE event log, double-waking every
+// worker — while the safety self-test printed PASS. These pin the real-path guard.
+describe("CTL-1534 M10 — shadow dir cannot resolve onto the live event log", () => {
+  test("refuses a shadow dir that is a symlink to the live events dir", () => {
+    const root = mkdtempSync(join(tmpdir(), "m10-sym-"));
+    mkdirSync(join(root, "events"), { recursive: true });
+    symlinkSync(join(root, "events"), join(root, "events-shadow"));
+    expect(() => resolveShadowDir(root)).toThrow();
+  });
+
+  test("refuses a shadow dir symlinked anywhere that resolves under the live dir", () => {
+    const root = mkdtempSync(join(tmpdir(), "m10-nest-"));
+    mkdirSync(join(root, "events", "inner"), { recursive: true });
+    symlinkSync(join(root, "events", "inner"), join(root, "events-shadow"));
+    expect(() => resolveShadowDir(root)).toThrow();
+  });
+
+  test("accepts an ordinary shadow dir", () => {
+    const root = mkdtempSync(join(tmpdir(), "m10-ok-"));
+    mkdirSync(join(root, "events"), { recursive: true });
+    expect(resolveShadowDir(root)).toBe(join(root, "events-shadow"));
+  });
+
+  test("shadow filename does not collide with the live log basename", () => {
+    const root = mkdtempSync(join(tmpdir(), "m10-name-"));
+    const f = shadowFilePath(root, new Date(Date.UTC(2026, 6, 1)));
+    expect(basename(f)).toBe("shadow-2026-07.jsonl");
+    expect(basename(f)).not.toBe("2026-07.jsonl");
+  });
+});

--- a/plugins/dev/scripts/execution-core/cloud-event-consumer.test.mjs
+++ b/plugins/dev/scripts/execution-core/cloud-event-consumer.test.mjs
@@ -25,8 +25,10 @@ import {
   SEQ_ATTR,
   SHADOW_DIR_NAME,
   VALUE_FLAGS,
+  classifyDecline,
   classifyLine,
   classifyProviderType,
+  computeMissingRanges,
   createShadowAppender,
   ghEvent,
   isPayloadOmitted,
@@ -38,6 +40,7 @@ import {
   parseEnvFile,
   parseSinceArg,
   readCloudToken,
+  readLinearBotUserIds,
   readState,
   resolveShadowDir,
   runOnce,
@@ -106,8 +109,11 @@ async function runMain(argv, responses, extra = {}) {
   const code = await main(argv, {
     catalystDir: dir,
     tokenOverride: TOKEN,
-    linearTeams: [],
-    botUserIds: new Set(),
+    // A REALISTIC config, not an empty one. Since the M1 fix an empty roster / empty bot
+    // set is a declared degradation that exits 2, so a suite that injected `[]` would be
+    // testing the degraded path in every single case.
+    linearTeams: [{ key: "CTL", vcsRepo: "coalesce-labs/catalyst" }],
+    botUserIds: new Set(["bot-user-0"]),
     fetchImpl: async (url) => {
       requested.push(url);
       const next = queue.shift();
@@ -1392,5 +1398,318 @@ describe("CTL-1534 M10 — shadow dir cannot resolve onto the live event log", (
     const f = shadowFilePath(root, new Date(Date.UTC(2026, 6, 1)));
     expect(basename(f)).toBe("shadow-2026-07.jsonl");
     expect(basename(f)).not.toBe("2026-07.jsonl");
+  });
+});
+
+// ==========================================================================
+// CTL-1534 round 2 — the ten known defects the draft PR shipped with.
+// Each block names the false green it closes, and each assertion fails on the
+// code as it stood before the fix.
+// ==========================================================================
+
+describe("H — a hole ANYWHERE in the page pins the cursor, not just a late start", () => {
+  test("computeMissingRanges derives holes from the received SET, in any wire order", () => {
+    expect(computeMissingRanges(0, [1, 2, 3])).toEqual([]);
+    // an inversion delivers the whole range: NO hole
+    expect(computeMissingRanges(0, [2, 1, 3])).toEqual([]);
+    expect(computeMissingRanges(0, [9, 10])).toEqual([{ from: 1, to: 8 }]);
+    expect(computeMissingRanges(0, [1, 4])).toEqual([{ from: 2, to: 3 }]);
+    expect(computeMissingRanges(0, [1, 4, 8])).toEqual([{ from: 2, to: 3 }, { from: 5, to: 7 }]);
+    expect(computeMissingRanges(100, [101, 103])).toEqual([{ from: 102, to: 102 }]);
+  });
+
+  test("an INTERIOR-page gap writes a durable marker and refuses to advance the cursor", async () => {
+    const app = memAppender();
+    const r = await runOnce({
+      fetchImpl: async () => res({ head: 4, lines: [ghEvent(1, "d1"), ghEvent(4, "d4")] }),
+      token: "", since: 0, appender: app, seen: new Set(), log: collectLogs(),
+    });
+    expect(r.status).toBe(EXIT_PROBLEM);
+    // the pre-fix code advanced to lastSeq (4), burning seqs 2..3 forever
+    expect(r.cursorAdvancedTo).toBeNull();
+    expect(r.holes).toEqual([{ from: 2, to: 3 }]);
+    const gaps = app.records.filter((x) => x.attributes?.["event.name"] === MARKER_FEED_GAP);
+    expect(gaps.length).toBe(1);
+    expect(gaps[0].reason).toBe("coverage-interior-gap");
+    expect(gaps[0].body.missingRanges).toEqual([{ from: 2, to: 3 }]);
+  });
+
+  test("the interior-gap cursor pin survives a restart (the state file never moves)", async () => {
+    const first = await runMain(["--once", "--since", "0"], [
+      res({ head: 4, lines: [ghEvent(1, "d1"), ghEvent(4, "d4")] }),
+    ]);
+    expect(first.code).toBe(EXIT_PROBLEM);
+    expect(JSON.parse(readFileSync(statePath(dir), "utf8")).cursor).toBe(0);
+  });
+
+  test("multiple holes in one page are ALL recorded, not just the first", async () => {
+    const app = memAppender();
+    const r = await runOnce({
+      fetchImpl: async () => res({ head: 8, lines: [ghEvent(1, "d1"), ghEvent(4, "d4"), ghEvent(8, "d8")] }),
+      token: "", since: 0, appender: app, seen: new Set(), log: collectLogs(),
+    });
+    expect(r.holes).toEqual([{ from: 2, to: 3 }, { from: 5, to: 7 }]);
+    expect(r.cursorAdvancedTo).toBeNull();
+  });
+});
+
+describe("M — a wire-order inversion is an ordering fault, never a proven hole", () => {
+  test("2,1,3 fails integrity, passes coverage, writes NO gap marker and advances", async () => {
+    const app = memAppender();
+    const r = await runOnce({
+      fetchImpl: async () => res({ head: 3, lines: [ghEvent(2, "d2"), ghEvent(1, "d1"), ghEvent(3, "d3")] }),
+      token: "", since: 0, appender: app, seen: new Set(), log: collectLogs(),
+    });
+    expect(r.integrity.ok).toBe(false);
+    // pre-fix: firstSeq(2) !== since+1(1) claimed a hole at 1..1 that WAS delivered
+    expect(r.coverage.ok).toBe(true);
+    expect(r.holes).toEqual([]);
+    expect(r.cursorAdvancedTo).not.toBeNull();
+    expect(app.records.some((x) => x.attributes?.["event.name"] === MARKER_FEED_GAP)).toBe(false);
+  });
+
+  test("a genuinely late start is still a proven hole even when the page is inverted", async () => {
+    const r = await runOnce({
+      fetchImpl: async () => res({ head: 4, lines: [ghEvent(4, "d4"), ghEvent(3, "d3")] }),
+      token: "", since: 0, appender: memAppender(), seen: new Set(), log: collectLogs(),
+    });
+    expect(r.holes).toEqual([{ from: 1, to: 2 }]);
+    expect(r.cursorAdvancedTo).toBeNull();
+  });
+});
+
+describe("H — markers anchor their ts on receivedAt, not the wall clock", () => {
+  const RECEIVED = "2026-07-26T22:11:00.000Z";
+
+  test("a gap marker is placed in the window the events it describes belong to", async () => {
+    const app = memAppender();
+    await runOnce({
+      fetchImpl: async () => res({ head: 10, lines: [ghEvent(9, "d9", { receivedAt: RECEIVED })] }),
+      token: "", since: 0, appender: app, seen: new Set(), log: collectLogs(),
+    });
+    const gap = app.records.find((x) => x.attributes?.["event.name"] === MARKER_FEED_GAP);
+    expect(gap.ts).toBe(RECEIVED);
+    expect(gap.tsSource).toBe("receivedAt");
+    // the wall clock is kept, separately — the two are never conflated
+    expect(typeof gap.emittedAt).toBe("string");
+    expect(gap.emittedAt).not.toBe(gap.ts);
+  });
+
+  test("an elision marker is anchored on its own delivery's receivedAt", async () => {
+    const app = memAppender();
+    await runOnce({
+      fetchImpl: async () =>
+        res({
+          head: 1,
+          lines: [{
+            accountId: "t", seq: 1, deliveryId: "big-1", source: "linear", eventType: "Comment",
+            action: "create", receivedAt: RECEIVED, payload: null, payloadOmitted: true, payloadBytes: 120000,
+          }],
+        }),
+      token: "", since: 0, appender: app, seen: new Set(), log: collectLogs(),
+    });
+    const marker = app.records.find((x) => x.attributes?.["event.name"] === MARKER_UNMAPPABLE);
+    expect(marker.ts).toBe(RECEIVED);
+    expect(marker.tsSource).toBe("receivedAt");
+  });
+
+  test("with no usable receivedAt anchor the fallback is DECLARED, not disguised", async () => {
+    const app = memAppender();
+    await runOnce({
+      fetchImpl: async () => res({ status: 409, body: { error: "cursor_underflow", resync: true } }),
+      token: "", since: 5, appender: app, seen: new Set(), log: collectLogs(),
+    });
+    const gap = app.records.find((x) => x.attributes?.["event.name"] === MARKER_FEED_GAP);
+    expect(gap.tsSource).toBe("wall-clock");
+  });
+
+  test("a marker anchored on receivedAt lands INSIDE the harness window; a wall-clock one does not", async () => {
+    const { ingestText, parseArgs } = await import("./parity-harness.mjs");
+    const app = memAppender();
+    await runOnce({
+      fetchImpl: async () => res({ head: 10, lines: [ghEvent(9, "d9", { receivedAt: RECEIVED })] }),
+      token: "", since: 0, appender: app, seen: new Set(), log: collectLogs(),
+    });
+    // a window drawn around the TRAFFIC, which is how an operator picks --from/--to
+    const o = {
+      ...parseArgs([]).opts,
+      edgeMarginMs: 0,
+      fromMs: Date.parse("2026-07-26T22:00:00.000Z"), fromIso: "2026-07-26T22:00:00.000Z",
+      toMs: Date.parse("2026-07-26T23:00:00.000Z"), toIso: "2026-07-26T23:00:00.000Z",
+    };
+    const text = app.records.map((r) => JSON.stringify(r)).join("\n");
+    const acc = ingestText("shadow", text, o);
+    const gapMarkers = acc.markers.filter((m) => m.kind === "gap");
+    expect(gapMarkers.length).toBe(1);
+    expect(gapMarkers[0].inWindow).toBe(true);
+  });
+});
+
+describe("M11 — a dedup-only pass evaluated nothing and must not exit 0", () => {
+  test("every record already in the ring is exit 2, not a healthy confirmation", async () => {
+    const r = await runOnce({
+      fetchImpl: async () => res({ head: 2, lines: [ghEvent(1, "d1"), ghEvent(2, "d2")] }),
+      token: "", since: 0, appender: memAppender(), seen: new Set(["d1", "d2"]), log: collectLogs(),
+    });
+    expect(r.status).toBe(EXIT_UNEVALUATED);
+    expect(r.dedupOnly).toBe(true);
+    expect(r.appended).toBe(0);
+    expect(r.deduped).toBe(2);
+  });
+
+  test("a partly-deduped pass DID append something and stays healthy", async () => {
+    const r = await runOnce({
+      fetchImpl: async () => res({ head: 2, lines: [ghEvent(1, "d1"), ghEvent(2, "d2")] }),
+      token: "", since: 0, appender: memAppender(), seen: new Set(["d1"]), log: collectLogs(),
+    });
+    expect(r.status).toBe(EXIT_HEALTHY);
+    expect(r.dedupOnly).toBe(false);
+  });
+
+  test("an empty window at head is still healthy — nothing to dedup is not the same shape", async () => {
+    const r = await runOnce({
+      fetchImpl: async () => res({ head: 7, lines: [] }),
+      token: "", since: 7, appender: memAppender(), seen: new Set(), log: collectLogs(),
+    });
+    expect(r.status).toBe(EXIT_HEALTHY);
+    expect(r.dedupOnly).toBe(false);
+  });
+
+  test("a dedup-only pass that ALSO proved a hole keeps the stronger, evaluated verdict", async () => {
+    const r = await runOnce({
+      fetchImpl: async () => res({ head: 10, lines: [ghEvent(9, "d9"), ghEvent(10, "d10")] }),
+      token: "", since: 0, appender: memAppender(), seen: new Set(["d9", "d10"]), log: collectLogs(),
+    });
+    expect(r.status).toBe(EXIT_PROBLEM);
+    expect(r.dedupOnly).toBe(false);
+  });
+});
+
+describe("H10 — a PARTIAL mapper regression is visible, not only a total one", () => {
+  test("classifyDecline separates schema drift from a routine unhandled action", () => {
+    expect(classifyDecline("Comment: unknown action foo")).toBe("routine");
+    expect(classifyDecline("unhandled type: Widget")).toBe("routine");
+    expect(classifyDecline("unhandled event: widget")).toBe("routine");
+    expect(classifyDecline("issue_comment: not a PR comment")).toBe("routine");
+    expect(classifyDecline("Comment: missing data")).toBe("structural");
+    expect(classifyDecline("payload is not an object")).toBe("structural");
+    expect(classifyDecline("builder returned null")).toBe("structural");
+  });
+
+  test("one Comment maps and one is structurally declined — the type is still a problem", async () => {
+    const r = await runOnce({
+      fetchImpl: async () =>
+        res({
+          head: 2,
+          lines: [
+            linearEvent(1, "c1"),
+            { ...linearEvent(2, "c2"), payload: { type: "Comment", action: "create" } },
+          ],
+        }),
+      token: "", since: 0, appender: memAppender(), seen: new Set(), log: collectLogs(),
+    });
+    // pre-fix: appendedByType["linear:Comment"] === 1 skipped the check entirely
+    expect(r.appended).toBe(1);
+    expect(r.status).toBe(EXIT_PROBLEM);
+    expect(r.structuralDeclines["linear:Comment"]).toBe(1);
+    expect(r.problems.join(" ")).toContain("PARTIAL");
+  });
+
+  test("a routine unhandled ACTION on a mappable type is coverage data, not a regression", async () => {
+    const r = await runOnce({
+      fetchImpl: async () =>
+        res({
+          head: 2,
+          lines: [
+            linearEvent(1, "c1"),
+            { ...linearEvent(2, "c2"), payload: { type: "Comment", action: "restore", data: { id: "x" } }, action: "restore" },
+          ],
+        }),
+      token: "", since: 0, appender: memAppender(), seen: new Set(), log: collectLogs(),
+    });
+    expect(r.appended).toBe(1);
+    expect(r.structuralDeclines["linear:Comment"]).toBeUndefined();
+    expect(r.status).toBe(EXIT_HEALTHY);
+  });
+});
+
+describe("M — a failed durable marker write is exit 2, not an escaped throw", () => {
+  test("runOnce folds the write failure into the report instead of rejecting", async () => {
+    const r = await runOnce({
+      fetchImpl: async () => res({ status: 409, body: { error: "cursor_underflow", resync: true } }),
+      token: "", since: 5,
+      appender: { dir: "<broken>", write: () => { throw new Error("ENOSPC"); } },
+      seen: new Set(), log: collectLogs(),
+    });
+    expect(r.status).toBe(EXIT_UNEVALUATED);
+    expect(r.markersWritten).toBe(0);
+    expect(r.unevaluated.join(" ")).toContain("durable marker write FAILED");
+  });
+
+  test("a coverage-hole marker that cannot be written is exit 2, never a bare problem", async () => {
+    const r = await runOnce({
+      fetchImpl: async () => res({ head: 10, lines: [ghEvent(9, "d9"), ghEvent(10, "d10")] }),
+      token: "", since: 0,
+      appender: {
+        dir: "<half-broken>",
+        write: (rec) => {
+          if (rec?.attributes?.["event.name"] === MARKER_FEED_GAP) throw new Error("EACCES");
+        },
+      },
+      seen: new Set(), log: collectLogs(),
+    });
+    // the hole is real (exit 1) AND its durable record is missing (exit 2); 2 dominates
+    expect(r.status).toBe(EXIT_UNEVALUATED);
+    expect(r.unevaluated.join(" ")).toContain("durable marker write FAILED");
+  });
+});
+
+describe("M1 — a degraded config is exit 2, never a silently-accepted empty set", () => {
+  test("an EMPTY team roster refuses to run", async () => {
+    const { code, stderr } = await runMain(["--once", "--since", "0"], [res({ head: 1, lines: [ghEvent(1, "d1")] })], {
+      linearTeams: [],
+    });
+    expect(code).toBe(EXIT_UNEVALUATED);
+    expect(stderr).toContain("degraded config");
+    expect(stderr).toContain("roster is EMPTY");
+  });
+
+  test("an EMPTY bot-actor set refuses to run", async () => {
+    const { code, stderr } = await runMain(["--once", "--since", "0"], [res({ head: 1, lines: [ghEvent(1, "d1")] })], {
+      botUserIds: new Set(),
+    });
+    expect(code).toBe(EXIT_UNEVALUATED);
+    expect(stderr).toContain("bot actor id set is EMPTY");
+  });
+
+  test("--allow-empty-config makes the degradation DECLARED rather than inferred from silence", async () => {
+    const { code, stderr } = await runMain(
+      ["--once", "--since", "0", "--allow-empty-config"],
+      [res({ head: 1, lines: [ghEvent(1, "d1")] })],
+      { linearTeams: [], botUserIds: new Set() },
+    );
+    expect(code).toBe(EXIT_HEALTHY);
+    expect(stderr).toContain("waived by --allow-empty-config");
+  });
+
+  test("readLinearBotUserIds rejects a config file that exists but is not JSON", () => {
+    expect(() =>
+      readLinearBotUserIds({
+        env: {},
+        layer2Path: "/nope/layer2.json",
+        layer1Path: "/nope/layer1.json",
+        readFile: (p) => (p === "/nope/layer2.json" ? "{not json" : (() => { throw new Error("ENOENT"); })()),
+      }),
+    ).toThrow(/not parseable JSON/);
+  });
+
+  test("readLinearBotUserIds treats a genuinely ABSENT file as absent, not an error", () => {
+    const ids = readLinearBotUserIds({
+      env: {},
+      layer2Path: "/nope/layer2.json",
+      layer1Path: "/nope/layer1.json",
+      readFile: () => { throw new Error("ENOENT"); },
+    });
+    expect(ids.size).toBe(0);
   });
 });

--- a/plugins/dev/scripts/execution-core/parity-harness.mjs
+++ b/plugins/dev/scripts/execution-core/parity-harness.mjs
@@ -343,15 +343,21 @@ export function repoOf(obj) {
   return typeof v === "string" && v.length > 0 ? v : "(none)";
 }
 
-/** Read the cloud seq the consumer stamped on a shadow envelope. Strict: integers only. */
+/**
+ * Read the cloud seq the consumer stamped on a shadow envelope. Strict: integer NUMBERS only.
+ *
+ * A STRING seq used to be coerced through parseIntStrict. That is rule 6 ("never normalise
+ * the evidence") violated by the tool that enforces it: cloud-event-consumer's mapCloudEvent
+ * rejects anything but a safe-integer number before stamping, so a string here means the
+ * producer or the transport changed shape underneath us. Repairing it hides that; it is
+ * invalid evidence, and SEQ_ATTR_INVALID exists to say so.
+ */
 export function seqOf(obj, seqAttr) {
-  const v = obj?.attributes?.[seqAttr];
+  const attrs = obj?.attributes;
+  if (typeof attrs !== "object" || attrs === null || !Object.hasOwn(attrs, seqAttr)) return { ok: null }; // absent
+  const v = attrs[seqAttr];
   if (typeof v === "number") return Number.isSafeInteger(v) ? { ok: true, seq: v } : { ok: false, raw: v };
-  if (typeof v === "string") {
-    const p = parseIntStrict(v);
-    return p.ok ? { ok: true, seq: p.value } : { ok: false, raw: v };
-  }
-  return { ok: null }; // absent
+  return { ok: false, raw: v };
 }
 
 // ── JSONL ingestion ─────────────────────────────────────────────────────────────────────
@@ -1029,6 +1035,17 @@ export function evaluate({ live, shadow, opts, generatedAt = new Date().toISOStr
           `${unexplainedLoss.length} interior live delivery/deliveries never reached the shadow log`,
           { deliveries: capList(unexplainedLoss.map(fmtEntry), opts.maxList), byRepo: tally(unexplainedLoss, (e) => repoOf(e.obj)), byType: tally(unexplainedLoss, (e) => eventNameOf(e.obj)) })
   );
+  // The not_run row above is ALL-OR-NOTHING: it only fires when EVERY candidate was
+  // edge-excluded. A PARTIAL exclusion — 9 waived, 1 examined — printed a bare `pass`,
+  // which is indistinguishable from having examined all 10 (rule 10). The excluded ones
+  // are an unanswered question and are enumerated as one, exactly like a `--sources`
+  // exclusion; `--edge-margin 0` is what answers them.
+  if (!allLiveOnlyEdgeExcluded && liveOnlyEdge.length > 0) {
+    notAsserted.push({
+      id: "MISSING_FROM_SHADOW_EDGE_EXCLUDED",
+      reason: `${liveOnlyEdge.length} of ${liveOnly.length} live-only delivery/deliveries sat within --edge-margin ${opts.edgeMarginMs / 1000}s of a window boundary and were NOT examined. The detector answered only for the ${liveOnlyInterior.length} interior candidate(s) — a partial exclusion is not a full answer. Re-run with --edge-margin 0, or move --from/--to so they are interior.`,
+    });
+  }
 
   // Emitted at zero too: a filed gap that stopped appearing is a result worth seeing, and an
   // omitted row is indistinguishable from nobody looking.
@@ -1036,10 +1053,18 @@ export function evaluate({ live, shadow, opts, generatedAt = new Date().toISOStr
     knownGapDeficit.length === 0
       ? check("KNOWN_GAP_LOSSES", "pass", "live-only deliveries attributable to a FILED cloud-side gap",
           `0 in window (censused known gaps: ${DEFAULT_TYPE_CENSUS.filter((c) => c.expectation === "known-gap").map((c) => `${c.prefix}* [${c.ticket}]`).join(", ") || "none"})`)
-      : check("KNOWN_GAP_LOSSES", opts.strictKnownGaps ? "fail" : "warn",
+      // `info` by default, NOT `warn`. Every delivery counted here matched a census row
+      // that already names an open ticket, so `warn` (non-green, exit 1) made the harness
+      // permanently red for as long as that ticket stays open — which manufactures exactly
+      // the pressure to stop reading the verdict that this tool exists to resist. The
+      // distinction the exit code must preserve is NEW/uninvestigated vs KNOWN/filed: a
+      // loss that is NOT censused is already counted as unexplained by MISSING_FROM_SHADOW
+      // and FAILS there. This row keeps the tracked ones visible, with their ticket, every
+      // run; --strict-known-gaps escalates it to a hard fail for the phase-5 close-out.
+      : check("KNOWN_GAP_LOSSES", opts.strictKnownGaps ? "fail" : "info",
           "live-only deliveries attributable to a FILED cloud-side gap",
-          `${knownGapDeficit.length} delivery/deliveries match a known-gap census row (e.g. linear.reaction.* / CTC-297). Tracked, not new — but still a real gap that must close before phase 5.`,
-          { deliveries: capList(knownGapDeficit.map(fmtEntry), opts.maxList), byType: tally(knownGapDeficit, (e) => eventNameOf(e.obj)) })
+          `${knownGapDeficit.length} delivery/deliveries match a known-gap census row (e.g. linear.reaction.* / CTC-297) — TRACKED and still monitored, not new. Uncensused losses are NOT counted here; they fail MISSING_FROM_SHADOW. Pass --strict-known-gaps to make a filed gap block (required before phase 5).`,
+          { deliveries: capList(knownGapDeficit.map(fmtEntry), opts.maxList), byType: tally(knownGapDeficit, (e) => eventNameOf(e.obj)), tickets: [...new Set(knownGapDeficit.map((e) => censusExpectationFor(eventNameOf(e.obj)).ticket ?? "(untagged)"))] })
   );
 
   // Shadow-only is the EXPECTED direction (the cloud is a superset: more types, more repos).
@@ -1069,6 +1094,12 @@ export function evaluate({ live, shadow, opts, generatedAt = new Date().toISOStr
           `${shadowOnlyOverlapping.length} shadow-only delivery/deliveries of a type the LIVE side also carries — that is a smee-side drop (the 14h32m GitHub tunnel outage had exactly this shape), not the cloud superset. ${shadowOnlySuperset.length} further shadow-only deliveries are expected superset.`,
           { overlapping: capList(shadowOnlyOverlapping.map(fmtEntry), opts.maxList), byType: tally(shadowOnlyOverlapping, (e) => eventNameOf(e.obj)), supersetByType: tally(shadowOnlySuperset, (e) => eventNameOf(e.obj)) })
   );
+  if (!allShadowOnlyEdgeExcluded && shadowOnlyEdge.length > 0) {
+    notAsserted.push({
+      id: "SHADOW_ONLY_EDGE_EXCLUDED",
+      reason: `${shadowOnlyEdge.length} of ${shadowOnly.length} shadow-only delivery/deliveries sat within --edge-margin ${opts.edgeMarginMs / 1000}s of a window boundary and were NOT examined. The detector answered only for the ${shadowOnlyInterior.length} interior candidate(s). Re-run with --edge-margin 0, or move --from/--to so they are interior.`,
+    });
+  }
 
   // Invariant 6: the consumer dedups on delivery_id. A duplicate on the shadow side is a
   // dedup failure. A duplicate on the live side is a provider redelivery — reported, not failed.
@@ -1405,7 +1436,12 @@ FEED ORDERING
 
 STRICTNESS
   --strict-shadow-only   overlapping-type shadow-only deliveries FAIL (default: warn)
-  --strict-known-gaps    filed cloud-side gaps (CTC-297) FAIL (default: warn)
+  --strict-known-gaps    filed cloud-side gaps (CTC-297) FAIL. Default is "info": a gap
+                         that is already censused AND ticketed is tracked, printed every
+                         run with its ticket, and does NOT move the verdict — a row that
+                         is permanently red for the life of a ticket trains people to
+                         ignore it. An UNCENSUSED loss is never counted here; it fails
+                         MISSING_FROM_SHADOW. Pass this before the phase-5 close-out.
   --strict-attrs         locally-enriched attribute presence diffs FAIL
   --allow-version-span   waive the deploy-boundary gate (a window crossing a deploy lies)
   --allow-partial-overlap  waive the "sides cover different intervals" gate
@@ -1686,6 +1722,47 @@ export function selfTest() {
     shadowText: [f.g(1, "gh-1", 101), f.g(2, "gh-2", 102), f.l(3, "li-1", 103), f.l(4, "li-2", 104),
       JSON.stringify({ ts: f.T(5), attributes: { "event.name": "catalyst.cloud_feed.unmappable_payload", "webhook.delivery.id": "gh-3" }, reason: "payloadOmitted", payloadBytes: 12 })].join("\n"),
     expect: { exitCode: EXIT_CANNOT_EVALUATE, detector: "UNCORROBORATED_ELISION" },
+  }));
+
+  // 22. A STRING seq is INVALID EVIDENCE, not something to coerce (rule 6, applied to the
+  //     harness's own reader). The consumer stamps a number; a string means the producer
+  //     changed shape, and parseIntStrict-ing it hid that.
+  cases.push(runCase("a string seq value is rejected, never coerced", {
+    liveText: f.live,
+    shadowText: [f.g(1, "gh-1", 101), f.g(2, "gh-2", "102"), f.l(3, "li-1", 103), f.l(4, "li-2", 104), f.g(5, "gh-3", 105)].join("\n"),
+    expect: { exitCode: EXIT_CANNOT_EVALUATE, detector: "SEQ_ATTR_INVALID" },
+  }));
+
+  // 23. A PARTIAL edge exclusion is not a full answer. The not_run row only fires when
+  //     EVERY candidate is edge-excluded, so 1-of-2 waived printed a bare `pass`.
+  // (the matched `gh-anchor` pair at 22:59 keeps the window-overlap gate quiet; the two
+  //  live-only rows are the actual subject — one interior, one inside the trailing margin)
+  const edgeAnchor = (seq) => env({ name: "github.pr.opened", id: "gh-anchor", ts: "2026-07-26T22:59:00.000Z", seq, attrs: { "vcs.repository.name": "coalesce-labs/catalyst" } });
+  const partialEdge = runCase("a PARTIAL edge exclusion is enumerated, not folded into the pass", {
+    liveText: [f.live, edgeAnchor(null),
+      env({ name: "github.pr.opened", id: "gh-interior", ts: f.T(20), attrs: { "vcs.repository.name": "coalesce-labs/catalyst" } }),
+      env({ name: "github.pr.opened", id: "gh-edge", ts: "2026-07-26T22:59:30.000Z", attrs: { "vcs.repository.name": "coalesce-labs/catalyst" } })].join("\n"),
+    shadowText: [f.shadow, edgeAnchor(106)].join("\n"),
+    expect: { exitCode: EXIT_PROBLEM, detector: "MISSING_FROM_SHADOW" },
+  });
+  partialEdge.ok =
+    partialEdge.ok &&
+    partialEdge.report.notAsserted.some((n) => n.id === "MISSING_FROM_SHADOW_EDGE_EXCLUDED");
+  cases.push(partialEdge);
+
+  // 24. A FILED, censused gap is `info` — tracked and printed with its ticket, but it does
+  //     NOT hold the verdict red for the life of the ticket (which trains people to stop
+  //     reading it). --strict-known-gaps is the escalation, and it must still bite.
+  const knownGapShadow = [f.g(1, "gh-1", 101), f.g(2, "gh-2", 102), f.l(3, "li-1", 103), f.l(4, "li-2", 104), f.g(5, "gh-3", 105)].join("\n");
+  const knownGapLive = [f.live, env({ name: "linear.reaction.created", id: "rx-1", ts: f.T(3), attrs: {} })].join("\n");
+  cases.push(runCase("a filed, censused gap is tracked info — not a permanently red verdict", {
+    liveText: knownGapLive, shadowText: knownGapShadow,
+    expect: { exitCode: EXIT_HEALTHY, detector: null },
+  }));
+  cases.push(runCase("--strict-known-gaps still escalates a filed gap to a hard fail", {
+    liveText: knownGapLive, shadowText: knownGapShadow,
+    opts: { strictKnownGaps: true },
+    expect: { exitCode: EXIT_PROBLEM, detector: "KNOWN_GAP_LOSSES" },
   }));
 
   // 14. BAD INPUT — never coerced. `--from banana` must be rejected, not NaN'd into "scan

--- a/plugins/dev/scripts/execution-core/parity-harness.mjs
+++ b/plugins/dev/scripts/execution-core/parity-harness.mjs
@@ -1,0 +1,1793 @@
+#!/usr/bin/env bun
+// parity-harness.mjs — CTL-1534 (ADR-0008 leg 3, phase 3).
+//
+// Compares the SHADOW event log (~/catalyst/events-shadow/YYYY-MM.jsonl, produced by the
+// catalyst-cloud `/events/stream` consumer) against the LIVE event log
+// (~/catalyst/events/YYYY-MM.jsonl, produced by the smee webhook path), joined on
+// `attributes["webhook.delivery.id"]` (CTL-1532 — the ONLY join key; the cloud feed's
+// `deliveryId` carries the same provider-issued value).
+//
+// ────────────────────────────────────────────────────────────────────────────────────────
+// THE POINT OF THIS FILE IS TO NOT REPORT A CONFIDENT GREEN.
+//
+// Every rule below is a defect that actually shipped in catalyst-cloud's equivalent harness
+// (11 defects across 3 review rounds, every one producing a confident green). They are
+// correctness requirements, not style:
+//
+//  1. THREE-WAY EXIT.  0 = evaluated-healthy · 1 = evaluated-problem · 2 = COULD NOT EVALUATE.
+//     Collapsing 2 into 0 was the worst defect. "I could not check" NEVER renders as healthy.
+//  2. COVERAGE != INTEGRITY.  Asserted separately, and coverage is only asserted when the
+//     input can actually support it (see --seq-ledger-complete). A short read is internally
+//     contiguous and carries no control record; contiguity cannot see it at any rigour.
+//  3. A CONTROL RECORD INVALIDATES THE RUN -> exit 2. The prefix before it is contiguous, so a
+//     naive contiguity check passes a server-declared incomplete scan.
+//  4. WIRE ORDER ONLY, NEVER SORT. Sorting turns 1,3,2 into a clean pass.
+//  5. NON-ZERO MATCHED PAIRS PER SOURCE. A zero-match join is indistinguishable from perfect
+//     parity if you only count mismatches.
+//  6. NEVER NORMALISE THE EVIDENCE. No coercion (`--from banana` is rejected, never NaN'd),
+//     no defaulting, no sorting of adjacency evidence. Bad input -> exit 2.
+//  7. --since / persisted cursor from day one (here: --expect-first-seq / --expect-head-seq,
+//     never a hardcoded 0).
+//  8. NEGATIVE CONTROLS RUN CREDENTIAL-FREE AND OFFLINE (--self-test), and are OBSERVED to go
+//     red on seeded failures (plus a positive control, so a stuck-red harness cannot pass).
+//  9. PER-TYPE COUNTS, NEVER PRESENCE. "at least one workflow_job seen" is satisfied by one
+//     lucky event while a filter drops 99%.
+// 10. AN OMITTED ROW IS INDISTINGUISHABLE FROM NOBODY LOOKING. Expected-zero rows are printed
+//     as expected-zero. Checks that did not run are printed in the headline verdict.
+// ────────────────────────────────────────────────────────────────────────────────────────
+//
+// This file reads two on-disk logs. It never opens a network connection and never reads a
+// credential. Feed-side health (contiguity/coverage of the HTTP replay itself) is owned by
+// catalyst-cloud's `feed-health.mjs`; consume its exit code, do not re-derive it here.
+
+import { createReadStream, existsSync, statSync } from "node:fs";
+import { createInterface } from "node:readline";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+// ── exit contract ───────────────────────────────────────────────────────────────────────
+export const EXIT_HEALTHY = 0; // evaluated, healthy
+export const EXIT_PROBLEM = 1; // evaluated, problem found
+export const EXIT_CANNOT_EVALUATE = 2; // did NOT evaluate — never report as healthy
+
+// ── declared comparison policy (printed every run; never silent) ─────────────────────────
+
+// Attributes whose PRESENCE legitimately differs between the two producers because they are
+// enriched from LOCAL state (the monitor's PR-number cache, its Linear teams map, its
+// orchestrator resolver) that the shadow consumer may not have. A presence-only difference is
+// INFO; a difference where BOTH sides carry a value but the values disagree is always a FAIL.
+// `--strict-attrs` promotes presence-only differences to FAIL.
+export const ATTR_LOCAL_ENRICHMENT = new Set([
+  "catalyst.orchestrator.id",
+  "vcs.pr.number", // check_suite/status PR attribution comes from the local prCache
+  "vcs.repository.name", // linear.* gets this from the monitor's teamsMap (CTL-362)
+]);
+
+// Envelope-level fields deliberately NOT compared, with the reason. Printed as policy.
+export const ENVELOPE_UNCOMPARED = [
+  ["ts / observedTs", "cloud is ~12s ahead of smee by design; timestamps are not parity"],
+  ["id", "per-emission UUIDv4, unique per producer by construction"],
+  ["traceId / spanId", "derived per producer"],
+  ["resource.*", "service.name/version/host identify the PRODUCER, not the event"],
+  ["body.payload", "compared indirectly via attributes; payload diffs are mapper-identical by construction (same webhook-events.ts) and noisy to diff"],
+];
+
+// Type census. `event.name` PREFIX -> expectation. Counts, never presence (rule 9).
+//   both       — smee and the cloud should both deliver it; live > shadow is a DEFICIT (fail)
+//   cloud-only — the cloud carries it, smee never did; shadow > live is EXPECTED (info)
+//   known-gap  — a *tracked* cloud-side subscription gap; live > shadow is expected-and-filed
+export const DEFAULT_TYPE_CENSUS = [
+  { prefix: "github.pr.", expectation: "both" },
+  { prefix: "github.pr_review.", expectation: "both" },
+  { prefix: "github.pr_review_thread.", expectation: "both" },
+  { prefix: "github.issue_comment.", expectation: "both" },
+  { prefix: "github.status.", expectation: "both" },
+  { prefix: "github.deployment.", expectation: "both" },
+  { prefix: "github.deployment_status.", expectation: "both" },
+  { prefix: "github.release.", expectation: "both" },
+  // measured on the live feed (444 events, first hour): these were previously DISCARDED by the
+  // smee path (or, for push, never even enqueued) — a cloud superset, not an error.
+  { prefix: "github.check_suite.", expectation: "cloud-only" },
+  { prefix: "github.workflow_run.", expectation: "cloud-only" },
+  { prefix: "github.push.", expectation: "cloud-only" },
+  { prefix: "github.pr_review_comment.", expectation: "cloud-only" },
+  { prefix: "linear.issue.", expectation: "both" },
+  { prefix: "linear.comment.", expectation: "both" },
+  { prefix: "linear.cycle.", expectation: "both" },
+  { prefix: "linear.issue_label.", expectation: "both" },
+  { prefix: "linear.agent_session.", expectation: "both" },
+  { prefix: "linear.mention.", expectation: "both" },
+  // CTC-297: a real, filed cloud subscription gap — smee received a Reaction the cloud did not.
+  // Reported loudly every run; does not fail unless --strict-known-gaps.
+  { prefix: "linear.reaction.", expectation: "known-gap", ticket: "CTC-297" },
+];
+
+// Provider event types the cloud feed carries that `webhook-events.ts` has NO mapper for.
+// They therefore produce NO envelope on EITHER side and are structurally invisible to this
+// harness. Printed as expected-zero rows so the absence is a stated result, not an omission.
+export const UNMAPPABLE_PROVIDER_TYPES = [
+  { type: "workflow_job", source: "github", note: "no case in parseWebhookEvent -> ignored" },
+  { type: "check_run", source: "github", note: "no case in parseWebhookEvent -> ignored" },
+  { type: "Attachment", source: "linear", note: "no case in parseLinearWebhookEvent -> ignored (CTC-295)" },
+];
+
+// ── shadow-log MARKERS ──────────────────────────────────────────────────────────────────
+// The shadow consumer writes explicit marker records for the two things it cannot map into an
+// envelope. They are NOT webhook envelopes, so without this the harness would count them as
+// unrelated noise and skip them — while a `gap` marker means the consumer itself declared the
+// window incomplete, and an `elided` marker is the ONLY thing that makes a >96KB payloadOmitted
+// delivery attributable rather than a mystery live-only row.
+//
+//   gap    — the consumer declared a hole in its own coverage  -> the run is NOT evaluable
+//   elided — payloadOmitted (>96KB): unmappable by construction -> an ATTRIBUTED live-only row
+//
+// Names are matched by prefix (--marker-prefix) so a consumer rename surfaces as an UNKNOWN
+// marker (exit 2), never as silence.
+export const DEFAULT_MARKER_PREFIX = "catalyst.cloud_feed.";
+/**
+ * The cloud edge cap (96KB), enforced before the queue. An `elided` marker claims a
+ * delivery was over it; this harness verifies that claim before letting the marker
+ * excuse a missing delivery. Must match cloud-event-consumer.mjs PAYLOAD_CAP_BYTES.
+ */
+export const PAYLOAD_CAP_BYTES = 96 * 1024;
+export const MARKER_KINDS = {
+  "catalyst.cloud_feed.gap": "gap",
+  "catalyst.cloud_feed.unmappable_payload": "elided",
+};
+
+// What this harness structurally CANNOT see. Printed on every run — a blind spot that is not
+// stated is indistinguishable from a blind spot nobody looked for.
+export const BLIND_SPOTS = [
+  "Provider types with no mapper in webhook-events.ts (workflow_job, check_run, Linear Attachment) produce no envelope on EITHER side. Gate B's superset claim for those types needs cloud-side per-type counts (catalyst-cloud feed-health.mjs --json), not this harness.",
+  "Pre-append cloud loss classes (catalyst.mirror.ingest.enqueue_failed / dead_lettered) never receive a seq and never reach any log — cloud-side metrics own them.",
+  "A delivery neither provider path ever received is invisible to both sides. This harness detects DISAGREEMENT; it cannot detect 'both paths equally and quietly wrong'.",
+  "HTTP-level short reads the consumer handled internally without writing a marker to the shadow log. Feed coverage is feed-health.mjs's job (defect 6: integrity never implies coverage).",
+  "payloadOmitted (>96KB elided) deliveries are unmappable by construction. This harness attributes them ONLY via the consumer's elision markers (--marker-prefix); a consumer that writes no marker leaves them as unexplained live-only rows.",
+];
+
+// ── strict input parsing (rule 6: reject, never repair) ─────────────────────────────────
+
+const ISO_RE = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d{1,9})?(Z|[+-]\d{2}:\d{2})$/;
+
+/** Strict ISO-8601 timestamp -> epoch ms. No coercion, no Date() fallback parsing. */
+export function parseIsoStrict(value) {
+  if (typeof value !== "string" || !ISO_RE.test(value)) {
+    return { ok: false, reason: `not a strict ISO-8601 timestamp: ${JSON.stringify(value)}` };
+  }
+  const ms = Date.parse(value);
+  if (!Number.isFinite(ms)) return { ok: false, reason: `unparseable timestamp: ${value}` };
+  return { ok: true, ms };
+}
+
+/**
+ * Strict non-negative integer. `Number("banana")` -> NaN and `Number("")` -> 0 are exactly the
+ * coercions that let a harness silently report on a range nobody asked for.
+ */
+export function parseIntStrict(value) {
+  if (typeof value !== "string" || !/^(0|[1-9]\d*)$/.test(value)) {
+    return { ok: false, reason: `not a non-negative integer: ${JSON.stringify(value)}` };
+  }
+  const n = Number(value);
+  if (!Number.isSafeInteger(n)) return { ok: false, reason: `integer out of safe range: ${value}` };
+  return { ok: true, value: n };
+}
+
+const FLAGS_WITH_VALUE = new Set([
+  "--live", "--shadow", "--live-dir", "--shadow-dir", "--from", "--to",
+  "--edge-margin", "--sources", "--repos", "--seq-attr", "--ignore-attr", "--marker-prefix",
+  "--expect-first-seq", "--expect-head-seq", "--max-list",
+]);
+const BOOL_FLAGS = new Set([
+  "--json", "--self-test", "--help", "-h",
+  "--no-seq-checks", "--seq-ledger-complete", "--require-coverage",
+  "--allow-version-span", "--allow-partial-overlap",
+  "--strict-shadow-only", "--strict-known-gaps", "--strict-attrs",
+  "--tolerate-torn-tail",
+]);
+
+/** Parse argv. An unknown flag is an error — never silently ignored. */
+export function parseArgs(argv) {
+  const o = {
+    live: [], shadow: [],
+    liveDir: null, shadowDir: null,
+    fromIso: null, toIso: null, fromMs: null, toMs: null,
+    edgeMarginMs: 120_000,
+    sources: ["github", "linear"],
+    repos: null,
+    seqAttr: "catalyst.cloud.event.seq",
+    ignoreAttrs: [],
+    markerPrefix: DEFAULT_MARKER_PREFIX,
+    seqChecks: true,
+    seqLedgerComplete: false,
+    expectFirstSeq: null, expectHeadSeq: null, requireCoverage: false,
+    allowVersionSpan: false, allowPartialOverlap: false,
+    strictShadowOnly: false, strictKnownGaps: false, strictAttrs: false,
+    tolerateTornTail: false,
+    maxList: 25,
+    json: false, selfTest: false, help: false,
+  };
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (BOOL_FLAGS.has(a)) {
+      if (a === "--json") o.json = true;
+      else if (a === "--self-test") o.selfTest = true;
+      else if (a === "--help" || a === "-h") o.help = true;
+      else if (a === "--no-seq-checks") o.seqChecks = false;
+      else if (a === "--seq-ledger-complete") o.seqLedgerComplete = true;
+      else if (a === "--require-coverage") o.requireCoverage = true;
+      else if (a === "--allow-version-span") o.allowVersionSpan = true;
+      else if (a === "--allow-partial-overlap") o.allowPartialOverlap = true;
+      else if (a === "--strict-shadow-only") o.strictShadowOnly = true;
+      else if (a === "--strict-known-gaps") o.strictKnownGaps = true;
+      else if (a === "--strict-attrs") o.strictAttrs = true;
+      else if (a === "--tolerate-torn-tail") o.tolerateTornTail = true;
+      continue;
+    }
+    if (!FLAGS_WITH_VALUE.has(a)) {
+      return { ok: false, reason: `unknown argument: ${a} (run --help)` };
+    }
+    const v = argv[i + 1];
+    if (v === undefined || v.startsWith("--")) return { ok: false, reason: `${a} requires a value` };
+    i++;
+    switch (a) {
+      case "--live": o.live.push(v); break;
+      case "--shadow": o.shadow.push(v); break;
+      case "--live-dir": o.liveDir = v; break;
+      case "--shadow-dir": o.shadowDir = v; break;
+      case "--from": {
+        const p = parseIsoStrict(v);
+        if (!p.ok) return { ok: false, reason: `--from ${p.reason}` };
+        o.fromIso = v; o.fromMs = p.ms; break;
+      }
+      case "--to": {
+        const p = parseIsoStrict(v);
+        if (!p.ok) return { ok: false, reason: `--to ${p.reason}` };
+        o.toIso = v; o.toMs = p.ms; break;
+      }
+      case "--edge-margin": {
+        const p = parseIntStrict(v);
+        if (!p.ok) return { ok: false, reason: `--edge-margin ${p.reason}` };
+        o.edgeMarginMs = p.value * 1000; break;
+      }
+      case "--sources": {
+        const parts = v.split(",").map((s) => s.trim()).filter((s) => s.length > 0);
+        if (parts.length === 0) return { ok: false, reason: "--sources is empty" };
+        for (const s of parts) {
+          if (s !== "github" && s !== "linear") {
+            return { ok: false, reason: `--sources: unknown source ${JSON.stringify(s)} (github|linear)` };
+          }
+        }
+        o.sources = parts; break;
+      }
+      case "--repos": {
+        const parts = v.split(",").map((s) => s.trim()).filter((s) => s.length > 0);
+        if (parts.length === 0) return { ok: false, reason: "--repos is empty" };
+        o.repos = parts; break;
+      }
+      case "--seq-attr": {
+        // An empty key would make seqOf() read attributes[""] on every envelope and
+        // report "no seqs" — a silently disabled subsystem, not a configuration.
+        if (v.trim().length === 0) return { ok: false, reason: "--seq-attr is empty" };
+        o.seqAttr = v; break;
+      }
+      case "--ignore-attr": o.ignoreAttrs.push(v); break;
+      case "--marker-prefix": {
+        // An empty prefix makes marker detection a total no-op: the consumer's own
+        // coverage declarations fall through to the "unrelated noise" counter and a
+        // window the consumer declared INCOMPLETE reports healthy.
+        if (v.trim().length === 0) return { ok: false, reason: "--marker-prefix is empty — that would disable marker detection entirely" };
+        o.markerPrefix = v; break;
+      }
+      case "--expect-first-seq": {
+        const p = parseIntStrict(v);
+        if (!p.ok) return { ok: false, reason: `--expect-first-seq ${p.reason}` };
+        o.expectFirstSeq = p.value; break;
+      }
+      case "--expect-head-seq": {
+        const p = parseIntStrict(v);
+        if (!p.ok) return { ok: false, reason: `--expect-head-seq ${p.reason}` };
+        o.expectHeadSeq = p.value; break;
+      }
+      case "--max-list": {
+        const p = parseIntStrict(v);
+        if (!p.ok) return { ok: false, reason: `--max-list ${p.reason}` };
+        o.maxList = p.value; break;
+      }
+    }
+  }
+  if (o.fromMs !== null && o.toMs !== null && o.fromMs > o.toMs) {
+    return { ok: false, reason: `--from (${o.fromIso}) is after --to (${o.toIso})` };
+  }
+  return { ok: true, opts: o };
+}
+
+// ── record classification ───────────────────────────────────────────────────────────────
+
+/**
+ * A cloud-feed CONTROL RECORD: a line carrying `error` and NO `seq`
+ * (e.g. {"error":"cursor_underflow","resync":true}). Structural discrimination is the
+ * contract — provider JSON always nests under `payload`, so a provider body with its own
+ * `error` key surfaces at `payload.error` and cannot collide.
+ */
+export function isControlRecord(obj) {
+  return (
+    typeof obj === "object" && obj !== null && !Array.isArray(obj) &&
+    Object.hasOwn(obj, "error") && !Object.hasOwn(obj, "seq")
+  );
+}
+
+/** v2 envelope -> "github" | "linear" | null (the prefix of attributes["event.name"]). */
+export function envelopeSource(obj) {
+  const attrs = obj?.attributes;
+  if (typeof attrs !== "object" || attrs === null) return null;
+  const name = attrs["event.name"];
+  if (typeof name !== "string") return null;
+  const dot = name.indexOf(".");
+  if (dot <= 0) return null;
+  const prefix = name.slice(0, dot);
+  return prefix === "github" || prefix === "linear" ? prefix : null;
+}
+
+export function deliveryIdOf(obj) {
+  const v = obj?.attributes?.["webhook.delivery.id"];
+  return typeof v === "string" && v.length > 0 ? v : null;
+}
+
+export function eventNameOf(obj) {
+  const v = obj?.attributes?.["event.name"];
+  return typeof v === "string" ? v : "(missing event.name)";
+}
+
+export function repoOf(obj) {
+  const v = obj?.attributes?.["vcs.repository.name"];
+  return typeof v === "string" && v.length > 0 ? v : "(none)";
+}
+
+/** Read the cloud seq the consumer stamped on a shadow envelope. Strict: integers only. */
+export function seqOf(obj, seqAttr) {
+  const v = obj?.attributes?.[seqAttr];
+  if (typeof v === "number") return Number.isSafeInteger(v) ? { ok: true, seq: v } : { ok: false, raw: v };
+  if (typeof v === "string") {
+    const p = parseIntStrict(v);
+    return p.ok ? { ok: true, seq: p.value } : { ok: false, raw: v };
+  }
+  return { ok: null }; // absent
+}
+
+// ── JSONL ingestion ─────────────────────────────────────────────────────────────────────
+
+/**
+ * Fold one JSONL line into a side's accumulator. Kept pure and line-at-a-time so the file
+ * reader can STREAM (the live log is ~330MB; a whole-file readFileSync is the documented
+ * cause of multi-second event-loop stalls elsewhere in this repo).
+ */
+export function ingestLine(acc, rawLine, lineNo, file, opts) {
+  acc.lines++;
+  const line = rawLine.trim();
+  if (line.length === 0) { acc.blank++; return; }
+  // Tracked so the --tolerate-torn-tail waiver means "the last line WITH CONTENT" identically
+  // for the streaming file reader (no trailing empty element) and for ingestText (which yields
+  // one). Comparing against the raw line count would silently change what the waiver covers.
+  acc.lastContentLineNo = lineNo;
+  let obj;
+  try {
+    obj = JSON.parse(line);
+  } catch (err) {
+    acc.malformed.push({ file, lineNo, reason: err instanceof Error ? err.message : String(err) });
+    return;
+  }
+  if (isControlRecord(obj)) {
+    acc.control.push({ file, lineNo, record: obj });
+    return;
+  }
+  if (typeof obj !== "object" || obj === null || Array.isArray(obj)) {
+    acc.malformed.push({ file, lineNo, reason: "line is not a JSON object" });
+    return;
+  }
+  // Marker records first: they are consumer DECLARATIONS about coverage, not events, and are
+  // not source-prefixed — so classifying by source would file them under "unrelated noise".
+  // The BUILT-IN prefix is a floor that no flag can lower: re-pointing (or
+  // emptying) --marker-prefix must never make a consumer coverage declaration
+  // invisible. --marker-prefix only ever ADDS a second prefix to watch.
+  const rawName = obj?.attributes?.["event.name"];
+  if (
+    typeof rawName === "string" &&
+    (rawName.startsWith(DEFAULT_MARKER_PREFIX) ||
+      (opts.markerPrefix.length > 0 && rawName.startsWith(opts.markerPrefix)))
+  ) {
+    const mTs = parseIsoStrict(obj.ts);
+    acc.markers.push({
+      file, lineNo, name: rawName, kind: MARKER_KINDS[rawName] ?? "unknown",
+      deliveryId: deliveryIdOf(obj), ts: mTs.ok ? mTs.ms : null,
+      // A marker whose ts cannot be parsed is treated as IN window: a declaration we cannot
+      // place must not be silently excluded from the window it might belong to.
+      inWindow: !mTs.ok || ((opts.fromMs === null || mTs.ms >= opts.fromMs) && (opts.toMs === null || mTs.ms <= opts.toMs)),
+      raw: obj,
+    });
+    return;
+  }
+
+  const source = envelopeSource(obj);
+  if (source === null) { acc.nonWebhook++; return; }
+  acc.webhookTotal++;
+
+  const fileOrderIndex = acc.all.length;
+  const tsParsed = parseIsoStrict(obj.ts);
+  if (!tsParsed.ok) {
+    acc.badTs.push({ file, lineNo, reason: tsParsed.reason });
+    // Still recorded in file order so seq adjacency is not silently re-stitched around it.
+    acc.all.push({ file, lineNo, fileOrderIndex, obj, source, ts: null, inWindow: false });
+    return;
+  }
+  const entry = { file, lineNo, fileOrderIndex, obj, source, ts: tsParsed.ms, inWindow: false };
+
+  const afterFrom = opts.fromMs === null || tsParsed.ms >= opts.fromMs;
+  const beforeTo = opts.toMs === null || tsParsed.ms <= opts.toMs;
+  entry.inWindow = afterFrom && beforeTo;
+  acc.all.push(entry);
+  if (!entry.inWindow) { acc.outOfWindow++; return; }
+
+  // --repos scopes GitHub only: linear envelopes carry vcs.repository.name only when the
+  // monitor's teamsMap resolved it, so filtering them on repo would silently drop events.
+  if (opts.repos !== null && source === "github" && !opts.repos.includes(repoOf(obj))) {
+    acc.repoFiltered++;
+    return;
+  }
+  if (!opts.sources.includes(source)) { acc.sourceFiltered++; return; }
+
+  const version = obj?.resource?.["service.version"];
+  if (typeof version === "string") acc.versions.add(version);
+  const host = obj?.resource?.["host.name"];
+  if (typeof host === "string") acc.hosts.add(host);
+
+  const id = deliveryIdOf(obj);
+  if (id === null) {
+    acc.missingDeliveryId.push({ file, lineNo, eventName: eventNameOf(obj), ts: obj.ts });
+    return;
+  }
+  entry.deliveryId = id;
+  acc.selected.push(entry);
+}
+
+export function newSideAcc(label) {
+  return {
+    label, files: [],
+    lines: 0, blank: 0, nonWebhook: 0, webhookTotal: 0, lastContentLineNo: 0,
+    outOfWindow: 0, repoFiltered: 0, sourceFiltered: 0,
+    malformed: [], control: [], badTs: [], missingDeliveryId: [], markers: [],
+    versions: new Set(), hosts: new Set(),
+    all: [], selected: [],
+  };
+}
+
+/** Ingest an in-memory JSONL string. Used by the unit tests and the offline self-test. */
+export function ingestText(label, text, opts, file = "<memory>") {
+  const acc = newSideAcc(label);
+  acc.files.push(file);
+  const lines = text.split("\n");
+  // A trailing newline yields a final empty element — that is a blank line, not a torn line.
+  for (let i = 0; i < lines.length; i++) ingestLine(acc, lines[i], i + 1, file, opts);
+  return acc;
+}
+
+/** Stream a JSONL file into an accumulator (bounded memory over the compared subset). */
+export async function ingestFile(acc, file, opts) {
+  acc.files.push(file);
+  const rl = createInterface({ input: createReadStream(file, { encoding: "utf8" }), crlfDelay: Infinity });
+  let lineNo = 0;
+  for await (const line of rl) ingestLine(acc, line, ++lineNo, file, opts);
+}
+
+/** Month files (YYYY-MM.jsonl) covering the window; current month when unbounded. */
+export function monthFilesFor(dir, fromMs, toMs) {
+  const start = new Date(fromMs ?? Date.now());
+  const end = new Date(toMs ?? Date.now());
+  const out = [];
+  let y = start.getUTCFullYear();
+  let m = start.getUTCMonth();
+  const endY = end.getUTCFullYear();
+  const endM = end.getUTCMonth();
+  // Guard against an absurd window silently generating thousands of paths.
+  for (let guard = 0; guard < 240; guard++) {
+    out.push(join(dir, `${y}-${String(m + 1).padStart(2, "0")}.jsonl`));
+    if (y === endY && m === endM) break;
+    if (y > endY || (y === endY && m > endM)) break;
+    m++;
+    if (m > 11) { m = 0; y++; }
+  }
+  return out;
+}
+
+// ── join + comparison primitives (pure; unit-tested) ────────────────────────────────────
+
+/** Index selected entries by delivery id, in FILE ORDER. Duplicates are recorded, not merged. */
+export function indexByDelivery(selected) {
+  const byId = new Map();
+  const duplicates = [];
+  for (const e of selected) {
+    const prior = byId.get(e.deliveryId);
+    if (prior === undefined) byId.set(e.deliveryId, e);
+    else duplicates.push({ deliveryId: e.deliveryId, firstLine: prior.lineNo, dupLine: e.lineNo, eventName: eventNameOf(e.obj) });
+  }
+  return { byId, duplicates };
+}
+
+/** Join two id-indexes. No sorting anywhere. */
+export function joinDeliveries(liveById, shadowById) {
+  const matched = [];
+  const liveOnly = [];
+  for (const [id, live] of liveById) {
+    const shadow = shadowById.get(id);
+    if (shadow === undefined) liveOnly.push(live);
+    else matched.push({ id, live, shadow });
+  }
+  const shadowOnly = [];
+  for (const [id, shadow] of shadowById) if (!liveById.has(id)) shadowOnly.push(shadow);
+  return { matched, liveOnly, shadowOnly };
+}
+
+export function countBySource(entries, keyFn = (e) => e.source) {
+  const out = { github: 0, linear: 0 };
+  for (const e of entries) {
+    const k = keyFn(e);
+    if (k === "github" || k === "linear") out[k]++;
+  }
+  return out;
+}
+
+/** Per-type counts keyed on attributes["event.name"] — counts, never presence. */
+export function perTypeCounts(entries) {
+  const m = new Map();
+  for (const e of entries) {
+    const n = eventNameOf(e.obj);
+    m.set(n, (m.get(n) ?? 0) + 1);
+  }
+  return m;
+}
+
+export function censusExpectationFor(eventName, census = DEFAULT_TYPE_CENSUS) {
+  for (const row of census) {
+    if (eventName.startsWith(row.prefix)) return row;
+  }
+  return { prefix: null, expectation: "uncensused" };
+}
+
+/**
+ * Gate B input. Every type seen on EITHER side, plus explicit expected-zero rows for every
+ * censused prefix that produced nothing and for every unmappable provider type.
+ * Verdicts: deficit (live > shadow, censused "both"/"cloud-only"/"uncensused") is a FAIL
+ * candidate; known-gap deficits are reported against their ticket; shadow > live is the
+ * expected cloud superset.
+ */
+export function compareTypeCounts(liveCounts, shadowCounts, census = DEFAULT_TYPE_CENSUS, attributedByType = new Map()) {
+  const rows = [];
+  const seen = new Set([...liveCounts.keys(), ...shadowCounts.keys()]);
+  for (const type of seen) {
+    const live = liveCounts.get(type) ?? 0;
+    const shadow = shadowCounts.get(type) ?? 0;
+    // RAW counts stay in the row (they are the Gate B evidence and are never rewritten). The
+    // deficit VERDICT discounts deliveries the consumer explicitly attributed to an elision
+    // marker — otherwise an already-accounted-for >96KB payload reads as an unexplained loss.
+    const attributed = attributedByType.get(type) ?? 0;
+    const effectiveLive = live - attributed;
+    const c = censusExpectationFor(type, census);
+    let verdict;
+    if (effectiveLive > shadow) verdict = c.expectation === "known-gap" ? "known-gap-deficit" : "shadow-deficit";
+    else if (shadow > live) {
+      // The shadow>live direction is classified against the CENSUS, never against
+      // presence. Only a `cloud-only` row is the expected superset; for a row the
+      // census says BOTH sides carry, shadow>live is a LIVE-side loss — and
+      // live===0 is a TOTAL live-side loss, which is exactly the shape a
+      // presence-based split ("live has no key for this type, so it must be
+      // superset") mislabels as expected.
+      verdict =
+        c.expectation === "cloud-only"
+          ? "cloud-superset"
+          : live === 0
+            ? "live-total-loss"
+            : "live-deficit";
+    } else verdict = live === 0 ? "expected-zero" : attributed > 0 ? "equal-after-attribution" : "equal";
+    rows.push({ type, live, shadow, attributedElided: attributed, expectation: c.expectation, ticket: c.ticket ?? null, verdict });
+  }
+  // Censused prefixes that produced NOTHING on either side: printed as expected-zero rows.
+  // An omitted row is indistinguishable from nobody looking.
+  for (const row of census) {
+    const anySeen = [...seen].some((t) => t.startsWith(row.prefix));
+    if (!anySeen) {
+      rows.push({
+        type: `${row.prefix}*`, live: 0, shadow: 0, attributedElided: 0,
+        expectation: row.expectation, ticket: row.ticket ?? null, verdict: "expected-zero",
+      });
+    }
+  }
+  for (const u of UNMAPPABLE_PROVIDER_TYPES) {
+    rows.push({
+      type: `${u.type} (provider type, ${u.source})`, live: 0, shadow: 0, attributedElided: 0,
+      expectation: "unmappable", ticket: null, verdict: "expected-zero-structural", note: u.note,
+    });
+  }
+  // Alphabetical row order is PRESENTATION of counts. Adjacency evidence (seq) is never sorted.
+  rows.sort((a, b) => (a.type < b.type ? -1 : a.type > b.type ? 1 : 0));
+  return rows;
+}
+
+const STABLE_ENVELOPE_FIELDS = ["severityText"];
+
+/**
+ * Envelope equivalence for one matched pair. Returns a list of typed differences.
+ *
+ * `ignoreAttrs` holds TRANSPORT annotations the shadow consumer stamps that the smee path
+ * structurally cannot have (the cloud seq, and anything the operator declares via
+ * --ignore-attr). Everything else is compared strictly: an unexpected consumer-added
+ * attribute SHOULD surface as a difference rather than be quietly tolerated.
+ */
+export function compareEnvelope(live, shadow, { strictAttrs = false, ignoreAttrs = new Set() } = {}) {
+  const diffs = [];
+  for (const f of STABLE_ENVELOPE_FIELDS) {
+    if (live?.[f] !== shadow?.[f]) {
+      diffs.push({ field: f, live: live?.[f] ?? null, shadow: shadow?.[f] ?? null, class: "core" });
+    }
+  }
+  const la = live?.attributes ?? {};
+  const sa = shadow?.attributes ?? {};
+  const keys = new Set([...Object.keys(la), ...Object.keys(sa)]);
+  for (const k of keys) {
+    if (ignoreAttrs.has(k)) continue;
+    const lv = Object.hasOwn(la, k) ? la[k] : undefined;
+    const sv = Object.hasOwn(sa, k) ? sa[k] : undefined;
+    if (JSON.stringify(lv) === JSON.stringify(sv)) continue;
+    const presenceOnly = lv === undefined || sv === undefined;
+    const enrichment = ATTR_LOCAL_ENRICHMENT.has(k) && presenceOnly && !strictAttrs;
+    diffs.push({
+      field: `attributes.${k}`,
+      live: lv === undefined ? null : lv,
+      shadow: sv === undefined ? null : sv,
+      class: enrichment ? "local-enrichment-presence" : "core",
+    });
+  }
+  return diffs;
+}
+
+/**
+ * Wire-order adjacency over a seq stream. NEVER sorts (rule 4).
+ * `descents` = ordering violations; `gaps` = missing seqs. Two independent properties.
+ * NOTE: `ts` inversions are EXPECTED (seq is commit order, ts is receipt order) and are
+ * deliberately not checked here.
+ */
+export function checkSeqAdjacency(seqEntries) {
+  const descents = [];
+  const gaps = [];
+  for (let i = 1; i < seqEntries.length; i++) {
+    const prev = seqEntries[i - 1];
+    const cur = seqEntries[i];
+    if (cur.seq <= prev.seq) {
+      descents.push({ prev: prev.seq, cur: cur.seq, prevLine: prev.lineNo, curLine: cur.lineNo });
+      continue; // a descent already invalidates the adjacency; do not also call it a gap
+    }
+    if (cur.seq !== prev.seq + 1) {
+      gaps.push({ after: prev.seq, before: cur.seq, missing: cur.seq - prev.seq - 1, curLine: cur.lineNo });
+    }
+  }
+  return { descents, gaps };
+}
+
+/**
+ * The file-order span of shadow envelopes that brackets the window.
+ *
+ * Seq adjacency MUST NOT be computed over the ts-filtered subset: seq is assigned in COMMIT
+ * order while ts is receipt order, so ts filtering can exclude an interior seq and manufacture
+ * a gap that does not exist. We take the contiguous file-order slice between the first and
+ * last in-window envelopes instead.
+ */
+export function windowSpanSlice(all) {
+  let first = -1;
+  let last = -1;
+  for (let i = 0; i < all.length; i++) {
+    if (!all[i].inWindow) continue;
+    if (first === -1) first = i;
+    last = i;
+  }
+  if (first === -1) return [];
+  return all.slice(first, last + 1);
+}
+
+// ── the evaluation ──────────────────────────────────────────────────────────────────────
+
+function check(id, status, title, detail, evidence) {
+  return { id, status, title, detail, ...(evidence === undefined ? {} : { evidence }) };
+}
+
+function fmtEntry(e) {
+  return {
+    deliveryId: e.deliveryId ?? null,
+    eventName: eventNameOf(e.obj),
+    repo: repoOf(e.obj),
+    ts: e.obj?.ts ?? null,
+    source: e.source,
+    file: e.file,
+    line: e.lineNo,
+  };
+}
+
+function capList(arr, cap) {
+  return arr.length <= cap ? { items: arr, truncated: false, total: arr.length }
+    : { items: arr.slice(0, cap), truncated: true, total: arr.length };
+}
+
+/**
+ * Evaluate parity from two ingested sides. Pure: no IO, no clock dependence beyond the
+ * generatedAt stamp the caller supplies.
+ *
+ * Returns a report whose `verdict` is one of "healthy" | "problem" | "cannot_evaluate".
+ * Blockers (things that make the run non-evaluable) short-circuit EVERY assertion to
+ * status "not_run" — a check that did not run is never reported as a pass.
+ */
+export function evaluate({ live, shadow, opts, generatedAt = new Date().toISOString() }) {
+  const blockers = [];
+  const waivers = [];
+  const notAsserted = [];
+  const checks = [];
+
+  // ── evaluability gates ────────────────────────────────────────────────────────────────
+  for (const side of [live, shadow]) {
+    // A malformed line means the evidence is not trustworthy. A single torn FINAL line is the
+    // classic concurrent-append artifact and can be waived explicitly, nothing else.
+    const torn = side.malformed.filter((m) => opts.tolerateTornTail && m.lineNo === side.lastContentLineNo);
+    const fatal = side.malformed.filter((m) => !torn.includes(m));
+    if (torn.length > 0) {
+      waivers.push(`${side.label}: ${torn.length} torn final line(s) waived by --tolerate-torn-tail`);
+    }
+    if (fatal.length > 0) {
+      blockers.push({
+        id: "MALFORMED_INPUT",
+        detail: `${side.label}: ${fatal.length} unparseable line(s)`,
+        evidence: capList(fatal, opts.maxList),
+      });
+    }
+    if (side.control.length > 0) {
+      blockers.push({
+        id: "CONTROL_RECORD",
+        detail: `${side.label}: ${side.control.length} control record(s) — the feed declared this scan INCOMPLETE. The prefix before a control record is internally contiguous, so contiguity would have passed a server-declared short read.`,
+        evidence: capList(side.control, opts.maxList),
+      });
+    }
+    if (side.badTs.length > 0) {
+      blockers.push({
+        id: "UNPARSEABLE_TS",
+        detail: `${side.label}: ${side.badTs.length} envelope(s) with an unparseable ts — cannot be placed in the window`,
+        evidence: capList(side.badTs, opts.maxList),
+      });
+    }
+    if (side.missingDeliveryId.length > 0) {
+      blockers.push({
+        id: "MISSING_JOIN_KEY",
+        detail: `${side.label}: ${side.missingDeliveryId.length} in-window webhook envelope(s) carry no attributes["webhook.delivery.id"]. The join would silently under-match. Most likely the window predates the CTL-1532 deploy — move --from after it.`,
+        evidence: capList(side.missingDeliveryId, opts.maxList),
+      });
+    }
+    // NOTE: input existence is checked by the CLI before ingestion (INPUT_MISSING). `evaluate`
+    // is deliberately pure — no filesystem access — so the self-test and unit tests exercise
+    // exactly the code path a real run takes.
+    if (side.versions.size > 1) {
+      const msg = `${side.label}: window spans ${side.versions.size} producer versions (${[...side.versions].join(", ")}) — a window that crosses a deploy/config change produces a confidently wrong number in whichever direction the change went`;
+      if (opts.allowVersionSpan) waivers.push(`${msg} [waived by --allow-version-span]`);
+      else blockers.push({ id: "DEPLOY_BOUNDARY", detail: msg, evidence: [...side.versions] });
+    }
+    if (side.hosts.size > 1) {
+      blockers.push({
+        id: "MIXED_HOSTS",
+        detail: `${side.label}: envelopes from ${side.hosts.size} hosts (${[...side.hosts].join(", ")}) — parity is per-host; a mixed log compares two different producers`,
+        evidence: [...side.hosts],
+      });
+    }
+  }
+
+  const liveSel = live.selected;
+  const shadowSel = shadow.selected;
+
+  // Shadow-log markers: the consumer's own declarations about its coverage.
+  const markers = [...live.markers, ...shadow.markers].filter((m) => m.inWindow);
+  const gapMarkers = markers.filter((m) => m.kind === "gap");
+  const unknownMarkers = markers.filter((m) => m.kind === "unknown");
+  const elidedMarkers = markers.filter((m) => m.kind === "elided");
+  if (gapMarkers.length > 0) {
+    blockers.push({
+      id: "FEED_GAP_DECLARED",
+      detail: `${gapMarkers.length} feed-gap marker(s) in the window — the CONSUMER declared its own coverage incomplete. Same class as a control record: the surviving records are internally consistent, so every assertion below would have passed on a window that is known to be missing data.`,
+      evidence: capList(gapMarkers.map((m) => ({ name: m.name, ts: m.raw?.ts ?? null, line: m.lineNo, file: m.file })), opts.maxList),
+    });
+  }
+  // An elision marker is a self-declaration by the component under test that
+  // SUPPRESSES a MISSING_FROM_SHADOW row and DISCOUNTS a per-type deficit. It may only
+  // do that if it corroborates itself against the documented elision shape: an
+  // attributable delivery id, reason "payloadOmitted", and a payload actually over the
+  // 96KB edge cap. Anything else (a consumer bug reusing the elision path, a cloud
+  // regression stamping payloadOmitted on records it failed to store) would convert
+  // arbitrary data loss into a green run, so it is NOT EVALUABLE.
+  const corroboratedElisions = elidedMarkers.filter(
+    (m) =>
+      m.deliveryId !== null &&
+      m.raw?.reason === "payloadOmitted" &&
+      typeof m.raw?.payloadBytes === "number" &&
+      Number.isFinite(m.raw.payloadBytes) &&
+      m.raw.payloadBytes >= PAYLOAD_CAP_BYTES,
+  );
+  const uncorroboratedElisions = elidedMarkers.filter((m) => !corroboratedElisions.includes(m));
+  if (uncorroboratedElisions.length > 0) {
+    blockers.push({
+      id: "UNCORROBORATED_ELISION",
+      detail: `${uncorroboratedElisions.length} elision marker(s) do not corroborate themselves (required: a webhook.delivery.id, reason "payloadOmitted", and a numeric payloadBytes >= ${PAYLOAD_CAP_BYTES} — the documented cloud edge cap). An elision marker suppresses a loss row and discounts a type deficit, so an unverified one lets the component under test excuse its own data loss.`,
+      evidence: capList(uncorroboratedElisions.map((m) => ({ deliveryId: m.deliveryId, reason: m.raw?.reason ?? null, payloadBytes: m.raw?.payloadBytes ?? null, line: m.lineNo, file: m.file })), opts.maxList),
+    });
+  }
+  if (unknownMarkers.length > 0) {
+    blockers.push({
+      id: "UNKNOWN_SHADOW_MARKER",
+      detail: `${unknownMarkers.length} marker(s) matching --marker-prefix that this harness does not recognise (${[...new Set(unknownMarkers.map((m) => m.name))].join(", ")}). A marker is a declaration the consumer made about its coverage; an unrecognised one must not be read as silence. Teach the harness (MARKER_KINDS) or re-point --marker-prefix.`,
+      evidence: capList(unknownMarkers.map((m) => ({ name: m.name, line: m.lineNo, file: m.file })), opts.maxList),
+    });
+  }
+
+  // Overlap gate: a window in which one side simply was not writing yet (or had stopped) is
+  // not a parity measurement — every non-overlapping delivery would read as a loss.
+  let overlapNote = null;
+  if (liveSel.length > 0 && shadowSel.length > 0) {
+    // MUST be min/max over ts, never first/last in file order: the shadow log is appended in
+    // cloud COMMIT order (seq), which is deliberately not receivedAt order, so its ts column
+    // is non-monotone by design. Reading position 0 as "earliest" is how a correct-looking
+    // gate produces a wrong answer on real data.
+    const { min: firstLive, max: lastLive } = tsBounds(liveSel);
+    const { min: firstShadow, max: lastShadow } = tsBounds(shadowSel);
+    const startSkew = Math.abs(firstShadow - firstLive);
+    const endSkew = Math.abs(lastShadow - lastLive);
+    if (startSkew > opts.edgeMarginMs || endSkew > opts.edgeMarginMs) {
+      const suggestFrom = new Date(Math.max(firstLive, firstShadow)).toISOString();
+      const suggestTo = new Date(Math.min(lastLive, lastShadow)).toISOString();
+      const msg = `sides do not cover the same interval (start skew ${Math.round(startSkew / 1000)}s, end skew ${Math.round(endSkew / 1000)}s). Either the window is wrong or one side had an outage — both look identical from here. Overlap is --from ${suggestFrom} --to ${suggestTo}`;
+      if (opts.allowPartialOverlap) { overlapNote = msg; waivers.push(`${msg} [waived by --allow-partial-overlap]`); }
+      else blockers.push({ id: "WINDOW_OVERLAP", detail: msg, evidence: { firstLive: new Date(firstLive).toISOString(), lastLive: new Date(lastLive).toISOString(), firstShadow: new Date(firstShadow).toISOString(), lastShadow: new Date(lastShadow).toISOString() } });
+    }
+  }
+
+  // Seq availability gate. This runs UNCONDITIONALLY — it is a PRODUCER CONTRACT
+  // check, not an operator preference. The consumer stamps `catalyst.cloud.event.seq`
+  // on every envelope; if a whole window carries none, the producer and this harness
+  // no longer agree on a field name and the ordering/coverage subsystem is reading
+  // an attribute nobody writes. --no-seq-checks waives the ASSERTIONS (a deliberate
+  // "I am not measuring ordering today"); it can never waive "the evidence this tool
+  // reads does not exist", because that renders three checks structurally
+  // unreachable while the run still prints green.
+  const shadowSpan = windowSpanSlice(shadow.all);
+  const seqEntries = [];
+  let seqAbsent = 0;
+  const seqInvalid = [];
+  for (const e of shadowSpan) {
+    const s = seqOf(e.obj, opts.seqAttr);
+    if (s.ok === null) { seqAbsent++; continue; }
+    if (s.ok === false) { seqInvalid.push({ line: e.lineNo, raw: s.raw }); continue; }
+    seqEntries.push({ seq: s.seq, lineNo: e.lineNo });
+  }
+  if (shadowSpan.length > 0 && seqEntries.length === 0) {
+    const hint = [...new Set(shadowSpan.flatMap((e) => Object.keys(e.obj?.attributes ?? {})).filter((k) => /(^|\.)seq$/.test(k)))];
+    blockers.push({
+      id: "SEQ_ATTR_ABSENT",
+      detail: `shadow envelopes carry no ${JSON.stringify(opts.seqAttr)} attribute, so feed ordering cannot be evaluated.${hint.length ? ` Candidate keys present: ${hint.join(", ")} (pass --seq-attr).` : ""} This is a PRODUCER CONTRACT break (cloud-event-consumer.mjs stamps SEQ_ATTR on every envelope) and --no-seq-checks does NOT waive it: waiving would turn SEQ_WIRE_ORDER/SEQ_CONTIGUITY/SEQ_COVERAGE into three questions that can never be asked, under a green verdict. Fix the producer or re-point --seq-attr.`,
+      evidence: { seqAttr: opts.seqAttr, envelopesInSpan: shadowSpan.length, candidates: hint, waivableByNoSeqChecks: false },
+    });
+  } else if (seqAbsent > 0 && seqEntries.length > 0) {
+    blockers.push({
+      id: "SEQ_ATTR_PARTIAL",
+      detail: `shadow: ${seqAbsent} of ${shadowSpan.length} envelopes in the window span carry no ${opts.seqAttr} — a partially-stamped log cannot be ordered`,
+      evidence: { absent: seqAbsent, present: seqEntries.length },
+    });
+  }
+  if (seqInvalid.length > 0) {
+    blockers.push({ id: "SEQ_ATTR_INVALID", detail: `shadow: ${seqInvalid.length} non-integer ${opts.seqAttr} value(s)`, evidence: capList(seqInvalid, opts.maxList) });
+  }
+  if (!opts.seqChecks) {
+    waivers.push("seq integrity checks WAIVED by --no-seq-checks (feed ordering NOT evaluated here)");
+    notAsserted.push({ id: "SEQ_WIRE_ORDER", reason: "--no-seq-checks" });
+    notAsserted.push({ id: "SEQ_CONTIGUITY", reason: "--no-seq-checks" });
+    notAsserted.push({ id: "SEQ_COVERAGE", reason: "--no-seq-checks" });
+  }
+
+  // --require-coverage means "exit 2 unless coverage was actually ASSERTED". It used
+  // to guard only ONE of the three ways coverage ends up unasserted, so the operator
+  // could supply the cursor and the head, describe a short read, and still be told
+  // HEALTHY because the answer had quietly been demoted to `notAsserted` (which does
+  // not touch the verdict).
+  if (opts.requireCoverage) {
+    const missing = [];
+    if (opts.expectFirstSeq === null) missing.push("--expect-first-seq");
+    if (opts.expectHeadSeq === null) missing.push("--expect-head-seq");
+    if (!opts.seqLedgerComplete) missing.push("--seq-ledger-complete (SEQ_COVERAGE is gated behind it)");
+    if (!opts.seqChecks) missing.push("seq checks are waived by --no-seq-checks");
+    if (missing.length > 0) {
+      blockers.push({
+        id: "COVERAGE_REQUIRED",
+        detail: `--require-coverage was passed but coverage cannot be asserted: missing ${missing.join(", ")}. A demoted-to-not-asserted coverage question is NOT a coverage pass.`,
+        evidence: { missing },
+      });
+    }
+  }
+
+  // Window gates. The edge margin exists to forgive one-sided deliveries near a
+  // boundary — but a margin anchored to the DATA BEING JUDGED, or one wider than
+  // half the window, silently excludes every candidate from BOTH loss detectors,
+  // which then pass having examined nothing.
+  if (opts.edgeMarginMs > 0 && (opts.fromMs === null || opts.toMs === null)) {
+    blockers.push({
+      id: "UNBOUNDED_WINDOW",
+      detail: `--edge-margin is ${opts.edgeMarginMs / 1000}s but the window is unbounded (${opts.fromMs === null ? "--from" : "--to"} missing). Deriving the boundary from the data under test makes the earliest and latest deliveries permanently un-checkable, and for any burst shorter than 2× the margin it excludes EVERY delivery from MISSING_FROM_SHADOW and SHADOW_ONLY. Pass --from/--to, or --edge-margin 0.`,
+      evidence: { from: opts.fromIso, to: opts.toIso, edgeMarginSeconds: opts.edgeMarginMs / 1000 },
+    });
+  }
+  if (opts.edgeMarginMs > 0 && opts.fromMs !== null && opts.toMs !== null && 2 * opts.edgeMarginMs >= opts.toMs - opts.fromMs) {
+    blockers.push({
+      id: "EDGE_MARGIN_SWALLOWS_WINDOW",
+      detail: `the edge margin (2 × ${opts.edgeMarginMs / 1000}s) covers the whole window (${Math.round((opts.toMs - opts.fromMs) / 1000)}s), so every delivery would be edge-excluded and both loss detectors would pass having examined ZERO deliveries. Widen the window or lower --edge-margin.`,
+      evidence: { windowSeconds: (opts.toMs - opts.fromMs) / 1000, edgeMarginSeconds: opts.edgeMarginMs / 1000 },
+    });
+  }
+
+  // Rule 10: a source scoped out by --sources is an UNANSWERED question, not an
+  // absent one. Without this the report simply has no row for it.
+  for (const s of ["github", "linear"]) {
+    if (!opts.sources.includes(s)) {
+      notAsserted.push({ id: `MATCHED_NONZERO_${s}`, reason: `excluded by --sources ${opts.sources.join(",")} — the ${s} half of the cutover was NOT measured by this run` });
+    }
+  }
+
+  const scanned = {
+    live: sideStats(live),
+    shadow: sideStats(shadow),
+  };
+  const markerSummary = markers.map((m) => ({ name: m.name, kind: m.kind, deliveryId: m.deliveryId, ts: m.raw?.ts ?? null, file: m.file, line: m.lineNo }));
+
+  if (blockers.length > 0) {
+    // Every assertion is reported as not_run. This is the single most important branch in the
+    // file: a run that could not evaluate never emits a pass, and never exits 0.
+    for (const id of [
+      ...opts.sources.map((s) => `MATCHED_NONZERO_${s}`),
+      "ELIDED_PAYLOADS", "MISSING_FROM_SHADOW", "KNOWN_GAP_LOSSES", "SHADOW_ONLY", "DUPLICATE_DELIVERY_SHADOW",
+      "TYPE_COUNTS", "LIVE_DEFICIT_TYPES", "ENVELOPE_EQUIVALENCE", "SEQ_WIRE_ORDER",
+    ]) {
+      checks.push(check(id, "not_run", id, "not evaluated — the run is not evaluable (see blockers)"));
+    }
+    return finalize({ generatedAt, opts, scanned, checks, blockers, waivers, notAsserted, typeRows: [], join: null, overlapNote, markers: markerSummary });
+  }
+
+  // ── assertions ────────────────────────────────────────────────────────────────────────
+  const liveIdx = indexByDelivery(liveSel);
+  const shadowIdx = indexByDelivery(shadowSel);
+  const { matched, liveOnly, shadowOnly } = joinDeliveries(liveIdx.byId, shadowIdx.byId);
+
+  // Rule 5: NON-ZERO matched pairs PER SOURCE. A zero-match join is indistinguishable from
+  // perfect parity if you only count mismatches.
+  const matchedBySource = countBySource(matched.map((m) => m.live));
+  for (const s of opts.sources) {
+    const n = matchedBySource[s] ?? 0;
+    checks.push(
+      n > 0
+        ? check(`MATCHED_NONZERO_${s}`, "pass", `matched pairs (${s})`, `${n} matched pair(s)`)
+        : check(`MATCHED_NONZERO_${s}`, "fail", `matched pairs (${s})`,
+            `ZERO matched pairs for ${s}. This is NOT parity — the join matched nothing. Check the consumer is running, the window covers real traffic, and both sides stamp webhook.delivery.id. For a quiet source, inject a synthetic event rather than reading zero as agreement.`,
+            { live: countBySource(liveSel)[s] ?? 0, shadow: countBySource(shadowSel)[s] ?? 0 })
+    );
+  }
+
+  // Edge classification: deliveries within the edge margin of a window boundary can legitimately
+  // land on one side only (the cloud runs ~12s ahead of smee). Counted and printed, never dropped.
+  //
+  // The bounds come ONLY from --from/--to. Deriving them from the data under test made the
+  // margin a function of the very evidence being judged (and the two gates above guarantee a
+  // non-zero margin has an explicit, wide-enough window). Unbounded + margin 0 => nothing is edge.
+  const effFrom = opts.fromMs ?? -Infinity;
+  const effTo = opts.toMs ?? Infinity;
+  const isEdge = (e) =>
+    opts.edgeMarginMs > 0 && (e.ts - effFrom < opts.edgeMarginMs || effTo - e.ts < opts.edgeMarginMs);
+
+  const liveOnlyEdge = liveOnly.filter(isEdge);
+  const liveOnlyInterior = liveOnly.filter((e) => !isEdge(e));
+  // A live-only delivery the consumer EXPLICITLY marked as elided (>96KB payloadOmitted) is an
+  // attributed gap, not a mystery — but only the CORROBORATED markers may attribute (see the
+  // UNCORROBORATED_ELISION gate above, which blocks the run outright).
+  const elidedIds = new Set(
+    corroboratedElisions.map((m) => m.deliveryId).filter((id) => id !== null),
+  );
+  const elidedLoss = liveOnlyInterior.filter((e) => elidedIds.has(e.deliveryId));
+  const knownGapDeficit = liveOnlyInterior.filter((e) => !elidedIds.has(e.deliveryId) && censusExpectationFor(eventNameOf(e.obj)).expectation === "known-gap");
+  const unexplainedLoss = liveOnlyInterior.filter((e) => !elidedLoss.includes(e) && !knownGapDeficit.includes(e));
+
+  // Always emitted, including at zero: the >96KB elision path has NEVER executed in production
+  // (0 of 1766 events at last count), so its first firing is something to LOOK AT — and an
+  // omitted row is indistinguishable from nobody looking.
+  checks.push(
+    elidedMarkers.length === 0
+      ? check("ELIDED_PAYLOADS", "pass", "payloadOmitted (>96KB) elision markers", "0 elision markers in window (this path has never fired in production — a first firing is expected-zero until it is not)")
+      // `warn` is NON-GREEN (see finalize): an elided delivery genuinely never reached
+      // the shadow log and the consumer itself grades it EXIT_PROBLEM. The two halves of
+      // this deliverable must not give opposite verdicts on the same event.
+      : check("ELIDED_PAYLOADS", "warn", "payloadOmitted (>96KB) elision markers",
+          `${elidedMarkers.length} elided delivery/deliveries — unmappable by construction, so each needs a SCOPED RECONCILE. ${elidedLoss.length} of them explain a live-only row here.`,
+          capList(elidedMarkers.map((m) => ({ deliveryId: m.deliveryId, source: m.raw?.source ?? null, eventType: m.raw?.eventType ?? null, payloadBytes: m.raw?.payloadBytes ?? null, identity: m.raw?.identity ?? null, line: m.lineNo })), opts.maxList))
+  );
+
+  // A detector that examined ZERO candidates because every one of them was edge-excluded
+  // did not run. Reporting that as `pass` is the "omitted row is indistinguishable from
+  // nobody looking" defect with a green tick on top.
+  const allLiveOnlyEdgeExcluded = liveOnly.length > 0 && liveOnlyInterior.length === 0;
+  checks.push(
+    allLiveOnlyEdgeExcluded
+      ? check("MISSING_FROM_SHADOW", "not_run", "deliveries present in live, absent from shadow",
+          `NOT RUN — all ${liveOnly.length} live-only delivery/deliveries were edge-excluded by --edge-margin ${opts.edgeMarginMs / 1000}s, so this detector examined ZERO candidates. A waived candidate is not evidence of parity: re-run with --edge-margin 0, or move --from/--to so they are interior.`,
+          { edgeExcluded: capList(liveOnly.map(fmtEntry), opts.maxList) })
+      : unexplainedLoss.length === 0
+      ? check("MISSING_FROM_SHADOW", "pass", "deliveries present in live, absent from shadow",
+          `0 interior unexplained (edge-excluded ${liveOnlyEdge.length}, known-gap ${knownGapDeficit.length}, elided ${elidedLoss.length})`)
+      : check("MISSING_FROM_SHADOW", "fail", "deliveries present in live, absent from shadow",
+          `${unexplainedLoss.length} interior live delivery/deliveries never reached the shadow log`,
+          { deliveries: capList(unexplainedLoss.map(fmtEntry), opts.maxList), byRepo: tally(unexplainedLoss, (e) => repoOf(e.obj)), byType: tally(unexplainedLoss, (e) => eventNameOf(e.obj)) })
+  );
+
+  // Emitted at zero too: a filed gap that stopped appearing is a result worth seeing, and an
+  // omitted row is indistinguishable from nobody looking.
+  checks.push(
+    knownGapDeficit.length === 0
+      ? check("KNOWN_GAP_LOSSES", "pass", "live-only deliveries attributable to a FILED cloud-side gap",
+          `0 in window (censused known gaps: ${DEFAULT_TYPE_CENSUS.filter((c) => c.expectation === "known-gap").map((c) => `${c.prefix}* [${c.ticket}]`).join(", ") || "none"})`)
+      : check("KNOWN_GAP_LOSSES", opts.strictKnownGaps ? "fail" : "warn",
+          "live-only deliveries attributable to a FILED cloud-side gap",
+          `${knownGapDeficit.length} delivery/deliveries match a known-gap census row (e.g. linear.reaction.* / CTC-297). Tracked, not new — but still a real gap that must close before phase 5.`,
+          { deliveries: capList(knownGapDeficit.map(fmtEntry), opts.maxList), byType: tally(knownGapDeficit, (e) => eventNameOf(e.obj)) })
+  );
+
+  // Shadow-only is the EXPECTED direction (the cloud is a superset: more types, more repos).
+  // Split it so a superset claim is never used to hide a smee-side drop of a type smee carries
+  // — and split it by the CENSUS, never by presence. A presence-based split
+  // (`liveTypeCounts.has(name)`) fails exactly when the live-side drop is TOTAL: with zero live
+  // rows of that type there is no key, so every shadow-only delivery of a type the census says
+  // BOTH sides carry was auto-labelled "expected cloud superset".
+  const liveTypeCounts = perTypeCounts(liveSel);
+  const shadowOnlyEdge = shadowOnly.filter(isEdge);
+  const shadowOnlyInterior = shadowOnly.filter((e) => !isEdge(e));
+  const isSupersetType = (e) => censusExpectationFor(eventNameOf(e.obj)).expectation === "cloud-only";
+  const shadowOnlySuperset = shadowOnlyInterior.filter(isSupersetType);
+  const shadowOnlyOverlapping = shadowOnlyInterior.filter((e) => !isSupersetType(e));
+  const allShadowOnlyEdgeExcluded = shadowOnly.length > 0 && shadowOnlyInterior.length === 0;
+  checks.push(
+    allShadowOnlyEdgeExcluded
+      ? check("SHADOW_ONLY", "not_run", "deliveries present in shadow, absent from live",
+          `NOT RUN — all ${shadowOnly.length} shadow-only delivery/deliveries were edge-excluded by --edge-margin ${opts.edgeMarginMs / 1000}s, so this detector examined ZERO candidates. Re-run with --edge-margin 0, or move --from/--to so they are interior.`,
+          { edgeExcluded: capList(shadowOnly.map(fmtEntry), opts.maxList) })
+      : shadowOnlyOverlapping.length === 0
+      ? check("SHADOW_ONLY", "pass", "deliveries present in shadow, absent from live",
+          `${shadowOnlySuperset.length} expected-superset (census: cloud-only), 0 non-superset (edge-excluded ${shadowOnlyEdge.length})`,
+          { supersetByType: tally(shadowOnlySuperset, (e) => eventNameOf(e.obj)) })
+      : check("SHADOW_ONLY", opts.strictShadowOnly ? "fail" : "warn",
+          "deliveries present in shadow, absent from live",
+          `${shadowOnlyOverlapping.length} shadow-only delivery/deliveries of a type the LIVE side also carries — that is a smee-side drop (the 14h32m GitHub tunnel outage had exactly this shape), not the cloud superset. ${shadowOnlySuperset.length} further shadow-only deliveries are expected superset.`,
+          { overlapping: capList(shadowOnlyOverlapping.map(fmtEntry), opts.maxList), byType: tally(shadowOnlyOverlapping, (e) => eventNameOf(e.obj)), supersetByType: tally(shadowOnlySuperset, (e) => eventNameOf(e.obj)) })
+  );
+
+  // Invariant 6: the consumer dedups on delivery_id. A duplicate on the shadow side is a
+  // dedup failure. A duplicate on the live side is a provider redelivery — reported, not failed.
+  checks.push(
+    shadowIdx.duplicates.length === 0
+      ? check("DUPLICATE_DELIVERY_SHADOW", "pass", "shadow dedup on delivery id", "0 duplicates")
+      : check("DUPLICATE_DELIVERY_SHADOW", "fail", "shadow dedup on delivery id",
+          `${shadowIdx.duplicates.length} delivery id(s) appear more than once in the shadow log — the consumer's dedup (invariant 6) is not holding`,
+          capList(shadowIdx.duplicates, opts.maxList))
+  );
+  if (liveIdx.duplicates.length > 0) {
+    // `info`, not `warn`: a provider redelivery is genuinely benign and this is the one
+    // observation that must not move the verdict (every `warn` below is a real loss).
+    checks.push(check("DUPLICATE_DELIVERY_LIVE", "info", "live-side duplicate delivery ids",
+      `${liveIdx.duplicates.length} duplicate(s) in the live log (provider redelivery or a monitor restart clearing the in-process dedup set). The FIRST occurrence was used for the join.`,
+      capList(liveIdx.duplicates, opts.maxList)));
+  }
+
+  // Rule 9: per-type COUNTS on both sides — the Gate B superset input.
+  const shadowTypeCounts = perTypeCounts(shadowSel);
+  const elidedByType = new Map(Object.entries(tally(elidedLoss, (e) => eventNameOf(e.obj))));
+  const typeRows = compareTypeCounts(liveTypeCounts, shadowTypeCounts, DEFAULT_TYPE_CENSUS, elidedByType);
+  const deficits = typeRows.filter((r) => r.verdict === "shadow-deficit");
+  checks.push(
+    deficits.length === 0
+      ? check("TYPE_COUNTS", "pass", "per-type counts (Gate B input)",
+          `no shadow deficit across ${typeRows.length} censused/observed type row(s)`)
+      : check("TYPE_COUNTS", "fail", "per-type counts (Gate B input)",
+          `${deficits.length} type(s) where the live count exceeds the shadow count`, deficits)
+  );
+
+  // The OTHER direction, classified against the census rather than by presence. A censused
+  // `both` type the LIVE side lost 100% of used to read as "cloud-superset" and pass — the
+  // exact shape of the 14h32m smee GitHub outage.
+  const liveTotalLoss = typeRows.filter((r) => r.verdict === "live-total-loss");
+  const liveDeficits = typeRows.filter((r) => r.verdict === "live-deficit");
+  checks.push(
+    liveTotalLoss.length === 0 && liveDeficits.length === 0
+      ? check("LIVE_DEFICIT_TYPES", "pass", "per-type counts, live side (smee-drop detector)",
+          "no censused type where the shadow count exceeds the live count")
+      : liveTotalLoss.length > 0
+        ? check("LIVE_DEFICIT_TYPES", "fail", "per-type counts, live side (smee-drop detector)",
+            `${liveTotalLoss.length} censused type(s) the LIVE side carries ZERO of while the shadow side carries some — a total live-side loss, not the cloud superset`,
+            [...liveTotalLoss, ...liveDeficits])
+        : check("LIVE_DEFICIT_TYPES", opts.strictShadowOnly ? "fail" : "warn", "per-type counts, live side (smee-drop detector)",
+            `${liveDeficits.length} censused type(s) where the shadow count exceeds the live count`,
+            liveDeficits)
+  );
+
+  // Envelope equivalence on matched pairs.
+  const pairDiffs = [];
+  let enrichmentOnlyPairs = 0;
+  // Declared exclusions: the configured seq attribute is a TRANSPORT annotation the smee side
+  // structurally cannot carry, plus anything the operator declared via --ignore-attr. Both are
+  // printed in the report's `policy` block — an undeclared exclusion is a hidden pass.
+  const ignoreAttrs = new Set([opts.seqAttr, ...opts.ignoreAttrs]);
+  for (const m of matched) {
+    const diffs = compareEnvelope(m.live.obj, m.shadow.obj, { strictAttrs: opts.strictAttrs, ignoreAttrs });
+    if (diffs.length === 0) continue;
+    const core = diffs.filter((d) => d.class === "core");
+    if (core.length === 0) { enrichmentOnlyPairs++; continue; }
+    pairDiffs.push({ deliveryId: m.id, source: m.live.source, liveEvent: eventNameOf(m.live.obj), shadowEvent: eventNameOf(m.shadow.obj), diffs: core, liveLine: m.live.lineNo, shadowLine: m.shadow.lineNo });
+  }
+  checks.push(
+    pairDiffs.length === 0
+      ? check("ENVELOPE_EQUIVALENCE", "pass", "envelope equivalence on matched pairs",
+          `${matched.length} pair(s) equivalent (${enrichmentOnlyPairs} differ only in locally-enriched attributes: ${[...ATTR_LOCAL_ENRICHMENT].join(", ")})`)
+      : check("ENVELOPE_EQUIVALENCE", "fail", "envelope equivalence on matched pairs",
+          `${pairDiffs.length} of ${matched.length} matched pair(s) disagree on event.name or a key attribute`,
+          capList(pairDiffs, opts.maxList))
+  );
+
+  // Feed ordering (integrity) — separate from coverage, always.
+  if (opts.seqChecks && seqEntries.length === 0) {
+    // ZERO seq evidence (an empty window span). "no descent across 0 seqs" and "no gaps
+    // across 0 seqs" are three green rows asserting nothing — and --json is advertised as
+    // machine-readable, so a dashboard tile keyed on checks[].status reads them as answers.
+    for (const id of ["SEQ_WIRE_ORDER", "SEQ_CONTIGUITY", "SEQ_COVERAGE"]) {
+      notAsserted.push({ id, reason: "no seq evidence in the window span — zero shadow envelopes to order. A zero-evidence check is not a pass." });
+    }
+  } else if (opts.seqChecks) {
+    const { descents, gaps } = checkSeqAdjacency(seqEntries);
+    checks.push(
+      descents.length === 0
+        ? check("SEQ_WIRE_ORDER", "pass", "shadow seq strictly ascending in WIRE ORDER",
+            `${seqEntries.length} seq(s), unsorted, no descent (ts inversions are expected and not checked — seq is commit order)`)
+        : check("SEQ_WIRE_ORDER", "fail", "shadow seq strictly ascending in WIRE ORDER",
+            `${descents.length} ordering violation(s) in file order`, capList(descents, opts.maxList))
+    );
+    if (opts.seqLedgerComplete) {
+      checks.push(
+        gaps.length === 0
+          ? check("SEQ_CONTIGUITY", "pass", "shadow seq contiguity (ledger-complete mode)", `no gaps across ${seqEntries.length} seq(s)`)
+          : check("SEQ_CONTIGUITY", "fail", "shadow seq contiguity (ledger-complete mode)",
+              `${gaps.length} gap(s) — ${gaps.reduce((a, g) => a + g.missing, 0)} missing seq(s)`, capList(gaps, opts.maxList))
+      );
+    } else {
+      notAsserted.push({
+        id: "SEQ_CONTIGUITY",
+        reason: "the shadow log only contains MAPPED events; the consumer drops provider types webhook-events.ts has no mapper for (workflow_job, check_run, Attachment), so seq gaps are expected and a contiguity assertion here would be meaningless. Pass --seq-ledger-complete only if the consumer records EVERY feed seq.",
+      });
+    }
+    // COVERAGE != INTEGRITY (defect 6). Only assertable against a complete seq ledger; a
+    // "weak" coverage check (first >= since+1, last <= head) passes for a short read, which is
+    // precisely the false green this rule exists to prevent — so it is not offered.
+    if (opts.expectFirstSeq !== null || opts.expectHeadSeq !== null) {
+      if (!opts.seqLedgerComplete) {
+        notAsserted.push({ id: "SEQ_COVERAGE", reason: "--expect-first-seq/--expect-head-seq supplied without --seq-ledger-complete. A mapped log legitimately omits seqs, so first==since+1 / last==head cannot be asserted; the weak form would pass for a short read." });
+      } else {
+        const first = seqEntries.length > 0 ? seqEntries[0].seq : null;
+        const last = seqEntries.length > 0 ? seqEntries[seqEntries.length - 1].seq : null;
+        const problems = [];
+        if (opts.expectFirstSeq !== null) {
+          if (first === null && opts.expectFirstSeq <= (opts.expectHeadSeq ?? Infinity)) problems.push(`empty replay but first seq was expected at ${opts.expectFirstSeq}`);
+          else if (first !== null && first !== opts.expectFirstSeq) problems.push(`first seq ${first} != expected ${opts.expectFirstSeq} (replay starts after the cursor — internally contiguous, invisible to a gap check)`);
+        }
+        // `last === null` is the EMPTY replay. Guarding the head comparison on it meant
+        // "empty while the head is ahead" — one of the three short-read shapes this check
+        // exists for — silently printed `pass  first=null last=null`.
+        if (opts.expectHeadSeq !== null && last === null) {
+          problems.push(`empty replay while the head was expected at ${opts.expectHeadSeq} — zero seqs is not coverage`);
+        } else if (opts.expectHeadSeq !== null && last !== opts.expectHeadSeq) {
+          problems.push(`last seq ${last} != head ${opts.expectHeadSeq} (SHORT READ — internally contiguous, no control record, invisible to a gap check)`);
+        }
+        checks.push(
+          problems.length === 0
+            ? check("SEQ_COVERAGE", "pass", "coverage: the replay spans what was asked for", `first=${first} last=${last}`)
+            : check("SEQ_COVERAGE", "fail", "coverage: the replay spans what was asked for", problems.join("; "), { first, last, expectFirstSeq: opts.expectFirstSeq, expectHeadSeq: opts.expectHeadSeq })
+        );
+      }
+    } else {
+      notAsserted.push({ id: "SEQ_COVERAGE", reason: "no --expect-first-seq/--expect-head-seq supplied. Integrity does NOT imply coverage: a replay that starts after the cursor or stops before the head is internally contiguous with no control record. Feed coverage is owned by catalyst-cloud feed-health.mjs — consume its exit code." });
+    }
+  }
+
+  const join = {
+    matched: matched.length,
+    matchedBySource,
+    liveOnly: { total: liveOnly.length, interior: liveOnlyInterior.length, edge: liveOnlyEdge.length, knownGap: knownGapDeficit.length, elided: elidedLoss.length, unexplained: unexplainedLoss.length, deliveries: capList(liveOnly.map(fmtEntry), opts.maxList) },
+    shadowOnly: { total: shadowOnly.length, interior: shadowOnlyInterior.length, edge: shadowOnlyEdge.length, superset: shadowOnlySuperset.length, overlapping: shadowOnlyOverlapping.length, deliveries: capList(shadowOnly.map(fmtEntry), opts.maxList) },
+    envelopeDiffs: capList(pairDiffs, opts.maxList),
+    enrichmentOnlyPairs,
+  };
+
+  return finalize({ generatedAt, opts, scanned, checks, blockers, waivers, notAsserted, typeRows, join, overlapNote, markers: markerSummary });
+}
+
+/** min/max ts over entries. Never assumes file order == time order (see the overlap gate). */
+export function tsBounds(entries) {
+  let min = Infinity;
+  let max = -Infinity;
+  for (const e of entries) {
+    if (e.ts === null) continue;
+    if (e.ts < min) min = e.ts;
+    if (e.ts > max) max = e.ts;
+  }
+  return { min, max };
+}
+
+function tally(entries, keyFn) {
+  const m = {};
+  for (const e of entries) {
+    const k = keyFn(e);
+    m[k] = (m[k] ?? 0) + 1;
+  }
+  return m;
+}
+
+function sideStats(side) {
+  return {
+    files: side.files,
+    lines: side.lines, blank: side.blank, nonWebhook: side.nonWebhook,
+    webhookEnvelopes: side.webhookTotal, outOfWindow: side.outOfWindow,
+    repoFiltered: side.repoFiltered, sourceFiltered: side.sourceFiltered,
+    compared: side.selected.length,
+    bySource: countBySource(side.selected),
+    malformed: side.malformed.length, control: side.control.length,
+    badTs: side.badTs.length, missingDeliveryId: side.missingDeliveryId.length,
+    markers: { total: side.markers.length, inWindow: side.markers.filter((m) => m.inWindow).length, byKind: side.markers.filter((m) => m.inWindow).reduce((a, m) => { a[m.kind] = (a[m.kind] ?? 0) + 1; return a; }, {}) },
+    producerVersions: [...side.versions], hosts: [...side.hosts],
+  };
+}
+
+function finalize({ generatedAt, opts, scanned, checks, blockers, waivers, notAsserted, typeRows, join, overlapNote, markers = [] }) {
+  const counts = {
+    pass: checks.filter((c) => c.status === "pass").length,
+    fail: checks.filter((c) => c.status === "fail").length,
+    warn: checks.filter((c) => c.status === "warn").length,
+    info: checks.filter((c) => c.status === "info").length,
+    notRun: checks.filter((c) => c.status === "not_run").length,
+    notAsserted: notAsserted.length,
+  };
+  // Precedence: cannot_evaluate > problem > healthy. Nothing red is ever green.
+  //
+  //  · blockers OR a not_run check => cannot_evaluate. A check that did not run is an
+  //    unanswered question, and an unanswered question is exit 2, never exit 0.
+  //  · fail OR warn => problem. `warn` used to be invisible to the exit code, so a
+  //    detected, described, printed loss (a 95% smee-side drop; every >96KB payload
+  //    dropped; a filed cloud gap) still exited 0 — the exact "evaluated-problem
+  //    rendered as evaluated-healthy" collapse this contract forbids. `info` is the
+  //    only non-verdict status and is reserved for genuinely benign observations.
+  const verdict =
+    blockers.length > 0 || counts.notRun > 0
+      ? "cannot_evaluate"
+      : counts.fail > 0 || counts.warn > 0
+        ? "problem"
+        : "healthy";
+  const exitCode = verdict === "cannot_evaluate" ? EXIT_CANNOT_EVALUATE : verdict === "problem" ? EXIT_PROBLEM : EXIT_HEALTHY;
+  return {
+    harness: "parity-harness", schemaVersion: 1, ticket: "CTL-1534", generatedAt,
+    window: { from: opts.fromIso, to: opts.toIso, edgeMarginSeconds: opts.edgeMarginMs / 1000, sources: opts.sources, repos: opts.repos },
+    policy: {
+      joinKey: 'attributes["webhook.delivery.id"]',
+      uncomparedEnvelopeFields: ENVELOPE_UNCOMPARED.map(([f, why]) => ({ field: f, why })),
+      localEnrichmentAttrs: [...ATTR_LOCAL_ENRICHMENT],
+      seqAttr: opts.seqAttr, seqChecks: opts.seqChecks, seqLedgerComplete: opts.seqLedgerComplete,
+      ignoredAttrs: [opts.seqAttr, ...opts.ignoreAttrs],
+      markerPrefix: opts.markerPrefix, knownMarkers: MARKER_KINDS,
+    },
+    scanned, verdict, exitCode, counts, checks, blockers, waivers, notAsserted, markers,
+    typeTable: typeRows, join, overlapNote, blindSpots: BLIND_SPOTS,
+  };
+}
+
+// ── human output ────────────────────────────────────────────────────────────────────────
+
+const ICON = { pass: "✅", fail: "❌", warn: "⚠️ ", info: "ℹ️ ", not_run: "🚫", waived: "➖" };
+
+function renderHuman(r, opts) {
+  const L = [];
+  L.push(`CTL-1534 parity harness — shadow(cloud feed) vs live(smee), joined on ${r.policy.joinKey}`);
+  L.push(`WINDOW   ${r.window.from ?? "(unbounded)"} → ${r.window.to ?? "(unbounded)"}   edge margin ${r.window.edgeMarginSeconds}s   sources ${r.window.sources.join(",")}${r.window.repos ? `   repos ${r.window.repos.join(",")}` : ""}`);
+  for (const [label, s] of [["LIVE  ", r.scanned.live], ["SHADOW", r.scanned.shadow]]) {
+    L.push(`${label}   ${s.files.join(" ")}`);
+    L.push(`         ${s.lines} lines · ${s.webhookEnvelopes} webhook envelopes · ${s.compared} compared (github ${s.bySource.github} / linear ${s.bySource.linear}) · ${s.outOfWindow} out-of-window · versions [${s.producerVersions.join(",")}] hosts [${s.hosts.join(",")}]`);
+  }
+  L.push("");
+  if (r.blockers.length > 0) {
+    L.push(`NOT EVALUABLE — ${r.blockers.length} blocker(s). Nothing below was asserted.`);
+    for (const b of r.blockers) L.push(`  ❌ ${b.id}  ${b.detail}`);
+    L.push("");
+  }
+  L.push("ASSERTIONS");
+  for (const c of r.checks) {
+    L.push(`  ${ICON[c.status] ?? c.status} ${c.id.padEnd(28)} ${c.detail}`);
+    if (c.status === "fail" || c.status === "warn") {
+      const ev = c.evidence;
+      const items = Array.isArray(ev?.items) ? ev.items : Array.isArray(ev?.deliveries?.items) ? ev.deliveries.items : Array.isArray(ev) ? ev : null;
+      if (items) {
+        for (const it of items.slice(0, opts.maxList)) L.push(`       · ${JSON.stringify(it)}`);
+        const total = ev?.total ?? ev?.deliveries?.total ?? items.length;
+        if (total > items.length) L.push(`       · … ${total - items.length} more (see --json)`);
+      }
+    }
+  }
+  L.push("");
+  if (r.typeTable.length > 0) {
+    L.push("PER-TYPE COUNTS (Gate B input — counts, never presence; expected-zero rows are printed)");
+    L.push(`  ${"type".padEnd(46)}${"live".padStart(7)}${"shadow".padStart(8)}  ${"expectation".padEnd(13)} verdict`);
+    for (const row of r.typeTable) {
+      const t = row.ticket ? ` [${row.ticket}]` : "";
+      const a = row.attributedElided > 0 ? ` (−${row.attributedElided} elided)` : "";
+      L.push(`  ${row.type.padEnd(46)}${String(row.live).padStart(7)}${String(row.shadow).padStart(8)}  ${row.expectation.padEnd(13)} ${row.verdict}${a}${t}`);
+    }
+    L.push("");
+  }
+  if (r.waivers.length > 0) {
+    L.push(`WAIVERS (${r.waivers.length}) — explicitly waived by a flag, NOT checked`);
+    for (const w of r.waivers) L.push(`  ➖ ${w}`);
+    L.push("");
+  }
+  if (r.notAsserted.length > 0) {
+    L.push(`NOT ASSERTED (${r.notAsserted.length}) — these questions were NOT answered by this run`);
+    for (const n of r.notAsserted) L.push(`  ◻︎ ${n.id}: ${n.reason}`);
+    L.push("");
+  }
+  L.push(`NOT COVERED HERE (${r.blindSpots.length}) — structural blind spots of a log-vs-log diff`);
+  for (const b of r.blindSpots) L.push(`  · ${b}`);
+  L.push("");
+  const v = r.verdict === "healthy" ? "HEALTHY" : r.verdict === "problem" ? "PROBLEM" : "CANNOT EVALUATE";
+  L.push(`VERDICT  ${v}   pass ${r.counts.pass} · fail ${r.counts.fail} · warn ${r.counts.warn} (non-green) · info ${r.counts.info ?? 0} · not-run ${r.counts.notRun} · not-asserted ${r.counts.notAsserted}   exit ${r.exitCode}`);
+  if (r.verdict === "cannot_evaluate" && r.blockers.length === 0 && r.counts.notRun > 0) {
+    L.push("         (no blocker, but a check DID NOT RUN — an unanswered question is exit 2, never a pass)");
+  }
+  if (r.verdict === "cannot_evaluate" && r.counts.fail > 0) {
+    L.push("         (assertions also FAILED, and the run is not evaluable — treat as red either way)");
+  }
+  return L.join("\n");
+}
+
+const HELP = `parity-harness.mjs — CTL-1534 · shadow(cloud) vs live(smee) event-log parity
+
+  bun parity-harness.mjs [--from ISO --to ISO] [options]
+  bun parity-harness.mjs --self-test          # offline, credential-free negative control
+
+EXIT  0 = evaluated-healthy · 1 = evaluated-problem · 2 = COULD NOT EVALUATE (never "healthy")
+      A "warn" row is a DETECTED LOSS and exits 1. A "not_run" row is an unanswered
+      question and exits 2. Only "info" rows leave the verdict untouched.
+
+INPUT
+  --live PATH            live log file (repeatable).   default: <live-dir>/YYYY-MM.jsonl
+  --shadow PATH          shadow log file (repeatable). default: <shadow-dir>/YYYY-MM.jsonl
+  --live-dir DIR         default ~/catalyst/events
+  --shadow-dir DIR       default ~/catalyst/events-shadow
+  --from ISO --to ISO    window, inclusive. STRICT ISO-8601 only; bad input exits 2, never
+                         coerced. Keep the window strictly INSIDE one config/deploy regime.
+  --edge-margin SECONDS  boundary settling margin (default 120) — the cloud runs ~12s ahead of
+                         smee, so near-boundary one-sided deliveries are counted, not failed.
+                         A non-zero margin REQUIRES --from/--to (the boundary is never derived
+                         from the data under test) and the window must exceed 2× the margin,
+                         else the margin would swallow every candidate: exit 2, not a pass.
+  --sources CSV          github,linear (default both)
+  --repos CSV            restrict GitHub events to these repos (linear is never repo-filtered)
+  --marker-prefix P      shadow-log marker event.name prefix (default catalyst.cloud_feed.).
+                         A "gap" marker makes the run non-evaluable; an "elided" marker
+                         ATTRIBUTES a live-only delivery; an UNRECOGNISED marker exits 2.
+
+FEED ORDERING
+  --seq-attr KEY         shadow attribute holding the cloud event_log.seq
+                         (default catalyst.cloud.event.seq)
+  --ignore-attr KEY      exclude an attribute from envelope equivalence (repeatable). The
+                         --seq-attr key is always excluded; both are printed in the policy block.
+  --no-seq-checks        WAIVE the ordering ASSERTIONS explicitly (recorded loudly). It does
+                         NOT waive SEQ_ATTR_ABSENT: a shadow log with no seq attribute at all
+                         is a producer-contract break and stays exit 2.
+  --seq-ledger-complete  assert the shadow log records EVERY feed seq (enables contiguity +
+                         coverage). Do not pass unless that is true.
+  --expect-first-seq N   coverage: first seq must equal N (= since+1)
+  --expect-head-seq N    coverage: last seq must equal N (= head)
+  --require-coverage     exit 2 unless coverage was actually ASSERTED — i.e. unless BOTH
+                         expectations are supplied AND --seq-ledger-complete is set AND the
+                         seq checks are not waived. A demoted-to-not-asserted coverage
+                         question is not a coverage pass.
+
+STRICTNESS
+  --strict-shadow-only   overlapping-type shadow-only deliveries FAIL (default: warn)
+  --strict-known-gaps    filed cloud-side gaps (CTC-297) FAIL (default: warn)
+  --strict-attrs         locally-enriched attribute presence diffs FAIL
+  --allow-version-span   waive the deploy-boundary gate (a window crossing a deploy lies)
+  --allow-partial-overlap  waive the "sides cover different intervals" gate
+  --tolerate-torn-tail   allow ONE unparseable FINAL line per file (concurrent-append artifact)
+
+OUTPUT
+  --json                 machine-readable report on stdout; exit code is the red/green key
+  --max-list N           console/JSON evidence cap (default 25; truncation is declared)
+`;
+
+// ── offline negative control ────────────────────────────────────────────────────────────
+
+function baseOpts(over = {}) {
+  const { opts } = parseArgs([]);
+  return { ...opts, ...over };
+}
+
+function env({ name, id, ts, seq = null, attrs = {}, version = "12.37.0", host = "mini", severity = "INFO" }) {
+  const attributes = { "event.name": name, "event.entity": name.split(".")[1], "event.action": name.split(".")[2] ?? "", "event.channel": "webhook", ...attrs };
+  if (id !== null) attributes["webhook.delivery.id"] = id;
+  if (seq !== null) attributes["catalyst.cloud.event.seq"] = seq;
+  return JSON.stringify({
+    ts, id: `uuid-${id ?? "none"}-${seq ?? 0}`, observedTs: ts, severityText: severity, severityNumber: 9,
+    traceId: null, spanId: null,
+    resource: { "service.name": name.startsWith("github") ? "catalyst.github" : "catalyst.linear", "service.namespace": "catalyst", "service.version": version, "host.name": host, "host.id": "abc" },
+    attributes, body: { message: `${name}`, payload: {} },
+  });
+}
+
+/**
+ * Seeded fixtures. Both sides are the same envelopes (the shadow consumer reuses
+ * webhook-events.ts unmodified), differing only in what each scenario perturbs.
+ */
+function fixtures() {
+  const T = (n) => `2026-07-26T22:${String(10 + n).padStart(2, "0")}:00.000Z`;
+  const g = (i, id, seq, over = {}) => env({ name: "github.pr.opened", id, ts: T(i), seq, attrs: { "vcs.repository.name": "coalesce-labs/catalyst", "vcs.pr.number": 2751 }, ...over });
+  const l = (i, id, seq, over = {}) => env({ name: "linear.comment.created", id, ts: T(i), seq, attrs: { "linear.issue.identifier": "CTL-1534" }, ...over });
+  const liveLines = [g(1, "gh-1"), g(2, "gh-2"), l(3, "li-1"), l(4, "li-2"), g(5, "gh-3")];
+  const shadowLines = [g(1, "gh-1", 101), g(2, "gh-2", 102), l(3, "li-1", 103), l(4, "li-2", 104), g(5, "gh-3", 105)];
+  return { g, l, T, live: liveLines.join("\n"), shadow: shadowLines.join("\n") };
+}
+
+/**
+ * Every case runs at the SHIPPED DEFAULTS unless it deliberately overrides them — in
+ * particular at the default 120s --edge-margin. Hard-setting edgeMarginMs:0 in every
+ * control meant the negative controls only went red because they disabled the margin
+ * the CLI actually uses: the shipped configuration was exercised nowhere. The fixture
+ * window (60 min, deliveries at 22:11..22:15) is comfortably wider than 2× the margin
+ * and all fixtures are interior, so the default is a real, exercised setting here.
+ */
+function runCase(name, { liveText, shadowText, opts, expect }) {
+  const o = baseOpts({ fromMs: Date.parse("2026-07-26T22:00:00.000Z"), fromIso: "2026-07-26T22:00:00.000Z", toMs: Date.parse("2026-07-26T23:00:00.000Z"), toIso: "2026-07-26T23:00:00.000Z", ...opts });
+  const live = ingestText("live", liveText, o, "<fixture:live>");
+  const shadow = ingestText("shadow", shadowText, o, "<fixture:shadow>");
+  const report = evaluate({ live, shadow, opts: o, generatedAt: "1970-01-01T00:00:00.000Z" });
+  // `fired` includes not_run rows when nothing blocked, so "the detector refused to
+  // answer" is an observable outcome and not just an absent pass.
+  const failedIds = new Set([
+    ...report.checks.filter((c) => c.status === "fail" || c.status === "warn").map((c) => c.id),
+    ...report.blockers.map((b) => b.id),
+    ...(report.blockers.length === 0 ? report.checks.filter((c) => c.status === "not_run").map((c) => `${c.id}:not_run`) : []),
+  ]);
+  const okExit = report.exitCode === expect.exitCode;
+  const okDetector = expect.detector === null ? true : failedIds.has(expect.detector);
+  return { name, ok: okExit && okDetector, exitCode: report.exitCode, expectedExit: expect.exitCode, detector: expect.detector, fired: [...failedIds], report };
+}
+
+/**
+ * Credential-free, offline, network-free negative control. Seeds synthetic fixtures and
+ * asserts the detectors GO RED — plus a POSITIVE control, so a harness stuck at red cannot
+ * pass its own negative control.
+ */
+export function selfTest() {
+  const f = fixtures();
+  const cases = [];
+
+  // 0. POSITIVE CONTROL — clean fixtures must be GREEN. Without this, "everything is red"
+  //    would pass every negative case below.
+  cases.push(runCase("positive control (clean parity)", { liveText: f.live, shadowText: f.shadow, expect: { exitCode: EXIT_HEALTHY, detector: null } }));
+
+  // 1. A DROPPED DELIVERY — one INTERIOR live delivery never reaches the shadow log. Dropped
+  //    from the middle on purpose: a dropped first/last delivery moves the window boundary and
+  //    would trip the (separate) overlap gate instead of the loss detector.
+  cases.push(runCase("dropped delivery (live-only, interior)", {
+    liveText: f.live,
+    shadowText: [f.g(1, "gh-1", 101), f.g(2, "gh-2", 102), f.l(4, "li-2", 104), f.g(5, "gh-3", 105)].join("\n"),
+    expect: { exitCode: EXIT_PROBLEM, detector: "MISSING_FROM_SHADOW" },
+  }));
+
+  // 2. ZERO-MATCH JOIN — disjoint delivery ids. Mismatch counting alone cannot tell this from
+  //    perfect parity; it MUST be loud.
+  cases.push(runCase("zero-match join (disjoint delivery ids)", {
+    liveText: f.live,
+    shadowText: [f.g(1, "x-1", 101), f.g(2, "x-2", 102), f.l(3, "x-3", 103), f.l(4, "x-4", 104), f.g(5, "x-5", 105)].join("\n"),
+    expect: { exitCode: EXIT_PROBLEM, detector: "MATCHED_NONZERO_github" },
+  }));
+
+  // 3. OUT-OF-ORDER SEQUENCE — 101,103,102 in wire order. Sorting would hide it.
+  cases.push(runCase("out-of-order seq (wire order, unsorted)", {
+    liveText: f.live,
+    shadowText: [f.g(1, "gh-1", 101), f.g(2, "gh-2", 103), f.l(3, "li-1", 102), f.l(4, "li-2", 104), f.g(5, "gh-3", 105)].join("\n"),
+    expect: { exitCode: EXIT_PROBLEM, detector: "SEQ_WIRE_ORDER" },
+  }));
+
+  // 4. SEQ GAP under an asserted complete ledger.
+  cases.push(runCase("seq gap (ledger-complete mode)", {
+    liveText: f.live,
+    shadowText: [f.g(1, "gh-1", 101), f.g(2, "gh-2", 102), f.l(3, "li-1", 104), f.l(4, "li-2", 105), f.g(5, "gh-3", 106)].join("\n"),
+    opts: { seqLedgerComplete: true },
+    expect: { exitCode: EXIT_PROBLEM, detector: "SEQ_CONTIGUITY" },
+  }));
+
+  // 5. SHORT READ — internally contiguous, ends before head, NO control record. Invisible to
+  //    any contiguity check (defect 6: coverage != integrity).
+  cases.push(runCase("short read (contiguous, ends before head)", {
+    liveText: f.live, shadowText: f.shadow,
+    opts: { seqLedgerComplete: true, expectFirstSeq: 101, expectHeadSeq: 200 },
+    expect: { exitCode: EXIT_PROBLEM, detector: "SEQ_COVERAGE" },
+  }));
+
+  // 6. CONTROL RECORD — the feed declared the scan incomplete. The prefix is contiguous, so a
+  //    naive contiguity check would pass a server-declared short read. Must be exit 2.
+  cases.push(runCase("control record invalidates the run", {
+    liveText: f.live,
+    shadowText: `${f.shadow}\n${JSON.stringify({ error: "cursor_underflow", resync: true })}`,
+    expect: { exitCode: EXIT_CANNOT_EVALUATE, detector: "CONTROL_RECORD" },
+  }));
+
+  // 6b. FEED-GAP MARKER — the consumer declared its OWN coverage incomplete. Everything else
+  //     in the window is internally consistent, so every assertion would otherwise pass.
+  cases.push(runCase("consumer feed-gap marker invalidates the run", {
+    liveText: f.live,
+    shadowText: `${f.shadow}\n${JSON.stringify({ ts: f.T(3), attributes: { "event.name": "catalyst.cloud_feed.gap" }, marker: "feed-gap" })}`,
+    expect: { exitCode: EXIT_CANNOT_EVALUATE, detector: "FEED_GAP_DECLARED" },
+  }));
+
+  // 6c. UNRECOGNISED MARKER — a consumer rename must surface, never read as silence.
+  cases.push(runCase("unrecognised shadow marker", {
+    liveText: f.live,
+    shadowText: `${f.shadow}\n${JSON.stringify({ ts: f.T(3), attributes: { "event.name": "catalyst.cloud_feed.something_new" } })}`,
+    expect: { exitCode: EXIT_CANNOT_EVALUATE, detector: "UNKNOWN_SHADOW_MARKER" },
+  }));
+
+  // 7. ENVELOPE MISMATCH on a matched pair (same delivery id, different mapped event.name).
+  cases.push(runCase("envelope mismatch on a matched pair", {
+    liveText: f.live,
+    shadowText: [f.g(1, "gh-1", 101), env({ name: "github.pr.closed", id: "gh-2", ts: f.T(2), seq: 102, attrs: { "vcs.repository.name": "coalesce-labs/catalyst", "vcs.pr.number": 2751 } }), f.l(3, "li-1", 103), f.l(4, "li-2", 104), f.g(5, "gh-3", 105)].join("\n"),
+    expect: { exitCode: EXIT_PROBLEM, detector: "ENVELOPE_EQUIVALENCE" },
+  }));
+
+  // 8. MALFORMED LINE — evidence not trustworthy, exit 2 (never repaired).
+  cases.push(runCase("malformed line", {
+    liveText: f.live, shadowText: `${f.shadow}\n{"attributes": broken`,
+    expect: { exitCode: EXIT_CANNOT_EVALUATE, detector: "MALFORMED_INPUT" },
+  }));
+
+  // 9. DEPLOY BOUNDARY — two producer versions inside the window. A window that crosses a
+  //    config change reports a confidently wrong number in whichever direction it went.
+  cases.push(runCase("window crosses a deploy boundary", {
+    liveText: f.live,
+    shadowText: [f.g(1, "gh-1", 101), f.g(2, "gh-2", 102, { version: "12.38.0" }), f.l(3, "li-1", 103), f.l(4, "li-2", 104), f.g(5, "gh-3", 105)].join("\n"),
+    expect: { exitCode: EXIT_CANNOT_EVALUATE, detector: "DEPLOY_BOUNDARY" },
+  }));
+
+  // 10. MISSING JOIN KEY (pre-CTL-1532 envelopes) — the join would silently under-match.
+  cases.push(runCase("missing webhook.delivery.id (pre-CTL-1532)", {
+    liveText: [f.g(1, "gh-1"), env({ name: "github.pr.opened", id: null, ts: f.T(2) }), f.l(3, "li-1"), f.l(4, "li-2"), f.g(5, "gh-3")].join("\n"),
+    shadowText: f.shadow,
+    expect: { exitCode: EXIT_CANNOT_EVALUATE, detector: "MISSING_JOIN_KEY" },
+  }));
+
+  // 11. SEQ ATTRIBUTE ABSENT — ordering cannot be evaluated; must not silently skip.
+  cases.push(runCase("shadow carries no seq attribute", {
+    liveText: f.live,
+    shadowText: [f.g(1, "gh-1"), f.g(2, "gh-2"), f.l(3, "li-1"), f.l(4, "li-2"), f.g(5, "gh-3")].join("\n"),
+    expect: { exitCode: EXIT_CANNOT_EVALUATE, detector: "SEQ_ATTR_ABSENT" },
+  }));
+
+  // 12. SHADOW-SIDE DUPLICATE — the consumer's dedup (invariant 6) is not holding.
+  cases.push(runCase("shadow duplicate delivery id", {
+    liveText: f.live,
+    shadowText: [f.g(1, "gh-1", 101), f.g(2, "gh-2", 102), f.g(2, "gh-2", 103), f.l(3, "li-1", 104), f.l(4, "li-2", 105), f.g(5, "gh-3", 106)].join("\n"),
+    expect: { exitCode: EXIT_PROBLEM, detector: "DUPLICATE_DELIVERY_SHADOW" },
+  }));
+
+  // 13. PER-TYPE DEFICIT — a type the live side carries more of than the shadow side.
+  cases.push(runCase("per-type shadow deficit", {
+    liveText: [f.g(1, "gh-1"), f.g(2, "gh-2"), f.g(5, "gh-3"), f.l(3, "li-1"), f.l(4, "li-2")].join("\n"),
+    shadowText: [f.g(1, "gh-1", 101), f.g(2, "gh-2", 102), f.l(3, "li-1", 103), f.l(4, "li-2", 104), env({ name: "github.check_suite.completed", id: "gh-3", ts: f.T(5), seq: 105, attrs: { "vcs.repository.name": "coalesce-labs/catalyst" } })].join("\n"),
+    expect: { exitCode: EXIT_PROBLEM, detector: "TYPE_COUNTS" },
+  }));
+
+  // 15. EDGE MARGIN CANNOT SWALLOW THE WINDOW. At the shipped 120s default, a 3-minute
+  //     window makes EVERY delivery "edge" — both loss detectors would examine zero
+  //     candidates and pass. Must be exit 2 before any assertion runs.
+  cases.push(runCase("edge margin covers the whole window", {
+    liveText: f.live, shadowText: f.shadow,
+    opts: { fromMs: Date.parse("2026-07-26T22:10:00.000Z"), fromIso: "2026-07-26T22:10:00.000Z", toMs: Date.parse("2026-07-26T22:13:00.000Z"), toIso: "2026-07-26T22:13:00.000Z" },
+    expect: { exitCode: EXIT_CANNOT_EVALUATE, detector: "EDGE_MARGIN_SWALLOWS_WINDOW" },
+  }));
+
+  // 15b. UNBOUNDED WINDOW + a non-zero margin: the boundary would be derived from the data
+  //      under test, which permanently waives the earliest and latest deliveries.
+  cases.push(runCase("unbounded window with the default edge margin", {
+    liveText: f.live, shadowText: f.shadow,
+    opts: { fromMs: null, fromIso: null, toMs: null, toIso: null },
+    expect: { exitCode: EXIT_CANNOT_EVALUATE, detector: "UNBOUNDED_WINDOW" },
+  }));
+
+  // 15c. EVERY loss candidate edge-excluded => the detector examined nothing. It must
+  //      report not_run (exit 2), never `pass`. Window 22:00–23:00, margin 120s: the only
+  //      one-sided delivery sits at 22:59:30, inside the trailing margin.
+  //      (a matched pair at 22:59:00 keeps the window-overlap gate quiet, so the ONLY thing
+  //      this case exercises is the edge exclusion itself)
+  const lateMatched = (seq) => env({ name: "github.pr.opened", id: "gh-late", ts: "2026-07-26T22:59:00.000Z", seq, attrs: { "vcs.repository.name": "coalesce-labs/catalyst" } });
+  cases.push(runCase("all loss candidates edge-excluded is not_run, never pass", {
+    liveText: [f.live, lateMatched(null),
+      env({ name: "github.pr.opened", id: "gh-edge", ts: "2026-07-26T22:59:30.000Z", attrs: { "vcs.repository.name": "coalesce-labs/catalyst" } })].join("\n"),
+    shadowText: [f.shadow, lateMatched(106)].join("\n"),
+    expect: { exitCode: EXIT_CANNOT_EVALUATE, detector: "MISSING_FROM_SHADOW:not_run" },
+  }));
+
+  // 16. SEQ ATTRIBUTE ABSENT IS NOT WAIVABLE. --no-seq-checks waives the assertions, not the
+  //     producer contract: waiving an attribute nobody writes makes three checks structurally
+  //     unreachable under a green verdict. This was THE false green.
+  cases.push(runCase("--no-seq-checks cannot waive a shadow log with NO seq attribute", {
+    liveText: f.live,
+    shadowText: [f.g(1, "gh-1"), f.g(2, "gh-2"), f.l(3, "li-1"), f.l(4, "li-2"), f.g(5, "gh-3")].join("\n"),
+    opts: { seqChecks: false },
+    expect: { exitCode: EXIT_CANNOT_EVALUATE, detector: "SEQ_ATTR_ABSENT" },
+  }));
+
+  // 17. --require-coverage with expectations but WITHOUT --seq-ledger-complete: coverage is
+  //     demoted to not-asserted, which used to have zero effect on the verdict.
+  cases.push(runCase("--require-coverage without a complete ledger cannot answer coverage", {
+    liveText: f.live, shadowText: f.shadow,
+    opts: { requireCoverage: true, expectFirstSeq: 101, expectHeadSeq: 200 },
+    expect: { exitCode: EXIT_CANNOT_EVALUATE, detector: "COVERAGE_REQUIRED" },
+  }));
+  cases.push(runCase("--require-coverage with the seq checks waived cannot answer coverage", {
+    liveText: f.live, shadowText: f.shadow,
+    opts: { requireCoverage: true, expectFirstSeq: 101, expectHeadSeq: 200, seqLedgerComplete: true, seqChecks: false },
+    expect: { exitCode: EXIT_CANNOT_EVALUATE, detector: "COVERAGE_REQUIRED" },
+  }));
+
+  // 18. TOTAL LIVE-SIDE LOSS of a censused `both` type. Presence-based classification called
+  //     this the "expected cloud superset" and passed — the 14h32m smee outage shape.
+  cases.push(runCase("total live-side loss of a censused `both` type", {
+    liveText: f.live,
+    shadowText: [f.shadow,
+      env({ name: "github.deployment_status.success", id: "dep-1", ts: f.T(2), seq: 106, attrs: { "vcs.repository.name": "coalesce-labs/catalyst" } }),
+      env({ name: "github.deployment_status.success", id: "dep-2", ts: f.T(3), seq: 107, attrs: { "vcs.repository.name": "coalesce-labs/catalyst" } })].join("\n"),
+    expect: { exitCode: EXIT_PROBLEM, detector: "LIVE_DEFICIT_TYPES" },
+  }));
+
+  // 19. OVERLAPPING-TYPE SHADOW-ONLY is a smee-side drop. `warn` used to be invisible to the
+  //     exit code, so the run printed the finding and exited 0.
+  cases.push(runCase("overlapping-type shadow-only deliveries are non-green", {
+    liveText: f.live,
+    shadowText: [f.shadow, f.g(2, "gh-extra", 106)].join("\n"),
+    expect: { exitCode: EXIT_PROBLEM, detector: "SHADOW_ONLY" },
+  }));
+
+  // 20. AN ELIDED DELIVERY never reached the shadow log — the consumer itself grades it a
+  //     problem. The harness must not disagree with its own producer by exiting 0.
+  cases.push(runCase("a corroborated elision is a non-green attributed loss", {
+    liveText: f.live,
+    shadowText: [f.g(1, "gh-1", 101), f.g(2, "gh-2", 102), f.l(3, "li-1", 103), f.l(4, "li-2", 104),
+      JSON.stringify({ ts: f.T(5), attributes: { "event.name": "catalyst.cloud_feed.unmappable_payload", "webhook.delivery.id": "gh-3" }, reason: "payloadOmitted", payloadBytes: 120000, source: "github", eventType: "pull_request" })].join("\n"),
+    expect: { exitCode: EXIT_PROBLEM, detector: "ELIDED_PAYLOADS" },
+  }));
+
+  // 21. AN UNCORROBORATED elision marker must not be allowed to excuse a loss: it suppresses
+  //     a MISSING_FROM_SHADOW row AND discounts a type deficit, on the say-so of the
+  //     component under test.
+  cases.push(runCase("an uncorroborated elision marker cannot excuse a loss", {
+    liveText: f.live,
+    shadowText: [f.g(1, "gh-1", 101), f.g(2, "gh-2", 102), f.l(3, "li-1", 103), f.l(4, "li-2", 104),
+      JSON.stringify({ ts: f.T(5), attributes: { "event.name": "catalyst.cloud_feed.unmappable_payload", "webhook.delivery.id": "gh-3" }, reason: "payloadOmitted", payloadBytes: 12 })].join("\n"),
+    expect: { exitCode: EXIT_CANNOT_EVALUATE, detector: "UNCORROBORATED_ELISION" },
+  }));
+
+  // 14. BAD INPUT — never coerced. `--from banana` must be rejected, not NaN'd into "scan
+  //     everything and report healthy about a range nobody asked for".
+  const badArgs = parseArgs(["--from", "banana"]);
+  cases.push({ name: "bad --from is rejected, never coerced", ok: badArgs.ok === false, exitCode: badArgs.ok ? "accepted" : EXIT_CANNOT_EVALUATE, expectedExit: EXIT_CANNOT_EVALUATE, detector: "ARG_PARSE", fired: badArgs.ok ? [] : ["ARG_PARSE"] });
+  const badSince = parseArgs(["--expect-head-seq", "banana"]);
+  cases.push({ name: "bad --expect-head-seq is rejected, never coerced", ok: badSince.ok === false, exitCode: badSince.ok ? "accepted" : EXIT_CANNOT_EVALUATE, expectedExit: EXIT_CANNOT_EVALUATE, detector: "ARG_PARSE", fired: badSince.ok ? [] : ["ARG_PARSE"] });
+  const badFlag = parseArgs(["--frmo", "x"]);
+  cases.push({ name: "unknown flag is rejected", ok: badFlag.ok === false, exitCode: badFlag.ok ? "accepted" : EXIT_CANNOT_EVALUATE, expectedExit: EXIT_CANNOT_EVALUATE, detector: "ARG_PARSE", fired: badFlag.ok ? [] : ["ARG_PARSE"] });
+  // An EMPTY value for a detector-bearing flag is the same defect through a wrapper's
+  // unset variable: `--marker-prefix ""` turns marker detection into a total no-op.
+  const emptyMarker = parseArgs(["--marker-prefix", ""]);
+  cases.push({ name: "empty --marker-prefix is rejected (it would disable marker detection)", ok: emptyMarker.ok === false, exitCode: emptyMarker.ok ? "accepted" : EXIT_CANNOT_EVALUATE, expectedExit: EXIT_CANNOT_EVALUATE, detector: "ARG_PARSE", fired: emptyMarker.ok ? [] : ["ARG_PARSE"] });
+  const emptySeqAttr = parseArgs(["--seq-attr", ""]);
+  cases.push({ name: "empty --seq-attr is rejected (it would read an attribute nobody writes)", ok: emptySeqAttr.ok === false, exitCode: emptySeqAttr.ok ? "accepted" : EXIT_CANNOT_EVALUATE, expectedExit: EXIT_CANNOT_EVALUATE, detector: "ARG_PARSE", fired: emptySeqAttr.ok ? [] : ["ARG_PARSE"] });
+  // A re-pointed prefix can ADD a watch, never hide the built-in one.
+  const repointed = runCase("a re-pointed --marker-prefix still sees the built-in consumer markers", {
+    liveText: f.live,
+    shadowText: `${f.shadow}\n${JSON.stringify({ ts: f.T(3), attributes: { "event.name": "catalyst.cloud_feed.gap" }, marker: "feed-gap" })}`,
+    opts: { markerPrefix: "some.other.prefix." },
+    expect: { exitCode: EXIT_CANNOT_EVALUATE, detector: "FEED_GAP_DECLARED" },
+  });
+  cases.push(repointed);
+
+  const negatives = cases.filter((c) => c.detector !== null);
+  const fired = negatives.filter((c) => c.ok).length;
+  const positive = cases.find((c) => c.detector === null);
+  return { cases, negatives: negatives.length, fired, positiveOk: positive?.ok === true, allOk: cases.every((c) => c.ok) };
+}
+
+// ── CLI ─────────────────────────────────────────────────────────────────────────────────
+
+async function main(argv) {
+  const parsed = parseArgs(argv);
+  if (!parsed.ok) {
+    // Rule 6: reject bad input, never repair it. Bad input is COULD-NOT-EVALUATE, not a pass.
+    process.stderr.write(`parity-harness: ${parsed.reason}\n`);
+    return EXIT_CANNOT_EVALUATE;
+  }
+  const opts = parsed.opts;
+  if (opts.help) { process.stdout.write(HELP); return EXIT_HEALTHY; }
+
+  if (opts.selfTest) {
+    const r = selfTest();
+    if (opts.json) {
+      process.stdout.write(`${JSON.stringify({ mode: "self-test", negatives: r.negatives, fired: r.fired, positiveOk: r.positiveOk, allOk: r.allOk, cases: r.cases.map((c) => ({ name: c.name, ok: c.ok, expectedExit: c.expectedExit, exitCode: c.exitCode, detector: c.detector, fired: c.fired })) }, null, 2)}\n`);
+    } else {
+      process.stdout.write("parity-harness --self-test (offline, credential-free, no network)\n\n");
+      for (const c of r.cases) {
+        const tag = c.detector === null ? "positive" : "negative";
+        process.stdout.write(`  ${c.ok ? "✅" : "❌"} [${tag}] ${c.name}  → exit ${c.exitCode} (expected ${c.expectedExit})${c.detector ? ` detector ${c.detector}${c.ok ? " FIRED" : " DID NOT FIRE"}` : ""}\n`);
+      }
+      process.stdout.write(`\n  detectors fired: ${r.fired}/${r.negatives}   positive control: ${r.positiveOk ? "GREEN" : "NOT GREEN"}\n`);
+      process.stdout.write(`  ${r.allOk ? "SELF-TEST PASS — the detectors go red on seeded failures and green on clean input." : "SELF-TEST FAIL — a detector did not behave as specified. Do NOT trust a green parity run."}\n`);
+    }
+    return r.allOk ? EXIT_HEALTHY : EXIT_PROBLEM;
+  }
+
+  const liveDir = opts.liveDir ?? join(homedir(), "catalyst", "events");
+  const shadowDir = opts.shadowDir ?? join(homedir(), "catalyst", "events-shadow");
+  const liveFiles = opts.live.length > 0 ? opts.live : monthFilesFor(liveDir, opts.fromMs, opts.toMs);
+  const shadowFiles = opts.shadow.length > 0 ? opts.shadow : monthFilesFor(shadowDir, opts.fromMs, opts.toMs);
+
+  const missing = [...liveFiles, ...shadowFiles].filter((f) => !existsSync(f) || !statSync(f).isFile());
+  if (missing.length > 0) {
+    // A missing input is COULD-NOT-EVALUATE. Notably: an absent shadow log means the consumer
+    // never ran — that is not "no differences found".
+    const report = {
+      harness: "parity-harness", schemaVersion: 1, ticket: "CTL-1534", generatedAt: new Date().toISOString(),
+      verdict: "cannot_evaluate", exitCode: EXIT_CANNOT_EVALUATE,
+      blockers: [{ id: "INPUT_MISSING", detail: `input log(s) not found: ${missing.join(", ")}`, evidence: missing }],
+      checks: [], counts: { pass: 0, fail: 0, warn: 0, notRun: 0, notAsserted: 0 },
+      notAsserted: [], waivers: [], blindSpots: BLIND_SPOTS, typeTable: [], join: null,
+      scanned: { live: { files: liveFiles }, shadow: { files: shadowFiles } },
+      window: { from: opts.fromIso, to: opts.toIso },
+    };
+    process.stdout.write(opts.json ? `${JSON.stringify(report, null, 2)}\n` : `parity-harness: CANNOT EVALUATE — input log(s) not found:\n  ${missing.join("\n  ")}\n\nA missing shadow log means the consumer never wrote — that is not "no differences found".\nexit ${EXIT_CANNOT_EVALUATE}\n`);
+    return EXIT_CANNOT_EVALUATE;
+  }
+
+  const live = newSideAcc("live");
+  const shadow = newSideAcc("shadow");
+  try {
+    for (const f of liveFiles) await ingestFile(live, f, opts);
+    for (const f of shadowFiles) await ingestFile(shadow, f, opts);
+  } catch (err) {
+    process.stderr.write(`parity-harness: CANNOT EVALUATE — read failed: ${err instanceof Error ? err.message : String(err)}\n`);
+    return EXIT_CANNOT_EVALUATE;
+  }
+
+  const report = evaluate({ live, shadow, opts });
+  process.stdout.write(opts.json ? `${JSON.stringify(report, null, 2)}\n` : `${renderHuman(report, opts)}\n`);
+  return report.exitCode;
+}
+
+if (import.meta.main) {
+  main(process.argv.slice(2))
+    .then((code) => { process.exit(code); })
+    .catch((err) => {
+      // An unexpected throw is COULD-NOT-EVALUATE, never healthy.
+      process.stderr.write(`parity-harness: CANNOT EVALUATE — unhandled error: ${err instanceof Error ? err.stack : String(err)}\n`);
+      process.exit(EXIT_CANNOT_EVALUATE);
+    });
+}

--- a/plugins/dev/scripts/execution-core/parity-harness.test.mjs
+++ b/plugins/dev/scripts/execution-core/parity-harness.test.mjs
@@ -180,10 +180,16 @@ describe("envelopeSource / deliveryIdOf / seqOf", () => {
 
   test("seqOf is strict: absent vs invalid vs valid are three different answers", () => {
     expect(seqOf(envelope({ seq: 101 }), "catalyst.cloud.event.seq")).toEqual({ ok: true, seq: 101 });
-    expect(seqOf(envelope({ seq: "101" }), "catalyst.cloud.event.seq")).toEqual({ ok: true, seq: 101 });
     expect(seqOf(envelope({}), "catalyst.cloud.event.seq").ok).toBeNull();
     expect(seqOf(envelope({ seq: "banana" }), "catalyst.cloud.event.seq").ok).toBe(false);
     expect(seqOf(envelope({ seq: 1.5 }), "catalyst.cloud.event.seq").ok).toBe(false);
+    // A NUMERIC-LOOKING STRING is invalid evidence, not something to repair. The consumer
+    // stamps a number; a string means the producer or transport changed shape, and
+    // coercing it through parseIntStrict hid exactly that (rule 6, applied to the reader).
+    expect(seqOf(envelope({ seq: "101" }), "catalyst.cloud.event.seq")).toEqual({ ok: false, raw: "101" });
+    // An explicitly-null value is PRESENT-but-invalid; only a missing key is "absent".
+    expect(seqOf({ attributes: { "catalyst.cloud.event.seq": null } }, "catalyst.cloud.event.seq"))
+      .toEqual({ ok: false, raw: null });
   });
 });
 
@@ -617,13 +623,17 @@ describe("evaluate — three-way exit contract", () => {
     expect(r.blockers.some((b) => b.id === "COVERAGE_REQUIRED")).toBe(true);
   });
 
-  test("a known-gap loss (CTC-297) is warned against its ticket, not silently ignored", () => {
+  test("a known-gap loss (CTC-297) is tracked against its ticket, not silently ignored", () => {
     // interior ts on purpose: both sides keep the same min/max, so the (separate) overlap
     // gate stays quiet and the known-gap classifier is what is under test.
     const live = [clean, line(envelope({ id: "rx-1", name: "linear.reaction.created", ts: "2026-07-26T22:12:30.000Z" }))].join("\n");
     const r = run(live, cleanShadow, { edgeMarginMs: 0 });
     const kg = r.checks.find((c) => c.id === "KNOWN_GAP_LOSSES");
-    expect(kg.status).toBe("warn");
+    // `info`, not `warn`: the row names an OPEN ticket, so warn held the whole harness red
+    // for the life of that ticket — which is how a signal gets trained out of. It is still
+    // printed every run, with its ticket. An UNCENSUSED loss has no such downgrade.
+    expect(kg.status).toBe("info");
+    expect(kg.evidence.tickets).toContain("CTC-297");
     expect(r.checks.find((c) => c.id === "MISSING_FROM_SHADOW").status).toBe("pass");
   });
 
@@ -990,12 +1000,13 @@ describe("warn is NON-GREEN; only info leaves the verdict alone", () => {
     expect(r.exitCode).toBe(EXIT_PROBLEM);
   });
 
-  test("a known-gap loss is reported AND non-green (it is still a real gap)", () => {
+  test("a known-gap loss is reported but does NOT hold the verdict red for the ticket's life", () => {
     const live = [ev("a", "2026-07-26T22:11:00.000Z"), ev("rx", "2026-07-26T22:12:00.000Z", null, "linear.reaction.created"), ev("c", "2026-07-26T22:13:00.000Z", null, "linear.comment.created")].join("\n");
     const shadow = [ev("a", "2026-07-26T22:11:00.000Z", 1), ev("c", "2026-07-26T22:13:00.000Z", 2, "linear.comment.created")].join("\n");
     const r = runW(live, shadow);
-    expect(r.checks.find((c) => c.id === "KNOWN_GAP_LOSSES").status).toBe("warn");
-    expect(r.exitCode).toBe(EXIT_PROBLEM);
+    expect(r.checks.find((c) => c.id === "KNOWN_GAP_LOSSES").status).toBe("info");
+    // The gap is still visible in the report; --strict-known-gaps is the escalation.
+    expect(r.checks.find((c) => c.id === "KNOWN_GAP_LOSSES").detail).toContain("TRACKED");
   });
 
   test("a live-side duplicate delivery is `info` — a provider redelivery contributes no warn", () => {
@@ -1051,5 +1062,73 @@ describe("a question that was not answered is never a green row", () => {
     const shadow = [ev("a", "2026-07-26T22:11:00.000Z", 1), ev("c", "2026-07-26T22:13:00.000Z", 2, "linear.comment.created")].join("\n");
     const r = runW(live, shadow, { sources: ["github"] });
     expect(r.notAsserted.some((n) => n.id === "MATCHED_NONZERO_linear")).toBe(true);
+  });
+});
+
+// ==========================================================================
+// CTL-1534 round 2 — defects the draft PR shipped with.
+// ==========================================================================
+
+describe("M — a PARTIAL edge exclusion is an unanswered question, not a clean pass", () => {
+  const W = {
+    fromMs: Date.parse("2026-07-26T22:00:00.000Z"), fromIso: "2026-07-26T22:00:00.000Z",
+    toMs: Date.parse("2026-07-26T23:00:00.000Z"), toIso: "2026-07-26T23:00:00.000Z",
+    edgeMarginMs: 120_000,
+  };
+  const run = (liveText, shadowText, over = {}) => {
+    const o = opts({ ...W, ...over });
+    return evaluate({ live: ingestText("live", liveText, o), shadow: ingestText("shadow", shadowText, o), opts: o, generatedAt: "1970-01-01T00:00:00.000Z" });
+  };
+  // Matched pairs at BOTH ends keep the window-overlap gate quiet (it fires on a >margin
+  // skew between the sides' ts bounds); the one-sided rows below are the actual subject.
+  const headLive = line(envelope({ id: "head", ts: "2026-07-26T22:05:00.000Z" }));
+  const headShadow = line(envelope({ id: "head", ts: "2026-07-26T22:05:00.000Z", seq: 1 }));
+  const tailLive = line(envelope({ id: "tail", ts: "2026-07-26T22:59:00.000Z" }));
+  const tailShadow = line(envelope({ id: "tail", ts: "2026-07-26T22:59:00.000Z", seq: 9 }));
+  const edgeOnly = line(envelope({ id: "edge-1", ts: "2026-07-26T22:59:30.000Z" }));
+  const interiorOnly = line(envelope({ id: "int-1", ts: "2026-07-26T22:35:00.000Z" }));
+
+  test("some-excluded-some-examined enumerates the waived candidates instead of hiding them", () => {
+    const r = run([headLive, interiorOnly, tailLive, edgeOnly].join("\n"), [headShadow, tailShadow].join("\n"));
+    // the interior candidate IS answered — and it is a real loss
+    expect(r.checks.find((c) => c.id === "MISSING_FROM_SHADOW").status).toBe("fail");
+    // ...and the edge-excluded one is named as NOT answered, rather than folded into the row
+    expect(r.notAsserted.some((n) => n.id === "MISSING_FROM_SHADOW_EDGE_EXCLUDED")).toBe(true);
+  });
+
+  test("when EVERY candidate is edge-excluded the all-or-nothing not_run row still fires", () => {
+    const r = run([headLive, tailLive, edgeOnly].join("\n"), [headShadow, tailShadow].join("\n"));
+    expect(r.checks.find((c) => c.id === "MISSING_FROM_SHADOW").status).toBe("not_run");
+  });
+
+  test("shadow-only edge exclusions get the same treatment", () => {
+    const r = run(
+      [headLive, tailLive].join("\n"),
+      [headShadow, tailShadow,
+        line(envelope({ id: "sh-int", ts: "2026-07-26T22:36:00.000Z", seq: 5 })),
+        line(envelope({ id: "sh-edge", ts: "2026-07-26T22:59:30.000Z", seq: 10 }))].join("\n"),
+    );
+    expect(r.notAsserted.some((n) => n.id === "SHADOW_ONLY_EDGE_EXCLUDED")).toBe(true);
+  });
+
+  test("with --edge-margin 0 nothing is waived and no unanswered row is emitted", () => {
+    const r = run([headLive, interiorOnly, tailLive, edgeOnly].join("\n"), [headShadow, tailShadow].join("\n"), { edgeMarginMs: 0 });
+    expect(r.notAsserted.some((n) => n.id.endsWith("_EDGE_EXCLUDED"))).toBe(false);
+  });
+});
+
+describe("L — seqOf never repairs the evidence it reads", () => {
+  test("a string seq becomes SEQ_ATTR_INVALID, not a silently-parsed integer", () => {
+    const W = {
+      fromMs: Date.parse("2026-07-26T22:00:00.000Z"), fromIso: "2026-07-26T22:00:00.000Z",
+      toMs: Date.parse("2026-07-26T23:00:00.000Z"), toIso: "2026-07-26T23:00:00.000Z",
+      edgeMarginMs: 0,
+    };
+    const o = opts(W);
+    const live = [line(envelope({ id: "a", ts: "2026-07-26T22:11:00.000Z" })), line(envelope({ id: "b", ts: "2026-07-26T22:12:00.000Z" }))].join("\n");
+    const shadow = [line(envelope({ id: "a", ts: "2026-07-26T22:11:00.000Z", seq: 1 })), line(envelope({ id: "b", ts: "2026-07-26T22:12:00.000Z", seq: "2" }))].join("\n");
+    const r = evaluate({ live: ingestText("live", live, o), shadow: ingestText("shadow", shadow, o), opts: o, generatedAt: "1970-01-01T00:00:00.000Z" });
+    expect(r.blockers.some((b) => b.id === "SEQ_ATTR_INVALID")).toBe(true);
+    expect(r.exitCode).toBe(EXIT_CANNOT_EVALUATE);
   });
 });

--- a/plugins/dev/scripts/execution-core/parity-harness.test.mjs
+++ b/plugins/dev/scripts/execution-core/parity-harness.test.mjs
@@ -1,0 +1,1055 @@
+// parity-harness.test.mjs — CTL-1534.
+//
+// Unit tests for the PURE comparison functions. These run offline with no credential and no
+// network — same constraint as `--self-test` (rule 8: the negative control must run where it
+// is needed, which is CI).
+//
+// The tests are written against the defect list that produced the harness rules: each block
+// names the false-green it exists to prevent.
+
+import { describe, expect, test } from "bun:test";
+
+import {
+  DEFAULT_TYPE_CENSUS,
+  EXIT_CANNOT_EVALUATE,
+  EXIT_HEALTHY,
+  EXIT_PROBLEM,
+  censusExpectationFor,
+  checkSeqAdjacency,
+  compareEnvelope,
+  compareTypeCounts,
+  countBySource,
+  deliveryIdOf,
+  envelopeSource,
+  evaluate,
+  indexByDelivery,
+  ingestText,
+  isControlRecord,
+  joinDeliveries,
+  monthFilesFor,
+  parseArgs,
+  parseIntStrict,
+  parseIsoStrict,
+  perTypeCounts,
+  selfTest,
+  seqOf,
+  tsBounds,
+  windowSpanSlice,
+} from "./parity-harness.mjs";
+
+// ── helpers ─────────────────────────────────────────────────────────────────────────────
+
+const opts = (over = {}) => ({ ...parseArgs([]).opts, ...over });
+
+function envelope({ name = "github.pr.opened", id = "d1", ts = "2026-07-26T22:11:00.000Z", seq = null, attrs = {}, version = "12.37.0", host = "mini", severity = "INFO" } = {}) {
+  const attributes = { "event.name": name, "event.entity": name.split(".")[1], "event.action": name.split(".")[2] ?? "", ...attrs };
+  if (id !== null) attributes["webhook.delivery.id"] = id;
+  if (seq !== null) attributes["catalyst.cloud.event.seq"] = seq;
+  return {
+    ts, id: `uuid-${id}`, observedTs: ts, severityText: severity, severityNumber: 9,
+    traceId: null, spanId: null,
+    resource: { "service.name": "catalyst.github", "service.namespace": "catalyst", "service.version": version, "host.name": host, "host.id": "h" },
+    attributes, body: { message: name, payload: {} },
+  };
+}
+const line = (e) => JSON.stringify(e);
+const entry = (obj, i = 0, inWindow = true) => ({
+  file: "<m>", lineNo: i + 1, fileOrderIndex: i, obj,
+  source: envelopeSource(obj), ts: Date.parse(obj.ts), inWindow,
+  deliveryId: deliveryIdOf(obj),
+});
+
+// ── strict input parsing (defects 3 + 9: never repair the input) ─────────────────────────
+
+describe("parseIsoStrict — rejects, never coerces", () => {
+  test("accepts strict ISO-8601 with Z and with an offset", () => {
+    expect(parseIsoStrict("2026-07-26T22:11:00Z").ok).toBe(true);
+    expect(parseIsoStrict("2026-07-26T22:11:00.123Z").ok).toBe(true);
+    expect(parseIsoStrict("2026-07-26T22:11:00+02:00").ok).toBe(true);
+  });
+
+  test.each([
+    ["banana"], ["2026-07-26"], ["2026-07-26 22:11:00Z"], ["Jul 26 2026"], [""], ["0"],
+  ])("rejects %p", (v) => {
+    expect(parseIsoStrict(v).ok).toBe(false);
+  });
+
+  test("rejects non-strings rather than stringifying them", () => {
+    expect(parseIsoStrict(1753567860000).ok).toBe(false);
+    expect(parseIsoStrict(null).ok).toBe(false);
+    expect(parseIsoStrict(undefined).ok).toBe(false);
+  });
+});
+
+describe("parseIntStrict — the `--since banana -> NaN -> scanned everything` defect", () => {
+  test("accepts non-negative integers", () => {
+    expect(parseIntStrict("0")).toEqual({ ok: true, value: 0 });
+    expect(parseIntStrict("1766")).toEqual({ ok: true, value: 1766 });
+  });
+
+  test.each([["banana"], ["-1"], ["1.5"], [""], [" 7"], ["7 "], ["0x10"], ["1e3"], ["007"]])(
+    "rejects %p (Number() would have coerced or silently accepted it)", (v) => {
+      expect(parseIntStrict(v).ok).toBe(false);
+    });
+});
+
+describe("parseArgs", () => {
+  test("rejects an unknown flag rather than ignoring it", () => {
+    const r = parseArgs(["--frmo", "x"]);
+    expect(r.ok).toBe(false);
+    expect(r.reason).toContain("unknown argument");
+  });
+
+  test("rejects a flag with no value", () => {
+    expect(parseArgs(["--from"]).ok).toBe(false);
+    expect(parseArgs(["--from", "--json"]).ok).toBe(false);
+  });
+
+  test("rejects a non-ISO --from and a non-integer --expect-head-seq", () => {
+    expect(parseArgs(["--from", "banana"]).ok).toBe(false);
+    expect(parseArgs(["--expect-head-seq", "banana"]).ok).toBe(false);
+  });
+
+  test("rejects an inverted window", () => {
+    const r = parseArgs(["--from", "2026-07-26T23:00:00Z", "--to", "2026-07-26T22:00:00Z"]);
+    expect(r.ok).toBe(false);
+    expect(r.reason).toContain("after");
+  });
+
+  test("rejects an unknown --sources value", () => {
+    expect(parseArgs(["--sources", "gitlab"]).ok).toBe(false);
+    expect(parseArgs(["--sources", "github"]).opts.sources).toEqual(["github"]);
+  });
+
+  test("collects repeatable inputs", () => {
+    const { opts: o } = parseArgs(["--live", "a", "--live", "b", "--ignore-attr", "x", "--ignore-attr", "y"]);
+    expect(o.live).toEqual(["a", "b"]);
+    expect(o.ignoreAttrs).toEqual(["x", "y"]);
+  });
+
+  test("defaults do not silently pick a cursor of 0", () => {
+    const { opts: o } = parseArgs([]);
+    expect(o.expectFirstSeq).toBeNull();
+    expect(o.expectHeadSeq).toBeNull();
+    expect(o.fromMs).toBeNull();
+  });
+});
+
+// ── record classification ───────────────────────────────────────────────────────────────
+
+describe("isControlRecord — structural discrimination (`error` and no `seq`)", () => {
+  test("a control record is detected", () => {
+    expect(isControlRecord({ error: "cursor_underflow", resync: true })).toBe(true);
+    expect(isControlRecord({ error: "cursor_ahead_of_head", resync: true, head: 113 })).toBe(true);
+  });
+
+  test("an event line carrying seq is never a control record", () => {
+    expect(isControlRecord({ seq: 5, error: "weird", payload: {} })).toBe(false);
+  });
+
+  test("a provider body with its own `error` key cannot collide (it nests under payload)", () => {
+    expect(isControlRecord({ seq: 5, payload: { error: "provider-side" } })).toBe(false);
+    expect(isControlRecord(envelope())).toBe(false);
+  });
+
+  test("non-objects are not control records", () => {
+    expect(isControlRecord(null)).toBe(false);
+    expect(isControlRecord(["error"])).toBe(false);
+    expect(isControlRecord("error")).toBe(false);
+  });
+});
+
+describe("envelopeSource / deliveryIdOf / seqOf", () => {
+  test("source comes from the event.name prefix", () => {
+    expect(envelopeSource(envelope({ name: "github.pr.opened" }))).toBe("github");
+    expect(envelopeSource(envelope({ name: "linear.comment.created" }))).toBe("linear");
+  });
+
+  test("non-webhook events are not a source", () => {
+    expect(envelopeSource(envelope({ name: "phase.implement.complete.CTL-1" }))).toBeNull();
+    expect(envelopeSource(envelope({ name: "broker.daemon.start" }))).toBeNull();
+    expect(envelopeSource({ attributes: {} })).toBeNull();
+    expect(envelopeSource({})).toBeNull();
+  });
+
+  test("an empty delivery id is treated as absent, not as a joinable key", () => {
+    expect(deliveryIdOf(envelope({ id: "abc" }))).toBe("abc");
+    expect(deliveryIdOf(envelope({ id: null }))).toBeNull();
+    expect(deliveryIdOf({ attributes: { "webhook.delivery.id": "" } })).toBeNull();
+  });
+
+  test("seqOf is strict: absent vs invalid vs valid are three different answers", () => {
+    expect(seqOf(envelope({ seq: 101 }), "catalyst.cloud.event.seq")).toEqual({ ok: true, seq: 101 });
+    expect(seqOf(envelope({ seq: "101" }), "catalyst.cloud.event.seq")).toEqual({ ok: true, seq: 101 });
+    expect(seqOf(envelope({}), "catalyst.cloud.event.seq").ok).toBeNull();
+    expect(seqOf(envelope({ seq: "banana" }), "catalyst.cloud.event.seq").ok).toBe(false);
+    expect(seqOf(envelope({ seq: 1.5 }), "catalyst.cloud.event.seq").ok).toBe(false);
+  });
+});
+
+// ── adjacency (defect 4: never sort) ────────────────────────────────────────────────────
+
+describe("checkSeqAdjacency — WIRE ORDER, never sorted", () => {
+  const seqs = (list) => list.map((s, i) => ({ seq: s, lineNo: i + 1 }));
+
+  test("a contiguous ascending run is clean", () => {
+    expect(checkSeqAdjacency(seqs([101, 102, 103]))).toEqual({ descents: [], gaps: [] });
+  });
+
+  test("1,3,2 is a DESCENT — sorting would have turned it into a clean pass", () => {
+    const r = checkSeqAdjacency(seqs([1, 3, 2]));
+    expect(r.descents.length).toBe(1);
+    expect(r.descents[0]).toMatchObject({ prev: 3, cur: 2 });
+  });
+
+  test("a repeated seq is a descent, not a gap", () => {
+    const r = checkSeqAdjacency(seqs([5, 5]));
+    expect(r.descents.length).toBe(1);
+    expect(r.gaps.length).toBe(0);
+  });
+
+  test("a gap is reported with the count of missing seqs", () => {
+    const r = checkSeqAdjacency(seqs([101, 104]));
+    expect(r.gaps).toEqual([{ after: 101, before: 104, missing: 2, curLine: 2 }]);
+    expect(r.descents.length).toBe(0);
+  });
+
+  test("order and contiguity are INDEPENDENT properties", () => {
+    const r = checkSeqAdjacency(seqs([1, 5, 3, 4]));
+    expect(r.gaps.length).toBe(1); // 1 -> 5
+    expect(r.descents.length).toBe(1); // 5 -> 3
+  });
+
+  test("empty and single-element runs assert nothing", () => {
+    expect(checkSeqAdjacency([])).toEqual({ descents: [], gaps: [] });
+    expect(checkSeqAdjacency(seqs([42]))).toEqual({ descents: [], gaps: [] });
+  });
+});
+
+describe("windowSpanSlice — seq adjacency must not be computed over a ts-filtered subset", () => {
+  test("returns the contiguous FILE-ORDER slice bracketing the in-window records", () => {
+    const all = [
+      entry(envelope({ id: "a", seq: 1 }), 0, false),
+      entry(envelope({ id: "b", seq: 2 }), 1, true),
+      entry(envelope({ id: "c", seq: 3 }), 2, false), // interior, ts outside the window
+      entry(envelope({ id: "d", seq: 4 }), 3, true),
+      entry(envelope({ id: "e", seq: 5 }), 4, false),
+    ];
+    const span = windowSpanSlice(all);
+    // c is KEPT: seq is commit order while ts is receipt order, so dropping it would
+    // manufacture a gap that does not exist on the feed.
+    expect(span.map((e) => e.obj.attributes["webhook.delivery.id"])).toEqual(["b", "c", "d"]);
+  });
+
+  test("no in-window records yields an empty span", () => {
+    expect(windowSpanSlice([entry(envelope(), 0, false)])).toEqual([]);
+  });
+});
+
+describe("tsBounds — file order is NOT time order on the shadow side", () => {
+  test("min/max ignore file position", () => {
+    const b = tsBounds([
+      entry(envelope({ ts: "2026-07-26T22:30:00.000Z" })),
+      entry(envelope({ ts: "2026-07-26T22:10:00.000Z" })), // commit-order inversion
+      entry(envelope({ ts: "2026-07-26T22:20:00.000Z" })),
+    ]);
+    expect(new Date(b.min).toISOString()).toBe("2026-07-26T22:10:00.000Z");
+    expect(new Date(b.max).toISOString()).toBe("2026-07-26T22:30:00.000Z");
+  });
+});
+
+// ── join ────────────────────────────────────────────────────────────────────────────────
+
+describe("indexByDelivery / joinDeliveries", () => {
+  test("duplicates are recorded, never merged away", () => {
+    const idx = indexByDelivery([entry(envelope({ id: "a" }), 0), entry(envelope({ id: "a" }), 1)]);
+    expect(idx.byId.size).toBe(1);
+    expect(idx.duplicates.length).toBe(1);
+    expect(idx.duplicates[0]).toMatchObject({ deliveryId: "a", firstLine: 1, dupLine: 2 });
+  });
+
+  test("join splits matched / live-only / shadow-only", () => {
+    const live = indexByDelivery([entry(envelope({ id: "a" }), 0), entry(envelope({ id: "b" }), 1)]);
+    const shadow = indexByDelivery([entry(envelope({ id: "b" }), 0), entry(envelope({ id: "c" }), 1)]);
+    const j = joinDeliveries(live.byId, shadow.byId);
+    expect(j.matched.map((m) => m.id)).toEqual(["b"]);
+    expect(j.liveOnly.map((e) => e.deliveryId)).toEqual(["a"]);
+    expect(j.shadowOnly.map((e) => e.deliveryId)).toEqual(["c"]);
+  });
+
+  test("disjoint ids produce ZERO matches — the case a mismatch-only harness cannot see", () => {
+    const live = indexByDelivery([entry(envelope({ id: "a" }), 0)]);
+    const shadow = indexByDelivery([entry(envelope({ id: "z" }), 0)]);
+    const j = joinDeliveries(live.byId, shadow.byId);
+    expect(j.matched.length).toBe(0);
+    expect(j.liveOnly.length).toBe(1);
+    expect(j.shadowOnly.length).toBe(1);
+  });
+
+  test("countBySource counts per source, so a per-source zero cannot hide behind a total", () => {
+    const c = countBySource([
+      entry(envelope({ name: "github.pr.opened" })),
+      entry(envelope({ name: "github.pr.closed" })),
+    ]);
+    expect(c).toEqual({ github: 2, linear: 0 });
+  });
+});
+
+// ── per-type counts (rule 9: counts, never presence) ────────────────────────────────────
+
+describe("compareTypeCounts", () => {
+  const rowFor = (rows, type) => rows.find((r) => r.type === type);
+
+  test("live > shadow on a shared type is a DEFICIT", () => {
+    const rows = compareTypeCounts(new Map([["github.pr.opened", 5]]), new Map([["github.pr.opened", 3]]));
+    expect(rowFor(rows, "github.pr.opened")).toMatchObject({ live: 5, shadow: 3, verdict: "shadow-deficit", expectation: "both" });
+  });
+
+  test("shadow > live on a cloud-only type is the EXPECTED superset, not an error", () => {
+    const rows = compareTypeCounts(new Map(), new Map([["github.check_suite.completed", 44]]));
+    expect(rowFor(rows, "github.check_suite.completed")).toMatchObject({ shadow: 44, verdict: "cloud-superset", expectation: "cloud-only" });
+  });
+
+  test("a FILED cloud gap is classified against its ticket, not as an unexplained deficit", () => {
+    const rows = compareTypeCounts(new Map([["linear.reaction.created", 2]]), new Map());
+    expect(rowFor(rows, "linear.reaction.created")).toMatchObject({ verdict: "known-gap-deficit", expectation: "known-gap", ticket: "CTC-297" });
+  });
+
+  test("expected-zero rows are PRINTED — an omitted row is indistinguishable from nobody looking", () => {
+    const rows = compareTypeCounts(new Map(), new Map());
+    const zeroRows = rows.filter((r) => r.verdict.startsWith("expected-zero"));
+    expect(zeroRows.length).toBe(DEFAULT_TYPE_CENSUS.length + 3);
+    expect(rowFor(rows, "github.push.*")).toMatchObject({ live: 0, shadow: 0, verdict: "expected-zero" });
+  });
+
+  test("unmappable provider types are declared structurally invisible, not silently absent", () => {
+    const rows = compareTypeCounts(new Map(), new Map());
+    for (const t of ["workflow_job", "check_run", "Attachment"]) {
+      const row = rows.find((r) => r.type.startsWith(t));
+      expect(row).toBeDefined();
+      expect(row.verdict).toBe("expected-zero-structural");
+      expect(row.expectation).toBe("unmappable");
+    }
+  });
+
+  test("equal counts on a real type are `equal`, not `expected-zero`", () => {
+    const rows = compareTypeCounts(new Map([["linear.issue.updated", 7]]), new Map([["linear.issue.updated", 7]]));
+    expect(rowFor(rows, "linear.issue.updated").verdict).toBe("equal");
+  });
+
+  test("an uncensused type still gets a row and still fails on deficit", () => {
+    const rows = compareTypeCounts(new Map([["github.brand_new.thing", 2]]), new Map());
+    expect(rowFor(rows, "github.brand_new.thing")).toMatchObject({ expectation: "uncensused", verdict: "shadow-deficit" });
+  });
+
+  test("censusExpectationFor matches by prefix", () => {
+    expect(censusExpectationFor("github.pr.opened").expectation).toBe("both");
+    expect(censusExpectationFor("github.workflow_run.completed").expectation).toBe("cloud-only");
+    expect(censusExpectationFor("mystery.thing").expectation).toBe("uncensused");
+  });
+
+  test("perTypeCounts counts, it does not merely record presence", () => {
+    const m = perTypeCounts([
+      entry(envelope({ name: "github.pr.opened" })),
+      entry(envelope({ name: "github.pr.opened" })),
+      entry(envelope({ name: "github.pr.closed" })),
+    ]);
+    expect(m.get("github.pr.opened")).toBe(2);
+    expect(m.get("github.pr.closed")).toBe(1);
+  });
+});
+
+// ── envelope equivalence ────────────────────────────────────────────────────────────────
+
+describe("compareEnvelope", () => {
+  test("identical envelopes have no differences", () => {
+    expect(compareEnvelope(envelope(), envelope())).toEqual([]);
+  });
+
+  test("a different mapped event.name is a CORE difference", () => {
+    const d = compareEnvelope(envelope({ name: "github.pr.opened" }), envelope({ name: "github.pr.closed" }));
+    expect(d.some((x) => x.field === "attributes.event.name" && x.class === "core")).toBe(true);
+  });
+
+  test("a value disagreement on a locally-enriched attribute is still CORE", () => {
+    const d = compareEnvelope(
+      envelope({ attrs: { "vcs.pr.number": 1 } }),
+      envelope({ attrs: { "vcs.pr.number": 2 } }));
+    expect(d.find((x) => x.field === "attributes.vcs.pr.number").class).toBe("core");
+  });
+
+  test("a PRESENCE-only difference on a locally-enriched attribute is not core", () => {
+    const d = compareEnvelope(envelope({ attrs: { "catalyst.orchestrator.id": "orch-1" } }), envelope());
+    expect(d.find((x) => x.field === "attributes.catalyst.orchestrator.id").class).toBe("local-enrichment-presence");
+  });
+
+  test("--strict-attrs promotes an enrichment presence difference to core", () => {
+    const d = compareEnvelope(envelope({ attrs: { "catalyst.orchestrator.id": "orch-1" } }), envelope(), { strictAttrs: true });
+    expect(d.find((x) => x.field === "attributes.catalyst.orchestrator.id").class).toBe("core");
+  });
+
+  test("ignoreAttrs excludes a declared transport annotation (the cloud seq)", () => {
+    const withSeq = envelope({ seq: 101 });
+    expect(compareEnvelope(envelope(), withSeq).length).toBe(1);
+    expect(compareEnvelope(envelope(), withSeq, { ignoreAttrs: new Set(["catalyst.cloud.event.seq"]) })).toEqual([]);
+  });
+
+  test("an UNDECLARED consumer-added attribute still surfaces as a difference", () => {
+    const d = compareEnvelope(envelope(), envelope({ attrs: { "some.new.attr": 1 } }));
+    expect(d.find((x) => x.field === "attributes.some.new.attr").class).toBe("core");
+  });
+
+  test("severity differences are caught", () => {
+    const d = compareEnvelope(envelope({ severity: "INFO" }), envelope({ severity: "ERROR" }));
+    expect(d.some((x) => x.field === "severityText")).toBe(true);
+  });
+
+  test("ts / id / resource differences are NOT differences (declared policy)", () => {
+    const live = envelope({ ts: "2026-07-26T22:11:00.000Z", version: "12.37.0", host: "mini" });
+    const shadow = envelope({ ts: "2026-07-26T22:10:48.000Z", version: "0.1.0", host: "mini" });
+    shadow.id = "different-uuid";
+    expect(compareEnvelope(live, shadow)).toEqual([]);
+  });
+});
+
+// ── ingestion ───────────────────────────────────────────────────────────────────────────
+
+describe("ingestText", () => {
+  test("counts malformed lines rather than skipping them", () => {
+    const acc = ingestText("live", `${line(envelope())}\n{not json`, opts());
+    expect(acc.malformed.length).toBe(1);
+    expect(acc.selected.length).toBe(1);
+  });
+
+  test("captures control records separately from events", () => {
+    const acc = ingestText("shadow", `${line(envelope())}\n${JSON.stringify({ error: "cursor_underflow", resync: true })}`, opts());
+    expect(acc.control.length).toBe(1);
+    expect(acc.malformed.length).toBe(0);
+  });
+
+  test("non-webhook events are excluded from the comparison but counted", () => {
+    const acc = ingestText("live", [line(envelope()), line(envelope({ name: "phase.implement.complete.CTL-1" }))].join("\n"), opts());
+    expect(acc.nonWebhook).toBe(1);
+    expect(acc.webhookTotal).toBe(1);
+  });
+
+  test("blank lines and a trailing newline are not malformed", () => {
+    const acc = ingestText("live", `${line(envelope())}\n\n`, opts());
+    expect(acc.malformed.length).toBe(0);
+    expect(acc.blank).toBe(2);
+  });
+
+  test("the window filters on ts, inclusive at both ends", () => {
+    const o = opts({ fromMs: Date.parse("2026-07-26T22:00:00Z"), toMs: Date.parse("2026-07-26T23:00:00Z") });
+    const acc = ingestText("live", [
+      line(envelope({ id: "before", ts: "2026-07-26T21:59:59.000Z" })),
+      line(envelope({ id: "start", ts: "2026-07-26T22:00:00.000Z" })),
+      line(envelope({ id: "end", ts: "2026-07-26T23:00:00.000Z" })),
+      line(envelope({ id: "after", ts: "2026-07-26T23:00:01.000Z" })),
+    ].join("\n"), o);
+    expect(acc.selected.map((e) => e.deliveryId)).toEqual(["start", "end"]);
+    expect(acc.outOfWindow).toBe(2);
+  });
+
+  test("an envelope with no delivery id is recorded as a join-key gap, not silently dropped", () => {
+    const acc = ingestText("live", line(envelope({ id: null })), opts());
+    expect(acc.missingDeliveryId.length).toBe(1);
+    expect(acc.selected.length).toBe(0);
+  });
+
+  test("--repos filters GitHub only; Linear is never repo-filtered", () => {
+    const o = opts({ repos: ["coalesce-labs/catalyst"] });
+    const acc = ingestText("live", [
+      line(envelope({ id: "in", attrs: { "vcs.repository.name": "coalesce-labs/catalyst" } })),
+      line(envelope({ id: "out", attrs: { "vcs.repository.name": "ryanrozich/slides" } })),
+      line(envelope({ id: "lin", name: "linear.comment.created" })),
+    ].join("\n"), o);
+    expect(acc.selected.map((e) => e.deliveryId).sort()).toEqual(["in", "lin"]);
+    expect(acc.repoFiltered).toBe(1);
+  });
+});
+
+describe("monthFilesFor", () => {
+  test("covers every month the window spans", () => {
+    const f = monthFilesFor("/d", Date.parse("2026-06-20T00:00:00Z"), Date.parse("2026-08-02T00:00:00Z"));
+    expect(f).toEqual(["/d/2026-06.jsonl", "/d/2026-07.jsonl", "/d/2026-08.jsonl"]);
+  });
+
+  test("a single-month window yields one file", () => {
+    expect(monthFilesFor("/d", Date.parse("2026-07-01T00:00:00Z"), Date.parse("2026-07-31T00:00:00Z")))
+      .toEqual(["/d/2026-07.jsonl"]);
+  });
+});
+
+// ── the exit contract (defect 1: the worst one) ─────────────────────────────────────────
+
+describe("evaluate — three-way exit contract", () => {
+  const window = { fromMs: Date.parse("2026-07-26T22:00:00Z"), fromIso: "2026-07-26T22:00:00Z", toMs: Date.parse("2026-07-26T23:00:00Z"), toIso: "2026-07-26T23:00:00Z", edgeMarginMs: 0 };
+  const clean = [
+    line(envelope({ id: "gh-1", ts: "2026-07-26T22:11:00.000Z" })),
+    line(envelope({ id: "gh-2", ts: "2026-07-26T22:12:00.000Z" })),
+    line(envelope({ id: "li-1", name: "linear.comment.created", ts: "2026-07-26T22:13:00.000Z" })),
+  ].join("\n");
+  const cleanShadow = [
+    line(envelope({ id: "gh-1", ts: "2026-07-26T22:11:00.000Z", seq: 1 })),
+    line(envelope({ id: "gh-2", ts: "2026-07-26T22:12:00.000Z", seq: 2 })),
+    line(envelope({ id: "li-1", name: "linear.comment.created", ts: "2026-07-26T22:13:00.000Z", seq: 3 })),
+  ].join("\n");
+
+  const run = (liveText, shadowText, over = {}) => {
+    const o = opts({ ...window, ...over });
+    return evaluate({ live: ingestText("live", liveText, o), shadow: ingestText("shadow", shadowText, o), opts: o, generatedAt: "1970-01-01T00:00:00.000Z" });
+  };
+
+  test("clean parity exits 0 and reports matched pairs per source", () => {
+    const r = run(clean, cleanShadow);
+    expect(r.exitCode).toBe(EXIT_HEALTHY);
+    expect(r.verdict).toBe("healthy");
+    expect(r.join.matchedBySource).toEqual({ github: 2, linear: 1 });
+  });
+
+  test("a zero-match join is a LOUD failure, never a pass", () => {
+    const shadow = cleanShadow.replaceAll("gh-", "zz-").replaceAll("li-", "yy-");
+    const r = run(clean, shadow);
+    expect(r.exitCode).toBe(EXIT_PROBLEM);
+    for (const s of ["github", "linear"]) {
+      expect(r.checks.find((c) => c.id === `MATCHED_NONZERO_${s}`).status).toBe("fail");
+    }
+  });
+
+  test("a control record makes the run NOT EVALUABLE (exit 2), never healthy", () => {
+    const r = run(clean, `${cleanShadow}\n${JSON.stringify({ error: "cursor_underflow", resync: true })}`);
+    expect(r.exitCode).toBe(EXIT_CANNOT_EVALUATE);
+    expect(r.blockers.some((b) => b.id === "CONTROL_RECORD")).toBe(true);
+  });
+
+  test("when the run is not evaluable, EVERY assertion is `not_run` — none is a pass", () => {
+    const r = run(clean, `${cleanShadow}\n${JSON.stringify({ error: "cursor_underflow" })}`);
+    expect(r.checks.length).toBeGreaterThan(0);
+    expect(r.checks.every((c) => c.status === "not_run")).toBe(true);
+    expect(r.counts.pass).toBe(0);
+  });
+
+  test("cannot_evaluate takes precedence over problem — a partial evaluation is never a verdict", () => {
+    const broken = `${cleanShadow.split("\n").slice(0, 1).join("\n")}\n${JSON.stringify({ error: "cursor_underflow" })}`;
+    const r = run(clean, broken);
+    expect(r.verdict).toBe("cannot_evaluate");
+    expect(r.exitCode).toBe(EXIT_CANNOT_EVALUATE);
+  });
+
+  test("a window spanning two producer versions is not evaluable (deploy boundary)", () => {
+    const shadow = [
+      line(envelope({ id: "gh-1", ts: "2026-07-26T22:11:00.000Z", seq: 1, version: "0.1.0" })),
+      line(envelope({ id: "gh-2", ts: "2026-07-26T22:12:00.000Z", seq: 2, version: "0.2.0" })),
+      line(envelope({ id: "li-1", name: "linear.comment.created", ts: "2026-07-26T22:13:00.000Z", seq: 3, version: "0.2.0" })),
+    ].join("\n");
+    const r = run(clean, shadow);
+    expect(r.exitCode).toBe(EXIT_CANNOT_EVALUATE);
+    expect(r.blockers.some((b) => b.id === "DEPLOY_BOUNDARY")).toBe(true);
+  });
+
+  test("--allow-version-span converts the deploy gate into a printed waiver", () => {
+    const shadow = [
+      line(envelope({ id: "gh-1", ts: "2026-07-26T22:11:00.000Z", seq: 1, version: "0.1.0" })),
+      line(envelope({ id: "gh-2", ts: "2026-07-26T22:12:00.000Z", seq: 2, version: "0.2.0" })),
+      line(envelope({ id: "li-1", name: "linear.comment.created", ts: "2026-07-26T22:13:00.000Z", seq: 3, version: "0.2.0" })),
+    ].join("\n");
+    const r = run(clean, shadow, { allowVersionSpan: true });
+    expect(r.blockers.some((b) => b.id === "DEPLOY_BOUNDARY")).toBe(false);
+    expect(r.waivers.some((w) => w.includes("--allow-version-span"))).toBe(true);
+  });
+
+  test("a missing seq attribute is exit 2, not a silently skipped check", () => {
+    const r = run(clean, clean);
+    expect(r.exitCode).toBe(EXIT_CANNOT_EVALUATE);
+    expect(r.blockers.some((b) => b.id === "SEQ_ATTR_ABSENT")).toBe(true);
+  });
+
+  test("--no-seq-checks waives the ordering ASSERTIONS when the seqs are actually there", () => {
+    const r = run(clean, cleanShadow, { seqChecks: false });
+    expect(r.exitCode).toBe(EXIT_HEALTHY);
+    expect(r.notAsserted.map((n) => n.id)).toContain("SEQ_WIRE_ORDER");
+    expect(r.waivers.some((w) => w.includes("--no-seq-checks"))).toBe(true);
+  });
+
+  // C1/C3/H15/M4: the seq attribute is a PRODUCER CONTRACT, not an operator preference.
+  // When it is absent the three seq questions cannot ever be asked, so waiving them would
+  // manufacture a permanent green with the whole ordering/coverage subsystem switched off.
+  test("--no-seq-checks does NOT waive a shadow log carrying no seq attribute at all", () => {
+    const r = run(clean, clean, { seqChecks: false });
+    expect(r.exitCode).toBe(EXIT_CANNOT_EVALUATE);
+    const blocker = r.blockers.find((b) => b.id === "SEQ_ATTR_ABSENT");
+    expect(blocker).toBeDefined();
+    expect(blocker.evidence.waivableByNoSeqChecks).toBe(false);
+  });
+
+  test("a shadow log with no seq attribute is exit 2 with the seq checks ON as well", () => {
+    const r = run(clean, clean);
+    expect(r.exitCode).toBe(EXIT_CANNOT_EVALUATE);
+    expect(r.blockers.some((b) => b.id === "SEQ_ATTR_ABSENT")).toBe(true);
+    expect(r.checks.every((c) => c.status === "not_run")).toBe(true);
+  });
+
+  test("coverage is NOT asserted by default, and says so (integrity never implies coverage)", () => {
+    const r = run(clean, cleanShadow);
+    const cov = r.notAsserted.find((n) => n.id === "SEQ_COVERAGE");
+    expect(cov).toBeDefined();
+    expect(cov.reason).toContain("feed-health");
+    expect(r.checks.some((c) => c.id === "SEQ_COVERAGE")).toBe(false);
+  });
+
+  test("coverage expectations without a complete ledger are refused, not weakened", () => {
+    const r = run(clean, cleanShadow, { expectFirstSeq: 1, expectHeadSeq: 3 });
+    expect(r.notAsserted.some((n) => n.id === "SEQ_COVERAGE")).toBe(true);
+    expect(r.checks.some((c) => c.id === "SEQ_COVERAGE")).toBe(false);
+  });
+
+  test("a SHORT READ fails coverage while contiguity passes — the two are independent", () => {
+    const r = run(clean, cleanShadow, { seqLedgerComplete: true, expectFirstSeq: 1, expectHeadSeq: 99 });
+    expect(r.checks.find((c) => c.id === "SEQ_CONTIGUITY").status).toBe("pass");
+    expect(r.checks.find((c) => c.id === "SEQ_COVERAGE").status).toBe("fail");
+    expect(r.exitCode).toBe(EXIT_PROBLEM);
+  });
+
+  test("--require-coverage without expectations is exit 2", () => {
+    const r = run(clean, cleanShadow, { requireCoverage: true });
+    expect(r.exitCode).toBe(EXIT_CANNOT_EVALUATE);
+    expect(r.blockers.some((b) => b.id === "COVERAGE_REQUIRED")).toBe(true);
+  });
+
+  test("a known-gap loss (CTC-297) is warned against its ticket, not silently ignored", () => {
+    // interior ts on purpose: both sides keep the same min/max, so the (separate) overlap
+    // gate stays quiet and the known-gap classifier is what is under test.
+    const live = [clean, line(envelope({ id: "rx-1", name: "linear.reaction.created", ts: "2026-07-26T22:12:30.000Z" }))].join("\n");
+    const r = run(live, cleanShadow, { edgeMarginMs: 0 });
+    const kg = r.checks.find((c) => c.id === "KNOWN_GAP_LOSSES");
+    expect(kg.status).toBe("warn");
+    expect(r.checks.find((c) => c.id === "MISSING_FROM_SHADOW").status).toBe("pass");
+  });
+
+  test("--strict-known-gaps promotes a filed gap to a failure", () => {
+    const live = [clean, line(envelope({ id: "rx-1", name: "linear.reaction.created", ts: "2026-07-26T22:12:30.000Z" }))].join("\n");
+    const r = run(live, cleanShadow, { edgeMarginMs: 0, strictKnownGaps: true });
+    expect(r.checks.find((c) => c.id === "KNOWN_GAP_LOSSES").status).toBe("fail");
+    expect(r.exitCode).toBe(EXIT_PROBLEM);
+  });
+
+  test("shadow-only of a type the live side ALSO carries is flagged (smee-side drop shape)", () => {
+    const live = clean;
+    const shadow = [cleanShadow, line(envelope({ id: "gh-9", ts: "2026-07-26T22:12:30.000Z", seq: 4 }))].join("\n");
+    const r = run(live, shadow, { edgeMarginMs: 0 });
+    const c = r.checks.find((c2) => c2.id === "SHADOW_ONLY");
+    expect(c.status).toBe("warn");
+    expect(c.detail).toContain("smee-side drop");
+  });
+
+  test("shadow-only of a CLOUD-ONLY type is the expected superset and stays green", () => {
+    const shadow = [cleanShadow, line(envelope({ id: "wf-1", name: "github.workflow_run.completed", ts: "2026-07-26T22:12:30.000Z", seq: 4 }))].join("\n");
+    const r = run(clean, shadow, { edgeMarginMs: 0 });
+    expect(r.checks.find((c) => c.id === "SHADOW_ONLY").status).toBe("pass");
+    expect(r.exitCode).toBe(EXIT_HEALTHY);
+  });
+
+  test("blind spots are reported on EVERY run, including a healthy one", () => {
+    const r = run(clean, cleanShadow);
+    expect(r.blindSpots.length).toBeGreaterThanOrEqual(5);
+    expect(r.blindSpots.join(" ")).toContain("workflow_job");
+  });
+
+  test("the report declares its own comparison policy (nothing excluded silently)", () => {
+    const r = run(clean, cleanShadow);
+    expect(r.policy.ignoredAttrs).toContain("catalyst.cloud.event.seq");
+    expect(r.policy.uncomparedEnvelopeFields.length).toBeGreaterThan(0);
+    expect(r.policy.joinKey).toContain("webhook.delivery.id");
+  });
+
+  test("an interior live-only delivery fails, and the failure lists the delivery id", () => {
+    const shadow = [
+      line(envelope({ id: "gh-1", ts: "2026-07-26T22:11:00.000Z", seq: 1 })),
+      line(envelope({ id: "li-1", name: "linear.comment.created", ts: "2026-07-26T22:13:00.000Z", seq: 3 })),
+    ].join("\n");
+    const r = run(clean, shadow);
+    const c = r.checks.find((c2) => c2.id === "MISSING_FROM_SHADOW");
+    expect(c.status).toBe("fail");
+    expect(JSON.stringify(c.evidence)).toContain("gh-2");
+  });
+});
+
+// ── the negative control itself ─────────────────────────────────────────────────────────
+
+describe("selfTest — the negative control must be OBSERVED to go red", () => {
+  test("every seeded detector fires and the positive control stays green", () => {
+    const r = selfTest();
+    const failed = r.cases.filter((c) => !c.ok).map((c) => `${c.name} (exit ${c.exitCode}, expected ${c.expectedExit})`);
+    expect(failed).toEqual([]);
+    expect(r.fired).toBe(r.negatives);
+    expect(r.positiveOk).toBe(true);
+    expect(r.allOk).toBe(true);
+  });
+
+  test("it covers the five scenarios the harness contract names, plus a positive control", () => {
+    const names = selfTest().cases.map((c) => c.name).join(" | ");
+    for (const needle of ["dropped delivery", "zero-match join", "out-of-order seq", "control record", "envelope mismatch", "positive control"]) {
+      expect(names).toContain(needle);
+    }
+  });
+});
+
+// ── the torn-tail waiver (narrow by construction) ───────────────────────────────────────
+
+describe("--tolerate-torn-tail", () => {
+  const window = { fromMs: Date.parse("2026-07-26T22:00:00Z"), toMs: Date.parse("2026-07-26T23:00:00Z"), edgeMarginMs: 0 };
+  const good = [
+    line(envelope({ id: "a", ts: "2026-07-26T22:11:00.000Z" })),
+    line(envelope({ id: "b", name: "linear.comment.created", ts: "2026-07-26T22:12:00.000Z" })),
+  ].join("\n");
+  const goodShadow = [
+    line(envelope({ id: "a", ts: "2026-07-26T22:11:00.000Z", seq: 1 })),
+    line(envelope({ id: "b", name: "linear.comment.created", ts: "2026-07-26T22:12:00.000Z", seq: 2 })),
+  ].join("\n");
+  const run = (liveText, shadowText, over = {}) => {
+    const o = opts({ ...window, ...over });
+    return evaluate({ live: ingestText("live", liveText, o), shadow: ingestText("shadow", shadowText, o), opts: o, generatedAt: "1970-01-01T00:00:00.000Z" });
+  };
+
+  test("a torn FINAL line is exit 2 unless the waiver is passed", () => {
+    expect(run(good, `${goodShadow}\n{"attributes":`).exitCode).toBe(EXIT_CANNOT_EVALUATE);
+  });
+
+  test("the waiver covers the last CONTENT line even with a trailing newline", () => {
+    const r = run(good, `${goodShadow}\n{"attributes":\n`, { tolerateTornTail: true });
+    expect(r.exitCode).toBe(EXIT_HEALTHY);
+    expect(r.waivers.some((w) => w.includes("torn final line"))).toBe(true);
+  });
+
+  test("the waiver does NOT cover a malformed line in the middle of a file", () => {
+    const r = run(good, `${line(envelope({ id: "a", ts: "2026-07-26T22:11:00.000Z", seq: 1 }))}\n{"broken":\n${line(envelope({ id: "b", name: "linear.comment.created", ts: "2026-07-26T22:12:00.000Z", seq: 2 }))}`, { tolerateTornTail: true });
+    expect(r.exitCode).toBe(EXIT_CANNOT_EVALUATE);
+    expect(r.blockers.some((b) => b.id === "MALFORMED_INPUT")).toBe(true);
+  });
+});
+
+// ── shadow-log markers (consumer declarations about its own coverage) ───────────────────
+
+describe("shadow markers", () => {
+  const window = { fromMs: Date.parse("2026-07-26T22:00:00Z"), toMs: Date.parse("2026-07-26T23:00:00Z"), edgeMarginMs: 0 };
+  const live = [
+    line(envelope({ id: "a", ts: "2026-07-26T22:11:00.000Z" })),
+    line(envelope({ id: "big", ts: "2026-07-26T22:12:00.000Z" })),
+    line(envelope({ id: "c", name: "linear.comment.created", ts: "2026-07-26T22:13:00.000Z" })),
+  ].join("\n");
+  const shadow = [
+    line(envelope({ id: "a", ts: "2026-07-26T22:11:00.000Z", seq: 1 })),
+    line(envelope({ id: "c", name: "linear.comment.created", ts: "2026-07-26T22:13:00.000Z", seq: 3 })),
+  ].join("\n");
+  const elisionMarker = JSON.stringify({
+    marker: "unmappable-payload", ts: "2026-07-26T22:12:01.000Z",
+    attributes: { "event.name": "catalyst.cloud_feed.unmappable_payload", "webhook.delivery.id": "big" },
+    seq: 2, deliveryId: "big", source: "github", eventType: "pull_request", payloadBytes: 120000,
+    reason: "payloadOmitted",
+  });
+  const run = (liveText, shadowText, over = {}) => {
+    const o = opts({ ...window, ...over });
+    return evaluate({ live: ingestText("live", liveText, o), shadow: ingestText("shadow", shadowText, o), opts: o, generatedAt: "1970-01-01T00:00:00.000Z" });
+  };
+
+  test("without a marker the elided delivery is UNEXPLAINED loss", () => {
+    const r = run(live, shadow);
+    expect(r.checks.find((c) => c.id === "MISSING_FROM_SHADOW").status).toBe("fail");
+    expect(r.join.liveOnly.unexplained).toBe(1);
+  });
+
+  test("an elision marker ATTRIBUTES the live-only delivery instead of hiding or failing it", () => {
+    const r = run(live, `${shadow}\n${elisionMarker}`);
+    expect(r.checks.find((c) => c.id === "MISSING_FROM_SHADOW").status).toBe("pass");
+    expect(r.join.liveOnly.elided).toBe(1);
+    expect(r.join.liveOnly.unexplained).toBe(0);
+    const el = r.checks.find((c) => c.id === "ELIDED_PAYLOADS");
+    expect(el.status).toBe("warn");
+    expect(JSON.stringify(el.evidence)).toContain("big");
+    // the attributed delivery must not resurface as a per-type deficit (the two checks
+    // have to agree about the same delivery) ...
+    expect(r.checks.find((c) => c.id === "TYPE_COUNTS").status).toBe("pass");
+    // ... but H1: an elided delivery genuinely never reached the shadow log, and the
+    // consumer grades it EXIT_PROBLEM. A `warn` is NON-GREEN, so the two halves of this
+    // deliverable cannot give opposite verdicts on the same event any more.
+    expect(r.exitCode).toBe(EXIT_PROBLEM);
+    expect(r.verdict).toBe("problem");
+  });
+
+  test("an UNCORROBORATED elision marker cannot excuse a loss (exit 2, not attribution)", () => {
+    // Same marker, but the payload is nowhere near the 96KB cap it claims to have hit.
+    const bogus = JSON.stringify({
+      marker: "unmappable-payload", ts: "2026-07-26T22:12:01.000Z",
+      attributes: { "event.name": "catalyst.cloud_feed.unmappable_payload", "webhook.delivery.id": "big" },
+      deliveryId: "big", reason: "payloadOmitted", payloadBytes: 12,
+    });
+    const r = run(live, `${shadow}\n${bogus}`);
+    expect(r.exitCode).toBe(EXIT_CANNOT_EVALUATE);
+    expect(r.blockers.some((b) => b.id === "UNCORROBORATED_ELISION")).toBe(true);
+  });
+
+  test("an elision marker with no reason/payloadBytes cannot attribute either", () => {
+    const bare = JSON.stringify({
+      ts: "2026-07-26T22:12:01.000Z",
+      attributes: { "event.name": "catalyst.cloud_feed.unmappable_payload", "webhook.delivery.id": "big" },
+    });
+    const r = run(live, `${shadow}\n${bare}`);
+    expect(r.exitCode).toBe(EXIT_CANNOT_EVALUATE);
+    expect(r.blockers.some((b) => b.id === "UNCORROBORATED_ELISION")).toBe(true);
+  });
+
+  test("the ELIDED_PAYLOADS row is emitted even at zero (expected-zero is a result)", () => {
+    const clean = [line(envelope({ id: "a", ts: "2026-07-26T22:11:00.000Z", seq: 1 })), line(envelope({ id: "c", name: "linear.comment.created", ts: "2026-07-26T22:13:00.000Z", seq: 3 }))].join("\n");
+    const liveClean = [line(envelope({ id: "a", ts: "2026-07-26T22:11:00.000Z" })), line(envelope({ id: "c", name: "linear.comment.created", ts: "2026-07-26T22:13:00.000Z" }))].join("\n");
+    const r = run(liveClean, clean);
+    const el = r.checks.find((c) => c.id === "ELIDED_PAYLOADS");
+    expect(el.status).toBe("pass");
+    expect(el.detail).toContain("never fired in production");
+  });
+
+  test("a consumer-declared feed gap makes the run NOT evaluable", () => {
+    const gap = JSON.stringify({ ts: "2026-07-26T22:12:00.000Z", attributes: { "event.name": "catalyst.cloud_feed.gap" }, marker: "feed-gap" });
+    const r = run(live, `${shadow}\n${gap}`);
+    expect(r.exitCode).toBe(EXIT_CANNOT_EVALUATE);
+    expect(r.blockers.some((b) => b.id === "FEED_GAP_DECLARED")).toBe(true);
+    expect(r.checks.every((c) => c.status === "not_run")).toBe(true);
+  });
+
+  test("an UNRECOGNISED marker is exit 2, not silence (a consumer rename must surface)", () => {
+    const unknown = JSON.stringify({ ts: "2026-07-26T22:12:00.000Z", attributes: { "event.name": "catalyst.cloud_feed.renamed_thing" } });
+    const r = run(live, `${shadow}\n${unknown}`);
+    expect(r.exitCode).toBe(EXIT_CANNOT_EVALUATE);
+    expect(r.blockers.some((b) => b.id === "UNKNOWN_SHADOW_MARKER")).toBe(true);
+  });
+
+  test("a marker with an unparseable ts is treated as IN window, never dropped", () => {
+    const gap = JSON.stringify({ ts: "not-a-timestamp", attributes: { "event.name": "catalyst.cloud_feed.gap" } });
+    const r = run(live, `${shadow}\n${gap}`);
+    expect(r.blockers.some((b) => b.id === "FEED_GAP_DECLARED")).toBe(true);
+  });
+
+  test("markers are not counted as webhook envelopes and are surfaced in the report", () => {
+    const r = run(live, `${shadow}\n${elisionMarker}`);
+    expect(r.scanned.shadow.webhookEnvelopes).toBe(2);
+    expect(r.scanned.shadow.markers.byKind).toEqual({ elided: 1 });
+    expect(r.markers.some((m) => m.kind === "elided" && m.deliveryId === "big")).toBe(true);
+  });
+});
+
+describe("elision attribution cannot be used to hide a real deficit", () => {
+  test("attribution discounts EXACTLY the marked deliveries, not the whole type", () => {
+    // 3 live of one type, 1 shadow, 1 marked elided -> still a net deficit of 1.
+    const rows = compareTypeCounts(
+      new Map([["github.pr.opened", 3]]),
+      new Map([["github.pr.opened", 1]]),
+      DEFAULT_TYPE_CENSUS,
+      new Map([["github.pr.opened", 1]]));
+    const row = rows.find((r) => r.type === "github.pr.opened");
+    expect(row).toMatchObject({ live: 3, shadow: 1, attributedElided: 1, verdict: "shadow-deficit" });
+  });
+
+  test("raw counts are never rewritten by the attribution (Gate B evidence stays raw)", () => {
+    const rows = compareTypeCounts(
+      new Map([["github.pr.opened", 2]]),
+      new Map([["github.pr.opened", 1]]),
+      DEFAULT_TYPE_CENSUS,
+      new Map([["github.pr.opened", 1]]));
+    const row = rows.find((r) => r.type === "github.pr.opened");
+    expect(row.live).toBe(2);
+    expect(row.shadow).toBe(1);
+    expect(row.verdict).toBe("equal-after-attribution");
+  });
+});
+
+// ────────────────────────────────────────────────────────────────────────────────────────
+// CTL-1534 review remediation — each block names the false green it prevents.
+// ────────────────────────────────────────────────────────────────────────────────────────
+
+const W = { fromMs: Date.parse("2026-07-26T22:00:00Z"), fromIso: "2026-07-26T22:00:00Z", toMs: Date.parse("2026-07-26T23:00:00Z"), toIso: "2026-07-26T23:00:00Z" };
+const ev = (id, ts, seq, name = "github.pr.opened") => line(envelope({ id, ts, seq, name }));
+const runW = (liveText, shadowText, over = {}) => {
+  const o = opts({ ...W, ...over });
+  return evaluate({ live: ingestText("live", liveText, o), shadow: ingestText("shadow", shadowText, o), opts: o, generatedAt: "1970-01-01T00:00:00.000Z" });
+};
+
+// C2 / H7 / H14 — a margin that can swallow the whole window is a detector that cannot fire
+describe("the edge margin can never swallow the window", () => {
+  const live = [ev("a", "2026-07-26T22:01:00.000Z"), ev("b", "2026-07-26T22:01:30.000Z"), ev("c", "2026-07-26T22:02:00.000Z", null, "linear.comment.created")].join("\n");
+  const shadow = [ev("a", "2026-07-26T22:01:00.000Z", 1), ev("d", "2026-07-26T22:01:30.000Z", 2), ev("c", "2026-07-26T22:02:00.000Z", 3, "linear.comment.created")].join("\n");
+
+  test("a 3-minute window at the DEFAULT 120s margin is exit 2, not a green with two vacuous detectors", () => {
+    const r = runW(live, shadow, { fromMs: Date.parse("2026-07-26T22:00:00Z"), toMs: Date.parse("2026-07-26T22:03:00Z"), toIso: "2026-07-26T22:03:00Z" });
+    expect(r.exitCode).toBe(EXIT_CANNOT_EVALUATE);
+    expect(r.blockers.some((b) => b.id === "EDGE_MARGIN_SWALLOWS_WINDOW")).toBe(true);
+    expect(r.checks.every((c) => c.status === "not_run")).toBe(true);
+  });
+
+  test("the same bytes with a wide-enough window DO fail the loss detector (the check works)", () => {
+    const r = runW(live, shadow, { edgeMarginMs: 0 });
+    expect(r.exitCode).toBe(EXIT_PROBLEM);
+    expect(r.checks.find((c) => c.id === "MISSING_FROM_SHADOW").status).toBe("fail");
+  });
+
+  test("an UNBOUNDED window with a non-zero margin refuses to derive the boundary from the data", () => {
+    const o = opts({ fromMs: null, fromIso: null, toMs: null, toIso: null });
+    const r = evaluate({ live: ingestText("live", live, o), shadow: ingestText("shadow", shadow, o), opts: o, generatedAt: "1970-01-01T00:00:00.000Z" });
+    expect(r.exitCode).toBe(EXIT_CANNOT_EVALUATE);
+    expect(r.blockers.some((b) => b.id === "UNBOUNDED_WINDOW")).toBe(true);
+  });
+
+  test("unbounded is allowed only with --edge-margin 0 (nothing is edge-excluded then)", () => {
+    const o = opts({ fromMs: null, fromIso: null, toMs: null, toIso: null, edgeMarginMs: 0 });
+    const r = evaluate({ live: ingestText("live", live, o), shadow: ingestText("shadow", shadow, o), opts: o, generatedAt: "1970-01-01T00:00:00.000Z" });
+    expect(r.blockers.some((b) => b.id === "UNBOUNDED_WINDOW")).toBe(false);
+    expect(r.checks.find((c) => c.id === "MISSING_FROM_SHADOW").status).toBe("fail");
+  });
+
+  test("a detector whose every candidate was edge-excluded is not_run — never a pass", () => {
+    // one matched pair near the end keeps the overlap gate quiet; the single one-sided
+    // delivery sits inside the trailing 120s margin.
+    const l = [ev("a", "2026-07-26T22:10:00.000Z"), ev("z", "2026-07-26T22:59:00.000Z"), ev("edge", "2026-07-26T22:59:30.000Z"), ev("li", "2026-07-26T22:11:00.000Z", null, "linear.comment.created")].join("\n");
+    const s = [ev("a", "2026-07-26T22:10:00.000Z", 1), ev("z", "2026-07-26T22:59:00.000Z", 2), ev("li", "2026-07-26T22:11:00.000Z", 3, "linear.comment.created")].join("\n");
+    const r = runW(l, s);
+    const c = r.checks.find((x) => x.id === "MISSING_FROM_SHADOW");
+    expect(c.status).toBe("not_run");
+    expect(r.exitCode).toBe(EXIT_CANNOT_EVALUATE);
+  });
+});
+
+// C4 — --require-coverage must guard EVERY route to an unasserted coverage answer
+describe("--require-coverage cannot be satisfied by a demotion to not-asserted", () => {
+  const live = [ev("a", "2026-07-26T22:11:00.000Z"), ev("c", "2026-07-26T22:13:00.000Z", null, "linear.comment.created")].join("\n");
+  const shadow = [ev("a", "2026-07-26T22:11:00.000Z", 101), ev("c", "2026-07-26T22:13:00.000Z", 102, "linear.comment.created")].join("\n");
+
+  test("with expectations but WITHOUT --seq-ledger-complete it is exit 2, not healthy", () => {
+    const r = runW(live, shadow, { requireCoverage: true, expectFirstSeq: 101, expectHeadSeq: 200 });
+    expect(r.exitCode).toBe(EXIT_CANNOT_EVALUATE);
+    const b = r.blockers.find((x) => x.id === "COVERAGE_REQUIRED");
+    expect(b.evidence.missing.join(" ")).toContain("--seq-ledger-complete");
+  });
+
+  test("with --no-seq-checks it is exit 2, not healthy", () => {
+    const r = runW(live, shadow, { requireCoverage: true, expectFirstSeq: 101, expectHeadSeq: 200, seqLedgerComplete: true, seqChecks: false });
+    expect(r.exitCode).toBe(EXIT_CANNOT_EVALUATE);
+    expect(r.blockers.some((x) => x.id === "COVERAGE_REQUIRED")).toBe(true);
+  });
+
+  test("with every precondition met the coverage question is actually ANSWERED (and red here)", () => {
+    const r = runW(live, shadow, { requireCoverage: true, expectFirstSeq: 101, expectHeadSeq: 200, seqLedgerComplete: true });
+    expect(r.blockers.some((x) => x.id === "COVERAGE_REQUIRED")).toBe(false);
+    expect(r.checks.find((c) => c.id === "SEQ_COVERAGE").status).toBe("fail");
+    expect(r.exitCode).toBe(EXIT_PROBLEM);
+  });
+});
+
+// C7 — the census is consulted in BOTH directions; presence never classifies
+describe("shadow > live is classified by the CENSUS, not by presence", () => {
+  test("a censused `both` type the live side lost 100% of is a live-total-loss, not a superset", () => {
+    const rows = compareTypeCounts(new Map(), new Map([["github.deployment_status.success", 40]]));
+    const row = rows.find((r) => r.type === "github.deployment_status.success");
+    expect(row.expectation).toBe("both");
+    expect(row.verdict).toBe("live-total-loss");
+  });
+
+  test("a partial live-side deficit on a `both` type is a live-deficit", () => {
+    const rows = compareTypeCounts(new Map([["github.pr.opened", 2]]), new Map([["github.pr.opened", 41]]));
+    expect(rows.find((r) => r.type === "github.pr.opened").verdict).toBe("live-deficit");
+  });
+
+  test("a cloud-only type is still the expected superset", () => {
+    const rows = compareTypeCounts(new Map(), new Map([["github.check_suite.completed", 9]]));
+    expect(rows.find((r) => r.type === "github.check_suite.completed").verdict).toBe("cloud-superset");
+  });
+
+  test("end to end: a total live-side loss of a `both` type is exit 1, not a green run", () => {
+    const live = [ev("a", "2026-07-26T22:11:00.000Z"), ev("c", "2026-07-26T22:13:00.000Z", null, "linear.comment.created")].join("\n");
+    const shadow = [
+      ev("a", "2026-07-26T22:11:00.000Z", 1),
+      ev("c", "2026-07-26T22:13:00.000Z", 2, "linear.comment.created"),
+      ev("d1", "2026-07-26T22:14:00.000Z", 3, "github.deployment_status.success"),
+      ev("d2", "2026-07-26T22:15:00.000Z", 4, "github.deployment_status.success"),
+    ].join("\n");
+    const r = runW(live, shadow);
+    expect(r.exitCode).toBe(EXIT_PROBLEM);
+    expect(r.checks.find((c) => c.id === "LIVE_DEFICIT_TYPES").status).toBe("fail");
+    // and the shadow-only split must not have called them "expected superset"
+    expect(r.join.shadowOnly.superset).toBe(0);
+    expect(r.join.shadowOnly.overlapping).toBe(2);
+  });
+});
+
+// H1 / H11 — a detected loss must not render as evaluated-healthy
+describe("warn is NON-GREEN; only info leaves the verdict alone", () => {
+  test("overlapping-type shadow-only (a smee-side drop) exits 1", () => {
+    const live = [ev("a", "2026-07-26T22:11:00.000Z"), ev("c", "2026-07-26T22:13:00.000Z", null, "linear.comment.created")].join("\n");
+    const shadow = [ev("a", "2026-07-26T22:11:00.000Z", 1), ev("c", "2026-07-26T22:13:00.000Z", 2, "linear.comment.created"), ev("extra", "2026-07-26T22:12:00.000Z", 3)].join("\n");
+    const r = runW(live, shadow);
+    expect(r.checks.find((c) => c.id === "SHADOW_ONLY").status).toBe("warn");
+    expect(r.verdict).toBe("problem");
+    expect(r.exitCode).toBe(EXIT_PROBLEM);
+  });
+
+  test("a known-gap loss is reported AND non-green (it is still a real gap)", () => {
+    const live = [ev("a", "2026-07-26T22:11:00.000Z"), ev("rx", "2026-07-26T22:12:00.000Z", null, "linear.reaction.created"), ev("c", "2026-07-26T22:13:00.000Z", null, "linear.comment.created")].join("\n");
+    const shadow = [ev("a", "2026-07-26T22:11:00.000Z", 1), ev("c", "2026-07-26T22:13:00.000Z", 2, "linear.comment.created")].join("\n");
+    const r = runW(live, shadow);
+    expect(r.checks.find((c) => c.id === "KNOWN_GAP_LOSSES").status).toBe("warn");
+    expect(r.exitCode).toBe(EXIT_PROBLEM);
+  });
+
+  test("a live-side duplicate delivery is `info` — a provider redelivery contributes no warn", () => {
+    const live = [ev("a", "2026-07-26T22:11:00.000Z"), ev("a", "2026-07-26T22:11:30.000Z"), ev("c", "2026-07-26T22:13:00.000Z", null, "linear.comment.created")].join("\n");
+    const shadow = [ev("a", "2026-07-26T22:11:00.000Z", 1), ev("c", "2026-07-26T22:13:00.000Z", 2, "linear.comment.created")].join("\n");
+    const r = runW(live, shadow);
+    expect(r.checks.find((c) => c.id === "DUPLICATE_DELIVERY_LIVE").status).toBe("info");
+    // it raises no warn of its own (the per-type deficit the second copy creates is a
+    // separate, genuine signal and is allowed to speak for itself)
+    expect(r.counts.warn).toBe(0);
+    expect(r.counts.info).toBe(1);
+  });
+});
+
+// H8 — the marker prefix is a floor, not a switch
+describe("marker detection cannot be turned off by a flag", () => {
+  test("an empty --marker-prefix is rejected at parse time", () => {
+    expect(parseArgs(["--marker-prefix", ""]).ok).toBe(false);
+    expect(parseArgs(["--seq-attr", ""]).ok).toBe(false);
+  });
+
+  test("re-pointing --marker-prefix still surfaces a built-in consumer gap declaration", () => {
+    const live = [ev("a", "2026-07-26T22:11:00.000Z"), ev("c", "2026-07-26T22:13:00.000Z", null, "linear.comment.created")].join("\n");
+    const shadow = [ev("a", "2026-07-26T22:11:00.000Z", 1), ev("c", "2026-07-26T22:13:00.000Z", 2, "linear.comment.created"),
+      JSON.stringify({ ts: "2026-07-26T22:12:00.000Z", attributes: { "event.name": "catalyst.cloud_feed.gap" }, reason: "cursor_underflow" })].join("\n");
+    const r = runW(live, shadow, { markerPrefix: "something.else." });
+    expect(r.exitCode).toBe(EXIT_CANNOT_EVALUATE);
+    expect(r.blockers.some((b) => b.id === "FEED_GAP_DECLARED")).toBe(true);
+  });
+});
+
+// M3 / M6 — zero evidence and scoped-away questions are stated, never printed as passes
+describe("a question that was not answered is never a green row", () => {
+  test("an empty shadow window does not print three green seq rows", () => {
+    const live = [ev("a", "2026-07-26T22:11:00.000Z"), ev("c", "2026-07-26T22:13:00.000Z", null, "linear.comment.created")].join("\n");
+    const r = runW(live, "", { seqLedgerComplete: true, expectHeadSeq: 500 });
+    for (const id of ["SEQ_WIRE_ORDER", "SEQ_CONTIGUITY", "SEQ_COVERAGE"]) {
+      expect(r.checks.some((c) => c.id === id && c.status === "pass")).toBe(false);
+      expect(r.notAsserted.some((n) => n.id === id)).toBe(true);
+    }
+  });
+
+  test("SEQ_COVERAGE fails on an EMPTY replay while a head was expected", () => {
+    const live = [ev("a", "2026-07-26T22:11:00.000Z"), ev("c", "2026-07-26T22:13:00.000Z", null, "linear.comment.created")].join("\n");
+    const shadow = [ev("a", "2026-07-26T22:11:00.000Z", 101), ev("c", "2026-07-26T22:13:00.000Z", 102, "linear.comment.created")].join("\n");
+    // seqs present (so the subsystem runs) but the operator asked for head 500
+    const r = runW(live, shadow, { seqLedgerComplete: true, expectHeadSeq: 500 });
+    expect(r.checks.find((c) => c.id === "SEQ_COVERAGE").status).toBe("fail");
+  });
+
+  test("a source scoped out by --sources is a STATED not-asserted row, not an omission", () => {
+    const live = [ev("a", "2026-07-26T22:11:00.000Z"), ev("c", "2026-07-26T22:13:00.000Z", null, "linear.comment.created")].join("\n");
+    const shadow = [ev("a", "2026-07-26T22:11:00.000Z", 1), ev("c", "2026-07-26T22:13:00.000Z", 2, "linear.comment.created")].join("\n");
+    const r = runW(live, shadow, { sources: ["github"] });
+    expect(r.notAsserted.some((n) => n.id === "MATCHED_NONZERO_linear")).toBe(true);
+  });
+});


### PR DESCRIPTION
Phase 3 of the smee → Catalyst Cloud event-delivery cutover (ADR-0008 leg 3). CTL-1534.

**Deliberately a DRAFT.** The machinery is built, its negative controls are observed to fire, and the ten known defects listed in the original draft are now fixed — but the central claim is still not demonstrated. Details below. I'd rather this sit visible and honest than merge a harness that can report a false green.

## What's here

- **`cloud-event-consumer.mjs`** — polls the cloud `/events/stream`, dedups on `deliveryId`, maps each **raw** payload through the **unmodified** orch-monitor mappers (no second mapper — both paths must run identical mapping code, so any diff is transport or coverage, never mapping), stamps `webhook.delivery.id` + the feed seq, appends to a **shadow** log.
- **`parity-harness.mjs`** — joins shadow ↔ live on `webhook.delivery.id`; asserts **coverage and integrity separately**, per-source **non-zero** matched pairs, per-type **counts** (never presence) for the Gate B superset.
- Three-way exit on both (`0` healthy / `1` problem / `2` **could not evaluate**) and credential-free offline negative controls.

## Process

Built, then adversarially reviewed against the **11 real defects** catalyst-cloud found in its equivalent harness. The review found **35 (8 critical)** — every one *reproduced by execution*, not argued. All 8 criticals + 15 highs fixed and independently re-verified **by execution** (58 confirmed). A second round then closed the 10 defects that re-verification had left open (below).

The most instructive defect came from the build structure itself: the consumer never stamped a cloud-seq attribute, so the harness's entire seq subsystem keyed on an attribute that was never present — **evaluating nothing while passing**. Building the two halves in parallel produced exactly the false-green class the tool exists to prevent.

**The safety-critical fix, done by hand rather than delegated:** the shadow-dir guard was purely **lexical**, and `resolve()` does not follow symlinks. A symlinked `<root>/events-shadow → <root>/events` passed every check and would have written the **live** event log — double-waking every worker — while the safety self-test printed PASS. Now: refuses a symlinked shadow dir, re-checks on `realpath`, and writes `shadow-YYYY-MM.jsonl` so a shadow write can never even share the live basename. Regression tests reproduce the original attack.

## Round 2 — the ten known defects are FIXED

Each fix is pinned by a regression test that **fails on the pre-fix code**. Verified by mutation: every one of the eleven behaviours below was individually reverted and the suite went red.

| id | issue | fix |
|---|---|---|
| H | interior-page gap did **not** pin the cursor (only late-start did) → could advance past a proven hole | ✅ any proven hole pins the cursor and writes a durable `feed-gap` marker, wherever it sits in the page |
| H | marker `ts` was wall-clock while envelopes use `receivedAt` → markers fell outside their own window | ✅ markers anchor `ts` on `receivedAt`; the wall clock is kept separately as `emittedAt`, with `tsSource` naming which is which |
| M11 | a dedup-only pass (0 appended) still exited 0 | ✅ exit 2 — a pass that appended nothing confirmed nothing. Gated on an otherwise-healthy pass so a cursor pinned at a hole keeps its stronger, evaluated verdict |
| H10 | mapper-decline detector implemented only for *zero* appends; a **partial** regression was invisible | ✅ `classifyDecline` splits schema drift (structural) from a routine unhandled action; a structural decline on a declared-mappable type is a problem at **any** ratio |
| M | `provenHole` could assert a hole that doesn't exist under wire-order inversions | ✅ holes derive from the received **set** (`computeMissingRanges`), not `firstSeq`. Order and presence are separate questions; wire-order integrity is unchanged and still unsorted |
| M | durable marker writes sat outside the try/catch → wrong exit class on a write failure | ✅ single guarded `writeMarker`; a failed write is exit 2 with a named reason, never an escaped throw |
| M | edge-exclusion `not_run` was all-or-nothing; a partial exclusion still passed | ✅ `MISSING_FROM_SHADOW_EDGE_EXCLUDED` / `SHADOW_ONLY_EDGE_EXCLUDED` enumerate the waived candidates instead of folding them into a bare `pass` |
| M1 | config-read failures failed **open** (empty roster/bot set) instead of exit 2 | ✅ an empty roster or bot set is exit 2; a deliberate degradation must be **declared** via `--allow-empty-config`; a config file that exists but doesn't parse now throws |
| L | `seqOf()` coerced a string seq — evidence normalisation, the rule it violates | ✅ rejected as `SEQ_ATTR_INVALID`. The consumer stamps a number; a string means the producer changed shape |
| L | CI `bun test <file>` silently ignored a renamed/missing file and exited 0 | ✅ a guard step asserts every `bun test` argument resolves first. The list is parsed out of the workflow (never duplicated), resolution is by suffix (a bun-test arg is a filename filter), and a parse yielding nothing fails too |

**Plus the `KNOWN_GAP_LOSSES` alert-fatigue wrinkle:** it is now `info`, not `warn`. Every delivery it counts already matched a census row naming an open ticket, so `warn` held the harness permanently red for that ticket's whole life — which is precisely how a signal gets trained out of. The distinction the exit code must preserve is **new/uninvestigated** vs **known/filed**: an uncensused loss is not counted here at all and still **fails** `MISSING_FROM_SHADOW`. `--strict-known-gaps` escalates the tracked ones to a hard fail for the phase-5 close-out.

## Verification

- `bun test cloud-event-consumer.test.mjs parity-harness.test.mjs` → **272 pass, 0 fail** (was 243)
- `cloud-event-consumer.mjs --self-test` → **36 cases, 29 detectors expected red, 36 correct** (was 30/30)
- `parity-harness.mjs --self-test` → **34/34 detectors fired**, positive control green (was 31/31)
- Mutation check: each of the 11 fixed behaviours reverted individually → the suite goes red for each

## Still a draft — why

**The central claim is undemonstrated.** No non-zero shadow↔live join has been observed. The laptop's live log has no `webhook.delivery.id` rows (off-roster, monitor not running); `mini` has them only since CTL-1532. **This must be proven on `mini` before any parity claim** — a separate, deliberate step, not part of this round.

## Not done

- Not deployed anywhere.
- Gate A's ≥7-day parity window is calendar time, not work. This PR is the machinery plus evidence the machinery detects failure — **not** a completed parity run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
