### PR TITLE
feat(dev): CTL-1617 gate orch-monitor smee tunnels on deployment mode (PR3 of 7)

### DIFF
--- a/plugins/dev/scripts/orch-monitor/__tests__/deployment-mode-tunnel-gate.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/deployment-mode-tunnel-gate.test.ts
@@ -1,0 +1,292 @@
+// deployment-mode-tunnel-gate.test.ts — CTL-1617 PR3.
+//
+// Covers the additional AND-gate on the smee webhook tunnel-start sites
+// (server.ts, GitHub + Linear tunnels): a node whose deployment mode
+// resolves to "cloud" must NOT open either tunnel (its event source is the
+// future cloud SDK connection instead — design §2/§6); every other
+// deployment mode — including the "single-host" default every host
+// resolves today — must be a byte-for-byte no-op.
+//
+// Risk 7 (design §10) — "consumer-side inversion bugs": a consumer that
+// reads `mode === "cloud"` to *skip* something must independently prove it
+// never skips for single-host/cluster/default. That is the explicit focus
+// of the "never skips" describe block below, not just the cloud-suppression
+// case.
+import { describe, it, expect, afterEach } from "bun:test";
+import { mkdtempSync, rmSync, mkdirSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { createServer } from "../server";
+
+// Fake smee-client constructor — never opens a real network connection.
+// Mirrors the `fakeFactory` convention used throughout server.test.ts.
+function makeFakeFactory(): {
+  factory: () => { start: () => Promise<unknown>; stop: () => Promise<void> };
+  constructorCalls: () => number;
+} {
+  let calls = 0;
+  return {
+    factory: () => {
+      calls++;
+      return {
+        start: () => Promise.resolve({}),
+        stop: () => Promise.resolve(),
+      };
+    },
+    constructorCalls: () => calls,
+  };
+}
+
+const cleanups: Array<() => void> = [];
+
+afterEach(() => {
+  while (cleanups.length > 0) {
+    const fn = cleanups.pop();
+    try {
+      fn?.();
+    } catch {
+      /* ignore */
+    }
+  }
+});
+
+function makeWtDir(prefix: string): string {
+  const tmp = mkdtempSync(join(tmpdir(), prefix));
+  const wtDir = join(tmp, "wt");
+  mkdirSync(wtDir, { recursive: true });
+  cleanups.push(() => rmSync(tmp, { recursive: true, force: true }));
+  return wtDir;
+}
+
+async function settle(ms = 30): Promise<void> {
+  await new Promise((r) => setTimeout(r, ms));
+}
+
+describe("CTL-1617 deployment-mode gate — never skips for single-host/cluster/default", () => {
+  // This is the explicit inversion-bug guard the design mandates (§10 risk
+  // 7): prove the gate does NOT suppress tunnel startup for every mode other
+  // than "cloud", not just that it suppresses "cloud".
+  for (const mode of ["single-host", "cluster"] as const) {
+    it(`starts the GitHub tunnel when deployment mode resolves "${mode}"`, async () => {
+      const wtDir = makeWtDir(`dm-gate-gh-${mode}-`);
+      const srv = createServer({
+        port: 0,
+        wtDir,
+        startWatcher: false,
+        webhookConfig: {
+          smeeChannel: "https://smee.io/test",
+          secret: "s3cr3t",
+          tunnelFactory: () => ({
+            start: () => Promise.resolve({}),
+            stop: () => Promise.resolve(),
+          }),
+        },
+        deploymentModeReader: () => mode,
+      });
+      cleanups.push(() => void srv.stop(true));
+      await settle();
+
+      const res = await fetch(
+        `http://localhost:${srv.port}/api/status/webhook-tunnel`,
+      );
+      const body = (await res.json()) as Record<string, unknown>;
+      expect(body.connected).toBe(true);
+    });
+
+    it(`starts the Linear tunnel when deployment mode resolves "${mode}"`, async () => {
+      const wtDir = makeWtDir(`dm-gate-linear-${mode}-`);
+      const { factory, constructorCalls } = makeFakeFactory();
+      const srv = createServer({
+        port: 0,
+        wtDir,
+        startWatcher: false,
+        linearWebhookConfig: {
+          linearSecrets: [{ key: "test", secret: "linear-test-secret" }],
+          smeeChannel: "https://smee.io/linear-test",
+          tunnelFactory: factory,
+        },
+        deploymentModeReader: () => mode,
+      });
+      cleanups.push(() => void srv.stop(true));
+      await settle();
+
+      expect(constructorCalls()).toBe(1);
+    });
+  }
+
+  it("starts the GitHub tunnel when deployment mode is unset (real resolver, inferred default)", async () => {
+    // No deploymentModeReader injected at all — exercises the PRODUCTION
+    // wiring (`deploymentModeReaderOpt ?? getDeploymentMode`) end-to-end
+    // against the real resolver, not a stub. Isolated from the real
+    // environment/config files so the resolution deterministically falls
+    // through every layer to the constant "single-host" default.
+    const prevEnv = process.env.CATALYST_DEPLOYMENT_MODE;
+    const prevL1 = process.env.CATALYST_CONFIG_FILE;
+    const prevL2 = process.env.CATALYST_LAYER2_CONFIG_FILE;
+    delete process.env.CATALYST_DEPLOYMENT_MODE;
+    const tmp = mkdtempSync(join(tmpdir(), "dm-gate-default-"));
+    process.env.CATALYST_CONFIG_FILE = join(tmp, "does-not-exist.json");
+    process.env.CATALYST_LAYER2_CONFIG_FILE = join(
+      tmp,
+      "also-does-not-exist.json",
+    );
+    cleanups.push(() => {
+      if (prevEnv === undefined) delete process.env.CATALYST_DEPLOYMENT_MODE;
+      else process.env.CATALYST_DEPLOYMENT_MODE = prevEnv;
+      if (prevL1 === undefined) delete process.env.CATALYST_CONFIG_FILE;
+      else process.env.CATALYST_CONFIG_FILE = prevL1;
+      if (prevL2 === undefined) delete process.env.CATALYST_LAYER2_CONFIG_FILE;
+      else process.env.CATALYST_LAYER2_CONFIG_FILE = prevL2;
+      rmSync(tmp, { recursive: true, force: true });
+    });
+
+    const wtDir = makeWtDir("dm-gate-default-wt-");
+    const srv = createServer({
+      port: 0,
+      wtDir,
+      startWatcher: false,
+      webhookConfig: {
+        smeeChannel: "https://smee.io/test",
+        secret: "s3cr3t",
+        tunnelFactory: () => ({
+          start: () => Promise.resolve({}),
+          stop: () => Promise.resolve(),
+        }),
+      },
+      // deploymentModeReader intentionally omitted.
+    });
+    cleanups.push(() => void srv.stop(true));
+    await settle();
+
+    const res = await fetch(
+      `http://localhost:${srv.port}/api/status/webhook-tunnel`,
+    );
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body.connected).toBe(true);
+  });
+});
+
+describe("CTL-1617 deployment-mode gate — cloud suppression", () => {
+  it('does NOT start the GitHub tunnel when deployment mode resolves "cloud", and logs the suppression', async () => {
+    const wtDir = makeWtDir("dm-gate-gh-cloud-");
+    let constructorCalls = 0;
+    const infoLogs: unknown[][] = [];
+    const realInfo = console.info;
+    console.info = (...args: unknown[]) => {
+      infoLogs.push(args);
+    };
+    cleanups.push(() => {
+      console.info = realInfo;
+    });
+
+    const srv = createServer({
+      port: 0,
+      wtDir,
+      startWatcher: false,
+      webhookConfig: {
+        smeeChannel: "https://smee.io/test",
+        secret: "s3cr3t",
+        tunnelFactory: () => {
+          constructorCalls++;
+          return { start: () => Promise.resolve({}), stop: () => Promise.resolve() };
+        },
+      },
+      deploymentModeReader: () => "cloud",
+    });
+    cleanups.push(() => void srv.stop(true));
+    await settle();
+
+    // Never even constructs the smee client — the gate short-circuits
+    // before createWebhookTunnel() is called.
+    expect(constructorCalls).toBe(0);
+
+    const res = await fetch(
+      `http://localhost:${srv.port}/api/status/webhook-tunnel`,
+    );
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body.connected).toBe(false);
+
+    expect(
+      infoLogs.some(
+        (args) =>
+          String(args[0]).includes("suppressing") &&
+          String(args[0]).includes("GitHub") &&
+          String(args[0]).toLowerCase().includes("cloud"),
+      ),
+    ).toBe(true);
+  });
+
+  it('does NOT start the Linear tunnel when deployment mode resolves "cloud", and logs the suppression', async () => {
+    const wtDir = makeWtDir("dm-gate-linear-cloud-");
+    const { factory, constructorCalls } = makeFakeFactory();
+    const infoLogs: unknown[][] = [];
+    const realInfo = console.info;
+    console.info = (...args: unknown[]) => {
+      infoLogs.push(args);
+    };
+    cleanups.push(() => {
+      console.info = realInfo;
+    });
+
+    const srv = createServer({
+      port: 0,
+      wtDir,
+      startWatcher: false,
+      linearWebhookConfig: {
+        linearSecrets: [{ key: "test", secret: "linear-test-secret" }],
+        smeeChannel: "https://smee.io/linear-test",
+        tunnelFactory: factory,
+      },
+      deploymentModeReader: () => "cloud",
+    });
+    cleanups.push(() => void srv.stop(true));
+    await settle();
+
+    expect(constructorCalls()).toBe(0);
+    expect(
+      infoLogs.some(
+        (args) =>
+          String(args[0]).includes("suppressing") &&
+          String(args[0]).includes("Linear") &&
+          String(args[0]).toLowerCase().includes("cloud"),
+      ),
+    ).toBe(true);
+  });
+
+  it("suppresses both tunnels off a SINGLE deployment-mode resolution (reader called once)", async () => {
+    // Design §6: "Resolved ONCE here (not per-tunnel) so both gates agree
+    // within a single startup." Prove the reader isn't re-invoked per tunnel
+    // (which could observe a torn read on a live-reloading file source).
+    const wtDir = makeWtDir("dm-gate-single-resolve-");
+    let readerCalls = 0;
+    const srv = createServer({
+      port: 0,
+      wtDir,
+      startWatcher: false,
+      webhookConfig: {
+        smeeChannel: "https://smee.io/test",
+        secret: "s3cr3t",
+        tunnelFactory: () => ({
+          start: () => Promise.resolve({}),
+          stop: () => Promise.resolve(),
+        }),
+      },
+      linearWebhookConfig: {
+        linearSecrets: [{ key: "test", secret: "linear-test-secret" }],
+        smeeChannel: "https://smee.io/linear-test",
+        tunnelFactory: () => ({
+          start: () => Promise.resolve({}),
+          stop: () => Promise.resolve(),
+        }),
+      },
+      deploymentModeReader: () => {
+        readerCalls++;
+        return "cloud";
+      },
+    });
+    cleanups.push(() => void srv.stop(true));
+    await settle();
+
+    expect(readerCalls).toBe(1);
+  });
+});

