### PR TITLE
fix(dev): CTL-1567 clear needs-human the moment a human responds

### DIFF
--- a/plugins/dev/scripts/execution-core/daemon.mjs
+++ b/plugins/dev/scripts/execution-core/daemon.mjs
@@ -122,6 +122,7 @@ import {
   defaultClearStall, // CTL-1067: J3 stall-clear seam
 } from "./scheduler.mjs";
 import * as linearWrite from "./linear-write.mjs"; // CTL-1067: writeStatus for defaultClearStall
+import { labelMarkerBase } from "./label-guard.mjs"; // CTL-1567: canonical once-marker path (single source of truth)
 import { appendWorkerTransitionEvent as defaultAppendWorkerTransitionEvent } from "./worker-transition-event.mjs"; // CTL-764 finding 11: needs-input→cleared on comment wake
 import {
   writeBootMarker,
@@ -324,24 +325,55 @@ function ensureState(orchDir) {
   }
 }
 
+// defaultIsManagedTicket — CTL-1567 (Codex P1): does THIS installation manage the
+// ticket? Two independent proofs, either is sufficient:
+//   1. a local `workers/<TICKET>/` dir exists — Catalyst has demonstrably run it; or
+//   2. the ticket's team prefix is a registered project in registry.json — the
+//      ticket is in scope even though its worker dir was reaped (the exact case
+//      this whole change exists to serve).
+// Fails CLOSED: an unreadable/absent registry with no worker dir ⇒ false, so a
+// misconfigured host never mutates labels on tickets it does not own.
+export function defaultIsManagedTicket(ticket, orchDir) {
+  if (!ticket || !orchDir) return false;
+  try {
+    if (existsSync(join(orchDir, "workers", ticket))) return true;
+  } catch {
+    /* fall through to the registry check */
+  }
+  const prefix = String(ticket).split("-")[0];
+  if (!prefix) return false;
+  try {
+    const reg = JSON.parse(readFileSync(join(orchDir, "registry.json"), "utf8"));
+    return (reg?.projects ?? []).some((p) => p?.team === prefix);
+  } catch {
+    return false; // no registry ⇒ prove nothing ⇒ touch nothing
+  }
+}
+
 // clearNeedsHumanMarkers — CTL-1567: delete the once-markers that pair with the
 // `needs-human` Linear label, so a cleared label and the local marker can never
-// disagree. Mirrors the marker path in label-guard.mjs (`labelMarkerBase`) and
-// the pair that clearStalledLabel removes. Best-effort: a missing marker (the
-// common case — most parked tickets have no worker dir at all) is success, not
-// an error. Returns the paths actually removed, for logging/tests.
+// disagree. Uses label-guard's `labelMarkerBase` — the SAME path builder labelOnce
+// and clearStalledLabel use — rather than a second copy of the layout, so the
+// marker naming can never drift between the writer and this reconciler.
+// A missing marker is success, not an error: most parked tickets have no worker
+// dir at all. A REAL failure (permissions, EIO) is surfaced to the caller rather
+// than swallowed, so a marker we could not delete is never reported as reconciled.
 export function clearNeedsHumanMarkers(orchDir, ticket, { rm = unlinkSync } = {}) {
-  const base = join(orchDir, "workers", ticket, ".linear-label-needs-human");
+  const base = labelMarkerBase(orchDir, ticket, "needs-human");
   const removed = [];
+  const failed = [];
   for (const suffix of [".applied", ".skipped"]) {
+    const p = `${base}${suffix}`;
     try {
-      rm(`${base}${suffix}`);
-      removed.push(`${base}${suffix}`);
-    } catch {
-      /* absent → nothing to reconcile for this suffix */
+      rm(p);
+      removed.push(p);
+    } catch (err) {
+      // ENOENT is the expected, benign case. Anything else means the marker is
+      // still on disk and the label/marker pair is now inconsistent.
+      if (err?.code !== "ENOENT") failed.push({ path: p, code: err?.code });
     }
   }
-  return removed;
+  return { removed, failed };
 }
 
 // handleCommentWake — CTL-549 re-dispatch hook. Called on each
