### PR TITLE
fix(dev): CTL-1628 ADR-026 precision + daemon comment-wake transition-event dispositions (Codex #2961 post-merge)

### DIFF
--- a/docs/adrs.md
+++ b/docs/adrs.md
@@ -531,20 +531,31 @@ implemented** anywhere, live path or otherwise — no schema, no writer, no brok
 the codebase. CTL-1628 removed the retired module as consumer-free.
 
 **The chokepoint is not the only `worker.transition` emitter.** The daemon's `handleCommentWake`
-(CTL-768, `execution-core/daemon.mjs`) calls `appendWorkerTransitionEvent` directly at two sites —
-clearing a stale `needs-human` marker on human reply, and clearing `needs-input` after a
-comment-driven wake — bypassing `recordTransition` entirely; its own code comment explains why:
-"scheduler.mjs owns the park/apply emission; the clear is emitted here (the daemon removes the
-durable label out-of-band and redispatches — the scheduler never observes this edge)." This is a
-deliberate, self-documented second producer.
+(CTL-768, `execution-core/daemon.mjs`) calls `appendWorkerTransitionEvent` directly at two
+structurally distinct sites, both bypassing `recordTransition` but for different reasons:
+- The **`needs-input` clear** (a per-signal branch gated on `status === "needs-input"`) removes the
+  label, emits the clear, and redispatches the parked worker in the same block. Its own code comment
+  explains the bypass: "scheduler.mjs owns the park/apply emission; the clear is emitted here (the
+  daemon removes the durable label out-of-band and redispatches — the scheduler never observes this
+  edge)."
+- The **`needs-human` clear** runs once per comment-wake call, gated on positive human provenance
+  and a managed ticket, with **no redispatch** in that block. It bypasses `recordTransition` because
+  the scheduler's own needs-human handling is STICKY-by-design (never clears it itself on a
+  steady-state admission pass, per the `recordTransition` suppression logic above) — the
+  "redispatches" half of the quoted rationale does not apply to this site.
 
-**A separate escalation path emits no `worker.transition` at all.** Pass 0w's hung-worker escalation
-(`killHungWorker` in `watchdog-action.mjs`, invoked from `scheduler.mjs`'s progress-watchdog pass)
-applies the `needs-human` label via `labelNeedsHumanUnlessBeliefOwner` (`label-guard.mjs`) but never
-calls `recordTransition`, `appendWorkerTransitionEvent`, or any other event emitter anywhere in that
-path — a real Axis-2 transition with no `worker.transition` record. Unlike the daemon's comment-wake
-sites above, this is a genuine coverage gap, not an alternate producer. See "Two-axis worker state &
-the recordWorkerTransition chokepoint (CTL-764)" in `docs/architecture.md` for the live mechanism.
+Both are deliberate, self-documented second-producer sites.
+
+**A separate escalation path emits no `worker.transition` for its disposition change.** Pass 0w's
+hung-worker escalation (`killHungWorker` in `watchdog-action.mjs`, invoked from `scheduler.mjs`'s
+progress-watchdog pass) does emit `phase.terminal.reap-requested` (via `emitReapIntent`, when
+`bgJobId` exists) for the kill/reap side of the sequence — that part of the path is observable. But
+it applies the `needs-human` label via `labelNeedsHumanUnlessBeliefOwner` (`label-guard.mjs`) and
+never calls `recordTransition`, `appendWorkerTransitionEvent`, or any other `worker.transition`
+emitter anywhere in that path — a real Axis-2 transition with no `worker.transition` record. Unlike
+the daemon's comment-wake sites above, this is a genuine coverage gap in the transition stream
+specifically, not an alternate producer. See "Two-axis worker state & the recordWorkerTransition
+chokepoint (CTL-764)" in `docs/architecture.md` for the live mechanism.
 
 **Two orthogonal axes (never blurred):**
 
@@ -577,8 +588,16 @@ merged axes into a single status enum (rejected: pipeline stage and disposition 
 both need independent observability); async `recordWorkerTransition` only (rejected: `schedulerTick`
 is sync; async would require a separate flush loop with new failure modes).
 
-**Consequences** — every scheduler-owned transition fans out to four **live** sinks (Linear Status,
-label, event log, OTLP via otel-forward); all fail-open. A fifth sink (an optional broker
+**Consequences** — four sinks are **live** (Linear Status, label, event log, OTLP via otel-forward);
+all fail-open. No single transition reaches all four — each recordTransition call is either
+stage-only or disposition-only (`toDisposition === undefined` means "no disposition guard, always
+emit" for a pure stage move; omitting `toStage`/`fromStage` means no Linear-Status write for a pure
+disposition move), so a transition reaches at most three: a stage move touches Linear Status + event
+log + OTLP (skips the label sink); a disposition move touches the label + event log + OTLP (skips
+Linear Status) — e.g. the dependency-cycle escalation (`scheduler.mjs` ~5666-5678) calls
+`labelNeedsHumanUnlessBeliefOwner` (label) and `recordTransition({ toDisposition: "needs-human" })`
+(event log + OTLP) with no stage touched at all. Only a call that sets both `toStage` and
+`toDisposition` together would reach all four. A fifth sink (an optional broker
 `ticket_state_transitions` table, CTL-764 Phase 10) was designed but never implemented — no schema,
 writer, or broker consumer exist for it. The HUD capacity header gains per-disposition buckets and
 triage is carved out of `maxParallel` counting. AGENTS.md / architecture.md carry the two-axis model

--- a/docs/adrs.md
+++ b/docs/adrs.md
@@ -514,19 +514,29 @@ resolvable stalls consuming attention); leave re-engagement to the inference eng
 
 ## ADR-026: Two-Axis Worker State Model + worker-status Label Group (CTL-764)
 
-**Decision** — all worker state transitions are consolidated behind a single chokepoint and a
-workspace-scoped, single-valued `worker-status` Linear label group carrying worker _disposition_
-independently of _pipeline stage_. The live chokepoint is the **inline `recordTransition`** function
-inside `scheduler.mjs`'s `schedulerTick` — not the standalone `recordWorkerTransition` module
-(`record-worker-transition.mjs`) named in this ADR's original design: that module's own doc comment
-declared only three of the eventual five sinks (Sink 1 Linear workflow status via `applyPhaseStatus`,
-Sink 2 the disposition label via `convergeLabel`, Sink 3 the unified event log via
-`appendWorkerTransitionEvent`) and flagged itself as unfinished — "Phase 5 will wire the production
-defaults... and route all call sites here." That Phase 5 wiring never happened; the scheduler's live
-path never called the module, and OTLP forwarding (sink 4) and the broker `ticket_state_transitions`
-table (sink 5) were added directly to the live inline path, never retrofitted into it. CTL-1628
-removed it as consumer-free. See "Two-axis worker state & the recordWorkerTransition chokepoint
-(CTL-764)" in `docs/architecture.md` for the live mechanism.
+**Decision** — all **scheduler-owned** worker state transitions are consolidated behind a single
+chokepoint and a workspace-scoped, single-valued `worker-status` Linear label group carrying worker
+_disposition_ independently of _pipeline stage_. The live chokepoint is the **inline
+`recordTransition`** function inside `scheduler.mjs`'s `schedulerTick` — not the standalone
+`recordWorkerTransition` module (`record-worker-transition.mjs`) named in this ADR's original
+design: that module's own doc comment declared only three of the eventual five sinks (Sink 1 Linear
+workflow status via `applyPhaseStatus`, Sink 2 the disposition label via `convergeLabel`, Sink 3 the
+unified event log via `appendWorkerTransitionEvent`) and flagged itself as unfinished — "Phase 5 will
+wire the production defaults... and route all call sites here." That Phase 5 wiring never happened;
+the scheduler's live path never called the module. Of the two sinks the module never reached, only
+sink 4 (OTLP via `otel-forward`) is actually live — it rides automatically on sink 3's event-log
+write. Sink 5 (a broker `ticket_state_transitions` table, CTL-764 Phase 10) was **never
+implemented** anywhere, live path or otherwise — no schema, no writer, no broker consumer exist in
+the codebase. CTL-1628 removed the retired module as consumer-free.
+
+**The chokepoint is not the only `worker.transition` emitter.** The daemon's `handleCommentWake`
+(CTL-768, `execution-core/daemon.mjs`) calls `appendWorkerTransitionEvent` directly at two sites —
+clearing a stale `needs-human` marker on human reply, and clearing `needs-input` after a
+comment-driven wake — bypassing `recordTransition` entirely; its own code comment explains why:
+"scheduler.mjs owns the park/apply emission; the clear is emitted here (the daemon removes the
+durable label out-of-band and redispatches — the scheduler never observes this edge)." This is a
+deliberate, self-documented second producer. See "Two-axis worker state & the recordWorkerTransition
+chokepoint (CTL-764)" in `docs/architecture.md` for the live mechanism.
 
 **Two orthogonal axes (never blurred):**
 

