### PR TITLE
fix(dev): CTL-1628 A2 post-merge hardening (Codex #2946 threads)

### DIFF
--- a/plugins/dev/scripts/__tests__/catalyst-runtime-root.test.sh
+++ b/plugins/dev/scripts/__tests__/catalyst-runtime-root.test.sh
@@ -128,6 +128,27 @@ OUT=$(run_lib "$SCRATCH/empty-cwd" "$CACHE_HOME" "")
 assert_eq "${OUT%%|*}" "0" "cache glob: return 0"
 assert_eq "${OUT#*|}" "$NEWEST_CACHE" "cache glob: sort -V picks 1.10.0 over 1.2.0 (numeric, not lexical)"
 
+# ─── catalyst_dev_scripts: marketplace glob skips a partial newest install ──
+# CTL-1628 A2 post-merge fix: the newest candidate (catalyst-v2, no sentinel
+# — a partial/broken install) must NOT sink the whole rung; the resolver
+# should fall back to the next-newest VALID candidate (catalyst-v1).
+MKT_PARTIAL_HOME="$SCRATCH/mkt-partial-home"
+VALID_MKT="$MKT_PARTIAL_HOME/.claude/plugins/marketplaces/catalyst-v1/plugins/dev/scripts"
+make_dev_scripts_dir "$VALID_MKT"
+mkdir -p "$MKT_PARTIAL_HOME/.claude/plugins/marketplaces/catalyst-v2/plugins/dev/scripts"  # no sentinel file
+OUT=$(run_lib "$SCRATCH/empty-cwd" "$MKT_PARTIAL_HOME" "")
+assert_eq "${OUT%%|*}" "0" "marketplace glob: partial newest — return 0"
+assert_eq "${OUT#*|}" "$VALID_MKT" "marketplace glob: partial newest (v2) skipped, falls back to valid v1"
+
+# ─── catalyst_dev_scripts: cache glob skips a partial newest install ────────
+CACHE_PARTIAL_HOME="$SCRATCH/cache-partial-home"
+VALID_CACHE="$CACHE_PARTIAL_HOME/.claude/plugins/cache/catalyst/catalyst-dev/1.0.0/scripts"
+make_dev_scripts_dir "$VALID_CACHE"
+mkdir -p "$CACHE_PARTIAL_HOME/.claude/plugins/cache/catalyst/catalyst-dev/2.0.0/scripts"  # no sentinel file
+OUT=$(run_lib "$SCRATCH/empty-cwd" "$CACHE_PARTIAL_HOME" "")
+assert_eq "${OUT%%|*}" "0" "cache glob: partial newest — return 0"
+assert_eq "${OUT#*|}" "$VALID_CACHE" "cache glob: partial newest (2.0.0) skipped, falls back to valid 1.0.0"
+
 # ─── catalyst_dev_scripts: total miss is LOUD (stderr) and returns 1 ────────
 OUT=$(cd "$SCRATCH/empty-cwd" && env -i HOME="$SCRATCH/empty-home" PATH="$PATH" LIB="$LIB" bash -c '
   unset CATALYST_DEV_SCRIPTS CLAUDE_PLUGIN_ROOT

--- a/plugins/dev/scripts/lib/catalyst-runtime-root.mjs
+++ b/plugins/dev/scripts/lib/catalyst-runtime-root.mjs
@@ -94,7 +94,24 @@ function expandStarGlob(pattern) {
           continue; // absent/unreadable optional layout root — skip, don't abort
         }
         for (const e of entries) {
-          if (e.isDirectory()) next.push(join(dir, e.name));
+          const full = join(dir, e.name);
+          if (e.isDirectory()) {
+            next.push(full);
+          } else if (e.isSymbolicLink()) {
+            // CTL-1628 A2 post-merge fix: Dirent.isDirectory() is false for
+            // a symlink (it reports the dirent's OWN type, not its target),
+            // so a symlinked marketplace/cache install used to be silently
+            // dropped here while the bash twin's `ls -d` glob (which follows
+            // symlinks) accepted it — a same-inputs, different-output
+            // divergence between the twins. statSync follows the link;
+            // stat-through a broken symlink throws, so skip it like any
+            // other unreadable entry.
+            try {
+              if (statSync(full).isDirectory()) next.push(full);
+            } catch {
+              continue; // broken symlink — skip, don't abort
+            }
+          }
         }
       } else {
         next.push(join(dir, seg));
@@ -105,20 +122,27 @@ function expandStarGlob(pattern) {
   return current.filter((p) => existsSync(p));
 }
 
-// newestDevScriptsDir — CTL-1628 A2 verify-round-2 parity fix: mirrors the
-// bash twin's rung semantics exactly. lib/catalyst-runtime-root.sh's
-// catalyst_dev_scripts picks the newest path FIRST (`sort -V | tail -1`)
-// and only THEN sentinel-validates it — if that single newest entry is
-// broken, the whole rung fails (falls through to the next rung) rather than
-// trying the next-newest candidate. This used to filter to valid paths
-// first and pick the newest of those, which silently accepted a
-// second-newest-but-valid dir where the bash lib returns nothing for the
-// rung — a same-inputs, different-output divergence between the twins.
+// newestDevScriptsDir — CTL-1628 A2 post-merge fix: mirrors the bash twin's
+// rung semantics exactly. lib/catalyst-runtime-root.sh's catalyst_dev_scripts
+// walks candidates newest-to-oldest (`sort -rV`) and returns the first one
+// that sentinel-validates, rather than validating ONLY the single newest
+// candidate. A partial/broken newest install (sentinel missing) used to fail
+// the WHOLE rung even when an older, fully-valid install sat right next to
+// it — register-thought.sh's workflow-context.sh lookup hit exactly this: it
+// validates a DIFFERENT file than catalyst_dev_scripts' own sentinel, so a
+// newest cache dir that passes THIS sentinel but happens to be missing
+// workflow-context.sh specifically shadowed an older cache dir that had it.
+// (An earlier "verify-round-2" pass here intentionally matched a STRICTER
+// newest-then-validate-only bash behavior; this pass changes BOTH twins
+// together to the more robust validate-then-accept walk, so the twins stay
+// in parity either way.)
 function newestDevScriptsDir(paths) {
   if (paths.length === 0) return null;
-  const sorted = [...paths].sort(versionCompare);
-  const newest = sorted[sorted.length - 1];
-  return isValidDevScriptsDir(newest) ? newest : null;
+  const sorted = [...paths].sort(versionCompare).reverse();
+  for (const candidate of sorted) {
+    if (isValidDevScriptsDir(candidate)) return candidate;
+  }
+  return null;
 }
 
 // catalystDevScripts([requestingPlugin], [opts]) — Q1. Resolves the shared
@@ -191,6 +215,18 @@ export function catalystPluginRoot(startDir = process.cwd()) {
   let dir;
   try {
     dir = resolvePath(startDir);
+  } catch {
+    return null;
+  }
+  // CTL-1628 A2 post-merge fix: the bash twin's `cd "$__cpr_dir" 2>/dev/null`
+  // fails outright on a nonexistent/non-directory startDir, producing an
+  // immediate miss with no ancestor walk at all. resolvePath() only performs
+  // lexical path resolution — it never touches the filesystem — so a
+  // stale/mistyped startDir beneath a valid plugin used to walk UP from that
+  // nonexistent path and return the valid ancestor's root, diverging from
+  // the bash twin. Validate existence up front to match.
+  try {
+    if (!statSync(dir).isDirectory()) return null;
   } catch {
     return null;
   }

--- a/plugins/dev/scripts/lib/catalyst-runtime-root.sh
+++ b/plugins/dev/scripts/lib/catalyst-runtime-root.sh
@@ -85,10 +85,34 @@ catalyst_dev_scripts() {
     fi
     __cd_root="$( cd "./plugins/dev/scripts" 2>/dev/null && pwd )"
     __cd_valid "$__cd_root" && { printf '%s\n' "$__cd_root"; return 0; }
-    __cd_mkt="$( ls -d "$HOME"/.claude/plugins/marketplaces/*/plugins/dev/scripts 2>/dev/null | sort -V | tail -1 )"
-    __cd_valid "$__cd_mkt" && { printf '%s\n' "$__cd_mkt"; return 0; }
-    __cd_cache="$( ls -d "$HOME"/.claude/plugins/cache/*/catalyst-dev/*/scripts 2>/dev/null | sort -V | tail -1 )"
-    __cd_valid "$__cd_cache" && { printf '%s\n' "$__cd_cache"; return 0; }
+    # CTL-1628 A2 post-merge fix: these two rungs used to pick the SINGLE
+    # newest candidate (`sort -V | tail -1`) and validate only that one — if
+    # the newest install was partial/broken (sentinel missing), the WHOLE
+    # rung failed even when an older, fully-valid install sat right next to
+    # it. Concretely, register-thought.sh delegates here to find
+    # workflow-context.sh: catalyst_dev_scripts validates a DIFFERENT
+    # sentinel (check-project-setup.sh), so a newest cache dir that passes
+    # THIS sentinel but happens to be missing workflow-context.sh specifically
+    # would shadow an older cache dir that has it. Walk candidates
+    # newest-to-oldest (`sort -rV`) and take the first one that validates,
+    # via a heredoc-fed loop (not a pipe) so `return` propagates out of
+    # __cd_resolve rather than exiting an unwanted subshell.
+    __cd_mkt_list="$( ls -d "$HOME"/.claude/plugins/marketplaces/*/plugins/dev/scripts 2>/dev/null | sort -rV )"
+    if [ -n "$__cd_mkt_list" ]; then
+      while IFS= read -r __cd_mkt; do
+        __cd_valid "$__cd_mkt" && { printf '%s\n' "$__cd_mkt"; return 0; }
+      done <<__CD_MKT_EOF__
+$__cd_mkt_list
+__CD_MKT_EOF__
+    fi
+    __cd_cache_list="$( ls -d "$HOME"/.claude/plugins/cache/*/catalyst-dev/*/scripts 2>/dev/null | sort -rV )"
+    if [ -n "$__cd_cache_list" ]; then
+      while IFS= read -r __cd_cache; do
+        __cd_valid "$__cd_cache" && { printf '%s\n' "$__cd_cache"; return 0; }
+      done <<__CD_CACHE_EOF__
+$__cd_cache_list
+__CD_CACHE_EOF__
+    fi
     return 1
   }
 
@@ -99,7 +123,7 @@ catalyst_dev_scripts() {
     echo "       Fix: install/enable catalyst-dev —  claude plugin install catalyst-dev@catalyst" >&2
     echo "       (or export CATALYST_DEV_SCRIPTS=/path/to/catalyst-dev/scripts)" >&2
     unset -f __cd_valid __cd_resolve 2>/dev/null
-    unset __cd_requesting_plugin __cd_sentinel __cd_sib __cd_root __cd_mkt __cd_cache 2>/dev/null
+    unset __cd_requesting_plugin __cd_sentinel __cd_sib __cd_root __cd_mkt __cd_cache __cd_mkt_list __cd_cache_list 2>/dev/null
     return 1
   fi
   export CATALYST_DEV_SCRIPTS

--- a/plugins/dev/scripts/lib/catalyst-runtime-root.test.mjs
+++ b/plugins/dev/scripts/lib/catalyst-runtime-root.test.mjs
@@ -8,7 +8,7 @@
 // so this suite never touches the real ~/.claude or the runner's own cwd.
 
 import { describe, test, expect, afterEach } from "bun:test";
-import { mkdtempSync, mkdirSync, writeFileSync, rmSync, realpathSync } from "node:fs";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync, realpathSync, symlinkSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { catalystDevScripts, catalystPluginRoot, catalystRuntimeLayout } from "./catalyst-runtime-root.mjs";
@@ -89,6 +89,64 @@ describe("catalystDevScripts", () => {
     expect(() => catalystDevScripts(undefined, { env: { HOME: home }, cwd: scratch() })).not.toThrow();
   });
 
+  test("marketplace: skips a partial newest install, falls back to the newest VALID candidate", () => {
+    // CTL-1628 A2 post-merge fix: the newest candidate (catalyst-v2, no
+    // sentinel — a partial/broken install) must not sink the whole rung;
+    // resolution should fall back to the next-newest valid candidate.
+    const home = scratch();
+    const valid = join(home, ".claude/plugins/marketplaces/catalyst-v1/plugins/dev/scripts");
+    makeDevScripts(valid);
+    mkdirSync(join(home, ".claude/plugins/marketplaces/catalyst-v2/plugins/dev/scripts"), {
+      recursive: true,
+    }); // no sentinel file — partial install
+    const result = catalystDevScripts(undefined, { env: { HOME: home }, cwd: scratch() });
+    expect(result).toEqual({ path: valid, source: "marketplace" });
+  });
+
+  test("cache: skips a partial newest install (2.0.0), falls back to valid 1.0.0", () => {
+    const home = scratch();
+    const valid = join(home, ".claude/plugins/cache/catalyst/catalyst-dev/1.0.0/scripts");
+    makeDevScripts(valid);
+    mkdirSync(join(home, ".claude/plugins/cache/catalyst/catalyst-dev/2.0.0/scripts"), {
+      recursive: true,
+    }); // no sentinel file — partial install
+    const result = catalystDevScripts(undefined, { env: { HOME: home }, cwd: scratch() });
+    expect(result).toEqual({ path: valid, source: "cache" });
+  });
+
+  test("marketplace: follows a symlinked installation directory (matches `ls -d` glob semantics)", () => {
+    // CTL-1628 A2 post-merge fix: Dirent.isDirectory() is false for a
+    // symlink entry, so a symlinked marketplace clone (e.g. a dev checkout
+    // symlinked into ~/.claude/plugins/marketplaces/) used to be silently
+    // dropped by the wildcard expansion, diverging from the bash twin's
+    // `ls -d ...*/plugins/dev/scripts`, which follows symlinks.
+    const home = scratch();
+    const realTarget = scratch();
+    makeDevScripts(join(realTarget, "plugins", "dev", "scripts"));
+    mkdirSync(join(home, ".claude/plugins/marketplaces"), { recursive: true });
+    symlinkSync(realTarget, join(home, ".claude/plugins/marketplaces", "catalyst-symlinked"), "dir");
+    const result = catalystDevScripts(undefined, { env: { HOME: home }, cwd: scratch() });
+    expect(result.source).toBe("marketplace");
+    expect(result.path).toBe(join(home, ".claude/plugins/marketplaces/catalyst-symlinked/plugins/dev/scripts"));
+  });
+
+  test("cache: follows a symlinked version directory (second wildcard segment)", () => {
+    // The symlink sits at the SECOND `*` in `cache/*/catalyst-dev/*/scripts`
+    // (the version dir) — the wildcard position the Dirent.isDirectory()
+    // bug actually affects, as opposed to a literal path segment which
+    // reaches existsSync() unconditionally and was never at risk.
+    const home = scratch();
+    const realTarget = scratch();
+    makeDevScripts(join(realTarget, "scripts"));
+    mkdirSync(join(home, ".claude/plugins/cache/catalyst/catalyst-dev"), { recursive: true });
+    symlinkSync(realTarget, join(home, ".claude/plugins/cache/catalyst/catalyst-dev", "1.0.0"), "dir");
+    const result = catalystDevScripts(undefined, { env: { HOME: home }, cwd: scratch() });
+    expect(result.source).toBe("cache");
+    expect(result.path).toBe(
+      join(home, ".claude/plugins/cache/catalyst/catalyst-dev/1.0.0/scripts"),
+    );
+  });
+
   test("total miss: returns null path/source and prints a LOUD stderr diagnostic", () => {
     const home = scratch();
     const originalError = console.error;
@@ -128,6 +186,31 @@ describe("catalystPluginRoot", () => {
 
   test("defaults startDir to process.cwd() and never throws on a bogus dir", () => {
     expect(() => catalystPluginRoot("/nonexistent-" + Date.now())).not.toThrow();
+  });
+
+  test("rejects a nonexistent startDir even when nested beneath a valid plugin root", () => {
+    // CTL-1628 A2 post-merge fix: the bash twin's `cd "$dir" 2>/dev/null`
+    // fails outright on a nonexistent startDir (immediate miss, no ancestor
+    // walk). resolvePath() alone never touches the filesystem, so a stale/
+    // mistyped startDir under a real plugin used to walk UP from the
+    // nonexistent path and return the valid ancestor instead of null.
+    const root = scratch();
+    const plugin = join(root, "plugins", "dev");
+    mkdirSync(join(plugin, ".claude-plugin"), { recursive: true });
+    writeFileSync(join(plugin, "version.txt"), "1.0.0\n");
+    writeFileSync(join(plugin, ".claude-plugin", "plugin.json"), "{}");
+    const stale = join(plugin, "scripts", "does-not-exist");
+    expect(catalystPluginRoot(stale)).toBeNull();
+  });
+
+  test("rejects a startDir that resolves to a file, not a directory", () => {
+    const root = scratch();
+    const plugin = join(root, "plugins", "dev");
+    mkdirSync(join(plugin, ".claude-plugin"), { recursive: true });
+    writeFileSync(join(plugin, "version.txt"), "1.0.0\n");
+    writeFileSync(join(plugin, ".claude-plugin", "plugin.json"), "{}");
+    const notADir = join(plugin, "version.txt");
+    expect(catalystPluginRoot(notADir)).toBeNull();
   });
 });
 

--- a/plugins/dev/skills/phase-implement/SKILL.md
+++ b/plugins/dev/skills/phase-implement/SKILL.md
@@ -72,7 +72,44 @@ SIGNAL_FILE="${ORCH_DIR}/workers/${TICKET}/phase-${PHASE}.json"
 [[ -f "$SIGNAL_FILE" ]] || { echo "phase-${PHASE}: signal file missing" >&2; exit 1; }
 
 PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT:-}"
-[[ -n "$PLUGIN_ROOT" ]] || PLUGIN_ROOT="$(dirname "$(dirname "$(dirname "$(realpath "${BASH_SOURCE[0]:-$0}" 2>/dev/null || echo .)")")")"
+if [[ -z "$PLUGIN_ROOT" ]]; then
+  # CTL-1628 Phase A2 post-merge fix: this used to fall back to
+  # `dirname(dirname(dirname($BASH_SOURCE/$0)))`, which in a bash command
+  # block (not a sourced script file) resolves to something bogus like "/" —
+  # a bad PLUGIN_ROOT here means `[[ -x "$YIELD_CHECK" ]]` below just
+  # evaluates false and the CTL-615 duplicate-worker yield gate is skipped
+  # WITHOUT any warning, the exact silent-skip exposure the A2 fix targeted
+  # in _phase-agent-template. Resolve properly via
+  # lib/catalyst-runtime-root.sh's catalyst_dev_scripts (cwd sibling →
+  # marketplace clone → versioned cache), and make a genuine miss LOUD
+  # instead of silently proceeding with a broken PLUGIN_ROOT.
+  RUNTIME_ROOT_LIB=""
+  if [[ -f "./plugins/dev/scripts/lib/catalyst-runtime-root.sh" ]]; then
+    RUNTIME_ROOT_LIB="./plugins/dev/scripts/lib/catalyst-runtime-root.sh"
+  else
+    __rr_mkt="$( ls -d "$HOME"/.claude/plugins/marketplaces/*/plugins/dev/scripts/lib/catalyst-runtime-root.sh 2>/dev/null | sort -V | tail -1 || true )"
+    if [[ -n "$__rr_mkt" && -f "$__rr_mkt" ]]; then
+      RUNTIME_ROOT_LIB="$__rr_mkt"
+    else
+      __rr_cache="$( ls -d "$HOME"/.claude/plugins/cache/*/catalyst-dev/*/scripts/lib/catalyst-runtime-root.sh 2>/dev/null | sort -V | tail -1 || true )"
+      [[ -n "$__rr_cache" && -f "$__rr_cache" ]] && RUNTIME_ROOT_LIB="$__rr_cache"
+      unset __rr_cache
+    fi
+    unset __rr_mkt
+  fi
+  DEV_SCRIPTS=""
+  if [[ -n "$RUNTIME_ROOT_LIB" ]]; then
+    # shellcheck disable=SC1090
+    . "$RUNTIME_ROOT_LIB"
+    catalyst_dev_scripts >/dev/null 2>&1 || true
+    DEV_SCRIPTS="${CATALYST_DEV_SCRIPTS:-}"
+  fi
+  if [[ -z "$DEV_SCRIPTS" ]]; then
+    echo "phase-${PHASE}: FATAL — CLAUDE_PLUGIN_ROOT unset and catalyst_dev_scripts probe missed too; refusing to silently skip the CTL-615 yield gate with a guessed PLUGIN_ROOT" >&2
+    exit 1
+  fi
+  PLUGIN_ROOT="$(dirname "$DEV_SCRIPTS")"
+fi
 
 # 0. Codified bg_job_id yield (CTL-615). If the signal file's bg_job_id
 #    names a DIFFERENT live bg job, we are a redispatch duplicate of a

--- a/plugins/dev/skills/phase-remediate/SKILL.md
+++ b/plugins/dev/skills/phase-remediate/SKILL.md
@@ -79,7 +79,44 @@ SIGNAL_FILE="${ORCH_DIR}/workers/${TICKET}/phase-${PHASE}.json"
 [[ -f "$SIGNAL_FILE" ]] || { echo "phase-${PHASE}: signal file missing" >&2; exit 1; }
 
 PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT:-}"
-[[ -n "$PLUGIN_ROOT" ]] || PLUGIN_ROOT="$(dirname "$(dirname "$(dirname "$(realpath "${BASH_SOURCE[0]:-$0}" 2>/dev/null || echo .)")")")"
+if [[ -z "$PLUGIN_ROOT" ]]; then
+  # CTL-1628 Phase A2 post-merge fix: this used to fall back to
+  # `dirname(dirname(dirname($BASH_SOURCE/$0)))`, which in a bash command
+  # block (not a sourced script file) resolves to something bogus like "/" —
+  # a bad PLUGIN_ROOT here means `[[ -x "$YIELD_CHECK" ]]` below just
+  # evaluates false and the CTL-615 duplicate-worker yield gate is skipped
+  # WITHOUT any warning, the exact silent-skip exposure the A2 fix targeted
+  # in _phase-agent-template. Resolve properly via
+  # lib/catalyst-runtime-root.sh's catalyst_dev_scripts (cwd sibling →
+  # marketplace clone → versioned cache), and make a genuine miss LOUD
+  # instead of silently proceeding with a broken PLUGIN_ROOT.
+  RUNTIME_ROOT_LIB=""
+  if [[ -f "./plugins/dev/scripts/lib/catalyst-runtime-root.sh" ]]; then
+    RUNTIME_ROOT_LIB="./plugins/dev/scripts/lib/catalyst-runtime-root.sh"
+  else
+    __rr_mkt="$( ls -d "$HOME"/.claude/plugins/marketplaces/*/plugins/dev/scripts/lib/catalyst-runtime-root.sh 2>/dev/null | sort -V | tail -1 || true )"
+    if [[ -n "$__rr_mkt" && -f "$__rr_mkt" ]]; then
+      RUNTIME_ROOT_LIB="$__rr_mkt"
+    else
+      __rr_cache="$( ls -d "$HOME"/.claude/plugins/cache/*/catalyst-dev/*/scripts/lib/catalyst-runtime-root.sh 2>/dev/null | sort -V | tail -1 || true )"
+      [[ -n "$__rr_cache" && -f "$__rr_cache" ]] && RUNTIME_ROOT_LIB="$__rr_cache"
+      unset __rr_cache
+    fi
+    unset __rr_mkt
+  fi
+  DEV_SCRIPTS=""
+  if [[ -n "$RUNTIME_ROOT_LIB" ]]; then
+    # shellcheck disable=SC1090
+    . "$RUNTIME_ROOT_LIB"
+    catalyst_dev_scripts >/dev/null 2>&1 || true
+    DEV_SCRIPTS="${CATALYST_DEV_SCRIPTS:-}"
+  fi
+  if [[ -z "$DEV_SCRIPTS" ]]; then
+    echo "phase-${PHASE}: FATAL — CLAUDE_PLUGIN_ROOT unset and catalyst_dev_scripts probe missed too; refusing to silently skip the CTL-615 yield gate with a guessed PLUGIN_ROOT" >&2
+    exit 1
+  fi
+  PLUGIN_ROOT="$(dirname "$DEV_SCRIPTS")"
+fi
 
 # 0. Codified bg_job_id yield (CTL-615). If the signal file's bg_job_id names a
 #    DIFFERENT live bg job, we are a redispatch duplicate of a still-running

--- a/plugins/dev/skills/recovery-pass/SKILL.md
+++ b/plugins/dev/skills/recovery-pass/SKILL.md
@@ -104,7 +104,44 @@ TICKET="${CATALYST_TICKET:-}"   # set when router-dispatched; empty for the swee
 CHANNEL="orch-${ORCH_ID}"
 
 PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT:-}"
-[[ -n "$PLUGIN_ROOT" ]] || PLUGIN_ROOT="$(dirname "$(dirname "$(dirname "$(realpath "${BASH_SOURCE[0]:-$0}" 2>/dev/null || echo .)")")")"
+if [[ -z "$PLUGIN_ROOT" ]]; then
+  # CTL-1628 Phase A2 post-merge fix: this used to fall back to
+  # `dirname(dirname(dirname($BASH_SOURCE/$0)))`, which in a bash command
+  # block (not a sourced script file) resolves to something bogus like "/" —
+  # a bad PLUGIN_ROOT here means `[[ -x "$YIELD_CHECK" ]]` below (in
+  # router-dispatched mode) just evaluates false and the CTL-615
+  # duplicate-worker yield gate is skipped WITHOUT any warning, the exact
+  # silent-skip exposure the A2 fix targeted in _phase-agent-template.
+  # Resolve properly via lib/catalyst-runtime-root.sh's catalyst_dev_scripts
+  # (cwd sibling → marketplace clone → versioned cache), and make a genuine
+  # miss LOUD instead of silently proceeding with a broken PLUGIN_ROOT.
+  RUNTIME_ROOT_LIB=""
+  if [[ -f "./plugins/dev/scripts/lib/catalyst-runtime-root.sh" ]]; then
+    RUNTIME_ROOT_LIB="./plugins/dev/scripts/lib/catalyst-runtime-root.sh"
+  else
+    __rr_mkt="$( ls -d "$HOME"/.claude/plugins/marketplaces/*/plugins/dev/scripts/lib/catalyst-runtime-root.sh 2>/dev/null | sort -V | tail -1 || true )"
+    if [[ -n "$__rr_mkt" && -f "$__rr_mkt" ]]; then
+      RUNTIME_ROOT_LIB="$__rr_mkt"
+    else
+      __rr_cache="$( ls -d "$HOME"/.claude/plugins/cache/*/catalyst-dev/*/scripts/lib/catalyst-runtime-root.sh 2>/dev/null | sort -V | tail -1 || true )"
+      [[ -n "$__rr_cache" && -f "$__rr_cache" ]] && RUNTIME_ROOT_LIB="$__rr_cache"
+      unset __rr_cache
+    fi
+    unset __rr_mkt
+  fi
+  DEV_SCRIPTS=""
+  if [[ -n "$RUNTIME_ROOT_LIB" ]]; then
+    # shellcheck disable=SC1090
+    . "$RUNTIME_ROOT_LIB"
+    catalyst_dev_scripts >/dev/null 2>&1 || true
+    DEV_SCRIPTS="${CATALYST_DEV_SCRIPTS:-}"
+  fi
+  if [[ -z "$DEV_SCRIPTS" ]]; then
+    echo "recovery-pass: FATAL — CLAUDE_PLUGIN_ROOT unset and catalyst_dev_scripts probe missed too; refusing to silently skip the CTL-615 yield gate with a guessed PLUGIN_ROOT" >&2
+    exit 1
+  fi
+  PLUGIN_ROOT="$(dirname "$DEV_SCRIPTS")"
+fi
 EXEC_CORE="${PLUGIN_ROOT}/scripts/execution-core"
 
 # ── Mode + the app-actor coordination-comment shim (CTL-1176) ────────────────


### PR DESCRIPTION
## Summary

Remediates the 4 post-merge Codex findings on #2946 (the `catalyst-runtime-root` resolver, CTL-1628 Phase A2):

1. **P1** — `_phase-agent-template`'s corrected `PLUGIN_ROOT` resolver was never propagated to the runnable phase skills that carry the CTL-615 duplicate-worker yield gate. `phase-implement` and `phase-remediate` (and `recovery-pass`, found via audit) still had the old `$BASH_SOURCE`/`$0` fallback, which resolves to a bogus path in a bash command block — silently disabling the yield gate. Propagated the fix to all three. Audited the remaining 8 runnable `phase-*` skills: none of them carry the yield gate, so they're unaffected by this specific exposure.
2. **P2** — `catalystPluginRoot` (mjs) now rejects a nonexistent/non-directory `startDir` up front, matching the bash twin's `cd` failure semantics.
3. **P2** — the mjs wildcard glob expansion now follows symlinked marketplace/cache install directories, matching the bash twin's `ls -d`.
4. **P2** — `catalyst_dev_scripts`' marketplace/cache rungs (both twins) now walk candidates newest→oldest and take the first that validates, instead of validating only the single newest candidate — a partial/broken newest install no longer shadows a valid older one (this is what `register-thought.sh`'s `workflow-context.sh` lookup hit).

Closes out the 4 open review threads on #2946.

## Test plan

- [x] `catalyst-runtime-root.test.sh`: 24 → 28 passed, 0 failed
- [x] `catalyst-runtime-root.test.mjs`: 17 → 23 passed, 0 failed
- [x] `phase-agent-template.test.sh`: 19/19
- [x] `contract-doc-lint.test.sh`: 19/19
- [x] `orchestrate-comms-integration.test.sh`: 25/25
- [x] `recovery-pass-pr-not-merged.test.sh`: 5/5
- [x] `phase-implement-e2e.test.sh`: 172/172
- [x] `phase-goal-no-turn-caps.test.sh`: 10/10
- [x] `god-gather-classify.test.sh`: 12/12
- [x] `phase-agent-dispatch.test.sh`: 293/294 — the 1 failure (Test 38, worktree-recreate) reproduces identically on the unmodified merge-base commit, confirmed pre-existing/unrelated
- [x] `shellcheck -s bash` on both touched `.sh` files — only pre-existing info-level findings
- [x] `bash -n` clean on all 3 edited SKILL.md prelude blocks

🤖 Generated with [Claude Code](https://claude.com/claude-code)