### PR TITLE
feat(dev): CTL-1616 fold the 9-file Linear read into the secret contract + doctor cutover (PR3)

### DIFF
--- a/plugins/dev/scripts/execution-core/__tests__/doctor-worker-labels.test.mjs
+++ b/plugins/dev/scripts/execution-core/__tests__/doctor-worker-labels.test.mjs
@@ -16,10 +16,10 @@ function healthyNodes() {
 
 // "healthy" defaults; override per test.
 //
-// CTL-1616 PR2: resolveSecretContract is a shadow-only dependency (design §7) —
-// it must AGREE with `linearToken` here so these pre-existing behavioral tests
-// (which predate the shadow pass) don't spuriously grow an extra
-// worker-labels-secret-contract-shadow entry. Fixed values, never the real
+// CTL-1616 PR3: linearToken's default now routes through the injected
+// resolveSecretContract (the LIVE answer — see resolveLinearTokenLive in
+// doctor.mjs), and every test below still injects an explicit `linearToken`
+// too, which overrides that default outright. Fixed values, never the real
 // registry resolver — the real resolver would make these tests' output depend
 // on whatever LINEAR_API_TOKEN/LINEAR_API_KEY happen to be set in the runner's
 // ambient environment (present on a dev shell, absent under `bun test`'s
@@ -154,52 +154,67 @@ describe("checkWorkerLabels", () => {
   });
 });
 
