### PR TITLE
feat(dev): CTL-1609 delegate-first escalation + explanation-required chokepoint

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -389,6 +389,46 @@ it as a recovery item. Previously the classifier blindly escalated it to a human
 The behavior is gated by `CATALYST_RECOVERY_PASS` (off by default); shadow mode logs a
 `recovery.would-fix` event without dispatching; enforce dispatches the recovery-pass worker.
 
+### Delegate-first escalation + explanation chokepoint (CTL-1609)
+
+Two gaps closed at the point where the scheduler labels a ticket `needs-human`:
+
+**Gap 1 — Delegate-first routing seam.** Every `needs-human` producer (six sites in
+`scheduler.mjs` / `monitor.mjs` / `stale-pr-rescue-timer.mjs`, not including `attempts-exhausted`
+which is post-delegate by definition) now routes through `routeStuckTicketToDelegate`
+(`execution-core/delegate-first.mjs`) instead of calling `labelNeedsHumanUnlessBeliefOwner`
+directly. Ordered fallback: **(1) auto-fix [deferred]** → **(2) delegate runner** → **(3) human**.
+
+- **`CATALYST_DELEGATE_FIRST=off`** (default): byte-identical to the direct call — no behavior
+  change until the flag is lit.
+- **`CATALYST_DELEGATE_FIRST=shadow`**: logs a `delegate.would-route` event per eligible ticket
+  but still labels `needs-human`. Safe dry-run.
+- **`CATALYST_DELEGATE_FIRST=enforce`**: calls `enqueueDelegateIntent`; if the queue accepts
+  (`enqueued`, `already-pending`, or `worker-live`) emits `delegate.routed` and returns without
+  labelling. Queue-full / write-failed / no-orch-dir → emit `delegate.route-fallback` and fall
+  back to labelling. Side effects (`recordTransition`, `cache.invalidate`) are gated on
+  `result.labelled === true` so routed tickets never record a spurious `needs-human` transition.
+
+**Gap 2 — Explanation-required chokepoint.** `labelNeedsHumanUnlessBeliefOwner`
+(`execution-core/label-guard.mjs`) now accepts an optional `explanation` object. After a
+confirmed label application:
+
+- If `explanation` is absent → emits `escalation.explanation-absent` warn and coerces a degraded
+  fallback via `coerceExplanation` (type `authorization`, `degraded: true`).
+- Writes the coerced or caller-supplied explanation to
+  `workers/<TICKET>/phase-recovery-pass.json` via `writeExplanationSignal` (atomic tmp+rename).
+  A **no-overwrite guard** protects the rich curated signal written by `escalateExhaustedIntents`
+  before it calls the label function — `prior.explanation && prior.explanation.degraded !== true`
+  prevents the thin hint from clobbering it.
+- All six wired sites supply a `problem` + `call_to_action` structured explanation so the operator
+  inbox can render a real "What's needed now" card instead of a bare label.
+- The `attempts-exhausted` site passes a thin hint; `escalateExhaustedIntents` writes the full
+  curated explanation first via a direct `writeExplanationSignal` call, and the no-overwrite guard
+  ensures the chokepoint's coercion cannot overwrite it.
+
+New event names (registered in `broker/namespace-parity.test.mjs`): `escalation.explanation-absent`,
+`delegate.would-route`, `delegate.routed`, `delegate.route-fallback`.
+
 ### Runaway-loop guards (CTL-671)
 
 `schedulerTick` is hardened against runaway dispatch/reclaim loops on phantom/non-resolving tickets

--- a/plugins/dev/scripts/broker/namespace-parity.test.mjs
+++ b/plugins/dev/scripts/broker/namespace-parity.test.mjs
@@ -59,6 +59,10 @@ const INLINE_EVENT_NAMES = [
   "agent.resumed",                    // wait-event.mjs:buildWaitEnvelope
   "fence.claimed.CTL-1",              // CTL-863 fence-event.mjs (exec-core-owned, projected-not-re-emitted)
   "fence.released.CTL-1",             // CTL-863 fence-event.mjs
+  "escalation.explanation-absent",    // CTL-1609 label-guard.mjs (warn when explanation omitted)
+  "delegate.would-route",             // CTL-1609 delegate-first.mjs (shadow mode — would enqueue)
+  "delegate.routed",                  // CTL-1609 delegate-first.mjs (enforce mode — enqueued ok)
+  "delegate.route-fallback",          // CTL-1609 delegate-first.mjs (enforce mode — queue full / failed)
 ];
 
 // Build the flat list of all static exec-core event names.

--- a/plugins/dev/scripts/execution-core/daemon.mjs
+++ b/plugins/dev/scripts/execution-core/daemon.mjs
@@ -1843,6 +1843,12 @@ function startReaperAndTimer({
       intervalSeconds: rescueCfg.intervalSeconds ?? RESCUE_DEFAULTS.intervalSeconds,
       orchDir,
       config: rescueCfg,
+      // CTL-1609 (Codex P1): the delegate ceiling for this timer's escalation
+      // enqueues. Resolved lazily per escalation (not captured at boot) so an
+      // autotuned maxParallel is honored without a daemon restart. Injected here
+      // because the daemon already owns concurrency — importing readMaxParallel
+      // inside the timer would pull scheduler.mjs's bun:sqlite graph into it.
+      maxParallel: () => readMaxParallel(orchDir),
     });
   }
 

--- a/plugins/dev/scripts/execution-core/delegate-first.mjs
+++ b/plugins/dev/scripts/execution-core/delegate-first.mjs
@@ -9,6 +9,7 @@
 // Ordered fallback: (auto-fix [deferred]) → delegate → human.
 import { enqueueDelegateIntent } from "./delegate-queue.mjs";
 import { labelNeedsHumanUnlessBeliefOwner } from "./label-guard.mjs";
+import { readDelegateRunnerConfig } from "./config.mjs";
 
 const VALID_MODES = new Set(["off", "shadow", "enforce"]);
 
@@ -91,6 +92,25 @@ export function routeStuckTicketToDelegate(
   }
 
   // ── enforce: enqueue to delegate, fall back to label on failure ───────────
