### PR TITLE
fix(dev): CTL-1588 queue humanHold falls back to replica labels when the webhook-fed store has gaps

### DIFF
--- a/plugins/dev/scripts/execution-core/replica-read.mjs
+++ b/plugins/dev/scripts/execution-core/replica-read.mjs
@@ -528,7 +528,7 @@ export function createReplicaReader({ dbPath = getReplicaDbPath() } = {}) {
         const ph = wanted.map(() => "?").join(",");
         return handle
           .prepare(
-            `SELECT i.identifier AS identifier, l.name AS name FROM issues i JOIN issue_labels il ON il.issue_id = i.id JOIN labels l ON l.id = il.label_id WHERE i.identifier IN (${ph}) AND i.removed_at IS NULL`
+            `SELECT i.identifier AS identifier, l.name AS name FROM issues i JOIN issue_labels il ON il.issue_id = i.id JOIN labels l ON l.id = il.label_id WHERE i.identifier IN (${ph}) AND i.removed_at IS NULL AND l.removed_at IS NULL`
           )
           .all(...wanted);
       })();

--- a/plugins/dev/scripts/execution-core/replica-read.mjs
+++ b/plugins/dev/scripts/execution-core/replica-read.mjs
@@ -510,6 +510,38 @@ export function createReplicaReader({ dbPath = getReplicaDbPath() } = {}) {
     }
   };
 
