### PR TITLE
feat(dev): CTL-1616 secret-contract registry pair + cluster-sync derivation (PR1)

### DIFF
--- a/plugins/dev/scripts/__tests__/catalyst-secret-contract.test.sh
+++ b/plugins/dev/scripts/__tests__/catalyst-secret-contract.test.sh
@@ -196,6 +196,18 @@ printf 'c\x00loud' > "${TMP_DIR}/nul-cfg/github-token"
 OUT="$(_run "CATALYST_CONFIG_DIR=${TMP_DIR}/nul-cfg" "GH_TOKEN=fallback-after-nul" 'catalyst_resolve_secret github-token')"
 expect_eq "resolve github-token: NUL-containing file rejected, falls through" "fallback-after-nul|inherited|bare-file" "$OUT"
 
+# NON-UTF-8 BYTES (Codex finding fix): a file whose bytes are not valid UTF-8 must be
+# REJECTED consistently on both sides — never silently served as a mutated credential.
+mkdir -p "${TMP_DIR}/badutf8-cfg"
+printf '\xff\xfehi' > "${TMP_DIR}/badutf8-cfg/github-token"
+OUT="$(_run "CATALYST_CONFIG_DIR=${TMP_DIR}/badutf8-cfg" "GH_TOKEN=fallback-after-bad-utf8" 'catalyst_resolve_secret github-token')"
+expect_eq "resolve github-token: non-UTF-8 file rejected, falls through" "fallback-after-bad-utf8|inherited|bare-file" "$OUT"
+
+mkdir -p "${TMP_DIR}/goodutf8-cfg"
+printf 'tok-\xe2\x9c\x93-value\n' > "${TMP_DIR}/goodutf8-cfg/github-token"
+OUT="$(_run "CATALYST_CONFIG_DIR=${TMP_DIR}/goodutf8-cfg" 'catalyst_resolve_secret github-token')"
+expect_eq "resolve github-token: valid multi-byte UTF-8 is preserved, not rejected" $'tok-\xe2\x9c\x93-value|shared-file|bare-file' "$OUT"
+
 # --- resolveSecret: unknown id ----------------------------------------------
 OUT="$(_run 'catalyst_resolve_secret does-not-exist-xyz')"
 expect_eq "resolve unknown id: empty triple, never fails the caller" "||" "$OUT"
@@ -238,7 +250,46 @@ expect_eq "groq-api-key: bare JSON false settles as none (BLOCKING-1 class), nev
 
 printf '%s' '{"catalyst":{"linear":{"bot":{"orchestrator":"{\"apiKey\":\"x\"}"}}}}' > "${TMP_DIR}/l2cfg/config.json"
 OUT="$(_run "CATALYST_LAYER2_CONFIG_FILE=${TMP_DIR}/l2cfg/config.json" 'catalyst_resolve_secret linear-orchestrator-actor')"
-expect_eq "linear-orchestrator-actor: reads the dotted config path" '{"apiKey":"x"}|config-json|config-json' "$OUT"
+expect_eq "linear-orchestrator-actor: reads the dotted config path (string-shaped value)" '{"apiKey":"x"}|config-json|config-json' "$OUT"
+
+# --- ACTOR ROW SHAPE (Codex finding fix): the AUTHORITATIVE Layer-2 schema stores
+# catalyst.linear.bot.orchestrator/.worker as OBJECTS ({clientId, clientSecret, ...}), never
+# a string — this fixture uses a REAL object (not a string containing JSON text, which
+# masked the pre-fix bug) and asserts the canonicalized (sorted-key) output.
+printf '%s' '{"catalyst":{"linear":{"bot":{"orchestrator":{"clientSecret":"s3cr3t","clientId":"abc123"}}}}}' > "${TMP_DIR}/l2cfg/config.json"
+OUT="$(_run "CATALYST_LAYER2_CONFIG_FILE=${TMP_DIR}/l2cfg/config.json" 'catalyst_resolve_secret linear-orchestrator-actor')"
+expect_eq "linear-orchestrator-actor: OBJECT-shaped value canonicalizes with sorted keys" \
+  '{"clientId":"abc123","clientSecret":"s3cr3t"}|config-json|config-json' "$OUT"
+
+printf '%s' '{"catalyst":{"linear":{"bot":{"orchestrator":{}}}}}' > "${TMP_DIR}/l2cfg/config.json"
+OUT="$(_run "CATALYST_LAYER2_CONFIG_FILE=${TMP_DIR}/l2cfg/config.json" 'catalyst_resolve_secret linear-orchestrator-actor')"
+expect_eq "linear-orchestrator-actor: an EMPTY object still resolves (canonical '{}')" \
+  '{}|config-json|config-json' "$OUT"
+
+printf '%s' '{"catalyst":{"linear":{"bot":{"orchestrator":["nope"]}}}}' > "${TMP_DIR}/l2cfg/config.json"
+OUT="$(_run "CATALYST_LAYER2_CONFIG_FILE=${TMP_DIR}/l2cfg/config.json" 'catalyst_resolve_secret linear-orchestrator-actor')"
+expect_eq "linear-orchestrator-actor: an ARRAY is rejected (not a valid credential shape)" "|none|config-json" "$OUT"
+
+# --- TRAILING NEWLINES IN JSON VALUES (Codex finding fix) -------------------
+printf '%s' '{"groq":{"apiKey":"abc\n"}}' > "${TMP_DIR}/l2cfg/config.json"
+OUT="$(_run "CATALYST_LAYER2_CONFIG_FILE=${TMP_DIR}/l2cfg/config.json" 'catalyst_resolve_secret groq-api-key')"
+expect_eq "groq-api-key: a trailing newline in the JSON string value is preserved byte-for-byte" \
+  $'abc\n|config-json|config-json' "$OUT"
+
+# --- JSON ACCEPTANCE NORMALIZATION (Codex finding fix) ----------------------
+# BOM-prefixed Layer-2 file: jq tolerates it, JSON.parse rejects it — must settle @ABSENT
+# (falls through to none) on the bash side too.
+BOM_CFG="${TMP_DIR}/l2cfg/bom-config.json"
+printf '\xEF\xBB\xBF{"groq":{"apiKey":"should-not-resolve"}}' > "$BOM_CFG"
+OUT="$(_run "CATALYST_LAYER2_CONFIG_FILE=${BOM_CFG}" 'catalyst_resolve_secret groq-api-key')"
+expect_eq "hostile: BOM-prefixed Layer-2 file settles as none (malformed, matches JSON.parse)" "|none|config-json" "$OUT"
+
+# Multi-document Layer-2 file: jq without -s processes each document independently (emits
+# multiple tags); JSON.parse rejects the whole file. Must settle @ABSENT (none) here too.
+MULTIDOC_CFG="${TMP_DIR}/l2cfg/multidoc-config.json"
+printf '{"groq":{"apiKey":"first-doc"}}{"groq":{"apiKey":"second-doc"}}' > "$MULTIDOC_CFG"
+OUT="$(_run "CATALYST_LAYER2_CONFIG_FILE=${MULTIDOC_CFG}" 'catalyst_resolve_secret groq-api-key')"
+expect_eq "hostile: multi-document Layer-2 file settles as none (malformed, matches JSON.parse)" "|none|config-json" "$OUT"
 
 # --- resolveSecret: platform-env (cloud-token) ------------------------------
 OUT="$(_run "CATALYST_CLOUD_TOKEN=cloud-val" 'catalyst_resolve_secret cloud-token')"
@@ -250,6 +301,31 @@ OUT="$(_run "CATALYST_LAYER2_CONFIG_FILE=${TMP_DIR}/l2cfg/config.json" "OTHER_VA
 expect_eq "cloud-token: Layer-2 NAME override" "v2|platform-env|platform-env" "$OUT"
 OUT="$(_run 'catalyst_resolve_secret cloud-token')"
 expect_eq "cloud-token: name resolves, value unset ⇒ none" "|none|platform-env" "$OUT"
+
+# --- INVALID ENV NAME (Codex finding fix): CATALYST_CLOUD_TOKEN_ENV / the Layer-2 override
+# is operator-controlled text — an invalid shell-identifier value must degrade to the
+# documented unresolved result (source=none), never a fatal "invalid variable name" abort.
+OUT="$(_run "CATALYST_CLOUD_TOKEN_ENV=BAD-NAME" 'catalyst_resolve_secret cloud-token')"
+RC=$?
+expect_eq "cloud-token: invalid env-name override does not abort the caller (rc=0)" "0" "$RC"
+expect_eq "cloud-token: invalid env-name override resolves none (JS parity), never a crash" "|none|platform-env" "$OUT"
+
+printf '%s' '{"catalyst":{"cloud":{"tokenEnv":"BAD-NAME-FROM-LAYER2"}}}' > "${TMP_DIR}/l2cfg/config.json"
+OUT="$(_run "CATALYST_LAYER2_CONFIG_FILE=${TMP_DIR}/l2cfg/config.json" 'catalyst_resolve_secret cloud-token')"
+RC=$?
+expect_eq "cloud-token: invalid Layer-2 tokenEnv override does not abort the caller (rc=0)" "0" "$RC"
+expect_eq "cloud-token: invalid Layer-2 tokenEnv override resolves none" "|none|platform-env" "$OUT"
+
+# Errexit-safety regression: run the SAME invalid-name probe under `set -e` in a fresh
+# process — before the fix, `${!_env_var-}` on an invalid identifier fatally aborted the
+# WHOLE process, not just the lookup. (CATALYST_CLOUD_TOKEN_ENV is passed as a leading
+# assignment arg to _run, not embedded in the snippet text — _run's own `[[ "$1" == *=* ]]`
+# assignment-parsing loop would otherwise misparse a snippet body containing a literal "=".)
+ERREXIT_ENV_OUT="$(_run "CATALYST_CLOUD_TOKEN_ENV=BAD-NAME" 'set -e
+catalyst_resolve_secret cloud-token')"
+ERREXIT_ENV_RC=$?
+expect_eq "invalid env name under set -e: caller process exits 0 (no abort)" "0" "$ERREXIT_ENV_RC"
+expect_eq "invalid env name under set -e: still resolves none" "|none|platform-env" "$ERREXIT_ENV_OUT"
 
 # --- resolveSecret: local-only (age-key), never fetched ---------------------
 mkdir -p "${TMP_DIR}/agehome/.config/catalyst"
@@ -280,6 +356,21 @@ OUT="$(_run "GH_TOKEN=should-not-be-returned" 'catalyst_resolve_secret github-to
 expect_eq "bootstrap short-circuit: cloud-token absent ⇒ every other row's cloud resolution is empty/empty" "||bare-file" "$OUT"
 OUT="$(_run 'catalyst_resolve_secret cloud-token cloud false')"
 expect_eq "bootstrap short-circuit does not apply to cloud-token itself (resolves normally, absent here)" "|none|platform-env" "$OUT"
+
+# --- CLOUD-TOKEN NAME OVERRIDE (Codex finding fix): genuine cloud mode must honor
+# CATALYST_CLOUD_TOKEN_ENV / the Layer-2 override, not only the hardcoded default name ------
+OUT="$(_run "CATALYST_CLOUD_TOKEN_ENV=MY_PLATFORM_TOKEN" "MY_PLATFORM_TOKEN=the-real-token" 'catalyst_resolve_secret cloud-token cloud false')"
+expect_eq "cloud-token: genuine cloud mode honors CATALYST_CLOUD_TOKEN_ENV override" \
+  "the-real-token|platform-env|platform-env" "$OUT"
+
+printf '%s' '{"catalyst":{"cloud":{"tokenEnv":"OTHER_TOKEN_VAR"}}}' > "${TMP_DIR}/l2cfg/config.json"
+OUT="$(_run "CATALYST_LAYER2_CONFIG_FILE=${TMP_DIR}/l2cfg/config.json" "OTHER_TOKEN_VAR=v2" 'catalyst_resolve_secret cloud-token cloud false')"
+expect_eq "cloud-token: genuine cloud mode honors the Layer-2 catalyst.cloud.tokenEnv override too" \
+  "v2|platform-env|platform-env" "$OUT"
+
+OUT="$(_run "CATALYST_CLOUD_TOKEN_ENV=MY_PLATFORM_TOKEN" "CATALYST_CLOUD_TOKEN=should-not-be-used" 'catalyst_resolve_secret cloud-token cloud false')"
+expect_eq "cloud-token: override name genuinely consulted — the default var being set does NOT resolve it" \
+  "|none|platform-env" "$OUT"
 
 # --- arm state: MUST be called directly (not via $()) for state to persist -
 catalyst_secret_reset_arm_state
@@ -337,6 +428,43 @@ expect_eq "arm: rotation differing only AFTER the pipe is detected (restartRequi
   "false|true|true" \
   "${CATALYST_SECRET_ARM_ARMED}|${CATALYST_SECRET_ARM_ROTATED}|${CATALYST_SECRET_ARM_RESTART_REQUIRED}"
 unset CATALYST_CONFIG_DIR
+
+# --- ARM DEPLOYMENT MODE (Codex finding fix, design §8): catalyst_arm_secret must thread
+# the SAME deployment-mode args catalyst_resolve_secret takes, so a cloud-mode arm baseline
+# consults the identical provider chain direct resolution uses. Scenario: cloud mode with an
+# injected env token AND a stale local file — a file-only edit must NOT report a false
+# restartRequired, and rotating the REAL (env) token MUST be detected. ---------------------
+ARM_CLOUD_TMP="${TMP_DIR}/arm-cloud-cfg"
+mkdir -p "$ARM_CLOUD_TMP"
+export CATALYST_CONFIG_DIR="$ARM_CLOUD_TMP"
+export GH_TOKEN="cloud-injected-v1"
+export CATALYST_CLOUD_TOKEN="boot"
+catalyst_secret_reset_arm_state
+printf 'stale-file-value-v1' > "${ARM_CLOUD_TMP}/github-token"
+
+# Direct resolution (the ground truth arm's baseline must match) resolves via env, not file.
+DIRECT_OUT="$(catalyst_resolve_secret github-token cloud false)"
+expect_eq "arm-deployment-mode: direct resolution in cloud mode uses the env value, not the stale file" \
+  "cloud-injected-v1|inherited|bare-file" "$DIRECT_OUT"
+
+catalyst_arm_secret github-token cloud false >/dev/null
+expect_eq "arm-deployment-mode: first observation establishes baseline" "false|false|false" \
+  "${CATALYST_SECRET_ARM_ARMED}|${CATALYST_SECRET_ARM_ROTATED}|${CATALYST_SECRET_ARM_RESTART_REQUIRED}"
+
+# Rewriting the STALE FILE ONLY must NOT be observed as a rotation.
+printf 'stale-file-value-v2-changed' > "${ARM_CLOUD_TMP}/github-token"
+catalyst_arm_secret github-token cloud false >/dev/null
+expect_eq "arm-deployment-mode: a file-only change is IGNORED — baseline tracks the env-derived value like direct resolution does" \
+  "false|false|false" \
+  "${CATALYST_SECRET_ARM_ARMED}|${CATALYST_SECRET_ARM_ROTATED}|${CATALYST_SECRET_ARM_RESTART_REQUIRED}"
+
+# Rotating the ACTUAL cloud-injected env value MUST be detected.
+export GH_TOKEN="cloud-injected-v2-rotated"
+catalyst_arm_secret github-token cloud false >/dev/null
+expect_eq "arm-deployment-mode: rotating the REAL cloud-injected value IS detected (restartRequired fires)" \
+  "false|true|true" \
+  "${CATALYST_SECRET_ARM_ARMED}|${CATALYST_SECRET_ARM_ROTATED}|${CATALYST_SECRET_ARM_RESTART_REQUIRED}"
+unset CATALYST_CONFIG_DIR GH_TOKEN CATALYST_CLOUD_TOKEN
 
 # --- B4 regression: catalyst_arm_secret(unknown id) must not abort a `set -e` caller ------
 # Same-shell direct call (no `set -e` in THIS process) — asserts the quiet {armed:false}

--- a/plugins/dev/scripts/__tests__/catalyst-secret-contract.test.sh
+++ b/plugins/dev/scripts/__tests__/catalyst-secret-contract.test.sh
@@ -1,0 +1,364 @@
+#!/usr/bin/env bash
+# Shell unit tests for plugins/dev/scripts/lib/catalyst-secret-contract.sh (CTL-1616).
+# Standalone per-language suite — cross-stack agreement with lib/secret-contract.mjs is
+# covered separately by __tests__/secret-contract-parity.test.sh. Follows the
+# __tests__/catalyst-deployment-mode.test.sh conventions (ok/fail/expect_eq,
+# PASSES/FAILURES exit code).
+#
+# SECRET HYGIENE (mirrors __tests__/catalyst-execution-core-github-token.test.sh): every
+# probe below runs under `env -i` with HOME repointed at a scratch tmpdir, so a developer's
+# real shell LINEAR_API_KEY/GITHUB_TOKEN/age-key file can never leak into a fixture or this
+# test's own output. Fixtures are obviously-fake literals.
+#
+# Run: bash plugins/dev/scripts/__tests__/catalyst-secret-contract.test.sh
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../../.." && pwd)"
+LIB="${REPO_ROOT}/plugins/dev/scripts/lib/catalyst-secret-contract.sh"
+
+# shellcheck disable=SC1090
+source "$LIB"
+
+# Defensive secret-hygiene guard for the arm-state section below, which (necessarily) calls
+# catalyst_arm_secret directly in THIS process rather than through the `_run`/`env -i`
+# wrapper (see that section's own comment for why). Nothing in this file's assertions
+# depends on any of these ever being set, but clearing them here means a developer's real
+# ambient credential can never even theoretically leak into an arm-state assertion.
+unset GH_TOKEN GITHUB_TOKEN LINEAR_API_TOKEN LINEAR_API_KEY GROQ_API_KEY \
+  CATALYST_CLOUD_TOKEN SOPS_AGE_KEY_FILE CATALYST_WEBHOOK_SECRET 2>/dev/null || true
+
+FAILURES=0
+PASSES=0
+
+ok() {
+  local name="$1"
+  PASSES=$((PASSES+1))
+  echo "  PASS: $name"
+}
+fail() {
+  local name="$1" detail="$2"
+  FAILURES=$((FAILURES+1))
+  echo "  FAIL: $name"
+  echo "    $detail"
+}
+expect_eq() {
+  local name="$1" expected="$2" actual="$3"
+  if [[ "$expected" == "$actual" ]]; then
+    ok "$name"
+  else
+    fail "$name" "expected '$expected' got '$actual'"
+  fi
+}
+
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+SANDBOX_HOME="${TMP_DIR}/home"
+mkdir -p "$SANDBOX_HOME"
+
+# _run runs a snippet under `env -i` (real environment fully cleared) with HOME pointed at
+# the sandbox, plus any extra assignments passed as leading args. Mirrors the isolation
+# convention used across this repo's other hermetic __tests__ suites.
+#
+# B6 FIX: `"${assigns[@]}"` on a POSSIBLY-EMPTY array — most call sites pass zero
+# assignments (e.g. `_run 'catalyst_resolve_secret age-key'`) — false-fails under stock
+# macOS bash 3.2 (/bin/bash) run with `set -u`/nounset: bash 3.2's array expansion treats
+# an empty array's "${arr[@]}" as an unset-parameter reference and aborts with "assigns[@]:
+# unbound variable" (this is a real 3.2-vs-4+ behavior difference, fixed upstream in bash
+# 4.4; this repo's compatibility bar is 3.2, matching lib/catalyst-secret-contract.sh's own
+# stated bar). `"${assigns[@]+"${assigns[@]}"}"` is the standard bash 3.2-safe idiom: the
+# `+` alternate-value test only expands the inner "${assigns[@]}" when the array is SET
+# (even to zero elements), so an empty array yields nothing instead of triggering nounset.
+_run() {
+  local -a assigns=()
+  while [[ "$1" == *=* ]]; do
+    assigns+=("$1")
+    shift
+  done
+  local snippet="$1"
+  env -i PATH="$PATH" HOME="$SANDBOX_HOME" "${assigns[@]+"${assigns[@]}"}" \
+    bash -c "source '$LIB'; $snippet"
+}
+
+# --- idempotent-load guard ------------------------------------------------
+expect_eq "idempotent-source guard set" "1" "${_CATALYST_SECRET_CONTRACT_SH_LOADED:-}"
+
+# --- registry shape --------------------------------------------------------
+IDS_OUT="$(catalyst_secret_registry_ids | tr '\n' ',')"
+expect_eq "11 registry ids in order" \
+  "github-token,webhook-secret,linear-webhook-secret,claude-accounts.env,execution-core.env,linear-api-token,linear-orchestrator-actor,linear-worker-actor,groq-api-key,cloud-token,age-key," \
+  "$IDS_OUT"
+
+expect_eq "unknown id delivery is empty, not a crash" "" "$(catalyst_secret_delivery bogus-id-xyz)"
+expect_eq "github-token delivery" "bare-file" "$(catalyst_secret_delivery github-token)"
+expect_eq "linear-webhook-secret delivery" "bare-file-family" "$(catalyst_secret_delivery linear-webhook-secret)"
+expect_eq "linear-api-token delivery" "env-alias" "$(catalyst_secret_delivery linear-api-token)"
+expect_eq "cloud-token delivery" "platform-env" "$(catalyst_secret_delivery cloud-token)"
+expect_eq "age-key delivery" "local-only" "$(catalyst_secret_delivery age-key)"
+expect_eq "age-key rotation class" "n/a" "$(catalyst_secret_rotation_class age-key)"
+expect_eq "github-token rotation class" "re-armable" "$(catalyst_secret_rotation_class github-token)"
+expect_eq "github-token rotation trigger" "timer" "$(catalyst_secret_rotation_trigger github-token)"
+expect_eq "linear-api-token rotation trigger" "on-401" "$(catalyst_secret_rotation_trigger linear-api-token)"
+expect_eq "cloud-token bootstrapFor" "cloud" "$(catalyst_secret_bootstrap_for cloud-token)"
+expect_eq "age-key bootstrapFor" "cluster" "$(catalyst_secret_bootstrap_for age-key)"
+expect_eq "github-token bootstrapFor is empty" "" "$(catalyst_secret_bootstrap_for github-token)"
+expect_eq "linear-orchestrator-actor config path" "catalyst.linear.bot.orchestrator" "$(catalyst_secret_config_json_path linear-orchestrator-actor)"
+expect_eq "linear-worker-actor config path (distinct from orchestrator)" "catalyst.linear.bot.worker" "$(catalyst_secret_config_json_path linear-worker-actor)"
+
+ENV_NAMES_OUT="$(catalyst_secret_env_names github-token | tr '\n' ',')"
+expect_eq "github-token env names" "GH_TOKEN,GITHUB_TOKEN," "$ENV_NAMES_OUT"
+ENV_NAMES_EMPTY="$(catalyst_secret_env_names linear-orchestrator-actor | tr '\n' ',')"
+expect_eq "linear-orchestrator-actor has no env-name aliases" "" "$ENV_NAMES_EMPTY"
+
+# --- B1 regression: env-name splitting must not depend on the caller's ambient $IFS -------
+# A caller that sources this file under the common strict-shell IFS=$'\n\t' (no space in
+# it) previously made catalyst_secret_env_names return "GH_TOKEN GITHUB_TOKEN" as ONE
+# unsplit token, which then FATALLY ABORTED the whole sourcing process the moment
+# _csc_resolve_env_alias_only tried `${!_name-}` on that space-containing "variable name".
+_STRICT_IFS=$'\n\t'
+ENV_NAMES_STRICT_IFS="$(_run "IFS=${_STRICT_IFS}" 'catalyst_secret_env_names github-token | tr "\n" ","')"
+expect_eq "B1: env names split correctly under strict IFS=\$'\\n\\t' (no crash)" \
+  "GH_TOKEN,GITHUB_TOKEN," "$ENV_NAMES_STRICT_IFS"
+RESOLVE_STRICT_IFS="$(_run "IFS=${_STRICT_IFS}" "GITHUB_TOKEN=strict-ifs-value" 'catalyst_resolve_secret github-token')"
+expect_eq "B1: catalyst_resolve_secret resolves github-token under strict IFS (no crash, no bogus 'invalid variable name' abort)" \
+  "strict-ifs-value|inherited|bare-file" "$RESOLVE_STRICT_IFS"
+
+# --- isSecretFamilyMember mirror -------------------------------------------
+if catalyst_secret_is_family_member "linear-webhook-secret-CTL"; then
+  ok "family member: mixed-case team key"
+else
+  fail "family member: mixed-case team key" "expected match"
+fi
+if catalyst_secret_is_family_member "linear-webhook-secret-"; then
+  fail "bare prefix must NOT be a member" "matched"
+else
+  ok "bare prefix is not a member"
+fi
+if catalyst_secret_is_family_member "linear-webhook-secretXXX"; then
+  fail "run-on name must NOT be a member" "matched"
+else
+  ok "run-on name is not a member"
+fi
+
+# --- explicit-file-override var derivation ---------------------------------
+expect_eq "github-token override var" "CATALYST_GITHUB_TOKEN_FILE" "$(catalyst_secret_explicit_file_override_var github-token)"
+expect_eq "webhook-secret override var" "CATALYST_WEBHOOK_SECRET_FILE" "$(catalyst_secret_explicit_file_override_var webhook-secret)"
+expect_eq "claude-accounts.env override var (dash AND dot collapse to one underscore)" \
+  "CATALYST_CLAUDE_ACCOUNTS_ENV_FILE" "$(catalyst_secret_explicit_file_override_var claude-accounts.env)"
+
+# --- resolveLayer2Path — the §2 canonical chain ----------------------------
+OUT="$(_run "CATALYST_LAYER2_CONFIG_FILE=/explicit/path.json" 'catalyst_secret_resolve_layer2_path')"
+expect_eq "layer2 path: explicit override wins" "/explicit/path.json" "$OUT"
+OUT="$(_run "CATALYST_MACHINE_CONFIG=/machine/config.json" 'catalyst_secret_resolve_layer2_path')"
+expect_eq "layer2 path: CATALYST_MACHINE_CONFIG wins over default" "/machine/config.json" "$OUT"
+OUT="$(_run "XDG_CONFIG_HOME=${TMP_DIR}/xdg" 'catalyst_secret_resolve_layer2_path')"
+expect_eq "layer2 path: XDG_CONFIG_HOME wins over bare-HOME default" "${TMP_DIR}/xdg/catalyst/config.json" "$OUT"
+OUT="$(_run 'catalyst_secret_resolve_layer2_path')"
+expect_eq "layer2 path: default ~/.config/catalyst/config.json" "${SANDBOX_HOME}/.config/catalyst/config.json" "$OUT"
+
+# --- catalyst_secret_candidates ---------------------------------------------
+OUT="$(_run "CATALYST_GITHUB_TOKEN_FILE=/x/y" 'catalyst_secret_candidates github-token | tr "\n" ","')"
+expect_eq "candidates: explicit override short-circuits" "/x/y," "$OUT"
+OUT="$(_run "CATALYST_CONFIG_DIR=/cfgdir" 'catalyst_secret_candidates github-token | tr "\n" ","')"
+expect_eq "candidates: CATALYST_CONFIG_DIR short-circuits" "/cfgdir/github-token," "$OUT"
+OUT="$(_run 'catalyst_secret_candidates github-token | tr "\n" ","')"
+expect_eq "candidates: default chain dedupes to one (layer2-dir == xdg-dir by default)" \
+  "${SANDBOX_HOME}/.config/catalyst/github-token," "$OUT"
+OUT="$(_run "CATALYST_LAYER2_CONFIG_FILE=/other/config.json" "XDG_CONFIG_HOME=/xdg" 'catalyst_secret_candidates github-token | tr "\n" ","')"
+expect_eq "candidates: distinct XDG dir yields two candidates" "/other/github-token,/xdg/catalyst/github-token," "$OUT"
+
+# --- resolveSecret: bare-file (github-token) --------------------------------
+mkdir -p "${TMP_DIR}/cfg"
+printf 'tok-value\n' > "${TMP_DIR}/cfg/github-token"
+OUT="$(_run "CATALYST_CONFIG_DIR=${TMP_DIR}/cfg" 'catalyst_resolve_secret github-token')"
+expect_eq "resolve github-token from CATALYST_CONFIG_DIR" "tok-value|shared-file|bare-file" "$OUT"
+
+printf 'override-val' > "${TMP_DIR}/explicit-gh-token"
+OUT="$(_run "CATALYST_GITHUB_TOKEN_FILE=${TMP_DIR}/explicit-gh-token" 'catalyst_resolve_secret github-token')"
+expect_eq "resolve github-token from explicit override" "override-val|operator-override|bare-file" "$OUT"
+
+OUT="$(_run "CATALYST_CONFIG_DIR=${TMP_DIR}/does-not-exist-dir" "GH_TOKEN=inherited-val" 'catalyst_resolve_secret github-token')"
+expect_eq "resolve github-token falls back to inherited env alias" "inherited-val|inherited|bare-file" "$OUT"
+
+OUT="$(_run "CATALYST_CONFIG_DIR=${TMP_DIR}/does-not-exist-dir" 'catalyst_resolve_secret github-token')"
+expect_eq "resolve github-token: nothing anywhere ⇒ none" "|none|bare-file" "$OUT"
+
+mkdir -p "${TMP_DIR}/blank-cfg"
+printf '   \n' > "${TMP_DIR}/blank-cfg/github-token"
+OUT="$(_run "CATALYST_CONFIG_DIR=${TMP_DIR}/blank-cfg" "GH_TOKEN=fallback-val" 'catalyst_resolve_secret github-token')"
+expect_eq "resolve github-token: whitespace-only file treated as absent" "fallback-val|inherited|bare-file" "$OUT"
+
+# NUL-byte parity fixture: a file with an embedded NUL must be rejected (falls through to
+# the env alias), never silently truncated to a partial value.
+mkdir -p "${TMP_DIR}/nul-cfg"
+printf 'c\x00loud' > "${TMP_DIR}/nul-cfg/github-token"
+OUT="$(_run "CATALYST_CONFIG_DIR=${TMP_DIR}/nul-cfg" "GH_TOKEN=fallback-after-nul" 'catalyst_resolve_secret github-token')"
+expect_eq "resolve github-token: NUL-containing file rejected, falls through" "fallback-after-nul|inherited|bare-file" "$OUT"
+
+# --- resolveSecret: unknown id ----------------------------------------------
+OUT="$(_run 'catalyst_resolve_secret does-not-exist-xyz')"
+expect_eq "resolve unknown id: empty triple, never fails the caller" "||" "$OUT"
+
+# --- resolveSecret: bare-file-family (no scalar value) ----------------------
+OUT="$(_run 'catalyst_resolve_secret linear-webhook-secret')"
+expect_eq "resolve linear-webhook-secret (family row): no single value" "||bare-file-family" "$OUT"
+
+# --- resolveSecret: env-file presence (claude-accounts.env) -----------------
+mkdir -p "${TMP_DIR}/envfile-cfg"
+printf 'CLAUDE_CODE_OAUTH_TOKEN=abc\n' > "${TMP_DIR}/envfile-cfg/claude-accounts.env"
+OUT="$(_run "CATALYST_CONFIG_DIR=${TMP_DIR}/envfile-cfg" 'catalyst_resolve_secret claude-accounts.env')"
+expect_eq "resolve claude-accounts.env: presence, value is the PATH" \
+  "${TMP_DIR}/envfile-cfg/claude-accounts.env|shared-file|env-file" "$OUT"
+
+mkdir -p "${TMP_DIR}/empty-envfile-cfg"
+: > "${TMP_DIR}/empty-envfile-cfg/claude-accounts.env"
+OUT="$(_run "CATALYST_CONFIG_DIR=${TMP_DIR}/empty-envfile-cfg" 'catalyst_resolve_secret claude-accounts.env')"
+expect_eq "resolve claude-accounts.env: empty file counts as absent" "|none|env-file" "$OUT"
+
+# --- resolveSecret: env-alias (linear-api-token) ----------------------------
+OUT="$(_run "LINEAR_API_TOKEN=tok-a" "LINEAR_API_KEY=tok-b" 'catalyst_resolve_secret linear-api-token')"
+expect_eq "linear-api-token: LINEAR_API_TOKEN wins" "tok-a|inherited|env-alias" "$OUT"
+OUT="$(_run "LINEAR_API_KEY=tok-b" 'catalyst_resolve_secret linear-api-token')"
+expect_eq "linear-api-token: LINEAR_API_KEY-only fixture (CTL-1619 class) resolves" "tok-b|inherited|env-alias" "$OUT"
+OUT="$(_run 'catalyst_resolve_secret linear-api-token')"
+expect_eq "linear-api-token: neither set ⇒ none" "|none|env-alias" "$OUT"
+
+# --- resolveSecret: config-json (groq-api-key, linear-orchestrator-actor) --
+mkdir -p "${TMP_DIR}/l2cfg"
+printf '%s' '{"groq":{"apiKey":"from-config"}}' > "${TMP_DIR}/l2cfg/config.json"
+OUT="$(_run "CATALYST_LAYER2_CONFIG_FILE=${TMP_DIR}/l2cfg/config.json" "GROQ_API_KEY=from-env" 'catalyst_resolve_secret groq-api-key')"
+expect_eq "groq-api-key: env alias wins over config" "from-env|inherited|config-json" "$OUT"
+OUT="$(_run "CATALYST_LAYER2_CONFIG_FILE=${TMP_DIR}/l2cfg/config.json" 'catalyst_resolve_secret groq-api-key')"
+expect_eq "groq-api-key: falls back to config when env unset" "from-config|config-json|config-json" "$OUT"
+
+printf '%s' '{"groq":{"apiKey":false}}' > "${TMP_DIR}/l2cfg/config.json"
+OUT="$(_run "CATALYST_LAYER2_CONFIG_FILE=${TMP_DIR}/l2cfg/config.json" 'catalyst_resolve_secret groq-api-key')"
+expect_eq "groq-api-key: bare JSON false settles as none (BLOCKING-1 class), never coerced" "|none|config-json" "$OUT"
+
+printf '%s' '{"catalyst":{"linear":{"bot":{"orchestrator":"{\"apiKey\":\"x\"}"}}}}' > "${TMP_DIR}/l2cfg/config.json"
+OUT="$(_run "CATALYST_LAYER2_CONFIG_FILE=${TMP_DIR}/l2cfg/config.json" 'catalyst_resolve_secret linear-orchestrator-actor')"
+expect_eq "linear-orchestrator-actor: reads the dotted config path" '{"apiKey":"x"}|config-json|config-json' "$OUT"
+
+# --- resolveSecret: platform-env (cloud-token) ------------------------------
+OUT="$(_run "CATALYST_CLOUD_TOKEN=cloud-val" 'catalyst_resolve_secret cloud-token')"
+expect_eq "cloud-token: default name" "cloud-val|platform-env|platform-env" "$OUT"
+OUT="$(_run "CATALYST_CLOUD_TOKEN_ENV=MY_TOKEN" "MY_TOKEN=v" 'catalyst_resolve_secret cloud-token')"
+expect_eq "cloud-token: env-var NAME override" "v|platform-env|platform-env" "$OUT"
+printf '%s' '{"catalyst":{"cloud":{"tokenEnv":"OTHER_VAR"}}}' > "${TMP_DIR}/l2cfg/config.json"
+OUT="$(_run "CATALYST_LAYER2_CONFIG_FILE=${TMP_DIR}/l2cfg/config.json" "OTHER_VAR=v2" 'catalyst_resolve_secret cloud-token')"
+expect_eq "cloud-token: Layer-2 NAME override" "v2|platform-env|platform-env" "$OUT"
+OUT="$(_run 'catalyst_resolve_secret cloud-token')"
+expect_eq "cloud-token: name resolves, value unset ⇒ none" "|none|platform-env" "$OUT"
+
+# --- resolveSecret: local-only (age-key), never fetched ---------------------
+mkdir -p "${TMP_DIR}/agehome/.config/catalyst"
+printf 'AGE-SECRET-KEY-fake' > "${TMP_DIR}/agehome/.config/catalyst/age.key"
+OUT="$(env -i PATH="$PATH" HOME="${TMP_DIR}/agehome" bash -c "source '$LIB'; catalyst_resolve_secret age-key")"
+expect_eq "age-key: presence at default path" "${TMP_DIR}/agehome/.config/catalyst/age.key|present|local-only" "$OUT"
+OUT="$(_run 'catalyst_resolve_secret age-key')"
+expect_eq "age-key: absence" "|absent|local-only" "$OUT"
+printf 'AGE-SECRET-KEY-fake' > "${TMP_DIR}/custom-age.key"
+OUT="$(_run "SOPS_AGE_KEY_FILE=${TMP_DIR}/custom-age.key" 'catalyst_resolve_secret age-key')"
+expect_eq "age-key: SOPS_AGE_KEY_FILE override honored" "${TMP_DIR}/custom-age.key|present|local-only" "$OUT"
+
+# --- cloud guard (design §4) -------------------------------------------------
+mkdir -p "${TMP_DIR}/cloudguard-cfg"
+printf 'file-value' > "${TMP_DIR}/cloudguard-cfg/github-token"
+OUT="$(_run "CATALYST_CONFIG_DIR=${TMP_DIR}/cloudguard-cfg" 'catalyst_resolve_secret github-token cloud true')"
+expect_eq "cloud guard: inferred=true does NOT activate cloud — file chain still runs" \
+  "file-value|shared-file|bare-file" "$OUT"
+OUT="$(_run "CATALYST_CONFIG_DIR=${TMP_DIR}/cloudguard-cfg" 'catalyst_resolve_secret github-token single-host false')"
+expect_eq "cloud guard: mode=single-host never activates cloud" "file-value|shared-file|bare-file" "$OUT"
+OUT="$(_run "CATALYST_CONFIG_DIR=${TMP_DIR}/cloudguard-cfg" 'catalyst_resolve_secret github-token cluster false')"
+expect_eq "cloud guard: mode=cluster never activates cloud (zero new cluster resolution code)" "file-value|shared-file|bare-file" "$OUT"
+OUT="$(_run "CATALYST_CONFIG_DIR=${TMP_DIR}/cloudguard-cfg" "CATALYST_CLOUD_TOKEN=boot" 'catalyst_resolve_secret github-token cloud false')"
+expect_eq "cloud guard: genuinely cloud, no GH_TOKEN ⇒ file NEVER consulted, resolves none" "|none|bare-file" "$OUT"
+OUT="$(_run "CATALYST_CONFIG_DIR=${TMP_DIR}/cloudguard-cfg" "GH_TOKEN=cloud-injected" "CATALYST_CLOUD_TOKEN=boot" 'catalyst_resolve_secret github-token cloud false')"
+expect_eq "cloud guard: genuinely cloud with env alias present resolves via env" "cloud-injected|inherited|bare-file" "$OUT"
+OUT="$(_run "GH_TOKEN=should-not-be-returned" 'catalyst_resolve_secret github-token cloud false')"
+expect_eq "bootstrap short-circuit: cloud-token absent ⇒ every other row's cloud resolution is empty/empty" "||bare-file" "$OUT"
+OUT="$(_run 'catalyst_resolve_secret cloud-token cloud false')"
+expect_eq "bootstrap short-circuit does not apply to cloud-token itself (resolves normally, absent here)" "|none|platform-env" "$OUT"
+
+# --- arm state: MUST be called directly (not via $()) for state to persist -
+catalyst_secret_reset_arm_state
+# Seed a synthetic delivery/rotation row is not possible (registry is static data), so this
+# section exercises the REAL github-token row against a controlled CATALYST_CONFIG_DIR,
+# calling catalyst_arm_secret directly in the SAME shell (not "$(...)"-wrapped) exactly as
+# its own docstring requires.
+# Deliberately NOT wrapped in a `( ... )` subshell or `$(...)` command substitution: this
+# test file's own PASSES/FAILURES tally lives in THIS shell, and (per catalyst_arm_secret's
+# own docstring) a subshell would silently discard both the arm-state mutation AND any
+# counter increments made inside it — the identical subshell-export trap this whole suite
+# exists to guard against, one level up the call stack.
+ARM_TMP="${TMP_DIR}/arm-cfg"
+mkdir -p "$ARM_TMP"
+export CATALYST_CONFIG_DIR="$ARM_TMP"
+catalyst_secret_reset_arm_state
+printf 'FAKE-TOKEN-XYZ' > "${ARM_TMP}/github-token"
+catalyst_arm_secret github-token >/dev/null
+expect_eq "arm: first observation establishes baseline" "false|false|false" \
+  "${CATALYST_SECRET_ARM_ARMED}|${CATALYST_SECRET_ARM_ROTATED}|${CATALYST_SECRET_ARM_RESTART_REQUIRED}"
+catalyst_arm_secret github-token >/dev/null
+expect_eq "arm: unchanged value ⇒ no rotation" "false|false|false" \
+  "${CATALYST_SECRET_ARM_ARMED}|${CATALYST_SECRET_ARM_ROTATED}|${CATALYST_SECRET_ARM_RESTART_REQUIRED}"
+printf 'FAKE-TOKEN-ROTATED' > "${ARM_TMP}/github-token"
+catalyst_arm_secret github-token >/dev/null
+expect_eq "arm: changed value ⇒ rotated + restartRequired (Gherkin Scenario 2)" "false|true|true" \
+  "${CATALYST_SECRET_ARM_ARMED}|${CATALYST_SECRET_ARM_ROTATED}|${CATALYST_SECRET_ARM_RESTART_REQUIRED}"
+catalyst_arm_secret github-token >/dev/null
+expect_eq "arm: settles again after the rotation is observed once" "false|false|false" \
+  "${CATALYST_SECRET_ARM_ARMED}|${CATALYST_SECRET_ARM_ROTATED}|${CATALYST_SECRET_ARM_RESTART_REQUIRED}"
+unset CATALYST_CONFIG_DIR
+
+catalyst_secret_reset_arm_state
+catalyst_arm_secret age-key >/dev/null
+expect_eq "arm: age-key (n/a rotation class) is always a no-op" "false|false|false" \
+  "${CATALYST_SECRET_ARM_ARMED}|${CATALYST_SECRET_ARM_ROTATED}|${CATALYST_SECRET_ARM_RESTART_REQUIRED}"
+
+# --- R1 regression: pipe-containing VALUES survive the arm rotation diff -------------------
+# The pre-fix code parsed resolve's pipe-joined stdout with ${x%%|*}, truncating any value
+# at its first "|" — two rotations differing only AFTER a pipe compared equal, silently
+# losing the rotation AND its restartRequired signal (the literal 2026-08-02 outage
+# mechanism this contract exists to report). The fix reads CATALYST_SECRET_LAST_VALUE
+# directly; these cells pin the full-byte diff.
+ARM_PIPE_TMP="${TMP_DIR}/arm-pipe-cfg"
+mkdir -p "$ARM_PIPE_TMP"
+export CATALYST_CONFIG_DIR="$ARM_PIPE_TMP"
+catalyst_secret_reset_arm_state
+printf 'FAKE|first' > "${ARM_PIPE_TMP}/github-token"
+catalyst_arm_secret github-token >/dev/null
+expect_eq "arm: pipe-containing value — baseline observation" "false|false|false" \
+  "${CATALYST_SECRET_ARM_ARMED}|${CATALYST_SECRET_ARM_ROTATED}|${CATALYST_SECRET_ARM_RESTART_REQUIRED}"
+printf 'FAKE|second' > "${ARM_PIPE_TMP}/github-token"
+catalyst_arm_secret github-token >/dev/null
+expect_eq "arm: rotation differing only AFTER the pipe is detected (restartRequired fires)" \
+  "false|true|true" \
+  "${CATALYST_SECRET_ARM_ARMED}|${CATALYST_SECRET_ARM_ROTATED}|${CATALYST_SECRET_ARM_RESTART_REQUIRED}"
+unset CATALYST_CONFIG_DIR
+
+# --- B4 regression: catalyst_arm_secret(unknown id) must not abort a `set -e` caller ------
+# Same-shell direct call (no `set -e` in THIS process) — asserts the quiet {armed:false}
+# triple, matching lib/secret-contract.mjs's armSecret for an unknown id.
+catalyst_secret_reset_arm_state
+catalyst_arm_secret does-not-exist-xyz >/dev/null
+expect_eq "arm: unknown id returns the quiet false/false/false triple (matches JS armSecret)" \
+  "false|false|false" \
+  "${CATALYST_SECRET_ARM_ARMED}|${CATALYST_SECRET_ARM_ROTATED}|${CATALYST_SECRET_ARM_RESTART_REQUIRED}"
+
+# The actual regression: run under `set -e` in a FRESH bash -c process (via _run) — before
+# the B4 fix, catalyst_secret_rotation_class's rc=1 on an unknown id propagated through the
+# bare `_rotation_class=$(...)` assignment and killed this whole process before the echo
+# ever ran, so ERREXIT_OUT would come back empty and ERREXIT_RC nonzero.
+ERREXIT_OUT="$(_run 'set -e
+catalyst_arm_secret does-not-exist-xyz >/dev/null
+printf "%s|%s|%s" "$CATALYST_SECRET_ARM_ARMED" "$CATALYST_SECRET_ARM_ROTATED" "$CATALYST_SECRET_ARM_RESTART_REQUIRED"')"
+ERREXIT_RC=$?
+expect_eq "B4: catalyst_arm_secret(unknown id) under set -e exits 0 (does not abort the caller)" "0" "$ERREXIT_RC"
+expect_eq "B4: catalyst_arm_secret(unknown id) under set -e still returns the quiet triple" \
+  "false|false|false" "$ERREXIT_OUT"
+
+echo ""
+echo "Total: $((PASSES + FAILURES)), Passed: $PASSES, Failed: $FAILURES, Skipped: 0"
+exit "$FAILURES"

