### PR TITLE
fix(dev): add worktree git-dir/common-dir to codex-exec writable_roots

### DIFF
--- a/plugins/dev/scripts/execution-core/codex-run-phase-agent.mjs
+++ b/plugins/dev/scripts/execution-core/codex-run-phase-agent.mjs
@@ -319,9 +319,39 @@ function resolveThoughtsRoot(worktreePath) {
   }
 }
 
+// resolveWorktreeGitDirs — the REAL git metadata paths for a linked worktree.
+// For a linked worktree (every ticket worktree under wt/<TICKET>), `git commit`
+// writes per-worktree state (HEAD, index, index.lock, COMMIT_EDITMSG) under
+// `--absolute-git-dir`, which lives OUTSIDE the worktree tree entirely (in the
+// main checkout's `.git/worktrees/<name>/`) — and updates the object database +
+// refs under `--git-common-dir` (the shared `.git`, also outside the worktree).
+// Neither was previously in the sandbox's writable_roots, so `git commit` inside
+// a codex-exec worktree was refused with a permission error on `index.lock`.
+// Mirrors resolveGitExcludePath's spawnSync-and-fall-through style. Returns
+// { gitDir, commonDir }, either null on any resolution failure — best-effort,
+// never throws.
+function resolveWorktreeGitDirs(worktreePath) {
+  const run = (args) => {
+    try {
+      const res = spawnSync("git", ["-C", worktreePath, ...args], { encoding: "utf8" });
+      if (res && res.status === 0 && typeof res.stdout === "string" && res.stdout.trim()) {
+        return res.stdout.trim();
+      }
+    } catch {
+      /* best-effort */
+    }
+    return null;
+  };
+  return {
+    gitDir: run(["rev-parse", "--absolute-git-dir"]),
+    commonDir: run(["rev-parse", "--path-format=absolute", "--git-common-dir"]),
+  };
+}
+
 // resolveWritableRoots — the de-duplicated, absolute writable-root set for the
 // `-c sandbox_workspace_write.writable_roots=[…]` override: the configured roots
-// ∪ {orchDir} ∪ {the resolved thoughts real-root of the worktree if present}.
+// ∪ {orchDir} ∪ {the resolved thoughts real-root of the worktree if present}
+// ∪ {the worktree's real git-dir and git-common-dir, for linked worktrees}.
 // Order-preserving; drops non-absolute / empty / duplicate entries.
 function resolveWritableRoots(cfg, { orchDir, worktreePath } = {}) {
   const out = [];
@@ -335,6 +365,9 @@ function resolveWritableRoots(cfg, { orchDir, worktreePath } = {}) {
   for (const r of cfg?.writableRoots ?? []) add(r);
   add(orchDir);
   add(resolveThoughtsRoot(worktreePath));
+  const { gitDir, commonDir } = resolveWorktreeGitDirs(worktreePath);
+  add(gitDir);
+  add(commonDir);
   return out;
 }
 

--- a/plugins/dev/scripts/execution-core/codex-run-phase-agent.test.mjs
+++ b/plugins/dev/scripts/execution-core/codex-run-phase-agent.test.mjs
@@ -407,6 +407,53 @@ describe("buildCodexArgs", () => {
     expect(args.slice(0, 2)).toEqual(["exec", "--json"]);
     expect(args).not.toContain("resume");
   });
+
+  // CTL-1457 follow-up: for a LINKED worktree (every real ticket worktree), the
+  // actual git-dir (HEAD/index/index.lock) and git-common-dir (object db + refs)
+  // live OUTSIDE the worktree tree entirely — `git commit` there was refused with
+  // a permission error because neither was ever in writable_roots. Uses a real
+  // `git worktree add` (not just `git init`) so `--absolute-git-dir` genuinely
+  // resolves outside `wt`, exercising the actual bug scenario.
+  test("linked worktree → writable_roots includes the real --absolute-git-dir and --git-common-dir (both live outside the worktree tree)", () => {
+    const main = mkdtempSync(join(tmpdir(), "codex-main-"));
+    const env = {
+      ...process.env,
+      GIT_AUTHOR_NAME: "t",
+      GIT_AUTHOR_EMAIL: "t@t.invalid",
+      GIT_COMMITTER_NAME: "t",
+      GIT_COMMITTER_EMAIL: "t@t.invalid",
+    };
+    Bun.spawnSync(["git", "init", "-b", "main"], { cwd: main });
+    Bun.spawnSync(["git", "commit", "--allow-empty", "-m", "init"], { cwd: main, env });
+    // `git worktree add` requires the target path not to already exist yet, so
+    // mkdtemp-then-remove just to mint a unique path (mirrors the mkdtemp pattern
+    // used elsewhere in this file for real-git fixtures).
+    const wt = mkdtempSync(join(tmpdir(), "codex-linked-wt-"));
+    rmSync(wt, { recursive: true, force: true });
+    Bun.spawnSync(["git", "worktree", "add", "-b", "feature", wt], { cwd: main });
+
+    const spec = makeCodexSpec();
+    const args = buildCodexArgs(spec, { ...CFG, writableRoots: [] }, { orchDir: "/ec", worktreePath: wt });
+    const firstC = args.indexOf("-c");
+    const roots = JSON.parse(args[firstC + 1].slice("sandbox_workspace_write.writable_roots=".length));
+
+    const gitDir = Bun.spawnSync(["git", "-C", wt, "rev-parse", "--absolute-git-dir"], { encoding: "utf8" })
+      .stdout.toString()
+      .trim();
+    const commonDir = Bun.spawnSync(
+      ["git", "-C", wt, "rev-parse", "--path-format=absolute", "--git-common-dir"],
+      { encoding: "utf8" },
+    )
+      .stdout.toString()
+      .trim();
+
+    expect(gitDir.startsWith(wt)).toBe(false); // proves it's genuinely OUTSIDE the worktree tree
+    expect(roots).toContain(gitDir);
+    expect(roots).toContain(commonDir);
+
+    Bun.spawnSync(["git", "worktree", "remove", "--force", wt], { cwd: main });
+    rmSync(main, { recursive: true, force: true });
+  });
 });
 
 // ── buildCodexEnv ───────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