+  // labelsBatch(identifiers) → { identifier: [name…] } | undefined (CTL-1588
+  // #2845): ONE freshness check + ONE deferred snapshot + ONE IN query for a
+  // bounded id set. The monitor's queue hold-annotation reads every
+  // not-in-flight ticket per board assemble — per-id labels() calls would cost
+  // N transactions (and N freshness stats) on a 3s refresh cadence. undefined =
+  // fall through (stale writer / mid-reseed / throw). An id with no rows simply
+  // has no key: no label knowledge is fabricated for absent/removed tickets.
+  const labelsBatch = (identifiers) => {
+    const wanted = [...new Set((Array.isArray(identifiers) ? identifiers : []).filter(Boolean))];
+    if (wanted.length === 0) return {};
+    if (!isReplicaFresh(dbPath)) return undefined;
+    try {
+      const handle = open();
+      const rows = handle.transaction(() => {
+        if (!handle.prepare(SEED_COMPLETE_SELECT).get()) return undefined; // mid-reseed
+        const ph = wanted.map(() => "?").join(",");
+        return handle
+          .prepare(
+            `SELECT i.identifier AS identifier, l.name AS name FROM issues i JOIN issue_labels il ON il.issue_id = i.id JOIN labels l ON l.id = il.label_id WHERE i.identifier IN (${ph}) AND i.removed_at IS NULL`
+          )
+          .all(...wanted);
+      })();
+      if (!rows) return undefined;
+      const out = {};
+      for (const r of rows) (out[r.identifier] ??= []).push(r.name);
+      return out;
+    } catch {
+      dropHandle();
+      return undefined;
+    }
+  };
+
   return {
     lookup,
     freshness,
@@ -517,6 +549,7 @@ export function createReplicaReader({ dbPath = getReplicaDbPath() } = {}) {
     eligible,
     ownership,
     labels,
+    labelsBatch,
     stateAndLabels,
     // isFresh — WRITER-LIVENESS gate (the `.writer.lock` heartbeat), bound to
     // this reader's dbPath. Callers composing replica-first reads (the broker's

--- a/plugins/dev/scripts/execution-core/replica-read.test.mjs
+++ b/plugins/dev/scripts/execution-core/replica-read.test.mjs
@@ -610,12 +610,12 @@ function seedEligibleLabeled() {
   db.run(`CREATE INDEX idx_issues_identifier ON issues (identifier)`);
   db.run(`CREATE TABLE relations (type TEXT, issue_identifier TEXT, related_identifier TEXT)`);
   db.run(`CREATE TABLE projects (id TEXT, name TEXT)`);
-  db.run(`CREATE TABLE labels (id TEXT, name TEXT)`);
+  db.run(`CREATE TABLE labels (id TEXT, name TEXT, removed_at TEXT)`);
   db.run(`CREATE TABLE issue_labels (issue_id TEXT, label_id TEXT)`);
   db.run(`CREATE TABLE sync_meta (key TEXT PRIMARY KEY, value TEXT)`);
   db.run(`INSERT INTO sync_meta VALUES ('cursor', '42')`);
-  db.run(`INSERT INTO labels VALUES ('lab-bug', 'bug')`);
-  db.run(`INSERT INTO labels VALUES ('lab-chore', 'chore')`);
+  db.run(`INSERT INTO labels VALUES ('lab-bug', 'bug', NULL)`);
+  db.run(`INSERT INTO labels VALUES ('lab-chore', 'chore', NULL)`);
   // CTL-200 labeled 'bug'; CTL-201 labeled 'chore'; both Todo.
   db.run(
     `INSERT INTO issues VALUES ('id-200', 'CTL-200', 'Bug ticket', 'Todo', 2, NULL, NULL, NULL, NULL, NULL, NULL, 3000, 100)`,
@@ -935,6 +935,16 @@ describe("createReplicaReader.labelsBatch", () => {
     reader = createReplicaReader({ dbPath });
     const out = reader.labelsBatch(["CTL-200", "CTL-201", "CTL-999"]);
     expect(out).toEqual({ "CTL-200": ["bug"], "CTL-201": ["chore"] });
+  });
+
+  test("a tombstoned label is excluded (same live-label predicate as labels())", () => {
+    seedEligibleLabeled();
+    const db = new Database(dbPath);
+    db.run(`UPDATE labels SET removed_at = '2026-07-31T00:00:00Z' WHERE name = 'bug'`);
+    db.close();
+    freshen();
+    reader = createReplicaReader({ dbPath });
+    expect(reader.labelsBatch(["CTL-200", "CTL-201"])).toEqual({ "CTL-201": ["chore"] });
   });
 
   test("empty/absent input → {} without touching the db", () => {

--- a/plugins/dev/scripts/execution-core/replica-read.test.mjs
+++ b/plugins/dev/scripts/execution-core/replica-read.test.mjs
@@ -927,3 +927,29 @@ describe("createReplicaReader.stateAndLabels (CTL-1571 — one-snapshot pair)", 
     expect(reader.stateAndLabels("CTL-999")).toBeUndefined();
   });
 });
+
+// ── labelsBatch (CTL-1588 #2845) — one snapshot, one IN query ────────────────
+describe("createReplicaReader.labelsBatch", () => {
+  test("returns {identifier: [names]} for the id set in one call; absent ids have no key", () => {
+    seedEligibleLabeled();
+    reader = createReplicaReader({ dbPath });
+    const out = reader.labelsBatch(["CTL-200", "CTL-201", "CTL-999"]);
+    expect(out).toEqual({ "CTL-200": ["bug"], "CTL-201": ["chore"] });
+  });
+
+  test("empty/absent input → {} without touching the db", () => {
+    reader = createReplicaReader({ dbPath });
+    expect(reader.labelsBatch([])).toEqual({});
+    expect(reader.labelsBatch(undefined)).toEqual({});
+  });
+
+  test("stale writer (no freshness) → undefined (fall through, never a stale answer)", () => {
+    seedEligibleLabeled();
+    // Backdate the DB + -wal well past the default 5-min staleness threshold.
+    const old = new Date(Date.now() - 10 * 60_000);
+    utimesSync(dbPath, old, old);
+    try { utimesSync(dbPath + "-wal", old, old); } catch { /* -wal may be absent */ }
+    reader = createReplicaReader({ dbPath });
+    expect(reader.labelsBatch(["CTL-200"])).toBeUndefined();
+  });
+});

--- a/plugins/dev/scripts/orch-monitor/__tests__/board-parked-needs-human.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/board-parked-needs-human.test.ts
@@ -280,3 +280,42 @@ describe("CTL-1588 follow-up: queue humanHold merges replica holds (source contr
     expect(nospace(boardDataSrc)).toContain(nospace("...Object.entries(replicaHolds),"));
   });
 });
