### PR TITLE
fix(execution-core): pin CATALYST_CONFIG_FILE in cmd_start so daemon config never falls back to the operator's cwd

### DIFF
--- a/plugins/dev/scripts/__tests__/create-worktree-gitignore-artifacts.test.sh
+++ b/plugins/dev/scripts/__tests__/create-worktree-gitignore-artifacts.test.sh
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+# Tests for catalyst_git_exclude_worktree_artifacts (create-worktree.sh):
+# Catalyst's own worktree-local runtime artifacts (thoughts/,
+# .catalyst/.workflow-context.json, etc.) must never show up as dirty/untracked
+# in a fresh worktree's `git status` — without ever touching the project's
+# TRACKED .gitignore. This is what makes a project's verify-phase rebase never
+# get refused by Catalyst's own noise (the root cause of a real stalled-ticket
+# incident: rebase_refused_dirty_tree on thoughts/ + .workflow-context.json).
+# Run: bash plugins/dev/scripts/__tests__/create-worktree-gitignore-artifacts.test.sh
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../../.." && pwd)"
+CREATE_WT="${REPO_ROOT}/plugins/dev/scripts/create-worktree.sh"
+
+FAILURES=0
+PASSES=0
+fail() {
+	FAILURES=$((FAILURES + 1))
+	echo "  FAIL: $1"
+}
+pass() {
+	PASSES=$((PASSES + 1))
+	echo "  PASS: $1"
+}
+assert_eq() {
+	if [[ $1 == "$2" ]]; then pass "$3"; else fail "$3 — expected '$1', got '$2'"; fi
+}
+assert_contains() {
+	if [[ $2 == *"$1"* ]]; then pass "$3"; else fail "$3 — expected to find '$1' in: $2"; fi
+}
+
+# Scratch layout mirrors create-worktree-tracked-clean.test.sh.
+COMMITTED_CATALYST_CFG='{"catalyst":{"projectKey":"t","worktree":{"setup":["true"]}}}'
+build_scratch() {
+	SCRATCH="$(mktemp -d -t cwt-gitignore-XXXXXX)"
+	ORIGIN="$SCRATCH/origin.git"
+	SRC="$SCRATCH/src"
+	WT="$SCRATCH/wt"
+	FAKEHOME="$SCRATCH/home"
+	mkdir -p "$WT" "$FAKEHOME"
+	git init -q --bare "$ORIGIN"
+	# Robust to the host's init.defaultBranch (may be "master" locally, "main" in
+	# CI) — pin the bare origin's HEAD to "main" explicitly so clone/push below
+	# never depend on the ambient default.
+	git -C "$ORIGIN" symbolic-ref HEAD refs/heads/main
+
+	local SEED="$SCRATCH/seed"
+	git clone -q "$ORIGIN" "$SEED"
+	git -C "$SEED" config user.email t@t.t
+	git -C "$SEED" config user.name t
+	git -C "$SEED" checkout -q -b main 2>/dev/null || git -C "$SEED" checkout -q main
+	mkdir -p "$SEED/.catalyst"
+	printf '%s\n' "$COMMITTED_CATALYST_CFG" >"$SEED/.catalyst/config.json"
+	git -C "$SEED" add -A
+	git -C "$SEED" commit -q -m c1
+	git -C "$SEED" push -q -u origin main
+
+	git clone -q "$ORIGIN" "$SRC"
+	git -C "$SRC" config user.email t@t.t
+	git -C "$SRC" config user.name t
+}
+
+run_create() { # $1 worktree name; $@ extra args
+	local NAME="$1"
+	shift
+	OUTPUT="$(cd "$SRC" && HOME="$FAKEHOME" \
+		bash "$CREATE_WT" "$NAME" main --worktree-dir "$WT" "$@" 2>&1)"
+	EXIT=$?
+	WT_PATH="$WT/$NAME"
+}
+
+echo "Test 1: fresh worktree's local git exclude carries every Catalyst runtime-artifact pattern"
+build_scratch
+run_create wt-exclude
+assert_eq "0" "$EXIT" "exits 0"
+EXCLUDE_FILE="$(git -C "$WT_PATH" rev-parse --git-path info/exclude 2>/dev/null)"
+[[ $EXCLUDE_FILE == /* ]] || EXCLUDE_FILE="$WT_PATH/$EXCLUDE_FILE"
+EXCLUDE_CONTENT="$(cat "$EXCLUDE_FILE" 2>/dev/null || true)"
+for pattern in "thoughts/" ".catalyst/.workflow-context.json" ".catalyst/.workflow-context.json.bak" \
+	".catalyst/worktree-provenance.json" ".needs-cleanup" ".orphaned_at" ".trunk"; do
+	assert_contains "$pattern" "$EXCLUDE_CONTENT" "exclude file contains '$pattern'"
+done
+rm -rf "$SCRATCH"
+
+echo ""
+echo "Test 2: these artifacts don't show up in git status even when present on disk"
+build_scratch
+run_create wt-status
+assert_eq "0" "$EXIT" "exits 0"
+mkdir -p "$WT_PATH/thoughts/shared" "$WT_PATH/.catalyst"
+printf 'x\n' >"$WT_PATH/thoughts/shared/doc.md"
+printf '{}\n' >"$WT_PATH/.catalyst/worktree-provenance.json"
+: >"$WT_PATH/.needs-cleanup"
+PORCELAIN="$(git -C "$WT_PATH" status --porcelain 2>/dev/null | grep -E 'thoughts/|worktree-provenance|needs-cleanup' || true)"
+assert_eq "" "$PORCELAIN" "none of the seeded artifacts appear in git status"
+rm -rf "$SCRATCH"
+
+echo ""
+echo "Test 3: idempotent — calling the exclude function twice adds no duplicate lines"
+build_scratch
+run_create wt-idempotent
+assert_eq "0" "$EXIT" "exits 0"
+# Extract just the function under test (create-worktree.sh's top level expects
+# real positional args and would fail if sourced directly) and re-invoke it
+# against the same worktree to exercise idempotency in isolation.
+FUNC_SRC="$(sed -n '/^catalyst_git_exclude_worktree_artifacts()/,/^}/p' "$CREATE_WT")"
+bash -c "$FUNC_SRC"$'\n'"catalyst_git_exclude_worktree_artifacts \"\$1\"" -- "$WT_PATH"
+EXCLUDE_FILE="$(git -C "$WT_PATH" rev-parse --git-path info/exclude 2>/dev/null)"
+[[ $EXCLUDE_FILE == /* ]] || EXCLUDE_FILE="$WT_PATH/$EXCLUDE_FILE"
+AFTER_COUNT="$(grep -cxF 'thoughts/' "$EXCLUDE_FILE" 2>/dev/null || echo 0)"
+assert_eq "1" "$AFTER_COUNT" "'thoughts/' still appears exactly once after a second call"
+rm -rf "$SCRATCH"
+
+echo ""
+echo "Passed: $PASSES  Failed: $FAILURES"
+[[ $FAILURES -eq 0 ]] || exit 1

--- a/plugins/dev/scripts/catalyst-execution-core
+++ b/plugins/dev/scripts/catalyst-execution-core
@@ -253,6 +253,17 @@ cmd_start() {
 	# the same block; fail-open — a failed mint leaves the existing LINEAR_API_TOKEN intact.
 	source "$SCRIPT_DIR/lib/linear-app-actor.sh"
 	linear_app_actor_auth "catalyst-execution-core"
+	# CATALYST_CONFIG_FILE pins the Layer-1 config path explicitly so the daemon's
+	# own config resolution (daemon.mjs main(): `process.env.CATALYST_CONFIG_FILE ||
+	# resolve(process.cwd(), ".catalyst", "config.json")`) never falls back to a
+	# cwd-relative lookup. Without this, the daemon inherits whatever directory the
+	# operator happened to be in when they ran `catalyst-execution-core start` /
+	# `catalyst-stack start` — if that directory has no `.catalyst/config.json`,
+	# every Layer-1-config-driven feature (executorByPhase routing, the reaper/
+	# worktree-refresh/stale-PR-rescue timers, reconcile config) silently reads
+	# empty defaults instead of the real config, with no error surfaced anywhere.
+	# Only set when the caller hasn't already pointed at a specific file.
+	CATALYST_CONFIG_FILE="${CATALYST_CONFIG_FILE:-$CATALYST_DIR/.catalyst/config.json}" \
 	nohup "$runtime" "$DAEMON_SCRIPT" --pid-file "$PID_FILE" >"$LOG_FILE" 2>&1 &
 	local server_pid=$!
 	disown "$server_pid" 2>/dev/null || true

--- a/plugins/dev/scripts/catalyst-monitor.sh
+++ b/plugins/dev/scripts/catalyst-monitor.sh
@@ -516,6 +516,17 @@ cmd_start() {
     linear_app_actor_auth "catalyst-monitor" CATALYST_MONITOR_APP_ACTOR_TOKEN
   fi
 
+  # CATALYST_CONFIG_FILE pins the Layer-1 config path explicitly so the spawned
+  # server's config resolution (orch-monitor/lib/config-path.ts) never falls back
+  # to a cwd-relative `.catalyst/config.json` lookup. Without this, the server
+  # inherits whatever directory the operator happened to be in when they ran
+  # `catalyst-monitor start` / `catalyst-stack start` — if that directory has no
+  # `.catalyst/config.json` (or the wrong one), the team/project roster and the
+  # Layer-2 Linear-token resolution both silently degrade (empty project list,
+  # board views that never resolve, replies failing with "no Linear credential")
+  # even though a correctly-configured `$CATALYST_DIR/.catalyst/config.json`
+  # exists. Only set when the caller hasn't already pointed at a specific file.
+  CATALYST_CONFIG_FILE="${CATALYST_CONFIG_FILE:-$CATALYST_DIR/.catalyst/config.json}" \
   CATALYST_CONFIG_PATH="${CATALYST_CONFIG_PATH:-}" \
   MONITOR_PORT="$PORT" \
   MONITOR_PUBLIC_DIR="${MONITOR_UI_DIST_DIR}" \

--- a/plugins/dev/scripts/create-worktree.sh
+++ b/plugins/dev/scripts/create-worktree.sh
@@ -22,6 +22,38 @@ YELLOW='\033[1;33m'
 RED='\033[0;31m'
 NC='\033[0m'
 
+# catalyst_git_exclude_worktree_artifacts <worktree_path> — keep Catalyst's own
+# worktree-local runtime bookkeeping out of every project's git status, without
+# ever touching that project's TRACKED .gitignore. Mirrors the existing pattern
+# already used for .agents/ (codex-run-phase-agent.mjs's gitExcludeAgents +
+# resolveGitExcludePath): writes to this worktree's LOCAL, uncommitted
+# `git rev-parse --git-path info/exclude`, so it applies only here, never
+# leaks into the project's history, and needs no per-project PR.
+#
+# Before this, every onboarded project had to carry its own .gitignore entries
+# for these paths — miss one and `git status` shows Catalyst's own noise as
+# dirty, which is exactly what stalled a real ticket's verify phase (rebase
+# refused a "dirty" tree that was only dirty because of thoughts/ and
+# .catalyst/.workflow-context.json). Idempotent + best-effort: failures here
+# must never abort worktree creation.
+catalyst_git_exclude_worktree_artifacts() {
+	local worktree_path="$1" exclude_path pattern
+	exclude_path=$(git -C "$worktree_path" rev-parse --git-path info/exclude 2>/dev/null) || return 0
+	[[ "$exclude_path" = /* ]] || exclude_path="${worktree_path}/${exclude_path}"
+	mkdir -p "$(dirname "$exclude_path")" 2>/dev/null || return 0
+	[ -f "$exclude_path" ] || : >"$exclude_path"
+	for pattern in \
+		"thoughts/" \
+		".catalyst/.workflow-context.json" \
+		".catalyst/.workflow-context.json.bak" \
+		".catalyst/worktree-provenance.json" \
+		".needs-cleanup" \
+		".orphaned_at" \
+		".trunk"; do
+		grep -qxF "$pattern" "$exclude_path" 2>/dev/null || printf '%s\n' "$pattern" >>"$exclude_path"
+	done
+}
+
 # Parse flags (collect positional args separately)
 POSITIONAL=()
 OVERRIDE_WORKTREE_DIR=""
@@ -340,6 +372,13 @@ if [ -f "${SCRIPT_DIR}/workflow-context.sh" ]; then
 		echo "📋 Orchestration context set: ${ORCHESTRATION_NAME}"
 	fi
 fi
+
+# Keep Catalyst's own worktree-local runtime artifacts (thoughts/,
+# .catalyst/.workflow-context.json, etc.) out of `git status` for every
+# project, unconditionally — via this worktree's local git exclude, never the
+# project's tracked .gitignore. Runs regardless of executor (bg/sdk/codex-exec)
+# and regardless of whether thoughts-init below even runs.
+catalyst_git_exclude_worktree_artifacts "$WORKTREE_PATH"
 
 # Generate .envrc for OTEL context (source_up inherits parent profiles)
 # Note: direnv allow runs AFTER setup hooks to avoid re-blocking if hooks modify .envrc

--- a/plugins/dev/scripts/execution-core/codex-run-phase-agent.mjs
+++ b/plugins/dev/scripts/execution-core/codex-run-phase-agent.mjs
@@ -319,9 +319,39 @@ function resolveThoughtsRoot(worktreePath) {
   }
 }
 
+// resolveWorktreeGitDirs — the REAL git metadata paths for a linked worktree.
+// For a linked worktree (every ticket worktree under wt/<TICKET>), `git commit`
+// writes per-worktree state (HEAD, index, index.lock, COMMIT_EDITMSG) under
+// `--absolute-git-dir`, which lives OUTSIDE the worktree tree entirely (in the
+// main checkout's `.git/worktrees/<name>/`) — and updates the object database +
+// refs under `--git-common-dir` (the shared `.git`, also outside the worktree).
+// Neither was previously in the sandbox's writable_roots, so `git commit` inside
+// a codex-exec worktree was refused with a permission error on `index.lock`.
+// Mirrors resolveGitExcludePath's spawnSync-and-fall-through style. Returns
+// { gitDir, commonDir }, either null on any resolution failure — best-effort,
+// never throws.
+function resolveWorktreeGitDirs(worktreePath) {
+  const run = (args) => {
+    try {
+      const res = spawnSync("git", ["-C", worktreePath, ...args], { encoding: "utf8" });
+      if (res && res.status === 0 && typeof res.stdout === "string" && res.stdout.trim()) {
+        return res.stdout.trim();
+      }
+    } catch {
+      /* best-effort */
+    }
+    return null;
+  };
+  return {
+    gitDir: run(["rev-parse", "--absolute-git-dir"]),
+    commonDir: run(["rev-parse", "--path-format=absolute", "--git-common-dir"]),
+  };
+}
+
 // resolveWritableRoots — the de-duplicated, absolute writable-root set for the
 // `-c sandbox_workspace_write.writable_roots=[…]` override: the configured roots
