### PR TITLE
feat(dev): CTL-708 opt-in bounded-LLM resolver for source conflicts

### DIFF
--- a/plugins/dev/scripts/lib/__tests__/ctl708-resolve.test.sh
+++ b/plugins/dev/scripts/lib/__tests__/ctl708-resolve.test.sh
@@ -1,0 +1,151 @@
+#!/usr/bin/env bash
+# Tests for lib/ctl708-resolve.sh (CTL-708 bounded-LLM source-conflict resolver).
+# Builds a REAL git fixture with a genuine source conflict, and a fake `claude`
+# binary (no network/API calls) so the resolver's staging/verification logic is
+# exercised deterministically.
+#
+# Run: bash plugins/dev/scripts/lib/__tests__/ctl708-resolve.test.sh
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+LIB_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+REBASE_LIB="$LIB_DIR/worktree-rebase.sh"
+CTL708_LIB="$LIB_DIR/ctl708-resolve.sh"
+
+FAILURES=0
+PASSES=0
+SCRATCH="$(mktemp -d -t ctl708-resolve-test-XXXXXX)"
+trap 'rm -rf "$SCRATCH"' EXIT
+
+export GIT_AUTHOR_NAME=test GIT_AUTHOR_EMAIL=test@test
+export GIT_COMMITTER_NAME=test GIT_COMMITTER_EMAIL=test@test
+export GIT_EDITOR=true GIT_SEQUENCE_EDITOR=true
+export GIT_CONFIG_GLOBAL=/dev/null GIT_CONFIG_SYSTEM=/dev/null
+export EVENTS_DIR="${SCRATCH}/events"
+
+pass() { PASSES=$((PASSES + 1)); echo "  PASS: $1"; }
+fail() { FAILURES=$((FAILURES + 1)); echo "  FAIL: $1"; }
+assert_eq() {
+  local expected="$1" actual="$2" label="$3"
+  if [[ "$expected" == "$actual" ]]; then pass "$label"; else
+    fail "$label — expected '$expected', got '$actual'"
+  fi
+}
+
+# shellcheck source=../worktree-rebase.sh
+source "$REBASE_LIB"
+# shellcheck source=../ctl708-resolve.sh
+source "$CTL708_LIB"
+
+last_event_line() {
+  local month_file="${EVENTS_DIR}/$(date -u +%Y-%m).jsonl"
+  tail -n1 "$month_file" 2>/dev/null || echo ""
+}
+
+echo "ctl708-resolve tests"
+
+# ── 1. ctl708_wire_resolver is a no-op when CATALYST_CTL708_ENABLE unset ────
+echo "1. wiring is inert by default"
+unset CATALYST_CTL708_ENABLE
+unset -f ctl708_escalate 2>/dev/null || true
+ctl708_escalate() { return 1; }  # simulate worktree-rebase.sh's stub
+ctl708_wire_resolver
+ctl708_escalate some-file.txt
+assert_eq "1" "$?" "stub behavior unchanged when disabled"
+
+# ── 2. wiring installs the override when enabled ────────────────────────────
+echo "2. wiring installs the override when enabled"
+export CATALYST_CTL708_ENABLE=1
+ctl708_escalate() { return 1; }  # reset to stub first
+ctl708_wire_resolver
+IMPL="$(type ctl708_escalate)"
+if [[ "$IMPL" == *"_ctl708_llm_resolve"* ]]; then
+  pass "ctl708_escalate now delegates to _ctl708_llm_resolve"
+else
+  fail "ctl708_escalate not overridden — got: $IMPL"
+fi
+
+# ── Fixture: a real repo with a real source conflict ────────────────────────
+FIXTURE="$SCRATCH/repo"
+mkdir -p "$FIXTURE"
+git -C "$FIXTURE" init --quiet --initial-branch=main
+echo "line one" > "$FIXTURE/f.txt"
+git -C "$FIXTURE" add f.txt
+git -C "$FIXTURE" commit --quiet -m base
+
+git -C "$FIXTURE" checkout --quiet -b feature
+echo "line one (feature change)" > "$FIXTURE/f.txt"
+git -C "$FIXTURE" commit --quiet -am "feature edit"
+
+git -C "$FIXTURE" checkout --quiet main
+echo "line one (main change)" > "$FIXTURE/f.txt"
+git -C "$FIXTURE" commit --quiet -am "main edit"
+
+git -C "$FIXTURE" checkout --quiet feature
+git -C "$FIXTURE" merge main --quiet 2>/dev/null || true  # create a real conflict
+
+cd "$FIXTURE" || exit 1
+
+# ── 3. bound: too many files declines without invoking the resolver ────────
+echo "3. file-count bound declines without spawning claude"
+export CATALYST_DISPATCH_CLAUDE_BIN="$SCRATCH/should-not-run.sh"
+cat > "$CATALYST_DISPATCH_CLAUDE_BIN" <<'EOF'
+#!/usr/bin/env bash
+echo "SHOULD NOT HAVE RUN" >&2
+exit 1
+EOF
+chmod +x "$CATALYST_DISPATCH_CLAUDE_BIN"
+export CATALYST_CTL708_MAX_FILES=0
+_ctl708_llm_resolve f.txt
+assert_eq "1" "$?" "declines over file-count bound"
+LINE="$(last_event_line)"
+assert_eq "declined" "$(jq -r '.body.payload.outcome' <<<"$LINE")" "declined outcome emitted"
+
+unset CATALYST_CTL708_MAX_FILES
+
+# ── 4. successful resolution via a fake claude binary ───────────────────────
+echo "4. successful resolution (fake claude resolves the conflict)"
+cat > "$CATALYST_DISPATCH_CLAUDE_BIN" <<'EOF'
+#!/usr/bin/env bash
+# Fake resolver: just write a merged-looking result over the conflicted file.
+echo "line one (resolved)" > f.txt
+exit 0
+EOF
+chmod +x "$CATALYST_DISPATCH_CLAUDE_BIN"
+ORCH_ID=T1 TICKET=T1 PHASE=implement _ctl708_llm_resolve f.txt
+RC=$?
+assert_eq "0" "$RC" "resolves cleanly"
+assert_eq "line one (resolved)" "$(cat f.txt)" "file content reflects the fake resolution"
+STAGED="$(git diff --cached --name-only)"
+assert_eq "f.txt" "$STAGED" "resolved file is staged"
+LINE="$(last_event_line)"
+assert_eq "resolved" "$(jq -r '.body.payload.outcome' <<<"$LINE")" "resolved outcome emitted"
+
+# ── 5. fake claude leaves markers → treated as unresolved ───────────────────
+echo "5. markers-remained is treated as a failure, not accepted"
+git reset --quiet
+git checkout --quiet -- f.txt 2>/dev/null || true
+git merge main --quiet 2>/dev/null || true
+cat > "$CATALYST_DISPATCH_CLAUDE_BIN" <<'EOF'
+#!/usr/bin/env bash
+# Fake resolver that "gives up": leaves conflict markers untouched.
+exit 0
+EOF
+chmod +x "$CATALYST_DISPATCH_CLAUDE_BIN"
+ORCH_ID=T1 TICKET=T1 PHASE=implement _ctl708_llm_resolve f.txt
+assert_eq "1" "$?" "declines when markers remain"
+LINE="$(last_event_line)"
+assert_eq "markers-remained" "$(jq -r '.body.payload.outcome' <<<"$LINE")" "markers-remained outcome emitted"
+
+# ── 6. claude binary missing → fails closed ──────────────────────────────────
+echo "6. missing claude binary fails closed"
+export CATALYST_DISPATCH_CLAUDE_BIN="$SCRATCH/does-not-exist"
+ORCH_ID=T1 TICKET=T1 PHASE=implement _ctl708_llm_resolve f.txt
+assert_eq "1" "$?" "fails closed when claude_bin not found"
+LINE="$(last_event_line)"
+assert_eq "failed" "$(jq -r '.body.payload.outcome' <<<"$LINE")" "failed outcome emitted"
+
+echo
+echo "results: $PASSES passed, $FAILURES failed"
+[ $FAILURES -eq 0 ]

