### PR TITLE
fix(dev): fenceGuard fails OPEN on a missing generation at the terminal-sweep needs-human escalation site

### DIFF
--- a/plugins/dev/scripts/execution-core/fence-guard.mjs
+++ b/plugins/dev/scripts/execution-core/fence-guard.mjs
@@ -193,6 +193,17 @@ export function fenceGuard(
     // default (false = fail-closed): suppressing a mutating write on "can't tell"
     // is the safe side; dropping a needs-human escalation is NOT.
     proceedOnMissingGeneration = false,
+    // CTL-1329 interlock: fired whenever a generation could not be determined
+    // (regardless of proceedOnMissingGeneration), BEFORE the proceed/fail-closed
+    // branch. A call site sitting inside the terminal-sweep's fence-suppress
+    // cooldown (stampFenceSuppress/isFenceSuppressFresh) uses this to arm the
+    // cooldown even when it opted into proceedOnMissingGeneration — a missing
+    // generation stays missing next tick regardless of whether this tick wrote,
+    // so re-probing every tick is the same unbounded burn CTL-1329 fixed
+    // (2026-06-23 OAuth-drain incident), just relocated from the write path to
+    // the terminal-probe path. Optional; default no-op so existing callers are
+    // unaffected.
+    onMissingGeneration = null,
   } = {},
 ) {
   // N=1 single-host gate: provably no peer → trust local unconditionally.
@@ -253,6 +264,16 @@ export function fenceGuard(
       }
     }
     if (!Number.isFinite(generation)) {
+      if (typeof onMissingGeneration === "function") {
+        try {
+          onMissingGeneration({ ticket });
+        } catch (err) {
+          logger?.debug?.(
+            { ticket, err: err?.message },
+            "fenceGuard: onMissingGeneration hook threw — continuing",
+          );
+        }
+      }
       if (proceedOnMissingGeneration) {
         // Loud fail-open: never silently drop an escalation on "can't tell".
         logger?.warn?.(

--- a/plugins/dev/scripts/execution-core/scheduler.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.mjs
@@ -5662,7 +5662,12 @@ export function schedulerTick(
         for (const member of anomaly.members) {
           if (triagedWaiting.includes(member)) {
             cycleMembers.add(member);
-            if (fenceGuard({ ticket: member, orchDir, multiHost, gateway, self })) {
+            if (
+              fenceGuard(
+                { ticket: member, orchDir, multiHost, gateway, self },
+                { proceedOnMissingGeneration: true }
+              )
+            ) {
               const wrote = labelNeedsHumanUnlessBeliefOwner(orchDir, member, writeStatus, {
                 env,
                 site: "dependency-cycle",
@@ -6469,7 +6474,12 @@ export function schedulerTick(
           );
           // CTL-863 fence: external Linear write — a zombie host that lost its
           // claim must not label after takeover (mirrors the A.5 cycle site).
-          if (fenceGuard({ ticket: member, orchDir, multiHost, gateway, self })) {
+          if (
+            fenceGuard(
+              { ticket: member, orchDir, multiHost, gateway, self },
+              { proceedOnMissingGeneration: true }
+            )
+          ) {
             const wrote = labelNeedsHumanUnlessBeliefOwner(orchDir, member, writeStatus, {
               env,
               site: "ctl-925-cycle",
@@ -7080,7 +7090,21 @@ export function schedulerTick(
         } else {
           // Non-terminal stalled/failed ticket → apply the belief-aware needs-human
           // label (CTL-1241: skipped when the belief engine owns the reclaim).
-          if (fenceGuard({ ticket, orchDir, multiHost, gateway, self })) {
+          if (
+            fenceGuard(
+              { ticket, orchDir, multiHost, gateway, self },
+              {
+                proceedOnMissingGeneration: true,
+                // CTL-1329: a missing generation stays missing next tick regardless
+                // of whether THIS tick's escalation write succeeded, so arm the same
+                // cooldown the fail-closed suppression branch below arms — otherwise
+                // proceeding here (instead of suppressing) reintroduces the unbounded
+                // per-tick terminal-probe burn CTL-1329 fixed, just on the write path
+                // instead of the read path.
+                onMissingGeneration: () => stampFenceSuppress(orchDir, ticket, now()),
+              }
+            )
+          ) {
             const wrote = labelNeedsHumanUnlessBeliefOwner(orchDir, ticket, writeStatus, {
               env,
               site: "terminal-sweep",


### PR DESCRIPTION
## Summary
- A stalled/failed worker dir with no `cluster-generation.json` (claimed before the cluster went multi-host) had its needs-human escalation silently dropped forever — `fenceGuard` fail-closed on a missing generation at three escalation-write sites in `schedulerTick`, when the intended behavior for an escalation write (never mutating-write) is to fail OPEN, matching the existing `stale-pr-rescue-timer` pattern.
- The terminal-sweep site sits inside the CTL-1329 fence-suppress cooldown, which bounds the per-tick terminal-probe cost for a dir whose fence keeps failing. Simply flipping that site to proceed-on-missing broke the cooldown (it never re-arms once the write succeeds), reintroducing the unbounded per-tick probe burn CTL-1329 was built to prevent. `fenceGuard` gained an optional `onMissingGeneration` hook so the terminal-sweep call site can still arm the cooldown while proceeding with the write.

## Test plan
- [x] `bun test fence-guard.test.mjs fence-guard-integration.test.mjs` — 41/41 pass
- [x] Full `execution-core` suite run twice (baseline vs. with-fix) and diffed failing-test-name sets — zero new failures introduced (176 with-fix vs. 189 baseline, with-fix a strict subset; remaining failures are pre-existing environment-dependent flakiness unrelated to this change, e.g. `hostName`/`hostId` tests reading the real machine hostname)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
https://claude.ai/code/session_018Hj1J7kfaQrPNh5RVzAPa9