### PR TITLE
feat(dev): CTL-1603 — fix board showing zero tickets for cluster-only teams

### DIFF
--- a/plugins/dev/scripts/orch-monitor/board-data-team-repo.test.ts
+++ b/plugins/dev/scripts/orch-monitor/board-data-team-repo.test.ts
@@ -1,6 +1,11 @@
 // CTL-1152: unit tests for the config-driven team→repo map helpers exported
 // from board-data.mjs. board-data.mjs is plain JS so we import dynamically.
 import { describe, it, expect } from "bun:test";
+import { mkdtempSync, writeFileSync, mkdirSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const { readClusterProjects } = await import("./lib/cluster-roster.ts");
 
 const { buildTeamRepoMap, repoForWith } = await import("./lib/board-data.mjs");
 
@@ -49,5 +54,52 @@ describe("config-driven team→repo (CTL-1152)", () => {
     expect(repoForWith(map, "CTL-1")).toBe("catalyst");
     expect(repoForWith(map, "BAD-1")).toBe("unconfigured");
     expect(repoForWith(map, "X-1")).toBe("unconfigured");
+  });
+});
+
+describe("board cluster-roster integration (CTL-1603)", () => {
+  it("maps a cluster-only team to its real short repo name", () => {
+    const dir = mkdtempSync(join(tmpdir(), "ctl1603-"));
+    const clusterDir = join(dir, "catalyst-cluster");
+    mkdirSync(clusterDir, { recursive: true });
+    writeFileSync(
+      join(clusterDir, "cluster.json"),
+      JSON.stringify({
+        projects: [
+          { teamKey: "CTC", vcsRepo: "coalesce-labs/catalyst-cloud", projectKey: "catalyst-cloud" },
+        ],
+      }),
+    );
+    const layer1ConfigPath = join(dir, "config.json"); // does not exist → Layer-1 contributes nothing
+
+    const teams = readClusterProjects({ clusterDir, layer1ConfigPath });
+    const map = buildTeamRepoMap(teams);
+
+    expect(repoForWith(map, "CTC-1234")).toBe("catalyst-cloud");
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("still resolves a Layer-1-only team (union: cluster wins, L1-only retained)", () => {
+    const dir = mkdtempSync(join(tmpdir(), "ctl1603-"));
+    const clusterDir = join(dir, "catalyst-cluster");
+    mkdirSync(clusterDir, { recursive: true });
+    writeFileSync(
+      join(clusterDir, "cluster.json"),
+      JSON.stringify({
+        projects: [
+          { teamKey: "CTC", vcsRepo: "coalesce-labs/catalyst-cloud", projectKey: "catalyst-cloud" },
+        ],
+      }),
+    );
+    const layer1ConfigPath = join(dir, "config.json");
+    writeFileSync(
+      layer1ConfigPath,
+      JSON.stringify({ monitor: { linear: { teams: [{ key: "CTL", vcsRepo: "coalesce-labs/catalyst" }] } } }),
+    );
+
+    const map = buildTeamRepoMap(readClusterProjects({ clusterDir, layer1ConfigPath }));
+    expect(repoForWith(map, "CTC-1")).toBe("catalyst-cloud"); // cluster team
+    expect(repoForWith(map, "CTL-1")).toBe("catalyst");       // L1-only team retained
+    rmSync(dir, { recursive: true, force: true });
   });
 });

--- a/plugins/dev/scripts/orch-monitor/lib/board-data.mjs
+++ b/plugins/dev/scripts/orch-monitor/lib/board-data.mjs
@@ -56,6 +56,7 @@ import { getEventLogPath } from "../../execution-core/config.mjs";
 // bun:sqlite/pino edge, so this import is graph-safe.
 import { recordFullRead, scanFileLines } from "./event-log-reader.ts"; // CTL-1529: bounded chunked scan
 import { isLinearTerminal } from "../../execution-core/terminal-state.mjs";
+import { readClusterProjects } from "./cluster-roster.ts";
 
 const execFileP = promisify(execFile);
 
@@ -406,22 +407,12 @@ export function buildTeamRepoMap(teams) {
   return map;
 }
 
-// loadTeamRepoMap() — sync L2-then-L1 config read, fail-open to {}. Same two
-// locations and precedence direction maxParallel() uses (L2 = ~/.config/catalyst,
-// L1 = cwd/.catalyst), preferring the L2 teams[] then L1.
-function readJSONSync(path) {
-  try {
-    return JSON.parse(readFileSync(path, "utf8"));
-  } catch {
-    return null;
-  }
-}
+// loadTeamRepoMap() — cluster-aware team→repo map (CTL-1603, the 4th CTL-1214
+// Phase 2 migration). readClusterProjects() unions cluster.json with the
+// Layer-1 fallback (cluster wins on conflict, Layer-1-only teams retained)
+// and is sync + fail-open, preserving the const-loaded-once semantics of TEAM_REPO.
 function loadTeamRepoMap() {
-  const l2 = readJSONSync(join(HOME, ".config", "catalyst", "config.json"));
-  const l1 = readJSONSync(join(process.cwd(), ".catalyst", "config.json"));
-  const pickTeams = (c) => c?.catalyst?.monitor?.linear?.teams ?? c?.monitor?.linear?.teams;
-  const teams = pickTeams(l2) ?? pickTeams(l1) ?? [];
-  return buildTeamRepoMap(teams);
+  return buildTeamRepoMap(readClusterProjects());
 }
 
 const TEAM_REPO = loadTeamRepoMap();


### PR DESCRIPTION
<!-- Auto-generated: 2026-08-02T11:05:00Z -->
<!-- Last updated: 2026-08-02T11:05:00Z -->
<!-- PR: #2868 -->
<!-- Previous commits: 66436ea9452963ff84fa89f5764bc83cea4202bd -->

## Summary

Migrates `board-data.mjs`'s `loadTeamRepoMap()` from a standalone L1/L2 config read to `readClusterProjects()` from `cluster-roster.ts`, completing the fourth and final CTL-1214 Phase 2 migration.

**Problem**: `loadTeamRepoMap()` read only `monitor.linear.teams[]` from the Layer-1 / Layer-2 config files and was never connected to `catalyst-cluster/cluster.json`. Any team registered only in the fleet-wide cluster roster (e.g. CTC → `catalyst-cloud`, added by a prior ticket) resolved to the bare lowercased ticket prefix instead of its real project key. Concretely: selecting "Catalyst Cloud" on the board set `?scope=catalyst-cloud`, but `board-data.mjs` produced `.repo = "ctc"` for CTC tickets — zero matches, every column empty — even though the Workers page showed those workers actively running.

**Solution**: Replace the standalone config read with `readClusterProjects()`, which unions `cluster.json` with the Layer-1 fallback (cluster wins on conflict; Layer-1-only teams are retained). Two regression tests verify the cluster-only-team path and the union rule.

## Changes Made

### `board-data.mjs`

- Removes `readJSONSync()` helper and the standalone L1/L2 team-list extraction
- `loadTeamRepoMap()` now delegates entirely to `readClusterProjects()` from `cluster-roster.ts`
- Adds the `readClusterProjects` import at the top of the file

### `board-data-team-repo.test.ts`

- Adds `describe("board cluster-roster integration (CTL-1603)")` with two tests:
  - `maps a cluster-only team to its real short repo name` — verifies `CTC-1234` resolves to `"catalyst-cloud"` when the team is in `cluster.json` only
  - `still resolves a Layer-1-only team (union: cluster wins, L1-only retained)` — verifies the union: CTC from cluster and CTL from Layer-1 both resolve correctly

## How to Verify It

- [x] `bun test board-data-team-repo.test.ts` — 8 pass (6 pre-existing + 2 new CTL-1603 tests)
- [x] `bun test` — 6574 pass / 38 fail (38 failures are pre-existing baseline, unchanged)
- [x] TypeScript: 0 non-UI errors (1521 UI errors are pre-existing)
- [x] Lint: clean on changed files
- [x] Knip: no new dead-code findings
- [ ] On a board with a cluster-only team: select that team's project scope — board shows its tickets instead of zero

## Related Issues

- Fixes https://linear.app/coalesce-labs/issue/CTL-1603

## Changelog Entry

**feat(dev): fix board showing zero tickets for cluster-only teams (CTL-1603)**

`loadTeamRepoMap()` now delegates to `readClusterProjects()` (the CTL-1214 single source of truth) instead of reading only the Layer-1/L2 config files. Teams registered only in `cluster.json` — such as CTC (`catalyst-cloud`) — now resolve to their correct project key, so the board's scope filter matches their cards.

<!-- Linear automation guard (CTL-623/CTL-633): unlink sibling tickets so this PR does not drag their workflow status. -->
skip CTC-1234
skip CTL-1214
skip CTL-1595
skip CTL-623
skip CTL-633