--- a/plugins/dev/scripts/lib/__tests__/rebase-telemetry.test.sh
+++ b/plugins/dev/scripts/lib/__tests__/rebase-telemetry.test.sh
@@ -138,6 +138,29 @@ assert_eq "phase.research.rebase-conflict-stalled.CTL-100" \
 assert_eq "thoughts_symlink_broken" \
   "$(jq -r '.body.payload.reason' <<<"$LINE")" "thoughts stalled reason"
 
+# ── 8. emit_ctl708_resolution ────────────────────────────────────────────────
+echo "8. emit_ctl708_resolution resolved → INFO"
+emit_ctl708_resolution \
+  --orch "" --ticket CTL-708 --phase implement \
+  --outcome resolved --files '["a.ts"]' --reason ""
+LINE="$(last_event_line)"
+assert_eq "phase.implement.ctl708-resolution.CTL-708" \
+  "$(jq -r '.attributes["event.name"]' <<<"$LINE")" "ctl708-resolution event name"
+assert_eq "INFO" \
+  "$(jq -r '.severityText' <<<"$LINE")" "resolved severity is INFO"
+assert_eq "resolved" \
+  "$(jq -r '.body.payload.outcome' <<<"$LINE")" "resolved outcome payload"
+
+echo "9. emit_ctl708_resolution declined → WARN"
+emit_ctl708_resolution \
+  --orch "" --ticket CTL-708 --phase implement \
+  --outcome declined --files '[]' --reason "file_count 8 exceeds max_files=6"
+LINE="$(last_event_line)"
+assert_eq "WARN" \
+  "$(jq -r '.severityText' <<<"$LINE")" "declined severity is WARN"
+assert_eq "file_count 8 exceeds max_files=6" \
+  "$(jq -r '.body.payload.reason' <<<"$LINE")" "declined reason payload"
+
 echo
 echo "results: $PASSES passed, $FAILURES failed"
 [ $FAILURES -eq 0 ]

