### PR TITLE
fix(dev): CTL-1628 A1 retry TMPDIR when safe-cache mktemp fails (Codex #2972 post-merge)

### DIFF
--- a/plugins/dev/scripts/create-worktree.sh
+++ b/plugins/dev/scripts/create-worktree.sh
@@ -636,9 +636,24 @@ else
 					fi
 				fi
 			fi
+			# CTL-1628 post-merge (Codex #2972 post-merge, round 13): the
+			# safe-cache and TMPDIR attempts used to be mutually exclusive
+			# (if/else) — when $HOME/.cache passed the safety check but the
+			# mktemp call THERE specifically failed (e.g. that filesystem is
+			# full or over quota, independent of $TMPDIR), the sniff gave up
+			# rather than trying TMPDIR as a second attempt. Try the safe
+			# cache first (still preferred — single-user by construction),
+			# and only on ITS mktemp failing (not merely CACHE_SAFE being
+			# false) fall through to the TMPDIR-based mktemp, which is safe
+			# on its own terms — mktemp's own atomic O_EXCL creation already
+			# guarantees whatever it creates is 0700 owned by us, the same
+			# baseline guarantee round 9's original /tmp-based fix relied on
+			# before $HOME/.cache was even added as a preference.
+			BUN_SNIFF_CWD=""
 			if [ "$CACHE_SAFE" = true ]; then
 				BUN_SNIFF_CWD=$(mktemp -d "${CATALYST_SNIFF_CACHE}/catalyst-sniff.XXXXXXXX" 2>/dev/null) || BUN_SNIFF_CWD=""
-			else
+			fi
+			if [ -z "$BUN_SNIFF_CWD" ]; then
 				BUN_SNIFF_CWD=$(mktemp -d "${TMPDIR:-/tmp}/catalyst-sniff.XXXXXXXX" 2>/dev/null) || BUN_SNIFF_CWD=""
 			fi
 			if [ -n "$BUN_SNIFF_CWD" ]; then


### PR DESCRIPTION
## Summary

Codex flagged a post-merge P2 on #2972: the safe-cache and TMPDIR scratch-dir attempts were mutually exclusive branches. When `$HOME/.cache` passed the ownership/permission safety check but the `mktemp` call *there specifically* failed (e.g. that filesystem full or over quota, independent of `$TMPDIR`), the sniff gave up on the bun tier entirely rather than trying `TMPDIR` as a second attempt — even though `TMPDIR` was perfectly usable.

Restructured to try the safe cache first (still preferred) and fall through to the `TMPDIR`-based `mktemp` only when its specific attempt fails, not merely when `CACHE_SAFE` was false. The `TMPDIR` path needs no additional verification of its own — `mktemp`'s atomic `O_EXCL` creation already guarantees whatever it creates is `0700` owned by us, the same baseline guarantee round 9's original `/tmp`-based fix relied on before `$HOME/.cache` was added as a preference.

## Test plan

- [x] New: a stub `mktemp` that fails only when the target path contains `/.cache/` (simulating a quota/full-filesystem failure isolated to that mount) while succeeding normally for `TMPDIR`-based calls → confirmed the sniff still resolves via the bun tier end to end.
- [x] Directly instrumented the retry logic to confirm the scratch dir actually falls back to `TMPDIR` rather than merely succeeding some other way.
- [x] Re-verified both poisoning scenarios (project-level `bunfig.toml`, one planted at `/tmp`), the read-only-`HOME` and loose-`~/.cache` cases from the prior round, and the full mktemp-failure cascade to node — all still hold.
- [x] `bash -n` clean; `shellcheck -x` shows the same 3 pre-existing findings as before this change, zero new.
- [x] `create-worktree-guard.test.sh` 10/10, `create-worktree-expected-branch.test.sh` 6/6, plus the full `create-worktree` suite set — all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)