### PR TITLE
feat(dev): CTL-1650 catalyst-stack claude-account subcommand + commit the accounts-usage tool

### DIFF
--- a/plugins/dev/scripts/__tests__/catalyst-stack-claude-account.test.sh
+++ b/plugins/dev/scripts/__tests__/catalyst-stack-claude-account.test.sh
@@ -1,0 +1,337 @@
+#!/usr/bin/env bash
+# Shell tests for `catalyst-stack claude-account` (CTL-1650): fleet-wide Claude
+# OAuth-account status/switch/sync. Follows the __tests__/catalyst-stack-parity.test.sh
+# / __tests__/catalyst-secret-contract.test.sh conventions (check()/PASSES/FAILURES,
+# hermetic scratch fixtures, no network or real sops/cluster-repo calls).
+#
+# SECRET HYGIENE: every fixture below uses obviously-fake literals (never a real
+# token), and no test invokes the real `sops` binary or the real cluster repo —
+# `_ca_resolve_sops`/`_ca_age_key_file`/`_ca_cluster_repo_dir` are exercised against
+# scratch dirs via CA_SOPS_CANDIDATES / CATALYST_AGE_KEY_FILE / CATALYST_CLUSTER_DIR
+# overrides, and the sed selector-flip transform (`_ca_flip_selector_file`) is
+# exercised directly against fixture files — never through a real `sops edit`.
+#
+# Run: bash plugins/dev/scripts/__tests__/catalyst-stack-claude-account.test.sh
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../../.." && pwd)"
+STACK="${REPO_ROOT}/plugins/dev/scripts/catalyst-stack"
+
+FAILURES=0
+PASSES=0
+SCRATCH="$(mktemp -d)"
+trap 'rm -rf "$SCRATCH"' EXIT
+
+ok() {
+  local name="$1"
+  PASSES=$((PASSES+1))
+  echo "  PASS: $name"
+}
+fail_t() {
+  local name="$1" detail="${2:-}"
+  FAILURES=$((FAILURES+1))
+  echo "  FAIL: $name"
+  [[ -n "$detail" ]] && echo "    $detail"
+}
+check() {
+  local name="$1"; shift
+  if "$@" > "${SCRATCH}/out" 2>&1; then
+    ok "$name"
+  else
+    fail_t "$name" "$(sed 's/^/      /' "${SCRATCH}/out")"
+  fi
+}
+
+echo "catalyst-stack claude-account (CTL-1650) tests"
+
+# ─── source the script (guarded dispatch) to reach the pure helpers ─────────
+# shellcheck disable=SC1090
+source "$STACK"
+
+# ── 1. handle validation ─────────────────────────────────────────────────────
+t_handle_valid_acct2()      { _ca_valid_handle "acct2"; }
+check "accepts acct2" t_handle_valid_acct2
+t_handle_valid_acct12()     { _ca_valid_handle "acct12"; }
+check "accepts multi-digit acct12" t_handle_valid_acct12
+t_handle_reject_dash()      { ! _ca_valid_handle "acct-2"; }
+check "rejects acct-2 (dash)" t_handle_reject_dash
+t_handle_reject_upper()     { ! _ca_valid_handle "ACCT2"; }
+check "rejects ACCT2 (uppercase)" t_handle_reject_upper
+t_handle_reject_empty()     { ! _ca_valid_handle ""; }
+check "rejects empty string" t_handle_reject_empty
+t_handle_reject_injection() { ! _ca_valid_handle 'acct2; rm -rf /'; }
+check "rejects shell-injection string" t_handle_reject_injection
+t_handle_reject_bare()      { ! _ca_valid_handle "acct"; }
+check "rejects bare 'acct' (no digits)" t_handle_reject_bare
+t_handle_reject_leading_zero_ok() { _ca_valid_handle "acct01"; }
+check "accepts leading-zero digits (acct01) — digits-only rule, not numeric" t_handle_reject_leading_zero_ok
+
+# ── 2. sops-binary resolution order ──────────────────────────────────────────
+SOPSDIR="${SCRATCH}/sopsbins"
+mkdir -p "${SOPSDIR}/opt/homebrew/bin" "${SOPSDIR}/usr/local/bin" "${SOPSDIR}/usr/bin" "${SOPSDIR}/home/.local/bin" "${SOPSDIR}/pathdir"
+
+t_sops_none_found() {
+  CA_SOPS_CANDIDATES=("${SOPSDIR}/opt/homebrew/bin/sops" "${SOPSDIR}/usr/local/bin/sops")
+  local out
+  out="$(PATH="${SOPSDIR}/pathdir" _ca_resolve_sops)"
+  [[ -z "$out" ]]
+}
+check "no candidate + empty PATH dir resolves nothing" t_sops_none_found
+
+touch "${SOPSDIR}/usr/local/bin/sops"; chmod +x "${SOPSDIR}/usr/local/bin/sops"
+touch "${SOPSDIR}/opt/homebrew/bin/sops"; chmod +x "${SOPSDIR}/opt/homebrew/bin/sops"
+t_sops_homebrew_wins() {
+  CA_SOPS_CANDIDATES=("${SOPSDIR}/opt/homebrew/bin/sops" "${SOPSDIR}/usr/local/bin/sops" "${SOPSDIR}/usr/bin/sops" "${SOPSDIR}/home/.local/bin/sops")
+  local out
+  out="$(_ca_resolve_sops)"
+  [[ "$out" == "${SOPSDIR}/opt/homebrew/bin/sops" ]]
+}
+check "known-dir order: /opt/homebrew/bin wins over /usr/local/bin when both exist" t_sops_homebrew_wins
+
+rm -f "${SOPSDIR}/opt/homebrew/bin/sops"
+t_sops_falls_through_to_local() {
+  CA_SOPS_CANDIDATES=("${SOPSDIR}/opt/homebrew/bin/sops" "${SOPSDIR}/usr/local/bin/sops" "${SOPSDIR}/usr/bin/sops" "${SOPSDIR}/home/.local/bin/sops")
+  local out
+  out="$(_ca_resolve_sops)"
+  [[ "$out" == "${SOPSDIR}/usr/local/bin/sops" ]]
+}
+check "falls through to next known dir when the first is absent" t_sops_falls_through_to_local
+
+rm -f "${SOPSDIR}/usr/local/bin/sops"
+touch "${SOPSDIR}/home/.local/bin/sops"; chmod +x "${SOPSDIR}/home/.local/bin/sops"
+t_sops_local_bin() {
+  CA_SOPS_CANDIDATES=("${SOPSDIR}/opt/homebrew/bin/sops" "${SOPSDIR}/usr/local/bin/sops" "${SOPSDIR}/usr/bin/sops" "${SOPSDIR}/home/.local/bin/sops")
+  local out
+  out="$(_ca_resolve_sops)"
+  [[ "$out" == "${SOPSDIR}/home/.local/bin/sops" ]]
+}
+check "~/.local/bin/sops candidate resolves when it's the only one present" t_sops_local_bin
+
+rm -f "${SOPSDIR}/home/.local/bin/sops"
+touch "${SOPSDIR}/pathdir/sops"; chmod +x "${SOPSDIR}/pathdir/sops"
+t_sops_path_fallback() {
+  CA_SOPS_CANDIDATES=("${SOPSDIR}/opt/homebrew/bin/sops" "${SOPSDIR}/usr/local/bin/sops" "${SOPSDIR}/usr/bin/sops" "${SOPSDIR}/home/.local/bin/sops")
+  local out
+  out="$(PATH="${SOPSDIR}/pathdir" _ca_resolve_sops)"
+  [[ "$out" == "${SOPSDIR}/pathdir/sops" ]]
+}
+check "PATH scan is the final fallback when no known dir has sops" t_sops_path_fallback
+
+# ── 3. sed selector-flip transform (real sed, fixture files, no sops/network) ──
+# 3a. Plain env-file fixture (what claude-accounts.env looks like on disk).
+PLAIN_FIXTURE="${SCRATCH}/plain.env"
+cat > "$PLAIN_FIXTURE" <<'EOF'
+CLAUDE_TOKEN_acct1='tok1'  # a@b.com
+CLAUDE_TOKEN_acct2='tok2'  # c@d.com
+_catalyst_active_token="$CLAUDE_TOKEN_acct1"
+case "$_catalyst_active_token" in
+  *) export CLAUDE_CODE_OAUTH_TOKEN="$_catalyst_active_token" ;;
+esac
+EOF
+
+t_flip_plain_selector() {
+  _ca_flip_selector_file "$PLAIN_FIXTURE" acct1 acct2 || return 1
+  grep -qx '_catalyst_active_token="$CLAUDE_TOKEN_acct2"' "$PLAIN_FIXTURE"
+}
+check "plain fixture: flips the reference line acct1 -> acct2" t_flip_plain_selector
+
+t_flip_plain_definitions_untouched() {
+  grep -qx "CLAUDE_TOKEN_acct1='tok1'  # a@b.com" "$PLAIN_FIXTURE" \
+    && grep -qx "CLAUDE_TOKEN_acct2='tok2'  # c@d.com" "$PLAIN_FIXTURE"
+}
+check "plain fixture: CLAUDE_TOKEN_acctN= definition lines untouched" t_flip_plain_definitions_untouched
+
+t_flip_plain_no_backup_left() { [[ ! -f "${PLAIN_FIXTURE}.bak" ]]; }
+check "plain fixture: .bak scratch file cleaned up" t_flip_plain_no_backup_left
+
+# 3b. JSON-escaped fixture — mirrors the ACTUAL sops-decrypted-for-edit temp file
+# shape (empirically verified against a live `sops edit` round-trip during
+# development: claude-accounts.env is a JSON string value, so an embedded `"`
+# is rendered as the 2-char escape `\"`, and embedded newlines as literal `\n`,
+# not real newlines — the whole env file lives on ONE line of the temp file).
+JSON_FIXTURE="${SCRATCH}/sops-temp.json"
+cat > "$JSON_FIXTURE" <<'EOF'
+{
+	"claude-accounts.env": "CLAUDE_TOKEN_acct1='tok1'  # a@b.com\nCLAUDE_TOKEN_acct2='tok2'  # c@d.com\n_catalyst_active_token=\"$CLAUDE_TOKEN_acct1\"\ncase \"$_catalyst_active_token\" in\n  *) export CLAUDE_CODE_OAUTH_TOKEN=\"$_catalyst_active_token\" ;;\nesac\n",
+	"other-file": "hello\n"
+}
+EOF
+JSON_FIXTURE_BEFORE="${SCRATCH}/sops-temp-before.json"
+cp "$JSON_FIXTURE" "$JSON_FIXTURE_BEFORE"
+
+t_flip_json_selector() {
+  _ca_flip_selector_file "$JSON_FIXTURE" acct1 acct2 || return 1
+  grep -q '_catalyst_active_token=\\"\$CLAUDE_TOKEN_acct2\\"' "$JSON_FIXTURE"
+}
+check "JSON-escaped fixture (real sops-temp-file shape): flips the reference" t_flip_json_selector
+
+t_flip_json_definitions_untouched() {
+  grep -q "CLAUDE_TOKEN_acct1='tok1'" "$JSON_FIXTURE" \
+    && grep -q "CLAUDE_TOKEN_acct2='tok2'" "$JSON_FIXTURE"
+}
+check "JSON-escaped fixture: CLAUDE_TOKEN_acctN= definition lines untouched" t_flip_json_definitions_untouched
+
+t_flip_json_other_key_untouched() {
+  grep -q '"other-file": "hello' "$JSON_FIXTURE"
+}
+check "JSON-escaped fixture: unrelated sibling key untouched" t_flip_json_other_key_untouched
+
+t_flip_json_no_extra_diff() {
+  # Only the selector's handle digit should differ from the original — assert
+  # exactly one changed line (one '<' + one '>' from a classic diff).
+  local changed
+  changed="$(diff "$JSON_FIXTURE_BEFORE" "$JSON_FIXTURE" | grep -c '^[<>]')"
+  [[ "$changed" -eq 2 ]]
+}
+check "JSON-escaped fixture: exactly one line changed (surgical edit)" t_flip_json_no_extra_diff
+
+# 3c. acct1 vs acct10 prefix-collision guard.
+PREFIX_FIXTURE="${SCRATCH}/prefix.env"
+cat > "$PREFIX_FIXTURE" <<'EOF'
+CLAUDE_TOKEN_acct1='tok1'  # a@b.com
+CLAUDE_TOKEN_acct10='tokX'  # x@y.com
+_catalyst_active_token="$CLAUDE_TOKEN_acct1"
+EOF
+t_flip_no_prefix_collision() {
+  _ca_flip_selector_file "$PREFIX_FIXTURE" acct1 acct2 || return 1
+  grep -qx '_catalyst_active_token="$CLAUDE_TOKEN_acct2"' "$PREFIX_FIXTURE" \
+    && grep -qx "CLAUDE_TOKEN_acct10='tokX'  # x@y.com" "$PREFIX_FIXTURE"
+}
+check "acct1 -> acct2 flip does not corrupt a sibling acct10 definition line" t_flip_no_prefix_collision
+
+# 3d. no-op when OLD doesn't match anything (the scenario that makes real sops
+# report "File has not changed, exiting." — see the switch flow's handling of it).
+NOOP_FIXTURE="${SCRATCH}/noop.env"
+cat > "$NOOP_FIXTURE" <<'EOF'
+CLAUDE_TOKEN_acct1='tok1'  # a@b.com
+_catalyst_active_token="$CLAUDE_TOKEN_acct1"
+EOF
+NOOP_BEFORE="$(cat "$NOOP_FIXTURE")"
+t_flip_noop_when_old_absent() {
+  _ca_flip_selector_file "$NOOP_FIXTURE" acct9 acct2 || return 1
+  [[ "$(cat "$NOOP_FIXTURE")" == "$NOOP_BEFORE" ]]
+}
+check "sed is a byte-for-byte no-op when OLD handle isn't the active selector (would trigger sops' 'File has not changed')" t_flip_noop_when_old_absent
+
+# 3e. "File has not changed" detection is a plain substring/case-insensitive match
+# on sops' own message text (empirically: "File has not changed, exiting.").
+t_detects_unchanged_message() {
+  printf '%s' "File has not changed, exiting." | grep -qi "has not changed"
+}
+check "'File has not changed' detector matches sops' real message text" t_detects_unchanged_message
+t_detects_unchanged_message_case() {
+  printf '%s' "file HAS NOT changed" | grep -qi "has not changed"
+}
+check "'File has not changed' detector is case-insensitive" t_detects_unchanged_message_case
+t_ok_message_not_flagged() {
+  ! printf '%s' "" | grep -qi "has not changed"
+}
+check "a normal (empty) sops-edit output is not flagged as unchanged" t_ok_message_not_flagged
+
+# ── 4. _ca_current_active_handle ─────────────────────────────────────────────
+ACTIVE_FIXTURE="${SCRATCH}/active.env"
+cat > "$ACTIVE_FIXTURE" <<'EOF'
+CLAUDE_TOKEN_acct1='tok1'  # a@b.com
+CLAUDE_TOKEN_acct3='tok3'  # e@f.com
+_catalyst_active_token="$CLAUDE_TOKEN_acct3"
+EOF
+t_current_active_handle() {
+  [[ "$(_ca_current_active_handle "$ACTIVE_FIXTURE")" == "acct3" ]]
+}
+check "_ca_current_active_handle parses the selector line" t_current_active_handle
+
+t_current_active_handle_missing_file() {
+  ! _ca_current_active_handle "${SCRATCH}/does-not-exist.env" >/dev/null 2>&1
+}
+check "_ca_current_active_handle fails (not guesses) when the file is absent" t_current_active_handle_missing_file
+
+NOSELECTOR_FIXTURE="${SCRATCH}/noselector.env"
+printf "CLAUDE_TOKEN_acct1='tok1'\n" > "$NOSELECTOR_FIXTURE"
+t_current_active_handle_missing_line() {
+  ! _ca_current_active_handle "$NOSELECTOR_FIXTURE" >/dev/null 2>&1
+}
+check "_ca_current_active_handle fails (not guesses) when the selector line is absent" t_current_active_handle_missing_line
+
+# ── 5. age-key / cluster-repo guard failures (run the real dispatch as a
+#      subprocess so `fail()`'s exit doesn't kill this test runner; every
+#      external side effect — sops, git push, restart — is unreachable because
+#      the guard fires first) ──────────────────────────────────────────────
+GOOD_AGE_KEY="${SCRATCH}/age.key"
+printf 'AGE-SECRET-KEY-FAKE\n' > "$GOOD_AGE_KEY"
+GOOD_CLUSTER_DIR="${SCRATCH}/cluster-repo"
+mkdir -p "${GOOD_CLUSTER_DIR}/.git"  # only presence of .git is checked
+
+t_guard_missing_age_key() {
+  local out rc
+  out="$(env -i PATH="$PATH" HOME="${SCRATCH}/home-unused" \
+      CATALYST_AGE_KEY_FILE="${SCRATCH}/no-such-age.key" \
+      CATALYST_CLUSTER_DIR="$GOOD_CLUSTER_DIR" \
+      "$STACK" claude-account switch acct2 --yes 2>&1)"; rc=$?
+  [[ $rc -ne 0 ]] && grep -qi "cannot decrypt cluster secrets" <<<"$out"
+}
+check "switch: missing age key fails with the 'cannot decrypt' message" t_guard_missing_age_key
+
+t_guard_missing_cluster_repo() {
+  local out rc
+  out="$(env -i PATH="$PATH" HOME="${SCRATCH}/home-unused" \
+      CATALYST_AGE_KEY_FILE="$GOOD_AGE_KEY" \
+      CATALYST_CLUSTER_DIR="${SCRATCH}/no-such-cluster-repo" \
+      "$STACK" claude-account switch acct2 --yes 2>&1)"; rc=$?
+  [[ $rc -ne 0 ]] && grep -qi "no cluster repo clone" <<<"$out"
+}
+check "switch: missing cluster repo clone fails with a clear message" t_guard_missing_cluster_repo
+
+t_guard_missing_age_key_sync() {
+  local out rc
+  out="$(env -i PATH="$PATH" HOME="${SCRATCH}/home-unused" \
+      CATALYST_AGE_KEY_FILE="${SCRATCH}/no-such-age.key" \
+      CATALYST_CLUSTER_DIR="$GOOD_CLUSTER_DIR" \
+      "$STACK" claude-account sync --yes 2>&1)"; rc=$?
+  [[ $rc -ne 0 ]] && grep -qi "cannot decrypt cluster secrets" <<<"$out"
+}
+check "sync: missing age key fails with the 'cannot decrypt' message" t_guard_missing_age_key_sync
+
+t_invalid_handle_rejected_before_any_guard() {
+  local out rc
+  out="$(env -i PATH="$PATH" HOME="${SCRATCH}/home-unused" \
+      CATALYST_AGE_KEY_FILE="$GOOD_AGE_KEY" \
+      CATALYST_CLUSTER_DIR="$GOOD_CLUSTER_DIR" \
+      "$STACK" claude-account switch 'not-an-acct' --yes 2>&1)"; rc=$?
+  [[ $rc -ne 0 ]] && grep -qi "invalid handle" <<<"$out"
+}
+check "switch: invalid handle format is rejected with a clear message" t_invalid_handle_rejected_before_any_guard
+
+t_switch_no_handle_usage_error() {
+  local out rc
+  out="$(env -i PATH="$PATH" HOME="${SCRATCH}/home-unused" "$STACK" claude-account switch 2>&1)"; rc=$?
+  [[ $rc -ne 0 ]] && grep -qi "usage:" <<<"$out"
+}
+check "switch: no handle prints a usage error" t_switch_no_handle_usage_error
+
+t_claude_account_no_subcommand_usage_error() {
+  local out rc
+  out="$(env -i PATH="$PATH" HOME="${SCRATCH}/home-unused" "$STACK" claude-account 2>&1)"; rc=$?
+  [[ $rc -ne 0 ]] && grep -qi "status" <<<"$out" && grep -qi "switch" <<<"$out" && grep -qi "sync" <<<"$out"
+}
+check "claude-account: bare subcommand prints usage naming status/switch/sync" t_claude_account_no_subcommand_usage_error
+
+t_claude_account_unknown_subcommand() {
+  local out rc
+  out="$(env -i PATH="$PATH" HOME="${SCRATCH}/home-unused" "$STACK" claude-account bogus 2>&1)"; rc=$?
+  [[ $rc -ne 0 ]]
+}
+check "claude-account: unknown subcommand exits nonzero" t_claude_account_unknown_subcommand
+
+t_top_level_dispatch_knows_claude_account() {
+  local out
+  out="$(env -i PATH="$PATH" HOME="${SCRATCH}/home-unused" "$STACK" bogus-command 2>&1)"
+  grep -q "claude-account" <<<"$out"
+}
+check "top-level unknown-command message names claude-account" t_top_level_dispatch_knows_claude_account
+
+echo ""
+TOTAL=$((PASSES + FAILURES))
+echo "catalyst-stack-claude-account: $PASSES/$TOTAL passed, $FAILURES failed"
+exit "$FAILURES"

