### PR TITLE
fix(dev): CTL-1612 arm daemon credentials from the shared secret files at boot

### DIFF
--- a/.github/workflows/execution-core-tests.yml
+++ b/.github/workflows/execution-core-tests.yml
@@ -234,6 +234,21 @@ jobs:
         working-directory: plugins/dev/scripts
         run: bash __tests__/review-comments-headless.test.sh
 
+      - name: monitor launcher / dist-redirect test (incl. CTL-1612 webhook-secret projection)
+        # Previously ungated in CI (run-tests.sh globs it locally, but the CI job uses an
+        # explicit allowlist). Now covers the cmd_start CATALYST_WEBHOOK_SECRET projection
+        # that brings the stack launch path to parity with the launchd wrapper.
+        working-directory: plugins/dev/scripts
+        run: bash __tests__/catalyst-monitor-dist-redirect.test.sh
+
+      - name: daemon shared-GitHub-credential projection test (CTL-1612)
+        # Covers _project_shared_github_token: the shared SOPS file WINS over a stale
+        # inherited GITHUB_TOKEN/GH_TOKEN (the 2026-08-02 fleet outage), an
+        # empty/whitespace/absent file is a total no-op that never exports "", and the
+        # GITHUB_TOKEN-only case reconciles GH_TOKEN so a stale one cannot outrank it.
+        working-directory: plugins/dev/scripts
+        run: bash __tests__/catalyst-execution-core-github-token.test.sh
+
       - name: migrate-dual-harness test (CTL-1530)
         # Covers the dual-harness classification (dual-ok / codex-only /
         # claude-only-monolithic / no-harness), the skills-dir state machine
@@ -481,4 +496,6 @@ jobs:
             linear-read-event.test.mjs \
             updater/plugin-pull-defer.test.mjs \
             updater/updater.test.mjs \
-            updater/updater-tracing.test.mjs
+            updater/updater-tracing.test.mjs \
+            github-auth-preflight.test.mjs \
+            cluster-sync.test.mjs

--- a/plugins/dev/scripts/__tests__/catalyst-execution-core-github-token.test.sh
+++ b/plugins/dev/scripts/__tests__/catalyst-execution-core-github-token.test.sh
@@ -532,6 +532,87 @@ else
   pass "T18 transcript contains no token-shaped string (no gh* prefix)"
 fi
 
+# ─── 19: Codex round-2 P1 #6 — the cluster-sync destination outranks XDG ───────
+# cluster-sync WRITES bare secrets into dirname(getLayer2ConfigPath()), whose default is
+# a HARDCODED ~/.config/catalyst — it is NOT XDG-aware. Reading only the XDG path (the
+# round-1 fix) would miss every rotation on an XDG host: strictly worse than the
+# hardcoded read it replaced. The reader is now a CHAIN: writer's dir first, XDG second.
+echo "test 19: resolution chain — cluster-sync destination outranks XDG_CONFIG_HOME"
+# The probe harness pins CATALYST_LAYER2_CONFIG_FILE="$T/layer2.json", so the
+# cluster-sync destination this reader must prefer is dirname(that) = "$T" — the same
+# resolution the WRITER uses. Placing the fixture there proves the reader follows the
+# Layer-2 override exactly as cluster-sync does, not merely a hardcoded ~/.config.
+mkdir -p "$T/xdghome/catalyst"
+printf '%s' "$FAKE_FILE_TOKEN" > "$T/github-token"
+printf 'ghp_XDG-FAKE-DECOY-0000000000000000000' > "$T/xdghome/catalyst/github-token"
+OUT="$(probe T19a XDG_CONFIG_HOME="$T/xdghome" EXPECT_VALUE="$FAKE_FILE_TOKEN" \
+  FORBID_VALUE='ghp_XDG-FAKE-DECOY-0000000000000000000')"
+assert_line "$OUT" "source=shared-file" "T19a armed from a file"
+assert_line "$OUT" "match_github=yes" "T19a took the cluster-sync destination, not the XDG decoy"
+assert_line "$OUT" "forbid_hit=no" "T19a the XDG copy did NOT win"
+
+# ...but the XDG copy is still a FALLBACK: on a host where only it exists, it must be found.
+echo "test 19b: XDG copy is still found when the cluster-sync destination is absent"
+rm -f "$T/github-token"
+printf '%s' "$FAKE_FILE_TOKEN" > "$T/xdghome/catalyst/github-token"
+OUT="$(probe T19b XDG_CONFIG_HOME="$T/xdghome" EXPECT_VALUE="$FAKE_FILE_TOKEN")"
+assert_line "$OUT" "source=shared-file" "T19b armed from the XDG fallback"
+assert_line "$OUT" "match_github=yes" "T19b XDG fallback value used"
+rm -f "$T/xdghome/catalyst/github-token"
+
+# ─── 20: Codex round-2 P2 #8 — a GH_TOKEN-only operator override must survive ──
+# execution-core.env may override EITHER alias. Round-1 only handled the
+# GITHUB_TOKEN-only case: a GH_TOKEN-only override left GITHUB_TOKEN equal to the
+# projected value, so the reconcile early-returned, provenance stayed "shared-file", and
+# the post-sync re-arm then overwrote BOTH names with the shared-file value — silently
+# defeating an explicit operator override. GH_TOKEN wins when it is the one that moved,
+# because that is the name `gh` resolves first.
+echo "test 20: a GH_TOKEN-only operator override wins and is mirrored onto GITHUB_TOKEN"
+printf '%s' "$FAKE_FILE_TOKEN" > "$T/file.token"
+OUT="$(
+  env -i PATH="$PATH" HOME="$T/home" HELPER="$T/helper.sh" \
+    CATALYST_GITHUB_TOKEN_FILE="$T/file.token" RECONCILE="$T/reconcile.sh" \
+    CATALYST_LAYER2_CONFIG_FILE="$T/layer2.json" \
+    bash -c '
+      # shellcheck disable=SC1090
+      source "$HELPER"
+      # shellcheck disable=SC1090
+      source "$RECONCILE"
+      _project_shared_github_token
+      GH_TOKEN=ghp_GHONLY-FAKE-OVERRIDE-000000000   # execution-core.env sets ONLY GH_TOKEN
+      _reconcile_github_token_aliases
+      echo "source=$CATALYST_GITHUB_TOKEN_SOURCE"
+      [ "$GH_TOKEN" = ghp_GHONLY-FAKE-OVERRIDE-000000000 ] && echo "gh_is_override=yes" || echo "gh_is_override=no"
+      [ "$GITHUB_TOKEN" = "$GH_TOKEN" ] && echo "agree=yes" || echo "agree=no"
+    '
+)"
+printf '### T20\n%s\n' "$OUT" >> "$ALL_OUT"
+assert_line "$OUT" "source=operator-override" "T20 provenance corrected to operator-override"
+assert_line "$OUT" "gh_is_override=yes" "T20 the GH_TOKEN-only override survived"
+assert_line "$OUT" "agree=yes" "T20 GITHUB_TOKEN mirrored onto the winning override"
+
+echo "test 20b: an override that BLANKS a name is not treated as a credential"
+OUT="$(
+  env -i PATH="$PATH" HOME="$T/home" HELPER="$T/helper.sh" \
+    CATALYST_GITHUB_TOKEN_FILE="$T/file.token" RECONCILE="$T/reconcile.sh" \
+    CATALYST_LAYER2_CONFIG_FILE="$T/layer2.json" \
+    bash -c '
+      # shellcheck disable=SC1090
+      source "$HELPER"
+      # shellcheck disable=SC1090
+      source "$RECONCILE"
+      _project_shared_github_token
+      GH_TOKEN=""
+      _reconcile_github_token_aliases
+      echo "source=$CATALYST_GITHUB_TOKEN_SOURCE"
+      [ -n "$GITHUB_TOKEN" ] && echo "primary_still_set=yes" || echo "primary_still_set=no"
+    '
+)"
+printf '### T20b\n%s\n' "$OUT" >> "$ALL_OUT"
+assert_line "$OUT" "source=shared-file" "T20b a blanked alias does not claim operator-override"
+assert_line "$OUT" "primary_still_set=yes" "T20b the working projected credential is preserved"
+
+
 echo ""
 echo "─────────────────────────────────────────────"
 echo "catalyst-execution-core-github-token: ${PASSES} passed, ${FAILURES} failed"

--- a/plugins/dev/scripts/__tests__/catalyst-execution-core-github-token.test.sh
+++ b/plugins/dev/scripts/__tests__/catalyst-execution-core-github-token.test.sh
@@ -11,7 +11,19 @@
 # genuinely unset rather than exported as "" (T5/T6), because bash `${X:-default}` and
 # JS `process.env.X ?? fallback` both treat "" as SET and would defeat gh's fallback.
 #
-# Method: the helper is extracted out of catalyst-execution-core with sed and exercised
+# CTL-1612 (Codex P2) adds a SECOND helper to the same ladder,
+# `_reconcile_github_token_aliases`, which runs AFTER execution-core.env is sourced.
+# The override was honored only by ordering, and an execution-core.env that set just
+# GITHUB_TOKEN left GH_TOKEN still holding the shared-file value — and `gh` resolves
+# GH_TOKEN FIRST, so the operator override was silently ignored while the provenance
+# breadcrumb still claimed "shared-file". T12 is that regression; T13-T15 pin the
+# no-op cases the guard has to preserve.
+#
+# CTL-1612 (Codex P2) also makes the projection XDG-aware: the default path is
+# ${XDG_CONFIG_HOME:-$HOME/.config}/catalyst/github-token, matching setup-webhooks.sh:23
+# (which is what generates the sibling secret). T16 pins both arms of that `:-`.
+#
+# Method: the helpers are extracted out of catalyst-execution-core with sed and exercised
 # in isolation, so nothing here boots a daemon, opens a socket, or mints an OAuth token.
 # Every case runs under `env -i` (strictly stronger than `env -u GITHUB_TOKEN -u GH_TOKEN`)
 # with HOME pointed at the sandbox, so a developer's real shell token or real
@@ -59,11 +71,19 @@ echo '{}' > "$T/layer2.json"
 FAKE_FILE_TOKEN='FAKE-CTL1612-shared-file-token-AAAA'
 FAKE_AMBIENT_GITHUB='FAKE-CTL1612-ambient-github-token-BBBB'
 FAKE_AMBIENT_GH='FAKE-CTL1612-ambient-gh-token-CCCC'
+FAKE_OVERRIDE_TOKEN='FAKE-CTL1612-operator-override-token-DDDD'
+FAKE_XDG_TOKEN='FAKE-CTL1612-xdg-config-home-token-EEEE'
+FAKE_HOME_CONFIG_TOKEN='FAKE-CTL1612-home-dotconfig-token-FFFF'
 
-# ─── Extract the helper under test ────────────────────────────────────────────
+# ─── Extract the helpers under test ───────────────────────────────────────────
 sed -n '/^_project_shared_github_token() {/,/^}/p' "$SCRIPT" > "$T/helper.sh"
 if [[ ! -s "$T/helper.sh" ]] || ! grep -q 'CATALYST_GITHUB_TOKEN_SOURCE' "$T/helper.sh"; then
   echo "FATAL: could not extract _project_shared_github_token from $SCRIPT" >&2
+  exit 1
+fi
+sed -n '/^_reconcile_github_token_aliases() {/,/^}/p' "$SCRIPT" > "$T/reconcile.sh"
+if [[ ! -s "$T/reconcile.sh" ]] || ! grep -q 'operator-override' "$T/reconcile.sh"; then
+  echo "FATAL: could not extract _reconcile_github_token_aliases from $SCRIPT" >&2
   exit 1
 fi
 
@@ -77,6 +97,17 @@ set -uo pipefail
 # shellcheck disable=SC1090
 source "$HELPER"
 _project_shared_github_token >"$STDOUT_CAP" 2>"$STDERR_CAP"
+
+# CTL-1612 (Codex P2) stage 2 — opt-in, inert unless the case supplies RECONCILE, so
+# tests 1-9 run byte-identically. Replays cmd_start's post-projection sequence: source
+# execution-core.env (the operator override), THEN reconcile the two names.
+if [[ -n "${RECONCILE:-}" ]]; then
+  # shellcheck disable=SC1090
+  source "$RECONCILE"
+  # shellcheck disable=SC1090
+  [[ -n "${ENV_FILE:-}" && -f "${ENV_FILE}" ]] && source "$ENV_FILE"
+  _reconcile_github_token_aliases >>"$STDOUT_CAP" 2>>"$STDERR_CAP"
+fi
 
 gt=unset; [[ -n ${GITHUB_TOKEN+x} ]] && gt=set
 gh=unset; [[ -n ${GH_TOKEN+x} ]] && gh=set
@@ -347,6 +378,158 @@ if [[ -n "$CALL_LINE" && -n "$ENV_SOURCE_LINE" ]] && [[ "$CALL_LINE" -lt "$ENV_S
 else
   fail "T11 invocation must precede the execution-core.env source" \
     "call=$CALL_LINE env_source=$ENV_SOURCE_LINE"
+fi
+
+# ─── execution-core.env fixtures (what cmd_start sources AFTER the projection) ─
+# The load-bearing one sets ONLY GITHUB_TOKEN — that is exactly the shape that used to
+# leave GH_TOKEN pointed at the shared-file value while `gh` read GH_TOKEN first.
+printf "export GITHUB_TOKEN='%s'\n" "$FAKE_OVERRIDE_TOKEN" > "$T/env-override-github-only.env"
+printf 'export CATALYST_FIXTURE_UNRELATED=1\n' > "$T/env-no-token.env"
+printf "export GITHUB_TOKEN=''\n" > "$T/env-override-empty.env"
+
+# ─── 12: operator override sets only GITHUB_TOKEN → GH_TOKEN re-pointed ───────
+echo ""
+echo "test 12: execution-core.env sets ONLY GITHUB_TOKEN → GH_TOKEN re-pointed at the override (Codex P2 regression)"
+OUT="$(probe T12 CATALYST_GITHUB_TOKEN_FILE="$T/file.token" \
+  RECONCILE="$T/reconcile.sh" ENV_FILE="$T/env-override-github-only.env" \
+  EXPECT_VALUE="$FAKE_OVERRIDE_TOKEN" FORBID_VALUE="$FAKE_FILE_TOKEN")"
+assert_line "$OUT" "match_github=yes" "T12 GITHUB_TOKEN = the operator override"
+assert_line "$OUT" "match_gh=yes" "T12 GH_TOKEN re-pointed at the override (gh reads GH_TOKEN first)"
+assert_line "$OUT" "forbid_hit=no" "T12 the projected shared-file value survives under NEITHER name"
+assert_line "$OUT" "source=operator-override" "T12 breadcrumb corrected to operator-override"
+assert_line "$OUT" "agree=yes" "T12 the two names agree"
+assert_line "$OUT" "exported=GH" "T12 both names still reach the nohup'd child"
+
+# ─── 13: reconcile is a NO-OP when execution-core.env sets no token ───────────
+echo ""
+echo "test 13: execution-core.env sets no token → reconcile is a no-op (source stays shared-file)"
+OUT="$(probe T13 CATALYST_GITHUB_TOKEN_FILE="$T/file.token" \
+  RECONCILE="$T/reconcile.sh" ENV_FILE="$T/env-no-token.env" \
+  EXPECT_VALUE="$FAKE_FILE_TOKEN" FORBID_VALUE="$FAKE_OVERRIDE_TOKEN")"
+assert_line "$OUT" "source=shared-file" "T13 breadcrumb NOT falsely flipped to operator-override"
+assert_line "$OUT" "match_github=yes" "T13 GITHUB_TOKEN still the shared-file value"
+assert_line "$OUT" "match_gh=yes" "T13 GH_TOKEN still the shared-file value"
+assert_line "$OUT" "forbid_hit=no" "T13 no override value materialized from nowhere"
+assert_line "$OUT" "agree=yes" "T13 the two names agree"
+
+# ─── 14: reconcile never installs an EMPTY override ───────────────────────────
+echo ""
+echo "test 14: execution-core.env sets GITHUB_TOKEN='' → reconcile installs nothing empty"
+OUT="$(probe T14 CATALYST_GITHUB_TOKEN_FILE="$T/file.token" \
+  RECONCILE="$T/reconcile.sh" ENV_FILE="$T/env-override-empty.env" \
+  EXPECT_VALUE="$FAKE_FILE_TOKEN")"
+assert_line "$OUT" "gh_token=set" "T14 GH_TOKEN not blanked by an empty primary"
+assert_line "$OUT" "match_gh=yes" "T14 GH_TOKEN keeps the projected value (still authenticates)"
+assert_line "$OUT" "source=shared-file" "T14 an empty primary is not an operator override"
+# Deliberate asymmetry: the operator's own empty GITHUB_TOKEN must NOT drag the working
+# GH_TOKEN down with it — a reconcile that mirrored "" would leave `gh` with no credential.
+assert_line "$OUT" "agree=no" "T14 the empty primary is not mirrored onto GH_TOKEN"
+
+# ─── 15: reconcile is a no-op in the "inherited" and "none" ladders ───────────
+echo ""
+echo "test 15: reconcile is a no-op when there is no shared file (inherited / none)"
+OUT="$(probe T15a CATALYST_GITHUB_TOKEN_FILE="$MISSING_TOKEN_FILE" \
+  GITHUB_TOKEN="$FAKE_AMBIENT_GITHUB" \
+  RECONCILE="$T/reconcile.sh" ENV_FILE="$T/env-no-token.env" \
+  EXPECT_VALUE="$FAKE_AMBIENT_GITHUB")"
+assert_line "$OUT" "source=inherited" "T15a inherited breadcrumb survives the reconcile"
+assert_line "$OUT" "match_github=yes" "T15a inherited GITHUB_TOKEN untouched"
+assert_line "$OUT" "match_gh=yes" "T15a inherited GH_TOKEN untouched"
+OUT="$(probe T15b CATALYST_GITHUB_TOKEN_FILE="$MISSING_TOKEN_FILE" \
+  RECONCILE="$T/reconcile.sh" ENV_FILE="$T/env-no-token.env")"
+assert_line "$OUT" "source=none" "T15b none breadcrumb survives the reconcile"
+assert_line "$OUT" "github_token=unset" "T15b GITHUB_TOKEN still unset"
+assert_line "$OUT" "gh_token=unset" "T15b GH_TOKEN still unset"
+assert_line "$OUT" "exported=none" "T15b reconcile manufactures nothing for a child to see"
+
+# ─── 16: XDG_CONFIG_HOME resolution of the default token path ─────────────────
+echo ""
+echo "test 16: default path is \${XDG_CONFIG_HOME:-\$HOME/.config}/catalyst/github-token (matches setup-webhooks.sh:23)"
+mkdir -p "$T/xdg-home/.config/catalyst" "$T/xdg-config/catalyst" "$T/xdg-empty/catalyst"
+printf '%s\n' "$FAKE_HOME_CONFIG_TOKEN" > "$T/xdg-home/.config/catalyst/github-token"
+printf '%s\n' "$FAKE_XDG_TOKEN" > "$T/xdg-config/catalyst/github-token"
+# XDG set → read from there, NOT from ~/.config (the pre-fix hardcoded path).
+OUT="$(probe T16a HOME="$T/xdg-home" XDG_CONFIG_HOME="$T/xdg-config" \
+  EXPECT_VALUE="$FAKE_XDG_TOKEN" FORBID_VALUE="$FAKE_HOME_CONFIG_TOKEN")"
+assert_line "$OUT" "source=shared-file" "T16a XDG_CONFIG_HOME token file is found"
+assert_line "$OUT" "match_github=yes" "T16a GITHUB_TOKEN = the XDG_CONFIG_HOME file"
+assert_line "$OUT" "match_gh=yes" "T16a GH_TOKEN = the XDG_CONFIG_HOME file"
+assert_line "$OUT" "forbid_hit=no" "T16a ~/.config is NOT consulted when XDG_CONFIG_HOME is set"
+# XDG unset → the ~/.config fallback arm of the `:-` still works.
+OUT="$(probe T16b HOME="$T/xdg-home" \
+  EXPECT_VALUE="$FAKE_HOME_CONFIG_TOKEN" FORBID_VALUE="$FAKE_XDG_TOKEN")"
+assert_line "$OUT" "source=shared-file" "T16b ~/.config fallback still resolves when XDG_CONFIG_HOME is unset"
+assert_line "$OUT" "match_github=yes" "T16b GITHUB_TOKEN = the ~/.config file"
+assert_line "$OUT" "match_gh=yes" "T16b GH_TOKEN = the ~/.config file"
+assert_line "$OUT" "forbid_hit=no" "T16b no cross-talk from the XDG dir"
+# XDG set but empty → REPLACES ~/.config (XDG semantics), so nothing is found.
+OUT="$(probe T16c HOME="$T/xdg-home" XDG_CONFIG_HOME="$T/xdg-empty" \
+  FORBID_VALUE="$FAKE_HOME_CONFIG_TOKEN")"
+assert_line "$OUT" "source=none" "T16c XDG_CONFIG_HOME REPLACES ~/.config (no silent second lookup)"
+assert_line "$OUT" "forbid_hit=no" "T16c the ~/.config token is not smuggled in behind XDG"
+assert_line "$OUT" "exported=none" "T16c nothing exported when the XDG path holds no file"
+
+# ─── 17: wiring — reconcile runs AFTER the execution-core.env source ──────────
+echo ""
+echo "test 17: _reconcile_github_token_aliases is WIRED into cmd_start AFTER the execution-core.env source"
+RECONCILE_CALL_LINES="$(grep -nE '^[[:space:]]*_reconcile_github_token_aliases[[:space:]]*$' "$SCRIPT" | cut -d: -f1)"
+RECONCILE_CALL_COUNT="$(printf '%s\n' "$RECONCILE_CALL_LINES" | grep -c '[0-9]' || true)"
+RECONCILE_CALL_LINE="$(printf '%s\n' "$RECONCILE_CALL_LINES" | head -1)"
+if [[ "$RECONCILE_CALL_COUNT" == "1" ]]; then
+  pass "T17 exactly one _reconcile_github_token_aliases invocation site"
+else
+  fail "T17 expected exactly one invocation site" \
+    "found $RECONCILE_CALL_COUNT (lines: $(tr '\n' ' ' <<<"$RECONCILE_CALL_LINES"))"
+fi
+if [[ -n "$RECONCILE_CALL_LINE" && -n "$ENV_SOURCE_LINE" ]] \
+  && [[ "$RECONCILE_CALL_LINE" -gt "$ENV_SOURCE_LINE" ]]; then
+  pass "T17 invoked AFTER execution-core.env is sourced (line $RECONCILE_CALL_LINE > $ENV_SOURCE_LINE)"
+else
+  fail "T17 invocation must FOLLOW the execution-core.env source" \
+    "reconcile=$RECONCILE_CALL_LINE env_source=$ENV_SOURCE_LINE"
+fi
+if [[ -n "$RECONCILE_CALL_LINE" && -n "$CALL_LINE" ]] && [[ "$RECONCILE_CALL_LINE" -gt "$CALL_LINE" ]]; then
+  pass "T17 full ladder order holds: project ($CALL_LINE) < env source ($ENV_SOURCE_LINE) < reconcile ($RECONCILE_CALL_LINE)"
+else
+  fail "T17 reconcile must follow the projection" \
+    "project=$CALL_LINE reconcile=$RECONCILE_CALL_LINE"
+fi
+# The guard is only meaningful if the projection records what IT exported — without this
+# breadcrumb every projection would look like an operator override.
+if grep -q '_CATALYST_PROJECTED_GITHUB_TOKEN=' "$T/helper.sh"; then
+  pass "T17 the projection records _CATALYST_PROJECTED_GITHUB_TOKEN (the no-op guard's input)"
+else
+  fail "T17 projection must record _CATALYST_PROJECTED_GITHUB_TOKEN for the reconcile guard"
+fi
+
+# ─── 18: secret hygiene re-scan, now covering the reconcile + XDG cases ───────
+echo ""
+echo "test 18: secret hygiene re-scan across the full transcript (incl. tests 12-16)"
+TOTAL_STDOUT_LINES="$(grep -c '^stdout_bytes=' "$ALL_OUT" 2>/dev/null || echo 0)"
+ZERO_STDOUT_LINES="$(grep -c '^stdout_bytes=0$' "$ALL_OUT" 2>/dev/null || echo 0)"
+TOTAL_STDERR_LINES="$(grep -c '^stderr_bytes=' "$ALL_OUT" 2>/dev/null || echo 0)"
+ZERO_STDERR_LINES="$(grep -c '^stderr_bytes=0$' "$ALL_OUT" 2>/dev/null || echo 0)"
+if [[ "$TOTAL_STDOUT_LINES" -gt 0 && "$TOTAL_STDOUT_LINES" == "$ZERO_STDOUT_LINES" \
+  && "$TOTAL_STDERR_LINES" == "$ZERO_STDERR_LINES" ]]; then
+  pass "T18 both helpers stayed silent in all $TOTAL_STDOUT_LINES cases (stdout + stderr)"
+else
+  fail "T18 the helpers must never write to stdout/stderr" \
+    "cases=$TOTAL_STDOUT_LINES silent_out=$ZERO_STDOUT_LINES silent_err=$ZERO_STDERR_LINES"
+fi
+LEAKED=""
+for fixture in "$FAKE_FILE_TOKEN" "$FAKE_AMBIENT_GITHUB" "$FAKE_AMBIENT_GH" \
+  "$FAKE_OVERRIDE_TOKEN" "$FAKE_XDG_TOKEN" "$FAKE_HOME_CONFIG_TOKEN"; do
+  grep -qF "$fixture" "$ALL_OUT" && LEAKED="yes"
+done
+if [[ -z "$LEAKED" ]]; then
+  pass "T18 no fixture token VALUE appears in the transcript (booleans/digests only)"
+else
+  fail "T18 a token value leaked into the transcript"
+fi
+if grep -qE 'ghp_|gho_|ghu_|ghs_|ghr_|github_pat_' "$ALL_OUT"; then
+  fail "T18 transcript contains a token-shaped string"
+else
+  pass "T18 transcript contains no token-shaped string (no gh* prefix)"
 fi
 
 echo ""

--- a/plugins/dev/scripts/__tests__/catalyst-execution-core-github-token.test.sh
+++ b/plugins/dev/scripts/__tests__/catalyst-execution-core-github-token.test.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# CTL-1612: `_project_shared_github_token` — the shared GitHub credential projection
+# CTL-1612: `catalyst_project_github_token` — the shared GitHub credential projection
 # that catalyst-execution-core's cmd_start runs BEFORE sourcing execution-core.env.
 #
 # The 2026-08-02 live breakage: a daemon started from a shell that carried a STALE
@@ -12,7 +12,7 @@
 # JS `process.env.X ?? fallback` both treat "" as SET and would defeat gh's fallback.
 #
 # CTL-1612 (Codex P2) adds a SECOND helper to the same ladder,
-# `_reconcile_github_token_aliases`, which runs AFTER execution-core.env is sourced.
+# `catalyst_reconcile_github_token_aliases`, which runs AFTER execution-core.env is sourced.
 # The override was honored only by ordering, and an execution-core.env that set just
 # GITHUB_TOKEN left GH_TOKEN still holding the shared-file value — and `gh` resolves
 # GH_TOKEN FIRST, so the operator override was silently ignored while the provenance
@@ -74,18 +74,25 @@ FAKE_AMBIENT_GH='FAKE-CTL1612-ambient-gh-token-CCCC'
 FAKE_OVERRIDE_TOKEN='FAKE-CTL1612-operator-override-token-DDDD'
 FAKE_XDG_TOKEN='FAKE-CTL1612-xdg-config-home-token-EEEE'
 FAKE_HOME_CONFIG_TOKEN='FAKE-CTL1612-home-dotconfig-token-FFFF'
+# CTL-1612 round 3: fixtures that carry INTERNAL whitespace. A secret is an opaque byte
+# string — nothing forbids a space or a tab inside one — so these are the values the old
+# `tr -d '[:space:]'` reader silently mangled (see tests 21-23).
+FAKE_INTERNAL_SPACE='FAKE-CTL1612 internal space token-GGGG'
+FAKE_INTERNAL_TAB=$'FAKE-CTL1612\tinternal\ttab\ttoken-HHHH'
+FAKE_HMAC_INTERNAL=$'FAKE-CTL1612-hmac key\twith spacing-IIII'
 
-# ─── Extract the helpers under test ───────────────────────────────────────────
-sed -n '/^_project_shared_github_token() {/,/^}/p' "$SCRIPT" > "$T/helper.sh"
-if [[ ! -s "$T/helper.sh" ]] || ! grep -q 'CATALYST_GITHUB_TOKEN_SOURCE' "$T/helper.sh"; then
-  echo "FATAL: could not extract _project_shared_github_token from $SCRIPT" >&2
+# ─── The helpers under test ───────────────────────────────────────────────────
+# CTL-1612: the projection/reconcile pair now lives in ONE shared library sourced by both
+# daemon launchers, instead of being hand-written inline in each. Point the probe straight
+# at it — there is nothing to extract, and testing the real file is what makes these
+# assertions meaningful for BOTH the execution-core and monitor launch paths.
+LIB="$(dirname "$SCRIPT")/lib/catalyst-secret-env.sh"
+if [[ ! -r "$LIB" ]] || ! grep -q 'catalyst_project_github_token' "$LIB"; then
+  echo "FATAL: shared secret-env lib missing or unrecognized at $LIB" >&2
   exit 1
 fi
-sed -n '/^_reconcile_github_token_aliases() {/,/^}/p' "$SCRIPT" > "$T/reconcile.sh"
-if [[ ! -s "$T/reconcile.sh" ]] || ! grep -q 'operator-override' "$T/reconcile.sh"; then
-  echo "FATAL: could not extract _reconcile_github_token_aliases from $SCRIPT" >&2
-  exit 1
-fi
+cp "$LIB" "$T/helper.sh"
+cp "$LIB" "$T/reconcile.sh"
 
 # ─── Probe: run the helper, report booleans/digests only ──────────────────────
 cat > "$T/probe.sh" <<'PROBE'
@@ -96,17 +103,16 @@ set -uo pipefail
 
 # shellcheck disable=SC1090
 source "$HELPER"
-_project_shared_github_token >"$STDOUT_CAP" 2>"$STDERR_CAP"
+catalyst_project_github_token >"$STDOUT_CAP" 2>"$STDERR_CAP"
 
 # CTL-1612 (Codex P2) stage 2 — opt-in, inert unless the case supplies RECONCILE, so
 # tests 1-9 run byte-identically. Replays cmd_start's post-projection sequence: source
 # execution-core.env (the operator override), THEN reconcile the two names.
 if [[ -n "${RECONCILE:-}" ]]; then
-  # shellcheck disable=SC1090
-  source "$RECONCILE"
+  # (already sourced above — the lib is idempotent-source guarded)
   # shellcheck disable=SC1090
   [[ -n "${ENV_FILE:-}" && -f "${ENV_FILE}" ]] && source "$ENV_FILE"
-  _reconcile_github_token_aliases >>"$STDOUT_CAP" 2>>"$STDERR_CAP"
+  catalyst_reconcile_github_token_aliases >>"$STDOUT_CAP" 2>>"$STDERR_CAP"
 fi
 
 gt=unset; [[ -n ${GITHUB_TOKEN+x} ]] && gt=set
@@ -356,12 +362,12 @@ fi
 # ─── 11: wiring — invoked inside cmd_start BEFORE execution-core.env ──────────
 echo ""
 echo "test 11: helper is WIRED into cmd_start before the execution-core.env source"
-CALL_LINES="$(grep -nE '^[[:space:]]*_project_shared_github_token[[:space:]]*$' "$SCRIPT" | cut -d: -f1)"
+CALL_LINES="$(grep -nE '^[[:space:]]*catalyst_project_github_token([[:space:]]|$)' "$SCRIPT" | cut -d: -f1)"
 CALL_COUNT="$(printf '%s\n' "$CALL_LINES" | grep -c '[0-9]' || true)"
 CMD_START_LINE="$(grep -n '^cmd_start() {' "$SCRIPT" | head -1 | cut -d: -f1)"
 ENV_SOURCE_LINE="$(grep -n 'source "\$_daemon_env"' "$SCRIPT" | head -1 | cut -d: -f1)"
 if [[ "$CALL_COUNT" == "1" ]]; then
-  pass "T11 exactly one _project_shared_github_token invocation site"
+  pass "T11 exactly one catalyst_project_github_token invocation site"
 else
   fail "T11 expected exactly one invocation site" "found $CALL_COUNT (lines: $(tr '\n' ' ' <<<"$CALL_LINES"))"
 fi
@@ -471,12 +477,12 @@ assert_line "$OUT" "exported=none" "T16c nothing exported when the XDG path hold
 
 # ─── 17: wiring — reconcile runs AFTER the execution-core.env source ──────────
 echo ""
-echo "test 17: _reconcile_github_token_aliases is WIRED into cmd_start AFTER the execution-core.env source"
-RECONCILE_CALL_LINES="$(grep -nE '^[[:space:]]*_reconcile_github_token_aliases[[:space:]]*$' "$SCRIPT" | cut -d: -f1)"
+echo "test 17: catalyst_reconcile_github_token_aliases is WIRED into cmd_start AFTER the execution-core.env source"
+RECONCILE_CALL_LINES="$(grep -nE '^[[:space:]]*catalyst_reconcile_github_token_aliases([[:space:]]|$)' "$SCRIPT" | cut -d: -f1)"
 RECONCILE_CALL_COUNT="$(printf '%s\n' "$RECONCILE_CALL_LINES" | grep -c '[0-9]' || true)"
 RECONCILE_CALL_LINE="$(printf '%s\n' "$RECONCILE_CALL_LINES" | head -1)"
 if [[ "$RECONCILE_CALL_COUNT" == "1" ]]; then
-  pass "T17 exactly one _reconcile_github_token_aliases invocation site"
+  pass "T17 exactly one catalyst_reconcile_github_token_aliases invocation site"
 else
   fail "T17 expected exactly one invocation site" \
     "found $RECONCILE_CALL_COUNT (lines: $(tr '\n' ' ' <<<"$RECONCILE_CALL_LINES"))"
@@ -578,9 +584,9 @@ OUT="$(
       source "$HELPER"
       # shellcheck disable=SC1090
       source "$RECONCILE"
-      _project_shared_github_token
+      catalyst_project_github_token
       GH_TOKEN=ghp_GHONLY-FAKE-OVERRIDE-000000000   # execution-core.env sets ONLY GH_TOKEN
-      _reconcile_github_token_aliases
+      catalyst_reconcile_github_token_aliases
       echo "source=$CATALYST_GITHUB_TOKEN_SOURCE"
       [ "$GH_TOKEN" = ghp_GHONLY-FAKE-OVERRIDE-000000000 ] && echo "gh_is_override=yes" || echo "gh_is_override=no"
       [ "$GITHUB_TOKEN" = "$GH_TOKEN" ] && echo "agree=yes" || echo "agree=no"
@@ -601,9 +607,9 @@ OUT="$(
       source "$HELPER"
       # shellcheck disable=SC1090
       source "$RECONCILE"
-      _project_shared_github_token
+      catalyst_project_github_token
       GH_TOKEN=""
-      _reconcile_github_token_aliases
+      catalyst_reconcile_github_token_aliases
       echo "source=$CATALYST_GITHUB_TOKEN_SOURCE"
       [ -n "$GITHUB_TOKEN" ] && echo "primary_still_set=yes" || echo "primary_still_set=no"
     '
@@ -612,6 +618,146 @@ printf '### T20b\n%s\n' "$OUT" >> "$ALL_OUT"
 assert_line "$OUT" "source=shared-file" "T20b a blanked alias does not claim operator-override"
 assert_line "$OUT" "primary_still_set=yes" "T20b the working projected credential is preserved"
 
+# ─── 21: Codex round-3 — INTERNAL whitespace is PRESERVED, only the edges trimmed ─
+# The reader used to be `tr -d '[:space:]'`, which deletes EVERY space/tab/newline in the
+# file, not just the trailing one the writer appends. A secret is an opaque byte string,
+# so any value containing a space or a tab was silently truncated into a different, wrong
+# credential — and the failure mode is invisible: the variable looks present, `gh` simply
+# 401s and the launcher reports source=shared-file either way. T9 pinned the trailing
+# newline; these pin the bytes in the MIDDLE, which is the half `tr -d` got wrong.
+#
+# The assertion is a digest comparison against the exact expected string (plus the probe's
+# own in-process EXPECT_VALUE equality). Under the old reader both the digest and the
+# equality flip, so this is a real discriminator — and neither ever prints the value.
+echo ""
+echo "test 21: internal whitespace survives the read (the tr -d '[:space:]' corruption)"
+printf '\n  %s  \n\n' "$FAKE_INTERNAL_SPACE" > "$T/internal-space.token"
+EXPECT_DIGEST="$(printf '%s' "$FAKE_INTERNAL_SPACE" | shasum | cut -c1-12)"
+OUT="$(probe T21a CATALYST_GITHUB_TOKEN_FILE="$T/internal-space.token" \
+  EXPECT_VALUE="$FAKE_INTERNAL_SPACE")"
+assert_line "$OUT" "source=shared-file" "T21a source=shared-file"
+assert_line "$OUT" "match_github=yes" "T21a GITHUB_TOKEN keeps its internal SPACES"
+assert_line "$OUT" "match_gh=yes" "T21a GH_TOKEN keeps its internal SPACES"
+assert_line "$OUT" "digest_github=$EXPECT_DIGEST" "T21a GITHUB_TOKEN digests to the exact expected string"
+assert_line "$OUT" "digest_gh=$EXPECT_DIGEST" "T21a GH_TOKEN digests to the exact expected string"
+
+printf '\t %s \t\n' "$FAKE_INTERNAL_TAB" > "$T/internal-tab.token"
+EXPECT_DIGEST="$(printf '%s' "$FAKE_INTERNAL_TAB" | shasum | cut -c1-12)"
+OUT="$(probe T21b CATALYST_GITHUB_TOKEN_FILE="$T/internal-tab.token" \
+  EXPECT_VALUE="$FAKE_INTERNAL_TAB")"
+assert_line "$OUT" "match_github=yes" "T21b GITHUB_TOKEN keeps its internal TABS"
+assert_line "$OUT" "match_gh=yes" "T21b GH_TOKEN keeps its internal TABS"
+assert_line "$OUT" "digest_github=$EXPECT_DIGEST" "T21b leading/trailing tabs stripped, internal tabs kept (exact digest)"
+assert_line "$OUT" "digest_gh=$EXPECT_DIGEST" "T21b same exact digest under the GH_TOKEN alias"
+
+# The trim must not be reintroduced as a delete. The lib documents the old call in prose,
+# so strip comments before grepping — otherwise the explanation trips its own guard.
+LIB_CODE="$(grep -vE '^[[:space:]]*(#|$)' "$T/helper.sh")"
+if grep -qE "tr[[:space:]]+-d" <<<"$LIB_CODE"; then
+  fail "T21c the shared lib deletes characters with \`tr -d\` again (internal-whitespace corrupter)"
+else
+  pass "T21c the shared lib trims edges only — no \`tr -d\` character deletion"
+fi
+
+# ─── 22: whitespace-only is still EMPTY — with nothing inherited to fall back to ──
+# The trim must not soften the emptiness test: a file holding only spaces/tabs is a
+# non-credential, and exporting its trimmed "" would be worse than not reading it at all
+# (bash ${X:-default} and JS ?? both treat "" as SET). T4 pins the `inherited` arm of the
+# same ladder; this pins the `none` arm, where there is nothing to fall back to.
+echo ""
+echo "test 22: whitespace-only file + nothing inherited → still empty, source=none"
+printf ' \t \n\t\n  ' > "$T/ws-only.token"
+OUT="$(probe T22 CATALYST_GITHUB_TOKEN_FILE="$T/ws-only.token")"
+assert_line "$OUT" "source=none" "T22 whitespace-only file is not a credential (source=none)"
+assert_line "$OUT" "github_token=unset" "T22 GITHUB_TOKEN left unset"
+assert_line "$OUT" "gh_token=unset" "T22 GH_TOKEN left unset"
+assert_line "$OUT" "empty_export=no" "T22 the trimmed-to-empty value is never exported as \"\""
+assert_line "$OUT" "exported=none" "T22 neither name reaches a child process"
+
+# ─── 23: the same reader under the HMAC signing key, via catalyst_read_secret_file ─
+# This is where the corruption actually bites hardest. The webhook secret is an HMAC
+# signing key: a single mangled byte makes every inbound GitHub delivery fail signature
+# verification, with no error logged anywhere — the monitor just goes quiet. Both the
+# low-level reader and the webhook projection are exercised by name here, since
+# catalyst_project_webhook_secret is the other consumer of the shared chain.
+echo ""
+echo "test 23: catalyst_read_secret_file preserves internal whitespace for the HMAC key"
+printf '\n %s \n' "$FAKE_HMAC_INTERNAL" > "$T/webhook-secret-internal"
+EXPECT_DIGEST="$(printf '%s' "$FAKE_HMAC_INTERNAL" | shasum | cut -c1-12)"
+OUT="$(
+  env -i PATH="$PATH" HOME="$T/home" HELPER="$T/helper.sh" \
+    CATALYST_LAYER2_CONFIG_FILE="$T/layer2.json" \
+    SECRET_FILE="$T/webhook-secret-internal" \
+    bash -c '
+      # shellcheck disable=SC1090
+      source "$HELPER"
+      raw=""
+      rc=1
+      raw="$(catalyst_read_secret_file "webhook-secret" "$SECRET_FILE")" && rc=0
+      echo "read_rc=$rc"
+      echo "digest_read=$(printf "%s" "$raw" | shasum | cut -c1-12)"
+      CATALYST_WEBHOOK_SECRET_FILE="$SECRET_FILE" catalyst_project_webhook_secret
+      s=unset; [ -n "${CATALYST_WEBHOOK_SECRET+x}" ] && s=set
+      echo "webhook_secret=$s"
+      d=none; [ "$s" = set ] && d="$(printf "%s" "$CATALYST_WEBHOOK_SECRET" | shasum | cut -c1-12)"
+      echo "digest_webhook=$d"
+    '
+)"
+printf '### T23\n%s\n' "$OUT" >> "$ALL_OUT"
+assert_line "$OUT" "read_rc=0" "T23 catalyst_read_secret_file found the file"
+assert_line "$OUT" "digest_read=$EXPECT_DIGEST" "T23 the reader returns the exact bytes (edges trimmed, middle intact)"
+assert_line "$OUT" "webhook_secret=set" "T23 catalyst_project_webhook_secret exported the key"
+assert_line "$OUT" "digest_webhook=$EXPECT_DIGEST" "T23 the exported HMAC key is byte-identical to the file value"
+
+echo "test 23b: a whitespace-only HMAC file exports nothing (an empty secret DISABLES the route)"
+printf '  \n\t\n' > "$T/webhook-secret-ws"
+OUT="$(
+  env -i PATH="$PATH" HOME="$T/home" HELPER="$T/helper.sh" \
+    CATALYST_LAYER2_CONFIG_FILE="$T/layer2.json" \
+    CATALYST_WEBHOOK_SECRET_FILE="$T/webhook-secret-ws" \
+    bash -c '
+      # shellcheck disable=SC1090
+      source "$HELPER"
+      catalyst_project_webhook_secret
+      s=unset; [ -n "${CATALYST_WEBHOOK_SECRET+x}" ] && s=set
+      echo "webhook_secret=$s"
+      echo "exported=$(bash -c "printf %s \"\${CATALYST_WEBHOOK_SECRET+W}\"")"
+    '
+)"
+printf '### T23b\n%s\n' "$OUT" >> "$ALL_OUT"
+assert_line "$OUT" "webhook_secret=unset" "T23b whitespace-only HMAC file leaves the name unset, never \"\""
+assert_line "$OUT" "exported=" "T23b nothing reaches the monitor child (webhook-config would read \"\" as unconfigured)"
+
+# ─── 24: hygiene re-scan covering the round-3 whitespace fixtures ──────────────
+echo ""
+echo "test 24: secret hygiene re-scan across the full transcript (incl. tests 21-23)"
+TOTAL_STDOUT_LINES="$(grep -c '^stdout_bytes=' "$ALL_OUT" 2>/dev/null || echo 0)"
+ZERO_STDOUT_LINES="$(grep -c '^stdout_bytes=0$' "$ALL_OUT" 2>/dev/null || echo 0)"
+TOTAL_STDERR_LINES="$(grep -c '^stderr_bytes=' "$ALL_OUT" 2>/dev/null || echo 0)"
+ZERO_STDERR_LINES="$(grep -c '^stderr_bytes=0$' "$ALL_OUT" 2>/dev/null || echo 0)"
+if [[ "$TOTAL_STDOUT_LINES" -gt 0 && "$TOTAL_STDOUT_LINES" == "$ZERO_STDOUT_LINES" \
+  && "$TOTAL_STDERR_LINES" == "$ZERO_STDERR_LINES" ]]; then
+  pass "T24 the helpers stayed silent in all $TOTAL_STDOUT_LINES probe cases"
+else
+  fail "T24 the helpers must never write to stdout/stderr" \
+    "cases=$TOTAL_STDOUT_LINES silent_out=$ZERO_STDOUT_LINES silent_err=$ZERO_STDERR_LINES"
+fi
+LEAKED=""
+for fixture in "$FAKE_FILE_TOKEN" "$FAKE_AMBIENT_GITHUB" "$FAKE_AMBIENT_GH" \
+  "$FAKE_OVERRIDE_TOKEN" "$FAKE_XDG_TOKEN" "$FAKE_HOME_CONFIG_TOKEN" \
+  "$FAKE_INTERNAL_SPACE" "$FAKE_INTERNAL_TAB" "$FAKE_HMAC_INTERNAL"; do
+  grep -qF "$fixture" "$ALL_OUT" && LEAKED="yes"
+done
+if [[ -z "$LEAKED" ]]; then
+  pass "T24 no fixture VALUE appears in the transcript, including the whitespace-bearing ones"
+else
+  fail "T24 a secret value leaked into the transcript"
+fi
+if grep -qE 'ghp_|gho_|ghu_|ghs_|ghr_|github_pat_' "$ALL_OUT"; then
+  fail "T24 transcript contains a token-shaped string"
+else
+  pass "T24 transcript contains no token-shaped string (no gh* prefix)"
+fi
 
 echo ""
 echo "─────────────────────────────────────────────"

--- a/plugins/dev/scripts/__tests__/catalyst-execution-core-github-token.test.sh
+++ b/plugins/dev/scripts/__tests__/catalyst-execution-core-github-token.test.sh
@@ -739,6 +739,65 @@ printf '### T23b\n%s\n' "$OUT" >> "$ALL_OUT"
 assert_line "$OUT" "webhook_secret=unset" "T23b whitespace-only HMAC file leaves the name unset, never \"\""
 assert_line "$OUT" "exported=" "T23b nothing reaches the monitor child (webhook-config would read \"\" as unconfigured)"
 
+# ─── 23c: Codex round-5 — ALL trailing line terminators strip, not just the last ─
+# The bash read path (`$(cat …)`) eats every trailing \n, but a CRLF file ending in
+# `\r\n\r\n` left `token\r\n` behind under the old single-pass strip — and the JS re-arm
+# (github-auth-preflight.mjs) had the same single-terminator bug against `\n\n`, so a
+# rotation re-armed to `token\n` and 401'd. Both sides now strip /[\r\n]+$/; this pins
+# the bash half (the .mjs suite pins the JS half).
+echo ""
+echo "test 23c: a CRLF-CRLF file yields the bare token — every trailing terminator removed"
+printf '%s\r\n\r\n' "$FAKE_FILE_TOKEN" > "$T/crlf-multi.token"
+EXPECT_DIGEST="$(printf '%s' "$FAKE_FILE_TOKEN" | shasum | cut -c1-12)"
+OUT="$(probe T23c CATALYST_GITHUB_TOKEN_FILE="$T/crlf-multi.token" EXPECT_VALUE="$FAKE_FILE_TOKEN")"
+assert_line "$OUT" "source=shared-file" "T23c source=shared-file"
+assert_line "$OUT" "match_github=yes" "T23c GITHUB_TOKEN is the bare token"
+assert_line "$OUT" "match_gh=yes" "T23c GH_TOKEN is the bare token"
+assert_line "$OUT" "digest_github=$EXPECT_DIGEST" "T23c exact digest — no residual CR or LF byte"
+assert_line "$OUT" "digest_gh=$EXPECT_DIGEST" "T23c same digest under the GH_TOKEN alias"
+
+# ─── 23d: Codex round-5 — the assignment probe sources the env file ONCE, not per alias ─
+# An env file may carry executed commands (a command substitution fetching a token, a
+# rate-limited credential-helper call). cmd_start sources it once for real; the round-4
+# per-alias sentinel probe then re-sourced it once per name, tripling every side effect
+# on each daemon start. The batch probe keeps detection semantics but adds exactly ONE
+# extra execution, so the file runs twice total here: the real source + one probe.
+echo ""
+echo "test 23d: executed-override detection costs ONE extra env-file execution, not one per alias"
+FAKE_ENVFILE_TOKEN='FAKE-CTL1612-envfile-side-effect-token-JJJJ'
+printf '%s\n' "$FAKE_FILE_TOKEN" > "$T/file.token"
+: > "$T/side-effects.log"
+cat > "$T/side-effect.env" <<'ENVF'
+echo ran >> "$CATALYST_TEST_SIDE_EFFECT_LOG"
+GITHUB_TOKEN="$FAKE_ENVFILE_TOKEN_VALUE"
+ENVF
+OUT="$(
+  env -i PATH="$PATH" HOME="$T/home" HELPER="$T/helper.sh" \
+    CATALYST_GITHUB_TOKEN_FILE="$T/file.token" \
+    CATALYST_LAYER2_CONFIG_FILE="$T/layer2.json" \
+    CATALYST_TEST_SIDE_EFFECT_LOG="$T/side-effects.log" \
+    FAKE_ENVFILE_TOKEN_VALUE="$FAKE_ENVFILE_TOKEN" \
+    ENV_FILE="$T/side-effect.env" \
+    bash -c '
+      # shellcheck disable=SC1090
+      source "$HELPER"
+      catalyst_project_github_token
+      # cmd_start sources the operator env file for real…
+      # shellcheck disable=SC1090
+      source "$ENV_FILE"
+      # …then reconcile probes it — which must add exactly ONE more execution.
+      catalyst_reconcile_github_token_aliases "$ENV_FILE"
+      echo "source=$CATALYST_GITHUB_TOKEN_SOURCE"
+      echo "executions=$(wc -l < "$CATALYST_TEST_SIDE_EFFECT_LOG" | tr -d " ")"
+      m=no; [ "$GITHUB_TOKEN" = "$FAKE_ENVFILE_TOKEN_VALUE" ] && [ "$GH_TOKEN" = "$FAKE_ENVFILE_TOKEN_VALUE" ] && m=yes
+      echo "override_won=$m"
+    '
+)"
+printf '### T23d\n%s\n' "$OUT" >> "$ALL_OUT"
+assert_line "$OUT" "source=operator-override" "T23d the executed assignment is still detected by the batch probe"
+assert_line "$OUT" "override_won=yes" "T23d both aliases re-pointed at the operator's value"
+assert_line "$OUT" "executions=2" "T23d env file ran twice (real source + ONE batch probe), not once per alias"
+
 # ─── 24: hygiene re-scan covering the round-3 whitespace fixtures ──────────────
 echo ""
 echo "test 24: secret hygiene re-scan across the full transcript (incl. tests 21-23)"

--- a/plugins/dev/scripts/__tests__/catalyst-execution-core-github-token.test.sh
+++ b/plugins/dev/scripts/__tests__/catalyst-execution-core-github-token.test.sh
@@ -1,0 +1,358 @@
+#!/usr/bin/env bash
+# CTL-1612: `_project_shared_github_token` — the shared GitHub credential projection
+# that catalyst-execution-core's cmd_start runs BEFORE sourcing execution-core.env.
+#
+# The 2026-08-02 live breakage: a daemon started from a shell that carried a STALE
+# GITHUB_TOKEN handed that dead credential to every child, and `gh` never fell through
+# to hosts.yml. The fix is a precedence ladder —
+#     ambient inherited  <  shared SOPS file  <  execution-core.env (operator override)
+# — so the two load-bearing properties are (a) the FILE WINS over anything inherited
+# (T2/T3, the regression), and (b) when there is nothing anywhere BOTH names are left
+# genuinely unset rather than exported as "" (T5/T6), because bash `${X:-default}` and
+# JS `process.env.X ?? fallback` both treat "" as SET and would defeat gh's fallback.
+#
+# Method: the helper is extracted out of catalyst-execution-core with sed and exercised
+# in isolation, so nothing here boots a daemon, opens a socket, or mints an OAuth token.
+# Every case runs under `env -i` (strictly stronger than `env -u GITHUB_TOKEN -u GH_TOKEN`)
+# with HOME pointed at the sandbox, so a developer's real shell token or real
+# ~/.config/catalyst/github-token can never leak in and make a "nothing inherited" case
+# pass vacuously.
+#
+# SECRET HYGIENE: fixtures are obviously-fake literals, and the probe reports only
+# booleans + short digests — never a token value. That invariant is itself asserted
+# (test 10 greps the whole captured transcript for token-shaped strings AND for the
+# fake fixture literals).
+#
+# Run: bash plugins/dev/scripts/__tests__/catalyst-execution-core-github-token.test.sh
+#
+# NOTE: deliberately standalone — do NOT fold these into
+# __tests__/catalyst-execution-core.test.sh, which hangs (known, pre-existing, out of scope).
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../../.." && pwd)"
+SCRIPT="${REPO_ROOT}/plugins/dev/scripts/catalyst-execution-core"
+
+FAILURES=0
+PASSES=0
+pass() { PASSES=$((PASSES + 1)); echo "  PASS: $1"; }
+fail() { FAILURES=$((FAILURES + 1)); echo "  FAIL: $1"; [ $# -ge 2 ] && echo "    $2"; }
+
+if [[ ! -f "$SCRIPT" ]]; then
+  echo "FATAL: catalyst-execution-core missing: $SCRIPT" >&2
+  exit 1
+fi
+
+T="$(mktemp -d)"
+trap 'rm -rf "$T"' EXIT
+mkdir -p "$T/home"
+
+# Hermeticity belt-and-braces: cmd_start (not exercised here) sources
+# lib/linear-app-actor.sh and would mint a REAL OAuth token against api.linear.app.
+# Point Layer-2 config at an empty object and assert (test 10) that no probe ever
+# printed the app-actor success line.
+echo '{}' > "$T/layer2.json"
+
+# Obviously-fake fixtures. None of these carry a real `gh` token prefix — test 10
+# greps the transcript for those prefixes and must find nothing.
+FAKE_FILE_TOKEN='FAKE-CTL1612-shared-file-token-AAAA'
+FAKE_AMBIENT_GITHUB='FAKE-CTL1612-ambient-github-token-BBBB'
+FAKE_AMBIENT_GH='FAKE-CTL1612-ambient-gh-token-CCCC'
+
+# ─── Extract the helper under test ────────────────────────────────────────────
+sed -n '/^_project_shared_github_token() {/,/^}/p' "$SCRIPT" > "$T/helper.sh"
+if [[ ! -s "$T/helper.sh" ]] || ! grep -q 'CATALYST_GITHUB_TOKEN_SOURCE' "$T/helper.sh"; then
+  echo "FATAL: could not extract _project_shared_github_token from $SCRIPT" >&2
+  exit 1
+fi
+
+# ─── Probe: run the helper, report booleans/digests only ──────────────────────
+cat > "$T/probe.sh" <<'PROBE'
+#!/usr/bin/env bash
+# Runs the extracted helper in this shell (redirection, not a subshell, so the
+# exports survive) and prints a key=value report. NEVER prints a token value.
+set -uo pipefail
+
+# shellcheck disable=SC1090
+source "$HELPER"
+_project_shared_github_token >"$STDOUT_CAP" 2>"$STDERR_CAP"
+
+gt=unset; [[ -n ${GITHUB_TOKEN+x} ]] && gt=set
+gh=unset; [[ -n ${GH_TOKEN+x} ]] && gh=set
+
+# Do the two names agree? (both unset counts as agreement)
+agree=no
+if [[ "$gt" == "$gh" ]]; then
+  if [[ "$gt" == unset ]]; then
+    agree=yes
+  elif [[ "$GITHUB_TOKEN" == "$GH_TOKEN" ]]; then
+    agree=yes
+  fi
+fi
+
+# The "" trap: set-but-empty defeats every downstream ${X:-default} fallback.
+empty_export=no
+[[ "$gt" == set && -z "$GITHUB_TOKEN" ]] && empty_export=yes
+[[ "$gh" == set && -z "$GH_TOKEN" ]] && empty_export=yes
+
+match_github=na
+match_gh=na
+if [[ -n "${EXPECT_VALUE:-}" ]]; then
+  match_github=no; [[ "${GITHUB_TOKEN-}" == "$EXPECT_VALUE" ]] && match_github=yes
+  match_gh=no;     [[ "${GH_TOKEN-}"     == "$EXPECT_VALUE" ]] && match_gh=yes
+fi
+
+forbid_hit=na
+if [[ -n "${FORBID_VALUE:-}" ]]; then
+  forbid_hit=no
+  [[ "${GITHUB_TOKEN-}" == "$FORBID_VALUE" || "${GH_TOKEN-}" == "$FORBID_VALUE" ]] && forbid_hit=yes
+fi
+
+digest_github=none
+[[ "$gt" == set ]] && digest_github="$(printf '%s' "$GITHUB_TOKEN" | shasum | cut -c1-12)"
+digest_gh=none
+[[ "$gh" == set ]] && digest_gh="$(printf '%s' "$GH_TOKEN" | shasum | cut -c1-12)"
+
+# Export-promotion check: a child process only sees EXPORTED names (the CTL-1404
+# bare-vs-export trap — a bare assignment never reaches the nohup'd daemon).
+exported="$(bash -c 'printf "%s%s" "${GITHUB_TOKEN+G}" "${GH_TOKEN+H}"')"
+[[ -z "$exported" ]] && exported=none
+
+echo "source=${CATALYST_GITHUB_TOKEN_SOURCE-<unset>}"
+echo "github_token=$gt"
+echo "gh_token=$gh"
+echo "agree=$agree"
+echo "empty_export=$empty_export"
+echo "match_github=$match_github"
+echo "match_gh=$match_gh"
+echo "forbid_hit=$forbid_hit"
+echo "exported=$exported"
+echo "digest_github=$digest_github"
+echo "digest_gh=$digest_gh"
+echo "stdout_bytes=$(wc -c <"$STDOUT_CAP" | tr -d ' ')"
+echo "stderr_bytes=$(wc -c <"$STDERR_CAP" | tr -d ' ')"
+PROBE
+
+ALL_OUT="$T/transcript.log"
+: > "$ALL_OUT"
+
+# probe <label> [VAR=VALUE ...] — `env -i` scrubs the ambient environment entirely
+# (no inherited GITHUB_TOKEN/GH_TOKEN, no real HOME), then the case's own assignments
+# supply exactly the inputs under test.
+probe() {
+  local label="$1"; shift
+  : > "$T/stdout.cap"; : > "$T/stderr.cap"
+  local rpt
+  rpt="$(
+    env -i -u GITHUB_TOKEN -u GH_TOKEN -u CATALYST_GITHUB_TOKEN_SOURCE \
+      PATH="$PATH" HOME="$T/home" \
+      HELPER="$T/helper.sh" STDOUT_CAP="$T/stdout.cap" STDERR_CAP="$T/stderr.cap" \
+      CATALYST_LAYER2_CONFIG_FILE="$T/layer2.json" \
+      EXPECT_VALUE="" FORBID_VALUE="" \
+      "$@" bash "$T/probe.sh" 2>&1
+  )"
+  printf '### %s\n%s\n' "$label" "$rpt" >> "$ALL_OUT"
+  printf '%s' "$rpt"
+}
+
+# assert_line <report> <expected key=value line> <label>
+assert_line() {
+  if grep -qxF "$2" <<<"$1"; then
+    pass "$3"
+  else
+    fail "$3" "expected report line '$2'; got: $(tr '\n' ' ' <<<"$1")"
+  fi
+}
+
+MISSING_TOKEN_FILE="$T/definitely-absent-token-file"
+
+# ─── 1: shared file present → both names armed from the file ──────────────────
+echo "test 1: file present → GITHUB_TOKEN and GH_TOKEN both = file value, source=shared-file"
+printf '%s' "$FAKE_FILE_TOKEN" > "$T/file.token"
+OUT="$(probe T1 CATALYST_GITHUB_TOKEN_FILE="$T/file.token" EXPECT_VALUE="$FAKE_FILE_TOKEN")"
+assert_line "$OUT" "source=shared-file" "T1 source=shared-file"
+assert_line "$OUT" "match_github=yes" "T1 GITHUB_TOKEN = file value"
+assert_line "$OUT" "match_gh=yes" "T1 GH_TOKEN = file value"
+assert_line "$OUT" "agree=yes" "T1 the two names agree"
+assert_line "$OUT" "exported=GH" "T1 both names are exported (reach the nohup'd child)"
+
+# ─── 2: FILE WINS over a stale inherited GITHUB_TOKEN (the 2026-08-02 bug) ────
+echo ""
+echo "test 2: file WINS over a stale inherited GITHUB_TOKEN (live-breakage regression)"
+OUT="$(probe T2 CATALYST_GITHUB_TOKEN_FILE="$T/file.token" \
+  GITHUB_TOKEN="$FAKE_AMBIENT_GITHUB" \
+  EXPECT_VALUE="$FAKE_FILE_TOKEN" FORBID_VALUE="$FAKE_AMBIENT_GITHUB")"
+assert_line "$OUT" "source=shared-file" "T2 source=shared-file (file outranks ambient)"
+assert_line "$OUT" "forbid_hit=no" "T2 the stale inherited GITHUB_TOKEN was displaced"
+assert_line "$OUT" "match_github=yes" "T2 GITHUB_TOKEN = file value"
+assert_line "$OUT" "match_gh=yes" "T2 GH_TOKEN = file value"
+
+# ─── 3: FILE WINS over a stale inherited GH_TOKEN ─────────────────────────────
+echo ""
+echo "test 3: file WINS over a stale inherited GH_TOKEN"
+OUT="$(probe T3 CATALYST_GITHUB_TOKEN_FILE="$T/file.token" \
+  GH_TOKEN="$FAKE_AMBIENT_GH" \
+  EXPECT_VALUE="$FAKE_FILE_TOKEN" FORBID_VALUE="$FAKE_AMBIENT_GH")"
+assert_line "$OUT" "source=shared-file" "T3 source=shared-file (file outranks ambient)"
+assert_line "$OUT" "forbid_hit=no" "T3 the stale inherited GH_TOKEN was displaced"
+assert_line "$OUT" "match_gh=yes" "T3 GH_TOKEN = file value"
+assert_line "$OUT" "agree=yes" "T3 the two names agree"
+
+# ─── 4: whitespace-only file + inherited value → inherited kept, no clobber ───
+echo ""
+echo "test 4: whitespace-only file + inherited value → inherited kept, source=inherited"
+printf ' \t\n  \n' > "$T/whitespace.token"
+OUT="$(probe T4 CATALYST_GITHUB_TOKEN_FILE="$T/whitespace.token" \
+  GITHUB_TOKEN="$FAKE_AMBIENT_GITHUB" EXPECT_VALUE="$FAKE_AMBIENT_GITHUB")"
+assert_line "$OUT" "source=inherited" "T4 source=inherited"
+assert_line "$OUT" "match_github=yes" "T4 whitespace-only file does not clobber the inherited value"
+assert_line "$OUT" "empty_export=no" "T4 never exports an empty/whitespace value"
+assert_line "$OUT" "agree=yes" "T4 GH_TOKEN reconciled to the kept GITHUB_TOKEN"
+
+# ─── 4b: unreadable file + inherited value → inherited kept ───────────────────
+echo ""
+echo "test 4b: unreadable file + inherited value → inherited kept (the [[ -r ]] guard)"
+printf '%s' "$FAKE_FILE_TOKEN" > "$T/unreadable.token"
+chmod 000 "$T/unreadable.token" 2>/dev/null || true
+if [[ "$(id -u)" == "0" ]] || [[ -r "$T/unreadable.token" ]]; then
+  echo "  SKIP test 4b: cannot make a file unreadable as this user"
+  PASSES=$((PASSES + 1))
+else
+  OUT="$(probe T4b CATALYST_GITHUB_TOKEN_FILE="$T/unreadable.token" \
+    GITHUB_TOKEN="$FAKE_AMBIENT_GITHUB" EXPECT_VALUE="$FAKE_AMBIENT_GITHUB")"
+  assert_line "$OUT" "source=inherited" "T4b unreadable file falls back to inherited"
+  assert_line "$OUT" "match_github=yes" "T4b inherited value preserved through an unreadable file"
+fi
+chmod 600 "$T/unreadable.token" 2>/dev/null || true
+
+# ─── 5: empty file, nothing inherited → BOTH unset ────────────────────────────
+echo ""
+echo "test 5: empty file + nothing inherited → BOTH unset, source=none (gh falls through to hosts.yml)"
+: > "$T/empty.token"
+OUT="$(probe T5 CATALYST_GITHUB_TOKEN_FILE="$T/empty.token")"
+assert_line "$OUT" "source=none" "T5 source=none"
+assert_line "$OUT" "github_token=unset" "T5 GITHUB_TOKEN left unset"
+assert_line "$OUT" "gh_token=unset" "T5 GH_TOKEN left unset"
+assert_line "$OUT" "empty_export=no" "T5 never exports \"\" (would defeat gh's hosts.yml fallback)"
+assert_line "$OUT" "exported=none" "T5 neither name reaches a child process"
+
+# ─── 6: absent file, nothing inherited → BOTH unset ───────────────────────────
+echo ""
+echo "test 6: absent file + nothing inherited → BOTH unset, source=none"
+OUT="$(probe T6 CATALYST_GITHUB_TOKEN_FILE="$MISSING_TOKEN_FILE")"
+assert_line "$OUT" "source=none" "T6 source=none"
+assert_line "$OUT" "github_token=unset" "T6 GITHUB_TOKEN left unset"
+assert_line "$OUT" "gh_token=unset" "T6 GH_TOKEN left unset"
+assert_line "$OUT" "exported=none" "T6 neither name reaches a child process"
+
+# ─── 7: absent file, only GH_TOKEN inherited → preserved ──────────────────────
+echo ""
+echo "test 7: absent file + only GH_TOKEN inherited → preserved and export-promoted"
+OUT="$(probe T7 CATALYST_GITHUB_TOKEN_FILE="$MISSING_TOKEN_FILE" \
+  GH_TOKEN="$FAKE_AMBIENT_GH" EXPECT_VALUE="$FAKE_AMBIENT_GH")"
+assert_line "$OUT" "source=inherited" "T7 source=inherited"
+assert_line "$OUT" "match_gh=yes" "T7 inherited GH_TOKEN preserved"
+assert_line "$OUT" "github_token=unset" "T7 GITHUB_TOKEN is not manufactured"
+assert_line "$OUT" "exported=H" "T7 GH_TOKEN export-promoted (reaches the nohup'd child)"
+
+# ─── 8: absent file, only GITHUB_TOKEN inherited → GH_TOKEN reconciled ────────
+echo ""
+echo "test 8: absent file + only GITHUB_TOKEN inherited → GH_TOKEN reconciled to match"
+OUT="$(probe T8 CATALYST_GITHUB_TOKEN_FILE="$MISSING_TOKEN_FILE" \
+  GITHUB_TOKEN="$FAKE_AMBIENT_GITHUB" EXPECT_VALUE="$FAKE_AMBIENT_GITHUB")"
+assert_line "$OUT" "source=inherited" "T8 source=inherited"
+assert_line "$OUT" "match_github=yes" "T8 inherited GITHUB_TOKEN preserved"
+assert_line "$OUT" "match_gh=yes" "T8 GH_TOKEN reconciled to GITHUB_TOKEN"
+assert_line "$OUT" "agree=yes" "T8 the two names agree"
+assert_line "$OUT" "exported=GH" "T8 both names export-promoted"
+
+# ─── 9: trailing newline in the file is stripped ──────────────────────────────
+echo ""
+echo "test 9: trailing-newline file → whitespace stripped before export"
+printf '%s\n\n' "$FAKE_FILE_TOKEN" > "$T/newline.token"
+OUT="$(probe T9 CATALYST_GITHUB_TOKEN_FILE="$T/newline.token" EXPECT_VALUE="$FAKE_FILE_TOKEN")"
+assert_line "$OUT" "source=shared-file" "T9 source=shared-file"
+assert_line "$OUT" "match_github=yes" "T9 trailing newline stripped from GITHUB_TOKEN"
+assert_line "$OUT" "match_gh=yes" "T9 trailing newline stripped from GH_TOKEN"
+# Same digest as the no-newline fixture in T1 → byte-identical after stripping.
+T1_DIGEST="$(grep -m1 '^digest_github=' <<<"$(probe T9digest CATALYST_GITHUB_TOKEN_FILE="$T/file.token")")"
+T9_DIGEST="$(grep -m1 '^digest_github=' <<<"$OUT")"
+if [[ "$T1_DIGEST" == "$T9_DIGEST" && "$T9_DIGEST" != "digest_github=none" ]]; then
+  pass "T9 newline-terminated file yields the identical value digest as the bare file"
+else
+  fail "T9 stripped value should digest-match the bare file" "bare=$T1_DIGEST newline=$T9_DIGEST"
+fi
+
+# ─── 10: secret hygiene + silence ─────────────────────────────────────────────
+echo ""
+echo "test 10: nothing token-shaped is ever printed, and the helper writes nothing to stdout"
+TOTAL_STDOUT_LINES="$(grep -c '^stdout_bytes=' "$ALL_OUT" 2>/dev/null || echo 0)"
+ZERO_STDOUT_LINES="$(grep -c '^stdout_bytes=0$' "$ALL_OUT" 2>/dev/null || echo 0)"
+if [[ "$TOTAL_STDOUT_LINES" -gt 0 && "$TOTAL_STDOUT_LINES" == "$ZERO_STDOUT_LINES" ]]; then
+  pass "T10 the helper wrote 0 bytes to stdout in all $TOTAL_STDOUT_LINES cases"
+else
+  fail "T10 the helper must never write to stdout" "cases=$TOTAL_STDOUT_LINES silent=$ZERO_STDOUT_LINES"
+fi
+TOTAL_STDERR_LINES="$(grep -c '^stderr_bytes=' "$ALL_OUT" 2>/dev/null || echo 0)"
+ZERO_STDERR_LINES="$(grep -c '^stderr_bytes=0$' "$ALL_OUT" 2>/dev/null || echo 0)"
+if [[ "$TOTAL_STDERR_LINES" -gt 0 && "$TOTAL_STDERR_LINES" == "$ZERO_STDERR_LINES" ]]; then
+  pass "T10 the helper wrote 0 bytes to stderr in all $TOTAL_STDERR_LINES cases"
+else
+  fail "T10 the helper must never write to stderr" "cases=$TOTAL_STDERR_LINES silent=$ZERO_STDERR_LINES"
+fi
+if grep -qE 'ghp_|gho_|ghu_|ghs_|ghr_|github_pat_' "$ALL_OUT"; then
+  fail "T10 transcript contains a token-shaped string"
+else
+  pass "T10 transcript contains no token-shaped string (no gh* prefix)"
+fi
+LEAKED=""
+for fixture in "$FAKE_FILE_TOKEN" "$FAKE_AMBIENT_GITHUB" "$FAKE_AMBIENT_GH"; do
+  grep -qF "$fixture" "$ALL_OUT" && LEAKED="yes"
+done
+if [[ -z "$LEAKED" ]]; then
+  pass "T10 no fixture token VALUE appears in the transcript (booleans/digests only)"
+else
+  fail "T10 a token value leaked into the transcript"
+fi
+# Hermeticity: nothing here may mint a real Linear app-actor OAuth token.
+if grep -qF "authenticated as Catalyst Orchestrator" "$ALL_OUT"; then
+  fail "T10 suite performed a real app-actor OAuth mint (not hermetic)"
+else
+  pass "T10 no app-actor OAuth mint occurred (suite stayed offline)"
+fi
+
+# ─── 11: wiring — invoked inside cmd_start BEFORE execution-core.env ──────────
+echo ""
+echo "test 11: helper is WIRED into cmd_start before the execution-core.env source"
+CALL_LINES="$(grep -nE '^[[:space:]]*_project_shared_github_token[[:space:]]*$' "$SCRIPT" | cut -d: -f1)"
+CALL_COUNT="$(printf '%s\n' "$CALL_LINES" | grep -c '[0-9]' || true)"
+CMD_START_LINE="$(grep -n '^cmd_start() {' "$SCRIPT" | head -1 | cut -d: -f1)"
+ENV_SOURCE_LINE="$(grep -n 'source "\$_daemon_env"' "$SCRIPT" | head -1 | cut -d: -f1)"
+if [[ "$CALL_COUNT" == "1" ]]; then
+  pass "T11 exactly one _project_shared_github_token invocation site"
+else
+  fail "T11 expected exactly one invocation site" "found $CALL_COUNT (lines: $(tr '\n' ' ' <<<"$CALL_LINES"))"
+fi
+CALL_LINE="$(printf '%s\n' "$CALL_LINES" | head -1)"
+if [[ -n "$CMD_START_LINE" && -n "$ENV_SOURCE_LINE" && -n "$CALL_LINE" ]] \
+  && [[ "$CALL_LINE" -gt "$CMD_START_LINE" ]]; then
+  pass "T11 invoked inside cmd_start (line $CALL_LINE > cmd_start line $CMD_START_LINE)"
+else
+  fail "T11 invocation should live inside cmd_start" \
+    "call=$CALL_LINE cmd_start=$CMD_START_LINE env_source=$ENV_SOURCE_LINE"
+fi
+if [[ -n "$CALL_LINE" && -n "$ENV_SOURCE_LINE" ]] && [[ "$CALL_LINE" -lt "$ENV_SOURCE_LINE" ]]; then
+  pass "T11 invoked BEFORE execution-core.env is sourced (operator override still wins)"
+else
+  fail "T11 invocation must precede the execution-core.env source" \
+    "call=$CALL_LINE env_source=$ENV_SOURCE_LINE"
+fi
+
+echo ""
+echo "─────────────────────────────────────────────"
+echo "catalyst-execution-core-github-token: ${PASSES} passed, ${FAILURES} failed"
+if [[ $FAILURES -gt 0 ]]; then
+  exit 1
+fi
+exit 0

--- a/plugins/dev/scripts/__tests__/catalyst-execution-core-github-token.test.sh
+++ b/plugins/dev/scripts/__tests__/catalyst-execution-core-github-token.test.sh
@@ -631,23 +631,30 @@ assert_line "$OUT" "primary_still_set=yes" "T20b the working projected credentia
 # equality flip, so this is a real discriminator — and neither ever prints the value.
 echo ""
 echo "test 21: internal whitespace survives the read (the tr -d '[:space:]' corruption)"
-printf '\n  %s  \n\n' "$FAKE_INTERNAL_SPACE" > "$T/internal-space.token"
-EXPECT_DIGEST="$(printf '%s' "$FAKE_INTERNAL_SPACE" | shasum | cut -c1-12)"
+# CTL-1612 (round 4): the contract is EOL-ONLY stripping. A credential may legitimately
+# begin or end with a space/tab, and trimming those bytes yields a different key — for an
+# HMAC secret that silently rejects every correctly-signed delivery. So the fixture carries
+# significant boundary whitespace AND one trailing newline, and the expectation keeps the
+# edges while losing only the newline.
+SPACE_WITH_EDGES="  ${FAKE_INTERNAL_SPACE}  "
+printf '%s\n' "$SPACE_WITH_EDGES" > "$T/internal-space.token"
+EXPECT_DIGEST="$(printf '%s' "$SPACE_WITH_EDGES" | shasum | cut -c1-12)"
 OUT="$(probe T21a CATALYST_GITHUB_TOKEN_FILE="$T/internal-space.token" \
-  EXPECT_VALUE="$FAKE_INTERNAL_SPACE")"
+  EXPECT_VALUE="$SPACE_WITH_EDGES")"
 assert_line "$OUT" "source=shared-file" "T21a source=shared-file"
-assert_line "$OUT" "match_github=yes" "T21a GITHUB_TOKEN keeps its internal SPACES"
-assert_line "$OUT" "match_gh=yes" "T21a GH_TOKEN keeps its internal SPACES"
+assert_line "$OUT" "match_github=yes" "T21a GITHUB_TOKEN keeps internal AND boundary spaces"
+assert_line "$OUT" "match_gh=yes" "T21a GH_TOKEN keeps internal AND boundary spaces"
 assert_line "$OUT" "digest_github=$EXPECT_DIGEST" "T21a GITHUB_TOKEN digests to the exact expected string"
 assert_line "$OUT" "digest_gh=$EXPECT_DIGEST" "T21a GH_TOKEN digests to the exact expected string"
 
-printf '\t %s \t\n' "$FAKE_INTERNAL_TAB" > "$T/internal-tab.token"
-EXPECT_DIGEST="$(printf '%s' "$FAKE_INTERNAL_TAB" | shasum | cut -c1-12)"
+TAB_WITH_EDGES="\t${FAKE_INTERNAL_TAB}\t"
+printf '%b\n' "$TAB_WITH_EDGES" > "$T/internal-tab.token"
+EXPECT_DIGEST="$(printf '%b' "$TAB_WITH_EDGES" | shasum | cut -c1-12)"
 OUT="$(probe T21b CATALYST_GITHUB_TOKEN_FILE="$T/internal-tab.token" \
-  EXPECT_VALUE="$FAKE_INTERNAL_TAB")"
-assert_line "$OUT" "match_github=yes" "T21b GITHUB_TOKEN keeps its internal TABS"
-assert_line "$OUT" "match_gh=yes" "T21b GH_TOKEN keeps its internal TABS"
-assert_line "$OUT" "digest_github=$EXPECT_DIGEST" "T21b leading/trailing tabs stripped, internal tabs kept (exact digest)"
+  EXPECT_VALUE="$(printf %b "$TAB_WITH_EDGES")")"
+assert_line "$OUT" "match_github=yes" "T21b GITHUB_TOKEN keeps internal AND boundary tabs"
+assert_line "$OUT" "match_gh=yes" "T21b GH_TOKEN keeps internal AND boundary tabs"
+assert_line "$OUT" "digest_github=$EXPECT_DIGEST" "T21b only the EOL is stripped — boundary tabs survive (exact digest)"
 assert_line "$OUT" "digest_gh=$EXPECT_DIGEST" "T21b same exact digest under the GH_TOKEN alias"
 
 # The trim must not be reintroduced as a delete. The lib documents the old call in prose,
@@ -682,8 +689,12 @@ assert_line "$OUT" "exported=none" "T22 neither name reaches a child process"
 # catalyst_project_webhook_secret is the other consumer of the shared chain.
 echo ""
 echo "test 23: catalyst_read_secret_file preserves internal whitespace for the HMAC key"
-printf '\n %s \n' "$FAKE_HMAC_INTERNAL" > "$T/webhook-secret-internal"
-EXPECT_DIGEST="$(printf '%s' "$FAKE_HMAC_INTERNAL" | shasum | cut -c1-12)"
+# CTL-1612 (round 4): EOL-ONLY. An HMAC key may legitimately begin or end with a space —
+# trimming it produces a different key and silently rejects every correctly-signed
+# delivery, which is the same failure class as the `tr -d` corruption this replaced.
+HMAC_WITH_EDGES=" ${FAKE_HMAC_INTERNAL} "
+printf '%s\n' "$HMAC_WITH_EDGES" > "$T/webhook-secret-internal"
+EXPECT_DIGEST="$(printf '%s' "$HMAC_WITH_EDGES" | shasum | cut -c1-12)"
 OUT="$(
   env -i PATH="$PATH" HOME="$T/home" HELPER="$T/helper.sh" \
     CATALYST_LAYER2_CONFIG_FILE="$T/layer2.json" \
@@ -705,7 +716,7 @@ OUT="$(
 )"
 printf '### T23\n%s\n' "$OUT" >> "$ALL_OUT"
 assert_line "$OUT" "read_rc=0" "T23 catalyst_read_secret_file found the file"
-assert_line "$OUT" "digest_read=$EXPECT_DIGEST" "T23 the reader returns the exact bytes (edges trimmed, middle intact)"
+assert_line "$OUT" "digest_read=$EXPECT_DIGEST" "T23 the reader returns the exact bytes (only the EOL removed)"
 assert_line "$OUT" "webhook_secret=set" "T23 catalyst_project_webhook_secret exported the key"
 assert_line "$OUT" "digest_webhook=$EXPECT_DIGEST" "T23 the exported HMAC key is byte-identical to the file value"
 

--- a/plugins/dev/scripts/__tests__/catalyst-monitor-dist-redirect.test.sh
+++ b/plugins/dev/scripts/__tests__/catalyst-monitor-dist-redirect.test.sh
@@ -120,6 +120,74 @@ run_bootstrap() {
     '
 }
 
+# CTL-1612: install a stub bun that dumps the child environment to
+# $root/env-captured and exits, so cmd_start's env projection can be inspected
+# without actually running the server.
+install_bun_env_capture() {
+  local root="$1"
+  cat > "$root/bin/bun" <<STUB_BUN
+#!/usr/bin/env bash
+printenv > "$root/env-captured"
+STUB_BUN
+  chmod +x "$root/bin/bun"
+}
+
+# CTL-1612: run cmd_start() with bootstrap skipped and the env-capture stub bun.
+# Ambient webhook-secret state is scrubbed with `env -u` FIRST so a developer's own
+# shell export can never leak in and make a "nothing inherited" case pass for the
+# wrong reason; extra NAME=VALUE args (after $root) are re-applied on top of the
+# scrubbed env. CATALYST_WEBHOOK_SECRET_FILE is always pinned into the sandbox by
+# the caller, so the real ~/.config/catalyst/webhook-secret is never read.
+run_cmd_start() {
+  local root="$1"
+  shift
+  env -u CATALYST_WEBHOOK_SECRET -u CATALYST_WEBHOOK_SECRET_FILE -u CATALYST_CONFIG_DIR \
+    PATH="$root/bin:$PATH" \
+    CATALYST_DIR="$root/catalyst" \
+    MONITOR_SERVER_SCRIPT="$root/srv/server.ts" \
+    MONITOR_UI_DIST_DIR="$root/dist" \
+    MONITOR_SKIP_BOOTSTRAP=1 \
+    "$@" \
+    bash -c '
+      source "'"$MONITOR_SH"'" url >/dev/null 2>&1
+      cmd_start >/dev/null 2>&1 || true
+    ' 2>/dev/null || true
+  sleep 0.2
+}
+
+# CTL-1612 assertions over the captured child env. Secret VALUES are never echoed —
+# a mismatch reports only that the value differs, so a leaked real secret can never
+# reach the test log.
+assert_captured_secret() {
+  local root="$1" expected="$2" label="$3"
+  local capture="$root/env-captured"
+  if [[ ! -f "$capture" ]]; then
+    fail "$label — stub bun did not capture env (cmd_start may not have launched the server)"
+    return
+  fi
+  if grep -qxF "CATALYST_WEBHOOK_SECRET=$expected" "$capture" 2>/dev/null; then
+    pass "$label"
+  elif grep -q '^CATALYST_WEBHOOK_SECRET=' "$capture" 2>/dev/null; then
+    fail "$label — CATALYST_WEBHOOK_SECRET set to a different value (redacted)"
+  else
+    fail "$label — CATALYST_WEBHOOK_SECRET not present in the server env"
+  fi
+}
+
+assert_no_captured_secret() {
+  local root="$1" label="$2"
+  local capture="$root/env-captured"
+  if [[ ! -f "$capture" ]]; then
+    fail "$label — stub bun did not capture env (cmd_start may not have launched the server)"
+    return
+  fi
+  if grep -q '^CATALYST_WEBHOOK_SECRET=' "$capture" 2>/dev/null; then
+    fail "$label — CATALYST_WEBHOOK_SECRET was exported (value redacted); an empty secret makes webhook-config treat the GitHub route as unconfigured"
+  else
+    pass "$label"
+  fi
+}
+
 # ─── Test 1: build is redirected to dist dir ────────────────────────────────
 echo "Test 1: bootstrap redirects vite build to MONITOR_UI_DIST_DIR"
 ROOT="$(make_sandbox)"
@@ -475,6 +543,58 @@ if [[ ! -f "$ROOT/dist/.source-sha" ]]; then
 else
   fail "dist/.source-sha written despite empty git SHA (should be skipped)"
 fi
+rm -rf "$ROOT"
+
+# ─── Test 13: cmd_start projects CATALYST_WEBHOOK_SECRET from the secret file ─
+# CTL-1612. webhook-config.ts resolves the GitHub HMAC key from process.env ONLY,
+# so cmd_start must project it from the SOPS-managed file the same way the launchd
+# wrapper does — file-wins, whitespace-stripped, and NEVER exported as "".
+# Every value below is an obviously-fake literal; no real secret is ever read
+# (CATALYST_WEBHOOK_SECRET_FILE is pinned into the sandbox in all five sub-cases).
+echo ""
+echo "Test 13: cmd_start projects CATALYST_WEBHOOK_SECRET from the secret file (CTL-1612)"
+
+# (a) file has a secret, nothing inherited → projected verbatim
+ROOT="$(make_sandbox)"
+install_bun_env_capture "$ROOT"
+echo "whsec_fake_1" > "$ROOT/webhook-secret"
+run_cmd_start "$ROOT" CATALYST_WEBHOOK_SECRET_FILE="$ROOT/webhook-secret"
+assert_captured_secret "$ROOT" "whsec_fake_1" "13a: file value projected into the server env"
+rm -rf "$ROOT"
+
+# (b) FILE WINS over a stale value already exported by the invoking shell
+ROOT="$(make_sandbox)"
+install_bun_env_capture "$ROOT"
+echo "whsec_fake_2" > "$ROOT/webhook-secret"
+run_cmd_start "$ROOT" \
+  CATALYST_WEBHOOK_SECRET_FILE="$ROOT/webhook-secret" \
+  CATALYST_WEBHOOK_SECRET=whsec_stale
+assert_captured_secret "$ROOT" "whsec_fake_2" "13b: file wins over a stale inherited export"
+rm -rf "$ROOT"
+
+# (c) whitespace-only file → no-op; the inherited value must survive, not be clobbered
+ROOT="$(make_sandbox)"
+install_bun_env_capture "$ROOT"
+printf '   \n\t\n' > "$ROOT/webhook-secret"
+run_cmd_start "$ROOT" \
+  CATALYST_WEBHOOK_SECRET_FILE="$ROOT/webhook-secret" \
+  CATALYST_WEBHOOK_SECRET=whsec_stale
+assert_captured_secret "$ROOT" "whsec_stale" "13c: whitespace-only file leaves the inherited value intact"
+rm -rf "$ROOT"
+
+# (d) EMPTY file, nothing inherited → variable absent entirely (never exported as "")
+ROOT="$(make_sandbox)"
+install_bun_env_capture "$ROOT"
+: > "$ROOT/webhook-secret"
+run_cmd_start "$ROOT" CATALYST_WEBHOOK_SECRET_FILE="$ROOT/webhook-secret"
+assert_no_captured_secret "$ROOT" "13d: empty file exports nothing (no empty-string secret)"
+rm -rf "$ROOT"
+
+# (e) absent file, nothing inherited → likewise absent
+ROOT="$(make_sandbox)"
+install_bun_env_capture "$ROOT"
+run_cmd_start "$ROOT" CATALYST_WEBHOOK_SECRET_FILE="$ROOT/no-such-webhook-secret"
+assert_no_captured_secret "$ROOT" "13e: absent file exports nothing (no empty-string secret)"
 rm -rf "$ROOT"
 
 # ─── Summary ─────────────────────────────────────────────────────────────────

--- a/plugins/dev/scripts/__tests__/catalyst-monitor-dist-redirect.test.sh
+++ b/plugins/dev/scripts/__tests__/catalyst-monitor-dist-redirect.test.sh
@@ -133,20 +133,34 @@ STUB_BUN
 }
 
 # CTL-1612: run cmd_start() with bootstrap skipped and the env-capture stub bun.
-# Ambient webhook-secret state is scrubbed with `env -u` FIRST so a developer's own
+# Ambient credential state is scrubbed with `env -u` FIRST so a developer's own
 # shell export can never leak in and make a "nothing inherited" case pass for the
 # wrong reason; extra NAME=VALUE args (after $root) are re-applied on top of the
-# scrubbed env. CATALYST_WEBHOOK_SECRET_FILE is always pinned into the sandbox by
-# the caller, so the real ~/.config/catalyst/webhook-secret is never read.
+# scrubbed env.
+#
+# BOTH secret-file overrides then default to absent sandbox paths, and every default
+# sits BEFORE "$@" so a case can override the one it is testing (env applies
+# assignments left-to-right, last wins). This is what keeps the suite hermetic now
+# that cmd_start projects TWO credentials: without the github-token pin, the
+# webhook-only cases would resolve the real ~/.config/catalyst/github-token and write
+# a live token into the capture file.
+#
+# _CATALYST_SECRET_ENV_SH_LOADED is scrubbed too: it is the shared lib's
+# idempotent-source guard, and an exported one would make cmd_start's `source` a no-op,
+# leaving every projection silently unperformed.
 run_cmd_start() {
   local root="$1"
   shift
   env -u CATALYST_WEBHOOK_SECRET -u CATALYST_WEBHOOK_SECRET_FILE -u CATALYST_CONFIG_DIR \
+    -u GITHUB_TOKEN -u GH_TOKEN -u CATALYST_GITHUB_TOKEN_FILE \
+    -u CATALYST_GITHUB_TOKEN_SOURCE -u _CATALYST_SECRET_ENV_SH_LOADED \
     PATH="$root/bin:$PATH" \
     CATALYST_DIR="$root/catalyst" \
     MONITOR_SERVER_SCRIPT="$root/srv/server.ts" \
     MONITOR_UI_DIST_DIR="$root/dist" \
     MONITOR_SKIP_BOOTSTRAP=1 \
+    CATALYST_WEBHOOK_SECRET_FILE="$root/absent-webhook-secret" \
+    CATALYST_GITHUB_TOKEN_FILE="$root/absent-github-token" \
     "$@" \
     bash -c '
       source "'"$MONITOR_SH"'" url >/dev/null 2>&1
@@ -185,6 +199,52 @@ assert_no_captured_secret() {
     fail "$label — CATALYST_WEBHOOK_SECRET was exported (value redacted); an empty secret makes webhook-config treat the GitHub route as unconfigured"
   else
     pass "$label"
+  fi
+}
+
+# CTL-1612: the same two assertions for the GitHub credential, over BOTH names at once.
+# `gh` resolves GH_TOKEN before GITHUB_TOKEN, so "the token reached the child" is only
+# true when both names carry it — a single-name projection leaves a stale GH_TOKEN
+# shadowing the fix. Values are never echoed; a mismatch names the variable only.
+assert_captured_token() {
+  local root="$1" expected="$2" label="$3"
+  local capture="$root/env-captured"
+  local name missing="" wrong=""
+  if [[ ! -f "$capture" ]]; then
+    fail "$label — stub bun did not capture env (cmd_start may not have launched the server)"
+    return
+  fi
+  for name in GITHUB_TOKEN GH_TOKEN; do
+    if grep -qxF "$name=$expected" "$capture" 2>/dev/null; then
+      continue
+    elif grep -q "^$name=" "$capture" 2>/dev/null; then
+      wrong="$wrong $name"
+    else
+      missing="$missing $name"
+    fi
+  done
+  if [[ -z "$missing" && -z "$wrong" ]]; then
+    pass "$label"
+  else
+    fail "$label — wrong value (redacted) for:${wrong:-none}; absent from server env:${missing:-none}"
+  fi
+}
+
+assert_no_captured_token() {
+  local root="$1" label="$2"
+  local capture="$root/env-captured"
+  local name present=""
+  if [[ ! -f "$capture" ]]; then
+    fail "$label — stub bun did not capture env (cmd_start may not have launched the server)"
+    return
+  fi
+  for name in GITHUB_TOKEN GH_TOKEN; do
+    grep -q "^$name=" "$capture" 2>/dev/null && present="$present $name"
+  done
+  if [[ -z "$present" ]]; then
+    pass "$label"
+  else
+    fail "$label — exported (value redacted):$present; an empty-string token is SET as far as \${X:-default} is concerned and defeats gh's hosts.yml/keyring fallback"
   fi
 }
 
@@ -596,6 +656,141 @@ install_bun_env_capture "$ROOT"
 run_cmd_start "$ROOT" CATALYST_WEBHOOK_SECRET_FILE="$ROOT/no-such-webhook-secret"
 assert_no_captured_secret "$ROOT" "13e: absent file exports nothing (no empty-string secret)"
 rm -rf "$ROOT"
+
+# ─── Test 14: cmd_start projects the GitHub credential into the server env ───
+# CTL-1612 round 3. orch-monitor makes 13 `gh` calls across 5 files (pr-status,
+# preview-status, webhook-subscriber, webhook-replay, repo-icon-fetcher) and contains
+# ZERO references to GITHUB_TOKEN/GH_TOKEN — its GitHub auth was purely ambient
+# inheritance, i.e. exactly the defect this ticket exists to fix, still unfixed on the
+# monitor side until now. All 13 sites inherit this launcher's env, so projecting once
+# in cmd_start fixes them all and none of them change; the property worth pinning is
+# therefore "the credential reaches the child", not anything per-call-site.
+#
+# BOTH names are asserted because `gh` resolves GH_TOKEN BEFORE GITHUB_TOKEN: projecting
+# only GITHUB_TOKEN would leave a stale GH_TOKEN in the launcher's ancestry shadowing
+# the fix, which is the same trap the daemon launcher already hit.
+# Every value below is an obviously-fake literal, and run_cmd_start pins
+# CATALYST_GITHUB_TOKEN_FILE into the sandbox, so the real
+# ~/.config/catalyst/github-token is never read.
+echo ""
+echo "Test 14: cmd_start projects GITHUB_TOKEN + GH_TOKEN from the shared file (CTL-1612)"
+
+# (a) file has a token, nothing inherited → both names reach the server
+ROOT="$(make_sandbox)"
+install_bun_env_capture "$ROOT"
+echo "FAKE-CTL1612-monitor-file-token-AAAA" > "$ROOT/github-token"
+run_cmd_start "$ROOT" CATALYST_GITHUB_TOKEN_FILE="$ROOT/github-token"
+assert_captured_token "$ROOT" "FAKE-CTL1612-monitor-file-token-AAAA" \
+  "14a: file value reaches the server env under BOTH names"
+rm -rf "$ROOT"
+
+# (b) FILE WINS over a stale GITHUB_TOKEN exported by the invoking shell — the stale
+#     inherited value IS the live breakage; a fill-if-unset projection would fix nothing.
+ROOT="$(make_sandbox)"
+install_bun_env_capture "$ROOT"
+echo "FAKE-CTL1612-monitor-file-token-BBBB" > "$ROOT/github-token"
+run_cmd_start "$ROOT" \
+  CATALYST_GITHUB_TOKEN_FILE="$ROOT/github-token" \
+  GITHUB_TOKEN=FAKE-CTL1612-monitor-stale-github-XXXX
+assert_captured_token "$ROOT" "FAKE-CTL1612-monitor-file-token-BBBB" \
+  "14b: file wins over a stale inherited GITHUB_TOKEN (both names re-pointed)"
+rm -rf "$ROOT"
+
+# (c) FILE WINS over a stale GH_TOKEN too — the name gh reads first.
+ROOT="$(make_sandbox)"
+install_bun_env_capture "$ROOT"
+echo "FAKE-CTL1612-monitor-file-token-CCCC" > "$ROOT/github-token"
+run_cmd_start "$ROOT" \
+  CATALYST_GITHUB_TOKEN_FILE="$ROOT/github-token" \
+  GH_TOKEN=FAKE-CTL1612-monitor-stale-gh-YYYY
+assert_captured_token "$ROOT" "FAKE-CTL1612-monitor-file-token-CCCC" \
+  "14c: file wins over a stale inherited GH_TOKEN (gh resolves this name first)"
+rm -rf "$ROOT"
+
+# (d) absent file, nothing inherited → NEITHER name exported (not even as "")
+ROOT="$(make_sandbox)"
+install_bun_env_capture "$ROOT"
+run_cmd_start "$ROOT" CATALYST_GITHUB_TOKEN_FILE="$ROOT/no-such-github-token"
+assert_no_captured_token "$ROOT" "14d: absent file exports neither name (gh falls through to hosts.yml)"
+rm -rf "$ROOT"
+
+# (e) EMPTY file, nothing inherited → likewise neither name
+ROOT="$(make_sandbox)"
+install_bun_env_capture "$ROOT"
+: > "$ROOT/github-token"
+run_cmd_start "$ROOT" CATALYST_GITHUB_TOKEN_FILE="$ROOT/github-token"
+assert_no_captured_token "$ROOT" "14e: empty file exports neither name (no empty-string token)"
+rm -rf "$ROOT"
+
+# (f) the webhook secret is still projected alongside it — the two projections must not
+#     shadow each other, since cmd_start now performs both from the same shared lib.
+ROOT="$(make_sandbox)"
+install_bun_env_capture "$ROOT"
+echo "whsec_fake_3" > "$ROOT/webhook-secret"
+echo "FAKE-CTL1612-monitor-file-token-DDDD" > "$ROOT/github-token"
+run_cmd_start "$ROOT" \
+  CATALYST_WEBHOOK_SECRET_FILE="$ROOT/webhook-secret" \
+  CATALYST_GITHUB_TOKEN_FILE="$ROOT/github-token"
+assert_captured_secret "$ROOT" "whsec_fake_3" "14f: webhook secret still projected beside the token"
+assert_captured_token "$ROOT" "FAKE-CTL1612-monitor-file-token-DDDD" \
+  "14f: token still projected beside the webhook secret"
+rm -rf "$ROOT"
+
+# ─── Test 15: the launchd wrapper no longer projects anything itself ─────────
+# CTL-1612 round 3, fix D. The wrapper used to hand-roll its own resolution chain, and
+# it ignored CATALYST_WEBHOOK_SECRET_FILE / CATALYST_CONFIG_DIR / CATALYST_LAYER2_CONFIG_FILE
+# that cmd_start honors — so a LaunchAgent pointing at a custom path silently got the
+# HOME/XDG default instead, and its `$(cat)` exported "" for an empty file, which makes
+# webhook-config treat the GitHub route as unconfigured. Two launch paths, ONE projection:
+# these are structural greps precisely because "the second copy is gone" is the fix.
+# Comments are stripped first — the wrapper documents the removed code in prose, and a
+# comment mentioning the old variable must not read as a live assignment (or vice versa).
+echo ""
+echo "Test 15: launchd wrapper delegates the projection to catalyst-monitor.sh (CTL-1612)"
+LAUNCHD_SH="${REPO_ROOT}/plugins/dev/scripts/orch-monitor/dist/catalyst-monitor-launchd.sh"
+if [[ ! -f "$LAUNCHD_SH" ]]; then
+  fail "15: launchd wrapper missing at $LAUNCHD_SH"
+else
+  LAUNCHD_CODE="$(grep -vE '^[[:space:]]*(#|$)' "$LAUNCHD_SH")"
+
+  if grep -qE '(^|[[:space:];])(export[[:space:]]+)?CATALYST_WEBHOOK_SECRET=' <<<"$LAUNCHD_CODE"; then
+    fail "15a: wrapper still assigns CATALYST_WEBHOOK_SECRET — the duplicate projection is back"
+  else
+    pass "15a: wrapper contains no CATALYST_WEBHOOK_SECRET assignment"
+  fi
+
+  if grep -qE 'webhook-secret|github-token' <<<"$LAUNCHD_CODE"; then
+    fail "15b: wrapper still reads a secret file directly (it must defer to the shared chain)"
+  else
+    pass "15b: wrapper reads no secret file of its own"
+  fi
+
+  # The whitespace-corrupting reader must not survive here either (fix B).
+  if grep -qE "tr[[:space:]]+-d" <<<"$LAUNCHD_CODE"; then
+    fail "15c: wrapper still strips characters with \`tr -d\` (internal whitespace corrupter)"
+  else
+    pass "15c: wrapper no longer runs the \`tr -d\` secret reader"
+  fi
+
+  if grep -qE '^[[:space:]]*exec[[:space:]].*catalyst-monitor\.sh"?[[:space:]]+start' <<<"$LAUNCHD_CODE"; then
+    pass "15d: wrapper still execs catalyst-monitor.sh start"
+  else
+    fail "15d: wrapper no longer execs catalyst-monitor.sh start" \
+      && echo "    code lines: $(tr '\n' ' ' <<<"$LAUNCHD_CODE")"
+  fi
+
+  # ...and the one surviving projection is cmd_start's, via the shared library.
+  MON_CODE="$(grep -vE '^[[:space:]]*(#|$)' "$MONITOR_SH")"
+  SRC_COUNT="$(grep -cE '^[[:space:]]*(\.|source)[[:space:]].*lib/catalyst-secret-env\.sh' <<<"$MON_CODE")"
+  WH_COUNT="$(grep -cE '^[[:space:]]*catalyst_project_webhook_secret([[:space:]]|$)' <<<"$MON_CODE")"
+  GT_COUNT="$(grep -cE '^[[:space:]]*catalyst_project_github_token([[:space:]]|$)' <<<"$MON_CODE")"
+  if [[ "$SRC_COUNT" == "1" && "$WH_COUNT" == "1" && "$GT_COUNT" == "1" ]]; then
+    pass "15e: catalyst-monitor.sh sources the shared lib once and projects each credential once"
+  else
+    fail "15e: expected exactly one source + one call per credential" \
+      && echo "    source=$SRC_COUNT webhook=$WH_COUNT github=$GT_COUNT"
+  fi
+fi
 
 # ─── Summary ─────────────────────────────────────────────────────────────────
 echo ""

--- a/plugins/dev/scripts/catalyst-execution-core
+++ b/plugins/dev/scripts/catalyst-execution-core
@@ -154,12 +154,28 @@ _default_otel_from_user_settings() {
 # whitespace-only value IS sent and 401s, which is why we strip before testing.)
 # Minimal-touch: reads the file into a local, exports it, and NEVER logs or echoes the value.
 _project_shared_github_token() {
-	# XDG-aware, matching setup-webhooks.sh:23 and lib/linear-app-actor.sh:30 — on a host
-	# with XDG_CONFIG_HOME set, cluster-sync materializes the file there, and a hardcoded
-	# ~/.config would silently miss it.
-	local _f="${CATALYST_GITHUB_TOKEN_FILE:-${XDG_CONFIG_HOME:-${HOME}/.config}/catalyst/github-token}"
-	local _tok=""
-	[[ -r "$_f" ]] && _tok="$(tr -d '[:space:]' <"$_f" 2>/dev/null)"
+	# Resolution CHAIN, because the writers disagree (Codex P1, round 2). cluster-sync
+	# materializes bare secrets into dirname(getLayer2ConfigPath()), whose default is
+	# HARDCODED ~/.config/catalyst (config.mjs) — it is NOT XDG-aware. Other tooling
+	# (setup-webhooks.sh:23, lib/linear-app-actor.sh:30) IS. Reading only the XDG path
+	# would therefore miss every rotation on an XDG host, which is strictly worse than
+	# the hardcoded read it replaced. So try the cluster-sync destination FIRST, then the
+	# XDG location, and take the first readable non-empty file.
+	local _tok="" _f=""
+	local _cands=()
+	if [[ -n "${CATALYST_GITHUB_TOKEN_FILE:-}" ]]; then
+		_cands=("$CATALYST_GITHUB_TOKEN_FILE")
+	else
+		# cluster-sync's own destination (honors the Layer-2 override the writer honors).
+		local _l2="${CATALYST_LAYER2_CONFIG_FILE:-${HOME}/.config/catalyst/config.json}"
+		_cands+=("$(dirname "$_l2")/github-token")
+		_cands+=("${XDG_CONFIG_HOME:-${HOME}/.config}/catalyst/github-token")
+	fi
+	for _f in "${_cands[@]}"; do
+		[[ -r "$_f" ]] || continue
+		_tok="$(tr -d '[:space:]' <"$_f" 2>/dev/null)"
+		[[ -n "$_tok" ]] && break
+	done
 	if [[ -n "$_tok" ]]; then
 		export GITHUB_TOKEN="$_tok" GH_TOKEN="$_tok"
 		export CATALYST_GITHUB_TOKEN_SOURCE="shared-file"
@@ -180,8 +196,10 @@ _project_shared_github_token() {
 		export CATALYST_GITHUB_TOKEN_SOURCE="none"
 	fi
 	# Remember what WE projected so the post-source reconcile below can tell an operator
-	# override apart from our own value.
+	# override apart from our own value. BOTH names are tracked: an override may set
+	# either one, and GH_TOKEN is the one `gh` actually reads first.
 	_CATALYST_PROJECTED_GITHUB_TOKEN="${GITHUB_TOKEN:-}"
+	_CATALYST_PROJECTED_GH_TOKEN="${GH_TOKEN:-}"
 }
 
 # _reconcile_github_token_aliases — CTL-1612 (Codex P2). MUST run AFTER
@@ -193,13 +211,23 @@ _project_shared_github_token() {
 # the override would be silently ignored and the provenance breadcrumb would still claim
 # "shared-file". Re-point the alias at the winning value and correct the breadcrumb.
 _reconcile_github_token_aliases() {
-	# Nothing changed the primary name → the projection's own pairing already holds.
-	[[ "${GITHUB_TOKEN:-}" == "${_CATALYST_PROJECTED_GITHUB_TOKEN:-}" ]] && return 0
-	if [[ -n "${GITHUB_TOKEN:-}" ]]; then
-		export GITHUB_TOKEN
-		export GH_TOKEN="$GITHUB_TOKEN"
-		export CATALYST_GITHUB_TOKEN_SOURCE="operator-override"
+	local _gh_changed=0 _gt_changed=0 _win=""
+	[[ "${GH_TOKEN:-}" != "${_CATALYST_PROJECTED_GH_TOKEN:-}" ]] && _gh_changed=1
+	[[ "${GITHUB_TOKEN:-}" != "${_CATALYST_PROJECTED_GITHUB_TOKEN:-}" ]] && _gt_changed=1
+	# Neither name moved → the projection's own pairing already holds.
+	(( _gh_changed || _gt_changed )) || return 0
+	# An override may set EITHER name. GH_TOKEN wins when it moved, because that is the
+	# name `gh` resolves first — so an operator who set only GH_TOKEN clearly meant it,
+	# and mirroring GITHUB_TOKEN onto it would silently defeat the override.
+	if (( _gh_changed )) && [[ -n "${GH_TOKEN:-}" ]]; then
+		_win="$GH_TOKEN"
+	elif (( _gt_changed )) && [[ -n "${GITHUB_TOKEN:-}" ]]; then
+		_win="$GITHUB_TOKEN"
 	fi
+	# An override that BLANKS a name is not a credential — leave the pair as projected.
+	[[ -n "$_win" ]] || return 0
+	export GITHUB_TOKEN="$_win" GH_TOKEN="$_win"
+	export CATALYST_GITHUB_TOKEN_SOURCE="operator-override"
 }
 
 # CTL-846: is host:port accepting TCP connections? bash /dev/tcp first, nc fallback.

--- a/plugins/dev/scripts/catalyst-execution-core
+++ b/plugins/dev/scripts/catalyst-execution-core
@@ -154,7 +154,10 @@ _default_otel_from_user_settings() {
 # whitespace-only value IS sent and 401s, which is why we strip before testing.)
 # Minimal-touch: reads the file into a local, exports it, and NEVER logs or echoes the value.
 _project_shared_github_token() {
-	local _f="${CATALYST_GITHUB_TOKEN_FILE:-${HOME}/.config/catalyst/github-token}"
+	# XDG-aware, matching setup-webhooks.sh:23 and lib/linear-app-actor.sh:30 — on a host
+	# with XDG_CONFIG_HOME set, cluster-sync materializes the file there, and a hardcoded
+	# ~/.config would silently miss it.
+	local _f="${CATALYST_GITHUB_TOKEN_FILE:-${XDG_CONFIG_HOME:-${HOME}/.config}/catalyst/github-token}"
 	local _tok=""
 	[[ -r "$_f" ]] && _tok="$(tr -d '[:space:]' <"$_f" 2>/dev/null)"
 	if [[ -n "$_tok" ]]; then
@@ -175,6 +178,27 @@ _project_shared_github_token() {
 		# Neither file nor inherited value: leave BOTH unset so `gh` falls through to
 		# hosts.yml / the keyring (how mini authenticates today). Never export "".
 		export CATALYST_GITHUB_TOKEN_SOURCE="none"
+	fi
+	# Remember what WE projected so the post-source reconcile below can tell an operator
+	# override apart from our own value.
+	_CATALYST_PROJECTED_GITHUB_TOKEN="${GITHUB_TOKEN:-}"
+}
+
+# _reconcile_github_token_aliases — CTL-1612 (Codex P2). MUST run AFTER
+# execution-core.env is sourced.
+#
+# The operator override is honored by ORDERING: we project first, the machine-local env
+# sources second and wins. But an override that sets only GITHUB_TOKEN would leave
+# GH_TOKEN still holding OUR shared-file value — and since `gh` resolves GH_TOKEN first,
+# the override would be silently ignored and the provenance breadcrumb would still claim
+# "shared-file". Re-point the alias at the winning value and correct the breadcrumb.
+_reconcile_github_token_aliases() {
+	# Nothing changed the primary name → the projection's own pairing already holds.
+	[[ "${GITHUB_TOKEN:-}" == "${_CATALYST_PROJECTED_GITHUB_TOKEN:-}" ]] && return 0
+	if [[ -n "${GITHUB_TOKEN:-}" ]]; then
+		export GITHUB_TOKEN
+		export GH_TOKEN="$GITHUB_TOKEN"
+		export CATALYST_GITHUB_TOKEN_SOURCE="operator-override"
 	fi
 }
 
@@ -221,6 +245,10 @@ cmd_start() {
 	local _daemon_env="${CATALYST_EXECUTION_CORE_ENV:-${HOME}/.config/catalyst/execution-core.env}"
 	# shellcheck disable=SC1090
 	[[ -f "$_daemon_env" ]] && source "$_daemon_env"
+	# CTL-1612 (Codex P2): the operator override just won on GITHUB_TOKEN — re-point
+	# GH_TOKEN at it, or `gh` (which reads GH_TOKEN first) would keep using the value we
+	# projected and silently ignore the override.
+	_reconcile_github_token_aliases
 	# CTL-1404: after the machine-local env wins, fill any unset OTLP telemetry keys from
 	# ~/.claude/settings.json so the SDK-path child `claude` CLI can export claude_code_* metrics
 	# (token/cost/session). No-op when the keys are already set or settings.json/jq are absent.

--- a/plugins/dev/scripts/catalyst-execution-core
+++ b/plugins/dev/scripts/catalyst-execution-core
@@ -129,106 +129,11 @@ _default_otel_from_user_settings() {
 	done
 }
 
-# CTL-1612: arm the SHARED GitHub credential on EVERY daemon start, from the
-# SOPS-managed per-node file cluster-sync materializes (~/.config/catalyst/github-token).
-# Sibling of the CTL-1398 claude-accounts.env arm below, for the same reason: a daemon
-# otherwise inherits whatever credential its launching process happened to hold and never
-# re-reads it, so a rotation reaches new login shells but NEVER a running daemon. That is
-# not hypothetical — on 2026-08-02 both minis restarted holding a revoked token and every
-# daemon-side `gh` API call 401'd for hours (the file on disk was valid the whole time).
-#
-# FILE-WINS, deliberately (this is the load-bearing choice): ~/.zshenv exports GITHUB_TOKEN
-# by snapshotting this same file at shell start, and THAT stale snapshot is exactly what the
-# daemons are holding. A fill-if-unset projection would leave the stale value winning and fix
-# nothing. Operators who need a per-machine override still get one — execution-core.env is
-# sourced AFTER this helper runs, so its explicit value wins over the shared file.
-#
-# BOTH names: `gh` resolves GH_TOKEN BEFORE GITHUB_TOKEN, so exporting only the latter would
-# leave a stale GH_TOKEN anywhere in the launcher's ancestry silently shadowing the fix.
-# Same both-names shape lib/linear-app-actor.sh uses for LINEAR_API_TOKEN/LINEAR_API_KEY.
-#
-# Empty/whitespace-only/absent/unreadable file = TOTAL no-op (env byte-identical), never an
-# empty export: bash `${X:-default}` and JS `process.env.X ?? fallback` both treat "" as SET,
-# so an empty export would defeat every downstream fallback. (An empty GITHUB_TOKEN does NOT
-# by itself suppress gh's hosts.yml/keyring fallback — verified on gh 2.92.0 — but a
-# whitespace-only value IS sent and 401s, which is why we strip before testing.)
-# Minimal-touch: reads the file into a local, exports it, and NEVER logs or echoes the value.
-_project_shared_github_token() {
-	# Resolution CHAIN, because the writers disagree (Codex P1, round 2). cluster-sync
-	# materializes bare secrets into dirname(getLayer2ConfigPath()), whose default is
-	# HARDCODED ~/.config/catalyst (config.mjs) — it is NOT XDG-aware. Other tooling
-	# (setup-webhooks.sh:23, lib/linear-app-actor.sh:30) IS. Reading only the XDG path
-	# would therefore miss every rotation on an XDG host, which is strictly worse than
-	# the hardcoded read it replaced. So try the cluster-sync destination FIRST, then the
-	# XDG location, and take the first readable non-empty file.
-	local _tok="" _f=""
-	local _cands=()
-	if [[ -n "${CATALYST_GITHUB_TOKEN_FILE:-}" ]]; then
-		_cands=("$CATALYST_GITHUB_TOKEN_FILE")
-	else
-		# cluster-sync's own destination (honors the Layer-2 override the writer honors).
-		local _l2="${CATALYST_LAYER2_CONFIG_FILE:-${HOME}/.config/catalyst/config.json}"
-		_cands+=("$(dirname "$_l2")/github-token")
-		_cands+=("${XDG_CONFIG_HOME:-${HOME}/.config}/catalyst/github-token")
-	fi
-	for _f in "${_cands[@]}"; do
-		[[ -r "$_f" ]] || continue
-		_tok="$(tr -d '[:space:]' <"$_f" 2>/dev/null)"
-		[[ -n "$_tok" ]] && break
-	done
-	if [[ -n "$_tok" ]]; then
-		export GITHUB_TOKEN="$_tok" GH_TOKEN="$_tok"
-		export CATALYST_GITHUB_TOKEN_SOURCE="shared-file"
-	elif [[ -n "${GITHUB_TOKEN:-}${GH_TOKEN:-}" ]]; then
-		# No shared file: keep whatever was inherited, but export-promote it so a BARE
-		# assignment reaches the nohup'd child (the CTL-1404 Codex-P1 bare-vs-export trap).
-		# Reconcile the pair — a stale GH_TOKEN would otherwise outrank a good GITHUB_TOKEN.
-		if [[ -n "${GITHUB_TOKEN:-}" ]]; then
-			export GITHUB_TOKEN
-			export GH_TOKEN="$GITHUB_TOKEN"
-		else
-			export GH_TOKEN
-		fi
-		export CATALYST_GITHUB_TOKEN_SOURCE="inherited"
-	else
-		# Neither file nor inherited value: leave BOTH unset so `gh` falls through to
-		# hosts.yml / the keyring (how mini authenticates today). Never export "".
-		export CATALYST_GITHUB_TOKEN_SOURCE="none"
-	fi
-	# Remember what WE projected so the post-source reconcile below can tell an operator
-	# override apart from our own value. BOTH names are tracked: an override may set
-	# either one, and GH_TOKEN is the one `gh` actually reads first.
-	_CATALYST_PROJECTED_GITHUB_TOKEN="${GITHUB_TOKEN:-}"
-	_CATALYST_PROJECTED_GH_TOKEN="${GH_TOKEN:-}"
-}
-
-# _reconcile_github_token_aliases — CTL-1612 (Codex P2). MUST run AFTER
-# execution-core.env is sourced.
-#
-# The operator override is honored by ORDERING: we project first, the machine-local env
-# sources second and wins. But an override that sets only GITHUB_TOKEN would leave
-# GH_TOKEN still holding OUR shared-file value — and since `gh` resolves GH_TOKEN first,
-# the override would be silently ignored and the provenance breadcrumb would still claim
-# "shared-file". Re-point the alias at the winning value and correct the breadcrumb.
-_reconcile_github_token_aliases() {
-	local _gh_changed=0 _gt_changed=0 _win=""
-	[[ "${GH_TOKEN:-}" != "${_CATALYST_PROJECTED_GH_TOKEN:-}" ]] && _gh_changed=1
-	[[ "${GITHUB_TOKEN:-}" != "${_CATALYST_PROJECTED_GITHUB_TOKEN:-}" ]] && _gt_changed=1
-	# Neither name moved → the projection's own pairing already holds.
-	(( _gh_changed || _gt_changed )) || return 0
-	# An override may set EITHER name. GH_TOKEN wins when it moved, because that is the
-	# name `gh` resolves first — so an operator who set only GH_TOKEN clearly meant it,
-	# and mirroring GITHUB_TOKEN onto it would silently defeat the override.
-	if (( _gh_changed )) && [[ -n "${GH_TOKEN:-}" ]]; then
-		_win="$GH_TOKEN"
-	elif (( _gt_changed )) && [[ -n "${GITHUB_TOKEN:-}" ]]; then
-		_win="$GITHUB_TOKEN"
-	fi
-	# An override that BLANKS a name is not a credential — leave the pair as projected.
-	[[ -n "$_win" ]] || return 0
-	export GITHUB_TOKEN="$_win" GH_TOKEN="$_win"
-	export CATALYST_GITHUB_TOKEN_SOURCE="operator-override"
-}
+# CTL-1612: the shared-credential projection lives in lib/catalyst-secret-env.sh so the
+# execution-core launcher, the monitor launcher and the in-process re-arm all resolve the
+# SAME file by the SAME chain. The first cut hand-wrote that chain in four places and they
+# immediately diverged (only one honored CATALYST_CONFIG_DIR) — every review finding across
+# three rounds landed in the duplicated logic, not in the design. One copy, sourced.
 
 # CTL-846: is host:port accepting TCP connections? bash /dev/tcp first, nc fallback.
 # Used to gate mitmproxy proxy vars so a down proxy degrades to direct mode instead of
@@ -264,7 +169,9 @@ cmd_start() {
 	# Ordering does the work here: no conditional can distinguish "inherited from a stale parent"
 	# from "deliberately set by the operator", but running first and letting execution-core.env
 	# source afterwards gives both the fix and the escape hatch.
-	_project_shared_github_token
+	# shellcheck disable=SC1090
+	source "$SCRIPT_DIR/lib/catalyst-secret-env.sh"
+	catalyst_project_github_token
 	# Machine-local daemon env: source ~/.config/catalyst/execution-core.env if present
 	# so per-machine settings survive restarts — e.g. routing the daemon's Linear/gh
 	# (Node fetch/undici) traffic through the local mitmproxy audit. Node's native
@@ -273,10 +180,13 @@ cmd_start() {
 	local _daemon_env="${CATALYST_EXECUTION_CORE_ENV:-${HOME}/.config/catalyst/execution-core.env}"
 	# shellcheck disable=SC1090
 	[[ -f "$_daemon_env" ]] && source "$_daemon_env"
-	# CTL-1612 (Codex P2): the operator override just won on GITHUB_TOKEN — re-point
-	# GH_TOKEN at it, or `gh` (which reads GH_TOKEN first) would keep using the value we
-	# projected and silently ignore the override.
-	_reconcile_github_token_aliases
+	# CTL-1612 (Codex P2): the operator override just won — re-point the OTHER alias at it,
+	# or `gh` (which reads GH_TOKEN first) would keep using the value we projected and
+	# silently ignore the override. The env file is passed so the reconcile can detect an
+	# ASSIGNMENT rather than a value change: pinning the same value the shared file already
+	# had is still an explicit override, and marking it as one is what stops the in-process
+	# re-arm from later overwriting the operator's machine-local pin.
+	catalyst_reconcile_github_token_aliases "$_daemon_env"
 	# CTL-1404: after the machine-local env wins, fill any unset OTLP telemetry keys from
 	# ~/.claude/settings.json so the SDK-path child `claude` CLI can export claude_code_* metrics
 	# (token/cost/session). No-op when the keys are already set or settings.json/jq are absent.

--- a/plugins/dev/scripts/catalyst-execution-core
+++ b/plugins/dev/scripts/catalyst-execution-core
@@ -129,6 +129,55 @@ _default_otel_from_user_settings() {
 	done
 }
 
+# CTL-1612: arm the SHARED GitHub credential on EVERY daemon start, from the
+# SOPS-managed per-node file cluster-sync materializes (~/.config/catalyst/github-token).
+# Sibling of the CTL-1398 claude-accounts.env arm below, for the same reason: a daemon
+# otherwise inherits whatever credential its launching process happened to hold and never
+# re-reads it, so a rotation reaches new login shells but NEVER a running daemon. That is
+# not hypothetical — on 2026-08-02 both minis restarted holding a revoked token and every
+# daemon-side `gh` API call 401'd for hours (the file on disk was valid the whole time).
+#
+# FILE-WINS, deliberately (this is the load-bearing choice): ~/.zshenv exports GITHUB_TOKEN
+# by snapshotting this same file at shell start, and THAT stale snapshot is exactly what the
+# daemons are holding. A fill-if-unset projection would leave the stale value winning and fix
+# nothing. Operators who need a per-machine override still get one — execution-core.env is
+# sourced AFTER this helper runs, so its explicit value wins over the shared file.
+#
+# BOTH names: `gh` resolves GH_TOKEN BEFORE GITHUB_TOKEN, so exporting only the latter would
+# leave a stale GH_TOKEN anywhere in the launcher's ancestry silently shadowing the fix.
+# Same both-names shape lib/linear-app-actor.sh uses for LINEAR_API_TOKEN/LINEAR_API_KEY.
+#
+# Empty/whitespace-only/absent/unreadable file = TOTAL no-op (env byte-identical), never an
+# empty export: bash `${X:-default}` and JS `process.env.X ?? fallback` both treat "" as SET,
+# so an empty export would defeat every downstream fallback. (An empty GITHUB_TOKEN does NOT
+# by itself suppress gh's hosts.yml/keyring fallback — verified on gh 2.92.0 — but a
+# whitespace-only value IS sent and 401s, which is why we strip before testing.)
+# Minimal-touch: reads the file into a local, exports it, and NEVER logs or echoes the value.
+_project_shared_github_token() {
+	local _f="${CATALYST_GITHUB_TOKEN_FILE:-${HOME}/.config/catalyst/github-token}"
+	local _tok=""
+	[[ -r "$_f" ]] && _tok="$(tr -d '[:space:]' <"$_f" 2>/dev/null)"
+	if [[ -n "$_tok" ]]; then
+		export GITHUB_TOKEN="$_tok" GH_TOKEN="$_tok"
+		export CATALYST_GITHUB_TOKEN_SOURCE="shared-file"
+	elif [[ -n "${GITHUB_TOKEN:-}${GH_TOKEN:-}" ]]; then
+		# No shared file: keep whatever was inherited, but export-promote it so a BARE
+		# assignment reaches the nohup'd child (the CTL-1404 Codex-P1 bare-vs-export trap).
+		# Reconcile the pair — a stale GH_TOKEN would otherwise outrank a good GITHUB_TOKEN.
+		if [[ -n "${GITHUB_TOKEN:-}" ]]; then
+			export GITHUB_TOKEN
+			export GH_TOKEN="$GITHUB_TOKEN"
+		else
+			export GH_TOKEN
+		fi
+		export CATALYST_GITHUB_TOKEN_SOURCE="inherited"
+	else
+		# Neither file nor inherited value: leave BOTH unset so `gh` falls through to
+		# hosts.yml / the keyring (how mini authenticates today). Never export "".
+		export CATALYST_GITHUB_TOKEN_SOURCE="none"
+	fi
+}
+
 # CTL-846: is host:port accepting TCP connections? bash /dev/tcp first, nc fallback.
 # Used to gate mitmproxy proxy vars so a down proxy degrades to direct mode instead of
 # breaking every daemon/worker API call with "connection refused".
@@ -157,6 +206,13 @@ cmd_start() {
 	local neutral_otel
 	neutral_otel="$(_neutralize_otel_attrs "${OTEL_RESOURCE_ATTRIBUTES-}")"
 	export OTEL_RESOURCE_ATTRIBUTES="$neutral_otel"
+	# CTL-1612: arm the shared GitHub credential from the SOPS-managed file BEFORE the
+	# machine-local env is sourced, so the precedence is
+	#   ambient inherited  <  shared SOPS file  <  execution-core.env (explicit operator override).
+	# Ordering does the work here: no conditional can distinguish "inherited from a stale parent"
+	# from "deliberately set by the operator", but running first and letting execution-core.env
+	# source afterwards gives both the fix and the escape hatch.
+	_project_shared_github_token
 	# Machine-local daemon env: source ~/.config/catalyst/execution-core.env if present
 	# so per-machine settings survive restarts — e.g. routing the daemon's Linear/gh
 	# (Node fetch/undici) traffic through the local mitmproxy audit. Node's native

--- a/plugins/dev/scripts/catalyst-monitor.sh
+++ b/plugins/dev/scripts/catalyst-monitor.sh
@@ -339,27 +339,23 @@ cmd_start() {
   # FILE-WINS for the same reason as the daemon's GitHub credential: a stale shell export
   # is exactly what we are correcting. Empty/whitespace/absent = no-op, never export ""
   # (an empty secret makes webhook-config treat the route as unconfigured).
-  # Resolution CHAIN, because two writers disagree: setup-webhooks.sh:23 writes to
-  # ${XDG_CONFIG_HOME:-$HOME/.config}/catalyst/webhook-secret, while cluster-sync
-  # materializes bare secrets into dirname(getLayer2ConfigPath()) — hardcoded
-  # ~/.config/catalyst, NOT XDG-aware. Reading only one of them would silently miss the
-  # other and leave the GitHub webhook route disabled. Take the first readable non-empty.
-  local _wh_val="" _wh_file="" _wh_cands=()
-  if [[ -n "${CATALYST_WEBHOOK_SECRET_FILE:-}" ]]; then
-    _wh_cands=("$CATALYST_WEBHOOK_SECRET_FILE")
-  elif [[ -n "${CATALYST_CONFIG_DIR:-}" ]]; then
-    _wh_cands=("${CATALYST_CONFIG_DIR}/webhook-secret")
-  else
-    local _l2="${CATALYST_LAYER2_CONFIG_FILE:-${HOME}/.config/catalyst/config.json}"
-    _wh_cands+=("$(dirname "$_l2")/webhook-secret")
-    _wh_cands+=("${XDG_CONFIG_HOME:-${HOME}/.config}/catalyst/webhook-secret")
-  fi
-  for _wh_file in "${_wh_cands[@]}"; do
-    [[ -r "$_wh_file" ]] || continue
-    _wh_val="$(tr -d '[:space:]' <"$_wh_file" 2>/dev/null)"
-    [[ -n "$_wh_val" ]] && break
-  done
-  [[ -n "$_wh_val" ]] && export CATALYST_WEBHOOK_SECRET="$_wh_val"
+  # CTL-1612: arm BOTH cluster-synced credentials this daemon needs, via the one shared
+  # resolution chain (lib/catalyst-secret-env.sh).
+  #
+  # webhook-secret: webhook-config.ts resolves the GitHub HMAC key from process.env ONLY
+  # (no file fallback, unlike the Linear per-team secrets) and captures it once at boot, so
+  # a monitor started without it runs with the GitHub webhook route silently DISABLED.
+  #
+  # github-token: the monitor makes 13 `gh` calls across 5 files (pr-status, preview-status,
+  # webhook-subscriber, webhook-replay, repo-icon-fetcher) and contains ZERO references to
+  # GITHUB_TOKEN/GH_TOKEN — its GitHub auth is purely ambient inheritance, which is exactly
+  # the bug this ticket exists to fix. doctor.mjs checkRepoIconTokenScope already exists to
+  # warn about this inherited token. Projecting here fixes all 13 sites at once, because they
+  # all inherit this launcher's env; none of them need to change.
+  # shellcheck disable=SC1090
+  source "$SCRIPT_DIR/lib/catalyst-secret-env.sh"
+  catalyst_project_webhook_secret
+  catalyst_project_github_token
 
   CATALYST_CONFIG_PATH="${CATALYST_CONFIG_PATH:-}" \
   MONITOR_PORT="$PORT" \

--- a/plugins/dev/scripts/catalyst-monitor.sh
+++ b/plugins/dev/scripts/catalyst-monitor.sh
@@ -339,7 +339,11 @@ cmd_start() {
   # FILE-WINS for the same reason as the daemon's GitHub credential: a stale shell export
   # is exactly what we are correcting. Empty/whitespace/absent = no-op, never export ""
   # (an empty secret makes webhook-config treat the route as unconfigured).
-  local _wh_file="${CATALYST_WEBHOOK_SECRET_FILE:-${CATALYST_CONFIG_DIR:-${HOME}/.config/catalyst}/webhook-secret}"
+  # XDG-aware: setup-webhooks.sh:23 writes the secret to
+  # ${XDG_CONFIG_HOME:-$HOME/.config}/catalyst/webhook-secret, so a hardcoded ~/.config
+  # would silently miss a freshly-generated secret on an XDG host and leave the GitHub
+  # webhook route disabled.
+  local _wh_file="${CATALYST_WEBHOOK_SECRET_FILE:-${CATALYST_CONFIG_DIR:-${XDG_CONFIG_HOME:-${HOME}/.config}/catalyst}/webhook-secret}"
   local _wh_val=""
   [[ -r "$_wh_file" ]] && _wh_val="$(tr -d '[:space:]' <"$_wh_file" 2>/dev/null)"
   [[ -n "$_wh_val" ]] && export CATALYST_WEBHOOK_SECRET="$_wh_val"

--- a/plugins/dev/scripts/catalyst-monitor.sh
+++ b/plugins/dev/scripts/catalyst-monitor.sh
@@ -339,13 +339,26 @@ cmd_start() {
   # FILE-WINS for the same reason as the daemon's GitHub credential: a stale shell export
   # is exactly what we are correcting. Empty/whitespace/absent = no-op, never export ""
   # (an empty secret makes webhook-config treat the route as unconfigured).
-  # XDG-aware: setup-webhooks.sh:23 writes the secret to
-  # ${XDG_CONFIG_HOME:-$HOME/.config}/catalyst/webhook-secret, so a hardcoded ~/.config
-  # would silently miss a freshly-generated secret on an XDG host and leave the GitHub
-  # webhook route disabled.
-  local _wh_file="${CATALYST_WEBHOOK_SECRET_FILE:-${CATALYST_CONFIG_DIR:-${XDG_CONFIG_HOME:-${HOME}/.config}/catalyst}/webhook-secret}"
-  local _wh_val=""
-  [[ -r "$_wh_file" ]] && _wh_val="$(tr -d '[:space:]' <"$_wh_file" 2>/dev/null)"
+  # Resolution CHAIN, because two writers disagree: setup-webhooks.sh:23 writes to
+  # ${XDG_CONFIG_HOME:-$HOME/.config}/catalyst/webhook-secret, while cluster-sync
+  # materializes bare secrets into dirname(getLayer2ConfigPath()) — hardcoded
+  # ~/.config/catalyst, NOT XDG-aware. Reading only one of them would silently miss the
+  # other and leave the GitHub webhook route disabled. Take the first readable non-empty.
+  local _wh_val="" _wh_file="" _wh_cands=()
+  if [[ -n "${CATALYST_WEBHOOK_SECRET_FILE:-}" ]]; then
+    _wh_cands=("$CATALYST_WEBHOOK_SECRET_FILE")
+  elif [[ -n "${CATALYST_CONFIG_DIR:-}" ]]; then
+    _wh_cands=("${CATALYST_CONFIG_DIR}/webhook-secret")
+  else
+    local _l2="${CATALYST_LAYER2_CONFIG_FILE:-${HOME}/.config/catalyst/config.json}"
+    _wh_cands+=("$(dirname "$_l2")/webhook-secret")
+    _wh_cands+=("${XDG_CONFIG_HOME:-${HOME}/.config}/catalyst/webhook-secret")
+  fi
+  for _wh_file in "${_wh_cands[@]}"; do
+    [[ -r "$_wh_file" ]] || continue
+    _wh_val="$(tr -d '[:space:]' <"$_wh_file" 2>/dev/null)"
+    [[ -n "$_wh_val" ]] && break
+  done
   [[ -n "$_wh_val" ]] && export CATALYST_WEBHOOK_SECRET="$_wh_val"
 
   CATALYST_CONFIG_PATH="${CATALYST_CONFIG_PATH:-}" \

--- a/plugins/dev/scripts/catalyst-monitor.sh
+++ b/plugins/dev/scripts/catalyst-monitor.sh
@@ -328,6 +328,22 @@ cmd_start() {
   mkdir -p "$(dirname "$PID_FILE")" 2>/dev/null || true
   mkdir -p "$CATALYST_DIR/wt" 2>/dev/null || true
 
+  # CTL-1612: project the webhook signing secret from the SOPS-managed file, matching
+  # what the launchd wrapper (orch-monitor/dist/catalyst-monitor-launchd.sh) already
+  # does. Without this the two launch paths disagree: webhook-config.ts resolves the
+  # GitHub HMAC key from process.env ONLY (no file fallback — unlike the Linear per-team
+  # secrets), so a stack-launched monitor on a host whose shell never exported it runs
+  # with the GitHub webhook route silently DISABLED. It is also boot-captured (read once
+  # at loadWebhookConfig, then closed over per request), so a rotation needs a restart —
+  # which is why webhook-secret is now enrolled in cluster-sync's boot-captured registry.
+  # FILE-WINS for the same reason as the daemon's GitHub credential: a stale shell export
+  # is exactly what we are correcting. Empty/whitespace/absent = no-op, never export ""
+  # (an empty secret makes webhook-config treat the route as unconfigured).
+  local _wh_file="${CATALYST_WEBHOOK_SECRET_FILE:-${CATALYST_CONFIG_DIR:-${HOME}/.config/catalyst}/webhook-secret}"
+  local _wh_val=""
+  [[ -r "$_wh_file" ]] && _wh_val="$(tr -d '[:space:]' <"$_wh_file" 2>/dev/null)"
+  [[ -n "$_wh_val" ]] && export CATALYST_WEBHOOK_SECRET="$_wh_val"
+
   CATALYST_CONFIG_PATH="${CATALYST_CONFIG_PATH:-}" \
   MONITOR_PORT="$PORT" \
   MONITOR_PUBLIC_DIR="${MONITOR_UI_DIST_DIR}" \

--- a/plugins/dev/scripts/execution-core/cluster-sync.mjs
+++ b/plugins/dev/scripts/execution-core/cluster-sync.mjs
@@ -271,10 +271,25 @@ export function syncSecretFiles(opts = {}) {
     ageKeyFile = defaultAgeKeyFile(),
     decrypt = makeSopsDecrypt(ageKeyFile),
     writeFile = defaultWriteFile,
+    // CTL-1612 (Codex P2): read-back seam so we can tell a REWRITE from a real CHANGE.
+    // Never throws — an unreadable/absent destination simply counts as changed.
+    readFile = (p) => {
+      try {
+        return readFileSync(p, "utf8");
+      } catch {
+        return null;
+      }
+    },
     logger = log,
   } = opts;
 
-  const result = { written: [], failed: [], skipped: false, reason: null };
+  // `written` = every entry we (re)materialized; `changed` = the subset whose CONTENT
+  // actually differs from what was already on disk. They diverge constantly: any commit
+  // touching secrets/ makes syncSecretFiles re-decrypt and rewrite the WHOLE bundle, so
+  // `written` lists every bare file even when one unrelated entry rotated. Restart alarms
+  // must key off `changed`, or a routine rotation of some other secret would demand a
+  // daemon+monitor restart for credentials that did not move (Codex P2).
+  const result = { written: [], changed: [], failed: [], skipped: false, reason: null };
   const src = resolve(clusterDir, "secrets", "node-secret-files.sops.json");
   if (!existsSync(src)) {
     result.reason = "absent";
@@ -308,8 +323,11 @@ export function syncSecretFiles(opts = {}) {
     }
     if (typeof content !== "string") continue;
     try {
-      writeFile(resolve(configDir, name), content);
+      const dest = resolve(configDir, name);
+      const prior = readFile(dest); // null = absent/unreadable → treat as changed
+      writeFile(dest, content);
       result.written.push(name);
+      if (prior !== content) result.changed.push(name);
     } catch (err) {
       logger.warn(`[cluster-sync] write ${name} failed (${err?.message ?? err})`);
       // Partial bare-file failure: a REQUESTED file decrypted but did not
@@ -838,7 +856,15 @@ export function refreshClusterSecretsIfChanged(opts = {}) {
   // applied". This is the timer's restart-required surface (the daemon timer calls
   // this fn); best-effort like every other emit here. Auto-restart is out of scope
   // (CTL-1398 re-sources the file on the next start, so a manual restart re-arms it).
-  const restartRequired = status.written.filter((f) => isEnvBackedSecretFile(f));
+  //
+  // Key off the files whose CONTENT actually changed, not every file rewritten (Codex
+  // P2). Any commit touching secrets/ makes syncSecretFiles re-decrypt and rewrite the
+  // whole bundle, so `written` names every bare file even when a single unrelated entry
+  // rotated — filtering on it would demand a daemon+monitor restart on every routine
+  // secret update. Fall back to `written` when a caller-injected syncSecretFiles predates
+  // the `changed` field, preserving the old (noisier but never-missing) behavior.
+  const rotated = Array.isArray(files?.changed) ? files.changed : status.written;
+  const restartRequired = rotated.filter((f) => isEnvBackedSecretFile(f));
   status.restartRequired = restartRequired;
   for (const file of restartRequired) {
     logger?.warn?.(

--- a/plugins/dev/scripts/execution-core/cluster-sync.mjs
+++ b/plugins/dev/scripts/execution-core/cluster-sync.mjs
@@ -70,6 +70,12 @@ function defaultConfigDir() {
 // silently ENOENTs and decrypt fails fail-open — a node then runs forever on stale
 // secrets with no signal. Resolving an ABSOLUTE path (and augmenting the spawn
 // PATH) makes that impossible.
+// CTL-1612: hard ceiling on every external spawn this module makes (git, sops). The boot
+// sync is synchronous and now precedes crash recovery, so an unbounded child would block
+// the daemon's startup path with the PID file already on disk — "running" to the launcher,
+// wedged in reality. Generous enough for a cold clone on a slow link; finite is the point.
+const CLUSTER_SYNC_SPAWN_TIMEOUT_MS = Number(process.env.CATALYST_CLUSTER_SYNC_TIMEOUT_MS) || 120_000;
+
 const SOPS_CANDIDATES = ["/opt/homebrew/bin/sops", "/usr/local/bin/sops", "/usr/bin/sops"];
 
 // Directories prepended to the spawn env PATH so sops itself — and any helper it
@@ -134,6 +140,11 @@ function makeSopsDecrypt(ageKeyFile, deps = {}) {
         env: { ...process.env, SOPS_AGE_KEY_FILE: ageKeyFile, PATH: augmentedPath() },
         encoding: "utf8",
         stdio: ["ignore", "pipe", "pipe"],
+        // CTL-1612: BOUNDED. clusterSync() now runs synchronously before boot recovery
+        // (so resumed workers never inherit a superseded credential), and the PID file is
+        // already written by then — an unbounded spawn would let the launcher report the
+        // daemon "up" while crash recovery is blocked indefinitely on a stalled sops.
+        timeout: CLUSTER_SYNC_SPAWN_TIMEOUT_MS,
       },
     );
     return JSON.parse(out);
@@ -142,7 +153,13 @@ function makeSopsDecrypt(ageKeyFile, deps = {}) {
 
 // Real `git` runner. Injected as `git` so tests never shell out.
 function defaultGit(args) {
-  execFileSync("git", args, { encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] });
+  // CTL-1612: BOUNDED — see the sops timeout above. A `git pull` that hangs on a
+  // credential prompt or an unreachable remote must not wedge daemon boot.
+  execFileSync("git", args, {
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+    timeout: CLUSTER_SYNC_SPAWN_TIMEOUT_MS,
+  });
 }
 
 // destForSecret — map a secrets/ filename to its ~/.config/catalyst destination.
@@ -476,7 +493,7 @@ const defaultNow = () => new Date().toISOString();
 // returns { status, stdout }. Injected as `gitCapture` so tests never shell out.
 // (defaultGit above is the MUTATING runner used by pullClusterRepo.)
 function defaultGitCapture(args) {
-  const r = spawnSync("git", args, { encoding: "utf8" });
+  const r = spawnSync("git", args, { encoding: "utf8", timeout: CLUSTER_SYNC_SPAWN_TIMEOUT_MS });
   return { status: r.status ?? (r.error ? 1 : 0), stdout: r.stdout ?? "" };
 }
 

--- a/plugins/dev/scripts/execution-core/cluster-sync.mjs
+++ b/plugins/dev/scripts/execution-core/cluster-sync.mjs
@@ -817,6 +817,35 @@ export function refreshClusterSecretsIfChanged(opts = {}) {
   // a failure too: advancing the marker over it would make lastSha===HEAD skip the
   // retry forever, stranding the un-applied rotation. On ANY shortfall: emit
   // refresh-failed naming the shortfall, do NOT advance the marker, return ok:false.
+  // 8b. Codex-B: a rotated boot-captured secret file is NOT live in a running process
+  // until it restarts (its value was captured at process start, not read per use). Emit a
+  // DISTINCT loud signal so "refreshed" is never mistaken for "the env secret is applied".
+  //
+  // Key off the files whose CONTENT actually changed, not every file rewritten (Codex P2):
+  // any commit touching secrets/ makes syncSecretFiles re-decrypt and rewrite the WHOLE
+  // bundle, so `written` names every bare file even when one unrelated entry rotated, and
+  // filtering on it would demand a restart on every routine secret update. Fall back to
+  // `written` for a caller-injected syncSecretFiles that predates the `changed` field —
+  // noisier, but a MISSED rotation notice is the silent-stale failure this exists to catch.
+  //
+  // Emitted BEFORE the shortfall early-return, deliberately (Codex P1, round 3). The
+  // rotated secret is already ON DISK at this point; whether some UNRELATED JSON or
+  // profile entry failed to materialize has no bearing on the fact that a restart is now
+  // required. Returning first would drop the notice permanently: the marker stays at the
+  // old sha, so the next attempt re-decrypts and rewrites the same bytes, `changed` comes
+  // back EMPTY, and once the unrelated failure clears the marker advances having never
+  // asked for the restart — leaving the daemon on the old credential forever.
+  const rotated = Array.isArray(files?.changed) ? files.changed : status.written;
+  const restartRequired = rotated.filter((f) => isEnvBackedSecretFile(f));
+  status.restartRequired = restartRequired;
+  for (const file of restartRequired) {
+    logger?.warn?.(
+      `[cluster-sync] boot-captured secret rotated (${file}) — restart the daemon(s) that ` +
+        "read it to apply (its value is captured at process start, not per use)",
+    );
+    emit({ name: "restart-required", node, now, payload: { file, fromSha: lastSha, toSha: head } });
+  }
+
   const { fullSuccess, reason: shortfall } = assessMaterialization({ sync, files, profiles });
   if (!fullSuccess) {
     status.ok = false;
@@ -849,30 +878,6 @@ export function refreshClusterSecretsIfChanged(opts = {}) {
     });
   }
 
-  // 8b. Codex-B: a rotated ENV-BACKED secret file (sourced into process.env at boot)
-  // is NOT live in the running daemon until a restart — the SDK path reads
-  // CLAUDE_CODE_OAUTH_TOKEN from process.env, captured at boot. Emit a DISTINCT loud
-  // signal so the "refreshed" event above is never mistaken for "the env secret is
-  // applied". This is the timer's restart-required surface (the daemon timer calls
-  // this fn); best-effort like every other emit here. Auto-restart is out of scope
-  // (CTL-1398 re-sources the file on the next start, so a manual restart re-arms it).
-  //
-  // Key off the files whose CONTENT actually changed, not every file rewritten (Codex
-  // P2). Any commit touching secrets/ makes syncSecretFiles re-decrypt and rewrite the
-  // whole bundle, so `written` names every bare file even when a single unrelated entry
-  // rotated — filtering on it would demand a daemon+monitor restart on every routine
-  // secret update. Fall back to `written` when a caller-injected syncSecretFiles predates
-  // the `changed` field, preserving the old (noisier but never-missing) behavior.
-  const rotated = Array.isArray(files?.changed) ? files.changed : status.written;
-  const restartRequired = rotated.filter((f) => isEnvBackedSecretFile(f));
-  status.restartRequired = restartRequired;
-  for (const file of restartRequired) {
-    logger?.warn?.(
-      `[cluster-sync] boot-captured secret rotated (${file}) — restart the daemon(s) that ` +
-        "read it to apply (its value is captured at process start, not per use)",
-    );
-    emit({ name: "restart-required", node, now, payload: { file, fromSha: lastSha, toSha: head } });
-  }
   return status;
 }
 

--- a/plugins/dev/scripts/execution-core/cluster-sync.mjs
+++ b/plugins/dev/scripts/execution-core/cluster-sync.mjs
@@ -579,7 +579,47 @@ export function emitClusterSecretEvent(opts = {}, io = {}) {
 // execution-core.env is machine-local (not in the bundle), so this entry is an inert
 // no-op — it only ever matches when execution-core.env appears in `status.written` —
 // but encoding it keeps the set faithful to its own contract and future-proofs that path.
-export const ENV_BACKED_SECRET_FILES = new Set(["claude-accounts.env", "execution-core.env"]);
+// CTL-1612: the membership rule generalizes from "sourced into the boot env" to
+// "CAPTURED AT PROCESS START, and therefore NOT live in a running process until it
+// restarts". Two capture mechanisms qualify, and both were previously unenrolled:
+//   (a) `source`d into the daemon's boot env — claude-accounts.env, execution-core.env,
+//       and now github-token (catalyst-execution-core's CTL-1612 _project_shared_github_token).
+//   (b) read ONCE from disk at server boot — webhook-secret and the linear-webhook-secret*
+//       family, resolved inside orch-monitor's loadWebhookConfig() at startup and then
+//       closed over per request (webhook-config.ts), never re-read per delivery.
+// Leaving these out is what let the 2026-08-02 outage look "applied": cluster-sync
+// rewrote github-token, recorded it in `written`, and emitted plain `refreshed` while
+// every running daemon kept 401ing on the revoked value it had captured at boot.
+const ENV_BACKED_SECRET_EXACT = new Set([
+  "claude-accounts.env",
+  "execution-core.env",
+  "github-token",
+  "webhook-secret",
+  "linear-webhook-secret",
+]);
+
+// The per-team Linear webhook secrets are a FAMILY, not fixed names: webhook-config.ts
+// builds `linear-webhook-secret-${key}` from the Layer-2 config's team keys, so the set of
+// filenames is open-ended and NOT guaranteed lowercase. An exact-match Set or a
+// `/^linear-webhook-secret-[a-z0-9-]+$/` regex would silently no-op on a team key like
+// "CTL" — exactly the miss this predicate exists to prevent. Match case-insensitively on
+// the prefix, requiring at least one character after the dash so the bare prefix
+// "linear-webhook-secret-" and a run-on like "linear-webhook-secretXXX" both stay OUT.
+const LINEAR_WEBHOOK_SECRET_PREFIX = "linear-webhook-secret-";
+
+// isEnvBackedSecretFile — the boot-captured predicate. Prefer this over direct Set
+// membership; ENV_BACKED_SECRET_FILES stays exported for back-compat with callers/tests
+// that only need the fixed names.
+export function isEnvBackedSecretFile(file) {
+  if (typeof file !== "string" || file.length === 0) return false;
+  const name = file.toLowerCase();
+  if (ENV_BACKED_SECRET_EXACT.has(name)) return true;
+  return (
+    name.startsWith(LINEAR_WEBHOOK_SECRET_PREFIX) && name.length > LINEAR_WEBHOOK_SECRET_PREFIX.length
+  );
+}
+
+export const ENV_BACKED_SECRET_FILES = ENV_BACKED_SECRET_EXACT;
 
 // assessMaterialization — Codex-A. Decide whether a refresh/boot decrypt FULLY
 // succeeded, given the syncClusterSecrets (`sync`) and syncSecretFiles (`files`)
@@ -798,12 +838,12 @@ export function refreshClusterSecretsIfChanged(opts = {}) {
   // applied". This is the timer's restart-required surface (the daemon timer calls
   // this fn); best-effort like every other emit here. Auto-restart is out of scope
   // (CTL-1398 re-sources the file on the next start, so a manual restart re-arms it).
-  const restartRequired = status.written.filter((f) => ENV_BACKED_SECRET_FILES.has(f));
+  const restartRequired = status.written.filter((f) => isEnvBackedSecretFile(f));
   status.restartRequired = restartRequired;
   for (const file of restartRequired) {
     logger?.warn?.(
-      `[cluster-sync] env-backed secret rotated (${file}) — daemon restart required to apply ` +
-        "(CLAUDE_CODE_OAUTH_TOKEN is read from process.env at boot)",
+      `[cluster-sync] boot-captured secret rotated (${file}) — restart the daemon(s) that ` +
+        "read it to apply (its value is captured at process start, not per use)",
     );
     emit({ name: "restart-required", node, now, payload: { file, fromSha: lastSha, toSha: head } });
   }

--- a/plugins/dev/scripts/execution-core/cluster-sync.test.mjs
+++ b/plugins/dev/scripts/execution-core/cluster-sync.test.mjs
@@ -1190,6 +1190,224 @@ describe("refreshClusterSecretsIfChanged (CTL-1393)", () => {
     expect(selectRotated(current, current.written)).toEqual([]);
   });
 
+  // ── CTL-1612 (Codex P1, round 3): the restart notice is emitted BEFORE the
+  //    materialization-shortfall early-return. The rotated boot-captured secret is
+  //    already ON DISK by then, so an UNRELATED JSON/profile entry failing to
+  //    materialize has no bearing on "a restart is now required".
+  //
+  //    Returning first lost the notice PERMANENTLY, and the loss is invisible to any
+  //    single-run test: the marker stays at the old sha, so the next attempt
+  //    re-decrypts and rewrites the SAME bytes, `changed` comes back EMPTY, and once
+  //    the unrelated failure clears the marker advances having never asked for the
+  //    restart — daemon left 401ing on the old credential forever. (g1) is the reason
+  //    run 2 is silent: a byte-identical rewrite is correctly not a rotation. So the
+  //    only run that can ever carry the notice is the one that also failed. ─────────
+
+  test("(h1) shortfall run (unrelated JSON secret skipped) → restart-required STILL emitted for the rotated github-token", () => {
+    seedClone();
+    writeClusterJson({ schemaVersion: 1, roster: ["mini"] });
+    touchSecret("cluster-bots.sops.json"); // succeeds → config.json
+    touchSecret("config-adva.sops.json"); // fails → skipped (the UNRELATED failure)
+    writeFileSync(join(clusterDir, "secrets", "node-secret-files.sops.json"), "{cipher}");
+    // the credential this node is running on today — the bundle rotates it below
+    writeFileSync(join(configDir, "github-token"), "fake-github-token-v1");
+    const statePath = join(configDir, ".state.json");
+    writeMarker(statePath, "OLDSHA");
+
+    const emits = [];
+    const res = refreshClusterSecretsIfChanged({
+      clusterDir,
+      configDir,
+      statePath,
+      git: baseGit,
+      gitCapture: makeGitCapture("NEWSHA", true),
+      decrypt: (p) => {
+        if (p.endsWith("node-secret-files.sops.json")) return { "github-token": "fake-github-token-v2" };
+        if (p.endsWith("config-adva.sops.json")) throw new Error("bad mac");
+        return { catalyst: { linear: { bot: { worker: { accessToken: "FRESH" } } } } };
+      },
+      emit: (e) => emits.push(e),
+      now: () => "t",
+      node: "test-node",
+      logger: QUIET,
+    });
+
+    // the refresh DID fall short, and the marker correctly stays behind so the next
+    // tick retries the skipped JSON secret
+    expect(res.ok).toBe(false);
+    expect(res.reason).toBe("secrets-skipped");
+    expect(readClusterSyncState(statePath).lastDecryptedSha).toBe("OLDSHA");
+
+    // …and the rotated boot-captured file still landed on disk, so the restart notice
+    // is owed REGARDLESS of the unrelated shortfall
+    expect(readFileSync(join(configDir, "github-token"), "utf8")).toBe("fake-github-token-v2");
+    expect(res.restartRequired).toEqual(["github-token"]);
+    const names = emits.map((e) => e.name);
+    expect(names).toContain("restart-required");
+    expect(names).toContain("refresh-failed");
+    const rr = emits.find((e) => e.name === "restart-required");
+    expect(rr.payload).toMatchObject({ file: "github-token", fromSha: "OLDSHA", toSha: "NEWSHA" });
+    // a shortfall run never claims success
+    expect(names).not.toContain("refreshed");
+  });
+
+  test("(h2) ORDERING — on a shortfall run restart-required is emitted BEFORE refresh-failed (profile-write variant)", () => {
+    seedClone();
+    writeClusterJson({ schemaVersion: 1, roster: ["mini"] });
+    touchSecret("cluster-bots.sops.json");
+    writeFileSync(join(clusterDir, "secrets", "node-secret-files.sops.json"), "{cipher}");
+    writeFileSync(join(clusterDir, "secrets", "profile-files.sops.json"), "{cipher}");
+    const profilesDir = join(configDir, "profiles");
+    // Force the UNRELATED failure on the profile side this time: a DIRECTORY at the
+    // profile's destination makes its write throw EISDIR.
+    mkdirSync(join(profilesDir, "catalyst-cloud.env"), { recursive: true });
+    writeFileSync(join(configDir, "webhook-secret"), "fake-hmac-key-v1");
+    const statePath = join(configDir, ".state.json");
+    writeMarker(statePath, "OLDSHA");
+
+    const emits = [];
+    const res = refreshClusterSecretsIfChanged({
+      clusterDir,
+      configDir,
+      profilesDir,
+      statePath,
+      git: baseGit,
+      gitCapture: makeGitCapture("NEWSHA", true),
+      decrypt: (p) => {
+        if (p.endsWith("node-secret-files.sops.json")) return { "webhook-secret": "fake-hmac-key-v2" };
+        if (p.endsWith("profile-files.sops.json")) return { "catalyst-cloud.env": "export GH_TEMP_PAT=x\n" };
+        return { catalyst: { linear: { bot: { worker: { accessToken: "FRESH" } } } } };
+      },
+      emit: (e) => emits.push(e),
+      now: () => "t",
+      node: "test-node",
+      logger: QUIET,
+    });
+
+    expect(res.ok).toBe(false);
+    expect(res.reason).toBe("profile-write-failed");
+    expect(res.restartRequired).toEqual(["webhook-secret"]);
+    expect(readClusterSyncState(statePath).lastDecryptedSha).toBe("OLDSHA");
+
+    // The sequence is the assertion: emitting restart-required only AFTER the
+    // shortfall gate would mean never emitting it at all (the early-return returns).
+    const names = emits.map((e) => e.name);
+    expect(names.indexOf("restart-required")).toBeGreaterThanOrEqual(0);
+    expect(names.indexOf("refresh-failed")).toBeGreaterThanOrEqual(0);
+    expect(names.indexOf("restart-required")).toBeLessThan(names.indexOf("refresh-failed"));
+    expect(names).toEqual(["restart-required", "refresh-failed"]);
+  });
+
+  test("(h3) END-TO-END — shortfall run then clean run: the marker advances and the restart notice was NOT lost", () => {
+    seedClone();
+    writeClusterJson({ schemaVersion: 1, roster: ["mini"] });
+    touchSecret("cluster-bots.sops.json");
+    touchSecret("config-adva.sops.json"); // the unrelated entry — fails on run 1 only
+    writeFileSync(join(clusterDir, "secrets", "node-secret-files.sops.json"), "{cipher}");
+    writeFileSync(join(configDir, "github-token"), "fake-github-token-v1");
+    const statePath = join(configDir, ".state.json");
+    writeMarker(statePath, "OLDSHA");
+
+    // `adva` decrypts only once the (unrelated) failure has cleared.
+    let advaHealthy = false;
+    const runRefresh = (emits) =>
+      refreshClusterSecretsIfChanged({
+        clusterDir,
+        configDir,
+        statePath,
+        git: baseGit,
+        gitCapture: makeGitCapture("NEWSHA", true),
+        decrypt: (p) => {
+          // the bundle serves the SAME rotated bytes on both runs — run 1 puts them on
+          // disk, so run 2's read-back sees no content change (see (g1))
+          if (p.endsWith("node-secret-files.sops.json")) return { "github-token": "fake-github-token-v2" };
+          if (p.endsWith("config-adva.sops.json")) {
+            if (!advaHealthy) throw new Error("bad mac");
+            return { ok: true };
+          }
+          return { catalyst: { linear: { bot: { worker: { accessToken: "FRESH" } } } } };
+        },
+        emit: (e) => emits.push(e),
+        now: () => "t",
+        node: "test-node",
+        logger: QUIET,
+      });
+
+    // ── run 1: the rotation lands on disk, but an unrelated JSON secret fails ──
+    const run1Emits = [];
+    const run1 = runRefresh(run1Emits);
+    expect(run1.ok).toBe(false);
+    expect(run1.reason).toBe("secrets-skipped");
+    expect(readClusterSyncState(statePath).lastDecryptedSha).toBe("OLDSHA"); // held back
+    expect(readFileSync(join(configDir, "github-token"), "utf8")).toBe("fake-github-token-v2");
+
+    // ── run 2: the unrelated failure clears; the token bytes are now IDENTICAL ──
+    advaHealthy = true;
+    const run2Emits = [];
+    const run2 = runRefresh(run2Emits);
+    expect(run2.ok).toBe(true);
+    // the marker advances — from here on the fast-path returns head-unchanged, so this
+    // is the LAST run that could ever have carried the notice
+    expect(readClusterSyncState(statePath).lastDecryptedSha).toBe("NEWSHA");
+    // …and run 2 is silent about the restart, correctly: nothing moved on disk
+    expect(run2.restartRequired).toEqual([]);
+    expect(run2Emits.map((e) => e.name)).not.toContain("restart-required");
+
+    // THE REGRESSION. Across the WHOLE sequence the operator was told to restart at
+    // least once. A test that inspected only run 2 would pass against the old code,
+    // which returned at the shortfall gate and dropped the notice forever.
+    const allEmits = [...run1Emits, ...run2Emits];
+    const restarts = allEmits.filter(
+      (e) => e.name === "restart-required" && e.payload?.file === "github-token",
+    );
+    expect(restarts.length).toBeGreaterThanOrEqual(1);
+    expect(restarts[0].payload).toMatchObject({ fromSha: "OLDSHA", toSha: "NEWSHA" });
+  });
+
+  test("(h4) NEGATIVE CONTROL — a shortfall run whose only bare change is non-boot-captured emits NO restart-required", () => {
+    seedClone();
+    writeClusterJson({ schemaVersion: 1, roster: ["mini"] });
+    touchSecret("cluster-bots.sops.json");
+    touchSecret("config-adva.sops.json"); // the unrelated failure → secrets-skipped
+    writeFileSync(join(clusterDir, "secrets", "node-secret-files.sops.json"), "{cipher}");
+    // github-token is present and does NOT move; only the plain bare file rotates
+    writeFileSync(join(configDir, "github-token"), "fake-github-token-v1");
+    writeFileSync(join(configDir, "cma-api-key"), "fake-cma-key-v1");
+    const statePath = join(configDir, ".state.json");
+    writeMarker(statePath, "OLDSHA");
+
+    const emits = [];
+    const res = refreshClusterSecretsIfChanged({
+      clusterDir,
+      configDir,
+      statePath,
+      git: baseGit,
+      gitCapture: makeGitCapture("NEWSHA", true),
+      decrypt: (p) => {
+        if (p.endsWith("node-secret-files.sops.json")) {
+          return {
+            "github-token": "fake-github-token-v1", // unchanged
+            "cma-api-key": "fake-cma-key-v2", // the actual rotation
+          };
+        }
+        if (p.endsWith("config-adva.sops.json")) throw new Error("bad mac");
+        return { catalyst: { linear: { bot: { worker: { accessToken: "FRESH" } } } } };
+      },
+      emit: (e) => emits.push(e),
+      now: () => "t",
+      node: "test-node",
+      logger: QUIET,
+    });
+
+    expect(res.ok).toBe(false);
+    expect(res.reason).toBe("secrets-skipped");
+    expect(readClusterSyncState(statePath).lastDecryptedSha).toBe("OLDSHA");
+    // hoisting the emit above the early-return must NOT turn every shortfall run into
+    // a restart nag — the predicate still gates on a boot-captured file that MOVED
+    expect(res.restartRequired).toEqual([]);
+    expect(emits.map((e) => e.name)).toEqual(["refresh-failed"]);
+  });
+
   // ── CTL-1393 (Codex P2 re-review of caf6b0e2): a too-new cluster.json
   //    (schemaSkipped) must NOT mask a FAILED bare bundle. The schemaSkipped
   //    short-circuit used to run FIRST and advance the marker over the un-applied

--- a/plugins/dev/scripts/execution-core/cluster-sync.test.mjs
+++ b/plugins/dev/scripts/execution-core/cluster-sync.test.mjs
@@ -213,6 +213,89 @@ describe("syncSecretFiles (CTL-1211)", () => {
     expect(res.reason).toBeNull();
     expect(res.skipped).toBe(false);
   });
+
+  // ── CTL-1612 (Codex P2): `written` ≠ `changed`. Any commit touching secrets/
+  //    re-decrypts and rewrites the WHOLE bundle, so `written` names every bare
+  //    file even when a single unrelated entry rotated. `changed` is the read-back
+  //    subset whose CONTENT actually moved — the only sound basis for a restart
+  //    alarm. ────────────────────────────────────────────────────────────────────
+
+  test("(CTL-1612) a byte-identical rewrite lands in written[] but NOT changed[]", () => {
+    writeNodeFiles();
+    // already on disk, byte-identical to what this bundle carries
+    writeFileSync(join(configDir, "github-token"), "fake-github-token-v1");
+    writeFileSync(join(configDir, "cma-api-key"), "fake-cma-key-v1");
+    const decrypt = () => ({
+      "github-token": "fake-github-token-v1", // untouched by this rotation
+      "cma-api-key": "fake-cma-key-v2", // the entry that actually rotated
+    });
+    const res = syncSecretFiles({ clusterDir, configDir, decrypt, logger: QUIET });
+    // the whole bundle is rewritten…
+    expect(res.written).toEqual(["github-token", "cma-api-key"]);
+    // …but only one entry MOVED
+    expect(res.changed).toEqual(["cma-api-key"]);
+    expect(readFileSync(join(configDir, "cma-api-key"), "utf8")).toBe("fake-cma-key-v2");
+  });
+
+  test("(CTL-1612) an absent destination counts as CHANGED (first materialization)", () => {
+    writeNodeFiles();
+    const decrypt = () => ({ "github-token": "fake-github-token-v1", "cma-api-key": "fake-cma-key-v1" });
+    // nothing pre-exists in configDir — a fresh node must announce every file
+    const res = syncSecretFiles({ clusterDir, configDir, decrypt, logger: QUIET });
+    expect(res.written).toEqual(["github-token", "cma-api-key"]);
+    expect(res.changed).toEqual(res.written);
+  });
+
+  test("(CTL-1612) the readFile seam is injectable; a null read-back counts as changed", () => {
+    writeNodeFiles();
+    writeFileSync(join(configDir, "cma-api-key"), "fake-cma-key-v1");
+    const decrypt = () => ({ "cma-api-key": "fake-cma-key-v1" });
+    // an UNREADABLE destination (perms, EIO) reads back null — never throws, and is
+    // conservatively treated as changed rather than silently swallowing a rotation.
+    const res = syncSecretFiles({
+      clusterDir,
+      configDir,
+      decrypt,
+      readFile: () => null,
+      logger: QUIET,
+    });
+    expect(res.written).toEqual(["cma-api-key"]);
+    expect(res.changed).toEqual(["cma-api-key"]);
+  });
+
+  test("(CTL-1612) `changed` is an array on EVERY return path (the fallback stays dormant)", () => {
+    // refreshClusterSecretsIfChanged degrades to `written` when `changed` is absent
+    // (back-compat for a legacy/injected result). That fallback must never fire for
+    // the in-tree caller — dropping the field would silently restore the noisy
+    // rewrite-is-a-rotation behavior this fix removed.
+    const absent = syncSecretFiles({ clusterDir, configDir, decrypt: () => ({}) });
+    expect(absent.reason).toBe("absent");
+    expect(Array.isArray(absent.changed)).toBe(true);
+
+    writeNodeFiles();
+    const failedDecrypt = syncSecretFiles({
+      clusterDir,
+      configDir,
+      decrypt: () => {
+        throw new Error("bad mac");
+      },
+      logger: QUIET,
+    });
+    expect(failedDecrypt.reason).toBe("decrypt-failed");
+    expect(Array.isArray(failedDecrypt.changed)).toBe(true);
+
+    const empty = syncSecretFiles({ clusterDir, configDir, decrypt: () => null, logger: QUIET });
+    expect(empty.reason).toBe("empty");
+    expect(Array.isArray(empty.changed)).toBe(true);
+
+    const ok = syncSecretFiles({
+      clusterDir,
+      configDir,
+      decrypt: () => ({ "cma-api-key": "fake-cma-key-v1" }),
+      logger: QUIET,
+    });
+    expect(Array.isArray(ok.changed)).toBe(true);
+  });
 });
 
 describe("pullClusterRepo (CTL-1211)", () => {
@@ -987,6 +1070,124 @@ describe("refreshClusterSecretsIfChanged (CTL-1393)", () => {
     });
     expect(emits.map((e) => e.name)).toContain("refreshed");
     expect(readClusterSyncState(statePath).lastDecryptedSha).toBe("NEWSHA");
+  });
+
+  // ── CTL-1612 (Codex P2): restart alarms key off CONTENT, not rewrites. Any
+  //    commit under secrets/ rewrites the whole bare bundle, so filtering
+  //    `written` fired a restart-required for github-token on EVERY routine
+  //    rotation of some unrelated secret — a nag that trains operators to ignore
+  //    the one signal that says "your daemon is running on a revoked credential".
+  //    These drive the real refresh through the real read-back (syncSecretFiles is
+  //    called with the module's own fs readFile, not an injected one). ───────────
+
+  test("(g1) UNCHANGED github-token + one rotated sibling → NO restart-required (T4 regression)", () => {
+    seedClone();
+    writeClusterJson({ schemaVersion: 1, roster: ["mini"] });
+    touchSecret("cluster-bots.sops.json");
+    writeFileSync(join(clusterDir, "secrets", "node-secret-files.sops.json"), "{cipher}");
+    // the credential this node is ALREADY running on, byte-identical to the bundle's
+    writeFileSync(join(configDir, "github-token"), "fake-github-token-v1");
+    writeFileSync(join(configDir, "cma-api-key"), "fake-cma-key-v1");
+    const statePath = join(configDir, ".state.json");
+    writeMarker(statePath, "OLDSHA");
+
+    const emits = [];
+    const res = refreshClusterSecretsIfChanged({
+      clusterDir,
+      configDir,
+      statePath,
+      git: baseGit,
+      gitCapture: makeGitCapture("NEWSHA", true),
+      decrypt: (p) =>
+        p.endsWith("node-secret-files.sops.json")
+          ? {
+              "github-token": "fake-github-token-v1", // did NOT move
+              "cma-api-key": "fake-cma-key-v2", // the actual rotation
+            }
+          : { catalyst: { linear: { bot: { worker: { accessToken: "FRESH" } } } } },
+      emit: (e) => emits.push(e),
+      now: () => "t",
+      node: "test-node",
+      logger: QUIET,
+    });
+
+    expect(res.ok).toBe(true);
+    // the whole bundle is re-materialized — `written` names both files…
+    expect(res.written).toEqual(["github-token", "cma-api-key"]);
+    // …and that is precisely why it cannot drive the alarm: nothing boot-captured moved
+    expect(res.restartRequired).toEqual([]);
+    const names = emits.map((e) => e.name);
+    expect(names).toContain("refreshed"); // the rotation IS announced
+    expect(names).not.toContain("restart-required"); // …without a spurious restart nag
+    // the unrelated rotation still landed on disk, and the marker advanced
+    expect(readFileSync(join(configDir, "cma-api-key"), "utf8")).toBe("fake-cma-key-v2");
+    expect(readClusterSyncState(statePath).lastDecryptedSha).toBe("NEWSHA");
+  });
+
+  test("(g2) genuinely rotated github-token → restart-required STILL fires (fix not over-corrected)", () => {
+    seedClone();
+    writeClusterJson({ schemaVersion: 1, roster: ["mini"] });
+    touchSecret("cluster-bots.sops.json");
+    writeFileSync(join(clusterDir, "secrets", "node-secret-files.sops.json"), "{cipher}");
+    writeFileSync(join(configDir, "github-token"), "fake-github-token-v1");
+    writeFileSync(join(configDir, "cma-api-key"), "fake-cma-key-v1");
+    const statePath = join(configDir, ".state.json");
+    writeMarker(statePath, "OLDSHA");
+
+    const emits = [];
+    const res = refreshClusterSecretsIfChanged({
+      clusterDir,
+      configDir,
+      statePath,
+      git: baseGit,
+      gitCapture: makeGitCapture("NEWSHA", true),
+      decrypt: (p) =>
+        p.endsWith("node-secret-files.sops.json")
+          ? {
+              "github-token": "fake-github-token-v2", // the credential MOVED
+              "cma-api-key": "fake-cma-key-v1", // untouched sibling, rewritten anyway
+            }
+          : { catalyst: { linear: { bot: { worker: { accessToken: "FRESH" } } } } },
+      emit: (e) => emits.push(e),
+      now: () => "t",
+      node: "test-node",
+      logger: QUIET,
+    });
+
+    expect(res.ok).toBe(true);
+    expect(res.written).toEqual(["github-token", "cma-api-key"]);
+    // status names the boot-captured file that actually rotated — and ONLY it
+    expect(res.restartRequired).toEqual(["github-token"]);
+    const restarts = emits.filter((e) => e.name === "restart-required");
+    expect(restarts).toHaveLength(1);
+    expect(restarts[0].payload).toMatchObject({
+      file: "github-token",
+      fromSha: "OLDSHA",
+      toSha: "NEWSHA",
+    });
+    expect(emits.map((e) => e.name)).toContain("refreshed");
+    expect(readClusterSyncState(statePath).lastDecryptedSha).toBe("NEWSHA");
+  });
+
+  test("(g3) legacy result shape (no `changed`) → falls back to `written`, never to nothing", () => {
+    // Back-compat guard for the `Array.isArray(files?.changed) ? … : status.written`
+    // selection. The in-tree caller always supplies `changed` (pinned by the
+    // syncSecretFiles shape test above) and refreshClusterSecretsIfChanged calls the
+    // module-local syncSecretFiles directly — so the legacy branch is reachable only
+    // from an externally-injected/older result. Pin the RULE: a missing `changed`
+    // must degrade to the old, noisier behavior (announce every rewritten file),
+    // never to silence — a rotation that stops being announced is the 2026-08-02
+    // outage all over again.
+    const selectRotated = (files, written) =>
+      (Array.isArray(files?.changed) ? files.changed : written).filter(isEnvBackedSecretFile);
+
+    const legacy = { written: ["github-token", "cma-api-key"], failed: [], skipped: false, reason: null };
+    expect(selectRotated(legacy, legacy.written)).toEqual(["github-token"]);
+
+    // and the current shape wins when present — an empty `changed` means "nothing
+    // moved", which is exactly what (g1) proves end-to-end.
+    const current = { written: ["github-token", "cma-api-key"], changed: [], failed: [] };
+    expect(selectRotated(current, current.written)).toEqual([]);
   });
 
   // ── CTL-1393 (Codex P2 re-review of caf6b0e2): a too-new cluster.json

--- a/plugins/dev/scripts/execution-core/cluster-sync.test.mjs
+++ b/plugins/dev/scripts/execution-core/cluster-sync.test.mjs
@@ -30,6 +30,8 @@ import {
   clusterSync,
   buildClusterSecretEnvelope,
   ENV_BACKED_SECRET_FILES,
+  // CTL-1612: the boot-captured predicate that widened the restart-required set.
+  isEnvBackedSecretFile,
 } from "./cluster-sync.mjs";
 
 const QUIET = { warn() {}, info() {} };
@@ -719,7 +721,11 @@ describe("refreshClusterSecretsIfChanged (CTL-1393)", () => {
       gitCapture: makeGitCapture("NEWSHA", true),
       decrypt: (p) =>
         p.endsWith("node-secret-files.sops.json")
-          ? { "github-token": "tok" }
+          ? // CTL-1612: was "github-token", which is now BOOT-CAPTURED and so legitimately
+            // emits restart-required. Re-pointed (not deleted) to cma-api-key — a genuine
+            // bare bundle file that nothing sources or boot-reads — so this stays a valid
+            // NEGATIVE CONTROL proving isEnvBackedSecretFile is not over-broad.
+            { "cma-api-key": "cma_xyz" }
           : { catalyst: { linear: { bot: { worker: { accessToken: "FRESH" } } } } },
       emit: (e) => emits.push(e),
       now: () => "t",
@@ -730,12 +736,12 @@ describe("refreshClusterSecretsIfChanged (CTL-1393)", () => {
     expect(res.ok).toBe(true);
     expect(res.changed).toBe(true);
     expect(res.synced).toEqual(["config.json"]);
-    expect(res.written).toEqual(["github-token"]);
+    expect(res.written).toEqual(["cma-api-key"]);
     // full success advances the marker (guard against over-correcting the predicate)
     expect(readClusterSyncState(statePath).lastDecryptedSha).toBe("NEWSHA");
     expect(emits.map((e) => e.name)).toContain("refreshed");
     expect(emits.map((e) => e.name)).not.toContain("refresh-failed");
-    // a non-env-backed bare file does NOT trigger a restart-required signal
+    // a non-boot-captured bare file does NOT trigger a restart-required signal
     expect(emits.map((e) => e.name)).not.toContain("restart-required");
   });
 
@@ -849,6 +855,137 @@ describe("refreshClusterSecretsIfChanged (CTL-1393)", () => {
     const rr = emits.find((e) => e.name === "restart-required");
     expect(rr.payload).toMatchObject({ file: "claude-accounts.env", fromSha: "OLDSHA", toSha: "NEWSHA" });
     // the marker still advances — the file IS materialized; only the env needs a restart
+    expect(readClusterSyncState(statePath).lastDecryptedSha).toBe("NEWSHA");
+  });
+
+  // ── CTL-1612: the widened boot-captured enrollment, exercised THROUGH the call
+  //    site. isEnvBackedSecretFile is unit-tested below, but a correct predicate
+  //    that is never wired into the restartRequired filter is exactly the 2026-08-02
+  //    outage shape — cluster-sync rewrote github-token, recorded it in `written`,
+  //    emitted plain `refreshed`, and every running daemon kept 401ing on the value
+  //    it had captured at boot. These three assert the wiring, not the predicate.
+  //    (The negative control lives in test (e) above: a bare cma-api-key rotation
+  //    must still emit NO restart-required.) ────────────────────────────────────
+
+  test("(f1) github-token rotated → restart-required emitted (CTL-1612 — the outage file)", () => {
+    seedClone();
+    writeClusterJson({ schemaVersion: 1, roster: ["mini"] });
+    touchSecret("cluster-bots.sops.json");
+    writeFileSync(join(clusterDir, "secrets", "node-secret-files.sops.json"), "{cipher}");
+    const statePath = join(configDir, ".state.json");
+    writeMarker(statePath, "OLDSHA");
+
+    const emits = [];
+    const res = refreshClusterSecretsIfChanged({
+      clusterDir,
+      configDir,
+      statePath,
+      git: baseGit,
+      gitCapture: makeGitCapture("NEWSHA", true),
+      decrypt: (p) =>
+        p.endsWith("node-secret-files.sops.json")
+          ? { "github-token": "fake-github-token-for-tests" }
+          : { catalyst: { linear: { bot: { worker: { accessToken: "FRESH" } } } } },
+      emit: (e) => emits.push(e),
+      now: () => "t",
+      node: "test-node",
+      logger: QUIET,
+    });
+
+    expect(res.ok).toBe(true);
+    expect(res.written).toEqual(["github-token"]);
+    expect(res.restartRequired).toEqual(["github-token"]);
+    const names = emits.map((e) => e.name);
+    expect(names).toContain("refreshed");
+    expect(names).toContain("restart-required");
+    const rr = emits.find((e) => e.name === "restart-required");
+    expect(rr.payload).toMatchObject({ file: "github-token", fromSha: "OLDSHA", toSha: "NEWSHA" });
+    expect(readClusterSyncState(statePath).lastDecryptedSha).toBe("NEWSHA");
+  });
+
+  test("(f2) linear-webhook-secret-<team> rotated → restart-required emitted (FAMILY wired at the call site)", () => {
+    seedClone();
+    writeClusterJson({ schemaVersion: 1, roster: ["mini"] });
+    touchSecret("cluster-bots.sops.json");
+    writeFileSync(join(clusterDir, "secrets", "node-secret-files.sops.json"), "{cipher}");
+    const statePath = join(configDir, ".state.json");
+    writeMarker(statePath, "OLDSHA");
+
+    const emits = [];
+    const res = refreshClusterSecretsIfChanged({
+      clusterDir,
+      configDir,
+      statePath,
+      git: baseGit,
+      gitCapture: makeGitCapture("NEWSHA", true),
+      decrypt: (p) =>
+        p.endsWith("node-secret-files.sops.json")
+          ? { "linear-webhook-secret-ctl": "fake-webhook-secret-for-tests" }
+          : { catalyst: { linear: { bot: { worker: { accessToken: "FRESH" } } } } },
+      emit: (e) => emits.push(e),
+      now: () => "t",
+      node: "test-node",
+      logger: QUIET,
+    });
+
+    expect(res.ok).toBe(true);
+    expect(res.written).toEqual(["linear-webhook-secret-ctl"]);
+    // the open-ended per-team family resolves through the predicate, not a fixed Set
+    expect(res.restartRequired).toEqual(["linear-webhook-secret-ctl"]);
+    const names = emits.map((e) => e.name);
+    expect(names).toContain("refreshed");
+    expect(names).toContain("restart-required");
+    const rr = emits.find((e) => e.name === "restart-required");
+    expect(rr.payload).toMatchObject({
+      file: "linear-webhook-secret-ctl",
+      fromSha: "OLDSHA",
+      toSha: "NEWSHA",
+    });
+    expect(readClusterSyncState(statePath).lastDecryptedSha).toBe("NEWSHA");
+  });
+
+  test("(f3) MIXED rotation → restart-required for the boot-captured file ONLY (predicate not over-broad)", () => {
+    seedClone();
+    writeClusterJson({ schemaVersion: 1, roster: ["mini"] });
+    touchSecret("cluster-bots.sops.json");
+    writeFileSync(join(clusterDir, "secrets", "node-secret-files.sops.json"), "{cipher}");
+    const statePath = join(configDir, ".state.json");
+    writeMarker(statePath, "OLDSHA");
+
+    const emits = [];
+    const res = refreshClusterSecretsIfChanged({
+      clusterDir,
+      configDir,
+      statePath,
+      git: baseGit,
+      gitCapture: makeGitCapture("NEWSHA", true),
+      decrypt: (p) =>
+        p.endsWith("node-secret-files.sops.json")
+          ? {
+              // one boot-captured, one plain bare file — same rotation
+              "webhook-secret": "fake-webhook-secret-for-tests",
+              "cma-api-key": "fake-cma-key-for-tests",
+            }
+          : { catalyst: { linear: { bot: { worker: { accessToken: "FRESH" } } } } },
+      emit: (e) => emits.push(e),
+      now: () => "t",
+      node: "test-node",
+      logger: QUIET,
+    });
+
+    expect(res.ok).toBe(true);
+    // BOTH files materialize…
+    expect(res.written).toEqual(["webhook-secret", "cma-api-key"]);
+    // …but only the boot-captured one needs a restart to apply
+    expect(res.restartRequired).toEqual(["webhook-secret"]);
+    const restarts = emits.filter((e) => e.name === "restart-required");
+    expect(restarts).toHaveLength(1);
+    expect(restarts[0].payload).toMatchObject({
+      file: "webhook-secret",
+      fromSha: "OLDSHA",
+      toSha: "NEWSHA",
+    });
+    expect(emits.map((e) => e.name)).toContain("refreshed");
     expect(readClusterSyncState(statePath).lastDecryptedSha).toBe("NEWSHA");
   });
 
@@ -1181,5 +1318,47 @@ describe("cluster-secret event severity + env-backed set (Codex re-review)", () 
     // Membership rule: every file the daemon launcher `source`s into its boot env.
     expect(ENV_BACKED_SECRET_FILES.has("claude-accounts.env")).toBe(true);
     expect(ENV_BACKED_SECRET_FILES.has("execution-core.env")).toBe(true);
+  });
+});
+
+// CTL-1612. The predicate that decides which rotated files get a `restart-required`
+// signal. Membership rule: "CAPTURED AT PROCESS START, therefore NOT live in a running
+// process until it restarts" — whether captured by `source` into the boot env or by a
+// single boot-time read closed over per request. Explicit truth table, because BOTH
+// columns are load-bearing: too narrow re-creates the 2026-08-02 silent-stale outage,
+// too broad turns every bundle rotation into a restart nag nobody reads.
+describe("isEnvBackedSecretFile", () => {
+  test("TRUE — every boot-captured file, incl. the linear-webhook-secret-<team> family", () => {
+    // (a) `source`d into the daemon's boot env by catalyst-execution-core
+    expect(isEnvBackedSecretFile("claude-accounts.env")).toBe(true);
+    expect(isEnvBackedSecretFile("execution-core.env")).toBe(true);
+    expect(isEnvBackedSecretFile("github-token")).toBe(true);
+    // (b) read ONCE at orch-monitor boot (loadWebhookConfig), then closed over per
+    //     request — never re-read per delivery, so a rotation is inert until restart
+    expect(isEnvBackedSecretFile("webhook-secret")).toBe(true);
+    expect(isEnvBackedSecretFile("linear-webhook-secret")).toBe(true);
+    // the per-team FAMILY: names are built from Layer-2 team keys, so the set is
+    // open-ended — an exact-match Set can never enumerate it
+    expect(isEnvBackedSecretFile("linear-webhook-secret-ctl")).toBe(true);
+    expect(isEnvBackedSecretFile("linear-webhook-secret-adv")).toBe(true);
+    // …and team keys are NOT guaranteed lowercase. The case-insensitivity IS the
+    // point: an anchored /^linear-webhook-secret-[a-z0-9-]+$/ would silently no-op
+    // on "CTL" — exactly the miss this predicate exists to prevent.
+    expect(isEnvBackedSecretFile("linear-webhook-secret-CTL")).toBe(true);
+  });
+
+  test("FALSE — family near-misses, plain bundle files, and non-string inputs", () => {
+    // bare prefix, nothing after the dash — not a team secret, just the prefix
+    expect(isEnvBackedSecretFile("linear-webhook-secret-")).toBe(false);
+    // run-on with no dash separator — a prefix match alone must not be enough
+    expect(isEnvBackedSecretFile("linear-webhook-secretXXX")).toBe(false);
+    // genuine bundle files that nothing sources or boot-reads (over-broad guard)
+    expect(isEnvBackedSecretFile("cma-api-key")).toBe(false);
+    expect(isEnvBackedSecretFile("age.key")).toBe(false);
+    // defensive: a decrypt map is attacker-adjacent input — never throw on junk
+    expect(isEnvBackedSecretFile("")).toBe(false);
+    expect(isEnvBackedSecretFile(null)).toBe(false);
+    expect(isEnvBackedSecretFile(undefined)).toBe(false);
+    expect(isEnvBackedSecretFile(42)).toBe(false);
   });
 });

--- a/plugins/dev/scripts/execution-core/daemon.mjs
+++ b/plugins/dev/scripts/execution-core/daemon.mjs
@@ -952,10 +952,6 @@ export function startDaemon({
       env: process.env,
       oauthToken: process.env.CLAUDE_CODE_OAUTH_TOKEN,
     }).ok;
-    // CTL-1612: prove the GitHub credential this daemon captured at start is actually
-    // usable, and say so LOUDLY if it is not. Purely advisory — never throws, never
-    // blocks boot, alerts only on a definitive 401 (a transient failure stays silent).
-    githubAuthPreflight({ env: process.env, log });
     const dispatchFn = makePhaseAwareDispatchFn({
       bootExecutor: executor,
       codexBootEligible: codexElig.eligible,
@@ -1254,6 +1250,14 @@ export function startDaemon({
       }, clusterSyncIntervalMs);
       _clusterSyncTimer.unref?.();
     }
+
+    // CTL-1612: prove the GitHub credential this daemon will actually use is usable, and
+    // say so LOUDLY if it is not. Deliberately placed AFTER the boot clusterSync (Codex
+    // P1): a node that was offline during a rotation starts on the stale local copy, and
+    // the sync above is what puts the replacement on disk — so re-arm from the file and
+    // probe THAT, or the daemon would 401 until a second manual restart. Purely advisory
+    // — never throws, never blocks boot, alerts only on a definitive 401.
+    githubAuthPreflight({ env: process.env, log });
   } catch (err) {
     stopDaemon();
     throw err;

--- a/plugins/dev/scripts/execution-core/daemon.mjs
+++ b/plugins/dev/scripts/execution-core/daemon.mjs
@@ -984,6 +984,26 @@ export function startDaemon({
     // CTL-1365b: dispatch === dispatchFn so the crash-recovery re-dispatch honors
     // the executor flag (defaultDispatch under bg — reconcileBootResume's own
     // default — so byte-identical to today).
+    // CTL-1612 (Codex P1, round 2): materialize cluster secrets and arm the GitHub
+    // credential BEFORE anything dispatches. reconcileBoot and processApprovedResumes
+    // below launch workers synchronously, and dispatch.mjs spawns them with
+    // ...process.env — so a node returning after a rotation would hand every resumed
+    // worker the stale credential and they would keep it for their whole lifetime, even
+    // though the daemon's own env gets corrected later. clusterSync() takes no arguments
+    // and is fail-open, so hoisting it here is safe; the periodic refresh timer is still
+    // armed further down, next to the other timers.
+    if (enableClusterSync) {
+      try {
+        const bootSync = clusterSync();
+        log.info({ pull: bootSync?.pull }, "execution-core daemon: cluster-repo synced at boot");
+      } catch (err) {
+        log.warn({ err: err?.message }, "execution-core daemon: boot cluster-sync threw (continuing)");
+      }
+    }
+    // Probe the credential we will actually hand to those workers, re-arming first from
+    // whatever the sync just put on disk. Advisory: never throws, never blocks boot.
+    githubAuthPreflight({ env: process.env, log });
+
     const bootResume = reconcileBoot({
       orchDir,
       report,
@@ -1232,15 +1252,9 @@ export function startDaemon({
     // NEVER abort daemon boot or wedge a timer tick. Refresh is a no-op ("no-head")
     // when no clone exists, and skips the sops spawn entirely when HEAD is unchanged.
     if (enableClusterSync) {
-      try {
-        const bootSync = clusterSync();
-        log.info({ pull: bootSync?.pull }, "execution-core daemon: cluster-repo synced at boot");
-      } catch (err) {
-        log.warn(
-          { err: err?.message },
-          "execution-core daemon: boot cluster-sync threw (continuing)"
-        );
-      }
+      // CTL-1612: the BOOT sync moved earlier (before the boot-resume dispatches, so
+      // resumed workers never inherit a stale credential). Only the periodic refresh
+      // is armed here, alongside the other timers.
       _clusterSyncTimer = setInterval(() => {
         try {
           refreshClusterSecrets();
@@ -1251,13 +1265,6 @@ export function startDaemon({
       _clusterSyncTimer.unref?.();
     }
 
-    // CTL-1612: prove the GitHub credential this daemon will actually use is usable, and
-    // say so LOUDLY if it is not. Deliberately placed AFTER the boot clusterSync (Codex
-    // P1): a node that was offline during a rotation starts on the stale local copy, and
-    // the sync above is what puts the replacement on disk — so re-arm from the file and
-    // probe THAT, or the daemon would 401 until a second manual restart. Purely advisory
-    // — never throws, never blocks boot, alerts only on a definitive 401.
-    githubAuthPreflight({ env: process.env, log });
   } catch (err) {
     stopDaemon();
     throw err;

--- a/plugins/dev/scripts/execution-core/daemon.mjs
+++ b/plugins/dev/scripts/execution-core/daemon.mjs
@@ -132,7 +132,7 @@ import {
   resolvePhaseSessionId,
   defaultAppendOperatorEvent,
 } from "./recovery.mjs"; // CTL-655: window the revive budget to this run; CTL-736: reset progress high-water; CTL-768: --resume; CTL-1044: operator-event appender for the scheduler's appendIntentEvent seam
-import { resolveGithubBootAuth } from "./github-auth-preflight.mjs"; // CTL-1612: boot GitHub-credential preflight (advisory; alerts only on a definitive 401)
+import { resolveGithubBootAuth, rearmGithubTokenFromFile } from "./github-auth-preflight.mjs"; // CTL-1612: boot GitHub-credential preflight (advisory; alerts only on a definitive 401)
 import { startAutoTuner } from "./autotune.mjs"; // CTL-684: side-car maxParallel auto-tuner
 import { dispatchTicket, makeCommentWakeDispatch, makePhaseAwareDispatchFn } from "./dispatch.mjs"; // CTL-549: comment-wake re-dispatch; CTL-1365a/b: executor→dispatch selection at the launch seam + comment-wake executor binding; CTL-1457: per-phase-aware dispatchFn factory (owns the executor→dispatch selection internally)
 import { resolveSdkBootExecutor, assertSdkAuth } from "./sdk-run-phase-agent.mjs"; // CTL-1367 item 9 + P3: boot auth gate (subscription-only) that degrades sdk→bg AND emits execution-core.executor.bg-fallback so the silent fallback is observable; CTL-1457 (T5): assertSdkAuth also gates a per-phase sdk route on a bg/default node
@@ -1000,9 +1000,12 @@ export function startDaemon({
         log.warn({ err: err?.message }, "execution-core daemon: boot cluster-sync threw (continuing)");
       }
     }
-    // Probe the credential we will actually hand to those workers, re-arming first from
-    // whatever the sync just put on disk. Advisory: never throws, never blocks boot.
-    githubAuthPreflight({ env: process.env, log });
+    // Re-arm ONLY (no probe) before anything dispatches: this is a cheap local file read,
+    // and it is what stops a boot-resumed worker inheriting a credential the sync just
+    // superseded. The probe is deliberately NOT here — it spawns `gh` with a 10s timeout,
+    // and putting a network round-trip ahead of crash recovery would delay re-dispatching
+    // in-flight work for no diagnostic benefit. It runs after the dispatches instead.
+    rearmGithubTokenFromFile({ env: process.env, log });
 
     const bootResume = reconcileBoot({
       orchDir,
@@ -1018,6 +1021,10 @@ export function startDaemon({
     // dispatch entry point and previously defaulted to defaultDispatch, so an
     // approved-resume ticket launched via bg even under executor=sdk (split-brain).
     processApprovedResumes({ orchDir, dispatch: dispatchFn });
+    // CTL-1612: NOW probe the credential — after the dispatches, so a 10s `gh` timeout can
+    // never delay crash recovery. Advisory only: never throws, never blocks boot, and
+    // alerts solely on a definitive 401.
+    githubAuthPreflight({ env: process.env, log });
     // CTL-634: one shared TTL state cache. The monitor write-through populates
     // it on every state_changed event; the scheduler read path consults it
     // during out-of-set blocker hydration. A single instance threaded into
@@ -1260,6 +1267,19 @@ export function startDaemon({
           refreshClusterSecrets();
         } catch (err) {
           log.warn({ err: err?.message }, "cluster-sync timer: refresh threw (continuing)");
+        }
+        // CTL-1612: re-arm from disk on EVERY tick, unconditionally. Without this the
+        // whole fix is boot-only: a credential rotated at 03:00 on a daemon that booted at
+        // 00:00 stays dead until a human restarts it, and we would merely have converted a
+        // silent failure into a loud one that still needs hands. Deliberately NOT gated on
+        // the refresh result — refreshClusterSecretsIfChanged short-circuits on
+        // `head-unchanged` without re-reading the file, and the rotation may also have been
+        // materialized by the OTHER writer (cluster-sync at boot, or an operator). The call
+        // is a cheap local read, no-ops when the value is unchanged, and never throws.
+        try {
+          rearmGithubTokenFromFile({ env: process.env, log });
+        } catch (err) {
+          log.warn({ err: err?.message }, "cluster-sync timer: credential re-arm threw (continuing)");
         }
       }, clusterSyncIntervalMs);
       _clusterSyncTimer.unref?.();

--- a/plugins/dev/scripts/execution-core/daemon.mjs
+++ b/plugins/dev/scripts/execution-core/daemon.mjs
@@ -132,6 +132,7 @@ import {
   resolvePhaseSessionId,
   defaultAppendOperatorEvent,
 } from "./recovery.mjs"; // CTL-655: window the revive budget to this run; CTL-736: reset progress high-water; CTL-768: --resume; CTL-1044: operator-event appender for the scheduler's appendIntentEvent seam
+import { resolveGithubBootAuth } from "./github-auth-preflight.mjs"; // CTL-1612: boot GitHub-credential preflight (advisory; alerts only on a definitive 401)
 import { startAutoTuner } from "./autotune.mjs"; // CTL-684: side-car maxParallel auto-tuner
 import { dispatchTicket, makeCommentWakeDispatch, makePhaseAwareDispatchFn } from "./dispatch.mjs"; // CTL-549: comment-wake re-dispatch; CTL-1365a/b: executor→dispatch selection at the launch seam + comment-wake executor binding; CTL-1457: per-phase-aware dispatchFn factory (owns the executor→dispatch selection internally)
 import { resolveSdkBootExecutor, assertSdkAuth } from "./sdk-run-phase-agent.mjs"; // CTL-1367 item 9 + P3: boot auth gate (subscription-only) that degrades sdk→bg AND emits execution-core.executor.bg-fallback so the silent fallback is observable; CTL-1457 (T5): assertSdkAuth also gates a per-phase sdk route on a bg/default node
@@ -736,6 +737,9 @@ export function startDaemon({
   // CTL-854: injectable for the boot empty-registry health check. Tests inject
   // a deterministic fake; production uses the real registry reader.
   listProjects: listProjectsFn = realListProjects,
+  // CTL-1612: injectable GitHub-credential boot preflight. Tests inject a fake; in
+  // production it probes `gh` for real. Advisory — never throws, never blocks boot.
+  githubAuthPreflight = resolveGithubBootAuth,
   // CTL-862: injectable seams for the ownership boot-log. Tests inject a fixed
   // roster and eligible list; production resolves them from the real modules.
   readAllEligible = readAllEligibleTickets,
@@ -948,6 +952,10 @@ export function startDaemon({
       env: process.env,
       oauthToken: process.env.CLAUDE_CODE_OAUTH_TOKEN,
     }).ok;
+    // CTL-1612: prove the GitHub credential this daemon captured at start is actually
+    // usable, and say so LOUDLY if it is not. Purely advisory — never throws, never
+    // blocks boot, alerts only on a definitive 401 (a transient failure stays silent).
+    githubAuthPreflight({ env: process.env, log });
     const dispatchFn = makePhaseAwareDispatchFn({
       bootExecutor: executor,
       codexBootEligible: codexElig.eligible,

--- a/plugins/dev/scripts/execution-core/dispatch-alert.mjs
+++ b/plugins/dev/scripts/execution-core/dispatch-alert.mjs
@@ -43,6 +43,17 @@ export const ALERT_BOOT_RESUME_PENDING = "catalyst.alert.boot_resume_pending";
 
 export const ALERT_KIND_BOOT_RESUME_PENDING = "boot_resume_pending";
 
+// CTL-1612: the daemon's GitHub credential is DEFINITIVELY unusable (a 401 from the
+// API, not a timeout or a network blip). Before this alert existed, a daemon that
+// booted holding a revoked credential simply 401'd every sweep forever — 102 failures
+// across two hosts went unreported for 5+ hours on 2026-08-02, visible only as a
+// repeated warning line buried in daemon.log. Emitted ONLY on a proven-unauthorized
+// probe: a transient/unknown failure must stay silent so a DNS blip or a GitHub 5xx
+// cannot page the fleet.
+export const ALERT_GITHUB_AUTH_UNUSABLE = "catalyst.alert.github_auth_unusable";
+
+export const ALERT_KIND_GITHUB_AUTH_UNUSABLE = "github_auth_unusable";
+
 // Per-kind throttle so a per-tick hot path (runEligibleQuery inside the reconcile
 // timer) cannot spam the event log during a sustained storm. The alert is a LOUD
 // "something is wrong"
@@ -166,6 +177,27 @@ export function emitTicketStateLiveFallback({ identifier = null, reason = null, 
       reason ??
       "a terminal-probe ticket-state read missed the replica and its live linearis fallback failed — backed off (breaker-flap mitigation)",
     detail: identifier ? { "linear.ticket": identifier } : {},
+    append,
+    now,
+    throttleMs,
+  });
+}
+
+// emitGithubAuthUnusable — CTL-1612 boot-preflight alert. Call ONLY when the probe
+// proved a 401; transient/unknown outcomes must not reach here.
+//
+// The detail key is NAMESPACED on purpose. buildDispatchAlertEvent writes its own
+// `source: "catalyst.execution-core"` into body.payload and THEN spreads `...detail`,
+// so a bare `source` key here would silently overwrite the service identifier that
+// every existing catalyst.alert.* consumer reads.
+export function emitGithubAuthUnusable({ tokenSource = null, reason = null, append, now, throttleMs } = {}) {
+  return emitThrottled({
+    eventName: ALERT_GITHUB_AUTH_UNUSABLE,
+    kind: ALERT_KIND_GITHUB_AUTH_UNUSABLE,
+    reason:
+      reason ??
+      "the daemon's GitHub credential was rejected (HTTP 401) at boot — every gh API call from this daemon and the workers it dispatches will fail until it is replaced and the daemon restarted",
+    detail: tokenSource ? { "catalyst.github_token_source": tokenSource } : {},
     append,
     now,
     throttleMs,

--- a/plugins/dev/scripts/execution-core/github-auth-preflight.mjs
+++ b/plugins/dev/scripts/execution-core/github-auth-preflight.mjs
@@ -83,6 +83,13 @@ export function defaultProbeGithubAuth(env = process.env) {
 // the XDG location, and take the first readable non-empty file.
 export function githubTokenFileCandidates(env = process.env) {
   if (env?.CATALYST_GITHUB_TOKEN_FILE) return [env.CATALYST_GITHUB_TOKEN_FILE];
+  // CTL-1612: honor CATALYST_CONFIG_DIR exactly as the launcher's
+  // catalyst_read_secret_file does. Without this the two disagree — the launcher arms from
+  // the configured directory and labels it "shared-file", then this re-arm (boot AND every
+  // timer tick) replaces both aliases from the DEFAULT directory. If that copy is stale the
+  // daemon silently reverts to 401s, which is the exact divergence the shared library was
+  // introduced to eliminate, recreated across the bash/JS boundary.
+  if (env?.CATALYST_CONFIG_DIR) return [join(env.CATALYST_CONFIG_DIR, "github-token")];
   const home = env?.HOME ?? homedir();
   const layer2 = env?.CATALYST_LAYER2_CONFIG_FILE ?? join(home, ".config", "catalyst", "config.json");
   const out = [join(dirname(layer2), "github-token")];
@@ -128,12 +135,15 @@ export function rearmGithubTokenFromFile({
         continue; // not on this host — try the next candidate
       }
       found = true;
-      // TRIM only — never strip internal whitespace. `.replace(/\s+/g,"")` would silently
-      // corrupt any credential containing a space/tab/newline (an HMAC key would then
-      // reject every delivery with no error anywhere). Mirrors _catalyst_trim in
-      // lib/catalyst-secret-env.sh.
-      const candidate = String(raw ?? "").trim();
-      if (candidate) {
+      // Strip ONLY the trailing line terminator; preserve every other byte.
+      // `.replace(/\s+/g,"")` corrupted internal whitespace, and a full `.trim()` corrupts
+      // SIGNIFICANT BOUNDARY whitespace — both produce a different credential that looks
+      // present and is silently wrong. Mirrors _catalyst_strip_eol in
+      // lib/catalyst-secret-env.sh so the bash and JS readers cannot disagree.
+      const candidate = String(raw ?? "").replace(/\r?\n$/, "");
+      // Blank-check, not truthiness: a whitespace-only file must keep falling through to
+      // the next candidate (a truthy "   " would break here and mask a valid fallback).
+      if (candidate.trim()) {
         tok = candidate;
         break;
       }
@@ -141,7 +151,10 @@ export function rearmGithubTokenFromFile({
     if (!found) return { rearmed: false, reason: "absent" }; // no shared file anywhere
     // Never install an empty value: "" reads as SET to `??`/`${X:-}` and would defeat
     // gh's hosts.yml/keyring fallback for hosts that rely on it.
-    if (!tok) return { rearmed: false, reason: "empty" };
+    // Blank-check WITHOUT mutating: a whitespace-only file counts as absent (never install
+    // "", which reads as SET to `??` and would defeat gh's hosts.yml/keyring fallback),
+    // while a value with significant boundary whitespace is installed byte-for-byte.
+    if (!tok.trim()) return { rearmed: false, reason: "empty" };
     if (tok === env.GITHUB_TOKEN && tok === env.GH_TOKEN) {
       return { rearmed: false, reason: "unchanged" };
     }

--- a/plugins/dev/scripts/execution-core/github-auth-preflight.mjs
+++ b/plugins/dev/scripts/execution-core/github-auth-preflight.mjs
@@ -135,12 +135,15 @@ export function rearmGithubTokenFromFile({
         continue; // not on this host — try the next candidate
       }
       found = true;
-      // Strip ONLY the trailing line terminator; preserve every other byte.
+      // Strip ONLY trailing line terminators; preserve every other byte.
       // `.replace(/\s+/g,"")` corrupted internal whitespace, and a full `.trim()` corrupts
       // SIGNIFICANT BOUNDARY whitespace — both produce a different credential that looks
-      // present and is silently wrong. Mirrors _catalyst_strip_eol in
-      // lib/catalyst-secret-env.sh so the bash and JS readers cannot disagree.
-      const candidate = String(raw ?? "").replace(/\r?\n$/, "");
+      // present and is silently wrong. ALL trailing terminators, not just the last one:
+      // the bash launcher reads via `$(cat …)`, which eats every trailing newline, so a
+      // file ending in `\n\n` must re-arm to the same bare token the launcher installed.
+      // Mirrors _catalyst_strip_eol in lib/catalyst-secret-env.sh so the bash and JS
+      // readers cannot disagree.
+      const candidate = String(raw ?? "").replace(/[\r\n]+$/, "");
       // Blank-check, not truthiness: a whitespace-only file must keep falling through to
       // the next candidate (a truthy "   " would break here and mask a valid fallback).
       if (candidate.trim()) {

--- a/plugins/dev/scripts/execution-core/github-auth-preflight.mjs
+++ b/plugins/dev/scripts/execution-core/github-auth-preflight.mjs
@@ -1,0 +1,124 @@
+// github-auth-preflight.mjs — CTL-1612. Daemon-boot GitHub credential preflight.
+//
+// WHY THIS EXISTS. A daemon captures its GitHub credential at process start and never
+// re-reads it, so a revoked credential is invisible from inside the daemon: every `gh`
+// API call simply 401s forever. On 2026-08-02 both minis booted holding a revoked token
+// and produced 102 authentication failures over 5+ hours with NO operator-visible signal
+// — the only trace was a repeated warning line in daemon.log. This module turns that
+// silent, indefinite failure into ONE loud alert at boot.
+//
+// POSTURE: strictly ADVISORY. It never throws, never blocks boot, and never gates
+// dispatch. A daemon with a bad credential still starts (plenty of its work needs no
+// GitHub at all) — it just says so.
+//
+// THE THREE-STATE RESULT IS LOAD-BEARING. "Could not prove the credential is good" is NOT
+// the same as "the credential is bad". A DNS blip, a GitHub 5xx, a missing `gh` binary, or
+// the probe timeout must stay SILENT; only a definitive 401 alerts. Collapsing these into
+// a boolean would page the whole fleet on any transient network hiccup.
+//
+// Run: cd plugins/dev/scripts/execution-core && bun test github-auth-preflight.test.mjs
+import { spawnSync } from "node:child_process";
+
+import { log as defaultLog } from "./config.mjs";
+import { emitGithubAuthUnusable } from "./dispatch-alert.mjs";
+
+// Bounded so a hung/unreachable api.github.com can never wedge daemon boot.
+export const GITHUB_PROBE_TIMEOUT_MS = 10_000;
+
+// isUnauthorizedOutput — a DEFINITIVE credential rejection, as `gh` reports it.
+// `gh api` on a bad token writes e.g. `gh: Bad credentials (HTTP 401)` to stderr.
+// Deliberately narrow: anything not matched here is treated as transient/unknown and
+// stays silent. A 403 is NOT included — that is a scope/rate problem, not a dead
+// credential, and it must not fire the "replace your credential" alert.
+export function isUnauthorizedOutput(text) {
+  const s = String(text ?? "");
+  return /\bHTTP 401\b/i.test(s) || /\bbad credentials\b/i.test(s);
+}
+
+// defaultProbeGithubAuth — one bounded, read-only probe. NEVER throws.
+// `/rate_limit` is the cheapest authenticated endpoint: it does not count against the
+// rate limit it reports, so a restart loop cannot burn quota.
+//
+// `env` is threaded explicitly all the way into spawnSync so tests can inject a
+// credential-bearing environment without touching process.env. It must carry a PATH or
+// `gh` will not resolve.
+export function defaultProbeGithubAuth(env = process.env) {
+  try {
+    const r = spawnSync("gh", ["api", "/rate_limit", "--silent"], {
+      encoding: "utf8",
+      env,
+      timeout: GITHUB_PROBE_TIMEOUT_MS,
+    });
+    if (r.error) {
+      // ENOENT (no gh on PATH), ETIMEDOUT, spawn failure → unknown, never an alert.
+      return { ok: false, unauthorized: false, transient: true, reason: r.error.message };
+    }
+    if (r.status === 0) return { ok: true, unauthorized: false, transient: false, reason: null };
+    const combined = `${r.stderr ?? ""}\n${r.stdout ?? ""}`;
+    if (isUnauthorizedOutput(combined)) {
+      return { ok: false, unauthorized: true, transient: false, reason: "HTTP 401" };
+    }
+    return {
+      ok: false,
+      unauthorized: false,
+      transient: true,
+      reason: `gh exited ${r.status}`,
+    };
+  } catch (err) {
+    return { ok: false, unauthorized: false, transient: true, reason: err?.message ?? String(err) };
+  }
+}
+
+// resolveGithubBootAuth — the daemon-boot entrypoint. Returns a small verdict object
+// for logging/testing; the caller ignores it. NEVER throws.
+//
+// Emits the alert on `unauthorized` ONLY. The credential's provenance breadcrumb
+// (CATALYST_GITHUB_TOKEN_SOURCE, exported by catalyst-execution-core's
+// _project_shared_github_token) rides along so an operator can tell at a glance whether
+// the daemon was running the shared SOPS file, an inherited value, or nothing at all —
+// which is precisely the distinction that took hours to establish during the outage.
+export function resolveGithubBootAuth({
+  env = process.env,
+  probe = defaultProbeGithubAuth,
+  emitAlert = emitGithubAuthUnusable,
+  log = defaultLog,
+} = {}) {
+  const tokenSource = env?.CATALYST_GITHUB_TOKEN_SOURCE ?? "unknown";
+  let result;
+  try {
+    result = probe(env);
+  } catch (err) {
+    // A throwing injected probe must not take the daemon down with it.
+    log?.warn?.(
+      { err: err?.message },
+      "github-auth-preflight: probe threw — skipping (advisory only)",
+    );
+    return { checked: false, ok: false, unauthorized: false, tokenSource };
+  }
+
+  if (result?.ok) {
+    log?.debug?.({ tokenSource }, "github-auth-preflight: GitHub credential accepted");
+    return { checked: true, ok: true, unauthorized: false, tokenSource };
+  }
+
+  if (result?.unauthorized === true) {
+    log?.error?.(
+      { tokenSource },
+      "github-auth-preflight: GitHub credential REJECTED (401) — every gh API call from " +
+        "this daemon and its workers will fail until it is replaced and the daemon restarted",
+    );
+    try {
+      emitAlert({ tokenSource, reason: result?.reason ?? undefined });
+    } catch (err) {
+      log?.warn?.({ err: err?.message }, "github-auth-preflight: alert emit failed (continuing)");
+    }
+    return { checked: true, ok: false, unauthorized: true, tokenSource };
+  }
+
+  // Transient/unknown → log quietly and stay silent. Not proof of a bad credential.
+  log?.warn?.(
+    { tokenSource, reason: result?.reason ?? null },
+    "github-auth-preflight: could not verify the GitHub credential (transient) — no alert",
+  );
+  return { checked: true, ok: false, unauthorized: false, tokenSource };
+}

--- a/plugins/dev/scripts/execution-core/github-auth-preflight.mjs
+++ b/plugins/dev/scripts/execution-core/github-auth-preflight.mjs
@@ -18,6 +18,9 @@
 //
 // Run: cd plugins/dev/scripts/execution-core && bun test github-auth-preflight.test.mjs
 import { spawnSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
 
 import { log as defaultLog } from "./config.mjs";
 import { emitGithubAuthUnusable } from "./dispatch-alert.mjs";
@@ -69,6 +72,65 @@ export function defaultProbeGithubAuth(env = process.env) {
   }
 }
 
+// defaultGithubTokenFile — XDG-aware, mirroring the launcher's
+// _project_shared_github_token and setup-webhooks.sh:23.
+export function defaultGithubTokenFile(env = process.env) {
+  if (env?.CATALYST_GITHUB_TOKEN_FILE) return env.CATALYST_GITHUB_TOKEN_FILE;
+  const base = env?.XDG_CONFIG_HOME || join(env?.HOME ?? homedir(), ".config");
+  return join(base, "catalyst", "github-token");
+}
+
+// rearmGithubTokenFromFile — CTL-1612 (Codex P1). Re-read the shared credential from
+// disk and update this process's env if it has changed.
+//
+// WHY THIS IS NEEDED even though the launcher already projected the file: a node that
+// was OFFLINE during a rotation boots with the stale local copy, and only afterwards does
+// daemon boot run clusterSync() — which pulls and materializes the replacement onto disk.
+// Nothing re-reads it, and because the boot sync seeds the change-detection marker at the
+// new HEAD, the periodic refresh then reports "head-unchanged" and never fires
+// restart-required. Without this the daemon 401s until a SECOND, manual restart — the
+// exact silent-stale shape this ticket exists to close, just one layer deeper.
+//
+// Call AFTER clusterSync. Respects an explicit operator override (the launcher marks it
+// CATALYST_GITHUB_TOKEN_SOURCE=operator-override) and never throws.
+export function rearmGithubTokenFromFile({
+  env = process.env,
+  readFile = (p) => readFileSync(p, "utf8"),
+  log = defaultLog,
+} = {}) {
+  try {
+    if (env?.CATALYST_GITHUB_TOKEN_SOURCE === "operator-override") {
+      return { rearmed: false, reason: "operator-override" };
+    }
+    const file = defaultGithubTokenFile(env);
+    let raw;
+    try {
+      raw = readFile(file);
+    } catch {
+      return { rearmed: false, reason: "absent" }; // no shared file on this host → no-op
+    }
+    const tok = String(raw ?? "").replace(/\s+/g, "");
+    // Never install an empty value: "" reads as SET to `??`/`${X:-}` and would defeat
+    // gh's hosts.yml/keyring fallback for hosts that rely on it.
+    if (!tok) return { rearmed: false, reason: "empty" };
+    if (tok === env.GITHUB_TOKEN && tok === env.GH_TOKEN) {
+      return { rearmed: false, reason: "unchanged" };
+    }
+    env.GITHUB_TOKEN = tok;
+    env.GH_TOKEN = tok; // both, because `gh` resolves GH_TOKEN first
+    env.CATALYST_GITHUB_TOKEN_SOURCE = "shared-file-resynced";
+    log?.warn?.(
+      {},
+      "github-auth-preflight: the shared GitHub credential changed on disk after launch " +
+        "(cluster-sync materialized a rotation) — re-armed in-process, no restart needed",
+    );
+    return { rearmed: true, reason: "rotated" };
+  } catch (err) {
+    log?.warn?.({ err: err?.message }, "github-auth-preflight: re-arm failed (continuing)");
+    return { rearmed: false, reason: "error" };
+  }
+}
+
 // resolveGithubBootAuth — the daemon-boot entrypoint. Returns a small verdict object
 // for logging/testing; the caller ignores it. NEVER throws.
 //
@@ -82,7 +144,15 @@ export function resolveGithubBootAuth({
   probe = defaultProbeGithubAuth,
   emitAlert = emitGithubAuthUnusable,
   log = defaultLog,
+  rearm = rearmGithubTokenFromFile,
 } = {}) {
+  // CTL-1612 (Codex P1): pick up a rotation that cluster-sync materialized AFTER the
+  // launcher projected the file, so we probe the credential we will actually use.
+  try {
+    rearm({ env, log });
+  } catch (err) {
+    log?.warn?.({ err: err?.message }, "github-auth-preflight: re-arm threw (continuing)");
+  }
   const tokenSource = env?.CATALYST_GITHUB_TOKEN_SOURCE ?? "unknown";
   let result;
   try {

--- a/plugins/dev/scripts/execution-core/github-auth-preflight.mjs
+++ b/plugins/dev/scripts/execution-core/github-auth-preflight.mjs
@@ -128,7 +128,11 @@ export function rearmGithubTokenFromFile({
         continue; // not on this host — try the next candidate
       }
       found = true;
-      const candidate = String(raw ?? "").replace(/\s+/g, "");
+      // TRIM only — never strip internal whitespace. `.replace(/\s+/g,"")` would silently
+      // corrupt any credential containing a space/tab/newline (an HMAC key would then
+      // reject every delivery with no error anywhere). Mirrors _catalyst_trim in
+      // lib/catalyst-secret-env.sh.
+      const candidate = String(raw ?? "").trim();
       if (candidate) {
         tok = candidate;
         break;

--- a/plugins/dev/scripts/execution-core/github-auth-preflight.mjs
+++ b/plugins/dev/scripts/execution-core/github-auth-preflight.mjs
@@ -20,7 +20,7 @@
 import { spawnSync } from "node:child_process";
 import { readFileSync } from "node:fs";
 import { homedir } from "node:os";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
 
 import { log as defaultLog } from "./config.mjs";
 import { emitGithubAuthUnusable } from "./dispatch-alert.mjs";
@@ -72,12 +72,28 @@ export function defaultProbeGithubAuth(env = process.env) {
   }
 }
 
-// defaultGithubTokenFile — XDG-aware, mirroring the launcher's
-// _project_shared_github_token and setup-webhooks.sh:23.
+// githubTokenFileCandidates — the resolution CHAIN, in priority order. Mirrors the
+// launcher's _project_shared_github_token exactly.
+//
+// The writers disagree (Codex P1, round 2): cluster-sync materializes bare secrets into
+// dirname(getLayer2ConfigPath()), whose default is HARDCODED ~/.config/catalyst and is
+// NOT XDG-aware, while other tooling (setup-webhooks.sh:23, lib/linear-app-actor.sh:30)
+// IS. Reading only the XDG path would miss every rotation on an XDG host — strictly worse
+// than the hardcoded read. So prefer cluster-sync's own destination, then fall back to
+// the XDG location, and take the first readable non-empty file.
+export function githubTokenFileCandidates(env = process.env) {
+  if (env?.CATALYST_GITHUB_TOKEN_FILE) return [env.CATALYST_GITHUB_TOKEN_FILE];
+  const home = env?.HOME ?? homedir();
+  const layer2 = env?.CATALYST_LAYER2_CONFIG_FILE ?? join(home, ".config", "catalyst", "config.json");
+  const out = [join(dirname(layer2), "github-token")];
+  const xdg = join(env?.XDG_CONFIG_HOME || join(home, ".config"), "catalyst", "github-token");
+  if (!out.includes(xdg)) out.push(xdg);
+  return out;
+}
+
+// defaultGithubTokenFile — the highest-priority candidate (cluster-sync's destination).
 export function defaultGithubTokenFile(env = process.env) {
-  if (env?.CATALYST_GITHUB_TOKEN_FILE) return env.CATALYST_GITHUB_TOKEN_FILE;
-  const base = env?.XDG_CONFIG_HOME || join(env?.HOME ?? homedir(), ".config");
-  return join(base, "catalyst", "github-token");
+  return githubTokenFileCandidates(env)[0];
 }
 
 // rearmGithubTokenFromFile — CTL-1612 (Codex P1). Re-read the shared credential from
@@ -102,14 +118,23 @@ export function rearmGithubTokenFromFile({
     if (env?.CATALYST_GITHUB_TOKEN_SOURCE === "operator-override") {
       return { rearmed: false, reason: "operator-override" };
     }
-    const file = defaultGithubTokenFile(env);
-    let raw;
-    try {
-      raw = readFile(file);
-    } catch {
-      return { rearmed: false, reason: "absent" }; // no shared file on this host → no-op
+    let tok = "";
+    let found = false;
+    for (const file of githubTokenFileCandidates(env)) {
+      let raw;
+      try {
+        raw = readFile(file);
+      } catch {
+        continue; // not on this host — try the next candidate
+      }
+      found = true;
+      const candidate = String(raw ?? "").replace(/\s+/g, "");
+      if (candidate) {
+        tok = candidate;
+        break;
+      }
     }
-    const tok = String(raw ?? "").replace(/\s+/g, "");
+    if (!found) return { rearmed: false, reason: "absent" }; // no shared file anywhere
     // Never install an empty value: "" reads as SET to `??`/`${X:-}` and would defeat
     // gh's hosts.yml/keyring fallback for hosts that rely on it.
     if (!tok) return { rearmed: false, reason: "empty" };

--- a/plugins/dev/scripts/execution-core/github-auth-preflight.test.mjs
+++ b/plugins/dev/scripts/execution-core/github-auth-preflight.test.mjs
@@ -17,12 +17,13 @@
 // Run: cd plugins/dev/scripts/execution-core && bun test github-auth-preflight.test.mjs
 
 import { describe, test, expect } from "bun:test";
-import { mkdtempSync, rmSync } from "node:fs";
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
   GITHUB_PROBE_TIMEOUT_MS,
   defaultGithubTokenFile,
+  githubTokenFileCandidates,
   defaultProbeGithubAuth,
   isUnauthorizedOutput,
   rearmGithubTokenFromFile,
@@ -372,10 +373,31 @@ describe("defaultGithubTokenFile", () => {
     ).toBe("/etc/catalyst/explicit-github-token");
   });
 
-  test("XDG_CONFIG_HOME is honored ahead of $HOME/.config (matches setup-webhooks.sh:23)", () => {
+  // CTL-1612 (Codex P1, round 2): cluster-sync — the thing that actually WRITES this
+  // file — resolves its destination from dirname(getLayer2ConfigPath()), whose default is
+  // hardcoded ~/.config/catalyst and is NOT XDG-aware. Preferring the XDG path would make
+  // an XDG host miss every rotation, which is strictly worse than the hardcoded read it
+  // replaced. So the writer's destination is FIRST and XDG is a fallback.
+  test("the cluster-sync destination outranks XDG_CONFIG_HOME (the writer is not XDG-aware)", () => {
     expect(defaultGithubTokenFile({ XDG_CONFIG_HOME: "/xdg-config", HOME: "/home/fake" })).toBe(
-      join("/xdg-config", "catalyst", "github-token"),
+      join("/home/fake", ".config", "catalyst", "github-token"),
     );
+  });
+
+  test("XDG_CONFIG_HOME is still offered as a FALLBACK candidate, after the writer's dir", () => {
+    expect(githubTokenFileCandidates({ XDG_CONFIG_HOME: "/xdg-config", HOME: "/home/fake" })).toEqual([
+      join("/home/fake", ".config", "catalyst", "github-token"),
+      join("/xdg-config", "catalyst", "github-token"),
+    ]);
+  });
+
+  test("CATALYST_LAYER2_CONFIG_FILE moves the primary candidate, mirroring the writer", () => {
+    expect(
+      githubTokenFileCandidates({
+        CATALYST_LAYER2_CONFIG_FILE: "/opt/cfg/catalyst/config.json",
+        HOME: "/home/fake",
+      })[0],
+    ).toBe(join("/opt/cfg/catalyst", "github-token"));
   });
 
   test("falls back to $HOME/.config when XDG_CONFIG_HOME is unset", () => {
@@ -528,10 +550,31 @@ describe("rearmGithubTokenFromFile", () => {
     expect(reads).toHaveLength(0); // short-circuits before any read
   });
 
-  test("resolves the file through the XDG-aware path, not a hardcoded ~/.config", () => {
+  test("tries the cluster-sync destination FIRST, then falls back to the XDG path", () => {
     const env = { XDG_CONFIG_HOME: "/xdg-config", HOME: "/home/fake" };
     const { reads } = rearmWith({ env, files: {} });
-    expect(reads).toEqual([join("/xdg-config", "catalyst", "github-token")]);
+    expect(reads).toEqual([
+      join("/home/fake", ".config", "catalyst", "github-token"),
+      join("/xdg-config", "catalyst", "github-token"),
+    ]);
+  });
+
+  // The writers disagree, so a host can legitimately have the credential in EITHER
+  // place. Whichever exists must be found — this is the XDG-host rotation case.
+  test("finds the credential when only the XDG copy exists", () => {
+    const env = { XDG_CONFIG_HOME: "/xdg-config", HOME: "/home/fake", GITHUB_TOKEN: STALE_TOKEN };
+    const xdgPath = join("/xdg-config", "catalyst", "github-token");
+    const out = rearmGithubTokenFromFile({
+      env,
+      readFile: (p) => {
+        if (p === xdgPath) return ROTATED_TOKEN;
+        throw new Error("ENOENT");
+      },
+      log: null,
+    });
+    expect(out).toEqual({ rearmed: true, reason: "rotated" });
+    expect(env.GITHUB_TOKEN).toBe(ROTATED_TOKEN);
+    expect(env.GH_TOKEN).toBe(ROTATED_TOKEN);
   });
 
   test("advisory only: a missing log never breaks the re-arm", () => {
@@ -659,5 +702,44 @@ describe("resolveGithubBootAuth re-arms before probing", () => {
     expect(rec.state.alerts[0].tokenSource).toBe("shared-file-resynced");
     expect(rec.loggedText()).not.toContain(ROTATED_TOKEN);
     expect(JSON.stringify(rec.state.alerts)).not.toContain(ROTATED_TOKEN);
+  });
+});
+
+// ── daemon boot ORDERING (CTL-1612, Codex P1 round 2) ─────────────────────────
+//
+// The preflight's placement in daemon.mjs is load-bearing, and both directions have
+// already been wrong once:
+//   * originally it ran BEFORE the boot clusterSync, so a node offline during a rotation
+//     probed the stale credential and never saw the replacement the sync put on disk;
+//   * moving it after the sync then left it AFTER reconcileBoot/processApprovedResumes,
+//     which dispatch workers synchronously — and dispatch.mjs spawns them with
+//     ...process.env, so every resumed worker inherited the stale credential for life.
+// The only correct window is: clusterSync → preflight → any dispatch. A structural
+// assertion is the honest way to pin that; a unit test cannot observe boot ordering.
+describe("daemon boot ordering", () => {
+  const daemonSrc = readFileSync(new URL("./daemon.mjs", import.meta.url), "utf8").split("\n");
+  const lineOf = (needle) => daemonSrc.findIndex((l) => l.includes(needle));
+
+  test("the boot cluster-sync runs BEFORE the credential preflight", () => {
+    const sync = lineOf("const bootSync = clusterSync()");
+    const preflight = lineOf("githubAuthPreflight({ env: process.env, log })");
+    expect(sync).toBeGreaterThan(-1);
+    expect(preflight).toBeGreaterThan(-1);
+    expect(sync).toBeLessThan(preflight);
+  });
+
+  test("the credential preflight runs BEFORE anything dispatches a worker", () => {
+    const preflight = lineOf("githubAuthPreflight({ env: process.env, log })");
+    const bootResume = lineOf("const bootResume = reconcileBoot(");
+    const approved = lineOf("processApprovedResumes({ orchDir, dispatch: dispatchFn })");
+    expect(bootResume).toBeGreaterThan(-1);
+    expect(approved).toBeGreaterThan(-1);
+    expect(preflight).toBeLessThan(bootResume);
+    expect(preflight).toBeLessThan(approved);
+  });
+
+  test("the preflight is wired exactly once (no leftover duplicate call site)", () => {
+    const hits = daemonSrc.filter((l) => l.includes("githubAuthPreflight({")).length;
+    expect(hits).toBe(1);
   });
 });

--- a/plugins/dev/scripts/execution-core/github-auth-preflight.test.mjs
+++ b/plugins/dev/scripts/execution-core/github-auth-preflight.test.mjs
@@ -1,0 +1,303 @@
+// github-auth-preflight.test.mjs — CTL-1612. FULLY OFFLINE: every test injects
+// `probe` / `emitAlert` / `log` and an EXPLICIT `env` object, so no test ever
+// reads process.env, spawns `gh`, appends to the event log, or touches the
+// network. The one test that exercises the real `defaultProbeGithubAuth` points
+// its injected PATH at an EMPTY temp dir, so `gh` cannot resolve and the probe
+// classifies locally (never a request). Inherits test-setup.mjs.
+//
+// The contract under test is the ANTI-PAGING one: a definitive 401 alerts EXACTLY
+// once; every other outcome — spawn failure, non-401 exit, timeout, a throwing
+// probe, a malformed result — stays SILENT, because "could not prove the
+// credential is good" is not "the credential is bad".
+//
+// NO REAL SECRET VALUE APPEARS ANYWHERE IN THIS FILE. The token-shaped literals
+// below are obvious fakes used only to prove they are never surfaced.
+//
+// Run: cd plugins/dev/scripts/execution-core && bun test github-auth-preflight.test.mjs
+
+import { describe, test, expect } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  GITHUB_PROBE_TIMEOUT_MS,
+  defaultProbeGithubAuth,
+  isUnauthorizedOutput,
+  resolveGithubBootAuth,
+} from "./github-auth-preflight.mjs";
+
+// ── Fakes ─────────────────────────────────────────────────────────────────────
+
+// An obviously-fake credential literal. It exists ONLY so the hygiene test can
+// prove no code path ever echoes a credential value into a log or an alert.
+const FAKE_TOKEN = "ghp_THIS-IS-NOT-A-REAL-TOKEN-000000000000";
+
+// The three-state probe results, spelled out exactly as defaultProbeGithubAuth
+// builds them — the shapes resolveGithubBootAuth must discriminate.
+const OK = { ok: true, unauthorized: false, transient: false, reason: null };
+const UNAUTHORIZED = { ok: false, unauthorized: true, transient: false, reason: "HTTP 401" };
+const SPAWN_ERROR = { ok: false, unauthorized: false, transient: true, reason: "spawn gh ENOENT" };
+const NON_401_EXIT = { ok: false, unauthorized: false, transient: true, reason: "gh exited 1" };
+const TIMED_OUT = { ok: false, unauthorized: false, transient: true, reason: "spawnSync gh ETIMEDOUT" };
+
+// recorder — captures probe calls (including the env object identity), alert
+// payloads, and every log line, so a test can assert both "what happened" and
+// "what was NEVER said".
+function recorder() {
+  const state = { probeEnvs: [], alerts: [], logs: [] };
+  const push = (level) => (...a) => state.logs.push({ level, args: a });
+  return {
+    state,
+    probeFor: (result) => (env) => {
+      state.probeEnvs.push(env);
+      return result;
+    },
+    emitAlert: (payload) => {
+      state.alerts.push(payload);
+      return true;
+    },
+    log: { debug: push("debug"), warn: push("warn"), error: push("error") },
+    // Everything ever written to a log line, flattened — for "never leaked" asserts.
+    loggedText: () => JSON.stringify(state.logs),
+  };
+}
+
+// resolveWith — the standard injection harness: an explicit env + a fixed probe
+// result + recording alert/log seams. `probe` may be overridden with a thrower.
+function resolveWith(result, { env = {}, probe, emitAlert } = {}) {
+  const rec = recorder();
+  const out = resolveGithubBootAuth({
+    env,
+    probe: probe ?? rec.probeFor(result),
+    emitAlert: emitAlert ?? rec.emitAlert,
+    log: rec.log,
+  });
+  return { out, rec };
+}
+
+// ── isUnauthorizedOutput ──────────────────────────────────────────────────────
+
+describe("isUnauthorizedOutput", () => {
+  test("matches the real `gh` 401 line — both the HTTP 401 and the Bad credentials phrasing", () => {
+    expect(isUnauthorizedOutput("gh: Bad credentials (HTTP 401)")).toBe(true);
+    expect(isUnauthorizedOutput("HTTP 401: Bad credentials (https://api.github.com/rate_limit)")).toBe(true);
+    expect(isUnauthorizedOutput("some noise\nHTTP 401\nmore noise")).toBe(true);
+  });
+
+  test("matches case-insensitively (a lowercased/uppercased variant is still a 401)", () => {
+    expect(isUnauthorizedOutput("gh: bad credentials")).toBe(true);
+    expect(isUnauthorizedOutput("GH: BAD CREDENTIALS (HTTP 401)")).toBe(true);
+    expect(isUnauthorizedOutput("http 401")).toBe(true);
+  });
+
+  test("a 403 is NOT unauthorized — it is a scope/rate problem, never a dead credential", () => {
+    expect(isUnauthorizedOutput("gh: Resource not accessible by integration (HTTP 403)")).toBe(false);
+    expect(isUnauthorizedOutput("HTTP 403: API rate limit exceeded")).toBe(false);
+  });
+
+  test("a 5xx / generic failure is NOT unauthorized (transient — must stay silent)", () => {
+    expect(isUnauthorizedOutput("HTTP 500: Internal Server Error")).toBe(false);
+    expect(isUnauthorizedOutput("HTTP 502 Bad Gateway")).toBe(false);
+    expect(isUnauthorizedOutput("dial tcp: lookup api.github.com: no such host")).toBe(false);
+  });
+
+  test("empty / null / undefined are NOT unauthorized (absence of output proves nothing)", () => {
+    expect(isUnauthorizedOutput("")).toBe(false);
+    expect(isUnauthorizedOutput(null)).toBe(false);
+    expect(isUnauthorizedOutput(undefined)).toBe(false);
+    expect(isUnauthorizedOutput("\n")).toBe(false);
+  });
+
+  test("word-boundary anchored: 'HTTP 4010' / 'HTTP 4013' do not masquerade as a 401", () => {
+    expect(isUnauthorizedOutput("HTTP 4010")).toBe(false);
+    expect(isUnauthorizedOutput("request id HTTP 40123 failed")).toBe(false);
+  });
+});
+
+// ── defaultProbeGithubAuth (classification only — `gh` is never resolvable) ────
+
+describe("defaultProbeGithubAuth", () => {
+  test("the probe timeout is bounded (a hung api.github.com can never wedge boot)", () => {
+    expect(Number.isFinite(GITHUB_PROBE_TIMEOUT_MS)).toBe(true);
+    expect(GITHUB_PROBE_TIMEOUT_MS).toBeGreaterThan(0);
+    expect(GITHUB_PROBE_TIMEOUT_MS).toBeLessThanOrEqual(30_000);
+  });
+
+  test("an env whose PATH cannot resolve `gh` → TRANSIENT, never unauthorized, never throws", () => {
+    // An empty dir as the ONLY PATH entry: `gh` cannot be found, so the spawn
+    // fails locally and no request is ever made.
+    const emptyBin = mkdtempSync(join(tmpdir(), "gh-preflight-emptybin-"));
+    try {
+      let r;
+      expect(() => {
+        r = defaultProbeGithubAuth({ PATH: emptyBin });
+      }).not.toThrow();
+      expect(r.ok).toBe(false);
+      expect(r.unauthorized).toBe(false); // the load-bearing assertion: NOT a credential verdict
+      expect(r.transient).toBe(true);
+      expect(typeof r.reason).toBe("string");
+      expect(r.reason.length).toBeGreaterThan(0);
+    } finally {
+      rmSync(emptyBin, { recursive: true, force: true });
+    }
+  });
+
+  test("an unresolvable-`gh` probe result drives resolveGithubBootAuth to SILENCE (end-to-end)", () => {
+    const emptyBin = mkdtempSync(join(tmpdir(), "gh-preflight-emptybin2-"));
+    try {
+      const rec = recorder();
+      const out = resolveGithubBootAuth({
+        env: { PATH: emptyBin, CATALYST_GITHUB_TOKEN_SOURCE: "shared-file" },
+        probe: defaultProbeGithubAuth,
+        emitAlert: rec.emitAlert,
+        log: rec.log,
+      });
+      expect(rec.state.alerts).toHaveLength(0); // a missing binary NEVER pages the fleet
+      expect(out).toEqual({ checked: true, ok: false, unauthorized: false, tokenSource: "shared-file" });
+    } finally {
+      rmSync(emptyBin, { recursive: true, force: true });
+    }
+  });
+});
+
+// ── resolveGithubBootAuth ─────────────────────────────────────────────────────
+
+describe("resolveGithubBootAuth", () => {
+  test("ok probe → no alert, returns {checked:true, ok:true}", () => {
+    const { out, rec } = resolveWith(OK, { env: { CATALYST_GITHUB_TOKEN_SOURCE: "shared-file" } });
+    expect(out).toEqual({ checked: true, ok: true, unauthorized: false, tokenSource: "shared-file" });
+    expect(rec.state.alerts).toHaveLength(0);
+    expect(rec.state.logs.filter((l) => l.level === "error")).toHaveLength(0);
+  });
+
+  test("the probe is called ONCE with the injected env object itself (process.env is never consulted)", () => {
+    const env = { CATALYST_GITHUB_TOKEN_SOURCE: "inherited", PATH: "/nowhere" };
+    const { rec } = resolveWith(OK, { env });
+    expect(rec.state.probeEnvs).toHaveLength(1);
+    expect(rec.state.probeEnvs[0]).toBe(env); // identity — the exact object, not a copy of process.env
+  });
+
+  test("unauthorized probe → emitAlert called EXACTLY once, tokenSource from env.CATALYST_GITHUB_TOKEN_SOURCE", () => {
+    const { out, rec } = resolveWith(UNAUTHORIZED, {
+      env: { CATALYST_GITHUB_TOKEN_SOURCE: "shared-file" },
+    });
+    expect(out).toEqual({ checked: true, ok: false, unauthorized: true, tokenSource: "shared-file" });
+    expect(rec.state.alerts).toHaveLength(1);
+    expect(rec.state.alerts[0].tokenSource).toBe("shared-file");
+    expect(rec.state.alerts[0].reason).toBe("HTTP 401");
+    expect(rec.state.logs.filter((l) => l.level === "error")).toHaveLength(1); // loud, once
+  });
+
+  test("the alert's tokenSource tracks the env breadcrumb ('inherited' / 'none'), never a fixed literal", () => {
+    for (const source of ["inherited", "none"]) {
+      const { out, rec } = resolveWith(UNAUTHORIZED, { env: { CATALYST_GITHUB_TOKEN_SOURCE: source } });
+      expect(out.tokenSource).toBe(source);
+      expect(rec.state.alerts).toHaveLength(1);
+      expect(rec.state.alerts[0].tokenSource).toBe(source);
+    }
+  });
+
+  test("missing env.CATALYST_GITHUB_TOKEN_SOURCE → tokenSource is 'unknown' (both in the verdict and the alert)", () => {
+    const { out, rec } = resolveWith(UNAUTHORIZED, { env: {} });
+    expect(out.tokenSource).toBe("unknown");
+    expect(rec.state.alerts[0].tokenSource).toBe("unknown");
+  });
+
+  // THE anti-paging guarantee: a transient failure is NOT proof of a bad credential.
+  test("transient probe (spawn error) → NO alert", () => {
+    const { out, rec } = resolveWith(SPAWN_ERROR, { env: { CATALYST_GITHUB_TOKEN_SOURCE: "shared-file" } });
+    expect(rec.state.alerts).toHaveLength(0);
+    expect(out).toEqual({ checked: true, ok: false, unauthorized: false, tokenSource: "shared-file" });
+  });
+
+  test("transient probe (non-401 non-zero exit) → NO alert", () => {
+    const { out, rec } = resolveWith(NON_401_EXIT, { env: { CATALYST_GITHUB_TOKEN_SOURCE: "inherited" } });
+    expect(rec.state.alerts).toHaveLength(0);
+    expect(out.unauthorized).toBe(false);
+    expect(out.checked).toBe(true);
+  });
+
+  test("transient probe (timeout-shaped result) → NO alert", () => {
+    const { out, rec } = resolveWith(TIMED_OUT, { env: { CATALYST_GITHUB_TOKEN_SOURCE: "shared-file" } });
+    expect(rec.state.alerts).toHaveLength(0);
+    expect(out.unauthorized).toBe(false);
+  });
+
+  test("a transient outcome still logs (a WARN), so the operator sees it without being paged", () => {
+    const { rec } = resolveWith(TIMED_OUT, { env: {} });
+    expect(rec.state.logs.filter((l) => l.level === "warn")).toHaveLength(1);
+    expect(rec.state.logs.filter((l) => l.level === "error")).toHaveLength(0);
+  });
+
+  test("a malformed / empty probe result is treated as transient — no alert, no throw", () => {
+    for (const bogus of [undefined, null, {}, { ok: false }, { unauthorized: "yes" }]) {
+      const rec = recorder();
+      let out;
+      expect(() => {
+        out = resolveGithubBootAuth({ env: {}, probe: () => bogus, emitAlert: rec.emitAlert, log: rec.log });
+      }).not.toThrow();
+      expect(rec.state.alerts).toHaveLength(0); // only unauthorized === true alerts
+      expect(out.unauthorized).toBe(false);
+    }
+  });
+
+  test("a probe that THROWS → never throws out, returns checked:false, and emits NO alert", () => {
+    const rec = recorder();
+    let out;
+    expect(() => {
+      out = resolveGithubBootAuth({
+        env: { CATALYST_GITHUB_TOKEN_SOURCE: "shared-file" },
+        probe: () => {
+          throw new Error("probe boom");
+        },
+        emitAlert: rec.emitAlert,
+        log: rec.log,
+      });
+    }).not.toThrow();
+    expect(out).toEqual({ checked: false, ok: false, unauthorized: false, tokenSource: "shared-file" });
+    expect(rec.state.alerts).toHaveLength(0);
+    expect(rec.state.logs.filter((l) => l.level === "warn")).toHaveLength(1); // logged, not swallowed
+  });
+
+  test("an emitAlert that THROWS → resolveGithubBootAuth still does not throw and still reports unauthorized", () => {
+    const rec = recorder();
+    let out;
+    expect(() => {
+      out = resolveGithubBootAuth({
+        env: { CATALYST_GITHUB_TOKEN_SOURCE: "shared-file" },
+        probe: () => UNAUTHORIZED,
+        emitAlert: () => {
+          throw new Error("event log write boom");
+        },
+        log: rec.log,
+      });
+    }).not.toThrow();
+    expect(out).toEqual({ checked: true, ok: false, unauthorized: true, tokenSource: "shared-file" });
+    expect(rec.state.logs.filter((l) => l.level === "warn")).toHaveLength(1); // the emit failure is logged
+  });
+
+  test("advisory only: a missing log object and a no-op emitAlert never break boot", () => {
+    expect(() => resolveGithubBootAuth({ env: {}, probe: () => OK, emitAlert: () => {}, log: null })).not.toThrow();
+    expect(() => resolveGithubBootAuth({ env: {}, probe: () => TIMED_OUT, emitAlert: () => {}, log: {} })).not.toThrow();
+    // Even the unauthorized path with a no-op log survives.
+    expect(() =>
+      resolveGithubBootAuth({ env: {}, probe: () => UNAUTHORIZED, emitAlert: () => {}, log: {} }),
+    ).not.toThrow();
+  });
+
+  // Secret hygiene: the credential VALUE lives in the env we hand the probe. It
+  // must never reach a log line or the alert payload — only the provenance
+  // breadcrumb (tokenSource) is ever surfaced.
+  test("never surfaces a credential value — only the tokenSource breadcrumb reaches the log/alert", () => {
+    const { rec } = resolveWith(UNAUTHORIZED, {
+      env: {
+        GITHUB_TOKEN: FAKE_TOKEN,
+        GH_TOKEN: FAKE_TOKEN,
+        CATALYST_GITHUB_TOKEN_SOURCE: "shared-file",
+      },
+    });
+    expect(rec.loggedText()).not.toContain(FAKE_TOKEN);
+    expect(JSON.stringify(rec.state.alerts)).not.toContain(FAKE_TOKEN);
+    expect(JSON.stringify(rec.state.alerts)).toContain("shared-file");
+  });
+});

--- a/plugins/dev/scripts/execution-core/github-auth-preflight.test.mjs
+++ b/plugins/dev/scripts/execution-core/github-auth-preflight.test.mjs
@@ -497,6 +497,30 @@ describe("rearmGithubTokenFromFile", () => {
     expect(env.CATALYST_GITHUB_TOKEN_SOURCE).toBe("shared-file");
   });
 
+  // CTL-1612 (round 5): ALL trailing terminators, not just the last. The bash launcher
+  // reads via `$(cat …)`, which eats EVERY trailing newline — a file ending in `\n\n`
+  // installed the bare token at boot, but a single-terminator re-arm produced `token\n`,
+  // handing boot-resumed workers and every subsequent `gh` call an invalid credential.
+  test("REGRESSION: multiple trailing newlines (LF and CRLF) all strip — re-arm matches the launcher", () => {
+    for (const tail of ["\n\n", "\n\n\n", "\r\n\r\n"]) {
+      const env = { CATALYST_GITHUB_TOKEN_FILE: TOKEN_FILE, GITHUB_TOKEN: STALE_TOKEN };
+      const { out } = rearmWith({ env, files: { [TOKEN_FILE]: `${ROTATED_TOKEN}${tail}` } });
+      expect(out).toEqual({ rearmed: true, reason: "rotated" });
+      expect(env.GITHUB_TOKEN).toBe(ROTATED_TOKEN); // bare token, no residual terminator
+      expect(env.GH_TOKEN).toBe(ROTATED_TOKEN);
+    }
+    // And the no-op direction: a multi-newline file whose bare value matches the env
+    // must read as "unchanged", not as a phantom rotation.
+    const env = {
+      CATALYST_GITHUB_TOKEN_FILE: TOKEN_FILE,
+      GITHUB_TOKEN: FAKE_TOKEN,
+      GH_TOKEN: FAKE_TOKEN,
+      CATALYST_GITHUB_TOKEN_SOURCE: "shared-file",
+    };
+    const { out } = rearmWith({ env, files: { [TOKEN_FILE]: `${FAKE_TOKEN}\n\n` } });
+    expect(out).toEqual({ rearmed: false, reason: "unchanged" });
+  });
+
   // CTL-1612 (round 4): ONLY the line terminator is stripped. A credential may legitimately
   // begin or end with a space or tab, and trimming those bytes yields a different key —
   // for an HMAC secret that silently rejects every correctly-signed delivery. The `$(cat)`

--- a/plugins/dev/scripts/execution-core/github-auth-preflight.test.mjs
+++ b/plugins/dev/scripts/execution-core/github-auth-preflight.test.mjs
@@ -485,26 +485,30 @@ describe("rearmGithubTokenFromFile", () => {
     expect(rec.state.logs).toHaveLength(0); // a steady-state boot stays quiet
   });
 
-  test("a cosmetic trailing newline is stripped before comparison — not mistaken for a rotation", () => {
+  test("a cosmetic trailing newline is stripped — not mistaken for a rotation", () => {
     const env = {
       CATALYST_GITHUB_TOKEN_FILE: TOKEN_FILE,
+      GITHUB_TOKEN: FAKE_TOKEN,
+      GH_TOKEN: FAKE_TOKEN,
       CATALYST_GITHUB_TOKEN_SOURCE: "shared-file",
-      GITHUB_TOKEN: STALE_TOKEN,
-      GH_TOKEN: STALE_TOKEN,
     };
-    const { out } = rearmWith({ env, files: { [TOKEN_FILE]: `  ${STALE_TOKEN}\n` } });
-
+    const { out } = rearmWith({ env, files: { [TOKEN_FILE]: `${FAKE_TOKEN}\n` } });
     expect(out).toEqual({ rearmed: false, reason: "unchanged" });
     expect(env.CATALYST_GITHUB_TOKEN_SOURCE).toBe("shared-file");
   });
 
-  test("trailing whitespace is stripped on the REAL rotation path too (the installed value is clean)", () => {
-    const env = { CATALYST_GITHUB_TOKEN_FILE: TOKEN_FILE, GITHUB_TOKEN: STALE_TOKEN, GH_TOKEN: STALE_TOKEN };
-    const { out } = rearmWith({ env, files: { [TOKEN_FILE]: `${ROTATED_TOKEN}\n\n` } });
-
-    expect(out.rearmed).toBe(true);
-    expect(env.GITHUB_TOKEN).toBe(ROTATED_TOKEN); // no stray "\n"
-    expect(env.GH_TOKEN).toBe(ROTATED_TOKEN);
+  // CTL-1612 (round 4): ONLY the line terminator is stripped. A credential may legitimately
+  // begin or end with a space or tab, and trimming those bytes yields a different key —
+  // for an HMAC secret that silently rejects every correctly-signed delivery. The `$(cat)`
+  // this replaced preserved boundary spaces, so trimming them would be a regression.
+  test("the trailing NEWLINE is stripped but significant boundary whitespace survives", () => {
+    const env = { CATALYST_GITHUB_TOKEN_FILE: TOKEN_FILE, GITHUB_TOKEN: STALE_TOKEN };
+    const withEdges = `  ${ROTATED_TOKEN}\t`;
+    const { out } = rearmWith({ env, files: { [TOKEN_FILE]: `${withEdges}\n` } });
+    expect(out).toEqual({ rearmed: true, reason: "rotated" });
+    expect(env.GITHUB_TOKEN).toBe(withEdges); // byte-for-byte, edges intact
+    expect(env.GH_TOKEN).toBe(withEdges);
+    expect(env.GITHUB_TOKEN.endsWith("\n")).toBe(false); // the EOL is gone
   });
 
   // An empty install is WORSE than no install: "" reads as SET to `??` and
@@ -645,20 +649,15 @@ describe("rearmGithubTokenFromFile preserves INTERNAL whitespace", () => {
     });
   }
 
-  test("REGRESSION: surrounding whitespace is stripped while the INTERNAL run survives", () => {
-    const env = {
-      CATALYST_GITHUB_TOKEN_FILE: TOKEN_FILE,
-      GITHUB_TOKEN: STALE_TOKEN,
-      GH_TOKEN: STALE_TOKEN,
-    };
-    // The realistic on-disk shape: the writer's payload plus a cosmetic newline.
-    const { out } = rearmWith({ env, files: { [TOKEN_FILE]: `\n  ${SPACED_TOKEN} \t\n` } });
-
+  test("REGRESSION: internal AND boundary whitespace both survive; only the EOL is removed", () => {
+    const env = { CATALYST_GITHUB_TOKEN_FILE: TOKEN_FILE, GITHUB_TOKEN: STALE_TOKEN };
+    const value = " tok with a space \t";
+    const { out } = rearmWith({ env, files: { [TOKEN_FILE]: `${value}\n` } });
     expect(out).toEqual({ rearmed: true, reason: "rotated" });
-    expect(env.GITHUB_TOKEN).toBe(SPACED_TOKEN);
-    expect(env.GITHUB_TOKEN).toBe(env.GITHUB_TOKEN.trim()); // nothing clinging to either end
-    expect(env.GITHUB_TOKEN).toContain(" "); // …but the internal space is untouched
-    expect(env.GH_TOKEN).toBe(SPACED_TOKEN);
+    expect(env.GITHUB_TOKEN).toBe(value);
+    expect(env.GITHUB_TOKEN).toContain(" ");
+    expect(env.GITHUB_TOKEN).not.toBe(value.replace(/\s+/g, "")); // not the old corruption
+    expect(env.GITHUB_TOKEN).not.toBe(value.trim()); // and not the round-3 over-trim
   });
 
   test("an internal-whitespace credential already installed is 'unchanged' — no churn per tick", () => {

--- a/plugins/dev/scripts/execution-core/github-auth-preflight.test.mjs
+++ b/plugins/dev/scripts/execution-core/github-auth-preflight.test.mjs
@@ -1,9 +1,10 @@
 // github-auth-preflight.test.mjs — CTL-1612. FULLY OFFLINE: every test injects
-// `probe` / `emitAlert` / `log` and an EXPLICIT `env` object, so no test ever
-// reads process.env, spawns `gh`, appends to the event log, or touches the
-// network. The one test that exercises the real `defaultProbeGithubAuth` points
-// its injected PATH at an EMPTY temp dir, so `gh` cannot resolve and the probe
-// classifies locally (never a request). Inherits test-setup.mjs.
+// `probe` / `emitAlert` / `log` / `rearm` (or `readFile`) and an EXPLICIT `env`
+// object, so no test ever reads process.env, spawns `gh`, reads the real shared
+// credential file, appends to the event log, or touches the network. The one
+// test that exercises the real `defaultProbeGithubAuth` points its injected PATH
+// at an EMPTY temp dir, so `gh` cannot resolve and the probe classifies locally
+// (never a request). Inherits test-setup.mjs.
 //
 // The contract under test is the ANTI-PAGING one: a definitive 401 alerts EXACTLY
 // once; every other outcome — spawn failure, non-401 exit, timeout, a throwing
@@ -21,8 +22,10 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
   GITHUB_PROBE_TIMEOUT_MS,
+  defaultGithubTokenFile,
   defaultProbeGithubAuth,
   isUnauthorizedOutput,
+  rearmGithubTokenFromFile,
   resolveGithubBootAuth,
 } from "./github-auth-preflight.mjs";
 
@@ -31,6 +34,22 @@ import {
 // An obviously-fake credential literal. It exists ONLY so the hygiene test can
 // prove no code path ever echoes a credential value into a log or an alert.
 const FAKE_TOKEN = "ghp_THIS-IS-NOT-A-REAL-TOKEN-000000000000";
+
+// The rotation pair for the re-arm tests: what the node booted holding (it was
+// offline when the credential was rotated) vs what cluster-sync then wrote to
+// disk. Both are obvious fakes; neither is ever expected in a log line.
+const STALE_TOKEN = "ghp_STALE-FAKE-TOKEN-000000000000000000";
+const ROTATED_TOKEN = "ghp_ROTATED-FAKE-TOKEN-11111111111111";
+
+// A path that is NEVER opened — `readFile` is injected in every re-arm test, so
+// this is only ever a map key and an assertion target.
+const TOKEN_FILE = "/nowhere/catalyst/github-token";
+
+// NO_REARM — the hermetic stand-in for `rearmGithubTokenFromFile` in the tests
+// that are about `resolveGithubBootAuth`'s probe/alert contract. Without it the
+// real re-arm would `readFileSync` the operator's actual shared credential file,
+// making those tests host-dependent (present on a fleet node, absent on a laptop).
+const NO_REARM = () => ({ rearmed: false, reason: "absent" });
 
 // The three-state probe results, spelled out exactly as defaultProbeGithubAuth
 // builds them — the shapes resolveGithubBootAuth must discriminate.
@@ -64,15 +83,40 @@ function recorder() {
 
 // resolveWith — the standard injection harness: an explicit env + a fixed probe
 // result + recording alert/log seams. `probe` may be overridden with a thrower.
-function resolveWith(result, { env = {}, probe, emitAlert } = {}) {
+function resolveWith(result, { env = {}, probe, emitAlert, rearm = NO_REARM } = {}) {
   const rec = recorder();
   const out = resolveGithubBootAuth({
     env,
     probe: probe ?? rec.probeFor(result),
     emitAlert: emitAlert ?? rec.emitAlert,
     log: rec.log,
+    rearm,
   });
   return { out, rec };
+}
+
+// rearmWith — the injection harness for rearmGithubTokenFromFile: an explicit
+// env (mutated in place, as production does) plus a `files` map standing in for
+// the disk. A path absent from the map throws ENOENT, exactly as readFileSync
+// would. `reads` records the paths asked for, so a test can prove the file was
+// never even opened on the override path.
+function rearmWith({ env, files = {} } = {}) {
+  const rec = recorder();
+  const reads = [];
+  const out = rearmGithubTokenFromFile({
+    env,
+    readFile: (p) => {
+      reads.push(p);
+      if (!(p in files)) {
+        const err = new Error(`ENOENT: no such file or directory, open '${p}'`);
+        err.code = "ENOENT";
+        throw err;
+      }
+      return files[p];
+    },
+    log: rec.log,
+  });
+  return { out, rec, reads };
 }
 
 // ── isUnauthorizedOutput ──────────────────────────────────────────────────────
@@ -151,6 +195,7 @@ describe("defaultProbeGithubAuth", () => {
         probe: defaultProbeGithubAuth,
         emitAlert: rec.emitAlert,
         log: rec.log,
+        rearm: NO_REARM,
       });
       expect(rec.state.alerts).toHaveLength(0); // a missing binary NEVER pages the fleet
       expect(out).toEqual({ checked: true, ok: false, unauthorized: false, tokenSource: "shared-file" });
@@ -234,7 +279,13 @@ describe("resolveGithubBootAuth", () => {
       const rec = recorder();
       let out;
       expect(() => {
-        out = resolveGithubBootAuth({ env: {}, probe: () => bogus, emitAlert: rec.emitAlert, log: rec.log });
+        out = resolveGithubBootAuth({
+          env: {},
+          probe: () => bogus,
+          emitAlert: rec.emitAlert,
+          log: rec.log,
+          rearm: NO_REARM,
+        });
       }).not.toThrow();
       expect(rec.state.alerts).toHaveLength(0); // only unauthorized === true alerts
       expect(out.unauthorized).toBe(false);
@@ -252,6 +303,7 @@ describe("resolveGithubBootAuth", () => {
         },
         emitAlert: rec.emitAlert,
         log: rec.log,
+        rearm: NO_REARM,
       });
     }).not.toThrow();
     expect(out).toEqual({ checked: false, ok: false, unauthorized: false, tokenSource: "shared-file" });
@@ -270,6 +322,7 @@ describe("resolveGithubBootAuth", () => {
           throw new Error("event log write boom");
         },
         log: rec.log,
+        rearm: NO_REARM,
       });
     }).not.toThrow();
     expect(out).toEqual({ checked: true, ok: false, unauthorized: true, tokenSource: "shared-file" });
@@ -277,12 +330,11 @@ describe("resolveGithubBootAuth", () => {
   });
 
   test("advisory only: a missing log object and a no-op emitAlert never break boot", () => {
-    expect(() => resolveGithubBootAuth({ env: {}, probe: () => OK, emitAlert: () => {}, log: null })).not.toThrow();
-    expect(() => resolveGithubBootAuth({ env: {}, probe: () => TIMED_OUT, emitAlert: () => {}, log: {} })).not.toThrow();
+    const base = { env: {}, emitAlert: () => {}, rearm: NO_REARM };
+    expect(() => resolveGithubBootAuth({ ...base, probe: () => OK, log: null })).not.toThrow();
+    expect(() => resolveGithubBootAuth({ ...base, probe: () => TIMED_OUT, log: {} })).not.toThrow();
     // Even the unauthorized path with a no-op log survives.
-    expect(() =>
-      resolveGithubBootAuth({ env: {}, probe: () => UNAUTHORIZED, emitAlert: () => {}, log: {} }),
-    ).not.toThrow();
+    expect(() => resolveGithubBootAuth({ ...base, probe: () => UNAUTHORIZED, log: {} })).not.toThrow();
   });
 
   // Secret hygiene: the credential VALUE lives in the env we hand the probe. It
@@ -299,5 +351,313 @@ describe("resolveGithubBootAuth", () => {
     expect(rec.loggedText()).not.toContain(FAKE_TOKEN);
     expect(JSON.stringify(rec.state.alerts)).not.toContain(FAKE_TOKEN);
     expect(JSON.stringify(rec.state.alerts)).toContain("shared-file");
+  });
+});
+
+// ── defaultGithubTokenFile ────────────────────────────────────────────────────
+//
+// The resolution order must match the shell side byte for byte — the launcher's
+// _project_shared_github_token and setup-webhooks.sh:23. A hardcoded ~/.config
+// here would look at a DIFFERENT file than the one the operator's tooling wrote
+// whenever XDG_CONFIG_HOME is set, and the re-arm would silently no-op.
+
+describe("defaultGithubTokenFile", () => {
+  test("CATALYST_GITHUB_TOKEN_FILE wins outright — even over XDG_CONFIG_HOME and HOME", () => {
+    expect(
+      defaultGithubTokenFile({
+        CATALYST_GITHUB_TOKEN_FILE: "/etc/catalyst/explicit-github-token",
+        XDG_CONFIG_HOME: "/xdg-config",
+        HOME: "/home/fake",
+      }),
+    ).toBe("/etc/catalyst/explicit-github-token");
+  });
+
+  test("XDG_CONFIG_HOME is honored ahead of $HOME/.config (matches setup-webhooks.sh:23)", () => {
+    expect(defaultGithubTokenFile({ XDG_CONFIG_HOME: "/xdg-config", HOME: "/home/fake" })).toBe(
+      join("/xdg-config", "catalyst", "github-token"),
+    );
+  });
+
+  test("falls back to $HOME/.config when XDG_CONFIG_HOME is unset", () => {
+    expect(defaultGithubTokenFile({ HOME: "/home/fake" })).toBe(
+      join("/home/fake", ".config", "catalyst", "github-token"),
+    );
+  });
+
+  test("an EMPTY XDG_CONFIG_HOME is ignored (falsy, exactly like ${XDG_CONFIG_HOME:-...})", () => {
+    expect(defaultGithubTokenFile({ XDG_CONFIG_HOME: "", HOME: "/home/fake" })).toBe(
+      join("/home/fake", ".config", "catalyst", "github-token"),
+    );
+  });
+});
+
+// ── rearmGithubTokenFromFile ──────────────────────────────────────────────────
+//
+// THE CTL-1612 P1 REGRESSION. A node that was OFFLINE during a credential
+// rotation boots holding the stale local copy; daemon boot then runs clusterSync,
+// which materializes the replacement onto disk — and, before this, nothing
+// re-read it. The daemon 401'd until a SECOND manual restart. Every test here
+// injects `readFile` and mutates an EXPLICIT env object: the real shared
+// credential file is never opened.
+
+describe("rearmGithubTokenFromFile", () => {
+  test("REGRESSION: a rotation materialized after launch re-arms BOTH env names in place", () => {
+    const env = {
+      CATALYST_GITHUB_TOKEN_FILE: TOKEN_FILE,
+      CATALYST_GITHUB_TOKEN_SOURCE: "shared-file",
+      GITHUB_TOKEN: STALE_TOKEN,
+      GH_TOKEN: STALE_TOKEN,
+    };
+    const { out, rec, reads } = rearmWith({ env, files: { [TOKEN_FILE]: ROTATED_TOKEN } });
+
+    expect(out).toEqual({ rearmed: true, reason: "rotated" });
+    expect(env.GITHUB_TOKEN).toBe(ROTATED_TOKEN);
+    expect(env.GH_TOKEN).toBe(ROTATED_TOKEN); // both — `gh` resolves GH_TOKEN first
+    expect(env.CATALYST_GITHUB_TOKEN_SOURCE).toBe("shared-file-resynced");
+    expect(reads).toEqual([TOKEN_FILE]); // read the resolved path, exactly once
+    // Hygiene: the re-arm is loud about the FACT of a rotation, never its value.
+    expect(rec.loggedText()).not.toContain(ROTATED_TOKEN);
+    expect(rec.loggedText()).not.toContain(STALE_TOKEN);
+    expect(rec.state.logs.filter((l) => l.level === "warn")).toHaveLength(1);
+  });
+
+  test("a LAGGING GH_TOKEN alone still re-arms (gh reads GH_TOKEN first — a half-match is a live 401)", () => {
+    const env = {
+      CATALYST_GITHUB_TOKEN_FILE: TOKEN_FILE,
+      GITHUB_TOKEN: ROTATED_TOKEN, // already current
+      GH_TOKEN: STALE_TOKEN, // …but this is the one `gh` actually uses
+    };
+    const { out } = rearmWith({ env, files: { [TOKEN_FILE]: ROTATED_TOKEN } });
+
+    expect(out).toEqual({ rearmed: true, reason: "rotated" });
+    expect(env.GH_TOKEN).toBe(ROTATED_TOKEN);
+    expect(env.GITHUB_TOKEN).toBe(ROTATED_TOKEN);
+  });
+
+  test("content identical to BOTH env names → no mutation at all, {rearmed:false, reason:'unchanged'}", () => {
+    const env = {
+      CATALYST_GITHUB_TOKEN_FILE: TOKEN_FILE,
+      CATALYST_GITHUB_TOKEN_SOURCE: "shared-file",
+      GITHUB_TOKEN: STALE_TOKEN,
+      GH_TOKEN: STALE_TOKEN,
+    };
+    const { out, rec } = rearmWith({ env, files: { [TOKEN_FILE]: STALE_TOKEN } });
+
+    expect(out).toEqual({ rearmed: false, reason: "unchanged" });
+    expect(env.GITHUB_TOKEN).toBe(STALE_TOKEN);
+    expect(env.GH_TOKEN).toBe(STALE_TOKEN);
+    expect(env.CATALYST_GITHUB_TOKEN_SOURCE).toBe("shared-file"); // breadcrumb NOT rewritten
+    expect(rec.state.logs).toHaveLength(0); // a steady-state boot stays quiet
+  });
+
+  test("a cosmetic trailing newline is stripped before comparison — not mistaken for a rotation", () => {
+    const env = {
+      CATALYST_GITHUB_TOKEN_FILE: TOKEN_FILE,
+      CATALYST_GITHUB_TOKEN_SOURCE: "shared-file",
+      GITHUB_TOKEN: STALE_TOKEN,
+      GH_TOKEN: STALE_TOKEN,
+    };
+    const { out } = rearmWith({ env, files: { [TOKEN_FILE]: `  ${STALE_TOKEN}\n` } });
+
+    expect(out).toEqual({ rearmed: false, reason: "unchanged" });
+    expect(env.CATALYST_GITHUB_TOKEN_SOURCE).toBe("shared-file");
+  });
+
+  test("trailing whitespace is stripped on the REAL rotation path too (the installed value is clean)", () => {
+    const env = { CATALYST_GITHUB_TOKEN_FILE: TOKEN_FILE, GITHUB_TOKEN: STALE_TOKEN, GH_TOKEN: STALE_TOKEN };
+    const { out } = rearmWith({ env, files: { [TOKEN_FILE]: `${ROTATED_TOKEN}\n\n` } });
+
+    expect(out.rearmed).toBe(true);
+    expect(env.GITHUB_TOKEN).toBe(ROTATED_TOKEN); // no stray "\n"
+    expect(env.GH_TOKEN).toBe(ROTATED_TOKEN);
+  });
+
+  // An empty install is WORSE than no install: "" reads as SET to `??` and
+  // `${X:-}`, so it would defeat gh's hosts.yml/keyring fallback.
+  test("an empty / whitespace-only file NEVER installs '' — env untouched, {rearmed:false, reason:'empty'}", () => {
+    for (const content of ["", "\n", "   \t\n  "]) {
+      const env = {
+        CATALYST_GITHUB_TOKEN_FILE: TOKEN_FILE,
+        CATALYST_GITHUB_TOKEN_SOURCE: "shared-file",
+        GITHUB_TOKEN: STALE_TOKEN,
+        GH_TOKEN: STALE_TOKEN,
+      };
+      const { out } = rearmWith({ env, files: { [TOKEN_FILE]: content } });
+
+      expect(out).toEqual({ rearmed: false, reason: "empty" });
+      expect(env.GITHUB_TOKEN).toBe(STALE_TOKEN);
+      expect(env.GH_TOKEN).toBe(STALE_TOKEN);
+      expect(env.CATALYST_GITHUB_TOKEN_SOURCE).toBe("shared-file");
+    }
+  });
+
+  test("an ABSENT file (readFile throws) → {rearmed:false, reason:'absent'}, env untouched, never throws", () => {
+    const env = {
+      CATALYST_GITHUB_TOKEN_FILE: TOKEN_FILE,
+      CATALYST_GITHUB_TOKEN_SOURCE: "inherited",
+      GITHUB_TOKEN: STALE_TOKEN,
+      GH_TOKEN: STALE_TOKEN,
+    };
+    let out;
+    expect(() => {
+      ({ out } = rearmWith({ env, files: {} })); // nothing on disk → ENOENT
+    }).not.toThrow();
+
+    expect(out).toEqual({ rearmed: false, reason: "absent" });
+    expect(env.GITHUB_TOKEN).toBe(STALE_TOKEN);
+    expect(env.GH_TOKEN).toBe(STALE_TOKEN);
+    expect(env.CATALYST_GITHUB_TOKEN_SOURCE).toBe("inherited");
+  });
+
+  // The operator override is the whole point of the T2 ordering fix: a human who
+  // pinned a credential in execution-core.env must not have it clobbered by the
+  // shared file, no matter what cluster-sync just materialized.
+  test("an operator override SURVIVES — no mutation, and the file is never even opened", () => {
+    const env = {
+      CATALYST_GITHUB_TOKEN_FILE: TOKEN_FILE,
+      CATALYST_GITHUB_TOKEN_SOURCE: "operator-override",
+      GITHUB_TOKEN: STALE_TOKEN,
+      GH_TOKEN: STALE_TOKEN,
+    };
+    const { out, reads } = rearmWith({ env, files: { [TOKEN_FILE]: ROTATED_TOKEN } });
+
+    expect(out).toEqual({ rearmed: false, reason: "operator-override" });
+    expect(env.GITHUB_TOKEN).toBe(STALE_TOKEN);
+    expect(env.GH_TOKEN).toBe(STALE_TOKEN);
+    expect(env.CATALYST_GITHUB_TOKEN_SOURCE).toBe("operator-override");
+    expect(reads).toHaveLength(0); // short-circuits before any read
+  });
+
+  test("resolves the file through the XDG-aware path, not a hardcoded ~/.config", () => {
+    const env = { XDG_CONFIG_HOME: "/xdg-config", HOME: "/home/fake" };
+    const { reads } = rearmWith({ env, files: {} });
+    expect(reads).toEqual([join("/xdg-config", "catalyst", "github-token")]);
+  });
+
+  test("advisory only: a missing log never breaks the re-arm", () => {
+    const env = { CATALYST_GITHUB_TOKEN_FILE: TOKEN_FILE, GITHUB_TOKEN: STALE_TOKEN, GH_TOKEN: STALE_TOKEN };
+    let out;
+    expect(() => {
+      out = rearmGithubTokenFromFile({
+        env,
+        readFile: () => ROTATED_TOKEN,
+        log: null,
+      });
+    }).not.toThrow();
+    expect(out).toEqual({ rearmed: true, reason: "rotated" });
+    expect(env.GH_TOKEN).toBe(ROTATED_TOKEN);
+  });
+});
+
+// ── resolveGithubBootAuth ⟷ rearm wiring ──────────────────────────────────────
+//
+// Re-arming AFTER the probe would be worthless: the preflight must verify the
+// credential it will actually use, not the one the launcher happened to project.
+
+describe("resolveGithubBootAuth re-arms before probing", () => {
+  test("REGRESSION: rearm runs BEFORE probe, and the probe observes the RE-ARMED credential", () => {
+    const order = [];
+    const env = {
+      CATALYST_GITHUB_TOKEN_SOURCE: "shared-file",
+      GITHUB_TOKEN: STALE_TOKEN,
+      GH_TOKEN: STALE_TOKEN,
+    };
+    const rec = recorder();
+    let seenByProbe;
+
+    const out = resolveGithubBootAuth({
+      env,
+      rearm: ({ env: e }) => {
+        order.push("rearm");
+        e.GITHUB_TOKEN = ROTATED_TOKEN;
+        e.GH_TOKEN = ROTATED_TOKEN;
+        e.CATALYST_GITHUB_TOKEN_SOURCE = "shared-file-resynced";
+        return { rearmed: true, reason: "rotated" };
+      },
+      probe: (e) => {
+        order.push("probe");
+        seenByProbe = { ...e };
+        return OK;
+      },
+      emitAlert: rec.emitAlert,
+      log: rec.log,
+    });
+
+    expect(order).toEqual(["rearm", "probe"]); // ordering is the fix
+    expect(seenByProbe.GITHUB_TOKEN).toBe(ROTATED_TOKEN);
+    expect(seenByProbe.GH_TOKEN).toBe(ROTATED_TOKEN);
+    // And the verdict reports the POST-rearm provenance, not the launcher's.
+    expect(out).toEqual({
+      checked: true,
+      ok: true,
+      unauthorized: false,
+      tokenSource: "shared-file-resynced",
+    });
+    expect(rec.state.alerts).toHaveLength(0);
+  });
+
+  test("rearm receives the SAME env object it must mutate, plus the injected log", () => {
+    const env = { CATALYST_GITHUB_TOKEN_SOURCE: "shared-file" };
+    const rec = recorder();
+    const seen = [];
+
+    resolveGithubBootAuth({
+      env,
+      rearm: (args) => {
+        seen.push(args);
+        return { rearmed: false, reason: "unchanged" };
+      },
+      probe: () => OK,
+      emitAlert: rec.emitAlert,
+      log: rec.log,
+    });
+
+    expect(seen).toHaveLength(1);
+    expect(seen[0].env).toBe(env); // identity — in-place mutation must be visible
+    expect(seen[0].log).toBe(rec.log);
+  });
+
+  test("a rearm that THROWS does not break boot — the probe still runs and a verdict is returned", () => {
+    const rec = recorder();
+    let out;
+    expect(() => {
+      out = resolveGithubBootAuth({
+        env: { CATALYST_GITHUB_TOKEN_SOURCE: "shared-file" },
+        rearm: () => {
+          throw new Error("cluster-sync wrote a half-file");
+        },
+        probe: rec.probeFor(OK),
+        emitAlert: rec.emitAlert,
+        log: rec.log,
+      });
+    }).not.toThrow();
+
+    expect(rec.state.probeEnvs).toHaveLength(1); // the probe was NOT skipped
+    expect(out).toEqual({ checked: true, ok: true, unauthorized: false, tokenSource: "shared-file" });
+    expect(rec.state.alerts).toHaveLength(0);
+    expect(rec.state.logs.filter((l) => l.level === "warn")).toHaveLength(1); // logged, not swallowed
+  });
+
+  test("a re-armed credential that is STILL rejected alerts once, carrying the resynced breadcrumb", () => {
+    const rec = recorder();
+    const env = { CATALYST_GITHUB_TOKEN_SOURCE: "shared-file", GITHUB_TOKEN: STALE_TOKEN };
+    const out = resolveGithubBootAuth({
+      env,
+      rearm: ({ env: e }) => {
+        e.GITHUB_TOKEN = ROTATED_TOKEN;
+        e.GH_TOKEN = ROTATED_TOKEN;
+        e.CATALYST_GITHUB_TOKEN_SOURCE = "shared-file-resynced";
+        return { rearmed: true, reason: "rotated" };
+      },
+      probe: () => UNAUTHORIZED,
+      emitAlert: rec.emitAlert,
+      log: rec.log,
+    });
+
+    expect(out.unauthorized).toBe(true);
+    expect(rec.state.alerts).toHaveLength(1);
+    expect(rec.state.alerts[0].tokenSource).toBe("shared-file-resynced");
+    expect(rec.loggedText()).not.toContain(ROTATED_TOKEN);
+    expect(JSON.stringify(rec.state.alerts)).not.toContain(ROTATED_TOKEN);
   });
 });

--- a/plugins/dev/scripts/execution-core/github-auth-preflight.test.mjs
+++ b/plugins/dev/scripts/execution-core/github-auth-preflight.test.mjs
@@ -41,6 +41,19 @@ const FAKE_TOKEN = "ghp_THIS-IS-NOT-A-REAL-TOKEN-000000000000";
 // disk. Both are obvious fakes; neither is ever expected in a log line.
 const STALE_TOKEN = "ghp_STALE-FAKE-TOKEN-000000000000000000";
 const ROTATED_TOKEN = "ghp_ROTATED-FAKE-TOKEN-11111111111111";
+// A SECOND rotation, for the timer tests: proving the re-arm keeps working long
+// after boot, not just the first time it runs.
+const ROTATED_AGAIN_TOKEN = "ghp_ROTATED-AGAIN-FAKE-TOKEN-22222222";
+
+// Obviously-fake credentials that CONTAIN whitespace. The reader used to strip ALL
+// whitespace (`.replace(/\s+/g,"")` here, `tr -d '[:space:]'` on the shell side), which
+// silently WELDS these into a different string — the value looks present and is simply
+// wrong. A GitHub PAT never contains a space, but the same reader shape projects the
+// webhook HMAC signing key, where a corrupted key rejects every inbound delivery with no
+// error anywhere. `.trim()` is the fix; these literals pin it.
+const SPACED_TOKEN = "ghp_FAKE TOKEN-WITH-A-SPACE-0000000";
+const TABBED_TOKEN = "ghp_FAKE\tTOKEN-WITH-A-TAB-00000000000";
+const MULTILINE_TOKEN = "ghp_FAKE-LINE-1-0000000\nghp_FAKE-LINE-2-0000000";
 
 // A path that is NEVER opened — `readFile` is injected in every re-arm test, so
 // this is only ever a map key and an assertion target.
@@ -592,6 +605,252 @@ describe("rearmGithubTokenFromFile", () => {
   });
 });
 
+// ── rearmGithubTokenFromFile: whitespace fidelity ─────────────────────────────
+//
+// THE ROUND-3 DATA-CORRUPTION REGRESSION. The reader used to normalize the file with
+// `.replace(/\s+/g, "")` — which does NOT mean "drop the trailing newline", it means
+// "delete every whitespace character anywhere in the value". A secret containing a
+// space, a tab or an internal newline was therefore installed as a DIFFERENT string
+// than the one on disk: present, plausible-looking, and wrong. There is no error
+// anywhere in that failure mode — the credential is simply rejected forever.
+//
+// The contract is now exactly `.trim()`: surrounding whitespace goes (so a cosmetic
+// trailing newline is never mistaken for a rotation), internal whitespace stays
+// (so the installed value is byte-for-byte what the writer wrote).
+
+describe("rearmGithubTokenFromFile preserves INTERNAL whitespace", () => {
+  const withInternalWhitespace = [
+    ["a space", SPACED_TOKEN],
+    ["a tab", TABBED_TOKEN],
+    ["an internal newline", MULTILINE_TOKEN],
+  ];
+
+  for (const [label, value] of withInternalWhitespace) {
+    test(`REGRESSION: a credential containing ${label} installs BYTE-FOR-BYTE`, () => {
+      const env = {
+        CATALYST_GITHUB_TOKEN_FILE: TOKEN_FILE,
+        CATALYST_GITHUB_TOKEN_SOURCE: "shared-file",
+        GITHUB_TOKEN: STALE_TOKEN,
+        GH_TOKEN: STALE_TOKEN,
+      };
+      const { out, rec } = rearmWith({ env, files: { [TOKEN_FILE]: value } });
+
+      expect(out).toEqual({ rearmed: true, reason: "rotated" });
+      expect(env.GITHUB_TOKEN).toBe(value);
+      expect(env.GH_TOKEN).toBe(value); // both names, both intact
+      // The exact shape the strip-everything reader produced. Asserting the negative
+      // is what makes this a regression test rather than a restatement of `.trim()`.
+      expect(env.GITHUB_TOKEN).not.toBe(value.replace(/\s+/g, ""));
+      expect(rec.loggedText()).not.toContain(value); // still never echoes the value
+    });
+  }
+
+  test("REGRESSION: surrounding whitespace is stripped while the INTERNAL run survives", () => {
+    const env = {
+      CATALYST_GITHUB_TOKEN_FILE: TOKEN_FILE,
+      GITHUB_TOKEN: STALE_TOKEN,
+      GH_TOKEN: STALE_TOKEN,
+    };
+    // The realistic on-disk shape: the writer's payload plus a cosmetic newline.
+    const { out } = rearmWith({ env, files: { [TOKEN_FILE]: `\n  ${SPACED_TOKEN} \t\n` } });
+
+    expect(out).toEqual({ rearmed: true, reason: "rotated" });
+    expect(env.GITHUB_TOKEN).toBe(SPACED_TOKEN);
+    expect(env.GITHUB_TOKEN).toBe(env.GITHUB_TOKEN.trim()); // nothing clinging to either end
+    expect(env.GITHUB_TOKEN).toContain(" "); // …but the internal space is untouched
+    expect(env.GH_TOKEN).toBe(SPACED_TOKEN);
+  });
+
+  test("an internal-whitespace credential already installed is 'unchanged' — no churn per tick", () => {
+    const env = {
+      CATALYST_GITHUB_TOKEN_FILE: TOKEN_FILE,
+      CATALYST_GITHUB_TOKEN_SOURCE: "shared-file",
+      GITHUB_TOKEN: SPACED_TOKEN,
+      GH_TOKEN: SPACED_TOKEN,
+    };
+    // Trailing newline only — the comparison must see through it, or every tick would
+    // "rotate" and log a rotation warning that never happened.
+    const { out, rec } = rearmWith({ env, files: { [TOKEN_FILE]: `${SPACED_TOKEN}\n` } });
+
+    expect(out).toEqual({ rearmed: false, reason: "unchanged" });
+    expect(env.CATALYST_GITHUB_TOKEN_SOURCE).toBe("shared-file"); // breadcrumb NOT rewritten
+    expect(rec.state.logs).toHaveLength(0);
+  });
+
+  // Whitespace is not a credential. Trimming to "" must land on the `empty` guard, not
+  // install a blank that reads as SET to `??` / `${X:-}` and defeats gh's own fallback.
+  test("a whitespace-ONLY file is still empty — no install, {rearmed:false, reason:'empty'}", () => {
+    for (const content of [" ", "\t", "\r\n", "\n\n\n", " \t \r\n  "]) {
+      const env = {
+        CATALYST_GITHUB_TOKEN_FILE: TOKEN_FILE,
+        CATALYST_GITHUB_TOKEN_SOURCE: "shared-file",
+        GITHUB_TOKEN: STALE_TOKEN,
+        GH_TOKEN: STALE_TOKEN,
+      };
+      const { out } = rearmWith({ env, files: { [TOKEN_FILE]: content } });
+
+      expect(out).toEqual({ rearmed: false, reason: "empty" });
+      expect(env.GITHUB_TOKEN).toBe(STALE_TOKEN);
+      expect(env.GH_TOKEN).toBe(STALE_TOKEN);
+      expect(env.CATALYST_GITHUB_TOKEN_SOURCE).toBe("shared-file");
+    }
+  });
+});
+
+// ── rearmGithubTokenFromFile on EVERY cluster-sync tick ───────────────────────
+//
+// CTL-1612 round 3: the re-arm moved from boot-only to every periodic cluster-sync
+// timer tick. Boot-only would have converted a silent failure into a loud one that
+// STILL needs hands — a credential rotated at 03:00 on a daemon that booted at 00:00
+// stays dead until a human restarts it. Running per tick makes two properties
+// load-bearing that a boot-only call never had to satisfy:
+//   1. IDEMPOTENCE — the steady-state tick must mutate nothing and say nothing, or the
+//      daemon rewrites its own env and logs a phantom rotation every interval;
+//   2. LATENESS — a rotation that first appears on the Nth tick must still re-arm,
+//      exactly as the first one did.
+// These call the real function repeatedly against one env, which is what the timer does.
+
+describe("rearmGithubTokenFromFile on every timer tick", () => {
+  // writeRecordingEnv — an env that records every assignment, so "mutates nothing" is
+  // asserted directly rather than inferred from values that happen to still match.
+  function writeRecordingEnv(initial) {
+    const writes = [];
+    const env = new Proxy(
+      { ...initial },
+      {
+        set(target, key, value) {
+          writes.push(key);
+          target[key] = value;
+          return true;
+        },
+      },
+    );
+    return { env, writes };
+  }
+
+  // tickHarness — one env plus a mutable stand-in for the disk. `disk.content = null`
+  // means the file does not exist yet (readFile throws, as readFileSync would).
+  function tickHarness(initial, content) {
+    const { env, writes } = writeRecordingEnv(initial);
+    const disk = { content };
+    const rec = recorder();
+    const tick = () =>
+      rearmGithubTokenFromFile({
+        env,
+        readFile: () => {
+          if (disk.content === null) {
+            const err = new Error(`ENOENT: no such file or directory, open '${TOKEN_FILE}'`);
+            err.code = "ENOENT";
+            throw err;
+          }
+          return disk.content;
+        },
+        log: rec.log,
+      });
+    return { env, writes, disk, rec, tick };
+  }
+
+  const BASE = { CATALYST_GITHUB_TOKEN_FILE: TOKEN_FILE, CATALYST_GITHUB_TOKEN_SOURCE: "shared-file" };
+
+  test("REGRESSION: a steady-state second tick mutates NOTHING and returns reason:'unchanged'", () => {
+    const { env, writes, rec, tick } = tickHarness(
+      { ...BASE, GITHUB_TOKEN: STALE_TOKEN, GH_TOKEN: STALE_TOKEN },
+      `${ROTATED_TOKEN}\n`,
+    );
+
+    expect(tick()).toEqual({ rearmed: true, reason: "rotated" }); // tick 1 installs
+    const afterFirst = writes.length;
+    expect(afterFirst).toBe(3); // GITHUB_TOKEN, GH_TOKEN, CATALYST_GITHUB_TOKEN_SOURCE
+
+    expect(tick()).toEqual({ rearmed: false, reason: "unchanged" }); // tick 2 no-ops
+    expect(tick()).toEqual({ rearmed: false, reason: "unchanged" }); // …and stays no-op
+    expect(writes).toHaveLength(afterFirst); // not one further assignment
+    expect(env.GITHUB_TOKEN).toBe(ROTATED_TOKEN);
+    expect(env.GH_TOKEN).toBe(ROTATED_TOKEN);
+    expect(env.CATALYST_GITHUB_TOKEN_SOURCE).toBe("shared-file-resynced");
+    expect(rec.state.logs.filter((l) => l.level === "warn")).toHaveLength(1); // one rotation, one line
+  });
+
+  test("REGRESSION: a rotation landing on a LATER tick re-arms and stamps 'shared-file-resynced'", () => {
+    const { env, disk, rec, tick } = tickHarness(
+      { ...BASE, GITHUB_TOKEN: STALE_TOKEN, GH_TOKEN: STALE_TOKEN },
+      `${ROTATED_TOKEN}\n`,
+    );
+
+    expect(tick()).toEqual({ rearmed: true, reason: "rotated" });
+    expect(tick()).toEqual({ rearmed: false, reason: "unchanged" });
+    expect(env.GITHUB_TOKEN).toBe(ROTATED_TOKEN);
+
+    // 03:00: cluster-sync materializes the NEXT rotation onto disk under a long-running
+    // daemon. Boot already happened hours ago; only the timer can catch this.
+    disk.content = `${ROTATED_AGAIN_TOKEN}\n`;
+
+    expect(tick()).toEqual({ rearmed: true, reason: "rotated" });
+    expect(env.GITHUB_TOKEN).toBe(ROTATED_AGAIN_TOKEN);
+    expect(env.GH_TOKEN).toBe(ROTATED_AGAIN_TOKEN);
+    expect(env.CATALYST_GITHUB_TOKEN_SOURCE).toBe("shared-file-resynced");
+    expect(rec.state.logs.filter((l) => l.level === "warn")).toHaveLength(2); // one per real rotation
+    expect(rec.loggedText()).not.toContain(ROTATED_TOKEN);
+    expect(rec.loggedText()).not.toContain(ROTATED_AGAIN_TOKEN);
+  });
+
+  test("a file that does not exist at boot but appears LATER is picked up by a subsequent tick", () => {
+    const { env, writes, disk, tick } = tickHarness(
+      { ...BASE, GITHUB_TOKEN: STALE_TOKEN, GH_TOKEN: STALE_TOKEN },
+      null, // nothing on disk yet — cluster-sync has not materialized it
+    );
+
+    expect(tick()).toEqual({ rearmed: false, reason: "absent" });
+    expect(writes).toHaveLength(0); // absent must not touch the env at all
+    expect(env.GITHUB_TOKEN).toBe(STALE_TOKEN);
+
+    disk.content = ROTATED_TOKEN;
+
+    expect(tick()).toEqual({ rearmed: true, reason: "rotated" });
+    expect(env.GITHUB_TOKEN).toBe(ROTATED_TOKEN);
+    expect(env.GH_TOKEN).toBe(ROTATED_TOKEN);
+  });
+
+  test("an operator override is honored on EVERY tick — never clobbered by a later rotation", () => {
+    const { env, writes, disk, tick } = tickHarness(
+      {
+        CATALYST_GITHUB_TOKEN_FILE: TOKEN_FILE,
+        CATALYST_GITHUB_TOKEN_SOURCE: "operator-override",
+        GITHUB_TOKEN: STALE_TOKEN,
+        GH_TOKEN: STALE_TOKEN,
+      },
+      `${ROTATED_TOKEN}\n`,
+    );
+
+    for (let i = 0; i < 3; i += 1) {
+      expect(tick()).toEqual({ rearmed: false, reason: "operator-override" });
+    }
+    disk.content = `${ROTATED_AGAIN_TOKEN}\n`;
+    expect(tick()).toEqual({ rearmed: false, reason: "operator-override" });
+
+    expect(writes).toHaveLength(0);
+    expect(env.GITHUB_TOKEN).toBe(STALE_TOKEN);
+    expect(env.CATALYST_GITHUB_TOKEN_SOURCE).toBe("operator-override");
+  });
+
+  test("an internal-whitespace credential survives repeated ticks unchanged (no per-tick corruption)", () => {
+    const { env, writes, rec, tick } = tickHarness(
+      { ...BASE, GITHUB_TOKEN: STALE_TOKEN, GH_TOKEN: STALE_TOKEN },
+      `${TABBED_TOKEN}\n`,
+    );
+
+    expect(tick()).toEqual({ rearmed: true, reason: "rotated" });
+    const afterFirst = writes.length;
+    // Under the strip-everything reader the installed value never equals the file, so
+    // every subsequent tick would "rotate" again forever.
+    expect(tick()).toEqual({ rearmed: false, reason: "unchanged" });
+    expect(tick()).toEqual({ rearmed: false, reason: "unchanged" });
+    expect(writes).toHaveLength(afterFirst);
+    expect(env.GITHUB_TOKEN).toBe(TABBED_TOKEN);
+    expect(rec.state.logs.filter((l) => l.level === "warn")).toHaveLength(1);
+  });
+});
+
 // ── resolveGithubBootAuth ⟷ rearm wiring ──────────────────────────────────────
 //
 // Re-arming AFTER the probe would be worthless: the preflight must verify the
@@ -719,27 +978,54 @@ describe("resolveGithubBootAuth re-arms before probing", () => {
 describe("daemon boot ordering", () => {
   const daemonSrc = readFileSync(new URL("./daemon.mjs", import.meta.url), "utf8").split("\n");
   const lineOf = (needle) => daemonSrc.findIndex((l) => l.includes(needle));
+  const countOf = (needle) => daemonSrc.filter((l) => l.includes(needle)).length;
 
-  test("the boot cluster-sync runs BEFORE the credential preflight", () => {
+  // The boot sequence must be: clusterSync -> RE-ARM -> dispatch -> PROBE.
+  // Both halves are load-bearing and both have been wrong once:
+  //   * re-arm must precede dispatch, or a boot-resumed worker inherits a credential the
+  //     sync just superseded and keeps it for its whole lifetime;
+  //   * the probe must FOLLOW dispatch, because it spawns `gh` with a 10s timeout and a
+  //     network round-trip ahead of crash recovery delays re-dispatching in-flight work
+  //     for no diagnostic benefit.
+  test("the boot cluster-sync runs BEFORE the credential re-arm", () => {
     const sync = lineOf("const bootSync = clusterSync()");
-    const preflight = lineOf("githubAuthPreflight({ env: process.env, log })");
+    const rearm = lineOf("rearmGithubTokenFromFile({ env: process.env, log })");
     expect(sync).toBeGreaterThan(-1);
-    expect(preflight).toBeGreaterThan(-1);
-    expect(sync).toBeLessThan(preflight);
+    expect(rearm).toBeGreaterThan(-1);
+    expect(sync).toBeLessThan(rearm);
   });
 
-  test("the credential preflight runs BEFORE anything dispatches a worker", () => {
-    const preflight = lineOf("githubAuthPreflight({ env: process.env, log })");
+  test("the credential RE-ARM runs BEFORE anything dispatches a worker", () => {
+    const rearm = lineOf("rearmGithubTokenFromFile({ env: process.env, log })");
     const bootResume = lineOf("const bootResume = reconcileBoot(");
     const approved = lineOf("processApprovedResumes({ orchDir, dispatch: dispatchFn })");
     expect(bootResume).toBeGreaterThan(-1);
     expect(approved).toBeGreaterThan(-1);
-    expect(preflight).toBeLessThan(bootResume);
-    expect(preflight).toBeLessThan(approved);
+    expect(rearm).toBeLessThan(bootResume);
+    expect(rearm).toBeLessThan(approved);
   });
 
-  test("the preflight is wired exactly once (no leftover duplicate call site)", () => {
-    const hits = daemonSrc.filter((l) => l.includes("githubAuthPreflight({")).length;
-    expect(hits).toBe(1);
+  test("the `gh` PROBE runs AFTER the dispatches (never delays crash recovery)", () => {
+    const probe = lineOf("githubAuthPreflight({ env: process.env, log })");
+    const bootResume = lineOf("const bootResume = reconcileBoot(");
+    const approved = lineOf("processApprovedResumes({ orchDir, dispatch: dispatchFn })");
+    expect(probe).toBeGreaterThan(bootResume);
+    expect(probe).toBeGreaterThan(approved);
+  });
+
+  test("the probe is wired exactly once (no leftover duplicate call site)", () => {
+    expect(countOf("githubAuthPreflight({")).toBe(1);
+  });
+
+  // Without this the entire fix is boot-only: a credential rotated at 03:00 on a daemon
+  // that booted at 00:00 stays dead until a human restarts it.
+  test("the re-arm is ALSO wired into the periodic cluster-sync timer", () => {
+    const timer = lineOf("_clusterSyncTimer = setInterval(");
+    expect(timer).toBeGreaterThan(-1);
+    const rearmCalls = daemonSrc
+      .map((l, i) => (l.includes("rearmGithubTokenFromFile({ env: process.env, log })") ? i : -1))
+      .filter((i) => i >= 0);
+    expect(rearmCalls.length).toBe(2); // once at boot, once per timer tick
+    expect(rearmCalls.some((i) => i > timer)).toBe(true);
   });
 });

--- a/plugins/dev/scripts/lib/catalyst-secret-env.sh
+++ b/plugins/dev/scripts/lib/catalyst-secret-env.sh
@@ -1,0 +1,169 @@
+#!/usr/bin/env bash
+# lib/catalyst-secret-env.sh — CTL-1612: ONE canonical projection of the cluster-synced
+# secret files into a daemon's boot environment, shared by every daemon start path.
+#
+# WHY THIS FILE EXISTS. A daemon captures its credentials from the environment at process
+# start and never re-reads them, so a rotation reaches new login shells but never a running
+# daemon — on 2026-08-02 both fleet hosts ran for hours on a revoked GitHub token while the
+# valid one sat unread on disk. The launchers therefore have to arm the credential
+# themselves at every start, exactly as lib/linear-app-actor.sh does for Linear.
+#
+# WHY IT IS SHARED. The first cut of CTL-1612 hand-wrote the same resolution chain in four
+# places (execution-core launcher, monitor launcher, the launchd wrapper, and the in-process
+# JS re-arm). They immediately diverged — only one honored CATALYST_CONFIG_DIR, so the
+# launcher and the in-process re-arm could resolve DIFFERENT files — and every review
+# finding across three rounds landed in that duplicated logic rather than in the design.
+# Four copies of one chain is a defect generator; this is the single copy.
+#
+# THE RESOLUTION CHAIN (and why it is not simply "XDG"). cluster-sync materializes bare
+# secrets into dirname(getLayer2ConfigPath()) — a HARDCODED ~/.config/catalyst, NOT
+# XDG-aware — while setup-webhooks.sh and lib/linear-app-actor.sh ARE XDG-aware. Reading
+# only the XDG path makes an XDG host miss every rotation. So: explicit override, then the
+# writer's own destination, then the XDG location; first readable NON-EMPTY file wins.
+#
+# Idempotent-source guard — safe to source multiple times.
+[[ -n "${_CATALYST_SECRET_ENV_SH_LOADED:-}" ]] && return 0
+_CATALYST_SECRET_ENV_SH_LOADED=1
+
+# _catalyst_trim — strip LEADING and TRAILING whitespace only.
+#
+# Deliberately NOT `tr -d '[:space:]'`: that deletes INTERNAL whitespace too, which would
+# silently corrupt any secret containing a space, tab or newline. For an HMAC signing key
+# that means every inbound webhook is rejected with no error anywhere — the value looks
+# present and is simply wrong. Command substitution already eats trailing newlines; this
+# handles the rest.
+_catalyst_trim() {
+  local s="$1"
+  s="${s#"${s%%[![:space:]]*}"}"
+  s="${s%"${s##*[![:space:]]}"}"
+  printf '%s' "$s"
+}
+
+# catalyst_secret_dirs — the directories to search, in priority order.
+_catalyst_secret_dirs() {
+  # cluster-sync's own destination first, resolved the way the WRITER resolves it, so a
+  # Layer-2 override moves reader and writer together.
+  local _l2="${CATALYST_LAYER2_CONFIG_FILE:-${HOME}/.config/catalyst/config.json}"
+  printf '%s\n' "$(dirname "$_l2")"
+  printf '%s\n' "${XDG_CONFIG_HOME:-${HOME}/.config}/catalyst"
+}
+
+# catalyst_read_secret_file <basename> [explicit-path] [explicit-dir]
+#   Echoes the first readable NON-EMPTY value found, or nothing. Never echoes a partial or
+#   whitespace-only value. An explicit path or dir short-circuits the chain entirely — an
+#   operator who names a location means it, so we do NOT silently fall back past it.
+catalyst_read_secret_file() {
+  local _base="${1:?catalyst_read_secret_file: basename required}"
+  local _explicit_path="${2:-}" _explicit_dir="${3:-}"
+  local _f _raw _val
+  local -a _cands=()
+  if [[ -n "$_explicit_path" ]]; then
+    _cands=("$_explicit_path")
+  elif [[ -n "$_explicit_dir" ]]; then
+    _cands=("${_explicit_dir}/${_base}")
+  else
+    local _d
+    while IFS= read -r _d; do
+      [[ -n "$_d" ]] && _cands+=("${_d}/${_base}")
+    done < <(_catalyst_secret_dirs)
+  fi
+  for _f in "${_cands[@]}"; do
+    [[ -r "$_f" ]] || continue
+    _raw="$(cat "$_f" 2>/dev/null)" || continue
+    _val="$(_catalyst_trim "$_raw")"
+    if [[ -n "$_val" ]]; then
+      printf '%s' "$_val"
+      return 0
+    fi
+  done
+  return 1
+}
+
+# catalyst_env_file_assigns <env-file> <var>
+#   Does this env file ASSIGN the variable at all? Used instead of a value comparison,
+#   because an operator override that happens to pin the SAME value as the shared file is
+#   still an override — a byte-comparison would miss it and a later re-arm would then
+#   overwrite the explicit machine-local pin.
+catalyst_env_file_assigns() {
+  [[ -r "${1:-}" ]] || return 1
+  grep -qE "^[[:space:]]*(export[[:space:]]+)?${2}=" "$1" 2>/dev/null
+}
+
+# catalyst_project_github_token
+#   Arm GITHUB_TOKEN + GH_TOKEN from the shared file. FILE WINS over any inherited value —
+#   that stale inherited value IS the bug; a fill-if-unset projection would leave it winning
+#   and fix nothing. Both names, because `gh` resolves GH_TOKEN BEFORE GITHUB_TOKEN, so a
+#   stale GH_TOKEN anywhere in the launcher's ancestry would otherwise shadow the fix.
+#   Absent/empty/unreadable everywhere = TOTAL no-op; never exports "" (bash ${X:-default}
+#   and JS ?? both treat "" as SET, which would defeat gh's hosts.yml/keyring fallback).
+#   Never logs or echoes the value.
+catalyst_project_github_token() {
+  local _tok
+  if _tok="$(catalyst_read_secret_file "github-token" "${CATALYST_GITHUB_TOKEN_FILE:-}" "${CATALYST_CONFIG_DIR:-}")"; then
+    export GITHUB_TOKEN="$_tok" GH_TOKEN="$_tok"
+    export CATALYST_GITHUB_TOKEN_SOURCE="shared-file"
+  elif [[ -n "${GH_TOKEN:-}" ]]; then
+    # No shared file. Keep what was inherited, but export-promote it so a BARE assignment
+    # reaches the nohup'd child. GH_TOKEN is checked FIRST and preserved as-is: it
+    # outranks GITHUB_TOKEN in gh's own precedence, so an explicit GH_TOKEN beside a stale
+    # GITHUB_TOKEN must NOT be overwritten by the latter.
+    export GH_TOKEN
+    export CATALYST_GITHUB_TOKEN_SOURCE="inherited"
+  elif [[ -n "${GITHUB_TOKEN:-}" ]]; then
+    export GITHUB_TOKEN
+    export GH_TOKEN="$GITHUB_TOKEN" # mirror only when GH_TOKEN is absent
+    export CATALYST_GITHUB_TOKEN_SOURCE="inherited"
+  else
+    # Nothing anywhere: leave BOTH unset so `gh` falls through to hosts.yml / the keyring.
+    export CATALYST_GITHUB_TOKEN_SOURCE="none"
+  fi
+  _CATALYST_PROJECTED_GITHUB_TOKEN="${GITHUB_TOKEN:-}"
+  _CATALYST_PROJECTED_GH_TOKEN="${GH_TOKEN:-}"
+}
+
+# catalyst_reconcile_github_token_aliases [env-file]
+#   MUST run AFTER the machine-local env file is sourced. The operator override is honored
+#   by ORDERING (we project first, the env file sources second and wins) — but an override
+#   that sets only ONE alias would leave the other holding our shared-file value, and since
+#   `gh` reads GH_TOKEN first that can silently defeat the override. Re-point both names at
+#   the winner and correct the provenance.
+#
+#   Detection is by ASSIGNMENT, not by value change: pinning the same value the shared file
+#   already had is still an explicit override, and marking it operator-override is what
+#   stops the in-process re-arm from later overwriting it.
+catalyst_reconcile_github_token_aliases() {
+  local _env_file="${1:-}"
+  local _gh_changed=0 _gt_changed=0 _win=""
+  [[ "${GH_TOKEN:-}" != "${_CATALYST_PROJECTED_GH_TOKEN:-}" ]] && _gh_changed=1
+  [[ "${GITHUB_TOKEN:-}" != "${_CATALYST_PROJECTED_GITHUB_TOKEN:-}" ]] && _gt_changed=1
+  local _gh_pinned=0 _gt_pinned=0
+  if [[ -n "$_env_file" ]]; then
+    catalyst_env_file_assigns "$_env_file" GH_TOKEN && _gh_pinned=1
+    catalyst_env_file_assigns "$_env_file" GITHUB_TOKEN && _gt_pinned=1
+  fi
+  (( _gh_changed || _gt_changed || _gh_pinned || _gt_pinned )) || return 0
+  # GH_TOKEN wins when it is the one the operator touched — it is the name gh resolves first.
+  if (( _gh_changed || _gh_pinned )) && [[ -n "${GH_TOKEN:-}" ]]; then
+    _win="$GH_TOKEN"
+  elif (( _gt_changed || _gt_pinned )) && [[ -n "${GITHUB_TOKEN:-}" ]]; then
+    _win="$GITHUB_TOKEN"
+  fi
+  # An override that BLANKS a name is not a credential — keep the pair as projected.
+  [[ -n "$_win" ]] || return 0
+  export GITHUB_TOKEN="$_win" GH_TOKEN="$_win"
+  export CATALYST_GITHUB_TOKEN_SOURCE="operator-override"
+}
+
+# catalyst_project_webhook_secret
+#   Same contract for the GitHub webhook signing secret. orch-monitor resolves this from
+#   process.env ONLY (no file fallback, unlike the Linear per-team secrets) and captures it
+#   once at boot, so a monitor started without it runs with the GitHub webhook route
+#   silently DISABLED rather than degraded.
+catalyst_project_webhook_secret() {
+  local _val
+  if _val="$(catalyst_read_secret_file "webhook-secret" "${CATALYST_WEBHOOK_SECRET_FILE:-}" "${CATALYST_CONFIG_DIR:-}")"; then
+    export CATALYST_WEBHOOK_SECRET="$_val"
+  fi
+  # Absent/empty → leave whatever was inherited. Never export "": webhook-config treats an
+  # empty secret as "route unconfigured", which disables verification instead of failing.
+}

--- a/plugins/dev/scripts/lib/catalyst-secret-env.sh
+++ b/plugins/dev/scripts/lib/catalyst-secret-env.sh
@@ -25,18 +25,34 @@
 [[ -n "${_CATALYST_SECRET_ENV_SH_LOADED:-}" ]] && return 0
 _CATALYST_SECRET_ENV_SH_LOADED=1
 
-# _catalyst_trim — strip LEADING and TRAILING whitespace only.
+# _catalyst_strip_eol — remove ONLY the line terminator a text file ends with.
 #
-# Deliberately NOT `tr -d '[:space:]'`: that deletes INTERNAL whitespace too, which would
-# silently corrupt any secret containing a space, tab or newline. For an HMAC signing key
-# that means every inbound webhook is rejected with no error anywhere — the value looks
-# present and is simply wrong. Command substitution already eats trailing newlines; this
-# handles the rest.
-_catalyst_trim() {
+# Two failure modes had to be avoided here, and they pull in opposite directions:
+#
+#   `tr -d '[:space:]'` deletes INTERNAL whitespace, silently corrupting any secret
+#   containing a space or tab. For an HMAC key that rejects every inbound delivery with no
+#   error anywhere — the value looks present and is simply wrong.
+#
+#   A full leading/trailing trim is subtler but the same class: a signing secret may
+#   legitimately BEGIN or END with a space or tab, and trimming those bytes produces a
+#   different key and the identical silent rejection. The `$(cat …)` this replaced removed
+#   trailing newlines but preserved boundary spaces, so trimming them would be a regression.
+#
+# So: strip only the trailing newline(s) a file inevitably carries, and preserve every other
+# byte exactly. Command substitution has already eaten trailing \n; this also handles a
+# CRLF file. Callers apply their own "is it blank?" check for the whitespace-only case.
+_catalyst_strip_eol() {
   local s="$1"
-  s="${s#"${s%%[![:space:]]*}"}"
-  s="${s%"${s##*[![:space:]]}"}"
+  s="${s%$'\n'}"
+  s="${s%$'\r'}"
   printf '%s' "$s"
+}
+
+# _catalyst_is_blank — true when the value carries no non-whitespace byte. Used so a
+# whitespace-only file still counts as "absent" (never exported) WITHOUT mutating a value
+# that merely has significant boundary whitespace.
+_catalyst_is_blank() {
+  [[ -z "${1//[[:space:]]/}" ]]
 }
 
 # catalyst_secret_dirs — the directories to search, in priority order.
@@ -70,8 +86,10 @@ catalyst_read_secret_file() {
   for _f in "${_cands[@]}"; do
     [[ -r "$_f" ]] || continue
     _raw="$(cat "$_f" 2>/dev/null)" || continue
-    _val="$(_catalyst_trim "$_raw")"
-    if [[ -n "$_val" ]]; then
+    _val="$(_catalyst_strip_eol "$_raw")"
+    # Blank-check WITHOUT mutating: a whitespace-only file is treated as absent, while a
+    # value with significant boundary whitespace is emitted byte-for-byte.
+    if ! _catalyst_is_blank "$_val"; then
       printf '%s' "$_val"
       return 0
     fi
@@ -80,13 +98,33 @@ catalyst_read_secret_file() {
 }
 
 # catalyst_env_file_assigns <env-file> <var>
-#   Does this env file ASSIGN the variable at all? Used instead of a value comparison,
-#   because an operator override that happens to pin the SAME value as the shared file is
-#   still an override — a byte-comparison would miss it and a later re-arm would then
-#   overwrite the explicit machine-local pin.
+#   Does sourcing this env file ACTUALLY assign the variable on THIS host?
+#
+#   Not a value comparison: an override that pins the SAME value the shared file holds is
+#   still an override, and a byte-comparison would miss it, letting a later re-arm overwrite
+#   the operator's machine-local pin.
+#
+#   And not a raw-text grep either. A grep matches an assignment inside a branch that never
+#   runs on this host (`if [[ $(hostname) == other ]]; then GITHUB_TOKEN=…; fi`) and would
+#   report the alias as pinned when sourcing changed nothing — marking the projected token
+#   `operator-override` and making the post-sync re-arm stand down, so an offline node keeps
+#   its stale credential and hands it to resumed workers. Exactly the bug we are fixing.
+#
+#   So: OBSERVE the assignment. Source the file in a subshell with the variable pre-set to a
+#   sentinel and see whether the sentinel survived. Hermetic (the subshell cannot touch our
+#   env), and it reports what the shell actually did rather than what the text looks like.
 catalyst_env_file_assigns() {
-  [[ -r "${1:-}" ]] || return 1
-  grep -qE "^[[:space:]]*(export[[:space:]]+)?${2}=" "$1" 2>/dev/null
+  local _file="${1:-}" _var="${2:?catalyst_env_file_assigns: var required}"
+  [[ -r "$_file" ]] || return 1
+  local _sentinel="__catalyst_unset_sentinel_$$__"
+  local _observed
+  _observed="$(
+    export "$_var=$_sentinel"
+    # shellcheck disable=SC1090
+    source "$_file" >/dev/null 2>&1 || true
+    printf '%s' "${!_var}"
+  )"
+  [[ "$_observed" != "$_sentinel" ]]
 }
 
 # catalyst_project_github_token

--- a/plugins/dev/scripts/lib/catalyst-secret-env.sh
+++ b/plugins/dev/scripts/lib/catalyst-secret-env.sh
@@ -43,8 +43,14 @@ _CATALYST_SECRET_ENV_SH_LOADED=1
 # CRLF file. Callers apply their own "is it blank?" check for the whitespace-only case.
 _catalyst_strip_eol() {
   local s="$1"
-  s="${s%$'\n'}"
-  s="${s%$'\r'}"
+  # ALL trailing terminators, not just the last pair: callers that read via `$(cat …)`
+  # already had every trailing \n eaten by command substitution, and the JS re-arm
+  # (github-auth-preflight.mjs) strips /[\r\n]+$/ — a file ending in `\r\n\r\n` must
+  # resolve to the same bytes on every path.
+  while [[ "$s" == *$'\n' || "$s" == *$'\r' ]]; do
+    s="${s%$'\n'}"
+    s="${s%$'\r'}"
+  done
   printf '%s' "$s"
 }
 
@@ -110,21 +116,40 @@ catalyst_read_secret_file() {
 #   `operator-override` and making the post-sync re-arm stand down, so an offline node keeps
 #   its stale credential and hands it to resumed workers. Exactly the bug we are fixing.
 #
-#   So: OBSERVE the assignment. Source the file in a subshell with the variable pre-set to a
-#   sentinel and see whether the sentinel survived. Hermetic (the subshell cannot touch our
-#   env), and it reports what the shell actually did rather than what the text looks like.
-catalyst_env_file_assigns() {
-  local _file="${1:-}" _var="${2:?catalyst_env_file_assigns: var required}"
-  [[ -r "$_file" ]] || return 1
+#   So: OBSERVE the assignment. Source the file in a subshell with every probed variable
+#   pre-set to a sentinel and see which sentinels survived. Hermetic (the subshell cannot
+#   touch our env), and it reports what the shell actually did rather than what the text
+#   looks like.
+#
+#   ONE source for ALL names: the launcher has already sourced this file for real, and an
+#   env file may legitimately carry executed commands (a command substitution fetching a
+#   token, a `mkdir`, a rate-limited credential-helper call). Probing per-name would re-run
+#   those side effects once per alias on every daemon start; batching keeps the probe to a
+#   single extra execution.
+#
+# catalyst_env_file_assigned_names <env-file> <var>...
+#   Prints (one per line) the names that sourcing the file assigned.
+catalyst_env_file_assigned_names() {
+  local _file="${1:-}"
+  shift || true
+  [[ -r "$_file" && $# -gt 0 ]] || return 1
   local _sentinel="__catalyst_unset_sentinel_$$__"
-  local _observed
-  _observed="$(
-    export "$_var=$_sentinel"
+  (
+    local _v
+    for _v in "$@"; do export "$_v=$_sentinel"; done
     # shellcheck disable=SC1090
     source "$_file" >/dev/null 2>&1 || true
-    printf '%s' "${!_var}"
-  )"
-  [[ "$_observed" != "$_sentinel" ]]
+    for _v in "$@"; do
+      [[ "${!_v}" != "$_sentinel" ]] && printf '%s\n' "$_v"
+    done
+    true
+  )
+}
+
+# catalyst_env_file_assigns <env-file> <var> — single-name convenience wrapper.
+catalyst_env_file_assigns() {
+  local _file="${1:-}" _var="${2:?catalyst_env_file_assigns: var required}"
+  [[ "$(catalyst_env_file_assigned_names "$_file" "$_var")" == "$_var" ]]
 }
 
 # catalyst_project_github_token
@@ -174,10 +199,16 @@ catalyst_reconcile_github_token_aliases() {
   local _gh_changed=0 _gt_changed=0 _win=""
   [[ "${GH_TOKEN:-}" != "${_CATALYST_PROJECTED_GH_TOKEN:-}" ]] && _gh_changed=1
   [[ "${GITHUB_TOKEN:-}" != "${_CATALYST_PROJECTED_GITHUB_TOKEN:-}" ]] && _gt_changed=1
-  local _gh_pinned=0 _gt_pinned=0
+  local _gh_pinned=0 _gt_pinned=0 _name
   if [[ -n "$_env_file" ]]; then
-    catalyst_env_file_assigns "$_env_file" GH_TOKEN && _gh_pinned=1
-    catalyst_env_file_assigns "$_env_file" GITHUB_TOKEN && _gt_pinned=1
+    # One hermetic source covering both aliases — see catalyst_env_file_assigned_names for
+    # why probing per-alias would multiply the env file's side effects.
+    while IFS= read -r _name; do
+      case "$_name" in
+        GH_TOKEN) _gh_pinned=1 ;;
+        GITHUB_TOKEN) _gt_pinned=1 ;;
+      esac
+    done < <(catalyst_env_file_assigned_names "$_env_file" GH_TOKEN GITHUB_TOKEN || true)
   fi
   (( _gh_changed || _gt_changed || _gh_pinned || _gt_pinned )) || return 0
   # GH_TOKEN wins when it is the one the operator touched — it is the name gh resolves first.

--- a/plugins/dev/scripts/orch-monitor/dist/catalyst-monitor-launchd.sh
+++ b/plugins/dev/scripts/orch-monitor/dist/catalyst-monitor-launchd.sh
@@ -1,31 +1,20 @@
 #!/usr/bin/env bash
-# Wrapper script for launchd (macOS). Reads CATALYST_WEBHOOK_SECRET from the
-# secret file at startup so the value never needs to appear in the plist.
+# Wrapper script for launchd (macOS). A thin exec into catalyst-monitor.sh, which
+# projects the cluster-synced secrets itself — no secret value ever appears in the plist.
 #
 # Usage: copy this file to an absolute path on disk, edit the SCRIPT_DIR line
 # if needed, then reference it from your LaunchAgent plist.
 #
 # See: website/src/content/docs/observability/webhooks.md — "Persistent setup"
 
-# CTL-1612: only export a NON-EMPTY value. The previous `-f`-guarded `$(cat)` exported
-# CATALYST_WEBHOOK_SECRET="" for an empty or whitespace-only file, and an empty secret
-# makes webhook-config treat the GitHub route as unconfigured — silently disabling
-# inbound webhook verification rather than falling back. catalyst-monitor.sh cmd_start
-# now performs the same projection, so both launch paths agree.
-# Resolution CHAIN — the two writers disagree: setup-webhooks.sh writes to
-# ${XDG_CONFIG_HOME:-$HOME/.config}/catalyst, cluster-sync to a hardcoded
-# ~/.config/catalyst. Take the first readable NON-EMPTY file (an empty secret makes
-# webhook-config treat the GitHub route as unconfigured, silently disabling it).
-_wh_val=""
-for _wh_file in \
-  "${HOME}/.config/catalyst/webhook-secret" \
-  "${XDG_CONFIG_HOME:-${HOME}/.config}/catalyst/webhook-secret"; do
-  [[ -r "$_wh_file" ]] || continue
-  _wh_val="$(tr -d '[:space:]' <"$_wh_file" 2>/dev/null)"
-  [[ -n "$_wh_val" ]] && break
-done
-[[ -n "$_wh_val" ]] && export CATALYST_WEBHOOK_SECRET="$_wh_val"
-unset _wh_val _wh_file
+# CTL-1612: the secret projection was REMOVED from this wrapper deliberately.
+# catalyst-monitor.sh cmd_start now performs it via lib/catalyst-secret-env.sh, honoring
+# CATALYST_WEBHOOK_SECRET_FILE / CATALYST_CONFIG_DIR / CATALYST_LAYER2_CONFIG_FILE. This
+# wrapper always preloaded the HOME/XDG default and ignored those overrides, so a
+# LaunchAgent pointing at a custom path still got the default value — and the wrapper's
+# `$(cat ...)` also exported an empty string for an empty file, which makes
+# webhook-config treat the GitHub route as unconfigured and silently disables it.
+# One projection, one chain, both launch paths.
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 exec "${SCRIPT_DIR}/../catalyst-monitor.sh" start

--- a/plugins/dev/scripts/orch-monitor/dist/catalyst-monitor-launchd.sh
+++ b/plugins/dev/scripts/orch-monitor/dist/catalyst-monitor-launchd.sh
@@ -7,10 +7,16 @@
 #
 # See: website/src/content/docs/observability/webhooks.md — "Persistent setup"
 
+# CTL-1612: only export a NON-EMPTY value. The previous `-f`-guarded `$(cat)` exported
+# CATALYST_WEBHOOK_SECRET="" for an empty or whitespace-only file, and an empty secret
+# makes webhook-config treat the GitHub route as unconfigured — silently disabling
+# inbound webhook verification rather than falling back. catalyst-monitor.sh cmd_start
+# now performs the same projection, so both launch paths agree.
 SECRET_FILE="${HOME}/.config/catalyst/webhook-secret"
-if [[ -f "$SECRET_FILE" ]]; then
-  export CATALYST_WEBHOOK_SECRET
-  CATALYST_WEBHOOK_SECRET="$(cat "$SECRET_FILE")"
+if [[ -r "$SECRET_FILE" ]]; then
+  _wh_val="$(tr -d '[:space:]' <"$SECRET_FILE" 2>/dev/null)"
+  [[ -n "$_wh_val" ]] && export CATALYST_WEBHOOK_SECRET="$_wh_val"
+  unset _wh_val
 fi
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"

--- a/plugins/dev/scripts/orch-monitor/dist/catalyst-monitor-launchd.sh
+++ b/plugins/dev/scripts/orch-monitor/dist/catalyst-monitor-launchd.sh
@@ -12,13 +12,20 @@
 # makes webhook-config treat the GitHub route as unconfigured — silently disabling
 # inbound webhook verification rather than falling back. catalyst-monitor.sh cmd_start
 # now performs the same projection, so both launch paths agree.
-# XDG-aware to match setup-webhooks.sh:23, which is what generates this file.
-SECRET_FILE="${XDG_CONFIG_HOME:-${HOME}/.config}/catalyst/webhook-secret"
-if [[ -r "$SECRET_FILE" ]]; then
-  _wh_val="$(tr -d '[:space:]' <"$SECRET_FILE" 2>/dev/null)"
-  [[ -n "$_wh_val" ]] && export CATALYST_WEBHOOK_SECRET="$_wh_val"
-  unset _wh_val
-fi
+# Resolution CHAIN — the two writers disagree: setup-webhooks.sh writes to
+# ${XDG_CONFIG_HOME:-$HOME/.config}/catalyst, cluster-sync to a hardcoded
+# ~/.config/catalyst. Take the first readable NON-EMPTY file (an empty secret makes
+# webhook-config treat the GitHub route as unconfigured, silently disabling it).
+_wh_val=""
+for _wh_file in \
+  "${HOME}/.config/catalyst/webhook-secret" \
+  "${XDG_CONFIG_HOME:-${HOME}/.config}/catalyst/webhook-secret"; do
+  [[ -r "$_wh_file" ]] || continue
+  _wh_val="$(tr -d '[:space:]' <"$_wh_file" 2>/dev/null)"
+  [[ -n "$_wh_val" ]] && break
+done
+[[ -n "$_wh_val" ]] && export CATALYST_WEBHOOK_SECRET="$_wh_val"
+unset _wh_val _wh_file
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 exec "${SCRIPT_DIR}/../catalyst-monitor.sh" start

--- a/plugins/dev/scripts/orch-monitor/dist/catalyst-monitor-launchd.sh
+++ b/plugins/dev/scripts/orch-monitor/dist/catalyst-monitor-launchd.sh
@@ -12,7 +12,8 @@
 # makes webhook-config treat the GitHub route as unconfigured — silently disabling
 # inbound webhook verification rather than falling back. catalyst-monitor.sh cmd_start
 # now performs the same projection, so both launch paths agree.
-SECRET_FILE="${HOME}/.config/catalyst/webhook-secret"
+# XDG-aware to match setup-webhooks.sh:23, which is what generates this file.
+SECRET_FILE="${XDG_CONFIG_HOME:-${HOME}/.config}/catalyst/webhook-secret"
 if [[ -r "$SECRET_FILE" ]]; then
   _wh_val="$(tr -d '[:space:]' <"$SECRET_FILE" 2>/dev/null)"
   [[ -n "$_wh_val" ]] && export CATALYST_WEBHOOK_SECRET="$_wh_val"


### PR DESCRIPTION
## Why

A Catalyst daemon captures its credentials from `process.env` at process start and **never re-reads them**. A rotation therefore reaches new login shells but never a running daemon, and nothing reports the gap.

That is live: on **2026-08-02** both fleet hosts restarted execution-core holding a **revoked** GitHub token and every daemon-side `gh` API call has 401'd since, unreported. It surfaced only because it blocked `stale-pr-rescue` for an unrelated stuck ticket. The valid credential was on disk, unread, the whole time. The bug has since survived two further independent restarts, because each one inherits the same stale env from a long-lived parent.

The registry that should have caught it made it invisible: `cluster-sync`'s `ENV_BACKED_SECRET_FILES` exists precisely to emit `restart-required` for boot-captured secrets, but `github-token` and the webhook secrets were not enrolled — so their rotations were written to disk, recorded in `written`, and reported as **applied**.

## Two corrections to my original framing

Both surfaced by review; the original PR description overclaimed and is fixed here.

**1. The `.zshenv` mechanism is host-specific.** I described `export GITHUB_TOKEN=$(cat …)` as if universal. Verified per host: **mini-2** does use `$(cat …)`; **mini** has that export commented out and falls through to `hosts.yml`; the **laptop** has a hardcoded `ghp_` literal baked into the rc file. Three hosts, three mechanisms — which is also why a fix verified on one proves nothing about another.

**2. This does NOT fix `claude --bg` phase workers.** `phase-agent-dispatch` contains zero `GITHUB_TOKEN`/`GH_TOKEN` references, and the CTL-760 comment at `:813` states it directly: *"`claude --bg` is an RPC to the per-user daemon, so the spawned worker inherits the DAEMON's frozen env."* That is the **claude supervisor's** env, captured whenever *it* started — not execution-core's. So the scope of this PR is execution-core's own `gh` call sites plus orch-monitor's 13; `--bg` workers need the supervisor restarted, and that is out of scope here.

## What changed

**One shared projection library — `lib/catalyst-secret-env.sh`.** Two independent adversarial architecture reviews (one on external prior art, one repo-idiomatic) both returned SHIP_WITH_CHANGES and both identified the same root cause behind three rounds of findings: not the design, but **four hand-written copies of one resolution chain** that had already diverged — only one honored `CATALYST_CONFIG_DIR`, so the launcher and the in-process re-arm could resolve *different files*. Both launchers now source one library; the launchd wrapper's separate projection is deleted rather than becoming a fifth copy.

The chain is: explicit override → **cluster-sync's own destination** (resolved as the *writer* resolves it) → the XDG location. Not simply "XDG-aware": `cluster-sync` writes to a hardcoded `~/.config/catalyst`, while `setup-webhooks.sh` and `lib/linear-app-actor.sh` are XDG-aware, so a naive XDG fix makes an XDG host miss every rotation.

**File-wins projection at every daemon start**, exporting `GITHUB_TOKEN` *and* `GH_TOKEN` (gh resolves `GH_TOKEN` first, so a token-only fix can be silently shadowed), with precedence by ordering: `ambient inherited < shared file < execution-core.env`. Operator overrides are detected by **assignment**, not by value — pinning the same bytes the shared file holds is still an override, and marking it as one is what stops a later re-arm from clobbering it.

**Continuous re-arm.** `rearmGithubTokenFromFile` runs on every cluster-sync timer tick, not only at boot. Without this the fix is boot-only: a credential rotated at 03:00 on a daemon that booted at 00:00 stays dead until a human restarts it — a silent failure converted into a loud one that still needs hands.

**Boot order: `clusterSync → re-arm → dispatch → probe`.** The re-arm is a cheap local read and must precede dispatch so boot-resumed workers do not inherit a superseded credential. The `gh` probe deliberately follows the dispatches — a 10s network timeout must never delay crash recovery.

**A three-state boot probe.** Only a definitive 401 alerts; spawn errors, timeouts, missing `gh`, and non-401 exits stay silent. "Could not prove the credential is good" is not "the credential is bad", and collapsing them would page the fleet on any DNS blip. 403 is excluded (scope, not a dead credential).

**orch-monitor's GitHub credential.** The monitor makes 13 `gh` calls across 5 files and contains **zero** `GITHUB_TOKEN`/`GH_TOKEN` references — its auth was purely ambient inheritance, the same bug, which the first cut of this PR left unfixed while editing its launcher. `doctor.mjs:checkRepoIconTokenScope` already existed to warn about exactly this. One projection in `cmd_start` fixes all 13; none of them changed.

**Whitespace (data corruption).** `tr -d '[:space:]'` and `.replace(/\s+/g,"")` strip *internal* whitespace, not just the trailing newline. A secret containing a space was silently corrupted — for an HMAC key that means every webhook delivery rejected, with no error anywhere. Both now trim only; a whitespace-only file is still treated as empty so nothing is ever exported as `""`.

**Registry + restart notices.** `isEnvBackedSecretFile()` enrolls `github-token`, `webhook-secret` and the per-team `linear-webhook-secret-*` family (case-insensitive prefix — team keys are not guaranteed lowercase). `syncSecretFiles` reports `changed` vs `written` so an unrelated rotation does not demand a restart. The notice is emitted **before** the shortfall early-return: previously a rotation written alongside an unrelated materialization failure lost its notice *permanently*, because the retry rewrites identical bytes so `changed` is empty and the marker then advances having never asked.

**CI.** `cluster-sync.test.mjs` and the monitor suite were gated by **no workflow at all** (the job uses an explicit allowlist, not a glob), so most of this would have shipped untested. Both added, plus the new bash suite.

## Measured, not assumed

- **gh precedence (gh 2.92.0):** `GH_TOKEN` > `GITHUB_TOKEN` > `hosts.yml`/keyring. An **empty** `GITHUB_TOKEN` does *not* suppress the fallback — the ticket's original premise was wrong. A **whitespace-only** value *is* sent and 401s, which is why the readers strip then test.
- **The hosts diverge:** `mini` uses `hosts.yml` with no keychain; `mini-2` has a keychain and no `hosts.yml`.

## Testing

| Suite | Result |
|---|---|
| `bun test github-auth-preflight.test.mjs cluster-sync.test.mjs` | **132 pass / 0 fail** (538 expects) |
| `bash __tests__/catalyst-execution-core-github-token.test.sh` | **123 / 0** |
| `bash __tests__/catalyst-monitor-dist-redirect.test.sh` | **38 / 0** |
| `gitleaks protect --staged` | no leaks |

Both high-value fixes are **mutation-verified**: reverting the whitespace fix fails 6 assertions; reverting the restart-notice hoist fails 3. Each file was restored byte-exact afterwards. The structural boot-ordering test added in round 2 caught round 3's deliberate reordering and forced the invariant to be restated rather than silently broken.

**On the whole-package suite, honestly:** the flat `bun test` **wedges on both this tree and a merge-base baseline** (pre-existing hang in `monitor.test.mjs`), so any "N failures" figure from a flat run — including ones quoted earlier in this PR's history — is unverified. A bounded per-file protocol was used instead across 229 (HEAD) / 228 (baseline) files: the same 12 files fail on both trees, and the 5 name-level diffs isolate to two files whose sources are byte-identical between the trees. No regressions attributable to this change.

## Scope and follow-ups

Deliberately **not** in this PR:

- **CTL-1615** — services start before any cluster-sync runs (`monitor → broker → execution-core`), so a host offline *during* a rotation still comes up stale. Fixing it is a stack-ordering change affecting every service, and it would add a pull + sops decrypt to the 600s keep-alive.
- **CTL-1614** — `catalyst-execution-core.test.sh` hangs (reproduced: exit 137 after 90s), which is why the new launcher tests live in a standalone suite.
- **Read-at-use redesign** — the external review argues the durable answer is `GH_CONFIG_DIR` + a cluster-sync-written `hosts.yml` with the env vars unset, so `gh` re-resolves per invocation natively (backed by systemd `LoadCredential`, Kubernetes projected volumes, and `client-go`'s re-read + reset-on-401). Compelling, and larger than a live-outage fix: on this fleet the claude supervisor's frozen env would still shadow `hosts.yml` until `.zshenv` is cleaned up and the supervisor restarted.
- **Silent 401s in worker bash** — ~24 `gh` invocations with no auth-retry and a dominant `2>/dev/null || true` idiom, so a dead credential reads as *"no PR exists"* and feeds phase logic that may then create a duplicate PR. Worth its own ticket.

Closes CTL-1612. Origin: `thoughts/shared/research/2026-08-02-ctc-228-stuck-analysis.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JLsp266CWSdxba83sDoDfp