--- a/docs/adrs.md
+++ b/docs/adrs.md
@@ -569,11 +569,16 @@ is always readable regardless of which team's ticket is in flight. Exclusive gro
 single-value; the daemon removes stale members before applying a new one.
 
 **Precedence** — `needs-human > needs-input > blocked > queued > none`. `needs-human` is sticky
-(applied by `labelOnce`, NOT tick-converged) and cleared only at explicit resolution (Done or
-terminal-sweep). `queued`/`blocked`/`needs-input` are tick-converged (re-derived on diff each tick).
+(applied by `labelOnce`, NOT tick-converged) and cleared only at explicit resolution.
+`queued`/`blocked`/`needs-input` are tick-converged (re-derived on diff each tick).
 
-**Resolution-gated clearing** — `clearStalledLabel`'s `onRemoved` callback fires only on confirmed
-Linear label removal, preventing false-positive "cleared" events on API failures.
+**Resolution-gated clearing — TWO removal paths (Codex #2970 round 5).** `needs-human` is removed
+only by an explicit, confirmed-removal signal, and there are two: (1) `clearStalledLabel`'s
+`onRemoved` callback, fired only on confirmed Linear label removal at scheduler-side resolution
+points (Done / terminal-sweep / no-stall-clear), preventing false-positive "cleared" events on API
+failures; and (2) the daemon's `handleCommentWake` needs-human clear on a managed ticket's confirmed
+human reply — a write-gated, emission-carrying removal via `removeLabel` directly (not
+`clearStalledLabel`), documented in the producer-split paragraph above.
 
 **`waiting` → `queued` rename** — the prior `waiting` label was renamed to `queued` to align with
 the disposition vocabulary. Back-compat: legacy `waiting` labels map to `queued` in the HUD and

--- a/docs/adrs.md
+++ b/docs/adrs.md
@@ -514,9 +514,10 @@ resolvable stalls consuming attention); leave re-engagement to the inference eng
 
 ## ADR-026: Two-Axis Worker State Model + worker-status Label Group (CTL-764)
 
-**Decision** — all **scheduler-owned** worker state transitions are consolidated behind a single
-chokepoint and a workspace-scoped, single-valued `worker-status` Linear label group carrying worker
-_disposition_ independently of _pipeline stage_. The live chokepoint is the **inline
+**Decision** — worker state transitions **that the scheduler records** are consolidated behind a
+single chokepoint and a workspace-scoped, single-valued `worker-status` Linear label group carrying
+worker _disposition_ independently of _pipeline stage_ (known gaps in that coverage are listed
+below). The live chokepoint is the **inline
 `recordTransition`** function inside `scheduler.mjs`'s `schedulerTick` — not the standalone
 `recordWorkerTransition` module (`record-worker-transition.mjs`) named in this ADR's original
 design: that module's own doc comment declared only three of the eventual five sinks (Sink 1 Linear
@@ -535,8 +536,15 @@ clearing a stale `needs-human` marker on human reply, and clearing `needs-input`
 comment-driven wake — bypassing `recordTransition` entirely; its own code comment explains why:
 "scheduler.mjs owns the park/apply emission; the clear is emitted here (the daemon removes the
 durable label out-of-band and redispatches — the scheduler never observes this edge)." This is a
