### PR TITLE
fix(dev): fix bash 3.2 syntax error in setup-plugin-source.sh

### DIFF
--- a/plugins/dev/scripts/__tests__/setup-plugin-source.test.sh
+++ b/plugins/dev/scripts/__tests__/setup-plugin-source.test.sh
@@ -78,6 +78,23 @@ run_setup_hb() {
 
 echo "setup-plugin-source (CTL-992) tests"
 
+# ── 0. Syntax must be valid under macOS's stock /bin/bash (3.2), not just ────
+# whatever newer bash happens to be first in PATH. A heredoc embedded inside a
+# $(...) command substitution, containing an apostrophe in its body text (even
+# in a comment), confuses bash 3.2's quote-tracking across the nested
+# heredoc/substitution boundary — bash 4+/5 parses it fine, but a fresh macOS
+# node (whose `bash` is the stock 3.2 until Homebrew's is on PATH) fails with a
+# syntax error deep in the file, far from the actual apostrophe (CTL-1214
+# verify: this exact class of bug silently broke node onboarding).
+if [[ -x /bin/bash ]]; then
+  t0() {
+    /bin/bash -n "$SETUP"
+  }
+  check "syntax is valid under macOS stock /bin/bash (3.2), not just PATH bash" t0
+else
+  echo "  SKIP: /bin/bash not present on this host"
+fi
+
 # ── 1. fresh clone → clones + registers pluginDirs in machine config ────────
 make_origin fresh
 MCFG1="${SCRATCH}/mcfg1.json"

--- a/plugins/dev/scripts/setup-plugin-source.sh
+++ b/plugins/dev/scripts/setup-plugin-source.sh
@@ -136,7 +136,7 @@ install_interactive_claude_wrapper() {
 ${start}
 # Interactive \`claude\` loads catalyst plugins LIVE from the plugin-source checkout
 # (never the lagging marketplace cache). Phase workers get this via
-# phase-agent-dispatch's --plugin-dir; this is the interactive equivalent.
+# the phase-agent-dispatch --plugin-dir flag; this is the interactive equivalent.
 claude() {
   case "\${1:-}" in
     plugin|mcp|config|update|doctor|install|migrate-installer|--help|-h|--version|-v)


### PR DESCRIPTION
## Summary
- An apostrophe in a comment inside a heredoc body (`<<WRAP`), itself nested inside a `$(...)` command substitution, confuses bash 3.2's quote-tracking across that nested boundary. Bash 4+/5 parses the file fine, but a fresh macOS node's stock `bash` is 3.2 until Homebrew's is on PATH — this silently broke the `setup-catalyst` join stage on any such node, with a syntax error reported dozens of lines from the actual apostrophe.
- Reworded the offending comment to avoid the apostrophe.
- Added a regression test asserting the script's syntax is valid under `/bin/bash` specifically (not just whatever bash is first in PATH).

Already merged and running on thagale/catalyst#10; proposing upstream per the fork-and-upstream default.

## Test plan
- [x] `bash -n` passes under both `/bin/bash` (3.2) and PATH bash (5+)
- [x] `plugins/dev/scripts/__tests__/setup-plugin-source.test.sh` — 14/14 passed

Claude-Session: https://claude.ai/code/session_0126MqxP29TnmkskRPGXgzsQ