### PR TITLE
fix(monitor): post-merge hardening — scan reachability, stop-cancels-remint, bash probe status

### DIFF
--- a/plugins/dev/scripts/__tests__/liveness-anchor-parity.test.sh
+++ b/plugins/dev/scripts/__tests__/liveness-anchor-parity.test.sh
@@ -139,18 +139,46 @@ _expect_node_eq() {
   fi
 }
 
+# _expect_bash_eq NAME EXPECTED — CTL-1612 post-merge #2978 (Codex P2
+# follow-up): the bash-side counterpart to _expect_node_eq above. CONTRACT
+# CHECK FIRST (per the finding's own caution — a resolver whose fail-open
+# path legitimately returns nonzero-with-empty would need per-fixture
+# exit-status PARITY, not a blanket fail): resolve_liveness_anchor_issue()
+# was audited and now explicitly `return 0`s on EVERY resolution path
+# (env-set, Layer-2-absent, jq-parsed, and — this round's production fix in
+# catalyst-monitor.sh — the jq-parse-failure and grep-fallback-no-match
+# paths, both of which used to leak a raw nonzero exit code: jq's own
+# invalid-JSON status on malformed input, and — because catalyst-monitor.sh
+# runs under `set -o pipefail` — grep's own no-match status through the
+# grep|head|sed pipeline on an ordinary "field not found" case). Node's
+# getLivenessAnchorIssue() has ALWAYS exited 0 unconditionally (try/catch
+# around JSON.parse, see execution-core/config.mjs). So post-fix, "exit
+# status parity with the node side" collapses to the same blanket
+# always-0-on-legitimate-resolution check as _expect_node_eq — not because
+# blanket-fail was assumed correct, but because that IS what auditing the
+# contract concluded it should be.
+_expect_bash_eq() {
+  local _name="$1" _expected="$2" _label="${3:-bash==expected}"
+  if [[ "$BASH_RC" -ne 0 ]]; then
+    fail "$_name ($_label)" "bash probe exited $BASH_RC (crash) instead of 0 — BASH_OUT='$BASH_OUT' cannot be trusted as a legitimate empty result"
+  else
+    expect_eq "$_name ($_label)" "$_expected" "$BASH_OUT"
+  fi
+}
+
 # _cell NAME EXPECTED [ENV_VAR=VAL ...] — runs BOTH implementations under
 # identical env -i fixtures and asserts bash==expected AND node==expected.
 _cell() {
   local _name="$1" _expected="$2"
   shift 2
-  local BASH_OUT
+  local BASH_OUT BASH_RC
   BASH_OUT="$(env -i PATH="$PATH" HOME="$SANDBOX_HOME" "$@" bash -c "
     source '$BASH_FN_PROBE'
     resolve_liveness_anchor_issue
   ")"
+  BASH_RC=$?
   _run_node_probe "$@"
-  expect_eq "$_name (bash==expected)" "$_expected" "$BASH_OUT"
+  _expect_bash_eq "$_name" "$_expected"
   _expect_node_eq "$_name" "$_expected"
 }
 
@@ -187,14 +215,15 @@ done
 _cell_nojq() {
   local _name="$1" _expected="$2"
   shift 2
-  local BASH_OUT
+  local BASH_OUT BASH_RC
   BASH_OUT="$(env -i PATH="$NOJQ_BIN" HOME="$SANDBOX_HOME" "$@" bash -c "
     command -v jq >/dev/null 2>&1 && echo 'FATAL: jq unexpectedly reachable in the jq-less fixture' >&2 && exit 1
     source '$BASH_FN_PROBE'
     resolve_liveness_anchor_issue
   ")"
+  BASH_RC=$?
   _run_node_probe "$@"
-  expect_eq "$_name (bash-without-jq==expected)" "$_expected" "$BASH_OUT"
+  _expect_bash_eq "$_name" "$_expected" "bash-without-jq==expected"
   _expect_node_eq "$_name" "$_expected"
 }
 