--- a/plugins/dev/scripts/orch-monitor/server.ts
+++ b/plugins/dev/scripts/orch-monitor/server.ts
@@ -61,6 +61,16 @@ import {
 // CTL-1100: FSM descriptor endpoint. Confirmed bun:sqlite-free (no computed
 // specifier needed — plain static import is safe for Vite/esbuild graph).
 import { buildFsmDescriptor } from "../lib/fsm-descriptor.mjs";
+// CTL-1617: the canonical deployment-mode resolver — a zero-import leaf
+// (node:fs/node:os/node:path only). Imported directly cross-directory rather
+// than via execution-core/config.mjs's re-export: config.mjs's own import
+// chain reaches bun:sqlite through linear-query.mjs, which doctor.mjs's
+// bare-Node runtime rejects — a constraint that doesn't apply to this file
+// (bun), but the leaf is the single source of truth either way, so importing
+// it directly here avoids adding a needless indirection. Precedent for this
+// exact direct cross-directory `.mjs` import shape: the fsm-descriptor.mjs
+// import immediately above, and ui/src/board/process-surface.test.ts:5.
+import { getDeploymentMode } from "../lib/deployment-mode.mjs";
 // CTL-1100: belief store query functions (pure, db-injected). belief-store-queries.mjs
 // has no static bun:sqlite import — plain static import is safe for Vite/esbuild graph.
 import {
@@ -525,6 +535,10 @@ export interface CreateServerOptions {
      * teams that appear here so the HUD's REPO column populates for Linear
      * events. Empty / absent = no enrichment (pre-CTL-362 behaviour). */
     linearTeams?: Array<{ key: string; vcsRepo: string }>;
+    /** Test override for the smee-client constructor used by the Linear
+     * webhook tunnel — mirrors `webhookConfig.tunnelFactory` above. Omitted
+     * in production (the real smee-client is used). CTL-1617. */
+    tunnelFactory?: SmeeClientFactory;
   } | null;
   /** App-actor user ids for agent classification on READ surfaces (the
    *  discussion timeline). Independent of webhook ingestion — configured bot
@@ -538,6 +552,15 @@ export interface CreateServerOptions {
   pushSubscriptionsDbPath?: string;
   /** Override for vapid-keys.json path. Defaults to ${catalystDir}/vapid-keys.json. */
   vapidKeysPath?: string;
+  /**
+   * CTL-1617: override for the deployment-mode reader that gates smee webhook
+   * tunnel startup (a node declared "cloud" must not open a smee tunnel — its
+   * event source is the cloud SDK connection instead). Production defaults to
+   * `getDeploymentMode` (env → Layer-2 → Layer-1 → "single-host"). Tests
+   * inject a deterministic reader so the gate can be exercised for every mode
+   * without touching process.env or real config files.
+   */
+  deploymentModeReader?: (() => string) | null;
 }
 
 const DEFAULT_PORT = 7400;
@@ -867,6 +890,7 @@ export function createServer(opts: CreateServerOptions): BunServer {
     pushBridge: pushBridgeOpt = true,
     pushSubscriptionsDbPath,
     vapidKeysPath,
+    deploymentModeReader: deploymentModeReaderOpt,
   } = opts;
 
   const buildOpts: BuildSnapshotOptions = { dbPath, runsDir };
@@ -5160,74 +5184,107 @@ export function createServer(opts: CreateServerOptions): BunServer {
     );
   }
 