@@ -364,6 +396,13 @@ export async function handleCommentWake(
     // CTL-764 finding 11: canonical worker.transition emitter for the needs-input→
     // cleared resolution. Injectable for tests; defaults to the real appender.
     appendWorkerTransitionEvent = defaultAppendWorkerTransitionEvent,
+    // CTL-1567 (Codex P1): is this ticket managed by THIS Catalyst installation?
+    // The daemon receives EVERY workspace `linear.comment.created`, so without this
+    // gate the no-worker-dir clear below would strip a same-named `needs-human`
+    // label off a ticket Catalyst has never owned — and burn one Linear write per
+    // workspace comment. Defaults to the real registry check (no wiring required,
+    // so an unwired production path is still SAFE, not silently permissive).
+    isManagedTicket = defaultIsManagedTicket,
   }
 ) {
   const { ticket } = parsed ?? {};
@@ -393,19 +432,46 @@ export async function handleCommentWake(
   // is what grows the inbox without bound. Idempotent: removeLabel reports the
   // already-absent case as removed:true, so this is safe to run on every comment
   // and safe to run concurrently on both hosts.
+  //
+  // TWO GATES, both fail CLOSED (Codex P1 ×2). Unlike the self-echo guard above —
+  // which may fail open because its only job is suppressing a re-dispatch — this
+  // path MUTATES Linear on a ticket that may have no local state at all, so
+  // "not sure" must mean "don't touch it":
+  //
+  //  (a) POSITIVE human provenance. `_isBotId` returns false when botUserId is
+  //      unset/malformed OR when authorId is absent, so "not a known bot" does NOT
+  //      imply "a human". In that supported fail-open config the escalation posts
+  //      its own app-actor explanation comment, whose webhook would then strip the
+  //      label it had just applied while the recovery intent stayed latched —
+  //      silently defeating the escalation. Require a known author AND a
+  //      configured bot set before believing a human answered.
+  //  (b) MANAGED ticket. The daemon sees every workspace comment; only clear on
+  //      tickets this installation actually manages.
+  const humanProvenance = Boolean(parsed.authorId) && Boolean(botUserId);
   let clearedNeedsHuman = false;
-  try {
-    const res = await removeLabel(ticket, "needs-human");
-    clearedNeedsHuman = res?.removed !== false; // undefined (test stub) ⇒ success
-  } catch {
-    /* fail-open — a Linear write failure must never block the wake path */
+  if (humanProvenance && isManagedTicket(ticket, orchDir)) {
+    try {
+      const res = await removeLabel(ticket, "needs-human");
+      clearedNeedsHuman = res?.removed !== false; // undefined (test stub) ⇒ success
+    } catch {
+      /* fail-open on the WRITE — a Linear 5xx must not block the wake path */
+    }
   }
   if (clearedNeedsHuman) {
     // Keep the once-marker in step with the label. Clearing one without the other
     // is the desync that leaves labelOnce permanently disarmed (or the board
     // showing a park Linear no longer has).
     try {
-      clearNeedsHumanMarkers(orchDir, ticket);
+      const { failed } = clearNeedsHumanMarkers(orchDir, ticket);
+      if (failed.length) {
+        // The label is gone from Linear but a marker survived: labelOnce stays
+        // disarmed for this ticket. Surface it — a silent swallow here is exactly
+        // the desync this change exists to prevent.
+        log.error(
+          { ticket, failed },
+          "handleCommentWake: needs-human marker NOT removed — labelOnce stays disarmed for this ticket"
+        );
+      }
     } catch (err) {
       log.warn(
         { ticket, err: err?.message },

--- a/plugins/dev/scripts/execution-core/daemon.mjs
+++ b/plugins/dev/scripts/execution-core/daemon.mjs
@@ -123,6 +123,7 @@ import {
 } from "./scheduler.mjs";
 import * as linearWrite from "./linear-write.mjs"; // CTL-1067: writeStatus for defaultClearStall
 import { labelMarkerBase } from "./label-guard.mjs"; // CTL-1567: canonical once-marker path (single source of truth)
+import { defaultForgetIntent } from "./recovery-reasoning.mjs"; // CTL-1567: re-arm recovery when a human responds
 import { appendWorkerTransitionEvent as defaultAppendWorkerTransitionEvent } from "./worker-transition-event.mjs"; // CTL-764 finding 11: needs-input→cleared on comment wake
 import {
   writeBootMarker,
@@ -403,6 +404,13 @@ export async function handleCommentWake(
     // workspace comment. Defaults to the real registry check (no wiring required,
     // so an unwired production path is still SAFE, not silently permissive).
     isManagedTicket = defaultIsManagedTicket,
+    // CTL-1567 (Codex P1): a human response must RE-ARM recovery, not just unpark.
+    // Clearing the label alone leaves `.recovery-intents/<TICKET>.json` latched
+    // `escalated:true` for up to 7 days, so the terminal sweep re-applies
+    // needs-human while the latch suppresses any fresh attempt — the ticket
+    // silently returns to the inbox and cannot be retried. A human answering IS
+    // the signal that another attempt is warranted.
+    forgetIntent = defaultForgetIntent,
   }
 ) {
   const { ticket } = parsed ?? {};
@@ -455,6 +463,26 @@ export async function handleCommentWake(
       clearedNeedsHuman = res?.removed !== false; // undefined (test stub) ⇒ success
     } catch {
       /* fail-open on the WRITE — a Linear 5xx must not block the wake path */
+    }
+    // CTL-1567 (Codex P1): `needs-input` is the OTHER park label, and the board
+    // treats either as a Needs-You ticket (it synthesizes no-worker-dir cards from
+    // both). Clearing only needs-human left a parked needs-input ticket in the
+    // inbox after the human answered — while this path claimed to be the complete
+    // response. Both labels are the same fact from the operator's side.
+    try {
+      await removeLabel(ticket, "needs-input");
+    } catch {
+      /* fail-open — same reasoning as above */
+    }
+    // Re-arm recovery: without this the latch survives and suppresses the retry
+    // this response was meant to authorize (see the forgetIntent option above).
+    try {
+      forgetIntent(ticket, { orchDir });
+    } catch (err) {
+      log.warn(
+        { ticket, err: err?.message },
+        "handleCommentWake: recovery-intent re-arm failed — a retry may stay suppressed"
+      );
     }
   }
   if (clearedNeedsHuman) {

--- a/plugins/dev/scripts/execution-core/daemon.mjs
+++ b/plugins/dev/scripts/execution-core/daemon.mjs
@@ -324,6 +324,26 @@ function ensureState(orchDir) {
   }
 }
 
+// clearNeedsHumanMarkers — CTL-1567: delete the once-markers that pair with the
+// `needs-human` Linear label, so a cleared label and the local marker can never
+// disagree. Mirrors the marker path in label-guard.mjs (`labelMarkerBase`) and
+// the pair that clearStalledLabel removes. Best-effort: a missing marker (the
+// common case — most parked tickets have no worker dir at all) is success, not
+// an error. Returns the paths actually removed, for logging/tests.
+export function clearNeedsHumanMarkers(orchDir, ticket, { rm = unlinkSync } = {}) {
+  const base = join(orchDir, "workers", ticket, ".linear-label-needs-human");
+  const removed = [];
+  for (const suffix of [".applied", ".skipped"]) {
+    try {
+      rm(`${base}${suffix}`);
+      removed.push(`${base}${suffix}`);
+    } catch {
+      /* absent → nothing to reconcile for this suffix */
+    }
+  }
+  return removed;
+}
+
 // handleCommentWake — CTL-549 re-dispatch hook. Called on each
 // `linear.comment.created` event by the daemon's `onComment` callback wired
 // into startMonitor. Scans all phase signals for the comment's ticket; for
@@ -354,6 +374,56 @@ export async function handleCommentWake(
   // writers' guard. botUserId accepts a string or Set<string>.
   if (_isBotId(botUserId, parsed.authorId)) return;
 
+  // CTL-1567: CLEAR FIRST — a human answered, so the ticket must drop off the
+  // "Needs you" list before anything else is attempted, and regardless of whether
+  // anything else succeeds.
+  //
+  // This used to happen only deep inside the per-signal loop below, which made it
+  // conditional on host-local state that has nothing to do with the label:
+  //   • no `workers/<TICKET>/` dir  → the `catch { return }` below fired and the
+  //     comment was silently dropped. The label lives in LINEAR; a reaped worker
+  //     directory must not make it permanently unclearable. Measured 2026-07-29:
+  //     10 of 12 parked tickets had no worker dir on either host.
+  //   • `status: "needs-human"`     → matched neither the `stalled` nor the
+  //     `needs-input` branch, so the ONE status that means "parked for a human"
+  //     was the one the wake path ignored.
+  //
+  // Re-adding is cheap and already automatic (`labelOnce` re-applies it if the
+  // ticket still needs a human after this response is processed); never-clearing
+  // is what grows the inbox without bound. Idempotent: removeLabel reports the
+  // already-absent case as removed:true, so this is safe to run on every comment
+  // and safe to run concurrently on both hosts.
+  let clearedNeedsHuman = false;
+  try {
+    const res = await removeLabel(ticket, "needs-human");
+    clearedNeedsHuman = res?.removed !== false; // undefined (test stub) ⇒ success
+  } catch {
+    /* fail-open — a Linear write failure must never block the wake path */
+  }
+  if (clearedNeedsHuman) {
+    // Keep the once-marker in step with the label. Clearing one without the other
+    // is the desync that leaves labelOnce permanently disarmed (or the board
+    // showing a park Linear no longer has).
+    try {
+      clearNeedsHumanMarkers(orchDir, ticket);
+    } catch (err) {
+      log.warn(
+        { ticket, err: err?.message },
+        "handleCommentWake: needs-human marker reconcile failed — label already cleared"
+      );
+    }
+    try {
+      appendWorkerTransitionEvent({
+        ticket,
+        from: "needs-human",
+        to: "cleared",
+        reason: "human-responded",
+      });
+    } catch {
+      /* observability only */
+    }
+  }
+
   const workerDir = join(orchDir, "workers", ticket);
   let signalFiles;
   try {
@@ -361,6 +431,7 @@ export async function handleCommentWake(
       (f) => f.startsWith("phase-") && f.endsWith(".json")
     );
   } catch {
+    // No local worker state: the label clear above is the entire correct response.
     return;
   }
 
@@ -376,7 +447,12 @@ export async function handleCommentWake(
     // the J3 seam (delete the synthetic stalled signal + remove the needs-human
     // label & markers + .orphan-detected). The scheduler re-derives advancement
     // from the preserved prior-done signal and re-dispatches the phase fresh.
-    if (sig.status === "stalled") {
+    // CTL-1567: `needs-human` is a SECOND signal status meaning exactly what
+    // `stalled` means (written by recovery-emit.mjs / recovery-reasoning.mjs).
+    // It matched neither branch here, so an operator answering one of those
+    // tickets got no stall clear and no re-dispatch. Treat the two identically
+    // until the duplicate status is normalized away (CTL-1552).
+    if (sig.status === "stalled" || sig.status === "needs-human") {
       const phase = fname.slice("phase-".length, -".json".length);
       try {
         clearStall({ ticket, phase });

--- a/plugins/dev/scripts/execution-core/daemon.test.mjs
+++ b/plugins/dev/scripts/execution-core/daemon.test.mjs
@@ -1507,9 +1507,11 @@ describe("handleCommentWake (CTL-549)", () => {
     const orch = tmpOrcDir(); // deliberately no workers/<TICKET>/ at all
     const removed = [];
     await handleCommentWake(
-      { ticket: "CTL-NODIR", body: "here is your answer" },
+      { ticket: "PROJ-NODIR", body: "here is your answer", authorId: "human-1" },
       {
         orchDir: orch,
+        botUserId: "bot-uuid",
+        isManagedTicket: () => true,
         dispatch: () => ({ code: 0 }),
         removeLabel: async (ticket, label) => {
           removed.push({ ticket, label });
@@ -1517,20 +1519,22 @@ describe("handleCommentWake (CTL-549)", () => {
       }
     );
     // The label lives in Linear; a reaped worker dir must not make it unclearable.
-    expect(removed).toContainEqual({ ticket: "CTL-NODIR", label: "needs-human" });
+    expect(removed).toContainEqual({ ticket: "PROJ-NODIR", label: "needs-human" });
   });
 
   test("REGRESSION: clears needs-human for a signal with status=needs-human", async () => {
     const orch = tmpOrcDir();
     // recovery-emit.mjs / recovery-reasoning.mjs write THIS status, which matched
     // neither the `stalled` nor the `needs-input` branch.
-    writeSignal(orch, "CTL-NH", "implement", { status: "needs-human" });
+    writeSignal(orch, "PROJ-NH", "implement", { status: "needs-human" });
     const removed = [];
     const cleared = [];
     await handleCommentWake(
-      { ticket: "CTL-NH", body: "answered" },
+      { ticket: "PROJ-NH", body: "answered", authorId: "human-1" },
       {
         orchDir: orch,
+        botUserId: "bot-uuid",
+        isManagedTicket: () => true,
         dispatch: () => ({ code: 0 }),
         removeLabel: async (ticket, label) => {
           removed.push({ ticket, label });
@@ -1541,16 +1545,16 @@ describe("handleCommentWake (CTL-549)", () => {
         },
       }
     );
-    expect(removed).toContainEqual({ ticket: "CTL-NH", label: "needs-human" });
+    expect(removed).toContainEqual({ ticket: "PROJ-NH", label: "needs-human" });
     // …and it is treated like `stalled`, so the stall is cleared too.
-    expect(cleared).toContainEqual({ ticket: "CTL-NH", phase: "implement" });
+    expect(cleared).toContainEqual({ ticket: "PROJ-NH", phase: "implement" });
   });
 
   test("the bot's OWN comment still does NOT clear the label (self-echo guard intact)", async () => {
     const orch = tmpOrcDir();
     const removed = [];
     await handleCommentWake(
-      { ticket: "CTL-BOT", body: "parking question", authorId: "bot-uuid" },
+      { ticket: "PROJ-BOT", body: "parking question", authorId: "bot-uuid" },
       {
         orchDir: orch,
         botUserId: "bot-uuid",
@@ -1563,13 +1567,67 @@ describe("handleCommentWake (CTL-549)", () => {
     expect(removed).toHaveLength(0);
   });
 
-  test("a Linear write failure does not throw — the wake path stays fail-open", async () => {
-    const orch = tmpOrcDir();
-    writeSignal(orch, "CTL-ERR", "implement", { status: "needs-human" });
+  // Both new gates FAIL CLOSED — "not sure" must mean "don't mutate Linear".
+  test("does NOT clear when the ticket is not managed by this installation", async () => {
+    const orch = tmpOrcDir(); // no worker dir, and no registry entry for FOREIGN
+    const removed = [];
     await handleCommentWake(
-      { ticket: "CTL-ERR", body: "answered" },
+      { ticket: "FOREIGN-1", body: "unrelated comment", authorId: "human-1" },
       {
         orchDir: orch,
+        botUserId: "bot-uuid",
+        dispatch: () => ({ code: 0 }),
+        removeLabel: async (t, l) => removed.push({ t, l }),
+      }
+    );
+    // The daemon sees EVERY workspace comment; an unmanaged ticket's same-named
+    // needs-human label must not be stripped, and no Linear write may be spent.
+    expect(removed).toHaveLength(0);
+  });
+
+  test("does NOT clear without positive human provenance (botUserId unset)", async () => {
+    const orch = tmpOrcDir();
+    const removed = [];
+    await handleCommentWake(
+      { ticket: "PROJ-NOPROV", body: "who wrote this?", authorId: "someone" },
+      {
+        orchDir: orch,
+        // botUserId intentionally omitted: _isBotId fails OPEN, so "not a known
+        // bot" does not prove "a human". The escalation's OWN app-actor comment
+        // would otherwise clear the label it just applied.
+        dispatch: () => ({ code: 0 }),
+        removeLabel: async (t, l) => removed.push({ t, l }),
+        isManagedTicket: () => true,
+      }
+    );
+    expect(removed).toHaveLength(0);
+  });
+
+  test("does NOT clear when the comment has no author at all", async () => {
+    const orch = tmpOrcDir();
+    const removed = [];
+    await handleCommentWake(
+      { ticket: "PROJ-NOAUTHOR", body: "anonymous" },
+      {
+        orchDir: orch,
+        botUserId: "bot-uuid",
+        dispatch: () => ({ code: 0 }),
+        removeLabel: async (t, l) => removed.push({ t, l }),
+        isManagedTicket: () => true,
+      }
+    );
+    expect(removed).toHaveLength(0);
+  });
+
+  test("a Linear write failure does not throw — the wake path stays fail-open", async () => {
+    const orch = tmpOrcDir();
+    writeSignal(orch, "PROJ-ERR", "implement", { status: "needs-human" });
+    await handleCommentWake(
+      { ticket: "PROJ-ERR", body: "answered", authorId: "human-1" },
+      {
+        orchDir: orch,
+        botUserId: "bot-uuid",
+        isManagedTicket: () => true,
         dispatch: () => ({ code: 0 }),
         removeLabel: async () => {
           throw new Error("linear 503");

--- a/plugins/dev/scripts/execution-core/daemon.test.mjs
+++ b/plugins/dev/scripts/execution-core/daemon.test.mjs
@@ -1496,6 +1496,91 @@ describe("handleCommentWake (CTL-549)", () => {
     expect(dispatchOrder.indexOf("remove")).toBeLessThan(dispatchOrder.indexOf("dispatch"));
   });
 
+  // ─── CTL-1567: a human response clears needs-human FIRST, unconditionally ───
+  //
+  // Both cases below were silently dropped before this fix, which is why the
+  // "Needs you" list only ever grew. Measured on the live fleet 2026-07-29: 10 of
+  // 12 parked tickets had NO worker dir on either host, and the ones that did
+  // carried `status: "needs-human"` — the one status the loop ignored.
+
+  test("REGRESSION: clears needs-human even when the ticket has NO worker directory", async () => {
+    const orch = tmpOrcDir(); // deliberately no workers/<TICKET>/ at all
+    const removed = [];
+    await handleCommentWake(
+      { ticket: "CTL-NODIR", body: "here is your answer" },
+      {
+        orchDir: orch,
+        dispatch: () => ({ code: 0 }),
+        removeLabel: async (ticket, label) => {
+          removed.push({ ticket, label });
+        },
+      }
+    );
+    // The label lives in Linear; a reaped worker dir must not make it unclearable.
+    expect(removed).toContainEqual({ ticket: "CTL-NODIR", label: "needs-human" });
+  });
+
+  test("REGRESSION: clears needs-human for a signal with status=needs-human", async () => {
+    const orch = tmpOrcDir();
+    // recovery-emit.mjs / recovery-reasoning.mjs write THIS status, which matched
+    // neither the `stalled` nor the `needs-input` branch.
+    writeSignal(orch, "CTL-NH", "implement", { status: "needs-human" });
+    const removed = [];
+    const cleared = [];
+    await handleCommentWake(
+      { ticket: "CTL-NH", body: "answered" },
+      {
+        orchDir: orch,
+        dispatch: () => ({ code: 0 }),
+        removeLabel: async (ticket, label) => {
+          removed.push({ ticket, label });
+        },
+        clearStall: ({ ticket, phase }) => {
+          cleared.push({ ticket, phase });
+          return true;
+        },
+      }
+    );
+    expect(removed).toContainEqual({ ticket: "CTL-NH", label: "needs-human" });
+    // …and it is treated like `stalled`, so the stall is cleared too.
+    expect(cleared).toContainEqual({ ticket: "CTL-NH", phase: "implement" });
+  });
+
+  test("the bot's OWN comment still does NOT clear the label (self-echo guard intact)", async () => {
+    const orch = tmpOrcDir();
+    const removed = [];
+    await handleCommentWake(
+      { ticket: "CTL-BOT", body: "parking question", authorId: "bot-uuid" },
+      {
+        orchDir: orch,
+        botUserId: "bot-uuid",
+        dispatch: () => ({ code: 0 }),
+        removeLabel: async (ticket, label) => {
+          removed.push({ ticket, label });
+        },
+      }
+    );
+    expect(removed).toHaveLength(0);
+  });
+
+  test("a Linear write failure does not throw — the wake path stays fail-open", async () => {
+    const orch = tmpOrcDir();
+    writeSignal(orch, "CTL-ERR", "implement", { status: "needs-human" });
+    await handleCommentWake(
+      { ticket: "CTL-ERR", body: "answered" },
+      {
+        orchDir: orch,
+        dispatch: () => ({ code: 0 }),
+        removeLabel: async () => {
+          throw new Error("linear 503");
+        },
+        clearStall: () => true,
+      }
+    );
+    // reaching here without throwing IS the assertion
+    expect(true).toBe(true);
+  });
+
   // CTL-764 finding 11: the daemon removes the durable needs-input label out-of-band and
   // redispatches — the scheduler never sees this edge, so the needs-input→cleared
   // resolution must be recorded here in the canonical worker.transition stream.

--- a/plugins/dev/scripts/execution-core/daemon.test.mjs
+++ b/plugins/dev/scripts/execution-core/daemon.test.mjs
@@ -1567,6 +1567,44 @@ describe("handleCommentWake (CTL-549)", () => {
     expect(removed).toHaveLength(0);
   });
 
+  test("also clears needs-input — the board treats BOTH labels as Needs-You", async () => {
+    const orch = tmpOrcDir();
+    const removed = [];
+    await handleCommentWake(
+      { ticket: "PROJ-BOTH", body: "answered", authorId: "human-1" },
+      {
+        orchDir: orch,
+        botUserId: "bot-uuid",
+        dispatch: () => ({ code: 0 }),
+        removeLabel: async (t, l) => { removed.push(l); },
+        isManagedTicket: () => true,
+        forgetIntent: () => true,
+      }
+    );
+    expect(removed).toContain("needs-human");
+    expect(removed).toContain("needs-input");
+  });
+
+  test("re-arms recovery so the response is not suppressed by the escalated latch", async () => {
+    const orch = tmpOrcDir();
+    const forgotten = [];
+    await handleCommentWake(
+      { ticket: "PROJ-REARM", body: "authorized, try again", authorId: "human-1" },
+      {
+        orchDir: orch,
+        botUserId: "bot-uuid",
+        dispatch: () => ({ code: 0 }),
+        removeLabel: async () => ({ removed: true }),
+        isManagedTicket: () => true,
+        forgetIntent: (t) => { forgotten.push(t); return true; },
+      }
+    );
+    // Without this the .recovery-intents latch survives up to 7 days, the terminal
+    // sweep re-applies needs-human, and the retry the human just authorized is
+    // suppressed — the ticket silently returns to the inbox.
+    expect(forgotten).toEqual(["PROJ-REARM"]);
+  });
+
   // Both new gates FAIL CLOSED — "not sure" must mean "don't mutate Linear".
   test("does NOT clear when the ticket is not managed by this installation", async () => {
     const orch = tmpOrcDir(); // no worker dir, and no registry entry for FOREIGN

--- a/plugins/dev/scripts/execution-core/label-guard.mjs
+++ b/plugins/dev/scripts/execution-core/label-guard.mjs
@@ -42,7 +42,7 @@ import { log } from "./config.mjs";
 // when the transient-failure path keeps re-attempting the write.
 // labelMarkerBase — shared path prefix for the once-marker files used by
 // labelOnce and clearStalledLabel (single source of truth for the marker path).
-function labelMarkerBase(orchDir, ticket, label) {
+export function labelMarkerBase(orchDir, ticket, label) {
   return join(orchDir, "workers", ticket, `.linear-label-${label}`);
 }
 


### PR DESCRIPTION
## The problem

Answering a parked ticket did nothing. The ticket kept `needs-human` and stayed on "Needs you" forever — which is why that list only ever grew.

Two independent gates in `handleCommentWake`:

**1. No worker directory ⇒ return before doing anything.**
```js
try { signalFiles = readdirSync(workerDir)… } catch { return; }
```
The label lives in **Linear**, but clearing it required a **host-local worker dir** to still exist. Once reaped, permanently unclearable. Measured on the live fleet 2026-07-29: **10 of 12** parked tickets had no worker dir on either host.

**2. `status: "needs-human"` matched neither branch.** The loop handled `stalled` and `needs-input` only, but signals are also written with `status: "needs-human"` (`recovery-emit.mjs`, `recovery-reasoning.mjs`) — so the one status that *means* "parked for a human" was the one the wake path ignored. Live: CTC-95, CTC-264, CTC-305 on mini.

## The fix

The clear is now **unconditional and first** — right after the bot self-echo guard, before any worker-dir or signal-status logic. A human responded, so the ticket drops off the list, whether or not anything downstream succeeds.

Re-adding is cheap and already automatic (`labelOnce` re-applies it if the ticket still needs a human). Never-clearing is what grows the inbox without bound.

- Idempotent (`removeLabel` reports already-absent as `removed: true`) → safe on every comment, safe concurrently on both hosts.
- Reconciles the once-marker in the same operation, closing the half-mutation this file had at `:429`.
- Emits a `worker.transition` so the resolution is auditable.
- `needs-human` is treated like `stalled` for stall-clearing until the duplicate status is normalized away (CTL-1552).
- Fail-open preserved: a Linear 5xx logs and continues.

## Verification

Mutation-tested, each confirmed individually:

| Mutation | Result |
|---|---|
| remove the unconditional clear | **2 named tests RED** |
| drop the `needs-human` branch | **1 named test RED** |

Full daemon suite: **142 pass / 0 fail**.

Closes CTL-1567.