### PR TITLE
fix(dev): CTL-1588 slot deck sees SDK-executor workers; queue partitions human-held tickets

### DIFF
--- a/plugins/dev/scripts/orch-monitor/__tests__/board-parked-needs-human.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/board-parked-needs-human.test.ts
@@ -186,3 +186,26 @@ describe("assembleBoard wiring — parked needs-human synthetic tickets", () => 
     expect(boardDataSrc).toContain("...parkedTickets");
   });
 });
+
+// ── CTL-1588: the queue must carry the human-hold annotation ─────────────────
+// "Dispatching next" is the raw eligible projection minus in-flight tickets; a
+// parked needs-human ticket that is still Todo in Linear sits in it and was
+// rendered as an imminent dispatch. The fix stamps `humanHold` from the SAME
+// parked descriptor set the attention cards use (annotate-not-hide — the eligible
+// projection itself must stay untouched: Pass-0a and the scheduler consume it).
+describe("CTL-1588: queue humanHold annotation (source contract)", () => {
+  const nospace = (s: string) => s.replace(/\s+/g, "");
+
+  it("assembleBoard builds the humanHold map from parkedNeedsHuman", () => {
+    expect(nospace(boardDataSrc)).toContain(nospace("const humanHoldByTicket = new Map("));
+    expect(nospace(boardDataSrc)).toContain(
+      nospace(`p.labels.includes("needs-input") ? "needs-input" : "needs-human"`),
+    );
+  });
+
+  it("every queue item is stamped with humanHold (null when dispatchable)", () => {
+    expect(nospace(boardDataSrc)).toContain(
+      nospace("humanHold: humanHoldByTicket.get(e.id) ?? null"),
+    );
+  });
+});

