### PR TITLE
fix(dev): CTL-1616 harden the layer2-path-divergence check (#2931 round-2 Codex x2)

### DIFF
--- a/plugins/dev/scripts/execution-core/doctor.mjs
+++ b/plugins/dev/scripts/execution-core/doctor.mjs
@@ -3531,8 +3531,12 @@ export function checkLayer2PathDivergence(deps = {}) {
   let legacyPath;
   let canonicalPath;
   try {
-    legacyPath = legacyPathFn();
-    canonicalPath = canonicalPathFn();
+    // #2931 round-2 (Codex P2): NORMALIZE before comparing — an equivalent
+    // absolute spelling (e.g. "$HOME/.config/catalyst/../catalyst/config.json")
+    // reaches the same file through both chains; a raw string compare would
+    // FAIL a valid host and block its catalyst-join activation gate.
+    legacyPath = resolve(legacyPathFn());
+    canonicalPath = resolve(canonicalPathFn());
   } catch {
     return []; // fail-open: a throwing resolver must not invent a divergence
   }
@@ -3547,7 +3551,10 @@ export function checkLayer2PathDivergence(deps = {}) {
         `and cloud-token name resolution) — a credential rotation would land where half the ` +
         `readers never look. This CATALYST_MACHINE_CONFIG/XDG_CONFIG_HOME-divergent layout is ` +
         `unsupported until the canonical reader/writer sweep; set CATALYST_LAYER2_CONFIG_FILE ` +
-        `(tier 1 of BOTH chains) to pin every reader and writer to one file`,
+        `(tier 1 of BOTH chains) MACHINE-WIDE — e.g. in the durable execution-core.env the ` +
+        `daemons source — not just the invoking shell: supervised launchd services do not ` +
+        `inherit a shell-only export, so a shell-scoped pin would pass this check while the ` +
+        `running services still split (see #2931 review; the full remedy is the CTL-1624 sweep)`,
     ),
   ];
 }

--- a/plugins/dev/scripts/execution-core/doctor.test.mjs
+++ b/plugins/dev/scripts/execution-core/doctor.test.mjs
@@ -5,7 +5,7 @@
 
 import { describe, it, expect, beforeAll, afterAll, beforeEach, afterEach } from "bun:test";
 import { mkdtempSync, writeFileSync, rmSync, readFileSync } from "node:fs";
-import { tmpdir } from "node:os";
+import { tmpdir, homedir } from "node:os";
 import { join } from "node:path";
 import {
   STATUS,
@@ -2515,6 +2515,24 @@ describe("checkLayer2PathDivergence (#2930 round-2)", () => {
     expect(checks[0].status).toBe(STATUS.FAIL);
     expect(checks[0].detail).toContain("/machine/split-test/config.json");
     expect(checks[0].detail).toContain("CATALYST_LAYER2_CONFIG_FILE");
+  });
+
+  it("does NOT fail on an alias-equivalent spelling of the same file (#2931 round-2)", () => {
+    const home = homedir();
+    const checks = checkLayer2PathDivergence({
+      env: {
+        CATALYST_MACHINE_CONFIG: join(home, ".config", "catalyst", "..", "catalyst", "config.json"),
+      },
+    });
+    expect(checks).toHaveLength(0);
+  });
+
+  it("names the machine-wide pin requirement in the remedy (shell-only export is not enough)", () => {
+    const checks = checkLayer2PathDivergence({
+      env: { CATALYST_MACHINE_CONFIG: "/machine/split-test/config.json" },
+    });
+    expect(checks[0].detail).toContain("MACHINE-WIDE");
+    expect(checks[0].detail).toContain("execution-core.env");
   });
 
   it("fails OPEN (zero rows) when a resolver throws", () => {


### PR DESCRIPTION
## Summary

Both round-2 #2931 findings fixed:

1. **P2** — paths are normalized (`resolve`) before comparison: an alias-equivalent spelling (`..` segments) of the same file no longer FAILs a valid host and blocks its `catalyst-join` activation gate. Test covers the alias shape.
2. **P1** — the remedy text now requires the `CATALYST_LAYER2_CONFIG_FILE` pin **machine-wide** (the durable `execution-core.env` the daemons source), never just the invoking shell — supervised launchd services don't inherit a shell export, so a shell-scoped pin would green doctor while services still split. Full supervised-environment validation is folded into **CTL-1624**'s (canonical sweep) acceptance.

`doctor.test.mjs` 359/0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WHfJt1JhsdArSUyxwZZzkN