### PR TITLE
fix(dev): CTL-1616 PR6 follow-up — observe-only Layer-2 shadow + doctor coherence (#2929 Codex x4)

### DIFF
--- a/plugins/dev/scripts/execution-core/config.mjs
+++ b/plugins/dev/scripts/execution-core/config.mjs
@@ -238,15 +238,22 @@ export function getLayer2ConfigPath() {
   if (legacyPath !== canonicalPath) {
     const msg =
       `layer2 config path shadow-diff (CTL-1616 PR6): legacy chain resolved "${legacyPath}" ` +
-      `but the canonical chain resolved "${canonicalPath}" — using "${canonicalPath}" (legacy ` +
-      `ignores CATALYST_MACHINE_CONFIG/XDG_CONFIG_HOME; set CATALYST_LAYER2_CONFIG_FILE to pin ` +
-      `explicitly if this is unexpected)`;
+      `but the canonical chain resolved "${canonicalPath}" — KEEPING the legacy path (this ` +
+      `function feeds WRITE destinations — cluster-sync secret materialization, cluster tune — ` +
+      `while catalyst-secret-env.sh and the scheduler's per-tick reload still read the legacy ` +
+      `chain; switching writes before the reader sweep would strand rotations on ` +
+      `MACHINE_CONFIG/XDG hosts. Set CATALYST_LAYER2_CONFIG_FILE to pin explicitly; the ` +
+      `canonical cutover lands with the full reader/writer sweep)`;
     if (!_warnedLayer2PathDrift.has(msg)) {
       _warnedLayer2PathDrift.add(msg);
       log.warn(msg);
     }
   }
-  return canonicalPath;
+  // #2929 post-merge Codex P1: LEGACY wins until every reader/writer of this
+  // path is swept onto the canonical chain in one PR — a split (canonical
+  // writes, legacy reads) makes a rotation write fresh credentials where the
+  // next daemon launch never looks, exporting the stale/revoked value forever.
+  return legacyPath;
 }
 
 // The repo root that owns the committed cluster roster (.catalyst/hosts.json).

--- a/plugins/dev/scripts/execution-core/config.test.mjs
+++ b/plugins/dev/scripts/execution-core/config.test.mjs
@@ -343,20 +343,20 @@ describe("getLayer2ConfigPath — CTL-1616 PR6 dual-read shadow-diff", () => {
     expect(warnCalls.length).toBe(0);
   });
 
-  test("differ case: CATALYST_MACHINE_CONFIG set (legacy ignores it) — warns once, the NEW (canonical) path wins", () => {
+  test("differ case: CATALYST_MACHINE_CONFIG set (legacy ignores it) — warns once, the LEGACY path wins (observe-only until the reader sweep)", () => {
     process.env.CATALYST_MACHINE_CONFIG = "/machine/pr6-machine-config-test/config.json";
     const result = getLayer2ConfigPath();
-    expect(result).toBe("/machine/pr6-machine-config-test/config.json");
+    expect(result).toBe(resolve(homedir(), ".config", "catalyst", "config.json"));
     expect(warnCalls.length).toBe(1);
     const msg = warnCalls[0][0];
     expect(msg).toContain(resolve(homedir(), ".config", "catalyst", "config.json"));
     expect(msg).toContain("/machine/pr6-machine-config-test/config.json");
   });
 
-  test("differ case: XDG_CONFIG_HOME set (legacy ignores it) — warns once, the NEW (canonical) path wins", () => {
+  test("differ case: XDG_CONFIG_HOME set (legacy ignores it) — warns once, the LEGACY path wins (observe-only until the reader sweep)", () => {
     process.env.XDG_CONFIG_HOME = "/xdg/pr6-xdg-test";
     const result = getLayer2ConfigPath();
-    expect(result).toBe(join("/xdg/pr6-xdg-test", "catalyst", "config.json"));
+    expect(result).toBe(resolve(homedir(), ".config", "catalyst", "config.json"));
     expect(warnCalls.length).toBe(1);
   });
 

--- a/plugins/dev/scripts/execution-core/doctor.mjs
+++ b/plugins/dev/scripts/execution-core/doctor.mjs
@@ -2567,6 +2567,12 @@ export function checkAgentBrowser(deps = {}) {
 // function's original ADVISORY/never-FAIL contract is UNCHANGED for single-host,
 // cluster, and inferred nodes — i.e. every live host today. All reads are injectable +
 // fail-open.
+// _isDeclaredCloud — the one gate PR6's escalation and the local-only wording
+// share: a genuinely DECLARED cloud mode (recognized, not inferred).
+function _isDeclaredCloud(dm) {
+  return Boolean(dm && dm.mode === "cloud" && dm.inferred === false && dm.recognized !== false);
+}
+
 export function checkCloudTokenEnv(deps = {}) {
   const {
     configDir = process.env.CATALYST_CONFIG_DIR || resolve(homedir(), ".config", "catalyst"),
@@ -2594,8 +2600,15 @@ export function checkCloudTokenEnv(deps = {}) {
     // resolver fails OPEN to today's INFO-only behavior (the escalation below
     // is gated on this being genuinely {mode:"cloud", inferred:false, ...} —
     // undefined never satisfies that gate).
-    deploymentMode = resolveDeploymentModeForShadow(),
+    // NOTE (#2929 post-merge Codex P2): the default must apply only when the
+    // caller OMITTED the key — a destructure default also fires on an
+    // explicitly-supplied `deploymentMode: undefined`, silently re-resolving
+    // the HOST's mode and making injected-state tests host-dependent. Hence
+    // the `in`-guarded assignment below instead of a destructure default.
+    deploymentMode: _deploymentModeDep,
   } = deps;
+  const deploymentMode =
+    "deploymentMode" in deps ? _deploymentModeDep : resolveDeploymentModeForShadow();
   const checks = [];
 
   // CTL-1616 PR6 §7 FAIL ESCALATION (design §5): "the one FAIL doctor cannot
@@ -2624,7 +2637,7 @@ export function checkCloudTokenEnv(deps = {}) {
   // correctly on inferred alone.
   const cloudBootstrapEscalationChecks = [];
   const dm = deploymentMode;
-  if (dm && dm.mode === "cloud" && dm.inferred === false && dm.recognized !== false) {
+  if (_isDeclaredCloud(dm)) {
     const bootstrapResolution = safeResolveSecretContract(resolveSecretContract, "cloud-token", {
       env: process.env,
       deploymentMode: dm,
@@ -2731,7 +2744,9 @@ export function checkCloudTokenEnv(deps = {}) {
       mkCheck(
         "cloud-token",
         STATUS.INFO,
-        "no cluster cloud token decrypted — node is local-only (expected unless opted into catalyst-cloud)",
+        _isDeclaredCloud(deploymentMode)
+          ? "no cluster-sync cloud token file — expected on a declared-cloud node (the platform environment is the token source; see cloud-token-bootstrap)"
+          : "no cluster cloud token decrypted — node is local-only (expected unless opted into catalyst-cloud)",
       ),
     );
     checks.push(...cloudShadowChecks, ...cloudBootstrapEscalationChecks);

--- a/plugins/dev/scripts/execution-core/doctor.test.mjs
+++ b/plugins/dev/scripts/execution-core/doctor.test.mjs
@@ -1851,6 +1851,10 @@ describe("checkCloudTokenEnv", () => {
   });
 
   it("never returns a FAIL status (the token is optional)", () => {
+    // Hermeticity (#2929 follow-up): pin an inferred mode so an ambient
+    // CATALYST_DEPLOYMENT_MODE=cloud on the host cannot arm the PR6
+    // escalation inside this pre-PR6 invariant test.
+    const pinnedMode = { mode: "single-host", source: "default", inferred: true, recognized: false };
     // Every branch must be at most WARN — absence/drift must not block activation.
     const branches = [
       reader({}),
@@ -1858,7 +1862,7 @@ describe("checkCloudTokenEnv", () => {
       reader({ cloud: clusterCloud("new"), env: exportLine("old") + "\n" }),
     ];
     for (const readFile of branches) {
-      const checks = checkCloudTokenEnv({ configDir: CFG, zshenvPath: ZSH, readFile, resolveSecretContract: agreeingCloudTokenContract });
+      const checks = checkCloudTokenEnv({ configDir: CFG, zshenvPath: ZSH, readFile, resolveSecretContract: agreeingCloudTokenContract, deploymentMode: pinnedMode });
       for (const c of checks) expect(c.status).not.toBe(STATUS.FAIL);
     }
   });
@@ -1971,6 +1975,31 @@ describe("checkCloudTokenEnv", () => {
         expect(checks.find((c) => c.name === "cloud-token-bootstrap")).toBeUndefined();
         expect(checks.find((c) => c.name === "cloud-token-bootstrap-secret-contract-shadow")).toBeUndefined();
       }
+    });
+
+    it("declared cloud + platform token + NO cluster-sync file: coherent report — bootstrap PASS and the primary INFO names the platform env as the source (#2929 P2)", () => {
+      const checks = checkCloudTokenEnv({
+        configDir: CFG,
+        zshenvPath: ZSH,
+        readFile: reader({}),
+        deploymentMode: { mode: "cloud", source: "layer1", inferred: false, recognized: true },
+        // Dual-shape fixture: name fields satisfy the name-shadow (agrees with
+        // the hardcoded literal), value satisfies the bootstrap resolution.
+        resolveSecretContract: () => ({
+          value: "platform-injected",
+          source: "platform-env",
+          provider: "platform-env",
+          envVar: "CATALYST_CLOUD_TOKEN",
+          envVarSource: "default",
+        }),
+      });
+      const bootstrap = checks.find((c) => c.name === "cloud-token-bootstrap");
+      expect(bootstrap).toBeDefined();
+      expect(bootstrap.status).toBe(STATUS.PASS);
+      const primary = checks.find((c) => c.name === "cloud-token");
+      expect(primary.status).toBe(STATUS.INFO);
+      expect(primary.detail).toContain("expected on a declared-cloud node");
+      expect(primary.detail).not.toContain("local-only");
     });
 
     it("fails OPEN to today's INFO-only behavior when the injected deploymentMode itself is undefined/throws (never crashes checkCloudTokenEnv)", () => {
@@ -2705,13 +2734,22 @@ describe("secret-contract cutover — checkPeerUniqueness/checkBotCredentials (C
     it("LINEAR_API_KEY-only fixture (real resolveSecret default): honors the alias, proceeds past the token gate", async () => {
       const savedToken = process.env.LINEAR_API_TOKEN;
       const savedKey = process.env.LINEAR_API_KEY;
+      const savedMode = process.env.CATALYST_DEPLOYMENT_MODE;
       try {
         delete process.env.LINEAR_API_TOKEN;
+        // Hermeticity (#2929 follow-up): an ambient declared-cloud host mode
+        // would arm the engine's cloud guard through the REAL resolver and
+        // short-circuit linear-api-token — this test is about the alias.
+        delete process.env.CATALYST_DEPLOYMENT_MODE;
         process.env.LINEAR_API_KEY = "lin_api_fromkey";
         const checks = await checkPeerUniqueness(base);
         expect(checks).toHaveLength(1);
         expect(checks[0].detail).toContain("empty"); // past the token gate
       } finally {
+        if (savedMode === undefined) delete process.env.CATALYST_DEPLOYMENT_MODE;
+        else process.env.CATALYST_DEPLOYMENT_MODE = savedMode;
+        if (savedMode === undefined) delete process.env.CATALYST_DEPLOYMENT_MODE;
+        else process.env.CATALYST_DEPLOYMENT_MODE = savedMode;
         if (savedToken === undefined) delete process.env.LINEAR_API_TOKEN;
         else process.env.LINEAR_API_TOKEN = savedToken;
         if (savedKey === undefined) delete process.env.LINEAR_API_KEY;
@@ -2750,8 +2788,13 @@ describe("secret-contract cutover — checkPeerUniqueness/checkBotCredentials (C
     it("LINEAR_API_KEY-only fixture (real resolveSecret default): honors the alias, reaches the connectivity probe", async () => {
       const savedToken = process.env.LINEAR_API_TOKEN;
       const savedKey = process.env.LINEAR_API_KEY;
+      const savedMode = process.env.CATALYST_DEPLOYMENT_MODE;
       try {
         delete process.env.LINEAR_API_TOKEN;
+        // Hermeticity (#2929 follow-up): an ambient declared-cloud host mode
+        // would arm the engine's cloud guard through the REAL resolver and
+        // short-circuit linear-api-token — this test is about the alias.
+        delete process.env.CATALYST_DEPLOYMENT_MODE;
         process.env.LINEAR_API_KEY = "lin_api_fromkey";
         const checks = await checkBotCredentials({
           readLinearBotUserIds: () => new Set(["bot-user-123"]),

--- a/plugins/dev/scripts/execution-core/lib/node-class-layer2-path.test.mjs
+++ b/plugins/dev/scripts/execution-core/lib/node-class-layer2-path.test.mjs
@@ -48,20 +48,20 @@ describe("node-class.mjs getLayer2ConfigPath — CTL-1616 PR6 dual-read shadow-d
     expect(warnCalls.length).toBe(0);
   });
 
-  test("differ case: CATALYST_MACHINE_CONFIG set (legacy ignores it) — warns once, the NEW (canonical) path wins", () => {
+  test("differ case: CATALYST_MACHINE_CONFIG set (legacy ignores it) — warns once, the LEGACY path wins (observe-only until the reader sweep)", () => {
     process.env.CATALYST_MACHINE_CONFIG = "/machine/nc-pr6-machine-config-test/config.json";
     const result = getLayer2ConfigPath();
-    expect(result).toBe("/machine/nc-pr6-machine-config-test/config.json");
+    expect(result).toBe(resolve(homedir(), ".config", "catalyst", "config.json"));
     expect(warnCalls.length).toBe(1);
     const msg = warnCalls[0][0];
     expect(msg).toContain(resolve(homedir(), ".config", "catalyst", "config.json"));
     expect(msg).toContain("/machine/nc-pr6-machine-config-test/config.json");
   });
 
-  test("differ case: XDG_CONFIG_HOME set (legacy ignores it) — warns once, the NEW (canonical) path wins", () => {
+  test("differ case: XDG_CONFIG_HOME set (legacy ignores it) — warns once, the LEGACY path wins (observe-only until the reader sweep)", () => {
     process.env.XDG_CONFIG_HOME = "/xdg/nc-pr6-xdg-test";
     const result = getLayer2ConfigPath();
-    expect(result).toBe(join("/xdg/nc-pr6-xdg-test", "catalyst", "config.json"));
+    expect(result).toBe(resolve(homedir(), ".config", "catalyst", "config.json"));
     expect(warnCalls.length).toBe(1);
   });
 

--- a/plugins/dev/scripts/execution-core/lib/node-class.mjs
+++ b/plugins/dev/scripts/execution-core/lib/node-class.mjs
@@ -45,15 +45,17 @@ export function getLayer2ConfigPath() {
   if (legacyPath !== canonicalPath) {
     const msg =
       `layer2 config path shadow-diff (CTL-1616 PR6): legacy chain resolved "${legacyPath}" ` +
-      `but the canonical chain resolved "${canonicalPath}" — using "${canonicalPath}" (legacy ` +
-      `ignores CATALYST_MACHINE_CONFIG/XDG_CONFIG_HOME; set CATALYST_LAYER2_CONFIG_FILE to pin ` +
-      `explicitly if this is unexpected)`;
+      `but the canonical chain resolved "${canonicalPath}" — KEEPING the legacy path until the ` +
+      `full reader/writer sweep (set CATALYST_LAYER2_CONFIG_FILE to pin explicitly)`;
     if (!_warnedLayer2PathDrift.has(msg)) {
       _warnedLayer2PathDrift.add(msg);
       console.warn(`[node-class] ${msg}`);
     }
   }
-  return canonicalPath;
+  // #2929 post-merge Codex P1: legacy wins (observe-only shadow) — this must
+  // stay path-consistent with config.mjs getLayer2ConfigPath and every
+  // un-swept legacy reader; the canonical cutover lands as one sweep.
+  return legacyPath;
 }
 
 // readLayer2NodeClass — the raw catalyst.node.class value from the Layer-2 file EXACTLY as


### PR DESCRIPTION
## Summary

All four post-merge #2929 Codex findings verified and fixed:

| Finding | Fix |
|---|---|
| **P1 — rotation-stranding reader/writer split**: canonical-wins moved cluster-sync's decrypted-secret write destination while `catalyst-secret-env.sh` still reads the legacy home path | `getLayer2ConfigPath` (config.mjs + node-class.mjs) is now **observe-only**: legacy wins, divergence logs one deduped warning naming both paths. The canonical cutover lands as one reader/writer sweep. |
| **P2 — `cluster tune` writes where the scheduler never reads** | Same fix — writes stay on the path every current reader uses. |
| **P2 — explicitly-`undefined` deploymentMode re-resolved the host's mode** | `in`-guarded assignment; the fail-open test is host-independent (suite green under ambient `CATALYST_DEPLOYMENT_MODE=cloud`). |
| **P2 — declared-cloud node reported "local-only"** | Coherent wording: the primary INFO names the platform env as the source on a declared-cloud node; gate + wording share one `_isDeclaredCloud` helper. |

Also hermeticized the PR3 real-resolver alias tests and the never-FAIL invariant against ambient host modes.

Suites: doctor 354/0 (normal + cloud-host probe) · node-class 5/0 · config 180/3 (documented pre-existing environmental baseline).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WHfJt1JhsdArSUyxwZZzkN