### PR TITLE
feat(dev): CTL-1616 fold the OAuth-mint trio + read-only 4th onto the secret contract (PR4)

### DIFF
--- a/plugins/dev/scripts/__tests__/catalyst-secret-contract.test.sh
+++ b/plugins/dev/scripts/__tests__/catalyst-secret-contract.test.sh
@@ -270,6 +270,128 @@ printf '%s' '{"catalyst":{"linear":{"bot":{"orchestrator":["nope"]}}}}' > "${TMP
 OUT="$(_run "CATALYST_LAYER2_CONFIG_FILE=${TMP_DIR}/l2cfg/config.json" 'catalyst_resolve_secret linear-orchestrator-actor')"
 expect_eq "linear-orchestrator-actor: an ARRAY is rejected (not a valid credential shape)" "|none|config-json" "$OUT"
 
+# --- linear-worker-actor: credentialEnvPair + legacyConfigTiers (CTL-1616 PR4) ----------
+# Every fixture here is mirrored byte-for-byte in __tests__/secret-contract-parity.test.sh's
+# linear-worker-actor cells and in lib/secret-contract.test.mjs's own describe block, proving
+# bash and JS agree — not merely each internally self-consistent.
+WA_DIR="${TMP_DIR}/wa"
+mkdir -p "$WA_DIR"
+WA_L2="${WA_DIR}/config.json"
+
+printf '%s' '{"catalyst":{"linear":{"bot":{"worker":{"clientId":"CFG","clientSecret":"CFGSEC"}}}}}' > "$WA_L2"
+OUT="$(_run "CATALYST_LAYER2_CONFIG_FILE=${WA_L2}" "CATALYST_LINEAR_AGENT_CLIENT_ID=EID" "CATALYST_LINEAR_AGENT_CLIENT_SECRET=ESEC" 'catalyst_resolve_secret linear-worker-actor')"
+expect_eq "linear-worker-actor: credentialEnvPair wins over every config tier when both halves present" \
+  '{"clientId":"EID","clientSecret":"ESEC"}|inherited|config-json' "$OUT"
+
+OUT="$(_run "CATALYST_LAYER2_CONFIG_FILE=${WA_L2}" "CATALYST_LINEAR_AGENT_CLIENT_ID=EID" 'catalyst_resolve_secret linear-worker-actor')"
+expect_eq "linear-worker-actor: credentialEnvPair with only ONE half set does not win — falls through" \
+  '{"clientId":"CFG","clientSecret":"CFGSEC"}|config-json|config-json' "$OUT"
+
+WA_REPO="${WA_DIR}/repo"
+mkdir -p "${WA_REPO}/.catalyst"
+printf '%s' '{"catalyst":{"projectKey":"proj1"}}' > "${WA_REPO}/.catalyst/config.json"
+printf '%s' '{"catalyst":{"linear":{"agent":{"clientId":"PERTEAM","clientSecret":"PERTEAMSEC"}}}}' > "${WA_DIR}/config-proj1.json"
+
+printf '%s' '{"catalyst":{"linear":{"bot":{"worker":{"clientId":"NEW","clientSecret":"NEWSEC"}},"agent":{"clientId":"GLOBALLEGACY","clientSecret":"GLOBALLEGACYSEC"}}}}' > "$WA_L2"
+OUT="$(_run "CATALYST_LAYER2_CONFIG_FILE=${WA_L2}" "cd '${WA_REPO}' && catalyst_resolve_secret linear-worker-actor")"
+expect_eq "linear-worker-actor: all-tiers-present — primary (NEW global bot.worker) wins" \
+  '{"clientId":"NEW","clientSecret":"NEWSEC"}|config-json|config-json' "$OUT"
+
+printf '%s' '{}' > "$WA_L2"
+OUT="$(_run "CATALYST_LAYER2_CONFIG_FILE=${WA_L2}" "cd '${WA_REPO}' && catalyst_resolve_secret linear-worker-actor")"
+expect_eq "linear-worker-actor: only-per-team-legacy-present — per-team tier wins" \
+  '{"clientId":"PERTEAM","clientSecret":"PERTEAMSEC"}|legacy-config-json|config-json' "$OUT"
+
+WA_REPO2="${WA_DIR}/repo2"
+mkdir -p "${WA_REPO2}/.catalyst"
+printf '%s' '{"catalyst":{"projectKey":"proj-no-file"}}' > "${WA_REPO2}/.catalyst/config.json"
+printf '%s' '{"catalyst":{"linear":{"agent":{"clientId":"GLOBALLEGACY","clientSecret":"GLOBALLEGACYSEC"}}}}' > "$WA_L2"
+OUT="$(_run "CATALYST_LAYER2_CONFIG_FILE=${WA_L2}" "cd '${WA_REPO2}' && catalyst_resolve_secret linear-worker-actor")"
+expect_eq "linear-worker-actor: only-global-legacy-present (projectKey resolves but its own per-team file is absent) — global-legacy tier wins" \
+  '{"clientId":"GLOBALLEGACY","clientSecret":"GLOBALLEGACYSEC"}|legacy-config-json|config-json' "$OUT"
+
+WA_NOANCESTRY="${WA_DIR}/no-ancestry"
+mkdir -p "$WA_NOANCESTRY"
+OUT="$(_run "CATALYST_LAYER2_CONFIG_FILE=${WA_L2}" "cd '${WA_NOANCESTRY}' && catalyst_resolve_secret linear-worker-actor" 2>/dev/null)"
+expect_eq "linear-worker-actor: no projectKey found anywhere — per-team tier's own fallback-to-global-path still resolves the global-only legacy layout" \
+  '{"clientId":"GLOBALLEGACY","clientSecret":"GLOBALLEGACYSEC"}|legacy-config-json|config-json' "$OUT"
+
+printf '%s' '{}' > "$WA_L2"
+OUT="$(_run "CATALYST_LAYER2_CONFIG_FILE=${WA_L2}" "cd '${WA_NOANCESTRY}' && catalyst_resolve_secret linear-worker-actor" 2>/dev/null)"
+expect_eq "linear-worker-actor: nothing present anywhere resolves to none" "|none|config-json" "$OUT"
+
+# --- B1 REGRESSION FIXTURES (CTL-1616 PR4 remediation): the OLD linear-comment-post.sh
+# advanced to the NEXT tier whenever clientId OR clientSecret was empty after a tier's read;
+# canonicalizeConfigJsonValue's "any non-null value wins" rule let a CREDENTIAL-FREE or
+# PARTIALLY-POPULATED object at a tier's path capture resolution instead, silently starving a
+# deeper, fully-populated tier — the caller then hard-failed on the empty fields rather than
+# falling through. Each fixture names the winning tier the OLD script would have picked (the
+# deeper FULL-credential tier) and proves the fixed engine agrees. Mirrored byte-for-byte in
+# lib/secret-contract.test.mjs and __tests__/secret-contract-parity.test.sh.
+WA_B1_REPO="${WA_DIR}/b1-repo"
+mkdir -p "${WA_B1_REPO}/.catalyst"
+printf '%s' '{"catalyst":{"projectKey":"proj1"}}' > "${WA_B1_REPO}/.catalyst/config.json"
+printf '%s' '{"catalyst":{"linear":{"agent":{"clientId":"PERTEAM","clientSecret":"PERTEAMSEC"}}}}' > "${WA_DIR}/config-proj1.json"
+
+printf '%s' '{"catalyst":{"linear":{"bot":{"worker":{"clientId":"partial-cid"}}}}}' > "$WA_L2"
+OUT="$(_run "CATALYST_LAYER2_CONFIG_FILE=${WA_L2}" "cd '${WA_B1_REPO}' && catalyst_resolve_secret linear-worker-actor")"
+expect_eq "B1: primary tier holds only clientId (no clientSecret) — per-team-legacy (full) wins" \
+  '{"clientId":"PERTEAM","clientSecret":"PERTEAMSEC"}|legacy-config-json|config-json' "$OUT"
+
+printf '%s' '{"catalyst":{"linear":{"bot":{"worker":{"webhookSecret":"whs","botUserId":"uuid-123"}}}}}' > "$WA_L2"
+OUT="$(_run "CATALYST_LAYER2_CONFIG_FILE=${WA_L2}" "cd '${WA_B1_REPO}' && catalyst_resolve_secret linear-worker-actor")"
+expect_eq "B1: primary tier holds a CREDENTIAL-FREE object ({webhookSecret,botUserId}) — per-team-legacy (full) wins" \
+  '{"clientId":"PERTEAM","clientSecret":"PERTEAMSEC"}|legacy-config-json|config-json' "$OUT"
+
+WA_B1_REPO_NOAGENT="${WA_DIR}/b1-repo-noagent"
+mkdir -p "${WA_B1_REPO_NOAGENT}/.catalyst"
+printf '%s' '{"catalyst":{"projectKey":"proj-noagent"}}' > "${WA_B1_REPO_NOAGENT}/.catalyst/config.json"
+# No config-proj-noagent.json file at all — the per-team-legacy tier's own file is absent.
+printf '%s' '{"catalyst":{"linear":{"bot":{"worker":{"clientId":"","clientSecret":""}},"agent":{"clientId":"GLOBALLEGACY","clientSecret":"GLOBALLEGACYSEC"}}}}' > "$WA_L2"
+OUT="$(_run "CATALYST_LAYER2_CONFIG_FILE=${WA_L2}" "cd '${WA_B1_REPO_NOAGENT}' && catalyst_resolve_secret linear-worker-actor")"
+expect_eq "B1: primary tier holds empty-string clientId/clientSecret — global-legacy (full) wins" \
+  '{"clientId":"GLOBALLEGACY","clientSecret":"GLOBALLEGACYSEC"}|legacy-config-json|config-json' "$OUT"
+
+printf '%s' '{"catalyst":{"linear":{"agent":{"clientId":"pid-only"}}}}' > "${WA_DIR}/config-proj1.json"
+printf '%s' '{"catalyst":{"linear":{"agent":{"clientId":"GLOBALLEGACY","clientSecret":"GLOBALLEGACYSEC"}}}}' > "$WA_L2"
+OUT="$(_run "CATALYST_LAYER2_CONFIG_FILE=${WA_L2}" "cd '${WA_B1_REPO}' && catalyst_resolve_secret linear-worker-actor")"
+expect_eq "B1: primary tier absent, per-team-legacy holds only clientId (no clientSecret) — global-legacy (full) wins" \
+  '{"clientId":"GLOBALLEGACY","clientSecret":"GLOBALLEGACYSEC"}|legacy-config-json|config-json' "$OUT"
+# Restore config-proj1.json to its full-credential shape for the B2 fixture below.
+printf '%s' '{"catalyst":{"linear":{"agent":{"clientId":"TEAMAGENT","clientSecret":"TEAMAGENTSEC"}}}}' > "${WA_DIR}/config-proj1.json"
+
+# --- B2 REGRESSION FIXTURE: no prior fixture populated BOTH legacy tiers with DISTINCT
+# credentials at once, so a swap of _CSC_LEGACY_TIERS's order survived every suite. (The
+# actual order-swap MUTATION is performed manually against this file on disk — see the
+# CTL-1616 PR4 remediation notes — since `_run` re-sources $LIB fresh in a child process for
+# every cell; mutating this suite's own in-memory _CSC_LEGACY_TIERS array would never reach
+# that child process and would silently no-op.)
+printf '%s' '{"catalyst":{"linear":{"agent":{"clientId":"GLOBALAGENT","clientSecret":"GLOBALAGENTSEC"}}}}' > "$WA_L2"
+OUT="$(_run "CATALYST_LAYER2_CONFIG_FILE=${WA_L2}" "cd '${WA_B1_REPO}' && catalyst_resolve_secret linear-worker-actor")"
+expect_eq "B2: BOTH legacy tiers present with DISTINCT full credentials — per-team-legacy wins (pins tier order)" \
+  '{"clientId":"TEAMAGENT","clientSecret":"TEAMAGENTSEC"}|legacy-config-json|config-json' "$OUT"
+
+# --- ROUND-2 B3 REGRESSION FIXTURES (both shapes empirically pinned against
+# `git show origin/main:.../linear-comment-post.sh` in a hermetic fixture — see the
+# requiredObjectFields row-field comment in lib/secret-contract.mjs for the two canon rules
+# and their pre-fold empirical results). Mirrored byte-for-byte in
+# __tests__/secret-contract-parity.test.sh and lib/secret-contract.test.mjs. Each fixture
+# ALSO populates a real legacy tier so the assertion proves genuine FALL-THROUGH to a deeper
+# tier, not merely "resolves to none".
+WA_NOANCESTRY_B3="${WA_DIR}/no-ancestry-b3"
+mkdir -p "$WA_NOANCESTRY_B3"
+printf '%s' '{"catalyst":{"linear":{"bot":{"worker":"{\"clientId\":\"str-cid\",\"clientSecret\":\"str-csec\"}"},"agent":{"clientId":"GLOBALLEGACY","clientSecret":"GLOBALLEGACYSEC"}}}}' > "$WA_L2"
+OUT="$(_run "CATALYST_LAYER2_CONFIG_FILE=${WA_L2}" "cd '${WA_NOANCESTRY_B3}' && catalyst_resolve_secret linear-worker-actor" 2>/dev/null)"
+expect_eq "CANON RULE 1: a bare STRING value at the primary tier — even one whose own text parses as a full credential object — falls through, never wins on string content" \
+  '{"clientId":"GLOBALLEGACY","clientSecret":"GLOBALLEGACYSEC"}|legacy-config-json|config-json' "$OUT"
+
+WA_NOANCESTRY_B3B="${WA_DIR}/no-ancestry-b3b"
+mkdir -p "$WA_NOANCESTRY_B3B"
+printf '%s\n' '{"catalyst":{"linear":{"bot":{"worker":{"clientId":"\n","clientSecret":"\n"}},"agent":{"clientId":"GLOBALLEGACY","clientSecret":"GLOBALLEGACYSEC"}}}}' > "$WA_L2"
+OUT="$(_run "CATALYST_LAYER2_CONFIG_FILE=${WA_L2}" "cd '${WA_NOANCESTRY_B3B}' && catalyst_resolve_secret linear-worker-actor" 2>/dev/null)"
+expect_eq "CANON RULE 2: newline-only clientId/clientSecret at the primary tier falls through, never wins on raw non-zero length" \
+  '{"clientId":"GLOBALLEGACY","clientSecret":"GLOBALLEGACYSEC"}|legacy-config-json|config-json' "$OUT"
+
 # --- TRAILING NEWLINES IN JSON VALUES (Codex finding fix) -------------------
 printf '%s' '{"groq":{"apiKey":"abc\n"}}' > "${TMP_DIR}/l2cfg/config.json"
 OUT="$(_run "CATALYST_LAYER2_CONFIG_FILE=${TMP_DIR}/l2cfg/config.json" 'catalyst_resolve_secret groq-api-key')"

--- a/plugins/dev/scripts/__tests__/secret-contract-parity.test.sh
+++ b/plugins/dev/scripts/__tests__/secret-contract-parity.test.sh
@@ -168,7 +168,11 @@ const id = process.env.CSC_PROBE_ID;
 const depMode = process.env.CSC_PROBE_DEP_MODE;
 const depInferred = process.env.CSC_PROBE_DEP_INFERRED;
 const deploymentMode = depMode ? { mode: depMode, inferred: depInferred === "true" } : undefined;
