### PR TITLE
fix(dev): CTL-1617 jq-exact lone-surrogate acceptance in the deployment-mode reader

### DIFF
--- a/plugins/dev/scripts/__tests__/deployment-mode-parity.test.sh
+++ b/plugins/dev/scripts/__tests__/deployment-mode-parity.test.sh
@@ -343,6 +343,43 @@ HOSTILE=$((HOSTILE+1))
 expect_eq "control: valid surrogate PAIR in a sibling field parses (bash==expected)" "$EXPECTED" "$BASH_OUT"
 expect_eq "control: valid surrogate PAIR in a sibling field parses (node==expected)" "$EXPECTED" "$NODE_OUT"
 
+# --- Probe 4c: jq-EXACT lone-surrogate semantics (CTL-1616 verifier lesson) ---
+# jq 1.7.1 rejects ONLY lone HIGH escapes; a lone LOW is accepted with U+FFFD
+# substitution, and an escaped-backslash-then-text "\\ud800" is literal text.
+# The JS scanner mirrors all three exactly.
+# (1) lone LOW in the mode VALUE: both engines read a U+FFFD-bearing string,
+#     a non-member, and SETTLE degraded at that layer.
+rm -f "$L2_PATH" "$L1_PATH"
+printf '%s' "{\"catalyst\":{\"deployment\":{\"mode\":\"clu${BACKSLASH}udc00ster\"}}}" > "$L2_PATH"
+printf '%s' '{"catalyst":{"deployment":{"mode":"cluster"}}}' > "$L1_PATH"
+EXPECTED="single-host|layer2|false|false"
+BASH_OUT="$(run_bash_probe)"
+NODE_OUT="$(run_node_probe)"
+HOSTILE=$((HOSTILE+1))
+expect_eq "jq-exact: lone LOW in the mode value settles degraded (bash==expected)" "$EXPECTED" "$BASH_OUT"
+expect_eq "jq-exact: lone LOW in the mode value settles degraded (node==expected)" "$EXPECTED" "$NODE_OUT"
+# (2) lone LOW in an UNRELATED field: document accepted by both, mode resolves.
+rm -f "$L2_PATH" "$L1_PATH"
+printf '%s' "{\"catalyst\":{\"deployment\":{\"mode\":\"cloud\",\"other\":\"x${BACKSLASH}udc00\"}}}" > "$L2_PATH"
+printf '%s' '{"catalyst":{"deployment":{"mode":"cluster"}}}' > "$L1_PATH"
+EXPECTED="cloud|layer2|true|false"
+BASH_OUT="$(run_bash_probe)"
+NODE_OUT="$(run_node_probe)"
+HOSTILE=$((HOSTILE+1))
+expect_eq "jq-exact: lone LOW in an unrelated field is accepted (bash==expected)" "$EXPECTED" "$BASH_OUT"
+expect_eq "jq-exact: lone LOW in an unrelated field is accepted (node==expected)" "$EXPECTED" "$NODE_OUT"
+# (3) escaped backslash + literal "ud800" text (even run — NOT a live escape):
+#     valid JSON both parsers accept; the document must not be rejected.
+rm -f "$L2_PATH" "$L1_PATH"
+printf '%s' "{\"catalyst\":{\"deployment\":{\"mode\":\"cloud\",\"other\":\"${BACKSLASH}${BACKSLASH}ud800\"}}}" > "$L2_PATH"
+printf '%s' '{"catalyst":{"deployment":{"mode":"cluster"}}}' > "$L1_PATH"
+EXPECTED="cloud|layer2|true|false"
+BASH_OUT="$(run_bash_probe)"
+NODE_OUT="$(run_node_probe)"
+HOSTILE=$((HOSTILE+1))
+expect_eq "jq-exact: escaped-backslash literal ud800 text is NOT a live escape (bash==expected)" "$EXPECTED" "$BASH_OUT"
+expect_eq "jq-exact: escaped-backslash literal ud800 text is NOT a live escape (node==expected)" "$EXPECTED" "$NODE_OUT"
+
 # --- Probe 5: multi-document Layer-2 JSON — FIXED, bash==node==expected ---
 # Two valid top-level documents. Bare jq streams both (exit 0, two tags,
 # bypassing the exit-status guard); JSON.parse rejects the file. The bash