+  // CTL-1617: deployment-mode gate for BOTH smee tunnels below (GitHub +
+  // Linear). A node declared "cloud" expects the cloud SDK event connection
+  // (future work — PR #2755 lineage) as its event source, not the smee
+  // tunnel; a live tunnel on a declared-cloud node is contrary-to-mode
+  // (design §2/§6). Resolved ONCE here (not per-tunnel) so both gates agree
+  // within a single startup. Every other deployment mode — including the
+  // inferred "single-host" default every host resolves today, since nothing
+  // in the live fleet declares a deployment mode yet — leaves this branch
+  // false, so tunnel startup is byte-for-byte unchanged (design §9 PR3
+  // success criterion: provable no-op on the live fleet).
+  const resolveDeploymentModeForTunnelGate =
+    deploymentModeReaderOpt ?? getDeploymentMode;
+  const deploymentModeForTunnelGate = resolveDeploymentModeForTunnelGate();
+  const cloudModeSuppressesTunnels = deploymentModeForTunnelGate === "cloud";
+
   if (webhookConfig && webhookHandler) {
-    const tunnelTarget =
-      webhookConfig.target ?? `http://localhost:${server.port}/api/webhook`;
-    webhookTunnel = createWebhookTunnel({
-      source: webhookConfig.smeeChannel,
-      target: tunnelTarget,
-      logger: {
-        info: (m) => console.info(m),
-        error: (m) => console.error(m),
-      },
-      factory: webhookConfig.tunnelFactory,
-    });
-    void webhookTunnel.start().catch((err: unknown) => {
-      console.error(
-        `[server] webhook tunnel start failed:`,
-        err instanceof Error ? err.message : String(err),
+    if (cloudModeSuppressesTunnels) {
+      // Loud on purpose: a declared-cloud node silently not opening the
+      // GitHub webhook tunnel would be undiagnosable otherwise (a channel is
+      // configured, so the OLD gate at `webhookConfig && webhookHandler`
+      // alone would have started it).
+      console.info(
+        `[server] suppressing GitHub webhook smee tunnel start: deployment mode is "cloud" (event ingestion is the cloud SDK connection, not the smee tunnel)`,
       );
-    });
-    if (webhookReplay && webhookSubscriber) {
-      const replay = webhookReplay;
-      const subscriber = webhookSubscriber;
-      // CTL-216: subscribe to configured watchRepos before replay so they're
-      // present in subscriber.listSubscribed() when replay runs. Errors per
-      // repo are tolerated by ensureSubscribed (logged + continue).
-      const watchRepos = webhookConfig.watchRepos ?? [];
-      const watchSubscriptions =
-        watchRepos.length > 0
-          ? Promise.allSettled(
-              watchRepos.map((repo) => subscriber.ensureSubscribed(repo)),
-            )
-          : Promise.resolve();
-      // 1-hour replay window — wide enough to cover most outages, narrow enough
-      // to keep startup latency under a few seconds.
-      const since = new Date(Date.now() - 60 * 60_000);
-      void watchSubscriptions
-        .then(() => replay.replaySince(subscriber.listSubscribed(), since))
-        .then((count) => {
-          if (count > 0) {
-            console.info(
-              `[server] replayed ${count} webhook deliveries from the last hour`,
+    } else {
+      const tunnelTarget =
+        webhookConfig.target ?? `http://localhost:${server.port}/api/webhook`;
+      webhookTunnel = createWebhookTunnel({
+        source: webhookConfig.smeeChannel,
+        target: tunnelTarget,
+        logger: {
+          info: (m) => console.info(m),
+          error: (m) => console.error(m),
+        },
+        factory: webhookConfig.tunnelFactory,
+      });
+      void webhookTunnel.start().catch((err: unknown) => {
+        console.error(
+          `[server] webhook tunnel start failed:`,
+          err instanceof Error ? err.message : String(err),
+        );
+      });
+      if (webhookReplay && webhookSubscriber) {
+        const replay = webhookReplay;
+        const subscriber = webhookSubscriber;
+        // CTL-216: subscribe to configured watchRepos before replay so they're
+        // present in subscriber.listSubscribed() when replay runs. Errors per
+        // repo are tolerated by ensureSubscribed (logged + continue).
+        const watchRepos = webhookConfig.watchRepos ?? [];
+        const watchSubscriptions =
+          watchRepos.length > 0
+            ? Promise.allSettled(
+                watchRepos.map((repo) => subscriber.ensureSubscribed(repo)),
+              )
+            : Promise.resolve();
+        // 1-hour replay window — wide enough to cover most outages, narrow enough
+        // to keep startup latency under a few seconds.
+        const since = new Date(Date.now() - 60 * 60_000);
+        void watchSubscriptions
+          .then(() => replay.replaySince(subscriber.listSubscribed(), since))
+          .then((count) => {
+            if (count > 0) {
+              console.info(
+                `[server] replayed ${count} webhook deliveries from the last hour`,
+              );
+            }
+          })
+          .catch((err: unknown) => {
+            console.error(
+              `[server] webhook replay failed:`,
+              err instanceof Error ? err.message : String(err),
             );
-          }
-        })
-        .catch((err: unknown) => {
-          console.error(
-            `[server] webhook replay failed:`,
-            err instanceof Error ? err.message : String(err),
-          );
-        });
+          });
+      }
     }
   }
 
   const linearSmeeChannel = opts.linearWebhookConfig?.smeeChannel ?? "";
   if (linearSmeeChannel.length > 0) {
-    linearWebhookTunnel = createWebhookTunnel({
-      source: linearSmeeChannel,
-      target: `http://localhost:${server.port}/api/webhook/linear`,
-      logger: {
-        info: (m) => console.info(`[linear-tunnel] ${m}`),
-        error: (m) => console.error(`[linear-tunnel] ${m}`),
-      },
-    });
-    void linearWebhookTunnel.start().catch((err: unknown) => {
-      console.error(
-        `[server] linear webhook tunnel start failed:`,
-        err instanceof Error ? err.message : String(err),
+    if (cloudModeSuppressesTunnels) {
+      // Same rationale as the GitHub branch above — loud on purpose.
+      console.info(
+        `[server] suppressing Linear webhook smee tunnel start: deployment mode is "cloud" (event ingestion is the cloud SDK connection, not the smee tunnel)`,
       );
-    });
+    } else {
+      linearWebhookTunnel = createWebhookTunnel({
+        source: linearSmeeChannel,
+        target: `http://localhost:${server.port}/api/webhook/linear`,
+        logger: {
+          info: (m) => console.info(`[linear-tunnel] ${m}`),
+          error: (m) => console.error(`[linear-tunnel] ${m}`),
+        },
+        factory: opts.linearWebhookConfig?.tunnelFactory,
+      });
+      void linearWebhookTunnel.start().catch((err: unknown) => {
+        console.error(
+          `[server] linear webhook tunnel start failed:`,
+          err instanceof Error ? err.message : String(err),
+        );
+      });
+    }
   }
 
   if (pidFile) {


### PR DESCRIPTION
## Summary

PR3 of the CTL-1617 migration plan (design §6 row 1 + §9-PR3): orch-monitor's GitHub and Linear smee tunnel starts gain a single AND-gate — tunnels start only when the resolved **deployment mode** is not `cloud`. One `getDeploymentMode()` read at startup (injectable `deploymentModeReader`), loud suppression logging, direct leaf import (no shim, no resolver copy).

**Provable no-op on the live fleet:** nothing resolves `cloud` today (declaration is PR4). The never-skips test block — mandated by design risk 7 (consumer-side inversion bugs) — proves `single-host`/`cluster`/undeclared-default all still start tunnels, exercised against the real resolver; a full-suite diff against baseline shows zero new failures.

Notes for reviewers:
- `linearWebhookConfig.tunnelFactory` is new (mirrors `webhookConfig.tunnelFactory`) — it's what makes the Linear tunnel branch testable without a real smee connection.
- The CTL-216 watchRepos-subscription + replay block rides the same cloud branch (replay is smee-lineage state; CTL-1532 delivery-id dedup keeps any transition window safe).
- Startup on undeclared hosts now logs the resolver's declare-it WARN once per process (same as PR2's execution-core wiring) — expected in deploy log diffs until PR4.

## Verification

8/8 gate tests; `tsc --noEmit` clean; lint clean; adversarial Fable verify PASS with zero blocking findings (including an actual gate-inversion mutation test — flipped the condition, watched the never-skips tests fail, restored).

Linear: CTL-1617

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WHfJt1JhsdArSUyxwZZzkN