### PR TITLE
fix(pm): CTL-1616 harden the score-tickets contract loader (#2921 post-merge Codex x2)

### DIFF
--- a/plugins/pm/scripts/estimate/score-tickets.ts
+++ b/plugins/pm/scripts/estimate/score-tickets.ts
@@ -60,20 +60,31 @@ type ResolveSecretFn = (
 
 async function loadResolveSecret(): Promise<ResolveSecretFn> {
   const glob = (await import("node:fs")).globSync ?? null;
-  const candidates: string[] = [
-    // 1. source-checkout sibling of this plugin
+  const candidates: string[] = [];
+  // 0. explicit override — require-catalyst-dev.sh's own highest-priority
+  //    source (#2921 post-merge P2): honor a configured CATALYST_DEV_SCRIPTS.
+  const devScripts = process.env.CATALYST_DEV_SCRIPTS;
+  if (devScripts) candidates.push(resolve(devScripts, "lib/secret-contract.mjs"));
+  // 1. source-checkout sibling of this plugin; 2. repo-root cwd
+  candidates.push(
     resolve(import.meta.dir, "../../../dev/scripts/lib/secret-contract.mjs"),
-    // 2. repo-root cwd
     resolve(process.cwd(), "plugins/dev/scripts/lib/secret-contract.mjs"),
-  ];
+  );
   if (glob) {
     // 3. installed marketplace clone(s); 4. versioned cache — newest last, so
-    // reverse for newest-first.
+    // reverse for newest-first. Each glob is individually guarded: on Bun
+    // 1.2.x globSync THROWS ENOENT when the pattern's root dir is absent
+    // (#2921 post-merge P1) — a missing optional layout must not abort the
+    // search before valid candidates are tried.
     for (const pat of [
       `${homedir()}/.claude/plugins/marketplaces/*/plugins/dev/scripts/lib/secret-contract.mjs`,
       `${homedir()}/.claude/plugins/cache/*/catalyst-dev/*/scripts/lib/secret-contract.mjs`,
     ]) {
-      candidates.push(...glob(pat).sort().reverse());
+      try {
+        candidates.push(...glob(pat).sort().reverse());
+      } catch {
+        /* absent optional layout root — skip */
+      }
     }
   }
   for (const p of candidates) {


### PR DESCRIPTION
## Summary

Both post-merge #2921 findings verified (the P1 reproduced locally: bare `globSync` on a missing root throws ENOENT under Bun) and fixed:

1. **P1** — each optional layout glob is individually try/caught, so a clean HOME without `~/.claude/plugins/{marketplaces,cache}` no longer aborts the candidate search before the valid source-checkout path is tried (`refresh-corpus.sh` defaults `--check-labels` on, so this broke the normal refresh in clean installs).
2. **P2** — `CATALYST_DEV_SCRIPTS` is now the highest-priority candidate, matching `require-catalyst-dev.sh`'s resolution order.

`bun build` clean; pm estimate suites 45/0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WHfJt1JhsdArSUyxwZZzkN