### PR TITLE
feat(dev): CTL-1617 deployment-mode resolver in isolation (PR1 of 7)

### DIFF
--- a/.github/workflows/execution-core-tests.yml
+++ b/.github/workflows/execution-core-tests.yml
@@ -257,6 +257,35 @@ jobs:
         working-directory: plugins/dev/scripts
         run: bash __tests__/migrate-dual-harness.test.sh
 
+      - name: deployment-mode resolver unit tests (bun, CTL-1617)
+        # Codex remediation: neither of the three deployment-mode suites was
+        # named anywhere in this workflow (nor any other), so required CI
+        # stayed green without ever exercising lib/deployment-mode.mjs, its
+        # Bash mirror, or their cross-stack agreement. This is the JS-side
+        # unit suite (resolveDeploymentMode/getDeploymentMode's validity
+        # ladder, the injected-env isolation contract). Its own step because
+        # lib/deployment-mode.mjs is a deliberately ZERO-IMPORT leaf outside
+        # the execution-core/ tree the "Run stable unit tests" step below is
+        # scoped to.
+        working-directory: plugins/dev/scripts/lib
+        run: bun test deployment-mode.test.mjs
+
+      - name: deployment-mode Bash resolver unit test (CTL-1617)
+        # The Bash mirror's own standalone suite (lib/catalyst-deployment-mode.sh) —
+        # see the bun step above for why this suite was previously ungated.
+        working-directory: plugins/dev/scripts
+        run: bash __tests__/catalyst-deployment-mode.test.sh
+
+      - name: deployment-mode cross-stack parity test (CTL-1617)
+        # The fixture-matrix parity test asserting bash == node == the
+        # design-spec-computed expected value at every cell (168 fixture
+        # cells x 2 assertions, plus the dedicated divergence-pinning probes
+        # for the NUL-byte, NBSP-padding, malformed-trailing-content, and
+        # lone-surrogate hostile inputs). Needs jq, preinstalled on
+        # ubuntu-latest runners.
+        working-directory: plugins/dev/scripts
+        run: bash __tests__/deployment-mode-parity.test.sh
+
       - name: Broker worker-state projection test (CTL-1529)
         # CTL-1529 round 2: broker/worker-state-projection.test.mjs guards the
         # bounded event-log scan in broker/projection.mjs (replayWorkerStateProjection),

--- a/docs/schemas/catalyst-config.schema.json
+++ b/docs/schemas/catalyst-config.schema.json
@@ -562,6 +562,19 @@
             }
           }
         },
+        "deployment": {
+          "type": "object",
+          "description": "Fleet-topology declaration (CTL-1617). Unlike orchestration.dispatchMode (node-scoped, relocated to Layer-2 by CTL-1214), deployment mode is genuinely fleet-scoped, so it is a first-class Layer-1 field. A per-host Layer-2 catalyst.deployment.mode value wins over this when present (the exception hatch — e.g. a laptop dev-clone of a cluster-declared repo overriding to single-host).",
+          "additionalProperties": false,
+          "properties": {
+            "mode": {
+              "type": "string",
+              "enum": ["single-host", "cluster", "cloud"],
+              "default": "single-host",
+              "description": "Declares this fleet's deployment topology. 'single-host' (default) — a lone node, no cluster substrate expected. 'cluster' — a coordinated multi-host fleet; roster/HRW/liveness are graded by catalyst doctor. 'cloud' — a managed-container node; the smee webhook tunnel must NOT be live and secrets are platform-delivered. Resolution precedence: env CATALYST_DEPLOYMENT_MODE > Layer-2 catalyst.deployment.mode > this Layer-1 value > constant default 'single-host'. An unset key or an unrecognized value both degrade to 'single-host' (the safest direction) — see lib/deployment-mode.mjs for the full validity ladder."
+            }
+          }
+        },
         "feedback": {
           "type": "object",
           "deprecated": true,

--- a/docs/schemas/machine-config.schema.json
+++ b/docs/schemas/machine-config.schema.json
@@ -134,6 +134,18 @@
             }
           }
         },
+        "deployment": {
+          "type": "object",
+          "description": "Per-host deployment-mode override (CTL-1617). Deployment mode is declared fleet-wide in Layer-1 (.catalyst/config.json → catalyst.deployment.mode), but this per-host value wins over it when present — the exception hatch for a laptop dev-clone of a cluster-declared repo, or one cloud worker joining an otherwise-cluster fleet.",
+          "additionalProperties": false,
+          "properties": {
+            "mode": {
+              "type": "string",
+              "enum": ["single-host", "cluster", "cloud"],
+              "description": "Machine-level deployment-mode override (catalyst.deployment.mode). Wins over the Layer-1 value when present; resolution precedence overall is env CATALYST_DEPLOYMENT_MODE > this Layer-2 value > Layer-1 > constant default 'single-host'. An unrecognized value degrades to 'single-host' (the safest direction), never silently to 'cluster'/'cloud'."
+            }
+          }
+        },
         "orchestration": {
           "type": "object",
           "description": "Orchestration overrides. Concurrency fields here win per-field over Layer-1 values. Use this to tune concurrency per machine without modifying committed config.",

--- a/plugins/dev/scripts/__tests__/catalyst-deployment-mode.test.sh
+++ b/plugins/dev/scripts/__tests__/catalyst-deployment-mode.test.sh
@@ -50,7 +50,10 @@ MISSING="${TMP_DIR}/does-not-exist.json"
 expect_eq "idempotent-source guard set" "1" "${_CATALYST_DEPLOYMENT_MODE_SH_LOADED:-}"
 
 # --- frozen enum -----------------------------------------------------------
-expect_eq "enum is the 3 canonical values" "single-host cluster cloud" "$_CATALYST_DEPLOYMENT_MODES"
+# _CATALYST_DEPLOYMENT_MODES is an array (IFS-independent membership fix,
+# CTL-1617 Codex remediation) — join with "${arr[*]}", not a bare "$arr"
+# (which would only yield the first element).
+expect_eq "enum is the 3 canonical values" "single-host cluster cloud" "${_CATALYST_DEPLOYMENT_MODES[*]}"
 if _catalyst_deployment_mode_is_member "single-host" && _catalyst_deployment_mode_is_member "cluster" \
    && _catalyst_deployment_mode_is_member "cloud"; then
   ok "all three canonical values are members"
@@ -163,6 +166,15 @@ OUT="$(env -i PATH="$PATH" HOME="$HOME" CATALYST_DEPLOYMENT_MODE="cluster" \
   CATALYST_LAYER2_CONFIG_FILE="$MISSING" CATALYST_CONFIG_FILE="$MISSING" \
   bash -c "source '$LIB'; catalyst_resolve_deployment_mode >/dev/null; printf '%s' \"\$CATALYST_DEPLOYMENT_MODE_INFERRED\"")"
 expect_eq "inferred=false when env settles the question" "false" "$OUT"
+
+# --- F8: enum membership is independent of caller IFS -----------------------
+# A sourcing script running under strict-shell IFS=$'\n\t' (no space) must
+# not break membership: the enum lives in a bash array iterated as
+# "${arr[@]}", so no word-splitting is ever involved.
+OUT="$(env -i PATH="$PATH" HOME="$HOME" CATALYST_DEPLOYMENT_MODE="cluster" \
+  CATALYST_LAYER2_CONFIG_FILE="$MISSING" CATALYST_CONFIG_FILE="$MISSING" \
+  bash -c "IFS=\$'\n\t'; source '$LIB'; catalyst_resolve_deployment_mode >/dev/null; printf '%s|%s|%s' \"\$CATALYST_DEPLOYMENT_MODE_RESOLVED\" \"\$CATALYST_DEPLOYMENT_MODE_SOURCE\" \"\$CATALYST_DEPLOYMENT_MODE_RECOGNIZED\"")"
+expect_eq "IFS=\$'\\n\\t' in the sourcing shell cannot break enum membership" "cluster|env|true" "$OUT"
 
 echo ""
 echo "Total: $((PASSES + FAILURES)), Passed: $PASSES, Failed: $FAILURES"

--- a/plugins/dev/scripts/__tests__/catalyst-deployment-mode.test.sh
+++ b/plugins/dev/scripts/__tests__/catalyst-deployment-mode.test.sh
@@ -176,6 +176,59 @@ OUT="$(env -i PATH="$PATH" HOME="$HOME" CATALYST_DEPLOYMENT_MODE="cluster" \
   bash -c "IFS=\$'\n\t'; source '$LIB'; catalyst_resolve_deployment_mode >/dev/null; printf '%s|%s|%s' \"\$CATALYST_DEPLOYMENT_MODE_RESOLVED\" \"\$CATALYST_DEPLOYMENT_MODE_SOURCE\" \"\$CATALYST_DEPLOYMENT_MODE_RECOGNIZED\"")"
 expect_eq "IFS=\$'\\n\\t' in the sourcing shell cannot break enum membership" "cluster|env|true" "$OUT"
 
+# --- Codex round 2: errexit-inheritance safety ------------------------------
+# Under `bash --posix` (or shopt -s inherit_errexit) a nonzero jq inside $()
+# aborts the whole shell unless the capture runs in a condition context. A
+# readable-but-malformed Layer-2 with a valid Layer-1 must fall through and
+# exit 0 even under set -e + POSIX mode.
+R2_L2="${TMP_DIR}/r2-malformed-l2.json"
+R2_L1="${TMP_DIR}/r2-valid-l1.json"
+printf '%s' '{"catalyst":{"deployment":{"mode":' > "$R2_L2"
+printf '%s' '{"catalyst":{"deployment":{"mode":"cluster"}}}' > "$R2_L1"
+OUT="$(env -i PATH="$PATH" HOME="$HOME" CATALYST_LAYER2_CONFIG_FILE="$R2_L2" CATALYST_CONFIG_FILE="$R2_L1" \
+  bash --posix -e -c "source '$LIB'; catalyst_resolve_deployment_mode >/dev/null; printf '%s|%s|rc0' \"\$CATALYST_DEPLOYMENT_MODE_RESOLVED\" \"\$CATALYST_DEPLOYMENT_MODE_SOURCE\"")"
+expect_eq "set -e + POSIX mode: malformed Layer-2 falls through, never aborts" "cluster|layer1|rc0" "$OUT"
+
+# --- Codex round 2: multi-document JSON rejected like JSON.parse ------------
+# Two valid top-level documents: bare jq streams both (exit 0, two tags);
+# JSON.parse rejects the file. --slurp collapses it to length!=1 → @ABSENT.
+R2_MULTI="${TMP_DIR}/r2-multidoc-l2.json"
+printf '%s\n%s\n' '{"catalyst":{"deployment":{"mode":"cloud"}}}' '{"catalyst":{"deployment":{"mode":"cluster"}}}' > "$R2_MULTI"
+OUT="$(env -i PATH="$PATH" HOME="$HOME" CATALYST_LAYER2_CONFIG_FILE="$R2_MULTI" CATALYST_CONFIG_FILE="$R2_L1" \
+  bash -c "source '$LIB'; catalyst_resolve_deployment_mode >/dev/null; printf '%s|%s' \"\$CATALYST_DEPLOYMENT_MODE_RESOLVED\" \"\$CATALYST_DEPLOYMENT_MODE_SOURCE\"")"
+expect_eq "multi-document Layer-2 is layer-malformed → falls through" "cluster|layer1" "$OUT"
+
+# --- Codex round 2: BOM-prefixed JSON rejected like JSON.parse --------------
+R2_BOM="${TMP_DIR}/r2-bom-l2.json"
+printf '\xef\xbb\xbf%s' '{"catalyst":{"deployment":{"mode":"cloud"}}}' > "$R2_BOM"
+OUT="$(env -i PATH="$PATH" HOME="$HOME" CATALYST_LAYER2_CONFIG_FILE="$R2_BOM" CATALYST_CONFIG_FILE="$R2_L1" \
+  bash -c "source '$LIB'; catalyst_resolve_deployment_mode >/dev/null; printf '%s|%s' \"\$CATALYST_DEPLOYMENT_MODE_RESOLVED\" \"\$CATALYST_DEPLOYMENT_MODE_SOURCE\"")"
+expect_eq "BOM-prefixed Layer-2 is layer-malformed → falls through" "cluster|layer1" "$OUT"
+
+# --- Codex round 2: HOME-unset resolution never probes /.config -------------
+# With HOME unset the resolver must still complete (tilde expansion falls back
+# to the passwd home, mirroring os.homedir()) and settle a valid Layer-1.
+OUT="$(env -i PATH="$PATH" CATALYST_CONFIG_FILE="$R2_L1" \
+  bash -c "unset HOME; source '$LIB'; catalyst_resolve_deployment_mode >/dev/null; printf '%s|%s' \"\$CATALYST_DEPLOYMENT_MODE_RESOLVED\" \"\$CATALYST_DEPLOYMENT_MODE_SOURCE\"")"
+expect_eq "HOME unset: resolver completes via passwd-home fallback" "cluster|layer1" "$OUT"
+
+# --- Codex round 2: jq-missing breadcrumb resets per resolution -------------
+# First resolution with jq hidden and a readable file → breadcrumb=1; a second
+# resolution in the same shell with jq restored must CLEAR it (no stale latch).
+R2_STUB="${TMP_DIR}/r2-no-jq-bin"
+mkdir -p "$R2_STUB"
+for t in bash printf head od tr cat env; do
+  p="$(command -v "$t" 2>/dev/null)" && ln -sf "$p" "$R2_STUB/$t"
+done
+OUT="$(env -i PATH="$PATH" HOME="$HOME" CATALYST_LAYER2_CONFIG_FILE="$R2_L1" CATALYST_CONFIG_FILE="$MISSING" \
+  bash -c "source '$LIB'
+    PATH='$R2_STUB' catalyst_resolve_deployment_mode >/dev/null
+    first=\${CATALYST_DEPLOYMENT_MODE_JQ_MISSING:-unset}
+    catalyst_resolve_deployment_mode >/dev/null
+    second=\${CATALYST_DEPLOYMENT_MODE_JQ_MISSING:-unset}
+    printf '%s|%s' \"\$first\" \"\$second\"")"
+expect_eq "jq-missing breadcrumb is per-resolution, not a latch" "1|unset" "$OUT"
+
 echo ""
 echo "Total: $((PASSES + FAILURES)), Passed: $PASSES, Failed: $FAILURES"
 exit "$FAILURES"

