### PR TITLE
fix(dev): CTL-1617 whole-document lone-surrogate parity + architecture-doc precision

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -108,28 +108,34 @@ direct writes (broker sole writer). Phase 3: mirror to SQLite per ADR-011. See A
 ## Deployment Mode (CTL-1617)
 
 One declared answer — **`catalyst.deployment.mode` ∈ `single-host` | `cluster` | `cloud`** — replaces
-the per-host hand-wiring of mode-dependent choices (event source, secret provider of record, cluster
-expectations). Resolved identically in bash and JS by a zero-import pair
+the per-host hand-wiring of mode-dependent choices. Resolved by a zero-import bash+JS pair
 (`plugins/dev/scripts/lib/deployment-mode.mjs` + `lib/catalyst-deployment-mode.sh`), kept honest by
-an exhaustive cross-stack parity fixture matrix (`__tests__/deployment-mode-parity.test.sh`).
+an exhaustive cross-stack parity fixture matrix (`__tests__/deployment-mode-parity.test.sh`). The
+schema itself (precedence ladder, examples, defaulting, every caveat) lives in its canonical
+reference, `website/src/content/docs/reference/configuration.md` — this section covers only the
+architectural role. **This repo's Layer-1 declares `cluster`**; dev-clones override to `single-host`
+via Layer-2.
 