+  //
+  // FAIL-SAFE GATE (Codex P1). Suppressing `needs-human` is only sound when
+  // something will actually drain the queue. `readDelegateRunnerConfig` couples the
+  // runner's default to CATALYST_BOARD_HEALTH / CATALYST_RECOVERY_PASS being
+  // `enforce` — it knows nothing about CATALYST_DELEGATE_FIRST. So an operator who
+  // lights ONLY this flag would get intents that queue forever (holding slot
+  // reservations) with the label suppressed and no human ever told: a silent
+  // black hole exactly where the escalation safety net is supposed to be.
+  //
+  // We refuse to route rather than auto-enabling the runner, because auto-enabling
+  // would change behavior for pathways nobody opted into. Escalate loudly instead
+  // of going quiet: fall through to the label.
+  const readRunnerConfig = deps.readRunnerConfig ?? readDelegateRunnerConfig;
+  if (readRunnerConfig(env).mode !== "on") {
+    appendEvent({ name: "delegate.route-fallback", ticket, site, reason: "runner-disabled" });
+    const labelled = labelDirect();
+    return { routed: false, labelled, reason: "runner-disabled" };
+  }
+
   const enqueue = deps.enqueue ?? enqueueDelegateIntent;
   const q = enqueue(
     ticket,

--- a/plugins/dev/scripts/execution-core/delegate-first.mjs
+++ b/plugins/dev/scripts/execution-core/delegate-first.mjs
@@ -1,0 +1,115 @@
+// delegate-first.mjs — CTL-1609 Gap 1: delegate-first escalation routing seam.
+//
+// Introduces routeStuckTicketToDelegate, a thin gate that—when
+// CATALYST_DELEGATE_FIRST=enforce—enqueues a stuck ticket to the delegate
+// runner instead of immediately labelling needs-human.  With the flag off or
+// unset the call is byte-identical to the direct Phase-1 chokepoint, so all
+// six sites can be rewired without changing live behaviour.
+//
+// Ordered fallback: (auto-fix [deferred]) → delegate → human.
+import { enqueueDelegateIntent } from "./delegate-queue.mjs";
+import { labelNeedsHumanUnlessBeliefOwner } from "./label-guard.mjs";
+
+const VALID_MODES = new Set(["off", "shadow", "enforce"]);
+
+// readDelegateFirstMode — read CATALYST_DELEGATE_FIRST; default "off".
+// Mirrors readBoardHealthConfig/CATALYST_RECOVERY_PASS parsing style.
+export function readDelegateFirstMode(env = process.env) {
+  const raw = env.CATALYST_DELEGATE_FIRST ?? "off";
+  return VALID_MODES.has(raw) ? raw : "off";
+}
+
+// ── routeStuckTicketToDelegate ────────────────────────────────────────────────
+//
+// Single seam replacing direct labelNeedsHumanUnlessBeliefOwner calls at the
+// six escalation sites (not `attempts-exhausted`, which is post-delegate by
+// definition).
+//
+// Params:
+//   orchDir       — the orchestrator working directory
+//   ticket        — ticket identifier
+//   opts:
+//     site          — caller identifier ("terminal-sweep", "dispatch-failures", …)
+//     kind          — intent kind (default "board-health")
+//     reason        — short string reason for the escalation
+//     boardContext  — structured context object for the delegate brief
+//     briefObj      — optional per-item brief (kind:"recovery-item")
+//     explanation   — structured explanation for Phase-1 label chokepoint
+//     deps          — passed through to enqueueDelegateIntent; add
+//                     `enqueue` key to override the queue function in tests
+//     applyLabel    — writeStatus object ({ applyLabel }) passed to Phase-1
+//     env           — process.env override (for tests / injection)
+//     log           — logger override
+//     appendEvent   — injectable event emitter (default: no-op; Phase-3 wires real)
+//
+// Returns:
+//   off / shadow   → { routed:false, labelled:<bool>, [shadow:true] }
+//   enforce+ok     → { routed:true, reason:<string> }
+//   enforce+fallback → { routed:false, labelled:<bool>, reason:<string> }
+//
+export function routeStuckTicketToDelegate(
+  orchDir,
+  ticket,
+  {
+    site = "unknown",
+    kind = "board-health",
+    reason = null,
+    boardContext = null,
+    briefObj = null,
+    explanation = undefined,
+    deps = {},
+    applyLabel,
+    env = process.env,
+    log: logArg = null,
+    appendEvent = () => {},
+  } = {}
+) {
+  const mode = readDelegateFirstMode(env);
+
+  // helper: call the Phase-1 label chokepoint and return { labelled: bool }
+  const labelDirect = () => {
+    const labelled = labelNeedsHumanUnlessBeliefOwner(
+      orchDir,
+      ticket,
+      applyLabel,
+      { env, site, log: logArg, explanation }
+    );
+    return labelled;
+  };
+
+  // ── off: byte-identical to Phase 1 ────────────────────────────────────────
+  if (mode === "off") {
+    const labelled = labelDirect();
+    return { routed: false, labelled };
+  }
+
+  // ── shadow: log would-route, do NOT enqueue, DO label ─────────────────────
+  if (mode === "shadow") {
+    appendEvent({ name: "delegate.would-route", ticket, site, reason });
+    const labelled = labelDirect();
+    return { routed: false, shadow: true, labelled };
+  }
+
+  // ── enforce: enqueue to delegate, fall back to label on failure ───────────
+  const enqueue = deps.enqueue ?? enqueueDelegateIntent;
+  const q = enqueue(
+    ticket,
+    { kind, phase: "recovery-pass", reason, boardContext, briefObj },
+    deps
+  );
+
+  // Mirror enqueueRecoveryItemDelegate's `initiated` predicate: a fresh enqueue
+  // OR an idempotent no-op both mean the delegate already owns the ticket.
+  const initiated =
+    q.enqueued || q.reason === "already-pending" || q.reason === "worker-live";
+
+  if (initiated) {
+    appendEvent({ name: "delegate.routed", ticket, site, reason: q.reason });
+    return { routed: true, reason: q.reason };
+  }
+
+  // Fallback: queue-full / write-failed / no-orch-dir → label+explain
+  appendEvent({ name: "delegate.route-fallback", ticket, site, reason: q.reason });
+  const labelled = labelDirect();
+  return { routed: false, labelled, reason: q.reason };
+}

--- a/plugins/dev/scripts/execution-core/delegate-first.test.mjs
+++ b/plugins/dev/scripts/execution-core/delegate-first.test.mjs
@@ -1,0 +1,235 @@
+// delegate-first.test.mjs — CTL-1609 Phase 2: routeStuckTicketToDelegate seam
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import {
+  readDelegateFirstMode,
+  routeStuckTicketToDelegate,
+} from "./delegate-first.mjs";
+
+// ─── test helpers ────────────────────────────────────────────────────────────
+
+function makeOpts({
+  labelCalls = [],
+  enqueueFn = () => ({ enqueued: true, reason: "enqueued" }),
+  events = [],
+  env = {},
+  explanation = { call_to_action: "do something" },
+} = {}) {
+  return {
+    site: "test-site",
+    kind: "board-health",
+    reason: "stalled",
+    boardContext: { ticket: "CTL-1" },
+    explanation,
+    deps: {
+      enqueue: enqueueFn,
+    },
+    applyLabel: {
+      applyLabel: (...args) => {
+        labelCalls.push(args);
+        return { applied: true };
+      },
+    },
+    env,
+    appendEvent: (e) => events.push(e),
+    log: { info: () => {}, warn: () => {} },
+  };
+}
+
+// ─── readDelegateFirstMode ────────────────────────────────────────────────────
+
+describe("readDelegateFirstMode", () => {
+  test("defaults to off when CATALYST_DELEGATE_FIRST unset", () => {
+    expect(readDelegateFirstMode({})).toBe("off");
+  });
+
+  test("returns enforce when set to enforce", () => {
+    expect(readDelegateFirstMode({ CATALYST_DELEGATE_FIRST: "enforce" })).toBe("enforce");
+  });
+
+  test("returns shadow when set to shadow", () => {
+    expect(readDelegateFirstMode({ CATALYST_DELEGATE_FIRST: "shadow" })).toBe("shadow");
+  });
+
+  test("returns off for unrecognised values (fail-safe)", () => {
+    expect(readDelegateFirstMode({ CATALYST_DELEGATE_FIRST: "bogus" })).toBe("off");
+  });
+});
+
+// ─── routeStuckTicketToDelegate — Phase 2 + 3 tests ─────────────────────────
+
+let orchDir;
+beforeEach(() => {
+  orchDir = mkdtempSync(join(tmpdir(), "delegate-first-"));
+});
+afterEach(() => {
+  rmSync(orchDir, { recursive: true, force: true });
+});
+
+describe("routeStuckTicketToDelegate (CTL-1609)", () => {
+  // Test 1: enforce + enqueue succeeds → no label, delegate.routed event
+  test("enforce + enqueue succeeds → no label applied, delegate.routed emitted", () => {
+    const labelCalls = [];
+    const events = [];
+    const opts = makeOpts({
+      labelCalls,
+      events,
+      enqueueFn: () => ({ enqueued: true, reason: "enqueued" }),
+      env: { CATALYST_DELEGATE_FIRST: "enforce" },
+    });
+
+    const result = routeStuckTicketToDelegate(orchDir, "CTL-1", opts);
+
+    expect(labelCalls).toHaveLength(0);
+    expect(result.routed).toBe(true);
+    const routedEvent = events.find((e) => e.name === "delegate.routed");
+    expect(routedEvent).toBeDefined();
+    expect(routedEvent.ticket).toBe("CTL-1");
+    expect(routedEvent.site).toBe("test-site");
+  });
+
+  // Test 2: enforce + queue-full → label+explain fallback, delegate.route-fallback event
+  test("enforce + queue-full → falls back to label+explanation, delegate.route-fallback emitted", () => {
+    const labelCalls = [];
+    const events = [];
+    const opts = makeOpts({
+      labelCalls,
+      events,
+      enqueueFn: () => ({ enqueued: false, reason: "queue-full" }),
+      env: { CATALYST_DELEGATE_FIRST: "enforce" },
+    });
+
+    const result = routeStuckTicketToDelegate(orchDir, "CTL-2", opts);
+
+    expect(labelCalls).toHaveLength(1);
+    expect(result.routed).toBe(false);
+    expect(result.labelled).toBe(true);
+    const fallbackEvent = events.find((e) => e.name === "delegate.route-fallback");
+    expect(fallbackEvent).toBeDefined();
+    expect(fallbackEvent.reason).toBe("queue-full");
+  });
+
+  // Test 3: enforce + already-pending / worker-live → no label (idempotent in-flight)
+  test("enforce + already-pending → no label, routed:true (idempotent)", () => {
+    const labelCalls = [];
+    const opts = makeOpts({
+      labelCalls,
+      enqueueFn: () => ({ enqueued: false, reason: "already-pending" }),
+      env: { CATALYST_DELEGATE_FIRST: "enforce" },
+    });
+
+    const result = routeStuckTicketToDelegate(orchDir, "CTL-3", opts);
+
+    expect(labelCalls).toHaveLength(0);
+    expect(result.routed).toBe(true);
+    expect(result.reason).toBe("already-pending");
+  });
+
+  test("enforce + worker-live → no label, routed:true (idempotent)", () => {
+    const labelCalls = [];
+    const opts = makeOpts({
+      labelCalls,
+      enqueueFn: () => ({ enqueued: false, reason: "worker-live" }),
+      env: { CATALYST_DELEGATE_FIRST: "enforce" },
+    });
+
+    const result = routeStuckTicketToDelegate(orchDir, "CTL-3b", opts);
+
+    expect(labelCalls).toHaveLength(0);
+    expect(result.routed).toBe(true);
+    expect(result.reason).toBe("worker-live");
+  });
+
+  // Test 4: shadow → delegate.would-route logged, enqueue NOT called, DOES label
+  test("shadow → delegate.would-route logged, enqueue NOT called, label applied", () => {
+    const labelCalls = [];
+    const events = [];
+    let enqueueCalled = false;
+    const opts = makeOpts({
+      labelCalls,
+      events,
+      enqueueFn: () => { enqueueCalled = true; return { enqueued: true, reason: "enqueued" }; },
+      env: { CATALYST_DELEGATE_FIRST: "shadow" },
+    });
+
+    const result = routeStuckTicketToDelegate(orchDir, "CTL-4", opts);
+
+    expect(enqueueCalled).toBe(false);
+    expect(labelCalls).toHaveLength(1);
+    expect(result.routed).toBe(false);
+    expect(result.shadow).toBe(true);
+    const wouldRoute = events.find((e) => e.name === "delegate.would-route");
+    expect(wouldRoute).toBeDefined();
+    expect(wouldRoute.ticket).toBe("CTL-4");
+  });
+
+  // Test 5: off → direct label+explanation, enqueue never referenced
+  test("off → direct label, enqueue never called (byte-identical to Phase 1)", () => {
+    const labelCalls = [];
+    let enqueueCalled = false;
+    const opts = makeOpts({
+      labelCalls,
+      enqueueFn: () => { enqueueCalled = true; return { enqueued: true }; },
+      env: { CATALYST_DELEGATE_FIRST: "off" },
+    });
+
+    const result = routeStuckTicketToDelegate(orchDir, "CTL-5", opts);
+
+    expect(enqueueCalled).toBe(false);
+    expect(labelCalls).toHaveLength(1);
+    expect(result.routed).toBe(false);
+  });
+
+  test("off (default, no env var) → direct label, enqueue never called", () => {
+    const labelCalls = [];
+    let enqueueCalled = false;
+    const opts = makeOpts({
+      labelCalls,
+      enqueueFn: () => { enqueueCalled = true; return { enqueued: true }; },
+      env: {},
+    });
+
+    const result = routeStuckTicketToDelegate(orchDir, "CTL-5b", opts);
+
+    expect(enqueueCalled).toBe(false);
+    expect(labelCalls).toHaveLength(1);
+    expect(result.routed).toBe(false);
+  });
+
+  // Test 6: no-orch-dir / write-failed → fallback to label
+  test("enforce + write-failed → label fallback, delegate.route-fallback emitted", () => {
+    const labelCalls = [];
+    const events = [];
+    const opts = makeOpts({
+      labelCalls,
+      events,
+      enqueueFn: () => ({ enqueued: false, reason: "write-failed" }),
+      env: { CATALYST_DELEGATE_FIRST: "enforce" },
+    });
+
+    const result = routeStuckTicketToDelegate(orchDir, "CTL-6", opts);
+
+    expect(labelCalls).toHaveLength(1);
+    expect(result.routed).toBe(false);
+    expect(result.labelled).toBe(true);
+    const fallbackEvent = events.find((e) => e.name === "delegate.route-fallback");
+    expect(fallbackEvent).toBeDefined();
+    expect(fallbackEvent.reason).toBe("write-failed");
+  });
+
+  test("enforce + no-orch-dir → label fallback", () => {
+    const labelCalls = [];
+    const opts = makeOpts({
+      labelCalls,
+      enqueueFn: () => ({ enqueued: false, reason: "no-orch-dir" }),
+      env: { CATALYST_DELEGATE_FIRST: "enforce" },
+    });
+
+    const result = routeStuckTicketToDelegate(orchDir, "CTL-6b", opts);
+
+    expect(labelCalls).toHaveLength(1);
+    expect(result.routed).toBe(false);
+  });
+});

--- a/plugins/dev/scripts/execution-core/delegate-first.test.mjs
+++ b/plugins/dev/scripts/execution-core/delegate-first.test.mjs
@@ -16,6 +16,11 @@ function makeOpts({
   events = [],
   env = {},
   explanation = { call_to_action: "do something" },
+  // CTL-1609 (Codex P1): enforce now REQUIRES a confirmed-enabled delegate runner
+  // before it may suppress the needs-human label. Default "on" here so the
+  // pre-existing enforce cases keep exercising the enqueue path; the fail-safe
+  // gate itself is covered by its own describe block below.
+  runnerMode = "on",
 } = {}) {
   return {
     site: "test-site",
@@ -25,6 +30,7 @@ function makeOpts({
     explanation,
     deps: {
       enqueue: enqueueFn,
+      readRunnerConfig: () => ({ mode: runnerMode }),
     },
     applyLabel: {
       applyLabel: (...args) => {
@@ -231,5 +237,101 @@ describe("routeStuckTicketToDelegate (CTL-1609)", () => {
 
     expect(labelCalls).toHaveLength(1);
     expect(result.routed).toBe(false);
+  });
+});
+
+// ─── CTL-1609 (Codex P1): runner-disabled fail-safe gate ──────────────────────
+//
+// enforce may suppress the needs-human label ONLY when a runner is confirmed
+// enabled to drain the queue. readDelegateRunnerConfig couples the runner's
+// default to CATALYST_BOARD_HEALTH / CATALYST_RECOVERY_PASS — it knows nothing
+// about CATALYST_DELEGATE_FIRST — so lighting only DELEGATE_FIRST would otherwise
+// queue intents forever with no human ever told.
+describe("routeStuckTicketToDelegate — runner-disabled fail-safe (CTL-1609)", () => {
+  test("enforce + runner off → does NOT enqueue, DOES label, reason runner-disabled", () => {
+    const labelCalls = [];
+    const events = [];
+    let enqueueCalls = 0;
+    const result = routeStuckTicketToDelegate(
+      orchDir,
+      "CTL-RD1",
+      makeOpts({
+        labelCalls,
+        events,
+        runnerMode: "off",
+        enqueueFn: () => {
+          enqueueCalls += 1;
+          return { enqueued: true, reason: "enqueued" };
+        },
+        env: { CATALYST_DELEGATE_FIRST: "enforce" },
+      })
+    );
+
+    // The safety net fires: a human is told rather than the ticket going quiet.
+    expect(enqueueCalls).toBe(0);
+    expect(labelCalls).toHaveLength(1);
+    expect(result.routed).toBe(false);
+    expect(result.labelled).toBe(true);
+    expect(result.reason).toBe("runner-disabled");
+    const fallback = events.find((e) => e.name === "delegate.route-fallback");
+    expect(fallback).toBeDefined();
+    expect(fallback.reason).toBe("runner-disabled");
+  });
+
+  test("enforce + runner on → routes (gate does not block the enabled path)", () => {
+    const labelCalls = [];
+    let enqueueCalls = 0;
+    const result = routeStuckTicketToDelegate(
+      orchDir,
+      "CTL-RD2",
+      makeOpts({
+        labelCalls,
+        runnerMode: "on",
+        enqueueFn: () => {
+          enqueueCalls += 1;
+          return { enqueued: true, reason: "enqueued" };
+        },
+        env: { CATALYST_DELEGATE_FIRST: "enforce" },
+      })
+    );
+
+    expect(enqueueCalls).toBe(1);
+    expect(labelCalls).toHaveLength(0);
+    expect(result.routed).toBe(true);
+  });
+
+  test("the gate is enforce-only — shadow still labels and never consults the runner", () => {
+    const labelCalls = [];
+    let runnerReads = 0;
+    const opts = makeOpts({
+      labelCalls,
+      env: { CATALYST_DELEGATE_FIRST: "shadow" },
+    });
+    opts.deps.readRunnerConfig = () => {
+      runnerReads += 1;
+      return { mode: "off" };
+    };
+
+    const result = routeStuckTicketToDelegate(orchDir, "CTL-RD3", opts);
+
+    expect(runnerReads).toBe(0);
+    expect(labelCalls).toHaveLength(1);
+    expect(result.shadow).toBe(true);
+  });
+
+  test("real readDelegateRunnerConfig: DELEGATE_FIRST=enforce alone leaves the runner off", () => {
+    // The exact operator mistake the gate exists for — asserted against the REAL
+    // resolver, not a stub, so a future coupling change surfaces here.
+    const labelCalls = [];
+    const opts = makeOpts({
+      labelCalls,
+      env: { CATALYST_DELEGATE_FIRST: "enforce" },
+    });
+    delete opts.deps.readRunnerConfig; // use the production resolver
+
+    const result = routeStuckTicketToDelegate(orchDir, "CTL-RD4", opts);
+
+    expect(result.reason).toBe("runner-disabled");
+    expect(labelCalls).toHaveLength(1);
   });
 });

--- a/plugins/dev/scripts/execution-core/label-guard.mjs
+++ b/plugins/dev/scripts/execution-core/label-guard.mjs
@@ -16,9 +16,10 @@
 //     dispatch cool-down rationale in scheduler.mjs::dispatchCooldownPath and
 //     memory project_scheduler_marker_under_workers_excludes_ticket).
 
-import { existsSync, mkdirSync, readFileSync, unlinkSync, writeFileSync } from "node:fs";
-import { join } from "node:path";
+import { existsSync, mkdirSync, readFileSync, renameSync, unlinkSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
 import { log } from "./config.mjs";
+import { coerceExplanation } from "./escalation-explanation.mjs";
 import { DISPOSITIONS } from "./worker-disposition.mjs";
 
 // ─── labelOnce — moved from scheduler.mjs (CTL-585, then CTL-638 re-home) ───
@@ -372,6 +373,64 @@ export function inEscalationCooldown(orchDir, ticket, phase, now) {
   return now - escalatedAt < ESCALATION_COOLDOWN_MS;
 }
 
+// ─── CTL-1609: explanation signal writer ─────────────────────────────────────
+//
+// Writes a board-readable `phase-recovery-pass.json` carrying `.explanation` so
+// the operator inbox renders a "What's needed now" card instead of a bare
+// "escalated — needs human". Shape mirrors writeEscalationSignal in
+// recovery-reasoning.mjs (the proven write pattern). Colocated here (not
+// imported from recovery-reasoning) to avoid pulling scheduler-adjacent
+// internals into this leaf module.
+//
+// No-overwrite guard: if the existing signal already carries a non-degraded
+// `.explanation` (e.g., from escalateExhaustedIntents's prior writeSignal call
+// on the `attempts-exhausted` site), the coerced thin explanation must NOT
+// clobber it. `degraded:true` means the earlier writer also fell back → the
+// new coerce may be equivalent or richer, so we overwrite; absent `degraded`
+// (a proper typed-union object) means a human-readable curated signal → keep.
+function writeExplanationSignal(orchDir, ticket, explanation, { log: logArg = null } = {}) {
+  if (!orchDir || !ticket || !explanation) return;
+  try {
+    const p = join(orchDir, "workers", ticket, "phase-recovery-pass.json");
+    let prior = {};
+    try {
+      prior = JSON.parse(readFileSync(p, "utf8")) ?? {};
+    } catch {
+      prior = {};
+    }
+    // No-overwrite guard for the `attempts-exhausted` site (and any future site
+    // that pre-writes a rich curated explanation before the label apply).
+    if (prior.explanation && prior.explanation.degraded !== true) return;
+    const nowIso = new Date().toISOString();
+    const signal = {
+      ...prior,
+      ticket,
+      status: "needs-human",
+      needsHumanSince:
+        typeof prior.needsHumanSince === "string" && prior.needsHumanSince !== ""
+          ? prior.needsHumanSince
+          : nowIso,
+      updatedAt: nowIso,
+      phase: "recovery-pass",
+      explanation,
+    };
+    mkdirSync(dirname(p), { recursive: true });
+    const tmp = `${p}.tmp.${process.pid}`;
+    writeFileSync(tmp, JSON.stringify(signal, null, 2));
+    renameSync(tmp, p);
+  } catch (err) {
+    try {
+      const logger = logArg ?? log;
+      logger.warn(
+        { ticket, err: err?.message },
+        "label-guard: explanation signal write failed — continuing"
+      );
+    } catch {
+      /* logging must never block the label path */
+    }
+  }
+}
+
 // ─── CTL-1241: belief-ownership deferral guard ────────────────────────────────
 //
 // When CATALYST_INTENTS_ENFORCE=1, the belief engine's executeEscalations
@@ -401,9 +460,11 @@ export function beliefOwnsNeedsHuman(env = process.env) {
 //   ticket      — ticket identifier
 //   writeStatus — { applyLabel } as passed to labelOnce
 //   opts        — {
-//     env   : Record<string,string>  (process.env in production)
-//     site  : string                 (short site-id for the deferral log)
-//     log   : { info }              (the module's log instance)
+//     env         : Record<string,string>  (process.env in production)
+//     site        : string                 (short site-id for the deferral log)
+//     log         : { info, warn }        (the module's log instance)
+//     explanation : object | undefined    (CTL-1609 Gap 2 — structured escalation
+//                   explanation; coerced via coerceExplanation if partial/absent)
 //   }
 //
 // CTL-764 finding 8 + finding C: returns whether the needs-human label was CONFIRMED
@@ -417,7 +478,7 @@ export function labelNeedsHumanUnlessBeliefOwner(
   orchDir,
   ticket,
   writeStatus,
-  { env = process.env, site = "unknown", log: logArg = null } = {}
+  { env = process.env, site = "unknown", log: logArg = null, explanation = undefined } = {}
 ) {
   if (beliefOwnsNeedsHuman(env)) {
     // Defer to executeEscalations — R12 belief owner. Record, do not page.
@@ -436,6 +497,24 @@ export function labelNeedsHumanUnlessBeliefOwner(
       applied = r.applied === true;
     },
   });
+  // CTL-1609 Gap 2: on a confirmed apply, coerce the explanation and persist it to
+  // the board-readable phase-recovery-pass.json so the operator inbox renders a real
+  // "What's needed now" card. Gated on `applied` (CTL-764 finding C) so a failed or
+  // marker-guarded no-op never manufactures a spurious explanation signal.
+  if (applied) {
+    // Use the injected log's warn if available; fall back to the module-level log
+    // so existing callers that only inject { info } don't break (warn is new).
+    const warnFn =
+      typeof logArg?.warn === "function" ? logArg.warn.bind(logArg) : log.warn.bind(log);
+    if (explanation === undefined || explanation === null) {
+      warnFn(
+        { ticket, site, event: "escalation.explanation-absent" },
+        "label-guard: needs-human applied without an explanation — coercing (CTL-1609)"
+      );
+    }
+    const coerced = coerceExplanation(explanation ?? {}, { ticket, canExecute: false });
+    writeExplanationSignal(orchDir, ticket, coerced, { log: logArg });
+  }
   return applied;
 }
 

--- a/plugins/dev/scripts/execution-core/label-guard.mjs
+++ b/plugins/dev/scripts/execution-core/label-guard.mjs
@@ -388,6 +388,12 @@ export function inEscalationCooldown(orchDir, ticket, phase, now) {
 // clobber it. `degraded:true` means the earlier writer also fell back → the
 // new coerce may be equivalent or richer, so we overwrite; absent `degraded`
 // (a proper typed-union object) means a human-readable curated signal → keep.
+// The recovery-pass statuses that mean a worker is in flight and owns
+// phase-recovery-pass.json. Must stay in sync with delegate-queue.mjs's
+// recoveryPassWorkerLive (the enqueue-time dedup probe) — those are the reads
+// that go blind if this file's status is overwritten.
+const LIVE_RECOVERY_PASS_STATUSES = new Set(["dispatched", "running"]);
+
 function writeExplanationSignal(orchDir, ticket, explanation, { log: logArg = null } = {}) {
   if (!orchDir || !ticket || !explanation) return;
   try {
@@ -397,6 +403,31 @@ function writeExplanationSignal(orchDir, ticket, explanation, { log: logArg = nu
       prior = JSON.parse(readFileSync(p, "utf8")) ?? {};
     } catch {
       prior = {};
+    }
+    // LIVE-WORKER guard (CTL-1609, Codex P1). `phase-recovery-pass.json` is not
+    // only an explanation carrier — it is the recovery-pass worker's own status
+    // record, and `dispatched`/`running` is exactly what the liveness probes read
+    // (delegate-queue's recoveryPassWorkerLive, the SDK occupancy accounting).
+    // Stamping `status:"needs-human"` over a live worker makes that worker
+    // invisible: it stops deduping a re-enqueue (double-dispatch) and drops out of
+    // capacity accounting. A ticket can legitimately be in both states at once —
+    // a sibling phase failed while its recovery-pass worker is still running — so
+    // this is reachable in normal operation, not a corner case.
+    //
+    // Preserve the live record verbatim rather than merging: the worker itself
+    // writes this file, so a concurrent partial update from here could interleave.
+    // The label still applies (this function is called AFTER the confirmed label
+    // write); only the signal-file mutation is skipped.
+    if (LIVE_RECOVERY_PASS_STATUSES.has(prior.status)) {
+      try {
+        (logArg ?? log).warn(
+          { ticket, priorStatus: prior.status },
+          "label-guard: live recovery-pass worker — preserving its signal, explanation not written"
+        );
+      } catch {
+        /* logging must never block the label path */
+      }
+      return;
     }
     // No-overwrite guard for the `attempts-exhausted` site (and any future site
     // that pre-writes a rich curated explanation before the label apply).

--- a/plugins/dev/scripts/execution-core/label-guard.test.mjs
+++ b/plugins/dev/scripts/execution-core/label-guard.test.mjs
@@ -1377,3 +1377,71 @@ describe("labelNeedsHumanUnlessBeliefOwner — explanation threading (CTL-1609)"
     expect(sig.explanation.call_to_action).toBe("resolve the dispatch failure for CTL-E7");
   });
 });
+
+// ─── CTL-1609 (Codex P1): live recovery-pass worker guard ─────────────────────
+//
+// phase-recovery-pass.json is not only an explanation carrier — it is the
+// recovery-pass worker's own status record, and `dispatched`/`running` is exactly
+// what the liveness probes read (delegate-queue's recoveryPassWorkerLive, the SDK
+// occupancy accounting). Stamping `needs-human` over a live worker makes it
+// invisible: it stops deduping a re-enqueue (double-dispatch) and drops out of
+// capacity accounting. Reachable in normal operation — a sibling phase can fail
+// while the recovery-pass worker is still running.
+describe("labelNeedsHumanUnlessBeliefOwner — live recovery-pass worker guard (CTL-1609)", () => {
+  const SIG = (ticket) => join(orchDir, "workers", ticket, "phase-recovery-pass.json");
+
+  function seedSignal(ticket, status) {
+    const workerDir = join(orchDir, "workers", ticket);
+    mkdirSync(workerDir, { recursive: true });
+    writeFileSync(
+      SIG(ticket),
+      JSON.stringify({ ticket, status, phase: "recovery-pass", bg_job_id: "job-live-1" })
+    );
+  }
+
+  function applyWith(ticket) {
+    return labelNeedsHumanUnlessBeliefOwner(
+      orchDir,
+      ticket,
+      { applyLabel: () => ({ applied: true }) },
+      {
+        env: { CATALYST_INTENTS_ENFORCE: "0" },
+        site: "terminal-sweep",
+        log: { info: () => {}, warn: () => {} },
+        explanation: { problem: "sibling phase failed", call_to_action: "review" },
+      }
+    );
+  }
+
+  for (const status of ["dispatched", "running"]) {
+    test(`does NOT overwrite a live '${status}' recovery-pass signal`, () => {
+      seedSignal(`CTL-LW-${status}`, status);
+      const wrote = applyWith(`CTL-LW-${status}`);
+
+      // The label itself still applies — only the signal-file mutation is skipped.
+      expect(wrote).toBe(true);
+      const sig = JSON.parse(readFileSync(SIG(`CTL-LW-${status}`), "utf8"));
+      expect(sig.status).toBe(status); // live worker's record preserved verbatim
+      expect(sig.bg_job_id).toBe("job-live-1");
+      expect(sig.explanation).toBeUndefined();
+    });
+  }
+
+  test("still writes when the prior signal is a terminal/non-live status", () => {
+    seedSignal("CTL-LW-done", "done");
+    const wrote = applyWith("CTL-LW-done");
+
+    expect(wrote).toBe(true);
+    const sig = JSON.parse(readFileSync(SIG("CTL-LW-done"), "utf8"));
+    expect(sig.status).toBe("needs-human");
+    expect(sig.explanation.call_to_action).toBe("review");
+  });
+
+  test("still writes when there is no prior signal at all", () => {
+    mkdirSync(join(orchDir, "workers", "CTL-LW-none"), { recursive: true });
+    const wrote = applyWith("CTL-LW-none");
+
+    expect(wrote).toBe(true);
+    expect(JSON.parse(readFileSync(SIG("CTL-LW-none"), "utf8")).status).toBe("needs-human");
+  });
+});

--- a/plugins/dev/scripts/execution-core/label-guard.test.mjs
+++ b/plugins/dev/scripts/execution-core/label-guard.test.mjs
@@ -3,7 +3,7 @@
 //   cd plugins/dev/scripts/execution-core && bun test label-guard.test.mjs
 
 import { describe, test, expect, beforeEach, afterEach, mock } from "bun:test";
-import { mkdtempSync, rmSync, mkdirSync, writeFileSync, existsSync } from "node:fs";
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync, readFileSync, existsSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
@@ -22,6 +22,7 @@ import {
   resolveAndApplyWorkerStatusLabel,
   WORKER_STATUS_LABELS,
 } from "./label-guard.mjs";
+import { validateExplanation } from "./escalation-explanation.mjs";
 
 let orchDir;
 
@@ -1205,5 +1206,143 @@ describe("resolveAndApplyWorkerStatusLabel", () => {
     // A backoff-skip is not a confirmed removal → evict must stay withheld.
     expect(res.evicted).toBe(false);
     expect(evicted).toEqual([]);
+  });
+});
+
+// ─── CTL-1609: explanation-required label chokepoint (Phase 1, Gap 2) ────────
+
+describe("labelNeedsHumanUnlessBeliefOwner — explanation threading (CTL-1609)", () => {
+  const RECOVERY_PASS_SIG = (orchDir, ticket) =>
+    join(orchDir, "workers", ticket, "phase-recovery-pass.json");
+
+  function makeAppliedWS() {
+    return { applyLabel: () => ({ applied: true }) };
+  }
+  function makeRateLimitedWS() {
+    return { applyLabel: () => ({ applied: false, reason: "rate-limited" }) };
+  }
+
+  test("explanation coerced and written on confirmed apply", () => {
+    const workerDir = join(orchDir, "workers", "CTL-E1");
+    mkdirSync(workerDir, { recursive: true });
+    const warns = [];
+    const wrote = labelNeedsHumanUnlessBeliefOwner(orchDir, "CTL-E1", makeAppliedWS(), {
+      env: { CATALYST_INTENTS_ENFORCE: "0" },
+      site: "dispatch-failures",
+      log: { info: () => {}, warn: (obj) => warns.push(obj) },
+      explanation: {
+        problem: "dispatch failed 8×",
+        call_to_action: "authorize retry of CTL-E1 or cancel",
+      },
+    });
+    expect(wrote).toBe(true);
+    const sig = JSON.parse(readFileSync(RECOVERY_PASS_SIG(orchDir, "CTL-E1"), "utf8"));
+    expect(sig.status).toBe("needs-human");
+    expect(typeof sig.needsHumanSince).toBe("string");
+    expect(sig.explanation.call_to_action).toBe("authorize retry of CTL-E1 or cancel");
+    // No absent-warn because explanation was supplied
+    expect(warns.some((w) => w.event === "escalation.explanation-absent")).toBe(false);
+  });
+
+  test("no explanation supplied → degraded coerce + WARN logged, signal still written", () => {
+    const workerDir = join(orchDir, "workers", "CTL-E2");
+    mkdirSync(workerDir, { recursive: true });
+    const warns = [];
+    const wrote = labelNeedsHumanUnlessBeliefOwner(orchDir, "CTL-E2", makeAppliedWS(), {
+      env: { CATALYST_INTENTS_ENFORCE: "0" },
+      site: "terminal-sweep",
+      log: { info: () => {}, warn: (obj) => warns.push(obj) },
+      // no explanation
+    });
+    expect(wrote).toBe(true);
+    const sig = JSON.parse(readFileSync(RECOVERY_PASS_SIG(orchDir, "CTL-E2"), "utf8"));
+    expect(sig.status).toBe("needs-human");
+    expect(sig.explanation).toBeTruthy();
+    expect(sig.explanation.degraded).toBe(true);
+    // call_to_action must pass the tautology gate
+    const { valid } = validateExplanation(sig.explanation);
+    expect(valid).toBe(true);
+    // WARN with event:"escalation.explanation-absent" and the site
+    const absentWarn = warns.find((w) => w.event === "escalation.explanation-absent");
+    expect(absentWarn).toBeTruthy();
+    expect(absentWarn.site).toBe("terminal-sweep");
+  });
+
+  test("label NOT applied (rate-limited) → no explanation signal written", () => {
+    const workerDir = join(orchDir, "workers", "CTL-E3");
+    mkdirSync(workerDir, { recursive: true });
+    const wrote = labelNeedsHumanUnlessBeliefOwner(orchDir, "CTL-E3", makeRateLimitedWS(), {
+      env: { CATALYST_INTENTS_ENFORCE: "0" },
+      site: "dispatch-failures",
+      log: { info: () => {}, warn: () => {} },
+      explanation: { problem: "failed", call_to_action: "retry CTL-E3 or cancel" },
+    });
+    expect(wrote).toBe(false);
+    expect(existsSync(RECOVERY_PASS_SIG(orchDir, "CTL-E3"))).toBe(false);
+  });
+
+  test("belief-owner deferral (CATALYST_INTENTS_ENFORCE=1) writes nothing", () => {
+    const wrote = labelNeedsHumanUnlessBeliefOwner(orchDir, "CTL-E4", makeAppliedWS(), {
+      env: { CATALYST_INTENTS_ENFORCE: "1" },
+      site: "terminal-sweep",
+      log: { info: () => {}, warn: () => {} },
+      explanation: { problem: "stuck", call_to_action: "retry CTL-E4 or close it" },
+    });
+    expect(wrote).toBe(false);
+    expect(existsSync(RECOVERY_PASS_SIG(orchDir, "CTL-E4"))).toBe(false);
+  });
+
+  test("invalid/garbage explanation never throws — coerced object still written", () => {
+    const workerDir = join(orchDir, "workers", "CTL-E5");
+    mkdirSync(workerDir, { recursive: true });
+    expect(() =>
+      labelNeedsHumanUnlessBeliefOwner(orchDir, "CTL-E5", makeAppliedWS(), {
+        env: { CATALYST_INTENTS_ENFORCE: "0" },
+        site: "dispatch-failures",
+        log: { info: () => {}, warn: () => {} },
+        explanation: { problem: 123 }, // garbage type
+      })
+    ).not.toThrow();
+    const sig = JSON.parse(readFileSync(RECOVERY_PASS_SIG(orchDir, "CTL-E5"), "utf8"));
+    expect(sig.status).toBe("needs-human");
+    expect(sig.explanation).toBeTruthy();
+  });
+
+  test("no-overwrite guard: richer pre-existing explanation is preserved", () => {
+    const workerDir = join(orchDir, "workers", "CTL-E6");
+    mkdirSync(workerDir, { recursive: true });
+    // Write a rich (non-degraded) explanation already on disk
+    const richSig = {
+      ticket: "CTL-E6",
+      status: "needs-human",
+      needsHumanSince: "2026-01-01T00:00:00.000Z",
+      updatedAt: "2026-01-01T00:00:00.000Z",
+      phase: "recovery-pass",
+      explanation: {
+        escalation_type: "authorization",
+        problem: "recovery attempts exhausted (rich signal)",
+        call_to_action: "authorize another recovery cycle for CTL-E6",
+        recommendation: "inspect the last recovery-pass session",
+        risk: "ticket rots silently without action",
+        why_asking: "risk-authority gate",
+        could_higher_tier_resolve: false,
+        authorize_label: "retry CTL-E6",
+      },
+    };
+    writeFileSync(
+      RECOVERY_PASS_SIG(orchDir, "CTL-E6"),
+      JSON.stringify(richSig)
+    );
+    // Now call the chokepoint with a thin explanation — should not overwrite
+    labelNeedsHumanUnlessBeliefOwner(orchDir, "CTL-E6", makeAppliedWS(), {
+      env: { CATALYST_INTENTS_ENFORCE: "0" },
+      site: "attempts-exhausted",
+      log: { info: () => {}, warn: () => {} },
+      explanation: { human_question: "see recovery-pass escalation brief" },
+    });
+    const sig = JSON.parse(readFileSync(RECOVERY_PASS_SIG(orchDir, "CTL-E6"), "utf8"));
+    // Rich explanation preserved — call_to_action unchanged
+    expect(sig.explanation.call_to_action).toBe("authorize another recovery cycle for CTL-E6");
+    expect(sig.explanation.degraded).toBeUndefined();
   });
 });

--- a/plugins/dev/scripts/execution-core/label-guard.test.mjs
+++ b/plugins/dev/scripts/execution-core/label-guard.test.mjs
@@ -1345,4 +1345,35 @@ describe("labelNeedsHumanUnlessBeliefOwner — explanation threading (CTL-1609)"
     expect(sig.explanation.call_to_action).toBe("authorize another recovery cycle for CTL-E6");
     expect(sig.explanation.degraded).toBeUndefined();
   });
+
+  test("no-overwrite guard: degraded prior IS overwritten by richer explanation", () => {
+    const workerDir = join(orchDir, "workers", "CTL-E7");
+    mkdirSync(workerDir, { recursive: true });
+    // Write a degraded signal (the prior call had no explanation)
+    const degradedSig = {
+      ticket: "CTL-E7",
+      status: "needs-human",
+      needsHumanSince: "2026-01-01T00:00:00.000Z",
+      updatedAt: "2026-01-01T00:00:00.000Z",
+      phase: "recovery-pass",
+      explanation: { escalation_type: "authorization", degraded: true },
+    };
+    writeFileSync(RECOVERY_PASS_SIG(orchDir, "CTL-E7"), JSON.stringify(degradedSig));
+    // Call chokepoint with a richer, non-degraded explanation — SHOULD overwrite
+    labelNeedsHumanUnlessBeliefOwner(orchDir, "CTL-E7", makeAppliedWS(), {
+      env: { CATALYST_INTENTS_ENFORCE: "0" },
+      site: "dispatch-failures",
+      log: { info: () => {}, warn: () => {} },
+      explanation: {
+        problem: "richer replacement for CTL-E7",
+        call_to_action: "resolve the dispatch failure for CTL-E7",
+      },
+    });
+    const sig = JSON.parse(readFileSync(RECOVERY_PASS_SIG(orchDir, "CTL-E7"), "utf8"));
+    // Guard allowed the overwrite — new problem/call_to_action from the second call are present.
+    // coerceExplanation always sets degraded:true, so the written signal is still degraded,
+    // but the content is the richer one (proving the guard did NOT block the write).
+    expect(sig.explanation.problem).toBe("richer replacement for CTL-E7");
+    expect(sig.explanation.call_to_action).toBe("resolve the dispatch failure for CTL-E7");
+  });
 });

--- a/plugins/dev/scripts/execution-core/monitor.mjs
+++ b/plugins/dev/scripts/execution-core/monitor.mjs
@@ -788,7 +788,11 @@ function dispatchTriage(
           problem: `${t} hit the triage re-dispatch cap (${TRIAGE_DISPATCH_CAP})`,
           call_to_action: `triage ${t} manually or re-scope it`,
         },
-        deps: { orchDir: dir },
+        // CTL-1609 (Codex P1): supply the configured ceiling so
+        // enqueueDelegateIntent can reach `queue-full` → human instead of
+        // defaulting to Infinity. Lazy: the state.json read is paid only on the
+        // enforce path that actually enqueues.
+        deps: { orchDir: dir, maxParallel: () => readMaxParallel(dir) },
       }),
     // CTL-1589 (Codex R3): when set (the sweep's Triage-BOARD candidates), the
     // ticket's LIVE state must still equal this workflow-state name at launch.