--- a/plugins/dev/scripts/__tests__/catalyst-deployment-mode.test.sh
+++ b/plugins/dev/scripts/__tests__/catalyst-deployment-mode.test.sh
@@ -1,0 +1,169 @@
+#!/usr/bin/env bash
+# Shell unit tests for plugins/dev/scripts/lib/catalyst-deployment-mode.sh
+# (CTL-1617). Standalone per-language suite — cross-stack agreement with
+# lib/deployment-mode.mjs is covered separately by
+# __tests__/deployment-mode-parity.test.sh. Follows the __tests__/
+# host-identity.test.sh conventions (ok/fail/expect_eq, PASSES/FAILURES exit
+# code).
+#
+# Run: bash plugins/dev/scripts/__tests__/catalyst-deployment-mode.test.sh
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../../.." && pwd)"
+LIB="${REPO_ROOT}/plugins/dev/scripts/lib/catalyst-deployment-mode.sh"
+
+# shellcheck disable=SC1090
+source "$LIB"
+
+FAILURES=0
+PASSES=0
+
+ok() {
+  local name="$1"
+  PASSES=$((PASSES+1))
+  echo "  PASS: $name"
+}
+fail() {
+  local name="$1" detail="$2"
+  FAILURES=$((FAILURES+1))
+  echo "  FAIL: $name"
+  echo "    $detail"
+}
+expect_eq() {
+  local name="$1" expected="$2" actual="$3"
+  if [[ "$expected" == "$actual" ]]; then
+    ok "$name"
+  else
+    fail "$name" "expected '$expected' got '$actual'"
+  fi
+}
+
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+L2="${TMP_DIR}/layer2.json"
+L1="${TMP_DIR}/layer1.json"
+MISSING="${TMP_DIR}/does-not-exist.json"
+
+# --- idempotent-load guard ------------------------------------------------
+expect_eq "idempotent-source guard set" "1" "${_CATALYST_DEPLOYMENT_MODE_SH_LOADED:-}"
+
+# --- frozen enum -----------------------------------------------------------
+expect_eq "enum is the 3 canonical values" "single-host cluster cloud" "$_CATALYST_DEPLOYMENT_MODES"
+if _catalyst_deployment_mode_is_member "single-host" && _catalyst_deployment_mode_is_member "cluster" \
+   && _catalyst_deployment_mode_is_member "cloud"; then
+  ok "all three canonical values are members"
+else
+  fail "canonical membership" "one of single-host/cluster/cloud rejected"
+fi
+if _catalyst_deployment_mode_is_member "both"; then
+  fail "no fourth value" "'both' was accepted as a member"
+else
+  ok "'both' is deliberately not a member (CTL-1617 design §2)"
+fi
+
+# --- default: nothing set anywhere -----------------------------------------
+rm -f "$L2" "$L1"
+OUT="$(env -i PATH="$PATH" HOME="$HOME" CATALYST_LAYER2_CONFIG_FILE="$MISSING" CATALYST_CONFIG_FILE="$MISSING" \
+  bash -c "source '$LIB'; catalyst_resolve_deployment_mode >/dev/null; printf '%s|%s|%s' \"\$CATALYST_DEPLOYMENT_MODE_RESOLVED\" \"\$CATALYST_DEPLOYMENT_MODE_SOURCE\" \"\$CATALYST_DEPLOYMENT_MODE_RECOGNIZED\"")"
+expect_eq "nothing set ⇒ default/single-host/recognized" "single-host|default|true" "$OUT"
+
+# --- env wins over both files ------------------------------------------
+printf '%s' '{"catalyst":{"deployment":{"mode":"cloud"}}}' > "$L2"
+printf '%s' '{"catalyst":{"deployment":{"mode":"cluster"}}}' > "$L1"
+OUT="$(env -i PATH="$PATH" HOME="$HOME" CATALYST_DEPLOYMENT_MODE="cluster" \
+  CATALYST_LAYER2_CONFIG_FILE="$L2" CATALYST_CONFIG_FILE="$L1" \
+  bash -c "source '$LIB'; catalyst_resolve_deployment_mode >/dev/null; printf '%s|%s|%s' \"\$CATALYST_DEPLOYMENT_MODE_RESOLVED\" \"\$CATALYST_DEPLOYMENT_MODE_SOURCE\" \"\$CATALYST_DEPLOYMENT_MODE_RECOGNIZED\"")"
+expect_eq "env wins over Layer-2 and Layer-1" "cluster|env|true" "$OUT"
+
+# --- Layer-2 wins over Layer-1 when env absent -----------------------------
+OUT="$(env -i PATH="$PATH" HOME="$HOME" CATALYST_LAYER2_CONFIG_FILE="$L2" CATALYST_CONFIG_FILE="$L1" \
+  bash -c "source '$LIB'; catalyst_resolve_deployment_mode >/dev/null; printf '%s|%s|%s' \"\$CATALYST_DEPLOYMENT_MODE_RESOLVED\" \"\$CATALYST_DEPLOYMENT_MODE_SOURCE\" \"\$CATALYST_DEPLOYMENT_MODE_RECOGNIZED\"")"
+expect_eq "Layer-2 wins when env absent" "cloud|layer2|true" "$OUT"
+
+# --- Layer-1 wins when env + Layer-2 absent --------------------------------
+rm -f "$L2"
+OUT="$(env -i PATH="$PATH" HOME="$HOME" CATALYST_LAYER2_CONFIG_FILE="$MISSING" CATALYST_CONFIG_FILE="$L1" \
+  bash -c "source '$LIB'; catalyst_resolve_deployment_mode >/dev/null; printf '%s|%s|%s' \"\$CATALYST_DEPLOYMENT_MODE_RESOLVED\" \"\$CATALYST_DEPLOYMENT_MODE_SOURCE\" \"\$CATALYST_DEPLOYMENT_MODE_RECOGNIZED\"")"
+expect_eq "Layer-1 wins when env + Layer-2 absent" "cluster|layer1|true" "$OUT"
+
+# --- explicit JSON null at Layer-2 falls through to Layer-1 ---------------
+printf '%s' '{"catalyst":{"deployment":{"mode":null}}}' > "$L2"
+OUT="$(env -i PATH="$PATH" HOME="$HOME" CATALYST_LAYER2_CONFIG_FILE="$L2" CATALYST_CONFIG_FILE="$L1" \
+  bash -c "source '$LIB'; catalyst_resolve_deployment_mode >/dev/null; printf '%s|%s|%s' \"\$CATALYST_DEPLOYMENT_MODE_RESOLVED\" \"\$CATALYST_DEPLOYMENT_MODE_SOURCE\" \"\$CATALYST_DEPLOYMENT_MODE_RECOGNIZED\"")"
+expect_eq "explicit null at Layer-2 falls through to Layer-1" "cluster|layer1|true" "$OUT"
+
+# --- unrecognized (typo) degrades AT that layer, does not fall through ----
+printf '%s' '{"catalyst":{"deployment":{"mode":"clustre"}}}' > "$L2"
+OUT="$(env -i PATH="$PATH" HOME="$HOME" CATALYST_LAYER2_CONFIG_FILE="$L2" CATALYST_CONFIG_FILE="$L1" \
+  bash -c "source '$LIB'; catalyst_resolve_deployment_mode >/dev/null; printf '%s|%s|%s' \"\$CATALYST_DEPLOYMENT_MODE_RESOLVED\" \"\$CATALYST_DEPLOYMENT_MODE_SOURCE\" \"\$CATALYST_DEPLOYMENT_MODE_RECOGNIZED\"")"
+expect_eq "typo at Layer-2 degrades to single-host, recognized:false, source layer2 (no fallthrough to a valid Layer-1)" \
+  "single-host|layer2|false" "$OUT"
+
+# --- unrecognized (typo) at env degrades, source env ------------------------
+OUT="$(env -i PATH="$PATH" HOME="$HOME" CATALYST_DEPLOYMENT_MODE="clustre" \
+  CATALYST_LAYER2_CONFIG_FILE="$MISSING" CATALYST_CONFIG_FILE="$MISSING" \
+  bash -c "source '$LIB'; catalyst_resolve_deployment_mode >/dev/null; printf '%s|%s|%s' \"\$CATALYST_DEPLOYMENT_MODE_RESOLVED\" \"\$CATALYST_DEPLOYMENT_MODE_SOURCE\" \"\$CATALYST_DEPLOYMENT_MODE_RECOGNIZED\"")"
+expect_eq "typo at env degrades to single-host, recognized:false, source env" "single-host|env|false" "$OUT"
+
+# --- case/whitespace normalization -----------------------------------------
+OUT="$(env -i PATH="$PATH" HOME="$HOME" CATALYST_DEPLOYMENT_MODE="  Cluster  " \
+  CATALYST_LAYER2_CONFIG_FILE="$MISSING" CATALYST_CONFIG_FILE="$MISSING" \
+  bash -c "source '$LIB'; catalyst_resolve_deployment_mode >/dev/null; printf '%s|%s|%s' \"\$CATALYST_DEPLOYMENT_MODE_RESOLVED\" \"\$CATALYST_DEPLOYMENT_MODE_SOURCE\" \"\$CATALYST_DEPLOYMENT_MODE_RECOGNIZED\"")"
+expect_eq "mixed-case/boundary-whitespace normalizes to canonical member" "cluster|env|true" "$OUT"
+
+# --- whitespace-only env falls through (mirrors an empty env var) ---------
+printf '%s' '{"catalyst":{"deployment":{"mode":"cluster"}}}' > "$L2"
+OUT="$(env -i PATH="$PATH" HOME="$HOME" CATALYST_DEPLOYMENT_MODE="   " \
+  CATALYST_LAYER2_CONFIG_FILE="$L2" CATALYST_CONFIG_FILE="$MISSING" \
+  bash -c "source '$LIB'; catalyst_resolve_deployment_mode >/dev/null; printf '%s|%s|%s' \"\$CATALYST_DEPLOYMENT_MODE_RESOLVED\" \"\$CATALYST_DEPLOYMENT_MODE_SOURCE\" \"\$CATALYST_DEPLOYMENT_MODE_RECOGNIZED\"")"
+expect_eq "whitespace-only env falls through to Layer-2" "cluster|layer2|true" "$OUT"
+
+# --- malformed JSON at Layer-2 treated as absent, falls through -----------
+printf '%s' '{not valid json' > "$L2"
+OUT="$(env -i PATH="$PATH" HOME="$HOME" CATALYST_LAYER2_CONFIG_FILE="$L2" CATALYST_CONFIG_FILE="$L1" \
+  bash -c "source '$LIB'; catalyst_resolve_deployment_mode >/dev/null; printf '%s|%s|%s' \"\$CATALYST_DEPLOYMENT_MODE_RESOLVED\" \"\$CATALYST_DEPLOYMENT_MODE_SOURCE\" \"\$CATALYST_DEPLOYMENT_MODE_RECOGNIZED\"")"
+expect_eq "malformed Layer-2 JSON treated as absent, falls through to Layer-1" "cluster|layer1|true" "$OUT"
+
+# --- BLOCKING 1: JSON `false`/non-string values settle degraded, never
+# fall through (the `// empty` bug this replaces would swallow JSON false) --
+printf '%s' '{"catalyst":{"deployment":{"mode":false}}}' > "$L2"
+OUT="$(env -i PATH="$PATH" HOME="$HOME" CATALYST_LAYER2_CONFIG_FILE="$L2" CATALYST_CONFIG_FILE="$L1" \
+  bash -c "source '$LIB'; catalyst_resolve_deployment_mode >/dev/null; printf '%s|%s|%s' \"\$CATALYST_DEPLOYMENT_MODE_RESOLVED\" \"\$CATALYST_DEPLOYMENT_MODE_SOURCE\" \"\$CATALYST_DEPLOYMENT_MODE_RECOGNIZED\"")"
+expect_eq "JSON false at Layer-2 settles degraded at layer2 (does NOT fall through to a valid Layer-1)" \
+  "single-host|layer2|false" "$OUT"
+
+printf '%s' '{"catalyst":{"deployment":{"mode":123}}}' > "$L2"
+OUT="$(env -i PATH="$PATH" HOME="$HOME" CATALYST_LAYER2_CONFIG_FILE="$L2" CATALYST_CONFIG_FILE="$L1" \
+  bash -c "source '$LIB'; catalyst_resolve_deployment_mode >/dev/null; printf '%s|%s|%s' \"\$CATALYST_DEPLOYMENT_MODE_RESOLVED\" \"\$CATALYST_DEPLOYMENT_MODE_SOURCE\" \"\$CATALYST_DEPLOYMENT_MODE_RECOGNIZED\"")"
+expect_eq "JSON number at Layer-2 settles degraded at layer2" "single-host|layer2|false" "$OUT"
+
+# --- BLOCKING 2: quote/CRLF-hostile env values trim as pure data, never as
+# shell syntax ----------------------------------------------------------
+rm -f "$L2"
+OUT="$(env -i PATH="$PATH" HOME="$HOME" CATALYST_LAYER2_CONFIG_FILE="$MISSING" CATALYST_CONFIG_FILE="$MISSING" \
+  bash -c "source '$LIB'; CATALYST_DEPLOYMENT_MODE='\"cluster\"'; catalyst_resolve_deployment_mode >/dev/null; printf '%s|%s|%s' \"\$CATALYST_DEPLOYMENT_MODE_RESOLVED\" \"\$CATALYST_DEPLOYMENT_MODE_SOURCE\" \"\$CATALYST_DEPLOYMENT_MODE_RECOGNIZED\"")"
+expect_eq "embedded-quotes env value is DATA, not a recognized member" "single-host|env|false" "$OUT"
+
+OUT="$(env -i PATH="$PATH" HOME="$HOME" CATALYST_LAYER2_CONFIG_FILE="$MISSING" CATALYST_CONFIG_FILE="$MISSING" \
+  bash -c "source '$LIB'; CATALYST_DEPLOYMENT_MODE='cluster\"'; catalyst_resolve_deployment_mode >/dev/null; printf '%s|%s|%s' \"\$CATALYST_DEPLOYMENT_MODE_RESOLVED\" \"\$CATALYST_DEPLOYMENT_MODE_SOURCE\" \"\$CATALYST_DEPLOYMENT_MODE_RECOGNIZED\"")"
+expect_eq "unmatched-quote env value never errors (no xargs 'unmatched quote')" "single-host|env|false" "$OUT"
+
+OUT="$(env -i PATH="$PATH" HOME="$HOME" CATALYST_LAYER2_CONFIG_FILE="$MISSING" CATALYST_CONFIG_FILE="$MISSING" \
+  bash -c "source '$LIB'; CATALYST_DEPLOYMENT_MODE=\$'cluster\r'; catalyst_resolve_deployment_mode >/dev/null; printf '%s|%s|%s' \"\$CATALYST_DEPLOYMENT_MODE_RESOLVED\" \"\$CATALYST_DEPLOYMENT_MODE_SOURCE\" \"\$CATALYST_DEPLOYMENT_MODE_RECOGNIZED\"")"
+expect_eq "CRLF-suffixed env value trims to a recognized member" "cluster|env|true" "$OUT"
+
+# --- A4: CATALYST_DEPLOYMENT_MODE_INFERRED ----------------------------------
+OUT="$(env -i PATH="$PATH" HOME="$HOME" CATALYST_LAYER2_CONFIG_FILE="$MISSING" CATALYST_CONFIG_FILE="$MISSING" \
+  bash -c "source '$LIB'; catalyst_resolve_deployment_mode >/dev/null; printf '%s' \"\$CATALYST_DEPLOYMENT_MODE_INFERRED\"")"
+expect_eq "inferred=true only for the constant default" "true" "$OUT"
+
+OUT="$(env -i PATH="$PATH" HOME="$HOME" CATALYST_DEPLOYMENT_MODE="cluster" \
+  CATALYST_LAYER2_CONFIG_FILE="$MISSING" CATALYST_CONFIG_FILE="$MISSING" \
+  bash -c "source '$LIB'; catalyst_resolve_deployment_mode >/dev/null; printf '%s' \"\$CATALYST_DEPLOYMENT_MODE_INFERRED\"")"
+expect_eq "inferred=false when env settles the question" "false" "$OUT"
+
+echo ""
+echo "Total: $((PASSES + FAILURES)), Passed: $PASSES, Failed: $FAILURES"
+exit "$FAILURES"

