### PR TITLE
fix(dev): CTL-1623 make the github-token rearm hook reject malformed files + run the bash parity suite in CI

### DIFF
--- a/.github/workflows/execution-core-tests.yml
+++ b/.github/workflows/execution-core-tests.yml
@@ -285,6 +285,23 @@ jobs:
         working-directory: plugins/dev/scripts
         run: bash __tests__/catalyst-execution-core-github-token.test.sh
 
+      - name: catalyst-secret-env A/B legacy-vs-folded parity test (CTL-1623)
+        # catalyst_project_github_token/_webhook_secret's FILE-READ tier now delegates to
+        # lib/catalyst-secret-contract.sh's catalyst_resolve_secret (the CTL-1616 registry
+        # engine) instead of hand-rolling its own file search. This suite freezes the
+        # pre-fold implementation as a test-local reference and asserts byte-identical
+        # results across the full fixture space (explicit overrides, CATALYST_CONFIG_DIR,
+        # CATALYST_LAYER2_CONFIG_FILE-derived dir, XDG dedupe, absent/whitespace-only files,
+        # trailing-EOL stripping, pipe-in-value, the full github-token precedence ladder),
+        # plus two FLAGGED, deliberately-divergent fail-closed cells (NUL-containing file,
+        # invalid-UTF-8 file — Codex post-merge round 1) where the folded engine now
+        # rejects a candidate the legacy reader would have silently mutated. Sibling suites
+        # secret-contract-parity.test.sh / catalyst-secret-contract.test.sh remain CI-dark
+        # (pre-existing family-wide gap, tracked separately) — this is the one directly
+        # exercising the CTL-1612 pair's own launcher-facing wrapper functions.
+        working-directory: plugins/dev/scripts
+        run: bash __tests__/catalyst-secret-env-legacy-parity.test.sh
+
       - name: migrate-dual-harness test (CTL-1530)
         # Covers the dual-harness classification (dual-ok / codex-only /
         # claude-only-monolithic / no-harness), the skills-dir state machine

--- a/plugins/dev/scripts/execution-core/github-auth-preflight.mjs
+++ b/plugins/dev/scripts/execution-core/github-auth-preflight.mjs
@@ -103,6 +103,30 @@ export function defaultGithubTokenFile(env = process.env) {
   return githubTokenFileCandidates(env)[0];
 }
 
+// containsNul / isValidUtf8RoundTrip — CTL-1623 post-merge fix (Codex round 1). Mirrors
+// lib/secret-contract.mjs's identically-named PRIVATE (unexported) helpers byte-for-byte —
+// duplicated here rather than exported from the engine, per this ticket's "don't touch the
+// shared engine unless a genuine parity bug forces it" discipline; these two functions are
+// ~4 lines each and stable, so the duplication cost is low next to the risk of widening the
+// engine's public surface. WHY THIS MATTERS HERE SPECIFICALLY: the bug Codex reproduced was
+// that rearmGithubTokenFromFile's default `readFile` used `readFileSync(p, "utf8")`, which
+// silently REPLACES any invalid UTF-8 byte with U+FFFD at decode time — so when the
+// catalyst-secret-env.sh launcher correctly fails closed on a malformed synced file (keeps
+// a good inherited GH_TOKEN, per lib/catalyst-secret-contract.sh's own containsNul/
+// isValidUtf8 guards), this hook then ran a SECOND, less careful read of the SAME file and
+// installed the U+FFFD-mangled bytes over the good inherited value at boot and on every
+// timer tick — defeating the fold's fail-closed hygiene one layer up. These two functions
+// let the candidate loop below apply the IDENTICAL validity gates the engine already
+// applies, so a candidate this hook cannot represent byte-for-byte falls through to the
+// next one (or to "absent") instead of installing a mutated credential.
+function containsNul(value) {
+  return value.includes("\u0000");
+}
+function isValidUtf8RoundTrip(buf, decoded) {
+  const reencoded = Buffer.from(decoded, "utf8");
+  return reencoded.length === buf.length && reencoded.equals(buf);
+}
+
 // rearmGithubTokenFromFile — CTL-1612 (Codex P1). Re-read the shared credential from
 // disk and update this process's env if it has changed.
 //
