### PR TITLE
feat(dev): CTL-1616 doctor cloud-guard escalation + shadow-diffed Layer-2 stragglers (PR6)

### DIFF
--- a/plugins/dev/scripts/__tests__/catalyst-secret-contract.test.sh
+++ b/plugins/dev/scripts/__tests__/catalyst-secret-contract.test.sh
@@ -479,6 +479,16 @@ expect_eq "bootstrap short-circuit: cloud-token absent ⇒ every other row's clo
 OUT="$(_run 'catalyst_resolve_secret cloud-token cloud false')"
 expect_eq "bootstrap short-circuit does not apply to cloud-token itself (resolves normally, absent here)" "|none|platform-env" "$OUT"
 
+# --- cloud guard RECOGNIZED extension (CTL-1616 PR6, design §12 Q3 belt-and-suspenders) -----
+# Mirrors lib/secret-contract.mjs's `deploymentMode.recognized !== false` addition: a 4th
+# positional RECOGNIZED arg, defaulting to "true" so every 2/3-arg call above is unaffected.
+OUT="$(_run "CATALYST_CONFIG_DIR=${TMP_DIR}/cloudguard-cfg" "GH_TOKEN=env-value-should-not-win" 'catalyst_resolve_secret github-token cloud false false')"
+expect_eq "cloud guard: recognized=false does NOT activate cloud even with mode=cloud inferred=false — file chain still runs" \
+  "file-value|shared-file|bare-file" "$OUT"
+OUT="$(_run "GH_TOKEN=should-not-be-returned" 'catalyst_resolve_secret github-token cloud false true')"
+expect_eq "cloud guard: recognized=true (explicit) activates cloud exactly like recognized omitted" \
+  "||bare-file" "$OUT"
+
 # --- CLOUD-TOKEN NAME OVERRIDE (Codex finding fix): genuine cloud mode must honor
 # CATALYST_CLOUD_TOKEN_ENV / the Layer-2 override, not only the hardcoded default name ------
 OUT="$(_run "CATALYST_CLOUD_TOKEN_ENV=MY_PLATFORM_TOKEN" "MY_PLATFORM_TOKEN=the-real-token" 'catalyst_resolve_secret cloud-token cloud false')"

--- a/plugins/dev/scripts/__tests__/secret-contract-parity.test.sh
+++ b/plugins/dev/scripts/__tests__/secret-contract-parity.test.sh
@@ -167,7 +167,12 @@ import { resolveSecret } from "${JS_LIB}";
 const id = process.env.CSC_PROBE_ID;
 const depMode = process.env.CSC_PROBE_DEP_MODE;
 const depInferred = process.env.CSC_PROBE_DEP_INFERRED;
-const deploymentMode = depMode ? { mode: depMode, inferred: depInferred === "true" } : undefined;
+// CTL-1616 PR6: RECOGNIZED defaults to true when unset — mirrors bash's \${4:-true} default,
+// so every pre-PR6 cell (which never sets CSC_PROBE_DEP_RECOGNIZED) exercises the identical
+// semantic input on both sides it always did.
+const depRecognizedRaw = process.env.CSC_PROBE_DEP_RECOGNIZED;
+const depRecognized = depRecognizedRaw === undefined ? true : depRecognizedRaw === "true";
+const deploymentMode = depMode ? { mode: depMode, inferred: depInferred === "true", recognized: depRecognized } : undefined;
 // CTL-1616 PR4: linear-worker-actor's per-team-legacy tier walks cwd upward — CSC_PROBE_CWD
 // threads the same working directory the bash side is cd'd into (see _cell_in_dir) so both
 // sides walk from the IDENTICAL starting point.