--- a/plugins/dev/scripts/__tests__/deployment-mode-parity.test.sh
+++ b/plugins/dev/scripts/__tests__/deployment-mode-parity.test.sh
@@ -1,0 +1,208 @@
+#!/usr/bin/env bash
+# Cross-stack parity test for lib/deployment-mode.mjs vs
+# lib/catalyst-deployment-mode.sh (CTL-1617).
+#
+# Built directly on the proven, CI-exercised cross-stack mechanism in
+# __tests__/host-identity.test.sh (shell out to node, run identical inputs
+# through both implementations, diff the outputs). Where host-identity.test.sh
+# checks one scenario, this runs a FULL fixture matrix over three axes:
+#
+#   ENV  (7): unset / valid / garbage / quoted / unmatched-quote / apostrophe / crlf
+#   L2   (6): absent / valid / garbage / null / bool-false / number
+#   L1   (4): absent / valid / garbage / bool-true
+#
+#   7 x 6 x 4 = 168 cells
+#
+# Each axis value is a SETTLE/FALLTHROUGH fixture (see the *_SETTLE/*_MODE/
+# *_RECOGNIZED arrays below) — the expected {mode, source, recognized,
+# inferred} for every cell is COMPUTED from the same env > layer2 > layer1 >
+# default cascade the design specifies (§4), not copied from either
+# implementation's output. The assertion is therefore threeway:
+# bash == expected AND node == expected — asserting bash == node alone (the
+# pre-fix version of this file) is a false-green on the exact property this
+# test exists to guard, since two implementations can agree with each other
+# while both disagreeing with the spec.
+#
+# The non-string L2/L1 fixtures ({"mode": false}, {"mode": 123},
+# {"mode": true}) exercise BLOCKING 1 (a bare jq `// empty` swallows JSON
+# `false`, silently falling through instead of settling degraded). The
+# quoted / unmatched-quote / apostrophe / crlf ENV fixtures exercise
+# BLOCKING 2 (xargs-as-trimmer performs quote/backslash reprocessing, errors
+# on an unmatched quote, and does not strip \r).
+#
+# Every cell runs in a hermetic `env -i` subshell for BOTH implementations —
+# only PATH/HOME plus the exact fixture inputs under test are passed through,
+# as ARRAY elements (never string-interpolated into an unquoted expansion),
+# so a hostile fixture value (embedded quotes, an unmatched quote, a raw CR)
+# is passed to `env`/`node` as literal DATA and can never be re-split or
+# re-parsed by the invoking shell — the "seal the transport, don't just stub
+# the helper" lesson.
+#
+# Run: bash plugins/dev/scripts/__tests__/deployment-mode-parity.test.sh
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../../.." && pwd)"
+LIB="${REPO_ROOT}/plugins/dev/scripts/lib/catalyst-deployment-mode.sh"
+JS_LIB="${REPO_ROOT}/plugins/dev/scripts/lib/deployment-mode.mjs"
+
+FAILURES=0
+PASSES=0
+SKIPPED=0
+
+ok() {
+  PASSES=$((PASSES+1))
+}
+fail() {
+  local name="$1" detail="$2"
+  FAILURES=$((FAILURES+1))
+  echo "  FAIL: $name"
+  echo "    $detail"
+}
+expect_eq() {
+  local name="$1" expected="$2" actual="$3"
+  if [[ "$expected" == "$actual" ]]; then
+    ok
+  else
+    fail "$name" "expected='$expected' actual='$actual'"
+  fi
+}
+
+if ! command -v node >/dev/null 2>&1 || ! command -v jq >/dev/null 2>&1 \
+   || [[ ! -f "$LIB" ]] || [[ ! -f "$JS_LIB" ]]; then
+  echo "  SKIP: deployment-mode-parity (node/jq unavailable or libs missing: $LIB / $JS_LIB)"
+  echo ""
+  echo "Total: 0, Passed: 0, Failed: 0, Skipped: 1"
+  exit 0
+fi
+
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+L2_PATH="${TMP_DIR}/layer2.json"
+L1_PATH="${TMP_DIR}/layer1.json"
+
+# Static JS probe — the import path is fixed, so no per-cell interpolation is
+# needed. Reads the SAME env vars the bash side reads (CATALYST_DEPLOYMENT_MODE
+# / CATALYST_LAYER2_CONFIG_FILE / CATALYST_CONFIG_FILE) via
+# resolveDeploymentMode()'s own process.env default — a true black-box parity
+# check of both public entry points. Fourth field is `inferred` (A4) — `raw`
+# stays JS-only (an exported bash var is a poor home for hostile raw bytes).
+PROBE_JS="${TMP_DIR}/probe.mjs"
+cat > "$PROBE_JS" <<EOF
+import { resolveDeploymentMode } from "${JS_LIB}";
+const r = resolveDeploymentMode();
+process.stdout.write(r.mode + "|" + r.source + "|" + String(r.recognized) + "|" + String(r.inferred));
+EOF
+
+# --- Fixture matrix -----------------------------------------------------
+# Each *_SETTLE[i] == 1 means this fixture value SETTLES the question at its
+# layer (with the paired *_MODE[i]/*_RECOGNIZED[i]); == 0 means it FALLS
+# THROUGH to the next layer (the paired MODE/RECOGNIZED entries are unused
+# and left empty).
+
+ENV_NAMES=(unset valid garbage quoted unmatched-quote apostrophe crlf)
+ENV_VALS=("" "cluster" "typo-env" "\"cluster\"" 'cluster"' "don't" $'cluster\r')
+ENV_SETTLE=(0 1 1 1 1 1 1)
+ENV_MODE=("" "cluster" "single-host" "single-host" "single-host" "single-host" "cluster")
+ENV_RECOGNIZED=("" "true" "false" "false" "false" "false" "true")
+
+L2_NAMES=(absent valid garbage null bool-false number)
+L2_BODIES=(
+  ""
+  '{"catalyst":{"deployment":{"mode":"cloud"}}}'
+  '{"catalyst":{"deployment":{"mode":"typo-l2"}}}'
+  '{"catalyst":{"deployment":{"mode":null}}}'
+  '{"catalyst":{"deployment":{"mode":false}}}'
+  '{"catalyst":{"deployment":{"mode":123}}}'
+)
+L2_SETTLE=(0 1 1 0 1 1)
+L2_MODE=("" "cloud" "single-host" "" "single-host" "single-host")
+L2_RECOGNIZED=("" "true" "false" "" "false" "false")
+
+L1_NAMES=(absent valid garbage bool-true)
+L1_BODIES=(
+  ""
+  '{"catalyst":{"deployment":{"mode":"single-host"}}}'
+  '{"catalyst":{"deployment":{"mode":"typo-l1"}}}'
+  '{"catalyst":{"deployment":{"mode":true}}}'
+)
+L1_SETTLE=(0 1 1 1)
+L1_MODE=("" "single-host" "single-host" "single-host")
+L1_RECOGNIZED=("" "true" "false" "false")
+
+CELLS=0
+for i in "${!ENV_NAMES[@]}"; do
+  env_name="${ENV_NAMES[$i]}"
+  env_val="${ENV_VALS[$i]}"
+  env_settle="${ENV_SETTLE[$i]}"
+
+  for j in "${!L2_NAMES[@]}"; do
+    l2_name="${L2_NAMES[$j]}"
+    l2_body="${L2_BODIES[$j]}"
+    l2_settle="${L2_SETTLE[$j]}"
+
+    for k in "${!L1_NAMES[@]}"; do
+      l1_name="${L1_NAMES[$k]}"
+      l1_body="${L1_BODIES[$k]}"
+      l1_settle="${L1_SETTLE[$k]}"
+      CELLS=$((CELLS+1))
+
+      rm -f "$L2_PATH" "$L1_PATH"
+      [[ "$l2_name" != "absent" ]] && printf '%s' "$l2_body" > "$L2_PATH"
+      [[ "$l1_name" != "absent" ]] && printf '%s' "$l1_body" > "$L1_PATH"
+
+      # --- compute EXPECTED from the design ladder (§4): env > layer2 > layer1 > default
+      if [[ "$env_name" != "unset" && "$env_settle" == "1" ]]; then
+        EXP_MODE="${ENV_MODE[$i]}"
+        EXP_SOURCE="env"
+        EXP_RECOGNIZED="${ENV_RECOGNIZED[$i]}"
+        EXP_INFERRED="false"
+      elif [[ "$l2_settle" == "1" ]]; then
+        EXP_MODE="${L2_MODE[$j]}"
+        EXP_SOURCE="layer2"
+        EXP_RECOGNIZED="${L2_RECOGNIZED[$j]}"
+        EXP_INFERRED="false"
+      elif [[ "$l1_settle" == "1" ]]; then
+        EXP_MODE="${L1_MODE[$k]}"
+        EXP_SOURCE="layer1"
+        EXP_RECOGNIZED="${L1_RECOGNIZED[$k]}"
+        EXP_INFERRED="false"
+      else
+        EXP_MODE="single-host"
+        EXP_SOURCE="default"
+        EXP_RECOGNIZED="true"
+        EXP_INFERRED="true"
+      fi
+      EXPECTED="${EXP_MODE}|${EXP_SOURCE}|${EXP_RECOGNIZED}|${EXP_INFERRED}"
+
+      BASH_ARGS=(env -i PATH="$PATH" HOME="$HOME")
+      [[ "$env_name" != "unset" ]] && BASH_ARGS+=("CATALYST_DEPLOYMENT_MODE=${env_val}")
+      BASH_ARGS+=(
+        CATALYST_LAYER2_CONFIG_FILE="$L2_PATH"
+        CATALYST_CONFIG_FILE="$L1_PATH"
+        bash -c "source '$LIB'; catalyst_resolve_deployment_mode >/dev/null; printf '%s|%s|%s|%s' \"\$CATALYST_DEPLOYMENT_MODE_RESOLVED\" \"\$CATALYST_DEPLOYMENT_MODE_SOURCE\" \"\$CATALYST_DEPLOYMENT_MODE_RECOGNIZED\" \"\$CATALYST_DEPLOYMENT_MODE_INFERRED\""
+      )
+      BASH_OUT="$("${BASH_ARGS[@]}")"
+
+      NODE_ARGS=(env -i PATH="$PATH" HOME="$HOME")
+      [[ "$env_name" != "unset" ]] && NODE_ARGS+=("CATALYST_DEPLOYMENT_MODE=${env_val}")
+      NODE_ARGS+=(
+        CATALYST_LAYER2_CONFIG_FILE="$L2_PATH"
+        CATALYST_CONFIG_FILE="$L1_PATH"
+        node "$PROBE_JS"
+      )
+      NODE_OUT="$("${NODE_ARGS[@]}" 2>&1)"
+
+      cell_name="env=$env_name l2=$l2_name l1=$l1_name"
+      expect_eq "$cell_name (bash==expected)" "$EXPECTED" "$BASH_OUT"
+      expect_eq "$cell_name (node==expected)" "$EXPECTED" "$NODE_OUT"
+    done
+  done
+done
+
+echo "Fixture cells run: $CELLS (7 env x 6 layer2 x 4 layer1 = 168; 2 assertions/cell)"
+echo ""
+echo "Total: $((PASSES + FAILURES)), Passed: $PASSES, Failed: $FAILURES, Skipped: $SKIPPED"
+exit "$FAILURES"

--- a/plugins/dev/scripts/__tests__/deployment-mode-parity.test.sh
+++ b/plugins/dev/scripts/__tests__/deployment-mode-parity.test.sh
@@ -204,5 +204,119 @@ done
 
 echo "Fixture cells run: $CELLS (7 env x 6 layer2 x 4 layer1 = 168; 2 assertions/cell)"
 echo ""
+
+# --- Hostile-probe extensions (Codex remediation on PR #2895, CTL-1617) ---
+#
+# Four divergence classes the 168-cell matrix above never exercised, because
+# each needs a fixture value the matrix's simple string-literal arrays can't
+# hold cleanly: an embedded NUL byte, Unicode (not ASCII) whitespace
+# padding, a syntactically-valid-JSON-PREFIX-then-garbage file, and a
+# JSON escape sequence (a lone UTF-16 surrogate) that only ONE of the two
+# parsers accepts. All four are FIXED and assert bash==node==expected, same
+# shape as the matrix above: the JS resolver was deliberately NARROWED to
+# what bash/jq can match (ASCII-only trim; unpaired-surrogate strings treated
+# as layer-malformed), so every exotic input degrades or falls through
+# IDENTICALLY on both sides. See the LONE-SURROGATE PARITY comment atop
+# _catalyst_deployment_mode_from_file in lib/catalyst-deployment-mode.sh for
+# the full rationale.
+HOSTILE=0
+
+run_bash_probe() {
+  # run_bash_probe [ENV_VAR=VAL ...] -- invokes catalyst_resolve_deployment_mode
+  # against $L2_PATH/$L1_PATH under a hermetic env -i, same shape as the
+  # per-cell BASH_ARGS above.
+  env -i PATH="$PATH" HOME="$HOME" "$@" \
+    CATALYST_LAYER2_CONFIG_FILE="$L2_PATH" CATALYST_CONFIG_FILE="$L1_PATH" \
+    bash -c "source '$LIB'; catalyst_resolve_deployment_mode >/dev/null; printf '%s|%s|%s|%s' \"\$CATALYST_DEPLOYMENT_MODE_RESOLVED\" \"\$CATALYST_DEPLOYMENT_MODE_SOURCE\" \"\$CATALYST_DEPLOYMENT_MODE_RECOGNIZED\" \"\$CATALYST_DEPLOYMENT_MODE_INFERRED\""
+}
+run_node_probe() {
+  env -i PATH="$PATH" HOME="$HOME" "$@" \
+    CATALYST_LAYER2_CONFIG_FILE="$L2_PATH" CATALYST_CONFIG_FILE="$L1_PATH" \
+    node "$PROBE_JS" 2>&1
+}
+
+# --- Probe 1: NUL-escape in JSON (Layer-2) — FIXED, bash==node==expected ---
+# {"catalyst":{"deployment":{"mode":"c<NUL>loud"}}} — built via jq's own
+# `[0] | implode` (a one-character string whose sole codepoint is 0) rather
+# than a literal escape sequence typed directly into this file, since a
+# JSON \u-style escape cannot survive this file's own authoring toolchain
+# intact (the same reason lib/catalyst-deployment-mode.sh's NUL-BYTE
+# CANDIDATE fix uses the same `[0] | implode` construction). Layer-1 holds a
+# VALID "cluster" so a
+# regression that wrongly falls through (instead of settling degraded at
+# layer2) is caught, not masked by an equally-valid default.
+rm -f "$L2_PATH" "$L1_PATH"
+jq -n '{catalyst:{deployment:{mode: ("c" + ([0] | implode) + "loud")}}}' > "$L2_PATH"
+printf '%s' '{"catalyst":{"deployment":{"mode":"cluster"}}}' > "$L1_PATH"
+EXPECTED="single-host|layer2|false|false"
+BASH_OUT="$(run_bash_probe)"
+NODE_OUT="$(run_node_probe)"
+HOSTILE=$((HOSTILE+1))
+expect_eq "hostile: NUL-escape in Layer-2 JSON (bash==expected)" "$EXPECTED" "$BASH_OUT"
+expect_eq "hostile: NUL-escape in Layer-2 JSON (node==expected)" "$EXPECTED" "$NODE_OUT"
+
+# --- Probe 2: NBSP-padded env value — FIXED, bash==node==expected ---
+# CATALYST_DEPLOYMENT_MODE = NBSP + "cluster" + NBSP (U+00A0 on both sides).
+# Built via `[160,...] | implode` for the same authoring reason as Probe 1
+# (NBSP is representable in a bash variable — unlike NUL, env vars can hold
+# it — so it's built once and passed straight through as env, not a file).
+# BOTH trims are ASCII-only by design (parity beats Unicode hospitality), so
+# the NBSP padding survives on both sides, fails enum membership on both
+# sides, and SETTLES degraded at env on both sides.
+rm -f "$L2_PATH" "$L1_PATH"
+NBSP_PADDED_CLUSTER="$(jq -n -r '[160,99,108,117,115,116,101,114,160] | implode')"
+EXPECTED="single-host|env|false|false"
+BASH_OUT="$(run_bash_probe "CATALYST_DEPLOYMENT_MODE=${NBSP_PADDED_CLUSTER}")"
+NODE_OUT="$(run_node_probe "CATALYST_DEPLOYMENT_MODE=${NBSP_PADDED_CLUSTER}")"
+HOSTILE=$((HOSTILE+1))
+expect_eq "hostile: NBSP-padded env value (bash==expected)" "$EXPECTED" "$BASH_OUT"
+expect_eq "hostile: NBSP-padded env value (node==expected)" "$EXPECTED" "$NODE_OUT"
+
+# --- Probe 3: malformed-trailing-content JSON (Layer-2) — FIXED,
+# bash==node==expected --- A syntactically valid object immediately
+# followed by stray non-JSON text. jq can print a tag for the valid PREFIX
+# before erroring on the trailing garbage; the fix discards that partial
+# output rather than concatenating it with a fallback "@ABSENT". Layer-1
+# holds a valid "cluster" so the malformed Layer-2 file must fall all the
+# way through to it.
+rm -f "$L2_PATH" "$L1_PATH"
+printf '%s' '{"catalyst":{"deployment":{"mode":"cloud"}}} this is not valid trailing json' > "$L2_PATH"
+printf '%s' '{"catalyst":{"deployment":{"mode":"cluster"}}}' > "$L1_PATH"
+EXPECTED="cluster|layer1|true|false"
+BASH_OUT="$(run_bash_probe)"
+NODE_OUT="$(run_node_probe)"
+HOSTILE=$((HOSTILE+1))
+expect_eq "hostile: malformed-trailing-content Layer-2 JSON (bash==expected)" "$EXPECTED" "$BASH_OUT"
+expect_eq "hostile: malformed-trailing-content Layer-2 JSON (node==expected)" "$EXPECTED" "$NODE_OUT"
+
+# --- Probe 4: lone-surrogate JSON (Layer-2) — FIXED, bash==node==expected ---
+# A JSON string containing an unpaired UTF-16 high surrogate escape
+# ("clu\ud800ster"). jq's parser rejects the escape and fails to parse the
+# WHOLE document (verified: jq-1.7.1 exits 5, "Invalid \uXXXX\uXXXX
+# surrogate pair escape"), so the bash resolver treats the file as @ABSENT
+# and falls through. The JS resolver is deliberately NARROWED to match:
+# readDeploymentModeField treats a mode string carrying an unpaired
+# surrogate as layer-malformed (undefined) — BOTH sides fall through to the
+# valid Layer-1 "cloud". (Valid surrogate PAIRS parse in both languages and
+# are simply non-members — not this case.)
+#
+# The escape is built via a variable-expansion split (a lone backslash in
+# its own variable, concatenated next to a literal "ud800ster") rather than
+# a literal \ud800 escape typed directly in this file's source, for the same
+# authoring-toolchain reason documented at Probe 1.
+rm -f "$L2_PATH" "$L1_PATH"
+# shellcheck disable=SC1003 # genuinely a literal single backslash, not an escape attempt
+BACKSLASH='\'
+printf '%s' "{\"catalyst\":{\"deployment\":{\"mode\":\"clu${BACKSLASH}ud800ster\"}}}" > "$L2_PATH"
+printf '%s' '{"catalyst":{"deployment":{"mode":"cloud"}}}' > "$L1_PATH"
+EXPECTED="cloud|layer1|true|false"
+BASH_OUT="$(run_bash_probe)"
+NODE_OUT="$(run_node_probe)"
+HOSTILE=$((HOSTILE+1))
+expect_eq "hostile: lone-surrogate Layer-2 JSON (bash==expected, falls through)" "$EXPECTED" "$BASH_OUT"
+expect_eq "hostile: lone-surrogate Layer-2 JSON (node==expected, falls through — JS narrowed to match jq)" "$EXPECTED" "$NODE_OUT"
+
+echo "Hostile probes run: $HOSTILE (NUL-escape / NBSP-padded-env / malformed-trailing-content / lone-surrogate; 2 assertions/probe)"
+echo ""
 echo "Total: $((PASSES + FAILURES)), Passed: $PASSES, Failed: $FAILURES, Skipped: $SKIPPED"
 exit "$FAILURES"

--- a/plugins/dev/scripts/__tests__/deployment-mode-parity.test.sh
+++ b/plugins/dev/scripts/__tests__/deployment-mode-parity.test.sh
@@ -316,7 +316,35 @@ HOSTILE=$((HOSTILE+1))
 expect_eq "hostile: lone-surrogate Layer-2 JSON (bash==expected, falls through)" "$EXPECTED" "$BASH_OUT"
 expect_eq "hostile: lone-surrogate Layer-2 JSON (node==expected, falls through — JS narrowed to match jq)" "$EXPECTED" "$NODE_OUT"
 
