### PR TITLE
feat(dev): CTL-1641 — wire unstuck-sweep escalation to reach the operator

### DIFF
--- a/.github/workflows/execution-core-tests.yml
+++ b/.github/workflows/execution-core-tests.yml
@@ -582,6 +582,8 @@ jobs:
             triage-redispatch-guard.test.mjs \
             recovery-evidence.test.mjs \
             unstuck-act-seams.test.mjs \
+            unstuck-escalate-seam.test.mjs \
+            unstuck-sweep.test.mjs \
             lib/catalyst-resource.test.mjs \
             lib/node-class-parity.test.mjs \
             lib/install-telemetry.test.mjs \

--- a/plugins/dev/scripts/execution-core/label-guard.mjs
+++ b/plugins/dev/scripts/execution-core/label-guard.mjs
@@ -496,6 +496,7 @@ export function beliefOwnsNeedsHuman(env = process.env) {
 //     log         : { info, warn }        (the module's log instance)
 //     explanation : object | undefined    (CTL-1609 Gap 2 — structured escalation
 //                   explanation; coerced via coerceExplanation if partial/absent)
+//     onOutcome   : ({deferred,applied,ran,reason}) => void  (optional, CTL-1641)
 //   }
 //
 // CTL-764 finding 8 + finding C: returns whether the needs-human label was CONFIRMED
@@ -505,16 +506,34 @@ export function beliefOwnsNeedsHuman(env = process.env) {
 // `true` ONLY when applyLabel reported applied:true. Callers gate their worker.transition
 // emission on this so neither a no-op re-application nor a failed attempt records a fresh
 // escalation. Existing callers ignore the return, so this stays backward-compatible.
+//
+// CTL-1641 (Codex #3005 P2): the boolean return CONFLATES three `false` cases —
+// belief-owner deferral, a marker-guarded no-op (label already handled this lifetime),
+// and a GENUINE non-confirming write (applyLabel ran but returned applied:false). A
+// caller that must count a failed escalation (unstuck-escalate-seam) cannot tell them
+// apart from the boolean alone. The optional `onOutcome` callback reports the richer
+// signal WITHOUT changing the return type: `deferred` (belief owner), `ran` (applyLabel
+// actually executed — false on a marker no-op), `applied`, and `reason`. A genuine
+// failure is exactly `!deferred && ran && !applied`.
 export function labelNeedsHumanUnlessBeliefOwner(
   orchDir,
   ticket,
   writeStatus,
-  { env = process.env, site = "unknown", log: logArg = null, explanation = undefined } = {}
+  {
+    env = process.env,
+    site = "unknown",
+    log: logArg = null,
+    explanation = undefined,
+    onOutcome = null,
+  } = {}
 ) {
   if (beliefOwnsNeedsHuman(env)) {
     // Defer to executeEscalations — R12 belief owner. Record, do not page.
     const logger = logArg ?? log;
     logger.info({ ticket, site }, "needs-human deferred to belief owner (CTL-1241)");
+    if (typeof onOutcome === "function") {
+      onOutcome({ deferred: true, applied: false, ran: false, reason: null });
+    }
     return false;
   }
   // Enforcement OFF (default): call labelOnce exactly as before. CTL-764 finding C:
@@ -523,9 +542,13 @@ export function labelNeedsHumanUnlessBeliefOwner(
   // landed). Capture applyLabel's applied result via onApplyResult; a marker-guarded no-op
   // (labelOnce early-returns, onApplyResult never fires) correctly stays false.
   let applied = false;
+  let ran = false;
+  let reason = null;
   labelOnce(orchDir, ticket, "needs-human", writeStatus, {
     onApplyResult: (r) => {
+      ran = true;
       applied = r.applied === true;
+      reason = r.reason ?? null;
     },
   });
   // CTL-1609 Gap 2: on a confirmed apply, coerce the explanation and persist it to
@@ -545,6 +568,9 @@ export function labelNeedsHumanUnlessBeliefOwner(
     }
     const coerced = coerceExplanation(explanation ?? {}, { ticket, canExecute: false });
     writeExplanationSignal(orchDir, ticket, coerced, { log: logArg });
+  }
+  if (typeof onOutcome === "function") {
+    onOutcome({ deferred: false, applied, ran, reason });
   }
   return applied;
 }

--- a/plugins/dev/scripts/execution-core/scheduler.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.mjs
@@ -302,6 +302,10 @@ import {
 // to production deps at the unstuckSweep wiring point below. Wiring this does NOT
 // flip enforce on — the mode gate stays at its safe 'off' default (ADR-023).
 import { buildUnstuckActSeams } from "./unstuck-act-seams.mjs";
+// CTL-1641: the production escalate seam (needs-human label + authored Linear
+// comment). Wired into the runTick unstuckSweep literal; fires ONLY in enforce
+// mode on candidates the escalate branch reaches. Does NOT flip enforce on.
+import { buildUnstuckEscalateSeam } from "./unstuck-escalate-seam.mjs";
 import {
   readUnstuckSweepConfig,
   readRecoveryPassConfig,
@@ -4895,7 +4899,8 @@ export function schedulerTick(
           ureport.acted.length ||
           ureport.wouldAct.length ||
           ureport.escalated.length ||
-          ureport.wouldEscalate.length
+          ureport.wouldEscalate.length ||
+          ureport.escalateFailures.length          // CTL-1641
         ) {
           log.info(
             {
@@ -4904,6 +4909,7 @@ export function schedulerTick(
               wouldAct: ureport.wouldAct.length,
               escalated: ureport.escalated.length,
               wouldEscalate: ureport.wouldEscalate.length,
+              escalateFailures: ureport.escalateFailures.length,   // CTL-1641
               skipped: ureport.skipped.length,
               failed: ureport.failed.length,
             },
@@ -8130,6 +8136,39 @@ function runTick() {
             },
             // runGit / fs primitives / emitPhaseComplete fall back to real defaults
             // inside unstuck-act-seams.mjs (git, node:fs, phase-agent-emit-complete).
+          }),
+        // CTL-1641: wire the production escalate seam. Fires ONLY on the enforce
+        // branch (the driver calls escalate solely when decision.action === "escalate");
+        // the mode gate (readUnstuckSweepConfig, default 'off') is UNTOUCHED, so
+        // production stays inert until an operator opts in. Operators can override via
+        // runningOpts.unstuckEscalate. The census is already HRW-gated by
+        // ownsForRecovery at the schedulerTick call site, so no second fenceGuard here.
+        escalate:
+          runningOpts.unstuckEscalate ??
+          buildUnstuckEscalateSeam({
+            orchDir: runningOpts.orchDir,
+            writeStatus: runningOpts.writeStatus ?? linearWrite,
+            env: process.env,
+            resolveWorktreePath: (ticket) => {
+              for (const sig of readWorkerSignals(runningOpts.orchDir)) {
+                if (sig.ticket === ticket && sig.worktreePath) return sig.worktreePath;
+              }
+              return null;
+            },
+            queryPR: (ticket) => {
+              const adapter = runningOpts.prAdapter;
+              if (!adapter || typeof adapter.prView !== "function") return null;
+              let pr = null;
+              for (const sig of readWorkerSignals(runningOpts.orchDir)) {
+                if (sig.ticket === ticket) { pr = sig.raw?.pr ?? sig.pr ?? null; if (pr?.number) break; }
+              }
+              if (!pr?.number) return null;
+              try {
+                const view = adapter.prView(ticket, pr);
+                if (view && (view.state === "MERGED" || view.mergedAt != null)) return "MERGED";
+                return view?.state ?? null;
+              } catch { return null; }
+            },
           }),
         // emit: the dedicated unstuck unified-log emitter (NOT emitReapIntent,
         // whose closed vocabulary throws on unstuck.* — CTL-1064). Explicit here

--- a/plugins/dev/scripts/execution-core/scheduler.test.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.test.mjs
@@ -10680,6 +10680,32 @@ describe("CTL-1191 — recovery passes HRW-gated over the surviving roster (Pass
     // covered exactly once — mac-studio handles CTL-B.
     expect(escalate.tickets).toEqual([T_STUDIO]);
   });
+
+  test("Pass 0u enforce: escalate seam returning errors[] is surfaced, not swallowed (CTL-1641)", () => {
+    writeFileSync(join(orchDir, "state.json"), JSON.stringify({ maxParallel: 1 }));
+    const escalateWithError = () => ({
+      labelApplied: true,
+      commentPosted: false,
+      errors: [{ sideEffect: "comment", err: "boom" }],
+    });
+    const res = schedulerTick(orchDir, {
+      readEligible: () => [],
+      dispatch: fakeDispatch({ code: 0 }),
+      hosts: ["solo"],
+      hostName: "solo",
+      verifyDispatched: verifyOk,
+      liveBackgroundCount: () => 0,
+      now: () => 9_000_000,
+      unstuckSweep: {
+        ...unstuckOpts(escalateWithError),
+        collectCandidates: () => [
+          { ticket: T_MINI, phase: "pr", evidence: { reason: "unknown", ticket: T_MINI, phase: "pr" } },
+        ],
+      },
+    });
+    // Tick must not throw; the ticket is still recorded as escalated (label landed)
+    expect(res.unstuckEscalated?.some(e => e.ticket === T_MINI)).toBe(true);
+  });
 });
 
 // ── CTL-1191: Pass 0r reasoning — terminal-state filter (PR #2163 verify flag) ──

--- a/plugins/dev/scripts/execution-core/unstuck-escalate-seam.mjs
+++ b/plugins/dev/scripts/execution-core/unstuck-escalate-seam.mjs
@@ -14,7 +14,7 @@
 import { spawnSync } from "node:child_process";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
-import { readFileSync } from "node:fs";
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
 import { log as defaultLog } from "./config.mjs";
 import { authorEscalationComment } from "./unstuck-sweep-escalation.mjs";
 import { captureDeepDiveEvidence } from "./unstuck-sweep-evidence.mjs";
@@ -33,6 +33,25 @@ function defaultReadSignal(orchDir, ticket, phase) {
   } catch {
     return null;
   }
+}
+
+// escalateCommentMarkerPath — CTL-1641 (Codex #3005 P2): per-(ticket,category,phase)
+// idempotency marker for the authored escalation COMMENT. The needs-human LABEL is
+// already once-guarded (labelOnce's .linear-label-needs-human marker), and the escalate
+// branch deliberately has no intent gate, so without this a candidate that stays stuck
+// (unknown / remediate-cap — cleared only by a human) would receive a fresh Linear
+// comment on EVERY sweep interval. Mirrors the sibling act-path marker in
+// unstuck-sweep.mjs:defaultPostUnstuckComment (.unstuck-comment-<cat>-<phase>.applied);
+// a distinct prefix keeps the two paths' markers from colliding. Returns null when the
+// path can't be formed (fail-open → post unconditionally, as before).
+function escalateCommentMarkerPath(orchDir, ticket, category, phase) {
+  if (!orchDir || !ticket || !phase) return null;
+  return join(
+    orchDir,
+    "workers",
+    ticket,
+    `.unstuck-escalate-comment-${category ?? "unknown"}-${phase}.applied`
+  );
 }
 
 // makeDefaultCommitsAhead — computes commits ahead of origin/main for a worktree.
@@ -93,10 +112,31 @@ export function buildUnstuckEscalateSeam(deps = {}) {
 
   const _commitsAhead = commitsAhead ?? makeDefaultCommitsAhead(runGit);
 
-  const _applyLabel = applyNeedsHuman ?? ((ticket) =>
+  // CTL-1641 (Codex #3005 P2): the DEFAULT label binding returns a structured
+  // { applied, error? } so escalate() can surface a GENUINE non-confirming write
+  // (applyLabel ran but did not land — rate-limited / verify-failed / missing-label)
+  // as a `label` side-effect error, while leaving benign belief-owner deferral and
+  // an already-applied marker no-op error-free. onOutcome carries the distinction
+  // that labelNeedsHumanUnlessBeliefOwner's boolean return erases. An INJECTED
+  // applyNeedsHuman still returns a bare boolean (a stub can't distinguish, so its
+  // `false` stays benign — see the belief-owner test) and escalate() handles both.
+  const _applyLabel = applyNeedsHuman ?? ((ticket) => {
+    let outcome = { deferred: false, applied: false, ran: false, reason: null };
     labelNeedsHumanUnlessBeliefOwner(orchDir, ticket, writeStatus, {
       env, site: "unstuck-escalate", log,
-    }));
+      onOutcome: (o) => { outcome = o; },
+    });
+    if (outcome.applied) return { applied: true };
+    // Attempted (applyLabel ran) but did not confirm, and not a belief-owner deferral →
+    // a real failed escalation surface. A marker no-op (ran:false) or deferral is benign.
+    if (!outcome.deferred && outcome.ran) {
+      return {
+        applied: false,
+        error: `needs-human label write did not confirm (reason: ${outcome.reason ?? "unknown"})`,
+      };
+    }
+    return { applied: false };
+  });
 
   const commentHelper = env.CATALYST_COMMENT_POST_HELPER ?? COMMENT_HELPER_DEFAULT;
   const _post = postComment ?? ((ticket, body) => {
@@ -107,6 +147,7 @@ export function buildUnstuckEscalateSeam(deps = {}) {
   return function escalate(candidate, decision) {
     const ticket = candidate?.ticket;
     const phase = candidate?.phase;
+    const category = decision?.category ?? candidate?.evidence?.reason ?? "unknown";
     const reason = candidate?.evidence?.reason ?? decision?.category;
     const errors = [];
 
@@ -125,20 +166,57 @@ export function buildUnstuckEscalateSeam(deps = {}) {
     const body = authorEscalationComment(evidence);
 
     // 2. Label FIRST — the operator's needs-attention surface. Independent of the comment.
+    //    The label seam may return either a bare boolean (injected stub) or a structured
+    //    { applied, error? } (the default binding). CTL-1641 (Codex #3005 P2): a genuine
+    //    non-confirming write surfaces via `error` so the sweep's escalateFailures counts
+    //    it, while benign deferral / already-applied no-ops stay error-free.
     let labelApplied = false;
     try {
-      labelApplied = Boolean(_applyLabel(ticket));
+      const lr = _applyLabel(ticket);
+      if (lr && typeof lr === "object") {
+        labelApplied = lr.applied === true;
+        if (lr.error) errors.push({ sideEffect: "label", err: lr.error });
+      } else {
+        labelApplied = Boolean(lr);
+      }
     } catch (err) {
       errors.push({ sideEffect: "label", err: err?.message ?? String(err) });
     }
 
-    // 3. Comment SECOND — independent; a failure never unwinds the label.
+    // 3. Comment SECOND — independent; a failure never unwinds the label. CTL-1641
+    //    (Codex #3005 P2): idempotent per (ticket, category, phase). Once a comment has
+    //    posted for this stall, a later sweep on the still-stuck candidate must NOT
+    //    re-post (the label is already once-guarded; the escalate branch has no intent
+    //    gate). A pre-existing marker means "already delivered" → satisfied, not a re-post
+    //    and not an error. The marker is written only after a CONFIRMED post; the worker
+    //    dir must already exist (a real candidate's always does — fail-open otherwise).
+    const commentMarker = escalateCommentMarkerPath(orchDir, ticket, category, phase);
+    const workerDir = orchDir && ticket ? join(orchDir, "workers", ticket) : null;
+    const markerGuardActive = Boolean(commentMarker && workerDir && existsSync(workerDir));
+
     let commentPosted = false;
-    try {
-      commentPosted = Boolean(_post(ticket, body));
-      if (!commentPosted) errors.push({ sideEffect: "comment", err: "post returned falsy" });
-    } catch (err) {
-      errors.push({ sideEffect: "comment", err: err?.message ?? String(err) });
+    if (markerGuardActive && existsSync(commentMarker)) {
+      commentPosted = true; // already delivered this lifetime — no duplicate, no error
+    } else {
+      try {
+        commentPosted = Boolean(_post(ticket, body));
+        if (commentPosted) {
+          if (markerGuardActive) {
+            try {
+              writeFileSync(commentMarker, "");
+            } catch (err) {
+              log.warn(
+                { ticket, err: err?.message },
+                "unstuck-escalate: comment idempotency marker write failed — continuing (CTL-1641)"
+              );
+            }
+          }
+        } else {
+          errors.push({ sideEffect: "comment", err: "post returned falsy" });
+        }
+      } catch (err) {
+        errors.push({ sideEffect: "comment", err: err?.message ?? String(err) });
+      }
     }
 
     return { ticket, phase, labelApplied, commentPosted, errors };

--- a/plugins/dev/scripts/execution-core/unstuck-escalate-seam.mjs
+++ b/plugins/dev/scripts/execution-core/unstuck-escalate-seam.mjs
@@ -13,6 +13,7 @@
 
 import { spawnSync } from "node:child_process";
 import { join } from "node:path";
+import { fileURLToPath } from "node:url";
 import { readFileSync } from "node:fs";
 import { log as defaultLog } from "./config.mjs";
 import { authorEscalationComment } from "./unstuck-sweep-escalation.mjs";
@@ -45,6 +46,21 @@ function makeDefaultCommitsAhead(runGit) {
     return Number.isFinite(n) ? n : null;
   };
 }
+
+// COMMENT_HELPER_DEFAULT — the app-actor Linear comment helper, resolved
+// location-independently the way the sibling daemon modules do
+// (recovery-emit.mjs:101-103, recovery-reasoning.mjs:61, recovery.mjs:665). The
+// execution-core daemon that runs this seam never exports PLUGIN_ROOT and its
+// cwd is the repo root (daemon.mjs), so the old `process.env.PLUGIN_ROOT ??
+// process.cwd()` + "scripts/lib/..." resolution silently missed and the
+// authored escalation comment never posted (CTL-1641 verify HIGH). From
+// execution-core/ this URL resolves to plugins/dev/scripts/lib/linear-comment-post.sh
+// regardless of cwd/env. The static URL resolution is import-time; the
+// CATALYST_COMMENT_POST_HELPER override is read per-build from the factory's
+// `env` (below) so it can't be frozen to the wrong value at import.
+const COMMENT_HELPER_DEFAULT = fileURLToPath(
+  new URL("../lib/linear-comment-post.sh", import.meta.url)
+);
 
 export function buildUnstuckEscalateSeam(deps = {}) {
   const {
@@ -82,12 +98,9 @@ export function buildUnstuckEscalateSeam(deps = {}) {
       env, site: "unstuck-escalate", log,
     }));
 
+  const commentHelper = env.CATALYST_COMMENT_POST_HELPER ?? COMMENT_HELPER_DEFAULT;
   const _post = postComment ?? ((ticket, body) => {
-    const helperPath = join(
-      process.env.PLUGIN_ROOT ?? process.cwd(),
-      "scripts/lib/linear-comment-post.sh"
-    );
-    const r = spawnSync(helperPath, [ticket, body], { encoding: "utf8", timeout: 10_000 });
+    const r = spawnSync(commentHelper, [ticket, body], { encoding: "utf8", timeout: 10_000 });
     return Boolean(r && r.status === 0);
   });
 

--- a/plugins/dev/scripts/execution-core/unstuck-escalate-seam.mjs
+++ b/plugins/dev/scripts/execution-core/unstuck-escalate-seam.mjs
@@ -1,0 +1,133 @@
+// unstuck-escalate-seam.mjs — CTL-1641 production escalate seam for the
+// unstuck-sweep Pass 0u driver (unstuck-sweep.mjs:runUnstuckSweepPass).
+//
+// The escalate branch fires only in mode:'enforce' on candidates whose stall
+// reason maps to no mechanical fix (remediate-cap / unknown / empty-branch).
+// This seam turns that decision into operator-visible state: it applies the
+// needs-human label FIRST (the operator's needs-attention surface), then posts
+// an authored Linear comment SECOND. The two side effects are independent — a
+// comment failure never blocks the label — and each failure is returned in
+// `errors[]` so the driver can report it (never swallow it). Pure-cored: every
+// IO is an injected dep with a real default. Enforce is an operator decision
+// per ADR-023; wiring this seam does NOT flip the mode gate.
+
+import { spawnSync } from "node:child_process";
+import { join } from "node:path";
+import { readFileSync } from "node:fs";
+import { log as defaultLog } from "./config.mjs";
+import { authorEscalationComment } from "./unstuck-sweep-escalation.mjs";
+import { captureDeepDiveEvidence } from "./unstuck-sweep-evidence.mjs";
+import { labelNeedsHumanUnlessBeliefOwner } from "./label-guard.mjs";
+
+function defaultRunGit(args) {
+  return spawnSync("git", args, { encoding: "utf8" });
+}
+
+// defaultReadSignal — read workers/<ticket>/phase-<phase>.json, return null on error.
+function defaultReadSignal(orchDir, ticket, phase) {
+  if (!orchDir || !ticket || !phase) return null;
+  try {
+    const p = join(orchDir, "workers", ticket, `phase-${phase}.json`);
+    return JSON.parse(readFileSync(p, "utf8"));
+  } catch {
+    return null;
+  }
+}
+
+// makeDefaultCommitsAhead — computes commits ahead of origin/main for a worktree.
+// Returns null on any error (authorEscalationComment treats null → reason-based dispatch).
+function makeDefaultCommitsAhead(runGit) {
+  return (worktreePath) => {
+    if (!worktreePath) return null;
+    const res = runGit(["-C", worktreePath, "rev-list", "--count", "origin/main..HEAD"]);
+    if (res?.error || (res?.status ?? 1) !== 0) return null;
+    const n = parseInt(String(res.stdout ?? "").trim(), 10);
+    return Number.isFinite(n) ? n : null;
+  };
+}
+
+export function buildUnstuckEscalateSeam(deps = {}) {
+  const {
+    orchDir,
+    writeStatus,                     // { applyLabel, removeLabel } — for the label primitive
+    env = process.env,
+    log = defaultLog,
+    runGit = defaultRunGit,
+    resolveWorktreePath = () => null,
+    queryPR = () => null,
+    // Seams (overridable in tests). Production binds the three below from the
+    // primitives above.
+    captureEvidence,                 // (subject) → evidence envelope
+    commitsAhead,                    // (worktreePath) → number|null
+    applyNeedsHuman,                 // (ticket) → boolean (confirmed-applied)
+    postComment,                     // (ticket, body) → truthy on success (throws/false on failure)
+  } = deps;
+
+  const _capture = captureEvidence ?? ((subject) =>
+    captureDeepDiveEvidence(subject, {
+      readSignal: (ticket, phase) => defaultReadSignal(orchDir, ticket, phase),
+      runGitPorcelain: (wt) => {
+        if (!wt) return null;
+        const r = runGit(["-C", wt, "status", "--porcelain"]);
+        return r?.error || (r?.status ?? 1) !== 0 ? null : (r.stdout ?? "");
+      },
+      queryPR,
+      listRemediateEvents: () => [],   // CTL-1641: real scanner is out of scope (stub)
+    }));
+
+  const _commitsAhead = commitsAhead ?? makeDefaultCommitsAhead(runGit);
+
+  const _applyLabel = applyNeedsHuman ?? ((ticket) =>
+    labelNeedsHumanUnlessBeliefOwner(orchDir, ticket, writeStatus, {
+      env, site: "unstuck-escalate", log,
+    }));
+
+  const _post = postComment ?? ((ticket, body) => {
+    const helperPath = join(
+      process.env.PLUGIN_ROOT ?? process.cwd(),
+      "scripts/lib/linear-comment-post.sh"
+    );
+    const r = spawnSync(helperPath, [ticket, body], { encoding: "utf8", timeout: 10_000 });
+    return Boolean(r && r.status === 0);
+  });
+
+  return function escalate(candidate, decision) {
+    const ticket = candidate?.ticket;
+    const phase = candidate?.phase;
+    const reason = candidate?.evidence?.reason ?? decision?.category;
+    const errors = [];
+
+    // 1. Evidence (best-effort — a failure degrades to a generic write-up).
+    let evidence = { ticket, phase, reason };
+    try {
+      const captured = _capture(`${ticket}/${phase}`) ?? {};
+      const worktreePath = captured?.signalJson?.worktreePath ?? resolveWorktreePath(ticket);
+      let ahead = null;
+      try { ahead = _commitsAhead(worktreePath); } catch { ahead = null; }
+      evidence = { ...captured, ticket, phase, reason, commitsAhead: ahead };
+    } catch (err) {
+      log.warn({ ticket, err: err?.message }, "unstuck-escalate: evidence capture failed — generic comment (CTL-1641)");
+    }
+
+    const body = authorEscalationComment(evidence);
+
+    // 2. Label FIRST — the operator's needs-attention surface. Independent of the comment.
+    let labelApplied = false;
+    try {
+      labelApplied = Boolean(_applyLabel(ticket));
+    } catch (err) {
+      errors.push({ sideEffect: "label", err: err?.message ?? String(err) });
+    }
+
+    // 3. Comment SECOND — independent; a failure never unwinds the label.
+    let commentPosted = false;
+    try {
+      commentPosted = Boolean(_post(ticket, body));
+      if (!commentPosted) errors.push({ sideEffect: "comment", err: "post returned falsy" });
+    } catch (err) {
+      errors.push({ sideEffect: "comment", err: err?.message ?? String(err) });
+    }
+
+    return { ticket, phase, labelApplied, commentPosted, errors };
+  };
+}

--- a/plugins/dev/scripts/execution-core/unstuck-escalate-seam.test.mjs
+++ b/plugins/dev/scripts/execution-core/unstuck-escalate-seam.test.mjs
@@ -1,0 +1,124 @@
+// unstuck-escalate-seam.test.mjs — CTL-1641 unit tests for the production
+// escalate seam factory. All IO is stubbed via deps injection; no real git/fs/Linear.
+
+import { describe, test, expect } from "bun:test";
+import { buildUnstuckEscalateSeam } from "./unstuck-escalate-seam.mjs";
+
+function candidate(reason = "unknown", ticket = "CTL-1", phase = "implement") {
+  return { ticket, phase, evidence: { reason, ticket, phase } };
+}
+
+function decision(category = "unknown") {
+  return { category, action: "escalate" };
+}
+
+describe("buildUnstuckEscalateSeam — CTL-1641", () => {
+  test("applies the label BEFORE posting the comment (label lands even when the comment throws)", () => {
+    const order = [];
+    const seam = buildUnstuckEscalateSeam({
+      orchDir: "/tmp/orch",
+      applyNeedsHuman: () => { order.push("label"); return true; },
+      postComment: () => { order.push("comment"); throw new Error("linear down"); },
+      captureEvidence: () => ({ reason: "unknown", porcelainLines: [], prState: null, remediateHistory: [] }),
+      commitsAhead: () => 3,
+    });
+    const r = seam(candidate(), decision());
+    expect(order).toEqual(["label", "comment"]);          // label first
+    expect(r.labelApplied).toBe(true);                     // label still landed
+    expect(r.commentPosted).toBe(false);
+    expect(r.errors).toEqual([{ sideEffect: "comment", err: "linear down" }]);
+  });
+
+  test("comment body is authored from evidence — empty-branch dispatch when commitsAhead===0", () => {
+    let postedBody = null;
+    const seam = buildUnstuckEscalateSeam({
+      orchDir: "/tmp/orch",
+      applyNeedsHuman: () => true,
+      postComment: (ticket, body) => { postedBody = body; return true; },
+      captureEvidence: () => ({ reason: "unknown", porcelainLines: [], prState: null, remediateHistory: [] }),
+      commitsAhead: () => 0,
+    });
+    const r = seam(candidate("unknown", "CTL-9", "implement"), decision("unknown"));
+    expect(r.commentPosted).toBe(true);
+    expect(postedBody).toContain("empty branch");
+    expect(postedBody).toContain("CTL-9");
+  });
+
+  test("remediate-cap dispatch uses the authored cap write-up", () => {
+    let body = null;
+    const seam = buildUnstuckEscalateSeam({
+      orchDir: "/tmp/orch",
+      applyNeedsHuman: () => true,
+      postComment: (t, b) => { body = b; return true; },
+      captureEvidence: () => ({ reason: "remediate-cycle-cap-exhausted", porcelainLines: [], prState: null, remediateHistory: [] }),
+      commitsAhead: () => 5,
+    });
+    seam(candidate("remediate-cycle-cap-exhausted"), decision("remediate-cap"));
+    expect(body).toContain("verify/remediate cap exhausted");
+  });
+
+  test("a failed label apply (returns false) is NOT an error (belief-owner deferral is legitimate); comment still posts", () => {
+    const seam = buildUnstuckEscalateSeam({
+      orchDir: "/tmp/orch",
+      applyNeedsHuman: () => false,          // belief-owner deferral or non-confirming apply
+      postComment: () => true,
+      captureEvidence: () => ({ reason: "unknown", porcelainLines: [], prState: null, remediateHistory: [] }),
+      commitsAhead: () => 2,
+    });
+    const r = seam(candidate(), decision());
+    expect(r.labelApplied).toBe(false);
+    expect(r.commentPosted).toBe(true);
+    expect(r.errors).toEqual([]);
+  });
+
+  test("a THROWING label apply is recorded as a 'label' side-effect error; the comment still posts", () => {
+    const seam = buildUnstuckEscalateSeam({
+      orchDir: "/tmp/orch",
+      applyNeedsHuman: () => { throw new Error("label API 429"); },
+      postComment: () => true,
+      captureEvidence: () => ({ reason: "unknown", porcelainLines: [], prState: null, remediateHistory: [] }),
+      commitsAhead: () => 1,
+    });
+    const r = seam(candidate(), decision());
+    expect(r.errors).toEqual([{ sideEffect: "label", err: "label API 429" }]);
+    expect(r.commentPosted).toBe(true);      // independence: comment still attempted
+  });
+
+  test("evidence capture failure degrades — still authors a generic comment + applies the label", () => {
+    const seam = buildUnstuckEscalateSeam({
+      orchDir: "/tmp/orch",
+      applyNeedsHuman: () => true,
+      postComment: () => true,
+      captureEvidence: () => { throw new Error("git unavailable"); },
+      commitsAhead: () => { throw new Error("no head"); },
+    });
+    const r = seam(candidate("unknown", "CTL-5", "verify"), decision("unknown"));
+    expect(r.labelApplied).toBe(true);
+    expect(r.commentPosted).toBe(true);      // generic write-up authored from ticket/phase alone
+  });
+
+  test("postComment returning falsy records a 'comment' error", () => {
+    const seam = buildUnstuckEscalateSeam({
+      orchDir: "/tmp/orch",
+      applyNeedsHuman: () => true,
+      postComment: () => false,
+      captureEvidence: () => ({ reason: "unknown", porcelainLines: [], prState: null, remediateHistory: [] }),
+      commitsAhead: () => 1,
+    });
+    const r = seam(candidate(), decision());
+    expect(r.commentPosted).toBe(false);
+    expect(r.errors.some(e => e.sideEffect === "comment")).toBe(true);
+  });
+
+  test("returns { ticket, phase, labelApplied, commentPosted, errors } on the happy path", () => {
+    const seam = buildUnstuckEscalateSeam({
+      orchDir: "/tmp/orch",
+      applyNeedsHuman: () => true,
+      postComment: () => true,
+      captureEvidence: () => ({ reason: "unknown", porcelainLines: [], prState: null, remediateHistory: [] }),
+      commitsAhead: () => 2,
+    });
+    const r = seam(candidate("unknown", "CTL-42", "verify"), decision("unknown"));
+    expect(r).toMatchObject({ ticket: "CTL-42", phase: "verify", labelApplied: true, commentPosted: true, errors: [] });
+  });
+});

--- a/plugins/dev/scripts/execution-core/unstuck-escalate-seam.test.mjs
+++ b/plugins/dev/scripts/execution-core/unstuck-escalate-seam.test.mjs
@@ -2,7 +2,7 @@
 // escalate seam factory. All IO is stubbed via deps injection; no real git/fs/Linear.
 
 import { describe, test, expect } from "bun:test";
-import { existsSync, mkdtempSync, writeFileSync, chmodSync, readFileSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, writeFileSync, chmodSync, readFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -124,6 +124,98 @@ describe("buildUnstuckEscalateSeam — CTL-1641", () => {
     });
     const r = seam(candidate("unknown", "CTL-42", "verify"), decision("unknown"));
     expect(r).toMatchObject({ ticket: "CTL-42", phase: "verify", labelApplied: true, commentPosted: true, errors: [] });
+  });
+});
+
+// CTL-1641 Codex #3005 P2 remediation — the two masking cases the injected-stub tests
+// above cannot reach: (1) a genuine non-confirming LABEL write must surface a `label`
+// error (not be swallowed as benign like a belief-owner deferral), and (2) the escalation
+// COMMENT must be idempotent per (ticket,category,phase) so a still-stuck candidate is not
+// re-commented on every sweep. Both exercise the DEFAULT bindings against a real temp
+// orchDir so the marker files and the labelOnce/onOutcome path actually run.
+describe("buildUnstuckEscalateSeam — CTL-1641 Codex #3005 P2 remediation", () => {
+  test("a genuine non-confirming label write (applyLabel ran, applied:false) surfaces a 'label' error", () => {
+    const dir = mkdtempSync(join(tmpdir(), "ctl1641-labelfail-"));
+    mkdirSync(join(dir, "workers", "CTL-1"), { recursive: true });
+    const seam = buildUnstuckEscalateSeam({
+      orchDir: dir,
+      env: {},                                                     // not belief-owner → real labelOnce path
+      writeStatus: { applyLabel: () => ({ applied: false, reason: "rate-limited" }) },
+      // applyNeedsHuman intentionally NOT injected — exercise the default structured binding.
+      postComment: () => true,
+      captureEvidence: () => ({ reason: "unknown", porcelainLines: [], prState: null, remediateHistory: [] }),
+      commitsAhead: () => 2,
+    });
+    const r = seam(candidate("unknown", "CTL-1", "verify"), decision("unknown"));
+    expect(r.labelApplied).toBe(false);
+    expect(r.errors.some((e) => e.sideEffect === "label")).toBe(true);
+    expect(r.commentPosted).toBe(true);                            // independence: the comment still posts
+  });
+
+  test("an already-applied needs-human marker (labelOnce no-op) is NOT a label error", () => {
+    const dir = mkdtempSync(join(tmpdir(), "ctl1641-labelnoop-"));
+    const wdir = join(dir, "workers", "CTL-2");
+    mkdirSync(wdir, { recursive: true });
+    writeFileSync(join(wdir, ".linear-label-needs-human.applied"), "");  // a prior lifetime already landed it
+    const seam = buildUnstuckEscalateSeam({
+      orchDir: dir,
+      env: {},
+      writeStatus: { applyLabel: () => { throw new Error("applyLabel must not run on a marker no-op"); } },
+      postComment: () => true,
+      captureEvidence: () => ({ reason: "unknown", porcelainLines: [], prState: null, remediateHistory: [] }),
+      commitsAhead: () => 1,
+    });
+    const r = seam(candidate("unknown", "CTL-2", "verify"), decision("unknown"));
+    expect(r.labelApplied).toBe(false);
+    expect(r.errors.some((e) => e.sideEffect === "label")).toBe(false);  // benign no-op — not a failure
+  });
+
+  test("the escalation comment posts once per (ticket,category,phase); a second sweep is suppressed by the marker", () => {
+    const dir = mkdtempSync(join(tmpdir(), "ctl1641-commentonce-"));
+    mkdirSync(join(dir, "workers", "CTL-3"), { recursive: true });
+    let posts = 0;
+    const seam = buildUnstuckEscalateSeam({
+      orchDir: dir,
+      env: {},
+      applyNeedsHuman: () => true,
+      postComment: () => { posts++; return true; },
+      captureEvidence: () => ({ reason: "unknown", porcelainLines: [], prState: null, remediateHistory: [] }),
+      commitsAhead: () => 2,
+    });
+    const c = candidate("unknown", "CTL-3", "verify");
+    const d = decision("unknown");
+    const r1 = seam(c, d);
+    const r2 = seam(c, d);                                          // same still-stuck candidate, next sweep
+    expect(posts).toBe(1);                                          // comment posted exactly once
+    expect(r1.commentPosted).toBe(true);
+    expect(r2.commentPosted).toBe(true);                           // second call satisfied by the marker
+    expect(r2.errors).toEqual([]);
+    expect(existsSync(join(dir, "workers", "CTL-3", ".unstuck-escalate-comment-unknown-verify.applied"))).toBe(true);
+  });
+
+  test("a failed comment post does NOT write the idempotency marker — the next sweep retries", () => {
+    const dir = mkdtempSync(join(tmpdir(), "ctl1641-commentretry-"));
+    mkdirSync(join(dir, "workers", "CTL-4"), { recursive: true });
+    let posts = 0;
+    const seam = buildUnstuckEscalateSeam({
+      orchDir: dir,
+      env: {},
+      applyNeedsHuman: () => true,
+      postComment: () => { posts++; return posts >= 2; },          // fail the first post, succeed the second
+      captureEvidence: () => ({ reason: "unknown", porcelainLines: [], prState: null, remediateHistory: [] }),
+      commitsAhead: () => 2,
+    });
+    const c = candidate("unknown", "CTL-4", "verify");
+    const d = decision("unknown");
+    const marker = join(dir, "workers", "CTL-4", ".unstuck-escalate-comment-unknown-verify.applied");
+    const r1 = seam(c, d);
+    expect(r1.commentPosted).toBe(false);
+    expect(r1.errors.some((e) => e.sideEffect === "comment")).toBe(true);
+    expect(existsSync(marker)).toBe(false);                        // no marker on failure
+    const r2 = seam(c, d);                                          // retry on the next sweep
+    expect(r2.commentPosted).toBe(true);
+    expect(posts).toBe(2);
+    expect(existsSync(marker)).toBe(true);                         // marker written after the confirmed post
   });
 });
 

--- a/plugins/dev/scripts/execution-core/unstuck-escalate-seam.test.mjs
+++ b/plugins/dev/scripts/execution-core/unstuck-escalate-seam.test.mjs
@@ -2,6 +2,10 @@
 // escalate seam factory. All IO is stubbed via deps injection; no real git/fs/Linear.
 
 import { describe, test, expect } from "bun:test";
+import { existsSync, mkdtempSync, writeFileSync, chmodSync, readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
 import { buildUnstuckEscalateSeam } from "./unstuck-escalate-seam.mjs";
 
 function candidate(reason = "unknown", ticket = "CTL-1", phase = "implement") {
@@ -120,5 +124,53 @@ describe("buildUnstuckEscalateSeam — CTL-1641", () => {
     });
     const r = seam(candidate("unknown", "CTL-42", "verify"), decision("unknown"));
     expect(r).toMatchObject({ ticket: "CTL-42", phase: "verify", labelApplied: true, commentPosted: true, errors: [] });
+  });
+});
+
+// CTL-1641 verify LOW: every test above injects postComment, so the production
+// DEFAULT _post binding (helper-path resolution + spawn) is 0% exercised — the
+// exact path where the verify HIGH bug lived (PLUGIN_ROOT/cwd-relative resolution
+// that silently missed for the daemon). These guard the default binding directly.
+describe("buildUnstuckEscalateSeam default _post binding — CTL-1641 verify LOW", () => {
+  test("the module's sibling-relative helper path resolves to a real file (guards the URL fallback the HIGH bug missed)", () => {
+    // The source module resolves `new URL('../lib/linear-comment-post.sh', import.meta.url)`.
+    // This test file sits in the same directory (execution-core/), so `../lib/...` from here
+    // resolves identically — it must point at a file that actually exists (cwd/env-independent),
+    // which the old `process.env.PLUGIN_ROOT ?? process.cwd()` + 'scripts/lib/...' did not.
+    const expected = fileURLToPath(new URL("../lib/linear-comment-post.sh", import.meta.url));
+    expect(existsSync(expected)).toBe(true);
+    expect(expected.endsWith("plugins/dev/scripts/lib/linear-comment-post.sh")).toBe(true);
+  });
+
+  test("default _post (no postComment injection) spawns the resolved helper with [ticket, body] and reports its exit status", () => {
+    // Bind a hermetic stub as the helper via the CATALYST_COMMENT_POST_HELPER seam — the same
+    // env override the sibling daemon modules honor — and exercise the REAL default _post path
+    // (spawnSync of COMMENT_HELPER), which no other test covers.
+    const dir = mkdtempSync(join(tmpdir(), "ctl1641-escalate-"));
+    const argvOut = join(dir, "argv.txt");
+    const stub = join(dir, "stub-comment-post.sh");
+    writeFileSync(stub, `#!/usr/bin/env bash\nprintf '%s\\n' "$1" "$2" > "${argvOut}"\nexit 0\n`);
+    chmodSync(stub, 0o755);
+
+    const prev = process.env.CATALYST_COMMENT_POST_HELPER;
+    process.env.CATALYST_COMMENT_POST_HELPER = stub;
+    try {
+      const seam = buildUnstuckEscalateSeam({
+        orchDir: dir,
+        applyNeedsHuman: () => true,           // label still injected (not under test here)
+        captureEvidence: () => ({ reason: "unknown", porcelainLines: [], prState: null, remediateHistory: [] }),
+        commitsAhead: () => 2,
+        // postComment intentionally NOT injected — exercise the production default.
+      });
+      const r = seam(candidate("unknown", "CTL-77", "verify"), decision("unknown"));
+      expect(r.commentPosted).toBe(true);
+      expect(r.errors).toEqual([]);
+      const [ticketArg, bodyArg] = readFileSync(argvOut, "utf8").split("\n");
+      expect(ticketArg).toBe("CTL-77");
+      expect(bodyArg).toContain("CTL-77");   // the authored escalation body reached the helper
+    } finally {
+      if (prev === undefined) delete process.env.CATALYST_COMMENT_POST_HELPER;
+      else process.env.CATALYST_COMMENT_POST_HELPER = prev;
+    }
   });
 });

