### PR TITLE
feat(dev): CTL-1616 cloud-token name-resolver unification + Groq resolveApiKey adoption (PR5)

### DIFF
--- a/plugins/dev/scripts/__tests__/health-responder.test.sh
+++ b/plugins/dev/scripts/__tests__/health-responder.test.sh
@@ -1087,6 +1087,54 @@ touch "$AGENT_PLIST_FILE"; touch -t 202501010000 "$AGENT_HEARTBEAT_FILE"
 run "T74: the agent block runs clean under real /bin/bash (production interpreter)" \
   bash -c "out=\$(RESPONDER_KICKSTART_WAIT_SECS=0 /bin/bash '$RESPONDER' 2>&1); printf '%s' \"\$out\" | grep -q 'unbound variable' && exit 1; grep -qF '$AGENT_KICK' '${KICKSTART_LOG}'"
 
+# ─── Phase 15: CTL-1616 PR5 — cloud-token fixture-matrix completion (T75–T77) ─
+#
+# T57-T59 (Phase 13, above) already cover the BASH-FALLBACK column of the design §9 PR5
+# fixture matrix ({env-override, layer2, default} x {bun-path, bash-fallback}) with bun
+# unavailable. T49x/T59 already cover the bun-path x default cell with REAL bun. T75-T76
+# close the two remaining cells — bun-path x env-override and bun-path x layer2-override —
+# with REAL bun (not mocked), completing all 6 matrix cells across this suite. No bun mock is
+# installed here, so `_resolve_token_env_via_bun` exercises the real config.mjs
+# resolveNodeCloudTokenEnv() delegate (which itself now folds onto lib/secret-contract.mjs's
+# resolveCloudTokenName — CTL-1616 PR5).
+
+_agent_reset
+touch "$PLIST"
+export MOCK_LAST_EXIT=0
+mkdir -p "${HOME}/.config/catalyst"
+printf 'export CATALYST_CLOUD_TOKEN_ENV=MY_CUSTOM_TOKEN\nexport MY_CUSTOM_TOKEN=real-value\n' > "${HOME}/.config/catalyst/cloud-sync.env"
+run "T75: bun AVAILABLE + env-override token name resolves via the bun path (fixture-matrix cell)" \
+  bash -c "out=\$(RESPONDER_KICKSTART_WAIT_SECS=0 bash '$RESPONDER'); printf '%s' \"\$out\" | grep -q 'failed-bounce signature' && test -s '${KICKSTART_LOG}'"
+rm -f "${HOME}/.config/catalyst/cloud-sync.env" "$KICKSTART_LOG"
+
+printf 'export ANOTHER_CUSTOM_TOKEN=real-value\n' > "${HOME}/.config/catalyst/cloud-sync.env"
+printf '{"catalyst":{"cloud":{"tokenEnv":"ANOTHER_CUSTOM_TOKEN"}}}' > "${SCRATCH}/layer2-config.json"
+run "T76: bun AVAILABLE + Layer-2 tokenEnv override resolves via the bun path (fixture-matrix cell)" \
+  bash -c "out=\$(CATALYST_LAYER2_CONFIG_FILE='${SCRATCH}/layer2-config.json' RESPONDER_KICKSTART_WAIT_SECS=0 bash '$RESPONDER'); printf '%s' \"\$out\" | grep -q 'failed-bounce signature' && test -s '${KICKSTART_LOG}'"
+rm -f "${HOME}/.config/catalyst/cloud-sync.env" "$KICKSTART_LOG" "${SCRATCH}/layer2-config.json"
+unset MOCK_LAST_EXIT
+
+# T77 (bash 3.2, CTL-1616 PR5): the sourced lib/catalyst-secret-contract.sh + the new
+# catalyst_secret_cloud_token_name call inside _token_provisioned's `probe="$(...)"` body must
+# not reintroduce the T64 comment-in-subshell defect — the function CALL itself is the only
+# thing textually inside that substitution (its definition lives in the separately-sourced
+# file, parsed before the subshell is ever entered), but this pins the empirical guarantee
+# under the real production interpreter with the bash-fallback path forced (bun mocked off).
+cat > "$MOCKBIN/bun" <<'EOF'
+#!/usr/bin/env bash
+exit 1
+EOF
+chmod +x "$MOCKBIN/bun"
+_agent_reset
+touch "$PLIST"
+export MOCK_LAST_EXIT=0
+mkdir -p "${HOME}/.config/catalyst"
+printf 'export CATALYST_CLOUD_TOKEN=real-value\n' > "${HOME}/.config/catalyst/cloud-sync.env"
+run "T77: bash-fallback path (bun unavailable) runs clean under real /bin/bash (production interpreter)" \
+  bash -c "out=\$(RESPONDER_KICKSTART_WAIT_SECS=0 /bin/bash '$RESPONDER' 2>&1); printf '%s' \"\$out\" | grep -q 'unbound variable' && exit 1; printf '%s' \"\$out\" | grep -q 'failed-bounce signature' && test -s '${KICKSTART_LOG}'"
+rm -f "${HOME}/.config/catalyst/cloud-sync.env" "$MOCKBIN/bun"
+unset MOCK_LAST_EXIT
+
 # ─── results ────────────────────────────────────────────────────────────────
 
 echo ""

--- a/plugins/dev/scripts/execution-core/__tests__/config-cloud-token-env.test.mjs
+++ b/plugins/dev/scripts/execution-core/__tests__/config-cloud-token-env.test.mjs
@@ -8,6 +8,7 @@ import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { resolveNodeCloudTokenEnv } from "../config.mjs";
+import { resolveCloudTokenName } from "../../lib/secret-contract.mjs";
 
 const ENV_KEYS = ["CATALYST_CLOUD_TOKEN_ENV", "CATALYST_CLOUD_TOKEN", "CATALYST_LAYER2_CONFIG_FILE", "CATALYST_HOST_NAME"];
 let saved;
