### PR TITLE
fix(dev): CTL-1589 level-triggered triage sweep — pick up tickets already sitting in Triage

### DIFF
--- a/.github/workflows/execution-core-tests.yml
+++ b/.github/workflows/execution-core-tests.yml
@@ -433,6 +433,7 @@ jobs:
             reconcile-health-event.test.mjs \
             recovery.test.mjs \
             registry.test.mjs \
+            replica-read.test.mjs \
             scan.test.mjs \
             scheduler-perproject.test.mjs \
             scheduler-rank.test.mjs \

--- a/plugins/dev/scripts/execution-core/linear-query.mjs
+++ b/plugins/dev/scripts/execution-core/linear-query.mjs
@@ -1365,3 +1365,57 @@ export function runEligibleQuery(
   recordDaemonRead(liveListSource, "ok", null, null, "eligible_list"); // CTL-1580: only after a clean parse
   return tickets;
 }
+
+// runTriageStateQuery — the sibling of runEligibleQuery that lists the tickets
+// currently SITTING IN the team's Triage state (CTL-1589). runEligibleQuery binds
+// `query.status` (Todo), so a ticket parked in Triage was invisible to every list
+// read the daemon does; triage admission was EDGE-triggered only (the →Triage
+// webhook), and a ticket whose one-shot dispatch was consumed could never be
+// re-noticed. sweepMissingTriage unions this read with the eligible set to make
+// that admission level-triggered.
+//
+// REPLICA-ONLY, deliberately — no `linearis issues list` fallback, which is the
+// one structural difference from runEligibleQuery. This read is SUPPLEMENTARY:
+// an unavailable answer costs one 10-minute sweep, where an unavailable eligible
+// board freezes admission fleet-wide (hence that path's linearis confirm +
+// empty-marker + breaker machinery). Adding a per-team live list on the reconcile
+// cadence would re-introduce exactly the shared-quota burn the replica tier exists
+// to remove. So: a DEFINED replica answer is served as-is (its writer-liveness +
+// seed-cursor + snapshot gates already prove it real), and anything else yields
+// [] with a distinguishing `onSource` marker for the caller to log. Consequence:
+// on a host with the replica tier OFF this read is inert and the sweep keeps its
+// pre-CTL-1589 eligible-only behavior — the caller reports that loudly.
+//
+// Also unlike runEligibleQuery: no priority floor, no project/label filter (see
+// replica-read's triageState — this mirrors the webhook →Triage predicate, which
+// applies neither), and no delegate batch (dispatchTriage resolves ownership per
+// ticket at its own claim gate).
+//
+// onSource(source, count) markers: "replica" (served) · "no-triage-status" (the
+// team configures none) · "no-replica" (tier off / no reader wired) ·
+// "replica-miss" (dead writer, mid-reseed, or a throw).
+export function runTriageStateQuery(query, { replica, onSource } = {}) {
+  if (!query?.triageStatus) {
+    onSource?.("no-triage-status", 0);
+    return [];
+  }
+  if (!replica?.triageState) {
+    onSource?.("no-replica", 0);
+    return [];
+  }
+  let local;
+  try {
+    local = replica.triageState(query);
+  } catch {
+    local = undefined;
+  }
+  if (!local || !Array.isArray(local.nodes)) {
+    onSource?.("replica-miss", 0);
+    recordDaemonRead("replica", "failed", null, null, "triage_list");
+    return [];
+  }
+  const tickets = local.nodes.map(normalizeTicket);
+  onSource?.("replica", tickets.length);
+  recordDaemonRead("replica", "ok", null, null, "triage_list");
+  return tickets;
+}

--- a/plugins/dev/scripts/execution-core/linear-query.test.mjs
+++ b/plugins/dev/scripts/execution-core/linear-query.test.mjs
@@ -9,6 +9,7 @@ import { __resetDispatchAlertThrottle } from "./dispatch-alert.mjs";
 import {
   buildLinearisArgs,
   runEligibleQuery,
+  runTriageStateQuery,
   __resetEligibleEmptyConfirm,
   fetchTicketState,
   fetchTicketLabels,
@@ -2679,5 +2680,109 @@ describe("runEligibleQuery structural body validation (CTL-1580 round 6)", () =>
     expect(() =>
       runEligibleQuery({ team: "PROJ", status: "Todo" }, { exec, now: () => 0 })
     ).toThrow(/nodes/);
+  });
+});
+
+// CTL-1589 — runTriageStateQuery: the Triage-state list that makes triage
+// admission level-triggered. REPLICA-ONLY by design (a supplementary read must
+// not add a per-team live list on the reconcile cadence), so the contract these
+// pin is: served from the replica or not at all, never a Linear call, and every
+// non-served case distinguishable via onSource so the caller can log it.
+describe("runTriageStateQuery (CTL-1589)", () => {
+  const query = { team: "CTL", status: "Todo", triageStatus: "Triage", project: null, label: null, priority: null };
+
+  // A replica stub whose triageState() returns a canned board-shaped result.
+  function replicaReturning(nodes) {
+    const calls = [];
+    return { calls, triageState: (q) => { calls.push(q); return { nodes }; } };
+  }
+
+  test("HIT: normalizes the replica board and records onSource('replica')", () => {
+    const replica = replicaReturning([
+      {
+        identifier: "ADV-1374",
+        title: "Stranded in triage",
+        state: "Triage",
+        priority: 1,
+        relations: { nodes: [] },
+        inverseRelations: { nodes: [] },
+      },
+    ]);
+    const sources = [];
+    const tickets = runTriageStateQuery(query, {
+      replica,
+      onSource: (source, count) => sources.push([source, count]),
+    });
+    expect(tickets).toHaveLength(1);
+    expect(tickets[0]).toMatchObject({ identifier: "ADV-1374", state: "Triage", priority: 1 });
+    expect(replica.calls).toEqual([query]); // the whole query reaches triageState()
+    expect(sources).toEqual([["replica", 1]]);
+  });
+
+  // Unlike the eligible board, an empty Triage board is served as-is: there is no
+  // freeze to avoid, so no linearis re-confirmation is worth the quota.
+  test("replica-EMPTY is trusted as-is (no confirmation, no Linear call)", () => {
+    const sources = [];
+    const tickets = runTriageStateQuery(query, {
+      replica: replicaReturning([]),
+      onSource: (source, count) => sources.push([source, count]),
+    });
+    expect(tickets).toEqual([]);
+    expect(sources).toEqual([["replica", 0]]);
+  });
+
+  test("the priority floor is NOT applied (mirrors the webhook →Triage predicate)", () => {
+    const replica = replicaReturning([
+      { identifier: "CTL-1", state: "Triage", priority: 4 },
+      { identifier: "CTL-2", state: "Triage", priority: 0 },
+    ]);
+    // A floor of 2 would drop both under runEligibleQuery's filter.
+    const tickets = runTriageStateQuery({ ...query, priority: 2 }, { replica });
+    expect(tickets.map((t) => t.identifier)).toEqual(["CTL-1", "CTL-2"]);
+  });
+
+  test("replica MISS (undefined) → [] with onSource('replica-miss'), never a linearis spawn", () => {
+    const sources = [];
+    const tickets = runTriageStateQuery(query, {
+      replica: { triageState: () => undefined },
+      onSource: (source, count) => sources.push([source, count]),
+    });
+    expect(tickets).toEqual([]);
+    expect(sources).toEqual([["replica-miss", 0]]);
+  });
+
+  test("a THROW out of the replica is swallowed → [] with onSource('replica-miss')", () => {
+    const sources = [];
+    const tickets = runTriageStateQuery(query, {
+      replica: { triageState: () => { throw new Error("db locked"); } },
+      onSource: (source, count) => sources.push([source, count]),
+    });
+    expect(tickets).toEqual([]);
+    expect(sources).toEqual([["replica-miss", 0]]);
+  });
+
+  // The replica tier is opt-in per host. With it off this read is INERT — the
+  // marker is what makes that visible rather than a silent no-op.
+  test("no replica wired → [] with onSource('no-replica')", () => {
+    const sources = [];
+    expect(runTriageStateQuery(query, { onSource: (s, c) => sources.push([s, c]) })).toEqual([]);
+    expect(sources).toEqual([["no-replica", 0]]);
+  });
+
+  test("a team with no triageStatus → [] with onSource('no-triage-status'), replica never consulted", () => {
+    const replica = replicaReturning([{ identifier: "CTL-1", state: "Triage" }]);
+    const sources = [];
+    const tickets = runTriageStateQuery(
+      { ...query, triageStatus: null },
+      { replica, onSource: (s, c) => sources.push([s, c]) }
+    );
+    expect(tickets).toEqual([]);
+    expect(sources).toEqual([["no-triage-status", 0]]);
+    expect(replica.calls).toEqual([]);
+  });
+
+  test("no query at all → [] (never throws into the sweep)", () => {
+    expect(runTriageStateQuery(undefined)).toEqual([]);
+    expect(runTriageStateQuery({})).toEqual([]);
   });
 });