`codex-exec`'s sandbox `writable_roots` allowlist never included a linked worktree's REAL git metadata directories, so `git commit` inside a `codex-exec`-routed `implement`/`remediate` phase was silently refused (or produced an empty commit / left work uncommitted) whenever the worktree was a linked worktree — which every ticket worktree is.

For a linked worktree (`git worktree add wt/<TICKET>`), the actual git state git needs to mutate on commit does **not** live inside the worktree tree:

- `HEAD`, `index`, `index.lock`, `COMMIT_EDITMSG` live under `--absolute-git-dir` (`<main-repo>/.git/worktrees/<name>/`)
- the object database + refs live under `--git-common-dir` (the main repo's shared `.git`)

Both are outside `worktreePath` and outside `orchDir`, so neither was ever added to `sandbox_workspace_write.writable_roots`, and `codex exec`'s sandbox refused writes to `index.lock` with a permission error — or, worse, `git commit` silently no-oped and the phase still reported `status: "done"` with the real work left uncommitted in the worktree.

## Fix

Add `resolveWorktreeGitDirs(worktreePath)` (mirrors the existing `resolveGitExcludePath` git-path-resolution style already in this file) and wire its `{ gitDir, commonDir }` into `resolveWritableRoots`. Best-effort — `spawnSync` failures/non-zero exits resolve to `null` and are filtered out by the existing `add()` dedup helper, so a missing/invalid worktree path degrades to the pre-fix behavior instead of throwing.

## Test plan

- New test in `codex-run-phase-agent.test.mjs`: builds a REAL linked worktree via `git worktree add` (not just `git init`, so `--absolute-git-dir` genuinely resolves outside the worktree tree — this is the actual bug scenario) and asserts `buildCodexArgs`'s resulting `writable_roots` contains both the real `--absolute-git-dir` and `--git-common-dir` paths.
- Confirmed the existing `buildCodexArgs` test (nonexistent `worktreePath`) is unaffected — `git rev-parse` against a nonexistent path fails, both resolve to `null`, filtered out, roots array unchanged.
- `bun test codex-run-phase-agent.test.mjs`: 55/55 passing.