--- a/plugins/dev/scripts/execution-core/monitor.mjs
+++ b/plugins/dev/scripts/execution-core/monitor.mjs
@@ -77,6 +77,7 @@ import {
   removeLabel, // CTL-1481: worker:<host> swap (remove-before-add)
 } from "./linear-write.mjs";
 import { labelNeedsHumanUnlessBeliefOwner } from "./label-guard.mjs"; // CTL-1441
+import { routeStuckTicketToDelegate } from "./delegate-first.mjs"; // CTL-1609
 import { appendTriageTransitionEvent as defaultAppendEvent } from "./triage-transition-event.mjs";
 import { countBackgroundAgents, resetLivenessCache } from "./claude-agents.mjs";
 import {
@@ -779,12 +780,16 @@ function dispatchTriage(
     // CTL-1441: needs-human application at the re-dispatch cap. Injectable so
     // tests never spawn a real linearis write; default = the label-guard path.
     labelNeedsHuman = (dir, t) =>
-      labelNeedsHumanUnlessBeliefOwner(dir, t, { applyLabel }, {
+      routeStuckTicketToDelegate(dir, t, {
         site: "triage-redispatch-cap",
+        reason: "triage-redispatch-cap",
+        boardContext: { cap: TRIAGE_DISPATCH_CAP },
+        applyLabel: { applyLabel },
         explanation: {
           problem: `${t} hit the triage re-dispatch cap (${TRIAGE_DISPATCH_CAP})`,
           call_to_action: `triage ${t} manually or re-scope it`,
         },
+        deps: { orchDir: dir },
       }),
     // CTL-1589 (Codex R3): when set (the sweep's Triage-BOARD candidates), the
     // ticket's LIVE state must still equal this workflow-state name at launch.

--- a/plugins/dev/scripts/execution-core/monitor.mjs
+++ b/plugins/dev/scripts/execution-core/monitor.mjs
@@ -76,7 +76,6 @@ import {
   applyLabel, // CTL-1441: needs-human at the triage re-dispatch cap
   removeLabel, // CTL-1481: worker:<host> swap (remove-before-add)
 } from "./linear-write.mjs";
-import { labelNeedsHumanUnlessBeliefOwner } from "./label-guard.mjs"; // CTL-1441
 import { routeStuckTicketToDelegate } from "./delegate-first.mjs"; // CTL-1609
 import { appendTriageTransitionEvent as defaultAppendEvent } from "./triage-transition-event.mjs";
 import { countBackgroundAgents, resetLivenessCache } from "./claude-agents.mjs";

--- a/plugins/dev/scripts/execution-core/monitor.mjs
+++ b/plugins/dev/scripts/execution-core/monitor.mjs
@@ -779,7 +779,13 @@ function dispatchTriage(
     // CTL-1441: needs-human application at the re-dispatch cap. Injectable so
     // tests never spawn a real linearis write; default = the label-guard path.
     labelNeedsHuman = (dir, t) =>
-      labelNeedsHumanUnlessBeliefOwner(dir, t, { applyLabel }, { site: "triage-redispatch-cap" }),
+      labelNeedsHumanUnlessBeliefOwner(dir, t, { applyLabel }, {
+        site: "triage-redispatch-cap",
+        explanation: {
+          problem: `${t} hit the triage re-dispatch cap (${TRIAGE_DISPATCH_CAP})`,
+          call_to_action: `triage ${t} manually or re-scope it`,
+        },
+      }),
     // CTL-1589 (Codex R3): when set (the sweep's Triage-BOARD candidates), the
     // ticket's LIVE state must still equal this workflow-state name at launch.
     // null/undefined (the webhook path, eligible-half candidates) skips the check.

--- a/plugins/dev/scripts/execution-core/scheduler.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.mjs
@@ -2411,7 +2411,13 @@ export function maybeEscalateDispatchFailures(
       could_higher_tier_resolve: false,
       authorize_label: `retry ${marker.ticket}`,
     },
-    deps: { orchDir },
+    // CTL-1609 (Codex P1): without a ceiling, enqueueDelegateIntent's
+    // resolveMaxParallel falls back to Infinity and `queue-full` — the documented
+    // fallback to a human — becomes unreachable. Resolved lazily so the state.json
+    // read is paid only on the enforce path that actually enqueues. This site cannot
+    // reuse schedulerTick's `maxParallel`: it is a separate exported function, and
+    // its two call sites sit above that binding in the tick.
+    deps: { orchDir, maxParallel: () => readMaxParallel(orchDir) },
   });
   appendEvent({
     ticket: marker.ticket,
@@ -5763,7 +5769,11 @@ export function schedulerTick(
                   ],
                   why_you: "automated dispatch cannot resolve circular dependencies — operator must choose which dependency to break",
                 },
-                deps: { orchDir },
+                // CTL-1609 (Codex P1): thread the tick's resolved ceiling so
+                // enqueueDelegateIntent can return `queue-full` instead of defaulting
+                // to Infinity. Without it a cycle larger than maxParallel enqueues
+                // every member in one tick and starves normal admission.
+                deps: { orchDir, maxParallel },
               });
               // CTL-764 finding 8: emit only on an actual label write (a persisted
               // marker after restart / belief-owner deferral is not a fresh escalation).
@@ -6584,7 +6594,9 @@ export function schedulerTick(
                 ],
                 why_you: "automated dispatch cannot resolve circular dependencies — operator must choose which dependency to break",
               },
-              deps: { orchDir },
+              // CTL-1609 (Codex P1): thread the tick's resolved ceiling — see the
+              // dependency-cycle site above for why Infinity is unsafe here.
+              deps: { orchDir, maxParallel },
             });
             // CTL-764 finding 8: emit only on an actual label write (a persisted
             // marker after restart / belief-owner deferral is not a fresh escalation).