--- a/plugins/dev/scripts/catalyst-stack
+++ b/plugins/dev/scripts/catalyst-stack
@@ -26,6 +26,29 @@
 #   catalyst-stack verify-updater [--json] [--no-e2e]
 #   catalyst-stack verify-node [--json]
 #   catalyst-stack sync-cloud-env
+#   catalyst-stack claude-account status
+#   catalyst-stack claude-account switch <handle> [--yes]
+#   catalyst-stack claude-account sync [--yes]
+#
+# claude-account (CTL-1650):
+#   Fleet-wide Claude OAuth-account control, one command.
+#   status         — run claude-accounts-usage.mjs and print per-account rate-limit
+#                    usage (5h/7d windows, which account is ACTIVE). Exits nonzero if
+#                    no account reported limits.
+#   switch <handle> — flip the fleet's active SDK account (handle form: acctN, e.g.
+#                    acct2). Guards on the local age key + a catalyst-cluster clone,
+#                    validates the handle is provisioned, probes its token auth
+#                    BEFORE switching (refuses a 401/expired account), flips the
+#                    `_catalyst_active_token` selector in
+#                    secrets/node-secret-files.sops.json via a non-interactive `sops
+#                    edit`, commits + pushes the cluster repo, re-materializes
+#                    ~/.config/catalyst/claude-accounts.env, restarts the stack, and
+#                    verifies the usage tool now reports the new account ACTIVE.
+#   sync            — for a second node after a switch was pushed elsewhere: git pull
+#                    the cluster repo, re-materialize claude-accounts.env, restart,
+#                    and verify.
+#   Token values are never echoed, logged, or written anywhere but the 0600
+#   ~/.config/catalyst/claude-accounts.env target file.
 #
 # sync-cloud-env (CTL-1307):
 #   Project the cluster-shared CATALYST_CLOUD_TOKEN (decrypted by cluster-sync into