--- a/plugins/dev/scripts/execution-core/monitor.mjs
+++ b/plugins/dev/scripts/execution-core/monitor.mjs
@@ -857,6 +857,37 @@ function dispatchTriage(
   // the triage worker as CATALYST_CLUSTER_GENERATION (mirrors CTL-864 scheduler
   // path). null on single-host → writeClusterGeneration and dispatchTicket both
   // treat null as a no-op (fence token is omitted from the env).
+  // CTL-1589 (Codex R3+R4): live revalidation for a Triage-BOARD candidate.
+  // Placement is deliberate on BOTH sides: AFTER the drain/HRW/delegate/cap
+  // gates (R3 P1 — the bare live read fires only for a dispatch this host would
+  // genuinely make, so the rate is bounded by launch attempts, never a
+  // per-sweep/per-candidate probe) and BEFORE the cross-host claim (R4 P1 — a
+  // skip must not bump the fence generation out from under a live later-phase
+  // worker holding the current one). A replica row can have MISSED the ticket's
+  // exit from Triage (delivery hole), and the CTL-758 guard refuses only
+  // TERMINAL backward writes — without this check the later status write could
+  // drag an advanced ticket back to Triage. FAIL-CLOSED (R4 P1): an unreadable
+  // live state skips this sweep — a stranded ticket loses one cycle (the next
+  // sweep retries), while proceeding blind could double-launch AND regress the
+  // ticket's state. No verdict caching: a cached positive could go stale after
+  // a failed dispatch and redispatch an advanced ticket on the next sweep.
+  if (requireTriageState) {
+    let live = null;
+    try {
+      live = fetchLiveState(identifier);
+    } catch {
+      live = null;
+    }
+    if (live !== requireTriageState) {
+      log.info(
+        { identifier, live, expected: requireTriageState },
+        live == null
+          ? "dispatchTriage: Triage-board candidate's live state unreadable — holding this sweep (CTL-1589)"
+          : "dispatchTriage: replica Triage row is stale — ticket already advanced; skipping (CTL-1589)"
+      );
+      return false;
+    }
+  }
   let clusterGeneration = null;
   if (multiHost) {
     const claim = claimDispatch({ ticket: identifier, hostName: self, phase: "triage" });
@@ -868,31 +899,6 @@ function dispatchTriage(
       return false;
     }
     clusterGeneration = claim.generation; // CTL-1028: forward to worker (mirrors CTL-864)
-  }
-  // CTL-1589 (Codex R3): live revalidation for a Triage-BOARD candidate, placed
-  // launch-imminent (post-drain/HRW/delegate/claim gates) so the bare live read
-  // fires only for a dispatch this host is genuinely about to launch — bounded
-  // by real launches, never a per-sweep/per-candidate probe. A replica row can
-  // have MISSED the ticket's exit from Triage (delivery hole), and the CTL-758
-  // guard refuses only TERMINAL backward writes — without this check the later
-  // status write could drag an advanced ticket back to Triage. No verdict is
-  // cached: a cached positive could go stale after a failed dispatch and
-  // redispatch an advanced ticket on the next sweep. Unreadable (null) proceeds
-  // — recovery bias; the status write re-reads.
-  if (requireTriageState) {
-    let live = null;
-    try {
-      live = fetchLiveState(identifier);
-    } catch {
-      /* unreadable → proceed */
-    }
-    if (live != null && live !== requireTriageState) {
-      log.info(
-        { identifier, live, expected: requireTriageState },
-        "dispatchTriage: replica Triage row is stale — ticket already advanced; skipping (CTL-1589)"
-      );
-      return false;
-    }
   }
   // CTL-1441 guard (a), placed HERE (post-gates, post-claim, launch imminent —
   // Codex R3): a done phase-triage.json with triage.json missing is the
@@ -1265,6 +1271,12 @@ export function sweepMissingTriage({
       // budget gate); everything else waits for the next sweep.
       if (budget.remaining <= 0 && readTriageDispatchCount(orchDir, t.identifier) < TRIAGE_DISPATCH_CAP) continue;
       if (hasTriageArtifact(orchDir, t.identifier)) continue;
+      // CTL-1589 (Codex R4): a Triage-STATE ticket whose triage worker is
+      // in-flight right now has no artifact yet and would route to an
+      // idempotent no-op launch — which still decrements the sweep budget
+      // (code 0) and would pay a pointless live revalidation read. Skip it
+      // here; the eligible half keeps its pre-existing behavior.
+      if (t.fromTriageBoard && isTriageInFlight(readTriageSignalStatus(orchDir, t.identifier))) continue;
       // CTL-1441 guard (a) note: the done-signal/missing-triage.json mismatch is
       // handled INSIDE dispatchTriage (post-gates, launch-imminent — Codex R3),
       // where the stale completion signal is retired immediately before a real

--- a/plugins/dev/scripts/execution-core/monitor.mjs
+++ b/plugins/dev/scripts/execution-core/monitor.mjs
@@ -1256,12 +1256,21 @@ export function sweepMissingTriage({
     // is busy. The stranded set is small and self-draining (one successful
     // triage removes the ticket permanently), while the eligible half retries
     // on the next 60s sweep — so stranded-first costs the Todo path at most one
-    // sweep of latency. Dual-presence is impossible in practice (a ticket has
-    // one state); dedup is belt-and-suspenders.
+    // sweep of latency. DUAL-PRESENCE (Codex R5): a feed hole can leave a stale
+    // Triage row for a ticket the live-confirmed eligible query reports as
+    // Todo — the Triage copy would walk first, fail launch revalidation, and
+    // its `seen` entry would then skip the genuinely dispatchable eligible
+    // copy every sweep. The eligible copy is the authoritative one (it came
+    // from a live-confirmed source and pays no revalidation), so a
+    // dual-present ticket keeps ONLY that copy.
+    const eligibleSet = getEligibleSet(p.team);
+    const eligibleIds = new Set(eligibleSet.map((t) => t.identifier));
     const seen = new Set();
     const candidates = [
-      ...triageStateTickets(p, { replica, runTriageState }),
-      ...getEligibleSet(p.team),
+      ...triageStateTickets(p, { replica, runTriageState }).filter(
+        (t) => !eligibleIds.has(t.identifier)
+      ),
+      ...eligibleSet,
     ];
     for (const t of candidates) {
       if (seen.has(t.identifier)) continue;

--- a/plugins/dev/scripts/execution-core/monitor.mjs
+++ b/plugins/dev/scripts/execution-core/monitor.mjs
@@ -1093,7 +1093,16 @@ export function markTriageCapped(orchDir, ticket, { now = () => new Date().toISO
 // unavailable cases are logged at WARN and never silent: with the replica tier
 // off (or its writer dead) this half of the fix is INERT, and a stranded Triage
 // ticket would otherwise look like a mysterious no-op.
-function triageStateTickets(entry, { replica, runTriageState }) {
+// TRIAGE_STATE_MIN_DWELL_MS — only sweep Triage rows that have DWELLED (Codex
+// R1 on #2843): a ticket that entered Triage seconds ago is the webhook fast
+// path's job, and a lagging replica row could otherwise re-triage a ticket that
+// already advanced out of Triage. 10 min comfortably covers replica write lag
+// (seconds-scale under a live writer) while leaving genuinely stranded tickets
+// (hours-to-weeks old) fully covered. A row with no timestamp cannot prove
+// youth — it stays sweepable (recovery bias).
+const TRIAGE_STATE_MIN_DWELL_MS = 10 * 60 * 1000;
+
+function triageStateTickets(entry, { replica, runTriageState, now = Date.now }) {
   const query = resolveEligibleQuery(entry);
   const onSource = (source, count) => {
     const line = { team: query.team, triage_source: source, triage_count: count };
@@ -1106,7 +1115,15 @@ function triageStateTickets(entry, { replica, runTriageState }) {
       );
   };
   try {
-    return runTriageState(query, { replica, onSource });
+    const rows = runTriageState(query, { replica, onSource });
+    // Dwell guard (Codex R1): drop rows whose replica timestamp is younger than
+    // the dwell window — see TRIAGE_STATE_MIN_DWELL_MS. Unparseable/absent
+    // timestamps stay sweepable.
+    const nowMs = now();
+    return rows.filter((t) => {
+      const ms = t?.updatedAt ? Date.parse(t.updatedAt) : NaN;
+      return !Number.isFinite(ms) || nowMs - ms >= TRIAGE_STATE_MIN_DWELL_MS;
+    });
   } catch (err) {
     log.warn(
       { team: query.team, err: err.message },
@@ -1202,13 +1219,19 @@ export function sweepMissingTriage({
     hasInProcessRoute, // CTL-1457 (N1)
   });
   for (const p of listProjects()) {
-    // CTL-1589: eligible set ∪ Triage-state board, deduped by ticket id. The
-    // eligible half comes first so a ticket present in both keeps its
-    // projection-backed record.
+    // CTL-1589: Triage-state board ∪ eligible set, deduped by ticket id. The
+    // STRANDED half walks first (Codex R1): under sustained admission load an
+    // eligible-first walk let fresh Todo tickets drain the per-sweep budget
+    // every sweep, starving the level-triggered recovery exactly when the fleet
+    // is busy. The stranded set is small and self-draining (one successful
+    // triage removes the ticket permanently), while the eligible half retries
+    // on the next 60s sweep — so stranded-first costs the Todo path at most one
+    // sweep of latency. Dual-presence is impossible in practice (a ticket has
+    // one state); dedup is belt-and-suspenders.
     const seen = new Set();
     const candidates = [
-      ...getEligibleSet(p.team),
       ...triageStateTickets(p, { replica, runTriageState }),
+      ...getEligibleSet(p.team),
     ];
     for (const t of candidates) {
       if (seen.has(t.identifier)) continue;

--- a/plugins/dev/scripts/execution-core/monitor.mjs
+++ b/plugins/dev/scripts/execution-core/monitor.mjs
@@ -728,6 +728,11 @@ function dispatchTriage(
     // tests never spawn a real linearis write; default = the label-guard path.
     labelNeedsHuman = (dir, t) =>
       labelNeedsHumanUnlessBeliefOwner(dir, t, { applyLabel }, { site: "triage-redispatch-cap" }),
+    // CTL-1589 (Codex R3): when set (the sweep's Triage-BOARD candidates), the
+    // ticket's LIVE state must still equal this workflow-state name at launch.
+    // null/undefined (the webhook path, eligible-half candidates) skips the check.
+    requireTriageState = null,
+    fetchLiveState = defaultFetchTicketState,
   }
 ) {
   if (!orchDir) {
@@ -863,6 +868,31 @@ function dispatchTriage(
       return false;
     }
     clusterGeneration = claim.generation; // CTL-1028: forward to worker (mirrors CTL-864)
+  }
+  // CTL-1589 (Codex R3): live revalidation for a Triage-BOARD candidate, placed
+  // launch-imminent (post-drain/HRW/delegate/claim gates) so the bare live read
+  // fires only for a dispatch this host is genuinely about to launch — bounded
+  // by real launches, never a per-sweep/per-candidate probe. A replica row can
+  // have MISSED the ticket's exit from Triage (delivery hole), and the CTL-758
+  // guard refuses only TERMINAL backward writes — without this check the later
+  // status write could drag an advanced ticket back to Triage. No verdict is
+  // cached: a cached positive could go stale after a failed dispatch and
+  // redispatch an advanced ticket on the next sweep. Unreadable (null) proceeds
+  // — recovery bias; the status write re-reads.
+  if (requireTriageState) {
+    let live = null;
+    try {
+      live = fetchLiveState(identifier);
+    } catch {
+      /* unreadable → proceed */
+    }
+    if (live != null && live !== requireTriageState) {
+      log.info(
+        { identifier, live, expected: requireTriageState },
+        "dispatchTriage: replica Triage row is stale — ticket already advanced; skipping (CTL-1589)"
+      );
+      return false;
+    }
   }
   // CTL-1441 guard (a), placed HERE (post-gates, post-claim, launch imminent —
   // Codex R3): a done phase-triage.json with triage.json missing is the
@@ -1087,45 +1117,6 @@ export function markTriageCapped(orchDir, ticket, { now = () => new Date().toISO
   return true;
 }
 
-// ── CTL-1589 (Codex R2): cached live-state revalidation for Triage-board rows ─
-// A Triage-board candidate rides a replica row that can have MISSED the
-// ticket's exit from Triage (a per-ticket delivery hole leaves an OLD
-// timestamp, so the dwell guard passes) — and applyTriageStatus's backward-write
-// guard refuses only TERMINAL states, so a stale row could drag an advanced
-// ticket back to Triage. Revalidate against the LIVE state before dispatch, but
-// CACHE the verdict in a marker for 30 min so a candidate the sweep revisits
-// every cycle (non-owner host, capped ticket, failing dispatch) costs at most
-// two live reads an hour — never the per-tick probe storm CTL-1580 eliminated.
-// A failed read (null) proceeds: recovery bias.
-const TRIAGE_REVALIDATE_COOLDOWN_MS = 30 * 60 * 1000;
-
-export function revalidatedTriageLiveState(orchDir, ticket, { fetchLiveState, now = Date.now } = {}) {
-  const dir = join(orchDir, ".triage-revalidate");
-  const path = join(dir, `${ticket}.json`);
-  const nowMs = now();
-  try {
-    const m = JSON.parse(readFileSync(path, "utf8"));
-    if (typeof m?.ts === "number" && nowMs - m.ts < TRIAGE_REVALIDATE_COOLDOWN_MS) {
-      return m.live ?? null;
-    }
-  } catch {
-    /* absent/corrupt marker -> live read */
-  }
-  let live = null;
-  try {
-    live = fetchLiveState(ticket) ?? null;
-  } catch {
-    live = null;
-  }
-  try {
-    mkdirSync(dir, { recursive: true });
-    writeFileSync(path, JSON.stringify({ ts: nowMs, live }));
-  } catch {
-    /* marker write is best-effort; worst case is an extra read next sweep */
-  }
-  return live;
-}
-
 // triageStateTickets — the CTL-1589 half of the sweep's ticket source: the
 // tickets currently SITTING IN this team's Triage state, read from the local
 // replica. Fail-open — an unavailable board yields [] and the sweep degrades to
@@ -1133,16 +1124,7 @@ export function revalidatedTriageLiveState(orchDir, ticket, { fetchLiveState, no
 // unavailable cases are logged at WARN and never silent: with the replica tier
 // off (or its writer dead) this half of the fix is INERT, and a stranded Triage
 // ticket would otherwise look like a mysterious no-op.
-// TRIAGE_STATE_MIN_DWELL_MS — only sweep Triage rows that have DWELLED (Codex
-// R1 on #2843): a ticket that entered Triage seconds ago is the webhook fast
-// path's job, and a lagging replica row could otherwise re-triage a ticket that
-// already advanced out of Triage. 10 min comfortably covers replica write lag
-// (seconds-scale under a live writer) while leaving genuinely stranded tickets
-// (hours-to-weeks old) fully covered. A row with no timestamp cannot prove
-// youth — it stays sweepable (recovery bias).
-const TRIAGE_STATE_MIN_DWELL_MS = 10 * 60 * 1000;
-
-function triageStateTickets(entry, { replica, runTriageState, now = Date.now }) {
+function triageStateTickets(entry, { replica, runTriageState }) {
   const query = resolveEligibleQuery(entry);
   const onSource = (source, count) => {
     const line = { team: query.team, triage_source: source, triage_count: count };
@@ -1156,19 +1138,13 @@ function triageStateTickets(entry, { replica, runTriageState, now = Date.now }) 
   };
   try {
     const rows = runTriageState(query, { replica, onSource });
-    // Dwell guard (Codex R1): drop rows whose replica timestamp is younger than
-    // the dwell window — see TRIAGE_STATE_MIN_DWELL_MS. Unparseable/absent
-    // timestamps stay sweepable.
-    const nowMs = now();
-    return rows
-      .filter((t) => {
-        const ms = t?.updatedAt ? Date.parse(t.updatedAt) : NaN;
-        return !Number.isFinite(ms) || nowMs - ms >= TRIAGE_STATE_MIN_DWELL_MS;
-      })
-      // Tag the source so the sweep can live-revalidate ONLY this half (Codex
-      // R2): an eligible-projection candidate never needs it, a replica Triage
-      // row might be a delivery-hole survivor.
-      .map((t) => ({ ...t, fromTriageBoard: true }));
+    // No dwell filter (Codex R3): issues.updated_at is generic last-modified, so
+    // a frequently-touched stranded ticket would never pass an age gate. A young
+    // row racing the →Triage webhook is harmless — dispatchTriage is idempotent
+    // (in-flight signals no-op, artifacts skip) and the launch-imminent live
+    // revalidation (dispatchTriage requireTriageState) is the stale-row guard.
+    // Tag the source so ONLY this half pays that live revalidation.
+    return rows.map((t) => ({ ...t, fromTriageBoard: true }));
   } catch (err) {
     log.warn(
       { team: query.team, err: err.message },
@@ -1289,18 +1265,6 @@ export function sweepMissingTriage({
       // budget gate); everything else waits for the next sweep.
       if (budget.remaining <= 0 && readTriageDispatchCount(orchDir, t.identifier) < TRIAGE_DISPATCH_CAP) continue;
       if (hasTriageArtifact(orchDir, t.identifier)) continue;
-      // CTL-1589 (Codex R2): stale-row revalidation — see
-      // revalidatedTriageLiveState for the mechanism and the read-rate bound.
-      if (t.fromTriageBoard && triageStatusName) {
-        const live = revalidatedTriageLiveState(orchDir, t.identifier, { fetchLiveState });
-        if (live != null && live !== triageStatusName) {
-          log.info(
-            { ticket: t.identifier, live, expected: triageStatusName },
-            "sweepMissingTriage: replica Triage row is stale — ticket already advanced; skipping (CTL-1589)"
-          );
-          continue;
-        }
-      }
       // CTL-1441 guard (a) note: the done-signal/missing-triage.json mismatch is
       // handled INSIDE dispatchTriage (post-gates, launch-imminent — Codex R3),
       // where the stale completion signal is retired immediately before a real
@@ -1312,6 +1276,10 @@ export function sweepMissingTriage({
         appendEvent,
         orchId: t.identifier,
         budget,
+        // CTL-1589 (Codex R3): Triage-BOARD candidates must still be in the
+        // Triage state at launch; eligible-half candidates skip the check.
+        requireTriageState: t.fromTriageBoard ? triageStatusName : null,
+        fetchLiveState,
         botUserIds,
         botWriteId,
         gateway,

--- a/plugins/dev/scripts/execution-core/monitor.mjs
+++ b/plugins/dev/scripts/execution-core/monitor.mjs
@@ -733,6 +733,10 @@ function dispatchTriage(
     // null/undefined (the webhook path, eligible-half candidates) skips the check.
     requireTriageState = null,
     fetchLiveState = defaultFetchTicketState,
+    // CTL-1589 (Codex R7): the candidate row's replica updatedAt (ISO). A row
+    // updated AFTER a cached negative verdict invalidates the marker — the
+    // ticket may have legitimately re-entered Triage.
+    candidateUpdatedAt = null,
   }
 ) {
   if (!orchDir) {
@@ -882,7 +886,11 @@ function dispatchTriage(
     const revalPath = join(revalDir, `${identifier}.json`);
     try {
       const m = JSON.parse(readFileSync(revalPath, "utf8"));
-      if (typeof m?.ts === "number" && Date.now() - m.ts < TRIAGE_REVALIDATE_NEGATIVE_MS) {
+      const rowMs = candidateUpdatedAt ? Date.parse(candidateUpdatedAt) : NaN;
+      // A replica row updated AFTER the verdict invalidates it (Codex R7): the
+      // ticket may have legitimately re-entered Triage since the negative.
+      const invalidated = Number.isFinite(rowMs) && typeof m?.ts === "number" && rowMs > m.ts;
+      if (!invalidated && typeof m?.ts === "number" && Date.now() - m.ts < TRIAGE_REVALIDATE_NEGATIVE_MS) {
         log.debug(
           { identifier, cachedLive: m.live ?? null },
           "dispatchTriage: Triage-board revalidation negative still cached — skipping without a read (CTL-1589)"
@@ -894,11 +902,12 @@ function dispatchTriage(
     }
     let live = null;
     try {
-      // Tiered (Codex R6): the broker's gateway descriptor store (60s state
-      // freshness, an INDEPENDENT webhook-fed source) answers without a
-      // subprocess when it can; only a miss shells the live read. The replica
-      // is deliberately NOT passed — it is the very source being audited.
-      live = fetchLiveState(identifier, { gateway });
+      // AUTHORITATIVE read only (Codex R7): no gateway/replica tier — a ≤60s
+      // cached "Triage" from the webhook-fed descriptor store could approve a
+      // duplicate launch on a just-advanced ticket, and the replica is the very
+      // source being audited. The negative cache above owns the read-rate
+      // bound, so the bare read stays ≤2/hour per stuck candidate.
+      live = fetchLiveState(identifier);
     } catch {
       live = null;
     }
@@ -1342,6 +1351,7 @@ export function sweepMissingTriage({
         // CTL-1589 (Codex R3): Triage-BOARD candidates must still be in the
         // Triage state at launch; eligible-half candidates skip the check.
         requireTriageState: t.fromTriageBoard ? triageStatusName : null,
+        candidateUpdatedAt: t.fromTriageBoard ? (t.updatedAt ?? null) : null,
         fetchLiveState,
         botUserIds,
         botWriteId,

--- a/plugins/dev/scripts/execution-core/monitor.mjs
+++ b/plugins/dev/scripts/execution-core/monitor.mjs
@@ -53,6 +53,7 @@ import { listProjects, getProjectConfig, resolveEligibleQuery } from "./registry
 import {
   runEligibleQuery,
   runTriageStateQuery as defaultRunTriageStateQuery, // CTL-1589: level-triggered Triage-state read
+  fetchTicketState as defaultFetchTicketState, // CTL-1589: last-moment stale-row revalidation
   fetchTicketAssignee,
   isAssigneeClaimable,
   isClaimable,
@@ -1086,6 +1087,45 @@ export function markTriageCapped(orchDir, ticket, { now = () => new Date().toISO
   return true;
 }
 
+// ── CTL-1589 (Codex R2): cached live-state revalidation for Triage-board rows ─
+// A Triage-board candidate rides a replica row that can have MISSED the
+// ticket's exit from Triage (a per-ticket delivery hole leaves an OLD
+// timestamp, so the dwell guard passes) — and applyTriageStatus's backward-write
+// guard refuses only TERMINAL states, so a stale row could drag an advanced
+// ticket back to Triage. Revalidate against the LIVE state before dispatch, but
+// CACHE the verdict in a marker for 30 min so a candidate the sweep revisits
+// every cycle (non-owner host, capped ticket, failing dispatch) costs at most
+// two live reads an hour — never the per-tick probe storm CTL-1580 eliminated.
+// A failed read (null) proceeds: recovery bias.
+const TRIAGE_REVALIDATE_COOLDOWN_MS = 30 * 60 * 1000;
+
+export function revalidatedTriageLiveState(orchDir, ticket, { fetchLiveState, now = Date.now } = {}) {
+  const dir = join(orchDir, ".triage-revalidate");
+  const path = join(dir, `${ticket}.json`);
+  const nowMs = now();
+  try {
+    const m = JSON.parse(readFileSync(path, "utf8"));
+    if (typeof m?.ts === "number" && nowMs - m.ts < TRIAGE_REVALIDATE_COOLDOWN_MS) {
+      return m.live ?? null;
+    }
+  } catch {
+    /* absent/corrupt marker -> live read */
+  }
+  let live = null;
+  try {
+    live = fetchLiveState(ticket) ?? null;
+  } catch {
+    live = null;
+  }
+  try {
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(path, JSON.stringify({ ts: nowMs, live }));
+  } catch {
+    /* marker write is best-effort; worst case is an extra read next sweep */
+  }
+  return live;
+}
+
 // triageStateTickets — the CTL-1589 half of the sweep's ticket source: the
 // tickets currently SITTING IN this team's Triage state, read from the local
 // replica. Fail-open — an unavailable board yields [] and the sweep degrades to
@@ -1120,10 +1160,15 @@ function triageStateTickets(entry, { replica, runTriageState, now = Date.now }) 
     // the dwell window — see TRIAGE_STATE_MIN_DWELL_MS. Unparseable/absent
     // timestamps stay sweepable.
     const nowMs = now();
-    return rows.filter((t) => {
-      const ms = t?.updatedAt ? Date.parse(t.updatedAt) : NaN;
-      return !Number.isFinite(ms) || nowMs - ms >= TRIAGE_STATE_MIN_DWELL_MS;
-    });
+    return rows
+      .filter((t) => {
+        const ms = t?.updatedAt ? Date.parse(t.updatedAt) : NaN;
+        return !Number.isFinite(ms) || nowMs - ms >= TRIAGE_STATE_MIN_DWELL_MS;
+      })
+      // Tag the source so the sweep can live-revalidate ONLY this half (Codex
+      // R2): an eligible-projection candidate never needs it, a replica Triage
+      // row might be a delivery-hole survivor.
+      .map((t) => ({ ...t, fromTriageBoard: true }));
   } catch (err) {
     log.warn(
       { team: query.team, err: err.message },
@@ -1203,6 +1248,8 @@ export function sweepMissingTriage({
   // from the local replica with no Linear call at all.
   replica = _injectedEligibleReplica,
   runTriageState = defaultRunTriageStateQuery,
+  // CTL-1589 (Codex R2): live-state read for stale-row revalidation; injectable.
+  fetchLiveState = defaultFetchTicketState,
 } = {}) {
   if (!orchDir) {
     log.debug("sweepMissingTriage: no orchDir wired — skipping triage sweep");
@@ -1219,6 +1266,7 @@ export function sweepMissingTriage({
     hasInProcessRoute, // CTL-1457 (N1)
   });
   for (const p of listProjects()) {
+    const triageStatusName = resolveEligibleQuery(p)?.triageStatus ?? null;
     // CTL-1589: Triage-state board ∪ eligible set, deduped by ticket id. The
     // STRANDED half walks first (Codex R1): under sustained admission load an
     // eligible-first walk let fresh Todo tickets drain the per-sweep budget
@@ -1241,6 +1289,18 @@ export function sweepMissingTriage({
       // budget gate); everything else waits for the next sweep.
       if (budget.remaining <= 0 && readTriageDispatchCount(orchDir, t.identifier) < TRIAGE_DISPATCH_CAP) continue;
       if (hasTriageArtifact(orchDir, t.identifier)) continue;
+      // CTL-1589 (Codex R2): stale-row revalidation — see
+      // revalidatedTriageLiveState for the mechanism and the read-rate bound.
+      if (t.fromTriageBoard && triageStatusName) {
+        const live = revalidatedTriageLiveState(orchDir, t.identifier, { fetchLiveState });
+        if (live != null && live !== triageStatusName) {
+          log.info(
+            { ticket: t.identifier, live, expected: triageStatusName },
+            "sweepMissingTriage: replica Triage row is stale — ticket already advanced; skipping (CTL-1589)"
+          );
+          continue;
+        }
+      }
       // CTL-1441 guard (a) note: the done-signal/missing-triage.json mismatch is
       // handled INSIDE dispatchTriage (post-gates, launch-imminent — Codex R3),
       // where the stale completion signal is retired immediately before a real

--- a/plugins/dev/scripts/execution-core/monitor.mjs
+++ b/plugins/dev/scripts/execution-core/monitor.mjs
@@ -872,13 +872,43 @@ function dispatchTriage(
   // ticket's state. No verdict caching: a cached positive could go stale after
   // a failed dispatch and redispatch an advanced ticket on the next sweep.
   if (requireTriageState) {
+    // NEGATIVE-verdict cache (Codex R6): a failed validation is not a launch,
+    // so a persistently-stale row (unhealed delivery hole) would otherwise pay
+    // one bare read per sweep forever. Caching ONLY negatives keeps R4's
+    // no-stale-positive property — a fresh negative marker just extends the
+    // skip of an already-skipped ticket, and expiry re-reads (2 reads/hour cap
+    // per stuck ticket).
+    const revalDir = join(orchDir, ".triage-revalidate");
+    const revalPath = join(revalDir, `${identifier}.json`);
+    try {
+      const m = JSON.parse(readFileSync(revalPath, "utf8"));
+      if (typeof m?.ts === "number" && Date.now() - m.ts < TRIAGE_REVALIDATE_NEGATIVE_MS) {
+        log.debug(
+          { identifier, cachedLive: m.live ?? null },
+          "dispatchTriage: Triage-board revalidation negative still cached — skipping without a read (CTL-1589)"
+        );
+        return false;
+      }
+    } catch {
+      /* absent/corrupt marker → read */
+    }
     let live = null;
     try {
-      live = fetchLiveState(identifier);
+      // Tiered (Codex R6): the broker's gateway descriptor store (60s state
+      // freshness, an INDEPENDENT webhook-fed source) answers without a
+      // subprocess when it can; only a miss shells the live read. The replica
+      // is deliberately NOT passed — it is the very source being audited.
+      live = fetchLiveState(identifier, { gateway });
     } catch {
       live = null;
     }
     if (live !== requireTriageState) {
+      try {
+        mkdirSync(revalDir, { recursive: true });
+        writeFileSync(revalPath, JSON.stringify({ ts: Date.now(), live }));
+      } catch {
+        /* marker is best-effort; worst case is a re-read next sweep */
+      }
       log.info(
         { identifier, live, expected: requireTriageState },
         live == null
@@ -886,6 +916,13 @@ function dispatchTriage(
           : "dispatchTriage: replica Triage row is stale — ticket already advanced; skipping (CTL-1589)"
       );
       return false;
+    }
+    // Positive: clear any expired negative so a healed ticket never waits on
+    // stale forensics. Best-effort.
+    try {
+      renameSync(revalPath, `${revalPath}.cleared`);
+    } catch {
+      /* no marker to clear */
     }
   }
   let clusterGeneration = null;
@@ -1130,6 +1167,11 @@ export function markTriageCapped(orchDir, ticket, { now = () => new Date().toISO
 // unavailable cases are logged at WARN and never silent: with the replica tier
 // off (or its writer dead) this half of the fix is INERT, and a stranded Triage
 // ticket would otherwise look like a mysterious no-op.
+// TRIAGE_REVALIDATE_NEGATIVE_MS — how long a NEGATIVE launch-revalidation
+// verdict (stale/unreadable) suppresses re-reading a Triage-board candidate.
+// See the negative-verdict cache inside dispatchTriage (Codex R6).
+const TRIAGE_REVALIDATE_NEGATIVE_MS = 30 * 60 * 1000;
+
 function triageStateTickets(entry, { replica, runTriageState }) {
   const query = resolveEligibleQuery(entry);
   const onSource = (source, count) => {

--- a/plugins/dev/scripts/execution-core/monitor.mjs
+++ b/plugins/dev/scripts/execution-core/monitor.mjs
@@ -52,6 +52,7 @@ import { claimDispatchSync } from "./cluster-claim-sync.mjs"; // CTL-862: cross-
 import { listProjects, getProjectConfig, resolveEligibleQuery } from "./registry.mjs";
 import {
   runEligibleQuery,
+  runTriageStateQuery as defaultRunTriageStateQuery, // CTL-1589: level-triggered Triage-state read
   fetchTicketAssignee,
   isAssigneeClaimable,
   isClaimable,
@@ -1085,6 +1086,36 @@ export function markTriageCapped(orchDir, ticket, { now = () => new Date().toISO
   return true;
 }
 
+// triageStateTickets — the CTL-1589 half of the sweep's ticket source: the
+// tickets currently SITTING IN this team's Triage state, read from the local
+// replica. Fail-open — an unavailable board yields [] and the sweep degrades to
+// its pre-CTL-1589 eligible-only behavior rather than aborting the pass. The
+// unavailable cases are logged at WARN and never silent: with the replica tier
+// off (or its writer dead) this half of the fix is INERT, and a stranded Triage
+// ticket would otherwise look like a mysterious no-op.
+function triageStateTickets(entry, { replica, runTriageState }) {
+  const query = resolveEligibleQuery(entry);
+  const onSource = (source, count) => {
+    const line = { team: query.team, triage_source: source, triage_count: count };
+    if (source === "replica") log.info(line, "triage sweep: Triage-state source");
+    else if (source === "no-triage-status") log.debug(line, "triage sweep: team configures no Triage state");
+    else
+      log.warn(
+        line,
+        "triage sweep: Triage-state board unavailable — sweeping the eligible set only (CTL-1589)"
+      );
+  };
+  try {
+    return runTriageState(query, { replica, onSource });
+  } catch (err) {
+    log.warn(
+      { team: query.team, err: err.message },
+      "sweepMissingTriage: Triage-state read threw — sweeping the eligible set only (CTL-1589)"
+    );
+    return [];
+  }
+}
+
 // sweepMissingTriage — the reconcile-path analogue of the CTL-625 webhook guard
 // (handleStateChangedEvent →Ready branch). After reconcileAll has (re)populated
 // the eligible sets, dispatch triage for every eligible ticket that lacks a
@@ -1094,6 +1125,18 @@ export function markTriageCapped(orchDir, ticket, { now = () => new Date().toISO
 // research dispatch dead-locks on phase-agent-dispatch's prior_artifact_missing
 // gate, looping prior_artifact_missing → 60s cooldown → retry forever (CTL-711:
 // CTL-704/705/706/710 each needed a manual triage dispatch after a restart).
+//
+// CTL-1589: the eligible set alone is NOT a sufficient source. It is fed by a
+// Todo-only query, so a ticket sitting in the TRIAGE state appears in neither
+// half of the retry loop — and the only path that ever noticed it, the →Triage
+// webhook, is edge-triggered and one-shot. A delegated ticket whose dispatch was
+// consumed and whose worker dir later vanished therefore stranded in Triage
+// forever (live: ADV-1374, ADV-1376, CTL-1381, OTL-5). The sweep now iterates the
+// UNION of the eligible set and the team's Triage-state board, deduped by ticket
+// id — making triage admission level-triggered. Only the sweep's ticket SOURCE
+// widens: Triage-state tickets are NOT added to the eligible projection (the
+// scheduler's new-work pull, the phantom sweep, and the dependency graph all
+// consume that, and a Triage ticket is never scheduler-pulled).
 //
 // Idempotent by construction: hasTriageArtifact skips already-triaged tickets
 // (no duplicate dispatch on normal webhook-driven tickets), and an in-flight
@@ -1138,6 +1181,11 @@ export function sweepMissingTriage({
   // CTL-1481: worker:<host> label-stamp seam — threaded through to
   // dispatchTriage (undefined → real default; tests inject a fake).
   stampWorkerLabel,
+  // CTL-1589: the Triage-state read seams. `replica` defaults to the same
+  // daemon-injected board reader reconcileProject uses, so the sweep is served
+  // from the local replica with no Linear call at all.
+  replica = _injectedEligibleReplica,
+  runTriageState = defaultRunTriageStateQuery,
 } = {}) {
   if (!orchDir) {
     log.debug("sweepMissingTriage: no orchDir wired — skipping triage sweep");
@@ -1154,7 +1202,17 @@ export function sweepMissingTriage({
     hasInProcessRoute, // CTL-1457 (N1)
   });
   for (const p of listProjects()) {
-    for (const t of getEligibleSet(p.team)) {
+    // CTL-1589: eligible set ∪ Triage-state board, deduped by ticket id. The
+    // eligible half comes first so a ticket present in both keeps its
+    // projection-backed record.
+    const seen = new Set();
+    const candidates = [
+      ...getEligibleSet(p.team),
+      ...triageStateTickets(p, { replica, runTriageState }),
+    ];
+    for (const t of candidates) {
+      if (seen.has(t.identifier)) continue;
+      seen.add(t.identifier);
       // Codex R4: at a saturated fleet, still ROUTE capped tickets (their park is
       // capacity-independent and dispatchTriage's cap gate runs before its
       // budget gate); everything else waits for the next sweep.

--- a/plugins/dev/scripts/execution-core/monitor.test.mjs
+++ b/plugins/dev/scripts/execution-core/monitor.test.mjs
@@ -1378,9 +1378,28 @@ describe("sweepMissingTriage — Triage-state union (CTL-1589)", () => {
       // ENG-2 appears in BOTH sources; ENG-3 only in Triage.
       runTriageState: triageReturning([triageNode("ENG-2"), triageNode("ENG-3")]),
     });
-    // Stranded-first (Codex R1): the Triage-state half walks BEFORE the eligible
-    // half so sustained admission load can't starve the recovery; ENG-2 dedupes.
-    expect(dispatch.mock.calls.map((c) => c[0].ticket)).toEqual(["ENG-2", "ENG-3", "ENG-1"]);
+    // Stranded-first (Codex R1) for Triage-ONLY rows; a dual-present ticket
+    // keeps its ELIGIBLE copy (Codex R5: the live-confirmed source, no
+    // revalidation) so ENG-2 dispatches from the eligible half.
+    expect(dispatch.mock.calls.map((c) => c[0].ticket)).toEqual(["ENG-3", "ENG-1", "ENG-2"]);
+  });
+
+  test("a dual-present ticket with a STALE Triage row still dispatches via its eligible copy (Codex R5)", () => {
+    enroll("ENG", { status: "Todo", triageStatus: "Triage" });
+    const realOrchDir = join(catalystDir, "execution-core");
+    const exec = execReturning({ ENG: [node("ENG-DUAL")] });
+    reconcileAll({ exec });
+    const dispatch = mock(() => ({ code: 0 }));
+    // The stale row would fail revalidation (live=Todo) — but the eligible copy
+    // must win the dedup and dispatch without ever consulting the live read.
+    const fetchLiveState = mock(() => "Todo");
+    sweepMissingTriage({
+      ...baseOpts(realOrchDir, dispatch),
+      fetchLiveState,
+      runTriageState: triageReturning([triageNode("ENG-DUAL")]),
+    });
+    expect(dispatch.mock.calls.map((c) => c[0].ticket)).toEqual(["ENG-DUAL"]);
+    expect(fetchLiveState).not.toHaveBeenCalled();
   });
 
   test("stranded Triage tickets walk before the eligible half (starvation guard)", () => {

--- a/plugins/dev/scripts/execution-core/monitor.test.mjs
+++ b/plugins/dev/scripts/execution-core/monitor.test.mjs
@@ -1344,9 +1344,10 @@ describe("sweepMissingTriage — Triage-state union (CTL-1589)", () => {
     appendEvent: () => {},
     readMaxParallelFn: () => 6,
     liveBackgroundCount: () => 0,
-    // CTL-1589 Codex R2: never let the revalidation shell a real linearis read
-    // from a unit test; null = unreadable -> proceed (recovery bias).
-    fetchLiveState: () => null,
+    // CTL-1589: never let the revalidation shell a real linearis read from a
+    // unit test. Default = live-confirms Triage (the happy path); tests that
+    // exercise stale/unreadable semantics override it.
+    fetchLiveState: () => "Triage",
   });
 
   test("dispatches a ticket that exists ONLY in the Triage state (never in the eligible set)", () => {
@@ -1427,7 +1428,7 @@ describe("sweepMissingTriage — Triage-state union (CTL-1589)", () => {
     expect(fetchLiveState).not.toHaveBeenCalled();
   });
 
-  test("a Triage row confirmed live in Triage dispatches; an unreadable live state proceeds (recovery bias)", () => {
+  test("a Triage row confirmed live in Triage dispatches; an unreadable live state HOLDS (fail-closed, Codex R4)", () => {
     enroll("ENG", { status: "Todo", triageStatus: "Triage" });
     const realOrchDir = join(catalystDir, "execution-core");
     const exec = execReturning({ ENG: [] });
@@ -1439,13 +1440,59 @@ describe("sweepMissingTriage — Triage-state union (CTL-1589)", () => {
       runTriageState: triageReturning([triageNode("ENG-CONFIRMED")]),
     });
     expect(dispatch.mock.calls.map((c) => c[0].ticket)).toEqual(["ENG-CONFIRMED"]);
+    // Unreadable → HOLD this sweep (a blind proceed could double-launch and the
+    // later status write could drag an advanced ticket back to Triage).
     const dispatch2 = mock(() => ({ code: 0 }));
     sweepMissingTriage({
       ...baseOpts(realOrchDir, dispatch2),
       fetchLiveState: () => null,
       runTriageState: triageReturning([triageNode("ENG-UNREADABLE")]),
     });
-    expect(dispatch2.mock.calls.map((c) => c[0].ticket)).toEqual(["ENG-UNREADABLE"]);
+    expect(dispatch2).not.toHaveBeenCalled();
+  });
+
+  test("a stale Triage row is skipped BEFORE the cross-host claim (fence untouched, Codex R4)", () => {
+    enroll("ENG", { status: "Todo", triageStatus: "Triage" });
+    const realOrchDir = join(catalystDir, "execution-core");
+    const exec = execReturning({ ENG: [] });
+    reconcileAll({ exec });
+    const dispatch = mock(() => ({ code: 0 }));
+    const claimCalls = [];
+    sweepMissingTriage({
+      ...baseOpts(realOrchDir, dispatch),
+      hosts: ["mini", "mini-2"],
+      hostName: "mini",
+      survivingRosterOverride: ["mini", "mini-2"],
+      claimDispatch: (arg) => {
+        claimCalls.push(arg);
+        return { won: true, generation: 7 };
+      },
+      fetchLiveState: () => "Research",
+      runTriageState: triageReturning([triageNode("ENG-3000")]),
+    });
+    expect(dispatch).not.toHaveBeenCalled();
+    // The skip must never bump the fence generation out from under a live
+    // later-phase worker — the claim is only taken when a launch will follow.
+    expect(claimCalls).toHaveLength(0);
+  });
+
+  test("an in-flight Triage-board candidate is skipped without a live read or budget spend (Codex R4)", () => {
+    enroll("ENG", { status: "Todo", triageStatus: "Triage" });
+    const realOrchDir = join(catalystDir, "execution-core");
+    const exec = execReturning({ ENG: [] });
+    reconcileAll({ exec });
+    const dir = join(realOrchDir, "workers", "ENG-RUN");
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(join(dir, "phase-triage.json"), JSON.stringify({ status: "running" }));
+    const dispatch = mock(() => ({ code: 0 }));
+    const fetchLiveState = mock(() => "Triage");
+    sweepMissingTriage({
+      ...baseOpts(realOrchDir, dispatch),
+      fetchLiveState,
+      runTriageState: triageReturning([triageNode("ENG-RUN")]),
+    });
+    expect(dispatch).not.toHaveBeenCalled();
+    expect(fetchLiveState).not.toHaveBeenCalled();
   });
 
   test("a recently-touched Triage row is still swept (no updated_at dwell gate — Codex R3)", () => {

--- a/plugins/dev/scripts/execution-core/monitor.test.mjs
+++ b/plugins/dev/scripts/execution-core/monitor.test.mjs
@@ -1395,20 +1395,36 @@ describe("sweepMissingTriage — Triage-state union (CTL-1589)", () => {
     expect(dispatch.mock.calls.map((c) => c[0].ticket)).toEqual(["ENG-STRANDED", "ENG-TODO"]);
   });
 
-  test("a stale Triage row (live state already advanced) is skipped, and the verdict is cached", () => {
+  test("a stale Triage row (live state already advanced) is skipped at launch", () => {
     enroll("ENG", { status: "Todo", triageStatus: "Triage" });
     const realOrchDir = join(catalystDir, "execution-core");
     const exec = execReturning({ ENG: [] });
     reconcileAll({ exec });
     const dispatch = mock(() => ({ code: 0 }));
     const fetchLiveState = mock(() => "Research"); // replica row lies; Linear says advanced
-    const opts = { ...baseOpts(realOrchDir, dispatch), fetchLiveState, runTriageState: triageReturning([triageNode("ENG-STALE")]) };
-    sweepMissingTriage(opts);
-    expect(dispatch).not.toHaveBeenCalled();
-    // Second sweep inside the cooldown: the cached verdict answers — no second live read.
-    sweepMissingTriage({ ...opts, runTriageState: triageReturning([triageNode("ENG-STALE")]) });
+    sweepMissingTriage({
+      ...baseOpts(realOrchDir, dispatch),
+      fetchLiveState,
+      runTriageState: triageReturning([triageNode("ENG-STALE")]),
+    });
     expect(dispatch).not.toHaveBeenCalled();
     expect(fetchLiveState).toHaveBeenCalledTimes(1);
+  });
+
+  test("eligible-half candidates never pay the live revalidation read", () => {
+    enroll("ENG", { status: "Todo", triageStatus: "Triage" });
+    const realOrchDir = join(catalystDir, "execution-core");
+    const exec = execReturning({ ENG: [node("ENG-1")] });
+    reconcileAll({ exec });
+    const dispatch = mock(() => ({ code: 0 }));
+    const fetchLiveState = mock(() => "Todo");
+    sweepMissingTriage({
+      ...baseOpts(realOrchDir, dispatch),
+      fetchLiveState,
+      runTriageState: triageReturning([]),
+    });
+    expect(dispatch.mock.calls.map((c) => c[0].ticket)).toEqual(["ENG-1"]);
+    expect(fetchLiveState).not.toHaveBeenCalled();
   });
 
   test("a Triage row confirmed live in Triage dispatches; an unreadable live state proceeds (recovery bias)", () => {
@@ -1432,21 +1448,21 @@ describe("sweepMissingTriage — Triage-state union (CTL-1589)", () => {
     expect(dispatch2.mock.calls.map((c) => c[0].ticket)).toEqual(["ENG-UNREADABLE"]);
   });
 
-  test("a Triage row younger than the dwell window is NOT swept (webhook-path territory)", () => {
+  test("a recently-touched Triage row is still swept (no updated_at dwell gate — Codex R3)", () => {
     enroll("ENG", { status: "Todo", triageStatus: "Triage" });
     const realOrchDir = join(catalystDir, "execution-core");
     const exec = execReturning({ ENG: [] });
     reconcileAll({ exec });
     const dispatch = mock(() => ({ code: 0 }));
-    const young = { ...triageNode("ENG-YOUNG"), updatedAt: new Date(Date.now() - 60_000).toISOString() };
-    const dwelled = { ...triageNode("ENG-DWELLED"), updatedAt: new Date(Date.now() - 11 * 60_000).toISOString() };
+    // Generic updated_at is last-modified — a stranded ticket touched by label
+    // churn must not be starved by an age gate; the live revalidation is the guard.
+    const touched = { ...triageNode("ENG-TOUCHED"), updatedAt: new Date(Date.now() - 60_000).toISOString() };
     sweepMissingTriage({
       ...baseOpts(realOrchDir, dispatch),
-      runTriageState: triageReturning([young, dwelled]),
+      fetchLiveState: () => "Triage",
+      runTriageState: triageReturning([touched]),
     });
-    // The young row is the →Triage webhook's job (and a lagging replica row must
-    // not re-triage a ticket that already advanced); the dwelled row sweeps.
-    expect(dispatch.mock.calls.map((c) => c[0].ticket)).toEqual(["ENG-DWELLED"]);
+    expect(dispatch.mock.calls.map((c) => c[0].ticket)).toEqual(["ENG-TOUCHED"]);
   });
 
   test("a Triage-state ticket that already has triage.json is still skipped (idempotence holds across both sources)", () => {

--- a/plugins/dev/scripts/execution-core/monitor.test.mjs
+++ b/plugins/dev/scripts/execution-core/monitor.test.mjs
@@ -1529,26 +1529,23 @@ describe("sweepMissingTriage — Triage-state union (CTL-1589)", () => {
     expect(fetchLiveState).toHaveBeenCalledTimes(1);
   });
 
-  test("the revalidation read is handed the gateway tier (Codex R6)", () => {
+  test("a replica row updated AFTER a cached negative invalidates the marker (Codex R7)", () => {
     enroll("ENG", { status: "Todo", triageStatus: "Triage" });
     const realOrchDir = join(catalystDir, "execution-core");
     const exec = execReturning({ ENG: [] });
     reconcileAll({ exec });
     const dispatch = mock(() => ({ code: 0 }));
-    const seenOpts = [];
-    const gw = { marker: "gw" };
-    sweepMissingTriage({
-      ...baseOpts(realOrchDir, dispatch),
-      gateway: gw,
-      fetchLiveState: (id, o) => {
-        seenOpts.push(o);
-        return "Triage";
-      },
-      runTriageState: triageReturning([triageNode("ENG-GW")]),
-    });
-    expect(dispatch.mock.calls.map((c) => c[0].ticket)).toEqual(["ENG-GW"]);
-    expect(seenOpts).toHaveLength(1);
-    expect(seenOpts[0]?.gateway).toBe(gw);
+    let liveNow = "Research"; // first sweep: genuinely advanced → negative cached
+    const fetchLiveState = mock(() => liveNow);
+    const opts = { ...baseOpts(realOrchDir, dispatch), fetchLiveState };
+    sweepMissingTriage({ ...opts, runTriageState: triageReturning([triageNode("ENG-BACK")]) });
+    expect(dispatch).not.toHaveBeenCalled();
+    // The ticket re-enters Triage: the replica row is now NEWER than the verdict.
+    liveNow = "Triage";
+    const reentered = { ...triageNode("ENG-BACK"), updatedAt: new Date(Date.now() + 1000).toISOString() };
+    sweepMissingTriage({ ...opts, runTriageState: triageReturning([reentered]) });
+    expect(dispatch.mock.calls.map((c) => c[0].ticket)).toEqual(["ENG-BACK"]);
+    expect(fetchLiveState).toHaveBeenCalledTimes(2);
   });
 
   test("a recently-touched Triage row is still swept (no updated_at dwell gate — Codex R3)", () => {

--- a/plugins/dev/scripts/execution-core/monitor.test.mjs
+++ b/plugins/dev/scripts/execution-core/monitor.test.mjs
@@ -1514,6 +1514,43 @@ describe("sweepMissingTriage — Triage-state union (CTL-1589)", () => {
     expect(fetchLiveState).not.toHaveBeenCalled();
   });
 
+  test("a negative revalidation verdict is cached — no repeat bare read per sweep (Codex R6)", () => {
+    enroll("ENG", { status: "Todo", triageStatus: "Triage" });
+    const realOrchDir = join(catalystDir, "execution-core");
+    const exec = execReturning({ ENG: [] });
+    reconcileAll({ exec });
+    const dispatch = mock(() => ({ code: 0 }));
+    const fetchLiveState = mock(() => "Research");
+    const opts = { ...baseOpts(realOrchDir, dispatch), fetchLiveState };
+    sweepMissingTriage({ ...opts, runTriageState: triageReturning([triageNode("ENG-STUCK")]) });
+    sweepMissingTriage({ ...opts, runTriageState: triageReturning([triageNode("ENG-STUCK")]) });
+    expect(dispatch).not.toHaveBeenCalled();
+    // The second sweep is answered by the negative marker — one read total.
+    expect(fetchLiveState).toHaveBeenCalledTimes(1);
+  });
+
+  test("the revalidation read is handed the gateway tier (Codex R6)", () => {
+    enroll("ENG", { status: "Todo", triageStatus: "Triage" });
+    const realOrchDir = join(catalystDir, "execution-core");
+    const exec = execReturning({ ENG: [] });
+    reconcileAll({ exec });
+    const dispatch = mock(() => ({ code: 0 }));
+    const seenOpts = [];
+    const gw = { marker: "gw" };
+    sweepMissingTriage({
+      ...baseOpts(realOrchDir, dispatch),
+      gateway: gw,
+      fetchLiveState: (id, o) => {
+        seenOpts.push(o);
+        return "Triage";
+      },
+      runTriageState: triageReturning([triageNode("ENG-GW")]),
+    });
+    expect(dispatch.mock.calls.map((c) => c[0].ticket)).toEqual(["ENG-GW"]);
+    expect(seenOpts).toHaveLength(1);
+    expect(seenOpts[0]?.gateway).toBe(gw);
+  });
+
   test("a recently-touched Triage row is still swept (no updated_at dwell gate — Codex R3)", () => {
     enroll("ENG", { status: "Todo", triageStatus: "Triage" });
     const realOrchDir = join(catalystDir, "execution-core");

--- a/plugins/dev/scripts/execution-core/monitor.test.mjs
+++ b/plugins/dev/scripts/execution-core/monitor.test.mjs
@@ -1344,6 +1344,9 @@ describe("sweepMissingTriage — Triage-state union (CTL-1589)", () => {
     appendEvent: () => {},
     readMaxParallelFn: () => 6,
     liveBackgroundCount: () => 0,
+    // CTL-1589 Codex R2: never let the revalidation shell a real linearis read
+    // from a unit test; null = unreadable -> proceed (recovery bias).
+    fetchLiveState: () => null,
   });
 
   test("dispatches a ticket that exists ONLY in the Triage state (never in the eligible set)", () => {
@@ -1390,6 +1393,43 @@ describe("sweepMissingTriage — Triage-state union (CTL-1589)", () => {
       runTriageState: triageReturning([triageNode("ENG-STRANDED")]),
     });
     expect(dispatch.mock.calls.map((c) => c[0].ticket)).toEqual(["ENG-STRANDED", "ENG-TODO"]);
+  });
+
+  test("a stale Triage row (live state already advanced) is skipped, and the verdict is cached", () => {
+    enroll("ENG", { status: "Todo", triageStatus: "Triage" });
+    const realOrchDir = join(catalystDir, "execution-core");
+    const exec = execReturning({ ENG: [] });
+    reconcileAll({ exec });
+    const dispatch = mock(() => ({ code: 0 }));
+    const fetchLiveState = mock(() => "Research"); // replica row lies; Linear says advanced
+    const opts = { ...baseOpts(realOrchDir, dispatch), fetchLiveState, runTriageState: triageReturning([triageNode("ENG-STALE")]) };
+    sweepMissingTriage(opts);
+    expect(dispatch).not.toHaveBeenCalled();
+    // Second sweep inside the cooldown: the cached verdict answers — no second live read.
+    sweepMissingTriage({ ...opts, runTriageState: triageReturning([triageNode("ENG-STALE")]) });
+    expect(dispatch).not.toHaveBeenCalled();
+    expect(fetchLiveState).toHaveBeenCalledTimes(1);
+  });
+
+  test("a Triage row confirmed live in Triage dispatches; an unreadable live state proceeds (recovery bias)", () => {
+    enroll("ENG", { status: "Todo", triageStatus: "Triage" });
+    const realOrchDir = join(catalystDir, "execution-core");
+    const exec = execReturning({ ENG: [] });
+    reconcileAll({ exec });
+    const dispatch = mock(() => ({ code: 0 }));
+    sweepMissingTriage({
+      ...baseOpts(realOrchDir, dispatch),
+      fetchLiveState: () => "Triage",
+      runTriageState: triageReturning([triageNode("ENG-CONFIRMED")]),
+    });
+    expect(dispatch.mock.calls.map((c) => c[0].ticket)).toEqual(["ENG-CONFIRMED"]);
+    const dispatch2 = mock(() => ({ code: 0 }));
+    sweepMissingTriage({
+      ...baseOpts(realOrchDir, dispatch2),
+      fetchLiveState: () => null,
+      runTriageState: triageReturning([triageNode("ENG-UNREADABLE")]),
+    });
+    expect(dispatch2.mock.calls.map((c) => c[0].ticket)).toEqual(["ENG-UNREADABLE"]);
   });
 
   test("a Triage row younger than the dwell window is NOT swept (webhook-path territory)", () => {

--- a/plugins/dev/scripts/execution-core/monitor.test.mjs
+++ b/plugins/dev/scripts/execution-core/monitor.test.mjs
@@ -1374,7 +1374,39 @@ describe("sweepMissingTriage — Triage-state union (CTL-1589)", () => {
       // ENG-2 appears in BOTH sources; ENG-3 only in Triage.
       runTriageState: triageReturning([triageNode("ENG-2"), triageNode("ENG-3")]),
     });
-    expect(dispatch.mock.calls.map((c) => c[0].ticket)).toEqual(["ENG-1", "ENG-2", "ENG-3"]);
+    // Stranded-first (Codex R1): the Triage-state half walks BEFORE the eligible
+    // half so sustained admission load can't starve the recovery; ENG-2 dedupes.
+    expect(dispatch.mock.calls.map((c) => c[0].ticket)).toEqual(["ENG-2", "ENG-3", "ENG-1"]);
+  });
+
+  test("stranded Triage tickets walk before the eligible half (starvation guard)", () => {
+    enroll("ENG", { status: "Todo", triageStatus: "Triage" });
+    const realOrchDir = join(catalystDir, "execution-core");
+    const exec = execReturning({ ENG: [node("ENG-TODO")] });
+    reconcileAll({ exec });
+    const dispatch = mock(() => ({ code: 0 }));
+    sweepMissingTriage({
+      ...baseOpts(realOrchDir, dispatch),
+      runTriageState: triageReturning([triageNode("ENG-STRANDED")]),
+    });
+    expect(dispatch.mock.calls.map((c) => c[0].ticket)).toEqual(["ENG-STRANDED", "ENG-TODO"]);
+  });
+
+  test("a Triage row younger than the dwell window is NOT swept (webhook-path territory)", () => {
+    enroll("ENG", { status: "Todo", triageStatus: "Triage" });
+    const realOrchDir = join(catalystDir, "execution-core");
+    const exec = execReturning({ ENG: [] });
+    reconcileAll({ exec });
+    const dispatch = mock(() => ({ code: 0 }));
+    const young = { ...triageNode("ENG-YOUNG"), updatedAt: new Date(Date.now() - 60_000).toISOString() };
+    const dwelled = { ...triageNode("ENG-DWELLED"), updatedAt: new Date(Date.now() - 11 * 60_000).toISOString() };
+    sweepMissingTriage({
+      ...baseOpts(realOrchDir, dispatch),
+      runTriageState: triageReturning([young, dwelled]),
+    });
+    // The young row is the →Triage webhook's job (and a lagging replica row must
+    // not re-triage a ticket that already advanced); the dwelled row sweeps.
+    expect(dispatch.mock.calls.map((c) => c[0].ticket)).toEqual(["ENG-DWELLED"]);
   });
 
   test("a Triage-state ticket that already has triage.json is still skipped (idempotence holds across both sources)", () => {

--- a/plugins/dev/scripts/execution-core/monitor.test.mjs
+++ b/plugins/dev/scripts/execution-core/monitor.test.mjs
@@ -1308,6 +1308,149 @@ describe("sweepMissingTriage (CTL-711)", () => {
   });
 });
 
+// --- CTL-1589: level-triggered triage sweep (eligible ∪ Triage-state) --------
+//
+// Triage admission used to be EDGE-triggered only: the →Triage webhook was the
+// sole path that ever noticed a Triage ticket, and the retry sweep iterated a
+// Todo-only eligible set. So a ticket already SITTING in Triage — whose one-shot
+// dispatch was consumed and whose worker dir later vanished — could never be
+// re-noticed (live: ADV-1374, ADV-1376, CTL-1381, OTL-5). The sweep now unions
+// the eligible set with the team's Triage-state board.
+
+describe("sweepMissingTriage — Triage-state union (CTL-1589)", () => {
+  const triageNode = (identifier, priority = 2) => ({
+    identifier,
+    state: "Triage",
+    priority,
+    relations: { nodes: [] },
+    inverseRelations: { nodes: [] },
+  });
+
+  // A runTriageState stub standing in for the replica-backed read, recording the
+  // queries it was handed.
+  const triageReturning = (tickets) => {
+    const fn = (query) => {
+      fn.queries.push(query);
+      return tickets;
+    };
+    fn.queries = [];
+    return fn;
+  };
+
+  const baseOpts = (realOrchDir, dispatch) => ({
+    orchDir: realOrchDir,
+    dispatch,
+    applyTriageStatus: () => ({ applied: false, verified: false, from_state: null, to_state: null, reason: null }),
+    appendEvent: () => {},
+    readMaxParallelFn: () => 6,
+    liveBackgroundCount: () => 0,
+  });
+
+  test("dispatches a ticket that exists ONLY in the Triage state (never in the eligible set)", () => {
+    enroll("ENG", { status: "Todo", triageStatus: "Triage" });
+    const realOrchDir = join(catalystDir, "execution-core");
+    const exec = execReturning({ ENG: [] }); // eligible set is EMPTY — the pre-fix blind spot
+    reconcileAll({ exec });
+    const dispatch = mock(() => ({ code: 0 }));
+    sweepMissingTriage({
+      ...baseOpts(realOrchDir, dispatch),
+      runTriageState: triageReturning([triageNode("ENG-1374")]),
+    });
+    expect(dispatch).toHaveBeenCalledWith({
+      orchDir: realOrchDir,
+      ticket: "ENG-1374",
+      phase: "triage",
+    });
+  });
+
+  test("sweeps the UNION and dedupes a ticket present in both sources", () => {
+    enroll("ENG", { status: "Todo", triageStatus: "Triage" });
+    const realOrchDir = join(catalystDir, "execution-core");
+    const exec = execReturning({ ENG: [node("ENG-1"), node("ENG-2")] });
+    reconcileAll({ exec });
+    const dispatch = mock(() => ({ code: 0 }));
+    sweepMissingTriage({
+      ...baseOpts(realOrchDir, dispatch),
+      // ENG-2 appears in BOTH sources; ENG-3 only in Triage.
+      runTriageState: triageReturning([triageNode("ENG-2"), triageNode("ENG-3")]),
+    });
+    expect(dispatch.mock.calls.map((c) => c[0].ticket)).toEqual(["ENG-1", "ENG-2", "ENG-3"]);
+  });
+
+  test("a Triage-state ticket that already has triage.json is still skipped (idempotence holds across both sources)", () => {
+    enroll("ENG", { status: "Todo", triageStatus: "Triage" });
+    const realOrchDir = join(catalystDir, "execution-core");
+    writeTriageArtifact(realOrchDir, "ENG-1374"); // already triaged
+    const exec = execReturning({ ENG: [] });
+    reconcileAll({ exec });
+    const dispatch = mock(() => ({ code: 0 }));
+    sweepMissingTriage({
+      ...baseOpts(realOrchDir, dispatch),
+      runTriageState: triageReturning([triageNode("ENG-1374"), triageNode("ENG-1376")]),
+    });
+    expect(dispatch.mock.calls.map((c) => c[0].ticket)).toEqual(["ENG-1376"]);
+  });
+
+  test("the resolved query (team + triageStatus) is handed to the Triage-state read", () => {
+    enroll("ENG", { status: "Todo", triageStatus: "Needs Triage" });
+    const realOrchDir = join(catalystDir, "execution-core");
+    reconcileAll({ exec: execReturning({ ENG: [] }) });
+    const runTriageState = triageReturning([]);
+    sweepMissingTriage({ ...baseOpts(realOrchDir, mock(() => ({ code: 0 }))), runTriageState });
+    expect(runTriageState.queries).toHaveLength(1);
+    expect(runTriageState.queries[0]).toMatchObject({ team: "ENG", triageStatus: "Needs Triage" });
+  });
+
+  test("an empty Triage board changes nothing — the eligible half sweeps as before", () => {
+    enroll("ENG", { status: "Todo", triageStatus: "Triage" });
+    const realOrchDir = join(catalystDir, "execution-core");
+    reconcileAll({ exec: execReturning({ ENG: [node("ENG-9")] }) });
+    const dispatch = mock(() => ({ code: 0 }));
+    sweepMissingTriage({ ...baseOpts(realOrchDir, dispatch), runTriageState: triageReturning([]) });
+    expect(dispatch.mock.calls.map((c) => c[0].ticket)).toEqual(["ENG-9"]);
+  });
+
+  test("a THROWING Triage-state read degrades to the eligible set — the sweep never aborts", () => {
+    enroll("ENG", { status: "Todo", triageStatus: "Triage" });
+    const realOrchDir = join(catalystDir, "execution-core");
+    reconcileAll({ exec: execReturning({ ENG: [node("ENG-9")] }) });
+    const dispatch = mock(() => ({ code: 0 }));
+    expect(() =>
+      sweepMissingTriage({
+        ...baseOpts(realOrchDir, dispatch),
+        runTriageState: () => {
+          throw new Error("replica exploded");
+        },
+      })
+    ).not.toThrow();
+    expect(dispatch.mock.calls.map((c) => c[0].ticket)).toEqual(["ENG-9"]);
+  });
+
+  // The read itself answers a null triageStatus with [] (see runTriageStateQuery);
+  // what matters here is that the sweep does no extra work and stays eligible-only.
+  test("triageStatus explicitly null → no extra dispatches (eligible set only)", () => {
+    enroll("ENG", { status: "Todo", triageStatus: null });
+    const realOrchDir = join(catalystDir, "execution-core");
+    reconcileAll({ exec: execReturning({ ENG: [node("ENG-9")] }) });
+    const dispatch = mock(() => ({ code: 0 }));
+    // The REAL read (no stub) with no replica wired — proves the default seam
+    // makes no Linear call and yields nothing.
+    sweepMissingTriage(baseOpts(realOrchDir, dispatch));
+    expect(dispatch.mock.calls.map((c) => c[0].ticket)).toEqual(["ENG-9"]);
+  });
+
+  test("Triage-state tickets are NOT added to the eligible projection (scheduler pull is untouched)", () => {
+    enroll("ENG", { status: "Todo", triageStatus: "Triage" });
+    const realOrchDir = join(catalystDir, "execution-core");
+    reconcileAll({ exec: execReturning({ ENG: [node("ENG-9")] }) });
+    sweepMissingTriage({
+      ...baseOpts(realOrchDir, mock(() => ({ code: 0 }))),
+      runTriageState: triageReturning([triageNode("ENG-1374")]),
+    });
+    expect(getEligibleSet("ENG").map((t) => t.identifier)).toEqual(["ENG-9"]);
+  });
+});
+
 // --- CTL-1441: triage re-dispatch guard (cap + artifact-mismatch) ------------
 
 describe("triage re-dispatch guard (CTL-1441)", () => {

--- a/plugins/dev/scripts/execution-core/replica-read.mjs
+++ b/plugins/dev/scripts/execution-core/replica-read.mjs
@@ -77,7 +77,8 @@ function coerceMs(v) {
 // The `issues` table has team_id (UUID) but NO team_key column, so we filter by
 // the Linear identifier prefix: identifiers are `<teamKey>-<number>`, so
 // `identifier LIKE 'CTL-%'` selects exactly team CTL (the hyphen disambiguates
-// CTL- from CTC-). state is the workflow-state NAME string (matches query.status).
+// CTL- from CTC-). state is the workflow-state NAME string — bound to
+// query.status by eligible(), to query.triageStatus by triageState() (CTL-1589).
 // removed_at IS NULL drops tombstones. LIMIT 200 matches linear-query DEFAULT_LIMIT.
 // The eligible board-list query, split HEAD/TAIL so D1 (project/label filters)
 // can inject extra WHERE clauses before the ORDER BY without a second SELECT.
@@ -298,23 +299,15 @@ export function createReplicaReader({ dbPath = getReplicaDbPath() } = {}) {
     }
   };
 
-  // eligible(query) → { nodes: [...] } | undefined  (CTL-1397)
-  //   A VALID answer is { nodes: [...] } — even { nodes: [] } (a fresh replica
-  //   with genuinely zero eligible tickets is a REAL answer, NOT a miss; the
-  //   caller must NOT fall through and re-run linearis for it).
-  //   undefined = "fall through to linearis" — returned when:
-  //     - the query is missing team or status (can't build the filter), OR
-  //     - the replica file is absent OR STALE by mtime (writer-liveness gate), OR
-  //     - any throw (→ dropHandle + undefined).
-  //   Fail-open everywhere: this tier can only ACCELERATE; any doubt falls
-  //   through to today's linearis behavior, never makes discovery WORSE.
-  const eligible = (query) => {
-    // Guard: need both filter dimensions.
-    // D1 (Stage 0): project/label filtered queries ARE now served from the replica
-    // (the replica carries projects + issue_labels⋈labels), closing the permanent
-    // every-tick fall-through to `linearis issues list` for project/label-scoped
-    // teams — buildEligibleSelect appends the matching WHERE clauses below.
-    if (!query || !query.team || !query.status) return undefined;
+  // readBoardByState(team, state, {project, label}) → { nodes: [...] } | undefined
+  //   The shared body of eligible() (CTL-1397) and triageState() (CTL-1589): the
+  //   writer-liveness gate, then the seed-completeness cursor + the board rows +
+  //   the relation enrichment inside ONE deferred read snapshot, then the node
+  //   projection. The ONLY thing the two callers vary is which workflow-state
+  //   string binds to `i.state` (and whether the D1 project/label filters apply),
+  //   so keeping one body means the gates can never drift between them.
+  //   undefined = "fall through to linearis" (gate fail / any throw).
+  const readBoardByState = (team, state, { project = null, label = null } = {}) => {
     // Freshness GATE (writer-liveness proxy) — a stale/absent replica falls
     // through so a dead writer can never freeze discovery on a stale board.
     if (!isReplicaFresh(dbPath)) return undefined;
@@ -344,13 +337,11 @@ export function createReplicaReader({ dbPath = getReplicaDbPath() } = {}) {
         if (!handle.prepare(SEED_COMPLETE_SELECT).get()) return undefined;
         // D1: bind order mirrors buildEligibleSelect's appended clauses —
         // [likePattern, status, (project?), (label?), LIMIT].
-        const params = [`${query.team}-%`, query.status];
-        if (query.project != null) params.push(query.project);
-        if (query.label != null) params.push(query.label);
+        const params = [`${team}-%`, state];
+        if (project != null) params.push(project);
+        if (label != null) params.push(label);
         params.push(ELIGIBLE_LIMIT);
-        const rows = handle
-          .prepare(buildEligibleSelect({ project: query.project, label: query.label }))
-          .all(...params);
+        const rows = handle.prepare(buildEligibleSelect({ project, label })).all(...params);
         const fwdStmt = handle.prepare(RELATIONS_FORWARD_SELECT);
         const invStmt = handle.prepare(RELATIONS_INVERSE_SELECT);
         return rows.map((row) => {
@@ -401,6 +392,57 @@ export function createReplicaReader({ dbPath = getReplicaDbPath() } = {}) {
       dropHandle();
       return undefined;
     }
+  };
+
+  // eligible(query) → { nodes: [...] } | undefined  (CTL-1397)
+  //   A VALID answer is { nodes: [...] } — even { nodes: [] } (a fresh replica
+  //   with genuinely zero eligible tickets is a REAL answer, NOT a miss; the
+  //   caller must NOT fall through and re-run linearis for it).
+  //   undefined = "fall through to linearis" — returned when:
+  //     - the query is missing team or status (can't build the filter), OR
+  //     - the replica file is absent OR STALE by mtime (writer-liveness gate), OR
+  //     - any throw (→ dropHandle + undefined).
+  //   Fail-open everywhere: this tier can only ACCELERATE; any doubt falls
+  //   through to today's linearis behavior, never makes discovery WORSE.
+  const eligible = (query) => {
+    // Guard: need both filter dimensions.
+    // D1 (Stage 0): project/label filtered queries ARE now served from the replica
+    // (the replica carries projects + issue_labels⋈labels), closing the permanent
+    // every-tick fall-through to `linearis issues list` for project/label-scoped
+    // teams — buildEligibleSelect appends the matching WHERE clauses.
+    if (!query || !query.team || !query.status) return undefined;
+    return readBoardByState(query.team, query.status, {
+      project: query.project ?? null,
+      label: query.label ?? null,
+    });
+  };
+
+  // triageState(query) → { nodes: [...] } | undefined  (CTL-1589)
+  //   The board of tickets currently SITTING IN the team's Triage state — the
+  //   read the reconcile-path triage sweep needs and that eligible() cannot
+  //   supply, because eligible() binds `query.status` (Todo). Before this, a
+  //   ticket parked in Triage appeared in NO replica read at all, so once its
+  //   one-shot →Triage webhook dispatch was consumed (and its worker dir later
+  //   vanished) nothing could ever re-notice it: triage admission was
+  //   EDGE-triggered only. This is the level-triggered half.
+  //
+  //   Filtered on team + state ONLY — deliberately no project/label/priority.
+  //   That mirrors the webhook →Triage predicate (monitor.mjs's
+  //   `parsed.toState === query.triageStatus`, which applies no other filter),
+  //   so the level-triggered sweep admits EXACTLY what the edge-triggered path
+  //   admits rather than a narrower set.
+  //
+  //   Return contract mirrors eligible(), with one deliberate difference:
+  //     - no team           → undefined (can't build the filter)
+  //     - no triageStatus   → { nodes: [] } — a CONFIRMED empty, not a miss. A
+  //         team with no configured Triage state genuinely has nothing to sweep,
+  //         so reporting "unknown" would make the caller log an anomaly for a
+  //         deliberate configuration.
+  //     - gate fail / throw → undefined (unavailable)
+  const triageState = (query) => {
+    if (!query || !query.team) return undefined;
+    if (!query.triageStatus) return { nodes: [] };
+    return readBoardByState(query.team, query.triageStatus);
   };
 
   // ownership(id) → { assignee, delegate } | undefined  (Stage 0 / A0, A1)
@@ -515,6 +557,7 @@ export function createReplicaReader({ dbPath = getReplicaDbPath() } = {}) {
     freshness,
     titles,
     eligible,
+    triageState, // CTL-1589
     ownership,
     labels,
     stateAndLabels,

--- a/plugins/dev/scripts/execution-core/replica-read.test.mjs
+++ b/plugins/dev/scripts/execution-core/replica-read.test.mjs
@@ -327,6 +327,20 @@ function seedEligible() {
   db.run(
     `INSERT INTO issues VALUES ('CTC-100', 'Other team todo', 'Todo', 2, NULL, NULL, NULL, NULL, NULL, NULL, 2700, 60)`,
   );
+  // CTL-1589 (triageState): rows in the TRIAGE state. Invisible to eligible()
+  // (which binds status=Todo) — the exact blind spot that stranded a ticket whose
+  // one-shot →Triage webhook dispatch was consumed.
+  db.run(
+    `INSERT INTO issues VALUES ('CTL-200', 'Sitting in triage', 'Triage', 1, NULL, NULL, NULL, NULL, NULL, NULL, 2900, 50)`,
+  );
+  // Tombstoned Triage row — excluded by removed_at IS NULL.
+  db.run(
+    `INSERT INTO issues VALUES ('CTL-201', 'Removed triage', 'Triage', 1, NULL, NULL, NULL, NULL, NULL, '2026-06-03T00:00:00Z', 2800, 40)`,
+  );
+  // Another team's Triage row — must not leak into a CTL query.
+  db.run(
+    `INSERT INTO issues VALUES ('CTC-200', 'Other team triage', 'Triage', 1, NULL, NULL, NULL, NULL, NULL, NULL, 2700, 30)`,
+  );
   // relations: CTL-100 blocks CTL-9 (forward); CTL-7 blocks CTL-100 (inverse).
   db.run(`INSERT INTO relations VALUES ('blocks', 'CTL-100', 'CTL-9')`);
   db.run(`INSERT INTO relations VALUES ('blocks', 'CTL-7', 'CTL-100')`);
@@ -582,6 +596,130 @@ describe("createReplicaReader.eligible (CTL-1397 board-list)", () => {
     expect(second.nodes[0].inverseRelations.nodes).toEqual([
       { type: "blocks", issue: { identifier: "CTL-7" } },
     ]);
+  });
+});
+
+// CTL-1589 — triageState(): the tickets SITTING IN the team's Triage state. The
+// level-triggered half of triage admission; eligible() binds status=Todo, so
+// before this a ticket parked in Triage appeared in no replica read at all. It
+// shares eligible()'s body (readBoardByState), so these tests pin the two things
+// that are genuinely its own — the state binding and the triageStatus contract —
+// plus the shared gates, which must hold identically for both readers.
+describe("createReplicaReader.triageState (CTL-1589)", () => {
+  test("selects by triageStatus, excluding Todo rows, removed rows, and other teams", () => {
+    seedEligible();
+    reader = createReplicaReader({ dbPath });
+    const res = reader.triageState({ team: "CTL", status: "Todo", triageStatus: "Triage" });
+    // CTL-200 only: NOT CTL-100/CTL-101 (Todo), NOT CTL-201 (removed), NOT CTC-200.
+    expect(res.nodes.map((n) => n.identifier)).toEqual(["CTL-200"]);
+  });
+
+  test("builds the same node shape eligible() does (normalizeTicket-consumable)", () => {
+    seedEligible();
+    reader = createReplicaReader({ dbPath });
+    const n = reader.triageState({ team: "CTL", triageStatus: "Triage" }).nodes[0];
+    expect(n.identifier).toBe("CTL-200");
+    expect(n.state).toBe("Triage");
+    expect(n.priority).toBe(1);
+    expect(n.updatedAt).toBe(new Date(2900).toISOString());
+    expect(n.relations.nodes).toEqual([]);
+    expect(n.inverseRelations.nodes).toEqual([]);
+  });
+
+  test("a custom triageStatus name binds through (not hardcoded to 'Triage')", () => {
+    seedEligible();
+    const db = new Database(dbPath);
+    db.run(`UPDATE issues SET state = 'Needs Triage' WHERE identifier = 'CTL-200'`);
+    db.close();
+    freshen();
+    reader = createReplicaReader({ dbPath });
+    expect(reader.triageState({ team: "CTL", triageStatus: "Triage" })).toEqual({ nodes: [] });
+    expect(
+      reader.triageState({ team: "CTL", triageStatus: "Needs Triage" }).nodes.map((n) => n.identifier)
+    ).toEqual(["CTL-200"]);
+  });
+
+  test("a team with genuinely zero Triage rows → { nodes: [] }, NOT undefined", () => {
+    seedEligible();
+    reader = createReplicaReader({ dbPath });
+    expect(reader.triageState({ team: "ZZZ", triageStatus: "Triage" })).toEqual({ nodes: [] });
+  });
+
+  // Deliberate divergence from eligible(): a missing STATE is a confirmed empty
+  // here, not a fall-through. A team with no configured Triage state has nothing
+  // to sweep, and there is no live query that could answer "the null state".
+  test("triageStatus null/absent → { nodes: [] } (confirmed empty), never a DB read", () => {
+    // No fixture at all — an absent DB would make any real read return undefined,
+    // so a { nodes: [] } here proves the short-circuit ran first.
+    reader = createReplicaReader({ dbPath });
+    expect(reader.triageState({ team: "CTL", triageStatus: null })).toEqual({ nodes: [] });
+    expect(reader.triageState({ team: "CTL" })).toEqual({ nodes: [] });
+  });
+
+  test("returns undefined (fall through) when team is missing", () => {
+    seedEligible();
+    reader = createReplicaReader({ dbPath });
+    expect(reader.triageState({ triageStatus: "Triage" })).toBeUndefined();
+  });
+
+  test("respects the freshness gate identically to eligible(): STALE → undefined", () => {
+    seedEligible();
+    const old = new Date(Date.now() - 10 * 60_000);
+    utimesSync(dbPath, old, old);
+    try { utimesSync(dbPath + "-wal", old, old); } catch { /* -wal may be absent */ }
+    reader = createReplicaReader({ dbPath });
+    expect(reader.triageState({ team: "CTL", triageStatus: "Triage" })).toBeUndefined();
+    // …and the sibling reader agrees, so the two can't drift apart.
+    expect(reader.eligible({ team: "CTL", status: "Todo" })).toBeUndefined();
+  });
+
+  test("DEAD WRITER (stale .writer.lock, fresh db) → undefined", () => {
+    seedEligible();
+    const old = new Date(Date.now() - 10 * 60_000);
+    writeFileSync(dbPath + ".writer.lock", "");
+    utimesSync(dbPath + ".writer.lock", old, old);
+    reader = createReplicaReader({ dbPath });
+    expect(reader.triageState({ team: "CTL", triageStatus: "Triage" })).toBeUndefined();
+  });
+
+  test("cursor row ABSENT (mid-reseed) → undefined (fall through), never a partial board", () => {
+    seedEligible();
+    const db = new Database(dbPath);
+    db.run(`DELETE FROM sync_meta WHERE key = 'cursor'`);
+    db.close();
+    freshen();
+    reader = createReplicaReader({ dbPath });
+    expect(reader.triageState({ team: "CTL", triageStatus: "Triage" })).toBeUndefined();
+  });
+
+  test("returns undefined when the replica file is absent", () => {
+    reader = createReplicaReader({ dbPath });
+    expect(reader.triageState({ team: "CTL", triageStatus: "Triage" })).toBeUndefined();
+  });
+
+  test("fail-open: DB without the issues table → undefined (query throws)", () => {
+    const empty = new Database(dbPath, { create: true });
+    empty.run(`CREATE TABLE unrelated (x INTEGER)`);
+    empty.close();
+    freshen();
+    reader = createReplicaReader({ dbPath });
+    expect(reader.triageState({ team: "CTL", triageStatus: "Triage" })).toBeUndefined();
+  });
+
+  // The webhook →Triage predicate filters on team + state ONLY, so the
+  // level-triggered read must not be narrowed by the query's project/label —
+  // otherwise the sweep would admit less than the edge-triggered path already does.
+  test("ignores the query's project/label filters (mirrors the webhook →Triage predicate)", () => {
+    seedEligible();
+    reader = createReplicaReader({ dbPath });
+    // CTL-200 has no project and no labels; a project-scoped query still finds it.
+    const res = reader.triageState({
+      team: "CTL",
+      triageStatus: "Triage",
+      project: "Harden the core",
+      label: "bug",
+    });
+    expect(res.nodes.map((n) => n.identifier)).toEqual(["CTL-200"]);
   });
 });
 


### PR DESCRIPTION
## The defect

Triage admission was **edge-triggered only**.

The webhook fast path in `monitor.mjs` (`parsed.toState === query.triageStatus`) is the *only* code that ever consulted a team's `triageStatus`, and it fires once, on the transition **into** Triage. The retry sweep that was supposed to back it up — `sweepMissingTriage` — iterates `getEligibleSet(team)`, which is fed by a **Todo-only** query (`replica-read.mjs` `eligible()` binds `query.status`; the `linearis` fallback passes `--status query.status`).

So a ticket *already sitting in Triage* — whose one-shot dispatch was consumed and whose worker dir later vanished — appeared in no code path at all and could never be re-noticed. Live strandings: ADV-1374, ADV-1376, CTL-1381, OTL-5.

## The fix

Give the sweep a second ticket source and make admission level-triggered.

- **`replica-read.mjs`** — new `triageState(query)`, binding `query.triageStatus` instead of `query.status`. `eligible()` and `triageState()` now share a single extracted `readBoardByState` body, so the writer-liveness gate, the seed-completeness cursor and the one-deferred-snapshot read cannot drift between them. It filters on **team + state only** (no project/label/priority), mirroring the webhook →Triage predicate, so the level-triggered path admits exactly what the edge-triggered path already does. A team with no `triageStatus` gets a confirmed `{ nodes: [] }` rather than an "unknown".

- **`linear-query.mjs`** — new `runTriageStateQuery(query, { replica, onSource })`. **Replica-only, deliberately** — this is the one structural divergence from `runEligibleQuery` and the main judgement call in the PR. The read is *supplementary*: an unavailable answer costs one 10-minute sweep, where an unavailable eligible board freezes admission fleet-wide (which is why that path carries the linearis re-confirm + empty-marker + breaker machinery). Adding a per-team `linearis issues list` on the reconcile cadence would re-introduce exactly the shared-quota burn the replica tier exists to remove (CTL-679 breaker, CTL-1397, CTL-1570). Both production hosts run `catalyst.linearReplica.mode = "on"`, so this is served locally with zero Linear calls. Every non-served case carries a distinct `onSource` marker (`no-replica`, `replica-miss`, `no-triage-status`) and the caller logs it at WARN — with the replica tier off this half is inert, and that is reported loudly rather than silently.

- **`monitor.mjs`** — `sweepMissingTriage` iterates the **union** of `getEligibleSet(team)` and the team's Triage-state board, deduped by ticket id. `dispatchTriage`'s existing idempotence (`hasTriageArtifact` skip, plus the drain/HRW/cap/budget/delegate/claim gates) makes re-sweeping safe. Only the sweep's ticket **source** widens — Triage-state tickets are **not** added to the eligible projection, since the scheduler's new-work pull, the Pass-0a phantom sweep and the dependency graph consume that and a Triage ticket is never scheduler-pulled. A read failure logs and degrades to the pre-CTL-1589 eligible-only behavior; it never aborts the pass.

## Tests

26 new cases. Notably: `triageState()` selects by `triageStatus` and honours the same freshness / dead-writer / mid-reseed gates as `eligible()` (asserted side by side so they can't diverge); a custom state name binds through; `sweepMissingTriage` dispatches a ticket present *only* in Triage, dedupes one present in both sources, still skips anything with a `triage.json`, and does no extra work when `triageStatus` is null.

`replica-read.test.mjs` was running in **no** workflow, so the new reader tests would not have gated anything — added it to the execution-core CI suite list (hermetic, ~0.5s).

```
bun test replica-read.test.mjs        → 79 pass, 0 fail
bun test linear-query.test.mjs        → 234 pass, 0 fail
bun test monitor.test.mjs             → 157 pass, 2 fail (both pre-existing)
bun test replica-read linear-query triage-redispatch-guard eligible-set dispatch registry
                                      → 514 pass, 0 fail
bun build daemon.mjs --target=node    → import graph resolves
```

The two `monitor.test.mjs` failures (`resumeFromCursor:false keeps the seed-at-EOF behavior`, `CTL-716 burst budget — 7 →Triage events drained in ONE pass`) were reproduced on a clean `origin/main` worktree before this branch's changes. Both are the wall-clock/`fs.watch` flakes that keep `monitor.test.mjs` out of CI in the first place.

Closes https://linear.app/rozich/issue/CTL-1589

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Wte59hchAL4FjhHiCwSVS3