--- a/plugins/dev/scripts/__tests__/secret-contract-parity.test.sh
+++ b/plugins/dev/scripts/__tests__/secret-contract-parity.test.sh
@@ -1,0 +1,406 @@
+#!/usr/bin/env bash
+# Cross-stack parity test for lib/secret-contract.mjs vs lib/catalyst-secret-contract.sh
+# (CTL-1616).
+#
+# Built directly on the proven, CI-exercised cross-stack mechanism in
+# __tests__/host-identity.test.sh / __tests__/deployment-mode-parity.test.sh (shell out to
+# node, run identical inputs through both implementations, diff the outputs). Three
+# non-negotiable properties (design §3):
+#
+#   1. THREE-WAY ASSERTION — bash == computed-expected AND node == computed-expected, never
+#      merely bash == node. Two implementations can agree with each other while both
+#      disagreeing with the spec; that is a false-green on the exact property this test
+#      exists to guard.
+#   2. ROW-ID-SET EQUALITY — the bash and JS registries must enumerate identical id sets. A
+#      row added on one side without the other fails closed, loudly.
+#   3. PARITY COST SCALES PER PROVIDER TYPE, NOT PER ROW — one representative fixture matrix
+#      per delivery type (bare-file, bare-file-family, env-file, env-alias, config-json,
+#      platform-env, local-only), not a combinatorial explosion across all 11 rows.
+#
+# SECRET HYGIENE: every cell runs under `env -i` (real environment fully cleared) with HOME
+# repointed at a scratch tmpdir — a developer's real ambient LINEAR_API_KEY/GITHUB_TOKEN/age
+# key can never leak into a fixture or this test's own output. Fixtures are
+# obviously-fake literals.
+#
+# Run: bash plugins/dev/scripts/__tests__/secret-contract-parity.test.sh
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../../.." && pwd)"
+LIB="${REPO_ROOT}/plugins/dev/scripts/lib/catalyst-secret-contract.sh"
+JS_LIB="${REPO_ROOT}/plugins/dev/scripts/lib/secret-contract.mjs"
+
+FAILURES=0
+PASSES=0
+SKIPPED=0
+
+ok() { PASSES=$((PASSES+1)); }
+fail() {
+  local name="$1" detail="$2"
+  FAILURES=$((FAILURES+1))
+  echo "  FAIL: $name"
+  echo "    $detail"
+}
+expect_eq() {
+  local name="$1" expected="$2" actual="$3"
+  if [[ "$expected" == "$actual" ]]; then
+    ok
+  else
+    fail "$name" "expected='$expected' actual='$actual'"
+  fi
+}
+
+if ! command -v node >/dev/null 2>&1 || ! command -v jq >/dev/null 2>&1 \
+   || [[ ! -f "$LIB" ]] || [[ ! -f "$JS_LIB" ]]; then
+  echo "  SKIP: secret-contract-parity (node/jq unavailable or libs missing: $LIB / $JS_LIB)"
+  echo ""
+  echo "Total: 0, Passed: 0, Failed: 0, Skipped: 1"
+  exit 0
+fi
+
+# shellcheck disable=SC1090
+source "$LIB"
+
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+SANDBOX_HOME="${TMP_DIR}/home"
+mkdir -p "$SANDBOX_HOME"
+
+# ─── Property 2: row-id-set equality ─────────────────────────────────────────────────────
+PROBE_IDS_JS="${TMP_DIR}/probe-ids.mjs"
+cat > "$PROBE_IDS_JS" <<EOF
+import { SECRET_REGISTRY } from "${JS_LIB}";
+process.stdout.write(SECRET_REGISTRY.map((r) => r.id).join("\n") + "\n");
+EOF
+BASH_IDS="$(catalyst_secret_registry_ids)"
+JS_IDS="$(node "$PROBE_IDS_JS")"
+expect_eq "row-id-set equality: bash registry ids == JS registry ids" "$JS_IDS" "$BASH_IDS"
+
+# Also assert the ORDER matches (not strictly required by "set equality", but a stronger,
+# still-true property here since both files are hand-authored to mirror each other row for
+# row — a silent reorder is itself worth flagging).
+IFS=$'\n' read -r -d '' -a JS_ID_ARR < <(printf '%s\0' "$JS_IDS")
+IFS=$'\n' read -r -d '' -a BASH_ID_ARR < <(printf '%s\0' "$BASH_IDS")
+expect_eq "row count matches (11)" "11" "${#JS_ID_ARR[@]}"
+expect_eq "row count matches (11)" "11" "${#BASH_ID_ARR[@]}"
+
+# ─── Property: per-row THREE-WAY field-parity table (B5) ────────────────────────────────
+# For every one of the 11 rows, assert delivery, rotation class/trigger, bootstrapFor,
+# configJsonPath, and envNames (ORDER-sensitive — precedence matters, e.g. GH_TOKEN before
+# GITHUB_TOKEN) against EXPECTED literals in BOTH languages — not merely bash==node. This is
+# the row-level analogue of property 1 (the resolveSecret cells below already do this for
+# resolved VALUES; this table does it for the STATIC FACTS every row declares).
+PROBE_FIELDS_JS="${TMP_DIR}/probe-fields.mjs"
+cat > "$PROBE_FIELDS_JS" <<EOF
+import { getSecretRow } from "${JS_LIB}";
+const row = getSecretRow(process.env.CSC_FIELD_PROBE_ID);
+if (!row) { process.stdout.write("MISSING"); process.exit(0); }
+const fields = [
+  row.delivery ?? "",
+  row.rotation?.class ?? "",
+  row.rotation?.trigger ?? "",
+  row.bootstrapFor ?? "",
+  row.configJsonPath ?? "",
+  (row.envNames ?? []).join(","),
+];
+process.stdout.write(fields.join("|"));
+EOF
+
+# _csc_fields_for ID — bash-side equivalent of the JS probe above, via the same public
+# accessor functions any real consumer would use. No `env -i` needed here (unlike the
+# resolveSecret cells below): every accessor is a pure registry-metadata lookup that never
+# consults process.env, so ambient shell state cannot influence the result.
+_csc_fields_for() {
+  local _id="$1" _delivery _rclass _rtrig _bfor _cjpath _envs
+  _delivery="$(catalyst_secret_delivery "$_id")"
+  _rclass="$(catalyst_secret_rotation_class "$_id")"
+  _rtrig="$(catalyst_secret_rotation_trigger "$_id")"
+  _bfor="$(catalyst_secret_bootstrap_for "$_id")"
+  _cjpath="$(catalyst_secret_config_json_path "$_id")"
+  _envs="$(catalyst_secret_env_names "$_id" | tr '\n' ',')"
+  _envs="${_envs%,}"
+  printf '%s|%s|%s|%s|%s|%s' "$_delivery" "$_rclass" "$_rtrig" "$_bfor" "$_cjpath" "$_envs"
+}
+
+# EXPECTED — one row per registry id, built via the SAME join shape as _csc_fields_for/the
+# JS probe (delivery|class|trigger|bootstrapFor|configJsonPath|envNames-comma-joined) so a
+# mismatch is a genuine data error, never a hand-counted-pipes typo. Verified against
+# design §2's seed table and both SECRET_REGISTRY (secret-contract.mjs) and the
+# _CSC_* arrays (this file's own bash mirror) at authoring time.
+_fp_row() { printf '%s|%s|%s|%s|%s|%s' "$1" "$2" "$3" "$4" "$5" "$6"; }
+_FP_IDS=(
+  github-token webhook-secret linear-webhook-secret claude-accounts.env execution-core.env
+  linear-api-token linear-orchestrator-actor linear-worker-actor groq-api-key cloud-token age-key
+)
+_FP_EXPECTED=(
+  "$(_fp_row bare-file re-armable timer '' '' 'GH_TOKEN,GITHUB_TOKEN')"
+  "$(_fp_row bare-file boot-only '' '' '' 'CATALYST_WEBHOOK_SECRET')"
+  "$(_fp_row bare-file-family boot-only '' '' '' '')"
+  "$(_fp_row env-file boot-only '' '' '' '')"
+  "$(_fp_row env-file boot-only '' '' '' '')"
+  "$(_fp_row env-alias re-armable on-401 '' '' 'LINEAR_API_TOKEN,LINEAR_API_KEY')"
+  "$(_fp_row config-json re-armable on-401 '' 'catalyst.linear.bot.orchestrator' '')"
+  "$(_fp_row config-json boot-only '' '' 'catalyst.linear.bot.worker' '')"
+  "$(_fp_row config-json boot-only '' '' 'groq.apiKey' 'GROQ_API_KEY')"
+  "$(_fp_row platform-env boot-only '' cloud 'catalyst.cloud.tokenEnv' 'CATALYST_CLOUD_TOKEN')"
+  "$(_fp_row local-only n/a '' cluster '' 'SOPS_AGE_KEY_FILE')"
+)
+for _fp_i in "${!_FP_IDS[@]}"; do
+  _fp_id="${_FP_IDS[$_fp_i]}"
+  _fp_exp="${_FP_EXPECTED[$_fp_i]}"
+  _fp_bash="$(_csc_fields_for "$_fp_id")"
+  _fp_js="$(CSC_FIELD_PROBE_ID="$_fp_id" node "$PROBE_FIELDS_JS")"
+  expect_eq "field-parity[$_fp_id]: bash==expected" "$_fp_exp" "$_fp_bash"
+  expect_eq "field-parity[$_fp_id]: node==expected" "$_fp_exp" "$_fp_js"
+done
+
+# ─── Static JS probe for resolveSecret — reads the SAME env vars the bash side reads via
+# its own process.env default, a true black-box parity check of both public entry points.
+# Deployment-mode args are threaded through synthetic env names (see below) since the JS
+# probe reads them from a small JSON blob rather than positional args (bash's
+# catalyst_resolve_secret takes them positionally instead — both call conventions are
+# exercised against the SAME semantic inputs per cell).
+PROBE_RESOLVE_JS="${TMP_DIR}/probe-resolve.mjs"
+cat > "$PROBE_RESOLVE_JS" <<EOF
+import { resolveSecret } from "${JS_LIB}";
+const id = process.env.CSC_PROBE_ID;
+const depMode = process.env.CSC_PROBE_DEP_MODE;
+const depInferred = process.env.CSC_PROBE_DEP_INFERRED;
+const deploymentMode = depMode ? { mode: depMode, inferred: depInferred === "true" } : undefined;
+const r = resolveSecret(id, { deploymentMode });
+process.stdout.write((r.value ?? "") + "|" + (r.source ?? "") + "|" + (r.provider ?? ""));
+EOF
+
+# _cell NAME EXPECTED [ENV_VAR=VAL ...] -- runs both implementations under identical env -i
+# fixtures (CSC_PROBE_ID/_DEP_MODE/_DEP_INFERRED are the JS probe's own inputs; the bash
+# side reads CSC_PROBE_ID/_DEP_MODE/_DEP_INFERRED too, via the wrapper below) and asserts
+# bash==expected AND node==expected.
+_cell() {
+  local _name="$1" _expected="$2"
+  shift 2
+  local BASH_OUT NODE_OUT
+  BASH_OUT="$(env -i PATH="$PATH" HOME="$SANDBOX_HOME" "$@" bash -c "
+    source '$LIB'
+    catalyst_resolve_secret \"\$CSC_PROBE_ID\" \"\${CSC_PROBE_DEP_MODE:-}\" \"\${CSC_PROBE_DEP_INFERRED:-true}\"
+  ")"
+  NODE_OUT="$(env -i PATH="$PATH" HOME="$SANDBOX_HOME" "$@" node "$PROBE_RESOLVE_JS" 2>&1)"
+  expect_eq "$_name (bash==expected)" "$_expected" "$BASH_OUT"
+  expect_eq "$_name (node==expected)" "$_expected" "$NODE_OUT"
+}
+
+# ─── bare-file: github-token ──────────────────────────────────────────────────────────────
+CFG_DIR="${TMP_DIR}/cfg"
+mkdir -p "$CFG_DIR"
+printf 'tok-value\n' > "${CFG_DIR}/github-token"
+_cell "bare-file: resolves from CATALYST_CONFIG_DIR" "tok-value|shared-file|bare-file" \
+  CSC_PROBE_ID=github-token "CATALYST_CONFIG_DIR=${CFG_DIR}"
+
+printf 'override-val' > "${TMP_DIR}/explicit-gh-token"
+_cell "bare-file: explicit override" "override-val|operator-override|bare-file" \
+  CSC_PROBE_ID=github-token "CATALYST_GITHUB_TOKEN_FILE=${TMP_DIR}/explicit-gh-token"
+
+_cell "bare-file: falls back to inherited env alias" "inherited-val|inherited|bare-file" \
+  CSC_PROBE_ID=github-token "CATALYST_CONFIG_DIR=${TMP_DIR}/does-not-exist-dir" "GH_TOKEN=inherited-val"
+
+_cell "bare-file: nothing anywhere ⇒ none" "|none|bare-file" \
+  CSC_PROBE_ID=github-token "CATALYST_CONFIG_DIR=${TMP_DIR}/does-not-exist-dir"
+
+BLANK_DIR="${TMP_DIR}/blank-cfg"
+mkdir -p "$BLANK_DIR"
+printf '   \n' > "${BLANK_DIR}/github-token"
+_cell "bare-file: whitespace-only file treated as absent" "fallback-val|inherited|bare-file" \
+  CSC_PROBE_ID=github-token "CATALYST_CONFIG_DIR=${BLANK_DIR}" "GH_TOKEN=fallback-val"
+
+# Hostile probe: NUL-byte-containing file — the CTL-1617 hard-won lesson, generalized from
+# JSON fields to raw file bytes. `$(cat)` truncates a NUL in bash; readFileSync does not.
+# Both sides MUST reject the candidate identically (fall through), never disagree on a
+# silently-truncated partial value.
+NUL_DIR="${TMP_DIR}/nul-cfg"
+mkdir -p "$NUL_DIR"
+printf 'c\x00loud' > "${NUL_DIR}/github-token"
+_cell "hostile: NUL-byte in bare-file candidate — rejected on both sides" \
+  "fallback-after-nul|inherited|bare-file" \
+  CSC_PROBE_ID=github-token "CATALYST_CONFIG_DIR=${NUL_DIR}" "GH_TOKEN=fallback-after-nul"
+
+# ─── unknown id ────────────────────────────────────────────────────────────────────────────
+_cell "unknown id: empty triple, never fails the caller" "||" CSC_PROBE_ID=does-not-exist-xyz
+
+# ─── bare-file-family: linear-webhook-secret (no scalar value) ────────────────────────────
+_cell "bare-file-family: no single scalar value" "||bare-file-family" CSC_PROBE_ID=linear-webhook-secret
+
+# ─── env-file: claude-accounts.env (presence, value is the PATH) ──────────────────────────
+ENVFILE_DIR="${TMP_DIR}/envfile-cfg"
+mkdir -p "$ENVFILE_DIR"
+printf 'CLAUDE_CODE_OAUTH_TOKEN=abc\n' > "${ENVFILE_DIR}/claude-accounts.env"
+_cell "env-file: presence, value is the path" \
+  "${ENVFILE_DIR}/claude-accounts.env|shared-file|env-file" \
+  CSC_PROBE_ID=claude-accounts.env "CATALYST_CONFIG_DIR=${ENVFILE_DIR}"
+
+EMPTY_ENVFILE_DIR="${TMP_DIR}/empty-envfile-cfg"
+mkdir -p "$EMPTY_ENVFILE_DIR"
+: > "${EMPTY_ENVFILE_DIR}/claude-accounts.env"
+_cell "env-file: empty file counts as absent" "|none|env-file" \
+  CSC_PROBE_ID=claude-accounts.env "CATALYST_CONFIG_DIR=${EMPTY_ENVFILE_DIR}"
+
+# ─── B5: previously-uncovered row — execution-core.env (same env-file shape as
+# claude-accounts.env, distinct id/basename) ────────────────────────────────────────────────
+EXECCORE_DIR="${TMP_DIR}/execcore-cfg"
+mkdir -p "$EXECCORE_DIR"
+printf 'CATALYST_EXECUTOR=codex\n' > "${EXECCORE_DIR}/execution-core.env"
+_cell "env-file: execution-core.env presence, value is the path" \
+  "${EXECCORE_DIR}/execution-core.env|shared-file|env-file" \
+  CSC_PROBE_ID=execution-core.env "CATALYST_CONFIG_DIR=${EXECCORE_DIR}"
+
+EMPTY_EXECCORE_DIR="${TMP_DIR}/empty-execcore-cfg"
+mkdir -p "$EMPTY_EXECCORE_DIR"
+: > "${EMPTY_EXECCORE_DIR}/execution-core.env"
+_cell "env-file: execution-core.env empty file counts as absent" "|none|env-file" \
+  CSC_PROBE_ID=execution-core.env "CATALYST_CONFIG_DIR=${EMPTY_EXECCORE_DIR}"
+
+# ─── B5: previously-uncovered row — webhook-secret (same bare-file shape as github-token,
+# distinct id/basename/env-alias) ────────────────────────────────────────────────────────────
+WEBHOOK_DIR="${TMP_DIR}/webhook-cfg"
+mkdir -p "$WEBHOOK_DIR"
+printf 'whsec-value\n' > "${WEBHOOK_DIR}/webhook-secret"
+_cell "bare-file: webhook-secret resolves from CATALYST_CONFIG_DIR" \
+  "whsec-value|shared-file|bare-file" \
+  CSC_PROBE_ID=webhook-secret "CATALYST_CONFIG_DIR=${WEBHOOK_DIR}"
+_cell "bare-file: webhook-secret falls back to inherited env alias" \
+  "wh-inherited|inherited|bare-file" \
+  CSC_PROBE_ID=webhook-secret "CATALYST_CONFIG_DIR=${TMP_DIR}/does-not-exist-dir" \
+  "CATALYST_WEBHOOK_SECRET=wh-inherited"
+
+# ─── env-alias: linear-api-token ───────────────────────────────────────────────────────────
+_cell "env-alias: LINEAR_API_TOKEN wins over LINEAR_API_KEY" "tok-a|inherited|env-alias" \
+  CSC_PROBE_ID=linear-api-token "LINEAR_API_TOKEN=tok-a" "LINEAR_API_KEY=tok-b"
+_cell "env-alias: LINEAR_API_KEY-only fixture (the CTL-1619 regression class)" \
+  "tok-b|inherited|env-alias" CSC_PROBE_ID=linear-api-token "LINEAR_API_KEY=tok-b"
+_cell "env-alias: neither set ⇒ none" "|none|env-alias" CSC_PROBE_ID=linear-api-token
+
+# ─── config-json: groq-api-key (env-then-config) + linear-orchestrator-actor (config-only) ─
+L2_DIR="${TMP_DIR}/l2cfg"
+mkdir -p "$L2_DIR"
+L2_FILE="${L2_DIR}/config.json"
+printf '%s' '{"groq":{"apiKey":"from-config"}}' > "$L2_FILE"
+_cell "config-json: env alias wins over config" "from-env|inherited|config-json" \
+  CSC_PROBE_ID=groq-api-key "CATALYST_LAYER2_CONFIG_FILE=${L2_FILE}" "GROQ_API_KEY=from-env"
+_cell "config-json: falls back to config when env unset" "from-config|config-json|config-json" \
+  CSC_PROBE_ID=groq-api-key "CATALYST_LAYER2_CONFIG_FILE=${L2_FILE}"
+
+printf '%s' '{"groq":{"apiKey":false}}' > "$L2_FILE"
+_cell "hostile: bare JSON false settles as none (BLOCKING-1 class), never coerced" \
+  "|none|config-json" CSC_PROBE_ID=groq-api-key "CATALYST_LAYER2_CONFIG_FILE=${L2_FILE}"
+
+printf '%s' '{"catalyst":{"linear":{"bot":{"orchestrator":"{\"apiKey\":\"x\"}"}}}}' > "$L2_FILE"
+_cell "config-json: reads the dotted path (linear-orchestrator-actor)" \
+  '{"apiKey":"x"}|config-json|config-json' \
+  CSC_PROBE_ID=linear-orchestrator-actor "CATALYST_LAYER2_CONFIG_FILE=${L2_FILE}"
+
+# B5: previously-uncovered row — linear-worker-actor (config-json, distinct configJsonPath
+# from linear-orchestrator-actor — the judge-unanimous "never collapse these two" graft).
+printf '%s' '{"catalyst":{"linear":{"bot":{"worker":"{\"apiKey\":\"w\"}"}}}}' > "$L2_FILE"
+_cell "config-json: reads the dotted path (linear-worker-actor)" \
+  '{"apiKey":"w"}|config-json|config-json' \
+  CSC_PROBE_ID=linear-worker-actor "CATALYST_LAYER2_CONFIG_FILE=${L2_FILE}"
+printf '%s' '{}' > "$L2_FILE"
+_cell "config-json: linear-worker-actor absent path falls through to none" "|none|config-json" \
+  CSC_PROBE_ID=linear-worker-actor "CATALYST_LAYER2_CONFIG_FILE=${L2_FILE}"
+
+# Hostile probe: a JSON string value carrying an embedded NUL escape. jq's own parser
+# accepts \u0000-style escapes inside a JSON string; both sides must recognize and reject it the same way
+# a bare non-string value is rejected (never truncated/coerced).
+printf '%s' '{"groq":{"apiKey":"c\u0000loud"}}' > "$L2_FILE"
+_cell "hostile: NUL-escape inside a JSON string value settles as none on both sides" \
+  "|none|config-json" CSC_PROBE_ID=groq-api-key "CATALYST_LAYER2_CONFIG_FILE=${L2_FILE}"
+
+# Hostile probe (B2): an EMPTY JSON string value at the config-json path. The previous bash
+# tagger's docstring falsely claimed "never empty per the select below" (no such select
+# existed) — an empty string was misclassified source=config-json instead of falling
+# through to none, diverging from lib/secret-contract.mjs's `raw.length > 0` check.
+printf '%s' '{"groq":{"apiKey":""}}' > "$L2_FILE"
+_cell "hostile (B2): empty JSON string value settles as none on both sides, never a resolved empty secret" \
+  "|none|config-json" CSC_PROBE_ID=groq-api-key "CATALYST_LAYER2_CONFIG_FILE=${L2_FILE}"
+
+# Hostile probe (B2, second call site): an EMPTY Layer-2 NAME-override string for cloud-token
+# — same empty-string-tag bug, distinct call site (_csc_resolve_cloud_token_name /
+# resolveCloudTokenName), must fall back to the DEFAULT env-var name, not to an empty
+# indirect-expansion variable name (which was a second "invalid variable name" fatal-abort
+# class on the bash side pre-fix).
+printf '%s' '{"catalyst":{"cloud":{"tokenEnv":""}}}' > "$L2_FILE"
+_cell "hostile (B2): empty Layer-2 cloud.tokenEnv override falls back to the default env-var name" \
+  "cloud-val|platform-env|platform-env" \
+  CSC_PROBE_ID=cloud-token "CATALYST_LAYER2_CONFIG_FILE=${L2_FILE}" "CATALYST_CLOUD_TOKEN=cloud-val"
+
+# ─── platform-env: cloud-token (two-step name-then-value resolution) ──────────────────────
+_cell "platform-env: default name" "cloud-val|platform-env|platform-env" \
+  CSC_PROBE_ID=cloud-token "CATALYST_CLOUD_TOKEN=cloud-val"
+_cell "platform-env: env-var NAME override" "v|platform-env|platform-env" \
+  CSC_PROBE_ID=cloud-token "CATALYST_CLOUD_TOKEN_ENV=MY_TOKEN" "MY_TOKEN=v"
+printf '%s' '{"catalyst":{"cloud":{"tokenEnv":"OTHER_VAR"}}}' > "$L2_FILE"
+_cell "platform-env: Layer-2 NAME override" "v2|platform-env|platform-env" \
+  CSC_PROBE_ID=cloud-token "CATALYST_LAYER2_CONFIG_FILE=${L2_FILE}" "OTHER_VAR=v2"
+_cell "platform-env: name resolves, value unset ⇒ none" "|none|platform-env" CSC_PROBE_ID=cloud-token
+
+# ─── local-only: age-key (presence, NEVER value-resolved) ─────────────────────────────────
+AGE_HOME="${TMP_DIR}/agehome"
+mkdir -p "${AGE_HOME}/.config/catalyst"
+printf 'AGE-SECRET-KEY-fake' > "${AGE_HOME}/.config/catalyst/age.key"
+BASH_OUT="$(env -i PATH="$PATH" HOME="$AGE_HOME" bash -c "source '$LIB'; catalyst_resolve_secret age-key")"
+NODE_OUT="$(env -i PATH="$PATH" HOME="$AGE_HOME" CSC_PROBE_ID=age-key node "$PROBE_RESOLVE_JS" 2>&1)"
+EXPECTED="${AGE_HOME}/.config/catalyst/age.key|present|local-only"
+expect_eq "local-only: presence at default path (bash==expected)" "$EXPECTED" "$BASH_OUT"
+expect_eq "local-only: presence at default path (node==expected)" "$EXPECTED" "$NODE_OUT"
+
+_cell "local-only: absence" "|absent|local-only" CSC_PROBE_ID=age-key
+CUSTOM_AGE="${TMP_DIR}/custom-age.key"
+printf 'AGE-SECRET-KEY-fake' > "$CUSTOM_AGE"
+_cell "local-only: SOPS_AGE_KEY_FILE override honored" "${CUSTOM_AGE}|present|local-only" \
+  CSC_PROBE_ID=age-key "SOPS_AGE_KEY_FILE=${CUSTOM_AGE}"
+
+# ─── cloud guard (design §4) — bash side needs the positional args; JS side needs the
+# CSC_PROBE_DEP_MODE/_INFERRED env vars the probe script reads ──────────────────────────────
+CLOUDGUARD_DIR="${TMP_DIR}/cloudguard-cfg"
+mkdir -p "$CLOUDGUARD_DIR"
+printf 'file-value' > "${CLOUDGUARD_DIR}/github-token"
+
+_cell "cloud guard: inferred=true does NOT activate cloud" "file-value|shared-file|bare-file" \
+  CSC_PROBE_ID=github-token "CATALYST_CONFIG_DIR=${CLOUDGUARD_DIR}" \
+  CSC_PROBE_DEP_MODE=cloud CSC_PROBE_DEP_INFERRED=true
+_cell "cloud guard: mode=single-host never activates cloud" "file-value|shared-file|bare-file" \
+  CSC_PROBE_ID=github-token "CATALYST_CONFIG_DIR=${CLOUDGUARD_DIR}" \
+  CSC_PROBE_DEP_MODE=single-host CSC_PROBE_DEP_INFERRED=false
+_cell "cloud guard: mode=cluster never activates cloud (zero new cluster resolution code)" \
+  "file-value|shared-file|bare-file" \
+  CSC_PROBE_ID=github-token "CATALYST_CONFIG_DIR=${CLOUDGUARD_DIR}" \
+  CSC_PROBE_DEP_MODE=cluster CSC_PROBE_DEP_INFERRED=false
+_cell "cloud guard: genuinely cloud, no GH_TOKEN ⇒ file NEVER consulted, resolves none" \
+  "|none|bare-file" \
+  CSC_PROBE_ID=github-token "CATALYST_CONFIG_DIR=${CLOUDGUARD_DIR}" "CATALYST_CLOUD_TOKEN=boot" \
+  CSC_PROBE_DEP_MODE=cloud CSC_PROBE_DEP_INFERRED=false
+_cell "cloud guard: genuinely cloud with env alias present resolves via env, file ignored" \
+  "cloud-injected|inherited|bare-file" \
+  CSC_PROBE_ID=github-token "CATALYST_CONFIG_DIR=${CLOUDGUARD_DIR}" "GH_TOKEN=cloud-injected" \
+  "CATALYST_CLOUD_TOKEN=boot" CSC_PROBE_DEP_MODE=cloud CSC_PROBE_DEP_INFERRED=false
+_cell "bootstrap short-circuit: cloud-token absent ⇒ every other row's cloud resolution is empty/empty" \
+  "||bare-file" CSC_PROBE_ID=github-token "GH_TOKEN=should-not-be-returned" \
+  CSC_PROBE_DEP_MODE=cloud CSC_PROBE_DEP_INFERRED=false
+_cell "bootstrap short-circuit does not apply to cloud-token itself" "|none|platform-env" \
+  CSC_PROBE_ID=cloud-token CSC_PROBE_DEP_MODE=cloud CSC_PROBE_DEP_INFERRED=false
+
+# Hostile probe (B3): the bootstrap-class secret's VALUE itself begins with "|". The
+# previous bash implementation captured the recursive resolve call's pipe-joined
+# "value|source|provider" stdout via $(...) and parsed it with `${_boot_out%%|*}` — a
+# leading "|" makes that pattern match at position 0, stripping the WHOLE string and
+# leaving _boot_val empty even though the bootstrap secret genuinely resolved. Bash would
+# then falsely apply the short-circuit (returning null/null) while JS — which reads
+# bootstrapResolved.value directly, never a delimited string — resolves github-token
+# normally via its env alias. Both sides MUST agree on the non-short-circuited result.
+_cell "hostile (B3): cloud-token value beginning with '|' must not falsely trigger the bootstrap short-circuit" \
+  "cloud-injected|inherited|bare-file" \
+  CSC_PROBE_ID=github-token "CATALYST_CONFIG_DIR=${CLOUDGUARD_DIR}" "GH_TOKEN=cloud-injected" \
+  "CATALYST_CLOUD_TOKEN=|leading-pipe-value" CSC_PROBE_DEP_MODE=cloud CSC_PROBE_DEP_INFERRED=false
+
+echo ""
+echo "Total: $((PASSES + FAILURES)), Passed: $PASSES, Failed: $FAILURES, Skipped: $SKIPPED"
+exit "$FAILURES"