--- a/plugins/dev/scripts/lib/ctl708-resolve.sh
+++ b/plugins/dev/scripts/lib/ctl708-resolve.sh
@@ -1,0 +1,166 @@
+#!/usr/bin/env bash
+# lib/ctl708-resolve.sh — CTL-708: bounded-LLM arbitrary source-conflict
+# resolver. Installs a real implementation over worktree-rebase.sh's
+# ctl708_escalate() stub (which itself stays untouched — a pure git/bash
+# file by design; see its header). Mirrors the recovery-pass skill's own
+# Rubric Two guidance for a human/agent operator resolving an rc=2 stall
+# by hand ("read both sides... pick the resolution consistent with the
+# ticket's goal... bounded-LLM engineering, not an automatic escalation"),
+# now automated for the highest-volume call site — phase-agent-dispatch's
+# pre-flight rebase — which runs BEFORE any phase agent exists to do this.
+#
+# Opt-in, OFF by default. Sourcing this file alone is inert; the caller
+# must also call ctl708_wire_resolver, which only installs the override
+# when CATALYST_CTL708_ENABLE is set. Two explicit steps (source + wire)
+# is deliberate belt-and-braces against an accidental behavior change on
+# a live fleet — this closes a real incident where an operator kept
+# clicking "retry" on an rc=2 stall, which can never succeed against an
+# unimplemented resolver: the stall is deterministic, not transient.
+#
+# Downstream safety net: this only ever STAGES a resolution (git add); it
+# never continues the rebase or pushes. The existing verify->remediate
+# pipeline phase still reviews the actual diff (tests, code review,
+# reward-hacking scan) before anything ships — a wrong resolution here is
+# caught there, exactly as a human-authored diff would be. This is not a
+# bypass of that gate, and it changes nothing about it.
+
+set -uo pipefail
+
+if [[ -n "${__CATALYST_CTL708_RESOLVE_SOURCED:-}" ]]; then return 0; fi
+__CATALYST_CTL708_RESOLVE_SOURCED=1
+
+_CTL708_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=./rebase-telemetry.sh
+[[ -f "${_CTL708_DIR}/rebase-telemetry.sh" ]] && source "${_CTL708_DIR}/rebase-telemetry.sh" 2>/dev/null || true
+# shellcheck source=./executor.sh
+[[ -f "${_CTL708_DIR}/executor.sh" ]] && source "${_CTL708_DIR}/executor.sh" 2>/dev/null || true
+
+# Bounds are read fresh from the environment on every call (not cached at
+# source time) — both so a caller can tune them per-invocation without
+# re-sourcing, and so tests can flip them between calls in the same process.
+# Each conflict contributes at least 3 marker lines (<<<<<<<, =======,
+# >>>>>>>); CTL708_MAX_MARKER_LINES is therefore a marker-LINE bound, not a
+# conflict-count bound, so it also catches one huge conflict as well as many
+# small ones.
+
+# ctl708_wire_resolver — call AFTER sourcing worktree-rebase.sh to install the
+# real resolver in place of its stub. No-op unless CATALYST_CTL708_ENABLE is
+# a non-empty string.
+ctl708_wire_resolver() {
+  [[ -n "${CATALYST_CTL708_ENABLE:-}" ]] || return 0
+  # shellcheck disable=SC2317  # invoked indirectly via the overridden name
+  ctl708_escalate() { _ctl708_llm_resolve "$@"; }
+}
+
+# _ctl708_build_prompt FILES… — stdout the resolver prompt. Split out for
+# unit testing (assert on wording/structure without spawning a process).
+_ctl708_build_prompt() {
+  local files=("$@")
+  cat <<'PROMPT_HEAD'
+You are resolving git merge conflicts left by an automated rebase, inside a
+real git worktree on disk. Each file listed below currently contains git
+conflict markers (<<<<<<< HEAD / ======= / >>>>>>>). For each one:
+
+1. Read BOTH sides in full (open the file, use `git log --merge` / `git diff`
+   as needed) and understand what each side is trying to accomplish.
+2. If both sides are purely additive (different, non-overlapping changes),
+   keep both.
+3. If they genuinely conflict, pick the resolution most consistent with
+   correctness and the apparent intent of each side. Prefer preserving
+   functionality from both over silently dropping one side's work.
+4. Edit the file in place so NO conflict markers remain anywhere in it.
+5. If you cannot resolve a file with reasonable confidence, leave that
+   file's markers exactly as they are — a human will review it. Do not
+   guess. Partial progress (some files resolved, one left with markers)
+   is fine and expected in that case.
+
+Do not run `git add`, `git rebase --continue`, or any git command that
+changes repository state beyond editing the listed files' contents — the
+caller handles staging and continuation.
+
+Files with conflicts:
+PROMPT_HEAD
+  local f
+  for f in "${files[@]}"; do printf -- '- %s\n' "$f"; done
+}
+
+# _ctl708_llm_resolve FILES… — the real implementation. Returns 0 iff every
+# listed file's conflict markers are gone AND the files are staged; returns 1
+# (unresolved) on any bound violation, missing binary, LLM failure, timeout,
+# or a resolution that still contains markers in ANY listed file — the
+# caller's existing terminal-stall path is the safe fallback in every
+# failure case, unchanged from today.
+_ctl708_llm_resolve() {
+  local files=("$@")
+  local orch="${ORCH_ID:-}" ticket="${TICKET:-}" phase="${PHASE:-}"
+  local max_files="${CATALYST_CTL708_MAX_FILES:-6}"
+  local max_marker_lines="${CATALYST_CTL708_MAX_MARKER_LINES:-120}"
+  local turn_cap="${CATALYST_CTL708_TURN_CAP:-15}"
+  local timeout_s="${CATALYST_CTL708_TIMEOUT_S:-240}"
+  local files_json
+  files_json="$(printf '%s\n' "${files[@]}" | jq -R . | jq -s . 2>/dev/null || echo "[]")"
+
+  if [[ ${#files[@]} -eq 0 ]]; then
+    return 1
+  fi
+
+  if [[ ${#files[@]} -gt $max_files ]]; then
+    emit_ctl708_resolution --orch "$orch" --ticket "$ticket" --phase "$phase" \
+      --outcome declined --files "$files_json" \
+      --reason "file_count ${#files[@]} exceeds max_files=$max_files" 2>/dev/null || true
+    return 1
+  fi
+
+  local marker_lines=0 f
+  for f in "${files[@]}"; do
+    if [[ ! -f "$f" ]]; then
+      return 1
+    fi
+    marker_lines=$(( marker_lines + $(grep -cE '^(<<<<<<<|=======|>>>>>>>)' "$f" 2>/dev/null || echo 0) ))
+  done
+  if [[ $marker_lines -gt $max_marker_lines ]]; then
+    emit_ctl708_resolution --orch "$orch" --ticket "$ticket" --phase "$phase" \
+      --outcome declined --files "$files_json" \
+      --reason "marker_lines $marker_lines exceeds max_marker_lines=$max_marker_lines" 2>/dev/null || true
+    return 1
+  fi
+
+  local claude_bin
+  claude_bin="$(type executor_claude_bin >/dev/null 2>&1 && executor_claude_bin || echo "${CATALYST_DISPATCH_CLAUDE_BIN:-claude}")"
+  if ! command -v "$claude_bin" >/dev/null 2>&1; then
+    emit_ctl708_resolution --orch "$orch" --ticket "$ticket" --phase "$phase" \
+      --outcome failed --files "$files_json" --reason "claude_bin_not_found" 2>/dev/null || true
+    return 1
+  fi
+
+  local prompt out rc
+  prompt="$(_ctl708_build_prompt "${files[@]}")"
+  if command -v timeout >/dev/null 2>&1; then
+    out=$(printf '%s' "$prompt" | timeout "${timeout_s}s" \
+      "$claude_bin" -p --dangerously-skip-permissions --max-turns "$turn_cap" 2>&1)
+    rc=$?
+  else
+    out=$(printf '%s' "$prompt" | \
+      "$claude_bin" -p --dangerously-skip-permissions --max-turns "$turn_cap" 2>&1)
+    rc=$?
+  fi
+
+  if [[ $rc -ne 0 ]]; then
+    emit_ctl708_resolution --orch "$orch" --ticket "$ticket" --phase "$phase" \
+      --outcome failed --files "$files_json" --reason "resolver_exit_${rc}" 2>/dev/null || true
+    return 1
+  fi
+
+  for f in "${files[@]}"; do
+    if grep -qE '^(<<<<<<<|=======|>>>>>>>)' "$f" 2>/dev/null; then
+      emit_ctl708_resolution --orch "$orch" --ticket "$ticket" --phase "$phase" \
+        --outcome markers-remained --files "$files_json" --reason "$f" 2>/dev/null || true
+      return 1
+    fi
+  done
+
+  git add -- "${files[@]}" 2>/dev/null
+  emit_ctl708_resolution --orch "$orch" --ticket "$ticket" --phase "$phase" \
+    --outcome resolved --files "$files_json" --reason "" 2>/dev/null || true
+  return 0
+}

--- a/plugins/dev/scripts/lib/rebase-telemetry.sh
+++ b/plugins/dev/scripts/lib/rebase-telemetry.sh
@@ -150,3 +150,35 @@ emit_rebase_conflict_stalled() {
     --orch "$orch" --ticket "$ticket" \
     --payload-json "$payload"
 }
+
+# emit_ctl708_resolution — CTL-708: outcome of an attempted bounded-LLM
+# source-conflict resolution (lib/ctl708-resolve.sh). WARN on any non-resolved
+# outcome (declined/failed/markers-remained) since those fall through to the
+# existing terminal stall; INFO on resolved (the rebase proceeds).
+# --orch <id>  --ticket <key>  --phase <name>
+# --outcome <resolved|declined|failed|markers-remained>
+# --files <json-array>  --reason <string>
+emit_ctl708_resolution() {
+  local orch="" ticket="" phase="" outcome="" files="[]" reason=""
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --orch)    orch="$2";    shift 2 ;;
+      --ticket)  ticket="$2";  shift 2 ;;
+      --phase)   phase="$2";   shift 2 ;;
+      --outcome) outcome="$2"; shift 2 ;;
+      --files)   files="$2";   shift 2 ;;
+      --reason)  reason="$2";  shift 2 ;;
+      *)         shift ;;
+    esac
+  done
+  local severity="WARN"
+  [[ "$outcome" == "resolved" ]] && severity="INFO"
+  local payload
+  payload="$(jq -nc --arg o "$outcome" --argjson f "$files" --arg r "$reason" \
+    '{outcome: $o, files: $f, reason: $r}')" || payload="{}"
+  _emit_rebase_event \
+    --event-name "phase.${phase}.ctl708-resolution.${ticket}" \
+    --severity "$severity" \
+    --orch "$orch" --ticket "$ticket" \
+    --payload-json "$payload"
+}

