### PR TITLE
fix(dev): drop pointless async from a synchronous server.stop() lifecycle test

### DIFF
--- a/plugins/dev/scripts/orch-monitor/__tests__/server.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/server.test.ts
@@ -2194,7 +2194,7 @@ describe("publicDir resolution", () => {
 // themselves are the two lines added alongside `stopped` in server.ts and
 // are covered by direct code inspection + this flag test, not a live mint.
 describe("server.stop() lifecycle flag (CTL-1612 post-merge #2978)", () => {
-  it("stopped starts false, flips true synchronously on stop(), and stays true", async () => {
+  it("stopped starts false, flips true synchronously on stop(), and stays true", () => {
     const stopTmp = mkdtempSync(join(tmpdir(), "orch-monitor-stopflag-"));
     const stopWt = join(stopTmp, "wt");
     mkdirSync(stopWt, { recursive: true });


### PR DESCRIPTION
Unblocks the `quality` lint gate on other PRs that happen to touch `orch-monitor/` (found while shipping #2987 — the plist file it adds lives under `orch-monitor/dist/`, which incidentally triggers this path-filtered gate and surfaced this pre-existing error unrelated to that PR). The test never awaits anything and explicitly tests synchronous behavior (see its own comment); `async` was vestigial. Verified test still passes and lint goes from 1 error/92 warnings to 0 errors/92 warnings.