### PR TITLE
feat(dev): CTL-1595 cluster-sync materializes direnv profiles from a SOPS bundle

### DIFF
--- a/plugins/dev/scripts/execution-core/cli/cluster.mjs
+++ b/plugins/dev/scripts/execution-core/cli/cluster.mjs
@@ -408,11 +408,15 @@ export function runTune(argv = []) {
 
 export function runSync(argv = []) {
   const res = clusterSync();
+  // CTL-1595 (Codex P2): a profile decrypt/write shortfall must fail the manual
+  // sync loudly — operators use this command to restore worker credentials.
+  const profilesFailed =
+    res.profiles?.reason === "decrypt-failed" || (res.profiles?.failed?.length ?? 0) > 0;
   if (argv.includes("--json")) {
     process.stdout.write(JSON.stringify(res) + "\n");
-    return res.sync.ok ? 0 : 1;
+    return res.sync.ok && !profilesFailed ? 0 : 1;
   }
-  const { pull, sync, files } = res;
+  const { pull, sync, files, profiles } = res;
   const lines = [
     `cluster-sync: pull ${pull.pulled ? "ok" : `skipped (${pull.reason ?? ""})`}`,
   ];
@@ -425,8 +429,12 @@ export function runSync(argv = []) {
     );
   }
   lines.push(`  secret-files: ${files.written.length} written`);
+  lines.push(
+    `  profiles: ${profiles?.written?.length ?? 0} written` +
+      (profilesFailed ? ` (FAILED: ${profiles?.reason ?? profiles?.failed?.join(",")})` : ""),
+  );
   process.stdout.write(lines.join("\n") + "\n");
-  return sync.ok ? 0 : 1;
+  return sync.ok && !profilesFailed ? 0 : 1;
 }
 
 // ── ownership — CTL-1211: make the HRW partition SEEABLE (no-contention proof) ─

--- a/plugins/dev/scripts/execution-core/cluster-sync.mjs
+++ b/plugins/dev/scripts/execution-core/cluster-sync.mjs
@@ -37,6 +37,7 @@ import {
   appendFileSync,
   chmodSync,
   mkdirSync,
+  rmSync,
 } from "node:fs";
 import { resolve, basename, dirname, delimiter } from "node:path";
 import { homedir } from "node:os";
@@ -326,8 +327,14 @@ export function syncSecretFiles(opts = {}) {
 // these were HAND-provisioned per host — mini carried six legacy files, mini-2
 // carried none, and catalyst-cloud.env existed nowhere, so catalyst-cloud
 // workers booted tokenless fleet-wide (the CTC-284 verdict-less-death class).
-function defaultProfilesDir() {
-  return resolve(homedir(), ".config", "direnv", "profiles");
+// XDG-aware (Codex P2): check-setup.sh derives the active direnv path from
+// ${XDG_CONFIG_HOME:-$HOME/.config}/direnv — writing anywhere else would report
+// success while use_profile still finds nothing. Exported for doctor/tests.
+export function defaultProfilesDir(env = process.env) {
+  const xdg = typeof env.XDG_CONFIG_HOME === "string" && env.XDG_CONFIG_HOME.length > 0
+    ? env.XDG_CONFIG_HOME
+    : resolve(homedir(), ".config");
+  return resolve(xdg, "direnv", "profiles");
 }
 
 // syncProfileFiles — decrypt secrets/profile-files.sops.json (a { "<name>.env":
@@ -730,7 +737,7 @@ export function refreshClusterSecretsIfChanged(opts = {}) {
       name: "refreshed",
       node,
       now,
-      payload: { fromSha: lastSha, toSha: head, written: status.written, synced: status.synced },
+      payload: { fromSha: lastSha, toSha: head, written: status.written, synced: status.synced, profiles: status.profiles },
     });
   }
 
