### PR TITLE
fix(dev): CTL-1623 resolve github-token/webhook-secret through the secret contract

### DIFF
--- a/.github/workflows/execution-core-tests.yml
+++ b/.github/workflows/execution-core-tests.yml
@@ -579,4 +579,5 @@ jobs:
             updater/updater.test.mjs \
             updater/updater-tracing.test.mjs \
             github-auth-preflight.test.mjs \
+            github-token-candidates-legacy-parity.test.mjs \
             cluster-sync.test.mjs

--- a/plugins/dev/scripts/__tests__/catalyst-execution-core-github-token.test.sh
+++ b/plugins/dev/scripts/__tests__/catalyst-execution-core-github-token.test.sh
@@ -93,6 +93,16 @@ if [[ ! -r "$LIB" ]] || ! grep -q 'catalyst_project_github_token' "$LIB"; then
 fi
 cp "$LIB" "$T/helper.sh"
 cp "$LIB" "$T/reconcile.sh"
+# CTL-1623: catalyst-secret-env.sh now sources its sibling catalyst-secret-contract.sh via
+# a BASH_SOURCE-relative path — since the lib is COPIED into $T above (for hermeticity, so
+# a stray edit to the real file mid-run can't change results underfoot), the sibling must be
+# copied alongside it too, or that source line resolves against $T and fails closed.
+CONTRACT_LIB="$(dirname "$LIB")/catalyst-secret-contract.sh"
+if [[ ! -r "$CONTRACT_LIB" ]]; then
+  echo "FATAL: catalyst-secret-contract.sh missing at $CONTRACT_LIB" >&2
+  exit 1
+fi
+cp "$CONTRACT_LIB" "$T/catalyst-secret-contract.sh"
 
 # ─── Probe: run the helper, report booleans/digests only ──────────────────────
 cat > "$T/probe.sh" <<'PROBE'