--- a/plugins/dev/scripts/execution-core/unstuck-sweep.mjs
+++ b/plugins/dev/scripts/execution-core/unstuck-sweep.mjs
@@ -332,6 +332,7 @@ export function runUnstuckSweepPass({
     wouldAct: [],
     escalated: [],
     wouldEscalate: [],
+    escalateFailures: [],   // CTL-1641: per-side-effect escalate failures (loud, not swallowed)
     skipped: [],
     failed: [],
   };
@@ -397,12 +398,30 @@ export function runUnstuckSweepPass({
       }
 
       // enforce — escalate path: no intent gate (genuine decisions always surface).
+      // CTL-1641: the escalate seam owns the operator-visible side effects (needs-human
+      // label FIRST, then the authored Linear comment). It returns
+      // { labelApplied, commentPosted, errors:[{sideEffect,err}] }; a THROW or any
+      // returned error is recorded in report.escalateFailures so a failed side effect
+      // surfaces in the sweep summary instead of being swallowed (Acceptance §2).
       if (decision.action === "escalate") {
-        try { escalate(c, decision); } catch (err) {
-          logger.warn({ ticket: c.ticket, err: err?.message }, "unstuck-sweep: escalate seam threw (CTL-1064)");
+        try {
+          const eres = escalate(c, decision) ?? {};
+          if (Array.isArray(eres.errors)) {
+            for (const e of eres.errors) {
+              report.escalateFailures.push({
+                ticket: c.ticket, phase: c.phase, category: decision.category,
+                sideEffect: e?.sideEffect ?? "unknown", err: e?.err ?? null,
+              });
+            }
+          }
+        } catch (err) {
+          logger.warn({ ticket: c.ticket, err: err?.message }, "unstuck-sweep: escalate seam threw (CTL-1641)");
+          report.escalateFailures.push({
+            ticket: c.ticket, phase: c.phase, category: decision.category,
+            sideEffect: "escalate-seam", err: err?.message ?? String(err),
+          });
         }
         fire(UNSTUCK_EVENT.escalated, { ticket: c.ticket, phase: c.phase, category: decision.category }, c.ticket);
-        try { postComment(c.ticket, decision.category ?? "unknown", c.phase); } catch { /* best-effort */ }
         report.escalated.push({ ticket: c.ticket, phase: c.phase, category: decision.category });
         continue;
       }

--- a/plugins/dev/scripts/execution-core/unstuck-sweep.test.mjs
+++ b/plugins/dev/scripts/execution-core/unstuck-sweep.test.mjs
@@ -222,22 +222,63 @@ describe("runUnstuckSweepPass — action driver (CTL-1064)", () => {
     expect(emitted).toContain("unstuck.cleared.noise");
   });
 
-  test("mode:'enforce' + escalate category → calls escalate seam + postComment + emits unstuck.escalated", () => {
+  test("mode:'enforce' + escalate → escalate seam is called with (candidate, decision); driver no longer calls postComment on the escalate path (CTL-1641)", () => {
     const escalateCalled = [];
     const commentCalled = [];
     const emitted = [];
-    runUnstuckSweepPass({
+    const report = runUnstuckSweepPass({
       mode: "enforce",
       collectCandidates: () => [makeCandidate({
         evidence: { reason: "remediate-cycle-cap-exhausted", ticket: "CTL-TEST", phase: "implement", liveSessionInWorktree: false, linearTerminal: false },
       })],
-      escalate: (c) => { escalateCalled.push(c.ticket); },
-      emit: (type) => { emitted.push(type); },
+      escalate: (c, d) => { escalateCalled.push({ ticket: c.ticket, cat: d.category }); return { labelApplied: true, commentPosted: true, errors: [] }; },
       postComment: (t) => { commentCalled.push(t); },
+      emit: (type) => { emitted.push(type); },
     });
-    expect(escalateCalled).toContain("CTL-TEST");
+    expect(escalateCalled[0].ticket).toBe("CTL-TEST");
+    expect(commentCalled).toHaveLength(0);           // escalate seam owns the comment now
     expect(emitted).toContain("unstuck.escalated");
-    expect(commentCalled).toContain("CTL-TEST");
+    expect(report.escalated).toHaveLength(1);
+    expect(report.escalateFailures).toEqual([]);
+  });
+
+  test("escalate seam that RETURNS errors[] → each error recorded in report.escalateFailures (loud, not swallowed) (CTL-1641)", () => {
+    const report = runUnstuckSweepPass({
+      mode: "enforce",
+      collectCandidates: () => [makeCandidate({
+        ticket: "CTL-ERR",
+        phase: "pr",
+        evidence: { reason: "unknown", ticket: "CTL-ERR", phase: "pr", liveSessionInWorktree: false, linearTerminal: false },
+      })],
+      escalate: () => ({ labelApplied: true, commentPosted: false, errors: [{ sideEffect: "comment", err: "linear 500" }] }),
+      emit: () => {},
+    });
+    expect(report.escalated).toHaveLength(1);         // still counted as escalated (label landed)
+    expect(report.escalateFailures).toHaveLength(1);
+    expect(report.escalateFailures[0]).toMatchObject({ ticket: "CTL-ERR", phase: "pr", sideEffect: "comment" });
+  });
+
+  test("escalate seam that THROWS → recorded in report.escalateFailures; the pass continues; the event still fires (CTL-1641)", () => {
+    const emitted = [];
+    const report = runUnstuckSweepPass({
+      mode: "enforce",
+      collectCandidates: () => [
+        makeCandidate({ ticket: "T1", evidence: { reason: "unknown", ticket: "T1", phase: "pr", liveSessionInWorktree: false, linearTerminal: false } }),
+        makeCandidate({ ticket: "T2", evidence: { reason: "unknown", ticket: "T2", phase: "pr", liveSessionInWorktree: false, linearTerminal: false } }),
+      ],
+      escalate: (c) => { if (c.ticket === "T1") throw new Error("seam blew up"); return { labelApplied: true, commentPosted: true, errors: [] }; },
+      emit: (type) => { emitted.push(type); },
+    });
+    expect(report.escalateFailures.some(f => f.ticket === "T1" && f.sideEffect === "escalate-seam")).toBe(true);
+    expect(report.escalated.some(e => e.ticket === "T2")).toBe(true);        // T2 unaffected
+    expect(emitted.filter(t => t === "unstuck.escalated")).toHaveLength(2);  // event fires for both
+  });
+
+  test("report always initializes escalateFailures (empty on the happy path and in off/shadow) (CTL-1641)", () => {
+    const off = runUnstuckSweepPass({ mode: "off", collectCandidates: () => [] });
+    const shadow = runUnstuckSweepPass({ mode: "shadow", collectCandidates: () => [makeCandidate()], emit: () => {} });
+    expect(off.escalateFailures).toEqual([]);
+    expect(shadow.escalateFailures).toEqual([]);
   });
 
   test("mode:'enforce' + skip (live session) → no act, no emit, no intent", () => {


### PR DESCRIPTION
<!-- Auto-generated: 2026-08-05T03:05:30Z -->
<!-- Last updated: 2026-08-05T03:05:30Z -->
<!-- PR: #3005 -->
<!-- Previous commits: 94feb3c56d0478fda34d1a97b8230f40e74f84c8,26c1acbe111683ce23a16e7780bb4fbca72970bf -->

## Summary

Wires the unstuck-sweep escalation path so stalled-ticket escalations reach the operator, rather than vanishing silently into the event log.

Prior to this change, when the unstuck sweep decided to escalate a stalled ticket, the decision produced exactly one artifact — an `unstuck.escalated` event in the JSONL log — with no Linear comment, no `needs-human` label, no inbox row, and no operator-visible push. The `authorEscalationComment` helper in `unstuck-sweep-escalation.mjs` had zero production callers. This was one of the two mechanisms behind the 2026-08-04 finding that 8 escalated tickets sat invisible for a week.

**Phase 1 (driver)** — `unstuck-sweep.mjs`: Adds `report.escalateFailures[]` channel so failed seam side-effects surface in the sweep summary instead of being swallowed. Removes the now-redundant inline `postComment` call from the escalate branch (the seam owns it from here on). Clears the stale test expectation.

**Phase 2 (seam)** — new `unstuck-escalate-seam.mjs`: `buildUnstuckEscalateSeam(deps)` is a pure-cored, fully-injectable factory that applies the `needs-human` label **first** (the sticky operator-visible surface), then posts an authored Linear escalation comment **second**. The two side effects are independent — failures are returned in `errors[]`, never swallowed. Respects the single-label-owner discipline via the `UnlessBeliefOwner` variant. 8 new unit tests covering label-before-comment ordering, evidence-failure graceful degradation, and independence of each side effect.

**Phase 3 (wiring)** — `scheduler.mjs`: Imports the seam factory and wires it as the `escalate:` key in the `runTick` `unstuckSweep` literal, bound to production deps already in scope (`writeStatus`, `prAdapter`, worktree resolver). Surfaces `escalateFailures.length` in the Pass 0u summary log. Does NOT change any mode defaults — `readUnstuckSweepConfig()` stays `'off'`; enforce remains an operator decision per ADR-023.

**Remediate** — fixes one HIGH finding from phase-verify: the `_post` helper was resolved via `process.env.PLUGIN_ROOT ?? process.cwd() + 'scripts/lib/...'`, which is never correct for the execution-core daemon (PLUGIN_ROOT unset, cwd is repo root), silently failing every authored escalation comment in production. Fixed using `fileURLToPath(new URL('../lib/linear-comment-post.sh', import.meta.url))` — the same pattern used by `recovery-emit.mjs`, `recovery-reasoning.mjs`, and `recovery.mjs`. Also wires the two new test files into `.github/workflows/execution-core-tests.yml` so they actually run in CI, and adds two tests for the previously-0%-covered default `_post` binding.

## Changes Made

### New files

- `plugins/dev/scripts/execution-core/unstuck-escalate-seam.mjs` (+146) — seam factory: label-before-comment, independent side effects, injectable deps
- `plugins/dev/scripts/execution-core/unstuck-escalate-seam.test.mjs` (+176) — 8 unit tests for the seam

### Modified files

- `plugins/dev/scripts/execution-core/unstuck-sweep.mjs` (+22/-3) — `escalateFailures[]` channel, removes stale inline `postComment` on escalate path
- `plugins/dev/scripts/execution-core/unstuck-sweep.test.mjs` (+47/-6) — 4 new tests, 1 updated expectation
- `plugins/dev/scripts/execution-core/scheduler.mjs` (+40/-1) — wires seam factory as `escalate:` key in `runTick` unstuckSweep literal
- `plugins/dev/scripts/execution-core/scheduler.test.mjs` (+26) — 1 new test for the escalate wiring
- `.github/workflows/execution-core-tests.yml` (+2) — adds `unstuck-escalate-seam.test.mjs` and `unstuck-sweep.test.mjs` to CI run

## How to Verify It

- [x] `bun test unstuck-sweep.test.mjs` — 56 pass (4 new, 1 updated)
- [x] `bun test unstuck-escalate-seam.test.mjs` — 8 pass (all new)
- [x] `bun test unstuck-sweep-escalation.test.mjs unstuck-sweep-evidence.test.mjs unstuck-act-seams.test.mjs` — all pass (no regressions)
- [x] `bun test scheduler.test.mjs` — 620 pass (1 new); 2 pre-existing CTL-781 flaky failures (same on `origin/main` baseline); 1 CTL-864 pre-existing timeout (passes in isolation, test-ordering artifact)
- [x] `node --check` on all 3 modified/created `.mjs` files — OK
- [x] Verify seam: regression_risk 0/10, all gates pass (syntax, tests, reward-hacking, code-review, coverage, silent-failure)
- [x] HIGH finding remediated: `fileURLToPath(new URL('../lib/...', import.meta.url))` path in `unstuck-escalate-seam.mjs` resolves to a real file in both test and production contexts
- [ ] Manual enforce dry-run against a stalled fixture (operator step — requires `CATALYST_UNSTUCK_SWEEP_MODE=enforce`)

## Related Issues/PRs

- Fixes https://linear.app/coalesce-labs/issue/CTL-1641

<!-- Linear automation guard (CTL-623/CTL-633): unlink sibling tickets so this PR does not drag their workflow status. -->
skip ADR-023
skip CTL-781
skip CTL-864