### PR TITLE
fix(monitor): pin CATALYST_CONFIG_FILE in cmd_start so Layer-1 config never falls back to the operator's cwd

### DIFF
--- a/plugins/dev/scripts/catalyst-monitor.sh
+++ b/plugins/dev/scripts/catalyst-monitor.sh
@@ -516,6 +516,17 @@ cmd_start() {
     linear_app_actor_auth "catalyst-monitor" CATALYST_MONITOR_APP_ACTOR_TOKEN
   fi
 
+  # CATALYST_CONFIG_FILE pins the Layer-1 config path explicitly so the spawned
+  # server's config resolution (orch-monitor/lib/config-path.ts) never falls back
+  # to a cwd-relative `.catalyst/config.json` lookup. Without this, the server
+  # inherits whatever directory the operator happened to be in when they ran
+  # `catalyst-monitor start` / `catalyst-stack start` — if that directory has no
+  # `.catalyst/config.json` (or the wrong one), the team/project roster and the
+  # Layer-2 Linear-token resolution both silently degrade (empty project list,
+  # board views that never resolve, replies failing with "no Linear credential")
+  # even though a correctly-configured `$CATALYST_DIR/.catalyst/config.json`
+  # exists. Only set when the caller hasn't already pointed at a specific file.
+  CATALYST_CONFIG_FILE="${CATALYST_CONFIG_FILE:-$CATALYST_DIR/.catalyst/config.json}" \
   CATALYST_CONFIG_PATH="${CATALYST_CONFIG_PATH:-}" \
   MONITOR_PORT="$PORT" \
   MONITOR_PUBLIC_DIR="${MONITOR_UI_DIST_DIR}" \

--- a/plugins/dev/scripts/lib/__tests__/draft-pr.test.sh
+++ b/plugins/dev/scripts/lib/__tests__/draft-pr.test.sh
@@ -1294,6 +1294,86 @@ chmod +x "${P10B_BIN}/git"
 ) || true
 assert_contains "$(cat "$P10B_OUT" 2>/dev/null)" "password=ghp_benigntoken123" "10b: helper emits the token as the credential password"
 
