### PR TITLE
test(dev): CTL-1616 make the bun-path matrix cells detect silent fallback

### DIFF
--- a/plugins/dev/scripts/__tests__/health-responder.test.sh
+++ b/plugins/dev/scripts/__tests__/health-responder.test.sh
@@ -1104,13 +1104,13 @@ export MOCK_LAST_EXIT=0
 mkdir -p "${HOME}/.config/catalyst"
 printf 'export CATALYST_CLOUD_TOKEN_ENV=MY_CUSTOM_TOKEN\nexport MY_CUSTOM_TOKEN=real-value\n' > "${HOME}/.config/catalyst/cloud-sync.env"
 run "T75: bun AVAILABLE + env-override token name resolves via the bun path (fixture-matrix cell)" \
-  bash -c "out=\$(RESPONDER_KICKSTART_WAIT_SECS=0 bash '$RESPONDER'); printf '%s' \"\$out\" | grep -q 'failed-bounce signature' && test -s '${KICKSTART_LOG}'"
+  bash -c "out=\$(RESPONDER_KICKSTART_WAIT_SECS=0 bash '$RESPONDER' 2>&1); printf '%s' \"\$out\" | grep -q 'failed-bounce signature' && test -s '${KICKSTART_LOG}' && printf '%s' \"\$out\" | grep -q 'token-env resolved via bun: MY_CUSTOM_TOKEN'"
 rm -f "${HOME}/.config/catalyst/cloud-sync.env" "$KICKSTART_LOG"
 
 printf 'export ANOTHER_CUSTOM_TOKEN=real-value\n' > "${HOME}/.config/catalyst/cloud-sync.env"
 printf '{"catalyst":{"cloud":{"tokenEnv":"ANOTHER_CUSTOM_TOKEN"}}}' > "${SCRATCH}/layer2-config.json"
 run "T76: bun AVAILABLE + Layer-2 tokenEnv override resolves via the bun path (fixture-matrix cell)" \
-  bash -c "out=\$(CATALYST_LAYER2_CONFIG_FILE='${SCRATCH}/layer2-config.json' RESPONDER_KICKSTART_WAIT_SECS=0 bash '$RESPONDER'); printf '%s' \"\$out\" | grep -q 'failed-bounce signature' && test -s '${KICKSTART_LOG}'"
+  bash -c "out=\$(CATALYST_LAYER2_CONFIG_FILE='${SCRATCH}/layer2-config.json' RESPONDER_KICKSTART_WAIT_SECS=0 bash '$RESPONDER' 2>&1); printf '%s' \"\$out\" | grep -q 'failed-bounce signature' && test -s '${KICKSTART_LOG}' && printf '%s' \"\$out\" | grep -q 'token-env resolved via bun: ANOTHER_CUSTOM_TOKEN'"
 rm -f "${HOME}/.config/catalyst/cloud-sync.env" "$KICKSTART_LOG" "${SCRATCH}/layer2-config.json"
 unset MOCK_LAST_EXIT
 

--- a/plugins/dev/scripts/health-responder.sh
+++ b/plugins/dev/scripts/health-responder.sh
@@ -345,6 +345,9 @@ _token_provisioned() {
     if [[ -z "$name" ]]; then
       catalyst_secret_cloud_token_name cloud-token >/dev/null
       name="$CATALYST_SECRET_TOKEN_NAME"
+      echo "[health-responder] token-env resolved via bash-fallback: ${name}" >&2
+    else
+      echo "[health-responder] token-env resolved via bun: ${name}" >&2
     fi
     [[ -n "${!name:-}" ]] && printf yes || printf no
   )"


### PR DESCRIPTION
## Summary

Post-merge #2927 Codex finding, verified: T75/T76 asserted only end-to-end responder outcomes that the bash fallback produces identically, so a broken `config.mjs`/`resolveCloudTokenName` delegate would leave the advertised bun-path matrix cells green.

`_token_provisioned` now emits a name-only provenance breadcrumb to stderr (`token-env resolved via bun: NAME` / `via bash-fallback: NAME` — names are non-secret per the resolver's contract), and T75/T76 assert the bun breadcrumb with the exact resolved name. The breadcrumbs are mutually exclusive on the same code path, so a silent fallback now fails both cells. Suite 149/0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WHfJt1JhsdArSUyxwZZzkN