### PR TITLE
fix(execution-core): close test-hermeticity gaps that only fail on a live, configured host

### DIFF
--- a/plugins/dev/scripts/execution-core/config.test.mjs
+++ b/plugins/dev/scripts/execution-core/config.test.mjs
@@ -10,6 +10,16 @@ import { describe, test, expect, beforeEach, afterEach } from "bun:test";
 import { mkdtempSync, writeFileSync, rmSync, mkdirSync, existsSync } from "node:fs";
 import { tmpdir, hostname, homedir } from "node:os";
 import { join, resolve } from "node:path";
+
+// Mirrors getHostName()'s fallback: strip everything after the FIRST dot, not
+// just a trailing ".local". A naive `.replace(/\.local$/, "")` only agrees with
+// this on a bare-label or *.local hostname — it diverges on any real multi-label
+// FQDN that isn't ".local" (e.g. this machine's "aldebaran.hagale.net"), which is
+// exactly the shape a live, non-mDNS Catalyst fleet host has.
+function firstDnsLabel(raw) {
+  const dot = raw.indexOf(".");
+  return dot === -1 ? raw : raw.slice(0, dot);
+}
 import {
   readWaitWatcherConfig,
   EVENT_DEBOUNCE_MS,
@@ -278,7 +288,7 @@ describe("getHostName (CTL-859)", () => {
   test("defaults to os.hostname() with trailing .local stripped", () => {
     // Point Layer-2 at a non-existent file so the hostname default is exercised.
     process.env.CATALYST_LAYER2_CONFIG_FILE = join(tmp, "absent.json");
-    const expected = hostname().replace(/\.local$/, "");
+    const expected = firstDnsLabel(hostname());
     expect(getHostName()).toBe(expected);
   });
 
@@ -301,7 +311,7 @@ describe("getHostName (CTL-859)", () => {
     const cfg = join(tmp, "config.json");
     writeFileSync(cfg, "{ this is not json");
     process.env.CATALYST_LAYER2_CONFIG_FILE = cfg;
-    const expected = hostname().replace(/\.local$/, "");
+    const expected = firstDnsLabel(hostname());
     expect(getHostName()).toBe(expected);
   });
 });
@@ -395,6 +405,12 @@ describe("getClusterHosts cluster-repo source (CTL-859 / CTL-1211 / CTL-1274)", 
     process.env.CATALYST_CONFIG_FILE = join(repo, ".catalyst", "config.json");
     process.env.CATALYST_CLUSTER_DIR = cluster;
     process.env.CATALYST_HOST_NAME = "solo-host";
+    // Point at a controlled, guaranteed-absent path rather than deleting the env
+    // var: an unset CATALYST_LAYER2_CONFIG_FILE falls back to the real
+    // ~/.config/catalyst/config.json, which on a live, configured Catalyst host
+    // (any actual fleet node) has a genuine catalyst.cluster.staticRoster —
+    // leaking the real fleet roster into this "degrades to single-host" case.
+    process.env.CATALYST_LAYER2_CONFIG_FILE = join(cluster, "absent-layer2.json");
   });
 
   afterEach(() => {

--- a/plugins/dev/scripts/execution-core/heartbeat-event.test.mjs
+++ b/plugins/dev/scripts/execution-core/heartbeat-event.test.mjs
@@ -18,6 +18,15 @@ import {
 } from "./heartbeat-event.mjs";
 import { readClusterHeartbeats } from "./recovery.mjs";
 
+// Mirrors getHostName()'s fallback: strip everything after the FIRST dot, not
+// just a trailing ".local" — a naive `.replace(/\.local$/, "")` diverges on any
+// real multi-label FQDN that isn't ".local" (e.g. a live fleet host's
+// "aldebaran.hagale.net").
+function firstDnsLabel(raw) {
+  const dot = raw.indexOf(".");
+  return dot === -1 ? raw : raw.slice(0, dot);
+}
+
 const HOST_ENVS = ["CATALYST_HOST_NAME", "CATALYST_LAYER2_CONFIG_FILE"];
 let savedEnv = {};
 
@@ -67,7 +76,7 @@ describe("buildHeartbeatEnvelope (CTL-859)", () => {
 
   test("host.name defaults to os.hostname() minus .local", () => {
     const env = buildHeartbeatEnvelope();
-    const expected = hostname().replace(/\.local$/, "");
+    const expected = firstDnsLabel(hostname());
     expect(env.body.payload["host.name"]).toBe(expected);
   });
 
@@ -191,6 +200,14 @@ describe("startHeartbeat (CTL-859)", () => {
 });
 
 describe("readClusterHeartbeats (CTL-859)", () => {
+  // These tests only exercise LOCAL log parsing, so every call passes an explicit
+  // roster: [] — readClusterHeartbeats defaults roster to the real getClusterHosts()
+  // and, for a roster.length > 1, merges in a real cross-host peer read
+  // (defaultReadPeers). On a live, configured multi-host Catalyst node (any actual
+  // fleet host) that default silently turns this "unit" test into a real network
+  // read that merges genuine peer heartbeat data into the result — flaky/incorrect
+  // depending on what the real daemon happened to have written moments earlier.
+  // roster: [] triggers CTL-1090's single-host exact no-op, making these hermetic.
   let tmp;
   let logPath;
 
@@ -204,7 +221,7 @@ describe("readClusterHeartbeats (CTL-859)", () => {
   });
 
   test("returns {} when the event log is absent", () => {
-    expect(readClusterHeartbeats({ logPath: join(tmp, "nope.jsonl") })).toEqual({});
+    expect(readClusterHeartbeats({ logPath: join(tmp, "nope.jsonl"), roster: [] })).toEqual({});
   });
 
   test("returns the latest ts per host", () => {
@@ -218,7 +235,7 @@ describe("readClusterHeartbeats (CTL-859)", () => {
     appendFileSync(logPath, hb("mini", "2026-06-08T00:00:00Z"));
     appendFileSync(logPath, hb("mini", "2026-06-08T00:01:00Z"));
     appendFileSync(logPath, hb("mac-studio", "2026-06-08T00:00:30Z"));
-    const seen = readClusterHeartbeats({ logPath });
+    const seen = readClusterHeartbeats({ logPath, roster: [] });
     expect(seen).toEqual({
       mini: "2026-06-08T00:01:00Z",
       "mac-studio": "2026-06-08T00:00:30Z",
@@ -244,7 +261,7 @@ describe("readClusterHeartbeats (CTL-859)", () => {
         body: { payload: { "host.name": "mini", epoch: 1 } },
       }) + "\n",
     );
-    expect(readClusterHeartbeats({ logPath })).toEqual({
+    expect(readClusterHeartbeats({ logPath, roster: [] })).toEqual({
       mini: "2026-06-08T00:02:00Z",
     });
   });
@@ -252,7 +269,7 @@ describe("readClusterHeartbeats (CTL-859)", () => {
   test("round-trips an emitHeartbeatEvent-produced line", async () => {
     process.env.CATALYST_HOST_NAME = "mini";
     await emitHeartbeatEvent({ logPath });
-    const seen = readClusterHeartbeats({ logPath });
+    const seen = readClusterHeartbeats({ logPath, roster: [] });
     expect(Object.keys(seen)).toEqual(["mini"]);
     expect(typeof seen.mini).toBe("string");
   });

--- a/plugins/dev/scripts/execution-core/test-setup.mjs
+++ b/plugins/dev/scripts/execution-core/test-setup.mjs
@@ -40,6 +40,23 @@ const hermeticDir = mkdtempSync(join(tmpdir(), "catalyst-hermetic-"));
 process.env.CATALYST_DIR = hermeticDir;
 process.env.CATALYST_HERMETIC_DIR = hermeticDir;
 
+// Pin CATALYST_LAYER2_CONFIG_FILE the same way, and for the same reason: unset,
+// getLayer2ConfigPath() falls back to the REAL ~/.config/catalyst/config.json —
+// which, on any actual fleet host (a developer's live Catalyst install, not a
+// clean CI runner), is a genuine machine-local config with a real multi-host
+// catalyst.cluster.staticRoster. A test that never overrides this env var then
+// silently becomes "multi-host" and picks up real HRW ownership filtering in
+// schedulerTick's ready.filter() — e.g. a ticket id that doesn't happen to hash
+// to this host gets dropped from `ready` and a "dispatches new work" assertion
+// fails, on this host only, for a reason that has nothing to do with the code
+// under test. Point at a guaranteed-absent path so getLayer2ConfigPath() always
+// resolves the "missing Layer-2 file" branch by default. Tests that want their
+// own Layer-2 fixture still set CATALYST_LAYER2_CONFIG_FILE themselves; the
+// existing save/restore pattern (save current value, delete/set for the test,
+// restore in afterEach) already handles a pinned non-undefined default the same
+// way it handles CATALYST_DIR's hermetic pin.
+process.env.CATALYST_LAYER2_CONFIG_FILE = join(hermeticDir, "layer2-config-absent.json");
+
 // Belt: a real linearis reached despite the shim writes nothing without creds.
 delete process.env.LINEAR_API_TOKEN;
 delete process.env.LINEAR_API_KEY;


### PR DESCRIPTION
## Summary
Investigating a batch of execution-core test failures that only reproduce on a real, already-configured multi-host Catalyst install — never on a clean CI runner, which is exactly why they went unnoticed. Already merged to thagale/catalyst#22; proposing upstream per the fork-and-upstream default.

Root-caused to test-hermeticity gaps, all in test-only files:

- `test-setup.mjs` (the `[test].preload`) pins `CATALYST_DIR` for hermeticity but never pinned `CATALYST_LAYER2_CONFIG_FILE` the same way. On a live host, unset falls through to the REAL `~/.config/catalyst/config.json` — including a genuine multi-host `catalyst.cluster.staticRoster` on any actual fleet node — silently turning "single-host" test setups into "multi-host," which then applies real HRW ownership filtering inside `schedulerTick`'s `ready.filter()`. This is what suppressed `integration.test.mjs`'s AC5 dispatch assertion on such a host.
- `config.test.mjs`'s "degrades to single-host" cases `delete`d the env var instead of pointing it at a guaranteed-absent path, leaking the same real roster into `getClusterHosts()` assertions.
- Both `config.test.mjs` and `heartbeat-event.test.mjs` asserted `hostname().replace(/\.local$/, "")` against `getHostName()`'s actual behavior (strip everything after the *first* dot) — the two formulas only agree on a bare label or a `*.local` host, and diverge on any real multi-label FQDN.
- `heartbeat-event.test.mjs`'s `readClusterHeartbeats` tests never passed `roster: []`, so on a real multi-host machine they picked up a genuine cross-host peer read merged into what should have been a local-only assertion.

All fixes make the failing assertions machine-independent rather than special-casing any particular host. No production code paths are touched — every changed line is inside a `.test.mjs` file or the shared test preload.

## Test plan
- [x] CI's exact curated test list (`execution-core-tests.yml`'s `bun test` invocation, upstream's current 153-file list): **5304/5304 pass, 0 fail**
- [x] Verified each fix's root cause with a standalone repro before patching (traced the AC5-style dispatch suppression to `schedulerTick`'s `multiHost` roster resolution via a scratch debug script, deleted after use)

Claude-Session: https://claude.ai/code/session_018Hj1J7kfaQrPNh5RVzAPa9