### PR TITLE
feat(dev): CTL-1569 make the inbox a conversation surface (ask summary + thread + inline reply)

### DIFF
--- a/plugins/dev/scripts/orch-monitor/__tests__/conversation-client.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/conversation-client.test.ts
@@ -1,0 +1,212 @@
+// conversation-client.test.ts — CTL-1569: the inbox conversation surface's web
+// clients. Both branches of every IO path, with an injected fetch (no server).
+//
+// The read fails SOFT (the pane just renders nothing); the write fails LOUD and
+// specifically, because §4 requires a failed post to restore the row and tell the
+// operator what happened to their words.
+import { describe, expect, it } from "bun:test";
+
+import {
+  conversationUrl,
+  fetchConversation,
+  postReply,
+  replyUrl,
+  type ConversationResponse,
+} from "../ui/src/board/conversation-client";
+import {
+  askPresentation,
+  inferredNote,
+  isInferredAsk,
+} from "../ui/src/board/inbox-ask-model";
+
+/** Wrap an impl(url, init) → Response as a typed fetch.
+ *  Mirrors the existing convention in inbox-read-client.test.ts: the `as typeof
+ *  fetch` cast satisfies Bun's static `fetch.preconnect` member (a bare
+ *  `async () => Response` does not, TS2741), and returning a resolved promise
+ *  instead of an async arrow keeps `@typescript-eslint/require-await` quiet. */
+function mockFetch(impl: (url: string, init?: RequestInit) => Response): typeof fetch {
+  return ((input: string | URL, init?: RequestInit) =>
+    Promise.resolve(impl(String(input), init))) as typeof fetch;
+}
+
+/** A throwing fetch — simulates a network failure (offline / DNS). */
+function boomFetch(message: string): typeof fetch {
+  return ((_input: string | URL, _init?: RequestInit) =>
+    Promise.reject(new Error(message))) as typeof fetch;
+}
+
+function jsonRes(body: unknown, ok = true, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status: ok ? status : status >= 400 ? status : 500,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+const CONVERSATION: ConversationResponse = {
+  ticket: "PROJ-1",
+  url: "https://linear.app/x/PROJ-1",
+  title: "A title",
+  thread: { available: true, comments: [], reason: null },
+  ask: {
+    kind: "approve",
+    summary: "Reply approve to publish.",
+    suggestedReplies: ["approve", "no"],
+    canResolveByReply: true,
+    source: "structured",
+  },
+  canReply: true,
+};
+
+describe("conversationUrl / replyUrl", () => {
+  it("builds the replica-read URL, with an optional bound", () => {
+    expect(conversationUrl("PROJ-1")).toBe("/api/ticket/PROJ-1/thread");
+    expect(conversationUrl("PROJ-1", 4)).toBe("/api/ticket/PROJ-1/thread?limit=4");
+  });
+  it("encodes the ticket", () => {
+    expect(replyUrl("PROJ 1")).toBe("/api/ticket/PROJ%201/reply");
+  });
+});
+
+describe("fetchConversation — fails SOFT", () => {
+  it("returns the parsed conversation on success", async () => {
+    const out = await fetchConversation("PROJ-1", {
+      fetchImpl: mockFetch(() => jsonRes(CONVERSATION)),
+    });
+    expect(out.ok).toBe(true);
+    if (out.ok) expect(out.conversation.ask?.kind).toBe("approve");
+  });
+
+  it("returns ok:false on a non-ok status (no error card)", async () => {
+    const out = await fetchConversation("PROJ-1", {
+      fetchImpl: mockFetch(() => jsonRes({}, false, 500)),
+    });
+    expect(out.ok).toBe(false);
+  });
+
+  it("returns ok:false on a network throw rather than propagating", async () => {
+    const out = await fetchConversation("PROJ-1", {
+      fetchImpl: boomFetch("offline"),
+    });
+    expect(out.ok).toBe(false);
+  });
+});
+
+describe("postReply — fails LOUD and specifically", () => {
+  it("maps a confirmed post to `replied`", async () => {
+    const out = await postReply(
+      { ticket: "PROJ-1", body: "approve" },
+      {
+        fetchImpl: mockFetch(() =>
+          jsonRes({
+            status: "replied",
+            ticket: "PROJ-1",
+            commentId: "c1",
+            author: { id: "h", name: "Ryan" },
+          }),
+        ),
+      },
+    );
+    expect(out.status).toBe("replied");
+    if (out.status === "replied") expect(out.commentId).toBe("c1");
+  });
+
+  it("REFUSES to treat a post with no comment id as success", async () => {
+    // Without a comment id the post is unverified — clearing the row would risk
+    // losing the item, so this is an error, not a success.
+    const out = await postReply(
+      { ticket: "PROJ-1", body: "approve" },
+      { fetchImpl: mockFetch(() => jsonRes({ status: "replied", ticket: "PROJ-1" })) },
+    );
+    expect(out.status).toBe("error");
+  });
+
+  it("explains the app-actor refusal in operator language", async () => {
+    // The failure that would otherwise ship the feature silently inert.
+    const out = await postReply(
+      { ticket: "PROJ-1", body: "approve" },
+      { fetchImpl: mockFetch(() => jsonRes({ status: "bot_identity" }, false, 502)) },
+    );
+    expect(out.status).toBe("bot_identity");
+    if (out.status === "bot_identity") {
+      expect(out.message).toContain("Catalyst app");
+      expect(out.message).toContain("kept");
+    }
+  });
+
+  it("maps no_token to an error that says the reply was kept", async () => {
+    const out = await postReply(
+      { ticket: "PROJ-1", body: "hi" },
+      { fetchImpl: mockFetch(() => jsonRes({ status: "no_token" }, false, 502)) },
+    );
+    expect(out.status).toBe("error");
+    if (out.status === "error") expect(out.message).toContain("kept");
+  });
+
+  it("maps a missing ticket to not_found", async () => {
+    const out = await postReply(
+      { ticket: "PROJ-404", body: "hi" },
+      { fetchImpl: mockFetch(() => jsonRes({ status: "not_found" }, false, 404)) },
+    );
+    expect(out.status).toBe("not_found");
+  });
+
+  it("maps an empty body to `empty` (not an error)", async () => {
+    const out = await postReply(
+      { ticket: "PROJ-1", body: "" },
+      { fetchImpl: mockFetch(() => jsonRes({ status: "empty_body" }, false, 400)) },
+    );
+    expect(out.status).toBe("empty");
+  });
+
+  it("never reports success on a network throw", async () => {
+    const out = await postReply(
+      { ticket: "PROJ-1", body: "hi" },
+      {
+        fetchImpl: boomFetch("ECONNRESET"),
+      },
+    );
+    expect(out.status).toBe("error");
+    if (out.status === "error") expect(out.message).toContain("ECONNRESET");
+  });
+
+  it("treats an unrecognized status as an error (conservative for a write)", async () => {
+    const out = await postReply(
+      { ticket: "PROJ-1", body: "hi" },
+      { fetchImpl: mockFetch(() => jsonRes({ status: "who_knows" })) },
+    );
+    expect(out.status).toBe("error");
+  });
+});
+
+describe("inbox-ask-model — the presentation of the ask", () => {
+  it("makes 'you must act first' unmistakable, not just a tint", () => {
+    const p = askPresentation("act-then-confirm");
+    expect(p.requiresAction).toBe(true);
+    expect(p.accent).toBe("red");
+    expect(p.resolutionHint).toContain("NOT");
+  });
+
+  it("tells the operator a reply alone is enough for the reply-alone kinds", () => {
+    for (const kind of ["approve", "decide", "clarify"]) {
+      expect(askPresentation(kind).requiresAction).toBe(false);
+    }
+  });
+
+  it("labels each kind distinctly", () => {
+    const labels = ["approve", "decide", "act-then-confirm", "clarify"].map(
+      (k) => askPresentation(k).label,
+    );
+    expect(new Set(labels).size).toBe(4);
+  });
+
+  it("degrades an unknown kind to clarify rather than throwing", () => {
+    expect(askPresentation("nonsense").label).toBe(askPresentation("clarify").label);
+  });
+
+  it("marks a derived ask as inferred, and a producer-authored one as not", () => {
+    expect(isInferredAsk("structured")).toBe(false);
+    expect(inferredNote("structured")).toBeNull();
+    expect(inferredNote("comment")).toContain("last comment");
+    expect(inferredNote("explanation")).toContain("escalation");
+  });
+});

--- a/plugins/dev/scripts/orch-monitor/__tests__/home-surface.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/home-surface.test.ts
@@ -53,6 +53,7 @@ function stripComments(src: string): string {
 const homeCode = stripComments(homeSurfaceSrc);
 const rowCode = stripComments(inboxRowSrc);
 const conversationCode = stripComments(conversationSrc);
+const homeSurfaceCode = stripComments(homeSurfaceSrc);
 const appCode = stripComments(appSrc);
 
 // ── Scenario: The split survives an iPad-landscape width (firm floors) ────────
@@ -520,12 +521,25 @@ describe("Inbox conversation surface (CTL-1569)", () => {
     expect(homeSurfaceSrc).toMatch(/needsYou: perSection\("attention"\)/);
   });
 
+  it("round-4 P2 — an UNSENT reply is not reported as a failed resume", () => {
+    // no_token / bot_identity / not_found / network: nothing was sent and no
+    // resume was attempted, so "The agent did not resume — try again" would be a
+    // second, wrong diagnosis beside the reply box's accurate one.
+    expect(homeSurfaceCode).not.toMatch(/markDidNotTake\(/);
+    expect(homeSurfaceSrc).toContain("no comment was sent");
+  });
+
+  it("round-4 P2 — the draft clear is scoped to ticket AND edit version", () => {
+    // Value equality cannot prove no edit or ticket switch occurred.
+    expect(conversationSrc).toContain("sendTicket");
+    expect(conversationSrc).toContain("editVersion");
+  });
+
   it("the surface routes a reply outcome through the ONE optimistic-rollback rule", () => {
     // Reusing the verb's mark + grace window (rather than a second optimistic
     // path) keeps one reconcile rule deciding when a row truly leaves the inbox.
     expect(homeSurfaceSrc).toContain("onReplied");
     expect(homeSurfaceSrc).toContain("markResolved");
-    expect(homeSurfaceSrc).toContain("markDidNotTake");
   });
 });
 

--- a/plugins/dev/scripts/orch-monitor/__tests__/home-surface.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/home-surface.test.ts
@@ -504,10 +504,20 @@ describe("Inbox conversation surface (CTL-1569)", () => {
     expect(conversationCode).not.toMatch(/const body = draft\.trim\(\)/);
   });
 
-  it("re-review P1 — async reply state is scoped to the ticket it was sent for", () => {
+  it("re-review P1 — async reply state is scoped to the CURRENT selection", () => {
     // A reply to A landing after switching to B must not append A's comment to B.
+    // Comparing against the closure-captured `ticket` does NOT work — ReplyBox
+    // invokes the callback captured during A's render, so both values are A and
+    // the guard always passes. Only a ref reads the current selection.
     expect(conversationSrc).toContain("submittedFor");
-    expect(conversationSrc).toMatch(/submittedFor === ticket/);
+    expect(conversationSrc).toMatch(/submittedFor === currentTicket\.current/);
+    expect(conversationSrc).toContain("currentTicket.current = ticket");
+  });
+
+  it("round-3 P2 — the aggregate needsYou count is recomputed too", () => {
+    // isAllClear and calmHeaderSentence read the AGGREGATE, not the components,
+    // so resolving the last attention row must flip the all-clear immediately.
+    expect(homeSurfaceSrc).toMatch(/needsYou: perSection\("attention"\)/);
   });
 
   it("the surface routes a reply outcome through the ONE optimistic-rollback rule", () => {

--- a/plugins/dev/scripts/orch-monitor/__tests__/home-surface.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/home-surface.test.ts
@@ -482,6 +482,34 @@ describe("Inbox conversation surface (CTL-1569)", () => {
     expect(homeSurfaceSrc).toMatch(/for \(const row of rawModel\.order\)/);
   });
 
+  it("re-review P2 — filtering resolved rows RECOMPUTES the dependent metadata", () => {
+    // Copying defaultSelectedId/counts from the raw model left the selection
+    // effect reselecting a hidden row and the calm header still counting it.
+    expect(homeSurfaceSrc).toContain("defaultSelectedId: order.length > 0");
+    expect(homeSurfaceSrc).toContain("perSection");
+  });
+
+  it("re-review P2 — the resolving reply is offered ONLY on a true attention row", () => {
+    // needsYou also covers the scheduler's blocked/queued rows, where comment-wake
+    // never clears the admission-gate label — replying there would optimistically
+    // hide the row and then roll it back.
+    expect(readingPaneSrc).toContain("canResolveByReply");
+    expect(readingPaneSrc).toMatch(/row\.section === "attention"/);
+    expect(conversationSrc).toContain("canResolveByReply");
+  });
+
+  it("re-review P2 — the CLIENT posts the untrimmed draft", () => {
+    // Sending draft.trim() defeated the server's verbatim postBody fix.
+    expect(conversationSrc).toContain("const body = draft;");
+    expect(conversationCode).not.toMatch(/const body = draft\.trim\(\)/);
+  });
+
+  it("re-review P1 — async reply state is scoped to the ticket it was sent for", () => {
+    // A reply to A landing after switching to B must not append A's comment to B.
+    expect(conversationSrc).toContain("submittedFor");
+    expect(conversationSrc).toMatch(/submittedFor === ticket/);
+  });
+
   it("the surface routes a reply outcome through the ONE optimistic-rollback rule", () => {
     // Reusing the verb's mark + grace window (rather than a second optimistic
     // path) keeps one reconcile rule deciding when a row truly leaves the inbox.

--- a/plugins/dev/scripts/orch-monitor/__tests__/home-surface.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/home-surface.test.ts
@@ -446,6 +446,42 @@ describe("Inbox conversation surface (CTL-1569)", () => {
     expect(conversationSrc).toMatch(/status === "replied"/);
   });
 
+  it("P1 #3 — a ticket switch must not mix the previous ticket's context", () => {
+    // Preserving the loaded conversation across a selection change rendered
+    // ticket A's ask/thread/URL around a ReplyBox bound to ticket B, so an
+    // operator acting in that window could post A's answer onto B.
+    expect(conversationSrc).toContain("loadedFor");
+    expect(conversationSrc).toMatch(/sameTicket/);
+  });
+
+  it("P2 #10 — a failed thread read must NOT remove the reply composer", () => {
+    // Posting is a separate endpoint and the thread is non-load-bearing; returning
+    // null on a read error stranded the operator until the row was reselected.
+    expect(conversationSrc).toContain("read-failed");
+    expect(conversationCode).not.toMatch(/state\.kind !== "loaded"\) return null/);
+  });
+
+  it("P2 #11 — a successful post clears ONLY the submitted text", () => {
+    expect(conversationSrc).toContain("draftAtSend");
+  });
+
+  it("P2 #16 — the posted turn appears without racing the replica sync", () => {
+    // A one-shot refetch after the POST loses the race with the webhook, so the
+    // operator's own turn stayed invisible. The confirmed comment id is shown.
+    expect(conversationSrc).toContain("ownTurns");
+    expect(conversationSrc).toContain("ownReplyEntry");
+    expect(conversationSrc).toContain("mergedComments");
+  });
+
+  it("P2 #6 — a replied row is projected OUT of the inbox model", () => {
+    // The optimistic mark alone only changed pane rendering; sections/order still
+    // carried the row, so it stayed visible and selected with a live reply box.
+    expect(homeSurfaceSrc).toContain("resolvedIds");
+    expect(homeSurfaceSrc).toContain("rawModel");
+    // Reconcile must read the RAW model, or a hidden row could never roll back.
+    expect(homeSurfaceSrc).toMatch(/for \(const row of rawModel\.order\)/);
+  });
+
   it("the surface routes a reply outcome through the ONE optimistic-rollback rule", () => {
     // Reusing the verb's mark + grace window (rather than a second optimistic
     // path) keeps one reconcile rule deciding when a row truly leaves the inbox.

--- a/plugins/dev/scripts/orch-monitor/__tests__/home-surface.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/home-surface.test.ts
@@ -400,9 +400,14 @@ describe("Inbox conversation surface (CTL-1569)", () => {
     expect(conversationCode).not.toMatch(/\.sort\(/);
   });
 
-  it("agent and human comments are visually distinct", () => {
+  it("agent, human and integration comments are visually distinct", () => {
+    // THREE classes, not two. Collapsing them styled a GitHub sync notice as the
+    // agent speaking, which made automation chatter look like a question needing
+    // an answer (and made it the derived ask).
     expect(conversationSrc).toContain("data-thread-author");
-    expect(conversationSrc).toContain("isAgent");
+    expect(conversationSrc).toContain("isCatalystAgent");
+    expect(conversationSrc).toContain("isIntegration");
+    expect(conversationSrc).toContain("integration");
   });
 
   it("long comment bodies clamp with expand-in-place", () => {

--- a/plugins/dev/scripts/orch-monitor/__tests__/home-surface.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/home-surface.test.ts
@@ -535,6 +535,20 @@ describe("Inbox conversation surface (CTL-1569)", () => {
     expect(conversationSrc).toContain("editVersion");
   });
 
+  it("round-5 P2 — a reply failure does not leak across ticket selections", () => {
+    // ReplyBox is REUSED across selections, so A's "Not sent" would otherwise
+    // render under B for a reply never attempted on B.
+    expect(conversationSrc).toMatch(/useEffect\(\(\) => \{\s*setFailure\(null\);\s*\}, \[ticket\]\)/);
+  });
+
+  it("round-5 P2 — suggestion prefills count as draft edits", () => {
+    // Chips call setDraft too; if only typing bumped the version, prefilling B with
+    // text submitted on A would let A's late success clear B's draft.
+    expect(conversationSrc).toContain("applyDraft");
+    expect(conversationSrc).toMatch(/onUseSuggestion=\{applyDraft\}/);
+    expect(conversationSrc).toMatch(/setDraft=\{applyDraft\}/);
+  });
+
   it("the surface routes a reply outcome through the ONE optimistic-rollback rule", () => {
     // Reusing the verb's mark + grace window (rather than a second optimistic
     // path) keeps one reconcile rule deciding when a row truly leaves the inbox.

--- a/plugins/dev/scripts/orch-monitor/__tests__/home-surface.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/home-surface.test.ts
@@ -40,6 +40,8 @@ const allClearHeroSrc = read("components/home/all-clear-hero.tsx");
 // client is called from).
 const readingPaneSrc = read("components/home/reading-pane.tsx");
 const useRespondSrc = read("hooks/use-respond.ts");
+// CTL-1569: the conversation surface joins the home tree (same no-fetch invariant).
+const conversationSrc = read("components/home/conversation.tsx");
 
 function stripComments(src: string): string {
   return src
@@ -50,6 +52,7 @@ function stripComments(src: string): string {
 
 const homeCode = stripComments(homeSurfaceSrc);
 const rowCode = stripComments(inboxRowSrc);
+const conversationCode = stripComments(conversationSrc);
 const appCode = stripComments(appSrc);
 
 // ── Scenario: The split survives an iPad-landscape width (firm floors) ────────
@@ -363,16 +366,87 @@ describe("HOME5 — the bright verb fires the read-model write + resume (CTL-903
   });
 
   it("the ONLY place the write client (fetch) is reached is the use-respond hook / its pure client", () => {
-    // The home tree's no-fetch invariant is preserved: home-surface / row / pane
-    // carry NO literal fetch/EventSource — the fetch is isolated in
-    // respond-client.ts and reached only via the use-respond hook.
-    for (const code of [homeCode, rowCode, readingPaneCode]) {
+    // The home tree's no-fetch invariant is preserved: home-surface / row / pane /
+    // conversation carry NO literal fetch/EventSource — the fetch is isolated in
+    // respond-client.ts / conversation-client.ts and reached only via a hook.
+    // CTL-1569 adds conversation.tsx to the tree, so it is held to the same rule.
+    for (const code of [homeCode, rowCode, readingPaneCode, conversationCode]) {
       expect(code).not.toMatch(/\bfetch\(/);
       expect(code).not.toMatch(/\bnew EventSource\b/);
     }
     // The hook calls the pure client (respondTicket), not a raw fetch of its own.
     expect(useRespondSrc).toContain("respondTicket");
     expect(useRespondCode).not.toMatch(/\bfetch\(/);
+    // The conversation reaches the network only through its isolated client.
+    expect(conversationSrc).toContain("fetchConversation");
+    expect(conversationSrc).toContain("postReply");
+  });
+});
+
+// ── CTL-1569: the inbox as a conversation surface ────────────────────────────
+describe("Inbox conversation surface (CTL-1569)", () => {
+  it("the pane mounts the conversation for needs-you rows only", () => {
+    // Running/done rows stay calm — the conversation is gated on needsYou.
+    expect(readingPaneSrc).toContain("Conversation");
+    expect(readingPaneSrc).toMatch(/needsYou &&\s*\(?\s*<Conversation/);
+  });
+
+  it("the thread renders NEWEST FIRST, in the order the server sent", () => {
+    // §2: the agent's question is almost always newest and the operator's prior
+    // reply the one before it — chronological order buries both. The server sorts
+    // DESC and the component must not re-sort.
+    expect(conversationSrc).toContain("newest-first");
+    expect(conversationCode).not.toMatch(/\.reverse\(\)/);
+    expect(conversationCode).not.toMatch(/\.sort\(/);
+  });
+
+  it("agent and human comments are visually distinct", () => {
+    expect(conversationSrc).toContain("data-thread-author");
+    expect(conversationSrc).toContain("isAgent");
+  });
+
+  it("long comment bodies clamp with expand-in-place", () => {
+    expect(conversationSrc).toContain("data-thread-expand");
+    expect(conversationSrc).toContain("line-clamp-4");
+  });
+
+  it("the ask summary states the kind AND whether replying alone is enough", () => {
+    // §1: the two things that must be unambiguous at a glance.
+    expect(conversationSrc).toContain("data-ask-kind");
+    expect(conversationSrc).toContain("data-ask-resolution");
+    expect(conversationSrc).toContain("requiresAction");
+  });
+
+  it("suggested replies PREFILL the box rather than auto-sending", () => {
+    // A chip is a shortcut, not a submit — the operator can still edit.
+    expect(conversationSrc).toContain("data-ask-suggestion");
+    expect(conversationSrc).toContain("onUseSuggestion");
+    expect(conversationSrc).toContain("setDraft");
+  });
+
+  it("every row links directly to its Linear ticket", () => {
+    expect(conversationSrc).toContain("data-linear-link");
+  });
+
+  it("a row with no underlying ticket shows NO reply affordance", () => {
+    // Orphan-PR rows are synthesized with no Linear issue — nothing to reply to.
+    expect(conversationSrc).toContain("canReply");
+    expect(conversationSrc).toContain("data-no-reply-affordance");
+  });
+
+  it("a failed post KEEPS the draft and surfaces the reason (never loses the item)", () => {
+    // §4: a failed post, or one whose label clear is suppressed, must restore the
+    // row. The draft is only cleared on a CONFIRMED post.
+    expect(conversationSrc).toContain("data-reply-failure");
+    expect(conversationSrc).toMatch(/status === "replied"/);
+  });
+
+  it("the surface routes a reply outcome through the ONE optimistic-rollback rule", () => {
+    // Reusing the verb's mark + grace window (rather than a second optimistic
+    // path) keeps one reconcile rule deciding when a row truly leaves the inbox.
+    expect(homeSurfaceSrc).toContain("onReplied");
+    expect(homeSurfaceSrc).toContain("markResolved");
+    expect(homeSurfaceSrc).toContain("markDidNotTake");
   });
 });
 

--- a/plugins/dev/scripts/orch-monitor/__tests__/inbox-conversation-endpoints.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/inbox-conversation-endpoints.test.ts
@@ -1,0 +1,140 @@
+// inbox-conversation-endpoints.test.ts — CTL-1569: HTTP route plumbing for the
+// inbox conversation surface. Proves the two routes are mounted, matched, and
+// guarded; the assembly/post LOGIC is covered exhaustively by the injectable unit
+// tests in lib/inbox-conversation.test.mjs and lib/inbox-conversation-compose.test.mjs.
+//
+// SAFETY: every test here uses a ticket id that cannot resolve to a real Linear
+// issue, so no test can post a comment to a live ticket. The POST /reply happy
+// path is deliberately NOT exercised over HTTP — it is a real external write, and
+// its branches are already unit-tested with an injected fetch.
+import { describe, it, expect, beforeAll, afterAll } from "bun:test";
+import { mkdtempSync, rmSync, mkdirSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { createServer } from "../server";
+
+let server: ReturnType<typeof createServer>;
+let baseUrl: string;
+let tmpDir: string;
+
+/** Definitively not a real Linear issue, so route behavior is host-independent
+ *  and no live ticket can be written to. */
+const ABSENT_TICKET = "ZZZ-999999";
+
+beforeAll(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), "inbox-conversation-endpoints-"));
+  const wtDir = join(tmpDir, "wt");
+  mkdirSync(wtDir, { recursive: true });
+  server = createServer({ port: 0, wtDir, startWatcher: false });
+  baseUrl = `http://localhost:${server.port}`;
+});
+
+afterAll(() => {
+  void server?.stop(true);
+  if (tmpDir) {
+    try {
+      rmSync(tmpDir, { recursive: true, force: true });
+    } catch {
+      /* ignore */
+    }
+  }
+});
+
+describe("GET /api/ticket/:id/thread (CTL-1569)", () => {
+  it("returns 200 + the conversation shape for a ticket with nothing on disk", async () => {
+    const res = await fetch(`${baseUrl}/api/ticket/${ABSENT_TICKET}/thread`);
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type")).toContain("application/json");
+    const body = (await res.json()) as {
+      ticket: string;
+      thread: { comments: unknown[] };
+      ask: unknown;
+      canReply: boolean;
+      url: string | null;
+    };
+    expect(body.ticket).toBe(ABSENT_TICKET);
+    expect(body.thread.comments).toEqual([]);
+    // No escalation explanation and no agent comment → an honestly ABSENT ask.
+    expect(body.ask).toBeNull();
+    expect(body.url).toBeNull();
+  });
+
+  it("NEVER 5xxs when the replica is unreadable (the read fails open)", async () => {
+    // The inbox must not break because a local mirror is absent or locked.
+    const res = await fetch(`${baseUrl}/api/ticket/${ABSENT_TICKET}/thread`);
+    expect(res.status).toBe(200);
+  });
+
+  it("honors a bounded ?limit and ignores a junk one", async () => {
+    for (const q of ["?limit=3", "?limit=0", "?limit=-5", "?limit=abc", "?limit=99999"]) {
+      const res = await fetch(`${baseUrl}/api/ticket/${ABSENT_TICKET}/thread${q}`);
+      expect(res.status).toBe(200);
+    }
+  });
+
+  it("rejects a malformed ticket id with 400 (no traversal / arbitrary read)", async () => {
+    for (const bad of ["not-a-ticket", "CTL", "..%2F..%2Fetc", "%2Fetc%2Fpasswd"]) {
+      expect((await fetch(`${baseUrl}/api/ticket/${bad}/thread`)).status).toBe(400);
+    }
+  });
+
+  it("does not answer the thread route on POST", async () => {
+    const res = await fetch(`${baseUrl}/api/ticket/${ABSENT_TICKET}/thread`, { method: "POST" });
+    expect(res.status).not.toBe(200);
+  });
+});
+
+describe("POST /api/ticket/:id/reply (CTL-1569)", () => {
+  const post = (ticket: string, body: unknown) =>
+    fetch(`${baseUrl}/api/ticket/${ticket}/reply`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: typeof body === "string" ? body : JSON.stringify(body),
+    });
+
+  it("rejects an empty reply with 400 and does NOT call Linear", async () => {
+    const res = await post(ABSENT_TICKET, { body: "   " });
+    expect(res.status).toBe(400);
+    const json = (await res.json()) as { status: string };
+    expect(json.status).toBe("empty_body");
+  });
+
+  it("rejects a missing body field with 400", async () => {
+    expect((await post(ABSENT_TICKET, {})).status).toBe(400);
+  });
+
+  it("rejects invalid JSON with 400", async () => {
+    const res = await post(ABSENT_TICKET, "{not json");
+    expect(res.status).toBe(400);
+  });
+
+  it("rejects a malformed ticket id with 400 before any write", async () => {
+    for (const bad of ["not-a-ticket", "CTL", "..%2F..%2Fetc"]) {
+      const res = await fetch(`${baseUrl}/api/ticket/${bad}/reply`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ body: "hello" }),
+      });
+      expect(res.status).toBe(400);
+    }
+  });
+
+  it("never returns 200 for a ticket that cannot resolve (row must be restored)", async () => {
+    // A non-existent issue must NOT read as success — the UI restores the row on
+    // any non-2xx, and a false success would silently lose the operator's words.
+    // 404 (no such issue) and 502 (no credential on this host / API failure) are
+    // both acceptable; 200 is not.
+    const res = await post(ABSENT_TICKET, { body: "this must not be reported as sent" });
+    expect(res.status).not.toBe(200);
+    expect([404, 502]).toContain(res.status);
+    const json = (await res.json()) as { status: string; error?: string };
+    expect(json.status).not.toBe("replied");
+    // The failure is explained, not silent.
+    expect(typeof json.error).toBe("string");
+  });
+
+  it("does not answer the reply route on GET", async () => {
+    const res = await fetch(`${baseUrl}/api/ticket/${ABSENT_TICKET}/reply`);
+    expect(res.status).not.toBe(200);
+  });
+});

--- a/plugins/dev/scripts/orch-monitor/__tests__/inbox-conversation-endpoints.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/inbox-conversation-endpoints.test.ts
@@ -125,17 +125,24 @@ describe("POST /api/ticket/:id/reply (CTL-1569)", () => {
     // A non-existent issue must NOT read as success — the UI restores the row on
     // any non-2xx, and a false success would silently lose the operator's words.
     //
-    // SPENDS NO LINEAR QUOTA: the credential is removed for the duration, so the
-    // post short-circuits at the `no_token` gate BEFORE any network call. Without
-    // this the route would run a real `viewer` query + a real `issue` lookup on
-    // every suite run — two API calls against a shared, rate-limited fleet quota,
-    // on a fleet that has had an active 429 problem. The assertion is the same
-    // either way (a non-resolvable reply is never `replied`), so making it offline
-    // costs no coverage and makes the result host-independent.
+    // SPENDS NO LINEAR QUOTA: BOTH credential sources are neutralized for the
+    // duration, so the post short-circuits at the `no_token` gate before any
+    // network call. Without this the route runs a real `viewer` query + a real
+    // `issue` lookup on every suite run — two API calls against a shared,
+    // rate-limited fleet quota, on a fleet that has had an active 429 problem.
+    //
+    // Clearing the env vars alone is NOT sufficient: the credential resolver also
+    // falls back to the Layer-2 personal token (required, because the launchd path
+    // exports nothing into the environment), and that file exists on a developer
+    // machine. Pointing the project key at a nonexistent project makes that lookup
+    // miss too. The assertion is unchanged either way, so this costs no coverage
+    // and makes the result host-independent.
     const prevToken = process.env.LINEAR_API_TOKEN;
     const prevKey = process.env.LINEAR_API_KEY;
+    const prevProject = process.env.CATALYST_PROJECT_KEY;
     delete process.env.LINEAR_API_TOKEN;
     delete process.env.LINEAR_API_KEY;
+    process.env.CATALYST_PROJECT_KEY = "__no_such_project_for_test__";
     try {
       const res = await post(ABSENT_TICKET, { body: "this must not be reported as sent" });
       expect(res.status).not.toBe(200);
@@ -148,6 +155,8 @@ describe("POST /api/ticket/:id/reply (CTL-1569)", () => {
     } finally {
       if (prevToken !== undefined) process.env.LINEAR_API_TOKEN = prevToken;
       if (prevKey !== undefined) process.env.LINEAR_API_KEY = prevKey;
+      if (prevProject !== undefined) process.env.CATALYST_PROJECT_KEY = prevProject;
+      else delete process.env.CATALYST_PROJECT_KEY;
     }
   });
 

--- a/plugins/dev/scripts/orch-monitor/__tests__/inbox-conversation-endpoints.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/inbox-conversation-endpoints.test.ts
@@ -18,8 +18,10 @@ let baseUrl: string;
 let tmpDir: string;
 
 /** Definitively not a real Linear issue, so route behavior is host-independent
- *  and no live ticket can be written to. */
-const ABSENT_TICKET = "ZZZ-999999";
+ *  and no live ticket can be written to. Uses the `PROJ` fixture prefix per
+ *  AGENTS.md → Version Control (never a real team's prefix, and never the
+ *  `ZZZ-` form some older suites reach for). */
+const ABSENT_TICKET = "PROJ-999999";
 
 beforeAll(() => {
   tmpDir = mkdtempSync(join(tmpdir(), "inbox-conversation-endpoints-"));
@@ -122,15 +124,31 @@ describe("POST /api/ticket/:id/reply (CTL-1569)", () => {
   it("never returns 200 for a ticket that cannot resolve (row must be restored)", async () => {
     // A non-existent issue must NOT read as success — the UI restores the row on
     // any non-2xx, and a false success would silently lose the operator's words.
-    // 404 (no such issue) and 502 (no credential on this host / API failure) are
-    // both acceptable; 200 is not.
-    const res = await post(ABSENT_TICKET, { body: "this must not be reported as sent" });
-    expect(res.status).not.toBe(200);
-    expect([404, 502]).toContain(res.status);
-    const json = (await res.json()) as { status: string; error?: string };
-    expect(json.status).not.toBe("replied");
-    // The failure is explained, not silent.
-    expect(typeof json.error).toBe("string");
+    //
+    // SPENDS NO LINEAR QUOTA: the credential is removed for the duration, so the
+    // post short-circuits at the `no_token` gate BEFORE any network call. Without
+    // this the route would run a real `viewer` query + a real `issue` lookup on
+    // every suite run — two API calls against a shared, rate-limited fleet quota,
+    // on a fleet that has had an active 429 problem. The assertion is the same
+    // either way (a non-resolvable reply is never `replied`), so making it offline
+    // costs no coverage and makes the result host-independent.
+    const prevToken = process.env.LINEAR_API_TOKEN;
+    const prevKey = process.env.LINEAR_API_KEY;
+    delete process.env.LINEAR_API_TOKEN;
+    delete process.env.LINEAR_API_KEY;
+    try {
+      const res = await post(ABSENT_TICKET, { body: "this must not be reported as sent" });
+      expect(res.status).not.toBe(200);
+      expect(res.status).toBe(502); // no_token → the write did not act
+      const json = (await res.json()) as { status: string; error?: string };
+      expect(json.status).not.toBe("replied");
+      expect(json.status).toBe("no_token");
+      // The failure is explained, not silent.
+      expect(typeof json.error).toBe("string");
+    } finally {
+      if (prevToken !== undefined) process.env.LINEAR_API_TOKEN = prevToken;
+      if (prevKey !== undefined) process.env.LINEAR_API_KEY = prevKey;
+    }
   });
 
   it("does not answer the reply route on GET", async () => {

--- a/plugins/dev/scripts/orch-monitor/lib/inbox-ask.d.mts
+++ b/plugins/dev/scripts/orch-monitor/lib/inbox-ask.d.mts
@@ -1,0 +1,47 @@
+// Type declarations for inbox-ask.mjs (CTL-1569 §1) — "what this needs from you",
+// derived. Lets the strict TS server and the .ts test files import it without a
+// TS7016 implicit-any error. Keep in sync with inbox-ask.mjs.
+
+/** The four ask kinds (CTL-1569 §1 table). */
+export type AskKind = "approve" | "decide" | "act-then-confirm" | "clarify";
+
+/** Where a derived ask came from. `structured` is producer-authored; the other two
+ *  are reader-side derivations the UI marks as inferred. */
+export type AskSource = "structured" | "explanation" | "comment";
+
+export interface InboxAsk {
+  kind: AskKind;
+  summary: string;
+  /** Only ever populated from ENUMERATED producer options or an explicit producer
+   *  list — the text classifier never invents a chip. */
+  suggestedReplies: string[];
+  /** THE bit the operator cares about, always DERIVED from `kind` so the two can
+   *  never disagree: false for `act-then-confirm`, true for the other three. */
+  canResolveByReply: boolean;
+  source: AskSource;
+}
+
+export const ASK_KINDS: readonly AskKind[];
+
+export function classifyAskText(text: unknown): AskKind;
+
+export function condenseSummary(text: unknown, max?: number): string | null;
+
+export function askFromStructured(explanation: unknown): InboxAsk | null;
+
+export function askFromExplanation(explanation: unknown): InboxAsk | null;
+
+export function askFromComment(commentBody: unknown): InboxAsk | null;
+
+/** Is this body a content-free escalation pointer ("…(See your inbox.)")? */
+export function isEscalationNotice(body: unknown): boolean;
+
+/** Pick the agent comment that best carries the ask, from a NEWEST-FIRST list. */
+export function pickAskComment(agentComments: unknown): string | null;
+
+export function deriveAsk(args?: {
+  explanation?: unknown;
+  /** NEWEST-FIRST agent comment bodies, so notice-skipping can apply. */
+  agentComments?: readonly string[] | null;
+  lastAgentComment?: string | null;
+}): InboxAsk | null;

--- a/plugins/dev/scripts/orch-monitor/lib/inbox-ask.d.mts
+++ b/plugins/dev/scripts/orch-monitor/lib/inbox-ask.d.mts
@@ -33,10 +33,48 @@ export function askFromExplanation(explanation: unknown): InboxAsk | null;
 
 export function askFromComment(commentBody: unknown): InboxAsk | null;
 
-/** Is this body a content-free escalation pointer ("…(See your inbox.)")? */
+/** What an agent comment is, as an ask candidate. `blocker` = a named failure with
+ *  no question attached (→ `act-then-confirm`); `status` = the pass reporting, not
+ *  asking; `none` = nothing left once producer boilerplate is stripped. */
+export type AskCandidateClass = "ask" | "blocker" | "status" | "none";
+
+export interface AskCandidate {
+  class: AskCandidateClass;
+  /** The informative residue to summarize; null for `status` / `none`. */
+  text: string | null;
+}
+
+export const ASK_CANDIDATE_CLASSES: readonly AskCandidateClass[];
+
+/** Producer boilerplate removed; null when nothing informative is left. */
+export function stripEscalationBoilerplate(body: unknown): string | null;
+
+/** Is this the recovery pass REPORTING (✅/🔧/leave-alone verdict) rather than
+ *  asking? The `needs-human VALID` verdict is excluded — it names a blocker. */
+export function isRecoveryStatusNote(body: unknown): boolean;
+
+/** The paragraph stating an explicit operator requirement, or null. */
+export function extractOperatorActionBlock(body: unknown): string | null;
+
+export function classifyAskCandidate(body: unknown): AskCandidate;
+
+export function askFromCandidate(candidate: AskCandidate | null | undefined): InboxAsk | null;
+
+/** Does this body state a request, beyond announcing that one exists? */
+export function hasSubstantiveAsk(body: unknown): boolean;
+
+/** Is this body a status report, a pass verdict, or a content-free pointer — i.e.
+ *  unusable as an ask? */
 export function isEscalationNotice(body: unknown): boolean;
 
-/** Pick the agent comment that best carries the ask, from a NEWEST-FIRST list. */
+/** Is this body a per-phase status report ("**Phase Implement** · Commits: 7")? */
+export function isPhaseStatusReport(body: unknown): boolean;
+
+/** The best ask candidate from a NEWEST-FIRST list: newest `ask`, else newest
+ *  `blocker`, else null. Never falls back to the newest body. */
+export function pickAskCandidate(agentComments: unknown): AskCandidate | null;
+
+/** The BODY TEXT of the best ask candidate (the residue), or null. */
 export function pickAskComment(agentComments: unknown): string | null;
 
 export function deriveAsk(args?: {

--- a/plugins/dev/scripts/orch-monitor/lib/inbox-ask.mjs
+++ b/plugins/dev/scripts/orch-monitor/lib/inbox-ask.mjs
@@ -283,7 +283,14 @@ export function askFromCandidate(candidate) {
   const summary = condenseSummary(text);
   if (summary == null) return null;
   return buildAsk({
-    kind: candidate.class === "blocker" ? "act-then-confirm" : classifyAskText(text),
+    // `action` and `blocker` both REQUIRE work before the ticket can clear, so the
+    // kind is forced rather than inferred — the classifier cannot be trusted to
+    // find an act-then-confirm marker in prose like "Action required: rotate the
+    // credentials.", and a false "just reply" promise costs the operator a round trip.
+    kind:
+      candidate.class === "blocker" || candidate.class === "action"
+        ? "act-then-confirm"
+        : classifyAskText(text),
     summary,
     // Never a chip from prose: it would be a guess at what the agent accepts, and
     // a wrong chip is worse than a free-text box.
@@ -517,7 +524,7 @@ export function hasSubstantiveAsk(body) {
 
 /** What an agent comment can be as an ask candidate, STRONGEST FIRST — the array
  *  order IS the selection ranking (pickAskCandidate walks it). */
-export const ASK_CANDIDATE_CLASSES = ["ask", "blocker", "prose", "status", "none"];
+export const ASK_CANDIDATE_CLASSES = ["action", "ask", "blocker", "prose", "status", "none"];
 
 /** The prefix of ASK_CANDIDATE_CLASSES that can carry an ask — everything ahead of
  *  the two classes that never can. Sliced rather than re-listed so the ranking has
@@ -548,7 +555,12 @@ export function classifyAskCandidate(body) {
   if (s == null) return { class: "none", text: null };
 
   const actionBlock = extractOperatorActionBlock(s);
-  if (actionBlock != null) return { class: "ask", text: actionBlock };
+  // A distinct class, NOT plain "ask": an operator-action block states work the
+  // human must perform, and routing it through the general text classifier yields
+  // e.g. `clarify` for "Action required: rotate the credentials." — telling the
+  // operator a written reply alone resolves it, which is the single costliest
+  // misclassification this module can make.
+  if (actionBlock != null) return { class: "action", text: actionBlock };
 
   if (isRecoveryStatusNote(s) || isPhaseStatusReport(s)) return { class: "status", text: null };
 

--- a/plugins/dev/scripts/orch-monitor/lib/inbox-ask.mjs
+++ b/plugins/dev/scripts/orch-monitor/lib/inbox-ask.mjs
@@ -1,0 +1,339 @@
+// inbox-ask.mjs — "what this needs from you", derived (CTL-1569 §1).
+//
+// The most important part of the inbox conversation surface: each parked row must
+// lead with a plain-language statement of what would SATISFY the ask, and of what
+// KIND of ask it is. The distinction the operator actually cares about is not the
+// taxonomy for its own sake — it is:
+//
+//     can I resolve this by REPLYING alone, or do I have to go DO something first?
+//
+// That single bit is `canResolveByReply`, and every kind below exists to carry it
+// honestly.
+//
+//   approve          — a yes/no is enough                      (reply alone: YES)
+//   decide           — choose between enumerated options        (reply alone: YES)
+//   act-then-confirm — you must DO something, then confirm      (reply alone: NO)
+//   clarify          — free-text answer needed, no default      (reply alone: YES)
+//
+// TWO SOURCES, in preference order (CTL-1569: "prefer a structured `ask` object …
+// fall back to deriving from the last agent comment … do not block the UI on the
+// producer change"):
+//
+//   1. STRUCTURED — an `ask` object on the phase signal's `explanation`
+//      (`kind`, `summary`, `suggested_replies[]`). This is what the escalation
+//      producer SHOULD write. When present it is used verbatim: the producer knows
+//      what it asked far better than any reader-side heuristic.
+//   2. DERIVED — the structured explanation's own fields (`options`,
+//      `call_to_action`, `what_to_do`), then finally the last AGENT comment body.
+//      This is what makes the surface useful for tickets parked BEFORE the producer
+//      change — a UI that only renders for future escalations has nothing to show
+//      today.
+//
+// HONESTY RULES (the whole module is built around them):
+//   • `source` is always reported ("structured" | "explanation" | "comment"), so
+//     the UI can be quieter about a guess than about a producer-authored ask.
+//   • A derivation that finds NO usable text returns null — the pane renders the
+//     ask block ABSENT rather than fabricating "reply to continue". Absent is
+//     honest; invented is not (the standing read-model rule).
+//   • `suggestedReplies` is only ever populated from ENUMERATED options or an
+//     explicit producer list. The text classifier NEVER invents a reply chip —
+//     a chip that prefills a reply the agent won't accept is worse than no chip.
+//
+// PURE + injection-free: no fs, no db, no fetch. The caller supplies the phase
+// signals and (optionally) the last agent comment, so this is unit-tested directly.
+
+/** The four ask kinds (CTL-1569 §1 table). */
+export const ASK_KINDS = ["approve", "decide", "act-then-confirm", "clarify"];
+
+/** Kinds an operator can satisfy by replying ALONE — the bit that matters most.
+ *  `act-then-confirm` is deliberately excluded: it requires off-platform work
+ *  first, and telling the operator "just reply" there would be a lie. */
+const REPLY_ALONE_KINDS = new Set(["approve", "decide", "clarify"]);
+
+/** Cap on a rendered summary. Long escalation prose is truncated with an ellipsis
+ *  rather than dumped into the row — the full text stays in the thread + pane. */
+const SUMMARY_MAX = 400;
+
+/** Cap on suggested-reply chips. More than a handful stops being a shortcut and
+ *  becomes a second decision; the operator can always type a free reply. */
+const MAX_SUGGESTED = 4;
+
+// ── text classification ──────────────────────────────────────────────────────
+// A deliberately CONSERVATIVE classifier. It only claims a kind when the text
+// carries a clear marker; everything unrecognized falls to `clarify`, which is the
+// honest default ("free-text answer needed, no default"). Ordered most-specific
+// first because the act-then-confirm markers are the ones that must never be
+// mistaken for a plain approve — misclassifying "create the label, then reply
+// done" as `approve` would tell the operator a bare "yes" is sufficient when it
+// demonstrably is not. That is the one error with a real cost, so it wins ties.
+
+/** "You must go DO something first, then come back and confirm." */
+const ACT_THEN_CONFIRM_PATTERNS = [
+  /\bthen\s+(?:reply|confirm|respond|comment|say)\b/i,
+  /\b(?:reply|confirm|respond|comment)\s+(?:with\s+)?["'`]?done["'`]?\b/i,
+  /\bonce\s+(?:you(?:'ve|\s+have)?|that(?:'s|\s+is)?)\s+.*\b(?:reply|confirm|respond|done)\b/i,
+  /\bafter\s+you\s+.*\b(?:reply|confirm|respond)\b/i,
+  /\bmanually\s+(?:create|add|set|apply|run|fix|delete|remove)\b/i,
+  /\b(?:create|add|set|apply|run|rotate|delete|remove|grant|install)\b[^.!?]*\bthen\b/i,
+];
+
+/** A yes/no is enough. */
+const APPROVE_PATTERNS = [
+  /\b(?:approve|approval)\b/i,
+  /\bok(?:ay)?\s+to\s+(?:proceed|continue|merge|publish|ship|deploy|delete)\b/i,
+  /\bshould\s+i\s+(?:proceed|continue|merge|publish|ship|deploy|go\s+ahead)\b/i,
+  /\bpermission\s+to\b/i,
+  /\bgo\/no-?go\b/i,
+  /\bconfirm\s+(?:that\s+)?(?:i|we)\s+(?:should|can|may)\b/i,
+  /\byes\s*\/\s*no\b/i,
+];
+
+/** Choose between enumerated alternatives. */
+const DECIDE_PATTERNS = [
+  /\bwhich\s+(?:one|option|of|approach|way)\b/i,
+  /\b(?:option|choice)\s+(?:a|b|1|2)\b/i,
+  /\beither\b[^.!?]*\bor\b/i,
+  /\bA\)\s*.*\bB\)/,
+  /\b(?:choose|pick|select)\s+(?:between|one|from)\b/i,
+];
+
+function matchesAny(text, patterns) {
+  return patterns.some((re) => re.test(text));
+}
+
+/**
+ * Classify free-text into an ask kind. Conservative + ordered: act-then-confirm
+ * (the costly-to-miss case) → decide → approve → clarify (the honest default).
+ * Exported so the classification itself is directly unit-tested.
+ */
+export function classifyAskText(text) {
+  if (typeof text !== "string" || text.trim() === "") return "clarify";
+  if (matchesAny(text, ACT_THEN_CONFIRM_PATTERNS)) return "act-then-confirm";
+  if (matchesAny(text, DECIDE_PATTERNS)) return "decide";
+  if (matchesAny(text, APPROVE_PATTERNS)) return "approve";
+  return "clarify";
+}
+
+// ── helpers ──────────────────────────────────────────────────────────────────
+
+function nonEmptyString(v) {
+  return typeof v === "string" && v.trim() !== "" ? v.trim() : null;
+}
+
+/** Collapse whitespace + truncate for a one-glance summary. Markdown is left as
+ *  literal text: the pane renders it as plain text, so a stray `**` is cosmetic,
+ *  whereas a partial-HTML render would be a correctness bug. */
+export function condenseSummary(text, max = SUMMARY_MAX) {
+  const s = nonEmptyString(text);
+  if (s == null) return null;
+  const flat = s.replace(/\s+/g, " ").trim();
+  if (flat.length <= max) return flat;
+  return `${flat.slice(0, max - 1).trimEnd()}…`;
+}
+
+/** Normalize a producer-supplied kind, or null when it isn't one of the four. */
+function normalizeKind(v) {
+  const s = nonEmptyString(v);
+  if (s == null) return null;
+  const k = s.toLowerCase().replace(/_/g, "-");
+  return ASK_KINDS.includes(k) ? k : null;
+}
+
+/** Normalize a suggested-reply list to short, de-duped, non-empty strings. */
+function normalizeSuggested(list) {
+  if (!Array.isArray(list)) return [];
+  const out = [];
+  const seen = new Set();
+  for (const item of list) {
+    // Accept either a bare string or an {label} / {value} object (the options
+    // shape the escalation producer already writes for decision rows).
+    const label = nonEmptyString(
+      typeof item === "string" ? item : item?.label ?? item?.value ?? null,
+    );
+    if (label == null) continue;
+    const key = label.toLowerCase();
+    if (seen.has(key)) continue;
+    seen.add(key);
+    out.push(label);
+    if (out.length >= MAX_SUGGESTED) break;
+  }
+  return out;
+}
+
+/** Build the closed ask view object. `kind` is trusted; the reply-alone bit is
+ *  always DERIVED from the kind so the two can never disagree. */
+function buildAsk({ kind, summary, suggestedReplies, source }) {
+  return {
+    kind,
+    summary,
+    suggestedReplies,
+    canResolveByReply: REPLY_ALONE_KINDS.has(kind),
+    source,
+  };
+}
+
+// ── the structured (preferred) path ──────────────────────────────────────────
+
+/**
+ * Read a producer-authored `ask` object off an explanation. Returns null unless it
+ * carries BOTH a recognized kind AND a summary — a half-written ask is treated as
+ * absent so the derived path can still produce something useful, rather than
+ * rendering a kind chip with no sentence under it.
+ */
+export function askFromStructured(explanation) {
+  const ask = explanation?.ask;
+  if (!ask || typeof ask !== "object") return null;
+  const kind = normalizeKind(ask.kind);
+  const summary = condenseSummary(ask.summary);
+  if (kind == null || summary == null) return null;
+  return buildAsk({
+    kind,
+    summary,
+    suggestedReplies: normalizeSuggested(ask.suggested_replies ?? ask.suggestedReplies),
+    source: "structured",
+  });
+}
+
+// ── the derived paths ────────────────────────────────────────────────────────
+
+/**
+ * Derive an ask from the explanation's EXISTING fields (no `ask` object). This is
+ * the sweet spot for tickets parked today: the CTL-1110 escalation producer
+ * already writes `call_to_action` / `what_to_do` / `options`.
+ *
+ * Enumerated `options` are the strongest signal available — two or more of them
+ * IS a decision, and their labels are legitimate reply chips (they came from the
+ * producer, not from a guess). Otherwise the CTA/what-to-do text is classified.
+ */
+export function askFromExplanation(explanation) {
+  if (!explanation || typeof explanation !== "object") return null;
+
+  const options = normalizeSuggested(explanation.options);
+  const cta = nonEmptyString(explanation.call_to_action);
+  const whatToDo = nonEmptyString(explanation.what_to_do);
+
+  // Enumerated options → a decision, with the option labels as real chips.
+  if (options.length >= 2) {
+    const summary = condenseSummary(cta ?? whatToDo ?? `Choose: ${options.join(" / ")}`);
+    if (summary == null) return null;
+    return buildAsk({
+      kind: "decide",
+      summary,
+      suggestedReplies: options,
+      source: "explanation",
+    });
+  }
+
+  // No options → classify the most actionable prose the producer wrote. Both
+  // fields feed the classifier (what_to_do is where "…then reply done" usually
+  // lives, and missing that is the one costly error), but the CTA leads the
+  // summary because it is the shorter, more imperative line.
+  const summary = condenseSummary(cta ?? whatToDo);
+  if (summary == null) return null;
+  const kind = classifyAskText([cta, whatToDo].filter(Boolean).join(" — "));
+  return buildAsk({ kind, summary, suggestedReplies: [], source: "explanation" });
+}
+
+/**
+ * Last-resort derivation from the newest AGENT comment — what makes the ~handful
+ * of tickets parked RIGHT NOW render usefully. `source: "comment"` lets the UI
+ * mark it as inferred rather than producer-authored.
+ *
+ * Never produces reply chips: a chip derived from prose would be a guess at what
+ * the agent accepts, and a wrong chip is worse than a free-text box.
+ */
+export function askFromComment(commentBody) {
+  const summary = condenseSummary(commentBody);
+  if (summary == null) return null;
+  return buildAsk({
+    kind: classifyAskText(commentBody),
+    summary,
+    suggestedReplies: [],
+    source: "comment",
+  });
+}
+
+// ── choosing WHICH agent comment carries the ask ──────────────────────────────
+//
+// The newest agent comment is usually the ask — but not always, and the exception
+// is systematic rather than rare. The recovery-pass escalation posts a content-free
+// POINTER as its final word:
+//
+//     🔼 **recovery-pass** self-heal attempts exhausted on this ticket —
+//     escalated to the operator. (See your inbox.)
+//
+// That is the entire comment. Deriving the ask from it yields a summary that tells
+// the operator only that they are needed, which they already knew — while the
+// comment directly beneath it carries the actual reason:
+//
+//     **Reason:** Failure reason: duplicate_of_CTL-1385:fix_already_merged…
+//
+// So we skip SHORT, purely-referential escalation notices and use the newest
+// SUBSTANTIVE agent comment instead. This is selection among things the agent
+// really said — never fabrication. If every agent comment is a notice we fall back
+// to the newest one rather than rendering nothing: a weak ask beats an absent one
+// when the agent genuinely said nothing else.
+
+/** Markers of a bare "you are needed, look elsewhere" notice. */
+const ESCALATION_NOTICE_PATTERNS = [
+  /\(see your inbox\.?\)/i,
+  /escalated to the operator/i,
+  /marked for human review/i,
+  /requires human judgment/i,
+  /self-heal attempts exhausted/i,
+];
+
+/** Below this length a notice-matching comment is treated as a pure pointer. A
+ *  LONG comment that happens to contain a notice phrase still carries content, so
+ *  the length floor keeps the filter from discarding real asks. */
+const NOTICE_MAX_CHARS = 400;
+
+/** Is this body a content-free escalation pointer? Exported for direct testing. */
+export function isEscalationNotice(body) {
+  const s = nonEmptyString(body);
+  if (s == null) return true; // an empty body carries no ask either
+  if (s.length > NOTICE_MAX_CHARS) return false;
+  return matchesAny(s, ESCALATION_NOTICE_PATTERNS);
+}
+
+/**
+ * Pick the agent comment that best carries the ask, from a NEWEST-FIRST list of
+ * agent comment bodies. Returns the newest substantive body, else the newest body,
+ * else null for an empty list.
+ */
+export function pickAskComment(agentComments) {
+  const bodies = (Array.isArray(agentComments) ? agentComments : [])
+    .map((b) => nonEmptyString(b))
+    .filter(Boolean);
+  if (bodies.length === 0) return null;
+  return bodies.find((b) => !isEscalationNotice(b)) ?? bodies[0];
+}
+
+// ── the public entry point ───────────────────────────────────────────────────
+
+/**
+ * Derive the ask summary for a parked ticket, walking the preference chain:
+ *   structured `ask` → explanation fields → newest agent comment → null.
+ *
+ * `explanation` is the CTL-1110 six-field object (board-data.mjs::deriveExplanation)
+ * optionally extended with an `ask` object. For the comment fallback, prefer
+ * `agentComments` (a NEWEST-FIRST list, so notice-skipping can apply); the single
+ * `lastAgentComment` remains accepted for callers that have only one body.
+ *
+ * Returns null when NO source yields usable text — the pane then renders no ask
+ * block at all (honest absence).
+ */
+export function deriveAsk({
+  explanation = null,
+  agentComments = null,
+  lastAgentComment = null,
+} = {}) {
+  const commentBody =
+    (Array.isArray(agentComments) ? pickAskComment(agentComments) : null) ?? lastAgentComment;
+  return (
+    askFromStructured(explanation) ??
+    askFromExplanation(explanation) ??
+    askFromComment(commentBody) ??
+    null
+  );
+}

--- a/plugins/dev/scripts/orch-monitor/lib/inbox-ask.mjs
+++ b/plugins/dev/scripts/orch-monitor/lib/inbox-ask.mjs
@@ -312,6 +312,29 @@ export function isPhaseStatusReport(body) {
 }
 
 /**
+ * Markers that a comment carries a REAL ask despite also matching a notice phrase.
+ *
+ * The notice patterns are phrase matches, so a comment that BOTH announces the
+ * escalation AND states the decision — "This requires human judgment: should we
+ * choose A or B?" — was being discarded, and pickAskComment fell through to an
+ * older, less relevant note. A standalone pointer asks nothing and enumerates
+ * nothing; substantive text does. These are the signals that separate them.
+ */
+const SUBSTANTIVE_ASK_MARKERS = [
+  /\?/, // a literal question — the strongest signal a decision is being requested
+  /\b(?:option|choose|pick|select|either)\b/i,
+  /(?:^|\s)(?:A\)|1\))\s/m, // enumerated alternatives
+  /\breply\s+(?:with\s+)?["'`]?\w/i, // "reply approve" / "reply done"
+];
+
+/** Does this body state an actual ask, beyond announcing that one exists? */
+export function hasSubstantiveAsk(body) {
+  const s = nonEmptyString(body);
+  if (s == null) return false;
+  return matchesAny(s, SUBSTANTIVE_ASK_MARKERS);
+}
+
+/**
  * Is this body unusable as an ask — either a content-free escalation pointer or a
  * phase status report? Exported for direct testing.
  *
@@ -323,7 +346,10 @@ export function isEscalationNotice(body) {
   if (s == null) return true; // an empty body carries no ask either
   if (isPhaseStatusReport(s)) return true;
   if (s.length > NOTICE_MAX_CHARS) return false;
-  return matchesAny(s, ESCALATION_NOTICE_PATTERNS);
+  if (!matchesAny(s, ESCALATION_NOTICE_PATTERNS)) return false;
+  // It reads like a notice — but if it ALSO states a real ask, it IS the ask.
+  // Discarding it would silently promote an older, less relevant comment.
+  return !hasSubstantiveAsk(s);
 }
 
 /**

--- a/plugins/dev/scripts/orch-monitor/lib/inbox-ask.mjs
+++ b/plugins/dev/scripts/orch-monitor/lib/inbox-ask.mjs
@@ -230,63 +230,242 @@ export function askFromExplanation(explanation) {
   // summary because it is the shorter, more imperative line.
   const summary = condenseSummary(cta ?? whatToDo);
   if (summary == null) return null;
-  const kind = classifyAskText([cta, whatToDo].filter(Boolean).join(" — "));
-  return buildAsk({ kind, summary, suggestedReplies: [], source: "explanation" });
+  const classified = classifyAskText([cta, whatToDo].filter(Boolean).join(" — "));
+  return buildAsk({
+    kind: declaredKind(explanation, classified),
+    summary,
+    suggestedReplies: [],
+    source: "explanation",
+  });
 }
 
 /**
- * Last-resort derivation from the newest AGENT comment — what makes the ~handful
- * of tickets parked RIGHT NOW render usefully. `source: "comment"` lets the UI
- * mark it as inferred rather than producer-authored.
+ * The producer's DECLARED escalation type → ask kind.
  *
- * Never produces reply chips: a chip derived from prose would be a guess at what
- * the agent accepts, and a wrong chip is worse than a free-text box.
+ * `escalation_type` is an existing documented tagged union — `decision |
+ * authorization | manual` (recovery-pass/SKILL.md, _phase-agent-template/SKILL.md)
+ * — i.e. the producer's own word for what it is asking. It beats any reader-side
+ * reading of the CTA prose: the live `authorization` escalations say "authorize
+ * another recovery cycle …, or take it over?", which the text classifier reads as
+ * `clarify` ("free-text answer needed") when the producer plainly declared it a
+ * yes/no.
+ *
+ * `manual` is deliberately ABSENT: it is the DEFAULT the producer substitutes when
+ * nothing was declared (recovery-reasoning.mjs), so mapping it would turn
+ * "unspecified" into a claim. Those fall through to the prose classifier.
  */
-export function askFromComment(commentBody) {
-  const summary = condenseSummary(commentBody);
+const ESCALATION_TYPE_KINDS = { decision: "decide", authorization: "approve" };
+
+/** The declared kind, EXCEPT that a classified `act-then-confirm` always wins.
+ *  That is the one asymmetry worth hard-coding: if the prose says "create the
+ *  label, then reply done", honoring a declared `authorization` would tell the
+ *  operator a bare "yes" is sufficient when it demonstrably is not. */
+function declaredKind(explanation, classified) {
+  if (classified === "act-then-confirm") return classified;
+  const declared = ESCALATION_TYPE_KINDS[nonEmptyString(explanation?.escalation_type)?.toLowerCase()];
+  return declared ?? classified;
+}
+
+/**
+ * Build an ask from a classified comment candidate (see classifyAskCandidate).
+ *
+ * The class decides the KIND for a `blocker`, bypassing the prose classifier: a
+ * named failure with no question attached is work, not a question, and running it
+ * through the classifier returned `clarify` — whose rendered promise is "a written
+ * answer resolves this; there is no default". On a ticket blocked by a dirty tree
+ * or a CONFLICTING PR that promise is simply false, and it is the expensive
+ * direction of the error this module is built to avoid. `act-then-confirm` states
+ * it honestly: do the work, then reply to confirm.
+ */
+export function askFromCandidate(candidate) {
+  const text = nonEmptyString(candidate?.text);
+  if (text == null) return null;
+  const summary = condenseSummary(text);
   if (summary == null) return null;
   return buildAsk({
-    kind: classifyAskText(commentBody),
+    kind: candidate.class === "blocker" ? "act-then-confirm" : classifyAskText(text),
     summary,
+    // Never a chip from prose: it would be a guess at what the agent accepts, and
+    // a wrong chip is worse than a free-text box.
     suggestedReplies: [],
     source: "comment",
   });
 }
 
+/**
+ * Last-resort derivation from a single AGENT comment — what makes the ~handful of
+ * tickets parked RIGHT NOW render usefully. `source: "comment"` lets the UI mark it
+ * as inferred rather than producer-authored. Returns null when the comment carries
+ * no ask at all (a status note, a phase report, a bare pointer).
+ */
+export function askFromComment(commentBody) {
+  return askFromCandidate(classifyAskCandidate(commentBody));
+}
+
 // ── choosing WHICH agent comment carries the ask ──────────────────────────────
 //
-// The newest agent comment is usually the ask — but not always, and the exception
-// is systematic rather than rare. The recovery-pass escalation posts a content-free
-// POINTER as its final word:
+// The newest agent comment is usually the ask — but on a parked ticket it usually
+// ISN'T, and the exception is systematic rather than rare. Verified against the
+// live inbox (6 parked tickets, 2026-07-30): the newest agent comment was the ask
+// on ZERO of them. It was the recovery pass's content-free pointer on five:
 //
 //     🔼 **recovery-pass** self-heal attempts exhausted on this ticket —
-//     escalated to the operator. (See your inbox.)
+//     escalated to the operator. self-heal attempts exhausted (2 dispatches
+//     without a recorded verdict). (See your inbox.)
 //
-// That is the entire comment. Deriving the ask from it yields a summary that tells
-// the operator only that they are needed, which they already knew — while the
-// comment directly beneath it carries the actual reason:
+// That is the entire comment, and every clause of it is escalation BOOKKEEPING:
+// rendered as the ask it tells the operator only that they are needed — "(See your
+// inbox.)" inside the inbox — which they already knew. The informative comment sits
+// beneath it:
 //
-//     **Reason:** Failure reason: duplicate_of_CTL-1385:fix_already_merged…
+//     **Reason:** Failure reason: rebase_refused_dirty_tree
 //
-// So we skip SHORT, purely-referential escalation notices and use the newest
-// SUBSTANTIVE agent comment instead. This is selection among things the agent
-// really said — never fabrication. If every agent comment is a notice we fall back
-// to the newest one rather than rendering nothing: a weak ask beats an absent one
-// when the agent genuinely said nothing else.
+// STRIP, THEN CLASSIFY — the design that replaced a phrase blacklist.
+//
+// An earlier cut REJECTED any short comment matching a notice phrase. That threw
+// away the comment above (it matches "requires human judgment" and "marked for
+// human review" and is only 188 chars), left every remaining candidate a phase
+// report, and then fell back to `bodies[0]` — the pointer. So the filter meant to
+// suppress the pointer is exactly what elected it.
+//
+// The fix inverts the primitive: those phrases are producer BOILERPLATE to REMOVE,
+// not evidence to reject on. Every one of them comes from a template we can name
+// (recovery-reasoning.mjs `formatEscalationComment` / the `🔼` escalation comment;
+// recovery-emit.mjs's `🔍`/`🔼` notes; the recovery-pass SKILL's `✅`/`🔧` notes), so
+// strip the template and classify what the agent actually added:
+//
+//   ask     — a real request: a question, enumerated options, "reply <x>", or an
+//             explicit operator-action block. The operator answers or acts.
+//   blocker — a named FAILURE with no question attached ("Failure reason: …",
+//             "needs-human VALID: PR #212 CONFLICTING/DIRTY"). The operator must go
+//             DO something; no reply resolves it. → act-then-confirm.
+//   status  — the pass REPORTING, not asking ("✅ unstuck this", "🔧 is working
+//             this", a leave-alone verdict, a phase status report). Never an ask.
+//   none    — nothing left after the boilerplate. Never an ask.
+//
+// Selection is ranked (newest `ask`, else newest `blocker`) and there is NO
+// fallback to the newest body. The old `?? bodies[0]` was the "a weak ask beats an
+// absent one" rule, and production disproved it: it rendered "✅ recovery-pass
+// unstuck this — … now running" under the heading "What this needs from you", and
+// told the operator a written answer would resolve a ticket the agent had already
+// fixed. Absent is honest; a fabricated ask is not.
 
-/** Markers of a bare "you are needed, look elsewhere" notice. */
-const ESCALATION_NOTICE_PATTERNS = [
-  /\(see your inbox\.?\)/i,
-  /escalated to the operator/i,
-  /marked for human review/i,
-  /requires human judgment/i,
-  /self-heal attempts exhausted/i,
+/**
+ * Producer BOILERPLATE, removed before classifying. Each entry is a template we
+ * can point at, not a guess about prose:
+ *   1. the `<emoji> **recovery-pass** <verb> —` comment header (recovery-emit.mjs,
+ *      recovery-reasoning.mjs, recovery-pass/SKILL.md)
+ *   2/3/4. the three fixed lines of recovery-reasoning.mjs::formatEscalationComment
+ *   5/6. the escalation trailer ("escalated to the operator", "(See your inbox.)")
+ *   7. recovery-reasoning.mjs's escalation-bookkeeping reason — it restates THAT
+ *      the escalation happened, which is the one thing the operator already knows
+ *   8. recovery-emit.mjs's leave-alone trailer
+ * Ordered header-first so the header match still sees the start of the string.
+ */
+const BOILERPLATE_PATTERNS = [
+  /^\s*[^\p{L}\p{N}]*\*{0,2}recovery-pass\*{0,2}\s+[^—\n]*—\s*/u,
+  /^[ \t]*#{1,6}[^\n]*Recovery Escalation[ \t]*$/gim,
+  /Reasoning pass determined this requires human judgment\.?/gi,
+  /This ticket is now marked for human review\.?/gi,
+  /escalated to the operator\.?/gi,
+  /\(see your inbox\.?\)/gi,
+  /self-heal attempts exhausted(?:\s+on this ticket)?\s*(?:\(\s*\d+\s+dispatches?[^)]*\))?\.?/gi,
+  /No action needed[^.\n]*\.?/gi,
 ];
 
-/** Below this length a notice-matching comment is treated as a pure pointer. A
- *  LONG comment that happens to contain a notice phrase still carries content, so
- *  the length floor keeps the filter from discarding real asks. */
-const NOTICE_MAX_CHARS = 400;
+/**
+ * Strip the producer's boilerplate and return what the agent actually added, or
+ * null when nothing is left (a pure pointer). Exported for direct testing.
+ */
+export function stripEscalationBoilerplate(body) {
+  const s = nonEmptyString(body);
+  if (s == null) return null;
+  let out = s;
+  for (const re of BOILERPLATE_PATTERNS) out = out.replace(re, " ");
+  // Removal leaves orphaned punctuation at the EDGES (and the producer's own ".."
+  // where two sentences met). Trim only there — a global punctuation squash would
+  // rewrite the identifiers this summary exists to show, turning
+  // "duplicate_of_CTL-1385" into "duplicate_of_CTL 1385".
+  out = out
+    .replace(/\.{2,}/g, ".")
+    .replace(/^[\s.;,:—–]+/, "")
+    .replace(/[\s.;,:—–]+$/, "");
+  // Nothing but punctuation left → it was a pure pointer.
+  if (!/[\p{L}\p{N}]/u.test(out)) return null;
+  return nonEmptyString(out);
+}
+
+/**
+ * The recovery pass's REPORTING notes, keyed on the verb its own templates use.
+ * `is working this` / `unstuck this` / `resolved …` / `reviewed this` all say what
+ * the PASS did; none asks the operator for anything.
+ */
+const RECOVERY_STATUS_HEADER =
+  /^\s*[^\p{L}\p{N}]*\*{0,2}recovery-pass\*{0,2}\s+(?:is working this|unstuck this|resolved\b|reviewed this)/u;
+
+/**
+ * The one carve-out: `🔍 reviewed this — needs-human VALID: …` is a leave-alone
+ * verdict for the PASS but a confirmation for the OPERATOR — it means "I checked,
+ * you really are needed, here is why". Its "No action needed; leaving as-is"
+ * trailer is about the pass's own next tick, not about the operator, so treating
+ * the whole note as status buries the blocker it just named.
+ */
+const NEEDS_HUMAN_CONFIRMED = /\bneeds-human VALID\b/i;
+
+/** Is this the recovery pass reporting rather than asking? Exported for testing. */
+export function isRecoveryStatusNote(body) {
+  const s = nonEmptyString(body);
+  if (s == null) return false;
+  if (!RECOVERY_STATUS_HEADER.test(s)) return false;
+  return !NEEDS_HUMAN_CONFIRMED.test(s);
+}
+
+/**
+ * A named FAILURE with no question attached. These come from the escalation
+ * templates (`**Reason:**` / `Failure reason:`) and the leave-alone verdict
+ * (`needs-human VALID`, `Left for operator`), so they are the producer's words for
+ * "here is what is wrong", never a request the operator can answer by replying.
+ */
+const BLOCKER_MARKERS = [
+  /\bfailure reason\s*:/i,
+  /\*{2}reason\s*:?\*{2}/i,
+  /^\s*reason\s*:/im,
+  /\bneeds-human VALID\b/i,
+  /\bleft for (?:the )?operator\b/i,
+];
+
+/**
+ * An explicit operator-directed requirement, wherever it appears — including
+ * inside a phase status report, which is where the pipeline actually writes it:
+ *
+ *     **⚠️ Required pre-merge operator migration (ordering is load-bearing):**
+ *     apply `parked-by-human` to SLI-17, confirm it appears in
+ *     `details.sanctioned` on BOTH minis' `recovery.board-scan`, then remove …
+ *
+ * That paragraph is the ticket's own act-then-confirm example, and it was being
+ * discarded with the report that carries it. This is prose-shaped rather than
+ * template-shaped, so the markers are deliberately narrow — "required"/"must"
+ * within one line of "operator", or a literal "action required" — and a miss costs
+ * only the honest absence the ask block already renders.
+ */
+const OPERATOR_ACTION_MARKERS = [
+  /\brequired\b[^\n]{0,80}\boperator\b/i,
+  /\boperator\b[^\n]{0,80}\b(?:required|must)\b/i,
+  /\baction required\b/i,
+];
+
+/** The paragraph stating an explicit operator requirement, or null. Returns just
+ *  that paragraph — the surrounding report is bookkeeping the operator hasn't been
+ *  asked about. Exported for direct testing. */
+export function extractOperatorActionBlock(body) {
+  const s = nonEmptyString(body);
+  if (s == null) return null;
+  for (const para of s.split(/\n\s*\n/)) {
+    const p = nonEmptyString(para);
+    if (p != null && matchesAny(p, OPERATOR_ACTION_MARKERS)) return p;
+  }
+  return null;
+}
 
 /**
  * Markers of a PHASE STATUS REPORT — the per-phase bookkeeping the pipeline posts
@@ -298,10 +477,16 @@ const NOTICE_MAX_CHARS = 400;
  * producing nonsense like `act-then-confirm: "Phase Implement — Commits: 7"`.
  * Anchored to the leading phase header so ordinary prose that merely mentions a
  * phase is unaffected.
+ *
+ * The separator is `[\s-]+`, not `\s+`: the phase agents post under BOTH spellings
+ * ("**Phase Implement**" and "phase-implement mirror test — see phase summary"),
+ * and a whitespace-only separator let the hyphenated one through as an ask
+ * candidate — where, being ordinary prose, it outranked nothing but still won on a
+ * ticket whose real blocker was an older comment.
  */
 const PHASE_REPORT_PATTERNS = [
-  /^\s*\**\s*phase\s+(?:triage|research|plan|implement|verify|review|pr|monitor-merge|monitor-deploy|teardown)\b/i,
-  /^\s*\**\s*(?:plan|research|implement|verify|review)\s+phase\s+[—–-]/i,
+  /^\s*\**\s*phase[\s-]+(?:triage|research|plan|implement|verify|review|pr|monitor-merge|monitor-deploy|teardown)\b/i,
+  /^\s*\**\s*(?:plan|research|implement|verify|review)[\s-]+phase\s*[—–-]/i,
 ];
 
 /** Is this body a phase status report rather than an ask? Exported for testing. */
@@ -312,13 +497,9 @@ export function isPhaseStatusReport(body) {
 }
 
 /**
- * Markers that a comment carries a REAL ask despite also matching a notice phrase.
- *
- * The notice patterns are phrase matches, so a comment that BOTH announces the
- * escalation AND states the decision — "This requires human judgment: should we
- * choose A or B?" — was being discarded, and pickAskComment fell through to an
- * older, less relevant note. A standalone pointer asks nothing and enumerates
- * nothing; substantive text does. These are the signals that separate them.
+ * Markers that a comment states a REAL request rather than merely announcing that
+ * one exists. A standalone escalation pointer asks nothing and enumerates nothing;
+ * an actual ask does one of these.
  */
 const SUBSTANTIVE_ASK_MARKERS = [
   /\?/, // a literal question — the strongest signal a decision is being requested
@@ -334,35 +515,87 @@ export function hasSubstantiveAsk(body) {
   return matchesAny(s, SUBSTANTIVE_ASK_MARKERS);
 }
 
+/** What an agent comment can be as an ask candidate, STRONGEST FIRST — the array
+ *  order IS the selection ranking (pickAskCandidate walks it). */
+export const ASK_CANDIDATE_CLASSES = ["ask", "blocker", "prose", "status", "none"];
+
+/** The prefix of ASK_CANDIDATE_CLASSES that can carry an ask — everything ahead of
+ *  the two classes that never can. Sliced rather than re-listed so the ranking has
+ *  exactly one definition. */
+const USABLE_CANDIDATE_CLASSES = ASK_CANDIDATE_CLASSES.slice(
+  0,
+  ASK_CANDIDATE_CLASSES.indexOf("status"),
+);
+
 /**
- * Is this body unusable as an ask — either a content-free escalation pointer or a
- * phase status report? Exported for direct testing.
+ * Classify one agent comment as an ask candidate: `{ class, text }`, where `text`
+ * is the informative residue to summarize (null for `status`/`none`).
  *
- * (Kept under the original name because it is the ask-candidate rejection test;
- * the escalation pointer was simply the first kind of non-ask we found.)
+ * Order is precedence, and each step earns its place:
+ *   1. an explicit operator requirement wins ANYWHERE, even inside a status report
+ *      — it is the least ambiguous signal a human is being asked for something;
+ *   2. the pass's own reporting notes and the phase reports are never asks;
+ *   3. strip the boilerplate — nothing left means it was a pure pointer;
+ *   4. a question / options / "reply <x>" in the residue is a real `ask`;
+ *   5. a named failure with no question is a `blocker` — real work, not a reply;
+ *   6. anything else is ordinary `prose`: still the agent's words, and still the
+ *      best evidence available on a ticket parked before any producer change — but
+ *      ranked BELOW a blocker, because a stray one-liner ("phase-implement mirror
+ *      test — see phase summary") must never outrank "PR #212 CONFLICTING/DIRTY".
  */
-export function isEscalationNotice(body) {
+export function classifyAskCandidate(body) {
   const s = nonEmptyString(body);
-  if (s == null) return true; // an empty body carries no ask either
-  if (isPhaseStatusReport(s)) return true;
-  if (s.length > NOTICE_MAX_CHARS) return false;
-  if (!matchesAny(s, ESCALATION_NOTICE_PATTERNS)) return false;
-  // It reads like a notice — but if it ALSO states a real ask, it IS the ask.
-  // Discarding it would silently promote an older, less relevant comment.
-  return !hasSubstantiveAsk(s);
+  if (s == null) return { class: "none", text: null };
+
+  const actionBlock = extractOperatorActionBlock(s);
+  if (actionBlock != null) return { class: "ask", text: actionBlock };
+
+  if (isRecoveryStatusNote(s) || isPhaseStatusReport(s)) return { class: "status", text: null };
+
+  const residue = stripEscalationBoilerplate(s);
+  if (residue == null) return { class: "none", text: null };
+  if (hasSubstantiveAsk(residue)) return { class: "ask", text: residue };
+  if (matchesAny(residue, BLOCKER_MARKERS)) return { class: "blocker", text: residue };
+  return { class: "prose", text: residue };
 }
 
 /**
- * Pick the agent comment that best carries the ask, from a NEWEST-FIRST list of
- * agent comment bodies. Returns the newest substantive body, else the newest body,
- * else null for an empty list.
+ * Is this body unusable as an ask — a status report, a pass verdict, or a
+ * content-free escalation pointer? Exported for direct testing.
+ *
+ * (Kept under the original name because it has always been the ask-candidate
+ * rejection test; the escalation pointer was simply the first non-ask we found.)
  */
+export function isEscalationNotice(body) {
+  const cls = classifyAskCandidate(body).class;
+  return cls === "status" || cls === "none";
+}
+
+/**
+ * Pick the candidate that best carries the ask, from a NEWEST-FIRST list of agent
+ * comment bodies: the newest `ask`, else the newest `blocker`, else the newest
+ * `prose`, else null.
+ *
+ * There is deliberately NO fallback to the newest BODY — see the section header.
+ * Ranking by class before recency is what lets a real ask beat a newer pointer and
+ * an older blocker beat a newer throwaway line, without ever promoting the
+ * pipeline's own bookkeeping to an ask.
+ */
+export function pickAskCandidate(agentComments) {
+  const candidates = (Array.isArray(agentComments) ? agentComments : [])
+    .map((b) => classifyAskCandidate(b))
+    .filter((c) => c.text != null);
+  for (const cls of USABLE_CANDIDATE_CLASSES) {
+    const hit = candidates.find((c) => c.class === cls);
+    if (hit) return hit;
+  }
+  return null;
+}
+
+/** The BODY TEXT of the best ask candidate (the residue, not the raw comment), or
+ *  null when no comment carries one. */
 export function pickAskComment(agentComments) {
-  const bodies = (Array.isArray(agentComments) ? agentComments : [])
-    .map((b) => nonEmptyString(b))
-    .filter(Boolean);
-  if (bodies.length === 0) return null;
-  return bodies.find((b) => !isEscalationNotice(b)) ?? bodies[0];
+  return pickAskCandidate(agentComments)?.text ?? null;
 }
 
 // ── the public entry point ───────────────────────────────────────────────────
@@ -371,25 +604,31 @@ export function pickAskComment(agentComments) {
  * Derive the ask summary for a parked ticket, walking the preference chain:
  *   structured `ask` → explanation fields → newest agent comment → null.
  *
- * `explanation` is the CTL-1110 six-field object (board-data.mjs::deriveExplanation)
- * optionally extended with an `ask` object. For the comment fallback, prefer
- * `agentComments` (a NEWEST-FIRST list, so notice-skipping can apply); the single
- * `lastAgentComment` remains accepted for callers that have only one body.
+ * `explanation` is the CTL-1110 escalation object passed VERBATIM (never through
+ * board-data.mjs::deriveExplanation, which projects only the six legacy string
+ * fields and would strip both `ask` and `options` — see
+ * inbox-conversation.mjs::deriveRichExplanation), optionally extended with an `ask`
+ * object. For the comment fallback, prefer `agentComments` (a NEWEST-FIRST list, so
+ * the ranked candidate pick can apply); the single `lastAgentComment` remains
+ * accepted for callers that have only one body.
  *
- * Returns null when NO source yields usable text — the pane then renders no ask
- * block at all (honest absence).
+ * Returns null when NO source yields usable text — including when every agent
+ * comment is a status note or a bare pointer. The pane then renders no ask block at
+ * all, which is honest; the alternative it replaced put "✅ recovery-pass unstuck
+ * this — now running" under the heading "What this needs from you".
  */
 export function deriveAsk({
   explanation = null,
   agentComments = null,
   lastAgentComment = null,
 } = {}) {
-  const commentBody =
-    (Array.isArray(agentComments) ? pickAskComment(agentComments) : null) ?? lastAgentComment;
+  const candidate =
+    (Array.isArray(agentComments) ? pickAskCandidate(agentComments) : null) ??
+    classifyAskCandidate(lastAgentComment);
   return (
     askFromStructured(explanation) ??
     askFromExplanation(explanation) ??
-    askFromComment(commentBody) ??
+    askFromCandidate(candidate) ??
     null
   );
 }

--- a/plugins/dev/scripts/orch-monitor/lib/inbox-ask.mjs
+++ b/plugins/dev/scripts/orch-monitor/lib/inbox-ask.mjs
@@ -288,10 +288,40 @@ const ESCALATION_NOTICE_PATTERNS = [
  *  the length floor keeps the filter from discarding real asks. */
 const NOTICE_MAX_CHARS = 400;
 
-/** Is this body a content-free escalation pointer? Exported for direct testing. */
+/**
+ * Markers of a PHASE STATUS REPORT — the per-phase bookkeeping the pipeline posts
+ * ("**Phase Implement** · Branch · Commits: 7 · Diff: 29 files changed").
+ *
+ * These are machine status posts, not questions. They are often the newest
+ * substantive agent comment, so without this filter they become the derived ask —
+ * and the classifier then reads their imperative bullets as an instruction,
+ * producing nonsense like `act-then-confirm: "Phase Implement — Commits: 7"`.
+ * Anchored to the leading phase header so ordinary prose that merely mentions a
+ * phase is unaffected.
+ */
+const PHASE_REPORT_PATTERNS = [
+  /^\s*\**\s*phase\s+(?:triage|research|plan|implement|verify|review|pr|monitor-merge|monitor-deploy|teardown)\b/i,
+  /^\s*\**\s*(?:plan|research|implement|verify|review)\s+phase\s+[—–-]/i,
+];
+
+/** Is this body a phase status report rather than an ask? Exported for testing. */
+export function isPhaseStatusReport(body) {
+  const s = nonEmptyString(body);
+  if (s == null) return false;
+  return matchesAny(s, PHASE_REPORT_PATTERNS);
+}
+
+/**
+ * Is this body unusable as an ask — either a content-free escalation pointer or a
+ * phase status report? Exported for direct testing.
+ *
+ * (Kept under the original name because it is the ask-candidate rejection test;
+ * the escalation pointer was simply the first kind of non-ask we found.)
+ */
 export function isEscalationNotice(body) {
   const s = nonEmptyString(body);
   if (s == null) return true; // an empty body carries no ask either
+  if (isPhaseStatusReport(s)) return true;
   if (s.length > NOTICE_MAX_CHARS) return false;
   return matchesAny(s, ESCALATION_NOTICE_PATTERNS);
 }

--- a/plugins/dev/scripts/orch-monitor/lib/inbox-ask.mjs
+++ b/plugins/dev/scripts/orch-monitor/lib/inbox-ask.mjs
@@ -205,6 +205,24 @@ export function askFromStructured(explanation) {
  * IS a decision, and their labels are legitimate reply chips (they came from the
  * producer, not from a guess). Otherwise the CTA/what-to-do text is classified.
  */
+/** Escalation types whose producer contract means the agent CANNOT do the work —
+ *  the human must perform it, so a written reply alone can never resolve them. */
+const ACTION_REQUIRED_ESCALATION_TYPES = new Set(["manual"]);
+
+/** A `manual` escalation is only trusted as action-required when the producer
+ *  actually filled the contract (a blocked capability / instructions), so a
+ *  legacy payload that merely DEFAULTED to "manual" still classifies normally. */
+export function isValidatedManualEscalation(expl) {
+  if (!expl || typeof expl !== "object") return false;
+  if (!ACTION_REQUIRED_ESCALATION_TYPES.has(expl.escalation_type)) return false;
+  for (const k of ["blocked_capability", "instructions", "remediation", "what_to_do"]) {
+    const v = expl[k];
+    if (typeof v === "string" && v.trim() !== "") return true;
+    if (Array.isArray(v) && v.length > 0) return true;
+  }
+  return false;
+}
+
 export function askFromExplanation(explanation) {
   if (!explanation || typeof explanation !== "object") return null;
 
@@ -262,6 +280,12 @@ const ESCALATION_TYPE_KINDS = { decision: "decide", authorization: "approve" };
  *  operator a bare "yes" is sufficient when it demonstrably is not. */
 function declaredKind(explanation, classified) {
   if (classified === "act-then-confirm") return classified;
+  // A VALIDATED `manual` escalation is action-required by contract: the producer
+  // says the agent could not do the work itself. Without this, a CTA like "Rotate
+  // the expired API credential." falls through to `clarify` and the pane promises
+  // that a written reply alone resolves it. Only validated payloads qualify, so a
+  // legacy signal that merely DEFAULTED to "manual" still classifies normally.
+  if (isValidatedManualEscalation(explanation)) return "act-then-confirm";
   const declared = ESCALATION_TYPE_KINDS[nonEmptyString(explanation?.escalation_type)?.toLowerCase()];
   return declared ?? classified;
 }
@@ -492,8 +516,11 @@ export function extractOperatorActionBlock(body) {
  * ticket whose real blocker was an older comment.
  */
 const PHASE_REPORT_PATTERNS = [
-  /^\s*\**\s*phase[\s-]+(?:triage|research|plan|implement|verify|review|pr|monitor-merge|monitor-deploy|teardown)\b/i,
-  /^\s*\**\s*(?:plan|research|implement|verify|review)[\s-]+phase\s*[—–-]/i,
+  // `remediate` included deliberately: phase-remediate posts `**Phase Remediate**`
+  // mirrors, and an unavailable field rendering as `?` made them classify as an ASK
+  // — putting pipeline bookkeeping under "What this needs from you".
+  /^\s*\**\s*phase[\s-]+(?:triage|research|plan|implement|verify|review|remediate|pr|monitor-merge|monitor-deploy|teardown)\b/i,
+  /^\s*\**\s*(?:plan|research|implement|verify|review|remediate)[\s-]+phase\s*[—–-]/i,
 ];
 
 /** Is this body a phase status report rather than an ask? Exported for testing. */

--- a/plugins/dev/scripts/orch-monitor/lib/inbox-conversation-compose.test.mjs
+++ b/plugins/dev/scripts/orch-monitor/lib/inbox-conversation-compose.test.mjs
@@ -364,7 +364,10 @@ describe("P2 — the legacy bot id must reach the READ path", () => {
 
 describe("P2 — an unusable explanation must not mask an older usable one", () => {
   it("recognizes what deriveAsk can actually consume", () => {
-    expect(isUsableExplanation({ ask: { summary: "x" } })).toBe(true);
+    // A structured ask needs a recognized KIND too — askFromStructured requires
+    // both, so summary-only must NOT stop the scan (see the round-3 tests below).
+    expect(isUsableExplanation({ ask: { kind: "approve", summary: "x" } })).toBe(true);
+    expect(isUsableExplanation({ ask: { summary: "x" } })).toBe(false);
     expect(isUsableExplanation({ options: [{ label: "a" }, { label: "b" }] })).toBe(true);
     expect(isUsableExplanation({ call_to_action: "do it" })).toBe(true);
     expect(isUsableExplanation({ what_to_do: "do it" })).toBe(true);
@@ -403,5 +406,25 @@ describe("P2 — an unusable explanation must not mask an older usable one", () 
     });
     expect(out.ask.source).toBe("explanation");
     expect(out.ask.kind).toBe("approve");
+  });
+});
+
+// ── Codex round-3 remediation ────────────────────────────────────────────────
+
+describe("round-3 P2 — isUsableExplanation must mirror askFromStructured", () => {
+  it("rejects a structured ask with a summary but no recognized kind", () => {
+    // askFromStructured requires BOTH, so declaring this usable lets it stop the
+    // scan and then produce nothing — the exact masking this predicate prevents.
+    expect(isUsableExplanation({ ask: { summary: "Waiting for input" } })).toBe(false);
+    expect(isUsableExplanation({ ask: { kind: "nonsense", summary: "x" } })).toBe(false);
+    expect(isUsableExplanation({ ask: { kind: "approve", summary: "Ship?" } })).toBe(true);
+  });
+
+  it("a partial structured ask no longer masks an older usable explanation", () => {
+    const expl = deriveRichExplanation([
+      { explanation: { call_to_action: "the real ask" } },
+      { explanation: { ask: { summary: "Waiting for input" } } },
+    ]);
+    expect(expl.call_to_action).toBe("the real ask");
   });
 });

--- a/plugins/dev/scripts/orch-monitor/lib/inbox-conversation-compose.test.mjs
+++ b/plugins/dev/scripts/orch-monitor/lib/inbox-conversation-compose.test.mjs
@@ -164,3 +164,144 @@ describe("readPhaseSignals", () => {
     expect(sigs.every((s) => s.status === "stalled")).toBe(true);
   });
 });
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Codex review remediation (PR #2801) — each test pins a finding that a real
+// installation would have hit.
+// ═══════════════════════════════════════════════════════════════════════════
+
+import {
+  catalystDir,
+  defaultWorkersDir,
+  deriveRichExplanation,
+  EXPLANATION_PHASES,
+} from "./inbox-conversation.mjs";
+import {
+  knownBotUserIds as botIds,
+  postBody,
+  resolveLinearToken,
+} from "./linear-comment.mjs";
+
+describe("P1 #4 — the structured ask must survive to the derivation", () => {
+  it("preserves `ask` and `options`, which board-data's projection discards", () => {
+    // deriveExplanation keeps only the six legacy strings, so routing the ask
+    // through it made the "structured" tier unreachable and killed option chips.
+    const expl = deriveRichExplanation([
+      { explanation: { ask: { kind: "approve", summary: "Ship it?" }, options: [{ label: "yes" }] } },
+    ]);
+    expect(expl.ask.kind).toBe("approve");
+    expect(expl.options).toHaveLength(1);
+  });
+
+  it("end-to-end: a structured ask now reaches getConversation as source=structured", async () => {
+    const out = await getConversation("PROJ-1", {
+      readThread: thread({ agentComments: ["a comment that must lose"] }),
+      readSignals: async () => [
+        {
+          explanation: {
+            ask: { kind: "decide", summary: "A or B?", suggested_replies: ["A", "B"] },
+          },
+        },
+      ],
+      config: null,
+    });
+    expect(out.ask.source).toBe("structured");
+    expect(out.ask.suggestedReplies).toEqual(["A", "B"]);
+  });
+
+  it("end-to-end: enumerated options become chips", async () => {
+    const out = await getConversation("PROJ-1", {
+      readThread: thread({ agentComments: [] }),
+      readSignals: async () => [
+        {
+          explanation: {
+            call_to_action: "Pick one.",
+            options: [{ label: "close" }, { label: "keep" }],
+          },
+        },
+      ],
+      config: null,
+    });
+    expect(out.ask.suggestedReplies).toEqual(["close", "keep"]);
+  });
+
+  it("takes the NEWEST explanation when several phases carry one", () => {
+    const expl = deriveRichExplanation([
+      { explanation: { call_to_action: "old" } },
+      { explanation: { call_to_action: "new" } },
+    ]);
+    expect(expl.call_to_action).toBe("new");
+  });
+});
+
+describe("P2 #7 — recovery-pass is where rich escalations are authored", () => {
+  it("scans the ancillary phases, not just PHASE_ORDER", () => {
+    expect(EXPLANATION_PHASES).toContain("recovery-pass");
+    expect(EXPLANATION_PHASES).toContain("remediate");
+    // Ancillary last, so the newest-first scan prefers them.
+    expect(EXPLANATION_PHASES.indexOf("recovery-pass")).toBeGreaterThan(
+      EXPLANATION_PHASES.indexOf("teardown"),
+    );
+  });
+});
+
+describe("P2 #17 — honor the configured Catalyst data directory", () => {
+  it("uses CATALYST_DIR rather than a hardcoded ~/catalyst", () => {
+    expect(catalystDir({ CATALYST_DIR: "/data/cat" })).toBe("/data/cat");
+    expect(defaultWorkersDir({ CATALYST_DIR: "/data/cat" })).toBe(
+      "/data/cat/execution-core/workers",
+    );
+  });
+  it("falls back to ~/catalyst when unset", () => {
+    expect(catalystDir({})).toContain("catalyst");
+  });
+});
+
+describe("P1 #2 — the reply credential must resolve on the launchd path", () => {
+  it("prefers the env token", () => {
+    expect(resolveLinearToken({ LINEAR_API_TOKEN: "env-tok" })).toBe("env-tok");
+  });
+
+  it("falls back to the Layer-2 personal token when the env carries none", () => {
+    // catalyst-monitor.sh exports NO Linear token, so without this fallback every
+    // inline reply on the normal persistent launch path returns `no_token`.
+    expect(
+      resolveLinearToken({}, { projectConfig: { linear: { apiToken: "lin_api_personal" } } }),
+    ).toBe("lin_api_personal");
+  });
+
+  it("NEVER falls back to the app-actor OAuth token in the same file", () => {
+    // Posting as the app is silently ignored by CTL-1567 — the inert failure.
+    const projectConfig = {
+      catalyst: { linear: { agent: { accessToken: "lin_oauth_app_actor" } } },
+    };
+    expect(resolveLinearToken({}, { projectConfig })).toBeNull();
+  });
+});
+
+describe("P2 #8 — the legacy per-repo botUserId form", () => {
+  it("reads catalyst.monitor.linear.botUserId as well as the global bot map", () => {
+    const ids = botIds({
+      config: { catalyst: { monitor: { linear: { botUserId: "legacy-id" } } } },
+    });
+    expect(ids.has("legacy-id")).toBe(true);
+  });
+  it("accepts it from the project config too", () => {
+    const ids = botIds({
+      projectConfig: { catalyst: { monitor: { linear: { botUserId: "proj-id" } } } },
+    });
+    expect(ids.has("proj-id")).toBe(true);
+  });
+});
+
+describe("P2 #15 — the operator's reply is posted verbatim", () => {
+  it("preserves leading indentation (an indented code block keeps its semantics)", () => {
+    expect(postBody("    const x = 1;\nplain")).toBe("    const x = 1;\nplain");
+  });
+  it("still strips trailing whitespace (invisible, never load-bearing)", () => {
+    expect(postBody("hello   \n\n")).toBe("hello");
+  });
+  it("returns empty string for a non-string", () => {
+    expect(postBody(null)).toBe("");
+  });
+});

--- a/plugins/dev/scripts/orch-monitor/lib/inbox-conversation-compose.test.mjs
+++ b/plugins/dev/scripts/orch-monitor/lib/inbox-conversation-compose.test.mjs
@@ -20,6 +20,10 @@ function thread({
   title = "T",
   agentComments = [],
   reason = null,
+  // Defaults to "the replica holds an issue row" unless a test says otherwise;
+  // `url` is an OPTIONAL deep link and is deliberately no longer the existence
+  // predicate (a real issue can have a null url mid-sync).
+  issueExists = url != null,
 } = {}) {
   return async () => ({
     ticket: "PROJ-1",
@@ -28,6 +32,8 @@ function thread({
     url,
     title,
     agentComments,
+    allAgentComments: agentComments,
+    issueExists,
     lastAgentComment: agentComments[0] ?? null,
     reason,
   });
@@ -121,11 +127,23 @@ describe("getConversation — the canReply gate (AC #10)", () => {
     expect(out.canReply).toBe(true);
   });
 
+  it("ALLOWS a reply when the issue EXISTS but its url is null (mid-sync)", async () => {
+    // `url` is optional; using it as the existence predicate hid the composer on
+    // tickets the POST path resolves fine by identifier.
+    const out = await getConversation("PROJ-1", {
+      readThread: thread({ available: true, url: null, issueExists: true }),
+      readSignals: noSignals,
+      config: null,
+      repoConfig: null,
+    });
+    expect(out.canReply).toBe(true);
+  });
+
   it("REFUSES a reply for a synthesized row with no Linear issue", async () => {
     // An orphan-PR card: the replica is readable and positively has no such issue,
     // so there is nothing to comment on → the UI shows no reply box.
     const out = await getConversation("ORPHAN-1", {
-      readThread: thread({ available: true, url: null }),
+      readThread: thread({ available: true, url: null, issueExists: false }),
       readSignals: noSignals,
       config: null,
     });
@@ -181,6 +199,7 @@ import {
   postBody,
   resolveLinearToken,
 } from "./linear-comment.mjs";
+import { configDir } from "./inbox-conversation.mjs";
 
 describe("P1 #4 — the structured ask must survive to the derivation", () => {
   it("preserves `ask` and `options`, which board-data's projection discards", () => {
@@ -426,5 +445,36 @@ describe("round-3 P2 — isUsableExplanation must mirror askFromStructured", () 
       { explanation: { ask: { summary: "Waiting for input" } } },
     ]);
     expect(expl.call_to_action).toBe("the real ask");
+  });
+});
+
+// ── Codex round-4 remediation ────────────────────────────────────────────────
+
+describe("round-4 — credential + config resolution", () => {
+  it("accepts BOTH Layer-2 token shapes", () => {
+    expect(resolveLinearToken({}, { projectConfig: { linear: { apiToken: "legacy" } } })).toBe("legacy");
+    expect(
+      resolveLinearToken({}, { projectConfig: { catalyst: { linear: { apiToken: "nested" } } } }),
+    ).toBe("nested");
+  });
+  it("still never falls back to the app-actor token", () => {
+    expect(
+      resolveLinearToken({}, {
+        projectConfig: { catalyst: { linear: { agent: { accessToken: "lin_oauth_app" } } } },
+      }),
+    ).toBeNull();
+  });
+  it("honors CATALYST_CONFIG_DIR for the secrets directory", () => {
+    expect(configDir({ CATALYST_CONFIG_DIR: "/custom" })).toBe("/custom");
+    expect(configDir({})).toContain(".config");
+  });
+});
+
+describe("round-4 — options must survive downstream normalization", () => {
+  it("rejects option shapes that normalize to fewer than two labels", () => {
+    expect(isUsableExplanation({ options: [{}, {}] })).toBe(false);
+    expect(isUsableExplanation({ options: ["A", "a"] })).toBe(false); // dedup → 1
+    expect(isUsableExplanation({ options: [{ label: "A" }] })).toBe(false);
+    expect(isUsableExplanation({ options: [{ label: "A" }, { label: "B" }] })).toBe(true);
   });
 });

--- a/plugins/dev/scripts/orch-monitor/lib/inbox-conversation-compose.test.mjs
+++ b/plugins/dev/scripts/orch-monitor/lib/inbox-conversation-compose.test.mjs
@@ -1,0 +1,166 @@
+// inbox-conversation-compose.test.mjs — CTL-1569: the COMPOSITION layer.
+//
+// The pure ask/thread/comment modules are covered in inbox-conversation.test.mjs.
+// This file covers `getConversation` — the assembly, the source-preference wiring,
+// and specifically the `canReply` gate, which is acceptance criterion #10 ("rows
+// with no underlying ticket show no reply affordance"). All collaborators are
+// injected: no replica, no worker dir, no config on disk.
+//
+// Fixtures use the PROJ prefix per AGENTS.md → Version Control.
+
+import { describe, expect, it } from "bun:test";
+
+import { getConversation, readPhaseSignals } from "./inbox-conversation.mjs";
+
+/** A readThread double with the shape the real reader returns. */
+function thread({
+  available = true,
+  comments = [],
+  url = "https://linear.app/x/PROJ-1",
+  title = "T",
+  agentComments = [],
+  reason = null,
+} = {}) {
+  return async () => ({
+    ticket: "PROJ-1",
+    available,
+    comments,
+    url,
+    title,
+    agentComments,
+    lastAgentComment: agentComments[0] ?? null,
+    reason,
+  });
+}
+
+const noSignals = async () => [];
+
+describe("getConversation — assembly", () => {
+  it("passes the thread, url and title straight through", async () => {
+    const out = await getConversation("PROJ-1", {
+      readThread: thread({ comments: [{ id: "c1", body: "hi", isAgent: true }] }),
+      readSignals: noSignals,
+      config: null,
+    });
+    expect(out.ticket).toBe("PROJ-1");
+    expect(out.url).toBe("https://linear.app/x/PROJ-1");
+    expect(out.title).toBe("T");
+    expect(out.thread.comments).toHaveLength(1);
+    expect(out.thread.available).toBe(true);
+  });
+
+  it("prefers the phase-signal explanation over the comment fallback", async () => {
+    const out = await getConversation("PROJ-1", {
+      readThread: thread({ agentComments: ["a comment that should lose"] }),
+      readSignals: async () => [
+        { status: "stalled", explanation: { call_to_action: "the explanation wins" } },
+      ],
+      config: null,
+    });
+    expect(out.ask.summary).toBe("the explanation wins");
+    expect(out.ask.source).toBe("explanation");
+  });
+
+  it("falls back to the agent comment when there is no worker dir", async () => {
+    // The common parked case: no signals on disk at all.
+    const out = await getConversation("PROJ-1", {
+      readThread: thread({ agentComments: ["Approve the rollout?"] }),
+      readSignals: noSignals,
+      config: null,
+    });
+    expect(out.ask.source).toBe("comment");
+    expect(out.ask.kind).toBe("approve");
+  });
+
+  it("reports a null ask when no source yields anything (renders absent)", async () => {
+    const out = await getConversation("PROJ-1", {
+      readThread: thread({ agentComments: [] }),
+      readSignals: noSignals,
+      config: null,
+    });
+    expect(out.ask).toBeNull();
+  });
+
+  it("survives a signal read that throws", async () => {
+    const out = await getConversation("PROJ-1", {
+      readThread: thread({ agentComments: ["Approve?"] }),
+      readSignals: async () => {
+        throw new Error("unreadable worker dir");
+      },
+      config: null,
+    });
+    expect(out.ask.source).toBe("comment"); // degraded to the fallback, no throw
+  });
+
+  it("threads configured app-actor ids into the thread read", async () => {
+    // The agent/human split depends on these — a Catalyst app actor reports
+    // is_bot=0, so without the ids every agent comment reads as the operator's.
+    let sawIds = null;
+    await getConversation("PROJ-1", {
+      readThread: async (_t, opts) => {
+        sawIds = opts.botUserIds;
+        return (await thread()());
+      },
+      readSignals: noSignals,
+      config: {
+        catalyst: { linear: { bot: { worker: { botUserId: "bot-uuid" } } } },
+      },
+    });
+    expect(sawIds.has("bot-uuid")).toBe(true);
+  });
+});
+
+// ── acceptance criterion #10: no reply affordance without a ticket ────────────
+describe("getConversation — the canReply gate (AC #10)", () => {
+  it("allows a reply when the replica resolved the issue", async () => {
+    const out = await getConversation("PROJ-1", {
+      readThread: thread({ available: true, url: "https://linear.app/x/PROJ-1" }),
+      readSignals: noSignals,
+      config: null,
+    });
+    expect(out.canReply).toBe(true);
+  });
+
+  it("REFUSES a reply for a synthesized row with no Linear issue", async () => {
+    // An orphan-PR card: the replica is readable and positively has no such issue,
+    // so there is nothing to comment on → the UI shows no reply box.
+    const out = await getConversation("ORPHAN-1", {
+      readThread: thread({ available: true, url: null }),
+      readSignals: noSignals,
+      config: null,
+    });
+    expect(out.canReply).toBe(false);
+  });
+
+  it("ALLOWS a reply when the replica is unreadable (absence ≠ evidence)", async () => {
+    // An unreadable local mirror is not proof the ticket doesn't exist. Refusing
+    // here would block the operator from answering a genuinely parked ticket
+    // because a cache was locked; the server-side post still 404s honestly.
+    const out = await getConversation("PROJ-1", {
+      readThread: thread({ available: false, url: null, reason: "replica-absent" }),
+      readSignals: noSignals,
+      config: null,
+    });
+    expect(out.canReply).toBe(true);
+    expect(out.thread.available).toBe(false);
+    expect(out.thread.reason).toBe("replica-absent");
+  });
+});
+
+describe("readPhaseSignals", () => {
+  it("returns [] when the worker dir is absent (the common parked case)", async () => {
+    const sigs = await readPhaseSignals("PROJ-1", {
+      workersDir: "/nonexistent/path/for/test",
+    });
+    expect(sigs).toEqual([]);
+  });
+
+  it("skips corrupt signal files instead of throwing", async () => {
+    const sigs = await readPhaseSignals("PROJ-1", {
+      read: async (p) => (String(p).includes("implement") ? "{not json" : '{"status":"stalled"}'),
+    });
+    // Every readable phase parsed; the corrupt one dropped.
+    expect(sigs.length).toBeGreaterThan(0);
+    expect(sigs.every((s) => s.status === "stalled")).toBe(true);
+  });
+});

--- a/plugins/dev/scripts/orch-monitor/lib/inbox-conversation-compose.test.mjs
+++ b/plugins/dev/scripts/orch-monitor/lib/inbox-conversation-compose.test.mjs
@@ -305,3 +305,103 @@ describe("P2 #15 — the operator's reply is posted verbatim", () => {
     expect(postBody(null)).toBe("");
   });
 });
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Codex RE-review remediation — four of the previous fixes were incomplete.
+// ═══════════════════════════════════════════════════════════════════════════
+
+import { isUsableExplanation, loadProjectConfig, loadRepoConfig } from "./inbox-conversation.mjs";
+
+describe("P1 — loadProjectConfig must not depend on process.cwd()", () => {
+  it("resolves the project key from an EXPLICIT Layer-1 path", async () => {
+    // launchd sets neither a working directory nor CATALYST_PROJECT_KEY, so a
+    // cwd-relative lookup misses and the reply stays inert on that path.
+    let asked = null;
+    const cfg = await loadProjectConfig({
+      projectKey: "myproj",
+      env: {},
+    });
+    // With no such Layer-2 file the loader fails open rather than throwing.
+    expect(cfg).toBeNull();
+    expect(asked).toBeNull();
+  });
+
+  it("prefers an explicit projectKey over the environment", async () => {
+    // Just asserting it does not throw and fails open — the file won't exist.
+    await expect(
+      loadProjectConfig({ projectKey: "__none__", env: { CATALYST_PROJECT_KEY: "other" } }),
+    ).resolves.toBeNull();
+  });
+
+  it("fails open when the Layer-1 path is unreadable", async () => {
+    await expect(
+      loadProjectConfig({ repoConfigPath: "/nonexistent/.catalyst/config.json", env: {} }),
+    ).resolves.toBeNull();
+  });
+});
+
+describe("P2 — the legacy bot id must reach the READ path", () => {
+  it("loadRepoConfig fails open on a missing Layer-1 file", async () => {
+    await expect(loadRepoConfig({ path: "/nonexistent/config.json" })).resolves.toBeNull();
+  });
+
+  it("getConversation feeds the Layer-1 legacy botUserId into the thread read", async () => {
+    // Previously only the GLOBAL config was passed, so a legacy installation
+    // classified every Catalyst app comment as human and lost the derived ask.
+    let sawIds = null;
+    await getConversation("PROJ-1", {
+      readThread: async (_t, opts) => {
+        sawIds = opts.botUserIds;
+        return await thread()();
+      },
+      readSignals: noSignals,
+      config: null,
+      repoConfig: { catalyst: { monitor: { linear: { botUserId: "legacy-uuid" } } } },
+    });
+    expect(sawIds.has("legacy-uuid")).toBe(true);
+  });
+});
+
+describe("P2 — an unusable explanation must not mask an older usable one", () => {
+  it("recognizes what deriveAsk can actually consume", () => {
+    expect(isUsableExplanation({ ask: { summary: "x" } })).toBe(true);
+    expect(isUsableExplanation({ options: [{ label: "a" }, { label: "b" }] })).toBe(true);
+    expect(isUsableExplanation({ call_to_action: "do it" })).toBe(true);
+    expect(isUsableExplanation({ what_to_do: "do it" })).toBe(true);
+    // Legacy/partial shapes deriveAsk cannot use:
+    expect(isUsableExplanation({ human_question: "?", problem: "p" })).toBe(false);
+    expect(isUsableExplanation({ options: [{ label: "only-one" }] })).toBe(false);
+    expect(isUsableExplanation({})).toBe(false);
+    expect(isUsableExplanation(null)).toBe(false);
+  });
+
+  it("keeps scanning past a newer partial signal to an older usable one", () => {
+    const expl = deriveRichExplanation([
+      { explanation: { call_to_action: "the real ask" } }, // older
+      { explanation: { problem: "only a problem field" } }, // newer, unusable
+    ]);
+    expect(expl.call_to_action).toBe("the real ask");
+  });
+
+  it("still returns the newest shaped explanation when NONE is usable", () => {
+    const expl = deriveRichExplanation([
+      { explanation: { problem: "old" } },
+      { explanation: { problem: "new" } },
+    ]);
+    expect(expl.problem).toBe("new");
+  });
+
+  it("end-to-end: a newer partial signal no longer suppresses the ask", async () => {
+    const out = await getConversation("PROJ-1", {
+      readThread: thread({ agentComments: [] }),
+      readSignals: async () => [
+        { explanation: { call_to_action: "Approve the rollout?" } },
+        { explanation: { what_failed: "something" } },
+      ],
+      config: null,
+      repoConfig: null,
+    });
+    expect(out.ask.source).toBe("explanation");
+    expect(out.ask.kind).toBe("approve");
+  });
+});

--- a/plugins/dev/scripts/orch-monitor/lib/inbox-conversation.d.mts
+++ b/plugins/dev/scripts/orch-monitor/lib/inbox-conversation.d.mts
@@ -28,7 +28,10 @@ export interface Conversation {
 }
 
 /** The global config carrying the app-actor `botUserId`s. Fails open to null. */
-export function loadGlobalConfig(opts?: { path?: string }): Promise<unknown>;
+export function loadGlobalConfig(opts?: {
+  path?: string | null;
+  env?: Record<string, string | undefined>;
+}): Promise<unknown>;
 
 /** The Layer-2 project secrets file, carrying the operator's personal
  *  `linear.apiToken` — the only Linear credential on the launchd path. Fails open. */
@@ -37,6 +40,9 @@ export function loadProjectConfig(opts?: {
   repoConfigPath?: string | null;
   env?: Record<string, string | undefined>;
 }): Promise<unknown>;
+
+/** The configured secrets directory, honoring CATALYST_CONFIG_DIR. */
+export function configDir(env?: Record<string, string | undefined>): string;
 
 /** The Layer-1 repo config (`.catalyst/config.json`). Fails open to null. */
 export function loadRepoConfig(opts?: { path?: string | null }): Promise<unknown>;

--- a/plugins/dev/scripts/orch-monitor/lib/inbox-conversation.d.mts
+++ b/plugins/dev/scripts/orch-monitor/lib/inbox-conversation.d.mts
@@ -1,0 +1,58 @@
+// Type declarations for inbox-conversation.mjs (CTL-1569) — the composition layer
+// behind the inbox conversation surface. Lets the strict TS server import it without
+// a TS7016 implicit-any error. Keep in sync with inbox-conversation.mjs.
+
+import type { InboxAsk } from "./inbox-ask.d.mts";
+import type { ThreadComment, TicketThread } from "./linear-thread.d.mts";
+
+/** The single payload the GET /api/ticket/<t>/thread route serves. */
+export interface Conversation {
+  ticket: string;
+  /** Deep link to the Linear ticket (§3); null when the issue did not resolve. */
+  url: string | null;
+  title: string | null;
+  thread: {
+    /** false = the replica could not be READ. Distinct from an empty thread, so
+     *  the UI can stay silent rather than claiming "no comments". */
+    available: boolean;
+    /** NEWEST FIRST (§2). */
+    comments: ThreadComment[];
+    reason: string | null;
+  };
+  ask: InboxAsk | null;
+  /** false ONLY when a READABLE replica positively has no such issue — i.e. a
+   *  synthesized row with nothing to reply to (§4 / orphan-PR rows). An UNREADABLE
+   *  replica is not evidence of absence, so it stays true and the server-side post
+   *  404s honestly if the issue really is gone. */
+  canReply: boolean;
+}
+
+/** The global config carrying the app-actor `botUserId`s. Fails open to null. */
+export function loadGlobalConfig(opts?: { path?: string }): Promise<unknown>;
+
+/** The ticket's phase signals in canonical order. A missing worker dir yields []
+ *  — the common parked case, not an error. */
+export function readPhaseSignals(
+  ticket: string,
+  opts?: {
+    workersDir?: string;
+    read?: (path: string, encoding: "utf8") => Promise<string>;
+  },
+): Promise<Record<string, unknown>[]>;
+
+export function getConversation(
+  ticket: string,
+  opts?: {
+    limit?: number;
+    readThread?: (
+      ticket: string,
+      opts: { limit: number; botUserIds: ReadonlySet<string> },
+    ) => Promise<TicketThread>;
+    readSignals?: (
+      ticket: string,
+      opts: { workersDir: string },
+    ) => Promise<Record<string, unknown>[]>;
+    workersDir?: string;
+    config?: unknown;
+  },
+): Promise<Conversation>;

--- a/plugins/dev/scripts/orch-monitor/lib/inbox-conversation.d.mts
+++ b/plugins/dev/scripts/orch-monitor/lib/inbox-conversation.d.mts
@@ -38,6 +38,12 @@ export function loadProjectConfig(opts?: {
   env?: Record<string, string | undefined>;
 }): Promise<unknown>;
 
+/** The Layer-1 repo config (`.catalyst/config.json`). Fails open to null. */
+export function loadRepoConfig(opts?: { path?: string | null }): Promise<unknown>;
+
+/** Can this explanation produce an ask deriveAsk can actually use? */
+export function isUsableExplanation(expl: unknown): boolean;
+
 /** The Catalyst data root, honoring CATALYST_DIR. */
 export function catalystDir(env?: Record<string, string | undefined>): string;
 export function defaultWorkersDir(env?: Record<string, string | undefined>): string;
@@ -78,5 +84,11 @@ export function getConversation(
     workersDir?: string | null;
     env?: Record<string, string | undefined>;
     config?: unknown;
+    /** Layer-1 repo config — carries the LEGACY `catalyst.monitor.linear.botUserId`
+     *  the read path needs for a correct agent/human split. */
+    repoConfig?: unknown;
+    /** Explicit Layer-1 config path (server-resolved). Never rely on process.cwd():
+     *  the launchd wrapper sets no working directory. */
+    repoConfigPath?: string | null;
   },
 ): Promise<Conversation>;

--- a/plugins/dev/scripts/orch-monitor/lib/inbox-conversation.d.mts
+++ b/plugins/dev/scripts/orch-monitor/lib/inbox-conversation.d.mts
@@ -30,13 +30,36 @@ export interface Conversation {
 /** The global config carrying the app-actor `botUserId`s. Fails open to null. */
 export function loadGlobalConfig(opts?: { path?: string }): Promise<unknown>;
 
+/** The Layer-2 project secrets file, carrying the operator's personal
+ *  `linear.apiToken` — the only Linear credential on the launchd path. Fails open. */
+export function loadProjectConfig(opts?: {
+  projectKey?: string | null;
+  repoConfigPath?: string | null;
+  env?: Record<string, string | undefined>;
+}): Promise<unknown>;
+
+/** The Catalyst data root, honoring CATALYST_DIR. */
+export function catalystDir(env?: Record<string, string | undefined>): string;
+export function defaultWorkersDir(env?: Record<string, string | undefined>): string;
+
+/** Phases whose signals may carry an escalation explanation — PHASE_ORDER plus the
+ *  ancillary `remediate`/`recovery-pass` (where rich escalations are authored). */
+export const EXPLANATION_PHASES: readonly string[];
+
+/** The newest explanation object, VERBATIM — preserving `ask` and `options`, which
+ *  board-data's projecting deriveExplanation discards. */
+export function deriveRichExplanation(
+  phaseSigs: Record<string, unknown>[],
+): Record<string, unknown> | null;
+
 /** The ticket's phase signals in canonical order. A missing worker dir yields []
  *  — the common parked case, not an error. */
 export function readPhaseSignals(
   ticket: string,
   opts?: {
-    workersDir?: string;
+    workersDir?: string | null;
     read?: (path: string, encoding: "utf8") => Promise<string>;
+    env?: Record<string, string | undefined>;
   },
 ): Promise<Record<string, unknown>[]>;
 
@@ -50,9 +73,10 @@ export function getConversation(
     ) => Promise<TicketThread>;
     readSignals?: (
       ticket: string,
-      opts: { workersDir: string },
+      opts: { workersDir: string | null; env?: Record<string, string | undefined> },
     ) => Promise<Record<string, unknown>[]>;
-    workersDir?: string;
+    workersDir?: string | null;
+    env?: Record<string, string | undefined>;
     config?: unknown;
   },
 ): Promise<Conversation>;

--- a/plugins/dev/scripts/orch-monitor/lib/inbox-conversation.mjs
+++ b/plugins/dev/scripts/orch-monitor/lib/inbox-conversation.mjs
@@ -1,0 +1,123 @@
+// inbox-conversation.mjs — the composition layer behind the inbox conversation
+// surface (CTL-1569). The routes stay thin: this module assembles ONE payload from
+// the three sources and owns the "can the operator reply here at all?" question.
+//
+// Sources, and why each:
+//   • the REPLICA thread          (linear-thread.mjs)  — the comments, newest-first,
+//                                                       zero Linear API calls.
+//   • the phase-signal EXPLANATION (board-data.mjs)    — the producer's structured
+//                                                       escalation fields, the
+//                                                       preferred ask source.
+//   • the newest AGENT comment     (from the thread)    — the ask FALLBACK, so
+//                                                       tickets parked before any
+//                                                       producer change still render.
+//
+// The ask derivation itself is pure (inbox-ask.mjs); this module only feeds it.
+//
+// REPLY ELIGIBILITY (§4's "rows with no underlying ticket show no reply
+// affordance"): orphan-PR rows are SYNTHESIZED by the board with no Linear issue
+// behind them, so there is nothing to comment on. The signal we use is the replica
+// itself — an issue row resolves (giving us a `url`) or it does not. When the
+// replica is UNAVAILABLE we deliberately allow the reply anyway: an unreadable
+// local mirror is not evidence that the ticket does not exist, and refusing to let
+// the operator answer a genuinely parked ticket because a local cache is locked
+// would be the worse failure. The server-side post still 404s honestly if the
+// issue truly is absent, so the optimistic direction is safe.
+
+import { readFile } from "node:fs/promises";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+import { PHASE_ORDER, deriveExplanation } from "./board-data.mjs";
+import { deriveAsk } from "./inbox-ask.mjs";
+import { knownBotUserIds } from "./linear-comment.mjs";
+import { DEFAULT_THREAD_LIMIT, readTicketThread } from "./linear-thread.mjs";
+
+const HOME = homedir();
+const DEFAULT_WORKERS_DIR = join(HOME, "catalyst", "execution-core", "workers");
+
+/** The global config that carries the app-actor `botUserId`s the authorship gate
+ *  cross-checks. Read lazily per call and fail-open to null — the gate's primary
+ *  defense is the `viewer` shape check, which needs no config. */
+export async function loadGlobalConfig({
+  path = join(HOME, ".config", "catalyst", "config.json"),
+} = {}) {
+  try {
+    return JSON.parse(await readFile(path, "utf8"));
+  } catch {
+    return null;
+  }
+}
+
+/** Read the ticket's phase signals in canonical order (oldest→newest), so
+ *  deriveExplanation's newest-first scan finds the most recent escalation. A
+ *  missing worker dir yields [] — the common parked case, not an error. */
+export async function readPhaseSignals(
+  ticket,
+  { workersDir = DEFAULT_WORKERS_DIR, read = readFile } = {},
+) {
+  const sigs = await Promise.all(
+    PHASE_ORDER.map(async (phase) => {
+      try {
+        return JSON.parse(await read(join(workersDir, ticket, `phase-${phase}.json`), "utf8"));
+      } catch {
+        return null; // absent / unreadable / corrupt → simply not a source
+      }
+    }),
+  );
+  return sigs.filter((s) => s && typeof s === "object");
+}
+
+/**
+ * Assemble the full conversation payload for one ticket.
+ *
+ * Returns (never throws):
+ *   {
+ *     ticket,
+ *     url,            // deep link to the Linear ticket (§3); null when unresolved
+ *     title,
+ *     thread: { available, comments[], reason },
+ *     ask,            // { kind, summary, suggestedReplies[], canResolveByReply, source } | null
+ *     canReply,       // false ONLY when the replica positively has no such issue
+ *   }
+ */
+export async function getConversation(
+  ticket,
+  {
+    limit = DEFAULT_THREAD_LIMIT,
+    readThread = readTicketThread,
+    readSignals = readPhaseSignals,
+    workersDir = DEFAULT_WORKERS_DIR,
+    /** Pre-loaded global config; when omitted it is read here. Carries the
+     *  app-actor ids that make the agent/human split correct (a Catalyst app
+     *  actor's comments have is_bot=0 — see linear-thread.mjs::normalizeComment). */
+    config = undefined,
+  } = {},
+) {
+  const cfg = config === undefined ? await loadGlobalConfig() : config;
+  const botUserIds = knownBotUserIds({ config: cfg });
+  const [thread, phaseSigs] = await Promise.all([
+    readThread(ticket, { limit, botUserIds }),
+    readSignals(ticket, { workersDir }).catch(() => []),
+  ]);
+
+  const explanation = deriveExplanation(phaseSigs);
+  const ask = deriveAsk({ explanation, agentComments: thread.agentComments });
+
+  // No issue row in a READABLE replica → a synthesized row with nothing to reply
+  // to. An UNREADABLE replica is not evidence of absence (see the header note).
+  const canReply = thread.available ? thread.url != null : true;
+
+  return {
+    ticket,
+    url: thread.url,
+    title: thread.title,
+    thread: {
+      available: thread.available,
+      comments: thread.comments,
+      reason: thread.reason,
+    },
+    ask,
+    canReply,
+  };
+}

--- a/plugins/dev/scripts/orch-monitor/lib/inbox-conversation.mjs
+++ b/plugins/dev/scripts/orch-monitor/lib/inbox-conversation.mjs
@@ -29,7 +29,7 @@ import { homedir } from "node:os";
 import { join } from "node:path";
 
 import { ANCILLARY_EXPLANATION_PHASES, PHASE_ORDER } from "./board-data.mjs";
-import { deriveAsk } from "./inbox-ask.mjs";
+import { askFromStructured, deriveAsk } from "./inbox-ask.mjs";
 import { knownBotUserIds } from "./linear-comment.mjs";
 import { DEFAULT_THREAD_LIMIT, readTicketThread } from "./linear-thread.mjs";
 
@@ -96,10 +96,12 @@ export function deriveRichExplanation(phaseSigs) {
  *  a structured `ask`, enumerated `options`, or the CTA / what-to-do prose. */
 export function isUsableExplanation(expl) {
   if (!expl || typeof expl !== "object") return false;
+  // Mirror askFromStructured EXACTLY: it requires a recognized `kind` AND a
+  // summary, so accepting `{ ask: { summary } }` here declares an explanation
+  // usable that then produces nothing — reproducing the very masking regression
+  // this predicate exists to prevent.
   const ask = expl.ask;
-  if (ask && typeof ask === "object" && typeof ask.summary === "string" && ask.summary.trim() !== "") {
-    return true;
-  }
+  if (ask && typeof ask === "object" && askFromStructured({ ask }) != null) return true;
   if (Array.isArray(expl.options) && expl.options.length >= 2) return true;
   for (const k of ["call_to_action", "what_to_do"]) {
     if (typeof expl[k] === "string" && expl[k].trim() !== "") return true;

--- a/plugins/dev/scripts/orch-monitor/lib/inbox-conversation.mjs
+++ b/plugins/dev/scripts/orch-monitor/lib/inbox-conversation.mjs
@@ -74,13 +74,37 @@ export const EXPLANATION_PHASES = [...PHASE_ORDER, ...ANCILLARY_EXPLANATION_PHAS
  * never render. This returns the explanation object VERBATIM instead.
  */
 export function deriveRichExplanation(phaseSigs) {
+  let firstShaped = null;
   for (let i = phaseSigs.length - 1; i >= 0; i--) {
     const sig = phaseSigs[i];
     if (!sig || typeof sig !== "object") continue;
     const expl = sig.explanation;
-    if (expl && typeof expl === "object") return expl;
+    if (!expl || typeof expl !== "object") continue;
+    if (firstShaped === null) firstShaped = expl;
+    // Keep scanning past an explanation that carries nothing deriveAsk can use.
+    // A newer legacy/partial signal (only `human_question`, `what_failed`, …)
+    // would otherwise MASK an older one holding a real `ask` / `call_to_action`,
+    // dropping the pane to comment inference or to no ask at all.
+    if (isUsableExplanation(expl)) return expl;
   }
-  return null;
+  // Nothing usable anywhere → return the newest shaped one so any passthrough
+  // consumer still sees what the producer wrote (deriveAsk will yield null).
+  return firstShaped;
+}
+
+/** Can this explanation actually produce an ask? Mirrors what inbox-ask.mjs reads:
+ *  a structured `ask`, enumerated `options`, or the CTA / what-to-do prose. */
+export function isUsableExplanation(expl) {
+  if (!expl || typeof expl !== "object") return false;
+  const ask = expl.ask;
+  if (ask && typeof ask === "object" && typeof ask.summary === "string" && ask.summary.trim() !== "") {
+    return true;
+  }
+  if (Array.isArray(expl.options) && expl.options.length >= 2) return true;
+  for (const k of ["call_to_action", "what_to_do"]) {
+    if (typeof expl[k] === "string" && expl[k].trim() !== "") return true;
+  }
+  return false;
 }
 
 /** The global config that carries the app-actor `botUserId`s the authorship gate
@@ -109,6 +133,12 @@ export async function loadProjectConfig({
   env = process.env,
 } = {}) {
   try {
+    // `repoConfigPath` MUST be supplied by the server (it already resolves the
+    // Layer-1 path via --config / CATALYST_CONFIG_PATH). Falling back to
+    // `process.cwd()` is not viable on the persistent launch path: the committed
+    // launchd wrapper sets neither a working directory nor CATALYST_PROJECT_KEY, so
+    // a cwd-relative lookup misses and every reply returns `no_token` — the very
+    // inertness this fallback exists to prevent.
     let key = projectKey ?? env.CATALYST_PROJECT_KEY ?? null;
     if (key == null) {
       const p = repoConfigPath ?? join(process.cwd(), ".catalyst", "config.json");
@@ -118,6 +148,22 @@ export async function loadProjectConfig({
     if (typeof key !== "string" || key === "") return null;
     const path = join(HOME, ".config", "catalyst", `config-${key}.json`);
     return JSON.parse(await readFile(path, "utf8"));
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * The Layer-1 repo config (`.catalyst/config.json`). The legacy app-actor id lives
+ * here as `catalyst.monitor.linear.botUserId`, and the GET /thread path needs it:
+ * without it, a legacy installation classifies every Catalyst app comment as HUMAN
+ * (they carry is_bot=0), which empties `agentComments` and kills the derived ask.
+ * Fail-open to null.
+ */
+export async function loadRepoConfig({ path = null } = {}) {
+  try {
+    const p = path ?? join(process.cwd(), ".catalyst", "config.json");
+    return JSON.parse(await readFile(p, "utf8"));
   } catch {
     return null;
   }
@@ -168,10 +214,17 @@ export async function getConversation(
      *  app-actor ids that make the agent/human split correct (a Catalyst app
      *  actor's comments have is_bot=0 — see linear-thread.mjs::normalizeComment). */
     config = undefined,
+    /** Layer-1 repo config — carries the LEGACY `catalyst.monitor.linear.botUserId`
+     *  that the read path also needs for a correct agent/human split. */
+    repoConfig = undefined,
+    repoConfigPath = null,
   } = {},
 ) {
-  const cfg = config === undefined ? await loadGlobalConfig() : config;
-  const botUserIds = knownBotUserIds({ config: cfg });
+  const [cfg, repoCfg] = await Promise.all([
+    config === undefined ? loadGlobalConfig() : Promise.resolve(config),
+    repoConfig === undefined ? loadRepoConfig({ path: repoConfigPath }) : Promise.resolve(repoConfig),
+  ]);
+  const botUserIds = knownBotUserIds({ config: cfg, projectConfig: repoCfg });
   const [thread, phaseSigs] = await Promise.all([
     readThread(ticket, { limit, botUserIds }),
     readSignals(ticket, { workersDir, env }).catch(() => []),

--- a/plugins/dev/scripts/orch-monitor/lib/inbox-conversation.mjs
+++ b/plugins/dev/scripts/orch-monitor/lib/inbox-conversation.mjs
@@ -29,7 +29,7 @@ import { homedir } from "node:os";
 import { join } from "node:path";
 
 import { ANCILLARY_EXPLANATION_PHASES, PHASE_ORDER } from "./board-data.mjs";
-import { askFromStructured, deriveAsk } from "./inbox-ask.mjs";
+import { askFromExplanation, askFromStructured, deriveAsk } from "./inbox-ask.mjs";
 import { knownBotUserIds } from "./linear-comment.mjs";
 import { DEFAULT_THREAD_LIMIT, readTicketThread } from "./linear-thread.mjs";
 
@@ -102,7 +102,15 @@ export function isUsableExplanation(expl) {
   // this predicate exists to prevent.
   const ask = expl.ask;
   if (ask && typeof ask === "object" && askFromStructured({ ask }) != null) return true;
-  if (Array.isArray(expl.options) && expl.options.length >= 2) return true;
+  // Run the DOWNSTREAM check, not a shape check: askFromExplanation normalizes and
+  // de-duplicates option labels and needs two VALID ones, so `[{}, {}]` or
+  // `["A","a"]` would pass a naive length test, stop the scan, and then produce no
+  // ask — masking an older valid explanation all over again.
+  // NOTE: pass ONLY the options. Injecting a call_to_action here would make the
+  // CTA branch succeed for ANY input and defeat the whole check.
+  if (Array.isArray(expl.options) && askFromExplanation({ options: expl.options }) != null) {
+    return true;
+  }
   for (const k of ["call_to_action", "what_to_do"]) {
     if (typeof expl[k] === "string" && expl[k].trim() !== "") return true;
   }
@@ -112,11 +120,18 @@ export function isUsableExplanation(expl) {
 /** The global config that carries the app-actor `botUserId`s the authorship gate
  *  cross-checks. Read lazily per call and fail-open to null — the gate's primary
  *  defense is the `viewer` shape check, which needs no config. */
-export async function loadGlobalConfig({
-  path = join(HOME, ".config", "catalyst", "config.json"),
-} = {}) {
+/** The configured secrets directory. `server.ts` already honors CATALYST_CONFIG_DIR
+ *  for OTel and webhook secrets; constructing a second hardcoded `~/.config/catalyst`
+ *  here made the reply route miss `config-<projectKey>.json` on such an install, so
+ *  every reply returned `no_token` while the credential sat in the configured dir. */
+export function configDir(env = process.env) {
+  return env.CATALYST_CONFIG_DIR || join(HOME, ".config", "catalyst");
+}
+
+export async function loadGlobalConfig({ path = null, env = process.env } = {}) {
+  const resolved = path ?? join(configDir(env), "config.json");
   try {
-    return JSON.parse(await readFile(path, "utf8"));
+    return JSON.parse(await readFile(resolved, "utf8"));
   } catch {
     return null;
   }
@@ -148,7 +163,7 @@ export async function loadProjectConfig({
       key = repo?.catalyst?.projectKey ?? repo?.projectKey ?? null;
     }
     if (typeof key !== "string" || key === "") return null;
-    const path = join(HOME, ".config", "catalyst", `config-${key}.json`);
+    const path = join(configDir(env), `config-${key}.json`);
     return JSON.parse(await readFile(path, "utf8"));
   } catch {
     return null;
@@ -235,9 +250,13 @@ export async function getConversation(
   const explanation = deriveRichExplanation(phaseSigs);
   const ask = deriveAsk({ explanation, agentComments: thread.agentComments });
 
-  // No issue row in a READABLE replica → a synthesized row with nothing to reply
-  // to. An UNREADABLE replica is not evidence of absence (see the header note).
-  const canReply = thread.available ? thread.url != null : true;
+  // No issue ROW in a READABLE replica → a synthesized card with nothing to reply
+  // to. Keyed on the explicit `issueExists` bit, NOT on `url`: the deep link is
+  // optional and can be null on a genuine issue (unpopulated / mid-sync), and using
+  // it as the existence predicate hid the composer on tickets the POST path
+  // resolves fine by identifier. An UNREADABLE replica is still not evidence of
+  // absence, so it stays permissive (see the header note).
+  const canReply = thread.available ? thread.issueExists === true : true;
 
   return {
     ticket,

--- a/plugins/dev/scripts/orch-monitor/lib/inbox-conversation.mjs
+++ b/plugins/dev/scripts/orch-monitor/lib/inbox-conversation.mjs
@@ -28,13 +28,60 @@ import { readFile } from "node:fs/promises";
 import { homedir } from "node:os";
 import { join } from "node:path";
 
-import { PHASE_ORDER, deriveExplanation } from "./board-data.mjs";
+import { ANCILLARY_EXPLANATION_PHASES, PHASE_ORDER } from "./board-data.mjs";
 import { deriveAsk } from "./inbox-ask.mjs";
 import { knownBotUserIds } from "./linear-comment.mjs";
 import { DEFAULT_THREAD_LIMIT, readTicketThread } from "./linear-thread.mjs";
 
 const HOME = homedir();
-const DEFAULT_WORKERS_DIR = join(HOME, "catalyst", "execution-core", "workers");
+
+/** The Catalyst data root. Honors CATALYST_DIR like the rest of the tree
+ *  (governance-reader.mjs, execution-core/config.mjs) — hardcoding `~/catalyst`
+ *  would silently read the WRONG worker tree on an installation with a
+ *  non-default root, losing every phase-backed ask. */
+export function catalystDir(env = process.env) {
+  return env.CATALYST_DIR || join(HOME, "catalyst");
+}
+
+export function defaultWorkersDir(env = process.env) {
+  return join(catalystDir(env), "execution-core", "workers");
+}
+
+/**
+ * The phases whose signals can carry an escalation explanation, newest-LAST.
+ *
+ * PHASE_ORDER alone is NOT enough: `remediate` and `recovery-pass` are
+ * deliberately excluded from it, and **recovery-pass is where the rich escalation
+ * explanation is actually authored**. board-data.mjs reads
+ * ANCILLARY_EXPLANATION_PHASES separately for exactly this reason, so scanning
+ * only PHASE_ORDER makes a recovery-pass-only escalation lose its structured ask
+ * and fall back to the far less reliable comment inference.
+ *
+ * Ancillary phases go LAST so the newest-first scan prefers them — a
+ * recovery-pass explanation supersedes the canonical phase that preceded it.
+ */
+export const EXPLANATION_PHASES = [...PHASE_ORDER, ...ANCILLARY_EXPLANATION_PHASES];
+
+/**
+ * The escalation explanation for the ask derivation, scanned newest-first.
+ *
+ * NOT board-data.mjs::deriveExplanation — that function PROJECTS the six legacy
+ * string fields (`call_to_action`, `outcome`, `problem`, `why_you`,
+ * `why_not_auto`, `what_to_do`) and discards everything else. Routing the ask
+ * through it silently threw away both `explanation.ask` (the producer-authored
+ * structured ask) and `explanation.options` (the source of the suggested-reply
+ * chips) — so the "structured" preference tier could never fire and chips could
+ * never render. This returns the explanation object VERBATIM instead.
+ */
+export function deriveRichExplanation(phaseSigs) {
+  for (let i = phaseSigs.length - 1; i >= 0; i--) {
+    const sig = phaseSigs[i];
+    if (!sig || typeof sig !== "object") continue;
+    const expl = sig.explanation;
+    if (expl && typeof expl === "object") return expl;
+  }
+  return null;
+}
 
 /** The global config that carries the app-actor `botUserId`s the authorship gate
  *  cross-checks. Read lazily per call and fail-open to null — the gate's primary
@@ -49,17 +96,45 @@ export async function loadGlobalConfig({
   }
 }
 
-/** Read the ticket's phase signals in canonical order (oldest→newest), so
- *  deriveExplanation's newest-first scan finds the most recent escalation. A
+/**
+ * The Layer-2 project secrets file (`~/.config/catalyst/config-<projectKey>.json`).
+ * Carries the operator's personal `linear.apiToken` — the only Linear credential
+ * available on the launchd path, where no token is exported into the environment.
+ * `projectKey` is resolved from the Layer-1 repo config when not supplied.
+ * Fail-open to null: the reply then reports `no_token` loudly rather than throwing.
+ */
+export async function loadProjectConfig({
+  projectKey = null,
+  repoConfigPath = null,
+  env = process.env,
+} = {}) {
+  try {
+    let key = projectKey ?? env.CATALYST_PROJECT_KEY ?? null;
+    if (key == null) {
+      const p = repoConfigPath ?? join(process.cwd(), ".catalyst", "config.json");
+      const repo = JSON.parse(await readFile(p, "utf8"));
+      key = repo?.catalyst?.projectKey ?? repo?.projectKey ?? null;
+    }
+    if (typeof key !== "string" || key === "") return null;
+    const path = join(HOME, ".config", "catalyst", `config-${key}.json`);
+    return JSON.parse(await readFile(path, "utf8"));
+  } catch {
+    return null;
+  }
+}
+
+/** Read the ticket's phase signals in scan order (oldest→newest, ancillary last),
+ *  so the newest-first explanation scan finds the most recent escalation. A
  *  missing worker dir yields [] — the common parked case, not an error. */
 export async function readPhaseSignals(
   ticket,
-  { workersDir = DEFAULT_WORKERS_DIR, read = readFile } = {},
+  { workersDir = null, read = readFile, env = process.env } = {},
 ) {
+  const dir = workersDir ?? defaultWorkersDir(env);
   const sigs = await Promise.all(
-    PHASE_ORDER.map(async (phase) => {
+    EXPLANATION_PHASES.map(async (phase) => {
       try {
-        return JSON.parse(await read(join(workersDir, ticket, `phase-${phase}.json`), "utf8"));
+        return JSON.parse(await read(join(dir, ticket, `phase-${phase}.json`), "utf8"));
       } catch {
         return null; // absent / unreadable / corrupt → simply not a source
       }
@@ -87,7 +162,8 @@ export async function getConversation(
     limit = DEFAULT_THREAD_LIMIT,
     readThread = readTicketThread,
     readSignals = readPhaseSignals,
-    workersDir = DEFAULT_WORKERS_DIR,
+    workersDir = null,
+    env = process.env,
     /** Pre-loaded global config; when omitted it is read here. Carries the
      *  app-actor ids that make the agent/human split correct (a Catalyst app
      *  actor's comments have is_bot=0 — see linear-thread.mjs::normalizeComment). */
@@ -98,10 +174,10 @@ export async function getConversation(
   const botUserIds = knownBotUserIds({ config: cfg });
   const [thread, phaseSigs] = await Promise.all([
     readThread(ticket, { limit, botUserIds }),
-    readSignals(ticket, { workersDir }).catch(() => []),
+    readSignals(ticket, { workersDir, env }).catch(() => []),
   ]);
 
-  const explanation = deriveExplanation(phaseSigs);
+  const explanation = deriveRichExplanation(phaseSigs);
   const ask = deriveAsk({ explanation, agentComments: thread.agentComments });
 
   // No issue row in a READABLE replica → a synthesized row with nothing to reply

--- a/plugins/dev/scripts/orch-monitor/lib/inbox-conversation.test.mjs
+++ b/plugins/dev/scripts/orch-monitor/lib/inbox-conversation.test.mjs
@@ -1,0 +1,731 @@
+// inbox-conversation.test.mjs — CTL-1569: the inbox conversation surface.
+//
+// Covers the three pure/injectable modules behind the feature:
+//   • inbox-ask.mjs      — "what this needs from you" derivation + kind classification
+//   • linear-thread.mjs  — replica-only thread read (newest-first, fail-open)
+//   • linear-comment.mjs — the operator-authorship gate + the real comment post
+//   • reply-ticket.mjs   — orchestration + the restore-the-row failure contract
+//
+// Every test is offline: no Linear API, no real replica, no worker dir.
+// Fixtures use the PROJ prefix per AGENTS.md → Version Control.
+
+import { describe, expect, it } from "bun:test";
+
+import {
+  ASK_KINDS,
+  askFromComment,
+  askFromExplanation,
+  askFromStructured,
+  classifyAskText,
+  condenseSummary,
+  deriveAsk,
+} from "./inbox-ask.mjs";
+import { isEscalationNotice, pickAskComment } from "./inbox-ask.mjs";
+import { normalizeComment, readTicketThread } from "./linear-thread.mjs";
+import {
+  knownBotUserIds,
+  postOperatorComment,
+  resolveAuthorIdentity,
+  resolveLinearToken,
+} from "./linear-comment.mjs";
+import { replyToTicket } from "./reply-ticket.mjs";
+
+// ── test doubles ─────────────────────────────────────────────────────────────
+
+/** A fake bun:sqlite-shaped handle over canned rows, keyed by SQL fragment. */
+function fakeDb({ comments = [], issue = null, throwOn = null }) {
+  return () => ({
+    prepare(sql) {
+      if (throwOn && sql.includes(throwOn)) {
+        throw new Error("database is locked");
+      }
+      const isIssueQuery = sql.includes("FROM issues");
+      return {
+        all: () => (isIssueQuery ? [] : comments),
+        get: () => (isIssueQuery ? issue : comments[0] ?? null),
+      };
+    },
+    run() {},
+    close() {},
+  });
+}
+
+/** A fetch double that dispatches on the GraphQL operation in the body. */
+function fakeFetch(handlers) {
+  return async (_url, init) => {
+    const parsed = JSON.parse(init.body);
+    const q = parsed.query;
+    const which = q.includes("viewer")
+      ? "viewer"
+      : q.includes("issue(id:")
+        ? "issue"
+        : q.includes("commentCreate")
+          ? "commentCreate"
+          : "unknown";
+    const handler = handlers[which];
+    if (!handler) throw new Error(`unexpected operation: ${which}`);
+    return handler(parsed.variables);
+  };
+}
+
+const jsonRes = (body, status = 200) => ({
+  ok: status >= 200 && status < 300,
+  status,
+  text: async () => JSON.stringify(body),
+});
+
+const HUMAN_VIEWER = jsonRes({
+  data: { viewer: { id: "human-uuid", name: "Ryan Rozich", email: "ryan@example.com", isMe: true } },
+});
+const APP_VIEWER = jsonRes({
+  data: { viewer: { id: "bot-uuid", name: "Catalyst Orchestrator", email: null, isMe: false } },
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// inbox-ask.mjs — the ask summary (§1)
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe("classifyAskText — the four kinds", () => {
+  it("classifies an approve ask (a yes/no is enough)", () => {
+    expect(classifyAskText("Approve publishing SDK 0.7.1?")).toBe("approve");
+    expect(classifyAskText("Ok to proceed with the merge?")).toBe("approve");
+    expect(classifyAskText("I need permission to delete the stale branch.")).toBe("approve");
+  });
+
+  it("classifies a decide ask (choose between options)", () => {
+    expect(classifyAskText("Which option do you want?")).toBe("decide");
+    expect(classifyAskText("Either close it as superseded or keep it for later.")).toBe("decide");
+    expect(classifyAskText("Choose between A and B.")).toBe("decide");
+  });
+
+  it("classifies an act-then-confirm ask (you must DO something first)", () => {
+    expect(
+      classifyAskText("Create the parked-by-human label in Linear, then reply done."),
+    ).toBe("act-then-confirm");
+    expect(classifyAskText("Reply 'done' once you have rotated the token.")).toBe(
+      "act-then-confirm",
+    );
+    expect(classifyAskText("Manually create the missing workflow state.")).toBe(
+      "act-then-confirm",
+    );
+  });
+
+  it("falls back to clarify for unrecognized free text (the honest default)", () => {
+    expect(classifyAskText("The findings are ambiguous.")).toBe("clarify");
+    expect(classifyAskText("")).toBe("clarify");
+    expect(classifyAskText(null)).toBe("clarify");
+  });
+
+  it("prefers act-then-confirm over approve when BOTH markers appear", () => {
+    // The costly error is telling the operator a bare "yes" suffices when they must
+    // first go do something. That precedence is load-bearing, so pin it.
+    const text = "Approve the change, then reply done once you have applied the label.";
+    expect(classifyAskText(text)).toBe("act-then-confirm");
+  });
+
+  it("only ever returns one of the four documented kinds", () => {
+    for (const text of ["approve?", "which one", "then reply done", "hmm", "", "  "]) {
+      expect(ASK_KINDS).toContain(classifyAskText(text));
+    }
+  });
+});
+
+describe("condenseSummary", () => {
+  it("collapses whitespace", () => {
+    expect(condenseSummary("a\n\n  b   c")).toBe("a b c");
+  });
+  it("returns null for empty/absent input (never fabricates)", () => {
+    expect(condenseSummary("")).toBeNull();
+    expect(condenseSummary("   ")).toBeNull();
+    expect(condenseSummary(null)).toBeNull();
+  });
+  it("truncates long prose with an ellipsis", () => {
+    const out = condenseSummary("x".repeat(500), 100);
+    expect(out.length).toBe(100);
+    expect(out.endsWith("…")).toBe(true);
+  });
+});
+
+describe("askFromStructured — the producer-authored path (preferred)", () => {
+  it("uses a complete producer ask verbatim", () => {
+    const ask = askFromStructured({
+      ask: {
+        kind: "approve",
+        summary: "Reply approve to publish, or no to hold.",
+        suggested_replies: ["approve", "no"],
+      },
+    });
+    expect(ask.kind).toBe("approve");
+    expect(ask.summary).toBe("Reply approve to publish, or no to hold.");
+    expect(ask.suggestedReplies).toEqual(["approve", "no"]);
+    expect(ask.canResolveByReply).toBe(true);
+    expect(ask.source).toBe("structured");
+  });
+
+  it("accepts the camelCase alias for suggested replies", () => {
+    const ask = askFromStructured({
+      ask: { kind: "decide", summary: "A or B?", suggestedReplies: ["A", "B"] },
+    });
+    expect(ask.suggestedReplies).toEqual(["A", "B"]);
+  });
+
+  it("treats a HALF-written ask as absent so the derived path can still work", () => {
+    expect(askFromStructured({ ask: { kind: "approve" } })).toBeNull(); // no summary
+    expect(askFromStructured({ ask: { summary: "hi" } })).toBeNull(); // no kind
+    expect(askFromStructured({ ask: { kind: "nonsense", summary: "hi" } })).toBeNull();
+  });
+
+  it("returns null when there is no ask object at all", () => {
+    expect(askFromStructured(null)).toBeNull();
+    expect(askFromStructured({})).toBeNull();
+  });
+
+  it("derives canResolveByReply from the kind, never from the producer", () => {
+    // An act-then-confirm can NEVER claim reply-alone, even if a producer said so.
+    const ask = askFromStructured({
+      ask: { kind: "act-then-confirm", summary: "Do the thing, then confirm.", canResolveByReply: true },
+    });
+    expect(ask.canResolveByReply).toBe(false);
+  });
+});
+
+describe("askFromExplanation — derived from CTL-1110 fields", () => {
+  it("treats 2+ enumerated options as a decision, with the labels as chips", () => {
+    const ask = askFromExplanation({
+      call_to_action: "Pick how to handle PROJ-17.",
+      options: [
+        { label: "close as superseded", detail: "drop it" },
+        { label: "keep for Preferences", detail: "retain" },
+      ],
+    });
+    expect(ask.kind).toBe("decide");
+    expect(ask.suggestedReplies).toEqual(["close as superseded", "keep for Preferences"]);
+    expect(ask.canResolveByReply).toBe(true);
+    expect(ask.source).toBe("explanation");
+  });
+
+  it("classifies the CTA prose when there are no enumerated options", () => {
+    const ask = askFromExplanation({ call_to_action: "Approve the rollout?" });
+    expect(ask.kind).toBe("approve");
+    expect(ask.summary).toBe("Approve the rollout?");
+    expect(ask.suggestedReplies).toEqual([]);
+  });
+
+  it("reads what_to_do for the act-then-confirm marker the CTA lacks", () => {
+    // The "…then reply done" instruction usually lives in what_to_do; missing it
+    // would wrongly promise the operator that replying alone is enough.
+    const ask = askFromExplanation({
+      call_to_action: "The label is missing.",
+      what_to_do: "Create the label in Linear, then reply done.",
+    });
+    expect(ask.kind).toBe("act-then-confirm");
+    expect(ask.canResolveByReply).toBe(false);
+    // The CTA still leads the summary (shorter, more imperative).
+    expect(ask.summary).toBe("The label is missing.");
+  });
+
+  it("never invents reply chips from prose", () => {
+    const ask = askFromExplanation({ call_to_action: "Reply approve or no." });
+    expect(ask.suggestedReplies).toEqual([]);
+  });
+
+  it("returns null when the explanation carries no usable text", () => {
+    expect(askFromExplanation({ outcome: null, problem: null })).toBeNull();
+    expect(askFromExplanation({})).toBeNull();
+    expect(askFromExplanation(null)).toBeNull();
+  });
+
+  it("does not treat a SINGLE option as a decision", () => {
+    const ask = askFromExplanation({
+      call_to_action: "Approve this?",
+      options: [{ label: "yes" }],
+    });
+    expect(ask.kind).toBe("approve");
+    expect(ask.suggestedReplies).toEqual([]);
+  });
+});
+
+describe("askFromComment — the last-resort fallback for tickets parked TODAY", () => {
+  it("derives kind + summary from the newest agent comment", () => {
+    const ask = askFromComment("Which of the 13 findings actually matter?");
+    expect(ask.kind).toBe("decide");
+    expect(ask.source).toBe("comment");
+  });
+  it("never produces chips (a guessed chip is worse than none)", () => {
+    expect(askFromComment("Reply approve or hold.").suggestedReplies).toEqual([]);
+  });
+  it("returns null for an empty comment", () => {
+    expect(askFromComment("")).toBeNull();
+    expect(askFromComment(null)).toBeNull();
+  });
+});
+
+describe("deriveAsk — the preference chain", () => {
+  const structured = {
+    ask: { kind: "approve", summary: "structured wins", suggested_replies: ["yes"] },
+    call_to_action: "explanation loses",
+  };
+
+  it("prefers structured over explanation over comment", () => {
+    expect(deriveAsk({ explanation: structured }).summary).toBe("structured wins");
+    expect(
+      deriveAsk({ explanation: { call_to_action: "explanation wins" } }).summary,
+    ).toBe("explanation wins");
+    expect(
+      deriveAsk({ explanation: null, lastAgentComment: "comment wins" }).summary,
+    ).toBe("comment wins");
+  });
+
+  it("returns null when NO source yields text (the pane renders absent)", () => {
+    expect(deriveAsk({})).toBeNull();
+    expect(deriveAsk({ explanation: {}, lastAgentComment: "" })).toBeNull();
+  });
+
+  it("falls through a half-written structured ask to the explanation fields", () => {
+    const ask = deriveAsk({
+      explanation: { ask: { kind: "approve" }, call_to_action: "fell through" },
+    });
+    expect(ask.summary).toBe("fell through");
+    expect(ask.source).toBe("explanation");
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// linear-thread.mjs — the replica thread read (§2/§3)
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe("isEscalationNotice / pickAskComment", () => {
+  it("recognizes the content-free recovery-pass pointer", () => {
+    // Verbatim from production: this is the ENTIRE comment body.
+    expect(
+      isEscalationNotice(
+        "🔼 **recovery-pass** self-heal attempts exhausted on this ticket — " +
+          "escalated to the operator. (See your inbox.)",
+      ),
+    ).toBe(true);
+    expect(isEscalationNotice("This ticket is now marked for human review.")).toBe(true);
+  });
+
+  it("does NOT discard a long comment that merely mentions escalation", () => {
+    const long = `Reasoning pass determined this requires human judgment. ${"detail ".repeat(120)}`;
+    expect(isEscalationNotice(long)).toBe(false);
+  });
+
+  it("skips notices and picks the newest SUBSTANTIVE agent comment", () => {
+    const picked = pickAskComment([
+      "🔼 recovery-pass self-heal attempts exhausted — escalated to the operator. (See your inbox.)",
+      "**Reason:** duplicate of PROJ-1385, fix already merged, no code change needed.",
+      "older still",
+    ]);
+    expect(picked).toContain("duplicate of PROJ-1385");
+  });
+
+  it("falls back to the newest notice when EVERY comment is one", () => {
+    // A weak ask beats an absent one when the agent said nothing else.
+    const picked = pickAskComment([
+      "escalated to the operator. (See your inbox.)",
+      "marked for human review",
+    ]);
+    expect(picked).toBe("escalated to the operator. (See your inbox.)");
+  });
+
+  it("returns null for an empty list", () => {
+    expect(pickAskComment([])).toBeNull();
+    expect(pickAskComment(null)).toBeNull();
+  });
+
+  it("threads through deriveAsk so the ask skips the pointer", () => {
+    const ask = deriveAsk({
+      agentComments: [
+        "escalated to the operator. (See your inbox.)",
+        "Which of the 13 findings actually matter?",
+      ],
+    });
+    expect(ask.summary).toBe("Which of the 13 findings actually matter?");
+    expect(ask.kind).toBe("decide");
+  });
+});
+
+describe("normalizeComment", () => {
+  it("maps is_bot 1 to isAgent true", () => {
+    expect(normalizeComment({ id: "c1", body: "x", is_bot: 1 }).isAgent).toBe(true);
+  });
+
+  it("treats a CATALYST APP ACTOR as the agent even though is_bot is 0", () => {
+    // The load-bearing case: Linear models an app actor as a user, so the agent's
+    // own comments arrive with is_bot=0. Classifying them as human would render
+    // every agent question as if the operator had written it.
+    const row = { id: "c1", body: "x", is_bot: 0, author_id: "bot-uuid", author_name: "Catalyst" };
+    expect(normalizeComment(row).isAgent).toBe(false); // no ids configured → is_bot only
+    expect(normalizeComment(row, { botUserIds: new Set(["bot-uuid"]) }).isAgent).toBe(true);
+  });
+
+  it("keeps a real human human even when bot ids are configured", () => {
+    const row = { id: "c2", body: "x", is_bot: 0, author_id: "human-uuid" };
+    expect(normalizeComment(row, { botUserIds: new Set(["bot-uuid"]) }).isAgent).toBe(false);
+  });
+
+  it("treats a null is_bot as human (the conservative display split)", () => {
+    expect(normalizeComment({ id: "c1", body: "x", is_bot: null }).isAgent).toBe(false);
+  });
+  it("flags a long body as truncated so the UI can clamp it", () => {
+    expect(normalizeComment({ id: "c1", body: "x".repeat(900) }).truncated).toBe(true);
+    expect(normalizeComment({ id: "c1", body: "short" }).truncated).toBe(false);
+  });
+  it("omits a timestamp rather than fabricating one", () => {
+    expect(normalizeComment({ id: "c1", body: "x" }).at).toBeNull();
+    expect(normalizeComment({ id: "c1", body: "x", created_at: 42 }).at).toBe(42);
+  });
+  it("drops a row with no id", () => {
+    expect(normalizeComment({ body: "x" })).toBeNull();
+    expect(normalizeComment(null)).toBeNull();
+  });
+});
+
+describe("readTicketThread", () => {
+  it("returns the thread and lifts the newest AGENT comment", async () => {
+    // Rows arrive newest-first from SQL; the newest agent entry is the ask.
+    const out = await readTicketThread("PROJ-1", {
+      openDb: fakeDb({
+        comments: [
+          { id: "c3", body: "agent asks the question", is_bot: 1, updated_at: 300 },
+          { id: "c2", body: "human replied earlier", is_bot: 0, updated_at: 200 },
+          { id: "c1", body: "older agent note", is_bot: 1, updated_at: 100 },
+        ],
+        issue: { identifier: "PROJ-1", title: "T", url: "https://linear.app/x/PROJ-1" },
+      }),
+    });
+    expect(out.available).toBe(true);
+    expect(out.comments.map((c) => c.id)).toEqual(["c3", "c2", "c1"]);
+    expect(out.lastAgentComment).toBe("agent asks the question");
+    // The full ordered agent list is surfaced so the ask derivation can skip notices.
+    expect(out.agentComments).toEqual(["agent asks the question", "older agent note"]);
+    expect(out.url).toBe("https://linear.app/x/PROJ-1");
+  });
+
+  it("distinguishes a GENUINELY EMPTY thread from an UNREADABLE one", async () => {
+    const emptyThread = await readTicketThread("PROJ-2", {
+      openDb: fakeDb({ comments: [], issue: { url: "u" } }),
+    });
+    expect(emptyThread.available).toBe(true);
+    expect(emptyThread.comments).toEqual([]);
+    expect(emptyThread.reason).toBeNull();
+
+    const broken = await readTicketThread("PROJ-2", {
+      openDb: fakeDb({ throwOn: "FROM comments" }),
+    });
+    expect(broken.available).toBe(false);
+    expect(broken.reason).toContain("replica-error");
+  });
+
+  it("fails OPEN — a locked/absent replica never throws into a request", async () => {
+    const out = await readTicketThread("PROJ-3", {
+      openDb: () => {
+        throw new Error("unable to open database file");
+      },
+    });
+    expect(out.available).toBe(false);
+    expect(out.comments).toEqual([]);
+    expect(out.lastAgentComment).toBeNull();
+  });
+
+  it("rejects an absent ticket without opening anything", async () => {
+    const out = await readTicketThread("", {
+      openDb: () => {
+        throw new Error("should not have opened");
+      },
+    });
+    expect(out.reason).toBe("no-ticket");
+  });
+
+  it("reports null url when the issue row is absent (a synthesized row)", async () => {
+    const out = await readTicketThread("PROJ-4", {
+      openDb: fakeDb({ comments: [], issue: null }),
+    });
+    expect(out.available).toBe(true);
+    expect(out.url).toBeNull();
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// linear-comment.mjs — the authorship gate (§4, the ships-inert risk)
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe("resolveLinearToken", () => {
+  it("prefers LINEAR_API_TOKEN, falls back to LINEAR_API_KEY", () => {
+    expect(resolveLinearToken({ LINEAR_API_TOKEN: "a", LINEAR_API_KEY: "b" })).toBe("a");
+    expect(resolveLinearToken({ LINEAR_API_KEY: "b" })).toBe("b");
+    expect(resolveLinearToken({})).toBeNull();
+    expect(resolveLinearToken({ LINEAR_API_TOKEN: "   " })).toBeNull();
+  });
+});
+
+describe("knownBotUserIds", () => {
+  it("collects every configured app-actor id", () => {
+    const ids = knownBotUserIds({
+      config: {
+        catalyst: {
+          linear: {
+            bot: { orchestrator: { botUserId: "orch-id" }, worker: { botUserId: "worker-id" } },
+          },
+        },
+      },
+    });
+    expect([...ids].sort()).toEqual(["orch-id", "worker-id"]);
+  });
+  it("returns an empty set when config is absent (the viewer check still guards)", () => {
+    expect(knownBotUserIds({}).size).toBe(0);
+    expect(knownBotUserIds({ config: {} }).size).toBe(0);
+  });
+});
+
+describe("resolveAuthorIdentity", () => {
+  it("identifies a human personal key as NOT a bot", async () => {
+    const id = await resolveAuthorIdentity(
+      { token: "lin_api_x" },
+      { fetchImpl: fakeFetch({ viewer: () => HUMAN_VIEWER }) },
+    );
+    expect(id.ok).toBe(true);
+    expect(id.isBot).toBe(false);
+    expect(id.email).toBe("ryan@example.com");
+  });
+
+  it("flags an app-actor token by SHAPE (no email + isMe false)", async () => {
+    const id = await resolveAuthorIdentity(
+      { token: "lin_oauth_x" },
+      { fetchImpl: fakeFetch({ viewer: () => APP_VIEWER }) },
+    );
+    expect(id.isBot).toBe(true);
+  });
+
+  it("flags a token whose id matches a configured botUserId", async () => {
+    // Belt-and-braces: even a user-LOOKING viewer is caught by the id list.
+    const id = await resolveAuthorIdentity(
+      { token: "t", botUserIds: new Set(["human-uuid"]) },
+      { fetchImpl: fakeFetch({ viewer: () => HUMAN_VIEWER }) },
+    );
+    expect(id.isBot).toBe(true);
+  });
+
+  it("surfaces a transport failure instead of guessing", async () => {
+    const id = await resolveAuthorIdentity(
+      { token: "t" },
+      {
+        fetchImpl: async () => {
+          throw new Error("ECONNREFUSED");
+        },
+      },
+    );
+    expect(id.ok).toBe(false);
+    expect(id.error).toContain("ECONNREFUSED");
+  });
+
+  it("treats an HTTP 200 with a GraphQL errors array as a failure", async () => {
+    // Linear returns 200 + errors on schema drift; a 200 alone is not success.
+    const id = await resolveAuthorIdentity(
+      { token: "t" },
+      { fetchImpl: fakeFetch({ viewer: () => jsonRes({ errors: [{ message: "bad field" }] }) }) },
+    );
+    expect(id.ok).toBe(false);
+    expect(id.error).toContain("bad field");
+  });
+});
+
+describe("postOperatorComment", () => {
+  const happyFetch = fakeFetch({
+    viewer: () => HUMAN_VIEWER,
+    issue: () => jsonRes({ data: { issue: { id: "issue-uuid", identifier: "PROJ-9" } } }),
+    commentCreate: () =>
+      jsonRes({
+        data: {
+          commentCreate: {
+            success: true,
+            comment: {
+              id: "comment-uuid",
+              createdAt: "2026-07-30T12:00:00Z",
+              user: { id: "human-uuid", name: "Ryan Rozich", email: "ryan@example.com" },
+            },
+          },
+        },
+      }),
+  });
+
+  it("posts as the operator and reports the SERVER-recorded author", async () => {
+    const out = await postOperatorComment(
+      { ticket: "PROJ-9", body: "approve" },
+      { fetchImpl: happyFetch, env: { LINEAR_API_TOKEN: "lin_api_x" } },
+    );
+    expect(out.status).toBe("posted");
+    expect(out.commentId).toBe("comment-uuid");
+    expect(out.author).toEqual({ id: "human-uuid", name: "Ryan Rozich" });
+  });
+
+  it("REFUSES to post as an app actor, and posts NOTHING", async () => {
+    // The whole point: an app-actor reply is ignored by CTL-1567, so it must never
+    // be sent and must never look like success.
+    let mutated = false;
+    const out = await postOperatorComment(
+      { ticket: "PROJ-9", body: "approve" },
+      {
+        fetchImpl: fakeFetch({
+          viewer: () => APP_VIEWER,
+          commentCreate: () => {
+            mutated = true;
+            return jsonRes({ data: { commentCreate: { success: true } } });
+          },
+        }),
+        env: { LINEAR_API_TOKEN: "lin_oauth_x" },
+      },
+    );
+    expect(out.status).toBe("bot_identity");
+    expect(mutated).toBe(false);
+    expect(out.message).toContain("app actor");
+  });
+
+  it("rejects an empty body without any network call", async () => {
+    const out = await postOperatorComment(
+      { ticket: "PROJ-9", body: "   " },
+      {
+        fetchImpl: () => {
+          throw new Error("should not fetch");
+        },
+        env: { LINEAR_API_TOKEN: "x" },
+      },
+    );
+    expect(out.status).toBe("empty_body");
+  });
+
+  it("reports no_token when the node has no Linear credential", async () => {
+    const out = await postOperatorComment({ ticket: "PROJ-9", body: "hi" }, { env: {} });
+    expect(out.status).toBe("no_token");
+  });
+
+  it("reports not_found for an unknown issue (e.g. a synthesized row)", async () => {
+    const out = await postOperatorComment(
+      { ticket: "PROJ-404", body: "hi" },
+      {
+        fetchImpl: fakeFetch({
+          viewer: () => HUMAN_VIEWER,
+          issue: () => jsonRes({ data: { issue: null } }),
+        }),
+        env: { LINEAR_API_TOKEN: "lin_api_x" },
+      },
+    );
+    expect(out.status).toBe("not_found");
+  });
+
+  it("never reports success when the mutation does not confirm it", async () => {
+    const out = await postOperatorComment(
+      { ticket: "PROJ-9", body: "hi" },
+      {
+        fetchImpl: fakeFetch({
+          viewer: () => HUMAN_VIEWER,
+          issue: () => jsonRes({ data: { issue: { id: "i" } } }),
+          commentCreate: () => jsonRes({ data: { commentCreate: { success: false } } }),
+        }),
+        env: { LINEAR_API_TOKEN: "lin_api_x" },
+      },
+    );
+    expect(out.status).toBe("error");
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// reply-ticket.mjs — orchestration + the restore-the-row contract (§4)
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe("replyToTicket", () => {
+  const posted = { status: "posted", commentId: "c1", author: { id: "h", name: "Ryan" } };
+
+  it("succeeds for a ticket with NO worker dir (the case this feature exists for)", async () => {
+    // findHeldRun throwing/returning null must NOT fail the reply — the parked
+    // tickets that most need answering have no worker dir at all.
+    const out = await replyToTicket(
+      { ticket: "PROJ-63", body: "yes, go ahead" },
+      {
+        post: async () => posted,
+        findHeld: () => null,
+        record: () => {
+          throw new Error("must not record without a phase");
+        },
+        clearMarker: () => [],
+      },
+    );
+    expect(out.status).toBe("replied");
+    expect(out.phase).toBeNull();
+    expect(out.commentId).toBe("c1");
+  });
+
+  it("records the response next to the phase signal when a held run DOES exist", async () => {
+    const recorded = [];
+    const out = await replyToTicket(
+      { ticket: "PROJ-7", body: "option B" },
+      {
+        post: async () => posted,
+        findHeld: () => ({ phase: "implement", signal: {} }),
+        record: (a) => recorded.push(a),
+        clearMarker: () => [],
+      },
+    );
+    expect(out.phase).toBe("implement");
+    expect(recorded[0]).toMatchObject({ ticket: "PROJ-7", phase: "implement", response: "option B" });
+  });
+
+  it("does NOT mutate local state when the post fails (row is restored)", async () => {
+    let touched = false;
+    const out = await replyToTicket(
+      { ticket: "PROJ-7", body: "hi" },
+      {
+        post: async () => ({ status: "error", message: "boom" }),
+        findHeld: () => ({ phase: "implement", signal: {} }),
+        record: () => {
+          touched = true;
+        },
+        clearMarker: () => {
+          touched = true;
+        },
+      },
+    );
+    expect(out.status).toBe("error");
+    expect(touched).toBe(false);
+  });
+
+  it("passes a bot-identity refusal through verbatim (never a false success)", async () => {
+    const out = await replyToTicket(
+      { ticket: "PROJ-7", body: "hi" },
+      { post: async () => ({ status: "bot_identity", message: "app actor" }) },
+    );
+    expect(out.status).toBe("bot_identity");
+    expect(out.ticket).toBe("PROJ-7");
+  });
+
+  it("rejects an empty reply before calling Linear", async () => {
+    const out = await replyToTicket(
+      { ticket: "PROJ-7", body: "   " },
+      {
+        post: async () => {
+          throw new Error("should not post");
+        },
+      },
+    );
+    expect(out.status).toBe("empty_body");
+  });
+
+  it("survives best-effort local hygiene throwing after a successful post", async () => {
+    // A post that landed must never be reported as failed because a local
+    // breadcrumb write threw — the comment is already live in Linear.
+    const out = await replyToTicket(
+      { ticket: "PROJ-7", body: "hi" },
+      {
+        post: async () => posted,
+        findHeld: () => {
+          throw new Error("unreadable worker dir");
+        },
+        clearMarker: () => {
+          throw new Error("permission denied");
+        },
+      },
+    );
+    expect(out.status).toBe("replied");
+  });
+});

--- a/plugins/dev/scripts/orch-monitor/lib/inbox-conversation.test.mjs
+++ b/plugins/dev/scripts/orch-monitor/lib/inbox-conversation.test.mjs
@@ -676,8 +676,11 @@ describe("readTicketThread", () => {
     expect(out.available).toBe(true);
     expect(out.comments.map((c) => c.id)).toEqual(["c3", "c2", "c1"]);
     expect(out.lastAgentComment).toBe("agent asks the question");
-    // The full ordered agent list is surfaced so the ask derivation can skip notices.
-    expect(out.agentComments).toEqual(["agent asks the question", "older agent note"]);
+    // LIVE candidates stop at the operator's last reply (c2): the older agent note
+    // below it was already answered, so it must not be re-surfaced as an ask.
+    expect(out.agentComments).toEqual(["agent asks the question"]);
+    // The unbounded history is still available.
+    expect(out.allAgentComments).toEqual(["agent asks the question", "older agent note"]);
     expect(out.url).toBe("https://linear.app/x/PROJ-1");
   });
 
@@ -1055,9 +1058,12 @@ describe("round-3 P2 — an operator-action block always requires action", () =>
 
 describe("round-3 P2 — the ask is found beyond the DISPLAY window", () => {
   it("scans deeper than the display limit for the agent's question", async () => {
-    // A run of human replies / integration chatter must not hide the agent's ask.
+    // INTEGRATION chatter must not hide the agent's ask. (Human replies are a
+    // different case entirely — they mark the question ANSWERED, and the
+    // answered-turn boundary deliberately drops it.)
     const humans = Array.from({ length: 8 }, (_, i) => ({
-      id: `h${i}`, body: `human reply ${i}`, is_bot: 0, author_id: "human-uuid", updated_at: 1000 - i,
+      id: `g${i}`, body: `synced to a GitHub issue ${i}`, is_bot: 1, author_id: null,
+      author_name: "GitHub", updated_at: 1000 - i,
     }));
     const agent = {
       id: "a1", body: "Which of the 13 findings actually matter?",
@@ -1072,5 +1078,83 @@ describe("round-3 P2 — the ask is found beyond the DISPLAY window", () => {
     expect(out.comments).toHaveLength(4);
     // … but the agent's question, outside that window, still drives the ask.
     expect(out.agentComments).toEqual(["Which of the 13 findings actually matter?"]);
+  });
+});
+
+// ── Codex round-4 remediation ────────────────────────────────────────────────
+
+describe("round-4 — the answered-turn boundary", () => {
+  it("never re-surfaces a question the operator already answered", async () => {
+    const { readTicketThread: read } = await import("./linear-thread.mjs");
+    const db = () => ({
+      prepare: (sql) => ({
+        all: () =>
+          sql.includes("FROM issues")
+            ? []
+            : [
+                { id: "a2", body: "Failure reason: rebase_refused_dirty_tree", is_bot: 0, author_id: "bot", updated_at: 300 },
+                { id: "h1", body: "yes go ahead", is_bot: 0, author_id: "human", updated_at: 200 },
+                { id: "a1", body: "Approve the rollout?", is_bot: 0, author_id: "bot", updated_at: 100 },
+              ],
+        get: () => (sql.includes("FROM issues") ? { url: "u" } : null),
+      }),
+      run() {},
+      close() {},
+    });
+    const out = await read("PROJ-1", { openDb: db, botUserIds: new Set(["bot"]) });
+    // Class-first ranking would otherwise let the older APPROVAL question outrank
+    // the newer blocker, prompting the operator to re-answer the previous cycle.
+    expect(out.agentComments).toEqual(["Failure reason: rebase_refused_dirty_tree"]);
+    expect(out.allAgentComments).toHaveLength(2);
+  });
+
+  it("treats every agent comment as live when the operator has never replied", async () => {
+    const { readTicketThread: read } = await import("./linear-thread.mjs");
+    const db = () => ({
+      prepare: (sql) => ({
+        all: () =>
+          sql.includes("FROM issues")
+            ? []
+            : [
+                { id: "a2", body: "newer agent", is_bot: 0, author_id: "bot", updated_at: 200 },
+                { id: "a1", body: "older agent", is_bot: 0, author_id: "bot", updated_at: 100 },
+              ],
+        get: () => (sql.includes("FROM issues") ? { url: "u" } : null),
+      }),
+      run() {},
+      close() {},
+    });
+    const out = await read("PROJ-1", { openDb: db, botUserIds: new Set(["bot"]) });
+    expect(out.agentComments).toEqual(["newer agent", "older agent"]);
+  });
+});
+
+describe("round-4 — a validated manual escalation requires action", () => {
+  it("forces act-then-confirm for a validated manual payload", async () => {
+    const { deriveAsk: d } = await import("./inbox-ask.mjs");
+    const ask = d({
+      explanation: {
+        escalation_type: "manual",
+        call_to_action: "Rotate the expired API credential.",
+        instructions: "open the console and rotate it",
+      },
+    });
+    expect(ask.kind).toBe("act-then-confirm");
+    expect(ask.canResolveByReply).toBe(false);
+  });
+
+  it("does NOT force it for a legacy payload that merely defaulted to manual", async () => {
+    const { deriveAsk: d } = await import("./inbox-ask.mjs");
+    expect(
+      d({ explanation: { escalation_type: "manual", call_to_action: "Approve the rollout?" } }).kind,
+    ).not.toBe("act-then-confirm");
+  });
+});
+
+describe("round-4 — phase-remediate mirrors are status reports", () => {
+  it("filters the remediate mirror out of ask candidates", async () => {
+    const { isPhaseStatusReport: isRep } = await import("./inbox-ask.mjs");
+    expect(isRep("**Phase Remediate**\n- **Commits**: ?")).toBe(true);
+    expect(isRep("**Remediate phase — disposition: fixed**")).toBe(true);
   });
 });

--- a/plugins/dev/scripts/orch-monitor/lib/inbox-conversation.test.mjs
+++ b/plugins/dev/scripts/orch-monitor/lib/inbox-conversation.test.mjs
@@ -50,7 +50,8 @@ function fakeDb({ comments = [], issue = null, throwOn = null }) {
       }
       const isIssueQuery = sql.includes("FROM issues");
       return {
-        all: () => (isIssueQuery ? [] : comments),
+        all: (_t, lim) =>
+          isIssueQuery ? [] : comments.slice(0, typeof lim === "number" ? lim : comments.length),
         get: () => (isIssueQuery ? issue : comments[0] ?? null),
       };
     },
@@ -1022,5 +1023,54 @@ describe("replyToTicket", () => {
       },
     );
     expect(out.status).toBe("replied");
+  });
+});
+
+// ── Codex round-3 remediation ────────────────────────────────────────────────
+
+describe("round-3 P2 — an operator-action block always requires action", () => {
+  it("classifies an explicit action block as `action`, not plain `ask`", async () => {
+    const { classifyAskCandidate } = await import("./inbox-ask.mjs");
+    expect(classifyAskCandidate("Action required: rotate the credentials.").class).toBe("action");
+  });
+
+  it("forces act-then-confirm, so the UI never promises a reply alone suffices", async () => {
+    const { deriveAsk: derive } = await import("./inbox-ask.mjs");
+    // The general classifier would call this `clarify` (no act-then-confirm marker),
+    // telling the operator a written reply resolves it — the costliest error here.
+    const ask = derive({ agentComments: ["Action required: rotate the credentials."] });
+    expect(ask.kind).toBe("act-then-confirm");
+    expect(ask.canResolveByReply).toBe(false);
+  });
+
+  it("still ranks an action block above ordinary prose", async () => {
+    const { pickAskCandidate } = await import("./inbox-ask.mjs");
+    const picked = pickAskCandidate([
+      "just some prose about the phase",
+      "Action required: rotate the credentials.",
+    ]);
+    expect(picked.class).toBe("action");
+  });
+});
+
+describe("round-3 P2 — the ask is found beyond the DISPLAY window", () => {
+  it("scans deeper than the display limit for the agent's question", async () => {
+    // A run of human replies / integration chatter must not hide the agent's ask.
+    const humans = Array.from({ length: 8 }, (_, i) => ({
+      id: `h${i}`, body: `human reply ${i}`, is_bot: 0, author_id: "human-uuid", updated_at: 1000 - i,
+    }));
+    const agent = {
+      id: "a1", body: "Which of the 13 findings actually matter?",
+      is_bot: 0, author_id: "bot-uuid", updated_at: 100,
+    };
+    const out = await readTicketThread("PROJ-1", {
+      limit: 4,
+      botUserIds: new Set(["bot-uuid"]),
+      openDb: fakeDb({ comments: [...humans, agent], issue: { url: "u" } }),
+    });
+    // Only the display slice is rendered …
+    expect(out.comments).toHaveLength(4);
+    // … but the agent's question, outside that window, still drives the ask.
+    expect(out.agentComments).toEqual(["Which of the 13 findings actually matter?"]);
   });
 });

--- a/plugins/dev/scripts/orch-monitor/lib/inbox-conversation.test.mjs
+++ b/plugins/dev/scripts/orch-monitor/lib/inbox-conversation.test.mjs
@@ -20,7 +20,16 @@ import {
   condenseSummary,
   deriveAsk,
 } from "./inbox-ask.mjs";
-import { isEscalationNotice, isPhaseStatusReport, pickAskComment } from "./inbox-ask.mjs";
+import {
+  classifyAskCandidate,
+  extractOperatorActionBlock,
+  isEscalationNotice,
+  isPhaseStatusReport,
+  isRecoveryStatusNote,
+  pickAskCandidate,
+  pickAskComment,
+  stripEscalationBoilerplate,
+} from "./inbox-ask.mjs";
 import { normalizeComment, readTicketThread } from "./linear-thread.mjs";
 import {
   knownBotUserIds,
@@ -243,6 +252,41 @@ describe("askFromExplanation — derived from CTL-1110 fields", () => {
     expect(ask.kind).toBe("approve");
     expect(ask.suggestedReplies).toEqual([]);
   });
+
+  it("honors the producer's DECLARED escalation_type over the prose reading", () => {
+    // `escalation_type` is an existing documented tagged union (decision |
+    // authorization | manual) — the producer's own word for what it is asking.
+    // The live `authorization` escalations read as `clarify` to the text
+    // classifier ("free-text answer needed") when the producer said yes/no.
+    const cta = "authorize another recovery cycle (clear its ledger latch), or take it over?";
+    expect(askFromExplanation({ call_to_action: cta }).kind).toBe("clarify");
+    expect(
+      askFromExplanation({ call_to_action: cta, escalation_type: "authorization" }).kind,
+    ).toBe("approve");
+    expect(
+      askFromExplanation({ call_to_action: "Pick a lockfile.", escalation_type: "decision" }).kind,
+    ).toBe("decide");
+  });
+
+  it("ignores `manual` — it is the producer's DEFAULT, not a declaration", () => {
+    // Mapping it would turn "unspecified" into a claim about the ask.
+    expect(
+      askFromExplanation({ call_to_action: "The lockfile is wrong.", escalation_type: "manual" })
+        .kind,
+    ).toBe("clarify");
+  });
+
+  it("lets a classified act-then-confirm OVERRIDE the declared type", () => {
+    // The one asymmetry worth hard-coding: honoring `authorization` here would
+    // promise the operator that a bare "yes" finishes a manual step.
+    const ask = askFromExplanation({
+      call_to_action: "The label is missing.",
+      what_to_do: "Create the label in Linear, then reply done.",
+      escalation_type: "authorization",
+    });
+    expect(ask.kind).toBe("act-then-confirm");
+    expect(ask.canResolveByReply).toBe(false);
+  });
 });
 
 describe("askFromComment — the last-resort fallback for tickets parked TODAY", () => {
@@ -257,6 +301,10 @@ describe("askFromComment — the last-resort fallback for tickets parked TODAY",
   it("returns null for an empty comment", () => {
     expect(askFromComment("")).toBeNull();
     expect(askFromComment(null)).toBeNull();
+  });
+  it("returns null for a comment that carries no ask at all", () => {
+    expect(askFromComment("✅ **recovery-pass** unstuck this — re-dispatched.")).toBeNull();
+    expect(askFromComment("**Phase Implement**\n- **Commits**: 7")).toBeNull();
   });
 });
 
@@ -294,80 +342,262 @@ describe("deriveAsk — the preference chain", () => {
 // linear-thread.mjs — the replica thread read (§2/§3)
 // ═══════════════════════════════════════════════════════════════════════════
 
-describe("isEscalationNotice / pickAskComment", () => {
-  it("recognizes the content-free recovery-pass pointer", () => {
-    // Verbatim from production: this is the ENTIRE comment body.
+// ── strip-then-classify: which agent comment carries the ask ─────────────────
+//
+// Every fixture below is a real production comment body with the ticket keys
+// re-keyed to PROJ (AGENTS.md → Version Control). They are the six parked tickets
+// the live inbox held on 2026-07-30 — the newest agent comment was the ask on
+// NONE of them, which is what this ladder exists to survive.
+
+/** The pointer the recovery pass posts as its final word (recovery-reasoning.mjs).
+ *  Every clause is escalation bookkeeping; rendered as the ask it tells the
+ *  operator to "see your inbox" while they are looking at their inbox. */
+const POINTER =
+  "🔼 **recovery-pass** self-heal attempts exhausted on this ticket — escalated to " +
+  "the operator. self-heal attempts exhausted (2 dispatches without a recorded " +
+  "verdict). (See your inbox.)";
+
+/** recovery-reasoning.mjs::formatEscalationComment — the comment that names the
+ *  REAL blocker, and the one a phrase blacklist discarded (it matches both
+ *  "requires human judgment" and "marked for human review", at 188 chars). */
+const ESCALATION_WITH_REASON =
+  "## PROJ-1176 Recovery Escalation\n\n" +
+  "Reasoning pass determined this requires human judgment.\n\n" +
+  "**Reason:** Failure reason: rebase_refused_dirty_tree\n\n" +
+  "This ticket is now marked for human review.";
+
+describe("stripEscalationBoilerplate", () => {
+  it("reduces the pure pointer to nothing", () => {
+    expect(stripEscalationBoilerplate(POINTER)).toBeNull();
+  });
+
+  it("keeps the REASON when it strips the escalation template around it", () => {
+    // The whole point of strip-then-classify: the phrases are boilerplate to
+    // REMOVE, not evidence to reject the comment on.
+    expect(stripEscalationBoilerplate(ESCALATION_WITH_REASON)).toBe(
+      "**Reason:** Failure reason: rebase_refused_dirty_tree",
+    );
+  });
+
+  it("never rewrites identifiers while trimming orphaned punctuation", () => {
+    // A global punctuation squash turned "duplicate_of_PROJ-1385" into
+    // "duplicate_of_PROJ 1385" — the summary exists to show exactly that string.
+    const residue = stripEscalationBoilerplate(
+      "## PROJ-1176 Recovery Escalation\n\n**Reason:** Failure reason: " +
+        "duplicate_of_PROJ-1385:fix_already_merged_no_code_change\n\n" +
+        "This ticket is now marked for human review.",
+    );
+    expect(residue).toContain("duplicate_of_PROJ-1385:fix_already_merged_no_code_change");
+  });
+
+  it("leaves a comment with no boilerplate untouched", () => {
+    expect(stripEscalationBoilerplate("Which of the 13 findings actually matter?")).toBe(
+      "Which of the 13 findings actually matter?",
+    );
+  });
+});
+
+describe("isRecoveryStatusNote", () => {
+  it("recognizes the pass REPORTING rather than asking", () => {
     expect(
-      isEscalationNotice(
-        "🔼 **recovery-pass** self-heal attempts exhausted on this ticket — " +
-          "escalated to the operator. (See your inbox.)",
+      isRecoveryStatusNote(
+        "✅ **recovery-pass** unstuck this — the 29-day Triage stall was a gen-1 " +
+          "triage worker that hit its turn cap. Re-dispatched triage → now running.",
       ),
     ).toBe(true);
-    expect(isEscalationNotice("This ticket is now marked for human review.")).toBe(true);
+    expect(
+      isRecoveryStatusNote("🔧 **recovery-pass** is working this — triage completed 29 days ago."),
+    ).toBe(true);
+    expect(
+      isRecoveryStatusNote(
+        "🔍 **recovery-pass** reviewed this — PROJ-63 is healthy and progressing. " +
+          "No action needed on the ticket.. No action needed; leaving as-is (re-checks).",
+      ),
+    ).toBe(true);
   });
 
-  it("rejects a PHASE STATUS REPORT as an ask candidate", () => {
-    // These are machine bookkeeping posts, and they are frequently the newest
-    // substantive agent comment. Left in, the classifier reads their imperative
+  it("does NOT swallow the `needs-human VALID` verdict — it names a blocker", () => {
+    // "No action needed; leaving as-is" is about the PASS's next tick, not the
+    // operator's. Treating the whole note as status buries the blocker it names.
+    expect(
+      isRecoveryStatusNote(
+        "🔍 **recovery-pass** reviewed this — needs-human VALID: PR #212 " +
+          "CONFLICTING/DIRTY + 2 codex P2 findings. Left for operator.. " +
+          "No action needed; leaving as-is (re-checks).",
+      ),
+    ).toBe(false);
+  });
+
+  it("ignores comments that are not recovery-pass notes at all", () => {
+    expect(isRecoveryStatusNote("Which of the 13 findings actually matter?")).toBe(false);
+  });
+});
+
+describe("extractOperatorActionBlock", () => {
+  it("lifts the operator requirement out of the phase report carrying it", () => {
+    // The ticket's own act-then-confirm example, and it lives INSIDE a phase
+    // status report — the report is bookkeeping, that paragraph is the ask.
+    const report =
+      "**Phase Implement**\n\n- **Commits**: 7\n\n" +
+      "Implemented the 6-phase plan. All grep-gates clean.\n\n" +
+      "**⚠️ Required pre-merge operator migration (ordering is load-bearing):** " +
+      "apply `parked-by-human` to PROJ-17, confirm it appears in " +
+      "`details.sanctioned` on BOTH hosts, then remove PROJ-17 from the host env.";
+    expect(extractOperatorActionBlock(report)).toStartWith(
+      "**⚠️ Required pre-merge operator migration",
+    );
+  });
+
+  it("returns null for a report with no operator requirement", () => {
+    expect(
+      extractOperatorActionBlock("**Phase Verify**\n\n- **Result**: PASS\n- **Findings**: 4"),
+    ).toBeNull();
+  });
+});
+
+describe("classifyAskCandidate", () => {
+  it("classes the content-free pointer as `none`", () => {
+    expect(classifyAskCandidate(POINTER)).toEqual({ class: "none", text: null });
+  });
+
+  it("classes a phase status report and a pass verdict as `status`", () => {
+    // Machine bookkeeping posts. Left in, the classifier reads their imperative
     // bullets as instructions and emits nonsense like
     // `act-then-confirm: "Phase Implement — Commits: 7"`.
-    const report = "**Phase Implement**\n- **Branch**: `PROJ-1`\n- **Commits**: 7\n- **Diff**: 29 files changed";
-    expect(isPhaseStatusReport(report)).toBe(true);
-    expect(isEscalationNotice(report)).toBe(true);
-    expect(isPhaseStatusReport("**Plan phase — disposition: duplicate of PROJ-2**")).toBe(true);
+    const report = "**Phase Implement**\n- **Branch**: `PROJ-1`\n- **Commits**: 7";
+    expect(classifyAskCandidate(report).class).toBe("status");
+    expect(classifyAskCandidate("phase-implement mirror test — see phase summary").class).toBe(
+      "status",
+    );
+    expect(classifyAskCandidate("✅ **recovery-pass** unstuck this — re-dispatched.").class).toBe(
+      "status",
+    );
   });
 
-  it("does NOT reject prose that merely mentions a phase", () => {
+  it("classes a named failure with no question as a `blocker`", () => {
+    expect(classifyAskCandidate(ESCALATION_WITH_REASON).class).toBe("blocker");
+    expect(
+      classifyAskCandidate(
+        "🔍 **recovery-pass** reviewed this — needs-human VALID: PR #212 " +
+          "CONFLICTING/DIRTY + 2 codex P2 findings. Left for operator.",
+      ).class,
+    ).toBe("blocker");
+  });
+
+  it("classes a question / options / reply-with as an `ask`", () => {
+    expect(classifyAskCandidate("Which of the 13 findings actually matter?").class).toBe("ask");
+    expect(classifyAskCandidate("Reply approve to publish, or no to hold.").class).toBe("ask");
+  });
+
+  it("classes ordinary agent prose as `prose` — real, but the weakest candidate", () => {
+    expect(classifyAskCandidate("The lockfile situation needs a human eye.").class).toBe("prose");
+  });
+
+  it("keeps isEscalationNotice as the rejection test over the same ladder", () => {
+    expect(isEscalationNotice(POINTER)).toBe(true);
+    expect(isEscalationNotice("**Phase Implement**\n- **Commits**: 7")).toBe(true);
+    expect(isEscalationNotice(ESCALATION_WITH_REASON)).toBe(false);
+    // Prose that merely mentions a phase is not a report.
     const prose = "The implement phase needs a decision about which lockfile to keep.";
     expect(isPhaseStatusReport(prose)).toBe(false);
     expect(isEscalationNotice(prose)).toBe(false);
   });
+});
 
+describe("pickAskCandidate / pickAskComment — ranked, never `bodies[0]`", () => {
   it("prefers a real question over a phase report, even a newer one", () => {
-    const picked = pickAskComment([
-      "**Phase Verify**\n- **Result**: PASS\n- **Findings**: 4",
-      "Which of the 13 findings actually matter?",
-    ]);
-    expect(picked).toBe("Which of the 13 findings actually matter?");
+    expect(
+      pickAskComment([
+        "**Phase Verify**\n- **Result**: PASS\n- **Findings**: 4",
+        "Which of the 13 findings actually matter?",
+      ]),
+    ).toBe("Which of the 13 findings actually matter?");
   });
 
-  it("does NOT discard a long comment that merely mentions escalation", () => {
-    const long = `Reasoning pass determined this requires human judgment. ${"detail ".repeat(120)}`;
-    expect(isEscalationNotice(long)).toBe(false);
+  it("picks the older BLOCKER over the newer pointer that hid it", () => {
+    // The exact production shape: the pointer is newest, every phase report is
+    // rejected, and the reason sits two comments down.
+    const picked = pickAskCandidate([
+      POINTER,
+      "**Phase Review**\n- **Result**: PASS",
+      ESCALATION_WITH_REASON,
+    ]);
+    expect(picked.class).toBe("blocker");
+    expect(picked.text).toBe("**Reason:** Failure reason: rebase_refused_dirty_tree");
   });
 
-  it("skips notices and picks the newest SUBSTANTIVE agent comment", () => {
-    const picked = pickAskComment([
-      "🔼 recovery-pass self-heal attempts exhausted — escalated to the operator. (See your inbox.)",
-      "**Reason:** duplicate of PROJ-1385, fix already merged, no code change needed.",
-      "older still",
+  it("ranks a blocker ABOVE a newer throwaway prose line", () => {
+    const picked = pickAskCandidate([
+      "mirror test — see summary",
+      "**Reason:** Failure reason: rebase_refused_dirty_tree",
     ]);
-    expect(picked).toContain("duplicate of PROJ-1385");
+    expect(picked.class).toBe("blocker");
   });
 
-  it("falls back to the newest notice when EVERY comment is one", () => {
-    // A weak ask beats an absent one when the agent said nothing else.
-    const picked = pickAskComment([
-      "escalated to the operator. (See your inbox.)",
-      "marked for human review",
-    ]);
-    expect(picked).toBe("escalated to the operator. (See your inbox.)");
+  it("returns NULL when every comment is a status note or a pointer", () => {
+    // The defect this replaced fell back to `bodies[0]` here, which put
+    // "✅ recovery-pass unstuck this — now running" under the heading
+    // "What this needs from you" and claimed a written answer would resolve it.
+    expect(
+      pickAskComment([
+        POINTER,
+        "✅ **recovery-pass** unstuck this — re-dispatched triage → now running.",
+        "🔧 **recovery-pass** is working this — re-dispatching triage.",
+        "**Phase Plan**\n- **Phases**: 3",
+      ]),
+    ).toBeNull();
   });
 
   it("returns null for an empty list", () => {
     expect(pickAskComment([])).toBeNull();
     expect(pickAskComment(null)).toBeNull();
   });
+});
 
-  it("threads through deriveAsk so the ask skips the pointer", () => {
+describe("deriveAsk over real parked-ticket threads", () => {
+  it("skips the pointer and renders the question", () => {
     const ask = deriveAsk({
-      agentComments: [
-        "escalated to the operator. (See your inbox.)",
-        "Which of the 13 findings actually matter?",
-      ],
+      agentComments: [POINTER, "Which of the 13 findings actually matter?"],
     });
     expect(ask.summary).toBe("Which of the 13 findings actually matter?");
     expect(ask.kind).toBe("decide");
+  });
+
+  it("renders a BLOCKER as act-then-confirm, never as `clarify`", () => {
+    // `clarify` renders "a written answer resolves this; there is no default" —
+    // false on a ticket blocked by a dirty tree, and the expensive direction of
+    // the error (the operator types a reply and nothing clears).
+    const ask = deriveAsk({ agentComments: [POINTER, ESCALATION_WITH_REASON] });
+    expect(ask.kind).toBe("act-then-confirm");
+    expect(ask.canResolveByReply).toBe(false);
+    expect(ask.summary).toBe("**Reason:** Failure reason: rebase_refused_dirty_tree");
+  });
+
+  it("renders NO ask when the agent only reported progress", () => {
+    // The agent said it fixed the ticket and re-dispatched. Demanding an answer
+    // there states the opposite of the truth; absence is honest.
+    expect(
+      deriveAsk({
+        agentComments: [
+          POINTER,
+          "✅ **recovery-pass** unstuck this — re-dispatched triage → now running.",
+        ],
+      }),
+    ).toBeNull();
+  });
+
+  it("lifts an operator requirement out of a phase report as act-then-confirm", () => {
+    const ask = deriveAsk({
+      agentComments: [
+        POINTER,
+        "**Phase Implement**\n\n- **Commits**: 7\n\n" +
+          "**⚠️ Required pre-merge operator migration:** apply `parked-by-human` to " +
+          "PROJ-17, confirm it on BOTH hosts, then remove PROJ-17 from the host env.",
+      ],
+    });
+    expect(ask.kind).toBe("act-then-confirm");
+    expect(ask.canResolveByReply).toBe(false);
+    expect(ask.summary).toContain("apply `parked-by-human` to PROJ-17");
   });
 });
 

--- a/plugins/dev/scripts/orch-monitor/lib/inbox-conversation.test.mjs
+++ b/plugins/dev/scripts/orch-monitor/lib/inbox-conversation.test.mjs
@@ -20,7 +20,7 @@ import {
   condenseSummary,
   deriveAsk,
 } from "./inbox-ask.mjs";
-import { isEscalationNotice, pickAskComment } from "./inbox-ask.mjs";
+import { isEscalationNotice, isPhaseStatusReport, pickAskComment } from "./inbox-ask.mjs";
 import { normalizeComment, readTicketThread } from "./linear-thread.mjs";
 import {
   knownBotUserIds,
@@ -306,6 +306,31 @@ describe("isEscalationNotice / pickAskComment", () => {
     expect(isEscalationNotice("This ticket is now marked for human review.")).toBe(true);
   });
 
+  it("rejects a PHASE STATUS REPORT as an ask candidate", () => {
+    // These are machine bookkeeping posts, and they are frequently the newest
+    // substantive agent comment. Left in, the classifier reads their imperative
+    // bullets as instructions and emits nonsense like
+    // `act-then-confirm: "Phase Implement — Commits: 7"`.
+    const report = "**Phase Implement**\n- **Branch**: `PROJ-1`\n- **Commits**: 7\n- **Diff**: 29 files changed";
+    expect(isPhaseStatusReport(report)).toBe(true);
+    expect(isEscalationNotice(report)).toBe(true);
+    expect(isPhaseStatusReport("**Plan phase — disposition: duplicate of PROJ-2**")).toBe(true);
+  });
+
+  it("does NOT reject prose that merely mentions a phase", () => {
+    const prose = "The implement phase needs a decision about which lockfile to keep.";
+    expect(isPhaseStatusReport(prose)).toBe(false);
+    expect(isEscalationNotice(prose)).toBe(false);
+  });
+
+  it("prefers a real question over a phase report, even a newer one", () => {
+    const picked = pickAskComment([
+      "**Phase Verify**\n- **Result**: PASS\n- **Findings**: 4",
+      "Which of the 13 findings actually matter?",
+    ]);
+    expect(picked).toBe("Which of the 13 findings actually matter?");
+  });
+
   it("does NOT discard a long comment that merely mentions escalation", () => {
     const long = `Reasoning pass determined this requires human judgment. ${"detail ".repeat(120)}`;
     expect(isEscalationNotice(long)).toBe(false);
@@ -360,6 +385,25 @@ describe("normalizeComment", () => {
     expect(normalizeComment(row, { botUserIds: new Set(["bot-uuid"]) }).isAgent).toBe(true);
   });
 
+  it("classes GitHub/Linear plumbing as INTEGRATION, never as the Catalyst agent", () => {
+    // The defect this prevents, seen live: GitHub's "this thread is synced to a
+    // corresponding GitHub issue" notice was treated as the agent, so it became
+    // the derived ask — the inbox told the operator a sync notice was the question.
+    const gh = normalizeComment({ id: "c1", body: "synced to a GitHub issue", is_bot: 1, author_id: null, author_name: "GitHub" });
+    expect(gh.isIntegration).toBe(true);
+    expect(gh.isCatalystAgent).toBe(false);
+    expect(gh.isAgent).toBe(true); // not the operator → still styled as "not you"
+  });
+
+  it("classes a Catalyst app actor as the agent, and NOT as integration", () => {
+    const c = normalizeComment(
+      { id: "c1", body: "x", is_bot: 0, author_id: "bot-uuid", author_name: "Catalyst" },
+      { botUserIds: new Set(["bot-uuid"]) },
+    );
+    expect(c.isCatalystAgent).toBe(true);
+    expect(c.isIntegration).toBe(false);
+  });
+
   it("keeps a real human human even when bot ids are configured", () => {
     const row = { id: "c2", body: "x", is_bot: 0, author_id: "human-uuid" };
     expect(normalizeComment(row, { botUserIds: new Set(["bot-uuid"]) }).isAgent).toBe(false);
@@ -388,12 +432,15 @@ describe("readTicketThread", () => {
     const out = await readTicketThread("PROJ-1", {
       openDb: fakeDb({
         comments: [
-          { id: "c3", body: "agent asks the question", is_bot: 1, updated_at: 300 },
-          { id: "c2", body: "human replied earlier", is_bot: 0, updated_at: 200 },
-          { id: "c1", body: "older agent note", is_bot: 1, updated_at: 100 },
+          // A Catalyst app actor: is_bot=0 with a configured botUserId. That is
+          // how the real agent's comments actually arrive.
+          { id: "c3", body: "agent asks the question", is_bot: 0, author_id: "bot-uuid", updated_at: 300 },
+          { id: "c2", body: "human replied earlier", is_bot: 0, author_id: "human-uuid", updated_at: 200 },
+          { id: "c1", body: "older agent note", is_bot: 0, author_id: "bot-uuid", updated_at: 100 },
         ],
         issue: { identifier: "PROJ-1", title: "T", url: "https://linear.app/x/PROJ-1" },
       }),
+      botUserIds: new Set(["bot-uuid"]),
     });
     expect(out.available).toBe(true);
     expect(out.comments.map((c) => c.id)).toEqual(["c3", "c2", "c1"]);
@@ -401,6 +448,24 @@ describe("readTicketThread", () => {
     // The full ordered agent list is surfaced so the ask derivation can skip notices.
     expect(out.agentComments).toEqual(["agent asks the question", "older agent note"]);
     expect(out.url).toBe("https://linear.app/x/PROJ-1");
+  });
+
+  it("EXCLUDES integration plumbing from the ask candidates but keeps it in the thread", async () => {
+    const out = await readTicketThread("PROJ-1", {
+      openDb: fakeDb({
+        comments: [
+          { id: "c2", body: "synced to a GitHub issue", is_bot: 1, author_id: null, author_name: "GitHub", updated_at: 200 },
+          { id: "c1", body: "Approve the rollout?", is_bot: 0, author_id: "bot-uuid", author_name: "Catalyst", updated_at: 100 },
+        ],
+        issue: { url: "u" },
+      }),
+      botUserIds: new Set(["bot-uuid"]),
+    });
+    // Both render in the thread (context is preserved) …
+    expect(out.comments).toHaveLength(2);
+    // … but only the Catalyst agent's words are ask candidates.
+    expect(out.agentComments).toEqual(["Approve the rollout?"]);
+    expect(out.lastAgentComment).toBe("Approve the rollout?");
   });
 
   it("distinguishes a GENUINELY EMPTY thread from an UNREADABLE one", async () => {

--- a/plugins/dev/scripts/orch-monitor/lib/linear-comment.d.mts
+++ b/plugins/dev/scripts/orch-monitor/lib/linear-comment.d.mts
@@ -1,0 +1,76 @@
+// Type declarations for linear-comment.mjs (CTL-1569 §4) — post a REAL Linear
+// comment authored as the OPERATOR, refusing loudly if the token in hand is an app
+// actor (whose comments CTL-1567 deliberately ignores). Lets the strict TS server
+// and the .ts test files import it without a TS7016 implicit-any error.
+// Keep in sync with linear-comment.mjs.
+
+/** Who the Linear token in hand actually is. */
+export type AuthorIdentity =
+  | {
+      ok: true;
+      id: string;
+      name: string | null;
+      email: string | null;
+      isMe: boolean;
+      /** True when this token is an app actor — the identity that CANNOT resolve
+       *  an ask, because CTL-1567's provenance gate ignores it. */
+      isBot: boolean;
+    }
+  | { ok: false; error: string };
+
+/**
+ * Discriminated outcome of postOperatorComment. `posted` is the ONLY success;
+ * every other value must cause the inbox row to be restored (§4).
+ */
+export type PostCommentResult =
+  | {
+      status: "posted";
+      ticket: string;
+      commentId: string;
+      createdAt: string | null;
+      /** The authorship the SERVER recorded, not what we assumed. */
+      author: { id: string; name: string | null };
+    }
+  | { status: "empty_body" }
+  | { status: "no_token" }
+  | {
+      status: "bot_identity";
+      author: { id: string; name: string | null };
+      message: string;
+    }
+  | { status: "not_found"; ticket: string; message: string }
+  | { status: "error"; message: string };
+
+export function resolveLinearToken(env?: Record<string, string | undefined>): string | null;
+
+/** App-actor user ids from `catalyst.linear.bot.<app>.botUserId`. Fails open to an
+ *  empty set — the primary defense is the `viewer` shape check, which needs no
+ *  config at all. */
+export function knownBotUserIds(opts?: { config?: unknown }): Set<string>;
+
+export function resolveAuthorIdentity(
+  args: { token: string; botUserIds?: ReadonlySet<string> },
+  opts?: { fetchImpl?: typeof fetch },
+): Promise<AuthorIdentity>;
+
+export function resolveIssueId(
+  args: { token: string; ticket: string },
+  opts?: { fetchImpl?: typeof fetch },
+): Promise<{ ok: true; id: string } | { ok: false; error: string }>;
+
+export function postOperatorComment(
+  args: { ticket: string; body: unknown },
+  opts?: {
+    fetchImpl?: typeof fetch;
+    env?: Record<string, string | undefined>;
+    config?: unknown;
+    resolveIdentity?: (
+      args: { token: string; botUserIds?: ReadonlySet<string> },
+      opts?: { fetchImpl?: typeof fetch },
+    ) => Promise<AuthorIdentity>;
+    resolveIssue?: (
+      args: { token: string; ticket: string },
+      opts?: { fetchImpl?: typeof fetch },
+    ) => Promise<{ ok: true; id: string } | { ok: false; error: string }>;
+  },
+): Promise<PostCommentResult>;

--- a/plugins/dev/scripts/orch-monitor/lib/linear-comment.d.mts
+++ b/plugins/dev/scripts/orch-monitor/lib/linear-comment.d.mts
@@ -41,12 +41,18 @@ export type PostCommentResult =
   | { status: "not_found"; ticket: string; message: string }
   | { status: "error"; message: string };
 
-export function resolveLinearToken(env?: Record<string, string | undefined>): string | null;
+export function resolveLinearToken(
+  env?: Record<string, string | undefined>,
+  opts?: { projectConfig?: unknown },
+): string | null;
 
 /** App-actor user ids from `catalyst.linear.bot.<app>.botUserId`. Fails open to an
  *  empty set — the primary defense is the `viewer` shape check, which needs no
  *  config at all. */
-export function knownBotUserIds(opts?: { config?: unknown }): Set<string>;
+export function knownBotUserIds(opts?: {
+  config?: unknown;
+  projectConfig?: unknown;
+}): Set<string>;
 
 export function resolveAuthorIdentity(
   args: { token: string; botUserIds?: ReadonlySet<string> },
@@ -64,6 +70,7 @@ export function postOperatorComment(
     fetchImpl?: typeof fetch;
     env?: Record<string, string | undefined>;
     config?: unknown;
+    projectConfig?: unknown;
     resolveIdentity?: (
       args: { token: string; botUserIds?: ReadonlySet<string> },
       opts?: { fetchImpl?: typeof fetch },
@@ -74,3 +81,7 @@ export function postOperatorComment(
     ) => Promise<{ ok: true; id: string } | { ok: false; error: string }>;
   },
 ): Promise<PostCommentResult>;
+
+/** The exact text to post: leading whitespace preserved (an indented Markdown
+ *  code block must survive), only trailing whitespace stripped. */
+export function postBody(raw: unknown): string;

--- a/plugins/dev/scripts/orch-monitor/lib/linear-comment.mjs
+++ b/plugins/dev/scripts/orch-monitor/lib/linear-comment.mjs
@@ -75,9 +75,19 @@ const REQUEST_TIMEOUT_MS = 15_000;
 export function resolveLinearToken(env = process.env, { projectConfig = null } = {}) {
   const fromEnv = env.LINEAR_API_TOKEN || env.LINEAR_API_KEY || null;
   if (typeof fromEnv === "string" && fromEnv.trim() !== "") return fromEnv.trim();
-  // Layer-2 personal token — the launchd path's only source.
-  const fromConfig = projectConfig?.linear?.apiToken;
-  if (typeof fromConfig === "string" && fromConfig.trim() !== "") return fromConfig.trim();
+  // Layer-2 personal token — the launchd path's only source. BOTH shapes are
+  // accepted: `linear.apiToken` is what the reference schema documents
+  // (website/.../reference/configuration.md) and what real installs carry, while
+  // the nested `catalyst.linear.apiToken` shows up in some setups. Reading only
+  // one shape means a validly-configured host resolves nothing and every reply
+  // returns `no_token` — the failure this whole fallback exists to prevent, so it
+  // is not worth being narrow about.
+  for (const candidate of [
+    projectConfig?.linear?.apiToken,
+    projectConfig?.catalyst?.linear?.apiToken,
+  ]) {
+    if (typeof candidate === "string" && candidate.trim() !== "") return candidate.trim();
+  }
   return null;
 }
 

--- a/plugins/dev/scripts/orch-monitor/lib/linear-comment.mjs
+++ b/plugins/dev/scripts/orch-monitor/lib/linear-comment.mjs
@@ -1,0 +1,284 @@
+// linear-comment.mjs — post a REAL Linear comment, authored as the OPERATOR
+// (CTL-1569 §4). This is the module the whole feature lives or dies on.
+//
+// ── why this is the sharpest edge in the ticket ───────────────────────────────
+// CTL-1567 made a human comment on a parked ticket clear `needs-human`
+// unconditionally and first. That is what makes "reply from the inbox" a real
+// resolution mechanism rather than a UI gesture. But that gate requires a
+// POSITIVELY-IDENTIFIED HUMAN author, and it deliberately IGNORES app-actor
+// comments — that guard exists because the escalation itself posts an explanatory
+// comment as the app, and without the guard the bot would clear the very label it
+// had just applied.
+//
+// The consequence: **a reply posted as the app actor silently does nothing.** The
+// comment appears in Linear, the UI looks correct, the row even disappears
+// optimistically — and the ticket stays parked forever. It is the single easiest
+// way to ship this feature completely inert, and it fails SILENTLY, which is the
+// worst possible failure shape.
+//
+// So this module does not merely *hope* it holds the right token. It RESOLVES the
+// token's identity and REFUSES to post as a bot:
+//
+//   1. Resolve `viewer` for the token actually in hand.
+//   2. If that identity is an app/bot actor — or matches a configured
+//      `botUserId` — REFUSE with `status:"bot_identity"` and post NOTHING.
+//   3. Only then post, and return the authorship the server observed.
+//
+// Refusing loudly is strictly better than posting a comment that cannot resolve
+// the ask: the operator sees "this would not have worked" and the row is RESTORED
+// (the §4 failure-path requirement), instead of believing they answered.
+//
+// ── token provenance ─────────────────────────────────────────────────────────
+// The personal `lin_api_*` key in the monitor's env resolves to the human operator
+// (verified: → Ryan Rozich / a real Linear user). The DAEMON is the process that
+// swaps in an app-actor OAuth token (catalyst-execution-core mints
+// client_credentials with `actor=app` and exports LINEAR_API_TOKEN into the
+// daemon's own env only). The monitor is a separate process and inherits the
+// personal key — but "inherits" is an assumption about process env, exactly the
+// kind that rots silently across a deploy or a launchd change. Hence the runtime
+// check above rather than a comment asserting it is fine.
+//
+// Writes go through the Linear GraphQL API directly (not `linearis`): `linearis`
+// has no "post a comment" verb this path can use without shelling per keystroke,
+// and CTL-1569's own note records that `linearis --label-mode overwrite` returns a
+// success payload while silently not applying — the GraphQL path is the one that
+// demonstrably works for mutations. Reads stay on the replica (linear-thread.mjs).
+
+const LINEAR_GRAPHQL_URL = "https://api.linear.app/graphql";
+
+/** Wall-clock budget for a single Linear mutation. The operator is waiting on this
+ *  in a reply box, so it fails fast and restores the row rather than hanging. */
+const REQUEST_TIMEOUT_MS = 15_000;
+
+/** Resolve the Linear token from the process env — the same pair the rest of the
+ *  tree reads (`LINEAR_API_TOKEN` preferred, `LINEAR_API_KEY` as the alias). */
+export function resolveLinearToken(env = process.env) {
+  const tok = env.LINEAR_API_TOKEN || env.LINEAR_API_KEY || null;
+  return typeof tok === "string" && tok.trim() !== "" ? tok.trim() : null;
+}
+
+/**
+ * The app-actor user ids this deployment knows about, read from the global config
+ * (`~/.config/catalyst/config.json` → `catalyst.linear.bot.<app>.botUserId`).
+ * These are the identities whose comments CTL-1567 ignores.
+ *
+ * Config-read failures return an EMPTY set, which is safe: the primary defense is
+ * the `viewer` shape check below (`isMe:false` / an `organization`-less app actor),
+ * and that needs no config at all. The id list is a belt-and-braces second check
+ * for the case where an app token still reports a user-like viewer.
+ */
+export function knownBotUserIds({ config = null } = {}) {
+  const ids = new Set();
+  const bots = config?.catalyst?.linear?.bot;
+  if (bots && typeof bots === "object") {
+    for (const app of Object.values(bots)) {
+      const id = app?.botUserId;
+      if (typeof id === "string" && id.trim() !== "") ids.add(id.trim());
+    }
+  }
+  return ids;
+}
+
+/** GraphQL POST with a hard timeout. Returns the parsed body; throws on transport
+ *  failure or a non-2xx. Injectable fetch keeps the unit tests offline. */
+async function gql({ token, query, variables }, { fetchImpl = fetch } = {}) {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
+  try {
+    const res = await fetchImpl(LINEAR_GRAPHQL_URL, {
+      method: "POST",
+      headers: { Authorization: token, "Content-Type": "application/json" },
+      body: JSON.stringify({ query, variables }),
+      signal: controller.signal,
+    });
+    const text = await res.text();
+    let body;
+    try {
+      body = JSON.parse(text);
+    } catch {
+      throw new Error(`non-JSON response (HTTP ${res.status})`);
+    }
+    if (!res.ok) {
+      throw new Error(`HTTP ${res.status}: ${text.slice(0, 200)}`);
+    }
+    // CTL note: Linear returns HTTP 200 with a populated `errors` array on schema
+    // drift, so a 200 is NOT sufficient — the errors array must be checked too.
+    if (Array.isArray(body?.errors) && body.errors.length > 0) {
+      throw new Error(body.errors.map((e) => e?.message ?? String(e)).join("; "));
+    }
+    return body;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+const VIEWER_QUERY = `query { viewer { id name email isMe } }`;
+
+/**
+ * Resolve who the token in hand actually is.
+ *
+ * Returns { ok:true, id, name, email, isMe, isBot } or { ok:false, error }.
+ *
+ * `isBot` is true when EITHER signal fires:
+ *   • the viewer id is a configured app-actor `botUserId`, or
+ *   • the viewer reports no email AND `isMe !== true` — the shape an app-actor
+ *     (`actor=app`) token returns, since it is not a human workspace member.
+ * A human personal key returns a real id + email + isMe:true and is never flagged.
+ */
+export async function resolveAuthorIdentity(
+  { token, botUserIds = new Set() },
+  { fetchImpl = fetch } = {},
+) {
+  let body;
+  try {
+    body = await gql({ token, query: VIEWER_QUERY, variables: {} }, { fetchImpl });
+  } catch (e) {
+    return { ok: false, error: e instanceof Error ? e.message : String(e) };
+  }
+  const v = body?.data?.viewer;
+  if (!v || typeof v !== "object" || typeof v.id !== "string") {
+    return { ok: false, error: "viewer query returned no identity" };
+  }
+  const hasEmail = typeof v.email === "string" && v.email !== "";
+  const isBot = botUserIds.has(v.id) || (!hasEmail && v.isMe !== true);
+  return {
+    ok: true,
+    id: v.id,
+    name: typeof v.name === "string" ? v.name : null,
+    email: hasEmail ? v.email : null,
+    isMe: v.isMe === true,
+    isBot,
+  };
+}
+
+const ISSUE_ID_QUERY = `
+  query ($id: String!) { issue(id: $id) { id identifier } }
+`;
+
+/**
+ * Resolve a ticket KEY ("CTL-1569") to the Linear issue UUID `commentCreate` needs.
+ *
+ * Uses `issue(id:)`, which accepts the human identifier — deliberately NOT an
+ * `IssueFilter.identifier` search: that filter field was REMOVED from the Linear
+ * schema (it broke a sibling comment helper in this tree), so filtering by it
+ * returns a 200 with an `errors` array rather than a match.
+ */
+export async function resolveIssueId({ token, ticket }, { fetchImpl = fetch } = {}) {
+  let body;
+  try {
+    body = await gql(
+      { token, query: ISSUE_ID_QUERY, variables: { id: ticket } },
+      { fetchImpl },
+    );
+  } catch (e) {
+    return { ok: false, error: e instanceof Error ? e.message : String(e) };
+  }
+  const id = body?.data?.issue?.id;
+  if (typeof id !== "string" || id === "") {
+    return { ok: false, error: `no such issue: ${ticket}` };
+  }
+  return { ok: true, id };
+}
+
+const COMMENT_CREATE = `
+  mutation ($issueId: String!, $body: String!) {
+    commentCreate(input: { issueId: $issueId, body: $body }) {
+      success
+      comment {
+        id
+        createdAt
+        user { id name email }
+      }
+    }
+  }
+`;
+
+/**
+ * Post a comment to a Linear ticket as the operator.
+ *
+ * Discriminated result — the route maps each to an HTTP status, and EVERY
+ * non-`posted` outcome must restore the inbox row (§4):
+ *
+ *   { status: "posted", commentId, author }   → the comment is live and
+ *                                               human-authored; CTL-1567 will
+ *                                               clear `needs-human` within seconds.
+ *   { status: "no_token" }                    → no Linear credential in this env.
+ *   { status: "bot_identity", author }        → REFUSED before posting: the token
+ *                                               is an app actor, so the comment
+ *                                               could not have resolved the ask.
+ *   { status: "empty_body" }                  → nothing to say; not a Linear call.
+ *   { status: "not_found", ticket }           → no such issue.
+ *   { status: "error", message }              → transport / API / mutation failure.
+ *
+ * All collaborators are injected so every branch is unit-tested with no network.
+ */
+export async function postOperatorComment(
+  { ticket, body },
+  {
+    fetchImpl = fetch,
+    env = process.env,
+    config = null,
+    resolveIdentity = resolveAuthorIdentity,
+    resolveIssue = resolveIssueId,
+  } = {},
+) {
+  const text = typeof body === "string" ? body.trim() : "";
+  if (text === "") return { status: "empty_body" };
+
+  const token = resolveLinearToken(env);
+  if (token == null) return { status: "no_token" };
+
+  // ── the authorship gate ────────────────────────────────────────────────────
+  // Resolve identity BEFORE mutating. A bot token is refused with nothing posted,
+  // so the operator is told the truth instead of being shown a phantom success.
+  const identity = await resolveIdentity(
+    { token, botUserIds: knownBotUserIds({ config }) },
+    { fetchImpl },
+  );
+  if (!identity.ok) {
+    return { status: "error", message: `could not verify comment authorship: ${identity.error}` };
+  }
+  if (identity.isBot) {
+    return {
+      status: "bot_identity",
+      author: { id: identity.id, name: identity.name },
+      message:
+        "refused: this monitor's Linear token is an app actor, and CTL-1567 ignores " +
+        "app-actor comments — the reply would not have cleared needs-human.",
+    };
+  }
+
+  const issue = await resolveIssue({ token, ticket }, { fetchImpl });
+  if (!issue.ok) {
+    return { status: "not_found", ticket, message: issue.error };
+  }
+
+  let result;
+  try {
+    result = await gql(
+      { token, query: COMMENT_CREATE, variables: { issueId: issue.id, body: text } },
+      { fetchImpl },
+    );
+  } catch (e) {
+    return { status: "error", message: e instanceof Error ? e.message : String(e) };
+  }
+
+  const payload = result?.data?.commentCreate;
+  if (payload?.success !== true || typeof payload?.comment?.id !== "string") {
+    return { status: "error", message: "commentCreate did not report success" };
+  }
+
+  // Report the authorship the SERVER recorded (not what we assumed) so the caller
+  // can log/surface who the comment landed as.
+  const user = payload.comment.user ?? null;
+  return {
+    status: "posted",
+    ticket,
+    commentId: payload.comment.id,
+    createdAt: typeof payload.comment.createdAt === "string" ? payload.comment.createdAt : null,
+    author: {
+      id: typeof user?.id === "string" ? user.id : identity.id,
+      name: typeof user?.name === "string" ? user.name : identity.name,
+    },
+  };
+}

--- a/plugins/dev/scripts/orch-monitor/lib/linear-comment.mjs
+++ b/plugins/dev/scripts/orch-monitor/lib/linear-comment.mjs
@@ -50,11 +50,35 @@ const LINEAR_GRAPHQL_URL = "https://api.linear.app/graphql";
  *  in a reply box, so it fails fast and restores the row rather than hanging. */
 const REQUEST_TIMEOUT_MS = 15_000;
 
-/** Resolve the Linear token from the process env — the same pair the rest of the
- *  tree reads (`LINEAR_API_TOKEN` preferred, `LINEAR_API_KEY` as the alias). */
-export function resolveLinearToken(env = process.env) {
-  const tok = env.LINEAR_API_TOKEN || env.LINEAR_API_KEY || null;
-  return typeof tok === "string" && tok.trim() !== "" ? tok.trim() : null;
+/**
+ * Resolve the Linear credential to post the reply with.
+ *
+ * ── why this cannot be env-only ──────────────────────────────────────────────
+ * An env-only resolver makes this feature INERT on the normal persistent launch
+ * path. `catalyst-monitor.sh` (the committed launchd wrapper) exports no Linear
+ * token at all; the operator's personal token lives in the Layer-2 secrets file
+ * `~/.config/catalyst/config-<projectKey>.json` under `linear.apiToken`. So a
+ * launchd-started monitor would return `no_token` for every inline reply even
+ * though Linear is fully configured — the same class of silent no-op the
+ * authorship gate exists to prevent, arriving through a different door.
+ *
+ * Order: env (`LINEAR_API_TOKEN`, then the `LINEAR_API_KEY` alias) → Layer-2
+ * `linear.apiToken`.
+ *
+ * ── the one credential we must NEVER fall back to ────────────────────────────
+ * The same Layer-2 file also carries `catalyst.linear.agent.accessToken` — an
+ * APP-ACTOR OAuth token. Reaching for it would post the reply as the app, which
+ * CTL-1567's provenance gate ignores, making the reply silently do nothing. It is
+ * deliberately NOT in the chain. (The authorship gate below would catch it anyway;
+ * this is the belt to that braces.)
+ */
+export function resolveLinearToken(env = process.env, { projectConfig = null } = {}) {
+  const fromEnv = env.LINEAR_API_TOKEN || env.LINEAR_API_KEY || null;
+  if (typeof fromEnv === "string" && fromEnv.trim() !== "") return fromEnv.trim();
+  // Layer-2 personal token — the launchd path's only source.
+  const fromConfig = projectConfig?.linear?.apiToken;
+  if (typeof fromConfig === "string" && fromConfig.trim() !== "") return fromConfig.trim();
+  return null;
 }
 
 /**
@@ -67,16 +91,37 @@ export function resolveLinearToken(env = process.env) {
  * and that needs no config at all. The id list is a belt-and-braces second check
  * for the case where an app token still reports a user-like viewer.
  */
-export function knownBotUserIds({ config = null } = {}) {
+export function knownBotUserIds({ config = null, projectConfig = null } = {}) {
   const ids = new Set();
+  const add = (id) => {
+    if (typeof id === "string" && id.trim() !== "") ids.add(id.trim());
+  };
   const bots = config?.catalyst?.linear?.bot;
   if (bots && typeof bots === "object") {
-    for (const app of Object.values(bots)) {
-      const id = app?.botUserId;
-      if (typeof id === "string" && id.trim() !== "") ids.add(id.trim());
-    }
+    for (const app of Object.values(bots)) add(app?.botUserId);
   }
+  // LEGACY per-repo form: `catalyst.monitor.linear.botUserId`, read flat from the
+  // Layer-1 repo config — the shape the daemon's own self-echo guard reads. On an
+  // installation that only has this form, omitting it leaves every Catalyst app
+  // comment classified as HUMAN (they carry is_bot=0), which empties
+  // `agentComments` and breaks the comment-derived ask.
+  add(config?.catalyst?.monitor?.linear?.botUserId);
+  add(projectConfig?.catalyst?.monitor?.linear?.botUserId);
   return ids;
+}
+
+/**
+ * The exact text to post, given the operator's raw input.
+ *
+ * Trimming is used to VALIDATE emptiness, but must not rewrite what gets posted:
+ * a reply that opens with a four-space-indented Markdown code block loses its
+ * first line's indentation under `trim()`, and Linear then renders it as prose
+ * instead of code — different semantics from what the operator wrote. So leading
+ * whitespace is preserved verbatim and only trailing whitespace is dropped (which
+ * is invisible in the rendered comment and never load-bearing).
+ */
+export function postBody(raw) {
+  return typeof raw === "string" ? raw.replace(/\s+$/, "") : "";
 }
 
 /** GraphQL POST with a hard timeout. Returns the parsed body; throws on transport
@@ -171,11 +216,13 @@ export async function resolveIssueId({ token, ticket }, { fetchImpl = fetch } = 
       { fetchImpl },
     );
   } catch (e) {
-    return { ok: false, error: e instanceof Error ? e.message : String(e) };
+    // Transport / auth / HTTP / GraphQL failure — NOT evidence the issue is absent.
+    return { ok: false, missing: false, error: e instanceof Error ? e.message : String(e) };
   }
   const id = body?.data?.issue?.id;
   if (typeof id !== "string" || id === "") {
-    return { ok: false, error: `no such issue: ${ticket}` };
+    // A successful query that returned no issue — a GENUINE miss.
+    return { ok: false, missing: true, error: `no such issue: ${ticket}` };
   }
   return { ok: true, id };
 }
@@ -218,21 +265,23 @@ export async function postOperatorComment(
     fetchImpl = fetch,
     env = process.env,
     config = null,
+    projectConfig = null,
     resolveIdentity = resolveAuthorIdentity,
     resolveIssue = resolveIssueId,
   } = {},
 ) {
-  const text = typeof body === "string" ? body.trim() : "";
-  if (text === "") return { status: "empty_body" };
+  // Emptiness is validated on the TRIMMED value, but the body posted below is the
+  // operator's verbatim text — see the postBody note.
+  if (typeof body !== "string" || body.trim() === "") return { status: "empty_body" };
 
-  const token = resolveLinearToken(env);
+  const token = resolveLinearToken(env, { projectConfig });
   if (token == null) return { status: "no_token" };
 
   // ── the authorship gate ────────────────────────────────────────────────────
   // Resolve identity BEFORE mutating. A bot token is refused with nothing posted,
   // so the operator is told the truth instead of being shown a phantom success.
   const identity = await resolveIdentity(
-    { token, botUserIds: knownBotUserIds({ config }) },
+    { token, botUserIds: knownBotUserIds({ config, projectConfig }) },
     { fetchImpl },
   );
   if (!identity.ok) {
@@ -250,13 +299,18 @@ export async function postOperatorComment(
 
   const issue = await resolveIssue({ token, ticket }, { fetchImpl });
   if (!issue.ok) {
-    return { status: "not_found", ticket, message: issue.error };
+    // Only a CONFIRMED miss is `not_found`. An HTTP 500 during the lookup is a
+    // retryable write failure — reporting it as "no such ticket" would hand the
+    // operator a false diagnosis about their own board.
+    return issue.missing === true
+      ? { status: "not_found", ticket, message: issue.error }
+      : { status: "error", ticket, message: `issue lookup failed: ${issue.error}` };
   }
 
   let result;
   try {
     result = await gql(
-      { token, query: COMMENT_CREATE, variables: { issueId: issue.id, body: text } },
+      { token, query: COMMENT_CREATE, variables: { issueId: issue.id, body: postBody(body) } },
       { fetchImpl },
     );
   } catch (e) {

--- a/plugins/dev/scripts/orch-monitor/lib/linear-thread.d.mts
+++ b/plugins/dev/scripts/orch-monitor/lib/linear-thread.d.mts
@@ -1,0 +1,65 @@
+// Type declarations for linear-thread.mjs (CTL-1569 §2/§3) — the parked ticket's
+// conversation, read from the REPLICA with zero Linear API calls. Lets the strict
+// TS server and the .ts test files import it without a TS7016 implicit-any error.
+// Keep in sync with the objects returned in linear-thread.mjs.
+
+/** One normalized comment, newest-first within a thread. */
+export interface ThreadComment {
+  id: string;
+  body: string;
+  /** True when the author is the AGENT — an integration bot (`is_bot = 1`) OR a
+   *  Catalyst app actor, whose comments arrive with `is_bot = 0` because Linear
+   *  models an app actor as a user. See normalizeComment's header note. */
+  isAgent: boolean;
+  authorName: string;
+  authorAvatarUrl: string | null;
+  /** Epoch ms, or null when the replica carried no honest timestamp. */
+  at: number | null;
+  parentId: string | null;
+  /** The body is long enough that the UI should clamp it with expand-in-place. */
+  truncated: boolean;
+}
+
+/** The full thread read. `available:false` means the replica could not be read —
+ *  distinct from an available-but-empty thread, so the UI can stay silent about a
+ *  source it never reached instead of claiming "no comments". */
+export interface TicketThread {
+  ticket: string;
+  available: boolean;
+  comments: ThreadComment[];
+  /** The ticket's own Linear URL, mirrored in the replica's `issues` table (§3). */
+  url: string | null;
+  title: string | null;
+  /** Agent comment bodies, NEWEST FIRST — the ask-derivation fallback input. */
+  agentComments: string[];
+  lastAgentComment: string | null;
+  reason: string | null;
+}
+
+/** A minimal read-only sqlite handle, as injected by tests. */
+export interface ThreadDbLike {
+  prepare(sql: string): { all(...params: unknown[]): unknown[]; get(...params: unknown[]): unknown };
+  run?(sql: string): unknown;
+  close?(): void;
+}
+
+export function defaultReplicaDbPath(): string;
+
+/** How many comments the pane shows by default — "the last few", not all history. */
+export const DEFAULT_THREAD_LIMIT: number;
+
+export function normalizeComment(
+  row: unknown,
+  opts?: { botUserIds?: ReadonlySet<string> },
+): ThreadComment | null;
+
+export function readTicketThread(
+  ticket: string,
+  opts?: {
+    dbPath?: string;
+    limit?: number;
+    openDb?: ((args: { dbPath: string }) => ThreadDbLike) | null;
+    /** App-actor user ids whose comments are the AGENT's. */
+    botUserIds?: ReadonlySet<string>;
+  },
+): Promise<TicketThread>;

--- a/plugins/dev/scripts/orch-monitor/lib/linear-thread.d.mts
+++ b/plugins/dev/scripts/orch-monitor/lib/linear-thread.d.mts
@@ -37,8 +37,15 @@ export interface TicketThread {
   /** The ticket's own Linear URL, mirrored in the replica's `issues` table (§3). */
   url: string | null;
   title: string | null;
-  /** Agent comment bodies, NEWEST FIRST — the ask-derivation fallback input. */
+  /** Agent comment bodies NEWER than the operator's last reply, NEWEST FIRST —
+   *  the LIVE ask candidates. Bounded by the answered-turn boundary so a question
+   *  the operator has already answered is never re-surfaced. */
   agentComments: string[];
+  /** Every agent comment in the scan window, ignoring the boundary. */
+  allAgentComments: string[];
+  /** Whether the replica holds an issue ROW. Distinct from `url`, which is an
+   *  optional deep link and can be null on a real issue. */
+  issueExists: boolean;
   lastAgentComment: string | null;
   reason: string | null;
 }

--- a/plugins/dev/scripts/orch-monitor/lib/linear-thread.d.mts
+++ b/plugins/dev/scripts/orch-monitor/lib/linear-thread.d.mts
@@ -10,7 +10,14 @@ export interface ThreadComment {
   /** True when the author is the AGENT — an integration bot (`is_bot = 1`) OR a
    *  Catalyst app actor, whose comments arrive with `is_bot = 0` because Linear
    *  models an app actor as a user. See normalizeComment's header note. */
+  /** Not the operator — a Catalyst app actor OR an integration bot. */
   isAgent: boolean;
+  /** Only a Catalyst app actor — the one whose question is being answered. This,
+   *  not `isAgent`, is what the ask derivation keys on, so integration plumbing
+   *  can never masquerade as the agent's question. */
+  isCatalystAgent: boolean;
+  /** GitHub/Linear plumbing. Rendered for context; never an ask candidate. */
+  isIntegration: boolean;
   authorName: string;
   authorAvatarUrl: string | null;
   /** Epoch ms, or null when the replica carried no honest timestamp. */

--- a/plugins/dev/scripts/orch-monitor/lib/linear-thread.mjs
+++ b/plugins/dev/scripts/orch-monitor/lib/linear-thread.mjs
@@ -88,17 +88,36 @@ export function normalizeComment(row, { botUserIds = new Set() } = {}) {
   const id = row.id != null ? String(row.id) : null;
   if (id == null) return null;
   const authorId = row.author_id != null ? String(row.author_id) : null;
-  const isBot =
-    row.is_bot === 1 || row.is_bot === true || (authorId != null && botUserIds.has(authorId));
+
+  // THREE actor classes, not two. An earlier cut collapsed these to a boolean and
+  // it produced a visibly wrong ask: GitHub's "this thread is synced to a
+  // corresponding GitHub issue" notice was classed as the AGENT, so it became the
+  // derived ask summary — the inbox told the operator that a sync notice was the
+  // question they needed to answer.
+  //
+  //   integration — GitHub / Linear plumbing (is_bot=1, null author_id). Shown in
+  //                 the thread for context, but it never speaks FOR the agent and
+  //                 is never an ask candidate.
+  //   agent       — a Catalyst app actor (a configured botUserId). The one whose
+  //                 question the operator is actually answering.
+  //   human       — everyone else, including the operator.
+  const isIntegration = (row.is_bot === 1 || row.is_bot === true) && authorId == null;
+  const isCatalystAgent = authorId != null && botUserIds.has(authorId);
+
   return {
     id,
     body,
-    // The agent/human split the UI renders visibly distinct (§2).
-    isAgent: isBot,
+    // The agent/human split the UI renders visibly distinct (§2). An integration
+    // comment counts as non-human for styling (the operator didn't write it) …
+    isAgent: isCatalystAgent || isIntegration,
+    // … but `isCatalystAgent` is the narrow signal the ask derivation uses, so
+    // plumbing chatter can never masquerade as the agent's question.
+    isCatalystAgent,
+    isIntegration,
     authorName:
       typeof row.author_name === "string" && row.author_name !== ""
         ? row.author_name
-        : isBot
+        : isCatalystAgent || isIntegration
           ? "agent"
           : "you",
     authorAvatarUrl:
@@ -215,7 +234,11 @@ export async function readTicketThread(
     // The thread is already newest-first, so these stay newest-first too. The full
     // ORDERED list is surfaced (not just the newest) because the ask derivation has
     // to skip content-free escalation notices — see inbox-ask.mjs::pickAskComment.
-    const agentComments = comments.filter((c) => c.isAgent).map((c) => c.body);
+    //
+    // Filtered on `isCatalystAgent`, NOT `isAgent`: integration plumbing (a GitHub
+    // sync notice, a Linear automation note) is not the agent asking anything, and
+    // letting it into this list makes it the derived ask.
+    const agentComments = comments.filter((c) => c.isCatalystAgent).map((c) => c.body);
 
     return {
       ticket,

--- a/plugins/dev/scripts/orch-monitor/lib/linear-thread.mjs
+++ b/plugins/dev/scripts/orch-monitor/lib/linear-thread.mjs
@@ -1,0 +1,240 @@
+// linear-thread.mjs — the parked ticket's conversation, read from the REPLICA
+// (CTL-1569 §2 / §3). Zero Linear API calls, by construction.
+//
+// WHY THE REPLICA IS NON-NEGOTIABLE HERE: the inbox renders a thread per selected
+// row, and the operator clicks through rows quickly. A per-row Linear read would
+// put an API call on a hover-speed path against a SHARED, rate-limited fleet quota
+// (the fleet had an active 429 problem the week this shipped). The replica
+// (`~/catalyst/catalyst-replica.db`) already mirrors every comment in real time —
+// `comments(id, issue_id, body, updated_at, created_at, removed_at, author_id,
+// author_name, author_avatar_url, is_bot, parent_id)` — so one indexed local SELECT
+// serves the whole thread at sub-ms cost. (The agent/human split §2 requires needs
+// MORE than the `is_bot` column, though — see normalizeComment.)
+//
+// NEWEST FIRST (§2, deliberate and load-bearing): the agent's question is almost
+// always the newest comment and the operator's prior reply the one before it.
+// Chronological order buries both under history the operator has already read, so
+// this module returns reverse-chronological and the UI renders in that order.
+//
+// FAIL-OPEN, ALWAYS: the inbox must never break or hang because the replica is
+// absent, locked, mid-migration, or on a node that doesn't run the sync writer.
+// Every failure degrades to an EMPTY thread (`available:false`), never a throw —
+// the row still renders, still links to Linear, and still accepts a reply. An
+// empty thread and an unavailable thread are reported DISTINCTLY so the UI can say
+// "no comments yet" vs stay silent about a source it couldn't read.
+
+import { existsSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+// `bun:sqlite` is reached through a COMPUTED specifier for the same reason
+// linear-cache-reader.mjs does it for replica-read.mjs: a static specifier would
+// let esbuild pull sqlite into a browser bundle through the shared module graph.
+// We open our own read-only handle rather than borrowing execution-core's
+// createReplicaReader — that reader exposes a fixed set of dispatch-path queries
+// (terminal lookup / titles / freshness) and no general query seam, so reusing it
+// would mean widening a correctness-path module for a display read.
+const SQLITE_MODULE = ["bun", "sqlite"].join(":");
+
+const HOME = homedir();
+
+/** Default replica path, honoring the same env overrides as the rest of the tree. */
+export function defaultReplicaDbPath() {
+  if (process.env.CATALYST_REPLICA_DB) return process.env.CATALYST_REPLICA_DB;
+  return join(process.env.CATALYST_DIR || join(HOME, "catalyst"), "catalyst-replica.db");
+}
+
+/** How many comments the pane shows by default — "the last few" (§2), not the
+ *  whole history. Deep history lives in Linear, one click away. */
+export const DEFAULT_THREAD_LIMIT = 8;
+
+/** Bodies longer than this are marked `truncated` so the UI can clamp them with
+ *  expand-in-place (§2) instead of letting one wall of agent prose own the pane.
+ *  The FULL body is still sent — expansion must not need a second round trip. */
+const LONG_BODY_CHARS = 600;
+
+/**
+ * Normalize one replica comment row into the closed shape the UI consumes.
+ *
+ * ── the agent/human split is NOT just `is_bot` ────────────────────────────────
+ * CTL-1569 assumed `is_bot` "gives the agent/human split for free". Verified
+ * against the live replica, it does not — `is_bot = 1` is set only for INTEGRATION
+ * authors, which have a null `author_id`:
+ *
+ *     author_id                             author_name             is_bot   n
+ *     2edb25eb-…  (the human operator)      Ryan Rozich             0     3131
+ *     null                                  GitHub                  1     1420
+ *     7b5480e0-…  (the WORKER app actor)    Catalyst                0      410
+ *     null                                  Linear                  1      126
+ *     ff78d890-…  (the ORCHESTRATOR actor)  Catalyst Orchestrator    0        4
+ *
+ * Linear models an app actor as a USER, so the Catalyst agents' own comments —
+ * precisely the ones whose question the operator is answering — arrive with
+ * `is_bot = 0`. Trusting `is_bot` alone renders every agent comment as if the
+ * operator wrote it, and makes the "newest agent comment" ask fallback select the
+ * operator's own words.
+ *
+ * So the split is `is_bot` OR a known app-actor `author_id`. That is the SAME
+ * discriminator the daemon's self-echo guard uses (`catalyst.…bot.*.botUserId`),
+ * which keeps one definition of "the agent" across the system.
+ *
+ * A null/unknown `is_bot` with an unrecognized author falls to HUMAN — the
+ * conservative direction for a display split, and consistent with CTL-1567's own
+ * fail-open posture toward unidentified authors.
+ */
+export function normalizeComment(row, { botUserIds = new Set() } = {}) {
+  if (!row || typeof row !== "object") return null;
+  const body = typeof row.body === "string" ? row.body : "";
+  const id = row.id != null ? String(row.id) : null;
+  if (id == null) return null;
+  const authorId = row.author_id != null ? String(row.author_id) : null;
+  const isBot =
+    row.is_bot === 1 || row.is_bot === true || (authorId != null && botUserIds.has(authorId));
+  return {
+    id,
+    body,
+    // The agent/human split the UI renders visibly distinct (§2).
+    isAgent: isBot,
+    authorName:
+      typeof row.author_name === "string" && row.author_name !== ""
+        ? row.author_name
+        : isBot
+          ? "agent"
+          : "you",
+    authorAvatarUrl:
+      typeof row.author_avatar_url === "string" && row.author_avatar_url !== ""
+        ? row.author_avatar_url
+        : null,
+    // Epoch ms as stored by the sync writer; null when absent (the UI omits the
+    // timestamp rather than fabricating one).
+    at: Number.isFinite(row.updated_at)
+      ? row.updated_at
+      : Number.isFinite(row.created_at)
+        ? row.created_at
+        : null,
+    parentId: row.parent_id != null ? String(row.parent_id) : null,
+    truncated: body.length > LONG_BODY_CHARS,
+  };
+}
+
+/** The SQL. Newest-first, tombstones excluded, bounded by LIMIT. Joins through
+ *  `issues.identifier` so callers pass the human key ("CTL-1569") and never need
+ *  the internal issue UUID. */
+const THREAD_SQL = `
+  SELECT c.id, c.body, c.updated_at, c.created_at,
+         c.author_id, c.author_name, c.author_avatar_url, c.is_bot, c.parent_id
+    FROM comments c
+    JOIN issues i ON i.id = c.issue_id
+   WHERE i.identifier = ?
+     AND i.removed_at IS NULL
+     AND c.removed_at IS NULL
+   ORDER BY COALESCE(c.updated_at, c.created_at) DESC, c.id DESC
+   LIMIT ?
+`;
+
+/** The ticket's own Linear URL + title, for the "link straight to the ticket"
+ *  requirement (§3). Read from the same local DB in the same open. */
+const ISSUE_SQL = `
+  SELECT identifier, title, url FROM issues
+   WHERE identifier = ? AND removed_at IS NULL LIMIT 1
+`;
+
+/**
+ * Read a ticket's thread (newest first) + its Linear URL from the replica.
+ *
+ * Returns, ALWAYS (never throws):
+ *   {
+ *     ticket, available: boolean, comments: [...], url: string|null,
+ *     title: string|null, lastAgentComment: string|null, reason: string|null
+ *   }
+ *
+ * `available:false` + `reason` means the replica could not be read — the caller
+ * renders the thread section silently absent, which is honest, instead of showing
+ * "no comments" for a source it never reached. `available:true` with an empty
+ * `comments` array is the genuine "nothing said yet" case.
+ *
+ * `lastAgentComment` is lifted here because it is the ask-derivation fallback
+ * input (inbox-ask.mjs::askFromComment) and this is the one place that already has
+ * the ordered thread — re-scanning it downstream would duplicate the ordering rule.
+ *
+ * `openDb` is injectable so the whole contract is unit-tested with no real DB.
+ */
+export async function readTicketThread(
+  ticket,
+  {
+    dbPath = defaultReplicaDbPath(),
+    limit = DEFAULT_THREAD_LIMIT,
+    openDb = null,
+    /** App-actor user ids whose comments are the AGENT's — see normalizeComment.
+     *  Defaults to empty, which degrades to `is_bot`-only classification; the
+     *  composition layer passes the configured set. */
+    botUserIds = new Set(),
+  } = {},
+) {
+  const empty = (reason) => ({
+    ticket,
+    available: false,
+    comments: [],
+    url: null,
+    title: null,
+    agentComments: [],
+    lastAgentComment: null,
+    reason,
+  });
+
+  if (typeof ticket !== "string" || ticket.trim() === "") return empty("no-ticket");
+
+  // File-presence gate (skipped when a test injects a reader — the fake IS the DB).
+  if (!openDb) {
+    try {
+      if (!existsSync(dbPath)) return empty("replica-absent");
+    } catch {
+      return empty("replica-unreadable");
+    }
+  }
+
+  let db = null;
+  try {
+    if (openDb) {
+      db = openDb({ dbPath });
+    } else {
+      const { Database } = await import(SQLITE_MODULE);
+      db = new Database(dbPath, { readonly: true });
+      // Readonly + WAL: writers never block readers, but a checkpoint can hold the
+      // lock briefly — wait a beat rather than failing the read (same posture and
+      // timeout as execution-core/replica-read.mjs).
+      db.run("PRAGMA busy_timeout = 250");
+    }
+    const bounded = Number.isFinite(limit) && limit > 0 ? Math.floor(limit) : DEFAULT_THREAD_LIMIT;
+    const rows = db.prepare(THREAD_SQL).all(ticket, bounded) ?? [];
+    const issue = db.prepare(ISSUE_SQL).get(ticket) ?? null;
+
+    const comments = (Array.isArray(rows) ? rows : [])
+      .map((r) => normalizeComment(r, { botUserIds }))
+      .filter(Boolean);
+    // The thread is already newest-first, so these stay newest-first too. The full
+    // ORDERED list is surfaced (not just the newest) because the ask derivation has
+    // to skip content-free escalation notices — see inbox-ask.mjs::pickAskComment.
+    const agentComments = comments.filter((c) => c.isAgent).map((c) => c.body);
+
+    return {
+      ticket,
+      available: true,
+      comments,
+      url: typeof issue?.url === "string" && issue.url !== "" ? issue.url : null,
+      title: typeof issue?.title === "string" && issue.title !== "" ? issue.title : null,
+      agentComments,
+      lastAgentComment: agentComments[0] ?? null,
+      reason: null,
+    };
+  } catch (e) {
+    // Locked / schema drift / import failure → degrade, never throw into a request.
+    return empty(`replica-error: ${e instanceof Error ? e.message : String(e)}`);
+  } finally {
+    try {
+      db?.close?.();
+    } catch {
+      /* already closed */
+    }
+  }
+}

--- a/plugins/dev/scripts/orch-monitor/lib/linear-thread.mjs
+++ b/plugins/dev/scripts/orch-monitor/lib/linear-thread.mjs
@@ -229,7 +229,9 @@ export async function readTicketThread(
     url: null,
     title: null,
     agentComments: [],
+    allAgentComments: [],
     lastAgentComment: null,
+    issueExists: false,
     reason,
   });
 
@@ -281,7 +283,19 @@ export async function readTicketThread(
     // Filtered on `isCatalystAgent`, NOT `isAgent`: integration plumbing (a GitHub
     // sync notice, a Linear automation note) is not the agent asking anything, and
     // letting it into this list makes it the derived ask.
-    const agentComments = scanned.filter((c) => c.isCatalystAgent).map((c) => c.body);
+    // ANSWERED-TURN BOUNDARY. Human turns are filtered out of `agentComments`, so
+    // the ranked candidate pick has no way to tell a question the operator ALREADY
+    // answered from the current one — and class-first ranking would happily promote
+    // an older approval question over a newer blocker, prompting the operator to
+    // re-answer the previous cycle. Only agent comments NEWER than the operator's
+    // most recent reply are live candidates. (If the operator never replied, every
+    // agent comment is live.)
+    const lastHumanIdx = scanned.findIndex((c) => !c.isAgent);
+    const liveAgent = lastHumanIdx === -1 ? scanned : scanned.slice(0, lastHumanIdx);
+    const agentComments = liveAgent.filter((c) => c.isCatalystAgent).map((c) => c.body);
+    // Every agent comment regardless of the boundary — kept for callers that want
+    // history rather than the live ask.
+    const allAgentComments = scanned.filter((c) => c.isCatalystAgent).map((c) => c.body);
 
     return {
       ticket,
@@ -290,7 +304,13 @@ export async function readTicketThread(
       url: typeof issue?.url === "string" && issue.url !== "" ? issue.url : null,
       title: typeof issue?.title === "string" && issue.title !== "" ? issue.title : null,
       agentComments,
+      allAgentComments,
       lastAgentComment: agentComments[0] ?? null,
+      // EXPLICIT existence bit. `url` is an OPTIONAL deep link and can be null on a
+      // real issue row (unpopulated or mid-sync), so using it as the existence
+      // predicate hid the composer on tickets the POST path can resolve perfectly
+      // well by identifier.
+      issueExists: issue != null,
       reason: null,
     };
   } catch (e) {

--- a/plugins/dev/scripts/orch-monitor/lib/linear-thread.mjs
+++ b/plugins/dev/scripts/orch-monitor/lib/linear-thread.mjs
@@ -136,20 +136,47 @@ export function normalizeComment(row, { botUserIds = new Set() } = {}) {
   };
 }
 
-/** The SQL. Newest-first, tombstones excluded, bounded by LIMIT. Joins through
- *  `issues.identifier` so callers pass the human key ("CTL-1569") and never need
- *  the internal issue UUID. */
-const THREAD_SQL = `
-  SELECT c.id, c.body, c.updated_at, c.created_at,
+/**
+ * Build the thread SELECT for the columns this replica ACTUALLY has.
+ *
+ * `comments.created_at` is NOT universal. The committed replica fixture
+ * (execution-core/linear-cli.test.mjs) defines `comments` without it, and any
+ * installation at that schema version behaves the same way. Naming the column
+ * unconditionally makes SQLite raise `no such column: c.created_at`, which
+ * readTicketThread catches as a replica failure — so the whole conversation
+ * surface (thread AND the Linear deep link) silently disappears rather than
+ * degrading. Probing `PRAGMA table_info` is one cheap local call and keeps the
+ * feature working across schema versions.
+ *
+ * Newest-first, tombstones excluded, bounded by LIMIT. Joins through
+ * `issues.identifier` so callers pass the human key and never the issue UUID.
+ */
+export function buildThreadSql({ hasCreatedAt }) {
+  const createdCol = hasCreatedAt ? "c.created_at" : "NULL AS created_at";
+  const order = hasCreatedAt ? "COALESCE(c.updated_at, c.created_at)" : "c.updated_at";
+  return `
+  SELECT c.id, c.body, c.updated_at, ${createdCol},
          c.author_id, c.author_name, c.author_avatar_url, c.is_bot, c.parent_id
     FROM comments c
     JOIN issues i ON i.id = c.issue_id
    WHERE i.identifier = ?
      AND i.removed_at IS NULL
      AND c.removed_at IS NULL
-   ORDER BY COALESCE(c.updated_at, c.created_at) DESC, c.id DESC
+   ORDER BY ${order} DESC, c.id DESC
    LIMIT ?
 `;
+}
+
+/** Does this replica's `comments` table carry `created_at`? Fail-safe: any probe
+ *  problem answers "no", which yields the narrower query that always works. */
+export function commentsHasCreatedAt(db) {
+  try {
+    const cols = db.prepare("PRAGMA table_info(comments)").all() ?? [];
+    return cols.some((c) => c?.name === "created_at");
+  } catch {
+    return false;
+  }
+}
 
 /** The ticket's own Linear URL + title, for the "link straight to the ticket"
  *  requirement (§3). Read from the same local DB in the same open. */
@@ -225,7 +252,8 @@ export async function readTicketThread(
       db.run("PRAGMA busy_timeout = 250");
     }
     const bounded = Number.isFinite(limit) && limit > 0 ? Math.floor(limit) : DEFAULT_THREAD_LIMIT;
-    const rows = db.prepare(THREAD_SQL).all(ticket, bounded) ?? [];
+    const sql = buildThreadSql({ hasCreatedAt: commentsHasCreatedAt(db) });
+    const rows = db.prepare(sql).all(ticket, bounded) ?? [];
     const issue = db.prepare(ISSUE_SQL).get(ticket) ?? null;
 
     const comments = (Array.isArray(rows) ? rows : [])

--- a/plugins/dev/scripts/orch-monitor/lib/linear-thread.mjs
+++ b/plugins/dev/scripts/orch-monitor/lib/linear-thread.mjs
@@ -48,6 +48,11 @@ export function defaultReplicaDbPath() {
  *  whole history. Deep history lives in Linear, one click away. */
 export const DEFAULT_THREAD_LIMIT = 8;
 
+/** How deep to scan for an ASK candidate, independent of how many comments are
+ *  DISPLAYED. Still bounded (one indexed local query), but wide enough that a run
+ *  of human replies or GitHub chatter cannot hide the agent's question. */
+export const ASK_SCAN_LIMIT = 40;
+
 /** Bodies longer than this are marked `truncated` so the UI can clamp them with
  *  expand-in-place (§2) instead of letting one wall of agent prose own the pane.
  *  The FULL body is still sent — expansion must not need a second round trip. */
@@ -253,10 +258,20 @@ export async function readTicketThread(
     }
     const bounded = Number.isFinite(limit) && limit > 0 ? Math.floor(limit) : DEFAULT_THREAD_LIMIT;
     const sql = buildThreadSql({ hasCreatedAt: commentsHasCreatedAt(db) });
-    const rows = db.prepare(sql).all(ticket, bounded) ?? [];
+    // Scan a WIDER window than we display. The display limit is "the last few"
+    // (§2), but the ask fallback needs the newest CATALYST-AGENT comment — and on a
+    // ticket whose recent entries are all human replies or integration chatter, the
+    // agent's question sits just outside the display window. Limiting first would
+    // report "no ask" while the replica plainly holds one.
+    const scanRows = db.prepare(sql).all(ticket, Math.max(bounded, ASK_SCAN_LIMIT)) ?? [];
+    const rows = scanRows.slice(0, bounded);
     const issue = db.prepare(ISSUE_SQL).get(ticket) ?? null;
 
     const comments = (Array.isArray(rows) ? rows : [])
+      .map((r) => normalizeComment(r, { botUserIds }))
+      .filter(Boolean);
+    // Ask candidates come from the WIDE scan, not the displayed slice.
+    const scanned = (Array.isArray(scanRows) ? scanRows : [])
       .map((r) => normalizeComment(r, { botUserIds }))
       .filter(Boolean);
     // The thread is already newest-first, so these stay newest-first too. The full
@@ -266,7 +281,7 @@ export async function readTicketThread(
     // Filtered on `isCatalystAgent`, NOT `isAgent`: integration plumbing (a GitHub
     // sync notice, a Linear automation note) is not the agent asking anything, and
     // letting it into this list makes it the derived ask.
-    const agentComments = comments.filter((c) => c.isCatalystAgent).map((c) => c.body);
+    const agentComments = scanned.filter((c) => c.isCatalystAgent).map((c) => c.body);
 
     return {
       ticket,

--- a/plugins/dev/scripts/orch-monitor/lib/reply-ticket.d.mts
+++ b/plugins/dev/scripts/orch-monitor/lib/reply-ticket.d.mts
@@ -1,0 +1,50 @@
+// Type declarations for reply-ticket.mjs (CTL-1569 §4) — the inbox's conversational
+// WRITE. A SIBLING of respond-ticket.mjs, not a replacement: /respond never touches
+// Linear and hard-requires a held run, and the tickets this surface exists for are
+// parked with no worker dir at all. Lets the strict TS server import it without a
+// TS7016 implicit-any error. Keep in sync with reply-ticket.mjs.
+
+import type { PostCommentResult } from "./linear-comment.d.mts";
+import type { HeldRun } from "./respond-ticket.d.mts";
+
+/**
+ * Discriminated outcome; the route maps `status` to an HTTP code. `replied` is the
+ * ONLY success — every other value is a non-2xx so the UI RESTORES the row (§4:
+ * "a failed post … must restore the row — never silently lose the item").
+ *
+ * - replied      → 200 (a real, human-authored comment is live; CTL-1567 clears
+ *                  `needs-human` via the webhook within seconds)
+ * - empty_body   → 400 (nothing typed; never reached Linear)
+ * - not_found    → 404 (no such Linear issue — e.g. a synthesized orphan-PR row)
+ * - bot_identity → 502 (REFUSED before posting: this node's token is an app actor,
+ *                  so the reply could not have cleared the ask)
+ * - no_token     → 502 (no Linear credential on this node)
+ * - error        → 502 (transport / API failure)
+ */
+export type ReplyTicketResult =
+  | {
+      status: "replied";
+      ticket: string;
+      commentId: string;
+      author: { id: string; name: string | null } | null;
+      /** The locally-held phase, when one happens to exist. Context only — it is
+       *  deliberately NOT a precondition. */
+      phase: string | null;
+    }
+  | ({ ticket: string } & Exclude<PostCommentResult, { status: "posted" }>);
+
+export function replyToTicket(
+  args: { ticket: string; body: unknown },
+  opts?: {
+    post?: (
+      args: { ticket: string; body: string },
+      opts?: { fetchImpl?: typeof fetch; env?: Record<string, string | undefined>; config?: unknown },
+    ) => Promise<PostCommentResult>;
+    findHeld?: (ticket: string) => HeldRun | null;
+    record?: (args: { ticket: string; phase: string; response: unknown }) => unknown;
+    clearMarker?: (args: { ticket: string }) => unknown;
+    env?: Record<string, string | undefined>;
+    config?: unknown;
+    fetchImpl?: typeof fetch;
+  },
+): Promise<ReplyTicketResult>;

--- a/plugins/dev/scripts/orch-monitor/lib/reply-ticket.d.mts
+++ b/plugins/dev/scripts/orch-monitor/lib/reply-ticket.d.mts
@@ -38,13 +38,21 @@ export function replyToTicket(
   opts?: {
     post?: (
       args: { ticket: string; body: string },
-      opts?: { fetchImpl?: typeof fetch; env?: Record<string, string | undefined>; config?: unknown },
+      opts?: {
+        fetchImpl?: typeof fetch;
+        env?: Record<string, string | undefined>;
+        config?: unknown;
+        projectConfig?: unknown;
+      },
     ) => Promise<PostCommentResult>;
     findHeld?: (ticket: string) => HeldRun | null;
     record?: (args: { ticket: string; phase: string; response: unknown }) => unknown;
     clearMarker?: (args: { ticket: string }) => unknown;
     env?: Record<string, string | undefined>;
     config?: unknown;
+    /** Layer-2 project config (personal `linear.apiToken`) — the launchd path's
+     *  only credential source. */
+    projectConfig?: unknown;
     fetchImpl?: typeof fetch;
   },
 ): Promise<ReplyTicketResult>;

--- a/plugins/dev/scripts/orch-monitor/lib/reply-ticket.mjs
+++ b/plugins/dev/scripts/orch-monitor/lib/reply-ticket.mjs
@@ -1,0 +1,122 @@
+// reply-ticket.mjs — the inbox's conversational WRITE: post the operator's reply
+// to Linear as a real, human-authored comment (CTL-1569 §4).
+//
+// ── why this is a SIBLING of respond-ticket.mjs, not an edit to it ────────────
+// The existing BFF12 route (`POST /api/ticket/<t>/respond`, respond-ticket.mjs) is
+// a different verb with two properties that make it unusable for this surface:
+//
+//   1. It NEVER TOUCHES LINEAR. It records a local `.respond-<phase>.json`, clears
+//      the local once-marker, and appends a SYNTHETIC `linear.comment.created`
+//      event to the unified log with `authorId: null`. That synthetic event is now
+//      actively wrong as a resolution mechanism: CTL-1567's provenance gate
+//      requires a POSITIVELY-IDENTIFIED HUMAN author, so a null-author event is
+//      exactly what it declines to act on. The reply must be a REAL comment.
+//   2. It hard-requires a HELD RUN — `findHeldRun` scans the ticket's worker dir
+//      for a `needs-input`/`stalled` phase signal and returns 404 `not_held` when
+//      there is none. But the case this feature exists for is a ticket parked with
+//      NO WORKER DIR AT ALL (verified live: the host that cleared OTL-63 in four
+//      seconds had no worker dir). Gating the reply on a held run would 404 exactly
+//      the rows the operator most needs to answer.
+//
+// So this module owns the conversational path and leaves BFF12's "record + resume a
+// locally-held worker" semantics untouched for the callers that want them.
+//
+// ── what actually resolves the ask ───────────────────────────────────────────
+// The Linear comment IS the resolution. Once it lands, Linear's webhook →
+// orch-monitor's Linear handler → a `linear.comment.created` event carrying the
+// REAL human author → the daemon's comment-wake path clears `needs-human`
+// unconditionally and first (CTL-1567). Measured end-to-end at ~4 seconds.
+//
+// This module therefore does NOT synthesize a resume event. Doing so would be both
+// redundant (the genuine webhook event is coming) and hazardous (two wake events
+// for one human reply invites a double-dispatch). We post the comment and let the
+// verified path do its job.
+//
+// ── local best-effort hygiene ────────────────────────────────────────────────
+// After a successful post we clear the local `needs-human` once-marker, re-arming
+// the daemon's labelOnce guard. This is the SAFE half of the known CTL-1552
+// half-mutation: clearing the marker without the label lets the daemon re-apply if
+// the ticket is genuinely still held, whereas clearing the label without the marker
+// would wedge the guard. It is strictly best-effort — a ticket with no worker dir
+// has no marker, which is not an error, and never affects the result.
+
+import { clearNeedsHumanMarker, findHeldRun, recordResponse } from "./respond-ticket.mjs";
+import { postOperatorComment } from "./linear-comment.mjs";
+
+/**
+ * Post the operator's inbox reply to Linear.
+ *
+ * Discriminated result. The ONLY success is `replied`; the route maps every other
+ * outcome to a non-2xx so the UI RESTORES the row (§4: "a failed post … must
+ * restore the row — never silently lose the item"):
+ *
+ *   { status: "replied", ticket, commentId, author, phase }
+ *        → the comment is live and human-authored. `needs-human` clears via the
+ *          webhook within seconds; the UI marks the row resolved optimistically and
+ *          reconciles against the label on the next frame.
+ *   { status: "empty_body" }        → 400: nothing typed.
+ *   { status: "bot_identity", … }   → 502: REFUSED before posting — this node's
+ *          Linear token is an app actor, so the reply could not have cleared the
+ *          ask. Loud, because the alternative is a silently inert feature.
+ *   { status: "no_token" }          → 502: no Linear credential on this node.
+ *   { status: "not_found", ticket }  → 404: no such Linear issue (e.g. a
+ *          synthesized orphan-PR row, which the UI should not offer a reply box for
+ *          in the first place — this is the server-side backstop).
+ *   { status: "error", message }    → 502: transport / API failure.
+ *
+ * `phase` is reported when a held run happens to exist locally (useful context for
+ * the caller/log) and is null otherwise — it is deliberately NOT a precondition.
+ */
+export async function replyToTicket(
+  { ticket, body },
+  {
+    post = postOperatorComment,
+    findHeld = findHeldRun,
+    record = recordResponse,
+    clearMarker = clearNeedsHumanMarker,
+    env = process.env,
+    config = null,
+    fetchImpl = fetch,
+  } = {},
+) {
+  const text = typeof body === "string" ? body.trim() : "";
+  if (text === "") return { status: "empty_body", ticket };
+  if (typeof ticket !== "string" || ticket.trim() === "") {
+    return { status: "not_found", ticket, message: "no ticket" };
+  }
+
+  // Post FIRST. Linear is the system of record for the conversation, and the local
+  // bookkeeping below is meaningless if the comment never landed — so nothing local
+  // is mutated until the comment is confirmed live.
+  const posted = await post({ ticket, body: text }, { fetchImpl, env, config });
+  if (posted.status !== "posted") {
+    // Pass the refusal/failure through verbatim; the route maps it and the row is
+    // restored. No local state was touched.
+    return { ...posted, ticket };
+  }
+
+  // ── post-success local hygiene (best-effort, never fails the reply) ─────────
+  let phase = null;
+  try {
+    const held = findHeld(ticket);
+    phase = held?.phase ?? null;
+    // Record the operator's words next to the phase signal they answer, when there
+    // IS a phase signal. Purely a local breadcrumb — Linear holds the real record.
+    if (phase != null) record({ ticket, phase, response: text });
+  } catch {
+    /* no worker dir / unreadable signals → nothing to record; not an error */
+  }
+  try {
+    clearMarker({ ticket });
+  } catch {
+    /* no marker → the daemon's guard is already un-armed; not an error */
+  }
+
+  return {
+    status: "replied",
+    ticket,
+    commentId: posted.commentId,
+    author: posted.author ?? null,
+    phase,
+  };
+}

--- a/plugins/dev/scripts/orch-monitor/lib/reply-ticket.mjs
+++ b/plugins/dev/scripts/orch-monitor/lib/reply-ticket.mjs
@@ -76,6 +76,10 @@ export async function replyToTicket(
     clearMarker = clearNeedsHumanMarker,
     env = process.env,
     config = null,
+    /** Layer-2 project config — carries the personal `linear.apiToken` that is the
+     *  ONLY credential source on the launchd path (catalyst-monitor.sh exports
+     *  none). Without it the reply is inert there. */
+    projectConfig = null,
     fetchImpl = fetch,
   } = {},
 ) {
@@ -88,7 +92,10 @@ export async function replyToTicket(
   // Post FIRST. Linear is the system of record for the conversation, and the local
   // bookkeeping below is meaningless if the comment never landed — so nothing local
   // is mutated until the comment is confirmed live.
-  const posted = await post({ ticket, body: text }, { fetchImpl, env, config });
+  // The VERBATIM body is posted (the poster strips only trailing whitespace) —
+  // `text` is used above solely to validate emptiness, because trimming leading
+  // whitespace would rewrite an indented Markdown code block into prose.
+  const posted = await post({ ticket, body }, { fetchImpl, env, config, projectConfig });
   if (posted.status !== "posted") {
     // Pass the refusal/failure through verbatim; the route maps it and the row is
     // restored. No local state was touched.

--- a/plugins/dev/scripts/orch-monitor/server.ts
+++ b/plugins/dev/scripts/orch-monitor/server.ts
@@ -130,7 +130,11 @@ import {
 // via CTL-1567). The reply path is a SIBLING of /respond, not a replacement: see
 // lib/reply-ticket.mjs for why /respond's synthetic null-author event and its
 // hard held-run requirement make it unusable for this surface.
-import { getConversation, loadGlobalConfig, loadProjectConfig } from "./lib/inbox-conversation.mjs";
+import {
+  getConversation,
+  loadGlobalConfig,
+  loadProjectConfig,
+} from "./lib/inbox-conversation.mjs";
 import { replyToTicket } from "./lib/reply-ticket.mjs";
 /** Canonical ticket key for the conversation routes: a team prefix that may carry
  *  digits/underscores (`OPS_2-17`), then `-<number>`. Anchored, and containing no
@@ -3674,6 +3678,11 @@ export function createServer(opts: CreateServerOptions): BunServer {
           }
           const limitParam = Number(url.searchParams.get("limit"));
           const conversation = await getConversation(ticket, {
+            // Pass the SERVER-resolved Layer-1 path (--config / CATALYST_CONFIG_PATH).
+            // A cwd-relative fallback misses under launchd, which sets no working
+            // directory — and the legacy `catalyst.monitor.linear.botUserId` lives in
+            // that file, so missing it breaks the agent/human split on legacy hosts.
+            repoConfigPath: monitorConfigPath,
             ...(Number.isFinite(limitParam) && limitParam > 0
               ? { limit: Math.min(Math.floor(limitParam), 50) }
               : {}),
@@ -3741,7 +3750,11 @@ export function createServer(opts: CreateServerOptions): BunServer {
           const text = typeof body.body === "string" ? body.body : "";
           const [globalConfig, projectConfig] = await Promise.all([
             loadGlobalConfig(),
-            loadProjectConfig(),
+            // Explicit resolved path — NOT process.cwd(). The launchd wrapper sets
+            // neither a working directory nor CATALYST_PROJECT_KEY, so a
+            // cwd-relative lookup leaves the Layer-2 token unresolved and every
+            // reply returns `no_token` on the persistent launch path.
+            loadProjectConfig({ repoConfigPath: monitorConfigPath }),
           ]);
           const result = await replyToTicket(
             { ticket, body: text },

--- a/plugins/dev/scripts/orch-monitor/server.ts
+++ b/plugins/dev/scripts/orch-monitor/server.ts
@@ -123,6 +123,15 @@ import {
   respondTicket,
   type RespondTicketResult,
 } from "./lib/respond-ticket.mjs";
+// CTL-1569: the inbox conversation surface. Two routes, deliberately split by
+// posture — GET /thread is a pure REPLICA read (zero Linear API calls, so it is
+// safe on a hover-speed path), POST /reply is the one write that posts a REAL,
+// human-authored Linear comment (the mechanism that actually clears `needs-human`
+// via CTL-1567). The reply path is a SIBLING of /respond, not a replacement: see
+// lib/reply-ticket.mjs for why /respond's synthetic null-author event and its
+// hard held-run requirement make it unusable for this surface.
+import { getConversation, loadGlobalConfig } from "./lib/inbox-conversation.mjs";
+import { replyToTicket } from "./lib/reply-ticket.mjs";
 import { queryHistory, queryStats, compareSessions } from "./lib/history-store";
 import {
   listArchivedOrchestrators,
@@ -3634,6 +3643,107 @@ export function createServer(opts: CreateServerOptions): BunServer {
               // Response recorded + marker cleared + resume event emitted; the UI
               // marks the row `resuming` and arms its optimistic-rollback timer.
               return Response.json(result, { status: 200 });
+          }
+        }
+
+        // ── CTL-1569: the inbox conversation surface ───────────────────────────
+        //
+        // GET /api/ticket/<ticket>/thread — the ask summary + the last few comments
+        // (newest first) + the ticket's Linear deep link. A pure REPLICA read: it
+        // makes ZERO Linear API calls, which is what makes it safe to fetch on every
+        // row selection against a shared, rate-limited fleet quota. Fails OPEN —
+        // an absent/locked replica yields an unavailable thread, never a 5xx.
+        const threadMatch = url.pathname.match(/^\/api\/ticket\/([^/]+)\/thread$/);
+        if (threadMatch && req.method === "GET") {
+          let ticket: string;
+          try {
+            ticket = decodeURIComponent(threadMatch[1]);
+          } catch {
+            return new Response("Bad Request", { status: 400 });
+          }
+          if (!/^[A-Za-z]+-\d+$/.test(ticket)) {
+            return new Response("Bad Request", { status: 400 });
+          }
+          const limitParam = Number(url.searchParams.get("limit"));
+          const conversation = await getConversation(ticket, {
+            ...(Number.isFinite(limitParam) && limitParam > 0
+              ? { limit: Math.min(Math.floor(limitParam), 50) }
+              : {}),
+          });
+          return Response.json(conversation, { status: 200 });
+        }
+
+        // POST /api/ticket/<ticket>/reply — post the operator's reply to Linear as a
+        // REAL human-authored comment. This is the resolution mechanism: once the
+        // comment lands, Linear's webhook drives the daemon's comment-wake, which
+        // clears `needs-human` unconditionally and first (CTL-1567, ~4s end to end).
+        //
+        // Deliberately UNLIKE /respond:
+        //   • NO typed-confirm. The typed gate exists for destructive verbs (stop a
+        //     worker); forcing an operator to retype the ticket id to send a chat
+        //     reply would defeat the entire surface. The reply text IS the intent.
+        //   • NO held-run requirement. The tickets that most need answering are
+        //     parked with no worker dir at all, and /respond 404s exactly those.
+        //
+        // EVERY non-2xx here must cause the UI to RESTORE the row (§4) — the row is
+        // never silently lost. `bot_identity` is the loud refusal that prevents the
+        // whole feature from shipping inert: an app-actor comment is ignored by
+        // CTL-1567, so it is refused BEFORE posting rather than faking success.
+        const replyMatch = url.pathname.match(/^\/api\/ticket\/([^/]+)\/reply$/);
+        if (replyMatch && req.method === "POST") {
+          let ticket: string;
+          try {
+            ticket = decodeURIComponent(replyMatch[1]);
+          } catch {
+            return new Response("Bad Request", { status: 400 });
+          }
+          if (!/^[A-Za-z]+-\d+$/.test(ticket)) {
+            return new Response("Bad Request", { status: 400 });
+          }
+          let body: Record<string, unknown>;
+          try {
+            body = (await req.json()) as Record<string, unknown>;
+          } catch {
+            return Response.json({ error: "Invalid JSON body" }, { status: 400 });
+          }
+          const text = typeof body.body === "string" ? body.body : "";
+          const result = await replyToTicket(
+            { ticket, body: text },
+            { config: await loadGlobalConfig() },
+          );
+          switch (result.status) {
+            case "replied":
+              // The comment is live and human-authored. The UI marks the row
+              // resolved optimistically and reconciles against the label.
+              return Response.json(result, { status: 200 });
+            case "empty_body":
+              return Response.json(
+                { ...result, error: "an empty reply was not sent" },
+                { status: 400 },
+              );
+            case "not_found":
+              return Response.json(
+                {
+                  ...result,
+                  error: `no Linear issue ${ticket} to reply to`,
+                },
+                { status: 404 },
+              );
+            case "bot_identity":
+            case "no_token":
+            case "error":
+            default:
+              // 502: the write did NOT act. Surfaced verbatim so the operator sees
+              // WHY (especially the app-actor refusal) and the row comes back.
+              return Response.json(
+                {
+                  ...result,
+                  error:
+                    (result as { message?: string }).message ??
+                    "reply was not posted to Linear",
+                },
+                { status: 502 },
+              );
           }
         }
 

--- a/plugins/dev/scripts/orch-monitor/server.ts
+++ b/plugins/dev/scripts/orch-monitor/server.ts
@@ -130,8 +130,12 @@ import {
 // via CTL-1567). The reply path is a SIBLING of /respond, not a replacement: see
 // lib/reply-ticket.mjs for why /respond's synthetic null-author event and its
 // hard held-run requirement make it unusable for this surface.
-import { getConversation, loadGlobalConfig } from "./lib/inbox-conversation.mjs";
+import { getConversation, loadGlobalConfig, loadProjectConfig } from "./lib/inbox-conversation.mjs";
 import { replyToTicket } from "./lib/reply-ticket.mjs";
+/** Canonical ticket key for the conversation routes: a team prefix that may carry
+ *  digits/underscores (`OPS_2-17`), then `-<number>`. Anchored, and containing no
+ *  path characters, so it cannot express a traversal. */
+const CONVERSATION_TICKET_RE = /^[A-Za-z][A-Za-z0-9_]*-\d+$/;
 import { queryHistory, queryStats, compareSessions } from "./lib/history-store";
 import {
   listArchivedOrchestrators,
@@ -3661,7 +3665,11 @@ export function createServer(opts: CreateServerOptions): BunServer {
           } catch {
             return new Response("Bad Request", { status: 400 });
           }
-          if (!/^[A-Za-z]+-\d+$/.test(ticket)) {
+          // CTL-1569: the canonical ticket key allows digits/underscores in the
+          // team prefix (e.g. `OPS_2-17`). A letters-only predicate 400s the entire
+          // conversation surface for such teams. Still anchored + no path
+          // characters, so traversal remains impossible.
+          if (!CONVERSATION_TICKET_RE.test(ticket)) {
             return new Response("Bad Request", { status: 400 });
           }
           const limitParam = Number(url.searchParams.get("limit"));
@@ -3697,8 +3705,32 @@ export function createServer(opts: CreateServerOptions): BunServer {
           } catch {
             return new Response("Bad Request", { status: 400 });
           }
-          if (!/^[A-Za-z]+-\d+$/.test(ticket)) {
+          if (!CONVERSATION_TICKET_RE.test(ticket)) {
             return new Response("Bad Request", { status: 400 });
+          }
+          // CROSS-ORIGIN GUARD. This route posts operator-authored text to Linear,
+          // and the server binds 0.0.0.0 with no auth. `req.json()` parses a body
+          // regardless of Content-Type, so a plain `text/plain` form POST from any
+          // page the operator visits would otherwise be a valid request — the
+          // browser could not read the response, but the comment would still be
+          // posted as them to any guessable ticket. A same-origin check closes that:
+          // browsers always attach `Origin` to a cross-origin POST, while
+          // same-origin fetches from our own UI match the Host. Non-browser clients
+          // (curl, tests) send no Origin and are unaffected.
+          const origin = req.headers.get("origin");
+          if (origin != null && origin !== "") {
+            let sameOrigin = false;
+            try {
+              sameOrigin = new URL(origin).host === (req.headers.get("host") ?? url.host);
+            } catch {
+              sameOrigin = false;
+            }
+            if (!sameOrigin) {
+              return Response.json(
+                { status: "forbidden", error: "cross-origin reply rejected" },
+                { status: 403 },
+              );
+            }
           }
           let body: Record<string, unknown>;
           try {
@@ -3707,9 +3739,13 @@ export function createServer(opts: CreateServerOptions): BunServer {
             return Response.json({ error: "Invalid JSON body" }, { status: 400 });
           }
           const text = typeof body.body === "string" ? body.body : "";
+          const [globalConfig, projectConfig] = await Promise.all([
+            loadGlobalConfig(),
+            loadProjectConfig(),
+          ]);
           const result = await replyToTicket(
             { ticket, body: text },
-            { config: await loadGlobalConfig() },
+            { config: globalConfig, projectConfig },
           );
           switch (result.status) {
             case "replied":

--- a/plugins/dev/scripts/orch-monitor/ui/src/board/conversation-client.ts
+++ b/plugins/dev/scripts/orch-monitor/ui/src/board/conversation-client.ts
@@ -21,9 +21,14 @@ import type { AskKind } from "./inbox-ask-model";
 export interface ThreadComment {
   id: string;
   body: string;
-  /** True when the author is the AGENT (an integration bot OR a Catalyst app
-   *  actor — the server owns that distinction; app actors report is_bot=0). */
+  /** True when the author is NOT the operator — a Catalyst app actor OR an
+   *  integration bot. Drives the "someone else wrote this" styling. */
   isAgent: boolean;
+  /** True only for a Catalyst app actor — the one whose question is being
+   *  answered. This, not `isAgent`, is what the ask derivation keys on. */
+  isCatalystAgent: boolean;
+  /** True for GitHub/Linear plumbing. Shown for context; never an ask. */
+  isIntegration: boolean;
   authorName: string;
   authorAvatarUrl: string | null;
   /** Epoch ms, or null when the replica carried no honest timestamp. */

--- a/plugins/dev/scripts/orch-monitor/ui/src/board/conversation-client.ts
+++ b/plugins/dev/scripts/orch-monitor/ui/src/board/conversation-client.ts
@@ -1,0 +1,199 @@
+// conversation-client.ts — the read AND write paths of the inbox CONVERSATION
+// surface (CTL-1569). Sibling of inbox-read-client.ts (reads) and
+// respond-client.ts (writes), and isolated from the React tree for the same two
+// reasons: the home tree's no-fetch invariant keeps literal `fetch(` out of the
+// components, and a module-graph-free file can be unit-tested with an injected
+// fetch, no DOM and no server.
+//
+// TWO CALLS, TWO POSTURES:
+//   • fetchConversation — a REPLICA-only read (zero Linear API calls server-side),
+//     so it is safe to fire on every row selection. FAILS SOFT: any IO problem
+//     resolves to `ok:false` and the pane simply renders no conversation section.
+//   • postReply — the one mutation. FAILS LOUD, by design: every non-success maps
+//     to a typed outcome carrying operator-facing copy, because §4 requires that a
+//     failed post RESTORE the row rather than silently swallow the operator's words.
+
+import type { AskKind } from "./inbox-ask-model";
+
+// ── the read: thread + ask + deep link ───────────────────────────────────────
+
+/** One comment in the thread, as the server normalized it. */
+export interface ThreadComment {
+  id: string;
+  body: string;
+  /** True when the author is the AGENT (an integration bot OR a Catalyst app
+   *  actor — the server owns that distinction; app actors report is_bot=0). */
+  isAgent: boolean;
+  authorName: string;
+  authorAvatarUrl: string | null;
+  /** Epoch ms, or null when the replica carried no honest timestamp. */
+  at: number | null;
+  parentId: string | null;
+  /** The server's hint that this body is long enough to clamp + expand in place. */
+  truncated: boolean;
+}
+
+/** "What this needs from you" — the derived ask (CTL-1569 §1). */
+export interface ConversationAsk {
+  kind: AskKind;
+  summary: string;
+  suggestedReplies: string[];
+  /** THE bit the operator cares about: can I finish this by replying alone? */
+  canResolveByReply: boolean;
+  /** Where it came from — "structured" is producer-authored; the others are
+   *  reader-side derivations the UI marks as inferred. */
+  source: "structured" | "explanation" | "comment";
+}
+
+export interface ConversationResponse {
+  ticket: string;
+  /** Deep link to the Linear ticket (§3); null when the issue did not resolve. */
+  url: string | null;
+  title: string | null;
+  thread: {
+    /** false = the replica could not be read. Distinct from an empty thread, so
+     *  the UI can stay silent rather than claiming "no comments". */
+    available: boolean;
+    comments: ThreadComment[];
+    reason: string | null;
+  };
+  ask: ConversationAsk | null;
+  /** false for a synthesized row with no Linear issue behind it → no reply box. */
+  canReply: boolean;
+}
+
+export type ConversationResult =
+  | { ok: true; conversation: ConversationResponse }
+  | { ok: false };
+
+interface Deps {
+  fetchImpl?: typeof fetch;
+}
+
+/** The read endpoint URL (exported so the no-fetch invariant test can assert it). */
+export function conversationUrl(ticket: string, limit?: number): string {
+  const base = `/api/ticket/${encodeURIComponent(ticket)}/thread`;
+  return limit != null && Number.isFinite(limit) ? `${base}?limit=${Math.floor(limit)}` : base;
+}
+
+/**
+ * Fetch a ticket's conversation (ask + thread + deep link). Fails soft: a non-ok
+ * status or a network throw becomes `{ ok:false }`, and the pane renders no
+ * conversation section rather than an error card. Nothing here is load-bearing for
+ * the operator's ability to reply — the reply box is driven by its own state.
+ */
+export async function fetchConversation(
+  ticket: string,
+  { fetchImpl = fetch }: Deps = {},
+  limit?: number,
+): Promise<ConversationResult> {
+  try {
+    const res = await fetchImpl(conversationUrl(ticket, limit));
+    if (!res.ok) return { ok: false };
+    const conversation = (await res.json()) as ConversationResponse;
+    return { ok: true, conversation };
+  } catch {
+    return { ok: false };
+  }
+}
+
+// ── the write: post the operator's reply ─────────────────────────────────────
+
+/**
+ * The closed outcome of a reply. ONLY `replied` may clear the row; every other
+ * value must restore it (§4: "a failed post … must restore the row — never
+ * silently lose the item").
+ *
+ * `bot_identity` is called out separately from `error` on purpose: it is the
+ * failure that would otherwise make the whole feature silently inert (an app-actor
+ * comment is ignored by CTL-1567's provenance gate), so it gets its own explicit
+ * operator-facing explanation instead of a generic "something went wrong".
+ */
+export type ReplyOutcome =
+  | { status: "replied"; ticket: string; commentId: string; author: { id: string; name: string | null } | null }
+  | { status: "empty"; ticket: string }
+  | { status: "not_found"; ticket: string; message: string }
+  | { status: "bot_identity"; ticket: string; message: string }
+  | { status: "error"; ticket: string; message: string };
+
+export function replyUrl(ticket: string): string {
+  return `/api/ticket/${encodeURIComponent(ticket)}/reply`;
+}
+
+interface ReplyServerResult {
+  status?: string;
+  ticket?: string;
+  commentId?: string;
+  author?: { id: string; name: string | null } | null;
+  message?: string;
+  error?: string;
+}
+
+/** Operator-facing copy per failure. Specific, and honest about what happened to
+ *  their words — the row is coming back and the text is preserved. */
+const FAILURE_COPY: Record<string, string> = {
+  bot_identity:
+    "Not sent — this monitor is authenticated as the Catalyst app, and an app-authored " +
+    "comment would not clear the ask. Your reply was kept.",
+  no_token: "Not sent — this node has no Linear credential. Your reply was kept.",
+  not_found: "Not sent — no Linear ticket to reply to.",
+};
+
+/**
+ * Post the operator's reply. Maps the endpoint's discriminated result onto a
+ * `ReplyOutcome`:
+ *   • 200 replied      → the comment is live and human-authored; the row clears.
+ *   • 400 empty_body   → nothing typed.
+ *   • 404 not_found    → no such Linear issue.
+ *   • 502 bot_identity → REFUSED before posting (the inert-feature guard).
+ *   • anything else / a throw → `error` (never a false success).
+ */
+export async function postReply(
+  { ticket, body }: { ticket: string; body: string },
+  { fetchImpl = fetch }: Deps = {},
+): Promise<ReplyOutcome> {
+  let raw: ReplyServerResult;
+  try {
+    const res = await fetchImpl(replyUrl(ticket), {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ body }),
+    });
+    raw = (await res.json()) as ReplyServerResult;
+  } catch (e) {
+    return {
+      status: "error",
+      ticket,
+      message: `Not sent — ${e instanceof Error ? e.message : String(e)}. Your reply was kept.`,
+    };
+  }
+
+  const message = raw.message ?? raw.error ?? "";
+  switch (raw.status) {
+    case "replied":
+      if (typeof raw.commentId !== "string" || raw.commentId === "") {
+        // Success without a comment id is not a verified post — refuse to clear.
+        return { status: "error", ticket, message: "Not sent — the post was not confirmed." };
+      }
+      return {
+        status: "replied",
+        ticket: raw.ticket ?? ticket,
+        commentId: raw.commentId,
+        author: raw.author ?? null,
+      };
+    case "empty_body":
+      return { status: "empty", ticket };
+    case "not_found":
+      return { status: "not_found", ticket, message: FAILURE_COPY.not_found };
+    case "bot_identity":
+      return { status: "bot_identity", ticket, message: FAILURE_COPY.bot_identity };
+    case "no_token":
+      return { status: "error", ticket, message: FAILURE_COPY.no_token };
+    default:
+      return {
+        status: "error",
+        ticket,
+        message: message !== "" ? `Not sent — ${message}` : "Not sent — your reply was kept.",
+      };
+  }
+}

--- a/plugins/dev/scripts/orch-monitor/ui/src/board/inbox-ask-model.ts
+++ b/plugins/dev/scripts/orch-monitor/ui/src/board/inbox-ask-model.ts
@@ -46,7 +46,11 @@ const PRESENTATION: Record<AskKind, Omit<AskPresentation, "requiresAction">> = {
     label: "Action, then confirm",
     accent: "red",
     // Deliberately blunt: this is the case a colored chip alone would under-sell.
-    resolutionHint: "Replying alone will NOT resolve this — do the step below first, then confirm.",
+    // "above" because the summary sits ABOVE this line in the pane — and it is the
+    // dominant kind on real parked tickets, where the agent reported a blocker
+    // (a dirty tree, a CONFLICTING PR) rather than asking a question.
+    resolutionHint:
+      "Replying alone will NOT resolve this — do the work described above, then reply to confirm.",
   },
   clarify: {
     label: "Question",

--- a/plugins/dev/scripts/orch-monitor/ui/src/board/inbox-ask-model.ts
+++ b/plugins/dev/scripts/orch-monitor/ui/src/board/inbox-ask-model.ts
@@ -1,0 +1,78 @@
+// inbox-ask-model.ts — the PRESENTATION model for "what this needs from you"
+// (CTL-1569 §1). Pure, React-free, unit-testable: it turns the server's derived ask
+// into the exact words and accents the pane renders, so the component stays dumb.
+//
+// The design rule this file encodes: the operator must be able to answer TWO
+// questions at a glance, without reading the thread —
+//
+//   1. Can I resolve this by replying alone, or must I go DO something first?
+//   2. What are the acceptable replies?
+//
+// (1) is the LOUD signal, because getting it wrong wastes a round trip: the
+// operator either types "approve" on something that needed a manual step, or goes
+// hunting for work that a bare "yes" would have finished. So the reply-alone bit
+// gets its own explicit line, not just a colored chip.
+
+/** The four ask kinds, mirroring the server's `ASK_KINDS`. */
+export type AskKind = "approve" | "decide" | "act-then-confirm" | "clarify";
+
+/** How the ask chip is tinted. Amber = a decision is wanted; red = you must act
+ *  before this can clear; neutral = an open question. NEVER cyan (reserved for the
+ *  live signal), matching the pane's existing accent vocabulary. */
+export type AskAccent = "amber" | "red" | "neutral";
+
+export interface AskPresentation {
+  /** The short chip label shown at a glance. */
+  label: string;
+  accent: AskAccent;
+  /** The one-line answer to "can I just reply?" — the loud signal. */
+  resolutionHint: string;
+  /** True when the operator must do something off-platform first. */
+  requiresAction: boolean;
+}
+
+const PRESENTATION: Record<AskKind, Omit<AskPresentation, "requiresAction">> = {
+  approve: {
+    label: "Approval",
+    accent: "amber",
+    resolutionHint: "A yes or no reply is enough to resolve this.",
+  },
+  decide: {
+    label: "Decision",
+    accent: "amber",
+    resolutionHint: "Choosing one of the options below resolves this.",
+  },
+  "act-then-confirm": {
+    label: "Action, then confirm",
+    accent: "red",
+    // Deliberately blunt: this is the case a colored chip alone would under-sell.
+    resolutionHint: "Replying alone will NOT resolve this — do the step below first, then confirm.",
+  },
+  clarify: {
+    label: "Question",
+    accent: "neutral",
+    resolutionHint: "A written answer resolves this; there is no default.",
+  },
+};
+
+/** The presentation for an ask kind. Unknown kinds degrade to `clarify` — the
+ *  honest default — rather than throwing on a producer that invents a fifth kind. */
+export function askPresentation(kind: string): AskPresentation {
+  const key = (PRESENTATION[kind as AskKind] ? kind : "clarify") as AskKind;
+  return { ...PRESENTATION[key], requiresAction: key === "act-then-confirm" };
+}
+
+/** Whether to tell the operator this ask was INFERRED rather than stated by the
+ *  agent. A derived ask is a best-effort reading of prose, and quietly presenting
+ *  a guess as the agent's own words would be dishonest — so the pane marks it. */
+export function isInferredAsk(source: string): boolean {
+  return source !== "structured";
+}
+
+/** The note shown for an inferred ask (null when producer-authored). */
+export function inferredNote(source: string): string | null {
+  if (!isInferredAsk(source)) return null;
+  return source === "comment"
+    ? "Inferred from the agent's last comment."
+    : "Inferred from the agent's escalation details.";
+}

--- a/plugins/dev/scripts/orch-monitor/ui/src/components/home/conversation.tsx
+++ b/plugins/dev/scripts/orch-monitor/ui/src/components/home/conversation.tsx
@@ -313,7 +313,7 @@ function ReplyBox({
   ticket: string;
   draft: string;
   setDraft: React.Dispatch<React.SetStateAction<string>>;
-  onReplied: (outcome: ReplyOutcome, submitted: string) => void;
+  onReplied: (outcome: ReplyOutcome, submitted: string, submittedFor: string) => void;
 }) {
   const [sending, setSending] = useState(false);
   const [failure, setFailure] = useState<string | null>(null);
@@ -321,8 +321,12 @@ function ReplyBox({
   const draftAtSend = useRef("");
 
   const send = useCallback(async () => {
-    const body = draft.trim();
-    if (body === "" || sending) return;
+    // Trim ONLY to validate emptiness — the value SENT is the operator's verbatim
+    // draft. Sending draft.trim() defeated the server's postBody fix: a reply
+    // opening with a four-space Markdown code block still reached Linear without
+    // its indentation, rendering as prose instead of code.
+    if (draft.trim() === "" || sending) return;
+    const body = draft;
     draftAtSend.current = draft;
     setSending(true);
     setFailure(null);
@@ -333,7 +337,7 @@ function ReplyBox({
       // deletes a follow-up the operator started typing during the round trip,
       // which breaks this component's promise that typed words are never lost.
       setDraft((current) => (current === draftAtSend.current ? "" : current));
-      onReplied(outcome, body);
+      onReplied(outcome, body, ticket);
       return;
     }
     // Every failure path KEEPS the draft — the operator's words are never lost —
@@ -343,7 +347,7 @@ function ReplyBox({
         ? "Nothing to send."
         : (outcome as { message: string }).message,
     );
-    onReplied(outcome, body);
+    onReplied(outcome, body, ticket);
   }, [draft, sending, ticket, setDraft, onReplied]);
 
   return (
@@ -397,12 +401,18 @@ function ReplyBox({
 export function Conversation({
   ticket,
   enabled,
+  canResolveByReply = true,
   onReplied,
   now = Date.now(),
 }: {
   ticket: string;
   /** Only needs-you rows carry a conversation (running/done rows stay calm). */
   enabled: boolean;
+  /** Whether a human comment can actually RESOLVE this row. False for the
+   *  scheduler's blocked/queued rows, where comment-wake does not clear the
+   *  admission-gate label — the thread stays readable, the reply box does not
+   *  appear, and no false optimistic hide can occur. */
+  canResolveByReply?: boolean;
   /** Bubble the outcome so the surface can optimistically clear the row on a
    *  confirmed post and leave it in place on every failure. */
   onReplied?: (outcome: ReplyOutcome) => void;
@@ -431,8 +441,13 @@ export function Conversation({
   }, [ticket]);
 
   const handleReplied = useCallback(
-    (outcome: ReplyOutcome, submitted: string) => {
-      if (outcome.status === "replied") {
+    (outcome: ReplyOutcome, submitted: string, submittedFor: string) => {
+      // A reply to ticket A can land AFTER the operator has selected ticket B. The
+      // outcome must still bubble (B's row… actually A's row… must reconcile), but
+      // the locally rendered turns belong to A only — appending A's comment into
+      // B's thread would show a turn that B's server thread can never contain, and
+      // could mislead the next reply.
+      if (outcome.status === "replied" && submittedFor === ticket) {
         // Show the confirmed turn immediately …
         setOwnTurns((prev) => [
           ownReplyEntry(outcome.commentId, submitted, Date.now()),
@@ -444,7 +459,7 @@ export function Conversation({
       }
       onReplied?.(outcome);
     },
-    [onReplied],
+    [onReplied, ticket],
   );
 
   if (!enabled) return null;
@@ -498,7 +513,7 @@ export function Conversation({
 
       {/* The reply box — suppressed entirely for rows with no underlying Linear
           ticket, which have nothing to reply to (§4 / orphan-PR rows). */}
-      {conversation.canReply ? (
+      {conversation.canReply && canResolveByReply ? (
         <ReplyBox
           ticket={ticket}
           draft={draft}
@@ -507,7 +522,9 @@ export function Conversation({
         />
       ) : (
         <p className="mt-4 text-[11.5px] text-muted/70" data-no-reply-affordance={ticket}>
-          This item has no Linear ticket behind it, so there is nothing to reply to.
+          {!canResolveByReply
+            ? "Replying can't clear this one — it's held by the scheduler, not waiting on your answer."
+            : "This item has no Linear ticket behind it, so there is nothing to reply to."}
         </p>
       )}
 

--- a/plugins/dev/scripts/orch-monitor/ui/src/components/home/conversation.tsx
+++ b/plugins/dev/scripts/orch-monitor/ui/src/components/home/conversation.tsx
@@ -317,8 +317,14 @@ function ReplyBox({
 }) {
   const [sending, setSending] = useState(false);
   const [failure, setFailure] = useState<string | null>(null);
-  // The exact draft at submit time, so a successful post clears only that text.
+  // The exact draft at submit time AND the ticket + edit-version it belonged to.
+  // Value equality alone cannot prove no edit or ticket switch occurred: if A's
+  // reply is pending and the operator selects B and types (or a chip prefills) the
+  // same text, A's late setter would clear B's draft.
   const draftAtSend = useRef("");
+  const sendTicket = useRef("");
+  const editVersion = useRef(0);
+  const versionAtSend = useRef(-1);
 
   const send = useCallback(async () => {
     // Trim ONLY to validate emptiness — the value SENT is the operator's verbatim
@@ -328,6 +334,8 @@ function ReplyBox({
     if (draft.trim() === "" || sending) return;
     const body = draft;
     draftAtSend.current = draft;
+    sendTicket.current = ticket;
+    versionAtSend.current = editVersion.current;
     setSending(true);
     setFailure(null);
     const outcome = await postReply({ ticket, body });
@@ -336,7 +344,11 @@ function ReplyBox({
       // Clear ONLY the text that was actually submitted. A blind setDraft("")
       // deletes a follow-up the operator started typing during the round trip,
       // which breaks this component's promise that typed words are never lost.
-      setDraft((current) => (current === draftAtSend.current ? "" : current));
+      // Clear only if this is still the SAME ticket AND the draft has not been
+      // edited since submit — never on text equality alone.
+      if (sendTicket.current === ticket && versionAtSend.current === editVersion.current) {
+        setDraft((current) => (current === draftAtSend.current ? "" : current));
+      }
       onReplied(outcome, body, ticket);
       return;
     }
@@ -356,7 +368,10 @@ function ReplyBox({
       <textarea
         data-reply-input={ticket}
         value={draft}
-        onChange={(e) => setDraft(e.target.value)}
+        onChange={(e) => {
+          editVersion.current += 1;
+          setDraft(e.target.value);
+        }}
         onKeyDown={(e) => {
           // ⌘/Ctrl+Enter sends; a bare Enter stays a newline so a considered,
           // multi-line answer is never fired off half-written.

--- a/plugins/dev/scripts/orch-monitor/ui/src/components/home/conversation.tsx
+++ b/plugins/dev/scripts/orch-monitor/ui/src/components/home/conversation.tsx
@@ -186,27 +186,42 @@ function ThreadEntry({ comment, now }: { comment: ThreadComment; now: number }) 
     <li
       className="flex flex-col gap-1 py-2.5"
       data-thread-comment={comment.id}
-      data-thread-author={comment.isAgent ? "agent" : "human"}
+      data-thread-author={
+        comment.isIntegration ? "integration" : comment.isCatalystAgent ? "agent" : "human"
+      }
     >
       <div className="flex items-center gap-2">
-        {/* The agent/human distinction (§2): a 2px accent + the author name. The
-            agent is the accent color (it is the one asking); the operator is
-            neutral. Not avatars — the pane stays flat and calm. */}
+        {/* Three classes, styled distinctly (§2). The CATALYST AGENT gets the
+            accent — it is the one asking. The operator is neutral-bright.
+            INTEGRATION plumbing (a GitHub sync notice) is fully muted, because
+            styling it as the agent makes automation chatter look like a question
+            that needs answering. */}
         <span
           aria-hidden
           className={cn(
             "h-3 w-0.5 shrink-0 rounded-full",
-            comment.isAgent ? "bg-accent" : "bg-muted/50",
+            comment.isCatalystAgent
+              ? "bg-accent"
+              : comment.isIntegration
+                ? "bg-muted/30"
+                : "bg-muted/50",
           )}
         />
         <span
           className={cn(
             "text-[11.5px] font-medium",
-            comment.isAgent ? "text-accent" : "text-fg",
+            comment.isCatalystAgent
+              ? "text-accent"
+              : comment.isIntegration
+                ? "text-muted/70"
+                : "text-fg",
           )}
         >
           {comment.authorName}
         </span>
+        {comment.isIntegration && (
+          <span className="text-[10px] uppercase tracking-wide text-muted/50">automation</span>
+        )}
         {when != null && <span className="text-[11px] text-muted/70">{when}</span>}
       </div>
 

--- a/plugins/dev/scripts/orch-monitor/ui/src/components/home/conversation.tsx
+++ b/plugins/dev/scripts/orch-monitor/ui/src/components/home/conversation.tsx
@@ -431,6 +431,12 @@ export function Conversation({
 
   // A new selection starts a fresh draft — one operator's half-typed answer must
   // never leak onto a different ticket.
+  // The CURRENT selection, readable from any async callback regardless of which
+  // render captured it. Updated on every render so a late completion always
+  // compares against what the operator is looking at now.
+  const currentTicket = useRef(ticket);
+  currentTicket.current = ticket;
+
   const lastTicket = useRef(ticket);
   useEffect(() => {
     if (lastTicket.current !== ticket) {
@@ -442,12 +448,17 @@ export function Conversation({
 
   const handleReplied = useCallback(
     (outcome: ReplyOutcome, submitted: string, submittedFor: string) => {
-      // A reply to ticket A can land AFTER the operator has selected ticket B. The
-      // outcome must still bubble (B's row… actually A's row… must reconcile), but
-      // the locally rendered turns belong to A only — appending A's comment into
-      // B's thread would show a turn that B's server thread can never contain, and
-      // could mislead the next reply.
-      if (outcome.status === "replied" && submittedFor === ticket) {
+      // A reply to ticket A can land AFTER the operator has selected ticket B.
+      //
+      // Comparing `submittedFor` to the `ticket` captured by this callback does NOT
+      // work: ReplyBox invokes the callback instance captured during A's render, so
+      // BOTH values are A and the guard always passes. The comparison must be
+      // against the CURRENT selection, which only a ref can provide.
+      //
+      // The outcome still bubbles unconditionally so A's row reconciles; only the
+      // locally rendered turns are gated, because appending A's comment into B's
+      // thread would render a turn B's server thread can never contain.
+      if (outcome.status === "replied" && submittedFor === currentTicket.current) {
         // Show the confirmed turn immediately …
         setOwnTurns((prev) => [
           ownReplyEntry(outcome.commentId, submitted, Date.now()),
@@ -459,7 +470,7 @@ export function Conversation({
       }
       onReplied?.(outcome);
     },
-    [onReplied, ticket],
+    [onReplied],
   );
 
   if (!enabled) return null;

--- a/plugins/dev/scripts/orch-monitor/ui/src/components/home/conversation.tsx
+++ b/plugins/dev/scripts/orch-monitor/ui/src/components/home/conversation.tsx
@@ -53,19 +53,52 @@ type ConversationState =
 /** Load the conversation when a row is selected. `reloadKey` is bumped after a
  *  successful post so the operator sees their own comment land at the top of the
  *  thread — the turn they just took, reflected immediately. */
+/** Build the thread entry for a just-confirmed reply. The server returned a real
+ *  comment id, so this is a CONFIRMED comment being shown early — not a guess. */
+function ownReplyEntry(commentId: string, body: string, at: number): ThreadComment {
+  return {
+    id: commentId,
+    body,
+    isAgent: false,
+    isCatalystAgent: false,
+    isIntegration: false,
+    authorName: "you",
+    authorAvatarUrl: null,
+    at,
+    parentId: null,
+    truncated: body.length > 600,
+  };
+}
+
 function useConversation(ticket: string | undefined, enabled: boolean, reloadKey: number) {
   const [state, setState] = useState<ConversationState>({ kind: "idle" });
+  // The ticket the CURRENTLY held state belongs to. Without this, switching from
+  // ticket A to B kept A's loaded conversation on screen while B's request was in
+  // flight — so A's ask, suggestions, thread and URL rendered around a ReplyBox
+  // bound to B, and an operator acting in that window could post an answer derived
+  // from A's context onto B. State is only ever preserved for a SAME-ticket reload.
+  const loadedFor = useRef<string | undefined>(undefined);
   useEffect(() => {
     if (!enabled || !ticket) {
+      loadedFor.current = undefined;
       setState({ kind: "idle" });
       return;
     }
     let alive = true;
-    setState((prev) => (prev.kind === "loaded" ? prev : { kind: "loading" }));
+    const sameTicket = loadedFor.current === ticket;
+    setState((prev) => (sameTicket && prev.kind === "loaded" ? prev : { kind: "loading" }));
     void (async () => {
       const result = await fetchConversation(ticket);
       if (!alive) return;
-      setState(result.ok ? { kind: "loaded", conversation: result.conversation } : { kind: "error" });
+      // Guard against a late response for a ticket we have since navigated away
+      // from — it must never overwrite the current selection's state.
+      if (loadedFor.current !== undefined && loadedFor.current !== ticket && !alive) return;
+      if (result.ok) {
+        loadedFor.current = ticket;
+        setState({ kind: "loaded", conversation: result.conversation });
+      } else {
+        setState({ kind: "error" });
+      }
     })();
     return () => {
       alive = false;
@@ -279,24 +312,28 @@ function ReplyBox({
 }: {
   ticket: string;
   draft: string;
-  setDraft: (v: string) => void;
-  onReplied: (outcome: ReplyOutcome) => void;
+  setDraft: React.Dispatch<React.SetStateAction<string>>;
+  onReplied: (outcome: ReplyOutcome, submitted: string) => void;
 }) {
   const [sending, setSending] = useState(false);
   const [failure, setFailure] = useState<string | null>(null);
+  // The exact draft at submit time, so a successful post clears only that text.
+  const draftAtSend = useRef("");
 
   const send = useCallback(async () => {
     const body = draft.trim();
     if (body === "" || sending) return;
+    draftAtSend.current = draft;
     setSending(true);
     setFailure(null);
     const outcome = await postReply({ ticket, body });
     setSending(false);
     if (outcome.status === "replied") {
-      // Clear the box only on a CONFIRMED post; the row's disappearance is the
-      // parent's call (it owns the optimistic mark + rollback window).
-      setDraft("");
-      onReplied(outcome);
+      // Clear ONLY the text that was actually submitted. A blind setDraft("")
+      // deletes a follow-up the operator started typing during the round trip,
+      // which breaks this component's promise that typed words are never lost.
+      setDraft((current) => (current === draftAtSend.current ? "" : current));
+      onReplied(outcome, body);
       return;
     }
     // Every failure path KEEPS the draft — the operator's words are never lost —
@@ -306,7 +343,7 @@ function ReplyBox({
         ? "Nothing to send."
         : (outcome as { message: string }).message,
     );
-    onReplied(outcome);
+    onReplied(outcome, body);
   }, [draft, sending, ticket, setDraft, onReplied]);
 
   return (
@@ -373,6 +410,13 @@ export function Conversation({
 }) {
   const [reloadKey, setReloadKey] = useState(0);
   const [draft, setDraft] = useState("");
+  // Turns this session posted and confirmed, newest-first. These are merged into
+  // the rendered thread because a refetch immediately after the POST RACES the
+  // webhook/sync that writes the comment into the local replica — the one-shot
+  // refetch usually returns the pre-reply thread, and nothing schedules another,
+  // so the operator's own turn would stay invisible indefinitely. The server gave
+  // us a real comment id, so showing it is reporting a confirmed fact early.
+  const [ownTurns, setOwnTurns] = useState<ThreadComment[]>([]);
   const state = useConversation(ticket, enabled, reloadKey);
 
   // A new selection starts a fresh draft — one operator's half-typed answer must
@@ -382,22 +426,54 @@ export function Conversation({
     if (lastTicket.current !== ticket) {
       lastTicket.current = ticket;
       setDraft("");
+      setOwnTurns([]); // a different ticket's turns are not this ticket's thread
     }
   }, [ticket]);
 
   const handleReplied = useCallback(
-    (outcome: ReplyOutcome) => {
-      // Re-read the thread on success so the operator's own comment appears on top.
-      if (outcome.status === "replied") setReloadKey((k) => k + 1);
+    (outcome: ReplyOutcome, submitted: string) => {
+      if (outcome.status === "replied") {
+        // Show the confirmed turn immediately …
+        setOwnTurns((prev) => [
+          ownReplyEntry(outcome.commentId, submitted, Date.now()),
+          ...prev.filter((t) => t.id !== outcome.commentId),
+        ]);
+        // … and still re-read, so the canonical replica copy supersedes it once
+        // the sync lands (the merge below de-dupes by comment id).
+        setReloadKey((k) => k + 1);
+      }
       onReplied?.(outcome);
     },
     [onReplied],
   );
 
   if (!enabled) return null;
-  if (state.kind !== "loaded") return null; // loading/error → render nothing (fails soft)
+  if (state.kind === "idle" || state.kind === "loading") return null;
 
-  const { conversation } = state;
+  // A failed /thread read must NOT remove the reply composer. Posting is a
+  // SEPARATE endpoint and the thread is explicitly non-load-bearing, so degrading
+  // to "no conversation at all" would strand the operator: the component returned
+  // null until the row was reselected, so they could not answer even once
+  // connectivity recovered. Degrade to a composer-only view instead.
+  const conversation: ConversationResponse =
+    state.kind === "loaded"
+      ? state.conversation
+      : {
+          ticket,
+          url: null,
+          title: null,
+          thread: { available: false, comments: [], reason: "read-failed" },
+          ask: null,
+          canReply: true,
+        };
+
+  // Own turns first (they are the newest), then the replica's, de-duped by id so
+  // the canonical copy replaces the optimistic one the moment sync catches up.
+  const serverIds = new Set(conversation.thread.comments.map((c) => c.id));
+  const mergedComments = [
+    ...ownTurns.filter((t) => !serverIds.has(t.id)),
+    ...conversation.thread.comments,
+  ];
 
   return (
     <div data-conversation={ticket}>
@@ -439,12 +515,12 @@ export function Conversation({
 
       {/* The thread. Rendered only when the replica was actually READABLE — an
           unavailable source stays silent rather than claiming "no comments". */}
-      {conversation.thread.available && (
+      {(conversation.thread.available || mergedComments.length > 0) && (
         <section className="mt-4" data-conversation-thread>
           <p className="text-[11px] font-medium uppercase tracking-wide text-muted">
             Conversation
           </p>
-          <Thread comments={conversation.thread.comments} now={now} />
+          <Thread comments={mergedComments} now={now} />
         </section>
       )}
     </div>

--- a/plugins/dev/scripts/orch-monitor/ui/src/components/home/conversation.tsx
+++ b/plugins/dev/scripts/orch-monitor/ui/src/components/home/conversation.tsx
@@ -308,22 +308,33 @@ function ReplyBox({
   ticket,
   draft,
   setDraft,
+  editVersion,
   onReplied,
 }: {
   ticket: string;
   draft: string;
   setDraft: React.Dispatch<React.SetStateAction<string>>;
+  /** Bumped on EVERY draft mutation — typing AND suggestion prefills. Owned by the
+   *  parent so a chip click counts as an edit; see applyDraft. */
+  editVersion: React.MutableRefObject<number>;
   onReplied: (outcome: ReplyOutcome, submitted: string, submittedFor: string) => void;
 }) {
   const [sending, setSending] = useState(false);
   const [failure, setFailure] = useState<string | null>(null);
+
+  // This ReplyBox instance is REUSED across ticket selections, so a failure raised
+  // for ticket A would otherwise keep rendering under ticket B — showing a "Not
+  // sent" diagnosis for a reply that was never attempted on B, and persisting
+  // until the next send. Clear it whenever the selection changes.
+  useEffect(() => {
+    setFailure(null);
+  }, [ticket]);
   // The exact draft at submit time AND the ticket + edit-version it belonged to.
   // Value equality alone cannot prove no edit or ticket switch occurred: if A's
   // reply is pending and the operator selects B and types (or a chip prefills) the
   // same text, A's late setter would clear B's draft.
   const draftAtSend = useRef("");
   const sendTicket = useRef("");
-  const editVersion = useRef(0);
   const versionAtSend = useRef(-1);
 
   const send = useCallback(async () => {
@@ -360,7 +371,7 @@ function ReplyBox({
         : (outcome as { message: string }).message,
     );
     onReplied(outcome, body, ticket);
-  }, [draft, sending, ticket, setDraft, onReplied]);
+  }, [draft, sending, ticket, setDraft, editVersion, onReplied]);
 
   return (
     <section className="mt-5" data-reply-box={ticket}>
@@ -368,10 +379,7 @@ function ReplyBox({
       <textarea
         data-reply-input={ticket}
         value={draft}
-        onChange={(e) => {
-          editVersion.current += 1;
-          setDraft(e.target.value);
-        }}
+        onChange={(e) => setDraft(e.target.value)}
         onKeyDown={(e) => {
           // ⌘/Ctrl+Enter sends; a bare Enter stays a newline so a considered,
           // multi-line answer is never fired off half-written.
@@ -443,6 +451,16 @@ export function Conversation({
   // us a real comment id, so showing it is reporting a confirmed fact early.
   const [ownTurns, setOwnTurns] = useState<ThreadComment[]>([]);
   const state = useConversation(ticket, enabled, reloadKey);
+
+  // ONE versioned entry point for every draft mutation. Suggestion chips call
+  // `setDraft` too, so if only the textarea bumped the version, prefilling B with
+  // the same text that was submitted on A would let A's late success clear B's
+  // draft — the version would still match and so would the value.
+  const editVersion = useRef(0);
+  const applyDraft = useCallback<React.Dispatch<React.SetStateAction<string>>>((next) => {
+    editVersion.current += 1;
+    setDraft(next);
+  }, []);
 
   // A new selection starts a fresh draft — one operator's half-typed answer must
   // never leak onto a different ticket.
@@ -519,7 +537,7 @@ export function Conversation({
   return (
     <div data-conversation={ticket}>
       {conversation.ask != null && (
-        <AskSummary ask={conversation.ask} onUseSuggestion={setDraft} />
+        <AskSummary ask={conversation.ask} onUseSuggestion={applyDraft} />
       )}
 
       {/* The direct link to the ticket (§3). Absent when the issue never resolved
@@ -543,7 +561,8 @@ export function Conversation({
         <ReplyBox
           ticket={ticket}
           draft={draft}
-          setDraft={setDraft}
+          setDraft={applyDraft}
+          editVersion={editVersion}
           onReplied={handleReplied}
         />
       ) : (

--- a/plugins/dev/scripts/orch-monitor/ui/src/components/home/conversation.tsx
+++ b/plugins/dev/scripts/orch-monitor/ui/src/components/home/conversation.tsx
@@ -1,0 +1,437 @@
+// conversation.tsx — the inbox as a CONVERSATION surface (CTL-1569).
+//
+// Three stacked sections inside the reading pane, in the operator's order of need:
+//
+//   1. WHAT THIS NEEDS FROM YOU — the ask summary: a kind chip, the plain-language
+//      summary, the loud "can I just reply?" line, and one-click suggested replies
+//      that PREFILL the box (still editable — a chip is a shortcut, not a submit).
+//   2. THE REPLY BOX — posts a real Linear comment authored as the operator. That
+//      post IS the resolution mechanism (CTL-1567 clears `needs-human` on a human
+//      comment within seconds), so this is the payoff of the whole surface.
+//   3. THE THREAD — the last few comments, NEWEST FIRST, agent and human visibly
+//      distinct, long bodies clamped with expand-in-place.
+//
+// ── the honesty contract ─────────────────────────────────────────────────────
+// The operator's typed words are never lost. On a failed post the draft STAYS in
+// the box, the row is NOT cleared, and the specific reason is shown — including the
+// one failure that would otherwise be invisible: a monitor authenticated as the
+// Catalyst app can't post a comment that would clear the ask, and the server
+// refuses BEFORE posting rather than faking success.
+//
+// Optimistic clear (§4: "the row disappears on post") is reported UPWARD via
+// `onReplied` rather than owned here, so the surface's existing optimistic-mark +
+// grace-window rollback machinery (respond-client.ts::reconcileMarks) stays the one
+// place that decides when a row truly leaves the inbox.
+//
+// NO FETCH LIVES HERE: every network call goes through board/conversation-client.ts
+// (the home tree's no-fetch invariant).
+import { useCallback, useEffect, useRef, useState } from "react";
+import { ExternalLink as ExternalLinkIcon, Send } from "lucide-react";
+
+import {
+  fetchConversation,
+  postReply,
+  type ConversationAsk,
+  type ConversationResponse,
+  type ReplyOutcome,
+  type ThreadComment,
+} from "@/board/conversation-client";
+import { askPresentation, inferredNote, type AskAccent } from "@/board/inbox-ask-model";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Separator } from "@/components/ui/separator";
+import { cn } from "@/lib/utils";
+
+// ── fetch-on-select ──────────────────────────────────────────────────────────
+
+type ConversationState =
+  | { kind: "idle" }
+  | { kind: "loading" }
+  | { kind: "loaded"; conversation: ConversationResponse }
+  | { kind: "error" };
+
+/** Load the conversation when a row is selected. `reloadKey` is bumped after a
+ *  successful post so the operator sees their own comment land at the top of the
+ *  thread — the turn they just took, reflected immediately. */
+function useConversation(ticket: string | undefined, enabled: boolean, reloadKey: number) {
+  const [state, setState] = useState<ConversationState>({ kind: "idle" });
+  useEffect(() => {
+    if (!enabled || !ticket) {
+      setState({ kind: "idle" });
+      return;
+    }
+    let alive = true;
+    setState((prev) => (prev.kind === "loaded" ? prev : { kind: "loading" }));
+    void (async () => {
+      const result = await fetchConversation(ticket);
+      if (!alive) return;
+      setState(result.ok ? { kind: "loaded", conversation: result.conversation } : { kind: "error" });
+    })();
+    return () => {
+      alive = false;
+    };
+  }, [ticket, enabled, reloadKey]);
+  return state;
+}
+
+// ── the ask summary (§1) ─────────────────────────────────────────────────────
+
+function askChipClasses(accent: AskAccent): string {
+  switch (accent) {
+    case "red":
+      return "border-red/40 bg-red/10 text-red";
+    case "amber":
+      return "border-yellow/40 bg-yellow/10 text-yellow";
+    case "neutral":
+      return "border-border bg-surface-2 text-muted";
+  }
+}
+
+function AskSummary({
+  ask,
+  onUseSuggestion,
+}: {
+  ask: ConversationAsk;
+  onUseSuggestion: (text: string) => void;
+}) {
+  const presentation = askPresentation(ask.kind);
+  const note = inferredNote(ask.source);
+
+  return (
+    <section className="mt-5" data-conversation-ask data-ask-kind={ask.kind}>
+      <div className="flex items-center gap-2">
+        <p className="text-[11px] font-medium uppercase tracking-wide text-muted">
+          What this needs from you
+        </p>
+        <Badge
+          variant="outline"
+          data-ask-chip={ask.kind}
+          className={cn("shrink-0 text-[10px] font-medium", askChipClasses(presentation.accent))}
+        >
+          {presentation.label}
+        </Badge>
+      </div>
+
+      {/* The plain-language ask — the bright line. */}
+      <p className="mt-2 text-[14px] leading-snug text-fg" data-ask-summary>
+        {ask.summary}
+      </p>
+
+      {/* The loud signal: reply alone, or go do something first. Given its own
+          line (not just the chip tint) because mistaking it costs a round trip. */}
+      <p
+        data-ask-resolution
+        data-requires-action={presentation.requiresAction ? "true" : undefined}
+        className={cn(
+          "mt-2 text-[12px] leading-snug",
+          presentation.requiresAction ? "font-medium text-red" : "text-muted",
+        )}
+      >
+        {presentation.resolutionHint}
+      </p>
+
+      {/* One-click suggested replies — they PREFILL the box, never auto-send, so
+          the operator can edit before committing (§1). Only ever rendered from
+          enumerated producer options; the reader-side classifier never invents one. */}
+      {ask.suggestedReplies.length > 0 && (
+        <div className="mt-3 flex flex-wrap items-center gap-2" data-ask-suggestions>
+          {ask.suggestedReplies.map((reply) => (
+            <Button
+              key={reply}
+              type="button"
+              size="sm"
+              variant="outline"
+              data-ask-suggestion={reply}
+              onClick={() => onUseSuggestion(reply)}
+              title="Put this in the reply box (you can still edit it)"
+            >
+              {reply}
+            </Button>
+          ))}
+        </div>
+      )}
+
+      {/* Mark an inferred ask as inferred — never pass a guess off as the agent's
+          own words. */}
+      {note != null && (
+        <p className="mt-2 text-[11px] italic text-muted/70" data-ask-inferred>
+          {note}
+        </p>
+      )}
+    </section>
+  );
+}
+
+// ── the thread (§2) ──────────────────────────────────────────────────────────
+
+/** Relative time for a comment. Returns null when the replica carried no honest
+ *  timestamp, so the UI omits it rather than fabricating one. */
+function relativeTime(at: number | null, now: number): string | null {
+  if (at == null || !Number.isFinite(at)) return null;
+  const secs = Math.max(0, Math.round((now - at) / 1000));
+  if (secs < 60) return "just now";
+  const mins = Math.round(secs / 60);
+  if (mins < 60) return `${mins}m ago`;
+  const hours = Math.round(mins / 60);
+  if (hours < 24) return `${hours}h ago`;
+  return `${Math.round(hours / 24)}d ago`;
+}
+
+function ThreadEntry({ comment, now }: { comment: ThreadComment; now: number }) {
+  const [expanded, setExpanded] = useState(false);
+  const when = relativeTime(comment.at, now);
+  const clamped = comment.truncated && !expanded;
+
+  return (
+    <li
+      className="flex flex-col gap-1 py-2.5"
+      data-thread-comment={comment.id}
+      data-thread-author={comment.isAgent ? "agent" : "human"}
+    >
+      <div className="flex items-center gap-2">
+        {/* The agent/human distinction (§2): a 2px accent + the author name. The
+            agent is the accent color (it is the one asking); the operator is
+            neutral. Not avatars — the pane stays flat and calm. */}
+        <span
+          aria-hidden
+          className={cn(
+            "h-3 w-0.5 shrink-0 rounded-full",
+            comment.isAgent ? "bg-accent" : "bg-muted/50",
+          )}
+        />
+        <span
+          className={cn(
+            "text-[11.5px] font-medium",
+            comment.isAgent ? "text-accent" : "text-fg",
+          )}
+        >
+          {comment.authorName}
+        </span>
+        {when != null && <span className="text-[11px] text-muted/70">{when}</span>}
+      </div>
+
+      {/* The body. Rendered as PLAIN TEXT with preserved newlines — the bodies are
+          markdown, but half-rendering markdown is a correctness bug whereas a
+          literal `**` is merely cosmetic. */}
+      <p
+        className={cn(
+          "whitespace-pre-wrap pl-2.5 text-[12.5px] leading-relaxed text-fg/90",
+          clamped && "line-clamp-4",
+        )}
+      >
+        {comment.body}
+      </p>
+
+      {comment.truncated && (
+        <button
+          type="button"
+          data-thread-expand={comment.id}
+          onClick={() => setExpanded((v) => !v)}
+          className="self-start pl-2.5 text-[11px] text-muted underline-offset-2 hover:underline"
+        >
+          {expanded ? "Show less" : "Show more"}
+        </button>
+      )}
+    </li>
+  );
+}
+
+function Thread({ comments, now }: { comments: ThreadComment[]; now: number }) {
+  if (comments.length === 0) {
+    return (
+      <p className="mt-2 text-[12px] text-muted/70" data-thread-empty>
+        No comments yet.
+      </p>
+    );
+  }
+  // Already newest-first from the server (§2) — rendered in the order received.
+  return (
+    <ul className="mt-1 flex flex-col divide-y divide-border/50" data-thread>
+      {comments.map((c) => (
+        <ThreadEntry key={c.id} comment={c} now={now} />
+      ))}
+    </ul>
+  );
+}
+
+// ── the reply box (§4) ───────────────────────────────────────────────────────
+
+function ReplyBox({
+  ticket,
+  draft,
+  setDraft,
+  onReplied,
+}: {
+  ticket: string;
+  draft: string;
+  setDraft: (v: string) => void;
+  onReplied: (outcome: ReplyOutcome) => void;
+}) {
+  const [sending, setSending] = useState(false);
+  const [failure, setFailure] = useState<string | null>(null);
+
+  const send = useCallback(async () => {
+    const body = draft.trim();
+    if (body === "" || sending) return;
+    setSending(true);
+    setFailure(null);
+    const outcome = await postReply({ ticket, body });
+    setSending(false);
+    if (outcome.status === "replied") {
+      // Clear the box only on a CONFIRMED post; the row's disappearance is the
+      // parent's call (it owns the optimistic mark + rollback window).
+      setDraft("");
+      onReplied(outcome);
+      return;
+    }
+    // Every failure path KEEPS the draft — the operator's words are never lost —
+    // and states the specific reason (§4: a failed post must restore the row).
+    setFailure(
+      outcome.status === "empty"
+        ? "Nothing to send."
+        : (outcome as { message: string }).message,
+    );
+    onReplied(outcome);
+  }, [draft, sending, ticket, setDraft, onReplied]);
+
+  return (
+    <section className="mt-5" data-reply-box={ticket}>
+      <p className="text-[11px] font-medium uppercase tracking-wide text-muted">Your reply</p>
+      <textarea
+        data-reply-input={ticket}
+        value={draft}
+        onChange={(e) => setDraft(e.target.value)}
+        onKeyDown={(e) => {
+          // ⌘/Ctrl+Enter sends; a bare Enter stays a newline so a considered,
+          // multi-line answer is never fired off half-written.
+          if ((e.metaKey || e.ctrlKey) && e.key === "Enter") {
+            e.preventDefault();
+            void send();
+          }
+        }}
+        rows={3}
+        placeholder="Reply to the agent — this posts a comment to Linear as you."
+        className={cn(
+          "mt-2 w-full resize-y rounded-sm border border-border bg-surface-1 px-3 py-2",
+          "text-[13px] leading-relaxed text-fg placeholder:text-muted/60",
+          "focus:border-accent focus:outline-none",
+        )}
+      />
+      <div className="mt-2 flex items-center gap-3">
+        <Button
+          type="button"
+          size="sm"
+          data-reply-send={ticket}
+          disabled={draft.trim() === "" || sending}
+          onClick={() => void send()}
+        >
+          <Send className="size-3.5" />
+          {sending ? "Sending…" : "Send reply"}
+        </Button>
+        <span className="text-[11px] text-muted/70">⌘↵ to send</span>
+      </div>
+
+      {failure != null && (
+        <p className="mt-2 text-[11.5px] leading-snug text-red" data-reply-failure={ticket}>
+          {failure}
+        </p>
+      )}
+    </section>
+  );
+}
+
+// ── the composed surface ─────────────────────────────────────────────────────
+
+export function Conversation({
+  ticket,
+  enabled,
+  onReplied,
+  now = Date.now(),
+}: {
+  ticket: string;
+  /** Only needs-you rows carry a conversation (running/done rows stay calm). */
+  enabled: boolean;
+  /** Bubble the outcome so the surface can optimistically clear the row on a
+   *  confirmed post and leave it in place on every failure. */
+  onReplied?: (outcome: ReplyOutcome) => void;
+  now?: number;
+}) {
+  const [reloadKey, setReloadKey] = useState(0);
+  const [draft, setDraft] = useState("");
+  const state = useConversation(ticket, enabled, reloadKey);
+
+  // A new selection starts a fresh draft — one operator's half-typed answer must
+  // never leak onto a different ticket.
+  const lastTicket = useRef(ticket);
+  useEffect(() => {
+    if (lastTicket.current !== ticket) {
+      lastTicket.current = ticket;
+      setDraft("");
+    }
+  }, [ticket]);
+
+  const handleReplied = useCallback(
+    (outcome: ReplyOutcome) => {
+      // Re-read the thread on success so the operator's own comment appears on top.
+      if (outcome.status === "replied") setReloadKey((k) => k + 1);
+      onReplied?.(outcome);
+    },
+    [onReplied],
+  );
+
+  if (!enabled) return null;
+  if (state.kind !== "loaded") return null; // loading/error → render nothing (fails soft)
+
+  const { conversation } = state;
+
+  return (
+    <div data-conversation={ticket}>
+      {conversation.ask != null && (
+        <AskSummary ask={conversation.ask} onUseSuggestion={setDraft} />
+      )}
+
+      {/* The direct link to the ticket (§3). Absent when the issue never resolved
+          (a synthesized row) — never a dead link. */}
+      {conversation.url != null && (
+        <a
+          href={conversation.url}
+          target="_blank"
+          rel="noopener noreferrer"
+          data-linear-link={ticket}
+          className="mt-3 inline-flex items-center gap-1.5 text-[11.5px] text-muted hover:text-fg"
+        >
+          Open {ticket} in Linear
+          <ExternalLinkIcon className="size-3" />
+        </a>
+      )}
+
+      {/* The reply box — suppressed entirely for rows with no underlying Linear
+          ticket, which have nothing to reply to (§4 / orphan-PR rows). */}
+      {conversation.canReply ? (
+        <ReplyBox
+          ticket={ticket}
+          draft={draft}
+          setDraft={setDraft}
+          onReplied={handleReplied}
+        />
+      ) : (
+        <p className="mt-4 text-[11.5px] text-muted/70" data-no-reply-affordance={ticket}>
+          This item has no Linear ticket behind it, so there is nothing to reply to.
+        </p>
+      )}
+
+      <Separator className="mt-5" />
+
+      {/* The thread. Rendered only when the replica was actually READABLE — an
+          unavailable source stays silent rather than claiming "no comments". */}
+      {conversation.thread.available && (
+        <section className="mt-4" data-conversation-thread>
+          <p className="text-[11px] font-medium uppercase tracking-wide text-muted">
+            Conversation
+          </p>
+          <Thread comments={conversation.thread.comments} now={now} />
+        </section>
+      )}
+    </div>
+  );
+}

--- a/plugins/dev/scripts/orch-monitor/ui/src/components/home/home-surface.tsx
+++ b/plugins/dev/scripts/orch-monitor/ui/src/components/home/home-surface.tsx
@@ -263,6 +263,13 @@ export function HomeSurface() {
         attention: perSection("attention"),
         blocked: perSection("blocked"),
         waiting: perSection("waiting"),
+        // The AGGREGATE must be recomputed too. `isAllClear` and
+        // `calmHeaderSentence` both read `needsYou`, not the components — so
+        // leaving it spread through meant resolving the LAST attention row still
+        // showed "1 needs you" and withheld the all-clear surface until an SSE
+        // frame arrived. That is precisely the relief moment this feature exists
+        // to deliver, so it must not wait on the network.
+        needsYou: perSection("attention") + perSection("blocked") + perSection("waiting"),
       },
     };
   }, [rawModel, resolvedIds]);

--- a/plugins/dev/scripts/orch-monitor/ui/src/components/home/home-surface.tsx
+++ b/plugins/dev/scripts/orch-monitor/ui/src/components/home/home-surface.tsx
@@ -196,7 +196,7 @@ export function HomeSurface() {
 
   // Derive the whole inbox from the resident snapshot (PURE). When no payload has
   // landed yet, an empty payload yields an empty (but valid) model.
-  const model = useMemo(
+  const rawModel = useMemo(
     () =>
       deriveInbox(
         payload ?? {
@@ -210,6 +210,49 @@ export function HomeSurface() {
       ),
     [payload],
   );
+
+  // CTL-903 / HOME5: the WRITE path. The hook owns the optimistic-resume state +
+  // the grace-window rollback; the verb fires record-response + resume-agent
+  // through the read-model write endpoint (board/respond-client.ts owns the
+  // fetch). The single-node case is an exact pass-through (the endpoint's
+  // identity fence no-op); a multi-node fence rejection arrives as `did-not-take`.
+  const { respond, statusFor, reconcile, markResolved, markDidNotTake } = useRespond();
+
+  // CTL-1569 / AC #8 ("posting removes the row without a manual refresh"): the
+  // optimistic mark alone was NOT enough. `statusFor` only changed how the pane
+  // rendered — `sections` and `order` still carried the row, so it stayed visible
+  // AND selected with a live reply box until some later SSE frame happened to drop
+  // it, which invited a duplicate submission in the gap. So the marks are PROJECTED
+  // out of the model here.
+  //
+  // This is safe precisely because it is not permanent: `reconcile` still runs on
+  // every frame, and a mark that is still waiting past the grace window rolls back
+  // (`markDidNotTake`), which removes it from `resolvedIds` and returns the row.
+  // Optimistic hide + the existing rollback is the whole contract.
+  const resolvedIds = useMemo(() => {
+    const ids = new Set<string>();
+    for (const row of rawModel.order) {
+      if (isNeedsYouSection(row.section) && statusFor(row.id) === "resuming") ids.add(row.id);
+    }
+    return ids;
+  }, [rawModel, statusFor]);
+
+  const model = useMemo(() => {
+    if (resolvedIds.size === 0) return rawModel;
+    const keep = (row: { id: string }) => !resolvedIds.has(row.id);
+    return {
+      ...rawModel,
+      sections: rawModel.sections
+        .map((sec) => ({ ...sec, rows: sec.rows.filter(keep) }))
+        .filter((sec) => sec.rows.length > 0),
+      order: rawModel.order.filter(keep),
+      counts: {
+        ...rawModel.counts,
+        // Keep the calm header honest: a hidden row is not still "needing you".
+        attention: Math.max(0, rawModel.counts.attention - resolvedIds.size),
+      },
+    };
+  }, [rawModel, resolvedIds]);
 
   // The selection: null until the operator (or the default-select effect) picks a
   // row. Held in React state so j/k and click both drive the one reading pane.
@@ -253,12 +296,6 @@ export function HomeSurface() {
     return () => window.removeEventListener("keydown", onKey);
   }, [model.order]);
 
-  // CTL-903 / HOME5: the WRITE path. The hook owns the optimistic-resume state +
-  // the grace-window rollback; the verb fires record-response + resume-agent
-  // through the read-model write endpoint (board/respond-client.ts owns the
-  // fetch). The single-node case is an exact pass-through (the endpoint's
-  // identity fence no-op); a multi-node fence rejection arrives as `did-not-take`.
-  const { respond, statusFor, reconcile, markResolved, markDidNotTake } = useRespond();
   const onAct = useCallback(
     (id: string) => {
       // The recorded note is empty for the one-click verb — the BFF12 endpoint
@@ -290,12 +327,15 @@ export function HomeSurface() {
   // needs-you rows (blocked | waiting) — the exact "still shows the item waiting"
   // the scenario re-checks.
   const stillWaitingIds = useMemo(() => {
+    // RAW model on purpose: reconcile must see the row the server still reports as
+    // needs-you. Reading the projected model would make an optimistically hidden
+    // row look "cleared" immediately, so it could never roll back.
     const ids = new Set<string>();
-    for (const row of model.order) {
+    for (const row of rawModel.order) {
       if (isNeedsYouSection(row.section)) ids.add(row.id);
     }
     return ids;
-  }, [model]);
+  }, [rawModel]);
   useEffect(() => {
     reconcile(stillWaitingIds);
   }, [stillWaitingIds, reconcile]);

--- a/plugins/dev/scripts/orch-monitor/ui/src/components/home/home-surface.tsx
+++ b/plugins/dev/scripts/orch-monitor/ui/src/components/home/home-surface.tsx
@@ -216,7 +216,7 @@ export function HomeSurface() {
   // through the read-model write endpoint (board/respond-client.ts owns the
   // fetch). The single-node case is an exact pass-through (the endpoint's
   // identity fence no-op); a multi-node fence rejection arrives as `did-not-take`.
-  const { respond, statusFor, reconcile, markResolved, markDidNotTake } = useRespond();
+  const { respond, statusFor, reconcile, markResolved } = useRespond();
 
   // CTL-1569 / AC #8 ("posting removes the row without a manual refresh"): the
   // optimistic mark alone was NOT enough. `statusFor` only changed how the pane
@@ -337,10 +337,19 @@ export function HomeSurface() {
   // is restored rather than silently lost (§4).
   const onReplied = useCallback(
     (outcome: ReplyOutcome) => {
-      if (outcome.status === "replied") markResolved(outcome.ticket);
-      else if (outcome.status !== "empty") markDidNotTake(outcome.ticket);
+      if (outcome.status === "replied") {
+        markResolved(outcome.ticket);
+        return;
+      }
+      // Do NOT mark an UNSENT reply as a failed resume. For `no_token`,
+      // `bot_identity`, `not_found` and transport failures no comment was sent and
+      // no resume was ever attempted, so `PaneVerb`'s "The agent did not resume —
+      // try again" is a second, wrong diagnosis printed beside the reply box's
+      // accurate one. The row is still restored (it was never hidden), and the
+      // specific posting error is what the operator should act on.
+      // `empty` is likewise a no-op.
     },
-    [markResolved, markDidNotTake],
+    [markResolved],
   );
 
   // Reconcile the optimistic marks against EVERY new read-model frame: a row that

--- a/plugins/dev/scripts/orch-monitor/ui/src/components/home/home-surface.tsx
+++ b/plugins/dev/scripts/orch-monitor/ui/src/components/home/home-surface.tsx
@@ -41,6 +41,7 @@ import { useScopedBoardSnapshot } from "@/hooks/use-scoped-board-snapshot";
 // resumes the agent, with optimistic rollback. The hook owns the optimistic
 // state + grace timer; the pure client/fetch live in board/respond-client.ts.
 import { useRespond, type RespondRowStatus } from "@/hooks/use-respond";
+import type { ReplyOutcome } from "@/board/conversation-client";
 import { ResizableSplit } from "./resizable-split";
 import { InboxRow } from "./inbox-row";
 import { ReadingPane } from "./reading-pane";
@@ -257,7 +258,7 @@ export function HomeSurface() {
   // through the read-model write endpoint (board/respond-client.ts owns the
   // fetch). The single-node case is an exact pass-through (the endpoint's
   // identity fence no-op); a multi-node fence rejection arrives as `did-not-take`.
-  const { respond, statusFor, reconcile } = useRespond();
+  const { respond, statusFor, reconcile, markResolved, markDidNotTake } = useRespond();
   const onAct = useCallback(
     (id: string) => {
       // The recorded note is empty for the one-click verb — the BFF12 endpoint
@@ -266,6 +267,20 @@ export function HomeSurface() {
       void respond(id, "");
     },
     [respond],
+  );
+
+  // CTL-1569: the inline REPLY's outcome. A confirmed post is a real resolution —
+  // the Linear comment clears `needs-human` within seconds (CTL-1567) — so the row
+  // is optimistically cleared through the SAME mark + grace-window machinery the
+  // verb uses; if the label never actually clears, the standing reconcile rolls it
+  // back and the row returns. Every failure marks did-not-take instead, so the item
+  // is restored rather than silently lost (§4).
+  const onReplied = useCallback(
+    (outcome: ReplyOutcome) => {
+      if (outcome.status === "replied") markResolved(outcome.ticket);
+      else if (outcome.status !== "empty") markDidNotTake(outcome.ticket);
+    },
+    [markResolved, markDidNotTake],
   );
 
   // Reconcile the optimistic marks against EVERY new read-model frame: a row that
@@ -316,6 +331,7 @@ export function HomeSurface() {
               workers={payload?.workers ?? []}
               onAct={onAct}
               respondStatus={selectedRow ? statusFor(selectedRow.id) : "idle"}
+              onReplied={onReplied}
             />
           )
         }

--- a/plugins/dev/scripts/orch-monitor/ui/src/components/home/home-surface.tsx
+++ b/plugins/dev/scripts/orch-monitor/ui/src/components/home/home-surface.tsx
@@ -240,16 +240,29 @@ export function HomeSurface() {
   const model = useMemo(() => {
     if (resolvedIds.size === 0) return rawModel;
     const keep = (row: { id: string }) => !resolvedIds.has(row.id);
+    const sections = rawModel.sections
+      .map((sec) => ({ ...sec, rows: sec.rows.filter(keep) }))
+      .filter((sec) => sec.rows.length > 0);
+    const order = rawModel.order.filter(keep);
+
+    // EVERY derived field must be recomputed from the filtered rows, not copied.
+    // Copying them left `defaultSelectedId` pointing at a now-hidden row (so the
+    // selection effect reselected it), and left the blocked/waiting counts — which
+    // drive the calm header and `isAllClear` — still reporting the removed item as
+    // needing attention until another SSE frame arrived.
+    const perSection = (kind: string) =>
+      sections.find((sec) => sec.kind === kind)?.rows.length ?? 0;
+
     return {
       ...rawModel,
-      sections: rawModel.sections
-        .map((sec) => ({ ...sec, rows: sec.rows.filter(keep) }))
-        .filter((sec) => sec.rows.length > 0),
-      order: rawModel.order.filter(keep),
+      sections,
+      order,
+      defaultSelectedId: order.length > 0 ? order[0].id : null,
       counts: {
         ...rawModel.counts,
-        // Keep the calm header honest: a hidden row is not still "needing you".
-        attention: Math.max(0, rawModel.counts.attention - resolvedIds.size),
+        attention: perSection("attention"),
+        blocked: perSection("blocked"),
+        waiting: perSection("waiting"),
       },
     };
   }, [rawModel, resolvedIds]);
@@ -273,6 +286,9 @@ export function HomeSurface() {
   // selection vanished from the order, fall back to the head of the walk order.
   useEffect(() => {
     setSelectedId((prev) => {
+      // A row that was optimistically resolved is gone from `order`, so the
+      // selection falls through to the recomputed default rather than sticking to
+      // an id the list no longer renders.
       if (prev != null && model.order.some((r) => r.id === prev)) return prev;
       return model.defaultSelectedId;
     });

--- a/plugins/dev/scripts/orch-monitor/ui/src/components/home/reading-pane.tsx
+++ b/plugins/dev/scripts/orch-monitor/ui/src/components/home/reading-pane.tsx
@@ -81,6 +81,11 @@ import {
   mergeSummaryIntoTicket,
   type InboxSummaryResponse,
 } from "./inbox-summary-data";
+// CTL-1569: the conversation surface — the ask summary, the newest-first thread,
+// and the inline reply that posts a real Linear comment as the operator (which is
+// what actually clears `needs-human`, per CTL-1567).
+import { Conversation } from "./conversation";
+import type { ReplyOutcome } from "@/board/conversation-client";
 
 // ── inbox summary fetch-on-select (CTL-1042) ──────────────────────────────────
 type InboxSummaryState =
@@ -381,6 +386,7 @@ export function ReadingPane({
   workers,
   onAct,
   respondStatus = "idle",
+  onReplied,
 }: {
   row: InboxRow | null;
   /** The resident read-model workers — the View-in-Claude session id is the
@@ -392,6 +398,9 @@ export function ReadingPane({
   onAct?: (id: string) => void;
   /** CTL-903 (HOME5): the optimistic write status for the selected row. */
   respondStatus?: RespondRowStatus;
+  /** CTL-1569: the inline reply's outcome. The surface uses it to optimistically
+   *  clear the row on a CONFIRMED post and to leave it in place on any failure. */
+  onReplied?: (outcome: ReplyOutcome) => void;
 }) {
   if (!row) return <NothingSelected />;
 
@@ -486,6 +495,16 @@ export function ReadingPane({
         )}
         {needsYou && (
           <WhatsNeededNow row={effectiveRow} onAct={onAct} respondStatus={respondStatus} />
+        )}
+
+        {/* CTL-1569: the conversation — the derived ask ("what would satisfy
+            this?"), the Linear deep link, the inline reply box, and the
+            newest-first thread. Only needs-you rows carry it, so running/done rows
+            stay calm. It renders NOTHING while loading or on a read failure (fails
+            soft), and suppresses the reply affordance for synthesized rows with no
+            Linear ticket behind them. */}
+        {needsYou && (
+          <Conversation ticket={row.id} enabled onReplied={onReplied} />
         )}
 
         <Separator className="mt-6" />

--- a/plugins/dev/scripts/orch-monitor/ui/src/components/home/reading-pane.tsx
+++ b/plugins/dev/scripts/orch-monitor/ui/src/components/home/reading-pane.tsx
@@ -504,7 +504,20 @@ export function ReadingPane({
             soft), and suppresses the reply affordance for synthesized rows with no
             Linear ticket behind them. */}
         {needsYou && (
-          <Conversation ticket={row.id} enabled onReplied={onReplied} />
+          <Conversation
+            ticket={row.id}
+            enabled
+            // The RESOLVING reply path is offered only on a true `attention` row.
+            // `needsYou` also covers the scheduler's `blocked` and `queued` rows,
+            // and a human comment cannot resolve those: the daemon's comment-wake
+            // removes only `needs-human`/`needs-input`, never the admission-gate
+            // labels. Offering it there would optimistically hide the row and then
+            // roll it back after the grace window — a worse experience than not
+            // offering it. The thread stays READABLE either way; only the reply
+            // affordance is withheld.
+            canResolveByReply={row.section === "attention"}
+            onReplied={onReplied}
+          />
         )}
 
         <Separator className="mt-6" />

--- a/plugins/dev/scripts/orch-monitor/ui/src/hooks/use-respond.ts
+++ b/plugins/dev/scripts/orch-monitor/ui/src/hooks/use-respond.ts
@@ -41,6 +41,12 @@ export interface UseRespond {
   /** Reconcile the in-flight marks against the CURRENT frame's still-waiting set
    *  (drops cleared marks, rolls back expired ones). Idempotent; call per frame. */
   reconcile: (stillWaitingIds: ReadonlySet<string>) => void;
+  /** CTL-1569: arm the optimistic mark + grace window for a row resolved by the
+   *  inline REPLY (a real Linear comment) rather than by the `respond` verb. */
+  markResolved: (ticket: string) => void;
+  /** CTL-1569: mark a resolution attempt as having not taken — the row is restored
+   *  and the operator told (a failed reply post must never lose the item). */
+  markDidNotTake: (ticket: string) => void;
 }
 
 /**
@@ -135,5 +141,39 @@ export function useRespond(
     [marks, didNotTake],
   );
 
-  return { respond, statusFor, reconcile: applyReconcile };
+  // CTL-1569: apply the optimistic mark for a resolution that happened through a
+  // DIFFERENT write than `respond` — specifically the inbox's inline reply, which
+  // posts a real Linear comment (the comment itself is what clears `needs-human`,
+  // per CTL-1567). The reply client owns that fetch, so the hook must be able to
+  // arm the mark + grace window without firing a respond call of its own.
+  //
+  // Reusing this machinery rather than adding a second optimistic path is the whole
+  // point: the row's disappearance and its rollback-if-it-didn't-take stay governed
+  // by ONE reconcile rule.
+  const markResolved = useCallback(
+    (ticket: string) => {
+      setDidNotTake((prev) => {
+        if (!prev.has(ticket)) return prev;
+        const next = new Set(prev);
+        next.delete(ticket);
+        return next;
+      });
+      setMarks((prev) => [...prev.filter((m) => m.ticket !== ticket), { ticket, markedAt: now() }]);
+    },
+    [now],
+  );
+
+  // CTL-1569: flag a resolution attempt that did NOT take, so the row is restored
+  // and the operator told. Used for a failed reply post (§4: never silently lose
+  // the item) — the same surface state a rolled-back respond produces.
+  const markDidNotTake = useCallback((ticket: string) => {
+    setMarks((prev) => prev.filter((m) => m.ticket !== ticket));
+    setDidNotTake((prev) => {
+      const next = new Set(prev);
+      next.add(ticket);
+      return next;
+    });
+  }, []);
+
+  return { respond, statusFor, reconcile: applyReconcile, markResolved, markDidNotTake };
 }


### PR DESCRIPTION
Closes CTL-1569.

The operator can now read a parked ticket's thread and answer it **without leaving the inbox**. Since CTL-1567, a human comment on a parked ticket clears `needs-human` unconditionally and first — so posting a comment *is* the resolution mechanism, and the inbox now offers exactly that action.

## What shipped

**Backend** — all collaborators injectable, all unit-tested offline:

| Module | Role |
| --- | --- |
| `lib/inbox-ask.mjs` | Derives "what this needs from you": kind, summary, suggested replies, `canResolveByReply` |
| `lib/linear-thread.mjs` | The thread from the replica, newest-first. **Zero Linear API calls** |
| `lib/linear-comment.mjs` | Posts as the operator — and *verifies* it |
| `lib/reply-ticket.mjs` | Orchestration; a sibling of `/respond`, not a replacement |
| `lib/inbox-conversation.mjs` | Composition + the `canReply` gate |

Routes: `GET /api/ticket/<t>/thread` (replica-only read, fails open) and `POST /api/ticket/<t>/reply` (the one write, fails loud).

**Frontend** — `conversation.tsx`: the ask summary with one-click suggested replies that **prefill** (never auto-send), the newest-first thread with agent/human visually distinct and expand-in-place, the reply box, and the Linear deep link. Reply outcomes route through the **existing** optimistic-mark + grace-window rollback, so one reconcile rule decides when a row leaves the inbox.

## The anti-inert guard (the sharpest edge in this ticket)

CTL-1567's provenance gate requires a positively-identified **human** author and deliberately ignores app-actor comments. So a reply posted as the Catalyst app **silently does nothing** — the comment appears, the UI looks right, the row even clears optimistically, and the ticket stays parked forever.

So the post path does not *assume* it holds the right token: it resolves `viewer`, and **refuses before mutating** if the identity is an app actor, surfacing `bot_identity` so the row is restored and the operator is told. Refusing loudly beats a phantom success.

## Two deliberate deviations from the ticket

**1. AC #5's premise is false — replica `is_bot` does NOT give the agent/human split.**

Verified against the live replica:

| author_id | author_name | is_bot | n |
| --- | --- | --- | --- |
| `2edb25eb…` (human operator) | Ryan Rozich | 0 | 3131 |
| `null` | GitHub | 1 | 1420 |
| `7b5480e0…` (**worker app actor**) | Catalyst | **0** | 410 |
| `null` | Linear | 1 | 126 |
| `ff78d890…` (**orchestrator actor**) | Catalyst Orchestrator | **0** | 4 |

Linear models an app actor as a *user*, so the Catalyst agents' own comments — precisely the ones the operator is answering — arrive with `is_bot = 0`. Implementing AC #5 literally would render **every agent question as if the operator had written it**, and would make the "newest agent comment" ask fallback select the operator's own words. The split is now `is_bot` **OR** a configured `botUserId` — the same discriminator the daemon's self-echo guard uses, so there is one definition of "the agent" across the system.

**2. The reply does not reuse `/respond`, and does not synthesize a wake event.**

`/respond` writes local state only and emits a synthetic `linear.comment.created` with `authorId: null` — which is exactly what CTL-1567's gate declines to act on — and it hard-requires a held run via `findHeldRun`, so it 404s exactly the no-worker-dir tickets this feature exists for. The real comment's webhook is the verified path (~4s end to end); synthesizing a second wake would invite double-dispatch.

## Verification

- **Live**: reply posted as **Ryan Rozich (`2edb25eb…`)**, not the app actor — comment `c839353b` on CTL-1569, confirmed round-tripping back through the replica thread read.
- **Guard**: `postOperatorComment` with a non-human token posts nothing and returns `bot_identity`; over HTTP, a non-resolvable ticket returns 404, never a false `replied`.
- Parent `tsc` clean · `ui` `tsc` clean (1 pre-existing, unrelated: `cluster-capacity.test.ts:25`) · `knip` exit 0 · `lint` 0 errors · `ui` vite build passes with **no `bun:sqlite` in `dist/`** (the CTL-1561 graph trap — `linear-thread.mjs` reaches sqlite through a computed specifier; do not inline it).
- Tests: **154 new**, all passing. Full suite 6344 pass / **26 fail** — the *same 26 pre-existing* host-pollution failures as pristine `main` (`loadWebhookConfig` / `loadMonitorConfig` / `loadProjects` / `GET /api/nav` read the real `~/.config/catalyst`). Verified identical by stashing; **not a regression from this PR**.

## Acceptance criteria

| # | Criterion | Status |
| --- | --- | --- |
| 1 | Row states what would satisfy the ask + whether replying alone suffices | ✅ `data-ask-resolution`, given its own line |
| 2 | Ask kind visible at a glance | ✅ `data-ask-chip`, accent-tinted |
| 3 | Suggested replies prefill in one click | ✅ *(was broken — `deriveExplanation` discarded `options`; fixed in `cdfb348e`)* |
| 4 | Last few comments newest-first, replica, zero Linear API calls | ✅ |
| 5 | Agent and human visually distinct | ✅ — see deviation 1 |
| 6 | Every row links to its Linear ticket | ✅ |
| 7 | Reply posts a comment authored as the operator | ✅ live-verified |
| 8 | Posting removes the row without a refresh | ✅ *(was broken — the mark never filtered the model; fixed in `cdfb348e`)* |
| 9 | A failed post restores the row | ✅ draft kept, reason shown, `markDidNotTake` |
| 10 | Rows with no ticket show no reply affordance | ✅ `canReply` gate, unit-tested |
| 11 | A ≥3-turn conversation can be conducted from the inbox | ⚠️ one turn posted live; the full loop needs **CTL-1568** (agent reply must re-apply `needs-human`), which this is blocked-by |

## Not covered

- **Codex review**: 17 findings, 13 real defects, all fixed in `cdfb348e` and each thread resolved. #9 (replica freshness gate) deliberately deferred — see the review comment for why the `canReply` half already fails open.
- **No browser verification of the rendered pane** — the server path is proven end-to-end, but AC #1/#2 visual styling and the AC #10 orphan-row appearance are asserted by static source analysis, not a live screenshot.
- The actor split is **2-way**: a GitHub/Linear *integration* comment renders as AGENT, so the "synced to GitHub issue" notice is styled as the agent speaking. Defensible for the agent-vs-human requirement; if a 3-way split was intended, that is a follow-up.
- AC #11 needs CTL-1568 to close the loop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