@@ -186,7 +191,7 @@ _cell() {
   local BASH_OUT NODE_OUT
   BASH_OUT="$(env -i PATH="$PATH" HOME="$SANDBOX_HOME" "$@" bash -c "
     source '$LIB'
-    catalyst_resolve_secret \"\$CSC_PROBE_ID\" \"\${CSC_PROBE_DEP_MODE:-}\" \"\${CSC_PROBE_DEP_INFERRED:-true}\"
+    catalyst_resolve_secret \"\$CSC_PROBE_ID\" \"\${CSC_PROBE_DEP_MODE:-}\" \"\${CSC_PROBE_DEP_INFERRED:-true}\" \"\${CSC_PROBE_DEP_RECOGNIZED:-true}\"
   ")"
   NODE_OUT="$(env -i PATH="$PATH" HOME="$SANDBOX_HOME" "$@" node "$PROBE_RESOLVE_JS" 2>&1)"
   expect_eq "$_name (bash==expected)" "$_expected" "$BASH_OUT"
@@ -203,7 +208,7 @@ _cell_in_dir() {
   local BASH_OUT NODE_OUT
   BASH_OUT="$(cd "$_dir" && env -i PATH="$PATH" HOME="$SANDBOX_HOME" "$@" bash -c "
     source '$LIB'
-    catalyst_resolve_secret \"\$CSC_PROBE_ID\" \"\${CSC_PROBE_DEP_MODE:-}\" \"\${CSC_PROBE_DEP_INFERRED:-true}\"
+    catalyst_resolve_secret \"\$CSC_PROBE_ID\" \"\${CSC_PROBE_DEP_MODE:-}\" \"\${CSC_PROBE_DEP_INFERRED:-true}\" \"\${CSC_PROBE_DEP_RECOGNIZED:-true}\"
   ")"
   NODE_OUT="$(env -i PATH="$PATH" HOME="$SANDBOX_HOME" CSC_PROBE_CWD="$_dir" "$@" node "$PROBE_RESOLVE_JS" 2>&1)"
   expect_eq "$_name (bash==expected)" "$_expected" "$BASH_OUT"
@@ -703,6 +708,18 @@ _cell "bootstrap short-circuit: cloud-token absent ⇒ every other row's cloud r
   CSC_PROBE_DEP_MODE=cloud CSC_PROBE_DEP_INFERRED=false
 _cell "bootstrap short-circuit does not apply to cloud-token itself" "|none|platform-env" \
   CSC_PROBE_ID=cloud-token CSC_PROBE_DEP_MODE=cloud CSC_PROBE_DEP_INFERRED=false
+
+# ─── cloud guard RECOGNIZED extension (CTL-1616 PR6, design §12 Q3 belt-and-suspenders) ────
+# `recognized !== false` is ADDITIVE to the inferred check — a hand-constructed deploymentMode
+# with recognized:false must NOT activate cloud even when mode=cloud/inferred=false; omitting
+# or explicitly setting recognized:true must activate cloud exactly as before this PR.
+_cell "cloud guard: recognized=false does NOT activate cloud (even with mode=cloud, inferred=false)" \
+  "file-value|shared-file|bare-file" \
+  CSC_PROBE_ID=github-token "CATALYST_CONFIG_DIR=${CLOUDGUARD_DIR}" "GH_TOKEN=env-value-should-not-win" \
+  CSC_PROBE_DEP_MODE=cloud CSC_PROBE_DEP_INFERRED=false CSC_PROBE_DEP_RECOGNIZED=false
+_cell "cloud guard: recognized=true (explicit) activates cloud exactly like recognized omitted" \
+  "||bare-file" CSC_PROBE_ID=github-token "GH_TOKEN=should-not-be-returned" \
+  CSC_PROBE_DEP_MODE=cloud CSC_PROBE_DEP_INFERRED=false CSC_PROBE_DEP_RECOGNIZED=true
 
 # Hostile probe (B3): the bootstrap-class secret's VALUE itself begins with "|". The
 # previous bash implementation captured the recursive resolve call's pipe-joined

--- a/plugins/dev/scripts/execution-core/config.mjs
+++ b/plugins/dev/scripts/execution-core/config.mjs
@@ -20,7 +20,10 @@ import { schemaCompat } from "./config-schema.mjs";
 // via resolveNodeCloudTokenEnv below) and health-responder.sh's bash fallback
 // (via lib/catalyst-secret-contract.sh's catalyst_secret_cloud_token_name) —
 // same precedent as CTL-1617's deployment-mode re-export just below.
-import { resolveCloudTokenName } from "../lib/secret-contract.mjs";
+// CTL-1616 PR6: resolveLayer2Path is the registry's canonical Layer-2 path chain
+// (CATALYST_LAYER2_CONFIG_FILE > CATALYST_MACHINE_CONFIG > XDG_CONFIG_HOME > ~/.config),
+// consulted by getLayer2ConfigPath's dual-read shadow-diff below (design §8 PR6).
+import { resolveCloudTokenName, resolveLayer2Path } from "../lib/secret-contract.mjs";
 
 // --- Logger (CTL-578) ---
 // Pino is the daemon's runtime logger. A worktree checkout that hasn't run
@@ -209,14 +212,41 @@ export function getEventLogPath() {
 // Linear-CAS claim, takeover/healing) have one source of truth. Nothing in the
 // dispatch/claim/eligible-query path consults these yet.
 
-// Layer-2 (machine-local) config path. Mirrors daemon.mjs main()'s resolution:
-// CATALYST_LAYER2_CONFIG_FILE || ~/.config/catalyst/config.json. Each host's
-// Layer-2 file differs, so this is the right home for a per-host name.
+// Layer-2 (machine-local) config path. Historically CATALYST_LAYER2_CONFIG_FILE ||
+// ~/.config/catalyst/config.json (daemon.mjs main()'s resolution) — homedir-only, ignoring
+// CATALYST_MACHINE_CONFIG and XDG_CONFIG_HOME. Each host's Layer-2 file differs, so this is
+// the right home for a per-host name.
+//
+// CTL-1616 PR6 (design §8/§9): DUAL-READ shadow-diff for one release before this delegates
+// fully to the registry's canonical resolveLayer2Path (lib/secret-contract.mjs) chain —
+// CATALYST_LAYER2_CONFIG_FILE > CATALYST_MACHINE_CONFIG > XDG_CONFIG_HOME > ~/.config/catalyst.
+// The two chains AGREE whenever CATALYST_LAYER2_CONFIG_FILE is set (checked first by both) or
+// neither CATALYST_MACHINE_CONFIG nor XDG_CONFIG_HOME is set (both fall to the same homedir
+// default) — the common case on every host today, hence silent. They DISAGREE on a host that
+// sets CATALYST_MACHINE_CONFIG or XDG_CONFIG_HOME without also setting
+// CATALYST_LAYER2_CONFIG_FILE — a DOCUMENTED BEHAVIOR CHANGE (design risk 8), logged loudly
+// (once per unique divergence message, mirroring getNodeClass's _warnedNodeClass dedup below)
+// so the operator sees it before the next PR removes the legacy chain entirely. The NEW
+// (canonical) path is always what this function returns on a disagreement — matching the
+// operator-attention-flag direction #2927 already established for this class of shadow-diff.
+const _warnedLayer2PathDrift = new Set();
 export function getLayer2ConfigPath() {
-  return (
+  const legacyPath =
     process.env.CATALYST_LAYER2_CONFIG_FILE ||
-    resolve(homedir(), ".config", "catalyst", "config.json")
-  );
+    resolve(homedir(), ".config", "catalyst", "config.json");
+  const canonicalPath = resolveLayer2Path(process.env);
+  if (legacyPath !== canonicalPath) {
+    const msg =
+      `layer2 config path shadow-diff (CTL-1616 PR6): legacy chain resolved "${legacyPath}" ` +
+      `but the canonical chain resolved "${canonicalPath}" — using "${canonicalPath}" (legacy ` +
+      `ignores CATALYST_MACHINE_CONFIG/XDG_CONFIG_HOME; set CATALYST_LAYER2_CONFIG_FILE to pin ` +
+      `explicitly if this is unexpected)`;
+    if (!_warnedLayer2PathDrift.has(msg)) {
+      _warnedLayer2PathDrift.add(msg);
+      log.warn(msg);
+    }
+  }
+  return canonicalPath;
 }
 
 // The repo root that owns the committed cluster roster (.catalyst/hosts.json).

--- a/plugins/dev/scripts/execution-core/config.test.mjs
+++ b/plugins/dev/scripts/execution-core/config.test.mjs
@@ -8,8 +8,8 @@
 
 import { describe, test, expect, beforeEach, afterEach } from "bun:test";
 import { mkdtempSync, writeFileSync, rmSync, mkdirSync, existsSync } from "node:fs";
-import { tmpdir, hostname } from "node:os";
-import { join } from "node:path";
+import { tmpdir, hostname, homedir } from "node:os";
+import { join, resolve } from "node:path";
 import {
   readWaitWatcherConfig,
   EVENT_DEBOUNCE_MS,
@@ -55,6 +55,8 @@ import {
   codexConfig,
   readFleetHealthConfig,
   getFleetHealthDir,
+  getLayer2ConfigPath,
+  log,
 } from "./config.mjs";
 
 const PREV = process.env.CATALYST_WAIT_WATCHER;
@@ -301,6 +303,76 @@ describe("getHostName (CTL-859)", () => {
     process.env.CATALYST_LAYER2_CONFIG_FILE = cfg;
     const expected = hostname().replace(/\.local$/, "");
     expect(getHostName()).toBe(expected);
+  });
+});
+
+describe("getLayer2ConfigPath — CTL-1616 PR6 dual-read shadow-diff", () => {
+  const ENV_KEYS = ["CATALYST_LAYER2_CONFIG_FILE", "CATALYST_MACHINE_CONFIG", "XDG_CONFIG_HOME"];
+  let saved = {};
+  let warnCalls;
+  let origWarn;
+
+  beforeEach(() => {
+    for (const k of ENV_KEYS) {
+      saved[k] = process.env[k];
+      delete process.env[k];
+    }
+    warnCalls = [];
+    origWarn = log.warn;
+    log.warn = (...args) => warnCalls.push(args);
+  });
+
+  afterEach(() => {
+    for (const k of ENV_KEYS) {
+      if (saved[k] === undefined) delete process.env[k];
+      else process.env[k] = saved[k];
+    }
+    saved = {};
+    log.warn = origWarn;
+  });
+
+  test("agree case: no overrides at all — silent, returns the homedir default (both chains agree)", () => {
+    const expected = resolve(homedir(), ".config", "catalyst", "config.json");
+    expect(getLayer2ConfigPath()).toBe(expected);
+    expect(warnCalls.length).toBe(0);
+  });
+
+  test("agree case: CATALYST_LAYER2_CONFIG_FILE set — both chains check it first, silent", () => {
+    process.env.CATALYST_LAYER2_CONFIG_FILE = "/explicit/pr6-agree/config.json";
+    expect(getLayer2ConfigPath()).toBe("/explicit/pr6-agree/config.json");
+    expect(warnCalls.length).toBe(0);
+  });
+
+  test("differ case: CATALYST_MACHINE_CONFIG set (legacy ignores it) — warns once, the NEW (canonical) path wins", () => {
+    process.env.CATALYST_MACHINE_CONFIG = "/machine/pr6-machine-config-test/config.json";
+    const result = getLayer2ConfigPath();
+    expect(result).toBe("/machine/pr6-machine-config-test/config.json");
+    expect(warnCalls.length).toBe(1);
+    const msg = warnCalls[0][0];
+    expect(msg).toContain(resolve(homedir(), ".config", "catalyst", "config.json"));
+    expect(msg).toContain("/machine/pr6-machine-config-test/config.json");
+  });
+
+  test("differ case: XDG_CONFIG_HOME set (legacy ignores it) — warns once, the NEW (canonical) path wins", () => {
+    process.env.XDG_CONFIG_HOME = "/xdg/pr6-xdg-test";
+    const result = getLayer2ConfigPath();
+    expect(result).toBe(join("/xdg/pr6-xdg-test", "catalyst", "config.json"));
+    expect(warnCalls.length).toBe(1);
+  });
+
+  test("dedup: repeated calls with the SAME divergence warn only once (mirrors getNodeClass's _warnedNodeClass pattern)", () => {
+    process.env.CATALYST_MACHINE_CONFIG = "/machine/pr6-dedup-test/config.json";
+    getLayer2ConfigPath();
+    getLayer2ConfigPath();
+    getLayer2ConfigPath();
+    expect(warnCalls.length).toBe(1);
+  });
+
+  test("env override beats CATALYST_MACHINE_CONFIG on the canonical chain too — both agree, silent", () => {
+    process.env.CATALYST_LAYER2_CONFIG_FILE = "/explicit/pr6-precedence-test/config.json";
+    process.env.CATALYST_MACHINE_CONFIG = "/machine/should-not-win/config.json";
+    expect(getLayer2ConfigPath()).toBe("/explicit/pr6-precedence-test/config.json");
+    expect(warnCalls.length).toBe(0);
   });
 });
 

--- a/plugins/dev/scripts/execution-core/doctor.mjs
+++ b/plugins/dev/scripts/execution-core/doctor.mjs
@@ -2552,12 +2552,21 @@ export function checkAgentBrowser(deps = {}) {
   return checks;
 }
 
-// checkCloudTokenEnv — CTL-1307. ADVISORY ONLY (never FAIL): the cluster-shared
-// CATALYST_CLOUD_TOKEN is an OPTIONAL extension — a node stays fully local-only
-// without it, so its absence must NEVER block activation. WARN only on DRIFT: the
-// token has been decrypted from the catalyst-cluster repo (cluster-cloud.json)
-// but is not yet projected into the machine-level env (cluster.env + ~/.zshenv
-// guard). All reads are injectable + fail-open.
+// checkCloudTokenEnv — CTL-1307. ADVISORY for the cluster-shared-token distribution
+// checks below (the `cloud-token` row's original CTL-1307 scope): CATALYST_CLOUD_TOKEN
+// is an OPTIONAL extension for a cluster node — a node stays fully local-only without
+// it, so its absence must NEVER block activation there. WARN only on DRIFT: the token
+// has been decrypted from the catalyst-cluster repo (cluster-cloud.json) but is not yet
+// projected into the machine-level env (cluster.env + ~/.zshenv guard).
+//
+// CTL-1616 PR6 (design §5/§7) ADDS ONE FAIL: when the ACTIVE deployment mode is
+// DECLARED cloud (not cluster's optional extension — the actual managed-platform mode),
+// a missing/unresolvable bootstrap credential IS the one FAIL doctor cannot route
+// around — see the `cloud-token-bootstrap` check below. That escalation is gated
+// entirely on deployment mode and contributes ZERO checks for every other mode, so this
+// function's original ADVISORY/never-FAIL contract is UNCHANGED for single-host,
+// cluster, and inferred nodes — i.e. every live host today. All reads are injectable +
+// fail-open.
 export function checkCloudTokenEnv(deps = {}) {
   const {
     configDir = process.env.CATALYST_CONFIG_DIR || resolve(homedir(), ".config", "catalyst"),
@@ -2578,8 +2587,78 @@ export function checkCloudTokenEnv(deps = {}) {
     // here alongside the literal-name comparison so a clean shadow cycle
     // cannot mask that divergence.
     resolveReplicaTokenEnv = resolveNodeCloudTokenEnv,
+    // CTL-1616 PR6 (design §5/§7): the §7 FAIL escalation's deployment-mode
+    // input — injectable, same convention as every other secret-contract call
+    // site in this file. Default is throw-safe (resolveDeploymentModeForShadow
+    // catches internally and degrades to undefined), so an unset/throwing
+    // resolver fails OPEN to today's INFO-only behavior (the escalation below
+    // is gated on this being genuinely {mode:"cloud", inferred:false, ...} —
+    // undefined never satisfies that gate).
+    deploymentMode = resolveDeploymentModeForShadow(),
   } = deps;
   const checks = [];
+
+  // CTL-1616 PR6 §7 FAIL ESCALATION (design §5): "the one FAIL doctor cannot
+  // route around." Computed ONCE here (same convention as cloudShadowChecks
+  // just below) and appended at EVERY return point so it fires regardless of
+  // which cluster-cloud.json/cluster.env/zshenv branch this check's existing
+  // hand-rolled logic lands in — those branches answer "is CATALYST_CLOUD_TOKEN
+  // projected from the cluster-sync distribution path", an ORTHOGONAL question
+  // to "is this node's deployment mode declared cloud and did the bootstrap
+  // credential resolve" (design §4's bootstrapFor:"cloud" row IS this same
+  // secret, just consulted through the shared engine rather than the
+  // cluster-sync file trio).
+  //
+  // GATE: fires ONLY when the ACTIVE deployment mode is DECLARED cloud —
+  // recognized (not a typo'd/degraded value) AND not inferred (an operator
+  // explicitly set it, matching checkDeploymentModeConsistency's tunnel-
+  // consistency gate at ~line 3445 and the engine's own cloud guard in
+  // lib/secret-contract.mjs's resolveSecret). Structurally inert (contributes
+  // ZERO checks, hence zero grade change) for every other deployment mode —
+  // single-host, cluster, inferred, or an unrecognized explicit value — so
+  // this is provably a no-op on both live minis (cluster) and the laptop
+  // (single-host). `recognized !== false` mirrors the engine's own
+  // belt-and-suspenders extension (design §12 Q3) rather than requiring
+  // recognized===true, so a deploymentMode object that omits the field
+  // (legacy callers, most fixtures elsewhere in this file) still gates
+  // correctly on inferred alone.
+  const cloudBootstrapEscalationChecks = [];
+  const dm = deploymentMode;
+  if (dm && dm.mode === "cloud" && dm.inferred === false && dm.recognized !== false) {
+    const bootstrapResolution = safeResolveSecretContract(resolveSecretContract, "cloud-token", {
+      env: process.env,
+      deploymentMode: dm,
+    });
+    if (!bootstrapResolution.ok) {
+      cloudBootstrapEscalationChecks.push(
+        shadowThrowCheck("cloud-token-bootstrap", "cloud-token", bootstrapResolution.error),
+      );
+    } else {
+      const bootstrapResolved = bootstrapResolution.value;
+      const envVar = typeof bootstrapResolved?.envVar === "string" ? bootstrapResolved.envVar : "CATALYST_CLOUD_TOKEN";
+      if (bootstrapResolved?.value == null) {
+        cloudBootstrapEscalationChecks.push(
+          mkCheck(
+            "cloud-token-bootstrap",
+            STATUS.FAIL,
+            `deployment mode is declared "cloud" but the bootstrap credential (env var ` +
+              `"${envVar}") did not resolve — per the §4 cloud guard's bootstrap short-circuit, ` +
+              `EVERY other cloud-mode secret resolution returns null until this is set (a ` +
+              `half-provisioned managed container); set ${envVar} in the platform environment`,
+          ),
+        );
+      } else {
+        cloudBootstrapEscalationChecks.push(
+          mkCheck(
+            "cloud-token-bootstrap",
+            STATUS.PASS,
+            `deployment mode is declared "cloud" and the bootstrap credential resolved ` +
+              `(env var "${envVar}", source=${bootstrapResolved.envVarSource ?? bootstrapResolved.source})`,
+          ),
+        );
+      }
+    }
+  }
 
   // CTL-1616 PR2 (B1): computed ONCE here, but pushed at each return point
   // below so the shadow row is always APPENDED AFTER the primary rows (the
@@ -2655,7 +2734,7 @@ export function checkCloudTokenEnv(deps = {}) {
         "no cluster cloud token decrypted — node is local-only (expected unless opted into catalyst-cloud)",
       ),
     );
-    checks.push(...cloudShadowChecks);
+    checks.push(...cloudShadowChecks, ...cloudBootstrapEscalationChecks);
     return checks;
   }
 
@@ -2675,7 +2754,7 @@ export function checkCloudTokenEnv(deps = {}) {
         "cloud token decrypted but NOT projected to ~/.config/catalyst/cluster.env — run 'catalyst-stack sync-cloud-env'",
       ),
     );
-    checks.push(...cloudShadowChecks);
+    checks.push(...cloudShadowChecks, ...cloudBootstrapEscalationChecks);
     return checks;
   }
   if (!clusterEnv.includes(expected)) {
@@ -2686,7 +2765,7 @@ export function checkCloudTokenEnv(deps = {}) {
         "cluster.env CATALYST_CLOUD_TOKEN is STALE vs cluster-cloud.json — run 'catalyst-stack sync-cloud-env' and restart cloud daemons",
       ),
     );
