### PR TITLE
fix(dev): CTL-1648 — surface attentionReason in board stalled-phase derivation

### DIFF
--- a/plugins/dev/scripts/orch-monitor/__tests__/board-remediate.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/board-remediate.test.ts
@@ -243,3 +243,33 @@ describe("ticketColumns — remediate ticket routes to remediate column", () => 
 test("REMEDIATE_PHASE export equals 'remediate'", () => {
   expect(REMEDIATE_PHASE).toBe("remediate");
 });
+
+// CTL-1648: remediate derivation must surface attentionReason when failureReason is absent
+describe("derivePhaseWithRemediate — attentionReason surfacing (CTL-1648)", () => {
+  it("Case 1 (remediate RUNNING): surfaces remediate.attentionReason", () => {
+    const s = sigs();
+    s[idx("verify")] = { status: "done", updatedAt: "2026-08-05T01:00:00Z" };
+    const remediateSig = { status: "running", attentionReason: "ctl-587-revive-reset",
+      startedAt: "2026-08-05T01:05:00Z", updatedAt: "2026-08-05T01:06:00Z" };
+    expect(derivePhaseWithRemediate(s, remediateSig).failureReason)
+      .toBe("ctl-587-revive-reset");
+  });
+
+  it("Case 2 (remediate TERMINAL, wins by updatedAt): surfaces remediate.attentionReason", () => {
+    const s = sigs();
+    s[idx("verify")] = { status: "done", updatedAt: "2026-08-05T01:00:00Z" };
+    const remediateSig = { status: "failed", attentionReason: "sdk-overloaded-exhausted",
+      updatedAt: "2026-08-05T01:10:00Z" };
+    expect(derivePhaseWithRemediate(s, remediateSig).failureReason)
+      .toBe("sdk-overloaded-exhausted");
+  });
+
+  it("precedence: remediate.failureReason still wins over attentionReason", () => {
+    const s = sigs();
+    s[idx("verify")] = { status: "done", updatedAt: "2026-08-05T01:00:00Z" };
+    const remediateSig = { status: "failed", failureReason: "remediate-terminal",
+      attentionReason: "revive-reset", updatedAt: "2026-08-05T01:10:00Z" };
+    expect(derivePhaseWithRemediate(s, remediateSig).failureReason)
+      .toBe("remediate-terminal");
+  });
+});

--- a/plugins/dev/scripts/orch-monitor/board-data-failed-phase.test.ts
+++ b/plugins/dev/scripts/orch-monitor/board-data-failed-phase.test.ts
@@ -193,3 +193,55 @@ describe("phaseFailed call-site logic (CTL-1180 false-positive guard)", () => {
     expect(phaseFailed).toBe(false);
   });
 });
+
+// CTL-1648: board derivation must surface attentionReason when failureReason is absent
+describe("deriveCurrentPhase — attentionReason surfacing (CTL-1648)", () => {
+  it("non-terminal stalled phase: surfaces attentionReason as failureReason", () => {
+    const phaseSigs = [
+      { status: "done" },   // triage
+      { status: "done" },   // research
+      { status: "done" },   // plan
+      { status: "stalled", attentionReason: "sdk-overloaded-exhausted",
+        updatedAt: "2026-08-05T01:00:00Z" }, // implement (non-terminal → early return)
+    ];
+    const cur = deriveCurrentPhase(phaseSigs);
+    expect(cur.failureReason).toBe("sdk-overloaded-exhausted");
+  });
+
+  it("terminal failed phase: surfaces attentionReason as failureReason", () => {
+    const phaseSigs = [
+      { status: "done" },
+      { status: "done" },
+      { status: "failed", attentionReason: "preempted-by-priority",
+        updatedAt: "2026-08-05T01:00:00Z" }, // plan terminal → lastTerminal branch
+    ];
+    const cur = deriveCurrentPhase(phaseSigs);
+    expect(cur.failureReason).toBe("preempted-by-priority");
+  });
+
+  it("precedence: failureReason still wins over attentionReason", () => {
+    const phaseSigs = [
+      { status: "done" },
+      { status: "failed", failureReason: "real-terminal-failure",
+        attentionReason: "sdk-backstop", updatedAt: "2026-08-05T01:00:00Z" },
+    ];
+    expect(deriveCurrentPhase(phaseSigs).failureReason).toBe("real-terminal-failure");
+  });
+
+  it("precedence: legacy stalledReason still surfaces when it is the only field", () => {
+    const phaseSigs = [
+      { status: "done" },
+      { status: "stalled", stalledReason: "legacy-stalled",
+        updatedAt: "2026-08-05T01:00:00Z" },
+    ];
+    expect(deriveCurrentPhase(phaseSigs).failureReason).toBe("legacy-stalled");
+  });
+
+  it("none of the three fields → failureReason null (unknown-reason fallback intact)", () => {
+    const phaseSigs = [
+      { status: "done" },
+      { status: "stalled", updatedAt: "2026-08-05T01:00:00Z" },
+    ];
+    expect(deriveCurrentPhase(phaseSigs).failureReason).toBeNull();
+  });
+});

