### PR TITLE
fix(dev): CTL-1616 divergence check round 3 — reject relative paths, per-service remedy, no committed ticket prefix

### DIFF
--- a/plugins/dev/scripts/execution-core/doctor.mjs
+++ b/plugins/dev/scripts/execution-core/doctor.mjs
@@ -25,7 +25,7 @@
 // Exit code: number of FAIL-level checks (0 = all clear).
 
 import { readFileSync, statSync, existsSync } from "node:fs";
-import { resolve, dirname } from "node:path";
+import { resolve, dirname, isAbsolute } from "node:path";
 import { homedir } from "node:os";
 import { fileURLToPath } from "node:url";
 import { spawnSync, execFileSync } from "node:child_process";
@@ -3528,18 +3528,36 @@ export function checkLayer2PathDivergence(deps = {}) {
       env.CATALYST_LAYER2_CONFIG_FILE || resolve(homedir(), ".config", "catalyst", "config.json"),
     canonicalPathFn = () => resolveLayer2Path(env),
   } = deps;
-  let legacyPath;
-  let canonicalPath;
+  let legacyRaw;
+  let canonicalRaw;
   try {
-    // #2931 round-2 (Codex P2): NORMALIZE before comparing — an equivalent
-    // absolute spelling (e.g. "$HOME/.config/catalyst/../catalyst/config.json")
-    // reaches the same file through both chains; a raw string compare would
-    // FAIL a valid host and block its catalyst-join activation gate.
-    legacyPath = resolve(legacyPathFn());
-    canonicalPath = resolve(canonicalPathFn());
+    legacyRaw = legacyPathFn();
+    canonicalRaw = canonicalPathFn();
   } catch {
     return []; // fail-open: a throwing resolver must not invent a divergence
   }
+  // #2938 round-2 (Codex P2): a RELATIVE configured path must never be
+  // cwd-normalized into agreement — resolveLayer2Path preserves the relative
+  // string and canonical consumers read it against THEIR cwd, so a supervised
+  // service with a different cwd reads a different (or missing) file. Reject
+  // it outright instead of comparing.
+  if (!isAbsolute(legacyRaw) || !isAbsolute(canonicalRaw)) {
+    return [
+      mkCheck(
+        "layer2-path-divergence",
+        STATUS.FAIL,
+        `Layer-2 config path is RELATIVE ("${!isAbsolute(legacyRaw) ? legacyRaw : canonicalRaw}") — ` +
+          `each consumer resolves it against its own working directory, so different services read ` +
+          `different files; configure an ABSOLUTE path (CATALYST_LAYER2_CONFIG_FILE / ` +
+          `CATALYST_MACHINE_CONFIG must be absolute)`,
+      ),
+    ];
+  }
+  // #2931 round-2 (Codex P2): NORMALIZE (absolute-only — cwd-independent)
+  // before comparing, so an equivalent absolute spelling (e.g.
+  // "$HOME/.config/catalyst/../catalyst/config.json") is not a false FAIL.
+  const legacyPath = resolve(legacyRaw);
+  const canonicalPath = resolve(canonicalRaw);
   if (legacyPath === canonicalPath) return [];
   return [
     mkCheck(
@@ -3551,10 +3569,11 @@ export function checkLayer2PathDivergence(deps = {}) {
         `and cloud-token name resolution) — a credential rotation would land where half the ` +
         `readers never look. This CATALYST_MACHINE_CONFIG/XDG_CONFIG_HOME-divergent layout is ` +
         `unsupported until the canonical reader/writer sweep; set CATALYST_LAYER2_CONFIG_FILE ` +
-        `(tier 1 of BOTH chains) MACHINE-WIDE — e.g. in the durable execution-core.env the ` +
-        `daemons source — not just the invoking shell: supervised launchd services do not ` +
-        `inherit a shell-only export, so a shell-scoped pin would pass this check while the ` +
-        `running services still split (see #2931 review; the full remedy is the CTL-1624 sweep)`,
+        `(tier 1 of BOTH chains) in the environment of EVERY supervised service AND interactive ` +
+        `shell — no single env file covers them all today (execution-core sources ` +
+        `execution-core.env, the monitor's start path sources lib/catalyst-secret-env.sh, shells ` +
+        `have their own profile), so the pin must reach each service's own environment source; a ` +
+        `pin visible only to this doctor run would pass the check while running services still split`,
     ),
   ];
 }

--- a/plugins/dev/scripts/execution-core/doctor.test.mjs
+++ b/plugins/dev/scripts/execution-core/doctor.test.mjs
@@ -2527,12 +2527,22 @@ describe("checkLayer2PathDivergence (#2930 round-2)", () => {
     expect(checks).toHaveLength(0);
   });
 
-  it("names the machine-wide pin requirement in the remedy (shell-only export is not enough)", () => {
+  it("REJECTS a relative configured path instead of cwd-normalizing it into agreement (#2938 round-2)", () => {
+    const checks = checkLayer2PathDivergence({
+      env: { CATALYST_MACHINE_CONFIG: "config.json" },
+    });
+    expect(checks).toHaveLength(1);
+    expect(checks[0].status).toBe(STATUS.FAIL);
+    expect(checks[0].detail).toContain("RELATIVE");
+    expect(checks[0].detail).toContain("ABSOLUTE");
+  });
+
+  it("remedy names the every-supervised-service pin requirement without a committed ticket prefix", () => {
     const checks = checkLayer2PathDivergence({
       env: { CATALYST_MACHINE_CONFIG: "/machine/split-test/config.json" },
     });
-    expect(checks[0].detail).toContain("MACHINE-WIDE");
-    expect(checks[0].detail).toContain("execution-core.env");
+    expect(checks[0].detail).toContain("EVERY supervised service");
+    expect(checks[0].detail).not.toMatch(/CTL-\d+/);
   });
 
   it("fails OPEN (zero rows) when a resolver throws", () => {


### PR DESCRIPTION
## Summary

All three #2938 post-merge Codex findings fixed:

1. **P2** — relative configured paths are **rejected** (FAIL naming the fix: absolute paths only) instead of being cwd-normalized into false agreement — each consumer resolves a relative path against its own cwd, so doctor's normalization could mask a real per-service split.
2. **P2** — the remedy tells the truth about scope: no single env file is machine-wide today (execution-core.env vs the monitor's `catalyst-secret-env.sh` vs shell profiles); the pin must reach **every** supervised service's own environment source.
3. **P1 (house rule)** — the user-facing diagnostic no longer commits a repo-specific ticket prefix; a regression test asserts no `CTL-\d+` in the message.

`doctor.test.mjs` 360/0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WHfJt1JhsdArSUyxwZZzkN