### PR TITLE
fix(dev): CTL-1571 make queued/blocked labels retractable once a ticket starts

### DIFF
--- a/plugins/dev/scripts/execution-core/scheduler.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.mjs
@@ -23,6 +23,7 @@ import {
   rmSync,
   renameSync,
   statSync,
+  unlinkSync,
 } from "node:fs";
 import { spawnSync } from "node:child_process";
 import { monitorEventLoopDelay } from "node:perf_hooks";
@@ -346,6 +347,7 @@ import {
   labelNeedsHumanUnlessBeliefOwner,
   resolveAndApplyWorkerStatusLabel,
   WORKER_STATUS_LABELS,
+  labelMarkerBase, // CTL-1571: convergeHeldLabel writes the same once-marker labelOnce does
 } from "./label-guard.mjs";
 import { DISPOSITIONS } from "./worker-disposition.mjs"; // CTL-1605: precedence order for the onTerminalCleared aggregate-arg → pre-clear `from` resolution
 import { processApprovedResumes } from "./boot-resume.mjs"; // CTL-644: per-tick approval poll
@@ -1945,10 +1947,30 @@ export function convergeHeldLabel(
   // Promise (which read `.removed` as undefined and false-confirmed every removal);
   // the callback therefore fires post-tick in production and callers must not
   // assume it ran before this function returns.
+  // CTL-1571: delete the once-marker (see the apply side below) the moment a
+  // removal is CONFIRMED — mirrors CTL-1567's needs-human fix ("keep the
+  // once-marker in step with the label"). Only HELD_LABELS (blocked/queued) ever
+  // get a marker written here; the legacy "waiting" alias is drained above but
+  // never marked, so clearing its marker path is a harmless no-op (ENOENT).
+  const clearMarker = (label) => {
+    if (!orchDir) return;
+    const base = labelMarkerBase(orchDir, ticket, label);
+    for (const suffix of [".applied", ".skipped"]) {
+      try {
+        unlinkSync(`${base}${suffix}`);
+      } catch {
+        /* ENOENT is the expected case — no marker to clear */
+      }
+    }
+  };
   const settle = (label, res) => {
     if (res != null && typeof res.then === "function") {
       res.then(
-        (r) => onRemoveResult?.(label, r?.removed !== false),
+        (r) => {
+          const removed = r?.removed !== false;
+          if (removed) clearMarker(label);
+          onRemoveResult?.(label, removed);
+        },
         (err) => {
           log.warn(
             { ticket, phase: "admission", err: err?.message },
@@ -1959,7 +1981,9 @@ export function convergeHeldLabel(
       );
       return;
     }
-    onRemoveResult?.(label, res?.removed !== false);
+    const removed = res?.removed !== false;
+    if (removed) clearMarker(label);
+    onRemoveResult?.(label, removed);
   };
   for (const label of HELD_LABELS_REMOVABLE) {
     if (label !== desired && have.has(label)) {
@@ -1989,6 +2013,30 @@ export function convergeHeldLabel(
       );
     }
     writes++;
+    // CTL-1571: write the SAME once-marker labelOnce writes for needs-human, so
+    // convergeStartedHeldLabels (CTL-1068) — which gates retraction on this
+    // marker's existence — can find and retract this label if the ticket is
+    // later admitted and this clear-on-pickup write never lands (a transient
+    // failure, and admission drops the ticket out of the pool that retries it).
+    // A test stub returning undefined counts as success, matching labelOnce's
+    // own convention (applyLabel is otherwise never expected to return undefined
+    // in production). mkdirSync (recursive) guards a ticket whose worker dir
+    // does not exist yet — labelOnce assumes the dir is already there because it
+    // is only ever invoked deep in the dispatch path; convergeHeldLabel runs from
+    // the admission tick, which can precede worker-dir creation.
+    const applied = res === undefined || res?.applied === true;
+    if (orchDir && applied) {
+      const base = labelMarkerBase(orchDir, ticket, desired);
+      try {
+        mkdirSync(dirname(base), { recursive: true });
+        writeFileSync(`${base}.applied`, "");
+      } catch (err) {
+        log.warn(
+          { ticket, label: desired, err: err.message },
+          "ctl-1571: held-label once-marker write failed — retraction may miss this label later"
+        );
+      }
+    }
     if (orchDir && res && res.applied === false && UNRECOVERABLE_LABEL_REASONS.has(res.reason)) {
       recordLabelCooldown(orchDir, ticket, desired, now());
       log.warn(

--- a/plugins/dev/scripts/execution-core/scheduler.test.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.test.mjs
@@ -11759,6 +11759,40 @@ describe("CTL-1068: convergeStartedHeldLabels (unit)", () => {
     );
     expect(rearms).toBe(1);
   });
+
+  // CTL-1571: end-to-end regression for the bug convergeStartedHeldLabels was
+  // built to fix (CTL-1068) but couldn't, because the ONLY writer of the
+  // "queued"/"blocked" labels — convergeHeldLabel, in the pre-pickup admission
+  // loop — never left the once-marker this retraction sweep gates on. Reproduces
+  // the live-fleet incident directly: two real pilot tickets (CQD-1, PAN-1) sat
+  // for hours wearing a stale "queued" label after being admitted, because a
+  // transient clear-on-pickup failure at admission time was never retried (the
+  // ticket had already left the pre-pickup pool by the next tick).
+  test("CTL-1571: a label convergeHeldLabel applied is retractable by convergeStartedHeldLabels once the ticket starts", () => {
+    seedWorker("CTL-1571");
+    // Step 1 — admission tick applies "queued" (convergeHeldLabel, as the A.7
+    // admission loop does for a triaged-but-not-yet-admitted ticket). Before this
+    // fix, this call left the label in Linear but NO local trace of it.
+    const applyWs = { applyLabel: () => ({ applied: true, reason: null }), removeLabel: () => ({ removed: true }) };
+    const writes = convergeHeldLabel("CTL-1571", [], "queued", applyWs, { orchDir });
+    expect(writes).toBe(1);
+    expect(existsSync(markerPath("CTL-1571", "queued", "applied"))).toBe(true);
+
+    // Step 2 — the ticket is later picked up (dispatched) but the clear-on-pickup
+    // write that same admission tick would have issued never happened (simulated
+    // here by simply not calling convergeHeldLabel again with desired=null — the
+    // real-world failure mode is a transient removeLabel error, which the ticket's
+    // departure from the pre-pickup pool then makes unretriable). The label is
+    // still on Linear.
+    const { removed, ws: startedWs } = removeSpy();
+    convergeStartedHeldLabels(orchDir, "CTL-1571", startedWs, { multiHost: false });
+
+    // Before CTL-1571: removed would be [] (no marker → the loop `continue`s,
+    // exactly like the "steady-state: no held marker" test above) and the label
+    // would stay stuck on Linear indefinitely — the live bug.
+    expect(removed).toEqual([{ ticket: "CTL-1571", label: "queued" }]);
+    expect(existsSync(markerPath("CTL-1571", "queued", "applied"))).toBe(false);
+  });
 });
 
 // ── CTL-1068: Phase 2 — schedulerTick end-to-end (wiring tests) ──


### PR DESCRIPTION
## The problem

Two real pilot tickets sat for hours carrying a stale `queued` Linear label through multiple completed pipeline phases, long after being admitted and dispatched. The label served no purpose once the ticket started running, but nothing ever cleared it.

`convergeStartedHeldLabels` (CTL-1068) exists specifically to retract an orphaned held label from a STARTED ticket -- its own doc comment describes this exact scenario ("a ticket that was picked up and then failed wearing blocked/waiting is never revisited [by the admission loop], so its label lingers ... forever"). It is correctly wired into `schedulerTick` for every non-pre-pickup ticket, every tick.

But its retraction loop gates on the **existence of a local once-marker file** (`workers/<T>/.linear-label-<label>.{applied,skipped}`) before attempting anything -- and `queued`/`blocked` are never written through that marker convention. They are applied and removed entirely by `convergeHeldLabel`'s tick-diff in the pre-pickup admission loop, which uses a live label-set diff, not a marker file. So the one code path capable of finding and clearing a stuck `queued`/`blocked` label can never find one, because its precondition is never satisfied for these two labels -- even though the label really is present on Linear.

The failure is intermittent, not universal, which is why it slipped past most tickets: `convergeHeldLabel`'s clear-on-pickup write only gets ONE attempt, in the exact tick a ticket transitions from waiting to admitted. If that single `removeLabel` call fails for any transient reason, the ticket has already left the pre-pickup pool by the next tick and nothing ever retries it.

## The fix

`convergeHeldLabel` now writes the same once-marker `labelOnce` writes for `needs-human`, on confirmed apply, and deletes it on confirmed removal (mirroring #2796's "keep the once-marker in step with the label"). This gives `convergeStartedHeldLabels`' existing, already-tested, already-fenced retraction logic something to find. No new Linear reads, no new retry infrastructure -- just making the write side leave the breadcrumb the read side was always designed to look for.

## Verification

New test (CTL-1571) reproduces the bug end-to-end: applies `queued` via `convergeHeldLabel`, then calls `convergeStartedHeldLabels` as if the ticket had since started, and asserts the label is now retracted. Confirmed by mutation: reverting the `scheduler.mjs` fix makes this exact test fail at the marker-existence assertion (no source change reverts the test).

Full execution-core suite (`bun test`, 228 files): 7037 pass / 21 fail including this fix, vs 7039 pass / 18 fail on `main` -- the +3 delta isolates to +1 new passing test (this one) and a pre-existing flaky integration test (`execution-core integration — crash recovery (CTL-539) > AC5`) that did not reproduce on two further full-suite runs and passes cleanly in isolation regardless.

`scheduler.test.mjs` alone: 597 pass / 2 fail, unchanged from baseline's 596/2 plus this one new passing test.

Closes CTL-1571.

## Test plan
- [x] `bun test scheduler.test.mjs` -- 597 pass / 2 fail (2 pre-existing, unrelated: CTL-781 delegate tests)
- [x] `bun test` (full execution-core suite) -- no net-new regressions vs `main`, confirmed across 3 runs
- [x] Mutation-tested the new test against a reverted fix -- fails exactly at the expected assertion