### PR TITLE
fix(dev): CTL-1616 divergence check round 4 — prefix-agnostic assertion + no dead-end remedy

### DIFF
--- a/plugins/dev/scripts/execution-core/doctor.mjs
+++ b/plugins/dev/scripts/execution-core/doctor.mjs
@@ -3548,8 +3548,9 @@ export function checkLayer2PathDivergence(deps = {}) {
         STATUS.FAIL,
         `Layer-2 config path is RELATIVE ("${!isAbsolute(legacyRaw) ? legacyRaw : canonicalRaw}") — ` +
           `each consumer resolves it against its own working directory, so different services read ` +
-          `different files; configure an ABSOLUTE path (CATALYST_LAYER2_CONFIG_FILE / ` +
-          `CATALYST_MACHINE_CONFIG must be absolute)`,
+          `different files; set an ABSOLUTE CATALYST_LAYER2_CONFIG_FILE (tier 1 of BOTH chains — ` +
+          `an absolute CATALYST_MACHINE_CONFIG alone still diverges from the legacy chain and ` +
+          `fails the split-brain gate)`,
       ),
     ];
   }

--- a/plugins/dev/scripts/execution-core/doctor.mjs
+++ b/plugins/dev/scripts/execution-core/doctor.mjs
@@ -3549,8 +3549,8 @@ export function checkLayer2PathDivergence(deps = {}) {
         `Layer-2 config path is RELATIVE ("${!isAbsolute(legacyRaw) ? legacyRaw : canonicalRaw}") — ` +
           `each consumer resolves it against its own working directory, so different services read ` +
           `different files; set an ABSOLUTE CATALYST_LAYER2_CONFIG_FILE (tier 1 of BOTH chains — ` +
-          `an absolute CATALYST_MACHINE_CONFIG alone still diverges from the legacy chain and ` +
-          `fails the split-brain gate)`,
+          `an absolute CATALYST_MACHINE_CONFIG pointing anywhere other than the legacy default ` +
+          `path still diverges from the legacy chain and fails the split-brain gate)`,
       ),
     ];
   }

--- a/plugins/dev/scripts/execution-core/doctor.test.mjs
+++ b/plugins/dev/scripts/execution-core/doctor.test.mjs
@@ -2534,7 +2534,7 @@ describe("checkLayer2PathDivergence (#2930 round-2)", () => {
     expect(checks).toHaveLength(1);
     expect(checks[0].status).toBe(STATUS.FAIL);
     expect(checks[0].detail).toContain("RELATIVE");
-    expect(checks[0].detail).toContain("ABSOLUTE");
+    expect(checks[0].detail).toContain("ABSOLUTE CATALYST_LAYER2_CONFIG_FILE");
   });
 
   it("remedy names the every-supervised-service pin requirement without a committed ticket prefix", () => {
@@ -2542,7 +2542,9 @@ describe("checkLayer2PathDivergence (#2930 round-2)", () => {
       env: { CATALYST_MACHINE_CONFIG: "/machine/split-test/config.json" },
     });
     expect(checks[0].detail).toContain("EVERY supervised service");
-    expect(checks[0].detail).not.toMatch(/CTL-\d+/);
+    // Prefix-agnostic ticket matcher — the assertion itself must not commit a
+    // repo-specific prefix (the very rule it enforces).
+    expect(checks[0].detail).not.toMatch(/\b[A-Z]{2,}-\d+\b/);
   });
 
   it("fails OPEN (zero rows) when a resolver throws", () => {

--- a/plugins/dev/scripts/execution-core/doctor.test.mjs
+++ b/plugins/dev/scripts/execution-core/doctor.test.mjs
@@ -51,6 +51,7 @@ import {
   runDoctor,
 } from "./doctor.mjs";
 import { resolveSecret as resolveSecretReal } from "../lib/secret-contract.mjs";
+import { TICKET_KEY_RE } from "./ticket-key.mjs";
 import { validateLayer1Config } from "../lib/validate-catalyst-config.mjs";
 // CTL-1369 PR4: parity source for doctor's inlined defaultPluginPullOwner.
 import { resolvePluginPullOwner } from "../broker/plugin-refresh.mjs";
@@ -2542,11 +2543,13 @@ describe("checkLayer2PathDivergence (#2930 round-2)", () => {
       env: { CATALYST_MACHINE_CONFIG: "/machine/split-test/config.json" },
     });
     expect(checks[0].detail).toContain("EVERY supervised service");
-    // Prefix-agnostic ticket matcher mirroring the repo's canonical ticket
-    // grammar (ticket-key.mjs TICKET_KEY_RE: one-letter keys, digits and
-    // underscores allowed) — the assertion itself must not commit a
-    // repo-specific prefix (the very rule it enforces).
-    expect(checks[0].detail).not.toMatch(/\b[A-Z][A-Z0-9_]*-\d+\b/);
+    // Prefix-agnostic ticket scan DERIVED from the canonical grammar
+    // (ticket-key.mjs TICKET_KEY_RE, anchors stripped for substring scanning)
+    // so a future grammar extension cannot silently stale this assertion —
+    // and the assertion itself commits no repo-specific prefix (the very
+    // rule it enforces).
+    const ticketScanRe = new RegExp(`\\b${TICKET_KEY_RE.source.replace(/^\^|\$$/g, "")}\\b`);
+    expect(checks[0].detail).not.toMatch(ticketScanRe);
   });
 
   it("fails OPEN (zero rows) when a resolver throws", () => {

--- a/plugins/dev/scripts/execution-core/doctor.test.mjs
+++ b/plugins/dev/scripts/execution-core/doctor.test.mjs
@@ -2542,9 +2542,11 @@ describe("checkLayer2PathDivergence (#2930 round-2)", () => {
       env: { CATALYST_MACHINE_CONFIG: "/machine/split-test/config.json" },
     });
     expect(checks[0].detail).toContain("EVERY supervised service");
-    // Prefix-agnostic ticket matcher — the assertion itself must not commit a
+    // Prefix-agnostic ticket matcher mirroring the repo's canonical ticket
+    // grammar (ticket-key.mjs TICKET_KEY_RE: one-letter keys, digits and
+    // underscores allowed) — the assertion itself must not commit a
     // repo-specific prefix (the very rule it enforces).
-    expect(checks[0].detail).not.toMatch(/\b[A-Z]{2,}-\d+\b/);
+    expect(checks[0].detail).not.toMatch(/\b[A-Z][A-Z0-9_]*-\d+\b/);
   });
 
   it("fails OPEN (zero rows) when a resolver throws", () => {


### PR DESCRIPTION
## Summary

Both post-merge #2939 findings fixed: (P1) the no-committed-prefix regression test now uses a prefix-agnostic ticket matcher instead of hard-coding the very prefix it polices; (P2) the relative-path FAIL's remedy points straight at an absolute `CATALYST_LAYER2_CONFIG_FILE` (tier 1 of both chains) instead of suggesting an absolute `CATALYST_MACHINE_CONFIG` that immediately fails the split-brain gate. `doctor.test.mjs` 360/0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WHfJt1JhsdArSUyxwZZzkN