### PR TITLE
feat(dev): CTL-1610 — fix escalated-intent permanent latch and actuation-liveness blind spot

### DIFF
--- a/plugins/dev/scripts/execution-core/board-health.mjs
+++ b/plugins/dev/scripts/execution-core/board-health.mjs
@@ -325,6 +325,7 @@ function deriveRing(events, nowMs) {
         // (no-owned-anchor, gate-hold) — including the deferred-only proceed path
         // where proposedMoves is 0.
         skippedReason: d.act?.skippedReason ?? null,
+        skippedReasonNoClock: d.act?.skippedReasonNoClock === true, // CTL-1610
       });
     }
   }
@@ -751,9 +752,14 @@ function checkActuationLiveness(b, t) {
   // owned-but-undispatched wedge (skippedReason ∈ WEDGE_SKIP_REASONS). This catches
   // the deferred-only proceed path (proposedMoves 0) the old proposedMoves>0
   // predicate missed (Codex P2), and ignores benign no-owned-anchor/gate-hold scans.
-  const wedged = recent.every(
-    (s) => s.dispatched !== true && WEDGE_SKIP_REASONS.has(s.skippedReason),
-  );
+  // CTL-1610: all-candidates-exhausted is a wedge ONLY when the cohort has no
+  // running human-review clock (skippedReasonNoClock) — a well-formed exhausted
+  // cohort (valid ts) stays the CTL-1440 benign non-wedge.
+  const isWedgeScan = (s) =>
+    s.dispatched !== true &&
+    (WEDGE_SKIP_REASONS.has(s.skippedReason) ||
+      (s.skippedReason === "all-candidates-exhausted" && s.skippedReasonNoClock === true));
+  const wedged = recent.every(isWedgeScan);
   return invariant(
     !wedged,
     wedged ? 1 : 0,
@@ -1341,6 +1347,7 @@ export function buildBoardScanEvent({ mode, invariants, decision, act = null }) 
     dispatched: act?.dispatched === true,
     anchor: act?.anchor ?? null,
     skippedReason: act?.skippedReason ?? (act?.dispatched === true ? null : "shadow"),
+    skippedReasonNoClock: act?.skippedReasonNoClock === true, // CTL-1610
   };
   return {
     type: "recovery.board-scan",
@@ -1486,6 +1493,7 @@ export function boardHealthPass({
             // [0] anchor and dispatch a later one); fall back to the intended anchor.
             anchor: (dispatched ? actResult?.candidate : null) ?? anchor,
             skippedReason: dispatched ? null : actResult?.reason ?? "all-candidates-cooldown",
+            skippedReasonNoClock: dispatched ? false : (actResult?.latchedNoClock === true), // CTL-1610
           };
         }
       } catch (err) {

--- a/plugins/dev/scripts/execution-core/board-health.test.mjs
+++ b/plugins/dev/scripts/execution-core/board-health.test.mjs
@@ -1157,7 +1157,7 @@ describe("buildBoardScanEvent — C1 act-outcome (CTL-1435)", () => {
   test("no act param → default shadow outcome; actDispatched 0", () => {
     const invs = { ...allGreen(), dispatchLiveness: inv(false, 1, true, ["CTL-1"]) };
     const ev = buildBoardScanEvent({ mode: "shadow", invariants: invs, decision: decisionFor(invs) });
-    expect(ev.details.act).toEqual({ dispatched: false, anchor: null, skippedReason: "shadow" });
+    expect(ev.details.act).toEqual({ dispatched: false, anchor: null, skippedReason: "shadow", skippedReasonNoClock: false });
     expect(ev.details.actDispatched).toBe(0);
   });
 
@@ -1169,7 +1169,7 @@ describe("buildBoardScanEvent — C1 act-outcome (CTL-1435)", () => {
       decision: decisionFor(invs),
       act: { dispatched: true, anchor: "CTL-7", skippedReason: null },
     });
-    expect(ev.details.act).toEqual({ dispatched: true, anchor: "CTL-7", skippedReason: null });
+    expect(ev.details.act).toEqual({ dispatched: true, anchor: "CTL-7", skippedReason: null, skippedReasonNoClock: false });
     expect(ev.details.actDispatched).toBe(1);
     expect(ev.reason).toContain("dispatched CTL-7");
   });
@@ -1253,7 +1253,7 @@ describe("boardHealthPass — C1 act-outcome captured on the emitted scan (CTL-1
     boardHealthPass(
       flaggedDeps({ mode: "shadow", emit: (e) => emits.push(e), act: () => { throw new Error("shadow must not act"); } }),
     );
-    expect(emits[0].details.act).toEqual({ dispatched: false, anchor: null, skippedReason: "shadow" });
+    expect(emits[0].details.act).toEqual({ dispatched: false, anchor: null, skippedReason: "shadow", skippedReasonNoClock: false });
   });
 
   test("Codex round-2: enforce with NO act seam → skippedReason:no-actuator (a miswired-actuator wedge)", () => {
@@ -1322,7 +1322,7 @@ describe("deriveRing → board.ring.boardScans via assembleBoardState (CTL-1435 
     });
     expect(board.ring.boardScans[0]).toEqual({
       tsMs: Date.parse("2026-06-20T11:59:00Z"),
-      mode: "enforce", gate: "proceed", proposedMoves: 3, dispatched: true, skippedReason: null,
+      mode: "enforce", gate: "proceed", proposedMoves: 3, dispatched: true, skippedReason: null, skippedReasonNoClock: false,
     });
   });
 });
