### PR TITLE
fix(dev): CTL-1616 clear the sticky export attribute on the value breadcrumb

### DIFF
--- a/plugins/dev/scripts/__tests__/catalyst-secret-contract.test.sh
+++ b/plugins/dev/scripts/__tests__/catalyst-secret-contract.test.sh
@@ -622,6 +622,16 @@ case "$(declare -p CATALYST_SECRET_LAST_SOURCE 2>/dev/null)" in "declare -x"*) p
 expect_eq "hygiene: VALUE readable same-shell, NOT exported; SOURCE breadcrumb exported" \
   "tok-hygiene|notexported|exported" "$HYGIENE_OUT"
 
+# Sticky-export regression (#2925 post-merge P2): if the shell INHERITED the
+# breadcrumb already-exported (rolling upgrade from the pre-fix lib), plain
+# reassignment keeps bash's -x attribute — _csc_set_result must clear it.
+# The stale exported value is seeded via _run's assigns slot (env -i exports it).
+HYGIENE_STICKY="$(_run LINEAR_API_TOKEN=tok-hygiene CATALYST_SECRET_LAST_VALUE=stale-exported 'catalyst_resolve_secret linear-api-token >/dev/null
+printf "%s|" "${CATALYST_SECRET_LAST_VALUE:-ABSENT}"
+case "$(declare -p CATALYST_SECRET_LAST_VALUE 2>/dev/null)" in "declare -x"*) printf "exported" ;; *) printf "notexported" ;; esac')"
+expect_eq "hygiene: inherited-exported breadcrumb loses -x on the next resolve (sticky-export cleared)" \
+  "tok-hygiene|notexported" "$HYGIENE_STICKY"
+
 echo ""
 echo "Total: $((PASSES + FAILURES)), Passed: $PASSES, Failed: $FAILURES, Skipped: 0"
 exit "$FAILURES"

--- a/plugins/dev/scripts/lib/catalyst-secret-contract.sh
+++ b/plugins/dev/scripts/lib/catalyst-secret-contract.sh
@@ -493,6 +493,11 @@ _csc_set_result() {
   # catalyst-execution-core launch their runtimes from the resolving shell),
   # putting the credential in each child's environment. The non-secret
   # SOURCE/PROVIDER breadcrumbs stay exported for logging convenience.
+  # Bash's export attribute is STICKY across reassignment (#2925 post-merge
+  # Codex P2): a shell that inherited the variable already-exported (rolling
+  # upgrade from the pre-fix lib, or any caller's own export) would keep
+  # leaking the NEW value — so the attribute is cleared explicitly each time.
+  export -n CATALYST_SECRET_LAST_VALUE 2>/dev/null || true
   export CATALYST_SECRET_LAST_SOURCE CATALYST_SECRET_LAST_PROVIDER
   printf '%s|%s|%s' "$1" "$2" "$3"
 }


### PR DESCRIPTION
## Summary

Post-merge #2925 Codex finding, verified: bash's export attribute is sticky across reassignment, so a shell that inherited `CATALYST_SECRET_LAST_VALUE` already-exported (rolling upgrade from the pre-fix lib, or a caller's own export) kept leaking each newly resolved credential to children. `_csc_set_result` now clears the attribute explicitly (`export -n`) on every resolve.

Test seeds a stale exported breadcrumb and asserts the next resolve drops `-x`; mutation-verified (removing the line fails exactly that test). Suite 113/0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WHfJt1JhsdArSUyxwZZzkN