### PR TITLE
fix(dev): CTL-1620 resolve the rescue prompt template from plugins/dev/templates

### DIFF
--- a/plugins/dev/scripts/execution-core/stale-pr-rescue-timer.mjs
+++ b/plugins/dev/scripts/execution-core/stale-pr-rescue-timer.mjs
@@ -36,8 +36,12 @@ import * as linearWriteDefault from "./linear-write.mjs";
 export const defaultLinearWrite = linearWriteDefault;
 
 const ORCHESTRATE_REBASE_BIN = fileURLToPath(new URL("../orchestrate-rebase", import.meta.url));
+// Templates live at plugins/dev/templates/ (orchestrate-rebase resolves them as
+// PLUGIN_ROOT/templates), which from execution-core/ is TWO levels up. `../templates/`
+// pointed at scripts/templates/ — a directory that has never existed — so every rescue
+// dispatch died in awk. Masked by the CTL-1612 401 outage until 2026-08-02 (CTL-1620).
 const RESCUE_PROMPT_TEMPLATE = fileURLToPath(
-  new URL("../templates/rescue-rebase-prompt.md", import.meta.url)
+  new URL("../../templates/rescue-rebase-prompt.md", import.meta.url)
 );
 
 // readStalePrRescueConfig — read catalyst.orchestration.stalePrRescue.*

--- a/plugins/dev/scripts/execution-core/stale-pr-rescue-timer.test.mjs
+++ b/plugins/dev/scripts/execution-core/stale-pr-rescue-timer.test.mjs
@@ -569,6 +569,22 @@ describe("buildRescueDispatchArgs", () => {
     expect(args).not.toContain("--branch");
     expect(args).toContain("--dispatch");
   });
+
+  // CTL-1620 REGRESSION: the module resolved its template as ../templates/ from
+  // execution-core/ — a directory that has never existed — so every live rescue
+  // dispatch died in orchestrate-rebase's awk render. The bug shipped because no
+  // test ever touched the resolved path; this pins BOTH dispatch file arguments
+  // to real files on disk.
+  it("resolves --prompt-template and the orchestrate-rebase bin to files that exist", () => {
+    const args = buildRescueDispatchArgs("CTL-30", {
+      prNumber: 300, orchId: "CTL-30", orchDir: "/orch",
+      worktreePath: "/wt", base: "main", signalFile: "/orch/workers/CTL-30/rescue.json",
+    });
+    const tmpl = args[args.indexOf("--prompt-template") + 1];
+    expect(tmpl.endsWith("plugins/dev/templates/rescue-rebase-prompt.md")).toBe(true);
+    expect(existsSync(tmpl)).toBe(true);
+    expect(existsSync(args[0])).toBe(true); // ORCHESTRATE_REBASE_BIN
+  });
 });
 
 describe("escalation default seam", () => {


### PR DESCRIPTION
## Summary

Every stale-PR rescue dispatch on both fleet hosts was failing with:

```
awk: can't open file .../plugins/dev/scripts/templates/rescue-rebase-prompt.md
msg: "stale-pr-rescue: dispatch failed"
```

`stale-pr-rescue-timer.mjs` resolved its `--prompt-template` as `../templates/` relative to `execution-core/` — `plugins/dev/scripts/templates/`, a directory that has never existed on any branch. The real templates live at `plugins/dev/templates/` (`orchestrate-rebase` resolves them correctly as `PLUGIN_ROOT/templates`, orchestrate-rebase:44-46); only the timer's constant was one directory off.

The CTL-1612 401 outage masked this (dispatch failed earlier in the chain on auth); it surfaced on both minis the moment #2884 restored auth (2026-08-02 ~00:45Z, tickets CTC-310/CTL-1605). It blocks the rescue vector for the stuck PR-phase tickets.

## Fix

- `../templates/` → `../../templates/` in `RESCUE_PROMPT_TEMPLATE` (one line).
- Regression test: `buildRescueDispatchArgs`' `--prompt-template` value must end with `plugins/dev/templates/rescue-rebase-prompt.md` **and** exist on disk (also pins the orchestrate-rebase bin path). The bug shipped because nothing ever touched the resolved path.

## Testing

- `bun test stale-pr-rescue-timer.test.mjs` — 35 pass / 0 fail (new test included).

Linear: CTL-1620

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WHfJt1JhsdArSUyxwZZzkN