### PR TITLE
feat(dev): CTL-1617 execution-core wiring + advisory deployment-mode doctor checks (PR2 of 7)

### DIFF
--- a/plugins/dev/scripts/execution-core/config-pino-fallback.test.mjs
+++ b/plugins/dev/scripts/execution-core/config-pino-fallback.test.mjs
@@ -11,7 +11,7 @@
 
 import { describe, test, expect } from "bun:test";
 import { spawnSync } from "node:child_process";
-import { mkdtempSync, writeFileSync, cpSync } from "node:fs";
+import { mkdtempSync, mkdirSync, writeFileSync, cpSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, resolve, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -35,13 +35,24 @@ function pickProbeCommand() {
 }
 
 function stageScratch() {
-  const scratch = mkdtempSync(join(tmpdir(), "ctl-578-pino-"));
+  const root = mkdtempSync(join(tmpdir(), "ctl-578-pino-"));
+  // Mirror the real plugins/dev/scripts/ layout one level deep: config.mjs
+  // lives in execution-core/, its sibling config-schema.mjs alongside it, and
+  // (CTL-1617) the deployment-mode resolver one directory UP in lib/ — so
+  // config.mjs's relative import "../lib/deployment-mode.mjs" resolves
+  // exactly as it does in production instead of escaping the fixture root.
+  const scratch = join(root, "execution-core");
+  const libDir = join(root, "lib");
+  mkdirSync(scratch, { recursive: true });
+  mkdirSync(libDir, { recursive: true });
   cpSync(CONFIG_MJS, join(scratch, "config.mjs"));
   // CTL-1211: config.mjs imports the dep-free sibling config-schema.mjs — copy it
   // too so the scratch fixture can resolve config.mjs's local (non-pino) imports.
   // (The point of the fixture is that PINO is unresolvable; local siblings must
-  // still resolve, so any new sibling import config.mjs gains belongs here.)
+  // still resolve, so any new sibling/relative import config.mjs gains belongs here.)
   cpSync(resolve(__dirname, "config-schema.mjs"), join(scratch, "config-schema.mjs"));
+  // CTL-1617: the zero-import deployment-mode leaf config.mjs re-exports.
+  cpSync(resolve(__dirname, "../lib/deployment-mode.mjs"), join(libDir, "deployment-mode.mjs"));
   // type:module + no deps -> pino unresolvable from this directory tree.
   writeFileSync(
     join(scratch, "package.json"),

--- a/plugins/dev/scripts/execution-core/config.mjs
+++ b/plugins/dev/scripts/execution-core/config.mjs
@@ -62,6 +62,14 @@ try {
 }
 export { log };
 
+// CTL-1617: the canonical deployment-mode resolver is a zero-import leaf
+// (../lib/deployment-mode.mjs) shared verbatim by execution-core (this
+// re-export) and orch-monitor (direct cross-directory import) — never
+// reimplemented here. See lib/deployment-mode.mjs's file header for the
+// naming rule ("deployment mode", never bare "mode") and the env-vs-file
+// asymmetry caveat.
+export { DEPLOYMENT_MODES, resolveDeploymentMode, getDeploymentMode } from "../lib/deployment-mode.mjs";
+
 // --- Paths ---
 // Re-resolved per call so tests can redirect by setting CATALYST_DIR;
 // production launches pin a stable value.

--- a/plugins/dev/scripts/execution-core/doctor.mjs
+++ b/plugins/dev/scripts/execution-core/doctor.mjs
@@ -57,6 +57,11 @@ import {
   // change-detection marker the daemon's auto-refresh writes.
   getClusterRepoDir,
   getClusterSyncStatePath,
+  // CTL-1617: the one declared deployment-mode answer (single-host/cluster/
+  // cloud), re-exported from the zero-import lib leaf so doctor never grows
+  // a second copy of the resolution ladder.
+  DEPLOYMENT_MODES,
+  resolveDeploymentMode,
 } from "./config.mjs";
 import { scanEventsSince } from "./event-tail.mjs"; // CTL-1529: bounded event-log scan
 import { ownedBy } from "./hrw.mjs";
@@ -3089,6 +3094,141 @@ export function checkNodeClass(deps = {}) {
   ];
 }
 
+// ─── CTL-1617: deployment-mode consistency grading ───────────────────────────
+
+// checkDeploymentModeConsistency — grade catalyst.deployment.mode (CTL-1617
+// design §7, checks 1-3 only — check 4 tunnel-consistency is PR6). Every
+// message says "deployment mode" fully qualified: this codebase already has
+// three unrelated "mode" concepts (catalyst.orchestration.dispatchMode, the
+// executor-derived dispatch-mode telemetry, readLinearReplica().mode), so
+// bare "mode" in a doctor line is ambiguous.
+//
+//   1. deployment-mode — always emitted. Explicit+recognized → PASS (value +
+//      source). Explicit+UNRECOGNIZED (the resolver already degraded it to
+//      "single-host") → INFO deferring to deployment-mode-recognized below,
+//      which owns that FAIL — this check's own branches are declared-vs-
+//      inferred, not valid-vs-invalid, so it never duplicates check 2's FAIL.
+//      Inferred (unset everywhere) → WARN with the declare-it message
+//      (mirrors the host-name-source WARN-when-implicit pattern verbatim,
+//      ~line 184 above); escalates to FAIL when `strict:true` (the install-
+//      verification profile — an installer that was supposed to persist the
+//      value and didn't is the CTL-1355 install-correctness pattern, same as
+//      checkNodeClass's strict branch above). NOT wired into any strict
+//      profile by this PR — see the checksForClass wiring note below.
+//   2. deployment-mode-recognized — FAIL when `recognized: false` (explicit
+//      typo, already degraded to single-host by the resolver). Same severity
+//      class as checkNodeClass's typo path.
+//   3. deployment-mode-roster-consistency — GATED on `inferred: false` (a
+//      day-one inferred default on a live multi-host cluster must produce
+//      only check 1's declare-it WARN, not a second warning here). Reuses
+//      the same resolveClusterHosts() resolver checkHostIdentity already
+//      calls (no new probe — a cheap, pure, file-backed read, not a network
+//      call). Declared single-host + a multi-host roster resolved, OR
+//      declared cluster/cloud + no authoritative roster (source=single-host)
+//      → WARN. WARN, never FAIL: a transient cluster-repo git-fetch hiccup,
+//      or the declare-then-join migration window, must not flip a healthy
+//      node's doctor red.
+//
+// Injected deps (all have real defaults):
+//   deploymentMode — the resolveDeploymentMode() result object
+//                    ({mode,source,inferred,recognized,raw})
+//   resolveRoster  — () => { hosts, source, multiHost }
+//   strict         — bool, default false (see check 1 above)
+export function checkDeploymentModeConsistency(deps = {}) {
+  const {
+    deploymentMode: dm = resolveDeploymentMode(),
+    resolveRoster = resolveClusterHosts,
+    strict = false,
+  } = deps;
+
+  const checks = [];
+
+  // 1. deployment-mode — always emitted.
+  if (!dm.recognized) {
+    checks.push(
+      mkCheck(
+        "deployment-mode",
+        STATUS.INFO,
+        `deployment mode "${dm.raw}" is not recognized — see deployment-mode-recognized below`,
+      ),
+    );
+  } else if (dm.inferred) {
+    checks.push(
+      mkCheck(
+        "deployment-mode",
+        strict ? STATUS.FAIL : STATUS.WARN,
+        `deployment mode not declared — treating this node as "${dm.mode}"; set ` +
+          `catalyst.deployment.mode (Layer-1 for the fleet default, Layer-2 for this ` +
+          `host) or CATALYST_DEPLOYMENT_MODE`,
+      ),
+    );
+  } else {
+    checks.push(
+      mkCheck(
+        "deployment-mode",
+        STATUS.PASS,
+        `deployment mode="${dm.mode}" (explicit, source=${dm.source})`,
+      ),
+    );
+  }
+
+  // 2. deployment-mode-recognized — FAIL on an explicit typo.
+  if (!dm.recognized) {
+    checks.push(
+      mkCheck(
+        "deployment-mode-recognized",
+        STATUS.FAIL,
+        `deployment mode "${dm.raw}" is not one of [${DEPLOYMENT_MODES.join(", ")}] — ` +
+          `treating this node as "${dm.mode}" (safest); correct or unset the value ` +
+          `(source=${dm.source})`,
+      ),
+    );
+  }
+
+  // 3. deployment-mode-roster-consistency — gated on inferred:false.
+  if (!dm.inferred) {
+    const roster = resolveRoster() ?? {};
+    const rosterSource = roster.source ?? "unknown";
+    // "declared" vs "resolved": when the explicit value was a typo the resolver
+    // DEGRADED it to single-host — the operator declared the typo, not the mode
+    // this check is grading. Say "resolved (degraded from an unrecognized
+    // value)" in that case so this WARN cannot contradict check 2's FAIL.
+    const declaredPhrase = dm.recognized
+      ? "declared deployment mode"
+      : "resolved deployment mode (degraded from an unrecognized value)";
+    if (dm.mode === "single-host" && roster.multiHost) {
+      checks.push(
+        mkCheck(
+          "deployment-mode-roster-consistency",
+          STATUS.WARN,
+          `${declaredPhrase} "single-host" but a multi-host roster resolved ` +
+            `(source=${rosterSource}) — HRW dispatch/recovery gates still partition across it`,
+        ),
+      );
+    } else if ((dm.mode === "cluster" || dm.mode === "cloud") && rosterSource === "single-host") {
+      checks.push(
+        mkCheck(
+          "deployment-mode-roster-consistency",
+          STATUS.WARN,
+          `${declaredPhrase} "${dm.mode}" but no authoritative roster resolved ` +
+            `(source=single-host) — this node effectively runs single-host`,
+        ),
+      );
+    } else {
+      checks.push(
+        mkCheck(
+          "deployment-mode-roster-consistency",
+          STATUS.PASS,
+          `${declaredPhrase} "${dm.mode}" is consistent with the resolved roster ` +
+            `(source=${rosterSource}, multiHost=${Boolean(roster.multiHost)})`,
+        ),
+      );
+    }
+  }
+
+  return checks;
+}
+
 // ─── Developer/monitor: read-replica REACHABILITY (CTL-1346 + CTL-1355) ───────
 
 // defaultReadReplicaBaseUrl — mirror catalyst-stack _vn_read_replica_base /
@@ -3731,6 +3871,13 @@ export function checksForClass(nc, opts = {}) {
   } = opts;
 
   const nodeClassCheck = () => checkNodeClass({ nodeClass: nc });
+  // CTL-1617: deployment-mode consistency — a fleet-topology fact independent
+  // of node class, so it runs for every class (unlike nodeClassCheck it is
+  // never the class-selection short-circuit below). strict:false always here
+  // — this PR wires only the non-strict activation rubric (land-dormant,
+  // CTL-1523 convention); the strict install-profile escalation branch exists
+  // in checkDeploymentModeConsistency but is not wired into any profile yet.
+  const deploymentModeCheck = () => checkDeploymentModeConsistency({ resolveRoster });
 
   // Unrecognized explicit class → a single hard FAIL; grade no profile (CTL-1355).
   if (!nc.recognized) {
@@ -3787,6 +3934,7 @@ export function checksForClass(nc, opts = {}) {
     // worker-member Claude settings that don't apply to it.
     return [
       nodeClassCheck,
+      deploymentModeCheck, // CTL-1617: fleet-topology fact, graded for every class
       () => checkConnectivity({ seed, otel, fetch: _fetch }),
       () => checkSecretsHygiene(),
       developerBotCredentials,
@@ -3818,6 +3966,7 @@ export function checksForClass(nc, opts = {}) {
     // the FAIL is removed when the monitor rubric lands (CTL-1355 F3).
     return [
       nodeClassCheck,
+      deploymentModeCheck, // CTL-1617: fleet-topology fact, graded for every class
       () => checkConnectivity({ seed, otel, fetch: _fetch }),
       () => checkHrwPartition(), // would-own count (visibility)
       agentsThunk, // CTL-1369 PR4: updater agent installed, no worker stack (monitor is adopt-updater-shaped)
@@ -3841,6 +3990,7 @@ export function checksForClass(nc, opts = {}) {
   // unchanged, with the node-class check prepended (INFO/PASS — never FAILs here).
   return [
     nodeClassCheck,
+    deploymentModeCheck, // CTL-1617: fleet-topology fact, graded for every class
     () => checkHostIdentity(),
     () => checkHrwPartition(),
     () => checkPeerUniqueness(),

--- a/plugins/dev/scripts/execution-core/doctor.test.mjs
+++ b/plugins/dev/scripts/execution-core/doctor.test.mjs
@@ -31,6 +31,7 @@ import {
   checkRepoIconTokenScope,
   defaultConfiguredRepos,
   checkNodeClass,
+  checkDeploymentModeConsistency,
   checkReadReplicaReachable,
   checkMonitorProductionBuild,
   checkWontOwnWork,
@@ -2091,6 +2092,46 @@ describe("checksForClass — checkSdkDaemonEnv registration (CTL-1396)", () => {
   });
 });
 
+describe("checksForClass — checkDeploymentModeConsistency registration (CTL-1617)", () => {
+  const src = (nc, opts = {}) => checksForClass(nc, opts).map((f) => f.toString()).join("\n");
+
+  it("worker rubric includes checkDeploymentModeConsistency beside checkNodeClass", () => {
+    const s = src(nodeClassOf({ class: "worker", raw: "worker" }));
+    expect(s).toContain("checkNodeClass");
+    expect(s).toContain("checkDeploymentModeConsistency");
+  });
+
+  it("developer rubric includes checkDeploymentModeConsistency — a fleet-topology fact, not worker-only", () => {
+    const s = src(nodeClassOf({ class: "developer", raw: "developer" }));
+    expect(s).toContain("checkDeploymentModeConsistency");
+  });
+
+  it("monitor rubric includes checkDeploymentModeConsistency", () => {
+    const s = src(nodeClassOf({ class: "monitor", raw: "monitor" }));
+    expect(s).toContain("checkDeploymentModeConsistency");
+  });
+
+  it("an inferred (unset) node class still grades against the worker suite, deployment mode included", () => {
+    const inferred = nodeClassOf({ class: "worker", source: "default", inferred: true, recognized: true, raw: null });
+    const s = src(inferred);
+    expect(s).toContain("checkDeploymentModeConsistency");
+  });
+
+  it("unrecognized node class short-circuits to the single node-class FAIL — deployment mode not graded", () => {
+    const nc = nodeClassOf({ recognized: false, raw: "developr", class: "monitor" });
+    const suite = checksForClass(nc);
+    expect(suite).toHaveLength(1);
+  });
+
+  it("the deployment-mode thunk actually runs checkDeploymentModeConsistency and returns its checks", async () => {
+    const s = checksForClass(nodeClassOf({ class: "worker", raw: "worker" }));
+    const thunk = s.find((f) => f.toString().includes("checkDeploymentModeConsistency"));
+    expect(thunk).toBeDefined();
+    const out = await thunk();
+    expect(out.some((c) => c.name === "deployment-mode")).toBe(true);
+  });
+});
+
 // ─── checkConfigScopeLeak (CTL-1214) ─────────────────────────────────────────
 
 // A kitchen-sink Layer-1 config carrying every relocated stanza (the historical
@@ -2277,6 +2318,258 @@ describe("checkNodeClass (CTL-1355)", () => {
     expect(checks[0].status).toBe(STATUS.FAIL);
     expect(checks[0].detail).toContain("developr");
     expect(checks[0].detail).toContain("not one of");
+  });
+});
+
+// ─── CTL-1617: deployment-mode consistency grading ───────────────────────────
+
+const deploymentModeOf = (over = {}) => ({
+  mode: "single-host",
+  source: "layer1",
+  inferred: false,
+  recognized: true,
+  raw: "single-host",
+  ...over,
+});
+
+const rosterOf = (over = {}) => ({
+  hosts: ["mini"],
+  source: "single-host",
+  multiHost: false,
+  ...over,
+});
+
+describe("checkDeploymentModeConsistency (CTL-1617)", () => {
+  describe("check 1: deployment-mode", () => {
+    it("PASSes an explicit, recognized deployment mode showing value + source", () => {
+      const checks = checkDeploymentModeConsistency({
+        deploymentMode: deploymentModeOf({ mode: "cluster", source: "layer1" }),
+        resolveRoster: () => rosterOf({ hosts: ["mini", "mini-2"], source: "cluster-repo", multiHost: true }),
+      });
+      const dm = checks.find((c) => c.name === "deployment-mode");
+      expect(dm.status).toBe(STATUS.PASS);
+      expect(dm.detail).toContain("cluster");
+      expect(dm.detail).toContain("layer1");
+    });
+
+    it("WARNs (not FAILs) an inferred deployment mode by default, naming the declare-it fix", () => {
+      const checks = checkDeploymentModeConsistency({
+        deploymentMode: deploymentModeOf({
+          mode: "single-host",
+          source: "default",
+          inferred: true,
+          recognized: true,
+          raw: null,
+        }),
+        resolveRoster: () => rosterOf(),
+      });
+      const dm = checks.find((c) => c.name === "deployment-mode");
+      expect(dm.status).toBe(STATUS.WARN);
+      expect(dm.detail).toContain("deployment mode");
+      expect(dm.detail).toContain("not declared");
+      expect(dm.detail).toContain("catalyst.deployment.mode");
+      expect(dm.detail).toContain("CATALYST_DEPLOYMENT_MODE");
+    });
+
+    it("escalates an inferred deployment mode to FAIL under strict:true (install-verification profile)", () => {
+      const checks = checkDeploymentModeConsistency({
+        deploymentMode: deploymentModeOf({
+          mode: "single-host",
+          source: "default",
+          inferred: true,
+          recognized: true,
+          raw: null,
+        }),
+        resolveRoster: () => rosterOf(),
+        strict: true,
+      });
+      const dm = checks.find((c) => c.name === "deployment-mode");
+      expect(dm.status).toBe(STATUS.FAIL);
+    });
+
+    it("does not FAIL on an inferred deployment mode when strict is false (default)", () => {
+      const checks = checkDeploymentModeConsistency({
+        deploymentMode: deploymentModeOf({
+          mode: "single-host",
+          source: "default",
+          inferred: true,
+          recognized: true,
+          raw: null,
+        }),
+        resolveRoster: () => rosterOf(),
+        strict: false,
+      });
+      const dm = checks.find((c) => c.name === "deployment-mode");
+      expect(dm.status).not.toBe(STATUS.FAIL);
+    });
+
+    it("deployment-mode is always emitted even for an unrecognized explicit value", () => {
+      const checks = checkDeploymentModeConsistency({
+        deploymentMode: deploymentModeOf({
+          mode: "single-host", // resolver already degraded the typo to single-host
+          source: "env",
+          inferred: false,
+          recognized: false,
+          raw: "clustre",
+        }),
+        resolveRoster: () => rosterOf(),
+      });
+      const dm = checks.find((c) => c.name === "deployment-mode");
+      expect(dm).toBeDefined();
+      expect(dm.status).not.toBe(STATUS.FAIL); // check 2 owns the FAIL for this case
+    });
+  });
+
+  describe("check 2: deployment-mode-recognized", () => {
+    it("FAILs an explicit UNRECOGNIZED deployment mode, naming the raw value and the enum", () => {
+      const checks = checkDeploymentModeConsistency({
+        deploymentMode: deploymentModeOf({
+          mode: "single-host",
+          source: "env",
+          inferred: false,
+          recognized: false,
+          raw: "clustre",
+        }),
+        resolveRoster: () => rosterOf(),
+      });
+      const rec = checks.find((c) => c.name === "deployment-mode-recognized");
+      expect(rec).toBeDefined();
+      expect(rec.status).toBe(STATUS.FAIL);
+      expect(rec.detail).toContain("clustre");
+      expect(rec.detail).toContain("not one of");
+      expect(rec.detail).toContain("deployment mode");
+    });
+
+    it("is absent entirely when the deployment mode is recognized", () => {
+      const checks = checkDeploymentModeConsistency({
+        deploymentMode: deploymentModeOf({ mode: "single-host", recognized: true }),
+        resolveRoster: () => rosterOf(),
+      });
+      expect(checks.find((c) => c.name === "deployment-mode-recognized")).toBeUndefined();
+    });
+  });
+
+  describe("check 3: deployment-mode-roster-consistency", () => {
+    it("is GATED on inferred:false — absent entirely for an inferred deployment mode", () => {
+      const checks = checkDeploymentModeConsistency({
+        deploymentMode: deploymentModeOf({
+          mode: "single-host",
+          source: "default",
+          inferred: true,
+          recognized: true,
+          raw: null,
+        }),
+        // A multi-host roster would trip the WARN below if this check ran —
+        // proving the gate, not just an absence-of-signal false negative.
+        resolveRoster: () => rosterOf({ hosts: ["mini", "mini-2"], source: "cluster-repo", multiHost: true }),
+      });
+      expect(checks.find((c) => c.name === "deployment-mode-roster-consistency")).toBeUndefined();
+    });
+
+    it('WARNs when declared "single-host" but a multi-host roster resolved', () => {
+      const checks = checkDeploymentModeConsistency({
+        deploymentMode: deploymentModeOf({ mode: "single-host", source: "layer2" }),
+        resolveRoster: () => rosterOf({ hosts: ["mini", "mini-2"], source: "cluster-repo", multiHost: true }),
+      });
+      const rc = checks.find((c) => c.name === "deployment-mode-roster-consistency");
+      expect(rc.status).toBe(STATUS.WARN);
+      expect(rc.detail).toContain("single-host");
+      expect(rc.detail).toContain("multi-host roster");
+    });
+
+    it('WARNs when declared "cluster" but no authoritative roster resolved (source=single-host)', () => {
+      const checks = checkDeploymentModeConsistency({
+        deploymentMode: deploymentModeOf({ mode: "cluster", source: "layer1" }),
+        resolveRoster: () => rosterOf({ hosts: ["mini"], source: "single-host", multiHost: false }),
+      });
+      const rc = checks.find((c) => c.name === "deployment-mode-roster-consistency");
+      expect(rc.status).toBe(STATUS.WARN);
+      expect(rc.detail).toContain("cluster");
+      expect(rc.detail).toContain("no authoritative roster");
+    });
+
+    it('WARNs when declared "cloud" but no authoritative roster resolved (source=single-host)', () => {
+      const checks = checkDeploymentModeConsistency({
+        deploymentMode: deploymentModeOf({ mode: "cloud", source: "env" }),
+        resolveRoster: () => rosterOf({ hosts: ["mini"], source: "single-host", multiHost: false }),
+      });
+      const rc = checks.find((c) => c.name === "deployment-mode-roster-consistency");
+      expect(rc.status).toBe(STATUS.WARN);
+      expect(rc.detail).toContain("cloud");
+    });
+
+    it('PASSes when declared "single-host" and the roster is single-host', () => {
+      const checks = checkDeploymentModeConsistency({
+        deploymentMode: deploymentModeOf({ mode: "single-host", source: "layer1" }),
+        resolveRoster: () => rosterOf({ hosts: ["mini"], source: "single-host", multiHost: false }),
+      });
+      const rc = checks.find((c) => c.name === "deployment-mode-roster-consistency");
+      expect(rc.status).toBe(STATUS.PASS);
+    });
+
+    it('PASSes when declared "cluster" and an authoritative multi-host roster resolved', () => {
+      const checks = checkDeploymentModeConsistency({
+        deploymentMode: deploymentModeOf({ mode: "cluster", source: "layer1" }),
+        resolveRoster: () => rosterOf({ hosts: ["mini", "mini-2"], source: "cluster-repo", multiHost: true }),
+      });
+      const rc = checks.find((c) => c.name === "deployment-mode-roster-consistency");
+      expect(rc.status).toBe(STATUS.PASS);
+    });
+
+    it("never FAILs — roster inconsistency is always advisory (WARN), even on garbage roster shapes", () => {
+      const checks = checkDeploymentModeConsistency({
+        deploymentMode: deploymentModeOf({ mode: "cluster", source: "layer1" }),
+        resolveRoster: () => ({}), // malformed/empty resolver result
+      });
+      const rc = checks.find((c) => c.name === "deployment-mode-roster-consistency");
+      expect(rc.status).not.toBe(STATUS.FAIL);
+    });
+  });
+
+  describe("every message says \"deployment mode\" fully qualified", () => {
+    it("across PASS/WARN/FAIL branches, never bare \"mode\"", () => {
+      const scenarios = [
+        checkDeploymentModeConsistency({
+          deploymentMode: deploymentModeOf({ mode: "cluster", source: "layer1" }),
+          resolveRoster: () => rosterOf({ hosts: ["mini", "mini-2"], source: "cluster-repo", multiHost: true }),
+        }),
+        checkDeploymentModeConsistency({
+          deploymentMode: deploymentModeOf({
+            mode: "single-host",
+            source: "default",
+            inferred: true,
+            recognized: true,
+            raw: null,
+          }),
+          resolveRoster: () => rosterOf(),
+        }),
+        checkDeploymentModeConsistency({
+          deploymentMode: deploymentModeOf({
+            mode: "single-host",
+            source: "env",
+            inferred: false,
+            recognized: false,
+            raw: "clustre",
+          }),
+          resolveRoster: () => rosterOf(),
+        }),
+        checkDeploymentModeConsistency({
+          deploymentMode: deploymentModeOf({ mode: "single-host", source: "layer2" }),
+          resolveRoster: () => rosterOf({ hosts: ["mini", "mini-2"], source: "cluster-repo", multiHost: true }),
+        }),
+      ].flat();
+      for (const c of scenarios) {
+        expect(c.detail.toLowerCase()).toContain("deployment mode");
+      }
+    });
+  });
+
+  it("defaults resolveRoster to the real resolveClusterHosts when uninjected (no throw)", () => {
+    // Smoke test only — proves the default seam wires without throwing; does
+    // not assert on the (environment-dependent) resulting status.
+    expect(() =>
+      checkDeploymentModeConsistency({ deploymentMode: deploymentModeOf({ mode: "single-host" }) }),
+    ).not.toThrow();
   });
 });
 


### PR DESCRIPTION
## Summary

PR2 of the CTL-1617 migration plan (design: `thoughts/shared/research/2026-08-02-ctl-1617-deployment-mode-design.md` §7 + §9-PR2): execution-core gains the deployment-mode resolver through a one-line `config.mjs` re-export, and `catalyst doctor` gains `checkDeploymentModeConsistency` — three **advisory-only** checks wired into `checksForClass()`'s shared prelude for every node class.

| Check | Grades |
|---|---|
| `deployment-mode` | PASS explicit+recognized / WARN inferred (declare-it guidance). `strict:true` escalation implemented+tested, **not** wired into `installChecksForClass` until PR4 — no installer persists the mode yet, so a strict FAIL would flip install verification red fleet-wide (verifier advisory A1, deliberate). |
| `deployment-mode-recognized` | FAIL on an explicit typo (resolver degrades to `single-host`); check 1 defers via INFO to avoid double-alarming. |
| `deployment-mode-roster-consistency` | Gated on `inferred:false`; WARN-only both directions. Degraded typos read "resolved (degraded from an unrecognized value)" so the WARN can't contradict check 2's FAIL. |

**Land-dormant proof:** all 295 doctor tests — including every existing `checksForClass`/`runDoctor`/install-correctness test — pass unchanged; no existing check's grade moves for an undeclared node.

## Verification

- doctor.test.mjs 295/295; PR1 suites untouched and green (30 bun / 27 bash / 348 parity); adversarial Fable verify: PASS, zero blocking findings.
- Environmental failures in the broad execution-core run were cross-reproduced on a pre-CTL-1617 worktree (`ea5d0312`) — none in touched files.

Next: PR3 (orch-monitor tunnel gate), PR4 (declare the fleet sequentially + strict wiring decision).

Linear: CTL-1617

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WHfJt1JhsdArSUyxwZZzkN