@@ -301,6 +330,44 @@ if [[ "$FAILURES" -eq $((_SAVED_FAILURES + 1)) && "$PASSES" -eq $_SAVED_PASSES ]
 else
   FAILURES=$((_SAVED_FAILURES + 1))
   echo "  FAIL: crash-detection self-test — expected exactly 1 new failure and 0 new passes from the throwing probe, got +$((FAILURES - _SAVED_FAILURES)) failures / +$((PASSES - _SAVED_PASSES)) passes"
+fi
+
+# ── Bash-side crash-detection self-test (CTL-1612 post-merge #2978, Codex P2
+# follow-up) ─────────────────────────────────────────────────────────────
+# The bash-side counterpart to the node self-test above — proves
+# _expect_bash_eq actually fails a cell when the BASH probe exits nonzero,
+# not the vacuous pass Codex reported ("the committed malformed-JSON fixture
+# already exercises that shape — the resolver returns an empty value with a
+# nonzero jq status while the suite reports the 'never throws' case as
+# passing"). Uses a throwaway function body (nonzero exit, empty output) in
+# place of the real resolve_liveness_anchor_issue() to simulate that exact
+# shape directly, without depending on jq/malformed-JSON machinery for the
+# self-test itself. Same saved/restored counter scope as the node self-test,
+# for the same reason (the intentional failure this triggers must not leak
+# into the suite's real totals).
+echo ""
+echo "Bash-side crash-detection self-test: a nonzero-exiting bash probe must FAIL the cell, not pass vacuously"
+CRASH_FN_PROBE="${TMP_DIR}/crash-resolve-liveness-anchor-issue.sh"
+cat >"$CRASH_FN_PROBE" <<'EOF'
+resolve_liveness_anchor_issue() {
+  return 7
+}
+EOF
+_SAVED_FAILURES=$FAILURES
+_SAVED_PASSES=$PASSES
+BASH_OUT="$(env -i PATH="$PATH" HOME="$SANDBOX_HOME" bash -c "
+  source '$CRASH_FN_PROBE'
+  resolve_liveness_anchor_issue
+")"
+BASH_RC=$?
+_expect_bash_eq "bash-side crash-detection self-test" ""
+if [[ "$FAILURES" -eq $((_SAVED_FAILURES + 1)) && "$PASSES" -eq $_SAVED_PASSES ]]; then
+  FAILURES=$_SAVED_FAILURES
+  PASSES=$((_SAVED_PASSES + 1))
+  echo "  PASS: bash-side crash-detection self-test (nonzero-exiting probe correctly counted as a FAIL, not a vacuous pass)"
+else
+  FAILURES=$((_SAVED_FAILURES + 1))
+  echo "  FAIL: bash-side crash-detection self-test — expected exactly 1 new failure and 0 new passes from the nonzero-exiting probe, got +$((FAILURES - _SAVED_FAILURES)) failures / +$((PASSES - _SAVED_PASSES)) passes"
 fi
 
 echo ""

--- a/plugins/dev/scripts/__tests__/run-tests.test.sh
+++ b/plugins/dev/scripts/__tests__/run-tests.test.sh
@@ -117,7 +117,6 @@ else fail "LIB_SHELL_TEST_DIR override was not wired into the shell suite" "$OUT
 # (CTL-1612 round 13) ever stops recognizing a real wrapper shape. Counts
 # occurrences of the suite's own PASS marker line directly in the runner's
 # combined output — the property this test exists to pin.
-FIX7="$(make_fixture "secrets-hygiene:0")"
 # CTL-1612 round 12 (Codex P2 follow-up): the wrapped-exclusion is now gated
 # on the wrapper file actually being discovered under the active
 # SHELL_TEST_DIR (_lib_suite_wrapper_present), which greps each file there
@@ -127,13 +126,26 @@ FIX7="$(make_fixture "secrets-hygiene:0")"
 # wrapper and this test's "runs exactly once" assertion would break for the
 # wrong reason (double-run, not a fixed detection gap).
 #
-# CTL-1612 round 15 (Codex P2 follow-up): the appended line must be shaped
+# CTL-1612 round 15 (Codex P2 follow-up): the reference line must be shaped
 # like a REAL invocation (`bash`/`exec bash` as the line's first token), not
 # a comment — detection is now anchored to that shape (see run-tests.sh), so
-# a `#`-prefixed mention no longer counts. The line is still dead code here
-# (it lands after the fixture's own `exit 0`), it just has to look like a
-# genuine wrapper line for detection purposes.
-echo 'exec bash "${SCRIPT_DIR}/../lib/__tests__/secrets-hygiene.test.sh"' >>"${FIX7}/secrets-hygiene.test.sh"
+# a `#`-prefixed mention no longer counts.
+#
+# CTL-1612 post-merge #2978 (Codex P2 follow-up): the reference line must
+# ALSO be REACHABLE — placed before any top-level `exit` (see run-tests.sh's
+# awk truncation) — or it stops counting as a wrapper too. `if false; then …
+# fi` keeps it syntactically present (and textually before the trailing
+# `exit 0`, so detection still finds it) while never actually executing at
+# runtime — this fixture's whole point is to prove "a real-shaped, reachable
+# reference counts" without this test file genuinely re-invoking anything.
+FIX7="$(mktemp -d)"
+cat >"${FIX7}/secrets-hygiene.test.sh" <<'FIX7EOF'
+#!/usr/bin/env bash
+if false; then
+	exec bash "${SCRIPT_DIR}/../lib/__tests__/secrets-hygiene.test.sh"
+fi
+exit 0
+FIX7EOF
 FIX7_LIB="$(mktemp -d)"
 cp "${FIX7}/secrets-hygiene.test.sh" "${FIX7_LIB}/secrets-hygiene.test.sh"
 OUT="$(SHELL_TEST_DIR="$FIX7" LIB_SHELL_TEST_DIR="$FIX7_LIB" EXTRA_SHELL_TESTS="" SKIP_BUN=1 bash "$RUNNER" 2>&1)"
@@ -171,10 +183,17 @@ else fail "wrapped-basename lib suite was wrongly skipped with no active wrapper
 # up to date) would double-run this fixture since it isn't a recognized
 # member, while the derived-set implementation recognizes it purely from the
 # wrapper file's own exec-target reference.
-FIX10_SHELL="$(make_fixture "brand-new-lib-suite:0")"
-# CTL-1612 round 15: real-invocation shape, not a comment — see the note on
-# the equivalent FIX7 line above.
-echo 'exec bash "${SCRIPT_DIR}/../lib/__tests__/brand-new-lib-suite.test.sh"' >>"${FIX10_SHELL}/brand-new-lib-suite.test.sh"
+# CTL-1612 round 15 + post-merge #2978: real-invocation shape, reachable
+# before the trailing `exit 0` — see the note on the equivalent FIX7 fixture
+# above.
+FIX10_SHELL="$(mktemp -d)"
+cat >"${FIX10_SHELL}/brand-new-lib-suite.test.sh" <<'FIX10EOF'
+#!/usr/bin/env bash
+if false; then
+	exec bash "${SCRIPT_DIR}/../lib/__tests__/brand-new-lib-suite.test.sh"
+fi
+exit 0
+FIX10EOF
 FIX10_LIB="$(mktemp -d)"
 cp "${FIX10_SHELL}/brand-new-lib-suite.test.sh" "${FIX10_LIB}/brand-new-lib-suite.test.sh"
 OUT="$(SHELL_TEST_DIR="$FIX10_SHELL" LIB_SHELL_TEST_DIR="$FIX10_LIB" EXTRA_SHELL_TESTS="" SKIP_BUN=1 bash "$RUNNER" 2>&1)"
@@ -212,6 +231,35 @@ else fail "comment-only mention wrongly suppressed the lib suite (0 tests, silen
 if grep -q 'shell 2 passed / 0 failed / 0 skipped' <<<"$OUT"; then
 	pass "both the commenting shell suite and the mentioned lib suite are counted independently (no dedup)"
 else fail "aggregate summary miscounted the comment-only-mention fixture" "$OUT"; fi
+
+# Test 12 (CTL-1612 post-merge #2978, Codex P2 follow-up): an invocation-
+# shaped reference that is UNREACHABLE — dead code after a top-level `exit`
+# — must NOT be treated as a real wrapper either. Codex's concrete
+# reproduction was round 15's OWN FIX7/FIX10 fixtures (fixed above in this
+# same file): `exit 0` followed by an apparent `exec bash
+# ".../lib/__tests__/x.test.sh"` line the runner never actually reaches.
+# This fixture reproduces that exact pre-fix shape on purpose, paired with a
+# LIB_SHELL_TEST_DIR suite that FAILS — if the runner still (wrongly) treats
+# the dead exec line as a genuine wrapper, the failing lib suite gets
+# silently skipped and the aggregate reports a clean PASS despite real,
+# never-executed failing coverage; post-fix it must run directly and surface
+# the failure.
+FIX12_SHELL="$(mktemp -d)"
+trap 'rm -rf "$FIX" "$FIX2" "$FIX3" "$FIX4" "$FIX5" "$FIX6" "$FIX7" "$FIX7_LIB" "$FIX9_SHELL" "$FIX9_LIB" "$FIX10_SHELL" "$FIX10_LIB" "$FIX11_SHELL" "$FIX11_LIB" "$FIX12_SHELL" "$FIX12_LIB" "$EMPTY_LIB_DIR"' EXIT
+cat >"${FIX12_SHELL}/dead-code-wrapper.test.sh" <<'FIX12EOF'
+#!/usr/bin/env bash
+exit 0
+exec bash "${SCRIPT_DIR}/../lib/__tests__/dead-code-wrapper.test.sh"
+FIX12EOF
+FIX12_LIB="$(make_fixture "dead-code-wrapper:1")"
+OUT="$(SHELL_TEST_DIR="$FIX12_SHELL" LIB_SHELL_TEST_DIR="$FIX12_LIB" EXTRA_SHELL_TESTS="" SKIP_BUN=1 bash "$RUNNER" 2>&1)"
+RC=$?
+if grep -q 'FAIL .*dead-code-wrapper\.test\.sh' <<<"$OUT"; then
+	pass "an unreachable (post-exit) invocation-shaped reference does not suppress the real lib suite"
+else fail "unreachable reference wrongly suppressed the failing lib suite (0 tests, silently skipped)" "$OUT"; fi
+if [[ $RC -ne 0 ]]; then
+	pass "the failing lib suite's failure propagates to the aggregate exit code (not masked as PASS)"
+else fail "aggregate exited 0 despite a real, never-suppressed lib-suite failure" "$OUT"; fi
 
 echo ""
 echo "Results: $PASSES passed, $FAILURES failed"

--- a/plugins/dev/scripts/catalyst-monitor.sh
+++ b/plugins/dev/scripts/catalyst-monitor.sh
@@ -173,6 +173,18 @@ resolve_liveness_anchor_issue() {
     # number as text instead of treating it as absent — bash would resolve an
     # anchor the JS side never would, diverging on a hostile/malformed config.
     jq -r '(.catalyst.cluster.livenessAnchorIssue | select(type=="string")) // empty' "$_l2_path" 2>/dev/null
+    # CTL-1612 post-merge #2978 (Codex P2 follow-up): explicit, unconditional
+    # `return 0` — this function's contract everywhere else is "never surface
+    # an internal failure as our own; a resolution miss is always a clean
+    # empty" (see the two `return 0`s above: env-unset, file-absent). jq
+    # itself exits NONZERO on malformed/invalid JSON input, and this branch
+    # used to let that raw jq exit code silently become the FUNCTION's own
+    # exit status — the parity test's canonical JS side never has this gap
+    # (getLivenessAnchorIssue wraps its JSON.parse in try/catch and always
+    # returns cleanly; see execution-core/config.mjs), so a malformed Layer-2
+    # config made bash and node agree on OUTPUT (both empty) while disagreeing
+    # on STATUS (bash nonzero, node 0) — a real robustness gap this closes.
+    return 0
   else
     # CTL-1612 round 7 (Codex P2 follow-up): jq is neither a required nor
     # optional repo dependency and bootstrap does not enforce it (a
@@ -194,6 +206,15 @@ resolve_liveness_anchor_issue() {
     grep -oE '"livenessAnchorIssue"[[:space:]]*:[[:space:]]*"[^"]*"' "$_l2_path" 2>/dev/null \
       | head -1 \
       | sed -E 's/.*:[[:space:]]*"([^"]*)"/\1/'
+    # CTL-1612 post-merge #2978 (Codex P2 follow-up): same unconditional
+    # `return 0` as the jq branch above, for a SECOND (broader) reason on
+    # this branch specifically: the script runs under `set -o pipefail`
+    # (line 11), so a NO-MATCH `grep` (the ordinary, legitimate "field not
+    # present" or "no anchor configured" case — not an error) makes the
+    # WHOLE pipeline exit 1, even though `head`/`sed` on that empty input
+    # exit 0. Without this, most jq-less "resolves to empty" cells — not
+    # just malformed input — would report a spurious nonzero status.
+    return 0
   fi
 }
 

--- a/plugins/dev/scripts/orch-monitor/__tests__/server.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/server.test.ts
@@ -2171,3 +2171,57 @@ describe("publicDir resolution", () => {
     }
   });
 });
