### PR TITLE
fix(dev): CTL-1616 declare the split-brain Layer-2 layout unsupported + finish the observe-only story

### DIFF
--- a/plugins/dev/scripts/execution-core/config.mjs
+++ b/plugins/dev/scripts/execution-core/config.mjs
@@ -217,18 +217,19 @@ export function getEventLogPath() {
 // CATALYST_MACHINE_CONFIG and XDG_CONFIG_HOME. Each host's Layer-2 file differs, so this is
 // the right home for a per-host name.
 //
-// CTL-1616 PR6 (design §8/§9): DUAL-READ shadow-diff for one release before this delegates
-// fully to the registry's canonical resolveLayer2Path (lib/secret-contract.mjs) chain —
-// CATALYST_LAYER2_CONFIG_FILE > CATALYST_MACHINE_CONFIG > XDG_CONFIG_HOME > ~/.config/catalyst.
-// The two chains AGREE whenever CATALYST_LAYER2_CONFIG_FILE is set (checked first by both) or
-// neither CATALYST_MACHINE_CONFIG nor XDG_CONFIG_HOME is set (both fall to the same homedir
-// default) — the common case on every host today, hence silent. They DISAGREE on a host that
-// sets CATALYST_MACHINE_CONFIG or XDG_CONFIG_HOME without also setting
-// CATALYST_LAYER2_CONFIG_FILE — a DOCUMENTED BEHAVIOR CHANGE (design risk 8), logged loudly
-// (once per unique divergence message, mirroring getNodeClass's _warnedNodeClass dedup below)
-// so the operator sees it before the next PR removes the legacy chain entirely. The NEW
-// (canonical) path is always what this function returns on a disagreement — matching the
-// operator-attention-flag direction #2927 already established for this class of shadow-diff.
+// CTL-1616 PR6 (+#2929/#2930 follow-ups): OBSERVE-ONLY dual-read. This function RETURNS THE
+// LEGACY chain (CATALYST_LAYER2_CONFIG_FILE || homedir default) and only WARNS when the
+// registry's canonical resolveLayer2Path chain (… > CATALYST_MACHINE_CONFIG > XDG_CONFIG_HOME
+// > homedir) would disagree. It must NOT return the canonical path yet: this resolver feeds
+// WRITE destinations (cluster-sync secret materialization, cluster tune) whose READERS are
+// split across BOTH chains — catalyst-secret-env.sh and the scheduler's per-tick reload read
+// legacy, while the registry-based consumers folded in PR3-PR5 (the mint chain, cloud-token
+// name) read canonical. On a divergent (MACHINE_CONFIG/XDG-only) host there is NO consistent
+// half-migrated answer — doctor's layer2-path-divergence check FAILs that configuration as
+// unsupported-until-the-sweep, and CATALYST_LAYER2_CONFIG_FILE (tier 1 of BOTH chains) is the
+// operator pin that restores one file for everyone. The canonical cutover must land as ONE
+// sweep of every reader and writer — do not sequence it from an assumption that reads already
+// use the canonical path (they are split; see #2930's review).
 const _warnedLayer2PathDrift = new Set();
 export function getLayer2ConfigPath() {
   const legacyPath =

--- a/plugins/dev/scripts/execution-core/doctor.mjs
+++ b/plugins/dev/scripts/execution-core/doctor.mjs
@@ -72,7 +72,7 @@ import { readPeerHeartbeats } from "./cluster-heartbeat.mjs";
 // config.mjs, so doctor stays safe under bare Node. SHADOW ONLY in this PR: the
 // contract is consulted and compared, never used to decide a grade (see
 // checkSecretContract + buildContractShadowCheck below).
-import { resolveSecret } from "../lib/secret-contract.mjs";
+import { resolveSecret, resolveLayer2Path } from "../lib/secret-contract.mjs";
 // CTL-1481: the canonical worker-ownership label names — imported (not
 // re-hardcoded) so the doctor can never drift from what the stamper writes.
 // From the zero-import names leaf, NOT worker-label.mjs: doctor runs under
@@ -2684,7 +2684,11 @@ export function checkCloudTokenEnv(deps = {}) {
   const cloudShadowChecks = [];
   const contractResolution = safeResolveSecretContract(resolveSecretContract, "cloud-token", {
     env: process.env,
-    deploymentMode: resolveDeploymentModeForShadow(),
+    // #2930 round-2 (Codex P2): reuse the SAME resolved deploymentMode the
+    // bootstrap gate and the local-only wording use — an independent
+    // re-resolve here made an explicitly-injected mode (incl. undefined)
+    // evaluate the shadow under the HOST's mode.
+    deploymentMode,
   });
   if (!contractResolution.ok) {
     cloudShadowChecks.push(shadowThrowCheck("cloud-token", "cloud-token", contractResolution.error));
@@ -3503,6 +3507,50 @@ export function checkNodeClass(deps = {}) {
 }
 
 // ─── CTL-1617: deployment-mode consistency grading ───────────────────────────
+
+// checkLayer2PathDivergence — CTL-1616 PR6 follow-up (#2930 round-2 Codex P1).
+// On a host that sets CATALYST_MACHINE_CONFIG or XDG_CONFIG_HOME without
+// CATALYST_LAYER2_CONFIG_FILE, the fleet's Layer-2 readers/writers are SPLIT:
+// legacy readers (catalyst-secret-env.sh, the scheduler's per-tick reload) and
+// the write destinations fed by getLayer2ConfigPath use the legacy home chain,
+// while the registry-based consumers folded in PR3-PR5 (the OAuth mint chain,
+// cloud-token name) use the canonical resolveLayer2Path chain. A credential
+// rotation on such a host writes fresh material where half the readers never
+// look — so the configuration is UNSUPPORTED until the canonical cutover sweep,
+// and this check FAILs it loudly with the real remedy:
+// CATALYST_LAYER2_CONFIG_FILE is tier 1 of BOTH chains, pinning every reader
+// and writer to one file. On every non-divergent host (all live fleet hosts)
+// this check is a silent PASS-less no-op (zero rows).
+export function checkLayer2PathDivergence(deps = {}) {
+  const {
+    env = process.env,
+    legacyPathFn = () =>
+      env.CATALYST_LAYER2_CONFIG_FILE || resolve(homedir(), ".config", "catalyst", "config.json"),
+    canonicalPathFn = () => resolveLayer2Path(env),
+  } = deps;
+  let legacyPath;
+  let canonicalPath;
+  try {
+    legacyPath = legacyPathFn();
+    canonicalPath = canonicalPathFn();
+  } catch {
+    return []; // fail-open: a throwing resolver must not invent a divergence
+  }
+  if (legacyPath === canonicalPath) return [];
+  return [
+    mkCheck(
+      "layer2-path-divergence",
+      STATUS.FAIL,
+      `Layer-2 config path is SPLIT-BRAIN on this host: legacy chain resolves "${legacyPath}" ` +
+        `(read by catalyst-secret-env.sh + the scheduler reload; fed by cluster-sync writes) but ` +
+        `the registry's canonical chain resolves "${canonicalPath}" (read by the OAuth mint chain ` +
+        `and cloud-token name resolution) — a credential rotation would land where half the ` +
+        `readers never look. This CATALYST_MACHINE_CONFIG/XDG_CONFIG_HOME-divergent layout is ` +
+        `unsupported until the canonical reader/writer sweep; set CATALYST_LAYER2_CONFIG_FILE ` +
+        `(tier 1 of BOTH chains) to pin every reader and writer to one file`,
+    ),
+  ];
+}
 
 // checkDeploymentModeConsistency — grade catalyst.deployment.mode (CTL-1617
 // design §7, all four sub-checks). Every
@@ -4424,6 +4472,9 @@ export function checksForClass(nc, opts = {}) {
   // CTL-1523 convention); the strict install-profile escalation branch exists
   // in checkDeploymentModeConsistency but is not wired into any profile yet.
   const deploymentModeCheck = () => checkDeploymentModeConsistency({ resolveRoster });
+  // #2930 round-2: split-brain Layer-2 path layout is unsupported until the
+  // canonical sweep — zero rows on every non-divergent host.
+  const layer2PathDivergenceCheck = () => checkLayer2PathDivergence();
   // CTL-1616 PR2: secret-contract shadow pass — like deploymentModeCheck, a
   // fleet-topology-independent fact (does not consult resolveRoster), so it
   // runs for every class. SHADOW ONLY: every check it (and the injected
@@ -4488,6 +4539,7 @@ export function checksForClass(nc, opts = {}) {
     return [
       nodeClassCheck,
       deploymentModeCheck, // CTL-1617: fleet-topology fact, graded for every class
+      layer2PathDivergenceCheck, // CTL-1616 PR6 follow-up: split-brain Layer-2 layout FAILs until the sweep
       secretContractCheck, // CTL-1616 PR2: secret-contract shadow pass, INFO-only, graded for every class
       () => checkConnectivity({ seed, otel, fetch: _fetch }),
       () => checkSecretsHygiene(),
@@ -4521,6 +4573,7 @@ export function checksForClass(nc, opts = {}) {
     return [
       nodeClassCheck,
       deploymentModeCheck, // CTL-1617: fleet-topology fact, graded for every class
+      layer2PathDivergenceCheck, // CTL-1616 PR6 follow-up: split-brain Layer-2 layout FAILs until the sweep
       secretContractCheck, // CTL-1616 PR2: secret-contract shadow pass, INFO-only, graded for every class
       () => checkConnectivity({ seed, otel, fetch: _fetch }),
       () => checkHrwPartition(), // would-own count (visibility)
@@ -4546,6 +4599,7 @@ export function checksForClass(nc, opts = {}) {
   return [
     nodeClassCheck,
     deploymentModeCheck, // CTL-1617: fleet-topology fact, graded for every class
+      layer2PathDivergenceCheck, // CTL-1616 PR6 follow-up: split-brain Layer-2 layout FAILs until the sweep
     secretContractCheck, // CTL-1616 PR2: secret-contract shadow pass, INFO-only, graded for every class
     () => checkHostIdentity(),
     () => checkHrwPartition(),

--- a/plugins/dev/scripts/execution-core/doctor.test.mjs
+++ b/plugins/dev/scripts/execution-core/doctor.test.mjs
@@ -33,6 +33,7 @@ import {
   checkNodeClass,
   checkDeploymentModeConsistency,
   checkSecretContract,
+  checkLayer2PathDivergence,
   checkReadReplicaReachable,
   checkMonitorProductionBuild,
   checkWontOwnWork,
@@ -2498,6 +2499,36 @@ describe("secret-contract shadow — deployment-mode threading (#2916 Codex P2)"
   });
 });
 
+describe("checkLayer2PathDivergence (#2930 round-2)", () => {
+  it("returns zero rows when the chains agree (every live host)", () => {
+    expect(checkLayer2PathDivergence({ env: {} })).toHaveLength(0);
+    expect(
+      checkLayer2PathDivergence({ env: { CATALYST_LAYER2_CONFIG_FILE: "/pin/config.json" } }),
+    ).toHaveLength(0);
+  });
+
+  it("FAILs a MACHINE_CONFIG-divergent host, naming both paths and the CATALYST_LAYER2_CONFIG_FILE pin", () => {
+    const checks = checkLayer2PathDivergence({
+      env: { CATALYST_MACHINE_CONFIG: "/machine/split-test/config.json" },
+    });
+    expect(checks).toHaveLength(1);
+    expect(checks[0].status).toBe(STATUS.FAIL);
+    expect(checks[0].detail).toContain("/machine/split-test/config.json");
+    expect(checks[0].detail).toContain("CATALYST_LAYER2_CONFIG_FILE");
+  });
+
+  it("fails OPEN (zero rows) when a resolver throws", () => {
+    expect(
+      checkLayer2PathDivergence({
+        env: {},
+        canonicalPathFn: () => {
+          throw new Error("boom");
+        },
+      }),
+    ).toHaveLength(0);
+  });
+});
+
 describe("checkSecretContract (CTL-1616 PR2)", () => {
   it("emits one INFO observation per shadow-covered secret id (linear-api-token, groq-api-key)", () => {
     const checks = checkSecretContract({
@@ -2803,6 +2834,8 @@ describe("secret-contract cutover — checkPeerUniqueness/checkBotCredentials (C
         const connectivity = checks.find((c) => c.name === "linear-connectivity");
         expect(connectivity.status).toBe(STATUS.PASS);
       } finally {
+        if (savedMode === undefined) delete process.env.CATALYST_DEPLOYMENT_MODE;
+        else process.env.CATALYST_DEPLOYMENT_MODE = savedMode;
         if (savedToken === undefined) delete process.env.LINEAR_API_TOKEN;
         else process.env.LINEAR_API_TOKEN = savedToken;
         if (savedKey === undefined) delete process.env.LINEAR_API_KEY;

--- a/plugins/dev/scripts/execution-core/lib/node-class.mjs
+++ b/plugins/dev/scripts/execution-core/lib/node-class.mjs
@@ -32,12 +32,12 @@ const NODE_CLASS_MOST_RESTRICTIVE = "monitor";
 // ~/.config/catalyst/config.json, duplicated here to keep this a leaf (same pattern
 // host-identity.mjs uses for layer2HostName) and mirroring config.mjs's OWN legacy chain.
 //
-// CTL-1616 PR6 (design §8/§9): DUAL-READ shadow-diff for one release, delegating the
-// RETURNED path to the registry's canonical resolveLayer2Path chain (CATALYST_LAYER2_CONFIG_FILE
-// > CATALYST_MACHINE_CONFIG > XDG_CONFIG_HOME > ~/.config/catalyst) — same dual-read shape as
-// execution-core/config.mjs's getLayer2ConfigPath, which this file mirrors. Exported (unlike
-// before) so tests can exercise the shadow-diff directly. No `log` import here (zero-import
-// leaf) — uses console.warn, same as lib/deployment-mode.mjs's getDeploymentMode dedup.
+// CTL-1616 PR6 (+#2929/#2930): OBSERVE-ONLY dual-read — RETURNS THE LEGACY chain and only
+// WARNS when the registry's canonical resolveLayer2Path chain would disagree, staying
+// path-consistent with config.mjs's getLayer2ConfigPath and every un-swept legacy reader
+// (see that function's header for the reader/writer-split rationale; the canonical cutover
+// lands as ONE sweep). Exported so tests can exercise the shadow-diff directly. No `log`
+// import here (zero-import leaf) — uses console.warn, same as lib/deployment-mode.mjs.
 const _warnedLayer2PathDrift = new Set();
 export function getLayer2ConfigPath() {
   const legacyPath = process.env.CATALYST_LAYER2_CONFIG_FILE || resolve(homedir(), ".config", "catalyst", "config.json");


### PR DESCRIPTION
## Summary

All four round-2 #2930 Codex findings fixed:

| Finding | Fix |
|---|---|
| **P1 — canonical readers starve under legacy-wins** (mint chain reads canonical since PR4; cluster-sync writes legacy) | The truth is the split exists in BOTH directions on a MACHINE_CONFIG/XDG-divergent host — no half-migrated interim is consistent. New doctor check **`layer2-path-divergence`** FAILs that layout as unsupported until the canonical sweep, naming both paths and the real remedy: `CATALYST_LAYER2_CONFIG_FILE` is tier 1 of **both** chains, pinning every reader and writer to one file. Zero rows on every non-divergent host. |
| **P1 — headers describe the opposite of the shipped behavior** | Both `getLayer2ConfigPath` headers rewritten for the observe-only reality, explicitly warning the future sweep author that reads are split, not canonical. |
| **P2 — shadow re-resolved the host's mode** | The cloud-token name-shadow reuses the same resolved `deploymentMode` as the bootstrap gate. |
| **P2 — missing env restore** | The second alias test restores `CATALYST_DEPLOYMENT_MODE` in `finally`. |

Suites: doctor 357/0 (normal + ambient-cloud probe); live bare-Node smoke emits zero divergence rows on this host.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WHfJt1JhsdArSUyxwZZzkN