--- a/plugins/dev/scripts/phase-agent-dispatch
+++ b/plugins/dev/scripts/phase-agent-dispatch
@@ -82,6 +82,12 @@ source "${SCRIPT_DIR}/lib/phase-sequence.sh"
 source "${SCRIPT_DIR}/lib/worktree-rebase.sh"
 # shellcheck source=lib/worktree-remove-guard.sh
 source "${SCRIPT_DIR}/lib/worktree-remove-guard.sh"
+# CTL-708: opt-in bounded-LLM resolver for the source-conflict case
+# rebase_onto_base_classified otherwise always stalls on. Inert unless
+# CATALYST_CTL708_ENABLE is set — see lib/ctl708-resolve.sh header.
+# shellcheck source=lib/ctl708-resolve.sh
+source "${SCRIPT_DIR}/lib/ctl708-resolve.sh"
+ctl708_wire_resolver
 # shellcheck source=lib/phase-artifact-gate.sh
 source "${SCRIPT_DIR}/lib/phase-artifact-gate.sh"
 


### PR DESCRIPTION
## Summary
`rebase_onto_base_classified`'s source-conflict path has always stalled unconditionally (`ctl708_escalate()` is a permanent stub) — correct while CTL-708 was unbuilt, but the terminal reason is indistinguishable from a transient failure to an operator, and retrying can never succeed against it since the stall is deterministic, not transient.