-    checks.push(...cloudShadowChecks);
+    checks.push(...cloudShadowChecks, ...cloudBootstrapEscalationChecks);
     return checks;
   }
 
@@ -2704,7 +2783,7 @@ export function checkCloudTokenEnv(deps = {}) {
         "cluster.env present but ~/.zshenv lacks the source-guard — shells (and shell-launched cloud daemons) won't inherit CATALYST_CLOUD_TOKEN",
       ),
     );
-    checks.push(...cloudShadowChecks);
+    checks.push(...cloudShadowChecks, ...cloudBootstrapEscalationChecks);
     return checks;
   }
 
@@ -2715,7 +2794,7 @@ export function checkCloudTokenEnv(deps = {}) {
       "cluster cloud token projected to machine-level env (cluster.env + ~/.zshenv guard)",
     ),
   );
-  checks.push(...cloudShadowChecks);
+  checks.push(...cloudShadowChecks, ...cloudBootstrapEscalationChecks);
   return checks;
 }
 

--- a/plugins/dev/scripts/execution-core/doctor.test.mjs
+++ b/plugins/dev/scripts/execution-core/doctor.test.mjs
@@ -1862,6 +1862,162 @@ describe("checkCloudTokenEnv", () => {
       for (const c of checks) expect(c.status).not.toBe(STATUS.FAIL);
     }
   });
