### PR TITLE
CTL-1618: Doctor should report the webhook secret the way the running monitor actually reads it

### DIFF
--- a/plugins/dev/scripts/execution-core/doctor.mjs
+++ b/plugins/dev/scripts/execution-core/doctor.mjs
@@ -977,9 +977,15 @@ export function checkWebhookIngestion(deps = {}) {
   // the CTL-1612 projection lifts the on-disk `webhook-secret` file into the
   // DEFAULT name only, so the file is a valid proxy solely for the default. CTL-1618.
   const ghSmee = typeof m.github?.smeeChannel === "string" ? m.github.smeeChannel : "";
+  // Resolve the env secret with the SAME `??` chain as the runtime
+  // (webhook-config.ts:429): `process.env[name] ?? CATALYST_SMEE_SECRET ?? ""`.
+  // `??` (not `||`) matters — an env var explicitly set to "" is NOT nullish, so
+  // it short-circuits and the legacy CATALYST_SMEE_SECRET fallback is NOT reached,
+  // exactly as the monitor computes it. A prior `||`-of-length chain would let an
+  // empty primary fall through to a set SMEE secret and falsely report the route
+  // wired when the runtime disables it (secret.length === 0). CTL-1618.
   const ghEnvSecret =
-    (process.env[githubSecretEnvName] ?? "").length > 0 ||
-    (process.env.CATALYST_SMEE_SECRET ?? "").length > 0;
+    (process.env[githubSecretEnvName] ?? process.env.CATALYST_SMEE_SECRET ?? "").length > 0;
   const ghFileSecret =
     githubSecretEnvName === "CATALYST_WEBHOOK_SECRET" &&
     secretFileNonEmpty(configDir, "webhook-secret");
@@ -997,15 +1003,21 @@ export function checkWebhookIngestion(deps = {}) {
       typeof e.webhookId === "string" && e.webhookId.length > 0
     );
   });
-  // Linear per-key secret resolved as webhook-config.ts:157-171 does:
-  // file → per-key env (linearWebhookSecretEnv) → global CATALYST_LINEAR_WEBHOOK_SECRET. CTL-1618.
+  // Linear per-key secret resolved as webhook-config.ts:157-171 does: file →
+  // per-key env (linearWebhookSecretEnv) → global CATALYST_LINEAR_WEBHOOK_SECRET.
+  // The env leg uses the runtime's exact `??` chain, so an empty-string per-key
+  // env var short-circuits (does NOT fall through to the global) — matching
+  // resolveSecret, which returns "" and drops the key. CTL-1618.
   const keySecretWired = (k) =>
     secretFileNonEmpty(
       configDir,
       k === "workspace" ? "linear-webhook-secret" : `linear-webhook-secret-${k}`,
     ) ||
-    (linearSecretEnvName !== null && (process.env[linearSecretEnvName] ?? "").length > 0) ||
-    (process.env.CATALYST_LINEAR_WEBHOOK_SECRET ?? "").length > 0;
+    (
+      (linearSecretEnvName !== null ? process.env[linearSecretEnvName] : undefined) ??
+      process.env.CATALYST_LINEAR_WEBHOOK_SECRET ??
+      ""
+    ).length > 0;
   const wiredKeys = webhookKeys.filter(keySecretWired);
   const danglingKeys = webhookKeys.filter((k) => !keySecretWired(k));
   const linearWired = linSmee.length > 0 && wiredKeys.length > 0;

--- a/plugins/dev/scripts/execution-core/doctor.mjs
+++ b/plugins/dev/scripts/execution-core/doctor.mjs
@@ -922,12 +922,26 @@ function defaultSecretFileNonEmpty(dir, name) {
   }
 }
 