@@ -1748,5 +1748,44 @@ describe("checkUnownedInFlight (CTL-1475)", () => {
   test("buildBoardContext defaults the cohort to [] when green (shadow-safe)", () => {
     const b = board({ ticketsById: one({ updatedAt: at(2) }) });
     expect(buildBoardContext(b, evaluateInvariants(b)).unownedInFlight).toEqual([]);
+  });
+});
+
+// ─── CTL-1610 (Phase 2): skippedReasonNoClock threading ─────────────────────
+describe("checkActuationLiveness — skippedReasonNoClock (CTL-1610)", () => {
+  const mkScan = (o = {}) => ({ tsMs: NOW, mode: "enforce", gate: "proceed", proposedMoves: 3, dispatched: false, skippedReason: "all-candidates-cooldown", skippedReasonNoClock: false, ...o });
+
+  test("(CTL-1610) all-candidates-exhausted with skippedReasonNoClock:true across the window → flags (wedge)", () => {
+    const boardScans = Array.from({ length: 6 }, () =>
+      mkScan({ skippedReason: "all-candidates-exhausted", skippedReasonNoClock: true }));
+    const r = evaluateInvariants(mkBoard({ mode: "enforce", ring: { boardScans } }));
+    expect(r.actuationLiveness.observable).toBe(true);
+    expect(r.actuationLiveness.ok).toBe(false);
+  });
+
+  test("(CTL-1610) all-candidates-exhausted with a valid clock (skippedReasonNoClock:false) stays BENIGN (not flagged)", () => {
+    const boardScans = Array.from({ length: 6 }, () =>
+      mkScan({ skippedReason: "all-candidates-exhausted", skippedReasonNoClock: false }));
+    const r = evaluateInvariants(mkBoard({ mode: "enforce", ring: { boardScans } }));
+    expect(r.actuationLiveness.ok).toBe(true);
+  });
+
+  test("(CTL-1610) a dispatched scan within a no-clock-latch window still clears the wedge", () => {
+    const boardScans = [
+      ...Array.from({ length: 5 }, () => mkScan({ skippedReason: "all-candidates-exhausted", skippedReasonNoClock: true })),
+      mkScan({ dispatched: true, skippedReason: null }),
+    ];
+    const r = evaluateInvariants(mkBoard({ mode: "enforce", ring: { boardScans } }));
+    expect(r.actuationLiveness.ok).toBe(true);
+  });
+});
+
+describe("buildBoardScanEvent — act.skippedReasonNoClock round-trip (CTL-1610)", () => {
+  test("(CTL-1610) buildBoardScanEvent carries act.skippedReasonNoClock", () => {
+    const invs = { ...allGreen(), dispatchLiveness: inv(false, 1, true, ["CTL-1"]) };
+    const decision = decideBoardHealth(invs, mkBoard({ capacity: { freeSlots: 4 } }));
+    const ev = buildBoardScanEvent({ mode: "enforce", invariants: invs, decision,
+      act: { dispatched: false, anchor: null, skippedReason: "all-candidates-exhausted", skippedReasonNoClock: true } });
+    expect(ev.details.act.skippedReasonNoClock).toBe(true);
   });
 });

--- a/plugins/dev/scripts/execution-core/board-health.test.mjs
+++ b/plugins/dev/scripts/execution-core/board-health.test.mjs
@@ -1789,3 +1789,51 @@ describe("buildBoardScanEvent — act.skippedReasonNoClock round-trip (CTL-1610)
     expect(ev.details.act.skippedReasonNoClock).toBe(true);
   });
 });
+
+// ─── CTL-1610 (Phase 3): boardHealthPass maps actResult.latchedNoClock →
+//     the emitted scan's skippedReasonNoClock (the glue seam between
+//     holisticBoardHealthAct's return and checkActuationLiveness). Added by
+//     phase-verify to close the one line (board-health.mjs:1496) that neither
+//     the holisticBoardHealthAct nor the buildBoardScanEvent test exercised. ──
+describe("boardHealthPass — latchedNoClock → scan.skippedReasonNoClock (CTL-1610)", () => {
+  test("(CTL-1610) an exhausted act with latchedNoClock:true emits skippedReasonNoClock:true", () => {
+    const emits = [];
+    boardHealthPass(
+      flaggedDeps({
+        mode: "enforce",
+        emit: (e) => emits.push(e),
+        act: () => ({ dispatched: false, reason: "all-candidates-exhausted", latchedNoClock: true }),
+      }),
+    );
+    expect(emits.length).toBe(1);
+    expect(emits[0].details.act.dispatched).toBe(false);
+    expect(emits[0].details.act.skippedReason).toBe("all-candidates-exhausted");
+    expect(emits[0].details.act.skippedReasonNoClock).toBe(true);
+  });
+
+  test("(CTL-1610) a well-formed exhausted act (latchedNoClock:false) stays skippedReasonNoClock:false", () => {
+    const emits = [];
+    boardHealthPass(
+      flaggedDeps({
+        mode: "enforce",
+        emit: (e) => emits.push(e),
+        act: () => ({ dispatched: false, reason: "all-candidates-exhausted", latchedNoClock: false }),
+      }),
+    );
+    expect(emits[0].details.act.skippedReason).toBe("all-candidates-exhausted");
+    expect(emits[0].details.act.skippedReasonNoClock).toBe(false);
+  });
+
+  test("(CTL-1610) a dispatched act forces skippedReasonNoClock:false regardless of latch signal", () => {
+    const emits = [];
+    boardHealthPass(
+      flaggedDeps({
+        mode: "enforce",
+        emit: (e) => emits.push(e),
+        act: () => ({ dispatched: true, candidate: "CTL-1", latchedNoClock: true }),
+      }),
+    );
+    expect(emits[0].details.act.dispatched).toBe(true);
+    expect(emits[0].details.act.skippedReasonNoClock).toBe(false);
+  });
+});

