### PR TITLE
feat(dev): CTL-1643 escalation durability — verified-or-loud labels + GC-surviving attention store

### DIFF
--- a/plugins/dev/scripts/execution-core/daemon.mjs
+++ b/plugins/dev/scripts/execution-core/daemon.mjs
@@ -127,6 +127,7 @@ import {
 import * as linearWrite from "./linear-write.mjs"; // CTL-1067: writeStatus for defaultClearStall
 import { labelMarkerBase } from "./label-guard.mjs"; // CTL-1567: canonical once-marker path (single source of truth)
 import { defaultForgetIntent } from "./recovery-reasoning.mjs"; // CTL-1567: re-arm recovery when a human responds
+import { forgetDurableEscalation } from "./durable-escalation.mjs"; // CTL-1643: clear durable record on operator clear
 import { appendWorkerTransitionEvent as defaultAppendWorkerTransitionEvent } from "./worker-transition-event.mjs"; // CTL-764 finding 11: needs-input→cleared on comment wake
 import {
   writeBootMarker,
@@ -599,6 +600,9 @@ export async function handleCommentWake(
       } catch {
         /* observability only */
       }
+      // CTL-1643: clear the durable escalation record so the board durable-escalation
+      // card disappears when the operator responds. Fail-open (never throws).
+      forgetDurableEscalation(orchDir, ticket);
     }
   }
 

--- a/plugins/dev/scripts/execution-core/daemon.test.mjs
+++ b/plugins/dev/scripts/execution-core/daemon.test.mjs
@@ -3410,6 +3410,43 @@ describe("CTL-764 Phase 4 — handleCommentWake clears durable needs-input label
     const needsInputRemovals = removed.filter((r) => r.label === "needs-input");
     expect(needsInputRemovals).toHaveLength(0);
   });
+
+  // CTL-1643: a confirmed needs-human clear also removes the durable escalation
+  // record so the board durable-escalation card disappears when the operator responds.
+  test("CTL-1643: confirmed needs-human clear removes the durable escalation record", async () => {
+    const { recordDurableEscalation, readDurableEscalations } = await import(
+      "./durable-escalation.mjs"
+    );
+    const orch = tmpOrcDir();
+    // Seed a durable escalation record for the ticket.
+    recordDurableEscalation({
+      orchDir: orch,
+      ticket: "CTL-1",
+      phase: "implement",
+      reason: "stuck > 24h",
+      labelConfirmed: false,
+      commentPosted: true,
+      source: "scheduler",
+      now: Date.now(),
+    });
+    expect(readDurableEscalations(orch)).toHaveLength(1);
+
+    // humanProvenance = Boolean(authorId) && Boolean(botUserId) — both must be set
+    // for the needs-human clear path to run. isManagedTicket must also return true.
+    await handleCommentWake(
+      { ticket: "CTL-1", body: "answer from human", authorId: "human-user" },
+      {
+        orchDir: orch,
+        dispatch: () => ({ code: 0 }),
+        removeLabel: async () => ({ removed: true, wrote: true }),
+        botUserId: "bot-user-id",
+        isManagedTicket: () => true,
+        forgetIntent: () => true,
+      }
+    );
+    // The durable record must be gone after the confirmed clear.
+    expect(readDurableEscalations(orch)).toHaveLength(0);
+  });
 });
 
 // ─── CTL-1608 — stalled-PR timer gated on stalledPrSweep.enabled ─────────────