+
+  // ─── CTL-1616 PR6 §7 FAIL escalation (design §5) ───────────────────────────
+  describe("cloud-token-bootstrap FAIL escalation (CTL-1616 PR6)", () => {
+    const DECLARED_CLOUD = { mode: "cloud", source: "env", inferred: false, recognized: true };
+    // Every mode this escalation must be INERT for — the "zero grade change on
+    // every live host" success criterion (design §9 PR6): both minis are
+    // cluster, the laptop is single-host, and an inferred default must never
+    // fire this either.
+    const NON_DECLARED_CLOUD_MODES = [
+      { mode: "single-host", source: "default", inferred: true, recognized: true },
+      { mode: "single-host", source: "layer2", inferred: false, recognized: true },
+      { mode: "cluster", source: "layer1", inferred: false, recognized: true },
+      // Belt-and-suspenders (design §12 Q3): a hand-constructed cloud+inferred:false
+      // object with recognized:false must also stay inert.
+      { mode: "cloud", source: "env", inferred: false, recognized: false },
+    ];
+
+    it("FAILs cloud-token-bootstrap, naming the resolved env-var name and the §4 short-circuit consequence, when declared cloud mode's bootstrap credential does not resolve", () => {
+      const checks = checkCloudTokenEnv({
+        configDir: CFG,
+        zshenvPath: ZSH,
+        readFile: reader({}),
+        deploymentMode: DECLARED_CLOUD,
+        resolveSecretContract: () => ({
+          value: null,
+          source: "none",
+          provider: "platform-env",
+          envVar: "CATALYST_CLOUD_TOKEN",
+          envVarSource: "default",
+        }),
+      });
+      const boot = checks.find((c) => c.name === "cloud-token-bootstrap");
+      expect(boot).toBeDefined();
+      expect(boot.status).toBe(STATUS.FAIL);
+      expect(boot.detail).toContain("CATALYST_CLOUD_TOKEN");
+      expect(boot.detail.toLowerCase()).toContain("cloud");
+      expect(boot.detail.toLowerCase()).toContain("short-circuit");
+    });
+
+    it("names a CUSTOM resolved env-var name in the FAIL detail — never hardcodes CATALYST_CLOUD_TOKEN", () => {
+      const checks = checkCloudTokenEnv({
+        configDir: CFG,
+        zshenvPath: ZSH,
+        readFile: reader({}),
+        deploymentMode: DECLARED_CLOUD,
+        resolveSecretContract: () => ({
+          value: null,
+          source: "none",
+          provider: "platform-env",
+          envVar: "MY_CUSTOM_CLOUD_TOKEN",
+          envVarSource: "layer2",
+        }),
+      });
+      const boot = checks.find((c) => c.name === "cloud-token-bootstrap");
+      expect(boot.status).toBe(STATUS.FAIL);
+      expect(boot.detail).toContain("MY_CUSTOM_CLOUD_TOKEN");
+    });
+
+    it("PASSes cloud-token-bootstrap when declared cloud mode's bootstrap credential DOES resolve", () => {
+      const checks = checkCloudTokenEnv({
+        configDir: CFG,
+        zshenvPath: ZSH,
+        readFile: reader({}),
+        deploymentMode: DECLARED_CLOUD,
+        resolveSecretContract: () => ({
+          value: "the-real-token",
+          source: "platform-env",
+          provider: "platform-env",
+          envVar: "CATALYST_CLOUD_TOKEN",
+          envVarSource: "default",
+        }),
+      });
+      const boot = checks.find((c) => c.name === "cloud-token-bootstrap");
+      expect(boot).toBeDefined();
+      expect(boot.status).toBe(STATUS.PASS);
+    });
+
+    it("a throwing resolver in declared cloud mode degrades to a shadow-throw INFO row, never a crash", () => {
+      const checks = checkCloudTokenEnv({
+        configDir: CFG,
+        zshenvPath: ZSH,
+        readFile: reader({}),
+        deploymentMode: DECLARED_CLOUD,
+        resolveSecretContract: () => {
+          throw new Error("boom");
+        },
+      });
+      const boot = checks.find((c) => c.name === "cloud-token-bootstrap-secret-contract-shadow");
+      expect(boot).toBeDefined();
+      expect(boot.status).toBe(STATUS.INFO);
+      expect(checks.some((c) => c.status === STATUS.FAIL)).toBe(false);
+    });
+
+    it("is structurally INERT (contributes zero checks — not even INFO) for every non-declared-cloud deployment mode: zero grade change on every live host", () => {
+      for (const deploymentMode of NON_DECLARED_CLOUD_MODES) {
+        const checks = checkCloudTokenEnv({
+          configDir: CFG,
+          zshenvPath: ZSH,
+          readFile: reader({}),
+          deploymentMode,
+          // A resolver that WOULD FAIL if consulted — proves the gate short-circuits
+          // before ever calling it, not merely that its result happens to be non-FAIL.
+          resolveSecretContract: () => {
+            throw new Error("must never be called for this deployment mode");
+          },
+        });
+        expect(checks.find((c) => c.name === "cloud-token-bootstrap")).toBeUndefined();
+        expect(checks.find((c) => c.name === "cloud-token-bootstrap-secret-contract-shadow")).toBeUndefined();
+      }
+    });
+
+    it("fails OPEN to today's INFO-only behavior when the injected deploymentMode itself is undefined/throws (never crashes checkCloudTokenEnv)", () => {
+      const checks = checkCloudTokenEnv({
+        configDir: CFG,
+        zshenvPath: ZSH,
+        readFile: reader({}),
+        deploymentMode: undefined,
+        resolveSecretContract: agreeingCloudTokenContract,
+      });
+      expect(checks.find((c) => c.name === "cloud-token-bootstrap")).toBeUndefined();
+      expect(checks[0].status).toBe(STATUS.INFO);
+    });
+
+    // ─── §9 PR6 invariant (design §9 success criterion) ──────────────────────
+    it("END-TO-END with the REAL engine: a synthetic declared-cloud run with no platform token produces the FAIL and PROVABLY never touches the file-search path", () => {
+      // A real cluster-cloud.json/cluster.env/zshenv trio IS present (so the
+      // hand-rolled branches above would otherwise PASS) — the point of this
+      // test is that the NEW escalation fires independently, via the real
+      // resolveSecret engine, and that engine's cloud guard short-circuits
+      // before ever touching the file the CATALYST_CONFIG_DIR fixture below
+      // would otherwise satisfy.
+      const checks = checkCloudTokenEnv({
+        configDir: CFG,
+        zshenvPath: ZSH,
+        readFile: reader({
+          cloud: clusterCloud("tok"),
+          env: exportLine("tok") + "\n",
+          zsh: "# >>> catalyst cloud-token env (CTL-1307) >>>\n. cluster.env\n",
+        }),
+        deploymentMode: DECLARED_CLOUD,
+        // env has NO CATALYST_CLOUD_TOKEN — the real engine's cloud branch is a
+        // pure env-alias read (no file search at all), so this is genuinely
+        // absent regardless of the cluster-cloud.json/cluster.env fixtures above.
+        resolveSecretContract: (id, opts) => resolveSecretReal(id, { ...opts, env: {} }),
+      });
+      const boot = checks.find((c) => c.name === "cloud-token-bootstrap");
+      expect(boot).toBeDefined();
+      expect(boot.status).toBe(STATUS.FAIL);
+      expect(boot.detail).toContain("CATALYST_CLOUD_TOKEN");
+      // The original hand-rolled cluster-cloud.json/cluster.env/zshenv check
+      // still PASSes on its own terms (proving the two questions are genuinely
+      // orthogonal, not that one silently overrides the other).
+      expect(checks[0].name).toBe("cloud-token");
+      expect(checks[0].status).toBe(STATUS.PASS);
+    });
+  });
 });
 
 describe("checkSdkExecutorAuth (CTL-1367 item 9)", () => {

--- a/plugins/dev/scripts/execution-core/lib/node-class-layer2-path.test.mjs
+++ b/plugins/dev/scripts/execution-core/lib/node-class-layer2-path.test.mjs
@@ -1,0 +1,75 @@
+// node-class-layer2-path.test.mjs — CTL-1616 PR6 (design §8/§9). lib/node-class.mjs's
+// getLayer2ConfigPath dual-read shadow-diff: computes BOTH the legacy homedir-only chain
+// (CATALYST_LAYER2_CONFIG_FILE || ~/.config/catalyst/config.json) AND the registry's
+// canonical resolveLayer2Path chain (CATALYST_LAYER2_CONFIG_FILE > CATALYST_MACHINE_CONFIG >
+// XDG_CONFIG_HOME > ~/.config/catalyst) on every call; agreement stays silent, a divergence
+// warns once (console.warn — this is a zero-import leaf, no pino/log import) and the NEW
+// (canonical) path wins. Mirrors execution-core/config.test.mjs's equivalent suite for
+// config.mjs's own getLayer2ConfigPath.
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { homedir } from "node:os";
+import { resolve, join } from "node:path";
+import { getLayer2ConfigPath } from "./node-class.mjs";
+
+const ENV_KEYS = ["CATALYST_LAYER2_CONFIG_FILE", "CATALYST_MACHINE_CONFIG", "XDG_CONFIG_HOME"];
+let saved = {};
+let warnCalls;
+let origWarn;
+
+beforeEach(() => {
+  for (const k of ENV_KEYS) {
+    saved[k] = process.env[k];
+    delete process.env[k];
+  }
+  warnCalls = [];
+  origWarn = console.warn;
+  console.warn = (...args) => warnCalls.push(args);
+});
+
+afterEach(() => {
+  for (const k of ENV_KEYS) {
+    if (saved[k] === undefined) delete process.env[k];
+    else process.env[k] = saved[k];
+  }
+  saved = {};
+  console.warn = origWarn;
+});
+
+describe("node-class.mjs getLayer2ConfigPath — CTL-1616 PR6 dual-read shadow-diff", () => {
+  test("agree case: no overrides at all — silent, returns the homedir default", () => {
+    const expected = resolve(homedir(), ".config", "catalyst", "config.json");
+    expect(getLayer2ConfigPath()).toBe(expected);
+    expect(warnCalls.length).toBe(0);
+  });
+
+  test("agree case: CATALYST_LAYER2_CONFIG_FILE set — both chains check it first, silent", () => {
+    process.env.CATALYST_LAYER2_CONFIG_FILE = "/explicit/nc-pr6-agree/config.json";
+    expect(getLayer2ConfigPath()).toBe("/explicit/nc-pr6-agree/config.json");
+    expect(warnCalls.length).toBe(0);
+  });
+
+  test("differ case: CATALYST_MACHINE_CONFIG set (legacy ignores it) — warns once, the NEW (canonical) path wins", () => {
+    process.env.CATALYST_MACHINE_CONFIG = "/machine/nc-pr6-machine-config-test/config.json";
+    const result = getLayer2ConfigPath();
+    expect(result).toBe("/machine/nc-pr6-machine-config-test/config.json");
+    expect(warnCalls.length).toBe(1);
+    const msg = warnCalls[0][0];
+    expect(msg).toContain(resolve(homedir(), ".config", "catalyst", "config.json"));
+    expect(msg).toContain("/machine/nc-pr6-machine-config-test/config.json");
+  });
+
+  test("differ case: XDG_CONFIG_HOME set (legacy ignores it) — warns once, the NEW (canonical) path wins", () => {
+    process.env.XDG_CONFIG_HOME = "/xdg/nc-pr6-xdg-test";
+    const result = getLayer2ConfigPath();
+    expect(result).toBe(join("/xdg/nc-pr6-xdg-test", "catalyst", "config.json"));
+    expect(warnCalls.length).toBe(1);
+  });
+
+  test("dedup: repeated calls with the SAME divergence warn only once", () => {
+    process.env.CATALYST_MACHINE_CONFIG = "/machine/nc-pr6-dedup-test/config.json";
+    getLayer2ConfigPath();
+    getLayer2ConfigPath();
+    getLayer2ConfigPath();
+    expect(warnCalls.length).toBe(1);
+  });
+});

--- a/plugins/dev/scripts/execution-core/lib/node-class.mjs
+++ b/plugins/dev/scripts/execution-core/lib/node-class.mjs
@@ -1,17 +1,23 @@
 // lib/node-class.mjs — node-class resolution primitives for MJS emitters (CTL-1368).
 //
-// A dependency-free LEAF (node builtins only — no config.mjs, no pino, no bun:sqlite) so
-// the shared resource builder (lib/catalyst-resource.mjs) and any light emitter (broker,
-// catalyst-agent) can stamp `catalyst.node.class` WITHOUT dragging the heavy config.mjs
-// graph. Mirrors execution-core/config.mjs's resolveNodeClass EXACTLY — the same way
-// lib/host-identity.mjs mirrors getHostName's Layer-2 read rather than importing config.mjs.
-// Drift is guarded by lib/__tests__/node-class-parity.test.mjs (asserts this resolver and
-// config.mjs's agree across the full input matrix). config.mjs stays the canonical home for
-// the dispatch/doctor logic; this leaf is the read-only mirror for telemetry.
+// A dependency-free LEAF (node builtins + the OTHER zero-import leaf lib/secret-contract.mjs
+// only — no config.mjs, no pino, no bun:sqlite) so the shared resource builder
+// (lib/catalyst-resource.mjs) and any light emitter (broker, catalyst-agent) can stamp
+// `catalyst.node.class` WITHOUT dragging the heavy config.mjs graph. Mirrors
+// execution-core/config.mjs's resolveNodeClass EXACTLY — the same way lib/host-identity.mjs
+// mirrors getHostName's Layer-2 read rather than importing config.mjs. Drift is guarded by
+// lib/__tests__/node-class-parity.test.mjs (asserts this resolver and config.mjs's agree
+// across the full input matrix). config.mjs stays the canonical home for the dispatch/doctor
+// logic; this leaf is the read-only mirror for telemetry.
 
 import { homedir } from "node:os";
 import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
+// CTL-1616 PR6 (design §8/§9): resolveLayer2Path is the registry's canonical Layer-2 path
+// chain — consulted by getLayer2ConfigPath's dual-read shadow-diff below. Importing the
+// OTHER zero-import leaf (node:fs/os/path only, same as this file) does not reintroduce the
+// heavy config.mjs graph this file exists to avoid.
+import { resolveLayer2Path } from "../../lib/secret-contract.mjs";
 
 // The three node classes (frozen). Mirrors config.mjs NODE_CLASSES.
 export const NODE_CLASSES = Object.freeze(["developer", "worker", "monitor"]);
@@ -22,11 +28,32 @@ const NODE_CLASS_DEFAULT = "worker";
 // routes catalyst doctor to FAIL).
 const NODE_CLASS_MOST_RESTRICTIVE = "monitor";
 
-// Layer-2 (machine-local) config path — mirrors config.mjs getLayer2ConfigPath()
-// (CATALYST_LAYER2_CONFIG_FILE || ~/.config/catalyst/config.json), duplicated here to
-// keep this a leaf (same pattern host-identity.mjs uses for layer2HostName).
-function getLayer2ConfigPath() {
-  return process.env.CATALYST_LAYER2_CONFIG_FILE || resolve(homedir(), ".config", "catalyst", "config.json");
+// Layer-2 (machine-local) config path — historically CATALYST_LAYER2_CONFIG_FILE ||
+// ~/.config/catalyst/config.json, duplicated here to keep this a leaf (same pattern
+// host-identity.mjs uses for layer2HostName) and mirroring config.mjs's OWN legacy chain.
+//
+// CTL-1616 PR6 (design §8/§9): DUAL-READ shadow-diff for one release, delegating the
+// RETURNED path to the registry's canonical resolveLayer2Path chain (CATALYST_LAYER2_CONFIG_FILE
+// > CATALYST_MACHINE_CONFIG > XDG_CONFIG_HOME > ~/.config/catalyst) — same dual-read shape as
+// execution-core/config.mjs's getLayer2ConfigPath, which this file mirrors. Exported (unlike
+// before) so tests can exercise the shadow-diff directly. No `log` import here (zero-import
+// leaf) — uses console.warn, same as lib/deployment-mode.mjs's getDeploymentMode dedup.
+const _warnedLayer2PathDrift = new Set();
+export function getLayer2ConfigPath() {
+  const legacyPath = process.env.CATALYST_LAYER2_CONFIG_FILE || resolve(homedir(), ".config", "catalyst", "config.json");
+  const canonicalPath = resolveLayer2Path(process.env);
+  if (legacyPath !== canonicalPath) {
+    const msg =
+      `layer2 config path shadow-diff (CTL-1616 PR6): legacy chain resolved "${legacyPath}" ` +
+      `but the canonical chain resolved "${canonicalPath}" — using "${canonicalPath}" (legacy ` +
+      `ignores CATALYST_MACHINE_CONFIG/XDG_CONFIG_HOME; set CATALYST_LAYER2_CONFIG_FILE to pin ` +
+      `explicitly if this is unexpected)`;
+    if (!_warnedLayer2PathDrift.has(msg)) {
+      _warnedLayer2PathDrift.add(msg);
+      console.warn(`[node-class] ${msg}`);
+    }
+  }
+  return canonicalPath;
 }
 
 // readLayer2NodeClass — the raw catalyst.node.class value from the Layer-2 file EXACTLY as

--- a/plugins/dev/scripts/lib/catalyst-secret-contract.sh
+++ b/plugins/dev/scripts/lib/catalyst-secret-contract.sh
@@ -863,18 +863,23 @@ _csc_cloud_bootstrap_id() {
   return 1
 }
 
-# catalyst_resolve_secret ID [DEPLOYMENT_MODE] [INFERRED(true|false)] — mirrors
-# resolveSecret(id, {env, deploymentMode}). Echoes "value|source|provider" and sets
+# catalyst_resolve_secret ID [DEPLOYMENT_MODE] [INFERRED(true|false)] [RECOGNIZED(true|false)]
+# — mirrors resolveSecret(id, {env, deploymentMode}). Echoes "value|source|provider" and sets
 # CATALYST_SECRET_LAST_VALUE/_SOURCE/_PROVIDER. Never fails the caller (always echoes a
 # 3-field pipe-joined string, empty fields on miss/unresolved).
 #
-# CLOUD GUARD: activates ONLY when DEPLOYMENT_MODE == "cloud" AND INFERRED == "false" —
-# mirrors the JS engine's `deploymentMode.mode === "cloud" && deploymentMode.inferred ===
-# false` guard exactly. Any other combination (including DEPLOYMENT_MODE unset, "single-host",
-# "cluster", or "cloud" with INFERRED != "false") runs the normal per-delivery-type file/config
-# chain — the "never skips the file chain for single-host/cluster" invariant.
+# CLOUD GUARD: activates ONLY when DEPLOYMENT_MODE == "cloud" AND INFERRED == "false" AND
+# RECOGNIZED != "false" — mirrors the JS engine's `deploymentMode.mode === "cloud" &&
+# deploymentMode.inferred === false && deploymentMode.recognized !== false` guard exactly
+# (design §12 Q3 belt-and-suspenders extension — see lib/secret-contract.mjs's resolveSecret
+# docstring for the full rationale). RECOGNIZED defaults to "true" so every existing 2/3-arg
+# call site keeps today's behavior unchanged — this is an ADDITIVE 4th positional arg, never a
+# breaking one. Any other combination (including DEPLOYMENT_MODE unset, "single-host",
+# "cluster", "cloud" with INFERRED != "false", or "cloud"/inferred=false with RECOGNIZED ==
+# "false") runs the normal per-delivery-type file/config chain — the "never skips the file
+# chain for single-host/cluster" invariant.
 catalyst_resolve_secret() {
-  local _id="$1" _dep_mode="${2:-}" _dep_inferred="${3:-true}"
+  local _id="$1" _dep_mode="${2:-}" _dep_inferred="${3:-true}" _dep_recognized="${4:-true}"
   local _idx _delivery
   if ! _idx="$(_csc_index_of "$_id")"; then
     _csc_set_result "" "" ""
@@ -882,7 +887,7 @@ catalyst_resolve_secret() {
   fi
   _delivery="${_CSC_DELIVERY[$_idx]}"
 
-  if [[ "$_dep_mode" == "cloud" && "$_dep_inferred" == "false" ]]; then
+  if [[ "$_dep_mode" == "cloud" && "$_dep_inferred" == "false" && "$_dep_recognized" != "false" ]]; then
     local _bootstrap_for="${_CSC_BOOTSTRAP_FOR[$_idx]}"
     if [[ "$_bootstrap_for" != "cloud" ]]; then
       local _bid
@@ -986,13 +991,14 @@ catalyst_secret_reset_arm_state() {
   fi
 }
 
-# catalyst_arm_secret ID [DEPLOYMENT_MODE] [INFERRED(true|false)] — echoes
-# "armed|rotated|restartRequired" (each true|false) AND exports the same three fields as
-# CATALYST_SECRET_ARM_ARMED / _ROTATED / _RESTART_REQUIRED, mirroring armSecret's { armed,
-# rotated, restartRequired } shape. DEPLOYMENT_MODE/INFERRED are the SAME optional
+# catalyst_arm_secret ID [DEPLOYMENT_MODE] [INFERRED(true|false)] [RECOGNIZED(true|false)] —
+# echoes "armed|rotated|restartRequired" (each true|false) AND exports the same three fields
+# as CATALYST_SECRET_ARM_ARMED / _ROTATED / _RESTART_REQUIRED, mirroring armSecret's { armed,
+# rotated, restartRequired } shape. DEPLOYMENT_MODE/INFERRED/RECOGNIZED are the SAME optional
 # positional args catalyst_resolve_secret takes, threaded straight through (Codex finding
-# fix, design §8) — see the DEPLOYMENT-MODE THREADING FIX comment below for the concrete
-# bug this closes; a caller that never passes them gets EXACTLY today's non-cloud behavior.
+# fix, design §8; RECOGNIZED added in CTL-1616 PR6 alongside the cloud-guard extension) — see
+# the DEPLOYMENT-MODE THREADING FIX comment below for the concrete bug this closes; a caller
+# that never passes them gets EXACTLY today's non-cloud behavior.
 #
 # MUST BE CALLED DIRECTLY, NEVER WRAPPED IN $(...), by any caller that needs the persistent
 # baseline to survive across repeated calls in the same shell — this is the SAME
@@ -1005,7 +1011,7 @@ catalyst_secret_reset_arm_state() {
 # read the exported vars, or capture stdout via `out="$(catalyst_arm_secret id)"` ONLY when
 # the caller genuinely wants a one-shot, state-discarding check.
 catalyst_arm_secret() {
-  local _id="$1" _dep_mode="${2:-}" _dep_inferred="${3:-true}" _rotation_class=""
+  local _id="$1" _dep_mode="${2:-}" _dep_inferred="${3:-true}" _dep_recognized="${4:-true}" _rotation_class=""
   # B4 FIX (errexit safety): the assignment runs in an `if` condition — mirrors the
   # ERREXIT SAFETY pattern on _csc_read_json_string above. catalyst_secret_rotation_class
   # returns rc=1 (printing nothing) for an unknown id; a bare
@@ -1039,7 +1045,7 @@ catalyst_arm_secret() {
   # file, that mismatch made a stale-file edit falsely report restartRequired while a REAL
   # token rotation went unnoticed — mirrors lib/secret-contract.mjs's armSecret fix exactly.
   local _current _idx
-  catalyst_resolve_secret "$_id" "$_dep_mode" "$_dep_inferred" >/dev/null
+  catalyst_resolve_secret "$_id" "$_dep_mode" "$_dep_inferred" "$_dep_recognized" >/dev/null
   _current="${CATALYST_SECRET_LAST_VALUE-}"
   if _idx="$(_csc_arm_index_of "$_id")"; then
     local _previous="${_CSC_ARM_VALUES[$_idx]}"

--- a/plugins/dev/scripts/lib/secret-contract.mjs
+++ b/plugins/dev/scripts/lib/secret-contract.mjs
@@ -852,8 +852,20 @@ function resolveLocalOnlyPresence(row, env) {
 // } for a known row, or { value: null, source: null, provider: null, rotation: null } for an
 // unknown id.
 //
-// CLOUD GUARD (design §4): the cloud branch activates ONLY when
-// deploymentMode.mode === "cloud" AND deploymentMode.inferred === false — never on a guess.
+// CLOUD GUARD (design §4, belt-and-suspenders extension per design §12 Q3's operator-
+// recommended answer): the cloud branch activates ONLY when deploymentMode.mode === "cloud"
+// AND deploymentMode.inferred === false AND deploymentMode.recognized !== false — never on a
+// guess. CTL-1617 §8 literally mandates only the `inferred === false` half; §12 Q3 asked
+// whether to also refuse on `recognized === false` (an unrecognized EXPLICIT value) and
+// recommended blocking on both, since "an unrecognized explicit value degrades to
+// single-host anyway per the resolver" makes this a defense-in-depth belt-and-suspenders
+// check, not a behavior change for any deploymentMode object produced by the real
+// resolveDeploymentMode (which can never return mode:"cloud" with recognized:false — see
+// classifyCandidate in lib/deployment-mode.mjs). It DOES matter for a hand-constructed or
+// future-degraded deploymentMode object, which is exactly the scenario worth guarding.
+// `!== false` (not `=== true`) is deliberate: every pre-existing caller/test that omits
+// `recognized` entirely (undefined) must keep activating cloud exactly as before — this is
+// an ADDITIVE guard against the one explicit negative signal, not a new required field.
 // Because the guard lives HERE in the shared engine, every row gets it for free; no
 // per-secret guard to forget (mirrors the CTL-1617 §8 mandate this registry consumes). When
 // genuinely cloud, resolution short-circuits to a pure env-alias read of envNames — NO FILE
@@ -873,7 +885,8 @@ export function resolveSecret(id, { env = process.env, deploymentMode, cwd = pro
   const row = getSecretRow(id);
   if (!row) return { value: null, source: null, provider: null, rotation: null };
 
-  const useCloud = deploymentMode?.mode === "cloud" && deploymentMode?.inferred === false;
+  const useCloud =
+    deploymentMode?.mode === "cloud" && deploymentMode?.inferred === false && deploymentMode?.recognized !== false;
 
   if (useCloud) {
     if (row.bootstrapFor !== "cloud") {

--- a/plugins/dev/scripts/lib/secret-contract.test.mjs
+++ b/plugins/dev/scripts/lib/secret-contract.test.mjs
@@ -926,6 +926,38 @@ describe("resolveSecret — cloud guard (design §4)", () => {
     });
     expect(r).toMatchObject({ value: null, source: "none", envVar: "MY_PLATFORM_TOKEN" });
   });
+
+  // CTL-1616 PR6 (design §12 Q3 belt-and-suspenders extension): mode==="cloud" &&
+  // inferred===false && recognized===false cannot actually be produced by the real
+  // resolveDeploymentMode (classifyCandidate degrades an unrecognized explicit value's
+  // MODE to single-host before this ever sees "cloud") — so this exercises a
+  // hand-constructed deploymentMode object, proving the engine's OWN defense-in-depth
+  // guard, independent of whether any real caller can currently reach it.
+  test("recognized:false does NOT activate the cloud branch even with mode:cloud and inferred:false — the file chain still runs", () => {
+    const dir = fixtureDir();
+    writeFile(dir, "github-token", "file-value");
+    const r = resolveSecret("github-token", {
+      env: { CATALYST_CONFIG_DIR: dir, GH_TOKEN: "env-value-should-not-win" },
+      deploymentMode: { mode: "cloud", inferred: false, recognized: false },
+    });
+    expect(r).toMatchObject({ value: "file-value", source: "shared-file" });
+  });
+  test("recognized:undefined (omitted) still activates cloud — the guard is ADDITIVE, not a new required field (backward compat with every pre-existing caller)", () => {
+    const r = resolveSecret("github-token", {
+      env: { GH_TOKEN: "should-not-be-returned" },
+      deploymentMode: { mode: "cloud", inferred: false },
+    });
+    // Same bootstrap short-circuit result as the "recognized omitted" tests above —
+    // proves cloud activated (no cloud-token bootstrap ⇒ short-circuit to null/null).
+    expect(r).toEqual({ value: null, source: null, provider: "bare-file", rotation: expect.any(Object) });
+  });
+  test("recognized:true (explicit) activates cloud exactly like recognized omitted", () => {
+    const r = resolveSecret("github-token", {
+      env: { GH_TOKEN: "cloud-injected", CATALYST_CLOUD_TOKEN: "boot" },
+      deploymentMode: { mode: "cloud", inferred: false, recognized: true },
+    });
+    expect(r).toMatchObject({ value: "cloud-injected", provider: "bare-file" });
+  });
 });
 
 // ─── Registry validation (design §6) ─────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

CTL-1616 migration plan **PR6** — the final code slice.

- **Cloud guard hardened** (design §4 + §12 Q3): both engines refuse the cloud branch on `recognized===false` in addition to `inferred===true` — additive (`!== false`), threaded through `armSecret`, parity harness gains a `recognized` dimension.
- **Doctor §7 escalation**: new `cloud-token-bootstrap` check — a declared-cloud node whose platform token doesn't resolve gets the one FAIL doctor cannot route around (naming the resolved env-var + the §4 short-circuit consequence). Non-cloud modes contribute **zero** new checks; live bare-Node doctor A/B on a single-host laptop byte-identical pre/post; fail-open on a throwing resolver.
- **Layer-2 stragglers (shadow-diffed as §8 mandates)**: `config.mjs` + `node-class.mjs` `getLayer2ConfigPath` dual-read legacy vs canonical `resolveLayer2Path` — agreement silent, disagreement logs one deduped warning naming both paths and the canonical path wins.
- **§9 invariants**: synthetic declared-cloud run FAILs and provably never consults the file chain (mutation-covered at the engine layer); the single-host/cluster never-skips assertions extended with the recognized-guard cases.

## Noted follow-ups (verifier advisories, out of §8-PR6 scope)

- `lib/plugin-dirs.sh`'s machine-config path is missing the `CATALYST_LAYER2_CONFIG_FILE` rung — the design doc's own "already matches" claim was inexact (inherited inaccuracy, not new drift).
- Remaining hand-rolled legacy-chain mirrors (host-identity, deployment-mode lib, orch-monitor configs, broker GLOBAL_CONFIG_PATH, join/install scripts) diverge on XDG/MACHINE_CONFIG hosts until the cutover sweep — consistent with the design's scoping; candidates for the PR6-follow-up cutover.

## Verification

Fable adversarial verify: **PASS, zero blocking.** All four `{inferred, recognized}` combinations probed cross-engine; escalation-gate and file-chain mutations each killed by specific tests; MACHINE_CONFIG/XDG shadow-diff fixtures warn + canonical wins; every `getLayer2ConfigPath` caller classified.

Suites: doctor 353/0 · JS engine 114/0 · bash engine 115/0 · parity 179/0 · cloud-token 34/0 · node-class 51/0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WHfJt1JhsdArSUyxwZZzkN