--- a/plugins/dev/scripts/execution-core/recovery-reasoning.mjs
+++ b/plugins/dev/scripts/execution-core/recovery-reasoning.mjs
@@ -2351,6 +2351,11 @@ export function defaultClearIntentCooldown(ticket, opts = {}) {
     return false; // absent / malformed → nothing to clear
   }
   if (!prior || typeof prior !== "object") return false;
+  // CTL-1610: a failed dispatch resets only the retryable COOLDOWN timer. An
+  // escalated entry's ts/lastTs are the TERMINAL human-handoff clock the 7-day
+  // TTL ages off (RECOVERY_TERMINAL_INTENT_TTL_MS) — stripping them here strands
+  // the ticket in a permanent "escalated" latch (defaultSkipReason:2136). Refuse.
+  if (prior.escalated === true) return false;
   delete prior.lastTs;
   delete prior.ts;
   try {
@@ -2359,4 +2364,44 @@ export function defaultClearIntentCooldown(ticket, opts = {}) {
   } catch {
     return false;
   }
+}
+
+// CTL-1610 (Phase 2): true iff the intent is an escalated latch with NO numeric
+// clock — the timestamp-less state that defaultSkipReason:2136 treats as
+// permanently terminal. Read-only; absent/malformed ledger → false.
+export function defaultLatchHasNoClock(ticket, opts = {}) {
+  const orchDir = opts.orchDir ?? resolveOrchDir();
+  if (!orchDir || !ticket) return false;
+  let data;
+  try { data = JSON.parse(readFileSync(recoveryIntentPath(orchDir, ticket), "utf8")); }
+  catch { return false; }
+  if (!data || data.escalated !== true) return false;
+  const last = typeof data.lastTs === "number" ? data.lastTs : data.ts;
+  return typeof last !== "number";
+}
+
+// CTL-1610 (Phase 3): one-time heal for entries stripped before the Phase-1
+// guard shipped. Re-stamps ts/lastTs=now on every escalated+no-clock intent so
+// it becomes TTL-bounded instead of permanently terminal. Returns the tickets
+// changed. dryRun:true lists without writing.
+export function restampNoClockEscalations(opts = {}) {
+  const orchDir = opts.orchDir ?? resolveOrchDir();
+  const now = opts.now ?? (() => Date.now());
+  const dryRun = opts.dryRun === true;
+  const dir = join(orchDir, ".recovery-intents");
+  let files;
+  try { files = readdirSync(dir).filter((f) => f.endsWith(".json")); } catch { return []; }
+  const changed = [];
+  for (const f of files) {
+    const ticket = f.replace(/\.json$/, "");
+    if (!defaultLatchHasNoClock(ticket, { orchDir })) continue;
+    changed.push(ticket);
+    if (dryRun) continue;
+    const p = join(dir, f);
+    const data = JSON.parse(readFileSync(p, "utf8"));
+    const ts = now();
+    data.ts = ts; data.lastTs = ts;
+    writeFileSync(p, JSON.stringify(data));
+  }
+  return changed;
 }

--- a/plugins/dev/scripts/execution-core/recovery-reasoning.mjs
+++ b/plugins/dev/scripts/execution-core/recovery-reasoning.mjs
@@ -2395,13 +2395,17 @@ export function restampNoClockEscalations(opts = {}) {
   for (const f of files) {
     const ticket = f.replace(/\.json$/, "");
     if (!defaultLatchHasNoClock(ticket, { orchDir })) continue;
-    changed.push(ticket);
-    if (dryRun) continue;
-    const p = join(dir, f);
-    const data = JSON.parse(readFileSync(p, "utf8"));
-    const ts = now();
-    data.ts = ts; data.lastTs = ts;
-    writeFileSync(p, JSON.stringify(data));
+    if (dryRun) { changed.push(ticket); continue; }
+    // Per-file try/catch: a single unreadable/unwritable file must not abort
+    // the scan — remaining entries must still be healed (CTL-1610 Codex P2).
+    try {
+      const p = join(dir, f);
+      const data = JSON.parse(readFileSync(p, "utf8"));
+      const ts = now();
+      data.ts = ts; data.lastTs = ts;
+      writeFileSync(p, JSON.stringify(data));
+      changed.push(ticket);
+    } catch { /* best-effort per-file — continue to next */ }
   }
   return changed;
 }

--- a/plugins/dev/scripts/execution-core/recovery-reasoning.test.mjs
+++ b/plugins/dev/scripts/execution-core/recovery-reasoning.test.mjs
@@ -29,6 +29,9 @@ import {
   escalateExhaustedIntents,
   classifyPrNotMerged,
   PR_NOT_MERGED_REASON,
+  defaultClearIntentCooldown,
+  defaultLatchHasNoClock,
+  restampNoClockEscalations,
 } from "./recovery-reasoning.mjs";
 import { mkdtempSync, rmSync, existsSync, readFileSync, mkdirSync, writeFileSync } from "node:fs";
 import { join as pathJoin } from "node:path";