@@ -2787,6 +2810,347 @@ cmd_verify_node() {
   return $?
 }
 
+# ─── claude-account (CTL-1650) ──────────────────────────────────────────────
+# Fleet-wide Claude OAuth-account control: report per-account usage, and flip
+# WHICH durable setup-token the SDK executor boots as (the `_catalyst_active_token`
+# selector line inside secrets/node-secret-files.sops.json's claude-accounts.env
+# entry, decrypted by execution-core/cluster-sync.mjs into
+# ~/.config/catalyst/claude-accounts.env on every node — see catalyst-execution-core's
+# `source "$_accounts_env"` under executor=sdk).
+#
+# SECRETS HYGIENE (hard rule, mirrors claude-accounts-usage.mjs): token VALUES are
+# NEVER echoed, logged, or captured into a variable that outlives a single pipeline.
+# Membership checks pipe straight to `grep -q`; the temp EDITOR script contains only
+# a sed program built from account HANDLES (acctN labels), never a token value; the
+# script is removed after use.
+
+CA_AGE_KEY_FILE_DEFAULT="${HOME}/.config/catalyst/age.key"
+CA_CLUSTER_REPO_DIR_DEFAULT="${HOME}/catalyst/catalyst-cluster"
+CA_ACCOUNTS_ENV_DEFAULT="${HOME}/.config/catalyst/claude-accounts.env"
+# Known absolute sops install locations, checked in order before a PATH scan — same
+# posture as execution-core/cluster-sync.mjs's SOPS_CANDIDATES (CTL-1393: a restricted
+# daemon/shell PATH frequently omits /opt/homebrew/bin), plus ~/.local/bin (CTL-1650).
+CA_SOPS_CANDIDATES=("/opt/homebrew/bin/sops" "/usr/local/bin/sops" "/usr/bin/sops" "${HOME}/.local/bin/sops")
+
+_ca_age_key_file()    { echo "${CATALYST_AGE_KEY_FILE:-$CA_AGE_KEY_FILE_DEFAULT}"; }
+_ca_cluster_repo_dir() { echo "${CATALYST_CLUSTER_DIR:-$CA_CLUSTER_REPO_DIR_DEFAULT}"; }
+_ca_accounts_env_file() { echo "${CLAUDE_ACCOUNTS_ENV:-$CA_ACCOUNTS_ENV_DEFAULT}"; }
+_ca_secrets_file()     { echo "$(_ca_cluster_repo_dir)/secrets/node-secret-files.sops.json"; }
+_ca_usage_script()     { echo "${SCRIPT_DIR}/claude-accounts-usage.mjs"; }
+
+# _ca_valid_handle HANDLE — true iff HANDLE matches the provisioned-account form
+# `acctN` (digits only after the literal "acct" — rejects "acct-2", "ACCT2", "",
+# and anything with shell/regex metacharacters, since it's later interpolated into
+# a sed program and a `git commit` message).
+_ca_valid_handle() {
+  [[ "$1" =~ ^acct[0-9]+$ ]]
+}
+
+# _ca_resolve_sops — absolute sops path: known install dirs first, then PATH. Prints
+# nothing and returns 1 when sops is unresolvable anywhere.
+_ca_resolve_sops() {
+  local c
+  for c in "${CA_SOPS_CANDIDATES[@]}"; do
+    [[ -x "$c" ]] && { echo "$c"; return 0; }
+  done
+  command -v sops 2>/dev/null && return 0
+  return 1
+}
+
+_ca_node_runtime() {
+  if command -v bun >/dev/null 2>&1; then echo bun
+  elif command -v node >/dev/null 2>&1; then echo node
+  else return 1
+  fi
+}
+
+# _ca_current_active_handle [ENV_FILE] — reads the `_catalyst_active_token="$CLAUDE_TOKEN_acctN"`
+# selector line out of the locally-materialized claude-accounts.env and prints just
+# "acctN". Prints nothing (rc 1) when the file or the line is absent — NEVER guesses.
+_ca_current_active_handle() {
+  local env_file="${1:-$(_ca_accounts_env_file)}"
+  [[ -f "$env_file" ]] || return 1
+  local line
+  line="$(grep -m1 -oE '_catalyst_active_token="\$CLAUDE_TOKEN_[A-Za-z0-9_]+"' "$env_file" 2>/dev/null)" || return 1
+  [[ -n "$line" ]] || return 1
+  sed -E 's/.*CLAUDE_TOKEN_([A-Za-z0-9_]+)".*/\1/' <<<"$line"
+}
+
+# _ca_sed_program OLD NEW — the sed -E program that flips ONLY the
+# `_catalyst_active_token=` selector reference from $CLAUDE_TOKEN_OLD to
+# $CLAUDE_TOKEN_NEW, and leaves every `CLAUDE_TOKEN_<label>=` DEFINITION line alone
+# (those never have a `$`-prefixed reference immediately after `_catalyst_active_token=`).
+# The quote before/after the handle is matched as an OPTIONAL literal backslash + `"`,
+# because the real target is sops's decrypted-for-edit JSON temp file, where the
+# claude-accounts.env content is itself a JSON string — so a `"` inside it is
+# rendered as the 2-char escape `\"`, not a bare `"` (verified against a live
+# `sops edit` round-trip; a plain env-file fixture matches too, since the backslash
+# is optional). Bounding on the trailing quote (real or escaped) also prevents a
+# handle from matching as a bare prefix of a longer one (acct1 vs acct10).
+# The trailing `g` flag matters: sops's decrypted-for-edit temp file is the WHOLE env
+# rendered as a single JSON string line, so a `g`-less program only flips the FIRST
+# occurrence of the pattern on that line — e.g. a stray commented-out selector earlier
+# in the file would eat the substitution and leave the real, active selector untouched
+# while sops still reports "changed" (silently committing a no-op edit).
+_ca_sed_program() {
+  local old="$1" new="$2"
+  local pre='s/(_catalyst_active_token=\\?")\$CLAUDE_TOKEN_'
+  local mid='(\\?")/\1\$CLAUDE_TOKEN_'
+  local suf='\2/g'
+  printf '%s' "${pre}${old}${mid}${new}${suf}"
+}
+
+# _ca_flip_selector_file FILE OLD NEW — apply _ca_sed_program in place (BSD/GNU-sed
+# portable via the `.bak` suffix form). Exposed standalone so tests can exercise the
+# real transform against a fixture file without going anywhere near sops/network.
+_ca_flip_selector_file() {
+  local file="$1" old="$2" new="$3"
+  sed -E -i.bak -e "$(_ca_sed_program "$old" "$new")" "$file" || return 1
+  rm -f "${file}.bak"
+}
+
+# _ca_confirm PROMPT ASSUME_YES — same y/N gate every other catalyst-stack
+# interactive step (e.g. ensure_proxy_deps) uses; --yes skips the prompt.
+_ca_confirm() {
+  local prompt="$1" assume_yes="$2" ans
+  [[ "$assume_yes" == "yes" ]] && return 0
+  read -r -p "${prompt} [y/N] " ans
+  [[ "$ans" =~ ^[Yy]$ ]]
+}
+
+# _ca_probe_handle_ok HANDLE — runs claude-accounts-usage.mjs --json against the
+# CURRENTLY materialized ~/.config/catalyst/claude-accounts.env (which already holds
+# every provisioned account's token, regardless of which one is "active" — see the
+# tool's own header) and requires HANDLE's entry to report no error (i.e. it got real
+# rate-limit headers back, not a 401/403/network failure). Never prints token values;
+# only JSON already scrubbed of them by the usage tool itself.
+_ca_probe_handle_ok() {
+  local handle="$1" rt script json entry err
+  rt="$(_ca_node_runtime)" || fail "neither bun nor node found on PATH — cannot run claude-accounts-usage.mjs"
+  script="$(_ca_usage_script)"
+  [[ -f "$script" ]] || fail "claude-accounts-usage.mjs missing at ${script}"
+  json="$("$rt" "$script" --json 2>/dev/null)" || true
+  entry="$(printf '%s' "$json" | jq -c --arg h "$handle" '.accounts[]? | select(.label == $h)' 2>/dev/null)"
+  [[ -n "$entry" ]] || return 1
+  err="$(printf '%s' "$entry" | jq -r '.error // empty' 2>/dev/null)"
+  [[ -z "$err" ]]
+}
+
+# _ca_verify_active HANDLE — sources the just-materialized claude-accounts.env (which
+# sets CLAUDE_CODE_OAUTH_TOKEN from whichever account is now selected) in a subshell
+# and confirms the usage tool reports HANDLE — and only HANDLE — as ACTIVE. Prints the
+# tool's human report and returns nonzero on any mismatch.
+_ca_verify_active() {
+  local handle="$1" rt script dest json active active_err
+  rt="$(_ca_node_runtime)" || fail "neither bun nor node found on PATH — cannot verify"
+  script="$(_ca_usage_script)"
+  dest="$(_ca_accounts_env_file)"
+  json="$(
+    # shellcheck disable=SC1090
+    . "$dest" >/dev/null 2>&1
+    "$rt" "$script" --json 2>/dev/null
+  )" || true
+  active="$(printf '%s' "$json" | jq -r '[.accounts[]? | select(.isActive == true) | .label] | first // empty' 2>/dev/null)"
+  if [[ "$active" != "$handle" ]]; then
+    warn "verify: usage tool reports active account '${active:-<none>}', expected '${handle}'"
+    return 1
+  fi
+  # `isActive` is a token-value match only (usage.mjs) — it is set regardless of auth
+  # outcome, so an account can be isActive=true with a live auth error. Don't declare
+  # victory without also checking .error is empty for that same entry.
+  active_err="$(printf '%s' "$json" | jq -r --arg h "$handle" '[.accounts[]? | select(.label == $h) | (.error // empty)] | first // empty' 2>/dev/null)"
+  if [[ -n "$active_err" ]]; then
+    warn "verify: ${handle} is selected but reports an auth error: ${active_err}"
+    return 1
+  fi
+  log "claude-account: verified — ${handle} is ACTIVE"
+  (
+    # shellcheck disable=SC1090
+    . "$dest" >/dev/null 2>&1
+    "$rt" "$script"
+  )
+}
+
+cmd_claude_account_status() {
+  local rt script
+  [[ $# -eq 0 ]] || fail "unknown claude-account status arg: $1"
+  rt="$(_ca_node_runtime)" || fail "neither bun nor node found on PATH — cannot run claude-accounts-usage.mjs"
+  script="$(_ca_usage_script)"
+  [[ -f "$script" ]] || fail "claude-accounts-usage.mjs missing at ${script}"
+  "$rt" "$script"
+}
+
+cmd_claude_account_switch() {
+  local handle="${1:-}"
+  [[ -n "$handle" ]] || fail "usage: catalyst-stack claude-account switch <handle> [--yes] (e.g. acct2)"
+  shift
+  local assume_yes="${ASSUME_YES:-no}"
+  for a in "$@"; do
+    case "$a" in
+      --yes) assume_yes="yes" ;;
+      *) fail "unknown claude-account switch arg: $a" ;;
+    esac
+  done
+
+  _ca_valid_handle "$handle" || fail "invalid handle '${handle}' — must match ^acct[0-9]+\$ (e.g. acct2)"
+
+  local age_key; age_key="$(_ca_age_key_file)"
+  [[ -f "$age_key" ]] || fail "no age key at ${age_key} — this node cannot decrypt cluster secrets"
+
+  local cluster_dir; cluster_dir="$(_ca_cluster_repo_dir)"
+  [[ -d "${cluster_dir}/.git" ]] || fail "no cluster repo clone at ${cluster_dir}"
+
+  # Refuse on a dirty/staged clone: `git commit` with no pathspec commits the WHOLE
+  # index, so any bystander pre-staged change would be silently swept into the
+  # secrets commit and pushed fleet-wide. The commit below is also pathspec'd to the
+  # sops file as defense in depth, but this guard is what stops the switch happening
+  # at all against a dirty clone.
+  local dirty; dirty="$(cd "$cluster_dir" && git status --porcelain)"
+  [[ -z "$dirty" ]] || fail "cluster repo ${cluster_dir} has uncommitted or staged changes — refusing to switch (they would be swept into the secrets commit); commit, stash, or discard them first"
+
+  # Pre-edit sync: `switch` mutates shared fleet state, so start from origin's tip.
+  # Without this, a push below can be rejected as non-fast-forward any time another
+  # node has pushed since this clone last moved.
+  log "claude-account switch: syncing ${cluster_dir} with origin..."
+  ( cd "$cluster_dir" && git pull --ff-only ) \
+    || fail "git pull --ff-only failed in ${cluster_dir} — resolve the divergence manually, then retry switch"
+
+  local sops_bin; sops_bin="$(_ca_resolve_sops)" || fail "sops binary not found (checked known install dirs + PATH)"
+
+  local secrets_file; secrets_file="$(_ca_secrets_file)"
+  [[ -f "$secrets_file" ]] || fail "missing ${secrets_file}"
+
+  log "claude-account switch: validating CLAUDE_TOKEN_${handle} is provisioned..."
+  if ! SOPS_AGE_KEY_FILE="$age_key" "$sops_bin" -d --extract '["claude-accounts.env"]' "$secrets_file" 2>/dev/null \
+      | grep -q "^CLAUDE_TOKEN_${handle}="; then
+    fail "CLAUDE_TOKEN_${handle} not found in claude-accounts.env — is '${handle}' a provisioned account?"
+  fi
+
+  local old_handle; old_handle="$(_ca_current_active_handle)" \
+    || fail "could not determine the currently active account from $(_ca_accounts_env_file) — refusing to guess which selector line to flip"
+
+  if [[ "$old_handle" == "$handle" ]]; then
+    log "claude-account switch: ${handle} is already the active account — nothing to do"
+    return 0
+  fi
+
+  log "claude-account switch: probing ${handle}'s token auth before switching..."
+  _ca_probe_handle_ok "$handle" \
+    || fail "${handle} does not report ok rate-limit headers (401/expired/etc) — refusing to switch to a broken account"
+
+  _ca_confirm "Switch fleet active Claude account ${old_handle} -> ${handle}?" "$assume_yes" || fail "aborted"
+
+  log "claude-account switch: flipping selector ${old_handle} -> ${handle} in ${secrets_file}..."
+  local editor_script; editor_script="$(mktemp)"
+  trap 'rm -f "$editor_script"' EXIT
+  {
+    echo "#!/usr/bin/env bash"
+    echo "set -euo pipefail"
+    printf 'sed -E -i.bak -e %q -- "$1"\n' "$(_ca_sed_program "$old_handle" "$handle")"
+    echo 'rm -f "$1.bak"'
+  } > "$editor_script"
+  chmod +x "$editor_script"
+
+  local edit_out edit_rc
+  edit_out="$(SOPS_AGE_KEY_FILE="$age_key" EDITOR="$editor_script" "$sops_bin" edit "$secrets_file" 2>&1)"
+  edit_rc=$?
+  rm -f "$editor_script"
+  trap - EXIT
+  if printf '%s' "$edit_out" | grep -qi "has not changed"; then
+    fail "sops reported no change — the selector pattern for ${old_handle} did not match in ${secrets_file} (schema drift?): ${edit_out}"
+  fi
+  if [[ $edit_rc -ne 0 ]]; then
+    fail "sops edit failed: ${edit_out}"
+  fi
+  log "  → ${edit_out:-selector flipped}"
+
+  log "claude-account switch: committing + pushing ${cluster_dir}..."
+  (
+    cd "$cluster_dir" || exit 1
+    git add secrets/node-secret-files.sops.json || exit 1
+    # Pathspec'd so this commits ONLY the sops file, never whatever else happens to
+    # be staged in the index (defense in depth alongside the pre-edit dirty guard
+    # above).
+    git commit -qm "chore(secrets): switch active Claude account ${old_handle} -> ${handle}" \
+      -- secrets/node-secret-files.sops.json || exit 1
+    if ! git push; then
+      # Push rejected (e.g. another node pushed first). The flip is already
+      # committed locally — roll it back so the clone matches origin again and a
+      # retried `switch` starts clean instead of wedging behind a stale local
+      # commit (a retry would otherwise re-flip an already-flipped file, sops
+      # would report "no change", and the command would hard-fail with a
+      # misleading "schema drift?" message with no way out).
+      git reset --hard HEAD~1 >/dev/null 2>&1
+      exit 1
+    fi
+  ) || fail "cluster repo commit/push failed in ${cluster_dir} — local commit rolled back (clone matches origin again); retry switch"
+
+  log "claude-account switch: re-materializing local claude-accounts.env..."
+  local dest; dest="$(_ca_accounts_env_file)"
+  mkdir -p "$(dirname "$dest")"
+  ( umask 077; SOPS_AGE_KEY_FILE="$age_key" "$sops_bin" -d --extract '["claude-accounts.env"]' "$secrets_file" > "$dest" ) \
+    || fail "sops decrypt of claude-accounts.env failed"
+  chmod 600 "$dest"
+
+  log "claude-account switch: restarting stack..."
+  if [[ "$assume_yes" == "yes" ]]; then cmd_restart --yes; else cmd_restart; fi
+
+  _ca_verify_active "$handle" || fail "claude-account switch: post-switch verification failed"
+}
+
+cmd_claude_account_sync() {
+  local assume_yes="${ASSUME_YES:-no}"
+  for a in "$@"; do
+    case "$a" in
+      --yes) assume_yes="yes" ;;
+      *) fail "unknown claude-account sync arg: $a" ;;
+    esac
+  done
+
+  local age_key; age_key="$(_ca_age_key_file)"
+  [[ -f "$age_key" ]] || fail "no age key at ${age_key} — this node cannot decrypt cluster secrets"
+
+  local cluster_dir; cluster_dir="$(_ca_cluster_repo_dir)"
+  [[ -d "${cluster_dir}/.git" ]] || fail "no cluster repo clone at ${cluster_dir}"
+
+  local sops_bin; sops_bin="$(_ca_resolve_sops)" || fail "sops binary not found (checked known install dirs + PATH)"
+
+  local secrets_file; secrets_file="$(_ca_secrets_file)"
+
+  _ca_confirm "Pull cluster secrets + restart the stack on this node?" "$assume_yes" || fail "aborted"
+
+  log "claude-account sync: pulling ${cluster_dir}..."
+  ( cd "$cluster_dir" && git pull --ff-only ) || fail "git pull --ff-only failed in ${cluster_dir}"
+
+  [[ -f "$secrets_file" ]] || fail "missing ${secrets_file} after pull"
+
+  log "claude-account sync: re-materializing local claude-accounts.env..."
+  local dest; dest="$(_ca_accounts_env_file)"
+  mkdir -p "$(dirname "$dest")"
+  ( umask 077; SOPS_AGE_KEY_FILE="$age_key" "$sops_bin" -d --extract '["claude-accounts.env"]' "$secrets_file" > "$dest" ) \
+    || fail "sops decrypt of claude-accounts.env failed"
+  chmod 600 "$dest"
+
+  local handle; handle="$(_ca_current_active_handle "$dest")" \
+    || fail "could not determine the active account after sync"
+
+  log "claude-account sync: restarting stack..."
+  if [[ "$assume_yes" == "yes" ]]; then cmd_restart --yes; else cmd_restart; fi
+
+  _ca_verify_active "$handle" || fail "claude-account sync: post-sync verification failed"
+}
+
+cmd_claude_account() {
+  local sub="${1:-}"
+  [[ $# -gt 0 ]] && shift
+  case "$sub" in
+    status) cmd_claude_account_status "$@" ;;
+    switch) cmd_claude_account_switch "$@" ;;
+    sync)   cmd_claude_account_sync "$@" ;;
+    *) fail "usage: catalyst-stack claude-account status | switch <handle> [--yes] | sync [--yes]" ;;
+  esac
+}
+
 # ─── Dispatch ───────────────────────────────────────────────────────────────
 # Guard so the file can be sourced (e.g. by __tests__/verify-updater.test.sh) to
 # reach the pure helpers WITHOUT running a command. When executed directly,
