### PR TITLE
fix(dev): git-exclude Catalyst's own worktree-local runtime artifacts

### DIFF
--- a/plugins/dev/scripts/__tests__/create-worktree-gitignore-artifacts.test.sh
+++ b/plugins/dev/scripts/__tests__/create-worktree-gitignore-artifacts.test.sh
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+# Tests for catalyst_git_exclude_worktree_artifacts (create-worktree.sh):
+# Catalyst's own worktree-local runtime artifacts (thoughts/,
+# .catalyst/.workflow-context.json, etc.) must never show up as dirty/untracked
+# in a fresh worktree's `git status` — without ever touching the project's
+# TRACKED .gitignore. This is what makes a project's verify-phase rebase never
+# get refused by Catalyst's own noise (the root cause of a real stalled-ticket
+# incident: rebase_refused_dirty_tree on thoughts/ + .workflow-context.json).
+# Run: bash plugins/dev/scripts/__tests__/create-worktree-gitignore-artifacts.test.sh
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../../.." && pwd)"
+CREATE_WT="${REPO_ROOT}/plugins/dev/scripts/create-worktree.sh"
+
+FAILURES=0
+PASSES=0
+fail() {
+	FAILURES=$((FAILURES + 1))
+	echo "  FAIL: $1"
+}
+pass() {
+	PASSES=$((PASSES + 1))
+	echo "  PASS: $1"
+}
+assert_eq() {
+	if [[ $1 == "$2" ]]; then pass "$3"; else fail "$3 — expected '$1', got '$2'"; fi
+}
+assert_contains() {
+	if [[ $2 == *"$1"* ]]; then pass "$3"; else fail "$3 — expected to find '$1' in: $2"; fi
+}
+
+# Scratch layout mirrors create-worktree-tracked-clean.test.sh.
+COMMITTED_CATALYST_CFG='{"catalyst":{"projectKey":"t","worktree":{"setup":["true"]}}}'
+build_scratch() {
+	SCRATCH="$(mktemp -d -t cwt-gitignore-XXXXXX)"
+	ORIGIN="$SCRATCH/origin.git"
+	SRC="$SCRATCH/src"
+	WT="$SCRATCH/wt"
+	FAKEHOME="$SCRATCH/home"
+	mkdir -p "$WT" "$FAKEHOME"
+	git init -q --bare "$ORIGIN"
+	# Robust to the host's init.defaultBranch (may be "master" locally, "main" in
+	# CI) — pin the bare origin's HEAD to "main" explicitly so clone/push below
+	# never depend on the ambient default.
+	git -C "$ORIGIN" symbolic-ref HEAD refs/heads/main
+
+	local SEED="$SCRATCH/seed"
+	git clone -q "$ORIGIN" "$SEED"
+	git -C "$SEED" config user.email t@t.t
+	git -C "$SEED" config user.name t
+	git -C "$SEED" checkout -q -b main 2>/dev/null || git -C "$SEED" checkout -q main
+	mkdir -p "$SEED/.catalyst"
+	printf '%s\n' "$COMMITTED_CATALYST_CFG" >"$SEED/.catalyst/config.json"
+	git -C "$SEED" add -A
+	git -C "$SEED" commit -q -m c1
+	git -C "$SEED" push -q -u origin main
+
+	git clone -q "$ORIGIN" "$SRC"
+	git -C "$SRC" config user.email t@t.t
+	git -C "$SRC" config user.name t
+}
+
+run_create() { # $1 worktree name; $@ extra args
+	local NAME="$1"
+	shift
+	OUTPUT="$(cd "$SRC" && HOME="$FAKEHOME" \
+		bash "$CREATE_WT" "$NAME" main --worktree-dir "$WT" "$@" 2>&1)"
+	EXIT=$?
+	WT_PATH="$WT/$NAME"
+}
+
+echo "Test 1: fresh worktree's local git exclude carries every Catalyst runtime-artifact pattern"
+build_scratch
+run_create wt-exclude
+assert_eq "0" "$EXIT" "exits 0"
+EXCLUDE_FILE="$(git -C "$WT_PATH" rev-parse --git-path info/exclude 2>/dev/null)"
+[[ $EXCLUDE_FILE == /* ]] || EXCLUDE_FILE="$WT_PATH/$EXCLUDE_FILE"
+EXCLUDE_CONTENT="$(cat "$EXCLUDE_FILE" 2>/dev/null || true)"
+for pattern in "thoughts/" ".catalyst/.workflow-context.json" ".catalyst/.workflow-context.json.bak" \
+	".catalyst/worktree-provenance.json" ".needs-cleanup" ".orphaned_at" ".trunk"; do
+	assert_contains "$pattern" "$EXCLUDE_CONTENT" "exclude file contains '$pattern'"
+done
+rm -rf "$SCRATCH"
+
+echo ""
+echo "Test 2: these artifacts don't show up in git status even when present on disk"
+build_scratch
+run_create wt-status
+assert_eq "0" "$EXIT" "exits 0"
+mkdir -p "$WT_PATH/thoughts/shared" "$WT_PATH/.catalyst"
+printf 'x\n' >"$WT_PATH/thoughts/shared/doc.md"
+printf '{}\n' >"$WT_PATH/.catalyst/worktree-provenance.json"
+: >"$WT_PATH/.needs-cleanup"
+PORCELAIN="$(git -C "$WT_PATH" status --porcelain 2>/dev/null | grep -E 'thoughts/|worktree-provenance|needs-cleanup' || true)"
+assert_eq "" "$PORCELAIN" "none of the seeded artifacts appear in git status"
+rm -rf "$SCRATCH"
+
+echo ""
+echo "Test 3: idempotent — calling the exclude function twice adds no duplicate lines"
+build_scratch
+run_create wt-idempotent
+assert_eq "0" "$EXIT" "exits 0"
+# Extract just the function under test (create-worktree.sh's top level expects
+# real positional args and would fail if sourced directly) and re-invoke it
+# against the same worktree to exercise idempotency in isolation.
+FUNC_SRC="$(sed -n '/^catalyst_git_exclude_worktree_artifacts()/,/^}/p' "$CREATE_WT")"
+bash -c "$FUNC_SRC"$'\n'"catalyst_git_exclude_worktree_artifacts \"\$1\"" -- "$WT_PATH"
+EXCLUDE_FILE="$(git -C "$WT_PATH" rev-parse --git-path info/exclude 2>/dev/null)"
+[[ $EXCLUDE_FILE == /* ]] || EXCLUDE_FILE="$WT_PATH/$EXCLUDE_FILE"
+AFTER_COUNT="$(grep -cxF 'thoughts/' "$EXCLUDE_FILE" 2>/dev/null || echo 0)"
+assert_eq "1" "$AFTER_COUNT" "'thoughts/' still appears exactly once after a second call"
+rm -rf "$SCRATCH"
+
+echo ""
+echo "Passed: $PASSES  Failed: $FAILURES"
+[[ $FAILURES -eq 0 ]] || exit 1

--- a/plugins/dev/scripts/create-worktree.sh
+++ b/plugins/dev/scripts/create-worktree.sh
@@ -22,6 +22,38 @@ YELLOW='\033[1;33m'
 RED='\033[0;31m'
 NC='\033[0m'
 
+# catalyst_git_exclude_worktree_artifacts <worktree_path> — keep Catalyst's own
+# worktree-local runtime bookkeeping out of every project's git status, without
+# ever touching that project's TRACKED .gitignore. Mirrors the existing pattern
+# already used for .agents/ (codex-run-phase-agent.mjs's gitExcludeAgents +
+# resolveGitExcludePath): writes to this worktree's LOCAL, uncommitted
+# `git rev-parse --git-path info/exclude`, so it applies only here, never
+# leaks into the project's history, and needs no per-project PR.
+#
+# Before this, every onboarded project had to carry its own .gitignore entries
+# for these paths — miss one and `git status` shows Catalyst's own noise as
+# dirty, which is exactly what stalled a real ticket's verify phase (rebase
+# refused a "dirty" tree that was only dirty because of thoughts/ and
+# .catalyst/.workflow-context.json). Idempotent + best-effort: failures here
+# must never abort worktree creation.
+catalyst_git_exclude_worktree_artifacts() {
+	local worktree_path="$1" exclude_path pattern
+	exclude_path=$(git -C "$worktree_path" rev-parse --git-path info/exclude 2>/dev/null) || return 0
+	[[ "$exclude_path" = /* ]] || exclude_path="${worktree_path}/${exclude_path}"
+	mkdir -p "$(dirname "$exclude_path")" 2>/dev/null || return 0
+	[ -f "$exclude_path" ] || : >"$exclude_path"
+	for pattern in \
+		"thoughts/" \
+		".catalyst/.workflow-context.json" \
+		".catalyst/.workflow-context.json.bak" \
+		".catalyst/worktree-provenance.json" \
+		".needs-cleanup" \
+		".orphaned_at" \
+		".trunk"; do
+		grep -qxF "$pattern" "$exclude_path" 2>/dev/null || printf '%s\n' "$pattern" >>"$exclude_path"
+	done
+}
+
 # Parse flags (collect positional args separately)
 POSITIONAL=()
 OVERRIDE_WORKTREE_DIR=""
@@ -340,6 +372,13 @@ if [ -f "${SCRIPT_DIR}/workflow-context.sh" ]; then
 		echo "📋 Orchestration context set: ${ORCHESTRATION_NAME}"
 	fi
 fi
+
+# Keep Catalyst's own worktree-local runtime artifacts (thoughts/,
+# .catalyst/.workflow-context.json, etc.) out of `git status` for every
+# project, unconditionally — via this worktree's local git exclude, never the
+# project's tracked .gitignore. Runs regardless of executor (bg/sdk/codex-exec)
+# and regardless of whether thoughts-init below even runs.
+catalyst_git_exclude_worktree_artifacts "$WORKTREE_PATH"
 
 # Generate .envrc for OTEL context (source_up inherits parent profiles)
 # Note: direnv allow runs AFTER setup hooks to avoid re-blocking if hooks modify .envrc


### PR DESCRIPTION
## Summary

Every onboarded project had to hand-maintain its own tracked `.gitignore` entries for Catalyst's own worktree-local runtime bookkeeping: `thoughts/`, `.catalyst/.workflow-context.json(.bak)`, `.catalyst/worktree-provenance.json`, `.needs-cleanup`, `.orphaned_at`, `.trunk`. Miss one and `git status` shows Catalyst's own noise as dirty — which is exactly what stalled a real ticket's `verify` phase in production: the phase's pre-verify rebase refused to proceed against a tree that was only "dirty" because of `thoughts/` and `.workflow-context.json`, neither of which the project had ever been told to ignore.

Catalyst already has the right pattern for exactly this problem: `.agents/skills` (its own tooling symlink) is kept out of every project via the worktree's **local, uncommitted** `.git/info/exclude` (`codex-run-phase-agent.mjs`'s `gitExcludeAgents`/`resolveGitExcludePath`) — never the project's tracked `.gitignore`. That mechanism was (a) never extended to cover the other Catalyst-owned worktree-local artifacts, and (b) wired in only for the `codex-exec` executor path, not `bg`/`sdk`.

## Fix

Add `catalyst_git_exclude_worktree_artifacts` to `create-worktree.sh`, called unconditionally for every newly created worktree regardless of which executor will later run in it. It writes the same artifact-pattern list to the worktree's local git exclude (idempotent, best-effort — never aborts worktree creation on failure). No project ever needs a `.gitignore` PR for these again, retroactively or going forward.

## Test plan

- New test: `plugins/dev/scripts/__tests__/create-worktree-gitignore-artifacts.test.sh` — builds a real scratch git repo + bare origin, runs `create-worktree.sh` for real, and asserts: (1) all seven patterns land in the fresh worktree's local git exclude, (2) seeding each artifact on disk produces zero `git status` noise, (3) calling the exclude function twice is idempotent (no duplicate lines). 12/12 assertions pass.
- Ran the full existing `create-worktree-*.test.sh` suite before and after this change (`git stash`) — identical failure counts (all pre-existing, environment-specific: this host's git `init.defaultBranch` defaults to `master`, unrelated to this change). Zero regressions introduced.
