### PR TITLE
fix(dev): CTL-1551 budget the peer-liveness live window for transport lag

### DIFF
--- a/plugins/dev/scripts/orch-monitor/__tests__/cluster-signal.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/cluster-signal.test.ts
@@ -148,3 +148,28 @@ describe("deriveClusterSignal — defensive", () => {
     expect(typeof signal.generatedAt).toBe("string");
   });
 });
+
+// ── CTL-1551: selfHost passthrough ──
+describe("deriveClusterSignal selfHost (CTL-1551)", () => {
+  it("copies the view's selfHost so the UI never infers local identity from status", () => {
+    const sig = deriveClusterSignal({
+      generatedAt: "2026-07-30T17:00:00Z",
+      singleHost: false,
+      selfHost: "mini-2",
+      nodes: [
+        { host: "mini", status: "live", lastSeen: "2026-07-30T17:00:00Z", tickets: [] },
+        { host: "mini-2", status: "live", lastSeen: "2026-07-30T17:00:00Z", tickets: [] },
+      ],
+    } as never);
+    expect((sig as { selfHost?: string }).selfHost).toBe("mini-2");
+  });
+
+  it("omits selfHost when the view has none (back-compat frame shape)", () => {
+    const sig = deriveClusterSignal({
+      generatedAt: "2026-07-30T17:00:00Z",
+      singleHost: true,
+      nodes: [],
+    } as never);
+    expect("selfHost" in sig).toBe(false);
+  });
+});

--- a/plugins/dev/scripts/orch-monitor/__tests__/cluster-view.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/cluster-view.test.ts
@@ -305,19 +305,21 @@ describe("createClusterEntity — read-model integration (Scenario: the read-mod
     m.stop();
   });
 