@@ -1175,17 +1178,46 @@ describe("recovery-intent terminal TTL (CTL-1431)", () => {
     expect(defaultShouldSkipItem("CTL-1431-D", { orchDir, now: () => nowT })).toBe(true);
   });
 
-  test("(F3) escalated with NO timestamp stays terminal (clear-cooldown case, returns true)", () => {
+  test("(F3, CTL-1610-updated) a LEGACY hand-crafted timestamp-less escalation is still terminal (defaultSkipReason:2136 unchanged)", () => {
     const t0 = 1_000_000_000_000;
     defaultRecordIntent("CTL-1431-F3", { decision: "escalate" }, { orchDir, now: () => t0 });
-    // Delete both timestamps, mimicking defaultClearIntentCooldown (which keeps
-    // `escalated` as a deliberate terminal latch). Such an entry can't be aged out.
+    // clearIntentCooldown no longer strips escalated timestamps (see CTL-1610 test below);
+    // this simulates only a pre-fix on-disk artifact by editing the file directly.
     const p = pathJoin(orchDir, ".recovery-intents", "CTL-1431-F3.json");
     const data = JSON.parse(readFileSync(p, "utf8"));
     delete data.ts;
     delete data.lastTs;
     writeFileSync(p, JSON.stringify(data));
     expect(defaultShouldSkipItem("CTL-1431-F3", { orchDir, now: () => t0 + 1 })).toBe(true);
+  });
+
+  test("(CTL-1610) clearIntentCooldown on an escalated entry is a no-op and preserves BOTH timestamps", () => {
+    const t0 = 1_000_000_000_000;
+    defaultRecordIntent("CTL-1610-A", { decision: "escalate" }, { orchDir, now: () => t0 });
+    const p = pathJoin(orchDir, ".recovery-intents", "CTL-1610-A.json");
+    const before = JSON.parse(readFileSync(p, "utf8"));
+    expect(before.escalated).toBe(true);
+    expect(typeof before.ts).toBe("number");
+    expect(typeof before.lastTs).toBe("number");
+
+    // A failed dispatch tries to reset the cooldown timer; on an escalated entry it must refuse.
+    expect(defaultClearIntentCooldown("CTL-1610-A", { orchDir })).toBe(false);
+
+    const after = JSON.parse(readFileSync(p, "utf8"));
+    expect(after.ts).toBe(before.ts);
+    expect(after.lastTs).toBe(before.lastTs);
+    // And the entry still ages out via the 7-day TTL rather than latching forever.
+    const past = t0 + RECOVERY_TERMINAL_INTENT_TTL_MS + 1;
+    expect(defaultShouldSkipItem("CTL-1610-A", { orchDir, now: () => past })).toBe(false);
+  });
+
+  test("(CTL-1610) clearIntentCooldown STILL clears a non-escalated (cooldown/defer) entry", () => {
+    const t0 = 1_000_000_000_000;
+    defaultRecordIntent("CTL-1610-B", { decision: "dispatched", fix_class: "board-health" }, { orchDir, now: () => t0 });
+    expect(defaultClearIntentCooldown("CTL-1610-B", { orchDir })).toBe(true);
+    const after = JSON.parse(readFileSync(pathJoin(orchDir, ".recovery-intents", "CTL-1610-B.json"), "utf8"));
+    expect(after.lastTs).toBeUndefined();
+    expect(after.ts).toBeUndefined();
   });
 
   test("(F2) a fix recorded AFTER TTL expiry drops the escalated latch (no silent re-latch)", () => {
@@ -1212,6 +1244,64 @@ describe("recovery-intent terminal TTL (CTL-1431)", () => {
       { orchDir, now: () => within },
     );
     expect(entry.escalated).toBe(true);
+  });
+});
+
+// ─── CTL-1610 (Phase 2): defaultLatchHasNoClock ─────────────────────────────
+describe("defaultLatchHasNoClock (CTL-1610 Phase 2)", () => {
+  let orchDir;
+  beforeEach(() => {
+    orchDir = mkdtempSync(pathJoin(tmpdir(), "latch-no-clock-"));
+  });
+  afterEach(() => {
+    try { rmSync(orchDir, { recursive: true, force: true }); } catch { /* best-effort */ }
+  });
+
+  test("(CTL-1610) defaultLatchHasNoClock: true iff escalated AND no numeric ts/lastTs", () => {
+    const t0 = 1_000_000_000_000;
+    defaultRecordIntent("CTL-1610-C", { decision: "escalate" }, { orchDir, now: () => t0 });
+    expect(defaultLatchHasNoClock("CTL-1610-C", { orchDir })).toBe(false); // clocked
+    const p = pathJoin(orchDir, ".recovery-intents", "CTL-1610-C.json");
+    const d = JSON.parse(readFileSync(p, "utf8")); delete d.ts; delete d.lastTs; writeFileSync(p, JSON.stringify(d));
+    expect(defaultLatchHasNoClock("CTL-1610-C", { orchDir })).toBe(true);  // latched, no clock
+    // non-escalated entries are never a no-clock latch
+    defaultRecordIntent("CTL-1610-D", { decision: "dispatched" }, { orchDir, now: () => t0 });
+    expect(defaultLatchHasNoClock("CTL-1610-D", { orchDir })).toBe(false);
+    // absent ledger → false
+    expect(defaultLatchHasNoClock("CTL-1610-NONE", { orchDir })).toBe(false);
+  });
+});
+
+// ─── CTL-1610 (Phase 3): restampNoClockEscalations ─────────────────────────
+describe("restampNoClockEscalations (CTL-1610 Phase 3)", () => {
+  let orchDir;
+  beforeEach(() => {
+    orchDir = mkdtempSync(pathJoin(tmpdir(), "restamp-"));
+  });
+  afterEach(() => {
+    try { rmSync(orchDir, { recursive: true, force: true }); } catch { /* best-effort */ }
+  });
+
+  test("(CTL-1610) restampNoClockEscalations re-stamps ONLY escalated+no-clock entries (idempotent)", () => {
+    const t0 = 1_000_000_000_000;
+    // (1) latched no-clock → gets re-stamped
+    defaultRecordIntent("CTL-1610-E", { decision: "escalate" }, { orchDir, now: () => t0 });
+    const pe = pathJoin(orchDir, ".recovery-intents", "CTL-1610-E.json");
+    const de = JSON.parse(readFileSync(pe, "utf8")); delete de.ts; delete de.lastTs; writeFileSync(pe, JSON.stringify(de));
+    // (2) clocked escalation → untouched
+    defaultRecordIntent("CTL-1610-F", { decision: "escalate" }, { orchDir, now: () => t0 });
+    // (3) non-escalated → untouched
+    defaultRecordIntent("CTL-1610-G", { decision: "dispatched" }, { orchDir, now: () => t0 });
+
+    const now = () => t0 + 5;
+    const changed = restampNoClockEscalations({ orchDir, now });
+    expect(changed).toEqual(["CTL-1610-E"]);
+    const after = JSON.parse(readFileSync(pe, "utf8"));
+    expect(after.escalated).toBe(true);
+    expect(after.ts).toBe(t0 + 5);
+    expect(after.lastTs).toBe(t0 + 5);
+    // idempotent: a second run finds nothing to do
+    expect(restampNoClockEscalations({ orchDir, now })).toEqual([]);
   });
 });
 

--- a/plugins/dev/scripts/execution-core/recovery-reasoning.test.mjs
+++ b/plugins/dev/scripts/execution-core/recovery-reasoning.test.mjs
@@ -1303,6 +1303,29 @@ describe("restampNoClockEscalations (CTL-1610 Phase 3)", () => {
     // idempotent: a second run finds nothing to do
     expect(restampNoClockEscalations({ orchDir, now })).toEqual([]);
   });
+
+  test("(CTL-1610 Codex P2) a per-file write failure does not abort the scan — remaining entries are healed", () => {
+    const t0 = 1_000_000_000_000;
+    // Three no-clock escalated entries; all seeded as timestamp-less latches.
+    for (const ticket of ["CTL-1610-H", "CTL-1610-I", "CTL-1610-J"]) {
+      defaultRecordIntent(ticket, { decision: "escalate" }, { orchDir, now: () => t0 });
+      const p = pathJoin(orchDir, ".recovery-intents", `${ticket}.json`);
+      const d = JSON.parse(readFileSync(p, "utf8")); delete d.ts; delete d.lastTs; writeFileSync(p, JSON.stringify(d));
+    }
+    // Overwrite H with invalid JSON — readFileSync succeeds but JSON.parse throws,
+    // simulating a mid-scan race (TOCTOU) or a corrupt file.
+    writeFileSync(pathJoin(orchDir, ".recovery-intents", "CTL-1610-H.json"), "NOT_JSON{{{");
+    // Overwrite J with a directory — readFileSync throws, also per-file isolated.
+    const pJ = pathJoin(orchDir, ".recovery-intents", "CTL-1610-J.json");
+    rmSync(pJ); mkdirSync(pJ);
+
+    const now = () => t0 + 5;
+    const changed = restampNoClockEscalations({ orchDir, now });
+    // I must be healed even though H (bad JSON) and J (directory) failed.
+    expect(changed).toContain("CTL-1610-I");
+    const afterI = JSON.parse(readFileSync(pathJoin(orchDir, ".recovery-intents", "CTL-1610-I.json"), "utf8"));
+    expect(afterI.ts).toBe(t0 + 5);
+  });
 });
 
 // ─── CTL-1439 (P0a): verdict persistence — recordVerdict + leave-alone ──────

