### PR TITLE
fix(dev): CTL-1616 keep the resolved secret VALUE out of child-process environments

### DIFF
--- a/plugins/dev/scripts/__tests__/catalyst-secret-contract.test.sh
+++ b/plugins/dev/scripts/__tests__/catalyst-secret-contract.test.sh
@@ -609,6 +609,19 @@ expect_eq "B4: catalyst_arm_secret(unknown id) under set -e exits 0 (does not ab
 expect_eq "B4: catalyst_arm_secret(unknown id) under set -e still returns the quiet triple" \
   "false|false|false" "$ERREXIT_OUT"
 
+# ─── SECRET-ENV HYGIENE (#2924 post-merge Codex P2): the resolved VALUE must be
+# readable in the resolving shell but NEVER exported (a long-lived daemon shell
+# launches its runtime as a child; an exported credential lands in every
+# descendant's environment). Exportedness asserted via declare -p (-x flag).
+# NOTE: _run treats a leading *=* arg as an env assignment, so the snippet
+# below is written =-free and the token rides the assigns slot.
+HYGIENE_OUT="$(_run LINEAR_API_TOKEN=tok-hygiene 'catalyst_resolve_secret linear-api-token >/dev/null
+printf "%s|" "${CATALYST_SECRET_LAST_VALUE:-ABSENT}"
+case "$(declare -p CATALYST_SECRET_LAST_VALUE 2>/dev/null)" in "declare -x"*) printf "exported|" ;; *) printf "notexported|" ;; esac
+case "$(declare -p CATALYST_SECRET_LAST_SOURCE 2>/dev/null)" in "declare -x"*) printf "exported" ;; *) printf "notexported" ;; esac')"
+expect_eq "hygiene: VALUE readable same-shell, NOT exported; SOURCE breadcrumb exported" \
+  "tok-hygiene|notexported|exported" "$HYGIENE_OUT"
+
 echo ""
 echo "Total: $((PASSES + FAILURES)), Passed: $PASSES, Failed: $FAILURES, Skipped: 0"
 exit "$FAILURES"

--- a/plugins/dev/scripts/lib/catalyst-secret-contract.sh
+++ b/plugins/dev/scripts/lib/catalyst-secret-contract.sh
@@ -487,7 +487,13 @@ _csc_set_result() {
   CATALYST_SECRET_LAST_SOURCE="$2"
   # shellcheck disable=SC2034
   CATALYST_SECRET_LAST_PROVIDER="$3"
-  export CATALYST_SECRET_LAST_VALUE CATALYST_SECRET_LAST_SOURCE CATALYST_SECRET_LAST_PROVIDER
+  # SECRET HYGIENE (#2924 post-merge Codex P2): the VALUE is deliberately NOT
+  # exported — every reader is same-shell, and an exported value would be
+  # inherited by every child of a long-lived daemon shell (catalyst-broker /
+  # catalyst-execution-core launch their runtimes from the resolving shell),
+  # putting the credential in each child's environment. The non-secret
+  # SOURCE/PROVIDER breadcrumbs stay exported for logging convenience.
+  export CATALYST_SECRET_LAST_SOURCE CATALYST_SECRET_LAST_PROVIDER
   printf '%s|%s|%s' "$1" "$2" "$3"
 }
 

--- a/plugins/dev/scripts/lib/linear-app-actor.sh
+++ b/plugins/dev/scripts/lib/linear-app-actor.sh
@@ -37,6 +37,11 @@ linear_app_actor_auth() {
   local _ocid _ocsec _otok _creds
   catalyst_resolve_secret linear-orchestrator-actor >/dev/null
   _creds="$CATALYST_SECRET_LAST_VALUE"
+  # Clear the breadcrumb the moment it's copied (#2924 post-merge Codex P2):
+  # this shell goes on to exec the long-lived daemon runtime, and a lingering
+  # credential variable in the daemon shell serves nobody. (The lib no longer
+  # exports the VALUE at all; this unset is belt-and-braces for THIS shell.)
+  unset CATALYST_SECRET_LAST_VALUE
   if [[ -n "$_creds" ]]; then
     _ocid=$(printf '%s' "$_creds" | jq -r '.clientId // empty' 2>/dev/null)
     _ocsec=$(printf '%s' "$_creds" | jq -r '.clientSecret // empty' 2>/dev/null)

--- a/plugins/dev/scripts/lib/linear-comment-post.sh
+++ b/plugins/dev/scripts/lib/linear-comment-post.sh
@@ -42,6 +42,8 @@ if [[ -n "$CATALYST_SECRET_LAST_VALUE" ]]; then
   CLIENT_ID=$(printf '%s' "$CATALYST_SECRET_LAST_VALUE" | jq -r '.clientId // empty' 2>/dev/null)
   CLIENT_SECRET=$(printf '%s' "$CATALYST_SECRET_LAST_VALUE" | jq -r '.clientSecret // empty' 2>/dev/null)
 fi
+# Secret hygiene (#2924 post-merge Codex P2): drop the breadcrumb once copied.
+unset CATALYST_SECRET_LAST_VALUE
 
 # CTL-1111 back-compat: the pre-fold script ran the per-team directory walk-up (and its "no
 # projectKey found" loud warning) UNCONDITIONALLY whenever the env-credential-pair was absent


### PR DESCRIPTION
## Summary

Post-merge #2924 Codex finding, verified real: `_csc_set_result` exported `CATALYST_SECRET_LAST_VALUE`, so after the mint helper resolved orchestrator credentials the full JSON (including `clientSecret`) was inherited by the daemons' long-lived runtimes and every descendant process.

- The VALUE is no longer exported — every reader is same-shell; the non-secret SOURCE/PROVIDER breadcrumbs stay exported.
- Both consumers (`linear-app-actor.sh`, `linear-comment-post.sh`) also `unset` the breadcrumb immediately after copying into locals.
- New hygiene test asserts via `declare -p`: VALUE readable same-shell but not `-x`; SOURCE stays `-x`.

Suites: bash engine 112/0 · parity 175/0 · linear-comment-post at its pre-existing 12/5 env-noise baseline · shellcheck/bash -n clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WHfJt1JhsdArSUyxwZZzkN