### PR TITLE
chore(meta): CTL-1628 docs-truth batch — 10-phase corrections, coalescelabs.ai domain, cluster.json onboarding

### DIFF
--- a/docs/cluster-onboarding.md
+++ b/docs/cluster-onboarding.md
@@ -24,9 +24,10 @@ CATALYST_JOIN_GITHUB_TOKEN=<ghp_…> \
 config-merge → **doctor** (the CTL-1186 `catalyst-doctor` gate) → stack. It is
 idempotent — re-run after any failure and it resumes from the failed stage.
 
-**Result:** the node is provisioned and the stack is running under launchd, but the
-committed `.catalyst/hosts.json` is untouched, so it owns **zero tickets** (Stage-0
-SHADOW). Activation (adding it to the roster) is a deliberate later step — see
+**Result:** the node is provisioned and the stack is running under launchd, but its name
+has not been added to the committed roster (`cluster.json` `roster[]` in the private
+`catalyst-cluster` repo), so it owns **zero tickets** (Stage-0 SHADOW). Activation
+(adding it to the roster) is a deliberate later step — see
 [Activation](#activation-m2--future).
 
 ### Convenience wrapper (seed-driven)
@@ -110,7 +111,7 @@ Runs the final join stages:
 - ✅ Catalyst stack running (auto-restart on reboot)
 - ✅ Thoughts synced (all 3 orgs verified)
 - ✅ Local roster entry created (mini-2 registered locally)
-- ❌ Committed roster untouched (`hosts.json` still `["mini"]`) — node owns zero tickets
+- ❌ Committed roster untouched (`cluster.json` `roster[]` in `catalyst-cluster` still excludes it) — node owns zero tickets
 
 ### Phase 5: Verification
 
@@ -130,13 +131,17 @@ Check the onboard script's verification output:
 
 To activate mini-2 and begin accepting work:
 
-1. **Add to committed roster:**
+1. **Add to committed roster:** in the private `catalyst-cluster` repo, add the node's name to
+   `cluster.json` `roster[]` and push:
    ```bash
-   cd ~/catalyst
-   jq '.hosts += ["mini-2"]' .catalyst/hosts.json > /tmp/hosts.json && mv /tmp/hosts.json .catalyst/hosts.json
-   git add .catalyst/hosts.json && git commit -m "feat: activate mini-2 to cluster roster (CTL-1217)"
+   # in the catalyst-cluster repo
+   jq '.roster += ["mini-2"]' cluster.json > /tmp/cluster.json && mv /tmp/cluster.json cluster.json
+   git add cluster.json && git commit -m "feat: activate mini-2 to cluster roster (CTL-1217)"
    git push
    ```
+   `cluster-sync` pulls the update on every node and the next scheduler tick honors it — no restart
+   needed. See the [config-mirror contract](../website/src/content/docs/reference/cluster-config-mirror.md)
+   for the full SHARED/PER-NODE classification.
 
 2. **Verify all nodes pull the update:**
    ```bash
@@ -311,7 +316,8 @@ catalyst-stack install-services
 - **Node user:** local system user (ryan on mini, ryan on mini-2, etc.)
 - **HumanLayer global fallback:** `coalesce-labs` (primary org, never groundworkapp)
 - **Worktree location:** `~/catalyst/wt/catalyst-workspace/` (not ~/conductor)
-- **SHADOW mode:** nodes own zero tickets until added to committed `hosts.json`
+- **SHADOW mode:** nodes own zero tickets until added to the committed `cluster.json` `roster[]` in
+  the private `catalyst-cluster` repo
 
 ## Related Tickets
 

--- a/docs/schemas/catalyst-config.schema.json
+++ b/docs/schemas/catalyst-config.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "https://catalyst.coalesce-labs.com/schemas/catalyst-config.schema.json",
+  "$id": "https://catalyst.coalescelabs.ai/schemas/catalyst-config.schema.json",
   "title": "Catalyst Project Config",
   "description": "Schema for .catalyst/config.json — the Layer-1 project config committed to the repository. Contains team-wide settings safe to share. Secrets and host-specific overrides belong in the Layer-2 machine config (~/.config/catalyst/config.json).",
   "type": "object",

--- a/docs/schemas/machine-config.schema.json
+++ b/docs/schemas/machine-config.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "https://catalyst.coalesce-labs.com/schemas/machine-config.schema.json",
+  "$id": "https://catalyst.coalescelabs.ai/schemas/machine-config.schema.json",
   "title": "Catalyst Machine Config",
   "description": "Schema for ~/.config/catalyst/config.json — the Layer-2 machine-local config. Contains host-specific secrets, concurrency overrides, and webhook registration data. NEVER commit this file to version control.",
   "type": "object",

--- a/docs/schemas/phase-signal.schema.json
+++ b/docs/schemas/phase-signal.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "https://catalyst.coalesce-labs.com/schemas/phase-signal.schema.json",
+  "$id": "https://catalyst.coalescelabs.ai/schemas/phase-signal.schema.json",
   "title": "Phase Signal File",
   "description": "Schema for ~/catalyst/execution-core/workers/{TICKET}/phase-{name}.json — the per-phase coordination file written by the execution-core daemon and updated by phase-agent workers. The daemon dispatches work by writing this file; the phase-agent worker updates it (status, bg_job_id) as it runs; the daemon reads it to determine when to advance to the next phase.",
   "type": "object",

--- a/docs/schemas/registry.schema.json
+++ b/docs/schemas/registry.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "https://catalyst.coalesce-labs.com/schemas/registry.schema.json",
+  "$id": "https://catalyst.coalescelabs.ai/schemas/registry.schema.json",
   "title": "Execution-Core Registry",
   "description": "Schema for ~/catalyst/execution-core/registry.json — the per-project enrollment records read by the execution-core daemon scheduler. Each entry tells the daemon which Linear team and git repository constitute a 'project', and what Linear state to use when querying for eligible tickets. This file supersedes the deprecated catalyst.orchestration.executionCore.eligibleQuery field in .catalyst/config.json.",
   "type": "object",

--- a/docs/schemas/state-json-contract.schema.json
+++ b/docs/schemas/state-json-contract.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "https://catalyst.coalesce-labs.com/schemas/state-json-contract.schema.json",
+  "$id": "https://catalyst.coalescelabs.ai/schemas/state-json-contract.schema.json",
   "title": "Claude Code Job State File (External Contract)",
   "$comment": "EXTERNAL: this file is written by Claude Code, not Catalyst. Catalyst reads it read-only. This schema documents the fields Catalyst depends on. The authoritative source of truth for this file's shape is the Claude Code application itself. Field names and semantics may change across Claude Code versions. Catalyst currently handles both the >=2.x form (resumeSessionId) and the <2.x form (linkScanPath) as a fallback.",
   "description": "Schema documenting the fields Catalyst reads from ~/.claude/jobs/{bg_job_id}/state.json. This file is owned and written exclusively by Claude Code. Catalyst reads it read-only for session continuation and job liveness probes. Do NOT write to or delete this file from Catalyst code.",

--- a/plugins/dev/skills/phase-plan/SKILL.md
+++ b/plugins/dev/skills/phase-plan/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: phase-plan
 description: |
-  Phase agent for the plan step of the 9-phase orchestrator pipeline (CTL-450).
+  Phase agent for the plan step of the 10-phase orchestrator pipeline (CTL-450).
   Wraps /catalyst-dev:create-plan and produces
   thoughts/shared/plans/<date>-<ticket>.md, then emits phase.plan.complete.<ticket>.
   Reads the prior research document from thoughts/shared/research/ as its

--- a/plugins/dev/skills/phase-research/SKILL.md
+++ b/plugins/dev/skills/phase-research/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: phase-research
 description: |
-  Phase agent for the research step of the 9-phase orchestrator pipeline (CTL-450).
+  Phase agent for the research step of the 10-phase orchestrator pipeline (CTL-450).
   Wraps /catalyst-dev:research-codebase and produces
   thoughts/shared/research/<date>-<ticket>.md, then emits phase.research.complete.<ticket>.
   Reads triage.json from the worker dir as its prior-phase artifact.

--- a/plugins/dev/skills/phase-review/SKILL.md
+++ b/plugins/dev/skills/phase-review/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: phase-review
 description: |
-  Phase agent for the review step of the 9-phase orchestrator pipeline (CTL-450).
+  Phase agent for the review step of the 10-phase orchestrator pipeline (CTL-450).
   Wraps the /review skill (gstack) — explicitly skips /ultrareview per user decision.
   Reads verify.json from the prior phase, runs /review against the diff, writes
   ${ORCH_DIR}/workers/<TICKET>/review.json, and creates a remediation commit for

--- a/plugins/dev/skills/phase-verify/SKILL.md
+++ b/plugins/dev/skills/phase-verify/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: phase-verify
 description: |
-  Phase agent for the verify step of the 9-phase orchestrator pipeline (CTL-450).
+  Phase agent for the verify step of the 10-phase orchestrator pipeline (CTL-450).
   NEW skill — has no canonical wrapper. Runs read-only adversarial verification
   against the implement-phase diff: tsc, tests, lint, security scan, reward-hacking
   scan, code review, test coverage, silent-failure hunt. Writes

--- a/plugins/dev/skills/recovery-pass/SKILL.md
+++ b/plugins/dev/skills/recovery-pass/SKILL.md
@@ -335,9 +335,9 @@ a CONTEXT item — that node owns it, and acting would cause cross-host
 double-action. Reconstruct + fix only the YOURS items; read CONTEXT items for
 context. At N=1 every item is YOURS.
 
-**The pipeline model.** Catalyst ships work through a 9-phase pipeline — triage →
+**The pipeline model.** Catalyst ships work through a 10-phase pipeline — triage →
 research → plan → implement → verify → review → pr → monitor-merge →
-monitor-deploy. Each phase runs as one short-lived `claude --bg` worker. A worker
+monitor-deploy → teardown. Each phase runs as one short-lived `claude --bg` worker. A worker
 writes its state to a signal file at `${ORCH_DIR}/workers/<ticket>/phase-*.json`
 (`status`, `failureReason`, `bg_job_id`). A ticket is "stuck" when a phase signal
 sits at `needs-human`/`failed`/`stalled`, or its worker died with the signal frozen.

--- a/plugins/dev/templates/config.template.json
+++ b/plugins/dev/templates/config.template.json
@@ -59,7 +59,7 @@
       "mode": "single-host"
     },
     "orchestration": {
-      "_comment": "Worker dispatch mode. 'phase-agents' (default) dispatches the 9-phase pipeline on claude --bg; 'oneshot-legacy' keeps the pre-CTL-452 single-shot oneshot worker on claude -p.",
+      "_comment": "Worker dispatch mode. 'phase-agents' (default) dispatches the 10-phase pipeline on claude --bg; 'oneshot-legacy' keeps the pre-CTL-452 single-shot oneshot worker on claude -p.",
       "dispatchMode": "phase-agents",
       "executionCore": {
         "_comment": "Execution-core scheduler worker-slot ceiling (CTL-665). maxParallel is the committed source of truth (~/catalyst/execution-core/state.json is an optional runtime fallback consulted only when this is absent). minParallel/maxParallelCeiling clamp the resolved value — bounds for the future adaptive-concurrency feature. Default stays 4; the operator bump to 10 is gated on CTL-661/662/663. NOTE: eligibleQuery is intentionally NOT here — it lives centrally in registry.json (CTL-582 D4); only these concurrency knobs are templated.",

--- a/plugins/foundry/skills/setup-catalyst/SKILL.md
+++ b/plugins/foundry/skills/setup-catalyst/SKILL.md
@@ -155,7 +155,7 @@ fetch for every `--full` repo (CTL-722: not gated on `dispatchMode` any more).
 That step delegates to the standalone
 `plugins/dev/scripts/setup-execution-core-states.sh`, which ensures the team's
 contract workflow states exist (`Todo` + `Research`, `Plan`, `Implement`,
-`Validate`, `PR`; `Triage` already exists), writes the 9-phase → 5-state
+`Validate`, `PR`; `Triage` already exists), writes the 10-phase → 5-state
 collapse `stateMap` (idempotent — preserves user-customised maps), refreshes
 `stateIds`, and upserts the team's entry in the central
 `~/catalyst/execution-core/registry.json`. A Linear-permission failure in

--- a/plugins/legacy/skills/oneshot/SKILL.md
+++ b/plugins/legacy/skills/oneshot/SKILL.md
@@ -24,7 +24,7 @@ provides persistent handoff documents between phases.
 > `catalyst.orchestration.dispatchMode` to `"phase-agents"` in `.catalyst/config.json`, which runs
 > nine short-lived `claude --bg` skills (`phase-triage` … `phase-monitor-deploy`) instead of one
 > long `claude -p` `oneshot` worker. See
-> [Phase agents](https://catalyst.coalesce-labs.com/reference/orchestration/phase-agents/) for the
+> [Phase agents](https://catalyst.coalescelabs.ai/reference/orchestration/phase-agents/) for the
 > pipeline, model assignment, and cost economics.
 
 ## Prerequisites

--- a/plugins/legacy/skills/orchestrate/SKILL.md
+++ b/plugins/legacy/skills/orchestrate/SKILL.md
@@ -21,7 +21,7 @@ coordinates, monitors, and verifies.
 > phase skills (`phase-triage` … `phase-monitor-deploy`) per ticket, advancing on
 > `phase.<name>.complete.<ticket>` broker events. The phase-agents mode is the post-2026-06-15 path
 > that keeps worker dispatch on the subscription pool. See
-> [Phase agents](https://catalyst.coalesce-labs.com/reference/orchestration/phase-agents/) for the
+> [Phase agents](https://catalyst.coalescelabs.ai/reference/orchestration/phase-agents/) for the
 > pipeline, model assignment, cost economics, and the end-to-end runbook.
 
 ## Prerequisites
@@ -636,7 +636,7 @@ healthcheck:
 # CTL-452: --config gates the dispatch mode. With dispatchMode = "phase-agents",
 # the dispatcher launches phase-triage agents on `claude --bg` (subscription pool)
 # via `phase-agent-dispatch`, and the wake handler in this Phase 4 advances each
-# worker through the 9-phase sequence. With dispatchMode = "oneshot-legacy" or
+# worker through the 10-phase sequence. With dispatchMode = "oneshot-legacy" or
 # no --config, the dispatcher uses the legacy `-p oneshot` worker (one long
 # claude session per ticket). Phase advancement calls always pass explicit
 # `--phase <name> --ticket <T>` and bypass the dispatchMode default.
@@ -658,7 +658,7 @@ as reference for the underlying machinery.
   --ticket "${TICKET}" \
   --completed-phase "${COMPLETED_PHASE}"
 # Emits one-line JSON: {"advanced": true|false, "fromPhase": "<name>", "toPhase": "<next>|null", ...}
-# The helper resolves the next phase via the canonical 9-phase sequence,
+# The helper resolves the next phase via the canonical 10-phase sequence,
 # refuses to double-dispatch (idempotent), and delegates to dispatch-next
 # with --phase <next> --ticket <T>. If `completed-phase = monitor-deploy`,
 # the ticket has reached the terminal phase and no further advance happens.
@@ -980,7 +980,7 @@ The helper emits four deterministic interests (route without Groq):
 - `phase_lifecycle` (CTL-452, CTL-484, CTL-512) — `phase.<name>.complete.<TICKET>`,
   `phase.<name>.failed.<TICKET>`, `phase.<name>.turn-cap-exhausted.<TICKET>`, and
   `phase.<name>.skipped.<TICKET>` events emitted by phase agents. One interest per active ticket,
-  covering all 9 phase names. The turn-cap status routes through `orchestrate-revive`'s continuation
+  covering all 10 phase names. The turn-cap status routes through `orchestrate-revive`'s continuation
   branch (separate budget from error revives). The skipped status (CTL-512, monitor-deploy
   terminal-no-deploy) routes the same as complete via `orchestrate-phase-advance` — advance no-ops
   on monitor-deploy, so the wake's purpose is to free the wave slot via the scheduler's in-flight
@@ -1172,7 +1172,7 @@ scan so the response stays proportional. Every reaction reads authoritative stat
 | `github.deployment*`                                                                            | Record deploy outcome on the worker's signal file                                                                                                                                                                                                                                                                                                                                                                                                                         |
 | `linear.issue.state_changed`                                                                    | Reconcile Linear state with the worker signal                                                                                                                                                                                                                                                                                                                                                                                                                             |
 | `filter.wake.${ORCH_NAME}` (matched on full dotted `event.name`)                                | Daemon-filtered semantic wake: read `.body.payload.reason` for log context, then run the full reactive scan. The reason describes what triggered the daemon (e.g., "CI failed on PR #416") but is never the authoritative source                                                                                                                                                                                                                                          |
-| `phase.<name>.complete.<TICKET>` (via phase_lifecycle, CTL-452)                                 | Resolve the next phase via `orchestrate-phase-advance --ticket <T> --completed-phase <name>`; that helper looks up the next phase in the canonical 9-phase sequence and calls `orchestrate-dispatch-next --phase <next> --ticket <T>`. If `completed-phase=monitor-deploy`, no advance (terminal). The advance is idempotent under redundant wakes                                                                                                                        |
+| `phase.<name>.complete.<TICKET>` (via phase_lifecycle, CTL-452)                                 | Resolve the next phase via `orchestrate-phase-advance --ticket <T> --completed-phase <name>`; that helper looks up the next phase in the canonical 10-phase sequence and calls `orchestrate-dispatch-next --phase <next> --ticket <T>`. If `completed-phase=monitor-deploy`, no advance (terminal). The advance is idempotent under redundant wakes                                                                                                                        |
 | `phase.<name>.failed.<TICKET>` (via phase_lifecycle, CTL-452)                                   | Run `orchestrate-revive` once for the affected ticket; on the **second** failure (reviveCount ≥ MAX_REVIVES), mark worker `stalled` and post `attention` to the shared comms channel. Matches the existing one-retry-then-escalate handling for legacy oneshot workers                                                                                                                                                                                                    |
 | `phase.<name>.turn-cap-exhausted.<TICKET>` (via phase_lifecycle, CTL-484)                       | Run `orchestrate-revive` (same script — its continuation branch handles this status). The branch reads `handoffPath` from the per-phase signal, dispatches a `claude --bg --resume` continuation with `CATALYST_IS_CONTINUATION=true` + `CATALYST_HANDOFF_PATH` + `CATALYST_CONTINUATION_COUNT`, and bumps `.continuationCount` on a budget separate from `.reviveCount` (default 3). On budget exhaustion: `stalled` + `attentionReason="continuation-budget-exhausted"` |
 | `phase.<name>.skipped.<TICKET>` (via phase_lifecycle, CTL-512)                                   | Same as `complete`: resolve via `orchestrate-phase-advance --ticket <T> --completed-phase <name>`. Only emitted by `phase-monitor-deploy` when no `deployment_status` event arrived before `PHASE_DEPLOY_TIMEOUT_SEC`. Because `completed-phase=monitor-deploy`, the advance no-ops (terminal); the wake's purpose is to free the wave slot via the scheduler's in-flight predicate (`scheduler.mjs:isTicketInFlight`)                                                                                                                                                                       |


### PR DESCRIPTION
## Summary

CTL-1628 Phase B PR 7 — the batched mechanical docs-truth fixes (trivial only; the two needs-decision items are deliberately excluded as CTL-1629/CTL-1632):

- **9→10-phase corrections** (10 hits, 8 files): phase-plan/research/verify/review SKILL.md frontmatter (user-visible in skill listings), recovery-pass (incl. restoring the truncated `→ teardown` in the arrow chain), foundry setup-catalyst, config.template.json, and the 4 exact legacy-orchestrate line edits. Repo-wide re-grep: zero remaining current-pipeline "9-phase" references.
- **Dead docs domain**: `catalyst.coalesce-labs.com` → `catalyst.coalescelabs.ai` in 5 schema `$id` fields + 2 legacy skill references. The `hello@coalesce-labs.com` plugin.json emails are deliberately untouched (org email domain, not the dead docs subdomain).
- **docs/cluster-onboarding.md**: 4 locations still instructed enrollment via retired `.catalyst/hosts.json`; now point at the real mechanism (cluster.json roster in the private catalyst-cluster repo, per the cluster-config-mirror contract; CTL-1274 retirement). Zero hosts.json references remain in the file.

Lands after #2959 so docs and fence code agree.

## Verification

The SKILL.md source-text trap suite (orchestrate-comms-integration) 25/25 and ctl-764-docs 14/14, both exit 0 on my direct re-run; 16 suites total green per-file including all four phase e2e suites and the three catalyst-legacy pins (the 2 legacy-plugin version fails are pre-existing, stash-verified — that test pins 1.0.0 while the plugin is at 2.1.0); all edited JSON jq-valid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)