### PR TITLE
fix(dev): orch-monitor — mobile nav trigger + Linear reply-token identity walk

### DIFF
--- a/plugins/dev/scripts/orch-monitor/__tests__/app-shell.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/app-shell.test.ts
@@ -214,9 +214,13 @@ describe("one header: no search box, no SidebarTrigger collapse icon (CTL-1003)"
     expect(shellSrc).toContain("CommandDialog");
   });
 
-  it("the SidebarTrigger collapse icon + its Separator are removed from the header", () => {
-    // `[` / Cmd-B still toggle via shouldToggleSidebar — only the visible icon goes.
-    expect(shellSrc).not.toContain("SidebarTrigger");
+  it("the SidebarTrigger collapse icon's Separator stays removed; the icon itself is DESKTOP-hidden, not gone (mobile-nav fix)", () => {
+    // `[` / Cmd-B still toggle via shouldToggleSidebar on desktop. CTL-1003 removed
+    // the always-visible SidebarTrigger; the mobile-nav follow-up restored it, but
+    // ONLY behind `md:hidden` — below `md` the off-canvas Sheet has no keyboard
+    // (iOS Safari) and no other tap target, so a narrow-viewport icon is required.
+    // The Separator (a purely cosmetic divider) was NOT restored.
+    expect(shellSrc).toMatch(/<SidebarTrigger className="[^"]*\bmd:hidden\b[^"]*"/);
     expect(shellSrc).not.toMatch(/from "@\/components\/ui\/separator"/);
     expect(shellSrc).toContain("shouldToggleSidebar");
   });

--- a/plugins/dev/scripts/orch-monitor/lib/linear-comment.d.mts
+++ b/plugins/dev/scripts/orch-monitor/lib/linear-comment.d.mts
@@ -41,6 +41,15 @@ export type PostCommentResult =
   | { status: "not_found"; ticket: string; message: string }
   | { status: "error"; message: string };
 
+/** Every configured personal-token candidate, in priority order, deduplicated,
+ *  empty/falsy entries dropped. `postOperatorComment` identity-checks each in
+ *  turn instead of trusting the first non-empty string. */
+export function linearTokenCandidates(
+  env?: Record<string, string | undefined>,
+  opts?: { projectConfig?: unknown },
+): string[];
+
+/** The single highest-priority candidate (`linearTokenCandidates(...)[0]`). */
 export function resolveLinearToken(
   env?: Record<string, string | undefined>,
   opts?: { projectConfig?: unknown },

--- a/plugins/dev/scripts/orch-monitor/lib/linear-comment.mjs
+++ b/plugins/dev/scripts/orch-monitor/lib/linear-comment.mjs
@@ -44,14 +44,16 @@
 // success payload while silently not applying — the GraphQL path is the one that
 // demonstrably works for mutations. Reads stay on the replica (linear-thread.mjs).
 
-// CTL-1616 PR3: fold the env-alias leg of resolveLinearToken's chain onto the
-// shared secret-contract engine (design §8 PR3 table — this file was the one
-// outlier using `||` where the other 8 hand-rolled copies used `??`). Only the
-// env-alias LEG folds here: the Layer-2 `linear.apiToken` personal-token
-// fallback below is this file's own distinct chain (a different secret from
-// the registry's `linear-api-token` row's config-json shape) and is out of
-// scope for this PR.
-import { resolveSecret } from "../../lib/secret-contract.mjs";
+// CTL-1616 PR3 folded the env-alias leg of the OLD single-value
+// resolveLinearToken onto the shared secret-contract engine's resolveSecret().
+// #19 (below) supersedes that here: this file's `linearTokenCandidates` needs
+// LINEAR_API_TOKEN and LINEAR_API_KEY as two INDEPENDENT candidates (walking
+// each one's identity, since they can legitimately hold different
+// credentials), and resolveSecret's alias ladder collapses them to one value
+// — so this file reads the two env vars directly instead of importing
+// resolveSecret. Any future site here that only needs a single canonical
+// value (not a multi-candidate identity walk) should still prefer
+// resolveSecret("linear-api-token", ...) over a hand-rolled `??` ladder.
 
 const LINEAR_GRAPHQL_URL = "https://api.linear.app/graphql";
 
@@ -60,7 +62,8 @@ const LINEAR_GRAPHQL_URL = "https://api.linear.app/graphql";
 const REQUEST_TIMEOUT_MS = 15_000;
 
 /**
- * Resolve the Linear credential to post the reply with.
+ * Every place a personal Linear token might be configured, in priority order,
+ * deduplicated, empty/falsy entries dropped.
  *
  * ── why this cannot be env-only ──────────────────────────────────────────────
  * An env-only resolver makes this feature INERT on the normal persistent launch
@@ -71,27 +74,53 @@ const REQUEST_TIMEOUT_MS = 15_000;
  * though Linear is fully configured — the same class of silent no-op the
  * authorship gate exists to prevent, arriving through a different door.
  *
- * Order: env (`LINEAR_API_TOKEN`, then the `LINEAR_API_KEY` alias) → Layer-2
- * `linear.apiToken`.
+ * ── why the FIRST non-empty candidate is not good enough either (2026-08-02) ──
+ * `LINEAR_API_TOKEN`/`LINEAR_API_KEY` are not exclusively a personal-token slot:
+ * `lib/linear-app-actor.sh` exports the APP-ACTOR's own OAuth token into these
+ * exact two names for any daemon (broker/execution-core/monitor) that needs bot
+ * credentials for its normal automated reads/writes — a monitor process that also
+ * sources that script (as fixed for the CAT-1 liveness dashboard) will ALWAYS
+ * have a non-empty `LINEAR_API_TOKEN`, but it is the bot's, not a human's. The
+ * old "first non-empty string wins" resolver stopped right there and never even
+ * looked at Layer-2 config, so a correctly-configured personal `linear.apiToken`
+ * was permanently unreachable on such a host — not a missing-config problem, an
+ * unreachable-config one. `postOperatorComment` below now walks EVERY candidate
+ * this function returns and identity-checks each one, so a bot-shaped env value
+ * no longer shadows a genuine personal token sitting in config.
  *
- * ── the one credential we must NEVER fall back to ────────────────────────────
+ * Order: env `LINEAR_API_TOKEN` → env `LINEAR_API_KEY` → Layer-2 `linear.apiToken`
+ * → Layer-2 `catalyst.linear.apiToken` (BOTH config shapes are accepted —
+ * `linear.apiToken` is what the reference schema documents
+ * (website/.../reference/configuration.md) and what real installs carry, while
+ * the nested `catalyst.linear.apiToken` shows up in some setups; reading only one
+ * shape means a validly-configured host can still resolve nothing).
+ *
+ * ── the one credential we must NEVER include ─────────────────────────────────
  * The same Layer-2 file also carries `catalyst.linear.agent.accessToken` — an
  * APP-ACTOR OAuth token. Reaching for it would post the reply as the app, which
  * CTL-1567's provenance gate ignores, making the reply silently do nothing. It is
- * deliberately NOT in the chain. (The authorship gate below would catch it anyway;
- * this is the belt to that braces.)
+ * deliberately NOT in this list. (The authorship gate would catch it anyway if it
+ * somehow got resolved to a human-looking viewer; this is the belt to that brace.)
  */
-export function resolveLinearToken(env = process.env, { projectConfig = null } = {}) {
-  // CTL-1616 PR3: was `env.LINEAR_API_TOKEN || env.LINEAR_API_KEY || null` —
-  // folded onto resolveSecret's env-alias resolver (same alias precedence,
-  // same `env` injected here for tests). Precise semantics, unchanged from
-  // the old `||` ladder: an EMPTY-STRING token falls through to
-  // LINEAR_API_KEY (falsy before, non-empty-check now); a WHITESPACE-ONLY
-  // token wins the env leg in BOTH versions (truthy before, non-empty now),
-  // then fails the `.trim()` check below and falls to the Layer-2 personal
-  // token — SKIPPING LINEAR_API_KEY, exactly as it always did.
-  const fromEnv = resolveSecret("linear-api-token", { env }).value;
-  if (typeof fromEnv === "string" && fromEnv.trim() !== "") return fromEnv.trim();
+export function linearTokenCandidates(env = process.env, { projectConfig = null } = {}) {
+  const candidates = [];
+  const add = (v) => {
+    if (typeof v !== "string") return;
+    const trimmed = v.trim();
+    if (trimmed !== "" && !candidates.includes(trimmed)) candidates.push(trimmed);
+  };
+  // CTL-1616 PR3 folded the OLD single-value `resolveLinearToken` onto
+  // resolveSecret's env-alias resolver (TOKEN-before-KEY precedence, one
+  // value out). That collapse is right for a caller that wants "the one
+  // token", but WRONG here: this function's entire purpose (#19) is walking
+  // every DISTINCT raw candidate's identity, because LINEAR_API_TOKEN and
+  // LINEAR_API_KEY can legitimately hold two different credentials (e.g. a
+  // bot token in one, a human's in the other) — resolveSecret would silently
+  // discard whichever alias it doesn't pick, defeating the multi-candidate
+  // walk. So the two env aliases stay independent entries here; resolveSecret
+  // is still the right call for any site that only needs a single value.
+  add(env.LINEAR_API_TOKEN);
+  add(env.LINEAR_API_KEY);
   // Layer-2 personal token — the launchd path's only source. BOTH shapes are
   // accepted: `linear.apiToken` is what the reference schema documents
   // (website/.../reference/configuration.md) and what real installs carry, while
@@ -99,13 +128,19 @@ export function resolveLinearToken(env = process.env, { projectConfig = null } =
   // one shape means a validly-configured host resolves nothing and every reply
   // returns `no_token` — the failure this whole fallback exists to prevent, so it
   // is not worth being narrow about.
-  for (const candidate of [
-    projectConfig?.linear?.apiToken,
-    projectConfig?.catalyst?.linear?.apiToken,
-  ]) {
-    if (typeof candidate === "string" && candidate.trim() !== "") return candidate.trim();
-  }
-  return null;
+  add(projectConfig?.linear?.apiToken);
+  add(projectConfig?.catalyst?.linear?.apiToken);
+  return candidates;
+}
+
+/**
+ * The single highest-priority Linear credential. Kept for any caller that only
+ * ever wants "the one token" (e.g. `resolveIssueId` doesn't care about identity);
+ * `postOperatorComment` uses `linearTokenCandidates` directly instead, since it
+ * must try every candidate's IDENTITY, not just take the first non-empty string.
+ */
+export function resolveLinearToken(env = process.env, opts = {}) {
+  return linearTokenCandidates(env, opts)[0] ?? null;
 }
 
 /**
@@ -267,63 +302,10 @@ const COMMENT_CREATE = `
   }
 `;
 
-/**
- * Post a comment to a Linear ticket as the operator.
- *
- * Discriminated result — the route maps each to an HTTP status, and EVERY
- * non-`posted` outcome must restore the inbox row (§4):
- *
- *   { status: "posted", commentId, author }   → the comment is live and
- *                                               human-authored; CTL-1567 will
- *                                               clear `needs-human` within seconds.
- *   { status: "no_token" }                    → no Linear credential in this env.
- *   { status: "bot_identity", author }        → REFUSED before posting: the token
- *                                               is an app actor, so the comment
- *                                               could not have resolved the ask.
- *   { status: "empty_body" }                  → nothing to say; not a Linear call.
- *   { status: "not_found", ticket }           → no such issue.
- *   { status: "error", message }              → transport / API / mutation failure.
- *
- * All collaborators are injected so every branch is unit-tested with no network.
- */
-export async function postOperatorComment(
-  { ticket, body },
-  {
-    fetchImpl = fetch,
-    env = process.env,
-    config = null,
-    projectConfig = null,
-    resolveIdentity = resolveAuthorIdentity,
-    resolveIssue = resolveIssueId,
-  } = {},
-) {
-  // Emptiness is validated on the TRIMMED value, but the body posted below is the
-  // operator's verbatim text — see the postBody note.
-  if (typeof body !== "string" || body.trim() === "") return { status: "empty_body" };
-
-  const token = resolveLinearToken(env, { projectConfig });
-  if (token == null) return { status: "no_token" };
-
-  // ── the authorship gate ────────────────────────────────────────────────────
-  // Resolve identity BEFORE mutating. A bot token is refused with nothing posted,
-  // so the operator is told the truth instead of being shown a phantom success.
-  const identity = await resolveIdentity(
-    { token, botUserIds: knownBotUserIds({ config, projectConfig }) },
-    { fetchImpl },
-  );
-  if (!identity.ok) {
-    return { status: "error", message: `could not verify comment authorship: ${identity.error}` };
-  }
-  if (identity.isBot) {
-    return {
-      status: "bot_identity",
-      author: { id: identity.id, name: identity.name },
-      message:
-        "refused: this monitor's Linear token is an app actor, and CTL-1567 ignores " +
-        "app-actor comments — the reply would not have cleared needs-human.",
-    };
-  }
-
+/** The issue-lookup + commentCreate tail, run only once a candidate token has
+ *  resolved to a genuine human identity. Split out so postOperatorComment's
+ *  candidate loop doesn't duplicate it per-candidate. */
+async function createComment({ token, ticket, body, identity, fetchImpl, resolveIssue }) {
   const issue = await resolveIssue({ token, ticket }, { fetchImpl });
   if (!issue.ok) {
     // Only a CONFIRMED miss is `not_found`. An HTTP 500 during the lookup is a
@@ -361,5 +343,98 @@ export async function postOperatorComment(
       id: typeof user?.id === "string" ? user.id : identity.id,
       name: typeof user?.name === "string" ? user.name : identity.name,
     },
+  };
+}
+
+/**
+ * Post a comment to a Linear ticket as the operator.
+ *
+ * Discriminated result — the route maps each to an HTTP status, and EVERY
+ * non-`posted` outcome must restore the inbox row (§4):
+ *
+ *   { status: "posted", commentId, author }   → the comment is live and
+ *                                               human-authored; CTL-1567 will
+ *                                               clear `needs-human` within seconds.
+ *   { status: "no_token" }                    → no Linear credential anywhere.
+ *   { status: "bot_identity", author }        → REFUSED before posting: every
+ *                                               configured token is an app actor,
+ *                                               so the comment could not have
+ *                                               resolved the ask.
+ *   { status: "empty_body" }                  → nothing to say; not a Linear call.
+ *   { status: "not_found", ticket }           → no such issue.
+ *   { status: "error", message }              → transport / API / mutation failure.
+ *
+ * ── multi-candidate identity walk (2026-08-02 fix) ───────────────────────────
+ * `linearTokenCandidates` may return several tokens (env AND config both set —
+ * e.g. env holds the app-actor's OAuth token per `linear-app-actor.sh`, config
+ * holds the operator's real personal key). Each is identity-checked IN ORDER;
+ * the first one that resolves to a genuine human posts the comment. A candidate
+ * that resolves to a bot is not a hard failure — it just means "try the next
+ * one" — so a personal token in Layer-2 config is no longer permanently
+ * shadowed by a bot token that happens to occupy the higher-priority env slot.
+ * Only when EVERY candidate is exhausted (all bot, or none configured at all)
+ * does this return a failure — `bot_identity` if at least one candidate
+ * resolved (as a bot), `no_token` if there were no candidates to try at all.
+ *
+ * All collaborators are injected so every branch is unit-tested with no network.
+ */
+export async function postOperatorComment(
+  { ticket, body },
+  {
+    fetchImpl = fetch,
+    env = process.env,
+    config = null,
+    projectConfig = null,
+    resolveIdentity = resolveAuthorIdentity,
+    resolveIssue = resolveIssueId,
+  } = {},
+) {
+  // Emptiness is validated on the TRIMMED value, but the body posted below is the
+  // operator's verbatim text — see the postBody note.
+  if (typeof body !== "string" || body.trim() === "") return { status: "empty_body" };
+
+  const candidates = linearTokenCandidates(env, { projectConfig });
+  if (candidates.length === 0) return { status: "no_token" };
+
+  const botUserIds = knownBotUserIds({ config, projectConfig });
+  let lastBotIdentity = null;
+  let lastVerifyError = null;
+
+  // ── the authorship gate ────────────────────────────────────────────────────
+  // Resolve identity BEFORE mutating, for EVERY candidate in priority order. A
+  // candidate that resolves to a bot is skipped (not refused) so a later, human
+  // candidate still gets a chance — only exhausting the whole list is a refusal.
+  for (const token of candidates) {
+    const identity = await resolveIdentity({ token, botUserIds }, { fetchImpl });
+    if (!identity.ok) {
+      lastVerifyError = identity.error;
+      continue;
+    }
+    if (identity.isBot) {
+      lastBotIdentity = identity;
+      continue;
+    }
+    // Found a genuine human — post with THIS token/identity, not the first
+    // candidate that happened to be non-empty.
+    return await createComment({ token, ticket, body, identity, fetchImpl, resolveIssue });
+  }
+
+  if (lastBotIdentity) {
+    return {
+      status: "bot_identity",
+      author: { id: lastBotIdentity.id, name: lastBotIdentity.name },
+      message:
+        candidates.length > 1
+          ? `refused: all ${candidates.length} configured Linear tokens resolve to an app ` +
+            "actor, and CTL-1567 ignores app-actor comments — the reply would not have " +
+            "cleared needs-human."
+          : "refused: this monitor's Linear token is an app actor, and CTL-1567 ignores " +
+            "app-actor comments — the reply would not have cleared needs-human.",
+    };
+  }
+  // No candidate ever resolved to a bot — every one errored (network/auth/etc).
+  return {
+    status: "error",
+    message: `could not verify comment authorship: ${lastVerifyError ?? "unknown error"}`,
   };
 }

--- a/plugins/dev/scripts/orch-monitor/lib/linear-comment.test.mjs
+++ b/plugins/dev/scripts/orch-monitor/lib/linear-comment.test.mjs
@@ -1,0 +1,308 @@
+// linear-comment.test.mjs — CTL-1569 §4 + the 2026-08-02 multi-candidate
+// identity-walk fix. All collaborators (resolveIdentity/resolveIssue/fetchImpl)
+// are injected so every branch runs with zero network.
+
+import { describe, it, expect } from "bun:test";
+import {
+  linearTokenCandidates,
+  resolveLinearToken,
+  postOperatorComment,
+} from "./linear-comment.mjs";
+
+describe("linearTokenCandidates", () => {
+  it("returns [] with no env and no config", () => {
+    expect(linearTokenCandidates({}, {})).toEqual([]);
+  });
+
+  it("reads LINEAR_API_TOKEN", () => {
+    expect(linearTokenCandidates({ LINEAR_API_TOKEN: "tok-a" }, {})).toEqual(["tok-a"]);
+  });
+
+  it("reads LINEAR_API_KEY when LINEAR_API_TOKEN is absent", () => {
+    expect(linearTokenCandidates({ LINEAR_API_KEY: "tok-b" }, {})).toEqual(["tok-b"]);
+  });
+
+  it("LINEAR_API_TOKEN and LINEAR_API_KEY both present and DIFFERENT: token first, both kept", () => {
+    expect(
+      linearTokenCandidates({ LINEAR_API_TOKEN: "tok-a", LINEAR_API_KEY: "tok-b" }, {}),
+    ).toEqual(["tok-a", "tok-b"]);
+  });
+
+  it("LINEAR_API_TOKEN and LINEAR_API_KEY both present and IDENTICAL: deduplicated to one entry", () => {
+    expect(
+      linearTokenCandidates({ LINEAR_API_TOKEN: "tok-a", LINEAR_API_KEY: "tok-a" }, {}),
+    ).toEqual(["tok-a"]);
+  });
+
+  it("includes Layer-2 linear.apiToken after env", () => {
+    expect(
+      linearTokenCandidates(
+        { LINEAR_API_TOKEN: "tok-a" },
+        { projectConfig: { linear: { apiToken: "tok-personal" } } },
+      ),
+    ).toEqual(["tok-a", "tok-personal"]);
+  });
+
+  it("includes the nested catalyst.linear.apiToken shape too", () => {
+    expect(
+      linearTokenCandidates(
+        {},
+        { projectConfig: { catalyst: { linear: { apiToken: "tok-nested" } } } },
+      ),
+    ).toEqual(["tok-nested"]);
+  });
+
+  it("BOTH linear.apiToken and catalyst.linear.apiToken present and different: both kept", () => {
+    expect(
+      linearTokenCandidates(
+        {},
+        {
+          projectConfig: {
+            linear: { apiToken: "tok-flat" },
+            catalyst: { linear: { apiToken: "tok-nested" } },
+          },
+        },
+      ),
+    ).toEqual(["tok-flat", "tok-nested"]);
+  });
+
+  it("a config candidate identical to an env candidate is deduplicated", () => {
+    expect(
+      linearTokenCandidates(
+        { LINEAR_API_TOKEN: "tok-a" },
+        { projectConfig: { linear: { apiToken: "tok-a" } } },
+      ),
+    ).toEqual(["tok-a"]);
+  });
+
+  it("whitespace-only / empty-string values are ignored, not treated as present", () => {
+    expect(
+      linearTokenCandidates(
+        { LINEAR_API_TOKEN: "   ", LINEAR_API_KEY: "" },
+        { projectConfig: { linear: { apiToken: "tok-real" } } },
+      ),
+    ).toEqual(["tok-real"]);
+  });
+
+  it("trims surrounding whitespace on an otherwise-valid candidate", () => {
+    expect(linearTokenCandidates({ LINEAR_API_TOKEN: "  tok-a  " }, {})).toEqual(["tok-a"]);
+  });
+});
+
+describe("resolveLinearToken (single highest-priority candidate)", () => {
+  it("returns the first candidate", () => {
+    expect(
+      resolveLinearToken(
+        { LINEAR_API_TOKEN: "tok-a" },
+        { projectConfig: { linear: { apiToken: "tok-personal" } } },
+      ),
+    ).toBe("tok-a");
+  });
+
+  it("returns null when there are no candidates", () => {
+    expect(resolveLinearToken({}, {})).toBeNull();
+  });
+});
+
+// ── postOperatorComment ───────────────────────────────────────────────────────
+
+/** A fake resolveIdentity keyed by token → identity result, so a test can give
+ *  distinct candidates distinct (human/bot/error) outcomes and assert exactly
+ *  which token wins. */
+function identityMap(map) {
+  const calls = [];
+  const fn = async ({ token }) => {
+    calls.push(token);
+    const result = map[token];
+    if (!result) throw new Error(`identityMap: no entry for token ${token}`);
+    return result;
+  };
+  fn.calls = calls;
+  return fn;
+}
+
+const HUMAN = { ok: true, id: "user-1", name: "Tony", email: "tony@hagale.net", isMe: true, isBot: false };
+const BOT = { ok: true, id: "bot-1", name: "Catalyst App", email: null, isMe: false, isBot: true };
+const HUMAN2 = { ok: true, id: "user-2", name: "Other Human", email: "other@example.com", isMe: false, isBot: false };
+
+function fakeResolveIssue(result = { ok: true, id: "issue-uuid-1" }) {
+  return async () => result;
+}
+
+function fakeFetchPostingComment() {
+  return async () =>
+    new Response(
+      JSON.stringify({
+        data: {
+          commentCreate: {
+            success: true,
+            comment: { id: "comment-1", createdAt: "2026-08-03T00:00:00Z", user: { id: "user-1", name: "Tony", email: "tony@hagale.net" } },
+          },
+        },
+      }),
+      { status: 200 },
+    );
+}
+
+describe("postOperatorComment — single-candidate behavior (regression guard)", () => {
+  it("empty body short-circuits before ever resolving a token", async () => {
+    const resolveIdentity = identityMap({});
+    const result = await postOperatorComment(
+      { ticket: "CTL-1", body: "   " },
+      { env: { LINEAR_API_TOKEN: "tok-a" }, resolveIdentity },
+    );
+    expect(result).toEqual({ status: "empty_body" });
+    expect(resolveIdentity.calls).toEqual([]);
+  });
+
+  it("no_token when there are zero candidates", async () => {
+    const result = await postOperatorComment(
+      { ticket: "CTL-1", body: "hello" },
+      { env: {}, projectConfig: {} },
+    );
+    expect(result).toEqual({ status: "no_token" });
+  });
+
+  it("a single human candidate posts the comment", async () => {
+    const resolveIdentity = identityMap({ "tok-a": HUMAN });
+    const result = await postOperatorComment(
+      { ticket: "CTL-1", body: "continue" },
+      {
+        env: { LINEAR_API_TOKEN: "tok-a" },
+        resolveIdentity,
+        resolveIssue: fakeResolveIssue(),
+        fetchImpl: fakeFetchPostingComment(),
+      },
+    );
+    expect(result.status).toBe("posted");
+    expect(resolveIdentity.calls).toEqual(["tok-a"]);
+  });
+
+  it("a single bot candidate refuses with the ORIGINAL (non-plural) message", async () => {
+    const resolveIdentity = identityMap({ "tok-a": BOT });
+    const result = await postOperatorComment(
+      { ticket: "CTL-1", body: "continue" },
+      { env: { LINEAR_API_TOKEN: "tok-a" }, resolveIdentity },
+    );
+    expect(result.status).toBe("bot_identity");
+    expect(result.author).toEqual({ id: "bot-1", name: "Catalyst App" });
+    expect(result.message).not.toMatch(/all \d+ configured/);
+    expect(result.message).toMatch(/this monitor's Linear token is an app actor/);
+  });
+});
+
+describe("postOperatorComment — multi-candidate identity walk (2026-08-02 fix)", () => {
+  it("env resolves to a BOT, config resolves to a HUMAN: skips the bot, posts with the config token", async () => {
+    const resolveIdentity = identityMap({ "tok-bot": BOT, "tok-personal": HUMAN });
+    const resolveIssue = fakeResolveIssue();
+    let sawAuthToken = null;
+    const fetchImpl = async (_url, init) => {
+      sawAuthToken = init.headers.Authorization;
+      return fakeFetchPostingComment()();
+    };
+    const result = await postOperatorComment(
+      { ticket: "CTL-1", body: "continue" },
+      {
+        env: { LINEAR_API_TOKEN: "tok-bot" },
+        projectConfig: { linear: { apiToken: "tok-personal" } },
+        resolveIdentity,
+        resolveIssue,
+        fetchImpl,
+      },
+    );
+    expect(result.status).toBe("posted");
+    // BOTH candidates were identity-checked, in priority order — the bot was
+    // tried first (env wins priority) and skipped, not treated as a hard fail.
+    expect(resolveIdentity.calls).toEqual(["tok-bot", "tok-personal"]);
+    // The comment was actually posted with the HUMAN token, not the bot's.
+    expect(sawAuthToken).toBe("tok-personal");
+  });
+
+  it("both candidates are bots: refuses with the PLURAL message naming the count", async () => {
+    const resolveIdentity = identityMap({ "tok-bot-1": BOT, "tok-bot-2": { ...BOT, id: "bot-2" } });
+    const result = await postOperatorComment(
+      { ticket: "CTL-1", body: "continue" },
+      {
+        env: { LINEAR_API_TOKEN: "tok-bot-1", LINEAR_API_KEY: "tok-bot-2" },
+        resolveIdentity,
+      },
+    );
+    expect(result.status).toBe("bot_identity");
+    expect(result.message).toMatch(/all 2 configured Linear tokens/);
+    // Reports the LAST bot identity checked (both tried).
+    expect(resolveIdentity.calls).toEqual(["tok-bot-1", "tok-bot-2"]);
+    expect(result.author.id).toBe("bot-2");
+  });
+
+  it("the first candidate errors (transport/auth failure), the second is human: falls through to it", async () => {
+    const calls = [];
+    const outcomes = { "tok-broken": { ok: false, error: "HTTP 401: bad token" }, "tok-personal": HUMAN };
+    const resolveIdentity = async ({ token }) => {
+      calls.push(token);
+      return outcomes[token];
+    };
+    const result = await postOperatorComment(
+      { ticket: "CTL-1", body: "continue" },
+      {
+        env: { LINEAR_API_TOKEN: "tok-broken" },
+        projectConfig: { linear: { apiToken: "tok-personal" } },
+        resolveIdentity,
+        resolveIssue: fakeResolveIssue(),
+        fetchImpl: fakeFetchPostingComment(),
+      },
+    );
+    expect(result.status).toBe("posted");
+    expect(calls).toEqual(["tok-broken", "tok-personal"]);
+  });
+
+  it("every candidate errors: status error, message carries the LAST error", async () => {
+    const resolveIdentity = async ({ token }) => ({ ok: false, error: `boom for ${token}` });
+    const result = await postOperatorComment(
+      { ticket: "CTL-1", body: "continue" },
+      {
+        env: { LINEAR_API_TOKEN: "tok-a" },
+        projectConfig: { linear: { apiToken: "tok-b" } },
+        resolveIdentity,
+      },
+    );
+    expect(result.status).toBe("error");
+    expect(result.message).toMatch(/boom for tok-b/);
+  });
+
+  it("three candidates — first bot, second errors, third human: posts with the third", async () => {
+    const calls = [];
+    const outcomes = { "tok-bot": BOT, "tok-broken": { ok: false, error: "timeout" }, "tok-good": HUMAN2 };
+    const resolveIdentity = async ({ token }) => {
+      calls.push(token);
+      return outcomes[token];
+    };
+    const result = await postOperatorComment(
+      { ticket: "CTL-1", body: "continue" },
+      {
+        env: { LINEAR_API_TOKEN: "tok-bot", LINEAR_API_KEY: "tok-broken" },
+        projectConfig: { linear: { apiToken: "tok-good" } },
+        resolveIdentity,
+        resolveIssue: fakeResolveIssue(),
+        fetchImpl: fakeFetchPostingComment(),
+      },
+    );
+    expect(result.status).toBe("posted");
+    expect(calls).toEqual(["tok-bot", "tok-broken", "tok-good"]);
+  });
+
+  it("stops at the FIRST human candidate — never checks identity for candidates after it", async () => {
+    const resolveIdentity = identityMap({ "tok-first-human": HUMAN, "tok-never-reached": HUMAN2 });
+    const result = await postOperatorComment(
+      { ticket: "CTL-1", body: "continue" },
+      {
+        env: { LINEAR_API_TOKEN: "tok-first-human" },
+        projectConfig: { linear: { apiToken: "tok-never-reached" } },
+        resolveIdentity,
+        resolveIssue: fakeResolveIssue(),
+        fetchImpl: fakeFetchPostingComment(),
+      },
+    );
+    expect(result.status).toBe("posted");
+    expect(resolveIdentity.calls).toEqual(["tok-first-human"]);
+  });
+});

--- a/plugins/dev/scripts/orch-monitor/ui/src/components/app-shell.test.tsx
+++ b/plugins/dev/scripts/orch-monitor/ui/src/components/app-shell.test.tsx
@@ -31,3 +31,26 @@ describe("AppShell provides ServiceHealthContext (5th provider, CTL-945)", () =>
     expect(SRC).toContain("</ServiceHealthContext.Provider>");
   });
 });
+
+// CTL-1003 removed the header's SidebarTrigger for desktop (keyboard-only:
+// `[` / Cmd-B). Below the `md` breakpoint the sidebar is an off-canvas Sheet
+// with no keyboard available (iOS Safari) and no other tap target — the
+// SidebarRail drag-handle is itself desktop-only (`sm:flex`). This restores a
+// trigger, but ONLY on narrow viewports, so the deliberate desktop chrome is
+// unaffected.
+describe("AppShell restores a mobile-only sidebar trigger (narrow-viewport nav fix)", () => {
+  it("imports SidebarTrigger", () => {
+    expect(SRC).toMatch(/import \{[^}]*\bSidebarTrigger\b[^}]*\} from "@\/components\/ui\/sidebar"/s);
+  });
+  it("renders <SidebarTrigger> as the header's first child, before the breadcrumb", () => {
+    const headerIdx = SRC.indexOf("<header");
+    const triggerIdx = SRC.indexOf("<SidebarTrigger");
+    const breadcrumbIdx = SRC.indexOf("<Breadcrumb>");
+    expect(headerIdx).toBeGreaterThan(-1);
+    expect(triggerIdx).toBeGreaterThan(headerIdx);
+    expect(breadcrumbIdx).toBeGreaterThan(triggerIdx);
+  });
+  it("gates the trigger to narrow viewports only (md:hidden), leaving desktop keyboard-only", () => {
+    expect(SRC).toMatch(/<SidebarTrigger className="[^"]*\bmd:hidden\b[^"]*"/);
+  });
+});

--- a/plugins/dev/scripts/orch-monitor/ui/src/components/app-shell.tsx
+++ b/plugins/dev/scripts/orch-monitor/ui/src/components/app-shell.tsx
@@ -79,6 +79,7 @@ import {
 import {
   SidebarInset,
   SidebarProvider,
+  SidebarTrigger,
 } from "@/components/ui/sidebar";
 import { AppSidebar } from "@/components/app-sidebar";
 import { AppFooter } from "@/components/app-footer";
@@ -399,11 +400,16 @@ export function AppShell({ children }: { children: React.ReactNode }) {
         <SidebarInset className="min-h-0 overflow-hidden">
           {/* ── Thin top strip: the SINGLE header — breadcrumb + page actions ──
               CTL-1003 §A1: the sidebar collapse icon and the search button are
-              gone (`[` / Cmd-B still toggle, ⌘K / `/` still open the palette —
-              only the visible buttons are removed). The breadcrumb is the sole
-              left affordance; a detail page portals its prev/next chevrons into
-              the right-aligned HeaderActionsSlot. */}
+              gone on DESKTOP (`[` / Cmd-B still toggle, ⌘K / `/` still open the
+              palette — only the visible buttons are removed there). Below the
+              `md` breakpoint, though, the sidebar renders as an off-canvas Sheet
+              (components/ui/sidebar.tsx) with no keyboard available (iOS Safari)
+              and no other tap target to open it (the edge SidebarRail drag-handle
+              is itself `sm:flex`-gated, i.e. also desktop-only) — so the trigger
+              button is restored here, but ONLY for narrow viewports (`md:hidden`),
+              leaving the deliberate keyboard-only desktop chrome unchanged. */}
           <header className="flex h-12 shrink-0 items-center gap-2 border-b border-border px-3">
+            <SidebarTrigger className="text-muted-foreground md:hidden" />
             <Breadcrumb>
               <BreadcrumbList>
                 {crumbs.map((crumb, i) => {

--- a/website/src/content/docs/reference/configuration.md
+++ b/website/src/content/docs/reference/configuration.md
@@ -361,11 +361,30 @@ Never commit this. One file per project, linked by `projectKey`. It holds API ke
 
 | Integration | Required fields               | Used by                   |
 | ----------- | ----------------------------- | ------------------------- |
-| Linear      | `apiToken`, `teamKey`         | catalyst-dev, catalyst-pm |
+| Linear      | `apiToken`, `teamKey`         | catalyst-dev, catalyst-pm, orch-monitor inbox reply |
 | Sentry      | `org`, `project`, `authToken` | catalyst-debugging        |
 | PostHog     | `apiKey`, `projectId`         | catalyst-analytics        |
 
 Only set up the integrations you use — the setup script asks about each one.
+
+### `linear.apiToken` must be a PERSONAL token, not the app-actor's
+
+The orch-monitor Inbox's reply/unblock feature
+([`lib/linear-comment.mjs`](https://github.com/coalesce-labs/catalyst/blob/main/plugins/dev/scripts/orch-monitor/lib/linear-comment.mjs))
+posts comments as **you**, not as the Catalyst app — a Linear provenance gate (CTL-1567) deliberately
+ignores app-authored comments, so a reply posted as the bot would silently do nothing. It resolves a
+candidate token from, in priority order: env `LINEAR_API_TOKEN` → env `LINEAR_API_KEY` → this file's
+`linear.apiToken` → the nested `catalyst.linear.apiToken` — and identity-checks EACH candidate, using
+the first one that resolves to a real human (skipping, not failing on, any that resolve to an app
+actor).
+
+This matters because `LINEAR_API_TOKEN`/`LINEAR_API_KEY` are not exclusively a personal-token slot:
+`lib/linear-app-actor.sh` exports the app-actor's own OAuth token into those same two env vars for any
+daemon that needs bot credentials (broker/execution-core/monitor heartbeats). If your monitor process
+sources that script, its env will always carry a non-empty (but bot) token — the identity walk exists
+precisely so your real `linear.apiToken` here still gets tried and used instead of being permanently
+shadowed. Generate a personal key at Linear → Settings → API → Personal API keys (`lin_api_...`, not
+an OAuth `lin_oauth_...` value) and put it here.
 
 ## Cluster machine-level cloud token (`CATALYST_CLOUD_TOKEN`, CTL-1307)
 


### PR DESCRIPTION
## Summary
Two independent orch-monitor fixes, already merged into thagale/catalyst (#18, #19), now proposed upstream:

**1. Restore sidebar nav trigger for narrow viewports.** CTL-1003 removed the header's `SidebarTrigger` for desktop chrome cleanup (keyboard-only: `[` / Cmd-B). Below the `md` breakpoint the sidebar renders as an off-canvas Sheet with no keyboard available (iOS Safari) and no other tap target — the `SidebarRail` drag-handle is itself desktop-only (`sm:flex`) — leaving mobile users with no way to open navigation at all. Restores the trigger, gated to `md:hidden` so desktop's keyboard-only chrome is unchanged.

**2. Try every configured Linear token's identity, not just the first.** The Inbox reply/unblock feature (`lib/linear-comment.mjs`, CTL-1569) refuses to post when its Linear token resolves to the app actor (correct — CTL-1567 ignores app-authored comments). But it only ever resolved and identity-checked ONE token (first non-empty string across env → Layer-2 config), and `LINEAR_API_TOKEN`/`LINEAR_API_KEY` aren't an exclusively-personal slot: `lib/linear-app-actor.sh` exports the app-actor's own OAuth token into those same env vars for any daemon needing bot credentials. On a host where the monitor also sources that script, its env always carries a non-empty *bot* token, permanently shadowing a correctly-configured personal `linear.apiToken` in Layer-2 config. `linearTokenCandidates()` now returns every configured candidate, deduplicated; `postOperatorComment` identity-checks each in priority order and posts with the first genuine human, skipping (not failing on) any bot.

## Test plan
- [x] `bun run typecheck` — clean
- [x] `bun test` (app-shell.test.tsx, __tests__/app-shell.test.ts, linear-comment.test.mjs) — 55 pass, 0 fail
- [x] Both commits already shipped and running clean on thagale/catalyst since merge (thagale/catalyst#18, #19)

Claude-Session: https://claude.ai/code/session_0126MqxP29TnmkskRPGXgzsQ