-echo "Hostile probes run: $HOSTILE (NUL-escape / NBSP-padded-env / malformed-trailing-content / lone-surrogate; 2 assertions/probe)"
+# --- Probe 5: multi-document Layer-2 JSON — FIXED, bash==node==expected ---
+# Two valid top-level documents. Bare jq streams both (exit 0, two tags,
+# bypassing the exit-status guard); JSON.parse rejects the file. The bash
+# reader slurps (-s) so length!=1 classifies as layer-malformed — BOTH sides
+# fall through to the valid Layer-1.
+rm -f "$L2_PATH" "$L1_PATH"
+printf '%s\n%s\n' '{"catalyst":{"deployment":{"mode":"cloud"}}}' '{"catalyst":{"deployment":{"mode":"cluster"}}}' > "$L2_PATH"
+printf '%s' '{"catalyst":{"deployment":{"mode":"cluster"}}}' > "$L1_PATH"
+EXPECTED="cluster|layer1|true|false"
+BASH_OUT="$(run_bash_probe)"
+NODE_OUT="$(run_node_probe)"
+HOSTILE=$((HOSTILE+1))
+expect_eq "hostile: multi-document Layer-2 JSON (bash==expected, falls through)" "$EXPECTED" "$BASH_OUT"
+expect_eq "hostile: multi-document Layer-2 JSON (node==expected, falls through)" "$EXPECTED" "$NODE_OUT"
+
+# --- Probe 6: BOM-prefixed Layer-2 JSON — FIXED, bash==node==expected ---
+# This jq build tolerates a UTF-8 BOM; JSON.parse throws on one. The bash
+# reader byte-sniffs EF BB BF and reports @ABSENT — BOTH sides fall through.
+rm -f "$L2_PATH" "$L1_PATH"
+printf '\xef\xbb\xbf%s' '{"catalyst":{"deployment":{"mode":"cloud"}}}' > "$L2_PATH"
+printf '%s' '{"catalyst":{"deployment":{"mode":"cluster"}}}' > "$L1_PATH"
+EXPECTED="cluster|layer1|true|false"
+BASH_OUT="$(run_bash_probe)"
+NODE_OUT="$(run_node_probe)"
+HOSTILE=$((HOSTILE+1))
+expect_eq "hostile: BOM-prefixed Layer-2 JSON (bash==expected, falls through)" "$EXPECTED" "$BASH_OUT"
+expect_eq "hostile: BOM-prefixed Layer-2 JSON (node==expected, falls through)" "$EXPECTED" "$NODE_OUT"
+
+echo "Hostile probes run: $HOSTILE (NUL-escape / NBSP-padded-env / malformed-trailing-content / lone-surrogate / multi-document / BOM; 2 assertions/probe)"
 echo ""
 echo "Total: $((PASSES + FAILURES)), Passed: $PASSES, Failed: $FAILURES, Skipped: $SKIPPED"
 exit "$FAILURES"

--- a/plugins/dev/scripts/lib/catalyst-deployment-mode.sh
+++ b/plugins/dev/scripts/lib/catalyst-deployment-mode.sh
@@ -1,0 +1,210 @@
+#!/usr/bin/env bash
+# lib/catalyst-deployment-mode.sh — CTL-1617: bash mirror of
+# lib/deployment-mode.mjs's resolveDeploymentMode. Bash cannot import the JS
+# leaf, so this is a SECOND, independently-maintained implementation of the
+# same resolution chain — kept honest by the fixture-matrix cross-stack
+# parity test at __tests__/deployment-mode-parity.test.sh (built on the
+# `node --input-type=module` mechanism __tests__/host-identity.test.sh
+# already proves out in CI). Any enum or precedence change here MUST land
+# together with the matching change in lib/deployment-mode.mjs, or the parity
+# test fails loudly.
+#
+# Deployment mode gets its OWN lib file — rather than another hand-rolled jq
+# one-liner at each call site — precisely because CTL-1612 proved that
+# letting a multi-site jq one-liner drift across launchers is how outages
+# happen (lib/catalyst-secret-env.sh's header tells that story in full).
+#
+# NAMING RULE: always write "deployment mode" fully qualified in every log
+# line and comment in this file — never bare "mode" (see
+# lib/deployment-mode.mjs's header for the three unrelated "mode" concepts
+# this codebase already has).
+#
+# ENV-VS-FILE ASYMMETRY: see the identical caveat atop lib/deployment-mode.mjs
+# — CATALYST_DEPLOYMENT_MODE is captured into a long-lived daemon's
+# environment once, at launch; Layer-1/Layer-2 FILE edits are picked up live
+# on every call to catalyst_resolve_deployment_mode.
+#
+# JQ-ABSENT DIVERGENCE (loud, by design): when jq is unavailable, a Layer-1/
+# Layer-2 config FILE that exists and could theoretically decide the mode is
+# instead treated as ABSENT (falls through to the next layer) — this is a
+# real, best-effort divergence from lib/deployment-mode.mjs, which always
+# parses JSON natively and never depends on an external binary. This file
+# does not fail the caller for it (the contract is "never fails"); instead it
+# leaves a breadcrumb, CATALYST_DEPLOYMENT_MODE_JQ_MISSING=1, exported (never
+# printed to stderr) so `catalyst doctor` (PR2 of the CTL-1617 migration
+# plan) can grade a host that is silently degrading on this axis.
+#
+# Depends only on jq + bash. bash >= 3.2 compatible (no ${var,,}).
+#
+# Idempotent-source guard — safe to source multiple times.
+[[ -n "${_CATALYST_DEPLOYMENT_MODE_SH_LOADED:-}" ]] && return 0
+_CATALYST_DEPLOYMENT_MODE_SH_LOADED=1
+
+# The closed enum. Mirrors DEPLOYMENT_MODES in lib/deployment-mode.mjs — a
+# value added to one side without the other fails the parity test.
+_CATALYST_DEPLOYMENT_MODES="single-host cluster cloud"
+CATALYST_DEPLOYMENT_MODE_DEFAULT="single-host"
+
+# _catalyst_deployment_mode_is_member VALUE — true iff VALUE (already
+# trimmed + lowercased) names one of the enum members.
+_catalyst_deployment_mode_is_member() {
+  local _v="$1" _m
+  for _m in $_CATALYST_DEPLOYMENT_MODES; do
+    [[ "$_v" == "$_m" ]] && return 0
+  done
+  return 1
+}
+
+# _catalyst_deployment_mode_from_file FILE — jq-read catalyst.deployment.mode
+# and return a TAGGED string so the caller (classify) can distinguish "key
+# absent", "value is JSON null", "value is a string", and "value is present
+# but NOT a string" — the same four rungs classifyCandidate discriminates in
+# lib/deployment-mode.mjs. A bare `// empty` (the pre-fix approach) collapses
+# ALL FOUR to the same empty output, which silently swallows a JSON `false`
+# (jq: `false // empty` is empty, because `//` treats `false` as falsy) —
+# {"mode": false} would fall through here while JS correctly SETTLES at this
+# layer with recognized:false. Tags:
+#   @ABSENT   — key not present (or file unreadable/malformed/jq missing)
+#   @NULL     — value is JSON null
+#   @STR:xxx  — value is the string "xxx" (may itself be empty)
+#   @NONSTR   — value is present and NOT a string (bool/number/array/object)
+# @ABSENT and @NULL both mean "fall through" to classify, exactly like
+# classifyCandidate's `raw === undefined || raw === null` rung. @NONSTR means
+# "settle here, degraded" — never falls through. Never fails the caller.
+_catalyst_deployment_mode_from_file() {
+  local _f="$1"
+  if [[ ! -r "$_f" ]]; then
+    printf '@ABSENT'
+    return 0
+  fi
+  if ! command -v jq >/dev/null 2>&1; then
+    # File exists but we have no way to parse it — see the JQ-ABSENT
+    # DIVERGENCE note atop this file. Loud breadcrumb, not a stderr print.
+    export CATALYST_DEPLOYMENT_MODE_JQ_MISSING=1
+    printf '@ABSENT'
+    return 0
+  fi
+  jq -r '
+    (.catalyst.deployment // {})
+    | if has("mode") then
+        (.mode
+         | if . == null then "@NULL"
+           elif type == "string" then "@STR:" + .
+           else "@NONSTR"
+           end)
+      else "@ABSENT"
+      end
+  ' "$_f" 2>/dev/null || printf '@ABSENT'
+}
+
+# _catalyst_deployment_mode_env_tag — tag CATALYST_DEPLOYMENT_MODE the same
+# way _catalyst_deployment_mode_from_file tags a file value, so both layers
+# feed the same classify function. A real OS env var is always either unset
+# (@ABSENT) or a string (@STR:xxx, which may be empty) — env vars can never
+# be JSON null or a non-string type, so those two tags never occur here.
+_catalyst_deployment_mode_env_tag() {
+  if [[ -z "${CATALYST_DEPLOYMENT_MODE+set}" ]]; then
+    printf '@ABSENT'
+  else
+    printf '@STR:%s' "${CATALYST_DEPLOYMENT_MODE}"
+  fi
+}
+
+# _catalyst_deployment_mode_classify TAGGED SOURCE
+#   Sets the shared _cdm_mode/_cdm_source/_cdm_recognized output vars and
+#   returns 0 when TAGGED settles the question at this layer (a non-member
+#   string, or a non-string value, degrades to single-host but STILL settles
+#   here — it does not fall through). Returns 1 (leaving the output vars
+#   untouched) when this layer should fall through to the next: @ABSENT,
+#   @NULL, or a @STR: value that is empty after trimming (mirrors an empty
+#   env var / a whitespace-only file value — the same "cleared" rule
+#   lib/deployment-mode.mjs's classifyCandidate applies to a trimmed-empty
+#   string).
+#
+#   Trim is pure parameter expansion (bash 3.2-safe, no external process, no
+#   quote/backslash reinterpretation of the value — quote characters in the
+#   raw value are DATA, never re-parsed as shell syntax). Lowercase via
+#   `tr '[:upper:]' '[:lower:]'` (also bash-3.2-safe; ${var,,} is bash 4+).
+#   [:space:] covers space/tab/\n/\v/\f/\r, so a CRLF-suffixed value trims
+#   cleanly — the previous xargs-based trimmer mis-happened, erroring on
+#   unmatched quotes (masked by `|| true`) and re-interpreting quote/
+#   backslash characters as shell syntax instead of leaving them as data.
+_catalyst_deployment_mode_classify() {
+  local _tagged="$1" _source="$2" _raw _norm
+  case "$_tagged" in
+    "@ABSENT" | "@NULL")
+      return 1
+      ;;
+    "@NONSTR")
+      _cdm_source="$_source"
+      _cdm_mode="$CATALYST_DEPLOYMENT_MODE_DEFAULT"
+      _cdm_recognized="false"
+      return 0
+      ;;
+    "@STR:"*)
+      _raw="${_tagged#@STR:}"
+      ;;
+    *)
+      # Defensive: an unrecognized tag (should never happen) falls through
+      # rather than crashing the caller.
+      return 1
+      ;;
+  esac
+
+  _norm="$_raw"
+  _norm="${_norm#"${_norm%%[![:space:]]*}"}"
+  _norm="${_norm%"${_norm##*[![:space:]]}"}"
+  _norm="$(printf '%s' "$_norm" | tr '[:upper:]' '[:lower:]')"
+
+  [[ -n "$_norm" ]] || return 1
+  _cdm_source="$_source"
+  if _catalyst_deployment_mode_is_member "$_norm"; then
+    _cdm_mode="$_norm"
+    _cdm_recognized="true"
+  else
+    _cdm_mode="$CATALYST_DEPLOYMENT_MODE_DEFAULT"
+    _cdm_recognized="false"
+  fi
+  return 0
+}
+
+# catalyst_resolve_deployment_mode — echoes the winning deployment mode and
+# exports:
+#   CATALYST_DEPLOYMENT_MODE_RESOLVED    the mode (single-host|cluster|cloud)
+#   CATALYST_DEPLOYMENT_MODE_SOURCE      env|layer2|layer1|default
+#   CATALYST_DEPLOYMENT_MODE_RECOGNIZED  true|false (always true for "default")
+#   CATALYST_DEPLOYMENT_MODE_INFERRED    true|false (true only for "default" —
+#                                         mirrors lib/deployment-mode.mjs's
+#                                         `inferred` field; the raw candidate
+#                                         itself stays JS-only — an exported
+#                                         bash var is a poor home for
+#                                         adversarial/hostile-byte raw values)
+# mirroring CATALYST_GITHUB_TOKEN_SOURCE's side-channel-var convention
+# (lib/catalyst-secret-env.sh). Chain: CATALYST_DEPLOYMENT_MODE env →
+# Layer-2 catalyst.deployment.mode (${CATALYST_LAYER2_CONFIG_FILE:-~/.config/catalyst/config.json})
+# → Layer-1 catalyst.deployment.mode (${CATALYST_CONFIG_FILE:-./.catalyst/config.json})
+# → constant single-host. Never fails (always returns 0).
+catalyst_resolve_deployment_mode() {
+  local _cdm_mode="" _cdm_source="" _cdm_recognized="" _cdm_inferred="false"
+
+  if ! _catalyst_deployment_mode_classify "$(_catalyst_deployment_mode_env_tag)" "env"; then
+    local _l2="${CATALYST_LAYER2_CONFIG_FILE:-${HOME:-}/.config/catalyst/config.json}"
+    if ! _catalyst_deployment_mode_classify "$(_catalyst_deployment_mode_from_file "$_l2")" "layer2"; then
+      local _l1="${CATALYST_CONFIG_FILE:-$(pwd)/.catalyst/config.json}"
+      if ! _catalyst_deployment_mode_classify "$(_catalyst_deployment_mode_from_file "$_l1")" "layer1"; then
+        _cdm_mode="$CATALYST_DEPLOYMENT_MODE_DEFAULT"
+        _cdm_source="default"
+        _cdm_recognized="true"
+        _cdm_inferred="true"
+      fi
+    fi
+  fi
+
+  CATALYST_DEPLOYMENT_MODE_RESOLVED="$_cdm_mode"
+  CATALYST_DEPLOYMENT_MODE_SOURCE="$_cdm_source"
+  CATALYST_DEPLOYMENT_MODE_RECOGNIZED="$_cdm_recognized"
+  CATALYST_DEPLOYMENT_MODE_INFERRED="$_cdm_inferred"
+  export CATALYST_DEPLOYMENT_MODE_RESOLVED CATALYST_DEPLOYMENT_MODE_SOURCE \
+    CATALYST_DEPLOYMENT_MODE_RECOGNIZED CATALYST_DEPLOYMENT_MODE_INFERRED
+  printf '%s' "$_cdm_mode"
+}

--- a/plugins/dev/scripts/lib/catalyst-deployment-mode.sh
+++ b/plugins/dev/scripts/lib/catalyst-deployment-mode.sh
@@ -42,14 +42,27 @@ _CATALYST_DEPLOYMENT_MODE_SH_LOADED=1
 
 # The closed enum. Mirrors DEPLOYMENT_MODES in lib/deployment-mode.mjs — a
 # value added to one side without the other fails the parity test.