@@ -2806,10 +3170,11 @@ case "${1:-}" in
   verify-node)        shift; cmd_verify_node "$@" ;;
   services-status)    shift; cmd_services_status ;;
   sync-cloud-env)     shift; cmd_sync_cloud_env "$@" ;;
+  claude-account)     shift; cmd_claude_account "$@" ;;
   status|"") cmd_status ;;
   -h|--help)
     sed -n '2,/^$/p' "$0" | sed 's/^# \{0,1\}//'
     ;;
-  *) fail "unknown command: $1 (try: start | stop | restart | status | hotpatch | parity | install-services | uninstall-services | adopt-updater | adopt-cloud-sync | verify-updater | verify-node | services-status)" ;;
+  *) fail "unknown command: $1 (try: start | stop | restart | status | hotpatch | parity | install-services | uninstall-services | adopt-updater | adopt-cloud-sync | verify-updater | verify-node | services-status | claude-account)" ;;
 esac
 fi

--- a/plugins/dev/scripts/claude-accounts-usage.mjs
+++ b/plugins/dev/scripts/claude-accounts-usage.mjs
@@ -284,11 +284,13 @@ async function main() {
   const { accounts, missing } = parseAccountsEnv(envPath);
 
   if (missing) {
-    console.error(`No accounts file at ${envPath} (set CLAUDE_ACCOUNTS_ENV to override).`);
+    // CodeQL clear-text-logging guard: envPath derives from process.env, so it never
+    // reaches a log line — the operator knows which path they configured.
+    console.error("No accounts file found (default ~/.config/catalyst/claude-accounts.env; set CLAUDE_ACCOUNTS_ENV to override).");
     process.exit(1);
   }
   if (accounts.length === 0) {
-    console.error(`No CLAUDE_TOKEN_* tokens found in ${envPath}.`);
+    console.error("No CLAUDE_TOKEN_* tokens found in the accounts env file.");
     process.exit(1);
   }
 

--- a/plugins/dev/scripts/claude-accounts-usage.mjs
+++ b/plugins/dev/scripts/claude-accounts-usage.mjs
@@ -1,0 +1,319 @@
+#!/usr/bin/env node
+// claude-accounts-usage.mjs — read every durable Claude OAuth token in
+// claude-accounts.env and report, per subscription account: the email and each
+// rate-limit window's utilization + reset time + status.
+//
+// WHY THE INFERENCE PATH (not /api/oauth/usage):
+// The account usage API (GET /api/oauth/usage, /api/oauth/profile) only answers
+// to an *interactive-login* subscription token (the one `claude /login` writes to
+// the macOS Keychain / ~/.claude/.credentials.json). The DURABLE `setup-token`s
+// (sk-ant-oat…) in claude-accounts.env are inference-scoped and get a 403 there
+// (verified: same account, login token → 200, setup-token → 403). But they CAN
+// make inference calls, and every /v1/messages response carries the
+// `anthropic-ratelimit-unified-*` headers with the live 5h / 7d utilization,
+// reset epoch, and status. So this tool spends one tiny (max_tokens:1, Haiku)
+// call per account and reads its limits from the response headers — the only
+// mechanism that works for a durable token. Header utilization is a fraction of
+// 1 (0.06 → 6%); reset is unix-epoch seconds. Both calibrated against /usage.
+//
+// The account email is NOT available from a setup-token (profile 403s it), so it
+// is read from the inline comment each token line carries
+// (`CLAUDE_TOKEN_acctN='…'  # name@domain`).
+//
+// SECRETS HYGIENE (hard rule): OAuth tokens are read into local variables and
+// used as bearer credentials only. They are NEVER printed, logged, or placed in
+// any output. The active-account match compares values in memory. NEVER print a
+// token.
+//
+// Usage:
+//   node claude-accounts-usage.mjs            # human-readable table
+//   node claude-accounts-usage.mjs --json     # machine-readable JSON
+//   CLAUDE_ACCOUNTS_ENV=/path/to/file node claude-accounts-usage.mjs
+//
+// Exit code: 0 if at least one account reported limits; 1 if none could.
+
+import { execFileSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { resolve } from "node:path";
+
+const DEFAULT_ENV_PATH = resolve(homedir(), ".config", "catalyst", "claude-accounts.env");
+const MESSAGES_ENDPOINT = "https://api.anthropic.com/v1/messages";
+const OAUTH_BETA = "oauth-2025-04-20";
+const ANTHROPIC_VERSION = "2023-06-01";
+// Cheapest model + the Claude Code system-prompt prefix the OAuth path requires.
+const PROBE_MODEL = "claude-haiku-4-5-20251001";
+const PROBE_SYSTEM = "You are Claude Code, Anthropic's official CLI for Claude.";
+// Inter-account spacing — keeps a multi-account sweep clear of any shared limiter.
+const INTER_ACCOUNT_DELAY_MS = 500;
+
+const argv = process.argv.slice(2);
+const asJson = argv.includes("--json");
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+// getUserAgent — REQUIRED header; a wrong/missing UA can trigger an instant 429.
+// Built from the locally-installed claude version.
+function getUserAgent() {
+  try {
+    const out = execFileSync("claude", ["--version"], { encoding: "utf8" });
+    return `claude-code/${String(out).trim().split(/\s+/)[0] || "unknown"}`;
+  } catch {
+    return "claude-code/unknown";
+  }
+}
+
+const EMAIL_RE = /[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}/;
+
+// parseAssignment — split a `KEY=VALUE` RHS into { token, comment } exactly as a
+// POSIX shell would when sourcing the file: a quoted value runs to its matching
+// close quote; an unquoted value runs to the first whitespace; the remainder is
+// the inline comment (which carries the account email here). We do NOT evaluate
+// the file, so this mirror keeps the parsed token identical to `source`-ing it.
+function parseAssignment(rhs) {
+  const s = rhs.trimStart();
+  let token = "";
+  let rest = "";
+  if (s[0] === "'" || s[0] === '"') {
+    const q = s[0];
+    const end = s.indexOf(q, 1);
+    if (end === -1) {
+      token = s.slice(1);
+    } else {
+      token = s.slice(1, end);
+      rest = s.slice(end + 1);
+    }
+  } else {
+    const m = s.match(/^(\S+)(.*)$/);
+    token = m ? m[1] : s;
+    rest = m ? m[2] : "";
+  }
+  const comment = rest.replace(/^\s*#?\s*/, "").trim();
+  return { token: token.trim(), comment };
+}
+
+// parseAccountsEnv — extract every `CLAUDE_TOKEN_<label>=<token>` assignment.
+function parseAccountsEnv(path) {
+  let raw;
+  try {
+    raw = readFileSync(path, "utf8");
+  } catch (err) {
+    if (err?.code === "ENOENT") return { accounts: [], missing: true };
+    throw err;
+  }
+  const accounts = [];
+  const re = /^(?:export\s+)?CLAUDE_TOKEN_([A-Za-z0-9_]+)=(.*)$/;
+  for (const line of raw.split("\n")) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith("#")) continue;
+    const m = trimmed.match(re);
+    if (!m) continue;
+    const { token, comment } = parseAssignment(m[2]);
+    if (!token || token === "PASTE_TOKEN_HERE") continue;
+    accounts.push({ label: m[1], token, commentEmail: comment.match(EMAIL_RE)?.[0] ?? null });
+  }
+  return { accounts, missing: false };
+}
+
+// fetchUnifiedLimits — make one minimal inference call and read the rate-limit
+// state from the `anthropic-ratelimit-unified-*` response headers. Returns
+// { status, headers } where headers is the parsed unified block (null on a
+// non-200/non-429 failure). NEVER throws.
+async function fetchUnifiedLimits(token, userAgent, fetchImpl = fetch) {
+  const body = JSON.stringify({
+    model: PROBE_MODEL,
+    max_tokens: 1,
+    system: PROBE_SYSTEM,
+    messages: [{ role: "user", content: "hi" }],
+  });
+  let res;
+  try {
+    res = await fetchImpl(MESSAGES_ENDPOINT, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${token}`,
+        "anthropic-beta": OAUTH_BETA,
+        "anthropic-version": ANTHROPIC_VERSION,
+        "content-type": "application/json",
+        "User-Agent": userAgent,
+      },
+      body,
+    });
+  } catch {
+    return { status: 0, headers: null };
+  }
+  // Even a 429 carries the unified headers (status: rejected), so parse them
+  // whenever they are present.
+  const h = res.headers;
+  const num = (k) => {
+    const v = h.get(k);
+    return v == null || v === "" ? null : Number(v);
+  };
+  const epochToIso = (k) => {
+    const v = num(k);
+    return v == null || !Number.isFinite(v) ? null : new Date(v * 1000).toISOString();
+  };
+  const has = h.get("anthropic-ratelimit-unified-status") != null;
+  if (!has) return { status: res.status, headers: null };
+  // utilization headers are fractions of 1 → ×100 for percent (rounded to 0.1).
+  const pct = (k) => {
+    const v = num(k);
+    return v == null ? null : Math.round(v * 1000) / 10;
+  };
+  return {
+    status: res.status,
+    headers: {
+      overallStatus: h.get("anthropic-ratelimit-unified-status"),
+      representativeClaim: h.get("anthropic-ratelimit-unified-representative-claim"),
+      fiveHourPct: pct("anthropic-ratelimit-unified-5h-utilization"),
+      fiveHourResetsAt: epochToIso("anthropic-ratelimit-unified-5h-reset"),
+      fiveHourStatus: h.get("anthropic-ratelimit-unified-5h-status"),
+      sevenDayPct: pct("anthropic-ratelimit-unified-7d-utilization"),
+      sevenDayResetsAt: epochToIso("anthropic-ratelimit-unified-7d-reset"),
+      sevenDayStatus: h.get("anthropic-ratelimit-unified-7d-status"),
+    },
+  };
+}
+
+// gatherAccount — resolve one account into a plain, token-free result record.
+async function gatherAccount({ label, token, isActive, commentEmail }, userAgent) {
+  const base = {
+    label,
+    isActive: Boolean(isActive),
+    email: commentEmail ?? null,
+    overallStatus: null,
+    representativeClaim: null,
+    fiveHour: null,
+    sevenDay: null,
+    error: null,
+  };
+
+  const { status, headers } = await fetchUnifiedLimits(token, userAgent);
+  if (status === 401 || status === 403) {
+    base.error = `auth failed (${status}) — token invalid, expired, or lacks inference scope`;
+    return base;
+  }
+  if (!headers) {
+    base.error = status === 0 ? "network error" : `no rate-limit headers (HTTP ${status})`;
+    return base;
+  }
+  base.overallStatus = headers.overallStatus;
+  base.representativeClaim = headers.representativeClaim;
+  base.fiveHour =
+    headers.fiveHourPct == null
+      ? null
+      : { pct: headers.fiveHourPct, resetsAt: headers.fiveHourResetsAt, status: headers.fiveHourStatus };
+  base.sevenDay =
+    headers.sevenDayPct == null
+      ? null
+      : { pct: headers.sevenDayPct, resetsAt: headers.sevenDayResetsAt, status: headers.sevenDayStatus };
+  return base;
+}
+
+// ---- formatting helpers (human output) ----
+
+function fmtRelative(resetsAtIso, nowMs) {
+  const ms = Date.parse(resetsAtIso);
+  if (!Number.isFinite(ms)) return "?";
+  const delta = ms - nowMs;
+  if (delta <= 0) return "now";
+  const mins = Math.round(delta / 60000);
+  if (mins < 60) return `${mins}m`;
+  const h = Math.floor(mins / 60);
+  const m = mins % 60;
+  if (h < 24) return m ? `${h}h ${m}m` : `${h}h`;
+  const d = Math.floor(h / 24);
+  const rh = h % 24;
+  return rh ? `${d}d ${rh}h` : `${d}d`;
+}
+
+function fmtReset(resetsAtIso, nowMs) {
+  if (!resetsAtIso) return "—";
+  const ms = Date.parse(resetsAtIso);
+  if (!Number.isFinite(ms)) return resetsAtIso;
+  const local = new Date(ms).toLocaleString(undefined, {
+    month: "short",
+    day: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+  });
+  return `${local} (in ${fmtRelative(resetsAtIso, nowMs)})`;
+}
+
+function bar(pct, width = 20) {
+  if (pct == null) return `[${" ".repeat(width)}]  n/a`;
+  const clamped = Math.max(0, Math.min(100, pct));
+  const filled = Math.round((clamped / 100) * width);
+  const used = Math.round(clamped);
+  return `[${"█".repeat(filled)}${"░".repeat(width - filled)}]  ${String(used).padStart(3)}% used · ${Math.max(0, 100 - used)}% left`;
+}
+
+const STATUS_MARK = { allowed: "✓", allowed_warning: "⚠", rejected: "✗" };
+
+function windowLine(name, b, nowMs) {
+  if (b == null) return `    ${name.padEnd(14)} no usage`;
+  const mark = STATUS_MARK[b.status] ?? "";
+  return `    ${name.padEnd(14)} ${bar(b.pct)}  ${mark}  resets ${fmtReset(b.resetsAt, nowMs)}`;
+}
+
+function renderHuman(results, nowMs) {
+  const lines = ["", "Claude account usage", "════════════════════"];
+  for (const r of results) {
+    const who = r.email || `(unknown — env key ${r.label})`;
+    const flags = [];
+    if (r.isActive) flags.push("ACTIVE");
+    if (r.overallStatus && r.overallStatus !== "allowed") flags.push(r.overallStatus.toUpperCase());
+    const tag = flags.length ? `   ${flags.join(" · ")}` : "";
+    lines.push("", `● ${who}   [${r.label}]${tag}`);
+    if (r.error) {
+      lines.push(`    ⚠ ${r.error}`);
+      continue;
+    }
+    lines.push(windowLine("5-hour", r.fiveHour, nowMs));
+    lines.push(windowLine("7-day", r.sevenDay, nowMs));
+    if (r.representativeClaim) {
+      lines.push(`    binding window: ${r.representativeClaim === "five_hour" ? "5-hour" : r.representativeClaim === "seven_day" ? "7-day" : r.representativeClaim}`);
+    }
+  }
+  lines.push("");
+  return lines.join("\n");
+}
+
+async function main() {
+  const envPath = process.env.CLAUDE_ACCOUNTS_ENV || DEFAULT_ENV_PATH;
+  const { accounts, missing } = parseAccountsEnv(envPath);
+
+  if (missing) {
+    console.error(`No accounts file at ${envPath} (set CLAUDE_ACCOUNTS_ENV to override).`);
+    process.exit(1);
+  }
+  if (accounts.length === 0) {
+    console.error(`No CLAUDE_TOKEN_* tokens found in ${envPath}.`);
+    process.exit(1);
+  }
+
+  // Mark the active account by value-matching the live env override (never printed).
+  const activeToken = process.env.CLAUDE_CODE_OAUTH_TOKEN || null;
+  for (const a of accounts) a.isActive = activeToken != null && a.token === activeToken;
+
+  const userAgent = getUserAgent();
+  const results = [];
+  for (let i = 0; i < accounts.length; i++) {
+    if (i > 0) await sleep(INTER_ACCOUNT_DELAY_MS);
+    results.push(await gatherAccount(accounts[i], userAgent));
+  }
+
+  const nowMs = Date.now();
+  if (asJson) {
+    console.log(JSON.stringify({ generatedAt: new Date(nowMs).toISOString(), accounts: results }, null, 2));
+  } else {
+    console.log(renderHuman(results, nowMs));
+  }
+
+  process.exit(results.some((r) => r.fiveHour || r.sevenDay) ? 0 : 1);
+}
+
+main().catch((err) => {
+  console.error(`claude-accounts-usage: ${err?.message ?? err}`);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

Closes CTL-1650. Born from today's incident: the fleet's active Claude SDK account exhausted its 7-day usage window, every SDK dispatch failed as `sdk-overloaded-exhausted`, and recovering took a five-step manual SOPS procedure. This PR makes both halves one command.

- **`plugins/dev/scripts/claude-accounts-usage.mjs`** committed as a first-class tool: per-account 5-hour/7-day utilization, reset times, and ACTIVE flag — via one `max_tokens:1` probe per account reading the `anthropic-ratelimit-unified-*` response headers (`/api/oauth/usage` 403s for durable setup-tokens; headers are the only mechanism that works). Never prints a token.
- **`catalyst-stack claude-account`**:
  - `status` — the usage report, exit-code honest.
  - `switch <handle> [--yes]` — validated handle → sops-membership check (grep -q, values never printed) → pre-switch auth probe (refuses a 401 account) → non-interactive SOPS selector flip (scripted `$EDITOR`, JSON-escape-aware sed, "File has not changed" = failure) → scoped commit + push → local re-materialize (umask 077, 0600) → stack restart → verification that the new account is ACTIVE **and error-free**.
  - `sync [--yes]` — second-node adoption of an already-pushed switch (pull --ff-only, re-materialize, restart, verify).

## Hardening from the adversarial verify round (all applied)

- Dirty-worktree guard + pathspec'd commit — a bystander's staged change in the cluster clone can never be swept into the pushed secrets commit (was CONFIRMED reproducible pre-fix).
- Pre-edit `git pull --ff-only` + push-failure unwind (`reset --hard HEAD~1`) — a rejected push leaves the clone clean and the retry works, instead of wedging behind a misleading "schema drift" error.
- `_ca_verify_active` checks the account's `.error` field — "ACTIVE but 401" can no longer verify green.
- sed `g` flag (decoy-comment occurrences), umask-guarded decrypt redirects, EXIT-trap cleanup of the temp editor script, strict arg validation.

## Testing

- New `__tests__/catalyst-stack-claude-account.test.sh`: 36/36 — sources the real script, exercises the real helpers (handle validation, sops resolution order, the flip transform against a JSON-escaped fixture including the real `sops edit` temp-file shape, guard failures).
- `catalyst-stack-parity.test.sh` 9/9; full `catalyst-stack.test.sh` 63/67 (4 failures reproduced identically on baseline — pre-existing rsync/hotpatch flakes, unrelated).
- `bash -n` OK; `shellcheck --severity=warning -x` clean; `node --check` on the usage tool OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)