-const r = resolveSecret(id, { deploymentMode });
+// CTL-1616 PR4: linear-worker-actor's per-team-legacy tier walks cwd upward — CSC_PROBE_CWD
+// threads the same working directory the bash side is cd'd into (see _cell_in_dir) so both
+// sides walk from the IDENTICAL starting point.
+const cwd = process.env.CSC_PROBE_CWD;
+const r = resolveSecret(id, cwd ? { deploymentMode, cwd } : { deploymentMode });
 process.stdout.write((r.value ?? "") + "|" + (r.source ?? "") + "|" + (r.provider ?? ""));
 EOF
 
@@ -185,6 +189,23 @@ _cell() {
     catalyst_resolve_secret \"\$CSC_PROBE_ID\" \"\${CSC_PROBE_DEP_MODE:-}\" \"\${CSC_PROBE_DEP_INFERRED:-true}\"
   ")"
   NODE_OUT="$(env -i PATH="$PATH" HOME="$SANDBOX_HOME" "$@" node "$PROBE_RESOLVE_JS" 2>&1)"
+  expect_eq "$_name (bash==expected)" "$_expected" "$BASH_OUT"
+  expect_eq "$_name (node==expected)" "$_expected" "$NODE_OUT"
+}
+
+# _cell_in_dir DIR NAME EXPECTED [ENV_VAR=VAL ...] -- like _cell, but both languages resolve
+# with their working-directory equivalent (bash $PWD / JS cwd option) set to DIR first —
+# exercises linear-worker-actor's per-team-legacy tier (CTL-1616 PR4), which walks that
+# directory upward for a .catalyst/config.json.
+_cell_in_dir() {
+  local _dir="$1" _name="$2" _expected="$3"
+  shift 3
+  local BASH_OUT NODE_OUT
+  BASH_OUT="$(cd "$_dir" && env -i PATH="$PATH" HOME="$SANDBOX_HOME" "$@" bash -c "
+    source '$LIB'
+    catalyst_resolve_secret \"\$CSC_PROBE_ID\" \"\${CSC_PROBE_DEP_MODE:-}\" \"\${CSC_PROBE_DEP_INFERRED:-true}\"
+  ")"
+  NODE_OUT="$(env -i PATH="$PATH" HOME="$SANDBOX_HOME" CSC_PROBE_CWD="$_dir" "$@" node "$PROBE_RESOLVE_JS" 2>&1)"
   expect_eq "$_name (bash==expected)" "$_expected" "$BASH_OUT"
   expect_eq "$_name (node==expected)" "$_expected" "$NODE_OUT"
 }
@@ -340,12 +361,156 @@ _cell "config-json: ACTOR ROW SHAPE — an ARRAY is rejected on both sides (not 
 
 # B5: previously-uncovered row — linear-worker-actor (config-json, distinct configJsonPath
 # from linear-orchestrator-actor — the judge-unanimous "never collapse these two" graft).
-printf '%s' '{"catalyst":{"linear":{"bot":{"worker":"{\"apiKey\":\"w\"}"}}}}' > "$L2_FILE"
-_cell "config-json: reads the dotted path (linear-worker-actor)" \
-  '{"apiKey":"w"}|config-json|config-json' \
+# CTL-1616 PR4 remediation (B1 fix): this row now declares requiredObjectFields
+# ({clientId, clientSecret}), so — unlike linear-orchestrator-actor above — a bare STRING
+# value at its path can never WIN the gate, in EITHER engine (round-2 CANON RULE 1, see the
+# requiredObjectFields row-field comment in lib/secret-contract.mjs) — it always falls
+# through to the next tier, even when the string's own text parses as a full credential
+# object (see the dedicated "CANON RULE 1" cell below, which pins that exact shape).
+# CORRECTION (round-2): the claim that used to live here — that the OLD script's own
+# `jq '.clientId // empty'` on a string primitive "errors and yields empty" — is only half
+# right. Verified empirically (`git show origin/main:.../linear-comment-post.sh` run in a
+# hermetic fixture): jq exits 5 trying to INDEX a string with `.clientId`, and under that
+# script's own `set -euo pipefail` this is NOT a quiet per-tier fallthrough — it CRASHES the
+# whole script (nonzero exit, comment never posted). "Falls through" is the canon this
+# contract deliberately picks for BOTH engines instead (matches current JS, never aborts) —
+# it is not a literal reproduction of the pre-fold script's crash. Fixture below updated to
+# the row's real credential-object shape to keep exercising "distinct configJsonPath,
+# resolved independently of orchestrator's" without contradicting the B1 fix.
+printf '%s' '{"catalyst":{"linear":{"bot":{"worker":{"clientId":"w-cid","clientSecret":"w-csec"}}}}}' > "$L2_FILE"
+_cell "config-json: reads the dotted path (linear-worker-actor, credential-object shape)" \
+  '{"clientId":"w-cid","clientSecret":"w-csec"}|config-json|config-json' \
   CSC_PROBE_ID=linear-worker-actor "CATALYST_LAYER2_CONFIG_FILE=${L2_FILE}"
 printf '%s' '{}' > "$L2_FILE"
 _cell "config-json: linear-worker-actor absent path falls through to none" "|none|config-json" \
+  CSC_PROBE_ID=linear-worker-actor "CATALYST_LAYER2_CONFIG_FILE=${L2_FILE}"
+
+# ─── linear-worker-actor: credentialEnvPair + legacyConfigTiers (CTL-1616 PR4) ────────────
+# linear-comment-post.sh's THREE config tiers (NEW global bot.worker → OLD per-team agent →
+# OLD global agent) + its env-credential-pair tier, folded onto this row. Precedence fixtures
+# for ALL-TIERS-PRESENT / ONLY-LEGACY-PRESENT / ONLY-ENV-PRESENT / NOTHING-PRESENT (design
+# §9 PR4 success criterion), proven byte-for-byte identical bash==JS — the point of this
+# suite. Mirrored in lib/secret-contract.test.mjs and
+# __tests__/catalyst-secret-contract.test.sh.
+_cell "linear-worker-actor: only-env-present — credentialEnvPair wins" \
+  '{"clientId":"EID","clientSecret":"ESEC"}|inherited|config-json' \
+  CSC_PROBE_ID=linear-worker-actor "CATALYST_LAYER2_CONFIG_FILE=${L2_FILE}" \
+  "CATALYST_LINEAR_AGENT_CLIENT_ID=EID" "CATALYST_LINEAR_AGENT_CLIENT_SECRET=ESEC"
+
+printf '%s' '{"catalyst":{"linear":{"bot":{"worker":{"clientId":"CFG","clientSecret":"CFGSEC"}}}}}' > "$L2_FILE"
+_cell "linear-worker-actor: credentialEnvPair with only ONE half set does not win — falls through to config" \
+  '{"clientId":"CFG","clientSecret":"CFGSEC"}|config-json|config-json' \
+  CSC_PROBE_ID=linear-worker-actor "CATALYST_LAYER2_CONFIG_FILE=${L2_FILE}" \
+  "CATALYST_LINEAR_AGENT_CLIENT_ID=EID"
+
+WA_REPO="${L2_DIR}/wa-repo"
+mkdir -p "${WA_REPO}/.catalyst"
+printf '%s' '{"catalyst":{"projectKey":"proj1"}}' > "${WA_REPO}/.catalyst/config.json"
+printf '%s' '{"catalyst":{"linear":{"agent":{"clientId":"PERTEAM","clientSecret":"PERTEAMSEC"}}}}' > "${L2_DIR}/config-proj1.json"
+
+printf '%s' '{"catalyst":{"linear":{"bot":{"worker":{"clientId":"NEW","clientSecret":"NEWSEC"}},"agent":{"clientId":"GLOBALLEGACY","clientSecret":"GLOBALLEGACYSEC"}}}}' > "$L2_FILE"
+_cell_in_dir "$WA_REPO" "linear-worker-actor: all-tiers-present — primary (NEW global bot.worker) wins" \
+  '{"clientId":"NEW","clientSecret":"NEWSEC"}|config-json|config-json' \
+  CSC_PROBE_ID=linear-worker-actor "CATALYST_LAYER2_CONFIG_FILE=${L2_FILE}"
+
+printf '%s' '{}' > "$L2_FILE"
+_cell_in_dir "$WA_REPO" "linear-worker-actor: only-per-team-legacy-present — per-team tier wins" \
+  '{"clientId":"PERTEAM","clientSecret":"PERTEAMSEC"}|legacy-config-json|config-json' \
+  CSC_PROBE_ID=linear-worker-actor "CATALYST_LAYER2_CONFIG_FILE=${L2_FILE}"
+
+WA_REPO2="${L2_DIR}/wa-repo2"
+mkdir -p "${WA_REPO2}/.catalyst"
+printf '%s' '{"catalyst":{"projectKey":"proj-no-file"}}' > "${WA_REPO2}/.catalyst/config.json"
+printf '%s' '{"catalyst":{"linear":{"agent":{"clientId":"GLOBALLEGACY","clientSecret":"GLOBALLEGACYSEC"}}}}' > "$L2_FILE"
+_cell_in_dir "$WA_REPO2" "linear-worker-actor: only-global-legacy-present (own per-team file absent) — global-legacy tier wins" \
+  '{"clientId":"GLOBALLEGACY","clientSecret":"GLOBALLEGACYSEC"}|legacy-config-json|config-json' \
+  CSC_PROBE_ID=linear-worker-actor "CATALYST_LAYER2_CONFIG_FILE=${L2_FILE}"
+
+WA_NOANCESTRY="${L2_DIR}/wa-no-ancestry"
+mkdir -p "$WA_NOANCESTRY"
+_cell_in_dir "$WA_NOANCESTRY" "linear-worker-actor: no projectKey anywhere — per-team tier's own fallback-to-global-path still resolves a global-only legacy layout" \
+  '{"clientId":"GLOBALLEGACY","clientSecret":"GLOBALLEGACYSEC"}|legacy-config-json|config-json' \
+  CSC_PROBE_ID=linear-worker-actor "CATALYST_LAYER2_CONFIG_FILE=${L2_FILE}"
+
+printf '%s' '{}' > "$L2_FILE"
+_cell_in_dir "$WA_NOANCESTRY" "linear-worker-actor: nothing-present — resolves to none" \
+  "|none|config-json" \
+  CSC_PROBE_ID=linear-worker-actor "CATALYST_LAYER2_CONFIG_FILE=${L2_FILE}"
+
+# ─── B1 REGRESSION FIXTURES (CTL-1616 PR4 remediation): the OLD linear-comment-post.sh
+# advanced to the NEXT tier whenever clientId OR clientSecret was empty after a tier's read;
+# canonicalizeConfigJsonValue's "any non-null value wins" rule let a CREDENTIAL-FREE or
+# PARTIALLY-POPULATED object at a tier's path capture resolution instead, silently starving a
+# deeper, fully-populated tier — the caller then hard-failed on the empty fields rather than
+# falling through. Each fixture names the winning tier the OLD script would have picked (the
+# deeper FULL-credential tier) and proves the fixed engine agrees. Mirrored byte-for-byte in
+# lib/secret-contract.test.mjs and __tests__/catalyst-secret-contract.test.sh.
+printf '%s' '{"catalyst":{"linear":{"bot":{"worker":{"clientId":"partial-cid"}}}}}' > "$L2_FILE"
+_cell_in_dir "$WA_REPO" "B1: primary tier holds only clientId (no clientSecret) — per-team-legacy (full) wins" \
+  '{"clientId":"PERTEAM","clientSecret":"PERTEAMSEC"}|legacy-config-json|config-json' \
+  CSC_PROBE_ID=linear-worker-actor "CATALYST_LAYER2_CONFIG_FILE=${L2_FILE}"
+
+printf '%s' '{"catalyst":{"linear":{"bot":{"worker":{"webhookSecret":"whs","botUserId":"uuid-123"}}}}}' > "$L2_FILE"
+_cell_in_dir "$WA_REPO" "B1: primary tier holds a CREDENTIAL-FREE object ({webhookSecret,botUserId}) — per-team-legacy (full) wins" \
+  '{"clientId":"PERTEAM","clientSecret":"PERTEAMSEC"}|legacy-config-json|config-json' \
+  CSC_PROBE_ID=linear-worker-actor "CATALYST_LAYER2_CONFIG_FILE=${L2_FILE}"
+
+WA_REPO_NOAGENT="${L2_DIR}/wa-repo-noagent"
+mkdir -p "${WA_REPO_NOAGENT}/.catalyst"
+printf '%s' '{"catalyst":{"projectKey":"proj-noagent"}}' > "${WA_REPO_NOAGENT}/.catalyst/config.json"
+# No config-proj-noagent.json file at all — the per-team-legacy tier's own file is absent.
+printf '%s' '{"catalyst":{"linear":{"bot":{"worker":{"clientId":"","clientSecret":""}},"agent":{"clientId":"GLOBALLEGACY","clientSecret":"GLOBALLEGACYSEC"}}}}' > "$L2_FILE"
+_cell_in_dir "$WA_REPO_NOAGENT" "B1: primary tier holds empty-string clientId/clientSecret — global-legacy (full) wins" \
+  '{"clientId":"GLOBALLEGACY","clientSecret":"GLOBALLEGACYSEC"}|legacy-config-json|config-json' \
+  CSC_PROBE_ID=linear-worker-actor "CATALYST_LAYER2_CONFIG_FILE=${L2_FILE}"
+
+printf '%s' '{"catalyst":{"linear":{"agent":{"clientId":"pid-only"}}}}' > "${L2_DIR}/config-proj1.json"
+printf '%s' '{"catalyst":{"linear":{"agent":{"clientId":"GLOBALLEGACY","clientSecret":"GLOBALLEGACYSEC"}}}}' > "$L2_FILE"
+_cell_in_dir "$WA_REPO" "B1: primary tier absent, per-team-legacy holds only clientId (no clientSecret) — global-legacy (full) wins" \
+  '{"clientId":"GLOBALLEGACY","clientSecret":"GLOBALLEGACYSEC"}|legacy-config-json|config-json' \
+  CSC_PROBE_ID=linear-worker-actor "CATALYST_LAYER2_CONFIG_FILE=${L2_FILE}"
+# Restore config-proj1.json to its full-credential shape for the B2 fixture below.
+printf '%s' '{"catalyst":{"linear":{"agent":{"clientId":"TEAMAGENT","clientSecret":"TEAMAGENTSEC"}}}}' > "${L2_DIR}/config-proj1.json"
+
+# ─── B2 REGRESSION FIXTURE: no prior fixture populated BOTH legacy tiers with DISTINCT
+# credentials at once, so a swap of _CSC_LEGACY_TIERS's order survived every suite.
+printf '%s' '{"catalyst":{"linear":{"agent":{"clientId":"GLOBALAGENT","clientSecret":"GLOBALAGENTSEC"}}}}' > "$L2_FILE"
+_cell_in_dir "$WA_REPO" "B2: BOTH legacy tiers present with DISTINCT full credentials — per-team-legacy wins (pins tier order)" \
+  '{"clientId":"TEAMAGENT","clientSecret":"TEAMAGENTSEC"}|legacy-config-json|config-json' \
+  CSC_PROBE_ID=linear-worker-actor "CATALYST_LAYER2_CONFIG_FILE=${L2_FILE}"
+
+# ─── ROUND-2 B3 REGRESSION FIXTURES: the two proven cross-engine divergences on
+# linear-worker-actor's requiredObjectFields gate (both empirically pinned against
+# `git show origin/main:.../linear-comment-post.sh` in a hermetic fixture — see the
+# requiredObjectFields row-field comment in lib/secret-contract.mjs for the two canon rules
+# and their pre-fold empirical results). Mirrored byte-for-byte in
+# __tests__/catalyst-secret-contract.test.sh and lib/secret-contract.test.mjs. Each fixture
+# ALSO populates a real legacy tier so the assertion proves genuine FALL-THROUGH to a deeper
+# tier on BOTH sides — not merely "resolves to none" (which a broken engine could also
+# produce by a different, wrong path).
+WA_NOANCESTRY_B3="${L2_DIR}/no-ancestry-b3"
+mkdir -p "$WA_NOANCESTRY_B3"
+printf '%s' '{"catalyst":{"linear":{"bot":{"worker":"{\"clientId\":\"str-cid\",\"clientSecret\":\"str-csec\"}"},"agent":{"clientId":"GLOBALLEGACY","clientSecret":"GLOBALLEGACYSEC"}}}}' > "$L2_FILE"
+_cell_in_dir "$WA_NOANCESTRY_B3" "CANON RULE 1: a bare STRING value at the primary tier — even one whose own text parses as a full credential object — falls through, never wins on string content" \
+  '{"clientId":"GLOBALLEGACY","clientSecret":"GLOBALLEGACYSEC"}|legacy-config-json|config-json' \
+  CSC_PROBE_ID=linear-worker-actor "CATALYST_LAYER2_CONFIG_FILE=${L2_FILE}"
+
+WA_NOANCESTRY_B3B="${L2_DIR}/no-ancestry-b3b"
+mkdir -p "$WA_NOANCESTRY_B3B"
+printf '%s' '{"catalyst":{"linear":{"bot":{"worker":{"clientId":"\n","clientSecret":"\n"}},"agent":{"clientId":"GLOBALLEGACY","clientSecret":"GLOBALLEGACYSEC"}}}}' > "$L2_FILE"
+_cell_in_dir "$WA_NOANCESTRY_B3B" "CANON RULE 2: newline-only clientId/clientSecret at the primary tier falls through, never wins on raw non-zero length" \
+  '{"clientId":"GLOBALLEGACY","clientSecret":"GLOBALLEGACYSEC"}|legacy-config-json|config-json' \
+  CSC_PROBE_ID=linear-worker-actor "CATALYST_LAYER2_CONFIG_FILE=${L2_FILE}"
+
+# CANON RULE 2, CR-ONLY variant (round-3 verify advisory A-CR-COVERAGE): a bash $()
+# capture strips only trailing \n, NOT \r — the exact asymmetry the jq sub("[\r\n]+$")
+# approach exists to close. Without this cell, reverting the bash field check to a
+# $()-capture form survives the whole suite while diverging cross-engine on "\r".
+WA_NOANCESTRY_B3C="${L2_DIR}/no-ancestry-b3c"
+mkdir -p "$WA_NOANCESTRY_B3C"
+printf '%s' '{"catalyst":{"linear":{"bot":{"worker":{"clientId":"\r","clientSecret":"\r"}},"agent":{"clientId":"GLOBALLEGACY","clientSecret":"GLOBALLEGACYSEC"}}}}' > "$L2_FILE"
+_cell_in_dir "$WA_NOANCESTRY_B3C" "CANON RULE 2 (CR-only): carriage-return-only fields fall through identically — pins the jq-side EOL strip against a \$()-capture regression" \
+  '{"clientId":"GLOBALLEGACY","clientSecret":"GLOBALLEGACYSEC"}|legacy-config-json|config-json' \
   CSC_PROBE_ID=linear-worker-actor "CATALYST_LAYER2_CONFIG_FILE=${L2_FILE}"
 
 # Hostile probe: a JSON string value carrying an embedded NUL escape. jq's own parser