-_CATALYST_DEPLOYMENT_MODES="single-host cluster cloud"
+#
+# PARITY DECISION — IFS-INDEPENDENT ENUM (array, not a space-joined string):
+# a bare `for _m in $_CATALYST_DEPLOYMENT_MODES` word-splits on the CALLER's
+# IFS, not a fixed space. A sourcing script that sets the common strict-shell
+# IFS=$'\n\t' (no space in it) would stop splitting this string into three
+# words at all — every candidate, including valid ones, would then compare
+# against ONE giant "single-host cluster cloud" token and always report
+# unrecognized. An array's elements are already delimited at assignment time
+# and iterating "${arr[@]}" never re-splits them, so membership no longer
+# depends on unrelated caller shell state. `${_CATALYST_DEPLOYMENT_MODES[*]}`
+# (join on the FIRST character of IFS) is still available wherever the old
+# space-joined string is needed (e.g. WARN text), but that too is only used
+# from this file's own functions, which never run with a non-default IFS.
+_CATALYST_DEPLOYMENT_MODES=(single-host cluster cloud)
 CATALYST_DEPLOYMENT_MODE_DEFAULT="single-host"
 
 # _catalyst_deployment_mode_is_member VALUE — true iff VALUE (already
 # trimmed + lowercased) names one of the enum members.
 _catalyst_deployment_mode_is_member() {
   local _v="$1" _m
-  for _m in $_CATALYST_DEPLOYMENT_MODES; do
+  for _m in "${_CATALYST_DEPLOYMENT_MODES[@]}"; do
     [[ "$_v" == "$_m" ]] && return 0
   done
   return 1
@@ -64,37 +77,100 @@ _catalyst_deployment_mode_is_member() {
 # (jq: `false // empty` is empty, because `//` treats `false` as falsy) —
 # {"mode": false} would fall through here while JS correctly SETTLES at this
 # layer with recognized:false. Tags:
-#   @ABSENT   — key not present (or file unreadable/malformed/jq missing)
+#   @ABSENT          — key not present (or file unreadable/malformed)
+#   @ABSENT_JQMISSING — key can't be determined because jq itself is missing
+#                       (a distinct reason so the CALLER — not this function,
+#                       see the SUBSHELL-EXPORT DIVERGENCE note on
+#                       catalyst_resolve_deployment_mode below — can export
+#                       the CATALYST_DEPLOYMENT_MODE_JQ_MISSING breadcrumb)
 #   @NULL     — value is JSON null
 #   @STR:xxx  — value is the string "xxx" (may itself be empty)
-#   @NONSTR   — value is present and NOT a string (bool/number/array/object)
-# @ABSENT and @NULL both mean "fall through" to classify, exactly like
-# classifyCandidate's `raw === undefined || raw === null` rung. @NONSTR means
-# "settle here, degraded" — never falls through. Never fails the caller.
+#   @NONSTR   — value is present and NOT a string (bool/number/array/object),
+#               OR is a string that embeds a NUL byte (see NUL-BYTE
+#               CANDIDATE below) — both settle here, degraded, same as a
+#               non-member string would.
+# @ABSENT and @ABSENT_JQMISSING and @NULL all mean "fall through" to
+# classify, exactly like classifyCandidate's `raw === undefined || raw ===
+# null` rung. @NONSTR means "settle here, degraded" — never falls through.
+# Never fails the caller.
+#
+# LONE-SURROGATE PARITY (both sides fall through): a JSON string containing
+# an unpaired UTF-16 surrogate escape (e.g. "clu\ud800ster") is rejected by
+# jq at PARSE time for the WHOLE document (verified: jq-1.7.1 exits 5 —
+# there is no jq invocation that can read ANY field out of such a file), so
+# this function reports @ABSENT and the layer falls through. JSON.parse
+# WOULD accept the string, so the JS resolver deliberately narrows to match:
+# readDeploymentModeField (deployment-mode.mjs) treats a mode string
+# carrying an unpaired surrogate as layer-malformed and returns undefined —
+# both languages fall through to the deeper layer. Valid surrogate PAIRS
+# (astral characters) parse fine in both and are simply non-members.
 _catalyst_deployment_mode_from_file() {
-  local _f="$1"
+  local _f="$1" _jq_out _jq_rc
   if [[ ! -r "$_f" ]]; then
     printf '@ABSENT'
     return 0
   fi
   if ! command -v jq >/dev/null 2>&1; then
     # File exists but we have no way to parse it — see the JQ-ABSENT
-    # DIVERGENCE note atop this file. Loud breadcrumb, not a stderr print.
-    export CATALYST_DEPLOYMENT_MODE_JQ_MISSING=1
-    printf '@ABSENT'
+    # DIVERGENCE note atop this file. The breadcrumb itself is exported by
+    # the CALLER, not here (see the SUBSHELL-EXPORT DIVERGENCE note on
+    # catalyst_resolve_deployment_mode) — this function always runs inside a
+    # $(...) command-substitution subshell, so an `export` performed HERE
+    # would silently vanish the instant $() returns and never reach the
+    # caller's environment. Signal it through the tagged return value
+    # instead, which $() DOES propagate.
+    printf '@ABSENT_JQMISSING'
     return 0
   fi
-  jq -r '
+  # MALFORMED-TRAILING-CONTENT fix: jq streams top-level JSON values and can
+  # print a fully-formed tag for the FIRST one, THEN hit trailing garbage
+  # and exit non-zero (verified: a leading `{"catalyst":{"deployment":
+  # {"mode":"cloud"}}}` followed by stray text prints "@STR:cloud" to stdout
+  # before erroring). Command substitution captures stdout regardless of
+  # exit status, so the pre-fix `jq ... || printf '@ABSENT'` APPENDED
+  # "@ABSENT" onto the already-printed tag ("@STR:cloud\n@ABSENT") instead
+  # of replacing it -- _catalyst_deployment_mode_classify's `"@STR:"*` glob
+  # then matched that whole multi-line blob, so a malformed file with a
+  # syntactically valid PREFIX settled as an unrecognized string instead of
+  # falling through like JSON.parse (which rejects the entire malformed
+  # document and yields undefined). Fix: capture stdout and exit status
+  # SEPARATELY, and only trust the captured output when jq exited 0 -- any
+  # non-zero exit discards whatever partial text was printed and settles on
+  # a clean, single-tag @ABSENT.
+  _jq_out="$(jq -r '
     (.catalyst.deployment // {})
     | if has("mode") then
         (.mode
          | if . == null then "@NULL"
-           elif type == "string" then "@STR:" + .
+           elif type == "string" then
+             # NUL-BYTE CANDIDATE fix: a bash command substitution silently
+             # TRUNCATES an embedded NUL byte -- bash variables cannot
+             # represent one -- so a raw value with an embedded NUL between
+             # "c" and "loud" would otherwise arrive at the caller already
+             # collapsed to the recognized member "cloud" (a false
+             # positive: JS classifies that as a genuine, non-matching
+             # string and degrades it). jq itself still holds the full
+             # Unicode string (including the embedded NUL codepoint) at
+             # this point, so detect and settle it HERE, inside jq, exactly
+             # like any other non-member value -- never let a
+             # NUL-containing candidate reach the $()-boundary as a bare
+             # @STR: tag. The NUL character itself is built via
+             # `[0] | implode` (a one-character string whose sole codepoint
+             # is 0) rather than a literal escape, since jq string
+             # literals inside this single-quoted bash program text cannot
+             # spell a literal escape sequence without breaking bash quoting.
+             (if contains([0] | implode) then "@NONSTR" else "@STR:" + . end)
            else "@NONSTR"
            end)
       else "@ABSENT"
       end
-  ' "$_f" 2>/dev/null || printf '@ABSENT'
+  ' "$_f" 2>/dev/null)"
+  _jq_rc=$?
+  if [[ $_jq_rc -ne 0 ]]; then
+    printf '@ABSENT'
+    return 0
+  fi
+  printf '%s' "$_jq_out"
 }
 
 # _catalyst_deployment_mode_env_tag — tag CATALYST_DEPLOYMENT_MODE the same
@@ -110,6 +186,27 @@ _catalyst_deployment_mode_env_tag() {
   fi
 }
 
+# _catalyst_deployment_mode_trim VALUE — strip ASCII whitespace
+# (space/tab/LF/VT/FF/CR) from both ends. Pure parameter expansion: quote
+# and backslash characters in the value stay DATA, never re-parsed.
+#
+# PARITY DECISION — ASCII-ONLY BY DESIGN: the JS resolver
+# (deployment-mode.mjs classifyCandidate) deliberately narrows its trim to
+# the six ASCII whitespace characters rather than String.prototype.trim() —
+# cross-language parity beats Unicode hospitality. The character set here is
+# spelled out explicitly instead of [[:space:]] because that class is LOCALE
+# DATA: under a UTF-8 locale some platforms (macOS) classify NBSP as space
+# while a C-locale Linux runner does not — the exact same input would then
+# trim differently per host. An NBSP-padded "cluster" keeps its padding on
+# BOTH sides in EVERY locale, fails enum membership on both sides, and
+# degrades identically to single-host/recognized:false at its source layer.
+_catalyst_deployment_mode_trim() {
+  local _t="$1" _ws=$' \t\n\v\f\r'
+  _t="${_t#"${_t%%[!"$_ws"]*}"}"
+  _t="${_t%"${_t##*[!"$_ws"]}"}"
+  printf '%s' "$_t"
+}
+
 # _catalyst_deployment_mode_classify TAGGED SOURCE
 #   Sets the shared _cdm_mode/_cdm_source/_cdm_recognized output vars and
 #   returns 0 when TAGGED settles the question at this layer (a non-member
@@ -121,14 +218,13 @@ _catalyst_deployment_mode_env_tag() {
 #   lib/deployment-mode.mjs's classifyCandidate applies to a trimmed-empty
 #   string).
 #
-#   Trim is pure parameter expansion (bash 3.2-safe, no external process, no
-#   quote/backslash reinterpretation of the value — quote characters in the
-#   raw value are DATA, never re-parsed as shell syntax). Lowercase via
-#   `tr '[:upper:]' '[:lower:]'` (also bash-3.2-safe; ${var,,} is bash 4+).
-#   [:space:] covers space/tab/\n/\v/\f/\r, so a CRLF-suffixed value trims
-#   cleanly — the previous xargs-based trimmer mis-happened, erroring on
-#   unmatched quotes (masked by `|| true`) and re-interpreting quote/
-#   backslash characters as shell syntax instead of leaving them as data.
+#   Trim delegates to _catalyst_deployment_mode_trim (ASCII-only, see
+#   above) rather than pure parameter expansion, so quote/backslash
+#   characters in the raw value still stay DATA — never re-parsed as shell
+#   syntax — since jq consumes the value only as `-R` raw text input, not as
+#   a shell string. Lowercase via `tr '[:upper:]' '[:lower:]'` (bash
+#   3.2-safe; ${var,,} is bash 4+; the enum members are all plain ASCII, so
+#   an ASCII-only lowercase pass matches the ASCII-only trim above).
 _catalyst_deployment_mode_classify() {
   local _tagged="$1" _source="$2" _raw _norm
   case "$_tagged" in
@@ -151,9 +247,7 @@ _catalyst_deployment_mode_classify() {
       ;;
   esac
 
-  _norm="$_raw"
-  _norm="${_norm#"${_norm%%[![:space:]]*}"}"
-  _norm="${_norm%"${_norm##*[![:space:]]}"}"
+  _norm="$(_catalyst_deployment_mode_trim "$_raw")"
   _norm="$(printf '%s' "$_norm" | tr '[:upper:]' '[:lower:]')"
 
   [[ -n "$_norm" ]] || return 1
@@ -184,14 +278,42 @@ _catalyst_deployment_mode_classify() {
 # Layer-2 catalyst.deployment.mode (${CATALYST_LAYER2_CONFIG_FILE:-~/.config/catalyst/config.json})
 # → Layer-1 catalyst.deployment.mode (${CATALYST_CONFIG_FILE:-./.catalyst/config.json})
 # → constant single-host. Never fails (always returns 0).
+#
+# PARITY DECISION — SUBSHELL-EXPORT FIX: _catalyst_deployment_mode_from_file
+# sets its jq-missing breadcrumb by returning the @ABSENT_JQMISSING tag
+# (never by exporting internally — see that function's own header) precisely
+# because every call to it here is wrapped in a $(...) command substitution,
+# which bash always runs in a SUBSHELL: a variable exported from inside that
+# subshell is local to it and is discarded the instant $() returns, so the
+# breadcrumb would silently vanish before `catalyst doctor` (or any other
+# caller) could ever observe it. The fix is to capture each file lookup's
+# TAGGED STDOUT into a plain local variable first — $()'s stdout capture DOES
+# cross the subshell boundary — and only then, back in THIS function's own
+# (non-subshelled) scope, translate the @ABSENT_JQMISSING sentinel into the
+# real export plus a plain @ABSENT before handing it to classify. This also
+# preserves the original laziness: the breadcrumb is only ever exported for
+# a layer this call actually needed to consult (env settling the whole
+# question still means neither file, nor jq's absence, is ever examined).
 catalyst_resolve_deployment_mode() {
   local _cdm_mode="" _cdm_source="" _cdm_recognized="" _cdm_inferred="false"
 
   if ! _catalyst_deployment_mode_classify "$(_catalyst_deployment_mode_env_tag)" "env"; then
     local _l2="${CATALYST_LAYER2_CONFIG_FILE:-${HOME:-}/.config/catalyst/config.json}"
-    if ! _catalyst_deployment_mode_classify "$(_catalyst_deployment_mode_from_file "$_l2")" "layer2"; then
+    local _l2_tagged
+    _l2_tagged="$(_catalyst_deployment_mode_from_file "$_l2")"
+    if [[ "$_l2_tagged" == "@ABSENT_JQMISSING" ]]; then
+      export CATALYST_DEPLOYMENT_MODE_JQ_MISSING=1
+      _l2_tagged="@ABSENT"
+    fi
+    if ! _catalyst_deployment_mode_classify "$_l2_tagged" "layer2"; then
       local _l1="${CATALYST_CONFIG_FILE:-$(pwd)/.catalyst/config.json}"
-      if ! _catalyst_deployment_mode_classify "$(_catalyst_deployment_mode_from_file "$_l1")" "layer1"; then
+      local _l1_tagged
+      _l1_tagged="$(_catalyst_deployment_mode_from_file "$_l1")"
+      if [[ "$_l1_tagged" == "@ABSENT_JQMISSING" ]]; then
+        export CATALYST_DEPLOYMENT_MODE_JQ_MISSING=1
+        _l1_tagged="@ABSENT"
+      fi
+      if ! _catalyst_deployment_mode_classify "$_l1_tagged" "layer1"; then
         _cdm_mode="$CATALYST_DEPLOYMENT_MODE_DEFAULT"
         _cdm_source="default"
         _cdm_recognized="true"

--- a/plugins/dev/scripts/lib/catalyst-deployment-mode.sh
+++ b/plugins/dev/scripts/lib/catalyst-deployment-mode.sh
@@ -137,8 +137,31 @@ _catalyst_deployment_mode_from_file() {
   # SEPARATELY, and only trust the captured output when jq exited 0 -- any
   # non-zero exit discards whatever partial text was printed and settles on
   # a clean, single-tag @ABSENT.
-  _jq_out="$(jq -r '
-    (.catalyst.deployment // {})
+  # BOM SNIFF (parity): this jq build tolerates a UTF-8 BOM at the start of
+  # input, but JSON.parse rejects one — a BOM-prefixed config must read as
+  # layer-malformed (@ABSENT, fall through) on BOTH sides.
+  local _first3
+  _first3="$(head -c 3 "$_f" 2>/dev/null | od -An -tx1 | tr -d ' \n')"
+  if [[ "$_first3" == "efbbbf" ]]; then
+    printf '@ABSENT'
+    return 0
+  fi
+  # --slurp (parity): jq without -s processes each top-level JSON value in the
+  # file independently — a file holding TWO valid documents exits 0 and emits
+  # two tags, bypassing the exit-status check below, while JSON.parse rejects
+  # the whole file. Slurping collapses that to one array whose length exposes
+  # the multi-document case inside the filter (length != 1 → @ABSENT). A
+  # single document whose mode STRING merely contains an embedded newline is
+  # unaffected: it still emits one (multi-line) @STR: tag, which classify
+  # edge-trims and degrades as a non-member — same as JSON.parse's view.
+  #
+  # ERREXIT SAFETY: the assignment runs in an `if` condition so a nonzero jq
+  # exit cannot abort a caller running under `set -e` (POSIX mode /
+  # inherit_errexit propagate errexit INTO command substitutions — the
+  # documented never-fails contract must survive that).
+  if _jq_out="$(jq -rs '
+    if length != 1 then "@ABSENT" else .[0] |
+    ((.catalyst.deployment // {})
     | if has("mode") then
         (.mode
          | if . == null then "@NULL"
@@ -163,9 +186,13 @@ _catalyst_deployment_mode_from_file() {
            else "@NONSTR"
            end)
       else "@ABSENT"
-      end
-  ' "$_f" 2>/dev/null)"
-  _jq_rc=$?
+      end)
+    end
+  ' "$_f" 2>/dev/null)"; then
+    _jq_rc=0
+  else
+    _jq_rc=$?
+  fi
   if [[ $_jq_rc -ne 0 ]]; then
     printf '@ABSENT'
     return 0
@@ -296,9 +323,21 @@ _catalyst_deployment_mode_classify() {
 # question still means neither file, nor jq's absence, is ever examined).
 catalyst_resolve_deployment_mode() {
   local _cdm_mode="" _cdm_source="" _cdm_recognized="" _cdm_inferred="false"
+  # The jq-missing breadcrumb reflects THIS resolution only — clear any value
+  # latched by an earlier call (or inherited from a parent shell) so a later
+  # call where jq is back, or where env settles without consulting files,
+  # cannot report a stale active degradation to doctor.
+  unset CATALYST_DEPLOYMENT_MODE_JQ_MISSING 2>/dev/null || true
 
   if ! _catalyst_deployment_mode_classify "$(_catalyst_deployment_mode_env_tag)" "env"; then
-    local _l2="${CATALYST_LAYER2_CONFIG_FILE:-${HOME:-}/.config/catalyst/config.json}"
+    # HOME fallback (parity): os.homedir() consults the passwd database when
+    # HOME is unset; bash tilde expansion does the same ("If HOME is unset,
+    # the home directory of the user executing the shell is substituted").
+    # A bare "${HOME:-}" would silently probe /.config/catalyst/config.json
+    # and skip a real Layer-2 override on HOME-less service environments.
+    local _home="${HOME-}"
+    [[ -z "$_home" ]] && _home=~
+    local _l2="${CATALYST_LAYER2_CONFIG_FILE:-${_home}/.config/catalyst/config.json}"
     local _l2_tagged
     _l2_tagged="$(_catalyst_deployment_mode_from_file "$_l2")"
     if [[ "$_l2_tagged" == "@ABSENT_JQMISSING" ]]; then

--- a/plugins/dev/scripts/lib/deployment-mode.d.mts
+++ b/plugins/dev/scripts/lib/deployment-mode.d.mts
@@ -1,0 +1,36 @@
+// Types for deployment-mode.mjs (CTL-1617) — the runtime stays .mjs so the
+// broker/execution-core .mjs daemons import it unchanged (execution-core/
+// config.mjs re-exports it); this gives TS consumers (orch-monitor) proper
+// types. Mirrors the daemon-heartbeat.d.mts / process-memory-metric.d.mts
+// convention (hand-written companion, no build step).
+
+export type DeploymentMode = "single-host" | "cluster" | "cloud";
+export type DeploymentModeSource = "env" | "layer2" | "layer1" | "default";
+
+export const DEPLOYMENT_MODES: readonly DeploymentMode[];
+
+export interface DeploymentModeResolution {
+  mode: DeploymentMode;
+  source: DeploymentModeSource;
+  /** true only for the constant default — no explicit value anywhere */
+  inferred: boolean;
+  /** false when an explicit value was present but did not name a real deployment mode */
+  recognized: boolean;
+  /** the explicit value exactly as written, or null for the inferred default */
+  raw: unknown;
+}
+
+export interface ResolveDeploymentModeOptions {
+  /** resolution env (default process.env) */
+  env?: Record<string, string | undefined>;
+  /** explicit Layer-1 (.catalyst/config.json) path override */
+  layer1ConfigPath?: string;
+  /** explicit Layer-2 (~/.config/catalyst/config.json) path override */
+  layer2ConfigPath?: string;
+}
+
+export function resolveDeploymentMode(
+  opts?: ResolveDeploymentModeOptions,
+): DeploymentModeResolution;
+
+export function getDeploymentMode(opts?: ResolveDeploymentModeOptions): DeploymentMode;

--- a/plugins/dev/scripts/lib/deployment-mode.mjs
+++ b/plugins/dev/scripts/lib/deployment-mode.mjs
@@ -70,13 +70,30 @@ const DEPLOYMENT_MODE_DEFAULT = "single-host";
 // Mirrors execution-core/config.mjs getLayer2ConfigPath(), but reads the
 // injected `env` (not process.env directly) so the whole resolution stays
 // pure and testable without mutating the real environment.
+//
+// PARITY DECISION — RESOLVE ~ FROM THE INJECTED ENV, NOT THE REAL PROCESS:
+// the final fallback used to call node:os's homedir(), which always reads
+// the REAL process's home directory regardless of what `env` a caller
+// injected. A caller that supplies { env: { HOME: fixtureHome } } — the
+// documented isolation contract this function's own docstring promises —
+// intending to sandbox Layer-2 resolution to a fixture directory would
+// instead have this fallback silently read the ACTUAL current user's
+// machine config and resolve its deployment mode, ignoring the fixture
+// entirely (reproduced: a cloud config under the fixture home was ignored
+// in favor of the real home). Fixed by preferring env.HOME (when it is a
+// non-empty string) over homedir(), so an injected env — the same mechanism
+// resolveLayer1Path and the CATALYST_LAYER2_CONFIG_FILE override above
+// already honor — is honored on this path too. Every production call site
+// still calls resolveDeploymentMode() with no args, so env defaults to
+// process.env and env.HOME is the real user's home exactly as before.
 function resolveLayer2Path(env, layer2ConfigPath) {
   if (typeof layer2ConfigPath === "string" && layer2ConfigPath.length > 0) {
     return layer2ConfigPath;
   }
   const override = env?.CATALYST_LAYER2_CONFIG_FILE;
   if (typeof override === "string" && override.length > 0) return override;
-  return resolve(homedir(), ".config", "catalyst", "config.json");
+  const home = typeof env?.HOME === "string" && env.HOME.length > 0 ? env.HOME : homedir();
+  return resolve(home, ".config", "catalyst", "config.json");
 }
 
 // resolveLayer1Path — an explicit layer1ConfigPath wins; otherwise
@@ -97,9 +114,21 @@ function resolveLayer1Path(env, layer1ConfigPath) {
 // absent/malformed/unreadable OR the key is simply not present — both count
 // as "nothing here, try the next layer" (the readLayer2NodeClass contract,
 // execution-core/config.mjs:312-325). Never throws.
+// UNPAIRED_SURROGATE — a UTF-16 code unit in the surrogate range that is not
+// part of a valid high+low pair. JSON.parse accepts lone-surrogate escapes
+// (`"clu\ud800ster"`) but jq rejects the WHOLE document (exit 5), so the bash
+// mirror can never see such a value. Parity rule: a mode string carrying an
+// unpaired surrogate makes the LAYER malformed in BOTH languages — fall
+// through, exactly as bash does after jq's rejection. Valid surrogate PAIRS
+// (astral characters) parse fine in both and are simply non-members.
+const UNPAIRED_SURROGATE =
+  /(?:[\uD800-\uDBFF](?![\uDC00-\uDFFF]))|(?:(?<![\uD800-\uDBFF])[\uDC00-\uDFFF])/;
+
 function readDeploymentModeField(filePath) {
   try {
-    return JSON.parse(readFileSync(filePath, "utf8"))?.catalyst?.deployment?.mode;
+    const mode = JSON.parse(readFileSync(filePath, "utf8"))?.catalyst?.deployment?.mode;
+    if (typeof mode === "string" && UNPAIRED_SURROGATE.test(mode)) return undefined;
+    return mode;
   } catch {
     return undefined;
   }
@@ -117,8 +146,12 @@ function readDeploymentModeField(filePath) {
 //   - present but NOT a string (true, 123, [], {}) ⇒ explicit
 //     misconfiguration, never silently absent ⇒ degrade to single-host,
 //     recognized:false, AT this layer's source.
-//   - string ⇒ trim + lowercase. Empty after trim ⇒ treated as cleared ⇒
-//     fall through (mirrors an empty env var).
+//   - string ⇒ ASCII-only trim + lowercase. Empty after trim ⇒ treated as
+//     cleared ⇒ fall through (mirrors an empty env var). The trim is
+//     DELIBERATELY narrower than String.prototype.trim(): bash [[:space:]]
+//     under the C locale cannot see Unicode whitespace, and cross-language
+//     parity beats Unicode hospitality — an NBSP-padded value stays a
+//     non-member and degrades identically on both sides.
 //   - member of DEPLOYMENT_MODES ⇒ recognized:true.
 //   - non-member (typo) ⇒ degrade to single-host, recognized:false, AT this
 //     layer's source — doctor FAILs until corrected.
@@ -129,7 +162,7 @@ function classifyCandidate(raw, source) {
       result: { mode: DEPLOYMENT_MODE_DEFAULT, source, inferred: false, recognized: false, raw },
     };
   }
-  const normalized = raw.trim().toLowerCase();
+  const normalized = raw.replace(/^[\t\n\v\f\r ]+|[\t\n\v\f\r ]+$/g, "").toLowerCase();
   if (normalized.length === 0) return { fallthrough: true };
   if (DEPLOYMENT_MODES.includes(normalized)) {
     return { result: { mode: normalized, source, inferred: false, recognized: true, raw } };

--- a/plugins/dev/scripts/lib/deployment-mode.mjs
+++ b/plugins/dev/scripts/lib/deployment-mode.mjs
@@ -1,0 +1,206 @@
+// deployment-mode.mjs — CTL-1617: the canonical deployment-mode resolver.
+//
+// WHY THIS FILE EXISTS. Today a Catalyst node's deployment topology (a lone
+// laptop, a member of a coordinated cluster, or a managed-container cloud node)
+// is 100% inferred from side effects — a webhook tunnel opens because a channel
+// string happens to be configured, a cluster roster resolves to single-host
+// purely because no cluster-repo clone exists. Nothing declares deployment mode,
+// and nothing cross-checks the inferences against each other. This module is the
+// ONE declared answer — `catalyst.deployment.mode` ∈ {single-host, cluster,
+// cloud} — resolved identically here and in the bash mirror
+// (lib/catalyst-deployment-mode.sh), consumed by every deployment-mode-dependent
+// seam (webhook ingestion gating, secret-provider selection, doctor's
+// roster-consistency checks).
+//
+// ZERO-IMPORT LEAF (node:fs / node:os / node:path only) — mirrors the
+// execution-core/worker-label-names.mjs rationale: doctor.mjs runs under bare
+// Node and must import this without pulling a heavier module graph
+// (execution-core/config.mjs's own import chain reaches bun:sqlite via
+// linear-query.mjs, which the Node ESM loader rejects at load time).
+// execution-core/config.mjs re-exports these three names with a one-line
+// import; orch-monitor imports this file directly (cross-directory .mjs
+// import — precedent: orch-monitor/ui/src/board/process-surface.test.ts
+// importing ../../../../lib/fsm-descriptor.mjs). PR1 (this file) ships with
+// ZERO consumers outside its own tests — nothing outside tests may import it
+// yet; wiring lands in later PRs of the CTL-1617 migration plan.
+//
+// NAMING RULE: always write "deployment mode" fully qualified — in every log
+// line, WARN message, and comment in this file — never bare "mode". Three
+// unrelated "mode" concepts already exist in this codebase
+// (catalyst.orchestration.dispatchMode, the executor-derived dispatch-mode
+// telemetry, readLinearReplica().mode).
+//
+// ENV-VS-FILE ASYMMETRY — read this before touching the escape hatch on a
+// running daemon. Layer-1/Layer-2 FILE edits are picked up LIVE — every
+// resolveDeploymentMode() call re-reads both files from disk. The ENV var
+// (CATALYST_DEPLOYMENT_MODE) is captured into a long-lived daemon's
+// process.env exactly once, at process launch — changing it in a shell
+// profile or launchd plist reaches only freshly started processes. A running
+// daemon keeps resolving its OLD value until it is restarted. Forgetting this
+// reads as "the resolver is broken" when it is actually "the daemon needs a
+// restart" — same caveat class as the dormant-by-default broker-degraded
+// detector's env-gate (broker/broker-degraded.mjs).
+//
+// Precedent this mirrors: execution-core/config.mjs resolveNodeClass's
+// validity ladder (env → Layer-2 → default), extended one layer to also read
+// the committed Layer-1 default — node.class never needed a Layer-1 rung, but
+// deployment mode is genuinely fleet-scoped (design §3), so Layer-1 is a
+// real source here, read after Layer-2 (the per-host override still wins).
+
+import { readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { resolve } from "node:path";
+
+// DEPLOYMENT_MODES — the closed enum. Frozen: callers must never mutate this
+// in place to add a value. A 4th "both" value was deliberately rejected
+// (CTL-1617 design §2) — the provider's own webhook.delivery.id already makes
+// concurrent smee+cloud ingestion dedup-safe without one.
+export const DEPLOYMENT_MODES = Object.freeze(["single-host", "cluster", "cloud"]);
+
+// The safest degradation target for every soft-failure case (unset, a
+// present-but-non-string value, or an unrecognized string). Wrongly assuming
+// cluster/cloud would make a node skip its own webhook ingestion or expect
+// substrate that doesn't exist; wrongly assuming single-host means "act
+// exactly as every host does today" — zero-config, zero-behavior-change
+// (matches NODE_CLASS_DEFAULT's stated contract, execution-core/config.mjs:303).
+const DEPLOYMENT_MODE_DEFAULT = "single-host";
+
+// resolveLayer2Path — an explicit layer2ConfigPath wins; otherwise
+// env.CATALYST_LAYER2_CONFIG_FILE; otherwise ~/.config/catalyst/config.json.
+// Mirrors execution-core/config.mjs getLayer2ConfigPath(), but reads the
+// injected `env` (not process.env directly) so the whole resolution stays
+// pure and testable without mutating the real environment.
+function resolveLayer2Path(env, layer2ConfigPath) {
+  if (typeof layer2ConfigPath === "string" && layer2ConfigPath.length > 0) {
+    return layer2ConfigPath;
+  }
+  const override = env?.CATALYST_LAYER2_CONFIG_FILE;
+  if (typeof override === "string" && override.length > 0) return override;
+  return resolve(homedir(), ".config", "catalyst", "config.json");
+}
+
+// resolveLayer1Path — an explicit layer1ConfigPath wins; otherwise
+// env.CATALYST_CONFIG_FILE; otherwise cwd/.catalyst/config.json. Mirrors
+// execution-core/config.mjs getCatalystRepoDir()'s CATALYST_CONFIG_FILE
+// convention.
+function resolveLayer1Path(env, layer1ConfigPath) {
+  if (typeof layer1ConfigPath === "string" && layer1ConfigPath.length > 0) {
+    return layer1ConfigPath;
+  }
+  const override = env?.CATALYST_CONFIG_FILE;
+  if (typeof override === "string" && override.length > 0) return override;
+  return resolve(process.cwd(), ".catalyst", "config.json");
+}
+
+// readDeploymentModeField — pull catalyst.deployment.mode out of a config file
+// EXACTLY as written (whatever JSON type). Returns undefined when the file is
+// absent/malformed/unreadable OR the key is simply not present — both count
+// as "nothing here, try the next layer" (the readLayer2NodeClass contract,
+// execution-core/config.mjs:312-325). Never throws.
+function readDeploymentModeField(filePath) {
+  try {
+    return JSON.parse(readFileSync(filePath, "utf8"))?.catalyst?.deployment?.mode;
+  } catch {
+    return undefined;
+  }
+}
+
+// classifyCandidate — apply the validity ladder (CTL-1617 design §4) to ONE
+// layer's raw candidate. Returns { fallthrough: true } when this layer has
+// nothing decisive to say (try the next layer), or { result } with a
+// fully-formed resolution object when this layer settles the question
+// (valid or invalid).
+//
+// Ladder:
+//   - undefined (absent key / unreadable file / unset env) OR explicit JSON
+//     null ⇒ fall through to the next layer (both are the "unset" sentinel).
+//   - present but NOT a string (true, 123, [], {}) ⇒ explicit
+//     misconfiguration, never silently absent ⇒ degrade to single-host,
+//     recognized:false, AT this layer's source.
+//   - string ⇒ trim + lowercase. Empty after trim ⇒ treated as cleared ⇒
+//     fall through (mirrors an empty env var).
+//   - member of DEPLOYMENT_MODES ⇒ recognized:true.
+//   - non-member (typo) ⇒ degrade to single-host, recognized:false, AT this
+//     layer's source — doctor FAILs until corrected.
+function classifyCandidate(raw, source) {
+  if (raw === undefined || raw === null) return { fallthrough: true };
+  if (typeof raw !== "string") {
+    return {
+      result: { mode: DEPLOYMENT_MODE_DEFAULT, source, inferred: false, recognized: false, raw },
+    };
+  }
+  const normalized = raw.trim().toLowerCase();
+  if (normalized.length === 0) return { fallthrough: true };
+  if (DEPLOYMENT_MODES.includes(normalized)) {
+    return { result: { mode: normalized, source, inferred: false, recognized: true, raw } };
+  }
+  return {
+    result: { mode: DEPLOYMENT_MODE_DEFAULT, source, inferred: false, recognized: false, raw },
+  };
+}
+
+// resolveDeploymentMode — the pure, no-logging resolver. Never throws.
+// Precedence: env CATALYST_DEPLOYMENT_MODE → Layer-2 catalyst.deployment.mode
+// → Layer-1 catalyst.deployment.mode → constant default "single-host".
+// Returns { mode, source, inferred, recognized, raw }:
+//   - source     ∈ "env" | "layer2" | "layer1" | "default"
+//   - inferred   = true only for the constant default (no explicit value
+//                  anywhere)
+//   - recognized = whether the explicit value named a real deployment mode
+//                  (always true for the inferred default; false is what
+//                  routes doctor to FAIL)
+//   - raw        = the explicit value exactly as written (for WARN/doctor text)
+//
+// Accepts an injectable { env, layer1ConfigPath, layer2ConfigPath } so tests
+// (and the cross-stack parity fixture matrix in
+// __tests__/deployment-mode-parity.test.sh) can redirect every input without
+// touching process.env or the filesystem outside a fixture dir.
+export function resolveDeploymentMode({ env = process.env, layer1ConfigPath, layer2ConfigPath } = {}) {
+  const envCandidate = classifyCandidate(env?.CATALYST_DEPLOYMENT_MODE, "env");
+  if (envCandidate.result) return envCandidate.result;
+
+  const l2Path = resolveLayer2Path(env, layer2ConfigPath);
+  const l2Candidate = classifyCandidate(readDeploymentModeField(l2Path), "layer2");
+  if (l2Candidate.result) return l2Candidate.result;
+
+  const l1Path = resolveLayer1Path(env, layer1ConfigPath);
+  const l1Candidate = classifyCandidate(readDeploymentModeField(l1Path), "layer1");
+  if (l1Candidate.result) return l1Candidate.result;
+
+  return { mode: DEPLOYMENT_MODE_DEFAULT, source: "default", inferred: true, recognized: true, raw: null };
+}
+
+// getDeploymentMode — the convenience accessor the rest of the system reads.
+// Resolves FRESH on every call — the resolved value is never cached, only the
+// dedup Set of WARN messages already emitted is (once per process), mirroring
+// getNodeClass's _warnedNodeClass pattern (execution-core/config.mjs:380-396).
+// Caching the resolved value would defeat the "file edits are picked up live"
+// contract documented above. Hot-path callers that must stay strictly
+// log-free use resolveDeploymentMode().mode directly. Never throws.
+//
+// Accepts the same optional { env, layer1ConfigPath, layer2ConfigPath } as
+// resolveDeploymentMode (forwarded as-is) so tests can point this at an
+// explicit fixture instead of the real process.env/filesystem — needed to
+// deterministically exercise the WARN-dedup path (a real environment may or
+// may not be in a warn-worthy state). Every production call site still calls
+// getDeploymentMode() with no args, which resolves against process.env / the
+// real config files exactly as before.
+const _warnedDeploymentMode = new Set();
+export function getDeploymentMode(opts = {}) {
+  const r = resolveDeploymentMode(opts);
+  let msg = null;
+  if (r.inferred) {
+    msg =
+      `deployment mode is not declared; inferring "${r.mode}" ` +
+      `(set CATALYST_DEPLOYMENT_MODE, or catalyst.deployment.mode in Layer-1/Layer-2 config, to make it explicit)`;
+  } else if (!r.recognized) {
+    msg =
+      `deployment mode "${r.raw}" is not one of [${DEPLOYMENT_MODES.join(", ")}] — ` +
+      `treating this node as "${r.mode}" (safest); catalyst doctor will FAIL until the value is corrected`;
+  }
+  if (msg && !_warnedDeploymentMode.has(msg)) {
+    _warnedDeploymentMode.add(msg);
+    console.warn(`[deployment-mode] ${msg}`);
+  }
+  return r.mode;
+}

--- a/plugins/dev/scripts/lib/deployment-mode.mjs
+++ b/plugins/dev/scripts/lib/deployment-mode.mjs
@@ -218,6 +218,20 @@ export function resolveDeploymentMode({ env = process.env, layer1ConfigPath, lay
 // may not be in a warn-worthy state). Every production call site still calls
 // getDeploymentMode() with no args, which resolves against process.env / the
 // real config files exactly as before.
+// printableRaw — render the offending raw value for the WARN without ever
+// throwing: a template-literal `${raw}` coerces via toString, and a valid
+// JSON misconfiguration like {"mode": {"toString": null}} shadows it and
+// throws TypeError — which would break getDeploymentMode's never-throws
+// contract on exactly the degraded path it exists to report.
+function printableRaw(raw) {
+  if (typeof raw === "string") return raw;
+  try {
+    return JSON.stringify(raw) ?? String(raw);
+  } catch {
+    return "[unprintable value]";
+  }
+}
+
 const _warnedDeploymentMode = new Set();
 export function getDeploymentMode(opts = {}) {
   const r = resolveDeploymentMode(opts);
@@ -228,7 +242,7 @@ export function getDeploymentMode(opts = {}) {
       `(set CATALYST_DEPLOYMENT_MODE, or catalyst.deployment.mode in Layer-1/Layer-2 config, to make it explicit)`;
   } else if (!r.recognized) {
     msg =
-      `deployment mode "${r.raw}" is not one of [${DEPLOYMENT_MODES.join(", ")}] — ` +
+      `deployment mode "${printableRaw(r.raw)}" is not one of [${DEPLOYMENT_MODES.join(", ")}] — ` +
       `treating this node as "${r.mode}" (safest); catalyst doctor will FAIL until the value is corrected`;
   }
   if (msg && !_warnedDeploymentMode.has(msg)) {

--- a/plugins/dev/scripts/lib/deployment-mode.test.mjs
+++ b/plugins/dev/scripts/lib/deployment-mode.test.mjs
@@ -1,0 +1,293 @@
+import { describe, test, expect, afterEach } from "bun:test";
+import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { resolve } from "node:path";
+import { DEPLOYMENT_MODES, resolveDeploymentMode, getDeploymentMode } from "./deployment-mode.mjs";
+
+// Fixture-file helpers. Every test builds its own tmp dir so parallel test
+// runs never collide, and points layer1ConfigPath/layer2ConfigPath at the
+// fixture directly rather than touching process.env or a real config file.
+let _tmpDirs = [];
+function fixtureDir() {
+  const dir = mkdtempSync(resolve(tmpdir(), "deployment-mode-test-"));
+  _tmpDirs.push(dir);
+  return dir;
+}
+function writeConfig(dir, name, mode) {
+  const path = resolve(dir, name);
+  const body = mode === undefined ? {} : { catalyst: { deployment: { mode } } };
+  writeFileSync(path, JSON.stringify(body));
+  return path;
+}
+function missingPath(dir, name) {
+  // Never written — exercises the "absent file" rung without touching disk.
+  return resolve(dir, name);
+}
+afterEach(() => {
+  for (const dir of _tmpDirs) rmSync(dir, { recursive: true, force: true });
+  _tmpDirs = [];
+});
+
+describe("DEPLOYMENT_MODES", () => {
+  test("is the frozen 3-value enum", () => {
+    expect(DEPLOYMENT_MODES).toEqual(["single-host", "cluster", "cloud"]);
+    expect(Object.isFrozen(DEPLOYMENT_MODES)).toBe(true);
+  });
+  test("mutation attempts do not change the enum (strict-mode ESM throws)", () => {
+    expect(() => {
+      DEPLOYMENT_MODES.push("both");
+    }).toThrow();
+    expect(DEPLOYMENT_MODES).toEqual(["single-host", "cluster", "cloud"]);
+  });
+});
+
+describe("resolveDeploymentMode — the validity ladder", () => {
+  test("nothing set anywhere ⇒ constant default, inferred, recognized", () => {
+    const dir = fixtureDir();
+    const r = resolveDeploymentMode({
+      env: {},
+      layer1ConfigPath: missingPath(dir, "layer1.json"),
+      layer2ConfigPath: missingPath(dir, "layer2.json"),
+    });
+    expect(r).toEqual({ mode: "single-host", source: "default", inferred: true, recognized: true, raw: null });
+  });
+
+  test("env wins over everything else", () => {
+    const dir = fixtureDir();
+    const l2 = writeConfig(dir, "layer2.json", "cloud");
+    const l1 = writeConfig(dir, "layer1.json", "cluster");
+    const r = resolveDeploymentMode({
+      env: { CATALYST_DEPLOYMENT_MODE: "cluster" },
+      layer1ConfigPath: l1,
+      layer2ConfigPath: l2,
+    });
+    expect(r).toEqual({ mode: "cluster", source: "env", inferred: false, recognized: true, raw: "cluster" });
+  });
+
+  test("Layer-2 wins when env is absent", () => {
+    const dir = fixtureDir();
+    const l2 = writeConfig(dir, "layer2.json", "cloud");
+    const l1 = writeConfig(dir, "layer1.json", "cluster");
+    const r = resolveDeploymentMode({ env: {}, layer1ConfigPath: l1, layer2ConfigPath: l2 });
+    expect(r).toEqual({ mode: "cloud", source: "layer2", inferred: false, recognized: true, raw: "cloud" });
+  });
+
+  test("Layer-1 wins when env and Layer-2 are both absent", () => {
+    const dir = fixtureDir();
+    const l1 = writeConfig(dir, "layer1.json", "cluster");
+    const r = resolveDeploymentMode({
+      env: {},
+      layer1ConfigPath: l1,
+      layer2ConfigPath: missingPath(dir, "layer2.json"),
+    });
+    expect(r).toEqual({ mode: "cluster", source: "layer1", inferred: false, recognized: true, raw: "cluster" });
+  });
+
+  test("Layer-2 present but key absent ⇒ falls through to Layer-1", () => {
+    const dir = fixtureDir();
+    const l2 = writeConfig(dir, "layer2.json", undefined); // {} — no catalyst.deployment.mode key
+    const l1 = writeConfig(dir, "layer1.json", "cloud");
+    const r = resolveDeploymentMode({ env: {}, layer1ConfigPath: l1, layer2ConfigPath: l2 });
+    expect(r.source).toBe("layer1");
+    expect(r.mode).toBe("cloud");
+  });
+
+  test("Layer-2 file missing on disk ⇒ falls through to Layer-1 (never throws)", () => {
+    const dir = fixtureDir();
+    const l1 = writeConfig(dir, "layer1.json", "cluster");
+    const r = resolveDeploymentMode({
+      env: {},
+      layer1ConfigPath: l1,
+      layer2ConfigPath: missingPath(dir, "does-not-exist.json"),
+    });
+    expect(r).toEqual({ mode: "cluster", source: "layer1", inferred: false, recognized: true, raw: "cluster" });
+  });
+
+  test("Layer-2 malformed JSON ⇒ treated as absent, falls through (never throws)", () => {
+    const dir = fixtureDir();
+    const l2 = resolve(dir, "layer2.json");
+    writeFileSync(l2, "{not valid json");
+    const l1 = writeConfig(dir, "layer1.json", "cloud");
+    const r = resolveDeploymentMode({ env: {}, layer1ConfigPath: l1, layer2ConfigPath: l2 });
+    expect(r).toEqual({ mode: "cloud", source: "layer1", inferred: false, recognized: true, raw: "cloud" });
+  });
+
+  test("explicit JSON null at Layer-2 ⇒ unset sentinel, falls through to Layer-1", () => {
+    const dir = fixtureDir();
+    const l2 = writeConfig(dir, "layer2.json", null);
+    const l1 = writeConfig(dir, "layer1.json", "cluster");
+    const r = resolveDeploymentMode({ env: {}, layer1ConfigPath: l1, layer2ConfigPath: l2 });
+    expect(r).toEqual({ mode: "cluster", source: "layer1", inferred: false, recognized: true, raw: "cluster" });
+  });
+
+  test("explicit JSON null at env ⇒ unset sentinel, falls through past env", () => {
+    const dir = fixtureDir();
+    const l2 = writeConfig(dir, "layer2.json", "cloud");
+    const r = resolveDeploymentMode({
+      env: { CATALYST_DEPLOYMENT_MODE: null },
+      layer1ConfigPath: missingPath(dir, "layer1.json"),
+      layer2ConfigPath: l2,
+    });
+    expect(r.source).toBe("layer2");
+    expect(r.mode).toBe("cloud");
+  });
+
+  test("empty-string env ⇒ cleared, falls through to Layer-2", () => {
+    const dir = fixtureDir();
+    const l2 = writeConfig(dir, "layer2.json", "cluster");
+    const r = resolveDeploymentMode({
+      env: { CATALYST_DEPLOYMENT_MODE: "" },
+      layer1ConfigPath: missingPath(dir, "layer1.json"),
+      layer2ConfigPath: l2,
+    });
+    expect(r.source).toBe("layer2");
+    expect(r.mode).toBe("cluster");
+  });
+
+  test("whitespace-only env ⇒ cleared after trim, falls through", () => {
+    const dir = fixtureDir();
+    const l2 = writeConfig(dir, "layer2.json", "cluster");
+    const r = resolveDeploymentMode({
+      env: { CATALYST_DEPLOYMENT_MODE: "   " },
+      layer1ConfigPath: missingPath(dir, "layer1.json"),
+      layer2ConfigPath: l2,
+    });
+    expect(r.source).toBe("layer2");
+    expect(r.mode).toBe("cluster");
+  });
+
+  test("mixed-case / boundary-whitespace value normalizes to canonical member", () => {
+    const dir = fixtureDir();
+    const r = resolveDeploymentMode({
+      env: { CATALYST_DEPLOYMENT_MODE: "  Cluster  " },
+      layer1ConfigPath: missingPath(dir, "layer1.json"),
+      layer2ConfigPath: missingPath(dir, "layer2.json"),
+    });
+    expect(r).toEqual({ mode: "cluster", source: "env", inferred: false, recognized: true, raw: "  Cluster  " });
+  });
+});
+
+describe("resolveDeploymentMode — soft-failure degradations", () => {
+  test("present-but-non-string env value degrades to single-host, recognized:false, AT the env source", () => {
+    const dir = fixtureDir();
+    const r = resolveDeploymentMode({
+      env: { CATALYST_DEPLOYMENT_MODE: 123 },
+      layer1ConfigPath: missingPath(dir, "layer1.json"),
+      layer2ConfigPath: missingPath(dir, "layer2.json"),
+    });
+    expect(r).toEqual({ mode: "single-host", source: "env", inferred: false, recognized: false, raw: 123 });
+  });
+
+  test("present-but-non-string Layer-2 value (boolean) degrades AT layer2, does not fall through", () => {
+    const dir = fixtureDir();
+    const l2 = writeConfig(dir, "layer2.json", true);
+    const l1 = writeConfig(dir, "layer1.json", "cluster"); // must be ignored — layer2 already settled
+    const r = resolveDeploymentMode({ env: {}, layer1ConfigPath: l1, layer2ConfigPath: l2 });
+    expect(r).toEqual({ mode: "single-host", source: "layer2", inferred: false, recognized: false, raw: true });
+  });
+
+  test("present-but-non-string Layer-1 value (array) degrades AT layer1", () => {
+    const dir = fixtureDir();
+    const l1 = writeConfig(dir, "layer1.json", []);
+    const r = resolveDeploymentMode({
+      env: {},
+      layer1ConfigPath: l1,
+      layer2ConfigPath: missingPath(dir, "layer2.json"),
+    });
+    expect(r).toEqual({ mode: "single-host", source: "layer1", inferred: false, recognized: false, raw: [] });
+  });
+
+  test("unrecognized string (typo) at env degrades to single-host, source env", () => {
+    const dir = fixtureDir();
+    const r = resolveDeploymentMode({
+      env: { CATALYST_DEPLOYMENT_MODE: "clustre" },
+      layer1ConfigPath: missingPath(dir, "layer1.json"),
+      layer2ConfigPath: missingPath(dir, "layer2.json"),
+    });
+    expect(r).toEqual({
+      mode: "single-host",
+      source: "env",
+      inferred: false,
+      recognized: false,
+      raw: "clustre",
+    });
+  });
+
+  test("unrecognized string (typo) at Layer-2 degrades AT layer2, does not fall through to a valid Layer-1", () => {
+    const dir = fixtureDir();
+    const l2 = writeConfig(dir, "layer2.json", "clustre");
+    const l1 = writeConfig(dir, "layer1.json", "cluster");
+    const r = resolveDeploymentMode({ env: {}, layer1ConfigPath: l1, layer2ConfigPath: l2 });
+    expect(r).toEqual({
+      mode: "single-host",
+      source: "layer2",
+      inferred: false,
+      recognized: false,
+      raw: "clustre",
+    });
+  });
+
+  test("unrecognized string (typo) at Layer-1 degrades to single-host, source layer1", () => {
+    const dir = fixtureDir();
+    const l1 = writeConfig(dir, "layer1.json", "clowd");
+    const r = resolveDeploymentMode({
+      env: {},
+      layer1ConfigPath: l1,
+      layer2ConfigPath: missingPath(dir, "layer2.json"),
+    });
+    expect(r).toEqual({ mode: "single-host", source: "layer1", inferred: false, recognized: false, raw: "clowd" });
+  });
+});
+
+describe("resolveDeploymentMode — never throws", () => {
+  test("default env param (process.env) is accepted with no options object", () => {
+    expect(() => resolveDeploymentMode()).not.toThrow();
+  });
+  test("layer1/layer2 paths pointing at a directory (not a file) degrade gracefully", () => {
+    const dir = fixtureDir();
+    const r = resolveDeploymentMode({ env: {}, layer1ConfigPath: dir, layer2ConfigPath: dir });
+    expect(r.source).toBe("default");
+    expect(r.mode).toBe("single-host");
+  });
+});
+
+describe("getDeploymentMode", () => {
+  test("returns the resolved mode string", () => {
+    const mode = getDeploymentMode();
+    expect(DEPLOYMENT_MODES).toContain(mode);
+  });
+
+  test("warns at most once per distinct message (dedup Set), never throws on repeat calls", () => {
+    const dir = fixtureDir();
+    // Deterministic fixture, not the real process.env/filesystem: an
+    // unrecognized string at env forces the !recognized WARN branch to fire
+    // on every call (unlike the ambient environment, which may already be
+    // explicit/recognized and never warn at all — a prior version of this
+    // test called bare getDeploymentMode() and could pass vacuously with an
+    // empty `calls` array whenever the warn path didn't fire).
+    const opts = {
+      env: { CATALYST_DEPLOYMENT_MODE: "warn-dedup-fixture-typo-ctl-1617" },
+      layer1ConfigPath: missingPath(dir, "layer1.json"),
+      layer2ConfigPath: missingPath(dir, "layer2.json"),
+    };
+
+    const original = console.warn;
+    const calls = [];
+    console.warn = (...args) => calls.push(args.join(" "));
+    try {
+      getDeploymentMode(opts);
+      getDeploymentMode(opts);
+      getDeploymentMode(opts);
+    } finally {
+      console.warn = original;
+    }
+    // The warn path must actually have fired at least once — this is the
+    // assertion the vacuous bare-call version could never make.
+    expect(calls.length).toBeGreaterThan(0);
+    // Every emitted warning line is unique — no message repeats across the
+    // three calls (the dedup Set collapses repeats to zero further prints):
+    // three identical-fixture calls produce exactly one warn line.
+    expect(new Set(calls).size).toBe(calls.length);
+    expect(calls.length).toBe(1);
+  });
+});

--- a/plugins/dev/scripts/lib/deployment-mode.test.mjs
+++ b/plugins/dev/scripts/lib/deployment-mode.test.mjs
@@ -1,5 +1,5 @@
 import { describe, test, expect, afterEach } from "bun:test";
-import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { resolve } from "node:path";
 import { DEPLOYMENT_MODES, resolveDeploymentMode, getDeploymentMode } from "./deployment-mode.mjs";
@@ -248,6 +248,93 @@ describe("resolveDeploymentMode — never throws", () => {
     const r = resolveDeploymentMode({ env: {}, layer1ConfigPath: dir, layer2ConfigPath: dir });
     expect(r.source).toBe("default");
     expect(r.mode).toBe("single-host");
+  });
+});
+
+describe("resolveLayer2Path — injected HOME (Codex remediation, CTL-1617)", () => {
+  test("reads Layer-2 from env.HOME, not the real process homedir, when no explicit path/override is given", () => {
+    // Reproduces the bug exactly: NO layer2ConfigPath and NO
+    // CATALYST_LAYER2_CONFIG_FILE override — the only two things that used
+    // to matter — so resolution falls all the way to the homedir()
+    // fallback, which previously ignored the injected env entirely.
+    const fixtureHome = fixtureDir();
+    mkdirSync(resolve(fixtureHome, ".config", "catalyst"), { recursive: true });
+    writeFileSync(
+      resolve(fixtureHome, ".config", "catalyst", "config.json"),
+      JSON.stringify({ catalyst: { deployment: { mode: "cloud" } } }),
+    );
+
+    const r = resolveDeploymentMode({
+      env: { HOME: fixtureHome },
+      layer1ConfigPath: missingPath(fixtureDir(), "layer1.json"),
+      // layer2ConfigPath deliberately omitted — must fall through to
+      // env.HOME, not the real user's home.
+    });
+
+    expect(r).toEqual({
+      mode: "cloud",
+      source: "layer2",
+      inferred: false,
+      recognized: true,
+      raw: "cloud",
+    });
+  });
+
+  test("does not read the REAL process homedir's config when an isolated env.HOME is injected", () => {
+    // Guards against a false-positive fixture: if the real developer machine
+    // happens to also have ~/.config/catalyst/config.json with a deployment
+    // mode set, a bug that reads the real homedir() instead of the injected
+    // one could still coincidentally settle at layer2 with SOME value. This
+    // asserts the isolated fixture home — which has no Layer-1 file and an
+    // ABSENT Layer-2 file — resolves to the constant default, proving
+    // neither layer leaked in from the real homedir().
+    const fixtureHome = fixtureDir();
+    // No .config/catalyst/config.json written under fixtureHome at all.
+    const r = resolveDeploymentMode({
+      env: { HOME: fixtureHome },
+      layer1ConfigPath: missingPath(fixtureHome, "layer1.json"),
+    });
+    expect(r.source).toBe("default");
+    expect(r.mode).toBe("single-host");
+  });
+
+  test("an explicit layer2ConfigPath still wins over env.HOME (no regression)", () => {
+    const dir = fixtureDir();
+    const fixtureHome = fixtureDir();
+    const l2 = writeConfig(dir, "layer2.json", "cluster");
+    const r = resolveDeploymentMode({
+      env: { HOME: fixtureHome },
+      layer1ConfigPath: missingPath(dir, "layer1.json"),
+      layer2ConfigPath: l2,
+    });
+    expect(r.mode).toBe("cluster");
+    expect(r.source).toBe("layer2");
+  });
+
+  test("CATALYST_LAYER2_CONFIG_FILE override still wins over env.HOME (no regression)", () => {
+    const dir = fixtureDir();
+    const fixtureHome = fixtureDir();
+    const l2 = writeConfig(dir, "layer2.json", "cluster");
+    const r = resolveDeploymentMode({
+      env: { HOME: fixtureHome, CATALYST_LAYER2_CONFIG_FILE: l2 },
+      layer1ConfigPath: missingPath(dir, "layer1.json"),
+    });
+    expect(r.mode).toBe("cluster");
+    expect(r.source).toBe("layer2");
+  });
+
+  test("real process homedir() is still the fallback when env.HOME itself is absent (production default)", () => {
+    // No env override at all — resolveLayer2Path must still fall back to
+    // node:os homedir() exactly as before this fix, not throw or resolve to
+    // some empty/undefined path.
+    const r = resolveDeploymentMode({
+      env: {},
+      layer1ConfigPath: missingPath(fixtureDir(), "layer1.json"),
+    });
+    // Whatever the real machine's Layer-2/Layer-1 file says (or doesn't),
+    // this must not throw, and must resolve to a valid enum member (the
+    // resolver's own contract — it never fails the caller).
+    expect(DEPLOYMENT_MODES).toContain(r.mode);
   });
 });
 

--- a/plugins/dev/scripts/lib/deployment-mode.test.mjs
+++ b/plugins/dev/scripts/lib/deployment-mode.test.mjs
@@ -377,4 +377,32 @@ describe("getDeploymentMode", () => {
     expect(new Set(calls).size).toBe(calls.length);
     expect(calls.length).toBe(1);
   });
+
+  // Codex round 2: a valid JSON misconfiguration like {"mode": {"toString":
+  // null}} resolves safely (single-host, recognized:false) but a template
+  // literal `${raw}` in the WARN threw TypeError (shadowed toString) —
+  // breaking the never-throws contract on exactly the degraded path the WARN
+  // exists to report.
+  test("a toString-shadowing raw value warns without throwing", () => {
+    const dir = fixtureDir();
+    const l2 = resolve(dir, "layer2-tostring.json");
+    writeFileSync(l2, '{"catalyst":{"deployment":{"mode":{"toString":null}}}}');
+    const opts = {
+      env: {},
+      layer1ConfigPath: missingPath(dir, "layer1.json"),
+      layer2ConfigPath: l2,
+    };
+    const original = console.warn;
+    const calls = [];
+    console.warn = (...args) => calls.push(args.join(" "));
+    let mode;
+    try {
+      mode = getDeploymentMode(opts);
+    } finally {
+      console.warn = original;
+    }
+    expect(mode).toBe("single-host");
+    expect(calls.length).toBe(1);
+    expect(calls[0]).toContain('{"toString":null}');
+  });
 });

--- a/plugins/dev/templates/config.template.json
+++ b/plugins/dev/templates/config.template.json
@@ -55,6 +55,9 @@
         "botUserId": null
       }
     },
+    "deployment": {
+      "mode": "single-host"
+    },
     "orchestration": {
       "_comment": "Worker dispatch mode. 'phase-agents' (default) dispatches the 9-phase pipeline on claude --bg; 'oneshot-legacy' keeps the pre-CTL-452 single-shot oneshot worker on claude -p.",
       "dispatchMode": "phase-agents",

--- a/website/src/content/docs/reference/configuration.md
+++ b/website/src/content/docs/reference/configuration.md
@@ -512,6 +512,67 @@ name — never the value).
 { "catalyst": { "linearReplica": { "mode": "on" } } }
 ```
 
+## Deployment mode (`catalyst.deployment.mode`, CTL-1617)
+
+`catalyst.deployment.mode` is the ONE declared answer to a question the system otherwise infers from
+side effects — whether a webhook tunnel happens to be configured, whether a cluster roster happens to
+resolve to more than one host. It is resolved **identically** by two independently maintained
+implementations — `lib/deployment-mode.mjs` (Node/ESM) and `lib/catalyst-deployment-mode.sh` (the
+Bash mirror, since Bash cannot import a JS leaf) — kept honest by a fixture-matrix cross-stack parity
+test (`__tests__/deployment-mode-parity.test.sh`).
+
+| Value                  | Meaning                                                                                                                       |
+| ---------------------- | ------------------------------------------------------------------------------------------------------------------------------ |
+| `single-host` (default) | A lone node — no cluster substrate expected.                                                                                  |
+| `cluster`               | A coordinated multi-host fleet; roster/HRW/liveness are graded by `catalyst doctor`.                                          |
+| `cloud`                 | A managed-container node; the smee webhook tunnel must NOT be live and secrets are platform-delivered.                       |
+
+A 4th `both` value was deliberately rejected (CTL-1617 design §2) — the provider's own
+`webhook.delivery.id` already makes concurrent smee+cloud ingestion dedup-safe without one.
+
+Deployment mode is genuinely **fleet-scoped**, so — unlike `catalyst.node.class` — it lives primarily
+in **Layer-1** (committed, shared by the whole repo checkout), with a **Layer-2 override** as the
+exception hatch (e.g. a laptop dev-clone of a cluster-declared repo overriding to `single-host`):
+
+```json
+// .catalyst/config.json (Layer-1, fleet-wide default)
+{ "catalyst": { "deployment": { "mode": "cluster" } } }
+```
+
+```json
+// ~/.config/catalyst/config.json (Layer-2, per-host override)
+{ "catalyst": { "deployment": { "mode": "single-host" } } }
+```
+
+**Resolution** (`resolveDeploymentMode()` / `catalyst_resolve_deployment_mode`):
+
+| Precedence | Source                                                |
+| ---------- | ------------------------------------------------------ |
+| 1          | `CATALYST_DEPLOYMENT_MODE` env var                     |
+| 2          | `catalyst.deployment.mode` in the Layer-2 config       |
+| 3          | `catalyst.deployment.mode` in the Layer-1 config       |
+| 4          | constant default `single-host`                         |
+
+- **Absent everywhere ⇒ `single-host`** — zero-config, zero-behavior-change. A WARN notes the value
+  was inferred.
+- **An explicit but unrecognized value** (a typo) never silently activates cluster/cloud behavior —
+  it degrades to `single-host` (the safest direction) at the layer it was found, and `catalyst doctor`
+  **FAILs** until corrected.
+- A missing/malformed config file, or a present-but-non-string value (`true`, `123`, `[]`), both
+  settle rather than throw — see `lib/deployment-mode.mjs`'s `classifyCandidate` for the full validity
+  ladder.
+- **ENV-vs-FILE asymmetry**: `CATALYST_DEPLOYMENT_MODE` is captured into a long-lived daemon's
+  environment once, at launch. Layer-1/Layer-2 file edits are picked up **live**, on every call. A
+  daemon needs restarting for an env change to take effect.
+- **jq-absent degradation (Bash resolver only)**: when `jq` is unavailable, a Layer-1/Layer-2 file
+  that could otherwise decide the mode is treated as absent (falls through) instead of failing the
+  caller; the resolver exports `CATALYST_DEPLOYMENT_MODE_JQ_MISSING=1` as a loud breadcrumb so
+  `catalyst doctor` can grade a host silently degrading on this axis.
+
+PR1 (this file) ships the resolver in isolation — nothing outside its own tests imports it yet; wiring
+into webhook ingestion gating, secret-provider selection, and `catalyst doctor`'s roster-consistency
+checks lands in later PRs of the CTL-1617 migration plan.
+
 ## GitHub merge rules live in GitHub
 
 Catalyst can open PRs, fix CI, answer review bots, and merge. But GitHub decides what must pass

--- a/website/src/content/docs/reference/configuration.md
+++ b/website/src/content/docs/reference/configuration.md
@@ -534,13 +534,15 @@ Deployment mode is genuinely **fleet-scoped**, so — unlike `catalyst.node.clas
 in **Layer-1** (committed, shared by the whole repo checkout), with a **Layer-2 override** as the
 exception hatch (e.g. a laptop dev-clone of a cluster-declared repo overriding to `single-host`):
 
+In `.catalyst/config.json` (Layer-1, fleet-wide default):
+
 ```json
-// .catalyst/config.json (Layer-1, fleet-wide default)
 { "catalyst": { "deployment": { "mode": "cluster" } } }
 ```
 
+In `~/.config/catalyst/config.json` (Layer-2, per-host override):
+
 ```json
-// ~/.config/catalyst/config.json (Layer-2, per-host override)
 { "catalyst": { "deployment": { "mode": "single-host" } } }
 ```
 
@@ -553,11 +555,13 @@ exception hatch (e.g. a laptop dev-clone of a cluster-declared repo overriding t
 | 3          | `catalyst.deployment.mode` in the Layer-1 config       |
 | 4          | constant default `single-host`                         |
 
-- **Absent everywhere ⇒ `single-host`** — zero-config, zero-behavior-change. A WARN notes the value
-  was inferred.
+- **Absent everywhere ⇒ `single-host`** — zero-config, zero-behavior-change. (Once wired: a WARN
+  will note the value was inferred — the resolver itself is deliberately log-free; the WARN lives in
+  the `getDeploymentMode()` convenience wrapper, and doctor wiring lands in PR2 of the CTL-1617
+  migration plan.)
 - **An explicit but unrecognized value** (a typo) never silently activates cluster/cloud behavior —
-  it degrades to `single-host` (the safest direction) at the layer it was found, and `catalyst doctor`
-  **FAILs** until corrected.
+  it degrades to `single-host` (the safest direction) at the layer it was found. (Future behavior,
+  PR2: `catalyst doctor` will FAIL until the value is corrected.)
 - A missing/malformed config file, or a present-but-non-string value (`true`, `123`, `[]`), both
   settle rather than throw — see `lib/deployment-mode.mjs`'s `classifyCandidate` for the full validity
   ladder.
@@ -566,8 +570,9 @@ exception hatch (e.g. a laptop dev-clone of a cluster-declared repo overriding t
   daemon needs restarting for an env change to take effect.
 - **jq-absent degradation (Bash resolver only)**: when `jq` is unavailable, a Layer-1/Layer-2 file
   that could otherwise decide the mode is treated as absent (falls through) instead of failing the
-  caller; the resolver exports `CATALYST_DEPLOYMENT_MODE_JQ_MISSING=1` as a loud breadcrumb so
-  `catalyst doctor` can grade a host silently degrading on this axis.
+  caller; the resolver exports `CATALYST_DEPLOYMENT_MODE_JQ_MISSING=1` as a breadcrumb (reset at the
+  start of every resolution, so it always reflects the latest call). Grading that breadcrumb is
+  future doctor work (PR2) — nothing consumes it yet.
 
 PR1 (this file) ships the resolver in isolation — nothing outside its own tests imports it yet; wiring
 into webhook ingestion gating, secret-provider selection, and `catalyst doctor`'s roster-consistency


### PR DESCRIPTION
## Summary

PR1 of the CTL-1617 migration plan (design: `thoughts/shared/research/2026-08-02-ctl-1617-deployment-mode-design.md`, synthesized from a 3-design judge panel): the **deployment-mode resolver in isolation** — one declared answer `catalyst.deployment.mode ∈ {single-host, cluster, cloud}` resolved identically in bash and JS, with **zero consumers** (PR2 wires execution-core + doctor, PR3 the orch-monitor tunnel gate, PR4 declares the fleet).

## What's here

- `lib/deployment-mode.mjs` + `.d.mts` — zero-import leaf. Ladder: `CATALYST_DEPLOYMENT_MODE` env → Layer-2 → Layer-1 → constant `single-host` default (never roster-inferred, per judge-panel fatal-flaw ruling). Returns `{mode, source, inferred, recognized, raw}` (the `resolveNodeClass` shape). Non-string / typo values settle **degraded at their layer** (`single-host`, `recognized:false`) — never silent fallthrough.
- `lib/catalyst-deployment-mode.sh` — bash mirror: type-aware jq extraction (absent/null fall through; non-string settles degraded — jq's `// empty` swallowing JSON `false` was an empirically-proven bash/JS divergence), parameter-expansion trim (xargs re-parsed quotes and missed `\r` — four more proven divergences), `set -u` safe, side-channel exports `_RESOLVED/_SOURCE/_RECOGNIZED/_INFERRED`.
- `__tests__/deployment-mode-parity.test.sh` — **exhaustive 168-cell** fixture matrix (7 env × 6 Layer-2 × 4 Layer-1 including hostile cells: embedded/unmatched quotes, apostrophe, CRLF, JSON `false`/`123`/`true`), asserting **bash==expected AND node==expected** per cell.
- `__tests__/catalyst-deployment-mode.test.sh` — 21 bash-only unit tests.
- Schema entries (`catalyst-config.schema.json`, `machine-config.schema.json`) + `config.template.json` default.

## Verification

- 24 (bun) + 21 (bash) + 336 (parity) assertions green; shellcheck clean; JSON files validate.
- Two adversarial verification rounds: round 1 empirically proved 5 bash/JS divergences (all fixed); round 2 passed with 11/11 hostile probes agreeing bash==node==design-expectation.
- Grep-verified: nothing outside tests imports the new module (PR1 invariant).

Linear: CTL-1617

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WHfJt1JhsdArSUyxwZZzkN