-  it("forwards intervalMs so a transport-lagged peer classifies live, not degraded (CTL-1551)", async () => {
+  it("forwards intervalMsFor: lagged peer classifies live, SELF keeps the tight window (CTL-1551)", async () => {
     // The Loki peer pipeline adds ~30s beat + 60s poll + 20s cache of KNOWN lag,
-    // so the server budgets a wider live window. This pins the entity actually
-    // FORWARDING intervalMs (the accepted-but-dropped trap the reader params hit).
+    // so the server budgets a wider live window for PEERS ONLY — the self host's
+    // heartbeats come straight from the local log and must degrade promptly.
+    // This pins the entity actually FORWARDING intervalMsFor (the
+    // accepted-but-dropped trap the reader params hit).
     const snapshot = board([ticket("CTL-1")]);
     const cluster = createClusterEntity({
       ownerHostProvider: () => Promise.resolve({ "CTL-1": "mini" }),
       rosterProvider: () => ["mini", "mini-2"],
       heartbeatReader: () => ({
-        mini: new Date(now - 1000).toISOString(),
-        "mini-2": new Date(now - 90_000).toISOString(), // 90s old — healthy peer via lagged transport
+        mini: new Date(now - 90_000).toISOString(), // self, 90s silent — a REAL stall
+        "mini-2": new Date(now - 90_000).toISOString(), // peer, 90s = healthy via lagged transport
       }),
-      intervalMs: 120_000,
+      intervalMsFor: (host: string) => (host === "mini" ? undefined : 120_000),
       now: () => now,
     });
     const m = createReadModel({
@@ -326,8 +328,8 @@ describe("createClusterEntity — read-model integration (Scenario: the read-mod
       entities: { board: { project: (s: BoardPayload) => s }, cluster },
     });
     const view = (await m.getEntity("cluster")) as ClusterView;
-    const peer = view.nodes.find((n) => n.host === "mini-2");
-    expect(peer?.status).toBe("live"); // default 30s window would say "degraded"
+    expect(view.nodes.find((n) => n.host === "mini-2")?.status).toBe("live"); // peer budgeted
+    expect(view.nodes.find((n) => n.host === "mini")?.status).toBe("degraded"); // self stays tight
     m.stop();
   });
 

--- a/plugins/dev/scripts/orch-monitor/__tests__/cluster-view.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/cluster-view.test.ts
@@ -305,6 +305,32 @@ describe("createClusterEntity — read-model integration (Scenario: the read-mod
     m.stop();
   });
 
+  it("forwards intervalMs so a transport-lagged peer classifies live, not degraded (CTL-1551)", async () => {
+    // The Loki peer pipeline adds ~30s beat + 60s poll + 20s cache of KNOWN lag,
+    // so the server budgets a wider live window. This pins the entity actually
+    // FORWARDING intervalMs (the accepted-but-dropped trap the reader params hit).
+    const snapshot = board([ticket("CTL-1")]);
+    const cluster = createClusterEntity({
+      ownerHostProvider: () => Promise.resolve({ "CTL-1": "mini" }),
+      rosterProvider: () => ["mini", "mini-2"],
+      heartbeatReader: () => ({
+        mini: new Date(now - 1000).toISOString(),
+        "mini-2": new Date(now - 90_000).toISOString(), // 90s old — healthy peer via lagged transport
+      }),
+      intervalMs: 120_000,
+      now: () => now,
+    });
+    const m = createReadModel({
+      assemble: () => Promise.resolve(snapshot),
+      onDemandTtlMs: 5000,
+      entities: { board: { project: (s: BoardPayload) => s }, cluster },
+    });
+    const view = (await m.getEntity("cluster")) as ClusterView;
+    const peer = view.nodes.find((n) => n.host === "mini-2");
+    expect(peer?.status).toBe("live"); // default 30s window would say "degraded"
+    m.stop();
+  });
+
   it("groups by owner_host on a multi-host roster via injected deps", async () => {
     const snapshot = board([ticket("CTL-1"), ticket("CTL-2")]);
     const cluster = createClusterEntity({

--- a/plugins/dev/scripts/orch-monitor/__tests__/node-liveness.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/node-liveness.test.ts
@@ -113,3 +113,36 @@ describe("overlayClusterLiveness (CTL-884 — per-host overlay from lastSeen map
     expect(out[0]).toEqual({ host: "mini", status: "live", lastSeen: out[0].lastSeen });
   });
 });
+
+// ── CTL-1551: per-host live-window resolver ──
+import { overlayClusterLiveness as _overlay } from "../lib/node-liveness.mjs";
+
+describe("overlayClusterLiveness intervalMsFor (CTL-1551)", () => {
+  const NOW = Date.parse("2026-07-30T12:00:00Z");
+  const seen = {
+    self: new Date(NOW - 90_000).toISOString(),
+    peer: new Date(NOW - 90_000).toISOString(),
+  };
+
+  it("applies the per-host window: peer budgeted live, self degrades on the default", () => {
+    const out = _overlay(["self", "peer"], seen, {
+      now: NOW,
+      intervalMsFor: (h: string) => (h === "peer" ? 120_000 : undefined),
+    });
+    expect(out.find((n) => n.host === "peer")?.status).toBe("live");
+    expect(out.find((n) => n.host === "self")?.status).toBe("degraded");
+  });
+
+  it("a throwing/invalid resolver falls back to the shared window, never throws", () => {
+    const out = _overlay(["self", "peer"], seen, {
+      now: NOW,
+      intervalMs: 120_000,
+      intervalMsFor: () => {
+        throw new Error("boom");
+      },
+    });
+    expect(out.find((n) => n.host === "peer")?.status).toBe("live"); // shared window applied
+    const out2 = _overlay(["peer"], seen, { now: NOW, intervalMsFor: () => -5 });
+    expect(out2[0].status).toBe("degraded"); // invalid value → default window
+  });
+});

--- a/plugins/dev/scripts/orch-monitor/lib/cluster-signal.d.mts
+++ b/plugins/dev/scripts/orch-monitor/lib/cluster-signal.d.mts
@@ -15,6 +15,8 @@ export interface ClusterSignalNode {
 export interface ClusterSignal {
   /** True ⇒ exactly one node — footer shows one dot, the node filter is absent. */
   singleHost: boolean;
+  /** CTL-1551: this monitor's own (alias-folded) host; absent when unknown. */
+  selfHost?: string;
   /** One entry per REAL roster host (the synthetic unassigned bucket is dropped). */
   nodes: ClusterSignalNode[];
   /** The source ClusterView's generatedAt (passthrough for cache/debug). */

--- a/plugins/dev/scripts/orch-monitor/lib/cluster-signal.mjs
+++ b/plugins/dev/scripts/orch-monitor/lib/cluster-signal.mjs
@@ -70,6 +70,12 @@ export function deriveClusterSignal(view) {
     // A malformed/absent view degrades to the single-host empty signal (the footer
     // simply shows its unknown/muted dot until the first real frame lands).
     singleHost: view?.singleHost ?? true,
+    // CTL-1551: pass the monitor's own identity through so the UI (SlotDeck
+    // localHost) never infers self from "first live node" — with peers now
+    // legitimately live, that heuristic picks the wrong host.
+    ...(typeof view?.selfHost === "string" && view.selfHost.length > 0
+      ? { selfHost: view.selfHost }
+      : {}),
     nodes: projected,
     generatedAt:
       typeof view?.generatedAt === "string" ? view.generatedAt : "",

--- a/plugins/dev/scripts/orch-monitor/lib/cluster-view.d.mts
+++ b/plugins/dev/scripts/orch-monitor/lib/cluster-view.d.mts
@@ -28,6 +28,8 @@ export interface ClusterNode {
 }
 
 export interface ClusterView {
+  /** CTL-1551: this monitor's own (alias-folded) host, or null when unknown. */
+  selfHost?: string | null;
   generatedAt: string;
   /** True when the roster is absent or length 1 — the exact identity no-op path. */
   singleHost: boolean;
@@ -89,6 +91,8 @@ export interface ClusterEntityDeps {
    * shared/default window). Lets the server budget PEER transport lag without
    * loosening the self host's window. */
   intervalMsFor?: (host: string) => number | undefined;
+  /** CTL-1551: provider for this monitor's own (alias-folded) host; resolved per assemble. */
+  selfHostProvider?: (() => string | null) | null;
   /** Injected clock for tests. */
   now?: () => number;
 }

--- a/plugins/dev/scripts/orch-monitor/lib/cluster-view.d.mts
+++ b/plugins/dev/scripts/orch-monitor/lib/cluster-view.d.mts
@@ -80,6 +80,11 @@ export interface ClusterEntityDeps {
   admissionReader?:
     | ((host: string) => { accepting?: boolean; holdReason?: "drain" | "liveness-cold" | null } | null | undefined)
     | null;
+  /** CTL-1551: liveness live-window override (ms), forwarded to assembleClusterView —
+   * the server budgets it for the Loki peer transport's pipeline lag. */
+  intervalMs?: number;
+  /** CTL-1551: liveness offline-grace override (ms), forwarded to assembleClusterView. */
+  graceMs?: number;
   /** Injected clock for tests. */
   now?: () => number;
 }

--- a/plugins/dev/scripts/orch-monitor/lib/cluster-view.d.mts
+++ b/plugins/dev/scripts/orch-monitor/lib/cluster-view.d.mts
@@ -85,6 +85,10 @@ export interface ClusterEntityDeps {
   intervalMs?: number;
   /** CTL-1551: liveness offline-grace override (ms), forwarded to assembleClusterView. */
   graceMs?: number;
+  /** CTL-1551: per-host live-window resolver — (host) => ms | undefined (undefined =
+   * shared/default window). Lets the server budget PEER transport lag without
+   * loosening the self host's window. */
+  intervalMsFor?: (host: string) => number | undefined;
   /** Injected clock for tests. */
   now?: () => number;
 }

--- a/plugins/dev/scripts/orch-monitor/lib/cluster-view.mjs
+++ b/plugins/dev/scripts/orch-monitor/lib/cluster-view.mjs
@@ -68,6 +68,7 @@ const noLivenessReader = () => ({});
  * @param {number} [args.now] epoch ms (injected for tests)
  * @param {number} [args.intervalMs] liveness interval threshold
  * @param {number} [args.graceMs] liveness grace window
+ * @param {Function} [args.intervalMsFor] CTL-1551: per-host live-window resolver (host) => ms | undefined
  * @returns {import("./cluster-view.d.mts").ClusterView}
  */
 export function assembleClusterView({
@@ -80,6 +81,7 @@ export function assembleClusterView({
   now = Date.now(),
   intervalMs,
   graceMs,
+  intervalMsFor,
   // CTL-1095: injectable drain reader. Default → no drain info (fail-open:
   // draining:false). Production wires it from the local isDraining + inFlightCount.
   drainReader = null,
@@ -128,7 +130,7 @@ export function assembleClusterView({
   const heartbeatHosts = lastSeen && typeof lastSeen === "object" ? Object.keys(lastSeen) : [];
   const allHosts = [...new Set([...roster, ...heartbeatHosts])];
   const rosterSet = new Set(roster);
-  const liveness = overlayClusterLiveness(allHosts, lastSeen, { now, intervalMs, graceMs }).filter(
+  const liveness = overlayClusterLiveness(allHosts, lastSeen, { now, intervalMs, graceMs, intervalMsFor }).filter(
     (n) => rosterSet.has(n.host) || n.status !== "offline",
   );
   const displayHosts = liveness.map((n) => n.host);
@@ -314,12 +316,13 @@ export function createClusterEntity({
   // (host) -> { accepting, holdReason, … } | null. Default null = feature off.
   admissionReader = null,
   // CTL-1551: liveness thresholds, forwarded verbatim to assembleClusterView.
-  // The Loki peer transport adds known pipeline lag (beat cadence + background
-  // poll + sync-cache TTL) on top of heartbeat age, so the server passes a live
-  // window that budgets for it — otherwise a perfectly healthy peer is
-  // STRUCTURALLY classified "degraded". undefined = the node-liveness defaults.
+  // intervalMsFor is the PER-HOST resolver — the server budgets peer transport
+  // lag (beat cadence + background poll + sync-cache TTL) without loosening the
+  // SELF host's window (its heartbeats come straight from the local log).
+  // undefined = the node-liveness defaults.
   intervalMs = undefined,
   graceMs = undefined,
+  intervalMsFor = undefined,
   now = () => Date.now(),
 } = {}) {
   // Memoize the lazy execution-core import so repeated assembles don't re-import.
@@ -383,6 +386,7 @@ export function createClusterEntity({
         // trap as the three readers above.
         intervalMs,
         graceMs,
+        intervalMsFor,
       });
     },
   };

--- a/plugins/dev/scripts/orch-monitor/lib/cluster-view.mjs
+++ b/plugins/dev/scripts/orch-monitor/lib/cluster-view.mjs
@@ -313,6 +313,13 @@ export function createClusterEntity({
   // CTL-1322: injectable admission reader; forwarded verbatim to assembleClusterView.
   // (host) -> { accepting, holdReason, … } | null. Default null = feature off.
   admissionReader = null,
+  // CTL-1551: liveness thresholds, forwarded verbatim to assembleClusterView.
+  // The Loki peer transport adds known pipeline lag (beat cadence + background
+  // poll + sync-cache TTL) on top of heartbeat age, so the server passes a live
+  // window that budgets for it — otherwise a perfectly healthy peer is
+  // STRUCTURALLY classified "degraded". undefined = the node-liveness defaults.
+  intervalMs = undefined,
+  graceMs = undefined,
   now = () => Date.now(),
 } = {}) {
   // Memoize the lazy execution-core import so repeated assembles don't re-import.
@@ -372,6 +379,10 @@ export function createClusterEntity({
         aliases,
         drainReader,
         admissionReader,
+        // CTL-1551: forwarded, not defaulted here — same accepted-but-dropped
+        // trap as the three readers above.
+        intervalMs,
+        graceMs,
       });
     },
   };

--- a/plugins/dev/scripts/orch-monitor/lib/cluster-view.mjs
+++ b/plugins/dev/scripts/orch-monitor/lib/cluster-view.mjs
@@ -69,6 +69,7 @@ const noLivenessReader = () => ({});
  * @param {number} [args.intervalMs] liveness interval threshold
  * @param {number} [args.graceMs] liveness grace window
  * @param {Function} [args.intervalMsFor] CTL-1551: per-host live-window resolver (host) => ms | undefined
+ * @param {string|null} [args.selfHost] CTL-1551: this monitor's own (alias-folded) host — carried on the view so the UI never guesses local identity
  * @returns {import("./cluster-view.d.mts").ClusterView}
  */
 export function assembleClusterView({
@@ -82,6 +83,7 @@ export function assembleClusterView({
   intervalMs,
   graceMs,
   intervalMsFor,
+  selfHost = null,
   // CTL-1095: injectable drain reader. Default → no drain info (fail-open:
   // draining:false). Production wires it from the local isDraining + inFlightCount.
   drainReader = null,
@@ -201,12 +203,17 @@ export function assembleClusterView({
   // the multi-host branch (a single-node fleet attributes everything to its host).
   const makeTicket = (t, host) => ({ ...t, ownerHost: host });
 
+  // CTL-1551: normalized once — carried on BOTH return shapes so the UI never
+  // infers local identity from node status.
+  const foldedSelfHost = typeof selfHost === "string" && selfHost.length > 0 ? selfHost : null;
+
   if (singleHost) {
     const host = displayHosts[0] ?? null;
     const node = livenessByHost.get(host) ?? { host, status: host ? "offline" : null, lastSeen: null };
     return {
       generatedAt: board?.generatedAt ?? new Date(now).toISOString(),
       singleHost: true,
+      selfHost: foldedSelfHost,
       // Identity no-op: ALL board tickets, in board order, attributed to the one
       // host (preserves the flat board's ticket identity + ordering exactly).
       nodes: [
@@ -253,6 +260,7 @@ export function assembleClusterView({
   return {
     generatedAt: board?.generatedAt ?? new Date(now).toISOString(),
     singleHost: false,
+    selfHost: foldedSelfHost,
     nodes,
   };
 }
@@ -323,6 +331,9 @@ export function createClusterEntity({
   intervalMs = undefined,
   graceMs = undefined,
   intervalMsFor = undefined,
+  // CTL-1551: provider for this monitor's own (alias-folded) host name; resolved
+  // per assemble (execution-core deps load lazily). null = unknown.
+  selfHostProvider = null,
   now = () => Date.now(),
 } = {}) {
   // Memoize the lazy execution-core import so repeated assembles don't re-import.
@@ -387,6 +398,13 @@ export function createClusterEntity({
         intervalMs,
         graceMs,
         intervalMsFor,
+        selfHost: (() => {
+          try {
+            return typeof selfHostProvider === "function" ? (selfHostProvider() ?? null) : null;
+          } catch {
+            return null; // identity resolution is best-effort — never break the view
+          }
+        })(),
       });
     },
   };

--- a/plugins/dev/scripts/orch-monitor/lib/node-liveness.d.mts
+++ b/plugins/dev/scripts/orch-monitor/lib/node-liveness.d.mts
@@ -16,6 +16,10 @@ export interface LivenessThresholds {
   intervalMs?: number;
   /** The generous grace window (≤ this ago, past interval → degraded). Defaults to 5min. */
   graceMs?: number;
+  /** CTL-1551: per-host live-window resolver — (host) => ms | undefined. Lets the
+   * server budget PEER transport lag without loosening the self host's window.
+   * Invalid/throwing resolver falls back to intervalMs. */
+  intervalMsFor?: (host: string) => number | undefined;
 }
 
 /** node-heartbeat cadence default (mirrors execution-core HEARTBEAT_INTERVAL_MS). */

--- a/plugins/dev/scripts/orch-monitor/lib/node-liveness.mjs
+++ b/plugins/dev/scripts/orch-monitor/lib/node-liveness.mjs
@@ -111,15 +111,32 @@ export function mergeHeartbeatsNewestWins(...maps) {
 export function overlayClusterLiveness(
   hosts,
   lastSeenByHost,
-  { now = Date.now(), intervalMs = DEFAULT_HEARTBEAT_INTERVAL_MS, graceMs = DEFAULT_LIVENESS_GRACE_MS } = {},
+  {
+    now = Date.now(),
+    intervalMs = DEFAULT_HEARTBEAT_INTERVAL_MS,
+    graceMs = DEFAULT_LIVENESS_GRACE_MS,
+    // CTL-1551: optional PER-HOST live-window resolver — (host) => ms | undefined.
+    // The self host's heartbeats arrive directly from the local event log (no
+    // lag), while PEER heartbeats ride a transport with known pipeline latency,
+    // so one shared window is either too loose for self or too tight for peers.
+    // undefined/absent → the shared intervalMs.
+    intervalMsFor = null,
+  } = {},
 ) {
   const roster = Array.isArray(hosts) ? hosts : [];
   const seen = lastSeenByHost && typeof lastSeenByHost === "object" ? lastSeenByHost : {};
   return roster.map((host) => {
     const lastSeen = typeof seen[host] === "string" && seen[host].length > 0 ? seen[host] : null;
+    let hostIntervalMs = intervalMs;
+    try {
+      const v = typeof intervalMsFor === "function" ? intervalMsFor(host) : undefined;
+      if (Number.isFinite(v) && v > 0) hostIntervalMs = v;
+    } catch {
+      /* resolver failure → shared default; classification must never throw */
+    }
     return {
       host,
-      status: classifyHostLiveness(lastSeen, now, { intervalMs, graceMs }),
+      status: classifyHostLiveness(lastSeen, now, { intervalMs: hostIntervalMs, graceMs }),
       lastSeen,
     };
   });

--- a/plugins/dev/scripts/orch-monitor/server.ts
+++ b/plugins/dev/scripts/orch-monitor/server.ts
@@ -1674,13 +1674,25 @@ export function createServer(opts: CreateServerOptions): BunServer {
   // on the anchor — including a Stage-0 SHADOW node that owns zero tickets —
   // decoupled from the dispatch roster (see cluster-view.mjs CTL-1251 header).
   const clusterEntity = createClusterEntity({
-    // CTL-1551: the peer-liveness pipeline adds KNOWN lag on top of heartbeat
-    // age — ~30s beat cadence + the 60s background peer poll + the 20s Loki
-    // sync-cache TTL ≈ 110s worst case — so a healthy peer can NEVER satisfy
-    // the default 30s "live" window and would structurally render "degraded".
-    // Budget the live window for the transport (120s); "degraded" then means
-    // genuinely late (120s–5min), and offline semantics (5min grace) unchanged.
-    intervalMs: 120_000,
+    // CTL-1551: PER-HOST live window. The SELF host's heartbeats come straight
+    // from the local event log (no transport lag) and keep the default 30s
+    // window — a locally-dead daemon degrades promptly. PEER heartbeats ride a
+    // pipeline with KNOWN lag, so a healthy peer can never satisfy 30s and
+    // would structurally render "degraded"; budget by transport:
+    //   loki (default): ~30s beat + 60s poll + 20s sync cache  → 120s window
+    //   linear anchor:  ~120s publish cadence + 60s poll       → 240s window
+    // "degraded" then means genuinely late; the 5-min offline grace unchanged.
+    intervalMsFor: (host: string) => {
+      let self: string | null;
+      try {
+        self = execCoreDeps?.getHostName?.() ?? null;
+      } catch {
+        self = null;
+      }
+      if (self && host === self) return undefined; // default 30s — local log is direct
+      const src = (process.env.CATALYST_LIVENESS_READ_SOURCE ?? "").trim().toLowerCase();
+      return src === "linear" ? 240_000 : 120_000;
+    },
     rosterProvider: () => {
       try {
         return execCoreDeps?.getClusterHosts() ?? [];

--- a/plugins/dev/scripts/orch-monitor/server.ts
+++ b/plugins/dev/scripts/orch-monitor/server.ts
@@ -1591,8 +1591,14 @@ export function createServer(opts: CreateServerOptions): BunServer {
     const raw = Number(process.env.EXECUTION_CORE_LOKI_LIVENESS_CACHE_MS);
     return Number.isFinite(raw) && raw >= 0 ? raw : 20_000;
   })();
-  const HEARTBEAT_CADENCE_MS = 30_000; // node.heartbeat cadence (execution-core HEARTBEAT_INTERVAL_MS)
-  const ANCHOR_PUBLISH_CADENCE_MS = 120_000; // Linear-anchor publisher cadence (cluster-heartbeat-publisher)
+  // Cadences honor the same env overrides the daemon reads (execution-core
+  // config.mjs) so a re-tuned fleet widens the budget in lockstep.
+  const envMs = (name: string, fallback: number): number => {
+    const raw = Number(process.env[name]);
+    return Number.isFinite(raw) && raw > 0 ? raw : fallback;
+  };
+  const HEARTBEAT_CADENCE_MS = envMs("EXECUTION_CORE_HEARTBEAT_INTERVAL_MS", 30_000); // node.heartbeat cadence
+  const ANCHOR_PUBLISH_CADENCE_MS = envMs("EXECUTION_CORE_LIVENESS_PUBLISH_INTERVAL_MS", 120_000); // anchor publisher cadence
   const PEER_WINDOW_MARGIN_MS = 10_000;
   const lokiPeerWindowMs = HEARTBEAT_CADENCE_MS + peerPollMs + lokiCacheTtlMs + PEER_WINDOW_MARGIN_MS;
   const anchorPeerWindowMs = ANCHOR_PUBLISH_CADENCE_MS + peerPollMs + PEER_WINDOW_MARGIN_MS;
@@ -1674,7 +1680,10 @@ export function createServer(opts: CreateServerOptions): BunServer {
       // snapshot — retained entries keep the source that produced them.
       for (const [host, rec] of Object.entries(peers)) {
         if (rec?.last_seen && folded.heartbeats[host] === rec.last_seen) {
-          peerSourceByHost[host] = peerSource;
+          // Key provenance by the PINNED name — the resolver is called with
+          // alias-folded roster names (cluster-view folds heartbeat keys), so a
+          // raw-transport-keyed entry would never be found.
+          peerSourceByHost[resolveHostAlias(host, hostAliases) ?? host] = peerSource;
         }
       }
       anchorHeartbeatCache.map = folded.heartbeats;

--- a/plugins/dev/scripts/orch-monitor/server.ts
+++ b/plugins/dev/scripts/orch-monitor/server.ts
@@ -1674,6 +1674,13 @@ export function createServer(opts: CreateServerOptions): BunServer {
   // on the anchor — including a Stage-0 SHADOW node that owns zero tickets —
   // decoupled from the dispatch roster (see cluster-view.mjs CTL-1251 header).
   const clusterEntity = createClusterEntity({
+    // CTL-1551: the peer-liveness pipeline adds KNOWN lag on top of heartbeat
+    // age — ~30s beat cadence + the 60s background peer poll + the 20s Loki
+    // sync-cache TTL ≈ 110s worst case — so a healthy peer can NEVER satisfy
+    // the default 30s "live" window and would structurally render "degraded".
+    // Budget the live window for the transport (120s); "degraded" then means
+    // genuinely late (120s–5min), and offline semantics (5min grace) unchanged.
+    intervalMs: 120_000,
     rosterProvider: () => {
       try {
         return execCoreDeps?.getClusterHosts() ?? [];

--- a/plugins/dev/scripts/orch-monitor/server.ts
+++ b/plugins/dev/scripts/orch-monitor/server.ts
@@ -1577,6 +1577,8 @@ export function createServer(opts: CreateServerOptions): BunServer {
   // populated BEFORE the no-anchor early-return so it works single-host too.
   const localAdmissionCache: { map: Record<string, NodeAdmission> } = { map: {} };
   let execCoreDeps: Awaited<ReturnType<typeof loadDaemonDeps>> = null;
+  // CTL-1551: the peer transport the LAST poll actually used ("loki" | "anchor").
+  let lastPeerSource: string = "loki";
   let anchorPollTimer: ReturnType<typeof setInterval> | null = null;
   const pollAnchorHeartbeats = (): void => {
     try {
@@ -1625,13 +1627,17 @@ export function createServer(opts: CreateServerOptions): BunServer {
         cfgLokiUrl = null;
       }
       const explicitLokiUrl = process.env.CATALYST_LOKI_QUERY_URL?.trim() ? cfgLokiUrl : null;
-      const { peers } = readPeerRecords({
+      const { peers, source: peerSource } = readPeerRecords({
         rawSource: process.env.CATALYST_LIVENESS_READ_SOURCE,
         lokiUrl: explicitLokiUrl ?? lokiUrl ?? cfgLokiUrl ?? null,
         anchorIssue: execCoreDeps.getLivenessAnchorIssue(),
         readLoki: execCoreDeps.readClusterLivenessFromLokiSyncCached,
         readAnchor: execCoreDeps.readPeerHeartbeatsSync,
       }) as { peers: Record<string, AnchorPeerRec> | null; source: string };
+      // CTL-1551: remember which transport ACTUALLY served this poll — the
+      // liveness window resolver budgets by real transport, not by env intent
+      // (AUTO can fall back to the slower anchor when Loki is empty/down).
+      if (peerSource === "loki" || peerSource === "anchor") lastPeerSource = peerSource;
       if (peers == null) {
         anchorHeartbeatCache.map = {}; // no transport configured → no peers
         anchorCapacityCache.map = {};
@@ -1673,6 +1679,21 @@ export function createServer(opts: CreateServerOptions): BunServer {
   // anchor peer cache). createClusterEntity then surfaces any node currently live
   // on the anchor — including a Stage-0 SHADOW node that owns zero tickets —
   // decoupled from the dispatch roster (see cluster-view.mjs CTL-1251 header).
+  // CTL-1551: resolve this monitor's own host through config AND the alias map,
+  // so it matches the (pinned) node names the cluster view renders. getHostName
+  // alone can lag a sticky-identity restore (the daemon pins CATALYST_HOST_NAME
+  // only in its own process) — alias-folding covers the pre-pin raw-name case,
+  // the same normalization every heartbeat key gets. null when unknown.
+  const resolveSelfPinnedHost = (): string | null => {
+    try {
+      const raw = execCoreDeps?.getHostName?.() ?? null;
+      if (!raw) return null;
+      return resolveHostAlias(raw, hostAliases) ?? raw;
+    } catch {
+      return null;
+    }
+  };
+
   const clusterEntity = createClusterEntity({
     // CTL-1551: PER-HOST live window. The SELF host's heartbeats come straight
     // from the local event log (no transport lag) and keep the default 30s
@@ -1683,16 +1704,16 @@ export function createServer(opts: CreateServerOptions): BunServer {
     //   linear anchor:  ~120s publish cadence + 60s poll       → 240s window
     // "degraded" then means genuinely late; the 5-min offline grace unchanged.
     intervalMsFor: (host: string) => {
-      let self: string | null;
-      try {
-        self = execCoreDeps?.getHostName?.() ?? null;
-      } catch {
-        self = null;
-      }
+      const self = resolveSelfPinnedHost();
       if (self && host === self) return undefined; // default 30s — local log is direct
-      const src = (process.env.CATALYST_LIVENESS_READ_SOURCE ?? "").trim().toLowerCase();
-      return src === "linear" ? 240_000 : 120_000;
+      // Budget by the transport the poll ACTUALLY used last (AUTO can fall back
+      // to the anchor): loki ≈ 30s beat + 60s poll + 20s cache → 120s; the
+      // Linear anchor publishes every ~120s + 60s poll → 240s.
+      return lastPeerSource === "anchor" ? 240_000 : 120_000;
     },
+    // CTL-1551: the monitor's own identity for the view/signal (SlotDeck's
+    // localHost) — resolved per assemble, alias-folded like every other host key.
+    selfHostProvider: () => resolveSelfPinnedHost(),
     rosterProvider: () => {
       try {
         return execCoreDeps?.getClusterHosts() ?? [];

--- a/plugins/dev/scripts/orch-monitor/server.ts
+++ b/plugins/dev/scripts/orch-monitor/server.ts
@@ -1577,8 +1577,25 @@ export function createServer(opts: CreateServerOptions): BunServer {
   // populated BEFORE the no-anchor early-return so it works single-host too.
   const localAdmissionCache: { map: Record<string, NodeAdmission> } = { map: {} };
   let execCoreDeps: Awaited<ReturnType<typeof loadDaemonDeps>> = null;
-  // CTL-1551: the peer transport the LAST poll actually used ("loki" | "anchor").
+  // CTL-1551: the peer transport the LAST poll actually used ("loki" | "anchor"),
+  // plus PER-HOST source memory — an AUTO fallback poll must not hand a RETAINED
+  // Loki-era heartbeat the anchor's looser window (fold rejects the anchor's
+  // stale records, so the retained entry's provenance is still Loki).
   let lastPeerSource: string = "loki";
+  const peerSourceByHost: Record<string, string> = {};
+  // Live windows DERIVED from the configured cadences (an operator raising
+  // MONITOR_ANCHOR_POLL_MS or the cache TTL must not shrink the budget below
+  // the real pipeline): beat/publish cadence + poll interval + cache TTL + margin.
+  const peerPollMs = Number(process.env.MONITOR_ANCHOR_POLL_MS) || 60_000;
+  const lokiCacheTtlMs = (() => {
+    const raw = Number(process.env.EXECUTION_CORE_LOKI_LIVENESS_CACHE_MS);
+    return Number.isFinite(raw) && raw >= 0 ? raw : 20_000;
+  })();
+  const HEARTBEAT_CADENCE_MS = 30_000; // node.heartbeat cadence (execution-core HEARTBEAT_INTERVAL_MS)
+  const ANCHOR_PUBLISH_CADENCE_MS = 120_000; // Linear-anchor publisher cadence (cluster-heartbeat-publisher)
+  const PEER_WINDOW_MARGIN_MS = 10_000;
+  const lokiPeerWindowMs = HEARTBEAT_CADENCE_MS + peerPollMs + lokiCacheTtlMs + PEER_WINDOW_MARGIN_MS;
+  const anchorPeerWindowMs = ANCHOR_PUBLISH_CADENCE_MS + peerPollMs + PEER_WINDOW_MARGIN_MS;
   let anchorPollTimer: ReturnType<typeof setInterval> | null = null;
   const pollAnchorHeartbeats = (): void => {
     try {
@@ -1653,6 +1670,13 @@ export function createServer(opts: CreateServerOptions): BunServer {
         prevCapacity: anchorCapacityCache.map,
         peers,
       });
+      // Stamp provenance ONLY for hosts whose folded heartbeat came from THIS
+      // snapshot — retained entries keep the source that produced them.
+      for (const [host, rec] of Object.entries(peers)) {
+        if (rec?.last_seen && folded.heartbeats[host] === rec.last_seen) {
+          peerSourceByHost[host] = peerSource;
+        }
+      }
       anchorHeartbeatCache.map = folded.heartbeats;
       anchorCapacityCache.map = folded.capacity;
     } catch {
@@ -1664,8 +1688,7 @@ export function createServer(opts: CreateServerOptions): BunServer {
       execCoreDeps = d;
       pollAnchorHeartbeats(); // prime immediately once deps resolve
     });
-    const anchorPollMs = Number(process.env.MONITOR_ANCHOR_POLL_MS) || 60_000;
-    anchorPollTimer = setInterval(pollAnchorHeartbeats, anchorPollMs);
+    anchorPollTimer = setInterval(pollAnchorHeartbeats, peerPollMs);
     anchorPollTimer.unref?.();
   }
 
@@ -1706,10 +1729,11 @@ export function createServer(opts: CreateServerOptions): BunServer {
     intervalMsFor: (host: string) => {
       const self = resolveSelfPinnedHost();
       if (self && host === self) return undefined; // default 30s — local log is direct
-      // Budget by the transport the poll ACTUALLY used last (AUTO can fall back
-      // to the anchor): loki ≈ 30s beat + 60s poll + 20s cache → 120s; the
-      // Linear anchor publishes every ~120s + 60s poll → 240s.
-      return lastPeerSource === "anchor" ? 240_000 : 120_000;
+      // Budget by the transport that produced THIS host's cached heartbeat
+      // (per-host provenance; poll-global source only as a fallback), with the
+      // window DERIVED from the configured cadences.
+      const src = peerSourceByHost[host] ?? lastPeerSource;
+      return src === "anchor" ? anchorPeerWindowMs : lokiPeerWindowMs;
     },
     // CTL-1551: the monitor's own identity for the view/signal (SlotDeck's
     // localHost) — resolved per assemble, alias-folded like every other host key.

--- a/plugins/dev/scripts/orch-monitor/server.ts
+++ b/plugins/dev/scripts/orch-monitor/server.ts
@@ -1364,6 +1364,8 @@ export function createServer(opts: CreateServerOptions): BunServer {
     readClusterLivenessFromLokiSyncCached: (args: {
       lokiUrl: string;
     }) => Record<string, AnchorPeerRec>;
+    readStickyIdentity: (args: { dir: string }) => string | null;
+    getCatalystRepoDir: () => string;
     deriveDaemonHealth: typeof import("./lib/nav-signal.mjs").deriveDaemonHealth;
   } | null> | null = null;
   const loadDaemonDeps = () => {
@@ -1374,7 +1376,8 @@ export function createServer(opts: CreateServerOptions): BunServer {
           const configMod = ["..", "execution-core", "config.mjs"].join("/");
           const heartbeatSyncMod = ["..", "execution-core", "cluster-heartbeat-sync.mjs"].join("/");
           const lokiSyncMod = ["..", "execution-core", "loki-liveness-sync.mjs"].join("/");
-          const [recovery, config, heartbeatSync, lokiSync, navSignal] = await Promise.all([
+          const hostStickyMod = ["..", "execution-core", "host-sticky.mjs"].join("/");
+          const [recovery, config, heartbeatSync, lokiSync, hostSticky, navSignal] = await Promise.all([
             import(recoveryMod) as Promise<{
               readClusterHeartbeats: (opts: { logPath?: string }) => Record<string, string>;
               readClusterAdmission: (opts: { logPath?: string }) => Record<string, NodeAdmission>;
@@ -1384,6 +1387,7 @@ export function createServer(opts: CreateServerOptions): BunServer {
               getClusterHosts: () => string[];
               getLivenessAnchorIssue: () => string | null;
               getLokiQueryUrl: () => string | null;
+              getCatalystRepoDir: () => string;
             }>,
             import(heartbeatSyncMod) as Promise<{
               readPeerHeartbeatsSync: (args: { anchorIssue: string }) => Record<string, AnchorPeerRec>;
@@ -1392,6 +1396,9 @@ export function createServer(opts: CreateServerOptions): BunServer {
               readClusterLivenessFromLokiSyncCached: (args: {
                 lokiUrl: string;
               }) => Record<string, AnchorPeerRec>;
+            }>,
+            import(hostStickyMod) as Promise<{
+              readStickyIdentity: (args: { dir: string }) => string | null;
             }>,
             import("./lib/nav-signal.mjs"),
           ]);
@@ -1404,6 +1411,8 @@ export function createServer(opts: CreateServerOptions): BunServer {
             getLokiQueryUrl: config.getLokiQueryUrl,
             readPeerHeartbeatsSync: heartbeatSync.readPeerHeartbeatsSync,
             readClusterLivenessFromLokiSyncCached: lokiSync.readClusterLivenessFromLokiSyncCached,
+            readStickyIdentity: hostSticky.readStickyIdentity,
+            getCatalystRepoDir: config.getCatalystRepoDir,
             deriveDaemonHealth: navSignal.deriveDaemonHealth,
           };
         } catch {
@@ -1600,6 +1609,10 @@ export function createServer(opts: CreateServerOptions): BunServer {
   const HEARTBEAT_CADENCE_MS = envMs("EXECUTION_CORE_HEARTBEAT_INTERVAL_MS", 30_000); // node.heartbeat cadence
   const ANCHOR_PUBLISH_CADENCE_MS = envMs("EXECUTION_CORE_LIVENESS_PUBLISH_INTERVAL_MS", 120_000); // anchor publisher cadence
   const PEER_WINDOW_MARGIN_MS = 10_000;
+  // Live windows must stay strictly below the 5-min offline grace (classify
+  // checks live BEFORE grace, so a window ≥ grace would render a should-be-
+  // offline host as live). Cap leaves a real degraded band.
+  const PEER_WINDOW_GRACE_CAP_MS = 4 * 60_000;
   const lokiPeerWindowMs = HEARTBEAT_CADENCE_MS + peerPollMs + lokiCacheTtlMs + PEER_WINDOW_MARGIN_MS;
   const anchorPeerWindowMs = ANCHOR_PUBLISH_CADENCE_MS + peerPollMs + PEER_WINDOW_MARGIN_MS;
   let anchorPollTimer: ReturnType<typeof setInterval> | null = null;
@@ -1718,7 +1731,19 @@ export function createServer(opts: CreateServerOptions): BunServer {
   // the same normalization every heartbeat key gets. null when unknown.
   const resolveSelfPinnedHost = (): string | null => {
     try {
-      const raw = execCoreDeps?.getHostName?.() ?? null;
+      // Prefer the daemon's RECORDED sticky identity (host-sticky.mjs): on an
+      // unpinned multi-host install whose OS hostname changed, the daemon
+      // restores the sticky name only inside its own process — this separately
+      // launched monitor would otherwise see the NEW os.hostname(). Fall back
+      // to getHostName, then fold through the alias map like every host key.
+      let raw: string | null = null;
+      try {
+        const dir = execCoreDeps?.getCatalystRepoDir?.();
+        raw = dir ? (execCoreDeps?.readStickyIdentity?.({ dir }) ?? null) : null;
+      } catch {
+        raw = null;
+      }
+      raw = raw ?? execCoreDeps?.getHostName?.() ?? null;
       if (!raw) return null;
       return resolveHostAlias(raw, hostAliases) ?? raw;
     } catch {
@@ -1737,12 +1762,17 @@ export function createServer(opts: CreateServerOptions): BunServer {
     // "degraded" then means genuinely late; the 5-min offline grace unchanged.
     intervalMsFor: (host: string) => {
       const self = resolveSelfPinnedHost();
-      if (self && host === self) return undefined; // default 30s — local log is direct
+      // SELF: the local log is direct (no transport lag) — the window is the
+      // daemon's own configured beat cadence (default 30s), not a literal.
+      if (self && host === self) return HEARTBEAT_CADENCE_MS;
       // Budget by the transport that produced THIS host's cached heartbeat
       // (per-host provenance; poll-global source only as a fallback), with the
-      // window DERIVED from the configured cadences.
+      // window DERIVED from the configured cadences — capped below the 5-min
+      // offline grace so classify's live-check can never mask a host that
+      // should already be offline.
       const src = peerSourceByHost[host] ?? lastPeerSource;
-      return src === "anchor" ? anchorPeerWindowMs : lokiPeerWindowMs;
+      const win = src === "anchor" ? anchorPeerWindowMs : lokiPeerWindowMs;
+      return Math.min(win, PEER_WINDOW_GRACE_CAP_MS);
     },
     // CTL-1551: the monitor's own identity for the view/signal (SlotDeck's
     // localHost) — resolved per assemble, alias-folded like every other host key.

--- a/plugins/dev/scripts/orch-monitor/ui/src/components/queue/slot-deck.tsx
+++ b/plugins/dev/scripts/orch-monitor/ui/src/components/queue/slot-deck.tsx
@@ -244,7 +244,14 @@ export function SlotDeck({
 
   // Cluster-mode path: use aggregateClusterCapacity + assignClusterSlots
   if (clusterSignal && clusterSignal.nodes.length > 1) {
-    const localHost = clusterSignal.nodes.find((n) => n.status === "live")?.host ?? "";
+    // CTL-1551: prefer the signal's explicit self identity — with peers now
+    // legitimately "live" (Loki transport), first-live-node picks the wrong
+    // host on any monitor that isn't first in the roster. The old heuristic
+    // remains only as a fallback for pre-CTL-1551 cached frames.
+    const localHost =
+      clusterSignal.selfHost ??
+      clusterSignal.nodes.find((n) => n.status === "live")?.host ??
+      "";
     const allSlots = assignClusterSlots({
       nodes: clusterSignal.nodes as any,
       localHost,

--- a/plugins/dev/scripts/orch-monitor/ui/src/lib/cluster-signal.ts
+++ b/plugins/dev/scripts/orch-monitor/ui/src/lib/cluster-signal.ts
@@ -41,6 +41,8 @@ export interface ClusterSignalNode {
 export interface ClusterSignal {
   /** True ⇒ exactly one node — footer shows one dot, the node filter is absent. */
   singleHost: boolean;
+  /** CTL-1551: this monitor's own host; absent on pre-CTL-1551 frames. */
+  selfHost?: string;
   /** One entry per REAL roster host (the synthetic unassigned bucket is dropped server-side). */
   nodes: ClusterSignalNode[];
   /** The source snapshot's generatedAt (passthrough for dedupe/debug). */


### PR DESCRIPTION
Follow-up to #2808 (deployed and verified on both minis): peer nodes now render with real Loki-fed capacity, but they classify **degraded** instead of **live** because the peer transport's inherent lag (~30s heartbeat cadence + 60s background poll + 20s sync-cache TTL ≈ 110s worst case) can never satisfy the default 30-second live window — a structural misclassification for a healthy peer.

- `createClusterEntity` accepts and forwards `intervalMs`/`graceMs` to `assembleClusterView` (documented against the same accepted-but-dropped trap the reader params once hit).
- server passes `intervalMs: 120_000` — "degraded" now means genuinely late (120s–5min); the 5-minute offline grace is unchanged.
- New entity-level test pins the forward with a 90s-old peer heartbeat classifying live.

Linear: CTL-1551

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Wte59hchAL4FjhHiCwSVS3