### PR TITLE
fix(dev): CTL-1580 stop per-tick live probes of stuck tickets; instrument the invisible reads

### DIFF
--- a/plugins/dev/scripts/execution-core/linear-query.mjs
+++ b/plugins/dev/scripts/execution-core/linear-query.mjs
@@ -777,15 +777,12 @@ export function classifyTicketResolution(
     timeoutMs: LINEARIS_TERMINAL_READ_TIMEOUT_MS,
   });
   // CTL-1580 + CTL-1403: this path was named-but-uninstrumented — every live
-  // classify now lands in catalyst.linear.read (op=classify_resolution).
-  recordDaemonRead(
-    replica ? "linearis_miss" : "linearis",
-    code !== 0 ? "failed" : "ok",
-    identifier,
-    null,
-    "classify_resolution"
-  );
+  // classify now lands in catalyst.linear.read (op=classify_resolution). "ok"
+  // is recorded only AFTER a successful parse (Codex round 2): an exit-0
+  // garbage body is a failed read, not a healthy one.
+  const classifySrc = replica ? "linearis_miss" : "linearis";
   if (code !== 0) {
+    recordDaemonRead(classifySrc, "failed", identifier, null, "classify_resolution");
     // CTL-1504: the CLI now exits 1 for a genuinely-missing ticket, with the
     // not-found body on stderr. A definitive not-found is the ONLY nonzero that
     // may quarantine; every other nonzero (429/network/auth/timeout/invalid-format)
@@ -796,8 +793,10 @@ export function classifyTicketResolution(
   try {
     node = JSON.parse(stdout);
   } catch {
+    recordDaemonRead(classifySrc, "failed", identifier, null, "classify_resolution");
     return "unknown"; // unparseable — fail safe, re-check next tick
   }
+  recordDaemonRead(classifySrc, "ok", identifier, null, "classify_resolution");
   if (node == null) return "not-found";
   // The real missing-ticket shape: exit 0 + { error: "...not found" }. Only a
   // "not found" error is definitive; any other error body is transient.

--- a/plugins/dev/scripts/execution-core/linear-query.mjs
+++ b/plugins/dev/scripts/execution-core/linear-query.mjs
@@ -263,12 +263,12 @@ const GATEWAY_STATE_FRESH_MS = 60_000;
 // and the batch reads — are NOT yet instrumented, so catalyst_linear_read_total
 // undercounts those lower-frequency direct-read contexts. Tracked as a follow-up
 // (extend recordDaemonRead to those call sites) rather than expanded here.
-function recordDaemonRead(source, result, identifier, ageMs = null) {
+function recordDaemonRead(source, result, identifier, ageMs = null, op = "read_ticket") {
   try {
     emitLinearReadEvent({
       source,
       result,
-      op: "read_ticket",
+      op,
       entity: identifier,
       ageMs,
       serviceName: "catalyst.execution-core",
@@ -737,7 +737,7 @@ export function readTicketLabelNodes(identifier, { exec = defaultExec } = {}) {
 // retained for back-compat with any deployment still on the 2026-05-27 contract.
 export function classifyTicketResolution(
   identifier,
-  { exec = defaultExec, gateway, gatewayFreshMs = GATEWAY_EXISTS_FRESH_MS } = {}
+  { exec = defaultExec, gateway, replica, gatewayFreshMs = GATEWAY_EXISTS_FRESH_MS } = {}
 ) {
   // CTL-823: serve ONLY the cheap not-quarantine verdict from the durable
   // store — a fresh, present, not-removed descriptor proves existence.
@@ -748,12 +748,35 @@ export function classifyTicketResolution(
     const d = gateway.getDescriptor(identifier);
     if (d && !d.removed && descriptorAgeMs(d) <= gatewayFreshMs) return "exists";
   }
+  // CTL-1580: replica tier (mirrors fetchTicketState's CTL-1340 tier). A
+  // present, non-tombstoned replica row proves existence — the SAFE direction
+  // (it can only PREVENT quarantine). A removed/absent row reads as MISS
+  // (lookup → undefined) and falls through, so a true deletion still pays the
+  // definitive live read below. No `replica` → skipped (byte-identical).
+  // This matters for QUIET stuck tickets: their gateway descriptor ages out
+  // permanently (no webhooks refresh it), which made every Pass 0a tick a live
+  // read (the OTL-52 burn).
+  if (replica) {
+    if (replica.lookup(identifier) !== undefined) {
+      recordDaemonRead("replica", "ok", identifier, null, "classify_resolution");
+      return "exists";
+    }
+  }
   // CTL-1339: hot per-signal terminal read (phantom-sweep) — cap the wall-clock
   // so a 429-stalled linearis can't block the synchronous tick. A timed-out read
   // fails SAFE via the code-127 → "unknown" branch (never a false quarantine).
   const { code, stdout, stderr } = exec("linearis", ["issues", "read", identifier], {
     timeoutMs: LINEARIS_TERMINAL_READ_TIMEOUT_MS,
   });
+  // CTL-1580 + CTL-1403: this path was named-but-uninstrumented — every live
+  // classify now lands in catalyst.linear.read (op=classify_resolution).
+  recordDaemonRead(
+    replica ? "linearis_miss" : "linearis",
+    code !== 0 ? "failed" : "ok",
+    identifier,
+    null,
+    "classify_resolution"
+  );
   if (code !== 0) {
     // CTL-1504: the CLI now exits 1 for a genuinely-missing ticket, with the
     // not-found body on stderr. A definitive not-found is the ONLY nonzero that
@@ -1132,6 +1155,7 @@ export function runEligibleQuery(
       // populated delegate, so no GraphQL batch is needed).
       if (tickets.length > 0) {
         onSource?.("replica", tickets.length);
+        recordDaemonRead("replica", "ok", query.team, null, "eligible_list"); // CTL-1580
         return tickets;
       }
       // CTL-1397 (3/n) — a SEED-COMPLETE replica-empty. The reader only returns a
@@ -1160,6 +1184,7 @@ export function runEligibleQuery(
       //     trusts an unconfirmed empty as authoritative during a storm).
       if (now() - (_eligibleEmptyConfirmAt.get(query.team) ?? 0) < reconfirmMs) {
         onSource?.("replica", 0);
+        recordDaemonRead("replica", "ok", query.team, null, "eligible_list"); // CTL-1580
         return tickets; // [] — a recently linearis-confirmed empty, trusted (breaker-immune)
       }
       // CTL-1420 (freeze-avoidance): when the CTL-679 breaker is OPEN, the
@@ -1215,6 +1240,18 @@ export function runEligibleQuery(
   // monitor.reconcile.failing alert — exactly the failure mode CTL-1339 designed
   // against. `{ uncapped: true }` opts this spawn out of the default floor.
   const { code, stdout, stderr } = exec("linearis", buildLinearisArgs(query), { uncapped: true });
+  // CTL-1580 + CTL-1403: the eligible-list live spawn was completely invisible
+  // to catalyst.linear.read (only the plain eligible_source log line saw it) —
+  // instrument every outcome so Loki accounts for this burn. Source taxonomy:
+  // replica tier present but fell through (MISS / unconfirmed empty) →
+  // linearis_miss; no replica tier at all → linearis.
+  recordDaemonRead(
+    replica?.eligible ? "linearis_miss" : "linearis",
+    code !== 0 ? "failed" : "ok",
+    query.team,
+    null,
+    "eligible_list"
+  );
   if (code !== 0) {
     throw new Error(`linearis issues list failed (exit ${code}): ${(stderr || "").trim()}`);
   }

--- a/plugins/dev/scripts/execution-core/linear-query.mjs
+++ b/plugins/dev/scripts/execution-core/linear-query.mjs
@@ -737,14 +737,19 @@ export function readTicketLabelNodes(identifier, { exec = defaultExec } = {}) {
 // retained for back-compat with any deployment still on the 2026-05-27 contract.
 export function classifyTicketResolution(
   identifier,
-  { exec = defaultExec, gateway, replica, gatewayFreshMs = GATEWAY_EXISTS_FRESH_MS } = {}
+  // bypassCaches (CTL-1580 round 6): a DUE live recheck must skip BOTH cached
+  // tiers. It is a dedicated flag — not the absence of gateway/replica —
+  // because production injection (daemon.mjs runTick) deliberately spreads
+  // `{ ...opts, gateway }` so callers cannot accidentally drop the reader; a
+  // flag survives that spread where option omission does not.
+  { exec = defaultExec, gateway, replica, gatewayFreshMs = GATEWAY_EXISTS_FRESH_MS, bypassCaches = false } = {}
 ) {
   // CTL-823: serve ONLY the cheap not-quarantine verdict from the durable
   // store — a fresh, present, not-removed descriptor proves existence.
   // removed/absent/stale NEVER short-circuit: quarantine is a destructive
   // write, so those verdicts always pay a fresh live read
   // (fresh-before-quarantine).
-  if (gateway) {
+  if (gateway && !bypassCaches) {
     const d = gateway.getDescriptor(identifier);
     if (d && !d.removed && descriptorAgeMs(d) <= gatewayFreshMs) return "exists";
   }
@@ -778,7 +783,7 @@ export function classifyTicketResolution(
       return false; // descriptor read is best-effort — never blocks the tier
     }
   })();
-  if (!freshGatewayTombstone && replica && typeof replica.isFresh === "function" && replica.isFresh()) {
+  if (!bypassCaches && !freshGatewayTombstone && replica && typeof replica.isFresh === "function" && replica.isFresh()) {
     if (replica.lookup(identifier) !== undefined) {
       recordDaemonRead("replica", "ok", identifier, null, "classify_resolution");
       return "exists";
@@ -1305,9 +1310,17 @@ export function runEligibleQuery(
     recordDaemonRead(liveListSource, "failed", null, null, "eligible_list");
     throw new Error(`linearis stdout is not JSON: ${err.message}`);
   }
+  // Structural validation (Codex round 6): an exit-0 body WITHOUT nodes[] (a
+  // parseable auth-error object, '{}') must not normalize to an EMPTY BOARD —
+  // that would set the empty-confirm marker and zero admission for the trust
+  // window. Reject + record failed; reconcileProject preserves the prior set.
+  if (!Array.isArray(parsed?.nodes)) {
+    recordDaemonRead(liveListSource, "failed", null, null, "eligible_list");
+    throw new Error("linearis issues list body lacks nodes[] — structurally invalid");
+  }
   let tickets;
   try {
-    tickets = (parsed.nodes ?? []).map(normalizeTicket);
+    tickets = parsed.nodes.map(normalizeTicket);
     // Priority is a floor: keep tickets whose priority is more-urgent-or-equal
     // (1=Urgent … 4=Low). 0 ("No priority") is always below any floor.
     if (query.priority != null) {

--- a/plugins/dev/scripts/execution-core/linear-query.mjs
+++ b/plugins/dev/scripts/execution-core/linear-query.mjs
@@ -764,7 +764,21 @@ export function classifyTicketResolution(
   // when the accessor is absent (an older reader object) — the tier stays
   // inert rather than trusting an ungated row; the Pass 0a probe cool-down
   // still bounds the live fallback to one read per window.
-  if (replica && typeof replica.isFresh === "function" && replica.isFresh()) {
+  // Gateway TOMBSTONE veto (Codex round 5): a fresh { removed: true }
+  // descriptor is webhook-observed evidence of deletion; when the same deletion
+  // failed to apply to the replica (the CTL-1402 drift class), the stale
+  // non-tombstoned row must not serve "exists" — skip the replica tier and pay
+  // the definitive live read below.
+  const freshGatewayTombstone = (() => {
+    if (!gateway) return false;
+    try {
+      const d = gateway.getDescriptor(identifier);
+      return Boolean(d && d.removed === true && descriptorAgeMs(d) <= gatewayFreshMs);
+    } catch {
+      return false; // descriptor read is best-effort — never blocks the tier
+    }
+  })();
+  if (!freshGatewayTombstone && replica && typeof replica.isFresh === "function" && replica.isFresh()) {
     if (replica.lookup(identifier) !== undefined) {
       recordDaemonRead("replica", "ok", identifier, null, "classify_resolution");
       return "exists";

--- a/plugins/dev/scripts/execution-core/linear-query.mjs
+++ b/plugins/dev/scripts/execution-core/linear-query.mjs
@@ -755,8 +755,16 @@ export function classifyTicketResolution(
   // definitive live read below. No `replica` → skipped (byte-identical).
   // This matters for QUIET stuck tickets: their gateway descriptor ages out
   // permanently (no webhooks refresh it), which made every Pass 0a tick a live
-  // read (the OTL-52 burn).
-  if (replica) {
+  // read (the PROJ-52 burn).
+  //
+  // FRESHNESS-GATED (Codex review): lookup() itself has no writer-liveness
+  // gate, so a DEAD replica writer's stale non-tombstoned row would otherwise
+  // suppress the definitive deletion check indefinitely. Gate on the reader's
+  // isFresh() (the .writer.lock heartbeat accessor, CTL-1571) and fail CLOSED
+  // when the accessor is absent (an older reader object) — the tier stays
+  // inert rather than trusting an ungated row; the Pass 0a probe cool-down
+  // still bounds the live fallback to one read per window.
+  if (replica && typeof replica.isFresh === "function" && replica.isFresh()) {
     if (replica.lookup(identifier) !== undefined) {
       recordDaemonRead("replica", "ok", identifier, null, "classify_resolution");
       return "exists";
@@ -1155,7 +1163,9 @@ export function runEligibleQuery(
       // populated delegate, so no GraphQL batch is needed).
       if (tickets.length > 0) {
         onSource?.("replica", tickets.length);
-        recordDaemonRead("replica", "ok", query.team, null, "eligible_list"); // CTL-1580
+        // CTL-1580: entity null — event.label is a single-ticket field by
+        // contract; list/search ops must omit it.
+        recordDaemonRead("replica", "ok", null, null, "eligible_list");
         return tickets;
       }
       // CTL-1397 (3/n) — a SEED-COMPLETE replica-empty. The reader only returns a
@@ -1184,7 +1194,7 @@ export function runEligibleQuery(
       //     trusts an unconfirmed empty as authoritative during a storm).
       if (now() - (_eligibleEmptyConfirmAt.get(query.team) ?? 0) < reconfirmMs) {
         onSource?.("replica", 0);
-        recordDaemonRead("replica", "ok", query.team, null, "eligible_list"); // CTL-1580
+        recordDaemonRead("replica", "ok", null, null, "eligible_list"); // CTL-1580
         return tickets; // [] — a recently linearis-confirmed empty, trusted (breaker-immune)
       }
       // CTL-1420 (freeze-avoidance): when the CTL-679 breaker is OPEN, the
@@ -1203,6 +1213,11 @@ export function runEligibleQuery(
       // only ever trusts a genuinely-empty board; real Todo work still dispatches.
       if (breakerIsOpen()) {
         onSource?.("replica-empty-breaker-open", 0);
+        // CTL-1580 (Codex review): this branch fires exactly during the
+        // quota-exhaustion condition the counters exist for — an unrecorded
+        // replica serve here would distort the replica-hit ratio when it
+        // matters most.
+        recordDaemonRead("replica", "ok", null, null, "eligible_list");
         return tickets; // [] — trusted under quota exhaustion (freeze-avoidance)
       }
       // No recent confirmation AND breaker closed → fall through to the linearis
@@ -1244,21 +1259,20 @@ export function runEligibleQuery(
   // to catalyst.linear.read (only the plain eligible_source log line saw it) —
   // instrument every outcome so Loki accounts for this burn. Source taxonomy:
   // replica tier present but fell through (MISS / unconfirmed empty) →
-  // linearis_miss; no replica tier at all → linearis.
-  recordDaemonRead(
-    replica?.eligible ? "linearis_miss" : "linearis",
-    code !== 0 ? "failed" : "ok",
-    query.team,
-    null,
-    "eligible_list"
-  );
+  // linearis_miss; no replica tier at all → linearis. Entity is null (the
+  // event.label field is single-ticket by contract; list ops omit it), and
+  // "ok" is recorded only AFTER a successful parse — an exit-0 garbage body is
+  // a failed read, not a healthy one.
+  const liveListSource = replica?.eligible ? "linearis_miss" : "linearis";
   if (code !== 0) {
+    recordDaemonRead(liveListSource, "failed", null, null, "eligible_list");
     throw new Error(`linearis issues list failed (exit ${code}): ${(stderr || "").trim()}`);
   }
   let parsed;
   try {
     parsed = JSON.parse(stdout);
   } catch (err) {
+    recordDaemonRead(liveListSource, "failed", null, null, "eligible_list");
     throw new Error(`linearis stdout is not JSON: ${err.message}`);
   }
   let tickets = (parsed.nodes ?? []).map(normalizeTicket);
@@ -1296,5 +1310,6 @@ export function runEligibleQuery(
   // CTL-1397: mark the source (linearis) for the same verification seam as the
   // replica HIT above, so the daemon can log eligible_source for both paths.
   onSource?.("linearis", tickets.length);
+  recordDaemonRead(liveListSource, "ok", null, null, "eligible_list"); // CTL-1580: only after a clean parse
   return tickets;
 }

--- a/plugins/dev/scripts/execution-core/linear-query.mjs
+++ b/plugins/dev/scripts/execution-core/linear-query.mjs
@@ -777,34 +777,43 @@ export function classifyTicketResolution(
     timeoutMs: LINEARIS_TERMINAL_READ_TIMEOUT_MS,
   });
   // CTL-1580 + CTL-1403: this path was named-but-uninstrumented — every live
-  // classify now lands in catalyst.linear.read (op=classify_resolution). "ok"
-  // is recorded only AFTER a successful parse (Codex round 2): an exit-0
-  // garbage body is a failed read, not a healthy one.
+  // classify now lands in catalyst.linear.read (op=classify_resolution).
+  // Result semantics (Codex rounds 2–3): "ok" ⟺ the read produced a USABLE
+  // verdict (exists / not-found — the CTL-1504 exit-1 not-found included);
+  // "unknown" (nonzero exit, unparseable body, transient/auth error body) is a
+  // failed classify — recording it ok would conceal auth/CLI drift.
   const classifySrc = replica ? "linearis_miss" : "linearis";
+  const finishClassify = (verdict) => {
+    recordDaemonRead(
+      classifySrc,
+      verdict === "unknown" ? "failed" : "ok",
+      identifier,
+      null,
+      "classify_resolution"
+    );
+    return verdict;
+  };
   if (code !== 0) {
-    recordDaemonRead(classifySrc, "failed", identifier, null, "classify_resolution");
     // CTL-1504: the CLI now exits 1 for a genuinely-missing ticket, with the
     // not-found body on stderr. A definitive not-found is the ONLY nonzero that
     // may quarantine; every other nonzero (429/network/auth/timeout/invalid-format)
     // stays ambiguous → "unknown" so a Linear outage never quarantines a real ticket.
-    return bodyLooksNotFound(stderr, stdout) ? "not-found" : "unknown";
+    return finishClassify(bodyLooksNotFound(stderr, stdout) ? "not-found" : "unknown");
   }
   let node;
   try {
     node = JSON.parse(stdout);
   } catch {
-    recordDaemonRead(classifySrc, "failed", identifier, null, "classify_resolution");
-    return "unknown"; // unparseable — fail safe, re-check next tick
+    return finishClassify("unknown"); // unparseable — fail safe, re-check next tick
   }
-  recordDaemonRead(classifySrc, "ok", identifier, null, "classify_resolution");
-  if (node == null) return "not-found";
+  if (node == null) return finishClassify("not-found");
   // The real missing-ticket shape: exit 0 + { error: "...not found" }. Only a
   // "not found" error is definitive; any other error body is transient.
   if (typeof node.error === "string") {
-    return /not\s*found/i.test(node.error) ? "not-found" : "unknown";
+    return finishClassify(/not\s*found/i.test(node.error) ? "not-found" : "unknown");
   }
   const id = node?.identifier ?? node?.id ?? null;
-  return id ? "exists" : "not-found";
+  return finishClassify(id ? "exists" : "not-found");
 }
 
 // fetchTicketAssignee — the CTL-781 respect-assignment read: the ticket's
@@ -1145,11 +1154,15 @@ export function runEligibleQuery(
 ) {
   // CTL-1397: replica-backed board-list tier. Fail-open: a throw out of
   // eligible() is swallowed → local undefined → fall through to linearis.
+  // CTL-1580: the throw is remembered so the live-list telemetry can carry the
+  // canonical linearis_exception source (distinct from an ordinary miss).
+  let replicaThrew = false;
   if (replica?.eligible) {
     let local;
     try {
       local = replica.eligible(query);
     } catch {
+      replicaThrew = true;
       local = undefined; // any replica failure → fall through to linearis
     }
     if (local && Array.isArray(local.nodes)) {
@@ -1262,7 +1275,11 @@ export function runEligibleQuery(
   // event.label field is single-ticket by contract; list ops omit it), and
   // "ok" is recorded only AFTER a successful parse — an exit-0 garbage body is
   // a failed read, not a healthy one.
-  const liveListSource = replica?.eligible ? "linearis_miss" : "linearis";
+  const liveListSource = replicaThrew
+    ? "linearis_exception"
+    : replica?.eligible
+      ? "linearis_miss"
+      : "linearis";
   if (code !== 0) {
     recordDaemonRead(liveListSource, "failed", null, null, "eligible_list");
     throw new Error(`linearis issues list failed (exit ${code}): ${(stderr || "").trim()}`);
@@ -1274,11 +1291,20 @@ export function runEligibleQuery(
     recordDaemonRead(liveListSource, "failed", null, null, "eligible_list");
     throw new Error(`linearis stdout is not JSON: ${err.message}`);
   }
-  let tickets = (parsed.nodes ?? []).map(normalizeTicket);
-  // Priority is a floor: keep tickets whose priority is more-urgent-or-equal
-  // (1=Urgent … 4=Low). 0 ("No priority") is always below any floor.
-  if (query.priority != null) {
-    tickets = tickets.filter((t) => t.priority >= 1 && t.priority <= query.priority);
+  let tickets;
+  try {
+    tickets = (parsed.nodes ?? []).map(normalizeTicket);
+    // Priority is a floor: keep tickets whose priority is more-urgent-or-equal
+    // (1=Urgent … 4=Low). 0 ("No priority") is always below any floor.
+    if (query.priority != null) {
+      tickets = tickets.filter((t) => t.priority >= 1 && t.priority <= query.priority);
+    }
+  } catch (err) {
+    // Structurally invalid body (e.g. {"nodes":{}}): syntactically valid JSON
+    // whose shape throws in normalization — a failed read, recorded as such
+    // before the throw reaches reconcileProject (Codex round 3).
+    recordDaemonRead(liveListSource, "failed", null, null, "eligible_list");
+    throw err;
   }
   // CTL-1174: best-effort delegate enrichment from a single batched GraphQL POST.
   // Never throws — a delegate hiccup must not block the state/priority refresh.

--- a/plugins/dev/scripts/execution-core/linear-query.test.mjs
+++ b/plugins/dev/scripts/execution-core/linear-query.test.mjs
@@ -2645,3 +2645,21 @@ describe("classifyTicketResolution replica-tier freshness gate (CTL-1580 review)
     expect(classifyTicketResolution("CTL-9", { exec, replica })).toBe("not-found");
   });
 });
+
+describe("classifyTicketResolution gateway-tombstone veto (CTL-1580 round 5)", () => {
+  test("a fresh removed:true descriptor bypasses the replica tier — deletion pays the live read", () => {
+    const exec = fakeExec({ code: 0, stdout: "null" }); // live says: gone
+    const gateway = { getDescriptor: () => ({ removed: true, updatedAt: new Date().toISOString() }) };
+    const replica = { isFresh: () => true, lookup: () => ({ terminal: false, state: "Todo" }) }; // stale drift row
+    expect(classifyTicketResolution("CTL-9", { exec, gateway, replica })).toBe("not-found");
+  });
+
+  test("a fresh removed:false descriptor still short-circuits before either tier", () => {
+    let execs = 0;
+    const exec = () => { execs++; return { code: 0, stdout: "null", stderr: "" }; };
+    const gateway = { getDescriptor: () => ({ removed: false, state: "Todo", updatedAt: new Date().toISOString() }) };
+    const replica = { isFresh: () => true, lookup: () => undefined };
+    expect(classifyTicketResolution("CTL-10", { exec, gateway, replica })).toBe("exists");
+    expect(execs).toBe(0);
+  });
+});

--- a/plugins/dev/scripts/execution-core/linear-query.test.mjs
+++ b/plugins/dev/scripts/execution-core/linear-query.test.mjs
@@ -2601,8 +2601,8 @@ describe("classifyTicketResolution replica tier (CTL-1580)", () => {
       execs++;
       return { code: 0, stdout: "null", stderr: "" };
     };
-    const replica = { lookup: () => ({ terminal: false, state: "Implement" }) };
-    expect(classifyTicketResolution("OTL-52", { exec, replica })).toBe("exists");
+    const replica = { isFresh: () => true, lookup: () => ({ terminal: false, state: "Implement" }) };
+    expect(classifyTicketResolution("PROJ-52", { exec, replica })).toBe("exists");
     expect(execs).toBe(0);
   });
 
@@ -2612,14 +2612,14 @@ describe("classifyTicketResolution replica tier (CTL-1580)", () => {
       execs++;
       return { code: 0, stdout: "null", stderr: "" };
     };
-    const replica = { lookup: () => ({ terminal: true, state: "Done" }) };
+    const replica = { isFresh: () => true, lookup: () => ({ terminal: true, state: "Done" }) };
     expect(classifyTicketResolution("CTL-1", { exec, replica })).toBe("exists");
     expect(execs).toBe(0);
   });
 
   test("replica MISS falls through to the live read (deletion still definitive)", () => {
     const exec = fakeExec({ code: 0, stdout: "null" });
-    const replica = { lookup: () => undefined };
+    const replica = { isFresh: () => true, lookup: () => undefined };
     expect(classifyTicketResolution("CTL-9", { exec, replica })).toBe("not-found");
   });
 
@@ -2629,5 +2629,19 @@ describe("classifyTicketResolution replica tier (CTL-1580)", () => {
       stdout: JSON.stringify({ identifier: "CTL-100", state: { name: "Ready" } }),
     });
     expect(classifyTicketResolution("CTL-100", { exec })).toBe("exists");
+  });
+});
+
+describe("classifyTicketResolution replica-tier freshness gate (CTL-1580 review)", () => {
+  test("a STALE replica row never suppresses the definitive live check", () => {
+    const exec = fakeExec({ code: 0, stdout: "null" });
+    const replica = { isFresh: () => false, lookup: () => ({ terminal: false, state: "Todo" }) };
+    expect(classifyTicketResolution("CTL-9", { exec, replica })).toBe("not-found");
+  });
+
+  test("a reader without the isFresh accessor is treated as unfresh (fail-closed)", () => {
+    const exec = fakeExec({ code: 0, stdout: "null" });
+    const replica = { lookup: () => ({ terminal: false, state: "Todo" }) };
+    expect(classifyTicketResolution("CTL-9", { exec, replica })).toBe("not-found");
   });
 });

--- a/plugins/dev/scripts/execution-core/linear-query.test.mjs
+++ b/plugins/dev/scripts/execution-core/linear-query.test.mjs
@@ -2593,3 +2593,41 @@ describe("fetchTicketState — onExec span seam (CTL-1364)", () => {
     expect(fetchTicketState("CTL-9", { exec, onExec })).toBe("Done");
   });
 });
+
+describe("classifyTicketResolution replica tier (CTL-1580)", () => {
+  test("replica HIT (any present row) → exists with ZERO live execs", () => {
+    let execs = 0;
+    const exec = () => {
+      execs++;
+      return { code: 0, stdout: "null", stderr: "" };
+    };
+    const replica = { lookup: () => ({ terminal: false, state: "Implement" }) };
+    expect(classifyTicketResolution("OTL-52", { exec, replica })).toBe("exists");
+    expect(execs).toBe(0);
+  });
+
+  test("replica HIT on a terminal row also serves exists (still zero execs)", () => {
+    let execs = 0;
+    const exec = () => {
+      execs++;
+      return { code: 0, stdout: "null", stderr: "" };
+    };
+    const replica = { lookup: () => ({ terminal: true, state: "Done" }) };
+    expect(classifyTicketResolution("CTL-1", { exec, replica })).toBe("exists");
+    expect(execs).toBe(0);
+  });
+
+  test("replica MISS falls through to the live read (deletion still definitive)", () => {
+    const exec = fakeExec({ code: 0, stdout: "null" });
+    const replica = { lookup: () => undefined };
+    expect(classifyTicketResolution("CTL-9", { exec, replica })).toBe("not-found");
+  });
+
+  test("no replica → byte-identical live behavior", () => {
+    const exec = fakeExec({
+      code: 0,
+      stdout: JSON.stringify({ identifier: "CTL-100", state: { name: "Ready" } }),
+    });
+    expect(classifyTicketResolution("CTL-100", { exec })).toBe("exists");
+  });
+});

--- a/plugins/dev/scripts/execution-core/linear-query.test.mjs
+++ b/plugins/dev/scripts/execution-core/linear-query.test.mjs
@@ -2663,3 +2663,21 @@ describe("classifyTicketResolution gateway-tombstone veto (CTL-1580 round 5)", (
     expect(execs).toBe(0);
   });
 });
+
+describe("classifyTicketResolution bypassCaches (CTL-1580 round 6)", () => {
+  test("bypassCaches skips BOTH tiers even when production injection forces them in", () => {
+    const exec = fakeExec({ code: 0, stdout: "null" }); // live: gone
+    const gateway = { getDescriptor: () => ({ removed: false, state: "Todo", updatedAt: new Date().toISOString() }) };
+    const replica = { isFresh: () => true, lookup: () => ({ terminal: false, state: "Todo" }) };
+    expect(classifyTicketResolution("CTL-9", { exec, gateway, replica, bypassCaches: true })).toBe("not-found");
+  });
+});
+
+describe("runEligibleQuery structural body validation (CTL-1580 round 6)", () => {
+  test("an exit-0 body without nodes[] throws instead of zeroing the board", () => {
+    const exec = () => ({ code: 0, stdout: JSON.stringify({ error: "Authentication required" }), stderr: "" });
+    expect(() =>
+      runEligibleQuery({ team: "PROJ", status: "Todo" }, { exec, now: () => 0 })
+    ).toThrow(/nodes/);
+  });
+});

--- a/plugins/dev/scripts/execution-core/scheduler.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.mjs
@@ -2589,6 +2589,35 @@ function recordDeletionProbeIfDue(orchDir, ticket, now) {
   }
 }
 
+// CTL-1580 (Codex round 3): a replica-vouched "exists" must still pay a LIVE
+// verification at a long cadence. The replica's freshness gate proves the
+// WRITER is alive, not that THIS ticket's deletion applied (the ~0.7%
+// apply-drift class, CTL-1402) — without a periodic live recheck, a deleted
+// workerless ticket whose stale row keeps vouching would occupy a slot
+// indefinitely. Marker mirrors .deletion-probes; fail-OPEN on write failure
+// (keep the cheap replica tier, skip the recheck) — the opposite of the
+// probe marker's fail-closed, because here the failure mode is one more
+// replica read, not a quota loop.
+const REPLICA_VOUCH_RECHECK_MS = 6 * 3_600_000; // one live re-verify per ticket per 6h
+function replicaVouchRecheckPath(orchDir, ticket) {
+  return join(orchDir, ".replica-vouch-rechecks", ticket);
+}
+function recordReplicaVouchRecheckIfDue(orchDir, ticket, now) {
+  try {
+    const at = JSON.parse(readFileSync(replicaVouchRecheckPath(orchDir, ticket), "utf8"))?.probedAt;
+    if (typeof at === "number" && now - at < REPLICA_VOUCH_RECHECK_MS) return false;
+  } catch {
+    /* absent / malformed → due */
+  }
+  try {
+    mkdirSync(join(orchDir, ".replica-vouch-rechecks"), { recursive: true });
+    writeFileSync(replicaVouchRecheckPath(orchDir, ticket), JSON.stringify({ ticket, probedAt: now }));
+    return true;
+  } catch {
+    return false; // fail-open: replica tier stays on; live recheck deferred
+  }
+}
+
 // CTL-611: post-dispatch verifier. A dispatch is only really successful if
 // workers/<T>/phase-<P>.json was written with a non-empty bg_job_id and a
 // runnable status. A --dry-run leak (no signal at all) or a mark_launch_failed
@@ -4314,13 +4343,30 @@ export function schedulerTick(
     // DELETION_PROBE_INTERVAL_MS (the phantom branch already gated above).
     if (!isPhantomWorkerDir(phaseSignals) && !recordDeletionProbeIfDue(orchDir, sig.ticket, now()))
       continue;
-    if (classifyResolution(sig.ticket, { exec, gateway, replica }) !== "not-found") continue; // (b) definitive only
+    // CTL-1580 (Codex round 3): every REPLICA_VOUCH_RECHECK_MS the replica tier
+    // is bypassed so one LIVE read re-verifies existence — a stale row from a
+    // missed deletion apply (writer alive, isFresh green) must not vouch forever.
+    const liveRecheckDue = recordReplicaVouchRecheckIfDue(orchDir, sig.ticket, now());
+    if (
+      classifyResolution(sig.ticket, { exec, gateway, replica: liveRecheckDue ? undefined : replica }) !==
+      "not-found"
+    )
+      continue; // (b) definitive only
     if (maybeQuarantinePhantom(orchDir, sig.ticket, sig.phase)) {
       quarantinedPhantoms.push({ ticket: sig.ticket, phase: sig.phase });
       log.warn(
         { ticket: sig.ticket, phase: sig.phase },
         "scheduler: quarantined phantom worker dir (not-found + not-eligible + dead bg) — CTL-671"
       );
+    } else {
+      // CTL-1580 (Codex round 3): a definitive not-found whose quarantine write
+      // failed must not sit out the probe cool-down — clear the marker so the
+      // next tick retries the (local, read-free) quarantine immediately.
+      try {
+        rmSync(deletionProbePath(orchDir, sig.ticket), { force: true });
+      } catch {
+        /* best-effort — worst case the retry waits out the cool-down */
+      }
     }
   }
 

--- a/plugins/dev/scripts/execution-core/scheduler.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.mjs
@@ -4354,11 +4354,24 @@ export function schedulerTick(
     // read — a stale replica row from a missed deletion apply, or a
     // fresh-but-wrong gateway descriptor, must not vouch forever.
     const liveRecheckDue = recordReplicaVouchRecheckIfDue(orchDir, sig.ticket, now());
-    if (
-      classifyResolution(sig.ticket, liveRecheckDue ? { exec } : { exec, gateway, replica }) !==
-      "not-found"
-    )
-      continue; // (b) definitive only
+    // bypassCaches (not option-omission): production injection spreads
+    // `{ ...opts, gateway }` over these options, so only a dedicated flag
+    // survives to actually force the live read (Codex round 6).
+    const verdict = classifyResolution(
+      sig.ticket,
+      liveRecheckDue ? { exec, bypassCaches: true } : { exec, gateway, replica }
+    );
+    if (liveRecheckDue && verdict === "unknown") {
+      // An INCONCLUSIVE recheck (timeout/429/auth) must not spend the 6h stamp —
+      // surrender the marker so the next 10-min probe re-attempts the live
+      // verification instead of re-vouching from the replica for a full window.
+      try {
+        rmSync(replicaVouchRecheckPath(orchDir, sig.ticket), { force: true });
+      } catch {
+        /* best-effort */
+      }
+    }
+    if (verdict !== "not-found") continue; // (b) definitive only
     if (maybeQuarantinePhantom(orchDir, sig.ticket, sig.phase)) {
       quarantinedPhantoms.push({ ticket: sig.ticket, phase: sig.phase });
       log.warn(

--- a/plugins/dev/scripts/execution-core/scheduler.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.mjs
@@ -4343,12 +4343,13 @@ export function schedulerTick(
     // DELETION_PROBE_INTERVAL_MS (the phantom branch already gated above).
     if (!isPhantomWorkerDir(phaseSignals) && !recordDeletionProbeIfDue(orchDir, sig.ticket, now()))
       continue;
-    // CTL-1580 (Codex round 3): every REPLICA_VOUCH_RECHECK_MS the replica tier
-    // is bypassed so one LIVE read re-verifies existence — a stale row from a
-    // missed deletion apply (writer alive, isFresh green) must not vouch forever.
+    // CTL-1580 (Codex rounds 3–4): every REPLICA_VOUCH_RECHECK_MS BOTH cached
+    // tiers (replica AND gateway) are bypassed so the recheck is a genuine live
+    // read — a stale replica row from a missed deletion apply, or a
+    // fresh-but-wrong gateway descriptor, must not vouch forever.
     const liveRecheckDue = recordReplicaVouchRecheckIfDue(orchDir, sig.ticket, now());
     if (
-      classifyResolution(sig.ticket, { exec, gateway, replica: liveRecheckDue ? undefined : replica }) !==
+      classifyResolution(sig.ticket, liveRecheckDue ? { exec } : { exec, gateway, replica }) !==
       "not-found"
     )
       continue; // (b) definitive only
@@ -4359,11 +4360,14 @@ export function schedulerTick(
         "scheduler: quarantined phantom worker dir (not-found + not-eligible + dead bg) — CTL-671"
       );
     } else {
-      // CTL-1580 (Codex round 3): a definitive not-found whose quarantine write
-      // failed must not sit out the probe cool-down — clear the marker so the
-      // next tick retries the (local, read-free) quarantine immediately.
+      // CTL-1580 (Codex rounds 3–4): a definitive not-found whose quarantine
+      // write failed must not sit out EITHER cool-down — clear the probe marker
+      // (next tick retries immediately) AND the vouch-recheck marker (so that
+      // retry pays the live path again instead of being re-vouched by the very
+      // stale row the recheck just disproved).
       try {
         rmSync(deletionProbePath(orchDir, sig.ticket), { force: true });
+        rmSync(replicaVouchRecheckPath(orchDir, sig.ticket), { force: true });
       } catch {
         /* best-effort — worst case the retry waits out the cool-down */
       }

--- a/plugins/dev/scripts/execution-core/scheduler.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.mjs
@@ -2598,7 +2598,13 @@ function recordDeletionProbeIfDue(orchDir, ticket, now) {
 // (keep the cheap replica tier, skip the recheck) — the opposite of the
 // probe marker's fail-closed, because here the failure mode is one more
 // replica read, not a quota loop.
-const REPLICA_VOUCH_RECHECK_MS = 6 * 3_600_000; // one live re-verify per ticket per 6h
+// Env-tunable (Codex round 5): the correctness↔quota trade-off is per-fleet —
+// a quota-constrained deployment lengthens it, one prioritizing stale-deletion
+// latency shortens it. Non-finite/≤0 → default 6h.
+const REPLICA_VOUCH_RECHECK_MS = (() => {
+  const raw = Number(process.env.SCHEDULER_REPLICA_VOUCH_RECHECK_MS);
+  return Number.isFinite(raw) && raw > 0 ? raw : 6 * 3_600_000; // one live re-verify per ticket per 6h
+})();
 function replicaVouchRecheckPath(orchDir, ticket) {
   return join(orchDir, ".replica-vouch-rechecks", ticket);
 }
@@ -4365,11 +4371,18 @@ export function schedulerTick(
       // (next tick retries immediately) AND the vouch-recheck marker (so that
       // retry pays the live path again instead of being re-vouched by the very
       // stale row the recheck just disproved).
+      // Independent removals (Codex round 5): a transient failure on the first
+      // must not skip the second — a retained vouch marker would re-vouch the
+      // very row the recheck just disproved when the probe retries.
       try {
         rmSync(deletionProbePath(orchDir, sig.ticket), { force: true });
-        rmSync(replicaVouchRecheckPath(orchDir, sig.ticket), { force: true });
       } catch {
         /* best-effort — worst case the retry waits out the cool-down */
+      }
+      try {
+        rmSync(replicaVouchRecheckPath(orchDir, sig.ticket), { force: true });
+      } catch {
+        /* best-effort */
       }
     }
   }

--- a/plugins/dev/scripts/execution-core/scheduler.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.mjs
@@ -4304,7 +4304,17 @@ export function schedulerTick(
     // short-circuit (GATEWAY_EXISTS_FRESH_MS) can serve "exists" without a live
     // linearis read — a held-but-workerless dir costs at most one live read per
     // freshness window instead of one per tick.
-    if (classifyResolution(sig.ticket, { exec, gateway }) !== "not-found") continue; // (b) definitive only
+    // CTL-1580: that bound was illusory for a QUIET stuck ticket — no webhooks →
+    // the descriptor ages past the freshness window and is NEVER refreshed
+    // (gateway-read is read-only), so classify paid a live read EVERY tick (the
+    // OTL-52 burn). Two additive guards: (1) thread the replica so a present row
+    // serves "exists" for free (fail-safe — it only ever PREVENTS quarantine);
+    // (2) extend the CTL-1570 probe cool-down to the non-phantom branch, so even
+    // a replica-miss ticket costs at most one classify per
+    // DELETION_PROBE_INTERVAL_MS (the phantom branch already gated above).
+    if (!isPhantomWorkerDir(phaseSignals) && !recordDeletionProbeIfDue(orchDir, sig.ticket, now()))
+      continue;
+    if (classifyResolution(sig.ticket, { exec, gateway, replica }) !== "not-found") continue; // (b) definitive only
     if (maybeQuarantinePhantom(orchDir, sig.ticket, sig.phase)) {
       quarantinedPhantoms.push({ ticket: sig.ticket, phase: sig.phase });
       log.warn(

--- a/plugins/dev/scripts/execution-core/scheduler.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.mjs
@@ -4307,7 +4307,7 @@ export function schedulerTick(
     // CTL-1580: that bound was illusory for a QUIET stuck ticket — no webhooks →
     // the descriptor ages past the freshness window and is NEVER refreshed
     // (gateway-read is read-only), so classify paid a live read EVERY tick (the
-    // OTL-52 burn). Two additive guards: (1) thread the replica so a present row
+    // PROJ-52 burn). Two additive guards: (1) thread the replica so a present row
     // serves "exists" for free (fail-safe — it only ever PREVENTS quarantine);
     // (2) extend the CTL-1570 probe cool-down to the non-phantom branch, so even
     // a replica-miss ticket costs at most one classify per

--- a/plugins/dev/scripts/execution-core/scheduler.test.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.test.mjs
@@ -12715,8 +12715,15 @@ describe("Pass 0a live-probe bounding for non-phantom dirs (CTL-1580)", () => {
     expect(classifies).toBe(1);
   });
 
-  test("the replica reader is threaded into classifyResolution's options", () => {
+  test("the replica reader is threaded into classifyResolution's options (recheck not due)", () => {
     writeSignal("CTL-77", "implement", "running");
+    // Pre-seed a FRESH live-recheck marker so the periodic replica bypass is
+    // not due — the tier should then be threaded through.
+    mkdirSync(join(orchDir, ".replica-vouch-rechecks"), { recursive: true });
+    writeFileSync(
+      join(orchDir, ".replica-vouch-rechecks", "CTL-77"),
+      JSON.stringify({ ticket: "CTL-77", probedAt: Date.now() })
+    );
     const replica = { lookup: () => ({ terminal: false, state: "Implement" }) };
     let seenReplica = null;
     schedulerTick(orchDir, {
@@ -12731,5 +12738,24 @@ describe("Pass 0a live-probe bounding for non-phantom dirs (CTL-1580)", () => {
       replica,
     });
     expect(seenReplica).toBe(replica);
+  });
+
+  test("a DUE live recheck bypasses the replica tier for one classify (apply-drift guard)", () => {
+    writeSignal("CTL-78", "implement", "running");
+    const replica = { lookup: () => ({ terminal: false, state: "Implement" }) };
+    let seenReplica = "unset";
+    schedulerTick(orchDir, {
+      readEligible: () => [],
+      dispatch: () => ({ code: 0 }),
+      liveBackgroundCount: () => 0,
+      classifyResolution: (_t, opts) => {
+        seenReplica = opts?.replica;
+        return "exists";
+      },
+      isBgJobAlive: () => false,
+      replica,
+    });
+    // No recheck marker yet → the very first classify pays the live path.
+    expect(seenReplica).toBeUndefined();
   });
 });

--- a/plugins/dev/scripts/execution-core/scheduler.test.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.test.mjs
@@ -12694,7 +12694,7 @@ describe("computeDeadHosts (CTL-1524 C4a)", () => {
 // ── CTL-1580: non-phantom probe cool-down + replica threading ──
 describe("Pass 0a live-probe bounding for non-phantom dirs (CTL-1580)", () => {
   test("a stuck dir's classify is bounded to one per DELETION_PROBE_INTERVAL_MS", () => {
-    writeSignal("OTL-52", "implement", "running");
+    writeSignal("PROJ-52", "implement", "running");
     let classifies = 0;
     const deps = {
       readEligible: () => [],
@@ -12711,7 +12711,7 @@ describe("Pass 0a live-probe bounding for non-phantom dirs (CTL-1580)", () => {
     schedulerTick(orchDir, deps);
     // First tick probes (and records the marker); the next two are inside the
     // cool-down window and must NOT re-probe — this was the every-tick live
-    // read of a quiet stuck ticket (the OTL-52 burn).
+    // read of a quiet stuck ticket (the PROJ-52 burn).
     expect(classifies).toBe(1);
   });
 

--- a/plugins/dev/scripts/execution-core/scheduler.test.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.test.mjs
@@ -12690,3 +12690,46 @@ describe("computeDeadHosts (CTL-1524 C4a)", () => {
     ).toEqual([]);
   });
 });
+
+// ── CTL-1580: non-phantom probe cool-down + replica threading ──
+describe("Pass 0a live-probe bounding for non-phantom dirs (CTL-1580)", () => {
+  test("a stuck dir's classify is bounded to one per DELETION_PROBE_INTERVAL_MS", () => {
+    writeSignal("OTL-52", "implement", "running");
+    let classifies = 0;
+    const deps = {
+      readEligible: () => [],
+      dispatch: () => ({ code: 0 }),
+      liveBackgroundCount: () => 0,
+      classifyResolution: () => {
+        classifies++;
+        return "exists"; // real stuck ticket — never quarantined
+      },
+      isBgJobAlive: () => false,
+    };
+    schedulerTick(orchDir, deps);
+    schedulerTick(orchDir, deps);
+    schedulerTick(orchDir, deps);
+    // First tick probes (and records the marker); the next two are inside the
+    // cool-down window and must NOT re-probe — this was the every-tick live
+    // read of a quiet stuck ticket (the OTL-52 burn).
+    expect(classifies).toBe(1);
+  });
+
+  test("the replica reader is threaded into classifyResolution's options", () => {
+    writeSignal("CTL-77", "implement", "running");
+    const replica = { lookup: () => ({ terminal: false, state: "Implement" }) };
+    let seenReplica = null;
+    schedulerTick(orchDir, {
+      readEligible: () => [],
+      dispatch: () => ({ code: 0 }),
+      liveBackgroundCount: () => 0,
+      classifyResolution: (_t, opts) => {
+        seenReplica = opts?.replica ?? null;
+        return "exists";
+      },
+      isBgJobAlive: () => false,
+      replica,
+    });
+    expect(seenReplica).toBe(replica);
+  });
+});

--- a/plugins/dev/scripts/execution-core/scheduler.test.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.test.mjs
@@ -1570,6 +1570,13 @@ describe("phantom worker-dir validity sweep (CTL-671)", () => {
     // The sweep's call site historically passed only { exec }, so every probe
     // fell through to a live linearis read.
     writeSignal("PROJ-202", "implement", "running");
+    // CTL-1580: a DUE live recheck deliberately passes only { exec } — pre-seed
+    // a fresh recheck marker so this test observes the steady-state threading.
+    mkdirSync(join(orchDir, ".replica-vouch-rechecks"), { recursive: true });
+    writeFileSync(
+      join(orchDir, ".replica-vouch-rechecks", "PROJ-202"),
+      JSON.stringify({ ticket: "PROJ-202", probedAt: Date.now() })
+    );
     const gateway = { getDescriptor: () => null };
     let seenOpts = null;
     schedulerTick(orchDir, {


### PR DESCRIPTION
## Summary

Post-CTL-1577 validation found the app-actor 5000/hr bucket at ~93% steady-state utilization with ~4k req/hr **uninstrumented**. A `ps` sample caught the burner: exec-core's Pass 0a re-classifying the stuck ticket OTL-52 with a live `linearis issues read` on ~every tick. Root cause: `classifyTicketResolution` has no replica tier, and a quiet stuck ticket's gateway descriptor ages past its 10-min freshness and is never refreshed (gateway-read is read-only, refreshes ride webhooks the quiet ticket never gets) — so the CTL-1570 'at most one read per freshness window' bound silently degraded to one read per tick.

## Changes

- **`linear-query.mjs` — replica tier in `classifyTicketResolution`** (mirrors `fetchTicketState`'s CTL-1340 tier): present non-tombstoned row → `"exists"`, zero live reads. Fail-safe by construction — a replica HIT can only *prevent* quarantine; removed/absent rows read as MISS and fall through to the definitive live read, preserving fresh-before-quarantine.
- **`scheduler.mjs` Pass 0a** — threads `replica` into the classify call and extends the CTL-1570 `.deletion-probes` cool-down to the **non-phantom** branch: even a replica-miss stuck ticket costs ≤1 classify per `DELETION_PROBE_INTERVAL_MS` (10 min) instead of one per tick.
- **CTL-1403 instrumentation** on both named-but-invisible paths: `recordDaemonRead` gains an `op` param; classify emits `op=classify_resolution` (replica hit / live outcome / `linearis_miss` when the replica missed), and `runEligibleQuery` emits `op=eligible_list` on the live list + replica-served results. The eligible path was confirmed working-as-designed (bounded empty-reconfirm, no failing confirms since 7/13) — its fix is observability only.

## Testing

- 4 new `classifyTicketResolution` replica-tier tests (HIT zero-exec incl. terminal rows, MISS fall-through, no-replica byte-identical) — linear-query suite 220/220.
- 2 new scheduler tests: classify bounded to 1 across 3 ticks for a stuck dir; replica threaded into the classify options. Full local scheduler suite: 599 pass / 8 pre-existing wall-clock flakes (identical failures on unmodified main; the documented CTL-868 trio + CTL-781 pair among them).

## Post-merge

Composes with #2824 (CTL-1571, the broker half). After both deploy: verify `ps` sampling shows no recurring linearis children, app-bucket utilization drops well under the 5000/hr ceiling, and remove the interim reconcile throttle env from both minis.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Wte59hchAL4FjhHiCwSVS3