+
+// CTL-1612 post-merge #2978 (Codex P2 follow-up): server.stop() sets the
+// `stopped` lifecycle flag (see its comment above daemonDepsPromise in
+// server.ts) SYNCHRONOUSLY, before any other cleanup step — this is what the
+// fire-and-forget remint guard (readAnchor) and the mint-result guard
+// (applyToken) both check before acting, closing the "stop before deps
+// resolve → post-stop OAuth request / process.env mutation" gap Codex
+// reported. This suite creates its own server (no clusterReader — this
+// package's real, un-mocked loadDaemonDeps()/anchor-poll prime path, same as
+// every other describe block above except cluster-signal-endpoints.test.ts)
+// to observe the __stopped debug seam (CTL-1224 convention) directly.
+//
+// Scope note: this asserts the FLAG's lifecycle (unset → true, synchronously,
+// exactly once stop() runs) — the property server.stop() itself owns and
+// this PR adds. It does NOT drive a live remint attempt through
+// readAnchor/applyToken end-to-end: doing so needs a real
+// CATALYST_LIVENESS_ANCHOR_ISSUE, which test-setup.mjs deliberately clears
+// (round 11) specifically so this hermetic suite never reaches readAnchor's
+// downstream readPeerHeartbeatsSync — a real spawn/network call with no
+// built-in test seam to fake safely. The readAnchor/applyToken guards
+// themselves are the two lines added alongside `stopped` in server.ts and
+// are covered by direct code inspection + this flag test, not a live mint.
+describe("server.stop() lifecycle flag (CTL-1612 post-merge #2978)", () => {
+  it("stopped starts false, flips true synchronously on stop(), and stays true", async () => {
+    const stopTmp = mkdtempSync(join(tmpdir(), "orch-monitor-stopflag-"));
+    const stopWt = join(stopTmp, "wt");
+    mkdirSync(stopWt, { recursive: true });
+    const stopServer = createServer({
+      port: 0,
+      wtDir: stopWt,
+      startWatcher: false,
+      annotationsDbPath: join(stopTmp, "annotations.db"),
+    });
+    try {
+      const dbg = stopServer as unknown as { __stopped?: () => boolean };
+      expect(typeof dbg.__stopped).toBe("function");
+      expect(dbg.__stopped!()).toBe(false);
+
+      void stopServer.stop(true);
+      // No await, no setTimeout: stop() sets `stopped = true` as its FIRST
+      // statement (before unsubscribers, watcher/DB teardown, etc.), so this
+      // must already be true on the very next synchronous read — proving the
+      // flag isn't racing any of that other cleanup.
+      expect(dbg.__stopped!()).toBe(true);
+
+      // Idempotent: a second stop() (bun's own server.stop tolerates
+      // double-close) leaves it true, never resets to false.
+      void stopServer.stop(true);
+      expect(dbg.__stopped!()).toBe(true);
+    } finally {
+      rmSync(stopTmp, { recursive: true, force: true });
+    }
+  });
+});