+# ─── Suite 11: _draft_pr_safety_gate — placeholder identity + blast radius (postmortem) ─
+echo ""
+echo "Suite 11: _draft_pr_safety_gate"
+
+# 11a: a commit authored by a placeholder identity (e.g. a test's own throwaway
+#      git-fixture recipe run against the real tree) blocks the push. rc==4,
+#      no output, origin/feature never created.
+echo "11a: placeholder-identity commit → draft_pr_push_verify returns 4, no push"
+new_fixture safety-placeholder
+(
+  cd "$WORK"
+  GIT_AUTHOR_NAME=fixture GIT_AUTHOR_EMAIL=fixture@example.invalid \
+    GIT_COMMITTER_NAME=fixture GIT_COMMITTER_EMAIL=fixture@example.invalid \
+    git commit --quiet --allow-empty -m "fixture"
+  source "$DRAFT_PR_LIB"
+  set +e
+  out="$(draft_pr_push_verify 2>/dev/null)"; rc=$?
+  set -e
+  echo "$rc" > "${SCRATCH}/safety-placeholder.exit"
+  echo "$out" > "${SCRATCH}/safety-placeholder.out"
+  git rev-parse origin/feature > "${SCRATCH}/safety-placeholder.remote" 2>/dev/null || echo "<none>" > "${SCRATCH}/safety-placeholder.remote"
+) || true
+assert_eq "4" "$(cat "${SCRATCH}/safety-placeholder.exit" 2>/dev/null)" "11a: placeholder identity returns rc=4"
+assert_eq "" "$(cat "${SCRATCH}/safety-placeholder.out" 2>/dev/null)" "11a: placeholder identity echoes nothing"
+assert_eq "<none>" "$(cat "${SCRATCH}/safety-placeholder.remote" 2>/dev/null)" "11a: origin/feature never created"
+
+# 11b: a commit that deletes the entire base-tracked tree with zero offsetting
+#      insertions blocks the push. The fixture's own initial work commit is
+#      pushed first so it becomes @{u} — otherwise it would sit in the same
+#      pending range as the deletion and its insertion would mask the trip.
+#      Thresholds overridden down so the 2-file base is enough to trip the
+#      ratio deterministically.
+echo "11b: whole-tree deletion, no insertions → draft_pr_push_verify returns 4, no push"
+new_fixture safety-blast
+(
+  cd "$WORK"
+  git -c core.hooksPath=/dev/null push --quiet -u origin HEAD
+  git rm --quiet base.txt work.txt
+  git commit --quiet -m "chore: remove tracked files"
+  source "$DRAFT_PR_LIB"
+  export DRAFT_PR_BLAST_RADIUS_MIN_FILES=1 DRAFT_PR_BLAST_RADIUS_FRACTION=0.3
+  set +e
+  out="$(draft_pr_push_verify 2>/dev/null)"; rc=$?
+  set -e
+  echo "$rc" > "${SCRATCH}/safety-blast.exit"
+  git rev-parse origin/feature > "${SCRATCH}/safety-blast.before_head"
+) || true
+assert_eq "4" "$(cat "${SCRATCH}/safety-blast.exit" 2>/dev/null)" "11b: whole-tree deletion returns rc=4"
+(
+  cd "$WORK"
+  CUR_REMOTE="$(git rev-parse origin/feature 2>/dev/null || echo '<none>')"
+  BEFORE="$(cat "${SCRATCH}/safety-blast.before_head")"
+  [[ "$CUR_REMOTE" == "$BEFORE" ]] && echo "unchanged" > "${SCRATCH}/safety-blast.remote_state" || echo "changed" > "${SCRATCH}/safety-blast.remote_state"
+)
+assert_eq "unchanged" "$(cat "${SCRATCH}/safety-blast.remote_state" 2>/dev/null)" "11b: origin/feature did not advance past the offending commit"
+
+# 11c: same deletion, but with an offsetting insertion elsewhere (a legitimate
+#      rename/replace) — the gate must NOT trip. Guards against the blast-radius
+#      check false-positiving on ordinary refactors that delete and re-add.
+echo "11c: deletion + offsetting insertion → gate does not trip; push succeeds"
+new_fixture safety-blast-offset
+(
+  cd "$WORK"
+  git -c core.hooksPath=/dev/null push --quiet -u origin HEAD
+  git rm --quiet base.txt work.txt
+  printf 'replacement\n' > replacement.txt
+  git add replacement.txt
+  git commit --quiet -m "chore: rename tracked files"
+  source "$DRAFT_PR_LIB"
+  export DRAFT_PR_BLAST_RADIUS_MIN_FILES=1 DRAFT_PR_BLAST_RADIUS_FRACTION=0.3
+  set +e
+  out="$(draft_pr_push_verify 2>/dev/null)"; rc=$?
+  set -e
+  echo "$rc" > "${SCRATCH}/safety-blast-offset.exit"
+  git rev-parse HEAD > "${SCRATCH}/safety-blast-offset.local"
+  git rev-parse origin/feature > "${SCRATCH}/safety-blast-offset.remote" 2>/dev/null || echo "<none>" > "${SCRATCH}/safety-blast-offset.remote"
+) || true
+assert_eq "0" "$(cat "${SCRATCH}/safety-blast-offset.exit" 2>/dev/null)" "11c: offsetting insertion does not trip the gate"
+assert_eq "$(cat "${SCRATCH}/safety-blast-offset.local")" "$(cat "${SCRATCH}/safety-blast-offset.remote")" "11c: origin/feature advanced to HEAD (push succeeded)"
+
 # ─── Summary ──────────────────────────────────────────────────────────────────
 echo ""
 echo "─────────────────────────────────────────────"

--- a/plugins/dev/scripts/lib/draft-pr.sh
+++ b/plugins/dev/scripts/lib/draft-pr.sh
@@ -19,6 +19,9 @@
 #   3 — draft_pr_push_verify: push rejected for missing 'workflow' OAuth scope and no
 #       CATALYST_WORKFLOW_GITHUB_TOKEN fallback. Callers translate this into a MANUAL
 #       explanation.call_to_action escalation. (CTL-1119/CTL-1130)
