### PR TITLE
fix(dev): CTL-1551 Workers page reads peer liveness+capacity from Loki, not the dead Linear anchor

### DIFF
--- a/plugins/dev/scripts/execution-core/cluster-heartbeat-publisher.mjs
+++ b/plugins/dev/scripts/execution-core/cluster-heartbeat-publisher.mjs
@@ -50,7 +50,10 @@ function localClusterGeneration(orchDir, ticket) {
 // a cycle. Fail-open: any miss → null, so the heartbeat still publishes liveness
 // without claiming a slot count it can't prove (the monitor treats null as "no
 // data", never an error).
-function readLocalMaxParallel(orchDir) {
+// CTL-1551: exported so daemon.mjs can thread it into startHeartbeat's
+// maxParallelFn — the node.heartbeat attribute is now the cross-host capacity
+// transport (the Linear-anchor publish below is retired in loki mode).
+export function readLocalMaxParallel(orchDir) {
   if (!orchDir) return null;
   try {
     const n = JSON.parse(readFileSync(join(orchDir, "state.json"), "utf8"))?.maxParallel;

--- a/plugins/dev/scripts/execution-core/cluster-heartbeat-publisher.mjs
+++ b/plugins/dev/scripts/execution-core/cluster-heartbeat-publisher.mjs
@@ -50,10 +50,7 @@ function localClusterGeneration(orchDir, ticket) {
 // a cycle. Fail-open: any miss → null, so the heartbeat still publishes liveness
 // without claiming a slot count it can't prove (the monitor treats null as "no
 // data", never an error).
-// CTL-1551: exported so daemon.mjs can thread it into startHeartbeat's
-// maxParallelFn — the node.heartbeat attribute is now the cross-host capacity
-// transport (the Linear-anchor publish below is retired in loki mode).
-export function readLocalMaxParallel(orchDir) {
+function readLocalMaxParallel(orchDir) {
   if (!orchDir) return null;
   try {
     const n = JSON.parse(readFileSync(join(orchDir, "state.json"), "utf8"))?.maxParallel;

--- a/plugins/dev/scripts/execution-core/daemon.mjs
+++ b/plugins/dev/scripts/execution-core/daemon.mjs
@@ -1199,9 +1199,13 @@ export function startDaemon({
         // per-host capacity from Loki (the Linear-anchor capacity transport is
         // retired in loki mode). Uses the SAME readMaxParallel chokepoint the
         // scheduler enforces (config-precedence + bounds), NOT the raw state.json
-        // value — the two can diverge and peers must render the enforced ceiling.
-        // Fail-open: an invalid result → attribute omitted.
-        maxParallelFn: () => readMaxParallel(orchDir, concurrency),
+        // value — and RE-RESOLVES the Layer-1+Layer-2 concurrency per beat
+        // (resolveBootConcurrency, the designed hot-reload entry point) so an
+        // operator's live concurrency edit reaches peers without a restart,
+        // matching the scheduler's own per-tick re-read. Fail-open: an invalid
+        // result → attribute omitted.
+        maxParallelFn: () =>
+          readMaxParallel(orchDir, resolveBootConcurrency({ layer1Path: configPath, layer2Path })),
       });
       // CTL-1090: cross-host liveness publisher (multi-host only; single-host no-op).
       // startLivenessPublisher self-gates on roster.length > 1, so this is always safe.

--- a/plugins/dev/scripts/execution-core/daemon.mjs
+++ b/plugins/dev/scripts/execution-core/daemon.mjs
@@ -72,7 +72,7 @@ import { startRatelimitPoller as realStartRatelimitPoller } from "./ratelimit-po
 import { listProjects as realListProjects } from "./registry.mjs"; // CTL-854: boot health check
 import { startHeartbeat as realStartHeartbeat } from "./heartbeat-event.mjs"; // CTL-859: node.heartbeat emitter
 import { readAdmissionState } from "./admission-state.mjs"; // CTL-1322: live admission block for the heartbeat
-import { startLivenessPublisher as realStartLivenessPublisher, localInFlightTickets, readLocalMaxParallel } from "./cluster-heartbeat-publisher.mjs"; // CTL-1090: cross-host liveness; CTL-1420 (#17): in-flight list for the Loki heartbeat; CTL-1551: slot ceiling for the Loki heartbeat
+import { startLivenessPublisher as realStartLivenessPublisher, localInFlightTickets } from "./cluster-heartbeat-publisher.mjs"; // CTL-1090: cross-host liveness; CTL-1420 (#17): in-flight list for the Loki heartbeat
 import { emitBootEvent } from "./boot-event.mjs"; // CTL-1084: node.boot self-report
 import {
   recoverStartup,
@@ -120,6 +120,7 @@ import {
   readAllEligibleTickets, // CTL-862: boot-log ownership count
   clearHoldStopCooldown, // CTL-768
   defaultClearStall, // CTL-1067: J3 stall-clear seam
+  readMaxParallel, // CTL-1551: the SCHEDULER-ENFORCED slot ceiling for the heartbeat
 } from "./scheduler.mjs";
 import * as linearWrite from "./linear-write.mjs"; // CTL-1067: writeStatus for defaultClearStall
 import { labelMarkerBase } from "./label-guard.mjs"; // CTL-1567: canonical once-marker path (single source of truth)
@@ -1196,8 +1197,11 @@ export function startDaemon({
         inFlightTicketsFn: () => localInFlightTickets(getHostName(), { orchDir }),
         // CTL-1551: carry the live slot ceiling so a peer's monitor can render
         // per-host capacity from Loki (the Linear-anchor capacity transport is
-        // retired in loki mode). Fail-open: null → attribute omitted.
-        maxParallelFn: () => readLocalMaxParallel(orchDir),
+        // retired in loki mode). Uses the SAME readMaxParallel chokepoint the
+        // scheduler enforces (config-precedence + bounds), NOT the raw state.json
+        // value — the two can diverge and peers must render the enforced ceiling.
+        // Fail-open: an invalid result → attribute omitted.
+        maxParallelFn: () => readMaxParallel(orchDir, concurrency),
       });
       // CTL-1090: cross-host liveness publisher (multi-host only; single-host no-op).
       // startLivenessPublisher self-gates on roster.length > 1, so this is always safe.

--- a/plugins/dev/scripts/execution-core/daemon.mjs
+++ b/plugins/dev/scripts/execution-core/daemon.mjs
@@ -72,7 +72,7 @@ import { startRatelimitPoller as realStartRatelimitPoller } from "./ratelimit-po
 import { listProjects as realListProjects } from "./registry.mjs"; // CTL-854: boot health check
 import { startHeartbeat as realStartHeartbeat } from "./heartbeat-event.mjs"; // CTL-859: node.heartbeat emitter
 import { readAdmissionState } from "./admission-state.mjs"; // CTL-1322: live admission block for the heartbeat
-import { startLivenessPublisher as realStartLivenessPublisher, localInFlightTickets } from "./cluster-heartbeat-publisher.mjs"; // CTL-1090: cross-host liveness; CTL-1420 (#17): in-flight list for the Loki heartbeat
+import { startLivenessPublisher as realStartLivenessPublisher, localInFlightTickets, readLocalMaxParallel } from "./cluster-heartbeat-publisher.mjs"; // CTL-1090: cross-host liveness; CTL-1420 (#17): in-flight list for the Loki heartbeat; CTL-1551: slot ceiling for the Loki heartbeat
 import { emitBootEvent } from "./boot-event.mjs"; // CTL-1084: node.boot self-report
 import {
   recoverStartup,
@@ -1194,6 +1194,10 @@ export function startDaemon({
         // so a peer can read liveness + ownership from Loki (retiring the Linear
         // heartbeat attachment). Same local signal-scan source the publisher uses.
         inFlightTicketsFn: () => localInFlightTickets(getHostName(), { orchDir }),
+        // CTL-1551: carry the live slot ceiling so a peer's monitor can render
+        // per-host capacity from Loki (the Linear-anchor capacity transport is
+        // retired in loki mode). Fail-open: null → attribute omitted.
+        maxParallelFn: () => readLocalMaxParallel(orchDir),
       });
       // CTL-1090: cross-host liveness publisher (multi-host only; single-host no-op).
       // startLivenessPublisher self-gates on roster.length > 1, so this is always safe.

--- a/plugins/dev/scripts/execution-core/heartbeat-event.mjs
+++ b/plugins/dev/scripts/execution-core/heartbeat-event.mjs
@@ -47,9 +47,22 @@ export const HEARTBEAT_EVENT = "node.heartbeat";
  * @param {Function} [opts.inFlightTicketsFn]  CTL-1420 (#17): injectable fn returning
  *   this host's in-flight ticket IDs (string[]); the daemon supplies the local
  *   signal-scan list. Defaults to [] for non-daemon callers/tests.
+ * @param {Function} [opts.maxParallelFn]  CTL-1551: injectable fn returning this
+ *   host's live parallel-slot ceiling (positive integer, or null when unknown);
+ *   the daemon supplies readLocalMaxParallel. Carried as a top-level ATTRIBUTE
+ *   (body.payload is stripped before OTLP — otlp.ts:51) so a peer's monitor can
+ *   render per-host capacity from Loki now that the Linear-anchor publish (the
+ *   only prior cross-host max_parallel transport) is retired in loki mode.
  * @returns {object} the envelope object
  */
-export function buildHeartbeatEnvelope({ now, epochFn, governanceFn, admissionFn, inFlightTicketsFn } = {}) {
+export function buildHeartbeatEnvelope({
+  now,
+  epochFn,
+  governanceFn,
+  admissionFn,
+  inFlightTicketsFn,
+  maxParallelFn,
+} = {}) {
   const ts = now ? now() : new Date().toISOString().replace(/\.\d{3}Z$/, "Z");
   const epoch = epochFn ? epochFn() : Date.now();
   const host = getHostName();
@@ -71,6 +84,12 @@ export function buildHeartbeatEnvelope({ now, epochFn, governanceFn, admissionFn
   const inFlightTickets = Array.isArray(inFlightRaw)
     ? inFlightRaw.filter((t) => typeof t === "string" && t.length > 0)
     : [];
+  // CTL-1551: live slot ceiling as a Loki-reachable attribute (low-card int →
+  // structured metadata, same rationale as in_flight_count). Fail-safe: a
+  // missing/invalid value → attribute omitted, never a fake 0 (the monitor
+  // treats "absent" as no-data, but a literal 0 would render as zero capacity).
+  const mpRaw = maxParallelFn ? maxParallelFn() : null;
+  const maxParallel = Number.isInteger(mpRaw) && mpRaw > 0 ? mpRaw : null;
 
   return {
     ts,
@@ -89,6 +108,8 @@ export function buildHeartbeatEnvelope({ now, epochFn, governanceFn, admissionFn
       // CTL-1420 (#17): Loki-queryable cross-host liveness+ownership signal.
       "catalyst.node.in_flight_tickets": inFlightTickets.join(","),
       "catalyst.node.in_flight_count": inFlightTickets.length,
+      // CTL-1551: Loki-queryable cross-host capacity signal (omitted when unknown).
+      ...(maxParallel != null ? { "catalyst.node.max_parallel": maxParallel } : {}),
     },
     body: {
       payload: {
@@ -117,8 +138,9 @@ export async function emitHeartbeatEvent({
   governanceFn,
   admissionFn,
   inFlightTicketsFn, // CTL-1420 (#17): forward the in-flight-tickets seam to the builder
+  maxParallelFn, // CTL-1551: forward the slot-ceiling seam to the builder
 } = {}) {
-  const line = `${JSON.stringify(buildHeartbeatEnvelope({ now, epochFn, governanceFn, admissionFn, inFlightTicketsFn }))}\n`;
+  const line = `${JSON.stringify(buildHeartbeatEnvelope({ now, epochFn, governanceFn, admissionFn, inFlightTicketsFn, maxParallelFn }))}\n`;
   try {
     await mkdir(dirname(logPath), { recursive: true });
     await appendFile(logPath, line);
@@ -141,8 +163,9 @@ export async function emitHeartbeatEvent({
  * @param {Function} [opts.admissionFn]  CTL-1322: live admission-state fn (daemon-supplied)
  * @param {Function} [opts.governanceFn] CTL-1062: live governance snapshot fn (optional override)
  * @param {Function} [opts.inFlightTicketsFn] CTL-1420 (#17): live in-flight-tickets fn (daemon-supplied)
+ * @param {Function} [opts.maxParallelFn] CTL-1551: live slot-ceiling fn (daemon-supplied)
  */
-export function startHeartbeat({ intervalMs = HEARTBEAT_INTERVAL_MS, logPath, admissionFn, governanceFn, inFlightTicketsFn } = {}) {
+export function startHeartbeat({ intervalMs = HEARTBEAT_INTERVAL_MS, logPath, admissionFn, governanceFn, inFlightTicketsFn, maxParallelFn } = {}) {
   const tick = () => {
     // CTL-1280: deterministic liveness heartbeat to daemon.log (Alloy→Loki),
     // riding the same cadence as the node.heartbeat event but on the .log stream
@@ -152,7 +175,7 @@ export function startHeartbeat({ intervalMs = HEARTBEAT_INTERVAL_MS, logPath, ad
     // CTL-1517: per-process RSS/heap OTel gauge on the same tick (fire-and-forget; never
     // throws, never blocks) so per-daemon memory becomes attributable in Prometheus.
     emitProcessMemoryMetric({ serviceName: "catalyst.execution-core", log }).catch(() => {});
-    return emitHeartbeatEvent({ logPath, admissionFn, governanceFn, inFlightTicketsFn }).catch(() => {});
+    return emitHeartbeatEvent({ logPath, admissionFn, governanceFn, inFlightTicketsFn, maxParallelFn }).catch(() => {});
   };
   const started = tick(); // emit once at boot; Promise for callers that need to await it
   const timer = setInterval(tick, intervalMs);

--- a/plugins/dev/scripts/execution-core/heartbeat-event.test.mjs
+++ b/plugins/dev/scripts/execution-core/heartbeat-event.test.mjs
@@ -75,6 +75,21 @@ describe("buildHeartbeatEnvelope (CTL-859)", () => {
     const env = buildHeartbeatEnvelope();
     expect(env.ts).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$/);
   });
+
+  // ── CTL-1551: max_parallel as a Loki-reachable attribute ──
+  test("carries catalyst.node.max_parallel when maxParallelFn supplies a positive int", () => {
+    const env = buildHeartbeatEnvelope({ maxParallelFn: () => 3 });
+    expect(env.attributes["catalyst.node.max_parallel"]).toBe(3);
+  });
+
+  test("omits catalyst.node.max_parallel when unknown — never a fake 0", () => {
+    for (const bad of [null, 0, -1, 2.5, "3", NaN, undefined]) {
+      const env = buildHeartbeatEnvelope({ maxParallelFn: () => bad });
+      expect("catalyst.node.max_parallel" in env.attributes).toBe(false);
+    }
+    const noFn = buildHeartbeatEnvelope();
+    expect("catalyst.node.max_parallel" in noFn.attributes).toBe(false);
+  });
 });
 
 describe("emitHeartbeatEvent (CTL-859)", () => {

--- a/plugins/dev/scripts/execution-core/loki-liveness.mjs
+++ b/plugins/dev/scripts/execution-core/loki-liveness.mjs
@@ -76,9 +76,17 @@ export function parseLokiLivenessResponse(body) {
         (meta && meta.catalyst_node_in_flight_tickets) ??
         labels.catalyst_node_in_flight_tickets ??
         "";
+      // CTL-1551: capacity fields — same meta-or-label defensiveness as tickets.
+      // Loki serializes numeric attributes as strings; parse, reject non-finite.
+      const rawMp = (meta && meta.catalyst_node_max_parallel) ?? labels.catalyst_node_max_parallel;
+      const rawIfc = (meta && meta.catalyst_node_in_flight_count) ?? labels.catalyst_node_in_flight_count;
+      const mp = Number(rawMp);
+      const ifc = Number(rawIfc);
       out[host] = {
         last_seen: new Date(tsMs).toISOString(),
         in_flight_tickets: parseInFlight(rawTickets),
+        max_parallel: Number.isInteger(mp) && mp > 0 ? mp : null,
+        in_flight_count: Number.isInteger(ifc) && ifc >= 0 ? ifc : null,
       };
     }
   }
@@ -147,6 +155,26 @@ export async function readClusterLivenessFromLoki({
       }
     } catch (err) {
       logger?.warn?.({ err: err?.message }, "loki-liveness: tickets enrichment failed (ownership → local fallback)");
+    }
+    // CTL-1551 (query C, best-effort): capacity enrichment. Loki only surfaces a
+    // structured-metadata field when the query REFERENCES it (same reason query B
+    // exists), so a third filtered query forces catalyst_node_max_parallel into
+    // the response and its newest values are merged onto A. Failure leaves
+    // capacity null — the monitor renders "no data" zeros, liveness unaffected.
+    try {
+      const cBody = await queryLokiStreams(
+        mkUrl(`${sel} | catalyst_node_max_parallel=~\`.+\``),
+        timeoutMs,
+        fetcher,
+      );
+      const capEnriched = cBody ? parseLokiLivenessResponse(cBody) : {};
+      for (const [host, rec] of Object.entries(capEnriched)) {
+        if (!out[host]) continue;
+        if (rec.max_parallel != null) out[host].max_parallel = rec.max_parallel;
+        if (rec.in_flight_count != null) out[host].in_flight_count = rec.in_flight_count;
+      }
+    } catch (err) {
+      logger?.warn?.({ err: err?.message }, "loki-liveness: capacity enrichment failed (capacity → no-data)");
     }
     return out;
   } catch (err) {

--- a/plugins/dev/scripts/execution-core/loki-liveness.mjs
+++ b/plugins/dev/scripts/execution-core/loki-liveness.mjs
@@ -63,15 +63,19 @@ export function parseLokiLivenessResponse(body) {
   const newestMs = {};
   for (const stream of results) {
     const labels = (stream && stream.stream) || {};
-    const host = labels.host_name;
-    if (typeof host !== "string" || host.length === 0) continue;
     const values = Array.isArray(stream.values) ? stream.values : [];
     for (const v of values) {
       const tsMs = nsToMs(v && v[0]);
       if (!Number.isFinite(tsMs)) continue;
+      // CTL-1551: host resolves label-first (the deployed topology — Loki merges
+      // structured metadata into the response's stream object, verified live),
+      // with a per-entry structured-metadata fallback for a topology that keeps
+      // host_name entry-scoped instead.
+      const meta = (v && v[2]) || null;
+      const host = labels.host_name ?? (meta && meta.host_name);
+      if (typeof host !== "string" || host.length === 0) continue;
       if (host in newestMs && tsMs <= newestMs[host]) continue; // not strictly newer → skip
       newestMs[host] = tsMs;
-      const meta = (v && v[2]) || null;
       const rawTickets =
         (meta && meta.catalyst_node_in_flight_tickets) ??
         labels.catalyst_node_in_flight_tickets ??
@@ -162,8 +166,12 @@ export async function readClusterLivenessFromLoki({
     // the response and its newest values are merged onto A. Failure leaves
     // capacity null — the monitor renders "no data" zeros, liveness unaffected.
     try {
+      // Reference BOTH capacity fields so Loki surfaces them regardless of
+      // whether the topology promotes them into the response stream object —
+      // every mp-bearing heartbeat line also carries the count, so the AND
+      // filter matches the same lines.
       const cBody = await queryLokiStreams(
-        mkUrl(`${sel} | catalyst_node_max_parallel=~\`.+\``),
+        mkUrl(`${sel} | catalyst_node_max_parallel=~\`.+\` | catalyst_node_in_flight_count=~\`.+\``),
         timeoutMs,
         fetcher,
       );

--- a/plugins/dev/scripts/execution-core/loki-liveness.test.mjs
+++ b/plugins/dev/scripts/execution-core/loki-liveness.test.mjs
@@ -195,6 +195,21 @@ describe("capacity enrichment (CTL-1551)", () => {
     expect(out.mini.in_flight_count).toBe(2);
   });
 
+  test("parse: host from per-entry structured metadata when absent from stream labels (CTL-1551)", () => {
+    const out = parseLokiLivenessResponse({
+      data: {
+        result: [
+          {
+            stream: { event_name: "node.heartbeat" }, // no host_name label
+            values: [["1783451090000000000", "node.heartbeat", { host_name: "mini-2" }]],
+          },
+        ],
+      },
+    });
+    expect(out["mini-2"]).toBeDefined();
+    expect(out["mini-2"].last_seen).toBe("2026-07-07T19:04:50.000Z");
+  });
+
   test("parse: capacity from the promoted-stream-label shape", () => {
     const out = parseLokiLivenessResponse({
       data: { result: [capStream("mini-2", "1783451090000000000", { mp: "4", ifc: "0", asLabels: true })] },

--- a/plugins/dev/scripts/execution-core/loki-liveness.test.mjs
+++ b/plugins/dev/scripts/execution-core/loki-liveness.test.mjs
@@ -173,3 +173,79 @@ describe("readClusterLivenessFromLoki (CTL-1420 #17) — fail-open", () => {
     expect(out.mini.in_flight_tickets).toEqual([]);
   });
 });
+
+// ── CTL-1551: capacity fields (max_parallel / in_flight_count) ──
+// Loki only surfaces a structured-metadata field when the query references it, so
+// capacity rides a third best-effort query (C) merged onto A — mirroring tickets (B).
+describe("capacity enrichment (CTL-1551)", () => {
+  const capStream = (host, tsNs, { mp, ifc, asLabels } = {}) => {
+    const meta = {};
+    if (mp !== undefined) meta.catalyst_node_max_parallel = mp;
+    if (ifc !== undefined) meta.catalyst_node_in_flight_count = ifc;
+    const s = { host_name: host, event_name: "node.heartbeat" };
+    if (asLabels) Object.assign(s, meta);
+    return { stream: s, values: [asLabels ? [tsNs, "node.heartbeat"] : [tsNs, "node.heartbeat", meta]] };
+  };
+
+  test("parse: capacity from structured metadata (numbers arrive as Loki strings)", () => {
+    const out = parseLokiLivenessResponse({
+      data: { result: [capStream("mini", "1783451090000000000", { mp: "3", ifc: "2" })] },
+    });
+    expect(out.mini.max_parallel).toBe(3);
+    expect(out.mini.in_flight_count).toBe(2);
+  });
+
+  test("parse: capacity from the promoted-stream-label shape", () => {
+    const out = parseLokiLivenessResponse({
+      data: { result: [capStream("mini-2", "1783451090000000000", { mp: "4", ifc: "0", asLabels: true })] },
+    });
+    expect(out["mini-2"].max_parallel).toBe(4);
+    expect(out["mini-2"].in_flight_count).toBe(0);
+  });
+
+  test("parse: absent/invalid capacity → null, never 0 or NaN", () => {
+    const out = parseLokiLivenessResponse({
+      data: {
+        result: [
+          capStream("a", "1783451090000000000", {}),
+          capStream("b", "1783451090000000000", { mp: "garbage", ifc: "-1" }),
+          capStream("c", "1783451090000000000", { mp: "0" }),
+        ],
+      },
+    });
+    expect(out.a.max_parallel).toBeNull();
+    expect(out.a.in_flight_count).toBeNull();
+    expect(out.b.max_parallel).toBeNull();
+    expect(out.b.in_flight_count).toBeNull();
+    expect(out.c.max_parallel).toBeNull();
+  });
+
+  test("three-query: capacity from C merged onto A's liveness map", async () => {
+    const fetcher = async (url) => {
+      if (url.includes("max_parallel"))
+        return ok([capStream("mini", "1783451090000000000", { mp: "3", ifc: "1" })]);
+      if (url.includes("in_flight_tickets")) return ok([]);
+      return ok([
+        stream("mini", [{ tsNs: "1783451090000000000" }]),
+        stream("mini-2", [{ tsNs: "1783451092000000000" }]),
+      ]);
+    };
+    const out = await readClusterLivenessFromLoki({ lokiUrl: "http://loki:3100", fetcher, nowMs: 1783451100000 });
+    expect(out.mini.max_parallel).toBe(3);
+    expect(out.mini.in_flight_count).toBe(1);
+    expect(out["mini-2"].max_parallel).toBeNull(); // no capacity published → no-data, not 0
+  });
+
+  test("capacity-enrichment (query C) failure does NOT break liveness or tickets", async () => {
+    const fetcher = async (url) => {
+      if (url.includes("max_parallel")) throw new Error("loki blip on C");
+      if (url.includes("in_flight_tickets"))
+        return ok([stream("mini", [{ tsNs: "1783451090000000000", metaTickets: "CTL-7" }])]);
+      return ok([stream("mini", [{ tsNs: "1783451090000000000" }])]);
+    };
+    const out = await readClusterLivenessFromLoki({ lokiUrl: "http://loki:3100", fetcher });
+    expect(out.mini.last_seen).toBeDefined();
+    expect(out.mini.in_flight_tickets).toEqual(["CTL-7"]);
+    expect(out.mini.max_parallel).toBeNull();
+  });
+});

--- a/plugins/dev/scripts/orch-monitor/__tests__/peer-liveness.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/peer-liveness.test.ts
@@ -146,6 +146,50 @@ describe("readPeerRecords (CTL-1551)", () => {
     expect(retainMissingEntries(prev, null)).toEqual(prev);
   });
 
+  it("foldPeerSnapshot: a STALE anchor record (same host key, older ts) cannot regress a fresher cache", async () => {
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore — .mjs module
+    const { foldPeerSnapshot } = await import("../lib/peer-liveness.mjs");
+    const out = foldPeerSnapshot({
+      prevHeartbeats: { "mini-2": "2026-07-30T15:00:00Z" }, // fresh (from Loki)
+      prevCapacity: { "mini-2": { maxParallel: 3, inFlightCount: 1 } },
+      peers: {
+        // AUTO anchor fallback after a Loki blip: same host, weeks-old data
+        "mini-2": { last_seen: "2026-07-09T00:00:00Z", max_parallel: 3, in_flight_count: 6 },
+      },
+    });
+    expect(out.heartbeats["mini-2"]).toBe("2026-07-30T15:00:00Z"); // newest wins
+    expect(out.capacity["mini-2"]).toEqual({ maxParallel: 3, inFlightCount: 1 }); // stale capacity blocked
+  });
+
+  it("foldPeerSnapshot: capacity-less records (failed enrichment → nulls) retain previous capacity", async () => {
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore — .mjs module
+    const { foldPeerSnapshot } = await import("../lib/peer-liveness.mjs");
+    const out = foldPeerSnapshot({
+      prevHeartbeats: { mini: "2026-07-30T15:00:00Z" },
+      prevCapacity: { mini: { maxParallel: 3, inFlightCount: 2 } },
+      peers: {
+        mini: { last_seen: "2026-07-30T15:01:00Z", max_parallel: null, in_flight_count: null },
+      },
+    });
+    expect(out.heartbeats.mini).toBe("2026-07-30T15:01:00Z"); // liveness still advances
+    expect(out.capacity.mini).toEqual({ maxParallel: 3, inFlightCount: 2 }); // capacity retained, not zeroed
+  });
+
+  it("foldPeerSnapshot: a fresher capacity-bearing record updates both caches", async () => {
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore — .mjs module
+    const { foldPeerSnapshot } = await import("../lib/peer-liveness.mjs");
+    const out = foldPeerSnapshot({
+      prevHeartbeats: { mini: "2026-07-30T15:00:00Z" },
+      prevCapacity: { mini: { maxParallel: 3, inFlightCount: 2 } },
+      peers: { mini: { last_seen: "2026-07-30T15:01:00Z", max_parallel: 4, in_flight_count: 0 } },
+    });
+    expect(out.heartbeats.mini).toBe("2026-07-30T15:01:00Z");
+    expect(out.capacity.mini).toEqual({ maxParallel: 4, inFlightCount: 0 });
+  });
+
   it("a THROWING anchor read propagates (caller's outer catch keeps the last cache)", () => {
     expect(() =>
       readPeerRecords({

--- a/plugins/dev/scripts/orch-monitor/__tests__/peer-liveness.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/peer-liveness.test.ts
@@ -1,0 +1,141 @@
+// peer-liveness.test.ts — CTL-1551: source-aware peer-transport selection for the
+// monitor's background peer poll (Loki preferred, Linear anchor legacy fallback).
+import { describe, it, expect } from "bun:test";
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore — .mjs module without type declarations
+import { readPeerRecords } from "../lib/peer-liveness.mjs";
+
+const LOKI_PEERS = {
+  "mini-2": {
+    last_seen: "2026-07-30T15:00:00Z",
+    in_flight_tickets: ["CTL-1"],
+    max_parallel: 3,
+    in_flight_count: 1,
+  },
+};
+const ANCHOR_PEERS = {
+  mini: { last_seen: "2026-07-09T00:00:00Z", in_flight_tickets: [], max_parallel: 3, in_flight_count: 6 },
+};
+
+describe("readPeerRecords (CTL-1551)", () => {
+  it("AUTO (unset source): prefers Loki when the URL resolves and peers exist", () => {
+    const r = readPeerRecords({
+      rawSource: undefined,
+      lokiUrl: "http://loki:3100",
+      anchorIssue: "CTL-1217",
+      readLoki: () => LOKI_PEERS,
+      readAnchor: () => ANCHOR_PEERS,
+    });
+    expect(r.source).toBe("loki");
+    expect(r.peers).toEqual(LOKI_PEERS);
+  });
+
+  it("AUTO: empty Loki result falls back to the anchor", () => {
+    const r = readPeerRecords({
+      rawSource: "",
+      lokiUrl: "http://loki:3100",
+      anchorIssue: "CTL-1217",
+      readLoki: () => ({}),
+      readAnchor: () => ANCHOR_PEERS,
+    });
+    expect(r.source).toBe("anchor");
+    expect(r.peers).toEqual(ANCHOR_PEERS);
+  });
+
+  it("AUTO: a THROWING Loki read falls back to the anchor (Loki down ≠ blank display)", () => {
+    const r = readPeerRecords({
+      rawSource: undefined,
+      lokiUrl: "http://loki:3100",
+      anchorIssue: "CTL-1217",
+      readLoki: () => {
+        throw new Error("loki unreachable");
+      },
+      readAnchor: () => ANCHOR_PEERS,
+    });
+    expect(r.source).toBe("anchor");
+    expect(r.peers).toEqual(ANCHOR_PEERS);
+  });
+
+  it("AUTO: no Loki URL → anchor", () => {
+    const r = readPeerRecords({
+      rawSource: undefined,
+      lokiUrl: null,
+      anchorIssue: "CTL-1217",
+      readLoki: () => LOKI_PEERS,
+      readAnchor: () => ANCHOR_PEERS,
+    });
+    expect(r.source).toBe("anchor");
+  });
+
+  it("explicit loki: trusts an empty result — never reads the retired anchor", () => {
+    let anchorCalls = 0;
+    const r = readPeerRecords({
+      rawSource: "loki",
+      lokiUrl: "http://loki:3100",
+      anchorIssue: "CTL-1217",
+      readLoki: () => ({}),
+      readAnchor: () => {
+        anchorCalls++;
+        return ANCHOR_PEERS;
+      },
+    });
+    expect(r.source).toBe("loki");
+    expect(r.peers).toEqual({});
+    expect(anchorCalls).toBe(0);
+  });
+
+  it("explicit loki with no URL: fail-open to no peers, still never the anchor", () => {
+    const r = readPeerRecords({
+      rawSource: "LOKI",
+      lokiUrl: null,
+      anchorIssue: "CTL-1217",
+      readLoki: () => LOKI_PEERS,
+      readAnchor: () => ANCHOR_PEERS,
+    });
+    expect(r.source).toBe("loki");
+    expect(r.peers).toEqual({});
+  });
+
+  it("explicit linear: anchor only, Loki never consulted", () => {
+    let lokiCalls = 0;
+    const r = readPeerRecords({
+      rawSource: "linear",
+      lokiUrl: "http://loki:3100",
+      anchorIssue: "CTL-1217",
+      readLoki: () => {
+        lokiCalls++;
+        return LOKI_PEERS;
+      },
+      readAnchor: () => ANCHOR_PEERS,
+    });
+    expect(r.source).toBe("anchor");
+    expect(r.peers).toEqual(ANCHOR_PEERS);
+    expect(lokiCalls).toBe(0);
+  });
+
+  it("no transport configured (no URL, no anchor) → peers null so the caller clears caches", () => {
+    const r = readPeerRecords({
+      rawSource: undefined,
+      lokiUrl: null,
+      anchorIssue: null,
+      readLoki: () => LOKI_PEERS,
+      readAnchor: () => ANCHOR_PEERS,
+    });
+    expect(r.source).toBe("none");
+    expect(r.peers).toBeNull();
+  });
+
+  it("a THROWING anchor read propagates (caller's outer catch keeps the last cache)", () => {
+    expect(() =>
+      readPeerRecords({
+        rawSource: "linear",
+        lokiUrl: null,
+        anchorIssue: "CTL-1217",
+        readLoki: () => ({}),
+        readAnchor: () => {
+          throw new Error("anchor read failed");
+        },
+      })
+    ).toThrow("anchor read failed");
+  });
+});

--- a/plugins/dev/scripts/orch-monitor/__tests__/peer-liveness.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/peer-liveness.test.ts
@@ -113,6 +113,45 @@ describe("readPeerRecords (CTL-1551)", () => {
     expect(lokiCalls).toBe(0);
   });
 
+  it("AUTO loki-only (no anchor): a failed/empty Loki read returns EMPTY peers, not null — caches retained", () => {
+    const r = readPeerRecords({
+      rawSource: undefined,
+      lokiUrl: "http://loki:3100",
+      anchorIssue: null, // loki-only host — no legacy anchor
+      readLoki: () => ({}), // fail-open empty (outage)
+      readAnchor: undefined,
+    });
+    expect(r.source).toBe("loki");
+    expect(r.peers).toEqual({}); // {} flows through the fold → retention keeps caches
+  });
+
+  it("foldPeerSnapshot: partial capacity record merges per-field, never zeroing the absent one", async () => {
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore — .mjs module
+    const { foldPeerSnapshot } = await import("../lib/peer-liveness.mjs");
+    const out = foldPeerSnapshot({
+      prevHeartbeats: { mini: "2026-07-30T15:00:00Z" },
+      prevCapacity: { mini: { maxParallel: 3, inFlightCount: 2 } },
+      peers: { mini: { last_seen: "2026-07-30T15:01:00Z", max_parallel: 4, in_flight_count: null } },
+      nowMs: Date.parse("2026-07-30T15:01:30Z"),
+    });
+    expect(out.capacity.mini).toEqual({ maxParallel: 4, inFlightCount: 2 }); // ifc retained
+  });
+
+  it("foldPeerSnapshot: a FUTURE-skewed cached timestamp does not block corrected heartbeats", async () => {
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore — .mjs module
+    const { foldPeerSnapshot } = await import("../lib/peer-liveness.mjs");
+    const now = Date.parse("2026-07-30T15:00:00Z");
+    const out = foldPeerSnapshot({
+      prevHeartbeats: { mini: "2026-07-30T18:00:00Z" }, // 3h in the future — poisoned
+      prevCapacity: {},
+      peers: { mini: { last_seen: "2026-07-30T14:59:50Z" } }, // corrected clock
+      nowMs: now,
+    });
+    expect(out.heartbeats.mini).toBe("2026-07-30T14:59:50Z"); // recovered
+  });
+
   it("no transport configured (no URL, no anchor) → peers null so the caller clears caches", () => {
     const r = readPeerRecords({
       rawSource: undefined,

--- a/plugins/dev/scripts/orch-monitor/__tests__/peer-liveness.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/peer-liveness.test.ts
@@ -125,6 +125,27 @@ describe("readPeerRecords (CTL-1551)", () => {
     expect(r.peers).toBeNull();
   });
 
+  it("retainMissingEntries: a host missing from a partial snapshot keeps its previous entry", async () => {
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore — .mjs module
+    const { retainMissingEntries } = await import("../lib/peer-liveness.mjs");
+    const prev = { mini: "2026-07-30T15:00:00Z", "mini-2": "2026-07-30T15:00:10Z" };
+    const next = { mini: "2026-07-30T15:01:00Z" }; // mini-2 absent this snapshot
+    expect(retainMissingEntries(prev, next)).toEqual({
+      mini: "2026-07-30T15:01:00Z", // fresh value wins
+      "mini-2": "2026-07-30T15:00:10Z", // retained — ages out via liveness grace
+    });
+  });
+
+  it("retainMissingEntries: an EMPTY snapshot (Loki outage fail-open) keeps the whole cache", async () => {
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore — .mjs module
+    const { retainMissingEntries } = await import("../lib/peer-liveness.mjs");
+    const prev = { mini: { maxParallel: 3, inFlightCount: 1 } };
+    expect(retainMissingEntries(prev, {})).toEqual(prev);
+    expect(retainMissingEntries(prev, null)).toEqual(prev);
+  });
+
   it("a THROWING anchor read propagates (caller's outer catch keeps the last cache)", () => {
     expect(() =>
       readPeerRecords({

--- a/plugins/dev/scripts/orch-monitor/lib/peer-liveness.d.mts
+++ b/plugins/dev/scripts/orch-monitor/lib/peer-liveness.d.mts
@@ -31,3 +31,13 @@ export interface ReadPeerRecordsResult {
 }
 
 export function readPeerRecords(args?: ReadPeerRecordsArgs): ReadPeerRecordsResult;
+
+/**
+ * Retain previous-cache entries for hosts absent from the new snapshot, so a
+ * partial/empty Loki read cannot instantly blank a still-fresh peer (retained
+ * entries age out via the normal node-liveness grace).
+ */
+export function retainMissingEntries<T>(
+  prev: Record<string, T> | null | undefined,
+  next: Record<string, T> | null | undefined
+): Record<string, T>;

--- a/plugins/dev/scripts/orch-monitor/lib/peer-liveness.d.mts
+++ b/plugins/dev/scripts/orch-monitor/lib/peer-liveness.d.mts
@@ -41,3 +41,21 @@ export function retainMissingEntries<T>(
   prev: Record<string, T> | null | undefined,
   next: Record<string, T> | null | undefined
 ): Record<string, T>;
+
+export interface FoldPeerSnapshotArgs {
+  prevHeartbeats?: Record<string, string>;
+  prevCapacity?: Record<string, { maxParallel: number; inFlightCount: number }>;
+  peers?: Record<string, PeerRecord>;
+}
+
+export interface FoldPeerSnapshotResult {
+  heartbeats: Record<string, string>;
+  capacity: Record<string, { maxParallel: number; inFlightCount: number }>;
+}
+
+/**
+ * Fold one peer snapshot into the poll caches with the CTL-1551 guard set:
+ * per-host newest-wins, capacity only from capacity-bearing records, and
+ * retention for hosts missing from the snapshot.
+ */
+export function foldPeerSnapshot(args?: FoldPeerSnapshotArgs): FoldPeerSnapshotResult;

--- a/plugins/dev/scripts/orch-monitor/lib/peer-liveness.d.mts
+++ b/plugins/dev/scripts/orch-monitor/lib/peer-liveness.d.mts
@@ -1,0 +1,33 @@
+// Type declarations for peer-liveness.mjs (CTL-1551) — source-aware selection of
+// the cross-host peer-liveness transport (Loki preferred, Linear anchor legacy
+// fallback) for the monitor's background peer poll.
+
+/** Per-host peer record — the shape both transports produce (AnchorPeerRec-compatible). */
+export interface PeerRecord {
+  host?: string;
+  last_seen?: string;
+  in_flight_tickets?: string[];
+  max_parallel?: number | null;
+  in_flight_count?: number | null;
+}
+
+export interface ReadPeerRecordsArgs {
+  /** Raw CATALYST_LIVENESS_READ_SOURCE value: "loki" | "linear" | unset (AUTO). */
+  rawSource?: string | undefined;
+  /** Resolved Loki query base URL, or null when none is available. */
+  lokiUrl?: string | null;
+  /** The Linear liveness-anchor issue id, or null when unconfigured. */
+  anchorIssue?: string | null;
+  /** Loki transport (throws are swallowed → AUTO falls back to the anchor). */
+  readLoki?: (args: { lokiUrl: string }) => Record<string, PeerRecord>;
+  /** Anchor transport (throws PROPAGATE so the caller keeps its last cache). */
+  readAnchor?: (args: { anchorIssue: string }) => Record<string, PeerRecord>;
+}
+
+export interface ReadPeerRecordsResult {
+  /** The per-host map, or null when no transport is configured (clear caches). */
+  peers: Record<string, PeerRecord> | null;
+  source: "loki" | "anchor" | "none";
+}
+
+export function readPeerRecords(args?: ReadPeerRecordsArgs): ReadPeerRecordsResult;

--- a/plugins/dev/scripts/orch-monitor/lib/peer-liveness.d.mts
+++ b/plugins/dev/scripts/orch-monitor/lib/peer-liveness.d.mts
@@ -46,6 +46,8 @@ export interface FoldPeerSnapshotArgs {
   prevHeartbeats?: Record<string, string>;
   prevCapacity?: Record<string, { maxParallel: number; inFlightCount: number }>;
   peers?: Record<string, PeerRecord>;
+  /** Poll clock (injectable for tests) — used for the future-skew trust check. */
+  nowMs?: number;
 }
 
 export interface FoldPeerSnapshotResult {

--- a/plugins/dev/scripts/orch-monitor/lib/peer-liveness.mjs
+++ b/plugins/dev/scripts/orch-monitor/lib/peer-liveness.mjs
@@ -49,7 +49,14 @@ export function readPeerRecords({ rawSource, lokiUrl, anchorIssue, readLoki, rea
     return { peers: {}, source: "loki" };
   }
   if (!anchorIssue || typeof readAnchor !== "function") {
-    return { peers: null, source: "none" }; // no transport configured
+    // No anchor tier. `peers: null` (→ caller CLEARS caches) is reserved for
+    // "no transport configured AT ALL"; when a Loki transport exists but its
+    // read failed/was empty (the fail-open {}), return an EMPTY map instead so
+    // the caller's fold RETAINS its caches — a Loki blip on a loki-only AUTO
+    // host must not blank the display.
+    const lokiConfigured =
+      typeof lokiUrl === "string" && lokiUrl.length > 0 && typeof readLoki === "function";
+    return lokiConfigured ? { peers: {}, source: "loki" } : { peers: null, source: "none" };
   }
   return { peers: readAnchor({ anchorIssue }) ?? {}, source: "anchor" };
 }
@@ -84,7 +91,12 @@ export function retainMissingEntries(prev, next) {
 // Retained/blocked entries still age to offline via the node-liveness grace —
 // these guards only prevent instant regressions, never a false "live forever".
 // Returns { heartbeats, capacity } — the new cache maps.
-export function foldPeerSnapshot({ prevHeartbeats = {}, prevCapacity = {}, peers = {} } = {}) {
+// A cached timestamp more than this far in the FUTURE of the poll's clock is
+// untrusted (a clock-skewed publisher poisoned it): monotonic newest-wins would
+// otherwise reject every corrected heartbeat until wall time caught up.
+const FUTURE_SKEW_TOLERANCE_MS = 2 * 60_000;
+
+export function foldPeerSnapshot({ prevHeartbeats = {}, prevCapacity = {}, peers = {}, nowMs = Date.now() } = {}) {
   const nextHb = {};
   const nextCap = {};
   for (const [host, rec] of Object.entries(peers ?? {})) {
@@ -92,13 +104,26 @@ export function foldPeerSnapshot({ prevHeartbeats = {}, prevCapacity = {}, peers
     const hasTs = typeof rec.last_seen === "string" && rec.last_seen.length > 0;
     const newTs = hasTs ? Date.parse(rec.last_seen) : NaN;
     const prevTs = Date.parse(prevHeartbeats?.[host] ?? "");
-    const fresher = Number.isFinite(newTs) && (!Number.isFinite(prevTs) || newTs >= prevTs);
+    // A FUTURE-skewed cached ts is not a legitimate freshness bar — without this,
+    // one bad publish would block every corrected heartbeat until wall time
+    // reached the poisoned value (and retention would preserve it forever).
+    const prevTrusted =
+      Number.isFinite(prevTs) && prevTs <= nowMs + FUTURE_SKEW_TOLERANCE_MS;
+    const fresher = Number.isFinite(newTs) && (!prevTrusted || newTs >= prevTs);
     if (hasTs && fresher) nextHb[host] = rec.last_seen;
     const hasCapacity = rec.max_parallel != null || rec.in_flight_count != null;
     if (hasCapacity && fresher) {
+      // Per-FIELD merge: a record can carry one capacity field and not the other
+      // (partial structured metadata); the absent field retains its previous
+      // value instead of collapsing to zero.
+      const prevCap = prevCapacity?.[host];
       nextCap[host] = {
-        maxParallel: typeof rec.max_parallel === "number" ? rec.max_parallel : 0,
-        inFlightCount: typeof rec.in_flight_count === "number" ? rec.in_flight_count : 0,
+        maxParallel:
+          typeof rec.max_parallel === "number" ? rec.max_parallel : (prevCap?.maxParallel ?? 0),
+        inFlightCount:
+          typeof rec.in_flight_count === "number"
+            ? rec.in_flight_count
+            : (prevCap?.inFlightCount ?? 0),
       };
     }
   }

--- a/plugins/dev/scripts/orch-monitor/lib/peer-liveness.mjs
+++ b/plugins/dev/scripts/orch-monitor/lib/peer-liveness.mjs
@@ -1,0 +1,55 @@
+// peer-liveness.mjs — CTL-1551. Pure selection of the cross-host peer-liveness
+// transport for the monitor's background peer poll.
+//
+// Since CTL-1420 (#17) the daemons publish cross-host liveness to the unified
+// event log → Loki, and the Linear-anchor publish is RETIRED in loki mode — so on
+// a loki fleet the anchor (CTL-1217) is permanently stale and reading it painted
+// every peer "offline" with weeks-old capacity (the CTL-1551 dashboard bug).
+//
+// Selection contract (mirrors recovery.mjs's defaultReadPeers, plus an AUTO tier
+// because the monitor's launchd env usually carries no source var):
+//   rawSource === "linear" → anchor only (legacy fleets, explicit opt-out).
+//   rawSource === "loki"   → Loki only (daemon parity; an empty result is trusted
+//                            as "no peers" — fail-open, never a fallback to the
+//                            retired anchor).
+//   unset / anything else  → AUTO: prefer Loki when a query URL resolves AND it
+//                            returns at least one peer; otherwise fall back to
+//                            the anchor when one is configured.
+//
+// Error semantics (deliberate, mirrors the prior inline code):
+//   - a THROWING Loki read is swallowed here → falls through to the anchor tier
+//     (Loki being down must not blank the display when the anchor still works);
+//   - a THROWING anchor read propagates to the caller, whose outer catch keeps
+//     the LAST cache (transient anchor failure must not clear a good cache).
+//
+// Returns { peers, source }:
+//   peers  — the per-host record map ({ last_seen, in_flight_tickets,
+//            max_parallel?, in_flight_count? }), or null when NO transport is
+//            configured (caller clears its caches — "no peers by construction").
+//   source — "loki" | "anchor" | "none" (observability/debug).
+export function readPeerRecords({ rawSource, lokiUrl, anchorIssue, readLoki, readAnchor } = {}) {
+  const source = String(rawSource ?? "")
+    .trim()
+    .toLowerCase();
+
+  if (source !== "linear" && typeof lokiUrl === "string" && lokiUrl.length > 0 && typeof readLoki === "function") {
+    let lokiPeers;
+    try {
+      lokiPeers = readLoki({ lokiUrl }) ?? {};
+    } catch {
+      lokiPeers = {}; // Loki hiccup → AUTO falls through to the anchor tier
+    }
+    if (Object.keys(lokiPeers).length > 0 || source === "loki") {
+      return { peers: lokiPeers, source: "loki" };
+    }
+  }
+  if (source === "loki") {
+    // Explicit loki mode with no usable URL/reader: fail-open to "no peers"
+    // rather than silently reading the retired anchor.
+    return { peers: {}, source: "loki" };
+  }
+  if (!anchorIssue || typeof readAnchor !== "function") {
+    return { peers: null, source: "none" }; // no transport configured
+  }
+  return { peers: readAnchor({ anchorIssue }) ?? {}, source: "anchor" };
+}

--- a/plugins/dev/scripts/orch-monitor/lib/peer-liveness.mjs
+++ b/plugins/dev/scripts/orch-monitor/lib/peer-liveness.mjs
@@ -53,3 +53,19 @@ export function readPeerRecords({ rawSource, lokiUrl, anchorIssue, readLoki, rea
   }
   return { peers: readAnchor({ anchorIssue }) ?? {}, source: "anchor" };
 }
+
+// retainMissingEntries — CTL-1551. A successful Loki read can be PARTIAL (eventual
+// consistency, bounded result) or EMPTY-on-outage (the sync bridge fail-opens to
+// {}), and the poll replaces its caches wholesale — so a host merely MISSING from
+// one snapshot would flip offline instantly with zeroed capacity, bypassing the
+// liveness grace. Retain the previous entry for any host absent from the new
+// snapshot: a genuinely dead host's retained last_seen stops advancing, so the
+// node-liveness classifier ages it to offline on the SAME grace it always had —
+// retention only prevents the instant blank, never a false "live forever".
+export function retainMissingEntries(prev, next) {
+  const out = { ...(next ?? {}) };
+  for (const [host, entry] of Object.entries(prev ?? {})) {
+    if (!(host in out)) out[host] = entry;
+  }
+  return out;
+}

--- a/plugins/dev/scripts/orch-monitor/lib/peer-liveness.mjs
+++ b/plugins/dev/scripts/orch-monitor/lib/peer-liveness.mjs
@@ -69,3 +69,41 @@ export function retainMissingEntries(prev, next) {
   }
   return out;
 }
+
+// foldPeerSnapshot — CTL-1551. Fold one peer snapshot into the poll's caches,
+// with three guards a naive replace lacks (each was a reviewed failure mode):
+//   1. NEWEST-WINS per host (the CTL-1255 principle applied to the caches): an
+//      entry only updates when its last_seen is at least as fresh as the cached
+//      one — so the AUTO anchor fallback after a Loki blip (same host keys,
+//      weeks-old timestamps on a retired-writer anchor) can never regress a
+//      fresher cached heartbeat OR pin stale capacity over it.
+//   2. CAPACITY ONLY FROM CAPACITY-BEARING RECORDS: a failed capacity
+//      enrichment yields max_parallel/in_flight_count = null on every host —
+//      those must retain the previous capacity entry, never zero it.
+//   3. RETENTION for hosts missing from the snapshot (retainMissingEntries).
+// Retained/blocked entries still age to offline via the node-liveness grace —
+// these guards only prevent instant regressions, never a false "live forever".
+// Returns { heartbeats, capacity } — the new cache maps.
+export function foldPeerSnapshot({ prevHeartbeats = {}, prevCapacity = {}, peers = {} } = {}) {
+  const nextHb = {};
+  const nextCap = {};
+  for (const [host, rec] of Object.entries(peers ?? {})) {
+    if (!rec) continue;
+    const hasTs = typeof rec.last_seen === "string" && rec.last_seen.length > 0;
+    const newTs = hasTs ? Date.parse(rec.last_seen) : NaN;
+    const prevTs = Date.parse(prevHeartbeats?.[host] ?? "");
+    const fresher = Number.isFinite(newTs) && (!Number.isFinite(prevTs) || newTs >= prevTs);
+    if (hasTs && fresher) nextHb[host] = rec.last_seen;
+    const hasCapacity = rec.max_parallel != null || rec.in_flight_count != null;
+    if (hasCapacity && fresher) {
+      nextCap[host] = {
+        maxParallel: typeof rec.max_parallel === "number" ? rec.max_parallel : 0,
+        inFlightCount: typeof rec.in_flight_count === "number" ? rec.in_flight_count : 0,
+      };
+    }
+  }
+  return {
+    heartbeats: retainMissingEntries(prevHeartbeats, nextHb),
+    capacity: retainMissingEntries(prevCapacity, nextCap),
+  };
+}

--- a/plugins/dev/scripts/orch-monitor/server.ts
+++ b/plugins/dev/scripts/orch-monitor/server.ts
@@ -39,6 +39,7 @@ import type { NavSignal, DaemonHealth } from "./lib/nav-signal.mjs";
 // project it to the tiny per-node footer signal (cluster-signal.mjs). Single-host
 // is an exact identity no-op (one node — the local daemon).
 import { createClusterEntity } from "./lib/cluster-view.mjs";
+import { readPeerRecords } from "./lib/peer-liveness.mjs"; // CTL-1551: source-aware peer transport selection
 import type { ClusterView } from "./lib/cluster-view.mjs";
 // CTL-1092: alias loading + resolution for the prod capacity/liveness wiring.
 // loadHostAliases reads catalyst.host.aliases (fail-open {}); resolveHostAlias
@@ -1358,7 +1359,11 @@ export function createServer(opts: CreateServerOptions): BunServer {
     getHostName: () => string;
     getClusterHosts: () => string[];
     getLivenessAnchorIssue: () => string | null;
+    getLokiQueryUrl: () => string | null;
     readPeerHeartbeatsSync: (args: { anchorIssue: string }) => Record<string, AnchorPeerRec>;
+    readClusterLivenessFromLokiSyncCached: (args: {
+      lokiUrl: string;
+    }) => Record<string, AnchorPeerRec>;
     deriveDaemonHealth: typeof import("./lib/nav-signal.mjs").deriveDaemonHealth;
   } | null> | null = null;
   const loadDaemonDeps = () => {
@@ -1368,7 +1373,8 @@ export function createServer(opts: CreateServerOptions): BunServer {
           const recoveryMod = ["..", "execution-core", "recovery.mjs"].join("/");
           const configMod = ["..", "execution-core", "config.mjs"].join("/");
           const heartbeatSyncMod = ["..", "execution-core", "cluster-heartbeat-sync.mjs"].join("/");
-          const [recovery, config, heartbeatSync, navSignal] = await Promise.all([
+          const lokiSyncMod = ["..", "execution-core", "loki-liveness-sync.mjs"].join("/");
+          const [recovery, config, heartbeatSync, lokiSync, navSignal] = await Promise.all([
             import(recoveryMod) as Promise<{
               readClusterHeartbeats: (opts: { logPath?: string }) => Record<string, string>;
               readClusterAdmission: (opts: { logPath?: string }) => Record<string, NodeAdmission>;
@@ -1377,9 +1383,15 @@ export function createServer(opts: CreateServerOptions): BunServer {
               getHostName: () => string;
               getClusterHosts: () => string[];
               getLivenessAnchorIssue: () => string | null;
+              getLokiQueryUrl: () => string | null;
             }>,
             import(heartbeatSyncMod) as Promise<{
               readPeerHeartbeatsSync: (args: { anchorIssue: string }) => Record<string, AnchorPeerRec>;
+            }>,
+            import(lokiSyncMod) as Promise<{
+              readClusterLivenessFromLokiSyncCached: (args: {
+                lokiUrl: string;
+              }) => Record<string, AnchorPeerRec>;
             }>,
             import("./lib/nav-signal.mjs"),
           ]);
@@ -1389,7 +1401,9 @@ export function createServer(opts: CreateServerOptions): BunServer {
             getHostName: config.getHostName,
             getClusterHosts: config.getClusterHosts,
             getLivenessAnchorIssue: config.getLivenessAnchorIssue,
+            getLokiQueryUrl: config.getLokiQueryUrl,
             readPeerHeartbeatsSync: heartbeatSync.readPeerHeartbeatsSync,
+            readClusterLivenessFromLokiSyncCached: lokiSync.readClusterLivenessFromLokiSyncCached,
             deriveDaemonHealth: navSignal.deriveDaemonHealth,
           };
         } catch {
@@ -1586,13 +1600,37 @@ export function createServer(opts: CreateServerOptions): BunServer {
       } catch {
         /* keep last admission cache */
       }
-      const anchor = execCoreDeps.getLivenessAnchorIssue();
-      if (!anchor) {
-        anchorHeartbeatCache.map = {}; // no anchor configured → no peers
+      // CTL-1551: source-aware peer read. Since CTL-1420 (#17) the daemons publish
+      // cross-host liveness to the event log → Loki and the Linear-anchor publish
+      // is RETIRED in loki mode — so on a loki fleet the anchor is permanently
+      // stale and reading it painted every peer "offline" with weeks-old capacity.
+      // Selection: CATALYST_LIVENESS_READ_SOURCE=loki → Loki only (daemon parity);
+      // =linear → anchor only (legacy fleets); unset → AUTO: prefer Loki whenever
+      // a query URL resolves and it returns peers, else fall back to the anchor.
+      // The Loki record shape ({last_seen, in_flight_tickets, max_parallel,
+      // in_flight_count}) matches AnchorPeerRec, so both caches below populate
+      // identically from either source. URL resolution: the execution-core config
+      // getter first (env-driven), else the monitor's own otel-config lokiUrl —
+      // already resolved for the Telemetry surfaces, so a launchd monitor with a
+      // bare env still finds the same Loki its other pages use.
+      let lokiPeerUrl: string | null = null;
+      try {
+        lokiPeerUrl = execCoreDeps.getLokiQueryUrl?.() ?? null;
+      } catch {
+        lokiPeerUrl = null;
+      }
+      const { peers } = readPeerRecords({
+        rawSource: process.env.CATALYST_LIVENESS_READ_SOURCE,
+        lokiUrl: lokiPeerUrl ?? lokiUrl ?? null,
+        anchorIssue: execCoreDeps.getLivenessAnchorIssue(),
+        readLoki: execCoreDeps.readClusterLivenessFromLokiSyncCached,
+        readAnchor: execCoreDeps.readPeerHeartbeatsSync,
+      }) as { peers: Record<string, AnchorPeerRec> | null; source: string };
+      if (peers == null) {
+        anchorHeartbeatCache.map = {}; // no transport configured → no peers
         anchorCapacityCache.map = {};
         return;
       }
-      const peers = execCoreDeps.readPeerHeartbeatsSync({ anchorIssue: anchor });
       const next: Record<string, string> = {};
       const nextCap: Record<string, { maxParallel: number; inFlightCount: number }> = {};
       for (const [host, rec] of Object.entries(peers)) {

--- a/plugins/dev/scripts/orch-monitor/server.ts
+++ b/plugins/dev/scripts/orch-monitor/server.ts
@@ -1613,15 +1613,21 @@ export function createServer(opts: CreateServerOptions): BunServer {
       // getter first (env-driven), else the monitor's own otel-config lokiUrl —
       // already resolved for the Telemetry surfaces, so a launchd monitor with a
       // bare env still finds the same Loki its other pages use.
-      let lokiPeerUrl: string | null = null;
+      // URL precedence (CTL-1551 round 3): an EXPLICIT CATALYST_LOKI_QUERY_URL
+      // wins; else the monitor's own configured otel lokiUrl (known-good — its
+      // Telemetry pages already query it); else execution-core's port-swap
+      // HEURISTIC derived from OTEL_EXPORTER_OTLP_ENDPOINT (which can point at
+      // the collector host, not Loki, when the two are split).
+      let cfgLokiUrl: string | null = null;
       try {
-        lokiPeerUrl = execCoreDeps.getLokiQueryUrl?.() ?? null;
+        cfgLokiUrl = execCoreDeps.getLokiQueryUrl?.() ?? null;
       } catch {
-        lokiPeerUrl = null;
+        cfgLokiUrl = null;
       }
+      const explicitLokiUrl = process.env.CATALYST_LOKI_QUERY_URL?.trim() ? cfgLokiUrl : null;
       const { peers } = readPeerRecords({
         rawSource: process.env.CATALYST_LIVENESS_READ_SOURCE,
-        lokiUrl: lokiPeerUrl ?? lokiUrl ?? null,
+        lokiUrl: explicitLokiUrl ?? lokiUrl ?? cfgLokiUrl ?? null,
         anchorIssue: execCoreDeps.getLivenessAnchorIssue(),
         readLoki: execCoreDeps.readClusterLivenessFromLokiSyncCached,
         readAnchor: execCoreDeps.readPeerHeartbeatsSync,

--- a/plugins/dev/scripts/orch-monitor/server.ts
+++ b/plugins/dev/scripts/orch-monitor/server.ts
@@ -39,7 +39,7 @@ import type { NavSignal, DaemonHealth } from "./lib/nav-signal.mjs";
 // project it to the tiny per-node footer signal (cluster-signal.mjs). Single-host
 // is an exact identity no-op (one node — the local daemon).
 import { createClusterEntity } from "./lib/cluster-view.mjs";
-import { readPeerRecords } from "./lib/peer-liveness.mjs"; // CTL-1551: source-aware peer transport selection
+import { readPeerRecords, retainMissingEntries } from "./lib/peer-liveness.mjs"; // CTL-1551: source-aware peer transport selection + partial-snapshot retention
 import type { ClusterView } from "./lib/cluster-view.mjs";
 // CTL-1092: alias loading + resolution for the prod capacity/liveness wiring.
 // loadHostAliases reads catalyst.host.aliases (fail-open {}); resolveHostAlias
@@ -1643,8 +1643,14 @@ export function createServer(opts: CreateServerOptions): BunServer {
           nextCap[host] = { maxParallel: mp, inFlightCount: ifc };
         }
       }
-      anchorHeartbeatCache.map = next;
-      anchorCapacityCache.map = nextCap;
+      // CTL-1551: retain entries for hosts MISSING from this snapshot — a Loki
+      // read can be partial (eventual consistency) or empty-on-outage (the sync
+      // bridge fail-opens to {}), and a wholesale replace would flip such a host
+      // offline instantly with zeroed capacity, bypassing the liveness grace. A
+      // retained last_seen stops advancing, so a genuinely dead host still ages
+      // to offline on the normal node-liveness grace.
+      anchorHeartbeatCache.map = retainMissingEntries(anchorHeartbeatCache.map, next);
+      anchorCapacityCache.map = retainMissingEntries(anchorCapacityCache.map, nextCap);
     } catch {
       // fail-open: keep the last caches; stale entries age out via node-liveness
     }

--- a/plugins/dev/scripts/orch-monitor/server.ts
+++ b/plugins/dev/scripts/orch-monitor/server.ts
@@ -39,7 +39,7 @@ import type { NavSignal, DaemonHealth } from "./lib/nav-signal.mjs";
 // project it to the tiny per-node footer signal (cluster-signal.mjs). Single-host
 // is an exact identity no-op (one node — the local daemon).
 import { createClusterEntity } from "./lib/cluster-view.mjs";
-import { readPeerRecords, retainMissingEntries } from "./lib/peer-liveness.mjs"; // CTL-1551: source-aware peer transport selection + partial-snapshot retention
+import { readPeerRecords, foldPeerSnapshot } from "./lib/peer-liveness.mjs"; // CTL-1551: source-aware peer transport selection + guarded snapshot folding
 import type { ClusterView } from "./lib/cluster-view.mjs";
 // CTL-1092: alias loading + resolution for the prod capacity/liveness wiring.
 // loadHostAliases reads catalyst.host.aliases (fail-open {}); resolveHostAlias
@@ -1631,26 +1631,18 @@ export function createServer(opts: CreateServerOptions): BunServer {
         anchorCapacityCache.map = {};
         return;
       }
-      const next: Record<string, string> = {};
-      const nextCap: Record<string, { maxParallel: number; inFlightCount: number }> = {};
-      for (const [host, rec] of Object.entries(peers)) {
-        if (rec && typeof rec.last_seen === "string" && rec.last_seen.length > 0) {
-          next[host] = rec.last_seen;
-        }
-        if (rec) {
-          const mp = typeof rec.max_parallel === "number" ? rec.max_parallel : 0;
-          const ifc = typeof rec.in_flight_count === "number" ? rec.in_flight_count : 0;
-          nextCap[host] = { maxParallel: mp, inFlightCount: ifc };
-        }
-      }
-      // CTL-1551: retain entries for hosts MISSING from this snapshot — a Loki
-      // read can be partial (eventual consistency) or empty-on-outage (the sync
-      // bridge fail-opens to {}), and a wholesale replace would flip such a host
-      // offline instantly with zeroed capacity, bypassing the liveness grace. A
-      // retained last_seen stops advancing, so a genuinely dead host still ages
-      // to offline on the normal node-liveness grace.
-      anchorHeartbeatCache.map = retainMissingEntries(anchorHeartbeatCache.map, next);
-      anchorCapacityCache.map = retainMissingEntries(anchorCapacityCache.map, nextCap);
+      // CTL-1551: fold the snapshot through the pure guard set — per-host
+      // newest-wins (a stale AUTO anchor fallback can't regress fresher cached
+      // entries), capacity only from capacity-bearing records (a failed
+      // enrichment can't zero valid capacity), and retention for hosts missing
+      // from a partial/empty snapshot. See peer-liveness.mjs foldPeerSnapshot.
+      const folded = foldPeerSnapshot({
+        prevHeartbeats: anchorHeartbeatCache.map,
+        prevCapacity: anchorCapacityCache.map,
+        peers,
+      });
+      anchorHeartbeatCache.map = folded.heartbeats;
+      anchorCapacityCache.map = folded.capacity;
     } catch {
       // fail-open: keep the last caches; stale entries age out via node-liveness
     }


### PR DESCRIPTION
## Summary

Each host's Workers dashboard showed its healthy peer as **offline** and rendered capacity from a **20-day-stale source** ("6/3 slots in use" while 0 agents ran). Root cause: CTL-1420 #17 moved cross-host liveness to the event-log→Loki path and retired the Linear-anchor publish — but the monitor's peer poll still read the anchor (CTL-1217, last written 7/09), and the local event log structurally never contains a peer's heartbeats.

## Changes

1. **Cross-host capacity transport restored** — `node.heartbeat` now carries `catalyst.node.max_parallel` as a Loki-reachable attribute (`body.payload` is stripped by otel-forward before OTLP, so attributes are the only cross-host channel). Wired from the daemon via the now-exported `readLocalMaxParallel`. The retired anchor publish was the only prior transport for this value.
2. **Loki liveness reader surfaces capacity** — the parser extracts per-host `max_parallel` / `in_flight_count` (meta-or-label defensive, numbers-as-strings, invalid → `null` never fake 0), and a third best-effort query references `catalyst_node_max_parallel` so Loki surfaces the structured-metadata field (same pattern as the existing tickets enrichment; its failure never affects liveness).
3. **Monitor peer poll is source-aware** — new pure `lib/peer-liveness.mjs` `readPeerRecords`: explicit `CATALYST_LIVENESS_READ_SOURCE=loki` → Loki only (daemon parity, empty trusted, anchor never read); explicit `linear` → anchor only (legacy fleets); unset → AUTO (Loki when a URL resolves and returns peers, anchor fallback). URL resolution falls back to the monitor's own otel-config `lokiUrl`, so a launchd monitor with a bare env uses the same Loki its Telemetry pages already reach. The Loki record shape matches `AnchorPeerRec`, so the existing heartbeat + capacity caches populate identically from either source. Error semantics preserved: a throwing Loki read falls back to the anchor; a throwing anchor read propagates so the poll keeps its last cache.

No UI changes needed — `node-filter` / `slot-deck` render live peer status and real `N/M` capacity once the signal carries them.

## Tests

- `__tests__/peer-liveness.test.ts` — 9 cases covering AUTO/loki/linear selection, empty/throwing Loki, no-transport, anchor-throw propagation.
- `loki-liveness.test.mjs` — capacity parse (meta + label shapes, invalid → null) and the three-query merge, plus query-C failure isolation.
- `heartbeat-event.test.mjs` — `max_parallel` attribute present for positive ints, omitted for null/0/invalid (never a fake 0).
- Full suites green: orch-monitor cluster tests (57), recovery + loki-liveness-sync (323), daemon (147); `tsc --noEmit` clean.

Linear: CTL-1551

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Wte59hchAL4FjhHiCwSVS3