### PR TITLE
fix(dev): CTL-1628 credit survives throw + early-path needs-input dedup clear (Codex #2974 post-merge)

### DIFF
--- a/plugins/dev/scripts/execution-core/daemon.mjs
+++ b/plugins/dev/scripts/execution-core/daemon.mjs
@@ -496,6 +496,22 @@ export async function handleCommentWake(
     try {
       const earlyRes = await removeLabel(ticket, "needs-input");
       needsInputWroteEarly = earlyRes?.wrote === true;
+      // Codex #2970 post-merge round 5: this call can ALSO be a real, confirmed
+      // clear of the needs-input label — but if the ticket has no local worker
+      // dir, the readdirSync below returns before ever reaching the per-signal
+      // loop's own clearDispositionEmit(ticket, "needs-input") call. Without this,
+      // a live "needs-input" dedup entry would survive indefinitely (there's no
+      // later point in this invocation, or any self-heal path, that would reset
+      // it for a ticket with no local signal to match against). Reset it here,
+      // right where the confirmation is known, independent of whether a worker
+      // dir exists.
+      if (earlyRes === undefined || earlyRes?.removed !== false) {
+        try {
+          clearDispositionEmit(ticket, "needs-input");
+        } catch {
+          /* observability only */
+        }
+      }
     } catch {
       /* fail-open — same reasoning as above */
     }
@@ -682,15 +698,18 @@ export async function handleCommentWake(
       const res = await removeLabel(ticket, "needs-input"); // CTL-764 Phase 4: durable needs-input cleared on genuine resolution
       needsInputRemoved = res === undefined || res?.wrote === true || needsInputWroteEarly;
       needsInputConfirmed = res === undefined || res?.removed !== false;
+      // Codex #2970 post-merge round 3 / round 5: needsInputWroteEarly is declared
+      // once, BEFORE this loop — with multiple phase-*.json signals in needs-input,
+      // it would OR into every iteration's needsInputRemoved unchanged, turning one
+      // Linear write into one emission per matching signal. Consume the credit here,
+      // INSIDE the try, only once removeLabel has actually SUCCEEDED and this
+      // iteration has used it — not unconditionally after the try/catch. If this
+      // call throws, the catch below skips this line entirely, so a throwing FIRST
+      // signal doesn't burn the credit a later, successful signal could still use.
+      needsInputWroteEarly = false;
     } catch {
       /* fail-open */
     }
-    // Codex #2970 post-merge round 3: needsInputWroteEarly is declared once, BEFORE
-    // this loop — with multiple phase-*.json signals in needs-input, it would OR
-    // into every iteration's needsInputRemoved unchanged, turning one Linear write
-    // into one emission per matching signal. Consume the credit here, on the
-    // iteration that used it, so it can fund at most one emission across the loop.
-    needsInputWroteEarly = false;
     // CTL-764 finding 11: record the needs-input→cleared resolution in the canonical
     // worker.transition stream. scheduler.mjs owns the park/apply emission; the clear
     // is emitted here (the daemon removes the durable label out-of-band and redispatches

--- a/plugins/dev/scripts/execution-core/daemon.test.mjs
+++ b/plugins/dev/scripts/execution-core/daemon.test.mjs
@@ -1781,6 +1781,77 @@ describe("handleCommentWake (CTL-549)", () => {
     expect(needsInputClears).toHaveLength(1);
   });
 
+  // Codex #2970 post-merge round 5: the credit-consume line used to run
+  // unconditionally after the try/catch, so a THROWING first per-signal
+  // removeLabel call burned the credit without funding an emission — leaving a
+  // second, successful signal unable to claim it. Consuming it INSIDE the try
+  // (only on success) means a throw preserves the credit for the next iteration.
+  test("credit survives a throwing per-signal removeLabel call, funding a LATER successful signal's emission", async () => {
+    const orch = tmpOrcDir();
+    writeSignal(orch, "PROJ-THROW", "implement", {
+      status: "needs-input",
+      parkedFrom: "implement",
+    });
+    writeSignal(orch, "PROJ-THROW", "verify", {
+      status: "needs-input",
+      parkedFrom: "verify",
+    });
+    const transitions = [];
+    let needsInputCalls = 0;
+    await handleCommentWake(
+      { ticket: "PROJ-THROW", body: "answered", authorId: "human-1" },
+      {
+        orchDir: orch,
+        botUserId: "bot-uuid",
+        isManagedTicket: () => true,
+        dispatch: () => ({ code: 0 }),
+        removeLabel: async (_t, label) => {
+          if (label === "needs-human") return { removed: true, wrote: false };
+          needsInputCalls += 1;
+          // Call 1: the earlier needs-human-block cleanup earns the real write.
+          if (needsInputCalls === 1) return { removed: true, wrote: true };
+          // Call 2: the FIRST per-signal loop iteration — throws (transient error).
+          if (needsInputCalls === 2) throw new Error("transient Linear 5xx");
+          // Call 3: the SECOND per-signal loop iteration — succeeds, finds it
+          // already gone (the early write already cleared it).
+          return { removed: true, wrote: false };
+        },
+        appendWorkerTransitionEvent: (ev) => transitions.push(ev),
+      }
+    );
+    const needsInputClears = transitions.filter(
+      (e) => e.fromDisposition === "needs-input" && e.toDisposition === null
+    );
+    expect(needsInputClears).toHaveLength(1);
+  });
+
+  // Codex #2970 post-merge round 5: the EARLY needs-input removal (inside the
+  // needs-human block) can be a real, confirmed clear on its own — but a ticket
+  // with no local worker dir hits the readdirSync early-return before ever
+  // reaching the per-signal loop's own clearDispositionEmit(ticket, "needs-input")
+  // call. Without resetting it right where the confirmation is known, a live
+  // needs-input dedup entry would survive indefinitely for such a ticket.
+  test("resets the needs-input dedup entry from the EARLY removal when the ticket has no local worker dir", async () => {
+    const orch = tmpOrcDir(); // deliberately no workers/<TICKET>/ at all
+    const resetCalls = [];
+    await handleCommentWake(
+      { ticket: "PROJ-NODIR2", body: "answered", authorId: "human-1" },
+      {
+        orchDir: orch,
+        botUserId: "bot-uuid",
+        isManagedTicket: () => true,
+        dispatch: () => ({ code: 0 }),
+        removeLabel: async (_t, label) =>
+          label === "needs-human"
+            ? { removed: true, wrote: false }
+            : { removed: true, wrote: true },
+        appendWorkerTransitionEvent: () => {},
+        clearDispositionEmit: (ticket, expected) => resetCalls.push({ ticket, expected }),
+      }
+    );
+    expect(resetCalls).toContainEqual({ ticket: "PROJ-NODIR2", expected: "needs-input" });
+  });
+
   // Codex #2970 post-merge round 2, extended to needs-input for consistency with
   // the needs-human fix: when NEITHER of this invocation's two removeLabel calls
   // performed the write (a third host already cleared it before either ran), the


### PR DESCRIPTION
## Summary

Post-merge follow-up to #2974. Two narrow accounting bugs in the credit-consume and dedup-reset logic that PR built.

**1. Credit consumed on throw, even when unused.** `needsInputWroteEarly = false;` ran unconditionally after the per-signal loop's `try { removeLabel(...) } catch {}` block — so if the removeLabel call THREW (a transient Linear error), the credit earned by the earlier needs-human-block cleanup was burned without ever funding an emission, and a *second* needs-input signal on the same ticket then had no way to claim it (zero emissions for a ticket that really did get its label cleared). Moved the reset to the last line *inside* the `try`, so it only fires on a successful call — a throw leaves the credit intact for the next iteration to use.

**2. No-worker-dir early path never resets the needs-input dedup entry.** The earlier needs-human-block's `removeLabel(ticket, "needs-input")` cleanup can itself be a real, confirmed clear — but for a ticket with no local worker directory, the function returns immediately after `readdirSync` throws, before ever reaching the per-signal loop's own `clearDispositionEmit(ticket, "needs-input")` call. That left a live `needs-input` dedup entry stranded indefinitely for such tickets (no later point in the invocation, and no self-heal path, would ever reset it). Added the reset right where the early call's confirmation is known — independent of whether a worker dir exists.

## Test plan

- [x] `daemon.test.mjs` — 159/159 pass, including 2 new regression tests:
  - Two needs-input signals; the first per-signal `removeLabel` call throws, the second succeeds — asserts exactly one emission (fails with zero against the pre-fix code, since the throwing first call burns the credit the second call needed).
  - A ticket with no local worker dir, whose early needs-input removal succeeds with a real write — asserts `clearDispositionEmit(ticket, "needs-input")` is called (fails — empty — against the pre-fix code, since that path never calls it for this scenario).
- [x] `node --check` on both touched files: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)