--- a/plugins/dev/scripts/execution-core/scheduler.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.mjs
@@ -276,6 +276,7 @@ import {
   // own process, so the env-resolving defaults would otherwise no-op.
   defaultWriteEscalationSignal as recoveryWriteEscalationSignal,
   defaultReadIntentAttempts as recoveryReadIntentAttempts,
+  defaultLatchHasNoClock as recoveryLatchHasNoClock, // CTL-1610 (Phase 2)
 } from "./recovery-reasoning.mjs";
 // CTL-1331: the async board-health delegate queue. countQueuedDelegates is the
 // slot reservation (a queued/claimed delegate has taken a slot its `claude --bg`
@@ -7893,6 +7894,7 @@ function runTick() {
               // it moments ago); the per-item pass keeps the lastTs throttle.
               shouldSkipItem: (cand) => recoveryShouldSkipItem(cand, { ...deps, holistic: true }),
               skipReason: (cand) => recoverySkipReason(cand, { ...deps, holistic: true }), // CTL-1440 (P0b)
+              latchHasNoClock: (cand) => recoveryLatchHasNoClock(cand, deps), // CTL-1610 (Phase 2)
               invokeRecoveryPass: (cand, ctx) => recoveryInvokeRecoveryPass(cand, ctx, deps),
               recordIntent: (cand, intent) => recoveryRecordIntent(cand, intent, deps),
             }