+
+describe("readReplicaHumanHolds — batched path (#2845 Codex)", () => {
+  const readReplicaHumanHolds = (cacheMod as Record<string, unknown>)
+    .readReplicaHumanHolds as (opts?: {
+    ids?: string[];
+    readerFactory?: (o: { dbPath: string }) => unknown;
+  }) => Promise<Record<string, string>>;
+
+  it("prefers labelsBatch (one call) over per-id labels", async () => {
+    let batchCalls = 0;
+    let perIdCalls = 0;
+    const out = await readReplicaHumanHolds({
+      ids: ["CRM-1", "CRM-5", "CRM-9"],
+      readerFactory: () => ({
+        labelsBatch: (ids: string[]) => {
+          batchCalls += 1;
+          expect(ids.sort()).toEqual(["CRM-1", "CRM-5", "CRM-9"]);
+          return { "CRM-1": ["needs-human"], "CRM-5": ["etl", "needs-input"] };
+        },
+        labels: () => {
+          perIdCalls += 1;
+          return [];
+        },
+        close: () => {},
+      }),
+    });
+    expect(out).toEqual({ "CRM-1": "needs-human", "CRM-5": "needs-input" });
+    expect(batchCalls).toBe(1);
+    expect(perIdCalls).toBe(0);
+  });
+
+  it("an undefined batch (stale writer / mid-reseed) fails open to {}", async () => {
+    const out = await readReplicaHumanHolds({
+      ids: ["CRM-1"],
+      readerFactory: () => ({ labelsBatch: () => undefined, close: () => {} }),
+    });
+    expect(out).toEqual({});
+  });
+});

--- a/plugins/dev/scripts/orch-monitor/__tests__/board-parked-needs-human.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/board-parked-needs-human.test.ts
@@ -209,3 +209,74 @@ describe("CTL-1588: queue humanHold annotation (source contract)", () => {
     );
   });
 });
+
+// ── CTL-1588 follow-up: replica fallback for queue humanHold ─────────────────
+// The parked set is webhook-fed (single-homed receiver) — a label this node's
+// broker never saw left CRM-1/2/5/6 ranked as imminent dispatches on mini-2
+// while the replica carried their needs-human. readReplicaHumanHolds fills the
+// gap from the CTC replica with the same gate/fail-open contract as titles.
+describe("readReplicaHumanHolds (CTL-1588 follow-up)", () => {
+  const readReplicaHumanHolds = (cacheMod as Record<string, unknown>)
+    .readReplicaHumanHolds as (opts?: {
+    ids?: string[];
+    dbPath?: string;
+    readerFactory?: (o: { dbPath: string }) => unknown;
+  }) => Promise<Record<string, string>>;
+
+  const factoryWith = (labelsById: Record<string, Array<{ name: string }> | null>) => () => ({
+    labels: (id: string) => labelsById[id],
+    close: () => {},
+  });
+
+  it("maps needs-human and needs-input labels from replica label nodes", async () => {
+    const out = await readReplicaHumanHolds({
+      ids: ["CRM-1", "CRM-5", "CRM-9"],
+      readerFactory: factoryWith({
+        "CRM-1": [{ name: "needs-human" }],
+        "CRM-5": [{ name: "etl" }, { name: "needs-input" }],
+        "CRM-9": [{ name: "etl" }],
+      }),
+    });
+    expect(out).toEqual({ "CRM-1": "needs-human", "CRM-5": "needs-input" });
+  });
+
+  it("needs-human outranks needs-input on a dual-labeled ticket", async () => {
+    const out = await readReplicaHumanHolds({
+      ids: ["CRM-2"],
+      readerFactory: factoryWith({ "CRM-2": [{ name: "needs-input" }, { name: "needs-human" }] }),
+    });
+    expect(out).toEqual({ "CRM-2": "needs-human" });
+  });
+
+  it("fails open: throwing factory yields {}, unreadable single row is skipped", async () => {
+    const throwing = () => {
+      throw new Error("no replica");
+    };
+    expect(await readReplicaHumanHolds({ ids: ["A"], readerFactory: throwing })).toEqual({});
+    const out = await readReplicaHumanHolds({
+      ids: ["A", "B"],
+      readerFactory: () => ({
+        labels: (id: string) => {
+          if (id === "A") throw new Error("bad row");
+          return [{ name: "needs-human" }];
+        },
+        close: () => {},
+      }),
+    });
+    expect(out).toEqual({ B: "needs-human" });
+  });
+
+  it("empty ids short-circuits to {}", async () => {
+    expect(await readReplicaHumanHolds({ ids: [] })).toEqual({});
+  });
+});
+
+describe("CTL-1588 follow-up: queue humanHold merges replica holds (source contract)", () => {
+  const nospace = (s: string) => s.replace(/\s+/g, "");
+  it("assembleBoard reads replica holds for the queue ids and lets the parked set win", () => {
+    expect(nospace(boardDataSrc)).toContain(
+      nospace("const replicaHolds = await readReplicaHumanHolds({ ids: notInFlight.map((e) => e.id) })"),
+    );
+    expect(nospace(boardDataSrc)).toContain(nospace("...Object.entries(replicaHolds),"));
+  });
+});

