### PR TITLE
fix(dev): CTL-1628 single-consume early-write credit + disposition-scoped dedup reset (Codex #2973 post-merge)

### DIFF
--- a/plugins/dev/scripts/execution-core/daemon.mjs
+++ b/plugins/dev/scripts/execution-core/daemon.mjs
@@ -561,7 +561,12 @@ export async function handleCommentWake(
     // deleted that marker, so they'd never even attempt the clear).
     if (clearedNeedsHuman) {
       try {
-        clearDispositionEmit(ticket);
+        // Codex #2970 post-merge round 4: clearedNeedsHuman is true on the
+        // idempotent already-absent case too — a managed ticket whose CURRENT
+        // disposition is "blocked"/"queued" (needs-human never applied) still
+        // reaches here. Pass "needs-human" so clearDispositionEmit only resets
+        // when the map's live entry actually matches, never an unrelated one.
+        clearDispositionEmit(ticket, "needs-human");
       } catch {
         /* observability only */
       }
@@ -680,6 +685,12 @@ export async function handleCommentWake(
     } catch {
       /* fail-open */
     }
+    // Codex #2970 post-merge round 3: needsInputWroteEarly is declared once, BEFORE
+    // this loop — with multiple phase-*.json signals in needs-input, it would OR
+    // into every iteration's needsInputRemoved unchanged, turning one Linear write
+    // into one emission per matching signal. Consume the credit here, on the
+    // iteration that used it, so it can fund at most one emission across the loop.
+    needsInputWroteEarly = false;
     // CTL-764 finding 11: record the needs-input→cleared resolution in the canonical
     // worker.transition stream. scheduler.mjs owns the park/apply emission; the clear
     // is emitted here (the daemon removes the durable label out-of-band and redispatches
@@ -703,7 +714,9 @@ export async function handleCommentWake(
     // not write-only, so a cross-host clear resets this process's dedup entry too.
     if (needsInputConfirmed) {
       try {
-        clearDispositionEmit(ticket);
+        // Codex #2970 post-merge round 4: same expected-disposition guard as the
+        // needs-human site above.
+        clearDispositionEmit(ticket, "needs-input");
       } catch {
         /* observability only */
       }

--- a/plugins/dev/scripts/execution-core/daemon.test.mjs
+++ b/plugins/dev/scripts/execution-core/daemon.test.mjs
@@ -1739,6 +1739,48 @@ describe("handleCommentWake (CTL-549)", () => {
     expect(needsInputClears).toHaveLength(1);
   });
 
+  // Codex #2970 post-merge round 3: needsInputWroteEarly was declared once,
+  // BEFORE the per-signal loop, and never reset — with multiple needs-input
+  // signals for the same ticket, that one early Linear write funded a SEPARATE
+  // emission per signal instead of exactly one.
+  test("emits exactly ONE needs-input clear when the ticket has multiple needs-input signals and the early removal earned the write", async () => {
+    const orch = tmpOrcDir();
+    writeSignal(orch, "PROJ-MULTI", "implement", {
+      status: "needs-input",
+      parkedFrom: "implement",
+    });
+    writeSignal(orch, "PROJ-MULTI", "verify", {
+      status: "needs-input",
+      parkedFrom: "verify",
+    });
+    const transitions = [];
+    let needsInputCalls = 0;
+    await handleCommentWake(
+      { ticket: "PROJ-MULTI", body: "answered", authorId: "human-1" },
+      {
+        orchDir: orch,
+        botUserId: "bot-uuid",
+        isManagedTicket: () => true,
+        dispatch: () => ({ code: 0 }),
+        removeLabel: async (_t, label) => {
+          if (label === "needs-human") return { removed: true, wrote: false };
+          // The FIRST needs-input call (the earlier needs-human-block cleanup)
+          // performs the real write; every subsequent call — one per signal
+          // file the per-signal loop visits — finds it already gone.
+          needsInputCalls += 1;
+          return needsInputCalls === 1
+            ? { removed: true, wrote: true }
+            : { removed: true, wrote: false };
+        },
+        appendWorkerTransitionEvent: (ev) => transitions.push(ev),
+      }
+    );
+    const needsInputClears = transitions.filter(
+      (e) => e.fromDisposition === "needs-input" && e.toDisposition === null
+    );
+    expect(needsInputClears).toHaveLength(1);
+  });
+
   // Codex #2970 post-merge round 2, extended to needs-input for consistency with
   // the needs-human fix: when NEITHER of this invocation's two removeLabel calls
   // performed the write (a third host already cleared it before either ran), the

--- a/plugins/dev/scripts/execution-core/scheduler.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.mjs
@@ -7464,8 +7464,33 @@ const lastDispositionEmit = new Map();
 // ticket reaches terminal Done. This export lets the daemon reset the entry
 // immediately after ITS OWN confirmed clear, closing the window without waiting on
 // Done or a process restart.
-export function clearDispositionEmit(ticket) {
+//
+// Codex #2970 post-merge round 4: `expectedDisposition` is REQUIRED, not optional.
+// The daemon calls this whenever ITS OWN removeLabel(ticket, "needs-human") comes
+// back confirmed — including the idempotent case where needs-human was never
+// applied to this ticket at all (e.g. its current disposition is "blocked" or
+// "queued"). An unconditional `.set(ticket, null)` would overwrite that UNRELATED
+// entry with null, corrupting the tick-converged dedup for a disposition this call
+// never touched. Only clear when the map's CURRENT value for the ticket matches
+// what this caller believes it just cleared — a mismatch (including "never seen
+// this ticket") is a no-op, never a write.
+export function clearDispositionEmit(ticket, expectedDisposition) {
+  if (lastDispositionEmit.get(ticket) !== expectedDisposition) return;
   lastDispositionEmit.set(ticket, null);
+}
+
+// __seedDispositionEmitForTest / __readDispositionEmitForTest — Codex #2970
+// post-merge round 4: a direct, isolated way to unit-test
+// clearDispositionEmit's expected-disposition guard without driving a full
+// schedulerTick escalation (which needs stall-threshold/marker setup shared
+// across the describe block and is not reliably reproducible standalone —
+// verified: the existing terminal-sweep escalation test fails when run in
+// isolation too). Test-only; not part of the public contract.
+export function __seedDispositionEmitForTest(ticket, value) {
+  lastDispositionEmit.set(ticket, value);
+}
+export function __readDispositionEmitForTest(ticket) {
+  return lastDispositionEmit.get(ticket);
 }
 
 // CTL-1064: Pass 0u throttle — epoch-ms of the last unstuck-sweep run.

--- a/plugins/dev/scripts/execution-core/scheduler.test.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.test.mjs
@@ -59,6 +59,9 @@ import {
   gcDispatchCooldowns,
   maybeEscalateDispatchFailures,
   holisticBoardHealthAct,
+  clearDispositionEmit, // Codex #2970 post-merge round 4: expected-disposition-guarded dedup reset
+  __seedDispositionEmitForTest,
+  __readDispositionEmitForTest,
   __resetForTests,
   __getRunningOpts,
   // CTL-705: Phase 2 helpers
@@ -12300,6 +12303,37 @@ describe("CTL-764 Phase 5 — schedulerTick emits worker.transition events", () 
       (e) => e.toDisposition === "needs-human" && e.ticket === "CTL-764"
     );
     expect(needsHuman).toBeDefined();
+  });
+
+  // Codex #2970 post-merge round 4: clearDispositionEmit(ticket, expectedDisposition)
+  // must only clear the live entry when it MATCHES what the caller believes it just
+  // cleared — an unconditional clear would corrupt an UNRELATED disposition (e.g. the
+  // daemon calling it for "needs-human" on a ticket whose live entry is actually
+  // "blocked" or "queued"). Seeds lastDispositionEmit directly (via the test-only
+  // helpers) rather than driving a full schedulerTick escalation, which needs
+  // stall-threshold setup shared across this describe block and is not reliably
+  // reproducible standalone.
+  test("clearDispositionEmit only resets a MATCHING dedup entry, never an unrelated one", () => {
+    __seedDispositionEmitForTest("CTL-1", "needs-human");
+
+    // Wrong expected disposition — must be a no-op against the live "needs-human" entry.
+    clearDispositionEmit("CTL-1", "blocked");
+    expect(__readDispositionEmitForTest("CTL-1")).toBe("needs-human");
+
+    // Correct expected disposition — clears it.
+    clearDispositionEmit("CTL-1", "needs-human");
+    expect(__readDispositionEmitForTest("CTL-1")).toBeNull();
+  });
+
+  test("clearDispositionEmit never touches an UNRELATED ticket's entry", () => {
+    __seedDispositionEmitForTest("CTL-1", "needs-human");
+    __seedDispositionEmitForTest("CTL-2", "blocked");
+
+    clearDispositionEmit("CTL-1", "needs-human");
+
+    expect(__readDispositionEmitForTest("CTL-1")).toBeNull();
+    // CTL-2's unrelated "blocked" entry must survive untouched.
+    expect(__readDispositionEmitForTest("CTL-2")).toBe("blocked");
   });
 
   test("clear needs-human on terminal Done emits worker.transition(toDisposition=null)", () => {


### PR DESCRIPTION
## Summary

Post-merge follow-up to #2973. Two Codex findings on the accounting logic that PR built.

**1. Multi-signal emission over-count (`needsInputWroteEarly`).** The earlier needs-human-block's `needsInputWroteEarly` flag was declared once, before the per-signal loop, and never consumed. With a single ticket carrying multiple `phase-*.json` signals in `needs-input` status, one genuine early Linear write would OR into every iteration's emission gate unchanged — turning one write into one `worker.transition` clear *per matching signal* instead of exactly one. Consumed the credit on the iteration that used it (`needsInputWroteEarly = false` immediately after folding it into that iteration's `needsInputRemoved`), so it can fund at most one emission across the whole loop.

**2. Cross-disposition dedup corruption (`clearDispositionEmit`).** `clearDispositionEmit(ticket)` was called unconditionally whenever `clearedNeedsHuman` was true — but that's also true on the *idempotent already-absent* case, i.e. any managed ticket a human replies to, even one whose disposition was never `needs-human` in the first place (e.g. currently `blocked` or `queued`). The unconditional `.set(ticket, null)` overwrote that unrelated live entry, breaking the tick-converged only-on-change guard for a disposition this call never touched. Fixed at the source: `clearDispositionEmit(ticket, expectedDisposition)` now only clears when `lastDispositionEmit.get(ticket) === expectedDisposition` — a mismatch (including "never seen this ticket") is a no-op, never a write. Updated both daemon call sites to pass their expected disposition (`"needs-human"` / `"needs-input"`).

## Test plan

- [x] `daemon.test.mjs` — 157/157 pass, including a new regression test with two `needs-input` signals on one ticket asserting exactly one emission (fails against the pre-fix code with two).
- [x] `scheduler.test.mjs` — 615/622 pass (7 pre-existing flaky failures, confirmed identical to the known baseline set from prior rounds — none new). Added two direct unit tests for `clearDispositionEmit`'s expected-disposition guard, using new test-only `__seedDispositionEmitForTest`/`__readDispositionEmitForTest` helpers (a full-`schedulerTick`-driven integration test was tried first but proved unreliable — even the pre-existing "terminal-sweep needs-human" escalation test fails when run in isolation, confirming it's order-dependent on shared describe-block state, not a fit for a new isolated unit test).
- [x] `linear-write.test.mjs`, `worker-transition-event.test.mjs` — pass, unaffected.
- [x] `integration-ctl-768.test.mjs` — 1 pre-existing unrelated failure, consistent across every prior round of this work.
- [x] `node --check` on all four touched files: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)