-deliberate, self-documented second producer. See "Two-axis worker state & the recordWorkerTransition
-chokepoint (CTL-764)" in `docs/architecture.md` for the live mechanism.
+deliberate, self-documented second producer.
+
+**A separate escalation path emits no `worker.transition` at all.** Pass 0w's hung-worker escalation
+(`killHungWorker` in `watchdog-action.mjs`, invoked from `scheduler.mjs`'s progress-watchdog pass)
+applies the `needs-human` label via `labelNeedsHumanUnlessBeliefOwner` (`label-guard.mjs`) but never
+calls `recordTransition`, `appendWorkerTransitionEvent`, or any other event emitter anywhere in that
+path — a real Axis-2 transition with no `worker.transition` record. Unlike the daemon's comment-wake
+sites above, this is a genuine coverage gap, not an alternate producer. See "Two-axis worker state &
+the recordWorkerTransition chokepoint (CTL-764)" in `docs/architecture.md` for the live mechanism.
 
 **Two orthogonal axes (never blurred):**
 
@@ -569,10 +577,12 @@ merged axes into a single status enum (rejected: pipeline stage and disposition 
 both need independent observability); async `recordWorkerTransition` only (rejected: `schedulerTick`
 is sync; async would require a separate flush loop with new failure modes).
 
-**Consequences** — every transition fans out to five sinks (Linear Status, label, event log, OTLP
-via otel-forward, optional broker table); all fail-open. The HUD capacity header gains
-per-disposition buckets and triage is carved out of `maxParallel` counting. AGENTS.md /
-architecture.md carry the two-axis model as first-class concepts.
+**Consequences** — every scheduler-owned transition fans out to four **live** sinks (Linear Status,
+label, event log, OTLP via otel-forward); all fail-open. A fifth sink (an optional broker
+`ticket_state_transitions` table, CTL-764 Phase 10) was designed but never implemented — no schema,
+writer, or broker consumer exist for it. The HUD capacity header gains per-disposition buckets and
+triage is carved out of `maxParallel` counting. AGENTS.md / architecture.md carry the two-axis model
+as first-class concepts.
 
 ## ADR-027: Browser automation stays local — cloud browser backends rejected (2026-07-25)
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -447,19 +447,31 @@ transition (not fanned out from inside the chokepoint): (1) Linear Status via th
 
 **The scheduler chokepoint is not the only `worker.transition` emitter.** The daemon's
 `handleCommentWake` (CTL-768, `execution-core/daemon.mjs`) calls `appendWorkerTransitionEvent`
-directly at two sites — clearing a stale `needs-human` marker on human reply, and clearing
-`needs-input` after a comment-driven wake — bypassing `recordTransition` entirely. Its own code
-comment says why: "scheduler.mjs owns the park/apply emission; the clear is emitted here (the daemon
-removes the durable label out-of-band and redispatches — the scheduler never observes this edge)."
-This is a deliberate, self-documented second producer, not a gap in the chokepoint design.
+directly at two structurally distinct sites, both bypassing `recordTransition` — but for different
+reasons, not one shared rationale:
+- The **`needs-input` clear** (a per-signal branch gated on `status === "needs-input"`) removes the
+  label, emits the clear, and then redispatches the parked worker in the same block. Its own code
+  comment explains the bypass: "scheduler.mjs owns the park/apply emission; the clear is emitted
+  here (the daemon removes the durable label out-of-band and redispatches — the scheduler never
+  observes this edge)."
+- The **`needs-human` clear** runs once per comment-wake call, gated on positive human provenance
+  and a managed ticket — before any per-signal / worker-dir lookup, and with **no redispatch** in
+  that block at all. It bypasses `recordTransition` for the same underlying reason (the scheduler's
+  own STICKY needs-human handling explicitly defers clearing to an external confirmed-removal
+  signal, never clearing it itself on a steady-state admission pass), but the "redispatches" half of
+  the quoted rationale above does not apply to this site.
 
-**A separate escalation path emits no `worker.transition` at all.** Pass 0w's hung-worker
-escalation (`killHungWorker` in `watchdog-action.mjs`, invoked from `scheduler.mjs`'s
-progress-watchdog pass) applies the `needs-human` label via `labelNeedsHumanUnlessBeliefOwner`
-(`label-guard.mjs`) but never calls `recordTransition`, `appendWorkerTransitionEvent`, or any other
-event emitter anywhere in that path — a real Axis-2 transition with no `worker.transition` record.
-Unlike the daemon's comment-wake sites above, this is a genuine coverage gap, not an alternate
-producer.
+Both are deliberate, self-documented second-producer sites, not a gap in the chokepoint design.
+
+**A separate escalation path emits no `worker.transition` for its disposition change.** Pass 0w's
+hung-worker escalation (`killHungWorker` in `watchdog-action.mjs`, invoked from `scheduler.mjs`'s
+progress-watchdog pass) does emit `phase.terminal.reap-requested` (via `emitReapIntent`, when
+`bgJobId` exists) for the kill/reap side of the sequence — that part of the path is observable. But
+it applies the `needs-human` label via `labelNeedsHumanUnlessBeliefOwner` (`label-guard.mjs`) and
+never calls `recordTransition`, `appendWorkerTransitionEvent`, or any other `worker.transition`
+emitter anywhere in that path — a real Axis-2 transition with no `worker.transition` record. Unlike
+the daemon's comment-wake sites above, this is a genuine coverage gap in the transition stream
+specifically, not an alternate producer.
 
 The standalone `recordWorkerTransition` module (`record-worker-transition.mjs`) — an extracted,
 unit-tested scaffold for sinks 1–3 only (Linear status, disposition label, event log) whose own doc

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -453,6 +453,14 @@ comment says why: "scheduler.mjs owns the park/apply emission; the clear is emit
 removes the durable label out-of-band and redispatches — the scheduler never observes this edge)."
 This is a deliberate, self-documented second producer, not a gap in the chokepoint design.
 
