### PR TITLE
docs(dev): CTL-1616 secret-contract registry schema + architecture subsection (PR7)

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -130,12 +130,93 @@ via Layer-2.
   reader's `mode` are unrelated concepts) and the orch-monitor smee tunnel gate (a declared-`cloud`
   node suppresses tunnel start; the replacement cloud-SDK event connection is **future work** — the
   smee→cloud cutover, ADR-0008 lineage — so `cloud` today means "no smee ingestion", not "cloud
-  ingestion wired"). **Planned consumer**: the CTL-1616 secret contract's provider-of-record
-  dispatch receives the full resolution object and never activates a cloud provider on
+  ingestion wired"). **Consumer**: the CTL-1616 secret contract's provider-of-record dispatch
+  (below) receives the full resolution object and never activates a cloud provider on
   `inferred:true`.
 - **Orthogonal axes, never merged**: deployment mode (fleet topology) × `catalyst.node.class`
   (per-machine role) × `orchestration.dispatchMode` (process substrate within a node).
 - Design + migration plan: `thoughts/shared/research/2026-08-02-ctl-1617-deployment-mode-design.md`.
+
+## Secret Contract (CTL-1616)
+
+The 2026-08-02 fleet 401 outage was four divergent hand-written copies of one secret-resolution
+chain. CTL-1616 generalizes CTL-1612's proven github-token/webhook-secret pair into **one
+registry, two engines**: `plugins/dev/scripts/lib/secret-contract.mjs` (a zero-import JS leaf —
+`node:fs`/`os`/`path` only, so `catalyst doctor`'s bare-Node runtime can import it without pulling
+in `execution-core/config.mjs`'s `bun:sqlite` graph) and its independently-maintained bash mirror
+`lib/catalyst-secret-contract.sh`, held honest by a cross-stack **three-way parity suite**
+(`__tests__/secret-contract-parity.test.sh`: bash and JS each checked against a
+computed-expected value, never merely against each other, plus row-id-set equality between the
+two registries). The schema — the 11 registered secrets, the 7 delivery types, the resolution
+result shape, the cloud guard, and the Layer-2 path chain — is documented in full in its canonical
+reference, `website/src/content/docs/reference/configuration.md`; this section covers only the
+architectural role.
+
+```mermaid
+flowchart LR
+  REG[SECRET_REGISTRY<br/>one frozen row set] --> JS[secret-contract.mjs<br/>zero-import engine]
+  REG -.mirrored.-> SH[catalyst-secret-contract.sh<br/>bash engine]
+  JS <-. three-way parity .-> SH
+  JS --> DOCTOR[catalyst doctor<br/>shadow + 1 live cutover]
+  JS --> LINEAR[9-file Linear-token read<br/>PR3]
+  JS --> MINT[Linear OAuth-mint trio<br/>PR4]
+  JS --> CLOUD[cloud-token name<br/>PR5]
+  SH --> HEALTH[health-responder.sh<br/>bash fallback, PR5]
+```
+
+**Bootstrap classes, one per deployment mode** — the one credential the contract can never itself
+deliver, since it is what unlocks (or stands in for) everything else the chain resolves:
+
+| Mode          | Bootstrap credential                          | Row              |
+| ------------- | ---------------------------------------------- | ----------------- |
+| `single-host` | none — every secret is operator-placed          | — (no row)         |
+| `cluster`     | the SOPS age private key (`~/.config/catalyst/age.key`, `SOPS_AGE_KEY_FILE`-overridable) | `age-key` (`local-only`, presence-checked, value never read) |
+| `cloud`       | `CATALYST_CLOUD_TOKEN` (name itself resolvable via a 3-tier ladder) | `cloud-token` (`platform-env`) |
+
+**Rotation classes** generalize `cluster-sync.mjs`'s "captured at process start" prose into
+structured per-row data: `boot-only` (a value change needs a restart), `re-armable`/`timer`
+(proactively re-checked on a recurring tick — `github-token`'s declared shape; its actual re-arm
+today still runs through the pre-existing CTL-1612 `rearmGithubTokenFromFile`, called every
+daemon cluster-sync tick in `execution-core/daemon.mjs`, not yet through this contract's own
+`registerRearmHook`/`armSecret` seam), and `re-armable`/`on-401`
+(reactively re-minted on an observed auth failure — the Linear OAuth-mint shape). `armSecret()`
+never throws and reports `{ armed, rotated, restartRequired }` — `restartRequired: true` is the
+literal mechanism the 2026-08-02 outage lacked: a `boot-only` row (or a `re-armable` row with no
+hook registered yet — the two degrade identically, by design, so a consumer that never wires the
+arm path can't look safer than one that structurally can't) reports it the moment its resolved
+value changes underneath a still-running daemon.
+
+**Consumers folded onto the contract so far**: the 9-file/12-site Linear-token read (`linear-query.mjs`,
+`cluster-heartbeat.mjs`, `cluster-claim.mjs`, `linear-estimation-method.mjs`,
+`linear-reconcile-cli.mjs`, three `orch-monitor/lib/linear-*` fallback readers, and
+`score-tickets.ts`); the Linear OAuth-mint trio (`linear-app-actor.sh`'s bash mint,
+`linear-remint.mjs`'s orchestrator-actor reminter — registered as the row's live rearm hook — and
+`linear-comment-post.sh`'s worker-actor chain, legacy tiers preserved verbatim); the cloud-token
+env-var **name** resolver (`config.mjs`'s `resolveNodeCloudTokenEnv` and `health-responder.sh`'s
+bash fallback both now delegate to the one `resolveCloudTokenName` implementation); and
+`catalyst doctor` itself, which consults the contract through `resolveSecret` directly rather
+than a parallel presence check — as a **shadow**
+comparison (INFO-only, never changes a grade) for most checks, with `checkPeerUniqueness` /
+`checkBotCredentials` / `checkWorkerLabels` cut over to the contract as their *live*
+`linear-api-token` answer, and one grade-changing addition: `checkCloudTokenEnv` now FAILs when the
+active deployment mode is declared `cloud` and the `cloud-token` bootstrap row doesn't resolve —
+the one FAIL doctor cannot route around. The GitHub-token/webhook-secret pair that motivated the
+contract (CTL-1612's `catalyst-secret-env.sh` / `github-auth-preflight.mjs`) has **not yet** been
+re-pointed onto the shared engine — both rows exist in the registry today for shadow comparison and
+future consumers, but the live CTL-1612 code path is still its own, pre-existing implementation.
+
+The same PR5 that unified the cloud-token name resolver did adjacent, unrelated cleanup on Groq's
+`GROQ_API_KEY` ladder (`dsl-cli.mjs` and `hud.tsx` joined `broker/config.mjs` on the shared
+`resolveApiKey`) — but that is `lib/api-key-health.mjs`'s pre-existing (CTL-343) resolver, not this
+contract: none of those three call sites import `secret-contract.mjs`, and the registry's own
+`groq-api-key` row has no consumer today besides `checkSecretContract`'s shadow-only observation.
+
+**Secret-env hygiene rule**: the bash engine's `_csc_set_result` exports the non-secret
+`CATALYST_SECRET_LAST_SOURCE`/`_PROVIDER` breadcrumbs for the calling shell's convenience but
+**never** exports the resolved value itself (`CATALYST_SECRET_LAST_VALUE` stays same-shell-only,
+with `export -n` reasserted on every call since bash's export attribute is sticky across
+reassignment) — a long-lived daemon shell must not leak a credential into every child process it
+launches.
 
 ## Agent Teams vs Subagents
 

--- a/website/src/content/docs/reference/configuration.md
+++ b/website/src/content/docs/reference/configuration.md
@@ -583,6 +583,186 @@ PR1 (this file) ships the resolver in isolation — nothing outside its own test
 into webhook ingestion gating, secret-provider selection, and `catalyst doctor`'s roster-consistency
 checks lands in later PRs of the CTL-1617 migration plan.
 
+## Secret contract registry (CTL-1616)
+
+Every secret Catalyst resolves — the GitHub token, the Linear API token, the OAuth-mint
+credentials, the cloud token, the Groq key, the cluster age-key — is a row in **one frozen
+registry**, `SECRET_REGISTRY` in `plugins/dev/scripts/lib/secret-contract.mjs`. It replaces what
+used to be independently hand-rolled resolution ladders per secret (the 2026-08-02 fleet 401
+outage was four divergent copies of one chain). Bash cannot import a JS leaf, so the registry has a
+second, independently-maintained encoding — `plugins/dev/scripts/lib/catalyst-secret-contract.sh` —
+kept honest by a cross-stack **three-way parity test**
+(`__tests__/secret-contract-parity.test.sh`): bash and JS must each match a computed-expected
+value, never merely match each other, and the two registries must enumerate identical row-id sets.
+Both files are zero-import leaves (`node:fs`/`node:os`/`node:path` only on the JS side) so
+`catalyst doctor`, which runs under bare Node, can import the engine without pulling in
+`execution-core/config.mjs`'s `bun:sqlite`-reaching module graph.
+
+### Registry rows
+
+A row is a data fact, not code — the ~7-case engine below is what walks it. Every row declares:
+
+| Field           | Meaning                                                                                                     |
+| --------------- | ------------------------------------------------------------------------------------------------------------- |
+| `id`            | Canonical identity; doubles as the SOPS bare-file basename for file-backed rows.                             |
+| `envNames`      | Env-var aliases, precedence order (empty for rows with no direct env alias).                                |
+| `delivery`      | One of the 7 delivery types below.                                                                           |
+| `configJsonPath`| Dotted path inside the resolved Layer-2 JSON, for `config-json`/`platform-env` rows; `null` otherwise.       |
+| `rotation`      | `{ class, trigger? }` — see Rotation below.                                                                  |
+| `bootstrapFor`  | `"cluster"` \| `"cloud"` \| `null` — the deployment mode this row bootstraps.                                |
+
+Rows with a more specific shape declare additional fields: `familyPrefix` (the one
+`bare-file-family` row), `defaultLocalPath` (the one `local-only` row, resolved relative to
+`HOME`), and — `linear-worker-actor` only — `credentialEnvPair` (an env-var pair checked ahead of
+every config-file tier) and `legacyConfigTiers` + `requiredObjectFields` (§ Linear worker-actor
+tiers below).
+
+The 11 seed rows:
+
+| id                          | delivery          | rotation                | bootstrapFor | notes                                                                 |
+| ---------------------------- | ----------------- | ------------------------ | ------------ | ---------------------------------------------------------------------- |
+| `github-token`                | `bare-file`        | `re-armable` / `timer`   | —            | aliases `GH_TOKEN`, `GITHUB_TOKEN`                                    |
+| `webhook-secret`               | `bare-file`        | `boot-only`              | —            | env alias `CATALYST_WEBHOOK_SECRET`                                   |
+| `linear-webhook-secret`        | `bare-file-family` | `boot-only`              | —            | `familyPrefix: "linear-webhook-secret-"`; a predicate, not a scalar   |
+| `claude-accounts.env`          | `env-file`         | `boot-only`              | —            | presence-only (a whole sourced env file, not one value)               |
+| `execution-core.env`           | `env-file`         | `boot-only`              | —            | same shape as `claude-accounts.env`                                   |
+| `linear-api-token`             | `env-alias`        | `re-armable` / `on-401`  | —            | aliases `LINEAR_API_TOKEN`, `LINEAR_API_KEY`                          |
+| `linear-orchestrator-actor`    | `config-json`      | `re-armable` / `on-401`  | —            | `catalyst.linear.bot.orchestrator` — kept separate from worker-actor  |
+| `linear-worker-actor`          | `config-json`      | `boot-only`              | —            | `catalyst.linear.bot.worker` + a legacy fallback chain (below)        |
+| `groq-api-key`                 | `config-json`      | `boot-only`              | —            | env alias `GROQ_API_KEY`, config path `groq.apiKey`                   |
+| `cloud-token`                  | `platform-env`     | `boot-only`              | `cloud`      | default env-var `CATALYST_CLOUD_TOKEN`; the NAME is itself resolvable |
+| `age-key`                      | `local-only`       | `n/a`                    | `cluster`    | presence-checked only, never value-read; default `~/.config/catalyst/age.key` |
+
+`linear-orchestrator-actor` and `linear-worker-actor` are deliberately separate rows — they mint
+identically and differ only in their config path, an easy-to-collapse-wrongly refactor the registry
+exists to prevent.
+
+### Delivery types
+
+The engine dispatches on exactly one of 7 delivery types — parity cost between the bash and JS
+implementations scales per type, not per row:
+
+| Delivery           | Resolution chain                                                                                                     |
+| ------------------- | ------------------------------------------------------------------------------------------------------------------- |
+| `bare-file`          | explicit `CATALYST_<ID>_FILE` override → `CATALYST_CONFIG_DIR` → the directory holding the resolved Layer-2 file → XDG dir → falls back to an inherited env alias if no file is found |
+| `bare-file-family`   | not a resolvable scalar — a membership predicate (`isSecretFamilyMember`) over an open-ended prefix family          |
+| `env-file`           | presence/non-empty check of a whole file at the same bare-file candidate paths (the file is *sourced*, not read for one value) |
+| `env-alias`          | first non-empty `envNames` entry, in order — no file search at all                                                  |
+| `config-json`        | env alias (if any) → the resolved Layer-2 JSON's `configJsonPath`                                                   |
+| `platform-env`       | the row's env-var **name** is itself resolved (env override → Layer-2 name override → default), then that variable's value is read |
+| `local-only`         | `statSync` presence check of a single path only — the value is never read                                           |
+
+### Resolution result
+
+`resolveSecret(id, { env, deploymentMode, cwd })` (JS) / `catalyst_resolve_secret <id>` (bash)
+never throws. It returns `{ value, source, provider, rotation, ...extras }` for a known id, or
+`{ value: null, source: null, provider: null, rotation: null }` for an unknown one. `provider` is
+the row's `delivery` — a logging breadcrumb only; callers never branch on it. `source` is one of
+`shared-file` | `operator-override` | `inherited` | `config-json` | `legacy-config-json` |
+`platform-env` | `present` | `absent` | `none` — with one exception: the one `bare-file-family`
+row (`linear-webhook-secret`) is a known id with no scalar value, so it resolves to
+`{ value: null, source: null, provider: "bare-file-family", rotation: {...} }` — `source: null`,
+not one of the strings above, while `provider`/`rotation` stay populated (unlike the unknown-id
+shape, where every field is `null`). The bash mirror echoes the same three fields
+pipe-joined (`value|source|provider`) and additionally exports non-secret
+`CATALYST_SECRET_LAST_SOURCE`/`_PROVIDER` breadcrumbs for the calling shell — but deliberately
+**never exports the resolved value** (`export -n` is reasserted on every call, since bash's export
+attribute is sticky across reassignment), so a long-lived daemon shell can't leak a credential into
+every child process it launches.
+
+### Cloud guard
+
+The cloud provider only ever activates when the full CTL-1617 deployment-mode object satisfies
+**all three**: `mode === "cloud"`, `inferred === false`, and `recognized !== false`. Because the
+guard lives once in the shared engine, every row gets it for free. When genuinely cloud, resolution
+short-circuits to a pure env-alias read of `envNames` — no file search, ever. Anything else
+(single-host, cluster, or an inferred/unrecognized cloud guess) runs the row's normal
+delivery-type chain unchanged.
+
+A second gate — the **bootstrap short-circuit** — applies only in genuine cloud mode: if the active
+mode's `bootstrapFor` row (`cloud-token`) fails to resolve, every *other* cloud-mode secret
+resolution returns `{ value: null, source: null, provider, rotation }` (that row's own `provider`
+and `rotation`, populated) without probing further, so a half-provisioned managed container fails
+loudly and coherently instead of limping through partial resolution. The
+bootstrap row itself is exempt from this check (it must resolve on its own terms).
+
+### Layer-2 path resolution
+
+The registry's canonical Layer-2 config path chain, used by every `config-json`/`platform-env` row
+and exported as `resolveLayer2Path(env)` (JS) / `catalyst_secret_resolve_layer2_path` (bash):
+
+```
+CATALYST_LAYER2_CONFIG_FILE > CATALYST_MACHINE_CONFIG > $XDG_CONFIG_HOME/catalyst/config.json > ~/.config/catalyst/config.json
+```
+
+This is a distinct chain from `lib/deployment-mode.mjs`'s own `resolveLayer2Path`, which
+deliberately mirrors `execution-core/config.mjs`'s legacy homedir-only behavior — the two names
+resolve different things on purpose. `execution-core/config.mjs`'s `getLayer2ConfigPath()` and
+`execution-core/lib/node-class.mjs`'s own copy now delegate to this canonical chain, dual-read
+against their legacy homedir-only chain for one release: the two only disagree on a host that sets
+`CATALYST_MACHINE_CONFIG` or `XDG_CONFIG_HOME` without also setting `CATALYST_LAYER2_CONFIG_FILE`,
+in which case the canonical (new) path wins and a one-time-per-message `WARN` is logged.
+
+### Rotation
+
+Every row declares a rotation class:
+
+| Class                   | Meaning                                                                                          |
+| ------------------------ | ------------------------------------------------------------------------------------------------- |
+| `boot-only`              | Captured once (at daemon boot, or per-call for a config-json mint) — a value change requires a restart to take effect. |
+| `re-armable` / `timer`   | Proactively re-checked on a recurring tick — the row's declared shape (`github-token`). Its actual re-arm today still runs through the pre-existing CTL-1612 `rearmGithubTokenFromFile` (called every daemon cluster-sync tick in `execution-core/daemon.mjs`), not through this contract's own `registerRearmHook`/`armSecret` seam — see below, `github-token` remains hookless. |
+| `re-armable` / `on-401`  | Reactively re-minted on an observed auth failure, not a timer (the Linear OAuth-mint shape).      |
+| `n/a`                    | The row's value is never fetched at all (only `age-key` — rotation isn't a question the contract can answer for a presence-only row). |
+
+`armSecret(id, { env, deploymentMode })` never throws and returns `{ armed, rotated,
+restartRequired }`. `restartRequired` is the literal signal the 2026-08-02 outage lacked: it is
+`true` exactly when a `boot-only` row's resolved value has changed since the last observation.
+`registerRearmHook(id, fn)` attaches an in-process rearm implementation to a `re-armable` row — it
+refuses (returns `false`, never throws) against a `boot-only`/`n/a` row, an unknown id, or a
+non-function, so a hookless row can never silently claim "no restart needed". A `re-armable` row
+with **no** hook registered degrades to exactly the same `boot-only`-shaped behavior (resolve
+fresh, diff against the last-observed value, report `restartRequired` on change) — the capability
+ceiling is honest either way. As shipped, `linear-orchestrator-actor` has a real hook (registered
+by `execution-core/linear-remint.mjs` against its cooldown-guarded reminter); `github-token` and
+`linear-api-token` remain hookless, so both currently take the degrade path in practice.
+
+### Linear worker-actor's legacy fallback tiers
+
+`linear-worker-actor` is the one row with a multi-tier fallback chain, folded verbatim from
+`lib/linear-comment-post.sh`'s pre-existing four-rung precedence (deprecating the legacy tiers is
+an explicit, separate follow-up — not part of this fold):
+
+1. `credentialEnvPair` — `CATALYST_LINEAR_AGENT_CLIENT_ID`/`CATALYST_LINEAR_AGENT_CLIENT_SECRET`,
+   checked first; both must be non-empty.
+2. The primary `configJsonPath` tier (`catalyst.linear.bot.worker`).
+3. `legacyConfigTiers`' `per-team-legacy` tier, tried only once the above both miss: a per-team
+   legacy file (walking up from `cwd` for a `.catalyst/config.json` `projectKey`, reading a sibling
+   `config-<key>.json`).
+4. `legacyConfigTiers`' `global-legacy` tier, tried only once tier 3 also misses: the global
+   `catalyst.linear.agent` path in the canonical Layer-2 file.
+
+A row that declares `requiredObjectFields` (only `linear-worker-actor`, requiring `clientId` and
+`clientSecret`) must find every named field present and non-blank in a candidate tier's raw
+object value before that tier is allowed to win — a partially-populated tier (e.g. a
+credential-free `{webhookSecret, botUserId}` object) falls through to the next tier instead of
+capturing resolution and failing downstream.
+
+### Doctor integration
+
+`catalyst doctor` consults the contract through `resolveSecret` directly — never a second
+hand-rolled presence check — but for most checks it is **shadow-only observability**: the contract
+is resolved and compared against the check's existing hand-rolled answer, and a disagreement is
+reported as its own `STATUS.INFO` row (`<check>-secret-contract-shadow`) that never changes the
+check's grade or exit code. `checkPeerUniqueness`, `checkBotCredentials`, and `checkWorkerLabels`
+are the one cutover to date: they now read `linear-api-token` from the contract as their **live**
+answer (their old hand-rolled `LINEAR_API_TOKEN ?? LINEAR_API_KEY` read is gone, and so is the
+shadow comparison that has nothing left to compare against). `checkSecretContract` itself remains a
+standalone INFO-only observation (presence of `linear-api-token` and `groq-api-key`) for every node
+class. The one exception that does change doctor's exit code: `checkCloudTokenEnv` FAILs when the
+active deployment mode is declared `cloud` (recognized, not inferred) and the `cloud-token`
+bootstrap row does not resolve — the one FAIL doctor cannot route around, per the cloud guard's
+bootstrap short-circuit above.
+
 ## GitHub merge rules live in GitHub
 
 Catalyst can open PRs, fix CI, answer review bots, and merge. But GitHub decides what must pass


### PR DESCRIPTION
## Summary

CTL-1616 migration plan **PR7** (docs): the registry schema reference in `website/.../reference/configuration.md` (the AGENTS.md single-source home for config schema) and a `Secret Contract` subsection in `docs/architecture.md`.

Written from the **shipped code**, not the design doc — every claim carries a verified code location, and a second fact-check agent corrected five inaccuracies in place before this PR. Two notable truths surfaced:

- **Groq's `resolveApiKey` is a separate pre-existing helper (CTL-343), not the contract engine** — PR5 unified the three Groq sites onto it, but it is documented as adjacent cleanup, and the false diagram edge was removed.
- **The design's claimed CTL-1612 fold never landed**: `lib/catalyst-secret-env.sh` / `github-auth-preflight.mjs` were never repointed at the registry across PR1–PR6 (their registry rows exist for shadow comparison only). Both docs state this explicitly — it's a genuine remaining-work item, not a shipped fact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WHfJt1JhsdArSUyxwZZzkN