--- a/plugins/dev/scripts/__tests__/secret-contract-parity.test.sh
+++ b/plugins/dev/scripts/__tests__/secret-contract-parity.test.sh
@@ -223,6 +223,26 @@ _cell "hostile: NUL-byte in bare-file candidate — rejected on both sides" \
   "fallback-after-nul|inherited|bare-file" \
   CSC_PROBE_ID=github-token "CATALYST_CONFIG_DIR=${NUL_DIR}" "GH_TOKEN=fallback-after-nul"
 
+# Hostile probe (Codex finding fix): NON-UTF-8 BYTES in a bare-file candidate. Node's
+# readFileSync(file,"utf8") REPLACES an invalid byte sequence with U+FFFD rather than
+# failing — a bare-file secret containing a stray non-UTF-8 byte would silently decode to a
+# MUTATED credential in JS while bash's `cat` preserves the original bytes exactly. Both
+# sides MUST reject the candidate identically (fall through), same degrade shape as the
+# NUL-byte guard above.
+BADUTF8_DIR="${TMP_DIR}/badutf8-cfg"
+mkdir -p "$BADUTF8_DIR"
+printf '\xff\xfehi' > "${BADUTF8_DIR}/github-token"
+_cell "hostile: non-UTF-8 bytes in bare-file candidate — rejected on both sides" \
+  "fallback-after-bad-utf8|inherited|bare-file" \
+  CSC_PROBE_ID=github-token "CATALYST_CONFIG_DIR=${BADUTF8_DIR}" "GH_TOKEN=fallback-after-bad-utf8"
+
+GOODUTF8_DIR="${TMP_DIR}/goodutf8-cfg"
+mkdir -p "$GOODUTF8_DIR"
+printf 'tok-\xe2\x9c\x93-value\n' > "${GOODUTF8_DIR}/github-token"
+_cell "valid multi-byte UTF-8 in a bare-file candidate is preserved, not rejected" \
+  $'tok-\xe2\x9c\x93-value|shared-file|bare-file' \
+  CSC_PROBE_ID=github-token "CATALYST_CONFIG_DIR=${GOODUTF8_DIR}"
+
 # ─── unknown id ────────────────────────────────────────────────────────────────────────────
 _cell "unknown id: empty triple, never fails the caller" "||" CSC_PROBE_ID=does-not-exist-xyz
 
@@ -293,8 +313,29 @@ _cell "hostile: bare JSON false settles as none (BLOCKING-1 class), never coerce
   "|none|config-json" CSC_PROBE_ID=groq-api-key "CATALYST_LAYER2_CONFIG_FILE=${L2_FILE}"
 
 printf '%s' '{"catalyst":{"linear":{"bot":{"orchestrator":"{\"apiKey\":\"x\"}"}}}}' > "$L2_FILE"
-_cell "config-json: reads the dotted path (linear-orchestrator-actor)" \
+_cell "config-json: reads the dotted path (linear-orchestrator-actor, string-shaped value)" \
   '{"apiKey":"x"}|config-json|config-json' \
+  CSC_PROBE_ID=linear-orchestrator-actor "CATALYST_LAYER2_CONFIG_FILE=${L2_FILE}"
+
+# ACTOR ROW SHAPE (Codex finding fix): the AUTHORITATIVE Layer-2 schema stores
+# catalyst.linear.bot.orchestrator/.worker as OBJECTS ({clientId, clientSecret, ...}), never
+# a string — this fixture uses a REAL object (source key order deliberately
+# clientSecret-before-clientId, to prove the canonicalization is genuinely sorting, not just
+# echoing source order) and asserts both sides produce the IDENTICAL canonical (sorted-key)
+# JSON string.
+printf '%s' '{"catalyst":{"linear":{"bot":{"orchestrator":{"clientSecret":"s3cr3t","clientId":"abc123"}}}}}' > "$L2_FILE"
+_cell "config-json: ACTOR ROW SHAPE — OBJECT-shaped value canonicalizes with sorted keys identically on both sides" \
+  '{"clientId":"abc123","clientSecret":"s3cr3t"}|config-json|config-json' \
+  CSC_PROBE_ID=linear-orchestrator-actor "CATALYST_LAYER2_CONFIG_FILE=${L2_FILE}"
+
+printf '%s' '{"catalyst":{"linear":{"bot":{"orchestrator":{}}}}}' > "$L2_FILE"
+_cell "config-json: ACTOR ROW SHAPE — an EMPTY object still resolves (canonical '{}'), not silently coerced to none" \
+  '{}|config-json|config-json' \
+  CSC_PROBE_ID=linear-orchestrator-actor "CATALYST_LAYER2_CONFIG_FILE=${L2_FILE}"
+
+printf '%s' '{"catalyst":{"linear":{"bot":{"orchestrator":["nope"]}}}}' > "$L2_FILE"
+_cell "config-json: ACTOR ROW SHAPE — an ARRAY is rejected on both sides (not a valid credential shape)" \
+  "|none|config-json" \
   CSC_PROBE_ID=linear-orchestrator-actor "CATALYST_LAYER2_CONFIG_FILE=${L2_FILE}"
 
 # B5: previously-uncovered row — linear-worker-actor (config-json, distinct configJsonPath
@@ -331,6 +372,116 @@ printf '%s' '{"catalyst":{"cloud":{"tokenEnv":""}}}' > "$L2_FILE"
 _cell "hostile (B2): empty Layer-2 cloud.tokenEnv override falls back to the default env-var name" \
   "cloud-val|platform-env|platform-env" \
   CSC_PROBE_ID=cloud-token "CATALYST_LAYER2_CONFIG_FILE=${L2_FILE}" "CATALYST_CLOUD_TOKEN=cloud-val"
+
+# TRAILING NEWLINES IN JSON VALUES (Codex finding fix): a config-json STRING value ending in
+# "\n" must resolve BYTE-FOR-BYTE identically on both sides — the bash side previously lost
+# the trailing newline at the `_jq_out="$(jq ...)"` boundary (a bare command substitution
+# strips ALL trailing newlines from its own captured output).
+printf '%s' '{"groq":{"apiKey":"abc\n"}}' > "$L2_FILE"
+_cell "hostile: trailing newline in a config-json STRING value is preserved byte-for-byte" \
+  $'abc\n|config-json|config-json' \
+  CSC_PROBE_ID=groq-api-key "CATALYST_LAYER2_CONFIG_FILE=${L2_FILE}"
+
+# Byte-digest cross-check (independent of shell string-comparison quirks): compare a SHA-256
+# digest of the raw resolved VALUE bytes on both sides — not just the pipe-joined field
+# string, which can hide a byte-level truncation bug behind an apparently-matching test if
+# the harness's OWN capture happened to mask it too.
+JS_TRAILING_NL_OUT="$(env -i PATH="$PATH" HOME="$SANDBOX_HOME" "CATALYST_LAYER2_CONFIG_FILE=${L2_FILE}" CSC_PROBE_ID=groq-api-key node "$PROBE_RESOLVE_JS" 2>&1)"
+BASH_TRAILING_NL_OUT="$(env -i PATH="$PATH" HOME="$SANDBOX_HOME" "CATALYST_LAYER2_CONFIG_FILE=${L2_FILE}" bash -c "source '$LIB'; catalyst_resolve_secret groq-api-key")"
+JS_TRAILING_NL_VAL="${JS_TRAILING_NL_OUT%%|*}"
+BASH_TRAILING_NL_VAL="${BASH_TRAILING_NL_OUT%%|*}"
+JS_DIGEST="$(printf '%s' "$JS_TRAILING_NL_VAL" | shasum -a 256 | awk '{print $1}')"
+BASH_DIGEST="$(printf '%s' "$BASH_TRAILING_NL_VAL" | shasum -a 256 | awk '{print $1}')"
+expect_eq "byte-digest parity: trailing-newline config-json value SHA-256 matches" "$JS_DIGEST" "$BASH_DIGEST"
+
+# INVALID ENV NAME (Codex finding fix): CATALYST_CLOUD_TOKEN_ENV / the Layer-2 tokenEnv
+# override is operator-controlled text, not registry data — an invalid shell identifier
+# (e.g. "BAD-NAME") must degrade to the documented unresolved result on BOTH sides, never a
+# bash "invalid variable name" fatal abort (JS's `env?.[envVar]` never crashes on any string).
+_cell "hostile: invalid env-name override (CATALYST_CLOUD_TOKEN_ENV) resolves none, never aborts" \
+  "|none|platform-env" \
+  CSC_PROBE_ID=cloud-token "CATALYST_CLOUD_TOKEN_ENV=BAD-NAME"
+
+printf '%s' '{"catalyst":{"cloud":{"tokenEnv":"BAD-NAME-FROM-LAYER2"}}}' > "$L2_FILE"
+_cell "hostile: invalid env-name Layer-2 override resolves none, never aborts" \
+  "|none|platform-env" \
+  CSC_PROBE_ID=cloud-token "CATALYST_LAYER2_CONFIG_FILE=${L2_FILE}"
+
+# JSON ACCEPTANCE NORMALIZATION (Codex finding fix): BOM-prefixed / multi-document / a
+# lone-surrogate escape anywhere in the document must all settle @ABSENT-equivalent (none) on
+# BOTH sides, matching JSON.parse's rejection of all three (jq natively tolerates a BOM and
+# processes multiple top-level documents independently unless slurped).
+BOM_L2_FILE="${L2_DIR}/bom-config.json"
+printf '\xEF\xBB\xBF{"groq":{"apiKey":"should-not-resolve"}}' > "$BOM_L2_FILE"
+_cell "hostile: BOM-prefixed Layer-2 file settles as none on both sides" \
+  "|none|config-json" \
+  CSC_PROBE_ID=groq-api-key "CATALYST_LAYER2_CONFIG_FILE=${BOM_L2_FILE}"
+
+MULTIDOC_L2_FILE="${L2_DIR}/multidoc-config.json"
+printf '{"groq":{"apiKey":"first-doc"}}{"groq":{"apiKey":"second-doc"}}' > "$MULTIDOC_L2_FILE"
+_cell "hostile: multi-document Layer-2 file settles as none on both sides" \
+  "|none|config-json" \
+  CSC_PROBE_ID=groq-api-key "CATALYST_LAYER2_CONFIG_FILE=${MULTIDOC_L2_FILE}"
+
+# The lone \ud800 escape lives in an UNRELATED field; groq.apiKey's own value is otherwise
+# perfectly valid — jq rejects the ENTIRE document (verified: exit 5), so JS must degrade
+# identically via its raw-text whole-document scan, not merely check the extracted field.
+printf '%s' '{"groq":{"apiKey":"from-config"},"unrelated":"clu\ud800ster"}' > "$L2_FILE"
+_cell "hostile: unpaired-surrogate escape ANYWHERE in the document settles as none on both sides" \
+  "|none|config-json" \
+  CSC_PROBE_ID=groq-api-key "CATALYST_LAYER2_CONFIG_FILE=${L2_FILE}"
+
+# ─── E4/E6: jq 1.7.1 lone-LOW-surrogate + backslash-run-aware escape scanning parity ───────
+# Verified against real jq 1.7.1 (jq-1.7.1-apple): jq ACCEPTS a lone LOW surrogate escape
+# (\udc00), substituting U+FFFD and exiting 0 — it only REJECTS lone HIGH escapes (exit 5,
+# the control case directly above). The escape text is authored via the BACKSLASH
+# variable-expansion split (not a literal \uXXXX typed in this file's own source), matching
+# this suite's and deployment-mode-parity.test.sh's existing hostile-cell convention — some
+# authoring toolchains normalize a literal backslash-u sequence in a script's own source.
+# shellcheck disable=SC1003 # genuinely a literal single backslash, not an escape attempt
+BACKSLASH='\'
+
+# E4a: a lone LOW surrogate escape in an UNRELATED field must NOT reject the document — the
+# real value at groq.apiKey resolves normally on both sides.
+printf '%s' "{\"groq\":{\"apiKey\":\"good\"},\"unrelated\":\"clu${BACKSLASH}udc00ster\"}" > "$L2_FILE"
+_cell "E4a: lone LOW surrogate escape in an unrelated field — value resolves normally on both sides" \
+  "good|config-json|config-json" \
+  CSC_PROBE_ID=groq-api-key "CATALYST_LAYER2_CONFIG_FILE=${L2_FILE}"
+
+# E4b: a lone LOW surrogate escape INSIDE the resolved secret value itself — both engines
+# must produce the SAME bytes (jq's U+FFFD replacement), verified two ways: the pipe-joined
+# field string AND an independent SHA-256 byte-digest cross-check (mirrors the
+# trailing-newline byte-digest check above — a shell string-comparison quirk could otherwise
+# mask a byte-level divergence that the digest cannot).
+printf '%s' "{\"groq\":{\"apiKey\":\"x${BACKSLASH}udc00y\"}}" > "$L2_FILE"
+_cell "E4b: lone LOW surrogate escape inside the secret value — U+FFFD-replaced, resolved (not rejected)" \
+  $'x\xef\xbf\xbdy|config-json|config-json' \
+  CSC_PROBE_ID=groq-api-key "CATALYST_LAYER2_CONFIG_FILE=${L2_FILE}"
+JS_E4B_OUT="$(env -i PATH="$PATH" HOME="$SANDBOX_HOME" "CATALYST_LAYER2_CONFIG_FILE=${L2_FILE}" CSC_PROBE_ID=groq-api-key node "$PROBE_RESOLVE_JS" 2>&1)"
+BASH_E4B_OUT="$(env -i PATH="$PATH" HOME="$SANDBOX_HOME" "CATALYST_LAYER2_CONFIG_FILE=${L2_FILE}" bash -c "source '$LIB'; catalyst_resolve_secret groq-api-key")"
+JS_E4B_VAL="${JS_E4B_OUT%%|*}"
+BASH_E4B_VAL="${BASH_E4B_OUT%%|*}"
+JS_E4B_DIGEST="$(printf '%s' "$JS_E4B_VAL" | shasum -a 256 | awk '{print $1}')"
+BASH_E4B_DIGEST="$(printf '%s' "$BASH_E4B_VAL" | shasum -a 256 | awk '{print $1}')"
+expect_eq "E4b byte-digest parity: lone-LOW-surrogate U+FFFD replacement SHA-256 matches" "$JS_E4B_DIGEST" "$BASH_E4B_DIGEST"
+
+# E6: a field holding the LITERAL 7-character text \\ud800 (an escaped backslash followed by
+# the 5 literal characters "ud800") — valid JSON both parsers accept, and NOT a live escape
+# at all (the backslash run before "u" is length 2, EVEN — both backslashes pair off as one
+# escaped literal backslash, leaving "ud800" as ordinary text). A backslash-run-BLIND scanner
+# false-positives on the bare "\ud800" substring inside that literal text and rejects the
+# WHOLE document even though jq parses it fine and groq.apiKey resolves normally.
+printf '%s' "{\"groq\":{\"apiKey\":\"good\"},\"unrelated\":\"literal ${BACKSLASH}${BACKSLASH}ud800 text\"}" > "$L2_FILE"
+_cell "E6: literal escaped-backslash+text (not a live escape) in an unrelated field does not reject the document" \
+  "good|config-json|config-json" \
+  CSC_PROBE_ID=groq-api-key "CATALYST_LAYER2_CONFIG_FILE=${L2_FILE}"
+
+# Control: a valid astral surrogate PAIR (𐀀, forming U+10000) is accepted and
+# resolved, byte-for-byte, on both sides — the scanner's adjacent-live-pair acceptance path.
+printf '%s' "{\"groq\":{\"apiKey\":\"x${BACKSLASH}ud800${BACKSLASH}udc00y\"}}" > "$L2_FILE"
+_cell "control: valid astral surrogate pair resolves (accepted, not rejected) on both sides" \
+  $'x\xf0\x90\x80\x80y|config-json|config-json' \
+  CSC_PROBE_ID=groq-api-key "CATALYST_LAYER2_CONFIG_FILE=${L2_FILE}"
 
 # ─── platform-env: cloud-token (two-step name-then-value resolution) ──────────────────────
 _cell "platform-env: default name" "cloud-val|platform-env|platform-env" \
@@ -400,6 +551,26 @@ _cell "hostile (B3): cloud-token value beginning with '|' must not falsely trigg
   "cloud-injected|inherited|bare-file" \
   CSC_PROBE_ID=github-token "CATALYST_CONFIG_DIR=${CLOUDGUARD_DIR}" "GH_TOKEN=cloud-injected" \
   "CATALYST_CLOUD_TOKEN=|leading-pipe-value" CSC_PROBE_DEP_MODE=cloud CSC_PROBE_DEP_INFERRED=false
+
+# CLOUD-TOKEN NAME OVERRIDE (Codex finding fix): genuine cloud mode must resolve cloud-token
+# THROUGH the full name-override ladder (env override → Layer-2 override → default), not
+# only the hardcoded default env-var name — a direct resolveSecret("cloud-token",
+# {deploymentMode}) call previously bypassed that ladder entirely on both sides.
+_cell "cloud-token: genuine cloud mode honors CATALYST_CLOUD_TOKEN_ENV override" \
+  "the-real-token|platform-env|platform-env" \
+  CSC_PROBE_ID=cloud-token "CATALYST_CLOUD_TOKEN_ENV=MY_PLATFORM_TOKEN" "MY_PLATFORM_TOKEN=the-real-token" \
+  CSC_PROBE_DEP_MODE=cloud CSC_PROBE_DEP_INFERRED=false
+
+printf '%s' '{"catalyst":{"cloud":{"tokenEnv":"OTHER_TOKEN_VAR"}}}' > "$L2_FILE"
+_cell "cloud-token: genuine cloud mode honors the Layer-2 catalyst.cloud.tokenEnv override too" \
+  "v2|platform-env|platform-env" \
+  CSC_PROBE_ID=cloud-token "CATALYST_LAYER2_CONFIG_FILE=${L2_FILE}" "OTHER_TOKEN_VAR=v2" \
+  CSC_PROBE_DEP_MODE=cloud CSC_PROBE_DEP_INFERRED=false
+
+_cell "cloud-token: override name genuinely consulted in cloud mode — the default var being set does NOT resolve it" \
+  "|none|platform-env" \
+  CSC_PROBE_ID=cloud-token "CATALYST_CLOUD_TOKEN_ENV=MY_PLATFORM_TOKEN" "CATALYST_CLOUD_TOKEN=should-not-be-used" \
+  CSC_PROBE_DEP_MODE=cloud CSC_PROBE_DEP_INFERRED=false
 
 echo ""
 echo "Total: $((PASSES + FAILURES)), Passed: $PASSES, Failed: $FAILURES, Skipped: $SKIPPED"