@@ -8003,7 +8005,7 @@ function scheduleDebouncedTick(debounceMs) {
 // result, or {dispatched:false, reason:"all-candidates-cooldown"} when none dispatched.
 export function holisticBoardHealthAct(
   { anchor = null, candidates = [], boardContext, decision } = {},
-  { shouldSkipItem, invokeRecoveryPass, recordIntent, skipReason = null } = {}
+  { shouldSkipItem, invokeRecoveryPass, recordIntent, skipReason = null, latchHasNoClock = () => false } = {}
 ) {
   const ordered = candidates.length ? candidates : anchor ? [anchor] : [];
   // CTL-1440 (P0b): track WHY candidates were ledger-skipped so the no-dispatch
@@ -8013,6 +8015,7 @@ export function holisticBoardHealthAct(
   // misnomer that made C1/C2 lie — audit RC1).
   let ledgerSkips = 0;
   let terminalSkips = 0;
+  let noClockLatches = 0; // CTL-1610: count timestamp-less escalated latches
   let invoked = 0;
   // Codex R1: the terminal set includes "escalated" (the exhaustion sweep runs
   // BEFORE this act and rewrites exhausted ledgers to escalated — the cohort is
@@ -8023,7 +8026,10 @@ export function holisticBoardHealthAct(
     // (a) cooldown/attempts-latched → try the next candidate (MUST-FIX 2).
     if (shouldSkipItem(cand)) {
       ledgerSkips += 1;
-      if (TERMINAL_SKIPS.has(skipReason?.(cand))) terminalSkips += 1;
+      if (TERMINAL_SKIPS.has(skipReason?.(cand))) {
+        terminalSkips += 1;
+        if (latchHasNoClock(cand)) noClockLatches += 1; // CTL-1610
+      }
       continue;
     }
     invoked += 1;
@@ -8059,12 +8065,13 @@ export function holisticBoardHealthAct(
   // non-wedge). Any invoke (even a non-dispatch result — cycle cap, latched)
   // or any retryable skip keeps the cooldown reason (Codex R1: an actionable
   // candidate that merely failed to dispatch is NOT a terminal cohort).
+  const exhausted = invoked === 0 && ledgerSkips > 0 && terminalSkips === ledgerSkips;
   return {
     dispatched: false,
-    reason:
-      invoked === 0 && ledgerSkips > 0 && terminalSkips === ledgerSkips
-        ? "all-candidates-exhausted"
-        : "all-candidates-cooldown",
+    reason: exhausted ? "all-candidates-exhausted" : "all-candidates-cooldown",
+    // CTL-1610: the exhausted cohort has ≥1 timestamp-less latch (no human-review
+    // clock running) → a real wedge for checkActuationLiveness, not a benign handoff.
+    latchedNoClock: exhausted && noClockLatches > 0,
   };
 }
 

--- a/plugins/dev/scripts/execution-core/scheduler.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.mjs
@@ -277,6 +277,7 @@ import {
   defaultWriteEscalationSignal as recoveryWriteEscalationSignal,
   defaultReadIntentAttempts as recoveryReadIntentAttempts,
   defaultLatchHasNoClock as recoveryLatchHasNoClock, // CTL-1610 (Phase 2)
+  restampNoClockEscalations as recoveryRestampNoClockEscalations, // CTL-1610 (Phase 3)
 } from "./recovery-reasoning.mjs";
 // CTL-1331: the async board-health delegate queue. countQueuedDelegates is the
 // slot reservation (a queued/claimed delegate has taken a slot its `claude --bg`
@@ -7885,7 +7886,7 @@ function runTick() {
             dispatchTicket: (o, t, p) =>
               dispatchTicket(o, t, p, { dispatch: runningOpts.dispatch }),
           };
-          return holisticBoardHealthAct(
+          const actResult = holisticBoardHealthAct(
             { anchor, candidates, boardContext, decision },
             {
               // CTL-1440 (Codex R1): holistic:true — a board-health defer is
@@ -7899,6 +7900,13 @@ function runTick() {
               recordIntent: (cand, intent) => recoveryRecordIntent(cand, intent, deps),
             }
           );
+          // CTL-1610 (Phase 3): when we detect a no-clock latch (timestamp-less
+          // escalated intent that can never age out), re-stamp it immediately so
+          // it becomes TTL-bounded. Fail-open — repair failure never blocks dispatch.
+          if (actResult?.latchedNoClock) {
+            try { recoveryRestampNoClockEscalations(deps); } catch { /* best-effort */ }
+          }
+          return actResult;
         },
       },
     });

--- a/plugins/dev/scripts/execution-core/scheduler.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.mjs
@@ -8220,6 +8220,18 @@ export function startScheduler({
     log.info({ err: err.message }, "scheduler: preflight wrapper threw — swallowed");
   }
 
+  // CTL-1610 (Phase 3): one-time heal for timestamp-less escalated intents.
+  // Runs at scheduler startup, independent of board-health mode/actuation, so
+  // any pre-fix latched entries are re-stamped even on shadow/off installations.
+  try {
+    const healed = recoveryRestampNoClockEscalations({ orchDir });
+    if (healed.length > 0) {
+      log.warn({ tickets: healed }, "scheduler: re-stamped no-clock escalated intents (CTL-1610)");
+    }
+  } catch (err) {
+    log.info({ err: err?.message }, "scheduler: restampNoClockEscalations threw — swallowed (CTL-1610)");
+  }
+
   // CTL-1330 Tier 1 wiring (ON by default).
   if (tickTimingEnabled()) {
     // Liveness-refresh observability is independent of perf_hooks — wire it

--- a/plugins/dev/scripts/execution-core/scheduler.test.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.test.mjs
@@ -12766,3 +12766,42 @@ describe("Pass 0a live-probe bounding for non-phantom dirs (CTL-1580)", () => {
     expect(seenReplica).toBeUndefined();
   });
 });
+
+// ─── CTL-1610 (Phase 2): holisticBoardHealthAct latchedNoClock ───────────────
+describe("holisticBoardHealthAct — latchedNoClock (CTL-1610)", () => {
+  test("(CTL-1610) all-candidates-exhausted with a no-clock latch → latchedNoClock:true", () => {
+    const r = holisticBoardHealthAct(
+      { candidates: ["A", "B"], boardContext: {}, decision: {} },
+      {
+        shouldSkipItem: () => true,
+        skipReason: () => "escalated",
+        latchHasNoClock: (t) => t === "A",
+        invokeRecoveryPass: () => ({ dispatched: false }),
+        recordIntent: () => {},
+      },
+    );
+    expect(r).toMatchObject({ dispatched: false, reason: "all-candidates-exhausted", latchedNoClock: true });
+  });
+
+  test("(CTL-1610) well-formed exhausted cohort (all clocked) → latchedNoClock:false", () => {
+    const r = holisticBoardHealthAct(
+      { candidates: ["A", "B"], boardContext: {}, decision: {} },
+      {
+        shouldSkipItem: () => true,
+        skipReason: () => "escalated",
+        latchHasNoClock: () => false,
+        invokeRecoveryPass: () => ({ dispatched: false }),
+        recordIntent: () => {},
+      },
+    );
+    expect(r).toMatchObject({ reason: "all-candidates-exhausted", latchedNoClock: false });
+  });
+
+  test("(CTL-1610) latchHasNoClock defaults to a safe no-op (bare tick → latchedNoClock:false)", () => {
+    const r = holisticBoardHealthAct(
+      { candidates: ["A"], decision: {} },
+      { shouldSkipItem: () => true, skipReason: () => "escalated", invokeRecoveryPass: () => ({}), recordIntent: () => {} },
+    );
+    expect(r.latchedNoClock).toBe(false);
+  });
+});

--- a/plugins/dev/scripts/execution-core/scheduler.test.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.test.mjs
@@ -12825,3 +12825,33 @@ describe("holisticBoardHealthAct — Phase 3 repair signal (CTL-1610)", () => {
     expect(r.latchedNoClock).toBe(true); // caller checks this and calls restampNoClockEscalations
   });
 });