-// ∪ {orchDir} ∪ {the resolved thoughts real-root of the worktree if present}.
+// ∪ {orchDir} ∪ {the resolved thoughts real-root of the worktree if present}
+// ∪ {the worktree's real git-dir and git-common-dir, for linked worktrees}.
 // Order-preserving; drops non-absolute / empty / duplicate entries.
 function resolveWritableRoots(cfg, { orchDir, worktreePath } = {}) {
   const out = [];
@@ -335,6 +365,9 @@ function resolveWritableRoots(cfg, { orchDir, worktreePath } = {}) {
   for (const r of cfg?.writableRoots ?? []) add(r);
   add(orchDir);
   add(resolveThoughtsRoot(worktreePath));
+  const { gitDir, commonDir } = resolveWorktreeGitDirs(worktreePath);
+  add(gitDir);
+  add(commonDir);
   return out;
 }
 

--- a/plugins/dev/scripts/execution-core/codex-run-phase-agent.test.mjs
+++ b/plugins/dev/scripts/execution-core/codex-run-phase-agent.test.mjs
@@ -407,6 +407,53 @@ describe("buildCodexArgs", () => {
     expect(args.slice(0, 2)).toEqual(["exec", "--json"]);
     expect(args).not.toContain("resume");
   });
+
+  // CTL-1457 follow-up: for a LINKED worktree (every real ticket worktree), the
+  // actual git-dir (HEAD/index/index.lock) and git-common-dir (object db + refs)
+  // live OUTSIDE the worktree tree entirely — `git commit` there was refused with
+  // a permission error because neither was ever in writable_roots. Uses a real
+  // `git worktree add` (not just `git init`) so `--absolute-git-dir` genuinely
+  // resolves outside `wt`, exercising the actual bug scenario.
+  test("linked worktree → writable_roots includes the real --absolute-git-dir and --git-common-dir (both live outside the worktree tree)", () => {
+    const main = mkdtempSync(join(tmpdir(), "codex-main-"));
+    const env = {
+      ...process.env,
+      GIT_AUTHOR_NAME: "t",
+      GIT_AUTHOR_EMAIL: "t@t.invalid",
+      GIT_COMMITTER_NAME: "t",
+      GIT_COMMITTER_EMAIL: "t@t.invalid",
+    };
+    Bun.spawnSync(["git", "init", "-b", "main"], { cwd: main });
+    Bun.spawnSync(["git", "commit", "--allow-empty", "-m", "init"], { cwd: main, env });
+    // `git worktree add` requires the target path not to already exist yet, so
+    // mkdtemp-then-remove just to mint a unique path (mirrors the mkdtemp pattern
+    // used elsewhere in this file for real-git fixtures).
+    const wt = mkdtempSync(join(tmpdir(), "codex-linked-wt-"));
+    rmSync(wt, { recursive: true, force: true });
+    Bun.spawnSync(["git", "worktree", "add", "-b", "feature", wt], { cwd: main });
+
+    const spec = makeCodexSpec();
+    const args = buildCodexArgs(spec, { ...CFG, writableRoots: [] }, { orchDir: "/ec", worktreePath: wt });
+    const firstC = args.indexOf("-c");
+    const roots = JSON.parse(args[firstC + 1].slice("sandbox_workspace_write.writable_roots=".length));
+
+    const gitDir = Bun.spawnSync(["git", "-C", wt, "rev-parse", "--absolute-git-dir"], { encoding: "utf8" })
+      .stdout.toString()
+      .trim();
+    const commonDir = Bun.spawnSync(
+      ["git", "-C", wt, "rev-parse", "--path-format=absolute", "--git-common-dir"],
+      { encoding: "utf8" },
+    )
+      .stdout.toString()
+      .trim();
+
+    expect(gitDir.startsWith(wt)).toBe(false); // proves it's genuinely OUTSIDE the worktree tree
+    expect(roots).toContain(gitDir);
+    expect(roots).toContain(commonDir);
+
+    Bun.spawnSync(["git", "worktree", "remove", "--force", wt], { cwd: main });
+    rmSync(main, { recursive: true, force: true });
+  });
 });
 
 // ── buildCodexEnv ───────────────────────────────────────────────────────────