--- a/plugins/dev/scripts/execution-core/cluster-sync.mjs
+++ b/plugins/dev/scripts/execution-core/cluster-sync.mjs
@@ -53,6 +53,7 @@ import {
 import { writeSecretConfig } from "./write-secret-config.mjs";
 import { schemaCompat } from "./config-schema.mjs";
 import { nodeClass } from "./lib/node-class.mjs";
+import { SECRET_REGISTRY } from "../lib/secret-contract.mjs";
 
 // Default age key location on every node (the private half; mode 0o600).
 function defaultAgeKeyFile() {
@@ -625,13 +626,37 @@ export function emitClusterSecretEvent(opts = {}, io = {}) {
 // Leaving these out is what let the 2026-08-02 outage look "applied": cluster-sync
 // rewrote github-token, recorded it in `written`, and emitted plain `refreshed` while
 // every running daemon kept 401ing on the revoked value it had captured at boot.
-const ENV_BACKED_SECRET_EXACT = new Set([
-  "claude-accounts.env",
-  "execution-core.env",
-  "github-token",
-  "webhook-secret",
-  "linear-webhook-secret",
-]);
+// CTL-1616 (A2, same-commit derivation, design §2's "same-commit derivation constraint" —
+// judge-unanimous): this Set and the prefix below are now DERIVED from SECRET_REGISTRY
+// (lib/secret-contract.mjs) rather than hand-maintained in parallel with it — the exact
+// divergence-between-two-hand-authored-lists class this ticket exists to close, which would
+// otherwise be recreated one level up (the registry AND this file's own literal Set drifting
+// apart the same way the pre-CTL-1612 secret chains did). The registry's zero-consumer
+// invariant (its own header: "nothing outside this file's own tests imports it yet") is
+// DELIBERATELY RELAXED to exactly this one consumer, in the SAME commit that introduces the
+// registry — the design's explicit exception, not a violation of it.
+//
+// The boot-captured membership rule (both provenance paragraphs above: "sourced into the
+// daemon's boot env" OR "read ONCE from disk at server boot") maps exactly onto three
+// SECRET_DELIVERY types: "bare-file" (github-token, webhook-secret — read once at boot,
+// never re-read per request), "bare-file-family" (linear-webhook-secret — same read-once
+// shape, open-ended filenames), and "env-file" (claude-accounts.env, execution-core.env —
+// `source`d into the boot env). Every OTHER delivery type is explicitly excluded: "env-alias"
+// (linear-api-token) and "config-json" (the Linear actor rows, groq-api-key) are read FRESH
+// on each resolveSecret call, not captured once; "platform-env" (cloud-token) and
+// "local-only" (age-key) are not files this predicate is about at all. Filtering on
+// `delivery` (not `rotation.class`) is deliberate: github-token's rotation.class is
+// "re-armable" (the CTL-1612 timer-rearm mechanism), yet it MUST stay in this exact set —
+// rearm is an in-process live update, orthogonal to "was this file captured once at
+// process/daemon start", which is what determines whether cluster-sync needs to emit a
+// restart-required signal on a change.
+const _BOOT_CAPTURED_DELIVERIES = new Set(["bare-file", "bare-file-family", "env-file"]);
+
+const ENV_BACKED_SECRET_EXACT = new Set(
+  SECRET_REGISTRY.filter((row) => _BOOT_CAPTURED_DELIVERIES.has(row.delivery)).map(
+    (row) => row.id,
+  ),
+);
 
 // The per-team Linear webhook secrets are a FAMILY, not fixed names: webhook-config.ts
 // builds `linear-webhook-secret-${key}` from the Layer-2 config's team keys, so the set of
@@ -640,7 +665,12 @@ const ENV_BACKED_SECRET_EXACT = new Set([
 // "CTL" — exactly the miss this predicate exists to prevent. Match case-insensitively on
 // the prefix, requiring at least one character after the dash so the bare prefix
 // "linear-webhook-secret-" and a run-on like "linear-webhook-secretXXX" both stay OUT.
-const LINEAR_WEBHOOK_SECRET_PREFIX = "linear-webhook-secret-";
+// Derived from the linear-webhook-secret row's own familyPrefix (falls back to the
+// historical literal only if that row is ever removed from the registry, which the parity
+// test's row-id-set-equality assertion would already have failed loudly on).
+const LINEAR_WEBHOOK_SECRET_PREFIX =
+  SECRET_REGISTRY.find((row) => row.delivery === "bare-file-family")?.familyPrefix ??
+  "linear-webhook-secret-";
 
 // isEnvBackedSecretFile — the boot-captured predicate. Prefer this over direct Set
 // membership; ENV_BACKED_SECRET_FILES stays exported for back-compat with callers/tests

--- a/plugins/dev/scripts/execution-core/cluster-sync.test.mjs
+++ b/plugins/dev/scripts/execution-core/cluster-sync.test.mjs
@@ -1738,6 +1738,37 @@ describe("cluster-secret event severity + env-backed set (Codex re-review)", () 
     expect(ENV_BACKED_SECRET_FILES.has("claude-accounts.env")).toBe(true);
     expect(ENV_BACKED_SECRET_FILES.has("execution-core.env")).toBe(true);
   });
+
+  // CTL-1616 (A2): ENV_BACKED_SECRET_EXACT is now DERIVED from SECRET_REGISTRY
+  // (lib/secret-contract.mjs) instead of hand-maintained in parallel with it (see the
+  // derivation's own header comment above its definition). This test is the
+  // before/after PARITY ASSERTION the design's "same-commit derivation constraint"
+  // (§2) mandates for a load-bearing marker-advance gate: the derived set must equal
+  // the EXACT historical literal set this file hand-maintained before the derivation,
+  // byte-for-byte — a silent membership change here would (via isEnvBackedSecretFile →
+  // assessMaterialization) either mask a real rotation's restart-required signal or
+  // spuriously nag on a rotation that was never boot-captured.
+  test("ENV_BACKED_SECRET_EXACT (derived from SECRET_REGISTRY) equals the historical hand-maintained literal set", () => {
+    const historicalLiteralSet = new Set([
+      "claude-accounts.env",
+      "execution-core.env",
+      "github-token",
+      "webhook-secret",
+      "linear-webhook-secret",
+    ]);
+    expect(new Set(ENV_BACKED_SECRET_FILES)).toEqual(historicalLiteralSet);
+  });
+
+  test("LINEAR_WEBHOOK_SECRET_PREFIX (derived from the registry's family row) still matches every historical family fixture", () => {
+    // Cross-check via the PUBLIC predicate rather than reaching for the private prefix
+    // constant directly — this is exactly the behavior isEnvBackedSecretFile's own
+    // describe block below re-verifies in full; this test only pins the derivation
+    // didn't silently change the prefix STRING itself.
+    expect(isEnvBackedSecretFile("linear-webhook-secret-ctl")).toBe(true);
+    expect(isEnvBackedSecretFile("linear-webhook-secret-CTL")).toBe(true);
+    expect(isEnvBackedSecretFile("linear-webhook-secret-")).toBe(false);
+    expect(isEnvBackedSecretFile("linear-webhook-secretXXX")).toBe(false);
+  });
 });
 
 // CTL-1612. The predicate that decides which rotated files get a `restart-required`

--- a/plugins/dev/scripts/lib/catalyst-secret-contract.sh
+++ b/plugins/dev/scripts/lib/catalyst-secret-contract.sh
@@ -1,0 +1,688 @@
+#!/usr/bin/env bash
+# lib/catalyst-secret-contract.sh — CTL-1616: bash mirror of lib/secret-contract.mjs's
+# SECRET_REGISTRY + resolution engine. Bash cannot import the JS leaf, so this is a SECOND,
+# independently-maintained implementation of the same registry data and provider-type
+# dispatch — kept honest by the fixture-matrix cross-stack parity test at
+# __tests__/secret-contract-parity.test.sh (the same `node --input-type=module` mechanism
+# __tests__/deployment-mode-parity.test.sh already proves out in CI).
+#
+# THIS PR IS THE FIRST ISOLATION SLICE — ZERO CONSUMERS. Nothing sources this file except
+# its own tests. lib/catalyst-secret-env.sh's catalyst_project_github_token/_webhook_secret
+# and execution-core/cluster-sync.mjs's isEnvBackedSecretFile are left untouched — re-pointing
+# them onto this registry is later-migration-plan work.
+#
+# Depends only on bash + jq (jq only for the config-json/platform-env-name rows — every other
+# delivery type is pure bash/coreutils). bash >= 3.2 compatible (no ${var,,}, no
+# `declare -A`) — matches lib/catalyst-deployment-mode.sh's own compatibility bar.
+#
+# Idempotent-source guard — safe to source multiple times.
+[[ -n "${_CATALYST_SECRET_CONTRACT_SH_LOADED:-}" ]] && return 0
+_CATALYST_SECRET_CONTRACT_SH_LOADED=1
+
+# ─── The registry, as parallel indexed arrays (no declare -A — bash 3.2 parity with the
+# rest of this codebase's lib/*.sh) ──────────────────────────────────────────────────────
+#
+# Row order and content MUST mirror SECRET_REGISTRY in lib/secret-contract.mjs exactly — the
+# parity test's row-id-set-equality assertion fails loudly if the two drift.
+_CSC_IDS=(
+  "github-token" "webhook-secret" "linear-webhook-secret" "claude-accounts.env"
+  "execution-core.env" "linear-api-token" "linear-orchestrator-actor" "linear-worker-actor"
+  "groq-api-key" "cloud-token" "age-key"
+)
+_CSC_DELIVERY=(
+  "bare-file" "bare-file" "bare-file-family" "env-file" "env-file" "env-alias" "config-json"
+  "config-json" "config-json" "platform-env" "local-only"
+)
+# Space-joined env-name lists (env var names never contain spaces, so this is a safe
+# poor-man's array-in-a-string; split with `read -ra` / a for-loop, never re-quoted as a
+# single token).
+_CSC_ENV_NAMES=(
+  "GH_TOKEN GITHUB_TOKEN" "CATALYST_WEBHOOK_SECRET" "" "" "" "LINEAR_API_TOKEN LINEAR_API_KEY"
+  "" "" "GROQ_API_KEY" "CATALYST_CLOUD_TOKEN" "SOPS_AGE_KEY_FILE"
+)
+_CSC_CONFIG_JSON_PATH=(
+  "" "" "" "" "" "" "catalyst.linear.bot.orchestrator" "catalyst.linear.bot.worker"
+  "groq.apiKey" "catalyst.cloud.tokenEnv" ""
+)
+_CSC_ROTATION_CLASS=(
+  "re-armable" "boot-only" "boot-only" "boot-only" "boot-only" "re-armable" "re-armable"
+  "boot-only" "boot-only" "boot-only" "n/a"
+)
+_CSC_ROTATION_TRIGGER=(
+  "timer" "" "" "" "" "on-401" "on-401" "" "" "" ""
+)
+_CSC_BOOTSTRAP_FOR=(
+  "" "" "" "" "" "" "" "" "" "cloud" "cluster"
+)
+_CSC_FAMILY_PREFIX=(
+  "" "" "linear-webhook-secret-" "" "" "" "" "" "" "" ""
+)
+_CSC_DEFAULT_LOCAL_PATH=(
+  "" "" "" "" "" "" "" "" "" "" ".config/catalyst/age.key"
+)
+
+# _csc_index_of ID — echoes the row index or returns 1 (never prints on miss).
+_csc_index_of() {
+  local _id="$1" _i
+  for _i in "${!_CSC_IDS[@]}"; do
+    [[ "${_CSC_IDS[$_i]}" == "$_id" ]] && { printf '%s' "$_i"; return 0; }
+  done
+  return 1
+}
+
+catalyst_secret_registry_ids() {
+  printf '%s\n' "${_CSC_IDS[@]}"
+}
+
+catalyst_secret_delivery() {
+  local _i
+  _i="$(_csc_index_of "$1")" || { printf ''; return 1; }
+  printf '%s' "${_CSC_DELIVERY[$_i]}"
+}
+
+catalyst_secret_rotation_class() {
+  local _i
+  _i="$(_csc_index_of "$1")" || { printf ''; return 1; }
+  printf '%s' "${_CSC_ROTATION_CLASS[$_i]}"
+}
+
+catalyst_secret_rotation_trigger() {
+  local _i
+  _i="$(_csc_index_of "$1")" || { printf ''; return 1; }
+  printf '%s' "${_CSC_ROTATION_TRIGGER[$_i]}"
+}
+
+catalyst_secret_bootstrap_for() {
+  local _i
+  _i="$(_csc_index_of "$1")" || { printf ''; return 1; }
+  printf '%s' "${_CSC_BOOTSTRAP_FOR[$_i]}"
+}
+
+catalyst_secret_config_json_path() {
+  local _i
+  _i="$(_csc_index_of "$1")" || { printf ''; return 1; }
+  printf '%s' "${_CSC_CONFIG_JSON_PATH[$_i]}"
+}
+
+catalyst_secret_family_prefix() {
+  local _i
+  _i="$(_csc_index_of "$1")" || { printf ''; return 1; }
+  printf '%s' "${_CSC_FAMILY_PREFIX[$_i]}"
+}
+
+# catalyst_secret_env_names ID — prints one env-var name per line (may print nothing).
+#
+# B1 FIX (verified regression): the previous implementation did `printf '%s\n' $_names` —
+# an UNQUOTED expansion that relies on the CALLER's ambient $IFS containing a space to
+# split "GH_TOKEN GITHUB_TOKEN" back into two words. A caller that sources this file under
+# the common strict-shell IFS=$'\n\t' (no space in it — the SAME class of bug
+# lib/catalyst-deployment-mode.sh's own header documents for its mode enum) gets NO
+# splitting at all: $_names arrives as ONE token "GH_TOKEN GITHUB_TOKEN" containing an
+# embedded space, and _csc_resolve_env_alias_only's `${!_name-}` indirect expansion then
+# tries to use that whole string as a variable name — bash FATALLY aborts with "invalid
+# variable name", killing the caller's entire process, not just this lookup. `IFS=' ' read
+# -ra` below scopes the space-IFS to ONLY this one `read` invocation (a prefix assignment
+# on a single command does not leak to the rest of the function or its caller), so
+# splitting is correct regardless of what IFS the sourcing script has set. See
+# __tests__/catalyst-secret-contract.test.sh's "strict IFS" regression cell.
+catalyst_secret_env_names() {
+  local _i _names
+  _i="$(_csc_index_of "$1")" || return 1
+  _names="${_CSC_ENV_NAMES[$_i]}"
+  if [[ -n "$_names" ]]; then
+    local -a _arr=()
+    IFS=' ' read -r -a _arr <<< "$_names"
+    printf '%s\n' "${_arr[@]}"
+  fi
+  return 0
+}
+
+# isSecretFamilyMember mirror — absorbed verbatim from cluster-sync.mjs's
+# isEnvBackedSecretFile/LINEAR_WEBHOOK_SECRET_PREFIX (see lib/secret-contract.mjs's own
+# isSecretFamilyMember docstring for the full provenance). Case-insensitive; requires at
+# least one character after the dash. Lowercase via `tr` (bash 3.2-safe; ${var,,} is bash 4+).
+catalyst_secret_is_family_member() {
+  local _file="$1" _prefix _name
+  [[ -n "$_file" ]] || return 1
+  _prefix="$(catalyst_secret_family_prefix "linear-webhook-secret")"
+  [[ -n "$_prefix" ]] || _prefix="linear-webhook-secret-"
+  _name="$(printf '%s' "$_file" | tr '[:upper:]' '[:lower:]')"
+  case "$_name" in
+    "${_prefix}"?*) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+# ─── Layer-2 path resolution — the §2 canonical chain (DELIBERATELY NOT
+# catalyst-deployment-mode.sh's chain — see lib/secret-contract.mjs's resolveLayer2Path
+# docstring for why these are two different resolvers) ───────────────────────────────────
+# CATALYST_LAYER2_CONFIG_FILE > CATALYST_MACHINE_CONFIG > $XDG_CONFIG_HOME/catalyst/config.json
+# > ~/.config/catalyst/config.json
+catalyst_secret_resolve_layer2_path() {
+  if [[ -n "${CATALYST_LAYER2_CONFIG_FILE:-}" ]]; then
+    printf '%s' "$CATALYST_LAYER2_CONFIG_FILE"
+    return 0
+  fi
+  if [[ -n "${CATALYST_MACHINE_CONFIG:-}" ]]; then
+    printf '%s' "$CATALYST_MACHINE_CONFIG"
+    return 0
+  fi
+  # HOME fallback (parity with lib/catalyst-deployment-mode.sh's own HOME-unset lesson): a
+  # bare "${HOME:-}" would silently probe /.config/catalyst/config.json on a HOME-less
+  # service environment instead of the real per-user default.
+  local _home="${HOME-}"
+  [[ -z "$_home" ]] && _home=~
+  local _xdg="${XDG_CONFIG_HOME:-${_home}/.config}"
+  printf '%s' "${_xdg}/catalyst/config.json"
+}
+
+# _csc_read_json_string FILE DOTTED_PATH — tagged jq read of a STRING field, mirroring the
+# type-aware tagged extraction in lib/catalyst-deployment-mode.sh's
+# _catalyst_deployment_mode_from_file (the "a bare `// empty` swallows JSON `false`" lesson —
+# a config-json row whose value is `false`/123/an object must settle as ABSENT-to-this-caller,
+# never silently coerced to a string). Tags:
+#   @ABSENT  — path missing, file unreadable/malformed, jq unavailable, or value is JSON null
+#   @STR:xxx — value is the string "xxx". NOTE (B2 fix, verifier A1): xxx MAY be empty —
+#              there is no `select` here filtering the empty string out (the previous
+#              version of this comment's "never empty" claim was stale/aspirational; no
+#              such select exists). Callers that need "present AND non-empty" (every
+#              current caller does) must check for that explicitly — see the "@STR:"?*
+#              patterns in _csc_resolve_config_json / _csc_resolve_cloud_token_name, which
+#              require at least one character after the tag, mirroring
+#              lib/secret-contract.mjs's own `raw.length > 0` / `l2Name.length > 0` checks
+#              at the equivalent call sites (an empty JSON string classifies as
+#              absent/fall-through in BOTH languages).
+#   @NONSTR  — value is present but NOT a string, OR a string with an embedded NUL (see the
+#              NUL-BYTE note below) — both settle here, never treated as a usable secret
+# Never fails the caller (always echoes a tag, even "@ABSENT" on any error).
+_csc_read_json_string() {
+  local _f="$1" _path="$2" _jq_out _jq_rc
+  [[ -r "$_f" ]] || { printf '@ABSENT'; return 0; }
+  command -v jq >/dev/null 2>&1 || { printf '@ABSENT'; return 0; }
+  # ERREXIT SAFETY: the assignment runs in an `if` condition so a nonzero jq exit cannot
+  # abort a caller running under `set -e`/inherit_errexit.
+  # NUL-BYTE CANDIDATE: a bash command substitution silently TRUNCATES an embedded NUL byte,
+  # so a raw value with an embedded NUL between "c" and "loud" would otherwise arrive at the
+  # caller already collapsed to a DIFFERENT (truncated) string than what jq/JS actually saw.
+  # Detect it INSIDE jq (mirrors lib/catalyst-deployment-mode.sh's identical fix) and settle
+  # it as @NONSTR before it ever crosses the $() boundary.
+  if _jq_out="$(jq -r --arg p "$_path" '
+    (getpath($p | split("."))) as $v |
+    if $v == null then "@ABSENT"
+    elif ($v | type) == "string" then
+      (if ($v | contains([0] | implode)) then "@NONSTR" else "@STR:" + $v end)
+    else "@NONSTR"
+    end
+  ' "$_f" 2>/dev/null)"; then
+    _jq_rc=0
+  else
+    _jq_rc=$?
+  fi
+  [[ $_jq_rc -eq 0 ]] || { printf '@ABSENT'; return 0; }
+  printf '%s' "$_jq_out"
+}
+
+# ─── Bare-file candidate search — generalizes catalyst-secret-env.sh's _catalyst_secret_dirs
+# / github-auth-preflight.mjs's githubTokenFileCandidates to any row's basename ────────────
+
+# catalyst_secret_explicit_file_override_var ID — mirrors explicitFileOverrideEnvName in
+# lib/secret-contract.mjs: uppercase, replace every run of non-alnum with ONE underscore
+# (tr -s squeezes consecutive substitutions from -c into a single underscore, matching the
+# JS regex's `+` quantifier).
+catalyst_secret_explicit_file_override_var() {
+  local _upper
+  _upper="$(printf '%s' "$1" | tr '[:lower:]' '[:upper:]' | tr -c 'A-Z0-9' '_' | tr -s '_')"
+  # Strip a leading/trailing underscore artifact from tr -c mapping a leading/trailing
+  # non-alnum char — none of the registry ids have one, but this keeps the helper honest for
+  # any future id that might.
+  _upper="${_upper#_}"
+  _upper="${_upper%_}"
+  printf 'CATALYST_%s_FILE' "$_upper"
+}
+
+# catalyst_secret_candidates ID — prints the bare-file candidate search chain, one per line,
+# in priority order: explicit override → CATALYST_CONFIG_DIR → cluster-sync's own destination
+# dir → XDG dir. Mirrors secretFileCandidates(id, env) exactly.
+catalyst_secret_candidates() {
+  local _id="$1" _override_var _override
+  _override_var="$(catalyst_secret_explicit_file_override_var "$_id")"
+  _override="${!_override_var:-}"
+  if [[ -n "$_override" ]]; then
+    printf '%s\n' "$_override"
+    return 0
+  fi
+  if [[ -n "${CATALYST_CONFIG_DIR:-}" ]]; then
+    printf '%s/%s\n' "$CATALYST_CONFIG_DIR" "$_id"
+    return 0
+  fi
+  local _home="${HOME-}"
+  [[ -z "$_home" ]] && _home=~
+  local _l2="${CATALYST_LAYER2_CONFIG_FILE:-${_home}/.config/catalyst/config.json}"
+  local _c1
+  _c1="$(dirname "$_l2")/${_id}"
+  local _xdg_base="${XDG_CONFIG_HOME:-${_home}/.config}"
+  local _c2="${_xdg_base}/catalyst/${_id}"
+  printf '%s\n' "$_c1"
+  [[ "$_c2" != "$_c1" ]] && printf '%s\n' "$_c2"
+  return 0
+}
+
+# _csc_strip_eol / _csc_is_blank / _csc_contains_nul — self-contained equivalents of
+# _catalyst_strip_eol / _catalyst_is_blank (lib/catalyst-secret-env.sh). Deliberately NOT
+# sourced from that file — this pair stays a self-contained leaf (design §2's "one new pair
+# of zero-import leaves"), and duplicating three small primitives is cheaper than coupling
+# two independently-owned files. _csc_is_blank uses an EXPLICIT ASCII whitespace set, not
+# [[:space:]] — the CTL-1617 locale lesson: [[:space:]] is LOCALE DATA (macOS classifies NBSP
+# as space under a UTF-8 locale; a C-locale Linux runner does not), so the same file would
+# blank-check differently per host under the locale-dependent class.
+_csc_strip_eol() {
+  local s="$1"
+  while [[ "$s" == *$'\n' || "$s" == *$'\r' ]]; do
+    s="${s%$'\n'}"
+    s="${s%$'\r'}"
+  done
+  printf '%s' "$s"
+}
+_csc_is_blank() {
+  local _v="$1" _ws=$' \t\n\v\f\r'
+  [[ -z "${_v//["$_ws"]/}" ]]
+}
+# _csc_contains_nul FILE — true iff FILE's bytes contain an embedded NUL. PARITY GUARD
+# (generalizes the JSON-field NUL lesson to raw file bytes): `$(cat "$file")` truncates at
+# the first NUL, so without this check a NUL-containing file would resolve to a silently
+# TRUNCATED value here while lib/secret-contract.mjs's readFileSync sees the full byte
+# string — two different "resolved" values for the same file.
+#
+# WHY NOT `grep -q $'\x00'`: a NUL byte can never survive as a literal argv byte at all —
+# execve() arguments are themselves NUL-terminated C strings, so `$'\x00'` is silently
+# dropped to an EMPTY bash string before grep ever sees it, and `grep -q ""` (an empty
+# pattern) matches unconditionally — every file would wrongly report "contains NUL" and
+# every bare-file candidate would be skipped. This is the SAME "NUL dies at a boundary"
+# class the JSON-field lesson names, one boundary earlier (argv, not $()).
+#
+# The fix routes around the boundary instead of trying to cross it: `tr`'s own operand
+# parser (not bash, not execve) interprets the 4 literal characters `\`, `0`, `0`, `0` as an
+# octal escape for the NUL byte — portable POSIX `tr` behavior on both GNU and BSD — so
+# `tr -d '\000'` can delete every NUL from the file's byte stream without a real NUL ever
+# needing to exist as a shell argument. Comparing byte counts before/after then detects
+# whether anything was deleted, entirely via `wc -c`, which is itself NUL-safe (it counts
+# bytes, never treats one as a string terminator).
+_csc_contains_nul() {
+  local _f="$1" _orig _stripped
+  [[ -r "$_f" ]] || return 1
+  _orig="$(wc -c < "$_f" 2>/dev/null)" || return 1
+  _stripped="$(LC_ALL=C tr -d '\000' < "$_f" 2>/dev/null | wc -c)" || return 1
+  [[ "$_orig" -ne "$_stripped" ]]
+}
+
+# catalyst_secret_read_first_nonblank_file — tries each of "$@" in order; on the first
+# readable, non-NUL, non-blank (after EOL-strip) candidate, prints the value and returns 0.
+# Prints nothing and returns 1 if no candidate qualifies. (Deliberately does NOT report which
+# candidate won via a global — this is always called through $(...) by its one caller below,
+# and a global set inside a command-substitution subshell would be discarded before the
+# caller could read it; see the SUBSHELL-EXPORT CAVEAT on _csc_resolve_config_json for the
+# general shape of that trap.)
+catalyst_secret_read_first_nonblank_file() {
+  local _f _raw _val
+  for _f in "$@"; do
+    [[ -r "$_f" ]] || continue
+    _csc_contains_nul "$_f" && continue
+    _raw="$(cat "$_f" 2>/dev/null)" || continue
+    _val="$(_csc_strip_eol "$_raw")"
+    if ! _csc_is_blank "$_val"; then
+      printf '%s' "$_val"
+      return 0
+    fi
+  done
+  return 1
+}
+
+# ─── Per-delivery-type resolvers ─────────────────────────────────────────────────────────
+# Every _csc_resolve_* function sets CATALYST_SECRET_LAST_VALUE / _SOURCE / _PROVIDER and
+# echoes "value|source|provider" (empty fields when unresolved) — mirroring the
+# lib/catalyst-deployment-mode.sh probe-output convention the parity test already exercises.
+
+_csc_set_result() {
+  # Exported side-channel breadcrumbs (mirrors CATALYST_DEPLOYMENT_MODE_RESOLVED's
+  # convention in lib/catalyst-deployment-mode.sh) — a future consumer (not this PR) reads
+  # these after calling catalyst_resolve_secret without needing to reparse the pipe-joined
+  # stdout. Unused WITHIN this file itself, hence the shellcheck disable.
+  # shellcheck disable=SC2034
+  CATALYST_SECRET_LAST_VALUE="$1"
+  # shellcheck disable=SC2034
+  CATALYST_SECRET_LAST_SOURCE="$2"
+  # shellcheck disable=SC2034
+  CATALYST_SECRET_LAST_PROVIDER="$3"
+  export CATALYST_SECRET_LAST_VALUE CATALYST_SECRET_LAST_SOURCE CATALYST_SECRET_LAST_PROVIDER
+  printf '%s|%s|%s' "$1" "$2" "$3"
+}
+
+_csc_resolve_env_alias_only() {
+  local _id="$1" _delivery _name _val
+  _delivery="$(catalyst_secret_delivery "$_id")"
+  while IFS= read -r _name; do
+    [[ -n "$_name" ]] || continue
+    _val="${!_name-}"
+    if [[ -n "$_val" ]]; then
+      _csc_set_result "$_val" "inherited" "$_delivery"
+      return 0
+    fi
+  done < <(catalyst_secret_env_names "$_id")
+  _csc_set_result "" "none" "$_delivery"
+}
+
+_csc_resolve_bare_file() {
+  local _id="$1" _delivery _override_var _override _val _c
+  _delivery="$(catalyst_secret_delivery "$_id")"
+  _override_var="$(catalyst_secret_explicit_file_override_var "$_id")"
+  _override="${!_override_var:-}"
+  local -a _cands=()
+  while IFS= read -r _c; do [[ -n "$_c" ]] && _cands+=("$_c"); done < <(catalyst_secret_candidates "$_id")
+  if _val="$(catalyst_secret_read_first_nonblank_file "${_cands[@]}")"; then
+    local _source="shared-file"
+    [[ -n "$_override" ]] && _source="operator-override"
+    _csc_set_result "$_val" "$_source" "$_delivery"
+    return 0
+  fi
+  # Fall back to an inherited env alias, matching resolveBareFile in lib/secret-contract.mjs.
+  _csc_resolve_env_alias_only "$_id"
+}
+
+_csc_resolve_bare_file_family() {
+  local _id="$1" _delivery
+  _delivery="$(catalyst_secret_delivery "$_id")"
+  _csc_set_result "" "" "$_delivery"
+}
+
+_csc_resolve_env_file_presence() {
+  local _id="$1" _delivery _c
+  _delivery="$(catalyst_secret_delivery "$_id")"
+  while IFS= read -r _c; do
+    [[ -n "$_c" ]] || continue
+    if [[ -f "$_c" && -s "$_c" ]]; then
+      _csc_set_result "$_c" "shared-file" "$_delivery"
+      return 0
+    fi
+  done < <(catalyst_secret_candidates "$_id")
+  _csc_set_result "" "none" "$_delivery"
+}
+
+_csc_resolve_config_json() {
+  local _id="$1" _delivery _path _l2 _tagged
+  _delivery="$(catalyst_secret_delivery "$_id")"
+  if [[ -n "$(catalyst_secret_env_names "$_id")" ]]; then
+    # SUBSHELL-EXPORT CAVEAT (mirrors lib/catalyst-deployment-mode.sh's own documented fix):
+    # calling _csc_resolve_env_alias_only inside a $(...) command substitution would run it
+    # in a SUBSHELL, and the CATALYST_SECRET_LAST_* globals it sets would be discarded the
+    # instant $() returns — so this call is made DIRECTLY (redirecting only stdout, not
+    # wrapping the whole invocation in $()), keeping it in THIS function's own shell so the
+    # globals it sets survive to the check below.
+    _csc_resolve_env_alias_only "$_id" >/dev/null
+    if [[ "$CATALYST_SECRET_LAST_SOURCE" == "inherited" ]]; then
+      _csc_set_result "$CATALYST_SECRET_LAST_VALUE" "inherited" "$_delivery"
+      return 0
+    fi
+  fi
+  _path="$(catalyst_secret_config_json_path "$_id")"
+  _l2="$(catalyst_secret_resolve_layer2_path)"
+  _tagged="$(_csc_read_json_string "$_l2" "$_path")"
+  case "$_tagged" in
+    "@STR:"?*)
+      # B2 FIX: require at least one character after the tag — an empty extracted string
+      # ("@STR:" alone) falls through to the `*` branch below and classifies as absent.
+      # This mirrors lib/secret-contract.mjs's resolveConfigJson, which only accepts
+      # `raw.length > 0` (an empty config-json string is treated as "none", not a resolved
+      # empty-string secret). WITHOUT this guard, an empty JSON string value diverged from
+      # JS: this file reported source=config-json (with an empty value) while JS fell
+      # through to source=none.
+      _csc_set_result "${_tagged#@STR:}" "config-json" "$_delivery"
+      ;;
+    *)
+      _csc_set_result "" "none" "$_delivery"
+      ;;
+  esac
+}
+
+# _csc_resolve_cloud_token_name — cloud-token's two-step resolution: NAME (env override →
+# Layer-2 catalyst.cloud.tokenEnv → default CATALYST_CLOUD_TOKEN), then that variable's
+# VALUE. Mode-independent — always platform-env, never touches a file.
+_csc_resolve_cloud_token_name() {
+  local _id="$1" _delivery _path _l2 _tagged _env_var _val
+  _delivery="$(catalyst_secret_delivery "$_id")"
+  _path="$(catalyst_secret_config_json_path "$_id")"
+  if [[ -n "${CATALYST_CLOUD_TOKEN_ENV:-}" ]]; then
+    _env_var="$CATALYST_CLOUD_TOKEN_ENV"
+  else
+    _l2="$(catalyst_secret_resolve_layer2_path)"
+    _tagged="$(_csc_read_json_string "$_l2" "$_path")"
+    # B2 FIX: same "@STR:"?* non-empty guard as _csc_resolve_config_json — an empty
+    # Layer-2 NAME override must fall through to the default env-var name, matching
+    # lib/secret-contract.mjs's resolveCloudTokenName `l2Name.length > 0` check. Without
+    # this guard an empty tag left `_env_var` empty, and `_val="${!_env_var-}"` below would
+    # attempt an indirect expansion on an EMPTY variable name — a second "invalid variable
+    # name" fatal-abort class, the same failure shape as B1.
+    case "$_tagged" in
+      "@STR:"?*) _env_var="${_tagged#@STR:}" ;;
+      *) _env_var="$(catalyst_secret_env_names "$_id" | head -n1)" ;;
+    esac
+  fi
+  _val="${!_env_var-}"
+  if [[ -n "$_val" ]]; then
+    _csc_set_result "$_val" "platform-env" "$_delivery"
+  else
+    _csc_set_result "" "none" "$_delivery"
+  fi
+}
+
+# _csc_resolve_local_only_presence — age-key. PRESENCE-CHECKED ONLY: this function must never
+# `cat`/read the candidate file's contents — `[[ -f ]]`/`-s` alone.
+_csc_resolve_local_only_presence() {
+  local _id="$1" _delivery _override _home _default_rel _path
+  _delivery="$(catalyst_secret_delivery "$_id")"
+  _override="$(catalyst_secret_env_names "$_id" | head -n1)"
+  local _override_val="${!_override-}"
+  if [[ -n "$_override_val" ]]; then
+    _path="$_override_val"
+  else
+    _home="${HOME-}"
+    [[ -z "$_home" ]] && _home=~
+    _default_rel="$(_csc_index_of "$_id")"
+    _default_rel="${_CSC_DEFAULT_LOCAL_PATH[$_default_rel]}"
+    _path="${_home}/${_default_rel}"
+  fi
+  if [[ -f "$_path" ]]; then
+    _csc_set_result "$_path" "present" "$_delivery"
+  else
+    _csc_set_result "" "absent" "$_delivery"
+  fi
+}
+
+# ─── The public engine ───────────────────────────────────────────────────────────────────
+
+# _csc_cloud_bootstrap_id — the id of the row whose bootstrapFor === "cloud" (cloud-token).
+_csc_cloud_bootstrap_id() {
+  local _i
+  for _i in "${!_CSC_BOOTSTRAP_FOR[@]}"; do
+    [[ "${_CSC_BOOTSTRAP_FOR[$_i]}" == "cloud" ]] && { printf '%s' "${_CSC_IDS[$_i]}"; return 0; }
+  done
+  return 1
+}
+
+# catalyst_resolve_secret ID [DEPLOYMENT_MODE] [INFERRED(true|false)] — mirrors
+# resolveSecret(id, {env, deploymentMode}). Echoes "value|source|provider" and sets
+# CATALYST_SECRET_LAST_VALUE/_SOURCE/_PROVIDER. Never fails the caller (always echoes a
+# 3-field pipe-joined string, empty fields on miss/unresolved).
+#
+# CLOUD GUARD: activates ONLY when DEPLOYMENT_MODE == "cloud" AND INFERRED == "false" —
+# mirrors the JS engine's `deploymentMode.mode === "cloud" && deploymentMode.inferred ===
+# false` guard exactly. Any other combination (including DEPLOYMENT_MODE unset, "single-host",
+# "cluster", or "cloud" with INFERRED != "false") runs the normal per-delivery-type file/config
+# chain — the "never skips the file chain for single-host/cluster" invariant.
+catalyst_resolve_secret() {
+  local _id="$1" _dep_mode="${2:-}" _dep_inferred="${3:-true}"
+  local _idx _delivery
+  if ! _idx="$(_csc_index_of "$_id")"; then
+    _csc_set_result "" "" ""
+    return 0
+  fi
+  _delivery="${_CSC_DELIVERY[$_idx]}"
+
+  if [[ "$_dep_mode" == "cloud" && "$_dep_inferred" == "false" ]]; then
+    local _bootstrap_for="${_CSC_BOOTSTRAP_FOR[$_idx]}"
+    if [[ "$_bootstrap_for" != "cloud" ]]; then
+      local _bid
+      if _bid="$(_csc_cloud_bootstrap_id)"; then
+        local _boot_val
+        # B3 FIX: DIRECT CALL, NOT wrapped in $(...) — mirrors the SUBSHELL-EXPORT CAVEAT
+        # documented on _csc_resolve_config_json/catalyst_arm_secret. The previous
+        # implementation captured the recursive call's pipe-joined "value|source|provider"
+        # stdout via $() and parsed it with `${_boot_out%%|*}` — a cloud-token VALUE that
+        # itself BEGINS WITH "|" makes that pattern match at position 0, so `%%|*` strips
+        # the ENTIRE string and _boot_val came back empty even though the bootstrap secret
+        # genuinely resolved — bash then falsely short-circuited every other cloud-mode
+        # secret to null while the JS engine (which reads bootstrapResolved.value directly,
+        # never a delimited string) resolves normally. Reading the
+        # CATALYST_SECRET_LAST_VALUE breadcrumb that _csc_set_result exports in THIS shell
+        # (no subshell forked by a bare `>/dev/null` redirection, so the export survives)
+        # avoids parsing delimited stdout at all.
+        # No deployment-mode args passed onward — cloud-token's own resolution is
+        # mode-independent (matches resolveCloudTokenName's JS docstring), so this recurses
+        # exactly one level and terminates.
+        catalyst_resolve_secret "$_bid" >/dev/null
+        _boot_val="$CATALYST_SECRET_LAST_VALUE"
+        if [[ -z "$_boot_val" ]]; then
+          _csc_set_result "" "" "$_delivery"
+          return 0
+        fi
+      fi
+    fi
+    _csc_resolve_env_alias_only "$_id"
+    return 0
+  fi
+
+  case "$_delivery" in
+    bare-file) _csc_resolve_bare_file "$_id" ;;
+    bare-file-family) _csc_resolve_bare_file_family "$_id" ;;
+    env-file) _csc_resolve_env_file_presence "$_id" ;;
+    env-alias) _csc_resolve_env_alias_only "$_id" ;;
+    config-json) _csc_resolve_config_json "$_id" ;;
+    platform-env) _csc_resolve_cloud_token_name "$_id" ;;
+    local-only) _csc_resolve_local_only_presence "$_id" ;;
+    *) _csc_set_result "" "" "$_delivery" ;;
+  esac
+}
+
+# ─── armSecret mirror ────────────────────────────────────────────────────────────────────
+#
+# Bash has no first-class function values the way registerRearmHook(id, fn) does in
+# lib/secret-contract.mjs, so catalyst_arm_secret ALWAYS runs the HOOKLESS-DEGRADE path —
+# which in THIS PR is the identical behavior lib/secret-contract.mjs's armSecret produces for
+# every row too, since nothing has called registerRearmHook yet anywhere (zero consumers).
+# The two implementations are therefore expected to agree exactly today; see
+# __tests__/catalyst-secret-contract.test.sh's "arm state" section (this file's own
+# standalone suite) and lib/secret-contract.test.mjs's "registry validation (§6)" describe
+# block on the JS side. (A1 fix: this pointer previously named
+# __tests__/secret-contract-parity.test.sh, which has NO arm-state fixtures at all — the
+# cross-stack parity suite only exercises resolveSecret/catalyst_resolve_secret.) A future
+# PR that wires a real JS rearm hook does NOT need a bash equivalent of the hook path
+# itself — only of this degrade path, which stays correct on its own.
+#
+# State: per-id last-observed-value, kept in parallel arrays (no declare -A). Persists only
+# for the lifetime of the current shell process — a fresh shell has no baseline, matching a
+# freshly-started daemon.
+_CSC_ARM_IDS=()
+_CSC_ARM_VALUES=()
+
+_csc_arm_index_of() {
+  local _id="$1" _i
+  for _i in "${!_CSC_ARM_IDS[@]}"; do
+    [[ "${_CSC_ARM_IDS[$_i]}" == "$_id" ]] && { printf '%s' "$_i"; return 0; }
+  done
+  return 1
+}
+
+# catalyst_secret_reset_arm_state [ID] — test/reset seam, mirrors resetArmState(id).
+catalyst_secret_reset_arm_state() {
+  if [[ -z "${1:-}" ]]; then
+    _CSC_ARM_IDS=()
+    _CSC_ARM_VALUES=()
+    return 0
+  fi
+  local _i
+  if _i="$(_csc_arm_index_of "$1")"; then
+    unset "_CSC_ARM_IDS[$_i]" "_CSC_ARM_VALUES[$_i]"
+    _CSC_ARM_IDS=("${_CSC_ARM_IDS[@]}")
+    _CSC_ARM_VALUES=("${_CSC_ARM_VALUES[@]}")
+  fi
+}
+
+# catalyst_arm_secret ID — echoes "armed|rotated|restartRequired" (each true|false) AND
+# exports the same three fields as CATALYST_SECRET_ARM_ARMED / _ROTATED / _RESTART_REQUIRED,
+# mirroring armSecret's { armed, rotated, restartRequired } shape.
+#
+# MUST BE CALLED DIRECTLY, NEVER WRAPPED IN $(...), by any caller that needs the persistent
+# baseline to survive across repeated calls in the same shell — this is the SAME
+# SUBSHELL-EXPORT trap documented on _csc_resolve_config_json and
+# lib/catalyst-deployment-mode.sh's catalyst_resolve_deployment_mode: `$(catalyst_arm_secret
+# id)` forks a subshell, and this function's mutation of the _CSC_ARM_IDS/_CSC_ARM_VALUES
+# globals would happen in THAT subshell's copy and vanish the instant $() returns — every
+# call made that way would wrongly look like a first observation, forever. Call it plainly
+# (optionally redirecting stdout with `>/dev/null` if only the exported vars are wanted) and
+# read the exported vars, or capture stdout via `out="$(catalyst_arm_secret id)"` ONLY when
+# the caller genuinely wants a one-shot, state-discarding check.
+catalyst_arm_secret() {
+  local _id="$1" _rotation_class=""
+  # B4 FIX (errexit safety): the assignment runs in an `if` condition — mirrors the
+  # ERREXIT SAFETY pattern on _csc_read_json_string above. catalyst_secret_rotation_class
+  # returns rc=1 (printing nothing) for an unknown id; a bare
+  # `_rotation_class=$(catalyst_secret_rotation_class "$_id")`, run as a plain simple
+  # command with no enclosing if/while/`||`, has ITS OWN nonzero exit status — under `set
+  # -e`/errexit that kills the CALLER's entire process, rather than returning the quiet
+  # {armed:false} triple lib/secret-contract.mjs's armSecret returns for the same unknown
+  # id. See __tests__/catalyst-secret-contract.test.sh's errexit regression cell.
+  if ! _rotation_class="$(catalyst_secret_rotation_class "$_id")"; then
+    _csc_set_arm_result "false" "false" "false"
+    return 0
+  fi
+  if [[ -z "$_rotation_class" || "$_rotation_class" == "n/a" ]]; then
+    _csc_set_arm_result "false" "false" "false"
+    return 0
+  fi
+  # DELIMITED-STDOUT HAZARD (same class as the cloud-bootstrap fix above): a
+  # secret VALUE may legitimately contain "|", and parsing the pipe-joined
+  # resolve output with ${x%%|*} truncates it at the first pipe — the rotation
+  # diff below would then silently miss a real rotation AND its
+  # restart-required signal (the literal 2026-08-02 outage mechanism this
+  # contract exists to report). Call resolve directly (no $() — resolve never
+  # touches the arm arrays, so there is no subshell-state hazard) and read the
+  # CATALYST_SECRET_LAST_VALUE breadcrumb it exports in-shell.
+  local _current _idx
+  catalyst_resolve_secret "$_id" >/dev/null
+  _current="${CATALYST_SECRET_LAST_VALUE-}"
+  if _idx="$(_csc_arm_index_of "$_id")"; then
+    local _previous="${_CSC_ARM_VALUES[$_idx]}"
+    _CSC_ARM_VALUES[_idx]="$_current"
+    if [[ "$_current" == "$_previous" ]]; then
+      _csc_set_arm_result "false" "false" "false"
+    else
+      _csc_set_arm_result "false" "true" "true"
+    fi
+  else
+    _CSC_ARM_IDS+=("$_id")
+    _CSC_ARM_VALUES+=("$_current")
+    # First observation establishes the baseline — nothing has rotated relative to a
+    # baseline that did not exist yet.
+    _csc_set_arm_result "false" "false" "false"
+  fi
+}
+
+_csc_set_arm_result() {
+  # shellcheck disable=SC2034
+  CATALYST_SECRET_ARM_ARMED="$1"
+  # shellcheck disable=SC2034
+  CATALYST_SECRET_ARM_ROTATED="$2"
+  # shellcheck disable=SC2034
+  CATALYST_SECRET_ARM_RESTART_REQUIRED="$3"
+  export CATALYST_SECRET_ARM_ARMED CATALYST_SECRET_ARM_ROTATED CATALYST_SECRET_ARM_RESTART_REQUIRED
+  printf '%s|%s|%s' "$1" "$2" "$3"
+}

