### PR TITLE
fix(dev): CTL-1593 capture the recovery cursor before reconcileAll so boot telemetry can't shift it

### DIFF
--- a/plugins/dev/scripts/execution-core/recovery.mjs
+++ b/plugins/dev/scripts/execution-core/recovery.mjs
@@ -3195,12 +3195,11 @@ export function reclaimDeadWorkIfPossible(
 export function recoverStartup({ orchDir, exec, statJob, detectCold = detectColdStart } = {}) {
   if (!orchDir) throw new Error("recoverStartup: orchDir is required");
 
-  // (1) Routing state — reconcileAll re-reads the registry + polls Linear per
-  //     team; reconcileProject internally swallows poll/write failures.
-  reconcileAll({ exec });
-  const projects = listProjects().map((p) => p.team);
-
-  // (2) Durable event-log cursor — what the monitor's fast path will resume at.
+  // (1) Durable event-log cursor — what the monitor's fast path will resume at.
+  //     Captured BEFORE reconcileAll: since CTL-1580 the eligible-list query
+  //     emits catalyst.linear.read telemetry into this same log, so measuring
+  //     after reconcile would fold the boot's OWN telemetry into the resume
+  //     cursor and a fresh boot could never observe "no prior log" (CTL-1593).
   const logPath = getEventLogPath();
   let fileSize = 0;
   try {
@@ -3212,6 +3211,11 @@ export function recoverStartup({ orchDir, exec, statJob, detectCold = detectCold
   }
   const cursor = loadCursor();
   const startOffset = resolveStartOffset({ cursor, logPath, fileSize });
+
+  // (2) Routing state — reconcileAll re-reads the registry + polls Linear per
+  //     team; reconcileProject internally swallows poll/write failures.
+  reconcileAll({ exec });
+  const projects = listProjects().map((p) => p.team);
 
   // (3) Dispatch/worker state — classify in-flight claude --bg workers.
   const workers = reconstructWorkerState(orchDir, { statJob });


### PR DESCRIPTION
Fixes red main CI ([CTL-1593](https://linear.app/rozich/issue/CTL-1593)): `Execution Core Unit Tests` has failed on every PR/push since CTL-1580 (#2825) merged — `recoverStartup > no event log at all → cursor.byteOffset 0` fails deterministically (observed 634, expected 0).

**Mechanism:** `recoverStartup` ran `reconcileAll` first, and since CTL-1580 the eligible-list query inside it emits `catalyst.linear.read` telemetry via `emitLinearReadEvent` → `appendFileSync(eventLogPath())` — creating/growing the very log whose size and cursor are read immediately after. The boot cursor therefore folded in the boot's own telemetry, and a fresh boot could never observe "no prior log".

**Fix:** reorder — capture the event-log size + durable cursor *before* `reconcileAll`, so the resume cursor reflects pre-boot state. Telemetry appended during reconcile is then read once by the monitor fast path, which is harmless (`catalyst.linear.read` is not a routed phase event).

**Tests:** `recovery.test.mjs` 308/308 (was 307/308 on main), `boot-resume.test.mjs` 80/80, both in CI's stable set; scrubbed-env runs per the known local-pollution caveat.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Wte59hchAL4FjhHiCwSVS3