--- a/plugins/dev/scripts/execution-core/linear-remint.mjs
+++ b/plugins/dev/scripts/execution-core/linear-remint.mjs
@@ -4,11 +4,14 @@
 // otherwise fail every Linear call until restarted. Secrets hygiene: the
 // clientSecret/token are read into variables and never logged (house style:
 // ratelimit-poller.mjs).
+//
+// CTL-1616 PR4: defaultLayer2Path/readOrchestratorCreds are folded onto the shared secret
+// contract (resolveLayer2Path / resolveSecret("linear-orchestrator-actor")) so the Layer-2
+// chain + config-path read are defined ONCE; the mint mechanics below (buildMintCurlArgs,
+// defaultMint/defaultMintAsync) are UNCHANGED.
 import { spawn, spawnSync } from "node:child_process";
-import { readFileSync } from "node:fs";
-import { homedir } from "node:os";
-import { resolve } from "node:path";
 import { log } from "./config.mjs";
+import { registerRearmHook, resolveLayer2Path, resolveSecret } from "../lib/secret-contract.mjs";
 
 const OAUTH_ENDPOINT = "https://api.linear.app/oauth/token";
 const MINT_SCOPE = "read,write,comments:create,app:assignable,app:mentionable";
@@ -34,36 +37,40 @@ export function isBatchAuthError(errors) {
   );
 }
 
