### PR TITLE
feat(dev): CTL-1574 ticket activity feed (Discussion) in monitor inbox + ticket page

### DIFF
--- a/plugins/dev/scripts/orch-monitor/__tests__/ticket-discussion-reader.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/ticket-discussion-reader.test.ts
@@ -178,6 +178,7 @@ describe("readTicketDiscussion", () => {
       available: false,
       identifier: null,
       title: null,
+      createdAt: null,
       comments: [],
       activity: [],
     });

--- a/plugins/dev/scripts/orch-monitor/__tests__/ticket-discussion-reader.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/ticket-discussion-reader.test.ts
@@ -13,7 +13,7 @@
 
 import { describe, it, expect, beforeEach, afterEach } from "bun:test";
 import { Database } from "bun:sqlite";
-import { mkdtempSync, rmSync } from "node:fs";
+import { mkdtempSync, rmSync, utimesSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -120,7 +120,12 @@ function seed(): void {
     "INSERT INTO issue_history (id, issue_id, actor_id, created_at, added_label_ids) VALUES (?,?,?,?,?)",
     ["hist-2", "issue-1", "user-1", 4000, JSON.stringify(["label-1"])],
   );
+  // Freshness-gate substrate (CTL-1574 review): a live writer heartbeat and a
+  // completed seed cursor — the reader refuses stale/mid-reseed replicas.
+  db.run("CREATE TABLE sync_meta (key text PRIMARY KEY NOT NULL, value text)");
+  db.run("INSERT INTO sync_meta (key, value) VALUES ('cursor', 'cursor-1')");
   db.close();
+  writeFileSync(`${dbPath}.writer.lock`, String(process.pid));
 }
 
 beforeEach(() => {
@@ -194,6 +199,40 @@ describe("readTicketDiscussion", () => {
       expect(out.comments).toEqual([]);
       expect(out.activity).toEqual([]);
     }
+  });
+
+  it("reports unavailable when the writer heartbeat is stale (dead cloud-sync)", async () => {
+    seed();
+    const old = (Date.now() - 3_600_000) / 1000; // 1h-old heartbeat, threshold 5min
+    utimesSync(`${dbPath}.writer.lock`, old, old);
+    const out = await readTicketDiscussion("CTL-1574", { dbPath });
+    expect(out.available).toBe(false);
+    expect(out.comments).toEqual([]);
+  });
+
+  it("reports unavailable mid-reseed (sync_meta cursor absent)", async () => {
+    seed();
+    const db = new Database(dbPath);
+    db.run("DELETE FROM sync_meta WHERE key = 'cursor'");
+    db.close();
+    const out = await readTicketDiscussion("CTL-1574", { dbPath });
+    expect(out.available).toBe(false);
+    expect(out.comments).toEqual([]);
+  });
+
+  it("normalizes ISO-string timestamps to ms epoch (mixed writer versions)", async () => {
+    seed();
+    const db = new Database(dbPath);
+    db.run("UPDATE issues SET created_at = ? WHERE id = 'issue-1'", ["2026-07-30T12:00:00.000Z"]);
+    db.run("UPDATE comments SET updated_at = ? WHERE id = 'comment-1'", ["1970-01-01T00:00:01.000Z"]);
+    db.run("UPDATE issue_history SET created_at = ? WHERE id = 'hist-0'", ["1970-01-01T00:00:00.500Z"]);
+    db.close();
+    const out = await readTicketDiscussion("CTL-1574", { dbPath });
+    expect(out.createdAt).toBe(Date.parse("2026-07-30T12:00:00.000Z"));
+    // Look up by id — a string timestamp also perturbs SQLite's ORDER BY
+    // (text sorts after integers), which is exactly why normalization matters.
+    expect(out.comments.find((c) => c.id === "comment-1")).toMatchObject({ updated_at: 1000 });
+    expect(out.activity.find((e) => e.id === "hist-0")).toMatchObject({ created_at: 500 });
   });
 
   it("degrades to unavailable when the replica file is missing", async () => {

--- a/plugins/dev/scripts/orch-monitor/__tests__/ticket-discussion-reader.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/ticket-discussion-reader.test.ts
@@ -1,0 +1,225 @@
+// ticket-discussion-reader.test.ts — CTL-1574.
+//
+// Drives readTicketDiscussion against a TEMP bun:sqlite db carrying the minimal
+// subset of the CTC replica schema that `@catalyst-cloud/read-model`'s
+// buildIssueDetail touches (issues / comments / issue_history / users / labels /
+// issue_labels / relations / projects / cycles). Column definitions are copied
+// from the live replica's `.schema` so the fixture exercises the real SQL rather
+// than a shape we invented.
+//
+// The point of these cases is the FAILURE contract as much as the happy path: a
+// malformed identifier, an unknown ticket, and a missing db must all come back
+// `available:false` with empty arrays — never a throw into the route.
+
+import { describe, it, expect, beforeEach, afterEach } from "bun:test";
+import { Database } from "bun:sqlite";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { readTicketDiscussion } from "../lib/ticket-discussion-reader.mjs";
+
+let tmpRoot: string;
+let dbPath: string;
+
+// The replica subset buildIssueDetail reads. Trimmed to the columns the builders
+// SELECT (plus the primary keys) — a narrower table would fail the real query.
+const SCHEMA = `
+CREATE TABLE issues (
+  id text PRIMARY KEY NOT NULL, identifier text, title text, description text,
+  state text, state_id text, assignee text, assignee_id text, priority integer,
+  estimate real, project_id text, cycle_id text, team_id text, team_key text,
+  team_name text, delegate_id text, delegate_name text, bot_actor_name text,
+  bot_actor_type text, bot_actor_sub_type text, parent_id text,
+  parent_identifier text, url text, started_at integer, completed_at integer,
+  canceled_at integer, created_at integer, due_date text, priority_label text,
+  sort_order real, updated_at integer, removed_at integer
+);
+CREATE TABLE comments (
+  id text PRIMARY KEY NOT NULL, issue_id text, body text, updated_at integer,
+  removed_at integer, author_id text, author_name text, author_avatar_url text,
+  is_bot integer, parent_id text, created_at integer
+);
+CREATE TABLE issue_history (
+  id text PRIMARY KEY NOT NULL, issue_id text NOT NULL, actor_id text,
+  created_at integer, updated_at integer, from_state text, to_state text,
+  from_assignee_id text, to_assignee_id text, from_priority integer,
+  to_priority integer, from_estimate real, to_estimate real, from_title text,
+  to_title text, from_cycle_id text, to_cycle_id text, from_project_id text,
+  to_project_id text, from_parent_id text, to_parent_id text, from_team_id text,
+  to_team_id text, from_due_date text, to_due_date text, added_label_ids text,
+  removed_label_ids text, updated_description integer, archived integer,
+  auto_archived integer, auto_closed integer, trashed integer
+);
+CREATE TABLE users (
+  id text PRIMARY KEY NOT NULL, name text, display_name text, avatar_url text,
+  type text, source text, updated_at integer
+);
+CREATE TABLE labels (
+  id text PRIMARY KEY NOT NULL, name text, color text, updated_at integer,
+  removed_at integer
+);
+CREATE TABLE issue_labels (
+  issue_id text NOT NULL, label_id text NOT NULL, PRIMARY KEY (issue_id, label_id)
+);
+CREATE TABLE relations (
+  id text PRIMARY KEY NOT NULL, type text, issue_identifier text,
+  related_identifier text, updated_at integer
+);
+CREATE TABLE projects (
+  id text PRIMARY KEY NOT NULL, name text, state text, description text,
+  progress real, health text, updated_at integer, removed_at integer
+);
+CREATE TABLE cycles (
+  id text PRIMARY KEY NOT NULL, number integer, name text, starts_at integer,
+  ends_at integer, updated_at integer
+);
+`;
+
+/** Seed a replica with one issue, two comments and three history rows. */
+function seed(): void {
+  const db = new Database(dbPath, { create: true });
+  db.exec(SCHEMA);
+  db.run(
+    "INSERT INTO issues (id, identifier, title, removed_at) VALUES (?, ?, ?, NULL)",
+    ["issue-1", "CTL-1574", "Operators should see a ticket's activity feed"],
+  );
+  db.run("INSERT INTO users (id, name, avatar_url) VALUES (?, ?, ?)", [
+    "user-1",
+    "ryan",
+    "https://example.invalid/a.png",
+  ]);
+  db.run("INSERT INTO labels (id, name, color, removed_at) VALUES (?, ?, ?, NULL)", [
+    "label-1",
+    "needs-human",
+    "#e36b6b",
+  ]);
+  // Oldest-first by updated_at — the order buildIssueDetail returns.
+  db.run(
+    "INSERT INTO comments (id, issue_id, body, author_id, author_name, is_bot, updated_at, removed_at) VALUES (?,?,?,?,?,?,?,NULL)",
+    ["comment-1", "issue-1", "First turn.", "user-1", "ryan", 0, 1000],
+  );
+  db.run(
+    "INSERT INTO comments (id, issue_id, body, author_id, author_name, is_bot, updated_at, removed_at) VALUES (?,?,?,?,?,?,?,NULL)",
+    ["comment-2", "issue-1", "Agent reply.", null, "Catalyst", 1, 3000],
+  );
+  // A REMOVED comment must not surface (the read-model filters removed_at).
+  db.run(
+    "INSERT INTO comments (id, issue_id, body, author_name, is_bot, updated_at, removed_at) VALUES (?,?,?,?,?,?,?)",
+    ["comment-gone", "issue-1", "Deleted.", "ryan", 0, 2000, 2500],
+  );
+  db.run(
+    "INSERT INTO issue_history (id, issue_id, actor_id, created_at) VALUES (?,?,?,?)",
+    ["hist-0", "issue-1", "user-1", 500],
+  );
+  db.run(
+    "INSERT INTO issue_history (id, issue_id, actor_id, created_at, from_state, to_state) VALUES (?,?,?,?,?,?)",
+    ["hist-1", "issue-1", "user-1", 2000, "Backlog", "Implement"],
+  );
+  db.run(
+    "INSERT INTO issue_history (id, issue_id, actor_id, created_at, added_label_ids) VALUES (?,?,?,?,?)",
+    ["hist-2", "issue-1", "user-1", 4000, JSON.stringify(["label-1"])],
+  );
+  db.close();
+}
+
+beforeEach(() => {
+  tmpRoot = mkdtempSync(join(tmpdir(), "ctl1574-"));
+  dbPath = join(tmpRoot, "catalyst-replica.db");
+});
+
+afterEach(() => {
+  rmSync(tmpRoot, { recursive: true, force: true });
+});
+
+describe("readTicketDiscussion", () => {
+  it("returns the ticket's live comments oldest-first, with the author fields resolved", async () => {
+    seed();
+    const out = await readTicketDiscussion("CTL-1574", { dbPath });
+
+    expect(out.available).toBe(true);
+    expect(out.identifier).toBe("CTL-1574");
+    expect(out.title).toBe("Operators should see a ticket's activity feed");
+    expect(out.comments.map((c) => c.id)).toEqual(["comment-1", "comment-2"]);
+    expect(out.comments[0]).toMatchObject({
+      body: "First turn.",
+      author_name: "ryan",
+      is_bot: 0,
+      updated_at: 1000,
+    });
+    expect(out.comments[1]).toMatchObject({ author_name: "Catalyst", is_bot: 1 });
+  });
+
+  it("returns the activity events oldest-first with actor + label ids resolved to display values", async () => {
+    seed();
+    const out = await readTicketDiscussion("CTL-1574", { dbPath });
+
+    expect(out.activity.map((e) => e.id)).toEqual(["hist-0", "hist-1", "hist-2"]);
+    // Actor resolved from users.
+    expect(out.activity[0]).toMatchObject({
+      actor_name: "ryan",
+      actor_avatar_url: "https://example.invalid/a.png",
+      created_at: 500,
+    });
+    // A state transition carries both ends as raw state NAMES.
+    expect(out.activity[1]).toMatchObject({ from_state: "Backlog", to_state: "Implement" });
+    // Label ids resolve to {id,name,color}; the untouched side stays [].
+    expect(out.activity[2].added_labels).toEqual([
+      { id: "label-1", name: "needs-human", color: "#e36b6b" },
+    ]);
+    expect(out.activity[2].removed_labels).toEqual([]);
+  });
+
+  it("reports an unknown ticket as unavailable rather than an empty discussion", async () => {
+    seed();
+    const out = await readTicketDiscussion("CTL-9999", { dbPath });
+
+    expect(out).toEqual({
+      available: false,
+      identifier: null,
+      title: null,
+      comments: [],
+      activity: [],
+    });
+  });
+
+  it("rejects a malformed identifier before touching the db", async () => {
+    seed();
+    // No opener is provided, and dbPath is omitted — a reader that ran any SQL
+    // would fall through to the real replica. It must short-circuit on the regex.
+    for (const bad of ["", "CTL", "CTL-", "-1574", "CTL_1574", "CTL-1574; DROP TABLE issues", "../etc"]) {
+      const out = await readTicketDiscussion(bad);
+      expect(out.available).toBe(false);
+      expect(out.comments).toEqual([]);
+      expect(out.activity).toEqual([]);
+    }
+  });
+
+  it("degrades to unavailable when the replica file is missing", async () => {
+    // Nothing seeded — the path does not exist.
+    const out = await readTicketDiscussion("CTL-1574", { dbPath });
+    expect(out.available).toBe(false);
+    expect(out.comments).toEqual([]);
+  });
+
+  it("degrades to unavailable when opening the db throws", async () => {
+    seed();
+    const out = await readTicketDiscussion("CTL-1574", {
+      dbPath,
+      openDb: () => {
+        throw new Error("locked");
+      },
+    });
+    expect(out.available).toBe(false);
+    expect(out.activity).toEqual([]);
+  });
+
+  it("degrades to unavailable when the db has no replica schema", async () => {
+    const db = new Database(dbPath, { create: true });
+    db.exec("CREATE TABLE unrelated (id text)");
+    db.close();
+
+    const out = await readTicketDiscussion("CTL-1574", { dbPath });
+    expect(out.available).toBe(false);
+  });
+});

--- a/plugins/dev/scripts/orch-monitor/bun.lock
+++ b/plugins/dev/scripts/orch-monitor/bun.lock
@@ -4,6 +4,7 @@
   "workspaces": {
     "": {
       "dependencies": {
+        "@catalyst-cloud/read-model": "^0.1.1",
         "ink": "^5.2.1",
         "react": "^18.3.1",
         "smee-client": "^5.0.0",
@@ -25,6 +26,8 @@
   },
   "packages": {
     "@alcalzone/ansi-tokenize": ["@alcalzone/ansi-tokenize@0.1.3", "", { "dependencies": { "ansi-styles": "^6.2.1", "is-fullwidth-code-point": "^4.0.0" } }, "sha512-3yWxPTq3UQ/FY9p1ErPxIyfT64elWaMvM9lIHnaqpyft63tkxodF5aUElYHrdisWve5cETkh1+KBw1yJuW0aRw=="],
+
+    "@catalyst-cloud/read-model": ["@catalyst-cloud/read-model@0.1.1", "", {}, "sha512-DFnVumOR8lB4scX3aYyh9aCLc57LmfpRyrR+BX8pVFLmg7sbBNa/4kOevbq9bgXpEJ8nzUY096hoStHbcB8b7w=="],
 
     "@emnapi/core": ["@emnapi/core@1.9.2", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.1", "tslib": "^2.4.0" } }, "sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA=="],
 

--- a/plugins/dev/scripts/orch-monitor/knip.config.ts
+++ b/plugins/dev/scripts/orch-monitor/knip.config.ts
@@ -29,6 +29,15 @@ const config: KnipConfig = {
         "bin/gen-phosphor-icons.ts",
       ],
       project: ["**/*.{ts,tsx}", "!ui/**", "!public/**"],
+      ignoreDependencies: [
+        // CTL-1574: reached ONLY through the computed-specifier lazy `import()`
+        // in lib/ticket-discussion-reader.mjs. That specifier must stay computed
+        // (a literal would let esbuild pull the module — and bun:sqlite with it —
+        // into the Node-evaluated vite config bundle and break `vite build`; see
+        // the long note in that file). knip resolves static specifiers only, so
+        // it cannot see the usage.
+        "@catalyst-cloud/read-model",
+      ],
     },
     ui: {
       entry: ["index.html", "board.html", "src/board/main.tsx", "src/components/ui/*.{ts,tsx}", "src/components/kibo-ui/**/*.{ts,tsx}"],

--- a/plugins/dev/scripts/orch-monitor/lib/ticket-discussion-reader.d.mts
+++ b/plugins/dev/scripts/orch-monitor/lib/ticket-discussion-reader.d.mts
@@ -1,0 +1,120 @@
+// Type declarations for ticket-discussion-reader.mjs (CTL-1574). Keep in sync
+// with the object the .mjs assembles.
+//
+// PROVENANCE: `TicketComment` / `TicketActivityEvent` / `TicketActivityLabel`
+// are field-for-field copies of `IssueComment` / `IssueActivityEvent` /
+// `IssueActivityLabel` in catalyst-cloud's
+// `apps/web/src/lib/mirror-client.ts` (L227-296) — the client-side view of the
+// SAME `@catalyst-cloud/read-model` `buildIssueDetail` return this reader runs.
+// They are re-declared here rather than imported because the published package
+// exports raw `.ts` sources and this file must stay resolvable by the monitor's
+// own tsc pass. If the read-model's shape changes, these move with it.
+
+/** A resolved label reference on an activity event. `id` is always present;
+ *  `name`/`color` resolve HISTORICALLY (they survive a later label deletion) and
+ *  are null when the label id isn't mirrored — never fabricated. */
+export interface TicketActivityLabel {
+  id: string;
+  name: string | null;
+  color: string | null;
+}
+
+/** One mirrored Linear comment. Ordered oldest-to-newest by `updated_at` (the
+ *  timeline's sort key). Author fields are nullable — a pre-backfill or
+ *  bot-authored comment may lack them, so the UI falls back rather than invents. */
+export interface TicketComment {
+  id: string;
+  body: string | null;
+  author_id: string | null;
+  author_name: string | null;
+  author_avatar_url: string | null;
+  /** 1 when an agent/integration authored it (drives the "agent" marker). */
+  is_bot: number | null;
+  parent_id: string | null;
+  updated_at: number;
+}
+
+/** One `issue_history` transition. Ordered by `created_at` (ms epoch). Id-bearing
+ *  fields are resolved to display values by the read-model; raw scalars (state
+ *  NAMES, priority 0-4, estimate points, title, `due_date` as a "YYYY-MM-DD"
+ *  TimelessDate string) and the NULL-PRESERVING booleans (null = untouched,
+ *  0 = explicit false, 1 = true) are formatted by the client. Every field is
+ *  nullable — null on a from/to pair means this event did not touch that
+ *  property. */
+export interface TicketActivityEvent {
+  id: string;
+  created_at: number;
+  actor_id: string | null;
+  actor_name: string | null;
+  actor_avatar_url: string | null;
+  from_state: string | null;
+  to_state: string | null;
+  from_assignee_id: string | null;
+  from_assignee_name: string | null;
+  to_assignee_id: string | null;
+  to_assignee_name: string | null;
+  from_priority: number | null;
+  to_priority: number | null;
+  from_estimate: number | null;
+  to_estimate: number | null;
+  from_title: string | null;
+  to_title: string | null;
+  from_cycle_id: string | null;
+  from_cycle_number: number | null;
+  to_cycle_id: string | null;
+  to_cycle_number: number | null;
+  from_project_id: string | null;
+  from_project_name: string | null;
+  to_project_id: string | null;
+  to_project_name: string | null;
+  from_parent_id: string | null;
+  from_parent_identifier: string | null;
+  to_parent_id: string | null;
+  to_parent_identifier: string | null;
+  from_team_id: string | null;
+  to_team_id: string | null;
+  from_due_date: string | null;
+  to_due_date: string | null;
+  added_labels: TicketActivityLabel[];
+  removed_labels: TicketActivityLabel[];
+  updated_description: number | null;
+  archived: number | null;
+  auto_archived: number | null;
+  auto_closed: number | null;
+  trashed: number | null;
+}
+
+/** The `/api/ticket-discussion/<id>` payload. */
+export interface TicketDiscussion {
+  /** false when the replica could not be read OR the ticket is not mirrored —
+   *  distinct from an available read that simply found no comments/activity, so
+   *  the UI never claims "no discussion" about a source it never reached. */
+  available: boolean;
+  /** The mirrored identifier, or null when unavailable. */
+  identifier: string | null;
+  /** The mirrored issue title, or null. */
+  title: string | null;
+  /** Comments oldest-first (by `updated_at`); [] when unavailable. */
+  comments: TicketComment[];
+  /** Activity events oldest-first (by `created_at`); [] when unavailable. */
+  activity: TicketActivityEvent[];
+}
+
+export interface ReadTicketDiscussionOptions {
+  /** Replica path override (default: CATALYST_REPLICA_DB, else
+   *  $CATALYST_DIR/catalyst-replica.db, else ~/catalyst/catalyst-replica.db). */
+  dbPath?: string;
+  /** Database opener seam for tests. Must return a bun:sqlite-shaped handle
+   *  exposing `query(sql).all(...bindings)` and `close()`. */
+  openDb?: (path: string) => {
+    query: (sql: string) => { all: (...bindings: unknown[]) => unknown[] };
+    close: () => void;
+  };
+}
+
+/** Read a ticket's Linear comments + activity from the local replica. Never
+ *  throws: every failure yields `{ available: false, comments: [], activity: [] }`. */
+export function readTicketDiscussion(
+  identifier: string,
+  opts?: ReadTicketDiscussionOptions,
+): Promise<TicketDiscussion>;

--- a/plugins/dev/scripts/orch-monitor/lib/ticket-discussion-reader.d.mts
+++ b/plugins/dev/scripts/orch-monitor/lib/ticket-discussion-reader.d.mts
@@ -106,6 +106,10 @@ export interface ReadTicketDiscussionOptions {
   /** Replica path override (default: CATALYST_REPLICA_DB, else
    *  $CATALYST_DIR/catalyst-replica.db, else ~/catalyst/catalyst-replica.db). */
   dbPath?: string;
+  /** The server's resolved catalyst dir — takes the place of $CATALYST_DIR in
+   *  the default path resolution (a createServer({catalystDir}) install must
+   *  not read another installation's replica). */
+  catalystDir?: string;
   /** Database opener seam for tests. Must return a bun:sqlite-shaped handle
    *  exposing `query(sql).all(...bindings)` and `close()`. */
   openDb?: (path: string) => {

--- a/plugins/dev/scripts/orch-monitor/lib/ticket-discussion-reader.d.mts
+++ b/plugins/dev/scripts/orch-monitor/lib/ticket-discussion-reader.d.mts
@@ -94,6 +94,8 @@ export interface TicketDiscussion {
   identifier: string | null;
   /** The mirrored issue title, or null. */
   title: string | null;
+  /** Issue creation instant (ms epoch), or null when unavailable/unmirrored. */
+  createdAt: number | null;
   /** Comments oldest-first (by `updated_at`); [] when unavailable. */
   comments: TicketComment[];
   /** Activity events oldest-first (by `created_at`); [] when unavailable. */

--- a/plugins/dev/scripts/orch-monitor/lib/ticket-discussion-reader.mjs
+++ b/plugins/dev/scripts/orch-monitor/lib/ticket-discussion-reader.mjs
@@ -168,11 +168,22 @@ export async function readTicketDiscussion(identifier, { dbPath, openDb, catalys
     } catch {
       /* pragma unsupported on this handle — proceed without the wait */
     }
-    // Seed-completeness: a missing/empty cursor row means a re-seed is in
-    // flight and the tables may be half-truncated. (A missing sync_meta table
-    // throws → the outer catch reports unavailable, which is also correct.)
-    if (db.query(SEED_COMPLETE_SELECT).all().length === 0) return unavailable();
-    const detail = buildIssueDetail(bunSqlExecutor(db), identifier);
+    // Seed-completeness gate + ALL detail reads inside ONE deferred read
+    // transaction (replica-read.mjs CTL-1397 P1 pattern): as separate autocommit
+    // reads, a forced re-seed could slip between the cursor check and
+    // buildIssueDetail's SELECTs (writer deletes the cursor + truncates +
+    // repopulates) and a half-repopulated discussion would serve as
+    // available:true — the exact state the gate exists to reject. bun:sqlite's
+    // transaction() defaults to BEGIN DEFERRED (read-only-safe); the test
+    // opener seam has no transaction() and runs autocommit, as before.
+    // (A missing sync_meta table throws → outer catch → unavailable.)
+    const readDetail = () => {
+      if (db.query(SEED_COMPLETE_SELECT).all().length === 0) return undefined; // mid-reseed
+      return buildIssueDetail(bunSqlExecutor(db), identifier);
+    };
+    const detail =
+      typeof db.transaction === "function" ? db.transaction(readDetail)() : readDetail();
+    if (detail === undefined) return unavailable();
     // Unknown / removed ticket → buildIssueDetail returns null. That is a
     // successful read of a ticket with no mirrored row, but we report it as
     // unavailable:false-with-nothing because the UI has nothing honest to show

--- a/plugins/dev/scripts/orch-monitor/lib/ticket-discussion-reader.mjs
+++ b/plugins/dev/scripts/orch-monitor/lib/ticket-discussion-reader.mjs
@@ -69,7 +69,14 @@ const READ_MODEL_MODULE = ["@catalyst-cloud", "read-model"].join("/");
 // The empty/unavailable answer. A single frozen-shape factory so every failure
 // path returns the identical contract (the route JSON-serializes it as-is).
 function unavailable() {
-  return { available: false, identifier: null, title: null, comments: [], activity: [] };
+  return {
+    available: false,
+    identifier: null,
+    title: null,
+    createdAt: null,
+    comments: [],
+    activity: [],
+  };
 }
 
 /**
@@ -127,6 +134,9 @@ export async function readTicketDiscussion(identifier, { dbPath, openDb } = {}) 
       available: true,
       identifier: detail.identifier ?? identifier,
       title: detail.title ?? null,
+      // Issue creation instant (ms epoch) — the UI's guard against labeling a
+      // late bare history row "created this issue" (CTL-1574 review defect 2).
+      createdAt: typeof detail.created_at === "number" ? detail.created_at : null,
       comments: Array.isArray(detail.comments) ? detail.comments : [],
       activity: Array.isArray(detail.activity) ? detail.activity : [],
     };

--- a/plugins/dev/scripts/orch-monitor/lib/ticket-discussion-reader.mjs
+++ b/plugins/dev/scripts/orch-monitor/lib/ticket-discussion-reader.mjs
@@ -27,6 +27,7 @@
 // could not be read" from "this ticket genuinely has no discussion", so the UI
 // never claims "no comments" about a source it never reached.
 
+import { statSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
 
@@ -43,11 +44,44 @@ const IDENTIFIER_RE = /^[A-Za-z0-9]+-[0-9]+$/;
 // wins, else $CATALYST_DIR/catalyst-replica.db, else ~/catalyst/…. Resolving
 // this at module load froze the wrong path for CATALYST_DIR-configured nodes
 // once before (the CTL-1378 edge in linear-cache-reader.mjs); don't hoist it.
-function defaultReplicaDbPath() {
+function defaultReplicaDbPath(catalystDir) {
   return (
     process.env.CATALYST_REPLICA_DB ||
-    join(process.env.CATALYST_DIR || join(homedir(), "catalyst"), "catalyst-replica.db")
+    join(catalystDir || process.env.CATALYST_DIR || join(homedir(), "catalyst"), "catalyst-replica.db")
   );
+}
+
+// ── Freshness gate (CTL-1574 review) ─────────────────────────────────────────
+// Mirrors execution-core/replica-read.mjs isReplicaFresh: the `<db>.writer.lock`
+// heartbeat proves the cloud-sync writer is LIVE (the writer touches it every few
+// seconds regardless of feed activity — never gate on the db/-wal mtime), and the
+// `sync_meta` cursor row proves the seed is COMPLETE (the writer deletes it at
+// re-seed start). A stale or mid-reseed replica reads as unavailable — an
+// operator must never compose a reply against an outdated conversation that
+// renders as current.
+const SEED_COMPLETE_SELECT =
+  "SELECT 1 FROM sync_meta WHERE key = 'cursor' AND value IS NOT NULL AND value <> '' LIMIT 1";
+
+function isWriterFresh(dbPath) {
+  const thresholdMs = Number(process.env.CATALYST_LINEAR_REPLICA_STALE_MS) || 300_000;
+  try {
+    return Date.now() - statSync(`${dbPath}.writer.lock`).mtimeMs < thresholdMs;
+  } catch {
+    return false; // no heartbeat file → writer not proven live → unavailable
+  }
+}
+
+// toEpochMs — normalize a replica timestamp to ms epoch. The replica writers
+// have stored both integer epochs and ISO-8601 strings across versions (the
+// read-model's linear-cli path accepts either), and this payload's contract is
+// numeric — a string leaking through breaks every duration/sort in the UI.
+function toEpochMs(v) {
+  if (typeof v === "number" && Number.isFinite(v)) return v;
+  if (typeof v === "string") {
+    const parsed = Date.parse(v);
+    return Number.isNaN(parsed) ? null : parsed;
+  }
+  return null;
 }
 
 // Both specifiers below are COMPUTED, never string literals, and that is
@@ -112,7 +146,7 @@ function bunSqlExecutor(db) {
  *   • available:false with empty arrays for EVERY failure — never throws into
  *     the route, never fabricates a comment or an event.
  */
-export async function readTicketDiscussion(identifier, { dbPath, openDb } = {}) {
+export async function readTicketDiscussion(identifier, { dbPath, openDb, catalystDir } = {}) {
   if (typeof identifier !== "string" || !IDENTIFIER_RE.test(identifier)) return unavailable();
   let db = null;
   try {
@@ -122,7 +156,22 @@ export async function readTicketDiscussion(identifier, { dbPath, openDb } = {}) 
       open = (p) => new Database(p, { readonly: true });
     }
     const { buildIssueDetail } = await import(READ_MODEL_MODULE);
-    db = open(dbPath ?? defaultReplicaDbPath());
+    const path = dbPath ?? defaultReplicaDbPath(catalystDir);
+    if (!isWriterFresh(path)) return unavailable();
+    db = open(path);
+    // A checkpoint/schema lock can transiently SQLITE_BUSY the first query —
+    // wait briefly instead of reporting the whole discussion unavailable
+    // (same 250ms the linear-thread reader uses). Optional-chained: the test
+    // opener seam exposes only query/close.
+    try {
+      db.run?.("PRAGMA busy_timeout = 250");
+    } catch {
+      /* pragma unsupported on this handle — proceed without the wait */
+    }
+    // Seed-completeness: a missing/empty cursor row means a re-seed is in
+    // flight and the tables may be half-truncated. (A missing sync_meta table
+    // throws → the outer catch reports unavailable, which is also correct.)
+    if (db.query(SEED_COMPLETE_SELECT).all().length === 0) return unavailable();
     const detail = buildIssueDetail(bunSqlExecutor(db), identifier);
     // Unknown / removed ticket → buildIssueDetail returns null. That is a
     // successful read of a ticket with no mirrored row, but we report it as
@@ -136,9 +185,18 @@ export async function readTicketDiscussion(identifier, { dbPath, openDb } = {}) 
       title: detail.title ?? null,
       // Issue creation instant (ms epoch) — the UI's guard against labeling a
       // late bare history row "created this issue" (CTL-1574 review defect 2).
-      createdAt: typeof detail.created_at === "number" ? detail.created_at : null,
-      comments: Array.isArray(detail.comments) ? detail.comments : [],
-      activity: Array.isArray(detail.activity) ? detail.activity : [],
+      createdAt: toEpochMs(detail.created_at),
+      // Timestamps normalized to ms epoch (the payload contract is numeric; the
+      // replica has stored both integers and ISO strings across writer versions).
+      comments: (Array.isArray(detail.comments) ? detail.comments : []).map((c) => ({
+        ...c,
+        updated_at: toEpochMs(c.updated_at),
+        ...(c.created_at != null ? { created_at: toEpochMs(c.created_at) } : {}),
+      })),
+      activity: (Array.isArray(detail.activity) ? detail.activity : []).map((e) => ({
+        ...e,
+        created_at: toEpochMs(e.created_at),
+      })),
     };
   } catch {
     // Absent db file, locked db, a schema the read-model does not recognize, or a

--- a/plugins/dev/scripts/orch-monitor/lib/ticket-discussion-reader.mjs
+++ b/plugins/dev/scripts/orch-monitor/lib/ticket-discussion-reader.mjs
@@ -1,0 +1,144 @@
+// ticket-discussion-reader.mjs — a ticket's Linear DISCUSSION (comments +
+// issue_history activity) read from the local replica (CTL-1574).
+//
+// The monitor already surfaces a ticket's Linear *metadata* (ticket-detail-reader
+// over filter-state.db) and its *narrative* (use-linear-ticket over the cached
+// /api/linear-ticket fetch). Neither carries the conversation: who said what, and
+// which state/assignee/label transitions happened between the comments. That data
+// already exists locally in the CTC replica (`catalyst-replica.db` — the SDK's
+// Linear mirror, tables `comments` + `issue_history`), so this reader serves it
+// without a single Linear API call.
+//
+// SHARED DATA LAYER, NOT A REIMPLEMENTATION: the SQL + the id→display-value
+// resolution (actor/assignee → user names, label ids → {name,color}, project →
+// name, cycle → number, parent → identifier) is the published
+// `@catalyst-cloud/read-model` package's `buildIssueDetail`, run UNCHANGED here
+// over a bun:sqlite executor. That is the same portability seam catalyst-cloud's
+// host-sync daemon uses (ADR-0002); `bunSqlExecutor` below is a local mirror of
+// `apps/host-sync/src/read-adapter.ts` in that repo. We subset buildIssueDetail's
+// return to {identifier, title, comments, activity} — the rest of the detail view
+// is already served by the readers named above.
+//
+// READ-ONLY + NEVER-THROW: the replica is opened READONLY (the cloud-sync writer
+// owns it; WAL keeps this reader non-blocking), and every failure path — absent
+// db, locked db, unknown ticket, malformed identifier — returns
+// `{ available: false, comments: [], activity: [] }` so the route degrades to an
+// honest empty section instead of a 500. `available` distinguishes "the replica
+// could not be read" from "this ticket genuinely has no discussion", so the UI
+// never claims "no comments" about a source it never reached.
+
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+// A Linear issue identifier: TEAMKEY-NUMBER. Validated BEFORE any SQL runs.
+// buildIssueDetail binds the identifier as a parameter (no injection surface),
+// but rejecting the malformed input up front keeps a junk path segment from
+// reaching the DB layer at all, and lets the route answer without opening a
+// handle.
+const IDENTIFIER_RE = /^[A-Za-z0-9]+-[0-9]+$/;
+
+// The CTC replica path, resolved PER CALL so a process configured via
+// CATALYST_DIR (and the tests, which redirect it) is honored. Mirrors
+// execution-core/config.mjs::getReplicaDbPath exactly — CATALYST_REPLICA_DB
+// wins, else $CATALYST_DIR/catalyst-replica.db, else ~/catalyst/…. Resolving
+// this at module load froze the wrong path for CATALYST_DIR-configured nodes
+// once before (the CTL-1378 edge in linear-cache-reader.mjs); don't hoist it.
+function defaultReplicaDbPath() {
+  return (
+    process.env.CATALYST_REPLICA_DB ||
+    join(process.env.CATALYST_DIR || join(homedir(), "catalyst"), "catalyst-replica.db")
+  );
+}
+
+// Both specifiers below are COMPUTED, never string literals, and that is
+// load-bearing rather than stylistic — the same CTL-883 / CTL-1561 trap
+// documented at length in linear-cache-reader.mjs:46-66. `ui/vite.config.ts`
+// statically imports server-side .mjs modules and Vite esbuild-bundles that
+// config together with its relative import graph; esbuild follows dynamic
+// imports too, but ONLY when the argument is a plain string literal. A literal
+// `import("bun:sqlite")` reachable from that graph makes Node throw
+// ERR_UNSUPPORTED_ESM_URL_SCHEME on the `bun:` scheme and breaks `vite build`
+// (the monitor's deploy path). A computed specifier stays an opaque runtime
+// `import()` esbuild cannot follow; under Bun it resolves identically.
+// This module is not in the vite config graph TODAY, but the breakage would be
+// silent-until-deploy the moment anything in that graph reached it.
+// DO NOT inline either of these back to a literal.
+const BUN_SQLITE_MODULE = ["bun", "sqlite"].join(":");
+const READ_MODEL_MODULE = ["@catalyst-cloud", "read-model"].join("/");
+
+// The empty/unavailable answer. A single frozen-shape factory so every failure
+// path returns the identical contract (the route JSON-serializes it as-is).
+function unavailable() {
+  return { available: false, identifier: null, title: null, comments: [], activity: [] };
+}
+
+/**
+ * Wrap a bun:sqlite `Database` as the read-model's portable `SqlExecutor`.
+ *
+ * A local mirror of catalyst-cloud's `apps/host-sync/src/read-adapter.ts`
+ * (`bunSqlExecutor`), duplicated rather than imported because that adapter lives
+ * in an app, not the published package. The read-model emits parameterized SQL +
+ * scalar bindings via `exec(query, ...bindings).toArray()`, and bun:sqlite's
+ * `db.query(sql).all(...bindings)` is the exact inverse. The `ArrayBuffer` →
+ * `Uint8Array` coercion is defensive: the read-model's `SqlValue` union permits
+ * ArrayBuffer, though the read builders only ever bind string/number/null.
+ */
+function bunSqlExecutor(db) {
+  return {
+    exec: (query, ...bindings) => ({
+      toArray: () =>
+        db.query(query).all(...bindings.map((v) => (v instanceof ArrayBuffer ? new Uint8Array(v) : v))),
+    }),
+  };
+}
+
+/**
+ * readTicketDiscussion — the route-facing reader. Returns the ticket's Linear
+ * comments (oldest-first, by `updated_at`) and its issue_history activity events
+ * (oldest-first, by `created_at`), both already resolved to display values by the
+ * read-model. The UI interleaves them into one chronological timeline.
+ *
+ * `dbPath` and `openDb` are injection seams so the unit tests drive this against
+ * a temp db (and can force an open failure) without touching the real replica.
+ *
+ * Returns: { available, identifier, title, comments[], activity[] }
+ *   • available:false with empty arrays for EVERY failure — never throws into
+ *     the route, never fabricates a comment or an event.
+ */
+export async function readTicketDiscussion(identifier, { dbPath, openDb } = {}) {
+  if (typeof identifier !== "string" || !IDENTIFIER_RE.test(identifier)) return unavailable();
+  let db = null;
+  try {
+    let open = openDb;
+    if (!open) {
+      const { Database } = await import(BUN_SQLITE_MODULE);
+      open = (p) => new Database(p, { readonly: true });
+    }
+    const { buildIssueDetail } = await import(READ_MODEL_MODULE);
+    db = open(dbPath ?? defaultReplicaDbPath());
+    const detail = buildIssueDetail(bunSqlExecutor(db), identifier);
+    // Unknown / removed ticket → buildIssueDetail returns null. That is a
+    // successful read of a ticket with no mirrored row, but we report it as
+    // unavailable:false-with-nothing because the UI has nothing honest to show
+    // either way, and claiming "no comments" about a ticket we never found would
+    // be a fabrication.
+    if (!detail) return unavailable();
+    return {
+      available: true,
+      identifier: detail.identifier ?? identifier,
+      title: detail.title ?? null,
+      comments: Array.isArray(detail.comments) ? detail.comments : [],
+      activity: Array.isArray(detail.activity) ? detail.activity : [],
+    };
+  } catch {
+    // Absent db file, locked db, a schema the read-model does not recognize, or a
+    // non-Bun runtime with no bun:sqlite — all degrade to the honest empty.
+    return unavailable();
+  } finally {
+    try {
+      db?.close();
+    } catch {
+      /* a close failure on a read-only handle changes nothing we return */
+    }
+  }
+}

--- a/plugins/dev/scripts/orch-monitor/lib/webhook-config.ts
+++ b/plugins/dev/scripts/orch-monitor/lib/webhook-config.ts
@@ -363,6 +363,42 @@ export function loadLinearAgentConfig(
  *
  * Returns `null` if either the channel or secret cannot be resolved.
  */
+/** Linear app-actor user ids: worker + orchestrator botUserIds from the Layer-2
+ *  global config.json, plus the Layer-1 back-compat
+ *  `catalyst.monitor.linear.botUserId`. Exported SEPARATELY from
+ *  loadWebhookConfig because these ids also classify agent comments on read
+ *  surfaces (the discussion timeline) — a monitor with no webhook transport
+ *  configured must still recognize its app actors, and loadWebhookConfig's
+ *  no-transport early-return would otherwise discard them (CTL-1574 review). */
+export function loadLinearBotUserIds(
+  homeConfigDir: string,
+  projectConfigPath: string,
+): ReadonlySet<string> {
+  const linearBotUserIds = new Set<string>();
+  // NEW: Layer-2 global config.json carries worker + orchestrator botUserIds.
+  try {
+    const globalParsed: unknown = JSON.parse(readFileSync(join(homeConfigDir, "config.json"), "utf8"));
+    if (isRecord(globalParsed) && isRecord(globalParsed.catalyst)) {
+      const bot = globalParsed.catalyst.linear;
+      if (isRecord(bot) && isRecord(bot.bot)) {
+        const botSection = bot.bot;
+        if (isRecord(botSection.worker) && typeof botSection.worker.botUserId === "string") {
+          const id = botSection.worker.botUserId;
+          if (id.length > 0) linearBotUserIds.add(id);
+        }
+        if (isRecord(botSection.orchestrator) && typeof botSection.orchestrator.botUserId === "string") {
+          const id = botSection.orchestrator.botUserId;
+          if (id.length > 0) linearBotUserIds.add(id);
+        }
+      }
+    }
+  } catch { /* absent / malformed — continue to Layer-1 fallback */ }
+  // OLD Layer-1 back-compat: catalyst.monitor.linear.botUserId.
+  const layer1BotUserId = readGithubSection(projectConfigPath)?.linearBotUserId ?? "";
+  if (layer1BotUserId.length > 0) linearBotUserIds.add(layer1BotUserId);
+  return linearBotUserIds;
+}
+
 export function loadWebhookConfig(
   homeConfigDir: string,
   projectConfigPath: string,
@@ -430,29 +466,7 @@ export function loadWebhookConfig(
       : (fileLinearSmeeChannel ?? "");
 
   // Collect all known Linear bot user UUIDs for loop prevention. CTL-263.
-  // NEW: Layer-2 global config.json carries worker + orchestrator botUserIds.
-  // OLD: Layer-1 project config carries catalyst.monitor.linear.botUserId (back-compat).
-  const linearBotUserIds = new Set<string>();
-  try {
-    const globalParsed: unknown = JSON.parse(readFileSync(join(homeConfigDir, "config.json"), "utf8"));
-    if (isRecord(globalParsed) && isRecord(globalParsed.catalyst)) {
-      const bot = globalParsed.catalyst.linear;
-      if (isRecord(bot) && isRecord(bot.bot)) {
-        const botSection = bot.bot;
-        if (isRecord(botSection.worker) && typeof botSection.worker.botUserId === "string") {
-          const id = botSection.worker.botUserId;
-          if (id.length > 0) linearBotUserIds.add(id);
-        }
-        if (isRecord(botSection.orchestrator) && typeof botSection.orchestrator.botUserId === "string") {
-          const id = botSection.orchestrator.botUserId;
-          if (id.length > 0) linearBotUserIds.add(id);
-        }
-      }
-    }
-  } catch { /* absent / malformed — continue to Layer-1 fallback */ }
-  // OLD Layer-1 back-compat: catalyst.monitor.linear.botUserId.
-  const layer1BotUserId = projectExtract?.linearBotUserId ?? "";
-  if (layer1BotUserId.length > 0) linearBotUserIds.add(layer1BotUserId);
+  const linearBotUserIds = loadLinearBotUserIds(homeConfigDir, projectConfigPath);
 
   // Linear team→repo roster. CTL-1214 Phase 2: resolved through the shared
   // readClusterProjects() — cluster.json.projects[] first, Layer-1

--- a/plugins/dev/scripts/orch-monitor/package.json
+++ b/plugins/dev/scripts/orch-monitor/package.json
@@ -17,6 +17,7 @@
     "gen:icons": "bun run bin/gen-phosphor-icons.ts"
   },
   "dependencies": {
+    "@catalyst-cloud/read-model": "^0.1.1",
     "ink": "^5.2.1",
     "react": "^18.3.1",
     "smee-client": "^5.0.0",

--- a/plugins/dev/scripts/orch-monitor/server.ts
+++ b/plugins/dev/scripts/orch-monitor/server.ts
@@ -243,7 +243,7 @@ import { createEventRing } from "./lib/event-ring";
 import { createMemoizedRead } from "./lib/memoize-fresh.mjs";
 import { readSubStepEvents } from "./lib/substep-reader";
 import { loadOtelConfig } from "./lib/otel-config";
-import { loadWebhookConfig } from "./lib/webhook-config";
+import { loadLinearBotUserIds, loadWebhookConfig } from "./lib/webhook-config";
 import { detectProjectKey, detectProjectKeyFromConfig } from "./lib/project-key";
 import { loadMonitorConfig } from "./lib/monitor-config";
 // Shared Layer-1 config-path resolver (env pointer > cwd) — keeps
@@ -5297,6 +5297,13 @@ if (import.meta.main) {
     configPath,
     projectKey,
   );
+  // Loaded independently of loadWebhookConfig: that loader returns null when no
+  // webhook transport is configured, discarding the ids — but read surfaces
+  // (the discussion timeline) still need them to classify agent comments.
+  const linearBotIdsForReads = loadLinearBotUserIds(
+    process.env.CATALYST_CONFIG_DIR ?? `${process.env.HOME}/.config/catalyst`,
+    configPath,
+  );
   const webhookConfig =
     fullWebhookConfig &&
     fullWebhookConfig.smeeChannel.length > 0 &&
@@ -5394,10 +5401,7 @@ if (import.meta.main) {
       linearWebhookConfig,
       // Independent of webhook wiring: configured app-actor ids classify agent
       // comments on the discussion surface even when webhooks are disabled.
-      linearBotUserIds:
-        fullWebhookConfig && fullWebhookConfig.linearBotUserIds.size > 0
-          ? fullWebhookConfig.linearBotUserIds
-          : undefined,
+      linearBotUserIds: linearBotIdsForReads.size > 0 ? linearBotIdsForReads : undefined,
       projectsConfigPath: configPath,
       monitorConfigPath: configPath,
     });

--- a/plugins/dev/scripts/orch-monitor/server.ts
+++ b/plugins/dev/scripts/orch-monitor/server.ts
@@ -330,6 +330,10 @@ import {
 // request — the rate-limit win, consistent with the BFF1 (CTL-883) decision.
 import { readTicketDetail } from "./lib/ticket-detail-reader.mjs";
 import { readTicketArtifacts, readTicketArtifactContent } from "./lib/ticket-artifacts-reader.mjs";
+// CTL-1574: a ticket's Linear DISCUSSION (comments + issue_history activity) read
+// from the local CTC replica via the shared @catalyst-cloud/read-model builders.
+// Cache-only like the readers above — never a live Linear call per request.
+import { readTicketDiscussion } from "./lib/ticket-discussion-reader.mjs";
 // CTL-974 pattern: supplemental cached Linear {title, description} fetch for the
 // ticket-detail page. Board title is stale-sourced and the durable cache has no
 // description column, so both must be live-fetched (cached, TTL'd, fail-open).
@@ -2677,6 +2681,33 @@ export function createServer(opts: CreateServerOptions): BunServer {
           }
           const artifacts = await readTicketArtifacts(ticket);
           return Response.json(artifacts);
+        }
+
+        // CTL-1574: a ticket's Linear discussion — comments + issue_history
+        // activity events, both read from the local CTC replica through the
+        // shared read-model builders. The reader never throws: an absent/locked
+        // replica or an unmirrored ticket comes back
+        // `{ available:false, comments:[], activity:[] }`, which the UI renders
+        // as an honest empty section (never a fabricated "no comments").
+        const ticketDiscussionMatch = url.pathname.match(
+          /^\/api\/ticket-discussion\/([^/]+)$/,
+        );
+        if (ticketDiscussionMatch) {
+          let ticket: string;
+          try {
+            ticket = decodeURIComponent(ticketDiscussionMatch[1]);
+          } catch {
+            return new Response("Bad Request", { status: 400 });
+          }
+          if (
+            ticket.includes("..") ||
+            ticket.includes("/") ||
+            ticket.includes("\0")
+          ) {
+            return new Response("Bad Request", { status: 400 });
+          }
+          const discussion = await readTicketDiscussion(ticket);
+          return Response.json(discussion);
         }
 
         // CTL-1042: serve a ticket's research/plan artifact CONTENT by kind for

--- a/plugins/dev/scripts/orch-monitor/server.ts
+++ b/plugins/dev/scripts/orch-monitor/server.ts
@@ -525,6 +525,11 @@ export interface CreateServerOptions {
      * events. Empty / absent = no enrichment (pre-CTL-362 behaviour). */
     linearTeams?: Array<{ key: string; vcsRepo: string }>;
   } | null;
+  /** App-actor user ids for agent classification on READ surfaces (the
+   *  discussion timeline). Independent of webhook ingestion — configured bot
+   *  ids must classify even when no Linear webhook secret/smee channel is set
+   *  (linearWebhookConfig null). Falls back to linearWebhookConfig?.botUserIds. */
+  linearBotUserIds?: ReadonlySet<string>;
   // CTL-1167: PWA push notifications
   /** false disables the server-side push bridge startup task (useful in tests). Default: true. */
   pushBridge?: boolean;
@@ -853,6 +858,7 @@ export function createServer(opts: CreateServerOptions): BunServer {
     commsReader: commsReaderOpt,
     webhookConfig,
     linearWebhookConfig,
+    linearBotUserIds,
     daemonHealthReader: daemonHealthReaderOpt,
     clusterReader: clusterReaderOpt,
     screenLogsExec: screenLogsExecOpt,
@@ -2713,7 +2719,7 @@ export function createServer(opts: CreateServerOptions): BunServer {
           // Catalyst worker/orchestrator app actors are stored as users with
           // is_bot=0 (the linear-thread.mjs contract), so is_bot alone would
           // badge every agent comment as human.
-          const botIds = linearWebhookConfig?.botUserIds;
+          const botIds = linearBotUserIds ?? linearWebhookConfig?.botUserIds;
           if (botIds && discussion.comments.length > 0) {
             discussion.comments = discussion.comments.map((c) =>
               c.author_id != null && botIds.has(c.author_id) ? { ...c, is_bot: 1 } : c,
@@ -5386,6 +5392,12 @@ if (import.meta.main) {
       inboxSummaryProvider,
       webhookConfig,
       linearWebhookConfig,
+      // Independent of webhook wiring: configured app-actor ids classify agent
+      // comments on the discussion surface even when webhooks are disabled.
+      linearBotUserIds:
+        fullWebhookConfig && fullWebhookConfig.linearBotUserIds.size > 0
+          ? fullWebhookConfig.linearBotUserIds
+          : undefined,
       projectsConfigPath: configPath,
       monitorConfigPath: configPath,
     });

--- a/plugins/dev/scripts/orch-monitor/server.ts
+++ b/plugins/dev/scripts/orch-monitor/server.ts
@@ -2706,7 +2706,19 @@ export function createServer(opts: CreateServerOptions): BunServer {
           ) {
             return new Response("Bad Request", { status: 400 });
           }
-          const discussion = await readTicketDiscussion(ticket);
+          const discussion = await readTicketDiscussion(ticket, {
+            catalystDir: CATALYST_DIR,
+          });
+          // Agent classification is `is_bot` OR a configured app-actor author —
+          // Catalyst worker/orchestrator app actors are stored as users with
+          // is_bot=0 (the linear-thread.mjs contract), so is_bot alone would
+          // badge every agent comment as human.
+          const botIds = linearWebhookConfig?.botUserIds;
+          if (botIds && discussion.comments.length > 0) {
+            discussion.comments = discussion.comments.map((c) =>
+              c.author_id != null && botIds.has(c.author_id) ? { ...c, is_bot: 1 } : c,
+            );
+          }
           return Response.json(discussion);
         }
 

--- a/plugins/dev/scripts/orch-monitor/ui/src/app.css
+++ b/plugins/dev/scripts/orch-monitor/ui/src/app.css
@@ -43,6 +43,9 @@
   --color-border-subtle: var(--border-subtle);
   --color-fg: var(--fg);
   --color-muted: var(--fg-muted);
+  /* CTL-1574: most-recessive ink (catalyst-cloud app.css parity) — without this
+     mapping `text-fg-dim` compiles to NO css and dim text renders at full --fg. */
+  --color-fg-dim: var(--fg-dim);
   /* CTL-1099: accent is now a per-theme/brand var (was the literal blue #5e9ee8),
      so text-accent + every var(--color-accent) consumer (md-content links,
      ticket-ref pills, blockquote borders, prose-invert links) flips with the

--- a/plugins/dev/scripts/orch-monitor/ui/src/board/route-search.ts
+++ b/plugins/dev/scripts/orch-monitor/ui/src/board/route-search.ts
@@ -31,7 +31,9 @@ export type DetailLens = (typeof LENS_VALUES)[number];
 
 /** Which ticket-detail tab is active. Absent on the URL = the `spec` default
  *  (dropped from the URL to keep it clean, same idiom as scope:"all"). CTL-996. */
-export const TAB_VALUES = ["lifecycle", "cost", "activity", "execution"] as const;
+// CTL-1574 added "discussion" — the Linear conversation (comments + state
+// changes). Distinct from "activity", which is the execution event stream.
+export const TAB_VALUES = ["lifecycle", "cost", "activity", "discussion", "execution"] as const;
 export type DetailTab = (typeof TAB_VALUES)[number];
 
 /**

--- a/plugins/dev/scripts/orch-monitor/ui/src/components/home/pane-discussion.tsx
+++ b/plugins/dev/scripts/orch-monitor/ui/src/components/home/pane-discussion.tsx
@@ -18,7 +18,7 @@ import { useTicketDiscussion } from "@/hooks/use-ticket-discussion";
 const COLLAPSED_LIMIT = 5;
 
 export function PaneDiscussion({ ticket }: { ticket: string }) {
-  const { comments, activity, available, loading } = useTicketDiscussion(ticket);
+  const { comments, activity, createdAt, available, loading } = useTicketDiscussion(ticket);
   if (loading || !available) return null;
   if (comments.length === 0 && activity.length === 0) return null;
 
@@ -26,9 +26,14 @@ export function PaneDiscussion({ ticket }: { ticket: string }) {
     <section className="mt-6" data-pane-discussion={ticket}>
       <p className="text-[11px] font-medium uppercase tracking-wide text-muted">Discussion</p>
       <div className="mt-3">
+        {/* key: the reading pane keeps ONE instance across inbox selections, so
+            without it the previous ticket's "Show all" expansion leaks into the
+            next selection (and there is no Show-less to undo it). */}
         <TicketTimeline
+          key={ticket}
           comments={comments}
           activity={activity}
+          issueCreatedAt={createdAt}
           loaded
           available
           limit={COLLAPSED_LIMIT}

--- a/plugins/dev/scripts/orch-monitor/ui/src/components/home/pane-discussion.tsx
+++ b/plugins/dev/scripts/orch-monitor/ui/src/components/home/pane-discussion.tsx
@@ -1,0 +1,39 @@
+// pane-discussion.tsx — the reading pane's Linear DISCUSSION section (CTL-1574).
+//
+// Split into its own module purely so reading-pane.tsx can React.lazy it. The
+// timeline renders comment bodies through renderTicketDescriptionHtml, which
+// pulls the whole markdown stack (marked + marked-highlight + highlight.js);
+// ticket-description.tsx deliberately lazy-loads for exactly that reason, and a
+// static import from the inbox would have put ~21 kB gzip of markdown machinery
+// on the home route's critical path for a section that renders below the fold.
+//
+// Renders NOTHING while loading, when the replica is unreadable, and when the
+// ticket genuinely has no discussion — an unavailable source stays silent in the
+// inbox rather than adding an error line to a pane whose job is the next action
+// (the same fails-soft posture as the Conversation block above it).
+import { TicketTimeline } from "../ticket-discussion";
+import { useTicketDiscussion } from "@/hooks/use-ticket-discussion";
+
+/** How many of the newest timeline entries the pane shows before "Show all N". */
+const COLLAPSED_LIMIT = 5;
+
+export function PaneDiscussion({ ticket }: { ticket: string }) {
+  const { comments, activity, available, loading } = useTicketDiscussion(ticket);
+  if (loading || !available) return null;
+  if (comments.length === 0 && activity.length === 0) return null;
+
+  return (
+    <section className="mt-6" data-pane-discussion={ticket}>
+      <p className="text-[11px] font-medium uppercase tracking-wide text-muted">Discussion</p>
+      <div className="mt-3">
+        <TicketTimeline
+          comments={comments}
+          activity={activity}
+          loaded
+          available
+          limit={COLLAPSED_LIMIT}
+        />
+      </div>
+    </section>
+  );
+}

--- a/plugins/dev/scripts/orch-monitor/ui/src/components/home/reading-pane.tsx
+++ b/plugins/dev/scripts/orch-monitor/ui/src/components/home/reading-pane.tsx
@@ -538,7 +538,9 @@ export function ReadingPane({
             block above never reaches them with. Collapsed to the newest few turns
             so the pane stays scannable; "Show all N" opens the full stream. */}
         <Suspense fallback={null}>
-          <PaneDiscussion ticket={row.id} />
+          {/* key: remount per ticket so the previous selection's fetched
+              discussion never paints under the new ticket's header. */}
+          <PaneDiscussion key={row.id} ticket={row.id} />
         </Suspense>
       </div>
     </ScrollArea>

--- a/plugins/dev/scripts/orch-monitor/ui/src/components/home/reading-pane.tsx
+++ b/plugins/dev/scripts/orch-monitor/ui/src/components/home/reading-pane.tsx
@@ -22,7 +22,7 @@
 // StatusIcon glyph are the HOME2 Catalyst hand-rolls. Emphasis is a whisper of
 // background TINT + a left accent BAR (the attention-bar pattern) — NEVER a
 // bordered sub-card, never cyan (cyan is reserved for the live signal).
-import { useEffect, useState } from "react";
+import { Suspense, lazy, useEffect, useState } from "react";
 import { CheckCircle2, ExternalLink as ExternalLinkIcon } from "lucide-react";
 
 // CTL-1041: a small, restrained Claude logomark for the View-in-Claude pill — the
@@ -86,6 +86,13 @@ import {
 // what actually clears `needs-human`, per CTL-1567).
 import { Conversation } from "./conversation";
 import type { ReplyOutcome } from "@/board/conversation-client";
+// CTL-1574: the Linear discussion timeline — comment cards interleaved with the
+// ticket's state-change history, read from the local replica. LAZY: it renders
+// comment markdown, and a static import would put the whole marked/highlight.js
+// stack on the home route's critical path (see pane-discussion.tsx).
+const PaneDiscussion = lazy(() =>
+  import("./pane-discussion").then((m) => ({ default: m.PaneDiscussion })),
+);
 
 // ── inbox summary fetch-on-select (CTL-1042) ──────────────────────────────────
 type InboxSummaryState =
@@ -524,6 +531,15 @@ export function ReadingPane({
 
         {/* About — summary, goal, and the where-it's-at phase strip (for ANY item). */}
         <About row={effectiveRow} />
+
+        {/* Discussion — the Linear conversation: comment cards interleaved with
+            the ticket's state-change history (CTL-1574). Carried by ANY item, so
+            running and done rows get the context the needs-you-only Conversation
+            block above never reaches them with. Collapsed to the newest few turns
+            so the pane stays scannable; "Show all N" opens the full stream. */}
+        <Suspense fallback={null}>
+          <PaneDiscussion ticket={row.id} />
+        </Suspense>
       </div>
     </ScrollArea>
   );

--- a/plugins/dev/scripts/orch-monitor/ui/src/components/ticket-detail-page.tsx
+++ b/plugins/dev/scripts/orch-monitor/ui/src/components/ticket-detail-page.tsx
@@ -573,7 +573,8 @@ function ActivitySection({ ticketId }: { ticketId: string }) {
 // — that one is the EXECUTION event stream; this is what people said and what
 // changed on the ticket. Keyed off the id so it works off-board.
 function DiscussionSection({ ticketId }: { ticketId: string }) {
-  const { comments, activity, available, loading } = useTicketDiscussion(ticketId);
+  const { comments, activity, createdAt, available, loading, error } =
+    useTicketDiscussion(ticketId);
   return (
     <section data-ticket-discussion style={{ marginBottom: 8 }}>
       <div style={{ display: "flex", alignItems: "center", gap: 8, marginBottom: 8 }}>
@@ -592,10 +593,13 @@ function DiscussionSection({ ticketId }: { ticketId: string }) {
         }
       >
         <TicketTimeline
+          key={ticketId}
           comments={comments}
           activity={activity}
+          issueCreatedAt={createdAt}
           loaded={!loading}
           available={available}
+          error={error}
         />
       </Suspense>
     </section>

--- a/plugins/dev/scripts/orch-monitor/ui/src/components/ticket-detail-page.tsx
+++ b/plugins/dev/scripts/orch-monitor/ui/src/components/ticket-detail-page.tsx
@@ -582,7 +582,7 @@ function DiscussionSection({ ticketId }: { ticketId: string }) {
         <span style={{ flex: 1 }} />
         {available && !loading && (
           <span style={{ font: `10px ${C.mono}`, color: C.fgDim }}>
-            {comments.length} comment{comments.length === 1 ? "" : "s"} · {activity.length} change
+            {comments.length} comment{comments.length === 1 ? "" : "s"} · {activity.length} event
             {activity.length === 1 ? "" : "s"}
           </span>
         )}
@@ -1011,7 +1011,7 @@ export function TicketDetailPage({
               works off-board, same as the Activity tab above. */}
           <TabsContent value="discussion">
             <div style={{ paddingTop: 16 }}>
-              <DiscussionSection ticketId={ticket?.id ?? id} />
+              <DiscussionSection key={ticket?.id ?? id} ticketId={ticket?.id ?? id} />
             </div>
           </TabsContent>
 

--- a/plugins/dev/scripts/orch-monitor/ui/src/components/ticket-detail-page.tsx
+++ b/plugins/dev/scripts/orch-monitor/ui/src/components/ticket-detail-page.tsx
@@ -52,6 +52,9 @@ import { TicketGantt } from "./ticket-gantt";
 import { CommsView } from "./comms-view";
 import { ActivityEventRow } from "./activity-event-row";
 import { useActivityStream } from "@/hooks/use-activity";
+// CTL-1574: the Linear discussion (comments + state changes) behind the
+// Discussion tab.
+import { useTicketDiscussion } from "@/hooks/use-ticket-discussion";
 import { useRepoColors } from "@/hooks/use-repo-colors";
 import { TabsContent } from "./ui/tabs";
 import { PillTabs, type PillTab } from "./pill-tabs";
@@ -69,6 +72,13 @@ import { ExecutionTab } from "./execution-tab";
 // the same fixed-height skeleton as the not-yet-loaded state (no layout jump).
 const TicketDescription = lazy(() =>
   import("./ticket-description").then((m) => ({ default: m.TicketDescription })),
+);
+
+// CTL-1574: the discussion timeline renders comment markdown through the SAME
+// heavy engine, so it is lazy-loaded for the same reason (and because Discussion
+// is not the default tab — the chunk is only fetched once the operator opens it).
+const TicketTimeline = lazy(() =>
+  import("./ticket-discussion").then((m) => ({ default: m.TicketTimeline })),
 );
 
 /** The description block's fixed-height skeleton — shared by the Suspense
@@ -557,6 +567,41 @@ function ActivitySection({ ticketId }: { ticketId: string }) {
   );
 }
 
+// ── DISCUSSION (the Linear conversation) ────────────────────────────────────
+// CTL-1574: comment cards interleaved with the ticket's Linear state-change
+// history, read from the local replica. Distinct from the Activity section above
+// — that one is the EXECUTION event stream; this is what people said and what
+// changed on the ticket. Keyed off the id so it works off-board.
+function DiscussionSection({ ticketId }: { ticketId: string }) {
+  const { comments, activity, available, loading } = useTicketDiscussion(ticketId);
+  return (
+    <section data-ticket-discussion style={{ marginBottom: 8 }}>
+      <div style={{ display: "flex", alignItems: "center", gap: 8, marginBottom: 8 }}>
+        <SectionLabel>Discussion</SectionLabel>
+        <span style={{ flex: 1 }} />
+        {available && !loading && (
+          <span style={{ font: `10px ${C.mono}`, color: C.fgDim }}>
+            {comments.length} comment{comments.length === 1 ? "" : "s"} · {activity.length} change
+            {activity.length === 1 ? "" : "s"}
+          </span>
+        )}
+      </div>
+      <Suspense
+        fallback={
+          <div style={{ color: C.fgDim, font: `12px ${C.mono}` }}>Loading discussion…</div>
+        }
+      >
+        <TicketTimeline
+          comments={comments}
+          activity={activity}
+          loaded={!loading}
+          available={available}
+        />
+      </Suspense>
+    </section>
+  );
+}
+
 // ── TELEMETRY strip (CTL-917 / DETAIL6) ─────────────────────────────────────
 /** Fetch the ticket telemetry strip's REAL Prometheus sparklines for this Linear
  *  key. REAL today — no new plumbing. A 503 (Prometheus not configured) yields
@@ -957,6 +1002,15 @@ export function TicketDetailPage({
             </div>
           </TabsContent>
 
+          {/* Discussion: the LINEAR conversation — comment cards interleaved with
+              the ticket's state-change history (CTL-1574). Keyed off the id so it
+              works off-board, same as the Activity tab above. */}
+          <TabsContent value="discussion">
+            <div style={{ paddingTop: 16 }}>
+              <DiscussionSection ticketId={ticket?.id ?? id} />
+            </div>
+          </TabsContent>
+
           {/* Execution: the record of what happened — NOW card, narrative, Gantt,
               artifacts, exceptions & decisions, hop log (CTL-1102). */}
           <TabsContent value="execution">
@@ -975,11 +1029,14 @@ function TAB_IS_VALID(tab: string): tab is "spec" | DetailTab {
   return tab === "spec" || (TAB_VALUES as readonly string[]).includes(tab);
 }
 
-/** The visible tab set (Spec default · Lifecycle · Cost · Activity · Execution). */
+/** The visible tab set (Spec default · Lifecycle · Cost · Activity · Discussion ·
+ *  Execution). "Discussion" is the LINEAR conversation (CTL-1574); "Activity" is
+ *  the execution event stream and keeps its name. */
 const TAB_DEFS: PillTab[] = [
   { value: "spec", label: "Spec" },
   { value: "lifecycle", label: "Lifecycle" },
   { value: "cost", label: "Cost" },
   { value: "activity", label: "Activity" },
+  { value: "discussion", label: "Discussion" },
   { value: "execution", label: "Execution" },
 ];

--- a/plugins/dev/scripts/orch-monitor/ui/src/components/ticket-discussion.test.tsx
+++ b/plugins/dev/scripts/orch-monitor/ui/src/components/ticket-discussion.test.tsx
@@ -1,0 +1,294 @@
+// ticket-discussion.test.tsx — the PURE timeline math behind the Discussion
+// surface (CTL-1574). No rendering: buildTimeline / coalesceBursts /
+// describeOrNull / creationEventId are React-free by construction, which is what
+// makes the merge, tie-break and burst-collapse rules testable at all.
+//
+// The three rules worth pinning are the ones a reader cannot verify by eye and a
+// refactor can silently invert: the chronological merge, the SAME-MILLISECOND
+// tie-break (event before comment — the state changed, THEN someone commented),
+// and the burst threshold (a run must EXCEED 4 within 5 minutes to collapse).
+
+import { describe, it, expect } from "bun:test";
+import {
+  buildTimeline,
+  coalesceBursts,
+  creationEventId,
+  describeOrNull,
+  type CommentNode,
+  type EventNode,
+} from "./ticket-discussion";
+import type { TicketActivityEvent, TicketComment } from "../../../lib/ticket-discussion-reader.mjs";
+
+const BURST_WINDOW_MS = 5 * 60 * 1000;
+
+/** An activity event with every property untouched (all-null), overridden per-test.
+ *  A bare event like this describes NOTHING, which is exactly Linear's creation row. */
+function event(over: Partial<TicketActivityEvent> & { id: string; created_at: number }): TicketActivityEvent {
+  return {
+    actor_id: null,
+    actor_name: null,
+    actor_avatar_url: null,
+    from_state: null,
+    to_state: null,
+    from_assignee_id: null,
+    from_assignee_name: null,
+    to_assignee_id: null,
+    to_assignee_name: null,
+    from_priority: null,
+    to_priority: null,
+    from_estimate: null,
+    to_estimate: null,
+    from_title: null,
+    to_title: null,
+    from_cycle_id: null,
+    from_cycle_number: null,
+    to_cycle_id: null,
+    to_cycle_number: null,
+    from_project_id: null,
+    from_project_name: null,
+    to_project_id: null,
+    to_project_name: null,
+    from_parent_id: null,
+    from_parent_identifier: null,
+    to_parent_id: null,
+    to_parent_identifier: null,
+    from_team_id: null,
+    to_team_id: null,
+    from_due_date: null,
+    to_due_date: null,
+    added_labels: [],
+    removed_labels: [],
+    updated_description: null,
+    archived: null,
+    auto_archived: null,
+    auto_closed: null,
+    trashed: null,
+    ...over,
+  };
+}
+
+function comment(over: Partial<TicketComment> & { id: string; updated_at: number }): TicketComment {
+  return {
+    body: "hello",
+    author_id: null,
+    author_name: "ryan",
+    author_avatar_url: null,
+    is_bot: 0,
+    parent_id: null,
+    ...over,
+  };
+}
+
+/** A same-actor run of `n` events, `stepMs` apart, starting at `startTs`. */
+function run(actor: string, n: number, startTs: number, stepMs: number): TicketActivityEvent[] {
+  return Array.from({ length: n }, (_, i) =>
+    event({
+      id: `${actor}-${i}`,
+      created_at: startTs + i * stepMs,
+      actor_name: actor,
+      // Give each one a real transition so it is never mistaken for the creation row.
+      to_state: "Implement",
+      from_state: "Backlog",
+    }),
+  );
+}
+
+describe("buildTimeline", () => {
+  it("interleaves comments and events in ascending timestamp order", () => {
+    const nodes = buildTimeline(
+      [comment({ id: "c1", updated_at: 200 }), comment({ id: "c2", updated_at: 400 })],
+      [
+        event({ id: "e1", created_at: 100, actor_name: "ryan", to_state: "Todo" }),
+        event({ id: "e2", created_at: 300, actor_name: "ryan", to_state: "Implement" }),
+      ],
+    );
+
+    expect(nodes.map((n) => n.ts)).toEqual([100, 200, 300, 400]);
+    expect(nodes.map((n) => n.kind)).toEqual(["event", "comment", "event", "comment"]);
+  });
+
+  it("puts the event FIRST when an event and a comment share a millisecond", () => {
+    const nodes = buildTimeline(
+      [comment({ id: "c1", updated_at: 1000 })],
+      [event({ id: "e1", created_at: 1000, actor_name: "ryan", to_state: "Done" })],
+    );
+
+    expect(nodes.map((n) => n.kind)).toEqual(["event", "comment"]);
+  });
+
+  it("labels the earliest bare event as the creation row and never coalesces it", () => {
+    // A bare event (no transition) at t=0, then a 5-event same-actor burst.
+    const activity = [event({ id: "created", created_at: 0, actor_name: "ryan" }), ...run("ryan", 5, 1000, 10)];
+    const nodes = buildTimeline([], activity);
+
+    expect(creationEventId(activity)).toBe("created");
+    expect(nodes).toHaveLength(2);
+    expect(nodes[0]).toMatchObject({ kind: "event", isCreation: true });
+    expect(nodes[1]!.kind).toBe("burst");
+  });
+
+  it("returns [] for a ticket with no comments and no activity", () => {
+    expect(buildTimeline([], [])).toEqual([]);
+  });
+});
+
+describe("creationEventId", () => {
+  it("is null when the earliest event already describes a real change", () => {
+    // Nothing to label "created" — mislabeling a real transition would be a lie.
+    expect(creationEventId(run("ryan", 2, 500, 10))).toBeNull();
+  });
+
+  it("is null for an empty activity list", () => {
+    expect(creationEventId([])).toBeNull();
+  });
+});
+
+describe("coalesceBursts", () => {
+  const nodesOf = (events: TicketActivityEvent[]): EventNode[] =>
+    events.map((e) => ({ kind: "event", ts: e.created_at, event: e, isCreation: false }));
+
+  it("leaves a run of exactly 4 expanded (the threshold is EXCEED, not reach)", () => {
+    const out = coalesceBursts(nodesOf(run("ryan", 4, 0, 1000)));
+
+    expect(out).toHaveLength(4);
+    expect(out.every((n) => n.kind === "event")).toBe(true);
+  });
+
+  it("collapses a run of 5 within the 5-minute window into one burst", () => {
+    const out = coalesceBursts(nodesOf(run("ryan", 5, 0, 1000)));
+
+    expect(out).toHaveLength(1);
+    expect(out[0]).toMatchObject({ kind: "burst", actorName: "ryan" });
+    expect((out[0] as { events: TicketActivityEvent[] }).events).toHaveLength(5);
+    // The burst carries the LAST event's timestamp (when the run finished).
+    expect(out[0]!.ts).toBe(4000);
+  });
+
+  it("breaks a run on a gap LONGER than the 5-minute window", () => {
+    // 3 tight events, then a 4th one just past the window, then 2 more tight ones.
+    // Neither side exceeds 4, so nothing collapses.
+    const events = [
+      ...run("ryan", 3, 0, 1000),
+      ...run("ryan", 3, 3000 + BURST_WINDOW_MS + 1, 1000).map((e) => ({ ...e, id: `late-${e.id}` })),
+    ];
+    const out = coalesceBursts(nodesOf(events));
+
+    expect(out).toHaveLength(6);
+    expect(out.every((n) => n.kind === "event")).toBe(true);
+  });
+
+  it("keeps a gap of EXACTLY the window inside one run", () => {
+    const events = run("ryan", 5, 0, BURST_WINDOW_MS);
+    const out = coalesceBursts(nodesOf(events));
+
+    expect(out).toHaveLength(1);
+    expect(out[0]!.kind).toBe("burst");
+  });
+
+  it("breaks a run when the actor changes", () => {
+    const out = coalesceBursts(nodesOf([...run("ryan", 3, 0, 100), ...run("agent", 3, 1000, 100)]));
+
+    expect(out).toHaveLength(6);
+  });
+
+  it("breaks a run on an intervening comment", () => {
+    const mid: CommentNode = {
+      kind: "comment",
+      ts: 250,
+      comment: comment({ id: "c1", updated_at: 250 }),
+    };
+    const out = coalesceBursts([
+      ...nodesOf(run("ryan", 3, 0, 100)),
+      mid,
+      ...nodesOf(run("ryan", 3, 300, 100).map((e) => ({ ...e, id: `b-${e.id}` }))),
+    ]);
+
+    expect(out.map((n) => n.kind)).toEqual([
+      "event",
+      "event",
+      "event",
+      "comment",
+      "event",
+      "event",
+      "event",
+    ]);
+  });
+
+  it("never folds an actor-less system event into a burst", () => {
+    const systemRun = run("ryan", 6, 0, 100).map((e) => ({ ...e, actor_name: null }));
+    const out = coalesceBursts(nodesOf(systemRun));
+
+    expect(out).toHaveLength(6);
+  });
+});
+
+describe("describeOrNull", () => {
+  it("returns null for a bare event that touched nothing we describe", () => {
+    expect(describeOrNull(event({ id: "e", created_at: 1 }))).toBeNull();
+  });
+
+  it("carries the destination state's color as a dot for a state transition", () => {
+    const desc = describeOrNull(
+      event({ id: "e", created_at: 1, from_state: "Backlog", to_state: "Done" }),
+    );
+
+    // "Done" is the success bucket — the dot proves the state vocabulary is wired.
+    expect(desc?.dot).toBe("var(--color-green)");
+  });
+
+  it("describes a label change without a state dot", () => {
+    const desc = describeOrNull(
+      event({
+        id: "e",
+        created_at: 1,
+        added_labels: [{ id: "l1", name: "needs-human", color: "#e36b6b" }],
+      }),
+    );
+
+    expect(desc).not.toBeNull();
+    expect(desc?.dot).toBeUndefined();
+  });
+
+  it("ignores a label whose name the replica never resolved", () => {
+    // A null-name label cannot be shown without fabricating one, so the describer
+    // must fall through rather than render a nameless swatch.
+    const desc = describeOrNull(
+      event({ id: "e", created_at: 1, added_labels: [{ id: "l1", name: null, color: null }] }),
+    );
+
+    expect(desc).toBeNull();
+  });
+
+  it("distinguishes an explicit unarchive (0) from an untouched archive flag (null)", () => {
+    expect(describeOrNull(event({ id: "a", created_at: 1, archived: 1 }))).not.toBeNull();
+    expect(describeOrNull(event({ id: "b", created_at: 1, archived: 0 }))).not.toBeNull();
+    expect(describeOrNull(event({ id: "c", created_at: 1, archived: null }))).toBeNull();
+  });
+
+  it("gives every phase-contract state a non-neutral dot", () => {
+    // These are the states this workspace actually emits; a neutral dot on them
+    // would make the busiest transitions carry no color signal at all.
+    const expected: Record<string, string> = {
+      Research: "var(--color-blue)",
+      Plan: "var(--color-blue)",
+      Implement: "var(--color-blue)",
+      Validate: "var(--color-blue)",
+      PR: "var(--color-blue)",
+      Remediate: "var(--color-yellow)",
+      Done: "var(--color-green)",
+    };
+    for (const [state, color] of Object.entries(expected)) {
+      const desc = describeOrNull(event({ id: state, created_at: 1, to_state: state }));
+      expect(desc?.dot).toBe(color);
+    }
+  });
+
+  it("prefers the state transition when an event touches several properties", () => {
+    // DESCRIBERS is ordered; state wins so the row reads as the transition it is.
+    const desc = describeOrNull(
+      event({ id: "e", created_at: 1, to_state: "Implement", to_priority: 2 }),
+    );
+
+    expect(desc?.dot).toBe("var(--color-blue)");
+  });
+});

--- a/plugins/dev/scripts/orch-monitor/ui/src/components/ticket-discussion.test.tsx
+++ b/plugins/dev/scripts/orch-monitor/ui/src/components/ticket-discussion.test.tsx
@@ -141,6 +141,24 @@ describe("creationEventId", () => {
   it("is null for an empty activity list", () => {
     expect(creationEventId([])).toBeNull();
   });
+
+  it("labels a bare earliest row within the creation window of the issue's created_at", () => {
+    const activity = [event({ id: "created", created_at: 60_000, actor_name: "ryan" })];
+    expect(creationEventId(activity, 0)).toBe("created");
+  });
+
+  it("refuses the label when the bare earliest row arrives long after the issue was created", () => {
+    // Linear emits bare rows for unextracted properties (subscribers, relations);
+    // a bare row a month after created_at is one of those, not the creation.
+    const activity = [event({ id: "late-bare", created_at: 31 * 24 * 3_600_000, actor_name: "ryan" })];
+    expect(creationEventId(activity, 0)).toBeNull();
+  });
+
+  it("keeps the unguarded behavior when the issue's created_at is unknown", () => {
+    const activity = [event({ id: "created", created_at: 999_999_999, actor_name: "ryan" })];
+    expect(creationEventId(activity, null)).toBe("created");
+    expect(creationEventId(activity)).toBe("created");
+  });
 });
 
 describe("coalesceBursts", () => {

--- a/plugins/dev/scripts/orch-monitor/ui/src/components/ticket-discussion.test.tsx
+++ b/plugins/dev/scripts/orch-monitor/ui/src/components/ticket-discussion.test.tsx
@@ -165,6 +165,21 @@ describe("coalesceBursts", () => {
   const nodesOf = (events: TicketActivityEvent[]): EventNode[] =>
     events.map((e) => ({ kind: "event", ts: e.created_at, event: e, isCreation: false }));
 
+  it("splits a run on actor_id even when the display names collide", () => {
+    // Two accounts named "ryan": merging them would attribute the whole burst
+    // to the first. 5+5 adjacent events must yield two bursts, not one.
+    const a = run("ryan", 5, 0, 1000).map((e) => ({ ...e, actor_id: "user-a" }));
+    const b = run("ryan", 5, 5000, 1000).map((e, i) => ({
+      ...e,
+      id: `b-${i}`,
+      actor_id: "user-b",
+    }));
+    const out = coalesceBursts(nodesOf([...a, ...b]));
+
+    expect(out).toHaveLength(2);
+    expect(out.every((n) => n.kind === "burst")).toBe(true);
+  });
+
   it("leaves a run of exactly 4 expanded (the threshold is EXCEED, not reach)", () => {
     const out = coalesceBursts(nodesOf(run("ryan", 4, 0, 1000)));
 

--- a/plugins/dev/scripts/orch-monitor/ui/src/components/ticket-discussion.tsx
+++ b/plugins/dev/scripts/orch-monitor/ui/src/components/ticket-discussion.tsx
@@ -25,7 +25,8 @@
 // dominant; same-actor BURSTS collapse to one expandable row; the OUTCOME value
 // renders in text-fg with the rest in text-muted. buildTimeline / coalesceBursts /
 // describeOrNull are pure (no React, no Date.now) and exported for tests.
-import { Fragment, useState, type ReactNode } from "react";
+import { Fragment, useCallback, useState, type ReactNode } from "react";
+import { useNavigate } from "@tanstack/react-router";
 import {
   Archive,
   Bot,
@@ -49,7 +50,7 @@ import {
 } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { fmtRelativeDuration, statusSemantic, type StatusSemantic } from "@/lib/formatters";
-import { renderTicketDescriptionHtml } from "@/lib/ticket-markdown";
+import { isTicketRef, renderTicketDescriptionHtml } from "@/lib/ticket-markdown";
 import type {
   TicketActivityEvent,
   TicketActivityLabel,
@@ -226,6 +227,15 @@ export function buildTimeline(
   return coalesceBursts(nodes);
 }
 
+/** Same-actor test for burst coalescing: compare `actor_id` when both events
+ *  carry one (two accounts can share a display name — merging them would
+ *  misattribute the whole burst to the first), fall back to the display name
+ *  only when ids are absent. */
+function sameActor(a: TicketActivityEvent, b: TicketActivityEvent): boolean {
+  if (a.actor_id != null && b.actor_id != null) return a.actor_id === b.actor_id;
+  return a.actor_name === b.actor_name;
+}
+
 /** Fold contiguous same-actor event runs longer than BURST_MAX (within
  *  BURST_WINDOW_MS) into one burst node. A comment, a different actor, an
  *  actor-less (system) event, or a window gap breaks a run. Exported for tests. */
@@ -251,7 +261,7 @@ export function coalesceBursts(nodes: Array<CommentNode | EventNode>): TimelineN
       const prev = run[run.length - 1];
       if (
         prev &&
-        (prev.event.actor_name !== node.event.actor_name || node.ts - prev.ts > BURST_WINDOW_MS)
+        (!sameActor(prev.event, node.event) || node.ts - prev.ts > BURST_WINDOW_MS)
       ) {
         flush();
       }
@@ -566,6 +576,23 @@ function CommentItem({ comment, now }: { comment: TicketComment; now: number }) 
   const when = fmtRelativeDuration(now - comment.updated_at);
   const name = comment.author_name ?? UNKNOWN_AUTHOR;
   const isBot = Boolean(comment.is_bot);
+  const navigate = useNavigate();
+  // Soft-navigate ticket-ref pill clicks through TanStack Router — same
+  // interception as ticket-description.tsx, else a pill click is a full document
+  // navigation that discards the monitor's in-memory state.
+  const interceptTicketLinks = useCallback(
+    (e: React.MouseEvent<HTMLDivElement>) => {
+      if (e.metaKey || e.ctrlKey || e.shiftKey || e.altKey) return;
+      const target = e.target as HTMLElement | null;
+      const anchor = target?.closest("a.ticket-ref-pill") as HTMLAnchorElement | null;
+      if (!anchor) return;
+      const ref = (anchor.textContent ?? "").trim();
+      if (!isTicketRef(ref)) return;
+      e.preventDefault();
+      void navigate({ to: "/ticket/$id", params: { id: ref } });
+    },
+    [navigate],
+  );
   return (
     <li
       data-ticket-comment={comment.id}
@@ -590,6 +617,7 @@ function CommentItem({ comment, now }: { comment: TicketComment; now: number }) 
         <div
           data-ticket-comment-body
           className="ticket-desc prose prose-invert"
+          onClick={interceptTicketLinks}
           dangerouslySetInnerHTML={{ __html: renderTicketDescriptionHtml(comment.body) }}
         />
       ) : (

--- a/plugins/dev/scripts/orch-monitor/ui/src/components/ticket-discussion.tsx
+++ b/plugins/dev/scripts/orch-monitor/ui/src/components/ticket-discussion.tsx
@@ -161,20 +161,36 @@ export interface BurstNode {
 }
 export type TimelineNode = CommentNode | EventNode | BurstNode;
 
+/** How far (ms) a bare earliest history row may sit after the issue's own
+ *  created_at and still be labeled "created this issue". Linear also emits bare
+ *  rows for properties the read-model doesn't extract (subscribers, relations,
+ *  attachments); on live data ~1/6 of issues' earliest bare row arrives hours or
+ *  weeks late, so without this window the label is frequently a fabrication. */
+const CREATION_WINDOW_MS = 5 * 60_000;
+
 /**
  * The id of the "created this issue" event, or null. It's the EARLIEST activity
  * event that carries no recorded transition — Linear emits a bare IssueHistory row
  * for issue creation. If the earliest event already describes a real change, we
  * have no creation row to label and this returns null (a real transition is never
- * mislabeled as "created"). Exported for tests.
+ * mislabeled as "created"). When the issue's own creation instant is known, the
+ * bare row must also fall within CREATION_WINDOW_MS of it — a late bare row (an
+ * unextracted property change) is left unlabeled rather than mislabeled.
+ * Exported for tests.
  */
-export function creationEventId(activity: TicketActivityEvent[]): string | null {
+export function creationEventId(
+  activity: TicketActivityEvent[],
+  issueCreatedAt?: number | null,
+): string | null {
   if (activity.length === 0) return null;
   let minTs = Infinity;
   for (const e of activity) if (e.created_at < minTs) minTs = e.created_at;
   // Among the earliest-timestamp events, the bare (no-transition) one is creation.
   const created = activity.find((e) => e.created_at === minTs && describeOrNull(e) === null);
-  return created ? created.id : null;
+  if (!created) return null;
+  if (typeof issueCreatedAt === "number" && created.created_at - issueCreatedAt > CREATION_WINDOW_MS)
+    return null;
+  return created.id;
 }
 
 /**
@@ -190,8 +206,9 @@ export function creationEventId(activity: TicketActivityEvent[]): string | null 
 export function buildTimeline(
   comments: TicketComment[],
   activity: TicketActivityEvent[],
+  issueCreatedAt?: number | null,
 ): TimelineNode[] {
-  const createdId = creationEventId(activity);
+  const createdId = creationEventId(activity, issueCreatedAt);
   const nodes: Array<CommentNode | EventNode> = [
     ...comments.map((c): CommentNode => ({ kind: "comment", ts: c.updated_at, comment: c })),
     ...activity.map(
@@ -503,16 +520,38 @@ export function initialsOf(name: string | null): string {
   return (first + last).toUpperCase() || "?";
 }
 
-/** The 24px author mark — an initials circle, or a Bot glyph for an agent author.
- *  Replaces the source's shadcn Avatar (adaptation 3); the border is what gives it
- *  definition against the card's own bg-surface-2. */
-function AuthorMark({ name, isBot }: { name: string | null; isBot: boolean }) {
+/** The 24px author mark — the author's Linear avatar when one is mirrored, else
+ *  an initials circle, or a Bot glyph for an agent author. Replaces the source's
+ *  shadcn Avatar (adaptation 3) with a plain <img> + failure fallback; the border
+ *  is what gives it definition against the card's own bg-surface-2. */
+function AuthorMark({
+  name,
+  isBot,
+  avatarUrl,
+}: {
+  name: string | null;
+  isBot: boolean;
+  avatarUrl: string | null;
+}) {
+  const [imgFailed, setImgFailed] = useState(false);
+  const showImg = Boolean(avatarUrl) && !imgFailed;
   return (
     <span
       aria-hidden
-      className="flex size-6 shrink-0 items-center justify-center rounded-full border border-border bg-surface-2 text-[10px] font-medium text-muted"
+      className="flex size-6 shrink-0 items-center justify-center overflow-hidden rounded-full border border-border bg-surface-2 text-[10px] font-medium text-muted"
     >
-      {isBot ? <Bot className="size-3.5" /> : initialsOf(name)}
+      {showImg ? (
+        <img
+          src={avatarUrl ?? undefined}
+          alt=""
+          className="size-full object-cover"
+          onError={() => setImgFailed(true)}
+        />
+      ) : isBot ? (
+        <Bot className="size-3.5" />
+      ) : (
+        initialsOf(name)
+      )}
     </span>
   );
 }
@@ -534,7 +573,11 @@ function CommentItem({ comment, now }: { comment: TicketComment; now: number }) 
       className="flex flex-col gap-2 rounded-lg border border-border bg-surface-2 px-3.5 py-3 shadow-card"
     >
       <div data-ticket-comment-header className="flex items-center gap-2">
-        <AuthorMark name={comment.author_name} isBot={isBot} />
+        <AuthorMark
+          name={comment.author_name}
+          isBot={isBot}
+          avatarUrl={comment.author_avatar_url}
+        />
         <span className="text-[12px] font-medium text-fg">{name}</span>
         {isBot && <span className="font-mono text-[11px] text-muted">· agent</span>}
         {when && (
@@ -655,6 +698,8 @@ export function TicketTimeline({
   available = true,
   now = Date.now(),
   limit,
+  issueCreatedAt = null,
+  error = null,
 }: {
   comments: TicketComment[];
   activity: TicketActivityEvent[];
@@ -662,6 +707,11 @@ export function TicketTimeline({
   available?: boolean;
   now?: number;
   limit?: number;
+  /** The issue's own creation instant — gates the "created this issue" label. */
+  issueCreatedAt?: number | null;
+  /** Transport failure reason (fetch/HTTP), so an unreachable MONITOR is not
+   *  misreported as an unreadable REPLICA. */
+  error?: string | null;
 }) {
   const [showAll, setShowAll] = useState(false);
 
@@ -676,12 +726,14 @@ export function TicketTimeline({
   if (!available) {
     return (
       <div data-ticket-timeline-unavailable className="font-mono text-[12px] text-muted">
-        Linear discussion unavailable — the local replica could not be read.
+        {error
+          ? `Linear discussion could not be loaded — request failed (${error}).`
+          : "Linear discussion unavailable — the local replica could not be read."}
       </div>
     );
   }
 
-  const nodes = buildTimeline(comments, activity);
+  const nodes = buildTimeline(comments, activity, issueCreatedAt);
   if (nodes.length === 0) {
     return (
       <div data-ticket-timeline-empty className="font-mono text-[12px] text-muted">

--- a/plugins/dev/scripts/orch-monitor/ui/src/components/ticket-discussion.tsx
+++ b/plugins/dev/scripts/orch-monitor/ui/src/components/ticket-discussion.tsx
@@ -1,0 +1,729 @@
+// ticket-discussion.tsx — the interleaved Linear DISCUSSION timeline: comment
+// cards and state-change rows in ONE chronological stream (CTL-1574).
+//
+// PORTED from catalyst-cloud's `apps/web/src/components/tickets/ticket-timeline.tsx`
+// (buildTimeline / coalesceBursts / DESCRIBERS / ActivityRow / ActivityBurst /
+// TicketTimeline) plus the CommentItem card from `ticket-comments.tsx` in the same
+// directory. The data comes from the SAME `@catalyst-cloud/read-model`
+// buildIssueDetail those components consume, so the presentation is a copy rather
+// than a re-derivation. Behavior is unchanged except for four deliberate host
+// adaptations:
+//
+//   1. Markdown goes through THIS app's sanitizing pipeline
+//      (@/lib/ticket-markdown::renderTicketDescriptionHtml — marked + hljs +
+//      DOMPurify + ref pills), the same one ticket-description.tsx uses.
+//   2. Relative time uses @/lib/formatters::fmtRelativeDuration.
+//   3. No shadcn Avatar (the monitor has none): the comment card renders a 24px
+//      initials circle, and an `is_bot` author shows a Bot glyph instead.
+//   4. `stateColorVar` / `priorityLabel` are inlined below over the monitor's own
+//      `statusSemantic` + theme tokens (catalyst-cloud keeps them in
+//      lib/issue-presenter.ts, which has no counterpart here).
+//
+// Design, unchanged from the source: activity events are RECESSIVE single-line
+// rows (verb glyph + actor + outcome + relative time) so they read as quiet
+// annotations between full-weight comment cards and the human discussion stays
+// dominant; same-actor BURSTS collapse to one expandable row; the OUTCOME value
+// renders in text-fg with the rest in text-muted. buildTimeline / coalesceBursts /
+// describeOrNull are pure (no React, no Date.now) and exported for tests.
+import { Fragment, useState, type ReactNode } from "react";
+import {
+  Archive,
+  Bot,
+  CalendarClock,
+  ChevronRight,
+  CirclePlus,
+  CircleUser,
+  CornerUpLeft,
+  Dot,
+  FileText,
+  Flag,
+  FolderInput,
+  Gauge,
+  PencilLine,
+  RefreshCw,
+  RotateCw,
+  Tag,
+  Trash2,
+  XCircle,
+  type LucideIcon,
+} from "lucide-react";
+import { cn } from "@/lib/utils";
+import { fmtRelativeDuration, statusSemantic, type StatusSemantic } from "@/lib/formatters";
+import { renderTicketDescriptionHtml } from "@/lib/ticket-markdown";
+import type {
+  TicketActivityEvent,
+  TicketActivityLabel,
+  TicketComment,
+} from "../../../lib/ticket-discussion-reader.mjs";
+
+// ── Tunables (ported verbatim — deliberately easy to retune) ─────────────────
+/** A contiguous run of same-actor events LONGER than this collapses into one
+ *  expandable "made N changes" row, so a burst of agent edits never drowns the
+ *  human discussion. */
+const BURST_MAX = 4;
+/** Two same-actor events more than this far apart never coalesce (separate
+ *  working sessions). */
+const BURST_WINDOW_MS = 5 * 60 * 1000;
+/** A renamed-to title longer than this is truncated with an ellipsis (rows stay
+ *  one line). */
+const TITLE_MAX = 48;
+
+const MONTHS = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"];
+
+/** A neutral actor label when the replica has no name for the event's actor (a
+ *  system event). */
+const UNKNOWN_ACTOR = "Someone";
+/** A neutral label for an author the replica has no name for (never blank). */
+const UNKNOWN_AUTHOR = "Unknown";
+
+// ── State + priority presentation (adaptation 4) ─────────────────────────────
+/** Linear priority → human label. 0/absent = no priority (the row is omitted). */
+const PRIORITY_LABEL = ["No priority", "Urgent", "High", "Medium", "Low"] as const;
+
+function priorityLabel(priority: number | null): string | null {
+  if (priority == null || priority <= 0) return null;
+  return PRIORITY_LABEL[priority] ?? `P${priority}`;
+}
+
+/** The semantic bucket for a LINEAR WORKFLOW state name.
+ *
+ *  `statusSemantic` keys off the monitor's internal worker statuses (`running`,
+ *  `implementing`, …), which are NOT the strings Linear stores. The states that
+ *  actually appear in this workspace's `issue_history` are the phase-contract
+ *  names — Implement (2280 rows), PR (1774), Triage, Plan, Research, Validate,
+ *  Remediate, Ready — and every one of them falls through to `neutral` on that
+ *  table alone, which would leave the dot carrying no information on the busiest
+ *  transitions. So the contract states are mapped explicitly here and
+ *  `statusSemantic` remains the fallback for anything else. (catalyst-cloud's
+ *  issue-presenter.ts maps a shorter list; this one is widened to the states this
+ *  workspace really emits.) */
+function stateSemantic(state: string): StatusSemantic {
+  const key = state.trim().toLowerCase().replace(/\s+/g, "_");
+  const EXTRA: Record<string, StatusSemantic> = {
+    // In-flight pipeline states — the ticket is moving.
+    research: "info",
+    plan: "info",
+    implement: "info",
+    verify: "info",
+    validate: "info",
+    review: "info",
+    in_review: "info",
+    pr: "info",
+    "monitor-merge": "info",
+    "monitor-deploy": "info",
+    // Something needs attention before it moves again.
+    remediate: "warning",
+    // Not yet started / no longer live — quiet.
+    triage: "neutral",
+    backlog: "neutral",
+    todo: "neutral",
+    ready: "neutral",
+    duplicate: "neutral",
+  };
+  return EXTRA[key] ?? statusSemantic(key);
+}
+
+/** The theme token a state's dot resolves to. */
+function stateColorVar(state: string): string {
+  switch (stateSemantic(state)) {
+    case "success":
+      return "var(--color-green)";
+    case "info":
+      return "var(--color-blue)";
+    case "danger":
+      return "var(--color-red)";
+    case "warning":
+      return "var(--color-yellow)";
+    default:
+      return "var(--fg-muted)";
+  }
+}
+
+// ── Pure timeline model ──────────────────────────────────────────────────────
+export interface CommentNode {
+  kind: "comment";
+  ts: number;
+  comment: TicketComment;
+}
+export interface EventNode {
+  kind: "event";
+  ts: number;
+  event: TicketActivityEvent;
+  /** The "created this issue" row — Linear's creation event (see
+   *  creationEventId). Never coalesced into a burst, so creation stays visible. */
+  isCreation: boolean;
+}
+export interface BurstNode {
+  kind: "burst";
+  ts: number;
+  actorName: string;
+  events: TicketActivityEvent[];
+}
+export type TimelineNode = CommentNode | EventNode | BurstNode;
+
+/**
+ * The id of the "created this issue" event, or null. It's the EARLIEST activity
+ * event that carries no recorded transition — Linear emits a bare IssueHistory row
+ * for issue creation. If the earliest event already describes a real change, we
+ * have no creation row to label and this returns null (a real transition is never
+ * mislabeled as "created"). Exported for tests.
+ */
+export function creationEventId(activity: TicketActivityEvent[]): string | null {
+  if (activity.length === 0) return null;
+  let minTs = Infinity;
+  for (const e of activity) if (e.created_at < minTs) minTs = e.created_at;
+  // Among the earliest-timestamp events, the bare (no-transition) one is creation.
+  const created = activity.find((e) => e.created_at === minTs && describeOrNull(e) === null);
+  return created ? created.id : null;
+}
+
+/**
+ * Merge comments + activity into one chronological stream. Comments are FLAT —
+ * each is its own node ordered by `updated_at`, NOT threaded/indented
+ * (Linear-style; agent comments are top-level and the indent read as a confusing
+ * reply-thread). Activity events are single nodes. Sorted by timestamp ascending;
+ * on a tie the activity event sorts BEFORE a same-ms comment (the state changed,
+ * THEN someone commented). A contiguous run of >BURST_MAX same-actor events within
+ * BURST_WINDOW_MS collapses to one burst node — EXCEPT the creation event, which
+ * never coalesces. Pure — no React, no Date.now (the caller passes `now`).
+ */
+export function buildTimeline(
+  comments: TicketComment[],
+  activity: TicketActivityEvent[],
+): TimelineNode[] {
+  const createdId = creationEventId(activity);
+  const nodes: Array<CommentNode | EventNode> = [
+    ...comments.map((c): CommentNode => ({ kind: "comment", ts: c.updated_at, comment: c })),
+    ...activity.map(
+      (e): EventNode => ({
+        kind: "event",
+        ts: e.created_at,
+        event: e,
+        isCreation: e.id === createdId,
+      }),
+    ),
+  ];
+  // Stable in V8: tie → event (rank 0) before comment (rank 1).
+  const rank = (n: CommentNode | EventNode) => (n.kind === "event" ? 0 : 1);
+  nodes.sort((a, b) => a.ts - b.ts || rank(a) - rank(b));
+  return coalesceBursts(nodes);
+}
+
+/** Fold contiguous same-actor event runs longer than BURST_MAX (within
+ *  BURST_WINDOW_MS) into one burst node. A comment, a different actor, an
+ *  actor-less (system) event, or a window gap breaks a run. Exported for tests. */
+export function coalesceBursts(nodes: Array<CommentNode | EventNode>): TimelineNode[] {
+  const out: TimelineNode[] = [];
+  let run: EventNode[] = [];
+  const flush = () => {
+    if (run.length === 0) return;
+    if (run.length > BURST_MAX) {
+      out.push({
+        kind: "burst",
+        ts: run[run.length - 1]!.ts,
+        actorName: run[0]!.event.actor_name ?? UNKNOWN_ACTOR,
+        events: run.map((r) => r.event),
+      });
+    } else {
+      out.push(...run);
+    }
+    run = [];
+  };
+  for (const node of nodes) {
+    if (node.kind === "event" && !node.isCreation && node.event.actor_name != null) {
+      const prev = run[run.length - 1];
+      if (
+        prev &&
+        (prev.event.actor_name !== node.event.actor_name || node.ts - prev.ts > BURST_WINDOW_MS)
+      ) {
+        flush();
+      }
+      run.push(node);
+    } else {
+      flush();
+      out.push(node);
+    }
+  }
+  flush();
+  return out;
+}
+
+// ── Event wording ────────────────────────────────────────────────────────────
+export interface Descriptor {
+  icon: LucideIcon;
+  /** When set, ActivityRow renders this CSS color as a state DOT instead of the
+   *  icon — used for state transitions so the row carries the app's state-color
+   *  vocabulary. */
+  dot?: string;
+  /** Everything after the actor name: the verb phrase + outcome (outcome values
+   *  in text-fg). */
+  body: ReactNode;
+}
+
+/** The result/outcome value, emphasized so the eye lands on what changed. */
+function fg(value: ReactNode): ReactNode {
+  return <span className="text-fg">{value}</span>;
+}
+
+/** "YYYY-MM-DD" (a Linear TimelessDate, stored as-is) → "Mar 14". Never shifts
+ *  timezone. */
+function fmtDueDate(d: string): string {
+  const m = /^(\d{4})-(\d{2})-(\d{2})$/.exec(d);
+  if (!m) return d;
+  const month = MONTHS[Number(m[2]) - 1] ?? m[2]!;
+  return `${month} ${Number(m[3])}`;
+}
+
+function truncate(s: string, n: number): string {
+  return s.length > n ? `${s.slice(0, n - 1).trimEnd()}…` : s;
+}
+
+/** Inline label swatches (dot + name). Color is never the sole signal — the name
+ *  is always shown. Labels with a null name are filtered out before this renders.
+ *  Chips are separated by a real space (not just a flex gap) so the text reads
+ *  correctly for screen readers + copy-paste, not "bugui". */
+function LabelSwatches({ labels }: { labels: TicketActivityLabel[] }) {
+  return (
+    <>
+      {labels.map((l, i) => (
+        <Fragment key={l.id}>
+          {i > 0 ? " " : null}
+          <span className="inline-flex items-center gap-1 align-middle">
+            <span
+              aria-hidden
+              className="size-1.5 rounded-full"
+              style={{ background: l.color ?? "var(--fg-dim)" }}
+            />
+            <span className="text-fg">{l.name}</span>
+          </span>
+        </Fragment>
+      ))}
+    </>
+  );
+}
+
+/** Named labels only (a null-name label can't be shown without fabricating). */
+function namedLabels(labels: TicketActivityLabel[]): TicketActivityLabel[] {
+  return labels.filter((l) => l.name != null);
+}
+
+/** Ordered list of per-property describers — the FIRST that applies to an event
+ *  wins (an event usually touches one property). Each returns null when it doesn't
+ *  apply, so we fall through to the next, and ultimately to a generic "updated
+ *  this issue" so an event is never silently dropped. */
+const DESCRIBERS: Array<(e: TicketActivityEvent) => Descriptor | null> = [
+  // Workflow state — the leading glyph is the DESTINATION state's color dot.
+  (e) => {
+    if (e.to_state == null && e.from_state == null) return null;
+    if (e.to_state != null && e.from_state != null)
+      return {
+        icon: RefreshCw,
+        dot: stateColorVar(e.to_state),
+        body: (
+          <>
+            moved {fg(e.from_state)} → {fg(e.to_state)}
+          </>
+        ),
+      };
+    if (e.to_state != null)
+      return {
+        icon: RefreshCw,
+        dot: stateColorVar(e.to_state),
+        body: <>set the state to {fg(e.to_state)}</>,
+      };
+    return null;
+  },
+  // Assignee.
+  (e) => {
+    if (e.to_assignee_id == null && e.from_assignee_id == null) return null;
+    if (e.to_assignee_id != null) {
+      if (e.to_assignee_name != null && e.to_assignee_name === e.actor_name)
+        return { icon: CircleUser, body: <>self-assigned this</> };
+      return {
+        icon: CircleUser,
+        body: <>assigned this to {fg(e.to_assignee_name ?? "someone")}</>,
+      };
+    }
+    return {
+      icon: CircleUser,
+      body:
+        e.from_assignee_name != null ? (
+          <>unassigned {fg(e.from_assignee_name)}</>
+        ) : (
+          <>unassigned this</>
+        ),
+    };
+  },
+  // Labels added.
+  (e) => {
+    const added = namedLabels(e.added_labels);
+    if (added.length === 0) return null;
+    return {
+      icon: Tag,
+      body: (
+        <>
+          added label{added.length > 1 ? "s" : ""} <LabelSwatches labels={added} />
+        </>
+      ),
+    };
+  },
+  // Labels removed.
+  (e) => {
+    const removed = namedLabels(e.removed_labels);
+    if (removed.length === 0) return null;
+    return {
+      icon: Tag,
+      body: (
+        <>
+          removed label{removed.length > 1 ? "s" : ""} <LabelSwatches labels={removed} />
+        </>
+      ),
+    };
+  },
+  // Priority.
+  (e) => {
+    if (e.to_priority == null && e.from_priority == null) return null;
+    const name = e.to_priority == null ? null : priorityLabel(e.to_priority);
+    return {
+      icon: Flag,
+      body: name != null ? <>changed priority to {fg(name)}</> : <>cleared the priority</>,
+    };
+  },
+  // Estimate.
+  (e) => {
+    if (e.to_estimate == null && e.from_estimate == null) return null;
+    return {
+      icon: Gauge,
+      body:
+        e.to_estimate != null ? (
+          <>set the estimate to {fg(`${e.to_estimate} pts`)}</>
+        ) : (
+          <>cleared the estimate</>
+        ),
+    };
+  },
+  // Title.
+  (e) => {
+    if (e.to_title == null) return null;
+    return {
+      icon: PencilLine,
+      body: <>renamed this to {fg(`“${truncate(e.to_title, TITLE_MAX)}”`)}</>,
+    };
+  },
+  // Project.
+  (e) => {
+    if (e.to_project_id == null && e.from_project_id == null) return null;
+    if (e.to_project_name != null)
+      return { icon: FolderInput, body: <>moved this to project {fg(e.to_project_name)}</> };
+    if (e.to_project_id != null)
+      return { icon: FolderInput, body: <>moved this to another project</> };
+    if (e.from_project_name != null)
+      return { icon: FolderInput, body: <>removed this from project {fg(e.from_project_name)}</> };
+    return { icon: FolderInput, body: <>removed this from its project</> };
+  },
+  // Cycle.
+  (e) => {
+    if (e.to_cycle_id == null && e.from_cycle_id == null) return null;
+    if (e.to_cycle_number != null)
+      return { icon: RotateCw, body: <>moved this to {fg(`Cycle ${e.to_cycle_number}`)}</> };
+    if (e.to_cycle_id != null) return { icon: RotateCw, body: <>moved this to another cycle</> };
+    if (e.from_cycle_number != null)
+      return { icon: RotateCw, body: <>removed this from {fg(`Cycle ${e.from_cycle_number}`)}</> };
+    return { icon: RotateCw, body: <>removed this from its cycle</> };
+  },
+  // Parent issue.
+  (e) => {
+    if (e.to_parent_id == null && e.from_parent_id == null) return null;
+    const mono = (id: string) => <span className="font-mono text-accent">{id}</span>;
+    if (e.to_parent_identifier != null)
+      return { icon: CornerUpLeft, body: <>set the parent to {mono(e.to_parent_identifier)}</> };
+    if (e.to_parent_id != null) return { icon: CornerUpLeft, body: <>set a parent issue</> };
+    if (e.from_parent_identifier != null)
+      return { icon: CornerUpLeft, body: <>removed the parent {mono(e.from_parent_identifier)}</> };
+    return { icon: CornerUpLeft, body: <>removed the parent issue</> };
+  },
+  // Due date.
+  (e) => {
+    if (e.to_due_date == null && e.from_due_date == null) return null;
+    return {
+      icon: CalendarClock,
+      body:
+        e.to_due_date != null ? (
+          <>set the due date to {fg(fmtDueDate(e.to_due_date))}</>
+        ) : (
+          <>removed the due date</>
+        ),
+    };
+  },
+  // Archived (null-preserving: 1 archived, 0 unarchived).
+  (e) => {
+    if (e.auto_archived === 1) return { icon: Archive, body: <>auto-archived this</> };
+    if (e.archived === 1) return { icon: Archive, body: <>archived this</> };
+    if (e.archived === 0 || e.auto_archived === 0)
+      return { icon: Archive, body: <>unarchived this</> };
+    return null;
+  },
+  // Auto-closed.
+  (e) => (e.auto_closed === 1 ? { icon: XCircle, body: <>auto-closed this</> } : null),
+  // Trashed (1 trashed, 0 restored).
+  (e) => {
+    if (e.trashed === 1) return { icon: Trash2, body: <>moved this to trash</> };
+    if (e.trashed === 0) return { icon: Trash2, body: <>restored this from trash</> };
+    return null;
+  },
+  // Description edited.
+  (e) =>
+    e.updated_description === 1 ? { icon: FileText, body: <>edited the description</> } : null,
+];
+
+/** The matching describer for an event, or null when it touched nothing we
+ *  describe (a bare event — e.g. the creation row, which the timeline labels
+ *  separately). Pure; exported for tests. */
+export function describeOrNull(event: TicketActivityEvent): Descriptor | null {
+  for (const d of DESCRIBERS) {
+    const hit = d(event);
+    if (hit) return hit;
+  }
+  return null;
+}
+
+function describe(event: TicketActivityEvent): Descriptor {
+  return describeOrNull(event) ?? { icon: Dot, body: <>updated this issue</> };
+}
+
+// ── Comment card ─────────────────────────────────────────────────────────────
+/** Up to two initials from an author name (e.g. "Ada Lovelace" → "AL"). Exported
+ *  for tests. */
+export function initialsOf(name: string | null): string {
+  if (!name) return "?";
+  const parts = name.trim().split(/\s+/).filter(Boolean);
+  if (parts.length === 0) return "?";
+  const first = parts[0]![0] ?? "";
+  const last = parts.length > 1 ? (parts[parts.length - 1]![0] ?? "") : "";
+  return (first + last).toUpperCase() || "?";
+}
+
+/** The 24px author mark — an initials circle, or a Bot glyph for an agent author.
+ *  Replaces the source's shadcn Avatar (adaptation 3); the border is what gives it
+ *  definition against the card's own bg-surface-2. */
+function AuthorMark({ name, isBot }: { name: string | null; isBot: boolean }) {
+  return (
+    <span
+      aria-hidden
+      className="flex size-6 shrink-0 items-center justify-center rounded-full border border-border bg-surface-2 text-[10px] font-medium text-muted"
+    >
+      {isBot ? <Bot className="size-3.5" /> : initialsOf(name)}
+    </span>
+  );
+}
+
+/** A single rendered comment — a bordered, elevated card (bg-surface-2 +
+ *  shadow-card) with the author header above the markdown body, so it is visually
+ *  distinct from the recessive single-line activity rows. An agent (`is_bot`)
+ *  comment carries a muted "· agent" marker. The body goes through the same
+ *  sanitizing path as the ticket description, so nothing reaches the DOM
+ *  unsanitized. */
+function CommentItem({ comment, now }: { comment: TicketComment; now: number }) {
+  const when = fmtRelativeDuration(now - comment.updated_at);
+  const name = comment.author_name ?? UNKNOWN_AUTHOR;
+  const isBot = Boolean(comment.is_bot);
+  return (
+    <li
+      data-ticket-comment={comment.id}
+      data-comment-agent={isBot ? "true" : undefined}
+      className="flex flex-col gap-2 rounded-lg border border-border bg-surface-2 px-3.5 py-3 shadow-card"
+    >
+      <div data-ticket-comment-header className="flex items-center gap-2">
+        <AuthorMark name={comment.author_name} isBot={isBot} />
+        <span className="text-[12px] font-medium text-fg">{name}</span>
+        {isBot && <span className="font-mono text-[11px] text-muted">· agent</span>}
+        {when && (
+          <span className="font-mono text-[11px] text-fg-dim" title={String(comment.updated_at)}>
+            · {when}
+          </span>
+        )}
+      </div>
+      {comment.body ? (
+        <div
+          data-ticket-comment-body
+          className="ticket-desc prose prose-invert"
+          dangerouslySetInnerHTML={{ __html: renderTicketDescriptionHtml(comment.body) }}
+        />
+      ) : (
+        <div className="font-mono text-[12px] text-muted">(empty comment)</div>
+      )}
+    </li>
+  );
+}
+
+// ── Rows ─────────────────────────────────────────────────────────────────────
+/** One recessive activity event line. Lighter than a comment card by design
+ *  (metadata, not prose). `isCreation` renders "created this issue" instead of the
+ *  per-property description. */
+function ActivityRow({
+  event,
+  isCreation,
+  now,
+}: {
+  event: TicketActivityEvent;
+  isCreation?: boolean;
+  now: number;
+}) {
+  const desc: Descriptor = isCreation
+    ? { icon: CirclePlus, body: <>created this issue</> }
+    : describe(event);
+  const { icon: Icon, body, dot } = desc;
+  const actorName = event.actor_name ?? UNKNOWN_ACTOR;
+  const when = fmtRelativeDuration(now - event.created_at);
+  const iso = new Date(event.created_at).toISOString();
+  return (
+    <li
+      data-ticket-activity
+      className="flex items-center gap-2 py-0.5 text-[12px] leading-snug text-muted"
+    >
+      {/* No avatar on activity rows (Linear-style): just the leading glyph + actor
+          name, kept tight. State transitions show the destination state's color
+          dot; everything else a verb icon. */}
+      {dot ? (
+        <span aria-hidden className="flex size-3.5 shrink-0 items-center justify-center">
+          <span className="size-2 rounded-full" style={{ background: dot }} />
+        </span>
+      ) : (
+        <Icon aria-hidden className="size-3.5 shrink-0 text-fg-dim" />
+      )}
+      <span className="min-w-0 truncate">
+        <span className="text-fg">{actorName}</span> {body}
+      </span>
+      <span className="flex-1" />
+      {when && (
+        <time className="shrink-0 font-mono text-[11px] text-fg-dim" dateTime={iso} title={iso}>
+          {when}
+        </time>
+      )}
+    </li>
+  );
+}
+
+/** A collapsed run of same-actor events — keeps a noisy history from drowning the
+ *  discussion. */
+function ActivityBurst({ node, now }: { node: BurstNode; now: number }) {
+  const [open, setOpen] = useState(false);
+  return (
+    <li data-ticket-activity-burst className="flex flex-col gap-1">
+      <button
+        type="button"
+        aria-expanded={open}
+        onClick={() => setOpen((o) => !o)}
+        className="inline-flex items-center gap-1.5 self-start text-left text-[12px] text-fg-dim hover:text-muted"
+      >
+        <ChevronRight
+          aria-hidden
+          className={cn("size-3.5 transition-transform", open && "rotate-90")}
+        />
+        <span>
+          <span className="text-fg">{node.actorName}</span> made {node.events.length} changes
+        </span>
+      </button>
+      {open && (
+        <ol className="flex flex-col gap-0.5 pl-5">
+          {node.events.map((e) => (
+            <ActivityRow key={e.id} event={e} now={now} />
+          ))}
+        </ol>
+      )}
+    </li>
+  );
+}
+
+// ── Section ──────────────────────────────────────────────────────────────────
+/**
+ * The interleaved activity + comment timeline.
+ *
+ * `loaded` false holds a skeleton line so nothing below jumps. `available` false
+ * means the replica could not be read (or the ticket is not mirrored) — that is
+ * reported as its OWN state rather than as "no discussion", because claiming
+ * emptiness about a source we never reached would be a fabrication.
+ *
+ * `limit` renders only the newest N nodes with a "Show all N" toggle — the inbox
+ * reading pane uses it to keep the conversation near the respond verb without
+ * pushing it off-screen; the ticket page passes no limit and shows everything.
+ */
+export function TicketTimeline({
+  comments,
+  activity,
+  loaded,
+  available = true,
+  now = Date.now(),
+  limit,
+}: {
+  comments: TicketComment[];
+  activity: TicketActivityEvent[];
+  loaded: boolean;
+  available?: boolean;
+  now?: number;
+  limit?: number;
+}) {
+  const [showAll, setShowAll] = useState(false);
+
+  if (!loaded) {
+    return (
+      <div data-ticket-timeline-skeleton className="font-mono text-[12px] text-fg-dim">
+        Loading discussion…
+      </div>
+    );
+  }
+
+  if (!available) {
+    return (
+      <div data-ticket-timeline-unavailable className="font-mono text-[12px] text-muted">
+        Linear discussion unavailable — the local replica could not be read.
+      </div>
+    );
+  }
+
+  const nodes = buildTimeline(comments, activity);
+  if (nodes.length === 0) {
+    return (
+      <div data-ticket-timeline-empty className="font-mono text-[12px] text-muted">
+        No Linear discussion yet.
+      </div>
+    );
+  }
+
+  // Collapsed view keeps the NEWEST nodes (the stream is oldest-first).
+  const collapsed = limit != null && !showAll && nodes.length > limit;
+  const shown = collapsed ? nodes.slice(-limit) : nodes;
+
+  return (
+    <div data-ticket-timeline>
+      {collapsed && (
+        <button
+          type="button"
+          data-ticket-timeline-show-all
+          onClick={() => setShowAll(true)}
+          className="mb-2 text-[11px] text-muted underline-offset-2 hover:text-fg hover:underline"
+        >
+          Show all {nodes.length}
+        </button>
+      )}
+      <ol className="flex flex-col gap-3">
+        {shown.map((node) => {
+          if (node.kind === "comment") {
+            return <CommentItem key={`c-${node.comment.id}`} comment={node.comment} now={now} />;
+          }
+          if (node.kind === "burst") {
+            return <ActivityBurst key={`b-${node.events[0]!.id}`} node={node} now={now} />;
+          }
+          return (
+            <ActivityRow
+              key={`e-${node.event.id}`}
+              event={node.event}
+              isCreation={node.isCreation}
+              now={now}
+            />
+          );
+        })}
+      </ol>
+    </div>
+  );
+}

--- a/plugins/dev/scripts/orch-monitor/ui/src/hooks/use-ticket-discussion.ts
+++ b/plugins/dev/scripts/orch-monitor/ui/src/hooks/use-ticket-discussion.ts
@@ -27,6 +27,8 @@ export interface TicketDiscussionState {
   available: boolean;
   comments: TicketComment[];
   activity: TicketActivityEvent[];
+  /** Issue creation instant (ms epoch) — gates the "created this issue" label. */
+  createdAt: number | null;
   loading: boolean;
   /** The transport/read failure reason, or null. */
   error: string | null;
@@ -36,6 +38,7 @@ const IDLE: TicketDiscussionState = {
   available: false,
   comments: [],
   activity: [],
+  createdAt: null,
   loading: false,
   error: null,
 };
@@ -66,6 +69,7 @@ export function useTicketDiscussion(id: string | undefined): TicketDiscussionSta
           available: Boolean(body?.available),
           comments: Array.isArray(body?.comments) ? body.comments : [],
           activity: Array.isArray(body?.activity) ? body.activity : [],
+          createdAt: typeof body?.createdAt === "number" ? body.createdAt : null,
           loading: false,
           error: null,
         });

--- a/plugins/dev/scripts/orch-monitor/ui/src/hooks/use-ticket-discussion.ts
+++ b/plugins/dev/scripts/orch-monitor/ui/src/hooks/use-ticket-discussion.ts
@@ -1,0 +1,86 @@
+// use-ticket-discussion.ts — fetch a ticket's Linear DISCUSSION (comments +
+// issue_history activity) from /api/ticket-discussion/<id> (CTL-1574).
+//
+// One fetch on mount and on every id change; NO polling. The discussion is a
+// reading surface, not a live signal — the operator re-opens the ticket (or
+// re-selects the row) to see newer turns, and a poll here would multiply replica
+// reads across every open pane for content that changes on human timescales.
+//
+// Fail-open, mirroring use-linear-ticket.ts: any transport error resolves to
+// `available:false` with empty arrays and `loading:false`, so the surface renders
+// the honest "unavailable" line instead of hanging on a spinner. `available` is
+// carried through from the server so the UI can tell "the replica could not be
+// read" from "this ticket genuinely has no discussion" — the two must never render
+// the same, or we would be claiming emptiness about a source we never reached.
+
+import { useEffect, useState } from "react";
+import type {
+  TicketActivityEvent,
+  TicketComment,
+  TicketDiscussion,
+} from "../../../lib/ticket-discussion-reader.mjs";
+
+export type { TicketActivityEvent, TicketComment, TicketDiscussion };
+
+export interface TicketDiscussionState {
+  /** false when the replica could not be read OR the ticket is not mirrored. */
+  available: boolean;
+  comments: TicketComment[];
+  activity: TicketActivityEvent[];
+  loading: boolean;
+  /** The transport/read failure reason, or null. */
+  error: string | null;
+}
+
+const IDLE: TicketDiscussionState = {
+  available: false,
+  comments: [],
+  activity: [],
+  loading: false,
+  error: null,
+};
+
+export function useTicketDiscussion(id: string | undefined): TicketDiscussionState {
+  const [state, setState] = useState<TicketDiscussionState>(
+    id ? { ...IDLE, loading: true } : IDLE,
+  );
+
+  useEffect(() => {
+    if (!id) {
+      setState(IDLE);
+      return;
+    }
+    // `stop` guards against a late response for a ticket we have navigated away
+    // from overwriting the current selection's state (the same cleanup idiom as
+    // useLinearTicket).
+    let stop = false;
+    setState({ ...IDLE, loading: true });
+    fetch(`/api/ticket-discussion/${encodeURIComponent(id)}`)
+      .then(async (r) => {
+        if (!r.ok) throw new Error(`HTTP ${r.status}`);
+        return (await r.json()) as TicketDiscussion;
+      })
+      .then((body) => {
+        if (stop) return;
+        setState({
+          available: Boolean(body?.available),
+          comments: Array.isArray(body?.comments) ? body.comments : [],
+          activity: Array.isArray(body?.activity) ? body.activity : [],
+          loading: false,
+          error: null,
+        });
+      })
+      .catch((e: unknown) => {
+        if (stop) return;
+        setState({
+          ...IDLE,
+          error: e instanceof Error ? e.message : String(e),
+        });
+      });
+    return () => {
+      stop = true;
+    };
+  }, [id]);
+
+  return state;
+}


### PR DESCRIPTION
## Summary

Ports catalyst-cloud's ticket ACTIVITY timeline into orch-monitor so operators can reply to workers with full context: an interleaved stream of Linear comment cards (author, agent/human badge, sanitized markdown body, avatar) and recessive state-change rows (state-dot transitions, label add/remove, actor bursts), read from the local Linear replica — zero live Linear API calls.

Surfaces:
- **Ticket detail page** — new `Discussion` tab section (the name "Activity" was taken by the execution event stream): full timeline plus a "N comments · M changes" count line.
- **Inbox reading pane** — a Discussion section after About, collapsed to the newest 5 entries with "Show all N", keeping the conversation next to the reply composer.

## How

- `lib/ticket-discussion-reader.mjs` — server-side reader over `@catalyst-cloud/read-model`'s `buildIssueDetail` (parameterized SQL, identifier regex-gated, never throws; every failure → honest `available:false`, never a fabricated empty discussion). Endpoint `/api/ticket-discussion/:id` mirrors the neighboring `ticket-artifacts` route.
- `ui/src/components/ticket-discussion.tsx` — line-for-line port of catalyst-cloud's `buildTimeline`/`coalesceBursts`/describers (same tunables), adapted: no shadcn Avatar (plain img + initials fallback), `stateColorVar` widened for phase-contract state names, markdown through the existing DOMPurify pipeline.
- Bodies render via `renderTicketDescriptionHtml` (marked → DOMPurify → linkify) — same XSS posture as ticket descriptions.

Second commit addresses an internal adversarial port review (4 verified defects): missing `--color-fg-dim` theme mapping (dim text rendered at full foreground), a "created this issue" label that fabricated creation on late bare history rows (~1/6 of issues — now gated to a 5-minute window of the issue's `created_at`), "Show all" state leaking across inbox selections (keyed now), and transport failures misreported as replica failures.

## Testing

- `__tests__/ticket-discussion-reader.test.ts` — 7 tests: field resolution, ordering, unknown-ticket/malformed-identifier/missing-replica degradation (exact frozen shape).
- `ui/src/components/ticket-discussion.test.tsx` — 23 tests: interleave/tie ordering, burst coalescing, creation labeling incl. the new window guard, initials.
- Live-tested against the real replica (CTL-1574, CTL-1577, path-traversal identifiers) and a local server run.
- Gates: typecheck 0 errors, eslint clean, `vite build` OK (`text-fg-dim` verified present in the emitted CSS).

## Verification after deploy

Live-check mini-2:7400 — Discussion tab on a ticket with real comments (CTL-1384 has 8+) and the inbox pane section, both themes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Wte59hchAL4FjhHiCwSVS3