@@ -116,9 +140,18 @@ export function defaultGithubTokenFile(env = process.env) {
 //
 // Call AFTER clusterSync. Respects an explicit operator override (the launcher marks it
 // CATALYST_GITHUB_TOKEN_SOURCE=operator-override) and never throws.
+//
+// `readFile` READS RAW BYTES (a Buffer, matching plain `readFileSync(p)` with no encoding
+// argument) — CTL-1623 post-merge fix: the previous default decoded to "utf8" up front,
+// which is exactly what silently mangled an invalid-UTF-8 file (see the containsNul/
+// isValidUtf8RoundTrip comment above). The candidate loop below decodes+validates itself so
+// it can reject a candidate it cannot represent identically. Existing/injected test seams
+// that return a plain STRING (not a Buffer) still work unchanged — a string return is
+// treated as already-decoded text and wrapped in a Buffer for the round-trip check, which
+// trivially passes for any ordinary fixture literal.
 export function rearmGithubTokenFromFile({
   env = process.env,
-  readFile = (p) => readFileSync(p, "utf8"),
+  readFile = (p) => readFileSync(p),
   log = defaultLog,
 } = {}) {
   try {
@@ -134,6 +167,15 @@ export function rearmGithubTokenFromFile({
       } catch {
         continue; // not on this host — try the next candidate
       }
+      // PARITY GUARDS (CTL-1623 post-merge fix): reject a candidate this hook cannot
+      // represent identically to the engine's own bare-file read — an invalid-UTF-8 byte
+      // sequence or an embedded NUL — instead of silently installing a mutated value.
+      // Order matches lib/secret-contract.mjs's readFirstNonBlankFile: UTF-8 round-trip
+      // first, then NUL, both on the RAW bytes/decoded text, before the EOL strip.
+      const buf = Buffer.isBuffer(raw) ? raw : Buffer.from(String(raw ?? ""), "utf8");
+      const decoded = buf.toString("utf8");
+      if (!isValidUtf8RoundTrip(buf, decoded)) continue; // not on this host, effectively — try the next candidate
+      if (containsNul(decoded)) continue;
       found = true;
       // Strip ONLY trailing line terminators; preserve every other byte.
       // `.replace(/\s+/g,"")` corrupted internal whitespace, and a full `.trim()` corrupts
@@ -143,7 +185,7 @@ export function rearmGithubTokenFromFile({
       // file ending in `\n\n` must re-arm to the same bare token the launcher installed.
       // Mirrors _catalyst_strip_eol in lib/catalyst-secret-env.sh so the bash and JS
       // readers cannot disagree.
-      const candidate = String(raw ?? "").replace(/[\r\n]+$/, "");
+      const candidate = decoded.replace(/[\r\n]+$/, "");
       // Blank-check, not truthiness: a whitespace-only file must keep falling through to
       // the next candidate (a truthy "   " would break here and mask a valid fallback).
       if (candidate.trim()) {

--- a/plugins/dev/scripts/execution-core/github-auth-preflight.test.mjs
+++ b/plugins/dev/scripts/execution-core/github-auth-preflight.test.mjs
@@ -17,7 +17,7 @@
 // Run: cd plugins/dev/scripts/execution-core && bun test github-auth-preflight.test.mjs
 
 import { describe, test, expect } from "bun:test";
-import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
@@ -630,6 +630,112 @@ describe("rearmGithubTokenFromFile", () => {
     }).not.toThrow();
     expect(out).toEqual({ rearmed: true, reason: "rotated" });
     expect(env.GH_TOKEN).toBe(ROTATED_TOKEN);
+  });
+});
+
+// ── rearmGithubTokenFromFile: malformed-file PARITY GUARDS (CTL-1623 post-merge fix) ──
+//
+// CODEX'S REPRODUCED BUG: this hook's default `readFile` used to decode straight to
+// "utf8" (`readFileSync(p, "utf8")`), which silently REPLACES any invalid UTF-8 byte
+// with U+FFFD at decode time. So when the bash launcher (lib/catalyst-secret-env.sh,
+// via lib/catalyst-secret-contract.sh's own containsNul/isValidUtf8 guards) correctly
+// failed closed on a malformed synced credential file and kept a good inherited
+// GH_TOKEN, THIS hook then ran a second, less careful read of the SAME file and
+// installed the U+FFFD-mangled bytes over the good inherited value — at boot AND on
+// every timer tick — defeating the fold's fail-closed hygiene one layer up. These
+// tests pin the fix: a candidate this hook cannot represent identically to the engine
+// (lib/secret-contract.mjs's containsNul/isValidUtf8RoundTrip) now falls through
+// exactly like the "absent" case, never installing anything.
+describe("rearmGithubTokenFromFile: malformed-file PARITY GUARDS", () => {
+  test("REGRESSION (Codex): an invalid-UTF-8 file on disk + valid inherited GH_TOKEN/GITHUB_TOKEN in env → re-arm installs nothing, both aliases keep the inherited value, no U+FFFD anywhere", () => {
+    const env = {
+      CATALYST_GITHUB_TOKEN_FILE: TOKEN_FILE,
+      CATALYST_GITHUB_TOKEN_SOURCE: "inherited",
+      GITHUB_TOKEN: STALE_TOKEN, // "inherited" here stands in for a GOOD, currently-working credential
+      GH_TOKEN: STALE_TOKEN,
+    };
+    // 0xFF 0xFE is not a valid UTF-8 byte sequence anywhere — the exact byte shape
+    // Codex's report cites (a corrupted/partially-written sync of the shared file).
+    const out = rearmGithubTokenFromFile({
+      env,
+      readFile: () => Buffer.from([0xff, 0xfe, 0x68, 0x69]),
+      log: null,
+    });
+    expect(out).toEqual({ rearmed: false, reason: "absent" });
+    expect(env.GITHUB_TOKEN).toBe(STALE_TOKEN); // unchanged — the good inherited value
+    expect(env.GH_TOKEN).toBe(STALE_TOKEN);
+    expect(env.CATALYST_GITHUB_TOKEN_SOURCE).toBe("inherited"); // breadcrumb NOT rewritten
+    expect(env.GITHUB_TOKEN).not.toContain("�"); // the mutated-bytes regression, pinned negatively
+    expect(env.GH_TOKEN).not.toContain("�");
+  });
+
+  test("REGRESSION: a NUL-containing file installs nothing — falls through exactly like absent", () => {
+    const env = {
+      CATALYST_GITHUB_TOKEN_FILE: TOKEN_FILE,
+      CATALYST_GITHUB_TOKEN_SOURCE: "inherited",
+      GITHUB_TOKEN: STALE_TOKEN,
+      GH_TOKEN: STALE_TOKEN,
+    };
+    const out = rearmGithubTokenFromFile({
+      env,
+      readFile: () => Buffer.from("c\0loud"),
+      log: null,
+    });
+    expect(out).toEqual({ rearmed: false, reason: "absent" });
+    expect(env.GITHUB_TOKEN).toBe(STALE_TOKEN);
+    expect(env.GH_TOKEN).toBe(STALE_TOKEN);
+    expect(env.CATALYST_GITHUB_TOKEN_SOURCE).toBe("inherited");
+  });
+
+  test("an invalid-UTF-8 candidate falls through to a LATER, valid candidate — matches the engine's per-candidate fall-through, not a blanket abort", () => {
+    const env = { XDG_CONFIG_HOME: "/xdg-config", HOME: "/home/fake" };
+    const writerPath = join("/home/fake", ".config", "catalyst", "github-token");
+    const xdgPath = join("/xdg-config", "catalyst", "github-token");
+    const out = rearmGithubTokenFromFile({
+      env,
+      readFile: (p) => {
+        if (p === writerPath) return Buffer.from([0xff, 0xfe]); // corrupted primary candidate
+        if (p === xdgPath) return ROTATED_TOKEN; // the valid fallback candidate
+        throw new Error("ENOENT");
+      },
+      log: null,
+    });
+    expect(out).toEqual({ rearmed: true, reason: "rotated" });
+    expect(env.GITHUB_TOKEN).toBe(ROTATED_TOKEN);
+    expect(env.GH_TOKEN).toBe(ROTATED_TOKEN);
+  });
+
+  test("REGRESSION GUARD FOR THE FIX ITSELF: a real on-disk invalid-UTF-8 file, read via the PRODUCTION default readFile (no injected readFile) — proves the default now reads raw bytes, not readFileSync(p,\"utf8\")", () => {
+    const dir = mkdtempSync(join(tmpdir(), "gh-preflight-badutf8-"));
+    const file = join(dir, "github-token");
+    try {
+      writeFileSync(file, Buffer.from([0xff, 0xfe, 0x68, 0x69]));
+      const env = {
+        CATALYST_GITHUB_TOKEN_FILE: file,
+        CATALYST_GITHUB_TOKEN_SOURCE: "inherited",
+        GITHUB_TOKEN: STALE_TOKEN,
+        GH_TOKEN: STALE_TOKEN,
+      };
+      // No `readFile` override — exercises the real default.
+      const out = rearmGithubTokenFromFile({ env, log: null });
+      expect(out).toEqual({ rearmed: false, reason: "absent" });
+      expect(env.GITHUB_TOKEN).toBe(STALE_TOKEN);
+      expect(env.GH_TOKEN).toBe(STALE_TOKEN);
+      expect(env.GITHUB_TOKEN).not.toContain("�");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("a plain-string readFile return (the existing test-seam shape) is unaffected — round-trips as always-valid", () => {
+    const env = { CATALYST_GITHUB_TOKEN_FILE: TOKEN_FILE, GITHUB_TOKEN: STALE_TOKEN, GH_TOKEN: STALE_TOKEN };
+    const out = rearmGithubTokenFromFile({
+      env,
+      readFile: () => ROTATED_TOKEN, // a plain string, not a Buffer — the pre-existing seam shape
+      log: null,
+    });
+    expect(out).toEqual({ rearmed: true, reason: "rotated" });
+    expect(env.GITHUB_TOKEN).toBe(ROTATED_TOKEN);
   });
 });
 

--- a/plugins/dev/scripts/execution-core/github-token-candidates-legacy-parity.test.mjs
+++ b/plugins/dev/scripts/execution-core/github-token-candidates-legacy-parity.test.mjs
@@ -16,7 +16,7 @@
 import { describe, test, expect } from "bun:test";
 import { homedir } from "node:os";
 import { dirname, join } from "node:path";
-import { githubTokenFileCandidates } from "./github-auth-preflight.mjs";
+import { githubTokenFileCandidates, rearmGithubTokenFromFile } from "./github-auth-preflight.mjs";
 
 // ─── FROZEN LEGACY REFERENCE (verbatim copy of the pre-CTL-1623 githubTokenFileCandidates) ─
 function legacyGithubTokenFileCandidates(env = process.env) {
@@ -155,5 +155,72 @@ describe("FLAGGED BEHAVIOR CHANGE: CATALYST_LAYER2_CONFIG_FILE=\"\" (CTL-1623, s
   test("legacy and delegate DIVERGE for CATALYST_LAYER2_CONFIG_FILE=\"\" — pinned explicitly", () => {
     const env = { HOME: "/home/x", CATALYST_LAYER2_CONFIG_FILE: "" };
     expect(githubTokenFileCandidates(env)).not.toEqual(legacyGithubTokenFileCandidates(env));
+  });
+});
+
+// ─── THIRD FLAGGED DIVERGENCE (post-merge Codex round 1): malformed-file READ behavior ──
+//
+// Not a candidates-list divergence (githubTokenFileCandidates/secretFileCandidates never
+// disagree here — this is about what rearmGithubTokenFromFile does with the BYTES it reads
+// off a resolved candidate). Kept in this A/B parity file rather than a separate one since
+// this file is CTL-1623's designated "JS A/B parity suite" and the divergence is the exact
+// counterpart to catalyst-secret-env-legacy-parity.test.sh's (a)/(b) bash cells — the same
+// underlying bug, on the JS side of the CTL-1612 pair.
+//
+// LEGACY (pre-fix) rearmGithubTokenFromFile read every candidate via
+// `readFileSync(p, "utf8")` — decoding straight to a string, which silently REPLACES any
+// invalid UTF-8 byte with U+FFFD and does NOT reject an embedded NUL (NUL is itself valid
+// UTF-8, so it would have survived the strip/blank checks and been installed verbatim). The
+// FIXED rearmGithubTokenFromFile reads raw bytes and applies the same containsNul /
+// isValidUtf8RoundTrip parity guards lib/secret-contract.mjs's engine uses, so a malformed
+// candidate now falls through (effectively "absent") instead of installing a mutated value.
+describe("FLAGGED DIVERGENCE (post-merge fix): rearmGithubTokenFromFile — invalid-UTF-8 / NUL-containing candidates", () => {
+  // FROZEN LEGACY REFERENCE — the pre-fix read+strip+blank-check pipeline, verbatim (minus
+  // the surrounding candidate-loop/env-mutation plumbing, which is unchanged and not what
+  // diverges here). Operates on a raw Buffer so it can be exercised against the SAME
+  // fixture bytes the fixed implementation sees, mirroring how the bash suite freezes a
+  // reference rather than re-deriving legacy behavior from prose.
+  function legacyReadCandidate(buf) {
+    const decoded = buf.toString("utf8"); // the bug: decodes FIRST, mangling invalid bytes
+    const candidate = decoded.replace(/[\r\n]+$/, "");
+    return candidate.trim() ? candidate : null; // null == "blank, falls through" (unchanged today)
+  }
+
+  test("DOCUMENTED: the legacy read pipeline would have installed the U+FFFD-mangled value for an invalid-UTF-8 file", () => {
+    const buf = Buffer.from([0xff, 0xfe, 0x68, 0x69]);
+    const legacyResult = legacyReadCandidate(buf);
+    expect(legacyResult).not.toBeNull();
+    expect(legacyResult).toContain("�");
+  });
+
+  test("FLAGGED DIVERGENCE: the fixed rearmGithubTokenFromFile fails closed instead — installs nothing, no U+FFFD", () => {
+    const env = { CATALYST_GITHUB_TOKEN_FILE: "/fake/path", GITHUB_TOKEN: "good-inherited", GH_TOKEN: "good-inherited" };
+    const out = rearmGithubTokenFromFile({
+      env,
+      readFile: () => Buffer.from([0xff, 0xfe, 0x68, 0x69]),
+      log: null,
+    });
+    expect(out).toEqual({ rearmed: false, reason: "absent" });
+    expect(env.GITHUB_TOKEN).toBe("good-inherited");
+    expect(env.GITHUB_TOKEN).not.toContain("�");
+  });
+
+  test("DOCUMENTED: the legacy read pipeline would have installed the NUL-stripped mutated value for a NUL-containing file", () => {
+    const buf = Buffer.from("c\0loud");
+    const legacyResult = legacyReadCandidate(buf);
+    // NUL survives readFileSync(...,"utf8") decoding (it is valid UTF-8) and .trim() does
+    // not strip it — the legacy pipeline installs it verbatim, embedded NUL and all.
+    expect(legacyResult).toBe("c\0loud");
+  });
+
+  test("FLAGGED DIVERGENCE: the fixed rearmGithubTokenFromFile rejects the NUL-containing candidate", () => {
+    const env = { CATALYST_GITHUB_TOKEN_FILE: "/fake/path", GITHUB_TOKEN: "good-inherited", GH_TOKEN: "good-inherited" };
+    const out = rearmGithubTokenFromFile({
+      env,
+      readFile: () => Buffer.from("c\0loud"),
+      log: null,
+    });
+    expect(out).toEqual({ rearmed: false, reason: "absent" });
+    expect(env.GITHUB_TOKEN).toBe("good-inherited");
   });
 });


### PR DESCRIPTION
## Summary

Remediates both P2 findings from the post-merge Codex round on #2981 (CTL-1623).

**1. Real bug — the rearm hook defeated the fold's fail-closed hygiene one layer up.** `rearmGithubTokenFromFile`'s default reader was `readFileSync(p, "utf8")`, which silently replaces invalid UTF-8 bytes with U+FFFD (and passes embedded NULs through). So with a malformed synced `github-token` file on disk, the bash launcher correctly fail-closed and preserved a good inherited `GH_TOKEN` — and then the registered hook re-read the same file less carefully and installed the mangled bytes over the good token at boot and on every cluster-sync timer tick (Codex reproduced this).

Fix: the default reader now returns raw bytes, and the candidate loop applies the engine's own validity gates (UTF-8 round-trip + NUL check, duplicated verbatim from `lib/secret-contract.mjs`'s private helpers — the engine itself is untouched) with per-candidate fall-through. A candidate rejected on validity counts as absent, so the `{rearmed, reason}` contract is unchanged (no new reason values). Routing the read through `resolveSecret` was considered and rejected: its bare-file resolver falls back to inherited env, which would silently reclassify "absent" as "unchanged" and corrupt the return contract.

Tests: 5 new regression tests (Codex's exact scenario — malformed file + good inherited token → nothing installed, no U+FFFD; NUL case; fall-through-to-valid-candidate; production-default raw-byte read against a real on-disk malformed file; string-seam guard) plus 4 flagged-divergence cells in the JS A/B parity suite pinning the fail-closed behavior against the frozen legacy reference. All 9 verified load-bearing via temporary reverts.

**2. CI wiring.** `catalyst-secret-env-legacy-parity.test.sh` (the 33-cell bash A/B suite from #2981) is now enumerated in `execution-core-tests.yml`, so the suite guarding the bash wrapper fold actually runs in CI. Portability-scanned for ubuntu-latest (no stat/sed -i/locale hazards; fixture `printf` byte-patterns verified byte-identical under bash 3.2 and 5.3; the transitive `iconv` dependency fail-opens and is already exercised by the CI-wired sibling suite). Sibling CI-dark suites deliberately not added — pre-existing family-wide gap, out of scope.

## Testing

- `bun test` github-auth-preflight (68), candidates-legacy-parity (20), secret-contract (114), daemon (159): all pass, 0 fail
- Bash: new parity suite 33/33; regression sweep secret-contract-parity 179/179, catalyst-secret-contract 115/115, catalyst-execution-core-github-token 131/131
- shellcheck clean; workflow YAML parse OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)