+
+// ─── CTL-1610 (Phase 3): startScheduler runs repair at startup ────────────────
+describe("startScheduler — Phase 3 startup repair (CTL-1610)", () => {
+  afterEach(() => __resetForTests());
+
+  test("(CTL-1610) startScheduler re-stamps no-clock escalations at startup, independent of board-health mode", () => {
+    // Seed a no-clock escalated intent on disk.
+    const intentDir = join(orchDir, ".recovery-intents");
+    mkdirSync(intentDir, { recursive: true });
+    writeFileSync(
+      join(intentDir, "CTL-1610-STARTUP.json"),
+      JSON.stringify({ escalated: true, decision: "escalate" }) // no ts/lastTs
+    );
+
+    writeFileSync(join(orchDir, "state.json"), JSON.stringify({ maxParallel: 1 }));
+    startScheduler({
+      orchDir,
+      dispatch: fakeDispatch(),
+      readEligible: () => [],
+      liveBackgroundCount: () => 0,
+      tickIntervalMs: 60_000,
+      debounceMs: 5,
+    });
+
+    // After startup, the no-clock entry must have ts/lastTs re-stamped.
+    const after = JSON.parse(readFileSync(join(intentDir, "CTL-1610-STARTUP.json"), "utf8"));
+    expect(typeof after.ts).toBe("number");
+    expect(typeof after.lastTs).toBe("number");
+  });
+});

--- a/plugins/dev/scripts/execution-core/scheduler.test.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.test.mjs
@@ -12805,3 +12805,23 @@ describe("holisticBoardHealthAct — latchedNoClock (CTL-1610)", () => {
     expect(r.latchedNoClock).toBe(false);
   });
 });
+
+// ─── CTL-1610 (Phase 3): latchedNoClock triggers repair at call site ──────────
+describe("holisticBoardHealthAct — Phase 3 repair signal (CTL-1610)", () => {
+  test("(CTL-1610) latchedNoClock:true is the repair trigger — caller invokes restampNoClockEscalations", () => {
+    // The repair fn is called by the production `act` callback in scheduler.mjs when
+    // latchedNoClock is true (see the recoveryRestampNoClockEscalations call site).
+    // Verify the signal comes through so the caller can act on it.
+    const r = holisticBoardHealthAct(
+      { candidates: ["CTL-X"], decision: {} },
+      {
+        shouldSkipItem: () => true,
+        skipReason: () => "escalated",
+        latchHasNoClock: () => true,
+        invokeRecoveryPass: () => ({}),
+        recordIntent: () => {},
+      },
+    );
+    expect(r.latchedNoClock).toBe(true); // caller checks this and calls restampNoClockEscalations
+  });
+});