--- a/plugins/dev/scripts/execution-core/durable-escalation.mjs
+++ b/plugins/dev/scripts/execution-core/durable-escalation.mjs
@@ -1,0 +1,133 @@
+// durable-escalation.mjs — GC-surviving durable escalation store (CTL-1643).
+//
+// Writes per-ticket records to orchDir/.escalations/<T>.json, a directory that
+// survives stall-janitor J4 and worker-dir-gc.mjs (neither touches it). Both
+// the scheduler (recovery.mjs) and the board (board-data.mjs) import from here
+// without pulling in each other's dependency graph.
+//
+// Record shape:
+//   { ticket, phase, reason, escalatedAt, labelConfirmed, commentPosted,
+//     labelAttempts, source, lastTs }
+//
+// commentPosted — true once appendEscalatedEvent has fired for this episode.
+// Guards the comment/event so it fires at most once across retry ticks even
+// while the label is still unconfirmed (CTL-1643 verified-or-loud contract).
+//
+// Discipline mirrors recordEscalation / defaultForgetIntent: all helpers are
+// fail-open and never throw, so a filesystem error never crashes the scheduler
+// tick or the board assembly.
+
+import { existsSync, mkdirSync, readdirSync, readFileSync, renameSync, unlinkSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+function escalationsDir(orchDir) {
+  return join(orchDir, ".escalations");
+}
+
+function recordPath(orchDir, ticket) {
+  return join(escalationsDir(orchDir), `${ticket}.json`);
+}
+
+// recordDurableEscalation — write or upsert the escalation record.
+//
+// On first call: writes a fresh record with labelAttempts:1, escalatedAt:now.
+// On subsequent calls:
+//   labelConfirmed:false  → increments labelAttempts, updates lastTs, preserves escalatedAt.
+//   labelConfirmed:true   → sets labelConfirmed:true, does NOT increment labelAttempts.
+// commentPosted is OR'd with the prior value — once true it stays true.
+//
+// Returns the written record so callers can read labelAttempts immediately.
+// Never throws.
+export function recordDurableEscalation({
+  orchDir,
+  ticket,
+  phase,
+  reason,
+  labelConfirmed,
+  commentPosted: commentPostedArg,
+  source,
+  now,
+}) {
+  try {
+    const dir = escalationsDir(orchDir);
+    mkdirSync(dir, { recursive: true });
+    const path = recordPath(orchDir, ticket);
+    let prior = null;
+    if (existsSync(path)) {
+      try {
+        prior = JSON.parse(readFileSync(path, "utf8"));
+      } catch {
+        prior = null;
+      }
+    }
+    const escalatedAt = prior?.escalatedAt ?? now;
+    const labelAttempts =
+      labelConfirmed
+        ? (prior?.labelAttempts ?? 1)
+        : (prior?.labelAttempts ?? 0) + 1;
+    // commentPosted is sticky: once set true it is never cleared by a retry tick.
+    const commentPosted = commentPostedArg === true || prior?.commentPosted === true;
+    const rec = {
+      ticket,
+      phase,
+      reason,
+      escalatedAt,
+      labelConfirmed: labelConfirmed === true,
+      commentPosted,
+      labelAttempts,
+      source,
+      lastTs: now,
+    };
+    const tmp = `${path}.tmp.${process.pid}`;
+    writeFileSync(tmp, JSON.stringify(rec, null, 2));
+    renameSync(tmp, path);
+    return rec;
+  } catch {
+    // fail-open: a write failure is not a crash condition
+    return {
+      ticket,
+      phase,
+      reason,
+      escalatedAt: now,
+      labelConfirmed: labelConfirmed === true,
+      commentPosted: commentPostedArg === true,
+      labelAttempts: 1,
+      source,
+      lastTs: now,
+    };
+  }
+}
+
+// readDurableEscalations — scan .escalations/ and return all parseable records.
+// Absent dir, empty dir, or malformed files all degrade to [] (fail-open).
+export function readDurableEscalations(orchDir) {
+  try {
+    const dir = escalationsDir(orchDir);
+    if (!existsSync(dir)) return [];
+    const entries = readdirSync(dir).filter((f) => f.endsWith(".json"));
+    const records = [];
+    for (const entry of entries) {
+      try {
+        const raw = readFileSync(join(dir, entry), "utf8");
+        const rec = JSON.parse(raw);
+        if (rec && typeof rec === "object") records.push(rec);
+      } catch {
+        // skip malformed files
+      }
+    }
+    return records;
+  } catch {
+    return [];
+  }
+}
+
+// forgetDurableEscalation — unlink the record for a ticket.
+// Idempotent and never throws.
+export function forgetDurableEscalation(orchDir, ticket) {
+  try {
+    const path = recordPath(orchDir, ticket);
+    if (existsSync(path)) unlinkSync(path);
+  } catch {
+    // fail-open
+  }
+}

--- a/plugins/dev/scripts/execution-core/durable-escalation.test.mjs
+++ b/plugins/dev/scripts/execution-core/durable-escalation.test.mjs
@@ -1,0 +1,188 @@
+// durable-escalation.test.mjs — TDD tests for the CTL-1643 durable escalation
+// store (the GC-surviving orchDir-level record that survives worker-dir removal).
+//
+// Three helpers:
+//   recordDurableEscalation  — write/upsert .escalations/<T>.json under orchDir
+//   readDurableEscalations   — scan .escalations/, parse all records, fail-open
+//   forgetDurableEscalation  — unlink the record, idempotent, never throws
+
+import { describe, it, expect, beforeEach, afterEach } from "bun:test";
+import { mkdirSync, rmSync, existsSync, readFileSync, writeFileSync, mkdtempSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+const mod = await import("./durable-escalation.mjs");
+const { recordDurableEscalation, readDurableEscalations, forgetDurableEscalation } =
+  mod;
+
+// ─── helpers ─────────────────────────────────────────────────────────────────
+
+function tmpOrchDir() {
+  return mkdtempSync(join(tmpdir(), "ctl-1643-esc-test-"));
+}
+
+function escalationPath(orchDir, ticket) {
+  return join(orchDir, ".escalations", `${ticket}.json`);
+}
+
+// ─── recordDurableEscalation ─────────────────────────────────────────────────
+
+describe("recordDurableEscalation — write/upsert", () => {
+  let orchDir;
+  beforeEach(() => { orchDir = tmpOrchDir(); });
+  afterEach(() => { try { rmSync(orchDir, { recursive: true, force: true }); } catch {} });
+
+  it("writes .escalations/<T>.json with required fields on first call", () => {
+    const now = "2026-08-05T10:00:00Z";
+    recordDurableEscalation({
+      orchDir,
+      ticket: "CTL-1643",
+      phase: "implement",
+      reason: "no-progress",
+      labelConfirmed: false,
+      source: "scheduler",
+      now,
+    });
+    const rec = JSON.parse(readFileSync(escalationPath(orchDir, "CTL-1643"), "utf8"));
+    expect(rec.ticket).toBe("CTL-1643");
+    expect(rec.phase).toBe("implement");
+    expect(rec.reason).toBe("no-progress");
+    expect(rec.labelConfirmed).toBe(false);
+    expect(rec.labelAttempts).toBe(1);
+    expect(rec.escalatedAt).toBe(now);
+    expect(rec.source).toBe("scheduler");
+  });
+
+  it("a second call with labelConfirmed:false increments labelAttempts and preserves escalatedAt", () => {
+    const t1 = "2026-08-05T10:00:00Z";
+    const t2 = "2026-08-05T10:10:00Z";
+    recordDurableEscalation({ orchDir, ticket: "CTL-1643", phase: "implement", reason: "no-progress", labelConfirmed: false, source: "scheduler", now: t1 });
+    recordDurableEscalation({ orchDir, ticket: "CTL-1643", phase: "implement", reason: "no-progress", labelConfirmed: false, source: "scheduler", now: t2 });
+    const rec = JSON.parse(readFileSync(escalationPath(orchDir, "CTL-1643"), "utf8"));
+    expect(rec.labelAttempts).toBe(2);
+    expect(rec.escalatedAt).toBe(t1); // preserved from first call
+    expect(rec.lastTs).toBe(t2);
+  });
+
+  it("a call with labelConfirmed:true sets the flag and does NOT increment labelAttempts", () => {
+    const t1 = "2026-08-05T10:00:00Z";
+    const t2 = "2026-08-05T10:10:00Z";
+    recordDurableEscalation({ orchDir, ticket: "CTL-1643", phase: "implement", reason: "no-progress", labelConfirmed: false, source: "scheduler", now: t1 });
+    const rec1 = JSON.parse(readFileSync(escalationPath(orchDir, "CTL-1643"), "utf8"));
+    expect(rec1.labelAttempts).toBe(1);
+    recordDurableEscalation({ orchDir, ticket: "CTL-1643", phase: "implement", reason: "no-progress", labelConfirmed: true, source: "scheduler", now: t2 });
+    const rec2 = JSON.parse(readFileSync(escalationPath(orchDir, "CTL-1643"), "utf8"));
+    expect(rec2.labelConfirmed).toBe(true);
+    expect(rec2.labelAttempts).toBe(1); // did NOT increment
+  });
+
+  it("returns the written record (so callers can read labelAttempts)", () => {
+    const rec = recordDurableEscalation({
+      orchDir,
+      ticket: "CTL-1643",
+      phase: "implement",
+      reason: "no-progress",
+      labelConfirmed: false,
+      source: "scheduler",
+      now: "2026-08-05T10:00:00Z",
+    });
+    expect(rec.labelAttempts).toBe(1);
+    expect(rec.ticket).toBe("CTL-1643");
+  });
+
+  it("the record survives removal of workers/<T>/ (GC-survival guarantee)", () => {
+    const workerDir = join(orchDir, "workers", "CTL-1643");
+    mkdirSync(workerDir, { recursive: true });
+    recordDurableEscalation({ orchDir, ticket: "CTL-1643", phase: "implement", reason: "no-progress", labelConfirmed: false, source: "scheduler", now: "2026-08-05T10:00:00Z" });
+    rmSync(workerDir, { recursive: true, force: true });
+    // record still readable
+    expect(existsSync(escalationPath(orchDir, "CTL-1643"))).toBe(true);
+    const rec = JSON.parse(readFileSync(escalationPath(orchDir, "CTL-1643"), "utf8"));
+    expect(rec.ticket).toBe("CTL-1643");
+  });
+
+  it("never throws — a failed write (unwritable dir) is a silent no-op", () => {
+    // Pass a completely invalid path; must not throw.
+    expect(() => {
+      recordDurableEscalation({
+        orchDir: "/dev/null/cannot-exist",
+        ticket: "CTL-1643",
+        phase: "implement",
+        reason: "no-progress",
+        labelConfirmed: false,
+        source: "scheduler",
+        now: "2026-08-05T10:00:00Z",
+      });
+    }).not.toThrow();
+  });
+});
+
+// ─── readDurableEscalations ──────────────────────────────────────────────────
+
+describe("readDurableEscalations — directory scan", () => {
+  let orchDir;
+  beforeEach(() => { orchDir = tmpOrchDir(); });
+  afterEach(() => { try { rmSync(orchDir, { recursive: true, force: true }); } catch {} });
+
+  it("returns all non-empty, parseable records from .escalations/", () => {
+    recordDurableEscalation({ orchDir, ticket: "CTL-1643", phase: "implement", reason: "no-progress", labelConfirmed: false, source: "scheduler", now: "2026-08-05T10:00:00Z" });
+    recordDurableEscalation({ orchDir, ticket: "CTL-1644", phase: "triage", reason: "busy-ceiling-exceeded", labelConfirmed: true, source: "scheduler", now: "2026-08-05T11:00:00Z" });
+    const recs = readDurableEscalations(orchDir);
+    expect(recs).toHaveLength(2);
+    const ids = recs.map((r) => r.ticket).sort();
+    expect(ids).toEqual(["CTL-1643", "CTL-1644"]);
+  });
+
+  it("absent or empty .escalations/ → [] (never throws)", () => {
+    expect(readDurableEscalations(orchDir)).toEqual([]);
+    // non-existent orchDir also safe
+    expect(readDurableEscalations("/tmp/nonexistent-ctl1643-orch")).toEqual([]);
+  });
+
+  it("malformed JSON files are skipped (fail-open)", () => {
+    const dir = join(orchDir, ".escalations");
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(join(dir, "CTL-9999.json"), "not-json{{{{");
+    // Write a good one
+    recordDurableEscalation({ orchDir, ticket: "CTL-1643", phase: "implement", reason: "no-progress", labelConfirmed: false, source: "scheduler", now: "2026-08-05T10:00:00Z" });
+    const recs = readDurableEscalations(orchDir);
+    expect(recs).toHaveLength(1);
+    expect(recs[0].ticket).toBe("CTL-1643");
+  });
+
+  it("labelConfirmed:false records surface identically to labelConfirmed:true", () => {
+    recordDurableEscalation({ orchDir, ticket: "CTL-1643", phase: "implement", reason: "no-progress", labelConfirmed: false, source: "scheduler", now: "2026-08-05T10:00:00Z" });
+    recordDurableEscalation({ orchDir, ticket: "CTL-1644", phase: "triage", reason: "no-progress", labelConfirmed: true, source: "scheduler", now: "2026-08-05T11:00:00Z" });
+    const recs = readDurableEscalations(orchDir);
+    expect(recs).toHaveLength(2);
+    // both present — the board surfaces them regardless of label confirmation
+  });
+});
+
+// ─── forgetDurableEscalation ─────────────────────────────────────────────────
+
+describe("forgetDurableEscalation — removal", () => {
+  let orchDir;
+  beforeEach(() => { orchDir = tmpOrchDir(); });
+  afterEach(() => { try { rmSync(orchDir, { recursive: true, force: true }); } catch {} });
+
+  it("removes the .escalations/<T>.json file", () => {
+    recordDurableEscalation({ orchDir, ticket: "CTL-1643", phase: "implement", reason: "no-progress", labelConfirmed: false, source: "scheduler", now: "2026-08-05T10:00:00Z" });
+    expect(existsSync(escalationPath(orchDir, "CTL-1643"))).toBe(true);
+    forgetDurableEscalation(orchDir, "CTL-1643");
+    expect(existsSync(escalationPath(orchDir, "CTL-1643"))).toBe(false);
+  });
+
+  it("after removal, readDurableEscalations yields no entry for the ticket", () => {
+    recordDurableEscalation({ orchDir, ticket: "CTL-1643", phase: "implement", reason: "no-progress", labelConfirmed: false, source: "scheduler", now: "2026-08-05T10:00:00Z" });
+    recordDurableEscalation({ orchDir, ticket: "CTL-1644", phase: "triage", reason: "busy-ceiling-exceeded", labelConfirmed: true, source: "scheduler", now: "2026-08-05T11:00:00Z" });
+    forgetDurableEscalation(orchDir, "CTL-1643");
+    const recs = readDurableEscalations(orchDir);
+    expect(recs.map((r) => r.ticket)).toEqual(["CTL-1644"]);
+  });
+
+  it("is idempotent — calling on an already-absent record never throws", () => {
+    expect(() => forgetDurableEscalation(orchDir, "CTL-9999")).not.toThrow();
+    expect(() => forgetDurableEscalation("/tmp/nonexistent-ctl1643-orch", "CTL-9999")).not.toThrow();
+  });
+});

--- a/plugins/dev/scripts/execution-core/label-guard.mjs
+++ b/plugins/dev/scripts/execution-core/label-guard.mjs
@@ -345,6 +345,11 @@ export const ESCALATION_COOLDOWN_MS =
 // site parks the ticket terminally instead of asking again.
 export const ESCALATION_ASK_CAP = Number(process.env.CATALYST_ESCALATION_ASK_CAP) || 3;
 
+// LABEL_CONFIRM_CAP — maximum transient label-write attempts before escalation.label-unconfirmed
+// fires and the cooldown is written unconditionally. Bounds the label-retry storm so a persistent
+// Linear outage eventually produces a loud operator-visible alert instead of silent per-tick retries.
+export const LABEL_CONFIRM_CAP = Number(process.env.CATALYST_LABEL_CONFIRM_CAP) || 5;
+
 export function escalationCooldownPath(orchDir, ticket, phase) {
   return join(orchDir, ".escalation-cooldowns", `${ticket}-${phase}.json`);
 }

--- a/plugins/dev/scripts/execution-core/recovery.mjs
+++ b/plugins/dev/scripts/execution-core/recovery.mjs
@@ -2493,9 +2493,21 @@ export function reclaimDeadWorkIfPossible(
       source: "scheduler",
       now: now(),
     });
+    // CTL-1643: track whether the cooldown was already written by the
+    // confirmed/unrecoverable/cap-reached gate below, so the two immediate-
+    // terminal branches further down (ask-cap reached, no-probe-for-phase)
+    // can still guarantee exactly one recordEscalationFn call even when the
+    // label write is transient/unconfirmed (e.g. a belief-owner deferral
+    // under CATALYST_INTENTS_ENFORCE=1) — those branches never get a second
+    // tick to retry, so unlike the "transient + under cap" no-op case above,
+    // they must not silently skip the cooldown record (regression: recovery
+    // .test.mjs "supersede guard tolerates an unknown phase on the SIGNAL
+    // ITSELF" expected exactly 1 recordEscalation call and got 0).
+    let cooldownRecorded = false;
     if (labelApplied || labelUnrecoverable) {
       // Confirmed or unrecoverable: write the 10-min cooldown (unchanged path).
       recordEscalationFn(orchDir, ticket, phase, reason, now());
+      cooldownRecorded = true;
     } else if (durableRec.labelAttempts >= LABEL_CONFIRM_CAP) {
       // Cap reached without confirmation: emit a loud operator-visible alert so the
       // escalation remains visible even without a Linear label, then write the cooldown
@@ -2509,6 +2521,7 @@ export function reclaimDeadWorkIfPossible(
         "ctl-1643: needs-human label unconfirmed after cap attempts — emitting loud alert and writing cooldown"
       );
       recordEscalationFn(orchDir, ticket, phase, reason, now());
+      cooldownRecorded = true;
     }
     // else: transient + under cap → NO cooldown written → next tick retries the label.
     // CTL-1442: this ask consumed the cap → go TERMINAL. Flip the phase signal
@@ -2517,6 +2530,13 @@ export function reclaimDeadWorkIfPossible(
     // re-evaluating the ticket and the operator sees ONE final, complete ask
     // instead of an endless every-10-min echo.
     if (capApplies && priorAsks + 1 >= escalationAskCap) {
+      if (!cooldownRecorded) {
+        // This ask is terminal — there is no next tick to retry the label on,
+        // so the cooldown must be recorded now even though the label write
+        // itself was transient/unconfirmed (matches pre-CTL-1643 behavior,
+        // which called recordEscalationFn unconditionally here).
+        recordEscalationFn(orchDir, ticket, phase, reason, now());
+      }
       markEscalationCapTerminal({ orchDir, ticket, phase, explanation });
       log.warn(
         { ticket, phase, reason, asks: priorAsks + 1 },
@@ -2533,6 +2553,12 @@ export function reclaimDeadWorkIfPossible(
     // its prior non-terminal status would let listInFlightTickets keep
     // counting it as an occupied worker slot forever (Codex #3027 P1).
     if (reason === "no-probe-for-phase") {
+      if (!cooldownRecorded) {
+        // Same rationale as the ask-cap-terminal branch above: this is a
+        // first-and-only occurrence with no retry path, so the cooldown
+        // must be recorded now regardless of label-confirm outcome.
+        recordEscalationFn(orchDir, ticket, phase, reason, now());
+      }
       markEscalationCapTerminal({ orchDir, ticket, phase, explanation, stalledReason: reason });
       log.warn(
         { ticket, phase, reason },

--- a/plugins/dev/scripts/execution-core/recovery.mjs
+++ b/plugins/dev/scripts/execution-core/recovery.mjs
@@ -138,6 +138,8 @@ import {
   recordEscalation as defaultRecordEscalation,
   readEscalationRecord as defaultReadEscalationRecord, // CTL-1442: ask-cap gate
   ESCALATION_ASK_CAP, // CTL-1442
+  LABEL_CONFIRM_CAP, // CTL-1643: transient-retry cap before loud alert
+  labelMarkerBase, // CTL-1643: inspect .applied/.skipped markers without re-calling labelOnce
   labelNeedsHumanUnlessBeliefOwner,
 } from "./label-guard.mjs";
 import {
@@ -146,6 +148,10 @@ import {
   latestCompleteEventTs,
   latestCompleteEventAttempt,
 } from "./event-scan.mjs";
+import {
+  recordDurableEscalation,
+  readDurableEscalations,
+} from "./durable-escalation.mjs"; // CTL-1643: GC-surviving escalation store
 
 // phase-agent-emit-complete sits two directories up from execution-core/.
 const EMIT_COMPLETE_BIN = fileURLToPath(new URL("../phase-agent-emit-complete", import.meta.url));
@@ -2448,16 +2454,63 @@ export function reclaimDeadWorkIfPossible(
     }
     const explanation = buildEscExplanation();
     const enrichedExtras = { ...(extras ?? {}), explanation };
-    appendEscalatedEvent({
-      phase,
+    // CTL-1643: gate the event so it fires at most once per EPISODE. An episode
+    // ends when the 10-min cooldown is written (confirmed, unrecoverable, or cap).
+    // During a transient episode (no cooldown file ever written) we detect a
+    // prior fire via labelAttempts > 0 in the durable record. When the cooldown
+    // file exists — even if it has expired (new episode) — the gate is open so
+    // the fresh episode fires fresh. Phase is part of the key: a different-phase
+    // escalation on the same ticket is always a fresh fire.
+    const existingEscRec = readDurableEscalations(orchDir).find((r) => r.ticket === ticket);
+    const existingCooldownRec = readEscalationRecordFn(orchDir, ticket, phase);
+    const commentAlreadyPosted = !existingCooldownRec
+      && existingEscRec?.phase === phase
+      && (existingEscRec?.labelAttempts ?? 0) > 0;
+    if (!commentAlreadyPosted) {
+      appendEscalatedEvent({
+        phase,
+        ticket,
+        orchId,
+        reason,
+        final_attempt_count: finalAttemptCount,
+        extras: enrichedExtras,
+      });
+    }
+    // CTL-1643: capture the label-apply outcome (previously discarded). Gate the
+    // 10-min cooldown on confirmed-or-unrecoverable so a transient 429 leaves the
+    // retry window open. The .applied/.skipped markers written by labelOnce let us
+    // classify the outcome without repeating the API call.
+    const labelConfirmed = applyStalledLabel({ orchDir, ticket });
+    const markerBase = labelMarkerBase(orchDir, ticket, "needs-human");
+    const labelApplied = labelConfirmed || existsSync(`${markerBase}.applied`);
+    const labelUnrecoverable = existsSync(`${markerBase}.skipped`);
+    const durableRec = recordDurableEscalation({
+      orchDir,
       ticket,
-      orchId,
+      phase,
       reason,
-      final_attempt_count: finalAttemptCount,
-      extras: enrichedExtras,
+      labelConfirmed: labelApplied,
+      source: "scheduler",
+      now: now(),
     });
-    applyStalledLabel({ orchDir, ticket });
-    recordEscalationFn(orchDir, ticket, phase, reason, now());
+    if (labelApplied || labelUnrecoverable) {
+      // Confirmed or unrecoverable: write the 10-min cooldown (unchanged path).
+      recordEscalationFn(orchDir, ticket, phase, reason, now());
+    } else if (durableRec.labelAttempts >= LABEL_CONFIRM_CAP) {
+      // Cap reached without confirmation: emit a loud operator-visible alert so the
+      // escalation remains visible even without a Linear label, then write the cooldown
+      // to stop hammering the API. The durable record keeps the card on the board.
+      appendEvent({
+        "event.name": `escalation.label-unconfirmed.${ticket}`,
+        payload: { ticket, phase, reason, labelAttempts: durableRec.labelAttempts },
+      });
+      log.warn(
+        { ticket, phase, reason, labelAttempts: durableRec.labelAttempts },
+        "ctl-1643: needs-human label unconfirmed after cap attempts — emitting loud alert and writing cooldown"
+      );
+      recordEscalationFn(orchDir, ticket, phase, reason, now());
+    }
+    // else: transient + under cap → NO cooldown written → next tick retries the label.
     // CTL-1442: this ask consumed the cap → go TERMINAL. Flip the phase signal
     // to stalled with the curated explanation persisted on it (deriveExplanation
     // renders it in the monitor's Needs-You inbox), so the reclaim sweep stops

--- a/plugins/dev/scripts/execution-core/recovery.test.mjs
+++ b/plugins/dev/scripts/execution-core/recovery.test.mjs
@@ -48,7 +48,8 @@ import {
 import { saveCursor } from "./event-cursor.mjs";
 import { dropProject } from "./eligible-set.mjs";
 import { existsSync, appendFileSync, chmodSync } from "node:fs";
-import { recordEscalation } from "./label-guard.mjs"; // CTL-1442: seed reason-change scenarios
+import { recordEscalation, LABEL_CONFIRM_CAP } from "./label-guard.mjs"; // CTL-1442: seed reason-change scenarios; CTL-1643: cap
+import { readDurableEscalations } from "./durable-escalation.mjs"; // CTL-1643: durable store reader
 import { defaultClearStall } from "./scheduler.mjs"; // CTL-1442: operator re-arm resets the ask budget
 import { WORK_DONE_PROBES } from "./work-done-probes.mjs";
 
@@ -6241,5 +6242,153 @@ describe("buildEventEnvelope — CTL-1488 caused_by + event.stream_class parity"
   test("stamps attributes['event.stream_class'] = 'coordination' for every phase.* envelope", () => {
     const line = buildEventEnvelope({ phase: "verify", ticket: "CTL-1", action: "escalated", reason: "x" });
     expect(JSON.parse(line).attributes["event.stream_class"]).toBe("coordination");
+  });
+});
+
+// --- CTL-1643: escalateOnce verified-or-loud label application ---------------
+// Tests that escalateOnce gates the 10-min cooldown on a confirmed or
+// unrecoverable label write — not on a transient 429 — and persists a durable
+// escalation record that survives worker-dir GC.
+//
+// Drives reclaimDeadWorkIfPossible on the "no-progress-stopped" path
+// (dead worker, probe NOT done, zero progress, no escalation cooldown).
+// Uses the module-level orchDir real tmpdir (same beforeEach/afterEach).
+describe("CTL-1643: escalateOnce verified-or-loud label application", () => {
+  const ticket = "CTL-9";
+
+  // Minimal seam set that reaches escalateOnce via the no-progress-stopped path.
+  // All seams that would touch the real filesystem are injected so the tests are
+  // hermetic. recordEscalationFn is always injected to avoid writing real cooldowns.
+  function escSeams(extra = {}) {
+    return {
+      repoRoot: "/repo",
+      statJob: () => null,                          // dead-gone
+      probes: { implement: () => false },           // work NOT done
+      progressMark: () => 0,
+      readProgressMark: () => 0,
+      writeProgressMark: recorder(undefined),
+      appendEvent: recorder(undefined),
+      appendEscalatedEvent: recorder(undefined),
+      appendReviveEvent: recorder(undefined),
+      appendReviveSuppressedEvent: recorder(undefined),
+      applyStalledLabel: recorder(false),           // default: transient
+      recordEscalationFn: recorder(undefined),      // track cooldown writes
+      inEscalationCooldownFn: () => false,          // no existing cooldown
+      emitComplete: recorder({ code: 0 }),
+      reviveDispatch: recorder({ code: 0 }),
+      killBgJob: recorder(undefined),
+      countReviveEvents: recorder(0),
+      countDistinctRevivingTickets: recorder(0),
+      writeReviveMarker: recorder(undefined),
+      resolveSession: () => null,
+      postReclaimMirror: recorder(undefined),
+      listTicketPhases: () => ["implement"],
+      emitReapIntent: () => Promise.resolve(),
+      readBootSince: () => undefined,
+      readEscalationRecordFn: () => null,           // no prior asks
+      escalationAskCap: 100,                        // isolate from ask-cap effects
+      breaker: { isOpen: () => false },
+      now: () => 1_000_000,
+      ...extra,
+    };
+  }
+
+  test("transient 429 (applyStalledLabel returns false, no markers) → cooldown NOT written", () => {
+    const recordEscalation = recorder(undefined);
+    const result = reclaimDeadWorkIfPossible(orchDir, implementSignal(), escSeams({
+      applyStalledLabel: recorder(false),
+      recordEscalationFn: recordEscalation,
+    }));
+    expect(result).toBe("no-progress-stopped");
+    expect(recordEscalation.calls.length).toBe(0);
+  });
+
+  test("transient 429 → durable record written with labelConfirmed:false, labelAttempts:1", () => {
+    reclaimDeadWorkIfPossible(orchDir, implementSignal(), escSeams({
+      applyStalledLabel: recorder(false),
+    }));
+    const recs = readDurableEscalations(orchDir);
+    expect(recs).toHaveLength(1);
+    expect(recs[0].ticket).toBe(ticket);
+    expect(recs[0].labelConfirmed).toBe(false);
+    expect(recs[0].labelAttempts).toBe(1);
+  });
+
+  test("confirmed label (applyStalledLabel returns true) → cooldown written", () => {
+    const recordEscalation = recorder(undefined);
+    reclaimDeadWorkIfPossible(orchDir, implementSignal(), escSeams({
+      applyStalledLabel: recorder(true),
+      recordEscalationFn: recordEscalation,
+    }));
+    expect(recordEscalation.calls.length).toBe(1);
+  });
+
+  test("confirmed label → durable record written with labelConfirmed:true", () => {
+    reclaimDeadWorkIfPossible(orchDir, implementSignal(), escSeams({
+      applyStalledLabel: recorder(true),
+    }));
+    const recs = readDurableEscalations(orchDir);
+    expect(recs).toHaveLength(1);
+    expect(recs[0].labelConfirmed).toBe(true);
+  });
+
+  test(".skipped marker (unrecoverable) → cooldown written even if applyStalledLabel returns false", () => {
+    // Write the unrecoverable marker that labelOnce leaves when the label is missing/conflicting.
+    mkdirSync(join(orchDir, "workers", ticket), { recursive: true });
+    writeFileSync(join(orchDir, "workers", ticket, ".linear-label-needs-human.skipped"), "");
+    const recordEscalation = recorder(undefined);
+    reclaimDeadWorkIfPossible(orchDir, implementSignal(), escSeams({
+      applyStalledLabel: recorder(false),
+      recordEscalationFn: recordEscalation,
+    }));
+    expect(recordEscalation.calls.length).toBe(1);
+  });
+
+  test("cap reached after LABEL_CONFIRM_CAP transient ticks → cooldown written + loud event", () => {
+    const recordEscalation = recorder(undefined);
+    const appendEvent = recorder(undefined);
+    for (let i = 0; i < LABEL_CONFIRM_CAP; i++) {
+      reclaimDeadWorkIfPossible(orchDir, implementSignal(), escSeams({
+        applyStalledLabel: recorder(false),
+        recordEscalationFn: recordEscalation,
+        appendEvent,
+      }));
+    }
+    // Cooldown written exactly once — on the cap-reaching tick.
+    expect(recordEscalation.calls.length).toBe(1);
+    // A distinct escalation.label-unconfirmed.<ticket> event was emitted.
+    const loudEvents = appendEvent.calls.filter(
+      (c) => c[0]?.["event.name"] === `escalation.label-unconfirmed.${ticket}`,
+    );
+    expect(loudEvents.length).toBe(1);
+  });
+
+  test("appendEscalatedEvent fires AT MOST ONCE across N transient ticks (same-episode gate)", () => {
+    const appendEscalated = recorder(undefined);
+    // First tick: no prior labelAttempts → fires.
+    reclaimDeadWorkIfPossible(orchDir, implementSignal(), escSeams({
+      applyStalledLabel: recorder(false),
+      appendEscalatedEvent: appendEscalated,
+    }));
+    expect(appendEscalated.calls.length).toBe(1);
+    // Second tick: cooldown not written (transient), labelAttempts:1 in the
+    // durable record + no cooldown file → same-episode gate suppresses the event.
+    reclaimDeadWorkIfPossible(orchDir, implementSignal(), escSeams({
+      applyStalledLabel: recorder(false),
+      appendEscalatedEvent: appendEscalated,
+    }));
+    expect(appendEscalated.calls.length).toBe(1); // still 1, not 2
+  });
+
+  test("regression: confirmed-first-try path is byte-for-byte unchanged (event once, cooldown once)", () => {
+    const appendEscalated = recorder(undefined);
+    const recordEscalation = recorder(undefined);
+    reclaimDeadWorkIfPossible(orchDir, implementSignal(), escSeams({
+      applyStalledLabel: recorder(true),
+      appendEscalatedEvent: appendEscalated,
+      recordEscalationFn: recordEscalation,
+    }));
+    expect(appendEscalated.calls.length).toBe(1);
+    expect(recordEscalation.calls.length).toBe(1);
   });
 });

--- a/plugins/dev/scripts/execution-core/scheduler.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.mjs
@@ -111,6 +111,7 @@ import {
 // recovery evidence attachment (revives the structurally-dead R12 branch).
 import { collectBeliefsTick, getBeliefsDb, getEscalateHumanBelief } from "./beliefs/collector.mjs";
 import { buildRecoveryItems } from "./recovery-evidence.mjs";
+import { forgetDurableEscalation } from "./durable-escalation.mjs"; // CTL-1643: clear durable record on operator re-arm
 // CTL-1045 Bug 1: kill-storm suppression guard for defaultJanitorKillIntentRecorder.
 import {
   isIntentEffective,
@@ -3373,6 +3374,10 @@ export function defaultClearStall(orchDir, writeStatus) {
     } catch {
       /* best-effort */
     }
+    // 5. CTL-1643: clear the durable escalation record so the next same-episode
+    //    gate starts fresh. Without this, the labelAttempts > 0 guard in
+    //    escalateOnce suppresses the re-escalation event after the operator re-arms.
+    forgetDurableEscalation(orchDir, ticket);
     return true;
   };
 }

--- a/plugins/dev/scripts/execution-core/stall-janitor.mjs
+++ b/plugins/dev/scripts/execution-core/stall-janitor.mjs
@@ -38,6 +38,7 @@ import { existsSync, readdirSync, readFileSync, rmSync, statSync } from "node:fs
 import { join } from "node:path";
 import { spawnSync } from "node:child_process";
 import { log } from "./config.mjs";
+import { forgetDurableEscalation } from "./durable-escalation.mjs"; // CTL-1643: clear durable record on J4 terminal GC
 import { parseWorktreeForBranch } from "./worktree.mjs";
 import { cleanPorcelain } from "./worktree-safety.mjs";
 // CTL-1005 J3: prior-phase artifact completeness reuses the SAME work-done probes
@@ -899,6 +900,10 @@ export function defaultGcTerminalSignals(orchDir) {
   return ({ ticket }) => {
     try {
       rmSync(join(orchDir, "workers", ticket), { recursive: true, force: true });
+      // CTL-1643: also remove the durable escalation record so the board does not
+      // surface a ghost needs-human card after the worker dir is GC'd. Fail-open
+      // (forgetDurableEscalation never throws).
+      forgetDurableEscalation(orchDir, ticket);
       return true;
     } catch (err) {
       log.warn({ ticket, err: err?.message }, "stall-janitor: J4 gc rmSync failed — skipping (CTL-1242)");

--- a/plugins/dev/scripts/execution-core/stall-janitor.test.mjs
+++ b/plugins/dev/scripts/execution-core/stall-janitor.test.mjs
@@ -1084,6 +1084,34 @@ describe("defaultGcTerminalSignals (CTL-1242 J4 integration)", () => {
     const gc = defaultGcTerminalSignals(orchDir);
     expect(() => gc({ ticket: "CTL-1242-GONE" })).not.toThrow();
   });
+
+  // CTL-1643: J4 GC also removes the durable escalation record so the board
+  // does not surface a "ghost" needs-human card after the worker dir is gone.
+  test("CTL-1643: also removes .escalations/<T>.json when present", async () => {
+    const { recordDurableEscalation, readDurableEscalations } = await import(
+      "./durable-escalation.mjs"
+    );
+    const workerDir = join(orchDir, "workers", "CTL-1643-J4");
+    mkdirSync(workerDir, { recursive: true });
+    writeFileSync(join(workerDir, "phase-implement.json"), JSON.stringify({ status: "failed" }));
+    recordDurableEscalation({
+      orchDir,
+      ticket: "CTL-1643-J4",
+      phase: "implement",
+      reason: "stuck > 24h",
+      labelConfirmed: false,
+      commentPosted: true,
+      source: "scheduler",
+      now: Date.now(),
+    });
+    expect(readDurableEscalations(orchDir)).toHaveLength(1);
+
+    const gc = defaultGcTerminalSignals(orchDir);
+    gc({ ticket: "CTL-1643-J4" });
+
+    expect(existsSync(workerDir)).toBe(false);
+    expect(readDurableEscalations(orchDir)).toHaveLength(0);
+  });
 });
 
 describe("defaultCollectTerminalSignalGcCandidates (CTL-1242 J4)", () => {

--- a/plugins/dev/scripts/orch-monitor/__tests__/board-durable-escalations.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/board-durable-escalations.test.ts
@@ -1,0 +1,227 @@
+// board-durable-escalations.test.ts — CTL-1643: surface durable escalation records
+// on the board even when the worker dir has been GC'd and even when the Linear label
+// never confirmed (Hole 1 + Hole 2 in combination).
+//
+// Pattern mirrors board-parked-needs-human.test.ts:
+//   • the PURE synthesizer emits one attention card per durable record, deduped
+//     against the existing worker-dir / queued / orphan / parked card set;
+//   • labelConfirmed:false records surface identically to labelConfirmed:true
+//     (that is the whole point of Hole 1 — the store survives even when the label
+//     never landed in Linear, so the operator still sees the escalation);
+//   • terminal-aware: linfo or an explicit terminalIds set excludes tickets already
+//     at Done/Canceled;
+//   • malformed / empty input → [] (fail-open, never throws).
+
+import { describe, it, expect } from "bun:test";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+import { classifyTicket, deriveInbox } from "../ui/src/board/home-inbox";
+import type { BoardPayload, BoardTicket } from "../ui/src/board/types";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const read = (rel: string) => readFileSync(join(HERE, "..", rel), "utf8");
+const boardDataSrc = read("lib/board-data.mjs");
+
+const boardMod = await import(join(HERE, "..", "lib", "board-data.mjs"));
+const synthesizeDurableEscalations = (boardMod as Record<string, unknown>)
+  .synthesizeDurableEscalations as (
+  records: unknown,
+  existingIds: unknown,
+  now: number,
+  replicaTitles?: unknown,
+  linfo?: unknown,
+  terminalIds?: unknown,
+) => BoardTicket[];
+
+// Minimal durable record as recordDurableEscalation writes it.
+const durableRec = (over: Record<string, unknown> = {}): Record<string, unknown> => ({
+  ticket: "CTL-9",
+  phase: "implement",
+  reason: "Worker stuck > 24h, no progress",
+  escalatedAt: new Date(100_000).toISOString(),
+  labelConfirmed: false,
+  commentPosted: true,
+  labelAttempts: 3,
+  source: "scheduler",
+  lastTs: new Date(200_000).toISOString(),
+  ...over,
+});
+
+function mkPayload(tickets: BoardTicket[]): BoardPayload {
+  return {
+    generatedAt: "2026-08-05T00:00:00Z",
+    config: { maxParallel: 0, inFlight: 0, freeSlots: 0, active: 0, working: 0, stuck: 0 },
+    repos: ["catalyst"],
+    workers: [],
+    tickets,
+    queue: [],
+  };
+}
+
+describe("synthesizeDurableEscalations — the pure card builder", () => {
+  it("(a) a durable record with labelConfirmed:false and no existing card → attention card (Hole 1)", () => {
+    const cards = synthesizeDurableEscalations([durableRec()], new Set<string>(), 600_000);
+    expect(cards).toHaveLength(1);
+    expect(cards[0].id).toBe("CTL-9");
+    expect(cards[0].attention).toBe("needs-human");
+    // attentionSince anchored to the original escalatedAt (not lastTs / now).
+    expect(cards[0].attentionSince).toBe(new Date(100_000).toISOString());
+    // humanQuestion carries the escalation reason from the record.
+    expect(String(cards[0].humanQuestion)).toContain("Worker stuck");
+    // classifyTicket buckets it into the inbox "Needs you" section.
+    expect(classifyTicket(cards[0])).toBe("attention");
+    const model = deriveInbox(mkPayload(cards));
+    expect(model.counts.attention).toBe(1);
+    expect(model.counts.needsYou).toBe(1);
+    expect(model.sections.find((s) => s.kind === "attention")?.rows[0].id).toBe("CTL-9");
+  });
+
+  it("(b) a durable record with labelConfirmed:true surfaces identically to labelConfirmed:false", () => {
+    const cards = synthesizeDurableEscalations(
+      [durableRec({ ticket: "CTL-10", labelConfirmed: true })],
+      new Set<string>(),
+      600_000,
+    );
+    expect(cards).toHaveLength(1);
+    expect(cards[0].id).toBe("CTL-10");
+    expect(cards[0].attention).toBe("needs-human");
+    expect(classifyTicket(cards[0])).toBe("attention");
+  });
+
+  it("(c) a ticket already carded (worker-dir / parked / queued) is NOT duplicated", () => {
+    const cards = synthesizeDurableEscalations(
+      [durableRec()],
+      new Set(["CTL-9"]),
+      600_000,
+    );
+    expect(cards).toHaveLength(0);
+  });
+
+  it("dedupes a duplicate record in the input (one card per ticket id)", () => {
+    const cards = synthesizeDurableEscalations(
+      [durableRec(), durableRec()],
+      new Set<string>(),
+      600_000,
+    );
+    expect(cards).toHaveLength(1);
+  });
+
+  it("(d) terminal-aware: linfo carries Done linearState → NO card", () => {
+    const linfo: Record<string, { linearState?: string }> = {
+      "CTL-9": { linearState: "Done" },
+    };
+    const cards = synthesizeDurableEscalations(
+      [durableRec()],
+      new Set<string>(),
+      600_000,
+      {},
+      linfo,
+    );
+    expect(cards).toHaveLength(0);
+  });
+
+  it("terminal-aware: terminalIds Set excludes the ticket even without linfo", () => {
+    const cards = synthesizeDurableEscalations(
+      [durableRec()],
+      new Set<string>(),
+      600_000,
+      {},
+      {},
+      new Set(["CTL-9"]),
+    );
+    expect(cards).toHaveLength(0);
+  });
+
+  it("terminal-aware: Canceled linearState → NO card", () => {
+    const cards = synthesizeDurableEscalations(
+      [durableRec()],
+      new Set<string>(),
+      600_000,
+      {},
+      { "CTL-9": { linearState: "Canceled" } },
+    );
+    expect(cards).toHaveLength(0);
+  });
+
+  it("non-terminal linearState (Implement) → card is emitted", () => {
+    const cards = synthesizeDurableEscalations(
+      [durableRec()],
+      new Set<string>(),
+      600_000,
+      {},
+      { "CTL-9": { linearState: "Implement" } },
+    );
+    expect(cards).toHaveLength(1);
+  });
+
+  it("title resolution: replicaTitles > linfo > bare ticket id", () => {
+    const replica = synthesizeDurableEscalations(
+      [durableRec()],
+      new Set<string>(),
+      600_000,
+      { "CTL-9": "Replica title" },
+      { "CTL-9": { title: "Linfo title" } },
+    );
+    expect(replica[0].title).toBe("Replica title");
+
+    const linfoOnly = synthesizeDurableEscalations(
+      [durableRec()],
+      new Set<string>(),
+      600_000,
+      {},
+      { "CTL-9": { title: "Linfo title" } },
+    );
+    expect(linfoOnly[0].title).toBe("Linfo title");
+
+    const bareId = synthesizeDurableEscalations([durableRec()], new Set<string>(), 600_000);
+    expect(bareId[0].title).toBe("CTL-9");
+  });
+
+  it("card has the correct type, team, and repo fields", () => {
+    const cards = synthesizeDurableEscalations([durableRec()], new Set<string>(), 600_000);
+    expect(cards[0].type).toBe("durable-escalation");
+    expect(cards[0].team).toBe("CTL");
+    expect(classifyTicket(cards[0])).not.toBe("done");
+  });
+
+  it("existingIds may arrive as a plain array (also deduped)", () => {
+    const cards = synthesizeDurableEscalations([durableRec()], ["CTL-9"], 600_000);
+    expect(cards).toHaveLength(0);
+  });
+
+  it("empty / non-array records → [] (never throws)", () => {
+    expect(synthesizeDurableEscalations([], new Set<string>(), 600_000)).toHaveLength(0);
+    expect(synthesizeDurableEscalations(null, new Set<string>(), 600_000)).toHaveLength(0);
+    expect(
+      synthesizeDurableEscalations(undefined, new Set<string>(), 600_000),
+    ).toHaveLength(0);
+  });
+
+  it("malformed record without ticket field is skipped (never throws)", () => {
+    const cards = synthesizeDurableEscalations(
+      [{ reason: "bad", escalatedAt: "t" }],
+      new Set<string>(),
+      600_000,
+    );
+    expect(cards).toHaveLength(0);
+  });
+});
+
+// ── Static wiring guard ───────────────────────────────────────────────────────
+describe("assembleBoard wiring — durable escalation cards", () => {
+  it("board-data.mjs exports synthesizeDurableEscalations", () => {
+    expect(boardDataSrc).toContain("export function synthesizeDurableEscalations");
+  });
+
+  it("board-data.mjs imports readDurableEscalations from durable-escalation.mjs", () => {
+    expect(boardDataSrc).toContain("readDurableEscalations");
+    expect(boardDataSrc).toContain("durable-escalation.mjs");
+  });
+
+  it("assembleBoard calls synthesizeDurableEscalations and spreads the result", () => {
+    const nospace = (s: string) => s.replace(/\s+/g, "");
+    expect(nospace(boardDataSrc)).toContain(nospace("synthesizeDurableEscalations("));
+    expect(boardDataSrc).toContain("...durableTickets");
+  });
+});

--- a/plugins/dev/scripts/orch-monitor/lib/board-data.mjs
+++ b/plugins/dev/scripts/orch-monitor/lib/board-data.mjs
@@ -56,6 +56,7 @@ import { getEventLogPath } from "../../execution-core/config.mjs";
 // bun:sqlite/pino edge, so this import is graph-safe.
 import { recordFullRead, scanFileLines } from "./event-log-reader.ts"; // CTL-1529: bounded chunked scan
 import { isLinearTerminal } from "../../execution-core/terminal-state.mjs";
+import { readDurableEscalations } from "../../execution-core/durable-escalation.mjs"; // CTL-1643: GC-surviving escalation store
 import { readClusterProjects } from "./cluster-roster.ts";
 
 const execFileP = promisify(execFile);
@@ -1523,6 +1524,93 @@ export function synthesizeParkedNeedsHumanTickets(
   return cards;
 }
 
+// synthesizeDurableEscalations — CTL-1643: surface durable escalation records on
+// the board even when the worker dir has been GC'd (Hole 2) and even when the
+// needs-human label never confirmed in Linear (Hole 1). Mirrors the parked-synthesis
+// pattern: one attention card per durable record, deduped against every existing
+// card id. Terminal-aware: tickets at Done/Canceled are excluded via `linfo`
+// (linearState) or an explicit `terminalIds` Set injected by the caller. The
+// `reason` and `escalatedAt` come directly from the durable record — the board
+// always shows the original escalation reason and timestamp, even through retries.
+// Exported so unit tests can exercise it without the filesystem read.
+export function synthesizeDurableEscalations(
+  records,
+  existingIds,
+  now,
+  replicaTitles = {},
+  linfo = {},
+  terminalIds = new Set(),
+) {
+  if (!Array.isArray(records)) return [];
+  const seen = existingIds instanceof Set ? new Set(existingIds) : new Set(existingIds ?? []);
+  const terminal = terminalIds instanceof Set ? terminalIds : new Set();
+  const cards = [];
+  for (const rec of records) {
+    if (!rec || !rec.ticket) continue;
+    if (seen.has(rec.ticket)) continue;
+    // Terminal-aware: skip tickets already at Done/Canceled in Linear.
+    if (terminal.has(rec.ticket) || isLinearTerminal(linfo?.[rec.ticket]?.linearState)) continue;
+    seen.add(rec.ticket);
+    const replicaTitle =
+      typeof replicaTitles?.[rec.ticket] === "string" && replicaTitles[rec.ticket].length > 0
+        ? replicaTitles[rec.ticket]
+        : null;
+    const linfoTitle =
+      typeof linfo?.[rec.ticket]?.title === "string" && linfo[rec.ticket].title.length > 0
+        ? linfo[rec.ticket].title
+        : null;
+    cards.push({
+      id: rec.ticket,
+      title: replicaTitle || linfoTitle || rec.ticket,
+      type: "durable-escalation",
+      repo: repoFor(rec.ticket),
+      team: teamFor(rec.ticket),
+      phase: "queued",
+      status: "parked",
+      model: null,
+      linearState: typeof linfo?.[rec.ticket]?.linearState === "string"
+        ? linfo[rec.ticket].linearState
+        : "",
+      workerStatus: null,
+      activeState: null,
+      working: false,
+      lastActiveMs: null,
+      priority: typeof linfo?.[rec.ticket]?.priority === "number"
+        ? linfo[rec.ticket].priority
+        : 0,
+      estimate: null,
+      scope: null,
+      project: null,
+      held: null,
+      labels: [],
+      heldSince: null,
+      currentPhaseSince: null,
+      attention: "needs-human",
+      // attentionSince is anchored to the ORIGINAL escalatedAt — preserved through
+      // retry ticks so the operator sees "how long has it needed you" from the first
+      // escalation, not the most recent label-retry attempt.
+      attentionSince: rec.escalatedAt ?? null,
+      humanQuestion: typeof rec.reason === "string" ? rec.reason : "Escalated for a human.",
+      explanation: null,
+      pr: null,
+      prUrl: null,
+      mergeStateStatus: null,
+      prStuckReason: null,
+      costUSD: null,
+      tokens: null,
+      turns: null,
+      phaseCosts: null,
+      phaseSummary: [],
+      blockers: [],
+      updatedAt: rec.lastTs ?? new Date(now).toISOString(),
+      host: null,
+      generation: null,
+      failureReason: null,
+    });
+  }
+  return cards;
+}
+
 // ── Linear enrichment: priority / estimate / project / labels / relations /
 // assignee, read EXCLUSIVELY from the broker's durable caches (CTL-883).
 //
@@ -2264,6 +2352,26 @@ export async function assembleBoard({ getPrStatus = null, ring = null } = {}) {
     linfo
   );
   tickets = [...tickets, ...parkedTickets];
+
+  // CTL-1643: durable escalation cards. Read the GC-surviving per-ticket
+  // escalation records written by the scheduler's escalateOnce (even when the
+  // worker dir was torn down by J4 and even when the needs-human label never
+  // confirmed in Linear). Deduped against every existing card id (now including
+  // the parked set); terminal/Done/Canceled tickets excluded by isLinearTerminal.
+  const terminalLinearIds = new Set(
+    Object.keys(linfo).filter((id) => isLinearTerminal(linfo[id]?.linearState))
+  );
+  const durableEscalationRecords = readDurableEscalations(EC);
+  const durableCardIds = new Set(tickets.map((t) => t.id));
+  const durableTickets = synthesizeDurableEscalations(
+    durableEscalationRecords,
+    durableCardIds,
+    now,
+    replicaTitles,
+    linfo,
+    terminalLinearIds,
+  );
+  tickets = [...tickets, ...durableTickets];
 
   // CTL-1588: annotate-not-hide. A parked needs-human/needs-input ticket can
   // still be Todo in Linear (so it sits in the eligible projection) while the


### PR DESCRIPTION
<!-- Auto-generated: 2026-08-05T05:52:00Z -->
<!-- Last updated: 2026-08-05T05:52:00Z -->
<!-- PR: #3009 -->
<!-- Previous commits: 57a3824234486fe053e732e6b8ee6d7418507380 -->

## Summary

Closes two escalation durability holes that left operators without a visible Needs-You card after a ticket was escalated:

- **Hole 1 (verified-or-loud label)**: `escalateOnce` in `recovery.mjs` wrote the 10-min cooldown marker unconditionally after `applyStalledLabel`, even on a transient 429 — suppressing the retry that would have landed the label. Now gates the cooldown on a confirmed apply, unrecoverable skip-marker, or `LABEL_CONFIRM_CAP` (default 5) transient attempts. At the cap, emits a loud `escalation.label-unconfirmed.<ticket>` event so the operator knows the label failed to land. A same-episode gate suppresses re-fires within a transient episode.

- **Hole 2 (GC-surviving attention store)**: The board derived escalation cards from worker signal files and filesystem markers — both GC'd by stall-janitor J4 once a ticket goes terminal. New `durable-escalation.mjs` leaf module writes per-ticket records to `<orchDir>/.escalations/<T>.json` (survives J4). New `synthesizeDurableEscalations` in `board-data.mjs` surfaces these as Needs-You attention cards, terminal-aware and deduped. Resolution cleanup in J4 GC and `handleCommentWake` calls `forgetDurableEscalation` so the store stays bounded.

## Files changed

- **NEW** `execution-core/durable-escalation.mjs` — GC-surviving per-ticket escalation store (3 exports: record/read/forget)
- **NEW** `execution-core/durable-escalation.test.mjs` — 13 tests
- **MOD** `execution-core/label-guard.mjs` — `LABEL_CONFIRM_CAP` constant
- **MOD** `execution-core/recovery.mjs` — `escalateOnce` verified-or-loud gate + durable persistence
- **MOD** `execution-core/scheduler.mjs` — `defaultClearStall` clears durable record on re-arm
- **MOD** `execution-core/stall-janitor.mjs` — J4 `defaultGcTerminalSignals` calls `forgetDurableEscalation`
- **MOD** `execution-core/daemon.mjs` — `handleCommentWake` needs-human clear calls `forgetDurableEscalation`
- **MOD** `orch-monitor/lib/board-data.mjs` — `synthesizeDurableEscalations` + wiring in `assembleBoard`
- **NEW** `orch-monitor/__tests__/board-durable-escalations.test.ts` — 16 tests
- **MOD** `execution-core/recovery.test.mjs` — 8 new CTL-1643 tests
- **MOD** `execution-core/stall-janitor.test.mjs` — 1 new J4+durable test
- **MOD** `execution-core/daemon.test.mjs` — 1 new handleCommentWake+durable test

## Test plan

- [x] `bun test plugins/dev/scripts/execution-core/durable-escalation.test.mjs` — 13 pass ✅
- [x] `bun test plugins/dev/scripts/execution-core/recovery.test.mjs` — 313 pass, 3 pre-existing fail (identical baseline on main) ✅
- [x] `bun test plugins/dev/scripts/execution-core/label-guard.test.mjs` — pass ✅
- [x] `bun test plugins/dev/scripts/execution-core/stall-janitor.test.mjs` — 94 pass ✅
- [x] `bun test plugins/dev/scripts/execution-core/daemon.test.mjs` — 159 pass, 1 pre-existing fail ✅
- [x] `bun test plugins/dev/scripts/orch-monitor/__tests__/board-durable-escalations.test.ts` — 16 pass ✅

## Related Issues/PRs

- Fixes https://linear.app/coalesce-labs/issue/CTL-1643