### PR TITLE
fix(broker): CTL-1646 — prune pre-workspace member node_modules before a root install

### DIFF
--- a/plugins/dev/scripts/broker/plugin-refresh.mjs
+++ b/plugins/dev/scripts/broker/plugin-refresh.mjs
@@ -33,10 +33,10 @@
 // deterministically testable without real load, timers, network, or a checkout.
 // Mirrors the gc-liveness.mjs / autotune.mjs seam-injection convention.
 
-import { readFileSync } from "node:fs";
+import { readFileSync, existsSync, rmSync } from "node:fs";
 import { execFileSync } from "node:child_process";
 import { homedir } from "node:os";
-import { resolve } from "node:path";
+import { resolve, join } from "node:path";
 import { getEventName } from "./event-name.mjs"; // CTL-1348: leaf, not the heavy router
 
 // Throttle window: at most one pull per N seconds per checkout root. A merge
@@ -146,6 +146,57 @@ export function changedPackageDirs(root, diffOutput) {
     dirs.add(dir === "." ? root : resolve(root, dir));
   }
   return [...dirs];
+}
+
+// workspaceMemberNodeModules — pure helper: when `root` is a bun WORKSPACE root
+// (root package.json has `workspaces` and the root bun.lock is authoritative),
+// return each member's node_modules dir that exists and is not standalone-managed
+// (member has no bun.lock of its own). Exported for direct unit testing.
+//
+// WHY (CTL-1628 follow-up): the workspace conversion moved dep resolution to the
+// ROOT lockfile, but nodes migrated in place kept the node_modules the OLD
+// per-package flow had installed inside each member. Module resolution walks UP,
+// so that debris SHADOWS every root install forever: on the fleet this pinned the
+// running cloud-sync daemon to @catalyst-cloud/sdk 0.8.0 (no CTC-328 stale-frame
+// guard) while the root lock said 0.8.1 and every refresh "succeeded".
+//
+// Callers prune these dirs immediately BEFORE a root install — never on a bare
+// tick. That placement is the safety argument: bun legitimately creates nested
+// member node_modules for version conflicts, and no cheap signature separates
+// those from pre-workspace debris (verified: the fleet's stale trees carry no
+// .bun store either). Pruning only when an install follows makes a false
+// positive harmless — `bun install` recreates any nest it actually needs — and
+// costs nothing on ticks where no manifest changed.
+//
+// Glob workspace entries ("packages/*") are SKIPPED, not expanded: this repo
+// lists members literally, and silently expanding globs here would turn a new
+// pattern entry into a surprise rm -rf fan-out. A skipped glob is surfaced by
+// the caller's event detail, not swallowed.
+export function workspaceMemberNodeModules(root, { readFileFn = readFileSync, existsFn = existsSync } = {}) {
+  let manifest;
+  try {
+    manifest = JSON.parse(readFileFn(resolve(root, "package.json"), "utf8"));
+  } catch {
+    return [];
+  }
+  const entries = Array.isArray(manifest?.workspaces) ? manifest.workspaces : [];
+  if (entries.length === 0) return [];
+  if (!existsFn(resolve(root, "bun.lock"))) return []; // no authoritative root lock → not ours to prune
+  const out = [];
+  for (const entry of entries) {
+    if (typeof entry !== "string" || entry === "" || entry.includes("*")) continue;
+    const memberDir = resolve(root, entry);
+    if (!existsFn(join(memberDir, "package.json"))) continue;
+    if (existsFn(join(memberDir, "bun.lock"))) continue; // standalone-managed member — not workspace debris
+    const nm = join(memberDir, "node_modules");
+    if (existsFn(nm)) out.push(nm);
+  }
+  return out;
+}
+
+// defaultPruneFn — remove one member node_modules dir. Injectable for tests.
+function defaultPruneFn(dir) {
+  rmSync(dir, { recursive: true, force: true });
 }
 
 // defaultGitToplevelFn — map a pluginDirs entry (<checkout>/plugins/dev) to its
