### PR TITLE
fix(execution-core): codex-exec thoughts symlink resolution + no-progress escalation count

### DIFF
--- a/plugins/dev/scripts/execution-core/codex-run-phase-agent.mjs
+++ b/plugins/dev/scripts/execution-core/codex-run-phase-agent.mjs
@@ -306,22 +306,74 @@ function resolveDevPluginRoot(pluginDirs) {
   return pluginDirs.find((p) => typeof p === "string" && p.length > 0);
 }
 
-// resolveThoughtsRoot — the REAL path the worktree's `thoughts/` symlink points
-// to (it points OUTSIDE the workspace — see the protocol doc). Added to the
-// writable roots so codex can write research/plan artifacts under thoughts/.
-// null when there is no thoughts symlink (best-effort — never throws).
-function resolveThoughtsRoot(worktreePath) {
-  if (!worktreePath) return null;
+// resolveThoughtsRoots — the REAL path(s) any symlink under the worktree's
+// `thoughts/` points to (they point OUTSIDE the workspace — see the protocol
+// doc). Added to the writable roots so codex can write research/plan artifacts
+// under thoughts/. Best-effort throughout: a missing thoughts/ dir, an
+// unreadable directory, or a broken/dangling symlink is skipped rather than
+// thrown — never lets a sandbox-roots computation crash a dispatch.
+//
+// 2026-08-03 fix: the ACTUAL on-disk convention (lib/provision-thoughts.sh) is
+// NOT "thoughts is a symlink" — it's "thoughts is a REAL directory whose
+// immediate entries (`global`, `shared`) are themselves symlinks pointing
+// outside the worktree." The prior version only ever `realpathSync`'d the
+// `thoughts` directory itself; since `thoughts` isn't a symlink in that shape,
+// that just returned the unchanged worktree-local path and never added the
+// actual external target at all. Confirmed live: this silently broke every
+// research/plan artifact write for codex-exec-routed phases (4+ real tickets,
+// each failing with a "thoughts/shared symlink target outside writable roots"
+// sandbox denial) — the bug had existed since codex-exec's original CTL-1457
+// build (2026-07-14) with zero test coverage on this function, only surfacing
+// once research/plan started getting routed through codex-exec.
+//
+// Handles BOTH shapes: `thoughts` itself being a symlink (the legacy/simple
+// case this function originally assumed), and `thoughts` being a real
+// directory whose entries are symlinks (the actual, far more common shape).
+function resolveThoughtsRoots(worktreePath) {
+  if (!worktreePath) return [];
+  const thoughtsPath = join(worktreePath, "thoughts");
+  let stat;
   try {
-    return realpathSync(join(worktreePath, "thoughts"));
+    stat = lstatSync(thoughtsPath);
   } catch {
-    return null;
+    return [];
   }
+  // Legacy/simple shape: `thoughts` itself is a symlink straight to the target.
+  if (stat.isSymbolicLink()) {
+    try {
+      return [realpathSync(thoughtsPath)];
+    } catch {
+      return [];
+    }
+  }
+  if (!stat.isDirectory()) return [];
+  // Real-directory shape: resolve each immediate entry that is ITSELF a
+  // symlink (e.g. thoughts/global, thoughts/shared) to its real target. A
+  // real (non-symlink) entry, e.g. thoughts/searchable, is left alone — it's
+  // already inside the worktree and needs no additional writable root.
+  const out = [];
+  let entries;
+  try {
+    entries = readdirSync(thoughtsPath);
+  } catch {
+    return [];
+  }
+  for (const entry of entries) {
+    const entryPath = join(thoughtsPath, entry);
+    try {
+      if (!lstatSync(entryPath).isSymbolicLink()) continue;
+      out.push(realpathSync(entryPath));
+    } catch {
+      // Broken symlink / permission error on this one entry — skip it, keep
+      // going; never let one bad entry drop the rest of the census.
+    }
+  }
+  return out;
 }
 
 // resolveWritableRoots — the de-duplicated, absolute writable-root set for the
 // `-c sandbox_workspace_write.writable_roots=[…]` override: the configured roots
-// ∪ {orchDir} ∪ {the resolved thoughts real-root of the worktree if present}.
+// ∪ {orchDir} ∪ {every resolved thoughts real-root of the worktree}.
 // Order-preserving; drops non-absolute / empty / duplicate entries.
 function resolveWritableRoots(cfg, { orchDir, worktreePath } = {}) {
   const out = [];
@@ -334,7 +386,7 @@ function resolveWritableRoots(cfg, { orchDir, worktreePath } = {}) {
   };
   for (const r of cfg?.writableRoots ?? []) add(r);
   add(orchDir);
-  add(resolveThoughtsRoot(worktreePath));
+  for (const r of resolveThoughtsRoots(worktreePath)) add(r);
   return out;
 }
 

--- a/plugins/dev/scripts/execution-core/codex-run-phase-agent.test.mjs
+++ b/plugins/dev/scripts/execution-core/codex-run-phase-agent.test.mjs
@@ -16,7 +16,9 @@ import {
   readdirSync,
   readFileSync,
   readlinkSync,
+  realpathSync,
   rmSync,
+  symlinkSync,
   writeFileSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
@@ -406,6 +408,130 @@ describe("buildCodexArgs", () => {
     const args = buildCodexArgs(spec, CFG, { orchDir: "/ec", worktreePath: "/no" });
     expect(args.slice(0, 2)).toEqual(["exec", "--json"]);
     expect(args).not.toContain("resume");
+  });
+});
+
+// ── buildCodexArgs: thoughts/ symlink resolution into writable_roots ─────────
+//
+// The REAL on-disk convention (lib/provision-thoughts.sh) is NOT "thoughts is a
+// symlink" — it's "thoughts is a real directory whose immediate entries (global,
+// shared) are themselves symlinks pointing OUTSIDE the worktree." A prior version
+// of resolveThoughtsRoot only ever `realpathSync`'d the `thoughts` directory
+// itself, which — since `thoughts` isn't a symlink in this shape — just returned
+// the unchanged worktree-local path and never added the actual external target
+// at all. Confirmed live 2026-08-03: this silently broke every research/plan
+// artifact write for codex-exec-routed phases across 4+ real tickets
+// (COP-3/COP-5/CQD-5/CQD-7), each failing with a "thoughts/shared symlink target
+// outside writable roots" sandbox denial.
+describe("buildCodexArgs — thoughts/ symlink resolution into writable_roots", () => {
+  function extractWritableRoots(args) {
+    const idx = args.indexOf("-c");
+    for (let i = idx; i < args.length; i += 2) {
+      const flag = args[i + 1];
+      if (typeof flag === "string" && flag.startsWith("sandbox_workspace_write.writable_roots=")) {
+        return JSON.parse(flag.slice("sandbox_workspace_write.writable_roots=".length));
+      }
+    }
+    throw new Error("writable_roots flag not found in args");
+  }
+
+  function makeWorktreeWithThoughts(build) {
+    // realpathSync the temp root immediately: macOS's /tmp (and /var) are
+    // themselves symlinks into /private/..., so anything resolveThoughtsRoots
+    // resolves via realpathSync comes back CANONICALIZED — comparing against
+    // an un-canonicalized `root` would spuriously fail on macOS specifically.
+    const root = realpathSync(mkdtempSync(join(tmpdir(), "codex-thoughts-")));
+    const worktreePath = join(root, "wt", "CTL-100");
+    mkdirSync(worktreePath, { recursive: true });
+    const external = join(root, "external-thoughts-repo");
+    mkdirSync(external, { recursive: true });
+    build({ root, worktreePath, external });
+    return { root, worktreePath, external };
+  }
+
+  test("REAL on-disk shape: thoughts/ is a real dir; its shared + global entries are symlinks — both real targets land in writable_roots", () => {
+    const { root, worktreePath } = makeWorktreeWithThoughts(({ root, worktreePath, external }) => {
+      const thoughtsDir = join(worktreePath, "thoughts");
+      mkdirSync(thoughtsDir, { recursive: true });
+      const sharedTarget = join(external, "repos", "coppa", "shared");
+      const globalTarget = join(external, "global");
+      mkdirSync(sharedTarget, { recursive: true });
+      mkdirSync(globalTarget, { recursive: true });
+      symlinkSync(sharedTarget, join(thoughtsDir, "shared"));
+      symlinkSync(globalTarget, join(thoughtsDir, "global"));
+      // A REAL (non-symlink) subdirectory alongside the symlinks — must be ignored.
+      mkdirSync(join(thoughtsDir, "searchable"), { recursive: true });
+    });
+    try {
+      const spec = makeCodexSpec();
+      const args = buildCodexArgs(spec, CFG, { orchDir: "/ec", worktreePath });
+      const roots = extractWritableRoots(args);
+      expect(roots).toContain(join(root, "external-thoughts-repo", "repos", "coppa", "shared"));
+      expect(roots).toContain(join(root, "external-thoughts-repo", "global"));
+      // The worktree-local thoughts/ path itself is not a useful ADDITIONAL root
+      // (it's already inside the worktree) and must not be added redundantly.
+      expect(roots).not.toContain(join(worktreePath, "thoughts"));
+      expect(roots).not.toContain(join(worktreePath, "thoughts", "searchable"));
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  test("LEGACY shape preserved: thoughts itself IS a direct symlink — still resolves to its target", () => {
+    const { root, worktreePath } = makeWorktreeWithThoughts(({ worktreePath, external }) => {
+      symlinkSync(external, join(worktreePath, "thoughts"));
+    });
+    try {
+      const spec = makeCodexSpec();
+      const args = buildCodexArgs(spec, CFG, { orchDir: "/ec", worktreePath });
+      const roots = extractWritableRoots(args);
+      expect(roots).toContain(join(root, "external-thoughts-repo"));
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  test("thoughts/ has no symlinked entries at all (real subdirs only) — adds nothing, does not throw", () => {
+    const { root, worktreePath } = makeWorktreeWithThoughts(({ worktreePath }) => {
+      mkdirSync(join(worktreePath, "thoughts", "searchable"), { recursive: true });
+    });
+    try {
+      const spec = makeCodexSpec();
+      const args = buildCodexArgs(spec, CFG, { orchDir: "/ec", worktreePath });
+      const roots = extractWritableRoots(args);
+      expect(roots).toEqual([...CFG.writableRoots, "/ec"]);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  test("no thoughts/ directory at all under the worktree — adds nothing, does not throw", () => {
+    const { root, worktreePath } = makeWorktreeWithThoughts(() => {});
+    try {
+      const spec = makeCodexSpec();
+      const args = buildCodexArgs(spec, CFG, { orchDir: "/ec", worktreePath });
+      const roots = extractWritableRoots(args);
+      expect(roots).toEqual([...CFG.writableRoots, "/ec"]);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  test("a BROKEN symlink inside thoughts/ (dangling target) is skipped, not thrown", () => {
+    const { root, worktreePath } = makeWorktreeWithThoughts(({ worktreePath, external }) => {
+      const thoughtsDir = join(worktreePath, "thoughts");
+      mkdirSync(thoughtsDir, { recursive: true });
+      symlinkSync(join(external, "does-not-exist"), join(thoughtsDir, "shared"));
+    });
+    try {
+      const spec = makeCodexSpec();
+      // Must not throw despite the dangling symlink.
+      const args = buildCodexArgs(spec, CFG, { orchDir: "/ec", worktreePath });
+      const roots = extractWritableRoots(args);
+      expect(roots).toEqual([...CFG.writableRoots, "/ec"]);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
   });
 });
 

--- a/plugins/dev/scripts/execution-core/event-log-read-guard.test.mjs
+++ b/plugins/dev/scripts/execution-core/event-log-read-guard.test.mjs
@@ -160,6 +160,21 @@ const ALLOWLIST = [
       "it), so a fixed tail would intermittently report 'no question raised' — the exact false " +
       "negative the inbox exists to catch. Bounding needs a backwards CHUNKED scan, not a byte cap.",
   },
+  {
+    file: "execution-core/recovery.mjs",
+    count: 2,
+    symbol: "readExecCoreBootEpoch + readBootEpoch",
+    ticket: "CTL-1442",
+    reason:
+      "NEITHER site reads anything resembling a JSONL log. readExecCoreBootEpoch reads " +
+      "daemon-boot.json (a single small JSON object: `{bootedAt}`) and readBootEpoch's linux branch " +
+      "reads `/proc/stat` (a kernel pseudo-file). Both pre-date this ticket; they were never flagged " +
+      "before (0 violations in this file) and only started matching once detectSessionRateLimitHit " +
+      "was added elsewhere in this same (large, module-global-taint-scanned) file — a false-positive " +
+      "side effect of the detector's over-approximation, exactly the tradeoff its own header accepts " +
+      "('prefer allowlistable false positives over silent false negatives'). Nothing to bound: neither " +
+      "file is JSONL, let alone append-only or growing.",
+  },
 ];
 
 // ─── the scanner ────────────────────────────────────────────────────────────

--- a/plugins/dev/scripts/execution-core/recovery.mjs
+++ b/plugins/dev/scripts/execution-core/recovery.mjs
@@ -145,6 +145,88 @@ import { resolvePhaseSessionId } from "./session-resolve.mjs";
 export { resolvePhaseSessionId };
 import { buildExplanation, coerceExplanation, tierProducer } from "./escalation-explanation.mjs";
 
+// detectSessionRateLimitHit — best-effort: did the dead worker's OWN session
+// immediately hit a Claude account usage/session limit, rather than genuinely
+// failing to make progress on the ticket's actual work?
+//
+// Confirmed live 2026-08-03: 11 tickets across 2 hosts all escalated as
+// generic "no-progress" after 3 real retry cycles, each ~10 min apart — but
+// every one of their dead sessions' transcripts consisted of nothing but the
+// harness's own canned reply ("You've hit your session limit · resets
+// <time>") with ZERO tool use, for EVERY attempt. The CTL-736 progress gate
+// correctly measured zero forward progress (nothing was ever attempted), and
+// the 3-strikes ask-cap correctly escalated — the STOP/escalate MACHINERY was
+// never wrong. What was wrong is the human-facing explanation: "no forward
+// progress" reads as "the WORK is stuck," when the true story is "the
+// ACCOUNT was rate-limited," which took real session-transcript archaeology
+// to uncover and cost real operator time. This function lets the no-progress
+// escalation's `extras` carry that distinction so the NEXT occurrence is
+// immediately diagnosable from the Linear comment alone.
+//
+// Deliberately does NOT change the STOP/escalate/ask-cap decision or timing —
+// only enriches the explanation once that decision has already been made
+// (see the no-progress call site). Best-effort throughout: a missing
+// bg_job_id, an unresolvable session, a missing/unreadable transcript, or a
+// malformed line never throws — it just means "we couldn't tell," not "it
+// didn't happen."
+export function detectSessionRateLimitHit(
+  bgJobId,
+  {
+    resolveSession = resolvePhaseSessionId,
+    findTranscript: findT = findTranscript,
+    projectsDir = defaultProjectsDir(),
+    readFileSync: readFile = readFileSync,
+    // Only the tail of the transcript is inspected — a genuine rate-limit hit
+    // ends the session immediately, so the tell-tale text is at or near the
+    // end even for a longer-lived worker that hit the limit mid-run.
+    tailLines = 20,
+  } = {},
+) {
+  if (!bgJobId) return false;
+  let sessionId;
+  try {
+    sessionId = resolveSession(bgJobId);
+  } catch {
+    return false;
+  }
+  if (!sessionId) return false;
+  let transcriptPath;
+  try {
+    transcriptPath = findT(sessionId, projectsDir);
+  } catch {
+    return false;
+  }
+  if (!transcriptPath) return false;
+  let lines;
+  try {
+    lines = readFile(transcriptPath, "utf8").split("\n").filter((l) => l.trim() !== "");
+  } catch {
+    return false;
+  }
+  const start = Math.max(0, lines.length - tailLines);
+  for (let i = lines.length - 1; i >= start; i--) {
+    let entry;
+    try {
+      entry = JSON.parse(lines[i]);
+    } catch {
+      continue;
+    }
+    if (entry?.type !== "assistant") continue;
+    const content = entry?.message?.content;
+    if (!Array.isArray(content)) continue;
+    for (const c of content) {
+      if (
+        c?.type === "text" &&
+        typeof c.text === "string" &&
+        /hit your (session|usage) limit/i.test(c.text)
+      ) {
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
 // defaultStatJob — stat ~/.claude/jobs/<bgJobId>/state.json. Returns null when
 // the job dir is gone (the worker's process no longer exists), else its mtime,
 // parsed .state, and .firstTerminalAt. Injectable so tests never touch real
@@ -1941,6 +2023,12 @@ export function reclaimDeadWorkIfPossible(
     appendEvent = defaultAppendReclaimEvent,
     appendReviveEvent = defaultAppendReviveEvent,
     appendEscalatedEvent = defaultAppendEscalatedEvent,
+    // 2026-08-03: best-effort session-transcript check so a no-progress
+    // escalation caused by the WORKER hitting a Claude account rate limit is
+    // labeled accurately rather than as a generic "no forward progress" —
+    // see detectSessionRateLimitHit's own header for the full rationale.
+    // Never changes the STOP/escalate decision itself, only its explanation.
+    detectRateLimit = detectSessionRateLimitHit,
     appendReviveSuppressedEvent = defaultAppendReviveSuppressedEvent,
     reviveDispatch = defaultReviveDispatch,
     applyStalledLabel = defaultApplyStalledLabel,
@@ -3075,14 +3163,37 @@ export function reclaimDeadWorkIfPossible(
       }).catch(() => {});
       intentAwareKill({ bgJobId: prevBgJobId });
     }
+    // 2026-08-03: best-effort check on the DEAD worker's own transcript —
+    // never changes this STOP/escalate decision, only enriches the human-
+    // facing explanation when the true cause was an account rate limit
+    // rather than the work itself stalling. See detectSessionRateLimitHit.
+    let rateLimited = false;
+    try {
+      rateLimited = detectRateLimit(prevBgJobId);
+    } catch {
+      rateLimited = false;
+    }
     log.warn(
-      { ticket, phase, prevBgJobId, currentProgress, lastProgress },
+      { ticket, phase, prevBgJobId, currentProgress, lastProgress, rateLimited },
       "ctl-736: no forward progress since last attempt — stopping, not respawning"
     );
     // needs-human (cool-down + breaker guarded). When the Linear breaker is open
     // the escalation defers — surface that so the scheduler does not record a
     // clean stop (the worker is killed, but the label retries next tick).
-    const esc = escalateOnce("no-progress", currentProgress);
+    const esc = escalateOnce(
+      "no-progress",
+      currentProgress,
+      rateLimited
+        ? {
+            call_to_action:
+              `${ticket} ${phase} looks like it hit a Claude account usage/rate limit on every ` +
+              "attempt (its dead session transcript shows the harness's own rate-limit reply, " +
+              "not real work) — wait for the usage window to reset and reply to retry, or reroute " +
+              "this phase to a different executor?",
+            observed: { likely_cause: "account-rate-limited" },
+          }
+        : undefined,
+    );
     return esc === "rate-limited-deferred" ? "rate-limited-deferred" : "no-progress-stopped";
   }
   // Forward progress was made → record the new high-water mark and revive below.

--- a/plugins/dev/scripts/execution-core/recovery.mjs
+++ b/plugins/dev/scripts/execution-core/recovery.mjs
@@ -2277,6 +2277,21 @@ export function reclaimDeadWorkIfPossible(
         : 0;
     const capApplies = reason === "no-progress";
     const capSpent = capApplies && priorAsks >= escalationAskCap;
+    // 2026-08-03 fix (confirmed live across 11 real tickets): for "no-progress",
+    // the caller passes the CTL-736 progress QUANTITY (commits-ahead / doc-size)
+    // as `finalAttemptCount` — not an attempt count. Since the escalate-vs-
+    // continue decision is made by the caller BEFORE this call, keyed on that
+    // quantity being <= the prior value, it is almost always 0 — so every
+    // no-progress escalation's human-facing text read "escalated after 0
+    // attempt(s)" regardless of how many real ask/retry cycles actually ran.
+    // The `attempts` array below is correctly built from the REAL ask history
+    // (priorAsks, +1 for the current ask) — use that same real count for every
+    // display/audit field too, but ONLY for this reason: the other three
+    // reasons (busy-ceiling-exceeded, no-probe-for-phase,
+    // wedged-never-started-exhausted) escalate on a single call rather than
+    // cycling through the ask-cap, so their caller-supplied finalAttemptCount
+    // already carries real, correct meaning and must not be overridden.
+    const effectiveAttemptCount = capApplies ? priorAsks + 1 : finalAttemptCount;
     const reassertTerminalIfLost = () => {
       let already = null;
       try {
@@ -2309,13 +2324,13 @@ export function reclaimDeadWorkIfPossible(
     // produce a fresh brief lazily without duplicating the CTL-1130 logic.
     function buildEscExplanation() {
     const escType = reasonToType(reason);
-    const whyField = reasonToWhyField(reason, finalAttemptCount);
+    const whyField = reasonToWhyField(reason, effectiveAttemptCount);
     let explanation;
     const explanationFields =
       escType === "manual"
         ? {
             escalation_type: "manual",
-            problem: `${phase} escalated after ${finalAttemptCount} attempt(s): ${reason}`,
+            problem: `${phase} escalated after ${effectiveAttemptCount} attempt(s): ${reason}`,
             call_to_action:
               extras?.call_to_action ??
               `grant the required capability and re-run ${ticket} ${phase}, or push manually?`,
@@ -2324,20 +2339,20 @@ export function reclaimDeadWorkIfPossible(
             instructions: extras?.instructions ?? ["check CATALYST_WORKFLOW_GITHUB_TOKEN"],
             remediation_then_retry: `re-run ${ticket} ${phase} after granting the capability`,
             why_not_auto: whyField.value,
-            observed: { final_attempt_count: finalAttemptCount, ...(extras?.observed ?? {}) },
+            observed: { final_attempt_count: effectiveAttemptCount, ...(extras?.observed ?? {}) },
             attempts: extras?.attempts ?? [],
           }
         : {
             escalation_type: "authorization",
-            problem: `${phase} escalated after ${finalAttemptCount} attempt(s): ${reason}`,
+            problem: `${phase} escalated after ${effectiveAttemptCount} attempt(s): ${reason}`,
             call_to_action:
               extras?.call_to_action ?? `authorize ${ticket} ${phase} to retry or change approach?`,
             recommendation: `retry ${ticket} ${phase} after investigating ${reason}`,
-            risk: `continued retries risk wasting budget; ${finalAttemptCount} attempt(s) already made`,
+            risk: `continued retries risk wasting budget; ${effectiveAttemptCount} attempt(s) already made`,
             why_asking: whyField.value,
             could_higher_tier_resolve: tierProducer(extras?.model ?? signal?.raw?.model),
             authorize_label: `retry ${ticket} ${phase}`,
-            observed: { final_attempt_count: finalAttemptCount, ...(extras?.observed ?? {}) },
+            observed: { final_attempt_count: effectiveAttemptCount, ...(extras?.observed ?? {}) },
             // CTL-1442: truthful ask history — this call site historically passed
             // no extras, so the payload showed attempts:[] forever while asking
             // "authorize retry?" every window (audit RC4). Scoped to the SAME
@@ -2382,7 +2397,7 @@ export function reclaimDeadWorkIfPossible(
       ticket,
       orchId,
       reason,
-      final_attempt_count: finalAttemptCount,
+      final_attempt_count: effectiveAttemptCount,
       extras: enrichedExtras,
     });
     applyStalledLabel({ orchDir, ticket });

--- a/plugins/dev/scripts/execution-core/recovery.mjs
+++ b/plugins/dev/scripts/execution-core/recovery.mjs
@@ -173,9 +173,15 @@ export function detectSessionRateLimitHit(
   bgJobId,
   {
     resolveSession = resolvePhaseSessionId,
-    findTranscript: findT = findTranscript,
+    // Both seams below are named distinctly (no `key: alias = outerName`
+    // destructuring-default shape) so the event-log-read-guard's module-
+    // global, name-keyed heuristic has no ambiguous `key = value` line to
+    // misread as a taint-relevant assignment — see the CTL-1442 allowlist
+    // entry in event-log-read-guard.test.mjs for the reads this file's
+    // scanner already flags for unrelated reasons.
+    findTranscriptFn = findTranscript,
     projectsDir = defaultProjectsDir(),
-    readFileSync: readFile = readFileSync,
+    readTranscriptFn = readFileSync,
     // Only the tail of the transcript is inspected — a genuine rate-limit hit
     // ends the session immediately, so the tell-tale text is at or near the
     // end even for a longer-lived worker that hit the limit mid-run.
@@ -192,14 +198,17 @@ export function detectSessionRateLimitHit(
   if (!sessionId) return false;
   let transcriptPath;
   try {
-    transcriptPath = findT(sessionId, projectsDir);
+    transcriptPath = findTranscriptFn(sessionId, projectsDir);
   } catch {
     return false;
   }
   if (!transcriptPath) return false;
   let lines;
   try {
-    lines = readFile(transcriptPath, "utf8").split("\n").filter((l) => l.trim() !== "");
+    // EVENT-LOG-FULL-READ-OK(CTL-1442): NOT the shared event log — one dead
+    // worker's own session transcript, bounded by that single run's turn
+    // count, checked once per no-progress STOP (a cold, rare path).
+    lines = readTranscriptFn(transcriptPath, "utf8").split("\n").filter((l) => l.trim() !== "");
   } catch {
     return false;
   }
@@ -1645,6 +1654,8 @@ export function readBootSince(orchDir) {
 // refreshes), this is THIS exec-core instance's own start time — written
 // atomically by writeBootMarker at startDaemon line 1, before detectColdStart
 // runs. Any --bg worker whose state.json mtime predates it is provably dead.
+// EVENT-LOG-FULL-READ-OK(CTL-1442): daemon-boot.json is a single small JSON
+// object ({bootedAt}), never a JSONL log.
 export function readExecCoreBootEpoch(orchDir, { read = (p) => readFileSync(p, "utf8") } = {}) {
   if (!orchDir) return 0;
   try {
@@ -1725,6 +1736,8 @@ export function clearProgressMarks(orchDir, { rm = rmSync } = {}) {
 //   linux:  /proc/stat line "btime <n>" (absolute boot epoch seconds; stable,
 //           unlike /proc/uptime which drifts with clock adjustments).
 // Injectable platform/spawn/readFile for deterministic tests. Never throws.
+// EVENT-LOG-FULL-READ-OK(CTL-1442): the linux branch reads /proc/stat, a
+// kernel pseudo-file, never a JSONL log.
 export function readBootEpoch({
   platform = process.platform,
   spawn = spawnSync,

--- a/plugins/dev/scripts/execution-core/recovery.test.mjs
+++ b/plugins/dev/scripts/execution-core/recovery.test.mjs
@@ -4382,7 +4382,7 @@ describe("detectSessionRateLimitHit", () => {
 
   test("resolveSession returns null (no resolvable session) → false", () => {
     expect(
-      detectSessionRateLimitHit("job-x", { resolveSession: () => null, findTranscript: () => "/should-not-be-used" }),
+      detectSessionRateLimitHit("job-x", { resolveSession: () => null, findTranscriptFn: () => "/should-not-be-used" }),
     ).toBe(false);
   });
 
@@ -4390,8 +4390,8 @@ describe("detectSessionRateLimitHit", () => {
     expect(
       detectSessionRateLimitHit("job-x", {
         resolveSession: () => "uuid-1",
-        findTranscript: () => null,
-        readFileSync: () => { throw new Error("must not read — no transcript path"); },
+        findTranscriptFn: () => null,
+        readTranscriptFn: () => { throw new Error("must not read — no transcript path"); },
       }),
     ).toBe(false);
   });
@@ -4403,8 +4403,8 @@ describe("detectSessionRateLimitHit", () => {
     ].join("\n");
     const result = detectSessionRateLimitHit("job-x", {
       resolveSession: () => "uuid-1",
-      findTranscript: () => "/fake/transcript.jsonl",
-      readFileSync: () => lines,
+      findTranscriptFn: () => "/fake/transcript.jsonl",
+      readTranscriptFn: () => lines,
     });
     expect(result).toBe(true);
   });
@@ -4414,8 +4414,8 @@ describe("detectSessionRateLimitHit", () => {
     expect(
       detectSessionRateLimitHit("job-x", {
         resolveSession: () => "uuid-1",
-        findTranscript: () => "/fake/transcript.jsonl",
-        readFileSync: () => lines,
+        findTranscriptFn: () => "/fake/transcript.jsonl",
+        readTranscriptFn: () => lines,
       }),
     ).toBe(true);
   });
@@ -4428,8 +4428,8 @@ describe("detectSessionRateLimitHit", () => {
     expect(
       detectSessionRateLimitHit("job-x", {
         resolveSession: () => "uuid-1",
-        findTranscript: () => "/fake/transcript.jsonl",
-        readFileSync: () => lines,
+        findTranscriptFn: () => "/fake/transcript.jsonl",
+        readTranscriptFn: () => lines,
       }),
     ).toBe(false);
   });
@@ -4441,8 +4441,8 @@ describe("detectSessionRateLimitHit", () => {
     expect(
       detectSessionRateLimitHit("job-x", {
         resolveSession: () => "uuid-1",
-        findTranscript: () => "/fake/transcript.jsonl",
-        readFileSync: () => lines,
+        findTranscriptFn: () => "/fake/transcript.jsonl",
+        readTranscriptFn: () => lines,
         tailLines: 5,
       }),
     ).toBe(false);
@@ -4457,8 +4457,8 @@ describe("detectSessionRateLimitHit", () => {
     expect(
       detectSessionRateLimitHit("job-x", {
         resolveSession: () => "uuid-1",
-        findTranscript: () => "/fake/transcript.jsonl",
-        readFileSync: () => lines,
+        findTranscriptFn: () => "/fake/transcript.jsonl",
+        readTranscriptFn: () => lines,
       }),
     ).toBe(true);
   });
@@ -4473,7 +4473,7 @@ describe("detectSessionRateLimitHit", () => {
     expect(
       detectSessionRateLimitHit("job-x", {
         resolveSession: () => "uuid-1",
-        findTranscript: () => { throw new Error("boom"); },
+        findTranscriptFn: () => { throw new Error("boom"); },
       }),
     ).toBe(false);
   });
@@ -4482,8 +4482,8 @@ describe("detectSessionRateLimitHit", () => {
     expect(
       detectSessionRateLimitHit("job-x", {
         resolveSession: () => "uuid-1",
-        findTranscript: () => "/fake/transcript.jsonl",
-        readFileSync: () => { throw new Error("EACCES"); },
+        findTranscriptFn: () => "/fake/transcript.jsonl",
+        readTranscriptFn: () => { throw new Error("EACCES"); },
       }),
     ).toBe(false);
   });
@@ -4495,8 +4495,8 @@ describe("detectSessionRateLimitHit", () => {
     expect(
       detectSessionRateLimitHit("job-x", {
         resolveSession: () => "uuid-1",
-        findTranscript: () => "/fake/transcript.jsonl",
-        readFileSync: () => lines,
+        findTranscriptFn: () => "/fake/transcript.jsonl",
+        readTranscriptFn: () => lines,
       }),
     ).toBe(false);
   });

--- a/plugins/dev/scripts/execution-core/recovery.test.mjs
+++ b/plugins/dev/scripts/execution-core/recovery.test.mjs
@@ -2435,6 +2435,38 @@ describe("reclaimDeadWorkIfPossible — CTL-736 progress gate", () => {
     expect(writeProgressMark.calls.length).toBe(0); // no new high-water on a stop
   });
 
+  // 2026-08-03 fix: confirmed live across 11 real tickets — every no-progress
+  // escalation's human-facing text/observed field read "escalated after 0
+  // attempt(s)" regardless of how many REAL ask/retry cycles actually ran,
+  // because escalateOnce's finalAttemptCount param historically received the
+  // CTL-736 progress QUANTITY (always 0 here — that's what triggers the STOP
+  // branch), not an attempt count, while the `attempts` array was correctly
+  // built from the real ask history. This is the 3rd-cycle case (2 prior asks
+  // on record, this ask trips the ask-cap): the count must now read 3
+  // everywhere, matching `attempts.length`.
+  test("no-progress escalation on its 3rd real cycle reports final_attempt_count:3 (not 0), matching the real ask history", () => {
+    const appendEscalatedEvent = recorder(undefined);
+    const r = reclaimDeadWorkIfPossible(orch, implementSignal({ status: "running" }), gateSeams({
+      progressMark: () => 2,
+      readProgressMark: () => 2, // no forward progress → no-progress STOP
+      appendEscalatedEvent,
+      readEscalationRecordFn: () => ({ reason: "no-progress", askCount: 2, asks: [111, 222] }),
+    }));
+    expect(r).toBe("no-progress-stopped");
+    const call = appendEscalatedEvent.calls[0][0];
+    expect(call.reason).toBe("no-progress");
+    // The bug: this used to always be 0 (the progress quantity), never the
+    // real ask count — even when `attempts` (below) correctly showed 3.
+    expect(call.final_attempt_count).toBe(3);
+    const explanation = call.extras.explanation;
+    expect(explanation.problem).toBe("implement escalated after 3 attempt(s): no-progress");
+    expect(explanation.risk).toBe("continued retries risk wasting budget; 3 attempt(s) already made");
+    expect(explanation.observed.final_attempt_count).toBe(3);
+    expect(explanation.why_asking).toBe("no forward progress after 3 attempt(s) — stop-and-escalate");
+    // The real ask history: 2 prior + this one = 3, exactly matching the count above.
+    expect(explanation.attempts).toEqual([111, 222, 1_000_000]);
+  });
+
   test("first death with no prior mark (readProgressMark -1) always gets one revive — even at zero progress", () => {
     const reviveDispatch = recorder({ code: 0 });
     const r = reclaimDeadWorkIfPossible(orch, implementSignal({ status: "running" }), gateSeams({

--- a/plugins/dev/scripts/execution-core/recovery.test.mjs
+++ b/plugins/dev/scripts/execution-core/recovery.test.mjs
@@ -44,6 +44,8 @@ import {
   defaultAppendBootResumePhaseRegressionEvent,
   // CTL-1044
   defaultAppendOperatorEvent,
+  // 2026-08-03
+  detectSessionRateLimitHit,
 } from "./recovery.mjs";
 import { saveCursor } from "./event-cursor.mjs";
 import { dropProject } from "./eligible-set.mjs";
@@ -2467,6 +2469,60 @@ describe("reclaimDeadWorkIfPossible — CTL-736 progress gate", () => {
     expect(explanation.attempts).toEqual([111, 222, 1_000_000]);
   });
 
+  // 2026-08-03 fix: confirmed live across 11 real tickets on 2 hosts — every
+  // one's dead session transcript showed nothing but the Claude harness's own
+  // "You've hit your session limit" reply on every attempt (zero real tool
+  // use), yet the escalation read as generic "no forward progress," which
+  // reads as "the WORK is stuck" when the true story is "the ACCOUNT is
+  // rate-limited." This does NOT change the STOP/escalate decision or the
+  // ask-cap — only enriches the explanation once that decision is made.
+  test("a no-progress STOP whose dead session hit an account rate limit gets an accurate call_to_action + observed.likely_cause", () => {
+    const appendEscalatedEvent = recorder(undefined);
+    const r = reclaimDeadWorkIfPossible(orch, implementSignal({ status: "running" }), gateSeams({
+      progressMark: () => 2,
+      readProgressMark: () => 2, // no forward progress → no-progress STOP
+      appendEscalatedEvent,
+      detectRateLimit: (bgJobId) => {
+        expect(bgJobId).toBe("job-x"); // the seam receives the dead worker's OWN bg_job_id
+        return true;
+      },
+    }));
+    expect(r).toBe("no-progress-stopped");
+    const explanation = appendEscalatedEvent.calls[0][0].extras.explanation;
+    expect(explanation.observed.likely_cause).toBe("account-rate-limited");
+    expect(explanation.call_to_action).toMatch(/usage\/rate limit/);
+    expect(explanation.call_to_action).toMatch(/wait for the usage window to reset/);
+    // The underlying reason/cap machinery is UNCHANGED — still "no-progress".
+    expect(appendEscalatedEvent.calls[0][0].reason).toBe("no-progress");
+  });
+
+  test("a no-progress STOP whose dead session shows NO rate-limit signature keeps the original generic explanation", () => {
+    const appendEscalatedEvent = recorder(undefined);
+    const r = reclaimDeadWorkIfPossible(orch, implementSignal({ status: "running" }), gateSeams({
+      progressMark: () => 2,
+      readProgressMark: () => 2,
+      appendEscalatedEvent,
+      detectRateLimit: () => false,
+    }));
+    expect(r).toBe("no-progress-stopped");
+    const explanation = appendEscalatedEvent.calls[0][0].extras.explanation;
+    expect(explanation.observed.likely_cause).toBeUndefined();
+    expect(explanation.call_to_action).toBe("authorize CTL-9 implement to retry or change approach?");
+  });
+
+  test("a throwing detectRateLimit seam degrades to the generic explanation, never breaks the STOP", () => {
+    const appendEscalatedEvent = recorder(undefined);
+    const r = reclaimDeadWorkIfPossible(orch, implementSignal({ status: "running" }), gateSeams({
+      progressMark: () => 2,
+      readProgressMark: () => 2,
+      appendEscalatedEvent,
+      detectRateLimit: () => { throw new Error("boom"); },
+    }));
+    expect(r).toBe("no-progress-stopped");
+    const explanation = appendEscalatedEvent.calls[0][0].extras.explanation;
+    expect(explanation.observed.likely_cause).toBeUndefined();
+  });
+
   test("first death with no prior mark (readProgressMark -1) always gets one revive — even at zero progress", () => {
     const reviveDispatch = recorder({ code: 0 });
     const r = reclaimDeadWorkIfPossible(orch, implementSignal({ status: "running" }), gateSeams({
@@ -4306,6 +4362,143 @@ describe("resolvePhaseSessionId", () => {
     mkdirSync(join(jobsDir, "nolink"), { recursive: true });
     writeFileSync(join(jobsDir, "nolink", "state.json"), JSON.stringify({ state: "stopped" }));
     expect(resolvePhaseSessionId("nolink", { jobsDir })).toBeNull();
+  });
+});
+
+// 2026-08-03: detectSessionRateLimitHit — see recovery.mjs's own header comment
+// for the full incident (11 real tickets, 2 hosts, escalated as generic
+// "no-progress" when every dead session's transcript showed nothing but the
+// Claude harness's own rate-limit reply).
+describe("detectSessionRateLimitHit", () => {
+  function assistantLine(text) {
+    return JSON.stringify({ type: "assistant", message: { content: [{ type: "text", text }] } });
+  }
+
+  test("no bgJobId → false, resolveSession never called", () => {
+    const resolveSession = () => { throw new Error("must not be called"); };
+    expect(detectSessionRateLimitHit(null, { resolveSession })).toBe(false);
+    expect(detectSessionRateLimitHit(undefined, { resolveSession })).toBe(false);
+  });
+
+  test("resolveSession returns null (no resolvable session) → false", () => {
+    expect(
+      detectSessionRateLimitHit("job-x", { resolveSession: () => null, findTranscript: () => "/should-not-be-used" }),
+    ).toBe(false);
+  });
+
+  test("findTranscript returns null (no transcript on disk) → false", () => {
+    expect(
+      detectSessionRateLimitHit("job-x", {
+        resolveSession: () => "uuid-1",
+        findTranscript: () => null,
+        readFileSync: () => { throw new Error("must not read — no transcript path"); },
+      }),
+    ).toBe(false);
+  });
+
+  test("a transcript whose tail shows the literal session-limit reply → true", () => {
+    const lines = [
+      JSON.stringify({ type: "system", subtype: "init" }),
+      assistantLine("You've hit your session limit · resets 10:50pm (America/Chicago)"),
+    ].join("\n");
+    const result = detectSessionRateLimitHit("job-x", {
+      resolveSession: () => "uuid-1",
+      findTranscript: () => "/fake/transcript.jsonl",
+      readFileSync: () => lines,
+    });
+    expect(result).toBe(true);
+  });
+
+  test("the 'usage limit' phrasing variant also matches", () => {
+    const lines = assistantLine("You've hit your usage limit · resets tomorrow");
+    expect(
+      detectSessionRateLimitHit("job-x", {
+        resolveSession: () => "uuid-1",
+        findTranscript: () => "/fake/transcript.jsonl",
+        readFileSync: () => lines,
+      }),
+    ).toBe(true);
+  });
+
+  test("a transcript with real research content (no rate-limit phrase) → false", () => {
+    const lines = [
+      assistantLine("I'll start by reading the coordinator module..."),
+      JSON.stringify({ type: "assistant", message: { content: [{ type: "tool_use", name: "Read", input: {} }] } }),
+    ].join("\n");
+    expect(
+      detectSessionRateLimitHit("job-x", {
+        resolveSession: () => "uuid-1",
+        findTranscript: () => "/fake/transcript.jsonl",
+        readFileSync: () => lines,
+      }),
+    ).toBe(false);
+  });
+
+  test("the phrase appears only OUTSIDE the tail window → false (tail-only scan, not full-file)", () => {
+    const earlyHit = assistantLine("You've hit your session limit · resets soon");
+    const filler = Array.from({ length: 30 }, () => assistantLine("real work happening here")).join("\n");
+    const lines = [earlyHit, filler].join("\n");
+    expect(
+      detectSessionRateLimitHit("job-x", {
+        resolveSession: () => "uuid-1",
+        findTranscript: () => "/fake/transcript.jsonl",
+        readFileSync: () => lines,
+        tailLines: 5,
+      }),
+    ).toBe(false);
+  });
+
+  test("malformed JSON lines interspersed do not prevent finding the real match", () => {
+    const lines = [
+      "{not valid json",
+      assistantLine("You've hit your session limit · resets later"),
+      "another { broken line",
+    ].join("\n");
+    expect(
+      detectSessionRateLimitHit("job-x", {
+        resolveSession: () => "uuid-1",
+        findTranscript: () => "/fake/transcript.jsonl",
+        readFileSync: () => lines,
+      }),
+    ).toBe(true);
+  });
+
+  test("resolveSession throwing degrades to false, never throws", () => {
+    expect(
+      detectSessionRateLimitHit("job-x", { resolveSession: () => { throw new Error("boom"); } }),
+    ).toBe(false);
+  });
+
+  test("findTranscript throwing degrades to false, never throws", () => {
+    expect(
+      detectSessionRateLimitHit("job-x", {
+        resolveSession: () => "uuid-1",
+        findTranscript: () => { throw new Error("boom"); },
+      }),
+    ).toBe(false);
+  });
+
+  test("readFileSync throwing (unreadable transcript) degrades to false, never throws", () => {
+    expect(
+      detectSessionRateLimitHit("job-x", {
+        resolveSession: () => "uuid-1",
+        findTranscript: () => "/fake/transcript.jsonl",
+        readFileSync: () => { throw new Error("EACCES"); },
+      }),
+    ).toBe(false);
+  });
+
+  test("a non-assistant entry (e.g. user/system) mentioning the phrase in passing is ignored", () => {
+    const lines = [
+      JSON.stringify({ type: "user", message: { content: "did you hit your session limit earlier?" } }),
+    ].join("\n");
+    expect(
+      detectSessionRateLimitHit("job-x", {
+        resolveSession: () => "uuid-1",
+        findTranscript: () => "/fake/transcript.jsonl",
+        readFileSync: () => lines,
+      }),
+    ).toBe(false);
   });
 });
 


### PR DESCRIPTION
## Summary
Three related fixes in execution-core's dispatch/escalation path, found while investigating a batch of failed tickets in a real multi-tenant deployment. Already merged to thagale/catalyst#20 + thagale/catalyst#21; proposing upstream per the fork-and-upstream default.

**1. resolveThoughtsRoot never actually resolved the thoughts symlink target.** The real on-disk convention (`lib/provision-thoughts.sh`) is: `thoughts/` is a real directory whose immediate entries (`global`, `shared`) are themselves symlinks pointing outside the worktree — not "`thoughts` itself is a symlink" as the function assumed. Since `thoughts` isn't a symlink in the real shape, `realpathSync` just returned the unchanged worktree-local path, so the actual external write target never made it into codex's sandbox `writable_roots`. This has existed since codex-exec's original build (CTL-1457, 2026-07-14) with zero test coverage, only surfacing once research/plan phases actually started routing through codex-exec — which broke every research-phase artifact write for tickets caught in that routing.

**2. no-progress escalations always reported "0 attempt(s)" regardless of real retry history.** `escalateOnce`'s `finalAttemptCount` parameter is used both for the human-facing message AND (separately) the `attempts` array, which is built from the real ask history. For "no-progress" specifically, the caller passes a progress *quantity* (commits-ahead / doc size) instead of an attempt count — since the escalate decision fires when that quantity is unchanged, it's almost always 0. Confirmed across multiple real tickets: identical contradiction every time (3 real timestamps in `attempts`, "0 attempt(s)" in the message). Diagnosed as cosmetic-only — the actual 3-strikes retry/ask-cap logic runs and enforces correctly before this message is built — but still misleading for anyone trying to understand an escalation before answering it.

**3. no-progress escalations couldn't distinguish "genuinely stuck" from "the Claude account backing this bg executor hit its usage/session limit."** Root-caused a batch of 11 escalation-ask-cap tickets across a multi-host fleet to a single cause: the account hit its rate limit, and every retry attempt just replayed the harness's own "You've hit your session limit" reply with zero real work — which the existing progress gate correctly saw as "no forward progress" but had no way to label accurately. Added `detectSessionRateLimitHit`, which inspects the dead worker's own session transcript (tail-only, bounded) for that literal harness reply and, when found, gives the escalation an accurate `call_to_action` ("wait for the usage window to reset, or reroute to a different executor") and `observed.likely_cause: "account-rate-limited"` instead of the generic no-progress message.

Adding that new transcript read also tripped `event-log-read-guard.test.mjs`'s (CTL-1529) module-global taint-scan into flagging two pre-existing, unrelated reads (`readExecCoreBootEpoch`'s `daemon-boot.json`, `readBootEpoch`'s `/proc/stat`) that had never been flagged before — a false-positive side effect of the detector's over-approximation (its own header prefers this tradeoff). Allowlisted both with an honest reason + marker comments, matching the guard's own sanctioned remedy.

## Test plan
- [x] `codex-run-phase-agent.test.mjs` — 5 new tests (real on-disk shape with nested symlinks, legacy direct-symlink shape preserved, no-symlink dir, no thoughts dir, dangling symlink)
- [x] `recovery.test.mjs` — 1 regression test proving a 3rd-cycle no-progress escalation reports `final_attempt_count: 3` (matching `attempts.length`), not the old `0`/progress-quantity value; 15 new tests for `detectSessionRateLimitHit` (unit + wiring)
- [x] `event-log-read-guard.test.mjs` — 40/40 pass with the new allowlist entry
- [x] All three files: 427 pass, 0 fail

**Note on scope**: this PR is deliberately narrower than what shipped on the fork — it excludes the git-dir/common-dir writable-roots addition (already tracked separately as an open upstream PR, #2852) since `main` doesn't have that feature yet; this PR's `resolveWritableRoots` only adds the thoughts-symlink resolution.

Claude-Session: https://claude.ai/code/session_0126MqxP29TnmkskRPGXgzsQ