-// defaultLayer2Path — the FULL Layer-2 selection chain (install-lifecycle.mjs
-// order: CATALYST_LAYER2_CONFIG_FILE > CATALYST_MACHINE_CONFIG >
-// $XDG_CONFIG_HOME/catalyst/config.json > ~/.config/catalyst/config.json).
-// CTL-1577 round 2: previously only the first env override was honored, so a
-// daemon launched with MACHINE_CONFIG/XDG would startup-mint fine (the bash
-// helper resolves the chain) but find NO creds at re-mint time.
-function defaultLayer2Path() {
-  return (
-    process.env.CATALYST_LAYER2_CONFIG_FILE ||
-    process.env.CATALYST_MACHINE_CONFIG ||
-    (process.env.XDG_CONFIG_HOME
-      ? resolve(process.env.XDG_CONFIG_HOME, "catalyst", "config.json")
-      : resolve(homedir(), ".config", "catalyst", "config.json"))
-  );
+// defaultLayer2Path — CTL-1616 PR4: delegates to the shared secret contract's
+// resolveLayer2Path, which implements this SAME chain (CATALYST_LAYER2_CONFIG_FILE >
+// CATALYST_MACHINE_CONFIG > $XDG_CONFIG_HOME/catalyst/config.json >
+// ~/.config/catalyst/config.json — install-lifecycle.mjs order). Kept as a named export
+// (rather than inlined at its one call site) for back-compat with any existing import.
+export function defaultLayer2Path() {
+  return resolveLayer2Path();
 }
 
-export function readOrchestratorCreds(layer2Path = defaultLayer2Path()) {
+// readOrchestratorCreds — CTL-1616 PR4: the config-path + clientId/clientSecret READ is
+// folded onto resolveSecret("linear-orchestrator-actor"), which resolves through the
+// IDENTICAL Layer-2 chain and reads the SAME catalyst.linear.bot.orchestrator dotted path.
+// `layer2Path` is accepted (and still honored) for back-compat with any existing caller that
+// passes an explicit override path — it is threaded through as
+// CATALYST_LAYER2_CONFIG_FILE (the highest-priority link in the chain, so an explicit
+// override here still wins over ambient env).
+export function readOrchestratorCreds(layer2Path) {
+  const env = layer2Path
+    ? { ...process.env, CATALYST_LAYER2_CONFIG_FILE: layer2Path }
+    : process.env;
+  const resolved = resolveSecret("linear-orchestrator-actor", { env });
+  if (typeof resolved.value !== "string" || resolved.value.length === 0) return null;
   try {
-    const parsed = JSON.parse(readFileSync(layer2Path, "utf8"));
-    const o = parsed?.catalyst?.linear?.bot?.orchestrator;
+    const parsed = JSON.parse(resolved.value);
     if (
-      typeof o?.clientId === "string" &&
-      o.clientId &&
-      typeof o?.clientSecret === "string" &&
-      o.clientSecret
+      typeof parsed?.clientId === "string" &&
+      parsed.clientId &&
+      typeof parsed?.clientSecret === "string" &&
+      parsed.clientSecret
     ) {
-      return { clientId: o.clientId, clientSecret: o.clientSecret };
+      return { clientId: parsed.clientId, clientSecret: parsed.clientSecret };
     }
   } catch {
-    /* unreadable/malformed → null (fail-open) */
+    /* malformed canonicalized value — should be unreachable; fail-open */
   }
   return null;
 }
@@ -150,6 +157,34 @@ export function createReminter({
 
 // Process-wide singleton (same pattern as linearBreaker).
 export const linearReminter = createReminter();
+
+// createOrchestratorActorRearmHook — CTL-1616 PR4: adapts ANY reminter's `.attempt()` (the
+// createReminter/createAsyncReminter cooldown/read/mint/apply contract is UNCHANGED — this
+// wraps it, never replaces it) into the registerRearmHook seam's synchronous
+// `({env, deploymentMode}) => {rearmed}` contract. A pure function so it is unit-testable
+// against a fully fake reminter — never the real `linearReminter` singleton — with zero risk
+// of a hermetic test triggering a genuine network mint against api.linear.app.
+export function createOrchestratorActorRearmHook(reminter) {
+  return () => ({ rearmed: reminter.attempt() });
+}
+
+// Wire the process-wide sync reminter into the secret contract's rearm-hook seam (design
+// §8/§9: "the cooldown reminters register as the row's on-401 rearm hook, unchanged in
+// shape"). This is the reminter's mechanics UNCHANGED — only its existing .attempt() is now
+// ALSO reachable through armSecret("linear-orchestrator-actor"), the same reminter
+// withAuthRemint already drives reactively on an observed 401 below. registerRearmHook's own
+// capability-ceiling check (design §6 rule 1) is what keeps a hookless re-armable row honest;
+// this call is what satisfies it for this row.
+//
+// linearAsyncReminter (below) is DELIBERATELY NOT registered through this seam:
+// registerRearmHook's contract is synchronous (armSecret reads `hook(...).rearmed`
+// immediately, never awaiting), while the async reminter exists specifically so the broker's
+// event loop is never blocked by a slow OAuth endpoint (CTL-1577 round 2) — forcing it
+// through a synchronous hook would mean either blocking that event loop (defeating the
+// reason it is async) or misreporting `rearmed` while a mint is still in flight. It keeps
+// functioning exactly as today via withAuthRemint(rawExec, { reminter: linearAsyncReminter })
+// in the broker's cache-reconcile path, untouched by this PR.
+registerRearmHook("linear-orchestrator-actor", createOrchestratorActorRearmHook(linearReminter));
 
 // defaultMintAsync — non-blocking mint (spawn, not spawnSync) for daemons whose
 // event loop must stay free during a slow OAuth endpoint (the broker routes

--- a/plugins/dev/scripts/execution-core/linear-remint.test.mjs
+++ b/plugins/dev/scripts/execution-core/linear-remint.test.mjs
@@ -8,13 +8,17 @@ import {
   isAuthError,
   isBatchAuthError,
   readOrchestratorCreds,
+  defaultLayer2Path,
   buildMintCurlArgs,
   parseMintResponse,
   createReminter,
   createAsyncReminter,
+  createOrchestratorActorRearmHook,
+  linearReminter,
   withAuthRemint,
 } from "./linear-remint.mjs";
 import { createLinearBreaker, withBreaker } from "./linear-breaker.mjs";
+import { resolveLayer2Path, armSecret, registerRearmHook, resetArmState } from "../lib/secret-contract.mjs";
 
 const silentLogger = { warn() {}, info() {}, error() {} };
 
@@ -130,6 +134,70 @@ describe("readOrchestratorCreds", () => {
   test("null when orchestrator key is entirely absent", () => {
     const p = writeCfg({ catalyst: { linear: { bot: {} } } });
     expect(readOrchestratorCreds(p)).toBeNull();
+  });
+});
+
+// ── defaultLayer2Path (CTL-1616 PR4 fold) ─────────────────────────────────────
+// defaultLayer2Path/readOrchestratorCreds are folded onto the shared secret contract
+// (resolveLayer2Path / resolveSecret("linear-orchestrator-actor")) so the Layer-2 chain +
+// config-path read are defined ONCE. This asserts the delegation, not a re-implementation.
+describe("defaultLayer2Path (CTL-1616 PR4 fold)", () => {
+  test("delegates to the shared secret contract's resolveLayer2Path — no second chain", () => {
+    expect(defaultLayer2Path()).toBe(resolveLayer2Path());
+  });
+});
+
+// ── createOrchestratorActorRearmHook (CTL-1616 PR4) ───────────────────────────
+// Pure adapter, unit-tested against a FAKE reminter only — never linearReminter (the real
+// process-wide singleton), which would attempt a genuine network mint against api.linear.app
+// using whatever real Layer-2 credentials the host running this test happens to have.
+describe("createOrchestratorActorRearmHook (CTL-1616 PR4)", () => {
+  test("adapts a reminter whose attempt() returns true into {rearmed:true}", () => {
+    expect(createOrchestratorActorRearmHook({ attempt: () => true })({ env: {} })).toEqual({ rearmed: true });
+  });
+  test("adapts a reminter whose attempt() returns false into {rearmed:false}", () => {
+    expect(createOrchestratorActorRearmHook({ attempt: () => false })({ env: {} })).toEqual({ rearmed: false });
+  });
+  test("end-to-end against a fully injected createReminter — mint/readCreds/applyToken never touch the real network", () => {
+    let mintCalls = 0;
+    const fakeReminter = createReminter({
+      readCreds: () => ({ clientId: "c", clientSecret: "s" }),
+      mint: () => {
+        mintCalls += 1;
+        return "tok";
+      },
+      applyToken: () => {},
+      logger: silentLogger,
+    });
+    expect(createOrchestratorActorRearmHook(fakeReminter)({ env: {} })).toEqual({ rearmed: true });
+    expect(mintCalls).toBe(1);
+  });
+});
+
+// ── linear-orchestrator-actor rearm-hook wiring (CTL-1616 PR4) ────────────────
+// Exercises the ACTUAL registerRearmHook/armSecret seam this row is wired through in
+// production (design §8/§9: "the cooldown reminters register as the row's on-401 rearm
+// hook") — with an INJECTED fake reminter, never the real linearReminter singleton.
+describe("linear-orchestrator-actor rearm-hook wiring (CTL-1616 PR4)", () => {
+  afterEach(() => {
+    // Restore production wiring exactly as the module registers it at import time, so this
+    // describe block leaves no cross-test contamination for anything that runs after it in
+    // the same process.
+    registerRearmHook("linear-orchestrator-actor", createOrchestratorActorRearmHook(linearReminter));
+    resetArmState("linear-orchestrator-actor");
+  });
+
+  test("armSecret routes through the registered hook (armed path), not the hookless-degrade path", () => {
+    let attempts = 0;
+    const fakeReminter = { attempt: () => { attempts += 1; return true; } };
+    registerRearmHook("linear-orchestrator-actor", createOrchestratorActorRearmHook(fakeReminter));
+    expect(armSecret("linear-orchestrator-actor", { env: {} })).toEqual({ armed: true, rotated: true, restartRequired: false });
+    expect(attempts).toBe(1);
+  });
+
+  test("a false attempt() (cooldown active / no creds / mint failed) reports no rotation", () => {
+    registerRearmHook("linear-orchestrator-actor", createOrchestratorActorRearmHook({ attempt: () => false }));
+    expect(armSecret("linear-orchestrator-actor", { env: {} })).toEqual({ armed: false, rotated: false, restartRequired: false });
   });
 });
 

--- a/plugins/dev/scripts/lib/catalyst-secret-contract.sh
+++ b/plugins/dev/scripts/lib/catalyst-secret-contract.sh
@@ -60,6 +60,55 @@ _CSC_FAMILY_PREFIX=(
 _CSC_DEFAULT_LOCAL_PATH=(
   "" "" "" "" "" "" "" "" "" "" ".config/catalyst/age.key"
 )
+# CTL-1616 PR4 (append-only, linear-worker-actor only): the env-credential-pair tier
+# ("IDVAR:SECRETVAR") and the two legacy config-json fallback tiers
+# ("scope:path|scope:path"), mirroring secret-contract.mjs's credentialEnvPair/
+# legacyConfigTiers row fields exactly. Empty string for every row that doesn't declare one.
+_CSC_CREDENTIAL_ENV_PAIR=(
+  "" "" "" "" "" "" "" "CATALYST_LINEAR_AGENT_CLIENT_ID:CATALYST_LINEAR_AGENT_CLIENT_SECRET" "" "" ""
+)
+_CSC_LEGACY_TIERS=(
+  "" "" "" "" "" "" "" "per-team-legacy:catalyst.linear.agent|global-legacy:catalyst.linear.agent" "" "" ""
+)
+# _CSC_REQUIRED_OBJECT_FIELDS — CTL-1616 PR4 remediation (B1 fix). Space-joined field names
+# a row's OBJECT-shaped config-json value must hold, ALL non-empty, before a tier is allowed
+# to WIN — mirrors secret-contract.mjs's row-declared requiredObjectFields exactly (a
+# generic, row-declared gate, never a hardcoded id check). Empty string for every row that
+# doesn't declare one (only linear-worker-actor does today).
+_CSC_REQUIRED_OBJECT_FIELDS=(
+  "" "" "" "" "" "" "" "clientId clientSecret" "" "" ""
+)
+
+# catalyst_secret_required_object_fields ID — echoes the space-joined required field list
+# (may echo nothing).
+catalyst_secret_required_object_fields() {
+  local _i
+  _i="$(_csc_index_of "$1")" || { printf ''; return 1; }
+  printf '%s' "${_CSC_REQUIRED_OBJECT_FIELDS[$_i]}"
+}
+
+# catalyst_secret_credential_env_pair ID — echoes "IDVAR SECRETVAR" (space-joined) or nothing.
+catalyst_secret_credential_env_pair() {
+  local _i _v
+  _i="$(_csc_index_of "$1")" || return 1
+  _v="${_CSC_CREDENTIAL_ENV_PAIR[$_i]}"
+  [[ -n "$_v" ]] && printf '%s' "${_v/:/ }"
+  return 0
+}
+
+# catalyst_secret_legacy_tiers ID — prints one "scope|configJsonPath" per line, in order
+# (may print nothing).
+catalyst_secret_legacy_tiers() {
+  local _i _v _tier
+  _i="$(_csc_index_of "$1")" || return 1
+  _v="${_CSC_LEGACY_TIERS[$_i]}"
+  [[ -n "$_v" ]] || return 0
+  local -a _tiers=()
+  IFS='|' read -r -a _tiers <<< "$_v"
+  for _tier in "${_tiers[@]}"; do
+    printf '%s\n' "${_tier/:/|}"
+  done
+}
 
 # _csc_index_of ID — echoes the row index or returns 1 (never prints on miss).
 _csc_index_of() {
@@ -492,9 +541,124 @@ _csc_resolve_env_file_presence() {
   _csc_set_result "" "none" "$_delivery"
 }
 
+# _csc_resolve_legacy_per_team_path — CTL-1616 PR4 (linear-worker-actor only). Mirrors
+# linear-comment-post.sh's _find_layer2_config VERBATIM, including its loud stderr warning
+# (that warning is exactly what __tests__/linear-comment-post.test.sh's CTL-1111 cells 13/14
+# assert on, so it stays here, not in secret-contract.mjs's zero-side-effect JS mirror): walk
+# $PWD upward for a .catalyst/config.json, read .catalyst.projectKey (nested) or a bare
+# top-level .projectKey (legacy layout), and build the sibling config-<key>.json NEXT TO the
+# canonical Layer-2 directory (dirname of catalyst_secret_resolve_layer2_path) — not a
+# hardcoded ${HOME}/.config/catalyst literal, consistent with this row's own primary tier
+# already reading through the canonical chain. Falls back to the canonical global path itself
+# when no projectKey is found anywhere in the ancestry.
+_csc_resolve_legacy_per_team_path() {
+  local _dir="$PWD" _cfg _key
+  while [[ "$_dir" != "/" ]]; do
+    _cfg="$_dir/.catalyst/config.json"
+    if [[ -f "$_cfg" ]]; then
+      _key="$(jq -r '.catalyst.projectKey // .projectKey // empty' "$_cfg" 2>/dev/null)" || true
+      if [[ -n "$_key" ]]; then
+        printf '%s/config-%s.json' "$(dirname "$(catalyst_secret_resolve_layer2_path)")" "$_key"
+        return 0
+      fi
+    fi
+    _dir="$(dirname "$_dir")"
+  done
+  echo "catalyst-secret-contract: no projectKey in any .catalyst/config.json from $PWD upward — per-team config-<key>.json NOT resolved; falling back to global config.json" >&2
+  catalyst_secret_resolve_layer2_path
+}
+
+# _csc_meets_required_object_fields ID JSON — CTL-1616 PR4 remediation (B1 fix; round-2 B3
+# fix below). Mirrors lib/secret-contract.mjs's meetsRequiredObjectFields: a row with no
+# requiredObjectFields declared passes trivially (echoes nothing declared -> return 0); a
+# row that DOES declare fields requires JSON to be a JSON OBJECT with every named field
+# present as a non-empty (post-EOL-strip — CANON RULE 2, see
+# _CSC_REQUIRED_OBJECT_FIELDS above) string. JSON here is always an already-decoded
+# canonical value handed in ONLY when the caller (_csc_config_json_tag_accepted) has already
+# confirmed the ORIGINAL tag was "@OBJ64:" — never a plain "@STR64:" string reinterpreted as
+# JSON (CANON RULE 1: see the tag-gating fix on that function; a JSON.parse/jq round-trip of
+# a STRING's own text is exactly the B3 bug this avoids). Never aborts the caller (jq errors
+# are swallowed via 2>/dev/null, matching every other jq call site in this file).
+#
+# ROUND-2 B3 FIX: the field value is now stripped of a TRAILING RUN of \r/\n bytes INSIDE the
+# same jq invocation (`sub("[\r\n]+$";"")`, Oniguruma regex, byte-for-byte the same rule as
+# JS's `stripEol`'s `.replace(/[\r\n]+$/, "")`) before the emptiness check — not left to bash's
+# own $() capture, which only ever strips trailing "\n" bytes and would silently leave a
+# trailing lone "\r" (or a "\r\n\r\n" mixed run) unstripped, an LF/CR asymmetry a purely-
+# implicit $() reliance would introduce between the two engines.
+_csc_meets_required_object_fields() {
+  local _id="$1" _json="$2" _fields _field _val
+  _fields="$(catalyst_secret_required_object_fields "$_id")"
+  [[ -n "$_fields" ]] || return 0
+  local -a _farr=()
+  IFS=' ' read -r -a _farr <<< "$_fields"
+  for _field in "${_farr[@]}"; do
+    _val="$(printf '%s' "$_json" | jq -r --arg f "$_field" '
+      if type == "object" and ((.[$f] | type) == "string") then
+        (.[$f] | sub("[\r\n]+$"; ""))
+      else "" end
+    ' 2>/dev/null)"
+    [[ -n "$_val" ]] || return 1
+  done
+  return 0
+}
+
+# _csc_config_json_tag_accepted ID TAG — ROUND-2 B3 FIX. Returns 0 (accept) iff TAG (an
+# "@OBJ64:"/"@STR64:"/"@ABSENT"/"@NONSTR" value from _csc_read_json_string) is eligible to be
+# decoded and checked against ID's requiredObjectFields gate; 1 (reject, fall through
+# immediately) otherwise. CANON RULE 1 (see the requiredObjectFields row-field comment in
+# lib/secret-contract.mjs): when ID declares requiredObjectFields, ONLY "@OBJ64:" is
+# eligible — a bare "@STR64:" (the ORIGINAL value was a JSON STRING) is rejected here
+# unconditionally, before ever being decoded, REGARDLESS of what its own text would parse to.
+#
+# WHY GATE ON THE TAG, NOT ON DECODED CONTENT: the previous implementation accepted both tags
+# and asked _csc_meets_required_object_fields to sort it out — but that function pipes the
+# ALREADY-DECODED text back into `jq`, which happily RE-PARSES a string's own text as JSON.
+# A tier storing '"{\"clientId\":\"x\",\"clientSecret\":\"y\"}"' (a JSON STRING whose content
+# looks like a full credential object) would decode to that exact object-shaped text, jq would
+# re-parse it as an object, and the gate would incorrectly WIN — while
+# lib/secret-contract.mjs's meetsRequiredObjectFields never reparses (it inspects
+# `typeof raw`, the type JSON.parse/jq already assigned the value, once) and correctly falls
+# through. The "@OBJ64:"/"@STR64:" tag already carries that original-type fact losslessly (set
+# by _csc_read_json_string BEFORE any decoding), so gating on the TAG closes the divergence at
+# its source instead of trying to out-guess jq's stdin-is-always-JSON re-parsing behavior.
+#
+# A row with no requiredObjectFields declared is unaffected — both tags stay eligible here,
+# matching every other config-json row's pre-existing (pre-PR4) behavior; the ACTOR ROW SHAPE
+# FIX this file's own history documents (accepting @STR64 for the generic groq-api-key shape)
+# is untouched.
+_csc_config_json_tag_accepted() {
+  local _id="$1" _tag="$2" _req_fields
+  case "$_tag" in
+    "@OBJ64:"*) return 0 ;;
+    "@STR64:"*)
+      _req_fields="$(catalyst_secret_required_object_fields "$_id")"
+      [[ -z "$_req_fields" ]]
+      return $?
+      ;;
+    *) return 1 ;;
+  esac
+}
+
 _csc_resolve_config_json() {
   local _id="$1" _delivery _path _l2 _tagged
   _delivery="$(catalyst_secret_delivery "$_id")"
+  # ENV-PAIR TIER (CTL-1616 PR4, linear-worker-actor only): checked BEFORE the primary
+  # configJsonPath tier — mirrors linear-comment-post.sh's own precedence exactly. BOTH
+  # halves must be present (an id with no secret, or vice versa, is not a usable credential).
+  local _pair _idvar _secvar _idval _secval
+  if _pair="$(catalyst_secret_credential_env_pair "$_id")" && [[ -n "$_pair" ]]; then
+    _idvar="${_pair%% *}"
+    _secvar="${_pair#* }"
+    _idval="${!_idvar-}"
+    _secval="${!_secvar-}"
+    if [[ -n "$_idval" && -n "$_secval" ]]; then
+      local _obj
+      _obj="$(jq -nc --arg id "$_idval" --arg sec "$_secval" '{clientId:$id, clientSecret:$sec}')"
+      _csc_set_result "$_obj" "inherited" "$_delivery"
+      return 0
+    fi
+  fi
   if [[ -n "$(catalyst_secret_env_names "$_id")" ]]; then
     # SUBSHELL-EXPORT CAVEAT (mirrors lib/catalyst-deployment-mode.sh's own documented fix):
     # calling _csc_resolve_env_alias_only inside a $(...) command substitution would run it
@@ -521,20 +685,51 @@ _csc_resolve_config_json() {
   # lib/secret-contract.mjs's `raw.length > 0`); an empty object decodes to the 2-byte
   # canonical string "{}" (non-empty — DOES resolve, matching
   # canonicalizeConfigJsonValue's "empty object still resolves" behavior).
-  case "$_tagged" in
-    "@STR64:"*|"@OBJ64:"*)
-      local _decoded
-      _csc_b64_decode_var _decoded "${_tagged#@*:}"
-      if [[ -n "$_decoded" ]]; then
-        _csc_set_result "$_decoded" "config-json" "$_delivery"
-      else
-        _csc_set_result "" "none" "$_delivery"
+  #
+  # ROUND-2 B3 FIX: the "accepts BOTH tags" claim above is now GATED by
+  # _csc_config_json_tag_accepted, not a bare case-pattern match — for a row that declares
+  # requiredObjectFields, a "@STR64:" tag is rejected unconditionally (CANON RULE 1), never
+  # reaching _csc_meets_required_object_fields at all. See that helper's docstring.
+  if _csc_config_json_tag_accepted "$_id" "$_tagged"; then
+    local _decoded
+    _csc_b64_decode_var _decoded "${_tagged#@*:}"
+    # B1 FIX: a decoded-but-INCOMPLETE credential object (e.g. {clientId} alone, or a
+    # credential-free object like {webhookSecret,botUserId}) must NOT capture resolution
+    # here — falls through to the legacy tiers below instead, mirroring the OLD script's
+    # per-tier `[[ -z "$CLIENT_ID" || -z "$CLIENT_SECRET" ]]` advance rule exactly. A row
+    # with no requiredObjectFields declared is unaffected (the gate passes trivially).
+    if [[ -n "$_decoded" ]] && _csc_meets_required_object_fields "$_id" "$_decoded"; then
+      _csc_set_result "$_decoded" "config-json" "$_delivery"
+      return 0
+    fi
+  fi
+  # LEGACY TIERS (CTL-1616 PR4, linear-worker-actor only): tried, in order, ONLY once the
+  # primary tier misses above — preserves linear-comment-post.sh's fallthrough exactly
+  # (design §8 PR4 / §9's "all three tiers preserved verbatim"). B1 fix: "misses" now means
+  # EITHER absent OR (for a row declaring requiredObjectFields) present-but-incomplete.
+  local _tier_line _tier_scope _tier_path _tier_l2 _tier_tagged _tier_decoded
+  while IFS= read -r _tier_line; do
+    [[ -n "$_tier_line" ]] || continue
+    _tier_scope="${_tier_line%%|*}"
+    _tier_path="${_tier_line#*|}"
+    if [[ "$_tier_scope" == "per-team-legacy" ]]; then
+      _tier_l2="$(_csc_resolve_legacy_per_team_path)"
+    else
+      _tier_l2="$(catalyst_secret_resolve_layer2_path)"
+    fi
+    _tier_tagged="$(_csc_read_json_string "$_tier_l2" "$_tier_path")"
+    # ROUND-2 B3 FIX: same tag-gating as the primary tier above (CANON RULE 1) — a legacy
+    # tier's own "@STR64:" value is equally rejected unconditionally when ID declares
+    # requiredObjectFields, never reaching _csc_meets_required_object_fields.
+    if _csc_config_json_tag_accepted "$_id" "$_tier_tagged"; then
+      _csc_b64_decode_var _tier_decoded "${_tier_tagged#@*:}"
+      if [[ -n "$_tier_decoded" ]] && _csc_meets_required_object_fields "$_id" "$_tier_decoded"; then
+        _csc_set_result "$_tier_decoded" "legacy-config-json" "$_delivery"
+        return 0
       fi
-      ;;
-    *)
-      _csc_set_result "" "none" "$_delivery"
-      ;;
-  esac
+    fi
+  done < <(catalyst_secret_legacy_tiers "$_id")
+  _csc_set_result "" "none" "$_delivery"
 }
 
 # _csc_resolve_cloud_token_name — cloud-token's two-step resolution: NAME (env override →

--- a/plugins/dev/scripts/lib/linear-app-actor.sh
+++ b/plugins/dev/scripts/lib/linear-app-actor.sh
@@ -22,16 +22,26 @@
 [[ -n "${_CATALYST_LINEAR_APP_ACTOR_SH_LOADED:-}" ]] && return 0
 _CATALYST_LINEAR_APP_ACTOR_SH_LOADED=1
 
+# CTL-1616 PR4: the Layer-2 selection chain + clientId/clientSecret READ are folded onto the
+# shared secret contract (catalyst_resolve_secret linear-orchestrator-actor) so the chain is
+# defined ONCE — this file no longer hand-rolls its own copy of the
+# CATALYST_LAYER2_CONFIG_FILE > CATALYST_MACHINE_CONFIG > XDG > ~/.config/… chain (this row's
+# chain IS that canonical chain; the registry adopted it, not vice versa — design §2/§8). MINT
+# mechanics below (the curl POST) are UNCHANGED.
+_LAA_LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck disable=SC1091
+source "${_LAA_LIB_DIR}/catalyst-secret-contract.sh"
+
 linear_app_actor_auth() {
   local _daemon="${1:?linear_app_actor_auth: daemon name required}"
-  # Layer-2 selection chain — mirrors execution-core/install-lifecycle.mjs (and
-  # linear-remint.mjs defaultLayer2Path): CATALYST_LAYER2_CONFIG_FILE >
-  # CATALYST_MACHINE_CONFIG > $XDG_CONFIG_HOME/catalyst/config.json > ~/.config/….
-  local _g="${CATALYST_LAYER2_CONFIG_FILE:-${CATALYST_MACHINE_CONFIG:-${XDG_CONFIG_HOME:-${HOME}/.config}/catalyst/config.json}}"
-  local _ocid _ocsec _otok
-  _ocid=$(jq -r '.catalyst.linear.bot.orchestrator.clientId // empty' "$_g" 2>/dev/null)
-  _ocsec=$(jq -r '.catalyst.linear.bot.orchestrator.clientSecret // empty' "$_g" 2>/dev/null)
-  if [[ -n "$_ocid" && -n "$_ocsec" ]]; then
+  local _ocid _ocsec _otok _creds
+  catalyst_resolve_secret linear-orchestrator-actor >/dev/null
+  _creds="$CATALYST_SECRET_LAST_VALUE"
+  if [[ -n "$_creds" ]]; then
+    _ocid=$(printf '%s' "$_creds" | jq -r '.clientId // empty' 2>/dev/null)
+    _ocsec=$(printf '%s' "$_creds" | jq -r '.clientSecret // empty' 2>/dev/null)
+  fi
+  if [[ -n "${_ocid:-}" && -n "${_ocsec:-}" ]]; then
     # Secret travels via --data @- on stdin, never argv (process-table hygiene —
     # house style: linear-remint.mjs buildMintCurlArgs), values URL-encoded via
     # jq @uri (parity with the re-minter's URLSearchParams — a form-reserved

--- a/plugins/dev/scripts/lib/linear-comment-post.sh
+++ b/plugins/dev/scripts/lib/linear-comment-post.sh
@@ -23,68 +23,53 @@ LINEAR_API="https://api.linear.app"
 # execution-core/linear-remint.mjs (MINT_SCOPE) and catalyst-execution-core.
 MINT_SCOPE="read,write,comments:create,app:assignable,app:mentionable"
 
-# _find_layer2_config — resolve the OLD per-team Layer-2 file
-# (~/.config/catalyst/config-<key>.json) by walking up for .catalyst/config.json
-# and reading the project key. The key lives at `.catalyst.projectKey` (nested);
-# a bare top-level `.projectKey` is also honored for any legacy layout. Falls
-# back to the GLOBAL ~/.config/catalyst/config.json when no key is found.
-_find_layer2_config() {
-  local dir="$PWD"
-  while [[ "$dir" != "/" ]]; do
-    local cfg="$dir/.catalyst/config.json"
-    if [[ -f "$cfg" ]]; then
-      local key
-      key=$(jq -r '.catalyst.projectKey // .projectKey // empty' "$cfg" 2>/dev/null) || true
-      if [[ -n "$key" ]]; then
-        echo "$HOME/.config/catalyst/config-${key}.json"
-        return 0
-      fi
-    fi
-    dir="$(dirname "$dir")"
-  done
-  # CTL-1111: no projectKey found anywhere in the ancestry. Make the drift LOUD
-  # instead of silently aliasing to the global config — name what's missing so an
-  # operator can see why the per-team config-<key>.json was not consulted. Still
-  # return the global path so branch 1 (global bot.worker) back-compat keeps
-  # working. Warning goes to stderr; stdout remains the resolved path.
-  echo "linear-comment-post: no projectKey in any .catalyst/config.json from $PWD upward — per-team config-<key>.json NOT resolved; falling back to global config.json" >&2
-  echo "$HOME/.config/catalyst/config.json"
-}
+# CTL-1616 PR4: the credential-env-pair check + the THREE config-json tiers below (NEW global
+# bot.worker → OLD per-team agent → OLD global agent) are folded onto the shared secret
+# contract's linear-worker-actor row (catalyst_resolve_secret linear-worker-actor) — ALL THREE
+# TIERS PRESERVED VERBATIM (deprecating them is an explicit follow-up ticket, design §12 Q6;
+# collapsing live credential paths on a recovering fleet is exactly what this fold defers).
+# The directory walk-up + its CTL-1111 loud stderr warning now live in
+# lib/catalyst-secret-contract.sh's _csc_resolve_legacy_per_team_path (same wording, same
+# stderr channel — __tests__/linear-comment-post.test.sh's warning assertions are unaffected).
+_LCP_LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck disable=SC1091
+source "${_LCP_LIB_DIR}/catalyst-secret-contract.sh"
 
-CLIENT_ID="${CATALYST_LINEAR_AGENT_CLIENT_ID:-}"
-CLIENT_SECRET="${CATALYST_LINEAR_AGENT_CLIENT_SECRET:-}"
+CLIENT_ID=""
+CLIENT_SECRET=""
+catalyst_resolve_secret linear-worker-actor >/dev/null
+if [[ -n "$CATALYST_SECRET_LAST_VALUE" ]]; then
+  CLIENT_ID=$(printf '%s' "$CATALYST_SECRET_LAST_VALUE" | jq -r '.clientId // empty' 2>/dev/null)
+  CLIENT_SECRET=$(printf '%s' "$CATALYST_SECRET_LAST_VALUE" | jq -r '.clientSecret // empty' 2>/dev/null)
+fi
+
+# CTL-1111 back-compat: the pre-fold script ran the per-team directory walk-up (and its "no
+# projectKey found" loud warning) UNCONDITIONALLY whenever the env-credential-pair was absent
+# — even when the global bot.worker tier already won — because a misconfigured worktree
+# (missing .catalyst/config.json ancestry) is worth flagging regardless of which tier
+# ultimately supplied the credential. catalyst_resolve_secret's chain only consults the
+# per-team tier LAZILY (once every earlier tier misses), so this call preserves that
+# diagnostic side effect explicitly; its return value is discarded — the credential itself
+# always comes solely from the canonical resolution above.
+#
+# A2 FIX (CTL-1616 PR4 remediation, duplicate-warning regression): fires ONLY when the
+# PRIMARY tier itself won (source "config-json" — unique to that tier for this row, since it
+# is the only tier that resolves without ever touching a legacy tier). That is the ONE case
+# where catalyst_resolve_secret's own chain returns EARLY without ever invoking the per-team
+# walk-up at all, so calling it here is genuinely the FIRST and ONLY invocation. Every OTHER
+# outcome ("inherited" — the env pair won; "legacy-config-json"/"none" — the primary tier
+# missed) means the chain's own legacyConfigTiers loop ALREADY tried the per-team-legacy tier
+# as its first rung (and already fired the loud warning if no projectKey was found) —
+# calling this again here would print the SAME warning a second time, which is exactly the
+# regression this fix closes (the old unconditional-except-"inherited" guard fired here in
+# BOTH the "already handled internally" cases above, not just the one that needed it).
+if [[ "$CATALYST_SECRET_LAST_SOURCE" == "config-json" ]]; then
+  _csc_resolve_legacy_per_team_path >/dev/null
+fi
 
 if [[ -z "$CLIENT_ID" || -z "$CLIENT_SECRET" ]]; then
-  GLOBAL_CONFIG="$HOME/.config/catalyst/config.json"
-  LAYER2_CONFIG="$(_find_layer2_config)"
-
-  # 1. NEW global path (~/.config/catalyst/config.json):
-  #    catalyst.linear.bot.worker.{clientId,clientSecret}
-  if [[ -f "$GLOBAL_CONFIG" ]]; then
-    CLIENT_ID=$(jq -r '.catalyst.linear.bot.worker.clientId // empty' "$GLOBAL_CONFIG" 2>/dev/null)
-    CLIENT_SECRET=$(jq -r '.catalyst.linear.bot.worker.clientSecret // empty' "$GLOBAL_CONFIG" 2>/dev/null)
-  fi
-
-  # 2. OLD per-team path fallback (config-<key>.json, resolved above):
-  #    catalyst.linear.agent.{clientId,clientSecret}. During the transition the
-  #    worker creds may still live in the per-team file under the legacy key.
-  if [[ -z "$CLIENT_ID" || -z "$CLIENT_SECRET" ]] && [[ -f "$LAYER2_CONFIG" ]]; then
-    CLIENT_ID=$(jq -r '.catalyst.linear.agent.clientId // empty' "$LAYER2_CONFIG" 2>/dev/null)
-    CLIENT_SECRET=$(jq -r '.catalyst.linear.agent.clientSecret // empty' "$LAYER2_CONFIG" 2>/dev/null)
-  fi
-
-  # 3. OLD global path fallback: legacy catalyst.linear.agent.* in the global
-  #    config.json (covers a global-only legacy layout when no per-team file
-  #    exists or the resolver already pointed at config.json).
-  if [[ -z "$CLIENT_ID" || -z "$CLIENT_SECRET" ]] && [[ -f "$GLOBAL_CONFIG" ]]; then
-    CLIENT_ID=$(jq -r '.catalyst.linear.agent.clientId // empty' "$GLOBAL_CONFIG" 2>/dev/null)
-    CLIENT_SECRET=$(jq -r '.catalyst.linear.agent.clientSecret // empty' "$GLOBAL_CONFIG" 2>/dev/null)
-  fi
-
-  if [[ -z "$CLIENT_ID" || -z "$CLIENT_SECRET" ]]; then
-    echo "linear-comment-post: catalyst.linear.bot.worker.{clientId,clientSecret} (global) or legacy catalyst.linear.agent.* (per-team $LAYER2_CONFIG / global $GLOBAL_CONFIG) not found" >&2
-    exit 1
-  fi
+  echo "linear-comment-post: catalyst.linear.bot.worker.{clientId,clientSecret} (global) or legacy catalyst.linear.agent.* (per-team / global) not found" >&2
+  exit 1
 fi
 
 # 1. Mint app-actor token via client_credentials grant.

--- a/plugins/dev/scripts/lib/secret-contract.d.mts
+++ b/plugins/dev/scripts/lib/secret-contract.d.mts
@@ -21,6 +21,12 @@ export interface SecretRotation {
   trigger?: RotationTrigger;
 }
 
+/** CTL-1616 PR4: a single legacy config-json fallback tier (linear-worker-actor only). */
+export interface LegacyConfigTier {
+  scope: "per-team-legacy" | "global-legacy";
+  configJsonPath: string;
+}
+
 export interface SecretRow {
   id: string;
   envNames: readonly string[];
@@ -33,6 +39,17 @@ export interface SecretRow {
   familyPrefix?: string;
   /** present only on the age-key local-only row, relative to HOME */
   defaultLocalPath?: readonly string[];
+  /**
+   * CTL-1616 PR4 (linear-worker-actor only): an env-var pair checked BEFORE configJsonPath —
+   * folds linear-comment-post.sh's CATALYST_LINEAR_AGENT_CLIENT_ID/_SECRET precedence tier.
+   */
+  credentialEnvPair?: { clientId: string; clientSecret: string };
+  /**
+   * CTL-1616 PR4 (linear-worker-actor only): additional config-json tiers tried, in order,
+   * only once configJsonPath itself misses — folds linear-comment-post.sh's two legacy
+   * catalyst.linear.agent tiers verbatim.
+   */
+  legacyConfigTiers?: readonly LegacyConfigTier[];
 }
 
 export const SECRET_DELIVERY: readonly SecretDelivery[];
@@ -45,6 +62,12 @@ export function isSecretFamilyMember(filename: string): boolean;
 export function resolveLayer2Path(env?: Record<string, string | undefined>): string;
 export function explicitFileOverrideEnvName(id: string): string;
 export function secretFileCandidates(id: string, env?: Record<string, string | undefined>): string[];
+/** CTL-1616 PR4: linear-worker-actor's per-team-legacy tier path (mirrors
+ *  linear-comment-post.sh's _find_layer2_config directory walk-up). */
+export function resolveLegacyPerTeamConfigPath(
+  env?: Record<string, string | undefined>,
+  cwd?: string,
+): string;
 
 /** The subset of CTL-1617's resolveDeploymentMode() output this engine consumes. */
 export interface DeploymentModeInput {
@@ -57,6 +80,8 @@ export interface DeploymentModeInput {
 export interface ResolveSecretOptions {
   env?: Record<string, string | undefined>;
   deploymentMode?: DeploymentModeInput;
+  /** CTL-1616 PR4: cwd the per-team-legacy tier's directory walk starts from (linear-worker-actor only). Defaults to process.cwd(). */
+  cwd?: string;
 }
 
 export interface ResolvedSecret {

--- a/plugins/dev/scripts/lib/secret-contract.mjs
+++ b/plugins/dev/scripts/lib/secret-contract.mjs
@@ -163,12 +163,86 @@ export const SECRET_REGISTRY = Object.freeze(
       id: "linear-worker-actor",
       envNames: [],
       delivery: "config-json",
-      // Primary tier only. linear-comment-post.sh's 3-tier chain (bot.worker → legacy
-      // catalyst.linear.agent → legacy per-team) is preserved VERBATIM in its own file per
-      // design §8 PR4 — this row's single configJsonPath is the primary tier; the legacy
-      // tiers are a PR4 concern, not duplicated here (design explicitly defers their
-      // deprecation to a follow-up ticket, design §6/§12 Q6).
+      // Primary (NEW global) tier: catalyst.linear.bot.worker.
       configJsonPath: "catalyst.linear.bot.worker",
+      // CTL-1616 PR4 (append-only row extension, design §8/§9): the row shipped in PR1/PR3
+      // encoded only the primary tier — linear-comment-post.sh's OWN four-rung chain (an
+      // env-credential-pair tier checked BEFORE any config read, then two MORE legacy
+      // config-json tiers below the primary) is folded on here VERBATIM rather than left as
+      // a parallel hand-rolled chain in that script. Deprecating the legacy tiers is an
+      // explicit follow-up ticket (design §12 Q6) — every tier below is preserved exactly,
+      // not collapsed.
+      //
+      // credentialEnvPair — CATALYST_LINEAR_AGENT_CLIENT_ID/_SECRET, checked FIRST (ahead of
+      // even the primary configJsonPath tier), mirroring linear-comment-post.sh's own
+      // precedence: an operator-set env pair always wins over every config file. Resolved as
+      // a canonical {clientId, clientSecret} object (source "inherited"), the same shape a
+      // config-json tier resolves to — see resolveConfigJson's ENV-PAIR TIER.
+      credentialEnvPair: {
+        clientId: "CATALYST_LINEAR_AGENT_CLIENT_ID",
+        clientSecret: "CATALYST_LINEAR_AGENT_CLIENT_SECRET",
+      },
+      // requiredObjectFields — CTL-1616 PR4 remediation (B1 fix). The old linear-comment-post.sh
+      // advanced to the NEXT tier whenever clientId OR clientSecret was empty after a tier's
+      // read (`[[ -z "$CLIENT_ID" || -z "$CLIENT_SECRET" ]]`); canonicalizeConfigJsonValue's
+      // "any non-null value wins" rule (needed elsewhere so a legitimately-empty `{}` or a
+      // credential-free object like {webhookSecret, botUserId} — a REALISTIC production
+      // shape — still round-trips through the engine) let a tier holding exactly one of
+      // those shapes capture resolution instead of falling through, so the caller then
+      // hard-failed on the empty fields rather than reaching a deeper, fully-populated
+      // tier. Declaring the row's required object fields HERE (a data fact any config-json
+      // tier resolver can consult generically via meetsRequiredObjectFields, below — never a
+      // hardcoded `row.id === "linear-worker-actor"` special case) restores the old
+      // script's per-tier advance rule for every tier this row declares (env pair, primary,
+      // and both legacy tiers) without changing behavior for any row that does NOT declare
+      // this field (e.g. linear-orchestrator-actor, which has no fallback chain to advance
+      // down in the first place).
+      //
+      // TWO CROSS-ENGINE CANON RULES (round-2 remediation, B3 fix — both empirically pinned
+      // against `git show origin/main:.../linear-comment-post.sh` run in a hermetic fixture,
+      // see __tests__/secret-contract-parity.test.sh's "string-shape" / "newline-only"
+      // cells):
+      //
+      // 1. A bare STRING value at a gated tier's path ALWAYS falls through, even when that
+      //    string's own CONTENT happens to parse as JSON holding every required field (e.g.
+      //    the tier stores '"{\"clientId\":\"x\",\"clientSecret\":\"y\"}"' — a STRING, not an
+      //    object). meetsRequiredObjectFields's `typeof raw !== "object"` guard already
+      //    rejects this on the JS side (raw is the untouched parsed value — a string is never
+      //    reinterpreted as JSON here). The bash mirror needed an explicit fix for this: its
+      //    _csc_meets_required_object_fields pipes the ALREADY-DECODED value back into `jq`
+      //    for the field check, and jq happily re-parses a string's own text as JSON —
+      //    incorrectly treating object-shaped string CONTENT as a winning object. The fix
+      //    (_csc_config_json_tag_accepted) gates on the `_csc_read_json_string` TAG itself
+      //    (@OBJ64: vs @STR64:) — which losslessly records the ORIGINAL value's type — instead
+      //    of re-deriving type from decoded text, so a tagged-@STR64 value can never reach the
+      //    object field-check at all when the row declares requiredObjectFields. (Empirically,
+      //    the actual PRE-FOLD script does NEITHER "win" NOR "cleanly fall through" for this
+      //    exact shape: `jq -r '.clientId // empty'` errors trying to index a string, and under
+      //    the script's own `set -euo pipefail` that CRASHES the whole process (verified: exit
+      //    5) rather than advancing to the next tier. "Falls through" is the safer canon this
+      //    contract picks for both engines — matching current JS and never crashing — since a
+      //    hard abort is not a reproducible-in-both-engines behavior to mirror.)
+      //
+      // 2. A field is "empty" (fails the gate) using the SAME trailing-EOL-stripped emptiness
+      //    stripEol() already applies to bare-file values — NOT raw `.length > 0`. Pinned
+      //    empirically: the OLD script's `CLIENT_ID=$(jq -r '...clientId // empty' "$FILE")`
+      //    command-substitution silently strips ALL trailing newline bytes from jq's captured
+      //    output, so a field holding the single character "\n" captures as CLIENT_ID="" and
+      //    `[[ -z "$CLIENT_ID" ]]` correctly advances to the next tier. A bare JS
+      //    `raw[field].length > 0` check does NOT reproduce this (a lone "\n" has length 1 —
+      //    JS previously WON a tier the old script would have advanced past). See
+      //    meetsRequiredObjectFields below, which now runs each field through stripEol()
+      //    before the length check.
+      requiredObjectFields: ["clientId", "clientSecret"],
+      // legacyConfigTiers — tried, in order, ONLY once credentialEnvPair AND the primary
+      // configJsonPath tier both miss. "per-team-legacy" mirrors _find_layer2_config's
+      // directory walk-up for a projectKey-keyed config-<key>.json (see
+      // resolveLegacyPerTeamConfigPath); "global-legacy" reads the SAME global catalyst.linear
+      // agent key from the canonical Layer-2 file the primary tier already reads.
+      legacyConfigTiers: [
+        { scope: "per-team-legacy", configJsonPath: "catalyst.linear.agent" },
+        { scope: "global-legacy", configJsonPath: "catalyst.linear.agent" },
+      ],
       // Boot-only (per-call mint) per the seed table — distinct from the orchestrator actor,
       // which is proactively re-armed on a timer-adjacent cooldown reminter.
       rotation: { class: "boot-only" },
@@ -282,6 +356,45 @@ export function resolveLayer2Path(env = process.env) {
   const home = typeof env?.HOME === "string" && env.HOME.length > 0 ? env.HOME : homedir();
   const xdg = typeof env?.XDG_CONFIG_HOME === "string" && env.XDG_CONFIG_HOME.length > 0 ? env.XDG_CONFIG_HOME : join(home, ".config");
   return join(xdg, "catalyst", "config.json");
+}
+
+// resolveLegacyPerTeamConfigPath — CTL-1616 PR4. Mirrors linear-comment-post.sh's
+// _find_layer2_config VERBATIM: walk `cwd` upward looking for a `.catalyst/config.json`,
+// read its `.catalyst.projectKey` (nested) or bare top-level `.projectKey` (legacy layout),
+// and build the sibling per-team file name `config-<key>.json`. The ONE deliberate
+// generalization (matching every other row's dirname(layer2)-relative-to-canonical-chain
+// convention, e.g. secretFileCandidates): the sibling file lives next to the CANONICAL
+// resolveLayer2Path(env) directory, not a hardcoded `${HOME}/.config/catalyst` literal — this
+// row's own PRIMARY tier already reads through resolveLayer2Path (a decision that predates
+// this PR), so the per-team legacy file tracks the same directory rather than reintroducing a
+// second, independently-hardcoded location.
+//
+// Falls back to resolveLayer2Path(env) itself when no projectKey is found anywhere in the
+// ancestry (matching the script's own "falls back to the global path" behavior) — this
+// function stays silent (zero-import-leaf convention: no console output from this file); the
+// LOUD stderr warning the pre-fold script emits on that fallback is the CALLER's
+// responsibility (lib/catalyst-secret-contract.sh's mirror keeps it, since it is what
+// linear-comment-post.sh's test suite asserts against).
+export function resolveLegacyPerTeamConfigPath(env = process.env, cwd = process.cwd()) {
+  let dir = cwd;
+  for (;;) {
+    const cfg = join(dir, ".catalyst", "config.json");
+    if (existsSync(cfg)) {
+      try {
+        const parsed = JSON.parse(readFileSync(cfg, "utf8"));
+        const key = parsed?.catalyst?.projectKey ?? parsed?.projectKey;
+        if (typeof key === "string" && key.length > 0) {
+          return join(dirname(resolveLayer2Path(env)), `config-${key}.json`);
+        }
+      } catch {
+        /* malformed ancestor config — keep walking, matches the script's `|| true` swallow */
+      }
+    }
+    const parent = dirname(dir);
+    if (parent === dir) break; // reached the filesystem root
+    dir = parent;
+  }
+  return resolveLayer2Path(env);
 }
 
 // readJsonField — pull a dotted-path value out of a JSON file EXACTLY as written (whatever
@@ -451,6 +564,33 @@ function canonicalizeConfigJsonValue(raw) {
   return null;
 }
 
+// meetsRequiredObjectFields — CTL-1616 PR4 remediation (B1 fix; round-2 B3 fix below). A row
+// that declares requiredObjectFields (currently only linear-worker-actor's {clientId,
+// clientSecret} shape) must have EVERY named field present in the RAW parsed value as a
+// non-empty (post-EOL-strip — see round-2 fix below) string before a config-json tier is
+// allowed to WIN — mirrors linear-comment-post.sh's own
+// `[[ -z "$CLIENT_ID" || -z "$CLIENT_SECRET" ]]` per-tier advance check exactly. A row with
+// no requiredObjectFields declared is unaffected (returns true unconditionally, matching
+// today's behavior for every other config-json row).
+//
+// `typeof raw !== "object"` (below) is also what implements CANON RULE 1 from the
+// requiredObjectFields row-field comment above: a bare STRING raw value (even one whose own
+// text parses as a fully-populated credential object) is rejected here WITHOUT ever being
+// reparsed as JSON — this function only ever inspects the type jq/JSON.parse already gave the
+// value at the config path, never the string's own contents. Operates on the RAW value
+// (before canonicalizeConfigJsonValue's string-serialization), so this gate composes cleanly
+// with that function rather than re-parsing its output.
+//
+// ROUND-2 B3 FIX: each field's emptiness check now runs the value through stripEol() first —
+// CANON RULE 2 above — instead of a bare `.length > 0`. A field holding only a trailing
+// newline (e.g. "\n") now correctly fails the gate (falls through) exactly like the OLD
+// script's command-substitution-stripped capture did, rather than winning on raw length.
+function meetsRequiredObjectFields(row, raw) {
+  if (!row.requiredObjectFields) return true;
+  if (raw === null || typeof raw !== "object" || Array.isArray(raw)) return false;
+  return row.requiredObjectFields.every((field) => typeof raw[field] === "string" && stripEol(raw[field]).length > 0);
+}
+
 // ─── Bare-file candidate search — generalizes githubTokenFileCandidates ─────
 
 // explicitFileOverrideEnvName — the per-row explicit-override env var, e.g. "github-token" →
@@ -589,7 +729,23 @@ function resolveEnvFilePresence(row, env) {
   return { value: null, source: "none", provider: row.delivery, rotation: row.rotation };
 }
 
-function resolveConfigJson(row, env) {
+function resolveConfigJson(row, env, cwd) {
+  // ENV-PAIR TIER (CTL-1616 PR4, linear-worker-actor only): checked BEFORE the primary
+  // configJsonPath tier — mirrors linear-comment-post.sh's own precedence, where
+  // CATALYST_LINEAR_AGENT_CLIENT_ID/_SECRET win over every config file. BOTH halves of the
+  // pair must be present (an id with no secret, or vice versa, is not a usable credential —
+  // matches the script's `[[ -z "$CLIENT_ID" || -z "$CLIENT_SECRET" ]]` guard exactly).
+  if (row.credentialEnvPair) {
+    const idVal = env?.[row.credentialEnvPair.clientId];
+    const secretVal = env?.[row.credentialEnvPair.clientSecret];
+    if (
+      typeof idVal === "string" && idVal.length > 0 &&
+      typeof secretVal === "string" && secretVal.length > 0
+    ) {
+      const canon = canonicalJsonStringify({ clientId: idVal, clientSecret: secretVal });
+      return { value: canon, source: "inherited", provider: row.delivery, rotation: row.rotation };
+    }
+  }
   if ((row.envNames ?? []).length > 0) {
     const viaEnv = resolveEnvAliasOnly(row, env);
     if (viaEnv.value != null) return viaEnv;
@@ -597,8 +753,33 @@ function resolveConfigJson(row, env) {
   const path = resolveLayer2Path(env);
   const raw = readJsonField(path, row.configJsonPath);
   const resolved = canonicalizeConfigJsonValue(raw);
-  if (resolved != null) {
+  if (resolved != null && meetsRequiredObjectFields(row, raw)) {
     return { value: resolved, source: "config-json", provider: row.delivery, rotation: row.rotation, filePath: path };
+  }
+  // LEGACY TIERS (CTL-1616 PR4, linear-worker-actor only): tried, in order, ONLY once the
+  // primary tier misses — preserves linear-comment-post.sh's fallthrough exactly (design §8
+  // PR4 / §9's "all three tiers preserved verbatim"). B1 fix: "misses" now means EITHER
+  // absent OR (for a row declaring requiredObjectFields) present-but-incomplete — a lone
+  // clientId, a credential-free object, or empty-string fields all continue the chain
+  // instead of falsely capturing it.
+  if (row.legacyConfigTiers) {
+    for (const tier of row.legacyConfigTiers) {
+      const tierPath = tier.scope === "per-team-legacy"
+        ? resolveLegacyPerTeamConfigPath(env, cwd)
+        : resolveLayer2Path(env);
+      const tierRaw = readJsonField(tierPath, tier.configJsonPath);
+      const tierResolved = canonicalizeConfigJsonValue(tierRaw);
+      if (tierResolved != null && meetsRequiredObjectFields(row, tierRaw)) {
+        return {
+          value: tierResolved,
+          source: "legacy-config-json",
+          provider: row.delivery,
+          rotation: row.rotation,
+          filePath: tierPath,
+          legacyScope: tier.scope,
+        };
+      }
+    }
   }
   return { value: null, source: "none", provider: row.delivery, rotation: row.rotation };
 }
@@ -678,7 +859,7 @@ function resolveLocalOnlyPresence(row, env) {
 // is exempt (it must resolve on its own terms) and resolveCloudTokenName never triggers this
 // check (recursion terminates in one level: cloud-token's own resolution never consults
 // `deploymentMode`).
-export function resolveSecret(id, { env = process.env, deploymentMode } = {}) {
+export function resolveSecret(id, { env = process.env, deploymentMode, cwd = process.cwd() } = {}) {
   const row = getSecretRow(id);
   if (!row) return { value: null, source: null, provider: null, rotation: null };
 
@@ -720,7 +901,7 @@ export function resolveSecret(id, { env = process.env, deploymentMode } = {}) {
     case "env-alias":
       return resolveEnvAliasOnly(row, env);
     case "config-json":
-      return resolveConfigJson(row, env);
+      return resolveConfigJson(row, env, cwd);
     case "platform-env":
       return resolveCloudTokenName(row, env);
     case "local-only":

--- a/plugins/dev/scripts/lib/secret-contract.test.mjs
+++ b/plugins/dev/scripts/lib/secret-contract.test.mjs
@@ -9,6 +9,7 @@ import {
   getSecretRow,
   isSecretFamilyMember,
   resolveLayer2Path,
+  resolveLegacyPerTeamConfigPath,
   explicitFileOverrideEnvName,
   secretFileCandidates,
   resolveSecret,
@@ -407,6 +408,312 @@ describe("resolveSecret — config-json delivery (linear-orchestrator-actor, gro
   });
 });
 
+// ─── resolveSecret — linear-worker-actor's CTL-1616 PR4 credentialEnvPair + legacyConfigTiers
+// fold (linear-comment-post.sh's THREE config tiers + its env-pair tier, preserved verbatim).
+// Every precedence fixture below is mirrored byte-for-byte in
+// __tests__/secret-contract-parity.test.sh so bash and JS are proven to agree, not merely
+// each internally self-consistent.
+describe("resolveSecret — linear-worker-actor credentialEnvPair + legacyConfigTiers (CTL-1616 PR4)", () => {
+  test("credentialEnvPair wins over every config tier when both halves are present", () => {
+    const dir = fixtureDir();
+    const l2 = writeFile(
+      dir,
+      "config.json",
+      JSON.stringify({ catalyst: { linear: { bot: { worker: { clientId: "CFG", clientSecret: "CFGSEC" } } } } }),
+    );
+    const r = resolveSecret("linear-worker-actor", {
+      env: {
+        CATALYST_LAYER2_CONFIG_FILE: l2,
+        CATALYST_LINEAR_AGENT_CLIENT_ID: "EID",
+        CATALYST_LINEAR_AGENT_CLIENT_SECRET: "ESEC",
+      },
+    });
+    expect(r).toMatchObject({ value: '{"clientId":"EID","clientSecret":"ESEC"}', source: "inherited" });
+  });
+
+  test("credentialEnvPair with only ONE half set does not win — falls through to the config tiers", () => {
+    const dir = fixtureDir();
+    const l2 = writeFile(
+      dir,
+      "config.json",
+      JSON.stringify({ catalyst: { linear: { bot: { worker: { clientId: "CFG", clientSecret: "CFGSEC" } } } } }),
+    );
+    const r = resolveSecret("linear-worker-actor", {
+      env: { CATALYST_LAYER2_CONFIG_FILE: l2, CATALYST_LINEAR_AGENT_CLIENT_ID: "EID" },
+    });
+    expect(r).toMatchObject({ value: '{"clientId":"CFG","clientSecret":"CFGSEC"}', source: "config-json" });
+  });
+
+  test("primary configJsonPath (NEW global bot.worker) wins over both legacy tiers when all three are present", () => {
+    const dir = fixtureDir();
+    const l2 = writeFile(
+      dir,
+      "config.json",
+      JSON.stringify({
+        catalyst: {
+          linear: {
+            bot: { worker: { clientId: "NEW", clientSecret: "NEWSEC" } },
+            agent: { clientId: "GLOBALLEGACY", clientSecret: "GLOBALLEGACYSEC" },
+          },
+        },
+      }),
+    );
+    const repo = resolve(dir, "repo");
+    mkdirSync(resolve(repo, ".catalyst"), { recursive: true });
+    writeFile(dir, "repo/.catalyst/config.json", JSON.stringify({ catalyst: { projectKey: "proj1" } }));
+    writeFile(dir, "config-proj1.json", JSON.stringify({ catalyst: { linear: { agent: { clientId: "PERTEAM", clientSecret: "PERTEAMSEC" } } } }));
+    const r = resolveSecret("linear-worker-actor", { env: { CATALYST_LAYER2_CONFIG_FILE: l2 }, cwd: repo });
+    expect(r).toMatchObject({ value: '{"clientId":"NEW","clientSecret":"NEWSEC"}', source: "config-json" });
+  });
+
+  test("per-team-legacy tier wins when the primary tier misses (only per-team agent creds present)", () => {
+    const dir = fixtureDir();
+    const l2 = writeFile(dir, "config.json", JSON.stringify({}));
+    const repo = resolve(dir, "repo");
+    mkdirSync(resolve(repo, ".catalyst"), { recursive: true });
+    writeFile(dir, "repo/.catalyst/config.json", JSON.stringify({ catalyst: { projectKey: "proj1" } }));
+    writeFile(dir, "config-proj1.json", JSON.stringify({ catalyst: { linear: { agent: { clientId: "PERTEAM", clientSecret: "PERTEAMSEC" } } } }));
+    const r = resolveSecret("linear-worker-actor", { env: { CATALYST_LAYER2_CONFIG_FILE: l2 }, cwd: repo });
+    expect(r).toMatchObject({
+      value: '{"clientId":"PERTEAM","clientSecret":"PERTEAMSEC"}',
+      source: "legacy-config-json",
+      legacyScope: "per-team-legacy",
+    });
+  });
+
+  test("global-legacy tier wins when the primary tier AND the per-team tier both miss (projectKey resolves, but the per-team file lacks agent creds; only the global file's legacy agent key is set)", () => {
+    const dir = fixtureDir();
+    const l2 = writeFile(dir, "config.json", JSON.stringify({ catalyst: { linear: { agent: { clientId: "GLOBALLEGACY", clientSecret: "GLOBALLEGACYSEC" } } } }));
+    const repo = resolve(dir, "repo");
+    mkdirSync(resolve(repo, ".catalyst"), { recursive: true });
+    writeFile(dir, "repo/.catalyst/config.json", JSON.stringify({ catalyst: { projectKey: "proj1" } }));
+    // No config-proj1.json at all — the per-team-legacy tier's own file is simply absent.
+    const r = resolveSecret("linear-worker-actor", { env: { CATALYST_LAYER2_CONFIG_FILE: l2 }, cwd: repo });
+    expect(r).toMatchObject({
+      value: '{"clientId":"GLOBALLEGACY","clientSecret":"GLOBALLEGACYSEC"}',
+      source: "legacy-config-json",
+      legacyScope: "global-legacy",
+    });
+  });
+
+  test("no projectKey found anywhere in the ancestry: the per-team-legacy tier itself falls back to the canonical global path, so a global-only legacy layout still resolves via legacyScope 'per-team-legacy' (matches the pre-fold script's own fallthrough exactly — tier 2's LAYER2_CONFIG degenerates to the same file tier 3 would have read)", () => {
+    const dir = fixtureDir();
+    const l2 = writeFile(dir, "config.json", JSON.stringify({ catalyst: { linear: { agent: { clientId: "GL", clientSecret: "GLSEC" } } } }));
+    const cwdNoAncestry = resolve(dir, "no-ancestry-dir");
+    mkdirSync(cwdNoAncestry, { recursive: true });
+    const r = resolveSecret("linear-worker-actor", { env: { CATALYST_LAYER2_CONFIG_FILE: l2 }, cwd: cwdNoAncestry });
+    expect(r).toMatchObject({ value: '{"clientId":"GL","clientSecret":"GLSEC"}', source: "legacy-config-json", legacyScope: "per-team-legacy" });
+  });
+
+  test("nothing present anywhere (no env pair, no config tiers) resolves to none", () => {
+    const dir = fixtureDir();
+    const l2 = writeFile(dir, "config.json", JSON.stringify({}));
+    const cwdNoAncestry = resolve(dir, "empty-dir");
+    mkdirSync(cwdNoAncestry, { recursive: true });
+    const r = resolveSecret("linear-worker-actor", { env: { CATALYST_LAYER2_CONFIG_FILE: l2 }, cwd: cwdNoAncestry });
+    expect(r).toMatchObject({ value: null, source: "none" });
+  });
+
+  // ─── B1 REGRESSION FIXTURES (CTL-1616 PR4 remediation): the OLD linear-comment-post.sh
+  // advanced to the NEXT tier whenever clientId OR clientSecret was empty after a tier's
+  // read; canonicalizeConfigJsonValue's "any non-null value wins" rule let a CREDENTIAL-FREE
+  // or PARTIALLY-POPULATED object at a tier's path capture resolution instead, silently
+  // starving a deeper, fully-populated tier — the caller then hard-failed on the empty
+  // fields rather than falling through. Each fixture names the winning tier the OLD script
+  // would have picked (the deeper FULL-credential tier) and proves the fixed engine agrees.
+  // Mirrored byte-for-byte in __tests__/secret-contract-parity.test.sh and
+  // __tests__/catalyst-secret-contract.test.sh.
+  test("B1: primary tier holds only clientId (no clientSecret) — per-team-legacy (full) wins, not the partial primary", () => {
+    const dir = fixtureDir();
+    const l2 = writeFile(dir, "config.json", JSON.stringify({ catalyst: { linear: { bot: { worker: { clientId: "partial-cid" } } } } }));
+    const repo = resolve(dir, "repo");
+    mkdirSync(resolve(repo, ".catalyst"), { recursive: true });
+    writeFile(dir, "repo/.catalyst/config.json", JSON.stringify({ catalyst: { projectKey: "proj1" } }));
+    writeFile(dir, "config-proj1.json", JSON.stringify({ catalyst: { linear: { agent: { clientId: "PERTEAM", clientSecret: "PERTEAMSEC" } } } }));
+    const r = resolveSecret("linear-worker-actor", { env: { CATALYST_LAYER2_CONFIG_FILE: l2 }, cwd: repo });
+    expect(r).toMatchObject({
+      value: '{"clientId":"PERTEAM","clientSecret":"PERTEAMSEC"}',
+      source: "legacy-config-json",
+      legacyScope: "per-team-legacy",
+    });
+  });
+
+  test("B1: primary tier holds a CREDENTIAL-FREE object ({webhookSecret, botUserId} — a realistic production shape) — per-team-legacy (full) wins", () => {
+    const dir = fixtureDir();
+    const l2 = writeFile(dir, "config.json", JSON.stringify({ catalyst: { linear: { bot: { worker: { webhookSecret: "whs", botUserId: "uuid-123" } } } } }));
+    const repo = resolve(dir, "repo");
+    mkdirSync(resolve(repo, ".catalyst"), { recursive: true });
+    writeFile(dir, "repo/.catalyst/config.json", JSON.stringify({ catalyst: { projectKey: "proj1" } }));
+    writeFile(dir, "config-proj1.json", JSON.stringify({ catalyst: { linear: { agent: { clientId: "PERTEAM", clientSecret: "PERTEAMSEC" } } } }));
+    const r = resolveSecret("linear-worker-actor", { env: { CATALYST_LAYER2_CONFIG_FILE: l2 }, cwd: repo });
+    expect(r).toMatchObject({
+      value: '{"clientId":"PERTEAM","clientSecret":"PERTEAMSEC"}',
+      source: "legacy-config-json",
+      legacyScope: "per-team-legacy",
+    });
+  });
+
+  test("B1: primary tier holds empty-string clientId/clientSecret — global-legacy (full) wins", () => {
+    const dir = fixtureDir();
+    const l2 = writeFile(
+      dir,
+      "config.json",
+      JSON.stringify({
+        catalyst: {
+          linear: {
+            bot: { worker: { clientId: "", clientSecret: "" } },
+            agent: { clientId: "GLOBALLEGACY", clientSecret: "GLOBALLEGACYSEC" },
+          },
+        },
+      }),
+    );
+    const repo = resolve(dir, "repo");
+    mkdirSync(resolve(repo, ".catalyst"), { recursive: true });
+    writeFile(dir, "repo/.catalyst/config.json", JSON.stringify({ catalyst: { projectKey: "proj-noagent" } }));
+    // No config-proj-noagent.json file at all — the per-team-legacy tier's own file is absent,
+    // so that tier misses naturally and the chain falls all the way to global-legacy.
+    const r = resolveSecret("linear-worker-actor", { env: { CATALYST_LAYER2_CONFIG_FILE: l2 }, cwd: repo });
+    expect(r).toMatchObject({
+      value: '{"clientId":"GLOBALLEGACY","clientSecret":"GLOBALLEGACYSEC"}',
+      source: "legacy-config-json",
+      legacyScope: "global-legacy",
+    });
+  });
+
+  test("B1: primary tier absent, per-team-legacy holds only clientId (no clientSecret) — global-legacy (full) wins", () => {
+    const dir = fixtureDir();
+    const l2 = writeFile(dir, "config.json", JSON.stringify({ catalyst: { linear: { agent: { clientId: "GLOBALLEGACY", clientSecret: "GLOBALLEGACYSEC" } } } }));
+    const repo = resolve(dir, "repo");
+    mkdirSync(resolve(repo, ".catalyst"), { recursive: true });
+    writeFile(dir, "repo/.catalyst/config.json", JSON.stringify({ catalyst: { projectKey: "proj1" } }));
+    writeFile(dir, "config-proj1.json", JSON.stringify({ catalyst: { linear: { agent: { clientId: "pid-only" } } } }));
+    const r = resolveSecret("linear-worker-actor", { env: { CATALYST_LAYER2_CONFIG_FILE: l2 }, cwd: repo });
+    expect(r).toMatchObject({
+      value: '{"clientId":"GLOBALLEGACY","clientSecret":"GLOBALLEGACYSEC"}',
+      source: "legacy-config-json",
+      legacyScope: "global-legacy",
+    });
+  });
+
+  // ─── B2 REGRESSION FIXTURE: no prior fixture populated BOTH legacy tiers with DISTINCT
+  // credentials at once, so a swap of _CSC_LEGACY_TIERS's order survived every suite. This
+  // fixture pins per-team-legacy BEFORE global-legacy — see the "MUTATION TEST" section in
+  // __tests__/catalyst-secret-contract.test.sh, which actually swaps the bash array order,
+  // confirms this exact scenario's bash cell fails, then restores it.
+  test("B2: BOTH legacy tiers present with DISTINCT full credentials — per-team-legacy wins (pins tier ORDER: per-team before global)", () => {
+    const dir = fixtureDir();
+    const l2 = writeFile(dir, "config.json", JSON.stringify({ catalyst: { linear: { agent: { clientId: "GLOBALAGENT", clientSecret: "GLOBALAGENTSEC" } } } }));
+    const repo = resolve(dir, "repo");
+    mkdirSync(resolve(repo, ".catalyst"), { recursive: true });
+    writeFile(dir, "repo/.catalyst/config.json", JSON.stringify({ catalyst: { projectKey: "proj1" } }));
+    writeFile(dir, "config-proj1.json", JSON.stringify({ catalyst: { linear: { agent: { clientId: "TEAMAGENT", clientSecret: "TEAMAGENTSEC" } } } }));
+    const r = resolveSecret("linear-worker-actor", { env: { CATALYST_LAYER2_CONFIG_FILE: l2 }, cwd: repo });
+    expect(r).toMatchObject({
+      value: '{"clientId":"TEAMAGENT","clientSecret":"TEAMAGENTSEC"}',
+      source: "legacy-config-json",
+      legacyScope: "per-team-legacy",
+    });
+  });
+
+  // ─── ROUND-2 B3 REGRESSION FIXTURES (both shapes empirically pinned against
+  // `git show origin/main:.../linear-comment-post.sh` in a hermetic fixture — see the
+  // requiredObjectFields row-field comment in secret-contract.mjs for the two canon rules and
+  // their pre-fold empirical results). Mirrored byte-for-byte in
+  // __tests__/secret-contract-parity.test.sh and __tests__/catalyst-secret-contract.test.sh.
+  // Each fixture ALSO populates a real legacy tier, so the assertion proves genuine
+  // FALL-THROUGH to a deeper tier — not merely "resolves to none" (which a totally broken
+  // engine could also produce).
+  test("CANON RULE 1: a bare STRING value at the primary tier's path — even one whose OWN TEXT parses as a full {clientId,clientSecret} object — falls through to the next tier, never wins on string content", () => {
+    const dir = fixtureDir();
+    const l2 = writeFile(
+      dir,
+      "config.json",
+      JSON.stringify({
+        catalyst: {
+          linear: {
+            bot: { worker: '{"clientId":"str-cid","clientSecret":"str-csec"}' },
+            agent: { clientId: "GLOBALLEGACY", clientSecret: "GLOBALLEGACYSEC" },
+          },
+        },
+      }),
+    );
+    const cwdNoAncestry = resolve(dir, "no-ancestry-dir");
+    mkdirSync(cwdNoAncestry, { recursive: true });
+    const r = resolveSecret("linear-worker-actor", { env: { CATALYST_LAYER2_CONFIG_FILE: l2 }, cwd: cwdNoAncestry });
+    expect(r).toMatchObject({
+      value: '{"clientId":"GLOBALLEGACY","clientSecret":"GLOBALLEGACYSEC"}',
+      source: "legacy-config-json",
+    });
+  });
+
+  test("CANON RULE 2: newline-only clientId/clientSecret at the primary tier ('\\n', which the OLD script's $() capture stripped to empty) falls through to the next tier, never wins on raw non-zero length", () => {
+    const dir = fixtureDir();
+    const l2 = writeFile(
+      dir,
+      "config.json",
+      JSON.stringify({
+        catalyst: {
+          linear: {
+            bot: { worker: { clientId: "\n", clientSecret: "\n" } },
+            agent: { clientId: "GLOBALLEGACY", clientSecret: "GLOBALLEGACYSEC" },
+          },
+        },
+      }),
+    );
+    const cwdNoAncestry = resolve(dir, "no-ancestry-dir-2");
+    mkdirSync(cwdNoAncestry, { recursive: true });
+    const r = resolveSecret("linear-worker-actor", { env: { CATALYST_LAYER2_CONFIG_FILE: l2 }, cwd: cwdNoAncestry });
+    expect(r).toMatchObject({
+      value: '{"clientId":"GLOBALLEGACY","clientSecret":"GLOBALLEGACYSEC"}',
+      source: "legacy-config-json",
+    });
+  });
+});
+
+describe("resolveLegacyPerTeamConfigPath — linear-comment-post.sh's _find_layer2_config, CTL-1616 PR4", () => {
+  test("nested .catalyst.projectKey resolves to a sibling config-<key>.json next to the canonical Layer-2 path", () => {
+    const dir = fixtureDir();
+    const l2 = resolve(dir, "config.json");
+    const repo = resolve(dir, "a", "b", "repo");
+    mkdirSync(resolve(repo, ".catalyst"), { recursive: true });
+    writeFileSync(resolve(repo, ".catalyst", "config.json"), JSON.stringify({ catalyst: { projectKey: "proj1" } }));
+    const path = resolveLegacyPerTeamConfigPath({ CATALYST_LAYER2_CONFIG_FILE: l2 }, repo);
+    expect(path).toBe(resolve(dir, "config-proj1.json"));
+  });
+
+  test("bare top-level .projectKey (legacy layout) is also honored", () => {
+    const dir = fixtureDir();
+    const l2 = resolve(dir, "config.json");
+    const repo = resolve(dir, "repo");
+    mkdirSync(resolve(repo, ".catalyst"), { recursive: true });
+    writeFileSync(resolve(repo, ".catalyst", "config.json"), JSON.stringify({ projectKey: "legacy-key" }));
+    const path = resolveLegacyPerTeamConfigPath({ CATALYST_LAYER2_CONFIG_FILE: l2 }, repo);
+    expect(path).toBe(resolve(dir, "config-legacy-key.json"));
+  });
+
+  test("walks past a malformed ancestor .catalyst/config.json to find a projectKey further up", () => {
+    const dir = fixtureDir();
+    const l2 = resolve(dir, "config.json");
+    const mid = resolve(dir, "mid");
+    const leaf = resolve(mid, "leaf");
+    mkdirSync(resolve(mid, ".catalyst"), { recursive: true });
+    mkdirSync(resolve(leaf, ".catalyst"), { recursive: true });
+    writeFileSync(resolve(leaf, ".catalyst", "config.json"), "not-json");
+    writeFileSync(resolve(mid, ".catalyst", "config.json"), JSON.stringify({ catalyst: { projectKey: "mid-key" } }));
+    const path = resolveLegacyPerTeamConfigPath({ CATALYST_LAYER2_CONFIG_FILE: l2 }, leaf);
+    expect(path).toBe(resolve(dir, "config-mid-key.json"));
+  });
+
+  test("no projectKey found anywhere in the ancestry falls back to the canonical global path itself", () => {
+    const dir = fixtureDir();
+    const l2 = resolve(dir, "config.json");
+    const noAncestry = resolve(dir, "no", "ancestry", "dir");
+    mkdirSync(noAncestry, { recursive: true });
+    const path = resolveLegacyPerTeamConfigPath({ CATALYST_LAYER2_CONFIG_FILE: l2 }, noAncestry);
+    expect(path).toBe(l2);
+  });
+});
+
 // hasLiveLoneHighSurrogateEscape is an unexported module-internal helper (same convention as
 // every other readJsonField primitive in this file — containsNul, stripEol, etc. are never
 // exported either); these tests exercise its documented semantics through the one public
@@ -639,7 +946,21 @@ describe("registry validation (§6) — the rearm-hook honesty rules", () => {
     expect(registerRearmHook("github-token", null)).toBe(false);
   });
 
-  test("PR1 STATE (self-documenting, expected to shrink as later PRs wire real hooks): every SEED re-armable row currently has NO hook registered, so armSecret degrades ALL of them to the same shape a boot-only row gets", () => {
+  test("IN THIS ZERO-IMPORT LEAF (no consumer imported, this file's own beforeEach clears every hook): every SEED re-armable row degrades to the hookless shape a boot-only row gets — the underlying degrade mechanism, proven independently of any production wiring", () => {
+    // UPDATE (CTL-1616 PR4, exactly the update this test's own PR1-era comment anticipated:
+    // "that list must shrink as later PRs call registerRearmHook, and the test will need
+    // updating then — that is by design, not an oversight"): linear-orchestrator-actor now
+    // HAS a real production hook — registered in execution-core/linear-remint.mjs against
+    // the process-wide linearReminter singleton (see linear-remint.test.mjs's own
+    // "rearm-hook wiring" suite for that integration, exercised with an injected fake
+    // reminter — never the real singleton, to avoid a hermetic test triggering a genuine
+    // network mint). This file stays a zero-import leaf and never imports linear-remint.mjs,
+    // so from ITS isolated perspective (and this describe block's own beforeEach, which
+    // unconditionally clears every row's hook before each test) every re-armable row still
+    // degrades identically here — this test proves that degrade mechanism in isolation, not
+    // "no hook exists anywhere in the codebase" (which is no longer true for
+    // linear-orchestrator-actor). github-token and linear-api-token remain genuinely
+    // hookless everywhere in the codebase as of this PR.
     const reArmable = SECRET_REGISTRY.filter((r) => r.rotation.class === "re-armable");
     expect(reArmable.map((r) => r.id).sort()).toEqual(
       ["github-token", "linear-api-token", "linear-orchestrator-actor"].sort(),

--- a/plugins/dev/scripts/orch-monitor/lib/webhook-config.ts
+++ b/plugins/dev/scripts/orch-monitor/lib/webhook-config.ts
@@ -1,6 +1,13 @@
 import { readFileSync } from "fs";
 import { join } from "path";
 import { readClusterProjects, type TeamEntry } from "./cluster-roster";
+// CTL-1616 PR4: the linear-worker-actor registry row is the single declared source of the
+// NEW/OLD config-json dotted paths loadLinearAgentConfig reads — imported directly
+// cross-directory (zero-import leaf, node:fs/os/path only) rather than re-derived by hand
+// here, so a future registry change can't silently drift out of parity with this reader.
+// Precedent for this exact direct cross-directory `.mjs` + `.d.mts` import shape:
+// server.ts's `getDeploymentMode` import from "../lib/deployment-mode.mjs".
+import { getSecretRow } from "../../lib/secret-contract.mjs";
 
 export interface WebhookCliConfig {
   smeeChannel: string;
@@ -283,6 +290,26 @@ function readGithubSection(filePath: string): FileExtract | null {
   };
 }
 
+// CTL-1616 PR4: the dotted config-json paths below are single-sourced from the shared secret
+// contract's linear-worker-actor registry row — precedence PARITY with the row's own
+// resolution order (NEW global bot.worker tier, then its per-team-legacy tier), so a future
+// registry change can't silently drift out of sync with this reader. This does NOT fold onto
+// resolveSecret's own return shape: this function's distinct return shape (creds +
+// webhookSecret + botUserId, vs. resolveSecret's canonicalized {clientId,clientSecret} JSON
+// string) is preserved, and this reader still does NOT consult the row's credentialEnvPair
+// tier or its global-legacy tier — it stays the narrower 2-tier reader it has always been
+// (CTL-550); folding it onto the full resolveSecret behavior is out of this PR's scope. The
+// `?? ` literal fallbacks below are defensive only — the row/fields always exist in the
+// current registry; they guard this reader against ever crashing on a future refactor.
+const WORKER_ACTOR_ROW = getSecretRow("linear-worker-actor");
+const NEW_GLOBAL_AGENT_PATH: string[] = (
+  WORKER_ACTOR_ROW?.configJsonPath ?? "catalyst.linear.bot.worker"
+).split(".");
+const OLD_PER_TEAM_AGENT_PATH: string[] = (
+  WORKER_ACTOR_ROW?.legacyConfigTiers?.find((t) => t.scope === "per-team-legacy")?.configJsonPath ??
+  "catalyst.linear.agent"
+).split(".");
+
 /**
  * Load the Linear app-actor (worker) credentials. Reads from two locations with
  * the NEW global path taking precedence over the OLD per-team path:
@@ -327,7 +354,7 @@ export function loadLinearAgentConfig(
   const globalConfigPath = join(homeConfigDir, "config.json");
   try {
     const globalParsed: unknown = JSON.parse(readFileSync(globalConfigPath, "utf8"));
-    const result = extractCreds(globalParsed, ["catalyst", "linear", "bot", "worker"]);
+    const result = extractCreds(globalParsed, NEW_GLOBAL_AGENT_PATH);
     if (result !== null) return result;
   } catch { /* absent / malformed — fall through */ }
 
@@ -336,7 +363,7 @@ export function loadLinearAgentConfig(
   const perTeamConfigPath = join(homeConfigDir, `config-${projectKey}.json`);
   try {
     const perTeamParsed: unknown = JSON.parse(readFileSync(perTeamConfigPath, "utf8"));
-    return extractCreds(perTeamParsed, ["catalyst", "linear", "agent"]);
+    return extractCreds(perTeamParsed, OLD_PER_TEAM_AGENT_PATH);
   } catch {
     return null;
   }


### PR DESCRIPTION
## Summary

CTL-1616 migration plan **PR4** — the highest-blast-radius slice (live credential paths). The four mint-chain sites now resolve through the registry: `lib/linear-app-actor.sh` (canonical bash mint — mechanics byte-identical), `execution-core/linear-remint.mjs` (+ the cooldown reminter registered as the row's **on-401 rearm hook** — the first production `registerRearmHook` wiring; the broker's async reminter deliberately stays outside the sync seam), `lib/linear-comment-post.sh` (all four tiers moved into the `linear-worker-actor` row: `credentialEnvPair` + `legacyConfigTiers`, append-only), and `orch-monitor/lib/webhook-config.ts` (paths derived from the row, return shape preserved).

**New row-declared gate** `requiredObjectFields: ["clientId","clientSecret"]` — a config tier wins only with all fields non-empty (post EOL-strip), else the chain continues. Two canon rules pinned **empirically against the pre-fold script** and enforced identically in both engines: a JSON-string tier value falls through (the old script *crashed* there under `set -euo pipefail`; fall-through is the safe canon), and trailing-EOL-only fields fall through (jq-side `[\r\n]+$` strip; a CR-only parity cell pins the exact `$()`-capture asymmetry).

## ⚠️ Flagged behavior changes (design risk-4 discipline)

1. **Layer-2 path convergence** (sanctioned by §8's PR4 heading): `linear-comment-post`'s tiers move from hardcoded `$HOME` literals to the canonical `resolveLayer2Path` chain — override env vars now honored; inert on default-env hosts (both minis).
2. Stringified-credential-JSON at `catalyst.linear.bot.orchestrator` is now accepted (old code errored) — fail→success, cross-stack consistent; the orchestrator row is single-tier.
3. `resolveLayer2Path` prefers `env.HOME` over `os.homedir()` (scrubbed launchd-style environments only).

## Verification — three adversarial rounds, every finding fixed + re-verified

- **R1 BLOCK**: partial-tier capture (a credential-free `bot.worker` object — a realistic shape holding only `webhookSecret`/`botUserId` — swallowed the chain and hard-failed where the old script fell through) + legacy-tier order completely unpinned (registry swap survived all suites). 
- **R2 BLOCK**: the fix itself diverged cross-engine (bash won on string-JSON via a lossy jq/`$()` re-parse; JS won on newline-only fields).
- **R3 PASS**: `@OBJ64`-tag gating + jq-side EOL strip; all divergent shapes byte-identical across engines; mutations (gate revert, stripEol revert, tier swap) each killed by a specific cell; pre-fold behavior confirmed by running the old script from `git show origin/main` in hermetic fixtures.

Suites (direct exit codes): parity **175/0** · bash engine 111/0 · JS engine 111/0 · remint 65/0 · doctor 346/0 · linear-comment-post at its pre-existing 12/5 env-noise baseline (verified unchanged vs main).

## Post-merge plan (merge gate per design §9 PR4)

Sequential deploy: mini → live mint + `checkBotCredentials` + **pre/post credential-source diff** → only then mini-2 → same. The diff (which credential each chain selects, names/sources only) is the gate, not a nicety.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WHfJt1JhsdArSUyxwZZzkN