@@ -396,6 +447,10 @@ export function refreshPluginCheckout({
   now = Date.now(),
   gitFn = defaultGitFn,
   bunInstallFn = defaultBunInstallFn,
+  // CTL-1628 follow-up seams: stale-member-node_modules pruning ahead of a root
+  // install (see workspaceMemberNodeModules for why). Injectable for tests.
+  memberNodeModulesFn = workspaceMemberNodeModules,
+  pruneFn = defaultPruneFn,
   emitFn,
   loadedCommit = null,
   loadedCommitRoot = null,
@@ -535,10 +590,33 @@ export function refreshPluginCheckout({
   // triggers the monitor restart). Install failures are surfaced as WARN events
   // and never block the checkout-updated signal (reset already succeeded).
   const depsInstalled = [];
+  const staleNodeModulesPruned = [];
   if (oldSha) {
     let diffOut = "";
     try { diffOut = gitFn(root, ["diff", "--name-only", oldSha, newSha]); } catch { diffOut = ""; }
-    for (const pkgDir of changedPackageDirs(root, diffOut)) {
+    const pkgDirs = changedPackageDirs(root, diffOut);
+    // CTL-1628 follow-up: an install is about to run and the root lockfile is
+    // authoritative, so first clear any member node_modules that would SHADOW
+    // it (pre-workspace debris; see workspaceMemberNodeModules). Prune failures
+    // are non-fatal for the same reason install failures are — the reset
+    // already succeeded — but they surface as WARN, never silently.
+    if (pkgDirs.length > 0) {
+      for (const nm of memberNodeModulesFn(root)) {
+        try {
+          pruneFn(nm);
+          staleNodeModulesPruned.push(nm);
+        } catch (err) {
+          emitFn({
+            event: "plugin.checkout.node_modules_prune_failed",
+            orchestrator: null,
+            worker: null,
+            severity: "WARN",
+            detail: { checkout: root, node_modules_dir: nm, error: err?.message ?? String(err) },
+          });
+        }
+      }
+    }
+    for (const pkgDir of pkgDirs) {
       try {
         bunInstallFn(pkgDir);
         depsInstalled.push(pkgDir);
@@ -565,6 +643,7 @@ export function refreshPluginCheckout({
       loaded_commit: loadedCommit,
       restart_needed: restartNeeded,
       deps_installed: depsInstalled,
+      stale_node_modules_pruned: staleNodeModulesPruned,
     },
   });
   return { pulled: true, throttled: false, changed: true, failed: false, root, oldSha, newSha, restartNeeded };

--- a/plugins/dev/scripts/broker/plugin-refresh.test.mjs
+++ b/plugins/dev/scripts/broker/plugin-refresh.test.mjs
@@ -29,6 +29,7 @@ import {
   startPluginDriftCheck,
   handlePluginRefreshEvent,
   changedPackageDirs,
+  workspaceMemberNodeModules,
   PLUGIN_REFRESH_THROTTLE_MS,
   PLUGIN_DRIFT_CHECK_INTERVAL_MS,
   __clearThrottleForTest,
@@ -1411,5 +1412,171 @@ describe("refreshPluginCheckout — bunInstallFn seam (CTL-1223)", () => {
     expect(updEv).toBeDefined();
     expect(Array.isArray(updEv.detail.deps_installed)).toBe(true);
     expect(updEv.detail.deps_installed).toContain("/repo/plugins/dev/scripts/orch-monitor/ui");
+  });
+});
+
+// ─── workspaceMemberNodeModules + install-time pruning (CTL-1628 follow-up) ──
+//
+// The workspace conversion moved dep resolution to the ROOT lockfile, but nodes
+// migrated in place kept each member's pre-workspace node_modules. Module
+// resolution walks UP, so that debris SHADOWS every root install: on the fleet
+// this pinned the running cloud-sync daemon to @catalyst-cloud/sdk 0.8.0 (no
+// CTC-328 stale-frame guard) while the root lock said 0.8.1 and every refresh
+// "succeeded". The prune runs ONLY immediately before an install — bun
+// recreates any nested layout it legitimately needs, which is what makes a
+// false positive harmless — and never on a bare tick.
+
+function makeWorkspaceFs({
+  workspaces = ["plugins/dev/scripts/execution-core"],
+  rootLock = true,
+  members = {},
+} = {}) {
+  // members: { "<entry>": { pkg: true, lock: false, nodeModules: true } }
+  const files = new Set();
+  const contents = new Map();
+  contents.set("/co/package.json", JSON.stringify({ workspaces }));
+  files.add("/co/package.json");
+  if (rootLock) files.add("/co/bun.lock");
+  for (const [entry, m] of Object.entries(members)) {
+    if (m.pkg !== false) files.add(`/co/${entry}/package.json`);
+    if (m.lock) files.add(`/co/${entry}/bun.lock`);
+    if (m.nodeModules !== false) files.add(`/co/${entry}/node_modules`);
+  }
+  return {
+    readFileFn: (path) => {
+      const key = String(path);
+      if (!contents.has(key)) throw new Error(`ENOENT: ${key}`);
+      return contents.get(key);
+    },
+    existsFn: (path) => files.has(String(path)),
+  };
+}
+
+describe("workspaceMemberNodeModules", () => {
+  test("returns a member's node_modules when the member has no lockfile of its own", () => {
+    const fs = makeWorkspaceFs({
+      members: { "plugins/dev/scripts/execution-core": { nodeModules: true } },
+    });
+    expect(workspaceMemberNodeModules("/co", fs)).toEqual([
+      "/co/plugins/dev/scripts/execution-core/node_modules",
+    ]);
+  });
+
+  test("skips a member that manages itself (own bun.lock) — that is not workspace debris", () => {
+    const fs = makeWorkspaceFs({
+      members: { "plugins/dev/scripts/execution-core": { nodeModules: true, lock: true } },
+    });
+    expect(workspaceMemberNodeModules("/co", fs)).toEqual([]);
+  });
+
+  test("returns [] when the ROOT has no bun.lock — without an authoritative root lock, nothing is ours to prune", () => {
+    const fs = makeWorkspaceFs({
+      rootLock: false,
+      members: { "plugins/dev/scripts/execution-core": { nodeModules: true } },
+    });
+    expect(workspaceMemberNodeModules("/co", fs)).toEqual([]);
+  });
+
+  test("returns [] for a non-workspace root, and skips glob entries rather than expanding them", () => {
+    const noWs = makeWorkspaceFs({ workspaces: [] });
+    expect(workspaceMemberNodeModules("/co", noWs)).toEqual([]);
+
+    // A glob entry must NOT silently become an rm -rf fan-out.
+    const glob = makeWorkspaceFs({
+      workspaces: ["packages/*"],
+      members: { "packages/a": { nodeModules: true } },
+    });
+    expect(workspaceMemberNodeModules("/co", glob)).toEqual([]);
+  });
+
+  test("an unreadable root package.json yields [] rather than a throw — refresh must not die on it", () => {
+    expect(
+      workspaceMemberNodeModules("/co", {
+        readFileFn: () => {
+          throw new Error("EACCES");
+        },
+        existsFn: () => true,
+      }),
+    ).toEqual([]);
+  });
+});
+
+describe("refreshPluginCheckout — stale node_modules pruning", () => {
+  beforeEach(() => {
+    __clearThrottleForTest();
+    __clearLagStateForTest();
+  });
+
+  // A gitFn whose diff reports the root lockfile changed → install will run at root.
+  function makeGitFnWithDiff(diffLines) {
+    const inner = makeGitFn({ before: "old111", after: "new222" });
+    const gitFn = (root, args) => {
+      if (args[0] === "diff") return diffLines.join("\n");
+      return inner(root, args);
+    };
+    gitFn.calls = inner.calls;
+    return gitFn;
+  }
+
+  test("prunes stale member node_modules BEFORE the install, and says so in the updated event", () => {
+    const emitted = [];
+    const order = [];
+    const res = refreshPluginCheckout({
+      root: "/co",
+      now: 0,
+      gitFn: makeGitFnWithDiff(["bun.lock"]),
+      memberNodeModulesFn: () => ["/co/plugins/dev/scripts/execution-core/node_modules"],
+      pruneFn: (dir) => order.push(`prune:${dir}`),
+      bunInstallFn: (dir) => order.push(`install:${dir}`),
+      emitFn: (e) => emitted.push(e),
+    });
+
+    expect(res.failed).toBe(false);
+    // ORDER is the point: pruning after the install would leave the shadow in place.
+    expect(order).toEqual([
+      "prune:/co/plugins/dev/scripts/execution-core/node_modules",
+      "install:/co",
+    ]);
+    const updated = emitted.find((e) => e.event === "plugin.checkout.updated");
+    expect(updated.detail.stale_node_modules_pruned).toEqual([
+      "/co/plugins/dev/scripts/execution-core/node_modules",
+    ]);
+    expect(updated.detail.deps_installed).toEqual(["/co"]);
+  });
+
+  test("does NOT prune on a pull with no manifest changes — never on a bare tick", () => {
+    const pruned = [];
+    refreshPluginCheckout({
+      root: "/co",
+      now: 0,
+      gitFn: makeGitFnWithDiff(["some/other/file.mjs"]),
+      memberNodeModulesFn: () => ["/co/plugins/dev/scripts/execution-core/node_modules"],
+      pruneFn: (dir) => pruned.push(dir),
+      bunInstallFn: () => {},
+      emitFn: () => {},
+    });
+    expect(pruned).toEqual([]);
+  });
+
+  test("a prune failure WARNs and the install still runs — same non-fatal contract as install failures", () => {
+    const emitted = [];
+    const installed = [];
+    refreshPluginCheckout({
+      root: "/co",
+      now: 0,
+      gitFn: makeGitFnWithDiff(["bun.lock"]),
+      memberNodeModulesFn: () => ["/co/x/node_modules"],
+      pruneFn: () => {
+        throw new Error("EPERM: operation not permitted");
+      },
+      bunInstallFn: (dir) => installed.push(dir),
+      emitFn: (e) => emitted.push(e),
+    });
+
+    const warn = emitted.find((e) => e.event === "plugin.checkout.node_modules_prune_failed");
+    expect(warn.severity).toBe("WARN");
+    expect(warn.detail.node_modules_dir).toBe("/co/x/node_modules");
+    expect(warn.detail.error).toContain("EPERM");
+    expect(installed).toEqual(["/co"]); // the checkout still converges as far as it can
   });
 });


### PR DESCRIPTION
Closes CTL-1646. Found while tracing why the CTC-328 stale-frame guard never reached the fleet's host replicas.

## The failure

CTL-1628 Phase A1 moved dep resolution to the repo-root `bun.lock`. Nodes migrated **in place** kept each member's pre-workspace `node_modules` — and module resolution walks **up**, so that debris shadows every root install, forever.

Observed on both minis: root lock resolves `@catalyst-cloud/sdk@0.8.1`, the root install ran and "succeeded" — and the running `catalyst-cloud-sync` daemons loaded **0.8.0** from `execution-core/node_modules` (a 117-entry pre-workspace tree). **The production host replicas ran without the CTC-328 delete-corruption guard while every refresh looked green.**

## The fix

Prune workspace-member `node_modules` **only immediately before an install triggered by a manifest change** — never on a bare tick.

That placement is the whole safety argument. bun legitimately creates nested member `node_modules` for version conflicts, and **no cheap signature separates those from pre-workspace debris** — I tried; the fleet's stale trees carry no `.bun` store either. Pruning only when an install follows makes a false positive *harmless by construction* (bun recreates any nest it needs) and costs nothing on quiet ticks.

Guardrails:
- members with their own `bun.lock` are skipped (standalone-managed, not workspace debris)
- **glob workspace entries are skipped, not expanded** — a new `packages/*` entry must not become a surprise `rm -rf` fan-out
- pruned dirs surface in `plugin.checkout.updated` (`stale_node_modules_pruned`); prune failures WARN (`plugin.checkout.node_modules_prune_failed`) and never block the install — the same non-fatal contract `deps_install_failed` already has

Existing broken nodes converge on the next root-manifest-touching pull (any dep bump). I'm remediating the current fleet by hand once, separately.

## Tests

8 new (5 pure helper, 3 wiring). The wiring test asserts **order** — prune, *then* install — because pruning after would leave the shadow in place.

**Negative control**: disabling the wiring fails exactly the 2 prune-behaviour tests while "never on a bare tick" still passes.

Broker suite: 877 tests, 873 pass + the same 4 environment-dependent failures present on clean `origin/main` (hermetic CATALYST_DIR preload ×3, held-label lockstep ×1).

## Deliberately not in this PR (in the ticket)

1. Auto-restarting daemons on dep change — `restart_needed` is documented as *"VISIBLE, not auto-restarted"*; reversing that is a design call.
2. A doctor check asserting the *running* daemon's resolved sdk == the root lock — the visibility gap that let this hide.
3. The 180s `BUN_INSTALL_TIMEOUT_MS` SIGKILL ceiling, which can leave a partial root install on the heavy desktop/ui members.

🤖 Generated with [Claude Code](https://claude.com/claude-code)