### PR TITLE
feat(dev): resolve-conflict-sweep — self-healing sibling-merge conflict resolution (#1461)

### DIFF
--- a/docs/adrs.md
+++ b/docs/adrs.md
@@ -767,8 +767,11 @@ proposed, cannot reach them without threading the in-flight gate itself.
    `countResolveConflictCycles` mirroring `countRecoveryPassCycles` — a standalone-sweep cap, not a
    `workflow.default.json` FSM-cycle entry, since this isn't a bidirectional FSM edge like
    verify⇄remediate. Cap exhausted → `stalledReason: resolve-conflict-cycle-cap-exhausted` (new),
-   escalation comment in the `🔼 **phase-resolve-conflict** escalated...` header convention (parsed by
-   `orch-monitor/lib/inbox-ask.mjs`).
+   escalation comment in the `🔼 **phase-resolve-conflict** escalated...` header convention (visual
+   style only — `orch-monitor/lib/inbox-ask.mjs`'s header regexes are hardcoded to the literal string
+   `recovery-pass`, so this does not parse into the structured inbox without a separate follow-up
+   generalizing those regexes; not attempted here given the file's own documented history of subtle
+   parsing regressions).
 
 Two small, targeted edits to shared files (not a redesign of either): `unstuck-sweep.mjs`'s
 `STALL_CATEGORY_MAP` gets a `source_conflict_resolvable → skip` entry so CTL-855's seam doesn't fight

--- a/docs/adrs.md
+++ b/docs/adrs.md
@@ -691,7 +691,7 @@ relying on them.
 `0.0.0.0` is a standing finding, currently contained only by the tailnet perimeter. Untickted as of
 this ADR.
 
-## ADR-028: Catalyst self-hosts its CAT backlog via a separate fork clone (CAT-52)
+## ADR-029: Catalyst self-hosts its CAT backlog via a separate fork clone (CAT-52)
 
 **Decision.** The CAT team is registered in `execution-core/registry.json`, allowing the fleet to
 work Catalyst's own self-healing findings. Its `repoRoot` is a **separate clone of the fork**
@@ -725,3 +725,68 @@ is still dispatched so a typo cannot silently stop fleet work. Nothing yet detec
 with Todo work that is wholly absent from the registry; that requires a workspace-wide Linear team
 sweep and remains outside CAT-52. The `coalesce-labs/catalyst` clone remains the CTL project and
 keeps its `CTL` Layer-1 declaration; it is not a valid CAT `repoRoot`.
+
+## ADR-028: Deterministic resolvable-conflict sweep (`phase-resolve-conflict`, #1461)
+
+**Proposed 2026-08-02.** Sibling-PR-merge source conflicts stall a ticket with `stalledReason:
+source_conflict_ctl708_unavailable` — written generically at dispatch-time pre-flight rebase, for
+whichever phase (implement/verify/review) was about to run. Two existing mechanisms only partially
+cover this. The CTL-855 `sourceConflictActSeam` (`unstuck-sweep`, ADR-024) force-pushes an
+already-clean branch past a stale flag but throws on any genuine conflict — it was never a resolver.
+`recovery-pass` (ADR-025, CTL-1176, shadow fleet-wide since 2026-08-01) tells its LLM to "resolve it
+yourself" ad hoc on rc=2 — no `classifyMergeTree` gate, no dedicated typed phase, no cycle cap,
+violating ADR-025's own guardrail ("DETERMINISTIC when stuck-type is typed and fix mechanical...
+LLM only with a structured brief + downstream deterministic re-check + hard cycle cap"). Separately,
+`isTicketInFlight` excludes any `stalled` ticket, so `deriveAdvancement`'s verify⇄remediate-style
+detour (CTL-653) never sees these tickets at all — a `deriveAdvancement` branch, as #1461 originally
+proposed, cannot reach them without threading the in-flight gate itself.
+
+**Decision** — a new dedicated tick-loop sweep, `resolve-conflict-sweep.mjs`, structurally mirroring
+`stall-janitor`/`unstuck-sweep` (ADR-024) and governed by ADR-023 (off/shadow/enforce, default
+`off`, every tick — candidates are rare and the classify step is cheap):
+
+1. Scan for phase signals `status:"stalled"`, `stalledReason:"source_conflict_ctl708_unavailable"`,
+   not already marked `source_conflict_resolvable`, under cap.
+2. Classify live: re-run `git merge-tree`, reuse the existing, untouched `classifyMergeTree` from
+   `stale-pr-rescue.mjs` (no reimplementation). Not resolvable → leave for the existing needs-human
+   surfacing (ADR-025 pt. 2). Resolvable → mark `source_conflict_resolvable` (new, non-colliding
+   reason) and dispatch.
+3. Dispatch through the standard `dispatch.mjs → phase-agent-dispatch` envelope (the one recovery-pass
+   already uses) to a new skill, `phase-resolve-conflict`, cloned from `phase-remediate`'s envelope but
+   reading a `resolve-conflict-brief.json` (mirrors `recovery-pass.json` v2 shape) instead of
+   `verify.json`. Rebases additively per the brief's conflict files/types, runs targeted gates,
+   commits, emits `phase.resolve-conflict.complete.<ticket>`.
+4. Once complete, the sweep — not the skill — mechanically clears the original phase's stalled
+   signal, mirroring `maybeResetForRemediateCycle`, dropping the ticket back into `isTicketInFlight`
+   so the ordinary dispatch loop redispatches the phase that stalled. **No `deriveAdvancement` /
+   `resolveReapPredecessor` changes needed**: because the stall reason is already written generically
+   at dispatch time for whichever phase is about to run, the sweep covers implement/verify/review
+   uniformly by construction — the three-predecessor generalization #1461 asked for turns out not to
+   require touching the FSM's predecessor logic at all.
+5. Capped via `RESOLVE_CONFLICT_CYCLE_CAP` (env override, default 3), event-counted via a new
+   `countResolveConflictCycles` mirroring `countRecoveryPassCycles` — a standalone-sweep cap, not a
+   `workflow.default.json` FSM-cycle entry, since this isn't a bidirectional FSM edge like
+   verify⇄remediate. Cap exhausted → `stalledReason: resolve-conflict-cycle-cap-exhausted` (new),
+   escalation comment in the `🔼 **phase-resolve-conflict** escalated...` header convention (parsed by
+   `orch-monitor/lib/inbox-ask.mjs`).
+
+Two small, targeted edits to shared files (not a redesign of either): `unstuck-sweep.mjs`'s
+`STALL_CATEGORY_MAP` gets a `source_conflict_resolvable → skip` entry so CTL-855's seam doesn't fight
+over a ticket this sweep already owns; the terminal-label sweep (`scheduler.mjs`) exempts
+`source_conflict_resolvable` from immediate `needs-human` labeling, so a ticket isn't flagged
+needs-human on the same tick the fix is already in flight.
+
+**Rationale** — matches ADR-025's own deterministic-vs-flexible boundary better than the status quo
+(recovery-pass currently freelances this without the structured-brief/cycle-cap/deterministic-recheck
+guardrail its own ADR requires); reuses `classifyMergeTree` and the standard phase-agent-dispatch
+envelope rather than inventing new conflict-classification or dispatch machinery; sidesteps the
+in-flight gate rather than widening it, per #1461's own scoping comment
+(`#1461#issuecomment-5155144010`).
+
+**Consequences** — `recovery-pass/SKILL.md`'s "resolve it yourself" instruction for rc=2 should
+eventually defer to this sweep's typed path instead of ad hoc LLM resolution; noted here as a
+follow-up, not blocking, since recovery-pass ships shadow-only today and this sweep ships
+independently at `off`. **Rejected**: widening CTL-855's `sourceConflictActSeam` into a real resolver
+(solves a structurally narrower problem — force-push-past-staleness, not merge-conflict resolution);
+a `deriveAdvancement` detour as #1461 originally described (unreachable — stalled tickets are excluded
+from `isTicketInFlight` before `deriveAdvancement` ever runs).

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -332,7 +332,7 @@ CTL-707 replaced the binary CTL-667 rebase with a 4-layer strategy:
   `stalled`/`source_conflict_ctl708_unavailable` (see below, no longer a dead end); thoughts conflict
   (rc=3) → park on all phases.
 - **`resolve-conflict-sweep` (#1461, ADR-028)** — a tick-loop sweep (`execution-core/resolve-conflict-
-  sweep.mjs`, off/shadow/enforce, default off) that scans DIRECTLY for `source_conflict_ctl708_unavailable`
+  sweep.mjs`, off/shadow/enforce, default off, env `CATALYST_RESOLVE_CONFLICT_SWEEP`) that scans DIRECTLY for `source_conflict_ctl708_unavailable`
   stalls (bypassing the in-flight gate `deriveAdvancement` uses, since a stalled ticket is excluded from
   it), classifies resolvability live via the existing `classifyMergeTree` (`stale-pr-rescue.mjs`), and
   dispatches `phase-resolve-conflict` (cloned from `phase-remediate`'s envelope) through the standard

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -329,7 +329,17 @@ CTL-707 replaced the binary CTL-667 rebase with a 4-layer strategy:
   stall rc=3; real source → CTL-708 stub (always unavailable) → stall rc=2.
 - **L3 — Phase-aware fallback** (`phase-agent-dispatch`): terminal source conflict (rc=2) on
   `research`/`plan` → destroy+recreate worktree fresh; same on `implement`/`verify`/`review` → park
-  `needs-human`; thoughts conflict (rc=3) → park on all phases.
+  `stalled`/`source_conflict_ctl708_unavailable` (see below, no longer a dead end); thoughts conflict
+  (rc=3) → park on all phases.
+- **`resolve-conflict-sweep` (#1461, ADR-028)** — a tick-loop sweep (`execution-core/resolve-conflict-
+  sweep.mjs`, off/shadow/enforce, default off) that scans DIRECTLY for `source_conflict_ctl708_unavailable`
+  stalls (bypassing the in-flight gate `deriveAdvancement` uses, since a stalled ticket is excluded from
+  it), classifies resolvability live via the existing `classifyMergeTree` (`stale-pr-rescue.mjs`), and
+  dispatches `phase-resolve-conflict` (cloned from `phase-remediate`'s envelope) through the standard
+  `dispatch.mjs → phase-agent-dispatch` path for a RESOLVABLE conflict — capped at
+  `RESOLVE_CONFLICT_CYCLE_CAP` (default 3, env `CATALYST_RESOLVE_CONFLICT_CYCLE_CAP`), escalating to
+  `needs-human` past the cap exactly like the verify⇄remediate cycle already does. An UNRESOLVABLE
+  conflict is left for the existing needs-human surfacing, unchanged.
 - **L4 — Telemetry** (`lib/rebase-telemetry.sh`):
 
 | Event                                                | Severity | Emitter                  |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -78,7 +78,7 @@ per-orchestrator local state in worktrees stays the source of truth for crash re
   seam (swappable to a hosted table without touching callers). Each entry's `team` must match its
   `repoRoot`'s Layer-1 `catalyst.linear.teamKey`; `listProjects()` warns on a mismatch and
   `catalyst doctor` grades it with the advisory `registry-team-identity` check. Catalyst's own CAT
-  registration is recorded in ADR-028.
+  registration is recorded in ADR-029.
 - **Heartbeat** — orchestrators write `lastHeartbeat` every 2–3 min; entries stale >10 min are GC'd
   as `abandoned`.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -466,7 +466,7 @@ means "unknown", deliberately distinct from `false` ("mismatch"). `listProjects(
 mismatch and `checkRegistryTeamIdentity()` in `doctor.mjs` grades it (WARN mismatch / INFO
 unverified / PASS all-verified, never FAIL).
 
-See ADR-028 for Catalyst's own CAT registration.
+See ADR-029 for Catalyst's own CAT registration.
 
 ---
 

--- a/plugins/dev/scripts/__tests__/orchestrate-revive-phase.test.sh
+++ b/plugins/dev/scripts/__tests__/orchestrate-revive-phase.test.sh
@@ -413,6 +413,38 @@ PSNC=$(jq -r '.phaseSkippedNonCurrent' "$OUT_JSON")
   || fail "phaseSkippedNonCurrent == 1 (predecessor)" "got '$PSNC' summary: $(cat "$OUT_JSON")"
 scratch_teardown
 
+# ─── Test I (#1461 follow-up): phase-resolve-conflict.json is never reachable
+# by the CTL-607 current-phase guard, but the ORIGINAL stalled phase's reused
+# RESOLVED_MARKER_REASON in .failureReason IS read by phase_is_truly_failed as
+# a genuine failure and escalated — not redispatched, not a silent no-op.
+echo "test I (#1461): resolve-conflict marker interaction with orchestrate-revive"
+scratch_setup
+WORKTREE_BASE="${SCRATCH}/worktrees"
+set_repo_root_for_revive
+make_per_phase_signal "T-RC" "implement" "stalled" '.failureReason = "source_conflict_resolvable"'
+make_per_phase_signal "T-RC" "resolve-conflict" "stalled" '.attentionReason = "sdk-backstop"'
+run_revive
+if grep -q "dispatch-called.*--phase resolve-conflict.*T-RC" "$DISPATCH_LOG"; then
+  fail "resolve-conflict phase must NEVER be dispatched by orchestrate-revive" "log: $(cat "$DISPATCH_LOG")"
+else
+  pass "resolve-conflict phase never dispatched (CTL-607 excludes it structurally)"
+fi
+PSNC=$(jq -r '.phaseSkippedNonCurrent' "$OUT_JSON")
+[ "$PSNC" = "1" ] \
+  && pass "phaseSkippedNonCurrent == 1 (resolve-conflict skipped as non-current)" \
+  || fail "phaseSkippedNonCurrent == 1" "got '$PSNC' summary: $(cat "$OUT_JSON")"
+if grep -q "phase-failed-unrecoverable.*T-RC" "$STATE_LOG"; then
+  pass "documented: RESOLVED_MARKER_REASON on the original phase reads as truly-failed and escalates"
+else
+  fail "expected an escalate call for T-RC/implement (RESOLVED_MARKER_REASON read as truly-failed)" "state log: $(cat "$STATE_LOG")"
+fi
+if grep -q "dispatch-called.*--phase implement.*T-RC" "$DISPATCH_LOG"; then
+  fail "implement must NOT be redispatched (it escalates instead, per phase_is_truly_failed)" "log: $(cat "$DISPATCH_LOG")"
+else
+  pass "implement not redispatched — escalated instead"
+fi
+scratch_teardown
+
 echo ""
 echo "─────────────────────────────────────────────"
 echo "Results: ${PASSES} pass, ${FAILURES} fail"

--- a/plugins/dev/scripts/__tests__/phase-agent-dispatch.test.sh
+++ b/plugins/dev/scripts/__tests__/phase-agent-dispatch.test.sh
@@ -2507,6 +2507,37 @@ assert_eq "no" "$LAUNCHED74B" "74: the racing twin launched NO second worker (no
 assert_eq "$CLAIMS_BEFORE74" "$CLAIMS_AFTER74" "74: the twin won no additional generation (claim count unchanged)"
 
 echo ""
+echo "Test 71 (#1461): resolve-conflict dispatches with turnCap 40 + resolve-conflict-brief.json prior gate"
+fresh_env t71_resolve_conflict
+# resolve-conflict's prior artifact is resolve-conflict-brief.json (the
+# classification + which-phase-stalled envelope resolve-conflict-sweep.mjs
+# writes before dispatch) — create it so the gate passes.
+printf '%s\n' '{"schema":"resolve-conflict-brief/v1","stalledPhase":"implement","conflictFiles":["a.ts"],"conflictTypes":["content"],"base":"main","attempt":1,"maxAttempts":3}' \
+	>"${WORKER_DIR}/resolve-conflict-brief.json"
+"$DISPATCH" --phase resolve-conflict --ticket CTL-100 --orch-dir "$ORCH_DIR" --orch-id orch-test >/dev/null 2>&1
+SIGNAL_RC="${WORKER_DIR}/phase-resolve-conflict.json"
+if [[ ! -f $SIGNAL_RC ]]; then
+	fail "resolve-conflict signal file created: $SIGNAL_RC"
+else
+	pass "resolve-conflict signal file created"
+	assert_eq "resolve-conflict" "$(jq -r '.phase' "$SIGNAL_RC")" "signal.phase = resolve-conflict"
+	assert_eq "40" "$(jq -r '.turnCap' "$SIGNAL_RC")" "signal.turnCap = 40 (resolve-conflict, fix-scoped like remediate)"
+fi
+
+echo ""
+echo "Test 72 (#1461): resolve-conflict refuses when resolve-conflict-brief.json (prior artifact) is missing"
+fresh_env t72_resolve_conflict
+# No resolve-conflict-brief.json → the prior-artifact gate must refuse (exit 2, no signal).
+"$DISPATCH" --phase resolve-conflict --ticket CTL-100 --orch-dir "$ORCH_DIR" --orch-id orch-test \
+	>"${TEST_DIR}/rc.out" 2>/dev/null
+RC_RC=$?
+assert_eq "2" "$RC_RC" "exit code 2 when resolve-conflict's resolve-conflict-brief.json is missing"
+assert_eq "refused" "$(jq -r '.status' "${TEST_DIR}/rc.out" 2>/dev/null || echo "")" \
+	"resolve-conflict stdout JSON status = refused"
+[[ -f "${WORKER_DIR}/phase-resolve-conflict.json" ]] && SIG_RC_EXISTS="yes" || SIG_RC_EXISTS="no"
+assert_eq "no" "$SIG_RC_EXISTS" "no phase-resolve-conflict.json signal written on refusal"
+
+echo ""
 echo "─────────────────────────────────────────────"
 echo "phase-agent-dispatch: ${PASSES} passed, ${FAILURES} failed"
 if [[ $FAILURES -gt 0 ]]; then

--- a/plugins/dev/scripts/__tests__/phase-goal-no-turn-caps.test.sh
+++ b/plugins/dev/scripts/__tests__/phase-goal-no-turn-caps.test.sh
@@ -20,6 +20,7 @@ SKILLS=(
   "plugins/dev/skills/phase-monitor-merge/SKILL.md"
   "plugins/dev/skills/phase-remediate/SKILL.md"
   "plugins/dev/skills/recovery-pass/SKILL.md"
+  "plugins/dev/skills/phase-resolve-conflict/SKILL.md"
 )
 
 FAILURES=0; PASSES=0

--- a/plugins/dev/scripts/__tests__/phase-mirror-footer.test.sh
+++ b/plugins/dev/scripts/__tests__/phase-mirror-footer.test.sh
@@ -144,7 +144,7 @@ assert_grep 'session uuid `feedface-1111-2222-3333-444455556666`' "$OUT4" "uuid 
 echo ""
 echo "Test 5: all 9 phase mirror skills reference phase-mirror-footer.sh"
 SKILLS_DIR="${REPO_ROOT}/plugins/dev/skills"
-for phase in research plan implement verify remediate review triage pr monitor-merge; do
+for phase in research plan implement verify remediate review triage pr monitor-merge resolve-conflict; do
   skill="${SKILLS_DIR}/phase-${phase}/SKILL.md"
   if [[ -f "$skill" ]] && grep -q 'phase-mirror-footer\.sh' "$skill"; then
     pass "phase-${phase} wires the footer helper"

--- a/plugins/dev/scripts/execution-core/config.mjs
+++ b/plugins/dev/scripts/execution-core/config.mjs
@@ -1975,6 +1975,24 @@ export function readRecoveryPassConfig(envObj = process.env) {
   return { mode };
 }
 
+// #1461: resolve-conflict-sweep mode reader. Mirrors readRecoveryPassConfig
+// exactly: env (CATALYST_RESOLVE_CONFLICT_SWEEP) is the single operator knob,
+// default 'off' (ADR-023) — operators opt in to shadow then enforce.
+const RESOLVE_CONFLICT_SWEEP_MODES = new Set(["off", "shadow", "enforce"]);
+
+export function readResolveConflictSweepConfig(envObj = process.env) {
+  const env = envObj.CATALYST_RESOLVE_CONFLICT_SWEEP;
+  let mode;
+  if (env === "0") {
+    mode = "off";
+  } else if (typeof env === "string" && RESOLVE_CONFLICT_SWEEP_MODES.has(env)) {
+    mode = env;
+  } else {
+    mode = "off"; // safe default: off — operators opt into shadow then enforce
+  }
+  return { mode };
+}
+
 // CTL-1245: dead-but-running doc-worker reclaim mode reader. Mirrors
 // readRecoveryPassConfig / readUnstuckSweepConfig exactly: env
 // (CATALYST_DEAD_DOC_WORKER_RECLAIM) overrides Layer-2 config
@@ -2128,24 +2146,6 @@ export function readCoordinationConfig(env = process.env) {
         ? l2.hubUrl
         : null;
   return { mode, hubUrl };
-}
-
-// #1461: resolve-conflict-sweep mode reader. Mirrors readRecoveryPassConfig
-// exactly: env (CATALYST_RESOLVE_CONFLICT_SWEEP) is the single operator knob,
-// default 'off' (ADR-023) — operators opt in to shadow then enforce.
-const RESOLVE_CONFLICT_SWEEP_MODES = new Set(["off", "shadow", "enforce"]);
-
-export function readResolveConflictSweepConfig(envObj = process.env) {
-  const env = envObj.CATALYST_RESOLVE_CONFLICT_SWEEP;
-  let mode;
-  if (env === "0") {
-    mode = "off";
-  } else if (typeof env === "string" && RESOLVE_CONFLICT_SWEEP_MODES.has(env)) {
-    mode = env;
-  } else {
-    mode = "off"; // safe default: off — operators opt into shadow then enforce
-  }
-  return { mode };
 }
 
 // CTL-1488: the local-first coordination mirror. coordination-publish writes the

--- a/plugins/dev/scripts/execution-core/config.mjs
+++ b/plugins/dev/scripts/execution-core/config.mjs
@@ -2130,6 +2130,24 @@ export function readCoordinationConfig(env = process.env) {
   return { mode, hubUrl };
 }
 
+// #1461: resolve-conflict-sweep mode reader. Mirrors readRecoveryPassConfig
+// exactly: env (CATALYST_RESOLVE_CONFLICT_SWEEP) is the single operator knob,
+// default 'off' (ADR-023) — operators opt in to shadow then enforce.
+const RESOLVE_CONFLICT_SWEEP_MODES = new Set(["off", "shadow", "enforce"]);
+
+export function readResolveConflictSweepConfig(envObj = process.env) {
+  const env = envObj.CATALYST_RESOLVE_CONFLICT_SWEEP;
+  let mode;
+  if (env === "0") {
+    mode = "off";
+  } else if (typeof env === "string" && RESOLVE_CONFLICT_SWEEP_MODES.has(env)) {
+    mode = env;
+  } else {
+    mode = "off"; // safe default: off — operators opt into shadow then enforce
+  }
+  return { mode };
+}
+
 // CTL-1488: the local-first coordination mirror. coordination-publish writes the
 // ordered coordination subset here (with local_seq) synchronously before any
 // network call; the inbound mirror-tail client merges other hosts' rows in.

--- a/plugins/dev/scripts/execution-core/config.test.mjs
+++ b/plugins/dev/scripts/execution-core/config.test.mjs
@@ -68,6 +68,7 @@ import {
   getLayer2ConfigPath,
   log,
   readGovernanceSources,
+  readResolveConflictSweepConfig,
 } from "./config.mjs";
 
 const PREV = process.env.CATALYST_WAIT_WATCHER;
@@ -1800,5 +1801,33 @@ describe("getFleetHealthDir (CTL-1503)", () => {
     const dir = getFleetHealthDir();
     expect(dir).toContain("execution-core");
     expect(dir.endsWith("fleet-health")).toBe(true);
+  });
+});
+
+describe("readResolveConflictSweepConfig", () => {
+  const ORIGINAL_ENV = { ...process.env };
+  afterEach(() => {
+    process.env = { ...ORIGINAL_ENV };
+  });
+
+  test("defaults to off", () => {
+    delete process.env.CATALYST_RESOLVE_CONFLICT_SWEEP;
+    expect(readResolveConflictSweepConfig({})).toEqual({ mode: "off" });
+  });
+
+  test("env CATALYST_RESOLVE_CONFLICT_SWEEP=shadow overrides default", () => {
+    expect(readResolveConflictSweepConfig({ CATALYST_RESOLVE_CONFLICT_SWEEP: "shadow" })).toEqual({ mode: "shadow" });
+  });
+
+  test("env CATALYST_RESOLVE_CONFLICT_SWEEP=enforce overrides default", () => {
+    expect(readResolveConflictSweepConfig({ CATALYST_RESOLVE_CONFLICT_SWEEP: "enforce" })).toEqual({ mode: "enforce" });
+  });
+
+  test("env '0' is the off kill-switch", () => {
+    expect(readResolveConflictSweepConfig({ CATALYST_RESOLVE_CONFLICT_SWEEP: "0" })).toEqual({ mode: "off" });
+  });
+
+  test("an unrecognized env value falls back to off (safe default)", () => {
+    expect(readResolveConflictSweepConfig({ CATALYST_RESOLVE_CONFLICT_SWEEP: "bogus" })).toEqual({ mode: "off" });
   });
 });

--- a/plugins/dev/scripts/execution-core/config.test.mjs
+++ b/plugins/dev/scripts/execution-core/config.test.mjs
@@ -1572,6 +1572,34 @@ describe("readCoordinationConfig (CTL-1488)", () => {
   });
 });
 
+describe("readResolveConflictSweepConfig", () => {
+  const ORIGINAL_ENV = { ...process.env };
+  afterEach(() => {
+    process.env = { ...ORIGINAL_ENV };
+  });
+
+  test("defaults to off", () => {
+    delete process.env.CATALYST_RESOLVE_CONFLICT_SWEEP;
+    expect(readResolveConflictSweepConfig({})).toEqual({ mode: "off" });
+  });
+
+  test("env CATALYST_RESOLVE_CONFLICT_SWEEP=shadow overrides default", () => {
+    expect(readResolveConflictSweepConfig({ CATALYST_RESOLVE_CONFLICT_SWEEP: "shadow" })).toEqual({ mode: "shadow" });
+  });
+
+  test("env CATALYST_RESOLVE_CONFLICT_SWEEP=enforce overrides default", () => {
+    expect(readResolveConflictSweepConfig({ CATALYST_RESOLVE_CONFLICT_SWEEP: "enforce" })).toEqual({ mode: "enforce" });
+  });
+
+  test("env '0' is the off kill-switch", () => {
+    expect(readResolveConflictSweepConfig({ CATALYST_RESOLVE_CONFLICT_SWEEP: "0" })).toEqual({ mode: "off" });
+  });
+
+  test("an unrecognized env value falls back to off (safe default)", () => {
+    expect(readResolveConflictSweepConfig({ CATALYST_RESOLVE_CONFLICT_SWEEP: "bogus" })).toEqual({ mode: "off" });
+  });
+});
+
 describe("readLinearReplica (CTL-1340)", () => {
   const LR_ENVS = ["CATALYST_LINEAR_REPLICA", "CATALYST_LAYER2_CONFIG_FILE"];
   let saved = {}, tmp;
@@ -1801,33 +1829,5 @@ describe("getFleetHealthDir (CTL-1503)", () => {
     const dir = getFleetHealthDir();
     expect(dir).toContain("execution-core");
     expect(dir.endsWith("fleet-health")).toBe(true);
-  });
-});
-
-describe("readResolveConflictSweepConfig", () => {
-  const ORIGINAL_ENV = { ...process.env };
-  afterEach(() => {
-    process.env = { ...ORIGINAL_ENV };
-  });
-
-  test("defaults to off", () => {
-    delete process.env.CATALYST_RESOLVE_CONFLICT_SWEEP;
-    expect(readResolveConflictSweepConfig({})).toEqual({ mode: "off" });
-  });
-
-  test("env CATALYST_RESOLVE_CONFLICT_SWEEP=shadow overrides default", () => {
-    expect(readResolveConflictSweepConfig({ CATALYST_RESOLVE_CONFLICT_SWEEP: "shadow" })).toEqual({ mode: "shadow" });
-  });
-
-  test("env CATALYST_RESOLVE_CONFLICT_SWEEP=enforce overrides default", () => {
-    expect(readResolveConflictSweepConfig({ CATALYST_RESOLVE_CONFLICT_SWEEP: "enforce" })).toEqual({ mode: "enforce" });
-  });
-
-  test("env '0' is the off kill-switch", () => {
-    expect(readResolveConflictSweepConfig({ CATALYST_RESOLVE_CONFLICT_SWEEP: "0" })).toEqual({ mode: "off" });
-  });
-
-  test("an unrecognized env value falls back to off (safe default)", () => {
-    expect(readResolveConflictSweepConfig({ CATALYST_RESOLVE_CONFLICT_SWEEP: "bogus" })).toEqual({ mode: "off" });
   });
 });

--- a/plugins/dev/scripts/execution-core/event-scan.mjs
+++ b/plugins/dev/scripts/execution-core/event-scan.mjs
@@ -50,6 +50,12 @@ const REMEDIATE_NAME_PREFIX = "phase.remediate.complete.";
 // one phase.recovery-pass.complete.<ticket> event. Durable (survives signal
 // resets), so the cap holds across ticks/restarts.
 const RECOVERY_PASS_NAME_PREFIX = "phase.recovery-pass.complete.";
+// CTL-1176-adjacent, #1461: the resolve-conflict-sweep dispatch budget, event-
+// counted exactly like countRemediateCycles/countRecoveryPassCycles. One
+// completed resolve-conflict run == one phase.resolve-conflict.complete.<ticket>
+// event. Durable (survives the stalled-signal clear), so the cap holds across
+// ticks/restarts.
+const RESOLVE_CONFLICT_NAME_PREFIX = "phase.resolve-conflict.complete.";
 
 // CTL-802 — countTicketEventsInWindow (the CTL-671 runaway detector) used to scan
 // the WHOLE log from offset 0 on every call — and it is called once per in-flight
@@ -86,7 +92,10 @@ const _index = new Map(); // path -> { cursor, leftover, events: [...], phaseEve
 function isRelevant(name) {
   return (
     typeof name === "string" &&
-    (REVIVE_NAME_RE.test(name) || name.startsWith(REMEDIATE_NAME_PREFIX) || COMPLETE_NAME_RE.test(name))
+    (REVIVE_NAME_RE.test(name) ||
+      name.startsWith(REMEDIATE_NAME_PREFIX) ||
+      name.startsWith(RESOLVE_CONFLICT_NAME_PREFIX) ||
+      COMPLETE_NAME_RE.test(name))
   );
 }
 
@@ -211,6 +220,14 @@ export function countRemediateCycles({ ticket, orchId, since, path = getEventLog
 export function countRecoveryPassCycles({ ticket, orchId, since, path = getEventLogPath() } = {}) {
   if (!ticket) throw new Error("countRecoveryPassCycles: ticket required");
   return countByExactName(`${RECOVERY_PASS_NAME_PREFIX}${ticket}`, { orchId, since, path });
+}
+
+// countResolveConflictCycles — number of phase.resolve-conflict.complete.<ticket>
+// envelopes (#1461). The event-counted resolve-conflict-sweep dispatch budget,
+// mirroring countRemediateCycles/countRecoveryPassCycles exactly.
+export function countResolveConflictCycles({ ticket, orchId, since, path = getEventLogPath() } = {}) {
+  if (!ticket) throw new Error("countResolveConflictCycles: ticket required");
+  return countByExactName(`${RESOLVE_CONFLICT_NAME_PREFIX}${ticket}`, { orchId, since, path });
 }
 
 // countDistinctRevivingTickets — unique tickets that have any revive event

--- a/plugins/dev/scripts/execution-core/event-scan.mjs
+++ b/plugins/dev/scripts/execution-core/event-scan.mjs
@@ -66,6 +66,16 @@ const RESOLVE_CONFLICT_NAME_PREFIX = "phase.resolve-conflict.complete.";
 // repeated failures eventually reach RESOLVE_CONFLICT_CYCLE_CAP and escalate,
 // exactly like a repeated cycle would.
 const RESOLVE_CONFLICT_FAILED_PREFIX = "phase.resolve-conflict.failed.";
+// Escalation-gap fix (#1461 review follow-up): a resolve-conflict dispatch that
+// hits its maxTurns cutoff lands in a THIRD terminal shape distinct from both
+// "done" and "failed" — defaultEmitBackstop (sdk-run-phase-agent.mjs) emits
+// phase.resolve-conflict.turn-cap-exhausted.<ticket> (not .failed.) to keep the
+// event name matching the on-disk status:"turn-cap-exhausted" it also writes.
+// Without this prefix, isRelevant (below) never retained the event at all, so
+// countResolveConflictAttempts silently undercounted this specific failure
+// shape — the durable cap counter never climbed for it, no matter how many
+// times it recurred.
+const RESOLVE_CONFLICT_TURN_CAP_PREFIX = "phase.resolve-conflict.turn-cap-exhausted.";
 
 // CTL-802 — countTicketEventsInWindow (the CTL-671 runaway detector) used to scan
 // the WHOLE log from offset 0 on every call — and it is called once per in-flight
@@ -106,6 +116,7 @@ function isRelevant(name) {
       name.startsWith(REMEDIATE_NAME_PREFIX) ||
       name.startsWith(RESOLVE_CONFLICT_NAME_PREFIX) ||
       name.startsWith(RESOLVE_CONFLICT_FAILED_PREFIX) ||
+      name.startsWith(RESOLVE_CONFLICT_TURN_CAP_PREFIX) ||
       COMPLETE_NAME_RE.test(name))
   );
 }
@@ -243,19 +254,25 @@ export function countResolveConflictCycles({ ticket, orchId, since, path = getEv
 
 // countResolveConflictAttempts — #1461 Fix 2 (final-review finding): number of
 // phase.resolve-conflict.complete.<ticket> PLUS phase.resolve-conflict.failed.
-// <ticket> envelopes — every DISPATCH ATTEMPT, not just successful completions.
-// countResolveConflictCycles (above) is completion-only, which let a
-// repeatedly-FAILING resolve-conflict run never spend cap budget: the marker
-// (RESOLVED_MARKER_REASON) stuck around forever with cycleCount pinned at 0.
-// This is the counter the resolve-conflict-sweep wiring feeds into
-// classifyResolveConflictCandidate's cycleCount so a failed run counts toward
-// RESOLVE_CONFLICT_CYCLE_CAP exactly like a completed one, and repeated
-// failures eventually route through the SAME cap-exhaustion escalate path.
+// <ticket> PLUS phase.resolve-conflict.turn-cap-exhausted.<ticket> envelopes —
+// every DISPATCH ATTEMPT, not just successful completions. The turn-cap-exhausted
+// term was added by the escalation-gap review follow-up (#1461): a maxTurns
+// cutoff is a THIRD terminal shape distinct from both "done" and "failed" (see
+// RESOLVE_CONFLICT_TURN_CAP_PREFIX above), and was previously invisible to this
+// counter entirely (not even matched by isRelevant, so it never entered the
+// retained index at all). countResolveConflictCycles (above) is completion-only,
+// which let a repeatedly-FAILING resolve-conflict run never spend cap budget:
+// the marker (RESOLVED_MARKER_REASON) stuck around forever with cycleCount
+// pinned at 0. This is the counter the resolve-conflict-sweep wiring feeds into
+// classifyResolveConflictCandidate's cycleCount so a failed OR turn-cap-exhausted
+// run counts toward RESOLVE_CONFLICT_CYCLE_CAP exactly like a completed one, and
+// repeated failures eventually route through the SAME cap-exhaustion escalate path.
 export function countResolveConflictAttempts({ ticket, orchId, since, path = getEventLogPath() } = {}) {
   if (!ticket) throw new Error("countResolveConflictAttempts: ticket required");
   return (
     countByExactName(`${RESOLVE_CONFLICT_NAME_PREFIX}${ticket}`, { orchId, since, path }) +
-    countByExactName(`${RESOLVE_CONFLICT_FAILED_PREFIX}${ticket}`, { orchId, since, path })
+    countByExactName(`${RESOLVE_CONFLICT_FAILED_PREFIX}${ticket}`, { orchId, since, path }) +
+    countByExactName(`${RESOLVE_CONFLICT_TURN_CAP_PREFIX}${ticket}`, { orchId, since, path })
   );
 }
 

--- a/plugins/dev/scripts/execution-core/event-scan.mjs
+++ b/plugins/dev/scripts/execution-core/event-scan.mjs
@@ -56,6 +56,16 @@ const RECOVERY_PASS_NAME_PREFIX = "phase.recovery-pass.complete.";
 // event. Durable (survives the stalled-signal clear), so the cap holds across
 // ticks/restarts.
 const RESOLVE_CONFLICT_NAME_PREFIX = "phase.resolve-conflict.complete.";
+// #1461 Fix 2 (final-review finding): a resolve-conflict run that FAILS (the
+// skill's documented hard-error path, `phase.resolve-conflict.failed.<ticket>`)
+// never incremented the cap counter under the complete-only prefix above —
+// countResolveConflictCycles counts successes only, so a failed/never-completing
+// run left the ticket marked RESOLVED_MARKER_REASON forever with no path to the
+// cap-exhaustion escalate route (permanently invisible to every operator
+// surface). countResolveConflictAttempts (below) counts BOTH prefixes so
+// repeated failures eventually reach RESOLVE_CONFLICT_CYCLE_CAP and escalate,
+// exactly like a repeated cycle would.
+const RESOLVE_CONFLICT_FAILED_PREFIX = "phase.resolve-conflict.failed.";
 
 // CTL-802 — countTicketEventsInWindow (the CTL-671 runaway detector) used to scan
 // the WHOLE log from offset 0 on every call — and it is called once per in-flight
@@ -95,6 +105,7 @@ function isRelevant(name) {
     (REVIVE_NAME_RE.test(name) ||
       name.startsWith(REMEDIATE_NAME_PREFIX) ||
       name.startsWith(RESOLVE_CONFLICT_NAME_PREFIX) ||
+      name.startsWith(RESOLVE_CONFLICT_FAILED_PREFIX) ||
       COMPLETE_NAME_RE.test(name))
   );
 }
@@ -228,6 +239,24 @@ export function countRecoveryPassCycles({ ticket, orchId, since, path = getEvent
 export function countResolveConflictCycles({ ticket, orchId, since, path = getEventLogPath() } = {}) {
   if (!ticket) throw new Error("countResolveConflictCycles: ticket required");
   return countByExactName(`${RESOLVE_CONFLICT_NAME_PREFIX}${ticket}`, { orchId, since, path });
+}
+
+// countResolveConflictAttempts — #1461 Fix 2 (final-review finding): number of
+// phase.resolve-conflict.complete.<ticket> PLUS phase.resolve-conflict.failed.
+// <ticket> envelopes — every DISPATCH ATTEMPT, not just successful completions.
+// countResolveConflictCycles (above) is completion-only, which let a
+// repeatedly-FAILING resolve-conflict run never spend cap budget: the marker
+// (RESOLVED_MARKER_REASON) stuck around forever with cycleCount pinned at 0.
+// This is the counter the resolve-conflict-sweep wiring feeds into
+// classifyResolveConflictCandidate's cycleCount so a failed run counts toward
+// RESOLVE_CONFLICT_CYCLE_CAP exactly like a completed one, and repeated
+// failures eventually route through the SAME cap-exhaustion escalate path.
+export function countResolveConflictAttempts({ ticket, orchId, since, path = getEventLogPath() } = {}) {
+  if (!ticket) throw new Error("countResolveConflictAttempts: ticket required");
+  return (
+    countByExactName(`${RESOLVE_CONFLICT_NAME_PREFIX}${ticket}`, { orchId, since, path }) +
+    countByExactName(`${RESOLVE_CONFLICT_FAILED_PREFIX}${ticket}`, { orchId, since, path })
+  );
 }
 
 // countDistinctRevivingTickets — unique tickets that have any revive event

--- a/plugins/dev/scripts/execution-core/event-scan.test.mjs
+++ b/plugins/dev/scripts/execution-core/event-scan.test.mjs
@@ -9,7 +9,7 @@
 // Run: cd plugins/dev/scripts/execution-core && bun test event-scan.test.mjs
 
 import { describe, test, expect, beforeEach } from "bun:test";
-import { writeFileSync, appendFileSync, mkdtempSync } from "node:fs";
+import { writeFileSync, appendFileSync, mkdtempSync, unlinkSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import {
@@ -17,6 +17,7 @@ import {
   countDistinctRevivingTickets,
   countRemediateCycles,
   countRecoveryPassCycles,
+  countResolveConflictCycles,
   hasCompleteEvent,
   latestCompleteEventTs,
   latestCompleteEventAttempt,
@@ -267,6 +268,41 @@ describe("CTL-1176: countRecoveryPassCycles", () => {
 
   test("throws without ticket", () => {
     expect(() => countRecoveryPassCycles({})).toThrow();
+  });
+});
+
+describe("countResolveConflictCycles", () => {
+  const path = "/tmp/resolve-conflict-cycles-test.jsonl";
+
+  beforeEach(() => {
+    __resetEventScanIndexForTest();
+    try { unlinkSync(path); } catch {}
+  });
+
+  test("counts phase.resolve-conflict.complete.<ticket> envelopes", () => {
+    writeFileSync(
+      path,
+      [
+        JSON.stringify({ ts: "2026-08-02T00:00:00Z", attributes: { "event.name": "phase.resolve-conflict.complete.CTL-1" } }),
+        JSON.stringify({ ts: "2026-08-02T00:01:00Z", attributes: { "event.name": "phase.resolve-conflict.complete.CTL-1" } }),
+        JSON.stringify({ ts: "2026-08-02T00:02:00Z", attributes: { "event.name": "phase.resolve-conflict.complete.CTL-2" } }),
+      ].join("\n") + "\n",
+    );
+    expect(countResolveConflictCycles({ ticket: "CTL-1", path })).toBe(2);
+    expect(countResolveConflictCycles({ ticket: "CTL-2", path })).toBe(1);
+    expect(countResolveConflictCycles({ ticket: "CTL-9", path })).toBe(0);
+  });
+
+  test("does not match a suffix-only ticket (CTL-1 vs CTL-10)", () => {
+    writeFileSync(
+      path,
+      JSON.stringify({ ts: "2026-08-02T00:00:00Z", attributes: { "event.name": "phase.resolve-conflict.complete.CTL-10" } }) + "\n",
+    );
+    expect(countResolveConflictCycles({ ticket: "CTL-1", path })).toBe(0);
+  });
+
+  test("throws without a ticket", () => {
+    expect(() => countResolveConflictCycles({ path })).toThrow("countResolveConflictCycles: ticket required");
   });
 });
 

--- a/plugins/dev/scripts/execution-core/event-scan.test.mjs
+++ b/plugins/dev/scripts/execution-core/event-scan.test.mjs
@@ -359,6 +359,23 @@ describe("countResolveConflictAttempts", () => {
     expect(countResolveConflictAttempts({ ticket: "CTL-1", path })).toBe(0);
   });
 
+  // Escalation-gap fix (#1461 review follow-up): a maxTurns cutoff is a THIRD
+  // terminal shape — defaultEmitBackstop emits phase.resolve-conflict.
+  // turn-cap-exhausted.<ticket> (not .failed.) to match the on-disk
+  // status:"turn-cap-exhausted" it also writes. Before this fix, isRelevant
+  // never even retained this event name, so it was invisible to every counter.
+  test("counts phase.resolve-conflict.turn-cap-exhausted.<ticket> envelopes too", () => {
+    writeFileSync(
+      path,
+      [
+        JSON.stringify({ ts: "2026-08-02T00:00:00Z", attributes: { "event.name": "phase.resolve-conflict.turn-cap-exhausted.CTL-1" } }),
+        JSON.stringify({ ts: "2026-08-02T00:01:00Z", attributes: { "event.name": "phase.resolve-conflict.failed.CTL-1" } }),
+        JSON.stringify({ ts: "2026-08-02T00:02:00Z", attributes: { "event.name": "phase.resolve-conflict.complete.CTL-1" } }),
+      ].join("\n") + "\n",
+    );
+    expect(countResolveConflictAttempts({ ticket: "CTL-1", path })).toBe(3);
+  });
+
   test("throws without a ticket", () => {
     expect(() => countResolveConflictAttempts({ path })).toThrow("countResolveConflictAttempts: ticket required");
   });

--- a/plugins/dev/scripts/execution-core/event-scan.test.mjs
+++ b/plugins/dev/scripts/execution-core/event-scan.test.mjs
@@ -18,6 +18,7 @@ import {
   countRemediateCycles,
   countRecoveryPassCycles,
   countResolveConflictCycles,
+  countResolveConflictAttempts,
   hasCompleteEvent,
   latestCompleteEventTs,
   latestCompleteEventAttempt,
@@ -303,6 +304,63 @@ describe("countResolveConflictCycles", () => {
 
   test("throws without a ticket", () => {
     expect(() => countResolveConflictCycles({ path })).toThrow("countResolveConflictCycles: ticket required");
+  });
+});
+
+// #1461 Fix 2 (CRITICAL final-review finding): countResolveConflictAttempts —
+// complete + failed, not completions-only. A repeatedly-FAILING resolve-conflict
+// run never increments countResolveConflictCycles (completions-only), leaving
+// the cap counter pinned at 0 forever; countResolveConflictAttempts closes that
+// gap so a failed dispatch attempt counts toward the cap exactly like a
+// completed one.
+describe("countResolveConflictAttempts", () => {
+  const path = "/tmp/resolve-conflict-attempts-test.jsonl";
+
+  beforeEach(() => {
+    __resetEventScanIndexForTest();
+    try { unlinkSync(path); } catch {}
+  });
+
+  test("counts phase.resolve-conflict.failed.<ticket> envelopes (not just complete)", () => {
+    writeFileSync(
+      path,
+      [
+        JSON.stringify({ ts: "2026-08-02T00:00:00Z", attributes: { "event.name": "phase.resolve-conflict.failed.CTL-1" } }),
+        JSON.stringify({ ts: "2026-08-02T00:01:00Z", attributes: { "event.name": "phase.resolve-conflict.failed.CTL-1" } }),
+        JSON.stringify({ ts: "2026-08-02T00:02:00Z", attributes: { "event.name": "phase.resolve-conflict.failed.CTL-1" } }),
+      ].join("\n") + "\n",
+    );
+    // countResolveConflictCycles (completions-only) sees ZERO — this is the bug.
+    expect(countResolveConflictCycles({ ticket: "CTL-1", path })).toBe(0);
+    // countResolveConflictAttempts sees all 3 failed dispatch attempts.
+    expect(countResolveConflictAttempts({ ticket: "CTL-1", path })).toBe(3);
+  });
+
+  test("sums complete AND failed envelopes for the same ticket", () => {
+    writeFileSync(
+      path,
+      [
+        JSON.stringify({ ts: "2026-08-02T00:00:00Z", attributes: { "event.name": "phase.resolve-conflict.failed.CTL-1" } }),
+        JSON.stringify({ ts: "2026-08-02T00:01:00Z", attributes: { "event.name": "phase.resolve-conflict.failed.CTL-1" } }),
+        JSON.stringify({ ts: "2026-08-02T00:02:00Z", attributes: { "event.name": "phase.resolve-conflict.complete.CTL-1" } }),
+        JSON.stringify({ ts: "2026-08-02T00:03:00Z", attributes: { "event.name": "phase.resolve-conflict.failed.CTL-2" } }),
+      ].join("\n") + "\n",
+    );
+    expect(countResolveConflictAttempts({ ticket: "CTL-1", path })).toBe(3);
+    expect(countResolveConflictAttempts({ ticket: "CTL-2", path })).toBe(1);
+    expect(countResolveConflictAttempts({ ticket: "CTL-9", path })).toBe(0);
+  });
+
+  test("does not match a suffix-only ticket (CTL-1 vs CTL-10)", () => {
+    writeFileSync(
+      path,
+      JSON.stringify({ ts: "2026-08-02T00:00:00Z", attributes: { "event.name": "phase.resolve-conflict.failed.CTL-10" } }) + "\n",
+    );
+    expect(countResolveConflictAttempts({ ticket: "CTL-1", path })).toBe(0);
+  });
+
+  test("throws without a ticket", () => {
+    expect(() => countResolveConflictAttempts({ path })).toThrow("countResolveConflictAttempts: ticket required");
   });
 });
 

--- a/plugins/dev/scripts/execution-core/resolve-conflict-sweep-event-types.mjs
+++ b/plugins/dev/scripts/execution-core/resolve-conflict-sweep-event-types.mjs
@@ -1,0 +1,21 @@
+// resolve-conflict-sweep-event-types.mjs — #1461 resolve-conflict-sweep event
+// vocabulary. Dependency-free leaf, mirroring unstuck-sweep-event-types.mjs and
+// janitor-event-types.mjs. Every string the sweep passes to its emit() seam MUST
+// be listed here. This is its OWN closed vocabulary — not routed through
+// reap-intent.mjs or unstuck-sweep's UNSTUCK_SWEEP_EVENT_TYPES (same "closed
+// list per sweep" discipline those two modules already establish).
+
+export const RESOLVE_CONFLICT_SWEEP_EVENT_TYPES = Object.freeze([
+  // A resolvable candidate found — marked and about to dispatch.
+  "resolve-conflict.marked.resolvable",
+  "resolve-conflict.would.mark", // shadow twin
+  // phase-resolve-conflict dispatched via the standard envelope.
+  "resolve-conflict.dispatched",
+  "resolve-conflict.would.dispatch", // shadow twin
+  // The original stall cleared after a resolve-conflict completion.
+  "resolve-conflict.cleared",
+  "resolve-conflict.would.clear", // shadow twin
+  // Cycle cap exhausted without a clean resolution — escalated to the operator.
+  "resolve-conflict.escalated",
+  "resolve-conflict.would.escalate", // shadow twin
+]);

--- a/plugins/dev/scripts/execution-core/resolve-conflict-sweep-event-types.mjs
+++ b/plugins/dev/scripts/execution-core/resolve-conflict-sweep-event-types.mjs
@@ -18,4 +18,9 @@ export const RESOLVE_CONFLICT_SWEEP_EVENT_TYPES = Object.freeze([
   // Cycle cap exhausted without a clean resolution — escalated to the operator.
   "resolve-conflict.escalated",
   "resolve-conflict.would.escalate", // shadow twin
+  // #1461 escalation-gap fix: a FAILED (not done) resolve-conflict run, still
+  // under the cycle cap — the original stall reason reverted + the stale cycle
+  // reset so the ticket becomes a genuine candidate again on a later tick.
+  "resolve-conflict.retry-armed",
+  "resolve-conflict.would.retry", // shadow twin
 ]);

--- a/plugins/dev/scripts/execution-core/resolve-conflict-sweep-event-types.test.mjs
+++ b/plugins/dev/scripts/execution-core/resolve-conflict-sweep-event-types.test.mjs
@@ -1,0 +1,22 @@
+import { describe, test, expect } from "bun:test";
+import { RESOLVE_CONFLICT_SWEEP_EVENT_TYPES } from "./resolve-conflict-sweep-event-types.mjs";
+
+describe("RESOLVE_CONFLICT_SWEEP_EVENT_TYPES", () => {
+  test("is a frozen array of exactly these 8 strings", () => {
+    expect(Object.isFrozen(RESOLVE_CONFLICT_SWEEP_EVENT_TYPES)).toBe(true);
+    expect(RESOLVE_CONFLICT_SWEEP_EVENT_TYPES).toEqual([
+      "resolve-conflict.marked.resolvable",
+      "resolve-conflict.would.mark",
+      "resolve-conflict.dispatched",
+      "resolve-conflict.would.dispatch",
+      "resolve-conflict.cleared",
+      "resolve-conflict.would.clear",
+      "resolve-conflict.escalated",
+      "resolve-conflict.would.escalate",
+    ]);
+  });
+
+  test("every entry is unique", () => {
+    expect(new Set(RESOLVE_CONFLICT_SWEEP_EVENT_TYPES).size).toBe(RESOLVE_CONFLICT_SWEEP_EVENT_TYPES.length);
+  });
+});

--- a/plugins/dev/scripts/execution-core/resolve-conflict-sweep-event-types.test.mjs
+++ b/plugins/dev/scripts/execution-core/resolve-conflict-sweep-event-types.test.mjs
@@ -2,7 +2,7 @@ import { describe, test, expect } from "bun:test";
 import { RESOLVE_CONFLICT_SWEEP_EVENT_TYPES } from "./resolve-conflict-sweep-event-types.mjs";
 
 describe("RESOLVE_CONFLICT_SWEEP_EVENT_TYPES", () => {
-  test("is a frozen array of exactly these 8 strings", () => {
+  test("is a frozen array of exactly these 10 strings", () => {
     expect(Object.isFrozen(RESOLVE_CONFLICT_SWEEP_EVENT_TYPES)).toBe(true);
     expect(RESOLVE_CONFLICT_SWEEP_EVENT_TYPES).toEqual([
       "resolve-conflict.marked.resolvable",
@@ -13,6 +13,9 @@ describe("RESOLVE_CONFLICT_SWEEP_EVENT_TYPES", () => {
       "resolve-conflict.would.clear",
       "resolve-conflict.escalated",
       "resolve-conflict.would.escalate",
+      // #1461 escalation-gap fix
+      "resolve-conflict.retry-armed",
+      "resolve-conflict.would.retry",
     ]);
   });
 

--- a/plugins/dev/scripts/execution-core/resolve-conflict-sweep.mjs
+++ b/plugins/dev/scripts/execution-core/resolve-conflict-sweep.mjs
@@ -1,0 +1,114 @@
+// resolve-conflict-sweep.mjs — #1461 deterministic resolvable-conflict sweep
+// (ADR-028). Structurally mirrors stall-janitor.mjs / unstuck-sweep.mjs: a PURE
+// classifier (no IO) + an action driver (Task 6/7/8) with every side-effect seam
+// injected. Runs on stalled tickets DIRECTLY, independent of isTicketInFlight —
+// deriveAdvancement excludes any "stalled" ticket from its sweep entirely, so
+// this is a dedicated pass, not a deriveAdvancement detour (ADR-028 rationale).
+//
+// CONFIRMED FIELD-NAME BUG (see this plan's Global Constraints): the real
+// producer (phase-agent-dispatch:1150-1157) writes this stall as
+// `status:"stalled"` + `.failureReason`, NOT `.stalledReason` — despite every
+// existing consumer of this exact reason string (unstuck-sweep.mjs,
+// recovery-reasoning.mjs) checking `stalledReason`. This module checks BOTH
+// fields defensively so it actually finds real candidates in production.
+
+import { readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { isTicketKey } from "./ticket-key.mjs";
+
+export const RESOLVE_CONFLICT_STALL_REASON = "source_conflict_ctl708_unavailable";
+export const RESOLVED_MARKER_REASON = "source_conflict_resolvable";
+export const CAP_EXHAUSTED_REASON = "resolve-conflict-cycle-cap-exhausted";
+export const RESOLVE_CONFLICT_CYCLE_CAP =
+  Number(process.env.CATALYST_RESOLVE_CONFLICT_CYCLE_CAP) || 3;
+
+// classifyResolveConflictCandidate — PURE. ctx fields:
+//   stalledReasonMatches — the candidate's raw reason === RESOLVE_CONFLICT_STALL_REASON
+//   alreadyResolving     — the candidate's raw reason === RESOLVED_MARKER_REASON
+//                           (already marked + dispatched this cycle; awaiting completion)
+//   cycleCount            — countResolveConflictCycles({ticket}) — event-counted, durable
+//   classification         — classifyMergeTree(...) result, or null if the merge-tree
+//                            probe has not run yet / failed this tick
+export function classifyResolveConflictCandidate(ctx = {}) {
+  const { stalledReasonMatches, alreadyResolving, cycleCount = 0, classification } = ctx;
+  if (!stalledReasonMatches && !alreadyResolving) {
+    return { action: "skip", reason: "not-our-stall" };
+  }
+  if (cycleCount >= RESOLVE_CONFLICT_CYCLE_CAP) {
+    return { action: "cap-exhausted", reason: "cycle-cap-exhausted" };
+  }
+  if (alreadyResolving) {
+    return { action: "skip", reason: "already-resolving" };
+  }
+  if (!classification) {
+    return { action: "skip", reason: "classification-unavailable" };
+  }
+  if (!classification.resolvable) {
+    return { action: "skip", reason: "not-resolvable" };
+  }
+  return { action: "mark-and-dispatch", reason: "resolvable" };
+}
+
+// defaultCollectResolveConflictCandidates — read-only census over
+// workers/<ticket>/phase-*.json, mirroring defaultCollectUnstuckCandidates'
+// scope exactly (same dir layout, same per-candidate try/catch discipline).
+// Matches BOTH the real producer's field (failureReason) and the documented-
+// but-unused field (stalledReason) for RESOLVE_CONFLICT_STALL_REASON, plus
+// RESOLVED_MARKER_REASON (an in-flight candidate this sweep already marked).
+export function defaultCollectResolveConflictCandidates({
+  orchDir,
+  readdirSync: readdir = readdirSync,
+  readFileSync: readFile = readFileSync,
+  // resolveWorktreePath(ticket) → worktree path or null. Production wiring
+  // (Task 12) injects the real resolver; the bare default is null (fail-closed
+  // — classifyLiveConflict, Task 5, returns null for a null worktreePath, which
+  // the classifier reads as "classification-unavailable" and retries next tick).
+  resolveWorktreePath = () => null,
+  base = "main",
+} = {}) {
+  const out = [];
+  let workerDirs;
+  try {
+    workerDirs = readdir(join(orchDir, "workers"), { withFileTypes: true });
+  } catch {
+    return out;
+  }
+  for (const d of workerDirs) {
+    if (!d.isDirectory()) continue;
+    const ticket = d.name;
+    if (!isTicketKey(ticket)) continue;
+    try {
+      const workerDir = join(orchDir, "workers", ticket);
+      let files;
+      try {
+        files = readdir(workerDir);
+      } catch {
+        continue;
+      }
+      for (const f of files) {
+        const m = /^phase-(.+)\.json$/.exec(f);
+        if (!m) continue;
+        let raw;
+        try {
+          raw = JSON.parse(readFile(join(workerDir, f), "utf8"));
+        } catch {
+          continue;
+        }
+        if (raw?.status !== "stalled") continue;
+        const reason = raw.failureReason ?? raw.stalledReason ?? null;
+        if (reason !== RESOLVE_CONFLICT_STALL_REASON && reason !== RESOLVED_MARKER_REASON) continue;
+        let worktreePath = null;
+        try {
+          worktreePath = resolveWorktreePath(ticket);
+        } catch {
+          worktreePath = null; // fail-closed — never let a throwing resolver drop the candidate
+        }
+        out.push({ ticket, phase: m[1], workerDir, worktreePath, base, raw });
+      }
+    } catch {
+      // per-candidate failures degrade to "skip this ticket" — never abort the census.
+      continue;
+    }
+  }
+  return out;
+}

--- a/plugins/dev/scripts/execution-core/resolve-conflict-sweep.mjs
+++ b/plugins/dev/scripts/execution-core/resolve-conflict-sweep.mjs
@@ -554,13 +554,164 @@ export function defaultCollectResolveConflictCompletions({
   return out;
 }
 
+// defaultCollectResolveConflictFailures — escalation-gap fix (#1461 final-
+// review follow-up). Census sibling of defaultCollectResolveConflictCompletions,
+// same read-only discipline, but keyed on `phase-resolve-conflict.json`'s
+// status:"failed" instead of "done". Before this function existed, a FAILED
+// resolve-conflict run was invisible to every collector in this file: the cap
+// counter (countResolveConflictAttempts, event-scan.mjs) already incremented
+// correctly on the ticket's `phase.resolve-conflict.failed.<ticket>` event, but
+// nothing ever reverted the ORIGINAL stalled phase's RESOLVED_MARKER_REASON
+// marker that markStalledSignalResolving wrote before dispatch — so the ticket
+// could never again satisfy classifyResolveConflictCandidate's
+// stalledReasonMatches/alreadyResolving-at-cap branches on a FRESH classify pass
+// once it had been re-armed. See runResolveConflictSweepPass's failures sub-pass
+// (below) for the two outcomes this feeds: escalate (at/over cap) or revert +
+// reset (under cap).
+//
+// Same idempotence guard as Fix 1's completions collector, and for the exact
+// same reason: report a genuine, not-yet-acted-on failure ONLY while the
+// original stalled-phase signal still carries RESOLVED_MARKER_REASON. Once this
+// sweep's failure-handling path acts — reverting the reason back to
+// RESOLVE_CONFLICT_STALL_REASON, or escalating it to CAP_EXHAUSTED_REASON — the
+// reason no longer matches and this census naturally stops re-firing for the
+// same failure. No separate once-marker file needed; the existing signal
+// already carries the state.
+//
+// Includes `workerDir` in each item (unlike defaultCollectResolveConflictCompletions,
+// which omits it since its only consumer — clearStall — is pre-bound to orchDir
+// by the scheduler wiring) because this census's own consumer path calls the
+// SHARED escalateCapExhausted seam directly, and that seam's contract
+// (defaultEscalateCapExhausted) requires an explicit workerDir field, exactly
+// like the candidates census already supplies for its own cap-exhausted branch.
+export function defaultCollectResolveConflictFailures({
+  orchDir,
+  readdirSync: readdir = readdirSync,
+  readFileSync: readFile = readFileSync,
+} = {}) {
+  const out = [];
+  let workerDirs;
+  try {
+    workerDirs = readdir(join(orchDir, "workers"), { withFileTypes: true });
+  } catch {
+    return out;
+  }
+  for (const d of workerDirs) {
+    if (!d.isDirectory()) continue;
+    const ticket = d.name;
+    if (!isTicketKey(ticket)) continue;
+    try {
+      const workerDir = join(orchDir, "workers", ticket);
+      let sig;
+      try {
+        sig = JSON.parse(readFile(join(workerDir, "phase-resolve-conflict.json"), "utf8"));
+      } catch {
+        continue; // no resolve-conflict signal for this ticket
+      }
+      if (sig?.status !== "failed") continue;
+      let brief;
+      try {
+        brief = JSON.parse(readFile(join(workerDir, "resolve-conflict-brief.json"), "utf8"));
+      } catch {
+        continue; // failed signal but no brief — cannot know which phase to act on
+      }
+      if (!brief?.stalledPhase) continue;
+
+      let stalledRaw;
+      try {
+        stalledRaw = JSON.parse(readFile(join(workerDir, `phase-${brief.stalledPhase}.json`), "utf8"));
+      } catch {
+        continue; // absent/unreadable — already reverted/escalated, or never existed
+      }
+      const stalledReason = stalledRaw?.failureReason ?? stalledRaw?.stalledReason ?? null;
+      if (stalledReason !== RESOLVED_MARKER_REASON) continue; // already acted on by this sweep or something else
+
+      out.push({ ticket, stalledPhase: brief.stalledPhase, workerDir });
+    } catch {
+      continue;
+    }
+  }
+  return out;
+}
+
+// defaultRevertStallAndResetCycle — escalation-gap fix (#1461 final-review
+// follow-up), the UNDER-cap outcome for a FAILED resolve-conflict run. Two
+// steps:
+//   1. Revert the ORIGINAL stalled phase's signal reason from
+//      RESOLVED_MARKER_REASON back to RESOLVE_CONFLICT_STALL_REASON —
+//      read-modify-write, the exact mirror of markStalledSignalResolving but in
+//      reverse (every other field, e.g. bg_job_id, untouched).
+//   2. REUSE maybeResetForResolveConflictCycle verbatim (no duplicated deletion
+//      logic) to clear the stale terminal phase-resolve-conflict.json + its
+//      resolve-conflict-brief.json + claim tombstones/progress marker — the
+//      exact same reset defaultMarkAndDispatch already runs before a fresh
+//      cycle-2+ dispatch. Without step 2, a later successful re-classification
+//      of this ticket as a genuine candidate would immediately hit the SAME
+//      phase-agent-dispatch idempotency no-op maybeResetForResolveConflictCycle
+//      was originally built to prevent (see that function's own header comment).
+//
+// Once step 1 lands, defaultCollectResolveConflictFailures's own idempotence
+// guard stops re-reporting this failure (the reason no longer matches
+// RESOLVED_MARKER_REASON), and on a LATER tick
+// defaultCollectResolveConflictCandidates picks the ticket back up as a genuine
+// RESOLVE_CONFLICT_STALL_REASON candidate — classifyResolveConflictCandidate
+// then re-evaluates it fresh, exactly as if this were the ticket's first stall.
+//
+// Best-effort per step, mirroring defaultMarkAndDispatch's cycle-reset call:
+// step 2 failing must not undo step 1 (the revert is the safety-critical part —
+// worst case a stale reset leaves one extra idempotent no-op on the NEXT
+// dispatch, which itself re-runs this same reset before dispatching).
+export function defaultRevertStallAndResetCycle(
+  orchDir,
+  ticket,
+  stalledPhase,
+  {
+    readFileSync: readFile = readFileSync,
+    writeFileSync: writeFile = writeFileSync,
+    renameSync: rename = renameSync,
+    rmSync: rm = rmSync,
+    readdirSync: readdir = readdirSync,
+  } = {},
+) {
+  const workerDir = join(orchDir, "workers", ticket);
+  const signalPath = join(workerDir, `phase-${stalledPhase}.json`);
+  try {
+    const sig = JSON.parse(readFile(signalPath, "utf8"));
+    if ("stalledReason" in sig) sig.stalledReason = RESOLVE_CONFLICT_STALL_REASON;
+    else sig.failureReason = RESOLVE_CONFLICT_STALL_REASON;
+    sig.updatedAt = new Date().toISOString();
+    const tmp = `${signalPath}.tmp.${process.pid}`;
+    writeFile(tmp, JSON.stringify(sig, null, 2));
+    rename(tmp, signalPath);
+  } catch (err) {
+    log.warn(
+      { ticket, stalledPhase, err: err?.message },
+      "resolve-conflict-sweep: stall-reason revert failed (#1461 escalation-gap fix) — leaving failed cycle unresolved this tick"
+    );
+    return false;
+  }
+  try {
+    maybeResetForResolveConflictCycle(orchDir, ticket, { rmSync: rm, readFileSync: readFile, readdirSync: readdir });
+  } catch (err) {
+    log.warn(
+      { ticket, stalledPhase, err: err?.message },
+      "resolve-conflict-sweep: cycle-reset after stall-reason revert failed (#1461 escalation-gap fix) — proceeding anyway"
+    );
+  }
+  return true;
+}
+
 // runResolveConflictSweepPass — the action driver. Every side-effect seam is
 // injected; mirrors runUnstuckSweepPass's off/shadow/enforce shape + report.
-// Two independent sub-passes per tick: (1) candidates → classify → mark-and-
-// dispatch or cap-exhausted-escalate; (2) completions → clearStall. Order is
-// completions-then-candidates so a just-completed ticket's stall is cleared
-// before that same tick's candidate scan would otherwise re-see it (defensive;
-// either order is safe since a cleared ticket has no more stalled signal).
+// Three independent sub-passes per tick: (1) candidates → classify → mark-and-
+// dispatch or cap-exhausted-escalate; (2) completions (status:"done") →
+// clearStall; (3) failures (status:"failed", #1461 escalation-gap fix) →
+// cap-exhausted-escalate or revert-and-reset-cycle. Order is
+// completions-then-failures-then-candidates so a just-completed or
+// just-failed ticket's stall is cleared/reverted before that same tick's
+// candidate scan would otherwise re-see it (defensive; either order is safe
+// since an acted-on ticket no longer carries the marker the candidate census
+// keys on).
 // NOTE: deliberately NOT declared `async` at the top level. Mode "off" must
 // return the plain report object synchronously (no Promise wrapper) so a
 // caller can check it without awaiting; shadow/enforce need `await
@@ -571,14 +722,27 @@ export function runResolveConflictSweepPass({
   mode = "off",
   collectCandidates = () => [],
   collectCompletions = () => [],
+  collectFailures = () => [],
   classifyLive = async () => null,
   cycleCountOf = () => 0,
   markAndDispatch = () => ({ success: false, dispatched: false }),
   escalateCapExhausted = () => false,
   clearStall = () => false,
+  revertStallAndResetCycle = () => false,
   emit = async () => true,
 } = {}) {
-  const report = { marked: [], wouldMark: [], escalated: [], wouldEscalate: [], cleared: [], wouldClear: [], skipped: [], failed: [] };
+  const report = {
+    marked: [],
+    wouldMark: [],
+    escalated: [],
+    wouldEscalate: [],
+    cleared: [],
+    wouldClear: [],
+    retried: [],
+    wouldRetry: [],
+    skipped: [],
+    failed: [],
+  };
   if (mode === "off") return report;
   const enforce = mode === "enforce";
 
@@ -615,6 +779,53 @@ export function runResolveConflictSweepPass({
         report.cleared.push({ ticket: c.ticket, phase: c.stalledPhase });
       } catch (err) {
         report.failed.push({ ticket: c?.ticket, phase: c?.stalledPhase, reason: err?.message });
+      }
+    }
+
+    // ---- failures (#1461 escalation-gap fix): a FAILED resolve-conflict run
+    // either escalates (at/over cap, via the SAME escalateCapExhausted seam the
+    // candidates sub-pass below uses) or reverts the original stall + resets the
+    // stale cycle (under cap) so the ticket becomes a genuine candidate again on
+    // a later tick. See defaultCollectResolveConflictFailures /
+    // defaultRevertStallAndResetCycle above for the full rationale — this is a
+    // NEW, parallel path; it never touches a "done" completion (that's the
+    // completions sub-pass above) and never touches a dispatched/running signal
+    // (the collector's own idempotence guard + status:"failed" filter exclude
+    // those entirely).
+    let failures = [];
+    try {
+      failures = collectFailures() ?? [];
+    } catch {
+      failures = [];
+    }
+    for (const f of failures) {
+      try {
+        const cycleCount = cycleCountOf(f.ticket);
+        if (cycleCount >= RESOLVE_CONFLICT_CYCLE_CAP) {
+          if (!enforce) {
+            fire("resolve-conflict.would.escalate", { ticket: f.ticket, phase: f.stalledPhase });
+            report.wouldEscalate.push({ ticket: f.ticket, phase: f.stalledPhase });
+            continue;
+          }
+          const posted = escalateCapExhausted({ ticket: f.ticket, phase: f.stalledPhase, workerDir: f.workerDir, cycleCount });
+          fire("resolve-conflict.escalated", { ticket: f.ticket, phase: f.stalledPhase, posted });
+          report.escalated.push({ ticket: f.ticket, phase: f.stalledPhase });
+          continue;
+        }
+        if (!enforce) {
+          fire("resolve-conflict.would.retry", { ticket: f.ticket, phase: f.stalledPhase });
+          report.wouldRetry.push({ ticket: f.ticket, phase: f.stalledPhase });
+          continue;
+        }
+        const ok = revertStallAndResetCycle({ ticket: f.ticket, stalledPhase: f.stalledPhase });
+        if (ok === false) {
+          report.failed.push({ ticket: f.ticket, phase: f.stalledPhase, reason: "revert-stall-and-reset-cycle-returned-false" });
+          continue;
+        }
+        fire("resolve-conflict.retry-armed", { ticket: f.ticket, phase: f.stalledPhase });
+        report.retried.push({ ticket: f.ticket, phase: f.stalledPhase });
+      } catch (err) {
+        report.failed.push({ ticket: f?.ticket, phase: f?.stalledPhase, reason: err?.message });
       }
     }
 

--- a/plugins/dev/scripts/execution-core/resolve-conflict-sweep.mjs
+++ b/plugins/dev/scripts/execution-core/resolve-conflict-sweep.mjs
@@ -169,49 +169,88 @@ export function markStalledSignalResolving(
   rename(tmp, signalPath);
 }
 
+// The phase name resolve-conflict dispatches TO (phase-agent-dispatch resolves
+// this to the /catalyst-dev:resolve-conflict skill) — distinct from the STALLED
+// phase (`phase` param below, e.g. "implement"), whose own signal file is the one
+// markStalledSignalResolving rewrites.
+const RESOLVE_CONFLICT_DISPATCH_PHASE = "resolve-conflict";
+
 // defaultMarkAndDispatch — the "mark-and-dispatch" action seam. Mirrors
 // defaultInvokeRecoveryPass's dispatch section (recovery-reasoning.mjs:1650-
 // 1828) exactly: lazy-require dispatch.mjs (avoids loading the dispatch graph
 // on the off/shadow paths), settle an sdk-fleet Promise synchronously via
-// isThenable/settleDispatchSync so the success check works identically for bg
-// and sdk executors.
+// isThenable/settleDispatchSync, verify the settled signal is actually runnable
+// via sdkSignalRunnable (NOT a blind verifySync:true — a resolved {code:1} or a
+// signal that never went runnable must not be reported as success), and wire
+// backstopOnRejection as the onSettled handler so a REJECTED sdk dispatch flips
+// the stalled phase's signal to failed + emits phase.<phase>.failed instead of
+// stranding silently. The signal-mark + brief-write are wrapped in their own
+// try/catch (malformed JSON, filesystem errors) so a write failure returns a
+// structured {success:false, reason} instead of throwing out of the function —
+// exactly like defaultInvokeRecoveryPass's own brief-write guard
+// (recovery-reasoning.mjs:1733-1743).
 export function defaultMarkAndDispatch(
   { ticket, phase, workerDir, worktreePath, base, classification, cycleCount, orchDir },
   deps = {},
 ) {
   const signalPath = join(workerDir, `phase-${phase}.json`);
-  markStalledSignalResolving(signalPath, deps);
-
-  writeResolveConflictBrief(
-    orchDir,
-    ticket,
-    {
-      stalledPhase: phase,
-      conflictFiles: classification.conflictFiles,
-      conflictTypes: classification.conflictTypes,
-      worktreePath,
-      base,
-      attempt: cycleCount + 1,
-      maxAttempts: RESOLVE_CONFLICT_CYCLE_CAP,
-    },
-    deps,
-  );
-
-  let dispatchTicket, isThenable, settleDispatchSync;
   try {
-    ({ dispatchTicket, isThenable, settleDispatchSync } = deps.dispatchMod ?? _require("./dispatch.mjs"));
+    markStalledSignalResolving(signalPath, deps);
+
+    writeResolveConflictBrief(
+      orchDir,
+      ticket,
+      {
+        stalledPhase: phase,
+        conflictFiles: classification.conflictFiles,
+        conflictTypes: classification.conflictTypes,
+        worktreePath,
+        base,
+        attempt: cycleCount + 1,
+        maxAttempts: RESOLVE_CONFLICT_CYCLE_CAP,
+      },
+      deps,
+    );
+  } catch (err) {
+    return { success: false, dispatched: false, reason: `mark/brief write failed: ${err.message}` };
+  }
+
+  let dispatchTicket, isThenable, settleDispatchSync, backstopOnRejection, sdkSignalRunnable;
+  try {
+    ({ dispatchTicket, isThenable, settleDispatchSync, backstopOnRejection, sdkSignalRunnable } =
+      deps.dispatchMod ?? _require("./dispatch.mjs"));
   } catch (err) {
     return { success: false, dispatched: false, reason: `dispatch module load failed: ${err.message}` };
   }
   const dispatch = deps.dispatch ?? dispatchTicket;
   const thenableCheck = deps.isThenable ?? isThenable;
+  const verifyRunnable = deps.sdkSignalRunnable ?? sdkSignalRunnable;
+  const backstop = deps.backstopOnRejection ?? backstopOnRejection;
 
   let r;
   try {
-    const rawR = dispatch(orchDir, ticket, "resolve-conflict");
+    const rawR = dispatch(orchDir, ticket, RESOLVE_CONFLICT_DISPATCH_PHASE);
     if (thenableCheck && thenableCheck(rawR)) {
       const settle = deps.settleDispatchSync ?? settleDispatchSync;
-      r = settle(rawR, { verifySync: () => true });
+      // onSettled mirrors defaultInvokeRecoveryPass (recovery-reasoning.mjs:1759-
+      // 1786): fail on EITHER a rejection OR a resolved non-zero code, and on
+      // failure route through backstopOnRejection so the stalled phase's signal
+      // gets a terminal failed event instead of stranding at "dispatched".
+      const onSettled = (_res, err) => {
+        const failed = err || (_res && Number.isFinite(_res.code) && _res.code !== 0);
+        if (!failed) return; // clean resolution → the worker/skill owns its terminal event
+        try {
+          backstop?.(
+            { orchDir, ticket, phase: RESOLVE_CONFLICT_DISPATCH_PHASE },
+          )(_res, err ?? new Error(`sdk resolve-conflict resolved code=${_res?.code}`));
+        } catch {
+          /* best-effort — a failing backstop must not surface as an unhandled rejection */
+        }
+      };
+      r = settle(rawR, {
+        verifySync: () => (verifyRunnable ? verifyRunnable(orchDir, ticket, RESOLVE_CONFLICT_DISPATCH_PHASE) : true),
+        onSettled,
+      });
     } else {
       r = rawR;
     }
@@ -220,7 +259,17 @@ export function defaultMarkAndDispatch(
   }
 
   if (r && r.code === 0) {
-    return { success: true, dispatched: true, bgJobId: r.signal?.bg_job_id ?? null };
+    return {
+      success: true,
+      dispatched: true,
+      bgJobId: r.signal?.bg_job_id ?? null,
+      pendingSdk: r.async ? r.pending ?? null : null,
+    };
   }
-  return { success: false, dispatched: false, reason: r?.stderr ?? `dispatch failed (code ${r?.code ?? "unknown"})` };
+  return {
+    success: false,
+    dispatched: false,
+    reason: r?.stderr ?? `dispatch failed (code ${r?.code ?? "unknown"})`,
+    pendingSdk: r?.async ? r.pending ?? null : null,
+  };
 }

--- a/plugins/dev/scripts/execution-core/resolve-conflict-sweep.mjs
+++ b/plugins/dev/scripts/execution-core/resolve-conflict-sweep.mjs
@@ -15,6 +15,7 @@
 import { readdirSync, readFileSync, mkdirSync, writeFileSync, renameSync } from "node:fs";
 import { join, dirname } from "node:path";
 import { createRequire } from "node:module";
+import { spawnSync } from "node:child_process";
 import { isTicketKey } from "./ticket-key.mjs";
 import { classifyMergeTree } from "./stale-pr-rescue.mjs";
 import { defaultMergeTree } from "./stale-pr-rescue-timer.mjs";
@@ -272,4 +273,38 @@ export function defaultMarkAndDispatch(
     reason: r?.stderr ?? `dispatch failed (code ${r?.code ?? "unknown"})`,
     pendingSdk: r?.async ? r.pending ?? null : null,
   };
+}
+
+// defaultPostResolveConflictComment — thin wrapper over the shared
+// linear-comment-post.sh helper, mirroring defaultRunCommentPost in
+// unstuck-sweep.mjs. Best-effort: never throws.
+function defaultPostResolveConflictComment(ticket, body) {
+  const helperPath = join(process.env.PLUGIN_ROOT ?? process.cwd(), "scripts/lib/linear-comment-post.sh");
+  const res = spawnSync(helperPath, [ticket, body], { encoding: "utf8", timeout: 10_000 });
+  return !res.error && (res.status ?? 1) === 0;
+}
+
+// defaultEscalateCapExhausted — the cap-exhaustion escalate seam. Rewrites the
+// stalled phase's signal to CAP_EXHAUSTED_REASON (a NEW, non-colliding reason —
+// this is a normal `stalled` status, so the existing terminal-label sweep
+// (scheduler.mjs) applies needs-human to it exactly like
+// remediate-cycle-cap-exhausted already does; Task 10's exemption is scoped
+// ONLY to RESOLVED_MARKER_REASON, never to this one). Posts the escalation
+// comment mirroring recovery-emit.mjs's header convention VISUALLY (not wired
+// into inbox-ask.mjs's parser — see this plan's Global Constraints).
+export function defaultEscalateCapExhausted(
+  { ticket, phase, workerDir, cycleCount },
+  { readFileSync: readFile = readFileSync, writeFileSync: writeFile = writeFileSync, renameSync: rename = renameSync, postComment = defaultPostResolveConflictComment } = {},
+) {
+  const signalPath = join(workerDir, `phase-${phase}.json`);
+  const sig = JSON.parse(readFile(signalPath, "utf8"));
+  if ("stalledReason" in sig) sig.stalledReason = CAP_EXHAUSTED_REASON;
+  else sig.failureReason = CAP_EXHAUSTED_REASON;
+  sig.updatedAt = new Date().toISOString();
+  const tmp = `${signalPath}.tmp.${process.pid}`;
+  writeFile(tmp, JSON.stringify(sig, null, 2));
+  rename(tmp, signalPath);
+
+  const body = `🔼 **phase-resolve-conflict** escalated this to the operator — ${ticket}/${phase} hit the resolve-conflict cycle cap (${RESOLVE_CONFLICT_CYCLE_CAP}) after ${cycleCount} attempt(s) without a clean resolution; manual conflict resolution needed.`;
+  return postComment(ticket, body);
 }

--- a/plugins/dev/scripts/execution-core/resolve-conflict-sweep.mjs
+++ b/plugins/dev/scripts/execution-core/resolve-conflict-sweep.mjs
@@ -12,9 +12,11 @@
 // recovery-reasoning.mjs) checking `stalledReason`. This module checks BOTH
 // fields defensively so it actually finds real candidates in production.
 
-import { readdirSync, readFileSync } from "node:fs";
-import { join } from "node:path";
+import { readdirSync, readFileSync, mkdirSync, writeFileSync, renameSync } from "node:fs";
+import { join, dirname } from "node:path";
 import { isTicketKey } from "./ticket-key.mjs";
+import { classifyMergeTree } from "./stale-pr-rescue.mjs";
+import { defaultMergeTree } from "./stale-pr-rescue-timer.mjs";
 
 export const RESOLVE_CONFLICT_STALL_REASON = "source_conflict_ctl708_unavailable";
 export const RESOLVED_MARKER_REASON = "source_conflict_resolvable";
@@ -111,4 +113,38 @@ export function defaultCollectResolveConflictCandidates({
     }
   }
   return out;
+}
+
+// classifyLiveConflict — re-run git merge-tree against the LIVE worktree (never
+// trust stale census evidence — mirrors sourceConflictActSeam's own re-check
+// discipline in unstuck-act-seams.mjs) and classify with the existing,
+// UNMODIFIED classifyMergeTree. Returns null (not a classification) on any
+// probe failure or missing worktree — the caller's classifier then reads that
+// as "classification-unavailable" and retries next tick; it never guesses.
+export async function classifyLiveConflict({ worktreePath, base, head }, { mergeTree = defaultMergeTree } = {}) {
+  if (!worktreePath) return null;
+  try {
+    const mt = await mergeTree(worktreePath, base, head);
+    return classifyMergeTree(mt);
+  } catch {
+    return null;
+  }
+}
+
+// writeResolveConflictBrief — atomic tmp+rename of resolve-conflict-brief.json,
+// mirroring writeRecoveryBrief (recovery-reasoning.mjs). This is the
+// phase-resolve-conflict skill's prior-phase artifact (Task 9 wires
+// `signal:resolve-conflict-brief.json` into phase-artifact-gate.sh).
+export function writeResolveConflictBrief(
+  orchDir,
+  ticket,
+  brief,
+  { mkdirSync: mkdir = mkdirSync, writeFileSync: writeFile = writeFileSync, renameSync: rename = renameSync } = {},
+) {
+  const p = join(orchDir, "workers", ticket, "resolve-conflict-brief.json");
+  mkdir(dirname(p), { recursive: true });
+  const tmp = `${p}.tmp.${process.pid}`;
+  writeFile(tmp, JSON.stringify({ schema: "resolve-conflict-brief/v1", writtenAt: new Date().toISOString(), ...brief }, null, 2));
+  rename(tmp, p);
+  return p;
 }

--- a/plugins/dev/scripts/execution-core/resolve-conflict-sweep.mjs
+++ b/plugins/dev/scripts/execution-core/resolve-conflict-sweep.mjs
@@ -14,9 +14,12 @@
 
 import { readdirSync, readFileSync, mkdirSync, writeFileSync, renameSync } from "node:fs";
 import { join, dirname } from "node:path";
+import { createRequire } from "node:module";
 import { isTicketKey } from "./ticket-key.mjs";
 import { classifyMergeTree } from "./stale-pr-rescue.mjs";
 import { defaultMergeTree } from "./stale-pr-rescue-timer.mjs";
+
+const _require = createRequire(import.meta.url);
 
 export const RESOLVE_CONFLICT_STALL_REASON = "source_conflict_ctl708_unavailable";
 export const RESOLVED_MARKER_REASON = "source_conflict_resolvable";
@@ -147,4 +150,77 @@ export function writeResolveConflictBrief(
   writeFile(tmp, JSON.stringify({ schema: "resolve-conflict-brief/v1", writtenAt: new Date().toISOString(), ...brief }, null, 2));
   rename(tmp, p);
   return p;
+}
+
+// markStalledSignalResolving — atomic read-modify-write of the STALLED phase's
+// own signal file: rewrite failureReason (or stalledReason, whichever is
+// present) to RESOLVED_MARKER_REASON. Every other field (bg_job_id, status,
+// etc.) is preserved untouched — read-modify-write, never a blind overwrite.
+export function markStalledSignalResolving(
+  signalPath,
+  { readFileSync: readFile = readFileSync, writeFileSync: writeFile = writeFileSync, renameSync: rename = renameSync } = {},
+) {
+  const sig = JSON.parse(readFile(signalPath, "utf8"));
+  if ("stalledReason" in sig) sig.stalledReason = RESOLVED_MARKER_REASON;
+  else sig.failureReason = RESOLVED_MARKER_REASON;
+  sig.updatedAt = new Date().toISOString();
+  const tmp = `${signalPath}.tmp.${process.pid}`;
+  writeFile(tmp, JSON.stringify(sig, null, 2));
+  rename(tmp, signalPath);
+}
+
+// defaultMarkAndDispatch — the "mark-and-dispatch" action seam. Mirrors
+// defaultInvokeRecoveryPass's dispatch section (recovery-reasoning.mjs:1650-
+// 1828) exactly: lazy-require dispatch.mjs (avoids loading the dispatch graph
+// on the off/shadow paths), settle an sdk-fleet Promise synchronously via
+// isThenable/settleDispatchSync so the success check works identically for bg
+// and sdk executors.
+export function defaultMarkAndDispatch(
+  { ticket, phase, workerDir, worktreePath, base, classification, cycleCount, orchDir },
+  deps = {},
+) {
+  const signalPath = join(workerDir, `phase-${phase}.json`);
+  markStalledSignalResolving(signalPath, deps);
+
+  writeResolveConflictBrief(
+    orchDir,
+    ticket,
+    {
+      stalledPhase: phase,
+      conflictFiles: classification.conflictFiles,
+      conflictTypes: classification.conflictTypes,
+      worktreePath,
+      base,
+      attempt: cycleCount + 1,
+      maxAttempts: RESOLVE_CONFLICT_CYCLE_CAP,
+    },
+    deps,
+  );
+
+  let dispatchTicket, isThenable, settleDispatchSync;
+  try {
+    ({ dispatchTicket, isThenable, settleDispatchSync } = deps.dispatchMod ?? _require("./dispatch.mjs"));
+  } catch (err) {
+    return { success: false, dispatched: false, reason: `dispatch module load failed: ${err.message}` };
+  }
+  const dispatch = deps.dispatch ?? dispatchTicket;
+  const thenableCheck = deps.isThenable ?? isThenable;
+
+  let r;
+  try {
+    const rawR = dispatch(orchDir, ticket, "resolve-conflict");
+    if (thenableCheck && thenableCheck(rawR)) {
+      const settle = deps.settleDispatchSync ?? settleDispatchSync;
+      r = settle(rawR, { verifySync: () => true });
+    } else {
+      r = rawR;
+    }
+  } catch (err) {
+    return { success: false, dispatched: false, reason: `dispatch threw: ${err.message}` };
+  }
+
+  if (r && r.code === 0) {
+    return { success: true, dispatched: true, bgJobId: r.signal?.bg_job_id ?? null };
+  }
+  return { success: false, dispatched: false, reason: r?.stderr ?? `dispatch failed (code ${r?.code ?? "unknown"})` };
 }

--- a/plugins/dev/scripts/execution-core/resolve-conflict-sweep.mjs
+++ b/plugins/dev/scripts/execution-core/resolve-conflict-sweep.mjs
@@ -12,13 +12,16 @@
 // recovery-reasoning.mjs) checking `stalledReason`. This module checks BOTH
 // fields defensively so it actually finds real candidates in production.
 
-import { readdirSync, readFileSync, mkdirSync, writeFileSync, renameSync } from "node:fs";
+import { readdirSync, readFileSync, mkdirSync, writeFileSync, renameSync, appendFileSync } from "node:fs";
 import { join, dirname } from "node:path";
 import { createRequire } from "node:module";
 import { spawnSync } from "node:child_process";
 import { isTicketKey } from "./ticket-key.mjs";
 import { classifyMergeTree } from "./stale-pr-rescue.mjs";
-import { defaultMergeTree } from "./stale-pr-rescue-timer.mjs";
+import { log, getEventLogPath } from "./config.mjs";
+import { RESOLVE_CONFLICT_SWEEP_EVENT_TYPES } from "./resolve-conflict-sweep-event-types.mjs";
+
+export { RESOLVE_CONFLICT_SWEEP_EVENT_TYPES };
 
 const _require = createRequire(import.meta.url);
 
@@ -32,7 +35,10 @@ export const RESOLVE_CONFLICT_CYCLE_CAP =
 //   stalledReasonMatches — the candidate's raw reason === RESOLVE_CONFLICT_STALL_REASON
 //   alreadyResolving     — the candidate's raw reason === RESOLVED_MARKER_REASON
 //                           (already marked + dispatched this cycle; awaiting completion)
-//   cycleCount            — countResolveConflictCycles({ticket}) — event-counted, durable
+//   cycleCount            — countResolveConflictAttempts({ticket}) — event-counted,
+//                           durable; counts BOTH complete and failed dispatch
+//                           attempts (#1461 Fix 2), so a repeatedly-FAILING run
+//                           still reaches RESOLVE_CONFLICT_CYCLE_CAP and escalates
 //   classification         — classifyMergeTree(...) result, or null if the merge-tree
 //                            probe has not run yet / failed this tick
 export function classifyResolveConflictCandidate(ctx = {}) {
@@ -119,16 +125,52 @@ export function defaultCollectResolveConflictCandidates({
   return out;
 }
 
-// classifyLiveConflict — re-run git merge-tree against the LIVE worktree (never
-// trust stale census evidence — mirrors sourceConflictActSeam's own re-check
-// discipline in unstuck-act-seams.mjs) and classify with the existing,
-// UNMODIFIED classifyMergeTree. Returns null (not a classification) on any
-// probe failure or missing worktree — the caller's classifier then reads that
-// as "classification-unavailable" and retries next tick; it never guesses.
-export async function classifyLiveConflict({ worktreePath, base, head }, { mergeTree = defaultMergeTree } = {}) {
+// defaultLocalMergeTree — #1461 Fix 5 (final-review finding, human-approved
+// design): `git merge-tree --write-tree origin/<base> HEAD` run DIRECTLY in
+// the ticket's worktree — comparing the LIVE LOCAL worktree state (HEAD)
+// against the base, never the pushed remote ticket branch. The prior
+// classifyLiveConflict called stale-pr-rescue-timer.mjs's defaultMergeTree,
+// which fetches AND diffs origin/<base> against origin/<ticket> (the PUSHED
+// branch) — that only works once a ticket's branch has actually been pushed.
+// Dispatch-time pre-flight rebase stalls (this whole sweep's actual trigger)
+// typically happen on the IMPLEMENT phase, BEFORE the branch has ever been
+// pushed, so fetching origin/<ticket> always failed for that common case and
+// classifyLiveConflict permanently returned null (ADR-028's "reachable from
+// implement/verify/review" goal was defeated for its most common case). HEAD
+// is already local and never needs fetching; only origin/<base> is fetched
+// first, so a stale local remote-tracking ref can't produce a false
+// "resolvable" read against a base that has since moved on. Not injectable
+// via classifyLiveConflict's own `mergeTree` seam misuse — this is a NEW,
+// separate seam (do not reuse defaultMergeTree, which insists on fetching a
+// remote ref by the `head` name — fetching a literal remote "HEAD" would be
+// wrong). Returns the same {exitCode, output} shape classifyMergeTree expects.
+export async function defaultLocalMergeTree(worktreePath, base) {
+  const fetchRes = spawnSync("git", ["-C", worktreePath, "fetch", "origin", base], {
+    encoding: "utf8",
+    timeout: 30_000,
+  });
+  if (fetchRes.status !== 0) {
+    throw new Error(`git fetch origin ${base} failed (exit ${fetchRes.status}): ${fetchRes.stderr ?? ""}`);
+  }
+  const res = spawnSync(
+    "git",
+    ["-C", worktreePath, "merge-tree", "--write-tree", `origin/${base}`, "HEAD"],
+    { encoding: "utf8", timeout: 30_000 }
+  );
+  return { exitCode: res.status ?? 128, output: res.stdout ?? "" };
+}
+
+// classifyLiveConflict — re-run git merge-tree against the LIVE local worktree
+// (HEAD vs origin/<base> — never trust stale census evidence, and never the
+// pushed remote ticket branch; see defaultLocalMergeTree above for why) and
+// classify with the existing, UNMODIFIED classifyMergeTree. Returns null (not
+// a classification) on any probe failure or missing worktree — the caller's
+// classifier then reads that as "classification-unavailable" and retries next
+// tick; it never guesses.
+export async function classifyLiveConflict({ worktreePath, base }, { mergeTree = defaultLocalMergeTree } = {}) {
   if (!worktreePath) return null;
   try {
-    const mt = await mergeTree(worktreePath, base, head);
+    const mt = await mergeTree(worktreePath, base);
     return classifyMergeTree(mt);
   } catch {
     return null;
@@ -171,7 +213,8 @@ export function markStalledSignalResolving(
 }
 
 // The phase name resolve-conflict dispatches TO (phase-agent-dispatch resolves
-// this to the /catalyst-dev:resolve-conflict skill) — distinct from the STALLED
+// this, via skill_for_phase's default `phase-<PHASE>` convention, to the
+// /catalyst-dev:phase-resolve-conflict skill) — distinct from the STALLED
 // phase (`phase` param below, e.g. "implement"), whose own signal file is the one
 // markStalledSignalResolving rewrites.
 const RESOLVE_CONFLICT_DISPATCH_PHASE = "resolve-conflict";
@@ -312,6 +355,37 @@ export function defaultEscalateCapExhausted(
 // defaultCollectResolveConflictCompletions — find every ticket whose
 // resolve-conflict phase signal is "done" and read which original phase to
 // clear from resolve-conflict-brief.json's stalledPhase. Read-only.
+//
+// #1461 Fix 1 (CRITICAL final-review finding): this census used to key a
+// "completion" off ONLY {status:"done" on phase-resolve-conflict.json} + a
+// present resolve-conflict-brief.json — neither file is ever removed or
+// marked after a successful clear, so the SAME completion was re-collected on
+// EVERY subsequent tick forever (until the whole worker dir is archived at
+// pipeline teardown), and defaultClearStall does real, destructive work
+// UNCONDITIONALLY on every call: it deletes workers/<T>/phase-<stalledPhase>.json
+// (destroying a FRESH signal from a newly-redispatched live worker on every
+// tick after the first), deletes the escalation-cooldown marker every tick
+// (permanently defeating CTL-1442's ask-budget), deletes
+// .orphan-detected.applied every tick (spuriously re-emitting orphan-detected),
+// and calls clearStalledLabel every tick (a Linear API write per tick per
+// already-cleared ticket, forever).
+//
+// The fix: a completion is now reported ONLY when the ORIGINAL stalled-phase
+// signal (workers/<T>/phase-<stalledPhase>.json) is STILL PRESENT and STILL
+// carries the exact RESOLVED_MARKER_REASON this sweep itself wrote via
+// markStalledSignalResolving. defaultClearStall's own first step
+// unconditionally deletes that exact file, so once a clear has actually run,
+// the file is gone and this census naturally stops re-firing for that ticket —
+// no separate marker file needed (a second file that must ALSO be correctly
+// re-armed across a future, genuinely-new stall/resolve cycle on the same
+// ticket+phase would just be a second thing to keep in sync; the existing
+// signal file already carries the exact state needed). Three cases: (a) file
+// present + reason still RESOLVED_MARKER_REASON → genuine, not-yet-cleared
+// completion, report it; (b) file absent (clearStall already deleted it, or a
+// teardown/reap removed the worker) → already handled, do not re-report; (c)
+// file present but some OTHER process already changed the reason (e.g. a
+// manual operator re-arm, or CAP_EXHAUSTED_REASON from a parallel cap-exhaust
+// path) → something else already owns this ticket's stall, do not re-fire.
 export function defaultCollectResolveConflictCompletions({
   orchDir,
   readdirSync: readdir = readdirSync,
@@ -344,6 +418,18 @@ export function defaultCollectResolveConflictCompletions({
         continue; // done signal but no brief — cannot know which phase to clear
       }
       if (!brief?.stalledPhase) continue;
+
+      // Idempotence guard (Fix 1): only a still-marked, not-yet-cleared stall
+      // is a genuine completion to act on.
+      let stalledRaw;
+      try {
+        stalledRaw = JSON.parse(readFile(join(workerDir, `phase-${brief.stalledPhase}.json`), "utf8"));
+      } catch {
+        continue; // absent/unreadable — a prior clearStall already removed it
+      }
+      const stalledReason = stalledRaw?.failureReason ?? stalledRaw?.stalledReason ?? null;
+      if (stalledReason !== RESOLVED_MARKER_REASON) continue; // already changed/cleared by something else
+
       out.push({ ticket, stalledPhase: brief.stalledPhase });
     } catch {
       continue;
@@ -431,9 +517,12 @@ export function runResolveConflictSweepPass({
         const cycleCount = cycleCountOf(c.ticket);
         // Only probe merge-tree for a reason this sweep actually owns — never
         // spawn git for a not-our-stall candidate (classifier would skip it anyway).
+        // #1461 Fix 5: no `head` arg any more — classification is always against
+        // the LOCAL worktree's HEAD, not the pushed ticket branch (see
+        // classifyLiveConflict / defaultLocalMergeTree above).
         const classification =
           stalledReasonMatches && cycleCount < RESOLVE_CONFLICT_CYCLE_CAP
-            ? await classifyLive({ worktreePath: c.worktreePath, base: c.base, head: c.ticket })
+            ? await classifyLive({ worktreePath: c.worktreePath, base: c.base })
             : null;
         const decision = classifyResolveConflictCandidate({ stalledReasonMatches, alreadyResolving, cycleCount, classification });
 
@@ -457,6 +546,13 @@ export function runResolveConflictSweepPass({
         // mark-and-dispatch
         if (!enforce) {
           fire("resolve-conflict.would.mark", { ticket: c.ticket, phase: c.phase });
+          // #1461 Fix 4: the enforce path fires TWO distinct events for this
+          // action (marked.resolvable, then dispatched once markAndDispatch
+          // actually dispatches) — resolve-conflict.would.dispatch was in the
+          // closed vocabulary but never fired on the shadow twin, leaving it
+          // dead on both ends. Fire it alongside would.mark so shadow mode has
+          // full observability parity with what enforce would actually do.
+          fire("resolve-conflict.would.dispatch", { ticket: c.ticket, phase: c.phase });
           report.wouldMark.push({ ticket: c.ticket, phase: c.phase });
           continue;
         }
@@ -483,4 +579,42 @@ export function runResolveConflictSweepPass({
 
     return report;
   })();
+}
+
+// emitResolveConflictEvent — #1461 Fix 4 (IMPORTANT final-review finding):
+// dedicated unified-log emitter for the resolve-conflict-sweep vocabulary,
+// mirroring emitUnstuckEvent (unstuck-sweep.mjs) exactly. Without this, the
+// production `runTick` never set an `emit` seam, so runResolveConflictSweepPass
+// fell back to its own internal no-op default (`emit = async () => true`) —
+// shadow mode produced ZERO event output, defeating ADR-023's shadow-then-
+// enforce discipline: an operator flipping CATALYST_RESOLVE_CONFLICT_SWEEP=shadow
+// had no way to see what the sweep WOULD have done. Validates against this
+// sweep's OWN closed vocabulary (RESOLVE_CONFLICT_SWEEP_EVENT_TYPES) and
+// appends to the same unified log getEventLogPath() resolves to. Logs (does
+// NOT silently swallow) an append failure — this also closes the related
+// deferred finding that the driver's own `fire()` helper swallows emit
+// rejections with zero observability: now that a real logging emitter is
+// wired, an append failure is at least visible in the daemon's own logs.
+export async function emitResolveConflictEvent(eventType, fields = {}) {
+  if (!RESOLVE_CONFLICT_SWEEP_EVENT_TYPES.includes(eventType)) {
+    throw new Error(`unknown resolve-conflict-sweep event type: ${eventType}`);
+  }
+  const payload = {
+    ts: new Date().toISOString().replace(/\.\d{3}Z$/, "Z"),
+    event: eventType,
+  };
+  for (const [k, v] of Object.entries(fields)) {
+    if (v === undefined || v === null || v === "") continue;
+    payload[k] = v;
+  }
+  const line = JSON.stringify(payload) + "\n";
+  const logPath = getEventLogPath();
+  try {
+    mkdirSync(dirname(logPath), { recursive: true });
+    appendFileSync(logPath, line);
+    return true;
+  } catch (err) {
+    log.error({ err: err?.message, eventType }, "emitResolveConflictEvent: append failed (#1461)");
+    return false;
+  }
 }

--- a/plugins/dev/scripts/execution-core/resolve-conflict-sweep.mjs
+++ b/plugins/dev/scripts/execution-core/resolve-conflict-sweep.mjs
@@ -12,7 +12,7 @@
 // recovery-reasoning.mjs) checking `stalledReason`. This module checks BOTH
 // fields defensively so it actually finds real candidates in production.
 
-import { readdirSync, readFileSync, mkdirSync, writeFileSync, renameSync, appendFileSync } from "node:fs";
+import { readdirSync, readFileSync, mkdirSync, writeFileSync, renameSync, appendFileSync, rmSync } from "node:fs";
 import { join, dirname } from "node:path";
 import { createRequire } from "node:module";
 import { spawnSync } from "node:child_process";
@@ -219,6 +219,104 @@ export function markStalledSignalResolving(
 // markStalledSignalResolving rewrites.
 const RESOLVE_CONFLICT_DISPATCH_PHASE = "resolve-conflict";
 
+// RESOLVE_CONFLICT_CYCLE_TERMINAL_STATUSES — a workers/<T>/phase-resolve-conflict.json
+// in one of these statuses represents a FINISHED prior cycle — success (`done`),
+// a hard failure (`failed`), or a dead/never-launched attempt (`stalled`, the
+// launch-failure path — phase-agent-dispatch's mark_launch_failed). Safe to reset.
+// `dispatched`/`running` are deliberately excluded: those mean a worker may
+// still be genuinely in flight, and resetting would pull the rug out from under
+// real in-progress work — see maybeResetForResolveConflictCycle below.
+const RESOLVE_CONFLICT_CYCLE_TERMINAL_STATUSES = new Set(["done", "failed", "stalled"]);
+
+// maybeResetForResolveConflictCycle — final-whole-branch-re-review follow-up
+// (#1461). Mirrors scheduler.mjs's maybeResetForRemediateCycle (CTL-653)
+// exactly in spirit, adapted to resolve-conflict-sweep's shape: there is no
+// verify⇄remediate PAIR here — just the single `resolve-conflict` dispatch
+// phase, re-entered every time the SAME ticket stalls again for a genuinely NEW
+// source conflict.
+//
+// The gap: defaultMarkAndDispatch calls dispatch(orchDir, ticket,
+// "resolve-conflict") on every mark-and-dispatch decision. phase-agent-dispatch's
+// own idempotency guard (phase-agent-dispatch: `if EXISTING_STATUS ==
+// dispatched|running|done → no-op idempotent`) treats a SECOND dispatch call as
+// a no-op whenever workers/<T>/phase-resolve-conflict.json still shows a status
+// from the FIRST cycle — because nothing ever deletes that file once the cycle
+// finishes (defaultClearStall only ever deletes the ORIGINAL stalled-phase
+// signal, e.g. phase-implement.json, never phase-resolve-conflict.json itself).
+// defaultCollectResolveConflictCompletions then reads the STALE "done" as a
+// fresh completion and clearStall fires with zero real resolution work having
+// happened on cycle 2+. Repeats forever: no phase.resolve-conflict.complete/
+// failed event is ever emitted for cycle 2+, so countResolveConflictAttempts
+// never advances past cycle 1's contribution and RESOLVE_CONFLICT_CYCLE_CAP can
+// never trip — an unresolvable, recurring conflict spins forever instead of
+// ever escalating to a human.
+//
+// The fix: before defaultMarkAndDispatch initiates a NEW dispatch for a
+// candidate, delete the STALE workers/<T>/phase-resolve-conflict.json (+ its
+// resolve-conflict-brief.json artifact) IF AND ONLY IF the signal is in a
+// terminal status (RESOLVE_CONFLICT_CYCLE_TERMINAL_STATUSES) — a completed/dead
+// prior cycle, never an in-flight one. Also drops the phase's CTL-736
+// single-flight claim tombstones (`resolve-conflict.claim.<gen>`) so
+// phase-agent-dispatch's fresh (no-signal ⇒ gen 1) claim is exclusive instead of
+// colliding with a leftover gen-1 tombstone from the prior cycle (GATE-0,
+// mirrored from maybeResetForRemediateCycle's own claim-tombstone clear) — and
+// any `.progress-resolve-conflict` high-water marker, so a fresh attempt is
+// measured from zero rather than false-STOPPED by the prior cycle's progress.
+//
+// Safety-critical: an in-flight (`dispatched`/`running`) signal is left
+// completely untouched — this function only ever fires immediately before
+// defaultMarkAndDispatch's own fresh dispatch call, never on an independent
+// schedule that could race with an actual live worker.
+//
+// Returns true when a reset happened (there was a terminal signal to clear);
+// false when there was nothing to reset — no signal at all (the common first-
+// cycle case), an unreadable/malformed signal, or an in-flight one (left alone).
+export function maybeResetForResolveConflictCycle(
+  orchDir,
+  ticket,
+  { rmSync: rm = rmSync, readFileSync: readFile = readFileSync, readdirSync: readdir = readdirSync } = {},
+) {
+  const workerDir = join(orchDir, "workers", ticket);
+  const signalPath = join(workerDir, `phase-${RESOLVE_CONFLICT_DISPATCH_PHASE}.json`);
+  let sig;
+  try {
+    sig = JSON.parse(readFile(signalPath, "utf8"));
+  } catch {
+    return false; // absent/unreadable — nothing to reset (first cycle, or already clean)
+  }
+  if (!RESOLVE_CONFLICT_CYCLE_TERMINAL_STATUSES.has(sig?.status)) {
+    return false; // dispatched/running (or any other non-terminal status) — never touch
+  }
+  try {
+    rm(signalPath, { force: true });
+  } catch {
+    // best-effort — a missing file is the desired end state anyway
+  }
+  try {
+    rm(join(workerDir, "resolve-conflict-brief.json"), { force: true });
+  } catch {
+    /* best-effort */
+  }
+  let workerEntries;
+  try {
+    workerEntries = readdir(workerDir);
+  } catch {
+    workerEntries = []; // worker dir gone — nothing left to clean
+  }
+  for (const f of workerEntries) {
+    const isClaim = f.startsWith(`${RESOLVE_CONFLICT_DISPATCH_PHASE}.claim.`);
+    const isProgress = f === `.progress-${RESOLVE_CONFLICT_DISPATCH_PHASE}`;
+    if (isClaim || isProgress) {
+      try {
+        rm(join(workerDir, f), { force: true });
+      } catch {
+        /* best-effort */
+      }
+    }
+  }
+  return true;
+}
+
 // defaultMarkAndDispatch — the "mark-and-dispatch" action seam. Mirrors
 // defaultInvokeRecoveryPass's dispatch section (recovery-reasoning.mjs:1650-
 // 1828) exactly: lazy-require dispatch.mjs (avoids loading the dispatch graph
@@ -237,6 +335,24 @@ export function defaultMarkAndDispatch(
   { ticket, phase, workerDir, worktreePath, base, classification, cycleCount, orchDir },
   deps = {},
 ) {
+  // #1461 follow-up (final whole-branch re-review): reset a STALE terminal
+  // workers/<T>/phase-resolve-conflict.json (+ its claim tombstones/artifact)
+  // left over from a completed prior cycle, so THIS fresh dispatch is not
+  // silently swallowed as idempotent by phase-agent-dispatch's own guard. Runs
+  // immediately before initiating the dispatch below — never on an independent
+  // schedule — and never touches an in-flight (dispatched/running) signal; see
+  // maybeResetForResolveConflictCycle for the full rationale. Best-effort: a
+  // reset failure must not block the dispatch attempt (same degrade-and-
+  // continue discipline as the rest of this function).
+  try {
+    maybeResetForResolveConflictCycle(orchDir, ticket, deps);
+  } catch (err) {
+    log.warn(
+      { ticket, phase, err: err?.message },
+      "resolve-conflict-sweep: cycle-reset failed (#1461) — proceeding with dispatch anyway"
+    );
+  }
+
   const signalPath = join(workerDir, `phase-${phase}.json`);
   try {
     markStalledSignalResolving(signalPath, deps);

--- a/plugins/dev/scripts/execution-core/resolve-conflict-sweep.mjs
+++ b/plugins/dev/scripts/execution-core/resolve-conflict-sweep.mjs
@@ -221,12 +221,21 @@ const RESOLVE_CONFLICT_DISPATCH_PHASE = "resolve-conflict";
 
 // RESOLVE_CONFLICT_CYCLE_TERMINAL_STATUSES — a workers/<T>/phase-resolve-conflict.json
 // in one of these statuses represents a FINISHED prior cycle — success (`done`),
-// a hard failure (`failed`), or a dead/never-launched attempt (`stalled`, the
-// launch-failure path — phase-agent-dispatch's mark_launch_failed). Safe to reset.
-// `dispatched`/`running` are deliberately excluded: those mean a worker may
-// still be genuinely in flight, and resetting would pull the rug out from under
-// real in-progress work — see maybeResetForResolveConflictCycle below.
-const RESOLVE_CONFLICT_CYCLE_TERMINAL_STATUSES = new Set(["done", "failed", "stalled"]);
+// a hard failure (`failed`), a dead/never-launched attempt (`stalled`, the
+// launch-failure path — phase-agent-dispatch's mark_launch_failed, OR the
+// backstopOnRejection/defaultEmitBackstop rejection path — defaultWriteSignalStalled
+// writes the SAME `status:"stalled"` shape for a rejected async/codex dispatch),
+// or a maxTurns cutoff (`turn-cap-exhausted` — defaultEmitBackstop's OTHER
+// terminal shape, written by defaultWriteSignalTerminal to keep the on-disk
+// status matching its own distinct terminal event name). All four are safe to
+// reset. `dispatched`/`running` are deliberately excluded: those mean a worker
+// may still be genuinely in flight, and resetting would pull the rug out from
+// under real in-progress work — see maybeResetForResolveConflictCycle below.
+// Escalation-gap fix (#1461 review follow-up): this is also the exact set
+// defaultCollectResolveConflictFailures (below) reuses to recognize a FAILED
+// resolve-conflict cycle in any of its real shapes, not just the in-skill
+// `status:"failed"` hard-error path.
+const RESOLVE_CONFLICT_CYCLE_TERMINAL_STATUSES = new Set(["done", "failed", "stalled", "turn-cap-exhausted"]);
 
 // maybeResetForResolveConflictCycle — final-whole-branch-re-review follow-up
 // (#1461). Mirrors scheduler.mjs's maybeResetForRemediateCycle (CTL-653)
@@ -556,18 +565,46 @@ export function defaultCollectResolveConflictCompletions({
 
 // defaultCollectResolveConflictFailures — escalation-gap fix (#1461 final-
 // review follow-up). Census sibling of defaultCollectResolveConflictCompletions,
-// same read-only discipline, but keyed on `phase-resolve-conflict.json`'s
-// status:"failed" instead of "done". Before this function existed, a FAILED
-// resolve-conflict run was invisible to every collector in this file: the cap
-// counter (countResolveConflictAttempts, event-scan.mjs) already incremented
-// correctly on the ticket's `phase.resolve-conflict.failed.<ticket>` event, but
-// nothing ever reverted the ORIGINAL stalled phase's RESOLVED_MARKER_REASON
-// marker that markStalledSignalResolving wrote before dispatch — so the ticket
-// could never again satisfy classifyResolveConflictCandidate's
-// stalledReasonMatches/alreadyResolving-at-cap branches on a FRESH classify pass
-// once it had been re-armed. See runResolveConflictSweepPass's failures sub-pass
-// (below) for the two outcomes this feeds: escalate (at/over cap) or revert +
-// reset (under cap).
+// same read-only discipline, but keyed on `phase-resolve-conflict.json` landing
+// in any FAILURE-shaped terminal status instead of "done". Before this function
+// existed, a FAILED resolve-conflict run was invisible to every collector in
+// this file: the cap counter (countResolveConflictAttempts, event-scan.mjs)
+// already incremented correctly on the ticket's `phase.resolve-conflict.failed.
+// <ticket>` event, but nothing ever reverted the ORIGINAL stalled phase's
+// RESOLVED_MARKER_REASON marker that markStalledSignalResolving wrote before
+// dispatch — so the ticket could never again satisfy
+// classifyResolveConflictCandidate's stalledReasonMatches/alreadyResolving-at-cap
+// branches on a FRESH classify pass once it had been re-armed. See
+// runResolveConflictSweepPass's failures sub-pass (below) for the two outcomes
+// this feeds: escalate (at/over cap) or revert + reset (under cap).
+//
+// CTL review follow-up (post-fb135a0c): a bare `status === "failed"` check only
+// matched the in-skill hard-error path (phase-agent-emit-complete
+// --status failed). It MISSED the other two real failure shapes a resolve-
+// conflict dispatch can land in on-disk:
+//   - phase-agent-dispatch's mark_launch_failed (a dead/never-launched
+//     attempt) writes `status:"stalled"` (+ `attentionReason`, NOT
+//     `failureReason`/`stalledReason`) and emits phase.resolve-conflict.failed
+//     with --no-signal-update — so the durable counter climbs but the on-disk
+//     signal reads "stalled", not "failed".
+//   - dispatch.mjs's backstopOnRejection → defaultEmitBackstop writes the SAME
+//     `status:"stalled"` shape (via defaultWriteSignalStalled) for a REJECTED
+//     async/codex dispatch — this is defaultMarkAndDispatch's OWN `onSettled`
+//     handler (see below), so under an all-codex/all-sdk executor routing this
+//     is the LIVE production dispatch-failure path, and the ORIGINAL bare
+//     check missed it entirely.
+//   - the same backstop's maxTurns outcome writes `status:"turn-cap-exhausted"`
+//     (a THIRD terminal shape, kept distinct from "stalled" so its status
+//     matches its own differently-named terminal event).
+// Fix: match RESOLVE_CONFLICT_CYCLE_TERMINAL_STATUSES (the same set
+// maybeResetForResolveConflictCycle already uses to decide this exact file is
+// resettable) minus "done" — i.e. {failed, stalled, turn-cap-exhausted} — so
+// every real failure shape is recognized, not just the narrowest one. This is
+// safe: mark_launch_failed / defaultWriteSignalStalled write `attentionReason`,
+// not `failureReason`/`stalledReason`, so defaultCollectResolveConflictCandidates
+// resolves this SAME file's `reason` to null and never double-treats
+// phase-resolve-conflict.json itself as a candidate; `dispatched`/`running` stay
+// correctly excluded either way (not in the terminal set).
 //
 // Same idempotence guard as Fix 1's completions collector, and for the exact
 // same reason: report a genuine, not-yet-acted-on failure ONLY while the
@@ -608,7 +645,8 @@ export function defaultCollectResolveConflictFailures({
       } catch {
         continue; // no resolve-conflict signal for this ticket
       }
-      if (sig?.status !== "failed") continue;
+      if (sig?.status === "done") continue; // that's defaultCollectResolveConflictCompletions's job
+      if (!RESOLVE_CONFLICT_CYCLE_TERMINAL_STATUSES.has(sig?.status)) continue; // dispatched/running/undefined/etc. — not a finished failure
       let brief;
       try {
         brief = JSON.parse(readFile(join(workerDir, "resolve-conflict-brief.json"), "utf8"));
@@ -652,10 +690,15 @@ export function defaultCollectResolveConflictFailures({
 //
 // Once step 1 lands, defaultCollectResolveConflictFailures's own idempotence
 // guard stops re-reporting this failure (the reason no longer matches
-// RESOLVED_MARKER_REASON), and on a LATER tick
-// defaultCollectResolveConflictCandidates picks the ticket back up as a genuine
-// RESOLVE_CONFLICT_STALL_REASON candidate — classifyResolveConflictCandidate
-// then re-evaluates it fresh, exactly as if this were the ticket's first stall.
+// RESOLVED_MARKER_REASON). Because runResolveConflictSweepPass's candidates
+// sub-pass runs synchronously right after the failures sub-pass IN THE SAME
+// TICK (collectCandidates() re-reads the filesystem fresh, after this revert
+// has already landed on disk), defaultCollectResolveConflictCandidates can
+// pick the ticket back up as a genuine RESOLVE_CONFLICT_STALL_REASON candidate
+// in that SAME tick — classifyResolveConflictCandidate then re-evaluates it
+// fresh, exactly as if this were the ticket's first stall, and a fresh
+// mark-and-dispatch can fire before this tick even ends (not merely "a later
+// tick" — this revert is often invisible for less than one scheduler tick).
 //
 // Best-effort per step, mirroring defaultMarkAndDispatch's cycle-reset call:
 // step 2 failing must not undo step 1 (the revert is the safety-critical part —
@@ -677,6 +720,25 @@ export function defaultRevertStallAndResetCycle(
   const signalPath = join(workerDir, `phase-${stalledPhase}.json`);
   try {
     const sig = JSON.parse(readFile(signalPath, "utf8"));
+    // M2 (review follow-up): defensive re-check — only overwrite the reason if
+    // it's STILL RESOLVED_MARKER_REASON at the moment of the write. The
+    // collector already guards on this at census time, but a narrow window
+    // exists between that read and this write in which a concurrent writer
+    // (an operator re-arming the ticket, or a parallel recovery-pass/cap-
+    // exhaustion path) could have already changed the reason — e.g. to
+    // CAP_EXHAUSTED_REASON. Silently clobbering that with a stale revert would
+    // resurrect a ticket that was just correctly terminal-escalated. A
+    // mismatch here is not an error — something else already owns this
+    // ticket's stall — so this returns false (not-acted), same shape as any
+    // other no-op outcome, and never throws.
+    const currentReason = ("stalledReason" in sig ? sig.stalledReason : sig.failureReason) ?? null;
+    if (currentReason !== RESOLVED_MARKER_REASON) {
+      log.warn(
+        { ticket, stalledPhase, currentReason },
+        "resolve-conflict-sweep: stall reason changed out from under the revert (#1461 escalation-gap fix) — leaving it to whatever owns it now"
+      );
+      return false;
+    }
     if ("stalledReason" in sig) sig.stalledReason = RESOLVE_CONFLICT_STALL_REASON;
     else sig.failureReason = RESOLVE_CONFLICT_STALL_REASON;
     sig.updatedAt = new Date().toISOString();
@@ -785,13 +847,15 @@ export function runResolveConflictSweepPass({
     // ---- failures (#1461 escalation-gap fix): a FAILED resolve-conflict run
     // either escalates (at/over cap, via the SAME escalateCapExhausted seam the
     // candidates sub-pass below uses) or reverts the original stall + resets the
-    // stale cycle (under cap) so the ticket becomes a genuine candidate again on
-    // a later tick. See defaultCollectResolveConflictFailures /
-    // defaultRevertStallAndResetCycle above for the full rationale — this is a
-    // NEW, parallel path; it never touches a "done" completion (that's the
-    // completions sub-pass above) and never touches a dispatched/running signal
-    // (the collector's own idempotence guard + status:"failed" filter exclude
-    // those entirely).
+    // stale cycle (under cap) so the ticket becomes a genuine candidate again —
+    // and since collectCandidates() below runs synchronously right after this
+    // loop, in the SAME tick, a reverted ticket can be re-classified and
+    // re-dispatched before this tick even ends, not merely "on a later tick".
+    // See defaultCollectResolveConflictFailures / defaultRevertStallAndResetCycle
+    // above for the full rationale — this is a NEW, parallel path; it never
+    // touches a "done" completion (that's the completions sub-pass above) and
+    // never touches a dispatched/running signal (the collector's own
+    // idempotence guard + terminal-status filter exclude those entirely).
     let failures = [];
     try {
       failures = collectFailures() ?? [];

--- a/plugins/dev/scripts/execution-core/resolve-conflict-sweep.mjs
+++ b/plugins/dev/scripts/execution-core/resolve-conflict-sweep.mjs
@@ -308,3 +308,179 @@ export function defaultEscalateCapExhausted(
   const body = `🔼 **phase-resolve-conflict** escalated this to the operator — ${ticket}/${phase} hit the resolve-conflict cycle cap (${RESOLVE_CONFLICT_CYCLE_CAP}) after ${cycleCount} attempt(s) without a clean resolution; manual conflict resolution needed.`;
   return postComment(ticket, body);
 }
+
+// defaultCollectResolveConflictCompletions — find every ticket whose
+// resolve-conflict phase signal is "done" and read which original phase to
+// clear from resolve-conflict-brief.json's stalledPhase. Read-only.
+export function defaultCollectResolveConflictCompletions({
+  orchDir,
+  readdirSync: readdir = readdirSync,
+  readFileSync: readFile = readFileSync,
+} = {}) {
+  const out = [];
+  let workerDirs;
+  try {
+    workerDirs = readdir(join(orchDir, "workers"), { withFileTypes: true });
+  } catch {
+    return out;
+  }
+  for (const d of workerDirs) {
+    if (!d.isDirectory()) continue;
+    const ticket = d.name;
+    if (!isTicketKey(ticket)) continue;
+    try {
+      const workerDir = join(orchDir, "workers", ticket);
+      let sig;
+      try {
+        sig = JSON.parse(readFile(join(workerDir, "phase-resolve-conflict.json"), "utf8"));
+      } catch {
+        continue; // no resolve-conflict signal for this ticket
+      }
+      if (sig?.status !== "done") continue;
+      let brief;
+      try {
+        brief = JSON.parse(readFile(join(workerDir, "resolve-conflict-brief.json"), "utf8"));
+      } catch {
+        continue; // done signal but no brief — cannot know which phase to clear
+      }
+      if (!brief?.stalledPhase) continue;
+      out.push({ ticket, stalledPhase: brief.stalledPhase });
+    } catch {
+      continue;
+    }
+  }
+  return out;
+}
+
+// runResolveConflictSweepPass — the action driver. Every side-effect seam is
+// injected; mirrors runUnstuckSweepPass's off/shadow/enforce shape + report.
+// Two independent sub-passes per tick: (1) candidates → classify → mark-and-
+// dispatch or cap-exhausted-escalate; (2) completions → clearStall. Order is
+// completions-then-candidates so a just-completed ticket's stall is cleared
+// before that same tick's candidate scan would otherwise re-see it (defensive;
+// either order is safe since a cleared ticket has no more stalled signal).
+// NOTE: deliberately NOT declared `async` at the top level. Mode "off" must
+// return the plain report object synchronously (no Promise wrapper) so a
+// caller can check it without awaiting; shadow/enforce need `await
+// classifyLive(...)` internally, so that path is delegated to an inner async
+// IIFE and its Promise is returned instead. Either way the caller may safely
+// `await` the result — awaiting a non-Promise is a no-op.
+export function runResolveConflictSweepPass({
+  mode = "off",
+  collectCandidates = () => [],
+  collectCompletions = () => [],
+  classifyLive = async () => null,
+  cycleCountOf = () => 0,
+  markAndDispatch = () => ({ success: false, dispatched: false }),
+  escalateCapExhausted = () => false,
+  clearStall = () => false,
+  emit = async () => true,
+} = {}) {
+  const report = { marked: [], wouldMark: [], escalated: [], wouldEscalate: [], cleared: [], wouldClear: [], skipped: [], failed: [] };
+  if (mode === "off") return report;
+  const enforce = mode === "enforce";
+
+  return (async () => {
+    const fire = (type, fields) => {
+      try {
+        const p = emit(type, fields);
+        if (p && typeof p.catch === "function") p.catch(() => {});
+      } catch {
+        /* best-effort */
+      }
+    };
+
+    // ---- completions: clear the stall for a finished resolve-conflict run ----
+    let completions = [];
+    try {
+      completions = collectCompletions() ?? [];
+    } catch {
+      completions = [];
+    }
+    for (const c of completions) {
+      try {
+        if (!enforce) {
+          fire("resolve-conflict.would.clear", { ticket: c.ticket, phase: c.stalledPhase });
+          report.wouldClear.push({ ticket: c.ticket, phase: c.stalledPhase });
+          continue;
+        }
+        const ok = clearStall({ ticket: c.ticket, phase: c.stalledPhase });
+        if (ok === false) {
+          report.failed.push({ ticket: c.ticket, phase: c.stalledPhase, reason: "clearStall-returned-false" });
+          continue;
+        }
+        fire("resolve-conflict.cleared", { ticket: c.ticket, phase: c.stalledPhase });
+        report.cleared.push({ ticket: c.ticket, phase: c.stalledPhase });
+      } catch (err) {
+        report.failed.push({ ticket: c?.ticket, phase: c?.stalledPhase, reason: err?.message });
+      }
+    }
+
+    // ---- candidates: classify then mark-and-dispatch / cap-exhausted ----
+    let candidates = [];
+    try {
+      candidates = collectCandidates() ?? [];
+    } catch {
+      return report; // a throwing census degrades to "nothing to do" this tick
+    }
+    for (const c of candidates) {
+      try {
+        const reason = c.raw?.failureReason ?? c.raw?.stalledReason ?? null;
+        const stalledReasonMatches = reason === RESOLVE_CONFLICT_STALL_REASON;
+        const alreadyResolving = reason === RESOLVED_MARKER_REASON;
+        const cycleCount = cycleCountOf(c.ticket);
+        // Only probe merge-tree for a reason this sweep actually owns — never
+        // spawn git for a not-our-stall candidate (classifier would skip it anyway).
+        const classification =
+          stalledReasonMatches && cycleCount < RESOLVE_CONFLICT_CYCLE_CAP
+            ? await classifyLive({ worktreePath: c.worktreePath, base: c.base, head: c.ticket })
+            : null;
+        const decision = classifyResolveConflictCandidate({ stalledReasonMatches, alreadyResolving, cycleCount, classification });
+
+        if (decision.action === "skip") {
+          report.skipped.push({ ticket: c.ticket, phase: c.phase, reason: decision.reason });
+          continue;
+        }
+
+        if (decision.action === "cap-exhausted") {
+          if (!enforce) {
+            fire("resolve-conflict.would.escalate", { ticket: c.ticket, phase: c.phase });
+            report.wouldEscalate.push({ ticket: c.ticket, phase: c.phase });
+            continue;
+          }
+          const posted = escalateCapExhausted({ ticket: c.ticket, phase: c.phase, workerDir: c.workerDir, cycleCount });
+          fire("resolve-conflict.escalated", { ticket: c.ticket, phase: c.phase, posted });
+          report.escalated.push({ ticket: c.ticket, phase: c.phase });
+          continue;
+        }
+
+        // mark-and-dispatch
+        if (!enforce) {
+          fire("resolve-conflict.would.mark", { ticket: c.ticket, phase: c.phase });
+          report.wouldMark.push({ ticket: c.ticket, phase: c.phase });
+          continue;
+        }
+        const result = markAndDispatch({
+          ticket: c.ticket,
+          phase: c.phase,
+          workerDir: c.workerDir,
+          worktreePath: c.worktreePath,
+          base: c.base,
+          classification,
+          cycleCount,
+        });
+        if (!result?.success) {
+          report.failed.push({ ticket: c.ticket, phase: c.phase, reason: result?.reason ?? "mark-and-dispatch-failed" });
+          continue;
+        }
+        fire("resolve-conflict.marked.resolvable", { ticket: c.ticket, phase: c.phase });
+        if (result.dispatched) fire("resolve-conflict.dispatched", { ticket: c.ticket, phase: c.phase });
+        report.marked.push({ ticket: c.ticket, phase: c.phase });
+      } catch (err) {
+        report.failed.push({ ticket: c?.ticket, phase: c?.phase, reason: err?.message });
+      }
+    }
+
+    return report;
+  })();
+}

--- a/plugins/dev/scripts/execution-core/resolve-conflict-sweep.mjs
+++ b/plugins/dev/scripts/execution-core/resolve-conflict-sweep.mjs
@@ -47,6 +47,11 @@ export function classifyResolveConflictCandidate(ctx = {}) {
     return { action: "skip", reason: "not-our-stall" };
   }
   if (cycleCount >= RESOLVE_CONFLICT_CYCLE_CAP) {
+    // NOTE: this "cycle-cap-exhausted" string is this classifier's own decision-
+    // object vocabulary (report.wouldEscalate/escalated reasons), a SEPARATE
+    // namespace from the exported CAP_EXHAUSTED_REASON constant below (which is
+    // the value written into the SIGNAL's failureReason/stalledReason field by
+    // defaultEscalateCapExhausted). Do not conflate the two when grepping.
     return { action: "cap-exhausted", reason: "cycle-cap-exhausted" };
   }
   if (alreadyResolving) {
@@ -235,6 +240,35 @@ const RESOLVE_CONFLICT_DISPATCH_PHASE = "resolve-conflict";
 // defaultCollectResolveConflictFailures (below) reuses to recognize a FAILED
 // resolve-conflict cycle in any of its real shapes, not just the in-skill
 // `status:"failed"` hard-error path.
+//
+// Interaction with orchestrate-revive's legacy phase-mode retry sweep (#1461
+// follow-up, verified 2026-08-02): orchestrate-revive globs every
+// workers/<T>/phase-*.json, including phase-resolve-conflict.json, and its
+// CTL-607 current-phase guard computes CURRENT_PHASE via
+// lib/phase-sequence.sh's latest_phase_in_dir(), which only walks the 10
+// canonical PHASES entries (triage..teardown) — "resolve-conflict" is not one
+// of them. So P_PHASE="resolve-conflict" can NEVER equal CURRENT_PHASE, and
+// phase-resolve-conflict.json is unconditionally skipped by that guard on
+// every pass, regardless of its status. orchestrate-revive can never
+// re-dispatch or escalate this file directly.
+//
+// The ORIGINAL stalled phase's own signal (e.g. phase-implement.json) IS
+// reachable, though: while resolve-conflict-sweep is mid-cycle its
+// failureReason/stalledReason reads RESOLVED_MARKER_REASON (a non-empty
+// string), and orchestrate-revive's phase_is_truly_failed() only checks for a
+// non-empty .failureReason — it does not know this marker value is a
+// resolve-conflict-owned in-flight state, not a real failure. If
+// orchestrate-revive's phase-mode loop scans this ticket's worker dir while
+// the marker is set, it raises a spurious phase-failed-unrecoverable
+// attention item instead of a silent no-op. See
+// __tests__/orchestrate-revive-phase.test.sh Test I for both properties
+// proven directly against the real script.
+//
+// Blast radius is narrow: orchestrate-revive is invoked ONLY by the legacy
+// catalyst-legacy:orchestrate wave loop (grep confirms no execution-core
+// scheduler/daemon path calls it) — a team running dispatchMode:
+// execution-core exclusively never has this loop running against the same
+// worker dir, so the overlap only exists under a mixed/legacy deployment.
 const RESOLVE_CONFLICT_CYCLE_TERMINAL_STATUSES = new Set(["done", "failed", "stalled", "turn-cap-exhausted"]);
 
 // maybeResetForResolveConflictCycle — final-whole-branch-re-review follow-up
@@ -767,9 +801,10 @@ export function defaultRevertStallAndResetCycle(
 // injected; mirrors runUnstuckSweepPass's off/shadow/enforce shape + report.
 // Three independent sub-passes per tick: (1) candidates → classify → mark-and-
 // dispatch or cap-exhausted-escalate; (2) completions (status:"done") →
-// clearStall; (3) failures (status:"failed", #1461 escalation-gap fix) →
-// cap-exhausted-escalate or revert-and-reset-cycle. Order is
-// completions-then-failures-then-candidates so a just-completed or
+// clearStall; (3) failures (any RESOLVE_CONFLICT_CYCLE_TERMINAL_STATUSES shape
+// minus "done" — failed/stalled/turn-cap-exhausted, #1461 escalation-gap fix
+// widened at classify time) → cap-exhausted-escalate or revert-and-reset-cycle.
+// Order is completions-then-failures-then-candidates so a just-completed or
 // just-failed ticket's stall is cleared/reverted before that same tick's
 // candidate scan would otherwise re-see it (defensive; either order is safe
 // since an acted-on ticket no longer carries the marker the candidate census
@@ -934,15 +969,16 @@ export function runResolveConflictSweepPass({
           continue;
         }
 
-        // mark-and-dispatch
+        if (decision.action !== "mark-and-dispatch") {
+          // Defensive — classifyResolveConflictCandidate's closed return set never
+          // produces anything else today; a future new action value must not
+          // silently fall into mark-and-dispatch.
+          report.failed.push({ ticket: c.ticket, phase: c.phase, reason: `unknown classifier action: ${decision.action}` });
+          continue;
+        }
+
         if (!enforce) {
           fire("resolve-conflict.would.mark", { ticket: c.ticket, phase: c.phase });
-          // #1461 Fix 4: the enforce path fires TWO distinct events for this
-          // action (marked.resolvable, then dispatched once markAndDispatch
-          // actually dispatches) — resolve-conflict.would.dispatch was in the
-          // closed vocabulary but never fired on the shadow twin, leaving it
-          // dead on both ends. Fire it alongside would.mark so shadow mode has
-          // full observability parity with what enforce would actually do.
           fire("resolve-conflict.would.dispatch", { ticket: c.ticket, phase: c.phase });
           report.wouldMark.push({ ticket: c.ticket, phase: c.phase });
           continue;

--- a/plugins/dev/scripts/execution-core/resolve-conflict-sweep.test.mjs
+++ b/plugins/dev/scripts/execution-core/resolve-conflict-sweep.test.mjs
@@ -17,6 +17,8 @@ import {
   maybeResetForResolveConflictCycle,
   defaultEscalateCapExhausted,
   defaultCollectResolveConflictCompletions,
+  defaultCollectResolveConflictFailures,
+  defaultRevertStallAndResetCycle,
   runResolveConflictSweepPass,
   emitResolveConflictEvent,
   RESOLVE_CONFLICT_SWEEP_EVENT_TYPES,
@@ -720,11 +722,221 @@ describe("defaultCollectResolveConflictCompletions", () => {
   });
 });
 
+// #1461 escalation-gap fix (final-review follow-up, not an automated reviewer
+// this time): defaultCollectResolveConflictCompletions ONLY ever recognized
+// status:"done" — a status:"failed" phase-resolve-conflict.json was invisible
+// to every collector, so the ticket's RESOLVED_MARKER_REASON marker never
+// reverted after a genuine failure and the ticket silently fell out of
+// candidacy forever, no matter how high the (correctly-incrementing) cap
+// counter climbed. This describe block covers the new failure census.
+describe("defaultCollectResolveConflictFailures (#1461 escalation-gap fix)", () => {
+  function fakeFs({ workerDirs, files }) {
+    return {
+      readdirSync: (p, opts) => (opts?.withFileTypes ? (workerDirs[p] ?? []).map((n) => ({ name: n, isDirectory: () => true })) : (files[p] ?? [])),
+      readFileSync: (p) => { if (!(p in files)) throw new Error(`ENOENT: ${p}`); return files[p]; },
+    };
+  }
+
+  test("finds a ticket whose resolve-conflict phase FAILED, the brief names the stalled phase, and that phase is still marked resolving", () => {
+    const fs = fakeFs({
+      workerDirs: { "/orch/workers": ["CTL-1"] },
+      files: {
+        "/orch/workers/CTL-1": ["phase-resolve-conflict.json", "resolve-conflict-brief.json", "phase-implement.json"],
+        "/orch/workers/CTL-1/phase-resolve-conflict.json": JSON.stringify({ status: "failed" }),
+        "/orch/workers/CTL-1/resolve-conflict-brief.json": JSON.stringify({ stalledPhase: "implement" }),
+        "/orch/workers/CTL-1/phase-implement.json": JSON.stringify({ status: "stalled", failureReason: "source_conflict_resolvable" }),
+      },
+    });
+    const out = defaultCollectResolveConflictFailures({ orchDir: "/orch", ...fs });
+    expect(out).toEqual([{ ticket: "CTL-1", stalledPhase: "implement", workerDir: "/orch/workers/CTL-1" }]);
+  });
+
+  test("skips a ticket whose resolve-conflict phase is 'done' (that's the completions collector's job, not this one)", () => {
+    const fs = fakeFs({
+      workerDirs: { "/orch/workers": ["CTL-1"] },
+      files: {
+        "/orch/workers/CTL-1": ["phase-resolve-conflict.json", "resolve-conflict-brief.json", "phase-implement.json"],
+        "/orch/workers/CTL-1/phase-resolve-conflict.json": JSON.stringify({ status: "done" }),
+        "/orch/workers/CTL-1/resolve-conflict-brief.json": JSON.stringify({ stalledPhase: "implement" }),
+        "/orch/workers/CTL-1/phase-implement.json": JSON.stringify({ status: "stalled", failureReason: "source_conflict_resolvable" }),
+      },
+    });
+    expect(defaultCollectResolveConflictFailures({ orchDir: "/orch", ...fs })).toEqual([]);
+  });
+
+  // Safety-critical (c): an actually in-flight run must NEVER be touched by the
+  // new failure-handling path — proven here at the collector level, since the
+  // collector is what feeds the driver's failures sub-pass.
+  for (const inFlightStatus of ["dispatched", "running"]) {
+    test(`skips a ticket whose resolve-conflict phase is '${inFlightStatus}' (actually in flight — never touched)`, () => {
+      const fs = fakeFs({
+        workerDirs: { "/orch/workers": ["CTL-2"] },
+        files: {
+          "/orch/workers/CTL-2": ["phase-resolve-conflict.json", "resolve-conflict-brief.json", "phase-implement.json"],
+          "/orch/workers/CTL-2/phase-resolve-conflict.json": JSON.stringify({ status: inFlightStatus }),
+          "/orch/workers/CTL-2/resolve-conflict-brief.json": JSON.stringify({ stalledPhase: "implement" }),
+          "/orch/workers/CTL-2/phase-implement.json": JSON.stringify({ status: "stalled", failureReason: "source_conflict_resolvable" }),
+        },
+      });
+      expect(defaultCollectResolveConflictFailures({ orchDir: "/orch", ...fs })).toEqual([]);
+    });
+  }
+
+  test("skips a ticket with no resolve-conflict signal at all", () => {
+    const fs = fakeFs({ workerDirs: { "/orch/workers": ["CTL-3"] }, files: { "/orch/workers/CTL-3": ["phase-implement.json"] } });
+    expect(defaultCollectResolveConflictFailures({ orchDir: "/orch", ...fs })).toEqual([]);
+  });
+
+  test("skips a failed signal with no brief — cannot know which phase to act on", () => {
+    const fs = fakeFs({
+      workerDirs: { "/orch/workers": ["CTL-4"] },
+      files: {
+        "/orch/workers/CTL-4": ["phase-resolve-conflict.json"],
+        "/orch/workers/CTL-4/phase-resolve-conflict.json": JSON.stringify({ status: "failed" }),
+      },
+    });
+    expect(defaultCollectResolveConflictFailures({ orchDir: "/orch", ...fs })).toEqual([]);
+  });
+
+  // Idempotence guard — mirrors defaultCollectResolveConflictCompletions's own
+  // Fix-1 guard exactly, so the SAME failure is not re-collected forever once
+  // this sweep's failure-handling path has acted on it (reverted or escalated).
+  describe("idempotence guard", () => {
+    function filesFor(stalledSignalRaw) {
+      const files = {
+        "/orch/workers/CTL-1": ["phase-resolve-conflict.json", "resolve-conflict-brief.json", "phase-implement.json"],
+        "/orch/workers/CTL-1/phase-resolve-conflict.json": JSON.stringify({ status: "failed" }),
+        "/orch/workers/CTL-1/resolve-conflict-brief.json": JSON.stringify({ stalledPhase: "implement" }),
+      };
+      if (stalledSignalRaw !== undefined) {
+        files["/orch/workers/CTL-1/phase-implement.json"] = JSON.stringify(stalledSignalRaw);
+      }
+      return files;
+    }
+
+    test("(a) a failure is collected once when the stalled phase is still marked RESOLVED_MARKER_REASON", () => {
+      const fs = fakeFs({
+        workerDirs: { "/orch/workers": ["CTL-1"] },
+        files: filesFor({ status: "stalled", failureReason: "source_conflict_resolvable" }),
+      });
+      expect(defaultCollectResolveConflictFailures({ orchDir: "/orch", ...fs }))
+        .toEqual([{ ticket: "CTL-1", stalledPhase: "implement", workerDir: "/orch/workers/CTL-1" }]);
+    });
+
+    test("(b) NOT re-collected once the stalled-phase reason has been reverted back to RESOLVE_CONFLICT_STALL_REASON (simulates defaultRevertStallAndResetCycle having run)", () => {
+      const fs = fakeFs({
+        workerDirs: { "/orch/workers": ["CTL-1"] },
+        files: filesFor({ status: "stalled", failureReason: RESOLVE_CONFLICT_STALL_REASON }),
+      });
+      expect(defaultCollectResolveConflictFailures({ orchDir: "/orch", ...fs })).toEqual([]);
+    });
+
+    test("(c) NOT re-collected once escalated (CAP_EXHAUSTED_REASON)", () => {
+      const fs = fakeFs({
+        workerDirs: { "/orch/workers": ["CTL-1"] },
+        files: filesFor({ status: "stalled", failureReason: CAP_EXHAUSTED_REASON }),
+      });
+      expect(defaultCollectResolveConflictFailures({ orchDir: "/orch", ...fs })).toEqual([]);
+    });
+
+    test("(d) NOT re-collected once the stalled-phase signal file is gone entirely", () => {
+      const files = filesFor(undefined);
+      const fs = fakeFs({ workerDirs: { "/orch/workers": ["CTL-1"] }, files });
+      expect(defaultCollectResolveConflictFailures({ orchDir: "/orch", ...fs })).toEqual([]);
+    });
+  });
+});
+
+describe("defaultRevertStallAndResetCycle (#1461 escalation-gap fix)", () => {
+  const orchDir = "/orch";
+  const ticket = "CTL-1";
+  const workerDir = `${orchDir}/workers/${ticket}`;
+
+  test("reverts failureReason from RESOLVED_MARKER_REASON back to RESOLVE_CONFLICT_STALL_REASON, preserves other fields", () => {
+    const { files, deps } = inMemoryFs({
+      [`${workerDir}/phase-implement.json`]: JSON.stringify({ status: "stalled", failureReason: RESOLVED_MARKER_REASON, bg_job_id: "abc123" }),
+    });
+    const ok = defaultRevertStallAndResetCycle(orchDir, ticket, "implement", deps);
+    expect(ok).toBe(true);
+    const written = JSON.parse(files[`${workerDir}/phase-implement.json`]);
+    expect(written.status).toBe("stalled");
+    expect(written.failureReason).toBe(RESOLVE_CONFLICT_STALL_REASON);
+    expect(written.bg_job_id).toBe("abc123"); // untouched
+  });
+
+  test("reverts the legacy stalledReason field the same way", () => {
+    const { files, deps } = inMemoryFs({
+      [`${workerDir}/phase-implement.json`]: JSON.stringify({ status: "stalled", stalledReason: RESOLVED_MARKER_REASON }),
+    });
+    defaultRevertStallAndResetCycle(orchDir, ticket, "implement", deps);
+    expect(JSON.parse(files[`${workerDir}/phase-implement.json`]).stalledReason).toBe(RESOLVE_CONFLICT_STALL_REASON);
+  });
+
+  // REUSES maybeResetForResolveConflictCycle verbatim: the stale terminal
+  // phase-resolve-conflict.json (+ brief + claim tombstones/progress marker) is
+  // cleared in the same call, so a later re-classification doesn't immediately
+  // hit phase-agent-dispatch's own idempotency no-op.
+  test("also clears the stale terminal phase-resolve-conflict.json + brief + claim tombstone via the existing cycle-reset logic", () => {
+    const { files, deps } = inMemoryFs({
+      [`${workerDir}/phase-implement.json`]: JSON.stringify({ status: "stalled", failureReason: RESOLVED_MARKER_REASON }),
+      [`${workerDir}/phase-resolve-conflict.json`]: JSON.stringify({ status: "failed", generation: 1 }),
+      [`${workerDir}/resolve-conflict-brief.json`]: JSON.stringify({ stalledPhase: "implement", attempt: 1 }),
+      [`${workerDir}/resolve-conflict.claim.1`]: "{}",
+      [`${workerDir}/.progress-resolve-conflict`]: "3",
+    });
+    const ok = defaultRevertStallAndResetCycle(orchDir, ticket, "implement", deps);
+    expect(ok).toBe(true);
+    expect(`${workerDir}/phase-resolve-conflict.json` in files).toBe(false);
+    expect(`${workerDir}/resolve-conflict-brief.json` in files).toBe(false);
+    expect(`${workerDir}/resolve-conflict.claim.1` in files).toBe(false);
+    expect(`${workerDir}/.progress-resolve-conflict` in files).toBe(false);
+  });
+
+  test("malformed original signal JSON returns false instead of throwing, and never touches the reset", () => {
+    const { files, deps } = inMemoryFs({
+      [`${workerDir}/phase-implement.json`]: "{not valid json",
+      [`${workerDir}/phase-resolve-conflict.json`]: JSON.stringify({ status: "failed" }),
+    });
+    expect(() => defaultRevertStallAndResetCycle(orchDir, ticket, "implement", deps)).not.toThrow();
+    const ok = defaultRevertStallAndResetCycle(orchDir, ticket, "implement", deps);
+    expect(ok).toBe(false);
+    // The step-1 revert failed, so the reset (step 2) is skipped — the stale
+    // signal is left exactly as it was, for the next tick to retry cleanly.
+    expect(`${workerDir}/phase-resolve-conflict.json` in files).toBe(true);
+  });
+
+  // Safety-critical (c): even if this function were ever reached for a
+  // genuinely in-flight resolve-conflict run (it shouldn't be — the failures
+  // collector's status:"failed" filter is the real guarantee), the cycle-reset
+  // it reuses (maybeResetForResolveConflictCycle) independently refuses to
+  // touch a dispatched/running signal. Proven directly here for defense in depth.
+  test("never touches an in-flight ('running') phase-resolve-conflict.json, even if reached", () => {
+    const runningSignal = JSON.stringify({ status: "running", generation: 1 });
+    const { files, deps } = inMemoryFs({
+      [`${workerDir}/phase-implement.json`]: JSON.stringify({ status: "stalled", failureReason: RESOLVED_MARKER_REASON }),
+      [`${workerDir}/phase-resolve-conflict.json`]: runningSignal,
+    });
+    defaultRevertStallAndResetCycle(orchDir, ticket, "implement", deps);
+    expect(files[`${workerDir}/phase-resolve-conflict.json`]).toBe(runningSignal);
+  });
+});
+
 describe("runResolveConflictSweepPass", () => {
   test("mode 'off' skips everything, no census called", () => {
     const collectCandidates = () => { throw new Error("must not be called"); };
     const report = runResolveConflictSweepPass({ mode: "off", collectCandidates });
-    expect(report).toEqual({ marked: [], wouldMark: [], escalated: [], wouldEscalate: [], cleared: [], wouldClear: [], skipped: [], failed: [] });
+    expect(report).toEqual({
+      marked: [],
+      wouldMark: [],
+      escalated: [],
+      wouldEscalate: [],
+      cleared: [],
+      wouldClear: [],
+      retried: [],
+      wouldRetry: [],
+      skipped: [],
+      failed: [],
+    });
   });
 
   test("shadow mode classifies and emits would-mark, takes no action", async () => {
@@ -846,6 +1058,125 @@ describe("runResolveConflictSweepPass", () => {
     });
     expect(report.marked).toEqual([]);
     expect(report.failed).toEqual([]);
+  });
+
+  // #1461 escalation-gap fix: the failures sub-pass. A status:"failed"
+  // phase-resolve-conflict.json is a NEW, parallel path — never clearStall
+  // (which would let the original phase redispatch fresh with no memory of the
+  // failed attempt, silently discarding the failure without ever checking the
+  // cap).
+  describe("failures sub-pass (#1461 escalation-gap fix)", () => {
+    test("(a) UNDER the cap: reverts the original stall + resets the stale cycle via revertStallAndResetCycle, does NOT escalate", async () => {
+      const reverted = [];
+      const report = await runResolveConflictSweepPass({
+        mode: "enforce",
+        collectCandidates: () => [],
+        collectCompletions: () => [],
+        collectFailures: () => [{ ticket: "CTL-1", stalledPhase: "implement", workerDir: "/w" }],
+        cycleCountOf: () => RESOLVE_CONFLICT_CYCLE_CAP - 1, // under the cap
+        revertStallAndResetCycle: (f) => { reverted.push(f); return true; },
+        escalateCapExhausted: () => { throw new Error("must not escalate — under the cap"); },
+        emit: async () => true,
+      });
+      expect(report.retried).toEqual([{ ticket: "CTL-1", phase: "implement" }]);
+      expect(report.escalated).toEqual([]);
+      expect(reverted).toEqual([{ ticket: "CTL-1", stalledPhase: "implement" }]);
+    });
+
+    test("(b) AT the cap: escalates via escalateCapExhausted instead of reverting", async () => {
+      const escalated = [];
+      const report = await runResolveConflictSweepPass({
+        mode: "enforce",
+        collectCandidates: () => [],
+        collectCompletions: () => [],
+        collectFailures: () => [{ ticket: "CTL-2", stalledPhase: "verify", workerDir: "/w2" }],
+        cycleCountOf: () => RESOLVE_CONFLICT_CYCLE_CAP, // at the cap
+        revertStallAndResetCycle: () => { throw new Error("must not revert — at/over the cap"); },
+        escalateCapExhausted: (c) => { escalated.push(c); return true; },
+        emit: async () => true,
+      });
+      expect(report.escalated).toEqual([{ ticket: "CTL-2", phase: "verify" }]);
+      expect(report.retried).toEqual([]);
+      expect(escalated).toEqual([{ ticket: "CTL-2", phase: "verify", workerDir: "/w2", cycleCount: RESOLVE_CONFLICT_CYCLE_CAP }]);
+    });
+
+    test("OVER the cap also escalates (not just exactly-at)", async () => {
+      const escalated = [];
+      const report = await runResolveConflictSweepPass({
+        mode: "enforce",
+        collectCandidates: () => [],
+        collectCompletions: () => [],
+        collectFailures: () => [{ ticket: "CTL-3", stalledPhase: "implement", workerDir: "/w3" }],
+        cycleCountOf: () => RESOLVE_CONFLICT_CYCLE_CAP + 5,
+        revertStallAndResetCycle: () => { throw new Error("must not revert — over the cap"); },
+        escalateCapExhausted: (c) => { escalated.push(c); return true; },
+        emit: async () => true,
+      });
+      expect(report.escalated).toEqual([{ ticket: "CTL-3", phase: "implement" }]);
+    });
+
+    test("shadow mode emits would-retry for an under-cap failure, takes no action", async () => {
+      const emitted = [];
+      const report = await runResolveConflictSweepPass({
+        mode: "shadow",
+        collectCandidates: () => [],
+        collectCompletions: () => [],
+        collectFailures: () => [{ ticket: "CTL-1", stalledPhase: "implement", workerDir: "/w" }],
+        cycleCountOf: () => 0,
+        revertStallAndResetCycle: () => { throw new Error("must not be called in shadow"); },
+        emit: (type) => emitted.push(type),
+      });
+      expect(report.wouldRetry).toEqual([{ ticket: "CTL-1", phase: "implement" }]);
+      expect(emitted).toContain("resolve-conflict.would.retry");
+    });
+
+    test("shadow mode emits would-escalate for an at-cap failure, takes no action", async () => {
+      const emitted = [];
+      const report = await runResolveConflictSweepPass({
+        mode: "shadow",
+        collectCandidates: () => [],
+        collectCompletions: () => [],
+        collectFailures: () => [{ ticket: "CTL-1", stalledPhase: "implement", workerDir: "/w" }],
+        cycleCountOf: () => RESOLVE_CONFLICT_CYCLE_CAP,
+        escalateCapExhausted: () => { throw new Error("must not be called in shadow"); },
+        emit: (type) => emitted.push(type),
+      });
+      expect(report.wouldEscalate).toEqual([{ ticket: "CTL-1", phase: "implement" }]);
+      expect(emitted).toContain("resolve-conflict.would.escalate");
+    });
+
+    test("a revertStallAndResetCycle returning false is reported as a failure, not silently swallowed", async () => {
+      const report = await runResolveConflictSweepPass({
+        mode: "enforce",
+        collectCandidates: () => [],
+        collectCompletions: () => [],
+        collectFailures: () => [{ ticket: "CTL-1", stalledPhase: "implement", workerDir: "/w" }],
+        cycleCountOf: () => 0,
+        revertStallAndResetCycle: () => false,
+        emit: async () => true,
+      });
+      expect(report.retried).toEqual([]);
+      expect(report.failed).toEqual([{ ticket: "CTL-1", phase: "implement", reason: "revert-stall-and-reset-cycle-returned-false" }]);
+    });
+
+    test("a throwing collectFailures degrades to an empty failures sub-pass, never aborts the rest of the tick", async () => {
+      const dispatched = [];
+      const report = await runResolveConflictSweepPass({
+        mode: "enforce",
+        collectFailures: () => { throw new Error("failures census exploded"); },
+        collectCandidates: () => [{ ticket: "CTL-4", phase: "implement", workerDir: "/w", raw: { failureReason: RESOLVE_CONFLICT_STALL_REASON }, worktreePath: "/wt", base: "main" }],
+        collectCompletions: () => [],
+        cycleCountOf: () => 0,
+        classifyLive: async () => ({ resolvable: true, conflictFiles: [], conflictTypes: [] }),
+        markAndDispatch: (c) => { dispatched.push(c.ticket); return { success: true, dispatched: true }; },
+        emit: async () => true,
+      });
+      expect(report.retried).toEqual([]);
+      expect(report.failed).toEqual([]);
+      // the candidates sub-pass still ran normally — a throwing failures census
+      // degrades ONLY its own sub-pass, never the whole tick.
+      expect(dispatched).toEqual(["CTL-4"]);
+    });
   });
 });
 
@@ -978,6 +1309,149 @@ describe("#1461 follow-up: resolve-conflict cycle-cap end-to-end reachability", 
       expect(JSON.parse(files[`${workerDir}/phase-implement.json`]).failureReason).toBe(CAP_EXHAUSTED_REASON);
       expect(posted).toHaveLength(1);
       expect(posted[0][1]).toMatch(new RegExp(`cycle cap \\(${RESOLVE_CONFLICT_CYCLE_CAP}\\)`));
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+// #1461 escalation-gap fix, test (d): the end-to-end mirror of the E2E test
+// above, but for REPEATED FAILURES specifically (never a successful "done").
+// Before this fix, cycle 1's failure permanently stranded the ticket: the cap
+// counter kept climbing (countResolveConflictAttempts correctly counts BOTH
+// complete AND failed events — that part already worked), but nothing ever
+// reverted the original stalled-phase's RESOLVED_MARKER_REASON marker, so
+// classifyResolveConflictCandidate never got a fresh classify pass again and
+// defaultEscalateCapExhausted never fired no matter how high the counter got.
+// This test drives real dispatch → real failure → real revert-and-retry for
+// RESOLVE_CONFLICT_CYCLE_CAP - 1 cycles (each one genuinely redispatched, never
+// swallowed as an idempotent no-op), then proves the FINAL failure (the one
+// that pushes the durable counter to the cap) escalates instead of reverting.
+describe("#1461 escalation-gap fix: FAILURE cycle-cap end-to-end reachability", () => {
+  test("repeated FAILED (never completed) resolve-conflict cycles revert+retry under the cap, then escalate once the cap is reached", () => {
+    const dir = mkdtempSync(join(tmpdir(), "resolve-conflict-failure-e2e-"));
+    const eventLogPath = join(dir, "events.jsonl");
+    try {
+      const orchDir = "/orch";
+      const ticket = "CTL-FAIL-E2E";
+      const workerDir = `${orchDir}/workers/${ticket}`;
+      const { files, deps } = inMemoryFsForE2E();
+      deps.isThenable = () => false;
+
+      let dispatchGen = 0;
+      let idempotentNoOps = 0;
+      let realDispatches = 0;
+      deps.dispatch = (_orchDir, tk, phase) => {
+        const sigPath = `${workerDir}/phase-${phase}.json`;
+        let existingStatus = null;
+        if (sigPath in files) {
+          try {
+            existingStatus = JSON.parse(files[sigPath]).status;
+          } catch {
+            existingStatus = null;
+          }
+        }
+        if (["dispatched", "running", "done"].includes(existingStatus)) {
+          idempotentNoOps++;
+          return { code: 0, signal: { idempotent: true } };
+        }
+        dispatchGen++;
+        realDispatches++;
+        // Simulate the worker running and then genuinely FAILING this cycle —
+        // writes status:"failed" + emits the durable
+        // phase.resolve-conflict.failed.<ticket> event, exactly what the real
+        // /catalyst-dev:phase-resolve-conflict skill does on a hard failure.
+        files[sigPath] = JSON.stringify({ status: "failed", generation: dispatchGen });
+        appendFileSync(
+          eventLogPath,
+          JSON.stringify({
+            ts: new Date().toISOString(),
+            attributes: { "event.name": `phase.resolve-conflict.failed.${tk}`, "event.label": tk, "catalyst.orchestration": tk },
+          }) + "\n",
+        );
+        return { code: 0, signal: { bg_job_id: `job-${dispatchGen}` } };
+      };
+
+      function freshStall() {
+        files[`${workerDir}/phase-implement.json`] = JSON.stringify({
+          status: "stalled",
+          failureReason: RESOLVE_CONFLICT_STALL_REASON,
+        });
+      }
+
+      let escalatedPosted = null;
+
+      for (let i = 0; i < RESOLVE_CONFLICT_CYCLE_CAP; i++) {
+        freshStall();
+        const cycleCountBefore = countResolveConflictAttempts({ ticket, path: eventLogPath });
+        expect(cycleCountBefore).toBe(i); // the durable counter genuinely advancing on failures alone
+        const decision = classifyResolveConflictCandidate({
+          stalledReasonMatches: true,
+          alreadyResolving: false,
+          cycleCount: cycleCountBefore,
+          classification: { resolvable: true, conflictFiles: [], conflictTypes: [] },
+        });
+        expect(decision.action).toBe("mark-and-dispatch");
+        const result = defaultMarkAndDispatch(
+          {
+            ticket,
+            phase: "implement",
+            workerDir,
+            worktreePath: `/wt/${ticket}`,
+            base: "main",
+            classification: { resolvable: true, conflictFiles: [], conflictTypes: [] },
+            cycleCount: cycleCountBefore,
+            orchDir,
+          },
+          deps,
+        );
+        expect(result.success).toBe(true);
+        expect(result.dispatched).toBe(true);
+        // markStalledSignalResolving ran as part of this dispatch — the original
+        // phase is now marked RESOLVED_MARKER_REASON, awaiting completion.
+        expect(JSON.parse(files[`${workerDir}/phase-implement.json`]).failureReason).toBe(RESOLVED_MARKER_REASON);
+
+        // The dispatch above already simulated the worker FAILING (see deps.dispatch)
+        // — a later tick's failure handling now runs.
+        const cycleCountAfter = countResolveConflictAttempts({ ticket, path: eventLogPath });
+        expect(cycleCountAfter).toBe(i + 1);
+
+        if (cycleCountAfter >= RESOLVE_CONFLICT_CYCLE_CAP) {
+          // The cap was reached BY this failure — must escalate, must NOT revert.
+          const posted = [];
+          const escDeps = { ...deps, postComment: (tk, body) => { posted.push([tk, body]); return true; } };
+          const escalated = defaultEscalateCapExhausted(
+            { ticket, phase: "implement", workerDir, cycleCount: cycleCountAfter },
+            escDeps,
+          );
+          expect(escalated).toBe(true);
+          escalatedPosted = posted;
+          break;
+        }
+
+        // Still under the cap — this task's fix: revert the original stall back
+        // to the ORIGINAL reason + reset the stale terminal cycle (REUSING
+        // maybeResetForResolveConflictCycle), so the ticket genuinely becomes a
+        // candidate again on the NEXT loop iteration instead of being
+        // permanently stuck at RESOLVED_MARKER_REASON.
+        const reverted = defaultRevertStallAndResetCycle(orchDir, ticket, "implement", deps);
+        expect(reverted).toBe(true);
+        expect(JSON.parse(files[`${workerDir}/phase-implement.json`]).failureReason).toBe(RESOLVE_CONFLICT_STALL_REASON);
+        // the stale phase-resolve-conflict.json is gone — the NEXT dispatch
+        // (loop's next iteration) will not be silently swallowed as idempotent.
+        expect(`${workerDir}/phase-resolve-conflict.json` in files).toBe(false);
+      }
+
+      // Every cycle was a REAL dispatch that genuinely failed — none were
+      // silently swallowed as a stale idempotent no-op (the pre-fix bug, now
+      // proven closed for the FAILURE path specifically).
+      expect(realDispatches).toBe(RESOLVE_CONFLICT_CYCLE_CAP);
+      expect(idempotentNoOps).toBe(0);
+
+      // The escalation genuinely fired, exactly once, at the cap.
+      expect(escalatedPosted).toHaveLength(1);
+      expect(escalatedPosted[0][1]).toMatch(new RegExp(`cycle cap \\(${RESOLVE_CONFLICT_CYCLE_CAP}\\)`));
+      expect(JSON.parse(files[`${workerDir}/phase-implement.json`]).failureReason).toBe(CAP_EXHAUSTED_REASON);
     } finally {
       rmSync(dir, { recursive: true, force: true });
     }

--- a/plugins/dev/scripts/execution-core/resolve-conflict-sweep.test.mjs
+++ b/plugins/dev/scripts/execution-core/resolve-conflict-sweep.test.mjs
@@ -1,4 +1,7 @@
-import { describe, test, expect } from "bun:test";
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, rmSync, existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
 import {
   classifyResolveConflictCandidate,
   RESOLVE_CONFLICT_STALL_REASON,
@@ -7,12 +10,15 @@ import {
   RESOLVE_CONFLICT_CYCLE_CAP,
   defaultCollectResolveConflictCandidates,
   classifyLiveConflict,
+  defaultLocalMergeTree,
   writeResolveConflictBrief,
   markStalledSignalResolving,
   defaultMarkAndDispatch,
   defaultEscalateCapExhausted,
   defaultCollectResolveConflictCompletions,
   runResolveConflictSweepPass,
+  emitResolveConflictEvent,
+  RESOLVE_CONFLICT_SWEEP_EVENT_TYPES,
 } from "./resolve-conflict-sweep.mjs";
 
 describe("constants", () => {
@@ -38,6 +44,19 @@ describe("classifyResolveConflictCandidate", () => {
   test("already marked/dispatched this cycle → skip (dispatch is in flight)", () => {
     expect(classifyResolveConflictCandidate({ stalledReasonMatches: false, alreadyResolving: true, cycleCount: 0, classification: null }))
       .toEqual({ action: "skip", reason: "already-resolving" });
+  });
+
+  // #1461 Fix 2 (CRITICAL final-review finding): the cap check runs BEFORE the
+  // already-resolving check — this is exactly what lets a repeatedly-FAILING
+  // resolve-conflict run eventually escalate instead of being permanently
+  // invisible. Once cycleCount (now counting BOTH complete AND failed dispatch
+  // attempts, via countResolveConflictAttempts) reaches the cap, a candidate
+  // that's STILL marked "already-resolving" (the original stalled-phase signal
+  // never got de-marked because the dispatched runs kept failing, not
+  // completing) routes to cap-exhausted instead of skip-forever.
+  test("cap exhausted even while still marked already-resolving → cap-exhausted, not skip (Fix 2: repeated failures escalate)", () => {
+    expect(classifyResolveConflictCandidate({ stalledReasonMatches: false, alreadyResolving: true, cycleCount: 3, classification: null }))
+      .toEqual({ action: "cap-exhausted", reason: "cycle-cap-exhausted" });
   });
 
   test("classification unavailable (merge-tree probe failed this tick) → skip, retry next tick", () => {
@@ -143,27 +162,61 @@ describe("defaultCollectResolveConflictCandidates", () => {
   });
 });
 
+// #1461 Fix 5 (final-review finding, human-approved design): classifyLiveConflict
+// now diffs LOCAL HEAD (in the ticket's worktree) against origin/<base> — NOT
+// origin/<base> vs origin/<ticket> (the pushed remote branch). The `mergeTree`
+// seam is now a 2-arg (worktreePath, base) call — no `head`/ticket-branch arg —
+// since a dispatch-time pre-flight rebase stall typically happens BEFORE the
+// ticket's branch has ever been pushed, and local HEAD never needs fetching.
 describe("classifyLiveConflict", () => {
-  test("delegates to the injected mergeTree seam then classifyMergeTree", async () => {
-    const mergeTree = async (wt, base, head) => {
+  test("delegates to the injected 2-arg (worktreePath, base) mergeTree seam then classifyMergeTree", async () => {
+    const mergeTree = async (wt, base) => {
       expect(wt).toBe("/wt/CTL-1");
       expect(base).toBe("main");
-      expect(head).toBe("CTL-1");
       return { exitCode: 1, output: "CONFLICT (content): Merge conflict in a.ts" };
     };
-    const result = await classifyLiveConflict({ worktreePath: "/wt/CTL-1", base: "main", head: "CTL-1" }, { mergeTree });
+    const result = await classifyLiveConflict({ worktreePath: "/wt/CTL-1", base: "main" }, { mergeTree });
     expect(result).toEqual({ resolvable: true, conflictFiles: ["a.ts"], conflictTypes: ["content"] });
+  });
+
+  // Proves classification now works against a LOCAL, UNPUSHED worktree state:
+  // the fake mergeTree seam never receives (or needs) a ticket/head branch name
+  // at all — it only ever sees the worktree path + base, exactly what a
+  // pre-push implement-phase stall can supply.
+  test("classifies a local unpushed worktree's HEAD without ever referencing a ticket branch name", async () => {
+    let sawArgs;
+    const mergeTree = async (...args) => {
+      sawArgs = args;
+      // Simulates `git merge-tree --write-tree origin/main HEAD` finding a
+      // clean, additive resolution — no fetch/diff of any origin/<ticket> ref.
+      return { exitCode: 0, output: "" };
+    };
+    const result = await classifyLiveConflict({ worktreePath: "/wt/CTL-unpushed", base: "main" }, { mergeTree });
+    expect(sawArgs).toEqual(["/wt/CTL-unpushed", "main"]);
+    expect(result).toEqual({ resolvable: true, conflictFiles: [], conflictTypes: [] });
   });
 
   test("returns null when the mergeTree seam throws (probe failed this tick)", async () => {
     const mergeTree = async () => { throw new Error("fetch failed"); };
-    const result = await classifyLiveConflict({ worktreePath: "/wt/CTL-1", base: "main", head: "CTL-1" }, { mergeTree });
+    const result = await classifyLiveConflict({ worktreePath: "/wt/CTL-1", base: "main" }, { mergeTree });
     expect(result).toBeNull();
   });
 
   test("returns null when worktreePath is missing (never spawn git blind)", async () => {
-    const result = await classifyLiveConflict({ worktreePath: null, base: "main", head: "CTL-1" }, { mergeTree: async () => ({ exitCode: 0, output: "" }) });
+    const result = await classifyLiveConflict({ worktreePath: null, base: "main" }, { mergeTree: async () => ({ exitCode: 0, output: "" }) });
     expect(result).toBeNull();
+  });
+});
+
+// defaultLocalMergeTree — the real (non-injected) seam classifyLiveConflict
+// defaults to. Unit-testable only at the argv-shape level without spawning
+// real git (a real-git integration test, mirroring stale-pr-rescue-timer.test.mjs's
+// "defaultMergeTree (real git)" suite, is out of scope for this pass — the
+// task's own guidance is "inject a fake git-runner seam, don't spawn real git").
+describe("defaultLocalMergeTree", () => {
+  test("is exported and is an async function distinct from defaultMergeTree's remote-fetch shape", () => {
+    expect(typeof defaultLocalMergeTree).toBe("function");
+    expect(defaultLocalMergeTree.constructor.name).toBe("AsyncFunction");
   });
 });
 
@@ -351,13 +404,16 @@ describe("defaultCollectResolveConflictCompletions", () => {
     };
   }
 
-  test("finds a ticket whose resolve-conflict phase is done and reads stalledPhase from the brief", () => {
+  // #1461 Fix 1: a completion is now reported ONLY when the ORIGINAL
+  // stalled-phase signal is STILL present and STILL carries RESOLVED_MARKER_REASON.
+  test("finds a ticket whose resolve-conflict phase is done, the brief names the stalled phase, and that phase is still marked resolving", () => {
     const fs = fakeFs({
       workerDirs: { "/orch/workers": ["CTL-1"] },
       files: {
-        "/orch/workers/CTL-1": ["phase-resolve-conflict.json", "resolve-conflict-brief.json"],
+        "/orch/workers/CTL-1": ["phase-resolve-conflict.json", "resolve-conflict-brief.json", "phase-implement.json"],
         "/orch/workers/CTL-1/phase-resolve-conflict.json": JSON.stringify({ status: "done" }),
         "/orch/workers/CTL-1/resolve-conflict-brief.json": JSON.stringify({ stalledPhase: "implement" }),
+        "/orch/workers/CTL-1/phase-implement.json": JSON.stringify({ status: "stalled", failureReason: "source_conflict_resolvable" }),
       },
     });
     const out = defaultCollectResolveConflictCompletions({ orchDir: "/orch", ...fs });
@@ -379,6 +435,62 @@ describe("defaultCollectResolveConflictCompletions", () => {
   test("skips a ticket with no resolve-conflict signal at all", () => {
     const fs = fakeFs({ workerDirs: { "/orch/workers": ["CTL-3"] }, files: { "/orch/workers/CTL-3": ["phase-implement.json"] } });
     expect(defaultCollectResolveConflictCompletions({ orchDir: "/orch", ...fs })).toEqual([]);
+  });
+
+  // #1461 Fix 1 (CRITICAL final-review finding): idempotence guard tests.
+  describe("Fix 1 idempotence guard", () => {
+    function filesFor(stalledSignalRaw) {
+      const files = {
+        "/orch/workers/CTL-1": ["phase-resolve-conflict.json", "resolve-conflict-brief.json", "phase-implement.json"],
+        "/orch/workers/CTL-1/phase-resolve-conflict.json": JSON.stringify({ status: "done" }),
+        "/orch/workers/CTL-1/resolve-conflict-brief.json": JSON.stringify({ stalledPhase: "implement" }),
+      };
+      if (stalledSignalRaw !== undefined) {
+        files["/orch/workers/CTL-1/phase-implement.json"] = JSON.stringify(stalledSignalRaw);
+      }
+      return files;
+    }
+
+    test("(a) a completion is collected once when the stalled phase is still marked RESOLVED_MARKER_REASON", () => {
+      const fs = fakeFs({
+        workerDirs: { "/orch/workers": ["CTL-1"] },
+        files: filesFor({ status: "stalled", failureReason: "source_conflict_resolvable" }),
+      });
+      expect(defaultCollectResolveConflictCompletions({ orchDir: "/orch", ...fs }))
+        .toEqual([{ ticket: "CTL-1", stalledPhase: "implement" }]);
+    });
+
+    test("(b) the SAME ticket is NOT collected again once the stalled-phase signal file is gone (simulates defaultClearStall deleting it)", () => {
+      // First call: still present + marked → collected.
+      const fsBefore = fakeFs({
+        workerDirs: { "/orch/workers": ["CTL-1"] },
+        files: filesFor({ status: "stalled", failureReason: "source_conflict_resolvable" }),
+      });
+      expect(defaultCollectResolveConflictCompletions({ orchDir: "/orch", ...fsBefore }))
+        .toEqual([{ ticket: "CTL-1", stalledPhase: "implement" }]);
+
+      // Second call: defaultClearStall's own first step (rmSync phase-implement.json)
+      // has run — the file is gone. Must NOT be re-collected.
+      const filesAfterClear = filesFor(undefined);
+      delete filesAfterClear["/orch/workers/CTL-1/phase-implement.json"];
+      const fsAfter = fakeFs({ workerDirs: { "/orch/workers": ["CTL-1"] }, files: filesAfterClear });
+      expect(defaultCollectResolveConflictCompletions({ orchDir: "/orch", ...fsAfter })).toEqual([]);
+    });
+
+    test("(c) not re-collected when something else already re-marked the stalled phase with a DIFFERENT reason", () => {
+      const fs = fakeFs({
+        workerDirs: { "/orch/workers": ["CTL-1"] },
+        files: filesFor({ status: "stalled", failureReason: "resolve-conflict-cycle-cap-exhausted" }),
+      });
+      expect(defaultCollectResolveConflictCompletions({ orchDir: "/orch", ...fs })).toEqual([]);
+    });
+
+    test("not collected when the stalled-phase signal is unreadable/corrupt (treated like absent)", () => {
+      const files = filesFor(undefined);
+      files["/orch/workers/CTL-1/phase-implement.json"] = "{not valid json";
+      const fs = fakeFs({ workerDirs: { "/orch/workers": ["CTL-1"] }, files });
+      expect(defaultCollectResolveConflictCompletions({ orchDir: "/orch", ...fs })).toEqual([]);
+    });
   });
 });
 
@@ -402,6 +514,27 @@ describe("runResolveConflictSweepPass", () => {
     });
     expect(report.wouldMark).toEqual([{ ticket: "CTL-1", phase: "implement" }]);
     expect(emitted).toContain("resolve-conflict.would.mark");
+    // #1461 Fix 4: resolve-conflict.would.dispatch was in the closed vocabulary
+    // but never actually fired by the driver on the shadow twin — the enforce
+    // path fires TWO distinct events for this action (marked.resolvable, then
+    // dispatched), so shadow now fires both twins for observability parity.
+    expect(emitted).toContain("resolve-conflict.would.dispatch");
+  });
+
+  // #1461 Fix 4: shadow-mode "would escalate" observability parity — the cap-
+  // exhausted path's shadow twin must actually fire, not just the enforce path.
+  test("shadow mode emits would-escalate for a cap-exhausted candidate, takes no action", async () => {
+    const emitted = [];
+    const report = await runResolveConflictSweepPass({
+      mode: "shadow",
+      collectCandidates: () => [{ ticket: "CTL-1", phase: "implement", workerDir: "/w", raw: { failureReason: "source_conflict_resolvable" }, worktreePath: "/wt", base: "main" }],
+      collectCompletions: () => [],
+      cycleCountOf: () => 3,
+      escalateCapExhausted: () => { throw new Error("must not be called in shadow"); },
+      emit: (type) => emitted.push(type),
+    });
+    expect(report.wouldEscalate).toEqual([{ ticket: "CTL-1", phase: "implement" }]);
+    expect(emitted).toContain("resolve-conflict.would.escalate");
   });
 
   test("enforce mode marks + dispatches a resolvable candidate", async () => {
@@ -434,6 +567,37 @@ describe("runResolveConflictSweepPass", () => {
     expect(escalated).toEqual(["CTL-1"]);
   });
 
+  // #1461 Fix 2 (CRITICAL final-review finding): a REPEATEDLY-FAILING
+  // resolve-conflict run (never a successful completion) must still reach the
+  // cap and escalate via the SAME defaultEscalateCapExhausted path — driven end
+  // to end by cycleCountOf reflecting countResolveConflictAttempts (complete +
+  // failed), not the completion-only countResolveConflictCycles.
+  test("a candidate whose cycleCountOf reflects FAILED (not completed) dispatch attempts still escalates at the cap", async () => {
+    const escalated = [];
+    const cycleCountCalls = [];
+    // Simulates the real wiring: cycleCountOf === countResolveConflictAttempts,
+    // which has counted 3 `phase.resolve-conflict.failed.<ticket>` events (zero
+    // `.complete.` events) for this ticket — the run never once completed.
+    const cycleCountOf = (ticket) => {
+      cycleCountCalls.push(ticket);
+      return 3; // RESOLVE_CONFLICT_CYCLE_CAP reached via failures alone
+    };
+    const report = await runResolveConflictSweepPass({
+      mode: "enforce",
+      // Still marked "already-resolving" — nothing ever de-marked it, because
+      // every dispatched attempt FAILED rather than completing.
+      collectCandidates: () => [{ ticket: "CTL-2", phase: "implement", workerDir: "/w", raw: { failureReason: "source_conflict_resolvable" }, worktreePath: "/wt", base: "main" }],
+      collectCompletions: () => [],
+      cycleCountOf,
+      classifyLive: async () => { throw new Error("must not classify — cap check precedes classification"); },
+      escalateCapExhausted: (c) => { escalated.push(c.ticket); return true; },
+      emit: async () => true,
+    });
+    expect(cycleCountCalls).toEqual(["CTL-2"]);
+    expect(report.escalated).toEqual([{ ticket: "CTL-2", phase: "implement" }]);
+    expect(escalated).toEqual(["CTL-2"]);
+  });
+
   test("enforce mode clears a completion via the injected clearStall seam", async () => {
     const cleared = [];
     const report = await runResolveConflictSweepPass({
@@ -456,5 +620,50 @@ describe("runResolveConflictSweepPass", () => {
     });
     expect(report.marked).toEqual([]);
     expect(report.failed).toEqual([]);
+  });
+});
+
+// #1461 Fix 4 (IMPORTANT final-review finding): emitResolveConflictEvent — the
+// dedicated unified-log emitter, mirroring emitUnstuckEvent's own test suite
+// (unstuck-sweep.test.mjs "emitUnstuckEvent — dedicated unified-log emitter").
+describe("emitResolveConflictEvent — dedicated unified-log emitter (#1461)", () => {
+  let SCRATCH, LOG_PATH, prevDir;
+  beforeEach(() => {
+    SCRATCH = mkdtempSync(join(tmpdir(), "resolve-conflict-emit-"));
+    const ym = `${new Date().getUTCFullYear()}-${String(new Date().getUTCMonth() + 1).padStart(2, "0")}`;
+    LOG_PATH = join(SCRATCH, "events", `${ym}.jsonl`);
+    prevDir = process.env.CATALYST_DIR;
+    process.env.CATALYST_DIR = SCRATCH;
+  });
+  afterEach(() => {
+    if (prevDir === undefined) delete process.env.CATALYST_DIR;
+    else process.env.CATALYST_DIR = prevDir;
+    rmSync(SCRATCH, { recursive: true, force: true });
+  });
+
+  test("appends a valid resolve-conflict.* line to the unified log", async () => {
+    const ok = await emitResolveConflictEvent("resolve-conflict.would.mark", {
+      ticket: "CTL-Z",
+      phase: "implement",
+    });
+    expect(ok).toBe(true);
+    expect(existsSync(LOG_PATH)).toBe(true);
+    const last = JSON.parse(readFileSync(LOG_PATH, "utf8").trim().split("\n").pop());
+    expect(last.event).toBe("resolve-conflict.would.mark");
+    expect(last.ticket).toBe("CTL-Z");
+    expect(last.phase).toBe("implement");
+    expect(last.ts).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$/);
+  });
+
+  test("accepts every type in the sweep's own closed vocabulary", async () => {
+    for (const t of RESOLVE_CONFLICT_SWEEP_EVENT_TYPES) {
+      expect(await emitResolveConflictEvent(t, { ticket: "CTL-Z" })).toBe(true);
+    }
+  });
+
+  test("rejects an event type outside the sweep's closed vocabulary (does not silently no-op)", async () => {
+    await expect(emitResolveConflictEvent("unstuck.would.clear-noise", {})).rejects.toThrow(
+      /unknown resolve-conflict-sweep event type/
+    );
   });
 });

--- a/plugins/dev/scripts/execution-core/resolve-conflict-sweep.test.mjs
+++ b/plugins/dev/scripts/execution-core/resolve-conflict-sweep.test.mjs
@@ -10,6 +10,7 @@ import {
   writeResolveConflictBrief,
   markStalledSignalResolving,
   defaultMarkAndDispatch,
+  defaultEscalateCapExhausted,
 } from "./resolve-conflict-sweep.mjs";
 
 describe("constants", () => {
@@ -315,5 +316,27 @@ describe("defaultMarkAndDispatch", () => {
     expect(result.success).toBe(false);
     expect(result.dispatched).toBe(false);
     expect(result.reason).toMatch(/mark\/brief write failed/);
+  });
+});
+
+describe("defaultEscalateCapExhausted", () => {
+  test("marks the signal cap-exhausted and posts the escalation comment", () => {
+    const reads = { "/w/phase-implement.json": JSON.stringify({ status: "stalled", failureReason: "source_conflict_resolvable" }) };
+    const writes = [];
+    const posted = [];
+    const deps = {
+      readFileSync: (p) => reads[p],
+      writeFileSync: (p, body) => writes.push([p, body]),
+      renameSync: () => {},
+      postComment: (ticket, body) => { posted.push([ticket, body]); return true; },
+    };
+    const ok = defaultEscalateCapExhausted({ ticket: "CTL-1", phase: "implement", workerDir: "/w", cycleCount: 3 }, deps);
+    expect(ok).toBe(true);
+    const written = JSON.parse(writes[0][1]);
+    expect(written.failureReason).toBe("resolve-conflict-cycle-cap-exhausted");
+    expect(posted).toHaveLength(1);
+    expect(posted[0][0]).toBe("CTL-1");
+    expect(posted[0][1]).toMatch(/^🔼 \*\*phase-resolve-conflict\*\* escalated/);
+    expect(posted[0][1]).toMatch(/cycle cap \(3\)/);
   });
 });

--- a/plugins/dev/scripts/execution-core/resolve-conflict-sweep.test.mjs
+++ b/plugins/dev/scripts/execution-core/resolve-conflict-sweep.test.mjs
@@ -6,6 +6,8 @@ import {
   CAP_EXHAUSTED_REASON,
   RESOLVE_CONFLICT_CYCLE_CAP,
   defaultCollectResolveConflictCandidates,
+  classifyLiveConflict,
+  writeResolveConflictBrief,
 } from "./resolve-conflict-sweep.mjs";
 
 describe("constants", () => {
@@ -133,5 +135,51 @@ describe("defaultCollectResolveConflictCandidates", () => {
 
   test("a missing workers dir returns []", () => {
     expect(defaultCollectResolveConflictCandidates({ orchDir: "/nope", readdirSync: () => { throw new Error("ENOENT"); } })).toEqual([]);
+  });
+});
+
+describe("classifyLiveConflict", () => {
+  test("delegates to the injected mergeTree seam then classifyMergeTree", async () => {
+    const mergeTree = async (wt, base, head) => {
+      expect(wt).toBe("/wt/CTL-1");
+      expect(base).toBe("main");
+      expect(head).toBe("CTL-1");
+      return { exitCode: 1, output: "CONFLICT (content): Merge conflict in a.ts" };
+    };
+    const result = await classifyLiveConflict({ worktreePath: "/wt/CTL-1", base: "main", head: "CTL-1" }, { mergeTree });
+    expect(result).toEqual({ resolvable: true, conflictFiles: ["a.ts"], conflictTypes: ["content"] });
+  });
+
+  test("returns null when the mergeTree seam throws (probe failed this tick)", async () => {
+    const mergeTree = async () => { throw new Error("fetch failed"); };
+    const result = await classifyLiveConflict({ worktreePath: "/wt/CTL-1", base: "main", head: "CTL-1" }, { mergeTree });
+    expect(result).toBeNull();
+  });
+
+  test("returns null when worktreePath is missing (never spawn git blind)", async () => {
+    const result = await classifyLiveConflict({ worktreePath: null, base: "main", head: "CTL-1" }, { mergeTree: async () => ({ exitCode: 0, output: "" }) });
+    expect(result).toBeNull();
+  });
+});
+
+describe("writeResolveConflictBrief", () => {
+  test("writes the v1 brief atomically and returns the path", () => {
+    const writes = [];
+    const renames = [];
+    const deps = {
+      mkdirSync: () => {},
+      writeFileSync: (p, body) => writes.push([p, body]),
+      renameSync: (from, to) => renames.push([from, to]),
+    };
+    const brief = { ticket: "CTL-1", stalledPhase: "implement", conflictFiles: ["a.ts"], conflictTypes: ["content"], attempt: 1, maxAttempts: 3 };
+    const p = writeResolveConflictBrief("/orch", "CTL-1", brief, deps);
+    expect(p).toBe("/orch/workers/CTL-1/resolve-conflict-brief.json");
+    expect(writes).toHaveLength(1);
+    expect(writes[0][0]).toMatch(/\.tmp\./);
+    const written = JSON.parse(writes[0][1]);
+    expect(written.schema).toBe("resolve-conflict-brief/v1");
+    expect(written.ticket).toBe("CTL-1");
+    expect(written.stalledPhase).toBe("implement");
+    expect(renames).toEqual([[writes[0][0], p]]);
   });
 });

--- a/plugins/dev/scripts/execution-core/resolve-conflict-sweep.test.mjs
+++ b/plugins/dev/scripts/execution-core/resolve-conflict-sweep.test.mjs
@@ -11,6 +11,8 @@ import {
   markStalledSignalResolving,
   defaultMarkAndDispatch,
   defaultEscalateCapExhausted,
+  defaultCollectResolveConflictCompletions,
+  runResolveConflictSweepPass,
 } from "./resolve-conflict-sweep.mjs";
 
 describe("constants", () => {
@@ -338,5 +340,121 @@ describe("defaultEscalateCapExhausted", () => {
     expect(posted[0][0]).toBe("CTL-1");
     expect(posted[0][1]).toMatch(/^🔼 \*\*phase-resolve-conflict\*\* escalated/);
     expect(posted[0][1]).toMatch(/cycle cap \(3\)/);
+  });
+});
+
+describe("defaultCollectResolveConflictCompletions", () => {
+  function fakeFs({ workerDirs, files }) {
+    return {
+      readdirSync: (p, opts) => (opts?.withFileTypes ? (workerDirs[p] ?? []).map((n) => ({ name: n, isDirectory: () => true })) : (files[p] ?? [])),
+      readFileSync: (p) => { if (!(p in files)) throw new Error(`ENOENT: ${p}`); return files[p]; },
+    };
+  }
+
+  test("finds a ticket whose resolve-conflict phase is done and reads stalledPhase from the brief", () => {
+    const fs = fakeFs({
+      workerDirs: { "/orch/workers": ["CTL-1"] },
+      files: {
+        "/orch/workers/CTL-1": ["phase-resolve-conflict.json", "resolve-conflict-brief.json"],
+        "/orch/workers/CTL-1/phase-resolve-conflict.json": JSON.stringify({ status: "done" }),
+        "/orch/workers/CTL-1/resolve-conflict-brief.json": JSON.stringify({ stalledPhase: "implement" }),
+      },
+    });
+    const out = defaultCollectResolveConflictCompletions({ orchDir: "/orch", ...fs });
+    expect(out).toEqual([{ ticket: "CTL-1", stalledPhase: "implement" }]);
+  });
+
+  test("skips a ticket whose resolve-conflict phase is not done", () => {
+    const fs = fakeFs({
+      workerDirs: { "/orch/workers": ["CTL-2"] },
+      files: {
+        "/orch/workers/CTL-2": ["phase-resolve-conflict.json", "resolve-conflict-brief.json"],
+        "/orch/workers/CTL-2/phase-resolve-conflict.json": JSON.stringify({ status: "running" }),
+        "/orch/workers/CTL-2/resolve-conflict-brief.json": JSON.stringify({ stalledPhase: "verify" }),
+      },
+    });
+    expect(defaultCollectResolveConflictCompletions({ orchDir: "/orch", ...fs })).toEqual([]);
+  });
+
+  test("skips a ticket with no resolve-conflict signal at all", () => {
+    const fs = fakeFs({ workerDirs: { "/orch/workers": ["CTL-3"] }, files: { "/orch/workers/CTL-3": ["phase-implement.json"] } });
+    expect(defaultCollectResolveConflictCompletions({ orchDir: "/orch", ...fs })).toEqual([]);
+  });
+});
+
+describe("runResolveConflictSweepPass", () => {
+  test("mode 'off' skips everything, no census called", () => {
+    const collectCandidates = () => { throw new Error("must not be called"); };
+    const report = runResolveConflictSweepPass({ mode: "off", collectCandidates });
+    expect(report).toEqual({ marked: [], wouldMark: [], escalated: [], wouldEscalate: [], cleared: [], wouldClear: [], skipped: [], failed: [] });
+  });
+
+  test("shadow mode classifies and emits would-mark, takes no action", async () => {
+    const emitted = [];
+    const report = await runResolveConflictSweepPass({
+      mode: "shadow",
+      collectCandidates: () => [{ ticket: "CTL-1", phase: "implement", workerDir: "/w", raw: { failureReason: "source_conflict_ctl708_unavailable" }, worktreePath: "/wt", base: "main" }],
+      collectCompletions: () => [],
+      cycleCountOf: () => 0,
+      classifyLive: async () => ({ resolvable: true, conflictFiles: [], conflictTypes: [] }),
+      markAndDispatch: () => { throw new Error("must not be called in shadow"); },
+      emit: (type) => emitted.push(type),
+    });
+    expect(report.wouldMark).toEqual([{ ticket: "CTL-1", phase: "implement" }]);
+    expect(emitted).toContain("resolve-conflict.would.mark");
+  });
+
+  test("enforce mode marks + dispatches a resolvable candidate", async () => {
+    const dispatched = [];
+    const report = await runResolveConflictSweepPass({
+      mode: "enforce",
+      collectCandidates: () => [{ ticket: "CTL-1", phase: "implement", workerDir: "/w", raw: { failureReason: "source_conflict_ctl708_unavailable" }, worktreePath: "/wt", base: "main" }],
+      collectCompletions: () => [],
+      cycleCountOf: () => 0,
+      classifyLive: async () => ({ resolvable: true, conflictFiles: ["a.ts"], conflictTypes: ["content"] }),
+      markAndDispatch: (c) => { dispatched.push(c.ticket); return { success: true, dispatched: true }; },
+      emit: async () => true,
+    });
+    expect(report.marked).toEqual([{ ticket: "CTL-1", phase: "implement" }]);
+    expect(dispatched).toEqual(["CTL-1"]);
+  });
+
+  test("enforce mode escalates a cap-exhausted candidate", async () => {
+    const escalated = [];
+    const report = await runResolveConflictSweepPass({
+      mode: "enforce",
+      collectCandidates: () => [{ ticket: "CTL-1", phase: "implement", workerDir: "/w", raw: { failureReason: "source_conflict_resolvable" }, worktreePath: "/wt", base: "main" }],
+      collectCompletions: () => [],
+      cycleCountOf: () => 3,
+      classifyLive: async () => ({ resolvable: true, conflictFiles: [], conflictTypes: [] }),
+      escalateCapExhausted: (c) => { escalated.push(c.ticket); return true; },
+      emit: async () => true,
+    });
+    expect(report.escalated).toEqual([{ ticket: "CTL-1", phase: "implement" }]);
+    expect(escalated).toEqual(["CTL-1"]);
+  });
+
+  test("enforce mode clears a completion via the injected clearStall seam", async () => {
+    const cleared = [];
+    const report = await runResolveConflictSweepPass({
+      mode: "enforce",
+      collectCandidates: () => [],
+      collectCompletions: () => [{ ticket: "CTL-1", stalledPhase: "implement" }],
+      clearStall: (c) => { cleared.push(c); return true; },
+      emit: async () => true,
+    });
+    expect(report.cleared).toEqual([{ ticket: "CTL-1", phase: "implement" }]);
+    expect(cleared).toEqual([{ ticket: "CTL-1", phase: "implement" }]);
+  });
+
+  test("a throwing census degrades to an empty pass, never aborts", async () => {
+    const report = await runResolveConflictSweepPass({
+      mode: "enforce",
+      collectCandidates: () => { throw new Error("census exploded"); },
+      collectCompletions: () => [],
+      emit: async () => true,
+    });
+    expect(report.marked).toEqual([]);
+    expect(report.failed).toEqual([]);
   });
 });

--- a/plugins/dev/scripts/execution-core/resolve-conflict-sweep.test.mjs
+++ b/plugins/dev/scripts/execution-core/resolve-conflict-sweep.test.mjs
@@ -238,4 +238,82 @@ describe("defaultMarkAndDispatch", () => {
     expect(result.success).toBe(false);
     expect(result.dispatched).toBe(false);
   });
+
+  // fakeSettleDispatchSync — a minimal stand-in for the real settleDispatchSync
+  // (dispatch.mjs) that honors verifySync + onSettled exactly like the real one:
+  // the synchronous provisional code reflects verifySync(), and onSettled fires
+  // when the underlying promise resolves/rejects.
+  function fakeSettleDispatchSync(result, { verifySync, onSettled } = {}) {
+    const ok = verifySync ? verifySync() !== false : true;
+    const pending = Promise.resolve(result).then(
+      (r) => { onSettled?.(r, null); return r; },
+      (err) => { onSettled?.(null, err); return { code: 1, error: err }; },
+    );
+    return { code: ok ? 0 : 1, async: true, pending };
+  }
+
+  test("sdk dispatch path: verifySync (sdkSignalRunnable) false → reports failure, not a blind success", () => {
+    const deps = baseDeps({
+      dispatch: () => Promise.resolve({ code: 0 }),
+      isThenable: (x) => x != null && typeof x.then === "function",
+      settleDispatchSync: fakeSettleDispatchSync,
+      sdkSignalRunnable: () => false, // the prelaunch signal never went runnable
+    });
+    const result = defaultMarkAndDispatch(
+      { ticket: "CTL-1", phase: "implement", workerDir: "/orch/workers/CTL-1", worktreePath: "/wt/CTL-1", base: "main", classification: { resolvable: true, conflictFiles: [], conflictTypes: [] }, cycleCount: 0, orchDir: "/orch" },
+      deps,
+    );
+    expect(result.success).toBe(false);
+    expect(result.dispatched).toBe(false);
+  });
+
+  test("sdk dispatch path: a rejected promise triggers backstopOnRejection", async () => {
+    const backstopCalls = [];
+    const deps = baseDeps({
+      dispatch: () => Promise.reject(new Error("boom")),
+      isThenable: (x) => x != null && typeof x.then === "function",
+      settleDispatchSync: fakeSettleDispatchSync,
+      sdkSignalRunnable: () => true,
+      backstopOnRejection: (ctx) => (_res, err) => { backstopCalls.push([ctx, err.message]); },
+    });
+    const result = defaultMarkAndDispatch(
+      { ticket: "CTL-1", phase: "implement", workerDir: "/orch/workers/CTL-1", worktreePath: "/wt/CTL-1", base: "main", classification: { resolvable: true, conflictFiles: [], conflictTypes: [] }, cycleCount: 0, orchDir: "/orch" },
+      deps,
+    );
+    expect(result.pendingSdk).toBeTruthy();
+    await result.pendingSdk;
+    expect(backstopCalls).toHaveLength(1);
+    expect(backstopCalls[0][0]).toMatchObject({ ticket: "CTL-1", phase: "resolve-conflict" });
+    expect(backstopCalls[0][1]).toBe("boom");
+  });
+
+  test("malformed signal JSON returns a structured failure instead of throwing", () => {
+    const deps = baseDeps({ readFileSync: () => "{not json" });
+    const args = [
+      { ticket: "CTL-1", phase: "implement", workerDir: "/orch/workers/CTL-1", worktreePath: "/wt/CTL-1", base: "main", classification: { resolvable: true, conflictFiles: [], conflictTypes: [] }, cycleCount: 0, orchDir: "/orch" },
+      deps,
+    ];
+    expect(() => defaultMarkAndDispatch(...args)).not.toThrow();
+    const result = defaultMarkAndDispatch(...args);
+    expect(result.success).toBe(false);
+    expect(result.dispatched).toBe(false);
+    expect(result.reason).toMatch(/mark\/brief write failed/);
+  });
+
+  test("brief write failure returns a structured failure instead of throwing", () => {
+    const deps = baseDeps({
+      writeFileSync: (p) => {
+        if (String(p).includes("resolve-conflict-brief")) throw new Error("disk full");
+      },
+    });
+    const args = [
+      { ticket: "CTL-1", phase: "implement", workerDir: "/orch/workers/CTL-1", worktreePath: "/wt/CTL-1", base: "main", classification: { resolvable: true, conflictFiles: [], conflictTypes: [] }, cycleCount: 0, orchDir: "/orch" },
+      deps,
+    ];
+    expect(() => defaultMarkAndDispatch(...args)).not.toThrow();
+    const result = defaultMarkAndDispatch(...args);
+    expect(result.success).toBe(false);
+    expect(result.dispatched).toBe(false);
+    expect(result.reason).toMatch(/mark\/brief write failed/);
+  });
 });

--- a/plugins/dev/scripts/execution-core/resolve-conflict-sweep.test.mjs
+++ b/plugins/dev/scripts/execution-core/resolve-conflict-sweep.test.mjs
@@ -1,5 +1,5 @@
 import { describe, test, expect, beforeEach, afterEach } from "bun:test";
-import { mkdtempSync, rmSync, existsSync, readFileSync } from "node:fs";
+import { mkdtempSync, rmSync, existsSync, readFileSync, appendFileSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import {
@@ -14,12 +14,14 @@ import {
   writeResolveConflictBrief,
   markStalledSignalResolving,
   defaultMarkAndDispatch,
+  maybeResetForResolveConflictCycle,
   defaultEscalateCapExhausted,
   defaultCollectResolveConflictCompletions,
   runResolveConflictSweepPass,
   emitResolveConflictEvent,
   RESOLVE_CONFLICT_SWEEP_EVENT_TYPES,
 } from "./resolve-conflict-sweep.mjs";
+import { countResolveConflictAttempts } from "./event-scan.mjs";
 
 describe("constants", () => {
   test("stall reason strings match the real producer + do not collide with the enum", () => {
@@ -374,6 +376,230 @@ describe("defaultMarkAndDispatch", () => {
   });
 });
 
+// #1461 follow-up (final whole-branch re-review): the cycle-reset gap. Without
+// maybeResetForResolveConflictCycle, a SECOND genuine stall on the same ticket
+// calls dispatch() again while workers/<T>/phase-resolve-conflict.json still
+// shows a status from the FIRST cycle — phase-agent-dispatch's own idempotency
+// guard (dispatched|running|done → no-op) then silently swallows the redispatch,
+// no real resolution work ever happens on cycle 2+, and RESOLVE_CONFLICT_CYCLE_CAP
+// can never trip.
+//
+// inMemoryFs — a minimal in-memory filesystem double shared by the tests below.
+// Deliberately simple (flat map keyed by full path) so the reset logic's own
+// readdirSync(workerDir) call (a plain listing, no withFileTypes) can be
+// exercised faithfully alongside readFileSync/writeFileSync/renameSync/rmSync.
+function inMemoryFs(initial = {}) {
+  const files = { ...initial };
+  const deps = {
+    readFileSync: (p) => {
+      if (!(p in files)) throw new Error(`ENOENT: ${p}`);
+      return files[p];
+    },
+    writeFileSync: (p, body) => {
+      files[p] = body;
+    },
+    renameSync: (from, to) => {
+      files[to] = files[from];
+      delete files[from];
+    },
+    mkdirSync: () => {},
+    rmSync: (p) => {
+      delete files[p];
+    },
+    readdirSync: (dir) => {
+      const prefix = dir.endsWith("/") ? dir : `${dir}/`;
+      return Object.keys(files)
+        .filter((f) => f.startsWith(prefix) && !f.slice(prefix.length).includes("/"))
+        .map((f) => f.slice(prefix.length));
+    },
+  };
+  return { files, deps };
+}
+
+describe("maybeResetForResolveConflictCycle (#1461 follow-up)", () => {
+  const orchDir = "/orch";
+  const ticket = "CTL-1";
+  const workerDir = `${orchDir}/workers/${ticket}`;
+  const signalPath = `${workerDir}/phase-resolve-conflict.json`;
+  const briefPath = `${workerDir}/resolve-conflict-brief.json`;
+
+  test("(a) no existing signal at all → false, no-op (the common first-cycle case)", () => {
+    const { deps } = inMemoryFs({});
+    expect(maybeResetForResolveConflictCycle(orchDir, ticket, deps)).toBe(false);
+  });
+
+  test("(b) terminal 'done' → deletes the signal + brief + claim tombstones + progress marker, returns true", () => {
+    const { files, deps } = inMemoryFs({
+      [signalPath]: JSON.stringify({ status: "done", generation: 1 }),
+      [briefPath]: JSON.stringify({ stalledPhase: "implement", attempt: 1 }),
+      [`${workerDir}/resolve-conflict.claim.1`]: "{}",
+      [`${workerDir}/.progress-resolve-conflict`]: "3",
+      // an unrelated phase's claim + progress marker must survive
+      [`${workerDir}/implement.claim.1`]: "{}",
+      [`${workerDir}/.progress-implement`]: "9",
+    });
+    expect(maybeResetForResolveConflictCycle(orchDir, ticket, deps)).toBe(true);
+    expect(signalPath in files).toBe(false);
+    expect(briefPath in files).toBe(false);
+    expect(`${workerDir}/resolve-conflict.claim.1` in files).toBe(false);
+    expect(`${workerDir}/.progress-resolve-conflict` in files).toBe(false);
+    expect(`${workerDir}/implement.claim.1` in files).toBe(true);
+    expect(`${workerDir}/.progress-implement` in files).toBe(true);
+  });
+
+  test("(b) terminal 'failed' → resets", () => {
+    const { files, deps } = inMemoryFs({ [signalPath]: JSON.stringify({ status: "failed" }) });
+    expect(maybeResetForResolveConflictCycle(orchDir, ticket, deps)).toBe(true);
+    expect(signalPath in files).toBe(false);
+  });
+
+  test("(b) terminal 'stalled' (phase-agent-dispatch's mark_launch_failed path) → resets", () => {
+    const { files, deps } = inMemoryFs({ [signalPath]: JSON.stringify({ status: "stalled" }) });
+    expect(maybeResetForResolveConflictCycle(orchDir, ticket, deps)).toBe(true);
+    expect(signalPath in files).toBe(false);
+  });
+
+  test("(c) 'dispatched' (actually in-flight) → NEVER touched, returns false", () => {
+    const { files, deps } = inMemoryFs({
+      [signalPath]: JSON.stringify({ status: "dispatched", generation: 1 }),
+      [briefPath]: JSON.stringify({ stalledPhase: "implement" }),
+      [`${workerDir}/resolve-conflict.claim.1`]: "{}",
+    });
+    expect(maybeResetForResolveConflictCycle(orchDir, ticket, deps)).toBe(false);
+    expect(signalPath in files).toBe(true);
+    expect(briefPath in files).toBe(true);
+    expect(`${workerDir}/resolve-conflict.claim.1` in files).toBe(true);
+  });
+
+  test("(c) 'running' (actually in-flight) → NEVER touched, returns false", () => {
+    const { files, deps } = inMemoryFs({ [signalPath]: JSON.stringify({ status: "running" }) });
+    expect(maybeResetForResolveConflictCycle(orchDir, ticket, deps)).toBe(false);
+    expect(signalPath in files).toBe(true);
+  });
+
+  test("malformed signal JSON → treated like absent, returns false (never throws)", () => {
+    const { deps } = inMemoryFs({ [signalPath]: "{not json" });
+    expect(() => maybeResetForResolveConflictCycle(orchDir, ticket, deps)).not.toThrow();
+    expect(maybeResetForResolveConflictCycle(orchDir, ticket, deps)).toBe(false);
+  });
+});
+
+describe("defaultMarkAndDispatch — #1461 cycle-reset integration", () => {
+  const orchDir = "/orch";
+  const ticket = "CTL-1";
+  const workerDir = `${orchDir}/workers/${ticket}`;
+
+  // A fake `dispatch` that mirrors phase-agent-dispatch's OWN idempotency guard
+  // (EXISTING_STATUS in dispatched|running|done → no-op `idempotent:true`,
+  // otherwise write status:"dispatched" at a fresh generation) — reading the
+  // SAME in-memory files defaultMarkAndDispatch itself just wrote/deleted. This
+  // is what proves the reset actually changes what phase-agent-dispatch would see,
+  // not just that some internal seam was called.
+  function fakeDispatchLikeRealPhaseAgentDispatch(files) {
+    let calls = 0;
+    const fn = (_orchDir, tk, phase) => {
+      calls++;
+      const sigPath = `${workerDir}/phase-${phase}.json`;
+      let existingStatus = null;
+      if (sigPath in files) {
+        try {
+          existingStatus = JSON.parse(files[sigPath]).status;
+        } catch {
+          existingStatus = null;
+        }
+      }
+      if (["dispatched", "running", "done"].includes(existingStatus)) {
+        return { code: 0, signal: { idempotent: true } };
+      }
+      files[sigPath] = JSON.stringify({ status: "dispatched", generation: calls + 1 });
+      return { code: 0, signal: { bg_job_id: `job-${calls}` } };
+    };
+    fn.callCount = () => calls;
+    return fn;
+  }
+
+  test("(a) first cycle (no prior phase-resolve-conflict.json) — dispatches cleanly, no regression", () => {
+    const { files, deps } = inMemoryFs({
+      [`${workerDir}/phase-implement.json`]: JSON.stringify({ status: "stalled", failureReason: RESOLVE_CONFLICT_STALL_REASON }),
+    });
+    deps.isThenable = () => false;
+    deps.dispatch = fakeDispatchLikeRealPhaseAgentDispatch(files);
+    const result = defaultMarkAndDispatch(
+      { ticket, phase: "implement", workerDir, worktreePath: "/wt/CTL-1", base: "main", classification: { resolvable: true, conflictFiles: [], conflictTypes: [] }, cycleCount: 0, orchDir },
+      deps,
+    );
+    expect(result.success).toBe(true);
+    expect(result.dispatched).toBe(true);
+    expect(result.bgJobId).toBe("job-1");
+  });
+
+  // (b) — the actual gap this task fixes: a SECOND genuine stall, with a STALE
+  // "done" phase-resolve-conflict.json left over from a completed first cycle,
+  // must still result in a REAL dispatch (not an idempotent no-op).
+  test("(b) second genuine stall after a completed first cycle resets the stale terminal signal before redispatching", () => {
+    const { files, deps } = inMemoryFs({
+      [`${workerDir}/phase-resolve-conflict.json`]: JSON.stringify({ status: "done", generation: 1 }),
+      [`${workerDir}/resolve-conflict-brief.json`]: JSON.stringify({ stalledPhase: "implement", attempt: 1 }),
+      [`${workerDir}/resolve-conflict.claim.1`]: "{}",
+      // a FRESH stall on the original phase — a genuinely new, different conflict
+      [`${workerDir}/phase-implement.json`]: JSON.stringify({ status: "stalled", failureReason: RESOLVE_CONFLICT_STALL_REASON }),
+    });
+    deps.isThenable = () => false;
+    const dispatch = fakeDispatchLikeRealPhaseAgentDispatch(files);
+    deps.dispatch = dispatch;
+
+    const result = defaultMarkAndDispatch(
+      { ticket, phase: "implement", workerDir, worktreePath: "/wt/CTL-1", base: "main", classification: { resolvable: true, conflictFiles: [], conflictTypes: [] }, cycleCount: 1, orchDir },
+      deps,
+    );
+
+    // Proves the redispatch was NOT swallowed as idempotent: a real bg_job_id
+    // came back, not `{idempotent:true}`.
+    expect(result.success).toBe(true);
+    expect(result.dispatched).toBe(true);
+    expect(result.bgJobId).toBe("job-1");
+    expect(dispatch.callCount()).toBe(1);
+    // the stale gen-1 claim tombstone from cycle 1 is gone — the fresh
+    // gen-1 claim phase-agent-dispatch would attempt is exclusive, not colliding.
+    expect(`${workerDir}/resolve-conflict.claim.1` in files).toBe(false);
+    // phase-resolve-conflict.json now reflects the NEW dispatch, not the stale "done".
+    expect(JSON.parse(files[`${workerDir}/phase-resolve-conflict.json`]).status).toBe("dispatched");
+  });
+
+  // Defensive safety net: in production, an in-flight phase-resolve-conflict.json
+  // means the original stalled-phase signal is still RESOLVED_MARKER_REASON, which
+  // classifyResolveConflictCandidate routes to "skip: already-resolving" — this
+  // function is never reached. This test exercises defaultMarkAndDispatch's own
+  // reset call directly anyway, to prove the safety property holds even if it
+  // were ever reached: the in-flight signal is left byte-for-byte untouched.
+  test("(c) an actually in-flight ('running') phase-resolve-conflict.json is never touched by the reset", () => {
+    const runningSignal = JSON.stringify({ status: "running", generation: 1 });
+    const { files, deps } = inMemoryFs({
+      [`${workerDir}/phase-resolve-conflict.json`]: runningSignal,
+      [`${workerDir}/resolve-conflict-brief.json`]: JSON.stringify({ stalledPhase: "implement", attempt: 1 }),
+      [`${workerDir}/resolve-conflict.claim.1`]: "{}",
+      [`${workerDir}/phase-implement.json`]: JSON.stringify({ status: "stalled", failureReason: RESOLVED_MARKER_REASON }),
+    });
+    deps.isThenable = () => false;
+    deps.dispatch = fakeDispatchLikeRealPhaseAgentDispatch(files);
+
+    defaultMarkAndDispatch(
+      { ticket, phase: "implement", workerDir, worktreePath: "/wt/CTL-1", base: "main", classification: { resolvable: true, conflictFiles: [], conflictTypes: [] }, cycleCount: 1, orchDir },
+      deps,
+    );
+
+    // Safety-critical: the reset must never have fired — the running signal,
+    // its brief, and its claim tombstone all survive completely untouched.
+    // (dispatch() is still invoked by defaultMarkAndDispatch itself — that call
+    // is unconditional in this function — but per phase-agent-dispatch's OWN
+    // idempotency guard it would correctly no-op against the untouched "running"
+    // signal rather than double-launching a worker.)
+    expect(files[`${workerDir}/phase-resolve-conflict.json`]).toBe(runningSignal);
+    expect(`${workerDir}/resolve-conflict-brief.json` in files).toBe(true);
+    expect(`${workerDir}/resolve-conflict.claim.1` in files).toBe(true);
+  });
+});
+
 describe("defaultEscalateCapExhausted", () => {
   test("marks the signal cap-exhausted and posts the escalation comment", () => {
     const reads = { "/w/phase-implement.json": JSON.stringify({ status: "stalled", failureReason: "source_conflict_resolvable" }) };
@@ -622,6 +848,173 @@ describe("runResolveConflictSweepPass", () => {
     expect(report.failed).toEqual([]);
   });
 });
+
+// #1461 follow-up (final whole-branch re-review), test (d): a true end-to-end
+// proof that RESOLVE_CONFLICT_CYCLE_CAP is now REACHABLE via genuinely repeated
+// cycles — not the pre-fix world where cycle 2+ was silently swallowed as an
+// idempotent no-op forever. Drives defaultMarkAndDispatch through
+// RESOLVE_CONFLICT_CYCLE_CAP real cycles, using the REAL countResolveConflictAttempts
+// (event-scan.mjs) against a real temp events.jsonl as the durable counter — the
+// exact function production wires as cycleCountOf — and a fake `dispatch` that
+// mirrors phase-agent-dispatch's own idempotency guard byte-for-byte, so a
+// silently-swallowed redispatch would show up as a call returning
+// `{idempotent:true}` instead of a fresh bg_job_id.
+describe("#1461 follow-up: resolve-conflict cycle-cap end-to-end reachability", () => {
+  test("N genuinely-redispatched cycles advance the durable counter until the cap trips and escalates", () => {
+    const dir = mkdtempSync(join(tmpdir(), "resolve-conflict-e2e-"));
+    const eventLogPath = join(dir, "events.jsonl");
+    try {
+      const orchDir = "/orch";
+      const ticket = "CTL-E2E";
+      const workerDir = `${orchDir}/workers/${ticket}`;
+      const { files, deps } = inMemoryFsForE2E();
+      deps.isThenable = () => false;
+
+      let dispatchGen = 0;
+      let idempotentNoOps = 0;
+      let realDispatches = 0;
+      deps.dispatch = (_orchDir, tk, phase) => {
+        const sigPath = `${workerDir}/phase-${phase}.json`;
+        let existingStatus = null;
+        if (sigPath in files) {
+          try {
+            existingStatus = JSON.parse(files[sigPath]).status;
+          } catch {
+            existingStatus = null;
+          }
+        }
+        if (["dispatched", "running", "done"].includes(existingStatus)) {
+          idempotentNoOps++;
+          return { code: 0, signal: { idempotent: true } };
+        }
+        dispatchGen++;
+        realDispatches++;
+        // Simulate the worker completing this cycle: writes status:"done" and
+        // emits the durable phase.resolve-conflict.complete.<ticket> event —
+        // exactly what the real /catalyst-dev:phase-resolve-conflict skill does.
+        files[sigPath] = JSON.stringify({ status: "done", generation: dispatchGen });
+        appendFileSync(
+          eventLogPath,
+          JSON.stringify({
+            ts: new Date().toISOString(),
+            attributes: { "event.name": `phase.resolve-conflict.complete.${tk}`, "event.label": tk, "catalyst.orchestration": tk },
+          }) + "\n",
+        );
+        return { code: 0, signal: { bg_job_id: `job-${dispatchGen}` } };
+      };
+
+      function freshStall() {
+        // A brand-new stall on the ORIGINAL phase — as if defaultClearStall
+        // already deleted the prior cycle's marked signal and a fresh dispatch
+        // of that phase later stalled again for a genuinely NEW conflict.
+        files[`${workerDir}/phase-implement.json`] = JSON.stringify({
+          status: "stalled",
+          failureReason: RESOLVE_CONFLICT_STALL_REASON,
+        });
+      }
+
+      for (let cycle = 0; cycle < RESOLVE_CONFLICT_CYCLE_CAP; cycle++) {
+        freshStall();
+        const cycleCount = countResolveConflictAttempts({ ticket, path: eventLogPath });
+        expect(cycleCount).toBe(cycle); // the durable counter is genuinely advancing
+        const decision = classifyResolveConflictCandidate({
+          stalledReasonMatches: true,
+          alreadyResolving: false,
+          cycleCount,
+          classification: { resolvable: true, conflictFiles: [], conflictTypes: [] },
+        });
+        expect(decision.action).toBe("mark-and-dispatch");
+        const result = defaultMarkAndDispatch(
+          {
+            ticket,
+            phase: "implement",
+            workerDir,
+            worktreePath: `/wt/${ticket}`,
+            base: "main",
+            classification: { resolvable: true, conflictFiles: [], conflictTypes: [] },
+            cycleCount,
+            orchDir,
+          },
+          deps,
+        );
+        expect(result.success).toBe(true);
+        expect(result.dispatched).toBe(true);
+        // Simulate defaultCollectResolveConflictCompletions + clearStall having
+        // run in a later tick: the original stalled-phase signal is deleted.
+        delete files[`${workerDir}/phase-implement.json`];
+      }
+
+      // Every cycle was a REAL dispatch — the reset made sure none of them were
+      // silently swallowed as a stale idempotent no-op (the pre-fix bug).
+      expect(realDispatches).toBe(RESOLVE_CONFLICT_CYCLE_CAP);
+      expect(idempotentNoOps).toBe(0);
+
+      // The (cap+1)th stall: the durable counter now reflects CAP completed
+      // cycles → the classifier must route to cap-exhausted, not mark-and-dispatch.
+      freshStall();
+      const finalCount = countResolveConflictAttempts({ ticket, path: eventLogPath });
+      expect(finalCount).toBe(RESOLVE_CONFLICT_CYCLE_CAP);
+      const finalDecision = classifyResolveConflictCandidate({
+        stalledReasonMatches: true,
+        alreadyResolving: false,
+        cycleCount: finalCount,
+        classification: { resolvable: true, conflictFiles: [], conflictTypes: [] },
+      });
+      expect(finalDecision.action).toBe("cap-exhausted");
+
+      // And the escalation actually fires via the existing defaultEscalateCapExhausted seam.
+      const posted = [];
+      const escDeps = {
+        readFileSync: (p) => files[p],
+        writeFileSync: (p, body) => { files[p] = body; },
+        renameSync: (from, to) => { files[to] = files[from]; delete files[from]; },
+        postComment: (tk, body) => { posted.push([tk, body]); return true; },
+      };
+      const escalated = defaultEscalateCapExhausted(
+        { ticket, phase: "implement", workerDir, cycleCount: finalCount },
+        escDeps,
+      );
+      expect(escalated).toBe(true);
+      expect(JSON.parse(files[`${workerDir}/phase-implement.json`]).failureReason).toBe(CAP_EXHAUSTED_REASON);
+      expect(posted).toHaveLength(1);
+      expect(posted[0][1]).toMatch(new RegExp(`cycle cap \\(${RESOLVE_CONFLICT_CYCLE_CAP}\\)`));
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+// inMemoryFsForE2E — same shape as inMemoryFs above, duplicated locally so this
+// describe block reads standalone (no cross-describe-block state coupling).
+function inMemoryFsForE2E() {
+  const files = {};
+  return {
+    files,
+    deps: {
+      readFileSync: (p) => {
+        if (!(p in files)) throw new Error(`ENOENT: ${p}`);
+        return files[p];
+      },
+      writeFileSync: (p, body) => {
+        files[p] = body;
+      },
+      renameSync: (from, to) => {
+        files[to] = files[from];
+        delete files[from];
+      },
+      mkdirSync: () => {},
+      rmSync: (p) => {
+        delete files[p];
+      },
+      readdirSync: (dir) => {
+        const prefix = dir.endsWith("/") ? dir : `${dir}/`;
+        return Object.keys(files)
+          .filter((f) => f.startsWith(prefix) && !f.slice(prefix.length).includes("/"))
+          .map((f) => f.slice(prefix.length));
+      },
+    },
+  };
+}
 
 // #1461 Fix 4 (IMPORTANT final-review finding): emitResolveConflictEvent — the
 // dedicated unified-log emitter, mirroring emitUnstuckEvent's own test suite

--- a/plugins/dev/scripts/execution-core/resolve-conflict-sweep.test.mjs
+++ b/plugins/dev/scripts/execution-core/resolve-conflict-sweep.test.mjs
@@ -1,0 +1,137 @@
+import { describe, test, expect } from "bun:test";
+import {
+  classifyResolveConflictCandidate,
+  RESOLVE_CONFLICT_STALL_REASON,
+  RESOLVED_MARKER_REASON,
+  CAP_EXHAUSTED_REASON,
+  RESOLVE_CONFLICT_CYCLE_CAP,
+  defaultCollectResolveConflictCandidates,
+} from "./resolve-conflict-sweep.mjs";
+
+describe("constants", () => {
+  test("stall reason strings match the real producer + do not collide with the enum", () => {
+    expect(RESOLVE_CONFLICT_STALL_REASON).toBe("source_conflict_ctl708_unavailable");
+    expect(RESOLVED_MARKER_REASON).toBe("source_conflict_resolvable");
+    expect(CAP_EXHAUSTED_REASON).toBe("resolve-conflict-cycle-cap-exhausted");
+    expect(RESOLVE_CONFLICT_CYCLE_CAP).toBeGreaterThan(0);
+  });
+});
+
+describe("classifyResolveConflictCandidate", () => {
+  test("not our stall reason and not already resolving → skip", () => {
+    expect(classifyResolveConflictCandidate({ stalledReasonMatches: false, alreadyResolving: false, cycleCount: 0, classification: null }))
+      .toEqual({ action: "skip", reason: "not-our-stall" });
+  });
+
+  test("cap already exhausted → cap-exhausted regardless of classification", () => {
+    expect(classifyResolveConflictCandidate({ stalledReasonMatches: true, alreadyResolving: false, cycleCount: 3, classification: { resolvable: true, conflictFiles: [], conflictTypes: [] } }))
+      .toEqual({ action: "cap-exhausted", reason: "cycle-cap-exhausted" });
+  });
+
+  test("already marked/dispatched this cycle → skip (dispatch is in flight)", () => {
+    expect(classifyResolveConflictCandidate({ stalledReasonMatches: false, alreadyResolving: true, cycleCount: 0, classification: null }))
+      .toEqual({ action: "skip", reason: "already-resolving" });
+  });
+
+  test("classification unavailable (merge-tree probe failed this tick) → skip, retry next tick", () => {
+    expect(classifyResolveConflictCandidate({ stalledReasonMatches: true, alreadyResolving: false, cycleCount: 0, classification: null }))
+      .toEqual({ action: "skip", reason: "classification-unavailable" });
+  });
+
+  test("classified not-resolvable → skip, leave for existing needs-human surfacing", () => {
+    expect(classifyResolveConflictCandidate({ stalledReasonMatches: true, alreadyResolving: false, cycleCount: 0, classification: { resolvable: false, conflictFiles: ["a.ts"], conflictTypes: ["modify/delete"] } }))
+      .toEqual({ action: "skip", reason: "not-resolvable" });
+  });
+
+  test("resolvable and under cap → mark-and-dispatch", () => {
+    expect(classifyResolveConflictCandidate({ stalledReasonMatches: true, alreadyResolving: false, cycleCount: 1, classification: { resolvable: true, conflictFiles: ["a.ts"], conflictTypes: ["content"] } }))
+      .toEqual({ action: "mark-and-dispatch", reason: "resolvable" });
+  });
+});
+
+describe("defaultCollectResolveConflictCandidates", () => {
+  function fakeFs({ workerDirs, files }) {
+    return {
+      readdirSync: (p, opts) => {
+        if (opts?.withFileTypes) {
+          return (workerDirs[p] ?? []).map((name) => ({ name, isDirectory: () => true }));
+        }
+        return files[p] ?? [];
+      },
+      readFileSync: (p) => {
+        if (!(p in files)) throw new Error(`ENOENT: ${p}`);
+        return files[p];
+      },
+    };
+  }
+
+  test("finds a ticket stalled via failureReason (the real producer field)", () => {
+    const orchDir = "/orch";
+    const fs = fakeFs({
+      workerDirs: { "/orch/workers": ["CTL-1"] },
+      files: {
+        "/orch/workers/CTL-1": ["phase-implement.json"],
+        "/orch/workers/CTL-1/phase-implement.json": JSON.stringify({
+          status: "stalled",
+          failureReason: "source_conflict_ctl708_unavailable",
+        }),
+      },
+    });
+    const out = defaultCollectResolveConflictCandidates({ orchDir, ...fs });
+    expect(out).toHaveLength(1);
+    expect(out[0]).toMatchObject({ ticket: "CTL-1", phase: "implement" });
+  });
+
+  test("also finds a ticket via the legacy stalledReason field (defensive dual-check)", () => {
+    const orchDir = "/orch";
+    const fs = fakeFs({
+      workerDirs: { "/orch/workers": ["CTL-2"] },
+      files: {
+        "/orch/workers/CTL-2": ["phase-verify.json"],
+        "/orch/workers/CTL-2/phase-verify.json": JSON.stringify({
+          status: "stalled",
+          stalledReason: "source_conflict_ctl708_unavailable",
+        }),
+      },
+    });
+    const out = defaultCollectResolveConflictCandidates({ orchDir, ...fs });
+    expect(out).toHaveLength(1);
+    expect(out[0].ticket).toBe("CTL-2");
+  });
+
+  test("finds an already-marked (in-flight) ticket via RESOLVED_MARKER_REASON", () => {
+    const orchDir = "/orch";
+    const fs = fakeFs({
+      workerDirs: { "/orch/workers": ["CTL-3"] },
+      files: {
+        "/orch/workers/CTL-3": ["phase-review.json"],
+        "/orch/workers/CTL-3/phase-review.json": JSON.stringify({
+          status: "stalled",
+          failureReason: "source_conflict_resolvable",
+        }),
+      },
+    });
+    const out = defaultCollectResolveConflictCandidates({ orchDir, ...fs });
+    expect(out).toHaveLength(1);
+    expect(out[0].raw.failureReason).toBe("source_conflict_resolvable");
+  });
+
+  test("ignores an unrelated stall reason", () => {
+    const orchDir = "/orch";
+    const fs = fakeFs({
+      workerDirs: { "/orch/workers": ["CTL-4"] },
+      files: {
+        "/orch/workers/CTL-4": ["phase-implement.json"],
+        "/orch/workers/CTL-4/phase-implement.json": JSON.stringify({
+          status: "stalled",
+          failureReason: "rebase_refused_dirty_tree",
+        }),
+      },
+    });
+    expect(defaultCollectResolveConflictCandidates({ orchDir, ...fs })).toHaveLength(0);
+  });
+
+  test("a missing workers dir returns []", () => {
+    expect(defaultCollectResolveConflictCandidates({ orchDir: "/nope", readdirSync: () => { throw new Error("ENOENT"); } })).toEqual([]);
+  });
+});

--- a/plugins/dev/scripts/execution-core/resolve-conflict-sweep.test.mjs
+++ b/plugins/dev/scripts/execution-core/resolve-conflict-sweep.test.mjs
@@ -1,5 +1,5 @@
 import { describe, test, expect, beforeEach, afterEach } from "bun:test";
-import { mkdtempSync, rmSync, existsSync, readFileSync, appendFileSync } from "node:fs";
+import { mkdtempSync, rmSync, existsSync, readFileSync, writeFileSync, mkdirSync, appendFileSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import {
@@ -461,6 +461,15 @@ describe("maybeResetForResolveConflictCycle (#1461 follow-up)", () => {
     expect(signalPath in files).toBe(false);
   });
 
+  // C1 review follow-up: 'turn-cap-exhausted' (the maxTurns backstop shape) is
+  // also a FINISHED prior cycle — must reset, not no-op, or a fresh dispatch
+  // attempt collides with phase-agent-dispatch's own idempotency guard.
+  test("(b) terminal 'turn-cap-exhausted' (maxTurns backstop path) → resets", () => {
+    const { files, deps } = inMemoryFs({ [signalPath]: JSON.stringify({ status: "turn-cap-exhausted" }) });
+    expect(maybeResetForResolveConflictCycle(orchDir, ticket, deps)).toBe(true);
+    expect(signalPath in files).toBe(false);
+  });
+
   test("(c) 'dispatched' (actually in-flight) → NEVER touched, returns false", () => {
     const { files, deps } = inMemoryFs({
       [signalPath]: JSON.stringify({ status: "dispatched", generation: 1 }),
@@ -764,6 +773,45 @@ describe("defaultCollectResolveConflictFailures (#1461 escalation-gap fix)", () 
     expect(defaultCollectResolveConflictFailures({ orchDir: "/orch", ...fs })).toEqual([]);
   });
 
+  // C1 (review follow-up, CRITICAL): a bare `status === "failed"` check only
+  // caught the in-skill hard-error path. These two cases are the OTHER real
+  // on-disk shapes a resolve-conflict dispatch failure lands in — both must be
+  // recognized too, or the ticket is silently stranded exactly like before this
+  // fix, just via a different failure mode.
+  test("finds a ticket whose resolve-conflict phase is 'stalled' with an attentionReason — the mark_launch_failed / backstopOnRejection shape (C1 fix)", () => {
+    // Exactly what phase-agent-dispatch's mark_launch_failed AND
+    // dispatch.mjs's backstopOnRejection → defaultEmitBackstop →
+    // defaultWriteSignalStalled actually write on disk: status:"stalled" with
+    // `attentionReason`, NOT `failureReason`/`stalledReason`. Under an
+    // all-codex/all-sdk executor routing, the backstop path is the LIVE
+    // production dispatch-failure shape.
+    const fs = fakeFs({
+      workerDirs: { "/orch/workers": ["CTL-5"] },
+      files: {
+        "/orch/workers/CTL-5": ["phase-resolve-conflict.json", "resolve-conflict-brief.json", "phase-implement.json"],
+        "/orch/workers/CTL-5/phase-resolve-conflict.json": JSON.stringify({ status: "stalled", attentionReason: "sdk-backstop" }),
+        "/orch/workers/CTL-5/resolve-conflict-brief.json": JSON.stringify({ stalledPhase: "implement" }),
+        "/orch/workers/CTL-5/phase-implement.json": JSON.stringify({ status: "stalled", failureReason: "source_conflict_resolvable" }),
+      },
+    });
+    const out = defaultCollectResolveConflictFailures({ orchDir: "/orch", ...fs });
+    expect(out).toEqual([{ ticket: "CTL-5", stalledPhase: "implement", workerDir: "/orch/workers/CTL-5" }]);
+  });
+
+  test("finds a ticket whose resolve-conflict phase is 'turn-cap-exhausted' — the maxTurns backstop shape (C1 fix)", () => {
+    const fs = fakeFs({
+      workerDirs: { "/orch/workers": ["CTL-6"] },
+      files: {
+        "/orch/workers/CTL-6": ["phase-resolve-conflict.json", "resolve-conflict-brief.json", "phase-implement.json"],
+        "/orch/workers/CTL-6/phase-resolve-conflict.json": JSON.stringify({ status: "turn-cap-exhausted", attentionReason: "sdk-error-max-turns" }),
+        "/orch/workers/CTL-6/resolve-conflict-brief.json": JSON.stringify({ stalledPhase: "implement" }),
+        "/orch/workers/CTL-6/phase-implement.json": JSON.stringify({ status: "stalled", failureReason: "source_conflict_resolvable" }),
+      },
+    });
+    const out = defaultCollectResolveConflictFailures({ orchDir: "/orch", ...fs });
+    expect(out).toEqual([{ ticket: "CTL-6", stalledPhase: "implement", workerDir: "/orch/workers/CTL-6" }]);
+  });
+
   // Safety-critical (c): an actually in-flight run must NEVER be touched by the
   // new failure-handling path — proven here at the collector level, since the
   // collector is what feeds the driver's failures sub-pass.
@@ -918,6 +966,144 @@ describe("defaultRevertStallAndResetCycle (#1461 escalation-gap fix)", () => {
     });
     defaultRevertStallAndResetCycle(orchDir, ticket, "implement", deps);
     expect(files[`${workerDir}/phase-resolve-conflict.json`]).toBe(runningSignal);
+  });
+});
+
+// I1 (review follow-up, IMPORTANT): a REAL end-to-end chain over a REAL
+// filesystem (temp dir, no injected/faked deps at all), driving
+// runResolveConflictSweepPass with the ACTUAL defaultCollectResolveConflictFailures
+// + defaultRevertStallAndResetCycle, then verifying with the ACTUAL
+// defaultCollectResolveConflictCandidates — not hand-supplied classifier flags,
+// and not a hand-authored `{status:"failed"}` shortcut. The seeded
+// phase-resolve-conflict.json fixture is the shape mark_launch_failed /
+// backstopOnRejection ACTUALLY write on disk (status:"stalled" +
+// `attentionReason`, no failureReason/stalledReason) — exactly the shape the
+// pre-C1-fix bare `=== "failed"` predicate missed. This test is the proof the
+// chain is real: with the old predicate it would have found zero failures,
+// never reverted anything, and the final candidates assertion below would have
+// seen the ticket still stuck at RESOLVED_MARKER_REASON (an "already-resolving"
+// candidate) instead of a genuine RESOLVE_CONFLICT_STALL_REASON one.
+describe("#1461 escalation-gap fix: real end-to-end chain over a real filesystem (I1)", () => {
+  let dir;
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "resolve-conflict-real-fs-"));
+  });
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  for (const shape of [
+    { label: "mark_launch_failed / backstopOnRejection shape", status: "stalled", attentionReason: "sdk-backstop" },
+    { label: "maxTurns backstop shape", status: "turn-cap-exhausted", attentionReason: "sdk-error-max-turns" },
+  ]) {
+    test(`a real ${shape.label} on disk is collected, reverted, and the ticket becomes a genuine candidate again — in the SAME runResolveConflictSweepPass call`, async () => {
+      const orchDir = dir;
+      const ticket = "CTL-9101";
+      const workerDir = join(orchDir, "workers", ticket);
+      mkdirSync(workerDir, { recursive: true });
+
+      // The ORIGINAL phase already went through markStalledSignalResolving —
+      // marked RESOLVED_MARKER_REASON, awaiting the resolve-conflict worker.
+      writeFileSync(
+        join(workerDir, "phase-implement.json"),
+        JSON.stringify({ status: "stalled", failureReason: RESOLVED_MARKER_REASON, bg_job_id: "job-1" }),
+      );
+      writeFileSync(
+        join(workerDir, "resolve-conflict-brief.json"),
+        JSON.stringify({ stalledPhase: "implement", attempt: 1, maxAttempts: RESOLVE_CONFLICT_CYCLE_CAP }),
+      );
+      // The REAL on-disk shape the dispatch-failure path actually writes —
+      // NOT a hand-authored {status:"failed"} shortcut.
+      writeFileSync(
+        join(workerDir, "phase-resolve-conflict.json"),
+        JSON.stringify({ status: shape.status, attentionReason: shape.attentionReason, generation: 1 }),
+      );
+      writeFileSync(join(workerDir, "resolve-conflict.claim.1"), "{}");
+
+      // Drive the REAL driver with the REAL census + action functions, all bound
+      // to this real orchDir — no fakes anywhere in this call.
+      const report = await runResolveConflictSweepPass({
+        mode: "enforce",
+        collectCandidates: () => [],
+        collectCompletions: () => [],
+        collectFailures: () => defaultCollectResolveConflictFailures({ orchDir }),
+        cycleCountOf: () => 0, // under the cap
+        revertStallAndResetCycle: (f) => defaultRevertStallAndResetCycle(orchDir, f.ticket, f.stalledPhase),
+        emit: async () => true,
+      });
+
+      expect(report.retried).toEqual([{ ticket, phase: "implement" }]);
+      expect(report.escalated).toEqual([]);
+
+      // The revert genuinely landed on disk.
+      const revertedSignal = JSON.parse(readFileSync(join(workerDir, "phase-implement.json"), "utf8"));
+      expect(revertedSignal.failureReason).toBe(RESOLVE_CONFLICT_STALL_REASON);
+      expect(revertedSignal.bg_job_id).toBe("job-1"); // untouched
+
+      // The stale terminal signal + brief + claim are genuinely gone (the
+      // reused maybeResetForResolveConflictCycle reset).
+      expect(existsSync(join(workerDir, "phase-resolve-conflict.json"))).toBe(false);
+      expect(existsSync(join(workerDir, "resolve-conflict-brief.json"))).toBe(false);
+      expect(existsSync(join(workerDir, "resolve-conflict.claim.1"))).toBe(false);
+
+      // The REAL candidates census (not hand-supplied classifier flags) now
+      // finds this ticket as a genuine RESOLVE_CONFLICT_STALL_REASON candidate
+      // — proving the full chain: a real failure shape → collected → reverted
+      // → re-classifiable, all within this ONE runResolveConflictSweepPass call
+      // plus a direct candidates census call (mirroring how collectCandidates()
+      // would see it on the very next scheduler pass, same tick or the next).
+      const candidates = defaultCollectResolveConflictCandidates({ orchDir });
+      expect(candidates).toHaveLength(1);
+      expect(candidates[0]).toMatchObject({ ticket, phase: "implement" });
+      expect(candidates[0].raw.failureReason).toBe(RESOLVE_CONFLICT_STALL_REASON);
+
+      const decision = classifyResolveConflictCandidate({
+        stalledReasonMatches: candidates[0].raw.failureReason === RESOLVE_CONFLICT_STALL_REASON,
+        alreadyResolving: false,
+        cycleCount: 0,
+        classification: { resolvable: true, conflictFiles: [], conflictTypes: [] },
+      });
+      expect(decision.action).toBe("mark-and-dispatch");
+    });
+  }
+
+  test("at/over the cap, the same real failure shape escalates instead of reverting — phase-implement.json is left at RESOLVED_MARKER_REASON until escalateCapExhausted flips it", async () => {
+    const orchDir = dir;
+    const ticket = "CTL-9102";
+    const workerDir = join(orchDir, "workers", ticket);
+    mkdirSync(workerDir, { recursive: true });
+    writeFileSync(
+      join(workerDir, "phase-implement.json"),
+      JSON.stringify({ status: "stalled", failureReason: RESOLVED_MARKER_REASON }),
+    );
+    writeFileSync(join(workerDir, "resolve-conflict-brief.json"), JSON.stringify({ stalledPhase: "implement" }));
+    writeFileSync(
+      join(workerDir, "phase-resolve-conflict.json"),
+      JSON.stringify({ status: "stalled", attentionReason: "sdk-backstop" }),
+    );
+
+    const escalated = [];
+    const report = await runResolveConflictSweepPass({
+      mode: "enforce",
+      collectCandidates: () => [],
+      collectCompletions: () => [],
+      collectFailures: () => defaultCollectResolveConflictFailures({ orchDir }),
+      cycleCountOf: () => RESOLVE_CONFLICT_CYCLE_CAP,
+      revertStallAndResetCycle: () => { throw new Error("must not revert — at the cap"); },
+      escalateCapExhausted: (c) => { escalated.push(c); return true; },
+      emit: async () => true,
+    });
+
+    expect(report.escalated).toEqual([{ ticket, phase: "implement" }]);
+    expect(escalated).toEqual([{ ticket, phase: "implement", workerDir, cycleCount: RESOLVE_CONFLICT_CYCLE_CAP }]);
+    // phase-resolve-conflict.json's own reset never runs on the escalate path —
+    // only defaultEscalateCapExhausted (not exercised by this stub) would flip
+    // phase-implement.json to CAP_EXHAUSTED_REASON. The real function is
+    // covered directly by the "defaultEscalateCapExhausted" describe block and
+    // the existing E2E cap tests; here we're proving the driver ROUTES to it,
+    // not re-testing its own body.
+    const stillMarked = JSON.parse(readFileSync(join(workerDir, "phase-implement.json"), "utf8"));
+    expect(stillMarked.failureReason).toBe(RESOLVED_MARKER_REASON);
   });
 });
 

--- a/plugins/dev/scripts/execution-core/resolve-conflict-sweep.test.mjs
+++ b/plugins/dev/scripts/execution-core/resolve-conflict-sweep.test.mjs
@@ -164,6 +164,44 @@ describe("defaultCollectResolveConflictCandidates", () => {
   test("a missing workers dir returns []", () => {
     expect(defaultCollectResolveConflictCandidates({ orchDir: "/nope", readdirSync: () => { throw new Error("ENOENT"); } })).toEqual([]);
   });
+
+  test("skips a workers/ entry that is not a valid ticket key (isTicketKey filter)", () => {
+    const orchDir = "/orch";
+    const fs = fakeFs({
+      workerDirs: { "/orch/workers": ["not-a-ticket", "CTL-5"] },
+      files: {
+        "/orch/workers/CTL-5": ["phase-implement.json"],
+        "/orch/workers/CTL-5/phase-implement.json": JSON.stringify({
+          status: "stalled",
+          failureReason: "source_conflict_ctl708_unavailable",
+        }),
+      },
+    });
+    const out = defaultCollectResolveConflictCandidates({ orchDir, ...fs });
+    expect(out).toHaveLength(1);
+    expect(out[0].ticket).toBe("CTL-5");
+  });
+
+  test("a throwing resolveWorktreePath degrades to worktreePath:null (fail-closed), candidate still collected", () => {
+    const orchDir = "/orch";
+    const fs = fakeFs({
+      workerDirs: { "/orch/workers": ["CTL-6"] },
+      files: {
+        "/orch/workers/CTL-6": ["phase-implement.json"],
+        "/orch/workers/CTL-6/phase-implement.json": JSON.stringify({
+          status: "stalled",
+          failureReason: "source_conflict_ctl708_unavailable",
+        }),
+      },
+    });
+    const out = defaultCollectResolveConflictCandidates({
+      orchDir,
+      ...fs,
+      resolveWorktreePath: () => { throw new Error("resolver exploded"); },
+    });
+    expect(out).toHaveLength(1);
+    expect(out[0].worktreePath).toBeNull();
+  });
 });
 
 // #1461 Fix 5 (final-review finding, human-approved design): classifyLiveConflict
@@ -622,14 +660,31 @@ describe("defaultEscalateCapExhausted", () => {
       renameSync: () => {},
       postComment: (ticket, body) => { posted.push([ticket, body]); return true; },
     };
-    const ok = defaultEscalateCapExhausted({ ticket: "CTL-1", phase: "implement", workerDir: "/w", cycleCount: 3 }, deps);
+    const ok = defaultEscalateCapExhausted({ ticket: "CTL-1", phase: "implement", workerDir: "/w", cycleCount: 5 }, deps);
     expect(ok).toBe(true);
     const written = JSON.parse(writes[0][1]);
     expect(written.failureReason).toBe("resolve-conflict-cycle-cap-exhausted");
     expect(posted).toHaveLength(1);
     expect(posted[0][0]).toBe("CTL-1");
     expect(posted[0][1]).toMatch(/^🔼 \*\*phase-resolve-conflict\*\* escalated/);
-    expect(posted[0][1]).toMatch(/cycle cap \(3\)/);
+    expect(posted[0][1]).toMatch(/cycle cap \(3\)/);       // RESOLVE_CONFLICT_CYCLE_CAP (module constant)
+    expect(posted[0][1]).toMatch(/after 5 attempt\(s\)/);  // cycleCount (call argument) — now provably distinct
+  });
+
+  test("marks the signal cap-exhausted via stalledReason when that field is present instead of failureReason", () => {
+    const reads = { "/w/phase-implement.json": JSON.stringify({ status: "stalled", stalledReason: "source_conflict_resolvable" }) };
+    const writes = [];
+    const deps = {
+      readFileSync: (p) => reads[p],
+      writeFileSync: (p, body) => writes.push([p, body]),
+      renameSync: () => {},
+      postComment: () => true,
+    };
+    const ok = defaultEscalateCapExhausted({ ticket: "CTL-1", phase: "implement", workerDir: "/w", cycleCount: 3 }, deps);
+    expect(ok).toBe(true);
+    const written = JSON.parse(writes[0][1]);
+    expect(written.stalledReason).toBe("resolve-conflict-cycle-cap-exhausted");
+    expect(written.failureReason).toBeUndefined();
   });
 });
 
@@ -953,6 +1008,31 @@ describe("defaultRevertStallAndResetCycle (#1461 escalation-gap fix)", () => {
     expect(`${workerDir}/phase-resolve-conflict.json` in files).toBe(true);
   });
 
+  // M2 (review follow-up, see the source comment in defaultRevertStallAndResetCycle):
+  // the concurrent-write re-check. No existing fixture in this describe block
+  // exercised the REJECTION path — every one above seeds RESOLVED_MARKER_REASON
+  // and lets the revert proceed. Here the reason has already been changed away
+  // from RESOLVED_MARKER_REASON (to CAP_EXHAUSTED_REASON, simulating a
+  // concurrent cap-exhaustion escalate) by the time this function reads it —
+  // it must back off rather than clobber whatever owns the ticket's stall now.
+  test("M2 rejection: does NOT clobber the reason when a concurrent writer already changed it away from RESOLVED_MARKER_REASON", () => {
+    const { files, deps } = inMemoryFs({
+      [`${workerDir}/phase-implement.json`]: JSON.stringify({ status: "stalled", failureReason: CAP_EXHAUSTED_REASON, bg_job_id: "abc" }),
+    });
+    let readdirCalls = 0;
+    const spiedDeps = { ...deps, readdirSync: (...args) => { readdirCalls++; return deps.readdirSync(...args); } };
+    const ok = defaultRevertStallAndResetCycle(orchDir, ticket, "implement", spiedDeps);
+    expect(ok).toBe(false);
+    // never wrote anything — the concurrent CAP_EXHAUSTED_REASON write stands
+    expect(Object.keys(files)).toEqual([`${workerDir}/phase-implement.json`]);
+    // maybeResetForResolveConflictCycle (step 2) never invoked — step 1's
+    // rejection short-circuits before the reset is ever attempted.
+    expect(readdirCalls).toBe(0);
+    const untouched = JSON.parse(files[`${workerDir}/phase-implement.json`]);
+    expect(untouched.failureReason).toBe(CAP_EXHAUSTED_REASON);
+    expect(untouched.bg_job_id).toBe("abc"); // never rewritten
+  });
+
   // Safety-critical (c): even if this function were ever reached for a
   // genuinely in-flight resolve-conflict run (it shouldn't be — the failures
   // collector's status:"failed" filter is the real guarantee), the cycle-reset
@@ -1107,6 +1187,69 @@ describe("#1461 escalation-gap fix: real end-to-end chain over a real filesystem
   });
 });
 
+// I2 (#12 follow-up): I1 above only exercises the FAILURE→revert→re-candidate
+// chain. This is the sibling for the SUCCESSFUL-redispatch case: a real
+// runResolveConflictSweepPass → real defaultCollectResolveConflictCandidates →
+// real defaultMarkAndDispatch chain over a REAL filesystem, proving a fresh
+// stall behind a STALE terminal phase-resolve-conflict.json genuinely
+// re-dispatches (the stale-signal reset in defaultMarkAndDispatch actually
+// runs) rather than being silently swallowed by phase-agent-dispatch's own
+// idempotency guard as a no-op.
+describe("#1461 cycle-reset fix: real end-to-end successful-redispatch chain over a real filesystem (I2)", () => {
+  let dir;
+  beforeEach(() => { dir = mkdtempSync(join(tmpdir(), "resolve-conflict-redispatch-real-fs-")); });
+  afterEach(() => { rmSync(dir, { recursive: true, force: true }); });
+
+  test("a fresh stall behind a STALE done phase-resolve-conflict.json still gets a REAL dispatch, not a swallowed idempotent no-op", async () => {
+    const orchDir = dir;
+    const ticket = "CTL-9201";
+    const workerDir = join(orchDir, "workers", ticket);
+    mkdirSync(workerDir, { recursive: true });
+
+    // Stale terminal signal left over from a completed FIRST cycle.
+    writeFileSync(join(workerDir, "phase-resolve-conflict.json"), JSON.stringify({ status: "done", generation: 1 }));
+    writeFileSync(join(workerDir, "resolve-conflict-brief.json"), JSON.stringify({ stalledPhase: "implement", attempt: 1 }));
+    writeFileSync(join(workerDir, "resolve-conflict.claim.1"), "{}");
+    // A genuinely NEW stall on the same original phase.
+    writeFileSync(join(workerDir, "phase-implement.json"), JSON.stringify({ status: "stalled", failureReason: RESOLVE_CONFLICT_STALL_REASON }));
+
+    // fakeDispatchLikeRealPhaseAgentDispatch mirrors phase-agent-dispatch's own
+    // idempotency guard exactly (see the cycle-reset integration describe block
+    // above) — reused here unmodified against a REAL fs via readFileSync/writeFileSync.
+    let calls = 0;
+    const dispatch = (_orchDir, _tk, phase) => {
+      calls++;
+      const sigPath = join(workerDir, `phase-${phase}.json`);
+      let existingStatus = null;
+      try { existingStatus = JSON.parse(readFileSync(sigPath, "utf8")).status; } catch { existingStatus = null; }
+      if (["dispatched", "running", "done"].includes(existingStatus)) {
+        return { code: 0, signal: { idempotent: true } };
+      }
+      writeFileSync(sigPath, JSON.stringify({ status: "dispatched", generation: calls + 1 }));
+      return { code: 0, signal: { bg_job_id: `job-${calls}` } };
+    };
+
+    const report = await runResolveConflictSweepPass({
+      mode: "enforce",
+      collectCandidates: () => defaultCollectResolveConflictCandidates({ orchDir }),
+      collectCompletions: () => [],
+      collectFailures: () => [],
+      cycleCountOf: () => 1,
+      classifyLive: async () => ({ resolvable: true, conflictFiles: ["a.ts"], conflictTypes: ["content"] }),
+      markAndDispatch: (c) => defaultMarkAndDispatch({ ...c, orchDir }, { isThenable: () => false, dispatch }),
+      emit: async () => true,
+    });
+
+    expect(report.marked).toEqual([{ ticket, phase: "implement" }]);
+    expect(calls).toBe(1);
+    // The dispatch genuinely fired (not idempotent) — proven by the REAL
+    // phase-resolve-conflict.json now reading "dispatched", not the stale "done".
+    const finalSignal = JSON.parse(readFileSync(join(workerDir, "phase-resolve-conflict.json"), "utf8"));
+    expect(finalSignal.status).toBe("dispatched");
+    expect(existsSync(join(workerDir, "resolve-conflict.claim.1"))).toBe(false);
+  });
+});
+
 describe("runResolveConflictSweepPass", () => {
   test("mode 'off' skips everything, no census called", () => {
     const collectCandidates = () => { throw new Error("must not be called"); };
@@ -1244,6 +1387,46 @@ describe("runResolveConflictSweepPass", () => {
     });
     expect(report.marked).toEqual([]);
     expect(report.failed).toEqual([]);
+  });
+
+  test("a per-candidate throw (one ticket's cycleCountOf explodes) does not abort a sibling candidate in the same batch", async () => {
+    const marked = [];
+    const report = await runResolveConflictSweepPass({
+      mode: "enforce",
+      collectCandidates: () => [
+        { ticket: "CTL-BAD", phase: "implement", workerDir: "/w1", raw: { failureReason: "source_conflict_ctl708_unavailable" }, worktreePath: "/wt1", base: "main" },
+        { ticket: "CTL-GOOD", phase: "implement", workerDir: "/w2", raw: { failureReason: "source_conflict_ctl708_unavailable" }, worktreePath: "/wt2", base: "main" },
+      ],
+      collectCompletions: () => [],
+      cycleCountOf: (ticket) => { if (ticket === "CTL-BAD") throw new Error("boom"); return 0; },
+      classifyLive: async () => ({ resolvable: true, conflictFiles: [], conflictTypes: [] }),
+      markAndDispatch: (c) => { marked.push(c.ticket); return { success: true, dispatched: true }; },
+      emit: async () => true,
+    });
+    expect(report.failed).toEqual([{ ticket: "CTL-BAD", phase: "implement", reason: "boom" }]);
+    expect(report.marked).toEqual([{ ticket: "CTL-GOOD", phase: "implement" }]);
+    expect(marked).toEqual(["CTL-GOOD"]);
+  });
+
+  test("a per-completion throw (one ticket's clearStall explodes) does not abort a sibling completion in the same batch", async () => {
+    const cleared = [];
+    const report = await runResolveConflictSweepPass({
+      mode: "enforce",
+      collectCandidates: () => [],
+      collectCompletions: () => [
+        { ticket: "CTL-BAD", stalledPhase: "implement" },
+        { ticket: "CTL-GOOD", stalledPhase: "verify" },
+      ],
+      clearStall: (c) => {
+        if (c.ticket === "CTL-BAD") throw new Error("clear boom");
+        cleared.push(c.ticket);
+        return true;
+      },
+      emit: async () => true,
+    });
+    expect(report.failed).toEqual([{ ticket: "CTL-BAD", phase: "implement", reason: "clear boom" }]);
+    expect(report.cleared).toEqual([{ ticket: "CTL-GOOD", phase: "verify" }]);
+    expect(cleared).toEqual(["CTL-GOOD"]);
   });
 
   // #1461 escalation-gap fix: the failures sub-pass. A status:"failed"

--- a/plugins/dev/scripts/execution-core/resolve-conflict-sweep.test.mjs
+++ b/plugins/dev/scripts/execution-core/resolve-conflict-sweep.test.mjs
@@ -8,6 +8,8 @@ import {
   defaultCollectResolveConflictCandidates,
   classifyLiveConflict,
   writeResolveConflictBrief,
+  markStalledSignalResolving,
+  defaultMarkAndDispatch,
 } from "./resolve-conflict-sweep.mjs";
 
 describe("constants", () => {
@@ -181,5 +183,59 @@ describe("writeResolveConflictBrief", () => {
     expect(written.ticket).toBe("CTL-1");
     expect(written.stalledPhase).toBe("implement");
     expect(renames).toEqual([[writes[0][0], p]]);
+  });
+});
+
+describe("markStalledSignalResolving", () => {
+  test("rewrites failureReason to RESOLVED_MARKER_REASON, preserves other fields", () => {
+    const reads = { "/w/phase-implement.json": JSON.stringify({ status: "stalled", failureReason: "source_conflict_ctl708_unavailable", bg_job_id: "abc123" }) };
+    const writes = [];
+    const renames = [];
+    markStalledSignalResolving("/w/phase-implement.json", {
+      readFileSync: (p) => reads[p],
+      writeFileSync: (p, body) => writes.push([p, body]),
+      renameSync: (from, to) => renames.push([from, to]),
+    });
+    const written = JSON.parse(writes[0][1]);
+    expect(written.status).toBe("stalled");
+    expect(written.failureReason).toBe("source_conflict_resolvable");
+    expect(written.bg_job_id).toBe("abc123"); // untouched
+    expect(renames).toHaveLength(1);
+  });
+});
+
+describe("defaultMarkAndDispatch", () => {
+  function baseDeps(overrides = {}) {
+    return {
+      readFileSync: () => JSON.stringify({ status: "stalled", failureReason: "source_conflict_ctl708_unavailable" }),
+      writeFileSync: () => {},
+      renameSync: () => {},
+      mkdirSync: () => {},
+      dispatch: () => ({ code: 0, signal: { bg_job_id: "job-1" } }),
+      isThenable: () => false,
+      ...overrides,
+    };
+  }
+
+  test("marks the signal, writes the brief, dispatches — returns success:true", () => {
+    const dispatched = [];
+    const deps = baseDeps({ dispatch: (orchDir, ticket, phase) => { dispatched.push([orchDir, ticket, phase]); return { code: 0 }; } });
+    const result = defaultMarkAndDispatch(
+      { ticket: "CTL-1", phase: "implement", workerDir: "/orch/workers/CTL-1", worktreePath: "/wt/CTL-1", base: "main", classification: { resolvable: true, conflictFiles: ["a.ts"], conflictTypes: ["content"] }, cycleCount: 0, orchDir: "/orch" },
+      deps,
+    );
+    expect(result.success).toBe(true);
+    expect(result.dispatched).toBe(true);
+    expect(dispatched).toEqual([["/orch", "CTL-1", "resolve-conflict"]]);
+  });
+
+  test("returns success:false when dispatch reports a non-zero code", () => {
+    const deps = baseDeps({ dispatch: () => ({ code: 1, stderr: "boom" }) });
+    const result = defaultMarkAndDispatch(
+      { ticket: "CTL-1", phase: "implement", workerDir: "/orch/workers/CTL-1", worktreePath: "/wt/CTL-1", base: "main", classification: { resolvable: true, conflictFiles: [], conflictTypes: [] }, cycleCount: 0, orchDir: "/orch" },
+      deps,
+    );
+    expect(result.success).toBe(false);
+    expect(result.dispatched).toBe(false);
   });
 });

--- a/plugins/dev/scripts/execution-core/scheduler.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.mjs
@@ -5521,9 +5521,25 @@ export function schedulerTick(
   // escalated/cleared counts for the info log, or a failure for the warn log)
   // is handled fire-and-forget via .then()/.catch(), mirroring this file's
   // existing best-effort async discipline (e.g. the delegate-queue enqueue path).
+  //
+  // TOCTOU guard: because this pass is fire-and-forget with NO per-tick
+  // throttle (by design — see above), its async work (classifyLive's real
+  // `git merge-tree` spawn, then markAndDispatch's marker write) can still be
+  // pending when the NEXT tick fires. Without a guard, an overlapping tick
+  // would call collectCandidates() again, see the same still-unmarked
+  // candidate, and re-classify/re-dispatch it. _resolveConflictSweepInFlight
+  // (module-level, declared near _unstuckLastRunMs) makes a new tick skip
+  // starting a new pass while the previous one's promise is still pending; it
+  // is set the instant we decide to run and cleared once the promise settles
+  // (or synchronously below on a pre-Promise throw).
   {
     const rcMode = _resolveConflictMode ?? readResolveConflictSweepConfig().mode;
-    if (rcMode !== "off" && (_collectResolveConflictCandidates || _collectResolveConflictCompletions)) {
+    if (
+      rcMode !== "off" &&
+      (_collectResolveConflictCandidates || _collectResolveConflictCompletions) &&
+      !_resolveConflictSweepInFlight
+    ) {
+      _resolveConflictSweepInFlight = true;
       try {
         const rcResult = runResolveConflictSweepPass({
           mode: rcMode,
@@ -5552,16 +5568,27 @@ export function schedulerTick(
           }
         };
         if (rcResult && typeof rcResult.then === "function") {
-          rcResult.then(logRcReport).catch((err) => {
-            log.warn(
-              { step: "resolve-conflict-sweep", err: err?.message },
-              "scheduler: resolve-conflict-sweep pass failed — continuing tick (#1461)",
-            );
-          });
+          rcResult
+            .then(logRcReport)
+            .catch((err) => {
+              log.warn(
+                { step: "resolve-conflict-sweep", err: err?.message },
+                "scheduler: resolve-conflict-sweep pass failed — continuing tick (#1461)",
+              );
+            })
+            .finally(() => {
+              _resolveConflictSweepInFlight = false;
+            });
         } else {
+          // Defensive only — unreachable given the outer `rcMode !== "off"`
+          // gate (runResolveConflictSweepPass always takes the async-IIFE
+          // branch once mode isn't "off"), but keep the flag correct if that
+          // ever changes.
           logRcReport(rcResult);
+          _resolveConflictSweepInFlight = false;
         }
       } catch (err) {
+        _resolveConflictSweepInFlight = false; // threw before any promise was created
         log.warn({ step: "resolve-conflict-sweep", err: err.message }, "scheduler: resolve-conflict-sweep pass failed — continuing tick (#1461)");
       }
     }
@@ -8426,6 +8453,22 @@ let _unstuckLastRunMs = 0;
 // daemon restart (module reload) or via __resetForTests.
 let _stallJanitorCensusLastRunMs = 0;
 
+// #1461: resolve-conflict-sweep in-flight guard. runResolveConflictSweepPass is
+// fire-and-forget (see the wiring block above) — its async work (a real `git
+// merge-tree` subprocess in classifyLive, then the marker write in
+// markAndDispatch) settles strictly AFTER schedulerTick has already returned
+// to the setInterval-driven daemon loop, with no back-pressure between ticks.
+// Since this sweep runs every tick with NO throttle (by design, ADR-028 —
+// unlike unstuck-sweep's 15-min isThrottled gate), an overlapping tick could
+// otherwise re-collect + re-classify + re-dispatch the SAME still-unmarked
+// candidate before the previous tick's pass settles. This flag makes a new
+// tick skip starting a new pass while the prior one is still pending; cleared
+// in the settlement .then()/.catch() (or synchronously for mode='off', which
+// never goes async). Module-level so it persists across ticks without a db
+// write, mirroring _unstuckLastRunMs/_stallJanitorCensusLastRunMs above.
+// Reset to false on daemon restart (module reload) or via __resetForTests.
+let _resolveConflictSweepInFlight = false;
+
 function runTick() {
   try {
     // CTL-1330 Tier 1: emit the event-loop delay accumulated since the previous
@@ -9004,6 +9047,46 @@ function runTick() {
           typeof runningOpts.unstuckPostComment === "function"
             ? runningOpts.unstuckPostComment
             : undefined,
+      },
+      // #1461: wire the real resolve-conflict-sweep census + act seams (ADR-028).
+      // Like stallJanitor/unstuckSweep above, a bare schedulerTick (unit test)
+      // passes no `resolveConflictSweep` so the pass stays inert. Mode/emit
+      // default INSIDE schedulerTick (readResolveConflictSweepConfig() → 'off'
+      // unless CATALYST_RESOLVE_CONFLICT_SWEEP/Layer-2 opts in) — mirrors
+      // stallJanitor/unstuckSweep's own fallback blocks, which likewise never
+      // set `mode` here. Without this block, setting
+      // CATALYST_RESOLVE_CONFLICT_SWEEP=shadow/enforce would have zero effect
+      // in the running daemon (schedulerTick would still see undefined
+      // collectors and skip the pass every tick).
+      resolveConflictSweep: runningOpts.resolveConflictSweep ?? {
+        collectCandidates: () =>
+          defaultCollectResolveConflictCandidates({
+            orchDir: runningOpts.orchDir,
+            // Thread the worktree resolver from each worker's signal so
+            // classifyLiveConflict actually has a path to run `git merge-tree`
+            // against — mirrors the identical resolveWorktreePath closure used
+            // by the unstuckSweep census and stallJanitor J4 GC census above.
+            // Without this, resolveWorktreePath defaults to () => null and
+            // every candidate classifies as "classification-unavailable"
+            // forever (resolve-conflict-sweep.mjs's own header comment flags
+            // this as exactly what Task 12's production wiring must inject).
+            resolveWorktreePath: (ticket) => {
+              for (const sig of readWorkerSignals(runningOpts.orchDir)) {
+                if (sig.ticket === ticket && sig.worktreePath) return sig.worktreePath;
+              }
+              return null;
+            },
+          }),
+        collectCompletions: () =>
+          defaultCollectResolveConflictCompletions({ orchDir: runningOpts.orchDir }),
+        classifyLive: classifyLiveConflict,
+        cycleCountOf: (ticket) => countResolveConflictCycles({ ticket }),
+        markAndDispatch: (c) => defaultMarkAndDispatch({ ...c, orchDir: runningOpts.orchDir }),
+        escalateCapExhausted: defaultEscalateCapExhausted,
+        // clearStall: same real seam as the stallJanitor/unstuckSweep fallback
+        // blocks above (defaultClearStall bound to this tick's real orchDir +
+        // the real writeStatus/linear-write seam) — not a new dependency.
+        clearStall: defaultClearStall(runningOpts.orchDir, runningOpts.writeStatus ?? linearWrite),
       },
       // CTL-1150: thread the triage-artifact predicate (undefined → inline
       // existsSync default in schedulerTick; test seam via startScheduler).
@@ -9618,6 +9701,7 @@ export function __resetForTests() {
   lastDispositionEmit.clear(); // CTL-764 Phase 5: reset worker.transition only-on-change dedup
   _unstuckLastRunMs = 0; // CTL-1064: reset Pass 0u throttle between tests
   _stallJanitorCensusLastRunMs = 0; // CTL-1324: reset Pass 0j census throttle between tests
+  _resolveConflictSweepInFlight = false; // #1461: reset the in-flight guard between tests
   // rankedAboveSince is cleared by stopScheduler above (CTL-705)
 }
 

--- a/plugins/dev/scripts/execution-core/scheduler.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.mjs
@@ -66,7 +66,7 @@ export { STAGE_RANK, NON_PREEMPTABLE_PHASES };
 // budget) live here. deriveAdvancement stays pure — the impure reads happen in
 // the sweep and are injected, so the router itself is unit-testable.
 import { readVerifyVerdict } from "./work-done-probes.mjs";
-import { countRemediateCycles, countTicketEventsInWindow } from "./event-scan.mjs";
+import { countRemediateCycles, countTicketEventsInWindow, countResolveConflictCycles } from "./event-scan.mjs"; // #1461: countResolveConflictCycles
 import { tailParsedEvents } from "./event-tail.mjs"; // CTL-1514: bounded event-log tail
 import { rankTickets, compareTickets } from "./scheduler-rank.mjs";
 import {
@@ -252,6 +252,19 @@ import {
   defaultCollectUnstuckCandidates,
   emitUnstuckEvent,
 } from "./unstuck-sweep.mjs";
+// #1461: resolve-conflict-sweep (ADR-028) — every-tick classify-then-act pass
+// over the resolvable-source-conflict stalled backlog. Structurally mirrors
+// unstuck-sweep.mjs (pure classifier + injected action driver); the census
+// producers + live-classify seam are wired below. Mode='off' by default;
+// operators opt in via CATALYST_RESOLVE_CONFLICT_SWEEP=shadow then =enforce.
+import {
+  runResolveConflictSweepPass,
+  defaultCollectResolveConflictCandidates,
+  defaultCollectResolveConflictCompletions,
+  classifyLiveConflict,
+  defaultMarkAndDispatch,
+  defaultEscalateCapExhausted,
+} from "./resolve-conflict-sweep.mjs";
 // CTL-1176: Pass 0r — LLM reasoning recovery pass. Ships off by default (ADR-023);
 // operators opt in via CATALYST_RECOVERY_PASS=shadow then =enforce.
 //
@@ -320,6 +333,7 @@ import {
   getLokiQueryUrl,
   readReclaimGatewayFreshMs,
   isThrottled,
+  readResolveConflictSweepConfig, // #1461
 } from "./config.mjs";
 import { readPeerHeartbeatsSyncCached } from "./cluster-heartbeat-sync.mjs";
 // CAT-57: Loki-source peer read for the productivity signal, so nodeProductivity is
@@ -4426,6 +4440,23 @@ export function schedulerTick(
       postComment: _unstuckPostComment = undefined,
       nowMs: _unstuckNowMs = undefined,
     } = {},
+    // #1461: resolve-conflict-sweep seams (ADR-028). Mode resolves from
+    // readResolveConflictSweepConfig() (env CATALYST_RESOLVE_CONFLICT_SWEEP >
+    // Layer-2 > 'off') unless overridden. Defaults keep a bare tick fully
+    // inert — no census producer means nothing to collect. Production wires
+    // the real census (defaultCollectResolveConflictCandidates /
+    // defaultCollectResolveConflictCompletions) + act seams via startScheduler.
+    resolveConflictSweep: {
+      mode: _resolveConflictMode = undefined,
+      collectCandidates: _collectResolveConflictCandidates = undefined,
+      collectCompletions: _collectResolveConflictCompletions = undefined,
+      classifyLive: _resolveConflictClassifyLive = undefined,
+      cycleCountOf: _resolveConflictCycleCountOf = undefined,
+      markAndDispatch: _resolveConflictMarkAndDispatch = undefined,
+      escalateCapExhausted: _resolveConflictEscalate = undefined,
+      clearStall: _resolveConflictClearStall = undefined,
+      emit: _resolveConflictEmit = undefined,
+    } = {},
     // CTL-1176: Pass 0r — recovery-reasoning pass seams. Default undefined keeps
     // a bare tick fully inert. Production passes mode from env > Layer-2.
     recoveryPass: { mode: _recoveryPassMode = undefined } = {},
@@ -5472,6 +5503,71 @@ export function schedulerTick(
   }
 
   tick?.lap("unstuck-sweep");
+
+  // #1461: resolve-conflict-sweep — every tick (no throttle: candidates are
+  // rare and the classify step only spawns git for a candidate this sweep
+  // actually owns). Mode='off' by default (ADR-023/ADR-028); operators opt in
+  // via CATALYST_RESOLVE_CONFLICT_SWEEP=shadow then =enforce.
+  //
+  // runResolveConflictSweepPass is intentionally NOT awaited here: schedulerTick
+  // is a plain synchronous function (no `await` anywhere in this file — see
+  // runTick's bare `schedulerTick(...)` call below), so a top-level `await`
+  // would not compile. The pass itself is synchronous in mode='off' (returns
+  // the report directly) and returns a Promise only in shadow/enforce (it needs
+  // `await classifyLive(...)` per-candidate); either way `collectCandidates()` /
+  // `collectCompletions()` run synchronously BEFORE that first internal await
+  // (see resolve-conflict-sweep.mjs), so census wiring is still exercised
+  // deterministically within this tick. The eventual settlement (marked/
+  // escalated/cleared counts for the info log, or a failure for the warn log)
+  // is handled fire-and-forget via .then()/.catch(), mirroring this file's
+  // existing best-effort async discipline (e.g. the delegate-queue enqueue path).
+  {
+    const rcMode = _resolveConflictMode ?? readResolveConflictSweepConfig().mode;
+    if (rcMode !== "off" && (_collectResolveConflictCandidates || _collectResolveConflictCompletions)) {
+      try {
+        const rcResult = runResolveConflictSweepPass({
+          mode: rcMode,
+          collectCandidates: _collectResolveConflictCandidates ?? (() => defaultCollectResolveConflictCandidates({ orchDir })),
+          collectCompletions: _collectResolveConflictCompletions ?? (() => defaultCollectResolveConflictCompletions({ orchDir })),
+          classifyLive: _resolveConflictClassifyLive ?? classifyLiveConflict,
+          cycleCountOf: _resolveConflictCycleCountOf ?? ((ticket) => countResolveConflictCycles({ ticket })),
+          markAndDispatch: _resolveConflictMarkAndDispatch ?? ((c) => defaultMarkAndDispatch({ ...c, orchDir })),
+          escalateCapExhausted: _resolveConflictEscalate ?? defaultEscalateCapExhausted,
+          clearStall: _resolveConflictClearStall ?? defaultClearStall(orchDir, writeStatus),
+          emit: _resolveConflictEmit,
+        });
+        const logRcReport = (rcReport) => {
+          if (
+            rcReport.marked.length ||
+            rcReport.escalated.length ||
+            rcReport.cleared.length ||
+            rcReport.wouldMark.length ||
+            rcReport.wouldEscalate.length ||
+            rcReport.wouldClear.length
+          ) {
+            log.info(
+              { mode: rcMode, marked: rcReport.marked.length, escalated: rcReport.escalated.length, cleared: rcReport.cleared.length },
+              "scheduler: resolve-conflict-sweep pass (#1461)",
+            );
+          }
+        };
+        if (rcResult && typeof rcResult.then === "function") {
+          rcResult.then(logRcReport).catch((err) => {
+            log.warn(
+              { step: "resolve-conflict-sweep", err: err?.message },
+              "scheduler: resolve-conflict-sweep pass failed — continuing tick (#1461)",
+            );
+          });
+        } else {
+          logRcReport(rcResult);
+        }
+      } catch (err) {
+        log.warn({ step: "resolve-conflict-sweep", err: err.message }, "scheduler: resolve-conflict-sweep pass failed — continuing tick (#1461)");
+      }
+    }
+  }
+
+  tick?.lap("resolve-conflict-sweep");
 
   // CTL-1176: Pass 0r — LLM reasoning recovery pass. Low-frequency autonomous
   // triage of the stalled/failed/needs-human/UNKNOWN backlog. Mode resolves from

--- a/plugins/dev/scripts/execution-core/scheduler.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.mjs
@@ -261,6 +261,11 @@ import {
   runResolveConflictSweepPass,
   defaultCollectResolveConflictCandidates,
   defaultCollectResolveConflictCompletions,
+  // #1461 escalation-gap fix: failure census + its revert-and-reset action seam
+  // (a FAILED, not "done", resolve-conflict run — see resolve-conflict-sweep.mjs
+  // for the full rationale).
+  defaultCollectResolveConflictFailures,
+  defaultRevertStallAndResetCycle,
   classifyLiveConflict,
   defaultMarkAndDispatch,
   defaultEscalateCapExhausted,
@@ -4457,6 +4462,12 @@ export function schedulerTick(
       mode: _resolveConflictMode = undefined,
       collectCandidates: _collectResolveConflictCandidates = undefined,
       collectCompletions: _collectResolveConflictCompletions = undefined,
+      // #1461 escalation-gap fix: failure census + revert-and-reset action seam.
+      // Defaults undefined → inert (bare unit tick has no census → skip
+      // cleanly); production wires defaultCollectResolveConflictFailures +
+      // defaultRevertStallAndResetCycle below.
+      collectFailures: _collectResolveConflictFailures = undefined,
+      revertStallAndResetCycle: _resolveConflictRevertStallAndResetCycle = undefined,
       classifyLive: _resolveConflictClassifyLive = undefined,
       cycleCountOf: _resolveConflictCycleCountOf = undefined,
       markAndDispatch: _resolveConflictMarkAndDispatch = undefined,
@@ -5556,6 +5567,14 @@ export function schedulerTick(
           mode: rcMode,
           collectCandidates: _collectResolveConflictCandidates ?? (() => defaultCollectResolveConflictCandidates({ orchDir })),
           collectCompletions: _collectResolveConflictCompletions ?? (() => defaultCollectResolveConflictCompletions({ orchDir })),
+          // #1461 escalation-gap fix: a FAILED (status:"failed") resolve-conflict
+          // run — census + the revert-and-reset action seam (escalateCapExhausted
+          // is REUSED below for the at/over-cap outcome, same as the candidates
+          // sub-pass's own cap-exhausted branch).
+          collectFailures: _collectResolveConflictFailures ?? (() => defaultCollectResolveConflictFailures({ orchDir })),
+          revertStallAndResetCycle:
+            _resolveConflictRevertStallAndResetCycle ??
+            ((f) => defaultRevertStallAndResetCycle(orchDir, f.ticket, f.stalledPhase)),
           classifyLive: _resolveConflictClassifyLive ?? classifyLiveConflict,
           cycleCountOf: _resolveConflictCycleCountOf ?? ((ticket) => countResolveConflictAttempts({ ticket })),
           markAndDispatch: _resolveConflictMarkAndDispatch ?? ((c) => defaultMarkAndDispatch({ ...c, orchDir })),
@@ -5568,12 +5587,20 @@ export function schedulerTick(
             rcReport.marked.length ||
             rcReport.escalated.length ||
             rcReport.cleared.length ||
+            rcReport.retried.length ||
             rcReport.wouldMark.length ||
             rcReport.wouldEscalate.length ||
-            rcReport.wouldClear.length
+            rcReport.wouldClear.length ||
+            rcReport.wouldRetry.length
           ) {
             log.info(
-              { mode: rcMode, marked: rcReport.marked.length, escalated: rcReport.escalated.length, cleared: rcReport.cleared.length },
+              {
+                mode: rcMode,
+                marked: rcReport.marked.length,
+                escalated: rcReport.escalated.length,
+                cleared: rcReport.cleared.length,
+                retried: rcReport.retried.length,
+              },
               "scheduler: resolve-conflict-sweep pass (#1461)",
             );
           }

--- a/plugins/dev/scripts/execution-core/scheduler.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.mjs
@@ -66,7 +66,7 @@ export { STAGE_RANK, NON_PREEMPTABLE_PHASES };
 // budget) live here. deriveAdvancement stays pure — the impure reads happen in
 // the sweep and are injected, so the router itself is unit-testable.
 import { readVerifyVerdict } from "./work-done-probes.mjs";
-import { countRemediateCycles, countTicketEventsInWindow, countResolveConflictCycles } from "./event-scan.mjs"; // #1461: countResolveConflictCycles
+import { countRemediateCycles, countTicketEventsInWindow, countResolveConflictAttempts } from "./event-scan.mjs"; // #1461 Fix 2: countResolveConflictAttempts (complete+failed, not completions-only)
 import { tailParsedEvents } from "./event-tail.mjs"; // CTL-1514: bounded event-log tail
 import { rankTickets, compareTickets } from "./scheduler-rank.mjs";
 import {
@@ -264,6 +264,12 @@ import {
   classifyLiveConflict,
   defaultMarkAndDispatch,
   defaultEscalateCapExhausted,
+  // #1461 Fix 4: the resolve-conflict-sweep's emit seam MUST be
+  // emitResolveConflictEvent (mirrors unstuck-sweep's own emitUnstuckEvent
+  // wiring) — without it, `emit` defaults to undefined and the pass's
+  // internal no-op fallback swallows every shadow/enforce event, leaving
+  // shadow mode completely unobservable.
+  emitResolveConflictEvent,
 } from "./resolve-conflict-sweep.mjs";
 // CTL-1176: Pass 0r — LLM reasoning recovery pass. Ships off by default (ADR-023);
 // operators opt in via CATALYST_RECOVERY_PASS=shadow then =enforce.
@@ -4442,9 +4448,10 @@ export function schedulerTick(
     } = {},
     // #1461: resolve-conflict-sweep seams (ADR-028). Mode resolves from
     // readResolveConflictSweepConfig() (env CATALYST_RESOLVE_CONFLICT_SWEEP >
-    // Layer-2 > 'off') unless overridden. Defaults keep a bare tick fully
-    // inert — no census producer means nothing to collect. Production wires
-    // the real census (defaultCollectResolveConflictCandidates /
+    // 'off' — env-only, unlike unstuckSweep/recoveryPass below, this reader has
+    // no Layer-2 config path) unless overridden. Defaults keep a bare tick
+    // fully inert — no census producer means nothing to collect. Production
+    // wires the real census (defaultCollectResolveConflictCandidates /
     // defaultCollectResolveConflictCompletions) + act seams via startScheduler.
     resolveConflictSweep: {
       mode: _resolveConflictMode = undefined,
@@ -4455,7 +4462,11 @@ export function schedulerTick(
       markAndDispatch: _resolveConflictMarkAndDispatch = undefined,
       escalateCapExhausted: _resolveConflictEscalate = undefined,
       clearStall: _resolveConflictClearStall = undefined,
-      emit: _resolveConflictEmit = undefined,
+      // #1461 Fix 4: default to the real emitter (mirrors unstuckSweep's own
+      // `emit: _unstuckEmit = emitUnstuckEvent` default above) so even a bare
+      // schedulerTick call gets real shadow/enforce observability instead of
+      // silently no-op'ing.
+      emit: _resolveConflictEmit = emitResolveConflictEvent,
     } = {},
     // CTL-1176: Pass 0r — recovery-reasoning pass seams. Default undefined keeps
     // a bare tick fully inert. Production passes mode from env > Layer-2.
@@ -5546,7 +5557,7 @@ export function schedulerTick(
           collectCandidates: _collectResolveConflictCandidates ?? (() => defaultCollectResolveConflictCandidates({ orchDir })),
           collectCompletions: _collectResolveConflictCompletions ?? (() => defaultCollectResolveConflictCompletions({ orchDir })),
           classifyLive: _resolveConflictClassifyLive ?? classifyLiveConflict,
-          cycleCountOf: _resolveConflictCycleCountOf ?? ((ticket) => countResolveConflictCycles({ ticket })),
+          cycleCountOf: _resolveConflictCycleCountOf ?? ((ticket) => countResolveConflictAttempts({ ticket })),
           markAndDispatch: _resolveConflictMarkAndDispatch ?? ((c) => defaultMarkAndDispatch({ ...c, orchDir })),
           escalateCapExhausted: _resolveConflictEscalate ?? defaultEscalateCapExhausted,
           clearStall: _resolveConflictClearStall ?? defaultClearStall(orchDir, writeStatus),
@@ -7986,75 +7997,85 @@ export function schedulerTick(
           // linger (hygiene — the recovery router already drops terminal tickets).
           recoveryForgetIntent(ticket, { orchDir });
         } else {
-          // #1461: exempt a ticket resolve-conflict-sweep is actively resolving
-          // (failureReason/stalledReason === RESOLVED_MARKER_REASON, imported from
+          // #1461 Fix 3 (final-review finding): exempt a ticket
+          // resolve-conflict-sweep is actively resolving (failureReason/
+          // stalledReason === RESOLVED_MARKER_REASON, imported from
           // resolve-conflict-sweep.mjs) from immediate needs-human labeling —
-          // otherwise every candidate is flagged needs-human the same tick the fix
-          // is already in flight. A cap-exhausted stall (resolve-conflict-sweep.mjs's
-          // CAP_EXHAUSTED_REASON) is a NORMAL stalled reason and is NOT exempted —
-          // it surfaces exactly like remediate-cycle-cap-exhausted already does.
+          // otherwise every candidate is flagged needs-human the same tick the
+          // fix is already in flight. A cap-exhausted stall
+          // (resolve-conflict-sweep.mjs's CAP_EXHAUSTED_REASON) is a NORMAL
+          // stalled reason and is NOT exempted — it surfaces exactly like
+          // remediate-cycle-cap-exhausted already does.
+          //
+          // The exemption is narrowly scoped to ONLY the needs-human label
+          // call below — it used to `continue`, which skipped the ENTIRE rest
+          // of this loop iteration: convergeStartedHeldLabels (CTL-1068
+          // orphaned held-label retraction), convergeDispositionLabel (CTL-764
+          // finding 5), and the CTL-695 terminal-worker reap nomination below
+          // all have nothing to do with needs-human labeling and must still
+          // run normally for a ticket under active resolve-conflict resolution.
           const activeSignal = signalByTicket.get(ticket);
           const activeReason =
             activeSignal?.raw?.failureReason ?? activeSignal?.raw?.stalledReason ?? null;
-          if (activeReason === RESOLVED_MARKER_REASON) {
-            emitOrphanDetectedOnce(orchDir, ticket, signals, appendOrphanDetectedEvent);
-            continue;
-          }
-          // Non-terminal stalled/failed ticket → apply the belief-aware needs-human
-          // label (CTL-1241: skipped when the belief engine owns the reclaim).
-          if (
-            fenceGuard(
-              { ticket, orchDir, multiHost, gateway, self },
-              {
-                proceedOnMissingGeneration: true,
-                // CTL-1329: a missing generation stays missing next tick regardless
-                // of whether THIS tick's escalation write succeeded, so arm a cooldown
-                // — otherwise proceeding here (instead of suppressing) reintroduces the
-                // unbounded per-tick terminal-probe burn CTL-1329 fixed, just on the
-                // write path instead of the read path. It is the escalation-side marker,
-                // NOT `.fence-suppressed`: terminalDoneOnce reads the latter, so arming
-                // that one here would hold a genuinely-completed pipeline non-terminal
-                // for a whole cooldown window when recovery finishes teardown.
-                onMissingGeneration: () => stampEscalationProbeCooldown(orchDir, ticket, now()),
+          if (activeReason !== RESOLVED_MARKER_REASON) {
+            // Non-terminal stalled/failed ticket → apply the belief-aware needs-human
+            // label (CTL-1241: skipped when the belief engine owns the reclaim).
+            if (
+              fenceGuard(
+                { ticket, orchDir, multiHost, gateway, self },
+                {
+                  proceedOnMissingGeneration: true,
+                  // CTL-1329: a missing generation stays missing next tick regardless
+                  // of whether THIS tick's escalation write succeeded, so arm a cooldown
+                  // — otherwise proceeding here (instead of suppressing) reintroduces the
+                  // unbounded per-tick terminal-probe burn CTL-1329 fixed, just on the
+                  // write path instead of the read path. It is the escalation-side marker,
+                  // NOT `.fence-suppressed`: terminalDoneOnce reads the latter, so arming
+                  // that one here would hold a genuinely-completed pipeline non-terminal
+                  // for a whole cooldown window when recovery finishes teardown.
+                  onMissingGeneration: () => stampEscalationProbeCooldown(orchDir, ticket, now()),
+                }
+              )
+            ) {
+              const stalledSig = signalByTicket.get(ticket);
+              const tsResult = routeStuckTicketToDelegate(orchDir, ticket, {
+                site: "terminal-sweep",
+                reason: stalledSig?.stalledReason ?? "stalled",
+                boardContext: { status: stalledSig?.status, phase: stalledSig?.phase },
+                applyLabel: writeStatus,
+                env,
+                log,
+                explanation: {
+                  problem: `${ticket} has a ${stalledSig?.status ?? "stalled"} phase signal (${stalledSig?.stalledReason ?? "no reason"}) and is not terminal`,
+                  call_to_action: `decide whether to retry ${ticket} or close it`,
+                },
+                // CTL-1609 (Codex P1): thread the tick's resolved ceiling so a large
+                // terminal-sweep cohort cannot enqueue past maxParallel.
+                deps: { orchDir, maxParallel },
+              });
+              // CTL-764 finding 8: emit worker.transition ONLY when the label write
+              // actually occurred. A persisted .linear-label-needs-human marker after a
+              // daemon restart (labelOnce no-ops) or a belief-owner deferral changes no
+              // label — recording a fresh needs-human transition there is a false escalation.
+              if (tsResult.labelled === true) {
+                recordTransition({ ticket, toDisposition: "needs-human", source: "terminal-sweep" });
               }
-            )
-          ) {
-            const stalledSig = signalByTicket.get(ticket);
-            const tsResult = routeStuckTicketToDelegate(orchDir, ticket, {
-              site: "terminal-sweep",
-              reason: stalledSig?.stalledReason ?? "stalled",
-              boardContext: { status: stalledSig?.status, phase: stalledSig?.phase },
-              applyLabel: writeStatus,
-              env,
-              log,
-              explanation: {
-                problem: `${ticket} has a ${stalledSig?.status ?? "stalled"} phase signal (${stalledSig?.stalledReason ?? "no reason"}) and is not terminal`,
-                call_to_action: `decide whether to retry ${ticket} or close it`,
-              },
-              // CTL-1609 (Codex P1): thread the tick's resolved ceiling so a large
-              // terminal-sweep cohort cannot enqueue past maxParallel.
-              deps: { orchDir, maxParallel },
-            });
-            // CTL-764 finding 8: emit worker.transition ONLY when the label write
-            // actually occurred. A persisted .linear-label-needs-human marker after a
-            // daemon restart (labelOnce no-ops) or a belief-owner deferral changes no
-            // label — recording a fresh needs-human transition there is a false escalation.
-            if (tsResult.labelled === true) {
-              recordTransition({ ticket, toDisposition: "needs-human", source: "terminal-sweep" });
+            } else {
+              log.warn(
+                { ticket },
+                "ctl-863: stale fence — suppressing labelOnce(needs-human/failed-or-stalled) write (zombie guard)"
+              );
+              // CTL-1329: arm the cooldown so the next ticks skip this dir's probe+fence
+              // instead of re-burning Linear quota every tick until the dir is reaped.
+              stampFenceSuppress(orchDir, ticket, now());
             }
-          } else {
-            log.warn(
-              { ticket },
-              "ctl-863: stale fence — suppressing labelOnce(needs-human/failed-or-stalled) write (zombie guard)"
-            );
-            // CTL-1329: arm the cooldown so the next ticks skip this dir's probe+fence
-            // instead of re-burning Linear quota every tick until the dir is reaped.
-            stampFenceSuppress(orchDir, ticket, now());
           }
           // CTL-868 route (B): emit a canonical orphan-detected event (once) so a
           // non-terminal stalled/failed-no-recovery ticket is visible on the dashboard
           // (runs regardless of fence, matching main; the terminal branch above is
-          // excluded so a finished ticket is never re-surfaced as an orphan).
+          // excluded so a finished ticket is never re-surfaced as an orphan). Runs
+          // unconditionally here (including for the RESOLVED_MARKER_REASON exemption
+          // above) — a single emit, not duplicated.
           emitOrphanDetectedOnce(orchDir, ticket, signals, appendOrphanDetectedEvent);
         }
       }
@@ -9052,12 +9073,12 @@ function runTick() {
       // Like stallJanitor/unstuckSweep above, a bare schedulerTick (unit test)
       // passes no `resolveConflictSweep` so the pass stays inert. Mode/emit
       // default INSIDE schedulerTick (readResolveConflictSweepConfig() → 'off'
-      // unless CATALYST_RESOLVE_CONFLICT_SWEEP/Layer-2 opts in) — mirrors
-      // stallJanitor/unstuckSweep's own fallback blocks, which likewise never
-      // set `mode` here. Without this block, setting
-      // CATALYST_RESOLVE_CONFLICT_SWEEP=shadow/enforce would have zero effect
-      // in the running daemon (schedulerTick would still see undefined
-      // collectors and skip the pass every tick).
+      // unless CATALYST_RESOLVE_CONFLICT_SWEEP opts in — env-only, no Layer-2
+      // path for this reader) — mirrors stallJanitor/unstuckSweep's own
+      // fallback blocks, which likewise never set `mode` here. Without this
+      // block, setting CATALYST_RESOLVE_CONFLICT_SWEEP=shadow/enforce would
+      // have zero effect in the running daemon (schedulerTick would still see
+      // undefined collectors and skip the pass every tick).
       resolveConflictSweep: runningOpts.resolveConflictSweep ?? {
         collectCandidates: () =>
           defaultCollectResolveConflictCandidates({
@@ -9080,13 +9101,27 @@ function runTick() {
         collectCompletions: () =>
           defaultCollectResolveConflictCompletions({ orchDir: runningOpts.orchDir }),
         classifyLive: classifyLiveConflict,
-        cycleCountOf: (ticket) => countResolveConflictCycles({ ticket }),
+        // #1461 Fix 2: count DISPATCH ATTEMPTS (complete + failed), not just
+        // successful completions — a repeatedly-FAILING resolve-conflict run
+        // must still reach RESOLVE_CONFLICT_CYCLE_CAP and escalate, instead of
+        // leaving the ticket permanently marked RESOLVED_MARKER_REASON with a
+        // cycleCount pinned at 0 forever.
+        cycleCountOf: (ticket) => countResolveConflictAttempts({ ticket }),
         markAndDispatch: (c) => defaultMarkAndDispatch({ ...c, orchDir: runningOpts.orchDir }),
         escalateCapExhausted: defaultEscalateCapExhausted,
         // clearStall: same real seam as the stallJanitor/unstuckSweep fallback
         // blocks above (defaultClearStall bound to this tick's real orchDir +
         // the real writeStatus/linear-write seam) — not a new dependency.
         clearStall: defaultClearStall(runningOpts.orchDir, runningOpts.writeStatus ?? linearWrite),
+        // #1461 Fix 4: the dedicated resolve-conflict-sweep unified-log emitter
+        // (NOT emitUnstuckEvent — this sweep owns its own closed vocabulary,
+        // RESOLVE_CONFLICT_SWEEP_EVENT_TYPES). Explicit here so production
+        // wiring never silently depends on schedulerTick's own default;
+        // mirrors the unstuckSweep block's `emit: emitUnstuckEvent` above.
+        // Without this, shadow mode produced ZERO event output — an operator
+        // flipping CATALYST_RESOLVE_CONFLICT_SWEEP=shadow had no way to see
+        // what the sweep WOULD have done.
+        emit: emitResolveConflictEvent,
       },
       // CTL-1150: thread the triage-artifact predicate (undefined → inline
       // existsSync default in schedulerTick; test seam via startScheduler).

--- a/plugins/dev/scripts/execution-core/scheduler.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.mjs
@@ -5558,7 +5558,13 @@ export function schedulerTick(
     const rcMode = _resolveConflictMode ?? readResolveConflictSweepConfig().mode;
     if (
       rcMode !== "off" &&
-      (_collectResolveConflictCandidates || _collectResolveConflictCompletions) &&
+      // M3 (review follow-up): the gate must also recognize the failures
+      // collector — without this, a caller injecting ONLY collectFailures
+      // (e.g. a test isolating the failure path, or a future census-only
+      // wiring) would silently no-op the WHOLE sweep, including the
+      // candidates/completions sub-passes that collector's own default is
+      // never consulted for.
+      (_collectResolveConflictCandidates || _collectResolveConflictCompletions || _collectResolveConflictFailures) &&
       !_resolveConflictSweepInFlight
     ) {
       _resolveConflictSweepInFlight = true;

--- a/plugins/dev/scripts/execution-core/scheduler.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.mjs
@@ -5573,9 +5573,10 @@ export function schedulerTick(
           mode: rcMode,
           collectCandidates: _collectResolveConflictCandidates ?? (() => defaultCollectResolveConflictCandidates({ orchDir })),
           collectCompletions: _collectResolveConflictCompletions ?? (() => defaultCollectResolveConflictCompletions({ orchDir })),
-          // #1461 escalation-gap fix: a FAILED (status:"failed") resolve-conflict
-          // run — census + the revert-and-reset action seam (escalateCapExhausted
-          // is REUSED below for the at/over-cap outcome, same as the candidates
+          // #1461 escalation-gap fix: a resolve-conflict run that lands in ANY
+          // failure shape (failed, stalled, or turn-cap-exhausted — see
+          // RESOLVE_CONFLICT_CYCLE_TERMINAL_STATUSES) — census + the revert-and-reset action seam
+          // (escalateCapExhausted is REUSED below for the at/over-cap outcome, same as the candidates
           // sub-pass's own cap-exhausted branch).
           collectFailures: _collectResolveConflictFailures ?? (() => defaultCollectResolveConflictFailures({ orchDir })),
           revertStallAndResetCycle:

--- a/plugins/dev/scripts/execution-core/scheduler.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.mjs
@@ -365,6 +365,10 @@ import {
   labelMarkerBase, // CTL-1571: convergeHeldLabel writes the same once-marker labelOnce does
 } from "./label-guard.mjs";
 import { DISPOSITIONS } from "./worker-disposition.mjs"; // CTL-1605: precedence order for the onTerminalCleared aggregate-arg → pre-clear `from` resolution
+// #1461: the resolve-conflict-sweep in-flight marker reason, shared so the
+// terminal-sweep exemption below (~line 6942) can never silently desync from
+// the literal the sweep itself writes (resolve-conflict-sweep.mjs:26).
+import { RESOLVED_MARKER_REASON } from "./resolve-conflict-sweep.mjs";
 import { processApprovedResumes } from "./boot-resume.mjs"; // CTL-644: per-tick approval poll
 import { countReapOutcomes } from "./reaper-metrics.mjs";
 import {
@@ -7860,16 +7864,16 @@ export function schedulerTick(
           recoveryForgetIntent(ticket, { orchDir });
         } else {
           // #1461: exempt a ticket resolve-conflict-sweep is actively resolving
-          // (failureReason/stalledReason === source_conflict_resolvable) from
-          // immediate needs-human labeling — otherwise every candidate is
-          // flagged needs-human the same tick the fix is already in flight. A
-          // cap-exhausted stall (resolve-conflict-cycle-cap-exhausted) is a
-          // NORMAL stalled reason and is NOT exempted — it surfaces exactly
-          // like remediate-cycle-cap-exhausted already does.
+          // (failureReason/stalledReason === RESOLVED_MARKER_REASON, imported from
+          // resolve-conflict-sweep.mjs) from immediate needs-human labeling —
+          // otherwise every candidate is flagged needs-human the same tick the fix
+          // is already in flight. A cap-exhausted stall (resolve-conflict-sweep.mjs's
+          // CAP_EXHAUSTED_REASON) is a NORMAL stalled reason and is NOT exempted —
+          // it surfaces exactly like remediate-cycle-cap-exhausted already does.
           const activeSignal = signalByTicket.get(ticket);
           const activeReason =
             activeSignal?.raw?.failureReason ?? activeSignal?.raw?.stalledReason ?? null;
-          if (activeReason === "source_conflict_resolvable") {
+          if (activeReason === RESOLVED_MARKER_REASON) {
             emitOrphanDetectedOnce(orchDir, ticket, signals, appendOrphanDetectedEvent);
             continue;
           }

--- a/plugins/dev/scripts/execution-core/scheduler.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.mjs
@@ -7859,6 +7859,20 @@ export function schedulerTick(
           // linger (hygiene — the recovery router already drops terminal tickets).
           recoveryForgetIntent(ticket, { orchDir });
         } else {
+          // #1461: exempt a ticket resolve-conflict-sweep is actively resolving
+          // (failureReason/stalledReason === source_conflict_resolvable) from
+          // immediate needs-human labeling — otherwise every candidate is
+          // flagged needs-human the same tick the fix is already in flight. A
+          // cap-exhausted stall (resolve-conflict-cycle-cap-exhausted) is a
+          // NORMAL stalled reason and is NOT exempted — it surfaces exactly
+          // like remediate-cycle-cap-exhausted already does.
+          const activeSignal = signalByTicket.get(ticket);
+          const activeReason =
+            activeSignal?.raw?.failureReason ?? activeSignal?.raw?.stalledReason ?? null;
+          if (activeReason === "source_conflict_resolvable") {
+            emitOrphanDetectedOnce(orchDir, ticket, signals, appendOrphanDetectedEvent);
+            continue;
+          }
           // Non-terminal stalled/failed ticket → apply the belief-aware needs-human
           // label (CTL-1241: skipped when the belief engine owns the reclaim).
           if (

--- a/plugins/dev/scripts/execution-core/scheduler.test.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.test.mjs
@@ -105,6 +105,7 @@ import { removeLabel as realRemoveLabel } from "./linear-write.mjs"; // CTL-1079
 import { bootResumePendingPath, bootResumeApprovedPath } from "./boot-resume.mjs"; // CTL-1367 P2-C: per-tick approval-poll dispatch wiring
 import { recordRemovalFailure } from "./label-guard.mjs"; // CTL-1605 Codex thread: drive needs-human into CTL-1078 backoff for the terminal-stale multi-label tests
 import { getDrainFlagPath, getEventLogPath } from "./config.mjs"; // CTL-1678: drain-disabled override integration test
+import { RESOLVED_MARKER_REASON } from "./resolve-conflict-sweep.mjs"; // #1461: shared marker reason, not a re-typed literal
 
 let orchDir;
 let catalystDir;
@@ -5155,7 +5156,7 @@ describe("schedulerTick — terminal-sweep needs-human clear (CTL-1242)", () => 
   });
 
   // #1461: resolve-conflict-sweep marks the active signal failureReason
-  // source_conflict_resolvable while a fix is in flight — the terminal sweep must NOT
+  // RESOLVED_MARKER_REASON while a fix is in flight — the terminal sweep must NOT
   // immediately needs-human this ticket (every candidate would otherwise be flagged
   // needs-human the same tick the fix is already dispatched). Mirrors T3's fixture
   // (stalled signal, non-terminal Linear state) but swaps in the resolve-conflict
@@ -5166,7 +5167,7 @@ describe("schedulerTick — terminal-sweep needs-human clear (CTL-1242)", () => 
       ticket: TICKET,
       phase: "implement",
       status: "stalled",
-      failureReason: "source_conflict_resolvable",
+      failureReason: RESOLVED_MARKER_REASON,
     });
 
     const applied = [];
@@ -5201,9 +5202,16 @@ describe("schedulerTick — terminal-sweep needs-human clear (CTL-1242)", () => 
       // Force single-host determinism: this dev host's real cluster-repo roster
       // (aldebaran/sophon/vega) otherwise leaks into getClusterHosts() and makes
       // fenceGuard fail closed regardless of this test's own logic (a false green
-      // pre-implementation). T3's sibling fixture doesn't need this override
-      // because it isn't sensitive to the confound the same way this test is —
-      // see task-11-report.md for the full explanation.
+      // pre-implementation, since the new guard runs BEFORE fenceGuard and the
+      // observable "no needs-human" outcome is identical either way). T3's sibling
+      // fixture does NOT pin hosts/hostName either, and is EQUALLY exposed to this
+      // same confound — run in isolation it fails against unmodified code for the
+      // identical reason (verified; see task-11-report.md). It reads as "passing"
+      // only in specific run orders/process states (test-order and/or
+      // getClusterHosts()-caching dependent), not because it is immune. This test
+      // pins hosts/hostName explicitly so it does NOT depend on that same
+      // order/caching-dependent behavior — see task-11-report.md for the full
+      // investigation.
       hosts: ["solo"],
       hostName: "solo",
     });

--- a/plugins/dev/scripts/execution-core/scheduler.test.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.test.mjs
@@ -5214,6 +5214,19 @@ describe("schedulerTick — terminal-sweep needs-human clear (CTL-1242)", () => 
       // investigation.
       hosts: ["solo"],
       hostName: "solo",
+      // #1461 (final-review finding): this ticket's status:"stalled" signal
+      // ALSO matches the CTL-1176 recovery-pass filter (needs-human/failed/
+      // stalled/unknown), so on a host whose ambient CATALYST_CONFIG_FILE
+      // Layer-2 config has recovery.pass.mode=shadow (e.g. a dev machine
+      // enrolled in the fleet-wide shadow rollout), readRecoveryPassConfig()
+      // picks that up and the recovery-reasoning pass actually runs — and its
+      // OWN default postComment seam shells out to the real
+      // lib/linear-comment-post.sh, making a genuine network call (observed
+      // as "linear-comment-post: token mint failed" in test log output) that
+      // has nothing to do with what THIS test verifies (the terminal-sweep's
+      // needs-human exemption). Pin recovery-pass off explicitly so this test
+      // is hermetic regardless of ambient env/Layer-2 config.
+      recoveryPass: { mode: "off" },
     });
 
     // needs-human must never be applied while the fix is in flight.
@@ -5221,6 +5234,87 @@ describe("schedulerTick — terminal-sweep needs-human clear (CTL-1242)", () => 
     expect(removed.filter((r) => r.t === TICKET && r.l === "needs-human")).toHaveLength(0);
     // Still surfaced as an orphan for dashboard visibility.
     expect(orphans.some((o) => o.ticket === TICKET)).toBe(true);
+  });
+
+  // #1461 Fix 3 (final-review finding): the RESOLVED_MARKER_REASON exemption
+  // above used to `continue`, skipping the ENTIRE rest of the loop iteration —
+  // including convergeStartedHeldLabels (CTL-1068 orphaned held-label
+  // retraction) and the CTL-695 terminal-worker reap nomination, neither of
+  // which has anything to do with needs-human labeling. The fix narrows the
+  // exemption to ONLY the needs-human label call. This test proves both OTHER
+  // steps still run for a ticket under active resolve-conflict resolution.
+  //
+  // convergeDispositionLabel (CTL-764 finding 5) is NOT combined into this
+  // same integration test: it requires a needs-input phase signal, and
+  // byActivePhase (signal-reader.mjs) always ranks a NON-terminal phase (like
+  // needs-input) ahead of a terminal one (like the "stalled" phase carrying
+  // RESOLVED_MARKER_REASON) when picking the ticket's canonical active signal
+  // — so a ticket that would ever trip the OLD `continue` (i.e. whose
+  // canonical signal IS the RESOLVED_MARKER_REASON stall) structurally cannot
+  // simultaneously have a needs-input phase outrank it. Verified by code
+  // inspection instead: convergeDispositionLabel's block sits AFTER the whole
+  // if/else this fix touches, at the SAME loop-body nesting level — the fix
+  // (removing the `continue`, narrowing the skip to just the
+  // labelNeedsHumanUnlessBeliefOwner call) makes it unconditionally reachable
+  // for every ticket exactly like convergeStartedHeldLabels/reap-nomination
+  // below, which ARE directly integration-tested here.
+  test("#1461 Fix 3: RESOLVED_MARKER_REASON exemption is narrowly scoped — held-label retraction and reap nomination still run", () => {
+    const TICKET = "CTL-1461-T2";
+    // The stall this sweep is actively resolving (exempted from needs-human).
+    // Carries a bg_job_id so the CTL-695 reap nomination has something to act on.
+    writeSignalRaw(TICKET, "implement", {
+      ticket: TICKET,
+      phase: "implement",
+      status: "stalled",
+      failureReason: RESOLVED_MARKER_REASON,
+      bg_job_id: "resconf01",
+    });
+    // A stale "queued" held-label marker — exercises convergeStartedHeldLabels'
+    // retraction (CTL-1068), independent of the exemption.
+    const workerDir = join(orchDir, "workers", TICKET);
+    mkdirSync(workerDir, { recursive: true });
+    writeFileSync(join(workerDir, ".linear-label-queued.applied"), "");
+
+    const applied = [];
+    const removed = [];
+    const writeStatus = {
+      ...noWrites1242(),
+      applyLabel: (a) => {
+        applied.push(a);
+        return { applied: true };
+      },
+      removeLabel: (t, l) => {
+        removed.push({ t, l });
+        return { removed: true };
+      },
+    };
+    const gateway = {
+      getDescriptor: (id) =>
+        id === TICKET ? { state: "In Progress", removed: false, updatedAt: FRESH, labels: [] } : null,
+    };
+
+    schedulerTick(orchDir, {
+      readEligible: () => [],
+      dispatch: fakeDispatch(),
+      writeStatus,
+      gateway,
+      hosts: ["solo"],
+      hostName: "solo",
+      recoveryPass: { mode: "off" }, // see T1's own comment above for why
+    });
+
+    // needs-human exemption still holds.
+    expect(applied.some((a) => a.ticket === TICKET && a.label === "needs-human")).toBe(false);
+
+    // (1) CTL-1068 held-label retraction still runs.
+    expect(removed.some((r) => r.t === TICKET && r.l === "queued")).toBe(true);
+    expect(existsSync(join(workerDir, ".linear-label-queued.applied"))).toBe(false);
+
+    // (2) CTL-695 terminal-worker reap nomination still runs.
+    const reapEvts = readEventLog().filter(
+      (e) => e.event === "phase.terminal.reap-requested" && e.bg_job_id === "resconf01"
+    );
+    expect(reapEvts.length).toBe(1);
   });
 
   // T4: steady-state-zero-writes — no stalled/failed, no marker → zero needs-human writes

--- a/plugins/dev/scripts/execution-core/scheduler.test.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.test.mjs
@@ -10920,6 +10920,61 @@ describe("CTL-1191 — recovery passes HRW-gated over the surviving roster (Pass
   });
 });
 
+// ── #1461: resolve-conflict-sweep — scheduler wiring (Task 12) ─────────────────
+//
+// schedulerTick wires runResolveConflictSweepPass in exactly like unstuck-sweep:
+// a `resolveConflictSweep` options group (mode/collectCandidates/
+// collectCompletions/... seams), gated on mode !== "off", running every tick
+// (no throttle). These smoke tests only assert the wiring itself — the pure
+// classify/act behavior is covered by resolve-conflict-sweep.test.mjs.
+describe("#1461: resolve-conflict-sweep — scheduler wiring", () => {
+  test("runs every tick when mode is not off, uses the injected collectors", () => {
+    let candidatesCalled = false;
+    let completionsCalled = false;
+    schedulerTick(orchDir, {
+      readEligible: () => [],
+      dispatch: fakeDispatch({ code: 0 }),
+      writeStatus: {
+        applyLabel: () => ({ applied: true }),
+        removeLabel: () => ({ removed: true }),
+      },
+      resolveConflictSweep: {
+        mode: "shadow",
+        collectCandidates: () => {
+          candidatesCalled = true;
+          return [];
+        },
+        collectCompletions: () => {
+          completionsCalled = true;
+          return [];
+        },
+      },
+    });
+    expect(candidatesCalled).toBe(true);
+    expect(completionsCalled).toBe(true);
+  });
+
+  test("is skipped entirely when mode is off", () => {
+    let called = false;
+    schedulerTick(orchDir, {
+      readEligible: () => [],
+      dispatch: fakeDispatch({ code: 0 }),
+      writeStatus: {
+        applyLabel: () => ({ applied: true }),
+        removeLabel: () => ({ removed: true }),
+      },
+      resolveConflictSweep: {
+        mode: "off",
+        collectCandidates: () => {
+          called = true;
+          return [];
+        },
+      },
+    });
+    expect(called).toBe(false);
+  });
+});
+
 // ── CTL-1191: Pass 0r reasoning — terminal-state filter (PR #2163 verify flag) ──
 //
 // The reasoning pass must NOT reason over a ticket already finished (terminal

--- a/plugins/dev/scripts/execution-core/scheduler.test.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.test.mjs
@@ -105,7 +105,7 @@ import { removeLabel as realRemoveLabel } from "./linear-write.mjs"; // CTL-1079
 import { bootResumePendingPath, bootResumeApprovedPath } from "./boot-resume.mjs"; // CTL-1367 P2-C: per-tick approval-poll dispatch wiring
 import { recordRemovalFailure } from "./label-guard.mjs"; // CTL-1605 Codex thread: drive needs-human into CTL-1078 backoff for the terminal-stale multi-label tests
 import { getDrainFlagPath, getEventLogPath } from "./config.mjs"; // CTL-1678: drain-disabled override integration test
-import { RESOLVED_MARKER_REASON } from "./resolve-conflict-sweep.mjs"; // #1461: shared marker reason, not a re-typed literal
+import { RESOLVED_MARKER_REASON, RESOLVE_CONFLICT_STALL_REASON } from "./resolve-conflict-sweep.mjs"; // #1461: shared marker reasons, not re-typed literals
 
 let orchDir;
 let catalystDir;
@@ -10928,6 +10928,8 @@ describe("CTL-1191 — recovery passes HRW-gated over the surviving roster (Pass
 // (no throttle). These smoke tests only assert the wiring itself — the pure
 // classify/act behavior is covered by resolve-conflict-sweep.test.mjs.
 describe("#1461: resolve-conflict-sweep — scheduler wiring", () => {
+  afterEach(() => __resetForTests()); // reset the module-level in-flight guard between tests
+
   test("runs every tick when mode is not off, uses the injected collectors", () => {
     let candidatesCalled = false;
     let completionsCalled = false;
@@ -10972,6 +10974,67 @@ describe("#1461: resolve-conflict-sweep — scheduler wiring", () => {
       },
     });
     expect(called).toBe(false);
+  });
+
+  // TOCTOU guard (review follow-up): the pass is fire-and-forget with NO
+  // per-tick throttle, so its async classifyLive work can still be pending
+  // when the next tick fires. A module-level in-flight flag must make an
+  // overlapping tick skip starting a second pass entirely — otherwise the
+  // same still-unmarked candidate would be re-collected/re-classified.
+  test("an overlapping tick does not start a second pass while the first is still pending", async () => {
+    let candidatesCalls = 0;
+    const CANDIDATE = {
+      ticket: "CTL-1461-INFLIGHT",
+      phase: "implement",
+      workerDir: join(orchDir, "workers", "CTL-1461-INFLIGHT"),
+      worktreePath: "/tmp/does-not-matter",
+      base: "main",
+      raw: { failureReason: RESOLVE_CONFLICT_STALL_REASON },
+    };
+    // A controllable classifyLive promise this test settles by hand — keeps
+    // tick 1's pass genuinely "in flight" until we say otherwise.
+    let resolveClassify;
+    const pendingClassify = new Promise((res) => {
+      resolveClassify = res;
+    });
+
+    const baseOpts = {
+      readEligible: () => [],
+      dispatch: fakeDispatch({ code: 0 }),
+      writeStatus: {
+        applyLabel: () => ({ applied: true }),
+        removeLabel: () => ({ removed: true }),
+      },
+      resolveConflictSweep: {
+        mode: "shadow",
+        collectCandidates: () => {
+          candidatesCalls++;
+          return [CANDIDATE];
+        },
+        collectCompletions: () => [],
+        classifyLive: () => pendingClassify,
+        cycleCountOf: () => 0,
+      },
+    };
+
+    // Tick 1: starts the pass; classifyLive's promise is still unsettled.
+    schedulerTick(orchDir, baseOpts);
+    expect(candidatesCalls).toBe(1);
+
+    // Tick 2: fires WHILE tick 1's pass is still pending. The in-flight guard
+    // must skip starting a second pass — collectCandidates must NOT be
+    // called again.
+    schedulerTick(orchDir, baseOpts);
+    expect(candidatesCalls).toBe(1);
+
+    // Settle tick 1's pass and let the whole .then/.catch/.finally chain drain.
+    resolveClassify({ resolvable: false, conflictFiles: [], conflictTypes: [] });
+    await new Promise((r) => setTimeout(r, 10));
+
+    // Tick 3: the prior pass has now settled (the guard cleared) — a new tick
+    // starts a fresh pass.
+    schedulerTick(orchDir, baseOpts);
+    expect(candidatesCalls).toBe(2);
   });
 });
 

--- a/plugins/dev/scripts/execution-core/scheduler.test.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.test.mjs
@@ -11027,6 +11027,7 @@ describe("#1461: resolve-conflict-sweep — scheduler wiring", () => {
   test("runs every tick when mode is not off, uses the injected collectors", () => {
     let candidatesCalled = false;
     let completionsCalled = false;
+    let failuresCalled = false;
     schedulerTick(orchDir, {
       readEligible: () => [],
       dispatch: fakeDispatch({ code: 0 }),
@@ -11044,10 +11045,74 @@ describe("#1461: resolve-conflict-sweep — scheduler wiring", () => {
           completionsCalled = true;
           return [];
         },
+        // #1461 escalation-gap fix (I2 review follow-up): the failures census
+        // seam must be reachable through schedulerTick's real call path exactly
+        // like the candidates/completions seams already are.
+        collectFailures: () => {
+          failuresCalled = true;
+          return [];
+        },
       },
     });
     expect(candidatesCalled).toBe(true);
     expect(completionsCalled).toBe(true);
+    expect(failuresCalled).toBe(true);
+  });
+
+  // #1461 escalation-gap fix (I2 review follow-up): a genuine end-to-end
+  // reachability check for BOTH new seams (collectFailures,
+  // revertStallAndResetCycle) through schedulerTick's real production wiring —
+  // not just the "was it called" smoke test above. Drives an under-cap failure
+  // in enforce mode and asserts the revert seam receives exactly the
+  // {ticket, stalledPhase} shape defaultCollectResolveConflictFailures produces.
+  test("collectFailures + revertStallAndResetCycle are both reachable through schedulerTick in enforce mode", async () => {
+    const reverted = [];
+    schedulerTick(orchDir, {
+      readEligible: () => [],
+      dispatch: fakeDispatch({ code: 0 }),
+      writeStatus: {
+        applyLabel: () => ({ applied: true }),
+        removeLabel: () => ({ removed: true }),
+      },
+      resolveConflictSweep: {
+        mode: "enforce",
+        collectCandidates: () => [],
+        collectCompletions: () => [],
+        collectFailures: () => [{ ticket: "CTL-9201", stalledPhase: "implement", workerDir: join(orchDir, "workers", "CTL-9201") }],
+        cycleCountOf: () => 0, // under the cap
+        revertStallAndResetCycle: (f) => {
+          reverted.push(f);
+          return true;
+        },
+      },
+    });
+    // The resolve-conflict-sweep pass is fire-and-forget (see schedulerTick's own
+    // comment on _resolveConflictSweepInFlight) — let its microtask chain drain.
+    await new Promise((r) => setTimeout(r, 10));
+    expect(reverted).toEqual([{ ticket: "CTL-9201", stalledPhase: "implement" }]);
+  });
+
+  // M3 (review follow-up): injecting ONLY the failures collector (no
+  // candidates/completions override) must NOT silently no-op the whole sweep —
+  // the mode-gate has to recognize collectFailures too.
+  test("does not skip the sweep when ONLY collectFailures is injected (M3 gate fix)", () => {
+    let failuresCalled = false;
+    schedulerTick(orchDir, {
+      readEligible: () => [],
+      dispatch: fakeDispatch({ code: 0 }),
+      writeStatus: {
+        applyLabel: () => ({ applied: true }),
+        removeLabel: () => ({ removed: true }),
+      },
+      resolveConflictSweep: {
+        mode: "shadow",
+        collectFailures: () => {
+          failuresCalled = true;
+          return [];
+        },
+      },
+    });
+    expect(failuresCalled).toBe(true);
   });
 
   test("is skipped entirely when mode is off", () => {

--- a/plugins/dev/scripts/execution-core/scheduler.test.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.test.mjs
@@ -5200,7 +5200,7 @@ describe("schedulerTick — terminal-sweep needs-human clear (CTL-1242)", () => 
       gateway,
       appendOrphanDetectedEvent,
       // Force single-host determinism: this dev host's real cluster-repo roster
-      // (aldebaran/sophon/vega) otherwise leaks into getClusterHosts() and makes
+      // (real fleet hostnames) otherwise leaks into getClusterHosts() and makes
       // fenceGuard fail closed regardless of this test's own logic (a false green
       // pre-implementation, since the new guard runs BEFORE fenceGuard and the
       // observable "no needs-human" outcome is identical either way). T3's sibling

--- a/plugins/dev/scripts/execution-core/scheduler.test.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.test.mjs
@@ -5154,6 +5154,67 @@ describe("schedulerTick — terminal-sweep needs-human clear (CTL-1242)", () => 
     expect(orphans.some((o) => o.ticket === TICKET)).toBe(true);
   });
 
+  // #1461: resolve-conflict-sweep marks the active signal failureReason
+  // source_conflict_resolvable while a fix is in flight — the terminal sweep must NOT
+  // immediately needs-human this ticket (every candidate would otherwise be flagged
+  // needs-human the same tick the fix is already dispatched). Mirrors T3's fixture
+  // (stalled signal, non-terminal Linear state) but swaps in the resolve-conflict
+  // reason via writeSignalRaw so the raw JSON carries failureReason.
+  test("#1461: does not apply needs-human while resolve-conflict-sweep is actively resolving a ticket", () => {
+    const TICKET = "CTL-1461-T1";
+    writeSignalRaw(TICKET, "implement", {
+      ticket: TICKET,
+      phase: "implement",
+      status: "stalled",
+      failureReason: "source_conflict_resolvable",
+    });
+
+    const applied = [];
+    const removed = [];
+    const writeStatus = {
+      ...noWrites1242(),
+      applyLabel: (a) => {
+        applied.push(a);
+        return { applied: true };
+      },
+      removeLabel: (t, l) => {
+        removed.push({ t, l });
+        return { removed: true };
+      },
+    };
+    const gateway = {
+      getDescriptor: (id) =>
+        id === TICKET ? { state: "In Progress", removed: false, updatedAt: FRESH } : null,
+    };
+    const orphans = [];
+    const appendOrphanDetectedEvent = (e) => {
+      orphans.push(e);
+      return true;
+    };
+
+    schedulerTick(orchDir, {
+      readEligible: () => [],
+      dispatch: fakeDispatch(),
+      writeStatus,
+      gateway,
+      appendOrphanDetectedEvent,
+      // Force single-host determinism: this dev host's real cluster-repo roster
+      // (aldebaran/sophon/vega) otherwise leaks into getClusterHosts() and makes
+      // fenceGuard fail closed regardless of this test's own logic (a false green
+      // pre-implementation). T3's sibling fixture doesn't need this override
+      // because it isn't sensitive to the confound the same way this test is —
+      // see task-11-report.md for the full explanation.
+      hosts: ["solo"],
+      hostName: "solo",
+    });
+
+    // needs-human must never be applied while the fix is in flight.
+    expect(applied.some((a) => a.ticket === TICKET && a.label === "needs-human")).toBe(false);
+    expect(removed.filter((r) => r.t === TICKET && r.l === "needs-human")).toHaveLength(0);
+    // Still surfaced as an orphan for dashboard visibility.
+    expect(orphans.some((o) => o.ticket === TICKET)).toBe(true);
+  });
+
   // T4: steady-state-zero-writes — no stalled/failed, no marker → zero needs-human writes
   // (The terminal-or-merged probe only runs inside the anyStalled||anyFailed branch, so a
   // ticket with only done/running phases must produce zero needs-human label API calls.)

--- a/plugins/dev/scripts/execution-core/unstuck-sweep.mjs
+++ b/plugins/dev/scripts/execution-core/unstuck-sweep.mjs
@@ -105,6 +105,13 @@ export const STALL_CATEGORY_MAP = Object.freeze({
   // so every sweep interval would post another authored Linear comment on a ticket a
   // human is already holding. Same "already fully escalated" shape as the three above.
   needs_human:                        { category: "skip",           action: "skip" },
+  // #1461: resolve-conflict-sweep already owns a ticket once it marks
+  // source_conflict_resolvable — the unstuck sweep must stay quiet, not
+  // force-push over a ticket the dedicated sweep is actively resolving.
+  "source_conflict_resolvable":       { category: "skip",              action: "skip" },
+  // #1461: mirrors remediate-cycle-cap-exhausted's own entry shape — a
+  // typed category label for telemetry rather than falling to 'unknown'.
+  "resolve-conflict-cycle-cap-exhausted": { category: "resolve-conflict-cap", action: "escalate" },
 });
 
 // classifyStalledTicket — PURE top-level router (Phase 1). No IO.
@@ -161,10 +168,15 @@ export function defaultCollectUnstuckCandidates({
           signal = JSON.parse(readFile(signalPath, "utf8"));
         } catch { continue; }
 
-        // Accept both status shapes (CTL-1064 §Confirmed gaps).
+        // Accept both status shapes (CTL-1064 §Confirmed gaps), PLUS the real
+        // producer field for a dispatch-time-rebase stall (#1461 finding:
+        // phase-agent-dispatch writes status:"stalled" + .failureReason, NOT
+        // .stalledReason, for source_conflict_ctl708_unavailable — this
+        // category's force-push-if-clean action has never fired in production
+        // without this fix).
         let reason = null;
-        if (signal.status === "stalled" && signal.stalledReason) {
-          reason = signal.stalledReason;
+        if (signal.status === "stalled" && (signal.stalledReason || signal.failureReason)) {
+          reason = signal.stalledReason ?? signal.failureReason;
         } else if (signal.status === "failed" && signal.failureReason === "orphan-sweep-stale") {
           reason = "orphan-sweep-stale";
         } else {

--- a/plugins/dev/scripts/execution-core/unstuck-sweep.mjs
+++ b/plugins/dev/scripts/execution-core/unstuck-sweep.mjs
@@ -18,6 +18,11 @@ import { spawnSync } from "node:child_process";
 import { log, getEventLogPath } from "./config.mjs";
 import { UNSTUCK_SWEEP_EVENT_TYPES } from "./unstuck-sweep-event-types.mjs";
 import { isTicketKey } from "./ticket-key.mjs";
+// #1461 (final-review cleanup item): import the shared marker-reason constants
+// from resolve-conflict-sweep.mjs instead of re-typing the literal strings —
+// mirrors what scheduler.mjs already does for the same constants. No import
+// cycle: resolve-conflict-sweep.mjs does not import unstuck-sweep.mjs.
+import { RESOLVED_MARKER_REASON, CAP_EXHAUSTED_REASON } from "./resolve-conflict-sweep.mjs";
 
 export { UNSTUCK_SWEEP_EVENT_TYPES };
 
@@ -108,10 +113,27 @@ export const STALL_CATEGORY_MAP = Object.freeze({
   // #1461: resolve-conflict-sweep already owns a ticket once it marks
   // source_conflict_resolvable — the unstuck sweep must stay quiet, not
   // force-push over a ticket the dedicated sweep is actively resolving.
-  "source_conflict_resolvable":       { category: "skip",              action: "skip" },
+  [RESOLVED_MARKER_REASON]:           { category: "skip",              action: "skip" },
   // #1461: mirrors remediate-cycle-cap-exhausted's own entry shape — a
   // typed category label for telemetry rather than falling to 'unknown'.
-  "resolve-conflict-cycle-cap-exhausted": { category: "resolve-conflict-cap", action: "escalate" },
+  [CAP_EXHAUSTED_REASON]:             { category: "resolve-conflict-cap", action: "escalate" },
+  // #1461 Fix 6 (final-review finding, human-approved design): the
+  // failureReason/stalledReason field-name bugfix above (defaultCollectUnstuckCandidates
+  // now checks BOTH fields) was needed so source_conflict_ctl708_unavailable would
+  // actually match real production signals — but as a side effect it also admits 5
+  // OTHER previously-invisible stall reasons phase-agent-dispatch writes via the SAME
+  // code path (REBASE_LAST_STALL_REASON, lib/worktree-rebase.sh). None of these have a
+  // validated, safe automated remediation today, so each gets a distinct, descriptive
+  // category paired with action:"escalate" (a TYPED escalate, matching
+  // remediate-cycle-cap-exhausted / escalation-ask-cap's own shape) rather than falling
+  // through to the generic 'unknown' bucket — this preserves today's actual behavior
+  // (nothing new gets auto-remediated) while making the categorization explicit and
+  // intentional instead of an accidental fallthrough.
+  thoughts_conflict_with_origin_main: { category: "thoughts-conflict",        action: "escalate" },
+  worktree_live_handle_guard_refused: { category: "worktree-guard-refused",  action: "escalate" },
+  continue_failed:                    { category: "rebase-continue-failed", action: "escalate" },
+  no_rebase_in_progress:              { category: "no-rebase-in-progress",  action: "escalate" },
+  thoughts_symlink_broken:            { category: "thoughts-symlink-broken", action: "escalate" },
 });
 
 // classifyStalledTicket — PURE top-level router (Phase 1). No IO.
@@ -174,9 +196,21 @@ export function defaultCollectUnstuckCandidates({
         // .stalledReason, for source_conflict_ctl708_unavailable — this
         // category's force-push-if-clean action has never fired in production
         // without this fix).
+        //
+        // #1461 Fix 6 (deferred-minor finding): use `??` consistently for BOTH
+        // the presence guard and the value selection — a single computation,
+        // not a `||` guard paired with a `??` selection. The prior mismatch
+        // (`stalledReason || failureReason` for presence, `stalledReason ??
+        // failureReason` for the value) meant a `stalledReason === ""` edge
+        // case would fall through to failureReason for the GUARD (empty
+        // string is falsy) but resolve to the empty string for the VALUE
+        // (`??` treats "" as present) — an inconsistent, confusing read.
+        // `stalledReason` still takes precedence over `failureReason` when
+        // both are present (the `??` chain's left-to-right order).
         let reason = null;
-        if (signal.status === "stalled" && (signal.stalledReason || signal.failureReason)) {
-          reason = signal.stalledReason ?? signal.failureReason;
+        const candidateReason = signal.stalledReason ?? signal.failureReason ?? null;
+        if (signal.status === "stalled" && candidateReason != null) {
+          reason = candidateReason;
         } else if (signal.status === "failed" && signal.failureReason === "orphan-sweep-stale") {
           reason = "orphan-sweep-stale";
         } else {

--- a/plugins/dev/scripts/execution-core/unstuck-sweep.test.mjs
+++ b/plugins/dev/scripts/execution-core/unstuck-sweep.test.mjs
@@ -506,12 +506,12 @@ describe("defaultCollectUnstuckCandidates — shared census builder (CTL-1064)",
   });
 
   test("finds source_conflict_ctl708_unavailable via failureReason (the real producer field), not just stalledReason", () => {
-    const readdirSync = (p, opts) => {
-      if (p.endsWith("/workers")) return [{ name: "CTL-1", isDirectory: () => true }];
-      return [{ name: "phase-implement.json", isDirectory: () => false }];
-    };
-    const readFileSync = () => JSON.stringify({ status: "stalled", failureReason: "source_conflict_ctl708_unavailable" });
-    const out = defaultCollectUnstuckCandidates({ orchDir: "/orch", readdirSync, readFileSync });
+    makeWorker("CTL-2010", {
+      status: "stalled",
+      failureReason: "source_conflict_ctl708_unavailable",
+      stalledReason: undefined,
+    });
+    const out = defaultCollectUnstuckCandidates({ orchDir });
     expect(out).toHaveLength(1);
     expect(out[0].evidence.reason).toBe("source_conflict_ctl708_unavailable");
   });

--- a/plugins/dev/scripts/execution-core/unstuck-sweep.test.mjs
+++ b/plugins/dev/scripts/execution-core/unstuck-sweep.test.mjs
@@ -115,6 +115,53 @@ describe("STALL_CATEGORY_MAP — #1461 additions", () => {
   });
 });
 
+// #1461 Fix 6 (IMPORTANT final-review finding, human-approved design): the
+// failureReason/stalledReason field-name bugfix (defaultCollectUnstuckCandidates,
+// tested below) widened scope beyond the intended target
+// (source_conflict_ctl708_unavailable) — it also admits 5 OTHER previously-invisible
+// stall reasons phase-agent-dispatch writes via the same code path
+// (REBASE_LAST_STALL_REASON, lib/worktree-rebase.sh). None have a validated, safe
+// automated remediation today, so each routes to a distinct, descriptive
+// category with action:"escalate" instead of falling through to "unknown".
+describe("STALL_CATEGORY_MAP — Fix 6: the 5 newly-admitted rebase stall reasons route to typed escalate categories, not 'unknown'", () => {
+  test("thoughts_conflict_with_origin_main → thoughts-conflict/escalate", () => {
+    expect(classifyStalledTicket({ reason: "thoughts_conflict_with_origin_main" }))
+      .toEqual({ category: "thoughts-conflict", action: "escalate" });
+  });
+
+  test("worktree_live_handle_guard_refused → worktree-guard-refused/escalate", () => {
+    expect(classifyStalledTicket({ reason: "worktree_live_handle_guard_refused" }))
+      .toEqual({ category: "worktree-guard-refused", action: "escalate" });
+  });
+
+  test("continue_failed → rebase-continue-failed/escalate", () => {
+    expect(classifyStalledTicket({ reason: "continue_failed" }))
+      .toEqual({ category: "rebase-continue-failed", action: "escalate" });
+  });
+
+  test("no_rebase_in_progress → no-rebase-in-progress/escalate", () => {
+    expect(classifyStalledTicket({ reason: "no_rebase_in_progress" }))
+      .toEqual({ category: "no-rebase-in-progress", action: "escalate" });
+  });
+
+  test("thoughts_symlink_broken → thoughts-symlink-broken/escalate", () => {
+    expect(classifyStalledTicket({ reason: "thoughts_symlink_broken" }))
+      .toEqual({ category: "thoughts-symlink-broken", action: "escalate" });
+  });
+
+  test("none of the 5 fall through to the generic 'unknown' category", () => {
+    for (const reason of [
+      "thoughts_conflict_with_origin_main",
+      "worktree_live_handle_guard_refused",
+      "continue_failed",
+      "no_rebase_in_progress",
+      "thoughts_symlink_broken",
+    ]) {
+      expect(classifyStalledTicket({ reason }).category).not.toBe("unknown");
+    }
+  });
+});
+
 // ---------------------------------------------------------------------------
 // UNSTUCK_SWEEP_INTENT_KIND constant
 // ---------------------------------------------------------------------------
@@ -420,6 +467,42 @@ describe("defaultCollectUnstuckCandidates — shared census builder (CTL-1064)",
     const candidates = defaultCollectUnstuckCandidates({ orchDir });
     expect(candidates).toHaveLength(1);
     expect(candidates[0].evidence.reason).toBe("orphan-sweep-stale");
+  });
+
+  // #1461 Fix 6 (deferred-minor finding): stalledReason takes precedence over
+  // failureReason when BOTH are present with DIFFERENT values — there was
+  // previously no test proving this precedence, only that each field works
+  // alone. The `??` chain (stalledReason ?? failureReason ?? null) is
+  // left-to-right, so stalledReason wins whenever it is non-nullish.
+  test("stalledReason takes precedence over failureReason when both are present with different values", () => {
+    makeWorker("CTL-20021", {
+      status: "stalled",
+      stalledReason: "rebase_refused_dirty_tree",
+      failureReason: "source_conflict_ctl708_unavailable",
+    });
+    const candidates = defaultCollectUnstuckCandidates({ orchDir });
+    expect(candidates).toHaveLength(1);
+    expect(candidates[0].evidence.reason).toBe("rebase_refused_dirty_tree");
+  });
+
+  // #1461 Fix 6 (deferred-minor finding): the prior guard (`stalledReason ||
+  // failureReason`) and value selection (`stalledReason ?? failureReason`) used
+  // DIFFERENT operators — an empty-string stalledReason ("" is falsy but not
+  // nullish) would pass the `??` value-selection as "" (present) while the `||`
+  // guard would fall through to failureReason for the presence check, an
+  // inconsistent read. Now BOTH the guard and the value use the same `??`
+  // chain: an empty-string stalledReason IS treated as present (matches `??`
+  // semantics throughout), so the candidate's reason is the empty string, not
+  // a silent fallback to failureReason.
+  test("an empty-string stalledReason is treated as present (not falsy) — consistent ?? semantics throughout", () => {
+    makeWorker("CTL-20022", {
+      status: "stalled",
+      stalledReason: "",
+      failureReason: "source_conflict_ctl708_unavailable",
+    });
+    const candidates = defaultCollectUnstuckCandidates({ orchDir });
+    expect(candidates).toHaveLength(1);
+    expect(candidates[0].evidence.reason).toBe("");
   });
 
   test("finds source_conflict_ctl708_unavailable via failureReason (the real producer field), not just stalledReason", () => {

--- a/plugins/dev/scripts/execution-core/unstuck-sweep.test.mjs
+++ b/plugins/dev/scripts/execution-core/unstuck-sweep.test.mjs
@@ -105,6 +105,16 @@ describe("classifyStalledTicket — pure top-level router (CTL-1064)", () => {
   });
 });
 
+describe("STALL_CATEGORY_MAP — #1461 additions", () => {
+  test("source_conflict_resolvable routes to skip (resolve-conflict-sweep already owns it)", () => {
+    expect(classifyStalledTicket({ reason: "source_conflict_resolvable" })).toEqual({ category: "skip", action: "skip" });
+  });
+
+  test("resolve-conflict-cycle-cap-exhausted routes to escalate", () => {
+    expect(classifyStalledTicket({ reason: "resolve-conflict-cycle-cap-exhausted" })).toEqual({ category: "resolve-conflict-cap", action: "escalate" });
+  });
+});
+
 // ---------------------------------------------------------------------------
 // UNSTUCK_SWEEP_INTENT_KIND constant
 // ---------------------------------------------------------------------------
@@ -410,6 +420,17 @@ describe("defaultCollectUnstuckCandidates — shared census builder (CTL-1064)",
     const candidates = defaultCollectUnstuckCandidates({ orchDir });
     expect(candidates).toHaveLength(1);
     expect(candidates[0].evidence.reason).toBe("orphan-sweep-stale");
+  });
+
+  test("finds source_conflict_ctl708_unavailable via failureReason (the real producer field), not just stalledReason", () => {
+    const readdirSync = (p, opts) => {
+      if (p.endsWith("/workers")) return [{ name: "CTL-1", isDirectory: () => true }];
+      return [{ name: "phase-implement.json", isDirectory: () => false }];
+    };
+    const readFileSync = () => JSON.stringify({ status: "stalled", failureReason: "source_conflict_ctl708_unavailable" });
+    const out = defaultCollectUnstuckCandidates({ orchDir: "/orch", readdirSync, readFileSync });
+    expect(out).toHaveLength(1);
+    expect(out[0].evidence.reason).toBe("source_conflict_ctl708_unavailable");
   });
 
   test("skips running/done signals and tickets with wrong status", () => {

--- a/plugins/dev/scripts/lib/__tests__/phase-artifact-gate.test.sh
+++ b/plugins/dev/scripts/lib/__tests__/phase-artifact-gate.test.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+# Shell tests for lib/phase-artifact-gate.sh — prior-artifact gate specifications.
+#
+# Run: bash plugins/dev/scripts/lib/__tests__/phase-artifact-gate.test.sh
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+LIB_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+# shellcheck source=../phase-artifact-gate.sh
+. "$LIB_DIR/phase-artifact-gate.sh"
+
+FAILURES=0
+PASSES=0
+result=""
+
+pass() { PASSES=$((PASSES + 1)); echo "  PASS: $1"; }
+fail() { FAILURES=$((FAILURES + 1)); echo "  FAIL: $1"; }
+
+echo "phase-artifact-gate tests"
+
+# ── 1. resolve-conflict prior artifact ────────────────────────────────────────
+result="$(prior_artifact_for_phase resolve-conflict)"
+if [[ "$result" != "signal:resolve-conflict-brief.json" ]]; then
+	fail "prior_artifact_for_phase resolve-conflict = '${result}', expected 'signal:resolve-conflict-brief.json'"
+else
+	pass "prior_artifact_for_phase resolve-conflict"
+fi
+
+# ── 2. Entry point phases (no prior artifact) ────────────────────────────────────
+for phase in triage; do
+	result="$(prior_artifact_for_phase "$phase")"
+	if [[ "$result" == "" ]]; then
+		pass "prior_artifact_for_phase $phase (entry point)"
+	else
+		fail "prior_artifact_for_phase $phase = '${result}', expected ''"
+	fi
+done
+
+# ── 3. Standard signal-based phases ──────────────────────────────────────────────
+declare -A expected_signals=(
+	[research]="signal:triage.json"
+	[verify]="signal:phase-implement.json"
+	[review]="signal:verify.json"
+	[pr]="signal:review.json"
+	[monitor-merge]="signal:phase-pr.json"
+	[monitor-deploy]="signal:phase-monitor-merge.json"
+	[remediate]="signal:verify.json"
+	[recovery-pass]="signal:recovery-pass.json"
+	[teardown]="signal:phase-monitor-deploy.json"
+)
+
+for phase in "${!expected_signals[@]}"; do
+	result="$(prior_artifact_for_phase "$phase")"
+	expected="${expected_signals[$phase]}"
+	if [[ "$result" == "$expected" ]]; then
+		pass "prior_artifact_for_phase $phase = '$expected'"
+	else
+		fail "prior_artifact_for_phase $phase = '${result}', expected '${expected}'"
+	fi
+done
+
+# ── 4. Glob-based phases ─────────────────────────────────────────────────────────
+declare -A expected_globs=(
+	[plan]="glob:thoughts/shared/research"
+	[implement]="glob:thoughts/shared/plans"
+)
+
+for phase in "${!expected_globs[@]}"; do
+	result="$(prior_artifact_for_phase "$phase")"
+	expected="${expected_globs[$phase]}"
+	if [[ "$result" == "$expected" ]]; then
+		pass "prior_artifact_for_phase $phase = '$expected'"
+	else
+		fail "prior_artifact_for_phase $phase = '${result}', expected '${expected}'"
+	fi
+done
+
+echo
+echo "results: $PASSES passed, $FAILURES failed"
+[ $FAILURES -eq 0 ]

--- a/plugins/dev/scripts/lib/phase-artifact-gate.sh
+++ b/plugins/dev/scripts/lib/phase-artifact-gate.sh
@@ -48,6 +48,11 @@ prior_artifact_for_phase() {
 	# (the analogue of verify.json for remediate). The skill reads it as its
 	# prior-phase artifact.
 	recovery-pass) echo "signal:recovery-pass.json" ;;
+	# #1461: resolve-conflict's brief is resolve-conflict-brief.json — the
+	# classification + which-phase-stalled envelope resolve-conflict-sweep.mjs
+	# writes before dispatch (the analogue of recovery-pass.json for recovery-pass,
+	# verify.json for remediate). The skill reads it as its prior-phase artifact.
+	resolve-conflict) echo "signal:resolve-conflict-brief.json" ;;
 	teardown) echo "signal:phase-monitor-deploy.json" ;;
 	*) echo "" ;;
 	esac

--- a/plugins/dev/scripts/phase-agent-dispatch
+++ b/plugins/dev/scripts/phase-agent-dispatch
@@ -143,6 +143,12 @@ phase_default_turn_cap() {
 	monitor-merge) echo 50 ;;
 	monitor-deploy) echo 30 ;;
 	remediate) echo 40 ;; # CTL-653: fix-scoped — smaller than implement's 75
+	# resolve-conflict (#1461/ADR-028): rebases a stalled branch onto base and
+	# resolves the classified-resolvable conflict additively, per
+	# resolve-conflict-brief.json. Explicitly scoped like remediate — "the same
+	# fix-capable envelope" per the skill's own docs — rather than falling to
+	# the generic DEFAULT_TURN_CAP.
+	resolve-conflict) echo 40 ;;
 	# recovery-pass (CTL-1176 rung 3): a goal-driven senior-engineer sweep that
 	# resolves conflicts / rebases / merges / re-dispatches across the pipeline.
 	# Higher than remediate's fix-scoped 40 because it iterates to a fleet goal,

--- a/plugins/dev/skills/phase-resolve-conflict/SKILL.md
+++ b/plugins/dev/skills/phase-resolve-conflict/SKILL.md
@@ -1,0 +1,404 @@
+---
+name: phase-resolve-conflict
+description: |
+  Phase-agent that rebases a stalled ticket branch onto origin/main using the
+  additive resolution guidance in `resolve-conflict-brief.json` (ADR-028,
+  #1461). Dispatched by `resolve-conflict-sweep.mjs`'s mark-and-dispatch seam,
+  through the standard `dispatch.mjs → phase-agent-dispatch` envelope, once
+  `classifyMergeTree` has confirmed the stall is resolvable. Reads
+  `${ORCH_DIR}/workers/<ticket>/resolve-conflict-brief.json`
+  (conflictFiles/conflictTypes/base/attempt), resolves each conflict
+  additively (preserving both sides' intent), runs a targeted gate, commits,
+  and emits `phase.resolve-conflict.complete.<ticket>`. The sweep — not this
+  skill — clears the original stalled phase's signal once it observes the
+  complete event, dropping the ticket back into `isTicketInFlight`. Capped at
+  3 attempts via `RESOLVE_CONFLICT_CYCLE_CAP`
+  (env override `CATALYST_RESOLVE_CONFLICT_CYCLE_CAP`). Dispatched as a
+  `claude --bg` job by `phase-agent-dispatch`, which invokes it via slash
+  command — hence `user-invocable: true`.
+user-invocable: true
+disable-model-invocation: false  # invocable by model (Skill tool) AND user (slash command)
+allowed-tools:
+  - Bash
+  - Read
+  - Grep
+  - Glob
+  - Edit
+  - Write
+  - Task
+---
+
+# phase-resolve-conflict
+
+Phase-agent that owns the **resolve** half of the resolve-conflict sweep
+(ADR-028, #1461). Today a sibling-PR-merge source conflict stalls a ticket
+generically (`stalledReason: source_conflict_ctl708_unavailable`, written at
+dispatch-time pre-flight rebase for whichever phase — implement/verify/review
+— was about to run) with no dedicated resolver: `unstuck-sweep`'s
+`sourceConflictActSeam` (ADR-024) only force-pushes an already-clean branch
+past a stale flag and throws on a genuine conflict, and `recovery-pass`
+(ADR-025) tells its LLM to "resolve it yourself" ad hoc with no structured
+brief or cycle cap. `resolve-conflict-sweep.mjs` closes that gap: it classifies
+the live conflict with the existing, unmodified `classifyMergeTree`
+(`stale-pr-rescue.mjs`), and only when the shape is resolvable does it mark
+the stall `source_conflict_resolvable`, write `resolve-conflict-brief.json`,
+and dispatch this skill. `phase-resolve-conflict` reads that brief, rebases
+onto the base additively per the classified conflict files/types, runs a
+targeted gate, commits, and hands back a `complete` event. The sweep's own
+completions pass then clears the original phase's stalled signal — this skill
+never redispatches the stalled phase itself. The loop repeats up to
+`RESOLVE_CONFLICT_CYCLE_CAP` (default 3) attempts before escalating.
+
+Like `phase-remediate`, there is **no canonical "resolve-conflict" skill** to
+delegate to — the rebase/resolve work lives in this skill body. It is
+otherwise the same fix-capable envelope (Edit/Write/Task, CTL-615 yield check,
+CTL-632 Linear mirror, terminal emit).
+
+## Prerequisites
+
+- `CATALYST_ORCHESTRATOR_DIR`, `CATALYST_ORCHESTRATOR_ID`, `CATALYST_PHASE=resolve-conflict`, `CATALYST_TICKET` set by [[phase-agent-dispatch]].
+- A `resolve-conflict-brief.json` exists at `${ORCH_DIR}/workers/<ticket>/resolve-conflict-brief.json` — the dispatcher's prior-artifact gate (`signal:resolve-conflict-brief.json`, wired in `lib/phase-artifact-gate.sh`) already validates this; this skill re-reads it.
+- Current working directory is the ticket's worktree — the branch that failed its original phase's dispatch-time pre-flight rebase and is now stalled mid-conflict-classification.
+
+## Prelude (template — copy verbatim into the running session)
+
+```bash
+set -euo pipefail
+
+: "${CATALYST_ORCHESTRATOR_DIR:?required (set by phase-agent-dispatch)}"
+: "${CATALYST_ORCHESTRATOR_ID:?required}"
+: "${CATALYST_PHASE:?required}"
+: "${CATALYST_TICKET:?required}"
+
+ORCH_DIR="$CATALYST_ORCHESTRATOR_DIR"
+ORCH_ID="$CATALYST_ORCHESTRATOR_ID"
+PHASE="$CATALYST_PHASE"
+TICKET="$CATALYST_TICKET"
+CHANNEL="${ORCH_ID}"
+
+SIGNAL_FILE="${ORCH_DIR}/workers/${TICKET}/phase-${PHASE}.json"
+[[ -f "$SIGNAL_FILE" ]] || { echo "phase-${PHASE}: signal file missing" >&2; exit 1; }
+
+PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT:-}"
+[[ -n "$PLUGIN_ROOT" ]] || PLUGIN_ROOT="$(dirname "$(dirname "$(dirname "$(realpath "${BASH_SOURCE[0]:-$0}" 2>/dev/null || echo .)")")")"
+
+# 0. Codified bg_job_id yield (CTL-615). If the signal file's bg_job_id names a
+#    DIFFERENT live bg job, we are a redispatch duplicate of a still-running
+#    canonical worker. Bow out without touching the signal, without emitting any
+#    phase event. Encodes operator memories #43/#44/#49/#50. phase-resolve-conflict
+#    commits code (like implement/remediate), so it carries the gate.
+YIELD_CHECK="${PLUGIN_ROOT}/scripts/phase-agent-yield-check.sh"
+if [[ -x "$YIELD_CHECK" ]] && bash "$YIELD_CHECK" \
+     --signal "$SIGNAL_FILE" \
+     --phase "$PHASE" \
+     --worker-dir "$(dirname "$SIGNAL_FILE")"; then
+  echo "phase-${PHASE}: yielding to canonical worker (CTL-615)" >&2
+  exit 0
+fi
+
+# 1. Join the shared comms channel (best-effort).
+COMMS="${PLUGIN_ROOT}/scripts/catalyst-comms"
+[[ -x "$COMMS" ]] || COMMS="$(command -v catalyst-comms 2>/dev/null || true)"
+if [[ -n "$COMMS" && -x "$COMMS" ]]; then
+  "$COMMS" join "$CHANNEL" --as "$TICKET" \
+    --capabilities "phase-resolve-conflict: ${TICKET}" \
+    --orch "$ORCH_ID" --parent orchestrator --ttl 3600 >/dev/null 2>&1 || true
+  "$COMMS" send "$CHANNEL" "phase-resolve-conflict started" --as "$TICKET" --type info \
+    --orch "$ORCH_ID" >/dev/null 2>&1 || true
+fi
+
+# 2. Start a catalyst-session for cost/token instrumentation.
+SESSION_SCRIPT="${PLUGIN_ROOT}/scripts/catalyst-session.sh"
+if [[ -x "$SESSION_SCRIPT" ]]; then
+  CATALYST_SESSION_ID=$("$SESSION_SCRIPT" start \
+    --skill "phase-resolve-conflict" \
+    --ticket "$TICKET" \
+    --workflow "${CATALYST_SESSION_ID:-}")
+  export CATALYST_SESSION_ID
+fi
+
+# 3. Mark the signal file as running + persist catalystSessionId (CTL-496:
+#    orchestrate-roll-usage --phase reads this to attribute cost).
+TS=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+TMP="${SIGNAL_FILE}.tmp.$$"
+jq --arg ts "$TS" --arg sid "${CATALYST_SESSION_ID:-}" '
+  .status = "running"
+  | .updatedAt = $ts
+  | if $sid != "" then .catalystSessionId = $sid else . end
+' "$SIGNAL_FILE" > "$TMP" \
+  && mv "$TMP" "$SIGNAL_FILE"
+
+# CTL-587: test-kill after-prelude. Exits AFTER the signal is flipped to running
+# but BEFORE any commit work, so reclaimDeadWorkIfPossible's probe returns false
+# on the next staleness tick and the revive path engages. Mode suffix
+# `${PHASE}:after-prelude` keeps the env var phase-agnostic.
+if [[ "${CATALYST_TEST_KILL_PHASE:-}" == "${PHASE}:after-prelude" ]]; then
+  echo "[CTL-587 test-kill] aborting after prelude" >&2
+  exit 137
+fi
+
+# 4. Locate resolve-conflict-brief.json — the resolve brief. The dispatcher
+#    already gated on its existence (signal:resolve-conflict-brief.json); we
+#    re-read it to extract the stalled phase, base, and conflict evidence.
+BRIEF="${ORCH_DIR}/workers/${TICKET}/resolve-conflict-brief.json"
+[[ -f "$BRIEF" ]] || { echo "phase-resolve-conflict: resolve-conflict-brief.json missing for ${TICKET}" >&2; exit 1; }
+STALLED_PHASE="$(jq -r '.stalledPhase' "$BRIEF")"
+BASE_REF="$(jq -r '.base' "$BRIEF")"
+CONFLICT_FILES="$(jq -r '.conflictFiles[]?' "$BRIEF")"
+CONFLICT_TYPES="$(jq -r '.conflictTypes[]?' "$BRIEF")"
+echo "phase-resolve-conflict: ${TICKET} stalled on ${STALLED_PHASE}; base=${BASE_REF}"
+echo "phase-resolve-conflict: conflict files: ${CONFLICT_FILES}"
+echo "phase-resolve-conflict: conflict types: ${CONFLICT_TYPES}"
+
+# 5. Linear status is written by the coordinator (mirrors CTL-558's pattern
+#    for phase-remediate): the execution-core scheduler / resolve-conflict-sweep
+#    owns any Linear state transition around this dispatch. The phase agent
+#    itself never transitions Linear.
+```
+
+## /goal condition
+
+Transcript-evaluable so a `/goal` evaluator (which only sees Claude's text
+output, not the filesystem) can decide pass/fail from what the agent prints.
+
+```
+/goal "I have rebased this branch onto ${BASE_REF} (origin/main), resolved the
+       conflicts in the files resolve-conflict-brief.json named additively
+       (preserving both sides' intent — a content conflict keeps both edits
+       where they don't logically collide; an add/add conflict keeps both
+       files, renaming if the same path was independently added), run a
+       targeted gate (tsc/test/lint) on the touched files showing exit 0, and
+       committed so `git diff <base>..HEAD` includes the resolution. The
+       resolve-conflict-sweep clears the original stall once it sees
+       phase.resolve-conflict.complete — I do NOT redispatch the stalled phase
+       myself. (Linear status is written by the coordinator, not this agent.)"
+```
+
+## Phase-specific work
+
+Resolve-conflict is **fix-capable** and reads `resolve-conflict-brief.json` as
+its brief. There is no canonical wrapper — do the resolution work here:
+
+1. Fetch and rebase: `git fetch origin ${BASE_REF}` then `git rebase origin/${BASE_REF}`.
+2. On each conflict, resolve ADDITIVELY per the conflict type resolve-conflict-brief.json
+   named: for a `content` conflict, read both sides and merge them so neither
+   ticket's change is silently dropped (this is bounded — the brief's
+   `classifyMergeTree` gate already confirmed only `content`/`add/add` types and a
+   file count within the cap; if a conflict marker is found that ISN'T one of
+   these types, STOP and emit `failed` — see Failure handling, do not attempt an
+   unbounded resolution). For `add/add`, keep both files; rename one if the same
+   logical path was independently created for two different purposes.
+3. `git rebase --continue` after each resolution; repeat until the rebase completes.
+4. Run the targeted gate (tsc/test/lint scoped to the resolved files, e.g. via
+   `/catalyst-dev:validate-type-safety` scoped to the diff) and print its `exit 0`.
+5. The rebase itself IS the "commit" here (no separate fix-commit like remediate —
+   the resolution lands as part of the rebased history). Force-push is NOT this
+   skill's job — the redispatched phase (after the sweep clears the stall) will
+   push normally as part of its own work.
+
+## End block (terminal emit — copy verbatim)
+
+Mirror the phase output to Linear as a single comment (CTL-632). Re-derives the
+commit list at end-block time, falling back to `_base branch unknown_` if
+neither `origin/main` nor `main` exists. Fail-open and idempotent via the
+per-phase marker file. Uniquely-named fence so the e2e test can extract just
+this block.
+
+```bash phase-resolve-conflict-mirror
+LINEAR_MIRROR_MARKER="${ORCH_DIR}/workers/${TICKET}/.linear-mirror-${PHASE}"
+if [[ ! -e "${LINEAR_MIRROR_MARKER}" ]]; then
+  BASE_REF=""
+  if git rev-parse --verify --quiet origin/main >/dev/null 2>&1; then
+    BASE_REF="origin/main"
+  elif git rev-parse --verify --quiet main >/dev/null 2>&1; then
+    BASE_REF="main"
+  fi
+  BASE_SHA=""
+  if [[ -n "${BASE_REF}" ]]; then
+    BASE_SHA="$(git merge-base HEAD "${BASE_REF}" 2>/dev/null || true)"
+  fi
+  if [[ -n "${BASE_SHA}" ]]; then
+    COMMIT_LIST="$(git log --no-merges --oneline "${BASE_SHA}..HEAD" 2>/dev/null | sed 's/^/- /')"
+    COMMIT_COUNT="$(printf '%s\n' "${COMMIT_LIST}" | grep -c '^- ' || true)"
+    : "${COMMIT_COUNT:=0}"
+    DIFF_STAT="$(git diff --stat "${BASE_SHA}..HEAD" 2>/dev/null | tail -1)"
+    NAME_STATUS="$(git diff --name-status "${BASE_SHA}..HEAD" 2>/dev/null)"
+    FILES_ADDED="$(printf '%s\n' "${NAME_STATUS}" | grep -c '^A' || true)"
+    FILES_MODIFIED="$(printf '%s\n' "${NAME_STATUS}" | grep -c '^M' || true)"
+    FILES_DELETED="$(printf '%s\n' "${NAME_STATUS}" | grep -c '^D' || true)"
+    LINES_ADDED="$(git diff --numstat "${BASE_SHA}..HEAD" 2>/dev/null | awk '$1 ~ /^[0-9]+$/ {a+=$1} END {print a+0}')"
+    LINES_DELETED="$(git diff --numstat "${BASE_SHA}..HEAD" 2>/dev/null | awk '$2 ~ /^[0-9]+$/ {d+=$2} END {print d+0}')"
+  else
+    COMMIT_LIST="_base branch unknown_"
+    COMMIT_COUNT="?"
+    DIFF_STAT="_unavailable_"
+    FILES_ADDED="?"; FILES_MODIFIED="?"; FILES_DELETED="?"
+    LINES_ADDED="?"; LINES_DELETED="?"
+  fi
+  BRANCH_NAME="$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "${TICKET}")"
+  CONFLICT_FILES_JOINED="$(jq -r '.conflictFiles // [] | join(", ")' "${ORCH_DIR}/workers/${TICKET}/resolve-conflict-brief.json" 2>/dev/null || echo "?")"
+  MIRROR_BODY="$(cat <<EOF
+**Phase Resolve-Conflict**
+
+- **Branch**: \`${BRANCH_NAME}\`
+- **Commits**: ${COMMIT_COUNT}
+- **Files**: ${FILES_ADDED} added, ${FILES_MODIFIED} modified, ${FILES_DELETED} deleted
+- **Lines**: +${LINES_ADDED} / -${LINES_DELETED}
+- **Diff**: ${DIFF_STAT}
+- **Resolved conflict in**: ${CONFLICT_FILES_JOINED}
+
+<details>
+<summary>Commit list</summary>
+
+${COMMIT_LIST}
+
+</details>
+
+_Posted automatically by phase-resolve-conflict (ADR-028 / CTL-632). The
+resolve-conflict-sweep clears the original stall on this complete event and
+redispatches the phase that stalled; the resolve-conflict cycle caps at
+RESOLVE_CONFLICT_CYCLE_CAP (default 3)._
+EOF
+)"
+  MIRROR_FOOTER=""
+  if [[ -n "${PLUGIN_ROOT:-}" && -x "${PLUGIN_ROOT}/scripts/lib/phase-mirror-footer.sh" ]]; then
+    MIRROR_FOOTER="$("${PLUGIN_ROOT}/scripts/lib/phase-mirror-footer.sh" --orch-dir "${ORCH_DIR}" --ticket "${TICKET}" --phase "${PHASE}" 2>/dev/null || true)"
+  fi
+  [[ -n "${MIRROR_FOOTER}" ]] && MIRROR_BODY="${MIRROR_BODY}
+${MIRROR_FOOTER}"
+  if [[ ${#MIRROR_BODY} -gt 30000 ]]; then
+    MIRROR_BODY="${MIRROR_BODY:0:30000}
+
+_... (truncated)_"
+  fi
+  COMMENT_POST="${CATALYST_COMMENT_POST_HELPER:-${PLUGIN_ROOT}/scripts/lib/linear-comment-post.sh}"
+  if [[ ! -x "$COMMENT_POST" ]]; then COMMENT_POST="$(command -v linear-comment-post.sh 2>/dev/null || true)"; fi
+  if [[ -n "$COMMENT_POST" && -x "$COMMENT_POST" ]] && "$COMMENT_POST" "${TICKET}" "${MIRROR_BODY}" >/dev/null; then
+    : > "${LINEAR_MIRROR_MARKER}"
+  else
+    echo "phase-resolve-conflict: linear-comment-post failed (continuing)" >&2
+  fi
+fi
+```
+
+Then the empty-branch self-emit gate (CTL-608). Runs **before** the terminal
+`--status complete` so a worker cannot self-report resolve-conflict success on
+an empty ticket branch (0 commits ahead of its integration base). Uses only
+POSIX/zsh-safe `git rev-list --count`. Fail-open (warn + allow) only when the
+base is unresolvable. Uniquely-named fence so the e2e harness can
+extract+exercise it.
+
+```bash phase-resolve-conflict-empty-branch-gate
+EMPTY_BRANCH_GATE_BASE=""
+if git rev-parse --verify --quiet origin/main >/dev/null 2>&1; then
+  EMPTY_BRANCH_GATE_BASE="origin/main"
+elif git rev-parse --verify --quiet main >/dev/null 2>&1; then
+  EMPTY_BRANCH_GATE_BASE="main"
+fi
+if [[ -n "${EMPTY_BRANCH_GATE_BASE}" ]]; then
+  AHEAD="$(git rev-list --count "${EMPTY_BRANCH_GATE_BASE}..HEAD" 2>/dev/null || echo 0)"
+  if [[ "${AHEAD:-0}" -le 0 ]]; then
+    echo "phase-resolve-conflict: 0 commits ahead of ${EMPTY_BRANCH_GATE_BASE}; refusing to emit complete on an empty branch (CTL-608)" >&2
+    "${PLUGIN_ROOT}/scripts/phase-agent-emit-complete" \
+      --phase "$PHASE" --ticket "$TICKET" --status failed \
+      --reason "empty_branch:0_commits_ahead_of_${EMPTY_BRANCH_GATE_BASE}"
+    [[ -n "$COMMS" && -x "$COMMS" ]] && "$COMMS" send "$CHANNEL" \
+      "phase-resolve-conflict failed: empty branch (0 commits ahead of ${EMPTY_BRANCH_GATE_BASE})" \
+      --as "$TICKET" --type attention --orch "$ORCH_ID" >/dev/null 2>&1 || true
+    exit 1
+  fi
+else
+  echo "phase-resolve-conflict: could not resolve integration base (no origin/main or main); skipping empty-branch gate (CTL-608)" >&2
+fi
+```
+
+```bash
+EMIT="${PLUGIN_ROOT}/scripts/phase-agent-emit-complete"
+if [[ -x "$EMIT" ]]; then
+  # No --reason on success: phase-agent-emit-complete stamps --reason into
+  # .failureReason even on --status complete (operator memory).
+  "$EMIT" --phase "$PHASE" --ticket "$TICKET" --status complete
+fi
+[[ -n "$COMMS" && -x "$COMMS" ]] && "$COMMS" done "$CHANNEL" --as "$TICKET" >/dev/null 2>&1 || true
+```
+
+## Failure handling
+
+One failure mode — hard error (caller-supplied reason). When escalating to
+`stalled`/`needs-human`, populate an `explanation` block per CTL-1130 using
+the CLI shim (always exits 0; degrades gracefully on bad input):
+
+```bash
+REASON="${1:-conflict resolution failed}"  # caller-supplied short string
+
+# ADR-028: AUTHORIZATION — the agent can re-attempt resolution; only an
+# out-of-scope conflict shape or an exhausted cycle budget stops it.
+EXPL_JSON="$(node "${PLUGIN_ROOT}/scripts/execution-core/escalation-explain.mjs" \
+  --ticket "$TICKET" --phase "$PHASE" \
+  --type authorization \
+  --problem "resolve-conflict failed: ${REASON}" \
+  --call-to-action "should ${TICKET}'s rebase onto ${BASE_REF:-origin/main} be resolved manually, or should the resolve-conflict cycle cap be raised?" \
+  --recommendation "resolve the remaining conflict manually in the ${TICKET} worktree, then let the sweep clear the stall on the next tick" \
+  --risk "a conflict type outside {content, add/add} surfaced mid-rebase, or a third conflict wave appeared after the classified files were resolved — attempting an unbounded resolution risks silently dropping one side's change" \
+  --why-asking "risk-authority gate, not a capability gap" \
+  --authorize-label "manually resolve ${TICKET}" \
+  --could-higher-tier-resolve false \
+  --can-execute true \
+  2>/dev/null || echo '{}')"
+
+# Hard-error: emit failed + attention, exit non-zero. A `failed` event lets
+# the FSM revive resolve-conflict once (REVIVE_BUDGET) before stalling —
+# distinct from the sweep's own cycle counter (RESOLVE_CONFLICT_CYCLE_CAP),
+# which counts `complete` events via `countResolveConflictCycles`.
+"$EMIT" --phase "$PHASE" --ticket "$TICKET" --status failed --reason "$REASON"
+[[ -n "$COMMS" && -x "$COMMS" ]] && "$COMMS" send "$CHANNEL" \
+  "phase-resolve-conflict failed: ${REASON}" \
+  --as "$TICKET" --type attention --orch "$ORCH_ID" >/dev/null 2>&1 || true
+exit 1
+```
+
+The orchestrator receives `phase.resolve-conflict.complete.${TICKET}` and
+`resolve-conflict-sweep.mjs`'s own completions pass
+(`defaultCollectResolveConflictCompletions`) — not this skill — finds the
+`phase-resolve-conflict.json` signal at `status:"done"`, reads
+`resolve-conflict-brief.json.stalledPhase`, and mechanically clears that
+phase's own stalled signal, dropping the ticket back into `isTicketInFlight`
+so the ordinary dispatch loop redispatches the phase that originally stalled.
+`countResolveConflictCycles` counts this `complete` event toward
+`RESOLVE_CONFLICT_CYCLE_CAP` (default 3, env override
+`CATALYST_RESOLVE_CONFLICT_CYCLE_CAP`); cap-exhausted routes to
+`stalledReason: resolve-conflict-cycle-cap-exhausted` and an escalation
+comment instead of another resolve-conflict dispatch — the sole human entry
+for this path.
+
+## Comms discipline
+
+Inherits the contract from [[_phase-agent-template]]:
+
+| Type        | When                                                                                  |
+|-------------|--------------------------------------------------------------------------------------|
+| `info`      | At start; once after the rebase resolution completes and the targeted gate passes. |
+| `attention` | Missing resolve-conflict-brief.json, an out-of-scope conflict type, hard error. (Turn caps are enforced daemon-side — CTL-748 — not self-detected by this skill.) |
+| `question`  | A conflict the agent cannot resolve unilaterally without dropping one side's intent. |
+| `done`      | Emitted by `phase-agent-emit-complete` on success.                                   |
+
+Read inbound `directive` / `pause` / `abort` after each resolution round — the
+orchestrator may abort the worker while resolution is in flight.
+
+## Why this sweep, not a `deriveAdvancement` detour
+
+`isTicketInFlight` excludes any `stalled` ticket, so `deriveAdvancement`'s
+verify⇄remediate-style router (CTL-653) never sees a ticket stalled on
+`source_conflict_ctl708_unavailable` in the first place — a
+`deriveAdvancement` branch, as #1461 originally proposed, cannot reach these
+tickets without threading the in-flight gate itself. ADR-028 (`docs/adrs.md`)
+instead runs `resolve-conflict-sweep.mjs` as its own dedicated tick-loop pass,
+structurally mirroring `stall-janitor`/`unstuck-sweep` (ADR-024): it scans
+stalled signals directly, re-classifies the live conflict with the existing
+`classifyMergeTree`, and only dispatches this skill once that classification
+says the shape is resolvable. This skill is the worker that sweep dispatches;
+because the original stall reason is written generically at dispatch time for
+whichever phase was about to run, the sweep — and this skill — cover
+implement/verify/review uniformly by construction, with no FSM predecessor
+changes needed. See `docs/adrs.md`'s "ADR-028: Deterministic resolvable-conflict
+sweep" section for the full design and rejected alternatives.


### PR DESCRIPTION
## Summary

Builds the `phase-resolve-conflict` architecture designed in #1461: sibling-PR-merge source conflicts currently stall a ticket indefinitely with no automated recovery path. This adds a new tick-loop sweep (`execution-core/resolve-conflict-sweep.mjs`) that:

- Scans for tickets stalled with a dispatch-time-rebase source conflict, independent of the `isTicketInFlight` gate (per the scoping comment on #1461 — stalled tickets are excluded from `deriveAdvancement`'s normal sweep, so this needs to be a dedicated pass, not a `deriveAdvancement` detour)
- Re-classifies resolvability live against the local worktree (`git merge-tree` vs `origin/<base>`), reusing the existing, unmodified `classifyMergeTree` from `stale-pr-rescue.mjs` — no conflict-parsing logic reimplemented
- Dispatches a fix through the standard `dispatch.mjs → phase-agent-dispatch` envelope (the same one `recovery-pass` uses) to a new phase-agent skill, `phase-resolve-conflict` (cloned from `phase-remediate`'s envelope)
- Is capped (default 3 cycles, event-counted via `countResolveConflictAttempts`, counting both successful completions and failures so a repeatedly-failing run still escalates) and escalates to a human on cap exhaustion
- Ships **off by default**, mode-gated off/shadow/enforce per this repo's ADR-023 rollout discipline, with a working shadow-mode event emitter so an operator can validate before enforcing
- Is phase-agnostic by construction: the stall reason (`source_conflict_ctl708_unavailable`) is written generically at dispatch time for whichever phase (implement/verify/review) is about to run, so the sweep covers all three predecessors uniformly without any change to `deriveAdvancement`/`resolveReapPredecessor`

Design record: see the linked design doc in the companion PR (thagale/catalyst#15, already merged to my fork) for the full ADR-028 writeup and 15-task implementation history.

Two real, pre-existing production bugs were found and fixed along the way (both independent of this feature, needed for it to actually work):
- `unstuck-sweep.mjs`'s existing `source-conflict` category had never matched a real signal in production — the real producer (`phase-agent-dispatch`) writes `.failureReason`, not `.stalledReason`, for the relevant stall reason.
- The dispatch envelope for this new phase now has the same sdk-executor verification/rejection-backstop fidelity its sibling `recovery-pass` dispatch path has.

This is a larger, dedicated architectural build rather than a reuse of the two smaller, already-merged mitigations (#2863, #2864) — a prior scoping investigation on this issue found those solve a narrower, complementary problem and are not a substitute for the async `phase-resolve-conflict` architecture this issue actually asks for.

## Test plan

- [x] Built via 15 sequential TDD tasks, each independently task-reviewed
- [x] A final whole-branch review (2 Critical + 4 Important findings — a completions-census idempotence gap that would have re-cleared forever, a failed-run permanent-orphan gap, an overly-broad label-suppression `continue`, an unobservable shadow mode, a wrong-ref live classifier, and unintended stall-category scope creep) — all fixed and re-reviewed clean
- [x] A follow-up fix for a cycle-cap-reachability gap the final review surfaced (repeat cycles were silently no-op'd by the dispatcher's own idempotency guard) — also reviewed clean
- [x] Full `scheduler.test.mjs` suite run repeatedly throughout, diffed by failing-test *name* (not just aggregate counts) against the recorded baseline — zero net new regressions attributable to this branch
- [x] Confirmed the feature is inert by default at every layer (config default, scheduler wiring default, no other code path can force it on)

Opening for visibility/discussion per #1461 — not merging this myself.