### PR TITLE
fix(dev): CTL-1605 — route worker-status labels through a terminal-aware chokepoint

### DIFF
--- a/plugins/dev/scripts/execution-core/label-guard.mjs
+++ b/plugins/dev/scripts/execution-core/label-guard.mjs
@@ -484,7 +484,26 @@ export function resolveAndApplyWorkerStatusLabel(
     } else {
       try {
         const res = writeStatus?.removeLabel?.(ticket, label);
-        if (res == null || res?.removed !== false) fire();
+        // undefined (sync test stub) → success; else require removed !== false.
+        // Mirror clearStalledLabel / convergeHeldLabel: the production removeLabel
+        // is async, so fire onTerminalCleared when the write RESOLVES (post-tick),
+        // never eagerly off the Promise object (which would emit a false clear
+        // transition before a rejected/failed removal — audit-stream correctness).
+        const finalize = (r) => {
+          if (r == null || r?.removed !== false) fire();
+        };
+        if (res && typeof res.then === "function") {
+          res
+            .then(finalize)
+            .catch((err) =>
+              log.warn(
+                { ticket, label, err: err?.message },
+                "resolveAndApplyWorkerStatusLabel: removeLabel rejected — continuing"
+              )
+            );
+        } else {
+          finalize(res);
+        }
       } catch (err) {
         log.warn(
           { ticket, label, err: err?.message },

--- a/plugins/dev/scripts/execution-core/label-guard.mjs
+++ b/plugins/dev/scripts/execution-core/label-guard.mjs
@@ -411,6 +411,108 @@ export function labelNeedsHumanUnlessBeliefOwner(
   return applied;
 }
 
+// ─── CTL-1605: the worker-status label group (Axis 2) — single source of truth. ───
+// Precedence lives in worker-disposition.mjs; this is the flat membership set the
+// terminal chokepoint clears. Includes the legacy "waiting" so a terminal ticket
+// still wearing it is drained too.
+export const WORKER_STATUS_LABELS = Object.freeze([
+  "needs-human",
+  "needs-input",
+  "blocked",
+  "queued",
+  "waiting",
+]);
+
+// resolveAndApplyWorkerStatusLabel — the ONE terminal-aware chokepoint every
+// worker-status apply site routes through (CTL-1605). It reads live Linear Status
+// via the injected `isTerminal` probe (isTicketTerminalOrMerged in production —
+// fail-safe NOT-terminal, never throws). If the ticket is terminal it removes every
+// worker-status label present on the ticket and calls the injected `evictWorkerDir`
+// seam (guarded, live-session-safe — Phase 3), then returns { terminal:true } WITHOUT
+// applying `desired`. Otherwise it invokes the caller's existing `applyDesired`
+// closure (labelOnce / convergeHeldLabel / clearStalledLabel) unchanged and returns
+// { terminal:false }. All effects are seams → pure/leaf, fully unit-testable.
+//
+// `needs-human` is cleared through clearStalledLabel (re-arms markers + CTL-1078
+// backoff); the held labels through writeStatus.removeLabel. `onTerminalCleared(label)`
+// fires per label so the caller can recordTransition the clear.
+export function resolveAndApplyWorkerStatusLabel(
+  orchDir,
+  ticket,
+  {
+    desired = null,
+    currentLabels = [],
+    isTerminal,
+    writeStatus,
+    evictWorkerDir = null,
+    applyDesired = null,
+    onTerminalCleared = null,
+    now = () => Date.now(),
+  } = {}
+) {
+  // `desired` is a caller intent marker (which label WOULD be applied on the
+  // non-terminal path); the apply itself is owned by the caller's applyDesired
+  // closure, so we only read it for clarity — it is intentionally not used here.
+  void desired;
+  let verdict = { terminal: false };
+  try {
+    if (typeof isTerminal === "function") verdict = isTerminal(ticket) ?? { terminal: false };
+  } catch (err) {
+    // Fail-safe NOT-terminal — a throw must never manufacture a terminal verdict
+    // (mirrors isTicketTerminalOrMerged). Caller proceeds with its normal apply.
+    log.warn(
+      { ticket, err: err?.message },
+      "resolveAndApplyWorkerStatusLabel: isTerminal threw — treating NOT-terminal"
+    );
+    verdict = { terminal: false };
+  }
+
+  if (!verdict?.terminal) {
+    if (typeof applyDesired === "function") applyDesired();
+    return { terminal: false };
+  }
+
+  // Terminal: refuse the write. Clear every worker-status label present, then evict.
+  const present = new Set(currentLabels ?? []);
+  for (const label of WORKER_STATUS_LABELS) {
+    if (!present.has(label)) continue; // steady-state zero-write on a clean terminal ticket
+    const fire = () => {
+      if (typeof onTerminalCleared === "function") onTerminalCleared(label);
+    };
+    if (label === "needs-human") {
+      clearStalledLabel(orchDir, ticket, label, writeStatus, { onRemoved: fire, now });
+    } else {
+      try {
+        const res = writeStatus?.removeLabel?.(ticket, label);
+        if (res == null || res?.removed !== false) fire();
+      } catch (err) {
+        log.warn(
+          { ticket, label, err: err?.message },
+          "resolveAndApplyWorkerStatusLabel: removeLabel threw — continuing"
+        );
+      }
+    }
+  }
+
+  let evicted = false;
+  if (typeof evictWorkerDir === "function") {
+    try {
+      evicted = evictWorkerDir(ticket) === true;
+    } catch (err) {
+      log.warn(
+        { ticket, err: err?.message },
+        "resolveAndApplyWorkerStatusLabel: evict threw — continuing"
+      );
+    }
+  }
+  return {
+    terminal: true,
+    reason: verdict.reason ?? "linear-terminal",
+    state: verdict.state ?? null,
+    evicted,
+  };
+}
+
 export function recordEscalation(orchDir, ticket, phase, reason, now) {
   const dir = join(orchDir, ".escalation-cooldowns");
   try {

--- a/plugins/dev/scripts/execution-core/label-guard.mjs
+++ b/plugins/dev/scripts/execution-core/label-guard.mjs
@@ -19,6 +19,7 @@
 import { existsSync, mkdirSync, readFileSync, unlinkSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { log } from "./config.mjs";
+import { DISPOSITIONS } from "./worker-disposition.mjs";
 
 // ─── labelOnce — moved from scheduler.mjs (CTL-585, then CTL-638 re-home) ───
 //
@@ -146,16 +147,37 @@ export function labelOnce(
 // After REMOVAL_ESCALATION_THRESHOLD consecutive failures, activates a back-off
 // window (inRemovalBackoff) that short-circuits before calling removeLabel — the
 // storm-break. Escalates once with a log.error on the threshold trip.
+//
+// CTL-1605: accepts optional `onSettled(confirmed)` — fired EXACTLY ONCE per call
+// with the CONFIRMED removal outcome, on every exit path (backoff-skip, sync
+// success/failure, async resolve, async reject, sync throw). Unlike `onRemoved`
+// (which only fires on a confirmed removal, for marker/transition bookkeeping),
+// `onSettled` always fires so a caller can aggregate "did this removal land"
+// across several labels without inferring absence-of-call as failure — see
+// resolveAndApplyWorkerStatusLabel's eviction gate below. Never throws.
 export function clearStalledLabel(
   orchDir,
   ticket,
   label,
   writeStatus,
-  { onRemoved = null, now = () => Date.now() } = {}
+  { onRemoved = null, onSettled = null, now = () => Date.now() } = {}
 ) {
   const base = labelMarkerBase(orchDir, ticket, label);
+  const settle = (confirmed) => {
+    if (typeof onSettled === "function") {
+      try {
+        onSettled(confirmed);
+      } catch (err) {
+        log.warn(
+          { ticket, label, err: err?.message },
+          "clearStalledLabel: onSettled threw — continuing"
+        );
+      }
+    }
+  };
   // CTL-1078: guard at entry — if we're in backoff, skip the doomed removeLabel.
   if (inRemovalBackoff(orchDir, ticket, label, now())) {
+    settle(false); // backoff-skip is NOT a confirmed removal
     return;
   }
   try {
@@ -188,6 +210,7 @@ export function clearStalledLabel(
             );
           }
         }
+        settle(true);
       } else if (r?.removed === false) {
         // CTL-1078: record failure and escalate once at threshold.
         const { count } = recordRemovalFailure(orchDir, ticket, label, r.reason, now());
@@ -197,22 +220,27 @@ export function clearStalledLabel(
             "clearStalledLabel: removal failed threshold times — entering back-off (CTL-1078)"
           );
         }
+        settle(false);
+      } else {
+        settle(false);
       }
     };
     if (res && typeof res.then === "function") {
       res
         .then(finalize)
-        .catch((err) =>
+        .catch((err) => {
           log.warn(
             { ticket, label, err: err?.message },
             "clearStalledLabel: removeLabel rejected — continuing"
-          )
-        );
+          );
+          settle(false);
+        });
     } else {
       finalize(res);
     }
   } catch (err) {
     log.warn({ ticket, label, err: err.message }, "clearStalledLabel: threw — continuing tick");
+    settle(false);
   }
 }
 
@@ -412,16 +440,12 @@ export function labelNeedsHumanUnlessBeliefOwner(
 }
 
 // ─── CTL-1605: the worker-status label group (Axis 2) — single source of truth. ───
-// Precedence lives in worker-disposition.mjs; this is the flat membership set the
-// terminal chokepoint clears. Includes the legacy "waiting" so a terminal ticket
-// still wearing it is drained too.
-export const WORKER_STATUS_LABELS = Object.freeze([
-  "needs-human",
-  "needs-input",
-  "blocked",
-  "queued",
-  "waiting",
-]);
+// Membership DERIVES from worker-disposition.mjs's canonical DISPOSITIONS (its
+// header contract: "Import constants and functions from this module; never
+// instantiate them elsewhere"), plus the legacy "waiting" so a terminal ticket
+// still wearing it is drained too. worker-disposition.mjs is a pure leaf, so
+// this import creates no cycle.
+export const WORKER_STATUS_LABELS = Object.freeze([...DISPOSITIONS, "waiting"]);
 
 // resolveAndApplyWorkerStatusLabel — the ONE terminal-aware chokepoint every
 // worker-status apply site routes through (CTL-1605). It reads live Linear Status
@@ -434,8 +458,17 @@ export const WORKER_STATUS_LABELS = Object.freeze([
 // { terminal:false }. All effects are seams → pure/leaf, fully unit-testable.
 //
 // `needs-human` is cleared through clearStalledLabel (re-arms markers + CTL-1078
-// backoff); the held labels through writeStatus.removeLabel. `onTerminalCleared(label)`
-// fires per label so the caller can recordTransition the clear.
+// backoff); the held labels through writeStatus.removeLabel. `onTerminalCleared(arg)`
+// fires EXACTLY ONCE per call — after every present label's removal has settled,
+// the same aggregation point that gates eviction (CTL-1605 Codex thread,
+// scheduler.mjs:5518) — not once per label. A per-label firing let a single
+// confirmed removal on a multi-label ticket (e.g. "blocked") report a clear even
+// when a sibling label (e.g. the sticky "needs-human") was backoff-skipped or
+// failed to confirm, falsely telling the caller the ticket's disposition was
+// clear while a worker-status label was still live on Linear. `arg` is `null`
+// when every present label confirmed removed, or the highest-precedence
+// surviving label (DISPOSITIONS order; legacy "waiting" ranks last, since it
+// carries no precedence of its own) otherwise.
 export function resolveAndApplyWorkerStatusLabel(
   orchDir,
   ticket,
@@ -472,35 +505,79 @@ export function resolveAndApplyWorkerStatusLabel(
     return { terminal: false };
   }
 
-  // Terminal: refuse the write. Clear every worker-status label present, then evict.
+  // Terminal: refuse the write. Clear every worker-status label present, then evict
+  // — but ONLY once every present label's removal is CONFIRMED (CTL-1605 finding:
+  // evicting on the mere ISSUING of async removals destroys the only retry record,
+  // since STEP A / J3 / J4 all key their candidate sets off workers/<T>/ existing on
+  // disk). Each present label contributes a {settled, confirmed} outcome, tracked
+  // synchronously when the underlying write resolves synchronously (the common sync
+  // test-stub / already-settled-promise-free case) and asynchronously otherwise.
   const present = new Set(currentLabels ?? []);
+  const outcomes = []; // [{ label, settled: boolean, confirmed: boolean, promise: Promise<boolean> }]
+  const evictOnce = () => {
+    if (typeof evictWorkerDir !== "function") return false;
+    try {
+      return evictWorkerDir(ticket) === true;
+    } catch (err) {
+      log.warn(
+        { ticket, err: err?.message },
+        "resolveAndApplyWorkerStatusLabel: evict threw — continuing"
+      );
+      return false;
+    }
+  };
+  // rankOf / fireTerminalCleared — the single aggregation point for
+  // onTerminalCleared (see the header comment above). Only called once every
+  // present label's outcome has settled, and only when at least one label was
+  // present (mirrors the old per-label loop's zero-iteration no-op on a clean
+  // terminal ticket — nothing to report, nothing fires).
+  const rankOf = (label) => {
+    const idx = DISPOSITIONS.indexOf(label);
+    return idx === -1 ? DISPOSITIONS.length : idx; // legacy "waiting" ranks last
+  };
+  const fireTerminalCleared = () => {
+    if (outcomes.length === 0) return;
+    if (typeof onTerminalCleared !== "function") return;
+    const survivors = outcomes.filter((o) => !o.confirmed).map((o) => o.label);
+    const arg =
+      survivors.length === 0
+        ? null
+        : survivors.reduce((best, label) => (rankOf(label) < rankOf(best) ? label : best));
+    onTerminalCleared(arg);
+  };
   for (const label of WORKER_STATUS_LABELS) {
     if (!present.has(label)) continue; // steady-state zero-write on a clean terminal ticket
-    const fire = () => {
-      if (typeof onTerminalCleared === "function") onTerminalCleared(label);
+    const outcome = { label, settled: false, confirmed: false, promise: null };
+    outcomes.push(outcome);
+    let resolveOutcome;
+    outcome.promise = new Promise((resolve) => {
+      resolveOutcome = resolve;
+    });
+    const settle = (confirmed) => {
+      outcome.settled = true;
+      outcome.confirmed = confirmed;
+      resolveOutcome(confirmed);
     };
     if (label === "needs-human") {
-      clearStalledLabel(orchDir, ticket, label, writeStatus, { onRemoved: fire, now });
+      clearStalledLabel(orchDir, ticket, label, writeStatus, { onSettled: settle, now });
     } else {
       try {
         const res = writeStatus?.removeLabel?.(ticket, label);
         // undefined (sync test stub) → success; else require removed !== false.
-        // Mirror clearStalledLabel / convergeHeldLabel: the production removeLabel
-        // is async, so fire onTerminalCleared when the write RESOLVES (post-tick),
-        // never eagerly off the Promise object (which would emit a false clear
-        // transition before a rejected/failed removal — audit-stream correctness).
         const finalize = (r) => {
-          if (r == null || r?.removed !== false) fire();
+          const confirmed = r == null || r?.removed !== false;
+          settle(confirmed);
         };
         if (res && typeof res.then === "function") {
           res
             .then(finalize)
-            .catch((err) =>
+            .catch((err) => {
               log.warn(
                 { ticket, label, err: err?.message },
                 "resolveAndApplyWorkerStatusLabel: removeLabel rejected — continuing"
-              )
-            );
+              );
+              settle(false);
+            });
         } else {
           finalize(res);
         }
@@ -509,20 +586,27 @@ export function resolveAndApplyWorkerStatusLabel(
           { ticket, label, err: err?.message },
           "resolveAndApplyWorkerStatusLabel: removeLabel threw — continuing"
         );
+        settle(false);
       }
     }
   }
 
+  // Every outcome settled synchronously (the sync test-stub / no-present-labels
+  // case) → evict (or not) and fire the aggregate callback in THIS tick,
+  // preserving the prior synchronous contract. Any outcome still pending (a
+  // real async removeLabel) → defer BOTH to the aggregated resolution; the
+  // worker dir stays put — and thus retryable by STEP A / J3 / J4 — until every
+  // present label has settled.
+  const allSettled = outcomes.every((o) => o.settled);
   let evicted = false;
-  if (typeof evictWorkerDir === "function") {
-    try {
-      evicted = evictWorkerDir(ticket) === true;
-    } catch (err) {
-      log.warn(
-        { ticket, err: err?.message },
-        "resolveAndApplyWorkerStatusLabel: evict threw — continuing"
-      );
-    }
+  if (allSettled) {
+    if (outcomes.every((o) => o.confirmed)) evicted = evictOnce();
+    fireTerminalCleared();
+  } else {
+    Promise.all(outcomes.map((o) => o.promise)).then((results) => {
+      if (results.every(Boolean)) evictOnce();
+      fireTerminalCleared();
+    });
   }
   return {
     terminal: true,

--- a/plugins/dev/scripts/execution-core/label-guard.test.mjs
+++ b/plugins/dev/scripts/execution-core/label-guard.test.mjs
@@ -992,7 +992,13 @@ describe("resolveAndApplyWorkerStatusLabel", () => {
     expect(applyDesired).toHaveBeenCalledTimes(1);
   });
 
-  test("terminal clear fires onTerminalCleared per removed label", () => {
+  // ─── CTL-1605 Codex thread (scheduler.mjs:5518) — onTerminalCleared now fires
+  // EXACTLY ONCE per call with the AGGREGATE outcome across every present
+  // worker-status label, never once per label. The old per-label firing let a
+  // single confirmed removal on a multi-label ticket report a clear even when a
+  // sibling label (e.g. the sticky needs-human) never confirmed removal. ───
+
+  test("terminal clear, all present labels confirm → onTerminalCleared fires ONCE with null", () => {
     const cleared = [];
     resolveAndApplyWorkerStatusLabel(orchDir, "CTL-13", {
       desired: null,
@@ -1000,13 +1006,27 @@ describe("resolveAndApplyWorkerStatusLabel", () => {
       isTerminal: () => ({ terminal: true, state: "Done" }),
       writeStatus: { removeLabel: () => ({ removed: true }), applyLabel: mock(() => {}) },
       evictWorkerDir: () => true,
-      onTerminalCleared: (l) => cleared.push(l),
+      onTerminalCleared: (arg) => cleared.push(arg),
       applyDesired: mock(() => {}),
     });
-    expect(new Set(cleared)).toEqual(new Set(["queued", "needs-human"]));
+    expect(cleared).toEqual([null]);
   });
 
-  test("async removeLabel resolving removed:true → onTerminalCleared fires on resolve, not eagerly", async () => {
+  test("single label confirmed → onTerminalCleared fires ONCE with null (backward compat)", () => {
+    const cleared = [];
+    resolveAndApplyWorkerStatusLabel(orchDir, "CTL-13b", {
+      desired: null,
+      currentLabels: ["queued"],
+      isTerminal: () => ({ terminal: true, state: "Done" }),
+      writeStatus: { removeLabel: () => ({ removed: true }), applyLabel: mock(() => {}) },
+      evictWorkerDir: () => true,
+      onTerminalCleared: (arg) => cleared.push(arg),
+      applyDesired: mock(() => {}),
+    });
+    expect(cleared).toEqual([null]);
+  });
+
+  test("async removeLabel resolving removed:true → onTerminalCleared fires once on resolve, not eagerly", async () => {
     const cleared = [];
     resolveAndApplyWorkerStatusLabel(orchDir, "CTL-14", {
       desired: null,
@@ -1017,17 +1037,20 @@ describe("resolveAndApplyWorkerStatusLabel", () => {
         applyLabel: mock(() => {}),
       },
       evictWorkerDir: () => true,
-      onTerminalCleared: (l) => cleared.push(l),
+      onTerminalCleared: (arg) => cleared.push(arg),
       applyDesired: mock(() => {}),
     });
     // NOT fired synchronously off the Promise object.
     expect(cleared).toEqual([]);
+    // Extra hop vs the pre-fix version: the aggregate fire now runs off
+    // Promise.all(outcomes).then(...), one microtask hop past the per-label settle.
     await Promise.resolve();
     await Promise.resolve();
-    expect(cleared).toEqual(["blocked"]);
+    await Promise.resolve();
+    expect(cleared).toEqual([null]);
   });
 
-  test("async removeLabel resolving removed:false → onTerminalCleared NEVER fires (no false clear)", async () => {
+  test("async removeLabel resolving removed:false → onTerminalCleared fires once with the surviving label, never null", async () => {
     const cleared = [];
     resolveAndApplyWorkerStatusLabel(orchDir, "CTL-15", {
       desired: null,
@@ -1038,11 +1061,149 @@ describe("resolveAndApplyWorkerStatusLabel", () => {
         applyLabel: mock(() => {}),
       },
       evictWorkerDir: () => true,
-      onTerminalCleared: (l) => cleared.push(l),
+      onTerminalCleared: (arg) => cleared.push(arg),
       applyDesired: mock(() => {}),
     });
     await Promise.resolve();
     await Promise.resolve();
-    expect(cleared).toEqual([]);
+    await Promise.resolve();
+    expect(cleared).toEqual(["blocked"]);
+  });
+
+  test("multi-label ticket, needs-human backoff-skipped + blocked confirmed → onTerminalCleared fires ONCE with \"needs-human\", never null", () => {
+    const workerDir = join(orchDir, "workers", "CTL-13c");
+    mkdirSync(workerDir, { recursive: true });
+    const now = 5_000_000;
+    const THRESHOLD = Number(process.env.REMOVAL_ESCALATION_THRESHOLD) || 3;
+    for (let i = 0; i < THRESHOLD; i++) {
+      recordRemovalFailure(orchDir, "CTL-13c", "needs-human", "auth-error", now);
+    }
+    const cleared = [];
+    resolveAndApplyWorkerStatusLabel(orchDir, "CTL-13c", {
+      desired: null,
+      // DISPOSITIONS precedence order is needs-human, needs-input, blocked, queued —
+      // "blocked" outranks "needs-human" numerically LOWER index wins (needs-human is
+      // index 0, the highest precedence), so with needs-human surviving it must win
+      // over blocked as the reported survivor regardless of iteration order.
+      currentLabels: ["blocked", "needs-human"],
+      isTerminal: () => ({ terminal: true, state: "Done" }),
+      writeStatus: {
+        removeLabel: (t, l) => (l === "blocked" ? { removed: true } : { removed: true }),
+        applyLabel: mock(() => {}),
+      },
+      evictWorkerDir: () => true,
+      onTerminalCleared: (arg) => cleared.push(arg),
+      applyDesired: mock(() => {}),
+      now: () => now,
+    });
+    // needs-human is in CTL-1078 backoff → its removal is skipped (unconfirmed);
+    // blocked confirms. Aggregate must report the surviving "needs-human", never null.
+    expect(cleared).toEqual(["needs-human"]);
+  });
+
+  // ─── CTL-1605 review finding (label-guard.mjs:519) — eviction gated on
+  // CONFIRMED removal of every present label, not merely on the removals being
+  // ISSUED. Retry-loss: STEP A / J3 / J4 all key their candidate sets off
+  // workers/<T>/ existing on disk — evicting on an unconfirmed/failed removal
+  // destroys the only retry record and strands the stale Linear label forever. ───
+
+  test("async removals ALL confirmed → evict is DEFERRED past the call (not synchronous) then fires once settled", async () => {
+    let resolveBlocked, resolveQueued;
+    const evicted = [];
+    const res = resolveAndApplyWorkerStatusLabel(orchDir, "CTL-16", {
+      desired: null,
+      currentLabels: ["blocked", "queued"],
+      isTerminal: () => ({ terminal: true, state: "Done" }),
+      writeStatus: {
+        removeLabel: (t, l) =>
+          l === "blocked"
+            ? new Promise((r) => { resolveBlocked = r; })
+            : new Promise((r) => { resolveQueued = r; }),
+        applyLabel: mock(() => {}),
+      },
+      evictWorkerDir: (t) => { evicted.push(t); return true; },
+      applyDesired: mock(() => {}),
+    });
+    // Not every present label settled synchronously → evict cannot be decided yet.
+    expect(res.evicted).toBe(false);
+    expect(evicted).toEqual([]);
+    resolveBlocked({ removed: true });
+    resolveQueued({ removed: true });
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+    // Only NOW — once every present label's removal is CONFIRMED — does eviction fire.
+    expect(evicted).toEqual(["CTL-16"]);
+  });
+
+  test("async removals where ONE fails (removed:false) → evict NEVER fires, even after all settle", async () => {
+    const evicted = [];
+    resolveAndApplyWorkerStatusLabel(orchDir, "CTL-17", {
+      desired: null,
+      currentLabels: ["blocked", "queued"],
+      isTerminal: () => ({ terminal: true, state: "Done" }),
+      writeStatus: {
+        removeLabel: (t, l) =>
+          l === "blocked"
+            ? Promise.resolve({ removed: true })
+            : Promise.resolve({ removed: false, reason: "rate-limited" }),
+        applyLabel: mock(() => {}),
+      },
+      evictWorkerDir: (t) => { evicted.push(t); return true; },
+      applyDesired: mock(() => {}),
+    });
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+    // One label never confirmed removed → the worker dir stays (the only retry
+    // record for the still-attached label) instead of being evicted underneath it.
+    expect(evicted).toEqual([]);
+  });
+
+  test("sync removals where ONE fails (removed:false) → evict withheld synchronously (evicted:false)", () => {
+    const evicted = [];
+    const res = resolveAndApplyWorkerStatusLabel(orchDir, "CTL-18", {
+      desired: null,
+      currentLabels: ["blocked", "queued"],
+      isTerminal: () => ({ terminal: true, state: "Done" }),
+      writeStatus: {
+        removeLabel: (t, l) => (l === "blocked" ? { removed: true } : { removed: false, reason: "transient" }),
+        applyLabel: mock(() => {}),
+      },
+      evictWorkerDir: (t) => { evicted.push(t); return true; },
+      applyDesired: mock(() => {}),
+    });
+    expect(res.evicted).toBe(false);
+    expect(evicted).toEqual([]);
+  });
+
+  test("needs-human in CTL-1078 backoff (unconfirmed) → evict withheld even though the removal was never even attempted", () => {
+    const workerDir = join(orchDir, "workers", "CTL-19");
+    mkdirSync(workerDir, { recursive: true });
+    const now = 5_000_000;
+    // Drive clearStalledLabel's removal-failure counter to the backoff threshold.
+    const THRESHOLD = Number(process.env.REMOVAL_ESCALATION_THRESHOLD) || 3;
+    for (let i = 0; i < THRESHOLD; i++) {
+      recordRemovalFailure(orchDir, "CTL-19", "needs-human", "auth-error", now);
+    }
+    const evicted = [];
+    let removeLabelCalls = 0;
+    const res = resolveAndApplyWorkerStatusLabel(orchDir, "CTL-19", {
+      desired: null,
+      currentLabels: ["needs-human"],
+      isTerminal: () => ({ terminal: true, state: "Done" }),
+      writeStatus: {
+        removeLabel: () => { removeLabelCalls++; return { removed: true }; },
+        applyLabel: mock(() => {}),
+      },
+      evictWorkerDir: (t) => { evicted.push(t); return true; },
+      applyDesired: mock(() => {}),
+      now: () => now,
+    });
+    // Backoff short-circuits BEFORE removeLabel is ever called (CTL-1078 storm-break).
+    expect(removeLabelCalls).toBe(0);
+    // A backoff-skip is not a confirmed removal → evict must stay withheld.
+    expect(res.evicted).toBe(false);
+    expect(evicted).toEqual([]);
   });
 });

--- a/plugins/dev/scripts/execution-core/label-guard.test.mjs
+++ b/plugins/dev/scripts/execution-core/label-guard.test.mjs
@@ -1005,4 +1005,44 @@ describe("resolveAndApplyWorkerStatusLabel", () => {
     });
     expect(new Set(cleared)).toEqual(new Set(["queued", "needs-human"]));
   });
+
+  test("async removeLabel resolving removed:true → onTerminalCleared fires on resolve, not eagerly", async () => {
+    const cleared = [];
+    resolveAndApplyWorkerStatusLabel(orchDir, "CTL-14", {
+      desired: null,
+      currentLabels: ["blocked"],
+      isTerminal: () => ({ terminal: true, state: "Done" }),
+      writeStatus: {
+        removeLabel: () => Promise.resolve({ removed: true }),
+        applyLabel: mock(() => {}),
+      },
+      evictWorkerDir: () => true,
+      onTerminalCleared: (l) => cleared.push(l),
+      applyDesired: mock(() => {}),
+    });
+    // NOT fired synchronously off the Promise object.
+    expect(cleared).toEqual([]);
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(cleared).toEqual(["blocked"]);
+  });
+
+  test("async removeLabel resolving removed:false → onTerminalCleared NEVER fires (no false clear)", async () => {
+    const cleared = [];
+    resolveAndApplyWorkerStatusLabel(orchDir, "CTL-15", {
+      desired: null,
+      currentLabels: ["blocked"],
+      isTerminal: () => ({ terminal: true, state: "Done" }),
+      writeStatus: {
+        removeLabel: () => Promise.resolve({ removed: false, reason: "rate-limited" }),
+        applyLabel: mock(() => {}),
+      },
+      evictWorkerDir: () => true,
+      onTerminalCleared: (l) => cleared.push(l),
+      applyDesired: mock(() => {}),
+    });
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(cleared).toEqual([]);
+  });
 });

--- a/plugins/dev/scripts/execution-core/label-guard.test.mjs
+++ b/plugins/dev/scripts/execution-core/label-guard.test.mjs
@@ -2,7 +2,7 @@
 // escalation cool-down primitives (CTL-638). Run:
 //   cd plugins/dev/scripts/execution-core && bun test label-guard.test.mjs
 
-import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { describe, test, expect, beforeEach, afterEach, mock } from "bun:test";
 import { mkdtempSync, rmSync, mkdirSync, writeFileSync, existsSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -19,6 +19,8 @@ import {
   inRemovalBackoff,
   beliefOwnsNeedsHuman,
   labelNeedsHumanUnlessBeliefOwner,
+  resolveAndApplyWorkerStatusLabel,
+  WORKER_STATUS_LABELS,
 } from "./label-guard.mjs";
 
 let orchDir;
@@ -892,5 +894,115 @@ describe("labelNeedsHumanUnlessBeliefOwner (CTL-1241)", () => {
       log: { info: () => {} },
     });
     expect(wrote).toBe(true);
+  });
+});
+
+// ─── CTL-1605: terminal-aware worker-status chokepoint ───
+
+describe("resolveAndApplyWorkerStatusLabel", () => {
+  test("WORKER_STATUS_LABELS is the frozen group source-of-truth", () => {
+    expect(Object.isFrozen(WORKER_STATUS_LABELS)).toBe(true);
+    expect(new Set(WORKER_STATUS_LABELS)).toEqual(
+      new Set(["needs-human", "needs-input", "blocked", "queued", "waiting"])
+    );
+  });
+
+  test("terminal → clears every present label, evicts, no apply", () => {
+    const removed = [];
+    const evicted = [];
+    const applyDesired = mock(() => {});
+    const writeStatus = {
+      removeLabel: (t, l) => {
+        removed.push(l);
+        return { removed: true };
+      },
+      applyLabel: mock(() => {}),
+    };
+    const res = resolveAndApplyWorkerStatusLabel(orchDir, "CTL-9", {
+      desired: "blocked",
+      currentLabels: ["blocked", "needs-human"],
+      isTerminal: () => ({ terminal: true, reason: "linear-terminal", state: "Done" }),
+      writeStatus,
+      evictWorkerDir: (t) => {
+        evicted.push(t);
+        return true;
+      },
+      applyDesired,
+    });
+    expect(res).toMatchObject({ terminal: true, evicted: true });
+    expect(new Set(removed)).toEqual(new Set(["blocked", "needs-human"]));
+    expect(applyDesired).not.toHaveBeenCalled();
+    expect(evicted).toEqual(["CTL-9"]);
+    expect(writeStatus.applyLabel).not.toHaveBeenCalled();
+  });
+
+  test("non-terminal → invokes applyDesired, no clear, no evict", () => {
+    const applyDesired = mock(() => {});
+    const evict = mock(() => true);
+    const writeStatus = {
+      removeLabel: mock(() => ({ removed: true })),
+      applyLabel: mock(() => {}),
+    };
+    const res = resolveAndApplyWorkerStatusLabel(orchDir, "CTL-10", {
+      desired: "blocked",
+      currentLabels: [],
+      isTerminal: () => ({ terminal: false }),
+      writeStatus,
+      evictWorkerDir: evict,
+      applyDesired,
+    });
+    expect(res).toMatchObject({ terminal: false });
+    expect(applyDesired).toHaveBeenCalledTimes(1);
+    expect(evict).not.toHaveBeenCalled();
+    expect(writeStatus.removeLabel).not.toHaveBeenCalled();
+  });
+
+  test("terminal but no worker-status label present → evicts, zero removeLabel", () => {
+    const writeStatus = {
+      removeLabel: mock(() => ({ removed: true })),
+      applyLabel: mock(() => {}),
+    };
+    const evict = mock(() => true);
+    const res = resolveAndApplyWorkerStatusLabel(orchDir, "CTL-11", {
+      desired: null,
+      currentLabels: ["some-unrelated-label"],
+      isTerminal: () => ({ terminal: true, state: "Canceled" }),
+      writeStatus,
+      evictWorkerDir: evict,
+      applyDesired: mock(() => {}),
+    });
+    expect(res.terminal).toBe(true);
+    expect(writeStatus.removeLabel).not.toHaveBeenCalled();
+    expect(evict).toHaveBeenCalledTimes(1);
+  });
+
+  test("isTerminal throws → fail-safe NOT-terminal, applyDesired runs", () => {
+    const applyDesired = mock(() => {});
+    const res = resolveAndApplyWorkerStatusLabel(orchDir, "CTL-12", {
+      desired: "queued",
+      currentLabels: [],
+      isTerminal: () => {
+        throw new Error("linear 400");
+      },
+      writeStatus: { removeLabel: mock(() => ({ removed: true })), applyLabel: mock(() => {}) },
+      evictWorkerDir: mock(() => true),
+      applyDesired,
+    });
+    expect(res.terminal).toBe(false);
+    expect(applyDesired).toHaveBeenCalledTimes(1);
+  });
+
+  test("terminal clear fires onTerminalCleared per removed label", () => {
+    const cleared = [];
+    resolveAndApplyWorkerStatusLabel(orchDir, "CTL-13", {
+      desired: null,
+      currentLabels: ["queued", "needs-human"],
+      isTerminal: () => ({ terminal: true, state: "Done" }),
+      writeStatus: { removeLabel: () => ({ removed: true }), applyLabel: mock(() => {}) },
+      evictWorkerDir: () => true,
+      onTerminalCleared: (l) => cleared.push(l),
+      applyDesired: mock(() => {}),
+    });
+    expect(new Set(cleared)).toEqual(new Set(["queued", "needs-human"]));
   });
 });

--- a/plugins/dev/scripts/execution-core/scheduler.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.mjs
@@ -81,7 +81,7 @@ import {
   fetchTicketAssignee,
   isAssigneeClaimable,
   isClaimable,
-  readTicketLabels,
+  readTicketLabels as defaultReadTicketLabels,
   GATEWAY_EXISTS_FRESH_MS,
 } from "./linear-query.mjs";
 import { gatewayLabelsHit, descriptorAgeMs } from "./gateway-read.mjs"; // CTL-1079 / CTL-1570
@@ -98,7 +98,12 @@ import {
 } from "./signal-reader.mjs";
 // CTL-1410 Phase B: the in-process SDK worker registry — the liveness fact for
 // workers with no bg job (leaf module; a Map read, never a shell-out).
-import { isSdkWorkerLive as registrySdkWorkerLive } from "./sdk-worker-registry.mjs";
+// CTL-1605: isSdkWorkerLiveOnDisk is the cross-process disk-projection fence
+// (delegate-runner / codex-exec children) the fast-path evictor also consults.
+import {
+  isSdkWorkerLive as registrySdkWorkerLive,
+  isSdkWorkerLiveOnDisk,
+} from "./sdk-worker-registry.mjs";
 // CTL-933: shadow belief-store fact collector (opt-in CATALYST_BELIEFS_SHADOW=1).
 // CTL-937: getBeliefsDb exposes the module-level db handle for the diagnostician.
 // CTL-1241: getEscalateHumanBelief reads the latest escalate_human belief for the
@@ -340,7 +345,9 @@ import {
   clearStalledLabel,
   labelNeedsHumanUnlessBeliefOwner,
   resolveAndApplyWorkerStatusLabel,
+  WORKER_STATUS_LABELS,
 } from "./label-guard.mjs";
+import { DISPOSITIONS } from "./worker-disposition.mjs"; // CTL-1605: precedence order for the onTerminalCleared aggregate-arg → pre-clear `from` resolution
 import { processApprovedResumes } from "./boot-resume.mjs"; // CTL-644: per-tick approval poll
 import { countReapOutcomes } from "./reaper-metrics.mjs";
 import {
@@ -3598,6 +3605,11 @@ export function schedulerTick(
     // both hydrateOutOfSetBlockers calls. Defaults to the real batch helper;
     // tests inject a stub `(ids) => Map<id, descriptor>` so a tick never shells out.
     fetchBatch = fetchTicketsBatch,
+    // CTL-1605: single-ticket live label read seam — consulted by the STEP A
+    // terminal-stale branch (the batch-cached labels can trail the fresh-overlaid
+    // state; see the A.3.5 comment below) and by the retraction sweep's
+    // readLabels fallback. Injectable so tests never shell out to `linearis`.
+    readTicketLabels = defaultReadTicketLabels,
     // CTL-1605: guarded fast-path worker-dir eviction seam. STEP A routes a
     // Linear-terminal triaged-waiting ticket through resolveAndApplyWorkerStatusLabel,
     // which clears any stale worker-status label and calls this to evict the stale
@@ -5500,18 +5512,79 @@ export function schedulerTick(
       const liveTriagedWaiting = [];
       for (const ticket of triagedWaiting) {
         const rel = relByTicket.get(ticket) ?? null;
+        const staleTerminal = isLinearTerminal(rel?.state);
+        let currentLabels = rel?.labels ?? [];
+        let terminalConfirmed = staleTerminal;
+        if (staleTerminal) {
+          // CTL-1605 finding: rel.labels is the batch-cached (≤TTL-stale) label
+          // set — getRelations (linear-cache.mjs) overlays a FRESH state onto the
+          // cached descriptor but leaves labels untouched, and no label-apply site
+          // invalidates the relations cache entry (only the durable blocked_by
+          // edge write does, see the cache?.invalidate?.(candidate) below). A tick
+          // that cached labels:[] before this run's own A.7 stamped blocked/queued,
+          // immediately followed by Linear going terminal, would otherwise see
+          // present=∅ here and silently evict without ever clearing the
+          // just-applied label (the same retry-loss class as the eviction-gating
+          // fix above). Refresh live before computing the present set — one read
+          // per terminal-stale ticket, rare and self-extinguishing (the ticket is
+          // evicted once cleared). A failed live read DEFERS entirely — this
+          // ticket is treated as NOT-terminal for this tick (same fail-safe
+          // discipline as an isTerminal() throw) rather than risk a false
+          // clear/evict off possibly-stale labels.
+          const live = readTicketLabels(ticket);
+          if (live.ok) {
+            currentLabels = live.labels;
+          } else {
+            terminalConfirmed = false;
+          }
+        }
         const res = resolveAndApplyWorkerStatusLabel(orchDir, ticket, {
           desired: null, // STEP A never APPLIES here; it only refuses + clears when terminal
-          currentLabels: rel?.labels ?? [],
+          currentLabels,
           isTerminal: () => ({
-            terminal: isLinearTerminal(rel?.state),
+            terminal: terminalConfirmed,
             reason: "linear-terminal",
             state: rel?.state,
           }),
           writeStatus,
           evictWorkerDir,
-          onTerminalCleared: (label) => {
-            const from = label === LEGACY_HELD_LABEL_WAITING ? HELD_LABEL_WAITING : label;
+          // CTL-1605 (Codex thread, scheduler.mjs:5518): resolveAndApplyWorkerStatusLabel
+          // fires this callback ONCE per call with the AGGREGATE outcome across every
+          // present worker-status label, not once per label — the old per-label firing
+          // let a single confirmed removal (e.g. "blocked") record a worker.transition
+          // {to:null} on a multi-label ticket even when a sibling removal (e.g. the
+          // sticky "needs-human") was backoff-skipped or resolved removed:false, so the
+          // event stream falsely claimed the ticket was disposition-clear while a
+          // worker-status label was still live on Linear.
+          //
+          // `survivor === null` → every present label confirmed removed: Linear is
+          // genuinely disposition-clear, so record the {to:null} transition.
+          // `fromDisposition` is the highest-precedence label that WAS present before
+          // this clear (DISPOSITIONS order; legacy "waiting" normalized to "queued"
+          // first) — preserving the old per-label call's intent of naming what got
+          // cleared, now computed over the whole pre-clear set instead of one label.
+          //
+          // `survivor` non-null → at least one present label (typically the sticky
+          // needs-human CTL-1078 backoff-skip) did NOT confirm removal: the disposition
+          // is NOT actually clear. Recording {to:null} here would be exactly the false
+          // "disposition-clear" event this fix exists to stop, so it's skipped. A
+          // {to:<survivor>} transition is skipped too — nothing transitioned TO
+          // survivor, it was already the ticket's live disposition and is untouched by
+          // this call, so emitting it would only be a same-value re-announcement that
+          // recordTransition's lastDispositionEmit only-on-change guard would dedup
+          // away in the steady state anyway. Not calling recordTransition is simpler
+          // and can't accidentally seed that guard's state with a misleading
+          // fromDisposition for a transition that never happened.
+          onTerminalCleared: (survivor) => {
+            if (survivor !== null) return;
+            const rank = (label) => {
+              const idx = DISPOSITIONS.indexOf(label);
+              return idx === -1 ? DISPOSITIONS.length : idx;
+            };
+            const from = currentLabels
+              .filter((label) => WORKER_STATUS_LABELS.includes(label))
+              .map((label) => (label === LEGACY_HELD_LABEL_WAITING ? HELD_LABEL_WAITING : label))
+              .reduce((best, label) => (best === null || rank(label) < rank(best) ? label : best), null);
             recordTransition({
               ticket,
               fromDisposition: from,
@@ -5603,6 +5676,13 @@ export function schedulerTick(
                   toDisposition: "needs-human",
                   source: "dependency-cycle",
                 });
+                // CTL-1605 finding: this write just changed `member`'s live label
+                // set; the relations cache entry hydrated earlier this tick (A.3)
+                // still carries the PRE-write labels. Drop it so the next tick's
+                // getRelations (including a future terminal-stale live-label read
+                // above) never serves the stale set — mirrors the durable
+                // blocked_by edge-write invalidation below.
+                cache?.invalidate?.(member);
               }
             } else {
               log.warn(
@@ -5648,10 +5728,14 @@ export function schedulerTick(
           // Cycle member → owned by needs-human (labelOnce above). Clear any
           // stale held label so it doesn't double-signal, and drop its held
           // emit-state so a future non-cycle hold re-emits.
-          convergeHeldLabel(ticket, labelsByTicket.get(ticket), null, writeStatus, {
+          const cycleClearWrites = convergeHeldLabel(ticket, labelsByTicket.get(ticket), null, writeStatus, {
             orchDir,
             now,
           });
+          // CTL-1605 finding: invalidate on a genuine write only — mirrors the
+          // durable blocked_by edge-write invalidation below and avoids evicting
+          // the relations cache on every steady-state (zero-write) tick.
+          if (cycleClearWrites > 0) cache?.invalidate?.(ticket);
           lastHeldEmitState.delete(ticket);
           // CTL-764 Phase 5: cycle member superseded by needs-human → clear disposition.
           recordTransition({ ticket, toDisposition: null, source: "cycle-member-clear" });
@@ -5700,7 +5784,7 @@ export function schedulerTick(
         // double-callback (a ticket wearing two stale held labels). Legacy "waiting"
         // normalizes to the canonical "queued" (finding 2) so the stream never carries
         // a fifth disposition value.
-        convergeHeldLabel(ticket, labelsByTicket.get(ticket), desired, writeStatus, {
+        const admissionHeldWrites = convergeHeldLabel(ticket, labelsByTicket.get(ticket), desired, writeStatus, {
           orchDir,
           now,
           onRemoveResult: (label, removed) => {
@@ -5714,6 +5798,13 @@ export function schedulerTick(
             });
           },
         });
+        // CTL-1605 finding: a genuine held-label apply/remove just changed this
+        // ticket's live label set — drop the relations cache entry so the next
+        // tick's getRelations (and any terminal-stale live-label read above)
+        // never serves the pre-write labels. Mirrors the durable blocked_by
+        // edge-write invalidation below; conditioned on writes>0 so a
+        // steady-state (zero-write) tick stays a true no-op.
+        if (admissionHeldWrites > 0) cache?.invalidate?.(ticket);
 
         if (desired) {
           // Only-on-state-change emission: skip if the same held class already
@@ -7597,26 +7688,39 @@ function runTick() {
       // CTL-1605: arm the guarded fast-path eviction seam for the STEP A terminal
       // short-circuit. Reuses the SAME warm agents snapshot + freshness + worktree
       // resolver the J4 census uses (never removes a dir whose worktree hosts a live
-      // session; defers when the snapshot is not fresh). Tests inject their own by
-      // calling schedulerTick({ evictWorkerDir }) directly (see the CTL-1605 STEP A
-      // tests); the `runningOpts.evictWorkerDir` read is a forward-compat hook (not
-      // wired through startScheduler today). A bare unit tick gets defaultNoEvict.
+      // session; defers when the snapshot is not fresh), plus the SDK worker
+      // registry fences (in-process, then cross-process disk projection) so a live
+      // bg_job_id-less worker is never evicted out from under itself. Tests inject
+      // their own by calling schedulerTick({ evictWorkerDir }) directly (see the
+      // CTL-1605 STEP A tests); the `runningOpts.evictWorkerDir` read is a
+      // forward-compat hook (not wired through startScheduler today). A bare unit
+      // tick gets defaultNoEvict.
+      //
+      // CTL-1605 finding: this is a per-call closure — NOT an IIFE evaluated once
+      // at options-assembly time — so getAgentsCached() is re-read at the MOMENT
+      // each ticket is evicted, not captured before the (synchronous, potentially
+      // long-running) tick's earlier passes run. A snapshot that goes stale between
+      // options-assembly and STEP A would otherwise be evicted against blind
+      // (violating the CTL-1315 "never evict blind" discipline the frozen
+      // `agentsFresh` value exists to enforce).
       evictWorkerDir:
         runningOpts.evictWorkerDir ??
-        (() => {
+        ((ticket) => {
           const agentsSnap = getAgentsCached();
           return makeEvictWorkerDir({
             orchDir: runningOpts.orchDir,
             agents: agentsSnap.agents,
             agentsFresh: agentsSnap.isFresh,
-            resolveWorktreePath: (ticket) => {
+            resolveWorktreePath: (t) => {
               for (const sig of readWorkerSignals(runningOpts.orchDir)) {
-                if (sig.ticket === ticket && sig.worktreePath) return sig.worktreePath;
+                if (sig.ticket === t && sig.worktreePath) return sig.worktreePath;
               }
               return null;
             },
-          });
-        })(),
+            isSdkWorkerLive: registrySdkWorkerLive,
+            isSdkWorkerLiveOnDisk: (t) => isSdkWorkerLiveOnDisk(runningOpts.orchDir, t),
+          })(ticket);
+        }),
       // CTL-764 Phase 5: the LIVE worker.transition emitter (Sink-3, feeding OTLP
       // Sink-4 via otel-forward). schedulerTick defaults this to null, so a bare
       // unit tick stays silent; production MUST thread the real emitter here or

--- a/plugins/dev/scripts/execution-core/scheduler.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.mjs
@@ -7597,8 +7597,10 @@ function runTick() {
       // CTL-1605: arm the guarded fast-path eviction seam for the STEP A terminal
       // short-circuit. Reuses the SAME warm agents snapshot + freshness + worktree
       // resolver the J4 census uses (never removes a dir whose worktree hosts a live
-      // session; defers when the snapshot is not fresh). A test may inject its own
-      // via startScheduler({ evictWorkerDir }); a bare unit tick gets defaultNoEvict.
+      // session; defers when the snapshot is not fresh). Tests inject their own by
+      // calling schedulerTick({ evictWorkerDir }) directly (see the CTL-1605 STEP A
+      // tests); the `runningOpts.evictWorkerDir` read is a forward-compat hook (not
+      // wired through startScheduler today). A bare unit tick gets defaultNoEvict.
       evictWorkerDir:
         runningOpts.evictWorkerDir ??
         (() => {

--- a/plugins/dev/scripts/execution-core/scheduler.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.mjs
@@ -231,6 +231,7 @@ import {
   defaultCollectStallClearCandidates, // CTL-1005 J3
   defaultCollectTerminalSignalGcCandidates, // CTL-1242 J4
   defaultGcTerminalSignals, // CTL-1242 J4
+  defaultNoEvict, // CTL-1605: guarded fast-path eviction seam default (no-op)
 } from "./stall-janitor.mjs";
 // CTL-1064: unstuck-sweep (Pass 0u) — throttled classify-then-act sweep for
 // the stalled/needs-human ticket backlog. Pure classifiers + action driver in
@@ -333,7 +334,12 @@ import { isLinearTerminal, isTicketTerminalOrMerged } from "./terminal-state.mjs
 // labelOnce here would force recovery.mjs → scheduler.mjs to import it, but
 // scheduler.mjs already imports reclaimDeadWorkIfPossible from recovery.mjs —
 // a cycle. label-guard.mjs is the leaf module both can import.
-import { labelOnce, clearStalledLabel, labelNeedsHumanUnlessBeliefOwner } from "./label-guard.mjs";
+import {
+  labelOnce,
+  clearStalledLabel,
+  labelNeedsHumanUnlessBeliefOwner,
+  resolveAndApplyWorkerStatusLabel,
+} from "./label-guard.mjs";
 import { processApprovedResumes } from "./boot-resume.mjs"; // CTL-644: per-tick approval poll
 import { countReapOutcomes } from "./reaper-metrics.mjs";
 import {
@@ -3591,6 +3597,13 @@ export function schedulerTick(
     // both hydrateOutOfSetBlockers calls. Defaults to the real batch helper;
     // tests inject a stub `(ids) => Map<id, descriptor>` so a tick never shells out.
     fetchBatch = fetchTicketsBatch,
+    // CTL-1605: guarded fast-path worker-dir eviction seam. STEP A routes a
+    // Linear-terminal triaged-waiting ticket through resolveAndApplyWorkerStatusLabel,
+    // which clears any stale worker-status label and calls this to evict the stale
+    // local worker dir. Default is defaultNoEvict (no-op returning false) so a bare
+    // unit tick / un-wired host never deletes anything; production wires the armed
+    // makeEvictWorkerDir (live-session-fenced) via runTick.
+    evictWorkerDir = defaultNoEvict,
     // CTL-755: held-indicator audit emitter — phase.advance.held.<ticket>.
     // Best-effort, only-on-state-change. Mirrors appendDispatchRequestedEvent.
     appendPhaseAdvanceHeldEvent = defaultAppendPhaseAdvanceHeldEvent,
@@ -5475,6 +5488,48 @@ export function schedulerTick(
       // pseudo-issue descriptors in the buildDependencyEdges shape (state
       // re-nested into {name} — the descriptor carries a flat string state).
       const relByTicket = fetchBatch(triagedWaiting, { cache });
+
+      // CTL-1605: terminal-stale short-circuit. A triaged-waiting ticket whose LIVE
+      // Linear state (from the A.3 batch — ZERO extra reads) is terminal is a stale
+      // local record (the CTL-1603 reproducer: triage:done + no research signal on a
+      // ticket another host already finished). Route it through the terminal-aware
+      // chokepoint — clear any stale worker-status label + evict the stale dir — and
+      // drop it from the admission pool BEFORE it can reach convergeHeldLabel (A.7)
+      // and be re-stamped blocked/queued. Non-terminal tickets pass through unchanged.
+      const liveTriagedWaiting = [];
+      for (const ticket of triagedWaiting) {
+        const rel = relByTicket.get(ticket) ?? null;
+        const res = resolveAndApplyWorkerStatusLabel(orchDir, ticket, {
+          desired: null, // STEP A never APPLIES here; it only refuses + clears when terminal
+          currentLabels: rel?.labels ?? [],
+          isTerminal: () => ({
+            terminal: isLinearTerminal(rel?.state),
+            reason: "linear-terminal",
+            state: rel?.state,
+          }),
+          writeStatus,
+          evictWorkerDir,
+          onTerminalCleared: (label) => {
+            const from = label === LEGACY_HELD_LABEL_WAITING ? HELD_LABEL_WAITING : label;
+            recordTransition({
+              ticket,
+              fromDisposition: from,
+              toDisposition: null,
+              source: "terminal-stale-evict",
+            });
+          },
+        });
+        if (res.terminal) {
+          lastHeldEmitState.delete(ticket); // drop stale held emit-state; dir is being evicted
+          continue; // do NOT let this ticket reach A.3 hydration / A.7 convergeHeldLabel
+        }
+        liveTriagedWaiting.push(ticket);
+      }
+      // Replace the working set for the remainder of STEP A (mutate in place — the
+      // existing A.3 loop and STEP E read the same `triagedWaiting` binding).
+      triagedWaiting.length = 0;
+      triagedWaiting.push(...liveTriagedWaiting);
+
       const waitingDescriptors = [];
       const labelsByTicket = new Map(); // ticket → current Linear label set
       const readFailedTickets = new Set(); // fail-safe: missing read → held

--- a/plugins/dev/scripts/execution-core/scheduler.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.mjs
@@ -232,6 +232,7 @@ import {
   defaultCollectTerminalSignalGcCandidates, // CTL-1242 J4
   defaultGcTerminalSignals, // CTL-1242 J4
   defaultNoEvict, // CTL-1605: guarded fast-path eviction seam default (no-op)
+  makeEvictWorkerDir, // CTL-1605: armed live-session-fenced eviction seam (runTick)
 } from "./stall-janitor.mjs";
 // CTL-1064: unstuck-sweep (Pass 0u) — throttled classify-then-act sweep for
 // the stalled/needs-human ticket backlog. Pure classifiers + action driver in
@@ -7593,6 +7594,27 @@ function runTick() {
       // tests inject a stub through startScheduler so a daemon tick never shells out.
       fetchBatch: runningOpts.fetchBatch,
       appendPhaseAdvanceHeldEvent: runningOpts.appendPhaseAdvanceHeldEvent,
+      // CTL-1605: arm the guarded fast-path eviction seam for the STEP A terminal
+      // short-circuit. Reuses the SAME warm agents snapshot + freshness + worktree
+      // resolver the J4 census uses (never removes a dir whose worktree hosts a live
+      // session; defers when the snapshot is not fresh). A test may inject its own
+      // via startScheduler({ evictWorkerDir }); a bare unit tick gets defaultNoEvict.
+      evictWorkerDir:
+        runningOpts.evictWorkerDir ??
+        (() => {
+          const agentsSnap = getAgentsCached();
+          return makeEvictWorkerDir({
+            orchDir: runningOpts.orchDir,
+            agents: agentsSnap.agents,
+            agentsFresh: agentsSnap.isFresh,
+            resolveWorktreePath: (ticket) => {
+              for (const sig of readWorkerSignals(runningOpts.orchDir)) {
+                if (sig.ticket === ticket && sig.worktreePath) return sig.worktreePath;
+              }
+              return null;
+            },
+          });
+        })(),
       // CTL-764 Phase 5: the LIVE worker.transition emitter (Sink-3, feeding OTLP
       // Sink-4 via otel-forward). schedulerTick defaults this to null, so a bare
       // unit tick stays silent; production MUST thread the real emitter here or

--- a/plugins/dev/scripts/execution-core/scheduler.test.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.test.mjs
@@ -97,6 +97,7 @@ import { ownerForTicket } from "./hrw.mjs"; // CTL-850: HRW owner computation fo
 import { REMEDIATE_CYCLE_CAP } from "../lib/phase-fsm.mjs";
 import { removeLabel as realRemoveLabel } from "./linear-write.mjs"; // CTL-1079: exec-spy harness
 import { bootResumePendingPath, bootResumeApprovedPath } from "./boot-resume.mjs"; // CTL-1367 P2-C: per-tick approval-poll dispatch wiring
+import { recordRemovalFailure } from "./label-guard.mjs"; // CTL-1605 Codex thread: drive needs-human into CTL-1078 backoff for the terminal-stale multi-label tests
 
 let orchDir;
 let catalystDir;
@@ -12901,6 +12902,11 @@ describe("CTL-1605: STEP A terminal-stale short-circuit", () => {
       fetchBatch: batchWith(() => relBlockedBy("CTL-DEP", { state: "Done", labels: ["queued"] }), {
         "CTL-DEP": "In Progress",
       }),
+      // CTL-1605: the terminal branch now refreshes labels LIVE instead of
+      // trusting the batch-cached set (see the scheduler-review regression
+      // describe block below for the staleness case this closes) — stub the
+      // live read so this test never shells out to `linearis`.
+      readTicketLabels: () => ({ ok: true, labels: ["queued"] }),
       evictWorkerDir: (t) => {
         evicted.push(t);
         return true;
@@ -12938,5 +12944,213 @@ describe("CTL-1605: STEP A terminal-stale short-circuit", () => {
     expect(applied).toContainEqual({ ticket: "CTL-10", label: "queued" });
     // A live ticket is never evicted.
     expect(evicted).toEqual([]);
+  });
+
+  // ─── CTL-1605 Codex thread (scheduler.mjs:5518) — onTerminalCleared now fires
+  // ONCE per ticket with the AGGREGATE outcome, so STEP A's worker.transition
+  // recording must not claim a multi-label ticket is disposition-clear unless
+  // EVERY present worker-status label actually confirmed removal. ───
+
+  test("multi-label terminal ticket, both labels confirm → ONE worker.transition to null (fromDisposition = highest-precedence pre-clear label)", () => {
+    writeFileSync(join(orchDir, "state.json"), JSON.stringify({ maxParallel: 2 }));
+    writeSignal("CTL-33", "triage", "done");
+    const dispatch = fakeDispatch();
+    const { ws, removed } = labelSpy();
+    const evicted = [];
+    const transitions = [];
+    schedulerTick(orchDir, {
+      readEligible: () => [],
+      dispatch,
+      writeStatus: ws,
+      verifyDispatched: verifyOk,
+      liveBackgroundCount: () => 0,
+      fetchBatch: batchWith(
+        () => relBlockedBy("CTL-DEP7", { state: "Done", labels: ["blocked", "needs-human"] }),
+        { "CTL-DEP7": "In Progress" }
+      ),
+      readTicketLabels: () => ({ ok: true, labels: ["blocked", "needs-human"] }),
+      evictWorkerDir: (t) => {
+        evicted.push(t);
+        return true;
+      },
+      appendWorkerTransitionEvent: (ev) => transitions.push(ev),
+    });
+    expect(removed).toContainEqual({ ticket: "CTL-33", label: "blocked" });
+    expect(removed).toContainEqual({ ticket: "CTL-33", label: "needs-human" });
+    expect(evicted).toContain("CTL-33");
+    const evictTransitions = transitions.filter(
+      (e) => e.ticket === "CTL-33" && e.source === "terminal-stale-evict"
+    );
+    // Exactly ONE aggregate transition, not one per cleared label.
+    expect(evictTransitions).toHaveLength(1);
+    expect(evictTransitions[0]).toMatchObject({ toDisposition: null, fromDisposition: "needs-human" });
+  });
+
+  test("multi-label terminal ticket, needs-human in CTL-1078 backoff (unconfirmed) + blocked confirmed → NO to:null worker.transition (false disposition-clear guarded)", () => {
+    writeFileSync(join(orchDir, "state.json"), JSON.stringify({ maxParallel: 2 }));
+    writeSignal("CTL-34", "triage", "done");
+    // Drive needs-human's removal-failure counter to the CTL-1078 backoff threshold
+    // so clearStalledLabel short-circuits BEFORE calling writeStatus.removeLabel.
+    const THRESHOLD = Number(process.env.REMOVAL_ESCALATION_THRESHOLD) || 3;
+    for (let i = 0; i < THRESHOLD; i++) {
+      recordRemovalFailure(orchDir, "CTL-34", "needs-human", "auth-error", Date.now());
+    }
+    const dispatch = fakeDispatch();
+    const { ws, removed } = labelSpy();
+    const evicted = [];
+    const transitions = [];
+    schedulerTick(orchDir, {
+      readEligible: () => [],
+      dispatch,
+      writeStatus: ws,
+      verifyDispatched: verifyOk,
+      liveBackgroundCount: () => 0,
+      fetchBatch: batchWith(
+        () => relBlockedBy("CTL-DEP8", { state: "Done", labels: ["blocked", "needs-human"] }),
+        { "CTL-DEP8": "In Progress" }
+      ),
+      readTicketLabels: () => ({ ok: true, labels: ["blocked", "needs-human"] }),
+      evictWorkerDir: (t) => {
+        evicted.push(t);
+        return true;
+      },
+      appendWorkerTransitionEvent: (ev) => transitions.push(ev),
+    });
+    // needs-human's removal was never even attempted (backoff-skip); blocked confirmed.
+    expect(removed).toContainEqual({ ticket: "CTL-34", label: "blocked" });
+    expect(removed.some((r) => r.ticket === "CTL-34" && r.label === "needs-human")).toBe(false);
+    // The sticky needs-human label survives on Linear → the worker dir must stay
+    // (not evicted out from under the only retry record for that label).
+    expect(evicted).toEqual([]);
+    // The false "disposition-clear" event this fix exists to stop must NEVER appear.
+    const falseClears = transitions.filter(
+      (e) => e.ticket === "CTL-34" && e.source === "terminal-stale-evict" && e.toDisposition === null
+    );
+    expect(falseClears).toEqual([]);
+  });
+});
+
+// ── CTL-1605 review findings — STEP A live-label refresh + relations-cache
+// invalidation (scheduler.mjs threads PRRT_kwDOP8GlQM6VyO1_ / :5885) ──
+describe("CTL-1605 review: STEP A terminal-stale live label refresh", () => {
+  afterEach(() => __resetForTests());
+
+  function labelSpy() {
+    const applied = [];
+    const removed = [];
+    const ws = {
+      applyPhaseStatus: () => {},
+      applyTerminalDone: () => {},
+      applyEstimate: () => ({ applied: true }),
+      applyLabel: (a) => {
+        applied.push(a);
+        return { applied: true, reason: null };
+      },
+      removeLabel: (ticket, label) => {
+        removed.push({ ticket, label });
+        return { removed: true };
+      },
+    };
+    return { ws, applied, removed };
+  }
+
+  test("terminal ticket with a STALE (empty) batch-cached label set → refreshes LIVE, clears the REAL held label", () => {
+    writeFileSync(join(orchDir, "state.json"), JSON.stringify({ maxParallel: 2 }));
+    writeSignal("CTL-30", "triage", "done");
+    const dispatch = fakeDispatch();
+    const { ws, applied, removed } = labelSpy();
+    const evicted = [];
+    let liveReadCalls = 0;
+    schedulerTick(orchDir, {
+      readEligible: () => [],
+      dispatch,
+      writeStatus: ws,
+      verifyDispatched: verifyOk,
+      liveBackgroundCount: () => 0,
+      // Batch-cached labels are EMPTY (the ≤TTL-stale snapshot) — without the
+      // fix STEP A would see present=∅ and evict without ever clearing the
+      // ticket's REAL "blocked" label.
+      fetchBatch: batchWith(() => relBlockedBy("CTL-DEP4", { state: "Done", labels: [] }), {
+        "CTL-DEP4": "In Progress",
+      }),
+      readTicketLabels: (t) => {
+        liveReadCalls++;
+        expect(t).toBe("CTL-30");
+        return { ok: true, labels: ["blocked"] };
+      },
+      evictWorkerDir: (t) => {
+        evicted.push(t);
+        return true;
+      },
+    });
+    expect(liveReadCalls).toBe(1);
+    // The clear used the LIVE label set, not the stale empty batch-cached one.
+    expect(removed).toContainEqual({ ticket: "CTL-30", label: "blocked" });
+    expect(applied.some((a) => a.ticket === "CTL-30")).toBe(false);
+    expect(evicted).toContain("CTL-30");
+  });
+
+  test("terminal ticket whose LIVE label read fails → DEFERS (no clear, no evict) instead of trusting stale/absent labels", () => {
+    writeFileSync(join(orchDir, "state.json"), JSON.stringify({ maxParallel: 2 }));
+    writeSignal("CTL-31", "triage", "done");
+    const dispatch = fakeDispatch();
+    const { ws, applied, removed } = labelSpy();
+    const evicted = [];
+    schedulerTick(orchDir, {
+      readEligible: () => [],
+      dispatch,
+      writeStatus: ws,
+      verifyDispatched: verifyOk,
+      liveBackgroundCount: () => 0,
+      fetchBatch: batchWith(() => relBlockedBy("CTL-DEP5", { state: "Done", labels: ["blocked"] }), {
+        "CTL-DEP5": "In Progress",
+      }),
+      readTicketLabels: () => ({ ok: false, labels: null, code: 1, stderr: "boom" }),
+      evictWorkerDir: (t) => {
+        evicted.push(t);
+        return true;
+      },
+    });
+    // Fail-safe: no clear was attempted off a read we couldn't trust, and the
+    // stale dir was never evicted out from under a possibly-still-attached label.
+    expect(removed.some((r) => r.ticket === "CTL-31")).toBe(false);
+    expect(evicted).toEqual([]);
+  });
+
+  test("a genuine held-label write during STEP A invalidates the relations cache entry (mirrors the blocked_by edge-write invalidation)", () => {
+    writeFileSync(join(orchDir, "state.json"), JSON.stringify({ maxParallel: 1 }));
+    writeSignal("CTL-32", "triage", "done");
+    const cache = createTicketStateCache({ now: () => 0, ttlMs: 60_000 });
+    const dispatch = fakeDispatch();
+    const { ws, applied } = labelSpy();
+    const fetchBatch = (ids, opts) =>
+      fetchTicketsBatch(ids, {
+        ...opts,
+        exec: (chunk) =>
+          chunk.map((id) => ({
+            identifier: id,
+            state: { name: "Todo" },
+            priority: 2,
+            labels: { nodes: [] },
+            relations: { nodes: [] },
+            inverseRelations: { nodes: [{ type: "blocks", issue: { identifier: "CTL-DEP6" } }] },
+          })),
+      });
+    schedulerTick(orchDir, {
+      readEligible: () => [],
+      dispatch,
+      writeStatus: ws,
+      verifyDispatched: verifyOk,
+      liveBackgroundCount: () => 0,
+      fetchBatch,
+      cache,
+    });
+    // The tick applied "blocked" (held by the unresolved CTL-DEP6 dependency) —
+    // a genuine write, not a steady-state no-op.
+    expect(applied).toContainEqual({ ticket: "CTL-32", label: "blocked" });
+    // The write invalidated the relations cache entry hydrated earlier THIS
+    // SAME tick, even though its TTL has not elapsed — a later hydrate must
+    // re-read fresh rather than serve the pre-write (unlabeled) descriptor.
+    expect(cache.getRelations("CTL-32")).toBeUndefined();
   });
 });

--- a/plugins/dev/scripts/execution-core/scheduler.test.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.test.mjs
@@ -12855,3 +12855,88 @@ describe("startScheduler — Phase 3 startup repair (CTL-1610)", () => {
     expect(typeof after.lastTs).toBe("number");
   });
 });
+
+// ── CTL-1605: terminal-stale worker-status short-circuit (STEP A) ──
+describe("CTL-1605: STEP A terminal-stale short-circuit", () => {
+  afterEach(() => __resetForTests());
+
+  // A writeStatus spy recording label add/remove (mirrors the admission-gate labelSpy).
+  function labelSpy() {
+    const applied = [];
+    const removed = [];
+    const ws = {
+      applyPhaseStatus: () => {},
+      applyTerminalDone: () => {},
+      applyEstimate: () => ({ applied: true }),
+      applyLabel: (a) => {
+        applied.push(a);
+        return { applied: true, reason: null };
+      },
+      removeLabel: (ticket, label) => {
+        removed.push({ ticket, label });
+        return { removed: true };
+      },
+    };
+    return { ws, applied, removed };
+  }
+
+  test("stale-local Done ticket in triagedWaiting → no blocked/queued applied, dir evicted", () => {
+    // The CTL-1603 stale record: triage:done, NO research signal. The candidate is
+    // blocked-by-an-open-dep and UNLABELED, so WITHOUT the fix STEP A would stamp
+    // "blocked" on a ticket that is already Done. It also wears a stale "queued"
+    // held label to prove the terminal clear fires.
+    writeFileSync(join(orchDir, "state.json"), JSON.stringify({ maxParallel: 2 }));
+    writeSignal("CTL-9", "triage", "done");
+    const dispatch = fakeDispatch();
+    const { ws, applied, removed } = labelSpy();
+    const evicted = [];
+    const r = schedulerTick(orchDir, {
+      readEligible: () => [],
+      dispatch,
+      writeStatus: ws,
+      verifyDispatched: verifyOk,
+      liveBackgroundCount: () => 0,
+      // A.3 batch: live TERMINAL state (Done), blocked by an open dep, wearing a
+      // stale "queued" label that the terminal clear must drain.
+      fetchBatch: batchWith(() => relBlockedBy("CTL-DEP", { state: "Done", labels: ["queued"] }), {
+        "CTL-DEP": "In Progress",
+      }),
+      evictWorkerDir: (t) => {
+        evicted.push(t);
+        return true;
+      },
+    });
+    // No held re-stamp — the terminal ticket never reaches convergeHeldLabel.
+    expect(applied.some((a) => a.label === "blocked" || a.label === "queued")).toBe(false);
+    // The stale held label is cleared and the worker dir is evicted.
+    expect(removed).toContainEqual({ ticket: "CTL-9", label: "queued" });
+    expect(evicted).toContain("CTL-9");
+    // Not promoted (dropped from the admission pool before STEP B).
+    expect(r.advanced).toEqual([]);
+    expect(dispatch.calls).toEqual([]);
+  });
+
+  test("non-terminal triagedWaiting ticket → unchanged (still converges 'queued'), no evict", () => {
+    writeFileSync(join(orchDir, "state.json"), JSON.stringify({ maxParallel: 1 }));
+    writeSignal("CTL-10", "triage", "done");
+    const dispatch = fakeDispatch();
+    const { ws, applied } = labelSpy();
+    const evicted = [];
+    schedulerTick(orchDir, {
+      readEligible: () => [],
+      dispatch,
+      writeStatus: ws,
+      verifyDispatched: verifyOk,
+      liveBackgroundCount: () => 1, // saturated → ready-but-unadmitted → "queued"
+      fetchBatch: mkBatch(() => relUnblocked({ state: "Todo" })),
+      evictWorkerDir: (t) => {
+        evicted.push(t);
+        return true;
+      },
+    });
+    // Behavior byte-for-byte as before this change: capacity hold converges "queued".
+    expect(applied).toContainEqual({ ticket: "CTL-10", label: "queued" });
+    // A live ticket is never evicted.
+    expect(evicted).toEqual([]);
+  });
+});

--- a/plugins/dev/scripts/execution-core/stall-janitor.mjs
+++ b/plugins/dev/scripts/execution-core/stall-janitor.mjs
@@ -506,24 +506,37 @@ export const defaultNoEvict = () => false;
 // the STEP A terminal short-circuit (resolveAndApplyWorkerStatusLabel). Mirrors the
 // J4 census fences (classifyTerminalSignalGc + the agentsFresh bail): never remove
 // a dir whose worktree hosts a live session, and never evict when the liveness
-// snapshot is not fresh (defer to a trustworthy tick). Best-effort rmSync — never
-// throws. A no-op default (defaultNoEvict) protects any un-wired caller.
+// snapshot is not fresh (defer to a trustworthy tick). Also consults the SDK
+// worker registry (in-process, then the cross-process disk projection) BEFORE the
+// agents-roster fence — an in-process SDK/codex-exec worker has bg_job_id null and
+// is invisible to `claude agents`/the roster check (see sdk-worker-registry.mjs
+// header), so without this a live in-process worker's signal dir is deletable the
+// moment Linear goes terminal. Best-effort rmSync — never throws. A no-op default
+// (defaultNoEvict) protects any un-wired caller.
 export function makeEvictWorkerDir({
   orchDir,
   agents = [],
   agentsFresh = true,
   resolveWorktreePath = () => null,
+  isSdkWorkerLive = () => false,
+  isSdkWorkerLiveOnDisk = () => false,
 }) {
   return (ticket) => {
     if (!agentsFresh) return false; // never evict blind (CTL-1315 discipline)
+    if (isSdkWorkerLive(ticket) || isSdkWorkerLiveOnDisk(ticket)) return false; // live in-process/cross-process SDK worker owns this dir
     let worktreePath = null;
     try {
       worktreePath = resolveWorktreePath(ticket);
     } catch {
       /* conservative — treat as unresolved */
     }
+    // CTL-1605 finding: an unresolved worktree path (missing/pre-CTL-615 signal,
+    // or a resolver throw above) must DEFER, not fail open — the live-session
+    // probe below can only clear a ticket it can actually evaluate. The J4 census
+    // stays the slow backstop for a dir that never resolves a worktree.
+    if (!worktreePath) return false;
     const liveSession =
-      !!worktreePath && Array.isArray(agents) && agents.some((a) => cwdUnder(a?.cwd, worktreePath));
+      Array.isArray(agents) && agents.some((a) => cwdUnder(a?.cwd, worktreePath));
     if (liveSession) return false; // a live worker owns this dir
     try {
       rmSync(join(orchDir, "workers", ticket), { recursive: true, force: true });

--- a/plugins/dev/scripts/execution-core/stall-janitor.mjs
+++ b/plugins/dev/scripts/execution-core/stall-janitor.mjs
@@ -494,6 +494,15 @@ function cwdUnder(cwd, root) {
   return c === r || c.startsWith(r + "/");
 }
 
+// ─── CTL-1605: guarded fast-path worker-dir eviction seam ───
+//
+// Safe default consumed by bare unit ticks / un-wired callers: a no-op that
+// removes nothing and reports "did not evict". The armed factory is
+// makeEvictWorkerDir (added in Phase 3); until a caller injects that, the
+// terminal short-circuit clears the label but leaves the dir (the J4 census
+// stays the slow backstop).
+export const defaultNoEvict = () => false;
+
 // defaultCollectOrphanCandidates — enumerate every ticket whose pipeline reached
 // terminal Done (the .terminal-done.applied marker) and build the J1 classify ctx
 // from read-only probes. `projects` supplies [{team, repoRoot}] for the worktree

--- a/plugins/dev/scripts/execution-core/stall-janitor.mjs
+++ b/plugins/dev/scripts/execution-core/stall-janitor.mjs
@@ -497,11 +497,43 @@ function cwdUnder(cwd, root) {
 // ─── CTL-1605: guarded fast-path worker-dir eviction seam ───
 //
 // Safe default consumed by bare unit ticks / un-wired callers: a no-op that
-// removes nothing and reports "did not evict". The armed factory is
-// makeEvictWorkerDir (added in Phase 3); until a caller injects that, the
-// terminal short-circuit clears the label but leaves the dir (the J4 census
-// stays the slow backstop).
+// removes nothing and reports "did not evict". Until a caller injects the armed
+// makeEvictWorkerDir factory below, the terminal short-circuit clears the label
+// but leaves the dir (the J4 census stays the slow backstop).
 export const defaultNoEvict = () => false;
+
+// makeEvictWorkerDir (CTL-1605) — the guarded fast-path eviction seam consumed by
+// the STEP A terminal short-circuit (resolveAndApplyWorkerStatusLabel). Mirrors the
+// J4 census fences (classifyTerminalSignalGc + the agentsFresh bail): never remove
+// a dir whose worktree hosts a live session, and never evict when the liveness
+// snapshot is not fresh (defer to a trustworthy tick). Best-effort rmSync — never
+// throws. A no-op default (defaultNoEvict) protects any un-wired caller.
+export function makeEvictWorkerDir({
+  orchDir,
+  agents = [],
+  agentsFresh = true,
+  resolveWorktreePath = () => null,
+}) {
+  return (ticket) => {
+    if (!agentsFresh) return false; // never evict blind (CTL-1315 discipline)
+    let worktreePath = null;
+    try {
+      worktreePath = resolveWorktreePath(ticket);
+    } catch {
+      /* conservative — treat as unresolved */
+    }
+    const liveSession =
+      !!worktreePath && Array.isArray(agents) && agents.some((a) => cwdUnder(a?.cwd, worktreePath));
+    if (liveSession) return false; // a live worker owns this dir
+    try {
+      rmSync(join(orchDir, "workers", ticket), { recursive: true, force: true });
+      return true;
+    } catch (err) {
+      log.warn({ ticket, err: err?.message }, "ctl-1605: fast-path evict rmSync failed — skipping");
+      return false;
+    }
+  };
+}
 
 // defaultCollectOrphanCandidates — enumerate every ticket whose pipeline reached
 // terminal Done (the .terminal-done.applied marker) and build the J1 classify ctx

--- a/plugins/dev/scripts/execution-core/stall-janitor.test.mjs
+++ b/plugins/dev/scripts/execution-core/stall-janitor.test.mjs
@@ -27,6 +27,8 @@ import {
   defaultCollectTerminalSignalGcCandidates,
   defaultGcTerminalSignals,
   defaultTicketFromCwd,
+  makeEvictWorkerDir,
+  defaultNoEvict,
 } from "./stall-janitor.mjs";
 
 // ---------------------------------------------------------------------------
@@ -1216,5 +1218,63 @@ describe("defaultCollectTerminalSignalGcCandidates (CTL-1242 J4)", () => {
       agentsFresh: true,
     });
     expect(out.some((c) => c.ticket === "CTL-3008")).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// CTL-1605 — makeEvictWorkerDir (guarded fast-path worker-dir eviction seam)
+// ---------------------------------------------------------------------------
+describe("CTL-1605 makeEvictWorkerDir", () => {
+  let orchDir;
+  beforeEach(() => {
+    orchDir = mkdtempSync(join(tmpdir(), "ctl1605-evict-"));
+  });
+  afterEach(() => rmSync(orchDir, { recursive: true, force: true }));
+
+  function seedWorkerDir(ticket) {
+    const dir = join(orchDir, "workers", ticket);
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(join(dir, "phase-triage.json"), JSON.stringify({ ticket, status: "done" }));
+    return dir;
+  }
+
+  test("no live session + fresh snapshot → rmSync the worker dir, returns true", () => {
+    seedWorkerDir("CTL-9");
+    const evict = makeEvictWorkerDir({
+      orchDir,
+      agents: [],
+      agentsFresh: true,
+      resolveWorktreePath: () => "/wt/CTL-9",
+    });
+    expect(evict("CTL-9")).toBe(true);
+    expect(existsSync(join(orchDir, "workers", "CTL-9"))).toBe(false);
+  });
+
+  test("live session in worktree → NO removal, returns false", () => {
+    seedWorkerDir("CTL-9");
+    const evict = makeEvictWorkerDir({
+      orchDir,
+      agents: [{ cwd: "/wt/CTL-9/src" }],
+      agentsFresh: true,
+      resolveWorktreePath: () => "/wt/CTL-9",
+    });
+    expect(evict("CTL-9")).toBe(false);
+    expect(existsSync(join(orchDir, "workers", "CTL-9"))).toBe(true);
+  });
+
+  test("snapshot NOT fresh → NO removal (never evict blind), returns false", () => {
+    seedWorkerDir("CTL-9");
+    const evict = makeEvictWorkerDir({
+      orchDir,
+      agents: [],
+      agentsFresh: false,
+      resolveWorktreePath: () => "/wt/CTL-9",
+    });
+    expect(evict("CTL-9")).toBe(false);
+    expect(existsSync(join(orchDir, "workers", "CTL-9"))).toBe(true);
+  });
+
+  test("default evictWorkerDir seam (bare unit tick) is a no-op returning false", () => {
+    expect(defaultNoEvict("CTL-9")).toBe(false);
   });
 });

--- a/plugins/dev/scripts/execution-core/stall-janitor.test.mjs
+++ b/plugins/dev/scripts/execution-core/stall-janitor.test.mjs
@@ -1277,4 +1277,93 @@ describe("CTL-1605 makeEvictWorkerDir", () => {
   test("default evictWorkerDir seam (bare unit tick) is a no-op returning false", () => {
     expect(defaultNoEvict("CTL-9")).toBe(false);
   });
+
+  // ─── CTL-1605 review finding (stall-janitor.mjs:527) — an unresolved worktree
+  // path must DEFER, not fail open. Pre-fix, `!!worktreePath && ...some(...)`
+  // made a null/thrown resolver read as liveSession:false and fall through to
+  // rmSync — a pre-CTL-615 pathless signal (or a resolver throw) got evicted
+  // even with a LIVE agent whose cwd the probe never got the chance to check. ───
+
+  test("unresolved worktree path (resolver returns null) → DEFERS, no removal, returns false", () => {
+    seedWorkerDir("CTL-20");
+    const evict = makeEvictWorkerDir({
+      orchDir,
+      agents: [{ cwd: "/wt/CTL-20/src" }], // a LIVE session exists...
+      agentsFresh: true,
+      resolveWorktreePath: () => null, // ...but the probe can't tell — must defer
+    });
+    expect(evict("CTL-20")).toBe(false);
+    expect(existsSync(join(orchDir, "workers", "CTL-20"))).toBe(true);
+  });
+
+  test("resolveWorktreePath throws → DEFERS (same as an unresolved path), no removal", () => {
+    seedWorkerDir("CTL-21");
+    const evict = makeEvictWorkerDir({
+      orchDir,
+      agents: [],
+      agentsFresh: true,
+      resolveWorktreePath: () => {
+        throw new Error("signal read failed");
+      },
+    });
+    expect(evict("CTL-21")).toBe(false);
+    expect(existsSync(join(orchDir, "workers", "CTL-21"))).toBe(true);
+  });
+
+  test("resolved worktree path + no live session → still evicts (unaffected by the defer fix)", () => {
+    seedWorkerDir("CTL-22");
+    const evict = makeEvictWorkerDir({
+      orchDir,
+      agents: [],
+      agentsFresh: true,
+      resolveWorktreePath: () => "/wt/CTL-22",
+    });
+    expect(evict("CTL-22")).toBe(true);
+    expect(existsSync(join(orchDir, "workers", "CTL-22"))).toBe(false);
+  });
+
+  // ─── CTL-1605 review finding (scheduler.mjs:7611) — in-process SDK/codex-exec
+  // workers have bg_job_id null and are invisible to the agents-roster probe
+  // (`claude agents`); the SDK worker registry fences must be consulted BEFORE
+  // that roster check, or a live in-process worker's signal dir is deletable the
+  // moment Linear goes terminal. ───
+
+  test("isSdkWorkerLive(ticket) true → DEFERS even with an empty agents roster + resolved worktree", () => {
+    seedWorkerDir("CTL-23");
+    const evict = makeEvictWorkerDir({
+      orchDir,
+      agents: [], // roster empty — bg-keyed probe alone would say "not live"
+      agentsFresh: true,
+      resolveWorktreePath: () => "/wt/CTL-23",
+      isSdkWorkerLive: (t) => t === "CTL-23",
+    });
+    expect(evict("CTL-23")).toBe(false);
+    expect(existsSync(join(orchDir, "workers", "CTL-23"))).toBe(true);
+  });
+
+  test("isSdkWorkerLiveOnDisk(ticket) true (cross-process projection) → DEFERS", () => {
+    seedWorkerDir("CTL-24");
+    const evict = makeEvictWorkerDir({
+      orchDir,
+      agents: [],
+      agentsFresh: true,
+      resolveWorktreePath: () => "/wt/CTL-24",
+      isSdkWorkerLive: () => false,
+      isSdkWorkerLiveOnDisk: (t) => t === "CTL-24",
+    });
+    expect(evict("CTL-24")).toBe(false);
+    expect(existsSync(join(orchDir, "workers", "CTL-24"))).toBe(true);
+  });
+
+  test("both SDK fences false (default) → unaffected, evicts as before", () => {
+    seedWorkerDir("CTL-25");
+    const evict = makeEvictWorkerDir({
+      orchDir,
+      agents: [],
+      agentsFresh: true,
+      resolveWorktreePath: () => "/wt/CTL-25",
+    });
+    expect(evict("CTL-25")).toBe(true);
+    expect(existsSync(join(orchDir, "workers", "CTL-25"))).toBe(false);
+  });
 });


### PR DESCRIPTION
<!-- Auto-generated: 2026-08-02T15:10:55Z -->
<!-- Last updated: 2026-08-02T15:10:55Z -->
<!-- PR: #2872 -->
<!-- Previous commits: d4f35ad541e0cfe314309d3dd642d7e1642ac7a3,c1bfe64b399c27266cf5169072a05bc792f2783f,b4470da89c74dd7d4406e64abb6ea83b47e2ad54,3186d36b9bc666a705473f4d703ea8f7741b03d5 -->

## Summary

Operators were seeing stale `needs-human` / `blocked` worker-status labels on tickets that were
already **Done** — confirmed live at ~5% of Done CTL/CTC tickets (60 of 1,194). The root cause is
that every worker-status label write/read site made its own local judgment from host-local
`orchDir/workers/<ticket>/` signals, with no cross-check against the ticket's live Linear Status.
When one host completed a ticket that a second host still held a stale local record for, the second
host's admission-hold pass (`convergeHeldLabel`, which had **no** fence guard or terminal check at
all) would re-stamp `blocked`, and a subsequent reclaim + recovery-pass cycle would re-apply
`needs-human` — indefinitely.

This PR introduces a single terminal-aware read+write chokepoint that every worker-status label
site routes through, so a ticket that is terminal in Linear can never be re-labeled or
re-dispatched, and the stale local worker dir is evicted immediately instead of lingering until the
24h GC reaper.

## Changes Made

Implemented in four phases:

**Phase 1 — Terminal-aware chokepoint (`label-guard.mjs`, +121)**
Added `resolveAndApplyWorkerStatusLabel(ticket, desired, {isTerminal, applyDesired, onTerminalCleared, evictWorkerDir})`
plus the frozen `WORKER_STATUS_LABELS` source of truth. It reads the ticket's live disposition,
and on a terminal verdict short-circuits — removing any present worker-status label and (when armed)
evicting the local worker dir — before any desired-label write can proceed.

**Phase 2 — Route STEP A triaged-waiting through the chokepoint (`scheduler.mjs`, +80)**
STEP A now detects a triaged-waiting ticket whose live Linear state (already fetched in the A.3
batch — **zero** extra reads) is terminal, routes it through the chokepoint to clear the stale label
+ evict the dir, and drops it from the admission pool **before** it can reach `convergeHeldLabel`
(A.7) and be re-stamped `blocked`/`queued`.

**Phase 3 — Guarded fast-path eviction seam (`stall-janitor.mjs`, +41)**
Added `makeEvictWorkerDir()` — a live-session-fenced eviction factory that mirrors the J4 census
fences (never removes a dir whose worktree hosts a live session; never evicts when the liveness
probe throws). A no-op `defaultNoEvict` protects any un-wired caller, so a bare unit tick is inert.

**Phase 4 — Defer `onTerminalCleared` to async `removeLabel` resolution (`label-guard.mjs`)**
`removeLabel` is async, so `onTerminalCleared` now fires when the write **resolves** (post-tick)
rather than optimistically, keeping the eviction callback honest about actual Linear label removal.

## How to Verify It

- [x] Tests pass: `bun test` (`label-guard.test.mjs` +153, `scheduler.test.mjs` +85, `stall-janitor.test.mjs` +60)
- [x] Lint passes (Trunk-pinned prettier)
- [x] Reward-hacking scan: pass
- [x] Security scan: pass
- [x] Code review: pass (0 high-severity findings)
- [x] Empty-branch gate: pass
- [N/A] Typecheck: skipped — these are `.mjs` (plain JS), no `tsc` gate

Regression risk assessed at **2 / 10** by the verify phase.

## Related Issues/PRs

- Fixes https://linear.app/coalesce-labs/issue/CTL-1605

## Changelog Entry

`fix(dev)`: never re-apply a stale worker-status label (`needs-human`/`blocked`/`queued`/`needs-input`)
to a ticket that is already terminal in Linear; route all worker-status label sites through a single
terminal-aware chokepoint and evict the stale local worker dir immediately.