--- a/plugins/dev/scripts/__tests__/catalyst-secret-env-legacy-parity.test.sh
+++ b/plugins/dev/scripts/__tests__/catalyst-secret-env-legacy-parity.test.sh
@@ -1,0 +1,433 @@
+#!/usr/bin/env bash
+# A/B parity: lib/catalyst-secret-env.sh's catalyst_project_github_token /
+# catalyst_project_webhook_secret (CTL-1623 fold — the FILE-READ tier now delegates to
+# lib/catalyst-secret-contract.sh's catalyst_resolve_secret) vs a FROZEN, test-local,
+# verbatim copy of the pre-fold implementation (catalyst_read_secret_file +
+# _catalyst_secret_dirs, exactly as the two wrappers called them before this ticket).
+#
+# WHY A FROZEN COPY, NOT THE LIVE catalyst_read_secret_file: that primitive itself is
+# UNCHANGED by CTL-1623 (other callers still use it directly), so referencing the live
+# function would usually be equivalent — but it would also mean a future accidental edit to
+# catalyst_read_secret_file silently moves BOTH the "legacy" and the "new" side of this
+# comparison together, defeating the parity guard's whole purpose (catching drift). The copy
+# below is pinned to what catalyst-secret-env.sh actually did before this PR.
+#
+# THIS SUITE MUST FAIL ON DIVERGENCE — every cell is an exact-string assertion, never a fuzzy
+# comparison, on the real (unmodified) lib/catalyst-secret-env.sh sourced from its real
+# on-disk location (so its BASH_SOURCE-relative `source .../catalyst-secret-contract.sh`
+# resolves correctly — unlike __tests__/catalyst-execution-core-github-token.test.sh, this
+# suite does not need to copy the lib into a scratch dir, since it never mutates or replaces
+# the file under test).
+#
+# SECRET HYGIENE: every cell runs under `env -i` (real environment fully cleared) with HOME
+# repointed at a scratch tmpdir. Fixtures are obviously-fake literals.
+#
+# Run: bash plugins/dev/scripts/__tests__/catalyst-secret-env-legacy-parity.test.sh
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../../.." && pwd)"
+LIB="${REPO_ROOT}/plugins/dev/scripts/lib/catalyst-secret-env.sh"
+
+FAILURES=0
+PASSES=0
+ok() { PASSES=$((PASSES + 1)); }
+fail() {
+  local name="$1" detail="$2"
+  FAILURES=$((FAILURES + 1))
+  echo "  FAIL: $name"
+  echo "    $detail"
+}
+expect_eq() {
+  local name="$1" expected="$2" actual="$3"
+  if [[ "$expected" == "$actual" ]]; then
+    ok
+  else
+    fail "$name" "expected='$expected' actual='$actual'"
+  fi
+}
+
+if [[ ! -f "$LIB" ]]; then
+  echo "  SKIP: catalyst-secret-env-legacy-parity (lib missing: $LIB)"
+  echo ""
+  echo "Total: 0, Passed: 0, Failed: 0, Skipped: 1"
+  exit 0
+fi
+
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+SANDBOX_HOME="${TMP_DIR}/home"
+mkdir -p "$SANDBOX_HOME"
+
+# ─── FROZEN LEGACY REFERENCE (verbatim pre-CTL-1623 chain) ────────────────────────────────
+LEGACY_LIB="${TMP_DIR}/legacy-secret-env.sh"
+cat > "$LEGACY_LIB" <<'LEGACY'
+#!/usr/bin/env bash
+_legacy_strip_eol() {
+  local s="$1"
+  while [[ "$s" == *$'\n' || "$s" == *$'\r' ]]; do
+    s="${s%$'\n'}"
+    s="${s%$'\r'}"
+  done
+  printf '%s' "$s"
+}
+_legacy_is_blank() {
+  [[ -z "${1//[[:space:]]/}" ]]
+}
+_legacy_secret_dirs() {
+  local _l2="${CATALYST_LAYER2_CONFIG_FILE:-${HOME}/.config/catalyst/config.json}"
+  printf '%s\n' "$(dirname "$_l2")"
+  printf '%s\n' "${XDG_CONFIG_HOME:-${HOME}/.config}/catalyst"
+}
+legacy_read_secret_file() {
+  local _base="${1:?basename required}"
+  local _explicit_path="${2:-}" _explicit_dir="${3:-}"
+  local _f _raw _val
+  local -a _cands=()
+  if [[ -n "$_explicit_path" ]]; then
+    _cands=("$_explicit_path")
+  elif [[ -n "$_explicit_dir" ]]; then
+    _cands=("${_explicit_dir}/${_base}")
+  else
+    local _d
+    while IFS= read -r _d; do
+      [[ -n "$_d" ]] && _cands+=("${_d}/${_base}")
+    done < <(_legacy_secret_dirs)
+  fi
+  for _f in "${_cands[@]}"; do
+    [[ -r "$_f" ]] || continue
+    _raw="$(cat "$_f" 2>/dev/null)" || continue
+    _val="$(_legacy_strip_eol "$_raw")"
+    if ! _legacy_is_blank "$_val"; then
+      printf '%s' "$_val"
+      return 0
+    fi
+  done
+  return 1
+}
+legacy_project_github_token() {
+  local _tok
+  if _tok="$(legacy_read_secret_file "github-token" "${CATALYST_GITHUB_TOKEN_FILE:-}" "${CATALYST_CONFIG_DIR:-}")"; then
+    export GITHUB_TOKEN="$_tok" GH_TOKEN="$_tok"
+    export CATALYST_GITHUB_TOKEN_SOURCE="shared-file"
+  elif [[ -n "${GH_TOKEN:-}" ]]; then
+    export GH_TOKEN
+    export CATALYST_GITHUB_TOKEN_SOURCE="inherited"
+  elif [[ -n "${GITHUB_TOKEN:-}" ]]; then
+    export GITHUB_TOKEN
+    export GH_TOKEN="$GITHUB_TOKEN"
+    export CATALYST_GITHUB_TOKEN_SOURCE="inherited"
+  else
+    export CATALYST_GITHUB_TOKEN_SOURCE="none"
+  fi
+}
+legacy_project_webhook_secret() {
+  local _val
+  if _val="$(legacy_read_secret_file "webhook-secret" "${CATALYST_WEBHOOK_SECRET_FILE:-}" "${CATALYST_CONFIG_DIR:-}")"; then
+    export CATALYST_WEBHOOK_SECRET="$_val"
+  fi
+}
+LEGACY
+
+# ─── probe helpers ──────────────────────────────────────────────────────────────────────
+# Reports each var on its own line as NAME=set:<value> or NAME=unset — never pipe-joined
+# (test cell (h) below deliberately puts a literal "|" INSIDE a token value, so a
+# pipe-delimited report would itself be corrupted by the very hazard it exists to catch).
+_report_github() {
+  local n
+  for n in GITHUB_TOKEN GH_TOKEN CATALYST_GITHUB_TOKEN_SOURCE; do
+    if [[ -n "${!n+x}" ]]; then printf '%s=set:%s\n' "$n" "${!n}"; else printf '%s=unset\n' "$n"; fi
+  done
+}
+_report_webhook() {
+  if [[ -n "${CATALYST_WEBHOOK_SECRET+x}" ]]; then
+    printf 'CATALYST_WEBHOOK_SECRET=set:%s\n' "$CATALYST_WEBHOOK_SECRET"
+  else
+    printf 'CATALYST_WEBHOOK_SECRET=unset\n'
+  fi
+}
+
+# _cell_github NAME [ENV_VAR=VAL ...] -- runs BOTH the real (folded) and the frozen legacy
+# catalyst_project_github_token under identical env -i fixtures, asserts byte-identical
+# GITHUB_TOKEN/GH_TOKEN/CATALYST_GITHUB_TOKEN_SOURCE.
+_cell_github() {
+  local _name="$1"
+  shift
+  local NEW_OUT LEGACY_OUT
+  NEW_OUT="$(env -i PATH="$PATH" HOME="$SANDBOX_HOME" "$@" bash -c "
+    source '$LIB'
+    catalyst_project_github_token
+    $(declare -f _report_github)
+    _report_github
+  ")"
+  LEGACY_OUT="$(env -i PATH="$PATH" HOME="$SANDBOX_HOME" "$@" bash -c "
+    source '$LEGACY_LIB'
+    legacy_project_github_token
+    $(declare -f _report_github)
+    _report_github
+  ")"
+  expect_eq "$_name" "$LEGACY_OUT" "$NEW_OUT"
+}
+
+# _cell_webhook NAME [ENV_VAR=VAL ...] -- same shape, for catalyst_project_webhook_secret.
+_cell_webhook() {
+  local _name="$1"
+  shift
+  local NEW_OUT LEGACY_OUT
+  NEW_OUT="$(env -i PATH="$PATH" HOME="$SANDBOX_HOME" "$@" bash -c "
+    source '$LIB'
+    catalyst_project_webhook_secret
+    $(declare -f _report_webhook)
+    _report_webhook
+  ")"
+  LEGACY_OUT="$(env -i PATH="$PATH" HOME="$SANDBOX_HOME" "$@" bash -c "
+    source '$LEGACY_LIB'
+    legacy_project_webhook_secret
+    $(declare -f _report_webhook)
+    _report_webhook
+  ")"
+  expect_eq "$_name" "$LEGACY_OUT" "$NEW_OUT"
+}
+
+# ─── (a) explicit path override ─────────────────────────────────────────────────────────
+OVERRIDE_DIR="${TMP_DIR}/override"
+mkdir -p "$OVERRIDE_DIR"
+printf 'override-tok' > "${OVERRIDE_DIR}/gh.token"
+_cell_github "(a) CATALYST_GITHUB_TOKEN_FILE explicit override" \
+  "CATALYST_GITHUB_TOKEN_FILE=${OVERRIDE_DIR}/gh.token"
+
+printf 'override-whs' > "${OVERRIDE_DIR}/whs.token"
+_cell_webhook "(a) CATALYST_WEBHOOK_SECRET_FILE explicit override" \
+  "CATALYST_WEBHOOK_SECRET_FILE=${OVERRIDE_DIR}/whs.token"
+
+# ─── (b) CATALYST_CONFIG_DIR explicit dir ───────────────────────────────────────────────
+CFG_DIR="${TMP_DIR}/cfgdir"
+mkdir -p "$CFG_DIR"
+printf 'cfgdir-tok' > "${CFG_DIR}/github-token"
+printf 'cfgdir-whs' > "${CFG_DIR}/webhook-secret"
+_cell_github "(b) CATALYST_CONFIG_DIR explicit dir (github-token)" "CATALYST_CONFIG_DIR=${CFG_DIR}"
+_cell_webhook "(b) CATALYST_CONFIG_DIR explicit dir (webhook-secret)" "CATALYST_CONFIG_DIR=${CFG_DIR}"
+
+# ─── (c) CATALYST_LAYER2_CONFIG_FILE-derived dir ────────────────────────────────────────
+L2_DIR="${TMP_DIR}/l2dir"
+mkdir -p "$L2_DIR"
+printf 'l2dir-tok' > "${L2_DIR}/github-token"
+_cell_github "(c) CATALYST_LAYER2_CONFIG_FILE-derived dir" \
+  "CATALYST_LAYER2_CONFIG_FILE=${L2_DIR}/config.json"
+
+# ─── (d) default layer2 dir + XDG_CONFIG_HOME dedupe ────────────────────────────────────
+# (d1) same-dir dedupe: no XDG_CONFIG_HOME set, so the default layer2 dir and the XDG dir
+# are literally the same path — one candidate, not two.
+DEDUPE_HOME="${TMP_DIR}/dedupe-home"
+mkdir -p "${DEDUPE_HOME}/.config/catalyst"
+printf 'dedupe-tok' > "${DEDUPE_HOME}/.config/catalyst/github-token"
+_cell_github "(d1) default dir + XDG dedupe (same dir, one candidate)" \
+  "HOME=${DEDUPE_HOME}"
+
+# (d2) distinct XDG dir: the default layer2-dir candidate is absent; only the SEPARATE XDG
+# candidate holds the file — both implementations must fall through to it identically.
+XDG_HOME="${TMP_DIR}/xdg-home"
+XDG_DIR="${TMP_DIR}/xdg-only"
+mkdir -p "$XDG_HOME" "${XDG_DIR}/catalyst"
+printf 'xdg-only-tok' > "${XDG_DIR}/catalyst/github-token"
+_cell_github "(d2) distinct XDG_CONFIG_HOME (two-candidate case, second wins)" \
+  "HOME=${XDG_HOME}" "XDG_CONFIG_HOME=${XDG_DIR}"
+
+# ─── (e) file absent everywhere ─────────────────────────────────────────────────────────
+ABSENT_HOME="${TMP_DIR}/absent-home"
+mkdir -p "$ABSENT_HOME"
+_cell_github "(e) file absent everywhere, nothing inherited (github-token)" "HOME=${ABSENT_HOME}"
+_cell_webhook "(e) file absent everywhere (webhook-secret)" "HOME=${ABSENT_HOME}"
+_cell_github "(e) file absent everywhere, GH_TOKEN inherited" "HOME=${ABSENT_HOME}" "GH_TOKEN=inherited-fallback"
+
+# ─── (f) whitespace-only file — falls through, never exports "" ────────────────────────
+BLANK_DIR="${TMP_DIR}/blank"
+mkdir -p "$BLANK_DIR"
+printf '   \t \n  ' > "${BLANK_DIR}/github-token"
+_cell_github "(f) whitespace-only file, nothing inherited — falls through to none" \
+  "CATALYST_CONFIG_DIR=${BLANK_DIR}"
+_cell_github "(f) whitespace-only file, GH_TOKEN inherited — falls through to inherited" \
+  "CATALYST_CONFIG_DIR=${BLANK_DIR}" "GH_TOKEN=fallback-after-blank"
+printf '  \n\t\n' > "${BLANK_DIR}/webhook-secret"
+_cell_webhook "(f) whitespace-only webhook file — never exports \"\"" \
+  "CATALYST_CONFIG_DIR=${BLANK_DIR}"
+
+# ─── (g) trailing \n, \r\n, \n\n stripping — byte-identical token ──────────────────────
+EOL_DIR="${TMP_DIR}/eol"
+mkdir -p "$EOL_DIR"
+printf 'eol-tok-lf\n' > "${EOL_DIR}/github-token"
+_cell_github "(g) single trailing LF stripped" "CATALYST_CONFIG_DIR=${EOL_DIR}"
+printf 'eol-tok-crlf\r\n' > "${EOL_DIR}/github-token"
+_cell_github "(g) trailing CRLF stripped" "CATALYST_CONFIG_DIR=${EOL_DIR}"
+printf 'eol-tok-lflf\n\n' > "${EOL_DIR}/github-token"
+_cell_github "(g) double trailing LF stripped" "CATALYST_CONFIG_DIR=${EOL_DIR}"
+printf 'eol-tok-crlfcrlf\r\n\r\n' > "${EOL_DIR}/github-token"
+_cell_github "(g) double trailing CRLF stripped" "CATALYST_CONFIG_DIR=${EOL_DIR}"
+
+# ─── (h) value with internal whitespace AND a literal "|" (pipe-in-value hazard) ────────
+PIPE_DIR="${TMP_DIR}/pipe"
+mkdir -p "$PIPE_DIR"
+printf 'tok|with|pipes and spaces\ttab-too\n' > "${PIPE_DIR}/github-token"
+_cell_github "(h) internal whitespace + literal pipe survives byte-for-byte" \
+  "CATALYST_CONFIG_DIR=${PIPE_DIR}"
+printf 'whs|with|pipes\n' > "${PIPE_DIR}/webhook-secret"
+_cell_webhook "(h) webhook secret with literal pipe survives byte-for-byte" \
+  "CATALYST_CONFIG_DIR=${PIPE_DIR}"
+
+# ─── (i) github-token projection precedence combos ──────────────────────────────────────
+FILE_DIR="${TMP_DIR}/precedence"
+mkdir -p "$FILE_DIR"
+printf 'file-wins-tok' > "${FILE_DIR}/github-token"
+_cell_github "(i) file present AND GH_TOKEN/GITHUB_TOKEN inherited — file wins" \
+  "CATALYST_CONFIG_DIR=${FILE_DIR}" "GH_TOKEN=stale-gh" "GITHUB_TOKEN=stale-github"
+_cell_github "(i) no file, GH_TOKEN inherited — GH_TOKEN wins, no mirror needed" \
+  "HOME=${ABSENT_HOME}" "GH_TOKEN=inherited-gh-only"
+_cell_github "(i) no file, GITHUB_TOKEN-only inherited — mirrored onto GH_TOKEN" \
+  "HOME=${ABSENT_HOME}" "GITHUB_TOKEN=inherited-github-only"
+_cell_github "(i) nothing anywhere — both stay unset, SOURCE=none" "HOME=${ABSENT_HOME}"
+_cell_github "(i) no file, BOTH inherited — GH_TOKEN outranks GITHUB_TOKEN" \
+  "HOME=${ABSENT_HOME}" "GH_TOKEN=gh-wins" "GITHUB_TOKEN=github-loses"
+
+# ─── (j) CATALYST_SECRET_LAST_VALUE breadcrumb is UNSET after the wrapper returns ───────
+# Real lib only — the frozen legacy reference never touches this var at all, so there is
+# nothing to compare against; this is a standalone regression assertion (SECRET HYGIENE:
+# the wrapper runs in launcher shells whose env is inherited by every long-lived daemon and
+# child, so a lingering plain shell variable holding the raw credential is a leak surface).
+BREADCRUMB_DIR="${TMP_DIR}/breadcrumb"
+mkdir -p "$BREADCRUMB_DIR"
+printf 'breadcrumb-tok' > "${BREADCRUMB_DIR}/github-token"
+BREADCRUMB_OUT="$(env -i PATH="$PATH" HOME="$SANDBOX_HOME" "CATALYST_CONFIG_DIR=${BREADCRUMB_DIR}" bash -c "
+  source '$LIB'
+  catalyst_project_github_token
+  if [[ -n \"\${CATALYST_SECRET_LAST_VALUE+x}\" ]]; then echo 'LEAKED'; else echo 'CLEAN'; fi
+")"
+expect_eq "(j) CATALYST_SECRET_LAST_VALUE unset after catalyst_project_github_token" "CLEAN" "$BREADCRUMB_OUT"
+
+printf 'breadcrumb-whs' > "${BREADCRUMB_DIR}/webhook-secret"
+BREADCRUMB_WHS_OUT="$(env -i PATH="$PATH" HOME="$SANDBOX_HOME" "CATALYST_CONFIG_DIR=${BREADCRUMB_DIR}" bash -c "
+  source '$LIB'
+  catalyst_project_webhook_secret
+  if [[ -n \"\${CATALYST_SECRET_LAST_VALUE+x}\" ]]; then echo 'LEAKED'; else echo 'CLEAN'; fi
+")"
+expect_eq "(j) CATALYST_SECRET_LAST_VALUE unset after catalyst_project_webhook_secret" "CLEAN" "$BREADCRUMB_WHS_OUT"
+
+# Also: the breadcrumb must be unset even on the "no file, nothing inherited" path (the
+# engine still calls _csc_set_result internally for the "none" result).
+BREADCRUMB_NONE_OUT="$(env -i PATH="$PATH" HOME="$ABSENT_HOME" bash -c "
+  source '$LIB'
+  catalyst_project_github_token
+  if [[ -n \"\${CATALYST_SECRET_LAST_VALUE+x}\" ]]; then echo 'LEAKED'; else echo 'CLEAN'; fi
+")"
+expect_eq "(j) CATALYST_SECRET_LAST_VALUE unset even on the none/absent path" "CLEAN" "$BREADCRUMB_NONE_OUT"
+
+# ─── FLAGGED DIVERGENCES (fail-closed, outside the byte-parity fixture space) ───────────
+#
+# Four known divergences between the legacy chain (permissive: reads whatever bytes are on
+# disk) and the folded engine chain (defensive: rejects a candidate it cannot represent
+# identically on both the bash and JS sides of the CTL-1616 registry, per the PARITY GUARD
+# rationale in lib/catalyst-secret-contract.sh's _csc_contains_nul/_csc_is_valid_utf8 and
+# _csc_is_blank). In every case the engine FAILS CLOSED (falls through / resolves to none)
+# where the legacy reader would have silently served a mutated or locale-dependent value —
+# fail-closed is the deliberate, safer choice: a credential-shaped string that cannot be
+# represented byte-for-byte on both engines is not a value either engine should hand a
+# caller with confidence.
+#
+#   (a) NUL-containing file — PINNED BELOW. Legacy: bash's `$(cat ...)` command
+#       substitution silently DROPS the NUL byte (not a truncation — the surrounding bytes
+#       survive concatenated, e.g. "c\0loud" reads back as "cloud", 5 bytes not 6) and
+#       exports that mutated value. Folded: _csc_contains_nul rejects the candidate outright
+#       (falls through / none) — a mutated credential is worse than no credential.
+#   (b) invalid-UTF-8-byte file — PINNED BELOW. Legacy: `cat` preserves the raw bytes
+#       exactly (bash strings are untyped byte arrays) and exports them verbatim, even
+#       though the JS engine's readFileSync(...,"utf8") would silently replace the same
+#       bytes with U+FFFD — a cross-engine representation mismatch. Folded:
+#       _csc_is_valid_utf8 (iconv round-trip) rejects the candidate — neither engine can
+#       represent the value identically, so neither serves it.
+#   (c) NBSP-only file, locale-dependent (KNOWN, no cell — not portably pinnable in CI):
+#       legacy's _catalyst_is_blank uses the POSIX [[:space:]] class, which macOS classifies
+#       NBSP (U+00A0) as space under a UTF-8 locale (but a C-locale Linux runner does not) —
+#       so a NBSP-only file's blank/non-blank verdict depends on the RUNNER's locale under
+#       legacy. The folded engine's _csc_is_blank uses an explicit ASCII whitespace set (the
+#       CTL-1617 locale lesson), so its verdict is locale-INDEPENDENT — deliberately more
+#       predictable, not something a single CI runner's locale could prove either way.
+#   (d) HOME unset/empty (KNOWN, no cell — already covered from the JS-candidates angle in
+#       github-token-candidates-legacy-parity.test.mjs's HOME="" tests): legacy's
+#       _catalyst_secret_dirs interpolates "${HOME}/.config/catalyst/config.json" directly —
+#       an empty/unset HOME degenerates to the ABSOLUTE path "/.config/catalyst/config.json"
+#       (rooted at the filesystem root). The folded engine's catalyst_secret_candidates /
+#       catalyst_secret_resolve_layer2_path explicitly fall back to `~` (real HOME) when
+#       "${HOME-}" is empty — the same "??-vs-length-check" root cause as the JS suite's
+#       HOME="" divergence, just expressed as a bash `${HOME-}` emptiness check instead.
+#
+# (a) and (b) are pinned here because they are simple, deterministic, single-fixture
+# repros; (c) and (d) are locale/environment-dependent and are documented, not cell-pinned,
+# for the same reason the JS suite documents rather than blanket-asserts its HOME="" case
+# across every possible libc/locale.
+
+# ─── (a) NUL-containing file — FAILS CLOSED on the folded side (asserts NEW behavior, NOT
+# legacy parity — the two implementations deliberately diverge here) ────────────────────
+NUL_DIR="${TMP_DIR}/nul"
+mkdir -p "$NUL_DIR"
+printf 'c\x00loud' > "${NUL_DIR}/github-token"
+
+LEGACY_NUL_OUT="$(env -i PATH="$PATH" HOME="$SANDBOX_HOME" "CATALYST_CONFIG_DIR=${NUL_DIR}" bash -c "
+  source '$LEGACY_LIB'
+  legacy_project_github_token 2>/dev/null
+  $(declare -f _report_github)
+  _report_github
+")"
+NEW_NUL_OUT="$(env -i PATH="$PATH" HOME="$SANDBOX_HOME" "CATALYST_CONFIG_DIR=${NUL_DIR}" bash -c "
+  source '$LIB'
+  catalyst_project_github_token
+  $(declare -f _report_github)
+  _report_github
+")"
+# Pin the legacy (permissive) shape exactly, so a future accidental change to the frozen
+# reference itself doesn't silently make this "divergence" comparison meaningless.
+expect_eq "(a) DOCUMENTED: legacy exports the NUL-stripped mutated value" \
+  $'GITHUB_TOKEN=set:cloud\nGH_TOKEN=set:cloud\nCATALYST_GITHUB_TOKEN_SOURCE=set:shared-file' \
+  "$LEGACY_NUL_OUT"
+# Pin the NEW (folded, fail-closed) behavior — this is the assertion that matters: the
+# folded wrapper must NEVER export a NUL-mutated credential.
+expect_eq "(a) FLAGGED DIVERGENCE: folded wrapper fails closed on a NUL-containing file (source=none)" \
+  $'GITHUB_TOKEN=unset\nGH_TOKEN=unset\nCATALYST_GITHUB_TOKEN_SOURCE=set:none' \
+  "$NEW_NUL_OUT"
+if [[ "$LEGACY_NUL_OUT" == "$NEW_NUL_OUT" ]]; then
+  fail "(a) sanity: legacy and folded must NOT agree here" "they matched — the divergence fixture is broken"
+else
+  ok
+fi
+
+# ─── (b) invalid-UTF-8-byte file — FAILS CLOSED on the folded side ──────────────────────
+BADUTF8_DIR="${TMP_DIR}/badutf8"
+mkdir -p "$BADUTF8_DIR"
+printf '\xff\xfehi' > "${BADUTF8_DIR}/github-token"
+
+LEGACY_BADUTF8_OUT="$(env -i PATH="$PATH" HOME="$SANDBOX_HOME" "CATALYST_CONFIG_DIR=${BADUTF8_DIR}" bash -c "
+  source '$LEGACY_LIB'
+  legacy_project_github_token 2>/dev/null
+  echo \"SOURCE=\${CATALYST_GITHUB_TOKEN_SOURCE-<unset>}\"
+  printf '%s' \"\${GITHUB_TOKEN-}\" | od -An -tx1 | tr -d ' \n'
+")"
+NEW_BADUTF8_OUT="$(env -i PATH="$PATH" HOME="$SANDBOX_HOME" "CATALYST_CONFIG_DIR=${BADUTF8_DIR}" bash -c "
+  source '$LIB'
+  catalyst_project_github_token
+  echo \"SOURCE=\${CATALYST_GITHUB_TOKEN_SOURCE-<unset>}\"
+  printf '%s' \"\${GITHUB_TOKEN-}\" | od -An -tx1 | tr -d ' \n'
+")"
+expect_eq "(b) DOCUMENTED: legacy exports the raw invalid-UTF-8 bytes verbatim" \
+  $'SOURCE=shared-file\nfffe6869' \
+  "$LEGACY_BADUTF8_OUT"
+expect_eq "(b) FLAGGED DIVERGENCE: folded wrapper fails closed on an invalid-UTF-8 file (source=none, nothing exported)" \
+  "SOURCE=none" \
+  "$NEW_BADUTF8_OUT"
+if [[ "$LEGACY_BADUTF8_OUT" == "$NEW_BADUTF8_OUT" ]]; then
+  fail "(b) sanity: legacy and folded must NOT agree here" "they matched — the divergence fixture is broken"
+else
+  ok
+fi
+
+echo ""
+echo "Total: $((PASSES + FAILURES)), Passed: $PASSES, Failed: $FAILURES, Skipped: 0"
+[[ $FAILURES -eq 0 ]]

--- a/plugins/dev/scripts/execution-core/daemon.mjs
+++ b/plugins/dev/scripts/execution-core/daemon.mjs
@@ -134,6 +134,7 @@ import {
   defaultAppendOperatorEvent,
 } from "./recovery.mjs"; // CTL-655: window the revive budget to this run; CTL-736: reset progress high-water; CTL-768: --resume; CTL-1044: operator-event appender for the scheduler's appendIntentEvent seam
 import { resolveGithubBootAuth, rearmGithubTokenFromFile } from "./github-auth-preflight.mjs"; // CTL-1612: boot GitHub-credential preflight (advisory; alerts only on a definitive 401)
+import { registerRearmHook, armSecret } from "../lib/secret-contract.mjs"; // CTL-1623: wires rearmGithubTokenFromFile as the github-token row's registered timer rearm hook
 import { startAutoTuner } from "./autotune.mjs"; // CTL-684: side-car maxParallel auto-tuner
 import { dispatchTicket, makeCommentWakeDispatch, makePhaseAwareDispatchFn } from "./dispatch.mjs"; // CTL-549: comment-wake re-dispatch; CTL-1365a/b: executor→dispatch selection at the launch seam + comment-wake executor binding; CTL-1457: per-phase-aware dispatchFn factory (owns the executor→dispatch selection internally)
 import { resolveSdkBootExecutor, assertSdkAuth } from "./sdk-run-phase-agent.mjs"; // CTL-1367 item 9 + P3: boot auth gate (subscription-only) that degrades sdk→bg AND emits execution-core.executor.bg-fallback so the silent fallback is observable; CTL-1457 (T5): assertSdkAuth also gates a per-phase sdk route on a bg/default node
@@ -147,6 +148,14 @@ import { createGatewayReader } from "./gateway-read.mjs";
 import { createReplicaReader } from "./replica-read.mjs"; // CTL-1340: read-replica tier reader
 import { isBgJobAlive, refreshAgents, listClaudeAgentsResult } from "./claude-agents.mjs"; // CTL-1165 D3: fail-closed liveness reader for job-dir GC
 import { reconcileSdkRegistryOnBoot } from "./sdk-worker-registry.mjs"; // CTL-1410 Phase B
+
+// CTL-1623: register the github-token row's rearm hook at module load — BEFORE either
+// call site below (both live inside startDaemon(), invoked only later) can fire. Makes
+// the registry's "re-armable/timer" label live wiring instead of aspiration: previously
+// nothing had called registerRearmHook, so armSecret("github-token") would have taken the
+// hookless-degrade path (design §6). registerRearmHook is idempotent (Map.set), so a
+// module re-evaluation (a test re-importing this file) never double-registers.
+registerRearmHook("github-token", ({ env }) => rearmGithubTokenFromFile({ env, log }));
 
 const DEFAULT_MAX_PARALLEL = 3;
 
@@ -1114,7 +1123,10 @@ export function startDaemon({
     // superseded. The probe is deliberately NOT here — it spawns `gh` with a 10s timeout,
     // and putting a network round-trip ahead of crash recovery would delay re-dispatching
     // in-flight work for no diagnostic benefit. It runs after the dispatches instead.
-    rearmGithubTokenFromFile({ env: process.env, log });
+    // CTL-1623: routed through armSecret so the registered rearm hook fires (registerRearmHook
+    // above) instead of calling rearmGithubTokenFromFile directly — same effect (the hook
+    // closure IS rearmGithubTokenFromFile), but through the registry's arm path.
+    armSecret("github-token", { env: process.env });
 
     const bootResume = reconcileBoot({
       orchDir,
@@ -1385,11 +1397,15 @@ export function startDaemon({
         // `head-unchanged` without re-reading the file, and the rotation may also have been
         // materialized by the OTHER writer (cluster-sync at boot, or an operator). The call
         // is a cheap local read, no-ops when the value is unchanged, and never throws.
-        try {
-          rearmGithubTokenFromFile({ env: process.env, log });
-        } catch (err) {
-          log.warn({ err: err?.message }, "cluster-sync timer: credential re-arm threw (continuing)");
-        }
+        // CTL-1623: routed through armSecret (same hook, registered above) — see the
+        // boot-time call site's comment for why this isn't a second rearmGithubTokenFromFile
+        // call. No surrounding try/catch: armSecret itself never throws (it wraps the
+        // registered hook call in its own try/catch and returns the quiet
+        // {armed:false,...} triple on failure — see secret-contract.mjs's armSecret), and
+        // the hook closure (rearmGithubTokenFromFile) already logs+swallows its own errors
+        // via `log`. A wrapping try/catch here would only ever imply protection the callee
+        // already provides.
+        armSecret("github-token", { env: process.env });
       }, clusterSyncIntervalMs);
       _clusterSyncTimer.unref?.();
     }

--- a/plugins/dev/scripts/execution-core/github-auth-preflight.mjs
+++ b/plugins/dev/scripts/execution-core/github-auth-preflight.mjs
@@ -19,11 +19,10 @@
 // Run: cd plugins/dev/scripts/execution-core && bun test github-auth-preflight.test.mjs
 import { spawnSync } from "node:child_process";
 import { readFileSync } from "node:fs";
-import { homedir } from "node:os";
-import { dirname, join } from "node:path";
 
 import { log as defaultLog } from "./config.mjs";
 import { emitGithubAuthUnusable } from "./dispatch-alert.mjs";
+import { secretFileCandidates } from "../lib/secret-contract.mjs"; // CTL-1623: the github-token row's candidate chain, single-sourced from the registry
 
 // Bounded so a hung/unreachable api.github.com can never wedge daemon boot.
 export const GITHUB_PROBE_TIMEOUT_MS = 10_000;
@@ -72,30 +71,31 @@ export function defaultProbeGithubAuth(env = process.env) {
   }
 }
 
-// githubTokenFileCandidates — the resolution CHAIN, in priority order. Mirrors the
-// launcher's _project_shared_github_token exactly.
+// githubTokenFileCandidates — the resolution CHAIN, in priority order. CTL-1623: delegates
+// to the shared secret contract (lib/secret-contract.mjs's secretFileCandidates) instead of
+// hand-rolling a second copy of the chain — this function and
+// lib/catalyst-secret-env.sh's catalyst_project_github_token were the last CTL-1612 pair
+// still reading it by hand; the engine is now the single source for both.
 //
 // The writers disagree (Codex P1, round 2): cluster-sync materializes bare secrets into
 // dirname(getLayer2ConfigPath()), whose default is HARDCODED ~/.config/catalyst and is
 // NOT XDG-aware, while other tooling (setup-webhooks.sh:23, lib/linear-app-actor.sh:30)
 // IS. Reading only the XDG path would miss every rotation on an XDG host — strictly worse
 // than the hardcoded read. So prefer cluster-sync's own destination, then fall back to
-// the XDG location, and take the first readable non-empty file.
+// the XDG location, and take the first readable non-empty file. See
+// secretFileCandidates/explicitFileOverrideEnvName in lib/secret-contract.mjs for the exact
+// chain (explicit CATALYST_GITHUB_TOKEN_FILE override → CATALYST_CONFIG_DIR →
+// cluster-sync's own destination dir → XDG dir).
+//
+// ONE FLAGGED BEHAVIOR CHANGE (CTL-1623, HOME=""): the pre-fold chain used
+// `env?.HOME ?? homedir()`, which only substitutes on HOME being null/undefined — an
+// explicit empty-string HOME was used as-is (dirname("" + "/.config/...") stays relative to
+// "."). The engine's chain length-checks HOME (`typeof env?.HOME === "string" &&
+// env.HOME.length > 0`) and falls back to homedir() for an empty string too — the saner
+// behavior for a degenerate, presumably-unintentional HOME="". See
+// github-auth-preflight.test.mjs's "HOME=''" cell for the pinned before/after.
 export function githubTokenFileCandidates(env = process.env) {
-  if (env?.CATALYST_GITHUB_TOKEN_FILE) return [env.CATALYST_GITHUB_TOKEN_FILE];
-  // CTL-1612: honor CATALYST_CONFIG_DIR exactly as the launcher's
-  // catalyst_read_secret_file does. Without this the two disagree — the launcher arms from
-  // the configured directory and labels it "shared-file", then this re-arm (boot AND every
-  // timer tick) replaces both aliases from the DEFAULT directory. If that copy is stale the
-  // daemon silently reverts to 401s, which is the exact divergence the shared library was
-  // introduced to eliminate, recreated across the bash/JS boundary.
-  if (env?.CATALYST_CONFIG_DIR) return [join(env.CATALYST_CONFIG_DIR, "github-token")];
-  const home = env?.HOME ?? homedir();
-  const layer2 = env?.CATALYST_LAYER2_CONFIG_FILE ?? join(home, ".config", "catalyst", "config.json");
-  const out = [join(dirname(layer2), "github-token")];
-  const xdg = join(env?.XDG_CONFIG_HOME || join(home, ".config"), "catalyst", "github-token");
-  if (!out.includes(xdg)) out.push(xdg);
-  return out;
+  return secretFileCandidates("github-token", env);
 }
 
 // defaultGithubTokenFile — the highest-priority candidate (cluster-sync's destination).

--- a/plugins/dev/scripts/execution-core/github-auth-preflight.test.mjs
+++ b/plugins/dev/scripts/execution-core/github-auth-preflight.test.mjs
@@ -987,7 +987,8 @@ describe("resolveGithubBootAuth re-arms before probing", () => {
   });
 });
 
-// ── daemon boot ORDERING (CTL-1612, Codex P1 round 2) ─────────────────────────
+// ── daemon boot ORDERING (CTL-1612, Codex P1 round 2; CTL-1623: call sites now route
+// through armSecret) ────────────────────────────────────────────────────────────────────
 //
 // The preflight's placement in daemon.mjs is load-bearing, and both directions have
 // already been wrong once:
@@ -998,10 +999,18 @@ describe("resolveGithubBootAuth re-arms before probing", () => {
 //     ...process.env, so every resumed worker inherited the stale credential for life.
 // The only correct window is: clusterSync → preflight → any dispatch. A structural
 // assertion is the honest way to pin that; a unit test cannot observe boot ordering.
+//
+// CTL-1623: both call sites were re-pointed from a direct rearmGithubTokenFromFile() call
+// to armSecret("github-token", { env: process.env }) — routing through the registry's arm
+// path so the registerRearmHook-registered hook (== rearmGithubTokenFromFile itself, wired
+// at module load, see the "rearm hook registration" describe block below) actually fires.
+// The needle strings below track that rename; the ordering invariants themselves are
+// unchanged.
 describe("daemon boot ordering", () => {
   const daemonSrc = readFileSync(new URL("./daemon.mjs", import.meta.url), "utf8").split("\n");
   const lineOf = (needle) => daemonSrc.findIndex((l) => l.includes(needle));
   const countOf = (needle) => daemonSrc.filter((l) => l.includes(needle)).length;
+  const REARM_CALL = 'armSecret("github-token", { env: process.env });';
 
   // The boot sequence must be: clusterSync -> RE-ARM -> dispatch -> PROBE.
   // Both halves are load-bearing and both have been wrong once:
@@ -1012,14 +1021,14 @@ describe("daemon boot ordering", () => {
   //     for no diagnostic benefit.
   test("the boot cluster-sync runs BEFORE the credential re-arm", () => {
     const sync = lineOf("const bootSync = clusterSync()");
-    const rearm = lineOf("rearmGithubTokenFromFile({ env: process.env, log })");
+    const rearm = lineOf(REARM_CALL);
     expect(sync).toBeGreaterThan(-1);
     expect(rearm).toBeGreaterThan(-1);
     expect(sync).toBeLessThan(rearm);
   });
 
   test("the credential RE-ARM runs BEFORE anything dispatches a worker", () => {
-    const rearm = lineOf("rearmGithubTokenFromFile({ env: process.env, log })");
+    const rearm = lineOf(REARM_CALL);
     const bootResume = lineOf("const bootResume = reconcileBoot(");
     const approved = lineOf("processApprovedResumes({ orchDir, dispatch: dispatchFn })");
     expect(bootResume).toBeGreaterThan(-1);
@@ -1045,10 +1054,29 @@ describe("daemon boot ordering", () => {
   test("the re-arm is ALSO wired into the periodic cluster-sync timer", () => {
     const timer = lineOf("_clusterSyncTimer = setInterval(");
     expect(timer).toBeGreaterThan(-1);
-    const rearmCalls = daemonSrc
-      .map((l, i) => (l.includes("rearmGithubTokenFromFile({ env: process.env, log })") ? i : -1))
-      .filter((i) => i >= 0);
+    const rearmCalls = daemonSrc.map((l, i) => (l.includes(REARM_CALL) ? i : -1)).filter((i) => i >= 0);
     expect(rearmCalls.length).toBe(2); // once at boot, once per timer tick
     expect(rearmCalls.some((i) => i > timer)).toBe(true);
+  });
+
+  // CTL-1623: the registry's "re-armable/timer" label was aspiration until this PR — no
+  // caller had ever registered a hook, so armSecret("github-token") always took the
+  // hookless-degrade path (secret-contract.mjs's armSecret docstring). This pins that the
+  // hook registration is wired at module scope (before either call site above can fire,
+  // since both live inside startDaemon()) and that the registered hook IS
+  // rearmGithubTokenFromFile — not a second, parallel implementation.
+  describe("rearm hook registration (CTL-1623)", () => {
+    test("registerRearmHook(\"github-token\", ...) is called at module scope, not inside startDaemon", () => {
+      const regLine = lineOf('registerRearmHook("github-token"');
+      const startDaemonLine = lineOf("export function startDaemon({");
+      expect(regLine).toBeGreaterThan(-1);
+      expect(startDaemonLine).toBeGreaterThan(-1);
+      expect(regLine).toBeLessThan(startDaemonLine); // registered before startDaemon is even defined
+    });
+
+    test("the registered hook closure calls rearmGithubTokenFromFile (not a duplicate implementation)", () => {
+      const regLine = lineOf('registerRearmHook("github-token"');
+      expect(daemonSrc[regLine]).toContain("rearmGithubTokenFromFile");
+    });
   });
 });

--- a/plugins/dev/scripts/execution-core/github-token-candidates-legacy-parity.test.mjs
+++ b/plugins/dev/scripts/execution-core/github-token-candidates-legacy-parity.test.mjs
@@ -1,0 +1,159 @@
+// github-token-candidates-legacy-parity.test.mjs — CTL-1623 A/B parity.
+//
+// githubTokenFileCandidates (github-auth-preflight.mjs) now delegates to
+// lib/secret-contract.mjs's secretFileCandidates("github-token", env) instead of
+// hand-rolling its own chain. This suite freezes the PRE-FOLD implementation, verbatim, as
+// a test-local reference and asserts the delegate produces byte-identical candidate lists
+// for every realistic env combination — and pins the ONE known, deliberate divergence
+// (HOME="") separately, clearly labeled as a flagged behavior change (never smuggled as a
+// no-op fold).
+//
+// MUST FAIL ON DIVERGENCE: every cell is toEqual against the frozen legacy output, never a
+// fuzzy/partial match.
+//
+// Run: cd plugins/dev/scripts/execution-core && bun test github-token-candidates-legacy-parity.test.mjs
+
+import { describe, test, expect } from "bun:test";
+import { homedir } from "node:os";
+import { dirname, join } from "node:path";
+import { githubTokenFileCandidates } from "./github-auth-preflight.mjs";
+
+// ─── FROZEN LEGACY REFERENCE (verbatim copy of the pre-CTL-1623 githubTokenFileCandidates) ─
+function legacyGithubTokenFileCandidates(env = process.env) {
+  if (env?.CATALYST_GITHUB_TOKEN_FILE) return [env.CATALYST_GITHUB_TOKEN_FILE];
+  if (env?.CATALYST_CONFIG_DIR) return [join(env.CATALYST_CONFIG_DIR, "github-token")];
+  const home = env?.HOME ?? homedir();
+  const layer2 = env?.CATALYST_LAYER2_CONFIG_FILE ?? join(home, ".config", "catalyst", "config.json");
+  const out = [join(dirname(layer2), "github-token")];
+  const xdg = join(env?.XDG_CONFIG_HOME || join(home, ".config"), "catalyst", "github-token");
+  if (!out.includes(xdg)) out.push(xdg);
+  return out;
+}
+
+// _cell — asserts legacy and delegate produce IDENTICAL candidate arrays for the same env.
+function _cell(name, env) {
+  test(name, () => {
+    expect(githubTokenFileCandidates(env)).toEqual(legacyGithubTokenFileCandidates(env));
+  });
+}
+
+describe("githubTokenFileCandidates vs frozen legacy chain — realistic envs (must agree)", () => {
+  // (a) explicit CATALYST_GITHUB_TOKEN_FILE override — short-circuits everything else.
+  _cell("(a) explicit override wins outright, even with every other var set", {
+    CATALYST_GITHUB_TOKEN_FILE: "/explicit/override/path",
+    CATALYST_CONFIG_DIR: "/should/be/ignored",
+    HOME: "/home/x",
+    XDG_CONFIG_HOME: "/xdg",
+  });
+
+  // (b) CATALYST_CONFIG_DIR explicit dir.
+  _cell("(b) CATALYST_CONFIG_DIR short-circuits ahead of HOME/XDG", {
+    CATALYST_CONFIG_DIR: "/cfg/dir",
+    HOME: "/home/x",
+    XDG_CONFIG_HOME: "/xdg",
+  });
+
+  // (c) CATALYST_LAYER2_CONFIG_FILE-derived dir.
+  _cell("(c) CATALYST_LAYER2_CONFIG_FILE moves the primary candidate", {
+    CATALYST_LAYER2_CONFIG_FILE: "/opt/cfg/catalyst/config.json",
+    HOME: "/home/x",
+  });
+
+  // (d) default layer2 dir + XDG_CONFIG_HOME dedupe.
+  _cell("(d1) same-dir dedupe: no XDG override — one candidate, not two", {
+    HOME: "/home/x",
+  });
+  _cell("(d2) distinct XDG_CONFIG_HOME — two candidates, writer dir first", {
+    HOME: "/home/x",
+    XDG_CONFIG_HOME: "/xdg-distinct",
+  });
+
+  // (e) HOME set to a normal non-empty value, nothing else — the common real-world default.
+  _cell("(e) HOME-only default chain", { HOME: "/home/plain" });
+
+  // A grab-bag of realistic combinations, mirroring github-auth-preflight.test.mjs's own
+  // fixtures (kept in parity here too, not just against the pre-fold function once).
+  _cell("empty XDG_CONFIG_HOME is falsy-ignored on both sides", {
+    HOME: "/home/x",
+    XDG_CONFIG_HOME: "",
+  });
+  _cell("empty CATALYST_CONFIG_DIR falls through on both sides", {
+    HOME: "/home/x",
+    CATALYST_CONFIG_DIR: "",
+  });
+  _cell("empty CATALYST_GITHUB_TOKEN_FILE falls through on both sides", {
+    HOME: "/home/x",
+    CATALYST_GITHUB_TOKEN_FILE: "",
+  });
+});
+
+// ─── FLAGGED BEHAVIOR CHANGE: HOME="" ───────────────────────────────────────────────────
+//
+// Legacy: `env?.HOME ?? homedir()` — `??` substitutes ONLY on null/undefined, so an
+// explicit empty-string HOME is used AS-IS (home becomes "", and every downstream join()
+// treats "" as a relative-path root — dirname("" + "/.config/catalyst/config.json") stays
+// relative to ".", not the real home directory).
+//
+// Engine (secretFileCandidates / resolveLayer2Path, lib/secret-contract.mjs): explicitly
+// length-checks HOME (`typeof env?.HOME === "string" && env.HOME.length > 0`) and falls
+// back to homedir() for an empty string too — the saner behavior for a degenerate,
+// presumably-unintentional HOME="".
+//
+// This is a DELIBERATE, FLAGGED divergence (CTL-1623 design note, see
+// githubTokenFileCandidates's docstring) — not a bug to fix quietly, and not silently
+// smuggled as "the fold is behavior-preserving". This test PINS the new (engine) behavior
+// and documents exactly how it differs from the old one, so a future reviewer sees the
+// change explicitly rather than rediscovering it.
+describe("FLAGGED BEHAVIOR CHANGE: HOME=\"\" (CTL-1623)", () => {
+  test("legacy used HOME=\"\" as-is (relative-path degenerate result)", () => {
+    const legacy = legacyGithubTokenFileCandidates({ HOME: "" });
+    // dirname(join("", ".config", "catalyst", "config.json")) === ".config/catalyst" — a
+    // RELATIVE path, not the real home directory. Pinning the exact pre-fold shape so the
+    // divergence below is provably a real behavior change, not a guess.
+    expect(legacy[0]).toBe(join(".config", "catalyst", "github-token"));
+    expect(legacy[0]).not.toBe(join(homedir(), ".config", "catalyst", "github-token"));
+  });
+
+  test("the engine (new behavior) falls back to homedir() for HOME=\"\", never a relative path", () => {
+    const delegated = githubTokenFileCandidates({ HOME: "" });
+    expect(delegated[0]).toBe(join(homedir(), ".config", "catalyst", "github-token"));
+  });
+
+  test("legacy and delegate DIVERGE for HOME=\"\" — pinned explicitly, not asserted equal", () => {
+    const legacy = legacyGithubTokenFileCandidates({ HOME: "" });
+    const delegated = githubTokenFileCandidates({ HOME: "" });
+    expect(delegated).not.toEqual(legacy);
+  });
+
+  // A non-empty HOME (the realistic case in every production environment — a service
+  // account's shell always has a real HOME) never exercises this divergence.
+  test("a non-empty HOME never triggers the divergence — both agree", () => {
+    const env = { HOME: "/home/real" };
+    expect(githubTokenFileCandidates(env)).toEqual(legacyGithubTokenFileCandidates(env));
+  });
+});
+
+// ─── SECOND FLAGGED DIVERGENCE (same root cause): CATALYST_LAYER2_CONFIG_FILE="" ────────
+//
+// Same `??`-vs-length-check root cause as HOME="" above, on the OTHER variable the legacy
+// chain read with `??`: `env?.CATALYST_LAYER2_CONFIG_FILE ?? join(home, ...)`. An explicit
+// empty string is kept as-is (dirname("") === "." — a relative path), while the engine's
+// length-checked chain falls back to the default Layer-2 path. Flagged here for the same
+// reason as HOME="" — an unlikely-but-possible operator misconfiguration, not smuggled as a
+// behavior-preserving fold.
+describe("FLAGGED BEHAVIOR CHANGE: CATALYST_LAYER2_CONFIG_FILE=\"\" (CTL-1623, same root cause as HOME=\"\")", () => {
+  test("legacy used CATALYST_LAYER2_CONFIG_FILE=\"\" as-is (relative-path degenerate result)", () => {
+    const legacy = legacyGithubTokenFileCandidates({ HOME: "/home/x", CATALYST_LAYER2_CONFIG_FILE: "" });
+    expect(legacy[0]).toBe(join(".", "github-token"));
+  });
+
+  test("the engine falls back to the default Layer-2 dir for an empty override, never a relative path", () => {
+    const delegated = githubTokenFileCandidates({ HOME: "/home/x", CATALYST_LAYER2_CONFIG_FILE: "" });
+    expect(delegated[0]).toBe(join("/home/x", ".config", "catalyst", "github-token"));
+  });
+
+  test("legacy and delegate DIVERGE for CATALYST_LAYER2_CONFIG_FILE=\"\" — pinned explicitly", () => {
+    const env = { HOME: "/home/x", CATALYST_LAYER2_CONFIG_FILE: "" };
+    expect(githubTokenFileCandidates(env)).not.toEqual(legacyGithubTokenFileCandidates(env));
+  });
+});

--- a/plugins/dev/scripts/lib/catalyst-secret-env.sh
+++ b/plugins/dev/scripts/lib/catalyst-secret-env.sh
@@ -25,6 +25,18 @@
 [[ -n "${_CATALYST_SECRET_ENV_SH_LOADED:-}" ]] && return 0
 _CATALYST_SECRET_ENV_SH_LOADED=1
 
+# CTL-1623: the FILE-READ tier of catalyst_project_github_token/_webhook_secret below now
+# delegates to lib/catalyst-secret-contract.sh's catalyst_resolve_secret (the CTL-1616
+# registry/engine) instead of hand-rolling its own file-candidate search, so the github-token
+# and webhook-secret bare-file chains can never drift from the registry again — the exact
+# failure class CTL-1612 (this file) and CTL-1616 (the registry) both exist to close.
+# catalyst_read_secret_file itself is UNCHANGED below (other callers still use it directly);
+# only the two exported projection functions are re-pointed. Same sibling-lib sourcing
+# pattern as lib/linear-app-actor.sh / lib/linear-comment-post.sh.
+_CSE_LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck disable=SC1091
+source "${_CSE_LIB_DIR}/catalyst-secret-contract.sh"
+
 # _catalyst_strip_eol — remove ONLY the line terminator a text file ends with.
 #
 # Two failure modes had to be avoided here, and they pull in opposite directions:
@@ -160,9 +172,31 @@ catalyst_env_file_assigns() {
 #   Absent/empty/unreadable everywhere = TOTAL no-op; never exports "" (bash ${X:-default}
 #   and JS ?? both treat "" as SET, which would defeat gh's hosts.yml/keyring fallback).
 #   Never logs or echoes the value.
+#
+#   CTL-1623: the FILE-READ tier is now catalyst_resolve_secret's own bare-file chain
+#   (CATALYST_GITHUB_TOKEN_FILE override → CATALYST_CONFIG_DIR → cluster-sync's own
+#   destination dir → XDG dir — identical priority order to the pre-fold
+#   catalyst_read_secret_file call). This function's OWN inherited-alias precedence (the
+#   elif chain below) is untouched — the engine's own inherited-fallback branch is
+#   deliberately NOT trusted here (gated out by the source check) so those elif rungs keep
+#   deciding GH_TOKEN-vs-GITHUB_TOKEN precedence exactly as before.
 catalyst_project_github_token() {
-  local _tok
-  if _tok="$(catalyst_read_secret_file "github-token" "${CATALYST_GITHUB_TOKEN_FILE:-}" "${CATALYST_CONFIG_DIR:-}")"; then
+  local _tok _src
+  catalyst_resolve_secret "github-token" >/dev/null
+  _tok="$CATALYST_SECRET_LAST_VALUE"
+  _src="$CATALYST_SECRET_LAST_SOURCE"
+  # SECRET HYGIENE (CTL-1623): this launcher's env is inherited by every long-lived daemon
+  # and child it spawns. CATALYST_SECRET_LAST_VALUE is deliberately never exported by
+  # _csc_set_result (#2924/#2925 post-merge Codex P2 fixes) — unset it here too, defensively,
+  # so a plain (unexported) shell variable holding the raw credential does not linger in this
+  # launcher's shell past the point it is needed.
+  unset CATALYST_SECRET_LAST_VALUE
+  # Both "shared-file" (the default/config-dir candidates) and "operator-override" (the
+  # explicit CATALYST_GITHUB_TOKEN_FILE override) collapse to this wrapper's single
+  # "shared-file" breadcrumb — this function has never distinguished the two; only
+  # catalyst_reconcile_github_token_aliases (below) emits "operator-override", for a
+  # DIFFERENT override mechanism (a machine-local env file sourced after this runs).
+  if [[ -n "$_tok" && ( "$_src" == "shared-file" || "$_src" == "operator-override" ) ]]; then
     export GITHUB_TOKEN="$_tok" GH_TOKEN="$_tok"
     export CATALYST_GITHUB_TOKEN_SOURCE="shared-file"
   elif [[ -n "${GH_TOKEN:-}" ]]; then
@@ -228,11 +262,27 @@ catalyst_reconcile_github_token_aliases() {
 #   process.env ONLY (no file fallback, unlike the Linear per-team secrets) and captures it
 #   once at boot, so a monitor started without it runs with the GitHub webhook route
 #   silently DISABLED rather than degraded.
+#
+#   CTL-1623: same FILE-READ-tier fold as catalyst_project_github_token above — the file
+#   chain now runs through catalyst_resolve_secret's webhook-secret row (identical candidate
+#   priority to the pre-fold catalyst_read_secret_file call). The registry's webhook-secret
+#   row is "boot-only" rotation class, but that only affects ARM classification
+#   (catalyst_arm_secret) elsewhere — this function only ever RESOLVES, so it is unaffected.
+#   The leave-inherited-alone no-op is preserved exactly: gated on the same
+#   shared-file/operator-override source check as the github-token wrapper, so an
+#   inherited-only or absent resolution changes nothing here, matching the pre-fold
+#   function's silent no-op on that path byte for byte.
 catalyst_project_webhook_secret() {
-  local _val
-  if _val="$(catalyst_read_secret_file "webhook-secret" "${CATALYST_WEBHOOK_SECRET_FILE:-}" "${CATALYST_CONFIG_DIR:-}")"; then
+  local _val _src
+  catalyst_resolve_secret "webhook-secret" >/dev/null
+  _val="$CATALYST_SECRET_LAST_VALUE"
+  _src="$CATALYST_SECRET_LAST_SOURCE"
+  # SECRET HYGIENE (CTL-1623): see the identical unset in catalyst_project_github_token above.
+  unset CATALYST_SECRET_LAST_VALUE
+  if [[ -n "$_val" && ( "$_src" == "shared-file" || "$_src" == "operator-override" ) ]]; then
     export CATALYST_WEBHOOK_SECRET="$_val"
   fi
-  # Absent/empty → leave whatever was inherited. Never export "": webhook-config treats an
-  # empty secret as "route unconfigured", which disables verification instead of failing.
+  # Absent/empty/inherited-only → leave whatever was inherited. Never export "": webhook-config
+  # treats an empty secret as "route unconfigured", which disables verification instead of
+  # failing.
 }

--- a/plugins/dev/scripts/lib/secret-contract.test.mjs
+++ b/plugins/dev/scripts/lib/secret-contract.test.mjs
@@ -986,13 +986,17 @@ describe("registry validation (§6) — the rearm-hook honesty rules", () => {
     // the process-wide linearReminter singleton (see linear-remint.test.mjs's own
     // "rearm-hook wiring" suite for that integration, exercised with an injected fake
     // reminter — never the real singleton, to avoid a hermetic test triggering a genuine
-    // network mint). This file stays a zero-import leaf and never imports linear-remint.mjs,
-    // so from ITS isolated perspective (and this describe block's own beforeEach, which
-    // unconditionally clears every row's hook before each test) every re-armable row still
-    // degrades identically here — this test proves that degrade mechanism in isolation, not
-    // "no hook exists anywhere in the codebase" (which is no longer true for
-    // linear-orchestrator-actor). github-token and linear-api-token remain genuinely
-    // hookless everywhere in the codebase as of this PR.
+    // network mint). UPDATE (CTL-1623): github-token ALSO now has a real production hook —
+    // registered in execution-core/daemon.mjs at module scope
+    // (registerRearmHook("github-token", ...), wrapping rearmGithubTokenFromFile), so it
+    // joins linear-orchestrator-actor as no longer genuinely hookless anywhere in the
+    // codebase. This file stays a zero-import leaf and never imports daemon.mjs or
+    // linear-remint.mjs, so from ITS isolated perspective (and this describe block's own
+    // beforeEach, which unconditionally clears every row's hook before each test) every
+    // re-armable row still degrades identically here — this test proves that degrade
+    // mechanism in isolation, not "no hook exists anywhere in the codebase" (which is no
+    // longer true for linear-orchestrator-actor OR github-token). Only linear-api-token
+    // remains genuinely hookless everywhere in the codebase as of this PR.
     const reArmable = SECRET_REGISTRY.filter((r) => r.rotation.class === "re-armable");
     expect(reArmable.map((r) => r.id).sort()).toEqual(
       ["github-token", "linear-api-token", "linear-orchestrator-actor"].sort(),


### PR DESCRIPTION
## Summary

Folds the live CTL-1612 secret paths onto the CTL-1616 secret-contract registry so the `github-token` / `webhook-secret` pair can never silently drift from the registry's chains (gap surfaced by the PR7 docs fact-check, #2932). Closes CTL-1623.

- **JS candidates**: `githubTokenFileCandidates` is now a delegate over `secretFileCandidates("github-token")` (`lib/secret-contract.mjs`); `defaultGithubTokenFile` unchanged as `candidates[0]`.
- **Rearm hook is live wiring**: `rearmGithubTokenFromFile` is registered as the `github-token` row's timer rearm hook (`registerRearmHook`, module scope in `daemon.mjs`, before any call site can fire), and both daemon call sites (boot post-clusterSync, cluster-sync timer tick) route through `armSecret("github-token")`. The row's `re-armable/timer` label now reflects reality per the configuration.md honesty rule.
- **Bash wrappers**: `catalyst_project_github_token` / `catalyst_project_webhook_secret`'s FILE-READ tier delegates to `catalyst_resolve_secret`. The projection semantics are untouched: FILE-WINS-over-inherited, GH_TOKEN-outranks-GITHUB_TOKEN promotion, mirror-only-when-absent, never-export-empty, `CATALYST_GITHUB_TOKEN_SOURCE` breadcrumb values, and webhook's leave-inherited-alone no-op. The engine's inherited-fallback is deliberately gated out so the wrapper's own precedence ladder keeps deciding. Raw-credential variable (`CATALYST_SECRET_LAST_VALUE`) is unset after each read (it is also never exported by the engine, per #2924/#2925).
- **A/B parity suites are the merge gate**: `__tests__/catalyst-secret-env-legacy-parity.test.sh` (33 cells) and `execution-core/github-token-candidates-legacy-parity.test.mjs` freeze verbatim pre-fold reference copies and assert byte-identical behavior against the real folded code per tier (explicit-file override / explicit-dir / layer2-dir / XDG dedupe / absent / whitespace-only / EOL-stripping / pipe-in-value / projection ladder / breadcrumb-unset). Mutation-tested: breaking the fold makes cells genuinely fail. The JS suite is added to the execution-core CI allowlist.

## Flagged behavior changes (deliberate, fail-closed, unreachable in real deployments)

Per the design's risk-4 discipline these are flagged, never smuggled as no-ops. All require degenerate operator input:

1. **JS `HOME=""` / `CATALYST_LAYER2_CONFIG_FILE=""`**: legacy `??`/dirname produced relative/degenerate candidate paths; the engine length-checks and falls back to `homedir()` / the default Layer-2 dir. Pinned by dedicated tests.
2. **Bash NUL-containing secret file**: legacy exported NUL-stripped mutated bytes; folded resolves to nothing (no arm). Pinned by fixture cells.
3. **Bash invalid-UTF-8 secret file**: legacy exported raw bytes; folded resolves to nothing. Pinned by fixture cells.
4. Documented-only (locale/env-dependent, not portably pinnable in CI): NBSP-only file under a macOS UTF-8 locale; `HOME` unset/empty in bash.

In every case the new behavior refuses to install a corrupted/degenerate credential rather than exporting mutated bytes.

## Testing

- `bun test` secret-contract + github-auth-preflight + new JS parity suite: 193 pass / 0 fail
- `bun test daemon.test.mjs`: 159 pass / 0 fail (also run combined in one process with the above to prove no cross-file rearm-hook state pollution: 352 pass)
- Bash: `secret-contract-parity` 179/179, `catalyst-secret-contract` 115/115, new `catalyst-secret-env-legacy-parity` 33/33, `catalyst-execution-core-github-token` 131/131
- `shellcheck -x` clean on touched bash; standalone `env -i` source-load of `catalyst-secret-env.sh` OK
- Adversarially verified (independent review pass): source-gate enumeration ({shared-file, operator-override, inherited, none} — explicit-override tier arms correctly), no secret leakage into child envs, no hook-state test pollution, legacy reference copies verified byte-identical to origin/main

🤖 Generated with [Claude Code](https://claude.com/claude-code)