### PR TITLE
fix(dev): CTL-1623 export the canonical malformed-file validators instead of duplicating them

### DIFF
--- a/plugins/dev/scripts/execution-core/github-auth-preflight.mjs
+++ b/plugins/dev/scripts/execution-core/github-auth-preflight.mjs
@@ -22,7 +22,7 @@ import { readFileSync } from "node:fs";
 
 import { log as defaultLog } from "./config.mjs";
 import { emitGithubAuthUnusable } from "./dispatch-alert.mjs";
-import { secretFileCandidates } from "../lib/secret-contract.mjs"; // CTL-1623: the github-token row's candidate chain, single-sourced from the registry
+import { secretFileCandidates, containsNul, isValidUtf8RoundTrip } from "../lib/secret-contract.mjs"; // CTL-1623: the github-token row's candidate chain, single-sourced from the registry
 
 // Bounded so a hung/unreachable api.github.com can never wedge daemon boot.
 export const GITHUB_PROBE_TIMEOUT_MS = 10_000;
@@ -103,29 +103,14 @@ export function defaultGithubTokenFile(env = process.env) {
   return githubTokenFileCandidates(env)[0];
 }
 
-// containsNul / isValidUtf8RoundTrip — CTL-1623 post-merge fix (Codex round 1). Mirrors
-// lib/secret-contract.mjs's identically-named PRIVATE (unexported) helpers byte-for-byte —
-// duplicated here rather than exported from the engine, per this ticket's "don't touch the
-// shared engine unless a genuine parity bug forces it" discipline; these two functions are
-// ~4 lines each and stable, so the duplication cost is low next to the risk of widening the
-// engine's public surface. WHY THIS MATTERS HERE SPECIFICALLY: the bug Codex reproduced was
-// that rearmGithubTokenFromFile's default `readFile` used `readFileSync(p, "utf8")`, which
-// silently REPLACES any invalid UTF-8 byte with U+FFFD at decode time — so when the
-// catalyst-secret-env.sh launcher correctly fails closed on a malformed synced file (keeps
-// a good inherited GH_TOKEN, per lib/catalyst-secret-contract.sh's own containsNul/
-// isValidUtf8 guards), this hook then ran a SECOND, less careful read of the SAME file and
-// installed the U+FFFD-mangled bytes over the good inherited value at boot and on every
-// timer tick — defeating the fold's fail-closed hygiene one layer up. These two functions
-// let the candidate loop below apply the IDENTICAL validity gates the engine already
-// applies, so a candidate this hook cannot represent byte-for-byte falls through to the
-// next one (or to "absent") instead of installing a mutated credential.
-function containsNul(value) {
-  return value.includes("\u0000");
-}
-function isValidUtf8RoundTrip(buf, decoded) {
-  const reencoded = Buffer.from(decoded, "utf8");
-  return reencoded.length === buf.length && reencoded.equals(buf);
-}
+// containsNul / isValidUtf8RoundTrip are imported from lib/secret-contract.mjs (CTL-1623
+// Codex round 2) — the CANONICAL malformed-file validators the engine's own bare-file read
+// applies. Sharing one implementation (instead of the round-1 verbatim copies) means the
+// resolver and this hook can never drift on what counts as a representable credential
+// file: the bug Codex reproduced in round 1 was exactly a resolver-rejects/hook-installs
+// split, where readFileSync(p, "utf8") silently replaced invalid UTF-8 bytes with U+FFFD
+// and this hook installed the mangled token over a good inherited one at boot and on every
+// timer tick. See the candidate loop below for where the gates apply.
 
 // rearmGithubTokenFromFile — CTL-1612 (Codex P1). Re-read the shared credential from
 // disk and update this process's env if it has changed.

--- a/plugins/dev/scripts/lib/secret-contract.d.mts
+++ b/plugins/dev/scripts/lib/secret-contract.d.mts
@@ -62,6 +62,11 @@ export function isSecretFamilyMember(filename: string): boolean;
 export function resolveLayer2Path(env?: Record<string, string | undefined>): string;
 export function explicitFileOverrideEnvName(id: string): string;
 export function secretFileCandidates(id: string, env?: Record<string, string | undefined>): string[];
+/** Canonical malformed-file validators (CTL-1623 Codex round 2): shared with
+ *  execution-core's rearmGithubTokenFromFile so the resolver and the rearm hook can never
+ *  drift on what counts as a representable credential file. */
+export function containsNul(value: string): boolean;
+export function isValidUtf8RoundTrip(buf: Uint8Array, decoded: string): boolean;
 /** CTL-1616 PR4: linear-worker-actor's per-team-legacy tier path (mirrors
  *  linear-comment-post.sh's _find_layer2_config directory walk-up). */
 export function resolveLegacyPerTeamConfigPath(

--- a/plugins/dev/scripts/lib/secret-contract.mjs
+++ b/plugins/dev/scripts/lib/secret-contract.mjs
@@ -642,7 +642,13 @@ function isBlank(value) {
 // on BOTH sides (this file, and the bash mirror's analogous file-candidate loop) so a
 // NUL-containing file falls through to the next candidate identically everywhere, rather
 // than silently disagreeing on the resolved value.
-function containsNul(value) {
+//
+// EXPORTED (with isValidUtf8RoundTrip below) as the CANONICAL malformed-file validators:
+// execution-core's rearmGithubTokenFromFile applies the identical gates to its own
+// re-read of the github-token file, and a private parallel copy there could drift and
+// re-open the exact resolver-rejects/hook-installs split these guards exist to close.
+// Still zero-import: exporting pure helpers adds no dependency to this leaf.
+export function containsNul(value) {
   return value.includes("\u0000");
 }
 
@@ -658,7 +664,9 @@ function containsNul(value) {
 // serving whichever language's mutated/unmutated view happens to run first. Detected via a
 // byte round-trip: decode as UTF-8, re-encode, and compare against the original bytes —
 // any invalid sequence fails to round-trip byte-for-byte.
-function isValidUtf8RoundTrip(buf, decoded) {
+// Exported alongside containsNul above — see that comment for why the two validators are
+// the single canonical implementation shared with the rearm hook.
+export function isValidUtf8RoundTrip(buf, decoded) {
   const reencoded = Buffer.from(decoded, "utf8");
   return reencoded.length === buf.length && reencoded.equals(buf);
 }


### PR DESCRIPTION
## Summary

Remediates the Codex P1 on #2983: `containsNul` / `isValidUtf8RoundTrip` were duplicated verbatim from `lib/secret-contract.mjs` into `github-auth-preflight.mjs`, and if either copy were later updated for another malformed-byte case, the rearm hook could again install a credential the canonical resolver rejects — the exact drift class the round-1 fix exists to close.

The engine now exports the two validators as the canonical implementations (pure helpers, so the leaf's zero-import discipline is unchanged), the rearm hook imports them instead of carrying local copies, and declarations are added to `secret-contract.d.mts`.

## Testing

- `bun test` secret-contract + github-auth-preflight + candidates-legacy-parity: 202 pass / 0 fail
- `bun test daemon.test.mjs`: 159 pass / 0 fail
- `bash secret-contract-parity.test.sh`: 179/179

🤖 Generated with [Claude Code](https://claude.com/claude-code)