--- a/plugins/dev/scripts/orch-monitor/lib/board-data.d.mts
+++ b/plugins/dev/scripts/orch-monitor/lib/board-data.d.mts
@@ -103,6 +103,7 @@ export interface BoardCurrentPhase {
   model: string | null;
   startedAt?: string;
   updatedAt?: string;
+  failureReason?: string | null;
 }
 
 export interface BoardTicket {

--- a/plugins/dev/scripts/orch-monitor/lib/board-data.mjs
+++ b/plugins/dev/scripts/orch-monitor/lib/board-data.mjs
@@ -787,7 +787,9 @@ export function deriveCurrentPhase(phaseSigs) {
         model: sig.model || null,
         startedAt: sig.startedAt,
         updatedAt: sig.updatedAt,
-        failureReason: sig.failureReason ?? sig.stalledReason ?? null,
+        // attentionReason inserted between failureReason and stalledReason to match
+        // scheduler.mjs:2666 readDispatchFailureReason precedence (CTL-1648).
+        failureReason: sig.failureReason ?? sig.attentionReason ?? sig.stalledReason ?? null,
       };
     }
     lastTerminal = {
@@ -796,7 +798,7 @@ export function deriveCurrentPhase(phaseSigs) {
       model: sig.model || null,
       startedAt: sig.startedAt,
       updatedAt: sig.updatedAt,
-      failureReason: sig.failureReason ?? sig.stalledReason ?? null,
+      failureReason: sig.failureReason ?? sig.attentionReason ?? sig.stalledReason ?? null,
     };
     lastTerminalIndex = i;
   }
@@ -845,7 +847,7 @@ export function derivePhaseWithRemediate(phaseSigs, remediateSig) {
       model: remediateSig.model || null,
       startedAt: remediateSig.startedAt ?? null,
       updatedAt: remediateSig.updatedAt ?? null,
-      failureReason: remediateSig.failureReason ?? remediateSig.stalledReason ?? null,
+      failureReason: remediateSig.failureReason ?? remediateSig.attentionReason ?? remediateSig.stalledReason ?? null,
     };
   }
   // Case 2: remediate is terminal but more recent than what PHASE_ORDER surfaced.
@@ -860,7 +862,7 @@ export function derivePhaseWithRemediate(phaseSigs, remediateSig) {
       model: remediateSig.model || null,
       startedAt: remediateSig.startedAt ?? null,
       updatedAt: remUpdated || null,
-      failureReason: remediateSig.failureReason ?? remediateSig.stalledReason ?? null,
+      failureReason: remediateSig.failureReason ?? remediateSig.attentionReason ?? remediateSig.stalledReason ?? null,
     };
   }
   return cur;


### PR DESCRIPTION
<!-- Auto-generated: 2026-08-05T02:23:00Z -->
<!-- Last updated: 2026-08-05T02:23:00Z -->
<!-- PR: #3003 -->
<!-- Previous commits: 8ded17d7323f1b3f7870e5c7ca60eb8c977cfb83 -->

## Summary

The orch-monitor board was displaying "gave up — unknown reason" for stalled tickets even when their signal files carried a specific `attentionReason` (e.g., `sdk-overloaded-exhausted`, `preempted-by-priority`). This fix aligns the board derivation with the scheduler's existing precedence — `failureReason ?? attentionReason ?? stalledReason ?? null` — across all four derivation sites in `board-data.mjs`, so the real reason is surfaced to operators instead of the opaque fallback.

## What Changed

### `plugins/dev/scripts/orch-monitor/lib/board-data.mjs` (+6 / -4)

Four derivation sites in `deriveCurrentPhase` and `derivePhaseWithRemediate` updated to use:

```js
failureReason: sig.failureReason ?? sig.attentionReason ?? sig.stalledReason ?? null
```

Previously, `attentionReason` was skipped entirely. The new order matches `scheduler.mjs:2666`'s `readDispatchFailureReason` — the same field the SDK launch backstop and `mark_launch_failed` write deliberately (a `failureReason` would trip the revive loop's non-retrying escalate branch, so `attentionReason` is the correct writer choice). This is a read-side-only change; no signal writers are touched.

### `plugins/dev/scripts/orch-monitor/lib/board-data.d.mts` (+1)

Added `failureReason?: string | null` to `BoardCurrentPhase` — the field was being set by the derivation but wasn't declared in the type.

### `plugins/dev/scripts/orch-monitor/board-data-failed-phase.test.ts` (+52)

Five new cases covering `deriveCurrentPhase` attentionReason surfacing:
- Non-terminal stalled phase with `attentionReason` only
- Terminal failed phase with `attentionReason` only
- Precedence: `failureReason` still wins over `attentionReason`
- Legacy: `stalledReason` still surfaces when it's the only field
- No fields set → `failureReason` is `null` (unknown-reason fallback intact)

### `plugins/dev/scripts/orch-monitor/__tests__/board-remediate.test.ts` (+30)

Three new cases covering `derivePhaseWithRemediate` attentionReason surfacing:
- Case 1 (remediate running): surfaces `remediate.attentionReason`
- Case 2 (remediate terminal, wins by updatedAt): surfaces `remediate.attentionReason`
- Precedence: `remediate.failureReason` still wins over `attentionReason`

## How to Verify

- [x] `tsc --noEmit` passes — type-clean ✅
- [x] `bun test board-data` passes — 330 tests pass (48 in modified files, 8 new CTL-1648 cases) ✅
- [x] `eslint board-data.mjs` passes — 0 errors ✅
- [ ] Manual: open a ticket in the stalled bucket whose signal has `attentionReason` but no `failureReason` — board should show the reason string instead of "unknown reason"

## Related Issues/PRs

- Fixes https://linear.app/coalesce-labs/issue/CTL-1648