+**A separate escalation path emits no `worker.transition` at all.** Pass 0w's hung-worker
+escalation (`killHungWorker` in `watchdog-action.mjs`, invoked from `scheduler.mjs`'s
+progress-watchdog pass) applies the `needs-human` label via `labelNeedsHumanUnlessBeliefOwner`
+(`label-guard.mjs`) but never calls `recordTransition`, `appendWorkerTransitionEvent`, or any other
+event emitter anywhere in that path — a real Axis-2 transition with no `worker.transition` record.
+Unlike the daemon's comment-wake sites above, this is a genuine coverage gap, not an alternate
+producer.
+
 The standalone `recordWorkerTransition` module (`record-worker-transition.mjs`) — an extracted,
 unit-tested scaffold for sinks 1–3 only (Linear status, disposition label, event log) whose own doc
 comment flagged sinks 4–5 and full call-site wiring as unfinished ("Phase 5 will wire the production

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -429,25 +429,36 @@ at explicit resolution (Done or terminal-sweep-clear), not on steady-state ticks
 re-derived on every tick and applied/removed on diff; `needs-human` is removed only by
 `clearStalledLabel`'s `onRemoved` callback which fires only on confirmed Linear label removal.
 
-Worker transitions are recorded at the scheduler's transition sites, coordinated around a single
-**inline `recordTransition` chokepoint** inside `schedulerTick`. That chokepoint owns sink (3): it
-emits exactly one canonical `worker.transition.<TICKET>` event per genuine change to the unified
-event log, and the only-on-change guard (`lastDispositionEmit`) prevents double-emit on steady-state
-ticks. Its emitter defaults to `null` so a bare unit tick stays silent; **production threads the
-real emitter (`defaultAppendWorkerTransitionEvent`) via `runTick`** — without that wiring every
-`recordTransition` early-returns and the event stream is dark. That event feeds sink (4), OTLP via
-`otel-forward` (dims as attributes — `body.payload` is stripped off-machine). The remaining sinks
-are written at their own scheduler sites around the same transition (not fanned out from inside the
-chokepoint): (1) Linear Status via the `applyPhaseStatus` chokepoint (Axis 1), (2) the
-`worker-status` label via the admission converger (`convergeHeldLabel`) / `labelOnce` (Axis 2), and
-(5) the optional broker `ticket_state_transitions` table (CTL-764 Phase 10). The standalone
-`recordWorkerTransition` module (`record-worker-transition.mjs`) — an extracted, unit-tested scaffold
-for sinks 1–3 only (Linear status, disposition label, event log) whose own doc comment flagged sinks
-4–5 and full call-site wiring as unfinished ("Phase 5 will wire the production defaults... and route
-all call sites here") — never reached that Phase 5 and was retired as consumer-free (CTL-1628): the
-scheduler's live path has only ever used the inline `recordTransition` chokepoint described above,
-and sinks 4 (OTLP) and 5 (the broker table) were added directly to that live path, never retrofitted
-into the retired module. The analogous worker-state projection need (phase/status/PR/revive-count,
+Worker transitions **originating from the scheduler** are recorded at its transition sites,
+coordinated around a single **inline `recordTransition` chokepoint** inside `schedulerTick`. That
+chokepoint owns sink (3): it emits exactly one canonical `worker.transition.<TICKET>` event per
+genuine change to the unified event log, and the only-on-change guard (`lastDispositionEmit`)
+prevents double-emit on steady-state ticks. Its emitter defaults to `null` so a bare unit tick stays
+silent; **production threads the real emitter (`defaultAppendWorkerTransitionEvent`) via
+`runTick`** — without that wiring every `recordTransition` early-returns and the event stream is
+dark. That event feeds sink (4), OTLP via `otel-forward` (dims as attributes — `body.payload` is
+stripped off-machine) — the only other sink that's actually live. Sink (5), an optional broker
+`ticket_state_transitions` table (CTL-764 Phase 10), was **never implemented** — no schema, no
+writer, no broker consumer exist anywhere in the codebase; it remains a planned item, not a shipped
+one. The remaining scheduler-side sinks are written at their own scheduler sites around the same
+transition (not fanned out from inside the chokepoint): (1) Linear Status via the
+`applyPhaseStatus` chokepoint (Axis 1), (2) the `worker-status` label via the admission converger
+(`convergeHeldLabel`) / `labelOnce` (Axis 2).
+
+**The scheduler chokepoint is not the only `worker.transition` emitter.** The daemon's
+`handleCommentWake` (CTL-768, `execution-core/daemon.mjs`) calls `appendWorkerTransitionEvent`
+directly at two sites — clearing a stale `needs-human` marker on human reply, and clearing
+`needs-input` after a comment-driven wake — bypassing `recordTransition` entirely. Its own code
+comment says why: "scheduler.mjs owns the park/apply emission; the clear is emitted here (the daemon
+removes the durable label out-of-band and redispatches — the scheduler never observes this edge)."
+This is a deliberate, self-documented second producer, not a gap in the chokepoint design.
+
+The standalone `recordWorkerTransition` module (`record-worker-transition.mjs`) — an extracted,
+unit-tested scaffold for sinks 1–3 only (Linear status, disposition label, event log) whose own doc
+comment flagged sinks 4–5 and full call-site wiring as unfinished ("Phase 5 will wire the production
+defaults... and route all call sites here") — never reached that Phase 5 and was retired as
+consumer-free (CTL-1628): the scheduler's live path has only ever used the inline `recordTransition`
+chokepoint described above. The analogous worker-state projection need (phase/status/PR/revive-count,
 not disposition) is served live by the separate CTL-532 SQLite projection — see "Worker signal
 projection" above.
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -419,15 +419,26 @@ Every worker ticket has **two orthogonal axes** — never blurred:
   | `queued`      | converger (admission gate, tick-converged)          | pickup / Done                     |
   | `blocked`     | converger (dependency not terminal, tick-converged) | dep becomes terminal / Done       |
   | `needs-input` | daemon `handleCommentWake` (worker paused, CTL-768) | human reply                       |
-  | `needs-human` | `labelOnce` (sticky — NOT tick-converged)           | `clearStalledLabel` on resolution |
+  | `needs-human` | `labelOnce` (sticky — NOT tick-converged)           | two paths — see below             |
 
 **Precedence** (only one label at a time): `needs-human > needs-input > blocked > queued > none`.
 `needs-human` is **sticky** — it is never included in `TICK_CONVERGED_DISPOSITIONS` and only cleared
-at explicit resolution (Done or terminal-sweep-clear), not on steady-state ticks.
+at explicit resolution, not on steady-state ticks.
 
-**Resolution-gated clearing** — tick-converged labels (`queued`/`blocked`/`needs-input`) are
-re-derived on every tick and applied/removed on diff; `needs-human` is removed only by
-`clearStalledLabel`'s `onRemoved` callback which fires only on confirmed Linear label removal.
+**Resolution-gated clearing — TWO removal paths for `needs-human` (Codex #2970 round 5).**
+Tick-converged labels (`queued`/`blocked`/`needs-input`) are re-derived on every tick and
+applied/removed on diff. `needs-human` is different: it is removed only by an explicit,
+confirmed-removal signal, and there are two of those, not one:
+1. **`clearStalledLabel`'s `onRemoved` callback**, fired only on a confirmed Linear label removal at
+   scheduler-side resolution points (terminal-done-clear, terminal-sweep-clear, no-stall-clear).
+2. **The daemon's `handleCommentWake` needs-human clear** (CTL-1612/#2970) — a *write-gated*,
+   *emission-carrying* removal on a managed ticket's confirmed human reply. It calls `removeLabel`
+   directly (not `clearStalledLabel`), only treats the removal as genuine when the call performed a
+   real write (not a no-op re-check), emits the `worker.transition` clear itself
+   (`appendWorkerTransitionEvent`, bypassing `recordTransition`), and resets the scheduler's
+   in-process `lastDispositionEmit` dedup entry (`clearDispositionEmit`) so the shared chokepoint's
+   only-on-change guard doesn't swallow a later genuine re-escalation. See the producer-split
+   paragraph below for why this path exists separately from `clearStalledLabel`.
 
 Worker transitions **originating from the scheduler** are recorded at its transition sites,
 coordinated around a single **inline `recordTransition` chokepoint** inside `schedulerTick`. That

--- a/plugins/dev/references/event-schema.md
+++ b/plugins/dev/references/event-schema.md
@@ -663,11 +663,21 @@ emitting it during a mixed-version fleet rollout.
 
 Emitted by two producers: `recordTransition` in `scheduler.mjs` (the sync chokepoint for
 scheduler-owned transitions), and the daemon's `handleCommentWake` (CTL-768,
-`execution-core/daemon.mjs`), which calls `appendWorkerTransitionEvent` directly at two sites — the
-`needs-human`→cleared resolution on a human reply, and the `needs-input`→cleared resolution after a
-comment-driven wake — bypassing `recordTransition` because the scheduler never observes those edges
-(the daemon removes the durable label out-of-band and redispatches). Dims are **attributes** (not
-`body.payload`) because `otel-forward` strips `body.payload` before forwarding off-machine.
+`execution-core/daemon.mjs`), which calls `appendWorkerTransitionEvent` directly at two sites,
+bypassing `recordTransition` because the scheduler never observes these edges:
+- The `needs-human`→cleared resolution on a confirmed human reply to a managed ticket — emitted
+  unconditionally (not gated on a local worker dir/signal existing).
+- The `needs-input`→cleared resolution after a comment-driven wake — **only for signal-backed
+  wakes**: it fires from inside the per-signal loop over local `phase-*.json` files, which requires
+  a local worker dir. When the ticket has **no** local worker dir (e.g. already reaped) but still
+  carries a durable Linear `needs-input` label, the needs-human block's secondary
+  `removeLabel(ticket, "needs-input")` cleanup call still clears that label — but the function
+  returns before ever reaching the per-signal loop, so **no `worker.transition` is emitted for that
+  clear**. This is a real, unrecorded disposition change, not just a documentation gap — the same
+  class of coverage hole as the Pass 0w watchdog-escalation gap in ADR-026 / architecture.md.
+
+Dims are **attributes** (not `body.payload`) because `otel-forward` strips `body.payload` before
+forwarding off-machine.
 
 | attribute                          | type    | values / notes                                                              |
 | ---------------------------------- | ------- | --------------------------------------------------------------------------- |

--- a/plugins/dev/references/event-schema.md
+++ b/plugins/dev/references/event-schema.md
@@ -661,7 +661,12 @@ emitting it during a mixed-version fleet rollout.
 
 #### worker.transition fields (CTL-764)
 
-Emitted by `recordTransition` in `scheduler.mjs` (sync chokepoint). Dims are **attributes** (not
+Emitted by two producers: `recordTransition` in `scheduler.mjs` (the sync chokepoint for
+scheduler-owned transitions), and the daemon's `handleCommentWake` (CTL-768,
+`execution-core/daemon.mjs`), which calls `appendWorkerTransitionEvent` directly at two sites — the
+`needs-human`→cleared resolution on a human reply, and the `needs-input`→cleared resolution after a
+comment-driven wake — bypassing `recordTransition` because the scheduler never observes those edges
+(the daemon removes the durable label out-of-band and redispatches). Dims are **attributes** (not
 `body.payload`) because `otel-forward` strips `body.payload` before forwarding off-machine.
 
 | attribute                          | type    | values / notes                                                              |

--- a/plugins/dev/scripts/execution-core/daemon.mjs
+++ b/plugins/dev/scripts/execution-core/daemon.mjs
@@ -121,6 +121,7 @@ import {
   clearHoldStopCooldown, // CTL-768
   defaultClearStall, // CTL-1067: J3 stall-clear seam
   readMaxParallel, // CTL-1551: the SCHEDULER-ENFORCED slot ceiling for the heartbeat
+  clearDispositionEmit as defaultClearDispositionEmit, // Codex #2970 round 3: reset the in-process worker.transition dedup after an out-of-band clear
 } from "./scheduler.mjs";
 import * as linearWrite from "./linear-write.mjs"; // CTL-1067: writeStatus for defaultClearStall
 import { labelMarkerBase } from "./label-guard.mjs"; // CTL-1567: canonical once-marker path (single source of truth)
@@ -399,6 +400,11 @@ export async function handleCommentWake(
     // CTL-764 finding 11: canonical worker.transition emitter for the needs-input→
     // cleared resolution. Injectable for tests; defaults to the real appender.
     appendWorkerTransitionEvent = defaultAppendWorkerTransitionEvent,
+    // Codex #2970 round 3: resets the scheduler's in-process worker.transition
+    // dedup map (lastDispositionEmit) after this function's own out-of-band clear,
+    // so a later genuine re-escalation isn't swallowed by a stale entry. Injectable
+    // for tests; defaults to the real scheduler export.
+    clearDispositionEmit = defaultClearDispositionEmit,
     // CTL-1567 (Codex P1): is this ticket managed by THIS Catalyst installation?
     // The daemon receives EVERY workspace `linear.comment.created`, so without this
     // gate the no-worker-dir clear below would strip a same-named `needs-human`
@@ -459,10 +465,18 @@ export async function handleCommentWake(
   //      tickets this installation actually manages.
   const humanProvenance = Boolean(parsed.authorId) && Boolean(botUserId);
   let clearedNeedsHuman = false;
+  // Codex #2970 round 3: distinct from clearedNeedsHuman (which also covers the
+  // idempotent already-absent case and gates the marker reconcile below — that
+  // must run either way to keep labelOnce in step). This one is true ONLY when
+  // removeLabel performed a real write, so a duplicate webhook / second host
+  // re-checking an already-cleared label doesn't emit a second worker.transition
+  // "cleared" record for a state change that didn't happen on this call.
+  let clearedNeedsHumanWrote = false;
   if (humanProvenance && isManagedTicket(ticket, orchDir)) {
     try {
       const res = await removeLabel(ticket, "needs-human");
       clearedNeedsHuman = res?.removed !== false; // undefined (test stub) ⇒ success
+      clearedNeedsHumanWrote = res?.wrote === true;
     } catch {
       /* fail-open on the WRITE — a Linear 5xx must not block the wake path */
     }
@@ -508,16 +522,33 @@ export async function handleCommentWake(
         "handleCommentWake: needs-human marker reconcile failed — label already cleared"
       );
     }
-    try {
-      appendWorkerTransitionEvent({
-        ticket,
-        orchId: ticket,
-        fromDisposition: "needs-human",
-        toDisposition: null,
-        reason: "human-responded",
-      });
-    } catch {
-      /* observability only */
+    // Codex #2970 round 3: gate on a CONFIRMED write, not merely a confirmed-absent
+    // read — otherwise a duplicate webhook / second host that finds the label
+    // already gone would still record a fresh "cleared" transition for a change
+    // that happened on a prior call, mislabeling the timeline.
+    if (clearedNeedsHumanWrote) {
+      try {
+        appendWorkerTransitionEvent({
+          ticket,
+          orchId: ticket,
+          fromDisposition: "needs-human",
+          toDisposition: null,
+          reason: "human-responded",
+        });
+      } catch {
+        /* observability only */
+      }
+      // Codex #2970 round 3: the daemon and scheduler share lastDispositionEmit
+      // in-process — this out-of-band clear never went through recordTransition,
+      // so the map still thinks this ticket is "needs-human". Reset it now rather
+      // than waiting on the ticket reaching terminal Done (needs-human's self-heal
+      // paths are marker-gated and clearNeedsHumanMarkers above already deleted
+      // that marker, so they'd never even attempt the clear).
+      try {
+        clearDispositionEmit(ticket);
+      } catch {
+        /* observability only */
+      }
     }
   }
 
@@ -606,13 +637,18 @@ export async function handleCommentWake(
     // CTL-764 finding E: gate the needs-input→cleared emission on a CONFIRMED removal.
     // removeLabel reports a failed read/write as {removed:false} WITHOUT throwing, so the
     // try/catch alone never suppresses the event — a bare emit would record a clear the
-    // durable label never got. removed:true covers both a real removal AND the idempotent
-    // already-absent case (linear-write.mjs:289-291); an undefined return from a test stub
-    // is treated as success to keep the wake path testable.
+    // durable label never got. An undefined return from a test stub is treated as success
+    // to keep the wake path testable.
+    // Codex #2970 round 3: removed:true alone still covers both a real removal AND the
+    // idempotent already-absent case (linear-write.mjs) — gate the emission on the
+    // additive `wrote` field instead, so a duplicate webhook / second host re-checking an
+    // already-cleared label doesn't record a second "cleared" transition for a change
+    // that happened on a prior call. `wrote` is undefined on a test-stub `undefined`
+    // return, so the `res === undefined` success path stays gated on that alone.
     let needsInputRemoved = false;
     try {
       const res = await removeLabel(ticket, "needs-input"); // CTL-764 Phase 4: durable needs-input cleared on genuine resolution
-      needsInputRemoved = res === undefined || res?.removed === true;
+      needsInputRemoved = res === undefined || res?.wrote === true;
     } catch {
       /* fail-open */
     }
@@ -631,6 +667,16 @@ export async function handleCommentWake(
         reason: "comment-wake",
         source: "comment-wake-clear",
       });
+      // Codex #2970 round 3: scheduler.mjs already self-heals this specific stale
+      // entry on its next relevant tick (the `lastDispositionEmit.get(ticket) ===
+      // HELD_LABEL_NEEDS_INPUT` branch), but resetting it here too closes the
+      // window immediately rather than waiting a tick, and mirrors the needs-human
+      // site above for consistency.
+      try {
+        clearDispositionEmit(ticket);
+      } catch {
+        /* observability only */
+      }
     }
 
     dispatch(orchDir, ticket, parkedPhase, { handoffPath, resumeSession });

--- a/plugins/dev/scripts/execution-core/daemon.mjs
+++ b/plugins/dev/scripts/execution-core/daemon.mjs
@@ -511,8 +511,9 @@ export async function handleCommentWake(
     try {
       appendWorkerTransitionEvent({
         ticket,
-        from: "needs-human",
-        to: "cleared",
+        orchId: ticket,
+        fromDisposition: "needs-human",
+        toDisposition: null,
         reason: "human-responded",
       });
     } catch {

--- a/plugins/dev/scripts/execution-core/daemon.test.mjs
+++ b/plugins/dev/scripts/execution-core/daemon.test.mjs
@@ -1566,7 +1566,7 @@ describe("handleCommentWake (CTL-549)", () => {
         botUserId: "bot-uuid",
         isManagedTicket: () => true,
         dispatch: () => ({ code: 0 }),
-        removeLabel: async () => ({ removed: true }),
+        removeLabel: async () => ({ removed: true, wrote: true }),
         appendWorkerTransitionEvent: (ev) => transitions.push(ev),
       }
     );
@@ -1580,6 +1580,94 @@ describe("handleCommentWake (CTL-549)", () => {
     // The old buggy call's {from, to} keys must not resurface.
     expect(cleared.from).toBeUndefined();
     expect(cleared.to).toBeUndefined();
+  });
+
+  // Codex #2970 round 3: a no-op re-check (e.g. a duplicate webhook / second host
+  // finding the label already gone) must NOT emit a second "cleared" transition —
+  // only a call that performed a real write does. The marker reconcile still runs
+  // either way (clearedNeedsHuman, not clearedNeedsHumanWrote, gates that block).
+  test("does NOT emit worker.transition(needs-human→cleared) on a no-op ({removed:true, wrote:false})", async () => {
+    const orch = tmpOrcDir();
+    writeSignal(orch, "PROJ-NH3", "implement", { status: "needs-human" });
+    const transitions = [];
+    await handleCommentWake(
+      { ticket: "PROJ-NH3", body: "answered", authorId: "human-1" },
+      {
+        orchDir: orch,
+        botUserId: "bot-uuid",
+        isManagedTicket: () => true,
+        dispatch: () => ({ code: 0 }),
+        removeLabel: async () => ({ removed: true, wrote: false }),
+        appendWorkerTransitionEvent: (ev) => transitions.push(ev),
+      }
+    );
+    const cleared = transitions.find(
+      (e) => e.ticket === "PROJ-NH3" && e.fromDisposition === "needs-human"
+    );
+    expect(cleared).toBeUndefined();
+  });
+
+  // Codex #2970 round 3: the daemon and scheduler share lastDispositionEmit
+  // in-process (recordTransition's only-on-change guard). A real out-of-band
+  // clear must reset that shared dedup entry so a later GENUINE re-escalation to
+  // needs-human isn't silently swallowed by the guard comparing against a stale
+  // "needs-human" value.
+  test("resets the scheduler's disposition dedup on a real needs-human clear", async () => {
+    const orch = tmpOrcDir();
+    writeSignal(orch, "PROJ-NH4", "implement", { status: "needs-human" });
+    const resetTickets = [];
+    await handleCommentWake(
+      { ticket: "PROJ-NH4", body: "answered", authorId: "human-1" },
+      {
+        orchDir: orch,
+        botUserId: "bot-uuid",
+        isManagedTicket: () => true,
+        dispatch: () => ({ code: 0 }),
+        removeLabel: async () => ({ removed: true, wrote: true }),
+        appendWorkerTransitionEvent: () => {},
+        clearDispositionEmit: (ticket) => resetTickets.push(ticket),
+      }
+    );
+    expect(resetTickets).toContain("PROJ-NH4");
+  });
+
+  test("does NOT reset the scheduler's disposition dedup on a needs-human no-op", async () => {
+    const orch = tmpOrcDir();
+    writeSignal(orch, "PROJ-NH5", "implement", { status: "needs-human" });
+    const resetTickets = [];
+    await handleCommentWake(
+      { ticket: "PROJ-NH5", body: "answered", authorId: "human-1" },
+      {
+        orchDir: orch,
+        botUserId: "bot-uuid",
+        isManagedTicket: () => true,
+        dispatch: () => ({ code: 0 }),
+        removeLabel: async () => ({ removed: true, wrote: false }),
+        appendWorkerTransitionEvent: () => {},
+        clearDispositionEmit: (ticket) => resetTickets.push(ticket),
+      }
+    );
+    expect(resetTickets).toEqual([]);
+  });
+
+  test("resets the scheduler's disposition dedup on a real needs-input clear", async () => {
+    const orch = tmpOrcDir();
+    writeSignal(orch, "CTL-1", "implement", {
+      status: "needs-input",
+      parkedFrom: "implement",
+    });
+    const resetTickets = [];
+    await handleCommentWake(
+      { ticket: "CTL-1", body: "answer" },
+      {
+        orchDir: orch,
+        dispatch: () => ({ code: 0 }),
+        removeLabel: async () => ({ removed: true, wrote: true }),
+        appendWorkerTransitionEvent: () => {},
+        clearDispositionEmit: (ticket) => resetTickets.push(ticket),
+      }
+    );
+    expect(resetTickets).toContain("CTL-1");
   });
 
   test("the bot's OWN comment still does NOT clear the label (self-echo guard intact)", async () => {
@@ -1763,7 +1851,7 @@ describe("handleCommentWake (CTL-549)", () => {
     expect(cleared).toBeUndefined();
   });
 
-  test("finding E — emits the clear on a confirmed {removed:true}", async () => {
+  test("finding E — emits the clear on a confirmed real write ({removed:true, wrote:true})", async () => {
     const orch = tmpOrcDir();
     writeSignal(orch, "CTL-1", "implement", {
       status: "needs-input",
@@ -1775,7 +1863,7 @@ describe("handleCommentWake (CTL-549)", () => {
       {
         orchDir: orch,
         dispatch: () => ({ code: 0 }),
-        removeLabel: async () => ({ removed: true }),
+        removeLabel: async () => ({ removed: true, wrote: true }),
         appendWorkerTransitionEvent: (ev) => transitions.push(ev),
       }
     );
@@ -1784,6 +1872,31 @@ describe("handleCommentWake (CTL-549)", () => {
     );
     expect(cleared).toBeDefined();
     expect(cleared.source).toBe("comment-wake-clear");
+  });
+
+  // Codex #2970 round 3: removed:true alone (a no-op re-check on an already-cleared
+  // label — the second-host/duplicate-webhook case) must NOT emit a second "cleared"
+  // transition. Only wrote:true does.
+  test("finding E round 2 — does NOT emit the clear on a no-op ({removed:true, wrote:false})", async () => {
+    const orch = tmpOrcDir();
+    writeSignal(orch, "CTL-1", "implement", {
+      status: "needs-input",
+      parkedFrom: "implement",
+    });
+    const transitions = [];
+    await handleCommentWake(
+      { ticket: "CTL-1", body: "answer" },
+      {
+        orchDir: orch,
+        dispatch: () => ({ code: 0 }),
+        removeLabel: async () => ({ removed: true, wrote: false }),
+        appendWorkerTransitionEvent: (ev) => transitions.push(ev),
+      }
+    );
+    const cleared = transitions.find(
+      (e) => e.ticket === "CTL-1" && e.fromDisposition === "needs-input" && e.toDisposition === null
+    );
+    expect(cleared).toBeUndefined();
   });
 
   test("no-ops when ticket has no worker dir", async () => {

--- a/plugins/dev/scripts/execution-core/daemon.test.mjs
+++ b/plugins/dev/scripts/execution-core/daemon.test.mjs
@@ -1550,6 +1550,38 @@ describe("handleCommentWake (CTL-549)", () => {
     expect(cleared).toContainEqual({ ticket: "PROJ-NH", phase: "implement" });
   });
 
+  // Codex #2970: the needs-human clear call site passed {from, to} — keys
+  // buildWorkerTransitionEvent doesn't accept (it wants fromDisposition/
+  // toDisposition) — so the emitted worker.transition envelope carried neither
+  // disposition. This pins the fixed shape, mirroring the finding-11 pattern for
+  // the needs-input clear below.
+  test("emits worker.transition(needs-human→cleared) with fromDisposition/toDisposition set", async () => {
+    const orch = tmpOrcDir();
+    writeSignal(orch, "PROJ-NH2", "implement", { status: "needs-human" });
+    const transitions = [];
+    await handleCommentWake(
+      { ticket: "PROJ-NH2", body: "answered", authorId: "human-1" },
+      {
+        orchDir: orch,
+        botUserId: "bot-uuid",
+        isManagedTicket: () => true,
+        dispatch: () => ({ code: 0 }),
+        removeLabel: async () => ({ removed: true }),
+        appendWorkerTransitionEvent: (ev) => transitions.push(ev),
+      }
+    );
+    const cleared = transitions.find(
+      (e) => e.ticket === "PROJ-NH2" && e.fromDisposition === "needs-human"
+    );
+    expect(cleared).toBeDefined();
+    expect(cleared.toDisposition).toBeNull();
+    expect(cleared.orchId).toBe("PROJ-NH2");
+    expect(cleared.reason).toBe("human-responded");
+    // The old buggy call's {from, to} keys must not resurface.
+    expect(cleared.from).toBeUndefined();
+    expect(cleared.to).toBeUndefined();
+  });
+
   test("the bot's OWN comment still does NOT clear the label (self-echo guard intact)", async () => {
     const orch = tmpOrcDir();
     const removed = [];

--- a/plugins/dev/scripts/execution-core/linear-write.mjs
+++ b/plugins/dev/scripts/execution-core/linear-write.mjs
@@ -256,12 +256,17 @@ export function applyLabel({ ticket, label, exec = defaultExec }) {
 // and overwrite with the remainder (or --clear-labels when nothing remains).
 // This keeps the write inside linearis and preserves the issue's other labels.
 //
-// Idempotent: if the label is already absent we return { removed: true } without
-// a write. A failed read is { removed: false, reason } where reason is
+// Idempotent: if the label is already absent we return { removed: true, wrote: false }
+// without a write. A failed read is { removed: false, reason } where reason is
 // "auth-error" when the read's stderr matches isAuthError, otherwise "transient".
 // CTL-1078: injectable readLabels seam (defaults to readTicketLabels) returns the
 // richer { ok, labels, code, stderr } shape so the auth-vs-transient distinction
 // can be made. fetchLabels is accepted for back-compat (old test stubs). Never throws.
+// Codex #2970 round 3: `removed` alone can't distinguish "confirmed absent, no write
+// needed" from "this call performed the write" — both return removed:true. Callers that
+// must not double-record a state CHANGE (e.g. emitting a worker.transition clear once per
+// genuine removal, not once per no-op re-check on a duplicate webhook / second host) gate
+// on the additive `wrote` field instead.
 export async function removeLabel(
   ticket,
   label,
@@ -283,12 +288,12 @@ export async function removeLabel(
     if (!readResult.ok) {
       const reason = isAuthError(readResult.stderr ?? "") ? "auth-error" : "transient";
       log.warn({ ticket, label, reason, stderr: readResult.stderr }, "removeLabel: read failed");
-      return { removed: false, reason };
+      return { removed: false, wrote: false, reason };
     }
     const current = readResult.labels;
     if (!current.includes(label)) {
       // Idempotent: the label is already gone, no write needed.
-      return { removed: true };
+      return { removed: true, wrote: false };
     }
     const remaining = current.filter((l) => l !== label);
     let res;
@@ -317,12 +322,12 @@ export async function removeLabel(
     if ((res.code ?? res.status ?? 0) !== 0) {
       const reason = classifyLabelFailure(res.stderr ?? "");
       log.warn({ ticket, label, reason, stderr: res.stderr }, "removeLabel: write failed");
-      return { removed: false, reason };
+      return { removed: false, wrote: false, reason };
     }
-    return { removed: true };
+    return { removed: true, wrote: true };
   } catch (err) {
     log.warn({ ticket, label, reason: "transient", err: err.message }, "removeLabel: threw");
-    return { removed: false, reason: "transient" };
+    return { removed: false, wrote: false, reason: "transient" };
   }
 }
 

--- a/plugins/dev/scripts/execution-core/linear-write.test.mjs
+++ b/plugins/dev/scripts/execution-core/linear-write.test.mjs
@@ -617,6 +617,9 @@ describe("removeLabel (CTL-549)", () => {
     const fetchLabels = () => ["blocked", "orchestrator"];
     const result = await removeLabel("CTL-1", "blocked", { exec, fetchLabels });
     expect(result.removed).toBe(true);
+    // Codex #2970 round 3: a real write happened — distinguishable from the
+    // idempotent no-op case below via the additive `wrote` field.
+    expect(result.wrote).toBe(true);
     const args = cmds.find((c) => c.args[1] === "update").args;
     expect(args.slice(0, 3)).toEqual(["issues", "update", "CTL-1"]);
     expect(args).toContain("--labels");
@@ -638,12 +641,16 @@ describe("removeLabel (CTL-549)", () => {
     expect(args[args.indexOf("--label-mode") + 1]).toBe("overwrite");
   });
 
-  test("idempotent — label already absent: returns removed:true with NO write", async () => {
+  test("idempotent — label already absent: returns removed:true, wrote:false, NO write", async () => {
     const cmds = [];
     const exec = (cmd, args) => { cmds.push({ cmd, args }); return { code: 0, stdout: "", stderr: "" }; };
     const fetchLabels = () => ["orchestrator", "bug"]; // target 'blocked' not present
     const result = await removeLabel("CTL-1", "blocked", { exec, fetchLabels });
     expect(result.removed).toBe(true);
+    // Codex #2970 round 3: `removed:true` alone can't tell a no-op apart from a
+    // real write (e.g. a duplicate webhook / second host re-checking after the
+    // label is already gone). `wrote:false` is the additive signal for that.
+    expect(result.wrote).toBe(false);
     expect(cmds).toHaveLength(0); // no overwrite issued
   });
 
@@ -653,6 +660,7 @@ describe("removeLabel (CTL-549)", () => {
     const fetchLabels = () => ["needs-human/question"]; // the only label is the one removed
     const result = await removeLabel("CTL-1", "needs-human/question", { exec, fetchLabels });
     expect(result.removed).toBe(true);
+    expect(result.wrote).toBe(true);
     expect(cmds).toHaveLength(1);
     expect(cmds[0].args).toEqual(["issues", "update", "CTL-1", "--clear-labels"]);
     expect(cmds[0].args).not.toContain("--labels");

--- a/plugins/dev/scripts/execution-core/scheduler.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.mjs
@@ -7448,6 +7448,26 @@ const lastHeldEmitState = new Map();
 // (null = no label / cleared). Cleared on daemon restart (via __resetForTests).
 const lastDispositionEmit = new Map();
 
+// clearDispositionEmit — Codex #2970 round 3: the daemon runs the scheduler
+// in-process (daemon.mjs imports startScheduler from this module directly), so
+// lastDispositionEmit is the SAME live Map both share. handleCommentWake's
+// needs-human clear bypasses recordTransition entirely (CTL-764 finding: "the
+// scheduler never observes this edge"), so it never touches this map — leaving a
+// stale "needs-human" entry that would swallow a genuine LATER re-escalation to
+// needs-human via the only-on-change guard. The needs-input analog self-heals on
+// the next scheduler tick (the `else if (lastDispositionEmit.get(ticket) ===
+// HELD_LABEL_NEEDS_INPUT)` branch below); needs-human has no equivalent
+// unconditional check — its self-heal paths (clearStalledLabel's onRemoved →
+// recordTransition, at the terminal-done-clear / terminal-sweep-clear / no-stall-clear
+// sites) are marker-gated, and the daemon's clearNeedsHumanMarkers already deletes
+// that same marker, so those paths never even attempt the clear until (if ever) the
+// ticket reaches terminal Done. This export lets the daemon reset the entry
+// immediately after ITS OWN confirmed clear, closing the window without waiting on
+// Done or a process restart.
+export function clearDispositionEmit(ticket) {
+  lastDispositionEmit.set(ticket, null);
+}
+
 // CTL-1064: Pass 0u throttle — epoch-ms of the last unstuck-sweep run.
 // Module-level so the 15-min gate persists across ticks without a db write.
 // Reset to 0 on daemon restart (module reload) or via __resetForTests.


### PR DESCRIPTION
## Summary

Post-merge follow-up to #2961. Started as a docs-precision fix and grew a code fix: the docs verification pass exposed a real bug in the daemon's `worker.transition` emission.

**Code fix — malformed transition event (Codex #2970 round 2):**
- `handleCommentWake`'s needs-human clear (`execution-core/daemon.mjs:512-517`) called `appendWorkerTransitionEvent({ ticket, from: "needs-human", to: "cleared", reason })` — but `buildWorkerTransitionEvent` accepts `fromDisposition`/`toDisposition`, not `from`/`to`. The `from`/`to` keys were silently ignored, so every needs-human-cleared event shipped with both disposition fields `null`. Fixed the call site to pass `fromDisposition: "needs-human"`, `toDisposition: null` (the builder auto-encodes this as the `"cleared"` sentinel), and added `orchId` for schema parity with the sibling needs-input clear site. Added a regression test in `daemon.test.mjs` asserting the emitted envelope carries the correct dispositions and that the old `{from, to}` keys don't resurface.
- Retitled this PR `fix(dev)` so the bugfix ships with a catalyst-dev patch version bump.

**Docs precision, round 1 (Codex #2961 post-merge):**
- **Chokepoint scope**: scoped ADR-026's "all worker state transitions" claim to scheduler-owned transitions, naming the daemon's `handleCommentWake` as a known, self-documented second emitter (mirrored into `docs/architecture.md`).
- **Sink-5 overclaim**: verified `ticket_state_transitions` has zero schema/writer/consumer anywhere in the codebase — corrected both docs to say sink 5 (the broker table) was never implemented; only sink 4 (OTLP) is live.

**Docs precision, round 2 (Codex #2970):**
- `references/event-schema.md`'s `worker.transition` fields section claimed a single producer (`recordTransition`); added the daemon's comment-wake path as a second, real producer.
- ADR-026's Consequences section still advertised "five sinks... optional broker table" — reconciled with the sink-5-never-shipped correction (now: four live sinks, sink 5 never implemented).
- Verified `killHungWorker` (Pass 0w's hung-worker escalation, `watchdog-action.mjs`) applies `needs-human` via `labelNeedsHumanUnlessBeliefOwner` with **no** `worker.transition` emission anywhere in that path — a genuine coverage gap, distinct from the daemon's deliberate second-producer pattern. Documented it as such in both `docs/adrs.md` and `docs/architecture.md`, and reworded the ADR-026 "Decision" claim to "transitions the scheduler records" for precision.

## Test plan

- [x] `ctl-764-docs.test.sh` — 14/14 pass
- [x] `daemon.test.mjs` — 148/148 pass (incl. new regression test for the fixed call site)
- [x] `worker-transition-event.test.mjs` — pass
- [x] `watchdog-action.test.mjs` — 13/13 pass
- [x] `integration-ctl-768.test.mjs` — 1 pre-existing unrelated failure, confirmed via `git stash` against the branch tip before this change
- [x] Repo-wide grep confirms zero schema/writer/consumer for `ticket_state_transitions`
- [x] `node --check` on `daemon.mjs`

🤖 Generated with [Claude Code](https://claude.com/claude-code)