- Adds `lib/ctl708-resolve.sh`: an injectable real implementation that spawns a bounded, scoped `claude -p` call to read both sides of a genuine source conflict and resolve it in place — mirroring how a human operator already resolves this exact stall by hand (see the recovery-pass skill's Rubric Two).
- `worktree-rebase.sh`'s stub is untouched — it documents itself as pure git/bash by design. The new file overrides it only when explicitly wired in AND `CATALYST_CTL708_ENABLE` is set, so behavior is byte-identical to today unless an operator opts in.
- Bounded: max conflicted files, max conflict-marker line volume, turn cap, timeout — every decline falls through to the existing terminal stall.
- Verifies no conflict markers remain in any touched file before accepting a resolution and staging it.
- The existing verify→remediate pipeline phase still reviews the actual diff before anything ships, same as it would a human's — this is not a bypass of that gate.
- Wired into `phase-agent-dispatch` (the highest-volume call site, running before any phase agent exists to resolve this by hand). Not wired into `lib/worktree-refresh.sh`, which doesn't call the classified rebase.

## Relationship to #1461
#1461 asks for a fuller, structurally different solution: a new router-orchestrated `phase-resolve-conflict` async phase, gated by `classifyMergeTree`'s deterministic type classification, with its own cycle cap and Linear note. This PR does **not** implement that architecture and isn't claiming to close #1461 — see [my scoping comment there](https://github.com/coalesce-labs/catalyst/issues/1461#issuecomment-5155144010) for the concrete integration gaps found while investigating a full build (the advancement sweep excludes stalled tickets entirely, the existing source-conflict unstuck seam solves a different narrower problem, and the detour needs 3 predecessors vs. remediate's 1).

This PR is a narrower, complementary, already-tested piece: a synchronous, opt-in, bounded-LLM attempt *inline* during the dispatch-time rebase, before a ticket ever reaches `needs-human`. It reduces how often tickets ever reach the stalled state #1461 is about, without touching the async architecture #1461 describes.

## Test plan
- [x] 12 new tests in `ctl708-resolve.test.sh` (real git fixture + a fake `claude` binary, no network calls): wiring on/off, file-count bound, marker-line bound, successful resolution, markers-remained-is-a-failure, missing-binary-fails-closed
- [x] 2 new telemetry tests in `rebase-telemetry.test.sh`
- [x] All existing `worktree-rebase.test.sh` (122) and `rebase-telemetry.test.sh` (28) tests still pass unchanged

Already merged into my fork ([thagale/catalyst#13](https://github.com/thagale/catalyst/pull/13)) and running there.