--- a/plugins/dev/scripts/orch-monitor/server.ts
+++ b/plugins/dev/scripts/orch-monitor/server.ts
@@ -1424,6 +1424,26 @@ export function createServer(opts: CreateServerOptions): BunServer {
     effectiveCapacity: number;
     activeWorkers: number;
   };
+  // CTL-1612 post-merge #2978 (Codex P2 follow-up): server.stop() clears
+  // anchorPollTimer (stops FUTURE ticks) but does nothing about work already
+  // in flight when it's called — the `loadDaemonDeps().then(...)` prime
+  // below (which calls pollAnchorHeartbeats() directly, independent of the
+  // timer, once deps resolve) can still fire after stop() if deps hadn't
+  // resolved yet, and an in-flight `monitorAppActorReminter.attempt()` can
+  // still resolve and mutate `process.env.CATALYST_MONITOR_APP_ACTOR_TOKEN`
+  // after the server has shut down — a real OAuth request outliving the
+  // server instance, observable by anything (tests, or an embedding app)
+  // that keeps the Bun process alive after closing this server. `stopped`
+  // is set synchronously at the top of server.stop (see its definition
+  // below) and checked at the two points that matter: before the
+  // fire-and-forget remint is even attempted (readAnchor, in
+  // pollAnchorHeartbeats below) and before a mint RESULT is applied
+  // (applyToken, in loadDaemonDeps below) — an attempt already past that
+  // checkpoint when stop() fires still completes its network round-trip
+  // (this is a lifecycle guard against post-stop SIDE EFFECTS, not
+  // cancellation of in-flight I/O), but its result is discarded rather than
+  // written to process.env or acted on.
+  let stopped = false;
   let daemonDepsPromise: Promise<{
     readClusterHeartbeats: (opts: { logPath?: string }) => Record<string, string>;
     readClusterAdmission: (opts: { logPath?: string }) => Record<string, NodeAdmission>;
@@ -1566,7 +1586,14 @@ export function createServer(opts: CreateServerOptions): BunServer {
           // now also exports alongside the token.
           const monitorAppActorReminter = linearRemint.createAsyncReminter({
             readCreds: linearRemint.readOrchestratorCreds,
+            // CTL-1612 post-merge #2978 (Codex P2 follow-up): an attempt() in
+            // flight when server.stop() fires still runs to completion (see
+            // the `stopped` comment above daemonDepsPromise) — this guard is
+            // what makes that harmless: a mint that resolves post-stop is
+            // discarded here instead of writing a fresh token into
+            // process.env for a server instance that no longer exists.
             applyToken: (token: string) => {
+              if (stopped) return;
               process.env.CATALYST_MONITOR_APP_ACTOR_TOKEN = token;
             },
             cooldownMs: parsePositiveFiniteDurationMs(
@@ -1903,7 +1930,13 @@ export function createServer(opts: CreateServerOptions): BunServer {
         // gate (skips the mint entirely under CATALYST_LIVENESS_READ_SOURCE=loki)
         // since that is where the real network call would otherwise happen.
         readAnchor: (args: { anchorIssue: string }) => {
-          void execCoreDeps?.remintAppActorToken();
+          // CTL-1612 post-merge #2978 (Codex P2 follow-up): don't even START
+          // a remint attempt once stopped — see the `stopped` comment above
+          // daemonDepsPromise. This closure can still run post-stop via the
+          // loadDaemonDeps().then(...) prime firing after deps resolve late
+          // (anchorPollTimer being cleared only stops the interval, not that
+          // one already-scheduled continuation).
+          if (!stopped) void execCoreDeps?.remintAppActorToken();
           const scoped = process.env.CATALYST_MONITOR_APP_ACTOR_TOKEN?.trim();
           const anchorEnv = scoped
             ? { ...process.env, LINEAR_API_TOKEN: scoped, LINEAR_API_KEY: scoped }
@@ -5498,6 +5531,11 @@ export function createServer(opts: CreateServerOptions): BunServer {
 
   const originalStop = server.stop.bind(server);
   server.stop = ((closeActiveConnections?: boolean) => {
+    // CTL-1612 post-merge #2978 (Codex P2 follow-up): set FIRST, synchronously,
+    // before any other cleanup — see the `stopped` comment above
+    // daemonDepsPromise for what this guards (the fire-and-forget remint in
+    // readAnchor, and applyToken's process.env write).
+    stopped = true;
     for (const u of unsubscribers) u();
     watcher?.stop();
     boardSnapshot.stop();
@@ -5540,6 +5578,11 @@ export function createServer(opts: CreateServerOptions): BunServer {
     () => eventRing.listenerCount();
   (server as unknown as { __sseClientCount?: () => number }).__sseClientCount =
     () => sseClients.size;
+  // CTL-1612 post-merge #2978 (Codex P2 follow-up): same CTL-1224 debug-seam
+  // convention — exposes the `stopped` lifecycle flag (see its comment above
+  // daemonDepsPromise) so a test can assert it flips synchronously, before
+  // any other stop() cleanup runs. The UI never reads this.
+  (server as unknown as { __stopped?: () => boolean }).__stopped = () => stopped;
 
   return server;
 }

--- a/plugins/dev/scripts/run-tests.sh
+++ b/plugins/dev/scripts/run-tests.sh
@@ -71,6 +71,26 @@ LIB_SHELL_TEST_DIR="${LIB_SHELL_TEST_DIR:-${SCRIPT_DIR}/lib/__tests__}"
 # every real wrapper's exact shape (`exec bash ".../lib/__tests__/<name>"`)
 # and excluding comments (start with `#`) and fixture-building `echo`/
 # `printf` lines (start with `echo`/`printf`, not `bash`/`exec`).
+#
+# CTL-1612 post-merge #2978 (Codex P2 follow-up): the round-15 shape-anchor
+# alone still matches UNREACHABLE invocation-shaped lines — dead code after a
+# top-level `exit` — codified, concretely, by round 15's OWN smoke fixtures
+# (FIX7/FIX10 in run-tests.test.sh appended their `exec bash "..."` line
+# AFTER the fixture's `exit 0`). A wrapper file shaped that way never
+# actually runs the lib suite, yet got counted as if it had, silently
+# skipping a real (and here, hypothetically failing) lib suite with
+# `RESULT: PASS`. This is heuristic territory, not a place for a real bash
+# parser (control flow, subshells, `case`, sourced files, etc. are all still
+# unaccounted for and deliberately out of scope) — the cheap, high-value
+# improvement is to stop scanning a file's text past its first TOP-LEVEL
+# `exit` line (column 0, i.e. not indented — real wrapper files are a single
+# unindented top-level statement, so this never affects them). Residual
+# imprecision is accepted: an exec line reachable only through a real branch
+# (`if`/`case`) still counts as "wrapped" even on a path that's never
+# actually taken, and one truly dead only behind further control flow before
+# ever reaching a top-level `exit` also still counts. Both are strictly
+# rarer/subtler than the reproduced "dead code after exit" shape and are
+# left for a real static analyzer, not this glob-time heuristic.
 LIB_WRAPPED_BASENAMES=""
 if [[ -d $SHELL_TEST_DIR ]]; then
 	for _wrapper_file in "$SHELL_TEST_DIR"/*.test.sh; do
@@ -78,7 +98,8 @@ if [[ -d $SHELL_TEST_DIR ]]; then
 		while IFS= read -r _wrapped_basename; do
 			[[ -n $_wrapped_basename ]] || continue
 			LIB_WRAPPED_BASENAMES="${LIB_WRAPPED_BASENAMES}${_wrapped_basename}"$'\n'
-		done < <(grep -nE '^[[:space:]]*(exec[[:space:]]+)?bash[[:space:]].*lib/__tests__/[A-Za-z0-9._-]+\.test\.sh"' "$_wrapper_file" 2>/dev/null |
+		done < <(awk '/^exit([[:space:]]|$)/{exit} {print}' "$_wrapper_file" 2>/dev/null |
+			grep -nE '^[[:space:]]*(exec[[:space:]]+)?bash[[:space:]].*lib/__tests__/[A-Za-z0-9._-]+\.test\.sh"' |
 			grep -oE 'lib/__tests__/[A-Za-z0-9._-]+\.test\.sh"' |
 			sed -E 's#^lib/__tests__/(.+)"$#\1#')
 	done


### PR DESCRIPTION
## Summary

Final CTL-1612 follow-up, addressing Codex's fresh post-merge review on #2978 (3 P2s; a 4th, the jq-less credential-parse finding, was rebutted separately as CTL-1637).

- **run-tests.sh wrapper-detection reachability**: the round-15 invocation-shape scan still matched *unreachable* lines — dead code after a top-level `exit` — which round 15's own smoke fixtures ironically demonstrated (their `exec bash "..."` reference lines were placed after `exit 0`). Tightened by truncating the scan at each wrapper file's first top-level `exit` line (cheap heuristic, not a bash parser; residual imprecision around control flow is accepted and documented). Fixed the round-15 fixtures to use a reachable-but-inert (`if false; then …; fi`) shape, and added a negative pin using the exact dead-code-after-exit shape paired with a failing lib suite — proven with a git-stash repro showing the pre-fix runner reported `RESULT: PASS` while silently skipping a real failing suite.
- **server.stop() doesn't cancel pending remint work**: a `loadDaemonDeps().then(...)` prime or an in-flight `monitorAppActorReminter.attempt()` could still fire/resolve after `server.stop()`, permitting a post-stop OAuth request and a `process.env.CATALYST_MONITOR_APP_ACTOR_TOKEN` mutation outliving the server instance. Added a `stopped` flag, set synchronously as the first statement in `server.stop()`, checked before the fire-and-forget remint attempt (`readAnchor`) and before applying a mint result (`applyToken`). Added a `__stopped` debug seam (CTL-1224 convention) and a test asserting the flag flips synchronously and stays true. The deeper "live remint attempt through readAnchor" path isn't integration-tested — deliberately: `test-setup.mjs` (rounds 4/11) seals the liveness anchor + credentials specifically so this suite never reaches a real network call, and reproducing that safely would need new mocking infrastructure disproportionate to a minimal lifecycle guard. Documented in the test file.
- **liveness-anchor-parity.test.sh bash-probe exit-status propagation**: mirrors round 15's node-side fix. Audited the bash resolver's actual contract first — `resolve_liveness_anchor_issue()` was letting jq's raw exit code (malformed JSON) *and* a pipefail-propagated grep-no-match (the ordinary "field absent" case, since the script runs under `set -o pipefail`) leak through as the function's own exit status, while the canonical JS `getLivenessAnchorIssue()` always exits 0 (try/catch around `JSON.parse`). This was a genuine bash/node divergence, not an intentional fail-open-with-nonzero design, so fixed both sides: `catalyst-monitor.sh` now explicitly `return 0`s after both branches (matching its other two paths), and the test now propagates/asserts `BASH_RC` the same way it does `NODE_RC`, with a new bash-side crash-detection self-test proving the check isn't vacuous.

## Test plan

- [x] `plugins/dev/scripts/__tests__/run-tests.test.sh` — 17/17 (was 15; +2 new assertions in the dead-code-after-exit pin)
- [x] `plugins/dev/scripts/orch-monitor/__tests__/server.test.ts` — 96/96 (was 95; +1 new stop-lifecycle test)
- [x] `plugins/dev/scripts/__tests__/liveness-anchor-parity.test.sh` — 30/30 (was 28; +2 new: node-side already present, +1 new bash-side crash self-test)
- [x] `plugins/dev/scripts/__tests__/catalyst-monitor-dist-redirect.test.sh` — 52/52 (unaffected, confirmed no regression from the `resolve_liveness_anchor_issue()` exit-code fix)
- [x] `plugins/dev/scripts/lib/__tests__/linear-app-actor.test.sh` — 32/32 (unaffected)
- [x] orch-monitor bun suite (`catalyst-monitor.test.ts` + `peer-liveness.test.ts` + `mint-cooldown-seed.test.ts` + `server-activity*.test.ts`) — 67/67
- [x] `tsc --noEmit` — clean
- [x] `shellcheck` on all touched shell files — no new findings
- [x] Each finding verified with a real git-stash repro against the pre-fix code before implementing the fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)