@@ -816,6 +823,22 @@ export function clusterSync(opts = {}) {
     } else if (head && !fullSuccess) {
       // Boot materialization shortfall: DON'T seed the marker (so the periodic
       // refresh keeps retrying and doctor keeps flagging), make it LOUD.
+      // Codex P2 (CTL-1595): "don't seed" is NOT enough when a PRIOR marker
+      // already records this same HEAD — the refresh fast-path would return
+      // head-unchanged forever and never retry after the fs/key issue heals.
+      // Invalidate a same-SHA marker so the next refresh re-attempts. (Generic:
+      // the same wedge existed for bare-file boot shortfalls.)
+      try {
+        const prior = readClusterSyncState(statePath);
+        if (prior?.lastDecryptedSha === head) {
+          rmSync(statePath, { force: true });
+          logger?.warn?.(
+            "[cluster-sync] invalidated same-SHA change marker after boot shortfall — the refresh timer will re-attempt",
+          );
+        }
+      } catch {
+        /* best-effort; worst case is the pre-existing wedge */
+      }
       logger?.warn?.(
         `[cluster-sync] boot decrypt did not fully succeed (${shortfall}) — ` +
           "NOT seeding the change-detection marker; keeping node-local plaintext and retrying on the refresh timer",

--- a/plugins/dev/scripts/execution-core/cluster-sync.mjs
+++ b/plugins/dev/scripts/execution-core/cluster-sync.mjs
@@ -344,6 +344,12 @@ export function defaultProfilesDir(env = process.env) {
 // REQUESTED file whose write threw (blocks the marker), absent bundle = no-op.
 // No restart-required surface: direnv re-evaluates per worker spawn, so a
 // rotated profile is live for the NEXT worker without touching the daemon.
+// Sidecar manifest naming the profiles THIS mechanism manages, so a profile
+// deleted from the bundle is REMOVED from disk (stale plaintext credentials
+// must not outlive their rotation) while hand-provisioned node-local profiles
+// are never touched (they are not in the manifest). Codex R2.
+const PROFILES_MANIFEST = ".cluster-managed.json";
+
 export function syncProfileFiles(opts = {}) {
   const {
     clusterDir = getClusterRepoDir(),
@@ -354,7 +360,7 @@ export function syncProfileFiles(opts = {}) {
     logger = log,
   } = opts;
 
-  const result = { written: [], failed: [], skipped: false, reason: null };
+  const result = { written: [], failed: [], removed: [], skipped: false, reason: null };
   const src = resolve(clusterDir, "secrets", "profile-files.sops.json");
   if (!existsSync(src)) {
     result.reason = "absent";
@@ -381,9 +387,19 @@ export function syncProfileFiles(opts = {}) {
     /* profilesDir may exist; ignore */
   }
   for (const [name, content] of Object.entries(map)) {
-    // Refuse anything that isn't a bare, non-dotfile basename — no path traversal.
-    if (typeof name !== "string" || name !== basename(name) || name.startsWith(".") || name.length === 0) {
-      logger.warn(`[cluster-sync] refusing unsafe profile-file name "${name}"`);
+    // Refuse anything that isn't a bare, non-dotfile basename — no path
+    // traversal — AND require the ".env" suffix (Codex R2): `use_profile x`
+    // looks up profiles/x.env, so a suffix-less key would "succeed" while
+    // remaining invisible to every consumer, and the advanced marker would
+    // never retry the bad SHA.
+    if (
+      typeof name !== "string" ||
+      name !== basename(name) ||
+      name.startsWith(".") ||
+      name.length === 0 ||
+      !name.endsWith(".env")
+    ) {
+      logger.warn(`[cluster-sync] refusing unsafe/non-.env profile-file name "${name}"`);
       continue;
     }
     if (typeof content !== "string") continue;
@@ -394,6 +410,40 @@ export function syncProfileFiles(opts = {}) {
       logger.warn(`[cluster-sync] write profile ${name} failed (${err?.message ?? err})`);
       result.failed.push(name);
     }
+  }
+
+  // Reconcile removals (Codex R2): a profile PREVIOUSLY managed by this
+  // mechanism but absent from the current bundle is deleted — stale plaintext
+  // credentials must not outlive their rotation. Node-local files (never in
+  // the manifest) are untouched. A failed removal joins failed[] so the
+  // change-detection marker does not advance over the surviving stale file.
+  const manifestPath = resolve(profilesDir, PROFILES_MANIFEST);
+  let prevManaged = [];
+  try {
+    const m = JSON.parse(readFileSync(manifestPath, "utf8"));
+    if (Array.isArray(m)) prevManaged = m.filter((n) => typeof n === "string" && n === basename(n) && !n.startsWith("."));
+  } catch {
+    /* absent/corrupt manifest → nothing previously managed */
+  }
+  const current = new Set(Object.keys(map).filter((n) => typeof n === "string"));
+  for (const name of prevManaged) {
+    if (current.has(name)) continue;
+    try {
+      rmSync(resolve(profilesDir, name), { force: true });
+      result.removed.push(name);
+      logger.warn(`[cluster-sync] removed profile ${name} (deleted from the cluster bundle)`);
+    } catch (err) {
+      logger.warn(`[cluster-sync] remove profile ${name} failed (${err?.message ?? err})`);
+      result.failed.push(name);
+    }
+  }
+  // Manifest = everything currently materialized + anything we failed to
+  // remove (so the next sync retries the removal). Best-effort.
+  try {
+    const keep = [...new Set([...result.written, ...prevManaged.filter((n) => !current.has(n) && !result.removed.includes(n))])];
+    writeFile(manifestPath, JSON.stringify(keep));
+  } catch {
+    /* best-effort; worst case a later removal is missed until the next full sync */
   }
   return result;
 }

--- a/plugins/dev/scripts/execution-core/cluster-sync.mjs
+++ b/plugins/dev/scripts/execution-core/cluster-sync.mjs
@@ -210,11 +210,15 @@ export function syncClusterSecrets(opts = {}) {
   const secretsDir = resolve(clusterDir, "secrets");
   let files;
   try {
-    // node-secret-files.sops.json is the bare-file bundle handled by
-    // syncSecretFiles(), NOT a JSON config — exclude it here so it isn't
+    // node-secret-files.sops.json (bare-file bundle → syncSecretFiles) and
+    // profile-files.sops.json (direnv-profile bundle → syncProfileFiles,
+    // CTL-1595) are NOT JSON configs — exclude both so neither is
     // double-processed into a stray config-style file.
     files = readdirSync(secretsDir).filter(
-      (f) => f.endsWith(".sops.json") && f !== "node-secret-files.sops.json",
+      (f) =>
+        f.endsWith(".sops.json") &&
+        f !== "node-secret-files.sops.json" &&
+        f !== "profile-files.sops.json",
     );
   } catch {
     result.ok = false;
@@ -309,6 +313,78 @@ export function syncSecretFiles(opts = {}) {
       logger.warn(`[cluster-sync] write ${name} failed (${err?.message ?? err})`);
       // Partial bare-file failure: a REQUESTED file decrypted but did not
       // materialize. Surfaced so the marker does not advance over it (Codex-A).
+      result.failed.push(name);
+    }
+  }
+  return result;
+}
+
+// ─── CTL-1595: cluster-synced direnv profiles ────────────────────────────────
+
+// The direnv profile surface worker repos' .envrc files consume via
+// `use_profile <name>` (~/.config/direnv/profiles/<name>.env). Before CTL-1595
+// these were HAND-provisioned per host — mini carried six legacy files, mini-2
+// carried none, and catalyst-cloud.env existed nowhere, so catalyst-cloud
+// workers booted tokenless fleet-wide (the CTC-284 verdict-less-death class).
+function defaultProfilesDir() {
+  return resolve(homedir(), ".config", "direnv", "profiles");
+}
+
+// syncProfileFiles — decrypt secrets/profile-files.sops.json (a { "<name>.env":
+// content } map of cluster-shared direnv profiles) and materialize each as a
+// 0o600 file under ~/.config/direnv/profiles. Same contract as syncSecretFiles:
+// fail-open, never throws, basename-only (no path traversal), `failed[]` = a
+// REQUESTED file whose write threw (blocks the marker), absent bundle = no-op.
+// No restart-required surface: direnv re-evaluates per worker spawn, so a
+// rotated profile is live for the NEXT worker without touching the daemon.
+export function syncProfileFiles(opts = {}) {
+  const {
+    clusterDir = getClusterRepoDir(),
+    profilesDir = defaultProfilesDir(),
+    ageKeyFile = defaultAgeKeyFile(),
+    decrypt = makeSopsDecrypt(ageKeyFile),
+    writeFile = defaultWriteFile,
+    logger = log,
+  } = opts;
+
+  const result = { written: [], failed: [], skipped: false, reason: null };
+  const src = resolve(clusterDir, "secrets", "profile-files.sops.json");
+  if (!existsSync(src)) {
+    result.reason = "absent";
+    return result;
+  }
+  let map;
+  try {
+    map = decrypt(src);
+  } catch (err) {
+    logger.warn(
+      `[cluster-sync] decrypt profile-files failed (${err?.message ?? err}); keeping node-local`,
+    );
+    result.skipped = true;
+    result.reason = "decrypt-failed";
+    return result;
+  }
+  if (!map || typeof map !== "object") {
+    result.reason = "empty";
+    return result;
+  }
+  try {
+    mkdirSync(profilesDir, { recursive: true });
+  } catch {
+    /* profilesDir may exist; ignore */
+  }
+  for (const [name, content] of Object.entries(map)) {
+    // Refuse anything that isn't a bare, non-dotfile basename — no path traversal.
+    if (typeof name !== "string" || name !== basename(name) || name.startsWith(".") || name.length === 0) {
+      logger.warn(`[cluster-sync] refusing unsafe profile-file name "${name}"`);
+      continue;
+    }
+    if (typeof content !== "string") continue;
+    try {
+      writeFile(resolve(profilesDir, name), content);
+      result.written.push(name);
+    } catch (err) {
+      logger.warn(`[cluster-sync] write profile ${name} failed (${err?.message ?? err})`);
       result.failed.push(name);
     }
   }
@@ -475,10 +551,11 @@ export const ENV_BACKED_SECRET_FILES = new Set(["claude-accounts.env", "executio
 //   config-refused   — syncClusterSecrets refused (sync.ok === false), empty skipped
 //   secrets-skipped  — a JSON secret was skipped while another succeeded (partial)
 //   bare-write-failed — a bare file decrypted but its write failed (partial)
-function assessMaterialization({ sync, files }) {
+function assessMaterialization({ sync, files, profiles }) {
   const synced = Array.isArray(sync?.synced) ? sync.synced : [];
   const skipped = Array.isArray(sync?.skipped) ? sync.skipped : [];
   const bareFailed = Array.isArray(files?.failed) ? files.failed : [];
+  const profileFailed = Array.isArray(profiles?.failed) ? profiles.failed : [];
 
   // 1. Bare-bundle wholesale failure — the whole node-secret-files.sops.json bundle
   //    failed to decrypt. Checked BEFORE schemaSkipped so a too-new JSON schema can
@@ -490,6 +567,15 @@ function assessMaterialization({ sync, files }) {
   //    checked BEFORE schemaSkipped (same masking rationale).
   if (bareFailed.length > 0) {
     return { fullSuccess: false, reason: "bare-write-failed" };
+  }
+  // 2b. CTL-1595: the profile bundle mirrors the bare bundle — same masking
+  //     rationale, same pre-schemaSkipped placement. An ABSENT bundle is a
+  //     no-op (reason "absent" — not every cluster ships profiles).
+  if (profiles?.reason === "decrypt-failed") {
+    return { fullSuccess: false, reason: "profile-decrypt-failed" };
+  }
+  if (profileFailed.length > 0) {
+    return { fullSuccess: false, reason: "profile-write-failed" };
   }
   // 3. Schema too-new is fail-CLOSED by design — treat as success for the marker.
   //    Reaching here means the bare-file part is already confirmed OK (1–2 above), so
@@ -603,8 +689,12 @@ export function refreshClusterSecretsIfChanged(opts = {}) {
   // 6. Re-decrypt + materialize (reuse the existing CTL-1211 machinery).
   const sync = syncClusterSecrets({ clusterDir, configDir, ageKeyFile, decrypt: sopsDecrypt, logger });
   const files = syncSecretFiles({ clusterDir, configDir, ageKeyFile, decrypt: sopsDecrypt, logger });
+  // CTL-1595: the direnv-profile bundle rides the same refresh; profilesDir
+  // intentionally NOT overridable from here (tests inject via clusterSync/opts).
+  const profiles = syncProfileFiles({ clusterDir, profilesDir: opts.profilesDir, ageKeyFile, decrypt: sopsDecrypt, logger });
   status.synced = Array.isArray(sync?.synced) ? sync.synced : [];
   status.written = Array.isArray(files?.written) ? files.written : [];
+  status.profiles = Array.isArray(profiles?.written) ? profiles.written : [];
 
   // 7. Advance the marker ONLY on FULL materialization success (Codex-A). A PARTIAL
   // shortfall (a single JSON secret skipped while another succeeded, the config sync
@@ -612,7 +702,7 @@ export function refreshClusterSecretsIfChanged(opts = {}) {
   // a failure too: advancing the marker over it would make lastSha===HEAD skip the
   // retry forever, stranding the un-applied rotation. On ANY shortfall: emit
   // refresh-failed naming the shortfall, do NOT advance the marker, return ok:false.
-  const { fullSuccess, reason: shortfall } = assessMaterialization({ sync, files });
+  const { fullSuccess, reason: shortfall } = assessMaterialization({ sync, files, profiles });
   if (!fullSuccess) {
     status.ok = false;
     status.reason = shortfall;
@@ -635,7 +725,7 @@ export function refreshClusterSecretsIfChanged(opts = {}) {
   status.changed = true;
   status.reason = "refreshed";
   // Emit only on a real change: sha advanced AND something was materialized.
-  if (lastSha !== head && (status.written.length > 0 || status.synced.length > 0)) {
+  if (lastSha !== head && (status.written.length > 0 || status.synced.length > 0 || status.profiles.length > 0)) {
     emit({
       name: "refreshed",
       node,
@@ -694,6 +784,7 @@ export function clusterSync(opts = {}) {
   const pull = pullClusterRepo(opts);
   const sync = syncClusterSecrets(opts);
   const files = syncSecretFiles(opts);
+  const profiles = syncProfileFiles(opts); // CTL-1595: direnv profile bundle
 
   // Seed the marker ONLY when boot materialization FULLY succeeded — the SAME
   // hardened predicate the periodic refresh uses (Codex-A). A WHOLESALE failure (sops
@@ -704,7 +795,7 @@ export function clusterSync(opts = {}) {
   // stays fail-CLOSED (intentional, not a failure) and still seeds. An empty secrets
   // repo (nothing to decrypt) is full success and still seeds.
   const synced = Array.isArray(sync?.synced) ? sync.synced : [];
-  const { fullSuccess, reason: shortfall } = assessMaterialization({ sync, files });
+  const { fullSuccess, reason: shortfall } = assessMaterialization({ sync, files, profiles });
 
   try {
     const head = gitRevParseHead({ clusterDir, gitCapture });
@@ -717,6 +808,8 @@ export function clusterSync(opts = {}) {
           lastDecryptedAt: now(),
           written: Array.isArray(files?.written) ? files.written : [],
           synced,
+          // CTL-1595: additive — which direnv profiles this node materialized.
+          profiles: Array.isArray(profiles?.written) ? profiles.written : [],
         },
         logger,
       );
@@ -732,7 +825,7 @@ export function clusterSync(opts = {}) {
   } catch (err) {
     logger?.warn?.(`[cluster-sync] boot marker seed failed (${err?.message ?? err})`);
   }
-  return { pull, sync, files };
+  return { pull, sync, files, profiles };
 }
 
 // Exposed for doctor + tests.

--- a/plugins/dev/scripts/execution-core/cluster-sync.test.mjs
+++ b/plugins/dev/scripts/execution-core/cluster-sync.test.mjs
@@ -299,6 +299,38 @@ describe("syncProfileFiles (CTL-1595)", () => {
     expect(res.reason).toBe("decrypt-failed");
   });
 
+  test("rejects a bundle key without the .env suffix (use_profile can never find it)", () => {
+    writeProfileBundle();
+    const decrypt = () => ({ "catalyst-cloud": "x", "good.env": "y" });
+    const res = syncProfileFiles({ clusterDir, profilesDir: profilesDirOf(), decrypt, logger: QUIET });
+    expect(res.written).toEqual(["good.env"]);
+    expect(existsSync(join(profilesDirOf(), "catalyst-cloud"))).toBe(false);
+  });
+
+  test("removes a profile deleted from the bundle; node-local profiles untouched (Codex R2)", () => {
+    writeProfileBundle();
+    const dir = profilesDirOf();
+    // Sync 1: two managed profiles.
+    let res = syncProfileFiles({
+      clusterDir, profilesDir: dir,
+      decrypt: () => ({ "a.env": "1", "b.env": "2" }),
+      logger: QUIET,
+    });
+    expect(res.written.sort()).toEqual(["a.env", "b.env"]);
+    // A hand-provisioned node-local profile the mechanism must never touch.
+    writeFileSync(join(dir, "local.env"), "hand-made");
+    // Sync 2: b.env deleted from the bundle → removed from disk; local.env stays.
+    res = syncProfileFiles({
+      clusterDir, profilesDir: dir,
+      decrypt: () => ({ "a.env": "1" }),
+      logger: QUIET,
+    });
+    expect(res.removed).toEqual(["b.env"]);
+    expect(existsSync(join(dir, "b.env"))).toBe(false);
+    expect(existsSync(join(dir, "a.env"))).toBe(true);
+    expect(readFileSync(join(dir, "local.env"), "utf8")).toBe("hand-made");
+  });
+
   test("partial write failure → records the name in failed[], keeps the rest", () => {
     writeProfileBundle();
     const decrypt = () => ({ "good.env": "x", "bad.env": "y" });

--- a/plugins/dev/scripts/execution-core/cluster-sync.test.mjs
+++ b/plugins/dev/scripts/execution-core/cluster-sync.test.mjs
@@ -19,6 +19,7 @@ import {
   syncClusterSecrets,
   syncSecretFiles,
   syncProfileFiles,
+  defaultProfilesDir,
   pullClusterRepo,
   destForSecret,
   // CTL-1393: durable change-detection + periodic refresh.
@@ -241,6 +242,17 @@ describe("pullClusterRepo (CTL-1211)", () => {
       logger: QUIET,
     });
     expect(res).toEqual({ pulled: false, reason: "pull-failed" });
+  });
+});
+
+describe("defaultProfilesDir (CTL-1595 Codex P2 — XDG-aware)", () => {
+  test("honors XDG_CONFIG_HOME when set (check-setup.sh parity)", () => {
+    expect(defaultProfilesDir({ XDG_CONFIG_HOME: "/xdg" })).toBe(resolve("/xdg", "direnv", "profiles"));
+  });
+  test("falls back to ~/.config when XDG_CONFIG_HOME is unset/empty", () => {
+    const home = defaultProfilesDir({});
+    expect(home.endsWith(join(".config", "direnv", "profiles"))).toBe(true);
+    expect(defaultProfilesDir({ XDG_CONFIG_HOME: "" })).toBe(home);
   });
 });
 
@@ -762,6 +774,9 @@ describe("refreshClusterSecretsIfChanged (CTL-1393)", () => {
     expect(readFileSync(join(profilesDir, "catalyst-cloud.env"), "utf8")).toContain("LINEAR_API_KEY");
     expect(readClusterSyncState(statePath).lastDecryptedSha).toBe("NEWSHA");
     expect(emits.map((e) => e.name)).toContain("refreshed");
+    // Codex P2: the refreshed payload must name the materialized profiles.
+    const refreshed = emits.find((e) => e.name === "refreshed");
+    expect(refreshed.payload.profiles).toEqual(["catalyst-cloud.env"]);
     // a profile rotation needs NO daemon restart (direnv re-evaluates per spawn)
     expect(emits.map((e) => e.name)).not.toContain("restart-required");
   });
@@ -960,6 +975,43 @@ describe("clusterSync boot (CTL-1393 conditional marker seed)", () => {
     expect(res).toHaveProperty("pull");
     expect(res).toHaveProperty("sync");
     expect(res).toHaveProperty("files");
+  });
+
+  test("boot PROFILE shortfall with a SAME-SHA marker → marker INVALIDATED so the refresh retries (Codex P2)", () => {
+    seedClone();
+    writeClusterJson({ schemaVersion: 1, roster: ["mini"] });
+    touchSecret("cluster-bots.sops.json");
+    writeFileSync(join(clusterDir, "secrets", "profile-files.sops.json"), "{cipher}");
+    const statePath = join(configDir, ".state.json");
+    // A prior marker already records the clone's CURRENT head — without
+    // invalidation the refresh fast-path would return head-unchanged forever.
+    writeFileSync(
+      statePath,
+      JSON.stringify({ lastDecryptedSha: "NEWSHA", lastDecryptedAt: "old", written: [], synced: [] }),
+    );
+
+    const emits = [];
+    clusterSync({
+      clusterDir,
+      configDir,
+      profilesDir: join(configDir, "profiles"),
+      statePath,
+      git: baseGit,
+      gitCapture: makeGitCapture("NEWSHA"),
+      decrypt: (p) => {
+        if (p.endsWith("profile-files.sops.json")) throw new Error("bad mac");
+        return { catalyst: { linear: { bot: { worker: { accessToken: "FRESH" } } } } };
+      },
+      emit: (e) => emits.push(e),
+      now: () => "t",
+      node: "test-node",
+      logger: QUIET,
+    });
+
+    expect(emits.map((e) => e.name)).toContain("refresh-failed");
+    expect(emits[0].payload.reason).toBe("profile-decrypt-failed");
+    // The same-SHA marker is GONE — the periodic refresh will re-attempt.
+    expect(readClusterSyncState(statePath)).toBeNull();
   });
 
   test("boot decrypt SUCCEEDS → marker seeded to HEAD, no refresh-failed (guard against over-correcting)", () => {

--- a/plugins/dev/scripts/execution-core/cluster-sync.test.mjs
+++ b/plugins/dev/scripts/execution-core/cluster-sync.test.mjs
@@ -18,6 +18,7 @@ import { join, resolve } from "node:path";
 import {
   syncClusterSecrets,
   syncSecretFiles,
+  syncProfileFiles,
   pullClusterRepo,
   destForSecret,
   // CTL-1393: durable change-detection + periodic refresh.
@@ -133,6 +134,15 @@ describe("syncClusterSecrets (CTL-1211)", () => {
     expect(res.synced).toEqual(["config.json"]);
     expect(existsSync(join(configDir, "node-secret-files.json"))).toBe(false);
   });
+
+  test("does NOT process profile-files.sops.json (owned by syncProfileFiles, CTL-1595)", () => {
+    writeClusterJson({ schemaVersion: 1, roster: ["mini"] });
+    touchSecret("cluster-bots.sops.json");
+    touchSecret("profile-files.sops.json");
+    const res = syncClusterSecrets({ clusterDir, configDir, decrypt: () => ({ x: 1 }) });
+    expect(res.synced).toEqual(["config.json"]);
+    expect(existsSync(join(configDir, "profile-files.json"))).toBe(false);
+  });
 });
 
 describe("syncSecretFiles (CTL-1211)", () => {
@@ -231,6 +241,62 @@ describe("pullClusterRepo (CTL-1211)", () => {
       logger: QUIET,
     });
     expect(res).toEqual({ pulled: false, reason: "pull-failed" });
+  });
+});
+
+describe("syncProfileFiles (CTL-1595)", () => {
+  const writeProfileBundle = () =>
+    writeFileSync(join(clusterDir, "secrets", "profile-files.sops.json"), "{cipher}");
+  const profilesDirOf = () => join(configDir, "profiles");
+
+  test("materializes each map entry as a 0600 file under profilesDir", () => {
+    writeProfileBundle();
+    const decrypt = () => ({
+      "catalyst-cloud.env": "export GH_TEMP_PAT=x\nexport LINEAR_API_KEY=y\n",
+    });
+    const res = syncProfileFiles({ clusterDir, profilesDir: profilesDirOf(), decrypt });
+    expect(res.written).toEqual(["catalyst-cloud.env"]);
+    expect(readFileSync(join(profilesDirOf(), "catalyst-cloud.env"), "utf8")).toContain("GH_TEMP_PAT");
+    expect(statSync(join(profilesDirOf(), "catalyst-cloud.env")).mode & 0o777).toBe(0o600);
+  });
+
+  test("refuses path-traversal / dotfile names (no escape from profilesDir)", () => {
+    writeProfileBundle();
+    const decrypt = () => ({ "../escape.env": "x", ".ssh": "x", "ok.env": "good" });
+    const res = syncProfileFiles({ clusterDir, profilesDir: profilesDirOf(), decrypt, logger: QUIET });
+    expect(res.written).toEqual(["ok.env"]);
+  });
+
+  test("absent profile bundle → reason absent (no-op — not every cluster ships profiles)", () => {
+    const res = syncProfileFiles({ clusterDir, profilesDir: profilesDirOf(), decrypt: () => ({}) });
+    expect(res.reason).toBe("absent");
+    expect(res.written).toEqual([]);
+  });
+
+  test("decrypt failure → skipped, fail-open (never throws)", () => {
+    writeProfileBundle();
+    const res = syncProfileFiles({
+      clusterDir,
+      profilesDir: profilesDirOf(),
+      decrypt: () => {
+        throw new Error("bad mac");
+      },
+      logger: QUIET,
+    });
+    expect(res.skipped).toBe(true);
+    expect(res.reason).toBe("decrypt-failed");
+  });
+
+  test("partial write failure → records the name in failed[], keeps the rest", () => {
+    writeProfileBundle();
+    const decrypt = () => ({ "good.env": "x", "bad.env": "y" });
+    const writeFile = (path) => {
+      if (path.endsWith("bad.env")) throw new Error("EIO");
+    };
+    const res = syncProfileFiles({ clusterDir, profilesDir: profilesDirOf(), decrypt, writeFile, logger: QUIET });
+    expect(res.written).toEqual(["good.env"]);
+    expect(res.failed).toEqual(["bad.env"]);
+    expect(res.reason).toBeNull();
   });
 });
 
@@ -626,6 +692,77 @@ describe("refreshClusterSecretsIfChanged (CTL-1393)", () => {
     expect(emits.map((e) => e.name)).toContain("refreshed");
     expect(emits.map((e) => e.name)).not.toContain("refresh-failed");
     // a non-env-backed bare file does NOT trigger a restart-required signal
+    expect(emits.map((e) => e.name)).not.toContain("restart-required");
+  });
+
+  test("(p1) partial PROFILE write failure → marker NOT advanced, refresh-failed(profile-write-failed)", () => {
+    seedClone();
+    writeClusterJson({ schemaVersion: 1, roster: ["mini"] });
+    touchSecret("cluster-bots.sops.json");
+    writeFileSync(join(clusterDir, "secrets", "profile-files.sops.json"), "{cipher}");
+    const profilesDir = join(configDir, "profiles");
+    // Force a write failure: pre-create a DIRECTORY at the profile's destination.
+    mkdirSync(join(profilesDir, "catalyst-cloud.env"), { recursive: true });
+    const statePath = join(configDir, ".state.json");
+    writeMarker(statePath, "OLDSHA");
+
+    const emits = [];
+    const res = refreshClusterSecretsIfChanged({
+      clusterDir,
+      configDir,
+      profilesDir,
+      statePath,
+      git: baseGit,
+      gitCapture: makeGitCapture("NEWSHA", true),
+      decrypt: (p) =>
+        p.endsWith("profile-files.sops.json")
+          ? { "catalyst-cloud.env": "export GH_TEMP_PAT=x\n" }
+          : { catalyst: { linear: { bot: { worker: { accessToken: "FRESH" } } } } },
+      emit: (e) => emits.push(e),
+      now: () => "t",
+      node: "test-node",
+      logger: QUIET,
+    });
+
+    expect(res.ok).toBe(false);
+    expect(res.reason).toBe("profile-write-failed");
+    expect(emits.map((e) => e.name)).toContain("refresh-failed");
+    expect(readClusterSyncState(statePath).lastDecryptedSha).toBe("OLDSHA");
+  });
+
+  test("(p2) FULL success incl. profile bundle → profiles materialized, marker advances", () => {
+    seedClone();
+    writeClusterJson({ schemaVersion: 1, roster: ["mini"] });
+    touchSecret("cluster-bots.sops.json");
+    writeFileSync(join(clusterDir, "secrets", "profile-files.sops.json"), "{cipher}");
+    const profilesDir = join(configDir, "profiles");
+    const statePath = join(configDir, ".state.json");
+    writeMarker(statePath, "OLDSHA");
+
+    const emits = [];
+    const res = refreshClusterSecretsIfChanged({
+      clusterDir,
+      configDir,
+      profilesDir,
+      statePath,
+      git: baseGit,
+      gitCapture: makeGitCapture("NEWSHA", true),
+      decrypt: (p) =>
+        p.endsWith("profile-files.sops.json")
+          ? { "catalyst-cloud.env": "export GH_TEMP_PAT=x\nexport LINEAR_API_KEY=y\n" }
+          : { catalyst: { linear: { bot: { worker: { accessToken: "FRESH" } } } } },
+      emit: (e) => emits.push(e),
+      now: () => "t",
+      node: "test-node",
+      logger: QUIET,
+    });
+
+    expect(res.ok).toBe(true);
+    expect(res.profiles).toEqual(["catalyst-cloud.env"]);
+    expect(readFileSync(join(profilesDir, "catalyst-cloud.env"), "utf8")).toContain("LINEAR_API_KEY");
+    expect(readClusterSyncState(statePath).lastDecryptedSha).toBe("NEWSHA");
+    expect(emits.map((e) => e.name)).toContain("refreshed");
+    // a profile rotation needs NO daemon restart (direnv re-evaluates per spawn)
     expect(emits.map((e) => e.name)).not.toContain("restart-required");
   });
 


### PR DESCRIPTION
Brings the direnv-profile surface into the cluster secrets control plane ([CTL-1595](https://linear.app/rozich/issue/CTL-1595)). Worker repos' `.envrc` files consume `~/.config/direnv/profiles/<name>.env` via `use_profile`, but those files were hand-provisioned per host: mini carries six legacy files, mini-2 has none, and `catalyst-cloud.env` existed nowhere — so catalyst-cloud workers booted tokenless fleet-wide (the CTC-284 verdict-less-death class; only catalyst-cloud *depends* on its profile — it is the sole carrier of `GH_TEMP_PAT` + `LINEAR_API_KEY`).

**Mechanism** (option 1 from the ticket): `syncProfileFiles` decrypts `secrets/profile-files.sops.json` (a `{ "<name>.env": content }` map) and materializes each as a 0600 file under `~/.config/direnv/profiles/`. Exact `syncSecretFiles` contract: fail-open/never-throws, basename-only (no path traversal), `failed[]` = requested-but-unwritten (blocks the change-detection marker), absent bundle = no-op. Wired into the boot entrypoint and the periodic refresh; shortfalls fold into `assessMaterialization` **before** the schemaSkipped short-circuit (same masking rationale as the bare bundle). No restart-required surface — direnv re-evaluates per worker spawn, so a rotated profile is live for the next worker without touching the daemon. `syncClusterSecrets` excludes the bundle from JSON-config processing (stray-file guard + test).

**Tests:** 8 new (5 unit: materialize/0600, traversal refusal, absent, decrypt-fail, partial-write; 2 refresh-level: profile-write-failed blocks the marker + full-success materializes and advances; 1 exclusion guard). `cluster-sync.test.mjs` 51/51.

**Rollout:** merge + deploy this BEFORE pushing `profile-files.sops.json` to the cluster repo (older daemons would otherwise treat the bundle as a JSON config).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Wte59hchAL4FjhHiCwSVS3