+// Reads the configurable GitHub webhook-secret env-var NAME from Layer-1
+// (.catalyst/config.json → catalyst.monitor.github.webhookSecretEnv), matching
+// webhook-config.ts:412. Defaults to CATALYST_WEBHOOK_SECRET. CTL-1618.
+function defaultGithubSecretEnvName() {
+  try {
+    const obj = JSON.parse(readFileSync(layer1Path(), "utf8"));
+    const name = obj?.catalyst?.monitor?.github?.webhookSecretEnv;
+    return typeof name === "string" && name.length > 0 ? name : "CATALYST_WEBHOOK_SECRET";
+  } catch {
+    return "CATALYST_WEBHOOK_SECRET";
+  }
+}
+
 export function checkWebhookIngestion(deps = {}) {
   const {
     resolveRoster = resolveClusterHosts,
     monitor = defaultReadMonitor(),
     configDir = defaultWebhookConfigDir(),
     secretFileNonEmpty = defaultSecretFileNonEmpty,
+    githubSecretEnvName = defaultGithubSecretEnvName(), // CTL-1618
   } = deps;
 
   const roster = resolveRoster();
@@ -943,11 +957,19 @@ export function checkWebhookIngestion(deps = {}) {
 
   const m = monitor ?? {};
 
-  // GitHub route: smee channel + a github HMAC secret (file or env).
+  // GitHub route: smee channel + a github HMAC secret resolved the way the
+  // running monitor reads it (webhook-config.ts:412,429). The env-var NAME is
+  // configurable (Layer-1 webhookSecretEnv, default CATALYST_WEBHOOK_SECRET);
+  // the CTL-1612 projection lifts the on-disk `webhook-secret` file into the
+  // DEFAULT name only, so the file is a valid proxy solely for the default. CTL-1618.
   const ghSmee = typeof m.github?.smeeChannel === "string" ? m.github.smeeChannel : "";
-  const ghSecret =
-    secretFileNonEmpty(configDir, "webhook-secret") ||
-    (process.env.CATALYST_WEBHOOK_SECRET ?? "").length > 0;
+  const ghEnvSecret =
+    (process.env[githubSecretEnvName] ?? "").length > 0 ||
+    (process.env.CATALYST_SMEE_SECRET ?? "").length > 0;
+  const ghFileSecret =
+    githubSecretEnvName === "CATALYST_WEBHOOK_SECRET" &&
+    secretFileNonEmpty(configDir, "webhook-secret");
+  const ghSecret = ghEnvSecret || ghFileSecret;
   const githubWired = ghSmee.length > 0 && ghSecret;
 
   // Linear route: smee channel + ≥1 keyed webhookId whose HMAC secret resolves.

--- a/plugins/dev/scripts/execution-core/doctor.mjs
+++ b/plugins/dev/scripts/execution-core/doctor.mjs
@@ -925,9 +925,14 @@ function defaultSecretFileNonEmpty(dir, name) {
 // Reads the configurable GitHub webhook-secret env-var NAME from Layer-1
 // (.catalyst/config.json → catalyst.monitor.github.webhookSecretEnv), matching
 // webhook-config.ts:412. Defaults to CATALYST_WEBHOOK_SECRET. CTL-1618.
+// Resolve the Layer-1 path via resolveDoctorLayer1Path() (not layer1Path()) so
+// this reader honors the CATALYST_CONFIG_FILE / CATALYST_CONFIG_PATH pointers the
+// daemon/deploy sets and falls back to ${cwd}/.catalyst/config.json — the SAME
+// Layer-1 the running monitor resolves, so the env name matches at runtime
+// (Codex P1: a plugin-repo read diverges from the active project config).
 function defaultGithubSecretEnvName() {
   try {
-    const obj = JSON.parse(readFileSync(layer1Path(), "utf8"));
+    const obj = JSON.parse(readFileSync(resolveDoctorLayer1Path(), "utf8"));
     const name = obj?.catalyst?.monitor?.github?.webhookSecretEnv;
     return typeof name === "string" && name.length > 0 ? name : "CATALYST_WEBHOOK_SECRET";
   } catch {
@@ -938,9 +943,11 @@ function defaultGithubSecretEnvName() {
 // Reads the configurable Linear webhook-secret env-var NAME from Layer-1
 // (.catalyst/config.json → catalyst.monitor.linear.webhookSecretEnv), matching
 // webhook-config.ts:264-269. Null when unset (no per-key env override). CTL-1618.
+// Uses resolveDoctorLayer1Path() (not layer1Path()) for the same monitor-parity
+// reason as defaultGithubSecretEnvName above (Codex P1).
 function defaultLinearSecretEnvName() {
   try {
-    const obj = JSON.parse(readFileSync(layer1Path(), "utf8"));
+    const obj = JSON.parse(readFileSync(resolveDoctorLayer1Path(), "utf8"));
     const name = obj?.catalyst?.monitor?.linear?.webhookSecretEnv;
     return typeof name === "string" && name.length > 0 ? name : null;
   } catch {

--- a/plugins/dev/scripts/execution-core/doctor.mjs
+++ b/plugins/dev/scripts/execution-core/doctor.mjs
@@ -935,6 +935,19 @@ function defaultGithubSecretEnvName() {
   }
 }
 
+// Reads the configurable Linear webhook-secret env-var NAME from Layer-1
+// (.catalyst/config.json → catalyst.monitor.linear.webhookSecretEnv), matching
+// webhook-config.ts:264-269. Null when unset (no per-key env override). CTL-1618.
+function defaultLinearSecretEnvName() {
+  try {
+    const obj = JSON.parse(readFileSync(layer1Path(), "utf8"));
+    const name = obj?.catalyst?.monitor?.linear?.webhookSecretEnv;
+    return typeof name === "string" && name.length > 0 ? name : null;
+  } catch {
+    return null;
+  }
+}
+
 export function checkWebhookIngestion(deps = {}) {
   const {
     resolveRoster = resolveClusterHosts,
@@ -942,6 +955,7 @@ export function checkWebhookIngestion(deps = {}) {
     configDir = defaultWebhookConfigDir(),
     secretFileNonEmpty = defaultSecretFileNonEmpty,
     githubSecretEnvName = defaultGithubSecretEnvName(), // CTL-1618
+    linearSecretEnvName = defaultLinearSecretEnvName(), // CTL-1618
   } = deps;
 
   const roster = resolveRoster();
@@ -983,11 +997,15 @@ export function checkWebhookIngestion(deps = {}) {
       typeof e.webhookId === "string" && e.webhookId.length > 0
     );
   });
+  // Linear per-key secret resolved as webhook-config.ts:157-171 does:
+  // file → per-key env (linearWebhookSecretEnv) → global CATALYST_LINEAR_WEBHOOK_SECRET. CTL-1618.
   const keySecretWired = (k) =>
     secretFileNonEmpty(
       configDir,
       k === "workspace" ? "linear-webhook-secret" : `linear-webhook-secret-${k}`,
-    ) || (process.env.CATALYST_LINEAR_WEBHOOK_SECRET ?? "").length > 0;
+    ) ||
+    (linearSecretEnvName !== null && (process.env[linearSecretEnvName] ?? "").length > 0) ||
+    (process.env.CATALYST_LINEAR_WEBHOOK_SECRET ?? "").length > 0;
   const wiredKeys = webhookKeys.filter(keySecretWired);
   const danglingKeys = webhookKeys.filter((k) => !keySecretWired(k));
   const linearWired = linSmee.length > 0 && wiredKeys.length > 0;

--- a/plugins/dev/scripts/execution-core/doctor.test.mjs
+++ b/plugins/dev/scripts/execution-core/doctor.test.mjs
@@ -714,6 +714,23 @@ describe("checkWebhookIngestion", () => {
     expect(checks[0].status).toBe(STATUS.PASS);
   });
 
+  it("GitHub: custom webhookSecretEnv set to EMPTY string, CATALYST_SMEE_SECRET set → FAIL (?? parity: empty primary does NOT fall through)", () => {
+    // Runtime webhook-config.ts:429 is `process.env[name] ?? CATALYST_SMEE_SECRET ?? ""`.
+    // An empty (but defined) primary is not nullish, so `??` short-circuits to "" and
+    // the route is DISABLED (secret.length === 0) — the SMEE fallback is never reached.
+    // A `||`-of-length chain would wrongly pick up SMEE and false-PASS here.
+    process.env.GH_WH_CUSTOM = ""; // explicitly empty
+    process.env.CATALYST_SMEE_SECRET = "legacy-hmac";
+    const checks = checkWebhookIngestion({
+      resolveRoster: multiHost,
+      monitor: { github: { smeeChannel: "https://smee.io/GH" }, linear: {} },
+      githubSecretEnvName: "GH_WH_CUSTOM",
+      secretFileNonEmpty: noSecrets,
+    });
+    expect(checks[0].status).toBe(STATUS.FAIL);
+    expect(checks[0].detail).toContain("NO webhook route");
+  });
+
   it("PASSes a multiHost node with a keyed Linear route fully wired", () => {
     const checks = checkWebhookIngestion({
       resolveRoster: multiHost,
@@ -760,6 +777,27 @@ describe("checkWebhookIngestion", () => {
       secretFileNonEmpty: noSecrets,
     });
     expect(checks[0].status).toBe(STATUS.PASS);
+  });
+
+  it("Linear: per-key env set to EMPTY string, no global → FAIL half-wired (?? parity: empty per-key does NOT fall through)", () => {
+    // resolveSecret (webhook-config.ts:157-171) is
+    // `(perKeyEnv) ?? CATALYST_LINEAR_WEBHOOK_SECRET ?? ""`. An empty (defined)
+    // per-key var short-circuits to "" and the key is dropped — the global is
+    // never reached. Here there is no global either, so the key is dangling.
+    process.env.LIN_WH_CUSTOM = ""; // explicitly empty
+    const checks = checkWebhookIngestion({
+      resolveRoster: multiHost,
+      monitor: {
+        github: { smeeChannel: "https://smee.io/GH" }, // github wired so failure is the dangling key
+        linear: { smeeChannel: "https://smee.io/LIN", ctl: { webhookId: "wh-ctl" } },
+      },
+      githubSecretEnvName: "CATALYST_WEBHOOK_SECRET",
+      linearSecretEnvName: "LIN_WH_CUSTOM",
+      secretFileNonEmpty: (_dir, name) => name === "webhook-secret", // github ok, ctl absent everywhere
+    });
+    expect(checks[0].status).toBe(STATUS.FAIL);
+    expect(checks[0].detail).toContain("half-wired");
+    expect(checks[0].detail).toContain("ctl");
   });
 
   it("Linear: no file, per-key env name configured but unset, no global → FAIL half-wired", () => {

--- a/plugins/dev/scripts/execution-core/doctor.test.mjs
+++ b/plugins/dev/scripts/execution-core/doctor.test.mjs
@@ -622,6 +622,13 @@ describe("checkWebhookIngestion", () => {
     "CATALYST_SMEE_SECRET",
     "GH_WH_CUSTOM", // custom github env name used in tests below
     "LIN_WH_CUSTOM", // custom linear env name used in Phase 2 tests
+    // Layer-1 config pointers: the default env-name readers now resolve via
+    // resolveDoctorLayer1Path() (CTL-1618 Codex P1), which honors these. A test
+    // runner that inherits them pointing at a project with custom webhookSecretEnv
+    // names would otherwise make the cases that omit githubSecretEnvName/
+    // linearSecretEnvName environment-dependent (Codex P2). Clear both here.
+    "CATALYST_CONFIG_FILE",
+    "CATALYST_CONFIG_PATH",
   ];
   let savedEnv = {};
   beforeEach(() => {

--- a/plugins/dev/scripts/execution-core/doctor.test.mjs
+++ b/plugins/dev/scripts/execution-core/doctor.test.mjs
@@ -616,7 +616,13 @@ describe("checkDaemonToolPath", () => {
 describe("checkWebhookIngestion", () => {
   // Isolate the env-var secret fallbacks the check honors (matching
   // webhook-config.ts) so a dev shell with these set can't mask a dangling key.
-  const SECRET_ENVS = ["CATALYST_WEBHOOK_SECRET", "CATALYST_LINEAR_WEBHOOK_SECRET"];
+  const SECRET_ENVS = [
+    "CATALYST_WEBHOOK_SECRET",
+    "CATALYST_LINEAR_WEBHOOK_SECRET",
+    "CATALYST_SMEE_SECRET",
+    "GH_WH_CUSTOM", // custom github env name used in tests below
+    "LIN_WH_CUSTOM", // custom linear env name used in Phase 2 tests
+  ];
   let savedEnv = {};
   beforeEach(() => {
     for (const k of SECRET_ENVS) { savedEnv[k] = process.env[k]; delete process.env[k]; }
@@ -658,6 +664,51 @@ describe("checkWebhookIngestion", () => {
     const checks = checkWebhookIngestion({
       resolveRoster: multiHost,
       monitor: { github: { smeeChannel: "https://smee.io/GH" } },
+      secretFileNonEmpty: (_dir, name) => name === "webhook-secret",
+    });
+    expect(checks[0].status).toBe(STATUS.PASS);
+  });
+
+  it("GitHub: custom webhookSecretEnv with ONLY the on-disk file present → FAIL (file not projected into a custom name)", () => {
+    // Runtime reads process.env['GH_WH_CUSTOM']; the projection only exports the
+    // default CATALYST_WEBHOOK_SECRET, so the file is NOT a valid proxy here.
+    const checks = checkWebhookIngestion({
+      resolveRoster: multiHost,
+      monitor: { github: { smeeChannel: "https://smee.io/GH" }, linear: {} },
+      githubSecretEnvName: "GH_WH_CUSTOM",
+      secretFileNonEmpty: (_dir, name) => name === "webhook-secret",
+    });
+    expect(checks[0].status).toBe(STATUS.FAIL);
+    expect(checks[0].detail).toContain("NO webhook route");
+  });
+
+  it("GitHub: custom webhookSecretEnv whose env var IS set → PASS (doctor reads the configured name)", () => {
+    process.env.GH_WH_CUSTOM = "hmac-value";
+    const checks = checkWebhookIngestion({
+      resolveRoster: multiHost,
+      monitor: { github: { smeeChannel: "https://smee.io/GH" }, linear: {} },
+      githubSecretEnvName: "GH_WH_CUSTOM",
+      secretFileNonEmpty: noSecrets,
+    });
+    expect(checks[0].status).toBe(STATUS.PASS);
+  });
+
+  it("GitHub: CATALYST_SMEE_SECRET legacy fallback set (no file, default name unset) → PASS", () => {
+    process.env.CATALYST_SMEE_SECRET = "legacy-hmac";
+    const checks = checkWebhookIngestion({
+      resolveRoster: multiHost,
+      monitor: { github: { smeeChannel: "https://smee.io/GH" }, linear: {} },
+      githubSecretEnvName: "CATALYST_WEBHOOK_SECRET",
+      secretFileNonEmpty: noSecrets,
+    });
+    expect(checks[0].status).toBe(STATUS.PASS);
+  });
+
+  it("GitHub: default name + on-disk file present → PASS (regression guard — projection wires the default)", () => {
+    const checks = checkWebhookIngestion({
+      resolveRoster: multiHost,
+      monitor: { github: { smeeChannel: "https://smee.io/GH" }, linear: {} },
+      githubSecretEnvName: "CATALYST_WEBHOOK_SECRET",
       secretFileNonEmpty: (_dir, name) => name === "webhook-secret",
     });
     expect(checks[0].status).toBe(STATUS.PASS);

--- a/plugins/dev/scripts/execution-core/doctor.test.mjs
+++ b/plugins/dev/scripts/execution-core/doctor.test.mjs
@@ -739,6 +739,45 @@ describe("checkWebhookIngestion", () => {
     expect(checks[0].detail).toContain("ctl");
   });
 
+  it("Linear: keyed webhook wired purely via per-key linearWebhookSecretEnv env var → PASS", () => {
+    process.env.LIN_WH_CUSTOM = "lin-hmac";
+    const checks = checkWebhookIngestion({
+      resolveRoster: multiHost,
+      monitor: { linear: { smeeChannel: "https://smee.io/LIN", ctl: { webhookId: "wh-ctl" } } },
+      linearSecretEnvName: "LIN_WH_CUSTOM",
+      secretFileNonEmpty: noSecrets, // no file, no global CATALYST_LINEAR_WEBHOOK_SECRET
+    });
+    expect(checks[0].status).toBe(STATUS.PASS);
+    expect(checks[0].detail).toContain("linear keys=1");
+  });
+
+  it("Linear: per-key env name configured but empty, global CATALYST_LINEAR_WEBHOOK_SECRET set → PASS", () => {
+    process.env.CATALYST_LINEAR_WEBHOOK_SECRET = "global-hmac";
+    const checks = checkWebhookIngestion({
+      resolveRoster: multiHost,
+      monitor: { linear: { smeeChannel: "https://smee.io/LIN", ctl: { webhookId: "wh-ctl" } } },
+      linearSecretEnvName: "LIN_WH_CUSTOM", // set as a name, but the var itself is unset
+      secretFileNonEmpty: noSecrets,
+    });
+    expect(checks[0].status).toBe(STATUS.PASS);
+  });
+
+  it("Linear: no file, per-key env name configured but unset, no global → FAIL half-wired", () => {
+    const checks = checkWebhookIngestion({
+      resolveRoster: multiHost,
+      monitor: {
+        github: { smeeChannel: "https://smee.io/GH" }, // github wired so failure is the dangling key
+        linear: { smeeChannel: "https://smee.io/LIN", ctl: { webhookId: "wh-ctl" } },
+      },
+      githubSecretEnvName: "CATALYST_WEBHOOK_SECRET",
+      linearSecretEnvName: "LIN_WH_CUSTOM",
+      secretFileNonEmpty: (_dir, name) => name === "webhook-secret", // github ok, ctl absent everywhere
+    });
+    expect(checks[0].status).toBe(STATUS.FAIL);
+    expect(checks[0].detail).toContain("half-wired");
+    expect(checks[0].detail).toContain("ctl");
+  });
+
   it("PASSes when all routes and keyed secrets resolve", () => {
     const checks = checkWebhookIngestion({
       resolveRoster: multiHost,


### PR DESCRIPTION
<!-- Auto-generated: 2026-08-03T01:58:58Z -->
<!-- Last updated: 2026-08-03T01:58:58Z -->
<!-- PR: #2894 -->
<!-- Previous commits: 990a07f7,f5b5ca09,bd24d6ec -->

## Summary

Makes the execution-core `doctor` webhook-ingestion check resolve the webhook HMAC secret **the same way the running monitor actually reads it**, closing a set of false PASS/FAIL discrepancies between what `doctor` reports and what `webhook-config.ts` computes at runtime.

Previously `checkWebhookIngestion` hard-coded the default env-var names (`CATALYST_WEBHOOK_SECRET`, `CATALYST_LINEAR_WEBHOOK_SECRET`) and used a `||`-of-length secret chain. That diverged from the runtime in three ways, so `doctor` could report a route wired that the monitor has disabled (or vice-versa). This PR brings all three into parity.

## Changes Made

### `doctor.mjs`

- **GitHub webhook-secret resolver parity.** Added `defaultGithubSecretEnvName()`, which reads the configurable env-var **name** from Layer-1 `.catalyst/config.json → catalyst.monitor.github.webhookSecretEnv` (matching `webhook-config.ts:412`), defaulting to `CATALYST_WEBHOOK_SECRET`. The GitHub secret is now resolved via that configured name. The on-disk `webhook-secret` file counts as a valid proxy **only** for the default name, because the CTL-1612 projection lifts the file into the default env var only — a custom `webhookSecretEnv` with just the file present now correctly FAILs.
- **Linear per-key `webhookSecretEnv` parity.** Added `defaultLinearSecretEnvName()` (Layer-1 `catalyst.monitor.linear.webhookSecretEnv`, matching `webhook-config.ts:264-269`, null when unset). Per-key secret resolution now honors that configured per-key env name before falling back to the global `CATALYST_LINEAR_WEBHOOK_SECRET`.
- **Empty-string `??` parity.** Both resolvers now use the runtime's exact **`??`** chain (`process.env[name] ?? <fallback> ?? ""`) instead of a `||`-of-length chain. This matters because an env var explicitly set to `""` is **not** nullish: `??` short-circuits to `""` and the route is treated as disabled — exactly as the monitor computes it. The old `||` chain would let an empty primary fall through to a set legacy `CATALYST_SMEE_SECRET` (GitHub) or global (Linear) and **false-PASS** a route the runtime has turned off.
- Both env-var-name resolvers are exposed as injectable `deps` (`githubSecretEnvName`, `linearSecretEnvName`) so tests drive them deterministically.

### `doctor.test.mjs`

- Extended the env-isolation list with `CATALYST_SMEE_SECRET` plus the custom test names `GH_WH_CUSTOM` / `LIN_WH_CUSTOM` so a dev shell can't mask results.
- Added coverage for: custom GitHub `webhookSecretEnv` with only the file present (FAIL), custom name whose env var is set (PASS), the legacy `CATALYST_SMEE_SECRET` fallback (PASS), default-name + file regression guard (PASS), and the empty-string `??` short-circuit (FAIL).
- Added Linear coverage for: per-key env var wired (PASS), empty per-key name + global set (PASS), empty per-key env with no global (FAIL half-wired), and configured-but-unset per-key name with no global (FAIL half-wired).

## How to Verify It

- [x] Unit tests pass: `bun test plugins/dev/scripts/execution-core/doctor.test.mjs` — 273 pass / 0 fail (652 expect() calls)

## Changelog Entry

`doctor`'s webhook-ingestion check now resolves the GitHub and Linear webhook secrets using the same configurable env-var names and `??` fallback chain as the running monitor, eliminating false PASS/FAIL reports (including the empty-string edge case).

## Related Issues/PRs

- Fixes https://linear.app/coalesce/issue/CTL-1618

<!-- Linear automation guard (CTL-623/CTL-633): unlink sibling tickets so this PR does not drag their workflow status. -->
skip CTL-1612