@@ -79,6 +80,31 @@ describe("resolveNodeCloudTokenEnv — overrides (per-host config, not code)", (
     writeFileSync(p, "{ not json");
     process.env.CATALYST_LAYER2_CONFIG_FILE = p;
     expect(resolveNodeCloudTokenEnv()).toEqual({ envVar: "CATALYST_CLOUD_TOKEN", source: "default" });
+  });
+});
+
+describe("resolveNodeCloudTokenEnv — CTL-1616 PR5: byte-for-byte parity with the registry's resolveCloudTokenName", () => {
+  // resolveNodeCloudTokenEnv is now a thin delegate over lib/secret-contract.mjs's
+  // resolveCloudTokenName (design §8/§9 PR5) — this suite pins that delegation directly
+  // rather than only re-exercising resolveNodeCloudTokenEnv's own ladder, so a future
+  // refactor that reintroduces a SECOND hand-rolled copy fails loudly here. Fixture matrix
+  // per design §9 PR5 success criteria: {env-override, layer2, default} — the other half of
+  // the matrix ({bun-path, bash-fallback}) is exercised cross-language by
+  // __tests__/health-responder.test.sh (T57-T59 bash-fallback, T75-T76 bun-path).
+  test("no overrides → both resolvers agree: default/CATALYST_CLOUD_TOKEN", () => {
+    expect(resolveNodeCloudTokenEnv()).toEqual(resolveCloudTokenName(process.env));
+  });
+
+  test("env override → both resolvers agree", () => {
+    process.env.CATALYST_CLOUD_TOKEN_ENV = "MY_CUSTOM_TOKEN";
+    expect(resolveNodeCloudTokenEnv()).toEqual(resolveCloudTokenName(process.env));
+    expect(resolveNodeCloudTokenEnv()).toEqual({ envVar: "MY_CUSTOM_TOKEN", source: "env" });
+  });
+
+  test("Layer-2 catalyst.cloud.tokenEnv override → both resolvers agree", () => {
+    writeLayer2({ catalyst: { cloud: { tokenEnv: "L2_TOKEN" } } });
+    expect(resolveNodeCloudTokenEnv()).toEqual(resolveCloudTokenName(process.env));
+    expect(resolveNodeCloudTokenEnv()).toEqual({ envVar: "L2_TOKEN", source: "layer2" });
   });
 });
 

