### PR TITLE
fix(dev): CTL-1619 adopt LINEAR_API_KEY fallback in linear-reconcile-cli --graphql

### DIFF
--- a/plugins/dev/scripts/execution-core/linear-reconcile-cli.mjs
+++ b/plugins/dev/scripts/execution-core/linear-reconcile-cli.mjs
@@ -167,7 +167,7 @@ Options:
                     while a PR is still open.
   --branch <name>   no-op (retained for back-compat): the open-PR ENUMERATOR derives
                     the branchName from the local replica/cache itself.
-  --graphql         read current state via Linear GraphQL ($LINEAR_API_TOKEN)
+  --graphql         read current state via Linear GraphQL ($LINEAR_API_TOKEN / $LINEAR_API_KEY)
                     for tickets absent from the local cache (unenrolled repos)
   --json            machine-readable output
   -h, --help        show this help`;
@@ -185,7 +185,7 @@ function loadConfig(configPath) {
 async function graphqlReadState(ticket, token) {
   const m = /^([A-Za-z][A-Za-z0-9_]*)-(\d+)$/.exec(ticket);
   if (!m) return null;
-  if (!token) throw new Error("LINEAR_API_TOKEN not set (required for --graphql)");
+  if (!token) throw new Error("LINEAR_API_TOKEN / LINEAR_API_KEY not set (required for --graphql)");
   const [, key, number] = m;
   const query = `query($n: Float!){ issues(filter:{ team:{ key:{ eq:"${key}" } }, number:{ eq:$n } }){ nodes{ state{ name } } } }`;
   const r = await fetch("https://api.linear.app/graphql", {
@@ -200,13 +200,13 @@ async function graphqlReadState(ticket, token) {
   return j?.data?.issues?.nodes?.[0]?.state?.name ?? null;
 }
 
-async function buildReadState(args) {
+export async function buildReadState(args) {
   if (args.statesFile) {
     const map = JSON.parse(readFileSync(args.statesFile, "utf8"));
     return async (t) => map[t] ?? null;
   }
   if (args.graphql) {
-    const token = process.env.LINEAR_API_TOKEN;
+    const token = process.env.LINEAR_API_TOKEN ?? process.env.LINEAR_API_KEY ?? "";
     return async (t) => graphqlReadState(t, token);
   }
   // cache (filter-state.db). broker-state.mjs imports bun:sqlite → under plain

--- a/plugins/dev/scripts/execution-core/linear-reconcile-cli.mjs
+++ b/plugins/dev/scripts/execution-core/linear-reconcile-cli.mjs
@@ -206,10 +206,12 @@ export async function buildReadState(args) {
     return async (t) => map[t] ?? null;
   }
   if (args.graphql) {
-    // Nonempty-string fallback (NOT `??`): a launch env that exports
-    // LINEAR_API_TOKEN='' would defeat `??` (empty string is not nullish),
-    // stranding the LINEAR_API_KEY fallback. `||` treats "" as absent.
-    const token = process.env.LINEAR_API_TOKEN || process.env.LINEAR_API_KEY || "";
+    // Nonblank fallback (NOT `??`): a launch env that exports an empty or
+    // whitespace-only LINEAR_API_TOKEN would defeat `??` (a non-nullish "" /
+    // "  " is selected), stranding the LINEAR_API_KEY fallback and sending a
+    // blank Authorization header. Trim each source and treat blank as absent.
+    const token =
+      (process.env.LINEAR_API_TOKEN || "").trim() || (process.env.LINEAR_API_KEY || "").trim();
     return async (t) => graphqlReadState(t, token);
   }
   // cache (filter-state.db). broker-state.mjs imports bun:sqlite → under plain

--- a/plugins/dev/scripts/execution-core/linear-reconcile-cli.mjs
+++ b/plugins/dev/scripts/execution-core/linear-reconcile-cli.mjs
@@ -206,7 +206,10 @@ export async function buildReadState(args) {
     return async (t) => map[t] ?? null;
   }
   if (args.graphql) {
-    const token = process.env.LINEAR_API_TOKEN ?? process.env.LINEAR_API_KEY ?? "";
+    // Nonempty-string fallback (NOT `??`): a launch env that exports
+    // LINEAR_API_TOKEN='' would defeat `??` (empty string is not nullish),
+    // stranding the LINEAR_API_KEY fallback. `||` treats "" as absent.
+    const token = process.env.LINEAR_API_TOKEN || process.env.LINEAR_API_KEY || "";
     return async (t) => graphqlReadState(t, token);
   }
   // cache (filter-state.db). broker-state.mjs imports bun:sqlite → under plain

--- a/plugins/dev/scripts/execution-core/linear-reconcile-cli.test.mjs
+++ b/plugins/dev/scripts/execution-core/linear-reconcile-cli.test.mjs
@@ -2,7 +2,7 @@ import { test, expect } from "bun:test";
 import { mkdtempSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { parseArgs, main, defaultCheckOpenPrs } from "./linear-reconcile-cli.mjs";
+import { parseArgs, main, defaultCheckOpenPrs, buildReadState } from "./linear-reconcile-cli.mjs";
 import { defaultDeriveAttachmentPrs } from "./open-pr-gate.mjs";
 import { readDeclaration, listDeclarations } from "./linear-reconcile-store.mjs";
 
@@ -796,4 +796,49 @@ test("ENUMERATOR (CTL-1157): an UNDERIVABLE repo is UNVERIFIABLE (never runs gh 
   expect(r.ok).toBe(false);
   expect(r.unverifiable).toBe(true);
   expect(r.reason).toBe("repo-underivable");
+});
+
+// CTL-1619: --graphql token fallback
+test("--graphql: buildReadState uses LINEAR_API_KEY when LINEAR_API_TOKEN is absent", async () => {
+  const savedToken = process.env.LINEAR_API_TOKEN;
+  const savedKey = process.env.LINEAR_API_KEY;
+  const savedFetch = globalThis.fetch;
+  let seenAuth = null;
+  try {
+    delete process.env.LINEAR_API_TOKEN;
+    process.env.LINEAR_API_KEY = "lin_api_fromkey";
+    globalThis.fetch = async (_url, opts) => {
+      seenAuth = opts.headers.Authorization;
+      return {
+        ok: true,
+        json: async () => ({ data: { issues: { nodes: [{ state: { name: "Done" } }] } } }),
+      };
+    };
+    const readState = await buildReadState({ graphql: true });
+    const state = await readState("CTL-1");
+    expect(state).toBe("Done");
+    expect(seenAuth).toBe("lin_api_fromkey");
+  } finally {
+    if (savedToken === undefined) delete process.env.LINEAR_API_TOKEN;
+    else process.env.LINEAR_API_TOKEN = savedToken;
+    if (savedKey === undefined) delete process.env.LINEAR_API_KEY;
+    else process.env.LINEAR_API_KEY = savedKey;
+    globalThis.fetch = savedFetch;
+  }
+});
+
+test("--graphql: buildReadState with neither var set throws naming both variables", async () => {
+  const savedToken = process.env.LINEAR_API_TOKEN;
+  const savedKey = process.env.LINEAR_API_KEY;
+  try {
+    delete process.env.LINEAR_API_TOKEN;
+    delete process.env.LINEAR_API_KEY;
+    const readState = await buildReadState({ graphql: true });
+    await expect(readState("CTL-1")).rejects.toThrow(/LINEAR_API_TOKEN \/ LINEAR_API_KEY not set/);
+  } finally {
+    if (savedToken === undefined) delete process.env.LINEAR_API_TOKEN;
+    else process.env.LINEAR_API_TOKEN = savedToken;
+    if (savedKey === undefined) delete process.env.LINEAR_API_KEY;
+    else process.env.LINEAR_API_KEY = savedKey;
+  }
 });

--- a/plugins/dev/scripts/execution-core/linear-reconcile-cli.test.mjs
+++ b/plugins/dev/scripts/execution-core/linear-reconcile-cli.test.mjs
@@ -827,15 +827,20 @@ test("--graphql: buildReadState uses LINEAR_API_KEY when LINEAR_API_TOKEN is abs
   }
 });
 
-test("--graphql: buildReadState falls back to LINEAR_API_KEY when LINEAR_API_TOKEN is empty", async () => {
-  // CTL-1619 / Codex P2: an exported-but-empty LINEAR_API_TOKEN='' must not
-  // defeat the LINEAR_API_KEY fallback (the `??`→`||` fix).
+test.each([
+  ["empty", ""],
+  ["whitespace-only", "   "],
+])(
+  "--graphql: buildReadState falls back to LINEAR_API_KEY when LINEAR_API_TOKEN is %s",
+  async (_label, blankToken) => {
+  // CTL-1619 / Codex: a blank (empty OR whitespace-only) LINEAR_API_TOKEN must
+  // not defeat the LINEAR_API_KEY fallback (the `??`→trimmed-`||` fix).
   const savedToken = process.env.LINEAR_API_TOKEN;
   const savedKey = process.env.LINEAR_API_KEY;
   const savedFetch = globalThis.fetch;
   let seenAuth = null;
   try {
-    process.env.LINEAR_API_TOKEN = "";
+    process.env.LINEAR_API_TOKEN = blankToken;
     process.env.LINEAR_API_KEY = "lin_api_fromkey";
     globalThis.fetch = async (_url, opts) => {
       seenAuth = opts.headers.Authorization;

--- a/plugins/dev/scripts/execution-core/linear-reconcile-cli.test.mjs
+++ b/plugins/dev/scripts/execution-core/linear-reconcile-cli.test.mjs
@@ -827,6 +827,36 @@ test("--graphql: buildReadState uses LINEAR_API_KEY when LINEAR_API_TOKEN is abs
   }
 });
 
+test("--graphql: buildReadState falls back to LINEAR_API_KEY when LINEAR_API_TOKEN is empty", async () => {
+  // CTL-1619 / Codex P2: an exported-but-empty LINEAR_API_TOKEN='' must not
+  // defeat the LINEAR_API_KEY fallback (the `??`→`||` fix).
+  const savedToken = process.env.LINEAR_API_TOKEN;
+  const savedKey = process.env.LINEAR_API_KEY;
+  const savedFetch = globalThis.fetch;
+  let seenAuth = null;
+  try {
+    process.env.LINEAR_API_TOKEN = "";
+    process.env.LINEAR_API_KEY = "lin_api_fromkey";
+    globalThis.fetch = async (_url, opts) => {
+      seenAuth = opts.headers.Authorization;
+      return {
+        ok: true,
+        json: async () => ({ data: { issues: { nodes: [{ state: { name: "Done" } }] } } }),
+      };
+    };
+    const readState = await buildReadState({ graphql: true });
+    const state = await readState("CTL-1");
+    expect(state).toBe("Done");
+    expect(seenAuth).toBe("lin_api_fromkey");
+  } finally {
+    if (savedToken === undefined) delete process.env.LINEAR_API_TOKEN;
+    else process.env.LINEAR_API_TOKEN = savedToken;
+    if (savedKey === undefined) delete process.env.LINEAR_API_KEY;
+    else process.env.LINEAR_API_KEY = savedKey;
+    globalThis.fetch = savedFetch;
+  }
+});
+
 test("--graphql: buildReadState with neither var set throws naming both variables", async () => {
   const savedToken = process.env.LINEAR_API_TOKEN;
   const savedKey = process.env.LINEAR_API_KEY;


### PR DESCRIPTION
<!-- Auto-generated: 2026-08-03T01:38:00Z -->
<!-- Last updated: 2026-08-03T01:38:00Z -->
<!-- PR: #2893 -->
<!-- Previous commits: 5184c076ba471173a71bdfaeef327bbb0279516d -->

## Summary

Fixes the `--graphql` mode of `linear-reconcile-cli` to accept `LINEAR_API_KEY` as a fallback when `LINEAR_API_TOKEN` is absent. Before this fix, the `--graphql` seam was the only token-reading site in the codebase that ignored the canonical two-variable fallback, causing "not set" errors on hosts that export their Linear token as `LINEAR_API_KEY`.

## Changes Made

### Execution Core — `linear-reconcile-cli.mjs`

- **Token fallback**: Changed `process.env.LINEAR_API_TOKEN` to `process.env.LINEAR_API_TOKEN ?? process.env.LINEAR_API_KEY ?? ""` at the `buildReadState` call site (line 209), matching the pattern used at all 9 other token-reading sites in the codebase (`cluster-claim.mjs`, `cluster-heartbeat.mjs`, `linear-estimation-method.mjs`, `linear-query.mjs`, `doctor.mjs`, `linear-estimate-fallback.mjs`, `linear-title-description-fallback.mjs`).
- **Error message**: Updated the "not set" error message to name both variables: `LINEAR_API_TOKEN / LINEAR_API_KEY not set (required for --graphql)`.
- **Help text**: Updated `--graphql` flag description from `($LINEAR_API_TOKEN)` to `($LINEAR_API_TOKEN / $LINEAR_API_KEY)`.
- **Export**: Exported `buildReadState` so it can be imported by tests without requiring live API calls.

### Tests — `linear-reconcile-cli.test.mjs`

- Added import of `buildReadState` alongside the existing exports.
- **New test**: `--graphql: buildReadState uses LINEAR_API_KEY when LINEAR_API_TOKEN is absent` — verifies that a host exporting only `LINEAR_API_KEY` gets a working reconcile (correct `Authorization` header sent).
- **New test**: `--graphql: buildReadState with neither var set throws naming both variables` — verifies the error message contains `LINEAR_API_TOKEN / LINEAR_API_KEY`.

## How to Verify It

- [x] `bun test plugins/dev/scripts/execution-core/linear-reconcile-cli.test.mjs` — all tests pass including the two new CTL-1619 tests ✅
- [ ] On a host with `LINEAR_API_KEY` set and `LINEAR_API_TOKEN` absent: `linear-reconcile-cli --graphql` authenticates successfully
- [ ] On a host with neither variable set: error message names both `LINEAR_API_TOKEN / LINEAR_API_KEY`

## Related Issues/PRs

- Fixes https://linear.app/coalesce/issue/CTL-1619