-// ─── CTL-1616 PR2: secret-contract shadow (the "third value-read site") ────
-describe("checkWorkerLabels — secret-contract shadow (CTL-1616 PR2)", () => {
-  test("agree (both present) → no shadow row", async () => {
-    const recs = await checkWorkerLabels(deps());
+// ─── CTL-1616 PR3: secret-contract cutover (the "third value-read site") ───
+// PR3 (design §9) flips checkWorkerLabels from PR2's shadow-comparison to the
+// contract as its LIVE answer for linear-api-token — linearToken's default
+// now routes through resolveSecretContract, and the PR2 shadow-disagreement
+// row this check used to emit is retired (there is no hand-rolled answer left
+// to disagree with).
+describe("checkWorkerLabels — secret-contract cutover (CTL-1616 PR3)", () => {
+  test("resolveSecretContract resolving absent → linearToken() empty, the no-token INFO path, never a shadow row", async () => {
+    const recs = await checkWorkerLabels(
+      deps({ linearToken: undefined, resolveSecretContract: () => ({ value: null, source: "none", provider: "env-alias" }) }),
+    );
+    expect(recs).toHaveLength(1);
+    expect(recs[0].name).toBe("worker-labels");
+    expect(recs[0].status).toBe("info");
+    expect(recs[0].detail).toMatch(/token/i);
     expect(recs.some((r) => r.name.includes("secret-contract-shadow"))).toBe(false);
   });
 
-  test("disagree (hand-rolled present, contract absent) → loud INFO row, primary grade unchanged", async () => {
-    const recs = await checkWorkerLabels(
-      deps({ resolveSecretContract: () => ({ value: null, source: "none", provider: "env-alias" }) }),
-    );
-    const shadow = recs.find((r) => r.name === "worker-labels-secret-contract-shadow");
-    expect(shadow).toBeDefined();
-    expect(shadow.status).toBe("info");
-    expect(shadow.detail).toContain('secret="linear-api-token"');
-    expect(shadow.detail).toContain("hand-rolled=present");
-    expect(shadow.detail).toContain("contract={value:absent");
-    // Primary rows (group + per-host children) are untouched by the shadow.
-    expect(recs.filter((r) => r.name !== "worker-labels-secret-contract-shadow")).toHaveLength(ROSTER.length);
+  test("resolveSecretContract resolving present → linearToken() returns it, proceeds to query Linear", async () => {
+    const recs = await checkWorkerLabels(deps({ linearToken: undefined }));
+    expect(recs).toHaveLength(ROSTER.length);
+    expect(recs.some((r) => r.name.includes("secret-contract-shadow"))).toBe(false);
   });
 
-  test("a shadow disagreement never yields a FAIL record either", async () => {
-    const recs = await checkWorkerLabels(
-      deps({ resolveSecretContract: () => ({ value: null, source: "none", provider: "env-alias" }) }),
-    );
-    expect(noFail(recs)).toBe(true);
+  // CTL-1616 PR3 success criterion (design §9): a LINEAR_API_KEY-only
+  // environment resolves identically through the live cutover. Exercises the
+  // REAL resolveSecret default end-to-end — no linearToken/
+  // resolveSecretContract override at all.
+  test("LINEAR_API_KEY-only fixture (real resolveSecret default): honors the alias, proceeds to query Linear", async () => {
+    const savedToken = process.env.LINEAR_API_TOKEN;
+    const savedKey = process.env.LINEAR_API_KEY;
+    try {
+      delete process.env.LINEAR_API_TOKEN;
+      process.env.LINEAR_API_KEY = "lin_api_fromkey";
+      const recs = await checkWorkerLabels({
+        getRoster: () => ROSTER,
+        post: async () => ({ data: { issueLabels: { nodes: healthyNodes() } } }),
+      });
+      expect(recs).toHaveLength(ROSTER.length);
+      for (const host of ROSTER) expect(byName(recs)[`worker-label:${host}`].status).toBe("pass");
+    } finally {
+      if (savedToken === undefined) delete process.env.LINEAR_API_TOKEN;
+      else process.env.LINEAR_API_TOKEN = savedToken;
+      if (savedKey === undefined) delete process.env.LINEAR_API_KEY;
+      else process.env.LINEAR_API_KEY = savedKey;
+    }
   });
 
-  // CTL-1616 PR2 (B1): a throwing resolver must never crash this check —
-  // runDoctor's Promise.all has no per-check isolation, so an uncaught throw
-  // here would take down the whole doctor run.
-  test("resolver throws → normal graded rows still returned, plus a loud INFO throw-row, no FAIL", async () => {
+  test("a throwing resolveSecretContract degrades to the no-token INFO path, never crashes, no FAIL, no shadow row", async () => {
     const recs = await checkWorkerLabels(
       deps({
+        linearToken: undefined,
         resolveSecretContract: () => {
           throw new Error("boom: registry lookup exploded");
         },
       }),
     );
-    // Primary rows (group + per-host children) are untouched by the throw.
-    expect(recs.filter((r) => r.name !== "worker-labels-secret-contract-shadow")).toHaveLength(ROSTER.length);
-    const throwRow = recs.find((r) => r.name === "worker-labels-secret-contract-shadow");
-    expect(throwRow).toBeDefined();
-    expect(throwRow.status).toBe("info");
-    expect(throwRow.detail).toContain("SHADOW RESOLVER THREW");
-    expect(throwRow.detail).toContain("boom: registry lookup exploded");
+    expect(recs).toHaveLength(1);
+    expect(recs[0].name).toBe("worker-labels");
+    expect(recs[0].status).toBe("info");
+    expect(recs.some((r) => r.name.includes("secret-contract-shadow"))).toBe(false);
     expect(noFail(recs)).toBe(true);
   });
 });

--- a/plugins/dev/scripts/execution-core/cluster-claim.mjs
+++ b/plugins/dev/scripts/execution-core/cluster-claim.mjs
@@ -8,6 +8,14 @@
 // and self-contained makes it PR-order-independent: the only externalities are
 // the GraphQL `post` seam (injectable) and the Linear API token in the env.
 //
+// CTL-1616 PR3: resolveSecret from the shared zero-import lib/ leaf is NOT a
+// cross-module import of an execution-core sibling (the PR-order-independence
+// rule above is about staying independent of linear-query.mjs/
+// cluster-heartbeat.mjs's release order, not about the shared secret-contract
+// leaf; cluster-sync.mjs and doctor.mjs already set this precedent). Folds
+// defaultPost's own LINEAR_API_TOKEN/LINEAR_API_KEY ladder below.
+import { resolveSecret } from "../lib/secret-contract.mjs";
+//
 // ─── The storage mechanism (VERIFIED via live Linear API probe, 2026-06-08) ──
 // Linear has no custom fields and labels can't model a counter, so the claim +
 // fence + owner-name record is ONE Linear attachment per ticket:
@@ -78,7 +86,7 @@ export function authHeader(token = "") {
 // the caller's try/catch fails safe. Injectable via the `post` option on every
 // public function so tests never touch the network.
 async function defaultPost(query, variables) {
-  const token = process.env.LINEAR_API_TOKEN ?? process.env.LINEAR_API_KEY ?? "";
+  const token = resolveSecret("linear-api-token").value ?? ""; // CTL-1616 PR3
   const res = await fetch(LINEAR_GRAPHQL_ENDPOINT, {
     method: "POST",
     headers: {

--- a/plugins/dev/scripts/execution-core/cluster-claim.test.mjs
+++ b/plugins/dev/scripts/execution-core/cluster-claim.test.mjs
@@ -5,7 +5,7 @@
 // API does (attachmentCreate with the same url returns the same node with new
 // metadata), so claimTicket's read→write→read-back soft-CAS exercises real
 // semantics.
-import { describe, it, expect } from "bun:test";
+import { describe, it, expect, afterEach } from "bun:test";
 
 import {
   fenceUrl,
@@ -587,5 +587,39 @@ describe("runCli — the spawnSync CLI surface (CTL-850)", () => {
     const result = JSON.parse(out);
     expect(result.won).toBe(true);
     expect(result.generation).toBe(3); // bumped past generation 2
+  });
+});
+
+// CTL-1616 PR3: defaultPost's token resolution folds onto the shared
+// secret-contract engine (resolveSecret) — this is the synthetic
+// LINEAR_API_KEY-only fixture the design mandates, proven here by asserting
+// the Authorization header defaultPost actually sends (every other test in
+// this file injects its own fake `post`, bypassing defaultPost entirely).
+describe("defaultPost — secret-contract fold (CTL-1616 PR3)", () => {
+  const realFetch = globalThis.fetch;
+  afterEach(() => {
+    globalThis.fetch = realFetch;
+  });
+
+  it("LINEAR_API_KEY-only fixture: defaultPost sends it as the Authorization header when LINEAR_API_TOKEN is absent", async () => {
+    const savedToken = process.env.LINEAR_API_TOKEN;
+    const savedKey = process.env.LINEAR_API_KEY;
+    let seenAuth = null;
+    globalThis.fetch = async (_url, opts) => {
+      seenAuth = opts.headers.Authorization;
+      return { ok: true, json: async () => ({ data: { issue: { id: "issue-1" } } }) };
+    };
+    try {
+      delete process.env.LINEAR_API_TOKEN;
+      process.env.LINEAR_API_KEY = "lin_api_fromkey";
+      const issueId = await resolveIssueId("CTL-9");
+      expect(issueId).toBe("issue-1");
+      expect(seenAuth).toBe("lin_api_fromkey");
+    } finally {
+      if (savedToken === undefined) delete process.env.LINEAR_API_TOKEN;
+      else process.env.LINEAR_API_TOKEN = savedToken;
+      if (savedKey === undefined) delete process.env.LINEAR_API_KEY;
+      else process.env.LINEAR_API_KEY = savedKey;
+    }
   });
 });

--- a/plugins/dev/scripts/execution-core/cluster-heartbeat.mjs
+++ b/plugins/dev/scripts/execution-core/cluster-heartbeat.mjs
@@ -16,7 +16,13 @@
 // Shared GraphQL constants (RESOLVE_ISSUE_QUERY, READ_ATTACHMENTS_QUERY,
 // WRITE_ATTACHMENT_MUTATION, defaultPost, authHeader, resolveIssueId) are
 // copied verbatim from cluster-claim.mjs per the plan's no-cross-module-import
-// rule: each lib stays pure and PR-order-independent.
+// rule: each lib stays pure and PR-order-independent. That rule is about
+// execution-core siblings never depending on each other's release order — it
+// does not cover the shared zero-import lib/ leaf: CTL-1616 PR3 imports
+// resolveSecret from lib/secret-contract.mjs directly, the same precedent
+// cluster-sync.mjs and doctor.mjs already set, to fold this file's own
+// LINEAR_API_TOKEN/LINEAR_API_KEY ladder onto the shared contract.
+import { resolveSecret } from "../lib/secret-contract.mjs";
 
 const HEARTBEAT_URL_PREFIX = "catalyst://heartbeat/";
 const HEARTBEAT_ATTACHMENT_TITLE = "catalyst-liveness";
@@ -47,7 +53,7 @@ export function isRateClassLinearError(text) {
 // defaultPost — the production GraphQL POST. Injectable via `post` option on every
 // public function so tests never touch the network.
 async function defaultPost(query, variables) {
-  const token = process.env.LINEAR_API_TOKEN ?? process.env.LINEAR_API_KEY ?? "";
+  const token = resolveSecret("linear-api-token").value ?? ""; // CTL-1616 PR3
   const res = await fetch(LINEAR_GRAPHQL_ENDPOINT, {
     method: "POST",
     headers: {

--- a/plugins/dev/scripts/execution-core/cluster-heartbeat.test.mjs
+++ b/plugins/dev/scripts/execution-core/cluster-heartbeat.test.mjs
@@ -392,4 +392,31 @@ describe("defaultPost — !res.ok body handling (CTL-1420)", () => {
       restore();
     }
   });
+
+  // CTL-1616 PR3: defaultPost's token resolution folds onto the shared
+  // secret-contract engine (resolveSecret) — this is the synthetic
+  // LINEAR_API_KEY-only fixture the design mandates, proven here by asserting
+  // the Authorization header defaultPost actually sends.
+  test("LINEAR_API_KEY-only fixture: defaultPost sends it as the Authorization header when LINEAR_API_TOKEN is absent", async () => {
+    const savedToken = process.env.LINEAR_API_TOKEN;
+    const savedKey = process.env.LINEAR_API_KEY;
+    let seenAuth = null;
+    globalThis.fetch = async (_url, opts) => {
+      seenAuth = opts.headers.Authorization;
+      return { ok: true, json: async () => ({ data: { issue: { id: "issue-1" } } }) };
+    };
+    try {
+      delete process.env.LINEAR_API_TOKEN;
+      process.env.LINEAR_API_KEY = "lin_api_fromkey";
+      const issueId = await resolveIssueId("CTL-9");
+      expect(issueId).toBe("issue-1");
+      expect(seenAuth).toBe("lin_api_fromkey");
+    } finally {
+      restore();
+      if (savedToken === undefined) delete process.env.LINEAR_API_TOKEN;
+      else process.env.LINEAR_API_TOKEN = savedToken;
+      if (savedKey === undefined) delete process.env.LINEAR_API_KEY;
+      else process.env.LINEAR_API_KEY = savedKey;
+    }
+  });
 });

--- a/plugins/dev/scripts/execution-core/doctor.mjs
+++ b/plugins/dev/scripts/execution-core/doctor.mjs
@@ -127,11 +127,15 @@ export const STATUS = { PASS: "pass", WARN: "warn", FAIL: "fail", INFO: "info" }
 
 export const mkCheck = (name, status, detail) => ({ name, status, detail });
 
-// ─── CTL-1616 PR2: secret-contract shadow observability (zero grade change) ──
+// ─── CTL-1616 PR2/PR3: secret-contract observability (zero grade change) ─────
 //
-// safeResolveSecretContract — B1: every one of the 6 shadow call sites below
-// routes its call into the injected resolveSecretContract/resolveSecretFn
-// dependency through here instead of calling it directly. runDoctor's
+// safeResolveSecretContract — B1: every remaining shadow call site below
+// (checkWebhookIngestion's webhook-secret leg, checkCloudTokenEnv's cloud-token
+// name comparisons, checkSecretContract's own observations) plus the 3 sites
+// PR3 cut over to a LIVE answer (checkPeerUniqueness/checkBotCredentials/
+// checkWorkerLabels via resolveLinearTokenLive) routes its call into the
+// injected resolveSecretContract/resolveSecretFn dependency through here
+// instead of calling it directly. runDoctor's
 // `Promise.all(fns.map(...))` has no per-check isolation (out of scope to add
 // one here — see doctor.test.mjs's B1 tests), so an uncaught throw from ANY
 // check fn crashes the whole suite with zero report output. This wrapper
@@ -226,6 +230,32 @@ function buildContractShadowCheck({ checkName, secretId, handRolled, resolveSecr
       `contract={value:${contractPresent ? "present" : "absent"}, source:${contractResolved?.source ?? "none"}, ` +
       `provider:${contractResolved?.provider ?? "none"}} — never changes this check's grade or exit code`,
   );
+}
+
+// resolveLinearTokenLive — CTL-1616 PR3 cutover (design §7/§9): the shared
+// accessor checkPeerUniqueness/checkBotCredentials/checkWorkerLabels now use
+// to get the LIVE linear-api-token answer from the contract engine — these 3
+// sites no longer hand-roll their own `LINEAR_API_TOKEN ?? LINEAR_API_KEY`
+// env ladder (that read is GONE), and the PR2 shadow-comparison each of them
+// carried (buildContractShadowCheck against secretId "linear-api-token") is
+// retired with it: there is no longer a second, independently-computed
+// hand-rolled answer to compare the contract against, so the disagreement
+// row these sites used to emit cannot exist anymore. resolveSecret's own
+// contract promises "never throws", but this wraps via
+// safeResolveSecretContract anyway — matching this file's existing
+// defensive convention for every other secret-contract call site — so an
+// injected test double (or a future registry bug) that DOES throw degrades
+// to "no token" (the same WARN/INFO path a genuinely absent token already
+// takes) rather than crashing the whole doctor run. Threads the shared
+// resolveDeploymentModeForShadow() default so the cloud guard activates on a
+// declared-cloud node exactly like every other secret-contract call site in
+// this file (checkCloudTokenEnv, checkSecretContract).
+function resolveLinearTokenLive(resolveSecretContract, deploymentMode = resolveDeploymentModeForShadow()) {
+  const r = safeResolveSecretContract(resolveSecretContract, "linear-api-token", {
+    env: process.env,
+    deploymentMode,
+  });
+  return r.ok ? (r.value?.value ?? null) : null;
 }
 
 // ─── Internal path helpers ───────────────────────────────────────────────────
@@ -439,15 +469,12 @@ export async function checkPeerUniqueness(deps = {}) {
   const {
     getHostName: _getHostName = getHostName,
     getLivenessAnchorIssue: _getLivenessAnchorIssue = getLivenessAnchorIssue,
-    hasLinearToken = () =>
-      Boolean(
-        process.env.LINEAR_API_TOKEN?.length || process.env.LINEAR_API_KEY?.length,
-      ),
-    readPeerHeartbeats: _readPeerHeartbeats = readPeerHeartbeats,
-    // CTL-1616 PR2: shadow-only contract resolver for the "third value-read
-    // site" family (design §7) — consulted and COMPARED against hasLinearToken()
-    // below, never used to decide this check's grade.
+    // CTL-1616 PR3 cutover (design §9): resolveSecretContract is the LIVE
+    // answer now — see resolveLinearTokenLive's docstring for why the PR2
+    // shadow comparison this call site carried is retired, not merely muted.
     resolveSecretContract = resolveSecret,
+    hasLinearToken = () => resolveLinearTokenLive(resolveSecretContract) != null,
+    readPeerHeartbeats: _readPeerHeartbeats = readPeerHeartbeats,
   } = deps;
 
   const anchorIssue = _getLivenessAnchorIssue();
@@ -462,23 +489,13 @@ export async function checkPeerUniqueness(deps = {}) {
     ];
   }
 
-  const handRolledHasToken = hasLinearToken();
-  const shadowCheck = buildContractShadowCheck({
-    checkName: "peer-uniqueness",
-    secretId: "linear-api-token",
-    handRolled: handRolledHasToken,
-    resolveSecretContract,
-  });
-  const shadow = shadowCheck ? [shadowCheck] : [];
-
-  if (!handRolledHasToken) {
+  if (!hasLinearToken()) {
     return [
       mkCheck(
         "peer-uniqueness",
         STATUS.WARN,
         `no LINEAR_API_TOKEN / LINEAR_API_KEY — cannot read live peer heartbeats`,
       ),
-      ...shadow,
     ];
   }
 
@@ -493,7 +510,6 @@ export async function checkPeerUniqueness(deps = {}) {
         STATUS.WARN,
         `failed to read peer heartbeats: ${err?.message ?? err}`,
       ),
-      ...shadow,
     ];
   }
 
@@ -507,7 +523,6 @@ export async function checkPeerUniqueness(deps = {}) {
         STATUS.WARN,
         `peer heartbeats returned empty — cluster may be freshly initialized or anchor is stale`,
       ),
-      ...shadow,
     ];
   }
 
@@ -519,7 +534,6 @@ export async function checkPeerUniqueness(deps = {}) {
         `a live peer is already using host name "${self}" — two nodes with the same ` +
           `identity will cause HRW split-brain; set a unique catalyst.host.name`,
       ),
-      ...shadow,
     ];
   }
 
@@ -529,7 +543,6 @@ export async function checkPeerUniqueness(deps = {}) {
       STATUS.PASS,
       `no live peer is using host name "${self}" (${peerKeys.length} peer(s) seen)`,
     ),
-    ...shadow,
   ];
 }
 
@@ -542,28 +555,17 @@ const LINEAR_GQL = "https://api.linear.app/graphql";
 export async function checkBotCredentials(deps = {}) {
   const {
     readLinearBotUserIds: _readLinearBotUserIds = readLinearBotUserIds,
-    linearToken = () =>
-      process.env.LINEAR_API_TOKEN ?? process.env.LINEAR_API_KEY ?? "",
+    // CTL-1616 PR3 cutover (design §9): resolveSecretContract is the LIVE
+    // answer now — see resolveLinearTokenLive's docstring for why the PR2
+    // shadow comparison this call site carried is retired, not merely muted.
+    resolveSecretContract = resolveSecret,
+    linearToken = () => resolveLinearTokenLive(resolveSecretContract) ?? "",
     fetch: _fetch = globalThis.fetch,
     expectedBotUserId = null,
-    // CTL-1616 PR2: shadow-only contract resolver — consulted and COMPARED
-    // against linearToken() below, never used to decide this check's grade.
-    resolveSecretContract = resolveSecret,
   } = deps;
 
   const token = linearToken();
   const checks = [];
-
-  // CTL-1616 PR2 (A1): computed once here, but APPENDED after the primary
-  // rows at every return point below — matching the append-after convention
-  // every other shadow call site follows (a disagreement row must never
-  // become checks[0]).
-  const shadowCheck = buildContractShadowCheck({
-    checkName: "bot-credentials",
-    secretId: "linear-api-token",
-    handRolled: Boolean(token),
-    resolveSecretContract,
-  });
 
   // linear-connectivity
   if (!token) {
@@ -594,7 +596,6 @@ export async function checkBotCredentials(deps = {}) {
         mkCheck("bot-parity", STATUS.INFO, `no --expected-bot-user-id provided`),
       );
     }
-    if (shadowCheck) checks.push(shadowCheck);
     return checks;
   }
 
@@ -650,7 +651,6 @@ export async function checkBotCredentials(deps = {}) {
         `cannot verify bot parity — Linear unreachable`,
       ),
     );
-    if (shadowCheck) checks.push(shadowCheck);
     return checks;
   }
 
@@ -726,7 +726,6 @@ export async function checkBotCredentials(deps = {}) {
     );
   }
 
-  if (shadowCheck) checks.push(shadowCheck);
   return checks;
 }
 
@@ -3042,12 +3041,12 @@ async function defaultLinearGraphQLPost(query, token) {
 export async function checkWorkerLabels(deps = {}) {
   const {
     getRoster = getClusterHosts,
-    linearToken = () => process.env.LINEAR_API_TOKEN ?? process.env.LINEAR_API_KEY ?? "",
-    post = defaultLinearGraphQLPost,
-    // CTL-1616 PR2: shadow-only contract resolver for the "third value-read
-    // site" (design §7) — consulted and COMPARED against linearToken() below,
-    // never used to decide this check's grade.
+    // CTL-1616 PR3 cutover (design §9): resolveSecretContract is the LIVE
+    // answer now — see resolveLinearTokenLive's docstring for why the PR2
+    // shadow comparison this call site carried is retired, not merely muted.
     resolveSecretContract = resolveSecret,
+    linearToken = () => resolveLinearTokenLive(resolveSecretContract) ?? "",
+    post = defaultLinearGraphQLPost,
   } = deps;
 
   const REMEDIATION = "run plugins/dev/scripts/setup-execution-core-states.sh";
@@ -3059,18 +3058,10 @@ export async function checkWorkerLabels(deps = {}) {
   }
 
   const token = linearToken();
-  const shadowCheck = buildContractShadowCheck({
-    checkName: "worker-labels",
-    secretId: "linear-api-token",
-    handRolled: Boolean(token),
-    resolveSecretContract,
-  });
-  const shadow = shadowCheck ? [shadowCheck] : [];
 
   if (!token) {
     return [
       mkCheck("worker-labels", STATUS.INFO, "no LINEAR_API_TOKEN / LINEAR_API_KEY — skipping worker-label check"),
-      ...shadow,
     ];
   }
 
@@ -3081,14 +3072,14 @@ export async function checkWorkerLabels(deps = {}) {
   try {
     const json = await post(QUERY, token);
     if (json?.errors?.length) {
-      return [mkCheck("worker-labels", STATUS.WARN, `Linear GraphQL error: ${JSON.stringify(json.errors)}`), ...shadow];
+      return [mkCheck("worker-labels", STATUS.WARN, `Linear GraphQL error: ${JSON.stringify(json.errors)}`)];
     }
     nodes = json?.data?.issueLabels?.nodes;
     if (!Array.isArray(nodes)) {
-      return [mkCheck("worker-labels", STATUS.WARN, "unexpected issueLabels response shape from Linear"), ...shadow];
+      return [mkCheck("worker-labels", STATUS.WARN, "unexpected issueLabels response shape from Linear")];
     }
   } catch (err) {
-    return [mkCheck("worker-labels", STATUS.WARN, `Linear unreachable: ${err?.message ?? err}`), ...shadow];
+    return [mkCheck("worker-labels", STATUS.WARN, `Linear unreachable: ${err?.message ?? err}`)];
   }
 
   // #2631-safe match: the exclusive-group marker is parent==null + the group
@@ -3101,7 +3092,6 @@ export async function checkWorkerLabels(deps = {}) {
         STATUS.WARN,
         `workspace label group "${WORKER_LABEL_GROUP}" not found — ${REMEDIATION}`,
       ),
-      ...shadow,
     ];
   }
 
@@ -3115,7 +3105,7 @@ export async function checkWorkerLabels(deps = {}) {
         : mkCheck(`worker-label:${host}`, STATUS.WARN, `label "${childName}" missing — ${REMEDIATION}`),
     );
   }
-  return [...checks, ...shadow];
+  return checks;
 }
 
 // ─── CTL-1375: repo-icon token-scope advisory ────────────────────────────────
@@ -3604,33 +3594,36 @@ export async function checkDeploymentModeConsistency(deps = {}) {
   return checks;
 }
 
-// ─── CTL-1616 PR2: secret-contract shadow pass ───────────────────────────────
+// ─── CTL-1616 PR2/PR3: secret-contract observability ─────────────────────────
 //
-// checkSecretContract — SHADOW ONLY (design §7/§9). Resolves a handful of
-// SECRET_REGISTRY rows through the shared lib/secret-contract.mjs engine and
-// reports them as INFO-level OBSERVATIONS: presence for `linear-api-token` and
-// `groq-api-key` — NEW coverage design §7 asks for ("plus new Linear/Groq
-// presence checks"), since no existing doctor check resolves either through
-// the contract today (checkPeerUniqueness/checkBotCredentials/checkWorkerLabels
-// hand-roll their OWN linear-api-token read, shadow-compared at their own call
-// sites above; groq-api-key has no doctor check at all pre-CTL-1616).
+// checkSecretContract — INFO-ONLY OBSERVATION (design §7/§9), UNCHANGED by the
+// PR3 cutover below. Resolves a handful of SECRET_REGISTRY rows through the
+// shared lib/secret-contract.mjs engine and reports them as INFO-level
+// observations: presence for `linear-api-token` and `groq-api-key` — NEW
+// coverage design §7 asked for ("plus new Linear/Groq presence checks"), since
+// no existing doctor check resolved either through the contract pre-CTL-1616.
+//
+// PR3 (design §9) cuts checkPeerUniqueness/checkBotCredentials/checkWorkerLabels
+// over to the contract as their LIVE answer for linear-api-token — see
+// resolveLinearTokenLive above — which retires the PR2 shadow-comparison those
+// 3 call sites used to run against their own hand-rolled reads (there is no
+// hand-rolled answer left there to compare against). checkSecretContract
+// itself stays exactly what it was in PR2: an INFO-only observation, not a
+// graded check — grading `source` against the active deployment mode's
+// expected provider (PASS/WARN/FAIL) is explicitly NOT part of this cutover
+// and remains open work for a later PR. checkWebhookIngestion's
+// webhook-secret shadow and checkCloudTokenEnv's cloud-token shadow are also
+// UNCHANGED — those secrets cut over in their own later migration PRs (design
+// §8/§9 PR4-PR6), not this one.
 //
 // Every emitted check is STATUS.INFO — summarize() never counts INFO toward
 // pass/warn/fail (doctor.mjs:1728-1736 — see summarize()), so this check
 // cannot move doctor's exit code (the FAIL count) or its pass/warn/fail
-// summary line, satisfying the "zero grade change" discipline for the whole
-// shadow pass, not just the injected-dependency call sites above.
+// summary line.
 //
 // Fleet-topology-independent (does not consult resolveRoster) — wired into
 // checksForClass's shared prelude for EVERY class, exactly like
 // checkDeploymentModeConsistency (CTL-1617) just above it.
-//
-// PR3 (design §9) flips this from advisory OBSERVATION to a GRADED check:
-// PASS when `source` matches the active deployment mode's expected provider,
-// WARN on unexpected-provider resolution, FAIL when the active mode's
-// `bootstrapFor` row fails to resolve. None of that grading exists yet here —
-// this PR only proves the contract can be consulted safely, side by side with
-// every hand-rolled reader, without changing a single grade.
 export function checkSecretContract(deps = {}) {
   const { env = process.env, deploymentMode = resolveDeploymentModeForShadow(env), resolveSecretFn = resolveSecret } = deps;
   const checks = [];

--- a/plugins/dev/scripts/execution-core/doctor.test.mjs
+++ b/plugins/dev/scripts/execution-core/doctor.test.mjs
@@ -212,12 +212,15 @@ describe("checkHrwPartition", () => {
 
 // ─── Phase 3: checkPeerUniqueness ────────────────────────────────────────────
 
-// CTL-1616 PR2: resolveSecretContract is a shadow-only dependency (design §7).
-// These fixtures pin it to AGREE with whatever `hasLinearToken` the test sets,
-// so the pre-existing (pre-shadow) behavioral assertions below stay exact —
-// the real registry resolver would make agreement depend on whatever
+// CTL-1616 PR3: resolveSecretContract is the LIVE answer now (hasLinearToken's
+// default routes through it — see resolveLinearTokenLive in doctor.mjs). Every
+// test below still injects an explicit `hasLinearToken` too, which simply
+// overrides that default outright, so `resolveSecretContract` below is inert
+// where both are present — kept only so these fixtures read the same whether
+// or not a future edit drops the `hasLinearToken` override. Full DI throughout
+// means none of these behavioral assertions depend on whatever
 // LINEAR_API_TOKEN/LINEAR_API_KEY happen to be set in the runner's ambient
-// environment, which these tests were written (via full DI) to never depend on.
+// environment.
 const agreeingSecretContract = (present) => () =>
   present
     ? { value: "contract-token", source: "inherited", provider: "env-alias" }
@@ -363,9 +366,10 @@ const fakeFetch = (body, ok = true) => async (url, opts) => ({
   json: async () => body,
 });
 
-// CTL-1616 PR2 (A2): resolveSecretContract is a shadow-only dependency
-// (design §7). Every test below injects a fixture that AGREES with whatever
-// `linearToken` it sets, so these pre-existing (pre-shadow) assertions never
+// CTL-1616 PR3: resolveSecretContract is the LIVE answer now (linearToken's
+// default routes through it — see resolveLinearTokenLive in doctor.mjs).
+// Every test below still injects an explicit `linearToken` too, which simply
+// overrides that default outright, so these pre-existing assertions never
 // depend on the real registry resolver — which would read the runner's
 // actual LINEAR_API_TOKEN/LINEAR_API_KEY/~/.config/catalyst and make this
 // describe's behavior environment-dependent.
@@ -2240,12 +2244,15 @@ describe("secret-contract shadow — deployment-mode threading (#2916 Codex P2)"
     }
   });
 
-  it("shadowed comparison checks (buildContractShadowCheck path) also receive a deploymentMode", async () => {
+  it("CTL-1616 PR3 cutover: checkPeerUniqueness's LIVE resolveSecretContract call also receives a deploymentMode", async () => {
+    // No hasLinearToken override here (unlike the rest of this file's fixtures)
+    // — it must be absent so the default (which calls resolveSecretContract
+    // via resolveLinearTokenLive) actually runs and this assertion exercises
+    // something real.
     const seen = [];
     await checkPeerUniqueness({
       getHostName: () => "mini",
       getLivenessAnchorIssue: () => "CTL-1",
-      hasLinearToken: () => false,
       readPeerHeartbeats: async () => ({}),
       resolveSecretContract: (id, opts) => {
         seen.push(opts?.deploymentMode);
@@ -2373,13 +2380,17 @@ describe("checksForClass — checkSecretContract registration (CTL-1616 PR2)", (
   });
 });
 
-// ─── CTL-1616 PR2: secret-contract shadow — zero grade change ──────────────
+// ─── CTL-1616 PR2/PR3: secret-contract shadow — zero grade change ──────────
 //
-// The shadow discipline (design §7/§9): the contract is CONSULTED AND COMPARED
-// at 5 hand-rolled call sites (checkPeerUniqueness, checkBotCredentials,
-// checkWorkerLabels, checkWebhookIngestion, checkCloudTokenEnv) but decides
+// The shadow discipline (design §7/§9) still covers the 2 call sites PR3 left
+// alone — checkWebhookIngestion (webhook-secret) and checkCloudTokenEnv
+// (cloud-token) — where the contract is CONSULTED AND COMPARED but decides
 // NOTHING — every disagreement surfaces as an extra INFO row; every agreement
-// surfaces nothing extra. These tests prove both halves plus the invariant
+// surfaces nothing extra. checkPeerUniqueness/checkBotCredentials/
+// checkWorkerLabels were cut over to the contract as their LIVE answer in
+// PR3 (see the "secret-contract cutover" describe above and
+// doctor-worker-labels.test.mjs) — they no longer have an "agree/disagree"
+// axis at all. These tests prove both remaining-shadow halves plus the invariant
 // that grades/exit-code are IDENTICAL either way.
 describe("checkWebhookIngestion — deployment-mode alignment (CTL-1617, #2913 Codex P1)", () => {
   // Hermeticity: the linear/github env legs read process.env directly — an
@@ -2473,7 +2484,13 @@ describe("checkWebhookIngestion — deployment-mode alignment (CTL-1617, #2913 C
   });
 });
 
-describe("secret-contract shadow — zero grade change (CTL-1616 PR2)", () => {
+describe("secret-contract cutover — checkPeerUniqueness/checkBotCredentials (CTL-1616 PR3)", () => {
+  // PR3 (design §9) flips these two call sites from PR2's shadow-comparison to
+  // the contract as their LIVE answer — hasLinearToken/linearToken now DEFAULT
+  // to resolveSecretContract's own resolution, and the PR2 shadow-disagreement
+  // row these sites used to emit is retired (there is no second, independently
+  // hand-rolled answer left to disagree with). These tests replace the CTL-1616
+  // PR2 "shadow — zero grade change" describe for these two functions.
   describe("checkPeerUniqueness", () => {
     const base = {
       getHostName: () => "mini",
@@ -2481,59 +2498,97 @@ describe("secret-contract shadow — zero grade change (CTL-1616 PR2)", () => {
       readPeerHeartbeats: async () => ({}),
     };
 
-    it("agree (both absent) → no shadow row, primary grade unchanged", async () => {
+    it("resolveSecretContract resolving absent → hasLinearToken() false, no-token WARN, never a shadow row", async () => {
       const checks = await checkPeerUniqueness({
         ...base,
-        hasLinearToken: () => false,
         resolveSecretContract: () => ({ value: null, source: "none", provider: "env-alias" }),
       });
       expect(checks).toHaveLength(1);
+      expect(checks[0].name).toBe("peer-uniqueness");
+      expect(checks[0].status).toBe(STATUS.WARN);
+      expect(checks[0].detail).toContain("no LINEAR_API_TOKEN");
       expect(checks.some((c) => c.name.includes("secret-contract-shadow"))).toBe(false);
     });
 
-    it("disagree (hand-rolled says present, contract says absent) → loud INFO row, primary grade unchanged", async () => {
+    it("resolveSecretContract resolving present → hasLinearToken() true, proceeds past the token gate", async () => {
       const checks = await checkPeerUniqueness({
         ...base,
-        hasLinearToken: () => true,
-        resolveSecretContract: () => ({ value: null, source: "none", provider: "env-alias" }),
+        resolveSecretContract: () => ({ value: "contract-token", source: "inherited", provider: "env-alias" }),
       });
-      // Primary "peer-uniqueness" row is untouched (still WARN — empty heartbeats).
-      const primary = checks.find((c) => c.name === "peer-uniqueness");
-      expect(primary.status).toBe(STATUS.WARN);
-      const shadow = checks.find((c) => c.name === "peer-uniqueness-secret-contract-shadow");
-      expect(shadow).toBeDefined();
-      expect(shadow.status).toBe(STATUS.INFO);
-      expect(shadow.detail).toContain('secret="linear-api-token"');
-      expect(shadow.detail).toContain("hand-rolled=present");
-      expect(shadow.detail).toContain("contract={value:absent");
+      expect(checks).toHaveLength(1);
+      expect(checks[0].name).toBe("peer-uniqueness");
+      expect(checks[0].status).toBe(STATUS.WARN); // the EMPTY-heartbeats WARN, not the no-token WARN
+      expect(checks[0].detail).toContain("empty");
+      expect(checks.some((c) => c.name.includes("secret-contract-shadow"))).toBe(false);
+    });
+
+    // CTL-1616 PR3 success criterion (design §9): a LINEAR_API_KEY-only
+    // environment (no LINEAR_API_TOKEN) must resolve identically through the
+    // live cutover. Exercises the REAL resolveSecret default end-to-end — no
+    // hasLinearToken/resolveSecretContract override at all.
+    it("LINEAR_API_KEY-only fixture (real resolveSecret default): honors the alias, proceeds past the token gate", async () => {
+      const savedToken = process.env.LINEAR_API_TOKEN;
+      const savedKey = process.env.LINEAR_API_KEY;
+      try {
+        delete process.env.LINEAR_API_TOKEN;
+        process.env.LINEAR_API_KEY = "lin_api_fromkey";
+        const checks = await checkPeerUniqueness(base);
+        expect(checks).toHaveLength(1);
+        expect(checks[0].detail).toContain("empty"); // past the token gate
+      } finally {
+        if (savedToken === undefined) delete process.env.LINEAR_API_TOKEN;
+        else process.env.LINEAR_API_TOKEN = savedToken;
+        if (savedKey === undefined) delete process.env.LINEAR_API_KEY;
+        else process.env.LINEAR_API_KEY = savedKey;
+      }
     });
   });
 
   describe("checkBotCredentials", () => {
-    it("agree (both present) → no shadow row", async () => {
+    it("resolveSecretContract resolving present → linearToken() returns it, proceeds to the connectivity probe", async () => {
       const checks = await checkBotCredentials({
         readLinearBotUserIds: () => new Set(["bot-user-123"]),
-        linearToken: () => "lin_api_abc",
         fetch: fakeFetch({ data: { viewer: { id: "bot-user-123", name: "Bot", email: "bot@example.com" } } }),
-        resolveSecretContract: () => ({ value: "lin_api_abc", source: "inherited", provider: "env-alias" }),
+        resolveSecretContract: () => ({ value: "contract-token", source: "inherited", provider: "env-alias" }),
       });
+      const connectivity = checks.find((c) => c.name === "linear-connectivity");
+      expect(connectivity.status).toBe(STATUS.PASS);
       expect(checks.some((c) => c.name.includes("secret-contract-shadow"))).toBe(false);
     });
 
-    it("disagree (hand-rolled absent, contract present) → loud INFO row, grade unchanged", async () => {
+    it("resolveSecretContract resolving absent → linearToken() empty, the no-token WARN path, never a shadow row", async () => {
       const checks = await checkBotCredentials({
         readLinearBotUserIds: () => new Set(["bot-user-123"]),
-        linearToken: () => "",
         fetch: fakeFetch({}),
-        resolveSecretContract: () => ({ value: "some-token", source: "inherited", provider: "env-alias" }),
+        resolveSecretContract: () => ({ value: null, source: "none", provider: "env-alias" }),
       });
       const connectivity = checks.find((c) => c.name === "linear-connectivity");
-      expect(connectivity.status).toBe(STATUS.WARN); // unchanged from the no-shadow behavior
-      const shadow = checks.find((c) => c.name === "bot-credentials-secret-contract-shadow");
-      expect(shadow).toBeDefined();
-      expect(shadow.status).toBe(STATUS.INFO);
-      expect(shadow.detail).toContain("hand-rolled=absent");
-      expect(shadow.detail).toContain("contract={value:present");
+      expect(connectivity.status).toBe(STATUS.WARN);
+      expect(connectivity.detail).toContain("no LINEAR_API_TOKEN");
+      expect(checks.some((c) => c.name.includes("secret-contract-shadow"))).toBe(false);
+    });
+
+    // CTL-1616 PR3 success criterion (design §9): a LINEAR_API_KEY-only
+    // environment resolves identically through the live cutover — real
+    // resolveSecret default, no override at all.
+    it("LINEAR_API_KEY-only fixture (real resolveSecret default): honors the alias, reaches the connectivity probe", async () => {
+      const savedToken = process.env.LINEAR_API_TOKEN;
+      const savedKey = process.env.LINEAR_API_KEY;
+      try {
+        delete process.env.LINEAR_API_TOKEN;
+        process.env.LINEAR_API_KEY = "lin_api_fromkey";
+        const checks = await checkBotCredentials({
+          readLinearBotUserIds: () => new Set(["bot-user-123"]),
+          fetch: fakeFetch({ data: { viewer: { id: "bot-user-123", name: "Bot", email: "bot@example.com" } } }),
+        });
+        const connectivity = checks.find((c) => c.name === "linear-connectivity");
+        expect(connectivity.status).toBe(STATUS.PASS);
+      } finally {
+        if (savedToken === undefined) delete process.env.LINEAR_API_TOKEN;
+        else process.env.LINEAR_API_TOKEN = savedToken;
+        if (savedKey === undefined) delete process.env.LINEAR_API_KEY;
+        else process.env.LINEAR_API_KEY = savedKey;
+      }
     });
   });
 
@@ -2722,20 +2777,10 @@ describe("secret-contract shadow — zero grade change (CTL-1616 PR2)", () => {
   describe("grades and exit code are IDENTICAL with the shadow present, agree or disagree", () => {
     // summarize() only counts PASS/WARN/FAIL — INFO rows (agree = none, disagree =
     // one extra) never move pass/warn/fail counts or `ok` (design §7/§9's own
-    // exit-code invariant, doctor.mjs:1728-1736).
-    it("checkPeerUniqueness: summarize() is identical across an agree and a disagree fixture", async () => {
-      const base = {
-        getHostName: () => "mini",
-        getLivenessAnchorIssue: () => "CTL-9999",
-        hasLinearToken: () => true,
-        readPeerHeartbeats: async () => ({}),
-      };
-      const agree = await checkPeerUniqueness({ ...base, resolveSecretContract: () => ({ value: "x", source: "inherited", provider: "env-alias" }) });
-      const disagree = await checkPeerUniqueness({ ...base, resolveSecretContract: () => ({ value: null, source: "none", provider: "env-alias" }) });
-      expect(disagree.length).toBe(agree.length + 1); // exactly one extra INFO row
-      expect(summarize(agree)).toEqual(summarize(disagree));
-      expect(summarize(agree).fail).toBe(0);
-    });
+    // exit-code invariant, doctor.mjs:1728-1736). checkPeerUniqueness no longer
+    // has an "agree vs disagree" axis post-PR3-cutover (there is only ONE
+    // answer now — the contract's own) — see the "secret-contract cutover"
+    // describe above for its replacement coverage.
 
     it("checkWebhookIngestion: summarize() is identical across an agree and a disagree fixture", () => {
       const multiHost = () => ({ hosts: ["mini", "mini-2"], source: "cluster-repo", multiHost: true });
@@ -2768,47 +2813,38 @@ const THROWING_RESOLVER = () => {
   throw new Error("boom: registry lookup exploded");
 };
 
-describe("secret-contract shadow — resolver throw-safety (CTL-1616 PR2 B1)", () => {
-  it("checkPeerUniqueness: a throwing resolver still returns the normal graded row plus a throw-row", async () => {
+describe("secret-contract shadow — resolver throw-safety (CTL-1616 PR2/PR3)", () => {
+  // CTL-1616 PR3 cutover: checkPeerUniqueness/checkBotCredentials no longer
+  // run a shadow comparison — resolveLinearTokenLive (doctor.mjs) wraps the
+  // injected resolveSecretContract in the same safeResolveSecretContract B1
+  // discipline, but a throw now degrades directly to "no token" (the ordinary
+  // WARN path), never an extra INFO row (there is no shadow row left to emit).
+  it("checkPeerUniqueness: a throwing resolveSecretContract degrades to the no-token WARN, never crashes, no shadow row", async () => {
     const checks = await checkPeerUniqueness({
       getHostName: () => "mini",
       getLivenessAnchorIssue: () => "CTL-9999",
-      hasLinearToken: () => true,
       readPeerHeartbeats: async () => ({}),
       resolveSecretContract: THROWING_RESOLVER,
     });
-    const primary = checks.find((c) => c.name === "peer-uniqueness");
-    expect(primary).toBeDefined();
-    expect(primary.status).toBe(STATUS.WARN); // unchanged (empty heartbeats) — throw did not touch grade
-    const throwRow = checks.find((c) => c.name === "peer-uniqueness-secret-contract-shadow");
-    expect(throwRow).toBeDefined();
-    expect(throwRow.status).toBe(STATUS.INFO);
-    expect(throwRow.detail).toContain("SHADOW RESOLVER THREW");
-    expect(throwRow.detail).toContain('secret="linear-api-token"');
-    expect(throwRow.detail).toContain("boom: registry lookup exploded");
-    expect(throwRow.detail).toContain("grade unaffected");
+    expect(checks).toHaveLength(1);
+    expect(checks[0].name).toBe("peer-uniqueness");
+    expect(checks[0].status).toBe(STATUS.WARN);
+    expect(checks[0].detail).toContain("no LINEAR_API_TOKEN");
+    expect(checks.some((c) => c.name.includes("secret-contract-shadow"))).toBe(false);
     expect(summarize(checks).fail).toBe(0);
   });
 
-  it("checkBotCredentials: a throwing resolver still returns the normal graded rows, throw-row APPENDED (not checks[0] — A1)", async () => {
+  it("checkBotCredentials: a throwing resolveSecretContract degrades to the no-token WARN path, never crashes, no shadow row", async () => {
     const checks = await checkBotCredentials({
       readLinearBotUserIds: () => new Set(["bot-user-123"]),
-      linearToken: () => "lin_api_abc",
       fetch: fakeFetch({ data: { viewer: { id: "bot-user-123", name: "Bot", email: "bot@example.com" } } }),
       expectedBotUserId: null,
       resolveSecretContract: THROWING_RESOLVER,
     });
-    // A1: the shadow/throw row is never checks[0] — the primary connectivity
-    // row leads, exactly as it does with no shadow dependency at all.
-    expect(checks[0].name).toBe("linear-connectivity");
-    expect(checks[0].status).toBe(STATUS.PASS);
-    const identity = checks.find((c) => c.name === "bot-identity");
-    expect(identity.status).toBe(STATUS.PASS);
-    const throwRow = checks.find((c) => c.name === "bot-credentials-secret-contract-shadow");
-    expect(throwRow).toBeDefined();
-    expect(throwRow.status).toBe(STATUS.INFO);
-    expect(throwRow.detail).toContain("SHADOW RESOLVER THREW");
-    expect(checks[checks.length - 1]).toBe(throwRow); // appended last
+    const connectivity = checks.find((c) => c.name === "linear-connectivity");
+    expect(connectivity.status).toBe(STATUS.WARN);
+    expect(connectivity.detail).toContain("no LINEAR_API_TOKEN");
+    expect(checks.some((c) => c.name.includes("secret-contract-shadow"))).toBe(false);
     expect(summarize(checks).fail).toBe(0);
   });
 
@@ -2877,16 +2913,19 @@ describe("secret-contract shadow — resolver throw-safety (CTL-1616 PR2 B1)", (
     expect(summarize(checks)).toEqual({ pass: 0, warn: 0, fail: 0, ok: true });
   });
 
-  it("runDoctor: a throwing shadow resolver does not crash the run — exit code and check count match the non-throwing control", async () => {
+  // CTL-1616 PR3 cutover: checkPeerUniqueness's resolveSecretContract is now
+  // the LIVE answer, not a shadow — a throwing resolver degrades to "no
+  // token" (the ordinary WARN doctor already has for a genuinely absent
+  // token), not an extra INFO row. runDoctor must still never crash.
+  it("runDoctor: a throwing resolveSecretContract does not crash the run — degrades to the same WARN shape as a genuinely absent token", async () => {
     const controlChecks = [
       () => [mkCheck("always-pass", STATUS.PASS, "ok")],
       async () =>
         checkPeerUniqueness({
           getHostName: () => "mini",
           getLivenessAnchorIssue: () => "CTL-9999",
-          hasLinearToken: () => true,
           readPeerHeartbeats: async () => ({}),
-          resolveSecretContract: () => ({ value: "x", source: "inherited", provider: "env-alias" }),
+          resolveSecretContract: () => ({ value: null, source: "none", provider: "env-alias" }),
         }),
     ];
     const throwingChecks = [
@@ -2895,7 +2934,6 @@ describe("secret-contract shadow — resolver throw-safety (CTL-1616 PR2 B1)", (
         checkPeerUniqueness({
           getHostName: () => "mini",
           getLivenessAnchorIssue: () => "CTL-9999",
-          hasLinearToken: () => true,
           readPeerHeartbeats: async () => ({}),
           resolveSecretContract: THROWING_RESOLVER,
         }),
@@ -2908,8 +2946,11 @@ describe("secret-contract shadow — resolver throw-safety (CTL-1616 PR2 B1)", (
     expect(logs.throwing).not.toBeNull(); // doctor produced report output — did not crash
     const throwingReport = JSON.parse(logs.throwing);
     const controlReport = JSON.parse(logs.control);
-    expect(throwingReport.checks.length).toBe(controlReport.checks.length + 1); // one extra INFO throw-row
-    expect(throwingReport.checks.some((c) => c.name === "peer-uniqueness-secret-contract-shadow")).toBe(true);
+    expect(throwingReport.checks.length).toBe(controlReport.checks.length); // no extra row — no shadow left to emit
+    expect(throwingReport.checks.some((c) => c.name.includes("secret-contract-shadow"))).toBe(false);
+    const peerRow = throwingReport.checks.find((c) => c.name === "peer-uniqueness");
+    expect(peerRow.status).toBe("warn");
+    expect(peerRow.detail).toContain("no LINEAR_API_TOKEN");
   });
 });
 

--- a/plugins/dev/scripts/execution-core/linear-estimation-method.mjs
+++ b/plugins/dev/scripts/execution-core/linear-estimation-method.mjs
@@ -22,6 +22,9 @@
 import { existsSync, mkdirSync, readFileSync, renameSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { spawnSync } from "node:child_process";
+// CTL-1616 PR3: fold this file's inline LINEAR_API_TOKEN/LINEAR_API_KEY ladder
+// onto the shared secret-contract engine (design §8 PR3 table).
+import { resolveSecret } from "../lib/secret-contract.mjs";
 
 const LINEAR_GRAPHQL_ENDPOINT = "https://api.linear.app/graphql";
 const DEFAULT_TTL_MS = 7 * 24 * 60 * 60 * 1000; // 7 days
@@ -76,7 +79,7 @@ function writeCacheFile(teamId, method) {
 // ── Linear API fetch ─────────────────────────────────────────────────────────
 // Identical curl pattern to runBatchOnce in linear-query.mjs.
 function fetchFromLinear(teamId) {
-  const token = process.env.LINEAR_API_TOKEN ?? process.env.LINEAR_API_KEY ?? "";
+  const token = resolveSecret("linear-api-token").value ?? ""; // CTL-1616 PR3
   // authHeader — mirrors linear-query.mjs:authHeader.
   const auth = /^lin_oauth/i.test(token) ? `Bearer ${token}` : token;
   const payload = JSON.stringify({

--- a/plugins/dev/scripts/execution-core/linear-query.mjs
+++ b/plugins/dev/scripts/execution-core/linear-query.mjs
@@ -11,6 +11,9 @@ import { withBreaker, linearBreaker, isRateLimitError } from "./linear-breaker.m
 import { withAuthRemint, linearReminter, isBatchAuthError } from "./linear-remint.mjs";
 import { emitEligibleSourceUnavailable, emitTicketStateLiveFallback } from "./dispatch-alert.mjs";
 import { emitLinearReadEvent } from "./linear-read-event.mjs";
+// CTL-1616 PR3: fold this file's 3 inline LINEAR_API_TOKEN/LINEAR_API_KEY
+// ladders onto the shared secret-contract engine (design §8 PR3 table).
+import { resolveSecret } from "../lib/secret-contract.mjs";
 
 // linearis caps a single page; 200 comfortably covers a project's pickable
 // set without pagination (the reconcile poll runs every 10 min anyway).
@@ -578,7 +581,7 @@ export function buildBatchCurlArgs(ids, { token = "", ca } = {}) {
 // Returns { nodes, auth, ratelimit, curlFailed }. Never throws. Internal to
 // defaultBatchExec; extracted so the auth-retry path can call it a second time.
 function runBatchOnce(ids) {
-  const token = process.env.LINEAR_API_TOKEN ?? process.env.LINEAR_API_KEY ?? "";
+  const token = resolveSecret("linear-api-token").value ?? ""; // CTL-1616 PR3
   const { args, payload } = buildBatchCurlArgs(ids, { token, ca: process.env.NODE_EXTRA_CA_CERTS });
   const res = spawnSync("curl", args, { input: payload, encoding: "utf8", maxBuffer: 64 * 1024 * 1024 });
   if (res.status !== 0) {
@@ -975,7 +978,7 @@ export function buildDelegateCurlArgs(identifier, { token = "", ca } = {}) {
 }
 
 function runDelegateOnce(identifier) {
-  const token = process.env.LINEAR_API_TOKEN ?? process.env.LINEAR_API_KEY ?? "";
+  const token = resolveSecret("linear-api-token").value ?? ""; // CTL-1616 PR3
   const { args, payload } = buildDelegateCurlArgs(identifier, { token, ca: process.env.NODE_EXTRA_CA_CERTS });
   const res = spawnSync("curl", args, { input: payload, encoding: "utf8" });
   if (res.status !== 0) return { nodes: null };
@@ -1040,7 +1043,7 @@ export function buildDelegateBatchCurlArgs(team, identifiers, { token = "", ca }
 }
 
 function runDelegateBatchOnce(team, identifiers) {
-  const token = process.env.LINEAR_API_TOKEN ?? process.env.LINEAR_API_KEY ?? "";
+  const token = resolveSecret("linear-api-token").value ?? ""; // CTL-1616 PR3
   const { args, payload } = buildDelegateBatchCurlArgs(team, identifiers, {
     token,
     ca: process.env.NODE_EXTRA_CA_CERTS,

--- a/plugins/dev/scripts/execution-core/linear-reconcile-cli.mjs
+++ b/plugins/dev/scripts/execution-core/linear-reconcile-cli.mjs
@@ -36,6 +36,17 @@ import {
   appendRecoveryDoneOpenPrEvent,
   appendRecoveryDoneAppliedEvent,
 } from "./recovery-done-open-pr-event.mjs";
+// CTL-1616 PR3: the shared secret-contract engine, imported DIRECTLY from the
+// zero-import lib leaf (node:fs/os/path only) — same import shape as
+// cluster-sync.mjs/doctor.mjs (`../lib/secret-contract.mjs`). Folds this
+// file's own hand-rolled LINEAR_API_TOKEN/LINEAR_API_KEY ladder (below) onto
+// the shared registry so the alias fallback lives at the primitive instead of
+// per-call-site — closing CTL-1619 (the alias-drop regression this exact file
+// once carried) PERMANENTLY, and normalizing the one outlier implementation
+// (this file's own trimmed-blank hardening, design §1's "drops the alias"
+// divergence row) onto the SAME resolution every other of the 12 sites now
+// shares.
+import { resolveSecret } from "../lib/secret-contract.mjs";
 export { defaultCheckOpenPrs, defaultDeriveBranchName };
 
 const TICKET_RE = /^[A-Za-z][A-Za-z0-9_]*-\d+$/;
@@ -206,12 +217,19 @@ export async function buildReadState(args) {
     return async (t) => map[t] ?? null;
   }
   if (args.graphql) {
-    // Nonblank fallback (NOT `??`): a launch env that exports an empty or
-    // whitespace-only LINEAR_API_TOKEN would defeat `??` (a non-nullish "" /
-    // "  " is selected), stranding the LINEAR_API_KEY fallback and sending a
-    // blank Authorization header. Trim each source and treat blank as absent.
-    const token =
-      (process.env.LINEAR_API_TOKEN || "").trim() || (process.env.LINEAR_API_KEY || "").trim();
+    // CTL-1616 PR3: folded onto the shared secret-contract engine instead of
+    // this file's own hand-rolled LINEAR_API_TOKEN/LINEAR_API_KEY ladder —
+    // closes CTL-1619 (the alias-drop regression) at the primitive,
+    // permanently. NOTE (documented behavior normalizations, not bugs): the
+    // engine's env-alias resolver treats presence as "non-empty string" only
+    // (no trim). That differs from BOTH prior shapes: the other former-`??`
+    // sites treated an EMPTY-STRING LINEAR_API_TOKEN as set (producing a
+    // blank Authorization header — a guaranteed 401), where the engine now
+    // falls through to LINEAR_API_KEY; and this file additionally treated a
+    // WHITESPACE-ONLY token as blank (its own outlier). Both are normalized
+    // to the engine's one rule so all 12 sites resolve identically
+    // (design §8 PR3 table; both changes flagged in the PR body).
+    const token = resolveSecret("linear-api-token").value ?? "";
     return async (t) => graphqlReadState(t, token);
   }
   // cache (filter-state.db). broker-state.mjs imports bun:sqlite → under plain

--- a/plugins/dev/scripts/execution-core/linear-reconcile-cli.test.mjs
+++ b/plugins/dev/scripts/execution-core/linear-reconcile-cli.test.mjs
@@ -827,20 +827,18 @@ test("--graphql: buildReadState uses LINEAR_API_KEY when LINEAR_API_TOKEN is abs
   }
 });
 
-test.each([
-  ["empty", ""],
-  ["whitespace-only", "   "],
-])(
-  "--graphql: buildReadState falls back to LINEAR_API_KEY when LINEAR_API_TOKEN is %s",
-  async (_label, blankToken) => {
-  // CTL-1619 / Codex: a blank (empty OR whitespace-only) LINEAR_API_TOKEN must
-  // not defeat the LINEAR_API_KEY fallback (the `??`→trimmed-`||` fix).
+test("--graphql: buildReadState falls back to LINEAR_API_KEY when LINEAR_API_TOKEN is empty", async () => {
+  // CTL-1619 / Codex: an EMPTY LINEAR_API_TOKEN must not defeat the
+  // LINEAR_API_KEY fallback — the shared secret-contract engine's env-alias
+  // resolver (resolveEnvAliasOnly, lib/secret-contract.mjs) already treats a
+  // zero-length string as absent and falls through to the next alias, so
+  // this behavior survives the CTL-1616 PR3 fold onto resolveSecret.
   const savedToken = process.env.LINEAR_API_TOKEN;
   const savedKey = process.env.LINEAR_API_KEY;
   const savedFetch = globalThis.fetch;
   let seenAuth = null;
   try {
-    process.env.LINEAR_API_TOKEN = blankToken;
+    process.env.LINEAR_API_TOKEN = "";
     process.env.LINEAR_API_KEY = "lin_api_fromkey";
     globalThis.fetch = async (_url, opts) => {
       seenAuth = opts.headers.Authorization;
@@ -853,6 +851,49 @@ test.each([
     const state = await readState("CTL-1");
     expect(state).toBe("Done");
     expect(seenAuth).toBe("lin_api_fromkey");
+  } finally {
+    if (savedToken === undefined) delete process.env.LINEAR_API_TOKEN;
+    else process.env.LINEAR_API_TOKEN = savedToken;
+    if (savedKey === undefined) delete process.env.LINEAR_API_KEY;
+    else process.env.LINEAR_API_KEY = savedKey;
+    globalThis.fetch = savedFetch;
+  }
+});
+
+// CTL-1616 PR3 (documented behavior normalization, not a regression): this
+// file previously trimmed LINEAR_API_TOKEN before the presence check, so a
+// WHITESPACE-ONLY value was treated as blank and fell through to
+// LINEAR_API_KEY — an extra hardening unique to this file (design §1's
+// "linear-reconcile-cli.mjs:209 drops the alias" divergence row was about the
+// MISSING-alias case, but this file's fix went further than the other 11
+// LINEAR_API_TOKEN/LINEAR_API_KEY call sites, which used plain `??` ladders
+// that never trim). Folding onto the shared secret-contract engine
+// (resolveEnvAliasOnly: presence = non-empty string, no trim) puts all 12
+// sites on ONE rule (design §9 PR3 success criterion). Note the engine rule
+// is NOT identical to the old `??` ladders either: they treated an
+// EMPTY-STRING token as set (blank auth header), where the engine falls
+// through to LINEAR_API_KEY — that second normalization is flagged in the
+// PR body. Under the unified rule a whitespace-only LINEAR_API_TOKEN is
+// "set" and wins over LINEAR_API_KEY.
+test("--graphql: buildReadState treats a whitespace-only LINEAR_API_TOKEN as SET (unified with the other 11 sites)", async () => {
+  const savedToken = process.env.LINEAR_API_TOKEN;
+  const savedKey = process.env.LINEAR_API_KEY;
+  const savedFetch = globalThis.fetch;
+  let seenAuth = null;
+  try {
+    process.env.LINEAR_API_TOKEN = "   ";
+    process.env.LINEAR_API_KEY = "lin_api_fromkey";
+    globalThis.fetch = async (_url, opts) => {
+      seenAuth = opts.headers.Authorization;
+      return {
+        ok: true,
+        json: async () => ({ data: { issues: { nodes: [{ state: { name: "Done" } }] } } }),
+      };
+    };
+    const readState = await buildReadState({ graphql: true });
+    const state = await readState("CTL-1");
+    expect(state).toBe("Done");
+    expect(seenAuth).toBe("   ");
   } finally {
     if (savedToken === undefined) delete process.env.LINEAR_API_TOKEN;
     else process.env.LINEAR_API_TOKEN = savedToken;

--- a/plugins/dev/scripts/orch-monitor/__tests__/estimate-fallback.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/estimate-fallback.test.ts
@@ -332,3 +332,43 @@ describe("CTL-974: estimateDisplay correct per estimation method", () => {
     expect(deriveEstimateDisplay(null, "tShirt")).toBeNull();
   });
 });
+
+// CTL-1616 PR3: linearAuthHeader's token resolution folds onto the shared
+// secret-contract engine (resolveSecret) — this is the synthetic
+// LINEAR_API_KEY-only fixture the design mandates, proven end-to-end through
+// fillEstimateFallback by asserting the Authorization header actually sent.
+describe("CTL-1616 PR3: secret-contract fold — LINEAR_API_KEY-only fixture", () => {
+  beforeEach(() => {
+    _clearEstimateCache();
+    _clearMethodCache();
+  });
+
+  it("fillEstimateFallback sends LINEAR_API_KEY as the Authorization header when LINEAR_API_TOKEN is absent", async () => {
+    const savedToken = process.env.LINEAR_API_TOKEN;
+    const savedKey = process.env.LINEAR_API_KEY;
+    const originalFetch = globalThis.fetch;
+    let seenAuth: string | null = null;
+    globalThis.fetch = ((_url: unknown, init?: RequestInit) => {
+      const headers = (init?.headers ?? {}) as Record<string, string>;
+      seenAuth = headers.Authorization ?? null;
+      return Promise.resolve({
+        ok: true,
+        json: () =>
+          Promise.resolve({ data: { issues: { nodes: [{ number: 774, estimate: 8, team: { key: "CTL" } }] } } }),
+      } as Response);
+    }) as typeof fetch;
+    try {
+      delete process.env.LINEAR_API_TOKEN;
+      process.env.LINEAR_API_KEY = "lin_api_fromkey";
+      const result = await fillEstimateFallback(["CTL-774"]);
+      expect(result["CTL-774"]).toBe(8);
+      expect(seenAuth).toBe("lin_api_fromkey");
+    } finally {
+      globalThis.fetch = originalFetch;
+      if (savedToken === undefined) delete process.env.LINEAR_API_TOKEN;
+      else process.env.LINEAR_API_TOKEN = savedToken;
+      if (savedKey === undefined) delete process.env.LINEAR_API_KEY;
+      else process.env.LINEAR_API_KEY = savedKey;
+    }
+  });
+});

--- a/plugins/dev/scripts/orch-monitor/__tests__/linear-title-description-fallback.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/linear-title-description-fallback.test.ts
@@ -778,3 +778,44 @@ describe("CTL-1003 B3: fillTitleDescriptionFallback — parseTicketMeta + ttlMs 
     }
   });
 });
+
+// CTL-1616 PR3: linearAuthHeader's token resolution folds onto the shared
+// secret-contract engine (resolveSecret) — this is the synthetic
+// LINEAR_API_KEY-only fixture the design mandates, proven end-to-end through
+// fillTitleDescriptionFallback by asserting the Authorization header sent.
+describe("CTL-1616 PR3: secret-contract fold — LINEAR_API_KEY-only fixture", () => {
+  beforeEach(() => {
+    _clearTitleDescCache("CTL-926");
+  });
+
+  it("fillTitleDescriptionFallback sends LINEAR_API_KEY as the Authorization header when LINEAR_API_TOKEN is absent", async () => {
+    const savedToken = process.env.LINEAR_API_TOKEN;
+    const savedKey = process.env.LINEAR_API_KEY;
+    const originalFetch = globalThis.fetch;
+    let seenAuth: string | null = null;
+    globalThis.fetch = ((_url: unknown, init?: RequestInit) => {
+      const headers = (init?.headers ?? {}) as Record<string, string>;
+      seenAuth = headers.Authorization ?? null;
+      return Promise.resolve({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            data: { issues: { nodes: [{ number: 926, title: "Real title", description: "## Body", team: { key: "CTL" } }] } },
+          }),
+      } as Response);
+    }) as typeof fetch;
+    try {
+      delete process.env.LINEAR_API_TOKEN;
+      process.env.LINEAR_API_KEY = "lin_api_fromkey";
+      const result = await fillTitleDescriptionFallback(["CTL-926"]);
+      expect(result["CTL-926"].title).toBe("Real title");
+      expect(seenAuth).toBe("lin_api_fromkey");
+    } finally {
+      globalThis.fetch = originalFetch;
+      if (savedToken === undefined) delete process.env.LINEAR_API_TOKEN;
+      else process.env.LINEAR_API_TOKEN = savedToken;
+      if (savedKey === undefined) delete process.env.LINEAR_API_KEY;
+      else process.env.LINEAR_API_KEY = savedKey;
+    }
+  });
+});

--- a/plugins/dev/scripts/orch-monitor/lib/linear-comment.mjs
+++ b/plugins/dev/scripts/orch-monitor/lib/linear-comment.mjs
@@ -44,6 +44,15 @@
 // success payload while silently not applying — the GraphQL path is the one that
 // demonstrably works for mutations. Reads stay on the replica (linear-thread.mjs).
 
+// CTL-1616 PR3: fold the env-alias leg of resolveLinearToken's chain onto the
+// shared secret-contract engine (design §8 PR3 table — this file was the one
+// outlier using `||` where the other 8 hand-rolled copies used `??`). Only the
+// env-alias LEG folds here: the Layer-2 `linear.apiToken` personal-token
+// fallback below is this file's own distinct chain (a different secret from
+// the registry's `linear-api-token` row's config-json shape) and is out of
+// scope for this PR.
+import { resolveSecret } from "../../lib/secret-contract.mjs";
+
 const LINEAR_GRAPHQL_URL = "https://api.linear.app/graphql";
 
 /** Wall-clock budget for a single Linear mutation. The operator is waiting on this
@@ -73,7 +82,15 @@ const REQUEST_TIMEOUT_MS = 15_000;
  * this is the belt to that braces.)
  */
 export function resolveLinearToken(env = process.env, { projectConfig = null } = {}) {
-  const fromEnv = env.LINEAR_API_TOKEN || env.LINEAR_API_KEY || null;
+  // CTL-1616 PR3: was `env.LINEAR_API_TOKEN || env.LINEAR_API_KEY || null` —
+  // folded onto resolveSecret's env-alias resolver (same alias precedence,
+  // same `env` injected here for tests). Precise semantics, unchanged from
+  // the old `||` ladder: an EMPTY-STRING token falls through to
+  // LINEAR_API_KEY (falsy before, non-empty-check now); a WHITESPACE-ONLY
+  // token wins the env leg in BOTH versions (truthy before, non-empty now),
+  // then fails the `.trim()` check below and falls to the Layer-2 personal
+  // token — SKIPPING LINEAR_API_KEY, exactly as it always did.
+  const fromEnv = resolveSecret("linear-api-token", { env }).value;
   if (typeof fromEnv === "string" && fromEnv.trim() !== "") return fromEnv.trim();
   // Layer-2 personal token — the launchd path's only source. BOTH shapes are
   // accepted: `linear.apiToken` is what the reference schema documents

--- a/plugins/dev/scripts/orch-monitor/lib/linear-estimate-fallback.mjs
+++ b/plugins/dev/scripts/orch-monitor/lib/linear-estimate-fallback.mjs
@@ -36,6 +36,9 @@
 import { existsSync, mkdirSync, readFileSync, renameSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { homedir } from "node:os";
+// CTL-1616 PR3: fold this file's inline LINEAR_API_TOKEN/LINEAR_API_KEY ladder
+// onto the shared secret-contract engine (design §8 PR3 table).
+import { resolveSecret } from "../../lib/secret-contract.mjs";
 
 const HOME = homedir();
 
@@ -114,7 +117,7 @@ const TEAM_METHOD_QUERY = `query GetTeamEstimation($key: String!) {
 }`;
 
 function linearAuthHeader() {
-  const token = process.env.LINEAR_API_TOKEN ?? process.env.LINEAR_API_KEY ?? "";
+  const token = resolveSecret("linear-api-token").value ?? ""; // CTL-1616 PR3
   if (!token) return null;
   return /^lin_oauth/i.test(token) ? `Bearer ${token}` : token;
 }

--- a/plugins/dev/scripts/orch-monitor/lib/linear-title-description-fallback.mjs
+++ b/plugins/dev/scripts/orch-monitor/lib/linear-title-description-fallback.mjs
@@ -38,7 +38,10 @@
 //     Linear call on a request path").
 //   - NEVER throws.
 //
-// Dependencies: none beyond node built-ins + Bun's global `fetch`.
+// Dependencies: node built-ins + Bun's global `fetch`, plus (CTL-1616 PR3) the
+// shared secret-contract engine for the LINEAR_API_TOKEN/LINEAR_API_KEY
+// resolution below (design §8 PR3 table).
+import { resolveSecret } from "../../lib/secret-contract.mjs";
 
 // ── In-memory TTL cache ───────────────────────────────────────────────────────
 // Keyed by ticket ID (e.g. "CTL-926"). Value:
@@ -166,7 +169,7 @@ const TITLE_DESC_QUERY_FOR_TEAM = `query FallbackTitleDesc($teamKey: String!, $n
 }`;
 
 function linearAuthHeader() {
-  const token = process.env.LINEAR_API_TOKEN ?? process.env.LINEAR_API_KEY ?? "";
+  const token = resolveSecret("linear-api-token").value ?? ""; // CTL-1616 PR3
   if (!token) return null;
   return /^lin_oauth/i.test(token) ? `Bearer ${token}` : token;
 }

--- a/plugins/dev/skills/phase-triage/SKILL.md
+++ b/plugins/dev/skills/phase-triage/SKILL.md
@@ -375,8 +375,12 @@ where `REPO_ROOT` is the repo root (the worktree's checkout path, e.g. the direc
 team's estimation method with a single GraphQL call:
 
 ```bash
+# Token via the shared secret contract (CTL-1616) — never a hand-rolled
+# LINEAR_API_TOKEN/LINEAR_API_KEY ladder.
+source "${CLAUDE_PLUGIN_ROOT}/scripts/lib/catalyst-secret-contract.sh"
+catalyst_resolve_secret linear-api-token >/dev/null
 curl -s -X POST https://api.linear.app/graphql \
-  -H "Authorization: ${LINEAR_API_TOKEN:-$LINEAR_API_KEY}" \
+  -H "Authorization: ${CATALYST_SECRET_LAST_VALUE}" \
   -H "Content-Type: application/json" \
   -d '{"query":"query($k:String!){teams(filter:{key:{eq:$k}}){nodes{issueEstimation{type allowZero extended}}}}", "variables":{"k":"<TEAM_KEY>"}}' \
   | jq -r '.data.teams.nodes[0].issueEstimation.type'


### PR DESCRIPTION
## Summary

CTL-1616 migration plan **PR3**: all 12 Linear-token read sites (design §8 table) now resolve through `resolveSecret("linear-api-token")` instead of three divergent hand-rolled ladders (`??`, bare `||`, trimmed-`||`). The doctor's three reads **cut over from shadow to live** — grading through the contract via a shared throw-safe `resolveLinearTokenLive` (throw degrades to no-token, fail-closed); the now-redundant linear presence-comparison shadow rows collapse, while the webhook-secret and cloud-token shadows stay shadow-only pending their own cutover PRs.

**Precondition met before this PR:** one full clean shadow cycle on both fleet hosts (#2916 post-merge — zero disagreement rows).

## ⚠️ Three flagged behavior normalizations (none silent)

1. **CTL-1619 closed at the primitive**: `linear-reconcile-cli` honors the `LINEAR_API_KEY` alias again — and can never drop it, since the alias lives in the registry row.
2. **Empty-string token**: the 9 former-`??` sites treated `LINEAR_API_TOKEN=""` as *set* (blank Authorization header → guaranteed 401); the engine's non-empty presence rule now falls through to `LINEAR_API_KEY`. Benign in direction; surfaced by adversarial verify and documented at the fold site.
3. **Whitespace-only token**: reconcile-cli's private outlier (trimmed before presence) is normalized to the shared rule.

## Verification

- Fable adversarial verify: complete grep-sweep of every `LINEAR_API_TOKEN`/`LINEAR_API_KEY` hit in the tree, classified (folded / PR4-mint-chain / registry / tests / docs) — **zero missed sites**; per-site parity tracing; mutation tests (reverting a fold is caught by suites); live Linear auth verified through the real resolver (`linear-connectivity` PASS).
- `LINEAR_API_KEY`-only fixture passes identically at every foldable site (design §9 PR3 criterion).
- Suites (direct exit codes): doctor 345/0 · 11 exec-core suites 628/0 · orch-monitor 185/0 · pm estimate 45/0 · secret-contract 93/0 + parity 145/145 + bash 97/97 (all three unmodified).
- Bonus: `phase-triage` SKILL.md's copyable curl example now routes through `catalyst_resolve_secret` (verified live) instead of teaching agents a fresh hand-rolled ladder.

## Post-merge plan

Deploy rides the auto-reload; doctor-verify mini → then mini-2 (house sequential rule); then PR4 (OAuth-mint trio — the mint lives in `lib/linear-app-actor.sh`, not the ticket's stale citation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WHfJt1JhsdArSUyxwZZzkN