--- a/plugins/dev/scripts/execution-core/event-scan.mjs
+++ b/plugins/dev/scripts/execution-core/event-scan.mjs
@@ -244,6 +244,32 @@ export function hasCompleteEvent({ ticket, phase, path = getEventLogPath() } = {
   return entry.completes?.has(name) ?? false;
 }
 
+// CTL-778 P2: the ISO `ts` of the MOST RECENT phase.<phase>.complete.<ticket>
+// envelope, or null if none exists. hasCompleteEvent only answers "ever" —
+// unscoped to any particular dispatch attempt, so a phase that completed once
+// and is later redispatched (revive, retry, operator resume) has its brand-new
+// worker misread as "already done" by the CTL-778 alive-but-idle reclaim, which
+// checks hasCompleteEvent with no attempt/generation scoping at all. Callers
+// that need "did THIS dispatch's worker complete" (not "did any worker, ever")
+// should compare this against the current signal's startedAt instead of calling
+// hasCompleteEvent directly. Reuses entry.events (already retains ts per event
+// for every complete/revive/remediate envelope — see refreshIndex) so this adds
+// no extra indexing cost. String comparison on `ts` is valid because every
+// envelope's timestamp is the same fixed-width ISO-8601 UTC shape (buildEventEnvelope
+// et al never emit fractional-second-less or offset-suffixed variants), so
+// lexicographic order matches chronological order without a Date.parse per event.
+export function latestCompleteEventTs({ ticket, phase, path = getEventLogPath() } = {}) {
+  if (!ticket || !phase) return null;
+  const entry = refreshIndex(path);
+  const name = `phase.${phase}.complete.${ticket}`;
+  let latest = null;
+  for (const ev of entry.events) {
+    if (ev.name !== name || typeof ev.ts !== "string") continue;
+    if (latest === null || ev.ts > latest) latest = ev.ts;
+  }
+  return latest;
+}
+
 // __resetEventScanIndexForTest — clear the per-path index so a suite starts from
 // a known state. Test-only; not used by production code.
 export function __resetEventScanIndexForTest() {

--- a/plugins/dev/scripts/execution-core/event-scan.test.mjs
+++ b/plugins/dev/scripts/execution-core/event-scan.test.mjs
@@ -18,6 +18,7 @@ import {
   countRemediateCycles,
   countRecoveryPassCycles,
   hasCompleteEvent,
+  latestCompleteEventTs,
   __resetEventScanIndexForTest,
   __phaseEventsLengthForTest,
   countTicketEventsInWindow,
@@ -557,5 +558,67 @@ describe("hasCompleteEvent", () => {
     expect(hasCompleteEvent({ ticket: "", phase: "plan", path })).toBe(false);
     expect(hasCompleteEvent({ ticket: "CTL-1", phase: "", path })).toBe(false);
     expect(hasCompleteEvent({ path })).toBe(false);
+  });
+});
+
+// CTL-778 P2: latestCompleteEventTs — the ts of the most recent complete event,
+// so a caller can scope "seen" to a specific dispatch attempt (see recovery.mjs's
+// completeEventSeen sinceIso). hasCompleteEvent only answers "ever"; this is the
+// disambiguator that closes the stale-evidence reclaim bug.
+describe("latestCompleteEventTs", () => {
+  beforeEach(() => __resetEventScanIndexForTest());
+
+  test("null when no complete event exists", () => {
+    const { path } = tempLog([
+      makeEvent({ phase: "plan", action: "revive", ticket: "CTL-1", ts: "2026-06-08T00:00:00Z" }),
+    ]);
+    expect(latestCompleteEventTs({ ticket: "CTL-1", phase: "plan", path })).toBeNull();
+  });
+
+  test("null on a missing log (cold start)", () => {
+    const dir = mkdtempSync(join(tmpdir(), "evtscan-"));
+    expect(
+      latestCompleteEventTs({ ticket: "CTL-1", phase: "plan", path: join(dir, "events.jsonl") })
+    ).toBeNull();
+  });
+
+  test("returns the ts of a single complete event", () => {
+    const { path } = tempLog([
+      makeEvent({ phase: "verify", action: "complete", ticket: "CTL-1", ts: "2026-06-08T00:00:00Z" }),
+    ]);
+    expect(latestCompleteEventTs({ ticket: "CTL-1", phase: "verify", path })).toBe(
+      "2026-06-08T00:00:00Z"
+    );
+  });
+
+  // THE regression this exists to catch: a phase that completed once (e.g. a
+  // verify run that stalled out on a remediation-cycle cap) and is later
+  // redispatched emits a SECOND complete event for a later sub-run. The MAX must
+  // win — an out-of-order write, or a caller comparing against the wrong one,
+  // would silently reopen the CTL-778 stale-reclaim bug.
+  test("returns the LATEST ts across multiple complete events for the same ticket+phase", () => {
+    const { path } = tempLog([
+      makeEvent({ phase: "verify", action: "complete", ticket: "CTL-1", ts: "2026-06-08T00:00:00Z" }),
+      makeEvent({ phase: "verify", action: "complete", ticket: "CTL-1", ts: "2026-07-31T00:50:36Z" }),
+      makeEvent({ phase: "verify", action: "complete", ticket: "CTL-1", ts: "2026-06-09T00:00:00Z" }),
+    ]);
+    expect(latestCompleteEventTs({ ticket: "CTL-1", phase: "verify", path })).toBe(
+      "2026-07-31T00:50:36Z"
+    );
+  });
+
+  test("ignores complete events for a different ticket or phase", () => {
+    const { path } = tempLog([
+      makeEvent({ phase: "verify", action: "complete", ticket: "CTL-2", ts: "2026-06-08T00:00:00Z" }),
+      makeEvent({ phase: "review", action: "complete", ticket: "CTL-1", ts: "2026-06-08T00:00:00Z" }),
+    ]);
+    expect(latestCompleteEventTs({ ticket: "CTL-1", phase: "verify", path })).toBeNull();
+  });
+
+  test("returns null when ticket or phase is missing", () => {
+    const { path } = tempLog([]);
+    expect(latestCompleteEventTs({ ticket: "", phase: "plan", path })).toBeNull();
+    expect(latestCompleteEventTs({ ticket: "CTL-1", phase: "", path })).toBeNull();
+    expect(latestCompleteEventTs({ path })).toBeNull();
   });
 });

--- a/plugins/dev/scripts/execution-core/recovery.mjs
+++ b/plugins/dev/scripts/execution-core/recovery.mjs
@@ -133,7 +133,11 @@ import {
   ESCALATION_ASK_CAP, // CTL-1442
   labelNeedsHumanUnlessBeliefOwner,
 } from "./label-guard.mjs";
-import { countReviveEvents as defaultCountReviveEvents, hasCompleteEvent } from "./event-scan.mjs";
+import {
+  countReviveEvents as defaultCountReviveEvents,
+  hasCompleteEvent,
+  latestCompleteEventTs,
+} from "./event-scan.mjs";
 
 // phase-agent-emit-complete sits two directories up from execution-core/.
 const EMIT_COMPLETE_BIN = fileURLToPath(new URL("../phase-agent-emit-complete", import.meta.url));
@@ -2043,7 +2047,22 @@ export function reclaimDeadWorkIfPossible(
     // fan-out worker (suppress). Defaults to the incremental event-scan query;
     // tests inject a stub. Production wiring is correct by default since
     // hasCompleteEvent reads the real event log.
-    completeEventSeen = ({ ticket: t, phase: p }) => hasCompleteEvent({ ticket: t, phase: p }),
+    //
+    // CTL-778 P2 (bug fix): "seen" was unscoped to the CURRENT dispatch attempt —
+    // hasCompleteEvent only answers "has this ticket+phase EVER completed", so a
+    // phase that completed once and is later redispatched (revive, retry, an
+    // operator's resume) had its brand-new worker reclaimed within seconds of
+    // spawning, because the PRIOR attempt's complete event still satisfied this
+    // check. `sinceIso` (the current signal's own startedAt) scopes it: only a
+    // complete event AT OR AFTER this dispatch's own start counts as "this
+    // worker finished" — a stale complete event from a prior attempt no longer
+    // does. Callers that omit sinceIso keep the old (attempt-unscoped) "ever"
+    // behavior; only the CTL-778 reclaim call site below opts in.
+    completeEventSeen = ({ ticket: t, phase: p, sinceIso } = {}) => {
+      if (!sinceIso) return hasCompleteEvent({ ticket: t, phase: p });
+      const ts = latestCompleteEventTs({ ticket: t, phase: p });
+      return typeof ts === "string" && ts >= sinceIso;
+    },
     // CTL-658 — resume-session resolver. Maps the dead worker's bg_job_id to a
     // `claude --resume`-compatible UUID (or null) so the revive can continue the
     // dead session instead of re-walking from phase 0. Default reads the real
@@ -2493,7 +2512,7 @@ export function reclaimDeadWorkIfPossible(
     // (CTL-662/736/809-safe). Mirrors the dead-worker branch (B) below.
     if (
       hasProbe(phase) &&
-      completeEventSeen({ ticket, phase }) &&
+      completeEventSeen({ ticket, phase, sinceIso: signal.raw?.startedAt }) &&
       probes[phase]({ ticket, repoRoot, orchDir })
     ) {
       if (prevBgJobId) {

--- a/plugins/dev/scripts/execution-core/recovery.test.mjs
+++ b/plugins/dev/scripts/execution-core/recovery.test.mjs
@@ -5700,6 +5700,68 @@ describe("reclaimDeadWorkIfPossible — CTL-778 alive-probe-reclaim", () => {
     expect(mirror.calls.length).toBe(0);
   });
 
+  // CTL-778 P2 (bug fix): the reclaim call site must pass the CURRENT dispatch's
+  // own startedAt as sinceIso, so completeEventSeen can distinguish "this
+  // worker finished" from "some prior attempt finished, once, whenever." Without
+  // this wiring, a redispatched phase's brand-new worker gets reclaimed within
+  // seconds of spawning because a stale complete event from a PRIOR attempt
+  // still satisfies an attempt-unscoped check — the exact bug that made every
+  // resume/revive/retry of an already-once-completed phase unrecoverable.
+  test("CTL-778 P2: completeEventSeen is called with sinceIso = signal.raw.startedAt", () => {
+    const seenCalls = [];
+    const sig = implementSignal({ bgJobId: "abc12345", startedAt: STARTED });
+    reclaimDeadWorkIfPossible(orch, sig, {
+      statJob: () => ({ exists: true, state: "working" }),
+      probes: { implement: recorder(true) },
+      completeEventSeen: (args) => {
+        seenCalls.push(args);
+        return true;
+      },
+      emitComplete: recorder({ code: 0 }),
+      emitReapIntent: recorder(Promise.resolve()),
+      appendEvent: recorder(undefined),
+      postReclaimMirror: () => {},
+      agentsSnapshot: () => ({ agents: [{ sessionId: "abc12345-0000-0000-0000-000000000000" }], isFresh: true, ageMs: 0 }),
+      now: () => Date.parse(STARTED) + 1000,
+    });
+    expect(seenCalls).toHaveLength(1);
+    expect(seenCalls[0]).toMatchObject({ ticket: sig.ticket, phase: "implement", sinceIso: STARTED });
+  });
+
+  // CTL-778 P2: a complete event from a PRIOR attempt (older than this dispatch's
+  // own startedAt) must NOT trigger the reclaim — that's the stale-evidence bug.
+  // The comparison itself (latest-ts-wins, stale-rejected) is unit-tested against
+  // a real event log in event-scan.test.mjs's `latestCompleteEventTs` suite; this
+  // exercises the actual default completeEventSeen function in isolation (not
+  // through reclaimDeadWorkIfPossible, which has no path-injection seam to point
+  // the real default at a fixture log — the wiring test above already proves the
+  // sinceIso it would be compared against is correct).
+  test("CTL-778 P2: default completeEventSeen rejects a stale complete event, accepts a fresh one", async () => {
+    const { hasCompleteEvent, latestCompleteEventTs } = await import("./event-scan.mjs");
+    const dir = mkdtempSync(join(tmpdir(), "ctl778-p2-"));
+    const path = join(dir, "events.jsonl");
+    writeFileSync(
+      path,
+      JSON.stringify({
+        ts: "2026-06-07T00:00:00Z", // before STARTED
+        attributes: { "event.name": "phase.implement.complete.CTL-9" },
+        body: {},
+      }) + "\n"
+    );
+    // Same shape as recovery.mjs's real default (recovery.mjs:2046-2050), built
+    // here against the temp path directly since hasCompleteEvent/latestCompleteEventTs
+    // both accept an explicit path override.
+    const completeEventSeen = ({ ticket, phase, sinceIso }) => {
+      if (!sinceIso) return hasCompleteEvent({ ticket, phase, path });
+      const ts = latestCompleteEventTs({ ticket, phase, path });
+      return typeof ts === "string" && ts >= sinceIso;
+    };
+    expect(completeEventSeen({ ticket: "CTL-9", phase: "implement", sinceIso: STARTED })).toBe(false);
+    expect(
+      completeEventSeen({ ticket: "CTL-9", phase: "implement", sinceIso: "2026-06-01T00:00:00Z" })
+    ).toBe(true);
+  });
+
   // Regression: the existing CTL-736 test (no completeEventSeen injected → seam defaults
   // to a fn that returns false from an empty/absent log) must still pass unchanged.
   test("CTL-736 regression: alive worker without complete event is still alive-suppressed, probe never called", () => {

--- a/plugins/dev/scripts/lib/__tests__/draft-pr.test.sh
+++ b/plugins/dev/scripts/lib/__tests__/draft-pr.test.sh
@@ -1294,6 +1294,86 @@ chmod +x "${P10B_BIN}/git"
 ) || true
 assert_contains "$(cat "$P10B_OUT" 2>/dev/null)" "password=ghp_benigntoken123" "10b: helper emits the token as the credential password"
 
+# ─── Suite 11: _draft_pr_safety_gate — placeholder identity + blast radius (postmortem) ─
+echo ""
+echo "Suite 11: _draft_pr_safety_gate"
+
+# 11a: a commit authored by a placeholder identity (e.g. a test's own throwaway
+#      git-fixture recipe run against the real tree) blocks the push. rc==4,
+#      no output, origin/feature never created.
+echo "11a: placeholder-identity commit → draft_pr_push_verify returns 4, no push"
+new_fixture safety-placeholder
+(
+  cd "$WORK"
+  GIT_AUTHOR_NAME=fixture GIT_AUTHOR_EMAIL=fixture@example.invalid \
+    GIT_COMMITTER_NAME=fixture GIT_COMMITTER_EMAIL=fixture@example.invalid \
+    git commit --quiet --allow-empty -m "fixture"
+  source "$DRAFT_PR_LIB"
+  set +e
+  out="$(draft_pr_push_verify 2>/dev/null)"; rc=$?
+  set -e
+  echo "$rc" > "${SCRATCH}/safety-placeholder.exit"
+  echo "$out" > "${SCRATCH}/safety-placeholder.out"
+  git rev-parse origin/feature > "${SCRATCH}/safety-placeholder.remote" 2>/dev/null || echo "<none>" > "${SCRATCH}/safety-placeholder.remote"
+) || true
+assert_eq "4" "$(cat "${SCRATCH}/safety-placeholder.exit" 2>/dev/null)" "11a: placeholder identity returns rc=4"
+assert_eq "" "$(cat "${SCRATCH}/safety-placeholder.out" 2>/dev/null)" "11a: placeholder identity echoes nothing"
+assert_eq "<none>" "$(cat "${SCRATCH}/safety-placeholder.remote" 2>/dev/null)" "11a: origin/feature never created"
+
+# 11b: a commit that deletes the entire base-tracked tree with zero offsetting
+#      insertions blocks the push. The fixture's own initial work commit is
+#      pushed first so it becomes @{u} — otherwise it would sit in the same
+#      pending range as the deletion and its insertion would mask the trip.
+#      Thresholds overridden down so the 2-file base is enough to trip the
+#      ratio deterministically.
+echo "11b: whole-tree deletion, no insertions → draft_pr_push_verify returns 4, no push"
+new_fixture safety-blast
+(
+  cd "$WORK"
+  git -c core.hooksPath=/dev/null push --quiet -u origin HEAD
+  git rm --quiet base.txt work.txt
+  git commit --quiet -m "chore: remove tracked files"
+  source "$DRAFT_PR_LIB"
+  export DRAFT_PR_BLAST_RADIUS_MIN_FILES=1 DRAFT_PR_BLAST_RADIUS_FRACTION=0.3
+  set +e
+  out="$(draft_pr_push_verify 2>/dev/null)"; rc=$?
+  set -e
+  echo "$rc" > "${SCRATCH}/safety-blast.exit"
+  git rev-parse origin/feature > "${SCRATCH}/safety-blast.before_head"
+) || true
+assert_eq "4" "$(cat "${SCRATCH}/safety-blast.exit" 2>/dev/null)" "11b: whole-tree deletion returns rc=4"
+(
+  cd "$WORK"
+  CUR_REMOTE="$(git rev-parse origin/feature 2>/dev/null || echo '<none>')"
+  BEFORE="$(cat "${SCRATCH}/safety-blast.before_head")"
+  [[ "$CUR_REMOTE" == "$BEFORE" ]] && echo "unchanged" > "${SCRATCH}/safety-blast.remote_state" || echo "changed" > "${SCRATCH}/safety-blast.remote_state"
+)
+assert_eq "unchanged" "$(cat "${SCRATCH}/safety-blast.remote_state" 2>/dev/null)" "11b: origin/feature did not advance past the offending commit"
+
+# 11c: same deletion, but with an offsetting insertion elsewhere (a legitimate
+#      rename/replace) — the gate must NOT trip. Guards against the blast-radius
+#      check false-positiving on ordinary refactors that delete and re-add.
+echo "11c: deletion + offsetting insertion → gate does not trip; push succeeds"
+new_fixture safety-blast-offset
+(
+  cd "$WORK"
+  git -c core.hooksPath=/dev/null push --quiet -u origin HEAD
+  git rm --quiet base.txt work.txt
+  printf 'replacement\n' > replacement.txt
+  git add replacement.txt
+  git commit --quiet -m "chore: rename tracked files"
+  source "$DRAFT_PR_LIB"
+  export DRAFT_PR_BLAST_RADIUS_MIN_FILES=1 DRAFT_PR_BLAST_RADIUS_FRACTION=0.3
+  set +e
+  out="$(draft_pr_push_verify 2>/dev/null)"; rc=$?
+  set -e
+  echo "$rc" > "${SCRATCH}/safety-blast-offset.exit"
+  git rev-parse HEAD > "${SCRATCH}/safety-blast-offset.local"
+  git rev-parse origin/feature > "${SCRATCH}/safety-blast-offset.remote" 2>/dev/null || echo "<none>" > "${SCRATCH}/safety-blast-offset.remote"
+) || true
+assert_eq "0" "$(cat "${SCRATCH}/safety-blast-offset.exit" 2>/dev/null)" "11c: offsetting insertion does not trip the gate"
+assert_eq "$(cat "${SCRATCH}/safety-blast-offset.local")" "$(cat "${SCRATCH}/safety-blast-offset.remote")" "11c: origin/feature advanced to HEAD (push succeeded)"
+
 # ─── Summary ──────────────────────────────────────────────────────────────────
 echo ""
 echo "─────────────────────────────────────────────"

--- a/plugins/dev/scripts/lib/draft-pr.sh
+++ b/plugins/dev/scripts/lib/draft-pr.sh
@@ -19,6 +19,9 @@
 #   3 — draft_pr_push_verify: push rejected for missing 'workflow' OAuth scope and no
 #       CATALYST_WORKFLOW_GITHUB_TOKEN fallback. Callers translate this into a MANUAL
 #       explanation.call_to_action escalation. (CTL-1119/CTL-1130)
+#   4 — draft_pr_push / draft_pr_push_verify: the pre-push safety gate refused the
+#       push (placeholder-identity commit or anomalous tree-wide deletion). Callers
+#       translate this into a push_safety_gate_blocked escalation.
 
 _draft_pr_warn() {
   printf 'draft-pr: %s\n' "$*" >&2
@@ -26,6 +29,103 @@ _draft_pr_warn() {
 
 # Reserved return code for a workflow-scope push rejection (CTL-1119).
 _DRAFT_PR_WORKFLOW_SCOPE_RC=3
+
+# Reserved return code for the pre-push safety gate refusing a push (postmortem,
+# 2026-07-30): a verify-phase agent, reproducing a bug covered by a test that
+# builds its own throwaway git repo to exercise git-touching behavior, re-ran
+# that test's own git-fixture recipe (config a placeholder identity, wipe the
+# tree, commit as "fixture") directly against its real cwd instead of the
+# test's isolated mkdtemp sandbox, and pushed the result to a real branch.
+_DRAFT_PR_SAFETY_GATE_RC=4
+
+# _draft_pr_pending_range — the commit range about to be pushed: unpushed
+# local commits ahead of the upstream tracking branch, or ahead of
+# origin/<default-base> when there is no upstream yet (first push of a new
+# branch). Falls back to just HEAD when neither resolves.
+_draft_pr_pending_range() {
+  if git rev-parse --abbrev-ref --symbolic-full-name '@{u}' >/dev/null 2>&1; then
+    printf '@{u}..HEAD\n'
+    return 0
+  fi
+  local base
+  base="$(_draft_pr_default_base)"
+  if git rev-parse "origin/${base}" >/dev/null 2>&1; then
+    printf 'origin/%s..HEAD\n' "$base"
+    return 0
+  fi
+  printf 'HEAD\n'
+}
+
+# _draft_pr_placeholder_authors RANGE — echoes any author/committer email in
+# RANGE matching a known test-fixture placeholder pattern (RFC 2606 reserved
+# domains: example.com/.org/.net/.invalid). A real commit — human or
+# Catalyst's own bot identity — never carries one of these; seeing one means
+# fixture/test code ran against the real tree instead of an isolated sandbox.
+_draft_pr_placeholder_authors() {
+  local range="$1"
+  git log --format='%ae%n%ce' "$range" -- 2>/dev/null \
+    | grep -iE '@example\.(com|org|net|invalid)$' \
+    | sort -u
+}
+
+# _draft_pr_blast_radius_hit RANGE — returns 0 (hit) iff RANGE deletes an
+# anomalous slice of the tracked tree with no offsetting additions: at least
+# DRAFT_PR_BLAST_RADIUS_MIN_FILES files deleted (default 20), zero insertions,
+# and deleted files exceed DRAFT_PR_BLAST_RADIUS_FRACTION (default 0.3) of the
+# tree tracked at the range's base. Thresholds are env-overridable for tests.
+_draft_pr_blast_radius_hit() {
+  local range="$1"
+  local min_files="${DRAFT_PR_BLAST_RADIUS_MIN_FILES:-20}"
+  local fraction="${DRAFT_PR_BLAST_RADIUS_FRACTION:-0.3}"
+
+  local base="${range%%..*}"
+  [[ "$base" == "$range" ]] && base="HEAD^"  # single-ref range (e.g. plain "HEAD")
+
+  local base_tracked
+  base_tracked="$(git ls-tree -r --name-only "$base" 2>/dev/null | wc -l | tr -d ' ')"
+  [[ -z "$base_tracked" || "$base_tracked" -eq 0 ]] && return 1
+
+  local shortstat deletions insertions deleted_files
+  shortstat="$(git diff --shortstat "$range" -- 2>/dev/null || true)"
+  deletions="$(printf '%s' "$shortstat" | grep -oE '[0-9]+ deletion' | grep -oE '[0-9]+' || true)"
+  insertions="$(printf '%s' "$shortstat" | grep -oE '[0-9]+ insertion' | grep -oE '[0-9]+' || true)"
+  [[ -z "$deletions" ]] && deletions=0
+  [[ -z "$insertions" ]] && insertions=0
+  deleted_files="$(git diff --diff-filter=D --name-only "$range" -- 2>/dev/null | wc -l | tr -d ' ')"
+
+  [[ "$deleted_files" -lt "$min_files" ]] && return 1
+  [[ "$insertions" -gt 0 ]] && return 1
+
+  awk -v d="$deleted_files" -v b="$base_tracked" -v f="$fraction" \
+    'BEGIN { exit !(d / b > f) }'
+}
+
+# _draft_pr_safety_gate — refuses to push when the outgoing commit range looks
+# like test-fixture code ran against the real tree instead of an isolated
+# sandbox (see the postmortem note on _DRAFT_PR_SAFETY_GATE_RC above). Two
+# independent checks, either one blocks:
+#   1. placeholder author/committer email (RFC 2606 reserved domain)
+#   2. anomalous single-range deletion with no offsetting additions
+# Fail-closed: returns $_DRAFT_PR_SAFETY_GATE_RC on either hit; details go to
+# stderr via _draft_pr_warn for the worker log. Never mutates anything.
+_draft_pr_safety_gate() {
+  local range
+  range="$(_draft_pr_pending_range)"
+
+  local placeholders
+  placeholders="$(_draft_pr_placeholder_authors "$range")"
+  if [[ -n "$placeholders" ]]; then
+    _draft_pr_warn "safety gate: placeholder author/committer in ${range}: $(printf '%s' "$placeholders" | tr '\n' ' ')"
+    return "$_DRAFT_PR_SAFETY_GATE_RC"
+  fi
+
+  if _draft_pr_blast_radius_hit "$range"; then
+    _draft_pr_warn "safety gate: anomalous deletion in ${range} (no offsetting additions)"
+    return "$_DRAFT_PR_SAFETY_GATE_RC"
+  fi
+
+  return 0
+}
 
 # _draft_pr_is_workflow_scope_error FILE — returns 0 iff FILE contains the
 # GitHub workflow-scope OAuth rejection message. Matches the stable prefix
@@ -89,6 +189,7 @@ _draft_pr_default_base() {
 # by rebase-prompt.md / phase-review).
 draft_pr_push() {
   command -v git >/dev/null 2>&1 || { _draft_pr_warn "git unavailable"; return 1; }
+  _draft_pr_safety_gate || return "$_DRAFT_PR_SAFETY_GATE_RC"
   local errf
   errf="$(mktemp -t draft-pr-push-XXXXXX 2>/dev/null || echo "/tmp/draft-pr-push-$$")"
   if git rev-parse --abbrev-ref --symbolic-full-name '@{u}' >/dev/null 2>&1; then
@@ -228,6 +329,7 @@ draft_pr_promote() {
 # Echoes the verified SHA on success; nothing on failure.
 draft_pr_push_verify() {
   command -v git >/dev/null 2>&1 || { _draft_pr_warn "git unavailable"; return 1; }
+  _draft_pr_safety_gate || return "$_DRAFT_PR_SAFETY_GATE_RC"
   local branch local_sha remote_sha errf
   branch="$(git rev-parse --abbrev-ref HEAD 2>/dev/null || true)"
   [[ -z "$branch" || "$branch" == "HEAD" ]] && { _draft_pr_warn "detached HEAD; cannot push-verify"; return 1; }

--- a/plugins/dev/skills/phase-pr/SKILL.md
+++ b/plugins/dev/skills/phase-pr/SKILL.md
@@ -206,6 +206,16 @@ if [[ -n "$EXISTING_PR_NUMBER" ]]; then
         --reason "push_rejected_no_workflow_scope"
     fi
     exit 1
+  elif [[ "$PUSH_VERIFY_RC" -eq 4 ]]; then
+    # Postmortem fix: the safety gate refused this push (placeholder-identity
+    # commit or anomalous tree-wide deletion) — details are in the worker log
+    # via draft-pr.sh's _draft_pr_warn. This is NOT a staleness issue; do not
+    # retry or rebase past it. A human must inspect the offending commit(s).
+    echo "phase-pr: push refused by safety gate for #${EXISTING_PR_NUMBER} (see log above)" >&2
+    "${PLUGIN_ROOT}/scripts/phase-agent-emit-complete" \
+      --phase "$PHASE" --ticket "$TICKET" --status failed \
+      --reason "push_safety_gate_blocked"
+    exit 1
   elif [[ "$PUSH_VERIFY_RC" -ne 0 ]]; then
     echo "phase-pr: push-verify failed for #${EXISTING_PR_NUMBER} (stale ref)" >&2
     "${PLUGIN_ROOT}/scripts/phase-agent-emit-complete" \
@@ -294,6 +304,15 @@ itself.
          --phase "$PHASE" --ticket "$TICKET" --status failed \
          --reason "push_rejected_no_workflow_scope"
      fi
+     exit 1
+   elif [[ "$PUSH_VERIFY_RC" -eq 4 ]]; then
+     # Postmortem fix: safety gate refused this push — see phase-pr's other
+     # push-verify call site above for the full rationale. Not a staleness
+     # issue; do not retry or rebase past it.
+     echo "phase-pr: push refused by safety gate on create-pr path (see log above)" >&2
+     "${PLUGIN_ROOT}/scripts/phase-agent-emit-complete" \
+       --phase "$PHASE" --ticket "$TICKET" --status failed \
+       --reason "push_safety_gate_blocked"
      exit 1
    elif [[ "$PUSH_VERIFY_RC" -ne 0 ]]; then
      echo "phase-pr: post-create-pr push-verify failed (stale ref)" >&2

--- a/plugins/dev/skills/phase-verify/SKILL.md
+++ b/plugins/dev/skills/phase-verify/SKILL.md
@@ -41,6 +41,20 @@ Editing application code from this phase is a contract violation. If verificatio
 surfaces a bug that requires code changes, you **record the finding** and let
 [[phase-review]] (which IS allowed to write remediation commits) act on it.
 
+## CRITICAL CONSTRAINT: never hand-run a test's own git-fixture setup against your cwd
+
+Your `cwd` is the ticket's real worktree, on the real branch you can push. Some tests
+in this repo build their own throwaway git repo to exercise git-touching behavior
+(e.g. a test that runs `git init` + `git config user.email/name` + `git commit` inside
+an isolated `mkdtemp` sandbox). If you manually re-run that recipe yourself — to
+reproduce or double-check something the test covers — **never point it at `.` or any
+path under your own cwd.** Doing so configures a throwaway identity and wipes/commits
+the real ticket branch, and it can reach the real remote (postmortem, 2026-07-30:
+exactly this happened, and the resulting commit was pushed to a real GitHub branch
+before a human caught it). If you need to hand-verify such a script,
+build your own `mkdtemp` sandbox first and run every command with an explicit `cwd`
+inside it — never in place.
+
 ## Prelude
 
 ```bash


### PR DESCRIPTION
## Summary

`daemon.mjs`'s `main()` resolves its Layer-1 config path as:
```js
process.env.CATALYST_CONFIG_FILE || resolve(process.cwd(), ".catalyst", "config.json")
```
— the same class of bug as the monitor's `cmd_start` (see #2818). `cmd_start()`
never pinned `CATALYST_CONFIG_FILE` before spawning the daemon, so it
inherited whatever directory the operator happened to be in when they ran
`catalyst-execution-core start` / `catalyst-stack start`. When that
directory lacks `.catalyst/config.json`, every Layer-1-driven feature
(`executorByPhase` routing, the reaper/worktree-refresh/stale-PR-rescue
timers, reconcile config) silently reads empty defaults instead of the real
config — with nothing surfacing the mismatch anywhere.

Hit this live: added `executorByPhase` routing to a Layer-1 config,
restarted the daemon from the wrong cwd, and the routing was silently
invisible to the daemon (no warning, no error — it just wasn't there) until
restarted from the correct directory.

## Fix

Pin `CATALYST_CONFIG_FILE="${CATALYST_CONFIG_FILE:-$CATALYST_DIR/.catalyst/config.json}"`
in `cmd_start()`, only when the caller hasn't already pointed at a specific
file — identical shape to the monitor fix in #2818.

## Test plan
- [x] Ran `catalyst-execution-core.test.sh` — 30/30 passing, no regressions.
- [x] Verified live: restarted the daemon from the correct cwd, confirmed
      the `executorByPhase` boot-eligibility log line appeared (previously
      silent/absent).