--- a/plugins/dev/scripts/lib/catalyst-secret-contract.sh
+++ b/plugins/dev/scripts/lib/catalyst-secret-contract.sh
@@ -176,42 +176,105 @@ catalyst_secret_resolve_layer2_path() {
   printf '%s' "${_xdg}/catalyst/config.json"
 }
 
-# _csc_read_json_string FILE DOTTED_PATH — tagged jq read of a STRING field, mirroring the
+# _csc_b64_decode B64 — decode a base64 string to raw bytes on stdout. macOS/BSD base64 and
+# GNU coreutils base64 both accept -d; -D is BSD's long-standing alias, tried as a fallback
+# for any base64 build that only recognizes the BSD spelling. Never fails the caller (a
+# malformed/empty input decodes to empty output either way).
+_csc_b64_decode() {
+  local _in="$1"
+  if printf '%s' "$_in" | base64 -d 2>/dev/null; then
+    return 0
+  fi
+  printf '%s' "$_in" | base64 -D 2>/dev/null
+}
+
+# _csc_b64_decode_var VARNAME B64 — decodes B64 into VARNAME. Deliberately NOT
+# `VARNAME="$(_csc_b64_decode "$B64")"` — that bare $() capture would strip ANY trailing
+# newline byte off the DECODED value itself (the value is the ENTIRE output of that specific
+# command substitution), reintroducing the exact TRAILING-NEWLINE bug this base64 encoding
+# exists to fix, one boundary later. `read -d ''` over a process substitution captures every
+# byte up to an explicit NUL terminator WITHOUT the trailing-newline-stripping $() performs —
+# safe here because jq already rejects any NUL-containing value before base64-encoding it
+# (see _csc_read_json_string), so the decoded bytes are guaranteed NUL-free, the one byte
+# `read -d ''` cannot represent.
+_csc_b64_decode_var() {
+  local _varname="$1" _b64="$2"
+  IFS= read -r -d '' "$_varname" < <(_csc_b64_decode "$_b64"; printf '\0')
+}
+
+# _csc_read_json_string FILE DOTTED_PATH — tagged jq read of a field, mirroring the
 # type-aware tagged extraction in lib/catalyst-deployment-mode.sh's
 # _catalyst_deployment_mode_from_file (the "a bare `// empty` swallows JSON `false`" lesson —
-# a config-json row whose value is `false`/123/an object must settle as ABSENT-to-this-caller,
+# a config-json row whose value is `false`/123/an array must settle as ABSENT-to-this-caller,
 # never silently coerced to a string). Tags:
-#   @ABSENT  — path missing, file unreadable/malformed, jq unavailable, or value is JSON null
-#   @STR:xxx — value is the string "xxx". NOTE (B2 fix, verifier A1): xxx MAY be empty —
-#              there is no `select` here filtering the empty string out (the previous
-#              version of this comment's "never empty" claim was stale/aspirational; no
-#              such select exists). Callers that need "present AND non-empty" (every
-#              current caller does) must check for that explicitly — see the "@STR:"?*
-#              patterns in _csc_resolve_config_json / _csc_resolve_cloud_token_name, which
-#              require at least one character after the tag, mirroring
-#              lib/secret-contract.mjs's own `raw.length > 0` / `l2Name.length > 0` checks
-#              at the equivalent call sites (an empty JSON string classifies as
-#              absent/fall-through in BOTH languages).
-#   @NONSTR  — value is present but NOT a string, OR a string with an embedded NUL (see the
-#              NUL-BYTE note below) — both settle here, never treated as a usable secret
+#   @ABSENT    — path missing, file unreadable/malformed, jq unavailable, value is JSON null,
+#                a BOM-prefixed file, or a multi-document file (see BOM/MULTI-DOC below)
+#   @STR64:xxx — value is a JSON STRING, base64-encoded as xxx (see TRAILING-NEWLINE FIX
+#                below for why base64, not the value verbatim). xxx MAY decode to the empty
+#                string — no `select` filters that out; callers needing "present AND
+#                non-empty" check the DECODED length explicitly (see _csc_resolve_config_json
+#                / _csc_resolve_cloud_token_name), mirroring lib/secret-contract.mjs's own
+#                `raw.length > 0` checks at the equivalent call sites.
+#   @OBJ64:xxx — value is a JSON OBJECT, canonicalized (recursively sorted-key, matching
+#                lib/secret-contract.mjs's canonicalJsonStringify byte-for-byte) and
+#                base64-encoded as xxx (design §2 finding fix: catalyst.linear.bot.
+#                orchestrator/.worker store OBJECTS, not strings — see
+#                _csc_resolve_config_json, the ONLY caller that accepts this tag;
+#                _csc_resolve_cloud_token_name deliberately does NOT, since a NAME override
+#                can only ever be a plain string).
+#   @NONSTR    — value is present but is an array/boolean/number, OR a string/object whose
+#                canonical form carries an embedded NUL (see the NUL-BYTE note below) — never
+#                treated as a usable secret.
 # Never fails the caller (always echoes a tag, even "@ABSENT" on any error).
+#
+# TRAILING-NEWLINE FIX (Codex finding fix): the OLD implementation returned the tagged value
+# VERBATIM ("@STR:" + $v) through `_jq_out="$(jq ...)"` — and $() strips ALL trailing
+# newlines from its OWN captured output. A value like "abc\n" is the LAST thing printed (tag
+# then value), so its trailing byte WAS the captured string's trailing byte, and $() silently
+# truncated it to "abc" — while lib/secret-contract.mjs's JSON.parse preserves every byte.
+# Base64-encoding the value inside jq means the captured string's own trailing byte is
+# alphanumeric/+//= — NEVER a newline — so nothing is stripped; decoding afterward recovers
+# the exact original bytes, including any trailing newline.
+#
+# BOM SNIFF (parity, mirrors lib/catalyst-deployment-mode.sh's identical fix verbatim): this
+# jq build tolerates a UTF-8 BOM at the start of input; JSON.parse rejects one. A
+# BOM-prefixed Layer-2 file must settle @ABSENT (layer-malformed) on BOTH sides.
+#
+# --slurp / MULTI-DOCUMENT (parity, mirrors catalyst-deployment-mode.sh): jq without -s
+# processes each top-level JSON value in a file independently — a file holding TWO valid
+# documents exits 0 and emits two tags (garbage once collapsed through the $() boundary
+# below), while JSON.parse rejects the whole file (trailing-content SyntaxError). Slurping
+# collapses that to one array whose length exposes the multi-document case (length != 1 →
+# @ABSENT) — a single document is unaffected (length == 1, .[0] is that one document).
 _csc_read_json_string() {
   local _f="$1" _path="$2" _jq_out _jq_rc
   [[ -r "$_f" ]] || { printf '@ABSENT'; return 0; }
   command -v jq >/dev/null 2>&1 || { printf '@ABSENT'; return 0; }
+  local _first3
+  _first3="$(head -c 3 "$_f" 2>/dev/null | od -An -tx1 | tr -d ' \n')"
+  if [[ "$_first3" == "efbbbf" ]]; then
+    printf '@ABSENT'
+    return 0
+  fi
   # ERREXIT SAFETY: the assignment runs in an `if` condition so a nonzero jq exit cannot
   # abort a caller running under `set -e`/inherit_errexit.
   # NUL-BYTE CANDIDATE: a bash command substitution silently TRUNCATES an embedded NUL byte,
   # so a raw value with an embedded NUL between "c" and "loud" would otherwise arrive at the
   # caller already collapsed to a DIFFERENT (truncated) string than what jq/JS actually saw.
   # Detect it INSIDE jq (mirrors lib/catalyst-deployment-mode.sh's identical fix) and settle
-  # it as @NONSTR before it ever crosses the $() boundary.
-  if _jq_out="$(jq -r --arg p "$_path" '
+  # it as @NONSTR before it ever crosses the $() boundary. Applied identically to the
+  # canonicalized OBJECT form (see @OBJ64 above) via the same $canon-carrying branch.
+  if _jq_out="$(jq -rs --arg p "$_path" '
+    if length != 1 then "@ABSENT" else .[0] |
     (getpath($p | split("."))) as $v |
     if $v == null then "@ABSENT"
     elif ($v | type) == "string" then
-      (if ($v | contains([0] | implode)) then "@NONSTR" else "@STR:" + $v end)
+      (if ($v | contains([0] | implode)) then "@NONSTR" else "@STR64:" + ($v | @base64) end)
+    elif ($v | type) == "object" then
+      ($v | walk(if type == "object" then to_entries | sort_by(.key) | from_entries else . end) | tojson) as $canon |
+      (if ($canon | contains([0] | implode)) then "@NONSTR" else "@OBJ64:" + ($canon | @base64) end)
     else "@NONSTR"
+    end
     end
   ' "$_f" 2>/dev/null)"; then
     _jq_rc=0
@@ -315,6 +378,27 @@ _csc_contains_nul() {
   [[ "$_orig" -ne "$_stripped" ]]
 }
 
+# _csc_is_valid_utf8 FILE — true iff every byte in FILE forms valid UTF-8. PARITY GUARD
+# (Codex finding fix, generalizes the NUL-byte lesson above to the FULL byte-validity
+# question): Node's readFileSync(file, "utf8") REPLACES any invalid UTF-8 byte sequence with
+# U+FFFD rather than failing, so lib/secret-contract.mjs's JS side would silently decode a
+# bare-file secret containing a stray non-UTF-8 byte (e.g. a leading 0xFF 0xFE) into a
+# MUTATED credential, while this file's `cat` preserves the original bytes exactly — two
+# different "resolved" values for the same file. Neither behavior is safe to prefer: a
+# credential that cannot round-trip UTF-8 identically cannot be represented identically in
+# both engines, so BOTH sides REJECT the candidate (falls through to the next candidate,
+# same degrade shape as the NUL-byte guard) rather than one silently serving a mutated view.
+# `iconv -f UTF-8 -t UTF-8` is a standard, portable (GNU + BSD/macOS) round-trip validity
+# check: it exits non-zero the instant it hits a byte sequence that cannot be interpreted as
+# UTF-8, without ever needing to hold the (possibly credential-bearing) decoded text in a
+# shell variable.
+_csc_is_valid_utf8() {
+  local _f="$1"
+  [[ -r "$_f" ]] || return 1
+  command -v iconv >/dev/null 2>&1 || return 0
+  iconv -f UTF-8 -t UTF-8 "$_f" >/dev/null 2>&1
+}
+
 # catalyst_secret_read_first_nonblank_file — tries each of "$@" in order; on the first
 # readable, non-NUL, non-blank (after EOL-strip) candidate, prints the value and returns 0.
 # Prints nothing and returns 1 if no candidate qualifies. (Deliberately does NOT report which
@@ -327,6 +411,7 @@ catalyst_secret_read_first_nonblank_file() {
   for _f in "$@"; do
     [[ -r "$_f" ]] || continue
     _csc_contains_nul "$_f" && continue
+    _csc_is_valid_utf8 "$_f" || continue
     _raw="$(cat "$_f" 2>/dev/null)" || continue
     _val="$(_csc_strip_eol "$_raw")"
     if ! _csc_is_blank "$_val"; then
@@ -426,16 +511,25 @@ _csc_resolve_config_json() {
   _path="$(catalyst_secret_config_json_path "$_id")"
   _l2="$(catalyst_secret_resolve_layer2_path)"
   _tagged="$(_csc_read_json_string "$_l2" "$_path")"
+  # ACTOR ROW SHAPE FIX (Codex finding fix): accepts BOTH the "@STR64:" tag (a JSON string —
+  # the pre-existing groq-api-key/generic shape) AND the "@OBJ64:" tag (a JSON OBJECT — the
+  # catalyst.linear.bot.orchestrator/.worker shape, canonicalized+base64'd by
+  # _csc_read_json_string), mirroring lib/secret-contract.mjs's canonicalizeConfigJsonValue
+  # exactly: string-or-plain-object both resolve; array/boolean/number (@NONSTR) stay
+  # rejected. B2 FIX (empty-value guard, generalized): require the DECODED value to be
+  # non-empty — an empty string decodes to an empty string (falls through to "none", matching
+  # lib/secret-contract.mjs's `raw.length > 0`); an empty object decodes to the 2-byte
+  # canonical string "{}" (non-empty — DOES resolve, matching
+  # canonicalizeConfigJsonValue's "empty object still resolves" behavior).
   case "$_tagged" in
-    "@STR:"?*)
-      # B2 FIX: require at least one character after the tag — an empty extracted string
-      # ("@STR:" alone) falls through to the `*` branch below and classifies as absent.
-      # This mirrors lib/secret-contract.mjs's resolveConfigJson, which only accepts
-      # `raw.length > 0` (an empty config-json string is treated as "none", not a resolved
-      # empty-string secret). WITHOUT this guard, an empty JSON string value diverged from
-      # JS: this file reported source=config-json (with an empty value) while JS fell
-      # through to source=none.
-      _csc_set_result "${_tagged#@STR:}" "config-json" "$_delivery"
+    "@STR64:"*|"@OBJ64:"*)
+      local _decoded
+      _csc_b64_decode_var _decoded "${_tagged#@*:}"
+      if [[ -n "$_decoded" ]]; then
+        _csc_set_result "$_decoded" "config-json" "$_delivery"
+      else
+        _csc_set_result "" "none" "$_delivery"
+      fi
       ;;
     *)
       _csc_set_result "" "none" "$_delivery"
@@ -455,18 +549,44 @@ _csc_resolve_cloud_token_name() {
   else
     _l2="$(catalyst_secret_resolve_layer2_path)"
     _tagged="$(_csc_read_json_string "$_l2" "$_path")"
-    # B2 FIX: same "@STR:"?* non-empty guard as _csc_resolve_config_json — an empty
-    # Layer-2 NAME override must fall through to the default env-var name, matching
-    # lib/secret-contract.mjs's resolveCloudTokenName `l2Name.length > 0` check. Without
-    # this guard an empty tag left `_env_var` empty, and `_val="${!_env_var-}"` below would
-    # attempt an indirect expansion on an EMPTY variable name — a second "invalid variable
-    # name" fatal-abort class, the same failure shape as B1.
+    # B2 FIX: same non-empty guard as _csc_resolve_config_json — an empty Layer-2 NAME
+    # override must fall through to the default env-var name, matching
+    # lib/secret-contract.mjs's resolveCloudTokenName `l2Name.length > 0` check. STRICT
+    # STRING-ONLY BY DESIGN (unlike _csc_resolve_config_json): only the "@STR64:" tag is
+    # accepted here — an "@OBJ64:" (object-shaped) override is deliberately NOT
+    # canonicalized-and-used-as-a-name, mirroring lib/secret-contract.mjs's
+    # resolveCloudTokenName, which reads catalyst.cloud.tokenEnv via the SAME readJsonField
+    # call but applies its OWN `typeof l2Name === "string"` check (never routes through
+    # canonicalizeConfigJsonValue) — a NAME override can only ever be a plain
+    # env-var-name string, so an object there falls back to the default name on both sides.
     case "$_tagged" in
-      "@STR:"?*) _env_var="${_tagged#@STR:}" ;;
+      "@STR64:"*)
+        local _decoded
+        _csc_b64_decode_var _decoded "${_tagged#@STR64:}"
+        if [[ -n "$_decoded" ]]; then
+          _env_var="$_decoded"
+        else
+          _env_var="$(catalyst_secret_env_names "$_id" | head -n1)"
+        fi
+        ;;
       *) _env_var="$(catalyst_secret_env_names "$_id" | head -n1)" ;;
     esac
   fi
-  _val="${!_env_var-}"
+  # INVALID ENV NAME FIX (Codex finding fix): CATALYST_CLOUD_TOKEN_ENV / the Layer-2
+  # tokenEnv override is OPERATOR-CONTROLLED text, not registry data — a value like
+  # "BAD-NAME" (or anything else outside [A-Za-z_][A-Za-z0-9_]*) fed straight into
+  # `${!_env_var-}` FATALLY ABORTS the whole process with "invalid variable name" (verified;
+  # same failure CLASS as the B1/B3 fixes elsewhere in this file, at a call site those fixes
+  # didn't cover). lib/secret-contract.mjs's `env?.[envVar]` never crashes on any string —
+  # an invalid identifier there is simply a lookup that finds nothing. Validating BEFORE the
+  # indirect expansion makes an invalid override degrade to the documented unresolved result
+  # (source=none) identically on both sides, never an abort. The `[[ =~ ]]` test itself
+  # cannot trip errexit (a failed conditional in an `if`/`[[` context never does).
+  if [[ "$_env_var" =~ ^[A-Za-z_][A-Za-z0-9_]*$ ]]; then
+    _val="${!_env_var-}"
+  else
+    _val=""
+  fi
   if [[ -n "$_val" ]]; then
     _csc_set_result "$_val" "platform-env" "$_delivery"
   else