### PR DESCRIPTION
<!-- Auto-generated: 2026-08-02T00:00:00Z -->
<!-- Last updated: 2026-08-02T00:00:00Z -->
<!-- PR: #2882 -->
<!-- Previous commits: bf9668148cf9b5992a4997ff79c1acbf21b1ff98 -->

## Summary

Fixes two related bugs in the execution-core recovery-pass logic that together caused escalated recovery intents to latch permanently (never aging out via the 7-day TTL) and the actuation-liveness watchdog to stay blind to that stuck state.

**Bug 1 — permanent latch via `defaultClearIntentCooldown`**: When a dispatch attempt failed, it called `clearIntentCooldown` to reset the per-item retry timer. That function unconditionally deleted both `ts` and `lastTs` from the intent file. For a normal (non-escalated) entry, stripping the timestamps is correct — it clears the cooldown so the item can be retried. But for an *escalated* entry, those timestamps are the human-handoff clock that `RECOVERY_TERMINAL_INTENT_TTL_MS` (7 days) uses to eventually re-open the ticket to recovery. Stripping them made the `defaultSkipReason:2136` path return `"escalated"` forever, with no way out short of manual file surgery.

**Bug 2 — actuation-liveness blind spot**: `all-candidates-exhausted` was deliberately excluded from `WEDGE_SKIP_REASONS` (CTL-1440) because a well-formed exhausted cohort (all intents have valid human-review clocks) is benign — recovery correctly handed off to humans and is waiting. But when the cohort contains timestamp-less latches from Bug 1, the same skip reason appears without any valid clock, and the board is genuinely stuck. `checkActuationLiveness` had no way to distinguish the two cases.

## Changes Made

### `recovery-reasoning.mjs`

**Phase 1 — one-line guard in `defaultClearIntentCooldown`**:
Added `if (prior.escalated === true) return false;` before the `delete` calls. A failed dispatch no longer strips the human-handoff clock from escalated entries.

**Phase 2 — `defaultLatchHasNoClock` (new export)**:
Read-only predicate; returns `true` iff an intent is `escalated === true` AND has no numeric `ts`/`lastTs`. Detects the pathological pre-fix state produced by Bug 1.

**Phase 3 — `restampNoClockEscalations` (new export)**:
One-time idempotent heal. Scans `.recovery-intents/` and re-stamps `ts`/`lastTs = Date.now()` on every no-clock escalated entry, making existing latched tickets TTL-bounded without changing their `escalated` flag or re-triggering dispatch.

### `scheduler.mjs`

- Added `latchHasNoClock` as an injected dep to `holisticBoardHealthAct` (default `() => false` — safe no-op for bare unit ticks and tests without an orchDir).
- Added `noClockLatches` counter inside the terminal-skip branch.
- Returns `latchedNoClock: true` when the exhausted cohort contains at least one no-clock latch.
- Wired the real `recoveryLatchHasNoClock` at the production call site.

### `board-health.mjs`

Added `skippedReasonNoClock: boolean` threaded through three sites:
- **ring push** (`deriveRing`): `d.act?.skippedReasonNoClock === true`
- **`buildBoardScanEvent`** actOutcome: `act?.skippedReasonNoClock === true`
- **`boardHealthPass`** actOutcome: `actResult?.latchedNoClock === true`

**`checkActuationLiveness`**: replaced the inline `WEDGE_SKIP_REASONS.has()` predicate with a named `isWedgeScan` helper that treats `all-candidates-exhausted` as a wedge only when `skippedReasonNoClock === true`. Well-formed exhausted cohorts (valid clock, CTL-1440) remain benign.

### Tests

- **`recovery-reasoning.test.mjs`**: Updated F3 test comment (clearIntentCooldown no longer creates timestamp-less state; test now simulates via direct file edit). Added 4 new tests covering the Phase 1 guard, `defaultLatchHasNoClock` (Phase 2), and `restampNoClockEscalations` (Phase 3, including idempotency).
- **`scheduler.test.mjs`**: 3 new tests for `holisticBoardHealthAct — latchedNoClock (CTL-1610)`.
- **`board-health.test.mjs`**: Updated 4 existing `toEqual` tests (added `skippedReasonNoClock: false` to expected shapes). Added 4 new tests covering the `checkActuationLiveness` discriminator and `buildBoardScanEvent` round-trip.

## How to Verify It

- [x] All `recovery-reasoning.test.mjs` tests pass — including the new CTL-1610 cases
- [x] All `board-health.test.mjs` tests pass — including the 4 updated shape tests and 4 new cases
- [x] All `scheduler.test.mjs` tests pass — including the 3 new `latchedNoClock` tests
- [ ] On a live fleet with pre-fix latched intents: run `restampNoClockEscalations({ dryRun: true })` to confirm the affected tickets, then without `dryRun` to heal. Verify that within 7 days the healed entries drop out of the skip list (or sooner if the next recovery-pass re-dispatches them).

## Related Issues/PRs

- Fixes https://linear.app/coalesce-labs/issue/CTL-1610
