### PR TITLE
fix(dev): CTL-1628 comment-wake emission accounting + cross-host dedup reset (Codex #2970 post-merge)

### DIFF
--- a/plugins/dev/scripts/execution-core/daemon.mjs
+++ b/plugins/dev/scripts/execution-core/daemon.mjs
@@ -472,6 +472,14 @@ export async function handleCommentWake(
   // re-checking an already-cleared label doesn't emit a second worker.transition
   // "cleared" record for a state change that didn't happen on this call.
   let clearedNeedsHumanWrote = false;
+  // Codex #2970 post-merge round 1: this EARLIER needs-input removal (below) can
+  // itself be the call that performs the real write — the per-signal loop's own
+  // removeLabel(ticket, "needs-input") call then finds the label already absent
+  // ({wrote:false}) and would wrongly skip the emission that THIS call earned.
+  // Capture it here and OR it into the per-signal loop's write determination so a
+  // genuine write, wherever it happens in this invocation, produces exactly one
+  // emission instead of zero.
+  let needsInputWroteEarly = false;
   if (humanProvenance && isManagedTicket(ticket, orchDir)) {
     try {
       const res = await removeLabel(ticket, "needs-human");
@@ -486,7 +494,8 @@ export async function handleCommentWake(
     // inbox after the human answered — while this path claimed to be the complete
     // response. Both labels are the same fact from the operator's side.
     try {
-      await removeLabel(ticket, "needs-input");
+      const earlyRes = await removeLabel(ticket, "needs-input");
+      needsInputWroteEarly = earlyRes?.wrote === true;
     } catch {
       /* fail-open — same reasoning as above */
     }
@@ -522,10 +531,11 @@ export async function handleCommentWake(
         "handleCommentWake: needs-human marker reconcile failed — label already cleared"
       );
     }
-    // Codex #2970 round 3: gate on a CONFIRMED write, not merely a confirmed-absent
-    // read — otherwise a duplicate webhook / second host that finds the label
-    // already gone would still record a fresh "cleared" transition for a change
-    // that happened on a prior call, mislabeling the timeline.
+    // Codex #2970 round 3: gate the EMISSION on a CONFIRMED write, not merely a
+    // confirmed-absent read — otherwise a duplicate webhook / second host that
+    // finds the label already gone would still record a fresh "cleared"
+    // transition for a change that happened on a prior call, mislabeling the
+    // timeline. Only the writer host should ever emit.
     if (clearedNeedsHumanWrote) {
       try {
         appendWorkerTransitionEvent({
@@ -538,12 +548,18 @@ export async function handleCommentWake(
       } catch {
         /* observability only */
       }
-      // Codex #2970 round 3: the daemon and scheduler share lastDispositionEmit
-      // in-process — this out-of-band clear never went through recordTransition,
-      // so the map still thinks this ticket is "needs-human". Reset it now rather
-      // than waiting on the ticket reaching terminal Done (needs-human's self-heal
-      // paths are marker-gated and clearNeedsHumanMarkers above already deleted
-      // that marker, so they'd never even attempt the clear).
+    }
+    // Codex #2970 post-merge round 2: the daemon and scheduler share
+    // lastDispositionEmit in-process — this out-of-band clear never went through
+    // recordTransition, so the map still thinks this ticket is "needs-human".
+    // Reset it on any CONFIRMED clear (clearedNeedsHuman), not only a write by
+    // THIS process (clearedNeedsHumanWrote) — a cross-host clear (another host
+    // did the write; this host observes {removed:true, wrote:false}) is just as
+    // confirmed, and this process's dedup entry is just as stale either way. Do
+    // this rather than waiting on the ticket reaching terminal Done (needs-human's
+    // self-heal paths are marker-gated and clearNeedsHumanMarkers above already
+    // deleted that marker, so they'd never even attempt the clear).
+    if (clearedNeedsHuman) {
       try {
         clearDispositionEmit(ticket);
       } catch {
@@ -640,15 +656,27 @@ export async function handleCommentWake(
     // durable label never got. An undefined return from a test stub is treated as success
     // to keep the wake path testable.
     // Codex #2970 round 3: removed:true alone still covers both a real removal AND the
-    // idempotent already-absent case (linear-write.mjs) — gate the emission on the
+    // idempotent already-absent case (linear-write.mjs) — gate the EMISSION on the
     // additive `wrote` field instead, so a duplicate webhook / second host re-checking an
     // already-cleared label doesn't record a second "cleared" transition for a change
     // that happened on a prior call. `wrote` is undefined on a test-stub `undefined`
     // return, so the `res === undefined` success path stays gated on that alone.
+    // Codex #2970 post-merge round 1: `needsInputWroteEarly` folds in the EARLIER
+    // needs-input removal (in the needs-human block above) — that call can itself be
+    // the one that performed the real write, leaving THIS call observing
+    // {wrote:false} for a change it didn't make. OR'ing it in means a genuine write,
+    // wherever in this invocation it happened, still earns exactly one emission.
     let needsInputRemoved = false;
+    // Codex #2970 post-merge round 2: CONFIRMED removal (regardless of who wrote),
+    // separate from needsInputRemoved's write-only signal — gates clearDispositionEmit
+    // below, not the emission. A cross-host clear (another host wrote; this host
+    // observes {removed:true, wrote:false}) is just as confirmed and this process's
+    // dedup entry is just as stale either way.
+    let needsInputConfirmed = false;
     try {
       const res = await removeLabel(ticket, "needs-input"); // CTL-764 Phase 4: durable needs-input cleared on genuine resolution
-      needsInputRemoved = res === undefined || res?.wrote === true;
+      needsInputRemoved = res === undefined || res?.wrote === true || needsInputWroteEarly;
+      needsInputConfirmed = res === undefined || res?.removed !== false;
     } catch {
       /* fail-open */
     }
@@ -657,7 +685,7 @@ export async function handleCommentWake(
     // is emitted here (the daemon removes the durable label out-of-band and redispatches
     // — the scheduler never observes this edge). toDisposition:null is encoded as the
     // "cleared" sentinel in the event builder (finding 12). Fail-open — never blocks the
-    // wake. finding E: only emitted on a confirmed removal.
+    // wake. finding E: only emitted on a confirmed WRITE (only the writer host emits).
     if (needsInputRemoved) {
       appendWorkerTransitionEvent({
         ticket,
@@ -667,11 +695,13 @@ export async function handleCommentWake(
         reason: "comment-wake",
         source: "comment-wake-clear",
       });
-      // Codex #2970 round 3: scheduler.mjs already self-heals this specific stale
-      // entry on its next relevant tick (the `lastDispositionEmit.get(ticket) ===
-      // HELD_LABEL_NEEDS_INPUT` branch), but resetting it here too closes the
-      // window immediately rather than waiting a tick, and mirrors the needs-human
-      // site above for consistency.
+    }
+    // Codex #2970 round 3 / post-merge round 2: scheduler.mjs already self-heals this
+    // specific stale entry on its next relevant tick (the
+    // `lastDispositionEmit.get(ticket) === HELD_LABEL_NEEDS_INPUT` branch), but
+    // resetting it here too closes the window immediately. Gated on CONFIRMED removal,
+    // not write-only, so a cross-host clear resets this process's dedup entry too.
+    if (needsInputConfirmed) {
       try {
         clearDispositionEmit(ticket);
       } catch {

--- a/plugins/dev/scripts/execution-core/daemon.test.mjs
+++ b/plugins/dev/scripts/execution-core/daemon.test.mjs
@@ -1631,10 +1631,16 @@ describe("handleCommentWake (CTL-549)", () => {
     expect(resetTickets).toContain("PROJ-NH4");
   });
 
-  test("does NOT reset the scheduler's disposition dedup on a needs-human no-op", async () => {
+  // Codex #2970 post-merge round 2: {removed:true, wrote:false} is a CONFIRMED
+  // clear performed by a DIFFERENT host (cross-host case) — this process's
+  // lastDispositionEmit entry is just as stale as if it had done the write
+  // itself, so the dedup reset must still fire. Only the transition EMISSION
+  // stays write-gated (only the writer host emits).
+  test("resets the scheduler's disposition dedup on a cross-host needs-human clear (confirmed, not written here)", async () => {
     const orch = tmpOrcDir();
     writeSignal(orch, "PROJ-NH5", "implement", { status: "needs-human" });
     const resetTickets = [];
+    const transitions = [];
     await handleCommentWake(
       { ticket: "PROJ-NH5", body: "answered", authorId: "human-1" },
       {
@@ -1643,6 +1649,27 @@ describe("handleCommentWake (CTL-549)", () => {
         isManagedTicket: () => true,
         dispatch: () => ({ code: 0 }),
         removeLabel: async () => ({ removed: true, wrote: false }),
+        appendWorkerTransitionEvent: (ev) => transitions.push(ev),
+        clearDispositionEmit: (ticket) => resetTickets.push(ticket),
+      }
+    );
+    expect(resetTickets).toContain("PROJ-NH5");
+    // The clear was confirmed but not written BY THIS HOST — no emission here.
+    expect(transitions.find((e) => e.fromDisposition === "needs-human")).toBeUndefined();
+  });
+
+  test("does NOT reset the scheduler's disposition dedup when the needs-human removal is not confirmed", async () => {
+    const orch = tmpOrcDir();
+    writeSignal(orch, "PROJ-NH6", "implement", { status: "needs-human" });
+    const resetTickets = [];
+    await handleCommentWake(
+      { ticket: "PROJ-NH6", body: "answered", authorId: "human-1" },
+      {
+        orchDir: orch,
+        botUserId: "bot-uuid",
+        isManagedTicket: () => true,
+        dispatch: () => ({ code: 0 }),
+        removeLabel: async () => ({ removed: false, reason: "transient" }),
         appendWorkerTransitionEvent: () => {},
         clearDispositionEmit: (ticket) => resetTickets.push(ticket),
       }
@@ -1668,6 +1695,77 @@ describe("handleCommentWake (CTL-549)", () => {
       }
     );
     expect(resetTickets).toContain("CTL-1");
+  });
+
+  // Codex #2970 post-merge round 1: the EARLIER needs-input removal (inside the
+  // needs-human block, gated on humanProvenance + isManagedTicket) can itself
+  // perform the real write. The per-signal loop's OWN removeLabel(ticket,
+  // "needs-input") call then observes the label already absent ({wrote:false}) —
+  // without threading the earlier call's write, the emission this genuine clear
+  // earned would be silently dropped.
+  test("does not lose the needs-input clear emission when the EARLIER (needs-human-block) removal performed the real write", async () => {
+    const orch = tmpOrcDir();
+    writeSignal(orch, "PROJ-RACE", "implement", {
+      status: "needs-input",
+      parkedFrom: "implement",
+    });
+    const transitions = [];
+    let needsInputCalls = 0;
+    await handleCommentWake(
+      { ticket: "PROJ-RACE", body: "answered", authorId: "human-1" },
+      {
+        orchDir: orch,
+        botUserId: "bot-uuid",
+        isManagedTicket: () => true,
+        dispatch: () => ({ code: 0 }),
+        removeLabel: async (_t, label) => {
+          if (label === "needs-human") return { removed: true, wrote: false }; // never applied on this ticket
+          // needs-input: the FIRST call (the earlier needs-human-block cleanup)
+          // performs the real write; the SECOND call (the per-signal loop) finds
+          // it already gone.
+          needsInputCalls += 1;
+          return needsInputCalls === 1
+            ? { removed: true, wrote: true }
+            : { removed: true, wrote: false };
+        },
+        appendWorkerTransitionEvent: (ev) => transitions.push(ev),
+      }
+    );
+    const needsInputClears = transitions.filter(
+      (e) => e.fromDisposition === "needs-input" && e.toDisposition === null
+    );
+    // Exactly one emission for the one genuine write — not zero (lost), not two
+    // (double-counted).
+    expect(needsInputClears).toHaveLength(1);
+  });
+
+  // Codex #2970 post-merge round 2, extended to needs-input for consistency with
+  // the needs-human fix: when NEITHER of this invocation's two removeLabel calls
+  // performed the write (a third host already cleared it before either ran), the
+  // clear is still CONFIRMED — the dedup reset must fire even though no emission
+  // does (only the writer host emits).
+  test("resets the scheduler's disposition dedup on a fully cross-host needs-input clear, with no emission", async () => {
+    const orch = tmpOrcDir();
+    writeSignal(orch, "PROJ-RACE2", "implement", {
+      status: "needs-input",
+      parkedFrom: "implement",
+    });
+    const transitions = [];
+    const resetTickets = [];
+    await handleCommentWake(
+      { ticket: "PROJ-RACE2", body: "answer" },
+      {
+        orchDir: orch,
+        dispatch: () => ({ code: 0 }),
+        removeLabel: async () => ({ removed: true, wrote: false }),
+        appendWorkerTransitionEvent: (ev) => transitions.push(ev),
+        clearDispositionEmit: (ticket) => resetTickets.push(ticket),
+      }
+    );
+    expect(
+      transitions.find((e) => e.fromDisposition === "needs-input" && e.toDisposition === null)
+    ).toBeUndefined();
+    expect(resetTickets).toContain("PROJ-RACE2");
   });
 
   test("the bot's OWN comment still does NOT clear the label (self-echo guard intact)", async () => {


### PR DESCRIPTION
## Summary

Post-merge follow-up to #2970. Two Codex findings on `handleCommentWake`'s comment-wake logic, both around the interplay of its two `removeLabel` calls for `needs-input` and the shared `lastDispositionEmit` dedup map.

**1. Emission accounting race (needs-input).** `handleCommentWake` calls `removeLabel(ticket, "needs-input")` twice per invocation when a human reply lands on a managed ticket: once inside the needs-human block (a "both labels are the same fact" cleanup, result previously discarded) and once inside the per-signal loop (the call that actually gates the `worker.transition` emission). When the EARLIER call is the one that performs the real write, the LATER call finds the label already absent (`{wrote:false}`) and the emission the earlier write earned was silently dropped — a genuine clear produced zero events. Captured the earlier call's `wrote` result (`needsInputWroteEarly`) and OR'd it into the per-signal loop's emission gate, so a genuine write — wherever in the invocation it happens — produces exactly one emission, never zero or two.

**2. Cross-host dedup reset (needs-human, extended to needs-input for consistency).** `clearDispositionEmit` (added in #2970 to reset the scheduler's in-process `lastDispositionEmit` after an out-of-band clear) was nested under the write-gate (`clearedNeedsHumanWrote` / the needs-input equivalent) — so when a DIFFERENT host already performed the write and this host observes `{removed:true, wrote:false}` (a confirmed clear, just not by this process), the dedup reset never fired, leaving this process's entry stale. Split the two concerns: the transition **emission** stays write-gated (only the writer host emits, preventing duplicate "cleared" records), but the dedup **reset** now gates on the confirmed-removal signal (`removed !== false`) regardless of which host wrote it — since a stale dedup entry is just as stale either way. Applied identically to the needs-input site for consistency with the needs-human fix.

## Test plan

- [x] `daemon.test.mjs` — 156/156 pass, including 4 new/updated regression tests: the needs-input write-race (earlier call earns the write, later call observes absence, exactly one emission), the fully-cross-host needs-input no-op (no emission, dedup still resets), the needs-human cross-host confirmed clear (dedup resets, no emission), and the needs-human unconfirmed-removal case (no reset).
- [x] `linear-write.test.mjs`, `worker-transition-event.test.mjs` — pass (unaffected by this round).
- [x] `integration-ctl-768.test.mjs` — 1 pre-existing unrelated failure, consistent across all prior rounds of this work.
- [x] `scheduler.test.mjs` (the dedup-adjacent tests) — untouched this round (`scheduler.mjs` not modified); its ~5-7 fluctuating failures are pre-existing baseline flakiness confirmed in the prior PR round via git-stash A/B comparison.
- [x] `node --check` on `daemon.mjs`: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)