--- a/plugins/dev/scripts/orch-monitor/__tests__/board-parked-needs-human.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/board-parked-needs-human.test.ts
@@ -199,7 +199,7 @@ describe("CTL-1588: queue humanHold annotation (source contract)", () => {
   it("assembleBoard builds the humanHold map from parkedNeedsHuman", () => {
     expect(nospace(boardDataSrc)).toContain(nospace("const humanHoldByTicket = new Map("));
     expect(nospace(boardDataSrc)).toContain(
-      nospace(`p.labels.includes("needs-input") ? "needs-input" : "needs-human"`),
+      nospace(`p.labels.includes("needs-human") ? "needs-human" : "needs-input"`),
     );
   });
 

--- a/plugins/dev/scripts/orch-monitor/lib/board-data.mjs
+++ b/plugins/dev/scripts/orch-monitor/lib/board-data.mjs
@@ -2271,6 +2271,21 @@ export async function assembleBoard({ getPrStatus = null, ring = null } = {}) {
   );
   tickets = [...tickets, ...parkedTickets];
 
+  // CTL-1588: annotate-not-hide. A parked needs-human/needs-input ticket can
+  // still be Todo in Linear (so it sits in the eligible projection) while the
+  // admission gate holds it — presenting it as "dispatching next" is misleading.
+  // The parked descriptor set is already loaded above; stamp `humanHold` with the
+  // specific hold label so the UI can partition it out of the dispatchable rank.
+  // (`held` is reserved for the CTL-755 blocked/queued admission pair.) The
+  // eligible projection itself is NOT filtered (Pass-0a and the scheduler
+  // consume eligibleIds — daemon behavior must not change from a display fix).
+  const humanHoldByTicket = new Map(
+    parkedNeedsHuman.map((p) => [
+      p.ticket,
+      p.labels.includes("needs-input") ? "needs-input" : "needs-human",
+    ])
+  );
+
   // priority queue: eligible (not yet in-flight), globally ranked (Queue tab)
   const queue = await Promise.all(
     notInFlight.sort(compareDispatchOrder).map(async (e, i) => {
@@ -2304,6 +2319,9 @@ export async function assembleBoard({ getPrStatus = null, ring = null } = {}) {
         host: deriveHost([], linfo[e.id] ?? {}),
         // CTL-1066: active dispatch retry cool-down; null when not cooling down.
         dispatchCooldown: cooldowns.get(e.id) ?? null,
+        // CTL-1588: the human-hold keeping this ticket from dispatching
+        // ("needs-human" | "needs-input"), or null when genuinely dispatchable.
+        humanHold: humanHoldByTicket.get(e.id) ?? null,
       };
     })
   );

--- a/plugins/dev/scripts/orch-monitor/lib/board-data.mjs
+++ b/plugins/dev/scripts/orch-monitor/lib/board-data.mjs
@@ -2282,7 +2282,9 @@ export async function assembleBoard({ getPrStatus = null, ring = null } = {}) {
   const humanHoldByTicket = new Map(
     parkedNeedsHuman.map((p) => [
       p.ticket,
-      p.labels.includes("needs-input") ? "needs-input" : "needs-human",
+      // needs-human outranks needs-input on a dual-labeled ticket — same
+      // precedence as the parked cards / status counts / holding buckets.
+      p.labels.includes("needs-human") ? "needs-human" : "needs-input",
     ])
   );
 

--- a/plugins/dev/scripts/orch-monitor/ui/src/board/types.ts
+++ b/plugins/dev/scripts/orch-monitor/ui/src/board/types.ts
@@ -262,6 +262,11 @@ export interface BoardQueueItem {
   /** CTL-1066: active dispatch retry cool-down; drives the "retrying in …" chip.
    *  null when not cooling down. expiresAt is epoch ms; consecutiveFailures is the attempt count. */
   dispatchCooldown?: { expiresAt: number; consecutiveFailures: number } | null;
+  /** CTL-1588: the human-hold keeping this eligible ticket from actually
+   *  dispatching ("needs-human" | "needs-input"), stamped from the parked
+   *  descriptor set. The queue renders these in a separate held tail, never
+   *  tinted as an imminent dispatch. null/absent = genuinely dispatchable. */
+  humanHold?: "needs-human" | "needs-input" | null;
 }
 
 export interface BoardConfig {

--- a/plugins/dev/scripts/orch-monitor/ui/src/components/queue/cluster-capacity.test.ts
+++ b/plugins/dev/scripts/orch-monitor/ui/src/components/queue/cluster-capacity.test.ts
@@ -131,6 +131,21 @@ describe("assignClusterSlots (CTL-1092)", () => {
     expect(over[0]?.ticket).toBe("CTL-2");
   });
 
+  it("caps heartbeat-only additions by activeCount so worker turnover never double-counts (CTL-1588)", () => {
+    // Stale cached heartbeat still names CTL-OLD; a fresh local worker already
+    // replaced it with CTL-NEW. activeCount (1) is authoritative — no phantom
+    // second slot, no phantom OVER card.
+    const out = assignClusterSlots({
+      nodes: [{ host: "mini", status: "live", maxParallel: 4, inFlightCount: 1, activeCount: 1, freeSlots: 3, tickets: ["CTL-OLD"] }],
+      localHost: "mini",
+      localWorkers: [worker("w1", "mini", "CTL-NEW")],
+    });
+    const occupied = out.filter((s) => s.occupied);
+    expect(occupied.length).toBe(1);
+    expect(occupied[0]?.worker?.ticket).toBe("CTL-NEW");
+    expect(out.filter((s) => s.over).length).toBe(0);
+  });
+
   it("offline node produces no slot cards", () => {
     const out = assignClusterSlots({
       nodes: [liveNode("mini", 3, 1), offlineNode("laptop")],

--- a/plugins/dev/scripts/orch-monitor/ui/src/components/queue/cluster-capacity.test.ts
+++ b/plugins/dev/scripts/orch-monitor/ui/src/components/queue/cluster-capacity.test.ts
@@ -24,6 +24,7 @@ function offlineNode(host: string): SignalNode {
 function worker(name: string, hostName: string, ticket: string, startedAt = 1000): BoardWorker {
   return {
     name,
+    ticket,
     tickets: [ticket],
     phase: "implement",
     status: "running",
@@ -91,6 +92,43 @@ describe("assignClusterSlots (CTL-1092)", () => {
     });
     expect(out.filter((s) => s.occupied).length).toBe(0);
     expect(out.length).toBe(6); // 3 + 3 empty slots
+  });
+
+  it("unions self-host heartbeat tickets the worker list cannot see (CTL-1588: SDK executors)", () => {
+    // SDK/codex-exec executor children carry no bg-job id, so localWorkers can be
+    // EMPTY while the node's own heartbeat reports genuinely running tickets.
+    const out = assignClusterSlots({
+      nodes: [liveNode("mini-2", 4, 2, ["CTL-1417", "CTL-1557"])],
+      localHost: "mini-2",
+      localWorkers: [],
+    });
+    const occupied = out.filter((s) => s.occupied);
+    expect(occupied.map((s) => s.ticket)).toEqual(["CTL-1417", "CTL-1557"]);
+    expect(out.length).toBe(4); // 2 occupied + 2 empty — deck agrees with the pill
+  });
+
+  it("dedupes heartbeat tickets already covered by a rich local worker (CTL-1588)", () => {
+    const out = assignClusterSlots({
+      nodes: [liveNode("mini", 4, 2, ["CTL-1", "CTL-2"])],
+      localHost: "mini",
+      localWorkers: [worker("w1", "mini", "CTL-1")],
+    });
+    const occupied = out.filter((s) => s.occupied);
+    expect(occupied.length).toBe(2);
+    expect(occupied[0]?.worker?.ticket).toBe("CTL-1");
+    expect(occupied[1]?.ticket).toBe("CTL-2");
+    expect(out.length).toBe(4);
+  });
+
+  it("marks unioned heartbeat tickets beyond capacity as over (CTL-1588)", () => {
+    const out = assignClusterSlots({
+      nodes: [liveNode("mini", 1, 2, ["CTL-1", "CTL-2"])],
+      localHost: "mini",
+      localWorkers: [worker("w1", "mini", "CTL-1")],
+    });
+    const over = out.filter((s) => s.over);
+    expect(over.length).toBe(1);
+    expect(over[0]?.ticket).toBe("CTL-2");
   });
 
   it("offline node produces no slot cards", () => {

--- a/plugins/dev/scripts/orch-monitor/ui/src/components/queue/cluster-capacity.ts
+++ b/plugins/dev/scripts/orch-monitor/ui/src/components/queue/cluster-capacity.ts
@@ -98,7 +98,15 @@ export function assignClusterSlots({
         if (w.ticket) covered.add(w.ticket);
         for (const t of w.tickets ?? []) covered.add(t);
       }
-      const heartbeatOnly = (n.tickets ?? []).filter((t) => !covered.has(t));
+      let heartbeatOnly = (n.tickets ?? []).filter((t) => !covered.has(t));
+      // Bound the union by the authoritative occupancy COUNT: across a worker
+      // turnover the cached heartbeat can still name a ticket a fresh local
+      // worker already replaced — capping additions to the positive difference
+      // keeps turnover from double-counting (or minting a phantom OVER card).
+      const occ = n.activeCount;
+      if (occ != null) {
+        heartbeatOnly = heartbeatOnly.slice(0, Math.max(0, occ - localOccupied.length));
+      }
       const totalOccupied = localOccupied.length + heartbeatOnly.length;
       for (let i = 0; i < localOccupied.length; i++) {
         slots.push({

--- a/plugins/dev/scripts/orch-monitor/ui/src/components/queue/cluster-capacity.ts
+++ b/plugins/dev/scripts/orch-monitor/ui/src/components/queue/cluster-capacity.ts
@@ -86,8 +86,20 @@ export function assignClusterSlots({
       // Rich local slots via existing assignSlots. CTL-1581: over-capacity
       // workers are real processes — surface them as EXTRA occupied slots so
       // the box-derived headline shows the true 5/4 instead of clamping to 4/4.
-      const { occupied, emptyCount, overCapacity } = assignSlots(localWorkers, mp);
+      const { occupied, overCapacity } = assignSlots(localWorkers, mp);
       const localOccupied = [...occupied, ...overCapacity];
+      // CTL-1588: SDK/codex-exec executor children carry no bg-job id, so the
+      // board's live-agent worker list is structurally blind to them while the
+      // node's own heartbeat reports them active. Union in heartbeat tickets no
+      // worker covers (ticket-label slots, like a remote node) so the self-host
+      // deck agrees with its pill instead of rendering all-Open under load.
+      const covered = new Set<string>();
+      for (const w of localOccupied) {
+        if (w.ticket) covered.add(w.ticket);
+        for (const t of w.tickets ?? []) covered.add(t);
+      }
+      const heartbeatOnly = (n.tickets ?? []).filter((t) => !covered.has(t));
+      const totalOccupied = localOccupied.length + heartbeatOnly.length;
       for (let i = 0; i < localOccupied.length; i++) {
         slots.push({
           host: n.host,
@@ -97,8 +109,18 @@ export function assignClusterSlots({
           ...(mp > 0 && i >= mp ? { over: true } : {}),
         });
       }
-      for (let i = 0; i < emptyCount; i++) {
-        slots.push({ host: n.host, slotIndex: localOccupied.length + i, occupied: false });
+      for (let i = 0; i < heartbeatOnly.length; i++) {
+        const slotIndex = localOccupied.length + i;
+        slots.push({
+          host: n.host,
+          slotIndex,
+          occupied: true,
+          ticket: heartbeatOnly[i],
+          ...(mp > 0 && slotIndex >= mp ? { over: true } : {}),
+        });
+      }
+      for (let i = 0; i < Math.max(0, mp - totalOccupied); i++) {
+        slots.push({ host: n.host, slotIndex: totalOccupied + i, occupied: false });
       }
     } else if (Array.isArray(n.tickets)) {
       // Remote node with KNOWN occupancy labels ([] = known idle). May exceed

--- a/plugins/dev/scripts/orch-monitor/ui/src/components/queue/dispatch-queue.tsx
+++ b/plugins/dev/scripts/orch-monitor/ui/src/components/queue/dispatch-queue.tsx
@@ -152,6 +152,19 @@ export function DispatchQueue({
   const globalRankById = new Map<string, number>();
   dispatchQueue.forEach((q, i) => globalRankById.set(q.id, i + 1));
 
+  const renderHeldRow = (q: BoardQueueItem, indexInList: number) => (
+    <DispatchRow
+      key={q.id}
+      q={q}
+      globalRank={null}
+      dispatchable={false}
+      isFirstDispatch={false}
+      multiHost={multiHost}
+      withTopHairline={indexInList > 0}
+      onOpenTicket={onOpenTicket}
+    />
+  );
+
   const renderRow = (q: BoardQueueItem, indexInList: number) => {
     const globalRank = globalRankById.get(q.id) ?? indexInList + 1;
     const dispatchable = globalRank <= dispatchCount;
@@ -219,27 +232,30 @@ export function DispatchQueue({
       )}
 
       {/* CTL-1588: held tail — eligible tickets the admission gate is holding for
-          the operator. Dim, un-ranked, never tinted as an imminent dispatch. */}
+          the operator. Dim, un-ranked, never tinted as an imminent dispatch.
+          Honors the same By-node grouping as the dispatchable list above. */}
       {heldQueue.length > 0 && (
         <div data-dispatch-held-section style={{ marginTop: 10 }}>
           <div style={{ padding: "6px 8px", background: C.s1, borderRadius: 6 }}>
             <span style={{ fontSize: 12, fontWeight: 600, color: C.fgMuted }}>Held — awaiting you</span>
             <span style={{ fontSize: 12, color: C.fgDim }}> · {heldQueue.length}</span>
           </div>
-          <AnimatePresence initial={false}>
-            {heldQueue.map((q, i) => (
-              <DispatchRow
-                key={q.id}
-                q={q}
-                globalRank={null}
-                dispatchable={false}
-                isFirstDispatch={false}
-                multiHost={multiHost}
-                withTopHairline={i > 0}
-                onOpenTicket={onOpenTicket}
-              />
-            ))}
-          </AnimatePresence>
+          {grouped ? (
+            groupQueueByHost(heldQueue).map((g: QueueHostGroup) => (
+              <Fragment key={`held-${g.host?.id ?? g.label}`}>
+                <div style={{ padding: "4px 8px" }}>
+                  <span style={{ fontSize: 12, color: C.fgDim }}>{g.label} · {g.items.length} held</span>
+                </div>
+                <AnimatePresence initial={false}>
+                  {g.items.map((q, i) => renderHeldRow(q, i))}
+                </AnimatePresence>
+              </Fragment>
+            ))
+          ) : (
+            <AnimatePresence initial={false}>
+              {heldQueue.map((q, i) => renderHeldRow(q, i))}
+            </AnimatePresence>
+          )}
         </div>
       )}
     </section>

--- a/plugins/dev/scripts/orch-monitor/ui/src/components/queue/dispatch-queue.tsx
+++ b/plugins/dev/scripts/orch-monitor/ui/src/components/queue/dispatch-queue.tsx
@@ -23,7 +23,7 @@ import {
 } from "../../board/queue-grouping";
 import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group";
 import type { BoardQueueItem } from "../../board/types";
-import { ordinal, fmtAge, fmtCountdown } from "./queue-model";
+import { ordinal, fmtAge, fmtCountdown, partitionHumanHeld } from "./queue-model";
 import { QueueRowShell } from "./queue-row";
 
 const DISPATCH_BG = "rgba(65,189,125,0.05)";
@@ -41,7 +41,8 @@ function DispatchRow({
   onOpenTicket,
 }: {
   q: BoardQueueItem;
-  globalRank: number;
+  /** null in the held tail — a held row has no dispatch position. */
+  globalRank: number | null;
   dispatchable: boolean;
   isFirstDispatch: boolean;
   multiHost: boolean;
@@ -75,7 +76,7 @@ function DispatchRow({
               flex: "0 0 auto",
             }}
           >
-            {ordinal(globalRank)}
+            {globalRank == null ? "•" : ordinal(globalRank)}
           </span>
         }
         repo={q.repo}
@@ -87,6 +88,11 @@ function DispatchRow({
         onClick={onOpenTicket ? () => onOpenTicket(q.id) : undefined}
         meta={
           <>
+            {q.humanHold && (
+              <span style={{ fontFamily: C.mono, fontSize: 11, color: C.yellow, lineHeight: "18px" }}>
+                {q.humanHold}
+              </span>
+            )}
             <ScopeChip scope={q.scope} estimate={q.estimate} estimateDisplay={q.estimateDisplay} />
             {q.dispatchCooldown && (
               <span style={{ fontFamily: C.mono, fontSize: 11, color: C.fgMuted, lineHeight: "18px" }}>
@@ -130,15 +136,21 @@ export function DispatchQueue({
   const multiHost = queueHostMode(queue) === "multi";
   const [groupByNode, setGroupByNode] = useState(false);
   const grouped = multiHost && groupByNode;
-  const coolingCount = queue.filter((q) => q.dispatchCooldown).length;
+
+  // CTL-1588: a human-held ticket is eligible-but-not-dispatchable — the
+  // admission gate holds it until the operator acts. Partition it OUT of the
+  // rank/tint math (it must never read as an imminent dispatch) and render it
+  // in the dim held tail below.
+  const { dispatchQueue, heldQueue } = partitionHumanHeld(queue);
+  const coolingCount = dispatchQueue.filter((q) => q.dispatchCooldown).length;
 
   // dispatches-next affordance: the top min(freeSlots, queue.length) rows tint.
-  const dispatchCount = Math.min(Math.max(0, freeSlots), queue.length);
+  const dispatchCount = Math.min(Math.max(0, freeSlots), dispatchQueue.length);
 
-  // GLOBAL rank: position within the full queue (1-based), keyed by id so grouped
-  // sections preserve the same number the flat list would show.
+  // GLOBAL rank: position within the dispatchable queue (1-based), keyed by id so
+  // grouped sections preserve the same number the flat list would show.
   const globalRankById = new Map<string, number>();
-  queue.forEach((q, i) => globalRankById.set(q.id, i + 1));
+  dispatchQueue.forEach((q, i) => globalRankById.set(q.id, i + 1));
 
   const renderRow = (q: BoardQueueItem, indexInList: number) => {
     const globalRank = globalRankById.get(q.id) ?? indexInList + 1;
@@ -162,7 +174,7 @@ export function DispatchQueue({
     <section>
       <div style={{ display: "flex", alignItems: "center", gap: 8, marginBottom: 6 }}>
         <span style={{ fontSize: 13, fontWeight: 600, color: C.fg }}>Dispatching next</span>
-        <span style={{ fontSize: 13, fontWeight: 400, color: C.fgDim }}>· {queue.length} waiting{coolingCount > 0 ? ` · ${coolingCount} cooling down` : ""}</span>
+        <span style={{ fontSize: 13, fontWeight: 400, color: C.fgDim }}>· {dispatchQueue.length} waiting{coolingCount > 0 ? ` · ${coolingCount} cooling down` : ""}{heldQueue.length > 0 ? ` · ${heldQueue.length} held` : ""}</span>
         <span style={{ flex: 1 }} />
         {multiHost && (
           <ToggleGroup
@@ -182,11 +194,11 @@ export function DispatchQueue({
         )}
       </div>
 
-      {queue.length === 0 ? (
+      {dispatchQueue.length === 0 && heldQueue.length === 0 ? (
         <EmptyState freeSlots={freeSlots} />
       ) : grouped ? (
         <div>
-          {groupQueueByHost(queue).map((g: QueueHostGroup) => (
+          {groupQueueByHost(dispatchQueue).map((g: QueueHostGroup) => (
             <Fragment key={g.host?.id ?? g.label}>
               <div style={{ padding: "6px 8px", background: C.s1, borderRadius: 6 }}>
                 <span style={{ fontSize: 12, fontWeight: 600, color: C.fg }}>{g.label}</span>
@@ -201,7 +213,32 @@ export function DispatchQueue({
       ) : (
         <div>
           <AnimatePresence initial={false}>
-            {queue.map((q, i) => renderRow(q, i))}
+            {dispatchQueue.map((q, i) => renderRow(q, i))}
+          </AnimatePresence>
+        </div>
+      )}
+
+      {/* CTL-1588: held tail — eligible tickets the admission gate is holding for
+          the operator. Dim, un-ranked, never tinted as an imminent dispatch. */}
+      {heldQueue.length > 0 && (
+        <div data-dispatch-held-section style={{ marginTop: 10 }}>
+          <div style={{ padding: "6px 8px", background: C.s1, borderRadius: 6 }}>
+            <span style={{ fontSize: 12, fontWeight: 600, color: C.fgMuted }}>Held — awaiting you</span>
+            <span style={{ fontSize: 12, color: C.fgDim }}> · {heldQueue.length}</span>
+          </div>
+          <AnimatePresence initial={false}>
+            {heldQueue.map((q, i) => (
+              <DispatchRow
+                key={q.id}
+                q={q}
+                globalRank={null}
+                dispatchable={false}
+                isFirstDispatch={false}
+                multiHost={multiHost}
+                withTopHairline={i > 0}
+                onOpenTicket={onOpenTicket}
+              />
+            ))}
           </AnimatePresence>
         </div>
       )}

--- a/plugins/dev/scripts/orch-monitor/ui/src/components/queue/queue-model.test.ts
+++ b/plugins/dev/scripts/orch-monitor/ui/src/components/queue/queue-model.test.ts
@@ -12,6 +12,7 @@ import {
   groupHoldingBuckets,
   holdingTicketIds,
   deadWorkers,
+  partitionHumanHeld,
 } from "./queue-model";
 
 function w(p: Partial<BoardWorker> & { name: string; ticket: string }): BoardWorker {
@@ -404,5 +405,30 @@ describe("groupHoldingBuckets — queued/needsInput/needsHuman (CTL-764 Phase 8)
     expect(ids).toContain("CTL-10");
     expect(ids).toContain("CTL-11");
     expect(ids).toContain("CTL-12");
+  });
+});
+
+describe("partitionHumanHeld (CTL-1588)", () => {
+  const q = (id: string, humanHold: "needs-human" | "needs-input" | null = null) => ({ id, humanHold });
+
+  it("splits held rows out of the dispatchable queue, preserving order in both halves", () => {
+    const { dispatchQueue, heldQueue } = partitionHumanHeld([
+      q("CTL-1557"),
+      q("CRM-1", "needs-human"),
+      q("CTL-1417"),
+      q("CRM-5", "needs-input"),
+    ]);
+    expect(dispatchQueue.map((x) => x.id)).toEqual(["CTL-1557", "CTL-1417"]);
+    expect(heldQueue.map((x) => x.id)).toEqual(["CRM-1", "CRM-5"]);
+  });
+
+  it("treats absent/null humanHold as dispatchable", () => {
+    const items: Array<{ id: string; humanHold?: "needs-human" | "needs-input" | null }> = [
+      { id: "A" },
+      q("B", null),
+    ];
+    const { dispatchQueue, heldQueue } = partitionHumanHeld(items);
+    expect(dispatchQueue).toHaveLength(2);
+    expect(heldQueue).toHaveLength(0);
   });
 });

--- a/plugins/dev/scripts/orch-monitor/ui/src/components/queue/queue-model.ts
+++ b/plugins/dev/scripts/orch-monitor/ui/src/components/queue/queue-model.ts
@@ -62,6 +62,19 @@ export function ordinal(n: number): string {
   return `${n}${suffix}`;
 }
 
+/** CTL-1588: split the eligible queue into genuinely dispatchable rows and
+ *  human-held rows (needs-human/needs-input park). Held rows must never enter
+ *  the rank/tint math — presenting a parked ticket as "dispatching next" is a
+ *  lie the admission gate will not honor. Order is preserved within each half. */
+export function partitionHumanHeld<T extends { humanHold?: string | null }>(
+  queue: readonly T[],
+): { dispatchQueue: T[]; heldQueue: T[] } {
+  const dispatchQueue: T[] = [];
+  const heldQueue: T[] = [];
+  for (const q of queue) (q.humanHold ? heldQueue : dispatchQueue).push(q);
+  return { dispatchQueue, heldQueue };
+}
+
 // ── slot assignment ────────────────────────────────────────────────────────────
 
 export interface SlotAssignment {

--- a/plugins/dev/scripts/orch-monitor/ui/src/components/queue/slot-deck.tsx
+++ b/plugins/dev/scripts/orch-monitor/ui/src/components/queue/slot-deck.tsx
@@ -160,7 +160,19 @@ function EmptyCard({ slotLabel, first }: { slotLabel: string; first: boolean }) 
 
 // RemoteSlotCard — lightweight card for a remote node's in-flight ticket (CTL-1092).
 // Shows host chip + ticket id only; no worker detail (cross-node tail is CTL-885).
-function RemoteSlotCard({ slot }: { slot: ClusterSlot }) {
+function RemoteSlotCard({
+  slot,
+  local = false,
+  onOpenTicket,
+}: {
+  slot: ClusterSlot;
+  /** CTL-1588: a heartbeat-only slot on the SELF host (SDK/codex-exec worker the
+   *  live-agent list cannot see) renders through this lightweight card too —
+   *  label it honestly and keep the ticket clickable. */
+  local?: boolean;
+  onOpenTicket?: (key: string) => void;
+}) {
+  const ticket = slot.ticket;
   return (
     <div
       style={{
@@ -178,14 +190,23 @@ function RemoteSlotCard({ slot }: { slot: ClusterSlot }) {
         <span style={{ fontSize: 10, color: slot.over ? C.yellow : C.fgDim, letterSpacing: 1.2, textTransform: "uppercase", fontFamily: C.mono }}>
           {slot.over ? "OVER" : slotLabel(slot.slotIndex + 1)}
         </span>
-        <span style={{ fontSize: 10, color: C.fgDim, fontFamily: C.mono }}>remote</span>
+        <span style={{ fontSize: 10, color: C.fgDim, fontFamily: C.mono }}>{local ? "local" : "remote"}</span>
       </div>
       <div style={{ display: "flex", alignItems: "center", gap: 6, marginTop: 8 }}>
         <span style={{ fontSize: 10, color: C.fgDim, background: C.s3, borderRadius: 4, padding: "2px 5px", fontFamily: C.mono }}>{slot.host}</span>
         {/* CTL-1581: count-based fallback slots (old-daemon/anchor peers) have no
             ticket label — an honest "busy" beats a false Open. */}
-        <span style={{ fontFamily: C.mono, fontSize: 13, fontWeight: 600, color: slot.ticket ? C.blue : C.fgDim }}>
-          {slot.ticket ?? "busy"}
+        <span
+          style={{
+            fontFamily: C.mono,
+            fontSize: 13,
+            fontWeight: 600,
+            color: ticket ? C.blue : C.fgDim,
+            cursor: ticket && onOpenTicket ? "pointer" : undefined,
+          }}
+          onClick={ticket && onOpenTicket ? () => onOpenTicket(ticket) : undefined}
+        >
+          {ticket ?? "busy"}
         </span>
       </div>
     </div>
@@ -310,8 +331,16 @@ export function SlotDeck({
                   />
                 );
               }
-              // Remote slot with ticket label
-              return <RemoteSlotCard key={`remote-${slot.host}-${slot.slotIndex}`} slot={slot} />;
+              // Ticket-label slot: a remote node's worker, or a SELF-host worker
+              // only the heartbeat can see (CTL-1588: SDK/codex-exec executors).
+              return (
+                <RemoteSlotCard
+                  key={`remote-${slot.host}-${slot.slotIndex}`}
+                  slot={slot}
+                  local={slot.host === localHost}
+                  onOpenTicket={onOpenTicket}
+                />
+              );
             })}
           </AnimatePresence>
         </div>


### PR DESCRIPTION
Fixes the two REAL defects behind Ryan's contradictory mini-2 Workers page ([CTL-1588](https://linear.app/rozich/issue/CTL-1588); the header self-contradiction itself was deploy skew — stale SPA tab — filed separately as CTL-1591).

**1 — Self-host slot boxes were blind to SDK/codex-exec workers.** The node pill counts heartbeat occupancy (`activeCount` — CTL-1417/CTL-1557 were genuinely running), but the self-host deck rendered from `payload.workers`, built from `claude agents --json` + bg-job dirs. In-process executor children carry `bg_job_id: null`, so `workers: []` → all boxes Open under a 2/4 pill. `assignClusterSlots`' local branch now unions the node's own heartbeat tickets (dedup against rich worker refs; ticket-label slots like a remote node; `over` marker preserved), so the deck agrees with the pill.

**2 — "Dispatching next" presented held tickets as imminent.** The queue is the raw eligible projection minus in-flight; parked needs-human CRM-1/2/5/6 ranked 1st–6th "waiting" with green dispatch tint. board-data now stamps `humanHold` ("needs-human" | "needs-input") from the already-loaded parked descriptor set, and `DispatchQueue` partitions held rows out of the rank/tint math into a dim "Held — awaiting you" tail. The eligible projection itself is untouched (Pass-0a phantom sweep + scheduler consume `eligibleIds` — a display fix must not change daemon behavior).

Also fixes the pre-existing `ui/` tsc error (`cluster-capacity.test.ts` factory missing required `BoardWorker.ticket`).

**Tests:** 3 new union tests (heartbeat-only occupancy, dedup, over-capacity), 2 partition tests, 2 board-data source-contract guards. Full ui suite 1819/1819; parent `tsc --noEmit` + `bunx tsc --noEmit` (ui) clean; `__tests__/board-parked-needs-human.test.ts` 15/15.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Wte59hchAL4FjhHiCwSVS3