--- a/plugins/dev/scripts/orch-monitor/lib/board-data.mjs
+++ b/plugins/dev/scripts/orch-monitor/lib/board-data.mjs
@@ -26,6 +26,7 @@ import {
   readLinearCache,
   readParkedNeedsHumanTickets,
   readReplicaTitles,
+  readReplicaHumanHolds,
 } from "./linear-cache-reader.mjs";
 import { fillEstimateFallback, getEstimationMethodAsync } from "./linear-estimate-fallback.mjs";
 // CTL-1046: supplemental Linear-title fallback for cross-team (e.g. ADV) records.
@@ -2279,14 +2280,21 @@ export async function assembleBoard({ getPrStatus = null, ring = null } = {}) {
   // (`held` is reserved for the CTL-755 blocked/queued admission pair.) The
   // eligible projection itself is NOT filtered (Pass-0a and the scheduler
   // consume eligibleIds — daemon behavior must not change from a display fix).
-  const humanHoldByTicket = new Map(
-    parkedNeedsHuman.map((p) => [
+  // Second source (CTL-1588 follow-up): the parked set is webhook-fed and the
+  // receiver is single-homed, so a label this node's broker never saw leaves a
+  // durable gap (live: mini-2 ranked CRM-1/2/5/6 as imminent while the replica
+  // carried their needs-human). Replica labels fill the gaps; the parked
+  // descriptor (fresher on THIS node's webhook stream) wins on conflict.
+  const replicaHolds = await readReplicaHumanHolds({ ids: notInFlight.map((e) => e.id) });
+  const humanHoldByTicket = new Map([
+    ...Object.entries(replicaHolds),
+    ...parkedNeedsHuman.map((p) => [
       p.ticket,
       // needs-human outranks needs-input on a dual-labeled ticket — same
       // precedence as the parked cards / status counts / holding buckets.
       p.labels.includes("needs-human") ? "needs-human" : "needs-input",
-    ])
-  );
+    ]),
+  ]);
 
   // priority queue: eligible (not yet in-flight), globally ranked (Queue tab)
   const queue = await Promise.all(

--- a/plugins/dev/scripts/orch-monitor/lib/linear-cache-reader.mjs
+++ b/plugins/dev/scripts/orch-monitor/lib/linear-cache-reader.mjs
@@ -267,6 +267,64 @@ export async function readReplicaTitles({
   }
 }
 
+
+// readReplicaHumanHolds — replica-backed needs-human/needs-input holds for a
+// bounded id set (the CTL-1588 queue annotation's SECOND source). The parked
+// descriptor set (filter-state.db) is webhook-fed, and the webhook receiver is
+// single-homed — a label applied while this node's broker missed the delivery
+// leaves a durable gap (live: mini-2 missing CRM-1/2/5/6's needs-human), so the
+// queue kept ranking held tickets as imminent. The CTC replica is the SDK's
+// live Linear mirror and carries every label; one bounded read per assemble
+// (queue ids only — a handful) closes the gap. Same gating + fail-open contract
+// as readReplicaTitles above: file-presence gate, {} on ANY failure, and the
+// reader is closed either way. needs-human outranks needs-input (house
+// precedence).
+export async function readReplicaHumanHolds({
+  ids = [],
+  dbPath = process.env.CATALYST_REPLICA_DB || defaultReplicaDbPath(),
+  readerFactory = null,
+} = {}) {
+  const wanted = [...new Set((Array.isArray(ids) ? ids : []).filter(Boolean))];
+  if (wanted.length === 0) return {};
+  if (!readerFactory) {
+    try {
+      if (!existsSync(dbPath)) return {};
+    } catch {
+      return {};
+    }
+  }
+  let reader = null;
+  try {
+    let factory = readerFactory;
+    if (!factory) {
+      ({ createReplicaReader: factory } = await import(REPLICA_READ_MODULE));
+    }
+    reader = factory({ dbPath });
+    const out = {};
+    for (const id of wanted) {
+      let nodes;
+      try {
+        nodes = reader.labels(id);
+      } catch {
+        continue; // one bad row must not drop the rest
+      }
+      if (!Array.isArray(nodes)) continue;
+      const names = nodes.map((n) => n?.name).filter(Boolean);
+      if (names.includes("needs-human")) out[id] = "needs-human";
+      else if (names.includes("needs-input")) out[id] = "needs-input";
+    }
+    return out;
+  } catch {
+    return {}; // replica unavailable → the parked-set source stands alone
+  } finally {
+    try {
+      reader?.close?.();
+    } catch {
+      /* already closed */
+    }
+  }
+}
+
 // Read the scheduler's eligible projections for priority/project/relations on
 // tickets that may not have a ticket_state row yet (queued, not-yet-worked).
 async function readEligibleById(eligibleDir) {

--- a/plugins/dev/scripts/orch-monitor/lib/linear-cache-reader.mjs
+++ b/plugins/dev/scripts/orch-monitor/lib/linear-cache-reader.mjs
@@ -301,6 +301,21 @@ export async function readReplicaHumanHolds({
     }
     reader = factory({ dbPath });
     const out = {};
+    // Batched path (#2845 Codex): ONE transaction + ONE freshness check for the
+    // whole id set — per-id labels() would cost N transactions per assemble on
+    // the board's refresh cadence. Fall back to per-id for injected readers
+    // that predate labelsBatch.
+    if (typeof reader.labelsBatch === "function") {
+      const byId = reader.labelsBatch(wanted);
+      if (byId && typeof byId === "object") {
+        for (const [id, names] of Object.entries(byId)) {
+          if (!Array.isArray(names)) continue;
+          if (names.includes("needs-human")) out[id] = "needs-human";
+          else if (names.includes("needs-input")) out[id] = "needs-input";
+        }
+      }
+      return out; // undefined batch (stale writer / mid-reseed) → {} — fail-open
+    }
     for (const id of wanted) {
       let nodes;
       try {


### PR DESCRIPTION
Follow-up to #2840 ([CTL-1588](https://linear.app/rozich/issue/CTL-1588)), found during post-deploy live verification: mini-2's Workers page still ranked CRM-1/2/5/6 as imminent dispatches. Their `needs-human` labels are present in the CTC replica but absent from mini-2's `filter-state.db` — the parked-set source is webhook-fed and the receiver is single-homed on mini, so a label applied while this node's broker missed the delivery leaves a durable gap the annotation inherited.

**Fix:** `readReplicaHumanHolds` — a bounded replica label read for the queue's ids only (a handful per assemble), with the exact `readReplicaTitles` contract: file-presence gate, `{}` on any failure, reader closed either way, needs-human outranks needs-input. The humanHold map merges replica holds first, parked descriptors second (fresher on this node's webhook stream, they win on conflict). No daemon-path changes.

**Tests:** 4 new unit tests (mapping, dual-label precedence, fail-open incl. per-row throw, empty short-circuit) + source-contract lock. `board-parked-needs-human.test.ts` 20/20; parent `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Wte59hchAL4FjhHiCwSVS3