### PR TITLE
feat(dev): CTL-1585 discussion newest-first in inbox, inline on detail page, Spec tab renamed Detail

### DIFF
--- a/plugins/dev/scripts/orch-monitor/ui/src/board/execution-tab.contract.test.ts
+++ b/plugins/dev/scripts/orch-monitor/ui/src/board/execution-tab.contract.test.ts
@@ -15,8 +15,8 @@ describe("CTL-1102 Execution tab contract", () => {
     expect((TAB_VALUES as readonly string[]).includes("execution")).toBe(true);
   });
 
-  it("keeps the four prior tabs (no accidental drop on rename)", () => {
-    for (const t of ["lifecycle", "cost", "activity"]) {
+  it("keeps the prior tabs (no accidental drop on rename)", () => {
+    for (const t of ["lifecycle", "cost", "activity", "discussion"]) {
       expect((TAB_VALUES as readonly string[]).includes(t)).toBe(true);
     }
   });

--- a/plugins/dev/scripts/orch-monitor/ui/src/components/home/pane-discussion.tsx
+++ b/plugins/dev/scripts/orch-monitor/ui/src/components/home/pane-discussion.tsx
@@ -24,7 +24,14 @@ export function PaneDiscussion({ ticket }: { ticket: string }) {
 
   return (
     <section className="mt-6" data-pane-discussion={ticket}>
-      <p className="text-[11px] font-medium uppercase tracking-wide text-muted">Discussion</p>
+      <p className="text-[11px] font-medium uppercase tracking-wide text-muted">
+        Discussion
+        {/* The pane inverts to newest-first (the next thing to react to sits on
+            top); say so, since the ticket page reads chronologically. */}
+        <span className="ml-2 font-normal normal-case tracking-normal text-fg-dim">
+          newest first
+        </span>
+      </p>
       <div className="mt-3">
         {/* key: the reading pane keeps ONE instance across inbox selections, so
             without it the previous ticket's "Show all" expansion leaks into the
@@ -37,6 +44,7 @@ export function PaneDiscussion({ ticket }: { ticket: string }) {
           loaded
           available
           limit={COLLAPSED_LIMIT}
+          newestFirst
         />
       </div>
     </section>

--- a/plugins/dev/scripts/orch-monitor/ui/src/components/ticket-detail-page.tsx
+++ b/plugins/dev/scripts/orch-monitor/ui/src/components/ticket-detail-page.tsx
@@ -931,10 +931,13 @@ export function TicketDetailPage({
         </div>
       )}
 
-      {/* ── TABS — Spec (default) · Lifecycle · Cost · Activity ── */}
+      {/* ── TABS — Detail (default) · Lifecycle · Cost · Activity ── */}
       <div style={{ marginTop: 20 }} data-ticket-tabs data-active-tab={value}>
         <PillTabs value={value} onValueChange={setTab} tabs={TAB_DEFS}>
-          {/* Spec: the description prose — works from the live fetch on/off board. */}
+          {/* Detail (internal value "spec"): the description prose — works from
+              the live fetch on/off board — with the Linear discussion inline
+              below it (chronological), so the conversation is visible without
+              hunting for the Discussion tab. */}
           <TabsContent value="spec">
             <div data-ticket-spec style={{ paddingTop: 16 }}>
               {(linear.description || linear.loaded) && (
@@ -944,6 +947,9 @@ export function TicketDetailPage({
                   </Suspense>
                 </section>
               )}
+              <div style={{ marginTop: 24 }}>
+                <DiscussionSection key={ticket?.id ?? id} ticketId={ticket?.id ?? id} />
+              </div>
             </div>
           </TabsContent>
 
@@ -1033,11 +1039,13 @@ function TAB_IS_VALID(tab: string): tab is "spec" | DetailTab {
   return tab === "spec" || (TAB_VALUES as readonly string[]).includes(tab);
 }
 
-/** The visible tab set (Spec default · Lifecycle · Cost · Activity · Discussion ·
+/** The visible tab set (Detail default · Lifecycle · Cost · Activity · Discussion ·
  *  Execution). "Discussion" is the LINEAR conversation (CTL-1574); "Activity" is
- *  the execution event stream and keeps its name. */
+ *  the execution event stream and keeps its name. The default tab is LABELED
+ *  "Detail" (CTL-1585) but keeps the internal value "spec" so persisted entry
+ *  state and old ?tab=spec links keep resolving. */
 const TAB_DEFS: PillTab[] = [
-  { value: "spec", label: "Spec" },
+  { value: "spec", label: "Detail" },
   { value: "lifecycle", label: "Lifecycle" },
   { value: "cost", label: "Cost" },
   { value: "activity", label: "Activity" },

--- a/plugins/dev/scripts/orch-monitor/ui/src/components/ticket-discussion.test.tsx
+++ b/plugins/dev/scripts/orch-monitor/ui/src/components/ticket-discussion.test.tsx
@@ -165,6 +165,17 @@ describe("visibleTimelineNodes", () => {
     expect(shown.map((n) => n.ts)).toEqual([1000, 2000, 3000, 4000, 5000, 6000]);
   });
 
+  it("newestFirst keeps the same-millisecond tie-break (event still above its comment)", () => {
+    // t=1000 event+comment (tie-broken event-first), then a newer t=2000 comment.
+    const nodes = buildTimeline(
+      [comment({ id: "c1", updated_at: 1000 }), comment({ id: "c2", updated_at: 2000 })],
+      [event({ id: "e1", created_at: 1000, actor_name: "ryan", to_state: "Done" })],
+    );
+    const { shown } = visibleTimelineNodes(nodes, { limit: undefined, showAll: false, newestFirst: true });
+    // The t=2000 group leads; the t=1000 group follows with event BEFORE comment.
+    expect(shown.map((n) => `${n.ts}:${n.kind}`)).toEqual(["2000:comment", "1000:event", "1000:comment"]);
+  });
+
   it("does not mutate the ascending source when reversing", () => {
     const before = six.map((n) => n.ts);
     visibleTimelineNodes(six, { limit: undefined, showAll: false, newestFirst: true });

--- a/plugins/dev/scripts/orch-monitor/ui/src/components/ticket-discussion.test.tsx
+++ b/plugins/dev/scripts/orch-monitor/ui/src/components/ticket-discussion.test.tsx
@@ -14,6 +14,7 @@ import {
   coalesceBursts,
   creationEventId,
   describeOrNull,
+  visibleTimelineNodes,
   type CommentNode,
   type EventNode,
 } from "./ticket-discussion";
@@ -129,6 +130,45 @@ describe("buildTimeline", () => {
 
   it("returns [] for a ticket with no comments and no activity", () => {
     expect(buildTimeline([], [])).toEqual([]);
+  });
+});
+
+describe("visibleTimelineNodes", () => {
+  const six = buildTimeline(
+    [],
+    [1, 2, 3, 4, 5, 6].map((n) =>
+      // Alternate actors so the run never coalesces into a burst.
+      event({ id: `e${n}`, created_at: n * 1000, actor_id: `a${n % 2}`, actor_name: `u${n % 2}`, to_state: "Todo" }),
+    ),
+  );
+
+  it("collapse keeps the NEWEST limit nodes, ascending by default", () => {
+    const { collapsed, shown } = visibleTimelineNodes(six, { limit: 5, showAll: false, newestFirst: false });
+    expect(collapsed).toBe(true);
+    expect(shown.map((n) => n.ts)).toEqual([2000, 3000, 4000, 5000, 6000]);
+  });
+
+  it("newestFirst flips DISPLAY order only — collapse still keeps the newest", () => {
+    const { shown } = visibleTimelineNodes(six, { limit: 5, showAll: false, newestFirst: true });
+    expect(shown.map((n) => n.ts)).toEqual([6000, 5000, 4000, 3000, 2000]);
+  });
+
+  it("showAll expands the full stream and newestFirst still reverses it", () => {
+    const { collapsed, shown } = visibleTimelineNodes(six, { limit: 5, showAll: true, newestFirst: true });
+    expect(collapsed).toBe(false);
+    expect(shown.map((n) => n.ts)).toEqual([6000, 5000, 4000, 3000, 2000, 1000]);
+  });
+
+  it("no limit means nothing collapses and input order is preserved", () => {
+    const { collapsed, shown } = visibleTimelineNodes(six, { limit: undefined, showAll: false, newestFirst: false });
+    expect(collapsed).toBe(false);
+    expect(shown.map((n) => n.ts)).toEqual([1000, 2000, 3000, 4000, 5000, 6000]);
+  });
+
+  it("does not mutate the ascending source when reversing", () => {
+    const before = six.map((n) => n.ts);
+    visibleTimelineNodes(six, { limit: undefined, showAll: false, newestFirst: true });
+    expect(six.map((n) => n.ts)).toEqual(before);
   });
 });
 

--- a/plugins/dev/scripts/orch-monitor/ui/src/components/ticket-discussion.tsx
+++ b/plugins/dev/scripts/orch-monitor/ui/src/components/ticket-discussion.tsx
@@ -706,17 +706,37 @@ function ActivityBurst({ node, now }: { node: BurstNode; now: number }) {
   );
 }
 
+/** Reverse an ascending stream by TIMESTAMP GROUP: groups of equal-ts nodes swap
+ *  position but keep their internal order, so the same-millisecond tie-break
+ *  ("the state changed, THEN someone commented") still reads top-down. A plain
+ *  Array.reverse() would invert it. */
+function reverseByTimestamp(nodes: TimelineNode[]): TimelineNode[] {
+  const out: TimelineNode[] = [];
+  let end = nodes.length;
+  while (end > 0) {
+    let start = end - 1;
+    while (start > 0 && nodes[start - 1]?.ts === nodes[end - 1]?.ts) start--;
+    for (let i = start; i < end; i++) {
+      const n = nodes[i];
+      if (n) out.push(n);
+    }
+    end = start;
+  }
+  return out;
+}
+
 /** The collapse + display-order math, pure so it stays testable (bun has no DOM).
  *  Collapse keeps the NEWEST `limit` nodes (the stream is oldest-first);
  *  `newestFirst` then flips DISPLAY order only — the underlying timeline stays
- *  ascending, so burst coalescing and the same-ms tie-break are unaffected. */
+ *  ascending, so burst coalescing is unaffected, and equal-ts groups keep their
+ *  tie-break order (see reverseByTimestamp). */
 export function visibleTimelineNodes(
   nodes: TimelineNode[],
   { limit, showAll, newestFirst }: { limit?: number; showAll: boolean; newestFirst: boolean },
 ): { collapsed: boolean; shown: TimelineNode[] } {
   const collapsed = limit != null && !showAll && nodes.length > limit;
   const kept = limit != null && collapsed ? nodes.slice(-limit) : nodes;
-  return { collapsed, shown: newestFirst ? [...kept].reverse() : kept };
+  return { collapsed, shown: newestFirst ? reverseByTimestamp(kept) : kept };
 }
 
 // ── Section ──────────────────────────────────────────────────────────────────

--- a/plugins/dev/scripts/orch-monitor/ui/src/components/ticket-discussion.tsx
+++ b/plugins/dev/scripts/orch-monitor/ui/src/components/ticket-discussion.tsx
@@ -706,6 +706,19 @@ function ActivityBurst({ node, now }: { node: BurstNode; now: number }) {
   );
 }
 
+/** The collapse + display-order math, pure so it stays testable (bun has no DOM).
+ *  Collapse keeps the NEWEST `limit` nodes (the stream is oldest-first);
+ *  `newestFirst` then flips DISPLAY order only — the underlying timeline stays
+ *  ascending, so burst coalescing and the same-ms tie-break are unaffected. */
+export function visibleTimelineNodes(
+  nodes: TimelineNode[],
+  { limit, showAll, newestFirst }: { limit?: number; showAll: boolean; newestFirst: boolean },
+): { collapsed: boolean; shown: TimelineNode[] } {
+  const collapsed = limit != null && !showAll && nodes.length > limit;
+  const kept = limit != null && collapsed ? nodes.slice(-limit) : nodes;
+  return { collapsed, shown: newestFirst ? [...kept].reverse() : kept };
+}
+
 // ── Section ──────────────────────────────────────────────────────────────────
 /**
  * The interleaved activity + comment timeline.
@@ -726,6 +739,7 @@ export function TicketTimeline({
   available = true,
   now = Date.now(),
   limit,
+  newestFirst = false,
   issueCreatedAt = null,
   error = null,
 }: {
@@ -735,6 +749,10 @@ export function TicketTimeline({
   available?: boolean;
   now?: number;
   limit?: number;
+  /** Render newest node at the TOP. Purely a render-layer flip — buildTimeline
+   *  stays ascending (bursts coalesce on the ascending stream), and collapse
+   *  still keeps the newest `limit` nodes. */
+  newestFirst?: boolean;
   /** The issue's own creation instant — gates the "created this issue" label. */
   issueCreatedAt?: number | null;
   /** Transport failure reason (fetch/HTTP), so an unreachable MONITOR is not
@@ -770,9 +788,7 @@ export function TicketTimeline({
     );
   }
 
-  // Collapsed view keeps the NEWEST nodes (the stream is oldest-first).
-  const collapsed = limit != null && !showAll && nodes.length > limit;
-  const shown = collapsed ? nodes.slice(-limit) : nodes;
+  const { collapsed, shown } = visibleTimelineNodes(nodes, { limit, showAll, newestFirst });
 
   return (
     <div data-ticket-timeline>


### PR DESCRIPTION
Ryan's 2026-07-31 feedback on the CTL-1574 Discussion feed ([CTL-1585](https://linear.app/rozich/issue/CTL-1585)). Three changes:

**A — Inbox reading pane reads newest-first.** `TicketTimeline` gains a `newestFirst` prop implemented as a pure render-layer flip (`visibleTimelineNodes`): `buildTimeline` stays ascending so burst coalescing, the same-ms tie-break, and all existing order tests are untouched; collapse still keeps the newest 5. The pane's Discussion label now carries a small "newest first" hint.

**B — Discussion visible on the ticket detail page without tab-hunting.** `DiscussionSection` (chronological, full stream) now renders inline below the ticket description on the default tab. The Discussion tab remains for deep links.

**C — "Spec" tab relabeled "Detail".** Label-only change: the internal `"spec"` value is kept so persisted entry state and old `?tab=spec` links keep resolving (tab state is entry-state-driven since CTL-1049; `?tab=spec` was never a valid URL value — it falls through to the default tab, which is this one). `execution-tab.contract.test.ts` now also locks `"discussion"` against accidental drops.

**Tests:** 5 new pure tests for `visibleTimelineNodes` (collapse keeps newest; newestFirst flips display only; showAll; no-limit; no source mutation). `bun test` 32/32 across the two touched suites; parent `tsc --noEmit` clean. The one `ui/` tsc error (`cluster-capacity.test.ts` missing `ticket` prop) is pre-existing on main and untouched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Wte59hchAL4FjhHiCwSVS3