### PR TITLE
feat(dev): CTL-1607 promote board-scan slot scalars to chartable Loki attributes

### DIFF
--- a/plugins/dev/scripts/execution-core/board-health.mjs
+++ b/plugins/dev/scripts/execution-core/board-health.mjs
@@ -455,6 +455,11 @@ export function assembleBoardState({
       maxParallel: capacity?.maxParallel ?? 0,
       liveCount: capacity?.liveCount ?? 0,
       freeSlots: capacity?.freeSlots ?? 0,
+      // CTL-1607: the scheduler's new-work admission gate outcome for THIS tick
+      // (!livenessFresh || draining). Carried so buildBoardScanEvent can collapse
+      // the PUBLISHED slotFree to 0 on a node that will not admit — the emitted
+      // census is observational only; invariants read the un-gated freeSlots above.
+      admissionGated: !!capacity?.admissionGated,
     },
     reconcileMarkers: safe(() => getReconcileMarkers(), {}),
     // CTL-1432 (B2/B3): deferred board-health anchor candidates + the sanctioned
@@ -1349,6 +1354,30 @@ export function buildBoardScanEvent({ mode, invariants, decision, act = null, bo
     skippedReason: act?.skippedReason ?? (act?.dispatched === true ? null : "shadow"),
     skippedReasonNoClock: act?.skippedReasonNoClock === true, // CTL-1610
   };
+  // CTL-1607 (Codex #2985 P2 ×3): per-host slot census, corrected so a fleet
+  // consumer can SUM these across hosts without under/over-counting. Null when no
+  // board was threaded (back-compat). Three corrections vs the raw capacity snap:
+  //  · in_use is derived from FREE (capacity − rawFree), so it reflects the FULL
+  //    occupancy basis the scheduler admits against — liveCount + queued board-
+  //    health delegates + in-process SDK workers — not just live bg jobs. (Raw
+  //    board.capacity.freeSlots is already computeFreeSlots(maxParallel,
+  //    occupiedCount), so capacity − rawFree == occupiedCount.)
+  //  · a board-health delegate dispatched THIS scan reserves a slot the scheduler
+  //    charges immediately after this pass returns (scheduler.mjs: occupiedCount++
+  //    on act.dispatched), so free is debited (and in_use credited) by it here.
+  //  · a draining or stale-liveness node admits no new work — the scheduler's
+  //    admission gate collapses its free slots to 0 (`livenessFresh && !draining`)
+  //    — so its PUBLISHED free collapses to 0 too (admissionGated, threaded on
+  //    board.capacity by the scheduler).
+  const _slotCap = board?.capacity?.maxParallel ?? null;
+  const _rawFree = board?.capacity?.freeSlots ?? null;
+  const _slotGated = board?.capacity?.admissionGated === true;
+  const _slotReserved = actOutcome.dispatched ? 1 : 0;
+  const slotFree = _rawFree == null ? null : _slotGated ? 0 : Math.max(0, _rawFree - _slotReserved);
+  const slotInUse =
+    _slotCap == null || _rawFree == null
+      ? null
+      : Math.min(_slotCap, Math.max(0, _slotCap - _rawFree) + _slotReserved);
   return {
     type: "recovery.board-scan",
     ticket: null, // board/fleet-scoped → event.label:null; the board reader ignores it (correct)
@@ -1373,13 +1402,14 @@ export function buildBoardScanEvent({ mode, invariants, decision, act = null, bo
       // CTL-1435 (C1): 0/1 so Grafana can chart the dispatch RATE alongside the
       // proposal counts (proposed-vs-dispatched is the actuation-liveness signal).
       actDispatched: actOutcome.dispatched ? 1 : 0,
-      // CTL-1607: per-host slot census so fleet capacity is visible off-host. Null
-      // when no board was threaded (back-compat). NOTE: slotFree is occupancy-derived
-      // (>= slotCapacity - slotInUse when queued/SDK workers exist), so a fleet
-      // consumer must SUM recovery.slot.free directly, never capacity - in_use.
-      slotCapacity: board?.capacity?.maxParallel ?? null,
-      slotInUse: board?.capacity?.liveCount ?? null,
-      slotFree: board?.capacity?.freeSlots ?? null,
+      // CTL-1607: per-host slot census so fleet capacity is visible off-host
+      // (computed above; occupancy-derived in_use, delegate-debited + gate-collapsed
+      // free). A fleet consumer SUMs slotFree directly — never capacity − in_use:
+      // on a draining/stale node free is gate-collapsed to 0 while in_use still
+      // reports actual occupancy, so capacity − in_use overstates admittable free.
+      slotCapacity: _slotCap,
+      slotInUse,
+      slotFree,
       invariants: Object.fromEntries(
         Object.entries(invariants).map(([k, v]) => [k, { ok: v.ok, failed: v.failed, observable: v.observable }]),
       ),

--- a/plugins/dev/scripts/execution-core/board-health.mjs
+++ b/plugins/dev/scripts/execution-core/board-health.mjs
@@ -1337,7 +1337,7 @@ export function buildBoardContext(boardState, invariants) {
 // ── (6) buildBoardScanEvent — PURE. The flat event reused through the CTL-1287
 // emit envelope. Scalars at the top of details (CTL-1291 promotes them to
 // chartable attributes); rosters/move arrays stay in details → body.payload.
-export function buildBoardScanEvent({ mode, invariants, decision, act = null }) {
+export function buildBoardScanEvent({ mode, invariants, decision, act = null, board = null }) {
   const totalMoves = decision.proposed.tier1 + decision.proposed.tier2 + decision.proposed.tier3;
   // CTL-1435 (C1): the actuation OUTCOME of this scan. Without it the journal shows
   // proposedMoves but never whether anything was dispatched — the blind spot behind
@@ -1373,6 +1373,13 @@ export function buildBoardScanEvent({ mode, invariants, decision, act = null }) 
       // CTL-1435 (C1): 0/1 so Grafana can chart the dispatch RATE alongside the
       // proposal counts (proposed-vs-dispatched is the actuation-liveness signal).
       actDispatched: actOutcome.dispatched ? 1 : 0,
+      // CTL-1607: per-host slot census so fleet capacity is visible off-host. Null
+      // when no board was threaded (back-compat). NOTE: slotFree is occupancy-derived
+      // (>= slotCapacity - slotInUse when queued/SDK workers exist), so a fleet
+      // consumer must SUM recovery.slot.free directly, never capacity - in_use.
+      slotCapacity: board?.capacity?.maxParallel ?? null,
+      slotInUse: board?.capacity?.liveCount ?? null,
+      slotFree: board?.capacity?.freeSlots ?? null,
       invariants: Object.fromEntries(
         Object.entries(invariants).map(([k, v]) => [k, { ok: v.ok, failed: v.failed, observable: v.observable }]),
       ),
@@ -1505,7 +1512,7 @@ export function boardHealthPass({
 
   // CTL-1435 (C1): emit AFTER actuation so the scan event carries the act outcome.
   try {
-    emit(buildBoardScanEvent({ mode, invariants, decision: dec, act: actOutcome })); // shadow AND enforce
+    emit(buildBoardScanEvent({ mode, invariants, decision: dec, act: actOutcome, board })); // shadow AND enforce
   } catch (err) {
     log({ err: err.message }, "board-health: emit failed (continuing)");
   }

--- a/plugins/dev/scripts/execution-core/board-health.test.mjs
+++ b/plugins/dev/scripts/execution-core/board-health.test.mjs
@@ -791,6 +791,26 @@ describe("buildBoardScanEvent", () => {
     expect(ev.details.flagged).toContain("CTL-1");
     expect(Array.isArray(ev.details.tier1Moves)).toBe(true);
   });
+
+  // CTL-1607: per-host slot census threaded onto the board-scan event.
+  test("threads board.capacity into details.slot* scalars", () => {
+    const invs = { ...allGreen(), dispatchLiveness: inv(false, 1, true, ["CTL-1"]) };
+    const board = mkBoard({ capacity: { maxParallel: 4, liveCount: 3, freeSlots: 1 } });
+    const decision = decideBoardHealth(invs, board);
+    const ev = buildBoardScanEvent({ mode: "shadow", invariants: invs, decision, board });
+    expect(ev.details.slotCapacity).toBe(4);
+    expect(ev.details.slotInUse).toBe(3);
+    expect(ev.details.slotFree).toBe(1);
+  });
+
+  test("no board arg → slot* scalars default to null (back-compat)", () => {
+    const invs = allGreen();
+    const decision = decideBoardHealth(invs, mkBoard({ capacity: { freeSlots: 4 } }));
+    const ev = buildBoardScanEvent({ mode: "shadow", invariants: invs, decision });
+    expect(ev.details.slotCapacity).toBeNull();
+    expect(ev.details.slotInUse).toBeNull();
+    expect(ev.details.slotFree).toBeNull();
+  });
 });
 
 // ─── buildBoardContext — the whole-board brief the delegate gets injected ────

--- a/plugins/dev/scripts/execution-core/board-health.test.mjs
+++ b/plugins/dev/scripts/execution-core/board-health.test.mjs
@@ -799,8 +799,60 @@ describe("buildBoardScanEvent", () => {
     const decision = decideBoardHealth(invs, board);
     const ev = buildBoardScanEvent({ mode: "shadow", invariants: invs, decision, board });
     expect(ev.details.slotCapacity).toBe(4);
-    expect(ev.details.slotInUse).toBe(3);
+    expect(ev.details.slotInUse).toBe(3); // capacity − free = 4 − 1
     expect(ev.details.slotFree).toBe(1);
+  });
+
+  // CTL-1607 (Codex #2985 P2 #1): in_use is derived from capacity − freeSlots, so it
+  // reflects the FULL occupancy basis (liveCount + queued delegates + SDK inflight)
+  // the scheduler admits against — NOT the raw bg liveCount. Here occupancy is 4
+  // (freeSlots 0) while only 1 bg job is live: in_use must be 4, not 1.
+  test("slotInUse reflects occupancy (capacity − free), not bare liveCount", () => {
+    const invs = allGreen();
+    const board = mkBoard({ capacity: { maxParallel: 4, liveCount: 1, freeSlots: 0 } });
+    const ev = buildBoardScanEvent({
+      mode: "shadow",
+      invariants: invs,
+      decision: decideBoardHealth(invs, board),
+      board,
+    });
+    expect(ev.details.slotInUse).toBe(4);
+    expect(ev.details.slotFree).toBe(0);
+  });
+
+  // CTL-1607 (Codex #2985 P2 #2): a draining / stale-liveness node admits no new
+  // work, so its PUBLISHED slotFree collapses to 0 — while slotInUse still reports
+  // actual occupancy (capacity − rawFree = 2), not a collapsed value.
+  test("admissionGated collapses slotFree to 0 (in_use still real occupancy)", () => {
+    const invs = allGreen();
+    const board = mkBoard({
+      capacity: { maxParallel: 4, liveCount: 1, freeSlots: 2, admissionGated: true },
+    });
+    const ev = buildBoardScanEvent({
+      mode: "shadow",
+      invariants: invs,
+      decision: decideBoardHealth(invs, board),
+      board,
+    });
+    expect(ev.details.slotFree).toBe(0);
+    expect(ev.details.slotInUse).toBe(2);
+  });
+
+  // CTL-1607 (Codex #2985 P2 #3): a board-health delegate dispatched THIS scan
+  // reserves a slot the scheduler charges right after the pass returns, so free is
+  // debited (2 → 1) and in_use credited ((4−2)+1 = 3) here.
+  test("dispatched delegate debits slotFree and credits slotInUse", () => {
+    const invs = allGreen();
+    const board = mkBoard({ capacity: { maxParallel: 4, liveCount: 2, freeSlots: 2 } });
+    const ev = buildBoardScanEvent({
+      mode: "enforce",
+      invariants: invs,
+      decision: decideBoardHealth(invs, board),
+      board,
+      act: { dispatched: true, anchor: "CTL-1" },
+    });
+    expect(ev.details.slotFree).toBe(1);
+    expect(ev.details.slotInUse).toBe(3);
   });
 
   test("no board arg → slot* scalars default to null (back-compat)", () => {

--- a/plugins/dev/scripts/execution-core/recovery-reasoning.mjs
+++ b/plugins/dev/scripts/execution-core/recovery-reasoning.mjs
@@ -1253,8 +1253,10 @@ function promoteNumericAttrs(type, details) {
     num("recovery.act_dispatched", details.actDispatched);
     // CTL-1607: per-host slot census → chartable Loki metadata. Fleet-wide free
     // capacity is sum(recovery.slot.free) across hosts (host identity via host_name
-    // metadata). Sum FREE directly — slot.capacity - slot.in_use != slot.free when
-    // queued/SDK workers occupy slots (see the emit-site note in board-health.mjs).
+    // metadata). Sum FREE directly — never slot.capacity - slot.in_use: on a
+    // draining/stale-liveness node slot.free is gate-collapsed to 0 while
+    // slot.in_use still reports actual occupancy, so capacity − in_use overstates
+    // admittable free (see the emit-site note in board-health.mjs).
     num("recovery.slot.capacity", details.slotCapacity);
     num("recovery.slot.in_use", details.slotInUse);
     num("recovery.slot.free", details.slotFree);

--- a/plugins/dev/scripts/execution-core/recovery-reasoning.mjs
+++ b/plugins/dev/scripts/execution-core/recovery-reasoning.mjs
@@ -1251,6 +1251,13 @@ function promoteNumericAttrs(type, details) {
     // dashboards/alerts get a chartable dispatch-rate signal (the act object rides in
     // body.payload, which the OTel/Loki path does not make queryable).
     num("recovery.act_dispatched", details.actDispatched);
+    // CTL-1607: per-host slot census → chartable Loki metadata. Fleet-wide free
+    // capacity is sum(recovery.slot.free) across hosts (host identity via host_name
+    // metadata). Sum FREE directly — slot.capacity - slot.in_use != slot.free when
+    // queued/SDK workers occupy slots (see the emit-site note in board-health.mjs).
+    num("recovery.slot.capacity", details.slotCapacity);
+    num("recovery.slot.in_use", details.slotInUse);
+    num("recovery.slot.free", details.slotFree);
     str("recovery.gate_decision", details.gateDecision);
     str("recovery.gate_reason", details.gateReason);
     str("recovery.mode", details.mode);

--- a/plugins/dev/scripts/execution-core/recovery-reasoning.test.mjs
+++ b/plugins/dev/scripts/execution-core/recovery-reasoning.test.mjs
@@ -978,6 +978,32 @@ describe("buildRecoveryEnvelope numeric/enum promotion (CTL-1291)", () => {
     expect(a["recovery.inv.phantomMergedPr.failed"]).toBe(2);
   });
 
+  // CTL-1607: per-host slot census promoted to chartable recovery.slot.* attributes.
+  test("recovery.board-scan promotes slot* scalars under recovery.slot.* names", () => {
+    const details = {
+      mode: "shadow", invariantsFailed: 0,
+      gateDecision: "proceed", gateReason: "no wedge",
+      proposedTier1: 0, proposedTier2: 0, proposedTier3: 0,
+      invariants: {},
+      slotCapacity: 6, slotInUse: 4, slotFree: 2,
+    };
+    const a = buildRecoveryEnvelope({ type: "recovery.board-scan", ticket: null, details }).attributes;
+    expect(a["recovery.slot.capacity"]).toBe(6);
+    expect(a["recovery.slot.in_use"]).toBe(4);
+    expect(a["recovery.slot.free"]).toBe(2);
+  });
+
+  test("recovery.board-scan omits recovery.slot.* when slot scalars are null", () => {
+    const details = {
+      mode: "shadow", invariantsFailed: 0, gateDecision: "proceed", gateReason: "r",
+      proposedTier1: 0, proposedTier2: 0, proposedTier3: 0, invariants: {},
+      slotCapacity: null, slotInUse: null, slotFree: null,
+    };
+    const a = buildRecoveryEnvelope({ type: "recovery.board-scan", ticket: null, details }).attributes;
+    expect("recovery.slot.capacity" in a).toBe(false);
+    expect("recovery.slot.free" in a).toBe(false);
+  });
+
   test("recovery.board-scan never promotes rosters/move arrays (cardinality)", () => {
     const details = {
       mode: "shadow",

--- a/plugins/dev/scripts/execution-core/scheduler.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.mjs
@@ -5408,6 +5408,13 @@ export function schedulerTick(
             maxParallel,
             liveCount,
             freeSlots: computeFreeSlots(maxParallel, occupiedCount),
+            // CTL-1607 (Codex #2985 P2): the same new-work admission gate applied
+            // below (`livenessFresh && !draining`, line ~6576) — sampled here so the
+            // board-scan event's PUBLISHED slotFree collapses to 0 on a node that
+            // will not admit. Observational only; the un-gated freeSlots above still
+            // drives the dispatch-liveness invariant. Both seams are pure reads
+            // (livenessIsFresh is already called this tick at ~5703/~6560).
+            admissionGated: !livenessIsFresh() || isDraining(),
           },
           readEventRing: _boardHealth.readEventRing,
           ownerForTicket,


### PR DESCRIPTION
<!-- Auto-generated: 2026-08-04T20:32:56Z -->
<!-- Last updated: 2026-08-04T20:32:56Z -->
<!-- PR: #2985 -->
<!-- Previous commits: 923f04ccbf63a05783647470e2c388d4e04ebd9f,04ff1afa9b49cb52a2012f3cbbaec17173071d96 -->

## Summary

Makes per-host worker-slot capacity visible off-host and chartable across the fleet by
carrying the board's slot census on the `recovery.board-scan` event.

Today the board-health pass emits a scan event whose scalars ride to Grafana/Loki as promoted
attributes, but per-host slot counts (how many worker slots a host has, how many are in use, how
many are free) never leave the machine — so fleet-wide free capacity can't be summed in a dashboard.
This change threads the in-scope `board` object into the scan event and promotes three new slot
scalars to chartable Loki attributes, so `sum(recovery.slot.free)` across the per-host series
yields fleet-wide free capacity.

The two commits split the work cleanly: (1) emit the slot scalars into the event details, (2)
promote those scalars out of `body.payload` into queryable attributes.

## Changes Made

**`board-health.mjs` — emit per-host slot counts (923f04cc)**

- `buildBoardScanEvent` gains an optional `board = null` parameter (back-compat; a null-board
  scan emits null slot scalars).
- Writes three scalars into the event `details`: `slotCapacity` (`board.capacity.maxParallel`),
  `slotInUse` (`board.capacity.liveCount`), `slotFree` (`board.capacity.freeSlots`).
- `boardHealthPass` threads its in-scope `board` into the `buildBoardScanEvent` call.
- Emit-site note documents that `slotFree` is occupancy-derived, so consumers must SUM
  `recovery.slot.free` directly rather than computing `capacity - in_use`.

**`recovery-reasoning.mjs` — promote slot scalars to chartable attributes (04ff1afa)**

- `promoteNumericAttrs`' `recovery.board-scan` branch adds three `num()` promotions:
  `recovery.slot.capacity`, `recovery.slot.in_use`, `recovery.slot.free`.
- This lifts the scalars out of `body.payload` (which the OTel/Loki path does not make
  queryable) so they ride as promoted structured-metadata attributes.
- `num()` skips null-valued scalars (no zero-pollution), but a genuinely-zero host still
  promotes `recovery.slot.free = 0`.

## How to Verify It

- [x] Execution-core unit tests pass: `execution-core-unit-tests` CI check green
- [x] All required CI checks green (Analyze, CodeQL, validate, docs-gate, execution-core-unit-tests, etc.)
- New tests cover both new behaviors:
  - `board-health.test.mjs`: board.capacity threads into `details.slot*` scalars; no-board arg defaults them to null.
  - `recovery-reasoning.test.mjs`: `recovery.board-scan` promotes slot scalars under `recovery.slot.*`; omits them when null.

**Fleet query** (once emitting): `sum(recovery.slot.free)` across the per-host `recovery.board-scan`
series (host identity via `host_name` metadata) yields fleet-wide free capacity.

## Related Issues/PRs

- Fixes https://linear.app/coalesce/issue/CTL-1607

## Changelog Entry

feat(dev): board-scan events now carry per-host worker-slot counts as chartable Loki attributes
(`recovery.slot.capacity`/`in_use`/`free`), enabling fleet-wide free-capacity dashboards.