@@ -7204,7 +7216,9 @@ export function schedulerTick(
                 problem: `${ticket} has a ${stalledSig?.status ?? "stalled"} phase signal (${stalledSig?.stalledReason ?? "no reason"}) and is not terminal`,
                 call_to_action: `decide whether to retry ${ticket} or close it`,
               },
-              deps: { orchDir },
+              // CTL-1609 (Codex P1): thread the tick's resolved ceiling so a large
+              // terminal-sweep cohort cannot enqueue past maxParallel.
+              deps: { orchDir, maxParallel },
             });
             // CTL-764 finding 8: emit worker.transition ONLY when the label write
             // actually occurred. A persisted .linear-label-needs-human marker after a

--- a/plugins/dev/scripts/execution-core/scheduler.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.mjs
@@ -2397,6 +2397,16 @@ export function maybeEscalateDispatchFailures(
     env,
     site: "dispatch-failures",
     log,
+    explanation: {
+      escalation_type: "authorization",
+      problem: `dispatch failed ${marker.consecutiveFailures}× on ${marker.phase} (${marker.code})`,
+      call_to_action: `authorize retry of ${marker.ticket} or cancel`,
+      recommendation: "retry dispatch",
+      risk: `${marker.code} — ${marker.consecutiveFailures} consecutive failures on the ${marker.phase} phase`,
+      why_asking: "circuit breaker tripped; repeated dispatch failures require operator review",
+      could_higher_tier_resolve: false,
+      authorize_label: `retry ${marker.ticket}`,
+    },
   });
   appendEvent({
     ticket: marker.ticket,
@@ -5003,6 +5013,10 @@ export function schedulerTick(
               labelNeedsHuman: (dir, t) =>
                 labelNeedsHumanUnlessBeliefOwner(dir, t, writeStatus, {
                   site: "attempts-exhausted",
+                  // The curated explanation is already on disk from escalateExhaustedIntents's
+                  // prior writeSignal call. Pass a thin hint so the absent-warn is suppressed;
+                  // writeExplanationSignal's no-overwrite guard keeps the richer signal intact.
+                  explanation: { human_question: "see recovery-pass escalation brief" },
                 }),
               // Codex R1: a finished ticket's stale ledger is forgotten by the
               // terminal cleanup LATER in the tick — never page a human for it.
@@ -5731,6 +5745,16 @@ export function schedulerTick(
                 env,
                 site: "dependency-cycle",
                 log,
+                explanation: {
+                  escalation_type: "decision",
+                  problem: `${member} is in a dependency cycle: ${anomaly.members.join(" → ")}`,
+                  call_to_action: `break the cycle for ${member}: reprioritize a member or drop a dependency`,
+                  options: [
+                    { label: "reprioritize", tradeoff: "changes queue order for all cycle members" },
+                    { label: "drop dependency", tradeoff: "may leave a blocker unaddressed" },
+                  ],
+                  why_you: "automated dispatch cannot resolve circular dependencies — operator must choose which dependency to break",
+                },
               });
               // CTL-764 finding 8: emit only on an actual label write (a persisted
               // marker after restart / belief-owner deferral is not a fresh escalation).
@@ -6538,6 +6562,16 @@ export function schedulerTick(
               env,
               site: "ctl-925-cycle",
               log,
+              explanation: {
+                escalation_type: "decision",
+                problem: `${member} is in a dependency cycle among eligible tickets: ${anomaly.members.join(" → ")}`,
+                call_to_action: `break the cycle for ${member}: reprioritize a member or drop a dependency`,
+                options: [
+                  { label: "reprioritize", tradeoff: "changes queue order for all cycle members" },
+                  { label: "drop dependency", tradeoff: "may leave a blocker unaddressed" },
+                ],
+                why_you: "automated dispatch cannot resolve circular dependencies — operator must choose which dependency to break",
+              },
             });
             // CTL-764 finding 8: emit only on an actual label write (a persisted
             // marker after restart / belief-owner deferral is not a fresh escalation).
@@ -7145,10 +7179,15 @@ export function schedulerTick(
           // Non-terminal stalled/failed ticket → apply the belief-aware needs-human
           // label (CTL-1241: skipped when the belief engine owns the reclaim).
           if (fenceGuard({ ticket, orchDir, multiHost, gateway, self })) {
+            const stalledSig = signalByTicket.get(ticket);
             const wrote = labelNeedsHumanUnlessBeliefOwner(orchDir, ticket, writeStatus, {
               env,
               site: "terminal-sweep",
               log,
+              explanation: {
+                problem: `${ticket} has a ${stalledSig?.status ?? "stalled"} phase signal (${stalledSig?.stalledReason ?? "no reason"}) and is not terminal`,
+                call_to_action: `decide whether to retry ${ticket} or close it`,
+              },
             });
             // CTL-764 finding 8: emit worker.transition ONLY when the label write
             // actually occurred. A persisted .linear-label-needs-human marker after a

--- a/plugins/dev/scripts/execution-core/scheduler.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.mjs
@@ -371,6 +371,7 @@ import { ownedBy, ownerForTicket } from "./hrw.mjs"; // CTL-850: HRW ownership f
 import { computeDispatchRoster, readDeflapState, writeDeflapState } from "./liveness-deflap.mjs"; // CTL-1091: restore-side deflap for the dispatch roster
 import { boardHealthPass, lookupPrStatus } from "./board-health.mjs"; // CTL-1290: the whole-board health delegate (shadow-first). CTL-1644 (Codex P2): lookupPrStatus reused for getStrandedEvidence's no-cross-repo-borrow PR resolution.
 import { readStalledPrState } from "./stalled-pr-timer.mjs"; // CTL-1608: aggregate workers/*/stalled-pr.json → Map for board-health
+import { routeStuckTicketToDelegate } from "./delegate-first.mjs"; // CTL-1609: delegate-first escalation seam
 import {
   getAllTicketDescriptors,
   getAllPrStatuses,
@@ -2393,9 +2394,12 @@ export function maybeEscalateDispatchFailures(
   { writeStatus, appendEvent, env = process.env } = {}
 ) {
   if (!marker || marker.consecutiveFailures < DISPATCH_FAILURE_ESCALATION_THRESHOLD) return false;
-  const wrote = labelNeedsHumanUnlessBeliefOwner(orchDir, marker.ticket, writeStatus, {
-    env,
+  const result = routeStuckTicketToDelegate(orchDir, marker.ticket, {
     site: "dispatch-failures",
+    reason: `dispatch-circuit-breaker:${marker.consecutiveFailures}`,
+    boardContext: { phase: marker.phase, code: marker.code },
+    applyLabel: writeStatus,
+    env,
     log,
     explanation: {
       escalation_type: "authorization",
@@ -2407,6 +2411,7 @@ export function maybeEscalateDispatchFailures(
       could_higher_tier_resolve: false,
       authorize_label: `retry ${marker.ticket}`,
     },
+    deps: { orchDir },
   });
   appendEvent({
     ticket: marker.ticket,
@@ -2415,7 +2420,7 @@ export function maybeEscalateDispatchFailures(
     code: marker.code,
     consecutiveFailures: marker.consecutiveFailures,
   });
-  return wrote;
+  return result.labelled === true;
 }
 
 // CTL-712: the refused-dispatch path writes NO signal file (the artifact gate
@@ -5741,9 +5746,12 @@ export function schedulerTick(
           if (triagedWaiting.includes(member)) {
             cycleMembers.add(member);
             if (fenceGuard({ ticket: member, orchDir, multiHost, gateway, self })) {
-              const wrote = labelNeedsHumanUnlessBeliefOwner(orchDir, member, writeStatus, {
-                env,
+              const dcResult = routeStuckTicketToDelegate(orchDir, member, {
                 site: "dependency-cycle",
+                reason: "dependency-cycle",
+                boardContext: { members: anomaly.members },
+                applyLabel: writeStatus,
+                env,
                 log,
                 explanation: {
                   escalation_type: "decision",
@@ -5755,10 +5763,11 @@ export function schedulerTick(
                   ],
                   why_you: "automated dispatch cannot resolve circular dependencies — operator must choose which dependency to break",
                 },
+                deps: { orchDir },
               });
               // CTL-764 finding 8: emit only on an actual label write (a persisted
               // marker after restart / belief-owner deferral is not a fresh escalation).
-              if (wrote) {
+              if (dcResult.labelled === true) {
                 recordTransition({
                   ticket: member,
                   toDisposition: "needs-human",
@@ -6558,9 +6567,12 @@ export function schedulerTick(
           // CTL-863 fence: external Linear write — a zombie host that lost its
           // claim must not label after takeover (mirrors the A.5 cycle site).
           if (fenceGuard({ ticket: member, orchDir, multiHost, gateway, self })) {
-            const wrote = labelNeedsHumanUnlessBeliefOwner(orchDir, member, writeStatus, {
-              env,
+            const c925Result = routeStuckTicketToDelegate(orchDir, member, {
               site: "ctl-925-cycle",
+              reason: "dependency-cycle",
+              boardContext: { members: anomaly.members },
+              applyLabel: writeStatus,
+              env,
               log,
               explanation: {
                 escalation_type: "decision",
@@ -6572,10 +6584,11 @@ export function schedulerTick(
                 ],
                 why_you: "automated dispatch cannot resolve circular dependencies — operator must choose which dependency to break",
               },
+              deps: { orchDir },
             });
             // CTL-764 finding 8: emit only on an actual label write (a persisted
             // marker after restart / belief-owner deferral is not a fresh escalation).
-            if (wrote) {
+            if (c925Result.labelled === true) {
               recordTransition({
                 ticket: member,
                 toDisposition: "needs-human",
@@ -7180,20 +7193,24 @@ export function schedulerTick(
           // label (CTL-1241: skipped when the belief engine owns the reclaim).
           if (fenceGuard({ ticket, orchDir, multiHost, gateway, self })) {
             const stalledSig = signalByTicket.get(ticket);
-            const wrote = labelNeedsHumanUnlessBeliefOwner(orchDir, ticket, writeStatus, {
-              env,
+            const tsResult = routeStuckTicketToDelegate(orchDir, ticket, {
               site: "terminal-sweep",
+              reason: stalledSig?.stalledReason ?? "stalled",
+              boardContext: { status: stalledSig?.status, phase: stalledSig?.phase },
+              applyLabel: writeStatus,
+              env,
               log,
               explanation: {
                 problem: `${ticket} has a ${stalledSig?.status ?? "stalled"} phase signal (${stalledSig?.stalledReason ?? "no reason"}) and is not terminal`,
                 call_to_action: `decide whether to retry ${ticket} or close it`,
               },
+              deps: { orchDir },
             });
             // CTL-764 finding 8: emit worker.transition ONLY when the label write
             // actually occurred. A persisted .linear-label-needs-human marker after a
             // daemon restart (labelOnce no-ops) or a belief-owner deferral changes no
             // label — recording a fresh needs-human transition there is a false escalation.
-            if (wrote) {
+            if (tsResult.labelled === true) {
               recordTransition({ ticket, toDisposition: "needs-human", source: "terminal-sweep" });
             }
           } else {

--- a/plugins/dev/scripts/execution-core/stale-pr-rescue-timer.mjs
+++ b/plugins/dev/scripts/execution-core/stale-pr-rescue-timer.mjs
@@ -20,7 +20,6 @@ import { spawnSync } from "node:child_process";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { jobLifecycle } from "./recovery.mjs";
-import { labelNeedsHumanUnlessBeliefOwner } from "./label-guard.mjs";
 import { routeStuckTicketToDelegate } from "./delegate-first.mjs"; // CTL-1609
 import { fenceGuard } from "./fence-guard.mjs";
 import { appendFileSync } from "node:fs";

--- a/plugins/dev/scripts/execution-core/stale-pr-rescue-timer.mjs
+++ b/plugins/dev/scripts/execution-core/stale-pr-rescue-timer.mjs
@@ -311,11 +311,23 @@ function defaultDispatchRescue(ticket, opts) {
 // linearWrite defaults to the real linear-write module at the
 // startStalePrRescueTimer boundary; a null here means a caller explicitly
 // opted out, which leaves the ticket invisible to humans — say so loudly.
+//
+// CTL-1609 (Codex P1) — RETURNS a verified outcome so the caller can decide
+// whether the escalation is durable enough to latch `rescue.json.escalatedAt`:
+//   { confirmed, routed, reason }
+// `confirmed: true` ONLY when a needs-human label actually landed. A delegate
+// route is a HANDOFF, not a confirmed human escalation — the delegate can still
+// fail, and `escalatedAt` permanently skips the ticket in decideRescue, so
+// latching on a route would silently strand the PR. Fence-suppressed and
+// no-transport paths return confirmed:false too.
 export function defaultEscalate(
   ticket,
   detail,
-  { orchDir, linearWrite, multiHost = false, gateway = undefined, self = undefined, env = process.env } = {}
+  { orchDir, linearWrite, multiHost = false, gateway = undefined, self = undefined, env = process.env, maxParallel = undefined } = {}
 ) {
+  let routed = false;
+  let labelled = false;
+  let outcomeReason = "no-transport";
   if (linearWrite) {
     // This is an ESCALATION write (needs-human), so it fails OPEN on a MISSING
     // generation (proceedOnMissingGeneration): a zombie-guard that can't read a
@@ -323,7 +335,7 @@ export function defaultEscalate(
     // human escalation. A genuine supersession (readable generation, fresh
     // foreign owner / authoritative read says not-current) still suppresses.
     if (fenceGuard({ ticket, orchDir, multiHost, gateway, self }, { proceedOnMissingGeneration: true })) {
-      routeStuckTicketToDelegate(orchDir, ticket, {
+      const r = routeStuckTicketToDelegate(orchDir, ticket, {
         site: "stale-pr-rescue",
         reason: detail?.reason ?? "unresolvable-conflict",
         boardContext: { prNumber: detail?.prNumber },
@@ -334,9 +346,17 @@ export function defaultEscalate(
           problem: `stale PR for ${ticket} could not be rescued: ${detail?.reason ?? "unresolvable conflict"}`,
           call_to_action: `resolve the PR conflict for ${ticket} or close the PR`,
         },
-        deps: { orchDir },
+        // CTL-1609 (Codex P1): supply the configured ceiling so the enqueue can
+        // reach `queue-full` → human instead of resolving to Infinity. Injected
+        // from the daemon (which already owns concurrency) rather than importing
+        // the scheduler here, which would pull its bun:sqlite graph into this timer.
+        deps: { orchDir, ...(maxParallel === undefined ? {} : { maxParallel }) },
       });
+      routed = r.routed === true;
+      labelled = r.labelled === true;
+      outcomeReason = r.reason ?? (labelled ? "labelled" : "not-labelled");
     } else {
+      outcomeReason = "fence-suppressed";
       log.warn(
         { ticket },
         "ctl-863: stale fence — suppressing stale-pr-rescue labelOnce write (zombie guard)"
@@ -349,6 +369,59 @@ export function defaultEscalate(
     );
   }
   log.warn({ ticket, ...detail }, "stale-pr-rescue: escalating to needs-human");
+  return { confirmed: labelled, routed, reason: outcomeReason };
+}
+
+// recordEscalationOutcome — CTL-1609 (Codex P1): the verified-or-loud latch.
+//
+// `rescue.json.escalatedAt` is a PERMANENT skip — decideRescue returns
+// `already_escalated` for every later tick once it is set. Writing it
+// optimistically (before the escalation is confirmed) is therefore the difference
+// between "a human was told" and "this PR is silently stuck forever".
+//
+// Only a CONFIRMED needs-human label counts. A delegate route does not: the
+// runner can still fail the intent, and nothing downstream clears escalatedAt or
+// re-applies the label, so latching there reintroduces exactly the silent-drop
+// this guard exists to prevent. Unconfirmed outcomes leave the state retryable
+// (next tick re-evaluates) AND emit a loud event so the gap is observable rather
+// than invisible.
+//
+// Returns true when the escalation was latched (caller should emit the normal
+// `phase.rescue.escalated.<ticket>` event), false when it stayed retryable.
+function recordEscalationOutcome(orchDir, ticket, rescueState, outcome, nowMs, emit, reason) {
+  // Only a seam that actually speaks the outcome contract can withhold the latch.
+  // A custom `escalate` injection predating it returns undefined — or something
+  // incidental like `array.push(...)`'s new length — and must keep the prior
+  // latch-always behavior rather than silently retrying forever. In production
+  // `escalate` defaults to defaultEscalate, which always returns the contract, so
+  // the strict path is the one that actually runs.
+  const hasContract =
+    outcome != null && typeof outcome === "object" && "confirmed" in outcome;
+  const confirmed = !hasContract || outcome.confirmed === true;
+  if (confirmed) {
+    writeRescueState(orchDir, ticket, {
+      ...rescueState,
+      escalatedAt: new Date(nowMs).toISOString(),
+      escalateReason: reason,
+    });
+    return true;
+  }
+  writeRescueState(orchDir, ticket, {
+    ...rescueState,
+    lastEscalationAttemptAt: new Date(nowMs).toISOString(),
+    lastEscalationFailure: outcome.reason ?? "unconfirmed",
+  });
+  log.error(
+    { ticket, reason, outcome: outcome.reason ?? "unconfirmed", routed: outcome.routed === true },
+    "stale-pr-rescue: escalation NOT confirmed — leaving retryable (escalatedAt withheld)"
+  );
+  emit(`phase.rescue.escalation-unconfirmed.${ticket}`, {
+    ticket,
+    reason,
+    outcome: outcome.reason ?? "unconfirmed",
+    routed: outcome.routed === true,
+  });
+  return false;
 }
 
 // defaultEmit — append a bare event envelope to the event log.
@@ -383,6 +456,12 @@ export function startStalePrRescueTimer({
   // "not injected" → resolve fresh each tick; a test may still pass an explicit
   // boolean to pin it. Matches the per-tick `getClusterHosts()` in scheduler/monitor.
   multiHost = undefined,
+  // CTL-1609 (Codex P1): the configured delegate ceiling, threaded to
+  // enqueueDelegateIntent so `queue-full` → human stays reachable instead of
+  // resolving to Infinity. A number or a () => number. Injected by the daemon
+  // (which already owns concurrency); importing readMaxParallel here would pull
+  // scheduler.mjs's bun:sqlite graph into this timer. undefined → prior behavior.
+  maxParallel = undefined,
   // injectable seams
   jobLifecycle: jobLifecycleFn = jobLifecycle,
   prView = defaultPrView,
@@ -442,6 +521,7 @@ async function runTick({
   cfg,
   linearWrite,
   multiHost,
+  maxParallel,
   jobLifecycleFn,
   prView,
   compareBehind,
@@ -470,6 +550,7 @@ async function runTick({
         cfg,
         linearWrite,
         multiHost,
+        maxParallel,
         nowMs,
         jobLifecycleFn,
         prView,
@@ -493,6 +574,7 @@ async function processTicket({
   cfg,
   linearWrite,
   multiHost,
+  maxParallel,
   nowMs,
   jobLifecycleFn,
   prView,
@@ -550,16 +632,19 @@ async function processTicket({
         return;
       }
     }
-    escalate(
+    const stalledOutcome = escalate(
       ticket,
       { reason: "rescue_worker_stalled", ...rescueState },
-      { orchDir, orchId: effectiveOrchId, linearWrite, multiHost }
+      { orchDir, orchId: effectiveOrchId, linearWrite, multiHost, maxParallel }
     );
-    writeRescueState(orchDir, ticket, {
-      ...rescueState,
-      escalatedAt: new Date(nowMs).toISOString(),
-    });
-    emit(`phase.rescue.escalated.${ticket}`, { ticket, reason: "rescue_worker_stalled" });
+    // CTL-1609 (Codex P1): latch escalatedAt ONLY on a confirmed label write.
+    // decideRescue skips forever once escalatedAt exists, so latching on an
+    // unconfirmed escalation (delegate route that may still fail, fence
+    // suppression, missing transport) would leave the PR neither retried nor
+    // surfaced. Unconfirmed → stay retryable AND say so loudly.
+    if (recordEscalationOutcome(orchDir, ticket, rescueState, stalledOutcome, nowMs, emit, "rescue_worker_stalled")) {
+      emit(`phase.rescue.escalated.${ticket}`, { ticket, reason: "rescue_worker_stalled" });
+    }
     return;
   }
 
@@ -676,18 +761,19 @@ async function processTicket({
     }
 
     case "escalate": {
-      escalate(ticket, decision.detail ?? {}, {
+      const outcome = escalate(ticket, decision.detail ?? {}, {
         orchDir,
         orchId: effectiveOrchId,
         linearWrite,
         multiHost,
+        maxParallel,
       });
-      writeRescueState(orchDir, ticket, {
-        ...rescueState,
-        escalatedAt: new Date(nowMs).toISOString(),
-        escalateReason: decision.reason,
-      });
-      emit(`phase.rescue.escalated.${ticket}`, { ticket, reason: decision.reason });
+      // CTL-1609 (Codex P1): see recordEscalationOutcome — escalatedAt is a
+      // permanent skip in decideRescue, so it is written only when the needs-human
+      // label is confirmed applied.
+      if (recordEscalationOutcome(orchDir, ticket, rescueState, outcome, nowMs, emit, decision.reason)) {
+        emit(`phase.rescue.escalated.${ticket}`, { ticket, reason: decision.reason });
+      }
       return;
     }
   }

--- a/plugins/dev/scripts/execution-core/stale-pr-rescue-timer.mjs
+++ b/plugins/dev/scripts/execution-core/stale-pr-rescue-timer.mjs
@@ -327,6 +327,10 @@ export function defaultEscalate(
         env,
         site: "stale-pr-rescue",
         log,
+        explanation: {
+          problem: `stale PR for ${ticket} could not be rescued: ${detail?.reason ?? "unresolvable conflict"}`,
+          call_to_action: `resolve the PR conflict for ${ticket} or close the PR`,
+        },
       });
     } else {
       log.warn(

--- a/plugins/dev/scripts/execution-core/stale-pr-rescue-timer.mjs
+++ b/plugins/dev/scripts/execution-core/stale-pr-rescue-timer.mjs
@@ -21,6 +21,7 @@ import { join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { jobLifecycle } from "./recovery.mjs";
 import { labelNeedsHumanUnlessBeliefOwner } from "./label-guard.mjs";
+import { routeStuckTicketToDelegate } from "./delegate-first.mjs"; // CTL-1609
 import { fenceGuard } from "./fence-guard.mjs";
 import { appendFileSync } from "node:fs";
 import { log, getEventLogPath, getClusterHosts } from "./config.mjs";
@@ -323,14 +324,18 @@ export function defaultEscalate(
     // human escalation. A genuine supersession (readable generation, fresh
     // foreign owner / authoritative read says not-current) still suppresses.
     if (fenceGuard({ ticket, orchDir, multiHost, gateway, self }, { proceedOnMissingGeneration: true })) {
-      labelNeedsHumanUnlessBeliefOwner(orchDir, ticket, linearWrite, {
-        env,
+      routeStuckTicketToDelegate(orchDir, ticket, {
         site: "stale-pr-rescue",
+        reason: detail?.reason ?? "unresolvable-conflict",
+        boardContext: { prNumber: detail?.prNumber },
+        applyLabel: linearWrite,
+        env,
         log,
         explanation: {
           problem: `stale PR for ${ticket} could not be rescued: ${detail?.reason ?? "unresolvable conflict"}`,
           call_to_action: `resolve the PR conflict for ${ticket} or close the PR`,
         },
+        deps: { orchDir },
       });
     } else {
       log.warn(

--- a/plugins/dev/scripts/execution-core/stale-pr-rescue-timer.test.mjs
+++ b/plugins/dev/scripts/execution-core/stale-pr-rescue-timer.test.mjs
@@ -933,3 +933,129 @@ describe("readStalePrRescueConfig", () => {
     expect(readStalePrRescueConfig("")).toEqual({});
   });
 });
+
+// ─── CTL-1609 (Codex P1): verified-or-loud escalation latch ───────────────────
+//
+// `rescue.json.escalatedAt` is a PERMANENT skip in decideRescue. Writing it
+// before the escalation is confirmed is the difference between "a human was told"
+// and "this PR is silently stuck forever". Only a confirmed needs-human label
+// latches; a delegate route (which can still fail) and a fence-suppressed or
+// transport-less escalation must stay retryable AND emit loudly.
+describe("escalation durability — escalatedAt only on a confirmed escalation (CTL-1609)", () => {
+  // Build a ticket that decideRescue will route to `escalate` (worktree missing).
+  function mkEscalatingTicket(orchDir, ticket, clock) {
+    mkTicketDir(orchDir, ticket);
+    writeSignal(orchDir, ticket, "pr", {
+      status: "done",
+      bg_job_id: "dead-job",
+      pr: { number: 77, url: "https://github.com/org/repo/pull/77" },
+      worktreePath: "/some/wt",
+    });
+    writeRescueState(orchDir, ticket, {
+      firstSeenAt: new Date(clock.now() - 660_000).toISOString(),
+    });
+  }
+
+  async function runOneTick(orchDir, clock, escalateFn, events) {
+    startStalePrRescueTimer({
+      enabled: true,
+      orchDir,
+      intervalSeconds: 1,
+      config: { stableSeconds: 300, behindThreshold: 10, maxAttempts: 1 },
+      clock,
+      ...makeSeams({
+        escalate: escalateFn,
+        worktreeExists: () => false, // → decideRescue: escalate(worktree_missing)
+        emit: (name, payload) => events.push({ name, payload }),
+      }),
+    });
+    clock.advance(1_000);
+    await new Promise((r) => setTimeout(r, 20));
+  }
+
+  it("confirmed label → escalatedAt latched, second tick does not re-escalate", async () => {
+    const clock = fakeClock();
+    const orchDir = mkOrchDir();
+    mkEscalatingTicket(orchDir, "CTL-E1", clock);
+    const calls = [];
+    const events = [];
+    await runOneTick(
+      orchDir,
+      clock,
+      (t) => {
+        calls.push(t);
+        return { confirmed: true, routed: false, reason: "labelled" };
+      },
+      events
+    );
+
+    expect(calls.length).toBe(1);
+    expect(readRescueState(orchDir, "CTL-E1")?.escalatedAt).toBeTruthy();
+    clock.advance(1_000);
+    await new Promise((r) => setTimeout(r, 20));
+    expect(calls.length).toBe(1); // already_escalated
+  });
+
+  it("delegate ROUTE (unconfirmed) → escalatedAt withheld, stays retryable, emits loudly", async () => {
+    const clock = fakeClock();
+    const orchDir = mkOrchDir();
+    mkEscalatingTicket(orchDir, "CTL-E2", clock);
+    const calls = [];
+    const events = [];
+    await runOneTick(
+      orchDir,
+      clock,
+      (t) => {
+        calls.push(t);
+        return { confirmed: false, routed: true, reason: "enqueued" };
+      },
+      events
+    );
+
+    const rs = readRescueState(orchDir, "CTL-E2");
+    // The bug: latching here would make decideRescue skip forever even though the
+    // delegate can still fail and nothing would ever re-surface the PR.
+    expect(rs?.escalatedAt).toBeUndefined();
+    expect(rs?.lastEscalationFailure).toBe("enqueued");
+    const loud = events.find((e) => e.name.startsWith("phase.rescue.escalation-unconfirmed."));
+    expect(loud).toBeDefined();
+    expect(loud.payload.routed).toBe(true);
+    // and it is genuinely retryable — a second tick escalates again
+    clock.advance(1_000);
+    await new Promise((r) => setTimeout(r, 20));
+    expect(calls.length).toBe(2);
+  });
+
+  it("fence-suppressed (unconfirmed, not routed) → withheld + loud", async () => {
+    const clock = fakeClock();
+    const orchDir = mkOrchDir();
+    mkEscalatingTicket(orchDir, "CTL-E3", clock);
+    const events = [];
+    await runOneTick(
+      orchDir,
+      clock,
+      () => ({ confirmed: false, routed: false, reason: "fence-suppressed" }),
+      events
+    );
+
+    const rs = readRescueState(orchDir, "CTL-E3");
+    expect(rs?.escalatedAt).toBeUndefined();
+    expect(rs?.lastEscalationFailure).toBe("fence-suppressed");
+    expect(
+      events.find((e) => e.name.startsWith("phase.rescue.escalation-unconfirmed."))
+    ).toBeDefined();
+  });
+
+  it("legacy seam returning a non-contract value still latches (back-compat)", async () => {
+    const clock = fakeClock();
+    const orchDir = mkOrchDir();
+    mkEscalatingTicket(orchDir, "CTL-E4", clock);
+    const sink = [];
+    const events = [];
+    // `array.push(...)` returns a NUMBER — the shape every pre-existing test stub
+    // returns. It must not be mistaken for an unconfirmed outcome.
+    await runOneTick(orchDir, clock, (t) => sink.push(t), events);
+
+    expect(readRescueState(orchDir, "CTL-E4")?.escalatedAt).toBeTruthy();
+  });
+});


### PR DESCRIPTION
## Summary

- **Gap 1 — Delegate-first routing seam**: All `needs-human` label sites (except `attempts-exhausted`, which is post-delegate by definition) now route through `routeStuckTicketToDelegate` (`delegate-first.mjs`) instead of calling `labelNeedsHumanUnlessBeliefOwner` directly. Gated by `CATALYST_DELEGATE_FIRST=off|shadow|enforce` (default `off` — byte-identical to before). Ordered fallback: auto-fix [deferred] → delegate → human.
- **Gap 2 — Explanation-required chokepoint**: `labelNeedsHumanUnlessBeliefOwner` now accepts an optional `explanation` object. Absent explanations emit `escalation.explanation-absent` and coerce a degraded fallback. Present explanations are written atomically to `workers/<TICKET>/phase-recovery-pass.json` so the operator board renders "What's needed now" cards. No-overwrite guard protects `attempts-exhausted`'s rich curated signal.

## What changed

| File | Change |
|------|--------|
| `label-guard.mjs` | `writeExplanationSignal` + `explanation` opt in `labelNeedsHumanUnlessBeliefOwner` |
| `label-guard.test.mjs` | 6 new tests (explanation threading, no-overwrite guard, degraded coercion) |
| `delegate-first.mjs` | NEW: `routeStuckTicketToDelegate` + `readDelegateFirstMode` |
| `delegate-first.test.mjs` | NEW: 13 tests (all modes, fallback paths, idempotent queue outcomes) |
| `scheduler.mjs` | 4 sites rewired to delegate-first; explanation objects at 5 sites |
| `monitor.mjs` | `triage-redispatch-cap` rewired |
| `stale-pr-rescue-timer.mjs` | `stale-pr-rescue` rewired |
| `broker/namespace-parity.test.mjs` | Registered 4 new event names |
| `docs/architecture.md` | CTL-1609 section under Phase-Agent/scheduler routing |

## Test plan

- [ ] `bun test plugins/dev/scripts/execution-core/label-guard.test.mjs` — all pass (includes 6 new)
- [ ] `bun test plugins/dev/scripts/execution-core/delegate-first.test.mjs` — all pass (13 new)
- [ ] `bun test plugins/dev/scripts/broker/namespace-parity.test.mjs` — all 5 pass (new names no-collide)
- [ ] Full test suite regression: zero net-new failures vs baseline
- [ ] `CATALYST_DELEGATE_FIRST=off` behavior is byte-identical to pre-CTL-1609 (default path unchanged)
- [ ] Verify `attempts-exhausted` site does NOT route through `routeStuckTicketToDelegate`

🤖 Generated with [Claude Code](https://claude.com/claude-code)