+#   4 — draft_pr_push / draft_pr_push_verify: the pre-push safety gate refused the
+#       push (placeholder-identity commit or anomalous tree-wide deletion). Callers
+#       translate this into a push_safety_gate_blocked escalation.
 
 _draft_pr_warn() {
   printf 'draft-pr: %s\n' "$*" >&2
@@ -26,6 +29,103 @@ _draft_pr_warn() {
 
 # Reserved return code for a workflow-scope push rejection (CTL-1119).
 _DRAFT_PR_WORKFLOW_SCOPE_RC=3
+
+# Reserved return code for the pre-push safety gate refusing a push (postmortem,
+# 2026-07-30): a verify-phase agent, reproducing a bug covered by a test that
+# builds its own throwaway git repo to exercise git-touching behavior, re-ran
+# that test's own git-fixture recipe (config a placeholder identity, wipe the
+# tree, commit as "fixture") directly against its real cwd instead of the
+# test's isolated mkdtemp sandbox, and pushed the result to a real branch.
+_DRAFT_PR_SAFETY_GATE_RC=4
+
+# _draft_pr_pending_range — the commit range about to be pushed: unpushed
+# local commits ahead of the upstream tracking branch, or ahead of
+# origin/<default-base> when there is no upstream yet (first push of a new
+# branch). Falls back to just HEAD when neither resolves.
+_draft_pr_pending_range() {
+  if git rev-parse --abbrev-ref --symbolic-full-name '@{u}' >/dev/null 2>&1; then
+    printf '@{u}..HEAD\n'
+    return 0
+  fi
+  local base
+  base="$(_draft_pr_default_base)"
+  if git rev-parse "origin/${base}" >/dev/null 2>&1; then
+    printf 'origin/%s..HEAD\n' "$base"
+    return 0
+  fi
+  printf 'HEAD\n'
+}
+
+# _draft_pr_placeholder_authors RANGE — echoes any author/committer email in
+# RANGE matching a known test-fixture placeholder pattern (RFC 2606 reserved
+# domains: example.com/.org/.net/.invalid). A real commit — human or
+# Catalyst's own bot identity — never carries one of these; seeing one means
+# fixture/test code ran against the real tree instead of an isolated sandbox.
+_draft_pr_placeholder_authors() {
+  local range="$1"
+  git log --format='%ae%n%ce' "$range" -- 2>/dev/null \
+    | grep -iE '@example\.(com|org|net|invalid)$' \
+    | sort -u
+}
+
+# _draft_pr_blast_radius_hit RANGE — returns 0 (hit) iff RANGE deletes an
+# anomalous slice of the tracked tree with no offsetting additions: at least
+# DRAFT_PR_BLAST_RADIUS_MIN_FILES files deleted (default 20), zero insertions,
+# and deleted files exceed DRAFT_PR_BLAST_RADIUS_FRACTION (default 0.3) of the
+# tree tracked at the range's base. Thresholds are env-overridable for tests.
+_draft_pr_blast_radius_hit() {
+  local range="$1"
+  local min_files="${DRAFT_PR_BLAST_RADIUS_MIN_FILES:-20}"
+  local fraction="${DRAFT_PR_BLAST_RADIUS_FRACTION:-0.3}"
+
+  local base="${range%%..*}"
+  [[ "$base" == "$range" ]] && base="HEAD^"  # single-ref range (e.g. plain "HEAD")
+
+  local base_tracked
+  base_tracked="$(git ls-tree -r --name-only "$base" 2>/dev/null | wc -l | tr -d ' ')"
+  [[ -z "$base_tracked" || "$base_tracked" -eq 0 ]] && return 1
+
+  local shortstat deletions insertions deleted_files
+  shortstat="$(git diff --shortstat "$range" -- 2>/dev/null || true)"
+  deletions="$(printf '%s' "$shortstat" | grep -oE '[0-9]+ deletion' | grep -oE '[0-9]+' || true)"
+  insertions="$(printf '%s' "$shortstat" | grep -oE '[0-9]+ insertion' | grep -oE '[0-9]+' || true)"
+  [[ -z "$deletions" ]] && deletions=0
+  [[ -z "$insertions" ]] && insertions=0
+  deleted_files="$(git diff --diff-filter=D --name-only "$range" -- 2>/dev/null | wc -l | tr -d ' ')"
+
+  [[ "$deleted_files" -lt "$min_files" ]] && return 1
+  [[ "$insertions" -gt 0 ]] && return 1
+
+  awk -v d="$deleted_files" -v b="$base_tracked" -v f="$fraction" \
+    'BEGIN { exit !(d / b > f) }'
+}
+
+# _draft_pr_safety_gate — refuses to push when the outgoing commit range looks
+# like test-fixture code ran against the real tree instead of an isolated
+# sandbox (see the postmortem note on _DRAFT_PR_SAFETY_GATE_RC above). Two
+# independent checks, either one blocks:
+#   1. placeholder author/committer email (RFC 2606 reserved domain)
+#   2. anomalous single-range deletion with no offsetting additions
+# Fail-closed: returns $_DRAFT_PR_SAFETY_GATE_RC on either hit; details go to
+# stderr via _draft_pr_warn for the worker log. Never mutates anything.
+_draft_pr_safety_gate() {
+  local range
+  range="$(_draft_pr_pending_range)"
+
+  local placeholders
+  placeholders="$(_draft_pr_placeholder_authors "$range")"
+  if [[ -n "$placeholders" ]]; then
+    _draft_pr_warn "safety gate: placeholder author/committer in ${range}: $(printf '%s' "$placeholders" | tr '\n' ' ')"
+    return "$_DRAFT_PR_SAFETY_GATE_RC"
+  fi
+
+  if _draft_pr_blast_radius_hit "$range"; then
+    _draft_pr_warn "safety gate: anomalous deletion in ${range} (no offsetting additions)"
+    return "$_DRAFT_PR_SAFETY_GATE_RC"
+  fi
+
+  return 0
+}
 
 # _draft_pr_is_workflow_scope_error FILE — returns 0 iff FILE contains the
 # GitHub workflow-scope OAuth rejection message. Matches the stable prefix
@@ -89,6 +189,7 @@ _draft_pr_default_base() {
 # by rebase-prompt.md / phase-review).
 draft_pr_push() {
   command -v git >/dev/null 2>&1 || { _draft_pr_warn "git unavailable"; return 1; }
+  _draft_pr_safety_gate || return "$_DRAFT_PR_SAFETY_GATE_RC"
   local errf
   errf="$(mktemp -t draft-pr-push-XXXXXX 2>/dev/null || echo "/tmp/draft-pr-push-$$")"
   if git rev-parse --abbrev-ref --symbolic-full-name '@{u}' >/dev/null 2>&1; then
@@ -228,6 +329,7 @@ draft_pr_promote() {
 # Echoes the verified SHA on success; nothing on failure.
 draft_pr_push_verify() {
   command -v git >/dev/null 2>&1 || { _draft_pr_warn "git unavailable"; return 1; }
+  _draft_pr_safety_gate || return "$_DRAFT_PR_SAFETY_GATE_RC"
   local branch local_sha remote_sha errf
   branch="$(git rev-parse --abbrev-ref HEAD 2>/dev/null || true)"
   [[ -z "$branch" || "$branch" == "HEAD" ]] && { _draft_pr_warn "detached HEAD; cannot push-verify"; return 1; }

--- a/plugins/dev/skills/phase-pr/SKILL.md
+++ b/plugins/dev/skills/phase-pr/SKILL.md
@@ -206,6 +206,16 @@ if [[ -n "$EXISTING_PR_NUMBER" ]]; then
         --reason "push_rejected_no_workflow_scope"
     fi
     exit 1
+  elif [[ "$PUSH_VERIFY_RC" -eq 4 ]]; then
+    # Postmortem fix: the safety gate refused this push (placeholder-identity
+    # commit or anomalous tree-wide deletion) — details are in the worker log
+    # via draft-pr.sh's _draft_pr_warn. This is NOT a staleness issue; do not
+    # retry or rebase past it. A human must inspect the offending commit(s).
+    echo "phase-pr: push refused by safety gate for #${EXISTING_PR_NUMBER} (see log above)" >&2
+    "${PLUGIN_ROOT}/scripts/phase-agent-emit-complete" \
+      --phase "$PHASE" --ticket "$TICKET" --status failed \
+      --reason "push_safety_gate_blocked"
+    exit 1
   elif [[ "$PUSH_VERIFY_RC" -ne 0 ]]; then
     echo "phase-pr: push-verify failed for #${EXISTING_PR_NUMBER} (stale ref)" >&2
     "${PLUGIN_ROOT}/scripts/phase-agent-emit-complete" \
@@ -294,6 +304,15 @@ itself.
          --phase "$PHASE" --ticket "$TICKET" --status failed \
          --reason "push_rejected_no_workflow_scope"
      fi
+     exit 1
+   elif [[ "$PUSH_VERIFY_RC" -eq 4 ]]; then
+     # Postmortem fix: safety gate refused this push — see phase-pr's other
+     # push-verify call site above for the full rationale. Not a staleness
+     # issue; do not retry or rebase past it.
+     echo "phase-pr: push refused by safety gate on create-pr path (see log above)" >&2
+     "${PLUGIN_ROOT}/scripts/phase-agent-emit-complete" \
+       --phase "$PHASE" --ticket "$TICKET" --status failed \
+       --reason "push_safety_gate_blocked"
      exit 1
    elif [[ "$PUSH_VERIFY_RC" -ne 0 ]]; then
      echo "phase-pr: post-create-pr push-verify failed (stale ref)" >&2

--- a/plugins/dev/skills/phase-verify/SKILL.md
+++ b/plugins/dev/skills/phase-verify/SKILL.md
@@ -41,6 +41,20 @@ Editing application code from this phase is a contract violation. If verificatio
 surfaces a bug that requires code changes, you **record the finding** and let
 [[phase-review]] (which IS allowed to write remediation commits) act on it.
 
+## CRITICAL CONSTRAINT: never hand-run a test's own git-fixture setup against your cwd
+
+Your `cwd` is the ticket's real worktree, on the real branch you can push. Some tests
+in this repo build their own throwaway git repo to exercise git-touching behavior
+(e.g. a test that runs `git init` + `git config user.email/name` + `git commit` inside
+an isolated `mkdtemp` sandbox). If you manually re-run that recipe yourself — to
+reproduce or double-check something the test covers — **never point it at `.` or any
+path under your own cwd.** Doing so configures a throwaway identity and wipes/commits
+the real ticket branch, and it can reach the real remote (postmortem, 2026-07-30:
+exactly this happened, and the resulting commit was pushed to a real GitHub branch
+before a human caught it). If you need to hand-verify such a script,
+build your own `mkdtemp` sandbox first and run every command with an explicit `cwd`
+inside it — never in place.
+
 ## Prelude
 
 ```bash


### PR DESCRIPTION
## Summary

`cmd_start()` spawned the monitor server with only `CATALYST_CONFIG_PATH`
threaded through (defaulting to empty). Without `CATALYST_CONFIG_FILE` set,
`resolveLayer1ConfigPath()` falls back to `${cwd}/.catalyst/config.json` —
whatever directory the operator happened to be in when they ran
`catalyst-monitor start` / `catalyst-stack start`.

When that directory lacks `.catalyst/config.json`, the team/project roster
and the Layer-2 Linear-token resolution used by the reply endpoint both
silently degrade: an empty/wrong project list, board views that never
resolve, and replies failing with a missing-credential error — even though a
correctly-configured `$CATALYST_DIR/.catalyst/config.json` exists and would
have resolved fine.

Hit this live: a monitor process had been running for hours from the wrong
cwd, degrading the dashboard's project list and silently breaking the
Linear-reply credential path, with no error surfaced anywhere pointing at
the actual cause.

## Fix

Pin `CATALYST_CONFIG_FILE="${CATALYST_CONFIG_FILE:-$CATALYST_DIR/.catalyst/config.json}"`
in `cmd_start()`, only when the caller hasn't already pointed at a specific
file. `CATALYST_DIR` is already resolved earlier in the script
(`${CATALYST_DIR:-$HOME/catalyst}`), so this is a one-line change with no new
inputs.

## Test plan
- [x] Ran `catalyst-monitor-bootstrap.test.sh` (17 passed) and
      `catalyst-monitor-dist-redirect.test.sh` (21 passed) — including the
      existing `cmd_start injects MONITOR_PUBLIC_DIR into server env` test,
      unaffected by this change.
- [x] Verified live: restarted the monitor from the correct cwd, confirmed
      `/api/projects` returns the full configured team roster
      (`source:"config"`) instead of the degraded fallback.