@@ -371,7 +408,7 @@ HOSTILE=$((HOSTILE+1))
 expect_eq "hostile: BOM-prefixed Layer-2 JSON (bash==expected, falls through)" "$EXPECTED" "$BASH_OUT"
 expect_eq "hostile: BOM-prefixed Layer-2 JSON (node==expected, falls through)" "$EXPECTED" "$NODE_OUT"
 
-echo "Hostile probes run: $HOSTILE (NUL-escape / NBSP-padded-env / malformed-trailing-content / lone-surrogate x2 + pair-control / multi-document / BOM; 2 assertions/probe)"
+echo "Hostile probes run: $HOSTILE (NUL-escape / NBSP-padded-env / malformed-trailing-content / lone-HIGH x2 + lone-LOW x2 + literal-text + pair-control / multi-document / BOM; 2 assertions/probe)"
 echo ""
 echo "Total: $((PASSES + FAILURES)), Passed: $PASSES, Failed: $FAILURES, Skipped: $SKIPPED"
 exit "$FAILURES"

--- a/plugins/dev/scripts/lib/deployment-mode.mjs
+++ b/plugins/dev/scripts/lib/deployment-mode.mjs
@@ -114,38 +114,69 @@ function resolveLayer1Path(env, layer1ConfigPath) {
 // absent/malformed/unreadable OR the key is simply not present — both count
 // as "nothing here, try the next layer" (the readLayer2NodeClass contract,
 // execution-core/config.mjs:312-325). Never throws.
-// UNPAIRED_SURROGATE — a UTF-16 code unit in the surrogate range that is not
-// part of a valid high+low pair. JSON.parse accepts lone-surrogate escapes
-// (`"clu\ud800ster"`) but jq rejects the WHOLE document (exit 5), so the bash
-// mirror can never see ANY value out of such a file. Parity rule: an unpaired
-// surrogate escape ANYWHERE in the document makes the LAYER malformed in BOTH
-// languages — fall through, exactly as bash does after jq's whole-document
-// rejection. (Codex on #2903 proved checking only the extracted mode string
-// diverges: {"mode":"cloud","other":"\ud800"} fell through in bash but
-// resolved cloud in JS.) Valid surrogate PAIRS (astral characters) parse fine
-// in both and are simply non-members.
-//
-// The RAW-TEXT scan matches escape SEQUENCES (`\uD800` as six source chars,
-// case-insensitive, not preceded by a pair-forming high escape / not followed
-// by a low escape). Literal surrogate BYTES cannot occur: they are not valid
-// UTF-8, so a file containing them fails both parsers anyway. An even number
-// of preceding backslashes means the escape is live; this scan deliberately
-// over-rejects the pathological `\\ud800` (escaped-backslash-then-text) case —
-// a config whose text spells a surrogate escape at all is treated as malformed
-// at that layer, which only ever degrades toward fall-through, never toward
-// activating a mode.
-const UNPAIRED_SURROGATE =
-  /(?:[\uD800-\uDBFF](?![\uDC00-\uDFFF]))|(?:(?<![\uD800-\uDBFF])[\uDC00-\uDFFF])/;
-const UNPAIRED_SURROGATE_ESCAPE =
-  /(?:\\u[dD][89abAB][0-9a-fA-F]{2}(?!\\u[dD][c-fC-F][0-9a-fA-F]{2}))|(?:(?<!\\u[dD][89abAB][0-9a-fA-F]{2})\\u[dD][c-fC-F][0-9a-fA-F]{2})/;
+// JSON acceptance mirrors jq's ACTUAL parser (the bash mirror's engine), not an
+// approximation. The earlier regex guard here over-rejected two ways the
+// CTL-1616 verifier disproved empirically against jq 1.7.1:
+//   - jq ACCEPTS a lone LOW surrogate escape (\uDC00-\uDFFF), substituting
+//     U+FFFD — only a lone HIGH escape rejects the whole document (exit 5);
+//   - a backslash run of EVEN length before `uXXXX` is literal text (the JSON
+//     source `"\\ud800"` parses to the harmless 7-char string), not a live
+//     escape — the old regex was blind to the run and killed the whole read.
+// This scanner + toWellFormed pair is intentionally kept in lockstep with
+// lib/secret-contract.mjs's identical pair (both files are zero-import leaves,
+// so neither may import the other; the shared semantics are pinned by each
+// file's own parity suite against the same jq binary).
+function hasLiveLoneHighSurrogateEscape(text) {
+  const re = /(\\+)u([0-9a-fA-F]{4})/g;
+  const liveMatches = [];
+  let m;
+  while ((m = re.exec(text)) !== null) {
+    if (m[1].length % 2 !== 1) continue; // even run ⇒ literal backslashes + text
+    liveMatches.push({ index: m.index, end: m.index + m[0].length, code: parseInt(m[2], 16) });
+  }
+  for (let i = 0; i < liveMatches.length; i++) {
+    const cur = liveMatches[i];
+    if (cur.code < 0xd800 || cur.code > 0xdbff) continue; // not a HIGH surrogate
+    const next = liveMatches[i + 1];
+    const isPaired =
+      next != null && next.index === cur.end && next.code >= 0xdc00 && next.code <= 0xdfff;
+    if (!isPaired) return true;
+  }
+  return false;
+}
+
+// toWellFormedString — a lone LOW surrogate that survives into the parsed mode
+// string becomes U+FFFD, the same byte sequence jq substitutes at parse time
+// (JSON.parse carries the raw lone code unit through). Applied only at the
+// mode-extraction boundary.
+function toWellFormedString(str) {
+  if (typeof str.toWellFormed === "function") return str.toWellFormed();
+  let out = "";
+  for (let i = 0; i < str.length; i++) {
+    const code = str.charCodeAt(i);
+    if (code >= 0xd800 && code <= 0xdbff) {
+      const next = str.charCodeAt(i + 1);
+      if (next >= 0xdc00 && next <= 0xdfff) {
+        out += str[i] + str[i + 1];
+        i++;
+      } else {
+        out += "�";
+      }
+    } else if (code >= 0xdc00 && code <= 0xdfff) {
+      out += "�";
+    } else {
+      out += str[i];
+    }
+  }
+  return out;
+}
 
 function readDeploymentModeField(filePath) {
   try {
     const text = readFileSync(filePath, "utf8");
-    if (UNPAIRED_SURROGATE_ESCAPE.test(text)) return undefined;
+    if (hasLiveLoneHighSurrogateEscape(text)) return undefined;
     const mode = JSON.parse(text)?.catalyst?.deployment?.mode;
-    if (typeof mode === "string" && UNPAIRED_SURROGATE.test(mode)) return undefined;
-    return mode;
+    return typeof mode === "string" ? toWellFormedString(mode) : mode;
   } catch {
     return undefined;
   }


### PR DESCRIPTION
## Summary

Ports the jq-exact surrogate semantics (empirically proven during CTL-1616's #2902 verification, jq 1.7.1) into the deployment-mode reader, which still carried the earlier over-broad regex guard: only a **live lone HIGH** surrogate escape rejects a document (backslash-run-aware — `"\\ud800"` literal text is not an escape); lone LOWs are accepted with U+FFFD substitution at the mode-extraction boundary (`toWellFormed`), matching jq's own parse-time behavior.

Impact of the old guard: a `\\ud800` literal anywhere in a Layer-1/Layer-2 config made the JS reader treat the whole file as absent while bash read it normally — a silent cross-language mode divergence in pathological-but-valid configs.

Kept in deliberate lockstep with `lib/secret-contract.mjs`'s identical scanner (both zero-import leaves; each parity suite pins the shared semantics against the same jq binary). Parity suite: **358 assertions** (new lone-LOW-in-value / lone-LOW-unrelated-field / escaped-backslash-literal cells), all `bash==node==expected`; JS unit 30, bash unit 28, all green.

Linear: CTL-1617

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WHfJt1JhsdArSUyxwZZzkN