### PR TITLE
fix(dev): CTL-1617 close the three late #2918 Codex findings on the mode-aligned doctor grant

### DIFF
--- a/plugins/dev/scripts/__tests__/catalyst-join.test.sh
+++ b/plugins/dev/scripts/__tests__/catalyst-join.test.sh
@@ -1352,6 +1352,38 @@ run "T4.4 doctor gate failure exits non-zero before stack install" bash -c "
     bash '$JOIN' --bundle '$FIXTURE_BUNDLE' >/dev/null 2>&1; [[ \$? -ne 0 ]] && \
   ! grep -q 'catalyst-stack install-services' '$INVLOG4D'"
 
+# T4.4b: (#2918 follow-up P1) the doctor gate must run with CATALYST_CONFIG_FILE
+# pointed at the provisioner-parity plugin-source Layer-1 — the deployment-mode
+# resolver's own Layer-1 default is CWD-relative (the operator's invocation
+# dir), so without the override the gate resolves an inferred default and
+# keeps a webhook-ingestion FAIL the wiring gate intentionally aligned away.
+STUBS4B="${SCRATCH}/stubs4b"
+make_stubs "$STUBS4B"
+run "T4.4b doctor gate receives the plugin-source CATALYST_CONFIG_FILE (#2918 P1)" bash -c "
+  catdir='${SCRATCH}/c44b'
+  home44b='${SCRATCH}/h44b'
+  mkdir -p \"\$home44b/.config/catalyst\"
+  printf '{}' > \"\$home44b/.config/catalyst/config.json\"
+  envlog='${SCRATCH}/c44b-doctor-env.log'
+  cat > '${STUBS4B}/stub-doctor-envlog.sh' <<'STUB'
+#!/usr/bin/env bash
+echo \"CATALYST_CONFIG_FILE=\${CATALYST_CONFIG_FILE:-UNSET}\" >> '${SCRATCH}/c44b-doctor-env.log'
+exit 0
+STUB
+  chmod +x '${STUBS4B}/stub-doctor-envlog.sh'
+  env -i HOME=\"\$home44b\" CATALYST_DIR=\"\$catdir\" \
+    CATALYST_JOIN_TOKEN='$GOOD_TOKEN' \
+    CATALYST_JOIN_GITHUB_TOKEN='ghp_TEST_DUMMY_0000' \
+    CATALYST_JOIN_SETUP_SCRIPT='${STUBS4B}/stub-setup-catalyst.sh' \
+    CATALYST_JOIN_INSTALL_CLI_SCRIPT='${STUBS4B}/stub-install-cli.sh' \
+    CATALYST_JOIN_PLUGIN_SRC_SCRIPT='${STUBS4B}/stub-setup-plugin-source.sh' \
+    CATALYST_JOIN_PROVISION_THOUGHTS_SCRIPT='${STUBS4B}/stub-provision-thoughts.sh' \
+    CATALYST_JOIN_STACK_BIN='${STUBS4B}/stub-catalyst-stack' \
+    CATALYST_JOIN_DOCTOR_SCRIPT='${STUBS4B}/stub-doctor-envlog.sh' \
+    CATALYST_JOIN_REACH_PROBE='${STUBS4B}/stub-reach-probe.sh' \
+    bash '$JOIN' --bundle '$FIXTURE_BUNDLE' >/dev/null 2>&1
+  grep -qF \"CATALYST_CONFIG_FILE=\$home44b/catalyst/plugin-source/.catalyst/config.json\" \"\$envlog\""
+
 # T4.5: catalyst-stack install-services runs AFTER config merge
 STUBS4O="${SCRATCH}/stubs4o"
 make_stubs "$STUBS4O"