@@ -556,7 +676,22 @@ catalyst_resolve_secret() {
         fi
       fi
     fi
-    _csc_resolve_env_alias_only "$_id"
+    # PLATFORM-ENV NAME OVERRIDE FIX (Codex finding fix): a bare _csc_resolve_env_alias_only
+    # here only ever checks the row's static env-name list — for cloud-token that is JUST
+    # the hardcoded default "CATALYST_CLOUD_TOKEN" — so an operator-configured
+    # CATALYST_CLOUD_TOKEN_ENV or Layer-2 catalyst.cloud.tokenEnv override was silently
+    # ignored the moment genuine cloud mode activated, even though that SAME override IS
+    # honored one level up (the bootstrap check above recurses via `catalyst_resolve_secret
+    # "$_bid"` with NO deployment-mode args, which falls through to the normal case
+    # dispatch below → _csc_resolve_cloud_token_name). Dispatching platform-env rows through
+    # _csc_resolve_cloud_token_name here too — the SAME function, not a second copy — closes
+    # that gap identically to the JS-side fix (lib/secret-contract.mjs resolveSecret's cloud
+    # branch). Every other cloud-mode row still collapses to its plain env-alias chain.
+    if [[ "$_delivery" == "platform-env" ]]; then
+      _csc_resolve_cloud_token_name "$_id"
+    else
+      _csc_resolve_env_alias_only "$_id"
+    fi
     return 0
   fi
 
@@ -616,9 +751,13 @@ catalyst_secret_reset_arm_state() {
   fi
 }
 
-# catalyst_arm_secret ID — echoes "armed|rotated|restartRequired" (each true|false) AND
-# exports the same three fields as CATALYST_SECRET_ARM_ARMED / _ROTATED / _RESTART_REQUIRED,
-# mirroring armSecret's { armed, rotated, restartRequired } shape.
+# catalyst_arm_secret ID [DEPLOYMENT_MODE] [INFERRED(true|false)] — echoes
+# "armed|rotated|restartRequired" (each true|false) AND exports the same three fields as
+# CATALYST_SECRET_ARM_ARMED / _ROTATED / _RESTART_REQUIRED, mirroring armSecret's { armed,
+# rotated, restartRequired } shape. DEPLOYMENT_MODE/INFERRED are the SAME optional
+# positional args catalyst_resolve_secret takes, threaded straight through (Codex finding
+# fix, design §8) — see the DEPLOYMENT-MODE THREADING FIX comment below for the concrete
+# bug this closes; a caller that never passes them gets EXACTLY today's non-cloud behavior.
 #
 # MUST BE CALLED DIRECTLY, NEVER WRAPPED IN $(...), by any caller that needs the persistent
 # baseline to survive across repeated calls in the same shell — this is the SAME
@@ -631,7 +770,7 @@ catalyst_secret_reset_arm_state() {
 # read the exported vars, or capture stdout via `out="$(catalyst_arm_secret id)"` ONLY when
 # the caller genuinely wants a one-shot, state-discarding check.
 catalyst_arm_secret() {
-  local _id="$1" _rotation_class=""
+  local _id="$1" _dep_mode="${2:-}" _dep_inferred="${3:-true}" _rotation_class=""
   # B4 FIX (errexit safety): the assignment runs in an `if` condition — mirrors the
   # ERREXIT SAFETY pattern on _csc_read_json_string above. catalyst_secret_rotation_class
   # returns rc=1 (printing nothing) for an unknown id; a bare
@@ -656,8 +795,16 @@ catalyst_arm_secret() {
   # contract exists to report). Call resolve directly (no $() — resolve never
   # touches the arm arrays, so there is no subshell-state hazard) and read the
   # CATALYST_SECRET_LAST_VALUE breadcrumb it exports in-shell.
+  #
+  # DEPLOYMENT-MODE THREADING FIX (Codex finding fix, design §8): _dep_mode/_dep_inferred
+  # MUST be forwarded here — omitting them used to make the arm baseline resolve through the
+  # non-cloud file/config chain even when the CALLER is genuinely in cloud mode, while a
+  # sibling direct `catalyst_resolve_secret id cloud false` call correctly resolved via the
+  # cloud-only env-alias chain. In a cloud process with an injected token AND a stale local
+  # file, that mismatch made a stale-file edit falsely report restartRequired while a REAL
+  # token rotation went unnoticed — mirrors lib/secret-contract.mjs's armSecret fix exactly.
   local _current _idx
-  catalyst_resolve_secret "$_id" >/dev/null
+  catalyst_resolve_secret "$_id" "$_dep_mode" "$_dep_inferred" >/dev/null
   _current="${CATALYST_SECRET_LAST_VALUE-}"
   if _idx="$(_csc_arm_index_of "$_id")"; then
     local _previous="${_CSC_ARM_VALUES[$_idx]}"

--- a/plugins/dev/scripts/lib/secret-contract.d.mts
+++ b/plugins/dev/scripts/lib/secret-contract.d.mts
@@ -1,0 +1,92 @@
+// Types for secret-contract.mjs (CTL-1616) — the runtime stays .mjs so the
+// broker/execution-core .mjs daemons (and doctor.mjs's bare-Node import) import it
+// unchanged; this gives TS consumers (orch-monitor) proper types. Mirrors the
+// deployment-mode.d.mts convention (hand-written companion, no build step).
+
+export type SecretDelivery =
+  | "bare-file"
+  | "bare-file-family"
+  | "env-file"
+  | "env-alias"
+  | "config-json"
+  | "platform-env"
+  | "local-only";
+
+export type RotationClass = "boot-only" | "re-armable" | "n/a";
+export type RotationTrigger = "timer" | "on-401";
+
+export interface SecretRotation {
+  class: RotationClass;
+  /** present only when class === "re-armable" */
+  trigger?: RotationTrigger;
+}
+
+export interface SecretRow {
+  id: string;
+  envNames: readonly string[];
+  delivery: SecretDelivery;
+  configJsonPath: string | null;
+  rotation: SecretRotation;
+  /** the deployment mode this row bootstraps ("cluster" | "cloud"), or null */
+  bootstrapFor: "cluster" | "cloud" | null;
+  /** present only on the linear-webhook-secret family row */
+  familyPrefix?: string;
+  /** present only on the age-key local-only row, relative to HOME */
+  defaultLocalPath?: readonly string[];
+}
+
+export const SECRET_DELIVERY: readonly SecretDelivery[];
+export const ROTATION_CLASSES: readonly RotationClass[];
+export const ROTATION_TRIGGERS: readonly RotationTrigger[];
+export const SECRET_REGISTRY: readonly SecretRow[];
+
+export function getSecretRow(id: string): SecretRow | undefined;
+export function isSecretFamilyMember(filename: string): boolean;
+export function resolveLayer2Path(env?: Record<string, string | undefined>): string;
+export function explicitFileOverrideEnvName(id: string): string;
+export function secretFileCandidates(id: string, env?: Record<string, string | undefined>): string[];
+
+/** The subset of CTL-1617's resolveDeploymentMode() output this engine consumes. */
+export interface DeploymentModeInput {
+  mode: "single-host" | "cluster" | "cloud";
+  inferred: boolean;
+  source?: string;
+  recognized?: boolean;
+}
+
+export interface ResolveSecretOptions {
+  env?: Record<string, string | undefined>;
+  deploymentMode?: DeploymentModeInput;
+}
+
+export interface ResolvedSecret {
+  value: string | null;
+  source: string | null;
+  provider: SecretDelivery | null;
+  rotation: SecretRotation | null;
+  [extra: string]: unknown;
+}
+
+export function resolveSecret(id: string, opts?: ResolveSecretOptions): ResolvedSecret;
+
+export interface RearmHookResult {
+  rearmed: boolean;
+  reason?: string;
+}
+export type RearmHook = (opts: { env: Record<string, string | undefined> }) => RearmHookResult;
+
+export function registerRearmHook(id: string, fn: RearmHook): boolean;
+export function clearRearmHook(id: string): boolean;
+export function resetArmState(id?: string): void;
+
+export interface ArmSecretOptions {
+  env?: Record<string, string | undefined>;
+}
+
+export interface ArmedSecret {
+  armed: boolean;
+  rotated: boolean;
+  restartRequired: boolean;
+}
+
+export function armSecret(id: string, opts?: ArmSecretOptions): ArmedSecret;

--- a/plugins/dev/scripts/lib/secret-contract.mjs
+++ b/plugins/dev/scripts/lib/secret-contract.mjs
@@ -1,0 +1,661 @@
+// secret-contract.mjs — CTL-1616: the canonical secret registry + resolution engine.
+//
+// WHY THIS FILE EXISTS. The 2026-08-02 fleet 401 outage was four divergent hand-written
+// copies of one secret-resolution chain (CTL-1612 fixed the github-token/webhook-secret
+// instance). Every OTHER secret in the fleet inventory is still the pre-CTL-1612 failure
+// class today: 9 files/12 sites hand-roll `LINEAR_API_TOKEN ?? LINEAR_API_KEY`, 3 divergent
+// Linear OAuth-mint Layer-2 fallback chains, 2 divergent CATALYST_CLOUD_TOKEN name
+// resolvers, 2 divergent GROQ_API_KEY ladders, 6 divergent Layer-2-path resolvers. This
+// module is the ONE named secret contract every one of those call sites will eventually
+// fold onto: a frozen registry of per-secret FACTS (§2 of the design), walked by a small
+// closed provider-type ENGINE (~7 delivery-type cases whose bash/JS parity cost is fixed,
+// not per-secret).
+//
+// THIS PR IS THE FIRST ISOLATION SLICE — ZERO CONSUMERS. Nothing outside this file's own
+// tests imports it yet. cluster-sync.mjs's ENV_BACKED_SECRET_EXACT/isEnvBackedSecretFile,
+// catalyst-secret-env.sh's catalyst_project_github_token/_webhook_secret, and
+// github-auth-preflight.mjs's githubTokenFileCandidates/rearmGithubTokenFromFile are ALL
+// left untouched here — re-pointing them onto this registry is later-PR work (CTL-1616
+// design §9, PR1 proper). This file exists in isolation, exactly the way
+// lib/deployment-mode.mjs (CTL-1617 PR1) landed before any consumer moved onto it.
+//
+// REGISTRY IS CODE, NOT JSON (design §2, judge-mandated). A runtime-jq-parsed
+// secret-contract.json on the boot-critical path would convert six independently-divergent
+// resolution chains into one CORRELATED single point of failure, and would reimport the
+// bash-JSON fragility class the CTL-1617 parity work spent an entire remediation round
+// documenting (a bare `// empty` swallows JSON `false`; NUL bytes die at the $() boundary;
+// [[:space:]] is locale data; multi-document/BOM files parse differently per language).
+// SECRET_REGISTRY is a frozen in-module data constant that both this file's engine AND
+// lib/catalyst-secret-contract.sh's independently-maintained bash mirror encode — two
+// physical copies, one logical source, held honest by the row-id-set-equality assertion in
+// __tests__/secret-contract-parity.test.sh.
+//
+// ZERO-IMPORT LEAF (node:fs / node:os / node:path only) — same rationale as
+// lib/deployment-mode.mjs: doctor.mjs runs under bare Node and must import this without
+// pulling execution-core/config.mjs's bun:sqlite-reaching module graph. This also means the
+// real rearm/mint IMPLEMENTATIONS (rearmGithubTokenFromFile, the linear-remint.mjs
+// reminters) can never be baked into this leaf's static row data — they are registered
+// AGAINST rows from execution-core, in a later PR, via registerRearmHook() below (design §3:
+// "the mint action and rearm hooks stay in their execution-core homes ... and are registered
+// against rows"). See the "REARM-HOOK SEAM" comment on registerRearmHook for how PR1 proves
+// that seam works before any real hook exists.
+//
+// NAMING RULE, mirrored from lib/deployment-mode.mjs: every WARN/log/comment in this file
+// says "deployment mode" fully qualified where it discusses CTL-1617's resolution object —
+// never bare "mode" (this codebase already has 3 unrelated "mode" concepts).
+
+import { existsSync, readFileSync, statSync } from "node:fs";
+import { homedir } from "node:os";
+import { dirname, join, resolve as resolvePath } from "node:path";
+
+// ─── The closed enums ───────────────────────────────────────────────────────
+
+// SECRET_DELIVERY — the ~7 provider TYPES the engine dispatches on. Design §3's own stated
+// goal is that parity cost scales per TYPE, not per row — every one of the 11 seed rows maps
+// onto exactly one of these.
+export const SECRET_DELIVERY = Object.freeze([
+  "bare-file", // a single standalone secret file (github-token, webhook-secret)
+  "bare-file-family", // an open-ended prefix family of files (linear-webhook-secret-<team>)
+  "env-file", // a whole env file SOURCED at boot, not a scalar value (claude-accounts.env)
+  "env-alias", // a pure process.env alias ladder, no file at all (linear-api-token)
+  "config-json", // env alias (if any) then a dotted path inside the resolved Layer-2 JSON
+  "platform-env", // a platform-injected env var whose NAME is itself resolved (cloud-token)
+  "local-only", // presence-checked only, value never fetched (age-key)
+]);
+
+// ROTATION_CLASSES — generalizes cluster-sync.mjs's "CAPTURED AT PROCESS START" prose
+// (design §6) into structured data. "n/a" exists only for local-only rows: age-key is never
+// value-resolved, so "rotated" is not a question this contract can answer for it (doctor's
+// assessMaterialization owns that signal instead — design §5/§7).
+export const ROTATION_CLASSES = Object.freeze(["boot-only", "re-armable", "n/a"]);
+export const ROTATION_TRIGGERS = Object.freeze(["timer", "on-401"]);
+
+// ─── The registry ────────────────────────────────────────────────────────────
+//
+// Row shape (design §2): { id, envNames, delivery, configJsonPath, rotation, bootstrapFor }.
+// `id` doubles as the SOPS bare-file basename for bare-file/bare-file-family/env-file rows.
+// `familyPrefix` is present only on the one bare-file-family row. `defaultLocalPath` is
+// present only on the one local-only row. All rows and the registry array itself are frozen
+// — this is DATA, walked by the engine below, never mutated at runtime. (Per-row `rearmHook`
+// state — which design §2's row-shape example shows as a field on the row — lives instead in
+// the separate, explicitly-mutable `_rearmHooks` side table below the engine: a frozen row
+// cannot itself hold a hook a later PR registers. See registerRearmHook's docstring.)
+export const SECRET_REGISTRY = Object.freeze(
+  [
+    {
+      id: "github-token",
+      envNames: ["GH_TOKEN", "GITHUB_TOKEN"],
+      delivery: "bare-file",
+      configJsonPath: null,
+      rotation: { class: "re-armable", trigger: "timer" },
+      bootstrapFor: null,
+    },
+    {
+      id: "webhook-secret",
+      envNames: ["CATALYST_WEBHOOK_SECRET"],
+      delivery: "bare-file",
+      configJsonPath: null,
+      // Boot-only per design §2: orch-monitor's loadWebhookConfig() captures this once at
+      // boot (catalyst-secret-env.sh:226-230's own comment). Open Question 5 (design §12)
+      // asks whether this should upgrade to timer-re-armable in a follow-up — left boot-only
+      // here, matching the seed table.
+      rotation: { class: "boot-only" },
+      bootstrapFor: null,
+    },
+    {
+      id: "linear-webhook-secret",
+      envNames: [],
+      delivery: "bare-file-family",
+      // The per-team secrets are an open-ended FAMILY, not fixed names — absorbed from
+      // cluster-sync.mjs's LINEAR_WEBHOOK_SECRET_PREFIX (":644") and isEnvBackedSecretFile
+      // (":648-655"). Matched case-insensitively, requiring at least one character after the
+      // dash, so the bare prefix "linear-webhook-secret-" and a run-on like
+      // "linear-webhook-secretXXX" both stay OUT — see isSecretFamilyMember below, which
+      // mirrors that predicate exactly (not wired to cluster-sync in THIS PR).
+      familyPrefix: "linear-webhook-secret-",
+      configJsonPath: null,
+      rotation: { class: "boot-only" },
+      bootstrapFor: null,
+    },
+    {
+      id: "claude-accounts.env",
+      envNames: [],
+      delivery: "env-file",
+      configJsonPath: null,
+      // Sourced into the daemon's boot env by catalyst-execution-core; kept as a REGISTRY
+      // ROW (design §2) — not a parallel hand-maintained Set — so cluster-sync's
+      // rotation-report source is the registry once PR1-of-the-migration-plan re-points it.
+      rotation: { class: "boot-only" },
+      bootstrapFor: null,
+    },
+    {
+      id: "execution-core.env",
+      envNames: [],
+      delivery: "env-file",
+      configJsonPath: null,
+      rotation: { class: "boot-only" },
+      bootstrapFor: null,
+    },
+    {
+      id: "linear-api-token",
+      envNames: ["LINEAR_API_TOKEN", "LINEAR_API_KEY"],
+      delivery: "env-alias",
+      configJsonPath: null,
+      // Folds the 9-file/12-site inline `LINEAR_API_TOKEN ?? LINEAR_API_KEY` read (design §8
+      // PR3) — including the CTL-1619 alias-drop regression at linear-reconcile-cli.mjs:209.
+      // Re-armable/on-401: a cooldown-guarded reminter, once registered (design PR4's
+      // linear-remint.mjs), re-mints on an observed 401 — reactive, not a timer.
+      rotation: { class: "re-armable", trigger: "on-401" },
+      bootstrapFor: null,
+    },
+    {
+      id: "linear-orchestrator-actor",
+      envNames: [],
+      delivery: "config-json",
+      configJsonPath: "catalyst.linear.bot.orchestrator",
+      // Deliberately a SEPARATE row from linear-worker-actor (judge-unanimous graft, design
+      // §2) — they mint identically and differ only in this config path; collapsing them is
+      // an easy wrong refactor a future PR must not make.
+      rotation: { class: "re-armable", trigger: "on-401" },
+      bootstrapFor: null,
+    },
+    {
+      id: "linear-worker-actor",
+      envNames: [],
+      delivery: "config-json",
+      // Primary tier only. linear-comment-post.sh's 3-tier chain (bot.worker → legacy
+      // catalyst.linear.agent → legacy per-team) is preserved VERBATIM in its own file per
+      // design §8 PR4 — this row's single configJsonPath is the primary tier; the legacy
+      // tiers are a PR4 concern, not duplicated here (design explicitly defers their
+      // deprecation to a follow-up ticket, design §6/§12 Q6).
+      configJsonPath: "catalyst.linear.bot.worker",
+      // Boot-only (per-call mint) per the seed table — distinct from the orchestrator actor,
+      // which is proactively re-armed on a timer-adjacent cooldown reminter.
+      rotation: { class: "boot-only" },
+      bootstrapFor: null,
+    },
+    {
+      id: "groq-api-key",
+      envNames: ["GROQ_API_KEY"],
+      delivery: "config-json",
+      // Provider modeled on lib/api-key-health.mjs's resolveApiKey (env → config), the one
+      // already-adopted ladder (broker/config.mjs:45-53) — config-json's generic
+      // env-alias-then-json-path chain covers this without a dedicated 8th delivery type.
+      configJsonPath: "groq.apiKey",
+      rotation: { class: "boot-only" },
+      bootstrapFor: null,
+    },
+    {
+      id: "cloud-token",
+      // The DEFAULT env-var name only — the actual var name is itself resolved (see
+      // resolveCloudTokenName below), mirroring resolveNodeCloudTokenEnv's 3-tier ladder
+      // (execution-core/config.mjs:1949-1957): env override → Layer-2 name override →
+      // this default.
+      envNames: ["CATALYST_CLOUD_TOKEN"],
+      delivery: "platform-env",
+      // Holds the NAME-OVERRIDE dotted path (catalyst.cloud.tokenEnv), not the secret value.
+      configJsonPath: "catalyst.cloud.tokenEnv",
+      rotation: { class: "boot-only" },
+      bootstrapFor: "cloud",
+    },
+    {
+      id: "age-key",
+      // SOPS_AGE_KEY_FILE is the threaded override (cluster-sync.mjs:140); the row's
+      // envNames holds that override name so resolveLocalOnlyPresence can honor it uniformly
+      // with every other row's env-override convention, WITHOUT ever reading the file's
+      // contents through it — see resolveLocalOnlyPresence.
+      envNames: ["SOPS_AGE_KEY_FILE"],
+      delivery: "local-only",
+      configJsonPath: null,
+      defaultLocalPath: [".config", "catalyst", "age.key"],
+      // "n/a", not boot-only: this contract never fetches the KEY VALUE at all (presence-only
+      // — the never-fetched local-only contract), so "did it rotate" is not a question this
+      // engine can answer for it. assessMaterialization (cluster-sync.mjs:686) remains the
+      // authoritative decrypt-health signal (design §5/§7 risk 5).
+      rotation: { class: "n/a" },
+      bootstrapFor: "cluster",
+    },
+  ].map((row) => Object.freeze(row)),
+);
+
+// getSecretRow — the id → row lookup every engine function starts from. Returns undefined
+// for an unknown id (never throws).
+export function getSecretRow(id) {
+  return SECRET_REGISTRY.find((r) => r.id === id);
+}
+
+// isSecretFamilyMember — the linear-webhook-secret family PREDICATE, absorbed verbatim from
+// cluster-sync.mjs's isEnvBackedSecretFile/LINEAR_WEBHOOK_SECRET_PREFIX (":644-655") — NOT
+// wired to cluster-sync in this PR (that re-point is later-migration-plan work), but the
+// predicate itself is reproduced exactly so a later PR's before/after parity assertion
+// (design §2's "same-commit derivation constraint") has a byte-for-byte reference to diff
+// against. Case-insensitive on the whole filename; requires at least one character after the
+// dash so the bare prefix "linear-webhook-secret-" and a run-on "linear-webhook-secretXXX"
+// both stay OUT.
+export function isSecretFamilyMember(filename) {
+  if (typeof filename !== "string" || filename.length === 0) return false;
+  const row = getSecretRow("linear-webhook-secret");
+  const prefix = row?.familyPrefix ?? "linear-webhook-secret-";
+  const name = filename.toLowerCase();
+  return name.startsWith(prefix) && name.length > prefix.length;
+}
+
+// ─── Layer-2 path resolution — the §2 canonical chain ───────────────────────
+//
+// DELIBERATELY NOT lib/deployment-mode.mjs's resolveLayer2Path (design §2 flaw-resolution
+// paragraph, verified): that function deliberately mirrors execution-core/config.mjs's
+// non-XDG-aware getLayer2ConfigPath. This chain is the OTHER one — the one
+// install-lifecycle.mjs's layer2Path(), lib/linear-app-actor.sh:30, linear-remint.mjs:43-51,
+// and lib/plugin-dirs.sh:25 already use:
+//   CATALYST_LAYER2_CONFIG_FILE > CATALYST_MACHINE_CONFIG > $XDG_CONFIG_HOME/catalyst/config.json
+//   > ~/.config/catalyst/config.json
+// Fully env-injectable (no direct process.env/homedir() reads outside the `env` param), so
+// tests can redirect every input without touching the real filesystem — same isolation
+// contract as githubTokenFileCandidates(env).
+export function resolveLayer2Path(env = process.env) {
+  const explicit = env?.CATALYST_LAYER2_CONFIG_FILE;
+  if (typeof explicit === "string" && explicit.length > 0) return explicit;
+  const machineConfig = env?.CATALYST_MACHINE_CONFIG;
+  if (typeof machineConfig === "string" && machineConfig.length > 0) return machineConfig;
+  const home = typeof env?.HOME === "string" && env.HOME.length > 0 ? env.HOME : homedir();
+  const xdg = typeof env?.XDG_CONFIG_HOME === "string" && env.XDG_CONFIG_HOME.length > 0 ? env.XDG_CONFIG_HOME : join(home, ".config");
+  return join(xdg, "catalyst", "config.json");
+}
+
+// readJsonField — pull a dotted-path value out of a JSON file EXACTLY as written (whatever
+// JSON type), or undefined for absent/malformed/unreadable/null (the readLayer2NodeClass
+// contract, deployment-mode.mjs's identical convention). PARITY GUARD: a STRING value
+// carrying an embedded NUL escape (e.g. `"c\u0000loud"` — valid JSON, jq accepts it fine
+// too) is treated as undefined here — NOT because JSON.parse can't hold it (it can, the
+// full string round-trips through readFileSync/JSON.parse intact), but because both callers
+// of this function (resolveConfigJson, resolveCloudTokenName) return that value through this
+// module's own resolveSecret/probe boundary via `printf`/console output in the bash mirror
+// and this file's own test/parity harnesses, which — like every `$(...)` command
+// substitution in bash — silently DROP a NUL byte on capture (verified: bash prints "ignored
+// null byte in input" and truncates). Without this guard, this file would return the FULL
+// NUL-containing string as a "resolved" value while the bash mirror's
+// _csc_read_json_string tags the identical input @NONSTR — a real parity divergence, caught
+// by __tests__/secret-contract-parity.test.sh's hostile NUL-escape-in-JSON-string probe.
+// Rejecting it HERE (not just at the transport boundary) means a NUL-containing config-json
+// value degrades to "not found" identically in both languages, exactly like a non-string
+// value already does. Reuses the same containsNul() helper readFirstNonBlankFile uses
+// below (function declarations hoist, so the later definition is available here) rather
+// than a second copy.
+function readJsonField(filePath, dottedPath) {
+  if (!dottedPath) return undefined;
+  try {
+    const doc = JSON.parse(readFileSync(filePath, "utf8"));
+    let cur = doc;
+    for (const part of dottedPath.split(".")) {
+      if (cur == null || typeof cur !== "object") return undefined;
+      cur = cur[part];
+    }
+    if (typeof cur === "string" && containsNul(cur)) return undefined;
+    return cur;
+  } catch {
+    return undefined;
+  }
+}
+
+// ─── Bare-file candidate search — generalizes githubTokenFileCandidates ─────
+
+// explicitFileOverrideEnvName — the per-row explicit-override env var, e.g. "github-token" →
+// CATALYST_GITHUB_TOKEN_FILE (matching the existing CATALYST_GITHUB_TOKEN_FILE /
+// CATALYST_WEBHOOK_SECRET_FILE convention exactly).
+export function explicitFileOverrideEnvName(id) {
+  return `CATALYST_${id.toUpperCase().replace(/[^A-Z0-9]+/g, "_")}_FILE`;
+}
+
+// secretFileCandidates(id, env) — the resolution CHAIN, in priority order, generalizing
+// execution-core/github-auth-preflight.mjs's githubTokenFileCandidates (":84-99") to any
+// bare-file row's basename. Explicit override → CATALYST_CONFIG_DIR → cluster-sync's own
+// destination dir (dirname(resolveLayer2Path)) → XDG dir. Never throws.
+export function secretFileCandidates(id, env = process.env) {
+  const override = env?.[explicitFileOverrideEnvName(id)];
+  if (typeof override === "string" && override.length > 0) return [override];
+  if (typeof env?.CATALYST_CONFIG_DIR === "string" && env.CATALYST_CONFIG_DIR.length > 0) {
+    return [join(env.CATALYST_CONFIG_DIR, id)];
+  }
+  const home = typeof env?.HOME === "string" && env.HOME.length > 0 ? env.HOME : homedir();
+  const layer2 = typeof env?.CATALYST_LAYER2_CONFIG_FILE === "string" && env.CATALYST_LAYER2_CONFIG_FILE.length > 0
+    ? env.CATALYST_LAYER2_CONFIG_FILE
+    : join(home, ".config", "catalyst", "config.json");
+  const out = [join(dirname(layer2), id)];
+  const xdgBase = typeof env?.XDG_CONFIG_HOME === "string" && env.XDG_CONFIG_HOME.length > 0 ? env.XDG_CONFIG_HOME : join(home, ".config");
+  const xdg = join(xdgBase, "catalyst", id);
+  if (!out.includes(xdg)) out.push(xdg);
+  return out;
+}
+
+// stripEol — mirrors _catalyst_strip_eol (lib/catalyst-secret-env.sh) and the identical
+// regex in github-auth-preflight.mjs's rearmGithubTokenFromFile: strip ONLY trailing line
+// terminators, preserve every other byte (a signing secret may legitimately begin/end with a
+// significant space).
+function stripEol(raw) {
+  return String(raw ?? "").replace(/[\r\n]+$/, "");
+}
+
+function isBlank(value) {
+  return value.replace(/[ \t\n\r\f\v]/g, "").length === 0;
+}
+
+// containsNul — PARITY GUARD (CTL-1617 hard-won lesson, generalized from JSON to raw file
+// bytes): a bash `$(cat "$file")` command substitution silently TRUNCATES at the first NUL
+// byte — bash variables cannot represent one. readFileSync has no such limitation and would
+// see the full value, including the embedded NUL, which JS would then treat as a genuine
+// (if odd) credential while bash would see only a truncated PREFIX and treat THAT as the
+// credential — two different values for the same file. Reject any candidate carrying a NUL
+// on BOTH sides (this file, and the bash mirror's analogous file-candidate loop) so a
+// NUL-containing file falls through to the next candidate identically everywhere, rather
+// than silently disagreeing on the resolved value.
+function containsNul(value) {
+  return value.includes("\u0000");
+}
+
+function readFirstNonBlankFile(candidates) {
+  for (const file of candidates) {
+    let raw;
+    try {
+      raw = readFileSync(file, "utf8");
+    } catch {
+      continue;
+    }
+    if (containsNul(raw)) continue;
+    const val = stripEol(raw);
+    if (!isBlank(val)) return { value: val, filePath: file };
+  }
+  return null;
+}
+
+// ─── Per-delivery-type resolvers (the ~7 engine cases, §3) ──────────────────
+
+function resolveEnvAliasOnly(row, env) {
+  for (const name of row.envNames ?? []) {
+    const v = env?.[name];
+    if (typeof v === "string" && v.length > 0) {
+      return { value: v, source: "inherited", provider: row.delivery, rotation: row.rotation, envName: name };
+    }
+  }
+  return { value: null, source: "none", provider: row.delivery, rotation: row.rotation };
+}
+
+function resolveBareFile(row, env) {
+  const candidates = secretFileCandidates(row.id, env);
+  const explicitOverride = env?.[explicitFileOverrideEnvName(row.id)];
+  const hit = readFirstNonBlankFile(candidates);
+  if (hit) {
+    const source = typeof explicitOverride === "string" && explicitOverride.length > 0 ? "operator-override" : "shared-file";
+    return { value: hit.value, source, provider: row.delivery, rotation: row.rotation, filePath: hit.filePath };
+  }
+  // No shared file anywhere — fall back to whatever alias is already inherited (matches
+  // catalyst_project_github_token's "elif GH_TOKEN inherited" rung).
+  const inherited = resolveEnvAliasOnly(row, env);
+  if (inherited.value != null) return inherited;
+  return { value: null, source: "none", provider: row.delivery, rotation: row.rotation };
+}
+
+function resolveBareFileFamily(row) {
+  // A family row has no single scalar value (design §2's own framing: it is a PREDICATE,
+  // not a resolvable secret). Callers that need per-team membership use
+  // isSecretFamilyMember(filename) directly.
+  return { value: null, source: null, provider: row.delivery, rotation: row.rotation };
+}
+
+function resolveEnvFilePresence(row, env) {
+  const candidates = secretFileCandidates(row.id, env);
+  for (const file of candidates) {
+    try {
+      const st = statSync(file);
+      if (st.isFile() && st.size > 0) {
+        return { value: file, source: "shared-file", provider: row.delivery, rotation: row.rotation };
+      }
+    } catch {
+      continue;
+    }
+  }
+  return { value: null, source: "none", provider: row.delivery, rotation: row.rotation };
+}
+
+function resolveConfigJson(row, env) {
+  if ((row.envNames ?? []).length > 0) {
+    const viaEnv = resolveEnvAliasOnly(row, env);
+    if (viaEnv.value != null) return viaEnv;
+  }
+  const path = resolveLayer2Path(env);
+  const raw = readJsonField(path, row.configJsonPath);
+  if (typeof raw === "string" && raw.length > 0) {
+    return { value: raw, source: "config-json", provider: row.delivery, rotation: row.rotation, filePath: path };
+  }
+  return { value: null, source: "none", provider: row.delivery, rotation: row.rotation };
+}
+
+// resolveCloudTokenName — cloud-token's two-step resolution: first the env-var NAME (env
+// override → Layer-2 catalyst.cloud.tokenEnv → default CATALYST_CLOUD_TOKEN, mirroring
+// resolveNodeCloudTokenEnv, execution-core/config.mjs:1949-1957), THEN that variable's
+// VALUE. Mode-independent: cloud-token is always platform-env delivery regardless of
+// deployment mode, so this never touches a file.
+function resolveCloudTokenName(row, env) {
+  const nameOverride = env?.CATALYST_CLOUD_TOKEN_ENV;
+  let envVar, envVarSource;
+  if (typeof nameOverride === "string" && nameOverride.length > 0) {
+    envVar = nameOverride;
+    envVarSource = "env";
+  } else {
+    const l2Path = resolveLayer2Path(env);
+    const l2Name = readJsonField(l2Path, row.configJsonPath);
+    if (typeof l2Name === "string" && l2Name.length > 0) {
+      envVar = l2Name;
+      envVarSource = "layer2";
+    } else {
+      envVar = row.envNames[0];
+      envVarSource = "default";
+    }
+  }
+  const value = env?.[envVar];
+  if (typeof value === "string" && value.length > 0) {
+    return { value, source: "platform-env", provider: row.delivery, rotation: row.rotation, envVar, envVarSource };
+  }
+  return { value: null, source: "none", provider: row.delivery, rotation: row.rotation, envVar, envVarSource };
+}
+
+// resolveLocalOnlyPresence — age-key. PRESENCE-CHECKED, NEVER VALUE-RESOLVED (design §5's
+// "never-fetched local-only contract" — fetching it here would be circular: the key that
+// unlocks every other cluster secret cannot itself be delivered by the chain it unlocks).
+// Uses statSync only — this function must never call readFileSync on the candidate path.
+function resolveLocalOnlyPresence(row, env) {
+  const override = env?.[row.envNames?.[0]];
+  const home = typeof env?.HOME === "string" && env.HOME.length > 0 ? env.HOME : homedir();
+  const path = typeof override === "string" && override.length > 0 ? override : resolvePath(home, ...(row.defaultLocalPath ?? []));
+  let present = false;
+  try {
+    present = existsSync(path) && statSync(path).isFile();
+  } catch {
+    present = false;
+  }
+  return {
+    value: present ? path : null,
+    source: present ? "present" : "absent",
+    provider: row.delivery,
+    rotation: row.rotation,
+  };
+}
+
+// ─── The public engine ───────────────────────────────────────────────────────
+
+// resolveSecret(id, { env, deploymentMode }) — never throws (deployment-mode contract,
+// design §3). Returns { value, source, provider, rotation, ...delivery-type-specific extras
+// } for a known row, or { value: null, source: null, provider: null, rotation: null } for an
+// unknown id.
+//
+// CLOUD GUARD (design §4): the cloud branch activates ONLY when
+// deploymentMode.mode === "cloud" AND deploymentMode.inferred === false — never on a guess.
+// Because the guard lives HERE in the shared engine, every row gets it for free; no
+// per-secret guard to forget (mirrors the CTL-1617 §8 mandate this registry consumes). When
+// genuinely cloud, resolution short-circuits to a pure env-alias read of envNames — NO FILE
+// SEARCH EVER, matching CTL-1617 §4's "a slot, honestly scoped" cloud provider. When NOT
+// genuinely cloud (single-host, cluster, or an inferred/unrecognized cloud guess), the normal
+// per-delivery-type file/config chain runs — this is the "never skips the file chain for
+// single-host/cluster" invariant design §4/§9 mandates as an explicit test assertion.
+//
+// BOOTSTRAP SHORT-CIRCUIT (design §4 rule 2): in genuine cloud mode, if the cloud
+// bootstrap-class row (cloud-token, bootstrapFor: "cloud") fails to resolve, every OTHER
+// cloud-mode resolution returns { value: null, source: null } without probing further — a
+// half-provisioned managed container fails loudly and coherently. The bootstrap row itself
+// is exempt (it must resolve on its own terms) and resolveCloudTokenName never triggers this
+// check (recursion terminates in one level: cloud-token's own resolution never consults
+// `deploymentMode`).
+export function resolveSecret(id, { env = process.env, deploymentMode } = {}) {
+  const row = getSecretRow(id);
+  if (!row) return { value: null, source: null, provider: null, rotation: null };
+
+  const useCloud = deploymentMode?.mode === "cloud" && deploymentMode?.inferred === false;
+
+  if (useCloud) {
+    if (row.bootstrapFor !== "cloud") {
+      const bootstrapRow = SECRET_REGISTRY.find((r) => r.bootstrapFor === "cloud");
+      if (bootstrapRow) {
+        const bootstrapResolved = resolveSecret(bootstrapRow.id, { env });
+        if (bootstrapResolved.value == null) {
+          return { value: null, source: null, provider: row.delivery, rotation: row.rotation };
+        }
+      }
+    }
+    return resolveEnvAliasOnly(row, env);
+  }
+
+  switch (row.delivery) {
+    case "bare-file":
+      return resolveBareFile(row, env);
+    case "bare-file-family":
+      return resolveBareFileFamily(row);
+    case "env-file":
+      return resolveEnvFilePresence(row, env);
+    case "env-alias":
+      return resolveEnvAliasOnly(row, env);
+    case "config-json":
+      return resolveConfigJson(row, env);
+    case "platform-env":
+      return resolveCloudTokenName(row, env);
+    case "local-only":
+      return resolveLocalOnlyPresence(row, env);
+    default:
+      // Unreachable for any row in SECRET_REGISTRY — defensive, never throws.
+      return { value: null, source: null, provider: row.delivery, rotation: row.rotation };
+  }
+}
+
+// ─── Rearm-hook seam + armSecret ─────────────────────────────────────────────
+//
+// REARM-HOOK SEAM (design §3/§6, Open Question 4). The row shape's `rearmHook` field in
+// design §2's pseudocode cannot live ON the frozen row object in THIS leaf: the real
+// implementations (rearmGithubTokenFromFile, the linear-remint.mjs cooldown reminters) live
+// in execution-core and would violate the zero-import contract if baked in here, and PR1 is
+// explicitly zero-consumer — nothing has registered a hook yet. So the seam is realized as a
+// separate, explicitly MUTABLE side table (`_rearmHooks`), kept OUT of the frozen registry,
+// that a later PR populates via registerRearmHook(id, fn) from execution-core — exactly where
+// design §3 says the hook implementations belong ("registered against rows"). This table is
+// EMPTY for every row in this PR; see armSecret's degrade behavior below for what that means
+// in practice, and secret-contract.test.mjs's "registry validation (§6)" suite for the tests
+// that prove both halves of the mechanism (hookless degrade, and hook-present pickup) work
+// correctly before any real hook exists.
+const _rearmHooks = new Map();
+
+// registerRearmHook(id, fn) — attach an in-process rearm implementation to a row. Returns
+// true on success, false (never throws) when: the id is unknown, the row's declared
+// rotation.class is not "re-armable" (design §6 rule 2, the CAPABILITY-CEILING rule — a
+// boot-only row's ceiling does not support an arm hook, registering one against it would be
+// misleading), or fn is not a function.
+export function registerRearmHook(id, fn) {
+  const row = getSecretRow(id);
+  if (!row || row.rotation?.class !== "re-armable" || typeof fn !== "function") return false;
+  _rearmHooks.set(id, fn);
+  return true;
+}
+
+// clearRearmHook(id) — test/reset seam. Returns true iff a hook was registered and removed.
+export function clearRearmHook(id) {
+  return _rearmHooks.delete(id);
+}
+
+// _lastArmedValue — the boot-time/last-observed-value snapshot per row id, used by the
+// hookless degrade path below to decide "did the provider-of-record value change since last
+// arm". Module-level mutable state, same pattern as getDeploymentMode's _warnedDeploymentMode
+// dedup Set (lib/deployment-mode.mjs) — deliberate: armSecret's whole contract is to observe
+// change ACROSS repeated calls over a daemon's lifetime.
+const _lastArmedValue = new Map();
+
+// resetArmState(id) — test seam: clear the remembered baseline for one row (or every row when
+// id is omitted), so a fresh armSecret call re-establishes the baseline instead of comparing
+// against another test's leftover state.
+export function resetArmState(id) {
+  if (id === undefined) {
+    _lastArmedValue.clear();
+    return;
+  }
+  _lastArmedValue.delete(id);
+}
+
+// armSecret(id, { env }) — never throws. Returns { armed, rotated, restartRequired }.
+//
+// TWO PATHS, per design §6:
+//
+// 1. HOOK PATH — rotation.class === "re-armable" AND a hook is currently registered
+//    (registerRearmHook): the hook performs the actual in-process rearm (e.g. re-read the
+//    shared file and update process.env, as rearmGithubTokenFromFile will once PR-of-a-later-
+//    migration-step registers it). A successful in-process rearm never requires a restart —
+//    that is the whole point of "re-armable". restartRequired is always false on this path.
+//
+// 2. HOOKLESS-DEGRADE PATH — every other case (boot-only rows, "n/a" rows, AND — this is the
+//    PR1-specific state — every re-armable row that has NOT had a hook registered against it
+//    yet, since nothing has in this isolation slice). Design §6 rule 1 says a hookless
+//    re-armable row is "structurally forced boot-only" by a registry-validation test failing;
+//    THIS implementation realizes that as a RUNTIME degrade instead of a load-time assertion,
+//    because the real hooks are execution-core-owned and do not exist inside this zero-import
+//    leaf yet — asserting their presence at registry-load time in PR1 would be asserting
+//    something that is honestly not yet true. The degrade itself is the same shape armSecret
+//    would give an actual boot-only row: resolve fresh, diff against the last-observed value,
+//    and report restartRequired: true iff it changed — the literal Gherkin-Scenario-2
+//    mechanism (design §6), proven correct here before any real hook exists. See
+//    secret-contract.test.mjs's registry-validation suite for the explicit assertion that
+//    every SEED re-armable row currently has NO hook registered (self-documenting: this list
+//    must shrink as later PRs call registerRearmHook, and the test will need updating then —
+//    that is by design, not an oversight).
+export function armSecret(id, { env = process.env } = {}) {
+  const row = getSecretRow(id);
+  if (!row) return { armed: false, rotated: false, restartRequired: false };
+
+  if (row.rotation?.class === "n/a") {
+    return { armed: false, rotated: false, restartRequired: false };
+  }
+
+  const hook = _rearmHooks.get(id);
+  if (row.rotation?.class === "re-armable" && typeof hook === "function") {
+    let result;
+    try {
+      result = hook({ env });
+    } catch {
+      return { armed: false, rotated: false, restartRequired: false };
+    }
+    const rotated = Boolean(result?.rearmed);
+    return { armed: rotated, rotated, restartRequired: false };
+  }
+
+  // Hookless degrade path (covers boot-only rows AND hookless re-armable rows identically).
+  const resolved = resolveSecret(id, { env });
+  const current = resolved.value ?? null;
+  const hadBaseline = _lastArmedValue.has(id);
+  const previous = _lastArmedValue.get(id) ?? null;
+  _lastArmedValue.set(id, current);
+
+  if (!hadBaseline) {
+    // First observation establishes the boot-time baseline — nothing has "rotated" relative
+    // to a baseline that did not exist yet.
+    return { armed: false, rotated: false, restartRequired: false };
+  }
+  // restartRequired mirrors `rotated` exactly on this path: reaching here already means
+  // either a genuine boot-only row OR a hookless re-armable row, and design §6 rule 1's
+  // honesty requirement is that BOTH degrade identically (a consumer that never wires the
+  // arm path must not appear safer than one that never could).
+  const rotated = current !== previous;
+  return { armed: false, rotated, restartRequired: rotated };
+}

--- a/plugins/dev/scripts/lib/secret-contract.mjs
+++ b/plugins/dev/scripts/lib/secret-contract.mjs
@@ -215,8 +215,30 @@ export const SECRET_REGISTRY = Object.freeze(
       rotation: { class: "n/a" },
       bootstrapFor: "cluster",
     },
-  ].map((row) => Object.freeze(row)),
+  ].map((row) => deepFreeze(row)),
 );
+
+// deepFreeze — Object.freeze only makes the OUTER object immutable; a row's nested
+// envNames/defaultLocalPath arrays and rotation object were previously left mutable, so
+// `getSecretRow("linear-api-token").envNames.push("EVIL")` or
+// `resolveSecret(id).rotation.class = "boot-only"` would silently corrupt shared registry
+// state for the rest of the process (every later resolution, hook registration, and arm
+// call reads the SAME frozen-row object) — exactly the "frozen registry" contract this
+// module's own header promises but didn't fully deliver. Recursively freezes every
+// object/array reachable from a row so a mutation attempt THROWS (strict-mode ESM) instead
+// of silently succeeding, for every accessor that returns a piece of registry data by
+// reference (getSecretRow, resolveSecret's `rotation` field, etc.) — "frozen" satisfies the
+// design's "return frozen or cloned structures" requirement without needing a clone on
+// every call.
+function deepFreeze(value) {
+  if (value !== null && typeof value === "object" && !Object.isFrozen(value)) {
+    Object.freeze(value);
+    for (const key of Object.getOwnPropertyNames(value)) {
+      deepFreeze(value[key]);
+    }
+  }
+  return value;
+}
 
 // getSecretRow — the id → row lookup every engine function starts from. Returns undefined
 // for an unknown id (never throws).
@@ -281,20 +303,152 @@ export function resolveLayer2Path(env = process.env) {
 // value already does. Reuses the same containsNul() helper readFirstNonBlankFile uses
 // below (function declarations hoist, so the later definition is available here) rather
 // than a second copy.
+// hasLiveLoneHighSurrogateEscape — CTL-1617 JSON-acceptance-normalization lesson, mirroring
+// jq 1.7.1's OWN acceptance rule exactly rather than the earlier (over-rejecting) regex
+// guard this replaces. Verified against real jq 1.7.1 (`jq --version` ⇒ jq-1.7.1-apple):
+//   - a lone HIGH surrogate escape (\uD800-\uDBFF, unpaired) ⇒ jq exits 5, rejects the WHOLE
+//     document.
+//   - a lone LOW surrogate escape (\uDC00-\uDFFF, unpaired) ⇒ jq exits 0 and substitutes
+//     U+FFFD for it — ACCEPTED, not rejected.
+//   - a valid HIGH+LOW pair ⇒ accepted, forms the intended astral character.
+// So only a live, unpaired HIGH escape must reject the document; a live lone LOW is fine
+// (handled at the value-extraction boundary below, via toWellFormed()).
+//
+// "Live" is the key subtlety the old regex guard got wrong (E6): a backslash run of ODD
+// length immediately before a `u` means the LAST backslash actually escapes that `u` (every
+// preceding pair of backslashes is itself one escaped literal backslash) — a genuine
+// \uXXXX escape. An EVEN-length run means every backslash pairs off as a literal backslash
+// and the following "uXXXX" is ordinary LITERAL TEXT, not an escape at all — e.g. the JSON
+// string source `"literal \\ud800 text"` (an escaped backslash followed by the 5 literal
+// characters "ud800") parses to the harmless string `literal \ud800 text` and must NOT
+// reject the document, even though the old regex — which only looked for a bare `\uXXXX`
+// substring, blind to what preceded the backslash — matched it and killed the whole read.
+//
+// Scans the RAW file text (before JSON.parse), matching jq's whole-document rejection
+// semantics: a live unpaired HIGH escape ANYWHERE in the document — even outside the field
+// being read — is what makes jq unable to produce ANY value from the file at all.
+function hasLiveLoneHighSurrogateEscape(text) {
+  const re = /(\\+)u([0-9a-fA-F]{4})/g;
+  const liveMatches = [];
+  let m;
+  while ((m = re.exec(text)) !== null) {
+    const isLive = m[1].length % 2 === 1;
+    if (!isLive) continue;
+    liveMatches.push({ index: m.index, end: m.index + m[0].length, code: parseInt(m[2], 16) });
+  }
+  for (let i = 0; i < liveMatches.length; i++) {
+    const cur = liveMatches[i];
+    if (cur.code < 0xd800 || cur.code > 0xdbff) continue; // not a HIGH surrogate
+    const next = liveMatches[i + 1];
+    const isPaired = next != null && next.index === cur.end && next.code >= 0xdc00 && next.code <= 0xdfff;
+    if (!isPaired) return true;
+  }
+  return false;
+}
+
+// toWellFormedString — normalizes a JS string so any lone (unpaired) surrogate code unit is
+// replaced with U+FFFD, mirroring what jq 1.7.1 already did AT PARSE TIME for a live lone LOW
+// surrogate escape (verified above). JSON.parse itself performs no such normalization — a
+// parsed JS string can carry a raw lone-low code unit straight through — so this is applied
+// explicitly at the value-extraction boundary (readJsonField's string-typed return), not
+// inside JSON.parse itself, so every OTHER caller of a parsed document (e.g. object/array
+// traversal above) still sees the untouched string. Uses the native
+// String.prototype.toWellFormed() where available (Node/bun both support it); falls back to
+// a manual code-unit walk on a runtime that lacks it.
+function toWellFormedString(str) {
+  if (typeof str.toWellFormed === "function") return str.toWellFormed();
+  let out = "";
+  for (let i = 0; i < str.length; i++) {
+    const code = str.charCodeAt(i);
+    if (code >= 0xd800 && code <= 0xdbff) {
+      const next = str.charCodeAt(i + 1);
+      if (next >= 0xdc00 && next <= 0xdfff) {
+        out += str[i] + str[i + 1];
+        i++;
+      } else {
+        out += "�";
+      }
+    } else if (code >= 0xdc00 && code <= 0xdfff) {
+      out += "�";
+    } else {
+      out += str[i];
+    }
+  }
+  return out;
+}
+
 function readJsonField(filePath, dottedPath) {
   if (!dottedPath) return undefined;
   try {
-    const doc = JSON.parse(readFileSync(filePath, "utf8"));
+    const text = readFileSync(filePath, "utf8");
+    // NOTE: a leading UTF-8 BOM and multi-document content are NOT special-cased here —
+    // JSON.parse already rejects both natively (verified: a leading U+FEFF and any
+    // non-whitespace trailing a complete top-level value both throw SyntaxError), matching
+    // jq's own BOM-tolerant-but-multi-doc-tolerant behavior once the bash mirror's
+    // BOM-sniff + --slurp length check (design §5) settle those two cases to @ABSENT. Only
+    // the unpaired-HIGH-surrogate-escape direction needs an explicit JS-side guard (above) —
+    // a lone LOW escape is accepted by both engines (see hasLiveLoneHighSurrogateEscape).
+    if (hasLiveLoneHighSurrogateEscape(text)) return undefined;
+    const doc = JSON.parse(text);
     let cur = doc;
     for (const part of dottedPath.split(".")) {
       if (cur == null || typeof cur !== "object") return undefined;
       cur = cur[part];
     }
-    if (typeof cur === "string" && containsNul(cur)) return undefined;
+    if (typeof cur === "string") {
+      if (containsNul(cur)) return undefined;
+      // WELL-FORMED NORMALIZATION (mirrors jq's own lone-LOW-surrogate replacement, done at
+      // parse time on the bash side) — applied ONLY here, at the value-extraction boundary,
+      // per-value, not to the whole parsed document.
+      return toWellFormedString(cur);
+    }
     return cur;
   } catch {
     return undefined;
   }
+}
+
+// canonicalJsonStringify — deterministic (sorted-key, recursive) JSON serialization, used
+// ONLY to canonicalize an object-shaped config-json value (see canonicalizeConfigJsonValue
+// below). Sorting keys makes the output independent of source-file field order AND of any
+// difference between JS's/jq's default object-iteration order, so the bash mirror's
+// `walk(if type == "object" then to_entries | sort_by(.key) | from_entries else . end) |
+// tojson` produces the BYTE-IDENTICAL string for the same input (verified at authoring
+// time: `{"clientSecret":"s3cr3t","clientId":"abc123"}` canonicalizes to
+// `{"clientId":"abc123","clientSecret":"s3cr3t"}` on both sides).
+function canonicalJsonStringify(value) {
+  if (Array.isArray(value)) return `[${value.map(canonicalJsonStringify).join(",")}]`;
+  if (value !== null && typeof value === "object") {
+    const keys = Object.keys(value).sort();
+    return `{${keys.map((k) => `${JSON.stringify(k)}:${canonicalJsonStringify(value[k])}`).join(",")}}`;
+  }
+  return JSON.stringify(value);
+}
+
+// canonicalizeConfigJsonValue — the config-json engine's value-acceptance rule (design §2
+// finding fix: the AUTHORITATIVE Layer-2 schema stores catalyst.linear.bot.orchestrator/
+// .worker as OBJECTS — {clientId, clientSecret, ...} — not strings; a resolver that only
+// accepted strings made both actor rows permanently resolve to "none" for every valid
+// production config, which the pre-fix test suite masked by fixturing a
+// JSON-STRING-CONTAINING-JSON instead of a real object). Accepts a non-empty, NUL-free
+// STRING as-is (the pre-existing groq-api-key/generic shape), or a plain OBJECT (not an
+// array), canonicalized via canonicalJsonStringify so a future consumer can
+// JSON.parse(resolved.value) and pull out clientId/clientSecret — the row's value
+// semantics this finding asks for. Arrays/booleans/numbers stay rejected (unchanged
+// BLOCKING-1 "never silently coerced" contract: a bare `false` at a config-json path is
+// "none", not truthy). NOTE: this generic object-acceptance is scoped to config-json ROW
+// resolution only — resolveCloudTokenName (below) deliberately keeps its OWN strict
+// string-only check on the SAME underlying readJsonField call, since a NAME override can
+// only ever be a plain env-var-name string.
+function canonicalizeConfigJsonValue(raw) {
+  if (typeof raw === "string") {
+    return raw.length > 0 ? raw : null;
+  }
+  if (raw !== null && typeof raw === "object" && !Array.isArray(raw)) {
+    const canon = canonicalJsonStringify(raw);
+    return containsNul(canon) ? null : canon;
+  }
+  return null;
 }
 
 // ─── Bare-file candidate search — generalizes githubTokenFileCandidates ─────
@@ -352,14 +506,33 @@ function containsNul(value) {
   return value.includes("\u0000");
 }
 
+// isValidUtf8RoundTrip — PARITY GUARD (generalizes the NUL-byte/JSON-acceptance lessons
+// above to raw file bytes): Node's readFileSync(file, "utf8") REPLACES any invalid UTF-8
+// byte sequence with U+FFFD (the Unicode replacement character) rather than failing — a
+// bare-file secret containing a stray non-UTF-8 byte (e.g. a leading 0xFF 0xFE) would
+// silently decode to a MUTATED credential in JS, while the bash mirror's `cat` preserves
+// the original bytes exactly. Neither behavior is safe to prefer over the other: a
+// credential that cannot round-trip UTF-8 identically cannot be represented identically in
+// both engines, so this file REJECTS the candidate on both sides (falls through to the
+// next candidate, matching the NUL-byte candidate's degrade shape) rather than silently
+// serving whichever language's mutated/unmutated view happens to run first. Detected via a
+// byte round-trip: decode as UTF-8, re-encode, and compare against the original bytes —
+// any invalid sequence fails to round-trip byte-for-byte.
+function isValidUtf8RoundTrip(buf, decoded) {
+  const reencoded = Buffer.from(decoded, "utf8");
+  return reencoded.length === buf.length && reencoded.equals(buf);
+}
+
 function readFirstNonBlankFile(candidates) {
   for (const file of candidates) {
-    let raw;
+    let buf;
     try {
-      raw = readFileSync(file, "utf8");
+      buf = readFileSync(file);
     } catch {
       continue;
     }
+    const raw = buf.toString("utf8");
+    if (!isValidUtf8RoundTrip(buf, raw)) continue;
     if (containsNul(raw)) continue;
     const val = stripEol(raw);
     if (!isBlank(val)) return { value: val, filePath: file };
@@ -423,8 +596,9 @@ function resolveConfigJson(row, env) {
   }
   const path = resolveLayer2Path(env);
   const raw = readJsonField(path, row.configJsonPath);
-  if (typeof raw === "string" && raw.length > 0) {
-    return { value: raw, source: "config-json", provider: row.delivery, rotation: row.rotation, filePath: path };
+  const resolved = canonicalizeConfigJsonValue(raw);
+  if (resolved != null) {
+    return { value: resolved, source: "config-json", provider: row.delivery, rotation: row.rotation, filePath: path };
   }
   return { value: null, source: "none", provider: row.delivery, rotation: row.rotation };
 }
@@ -520,7 +694,20 @@ export function resolveSecret(id, { env = process.env, deploymentMode } = {}) {
         }
       }
     }
-    return resolveEnvAliasOnly(row, env);
+    // PLATFORM-ENV NAME OVERRIDE FIX: a bare resolveEnvAliasOnly(row, env) here only ever
+    // checks row.envNames literally — for cloud-token that is JUST the hardcoded default
+    // "CATALYST_CLOUD_TOKEN", so an operator-configured CATALYST_CLOUD_TOKEN_ENV or Layer-2
+    // catalyst.cloud.tokenEnv override was silently ignored the moment genuine cloud mode
+    // activated, even though that exact override IS honored one level up (the bootstrap
+    // check above calls resolveSecret(bootstrapRow.id, { env }) WITHOUT deploymentMode,
+    // which routes through the normal switch below to resolveCloudTokenName). Dispatching
+    // platform-env rows through resolveCloudTokenName here — the SAME function, not a
+    // second copy — closes that gap: cloud-token resolves its configured NAME identically
+    // whether reached directly (this branch) or indirectly (the bootstrap check). Every
+    // other cloud-mode row (bare-file/env-alias/config-json rows collapsing to their
+    // envNames-only aliases) is unaffected — this is a targeted fix for the one
+    // platform-env row, not a broadening of what "genuinely cloud" resolves.
+    return row.delivery === "platform-env" ? resolveCloudTokenName(row, env) : resolveEnvAliasOnly(row, env);
   }
 
   switch (row.delivery) {
@@ -595,7 +782,12 @@ export function resetArmState(id) {
   _lastArmedValue.delete(id);
 }
 
-// armSecret(id, { env }) — never throws. Returns { armed, rotated, restartRequired }.
+// armSecret(id, { env, deploymentMode }) — never throws. Returns { armed, rotated,
+// restartRequired }. deploymentMode is the SAME optional CTL-1617 resolution object
+// resolveSecret accepts, threaded straight through (design §8 finding fix) so a cloud-mode
+// caller's arm baseline consults the identical provider chain its own direct resolveSecret
+// calls use — see the DEPLOYMENT-MODE THREADING FIX comment on the hookless-degrade path
+// below for the concrete failure this closes.
 //
 // TWO PATHS, per design §6:
 //
@@ -620,7 +812,7 @@ export function resetArmState(id) {
 //    every SEED re-armable row currently has NO hook registered (self-documenting: this list
 //    must shrink as later PRs call registerRearmHook, and the test will need updating then —
 //    that is by design, not an oversight).
-export function armSecret(id, { env = process.env } = {}) {
+export function armSecret(id, { env = process.env, deploymentMode } = {}) {
   const row = getSecretRow(id);
   if (!row) return { armed: false, rotated: false, restartRequired: false };
 
@@ -632,7 +824,10 @@ export function armSecret(id, { env = process.env } = {}) {
   if (row.rotation?.class === "re-armable" && typeof hook === "function") {
     let result;
     try {
-      result = hook({ env });
+      // Hooks receive the SAME context resolveSecret does (design §8 finding fix) — a
+      // future file-rearm hook must be able to see genuine-cloud mode too, so it never
+      // clobbers an injected platform token with a stale local file's contents.
+      result = hook({ env, deploymentMode });
     } catch {
       return { armed: false, rotated: false, restartRequired: false };
     }
@@ -641,7 +836,18 @@ export function armSecret(id, { env = process.env } = {}) {
   }
 
   // Hookless degrade path (covers boot-only rows AND hookless re-armable rows identically).
-  const resolved = resolveSecret(id, { env });
+  // DEPLOYMENT-MODE THREADING FIX (design §8 finding fix): this MUST pass the same
+  // deploymentMode a caller threads through to direct resolveSecret() calls — omitting it
+  // used to make the arm baseline resolve through the non-cloud file/config chain even in
+  // genuine cloud mode, while a sibling direct resolveSecret(id, { env, deploymentMode })
+  // call correctly resolved via the cloud-only env-alias chain. In a cloud process with an
+  // injected token AND a stale local file, that mismatch made a stale-file edit falsely
+  // report restartRequired while a REAL token rotation went unnoticed — the literal
+  // "arm baselines the wrong provider chain" bug this fix closes. Passing deploymentMode
+  // straight through (default: undefined, identical to resolveSecret's own default) means a
+  // caller that never passes it gets EXACTLY today's non-cloud behavior — this only changes
+  // behavior for a caller that already threads deploymentMode into armSecret.
+  const resolved = resolveSecret(id, { env, deploymentMode });
   const current = resolved.value ?? null;
   const hadBaseline = _lastArmedValue.has(id);
   const previous = _lastArmedValue.get(id) ?? null;

--- a/plugins/dev/scripts/lib/secret-contract.test.mjs
+++ b/plugins/dev/scripts/lib/secret-contract.test.mjs
@@ -1,0 +1,525 @@
+import { describe, test, expect, afterEach, beforeEach } from "bun:test";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { resolve } from "node:path";
+import {
+  SECRET_DELIVERY,
+  ROTATION_CLASSES,
+  SECRET_REGISTRY,
+  getSecretRow,
+  isSecretFamilyMember,
+  resolveLayer2Path,
+  explicitFileOverrideEnvName,
+  secretFileCandidates,
+  resolveSecret,
+  registerRearmHook,
+  clearRearmHook,
+  resetArmState,
+  armSecret,
+} from "./secret-contract.mjs";
+
+// Fixture-file helpers, following the deployment-mode.test.mjs convention: every test gets
+// its own tmp dir so parallel runs never collide, and points paths at fixtures directly
+// rather than the real filesystem or process.env.
+let _tmpDirs = [];
+function fixtureDir() {
+  const dir = mkdtempSync(resolve(tmpdir(), "secret-contract-test-"));
+  _tmpDirs.push(dir);
+  return dir;
+}
+function writeFile(dir, name, contents) {
+  const path = resolve(dir, name);
+  mkdirSync(resolve(path, ".."), { recursive: true });
+  writeFileSync(path, contents);
+  return path;
+}
+afterEach(() => {
+  for (const dir of _tmpDirs) rmSync(dir, { recursive: true, force: true });
+  _tmpDirs = [];
+  resetArmState();
+});
+beforeEach(() => {
+  // Every re-armable seed row must start each test with no registered hook — several tests
+  // below register/clear one explicitly, and a leaked registration would silently change
+  // another test's code path.
+  for (const row of SECRET_REGISTRY) clearRearmHook(row.id);
+});
+
+describe("SECRET_REGISTRY — shape", () => {
+  test("11 seed rows, matching the design §2 seed table", () => {
+    expect(SECRET_REGISTRY.length).toBe(11);
+    expect(SECRET_REGISTRY.map((r) => r.id)).toEqual([
+      "github-token",
+      "webhook-secret",
+      "linear-webhook-secret",
+      "claude-accounts.env",
+      "execution-core.env",
+      "linear-api-token",
+      "linear-orchestrator-actor",
+      "linear-worker-actor",
+      "groq-api-key",
+      "cloud-token",
+      "age-key",
+    ]);
+  });
+
+  test("registry and every row are frozen — DATA, never mutated at runtime", () => {
+    expect(Object.isFrozen(SECRET_REGISTRY)).toBe(true);
+    for (const row of SECRET_REGISTRY) expect(Object.isFrozen(row)).toBe(true);
+  });
+
+  test("mutating the frozen registry array throws (strict-mode ESM)", () => {
+    expect(() => {
+      SECRET_REGISTRY.push({ id: "bogus" });
+    }).toThrow();
+    expect(SECRET_REGISTRY.length).toBe(11);
+  });
+
+  test("every row's delivery is a member of SECRET_DELIVERY", () => {
+    for (const row of SECRET_REGISTRY) expect(SECRET_DELIVERY).toContain(row.delivery);
+  });
+
+  test("every row's rotation.class is a member of ROTATION_CLASSES", () => {
+    for (const row of SECRET_REGISTRY) expect(ROTATION_CLASSES).toContain(row.rotation.class);
+  });
+
+  test("only local-only rows may declare rotation.class 'n/a'", () => {
+    for (const row of SECRET_REGISTRY) {
+      if (row.rotation.class === "n/a") expect(row.delivery).toBe("local-only");
+      if (row.delivery === "local-only") expect(row.rotation.class).toBe("n/a");
+    }
+  });
+
+  test("linear-orchestrator-actor and linear-worker-actor are separate rows with distinct config paths (design §2 judge-unanimous graft)", () => {
+    const orch = getSecretRow("linear-orchestrator-actor");
+    const worker = getSecretRow("linear-worker-actor");
+    expect(orch).toBeDefined();
+    expect(worker).toBeDefined();
+    expect(orch.configJsonPath).not.toBe(worker.configJsonPath);
+  });
+
+  test("exactly one row per cloud/cluster bootstrap class (design §5)", () => {
+    const cloudRows = SECRET_REGISTRY.filter((r) => r.bootstrapFor === "cloud");
+    const clusterRows = SECRET_REGISTRY.filter((r) => r.bootstrapFor === "cluster");
+    expect(cloudRows.map((r) => r.id)).toEqual(["cloud-token"]);
+    expect(clusterRows.map((r) => r.id)).toEqual(["age-key"]);
+  });
+
+  test("getSecretRow returns undefined for an unknown id (never throws)", () => {
+    expect(getSecretRow("does-not-exist")).toBeUndefined();
+  });
+});
+
+describe("isSecretFamilyMember — absorbed cluster-sync.mjs predicate", () => {
+  test("case-insensitive prefix match with at least one char after the dash", () => {
+    expect(isSecretFamilyMember("linear-webhook-secret-CTL")).toBe(true);
+    expect(isSecretFamilyMember("LINEAR-WEBHOOK-SECRET-ctl")).toBe(true);
+    expect(isSecretFamilyMember("linear-webhook-secret-a")).toBe(true);
+  });
+  test("bare prefix (no team suffix) is NOT a member", () => {
+    expect(isSecretFamilyMember("linear-webhook-secret-")).toBe(false);
+  });
+  test("run-on name (no dash) is NOT a member", () => {
+    expect(isSecretFamilyMember("linear-webhook-secretXXX")).toBe(false);
+  });
+  test("the singular linear-webhook-secret exact name is NOT a family member", () => {
+    expect(isSecretFamilyMember("linear-webhook-secret")).toBe(false);
+  });
+  test("non-string/empty input never throws", () => {
+    expect(isSecretFamilyMember("")).toBe(false);
+    expect(isSecretFamilyMember(undefined)).toBe(false);
+    expect(isSecretFamilyMember(null)).toBe(false);
+  });
+});
+
+describe("resolveLayer2Path — the §2 canonical chain (distinct from deployment-mode.mjs's)", () => {
+  test("CATALYST_LAYER2_CONFIG_FILE wins", () => {
+    expect(resolveLayer2Path({ CATALYST_LAYER2_CONFIG_FILE: "/explicit/path.json" })).toBe("/explicit/path.json");
+  });
+  test("CATALYST_MACHINE_CONFIG wins over XDG/default", () => {
+    expect(resolveLayer2Path({ CATALYST_MACHINE_CONFIG: "/machine/config.json" })).toBe("/machine/config.json");
+  });
+  test("XDG_CONFIG_HOME wins over the bare-HOME default", () => {
+    expect(resolveLayer2Path({ HOME: "/home/x", XDG_CONFIG_HOME: "/xdg" })).toBe(resolve("/xdg", "catalyst", "config.json"));
+  });
+  test("falls back to ~/.config/catalyst/config.json", () => {
+    expect(resolveLayer2Path({ HOME: "/home/x" })).toBe(resolve("/home/x", ".config", "catalyst", "config.json"));
+  });
+});
+
+describe("secretFileCandidates / explicitFileOverrideEnvName", () => {
+  test("derives CATALYST_<ID>_FILE for github-token and webhook-secret (matches the pre-existing convention)", () => {
+    expect(explicitFileOverrideEnvName("github-token")).toBe("CATALYST_GITHUB_TOKEN_FILE");
+    expect(explicitFileOverrideEnvName("webhook-secret")).toBe("CATALYST_WEBHOOK_SECRET_FILE");
+  });
+  test("collapses runs of non-alnum (dash AND dot) to one underscore", () => {
+    expect(explicitFileOverrideEnvName("claude-accounts.env")).toBe("CATALYST_CLAUDE_ACCOUNTS_ENV_FILE");
+  });
+  test("explicit override short-circuits to a single candidate", () => {
+    expect(secretFileCandidates("github-token", { CATALYST_GITHUB_TOKEN_FILE: "/x/y" })).toEqual(["/x/y"]);
+  });
+  test("CATALYST_CONFIG_DIR short-circuits", () => {
+    expect(secretFileCandidates("github-token", { CATALYST_CONFIG_DIR: "/cfgdir" })).toEqual([resolve("/cfgdir", "github-token")]);
+  });
+  test("default chain: cluster-sync destination dir then XDG dir, deduped", () => {
+    const out = secretFileCandidates("github-token", { HOME: "/home/x" });
+    expect(out).toEqual([
+      resolve("/home/x", ".config", "catalyst", "github-token"),
+      // Same path both rungs (default Layer-2 dir === default XDG dir) — deduped to one.
+    ]);
+  });
+  test("distinct XDG dir yields two candidates", () => {
+    const out = secretFileCandidates("github-token", {
+      HOME: "/home/x",
+      CATALYST_LAYER2_CONFIG_FILE: "/other/config.json",
+      XDG_CONFIG_HOME: "/xdg",
+    });
+    expect(out).toEqual([resolve("/other", "github-token"), resolve("/xdg", "catalyst", "github-token")]);
+  });
+});
+
+describe("resolveSecret — bare-file delivery (github-token)", () => {
+  test("resolves from the explicit override file", () => {
+    const dir = fixtureDir();
+    const f = writeFile(dir, "gh", "tok-value\n");
+    const r = resolveSecret("github-token", { env: { CATALYST_GITHUB_TOKEN_FILE: f } });
+    expect(r.value).toBe("tok-value");
+    expect(r.source).toBe("operator-override");
+    expect(r.provider).toBe("bare-file");
+  });
+  test("resolves from CATALYST_CONFIG_DIR as shared-file", () => {
+    const dir = fixtureDir();
+    writeFile(dir, "github-token", "abc");
+    const r = resolveSecret("github-token", { env: { CATALYST_CONFIG_DIR: dir } });
+    expect(r).toMatchObject({ value: "abc", source: "shared-file", provider: "bare-file" });
+  });
+  test("falls back to an inherited env alias when no file exists anywhere", () => {
+    const dir = fixtureDir();
+    const r = resolveSecret("github-token", {
+      env: { CATALYST_CONFIG_DIR: dir, GH_TOKEN: "inherited-tok" },
+    });
+    expect(r).toMatchObject({ value: "inherited-tok", source: "inherited", provider: "bare-file" });
+  });
+  test("nothing anywhere resolves to none", () => {
+    const dir = fixtureDir();
+    const r = resolveSecret("github-token", { env: { CATALYST_CONFIG_DIR: dir } });
+    expect(r).toMatchObject({ value: null, source: "none", provider: "bare-file" });
+  });
+  test("preserves significant boundary whitespace, strips only trailing EOL", () => {
+    const dir = fixtureDir();
+    writeFile(dir, "github-token", " padded-value \n\n");
+    const r = resolveSecret("github-token", { env: { CATALYST_CONFIG_DIR: dir } });
+    expect(r.value).toBe(" padded-value ");
+  });
+  test("a whitespace-only file is treated as absent, falls through to env alias", () => {
+    const dir = fixtureDir();
+    writeFile(dir, "github-token", "   \n");
+    const r = resolveSecret("github-token", { env: { CATALYST_CONFIG_DIR: dir, GH_TOKEN: "fallback" } });
+    expect(r).toMatchObject({ value: "fallback", source: "inherited" });
+  });
+  test("a NUL-containing file is rejected (parity guard), falls through to env alias", () => {
+    const dir = fixtureDir();
+    writeFile(dir, "github-token", Buffer.from("c\0loud"));
+    const r = resolveSecret("github-token", { env: { CATALYST_CONFIG_DIR: dir, GH_TOKEN: "fallback" } });
+    expect(r).toMatchObject({ value: "fallback", source: "inherited" });
+  });
+});
+
+describe("resolveSecret — unknown id", () => {
+  test("never throws; returns the 4-field null shape", () => {
+    expect(resolveSecret("does-not-exist", { env: {} })).toEqual({
+      value: null,
+      source: null,
+      provider: null,
+      rotation: null,
+    });
+  });
+});
+
+describe("resolveSecret — bare-file-family (linear-webhook-secret)", () => {
+  test("has no single scalar value — resolveSecret returns null/null for it", () => {
+    const r = resolveSecret("linear-webhook-secret", { env: {} });
+    expect(r.value).toBeNull();
+    expect(r.provider).toBe("bare-file-family");
+  });
+});
+
+describe("resolveSecret — env-file delivery (claude-accounts.env)", () => {
+  test("presence-checks the file, value is the PATH not the content", () => {
+    const dir = fixtureDir();
+    const f = writeFile(dir, "claude-accounts.env", "CLAUDE_CODE_OAUTH_TOKEN=abc\n");
+    const r = resolveSecret("claude-accounts.env", { env: { CATALYST_CONFIG_DIR: dir } });
+    expect(r).toMatchObject({ value: f, source: "shared-file", provider: "env-file" });
+  });
+  test("an empty file counts as absent", () => {
+    const dir = fixtureDir();
+    writeFile(dir, "claude-accounts.env", "");
+    const r = resolveSecret("claude-accounts.env", { env: { CATALYST_CONFIG_DIR: dir } });
+    expect(r).toMatchObject({ value: null, source: "none" });
+  });
+});
+
+describe("resolveSecret — env-alias delivery (linear-api-token)", () => {
+  test("LINEAR_API_TOKEN wins over LINEAR_API_KEY", () => {
+    const r = resolveSecret("linear-api-token", {
+      env: { LINEAR_API_TOKEN: "tok-a", LINEAR_API_KEY: "tok-b" },
+    });
+    expect(r).toMatchObject({ value: "tok-a", envName: "LINEAR_API_TOKEN" });
+  });
+  test("LINEAR_API_KEY-only fixture resolves (the CTL-1619 regression this row folds/prevents)", () => {
+    const r = resolveSecret("linear-api-token", { env: { LINEAR_API_KEY: "tok-b" } });
+    expect(r).toMatchObject({ value: "tok-b", source: "inherited", envName: "LINEAR_API_KEY" });
+  });
+  test("neither set resolves to none", () => {
+    expect(resolveSecret("linear-api-token", { env: {} })).toMatchObject({ value: null, source: "none" });
+  });
+});
+
+describe("resolveSecret — config-json delivery (linear-orchestrator-actor, groq-api-key)", () => {
+  test("reads the dotted path from the Layer-2 file", () => {
+    const dir = fixtureDir();
+    const l2 = writeFile(
+      dir,
+      "config.json",
+      JSON.stringify({ catalyst: { linear: { bot: { orchestrator: '{"apiKey":"x"}' } } } }),
+    );
+    const r = resolveSecret("linear-orchestrator-actor", { env: { CATALYST_LAYER2_CONFIG_FILE: l2 } });
+    expect(r).toMatchObject({ value: '{"apiKey":"x"}', source: "config-json" });
+  });
+  test("groq-api-key prefers the env alias over the config path (matches resolveApiKey's env-first precedence)", () => {
+    const dir = fixtureDir();
+    const l2 = writeFile(dir, "config.json", JSON.stringify({ groq: { apiKey: "from-config" } }));
+    const r = resolveSecret("groq-api-key", {
+      env: { CATALYST_LAYER2_CONFIG_FILE: l2, GROQ_API_KEY: "from-env" },
+    });
+    expect(r).toMatchObject({ value: "from-env", source: "inherited" });
+  });
+  test("groq-api-key falls back to config when env is unset", () => {
+    const dir = fixtureDir();
+    const l2 = writeFile(dir, "config.json", JSON.stringify({ groq: { apiKey: "from-config" } }));
+    const r = resolveSecret("groq-api-key", { env: { CATALYST_LAYER2_CONFIG_FILE: l2 } });
+    expect(r).toMatchObject({ value: "from-config", source: "config-json" });
+  });
+  test("a non-string JSON value at the path (BLOCKING-1 class: bare `false`) settles as none, never silently coerced", () => {
+    const dir = fixtureDir();
+    const l2 = writeFile(dir, "config.json", JSON.stringify({ groq: { apiKey: false } }));
+    const r = resolveSecret("groq-api-key", { env: { CATALYST_LAYER2_CONFIG_FILE: l2 } });
+    expect(r).toMatchObject({ value: null, source: "none" });
+  });
+  test("absent path falls through to none", () => {
+    const dir = fixtureDir();
+    const l2 = writeFile(dir, "config.json", JSON.stringify({}));
+    const r = resolveSecret("linear-worker-actor", { env: { CATALYST_LAYER2_CONFIG_FILE: l2 } });
+    expect(r).toMatchObject({ value: null, source: "none" });
+  });
+});
+
+describe("resolveSecret — platform-env delivery (cloud-token)", () => {
+  test("default name, value from that env var", () => {
+    const r = resolveSecret("cloud-token", { env: { CATALYST_CLOUD_TOKEN: "cloud-val" } });
+    expect(r).toMatchObject({ value: "cloud-val", source: "platform-env", envVar: "CATALYST_CLOUD_TOKEN", envVarSource: "default" });
+  });
+  test("CATALYST_CLOUD_TOKEN_ENV overrides the NAME", () => {
+    const r = resolveSecret("cloud-token", { env: { CATALYST_CLOUD_TOKEN_ENV: "MY_TOKEN", MY_TOKEN: "v" } });
+    expect(r).toMatchObject({ value: "v", envVar: "MY_TOKEN", envVarSource: "env" });
+  });
+  test("Layer-2 catalyst.cloud.tokenEnv overrides the NAME when env override absent", () => {
+    const dir = fixtureDir();
+    const l2 = writeFile(dir, "config.json", JSON.stringify({ catalyst: { cloud: { tokenEnv: "OTHER_VAR" } } }));
+    const r = resolveSecret("cloud-token", { env: { CATALYST_LAYER2_CONFIG_FILE: l2, OTHER_VAR: "v2" } });
+    expect(r).toMatchObject({ value: "v2", envVar: "OTHER_VAR", envVarSource: "layer2" });
+  });
+  test("name resolves but the var is unset ⇒ none (still reports the resolved name)", () => {
+    const r = resolveSecret("cloud-token", { env: {} });
+    expect(r).toMatchObject({ value: null, source: "none", envVar: "CATALYST_CLOUD_TOKEN", envVarSource: "default" });
+  });
+});
+
+describe("resolveSecret — local-only delivery (age-key), never fetched", () => {
+  test("presence — default path under HOME", () => {
+    const dir = fixtureDir();
+    writeFile(dir, ".config/catalyst/age.key", "AGE-SECRET-KEY-fake");
+    const r = resolveSecret("age-key", { env: { HOME: dir } });
+    expect(r.source).toBe("present");
+    expect(r.value).toBe(resolve(dir, ".config", "catalyst", "age.key"));
+  });
+  test("absence", () => {
+    const dir = fixtureDir();
+    const r = resolveSecret("age-key", { env: { HOME: dir } });
+    expect(r).toMatchObject({ value: null, source: "absent" });
+  });
+  test("SOPS_AGE_KEY_FILE override is honored", () => {
+    const dir = fixtureDir();
+    const f = writeFile(dir, "custom/age.key", "AGE-SECRET-KEY-fake");
+    const r = resolveSecret("age-key", { env: { HOME: dir, SOPS_AGE_KEY_FILE: f } });
+    expect(r).toMatchObject({ value: f, source: "present" });
+  });
+  test("never reads the file's contents — a directory at the path (unreadable as a key) settles absent, not a crash", () => {
+    const dir = fixtureDir();
+    mkdirSync(resolve(dir, ".config", "catalyst", "age.key"), { recursive: true });
+    const r = resolveSecret("age-key", { env: { HOME: dir } });
+    expect(r).toMatchObject({ value: null, source: "absent" });
+  });
+});
+
+describe("resolveSecret — cloud guard (design §4)", () => {
+  test("mode:cloud but inferred:true does NOT activate the cloud branch — file chain still runs", () => {
+    const dir = fixtureDir();
+    writeFile(dir, "github-token", "file-value");
+    const r = resolveSecret("github-token", {
+      env: { CATALYST_CONFIG_DIR: dir },
+      deploymentMode: { mode: "cloud", inferred: true },
+    });
+    expect(r).toMatchObject({ value: "file-value", source: "shared-file" });
+  });
+  test("mode:single-host never activates cloud, even with envNames coincidentally set", () => {
+    const dir = fixtureDir();
+    writeFile(dir, "github-token", "file-value");
+    const r = resolveSecret("github-token", {
+      env: { CATALYST_CONFIG_DIR: dir, GH_TOKEN: "env-value-should-not-win" },
+      deploymentMode: { mode: "single-host", inferred: true },
+    });
+    expect(r.value).toBe("file-value");
+  });
+  test("mode:cluster never activates cloud — same file chain as single-host (design §4: zero new cluster resolution code)", () => {
+    const dir = fixtureDir();
+    writeFile(dir, "github-token", "file-value");
+    const r = resolveSecret("github-token", {
+      env: { CATALYST_CONFIG_DIR: dir },
+      deploymentMode: { mode: "cluster", inferred: false },
+    });
+    expect(r.value).toBe("file-value");
+  });
+  test("genuinely cloud (inferred:false) short-circuits to env-alias ONLY — the file is never consulted, even when it would have resolved", () => {
+    const dir = fixtureDir();
+    writeFile(dir, "github-token", "file-value-must-be-ignored");
+    const r = resolveSecret("github-token", {
+      env: { CATALYST_CONFIG_DIR: dir, CATALYST_CLOUD_TOKEN: "boot" },
+      deploymentMode: { mode: "cloud", inferred: false },
+    });
+    expect(r.value).toBeNull(); // no GH_TOKEN/GITHUB_TOKEN env set — file MUST be ignored
+    expect(r.source).toBe("none");
+  });
+  test("genuinely cloud with the env alias present resolves via env, not the file", () => {
+    const dir = fixtureDir();
+    writeFile(dir, "github-token", "file-value-must-be-ignored");
+    const r = resolveSecret("github-token", {
+      env: { CATALYST_CONFIG_DIR: dir, GH_TOKEN: "cloud-injected", CATALYST_CLOUD_TOKEN: "boot" },
+      deploymentMode: { mode: "cloud", inferred: false },
+    });
+    expect(r).toMatchObject({ value: "cloud-injected", provider: "bare-file" });
+  });
+  test("bootstrap short-circuit: cloud-token itself absent ⇒ every OTHER row's cloud resolution is null/null, without probing further", () => {
+    const r = resolveSecret("github-token", {
+      env: { GH_TOKEN: "should-not-be-returned" },
+      deploymentMode: { mode: "cloud", inferred: false },
+    });
+    expect(r).toEqual({ value: null, source: null, provider: "bare-file", rotation: expect.any(Object) });
+  });
+  test("bootstrap short-circuit does not apply to cloud-token itself", () => {
+    const r = resolveSecret("cloud-token", { env: {}, deploymentMode: { mode: "cloud", inferred: false } });
+    expect(r.source).toBe("none"); // resolves normally (absent), not short-circuited to null/null-provider
+    expect(r.provider).toBe("platform-env");
+  });
+});
+
+// ─── Registry validation (design §6) ─────────────────────────────────────────────────────
+describe("registry validation (§6) — the rearm-hook honesty rules", () => {
+  test("capability ceiling: registerRearmHook rejects a hook against any row whose declared rotation.class !== 're-armable'", () => {
+    const boot = SECRET_REGISTRY.filter((r) => r.rotation.class === "boot-only");
+    expect(boot.length).toBeGreaterThan(0);
+    for (const row of boot) {
+      expect(registerRearmHook(row.id, () => ({ rearmed: true }))).toBe(false);
+    }
+    const localOnly = SECRET_REGISTRY.find((r) => r.rotation.class === "n/a");
+    expect(registerRearmHook(localOnly.id, () => ({ rearmed: true }))).toBe(false);
+  });
+
+  test("registerRearmHook rejects an unknown id or a non-function", () => {
+    expect(registerRearmHook("does-not-exist", () => ({ rearmed: true }))).toBe(false);
+    expect(registerRearmHook("github-token", "not-a-function")).toBe(false);
+    expect(registerRearmHook("github-token", null)).toBe(false);
+  });
+
+  test("PR1 STATE (self-documenting, expected to shrink as later PRs wire real hooks): every SEED re-armable row currently has NO hook registered, so armSecret degrades ALL of them to the same shape a boot-only row gets", () => {
+    const reArmable = SECRET_REGISTRY.filter((r) => r.rotation.class === "re-armable");
+    expect(reArmable.map((r) => r.id).sort()).toEqual(
+      ["github-token", "linear-api-token", "linear-orchestrator-actor"].sort(),
+    );
+    for (const row of reArmable) {
+      const env = { PROBE_UNSET_VAR_FOR_TEST: "x" }; // resolves to none for every one of these rows
+      const first = armSecret(row.id, { env });
+      expect(first).toEqual({ armed: false, rotated: false, restartRequired: false });
+    }
+  });
+
+  test("hookless re-armable row degrades EXACTLY like a boot-only row: restartRequired flips true iff the resolved value changed (Gherkin Scenario 2, proven before any real hook exists)", () => {
+    const dir = fixtureDir();
+    const f = writeFile(dir, "linear-orchestrator.json", JSON.stringify({ catalyst: { linear: { bot: { orchestrator: "cred-v1" } } } }));
+    const env = { CATALYST_LAYER2_CONFIG_FILE: f };
+    expect(armSecret("linear-orchestrator-actor", { env })).toEqual({ armed: false, rotated: false, restartRequired: false });
+    expect(armSecret("linear-orchestrator-actor", { env })).toEqual({ armed: false, rotated: false, restartRequired: false });
+    writeFileSync(f, JSON.stringify({ catalyst: { linear: { bot: { orchestrator: "cred-v2-rotated" } } } }));
+    expect(armSecret("linear-orchestrator-actor", { env })).toEqual({ armed: false, rotated: true, restartRequired: true });
+  });
+
+  test("once a hook IS registered (simulating a later PR), armSecret switches to the hook path: armed:true, restartRequired ALWAYS false (in-process rearm needs no restart)", () => {
+    let calls = 0;
+    registerRearmHook("github-token", ({ env }) => {
+      calls += 1;
+      return { rearmed: true, reason: "test-hook" };
+    });
+    const result = armSecret("github-token", { env: {} });
+    expect(result).toEqual({ armed: true, rotated: true, restartRequired: false });
+    expect(calls).toBe(1);
+  });
+
+  test("hook path: rearmed:false from the hook reports no rotation", () => {
+    registerRearmHook("github-token", () => ({ rearmed: false, reason: "unchanged" }));
+    expect(armSecret("github-token", { env: {} })).toEqual({ armed: false, rotated: false, restartRequired: false });
+  });
+
+  test("hook path: a throwing hook is swallowed, never propagates (armSecret never throws)", () => {
+    registerRearmHook("github-token", () => {
+      throw new Error("boom");
+    });
+    expect(() => armSecret("github-token", { env: {} })).not.toThrow();
+    expect(armSecret("github-token", { env: {} })).toEqual({ armed: false, rotated: false, restartRequired: false });
+  });
+
+  test("clearRearmHook removes a registered hook and armSecret reverts to the hookless-degrade path", () => {
+    registerRearmHook("github-token", () => ({ rearmed: true }));
+    expect(clearRearmHook("github-token")).toBe(true);
+    expect(clearRearmHook("github-token")).toBe(false); // already removed
+    const env = {};
+    armSecret("github-token", { env }); // establishes baseline via the degrade path
+    const r = armSecret("github-token", { env });
+    expect(r.armed).toBe(false); // hook path never entered
+  });
+});
+
+describe("armSecret — n/a rows and unknown ids", () => {
+  test("age-key (rotation.class n/a) is always a no-op, regardless of presence changes", () => {
+    expect(armSecret("age-key", { env: {} })).toEqual({ armed: false, rotated: false, restartRequired: false });
+  });
+  test("unknown id never throws", () => {
+    expect(armSecret("does-not-exist", { env: {} })).toEqual({ armed: false, rotated: false, restartRequired: false });
+  });
+});
+
+describe("resetArmState", () => {
+  test("resets a single row's baseline", () => {
+    const env = { CATALYST_CONFIG_DIR: fixtureDir(), GH_TOKEN: "v1" };
+    armSecret("github-token", { env });
+    resetArmState("github-token");
+    const env2 = { ...env, GH_TOKEN: "v2" };
+    // With the baseline cleared, this call re-establishes rather than reporting a rotation.
+    expect(armSecret("github-token", { env: env2 })).toEqual({ armed: false, rotated: false, restartRequired: false });
+  });
+  test("resets every row's baseline when called with no id", () => {
+    armSecret("github-token", { env: {} });
+    armSecret("linear-api-token", { env: {} });
+    resetArmState();
+    expect(armSecret("github-token", { env: { GH_TOKEN: "x" } })).toEqual({ armed: false, rotated: false, restartRequired: false });
+  });
+});

--- a/plugins/dev/scripts/lib/secret-contract.test.mjs
+++ b/plugins/dev/scripts/lib/secret-contract.test.mjs
@@ -75,6 +75,43 @@ describe("SECRET_REGISTRY — shape", () => {
     expect(SECRET_REGISTRY.length).toBe(11);
   });
 
+  test("DEEP-FREEZE (Codex finding fix): every row's NESTED envNames array is also frozen, not just the outer row object", () => {
+    for (const row of SECRET_REGISTRY) {
+      expect(Object.isFrozen(row.envNames)).toBe(true);
+      expect(() => {
+        row.envNames.push("EVIL_ALIAS");
+      }).toThrow();
+    }
+  });
+
+  test("DEEP-FREEZE: every row's NESTED rotation object is also frozen — mutating it cannot permanently alter later resolution/hook/arm behavior", () => {
+    const row = getSecretRow("github-token");
+    expect(Object.isFrozen(row.rotation)).toBe(true);
+    expect(() => {
+      row.rotation.class = "boot-only";
+    }).toThrow();
+    // The registry itself is unaffected regardless — re-reading the row shows the original.
+    expect(getSecretRow("github-token").rotation.class).toBe("re-armable");
+  });
+
+  test("DEEP-FREEZE: age-key's nested defaultLocalPath array is frozen", () => {
+    const row = getSecretRow("age-key");
+    expect(Object.isFrozen(row.defaultLocalPath)).toBe(true);
+    expect(() => {
+      row.defaultLocalPath.push("evil");
+    }).toThrow();
+  });
+
+  test("DEEP-FREEZE: resolveSecret never returns a mutable live rotation reference — the caller cannot corrupt later resolutions for the same id", () => {
+    const r1 = resolveSecret("github-token", { env: {} });
+    expect(Object.isFrozen(r1.rotation)).toBe(true);
+    expect(() => {
+      r1.rotation.class = "hacked";
+    }).toThrow();
+    const r2 = resolveSecret("github-token", { env: {} });
+    expect(r2.rotation.class).toBe("re-armable");
+  });
+
   test("every row's delivery is a member of SECRET_DELIVERY", () => {
     for (const row of SECRET_REGISTRY) expect(SECRET_DELIVERY).toContain(row.delivery);
   });
@@ -223,6 +260,20 @@ describe("resolveSecret — bare-file delivery (github-token)", () => {
     const r = resolveSecret("github-token", { env: { CATALYST_CONFIG_DIR: dir, GH_TOKEN: "fallback" } });
     expect(r).toMatchObject({ value: "fallback", source: "inherited" });
   });
+  test("NON-UTF-8 BYTES (Codex finding fix): a file whose bytes are not valid UTF-8 is REJECTED consistently — never silently served as a U+FFFD-mutated credential — falls through to env alias", () => {
+    const dir = fixtureDir();
+    // 0xFF 0xFE is not a valid UTF-8 byte sequence anywhere; readFileSync(...,"utf8") would
+    // silently replace it with U+FFFD U+FFFD without this guard.
+    writeFile(dir, "github-token", Buffer.from([0xff, 0xfe, 0x68, 0x69]));
+    const r = resolveSecret("github-token", { env: { CATALYST_CONFIG_DIR: dir, GH_TOKEN: "fallback-after-bad-utf8" } });
+    expect(r).toMatchObject({ value: "fallback-after-bad-utf8", source: "inherited" });
+  });
+  test("valid multi-byte UTF-8 (e.g. an emoji/check-mark in a token) is preserved, not rejected", () => {
+    const dir = fixtureDir();
+    writeFile(dir, "github-token", Buffer.from("tok-✓-value\n", "utf8"));
+    const r = resolveSecret("github-token", { env: { CATALYST_CONFIG_DIR: dir } });
+    expect(r).toMatchObject({ value: "tok-✓-value", source: "shared-file" });
+  });
 });
 
 describe("resolveSecret — unknown id", () => {
@@ -276,15 +327,44 @@ describe("resolveSecret — env-alias delivery (linear-api-token)", () => {
 });
 
 describe("resolveSecret — config-json delivery (linear-orchestrator-actor, groq-api-key)", () => {
-  test("reads the dotted path from the Layer-2 file", () => {
+  test("ACTOR ROW SHAPE (Codex finding fix): the AUTHORITATIVE Layer-2 schema stores catalyst.linear.bot.orchestrator as an OBJECT ({clientId, clientSecret, ...}), never a string — the pre-fix test here fixtured a string CONTAINING json text, masking that resolveConfigJson only accepted strings and every real production config resolved to none", () => {
     const dir = fixtureDir();
     const l2 = writeFile(
       dir,
       "config.json",
-      JSON.stringify({ catalyst: { linear: { bot: { orchestrator: '{"apiKey":"x"}' } } } }),
+      JSON.stringify({
+        catalyst: { linear: { bot: { orchestrator: { clientSecret: "s3cr3t", clientId: "abc123" } } } },
+      }),
     );
     const r = resolveSecret("linear-orchestrator-actor", { env: { CATALYST_LAYER2_CONFIG_FILE: l2 } });
-    expect(r).toMatchObject({ value: '{"apiKey":"x"}', source: "config-json" });
+    expect(r.source).toBe("config-json");
+    // Canonicalized (sorted-key) so both languages produce the identical byte string
+    // regardless of source field order.
+    expect(r.value).toBe('{"clientId":"abc123","clientSecret":"s3cr3t"}');
+    // The row's value semantics must let a future consumer extract clientId/clientSecret.
+    expect(JSON.parse(r.value)).toEqual({ clientId: "abc123", clientSecret: "s3cr3t" });
+  });
+  test("reads the dotted path from the Layer-2 file (string-shaped config-json value, e.g. groq-api-key)", () => {
+    const dir = fixtureDir();
+    const l2 = writeFile(
+      dir,
+      "config.json",
+      JSON.stringify({ groq: { apiKey: "plain-string-value" } }),
+    );
+    const r = resolveSecret("groq-api-key", { env: { CATALYST_LAYER2_CONFIG_FILE: l2 } });
+    expect(r).toMatchObject({ value: "plain-string-value", source: "config-json" });
+  });
+  test("an EMPTY object at the path resolves to the canonical empty-object string, not silently coerced to none", () => {
+    const dir = fixtureDir();
+    const l2 = writeFile(dir, "config.json", JSON.stringify({ catalyst: { linear: { bot: { orchestrator: {} } } } }));
+    const r = resolveSecret("linear-orchestrator-actor", { env: { CATALYST_LAYER2_CONFIG_FILE: l2 } });
+    expect(r).toMatchObject({ value: "{}", source: "config-json" });
+  });
+  test("an ARRAY at the path is rejected (not a valid credential shape) — settles as none", () => {
+    const dir = fixtureDir();
+    const l2 = writeFile(dir, "config.json", JSON.stringify({ catalyst: { linear: { bot: { orchestrator: ["nope"] } } } }));
+    const r = resolveSecret("linear-orchestrator-actor", { env: { CATALYST_LAYER2_CONFIG_FILE: l2 } });
+    expect(r).toMatchObject({ value: null, source: "none" });
   });
   test("groq-api-key prefers the env alias over the config path (matches resolveApiKey's env-first precedence)", () => {
     const dir = fixtureDir();
@@ -311,6 +391,101 @@ describe("resolveSecret — config-json delivery (linear-orchestrator-actor, gro
     const l2 = writeFile(dir, "config.json", JSON.stringify({}));
     const r = resolveSecret("linear-worker-actor", { env: { CATALYST_LAYER2_CONFIG_FILE: l2 } });
     expect(r).toMatchObject({ value: null, source: "none" });
+  });
+  test("JSON ACCEPTANCE NORMALIZATION (Codex finding fix): an unpaired-surrogate escape ANYWHERE in the document — even outside the field being read — settles the whole layer as malformed (matches jq's whole-document rejection, exit 5)", () => {
+    const dir = fixtureDir();
+    // The lone \ud800 escape lives in an UNRELATED field; the real value at groq.apiKey is
+    // otherwise perfectly valid. jq rejects the ENTIRE document (verified: exit 5) so the
+    // bash mirror can never see ANY value out of this file — JS must degrade identically.
+    const l2 = writeFile(
+      dir,
+      "config.json",
+      '{"groq":{"apiKey":"from-config"},"unrelated":"clu\\ud800ster"}',
+    );
+    const r = resolveSecret("groq-api-key", { env: { CATALYST_LAYER2_CONFIG_FILE: l2 } });
+    expect(r).toMatchObject({ value: null, source: "none" });
+  });
+});
+
+// hasLiveLoneHighSurrogateEscape is an unexported module-internal helper (same convention as
+// every other readJsonField primitive in this file — containsNul, stripEol, etc. are never
+// exported either); these tests exercise its documented semantics through the one public
+// boundary that observes it, resolveSecret's config-json path, exactly like the "JSON
+// ACCEPTANCE NORMALIZATION" test right above. Verified against real jq 1.7.1 throughout (see
+// the scanner's own doc comment in lib/secret-contract.mjs for the exact jq invocations).
+describe("hasLiveLoneHighSurrogateEscape scanner — E4/E6 jq parity", () => {
+  test("odd backslash run (length 1) before a HIGH surrogate escape is LIVE; unpaired ⇒ rejects the whole document (E4/control)", () => {
+    const dir = fixtureDir();
+    const l2 = writeFile(
+      dir,
+      "config.json",
+      '{"groq":{"apiKey":"good"},"unrelated":"clu\\ud800ster"}',
+    );
+    const r = resolveSecret("groq-api-key", { env: { CATALYST_LAYER2_CONFIG_FILE: l2 } });
+    expect(r).toMatchObject({ value: null, source: "none" });
+  });
+
+  test("odd backslash run (length 1) before a LOW surrogate escape is LIVE; lone LOW is ACCEPTED (jq exit 0), not rejected (E4a)", () => {
+    const dir = fixtureDir();
+    const l2 = writeFile(
+      dir,
+      "config.json",
+      '{"groq":{"apiKey":"good"},"unrelated":"clu\\udc00ster"}',
+    );
+    const r = resolveSecret("groq-api-key", { env: { CATALYST_LAYER2_CONFIG_FILE: l2 } });
+    expect(r).toMatchObject({ value: "good", source: "config-json" });
+  });
+
+  test("even backslash run (length 2) before 'u' is NOT live — it is an escaped literal backslash followed by ordinary text; the document is not rejected (E6)", () => {
+    const dir = fixtureDir();
+    // Raw file text carries the LITERAL 7-character sequence \\ud800 (escaped backslash +
+    // the 5 literal characters "ud800") — valid JSON, and not an escape at all.
+    const l2 = writeFile(
+      dir,
+      "config.json",
+      '{"groq":{"apiKey":"good"},"unrelated":"literal \\\\ud800 text"}',
+    );
+    const r = resolveSecret("groq-api-key", { env: { CATALYST_LAYER2_CONFIG_FILE: l2 } });
+    expect(r).toMatchObject({ value: "good", source: "config-json" });
+    // The literal backslash+text itself round-trips untouched when it IS the read field.
+    const l2b = writeFile(
+      dir,
+      "config2.json",
+      '{"groq":{"apiKey":"literal \\\\ud800 text"}}',
+    );
+    const r2 = resolveSecret("groq-api-key", { env: { CATALYST_LAYER2_CONFIG_FILE: l2b } });
+    expect(r2).toMatchObject({ value: "literal \\ud800 text", source: "config-json" });
+  });
+
+  test("a live HIGH surrogate escape immediately (textually adjacent) followed by a live LOW surrogate escape is a paired astral character — accepted, not rejected", () => {
+    const dir = fixtureDir();
+    const l2 = writeFile(dir, "config.json", '{"groq":{"apiKey":"x\\ud800\\udc00y"}}');
+    const r = resolveSecret("groq-api-key", { env: { CATALYST_LAYER2_CONFIG_FILE: l2 } });
+    expect(r).toMatchObject({ value: "x\u{10000}y", source: "config-json" });
+  });
+
+  test("a live HIGH surrogate escape NOT textually adjacent to a following LOW escape remains unpaired — rejects the document", () => {
+    const dir = fixtureDir();
+    // A literal "Y" sits between the two escapes, breaking adjacency.
+    const l2 = writeFile(dir, "config.json", '{"groq":{"apiKey":"x\\ud800Y\\udc00y"}}');
+    const r = resolveSecret("groq-api-key", { env: { CATALYST_LAYER2_CONFIG_FILE: l2 } });
+    expect(r).toMatchObject({ value: null, source: "none" });
+  });
+
+  test("a live HIGH surrogate escape immediately followed by a NON-live (even-backslash-run) low-looking escape remains unpaired — rejects the document", () => {
+    const dir = fixtureDir();
+    // "\ud800" (live, HIGH) directly followed by "\\udc00" (even run — literal text, not an
+    // escape) — the pairing candidate must itself be LIVE to count, so this does not pair.
+    const l2 = writeFile(dir, "config.json", '{"groq":{"apiKey":"x\\ud800\\\\udc00y"}}');
+    const r = resolveSecret("groq-api-key", { env: { CATALYST_LAYER2_CONFIG_FILE: l2 } });
+    expect(r).toMatchObject({ value: null, source: "none" });
+  });
+
+  test("a live lone LOW surrogate escape INSIDE the resolved value itself is normalized to U+FFFD at the value-extraction boundary, mirroring jq's own replacement (E4b)", () => {
+    const dir = fixtureDir();
+    const l2 = writeFile(dir, "config.json", '{"groq":{"apiKey":"x\\udc00y"}}');
+    const r = resolveSecret("groq-api-key", { env: { CATALYST_LAYER2_CONFIG_FILE: l2 } });
+    expect(r).toMatchObject({ value: "x�y", source: "config-json" });
   });
 });
 
@@ -421,6 +596,29 @@ describe("resolveSecret — cloud guard (design §4)", () => {
     expect(r.source).toBe("none"); // resolves normally (absent), not short-circuited to null/null-provider
     expect(r.provider).toBe("platform-env");
   });
+  test("CLOUD-TOKEN NAME OVERRIDE (Codex finding fix): genuine cloud mode honors CATALYST_CLOUD_TOKEN_ENV, not only the hardcoded default name — a direct resolveSecret('cloud-token', {deploymentMode}) call previously bypassed resolveCloudTokenName entirely", () => {
+    const r = resolveSecret("cloud-token", {
+      env: { CATALYST_CLOUD_TOKEN_ENV: "MY_PLATFORM_TOKEN", MY_PLATFORM_TOKEN: "the-real-token" },
+      deploymentMode: { mode: "cloud", inferred: false },
+    });
+    expect(r).toMatchObject({ value: "the-real-token", source: "platform-env", envVar: "MY_PLATFORM_TOKEN", envVarSource: "env" });
+  });
+  test("CLOUD-TOKEN NAME OVERRIDE: genuine cloud mode honors the Layer-2 catalyst.cloud.tokenEnv override too", () => {
+    const dir = fixtureDir();
+    const l2 = writeFile(dir, "config.json", JSON.stringify({ catalyst: { cloud: { tokenEnv: "OTHER_TOKEN_VAR" } } }));
+    const r = resolveSecret("cloud-token", {
+      env: { CATALYST_LAYER2_CONFIG_FILE: l2, OTHER_TOKEN_VAR: "v2" },
+      deploymentMode: { mode: "cloud", inferred: false },
+    });
+    expect(r).toMatchObject({ value: "v2", source: "platform-env", envVar: "OTHER_TOKEN_VAR", envVarSource: "layer2" });
+  });
+  test("CLOUD-TOKEN NAME OVERRIDE: an overridden name with only the DEFAULT var set (not the override) still resolves none — the override name is genuinely the one consulted, not silently ignored in favor of the default", () => {
+    const r = resolveSecret("cloud-token", {
+      env: { CATALYST_CLOUD_TOKEN_ENV: "MY_PLATFORM_TOKEN", CATALYST_CLOUD_TOKEN: "should-not-be-used" },
+      deploymentMode: { mode: "cloud", inferred: false },
+    });
+    expect(r).toMatchObject({ value: null, source: "none", envVar: "MY_PLATFORM_TOKEN" });
+  });
 });
 
 // ─── Registry validation (design §6) ─────────────────────────────────────────────────────
@@ -504,6 +702,64 @@ describe("armSecret — n/a rows and unknown ids", () => {
   });
   test("unknown id never throws", () => {
     expect(armSecret("does-not-exist", { env: {} })).toEqual({ armed: false, rotated: false, restartRequired: false });
+  });
+});
+
+describe("armSecret — deployment-mode threading (Codex finding fix, design §8)", () => {
+  test("cloud mode with an injected env token AND a stale local file: arm's baseline matches DIRECT resolution (the env value), not the file — a file-only edit must not report a false restartRequired, and the real env rotation MUST be detected", () => {
+    const dir = fixtureDir();
+    writeFile(dir, "github-token", "stale-file-value-v1");
+    const deploymentMode = { mode: "cloud", inferred: false };
+    const env1 = { CATALYST_CONFIG_DIR: dir, GH_TOKEN: "cloud-injected-v1", CATALYST_CLOUD_TOKEN: "boot" };
+
+    // Direct resolution (the ground truth armSecret's baseline must match) resolves via the
+    // env alias, never the file, in genuine cloud mode.
+    const direct = resolveSecret("github-token", { env: env1, deploymentMode });
+    expect(direct).toMatchObject({ value: "cloud-injected-v1", source: "inherited" });
+
+    // First arm call establishes the baseline.
+    expect(armSecret("github-token", { env: env1, deploymentMode })).toEqual({
+      armed: false,
+      rotated: false,
+      restartRequired: false,
+    });
+
+    // Rewriting the STALE FILE ONLY must NOT be observed as a rotation — the arm baseline is
+    // the env-derived value, exactly like direct resolution, never the file's contents.
+    writeFileSync(resolve(dir, "github-token"), "stale-file-value-v2-changed");
+    expect(armSecret("github-token", { env: env1, deploymentMode })).toEqual({
+      armed: false,
+      rotated: false,
+      restartRequired: false,
+    });
+
+    // Rotating the ACTUAL cloud-injected env value MUST be detected.
+    const env2 = { ...env1, GH_TOKEN: "cloud-injected-v2-rotated" };
+    expect(armSecret("github-token", { env: env2, deploymentMode })).toEqual({
+      armed: false,
+      rotated: true,
+      restartRequired: true,
+    });
+  });
+
+  test("omitting deploymentMode entirely preserves today's non-cloud behavior exactly (default parity with resolveSecret's own default)", () => {
+    const dir = fixtureDir();
+    writeFile(dir, "github-token", "file-v1");
+    const env = { CATALYST_CONFIG_DIR: dir };
+    expect(armSecret("github-token", { env })).toEqual({ armed: false, rotated: false, restartRequired: false });
+    writeFileSync(resolve(dir, "github-token"), "file-v2");
+    expect(armSecret("github-token", { env })).toEqual({ armed: false, rotated: true, restartRequired: true });
+  });
+
+  test("hook path also receives deploymentMode in its context object", () => {
+    let received;
+    registerRearmHook("github-token", (ctx) => {
+      received = ctx;
+      return { rearmed: true };
+    });
+    const deploymentMode = { mode: "cluster", inferred: false };
+    armSecret("github-token", { env: {}, deploymentMode });
+    expect(received.deploymentMode).toEqual(deploymentMode);
   });
 });
 


### PR DESCRIPTION
## Summary

First slice of CTL-1616 (design: `thoughts/shared/research/2026-08-02-ctl-1616-secret-contract-design.md`, migration-risk-first base per the judge panel): the **secret CONTRACT/registry** — 11 seed rows covering every family in the divergence inventory — as a zero-import bash+JS pair, with exactly one consumer: `cluster-sync.mjs` now **derives** `ENV_BACKED_SECRET_EXACT` and the linear-webhook-secret family predicate from the registry (the design's judge-unanimous same-commit rule — no second hand-maintained secret list survives this commit; set-equality test pins the historical literals).

Key properties:
- Registry as **code** (runtime-parsed JSON was ruled fatally unsafe by the panel) — name → envNames (order-sensitive), delivery, rotation class/trigger, bootstrap class, config-json path.
- **Bootstrap class is explicit**: `age-key` (cluster) and `cloud-token` (cloud) are the one locally-rooted credential per mode; age-key's *value* is unfetchable through any contract path by construction.
- **Rotation model**: `armSecret` reports `{rotated, restartRequired}` (Gherkin Scenario 2); hookless re-armable rows degrade like boot-only until a rearm hook is registered (hooks live outside the leaf).
- **Deployment-mode seam**: provider dispatch consumes the CTL-1617 resolver's full resolution object; cloud providers never activate on `inferred:true`.
- Bash mirror hardened against the full CTL-1617-era hostile-input catalog from day one: strict-IFS, errexit/POSIX-mode, NUL bytes, empty JSON strings, pipe-containing values (both short-circuit and rotation-diff sites read the in-shell breadcrumb — no delimited-stdout parsing), bash-3.2 stock compatibility.

## Verification

- 76 bash unit tests (identical under `/bin/bash` 3.2.57 and bash 5.3), **107-cell three-way parity suite** (per-row field table across all 11 rows × 6 fields, bash==expected AND node==expected; hostile cells), 70 JS unit, cluster-sync 74/74.
- Mutation-validated: flipping one bash registry field or narrowing the derivation filter fails exactly the expected assertions and nothing else.
- Two adversarial Fable verification rounds; all 7 blocking findings across rounds fixed with pinned regressions.
- shellcheck clean; CTL-1612/CTL-1617 regression suites all green.

Next slices per the migration plan: doctor-through-the-contract, then the 9-copy Linear read fold-in, the 3-copy OAuth mint, cloud-token + Groq adoption.

Linear: CTL-1616

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WHfJt1JhsdArSUyxwZZzkN