### PR TITLE
feat(dev): CTL-1617 declare the fleet deployment mode (PR4 of 7)

### DIFF
--- a/.catalyst/config.json
+++ b/.catalyst/config.json
@@ -58,6 +58,9 @@
         ]
       }
     },
+    "deployment": {
+      "mode": "cluster"
+    },
     "orchestration": {
       "dispatchMode": "phase-agents",
       "worktreeRefresh": {

--- a/website/src/content/docs/reference/configuration.md
+++ b/website/src/content/docs/reference/configuration.md
@@ -546,6 +546,11 @@ In `~/.config/catalyst/config.json` (Layer-2, per-host override):
 { "catalyst": { "deployment": { "mode": "single-host" } } }
 ```
 
+**This repository declares `cluster`** (CTL-1617 PR4 — the working installation is a 2-host fleet).
+A dev-clone on a machine that runs no Catalyst stack should set the Layer-2 `single-host` override
+above; without it, `catalyst doctor` on that machine reports a declared-cluster-but-no-roster
+deployment-mode WARN (advisory only — nothing else changes).
+
 **Resolution** (`resolveDeploymentMode()` / `catalyst_resolve_deployment_mode`):
 
 | Precedence | Source                                                |


### PR DESCRIPTION
## Summary

PR4 of the CTL-1617 migration plan: the repo's Layer-1 `.catalyst/config.json` declares `catalyst.deployment.mode: "cluster"` (judge-verified correct value — this installation is a 2-host fleet), plus the documented Layer-2 `single-host` override for dev-clones.

Behavior surface: **doctor output only.** The PR2 checks are WARN/PASS-advisory and PR3's tunnel gate reacts only to `cloud`, so declaring `cluster` flips check 1 from WARN(inferred) to PASS(declared) and arms check 3 (roster-consistency, WARN-only) — which should PASS on the live 2-host roster. Nothing else reads the declaration.

Post-merge verification (will be posted to the ticket): per-host resolver + doctor deployment-mode outputs on mini then mini-2 (`mode=cluster source=layer1 recognized=true`, check 3 quiet), then the laptop Layer-2 override dogfooded.

Linear: CTL-1617

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WHfJt1JhsdArSUyxwZZzkN