--- a/plugins/dev/scripts/catalyst-join.sh
+++ b/plugins/dev/scripts/catalyst-join.sh
@@ -970,7 +970,14 @@ do_doctor_gate() {
   # Gate strictly on [$? -eq 0] per the doctor contract. This replaces the old
   # default of check-setup.sh, a cwd-relative full-workstation check that exits
   # nonzero on a fresh node (the reason mini-2's join needed a manual marker poke).
-  if bash "$DOCTOR_SCRIPT" --dry-run >/dev/null 2>&1; then
+  # #2918 follow-up (Codex P1): thread the SAME Layer-1 the webhook-wiring
+  # gate consulted (provisioner-parity plugin-source checkout) into the doctor
+  # run — the deployment-mode resolver's own Layer-1 default is CWD-relative
+  # (the operator's invocation directory), so without this the doctor gate
+  # resolves an inferred default and keeps the webhook-ingestion FAIL on a
+  # declared non-cluster join that the wiring gate intentionally skipped.
+  local _doctor_l1="${CATALYST_PLUGIN_SOURCE:-${HOME}/catalyst/plugin-source}/.catalyst/config.json"
+  if CATALYST_CONFIG_FILE="$_doctor_l1" bash "$DOCTOR_SCRIPT" --dry-run >/dev/null 2>&1; then
     info "Doctor gate passed (catalyst-doctor: 0 FAIL checks)."
     return 0
   else

--- a/plugins/dev/scripts/execution-core/doctor.mjs
+++ b/plugins/dev/scripts/execution-core/doctor.mjs
@@ -1226,6 +1226,36 @@ export function checkWebhookIngestion(deps = {}) {
       declaredMode.recognized === true &&
       declaredMode.mode !== "cluster"
     ) {
+      // #2918 follow-up (Codex P2 x2):
+      // (a) The aligned grant applies only to a FULLY-ABSENT route — a
+      //     dangling Linear webhookId without its HMAC secret is config
+      //     residue and must keep the half-wired FAIL even here (this
+      //     branch previously returned before the dangling check below).
+      if (danglingKeys.length > 0) {
+        return [
+          mkCheck(
+            "webhook-ingestion",
+            STATUS.FAIL,
+            `multiHost member with half-wired Linear webhook(s): ${danglingKeys.join(", ")} configured (webhookId) but missing HMAC secret file (linear-webhook-secret-<key>) — declared mode "${declaredMode.mode}" does not excuse config residue`,
+          ),
+          ...webhookShadow,
+        ];
+      }
+      // (b) Declared CLOUD is a WARN, not a PASS: cloud suppresses the smee
+      //     tunnels but its replacement ingestion (the cloud SDK event
+      //     connection) does not exist yet — an otherwise-green doctor must
+      //     not certify a node with zero event ingestion. Flips to PASS only
+      //     when a real cloud ingestion check exists to stand in its place.
+      if (declaredMode.mode === "cloud") {
+        return [
+          mkCheck(
+            "webhook-ingestion",
+            STATUS.WARN,
+            `declared deployment mode "cloud" (source=${declaredMode.source}) — smee ingestion intentionally not wired, but cloud replacement ingestion is NOT yet implemented: this node currently has no event ingestion at all`,
+          ),
+          ...webhookShadow,
+        ];
+      }
       return [
         mkCheck(
           "webhook-ingestion",

--- a/plugins/dev/scripts/execution-core/doctor.test.mjs
+++ b/plugins/dev/scripts/execution-core/doctor.test.mjs
@@ -2421,9 +2421,29 @@ describe("checkWebhookIngestion — deployment-mode alignment (CTL-1617, #2913 C
     expect(primary.detail).toContain("intentionally not wired");
   });
 
-  it("declared cloud: same aligned PASS (wire iff cluster, not skip iff single-host)", () => {
+  it("declared cloud: WARN, not PASS — cloud replacement ingestion does not exist yet (#2918 follow-up)", () => {
     const checks = checkWebhookIngestion({ ...NO_ROUTE_DEPS, resolveDeploymentModeFn: () => mode("cloud") });
-    expect(checks.find((c) => c.name === "webhook-ingestion").status).toBe(STATUS.PASS);
+    const primary = checks.find((c) => c.name === "webhook-ingestion");
+    expect(primary.status).toBe(STATUS.WARN);
+    expect(primary.detail).toContain("no event ingestion at all");
+  });
+
+  it("declared non-cluster with a DANGLING Linear key: half-wired FAIL fires before the aligned grant (#2918 follow-up ordering)", () => {
+    const checks = checkWebhookIngestion({
+      resolveRoster: multiHost,
+      // no github route at all + linear webhookId without its secret →
+      // both wired flags false → the old code granted the aligned PASS
+      // before ever reaching the dangling check.
+      monitor: { github: {}, linear: { smeeChannel: "https://smee.io/LIN", ctl: { webhookId: "wh-ctl" } } },
+      secretFileNonEmpty: () => false,
+      linearSecretEnvName: null,
+      resolveSecretContract: () => ({ value: null, source: "none", provider: "env-alias" }),
+      resolveDeploymentModeFn: () => mode("single-host"),
+    });
+    const primary = checks.find((c) => c.name === "webhook-ingestion");
+    expect(primary.status).toBe(STATUS.FAIL);
+    expect(primary.detail).toContain("half-wired");
+    expect(primary.detail).toContain("does not excuse config residue");
   });
 
   it("declared CLUSTER keeps the FAIL — the missed-activation-step-2b signal must survive", () => {


### PR DESCRIPTION
## Summary

Codex reviewed #2918 after its merge window; all three findings verified real and fixed here:

| Finding | Fix |
|---|---|
| **P1 — join's doctor gate never sees the Layer-1 declaration**: the wiring gate scopes `CATALYST_CONFIG_FILE` to its own resolver call, but `do_doctor_gate` inherited the operator's cwd → inferred default → the no-route FAIL persisted in exactly the flow the alignment targeted | `do_doctor_gate` now threads `CATALYST_CONFIG_FILE=${CATALYST_PLUGIN_SOURCE:-$HOME/catalyst/plugin-source}/.catalyst/config.json` into the doctor run (same provisioner-parity expression as the wiring gate). New `T4.4b` asserts the doctor subprocess receives it. |
| **P2 — aligned PASS ordered before the dangling-keys check**: declared non-cluster + no github + Linear `webhookId` missing its HMAC secret → PASS despite config residue | The aligned grant now checks `danglingKeys` first and keeps the half-wired FAIL ("declared mode does not excuse config residue"); new ordering test covers the exact shape (no github at all). |
| **P2 — declared cloud certified with zero ingestion**: cloud suppresses smee but replacement ingestion is future work | Declared cloud → **WARN** ("no event ingestion at all"), not PASS, until a real cloud-ingestion check exists to stand in its place. |

Suites: doctor 345/0 · join 50/1 (pre-existing T3.4 only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WHfJt1JhsdArSUyxwZZzkN