### PR TITLE
fix(dev): CTL-1628 A1 multiline-tolerant jq-less packageManager sniff (Codex #2948 post-merge)

### DIFF
--- a/plugins/dev/scripts/create-worktree.sh
+++ b/plugins/dev/scripts/create-worktree.sh
@@ -472,9 +472,21 @@ else
 		# prefix check this needs, and it degrades to the same lock-file-only
 		# detection (HAS_BUN_LOCK, no jq involved) in the worst case rather than
 		# ever crashing the script.
+		#
+		# CTL-1628 post-merge (Codex #2948, round 6): the fallback grep was
+		# line-oriented, so valid JSON that splits "packageManager", the colon,
+		# or "bun@..." across lines (pretty-printed with one token per line,
+		# multi-line formatting from some generators, etc.) missed a genuine
+		# bun-only project and fell through to npm. `tr -d '[:space:]'` collapses
+		# all whitespace — including newlines — before the substring match, so
+		# formatting no longer matters. Stripping whitespace can corrupt string
+		# *values* elsewhere in the file, but this fallback never reads those
+		# values back — it only tests whether this one substring exists —
+		# so that's harmless here. Still dependency-free (tr is as universal
+		# as grep).
 		if command -v jq >/dev/null 2>&1; then
 			PACKAGE_MANAGER_FIELD=$(jq -r '.packageManager // empty' package.json 2>/dev/null)
-		elif grep -qE '"packageManager"[[:space:]]*:[[:space:]]*"bun@' package.json 2>/dev/null; then
+		elif tr -d '[:space:]' <package.json 2>/dev/null | grep -q '"packageManager":"bun@'; then
 			PACKAGE_MANAGER_FIELD="bun@detected"
 		else
 			PACKAGE_MANAGER_FIELD=""


### PR DESCRIPTION
## Summary

Codex flagged a post-merge P2 on #2948: the jq-less fallback for sniffing bun evidence from package.json's `"packageManager"` field was line-oriented, so valid JSON that splits the key, colon, and `"bun@..."` value across multiple lines (pretty-printed with one token per line, some generators, manual formatting) would miss it entirely on a host without jq — falling through to npm and writing `package-lock.json` debris into a bun-managed tree.

Fixed by collapsing all whitespace (including newlines) out of `package.json` with `tr -d '[:space:]'` before the substring match against `"packageManager":"bun@` — formatting no longer matters, and the fallback stays dependency-free (`tr` is exactly as universal as `grep`, no new tooling requirement).

## Test plan

- [x] Reproduced the miss directly: built a real, `python3 -m json.tool`-parseable JSON file with `"packageManager"` split across three lines — the old line-oriented grep pattern missed it, confirmed before applying the fix.
- [x] New scenario K: a genuinely jq-absent PATH (grep/git/npm/bun/bash/tr symlinked into a scratch bin dir, jq deliberately omitted) against that same multiline package.json, bun present on PATH → correctly took the bun install path with zero `package-lock.json` written.
- [x] Re-verified prior scenarios (jq-absent + no bun evidence → npm path; jq-present + single-line `packageManager` → skip when bun absent) still behave identically.
- [x] `bash -n` clean; `shellcheck -x` shows the same 3 pre-existing findings as before this change, zero new.
- [x] `create-worktree-guard.test.sh` 10/10, `create-worktree-expected-branch.test.sh` 6/6, plus the full `create-worktree` suite set — all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)