--- a/plugins/dev/scripts/execution-core/config-pino-fallback.test.mjs
+++ b/plugins/dev/scripts/execution-core/config-pino-fallback.test.mjs
@@ -53,6 +53,11 @@ function stageScratch() {
   cpSync(resolve(__dirname, "config-schema.mjs"), join(scratch, "config-schema.mjs"));
   // CTL-1617: the zero-import deployment-mode leaf config.mjs re-exports.
   cpSync(resolve(__dirname, "../lib/deployment-mode.mjs"), join(libDir, "deployment-mode.mjs"));
+  // CTL-1616 PR5: config.mjs's resolveNodeCloudTokenEnv now delegates to the zero-import
+  // secret-contract leaf's resolveCloudTokenName — copy it too so this scratch fixture's
+  // module graph resolves identically to production (same rationale as deployment-mode.mjs
+  // above).
+  cpSync(resolve(__dirname, "../lib/secret-contract.mjs"), join(libDir, "secret-contract.mjs"));
   // type:module + no deps -> pino unresolvable from this directory tree.
   writeFileSync(
     join(scratch, "package.json"),

--- a/plugins/dev/scripts/execution-core/config.mjs
+++ b/plugins/dev/scripts/execution-core/config.mjs
@@ -15,6 +15,13 @@ import { readFileSync, existsSync, rmSync, writeFileSync, readdirSync } from "no
 // risk the pino try/catch below guards against.
 import { schemaCompat } from "./config-schema.mjs";
 
+// CTL-1616 PR5: the canonical cloud-token NAME resolver is a zero-import leaf
+// (../lib/secret-contract.mjs) shared verbatim by execution-core (this module,
+// via resolveNodeCloudTokenEnv below) and health-responder.sh's bash fallback
+// (via lib/catalyst-secret-contract.sh's catalyst_secret_cloud_token_name) —
+// same precedent as CTL-1617's deployment-mode re-export just below.
+import { resolveCloudTokenName } from "../lib/secret-contract.mjs";
+
 // --- Logger (CTL-578) ---
 // Pino is the daemon's runtime logger. A worktree checkout that hasn't run
 // `bun install` cannot resolve it — and any module graph that includes
@@ -1935,33 +1942,37 @@ export function getCloudSyncSelfHealPath() {
 // lets a host point at a differently-named var. NAME-ONLY: this never reads or returns the
 // secret VALUE (the writer reads process.env[name]; doctor checks presence by name), so the
 // result is safe to log.
-const DEFAULT_CLOUD_TOKEN_ENV = "CATALYST_CLOUD_TOKEN";
-
-// readLayer2CloudTokenEnv — the raw catalyst.cloud.tokenEnv string from the Layer-2
-// file, or undefined (absent/malformed/non-string). Never throws (parity with
-// readLayer2NodeClass). The per-host escape hatch — name your token var without a code change.
-function readLayer2CloudTokenEnv() {
-  try {
-    const v = JSON.parse(readFileSync(getLayer2ConfigPath(), "utf8"))?.catalyst?.cloud?.tokenEnv;
-    return typeof v === "string" && v.length > 0 ? v : undefined;
-  } catch {
-    return undefined;
-  }
-}
-
-// resolveNodeCloudTokenEnv — resolve the env-var NAME that holds this host's cloud token:
-// env override → Layer-2 override → the standard `CATALYST_CLOUD_TOKEN`. Returns
-// { envVar, source } where source ∈ "env" | "layer2" | "default". Pure + NAME-only: it never
-// reads process.env[envVar] (the secret value), so it is safe to log the result. No host
-// names are hardcoded — the resolver is host-agnostic by design.
+//
+// CTL-1616 PR5 FOLD: this used to be a hand-rolled 3-tier ladder (env override → Layer-2
+// override read via the OLD non-injectable getLayer2ConfigPath() → the hardcoded default)
+// duplicated against health-responder.sh's bash fallback (design table: "CATALYST_CLOUD_TOKEN
+// name resolution — 2 copies, hand-duplicated precedence ladder"). It is now a THIN DELEGATE
+// onto the secret contract's single NAME resolver (lib/secret-contract.mjs
+// resolveCloudTokenName) — the SAME implementation health-responder.sh's bash fallback mirrors
+// via lib/catalyst-secret-contract.sh's catalyst_secret_cloud_token_name (§9 PR5 fixture
+// matrix: both readers must agree byte-for-byte on the resolved NAME for
+// {env-override,layer2,default} × {bun-path,bash-fallback}). RETURN SHAPE is byte-compatible
+// with every existing caller (doctor.mjs's checkCloudSync `tokenEnv = resolveNodeCloudTokenEnv()`
+// and checkCloudTokenEnv's shadow-diff, cloud-sync.mjs, health-responder.sh's bun probe): still
+// { envVar, source } with source ∈ "env" | "layer2" | "default".
+//
+// ONE INCIDENTAL BEHAVIOR NOTE (not a named design risk, flagged here for honesty): the OLD
+// readLayer2CloudTokenEnv() read the Layer-2 file via getLayer2ConfigPath() — homedir-only,
+// ignoring CATALYST_MACHINE_CONFIG / XDG_CONFIG_HOME — and, separately, ALWAYS consulted real
+// process.env for that file path regardless of the `env` param a caller passed in (a latent
+// injection gap; every existing test mutates process.env directly rather than passing a custom
+// `env`, so this was never observed). resolveCloudTokenName delegates to the registry's
+// resolveLayer2Path, which IS the canonical CATALYST_LAYER2_CONFIG_FILE > CATALYST_MACHINE_CONFIG
+// > XDG_CONFIG_HOME > ~/.config/catalyst chain (design §2) and DOES honor the injected `env`
+// param. On a host that sets CATALYST_MACHINE_CONFIG or XDG_CONFIG_HOME but not
+// CATALYST_LAYER2_CONFIG_FILE, the Layer-2 file this resolver now reads for the
+// catalyst.cloud.tokenEnv override can differ from before PR5 — every existing test only sets
+// CATALYST_LAYER2_CONFIG_FILE directly (the tier both chains check first), so no test's
+// behavior changes, but this is a REAL, if narrow, behavior change worth flagging alongside the
+// Groq fold below rather than letting the general Layer-2-path unification (design §9 PR6)
+// quietly absorb it here first.
 export function resolveNodeCloudTokenEnv({ env = process.env } = {}) {
-  const override = env.CATALYST_CLOUD_TOKEN_ENV;
-  if (typeof override === "string" && override.length > 0) {
-    return { envVar: override, source: "env" };
-  }
-  const l2 = readLayer2CloudTokenEnv();
-  if (l2) return { envVar: l2, source: "layer2" };
-  return { envVar: DEFAULT_CLOUD_TOKEN_ENV, source: "default" };
+  return resolveCloudTokenName(env);
 }
 
 export function readDelegateRunnerConfig(env = process.env) {

--- a/plugins/dev/scripts/health-responder.sh
+++ b/plugins/dev/scripts/health-responder.sh
@@ -105,6 +105,16 @@ SCRIPT_DIR="$(cd "$(dirname "$_SRC")" && pwd)"
 unset _SRC
 export PATH="${PATH}:${SCRIPT_DIR}"
 
+# CTL-1616 PR5: the secret-contract bash mirror — sourced here (once, at script load, NOT
+# inside the bounded token-resolution path) so _token_provisioned's pure-bash fallback ladder
+# (below) can call catalyst_secret_cloud_token_name instead of hand-rolling its own jq-based
+# ladder. SAFE to source unconditionally: the file is pure function/array definitions at
+# source time (idempotent-load-guarded, no subprocess/network/jq call happens until a function
+# is actually invoked) — it cannot itself hang or wedge the sweep the way an unbounded `bun`
+# subprocess could (see _resolve_token_env_via_bun's own bounding below).
+# shellcheck source=lib/catalyst-secret-contract.sh
+source "${SCRIPT_DIR}/lib/catalyst-secret-contract.sh"
+
 # ─── arg parsing ────────────────────────────────────────────────────────────
 
 DRY_RUN="${RESPONDER_DRY_RUN:-0}"
@@ -243,10 +253,13 @@ RESPONDER_CLUSTER_ENV_FILE="${RESPONDER_CLUSTER_ENV_FILE:-${HOME}/.config/cataly
 # false-escalation storm). Mirrors catalyst-stack's install-time token probe
 # byte-for-byte: source both files in a subshell matching launch.sh's view,
 # resolve the env-var NAME via the same config.mjs helper (falls back to the
-# literal CATALYST_CLOUD_TOKEN if bun is unavailable), then check presence of
-# THAT resolved name — never a fixed/guessed variable name.
+# secret-contract bash mirror's catalyst_secret_cloud_token_name if bun is
+# unavailable — CTL-1616 PR5), then check presence of THAT resolved name —
+# never a fixed/guessed variable name.
 # _resolve_token_env_via_bun: prints the resolved env-var NAME from
-# resolveNodeCloudTokenEnv(), or prints nothing on timeout/failure/absence.
+# resolveNodeCloudTokenEnv() — which is itself now a thin delegate over
+# lib/secret-contract.mjs's resolveCloudTokenName (CTL-1616 PR5) — or prints
+# nothing on timeout/failure/absence.
 # Bounded the same way _last_exit_status bounds `launchctl list` (Codex P2
 # round 5): this runs INSIDE _token_provisioned, which runs AFTER the sweep
 # lock is acquired — an unbounded bun call there would let a wedged bun or
@@ -311,11 +324,16 @@ _resolve_token_env_via_bun() {
 # shell) since this responder has no different context to simulate and both
 # the bun path and the bash fallback below need to see a real override.
 # _resolve_token_env_via_bun returning empty means bun was unavailable or its
-# import failed; the fallback then replicates resolveNodeCloudTokenEnv's own
-# precedence in pure bash — env override (from the sourced files) first, then
-# the Layer-2 catalyst.cloud.tokenEnv key, then the standard name — instead
-# of hardcoding the default, which would misclassify a node with a genuinely
-# custom-named token as tokenless whenever bun happens to be unavailable.
+# import failed; the fallback then calls catalyst_secret_cloud_token_name
+# (lib/catalyst-secret-contract.sh, sourced at script load above) — the SAME
+# registry row's bash mirror, not a hand-duplicated ladder — which resolves
+# the identical env-override / Layer-2 catalyst.cloud.tokenEnv / default
+# precedence in pure bash (design §9 PR5: "both cloud-token readers agree
+# byte-for-byte on the resolved env-var name"). Sourcing that lib is cheap
+# (function/array definitions only — no subprocess/network at load time; see
+# the `source` comment above), so this fallback still never blocks on
+# anything heavier than the same jq call the OLD hand-rolled ladder already
+# made.
 _token_provisioned() {
   local probe
   probe="$(
@@ -325,16 +343,8 @@ _token_provisioned() {
     [[ -r "$RESPONDER_TOKEN_FILE" ]] && . "$RESPONDER_TOKEN_FILE"
     name="$(_resolve_token_env_via_bun)"
     if [[ -z "$name" ]]; then
-      if [[ -n "${CATALYST_CLOUD_TOKEN_ENV:-}" ]]; then
-        name="$CATALYST_CLOUD_TOKEN_ENV"
-      else
-        l2_file="${CATALYST_LAYER2_CONFIG_FILE:-${HOME}/.config/catalyst/config.json}"
-        name=""
-        if [[ -r "$l2_file" ]] && command -v jq >/dev/null 2>&1; then
-          name="$(jq -r '.catalyst.cloud.tokenEnv // empty' "$l2_file" 2>/dev/null)"
-        fi
-        [[ -z "$name" ]] && name="CATALYST_CLOUD_TOKEN"
-      fi
+      catalyst_secret_cloud_token_name cloud-token >/dev/null
+      name="$CATALYST_SECRET_TOKEN_NAME"
     fi
     [[ -n "${!name:-}" ]] && printf yes || printf no
   )"

--- a/plugins/dev/scripts/lib/api-key-health.d.mts
+++ b/plugins/dev/scripts/lib/api-key-health.d.mts
@@ -1,0 +1,71 @@
+// Type declarations for api-key-health.mjs (CTL-343) — kept in sync manually with the
+// runtime module, mirroring the dsl-compile.d.mts / secret-contract.d.mts convention (no
+// build step; orch-monitor's tsconfig has no `allowJs`, so any `.mjs` a `.ts`/`.tsx` file
+// imports directly needs a companion `.d.mts` or strict mode's noImplicitAny fails it).
+//
+// CTL-1616 PR5: added because orch-monitor/cli/hud.tsx now imports resolveApiKey directly
+// (folding its GROQ_API_KEY resolution onto the same shared resolver broker/config.mjs
+// already uses — see hud.tsx's PR5 comment for the fold rationale).
+
+export type ApiKeySource = "env" | "project-config" | "config" | null;
+
+export interface ResolveApiKeyOptions {
+  envName?: string;
+  configKeyPath: string;
+  /** Global config file path. Defaults to ~/.config/catalyst/config.json */
+  configPath?: string;
+  /** Optional per-project config file path, checked before the global config. */
+  projectConfigPath?: string;
+}
+
+export interface ResolvedApiKey {
+  value: string;
+  source: ApiKeySource;
+  prefix: string | null;
+}
+
+export function resolveApiKey(opts: ResolveApiKeyOptions): ResolvedApiKey;
+
+export function formatMissingKeyWarning(opts: {
+  name: string;
+  envName: string;
+  configPath: string;
+  configKeyPath: string;
+  getUrl: string;
+}): string;
+
+export function formatLoadedKeyInfo(opts: {
+  name: string;
+  source: ApiKeySource;
+  prefix: string | null;
+}): string;
+
+export interface GroqGatewayConfig {
+  enabled?: boolean;
+  baseUrl?: string;
+  headers?: Record<string, string>;
+}
+
+export interface DerivedGroqEndpoint {
+  url: string;
+  extraHeaders: Record<string, string>;
+  gatewayEnabled: boolean;
+}
+
+export function deriveGroqEndpoint(opts: { gateway?: GroqGatewayConfig | null }): DerivedGroqEndpoint;
+
+export type ProbeGroqStatus = "ok" | "missing" | "unauthorized" | "error";
+
+export interface ProbeGroqResult {
+  status: ProbeGroqStatus;
+  modelCount?: number;
+  error?: string;
+}
+
+export function probeGroq(opts: {
+  apiKey: string | null | undefined;
+  endpoint: string;
+  extraHeaders?: Record<string, string>;
+  fetch?: typeof fetch;
+  timeoutMs?: number;
+}): Promise<ProbeGroqResult>;

--- a/plugins/dev/scripts/lib/api-key-health.test.mjs
+++ b/plugins/dev/scripts/lib/api-key-health.test.mjs
@@ -2,9 +2,10 @@
 // Run from plugins/dev/scripts/broker: bun test ../lib/api-key-health.test.mjs
 
 import { describe, test, expect, beforeEach, afterEach } from "bun:test";
-import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
+import { mkdtempSync, writeFileSync, rmSync, readFileSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
 
 import {
   resolveApiKey,
@@ -13,6 +14,8 @@ import {
   probeGroq,
   deriveGroqEndpoint,
 } from "./api-key-health.mjs";
+
+const SCRIPTS_DIR = dirname(dirname(fileURLToPath(import.meta.url)));
 
 // ─── resolveApiKey ───────────────────────────────────────────────────────────
 
@@ -359,5 +362,119 @@ describe("probeGroq", () => {
       fetch: fakeFetch,
     });
     expect(calledHeaders.Authorization).toBe("Bearer gsk_test");
+  });
+});
+
+// ─── CTL-1616 PR5: Groq call-site fold parity ────────────────────────────────
+//
+// broker/config.mjs, lib/dsl-cli.mjs, and orch-monitor/cli/hud.tsx are the 3 Groq-key call
+// sites the design table tracks ("GROQ_API_KEY — 2 ladders; resolveApiKey adopted by 1 of 3
+// sites; tier count differs"). PR5 folds the other 2 onto the SAME resolveApiKey call shape
+// broker/config.mjs already uses. dsl-cli.mjs runs its CLI `main()` unconditionally at import
+// (unsafe to import in a test) and hud.tsx is a TSX Ink component (not unit-testable at this
+// call site without a full render harness) — so this suite proves the fold TWO ways instead:
+// (1) a STRUCTURAL check that all 3 sites now call resolveApiKey with the identical
+// {envName, configKeyPath} arguments (extracted from source text, the same idiom
+// __tests__/health-responder.test.sh's T54 uses for a render function it can't invoke
+// directly), and (2) a FUNCTIONAL fixture proving those extracted arguments resolve
+// IDENTICALLY across a {env, config, none} matrix — i.e. the 3 sites are not just
+// syntactically aligned but behaviorally identical for the same inputs.
+describe("Groq call-site fold parity (CTL-1616 PR5)", () => {
+  // Pulls the FIRST `resolveApiKey({ envName: "...", configKeyPath: "..." }` call's two
+  // literal arguments out of a file's source text. Deliberately dumb (no AST) — this only
+  // needs to catch a call-site regression back to a hand-rolled ladder, not parse arbitrary JS.
+  function extractResolveApiKeyArgs(sourcePath) {
+    const src = readFileSync(sourcePath, "utf8");
+    const m = src.match(/resolveApiKey\(\s*\{\s*envName:\s*"([^"]+)"\s*,\s*configKeyPath:\s*"([^"]+)"/);
+    if (!m) throw new Error(`no resolveApiKey({envName, configKeyPath}) call found in ${sourcePath}`);
+    return { envName: m[1], configKeyPath: m[2] };
+  }
+
+  const SITES = {
+    "broker/config.mjs": join(SCRIPTS_DIR, "broker", "config.mjs"),
+    "lib/dsl-cli.mjs": join(SCRIPTS_DIR, "lib", "dsl-cli.mjs"),
+    "orch-monitor/cli/hud.tsx": join(SCRIPTS_DIR, "orch-monitor", "cli", "hud.tsx"),
+  };
+
+  test("structural: all 3 sites call resolveApiKey with the identical {envName, configKeyPath}", () => {
+    const args = Object.fromEntries(
+      Object.entries(SITES).map(([name, path]) => [name, extractResolveApiKeyArgs(path)]),
+    );
+    expect(args["lib/dsl-cli.mjs"]).toEqual(args["broker/config.mjs"]);
+    expect(args["orch-monitor/cli/hud.tsx"]).toEqual(args["broker/config.mjs"]);
+    expect(args["broker/config.mjs"]).toEqual({ envName: "GROQ_API_KEY", configKeyPath: "groq.apiKey" });
+  });
+
+  test("structural: neither folded site still references the OLD hand-rolled ladder", () => {
+    const dslCli = readFileSync(SITES["lib/dsl-cli.mjs"], "utf8");
+    const hud = readFileSync(SITES["orch-monitor/cli/hud.tsx"], "utf8");
+    // The old pattern was an actual ASSIGNMENT — `apiKey = process.env.GROQ_API_KEY ||
+    // readGroqApiKeyFromConfig()` (or the bracket-index hud.tsx variant) — matched here on the
+    // live `apiKey =` prefix so this doesn't false-positive on this PR's own explanatory
+    // comments (above), which quote that old pattern verbatim as prose.
+    const oldPattern = /apiKey\s*=\s*process\.env(\.|\[)["']?GROQ_API_KEY["']?\]?\s*\|\|\s*readGroqApiKeyFromConfig\(\)/;
+    expect(dslCli).not.toMatch(oldPattern);
+    expect(hud).not.toMatch(oldPattern);
+    // And the import of the old function is gone too (not merely unused).
+    expect(dslCli).not.toMatch(/import\s*\{[^}]*readGroqApiKeyFromConfig[^}]*\}\s*from\s*["']\.\/dsl-compile\.mjs["']/);
+    expect(hud).not.toMatch(/import\s*\{[^}]*readGroqApiKeyFromConfig[^}]*\}\s*from\s*["']\.\.\/\.\.\/lib\/dsl-compile\.mjs["']/);
+  });
+
+  describe("functional: the shared fixture resolves identically for every extracted call site", () => {
+    let tmp;
+    let savedEnv;
+    beforeEach(() => {
+      tmp = mkdtempSync(join(tmpdir(), "groq-fold-parity-"));
+      savedEnv = process.env.GROQ_API_KEY;
+      delete process.env.GROQ_API_KEY;
+    });
+    afterEach(() => {
+      rmSync(tmp, { recursive: true, force: true });
+      if (savedEnv === undefined) delete process.env.GROQ_API_KEY;
+      else process.env.GROQ_API_KEY = savedEnv;
+    });
+
+    const callArgsPerSite = () =>
+      Object.fromEntries(
+        Object.entries(SITES).map(([name, path]) => [name, extractResolveApiKeyArgs(path)]),
+      );
+
+    test("env tier: identical result for every site's extracted args", () => {
+      process.env.GROQ_API_KEY = "gsk_sharedEnvFixture1";
+      const cfgPath = join(tmp, "config.json");
+      writeFileSync(cfgPath, JSON.stringify({ groq: { apiKey: "gsk_shouldNotWin" } }));
+      const perSite = callArgsPerSite();
+      const results = Object.fromEntries(
+        Object.entries(perSite).map(([name, args]) => [name, resolveApiKey({ ...args, configPath: cfgPath })]),
+      );
+      for (const r of Object.values(results)) {
+        expect(r).toEqual({ value: "gsk_sharedEnvFixture1", source: "env", prefix: "gsk_sharedEn" });
+      }
+    });
+
+    test("config tier: identical result for every site's extracted args (env unset)", () => {
+      const cfgPath = join(tmp, "config.json");
+      writeFileSync(cfgPath, JSON.stringify({ groq: { apiKey: "gsk_sharedCfgFixture2" } }));
+      const perSite = callArgsPerSite();
+      const results = Object.fromEntries(
+        Object.entries(perSite).map(([name, args]) => [name, resolveApiKey({ ...args, configPath: cfgPath })]),
+      );
+      for (const r of Object.values(results)) {
+        expect(r).toEqual({ value: "gsk_sharedCfgFixture2", source: "config", prefix: "gsk_sharedCf" });
+      }
+    });
+
+    test("none tier: identical result for every site's extracted args", () => {
+      const perSite = callArgsPerSite();
+      const results = Object.fromEntries(
+        Object.entries(perSite).map(([name, args]) => [
+          name,
+          resolveApiKey({ ...args, configPath: join(tmp, "does-not-exist.json") }),
+        ]),
+      );
+      for (const r of Object.values(results)) {
+        expect(r).toEqual({ value: "", source: null, prefix: null });
+      }
+    });
   });
 });

--- a/plugins/dev/scripts/lib/catalyst-secret-contract.sh
+++ b/plugins/dev/scripts/lib/catalyst-secret-contract.sh
@@ -743,15 +743,24 @@ _csc_resolve_config_json() {
   _csc_set_result "" "none" "$_delivery"
 }
 
-# _csc_resolve_cloud_token_name — cloud-token's two-step resolution: NAME (env override →
-# Layer-2 catalyst.cloud.tokenEnv → default CATALYST_CLOUD_TOKEN), then that variable's
-# VALUE. Mode-independent — always platform-env, never touches a file.
-_csc_resolve_cloud_token_name() {
-  local _id="$1" _delivery _path _l2 _tagged _env_var _val
-  _delivery="$(catalyst_secret_delivery "$_id")"
+# catalyst_secret_cloud_token_name ID — CTL-1616 PR5. NAME-ONLY resolution of the cloud-token
+# row's env-var NAME: env override (CATALYST_CLOUD_TOKEN_ENV) → Layer-2
+# catalyst.cloud.tokenEnv → default. NEVER reads the value of the resolved variable — mirrors
+# lib/secret-contract.mjs's EXPORTED resolveCloudTokenName(env) byte-for-byte (same
+# env-override / Layer-2 / default precedence, same STRICT string-only Layer-2 acceptance —
+# see the STRICT STRING-ONLY note below). PUBLIC (catalyst_ prefix, not _csc_) so
+# health-responder.sh's bash-fallback ladder can call this directly instead of hand-rolling its
+# own jq-based ladder (design §9 PR5: "both cloud-token readers agree byte-for-byte on the
+# resolved env-var name"). Echoes "envVar|source" and sets
+# CATALYST_SECRET_TOKEN_NAME/_SOURCE (mirrors _csc_set_result's exported-breadcrumb
+# convention) so a caller that only needs the NAME (not a resolve-and-check-presence round
+# trip) can skip re-parsing the pipe-joined echo.
+catalyst_secret_cloud_token_name() {
+  local _id="${1:-cloud-token}" _path _l2 _tagged _env_var _source
   _path="$(catalyst_secret_config_json_path "$_id")"
   if [[ -n "${CATALYST_CLOUD_TOKEN_ENV:-}" ]]; then
     _env_var="$CATALYST_CLOUD_TOKEN_ENV"
+    _source="env"
   else
     _l2="$(catalyst_secret_resolve_layer2_path)"
     _tagged="$(_csc_read_json_string "$_l2" "$_path")"
@@ -771,13 +780,33 @@ _csc_resolve_cloud_token_name() {
         _csc_b64_decode_var _decoded "${_tagged#@STR64:}"
         if [[ -n "$_decoded" ]]; then
           _env_var="$_decoded"
+          _source="layer2"
         else
           _env_var="$(catalyst_secret_env_names "$_id" | head -n1)"
+          _source="default"
         fi
         ;;
-      *) _env_var="$(catalyst_secret_env_names "$_id" | head -n1)" ;;
+      *)
+        _env_var="$(catalyst_secret_env_names "$_id" | head -n1)"
+        _source="default"
+        ;;
     esac
   fi
+  CATALYST_SECRET_TOKEN_NAME="$_env_var"
+  # shellcheck disable=SC2034
+  CATALYST_SECRET_TOKEN_NAME_SOURCE="$_source"
+  export CATALYST_SECRET_TOKEN_NAME CATALYST_SECRET_TOKEN_NAME_SOURCE
+  printf '%s|%s' "$_env_var" "$_source"
+}
+
+# _csc_resolve_cloud_token_name — cloud-token's two-step resolution: NAME (via
+# catalyst_secret_cloud_token_name above — single implementation, not a second copy), then
+# that variable's VALUE. Mode-independent — always platform-env, never touches a file.
+_csc_resolve_cloud_token_name() {
+  local _id="$1" _delivery _env_var _val
+  _delivery="$(catalyst_secret_delivery "$_id")"
+  catalyst_secret_cloud_token_name "$_id" >/dev/null
+  _env_var="$CATALYST_SECRET_TOKEN_NAME"
   # INVALID ENV NAME FIX (Codex finding fix): CATALYST_CLOUD_TOKEN_ENV / the Layer-2
   # tokenEnv override is OPERATOR-CONTROLLED text, not registry data — a value like
   # "BAD-NAME" (or anything else outside [A-Za-z_][A-Za-z0-9_]*) fed straight into

--- a/plugins/dev/scripts/lib/dsl-cli.mjs
+++ b/plugins/dev/scripts/lib/dsl-cli.mjs
@@ -16,13 +16,25 @@ import {
   compile,
   groqTranslate,
   parseGroqResponse,
-  readGroqApiKeyFromConfig,
   rewriteNode,
   DslError,
   GroqHttpError,
   GroqResponseError,
 } from "./dsl-compile.mjs";
 import { SYSTEM_PROMPT } from "./dsl-prompt.mjs";
+// CTL-1616 PR5 fold (design §8/§9, risk 8 — DOCUMENTED BEHAVIOR CHANGE, not a no-op): this
+// site used to be `process.env.GROQ_API_KEY || readGroqApiKeyFromConfig()` — a local 2-tier
+// ladder (env, then dsl-compile.mjs's own config-only reader) independent of every other
+// Groq call site. It now calls the SAME shared resolver broker/config.mjs already adopted
+// (lib/api-key-health.mjs resolveApiKey), with the identical {envName, configKeyPath} this
+// codebase's one other adopted site uses — joining broker/config.mjs onto ONE Groq-key
+// ladder instead of three independently-hand-rolled ones (design table: "GROQ_API_KEY — 2
+// ladders; resolveApiKey adopted by 1 of 3 sites; tier count differs"). FLAGGED: resolveApiKey
+// enforces `typeof value === "string"` at its config tier (the old readGroqApiKeyFromConfig
+// did not) and is capable of an additional project-config tier via an optional
+// projectConfigPath (not wired here, matching broker/config.mjs's own call shape) — see this
+// PR's report for the full behavior-change writeup.
+import { resolveApiKey } from "./api-key-health.mjs";
 
 function parseArgs(argv) {
   const out = { query: null, dsl: null, explain: false, limit: null, since: null };
@@ -94,7 +106,7 @@ async function main() {
     if (args.dsl != null) {
       dsl = parseGroqResponse(args.dsl);
     } else {
-      const apiKey = process.env.GROQ_API_KEY || readGroqApiKeyFromConfig();
+      const apiKey = resolveApiKey({ envName: "GROQ_API_KEY", configKeyPath: "groq.apiKey" }).value;
       dsl = await groqTranslate(args.query, { apiKey, systemPrompt: SYSTEM_PROMPT });
     }
   } catch (err) {

--- a/plugins/dev/scripts/lib/secret-contract.d.mts
+++ b/plugins/dev/scripts/lib/secret-contract.d.mts
@@ -94,6 +94,15 @@ export interface ResolvedSecret {
 
 export function resolveSecret(id: string, opts?: ResolveSecretOptions): ResolvedSecret;
 
+/** CTL-1616 PR5: NAME-ONLY resolution of the cloud-token row's env-var NAME (env override →
+ *  Layer-2 catalyst.cloud.tokenEnv → default). Never reads the secret VALUE — safe to log.
+ *  execution-core/config.mjs's resolveNodeCloudTokenEnv delegates to this. */
+export interface ResolvedCloudTokenName {
+  envVar: string;
+  source: "env" | "layer2" | "default";
+}
+export function resolveCloudTokenName(env?: Record<string, string | undefined>): ResolvedCloudTokenName;
+
 export interface RearmHookResult {
   rearmed: boolean;
   reason?: string;

--- a/plugins/dev/scripts/lib/secret-contract.mjs
+++ b/plugins/dev/scripts/lib/secret-contract.mjs
@@ -784,28 +784,38 @@ function resolveConfigJson(row, env, cwd) {
   return { value: null, source: "none", provider: row.delivery, rotation: row.rotation };
 }
 
-// resolveCloudTokenName — cloud-token's two-step resolution: first the env-var NAME (env
-// override → Layer-2 catalyst.cloud.tokenEnv → default CATALYST_CLOUD_TOKEN, mirroring
-// resolveNodeCloudTokenEnv, execution-core/config.mjs:1949-1957), THEN that variable's
-// VALUE. Mode-independent: cloud-token is always platform-env delivery regardless of
-// deployment mode, so this never touches a file.
-function resolveCloudTokenName(row, env) {
+// resolveCloudTokenName(env) — CTL-1616 PR5. NAME-ONLY resolution of the cloud-token row's
+// env-var NAME: env override (CATALYST_CLOUD_TOKEN_ENV) → Layer-2 catalyst.cloud.tokenEnv →
+// default CATALYST_CLOUD_TOKEN. NEVER reads process.env[envVar] (the secret VALUE) — safe to
+// log the result. EXPORTED so execution-core/config.mjs's resolveNodeCloudTokenEnv can become
+// a thin delegate onto this single implementation instead of hand-duplicating the ladder
+// (design §8/§9 PR5) — this is now THE canonical NAME resolver both engines' "cloud-token
+// reader" callers (config.mjs's bun path, health-responder.sh's bash-fallback ladder via
+// lib/catalyst-secret-contract.sh's catalyst_secret_cloud_token_name) delegate to/mirror.
+// Returns { envVar, source } where source ∈ "env" | "layer2" | "default" — the EXACT shape
+// resolveNodeCloudTokenEnv has always returned (byte-compatible for its existing callers,
+// including doctor.mjs's checkCloudSync `tokenEnv = resolveNodeCloudTokenEnv()` and
+// checkCloudTokenEnv's shadow-diff).
+export function resolveCloudTokenName(env = process.env) {
+  const row = getSecretRow("cloud-token");
   const nameOverride = env?.CATALYST_CLOUD_TOKEN_ENV;
-  let envVar, envVarSource;
   if (typeof nameOverride === "string" && nameOverride.length > 0) {
-    envVar = nameOverride;
-    envVarSource = "env";
-  } else {
-    const l2Path = resolveLayer2Path(env);
-    const l2Name = readJsonField(l2Path, row.configJsonPath);
-    if (typeof l2Name === "string" && l2Name.length > 0) {
-      envVar = l2Name;
-      envVarSource = "layer2";
-    } else {
-      envVar = row.envNames[0];
-      envVarSource = "default";
-    }
+    return { envVar: nameOverride, source: "env" };
   }
+  const l2Path = resolveLayer2Path(env);
+  const l2Name = readJsonField(l2Path, row?.configJsonPath);
+  if (typeof l2Name === "string" && l2Name.length > 0) {
+    return { envVar: l2Name, source: "layer2" };
+  }
+  return { envVar: row?.envNames?.[0] ?? "CATALYST_CLOUD_TOKEN", source: "default" };
+}
+
+// resolveCloudTokenValue(row, env) — cloud-token's two-step resolution used by the engine's
+// resolveSecret: the NAME (via resolveCloudTokenName above — single implementation, not a
+// second copy) THEN that variable's VALUE. Mode-independent: cloud-token is always
+// platform-env delivery regardless of deployment mode, so this never touches a file.
+function resolveCloudTokenValue(row, env) {
+  const { envVar, source: envVarSource } = resolveCloudTokenName(env);
   const value = env?.[envVar];
   if (typeof value === "string" && value.length > 0) {
     return { value, source: "platform-env", provider: row.delivery, rotation: row.rotation, envVar, envVarSource };
@@ -856,7 +866,7 @@ function resolveLocalOnlyPresence(row, env) {
 // bootstrap-class row (cloud-token, bootstrapFor: "cloud") fails to resolve, every OTHER
 // cloud-mode resolution returns { value: null, source: null } without probing further — a
 // half-provisioned managed container fails loudly and coherently. The bootstrap row itself
-// is exempt (it must resolve on its own terms) and resolveCloudTokenName never triggers this
+// is exempt (it must resolve on its own terms) and resolveCloudTokenValue never triggers this
 // check (recursion terminates in one level: cloud-token's own resolution never consults
 // `deploymentMode`).
 export function resolveSecret(id, { env = process.env, deploymentMode, cwd = process.cwd() } = {}) {
@@ -881,14 +891,14 @@ export function resolveSecret(id, { env = process.env, deploymentMode, cwd = pro
     // catalyst.cloud.tokenEnv override was silently ignored the moment genuine cloud mode
     // activated, even though that exact override IS honored one level up (the bootstrap
     // check above calls resolveSecret(bootstrapRow.id, { env }) WITHOUT deploymentMode,
-    // which routes through the normal switch below to resolveCloudTokenName). Dispatching
-    // platform-env rows through resolveCloudTokenName here — the SAME function, not a
+    // which routes through the normal switch below to resolveCloudTokenValue). Dispatching
+    // platform-env rows through resolveCloudTokenValue here — the SAME function, not a
     // second copy — closes that gap: cloud-token resolves its configured NAME identically
     // whether reached directly (this branch) or indirectly (the bootstrap check). Every
     // other cloud-mode row (bare-file/env-alias/config-json rows collapsing to their
     // envNames-only aliases) is unaffected — this is a targeted fix for the one
     // platform-env row, not a broadening of what "genuinely cloud" resolves.
-    return row.delivery === "platform-env" ? resolveCloudTokenName(row, env) : resolveEnvAliasOnly(row, env);
+    return row.delivery === "platform-env" ? resolveCloudTokenValue(row, env) : resolveEnvAliasOnly(row, env);
   }
 
   switch (row.delivery) {
@@ -903,7 +913,7 @@ export function resolveSecret(id, { env = process.env, deploymentMode, cwd = pro
     case "config-json":
       return resolveConfigJson(row, env, cwd);
     case "platform-env":
-      return resolveCloudTokenName(row, env);
+      return resolveCloudTokenValue(row, env);
     case "local-only":
       return resolveLocalOnlyPresence(row, env);
     default:

--- a/plugins/dev/scripts/orch-monitor/cli/hud.tsx
+++ b/plugins/dev/scripts/orch-monitor/cli/hud.tsx
@@ -25,12 +25,22 @@ import {
   compile,
   groqTranslate,
   rewriteNode,
-  readGroqApiKeyFromConfig,
   DslError,
   GroqHttpError,
   GroqResponseError,
 } from "../../lib/dsl-compile.mjs";
 import { buildSystemPrompt } from "../../lib/dsl-prompt.mjs";
+// CTL-1616 PR5 fold (design §8/§9, risk 8 — DOCUMENTED BEHAVIOR CHANGE, not a no-op): this
+// site used to be `process.env["GROQ_API_KEY"] || readGroqApiKeyFromConfig()` — a local
+// 2-tier ladder independent of every other Groq call site. It now calls the SAME shared
+// resolver broker/config.mjs already adopted (lib/api-key-health.mjs resolveApiKey), with the
+// identical {envName, configKeyPath} that site uses — joining broker/config.mjs onto ONE
+// Groq-key ladder (design table: "GROQ_API_KEY — 2 ladders; resolveApiKey adopted by 1 of 3
+// sites; tier count differs"). FLAGGED: resolveApiKey enforces `typeof value === "string"` at
+// its config tier (the old readGroqApiKeyFromConfig did not) and is capable of an additional
+// project-config tier via an optional projectConfigPath (not wired here, matching
+// broker/config.mjs's own call shape) — see this PR's report for the full writeup.
+import { resolveApiKey } from "../../lib/api-key-health.mjs";
 import type { CanonicalEvent } from "../lib/canonical-event.ts";
 import { readPluginVersion, formatVersionBlock } from "./lib/version.ts";
 import { loadHudConfig } from "../lib/monitor-config.ts";
@@ -390,7 +400,7 @@ function App({ repoFilter, predicate, sinceTs: initSinceTs }: AppProps) {
     }
 
     try {
-      const apiKey = process.env["GROQ_API_KEY"] || readGroqApiKeyFromConfig();
+      const apiKey = resolveApiKey({ envName: "GROQ_API_KEY", configKeyPath: "groq.apiKey" }).value;
       // CTL-365: inject current time per-request so "last 24 hours" etc. resolve
       // against the wall clock rather than silently degrading to UTC midnight.
       const systemPrompt = buildSystemPrompt({ now: new Date() });


### PR DESCRIPTION
## Summary

CTL-1616 migration plan **PR5**. Cloud-token env-var **name** resolution now has one implementation per stack, both in the registry: JS `resolveCloudTokenName` (with `config.mjs`'s `resolveNodeCloudTokenEnv` as a byte-compatible `{envVar, source}` delegate — all callers grepped and shape-pinned) and bash `catalyst_secret_cloud_token_name` (health-responder's fallback delegates; the bun-probe-first/bash-fallback shape preserved and proven with bun absent from PATH). Six-cell parity matrix byte-identical including old-vs-new A/B.

**Groq — documented behavior change (design risk 8):** `dsl-cli.mjs` + `hud.tsx` join `broker/config.mjs` on the shared `resolveApiKey` — all 3 sites, one implementation. Divergence: a non-string `groq.apiKey` config value now falls through to absent (type-checked tier) instead of being returned raw. Flagged at both call sites, structural regression guard in `api-key-health.test.mjs`.

## ⚠️ Operator attention: one scoped Layer-2-path front-run

The cloud-token NAME lookup now uses the canonical `resolveLayer2Path` chain (adds `CATALYST_MACHINE_CONFIG` / `XDG_CONFIG_HOME` tiers the old homedir-only read lacked). Design §8 assigns the general Layer-2 convergence to PR6 (shadow-diffed); this PR front-runs it for this one lookup because the registry's config-json resolution has used the canonical chain since PR1 — pinning the legacy chain inside the shared resolver would recreate the parallel-chain divergence this initiative exists to remove. **Inert on every live host** (all fleet hosts use the default path — verified in the PR4 merge-gate probes); both engines agree on the new tiers. Verifier probes documenting the divergence shapes are in the adversarial report.

## Verification

Fable adversarial verify: **PASS, zero blocking.** Six-cell matrix byte-identical (+ MACHINE_CONFIG/XDG divergence probes flagged above); bun-absent fallback end-to-end through the real responder; all `resolveNodeCloudTokenEnv` callers shape-pinned; Groq 3-site tier identity + the flagged non-string divergence confirmed; mutations bite (wrong default name → 5 failures).

Suites (post-rebase over #2925/#2926): bash engine 113/0 · parity 175/0 · health-responder 149/0 · JS engine 111/0 · api-key-health 34/0 · cloud-token 11/0 · doctor 346/0 · exec-core full-suite failing-set line-identical to baseline (stash A/B).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WHfJt1JhsdArSUyxwZZzkN