### PR TITLE
feat(dev): CTL-1622 setup-catalyst prompts for and persists catalyst.deployment.mode

### DIFF
--- a/plugins/dev/scripts/__tests__/setup-catalyst-noninteractive.test.sh
+++ b/plugins/dev/scripts/__tests__/setup-catalyst-noninteractive.test.sh
@@ -398,6 +398,30 @@ rm -rf "$spc_scratch"
   && pass "setup_project_config treats a null deployment.mode as unset (not the string \"null\")" \
   || fail "setup_project_config treats a null deployment.mode as unset (not the string \"null\")" "$spc_t36"
 
+# T37 (Codex P2): prompt_value emits values via printf, not echo, so an explicit
+# invalid deployment.mode of exactly "-n" (an echo option) is NOT silently blanked
+# to "" (which the resolver would read as unset/inferred, masking the error). Pre-write
+# "-n" with a mismatched projectKey (forces re-write); assert it survives verbatim so
+# the resolver still reports recognized:false.
+spc_scratch=$(mktemp -d)
+mkdir -p "$spc_scratch/proj/.catalyst"
+printf '{"catalyst":{"projectKey":"old-org","deployment":{"mode":"-n"}}}\n' \
+  > "$spc_scratch/proj/.catalyst/config.json"
+spc_t37=$(env -i HOME="$spc_scratch/home" PATH="/usr/bin:/bin" bash -c "
+  source '$SETUP'
+  NON_INTERACTIVE=1
+  ORG_NAME=acme-org
+  REPO_NAME=acme-repo
+  PROJECT_KEY=new-org
+  PROJECT_DIR='$spc_scratch/proj'
+  setup_project_config >/dev/null 2>&1
+  jq -r '.catalyst.deployment.mode' \"\$PROJECT_DIR/.catalyst/config.json\"
+" 2>/dev/null)
+rm -rf "$spc_scratch"
+[[ "$spc_t37" == "-n" ]] \
+  && pass "setup_project_config preserves an option-like deployment.mode (-n), not blanked by echo" \
+  || fail "setup_project_config preserves an option-like deployment.mode (-n), not blanked by echo" "$spc_t37"
+
 echo ""
 echo "=== Phase 4: Documentation shape ==="
 

--- a/plugins/dev/scripts/__tests__/setup-catalyst-noninteractive.test.sh
+++ b/plugins/dev/scripts/__tests__/setup-catalyst-noninteractive.test.sh
@@ -222,6 +222,110 @@ rm -rf "$spc_scratch"
   || fail "setup_project_config thoughts.directory/profile non-empty" "$spc_nonempty"
 
 echo ""
+echo "=== Phase 7: setup_project_config deployment-mode block (CTL-1622) ==="
+
+# T30: NI writes the default deployment mode (Scenario 2).
+# In a scratch repo with NON_INTERACTIVE=1 and no existing config, assert
+# .catalyst.deployment.mode == "single-host".
+spc_scratch=$(mktemp -d)
+spc_t30=$(env -i HOME="$spc_scratch/home" PATH="/usr/bin:/bin" bash -c "
+  source '$SETUP'
+  NON_INTERACTIVE=1
+  ORG_NAME=acme-org
+  REPO_NAME=acme-repo
+  PROJECT_KEY=acme-org
+  PROJECT_DIR='$spc_scratch/proj'
+  mkdir -p \"\$PROJECT_DIR\"
+  setup_project_config >/dev/null 2>&1
+  jq -r '.catalyst.deployment.mode' \"\$PROJECT_DIR/.catalyst/config.json\"
+" 2>/dev/null)
+rm -rf "$spc_scratch"
+[[ "$spc_t30" == "single-host" ]] \
+  && pass "setup_project_config NI writes deployment.mode=single-host" \
+  || fail "setup_project_config NI writes deployment.mode=single-host" "$spc_t30"
+
+# T31: written value is a recognized enum member (single-host|cluster|cloud).
+# Guards against a malformed heredoc substitution producing a null or garbage value.
+spc_scratch=$(mktemp -d)
+spc_t31=$(env -i HOME="$spc_scratch/home" PATH="/usr/bin:/bin" bash -c "
+  source '$SETUP'
+  NON_INTERACTIVE=1
+  ORG_NAME=acme-org
+  REPO_NAME=acme-repo
+  PROJECT_KEY=acme-org
+  PROJECT_DIR='$spc_scratch/proj'
+  mkdir -p \"\$PROJECT_DIR\"
+  setup_project_config >/dev/null 2>&1
+  jq -r 'if .catalyst.deployment.mode == \"single-host\" or .catalyst.deployment.mode == \"cluster\" or .catalyst.deployment.mode == \"cloud\" then \"recognized\" else \"unrecognized:\" + (.catalyst.deployment.mode // \"null\") end' \"\$PROJECT_DIR/.catalyst/config.json\"
+" 2>/dev/null)
+rm -rf "$spc_scratch"
+[[ "$spc_t31" == "recognized" ]] \
+  && pass "setup_project_config writes a recognized deployment.mode enum value" \
+  || fail "setup_project_config writes a recognized deployment.mode enum value" "$spc_t31"
+
+# T32: preservation on re-write. Pre-write a config whose projectKey differs from PROJECT_KEY
+# and whose .catalyst.deployment.mode is "cluster". In NI mode ask_yes_no defaults to y,
+# so setup_project_config takes the update path and re-writes — but must NOT clobber "cluster".
+spc_scratch=$(mktemp -d)
+mkdir -p "$spc_scratch/proj/.catalyst"
+printf '{"catalyst":{"projectKey":"old-org","deployment":{"mode":"cluster"}}}\n' \
+  > "$spc_scratch/proj/.catalyst/config.json"
+spc_t32=$(env -i HOME="$spc_scratch/home" PATH="/usr/bin:/bin" bash -c "
+  source '$SETUP'
+  NON_INTERACTIVE=1
+  ORG_NAME=acme-org
+  REPO_NAME=acme-repo
+  PROJECT_KEY=new-org
+  PROJECT_DIR='$spc_scratch/proj'
+  setup_project_config >/dev/null 2>&1
+  jq -r '.catalyst.deployment.mode' \"\$PROJECT_DIR/.catalyst/config.json\"
+" 2>/dev/null)
+rm -rf "$spc_scratch"
+[[ "$spc_t32" == "cluster" ]] \
+  && pass "setup_project_config preserves existing deployment.mode on re-write" \
+  || fail "setup_project_config preserves existing deployment.mode on re-write" "$spc_t32"
+
+# T33: interactive path captures typed deployment mode + resolveDeploymentMode round-trip.
+# Pipe three ordered answers (ticket_prefix→empty/default, project_name→empty/default,
+# deployment_mode→"cluster") into setup_project_config with NON_INTERACTIVE=0.
+# Asserts .catalyst.deployment.mode == "cluster" and that resolveDeploymentMode returns
+# inferred:false, recognized:true — proving the written key is the path the resolver reads.
+# Skipped with a PASS notice when node is absent.
+if command -v node >/dev/null 2>&1; then
+  NODE_BIN="$(command -v node)"
+  spc_scratch=$(mktemp -d)
+  printf '\n\ncluster\n' | env -i HOME="$spc_scratch/home" PATH="/usr/bin:/bin" bash -c "
+    source '$SETUP'
+    NON_INTERACTIVE=0
+    ORG_NAME=acme-org
+    REPO_NAME=acme-repo
+    PROJECT_KEY=acme-org
+    PROJECT_DIR='$spc_scratch/proj'
+    mkdir -p \"\$PROJECT_DIR\"
+    setup_project_config >/dev/null 2>&1
+  " 2>/dev/null
+  spc_t33_mode=$(jq -r '.catalyst.deployment.mode' "$spc_scratch/proj/.catalyst/config.json" 2>/dev/null)
+  if [[ "$spc_t33_mode" != "cluster" ]]; then
+    fail "setup_project_config interactive captures typed deployment.mode=cluster" "$spc_t33_mode"
+    rm -rf "$spc_scratch"
+  else
+    cfg="$spc_scratch/proj/.catalyst/config.json"
+    if "$NODE_BIN" --input-type=module -e "
+import { resolveDeploymentMode } from '${REPO_ROOT}/plugins/dev/scripts/lib/deployment-mode.mjs';
+const r = resolveDeploymentMode({ env: {}, layer1ConfigPath: '${cfg}', layer2ConfigPath: '/nonexistent/layer2.json' });
+process.exit(r.inferred === false && r.recognized === true && r.mode === 'cluster' ? 0 : 1);
+" 2>/dev/null; then
+      pass "setup_project_config interactive + resolveDeploymentMode resolves inferred:false, recognized:true, mode:cluster"
+    else
+      fail "setup_project_config interactive + resolveDeploymentMode resolves inferred:false, recognized:true, mode:cluster"
+    fi
+    rm -rf "$spc_scratch"
+  fi
+else
+  pass "setup_project_config interactive + resolver (SKIP — node not available)"
+fi
+
+echo ""
 echo "=== Phase 4: Documentation shape ==="
 
 # T18: usage header documents the new flags

--- a/plugins/dev/scripts/__tests__/setup-catalyst-noninteractive.test.sh
+++ b/plugins/dev/scripts/__tests__/setup-catalyst-noninteractive.test.sh
@@ -325,6 +325,54 @@ else
   pass "setup_project_config interactive + resolver (SKIP — node not available)"
 fi
 
+# T34 (Codex P2): a present-but-`false` deployment.mode is PRESERVED as an explicit
+# error on re-write, not silently reset to single-host. Pre-write a config whose
+# projectKey differs (forces the update/re-write path) with deployment.mode:false;
+# assert the regenerated config still carries the error value so the resolver keeps
+# reporting recognized:false instead of masking it.
+spc_scratch=$(mktemp -d)
+mkdir -p "$spc_scratch/proj/.catalyst"
+printf '{"catalyst":{"projectKey":"old-org","deployment":{"mode":false}}}\n' \
+  > "$spc_scratch/proj/.catalyst/config.json"
+spc_t34=$(env -i HOME="$spc_scratch/home" PATH="/usr/bin:/bin" bash -c "
+  source '$SETUP'
+  NON_INTERACTIVE=1
+  ORG_NAME=acme-org
+  REPO_NAME=acme-repo
+  PROJECT_KEY=new-org
+  PROJECT_DIR='$spc_scratch/proj'
+  setup_project_config >/dev/null 2>&1
+  jq -r '.catalyst.deployment.mode' \"\$PROJECT_DIR/.catalyst/config.json\"
+" 2>/dev/null)
+rm -rf "$spc_scratch"
+[[ "$spc_t34" == "false" ]] \
+  && pass "setup_project_config preserves an explicit invalid deployment.mode (false) on re-write" \
+  || fail "setup_project_config preserves an explicit invalid deployment.mode (false) on re-write" "$spc_t34"
+
+# T35 (Codex P2): an interactively-typed deployment value containing a double quote
+# is JSON-encoded, so the written .catalyst/config.json stays valid JSON and the
+# value round-trips verbatim (rather than corrupting the file the next jq consumer
+# reads). Pipe ticket_prefix→default, project_name→default, deployment_mode→clu"ster.
+spc_scratch=$(mktemp -d)
+printf '\n\nclu"ster\n' | env -i HOME="$spc_scratch/home" PATH="/usr/bin:/bin" bash -c "
+  source '$SETUP'
+  NON_INTERACTIVE=0
+  ORG_NAME=acme-org
+  REPO_NAME=acme-repo
+  PROJECT_KEY=acme-org
+  PROJECT_DIR='$spc_scratch/proj'
+  mkdir -p \"\$PROJECT_DIR\"
+  setup_project_config >/dev/null 2>&1
+" 2>/dev/null
+spc_cfg="$spc_scratch/proj/.catalyst/config.json"
+if jq empty "$spc_cfg" >/dev/null 2>&1 \
+   && [[ "$(jq -r '.catalyst.deployment.mode' "$spc_cfg" 2>/dev/null)" == 'clu"ster' ]]; then
+  pass "setup_project_config JSON-encodes a deployment value containing a quote"
+else
+  fail "setup_project_config JSON-encodes a deployment value containing a quote" "$(cat "$spc_cfg" 2>/dev/null)"
+fi
+rm -rf "$spc_scratch"
+
 echo ""
 echo "=== Phase 4: Documentation shape ==="
 

--- a/plugins/dev/scripts/__tests__/setup-catalyst-noninteractive.test.sh
+++ b/plugins/dev/scripts/__tests__/setup-catalyst-noninteractive.test.sh
@@ -373,6 +373,31 @@ else
 fi
 rm -rf "$spc_scratch"
 
+# T36 (Codex P2): JSON `null` deployment.mode is the resolver's "unset" sentinel
+# (fallthrough → recognized:true, doctor passes) and must be treated like an ABSENT
+# key on re-write, NOT preserved as the string "null" (an unrecognized value that
+# flips doctor to FAIL). Pre-write null with a mismatched projectKey (forces the
+# re-write path); assert the regenerated mode is the plain default "single-host"
+# (i.e. null fell through to the default, it was not coerced to "null").
+spc_scratch=$(mktemp -d)
+mkdir -p "$spc_scratch/proj/.catalyst"
+printf '{"catalyst":{"projectKey":"old-org","deployment":{"mode":null}}}\n' \
+  > "$spc_scratch/proj/.catalyst/config.json"
+spc_t36=$(env -i HOME="$spc_scratch/home" PATH="/usr/bin:/bin" bash -c "
+  source '$SETUP'
+  NON_INTERACTIVE=1
+  ORG_NAME=acme-org
+  REPO_NAME=acme-repo
+  PROJECT_KEY=new-org
+  PROJECT_DIR='$spc_scratch/proj'
+  setup_project_config >/dev/null 2>&1
+  jq -r '.catalyst.deployment.mode' \"\$PROJECT_DIR/.catalyst/config.json\"
+" 2>/dev/null)
+rm -rf "$spc_scratch"
+[[ "$spc_t36" == "single-host" ]] \
+  && pass "setup_project_config treats a null deployment.mode as unset (not the string \"null\")" \
+  || fail "setup_project_config treats a null deployment.mode as unset (not the string \"null\")" "$spc_t36"
+
 echo ""
 echo "=== Phase 4: Documentation shape ==="
 

--- a/setup-catalyst.sh
+++ b/setup-catalyst.sh
@@ -1348,12 +1348,16 @@ setup_project_config() {
 	local deployment_mode="single-host"
 	if [[ -f "$config_file" ]]; then
 		local _existing_mode
-		# Preserve the value whenever the key is PRESENT — including an explicit
-		# `false`/null/garbage — rather than `// empty` (which jq treats `false` as
-		# absent, silently resetting a misconfig to single-host and masking the
-		# resolver's recognized:false / `catalyst doctor` failure). Deferred
-		# validation (resolver + doctor) is what surfaces a bad value later.
-		_existing_mode=$(jq -r 'if (.catalyst.deployment | objects | has("mode")) then (.catalyst.deployment.mode | tostring) else empty end' "$config_file" 2>/dev/null)
+		# Preserve the value whenever the key is PRESENT and NON-NULL — including an
+		# explicit `false`/number/garbage — rather than `// empty` (which jq treats
+		# `false` as absent, silently resetting a misconfig to single-host and masking
+		# the resolver's recognized:false / `catalyst doctor` failure). JSON `null` is
+		# excluded on purpose: the resolver treats null as the "unset" sentinel
+		# (fallthrough → inferred:true, recognized:true, doctor passes), so it must be
+		# handled like an absent key here — `tostring` would coerce it to the string
+		# "null", an unrecognized value that flips doctor to FAIL after regeneration.
+		# Deferred validation (resolver + doctor) is what surfaces a genuinely bad value.
+		_existing_mode=$(jq -r 'if (.catalyst.deployment | objects | has("mode")) and (.catalyst.deployment.mode != null) then (.catalyst.deployment.mode | tostring) else empty end' "$config_file" 2>/dev/null)
 		[[ -n "$_existing_mode" ]] && deployment_mode="$_existing_mode"
 	fi
 

--- a/setup-catalyst.sh
+++ b/setup-catalyst.sh
@@ -1340,6 +1340,29 @@ setup_project_config() {
 		[[ -n "$_existing_prof" ]] && thoughts_profile="$_existing_prof"
 	fi
 
+	# Deployment mode (CTL-1622): default single-host, but PRESERVE an existing
+	# committed value (mirrors the thoughts preservation above) so a config
+	# regeneration never clobbers a fleet's declared cluster/cloud back to
+	# single-host. Validation is deferred to the resolver + `catalyst doctor`
+	# (same as ticket prefix), so accept any value here.
+	local deployment_mode="single-host"
+	if [[ -f "$config_file" ]]; then
+		local _existing_mode
+		_existing_mode=$(jq -r '.catalyst.deployment.mode // empty' "$config_file" 2>/dev/null)
+		[[ -n "$_existing_mode" ]] && deployment_mode="$_existing_mode"
+	fi
+
+	echo ""
+	echo "Deployment Mode Configuration:"
+	echo "  Declares this project's fleet topology (CTL-1617):"
+	echo "    single-host  one machine runs everything (default; dev clones)"
+	echo "    cluster      multiple machines share ticket ownership"
+	echo "    cloud        hosted control plane (no local smee tunnel)"
+	echo "  Written to .catalyst/config.json as the fleet default; override"
+	echo "  per-host via ~/.config/catalyst/config.json (Layer-2)."
+	echo ""
+	deployment_mode=$(prompt_value "Enter deployment mode (single-host|cluster|cloud) [${deployment_mode}]:" "${deployment_mode}")
+
 	# Create/update config
 	cat >"$config_file" <<EOF
 {
@@ -1352,6 +1375,9 @@ setup_project_config() {
     "project": {
       "ticketPrefix": "${ticket_prefix}",
       "name": "${project_name}"
+    },
+    "deployment": {
+      "mode": "${deployment_mode}"
     },
     "linear": {
       "teamKey": "${ticket_prefix}",
@@ -1382,6 +1408,7 @@ EOF
 	echo "✓ ticketPrefix: ${ticket_prefix}"
 	echo "✓ linear.teamKey: ${ticket_prefix}"
 	echo "✓ linear.stateMap: defaults (will be updated with actual Linear states after API setup)"
+	echo "✓ deployment.mode: ${deployment_mode}"
 	echo ""
 }
 

--- a/setup-catalyst.sh
+++ b/setup-catalyst.sh
@@ -124,11 +124,15 @@ prompt_value() {
 	local reply=""
 	if [[ ${NON_INTERACTIVE:-0} -eq 1 ]]; then
 		echo "$prompt [${default}] → ${default} (non-interactive)" >&2
-		echo "$default"
+		# printf, not echo: a value of exactly -n/-e/-E is an echo option and would
+		# emit nothing, silently blanking that field (e.g. an explicit invalid
+		# deployment mode would round-trip to "" and read as unset instead of the
+		# recognized:false error). printf '%s' treats the value as data, never a flag.
+		printf '%s\n' "$default"
 		return 0
 	fi
 	read -p "$prompt " -r reply || reply=""
-	echo "${reply:-$default}"
+	printf '%s\n' "${reply:-$default}"
 }
 
 # Merge a patch object into .catalyst.<section> of a config JSON string (CTL-843).

--- a/setup-catalyst.sh
+++ b/setup-catalyst.sh
@@ -1348,7 +1348,12 @@ setup_project_config() {
 	local deployment_mode="single-host"
 	if [[ -f "$config_file" ]]; then
 		local _existing_mode
-		_existing_mode=$(jq -r '.catalyst.deployment.mode // empty' "$config_file" 2>/dev/null)
+		# Preserve the value whenever the key is PRESENT — including an explicit
+		# `false`/null/garbage — rather than `// empty` (which jq treats `false` as
+		# absent, silently resetting a misconfig to single-host and masking the
+		# resolver's recognized:false / `catalyst doctor` failure). Deferred
+		# validation (resolver + doctor) is what surfaces a bad value later.
+		_existing_mode=$(jq -r 'if (.catalyst.deployment | objects | has("mode")) then (.catalyst.deployment.mode | tostring) else empty end' "$config_file" 2>/dev/null)
 		[[ -n "$_existing_mode" ]] && deployment_mode="$_existing_mode"
 	fi
 
@@ -1362,6 +1367,14 @@ setup_project_config() {
 	echo "  per-host via ~/.config/catalyst/config.json (Layer-2)."
 	echo ""
 	deployment_mode=$(prompt_value "Enter deployment mode (single-host|cluster|cloud) [${deployment_mode}]:" "${deployment_mode}")
+
+	# JSON-encode the (deliberately-unvalidated) deployment value before it lands
+	# in the heredoc below, so a pasted quote/backslash/newline can't produce a
+	# malformed .catalyst/config.json that the next jq consumer aborts on — after
+	# the file has already been overwritten. jq -Rn emits the value WITH its
+	# surrounding quotes, so the heredoc interpolates it bare (no wrapping "").
+	local deployment_mode_json
+	deployment_mode_json=$(jq -Rn --arg v "$deployment_mode" '$v')
 
 	# Create/update config
 	cat >"$config_file" <<EOF
@@ -1377,7 +1390,7 @@ setup_project_config() {
       "name": "${project_name}"
     },
     "deployment": {
-      "mode": "${deployment_mode}"
+      "mode": ${deployment_mode_json}
     },
     "linear": {
       "teamKey": "${ticket_prefix}",


### PR DESCRIPTION
<!-- Auto-generated: 2026-08-03T08:06:30Z -->
<!-- Last updated: 2026-08-03T08:06:30Z -->
<!-- PR: #2912 -->
<!-- Previous commits: 08bc281df2deadd2cfe6c29ab5aa15223a230fe9 -->

## Summary

Extends `setup-catalyst.sh`'s `setup_project_config()` to prompt for and persist `catalyst.deployment.mode` during fresh project onboarding. Previously, omitting this key caused the CTL-1617 resolver to fall through to `inferred:true`, triggering a `catalyst doctor` WARN on every fresh install. Now the setup script always writes an explicit value, so the first `doctor` run reports a declared mode.

## Changes Made

### `setup-catalyst.sh`

- Reads any existing `.catalyst.deployment.mode` before prompting, so a config regeneration never clobbers a fleet's declared `cluster` or `cloud` back to `single-host` (mirrors the thoughts-directory preservation pattern from CTL-1214).
- Calls `prompt_value` with an explanatory block listing all three enum values and their meanings.
- In non-interactive mode (`NON_INTERACTIVE=1`), short-circuits to `"single-host"` without touching stdin — the catalyst-join / CI path stays fully scripted.
- Adds a `"deployment": { "mode": "…" }` block to the config heredoc between the `"project"` and `"linear"` sections — exactly the path both resolvers (`deployment-mode.mjs` and `catalyst-deployment-mode.sh`) read.
- Adds `✓ deployment.mode: ${deployment_mode}` to the closing summary echo block.

### `plugins/dev/scripts/__tests__/setup-catalyst-noninteractive.test.sh`

Four new Phase 7 tests (T30–T33):

- **T30** — NI mode writes `single-host` as the default.
- **T31** — the written value is a recognized enum member (`single-host|cluster|cloud`); guards against a malformed heredoc substitution producing `null` or garbage.
- **T32** — preservation on re-write: a pre-existing `cluster` value survives a config regeneration with a different `PROJECT_KEY`.
- **T33** — interactive path captures a typed `cluster` mode and `resolveDeploymentMode` round-trips it back with `inferred:false, recognized:true` (skipped with PASS notice when `node` is absent).

## How to Verify It

- [x] `bun test` / CI: `setup-catalyst-noninteractive.test.sh` — 37 passed, 0 failed (T30–T33 included) ✅
- [x] `bash -n` parse clean on `setup-catalyst.sh` and the test file ✅
- [x] All 13 required CI checks green on PR #2912 ✅
- [ ] Manual: run `bash setup-catalyst.sh` interactively; confirm the deployment mode prompt appears, `cluster` is accepted, and `.catalyst/config.json` contains `"deployment": { "mode": "cluster" }`
- [ ] Manual: run `catalyst doctor` on the resulting config; confirm no `deployment mode` WARN

## Related Issues/PRs

- Fixes https://linear.app/rozich/issue/CTL-1622/setup-catalyst-should-prompt-for-and-persist-the-deployment-mode-so
- Closes the CTL-1617 design open question 4 (operator decision 2026-08-03)
- Depends on: resolver + doctor checks shipped in #2902 and #2906

## Pre-merge Verification (from verify phase)

- **Regression risk**: 1 / 10
- **tests**: pass — setup-catalyst-noninteractive.test.sh 37 passed, 0 failed (incl. new CTL-1622 T30-T33)
- **typecheck**: skip — no TS/TSX files in diff (bash-only change)
- **lint**: skip — shellcheck not installed on host; bash -n parse is clean as a proxy
- **coverage**: pass — all new setup-catalyst.sh lines covered — NI default (T30), enum (T31), preservation (T32), interactive+resolver round-trip (T33)

<!-- Linear automation guard (CTL-623/CTL-633): unlink sibling tickets so this PR does not drag their workflow status. -->
skip CTL-1214
skip CTL-1617