-- **Precedence**: `CATALYST_DEPLOYMENT_MODE` env → Layer-2 `catalyst.deployment.mode` (per-host
-  override, wins when present) → Layer-1 (committed fleet default; **this repo declares `cluster`**)
-  → constant `single-host`. The default is a constant, never roster-inferred — a derived default
-  silently flips with roster state and forces the two languages onto divergent inference signals.
-- **Degradation is the safety direction**: non-string / typo values settle at their layer as
-  `single-host, recognized:false` (asserting the fewest cross-host guarantees); malformed files
-  (bad JSON, multi-document, BOM, lone-surrogate strings) are layer-absent in BOTH languages.
-- **Consumers**: `catalyst doctor` (`checkDeploymentModeConsistency`, advisory: declared/inferred,
-  typo FAIL, roster-consistency WARN — every message says "deployment mode", never bare "mode",
-  since `dispatchMode`, executor dispatch-mode telemetry, and the replica reader's `mode` are
-  unrelated concepts); the orch-monitor smee tunnel gate (tunnels start only when the mode is not
-  `cloud`); and the CTL-1616 secret contract's provider-of-record dispatch, which receives the FULL
-  resolution object and never activates a cloud provider on `inferred:true`.
+- **Degradation is the safety direction**: invalid values settle at their layer as
+  `single-host, recognized:false` (asserting the fewest cross-host guarantees); malformed files are
+  layer-absent in BOTH languages. Two supported, deliberate asymmetry bounds: on a **jq-less host**
+  the bash resolver treats config files as absent (env-else-default, with a
+  `CATALYST_DEPLOYMENT_MODE_JQ_MISSING` breadcrumb for doctor) while the JS resolver still reads
+  them; and file-acceptance parity is defined by jq's parser (multi-document, BOM, and
+  lone-surrogate-escape documents are whole-document-malformed on both sides — the JS reader scans
+  raw text to match).
+- **Consumers today**: `catalyst doctor` (`checkDeploymentModeConsistency`, advisory:
+  declared/inferred, typo FAIL, roster-consistency WARN — every message says "deployment mode",
+  never bare "mode", since `dispatchMode`, executor dispatch-mode telemetry, and the replica
+  reader's `mode` are unrelated concepts) and the orch-monitor smee tunnel gate (a declared-`cloud`
+  node suppresses tunnel start; the replacement cloud-SDK event connection is **future work** — the
+  smee→cloud cutover, ADR-0008 lineage — so `cloud` today means "no smee ingestion", not "cloud
+  ingestion wired"). **Planned consumer**: the CTL-1616 secret contract's provider-of-record
+  dispatch receives the full resolution object and never activates a cloud provider on
+  `inferred:true`.
 - **Orthogonal axes, never merged**: deployment mode (fleet topology) × `catalyst.node.class`
   (per-machine role) × `orchestration.dispatchMode` (process substrate within a node).
-- Full reference (schema, examples, caveats): `website/src/content/docs/reference/configuration.md`;
-  design + migration plan: `thoughts/shared/research/2026-08-02-ctl-1617-deployment-mode-design.md`.
+- Design + migration plan: `thoughts/shared/research/2026-08-02-ctl-1617-deployment-mode-design.md`.
 
 ## Agent Teams vs Subagents
 

--- a/plugins/dev/scripts/__tests__/catalyst-deployment-mode.test.sh
+++ b/plugins/dev/scripts/__tests__/catalyst-deployment-mode.test.sh
@@ -206,11 +206,26 @@ OUT="$(env -i PATH="$PATH" HOME="$HOME" CATALYST_LAYER2_CONFIG_FILE="$R2_BOM" CA
 expect_eq "BOM-prefixed Layer-2 is layer-malformed → falls through" "cluster|layer1" "$OUT"
 
 # --- Codex round 2: HOME-unset resolution never probes /.config -------------
-# With HOME unset the resolver must still complete (tilde expansion falls back
-# to the passwd home, mirroring os.homedir()) and settle a valid Layer-1.
-OUT="$(env -i PATH="$PATH" CATALYST_CONFIG_FILE="$R2_L1" \
+# HERMETICITY BOUND: with HOME unset, tilde expansion falls back to the REAL
+# passwd home (mirroring os.homedir()) — which this sandbox cannot fake, so an
+# end-to-end assertion through the default Layer-2 path reads the developer's
+# actual ~/.config/catalyst/config.json and breaks the moment that file
+# declares a deployment mode (observed live 2026-08-03 when this machine
+# gained its Layer-2 override). Assert the two halves separately instead:
+# (1) the tilde fallback derives a real absolute home (never "" → /.config);
+# shellcheck disable=SC2016 # single quotes deliberate — the INNER shell must expand
+HOME_FALLBACK="$(env -i PATH="$PATH" bash -c 'unset HOME; h=~; printf "%s" "$h"')"
+if [[ "$HOME_FALLBACK" == /* && "$HOME_FALLBACK" != "/" ]]; then
+  ok "HOME unset: tilde fallback derives an absolute passwd home (never /.config)"
+else
+  fail "HOME unset: tilde fallback derives an absolute passwd home (never /.config)" \
+    "got '$HOME_FALLBACK'"
+fi
+# (2) the resolver completes under unset HOME with the Layer-2 path pinned
+# hermetically (no crash, no set -u abort, Layer-1 settles).
+OUT="$(env -i PATH="$PATH" CATALYST_LAYER2_CONFIG_FILE="$MISSING" CATALYST_CONFIG_FILE="$R2_L1" \
   bash -c "unset HOME; source '$LIB'; catalyst_resolve_deployment_mode >/dev/null; printf '%s|%s' \"\$CATALYST_DEPLOYMENT_MODE_RESOLVED\" \"\$CATALYST_DEPLOYMENT_MODE_SOURCE\"")"
-expect_eq "HOME unset: resolver completes via passwd-home fallback" "cluster|layer1" "$OUT"
+expect_eq "HOME unset: resolver completes without crashing (hermetic Layer-2)" "cluster|layer1" "$OUT"
 
 # --- Codex round 2: jq-missing breadcrumb resets per resolution -------------
 # First resolution with jq hidden and a readable file → breadcrumb=1; a second

--- a/plugins/dev/scripts/__tests__/deployment-mode-parity.test.sh
+++ b/plugins/dev/scripts/__tests__/deployment-mode-parity.test.sh
@@ -316,6 +316,33 @@ HOSTILE=$((HOSTILE+1))
 expect_eq "hostile: lone-surrogate Layer-2 JSON (bash==expected, falls through)" "$EXPECTED" "$BASH_OUT"
 expect_eq "hostile: lone-surrogate Layer-2 JSON (node==expected, falls through — JS narrowed to match jq)" "$EXPECTED" "$NODE_OUT"
 
+# --- Probe 4b: lone surrogate in an UNRELATED field (Codex on #2903) --------
+# {"mode":"cloud","other":"\ud800"}: jq rejects the WHOLE document, so bash
+# falls through — the JS reader must scan the RAW TEXT for unpaired surrogate
+# escapes (not just the extracted mode string) to match. A valid recognized
+# mode beside a poisoned sibling field must fall through on BOTH sides.
+rm -f "$L2_PATH" "$L1_PATH"
+printf '%s' "{\"catalyst\":{\"deployment\":{\"mode\":\"cloud\",\"other\":\"x${BACKSLASH}ud800\"}}}" > "$L2_PATH"
+printf '%s' '{"catalyst":{"deployment":{"mode":"cluster"}}}' > "$L1_PATH"
+EXPECTED="cluster|layer1|true|false"
+BASH_OUT="$(run_bash_probe)"
+NODE_OUT="$(run_node_probe)"
+HOSTILE=$((HOSTILE+1))
+expect_eq "hostile: lone surrogate in an UNRELATED field (bash==expected, whole document rejected)" "$EXPECTED" "$BASH_OUT"
+expect_eq "hostile: lone surrogate in an UNRELATED field (node==expected, raw-text scan matches jq)" "$EXPECTED" "$NODE_OUT"
+
+# Control: a VALID surrogate PAIR anywhere in the document parses in BOTH
+# languages — the raw-text scan must not over-reject astral characters.
+rm -f "$L2_PATH" "$L1_PATH"
+printf '%s' "{\"catalyst\":{\"deployment\":{\"mode\":\"cloud\",\"other\":\"x${BACKSLASH}ud83d${BACKSLASH}ude00\"}}}" > "$L2_PATH"
+printf '%s' '{"catalyst":{"deployment":{"mode":"cluster"}}}' > "$L1_PATH"
+EXPECTED="cloud|layer2|true|false"
+BASH_OUT="$(run_bash_probe)"
+NODE_OUT="$(run_node_probe)"
+HOSTILE=$((HOSTILE+1))
+expect_eq "control: valid surrogate PAIR in a sibling field parses (bash==expected)" "$EXPECTED" "$BASH_OUT"
+expect_eq "control: valid surrogate PAIR in a sibling field parses (node==expected)" "$EXPECTED" "$NODE_OUT"
+
 # --- Probe 5: multi-document Layer-2 JSON — FIXED, bash==node==expected ---
 # Two valid top-level documents. Bare jq streams both (exit 0, two tags,
 # bypassing the exit-status guard); JSON.parse rejects the file. The bash
@@ -344,7 +371,7 @@ HOSTILE=$((HOSTILE+1))
 expect_eq "hostile: BOM-prefixed Layer-2 JSON (bash==expected, falls through)" "$EXPECTED" "$BASH_OUT"
 expect_eq "hostile: BOM-prefixed Layer-2 JSON (node==expected, falls through)" "$EXPECTED" "$NODE_OUT"
 
-echo "Hostile probes run: $HOSTILE (NUL-escape / NBSP-padded-env / malformed-trailing-content / lone-surrogate / multi-document / BOM; 2 assertions/probe)"
+echo "Hostile probes run: $HOSTILE (NUL-escape / NBSP-padded-env / malformed-trailing-content / lone-surrogate x2 + pair-control / multi-document / BOM; 2 assertions/probe)"
 echo ""
 echo "Total: $((PASSES + FAILURES)), Passed: $PASSES, Failed: $FAILURES, Skipped: $SKIPPED"
 exit "$FAILURES"

--- a/plugins/dev/scripts/lib/deployment-mode.mjs
+++ b/plugins/dev/scripts/lib/deployment-mode.mjs
@@ -117,16 +117,33 @@ function resolveLayer1Path(env, layer1ConfigPath) {
 // UNPAIRED_SURROGATE — a UTF-16 code unit in the surrogate range that is not
 // part of a valid high+low pair. JSON.parse accepts lone-surrogate escapes
 // (`"clu\ud800ster"`) but jq rejects the WHOLE document (exit 5), so the bash
-// mirror can never see such a value. Parity rule: a mode string carrying an
-// unpaired surrogate makes the LAYER malformed in BOTH languages — fall
-// through, exactly as bash does after jq's rejection. Valid surrogate PAIRS
-// (astral characters) parse fine in both and are simply non-members.
+// mirror can never see ANY value out of such a file. Parity rule: an unpaired
+// surrogate escape ANYWHERE in the document makes the LAYER malformed in BOTH
+// languages — fall through, exactly as bash does after jq's whole-document
+// rejection. (Codex on #2903 proved checking only the extracted mode string
+// diverges: {"mode":"cloud","other":"\ud800"} fell through in bash but
+// resolved cloud in JS.) Valid surrogate PAIRS (astral characters) parse fine
+// in both and are simply non-members.
+//
+// The RAW-TEXT scan matches escape SEQUENCES (`\uD800` as six source chars,
+// case-insensitive, not preceded by a pair-forming high escape / not followed
+// by a low escape). Literal surrogate BYTES cannot occur: they are not valid
+// UTF-8, so a file containing them fails both parsers anyway. An even number
+// of preceding backslashes means the escape is live; this scan deliberately
+// over-rejects the pathological `\\ud800` (escaped-backslash-then-text) case —
+// a config whose text spells a surrogate escape at all is treated as malformed
+// at that layer, which only ever degrades toward fall-through, never toward
+// activating a mode.
 const UNPAIRED_SURROGATE =
   /(?:[\uD800-\uDBFF](?![\uDC00-\uDFFF]))|(?:(?<![\uD800-\uDBFF])[\uDC00-\uDFFF])/;
+const UNPAIRED_SURROGATE_ESCAPE =
+  /(?:\\u[dD][89abAB][0-9a-fA-F]{2}(?!\\u[dD][c-fC-F][0-9a-fA-F]{2}))|(?:(?<!\\u[dD][89abAB][0-9a-fA-F]{2})\\u[dD][c-fC-F][0-9a-fA-F]{2})/;
 
 function readDeploymentModeField(filePath) {
   try {
-    const mode = JSON.parse(readFileSync(filePath, "utf8"))?.catalyst?.deployment?.mode;
+    const text = readFileSync(filePath, "utf8");
+    if (UNPAIRED_SURROGATE_ESCAPE.test(text)) return undefined;
+    const mode = JSON.parse(text)?.catalyst?.deployment?.mode;
     if (typeof mode === "string" && UNPAIRED_SURROGATE.test(mode)) return undefined;
     return mode;
   } catch {


### PR DESCRIPTION
## Summary

Follow-up to the 5 Codex threads that raced the #2903 merge. One was a **real code divergence** extracted from the doc wording: jq rejects a whole document when *any* field carries a lone-surrogate escape, while `readDeploymentModeField` checked only the extracted mode string — `{"mode":"cloud","other":"\ud800"}` fell through in bash but resolved `cloud` in JS. The JS reader now scans raw text for unpaired surrogate escape sequences before parsing; parity probe 4b pins the unrelated-field case with an astral-pair control (352 parity assertions).

The other four were documentation precision, all applied: schema details deferred to configuration.md (single-source rule), CTL-1616 relabeled a planned consumer, cloud event-source wording corrected (suppression wired, ingestion future), and the jq-less-host asymmetry bound documented.

The five #2903 threads will be replied/resolved referencing this PR.

Linear: CTL-1617

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WHfJt1JhsdArSUyxwZZzkN