### PR TITLE
chore(dev): bump @catalyst-cloud/sdk to 0.8.0

### DIFF
--- a/plugins/dev/scripts/execution-core/bun.lock
+++ b/plugins/dev/scripts/execution-core/bun.lock
@@ -6,7 +6,7 @@
       "name": "catalyst-execution-core",
       "dependencies": {
         "@catalyst-cloud/read-model": "^0.1.0",
-        "@catalyst-cloud/sdk": "^0.7.0",
+        "@catalyst-cloud/sdk": "^0.8.0",
         "@opentelemetry/api": "^1.9.1",
         "@opentelemetry/exporter-trace-otlp-http": "^0.219.0",
         "@opentelemetry/resources": "^2.8.0",
@@ -51,7 +51,7 @@
 
     "@catalyst-cloud/schema": ["@catalyst-cloud/schema@0.1.3", "", { "dependencies": { "drizzle-orm": "0.44.7" } }, "sha512-qZGbGvJuvputQlX2TCH5IYAGGVJjunh7tZc9tsp4YxoE82Bj34F+zjqgtCuMTAc6yzR7rNJv90ZjZBLDNoKYwg=="],
 
-    "@catalyst-cloud/sdk": ["@catalyst-cloud/sdk@0.7.0", "", { "dependencies": { "@catalyst-cloud/read-model": "^0.1.0", "@catalyst-cloud/replicate": "^0.1.3", "@catalyst-cloud/schema": "^0.1.3" }, "peerDependencies": { "@opentelemetry/api": ">=1.3.0 <2", "@sqlite.org/sqlite-wasm": "*", "better-sqlite3": "*" }, "optionalPeers": ["@opentelemetry/api", "@sqlite.org/sqlite-wasm", "better-sqlite3"] }, "sha512-duwFyC67upHCDbxUQkiKU4mFIbSslEEezx/s4/UO/mIkKdRUIix63oMIerWh6r21SwtrsFvWaheLCDr3Ys4SqQ=="],
+    "@catalyst-cloud/sdk": ["@catalyst-cloud/sdk@0.8.0", "", { "dependencies": { "@catalyst-cloud/read-model": "^0.1.0", "@catalyst-cloud/replicate": "^0.1.3", "@catalyst-cloud/schema": "^0.1.3" }, "peerDependencies": { "@opentelemetry/api": ">=1.3.0 <2", "@sqlite.org/sqlite-wasm": "*", "better-sqlite3": "*" }, "optionalPeers": ["@opentelemetry/api", "@sqlite.org/sqlite-wasm", "better-sqlite3"] }, "sha512-FQxjNzYAFqpeqgv3CkBb+95y1IED+Kg22Jxw4CkyYz3kLtQJbBBTe6p4IwE+iC4QdSXoNWXw9pOwxD1jCeHHyg=="],
 
     "@hono/node-server": ["@hono/node-server@1.19.14", "", { "peerDependencies": { "hono": "^4" } }, "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw=="],
 

--- a/plugins/dev/scripts/execution-core/package.json
+++ b/plugins/dev/scripts/execution-core/package.json
@@ -7,7 +7,7 @@
   },
   "dependencies": {
     "@catalyst-cloud/read-model": "^0.1.0",
-    "@catalyst-cloud/sdk": "^0.7.0",
+    "@catalyst-cloud/sdk": "^0.8.0",
     "@opentelemetry/api": "^1.9.1",
     "@opentelemetry/exporter-trace-otlp-http": "^0.219.0",
     "@opentelemetry/resources": "^2.8.0",


### PR DESCRIPTION
## Summary

Deliberate bump to SDK **0.8.0** (CTC-114: new \`./browser\` entry — managed OPFS replica for browser apps). The \`/node\` entry this repo consumes is behaviorally unchanged — the only shared-file change between v0.7.0 and v0.8.0 is \`migrationsChangeRowShape\` hoisted into a browser-safe module and re-exported from its original path (public API preserved; verified by tag diff in catalyst-cloud-sdk).

The \`^0.7.0\` range already admitted 0.8.0; this pins the lockfile so both minis take the version intentionally, with tests, instead of on a future fresh install.

## Verification (on 0.8.0)

| Suite | Result |
|---|---|
| cloud-sync-log.test.mjs | 7 pass / 0 fail |
| __tests__/cloud-sync-telemetry.test.mjs | 30 pass / 0 fail |
| cluster-sync.test.mjs | 74 pass / 0 fail |
| replica-read.test.mjs | 0 fail |
| linear-cli.test.mjs | 42 pass / 1 fail — the failure ("mode off → linearis") is pre-existing laptop-env pollution, fails identically on 0.7.0 at origin/main |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WHfJt1JhsdArSUyxwZZzkN