### PR TITLE
feat(dev): CTL-1653 accounts-probe lib (probe runner + async TTL cache)

### DIFF
--- a/plugins/dev/scripts/orch-monitor/__tests__/accounts-endpoint.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/accounts-endpoint.test.ts
@@ -97,6 +97,43 @@ describe("/api/accounts", () => {
     await fetch(`${base}/api/accounts?refresh=true`);
     expect(calls).toBe(before + 1);
   });
+  it("?refresh=true from an untrusted cross-origin caller is rejected (403), no probe spent", async () => {
+    const before = calls;
+    const r = await fetch(`${base}/api/accounts?refresh=true`, {
+      headers: { Origin: "http://evil.example:1234" },
+    });
+    expect(r.status).toBe(403);
+    expect(calls).toBe(before); // no probe spawned
+  });
+  it("a plain (non-refresh) read is unaffected by a cross-origin caller", async () => {
+    const r = await fetch(`${base}/api/accounts`, {
+      headers: { Origin: "http://evil.example:1234" },
+    });
+    expect(r.status).toBe(200);
+  });
+});
+
+describe("/api/accounts when the accounts env file is absent", () => {
+  it("returns available:false (same contract as the disabled path), not available:true+status:unknown", async () => {
+    const { tmpDir, wtDir } = mkWtDir("accounts-endpoint-no-env-");
+    const s = createServer({
+      port: 0,
+      wtDir,
+      startWatcher: false,
+      // Mirrors defaultAccountsProbeExec's own no-env-file record.
+      accountsProbeExec: () =>
+        Promise.resolve({ generatedAt: new Date().toISOString(), accounts: [], available: false }),
+    });
+    const b = (await (await fetch(`http://localhost:${s.port}/api/accounts`)).json()) as AccountsBody;
+    expect(b.available).toBe(false);
+    expect(b.status).toBeUndefined();
+    void s.stop(true);
+    try {
+      rmSync(tmpDir, { recursive: true, force: true });
+    } catch {
+      /* ignore */
+    }
+  });
 });
 
 describe("/api/accounts/stream", () => {

--- a/plugins/dev/scripts/orch-monitor/__tests__/accounts-endpoint.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/accounts-endpoint.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect, beforeAll, afterAll } from "bun:test";
+import { mkdtempSync, mkdirSync, rmSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { createServer } from "../server";
+
+const FAKE = {
+  generatedAt: "2026-08-05T12:00:00.000Z",
+  accounts: [
+    {
+      label: "acctA",
+      isActive: true,
+      email: "a@x.io",
+      overallStatus: "rejected",
+      representativeClaim: "seven_day",
+      fiveHour: { pct: 40, resetsAt: "2026-08-05T13:00:00.000Z", status: "allowed" },
+      sevenDay: { pct: 100, resetsAt: "2026-08-06T00:00:00.000Z", status: "rejected" },
+      error: null,
+      token: "sk-ant-oat-SHOULD-NOT-APPEAR",
+    },
+  ],
+};
+
+// Minimal shape of the /api/accounts response body (token-free by construction).
+interface AccountsBody {
+  available?: boolean;
+  node?: string;
+  status?: string;
+  cached?: boolean;
+  active?: {
+    label?: string;
+    email?: string;
+    fiveHour?: { pct?: number };
+    sevenDay?: { status?: string };
+  };
+}
+
+function mkWtDir(prefix: string): { tmpDir: string; wtDir: string } {
+  const tmpDir = mkdtempSync(join(tmpdir(), prefix));
+  const wtDir = join(tmpDir, "wt");
+  mkdirSync(wtDir, { recursive: true });
+  return { tmpDir, wtDir };
+}
+
+describe("/api/accounts", () => {
+  let server: ReturnType<typeof createServer>;
+  let tmpDir = "";
+  let base = "";
+  let calls = 0;
+  beforeAll(() => {
+    const dirs = mkWtDir("accounts-endpoint-");
+    tmpDir = dirs.tmpDir;
+    server = createServer({
+      port: 0,
+      wtDir: dirs.wtDir,
+      startWatcher: false,
+      accountsProbeExec: () => {
+        calls += 1;
+        return Promise.resolve(FAKE);
+      },
+    });
+    base = `http://localhost:${server.port}`;
+  });
+  afterAll(() => {
+    void server.stop(true);
+    try {
+      rmSync(tmpDir, { recursive: true, force: true });
+    } catch {
+      /* ignore */
+    }
+  });
+
+  it("returns node identity, active account, per-window data, overall status; NO token", async () => {
+    const r = await fetch(`${base}/api/accounts`);
+    const b = (await r.json()) as AccountsBody;
+    expect(r.status).toBe(200);
+    expect(typeof b.node).toBe("string");
+    expect(b.active?.label).toBe("acctA");
+    expect(b.active?.email).toBe("a@x.io");
+    expect(b.active?.fiveHour?.pct).toBe(40);
+    expect(b.active?.sevenDay?.status).toBe("rejected");
+    expect(b.status).toBe("rejected");
+    expect(JSON.stringify(b)).not.toContain("sk-ant-oat");
+  });
+  it("serves cache on a second call within TTL (no new probe)", async () => {
+    const before = calls;
+    await fetch(`${base}/api/accounts`);
+    expect(calls).toBe(before); // cached, no probe spent
+    const b = (await (await fetch(`${base}/api/accounts`)).json()) as AccountsBody;
+    expect(b.cached).toBe(true);
+  });
+  it("?refresh=true forces a new probe", async () => {
+    const before = calls;
+    await fetch(`${base}/api/accounts?refresh=true`);
+    expect(calls).toBe(before + 1);
+  });
+});
+
+describe("/api/accounts disabled (accountsProbeExec:null)", () => {
+  it("returns available:false, never spawns", async () => {
+    const { tmpDir, wtDir } = mkWtDir("accounts-endpoint-disabled-");
+    const s = createServer({ port: 0, wtDir, startWatcher: false, accountsProbeExec: null });
+    const b = (await (
+      await fetch(`http://localhost:${s.port}/api/accounts`)
+    ).json()) as AccountsBody;
+    expect(b.available).toBe(false);
+    void s.stop(true);
+    try {
+      rmSync(tmpDir, { recursive: true, force: true });
+    } catch {
+      /* ignore */
+    }
+  });
+});

--- a/plugins/dev/scripts/orch-monitor/__tests__/accounts-endpoint.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/accounts-endpoint.test.ts
@@ -54,6 +54,9 @@ describe("/api/accounts", () => {
       port: 0,
       wtDir: dirs.wtDir,
       startWatcher: false,
+      // Disable the refresh floor so the ?refresh assertion exercises the route,
+      // not the DoS throttle (the floor has its own unit tests in accounts-probe).
+      accountsRefreshFloorMs: 0,
       accountsProbeExec: () => {
         calls += 1;
         return Promise.resolve(FAKE);

--- a/plugins/dev/scripts/orch-monitor/__tests__/accounts-endpoint.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/accounts-endpoint.test.ts
@@ -96,6 +96,34 @@ describe("/api/accounts", () => {
   });
 });
 
+describe("/api/accounts/stream", () => {
+  it("emits an 'account' framed SSE event on connect", async () => {
+    const { tmpDir, wtDir } = mkWtDir("accounts-stream-");
+    const s = createServer({
+      port: 0,
+      wtDir,
+      startWatcher: false,
+      accountsProbeExec: () => Promise.resolve(FAKE),
+      accountsTtlMs: 10,
+    });
+    const res = await fetch(`http://localhost:${s.port}/api/accounts/stream`, {
+      headers: { Accept: "text/event-stream" },
+    });
+    const reader = res.body!.getReader();
+    const { value } = await reader.read();
+    const text = new TextDecoder().decode(value);
+    expect(text).toContain("event: account");
+    expect(text).toContain('"status"');
+    await reader.cancel();
+    void s.stop(true);
+    try {
+      rmSync(tmpDir, { recursive: true, force: true });
+    } catch {
+      /* ignore */
+    }
+  });
+});
+
 describe("/api/accounts disabled (accountsProbeExec:null)", () => {
   it("returns available:false, never spawns", async () => {
     const { tmpDir, wtDir } = mkWtDir("accounts-endpoint-disabled-");

--- a/plugins/dev/scripts/orch-monitor/__tests__/server.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/server.test.ts
@@ -2194,7 +2194,7 @@ describe("publicDir resolution", () => {
 // themselves are the two lines added alongside `stopped` in server.ts and
 // are covered by direct code inspection + this flag test, not a live mint.
 describe("server.stop() lifecycle flag (CTL-1612 post-merge #2978)", () => {
-  it("stopped starts false, flips true synchronously on stop(), and stays true", async () => {
+  it("stopped starts false, flips true synchronously on stop(), and stays true", () => {
     const stopTmp = mkdtempSync(join(tmpdir(), "orch-monitor-stopflag-"));
     const stopWt = join(stopTmp, "wt");
     mkdirSync(stopWt, { recursive: true });

--- a/plugins/dev/scripts/orch-monitor/cli/__tests__/account-strip.test.ts
+++ b/plugins/dev/scripts/orch-monitor/cli/__tests__/account-strip.test.ts
@@ -1,0 +1,34 @@
+import { test, expect } from "bun:test";
+import { accountStripText, accountOverlayLines } from "../components/account-strip";
+import type { AccountStripSignal } from "../components/account-strip";
+
+test("strip shows active handle + binding pct, quiet color when ok", () => {
+  const s = accountStripText({
+    status: "ok",
+    active: { label: "acctA", bindingWindow: "five_hour", fiveHour: { pct: 12 } },
+  } as AccountStripSignal);
+  expect(s.text).toContain("acctA");
+  expect(s.text).toContain("12%");
+  expect(s.inverse).toBe(false);
+});
+test("strip goes inverse (loud) when active binding rejected", () => {
+  const s = accountStripText({
+    status: "rejected",
+    active: { label: "acctA", bindingWindow: "seven_day", sevenDay: { pct: 100 } },
+  } as AccountStripSignal);
+  expect(s.inverse).toBe(true);
+});
+test("overlay lines name reset + sibling when rejected; empty when ok", () => {
+  expect(accountOverlayLines({ status: "ok" } as AccountStripSignal)).toEqual([]);
+  const lines = accountOverlayLines({
+    status: "rejected",
+    active: {
+      label: "acctA",
+      sevenDay: { resetsAt: "2026-08-06T00:00:00.000Z" },
+      bindingWindow: "seven_day",
+    },
+    siblingWithHeadroom: { label: "acctB" },
+  } as AccountStripSignal);
+  expect(lines.join(" ")).toContain("acctB");
+  expect(lines.join(" ")).toContain("2026-08-06");
+});

--- a/plugins/dev/scripts/orch-monitor/cli/components/account-strip.ts
+++ b/plugins/dev/scripts/orch-monitor/cli/components/account-strip.ts
@@ -1,0 +1,98 @@
+// account-strip.ts — CTL-1653. The HUD sibling of the web account
+// indicator/banner (ui/src/hooks/account-signal-lib.ts). Pure Ink text builders:
+// a quiet-while-ok one-row strip + a loud round-border overlay when the active
+// binding window is `rejected`.
+//
+// MIRROR, not import: the cli bundle never reaches into ui/src (each surface —
+// server lib, web ui, cli hud — keeps its own hand-synced copy of the shape +
+// vocabulary, exactly as cli/lib mirrors server shapes and ui/src/lib/cluster-
+// signal.ts mirrors lib/cluster-signal.mjs). The status→tone semantics here are
+// byte-for-byte the same vocabulary as account-signal-lib.ts; keep them in sync.
+//
+// error ≠ rejected: a transport `error` is the sensor being broken (dim, never
+// inverse); only `rejected` (account exhausted) goes loud (inverse strip + overlay).
+
+/** One rate-limit window (token-free). */
+export interface AccountStripWindow {
+  pct?: number;
+  resetsAt?: string | null;
+}
+
+/** The minimal AccountSignal shape the HUD strip needs (mirror of AccountSignal). */
+export interface AccountStripSignal {
+  status: string;
+  active?: {
+    label?: string | null;
+    bindingWindow?: string | null;
+    fiveHour?: AccountStripWindow | null;
+    sevenDay?: AccountStripWindow | null;
+    error?: string | null;
+  } | null;
+  siblingWithHeadroom?: { label?: string | null } | null;
+}
+
+/** Short label for a binding window (five_hour → "5h", seven_day → "7d"). */
+function bindingWindowShort(bindingWindow?: string | null): string {
+  if (bindingWindow === "five_hour") return "5h";
+  if (bindingWindow === "seven_day") return "7d";
+  return "";
+}
+
+/** The window the binding claim points at (five_hour → active.fiveHour). */
+function bindingWindowOf(active: AccountStripSignal["active"]): AccountStripWindow | null {
+  if (!active) return null;
+  if (active.bindingWindow === "five_hour") return active.fiveHour ?? null;
+  if (active.bindingWindow === "seven_day") return active.sevenDay ?? null;
+  return null;
+}
+
+/**
+ * accountStripText — the compact one-row strip. Quiet (gray) while ok/unknown,
+ * yellow while degraded, dim while error, and INVERSE red while rejected (the
+ * `header-chips.ts` inverse idiom). Names the active handle + binding-window pct.
+ */
+export function accountStripText(signal: AccountStripSignal | null | undefined): {
+  text: string;
+  color: string;
+  inverse: boolean;
+} {
+  if (!signal) return { text: "account —", color: "gray", inverse: false };
+  const active = signal.active;
+  const status = signal.status;
+
+  if (!active || (!active.label && status === "unknown")) {
+    return { text: "acct: none", color: "gray", inverse: false };
+  }
+  if (status === "error") {
+    return { text: `acct ${active.label ?? "?"}: error`, color: "gray", inverse: false };
+  }
+  const win = bindingWindowShort(active.bindingWindow);
+  const w = bindingWindowOf(active);
+  const pct = typeof w?.pct === "number" ? `${w.pct}%` : "";
+  const suffix = [win, pct].filter(Boolean).join(" ");
+  const text = `acct ${active.label ?? "?"}${suffix ? ` · ${suffix}` : ""}`;
+
+  if (status === "rejected") return { text, color: "red", inverse: true };
+  if (status === "degraded") return { text, color: "yellow", inverse: false };
+  return { text, color: "gray", inverse: false }; // ok / anything quiet
+}
+
+/**
+ * accountOverlayLines — the loud round-border overlay lines. Empty unless the
+ * active binding window is `rejected`; otherwise the exhausted / reset / sibling
+ * lines naming the reset time + a sibling account with headroom.
+ */
+export function accountOverlayLines(signal: AccountStripSignal | null | undefined): string[] {
+  if (!signal || signal.status !== "rejected") return [];
+  const active = signal.active ?? null;
+  const who = active?.label ?? "the active account";
+  const w = bindingWindowOf(active);
+  // ISO date portion (YYYY-MM-DD) — deterministic + locale-free for the TUI.
+  const resetsAt = w?.resetsAt ?? null;
+  const resetLabel = resetsAt ? resetsAt.slice(0, 16).replace("T", " ") : "an unknown time";
+  const lines = [`Claude account ${who} is out of budget.`, `Resets ${resetLabel}.`];
+  if (signal.siblingWithHeadroom?.label) {
+    lines.push(`Switch to ${signal.siblingWithHeadroom.label} (has headroom).`);
+  }
+  return lines;
+}

--- a/plugins/dev/scripts/orch-monitor/cli/hooks/useAccountModel.ts
+++ b/plugins/dev/scripts/orch-monitor/cli/hooks/useAccountModel.ts
@@ -2,7 +2,13 @@
 // posture over the LOCAL monitor's `/api/accounts/stream` SSE. Unlike the read
 // model (which may point at a remote replica), account posture is inherently
 // per-node/local, so this always targets the local monitor
-// (CATALYST_MONITOR_URL, else http://127.0.0.1:<MONITOR_PORT|7400>).
+// (ACCOUNT_MONITOR_URL, else http://127.0.0.1:<MONITOR_PORT|7400>).
+//
+// Deliberately does NOT read CATALYST_MONITOR_URL: read-model-url.ts documents
+// that override as the first-precedence base for a developer node reading a
+// WORKER's remote monitor for board data. Honoring it here too would stream the
+// REMOTE worker's account posture under this (local) node's strip/banner —
+// account posture is node-scoped, so it needs its own, distinct escape hatch.
 //
 // Uses the HUD's dependency-free createNodeEventSource (no browser EventSource in
 // bun). createNodeEventSource is a ONE-SHOT reader (reconnect policy is the hook's
@@ -20,7 +26,7 @@ const MAX_BACKOFF_MS = 15_000;
 
 /** Resolve the LOCAL monitor base URL (no path). */
 function localMonitorBase(env: Record<string, string | undefined>): string {
-  const explicit = env.CATALYST_MONITOR_URL?.trim().replace(/\/+$/, "");
+  const explicit = env.ACCOUNT_MONITOR_URL?.trim().replace(/\/+$/, "");
   if (explicit) return explicit;
   const parsed = parseInt(env.MONITOR_PORT ?? "", 10);
   const port = Number.isFinite(parsed) && parsed > 0 ? parsed : DEFAULT_MONITOR_PORT;

--- a/plugins/dev/scripts/orch-monitor/cli/hooks/useAccountModel.ts
+++ b/plugins/dev/scripts/orch-monitor/cli/hooks/useAccountModel.ts
@@ -1,0 +1,80 @@
+// useAccountModel.ts — CTL-1653. Subscribe the HUD to THIS node's Claude-account
+// posture over the LOCAL monitor's `/api/accounts/stream` SSE. Unlike the read
+// model (which may point at a remote replica), account posture is inherently
+// per-node/local, so this always targets the local monitor
+// (CATALYST_MONITOR_URL, else http://127.0.0.1:<MONITOR_PORT|7400>).
+//
+// Uses the HUD's dependency-free createNodeEventSource (no browser EventSource in
+// bun). Never throws: any connection error just leaves the last posture (or null).
+
+import { useEffect, useState } from "react";
+import { createNodeEventSource } from "../lib/node-event-source";
+import { DEFAULT_MONITOR_PORT } from "../lib/read-model-url";
+import type { AccountStripSignal } from "../components/account-strip";
+
+/** Resolve the LOCAL monitor base URL (no path). */
+function localMonitorBase(env: Record<string, string | undefined>): string {
+  const explicit = env.CATALYST_MONITOR_URL?.trim().replace(/\/+$/, "");
+  if (explicit) return explicit;
+  const parsed = parseInt(env.MONITOR_PORT ?? "", 10);
+  const port = Number.isFinite(parsed) && parsed > 0 ? parsed : DEFAULT_MONITOR_PORT;
+  return `http://127.0.0.1:${port}`;
+}
+
+/** Decode an `account` SSE frame; null on garbage or a non-posture (available:false) frame. */
+function decodeAccountFrame(data: string): AccountStripSignal | null {
+  try {
+    const parsed: unknown = JSON.parse(data);
+    if (!parsed || typeof parsed !== "object") return null;
+    const p = parsed as Record<string, unknown>;
+    if (typeof p.status !== "string") return null; // e.g. {available:false} → no posture
+    return p as unknown as AccountStripSignal;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Subscribe to the local account-posture stream for the calling component's
+ * lifetime. Returns the latest posture (null until the first frame lands / when
+ * the endpoint is unavailable).
+ */
+export function useAccountModel(): AccountStripSignal | null {
+  const [signal, setSignal] = useState<AccountStripSignal | null>(null);
+
+  useEffect(() => {
+    let alive = true;
+    const base = localMonitorBase(process.env);
+
+    // Snapshot on mount so the strip populates immediately, not only on the next
+    // stream frame. Best-effort — a failure just waits for the stream.
+    void (async () => {
+      try {
+        const r = await fetch(`${base}/api/accounts`);
+        if (r.ok && alive) {
+          const body: unknown = await r.json();
+          const s = decodeAccountFrame(JSON.stringify(body));
+          if (s && alive) setSignal(s);
+        }
+      } catch {
+        /* offline — the stream (or a later snapshot) will populate it */
+      }
+    })();
+
+    const es = createNodeEventSource(`${base}/api/accounts/stream`);
+    es.addEventListener("account", (ev) => {
+      const next = decodeAccountFrame(ev.data);
+      if (next && alive) setSignal(next);
+    });
+    es.onerror = () => {
+      /* read-model/monitor unavailable — keep the last posture, no crash */
+    };
+
+    return () => {
+      alive = false;
+      es.close();
+    };
+  }, []);
+
+  return signal;
+}

--- a/plugins/dev/scripts/orch-monitor/cli/hooks/useAccountModel.ts
+++ b/plugins/dev/scripts/orch-monitor/cli/hooks/useAccountModel.ts
@@ -5,12 +5,18 @@
 // (CATALYST_MONITOR_URL, else http://127.0.0.1:<MONITOR_PORT|7400>).
 //
 // Uses the HUD's dependency-free createNodeEventSource (no browser EventSource in
-// bun). Never throws: any connection error just leaves the last posture (or null).
+// bun). createNodeEventSource is a ONE-SHOT reader (reconnect policy is the hook's
+// job), so this hook owns capped-backoff reconnect + a snapshot reconcile — without
+// it the strip would freeze on its last value forever the first time the local
+// monitor restarts or the stream drops. Never throws.
 
 import { useEffect, useState } from "react";
-import { createNodeEventSource } from "../lib/node-event-source";
+import { createNodeEventSource, type NodeEventSource } from "../lib/node-event-source";
 import { DEFAULT_MONITOR_PORT } from "../lib/read-model-url";
 import type { AccountStripSignal } from "../components/account-strip";
+
+const INITIAL_BACKOFF_MS = 500;
+const MAX_BACKOFF_MS = 15_000;
 
 /** Resolve the LOCAL monitor base URL (no path). */
 function localMonitorBase(env: Record<string, string | undefined>): string {
@@ -45,10 +51,13 @@ export function useAccountModel(): AccountStripSignal | null {
   useEffect(() => {
     let alive = true;
     const base = localMonitorBase(process.env);
+    let es: NodeEventSource | null = null;
+    let backoff = INITIAL_BACKOFF_MS;
+    let reconnectTimer: ReturnType<typeof setTimeout> | undefined;
 
-    // Snapshot on mount so the strip populates immediately, not only on the next
-    // stream frame. Best-effort — a failure just waits for the stream.
-    void (async () => {
+    // Snapshot from /api/accounts so the strip populates immediately (and re-seeds
+    // after a drop), not only on the next stream frame. Best-effort.
+    const reconcile = async () => {
       try {
         const r = await fetch(`${base}/api/accounts`);
         if (r.ok && alive) {
@@ -59,20 +68,56 @@ export function useAccountModel(): AccountStripSignal | null {
       } catch {
         /* offline — the stream (or a later snapshot) will populate it */
       }
-    })();
-
-    const es = createNodeEventSource(`${base}/api/accounts/stream`);
-    es.addEventListener("account", (ev) => {
-      const next = decodeAccountFrame(ev.data);
-      if (next && alive) setSignal(next);
-    });
-    es.onerror = () => {
-      /* read-model/monitor unavailable — keep the last posture, no crash */
     };
+
+    const scheduleReconnect = () => {
+      if (!alive) return;
+      const delay = backoff;
+      backoff = Math.min(MAX_BACKOFF_MS, backoff * 2);
+      reconnectTimer = setTimeout(connect, delay);
+      void reconcile();
+    };
+
+    function connect() {
+      if (!alive) return;
+      let src: NodeEventSource;
+      try {
+        src = createNodeEventSource(`${base}/api/accounts/stream`);
+      } catch {
+        scheduleReconnect();
+        return;
+      }
+      es = src;
+      src.addEventListener("account", (ev) => {
+        backoff = INITIAL_BACKOFF_MS; // reset on a real frame
+        const next = decodeAccountFrame(ev.data);
+        if (next && alive) setSignal(next);
+      });
+      src.onerror = () => {
+        // One-shot reader errored (monitor restart / stream drop) — close and
+        // reconnect with capped backoff so the strip resumes updating.
+        try {
+          src.close();
+        } catch {
+          /* noop */
+        }
+        if (es === src) es = null;
+        scheduleReconnect();
+      };
+    }
+
+    void reconcile();
+    connect();
 
     return () => {
       alive = false;
-      es.close();
+      clearTimeout(reconnectTimer);
+      try {
+        es?.close();
+      } catch {
+        /* noop */
+      }
+      es = null;
     };
   }, []);
 

--- a/plugins/dev/scripts/orch-monitor/cli/hud.tsx
+++ b/plugins/dev/scripts/orch-monitor/cli/hud.tsx
@@ -55,6 +55,9 @@ import { localHostRef } from "./lib/read-model-cluster.ts";
 // the HUD falls back to its raw `workers/*.json` scan, so it never goes dark.
 import { useReadModel } from "./hooks/useReadModel.ts";
 import { boardWorkersToSignals } from "./lib/read-model-workers.ts";
+// CTL-1653: THIS node's Claude-account posture strip + loud overlay.
+import { useAccountModel } from "./hooks/useAccountModel.ts";
+import { accountStripText, accountOverlayLines } from "./components/account-strip.ts";
 import type { WorkerSignal } from "./lib/worker-signals-reader.ts";
 
 interface AppProps {
@@ -195,6 +198,15 @@ function App({ repoFilter, predicate, sinceTs: initSinceTs }: AppProps) {
   // the SSE/fetch client path the HUD never had — and consumes the EXACT stream
   // the web/iPad consume, so a fix to the BFF assembly reaches all three readers.
   const readModel = useReadModel();
+  // CTL-1653: this node's Claude-account posture (quiet strip + loud overlay).
+  const accountSig = useAccountModel();
+  const accountStrip = accountStripText(accountSig);
+  const accountOverlay = accountOverlayLines(accountSig);
+  // The always-present strip is 1 row; a rejected-account overlay adds its lines
+  // plus the round border (top+bottom). Folded into chromeRows so the event list
+  // height stays correct.
+  const accountOverlayHeight = accountOverlay.length > 0 ? accountOverlay.length + 2 : 0;
+  const accountChromeRows = 1 + accountOverlayHeight;
   // Map the assembled BoardWorker[] onto the Dashboard's WorkerSignal rows when
   // connected; null tells the Dashboard to use its raw `workers/*.json` scan.
   const readModelWorkers = useMemo<WorkerSignal[] | null>(
@@ -261,7 +273,8 @@ function App({ repoFilter, predicate, sinceTs: initSinceTs }: AppProps) {
   // chrome = header + prompt-box(3 rows: top-border + content + bottom-border) + status-line(1) + dsl overlay (if any).
   // CTL-386: replaced separator(1) + filter(1) + query(1) with a single rounded PromptInput box(3).
   // CTL-417: split PromptInput into input-row(3) + status-row(1) = 4 rows total.
-  const chromeRows = headerRows + 4 + overlayHeight;
+  // CTL-1653: + the account strip (1 row) + its overlay when the account is rejected.
+  const chromeRows = headerRows + 4 + overlayHeight + accountChromeRows;
   const visibleRows = Math.max(1, layoutRows - chromeRows);
 
   const {
@@ -610,6 +623,23 @@ function App({ repoFilter, predicate, sinceTs: initSinceTs }: AppProps) {
           ))}
         </Box>
       )}
+      {/* CTL-1653: loud round-border overlay when the active account is exhausted
+          (rejected) — names the reset time + a sibling with headroom. */}
+      {accountOverlay.length > 0 && (
+        <Box flexShrink={0} flexDirection="column" borderStyle="round" borderColor="red" paddingX={1}>
+          {accountOverlay.map((line, i) => (
+            <Text key={i} color="red" bold={i === 0}>
+              {line}
+            </Text>
+          ))}
+        </Box>
+      )}
+      {/* CTL-1653: quiet-while-ok account strip; goes inverse (loud) when rejected. */}
+      <Box flexShrink={0}>
+        <Text color={accountStrip.color} inverse={accountStrip.inverse}>
+          {accountStrip.text}
+        </Text>
+      </Box>
       <Box flexShrink={0}>
         <PromptInput
           mode={inputMode}

--- a/plugins/dev/scripts/orch-monitor/lib/__tests__/account-status-latch.test.mjs
+++ b/plugins/dev/scripts/orch-monitor/lib/__tests__/account-status-latch.test.mjs
@@ -26,7 +26,7 @@ describe("nextAccountStatusLatch (pure edge)", () => {
   });
 });
 
-describe("checkAccountStatusTransition (persist-before-emit)", () => {
+describe("checkAccountStatusTransition (emit-then-advance)", () => {
   const summary = (status) => ({
     node: "mini-2",
     status,
@@ -79,35 +79,36 @@ describe("checkAccountStatusTransition (persist-before-emit)", () => {
     });
     expect(events.length).toBe(0);
   });
-  it("persist() failing emits NOTHING and leaves the latch un-advanced (retries next tick)", async () => {
-    // HIGH finding (CTL-1653): the durable marker is the source of truth. If it
-    // cannot be written we must not emit — a restart would otherwise re-announce
-    // an episode whose marker never landed. The edge is preserved for retry.
+  it("emit-then-advance: a failed marker write still emits + advances (in-memory authoritative)", async () => {
+    // CTL-1653 (2nd verify): the never-lose fix. The append is the source of truth,
+    // NOT the marker. A transient marker-write failure must NOT swallow a real
+    // transition — the event is emitted and the in-memory latch advances; only the
+    // durable copy lags (the module path retries it via _persistPending next tick).
     const state = { prev: false };
-    let persistOk = false;
     const emitted = [];
     const emit = (e) => (emitted.push(e), true);
-    await checkAccountStatusTransition(summary("rejected"), {
-      emit,
-      state,
-      persist: () => persistOk,
-    });
-    expect(emitted.length).toBe(0); // persist-before-emit: no marker → no event
-    expect(state.prev).toBe(false); // latch un-advanced → same edge next tick
-
-    persistOk = true; // marker write recovers
     const edge = await checkAccountStatusTransition(summary("rejected"), {
       emit,
       state,
-      persist: () => persistOk,
+      persist: () => false, // marker write fails
     });
-    expect(edge).toBe("rejected");
-    expect(emitted.length).toBe(1); // exactly one emit once the marker persists
-    expect(state.prev).toBe(true);
+    expect(edge).toBe("rejected"); // emitted despite the failed marker write
+    expect(emitted.length).toBe(1);
+    expect(state.prev).toBe(true); // in-memory advanced (authoritative)
+
+    // Still rejected: already latched → no re-emit even after the write recovers.
+    const noEdge = await checkAccountStatusTransition(summary("rejected"), {
+      emit,
+      state,
+      persist: () => true,
+    });
+    expect(noEdge).toBeNull();
+    expect(emitted.length).toBe(1);
   });
-  it("rolls the marker back and retries when the append fails AFTER a good persist", async () => {
-    // never-lose: a failed append must not leave the marker advanced (which would
-    // make a restart suppress the edge). The marker is rolled back to pre-edge.
+  it("append failing does NOT touch the marker and retries the SAME edge next tick", async () => {
+    // never-lose: the marker is written only AFTER a successful append, so a failed
+    // append leaves both the latch un-advanced AND the marker untouched (no bogus
+    // rollback dance) — the identical edge is recomputed and retried next tick.
     const state = { prev: false };
     const persistCalls = [];
     const persist = ({ latched }) => (persistCalls.push(latched), true);
@@ -118,8 +119,7 @@ describe("checkAccountStatusTransition (persist-before-emit)", () => {
       persist,
     });
     expect(state.prev).toBe(false); // un-advanced
-    // marker advanced true then rolled back to false (pre-edge)
-    expect(persistCalls).toEqual([true, false]);
+    expect(persistCalls).toEqual([]); // marker never touched on a failed append
 
     emitOk = true;
     const emitted = [];
@@ -131,6 +131,7 @@ describe("checkAccountStatusTransition (persist-before-emit)", () => {
     expect(edge).toBe("rejected");
     expect(emitted.length).toBe(1);
     expect(state.prev).toBe(true);
+    expect(persistCalls).toEqual([true]); // persisted once, AFTER the good append
   });
 });
 
@@ -172,5 +173,40 @@ describe("checkAccountStatusTransition durable marker + restart (real disk)", ()
     expect(emitted.length).toBe(1);
     expect(emitted[0].attributes["account.status"]).toBe("ok");
     expect(JSON.parse(readFileSync(getAccountStatusLatchPath(), "utf8")).latched).toBe(false);
+  });
+  it("_persistPending: a failed post-emit marker write is retried next tick without re-emitting", async () => {
+    // CTL-1653 (2nd verify): ports broker-degraded.mjs's Codex #2740 reconcile. A
+    // post-emit marker write that fails must NOT be swallowed (memory would outrun
+    // disk and a restart could re-emit a duplicate edge) — it is retried on the next
+    // module-path tick, and that retry NEVER re-emits (in-memory stays authoritative).
+    dir = mkdtempSync(join(tmpdir(), "acct-latch-"));
+    process.env.CATALYST_DIR = dir;
+    __resetAccountStatusLatchForTest();
+
+    const emitted = [];
+    const emit = (e) => (emitted.push(e), true);
+    // A fake persist we can fail then heal (module path → _persistPending is tracked).
+    let persistOk = false;
+    const persistCalls = [];
+    const persist = ({ latched }) => (persistCalls.push({ latched, ok: persistOk }), persistOk);
+
+    // Tick 1: ok→rejected. Append succeeds; the marker write FAILS → edge still emits,
+    // in-memory latch advances, _persistPending is armed.
+    const edge1 = await checkAccountStatusTransition(summary("rejected"), { emit, persist });
+    expect(edge1).toBe("rejected");
+    expect(emitted.length).toBe(1);
+    expect(persistCalls).toEqual([{ latched: true, ok: false }]);
+
+    // Tick 2: still rejected (no new edge). The reconcile retries the marker write —
+    // now succeeding — and emits NOTHING (already latched).
+    persistOk = true;
+    const edge2 = await checkAccountStatusTransition(summary("rejected"), { emit, persist });
+    expect(edge2).toBeNull();
+    expect(emitted.length).toBe(1); // no duplicate
+    // The reconcile fired with the authoritative latched=true, and it landed.
+    expect(persistCalls).toEqual([
+      { latched: true, ok: false },
+      { latched: true, ok: true },
+    ]);
   });
 });

--- a/plugins/dev/scripts/orch-monitor/lib/__tests__/account-status-latch.test.mjs
+++ b/plugins/dev/scripts/orch-monitor/lib/__tests__/account-status-latch.test.mjs
@@ -1,0 +1,74 @@
+import { describe, it, expect } from "bun:test";
+import { nextAccountStatusLatch, checkAccountStatusTransition } from "../account-status-latch.mjs";
+
+describe("nextAccountStatusLatch (pure edge)", () => {
+  it("ok→rejected trips with emit='rejected'", () =>
+    expect(nextAccountStatusLatch(false, { trip: true, clear: false })).toEqual({
+      latched: true,
+      emit: "rejected",
+    }));
+  it("rejected→ok clears with emit='recovered'", () =>
+    expect(nextAccountStatusLatch(true, { trip: false, clear: true })).toEqual({
+      latched: false,
+      emit: "recovered",
+    }));
+  it("no edge → emit:null", () => {
+    expect(nextAccountStatusLatch(true, { trip: true, clear: false }).emit).toBeNull();
+    expect(nextAccountStatusLatch(false, { trip: false, clear: false }).emit).toBeNull();
+  });
+});
+
+describe("checkAccountStatusTransition (emit-then-advance)", () => {
+  const summary = (status) => ({
+    node: "mini-2",
+    status,
+    active: { label: "acctA", email: "a@x.io", bindingWindow: "seven_day" },
+  });
+  it("emits ONE event on ok→rejected with node + handle + new status", async () => {
+    const events = [];
+    const emit = (env) => {
+      events.push(env);
+      return true;
+    };
+    const state = { prev: false }; // injected in-memory latch for the test
+    await checkAccountStatusTransition(summary("rejected"), { emit, state, persist: () => true });
+    await checkAccountStatusTransition(summary("rejected"), { emit, state, persist: () => true }); // no re-emit
+    expect(events.length).toBe(1);
+    const a = events[0].attributes;
+    expect(a["event.name"]).toBe("account.status.changed");
+    expect(a["account.handle"]).toBe("acctA");
+    expect(a["account.status"]).toBe("rejected");
+    expect(events[0].resource["host.name"]).toBeDefined();
+  });
+  it("does NOT advance the latch when emit fails (retries same edge next tick)", async () => {
+    const state = { prev: false };
+    let ok = false;
+    const emit = () => ok; // first tick fails, second succeeds
+    await checkAccountStatusTransition(summary("rejected"), { emit, state, persist: () => true });
+    expect(state.prev).toBe(false); // not advanced
+    ok = true;
+    const emitted = [];
+    await checkAccountStatusTransition(summary("rejected"), {
+      emit: (e) => (emitted.push(e), true),
+      state,
+      persist: () => true,
+    });
+    expect(emitted.length).toBe(1);
+    expect(state.prev).toBe(true);
+  });
+  it("degraded/allowed_warning and error do NOT trip the rejected latch", async () => {
+    const events = [];
+    const state = { prev: false };
+    await checkAccountStatusTransition(summary("degraded"), {
+      emit: (e) => (events.push(e), true),
+      state,
+      persist: () => true,
+    });
+    await checkAccountStatusTransition(summary("error"), {
+      emit: (e) => (events.push(e), true),
+      state,
+      persist: () => true,
+    });
+    expect(events.length).toBe(0);
+  });
+});

--- a/plugins/dev/scripts/orch-monitor/lib/__tests__/account-status-latch.test.mjs
+++ b/plugins/dev/scripts/orch-monitor/lib/__tests__/account-status-latch.test.mjs
@@ -1,5 +1,5 @@
 import { describe, it, expect, afterEach } from "bun:test";
-import { mkdtempSync, writeFileSync, readFileSync, rmSync } from "node:fs";
+import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
@@ -208,5 +208,23 @@ describe("checkAccountStatusTransition durable marker + restart (real disk)", ()
       { latched: true, ok: false },
       { latched: true, ok: true },
     ]);
+  });
+  it("a transient (non-ENOENT) hydration failure aborts evaluation instead of using default prev:false", async () => {
+    // Codex finding (CTL-1653): hydrateLatch() leaves `_hydrated` false on a
+    // read error other than ENOENT and touches nothing. Before the fix,
+    // checkAccountStatusTransition evaluated anyway against the default
+    // in-memory prev:false — if the persisted latch was actually still open,
+    // a sustained 'rejected' reading would emit a duplicate edge. Make the
+    // latch PATH itself a directory so readFileSync throws EISDIR, not ENOENT.
+    dir = mkdtempSync(join(tmpdir(), "acct-latch-"));
+    process.env.CATALYST_DIR = dir;
+    mkdirSync(getAccountStatusLatchPath());
+    __resetAccountStatusLatchForTest();
+
+    const emitted = [];
+    const emit = (e) => (emitted.push(e), true);
+    const edge = await checkAccountStatusTransition(summary("rejected"), { emit });
+    expect(edge).toBeNull();
+    expect(emitted.length).toBe(0); // aborted this tick — never evaluated
   });
 });

--- a/plugins/dev/scripts/orch-monitor/lib/__tests__/account-status-latch.test.mjs
+++ b/plugins/dev/scripts/orch-monitor/lib/__tests__/account-status-latch.test.mjs
@@ -1,5 +1,13 @@
-import { describe, it, expect } from "bun:test";
-import { nextAccountStatusLatch, checkAccountStatusTransition } from "../account-status-latch.mjs";
+import { describe, it, expect, afterEach } from "bun:test";
+import { mkdtempSync, writeFileSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  nextAccountStatusLatch,
+  checkAccountStatusTransition,
+  getAccountStatusLatchPath,
+  __resetAccountStatusLatchForTest,
+} from "../account-status-latch.mjs";
 
 describe("nextAccountStatusLatch (pure edge)", () => {
   it("ok→rejected trips with emit='rejected'", () =>
@@ -18,7 +26,7 @@ describe("nextAccountStatusLatch (pure edge)", () => {
   });
 });
 
-describe("checkAccountStatusTransition (emit-then-advance)", () => {
+describe("checkAccountStatusTransition (persist-before-emit)", () => {
   const summary = (status) => ({
     node: "mini-2",
     status,
@@ -70,5 +78,99 @@ describe("checkAccountStatusTransition (emit-then-advance)", () => {
       persist: () => true,
     });
     expect(events.length).toBe(0);
+  });
+  it("persist() failing emits NOTHING and leaves the latch un-advanced (retries next tick)", async () => {
+    // HIGH finding (CTL-1653): the durable marker is the source of truth. If it
+    // cannot be written we must not emit — a restart would otherwise re-announce
+    // an episode whose marker never landed. The edge is preserved for retry.
+    const state = { prev: false };
+    let persistOk = false;
+    const emitted = [];
+    const emit = (e) => (emitted.push(e), true);
+    await checkAccountStatusTransition(summary("rejected"), {
+      emit,
+      state,
+      persist: () => persistOk,
+    });
+    expect(emitted.length).toBe(0); // persist-before-emit: no marker → no event
+    expect(state.prev).toBe(false); // latch un-advanced → same edge next tick
+
+    persistOk = true; // marker write recovers
+    const edge = await checkAccountStatusTransition(summary("rejected"), {
+      emit,
+      state,
+      persist: () => persistOk,
+    });
+    expect(edge).toBe("rejected");
+    expect(emitted.length).toBe(1); // exactly one emit once the marker persists
+    expect(state.prev).toBe(true);
+  });
+  it("rolls the marker back and retries when the append fails AFTER a good persist", async () => {
+    // never-lose: a failed append must not leave the marker advanced (which would
+    // make a restart suppress the edge). The marker is rolled back to pre-edge.
+    const state = { prev: false };
+    const persistCalls = [];
+    const persist = ({ latched }) => (persistCalls.push(latched), true);
+    let emitOk = false;
+    await checkAccountStatusTransition(summary("rejected"), {
+      emit: () => emitOk, // append fails
+      state,
+      persist,
+    });
+    expect(state.prev).toBe(false); // un-advanced
+    // marker advanced true then rolled back to false (pre-edge)
+    expect(persistCalls).toEqual([true, false]);
+
+    emitOk = true;
+    const emitted = [];
+    const edge = await checkAccountStatusTransition(summary("rejected"), {
+      emit: (e) => (emitted.push(e), true),
+      state,
+      persist,
+    });
+    expect(edge).toBe("rejected");
+    expect(emitted.length).toBe(1);
+    expect(state.prev).toBe(true);
+  });
+});
+
+describe("checkAccountStatusTransition durable marker + restart (real disk)", () => {
+  let dir = null;
+  const summary = (status) => ({
+    node: "mini-2",
+    status,
+    active: { label: "acctA", email: "a@x.io", bindingWindow: "seven_day" },
+  });
+  afterEach(() => {
+    __resetAccountStatusLatchForTest();
+    delete process.env.CATALYST_DIR;
+    if (dir) {
+      rmSync(dir, { recursive: true, force: true });
+      dir = null;
+    }
+  });
+  it("a restart mid-'rejected' episode does NOT re-emit; the 'ok' edge emits exactly one 'recovered'", async () => {
+    // medium coverage (CTL-1653): exercise the REAL persistLatchToDisk + hydrateLatch
+    // over a temp CATALYST_DIR, the exact path the injected-state unit tests bypass.
+    dir = mkdtempSync(join(tmpdir(), "acct-latch-"));
+    process.env.CATALYST_DIR = dir;
+    // Simulate an open episode persisted by a prior process, then a restart.
+    writeFileSync(getAccountStatusLatchPath(), JSON.stringify({ latched: true, ts: 1 }));
+    __resetAccountStatusLatchForTest(); // clears hydration flag → next tick re-reads disk
+
+    const emitted = [];
+    const emit = (e) => (emitted.push(e), true);
+
+    // Post-restart tick still sees 'rejected': already latched → NO re-emit.
+    const noEdge = await checkAccountStatusTransition(summary("rejected"), { emit });
+    expect(noEdge).toBeNull();
+    expect(emitted.length).toBe(0);
+
+    // Account recovers: the ok edge emits exactly one 'recovered' and clears disk.
+    const edge = await checkAccountStatusTransition(summary("ok"), { emit });
+    expect(edge).toBe("recovered");
+    expect(emitted.length).toBe(1);
+    expect(emitted[0].attributes["account.status"]).toBe("ok");
+    expect(JSON.parse(readFileSync(getAccountStatusLatchPath(), "utf8")).latched).toBe(false);
   });
 });

--- a/plugins/dev/scripts/orch-monitor/lib/__tests__/accounts-probe.test.mjs
+++ b/plugins/dev/scripts/orch-monitor/lib/__tests__/accounts-probe.test.mjs
@@ -1,0 +1,137 @@
+import { describe, it, expect } from "bun:test";
+import { deriveAccountsSummary, createAccountsProbe } from "../accounts-probe.mjs";
+
+const REJECTED_ACTIVE = {
+  generatedAt: "2026-08-05T12:00:00.000Z",
+  accounts: [
+    {
+      label: "acctA",
+      isActive: true,
+      email: "a@x.io",
+      overallStatus: "rejected",
+      representativeClaim: "seven_day",
+      fiveHour: { pct: 40, resetsAt: "2026-08-05T13:00:00.000Z", status: "allowed" },
+      sevenDay: { pct: 100, resetsAt: "2026-08-06T00:00:00.000Z", status: "rejected" },
+      error: null,
+    },
+    {
+      label: "acctB",
+      isActive: false,
+      email: "b@x.io",
+      overallStatus: "allowed",
+      representativeClaim: "five_hour",
+      fiveHour: { pct: 10, resetsAt: "2026-08-05T13:00:00.000Z", status: "allowed" },
+      sevenDay: { pct: 20, resetsAt: "2026-08-12T00:00:00.000Z", status: "allowed" },
+      error: null,
+    },
+  ],
+};
+
+describe("deriveAccountsSummary", () => {
+  it("keys the node, picks the active account, and its binding-window status", () => {
+    const s = deriveAccountsSummary(REJECTED_ACTIVE, { node: "mini-2" });
+    expect(s.node).toBe("mini-2");
+    expect(s.active.label).toBe("acctA");
+    expect(s.active.bindingWindow).toBe("seven_day"); // == representativeClaim
+    expect(s.active.bindingStatus).toBe("rejected"); // sevenDay.status
+    expect(s.status).toBe("rejected"); // node-level == active binding status
+  });
+  it("names a sibling with headroom (allowed, not active) when the active is rejected", () => {
+    const s = deriveAccountsSummary(REJECTED_ACTIVE, { node: "mini-2" });
+    expect(s.siblingWithHeadroom).toEqual({ label: "acctB", email: "b@x.io" });
+  });
+  it("returns siblingWithHeadroom=null when no non-active account is allowed", () => {
+    const only = { ...REJECTED_ACTIVE, accounts: [REJECTED_ACTIVE.accounts[0]] };
+    expect(deriveAccountsSummary(only, { node: "n" }).siblingWithHeadroom).toBeNull();
+  });
+  it("distinguishes a transport error from rejected (status='error', not loud)", () => {
+    const errd = {
+      generatedAt: "t",
+      accounts: [
+        {
+          label: "acctA",
+          isActive: true,
+          email: "a@x.io",
+          overallStatus: null,
+          representativeClaim: null,
+          fiveHour: null,
+          sevenDay: null,
+          error: "network error",
+        },
+      ],
+    };
+    const s = deriveAccountsSummary(errd, { node: "n" });
+    expect(s.status).toBe("error");
+    expect(s.active.error).toBe("network error");
+  });
+  it("status='unknown' when no account is active (CLAUDE_CODE_OAUTH_TOKEN unset)", () => {
+    const none = { generatedAt: "t", accounts: [{ ...REJECTED_ACTIVE.accounts[1] }] };
+    expect(deriveAccountsSummary(none, { node: "n" }).status).toBe("unknown");
+  });
+  it("NEVER surfaces a token field even if one leaks into the raw record", () => {
+    const tainted = structuredClone(REJECTED_ACTIVE);
+    tainted.accounts[0].token = "sk-ant-oat-LEAK";
+    const s = deriveAccountsSummary(tainted, { node: "n" });
+    expect(JSON.stringify(s)).not.toContain("sk-ant-oat");
+    expect(JSON.stringify(s)).not.toContain("token");
+  });
+});
+
+describe("createAccountsProbe (cache)", () => {
+  const mkExec = () => {
+    // injected fake, counts invocations
+    let n = 0;
+    const exec = async () => {
+      n += 1;
+      return { ...REJECTED_ACTIVE, _n: n };
+    };
+    return { exec, calls: () => n };
+  };
+  it("probes once, then serves cache within TTL (no second probe)", async () => {
+    const { exec, calls } = mkExec();
+    let t = 1000;
+    const p = createAccountsProbe({ exec, ttlMs: 5000, now: () => t, node: "n" });
+    const a = await p.get();
+    t = 2000;
+    const b = await p.get();
+    expect(calls()).toBe(1);
+    expect(b.probedAt).toBe(a.probedAt);
+    expect(b.cached).toBe(true);
+  });
+  it("re-probes after TTL expiry", async () => {
+    const { exec, calls } = mkExec();
+    let t = 1000;
+    const p = createAccountsProbe({ exec, ttlMs: 5000, now: () => t, node: "n" });
+    await p.get();
+    t = 7000;
+    await p.get();
+    expect(calls()).toBe(2);
+  });
+  it("refresh:true bypasses a fresh cache", async () => {
+    const { exec, calls } = mkExec();
+    const p = createAccountsProbe({ exec, ttlMs: 5000, now: () => 1000, node: "n" });
+    await p.get();
+    await p.get({ refresh: true });
+    expect(calls()).toBe(2);
+  });
+  it("latest() returns the last posture without probing; null before first probe", async () => {
+    const { exec, calls } = mkExec();
+    const p = createAccountsProbe({ exec, ttlMs: 5000, now: () => 1000, node: "n" });
+    expect(p.latest()).toBeNull();
+    await p.get();
+    expect(p.latest()).not.toBeNull();
+    expect(calls()).toBe(1);
+  });
+  it("a throwing exec yields an error posture, never throws, and is not cached as fresh", async () => {
+    let n = 0;
+    const exec = async () => {
+      n += 1;
+      throw new Error("spawn EACCES");
+    };
+    const p = createAccountsProbe({ exec, ttlMs: 5000, now: () => 1000, node: "n" });
+    const r = await p.get();
+    expect(r.status).toBe("error");
+    await p.get(); // should retry, not serve a stale error
+    expect(n).toBe(2);
+  });
+});

--- a/plugins/dev/scripts/orch-monitor/lib/__tests__/accounts-probe.test.mjs
+++ b/plugins/dev/scripts/orch-monitor/lib/__tests__/accounts-probe.test.mjs
@@ -107,12 +107,60 @@ describe("createAccountsProbe (cache)", () => {
     await p.get();
     expect(calls()).toBe(2);
   });
-  it("refresh:true bypasses a fresh cache", async () => {
+  it("refresh:true bypasses a fresh cache (refreshFloorMs:0)", async () => {
     const { exec, calls } = mkExec();
-    const p = createAccountsProbe({ exec, ttlMs: 5000, now: () => 1000, node: "n" });
+    const p = createAccountsProbe({
+      exec,
+      ttlMs: 5000,
+      refreshFloorMs: 0,
+      now: () => 1000,
+      node: "n",
+    });
     await p.get();
     await p.get({ refresh: true });
     expect(calls()).toBe(2);
+  });
+  it("refresh WITHIN the floor serves cache (no probe) — DoS guard", async () => {
+    const { exec, calls } = mkExec();
+    let t = 1000;
+    const p = createAccountsProbe({
+      exec,
+      ttlMs: 5000,
+      refreshFloorMs: 2000,
+      now: () => t,
+      node: "n",
+    });
+    await p.get(); // probes, cache at t=1000
+    t = 2500; // within the 2000ms floor
+    const b = await p.get({ refresh: true });
+    expect(calls()).toBe(1); // refresh throttled by the floor
+    expect(b.cached).toBe(true);
+  });
+  it("refresh AFTER the floor re-probes", async () => {
+    const { exec, calls } = mkExec();
+    let t = 1000;
+    const p = createAccountsProbe({
+      exec,
+      ttlMs: 5000,
+      refreshFloorMs: 2000,
+      now: () => t,
+      node: "n",
+    });
+    await p.get();
+    t = 3500; // past the 2000ms floor
+    await p.get({ refresh: true });
+    expect(calls()).toBe(2);
+  });
+  it("coalesces concurrent get() calls into a single probe (DoS guard)", async () => {
+    let n = 0;
+    const exec = async () => {
+      n += 1;
+      await Promise.resolve(); // yield so all three callers overlap
+      return REJECTED_ACTIVE;
+    };
+    const p = createAccountsProbe({ exec, ttlMs: 5000, now: () => 1000, node: "n" });
+    await Promise.all([p.get(), p.get(), p.get()]);
+    expect(n).toBe(1);
   });
   it("latest() returns the last posture without probing; null before first probe", async () => {
     const { exec, calls } = mkExec();

--- a/plugins/dev/scripts/orch-monitor/lib/__tests__/accounts-probe.test.mjs
+++ b/plugins/dev/scripts/orch-monitor/lib/__tests__/accounts-probe.test.mjs
@@ -1,5 +1,12 @@
 import { describe, it, expect } from "bun:test";
-import { deriveAccountsSummary, createAccountsProbe } from "../accounts-probe.mjs";
+import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  deriveAccountsSummary,
+  createAccountsProbe,
+  defaultAccountsProbeExec,
+} from "../accounts-probe.mjs";
 
 const REJECTED_ACTIVE = {
   generatedAt: "2026-08-05T12:00:00.000Z",
@@ -170,16 +177,95 @@ describe("createAccountsProbe (cache)", () => {
     expect(p.latest()).not.toBeNull();
     expect(calls()).toBe(1);
   });
-  it("a throwing exec yields an error posture, never throws, and is not cached as fresh", async () => {
+  it("a throwing exec yields an error posture, never throws, and retries after the floor", async () => {
     let n = 0;
+    let t = 1000;
     const exec = async () => {
       n += 1;
       throw new Error("spawn EACCES");
     };
-    const p = createAccountsProbe({ exec, ttlMs: 5000, now: () => 1000, node: "n" });
+    const p = createAccountsProbe({ exec, ttlMs: 5000, refreshFloorMs: 2000, now: () => t, node: "n" });
     const r = await p.get();
     expect(r.status).toBe("error");
-    await p.get(); // should retry, not serve a stale error
+    t = 3000; // within ttl but past the refresh floor
+    const throttled = await p.get(); // normal read within ttl cadence → served, not re-probed
+    expect(n).toBe(1);
+    expect(throttled.status).toBe("error");
+    t = 7000; // past the ttl
+    await p.get(); // retries, not a stale error served forever
     expect(n).toBe(2);
+  });
+  it("a forced ?refresh during SUSTAINED failure cannot re-probe faster than the floor (DoS cold-hole)", async () => {
+    // low-severity DoS finding (CTL-1653): errors are uncached, so pre-fix every
+    // serialized refresh=true during a failing probe spawned a fresh subprocess +
+    // Haiku call. The floor now gates probe INITIATION, not just cache hits.
+    let n = 0;
+    let t = 1000;
+    const exec = async () => {
+      n += 1;
+      throw new Error("401 unauthorized");
+    };
+    const p = createAccountsProbe({ exec, ttlMs: 5000, refreshFloorMs: 2000, now: () => t, node: "n" });
+    const first = await p.get({ refresh: true }); // cold start → probes once
+    expect(n).toBe(1);
+    expect(first.status).toBe("error");
+    t = 1500; // within the floor, still no cache (error uncached)
+    const throttled = await p.get({ refresh: true });
+    expect(n).toBe(1); // NOT re-probed — served the recent error posture
+    expect(throttled.status).toBe("error");
+    expect(throttled.cached).toBe(true);
+    t = 3500; // past the floor → one retry allowed
+    await p.get({ refresh: true });
+    expect(n).toBe(2);
+  });
+});
+
+describe("defaultAccountsProbeExec (secrets hygiene)", () => {
+  it("returns an empty {accounts:[]} record when the env file is absent (no probe spawned)", async () => {
+    const missing = join(tmpdir(), "definitely-absent-accounts-env-" + process.pid + ".env");
+    const r = await defaultAccountsProbeExec({ envFile: missing });
+    expect(r.accounts).toEqual([]);
+    expect(typeof r.generatedAt).toBe("string");
+  });
+  it("makes the SOURCED token sole authority in the child, keeps the parent env clean, and returns token-free", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "accounts-exec-"));
+    const stub = join(dir, "stub-probe.mjs");
+    // The stub inspects its OWN (child) env and emits a token-FREE record describing
+    // what it saw — never the token value. It proves: (a) the ambient token was
+    // stripped, (b) the sourced token is the one present (sole authority).
+    writeFileSync(
+      stub,
+      [
+        "const tok = process.env.CLAUDE_CODE_OAUTH_TOKEN || '';",
+        "const rec = {",
+        "  generatedAt: 't',",
+        "  accounts: [{",
+        "    label: 'stub',",
+        "    isActive: true,",
+        "    sawSourced: tok === 'sk-ant-oat-SOURCED',", // sourced file won
+        "    sawAmbient: tok === 'sk-ant-oat-AMBIENT',", // ambient must have been stripped
+        "  }],",
+        "};",
+        "process.stdout.write(JSON.stringify(rec));", // token itself never printed
+      ].join("\n"),
+    );
+    const envFile = join(dir, "claude-accounts.env");
+    writeFileSync(envFile, 'CLAUDE_CODE_OAUTH_TOKEN="sk-ant-oat-SOURCED"\n');
+
+    // Ambient token in THIS process's env — the strip must remove it from the child so
+    // the sourced file is the sole authority; and it must remain in the parent unchanged.
+    const prior = process.env.CLAUDE_CODE_OAUTH_TOKEN;
+    process.env.CLAUDE_CODE_OAUTH_TOKEN = "sk-ant-oat-AMBIENT";
+    try {
+      const r = await defaultAccountsProbeExec({ envFile, probePath: stub });
+      expect(JSON.stringify(r)).not.toContain("sk-ant-oat"); // token-free wire output
+      expect(r.accounts[0].sawAmbient).toBe(false); // ambient stripped from child
+      expect(r.accounts[0].sawSourced).toBe(true); // sourced file is sole authority
+      expect(process.env.CLAUDE_CODE_OAUTH_TOKEN).toBe("sk-ant-oat-AMBIENT"); // parent untouched
+    } finally {
+      if (prior === undefined) delete process.env.CLAUDE_CODE_OAUTH_TOKEN;
+      else process.env.CLAUDE_CODE_OAUTH_TOKEN = prior;
+      rmSync(dir, { recursive: true, force: true });
+    }
   });
 });

--- a/plugins/dev/scripts/orch-monitor/lib/__tests__/accounts-probe.test.mjs
+++ b/plugins/dev/scripts/orch-monitor/lib/__tests__/accounts-probe.test.mjs
@@ -82,6 +82,13 @@ describe("deriveAccountsSummary", () => {
     expect(JSON.stringify(s)).not.toContain("sk-ant-oat");
     expect(JSON.stringify(s)).not.toContain("token");
   });
+  it("raw.available===false short-circuits to the SAME minimal shape as the disabled path", () => {
+    const s = deriveAccountsSummary(
+      { generatedAt: "t", accounts: [], available: false },
+      { node: "mini-2" },
+    );
+    expect(s).toEqual({ node: "mini-2", available: false });
+  });
 });
 
 describe("createAccountsProbe (cache)", () => {
@@ -221,11 +228,52 @@ describe("createAccountsProbe (cache)", () => {
 });
 
 describe("defaultAccountsProbeExec (secrets hygiene)", () => {
-  it("returns an empty {accounts:[]} record when the env file is absent (no probe spawned)", async () => {
+  it("returns an empty {accounts:[], available:false} record when the env file is absent (no probe spawned)", async () => {
     const missing = join(tmpdir(), "definitely-absent-accounts-env-" + process.pid + ".env");
     const r = await defaultAccountsProbeExec({ envFile: missing });
     expect(r.accounts).toEqual([]);
     expect(typeof r.generatedAt).toBe("string");
+    expect(r.available).toBe(false);
+  });
+  it("preserves the probe's stdout JSON when it exits nonzero (e.g. all accounts invalid)", async () => {
+    // CTL-1653 Codex finding: a nonzero exit still writes the token-free record
+    // to stdout first; execFileP rejects on nonzero, so the fix must recover
+    // stdout from the rejection rather than discard it in favor of a synthetic
+    // unlabeled spawn-error posture.
+    const dir = mkdtempSync(join(tmpdir(), "accounts-exec-nonzero-"));
+    const stub = join(dir, "stub-probe.mjs");
+    writeFileSync(
+      stub,
+      [
+        "const rec = {",
+        "  generatedAt: 't',",
+        "  accounts: [{ label: 'acctA', isActive: true, error: 'token expired' }],",
+        "};",
+        "process.stdout.write(JSON.stringify(rec));",
+        "process.exit(1);",
+      ].join("\n"),
+    );
+    const envFile = join(dir, "claude-accounts.env");
+    writeFileSync(envFile, 'CLAUDE_CODE_OAUTH_TOKEN="sk-ant-oat-X"\n');
+    try {
+      const r = await defaultAccountsProbeExec({ envFile, probePath: stub });
+      expect(r.accounts[0].label).toBe("acctA");
+      expect(r.accounts[0].error).toBe("token expired");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+  it("rethrows the original error when a nonzero exit produced no usable stdout", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "accounts-exec-nonzero-empty-"));
+    const stub = join(dir, "stub-probe.mjs");
+    writeFileSync(stub, ["process.stderr.write('boom');", "process.exit(1);"].join("\n"));
+    const envFile = join(dir, "claude-accounts.env");
+    writeFileSync(envFile, 'CLAUDE_CODE_OAUTH_TOKEN="sk-ant-oat-X"\n');
+    try {
+      await expect(defaultAccountsProbeExec({ envFile, probePath: stub })).rejects.toBeTruthy();
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
   });
   it("makes the SOURCED token sole authority in the child, keeps the parent env clean, and returns token-free", async () => {
     const dir = mkdtempSync(join(tmpdir(), "accounts-exec-"));

--- a/plugins/dev/scripts/orch-monitor/lib/__tests__/accounts-timer.test.mjs
+++ b/plugins/dev/scripts/orch-monitor/lib/__tests__/accounts-timer.test.mjs
@@ -1,0 +1,59 @@
+import { describe, it, expect } from "bun:test";
+import { createAccountsTimer } from "../accounts-timer.mjs";
+
+function fakeClock() {
+  // injectable setInterval/clearInterval
+  let fn = null;
+  return {
+    setInterval: (f) => {
+      fn = f;
+      return { unref() {} };
+    },
+    clearInterval: () => {
+      fn = null;
+    },
+    tick: async () => {
+      if (fn) await fn();
+    },
+  };
+}
+
+describe("createAccountsTimer", () => {
+  it("probes immediately on start and on each interval, calling onTick with the summary", async () => {
+    let n = 0;
+    const clock = fakeClock();
+    const probe = { get: async () => ({ node: "n", status: "ok", probedAt: n++ }) };
+    const ticks = [];
+    const t = createAccountsTimer({ probe, clock, onTick: (s) => ticks.push(s) });
+    t.start(); // immediate tick
+    await clock.tick(); // one interval
+    // the immediate tick is async; let it settle
+    await Promise.resolve();
+    expect(ticks.length).toBeGreaterThanOrEqual(2);
+    t.stop();
+  });
+  it("stop() clears the interval and unsubscribes further ticks", async () => {
+    const clock = fakeClock();
+    const probe = { get: async () => ({ node: "n", status: "ok" }) };
+    let count = 0;
+    const t = createAccountsTimer({ probe, clock, onTick: () => (count += 1) });
+    t.start();
+    await Promise.resolve();
+    const after = count;
+    t.stop();
+    await clock.tick();
+    expect(count).toBe(after);
+  });
+  it("a probe rejection inside a tick is swallowed (never throws out of the interval)", async () => {
+    const clock = fakeClock();
+    const probe = {
+      get: async () => {
+        throw new Error("boom");
+      },
+    };
+    const t = createAccountsTimer({ probe, clock, onTick: () => {}, onError: () => {} });
+    expect(() => t.start()).not.toThrow();
+    await clock.tick(); // must not reject
+    t.stop();
+  });
+});

--- a/plugins/dev/scripts/orch-monitor/lib/account-status-latch.d.mts
+++ b/plugins/dev/scripts/orch-monitor/lib/account-status-latch.d.mts
@@ -1,0 +1,24 @@
+// Type declarations for account-status-latch.mjs (CTL-1653).
+// Authored as .mjs (no tsc gate) but imported under the TS program by server.ts.
+
+import type { AccountsSummary } from "./accounts-probe";
+
+export declare const ACCOUNT_STATUS_CHANGED_EVENT: "account.status.changed";
+
+export declare function nextAccountStatusLatch(
+  prev: boolean,
+  verdict: { trip: boolean; clear: boolean },
+): { latched: boolean; emit: "rejected" | "recovered" | null };
+
+export declare function getAccountStatusLatchPath(): string;
+
+export declare function __resetAccountStatusLatchForTest(): void;
+
+export declare function checkAccountStatusTransition(
+  summary: Partial<AccountsSummary> & { status?: string },
+  opts?: {
+    emit?: (env: unknown) => boolean;
+    state?: { prev: boolean } | null;
+    persist?: (arg: { latched: boolean }) => boolean;
+  },
+): Promise<"rejected" | "recovered" | null>;

--- a/plugins/dev/scripts/orch-monitor/lib/account-status-latch.d.ts
+++ b/plugins/dev/scripts/orch-monitor/lib/account-status-latch.d.ts
@@ -1,0 +1,24 @@
+// Type declarations for account-status-latch.mjs (CTL-1653).
+// Authored as .mjs (no tsc gate) but imported under the TS program by server.ts.
+
+import type { AccountsSummary } from "./accounts-probe";
+
+export declare const ACCOUNT_STATUS_CHANGED_EVENT: "account.status.changed";
+
+export declare function nextAccountStatusLatch(
+  prev: boolean,
+  verdict: { trip: boolean; clear: boolean },
+): { latched: boolean; emit: "rejected" | "recovered" | null };
+
+export declare function getAccountStatusLatchPath(): string;
+
+export declare function __resetAccountStatusLatchForTest(): void;
+
+export declare function checkAccountStatusTransition(
+  summary: Partial<AccountsSummary> & { status?: string },
+  opts?: {
+    emit?: (env: unknown) => boolean;
+    state?: { prev: boolean } | null;
+    persist?: (arg: { latched: boolean }) => boolean;
+  },
+): Promise<"rejected" | "recovered" | null>;

--- a/plugins/dev/scripts/orch-monitor/lib/account-status-latch.mjs
+++ b/plugins/dev/scripts/orch-monitor/lib/account-status-latch.mjs
@@ -1,0 +1,169 @@
+// account-status-latch.mjs — CTL-1653. The edge-triggered transition emitter for
+// the active Claude account's ok↔rejected status. Appends exactly ONE
+// `account.status.changed` v2 event on each transition, never per probe.
+//
+// Mirrors broker-degraded.mjs: a PURE edge state machine (nextAccountStatusLatch),
+// a durable marker (~/catalyst/account-status-latch.json, atomic tmp+rename), and
+// EMIT-THEN-ADVANCE — the latch advances only on a successful append, so a
+// transient event-log failure re-attempts the same edge next tick.
+//
+// account.* is NOT a broker-protected namespace (account.ratelimit.sampled already
+// lives there), so no namespace-contract change is needed.
+//
+// Import-light: only catalyst-agent/emit.mjs (the same buildAgentEnvelope +
+// emitEventLog the existing account.ratelimit.sampled event uses) + node:*.
+
+import { mkdirSync, readFileSync, writeFileSync, renameSync, rmSync } from "node:fs";
+import { homedir } from "node:os";
+import { resolve, dirname, join } from "node:path";
+import { randomBytes } from "node:crypto";
+import { buildAgentEnvelope, emitEventLog } from "../../catalyst-agent/emit.mjs";
+
+export const ACCOUNT_STATUS_CHANGED_EVENT = "account.status.changed";
+
+/**
+ * nextAccountStatusLatch — PURE edge state machine (mirrors nextBrokerDegradedLatch).
+ * `trip` is only consulted when NOT latched; once latched only `clear` releases it,
+ * so a sustained `rejected` never re-emits.
+ *
+ * @param {boolean} prev  prior latch (true = an episode is open)
+ * @param {{trip:boolean, clear:boolean}} verdict
+ * @returns {{latched:boolean, emit:("rejected"|"recovered"|null)}}
+ */
+export function nextAccountStatusLatch(prev, { trip, clear } = {}) {
+  if (!prev && trip) return { latched: true, emit: "rejected" };
+  if (prev && clear) return { latched: false, emit: "recovered" };
+  return { latched: prev === true, emit: null };
+}
+
+// ─── Durable latch (mirrors broker-degraded.mjs) ─────────────────────────────
+// Module-scoped so the episode persists across ticks; PERSISTED to disk +
+// hydrated on the first tick so a monitor RESTART mid-episode does not re-emit.
+const _moduleLatch = { prev: false };
+let _hydrated = false;
+
+// Resolved per call (not a load-time const) so tests can redirect via CATALYST_DIR.
+// Prefer process.env.HOME over homedir() for parity with getEventLogPath (macOS's
+// homedir() ignores HOME).
+export function getAccountStatusLatchPath() {
+  const home = process.env.HOME ?? homedir();
+  const catalystDir = process.env.CATALYST_DIR ?? `${home}/catalyst`;
+  return resolve(catalystDir, "account-status-latch.json");
+}
+
+// hydrateLatch — lazily load the persisted episode on this process's first
+// module-path tick. Never throws. Absence/corruption are CONFIRMATIONS of "no
+// open episode"; any other read error is transient — leave un-hydrated so the
+// next tick retries and touch nothing.
+function hydrateLatch() {
+  if (_hydrated) return;
+  let raw;
+  try {
+    raw = readFileSync(getAccountStatusLatchPath(), "utf8");
+  } catch (err) {
+    if (err?.code === "ENOENT") {
+      _hydrated = true; // CONFIRMED: no episode on disk
+      _moduleLatch.prev = false;
+      return;
+    }
+    return; // transient — retry next tick, learn nothing
+  }
+  _hydrated = true;
+  try {
+    const m = JSON.parse(raw);
+    _moduleLatch.prev = m?.latched === true;
+  } catch {
+    _moduleLatch.prev = false; // malformed → unlatched
+  }
+}
+
+// persistLatchToDisk — atomic tmp + rename write of the episode state.
+// Best-effort; returns true on success, false on failure (never throws).
+function persistLatchToDisk({ latched }) {
+  let tmp = null;
+  try {
+    const path = getAccountStatusLatchPath();
+    const dir = dirname(path);
+    mkdirSync(dir, { recursive: true });
+    tmp = join(dir, `.account-status-latch.${randomBytes(4).toString("hex")}.tmp`);
+    writeFileSync(tmp, JSON.stringify({ latched, ts: Date.now() }));
+    renameSync(tmp, path);
+    return true;
+  } catch {
+    if (tmp !== null) {
+      try {
+        rmSync(tmp, { force: true });
+      } catch {
+        /* retry next tick uses a fresh name */
+      }
+    }
+    return false;
+  }
+}
+
+// __resetAccountStatusLatchForTest — clears in-memory episode + hydration flag so
+// the next module-path tick re-reads the CATALYST_DIR-scoped marker (simulates a
+// restart). The unit tests inject their own `state`, so this is for integration
+// coverage only.
+export function __resetAccountStatusLatchForTest() {
+  _moduleLatch.prev = false;
+  _hydrated = false;
+}
+
+const defaultEmit = (env) => emitEventLog(env);
+
+/**
+ * checkAccountStatusTransition — one timer-tick evaluation. Emits exactly one
+ * `account.status.changed` event on the active account's ok↔rejected edge, then
+ * advances the latch ONLY on a successful emit (emit-then-advance).
+ *
+ * `degraded`, `error`, and `unknown` neither trip nor clear — they HOLD the
+ * current latch (only a definitive `rejected`/`ok` moves it).
+ *
+ * @param {object} summary  a deriveAccountsSummary() result ({node, status, active})
+ * @param {object} [opts]
+ * @param {Function} [opts.emit]     (env) => boolean; false = failed append. Default: emitEventLog.
+ * @param {object}   [opts.state]    injectable latch { prev:boolean } (tests). Default: module latch.
+ * @param {Function} [opts.persist]  ({latched}) => boolean. Default: durable marker (module path only).
+ * @returns {Promise<"rejected"|"recovered"|null>} the emitted edge, or null.
+ */
+export async function checkAccountStatusTransition(summary, opts = {}) {
+  const { emit = defaultEmit, state = null } = opts;
+  const usingModule = state === null;
+  if (usingModule) hydrateLatch();
+  const latch = usingModule ? _moduleLatch : state;
+  const persist = opts.persist ?? (usingModule ? persistLatchToDisk : () => true);
+
+  const trip = summary?.status === "rejected";
+  const clear = summary?.status === "ok";
+  const { latched, emit: edge } = nextAccountStatusLatch(latch.prev === true, { trip, clear });
+  if (!edge) return null;
+
+  const status = edge === "rejected" ? "rejected" : "ok";
+  const env = buildAgentEnvelope(ACCOUNT_STATUS_CHANGED_EVENT, {
+    entity: "account",
+    label: summary.active?.email ?? summary.active?.label ?? "unknown",
+    attrs: {
+      "account.handle": summary.active?.label,
+      "account.email": summary.active?.email,
+      "account.status": status,
+      "account.binding_window": summary.active?.bindingWindow,
+      "node.name": summary.node,
+    },
+    payload: { node: summary.node, handle: summary.active?.label, status: edge },
+  });
+
+  let ok;
+  try {
+    ok = emit(env) !== false;
+  } catch {
+    ok = false;
+  }
+  // EMIT-THEN-ADVANCE: a failed append leaves the latch untouched so the next
+  // tick retries this edge (a real transition is never lost to one bad append).
+  if (!ok) return null;
+
+  latch.prev = latched;
+  persist({ latched });
+  return edge;
+}

--- a/plugins/dev/scripts/orch-monitor/lib/account-status-latch.mjs
+++ b/plugins/dev/scripts/orch-monitor/lib/account-status-latch.mjs
@@ -4,13 +4,19 @@
 //
 // Mirrors broker-degraded.mjs: a PURE edge state machine (nextAccountStatusLatch),
 // a durable marker (~/catalyst/account-status-latch.json, atomic tmp+rename), and
-// PERSIST-BEFORE-EMIT — the durable marker is the source of truth. The new episode
-// state is written to disk BEFORE the append, so a restart can never re-announce an
-// episode we already emitted (exactly-once across restarts). A failed persist emits
-// nothing (nothing to duplicate) and a failed append rolls the marker back, so in
-// either case the SAME edge is recomputed and retried next tick (never lose a real
-// transition). The in-memory latch only advances once BOTH the marker and the append
-// succeed, so it never diverges from disk in a way that re-announces an open episode.
+// EMIT-THEN-ADVANCE — the in-memory latch is authoritative and the marker follows it.
+// The append happens FIRST; the latch advances ONLY on a successful append, so a
+// transient log failure re-attempts the SAME edge next tick instead of swallowing a
+// real transition (never-lose). The durable marker is persisted AFTER the append, and
+// if that write fails a module-level `_persistPending` flag retries it on the next
+// tick — in-memory stays authoritative meanwhile, so the retry never changes what is
+// emitted; it only makes the on-disk copy catch up. This is exactly the reconcile
+// broker-degraded.mjs uses (Codex #2740) and it satisfies BOTH guarantees at once:
+// never re-announce an already-emitted episode after a restart (exactly-once) AND
+// never lose a real transition to one bad write. NOT persist-before-emit — writing the
+// advanced marker ahead of the append means a crash in that window hydrates an
+// episode we never emitted on restart, permanently suppressing the edge (the defect
+// this file previously regressed into).
 //
 // account.* is NOT a broker-protected namespace (account.ratelimit.sampled already
 // lives there), so no namespace-contract change is needed.
@@ -46,6 +52,13 @@ export function nextAccountStatusLatch(prev, { trip, clear } = {}) {
 // hydrated on the first tick so a monitor RESTART mid-episode does not re-emit.
 const _moduleLatch = { prev: false };
 let _hydrated = false;
+// Codex #2740 reconcile (ported from broker-degraded.mjs): the marker write can fail
+// AFTER the event append already succeeded and `_moduleLatch.prev` advanced. Swallowing
+// that would leave memory and disk disagreeing with nothing to reconcile them, so a
+// later restart could hydrate an absent/stale marker and re-emit a duplicate edge for
+// the same episode. When the post-emit write fails we remember it and retry on every
+// subsequent module-path tick until it lands; in-memory stays authoritative meanwhile.
+let _persistPending = false;
 
 // Resolved per call (not a load-time const) so tests can redirect via CATALYST_DIR.
 // Prefer process.env.HOME over homedir() for parity with getEventLogPath (macOS's
@@ -113,16 +126,19 @@ function persistLatchToDisk({ latched }) {
 export function __resetAccountStatusLatchForTest() {
   _moduleLatch.prev = false;
   _hydrated = false;
+  _persistPending = false;
 }
 
 const defaultEmit = (env) => emitEventLog(env);
 
 /**
  * checkAccountStatusTransition — one timer-tick evaluation. Emits exactly one
- * `account.status.changed` event on the active account's ok↔rejected edge. The
- * durable marker is persisted BEFORE the append and the in-memory latch advances
- * only once BOTH succeed (persist-before-emit), so a restart never re-announces an
- * already-emitted episode and a failed write re-attempts the same edge next tick.
+ * `account.status.changed` event on the active account's ok↔rejected edge. Uses
+ * EMIT-THEN-ADVANCE (mirrors broker-degraded.mjs): the append happens first, the
+ * in-memory latch advances only on a successful append (so a failed append retries
+ * the same edge next tick — never-lose), and the durable marker is persisted AFTER,
+ * with a `_persistPending` retry if that write fails, so a restart never re-announces
+ * an already-emitted episode (exactly-once) without ever losing a real transition.
  *
  * `degraded`, `error`, and `unknown` neither trip nor clear — they HOLD the
  * current latch (only a definitive `rejected`/`ok` moves it).
@@ -140,6 +156,15 @@ export async function checkAccountStatusTransition(summary, opts = {}) {
   if (usingModule) hydrateLatch();
   const latch = usingModule ? _moduleLatch : state;
   const persist = opts.persist ?? (usingModule ? persistLatchToDisk : () => true);
+
+  // Reconcile a previously-failed marker write before evaluating this tick (ported
+  // from broker-degraded.mjs). Runs AFTER hydrateLatch so it never clobbers the
+  // on-disk episode with un-hydrated defaults; in-memory state is authoritative, so
+  // this only makes the on-disk copy catch up. Module-path only — an injected-state
+  // test drives `persist` itself and never sets `_persistPending`.
+  if (usingModule && _persistPending) {
+    _persistPending = !persist({ latched: latch.prev === true });
+  }
 
   const trip = summary?.status === "rejected";
   const clear = summary?.status === "ok";
@@ -160,31 +185,28 @@ export async function checkAccountStatusTransition(summary, opts = {}) {
     payload: { node: summary.node, handle: summary.active?.label, status: edge },
   });
 
-  // PERSIST-BEFORE-EMIT: write the NEW episode state to the durable marker BEFORE
-  // appending, so the marker is the source of truth. If the marker write fails we
-  // emit nothing and leave the in-memory latch untouched — there is nothing to
-  // duplicate and the same edge is recomputed and retried next tick.
-  const prevLatched = latch.prev === true;
-  if (!persist({ latched })) return null;
-
+  // EMIT-THEN-ADVANCE: append the event FIRST. The in-memory latch advances ONLY on
+  // a successful append, so a transient log failure re-attempts the SAME edge next
+  // tick rather than silently dropping a real transition (never-lose). The durable
+  // marker is written AFTER — never before — because a marker advanced ahead of the
+  // append would, on a crash in that window, hydrate an already-advanced episode on
+  // restart and suppress an edge that was never emitted.
   let ok;
   try {
     ok = emit(env) !== false;
   } catch {
     ok = false;
   }
-  if (!ok) {
-    // Append failed after the marker advanced. Roll the marker back to the
-    // pre-edge state and leave the in-memory latch untouched so the next tick
-    // recomputes and retries this edge (a real transition is never lost to one
-    // bad append). The rollback keeps disk consistent with the un-advanced latch.
-    persist({ latched: prevLatched });
-    return null;
-  }
+  if (!ok) return null;
 
-  // Both the durable marker and the append succeeded — advance the in-memory
-  // latch to match disk. In-memory and on-disk never diverge in a way that
-  // re-announces an open episode after a restart.
+  // Append landed: the in-memory episode is now authoritative. Advance it, then
+  // pin hydration closed (module path) so a later successful read of a stale/absent
+  // marker — e.g. after a failed persist below — can never clobber what we just
+  // committed to the event log. Persist the marker AFTER; if that write fails,
+  // `_persistPending` retries it next tick (broker-degraded.mjs's reconcile).
   latch.prev = latched;
+  if (usingModule) _hydrated = true;
+  const persisted = persist({ latched });
+  if (usingModule) _persistPending = !persisted;
   return edge;
 }

--- a/plugins/dev/scripts/orch-monitor/lib/account-status-latch.mjs
+++ b/plugins/dev/scripts/orch-monitor/lib/account-status-latch.mjs
@@ -4,8 +4,13 @@
 //
 // Mirrors broker-degraded.mjs: a PURE edge state machine (nextAccountStatusLatch),
 // a durable marker (~/catalyst/account-status-latch.json, atomic tmp+rename), and
-// EMIT-THEN-ADVANCE — the latch advances only on a successful append, so a
-// transient event-log failure re-attempts the same edge next tick.
+// PERSIST-BEFORE-EMIT — the durable marker is the source of truth. The new episode
+// state is written to disk BEFORE the append, so a restart can never re-announce an
+// episode we already emitted (exactly-once across restarts). A failed persist emits
+// nothing (nothing to duplicate) and a failed append rolls the marker back, so in
+// either case the SAME edge is recomputed and retried next tick (never lose a real
+// transition). The in-memory latch only advances once BOTH the marker and the append
+// succeed, so it never diverges from disk in a way that re-announces an open episode.
 //
 // account.* is NOT a broker-protected namespace (account.ratelimit.sampled already
 // lives there), so no namespace-contract change is needed.
@@ -114,8 +119,10 @@ const defaultEmit = (env) => emitEventLog(env);
 
 /**
  * checkAccountStatusTransition — one timer-tick evaluation. Emits exactly one
- * `account.status.changed` event on the active account's ok↔rejected edge, then
- * advances the latch ONLY on a successful emit (emit-then-advance).
+ * `account.status.changed` event on the active account's ok↔rejected edge. The
+ * durable marker is persisted BEFORE the append and the in-memory latch advances
+ * only once BOTH succeed (persist-before-emit), so a restart never re-announces an
+ * already-emitted episode and a failed write re-attempts the same edge next tick.
  *
  * `degraded`, `error`, and `unknown` neither trip nor clear — they HOLD the
  * current latch (only a definitive `rejected`/`ok` moves it).
@@ -153,17 +160,31 @@ export async function checkAccountStatusTransition(summary, opts = {}) {
     payload: { node: summary.node, handle: summary.active?.label, status: edge },
   });
 
+  // PERSIST-BEFORE-EMIT: write the NEW episode state to the durable marker BEFORE
+  // appending, so the marker is the source of truth. If the marker write fails we
+  // emit nothing and leave the in-memory latch untouched — there is nothing to
+  // duplicate and the same edge is recomputed and retried next tick.
+  const prevLatched = latch.prev === true;
+  if (!persist({ latched })) return null;
+
   let ok;
   try {
     ok = emit(env) !== false;
   } catch {
     ok = false;
   }
-  // EMIT-THEN-ADVANCE: a failed append leaves the latch untouched so the next
-  // tick retries this edge (a real transition is never lost to one bad append).
-  if (!ok) return null;
+  if (!ok) {
+    // Append failed after the marker advanced. Roll the marker back to the
+    // pre-edge state and leave the in-memory latch untouched so the next tick
+    // recomputes and retries this edge (a real transition is never lost to one
+    // bad append). The rollback keeps disk consistent with the un-advanced latch.
+    persist({ latched: prevLatched });
+    return null;
+  }
 
+  // Both the durable marker and the append succeeded — advance the in-memory
+  // latch to match disk. In-memory and on-disk never diverge in a way that
+  // re-announces an open episode after a restart.
   latch.prev = latched;
-  persist({ latched });
   return edge;
 }

--- a/plugins/dev/scripts/orch-monitor/lib/account-status-latch.mjs
+++ b/plugins/dev/scripts/orch-monitor/lib/account-status-latch.mjs
@@ -153,7 +153,16 @@ const defaultEmit = (env) => emitEventLog(env);
 export async function checkAccountStatusTransition(summary, opts = {}) {
   const { emit = defaultEmit, state = null } = opts;
   const usingModule = state === null;
-  if (usingModule) hydrateLatch();
+  if (usingModule) {
+    hydrateLatch();
+    // hydrateLatch() leaves `_hydrated` false on a transient (non-ENOENT) read
+    // error and touches nothing else. Evaluating anyway would fall through to
+    // the default in-memory `prev:false` — if the persisted latch is actually
+    // still open, that can emit a duplicate `account.status.changed` on a
+    // sustained `rejected` reading. Abort this tick instead; the next tick
+    // retries hydration before evaluating.
+    if (!_hydrated) return null;
+  }
   const latch = usingModule ? _moduleLatch : state;
   const persist = opts.persist ?? (usingModule ? persistLatchToDisk : () => true);
 

--- a/plugins/dev/scripts/orch-monitor/lib/accounts-probe.d.mts
+++ b/plugins/dev/scripts/orch-monitor/lib/accounts-probe.d.mts
@@ -29,7 +29,8 @@ export interface AccountView {
 export type AccountsNodeStatus = "ok" | "degraded" | "rejected" | "error" | "unknown";
 
 /** The node-scoped summary the API/dashboards consume. Token-free by construction. */
-export interface AccountsSummary {
+export interface AccountsSummaryAvailable {
+  available?: true;
   node: string | null;
   generatedAt: string | null;
   status: AccountsNodeStatus;
@@ -37,6 +38,18 @@ export interface AccountsSummary {
   accounts: AccountView[];
   siblingWithHeadroom: { label: string | null; email: string | null } | null;
 }
+
+/**
+ * The reduced shape deriveAccountsSummary returns for `raw.available === false`
+ * (no `claude-accounts.env` on this node) — the SAME minimal shape the disabled
+ * (`accountsProbeExec:null`) path returns, so a caller can't tell the two apart.
+ */
+export interface AccountsSummaryUnavailable {
+  available: false;
+  node: string | null;
+}
+
+export type AccountsSummary = AccountsSummaryAvailable | AccountsSummaryUnavailable;
 
 /** A summary returned from the cache, stamped with probe time + cache-hit flag. */
 export type CachedAccountsSummary = AccountsSummary & { probedAt: number; cached: boolean };

--- a/plugins/dev/scripts/orch-monitor/lib/accounts-probe.d.mts
+++ b/plugins/dev/scripts/orch-monitor/lib/accounts-probe.d.mts
@@ -59,6 +59,7 @@ export interface AccountsProbe {
 export declare function createAccountsProbe(opts: {
   exec: () => Promise<unknown>;
   ttlMs?: number;
+  refreshFloorMs?: number;
   now?: () => number;
   node?: string;
 }): AccountsProbe;

--- a/plugins/dev/scripts/orch-monitor/lib/accounts-probe.d.mts
+++ b/plugins/dev/scripts/orch-monitor/lib/accounts-probe.d.mts
@@ -1,0 +1,64 @@
+// Type declarations for accounts-probe.mjs (CTL-1653).
+// The module is authored as .mjs (JS, no tsc gate — runs under bun/node) but
+// server.ts and its tests import it under the TS program; these declarations
+// give those consumers full type safety (mirrors belief-reader.d.ts).
+
+/** One rate-limit window's utilization/reset/status (token-free). */
+export interface AccountWindow {
+  pct: number;
+  resetsAt: string | null;
+  status: string | null;
+}
+
+/** A token-free per-account view (whitelist-mapped from the raw probe record). */
+export interface AccountView {
+  label: string | null;
+  isActive: boolean;
+  email: string | null;
+  overallStatus: string | null;
+  representativeClaim: string | null;
+  fiveHour: AccountWindow | null;
+  sevenDay: AccountWindow | null;
+  error: string | null;
+  /** Only present on the ACTIVE account view: its binding window + status. */
+  bindingWindow?: string | null;
+  bindingStatus?: string | null;
+}
+
+/** The node-scoped node status derived from the active account's binding window. */
+export type AccountsNodeStatus = "ok" | "degraded" | "rejected" | "error" | "unknown";
+
+/** The node-scoped summary the API/dashboards consume. Token-free by construction. */
+export interface AccountsSummary {
+  node: string | null;
+  generatedAt: string | null;
+  status: AccountsNodeStatus;
+  active: AccountView | null;
+  accounts: AccountView[];
+  siblingWithHeadroom: { label: string | null; email: string | null } | null;
+}
+
+/** A summary returned from the cache, stamped with probe time + cache-hit flag. */
+export type CachedAccountsSummary = AccountsSummary & { probedAt: number; cached: boolean };
+
+export declare function defaultAccountsProbeExec(opts?: {
+  envFile?: string;
+  timeoutMs?: number;
+}): Promise<unknown>;
+
+export declare function deriveAccountsSummary(
+  raw: unknown,
+  opts?: { node?: string },
+): AccountsSummary;
+
+export interface AccountsProbe {
+  get(opts?: { refresh?: boolean }): Promise<CachedAccountsSummary>;
+  latest(): AccountsSummary | null;
+}
+
+export declare function createAccountsProbe(opts: {
+  exec: () => Promise<unknown>;
+  ttlMs?: number;
+  now?: () => number;
+  node?: string;
+}): AccountsProbe;

--- a/plugins/dev/scripts/orch-monitor/lib/accounts-probe.d.ts
+++ b/plugins/dev/scripts/orch-monitor/lib/accounts-probe.d.ts
@@ -29,7 +29,8 @@ export interface AccountView {
 export type AccountsNodeStatus = "ok" | "degraded" | "rejected" | "error" | "unknown";
 
 /** The node-scoped summary the API/dashboards consume. Token-free by construction. */
-export interface AccountsSummary {
+export interface AccountsSummaryAvailable {
+  available?: true;
   node: string | null;
   generatedAt: string | null;
   status: AccountsNodeStatus;
@@ -37,6 +38,18 @@ export interface AccountsSummary {
   accounts: AccountView[];
   siblingWithHeadroom: { label: string | null; email: string | null } | null;
 }
+
+/**
+ * The reduced shape deriveAccountsSummary returns for `raw.available === false`
+ * (no `claude-accounts.env` on this node) — the SAME minimal shape the disabled
+ * (`accountsProbeExec:null`) path returns, so a caller can't tell the two apart.
+ */
+export interface AccountsSummaryUnavailable {
+  available: false;
+  node: string | null;
+}
+
+export type AccountsSummary = AccountsSummaryAvailable | AccountsSummaryUnavailable;
 
 /** A summary returned from the cache, stamped with probe time + cache-hit flag. */
 export type CachedAccountsSummary = AccountsSummary & { probedAt: number; cached: boolean };

--- a/plugins/dev/scripts/orch-monitor/lib/accounts-probe.d.ts
+++ b/plugins/dev/scripts/orch-monitor/lib/accounts-probe.d.ts
@@ -59,6 +59,7 @@ export interface AccountsProbe {
 export declare function createAccountsProbe(opts: {
   exec: () => Promise<unknown>;
   ttlMs?: number;
+  refreshFloorMs?: number;
   now?: () => number;
   node?: string;
 }): AccountsProbe;

--- a/plugins/dev/scripts/orch-monitor/lib/accounts-probe.d.ts
+++ b/plugins/dev/scripts/orch-monitor/lib/accounts-probe.d.ts
@@ -1,0 +1,64 @@
+// Type declarations for accounts-probe.mjs (CTL-1653).
+// The module is authored as .mjs (JS, no tsc gate — runs under bun/node) but
+// server.ts and its tests import it under the TS program; these declarations
+// give those consumers full type safety (mirrors belief-reader.d.ts).
+
+/** One rate-limit window's utilization/reset/status (token-free). */
+export interface AccountWindow {
+  pct: number;
+  resetsAt: string | null;
+  status: string | null;
+}
+
+/** A token-free per-account view (whitelist-mapped from the raw probe record). */
+export interface AccountView {
+  label: string | null;
+  isActive: boolean;
+  email: string | null;
+  overallStatus: string | null;
+  representativeClaim: string | null;
+  fiveHour: AccountWindow | null;
+  sevenDay: AccountWindow | null;
+  error: string | null;
+  /** Only present on the ACTIVE account view: its binding window + status. */
+  bindingWindow?: string | null;
+  bindingStatus?: string | null;
+}
+
+/** The node-scoped node status derived from the active account's binding window. */
+export type AccountsNodeStatus = "ok" | "degraded" | "rejected" | "error" | "unknown";
+
+/** The node-scoped summary the API/dashboards consume. Token-free by construction. */
+export interface AccountsSummary {
+  node: string | null;
+  generatedAt: string | null;
+  status: AccountsNodeStatus;
+  active: AccountView | null;
+  accounts: AccountView[];
+  siblingWithHeadroom: { label: string | null; email: string | null } | null;
+}
+
+/** A summary returned from the cache, stamped with probe time + cache-hit flag. */
+export type CachedAccountsSummary = AccountsSummary & { probedAt: number; cached: boolean };
+
+export declare function defaultAccountsProbeExec(opts?: {
+  envFile?: string;
+  timeoutMs?: number;
+}): Promise<unknown>;
+
+export declare function deriveAccountsSummary(
+  raw: unknown,
+  opts?: { node?: string },
+): AccountsSummary;
+
+export interface AccountsProbe {
+  get(opts?: { refresh?: boolean }): Promise<CachedAccountsSummary>;
+  latest(): AccountsSummary | null;
+}
+
+export declare function createAccountsProbe(opts: {
+  exec: () => Promise<unknown>;
+  ttlMs?: number;
+  now?: () => number;
+  node?: string;
+}): AccountsProbe;

--- a/plugins/dev/scripts/orch-monitor/lib/accounts-probe.mjs
+++ b/plugins/dev/scripts/orch-monitor/lib/accounts-probe.mjs
@@ -21,14 +21,22 @@ import { execFile } from "node:child_process";
 import { promisify } from "node:util";
 import { existsSync } from "node:fs";
 import { homedir } from "node:os";
-import { resolve } from "node:path";
+import { resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
 
 const execFileP = promisify(execFile);
-const PROBE = resolve(import.meta.dir, "..", "..", "claude-accounts-usage.mjs");
+// fileURLToPath(import.meta.url) resolves under BOTH bun and node (import.meta.dir
+// is a bun-only extension), so this module loads regardless of the parent runtime.
+const PROBE = resolve(
+  dirname(fileURLToPath(import.meta.url)),
+  "..",
+  "..",
+  "claude-accounts-usage.mjs",
+);
 const ENV_FILE =
   process.env.CLAUDE_ACCOUNTS_ENV ?? resolve(homedir(), ".config/catalyst/claude-accounts.env");
-// bun else node — mirrors catalyst-stack's _ca_node_runtime choice. The probe is
-// pure node:* + fetch, so either runtime runs it.
+// The CHILD runtime that runs the probe: bun else node — mirrors catalyst-stack's
+// _ca_node_runtime choice. The probe is pure node:* + fetch, so either runs it.
 const RUNTIME = existsSync(resolve(homedir(), ".bun/bin/bun")) ? "bun" : "node";
 
 /**
@@ -43,11 +51,17 @@ export async function defaultAccountsProbeExec({ envFile = ENV_FILE, timeoutMs =
   // `set -a` exports every sourced var to the exec'd child only; the token dies
   // with this bash -c subshell and never reaches the monitor's own env.
   const script = `set -a; . "$CATALYST_ACCOUNTS_ENV"; set +a; exec "$RT" "$PROBE" --json`;
+  // Defense-in-depth: strip any ambient CLAUDE_CODE_OAUTH_TOKEN from the child's
+  // inherited env so the sourced accounts file is the SOLE authority for the
+  // active-account selection — a monitor daemon mis-started with the token in its
+  // own env can't silently forward it (the design keeps it out of the monitor env).
+  const childEnv = { ...process.env, CATALYST_ACCOUNTS_ENV: envFile, RT: RUNTIME, PROBE };
+  delete childEnv.CLAUDE_CODE_OAUTH_TOKEN;
   const { stdout } = await execFileP("bash", ["-c", script], {
     encoding: "utf8",
     timeout: timeoutMs,
     maxBuffer: 8 * 1024 * 1024,
-    env: { ...process.env, CATALYST_ACCOUNTS_ENV: envFile, RT: RUNTIME, PROBE },
+    env: childEnv,
   });
   return JSON.parse(stdout);
 }
@@ -74,6 +88,15 @@ function bindingWindowStatus(active) {
   return active.overallStatus ?? null;
 }
 
+// Whitelist-map ONE rate-limit window to a token-free view. RECURSIVE field pick
+// so the "a leaked field can't ride along" guarantee holds at EVERY level, not
+// just the top — a future upstream change that attached anything under a window
+// object can never flow through to the API/SSE.
+function pickWindow(w) {
+  if (!w || typeof w !== "object") return null;
+  return { pct: w.pct ?? null, resetsAt: w.resetsAt ?? null, status: w.status ?? null };
+}
+
 // Whitelist-map ONE raw account to a token-free view. Explicit field pick — never
 // spread the raw record, so a leaked `token` (or any other unexpected field) can't
 // ride along into the summary.
@@ -84,8 +107,8 @@ function pickAccount(a) {
     email: a?.email ?? null,
     overallStatus: a?.overallStatus ?? null,
     representativeClaim: a?.representativeClaim ?? null,
-    fiveHour: a?.fiveHour ?? null,
-    sevenDay: a?.sevenDay ?? null,
+    fiveHour: pickWindow(a?.fiveHour),
+    sevenDay: pickWindow(a?.sevenDay),
     error: a?.error ?? null,
   };
 }
@@ -141,47 +164,79 @@ export function deriveAccountsSummary(raw, { node } = {}) {
  * A throwing exec yields an error posture that is NOT cached (so a transient failure
  * retries next call). `latest()` returns the last posture without probing.
  *
+ * Two DoS guards (each real probe spends one Haiku call PER account):
+ *  - **In-flight coalescing** — concurrent `get()` calls share ONE probe, so a
+ *    burst of parallel requests can never fan out into N subprocesses.
+ *  - **Refresh floor** — a forced `refresh` still serves the cache when it is
+ *    younger than `refreshFloorMs` (< `ttlMs`), so a client cannot loop
+ *    `?refresh=true` to spend unbounded inference / self-exhaust the accounts.
+ *
  * @param {object} o
- * @param {Function} o.exec         async () => raw probe record
- * @param {number}   [o.ttlMs]      cache TTL (default 5 min)
- * @param {Function} [o.now]        injectable clock (default Date.now)
- * @param {string}   o.node         this node's identity
+ * @param {Function} o.exec           async () => raw probe record
+ * @param {number}   [o.ttlMs]        cache TTL for normal reads (default 5 min)
+ * @param {number}   [o.refreshFloorMs] min age before a forced refresh re-probes (default 30 s)
+ * @param {Function} [o.now]          injectable clock (default Date.now)
+ * @param {string}   o.node           this node's identity
  * @returns {{get, latest}}
  */
-export function createAccountsProbe({ exec, ttlMs = 5 * 60 * 1000, now = () => Date.now(), node }) {
+export function createAccountsProbe({
+  exec,
+  ttlMs = 5 * 60 * 1000,
+  refreshFloorMs = 30 * 1000,
+  now = () => Date.now(),
+  node,
+}) {
   let cache = null; // { summary, probedAt }
+  let inflight = null; // shared promise while a probe is running (coalescing)
+
+  function serveCache() {
+    return { ...cache.summary, probedAt: cache.probedAt, cached: true };
+  }
+
+  function runProbe() {
+    if (inflight) return inflight; // coalesce concurrent callers onto one probe
+    inflight = (async () => {
+      try {
+        const raw = await exec();
+        const summary = deriveAccountsSummary(raw, { node });
+        cache = { summary, probedAt: now() };
+        return { ...summary, probedAt: cache.probedAt, cached: false };
+      } catch (err) {
+        // Build an error posture over a synthetic error record; return WITHOUT
+        // caching so the next call retries rather than serving a stale error.
+        const errRecord = {
+          generatedAt: new Date(now()).toISOString(),
+          accounts: [
+            {
+              label: null,
+              isActive: true,
+              email: null,
+              overallStatus: null,
+              representativeClaim: null,
+              fiveHour: null,
+              sevenDay: null,
+              error: err?.message ?? String(err),
+            },
+          ],
+        };
+        const summary = deriveAccountsSummary(errRecord, { node });
+        return { ...summary, probedAt: now(), cached: false };
+      } finally {
+        inflight = null;
+      }
+    })();
+    return inflight;
+  }
 
   async function get({ refresh = false } = {}) {
-    if (!refresh && cache && now() - cache.probedAt < ttlMs) {
-      return { ...cache.summary, probedAt: cache.probedAt, cached: true };
+    if (cache) {
+      // Normal reads serve within the full TTL; a forced refresh serves within the
+      // shorter floor. refreshFloorMs < ttlMs, so `refresh` still probes sooner —
+      // it just cannot be looped faster than the floor.
+      const threshold = refresh ? refreshFloorMs : ttlMs;
+      if (now() - cache.probedAt < threshold) return serveCache();
     }
-    let raw;
-    try {
-      raw = await exec();
-    } catch (err) {
-      // Build an error posture over a synthetic error record; return WITHOUT
-      // caching so the next call retries rather than serving a stale error.
-      const errRecord = {
-        generatedAt: new Date(now()).toISOString(),
-        accounts: [
-          {
-            label: null,
-            isActive: true,
-            email: null,
-            overallStatus: null,
-            representativeClaim: null,
-            fiveHour: null,
-            sevenDay: null,
-            error: err?.message ?? String(err),
-          },
-        ],
-      };
-      const summary = deriveAccountsSummary(errRecord, { node });
-      return { ...summary, probedAt: now(), cached: false };
-    }
-    const summary = deriveAccountsSummary(raw, { node });
-    cache = { summary, probedAt: now() };
-    return { ...summary, probedAt: cache.probedAt, cached: false };
+    return runProbe();
   }
 
   function latest() {

--- a/plugins/dev/scripts/orch-monitor/lib/accounts-probe.mjs
+++ b/plugins/dev/scripts/orch-monitor/lib/accounts-probe.mjs
@@ -46,7 +46,15 @@ const RUNTIME = existsSync(resolve(homedir(), ".bun/bin/bun")) ? "bun" : "node";
  * JSON record ({generatedAt, accounts:[…]}). When no env file exists, returns an
  * empty record so the surfaces render "unavailable"/quiet rather than erroring.
  */
-export async function defaultAccountsProbeExec({ envFile = ENV_FILE, timeoutMs = 30000 } = {}) {
+export async function defaultAccountsProbeExec({
+  envFile = ENV_FILE,
+  timeoutMs = 30000,
+  // probePath/runtime default to the module consts (production-identical); they are
+  // injectable ONLY so the secrets-hygiene mechanism is unit-testable against a stub
+  // probe with no network call — see accounts-probe.test.mjs.
+  probePath = PROBE,
+  runtime = RUNTIME,
+} = {}) {
   if (!existsSync(envFile)) return { generatedAt: new Date().toISOString(), accounts: [] };
   // `set -a` exports every sourced var to the exec'd child only; the token dies
   // with this bash -c subshell and never reaches the monitor's own env.
@@ -55,7 +63,7 @@ export async function defaultAccountsProbeExec({ envFile = ENV_FILE, timeoutMs =
   // inherited env so the sourced accounts file is the SOLE authority for the
   // active-account selection — a monitor daemon mis-started with the token in its
   // own env can't silently forward it (the design keeps it out of the monitor env).
-  const childEnv = { ...process.env, CATALYST_ACCOUNTS_ENV: envFile, RT: RUNTIME, PROBE };
+  const childEnv = { ...process.env, CATALYST_ACCOUNTS_ENV: envFile, RT: runtime, PROBE: probePath };
   delete childEnv.CLAUDE_CODE_OAUTH_TOKEN;
   const { stdout } = await execFileP("bash", ["-c", script], {
     encoding: "utf8",
@@ -188,6 +196,8 @@ export function createAccountsProbe({
 }) {
   let cache = null; // { summary, probedAt }
   let inflight = null; // shared promise while a probe is running (coalescing)
+  let lastProbeStartedAt = null; // probe INITIATION clock, set even when the probe errors
+  let lastResult = null; // most recent returned summary (ok OR error posture)
 
   function serveCache() {
     return { ...cache.summary, probedAt: cache.probedAt, cached: true };
@@ -195,12 +205,14 @@ export function createAccountsProbe({
 
   function runProbe() {
     if (inflight) return inflight; // coalesce concurrent callers onto one probe
+    lastProbeStartedAt = now(); // floor gates INITIATION, so record it before exec()
     inflight = (async () => {
       try {
         const raw = await exec();
         const summary = deriveAccountsSummary(raw, { node });
         cache = { summary, probedAt: now() };
-        return { ...summary, probedAt: cache.probedAt, cached: false };
+        lastResult = { ...summary, probedAt: cache.probedAt, cached: false };
+        return lastResult;
       } catch (err) {
         // Build an error posture over a synthetic error record; return WITHOUT
         // caching so the next call retries rather than serving a stale error.
@@ -220,7 +232,8 @@ export function createAccountsProbe({
           ],
         };
         const summary = deriveAccountsSummary(errRecord, { node });
-        return { ...summary, probedAt: now(), cached: false };
+        lastResult = { ...summary, probedAt: now(), cached: false };
+        return lastResult;
       } finally {
         inflight = null;
       }
@@ -229,12 +242,21 @@ export function createAccountsProbe({
   }
 
   async function get({ refresh = false } = {}) {
-    if (cache) {
-      // Normal reads serve within the full TTL; a forced refresh serves within the
-      // shorter floor. refreshFloorMs < ttlMs, so `refresh` still probes sooner —
-      // it just cannot be looped faster than the floor.
-      const threshold = refresh ? refreshFloorMs : ttlMs;
-      if (now() - cache.probedAt < threshold) return serveCache();
+    // Normal reads serve within the full TTL; a forced refresh serves within the
+    // shorter floor. refreshFloorMs < ttlMs, so `refresh` still probes sooner — it
+    // just cannot be looped faster than the floor.
+    const threshold = refresh ? refreshFloorMs : ttlMs;
+    if (cache && now() - cache.probedAt < threshold) return serveCache();
+    // A probe already running: coalesce onto it regardless of the floor.
+    if (inflight) return inflight;
+    // Gate probe INITIATION on the same cadence, not just cache hits: during a
+    // sustained probe failure (errors are intentionally uncached) or a cold start
+    // there is no cache to gate on, yet re-probing must not spawn a fresh subprocess +
+    // Haiku call faster than `threshold` (the DoS the finding flags for ?refresh=true).
+    // Serve the most recent posture (which may be an error) instead of re-probing;
+    // retry once the window lapses.
+    if (lastProbeStartedAt !== null && now() - lastProbeStartedAt < threshold) {
+      if (lastResult) return { ...lastResult, cached: true };
     }
     return runProbe();
   }

--- a/plugins/dev/scripts/orch-monitor/lib/accounts-probe.mjs
+++ b/plugins/dev/scripts/orch-monitor/lib/accounts-probe.mjs
@@ -35,16 +35,41 @@ const PROBE = resolve(
 );
 const ENV_FILE =
   process.env.CLAUDE_ACCOUNTS_ENV ?? resolve(homedir(), ".config/catalyst/claude-accounts.env");
+
+// resolveOnPath — mirrors catalyst-stack's `_ca_node_runtime` (`command -v bun`):
+// scan $PATH for the binary rather than assuming one fixed install location.
+function resolveOnPath(bin) {
+  for (const dir of (process.env.PATH ?? "").split(":")) {
+    if (dir && existsSync(resolve(dir, bin))) return true;
+  }
+  return false;
+}
 // The CHILD runtime that runs the probe: bun else node — mirrors catalyst-stack's
 // _ca_node_runtime choice. The probe is pure node:* + fetch, so either runs it.
-const RUNTIME = existsSync(resolve(homedir(), ".bun/bin/bun")) ? "bun" : "node";
+// Preference order: (1) this process's OWN runtime — when the monitor itself is
+// running under bun, bun is proven present regardless of where it is installed;
+// (2) `bun` resolved from PATH (the _ca_node_runtime parity check, catches a
+// Homebrew/managed install this process happens not to be running under); (3)
+// the historical `~/.bun/bin/bun` default-install check, kept for back-compat;
+// (4) node.
+const RUNTIME =
+  typeof Bun !== "undefined" ||
+  resolveOnPath("bun") ||
+  existsSync(resolve(homedir(), ".bun/bin/bun"))
+    ? "bun"
+    : "node";
 
 /**
  * defaultAccountsProbeExec — run the CTL-1650 probe in a subshell that sources the
  * accounts env so CLAUDE_CODE_OAUTH_TOKEN is visible for active-account detection
  * and never enters this (long-lived monitor) process's env. Returns the token-free
  * JSON record ({generatedAt, accounts:[…]}). When no env file exists, returns an
- * empty record so the surfaces render "unavailable"/quiet rather than erroring.
+ * empty `available:false` record so the surfaces render "unavailable"/quiet rather
+ * than erroring (deriveAccountsSummary propagates the flag; see below). When the
+ * probe exits nonzero (e.g. every configured account is invalid/auth-failing), the
+ * token-free JSON it already wrote to stdout is recovered from the rejected exec's
+ * `.stdout` rather than discarded — otherwise a diagnosable per-account auth error
+ * collapses into a synthetic unlabeled spawn-error posture.
  */
 export async function defaultAccountsProbeExec({
   envFile = ENV_FILE,
@@ -55,7 +80,9 @@ export async function defaultAccountsProbeExec({
   probePath = PROBE,
   runtime = RUNTIME,
 } = {}) {
-  if (!existsSync(envFile)) return { generatedAt: new Date().toISOString(), accounts: [] };
+  if (!existsSync(envFile)) {
+    return { generatedAt: new Date().toISOString(), accounts: [], available: false };
+  }
   // `set -a` exports every sourced var to the exec'd child only; the token dies
   // with this bash -c subshell and never reaches the monitor's own env.
   const script = `set -a; . "$CATALYST_ACCOUNTS_ENV"; set +a; exec "$RT" "$PROBE" --json`;
@@ -65,13 +92,28 @@ export async function defaultAccountsProbeExec({
   // own env can't silently forward it (the design keeps it out of the monitor env).
   const childEnv = { ...process.env, CATALYST_ACCOUNTS_ENV: envFile, RT: runtime, PROBE: probePath };
   delete childEnv.CLAUDE_CODE_OAUTH_TOKEN;
-  const { stdout } = await execFileP("bash", ["-c", script], {
-    encoding: "utf8",
-    timeout: timeoutMs,
-    maxBuffer: 8 * 1024 * 1024,
-    env: childEnv,
-  });
-  return JSON.parse(stdout);
+  try {
+    const { stdout } = await execFileP("bash", ["-c", script], {
+      encoding: "utf8",
+      timeout: timeoutMs,
+      maxBuffer: 8 * 1024 * 1024,
+      env: childEnv,
+    });
+    return JSON.parse(stdout);
+  } catch (err) {
+    // Node's promisified execFile attaches the child's stdout/stderr to the
+    // rejection even on a nonzero exit. Recover and parse it so a diagnosable
+    // per-account error (expired token, auth failure) survives; a parse failure
+    // (truly no usable stdout) falls through to rethrowing the original error.
+    if (typeof err?.stdout === "string" && err.stdout.trim() !== "") {
+      try {
+        return JSON.parse(err.stdout);
+      } catch {
+        /* fall through — rethrow below */
+      }
+    }
+    throw err;
+  }
 }
 
 // ── pure status mapping (the single canonical map Phases 3-6 import) ─────────
@@ -128,11 +170,17 @@ function pickAccount(a) {
  *   - active.error (transport)     → "error" (sensor broken, distinct from rejected)
  *   - else the active binding window's status mapped ok|degraded|rejected|unknown
  *
+ * `raw.available === false` (defaultAccountsProbeExec's no-env-file record) short-
+ * circuits to the SAME minimal shape the disabled (`accountsProbeExec:null`) path
+ * returns — no status/active/accounts — so /api/accounts and the SSE frame can't
+ * be told apart from a genuinely disabled probe by callers.
+ *
  * @param {object} raw   the probe's {generatedAt, accounts:[…]} record
  * @param {object} opts  { node }
  * @returns {{node, generatedAt, status, active, accounts, siblingWithHeadroom}}
  */
 export function deriveAccountsSummary(raw, { node } = {}) {
+  if (raw?.available === false) return { node: node ?? null, available: false };
   const accounts = Array.isArray(raw?.accounts) ? raw.accounts.map(pickAccount) : [];
   const active = accounts.find((a) => a.isActive) ?? null;
 

--- a/plugins/dev/scripts/orch-monitor/lib/accounts-probe.mjs
+++ b/plugins/dev/scripts/orch-monitor/lib/accounts-probe.mjs
@@ -1,0 +1,192 @@
+// accounts-probe.mjs — CTL-1653. Node-scoped Claude-account posture for the
+// orch-monitor read surfaces (/api/accounts, the SSE stream, both dashboards).
+//
+// Three exports:
+//   defaultAccountsProbeExec — the production child-process runner. Spawns the
+//     CTL-1650 probe (claude-accounts-usage.mjs --json) in a SUBSHELL that sources
+//     claude-accounts.env so CLAUDE_CODE_OAUTH_TOKEN is set for active-account
+//     detection and dies with the child — the token NEVER enters this long-lived
+//     monitor process's env (secrets hygiene, claude-accounts-usage.mjs:23-26).
+//   deriveAccountsSummary — PURE. Whitelist-maps the token-free probe record into
+//     the node-scoped summary the API/dashboards consume (active account, node
+//     status, siblingWithHeadroom). Never spreads the raw record, so a leaked
+//     `token` field can't ride along.
+//   createAccountsProbe — an async TTL cache around an injected exec (the sync
+//     createMemoizedRead can't wrap an async child-process probe).
+//
+// Exec and clock are injectable, so the whole module is unit-testable with no
+// subprocess and no network.
+
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+import { existsSync } from "node:fs";
+import { homedir } from "node:os";
+import { resolve } from "node:path";
+
+const execFileP = promisify(execFile);
+const PROBE = resolve(import.meta.dir, "..", "..", "claude-accounts-usage.mjs");
+const ENV_FILE =
+  process.env.CLAUDE_ACCOUNTS_ENV ?? resolve(homedir(), ".config/catalyst/claude-accounts.env");
+// bun else node — mirrors catalyst-stack's _ca_node_runtime choice. The probe is
+// pure node:* + fetch, so either runtime runs it.
+const RUNTIME = existsSync(resolve(homedir(), ".bun/bin/bun")) ? "bun" : "node";
+
+/**
+ * defaultAccountsProbeExec — run the CTL-1650 probe in a subshell that sources the
+ * accounts env so CLAUDE_CODE_OAUTH_TOKEN is visible for active-account detection
+ * and never enters this (long-lived monitor) process's env. Returns the token-free
+ * JSON record ({generatedAt, accounts:[…]}). When no env file exists, returns an
+ * empty record so the surfaces render "unavailable"/quiet rather than erroring.
+ */
+export async function defaultAccountsProbeExec({ envFile = ENV_FILE, timeoutMs = 30000 } = {}) {
+  if (!existsSync(envFile)) return { generatedAt: new Date().toISOString(), accounts: [] };
+  // `set -a` exports every sourced var to the exec'd child only; the token dies
+  // with this bash -c subshell and never reaches the monitor's own env.
+  const script = `set -a; . "$CATALYST_ACCOUNTS_ENV"; set +a; exec "$RT" "$PROBE" --json`;
+  const { stdout } = await execFileP("bash", ["-c", script], {
+    encoding: "utf8",
+    timeout: timeoutMs,
+    maxBuffer: 8 * 1024 * 1024,
+    env: { ...process.env, CATALYST_ACCOUNTS_ENV: envFile, RT: RUNTIME, PROBE },
+  });
+  return JSON.parse(stdout);
+}
+
+// ── pure status mapping (the single canonical map Phases 3-6 import) ─────────
+
+// The probe's per-window/overall status vocabulary → the surface tone vocabulary.
+const WINDOW_STATUS_MAP = {
+  allowed: "ok",
+  allowed_warning: "degraded",
+  rejected: "rejected",
+};
+
+function mapWindowStatus(status) {
+  return WINDOW_STATUS_MAP[status] ?? "unknown";
+}
+
+// The active account's binding window's raw status, via representativeClaim.
+function bindingWindowStatus(active) {
+  if (!active) return null;
+  if (active.representativeClaim === "five_hour") return active.fiveHour?.status ?? null;
+  if (active.representativeClaim === "seven_day") return active.sevenDay?.status ?? null;
+  // No representative claim — fall back to the overall status.
+  return active.overallStatus ?? null;
+}
+
+// Whitelist-map ONE raw account to a token-free view. Explicit field pick — never
+// spread the raw record, so a leaked `token` (or any other unexpected field) can't
+// ride along into the summary.
+function pickAccount(a) {
+  return {
+    label: a?.label ?? null,
+    isActive: Boolean(a?.isActive),
+    email: a?.email ?? null,
+    overallStatus: a?.overallStatus ?? null,
+    representativeClaim: a?.representativeClaim ?? null,
+    fiveHour: a?.fiveHour ?? null,
+    sevenDay: a?.sevenDay ?? null,
+    error: a?.error ?? null,
+  };
+}
+
+/**
+ * deriveAccountsSummary — PURE. Map the token-free probe record into the
+ * node-scoped summary. Node `status`:
+ *   - no active account            → "unknown"
+ *   - active.error (transport)     → "error" (sensor broken, distinct from rejected)
+ *   - else the active binding window's status mapped ok|degraded|rejected|unknown
+ *
+ * @param {object} raw   the probe's {generatedAt, accounts:[…]} record
+ * @param {object} opts  { node }
+ * @returns {{node, generatedAt, status, active, accounts, siblingWithHeadroom}}
+ */
+export function deriveAccountsSummary(raw, { node } = {}) {
+  const accounts = Array.isArray(raw?.accounts) ? raw.accounts.map(pickAccount) : [];
+  const active = accounts.find((a) => a.isActive) ?? null;
+
+  let status;
+  if (!active) {
+    status = "unknown";
+  } else if (active.error) {
+    status = "error";
+  } else {
+    status = mapWindowStatus(bindingWindowStatus(active));
+  }
+
+  const activeView = active
+    ? {
+        ...active,
+        bindingWindow: active.representativeClaim,
+        bindingStatus: bindingWindowStatus(active),
+      }
+    : null;
+
+  const sibling = accounts.find((a) => !a.isActive && a.overallStatus === "allowed");
+  const siblingWithHeadroom = sibling ? { label: sibling.label, email: sibling.email } : null;
+
+  return {
+    node: node ?? null,
+    generatedAt: raw?.generatedAt ?? null,
+    status,
+    active: activeView,
+    accounts,
+    siblingWithHeadroom,
+  };
+}
+
+/**
+ * createAccountsProbe — an async TTL cache around an injected exec. `get({refresh})`
+ * serves the cached summary while fresh; otherwise probes, derives, caches, returns.
+ * A throwing exec yields an error posture that is NOT cached (so a transient failure
+ * retries next call). `latest()` returns the last posture without probing.
+ *
+ * @param {object} o
+ * @param {Function} o.exec         async () => raw probe record
+ * @param {number}   [o.ttlMs]      cache TTL (default 5 min)
+ * @param {Function} [o.now]        injectable clock (default Date.now)
+ * @param {string}   o.node         this node's identity
+ * @returns {{get, latest}}
+ */
+export function createAccountsProbe({ exec, ttlMs = 5 * 60 * 1000, now = () => Date.now(), node }) {
+  let cache = null; // { summary, probedAt }
+
+  async function get({ refresh = false } = {}) {
+    if (!refresh && cache && now() - cache.probedAt < ttlMs) {
+      return { ...cache.summary, probedAt: cache.probedAt, cached: true };
+    }
+    let raw;
+    try {
+      raw = await exec();
+    } catch (err) {
+      // Build an error posture over a synthetic error record; return WITHOUT
+      // caching so the next call retries rather than serving a stale error.
+      const errRecord = {
+        generatedAt: new Date(now()).toISOString(),
+        accounts: [
+          {
+            label: null,
+            isActive: true,
+            email: null,
+            overallStatus: null,
+            representativeClaim: null,
+            fiveHour: null,
+            sevenDay: null,
+            error: err?.message ?? String(err),
+          },
+        ],
+      };
+      const summary = deriveAccountsSummary(errRecord, { node });
+      return { ...summary, probedAt: now(), cached: false };
+    }
+    const summary = deriveAccountsSummary(raw, { node });
+    cache = { summary, probedAt: now() };
+    return { ...summary, probedAt: cache.probedAt, cached: false };
+  }
+
+  function latest() {
+    return cache?.summary ?? null;
+  }
+
+  return { get, latest };
+}

--- a/plugins/dev/scripts/orch-monitor/lib/accounts-timer.d.mts
+++ b/plugins/dev/scripts/orch-monitor/lib/accounts-timer.d.mts
@@ -1,0 +1,21 @@
+// Type declarations for accounts-timer.mjs (CTL-1653).
+// Authored as .mjs (no tsc gate) but imported under the TS program by server.ts;
+// these types give that consumer full type safety (mirrors accounts-probe.d.ts).
+
+import type { AccountsProbe, CachedAccountsSummary } from "./accounts-probe";
+
+export interface AccountsTimer {
+  start(): void;
+  stop(): void;
+}
+
+export declare function createAccountsTimer(opts: {
+  probe: Pick<AccountsProbe, "get">;
+  clock?: {
+    setInterval: (fn: () => void, ms: number) => unknown;
+    clearInterval: (handle: unknown) => void;
+  };
+  intervalMs?: number;
+  onTick?: (summary: CachedAccountsSummary) => void;
+  onError?: (err: unknown) => void;
+}): AccountsTimer;

--- a/plugins/dev/scripts/orch-monitor/lib/accounts-timer.d.ts
+++ b/plugins/dev/scripts/orch-monitor/lib/accounts-timer.d.ts
@@ -1,0 +1,21 @@
+// Type declarations for accounts-timer.mjs (CTL-1653).
+// Authored as .mjs (no tsc gate) but imported under the TS program by server.ts;
+// these types give that consumer full type safety (mirrors accounts-probe.d.ts).
+
+import type { AccountsProbe, CachedAccountsSummary } from "./accounts-probe";
+
+export interface AccountsTimer {
+  start(): void;
+  stop(): void;
+}
+
+export declare function createAccountsTimer(opts: {
+  probe: Pick<AccountsProbe, "get">;
+  clock?: {
+    setInterval: (fn: () => void, ms: number) => unknown;
+    clearInterval: (handle: unknown) => void;
+  };
+  intervalMs?: number;
+  onTick?: (summary: CachedAccountsSummary) => void;
+  onError?: (err: unknown) => void;
+}): AccountsTimer;

--- a/plugins/dev/scripts/orch-monitor/lib/accounts-timer.mjs
+++ b/plugins/dev/scripts/orch-monitor/lib/accounts-timer.mjs
@@ -1,0 +1,64 @@
+// accounts-timer.mjs — CTL-1653. A periodic driver that refreshes the Phase-1
+// accounts cache and hands each fresh summary to onTick (which server.ts fans
+// out to /api/accounts/stream SSE subscribers + the Phase-4 transition latch).
+//
+// Modeled on worktree-refresh-timer.mjs (injectable `clock` seam,
+// handle.unref()) + service-health-monitor.ts (immediate first tick). A tick
+// NEVER throws out of the interval — a probe rejection is swallowed so a flaky
+// probe can't crash the interval or wedge the monitor.
+
+function realClock() {
+  return {
+    setInterval: (fn, ms) => setInterval(fn, ms),
+    clearInterval: (handle) => clearInterval(handle),
+  };
+}
+
+/**
+ * createAccountsTimer — build the periodic accounts-probe driver.
+ *
+ * @param {object} o
+ * @param {{get: (opts?: {refresh?: boolean}) => Promise<unknown>}} o.probe  the Phase-1 cache
+ * @param {object}   [o.clock]        fake-clock seam for tests (setInterval/clearInterval)
+ * @param {number}   [o.intervalMs]   probe cadence (default 5 min)
+ * @param {Function} o.onTick         called with each fresh summary
+ * @param {Function} [o.onError]      optional error sink (default console.error)
+ * @returns {{start: () => void, stop: () => void}}
+ */
+export function createAccountsTimer({
+  probe,
+  clock = realClock(),
+  intervalMs = 5 * 60 * 1000,
+  onTick,
+  onError = (err) => console.error("[accounts-timer] tick error:", err),
+} = {}) {
+  let handle = null;
+
+  async function tick() {
+    try {
+      const summary = await probe.get({ refresh: true });
+      onTick?.(summary);
+    } catch (err) {
+      // Swallow — a probe rejection must never escape the interval.
+      onError?.(err);
+    }
+  }
+
+  function start() {
+    // Immediate first tick (service-health style) so a fresh connection has a
+    // posture without waiting a whole interval. Fire-and-forget; tick() is
+    // never-throw, so a synchronous scheduling error can't escape start().
+    void tick();
+    handle = clock.setInterval(() => {
+      void tick();
+    }, intervalMs);
+    if (typeof handle?.unref === "function") handle.unref();
+  }
+
+  function stop() {
+    if (handle) clock.clearInterval(handle);
+    handle = null;
+  }
+
+  return { start, stop };
+}

--- a/plugins/dev/scripts/orch-monitor/server.ts
+++ b/plugins/dev/scripts/orch-monitor/server.ts
@@ -2469,10 +2469,25 @@ export function createServer(opts: CreateServerOptions): BunServer {
         // (active account + per-window utilization/resets/status +
         // siblingWithHeadroom), token-free, cached ~5 min. `?refresh=true`
         // forces a fresh probe. Disabled (accountsProbeExec:null) → a stable
-        // available:false response, matching the dbPath-gated endpoints.
+        // available:false response, matching the dbPath-gated endpoints. A
+        // no-env-file probe result carries its own available:false (see
+        // deriveAccountsSummary), which overrides the literal below via spread.
         if (url.pathname === "/api/accounts") {
           if (!accountsProbe) return Response.json({ available: false, node: hostName() });
           const refresh = url.searchParams.get("refresh") === "true";
+          // CROSS-ORIGIN GUARD on the state-changing path only. The monitor binds
+          // 0.0.0.0 with no auth, and `refresh=true` is the one per-request probe
+          // trigger — spending a real Haiku call per account (bounded by the
+          // refresh floor, but not to zero). Without this, any page the operator
+          // visits could drive it repeatedly. Same allowlist as the reply route
+          // (lib/trusted-origin.mjs); an absent Origin (non-browser callers) is
+          // allowed — see isOriginAllowed's doc comment.
+          if (refresh && !originAllowed(req.headers.get("origin"))) {
+            return Response.json(
+              { status: "forbidden", error: "cross-origin refresh rejected" },
+              { status: 403 },
+            );
+          }
           const summary = await accountsProbe.get({ refresh });
           return Response.json({ available: true, ...summary });
         }

--- a/plugins/dev/scripts/orch-monitor/server.ts
+++ b/plugins/dev/scripts/orch-monitor/server.ts
@@ -1102,9 +1102,15 @@ export function createServer(opts: CreateServerOptions): BunServer {
             }
           }
           // CTL-1653 Phase 4: edge-triggered account.status.changed emit. Best-
-          // effort — a marker/IO hiccup must never kill the tick.
+          // effort — a marker/IO hiccup must never kill the tick. The fn is async,
+          // so a synchronous try/catch cannot see a rejected promise; attach a
+          // .catch() so a future change that introduces a rejection can never
+          // become an unhandled rejection (the synchronous try/catch is retained
+          // for a throw before the first await).
           try {
-            void checkAccountStatusTransition(s);
+            checkAccountStatusTransition(s).catch((err) => {
+              console.error(`[server] account status transition check rejected:`, err);
+            });
           } catch (err) {
             console.error(`[server] account status transition check failed:`, err);
           }

--- a/plugins/dev/scripts/orch-monitor/server.ts
+++ b/plugins/dev/scripts/orch-monitor/server.ts
@@ -616,6 +616,9 @@ export interface CreateServerOptions {
   accountsProbeExec?: AccountsProbeExec | null;
   /** CTL-1653: accounts cache TTL (default 5 min). Also the periodic timer interval. */
   accountsTtlMs?: number;
+  /** CTL-1653: min age before a forced `?refresh=true` re-probes (default 30 s) —
+   *  the DoS floor that stops a client looping refresh to spend unbounded inference. */
+  accountsRefreshFloorMs?: number;
 }
 
 const DEFAULT_PORT = 7400;
@@ -948,6 +951,7 @@ export function createServer(opts: CreateServerOptions): BunServer {
     deploymentModeReader: deploymentModeReaderOpt,
     accountsProbeExec: accountsProbeExecOpt,
     accountsTtlMs = 5 * 60 * 1000,
+    accountsRefreshFloorMs = 30 * 1000,
   } = opts;
 
   const buildOpts: BuildSnapshotOptions = { dbPath, runsDir };
@@ -1077,6 +1081,7 @@ export function createServer(opts: CreateServerOptions): BunServer {
       : createAccountsProbe({
           exec: accountsProbeExecOpt ?? defaultAccountsProbeExec,
           ttlMs: accountsTtlMs,
+          refreshFloorMs: accountsRefreshFloorMs,
           node: hostName(),
         });
 

--- a/plugins/dev/scripts/orch-monitor/server.ts
+++ b/plugins/dev/scripts/orch-monitor/server.ts
@@ -54,10 +54,7 @@ import { readCapacityHistory } from "./lib/capacity-history.mjs";
 // queryable run entity (/api/ticket-runs/<id>) + serve one signal verbatim
 // (/api/ec-worker/<ticket>/<phase>). Pure file-reads of resident signals — no
 // live Linear/GitHub call per request.
-import {
-  assembleTicketRuns,
-  readPhaseSignalVerbatim,
-} from "./lib/ticket-runs.mjs";
+import { assembleTicketRuns, readPhaseSignalVerbatim } from "./lib/ticket-runs.mjs";
 // CTL-1100: FSM descriptor endpoint. Confirmed bun:sqlite-free (no computed
 // specifier needed — plain static import is safe for Vite/esbuild graph).
 import { buildFsmDescriptor } from "../lib/fsm-descriptor.mjs";
@@ -86,10 +83,7 @@ import { assembleJourney } from "./lib/journey.mjs";
 // is the EC equivalent — tails ~/.claude/projects/*/<sessionId>.jsonl and
 // emits typed StreamEvents over SSE for the worker [● live] tab + reasoning
 // rows + footer counters + the ticket active-node live tail.
-import {
-  resolveTranscriptPath,
-  TranscriptTail,
-} from "./lib/ec-worker-stream.mjs";
+import { resolveTranscriptPath, TranscriptTail } from "./lib/ec-worker-stream.mjs";
 // CTL-885 (BFF3): the cross-node live-tail SSE FAN-IN. The /api/ec-worker-stream
 // route is made node-aware: single-host (hosts.json absent/len 1) is an EXACT
 // identity no-op (tail the LOCAL transcript, zero added latency, no owner
@@ -108,11 +102,7 @@ import {
 // "Unknown command: /catalyst-dev:phase-plan" wedge). No follow flag exists, so
 // /api/ec-worker-screen/<shortId> polls every SCREEN_POLL_MS, ANSI-normalizes,
 // diffs, and pushes only CHANGED full-screen frames over SSE.
-import {
-  ScreenPoller,
-  deriveScreenShortId,
-  SCREEN_POLL_MS,
-} from "./lib/ec-worker-screen.mjs";
+import { ScreenPoller, deriveScreenShortId, SCREEN_POLL_MS } from "./lib/ec-worker-screen.mjs";
 import type { ScreenLogsExec } from "./lib/ec-worker-screen.mjs";
 import { hostName } from "./lib/canonical-event-shared.ts";
 // CTL-890 (BFF8): the read-model's ONE destructive endpoint (design P10) —
@@ -130,10 +120,7 @@ import { stopWorker, type StopWorkerResult } from "./lib/stop-worker.mjs";
 // multi-host rejects a stale/partitioned generation). Optimistic rollback is a
 // UI-side timer; the endpoint returns the verbatim ticket+phase identity the
 // client needs to mark the row `resuming` and arm that timer.
-import {
-  respondTicket,
-  type RespondTicketResult,
-} from "./lib/respond-ticket.mjs";
+import { respondTicket, type RespondTicketResult } from "./lib/respond-ticket.mjs";
 // CTL-1569: the inbox conversation surface. Two routes, deliberately split by
 // posture — GET /thread is a pure REPLICA read (zero Linear API calls, so it is
 // safe on a hover-speed path), POST /reply is the one write that posts a REAL,
@@ -141,13 +128,16 @@ import {
 // via CTL-1567). The reply path is a SIBLING of /respond, not a replacement: see
 // lib/reply-ticket.mjs for why /respond's synthetic null-author event and its
 // hard held-run requirement make it unusable for this surface.
-import {
-  getConversation,
-  loadGlobalConfig,
-  loadProjectConfig,
-} from "./lib/inbox-conversation.mjs";
+import { getConversation, loadGlobalConfig, loadProjectConfig } from "./lib/inbox-conversation.mjs";
 import { replyToTicket } from "./lib/reply-ticket.mjs";
 import { buildTrustedOrigins, isOriginAllowed } from "./lib/trusted-origin.mjs";
+// CTL-1653: node-scoped Claude-account posture surface. The probe runner spawns
+// claude-accounts-usage.mjs in a token-scoped subshell (defaultAccountsProbeExec);
+// the async TTL cache serves /api/accounts + the /api/accounts/stream SSE.
+import { createAccountsProbe, defaultAccountsProbeExec } from "./lib/accounts-probe.mjs";
+/** CTL-1653: the injectable child-process seam for the Claude-account probe.
+ *  Production is defaultAccountsProbeExec; tests inject a scripted fake record. */
+type AccountsProbeExec = () => Promise<unknown>;
 /** Canonical ticket key for the conversation routes: a team prefix that may carry
  *  digits/underscores (`OPS_2-17`), then `-<number>`. Anchored, and containing no
  *  path characters, so it cannot express a traversal. */
@@ -165,11 +155,7 @@ import {
   flattenTodosForWorker,
   streamFilePath,
 } from "./lib/subagent-tree";
-import {
-  sessionIdFromPid,
-  readWorkerTasks,
-  getTaskDiagnostic,
-} from "./lib/task-reader";
+import { sessionIdFromPid, readWorkerTasks, getTaskDiagnostic } from "./lib/task-reader";
 import {
   createEvent,
   parseFilter,
@@ -196,7 +182,11 @@ import { collectInboxItemState } from "./lib/inbox-state";
 import { loadAiConfig } from "./lib/ai-config";
 import type { SummarizeHandler } from "./lib/summarize";
 import { createSummarizeHandler } from "./lib/summarize";
-import { loadSummarizeConfig, type SummarizeConfig, type ProviderName } from "./lib/summarize/config";
+import {
+  loadSummarizeConfig,
+  type SummarizeConfig,
+  type ProviderName,
+} from "./lib/summarize/config";
 import { buildSummarizeSnapshot } from "./lib/summarize/snapshot";
 import { getProvider, type SummarizeProvider } from "./lib/summarize/providers";
 import { createCache } from "./lib/summarize/cache";
@@ -206,15 +196,9 @@ import {
   type ActivityWindow,
   VALID_ACTIVITY_WINDOWS,
 } from "./lib/activity-briefing";
-import {
-  createPreviewFetcher,
-  type PreviewFetcher,
-} from "./lib/preview-status";
+import { createPreviewFetcher, type PreviewFetcher } from "./lib/preview-status";
 import { writeMergedSignalFile } from "./lib/signal-writer";
-import {
-  createWebhookHandler,
-  type WebhookHandler,
-} from "./lib/webhook-handler";
+import { createWebhookHandler, type WebhookHandler } from "./lib/webhook-handler";
 import { createFileBasedPrCache } from "./lib/pr-cache";
 import {
   resolveOrchestrator as resolveOrchestratorFn,
@@ -235,14 +219,8 @@ import {
   type WebhookSubscriber,
   type SubscriberRunner,
 } from "./lib/webhook-subscriber";
-import {
-  createWebhookReplay,
-  type WebhookReplay,
-} from "./lib/webhook-replay";
-import {
-  createEventLogWriter,
-  type EventLogWriter,
-} from "./lib/event-log";
+import { createWebhookReplay, type WebhookReplay } from "./lib/webhook-replay";
+import { createEventLogWriter, type EventLogWriter } from "./lib/event-log";
 import { validatePredicate, createFilterStream, type FilterStream } from "./lib/event-filter";
 import {
   readBacklog,
@@ -266,15 +244,9 @@ import { loadProjects } from "./lib/project-roster";
 import { validateProjectPatch, writeProjectPatch } from "./lib/config-writer";
 // CTL-961: per-repo favicon auto-detection via GitHub API + disk cache.
 import { fetchRepoIcon } from "./lib/repo-icon-fetcher";
-import {
-  createPrometheusFetcher,
-  type PrometheusFetcher,
-} from "./lib/prometheus";
+import { createPrometheusFetcher, type PrometheusFetcher } from "./lib/prometheus";
 import { createLokiFetcher, type LokiFetcher } from "./lib/loki";
-import {
-  createOtelHealthChecker,
-  type OtelHealthChecker,
-} from "./lib/otel-health";
+import { createOtelHealthChecker, type OtelHealthChecker } from "./lib/otel-health";
 // CTL-1050: the service-health registry (one severity model, shared with CTL-1039).
 import {
   createServiceHealthMonitor,
@@ -330,11 +302,7 @@ import {
   deleteAnnotation,
 } from "./lib/annotations";
 import { startTerminalRenderer, type RenderOptions } from "./lib/terminal";
-import {
-  createCommsReader,
-  isValidChannelName,
-  type CommsReader,
-} from "./lib/comms-reader";
+import { createCommsReader, isValidChannelName, type CommsReader } from "./lib/comms-reader";
 // CTL-889 (P8/P9/P12): cache-backed Linear detail / artifacts / search readers.
 // All three read EXCLUSIVELY from durable caches (filter-state.db ticket_state +
 // the local thoughts tree) and NEVER do a synchronous live Linear call per
@@ -597,6 +565,15 @@ export interface CreateServerOptions {
    * without touching process.env or real config files.
    */
   deploymentModeReader?: (() => string) | null;
+  /**
+   * CTL-1653: override for the child-process Claude-account probe runner.
+   * Production spawns claude-accounts-usage.mjs in a token-scoped subshell
+   * (defaultAccountsProbeExec); tests inject a scripted fake; null disables
+   * the endpoint + periodic timer entirely (returns available:false).
+   */
+  accountsProbeExec?: AccountsProbeExec | null;
+  /** CTL-1653: accounts cache TTL (default 5 min). Also the periodic timer interval. */
+  accountsTtlMs?: number;
 }
 
 const DEFAULT_PORT = 7400;
@@ -658,10 +635,7 @@ function collectPrRefs(snapshot: MonitorSnapshot): PrRef[] {
   return refs;
 }
 
-function applyPrStatus(
-  snapshot: MonitorSnapshot,
-  fetcher: PrStatusFetcher,
-): MonitorSnapshot {
+function applyPrStatus(snapshot: MonitorSnapshot, fetcher: PrStatusFetcher): MonitorSnapshot {
   for (const orch of snapshot.orchestrators) {
     for (const worker of Object.values(orch.workers)) {
       if (!worker.pr) continue;
@@ -704,10 +678,7 @@ function applyPrStatus(
   return snapshot;
 }
 
-function applyPreviewStatus(
-  snapshot: MonitorSnapshot,
-  fetcher: PreviewFetcher,
-): void {
+function applyPreviewStatus(snapshot: MonitorSnapshot, fetcher: PreviewFetcher): void {
   for (const orch of snapshot.orchestrators) {
     for (const worker of Object.values(orch.workers)) {
       if (!worker.pr) continue;
@@ -743,30 +714,17 @@ const SSE_EVENTS = EVENT_TYPES;
 const BUS_BROADCAST_EVENTS = SSE_EVENTS.filter(
   (t) => t !== "global-event" && t !== "global-event-backlog",
 );
-const ALLOWED_PUBLIC_EXTENSIONS = new Set([
-  ".html",
-  ".css",
-  ".js",
-  ".svg",
-  ".png",
-  ".ico",
-]);
+const ALLOWED_PUBLIC_EXTENSIONS = new Set([".html", ".css", ".js", ".svg", ".png", ".ico"]);
 
 // CTL-1088: choose the served public dir. Prefer the out-of-repo dist the wrapper
 // built into (MONITOR_PUBLIC_DIR); fall back to the committed bundle when the env
 // var is unset/empty or points at a missing dir (cold-start path).
-export function resolvePublicDir(
-  envDir: string | undefined,
-  fallback: string,
-): string {
+export function resolvePublicDir(envDir: string | undefined, fallback: string): string {
   if (envDir && envDir.length > 0 && existsSync(envDir)) return envDir;
   return fallback;
 }
 
-function resolveSafeStaticPath(
-  publicDir: string,
-  relative: string,
-): string | null {
+function resolveSafeStaticPath(publicDir: string, relative: string): string | null {
   let realRoot: string;
   try {
     realRoot = realpathSync(publicDir);
@@ -801,7 +759,7 @@ function isSafeArchiveFileRel(s: string): boolean {
   if (s.length === 0 || s.length > 250) return false;
   if (s.startsWith("/")) return false;
   if (ARCHIVE_FILE_REL_FORBIDDEN.test(s)) return false;
-  return s.split("/").every((seg) => seg === "" ? false : SAFE_ARCHIVE_PART.test(seg));
+  return s.split("/").every((seg) => (seg === "" ? false : SAFE_ARCHIVE_PART.test(seg)));
 }
 
 function contentTypeForArchive(path: string): string {
@@ -885,10 +843,7 @@ export function createServer(opts: CreateServerOptions): BunServer {
     catalystDir: catalystDirOpt,
     runsDir = null,
     startWatcher = true,
-    publicDir = resolvePublicDir(
-      process.env.MONITOR_PUBLIC_DIR,
-      join(import.meta.dir, "public"),
-    ),
+    publicDir = resolvePublicDir(process.env.MONITOR_PUBLIC_DIR, join(import.meta.dir, "public")),
     pidFile,
     prStatusFetcher,
     prStatusRefreshMs = PR_STATUS_REFRESH_MS,
@@ -927,12 +882,13 @@ export function createServer(opts: CreateServerOptions): BunServer {
     pushSubscriptionsDbPath,
     vapidKeysPath,
     deploymentModeReader: deploymentModeReaderOpt,
+    accountsProbeExec: accountsProbeExecOpt,
+    accountsTtlMs = 5 * 60 * 1000,
   } = opts;
 
   const buildOpts: BuildSnapshotOptions = { dbPath, runsDir };
 
-  const CATALYST_DIR =
-    catalystDirOpt ?? process.env.CATALYST_DIR ?? `${process.env.HOME}/catalyst`;
+  const CATALYST_DIR = catalystDirOpt ?? process.env.CATALYST_DIR ?? `${process.env.HOME}/catalyst`;
   const annDbPath = annotationsDbPath ?? `${CATALYST_DIR}/annotations.db`;
   // CTL-1153 (M2): injectable config path for PUT /api/projects/:key + GET /api/projects.
   // Injected in tests to avoid rewriting the committed workspace config.json.
@@ -963,21 +919,14 @@ export function createServer(opts: CreateServerOptions): BunServer {
   // possibly-missing CATALYST_DIR nor open the module-level push-subscriptions
   // singleton, which would otherwise leak across tests in one `bun test` run.
   const pushConfigured =
-    pushBridgeOpt !== false ||
-    vapidKeysPath != null ||
-    pushSubscriptionsDbPath != null;
+    pushBridgeOpt !== false || vapidKeysPath != null || pushSubscriptionsDbPath != null;
   let vapidKeys: VapidKeys | null = null;
   if (pushConfigured) {
-    const pushSubsDbPath =
-      pushSubscriptionsDbPath ?? `${CATALYST_DIR}/push-subscriptions.db`;
+    const pushSubsDbPath = pushSubscriptionsDbPath ?? `${CATALYST_DIR}/push-subscriptions.db`;
     const vapidPath = vapidKeysPath ?? `${CATALYST_DIR}/vapid-keys.json`;
     vapidKeys = loadOrCreateVapidKeys(vapidPath);
     pushStore.openDb(pushSubsDbPath);
-    webpush.setVapidDetails(
-      "mailto:catalyst@localhost",
-      vapidKeys.publicKey,
-      vapidKeys.privateKey,
-    );
+    webpush.setVapidDetails("mailto:catalyst@localhost", vapidKeys.publicKey, vapidKeys.privateKey);
   }
 
   // CTL-1100: in-process LRU cache for /api/beliefs/rates (keyed by max tick_id,
@@ -1007,8 +956,7 @@ export function createServer(opts: CreateServerOptions): BunServer {
       ? null
       : (prStatusFetcher ??
         createPrStatusFetcher({
-          lastWebhookAt: (ref) =>
-            webhookHandlerRef?.getLastWebhookAt(ref.repo, ref.number) ?? null,
+          lastWebhookAt: (ref) => webhookHandlerRef?.getLastWebhookAt(ref.repo, ref.number) ?? null,
         }));
   let lastPrRefresh = 0;
 
@@ -1020,9 +968,7 @@ export function createServer(opts: CreateServerOptions): BunServer {
   // against the 2500/hr cap. Cache-backed by construction: an OPEN linear-breaker
   // can never be tripped from here.
   const linear: LinearFetcher | null =
-    linearFetcher === null
-      ? null
-      : (linearFetcher ?? createCacheBackedLinearFetcher());
+    linearFetcher === null ? null : (linearFetcher ?? createCacheBackedLinearFetcher());
   let linearStarted = false;
 
   const briefingProvider: BriefingProvider | null =
@@ -1034,18 +980,35 @@ export function createServer(opts: CreateServerOptions): BunServer {
   const summarizeHandler: SummarizeHandler | null =
     summarizeHandlerOpt === null ? null : (summarizeHandlerOpt ?? null);
 
-  const activityBriefingConfig: SummarizeConfig =
-    summarizeConfigOpt ?? { enabled: false, defaultProvider: "anthropic", defaultModel: "claude-sonnet-4-6", providers: {} };
+  const activityBriefingConfig: SummarizeConfig = summarizeConfigOpt ?? {
+    enabled: false,
+    defaultProvider: "anthropic",
+    defaultModel: "claude-sonnet-4-6",
+    providers: {},
+  };
 
   const prom: PrometheusFetcher | null =
     promFetcherOpt === null
       ? null
-      : (promFetcherOpt ?? (prometheusUrl ? createPrometheusFetcher({ baseUrl: prometheusUrl }) : null));
+      : (promFetcherOpt ??
+        (prometheusUrl ? createPrometheusFetcher({ baseUrl: prometheusUrl }) : null));
 
   const loki: LokiFetcher | null =
     lokiFetcherOpt === null
       ? null
       : (lokiFetcherOpt ?? (lokiUrl ? createLokiFetcher({ baseUrl: lokiUrl }) : null));
+
+  // CTL-1653: the node-scoped Claude-account posture probe (cached ~5 min).
+  // null disables /api/accounts + the periodic timer entirely (available:false),
+  // matching the dbPath-gated endpoints; a scripted exec is injected in tests.
+  const accountsProbe =
+    accountsProbeExecOpt === null
+      ? null
+      : createAccountsProbe({
+          exec: accountsProbeExecOpt ?? defaultAccountsProbeExec,
+          ttlMs: accountsTtlMs,
+          node: hostName(),
+        });
 
   // CTL-1050: the service-health registry monitor — ONE severity model shared by
   // the Fleet Ops strip, the outage emitter, the inbox decoration, AND the
@@ -1118,8 +1081,7 @@ export function createServer(opts: CreateServerOptions): BunServer {
         lokiSeverity: () =>
           serviceHealth.snapshot().services.find((s) => s.id === "loki")?.severity ?? null,
         prometheusSeverity: () =>
-          serviceHealth.snapshot().services.find((s) => s.id === "prometheus")?.severity ??
-          null,
+          serviceHealth.snapshot().services.find((s) => s.id === "prometheus")?.severity ?? null,
       },
     });
 
@@ -1129,8 +1091,7 @@ export function createServer(opts: CreateServerOptions): BunServer {
       : (previewFetcherOpt ??
         createPreviewFetcher({
           getPrState: (ref) => prFetcher?.get(ref.repo, ref.number)?.state ?? null,
-          lastWebhookAt: (ref) =>
-            webhookHandlerRef?.getLastWebhookAt(ref.repo, ref.number) ?? null,
+          lastWebhookAt: (ref) => webhookHandlerRef?.getLastWebhookAt(ref.repo, ref.number) ?? null,
         }));
   let lastPreviewRefresh = 0;
 
@@ -1201,8 +1162,7 @@ export function createServer(opts: CreateServerOptions): BunServer {
       previewFetcher: previewFetcher ?? undefined,
       findSignalPaths: findSignalPathsForRef,
       eventLog,
-      resolveOrchestrator: (input) =>
-        resolveOrchestratorFn(input, getActiveOrchestrators()),
+      resolveOrchestrator: (input) => resolveOrchestratorFn(input, getActiveOrchestrators()),
       emit: (type, data) => emit(type, data),
       prCache: createFileBasedPrCache(),
       logger: {
@@ -1314,10 +1274,7 @@ export function createServer(opts: CreateServerOptions): BunServer {
     }
     if (linear && !linearStarted) {
       linearStarted = true;
-      linear.start(
-        () => collectTicketKeys(buildSnapshot(wtDir, buildOpts)),
-        linearRefreshMs,
-      );
+      linear.start(() => collectTicketKeys(buildSnapshot(wtDir, buildOpts)), linearRefreshMs);
     }
     // CTL-867: surface per-team reconcile health (last successful eligible
     // refresh age + the `alerting` flag) so the dashboard can show a team whose
@@ -1331,10 +1288,7 @@ export function createServer(opts: CreateServerOptions): BunServer {
     return snap;
   }
 
-  const sseClients = new Map<
-    ReadableStreamDefaultController<Uint8Array>,
-    SSEFilter
-  >();
+  const sseClients = new Map<ReadableStreamDefaultController<Uint8Array>, SSEFilter>();
   const encoder = new TextEncoder();
 
   // CTL-1215: ONE shared, incrementally-maintained recent-event ring. Per-request
@@ -1650,10 +1604,18 @@ export function createServer(opts: CreateServerOptions): BunServer {
   // DO NOT inline the specifiers to string literals (see governance-reader.mjs header).
   let governanceDepsPromise: Promise<{
     openBeliefsDbRO: (p: string) => Promise<import("bun:sqlite").Database | null>;
-    withBeliefsDbRO: <T>(p: string, fn: (db: import("bun:sqlite").Database) => T, fallback: T) => Promise<T>;
+    withBeliefsDbRO: <T>(
+      p: string,
+      fn: (db: import("bun:sqlite").Database) => T,
+      fallback: T,
+    ) => Promise<T>;
     defaultBeliefsDbPath: (env?: NodeJS.ProcessEnv) => string;
     isGovernanceEvent: (name: string) => boolean;
-    traceTicket: (db: import("bun:sqlite").Database, ticket: string, opts?: { tickId?: number | null }) => unknown;
+    traceTicket: (
+      db: import("bun:sqlite").Database,
+      ticket: string,
+      opts?: { tickId?: number | null },
+    ) => unknown;
     latestTickForTicket: (db: import("bun:sqlite").Database, ticket: string) => number | null;
     RULE_MANIFEST: unknown;
     RULES_SHA: string;
@@ -1673,13 +1635,24 @@ export function createServer(opts: CreateServerOptions): BunServer {
           const [reader, why, rules] = await Promise.all([
             import(readerMod) as Promise<{
               openBeliefsDbRO: (p: string) => Promise<import("bun:sqlite").Database | null>;
-              withBeliefsDbRO: <T>(p: string, fn: (db: import("bun:sqlite").Database) => T, fallback: T) => Promise<T>;
+              withBeliefsDbRO: <T>(
+                p: string,
+                fn: (db: import("bun:sqlite").Database) => T,
+                fallback: T,
+              ) => Promise<T>;
               defaultBeliefsDbPath: (env?: NodeJS.ProcessEnv) => string;
               isGovernanceEvent: (name: string) => boolean;
             }>,
             import(whyMod) as Promise<{
-              traceTicket: (db: import("bun:sqlite").Database, ticket: string, opts?: { tickId?: number | null }) => unknown;
-              latestTickForTicket: (db: import("bun:sqlite").Database, ticket: string) => number | null;
+              traceTicket: (
+                db: import("bun:sqlite").Database,
+                ticket: string,
+                opts?: { tickId?: number | null },
+              ) => unknown;
+              latestTickForTicket: (
+                db: import("bun:sqlite").Database,
+                ticket: string,
+              ) => number | null;
             }>,
             import(rulesMod) as Promise<{
               RULE_MANIFEST: unknown;
@@ -1716,9 +1689,7 @@ export function createServer(opts: CreateServerOptions): BunServer {
   // sensitive. Widening the display window to quiet notifications was tried once
   // (CTL-1169, 30s→90s) and the storm returned. Unset → the module default;
   // 0 restores the pre-CTL-1522 immediate-edge behavior.
-  const daemonNotifyHoldMs = resolveDaemonNotifyHoldMs(
-    process.env.MONITOR_DAEMON_NOTIFY_HOLD_MS,
-  );
+  const daemonNotifyHoldMs = resolveDaemonNotifyHoldMs(process.env.MONITOR_DAEMON_NOTIFY_HOLD_MS);
 
   const productionDaemonHealth = async (): Promise<DaemonHealth> => {
     try {
@@ -1734,8 +1705,7 @@ export function createServer(opts: CreateServerOptions): BunServer {
       // heartbeat intervals, set in nav-signal.mjs) so normal heartbeat jitter
       // doesn't flap healthy↔degraded and storm the desktop notifications.
       // MONITOR_DAEMON_HEALTHY_WINDOW_MS overrides it; unset → the module default.
-      const healthyWindowMs =
-        Number(process.env.MONITOR_DAEMON_HEALTHY_WINDOW_MS) || undefined;
+      const healthyWindowMs = Number(process.env.MONITOR_DAEMON_HEALTHY_WINDOW_MS) || undefined;
       return deps.deriveDaemonHealth(lastSeen, deps.getHostName(), {
         intervalMs: healthyWindowMs,
       });
@@ -1744,9 +1714,7 @@ export function createServer(opts: CreateServerOptions): BunServer {
     }
   };
   const readDaemonHealth: () => Promise<DaemonHealth> =
-    daemonHealthReaderOpt != null
-      ? async () => daemonHealthReaderOpt()
-      : productionDaemonHealth;
+    daemonHealthReaderOpt != null ? async () => daemonHealthReaderOpt() : productionDaemonHealth;
 
   // assembleNavSignal — project the four nav signals off the board snapshot the
   // read-model already computed, layering the local daemon health. One board read
@@ -1841,7 +1809,8 @@ export function createServer(opts: CreateServerOptions): BunServer {
   // checks live BEFORE grace, so a window ≥ grace would render a should-be-
   // offline host as live). Cap leaves a real degraded band.
   const PEER_WINDOW_GRACE_CAP_MS = 4 * 60_000;
-  const lokiPeerWindowMs = HEARTBEAT_CADENCE_MS + peerPollMs + lokiCacheTtlMs + PEER_WINDOW_MARGIN_MS;
+  const lokiPeerWindowMs =
+    HEARTBEAT_CADENCE_MS + peerPollMs + lokiCacheTtlMs + PEER_WINDOW_MARGIN_MS;
   const anchorPeerWindowMs = ANCHOR_PUBLISH_CADENCE_MS + peerPollMs + PEER_WINDOW_MARGIN_MS;
   let anchorPollTimer: ReturnType<typeof setInterval> | null = null;
   const pollAnchorHeartbeats = (): void => {
@@ -2098,9 +2067,7 @@ export function createServer(opts: CreateServerOptions): BunServer {
     if (clusterReaderOpt != null) return clusterReaderOpt(board);
     return clusterEntity.project(board);
   };
-  const assembleClusterSignal = async (
-    board: BoardPayload,
-  ): Promise<ClusterSignal> => {
+  const assembleClusterSignal = async (board: BoardPayload): Promise<ClusterSignal> => {
     try {
       return deriveClusterSignal(await readClusterView(board));
     } catch (err) {
@@ -2159,18 +2126,14 @@ export function createServer(opts: CreateServerOptions): BunServer {
   // lazy TTL only fires on re-read, so a key fetched once and never re-requested
   // would sit forever. A low-frequency sweep evicts abandoned keys. Cleared in
   // server.stop().
-  const titleDescSweepTimer = setInterval(
-    () => _sweepTitleDescCache(),
-    5 * 60 * 1000,
-  );
+  const titleDescSweepTimer = setInterval(() => _sweepTitleDescCache(), 5 * 60 * 1000);
 
   // CTL-1330 Tier 1: monitor request-timing. Surface only slow requests
   // (default >250ms) so healthy traffic doesn't flood the log. ON unless
   // CATALYST_TICK_TIMING=off. Fields land as structured attributes for the
   // OTL metrics pipeline.
   const MONITOR_REQUEST_TIMING = process.env.CATALYST_TICK_TIMING !== "off";
-  const MONITOR_SLOW_REQUEST_MS =
-    Number(process.env.CATALYST_MONITOR_SLOW_REQUEST_MS) || 250;
+  const MONITOR_SLOW_REQUEST_MS = Number(process.env.CATALYST_MONITOR_SLOW_REQUEST_MS) || 250;
 
   // CTL-1573 P1: the allowlist must use the port the server ACTUALLY bound, not
   // the requested one — `port: 0` asks the OS for an ephemeral port (the test
@@ -2248,2199 +2211,119 @@ export function createServer(opts: CreateServerOptions): BunServer {
     async fetch(req) {
       const _reqT0 = performance.now();
       const _doFetch = async (): Promise<Response> => {
-      try {
-        const url = new URL(req.url);
+        try {
+          const url = new URL(req.url);
 
-        if (url.pathname === "/events") {
-          const filter = parseFilter(url);
+          if (url.pathname === "/events") {
+            const filter = parseFilter(url);
 
-          // Eagerly validate the activity predicate so we can return 400 before
-          // opening a stream. Empty-string predicate is allowed (means "no
-          // jq filter, all global events"); only validate non-empty.
-          if (
-            filter.activityPredicate !== undefined &&
-            filter.activityPredicate.trim() !== ""
-          ) {
-            const v = validatePredicate(filter.activityPredicate);
-            if (!v.ok) {
-              return new Response(
-                `activity filter error: ${v.error ?? "invalid"}`,
-                { status: 400 },
-              );
-            }
-          }
-
-          let captured: ReadableStreamDefaultController<Uint8Array> | null = null;
-          // CTL-1224: the live activity tail is now fed by the ONE shared
-          // event-ring (eventRing.onAppend) rather than a per-client
-          // tailEventLog poll loop + per-client backlog readFileSync. Each
-          // client keeps its OWN jq filter stream (predicates differ per
-          // client), but the expensive shared part — the file poll + byte read —
-          // is one backend loop (the ring's tick) regardless of client count.
-          let activityUnsub: (() => void) | null = null;
-          let activityFilter: FilterStream | null = null;
-          const stream = new ReadableStream<Uint8Array>({
-            async start(controller) {
-              captured = controller;
-              sseClients.set(controller, filter);
-              try {
-                // Initial snapshot always sent regardless of filter to bootstrap client state
-                const snapshot = snapshotWithPrStatus();
-                const envelope = createEvent("snapshot", snapshot, "filesystem");
-                const msg = `event: snapshot\ndata: ${JSON.stringify(envelope)}\n\n`;
-                controller.enqueue(encoder.encode(msg));
-              } catch (err) {
-                console.error(`[server] initial snapshot enqueue failed:`, err);
-              }
-
-              // Activity stream multiplex: only when the client opted in via
-              // `?activity=` (predicate may be empty for "all events").
-              if (filter.activityPredicate !== undefined) {
-                const predicate = filter.activityPredicate;
-                try {
-                  // CTL-1224: serve the backlog from the shared ring when it
-                  // covers the window; bounded file fallback on underflow. No
-                  // unconditional full-file readFileSync on the SSE path.
-                  const backlogLines = await readBacklog({
-                    catalystDir: CATALYST_DIR,
-                    predicate,
-                    limit: 100,
-                    ring: eventRing,
-                  });
-                  const parsed = backlogLines
-                    .map((l) => safeParseJson(l))
-                    .filter((v): v is Record<string, unknown> => v !== null);
-                  const backlogEnv = createEvent(
-                    "global-event-backlog",
-                    { events: parsed },
-                    "filesystem",
-                  );
-                  // Enqueue may race with client cancel; swallow the
-                  // ERR_INVALID_STATE that comes back if the controller has
-                  // already closed.
-                  try {
-                    controller.enqueue(
-                      encoder.encode(
-                        `event: global-event-backlog\ndata: ${JSON.stringify(backlogEnv)}\n\n`,
-                      ),
-                    );
-                  } catch {
-                    /* client cancelled */
-                  }
-                } catch (err) {
-                  console.error(`[server] activity backlog failed:`, err);
-                }
-
-                // CTL-1224: per-client jq filter (or passthrough for an empty
-                // predicate) fed by the SHARED ring tail. Matched lines are
-                // wrapped in the SAME global-event envelope + framing as before.
-                const filterStream = createFilterStream(predicate);
-                activityFilter = filterStream;
-                filterStream.onMatch((line) => {
-                  const parsed = safeParseJson(line);
-                  if (parsed === null) return;
-                  const env = createEvent("global-event", parsed, "filesystem");
-                  try {
-                    controller.enqueue(
-                      encoder.encode(
-                        `event: global-event\ndata: ${JSON.stringify(env)}\n\n`,
-                      ),
-                    );
-                  } catch {
-                    // client gone — stop feeding it
-                    activityUnsub?.();
-                    activityUnsub = null;
-                  }
-                });
-                activityUnsub = eventRing.onAppend((lines) => {
-                  for (const l of lines) filterStream.write(l);
-                  void filterStream.flush();
+            // Eagerly validate the activity predicate so we can return 400 before
+            // opening a stream. Empty-string predicate is allowed (means "no
+            // jq filter, all global events"); only validate non-empty.
+            if (filter.activityPredicate !== undefined && filter.activityPredicate.trim() !== "") {
+              const v = validatePredicate(filter.activityPredicate);
+              if (!v.ok) {
+                return new Response(`activity filter error: ${v.error ?? "invalid"}`, {
+                  status: 400,
                 });
               }
-            },
-            cancel() {
-              if (captured) sseClients.delete(captured);
-              activityUnsub?.(); // CTL-1224: deregister ring listener (no leak)
-              activityUnsub = null;
-              activityFilter?.close(); // CTL-1224: reap the per-client jq process
-              activityFilter = null;
-            },
-          });
-          return new Response(stream, {
-            headers: {
-              "Content-Type": "text/event-stream",
-              "Cache-Control": "no-cache",
-              Connection: "keep-alive",
-              "Access-Control-Allow-Origin": "*",
-            },
-          });
-        }
-
-        if (url.pathname === "/api/version") {
-          return Response.json({ version: CATALYST_DEV_VERSION });
-        }
-
-        if (url.pathname === "/api/snapshot") {
-          return Response.json(snapshotWithPrStatus());
-        }
-
-        if (url.pathname === "/api/config") {
-          const cfg = loadMonitorConfig(monitorConfigPath);
-          return Response.json(cfg);
-        }
-
-        // CTL-1152: GET /api/projects — the config-driven project roster. One
-        // descriptor per configured catalyst.monitor.linear.teams[] entry PLUS a
-        // self-identifying unconfigured lane per observed-work repo (the live
-        // board snapshot's `.repos`) with no configured descriptor (union rule).
-        // Fail-open: ANY error degrades to { projects: [] } (mirrors /api/config
-        // and the repo-icon endpoint) so the nav renders its empty state, never 5xx.
-        if (url.pathname === "/api/projects") {
-          try {
-            const board = await boardSnapshot.getLatest();
-            const observedRepos = board?.repos ?? [];
-            return Response.json({ projects: loadProjects({ observedRepos, configPath: projectsConfigPath }) });
-          } catch {
-            return Response.json({ projects: [] });
-          }
-        }
-
-        // CTL-1153 (M2): PUT /api/projects/:key — upsert one editable projects[] entry
-        // (name/color/icon/stateMap). First edit of a known team key migrates THAT project
-        // into catalyst.projects[]. READ (GET above) is fail-open; WRITE is fail-CLOSED on input.
-        // Validation → HTTP code table:
-        //   405  non-PUT method
-        //   400  bad JSON | non-object | unknown field (incl. vcsRepo/key) | bad name | bad hue | bad stateMap
-        //   404  key not in teams[] and not in existing projects[]
-        //   500  genuine persistence failure
-        //   200  { project, projects }
-        {
-          const projectKeyMatch = url.pathname.match(/^\/api\/projects\/([A-Za-z0-9._-]+)$/);
-          if (projectKeyMatch && projectKeyMatch[1]) {
-            if (req.method !== "PUT") return new Response("Method Not Allowed", { status: 405 });
-            let key: string;
-            try { key = decodeURIComponent(projectKeyMatch[1]); }
-            catch { return Response.json({ error: "Bad project key" }, { status: 400 }); }
-            let body: unknown;
-            try { body = await req.json(); }
-            catch { return Response.json({ error: "Invalid JSON body" }, { status: 400 }); }
-            const v = validateProjectPatch(body);
-            if (!v.ok) return Response.json({ error: v.error }, { status: v.status });
-            let result: ReturnType<typeof writeProjectPatch>;
-            try {
-              result = writeProjectPatch(projectsConfigPath, key.toUpperCase(), v.patch);
-            } catch (err) {
-              console.error(`[server] PUT /api/projects/${key} failed:`, err);
-              return Response.json({ error: "Failed to persist project settings" }, { status: 500 });
-            }
-            if (!result.ok) {
-              return Response.json({ error: `Unknown project key: ${key.toUpperCase()}` }, { status: 404 });
-            }
-            const board = await boardSnapshot.getLatest();
-            const observedRepos = board?.repos ?? [];
-            const projects = loadProjects({ observedRepos, configPath: projectsConfigPath });
-            return Response.json({ project: projects.find((p) => p.key === key.toUpperCase()) ?? null, projects });
-          }
-        }
-
-        // CTL-961: /api/repo-icon/<repoShortName> — auto-detect favicon from GitHub.
-        // Reads the owner/repo from the monitor config repoOwners map, probes common
-        // icon paths via `gh api`, caches the result for 7 days, returns a data URL.
-        // Fail-open: returns { found: false } (204) when not configured or not found.
-        if (url.pathname.startsWith("/api/repo-icon/")) {
-          // CTL-979: normalize to lowercase so /api/repo-icon/adva resolves "Adva" vcsRepo keys.
-          const repoKey = url.pathname.slice("/api/repo-icon/".length).trim().toLowerCase();
-          if (!repoKey || repoKey.includes("/")) {
-            return new Response("Bad repo key", { status: 400 });
-          }
-          const cfg = loadMonitorConfig(monitorConfigPath);
-          const ownerRepo = cfg.repoOwners[repoKey];
-          if (!ownerRepo) {
-            return Response.json({ found: false }, { status: 204 });
-          }
-          const cacheDir = join(CATALYST_DIR, "repo-icon-cache");
-          const result = await fetchRepoIcon(ownerRepo, cacheDir);
-          if (!result.found) return Response.json({ found: false }, { status: 204 });
-          return Response.json(result);
-        }
-
-        if (url.pathname === "/api/analytics") {
-          return Response.json(buildAnalyticsSnapshot(wtDir, buildOpts));
-        }
-
-        if (url.pathname === "/api/sessions") {
-          if (!dbPath) {
-            return Response.json({ available: false, sessions: [] });
-          }
-          const params = url.searchParams;
-          const limitRaw = params.get("limit");
-          const parsedLimit = limitRaw ? Number.parseInt(limitRaw, 10) : NaN;
-          const result = readSessionStore(dbPath, {
-            soloOnly: params.get("solo") === "true",
-            workflowId: params.get("workflow") ?? undefined,
-            ticket: params.get("ticket") ?? undefined,
-            status: params.get("status") ?? undefined,
-            limit: Number.isFinite(parsedLimit) ? parsedLimit : undefined,
-          });
-          const sessions: SessionState[] = result.sessions;
-          return Response.json({ available: result.available, sessions });
-        }
-
-        if (url.pathname === "/api/history") {
-          if (!dbPath) {
-            return Response.json({ entries: [], total: 0 });
-          }
-          const params = url.searchParams;
-          const limitRaw = params.get("limit");
-          const offsetRaw = params.get("offset");
-          const parsedLimit = limitRaw ? Number.parseInt(limitRaw, 10) : NaN;
-          const parsedOffset = offsetRaw ? Number.parseInt(offsetRaw, 10) : NaN;
-          return Response.json(
-            queryHistory(dbPath, {
-              skill: params.get("skill") ?? undefined,
-              ticket: params.get("ticket") ?? undefined,
-              since: params.get("since") ?? undefined,
-              search: params.get("search") ?? undefined,
-              limit: Number.isFinite(parsedLimit) ? parsedLimit : undefined,
-              offset: Number.isFinite(parsedOffset) ? parsedOffset : undefined,
-            }),
-          );
-        }
-
-        if (url.pathname === "/api/history/stats") {
-          if (!dbPath) {
-            return Response.json({
-              totalSessions: 0,
-              totalCostUsd: 0,
-              avgCostUsd: 0,
-              avgDurationMs: 0,
-              successRate: 0,
-              skillBreakdown: [],
-              dailyCosts: [],
-              topTools: [],
-            });
-          }
-          const params = url.searchParams;
-          return Response.json(
-            queryStats(dbPath, {
-              skill: params.get("skill") ?? undefined,
-              since: params.get("since") ?? undefined,
-            }),
-          );
-        }
-
-        if (url.pathname === "/api/history/compare") {
-          if (!dbPath) {
-            return Response.json(null);
-          }
-          const params = url.searchParams;
-          const a = params.get("a");
-          const b = params.get("b");
-          if (!a || !b) {
-            return new Response("Missing ?a=<id>&b=<id>", { status: 400 });
-          }
-          const result = compareSessions(dbPath, a, b);
-          if (!result) {
-            return new Response("Session(s) not found", { status: 404 });
-          }
-          return Response.json(result);
-        }
-
-        const rollupMatch = url.pathname.match(/^\/api\/rollup\/([^/]+)$/);
-        if (rollupMatch) {
-          let orchId: string;
-          try {
-            orchId = decodeURIComponent(rollupMatch[1]);
-          } catch {
-            return new Response("Bad Request", { status: 400 });
-          }
-          if (orchId.includes("..") || orchId.includes("/") || orchId.includes("\0")) {
-            return new Response("Bad Request", { status: 400 });
-          }
-          const snap = snapshotWithPrStatus();
-          const orch = snap.orchestrators.find((o) => o.id === orchId);
-          if (!orch) {
-            return new Response("Not Found", { status: 404 });
-          }
-          return Response.json({
-            orchId: orch.id,
-            rollup: orch.rollupBriefing ?? null,
-          });
-        }
-
-        const sessionMatch = url.pathname.match(
-          /^\/api\/session\/([^/]+)\/([^/]+)$/,
-        );
-        if (sessionMatch) {
-          let orchId: string;
-          let ticket: string;
-          try {
-            orchId = decodeURIComponent(sessionMatch[1]);
-            ticket = decodeURIComponent(sessionMatch[2]);
-          } catch {
-            return new Response("Bad Request", { status: 400 });
-          }
-          if (
-            orchId.includes("..") ||
-            orchId.includes("\0") ||
-            ticket.includes("..") ||
-            ticket.includes("/") ||
-            ticket.includes("\0")
-          ) {
-            return new Response("Bad Request", { status: 400 });
-          }
-          const detail = buildSessionDetail(wtDir, orchId, ticket, { runsDir });
-          if (!detail) {
-            return new Response("Not Found", { status: 404 });
-          }
-          if (prFetcher && detail.worker.pr) {
-            const repo = parseRepoFromPrUrl(detail.worker.pr.url);
-            if (repo) {
-              const status = prFetcher.get(repo, detail.worker.pr.number);
-              if (status) {
-                detail.worker.prState = status.state;
-                detail.worker.prMergedAt = status.mergedAt;
-              }
-            }
-          }
-          return Response.json(detail);
-        }
-
-        const streamMatch = url.pathname.match(
-          /^\/api\/worker-stream\/([^/]+)\/([^/]+)$/,
-        );
-        if (streamMatch) {
-          let orchId: string;
-          let ticket: string;
-          try {
-            orchId = decodeURIComponent(streamMatch[1]);
-            ticket = decodeURIComponent(streamMatch[2]);
-          } catch {
-            return new Response("Bad Request", { status: 400 });
-          }
-          if (
-            orchId.includes("..") ||
-            orchId.includes("\0") ||
-            ticket.includes("..") ||
-            ticket.includes("/") ||
-            ticket.includes("\0")
-          ) {
-            return new Response("Bad Request", { status: 400 });
-          }
-          const maxEventsRaw = url.searchParams.get("limit");
-          const maxEvents = maxEventsRaw ? Number.parseInt(maxEventsRaw, 10) : 30;
-          const stateReader = await import("./lib/state-reader");
-          const scanned = runsDir
-            ? stateReader.scanAllOrchestrators({ runsDir, wtDir })
-            : stateReader.scanOrchestrators(wtDir);
-          const entry = scanned.find((d) => basename(d.path) === orchId);
-          if (!entry) {
-            return new Response("Not Found", { status: 404 });
-          }
-          const events = readRecentStreamEvents(
-            entry.path,
-            ticket,
-            Number.isFinite(maxEvents) ? maxEvents : 30,
-          );
-          return Response.json({ orchId, ticket, events });
-        }
-
-        const subagentsMatch = url.pathname.match(
-          /^\/api\/worker\/([^/]+)\/([^/]+)\/subagents$/,
-        );
-        if (subagentsMatch) {
-          let orchId: string;
-          let ticket: string;
-          try {
-            orchId = decodeURIComponent(subagentsMatch[1]);
-            ticket = decodeURIComponent(subagentsMatch[2]);
-          } catch {
-            return new Response("Bad Request", { status: 400 });
-          }
-          if (
-            orchId.includes("..") ||
-            orchId.includes("/") ||
-            orchId.includes("\0") ||
-            ticket.includes("..") ||
-            ticket.includes("/") ||
-            ticket.includes("\0")
-          ) {
-            return new Response("Bad Request", { status: 400 });
-          }
-          const stateReader = await import("./lib/state-reader");
-          const scanned = runsDir
-            ? stateReader.scanAllOrchestrators({ runsDir, wtDir })
-            : stateReader.scanOrchestrators(wtDir);
-          const entry = scanned.find((d) => basename(d.path) === orchId);
-          if (!entry) return new Response("Not Found", { status: 404 });
-          const tree = parseStreamForSubagents(streamFilePath(entry.path, ticket));
-          return Response.json({ orchId, ticket, tree });
-        }
-
-        const workerTodosMatch = url.pathname.match(
-          /^\/api\/worker\/([^/]+)\/([^/]+)\/todos$/,
-        );
-        if (workerTodosMatch) {
-          let orchId: string;
-          let ticket: string;
-          try {
-            orchId = decodeURIComponent(workerTodosMatch[1]);
-            ticket = decodeURIComponent(workerTodosMatch[2]);
-          } catch {
-            return new Response("Bad Request", { status: 400 });
-          }
-          if (
-            orchId.includes("..") ||
-            orchId.includes("/") ||
-            orchId.includes("\0") ||
-            ticket.includes("..") ||
-            ticket.includes("/") ||
-            ticket.includes("\0")
-          ) {
-            return new Response("Bad Request", { status: 400 });
-          }
-          const stateReader = await import("./lib/state-reader");
-          const scanned = runsDir
-            ? stateReader.scanAllOrchestrators({ runsDir, wtDir })
-            : stateReader.scanOrchestrators(wtDir);
-          const entry = scanned.find((d) => basename(d.path) === orchId);
-          if (!entry) return new Response("Not Found", { status: 404 });
-          const tree = parseStreamForSubagents(streamFilePath(entry.path, ticket));
-          const todos = flattenTodosForWorker(tree, ticket);
-          return Response.json({ orchId, ticket, todos });
-        }
-
-        const orchTodosMatch = url.pathname.match(/^\/api\/orch\/([^/]+)\/todos$/);
-        if (orchTodosMatch) {
-          let orchId: string;
-          try {
-            orchId = decodeURIComponent(orchTodosMatch[1]);
-          } catch {
-            return new Response("Bad Request", { status: 400 });
-          }
-          if (orchId.includes("..") || orchId.includes("/") || orchId.includes("\0")) {
-            return new Response("Bad Request", { status: 400 });
-          }
-          const stateReader = await import("./lib/state-reader");
-          const scanned = runsDir
-            ? stateReader.scanAllOrchestrators({ runsDir, wtDir })
-            : stateReader.scanOrchestrators(wtDir);
-          const entry = scanned.find((d) => basename(d.path) === orchId);
-          if (!entry) return new Response("Not Found", { status: 404 });
-          const orchState = stateReader.readOrchestratorState(
-            entry.path,
-            "workspace" in entry ? entry.workspace : "default",
-          );
-          const todos = [];
-          for (const [, worker] of Object.entries(orchState.workers)) {
-            const ticket = worker.ticket;
-            if (!ticket) continue;
-            const tree = parseStreamForSubagents(streamFilePath(entry.path, ticket));
-            todos.push(...flattenTodosForWorker(tree, ticket));
-          }
-          return Response.json({ orchId, todos });
-        }
-
-        if (url.pathname === "/api/worker-tasks/debug") {
-          const pidRaw = url.searchParams.get("pid");
-          const sessionIdParam = url.searchParams.get("sessionId");
-          if (!pidRaw && !sessionIdParam) {
-            return new Response("pid or sessionId required", { status: 400 });
-          }
-          const diagnostic = getTaskDiagnostic({
-            pid: pidRaw ? Number(pidRaw) : undefined,
-            sessionId: sessionIdParam ?? undefined,
-          });
-          return Response.json(diagnostic);
-        }
-
-        const taskMatch = url.pathname.match(
-          /^\/api\/worker-tasks$/,
-        );
-        if (taskMatch) {
-          const pidRaw = url.searchParams.get("pid");
-          const sessionIdParam = url.searchParams.get("sessionId");
-          if (!pidRaw && !sessionIdParam) {
-            return new Response("pid or sessionId required", { status: 400 });
-          }
-          const sessionId = sessionIdParam
-            || (pidRaw ? sessionIdFromPid(Number(pidRaw)) : null);
-          if (!sessionId) {
-            return Response.json({ tasks: null });
-          }
-          const tasks = readWorkerTasks(sessionId);
-          return Response.json({ tasks });
-        }
-
-        if (url.pathname === "/api/comms/channels") {
-          if (!comms) return Response.json({ channels: [] });
-          return Response.json({ channels: await comms.listChannels() });
-        }
-
-        const commsStreamMatch = url.pathname.match(
-          /^\/api\/comms\/channels\/([^/]+)\/stream$/,
-        );
-        if (commsStreamMatch) {
-          let channelName: string;
-          try {
-            channelName = decodeURIComponent(commsStreamMatch[1]);
-          } catch {
-            return new Response("Bad Request", { status: 400 });
-          }
-          if (!isValidChannelName(channelName)) {
-            return new Response("Invalid channel name", { status: 400 });
-          }
-          if (!comms) return new Response("Comms not available", { status: 503 });
-
-          const commsReader = comms;
-          let offset = 0;
-          let timer: ReturnType<typeof setInterval> | null = null;
-          let inFlight = false;
-          const stream = new ReadableStream<Uint8Array>({
-            async start(controller) {
-              const initial = await commsReader.getChannel(channelName, { limit: 200 });
-              if (!initial) {
-                const errFrame = `event: error-event\ndata: ${JSON.stringify({ error: "channel-not-found", channel: channelName })}\n\n`;
-                try {
-                  controller.enqueue(encoder.encode(errFrame));
-                } catch {
-                  // Client may have already disconnected.
-                }
-                controller.close();
-                return;
-              }
-              offset = initial.tailOffset;
-              const snapshotFrame = `event: snapshot\ndata: ${JSON.stringify(initial)}\n\n`;
-              try {
-                controller.enqueue(encoder.encode(snapshotFrame));
-              } catch {
-                return;
-              }
-              timer = setInterval(() => {
-                if (inFlight) return;
-                inFlight = true;
-                void (async () => {
-                  try {
-                    const tail = await commsReader.tailChannel(channelName, offset);
-                    offset = tail.newOffset;
-                    for (const m of tail.messages) {
-                      const frame = `event: message\ndata: ${JSON.stringify(m)}\n\n`;
-                      controller.enqueue(encoder.encode(frame));
-                    }
-                  } catch {
-                    // Keep the stream alive on transient read errors.
-                  } finally {
-                    inFlight = false;
-                  }
-                })();
-              }, 500);
-            },
-            cancel() {
-              if (timer) clearInterval(timer);
-              timer = null;
-            },
-          });
-          return new Response(stream, {
-            headers: {
-              "Content-Type": "text/event-stream",
-              "Cache-Control": "no-cache",
-              Connection: "keep-alive",
-              "Access-Control-Allow-Origin": "*",
-            },
-          });
-        }
-
-        const commsChannelMatch = url.pathname.match(
-          /^\/api\/comms\/channels\/([^/]+)$/,
-        );
-        if (commsChannelMatch) {
-          let channelName: string;
-          try {
-            channelName = decodeURIComponent(commsChannelMatch[1]);
-          } catch {
-            return new Response("Bad Request", { status: 400 });
-          }
-          if (!isValidChannelName(channelName)) {
-            return new Response("Invalid channel name", { status: 400 });
-          }
-          if (!comms) return new Response("Not Found", { status: 404 });
-          const limitRaw = url.searchParams.get("limit");
-          const parsedLimit = limitRaw ? Number.parseInt(limitRaw, 10) : NaN;
-          const limit = Number.isFinite(parsedLimit)
-            ? Math.max(1, Math.min(parsedLimit, 1000))
-            : 200;
-          const detail = await comms.getChannel(channelName, { limit });
-          if (!detail) return new Response("Not Found", { status: 404 });
-          return Response.json(detail);
-        }
-
-        const commsParticipantMatch = url.pathname.match(
-          /^\/api\/comms\/participants\/([^/]+)$/,
-        );
-        if (commsParticipantMatch) {
-          let agentName: string;
-          try {
-            agentName = decodeURIComponent(commsParticipantMatch[1]);
-          } catch {
-            return new Response("Bad Request", { status: 400 });
-          }
-          if (agentName.includes("/") || agentName.includes("\0")) {
-            return new Response("Bad Request", { status: 400 });
-          }
-          if (!comms) return new Response("Not Found", { status: 404 });
-          const detail = await comms.getParticipant(agentName);
-          if (!detail) return new Response("Not Found", { status: 404 });
-          return Response.json(detail);
-        }
-
-        if (url.pathname === "/api/linear") {
-          const tickets: Record<string, LinearTicket> = {};
-          if (linear) {
-            for (const key of collectTicketKeys(buildSnapshot(wtDir, buildOpts))) {
-              const t = linear.get(key);
-              if (t) tickets[key] = t;
-            }
-          }
-          return Response.json({ tickets });
-        }
-
-        if (url.pathname === "/api/ticket-substeps") {
-          const ticketParam = url.searchParams.get("ticket");
-          if (!ticketParam) {
-            return new Response("Bad Request: missing ticket", { status: 400 });
-          }
-          if (
-            ticketParam.includes("..") ||
-            ticketParam.includes("/") ||
-            ticketParam.includes("\0")
-          ) {
-            return new Response("Bad Request", { status: 400 });
-          }
-          // CTL-1215: scan the shared event ring instead of reading the whole
-          // current-month log; the per-ticket substep slice is small + recent.
-          const subSteps = readSubStepEvents(eventRing, ticketParam);
-          return Response.json({ ticket: ticketParam, subSteps });
-        }
-
-        // CTL-889 (P8): cache-backed Linear ticket detail — description (null,
-        // not cached), labels[], the relation graph (forward + reverse
-        // blocks/related edges), assignee, and held classification. Read from
-        // filter-state.db ticket_state, NEVER a live `linearis` call. 404 when
-        // the ticket has no descriptor row.
-        const ticketDetailMatch = url.pathname.match(
-          /^\/api\/ticket-detail\/([^/]+)$/,
-        );
-        if (ticketDetailMatch) {
-          let ticket: string;
-          try {
-            ticket = decodeURIComponent(ticketDetailMatch[1]);
-          } catch {
-            return new Response("Bad Request", { status: 400 });
-          }
-          if (
-            ticket.includes("..") ||
-            ticket.includes("/") ||
-            ticket.includes("\0")
-          ) {
-            return new Response("Bad Request", { status: 400 });
-          }
-          const detail = await readTicketDetail(ticket, {
-            dbPath: filterStateDb,
-          });
-          if (!detail) {
-            return new Response("Not Found", { status: 404 });
-          }
-          return Response.json(detail);
-        }
-
-        // CTL-974 pattern: supplemental cached live Linear {title, description}
-        // fetch for the ticket-detail page. Separate from /api/ticket-detail to
-        // keep its 404-on-no-descriptor contract intact. The board title is
-        // stale-sourced (triage summary can win) and the durable cache has no
-        // description column, so BOTH the real title and the markdown
-        // description are live-fetched from Linear here — cached, TTL'd (5 min),
-        // batched, fail-open, NEVER spawning linearis on a request path.
-        // ALWAYS 200: an absent description is honest-empty, not an error.
-        const linearTicketMatch = url.pathname.match(
-          /^\/api\/linear-ticket\/([^/]+)$/,
-        );
-        if (linearTicketMatch) {
-          let ticket: string;
-          try {
-            ticket = decodeURIComponent(linearTicketMatch[1]);
-          } catch {
-            return new Response("Bad Request", { status: 400 });
-          }
-          if (
-            ticket.includes("..") ||
-            ticket.includes("/") ||
-            ticket.includes("\0")
-          ) {
-            return new Response("Bad Request", { status: 400 });
-          }
-          const map = await fillTitleDescriptionFallback([ticket]);
-          const entry = map[ticket] ?? { title: null, description: null, labels: null, relations: null, state: null, priority: null, project: null, estimate: null };
-          const available =
-            entry.title !== null || entry.description !== null;
-          return Response.json({
-            id: ticket,
-            title: entry.title,
-            description: entry.description,
-            labels: entry.labels ?? null,
-            relations: entry.relations ?? null,
-            state: entry.state ?? null,
-            priority: entry.priority ?? null,
-            project: entry.project ?? null,
-            estimate: entry.estimate ?? null,
-            source: available ? "linear-live" : "unavailable",
-          });
-        }
-
-        // CTL-889 (P9): a ticket's research/plan thoughts artifacts for the
-        // spine 📄 links — repo-root-relative paths + a peek preview, read from
-        // the LOCAL thoughts tree. Surfaces the CTL-866 cross-node eventual-
-        // consistency caveat (artifacts authored on another node appear only
-        // after a thoughts-sync push).
-        const ticketArtifactsMatch = url.pathname.match(
-          /^\/api\/ticket-artifacts\/([^/]+)$/,
-        );
-        if (ticketArtifactsMatch) {
-          let ticket: string;
-          try {
-            ticket = decodeURIComponent(ticketArtifactsMatch[1]);
-          } catch {
-            return new Response("Bad Request", { status: 400 });
-          }
-          if (
-            ticket.includes("..") ||
-            ticket.includes("/") ||
-            ticket.includes("\0")
-          ) {
-            return new Response("Bad Request", { status: 400 });
-          }
-          const artifacts = await readTicketArtifacts(ticket);
-          return Response.json(artifacts);
-        }
-
-        // CTL-1574: a ticket's Linear discussion — comments + issue_history
-        // activity events, both read from the local CTC replica through the
-        // shared read-model builders. The reader never throws: an absent/locked
-        // replica or an unmirrored ticket comes back
-        // `{ available:false, comments:[], activity:[] }`, which the UI renders
-        // as an honest empty section (never a fabricated "no comments").
-        const ticketDiscussionMatch = url.pathname.match(
-          /^\/api\/ticket-discussion\/([^/]+)$/,
-        );
-        if (ticketDiscussionMatch) {
-          let ticket: string;
-          try {
-            ticket = decodeURIComponent(ticketDiscussionMatch[1]);
-          } catch {
-            return new Response("Bad Request", { status: 400 });
-          }
-          if (
-            ticket.includes("..") ||
-            ticket.includes("/") ||
-            ticket.includes("\0")
-          ) {
-            return new Response("Bad Request", { status: 400 });
-          }
-          const discussion = await readTicketDiscussion(ticket, {
-            catalystDir: CATALYST_DIR,
-          });
-          // Agent classification is `is_bot` OR a configured app-actor author —
-          // Catalyst worker/orchestrator app actors are stored as users with
-          // is_bot=0 (the linear-thread.mjs contract), so is_bot alone would
-          // badge every agent comment as human.
-          const botIds = linearBotUserIds ?? linearWebhookConfig?.botUserIds;
-          if (botIds && discussion.comments.length > 0) {
-            discussion.comments = discussion.comments.map((c) =>
-              c.author_id != null && botIds.has(c.author_id) ? { ...c, is_bot: 1 } : c,
-            );
-          }
-          return Response.json(discussion);
-        }
-
-        // CTL-1042: serve a ticket's research/plan artifact CONTENT by kind for
-        // the reading-pane deep-dive pills. The list route above is anchored at
-        // the ticket segment ($), so it never matches this two-segment path;
-        // this opens the actual markdown the pill links to (without it the pill
-        // hit the SPA/404 fallback). The served file path is resolved by our own
-        // glob over the local thoughts tree — not attacker-supplied — but we
-        // still validate both URL segments defensively.
-        const ticketArtifactByKindMatch = url.pathname.match(
-          /^\/api\/ticket-artifacts\/([^/]+)\/([^/]+)$/,
-        );
-        if (ticketArtifactByKindMatch) {
-          let ticket: string;
-          let kind: string;
-          try {
-            ticket = decodeURIComponent(ticketArtifactByKindMatch[1]);
-            kind = decodeURIComponent(ticketArtifactByKindMatch[2]);
-          } catch {
-            return new Response("Bad Request", { status: 400 });
-          }
-          if (
-            ticket.includes("..") ||
-            ticket.includes("/") ||
-            ticket.includes("\0")
-          ) {
-            return new Response("Bad Request", { status: 400 });
-          }
-          if (kind !== "research" && kind !== "plan") {
-            return new Response("Bad Request", { status: 400 });
-          }
-          const doc = await readTicketArtifactContent(ticket, kind);
-          if (!doc) {
-            return new Response("Not Found", { status: 404 });
-          }
-          return new Response(doc.content, {
-            headers: { "Content-Type": "text/markdown; charset=utf-8" },
-          });
-        }
-
-        // CTL-889 (P12): cache-backed fuzzy ticket search for the ⌘K palette's
-        // "Search all tickets in Linear" action. Fuzzy-matches the durable
-        // ticket_state cache — NO per-keystroke live Linear API call. An empty
-        // ?q= returns an empty result set (the palette renders the row idle).
-        if (url.pathname === "/api/search") {
-          const q = url.searchParams.get("q") ?? "";
-          const limitRaw = url.searchParams.get("limit");
-          const parsedLimit = limitRaw ? Number.parseInt(limitRaw, 10) : NaN;
-          const limit = Number.isFinite(parsedLimit)
-            ? Math.max(1, Math.min(parsedLimit, 100))
-            : 20;
-          if (q.trim() === "") {
-            return Response.json({
-              query: q,
-              results: [],
-              source: "filter-state.db",
-            });
-          }
-          const result = await readTicketSearch(q, {
-            dbPath: filterStateDb,
-            limit,
-          });
-          return Response.json(result);
-        }
-
-        if (url.pathname === "/api/briefing") {
-          if (!briefingProvider) {
-            return Response.json({ enabled: false });
-          }
-          const snap = snapshotWithPrStatus();
-          const tickets: Record<string, LinearTicket> = {};
-          if (linear) {
-            for (const key of collectTicketKeys(snap)) {
-              const t = linear.get(key);
-              if (t) tickets[key] = t;
-            }
-          }
-          const result = await briefingProvider.generate(snap, tickets);
-          if (!result) {
-            return Response.json({ enabled: true, briefing: null });
-          }
-          return Response.json({
-            enabled: true,
-            briefing: result.briefing,
-            suggestedLabels: result.suggestedLabels,
-            generatedAt: result.generatedAt,
-          });
-        }
-
-        // CTL-1042: per-inbox-item AI summary — lazy, on operator select.
-        const inboxSummaryMatch =
-          req.method === "GET" && url.pathname.match(/^\/api\/inbox\/([^/]+)\/summary$/);
-        if (inboxSummaryMatch) {
-          let ticket: string;
-          try { ticket = decodeURIComponent(inboxSummaryMatch[1]); }
-          catch { return new Response("Bad Request", { status: 400 }); }
-          if (ticket.includes("..") || ticket.includes("/") || ticket.includes("\0")) {
-            return new Response("Bad Request", { status: 400 });
-          }
-          if (!inboxSummaryProvider) return Response.json({ enabled: false });
-          const phase = url.searchParams.get("phase") ?? undefined;
-          const result = await inboxSummaryProvider.generate(ticket, phase);
-          if (!result) return Response.json({ enabled: true, ask: null, summary: null, options: null, blocker: null });
-          return Response.json({ enabled: true, ...result });
-        }
-
-        if (url.pathname === "/api/briefing/activity") {
-          const windowParam = url.searchParams.get("window") ?? "30m";
-          if (!VALID_ACTIVITY_WINDOWS.has(windowParam as ActivityWindow)) {
-            return Response.json(
-              { error: "Invalid window. Use 30m, 1h, or 6h." },
-              { status: 400 },
-            );
-          }
-          const result = await generateActivityBriefing(
-            CATALYST_DIR,
-            activityBriefingConfig,
-            windowParam as ActivityWindow,
-            undefined,
-            eventRing,
-          );
-          return Response.json(result);
-        }
-
-        if (url.pathname === "/api/webhook" && req.method === "POST") {
-          if (!webhookHandler) {
-            return new Response("webhook receiver not configured", {
-              status: 503,
-            });
-          }
-          return webhookHandler.handle(req);
-        }
-
-        if (url.pathname === "/api/webhook/linear" && req.method === "POST") {
-          if (!linearWebhookHandler) {
-            return new Response("linear webhook receiver not configured", {
-              status: 503,
-            });
-          }
-          return linearWebhookHandler.handle(req);
-        }
-
-        if (url.pathname === "/api/summarize" && req.method === "POST") {
-          if (!summarizeHandler) {
-            return Response.json(
-              { error: "AI not configured" },
-              { status: 503 },
-            );
-          }
-          return summarizeHandler.handle(req);
-        }
-
-        if (url.pathname === "/api/otel/status") {
-          return Response.json({
-            enabled: prom !== null || loki !== null,
-            prometheus: prom ? prom.isAvailable() : false,
-            loki: loki ? loki.isAvailable() : false,
-          });
-        }
-
-        if (url.pathname === "/api/health/otel") {
-          const health = await otelHealth.check();
-          return Response.json(health);
-        }
-
-        // CTL-1050: the service-health registry snapshot — every stack service's
-        // shared up|degraded|down|unknown severity, last-checked, target/source
-        // for the Fleet Ops strip hover. The registry reads ONLY the monitor's own
-        // probes/event-recency, so Fleet Ops stays Prometheus/Loki-FREE.
-        if (url.pathname === "/api/health/services") {
-          return Response.json(serviceHealth.snapshot());
-        }
-
-        if (url.pathname === "/api/otel/cost") {
-          if (!prom) return Response.json({ error: "OTel not configured" }, { status: 503 });
-          const range = url.searchParams.get("range") ?? "1h";
-          const result = await costByTicket(prom, range);
-          return Response.json({ data: result });
-        }
-
-        if (url.pathname === "/api/otel/tokens") {
-          if (!prom) return Response.json({ error: "OTel not configured" }, { status: 503 });
-          const range = url.searchParams.get("range") ?? "1h";
-          const tokens = await tokensByType(prom, range);
-          const hitRate = await cacheHitRate(prom, range);
-          return Response.json({ data: { tokens, cacheHitRate: hitRate } });
-        }
-
-        if (url.pathname === "/api/otel/cost-rate") {
-          if (!prom) return Response.json({ error: "OTel not configured" }, { status: 503 });
-          const interval = url.searchParams.get("interval") ?? "5m";
-          const result = await costRateByModel(prom, interval);
-          return Response.json({ data: result });
-        }
-
-        // OBS-9 (FINOPS P-B): cost by pipeline stage. Routes the EXISTING (but
-        // previously unrouted) `costByTaskType` — `sum by (task_type)(increase(
-        // cost[r]))` — with the OBS-9 zero-series filter applied at the query layer
-        // so the by-stage bar never renders the ~5 exact-0 phases. 503 when
-        // Prometheus is not configured (the P-B ChartCard degrades via the ladder).
-        if (url.pathname === "/api/otel/cost-by-stage") {
-          if (!prom) return Response.json({ error: "OTel not configured" }, { status: 503 });
-          const range = url.searchParams.get("range") ?? "24h";
-          const result = await costByTaskType(prom, range);
-          return Response.json({ data: result });
-        }
-
-        // OBS-11 (FINOPS P-D): cost by model / agent. Groups the cost counter by a
-        // WHITELISTED native dimension (`model` or `agent_name` — never interpolated
-        // from input, so no PromQL injection) with the OBS-9 zero-series filter
-        // applied so the ranked bar never shows the exact-0 models/agents an
-        // increase() window carries. `dim` defaults to model; an unknown dim → 400
-        // (honest, never a silently-empty bar). 503 when Prometheus is off.
-        if (url.pathname === "/api/otel/cost-by-dim") {
-          if (!prom) return Response.json({ error: "OTel not configured" }, { status: 503 });
-          const dim = url.searchParams.get("dim") ?? "model";
-          if (!isCostDimension(dim)) {
-            return Response.json({ error: "unknown dimension" }, { status: 400 });
-          }
-          const range = url.searchParams.get("range") ?? "24h";
-          const result = await costByDimension(prom, dim, range);
-          return Response.json({ data: result });
-        }
-
-        // CTL-1040 (FINOPS): cost grouped by work type. Board-backed — groups the SAME
-        // signal-file costs the expensive-tickets table shows (BoardTicket.costUSD) by
-        // BoardTicket.type. Prometheus carries no catalyst_ticket_type label, so this
-        // is the honest current-state source (UI carries a "data since 2026-06-11"
-        // caption). Always 200 — no Prometheus dependency.
-        if (url.pathname === "/api/otel/cost-by-work-type") {
-          const board = await boardSnapshot.getLatest();
-          const tickets = (board?.tickets ?? []).map((t) => ({ type: t.type, costUSD: t.costUSD }));
-          return Response.json({ data: costByWorkType(tickets) });
-        }
-
-        // CTL-1040 (UTILIZATION): throughput grouped by work type. Loki-backed —
-        // counts phase.teardown.complete.* events per catalyst_ticket_type over the
-        // window. 503 when Loki is not configured (the ChartCard degrades via the ladder).
-        if (url.pathname === "/api/otel/throughput-by-work-type") {
-          if (!loki) return Response.json({ error: "OTel not configured" }, { status: 503 });
-          const range = url.searchParams.get("range") ?? "24h";
-          const result = await throughputByWorkType(loki, range);
-          if (result === null) return Response.json({ error: "Loki unavailable" }, { status: 503 });
-          return Response.json({ data: result });
-        }
-
-        // OBS-9 (FINOPS HERO): the today-vs-7d dollar band. todayUsd (spend since
-        // local midnight) + avg7dUsd (the prior 7 FULL days' mean baseline) + the
-        // delta fraction + a linear EOD projection — all off the cost counter, no
-        // new plumbing. The partial current day is EXCLUDED from the 7d baseline so
-        // "is today normal?" compares like-for-like. 503 when Prometheus is absent.
-        if (url.pathname === "/api/otel/cost-today") {
-          if (!prom) return Response.json({ error: "OTel not configured" }, { status: 503 });
-          const result = await costToday(prom);
-          if (result === null) {
-            return Response.json({ error: "Prometheus unavailable" }, { status: 503 });
-          }
-          return Response.json({ data: result });
-        }
-
-        // OBS-9 (FINOPS P-A): hourly spend-over-time bars + spike flags. A
-        // query_range of `sum(increase(cost[1h]))` stepped at 1h over the window;
-        // each point carries `isSpike` (spend > max(2× median, μ+2σ) — the P-A
-        // `--chart-4` dot). 503 when Prometheus is absent; an honest `[]` for a
-        // quiet stack (the ChartCard empty state, never a fabricated bar).
-        if (url.pathname === "/api/otel/cost-series") {
-          if (!prom) return Response.json({ error: "OTel not configured" }, { status: 503 });
-          const range = url.searchParams.get("range") ?? "24h";
-          const result = await costSeries(prom, range);
-          if (result === null) {
-            return Response.json({ error: "Prometheus unavailable" }, { status: 503 });
-          }
-          return Response.json({ data: result });
-        }
-
-        // OBS-9 (FINOPS HERO-C, THE HEADLINE): cache-ROI $. Σ_model cacheRead_tokens
-        // × (input_price − cache_read_price) from a per-model price book — the real
-        // dollars the 99.8%-hit-rate prompt cache saved — plus the "(Nx)" multiplier
-        // (savings / actual spend). 503 when Prometheus is absent.
-        if (url.pathname === "/api/otel/cache-savings") {
-          if (!prom) return Response.json({ error: "OTel not configured" }, { status: 503 });
-          const range = url.searchParams.get("range") ?? "24h";
-          const result = await cacheSavings(prom, range);
-          if (result === null) {
-            return Response.json({ error: "Prometheus unavailable" }, { status: 503 });
-          }
-          return Response.json({ data: result });
-        }
-
-        // OBS-10 (FINOPS P-A drill): cost at a single spiking hour. Clicking a
-        // spiking bar in the spend-over-time chart re-queries THAT hour's by-ticket
-        // + by-model split (the "one re-query with the hour window"). `hour` is the
-        // clicked bar's epoch-SECOND timestamp; the query anchors a 1h `increase()`
-        // window to it via PromQL `offset`. Both maps are zero-filtered. 503 when
-        // Prometheus is absent; 400 when `hour` is missing/non-numeric (never a
-        // fabricated empty drill).
-        if (url.pathname === "/api/otel/cost-at-hour") {
-          if (!prom) return Response.json({ error: "OTel not configured" }, { status: 503 });
-          const hourParam = url.searchParams.get("hour");
-          const hour = hourParam !== null ? Number(hourParam) : NaN;
-          if (!Number.isFinite(hour) || hour <= 0) {
-            return Response.json({ error: "hour (epoch seconds) required" }, { status: 400 });
-          }
-          const result = await costAtHour(prom, hour);
-          if (result === null) {
-            return Response.json({ error: "Prometheus unavailable" }, { status: 503 });
-          }
-          return Response.json({ data: result });
-        }
-
-        if (url.pathname === "/api/otel/tools") {
-          if (!loki) return Response.json({ error: "OTel not configured" }, { status: 503 });
-          const range = url.searchParams.get("range") ?? "1h";
-          const result = await toolUsageByName(loki, range);
-          return Response.json({ data: result });
-        }
-
-        // OBS-7 (TELEMETRY P3): per-tool p50/p95 latency, the half /api/otel/tools
-        // (counts only) is missing so the panel can sort by TOTAL TIME (count × p95)
-        // rather than chattiness. unwrap duration_ms on tool_result by tool_name
-        // (toolLatency in otel-queries.ts). 503 when Loki is not configured; an
-        // empty stream is an HONEST 200 with `data:{}` (counts-only fallback).
-        if (url.pathname === "/api/otel/tool-latency") {
-          if (!loki) return Response.json({ error: "OTel not configured" }, { status: 503 });
-          const range = url.searchParams.get("range") ?? "1h";
-          const result = await toolLatency(loki, range);
-          if (result === null) {
-            // null means the queryRange came back null. Distinguish HONESTLY: if the
-            // /ready probe passed, Loki IS reachable and this is a QUERY/backend
-            // error (e.g. a LogQL 400), NOT "Loki unavailable" — don't mislabel it.
-            return otelDegradedResponse(loki, "tool-latency");
-          }
-          return Response.json({ data: result });
-        }
-
-        if (url.pathname === "/api/otel/errors") {
-          if (!loki) return Response.json({ error: "OTel not configured" }, { status: 503 });
-          const range = url.searchParams.get("range") ?? "1h";
-          const rawLimit = parseInt(url.searchParams.get("limit") ?? "50", 10);
-          const limit = Number.isFinite(rawLimit) ? Math.min(Math.max(1, rawLimit), 500) : 50;
-          // CTL-1039: alongside the panel's error rows, carry the proportional
-          // counts WITH EXPLICIT WINDOWS (15m + today) the hero reads to pick
-          // NOTED vs ERRORING. Backward-compatible: `data` stays the row array.
-          const [result, counts] = await Promise.all([
-            apiErrors(loki, range, limit),
-            apiErrorCounts(loki),
-          ]);
-          return Response.json({ data: result, counts });
-        }
-
-        // OBS-16 (UTILIZATION P_active): fleet-wide active-time ratio. A single
-        // Prometheus read of `sum(rate(claude_code_active_time_seconds_total[range]))`
-        // — the active seconds-per-second across the fleet (≈ slots' worth of
-        // wall-clock genuinely computing). The UI divides this by config.inFlight
-        // (busy-slot capacity it already holds) to render "X% computing / Y%
-        // waiting". 503 when Prometheus is absent (the P_active ChartCard degrades
-        // via the [prom] ladder); an idle fleet is an HONEST 200 with
-        // `data:{activeSecondsPerSecond:0}` (the genuine low read, never a
-        // fabricated number).
-        if (url.pathname === "/api/otel/active-time") {
-          if (!prom) return Response.json({ error: "OTel not configured" }, { status: 503 });
-          const range = url.searchParams.get("range") ?? "1h";
-          const result = await activeTimeRatio(prom, range);
-          if (result === null) {
-            return Response.json({ error: "Prometheus unavailable" }, { status: 503 });
-          }
-          return Response.json({ data: result });
-        }
-
-        // OBS-7 (TELEMETRY P4): per-model api_request latency (p50/p95) + error%,
-        // read off the SAME claude-code Loki stream as the tail/errors — NOT a new
-        // Prometheus dependency. The LogQL unwraps `duration_ms` on api_request and
-        // aggregates with quantile_over_time by model (modelLatency in
-        // otel-queries.ts). 503 when Loki is not configured (the P4 ChartCard
-        // degrades via the ladder); an empty stream is an HONEST 200 with `data:[]`
-        // (the card's "no data in range" state, NOT an error).
-        if (url.pathname === "/api/otel/model-latency") {
-          if (!loki) return Response.json({ error: "OTel not configured" }, { status: 503 });
-          const range = url.searchParams.get("range") ?? "1h";
-          const result = await modelLatency(loki, range);
-          if (result === null) {
-            // null means the queryRange came back null. Surface it HONESTLY: a
-            // passing /ready probe means Loki is reachable and this is a query/
-            // backend error (degraded), NOT a fabricated empty or a false
-            // "Loki unavailable".
-            return otelDegradedResponse(loki, "model-latency");
-          }
-          return Response.json({ data: result });
-        }
-
-        // OBS-6 (TELEMETRY): the fleet-wide grouped live tail + freshness. ONE
-        // newest-first scan of the claude-code Loki stream (same pipe as the
-        // per-session history, minus the session filter). The hero reads
-        // `freshnessMs` (age of the newest line) to pick FLOWING vs QUIET; the P1
-        // panel groups `rows` by worker client-side. 503 when Loki is not
-        // configured (the surface degrades via the ChartCard ladder). An empty
-        // stream is an HONEST 200 with `freshnessMs:null` (QUIET, not an error).
-        if (url.pathname === "/api/otel/tail") {
-          if (!loki) return Response.json({ error: "OTel not configured" }, { status: 503 });
-          const range = url.searchParams.get("range") ?? "15m";
-          const rawLimit = parseInt(url.searchParams.get("limit") ?? "300", 10);
-          const limit = Number.isFinite(rawLimit)
-            ? Math.min(Math.max(1, rawLimit), 1000)
-            : 300;
-          const result = await recentTail(loki, range, limit);
-          if (result === null) {
-            // Loki probe failed mid-flight — honest 503, not a fabricated empty.
-            return Response.json({ error: "Loki unavailable" }, { status: 503 });
-          }
-          return Response.json({ data: result });
-        }
-
-        // OBS-8 (TELEMETRY P5): events/min heatmap, workers × time. ONE metric
-        // query over the claude-code Loki stream — `count_over_time` of every line
-        // per `session_id` in 15m buckets (eventsHeatmap in otel-queries.ts). The
-        // payload is {buckets, cells}; the UI joins cells[].sessionId to board
-        // worker names and renders a row for EVERY running worker (silent ones
-        // included) so an early stall — a `running` worker with dark recent cells —
-        // is visible. 503 when Loki is not configured (the P5 ChartCard degrades via
-        // the ladder, but its board-sourced row headers still render per design
-        // §3.1); a reachable-but-quiet stream is an HONEST 200 with empty cells.
-        if (url.pathname === "/api/otel/events-heatmap") {
-          if (!loki) return Response.json({ error: "OTel not configured" }, { status: 503 });
-          const range = url.searchParams.get("range") ?? "6h";
-          const result = await eventsHeatmap(loki, range);
-          if (result === null) {
-            // Loki probe failed mid-flight — honest 503, not a fabricated empty.
-            return Response.json({ error: "Loki unavailable" }, { status: 503 });
-          }
-          return Response.json({ data: result });
-        }
-
-        if (url.pathname === "/api/otel/cost-validation") {
-          if (!prom) return Response.json({ error: "OTel not configured" }, { status: 503 });
-          const range = url.searchParams.get("range") ?? "6h";
-          const snap = buildSnapshot(wtDir, buildOpts);
-          const signalCosts: Record<string, number> = {};
-          for (const orch of snap.orchestrators) {
-            for (const [key, worker] of Object.entries(orch.workers)) {
-              if (worker.cost?.costUSD) signalCosts[key] = worker.cost.costUSD;
-            }
-          }
-          const result = await costValidation(prom, signalCosts, range);
-          return Response.json({ data: result });
-        }
-
-        // CTL-914 (DETAIL3): the worker-page [history] tail. Queries the
-        // `claude-code` Loki stream for ONE run's transcript by its CC session
-        // UUID — REAL today, no plumbing — so a dead worker's tail is readable
-        // hours later (why the worker page is never empty). The filter is a
-        // `| session_id=\`UUID\`` STRUCTURED-METADATA pipe inside
-        // workerHistoryBySession (a `{session_id=}` label matcher returns 0).
-        // sessionId is UUID-validated before it ever reaches the LogQL, so the
-        // pipe can never be an injection vector. 503 when Loki is not configured
-        // (the UI degrades to the resident-data page), 400 on a bad id.
-        const ecWorkerHistoryMatch = url.pathname.match(
-          /^\/api\/ec-worker-history\/([^/]+)$/,
-        );
-        if (ecWorkerHistoryMatch) {
-          let sessionId: string;
-          try {
-            sessionId = decodeURIComponent(ecWorkerHistoryMatch[1]);
-          } catch {
-            return new Response("Bad Request", { status: 400 });
-          }
-          if (!isValidCcSessionId(sessionId)) {
-            return new Response("Bad Request", { status: 400 });
-          }
-          if (!loki) {
-            return Response.json({ error: "OTel not configured" }, { status: 503 });
-          }
-          const range = url.searchParams.get("range") ?? "24h";
-          const rawLimit = parseInt(url.searchParams.get("limit") ?? "500", 10);
-          const limit = Number.isFinite(rawLimit)
-            ? Math.min(Math.max(1, rawLimit), 2000)
-            : 500;
-          const rows = await workerHistoryBySession(loki, sessionId, range, limit);
-          if (rows === null) {
-            // Loki probe failed mid-flight — honest 503, not a fabricated empty.
-            return Response.json({ error: "Loki unavailable" }, { status: 503 });
-          }
-          return Response.json({ data: rows });
-        }
-
-        // CTL-917 (DETAIL6): the worker Burn Strip's REAL Prometheus sparklines.
-        // Four query_range series keyed on the CC session UUID (cost / tokens /
-        // tokens-by-type / active-seconds) — no new plumbing, the same already-
-        // emitting OTEL pipeline the `/api/otel/*` routes read. The UUID is
-        // UUID-validated before it reaches the PromQL `{session_id=…}` matcher,
-        // so the matcher can never be an injection vector. 503 when Prometheus is
-        // not configured (the UI falls back to the resident BoardWorker scalar),
-        // 400 on a bad id.
-        const otelBurnMatch = url.pathname.match(
-          /^\/api\/otel\/burn\/([^/]+)$/,
-        );
-        if (otelBurnMatch) {
-          let sessionId: string;
-          try {
-            sessionId = decodeURIComponent(otelBurnMatch[1]);
-          } catch {
-            return new Response("Bad Request", { status: 400 });
-          }
-          if (!isValidCcSessionId(sessionId)) {
-            return new Response("Bad Request", { status: 400 });
-          }
-          if (!prom) {
-            return Response.json({ error: "OTel not configured" }, { status: 503 });
-          }
-          const range = url.searchParams.get("range") ?? "1h";
-          const series = await workerBurnSeries(prom, sessionId, range);
-          if (series === null) {
-            // Prometheus probe failed mid-flight — honest 503, never a fake series.
-            return Response.json({ error: "Prometheus unavailable" }, { status: 503 });
-          }
-          return Response.json({ data: series });
-        }
-
-        // CTL-917 (DETAIL6): the ticket telemetry strip's REAL Prometheus
-        // sparklines keyed on the Linear key (total cost / tokens-by-type +
-        // cost-by-phase `sum by(task_type)` + cost-by-model `sum by(model)`).
-        // commits/LoC stay git-sourced (NEEDS-PLUMBING) so they are NOT queried
-        // here. The linear_key is validated before it reaches the PromQL matcher.
-        const otelTicketTelemetryMatch = url.pathname.match(
-          /^\/api\/otel\/ticket-telemetry\/([^/]+)$/,
-        );
-        if (otelTicketTelemetryMatch) {
-          let linearKey: string;
-          try {
-            linearKey = decodeURIComponent(otelTicketTelemetryMatch[1]);
-          } catch {
-            return new Response("Bad Request", { status: 400 });
-          }
-          if (!isValidLinearKey(linearKey)) {
-            return new Response("Bad Request", { status: 400 });
-          }
-          if (!prom) {
-            return Response.json({ error: "OTel not configured" }, { status: 503 });
-          }
-          const range = url.searchParams.get("range") ?? "1h";
-          const series = await ticketTelemetrySeries(prom, linearKey, range);
-          if (series === null) {
-            return Response.json({ error: "Prometheus unavailable" }, { status: 503 });
-          }
-          return Response.json({ data: series });
-        }
-
-        if (url.pathname === "/api/annotations") {
-          return Response.json({ annotations: getAllAnnotations() });
-        }
-
-        const annMatch = url.pathname.match(
-          /^\/api\/annotations\/([A-Za-z0-9._-]+)$/,
-        );
-        if (annMatch && annMatch[1]) {
-          const sessionId = decodeURIComponent(annMatch[1]);
-
-          if (req.method === "DELETE") {
-            deleteAnnotation(sessionId);
-            return Response.json({ ok: true });
-          }
-
-          if (req.method === "PUT") {
-            let body: Record<string, unknown>;
-            try {
-              body = (await req.json()) as Record<string, unknown>;
-            } catch {
-              return Response.json(
-                { error: "Invalid JSON body" },
-                { status: 400 },
-              );
             }
 
-            const VALID_FLAGS = new Set([
-              "starred",
-              "flagged",
-              "archived",
-            ]);
-
-            if (Array.isArray(body.addFlags)) {
-              for (const f of body.addFlags) {
-                if (typeof f !== "string" || !VALID_FLAGS.has(f)) {
-                  return Response.json(
-                    {
-                      error: `Invalid flag: ${String(f)}. Valid: starred, flagged, archived`,
-                    },
-                    { status: 400 },
-                  );
-                }
-              }
-            }
-
-            if (typeof body.displayName === "string") {
-              setDisplayName(sessionId, body.displayName);
-            } else if (body.displayName === null) {
-              setDisplayName(sessionId, null);
-            }
-
-            if (Array.isArray(body.addFlags)) {
-              for (const f of body.addFlags) {
-                if (typeof f === "string") addFlag(sessionId, f);
-              }
-            }
-            if (Array.isArray(body.removeFlags)) {
-              for (const f of body.removeFlags) {
-                if (typeof f === "string") removeFlag(sessionId, f);
-              }
-            }
-            if (typeof body.addNote === "string") {
-              addNote(sessionId, body.addNote);
-            }
-            if (
-              typeof body.removeNoteIndex === "number" &&
-              Number.isInteger(body.removeNoteIndex)
-            ) {
-              removeNote(sessionId, body.removeNoteIndex);
-            }
-            if (Array.isArray(body.addTags)) {
-              for (const t of body.addTags) {
-                if (typeof t === "string") addTag(sessionId, t);
-              }
-            }
-            if (Array.isArray(body.removeTags)) {
-              for (const t of body.removeTags) {
-                if (typeof t === "string") removeTag(sessionId, t);
-              }
-            }
-
-            const annotation = getAnnotation(sessionId);
-            return Response.json({ annotation });
-          }
-
-          return new Response("Method Not Allowed", { status: 405 });
-        }
-
-        if (url.pathname === "/api/archive/orchestrators") {
-          if (!dbPath) {
-            return Response.json({ entries: [], total: 0 });
-          }
-          const params = url.searchParams;
-          const limitRaw = params.get("limit");
-          const offsetRaw = params.get("offset");
-          const parsedLimit = limitRaw ? Number.parseInt(limitRaw, 10) : NaN;
-          const parsedOffset = offsetRaw ? Number.parseInt(offsetRaw, 10) : NaN;
-          const result = listArchivedOrchestrators(dbPath, {
-            since: params.get("since") ?? undefined,
-            until: params.get("until") ?? undefined,
-            ticket: params.get("ticket") ?? undefined,
-            status: params.get("status") ?? undefined,
-            limit: Number.isFinite(parsedLimit) ? parsedLimit : undefined,
-            offset: Number.isFinite(parsedOffset) ? parsedOffset : undefined,
-          });
-          return Response.json(result);
-        }
-
-        const archiveFileMatch = url.pathname.match(
-          /^\/api\/archive\/orchestrators\/([^/]+)\/files\/(.+)$/,
-        );
-        if (archiveFileMatch) {
-          if (!dbPath) {
-            return new Response("Not Found", { status: 404 });
-          }
-          let orchId: string;
-          let fileRel: string;
-          try {
-            orchId = decodeURIComponent(archiveFileMatch[1]);
-            fileRel = decodeURIComponent(archiveFileMatch[2]);
-          } catch {
-            return new Response("Bad Request", { status: 400 });
-          }
-          if (
-            !isSafeArchivePart(orchId) ||
-            !isSafeArchiveFileRel(fileRel)
-          ) {
-            return new Response("Bad Request", { status: 400 });
-          }
-          const archivePath = getArchivePath(dbPath, orchId);
-          if (!archivePath) {
-            return new Response("Not Found", { status: 404 });
-          }
-          const candidate = resolvePath(archivePath, fileRel);
-          let realRoot: string;
-          try {
-            realRoot = realpathSync(archivePath);
-          } catch {
-            return new Response("Not Found", { status: 404 });
-          }
-          let realTarget: string;
-          try {
-            realTarget = realpathSync(candidate);
-          } catch {
-            return new Response("Not Found", { status: 404 });
-          }
-          if (
-            realTarget !== realRoot &&
-            !realTarget.startsWith(realRoot + sep)
-          ) {
-            return new Response("Forbidden", { status: 403 });
-          }
-          const file = Bun.file(realTarget);
-          if (!(await file.exists())) {
-            return new Response("Not Found", { status: 404 });
-          }
-          return new Response(file, {
-            headers: {
-              "Content-Type": contentTypeForArchive(realTarget),
-              "Cache-Control": "private, max-age=60",
-            },
-          });
-        }
-
-        const archiveDetailMatch = url.pathname.match(
-          /^\/api\/archive\/orchestrators\/([^/]+)$/,
-        );
-        if (archiveDetailMatch) {
-          if (!dbPath) {
-            return new Response("Not Found", { status: 404 });
-          }
-          let orchId: string;
-          try {
-            orchId = decodeURIComponent(archiveDetailMatch[1]);
-          } catch {
-            return new Response("Bad Request", { status: 400 });
-          }
-          if (!isSafeArchivePart(orchId)) {
-            return new Response("Bad Request", { status: 400 });
-          }
-          const detail = getArchivedOrchestrator(dbPath, orchId);
-          if (!detail) {
-            return new Response("Not Found", { status: 404 });
-          }
-          return Response.json(detail);
-        }
-
-        // CTL-1133: PWA installability. The web app is installable as a
-        // chrome-less standalone window (desktop) / iOS home-screen app. The
-        // manifest and service worker are served from the ROOT (not /public/) so
-        // the SW's default scope is "/" and it controls the whole app — a SW at
-        // /public/service-worker.js would only scope /public/. Icons are plain
-        // PNGs served by the existing /public/* route.
-        if (url.pathname === "/manifest.webmanifest") {
-          const file = Bun.file(join(publicDir, "manifest.webmanifest"));
-          if (await file.exists()) {
-            return new Response(file, {
-              headers: {
-                "Content-Type": "application/manifest+json; charset=utf-8",
-                "Cache-Control": CACHE_REVALIDATE, // CTL-1374
-              },
-            });
-          }
-          return new Response("manifest not found", { status: 404 });
-        }
-        if (url.pathname === "/service-worker.js") {
-          const file = Bun.file(join(publicDir, "service-worker.js"));
-          if (await file.exists()) {
-            return new Response(file, {
-              headers: {
-                "Content-Type": "text/javascript; charset=utf-8",
-                // allow root scope even though the file lives under publicDir
-                "Service-Worker-Allowed": "/",
-                // never let a stale SW pin an old shell
-                "Cache-Control": "no-cache",
-              },
-            });
-          }
-          return new Response("service worker not found", { status: 404 });
-        }
-
-        // CTL-989: the app shell (index.html → main.tsx → the unified TanStack
-        // Router → AppShell layout) is the SINGLE canonical entry. It hosts every
-        // surface (Home/Tickets/Workers/Queue/Observe) AND every detail page
-        // inside the shared AppShell chrome — so `/` serves the shell. The legacy
-        // standalone board.html bundle is RETIRED; `/board` is now just the
-        // Tickets surface route, served by this same index.html (see the unified
-        // SPA fallback below).
-        if (url.pathname === "/" || url.pathname === "/index.html") {
-          const file = Bun.file(join(publicDir, "index.html"));
-          if (await file.exists()) {
-            return new Response(file, {
-              headers: {
-                "Content-Type": "text/html; charset=utf-8",
-                "Cache-Control": CACHE_REVALIDATE, // CTL-1374: always revalidate the shell
-              },
-            });
-          }
-          return new Response("index.html not found", { status: 500 });
-        }
-
-        // CTL-989: the unified SPA fallback. EVERY app route — the flat surface
-        // paths (/board, /workers, /queue, /telemetry, /utilization, /finops,
-        // /fleetops, /devops, /settings) AND the detail/dep-graph deep links
-        // (/ticket/$id, /worker/$id, /dep-graph) — is served by the ONE TanStack
-        // Router mounted from index.html. A hard navigation / refresh / shared
-        // link to any of them serves index.html; the router boots, reads the URL,
-        // and lands on the right surface or detail page. (`/` and `/index.html`
-        // are handled by the dedicated block above; `/legacy` + `/history` keep
-        // their own handlers below.) Vite emits absolute /assets/* paths, so the
-        // nested /ticket/$id pathname is safe. GET-only: a POST to an app path is
-        // not the SPA entry.
-        if (req.method === "GET" && isAppRoute(url.pathname)) {
-          const file = Bun.file(join(publicDir, "index.html"));
-          if (await file.exists()) {
-            return new Response(file, {
-              headers: {
-                "Content-Type": "text/html; charset=utf-8",
-                "Cache-Control": CACHE_REVALIDATE, // CTL-1374: always revalidate the shell
-              },
-            });
-          }
-          return new Response("index.html not found", { status: 500 });
-        }
-
-        if (
-          url.pathname === "/legacy" ||
-          url.pathname === "/legacy/" ||
-          url.pathname === "/history"
-        ) {
-          const htmlFile =
-            url.pathname === "/history" ? "history.html" : "index.html";
-          const file = Bun.file(join(publicDir, htmlFile));
-          if (await file.exists()) {
-            return new Response(file, {
-              headers: {
-                "Content-Type": "text/html; charset=utf-8",
-                "Cache-Control": CACHE_REVALIDATE, // CTL-1374
-              },
-            });
-          }
-          return new Response(`${htmlFile} not found`, { status: 500 });
-        }
-
-
-        if (url.pathname === "/mockups" || url.pathname === "/mockups/") {
-          const file = Bun.file(join(publicDir, "mockups", "index.html"));
-          if (await file.exists()) {
-            return new Response(file, {
-              headers: {
-                "Content-Type": "text/html; charset=utf-8",
-                "Cache-Control": CACHE_REVALIDATE, // CTL-1374
-              },
-            });
-          }
-        }
-
-        if (url.pathname.startsWith("/mockups/")) {
-          const rel = decodeURIComponent(
-            "mockups/" + url.pathname.slice("/mockups/".length),
-          );
-          const safe = resolveSafeStaticPath(publicDir, rel);
-          if (!safe) return new Response("Forbidden", { status: 403 });
-          const file = Bun.file(safe);
-          if (await file.exists()) {
-            const dot = safe.lastIndexOf(".");
-            const ext = dot >= 0 ? safe.slice(dot).toLowerCase() : "";
-            return new Response(file, {
-              headers: {
-                "Content-Type": contentTypeForExt(ext),
-                "Cache-Control": CACHE_REVALIDATE, // CTL-1374: mockups aren't content-hashed
-              },
-            });
-          }
-        }
-
-        if (url.pathname.startsWith("/public/") || url.pathname.startsWith("/assets/")) {
-          const rel = decodeURIComponent(
-            url.pathname.startsWith("/public/")
-              ? url.pathname.slice("/public/".length)
-              : url.pathname.slice(1),
-          );
-          const safe = resolveSafeStaticPath(publicDir, rel);
-          if (!safe) return new Response("Forbidden", { status: 403 });
-          const file = Bun.file(safe);
-          if (await file.exists()) {
-            const dot = safe.lastIndexOf(".");
-            const ext = dot >= 0 ? safe.slice(dot).toLowerCase() : "";
-            return new Response(file, {
-              headers: {
-                "Content-Type": contentTypeForExt(ext),
-                // CTL-1374: content-hashed /assets/* are immutable (forever-cacheable);
-                // non-hashed /public/* icons revalidate so a redeploy can update them.
-                "Cache-Control": cacheControlForStatic(url.pathname),
-              },
-            });
-          }
-        }
-
-        if (url.pathname === "/api/status/webhook-tunnel") {
-          const stats = readTunnelEventStats(CATALYST_DIR, eventRing);
-          if (!webhookConfig) {
-            return Response.json({
-              connected: false,
-              smeeUrl: null,
-              secretEnvName: null,
-              secretPresent: false,
-              lastEventAt: stats.lastEventAt,
-              eventCount24h: stats.eventCount24h,
-              eventCount24hByRepo: stats.eventCount24hByRepo,
-            });
-          }
-          return Response.json({
-            connected: webhookTunnel?.isStarted() ?? false,
-            smeeUrl: webhookConfig.smeeChannel || null,
-            secretEnvName: webhookConfig.secretEnvName ?? "CATALYST_WEBHOOK_SECRET",
-            secretPresent: webhookConfig.secret.length > 0,
-            lastEventAt: stats.lastEventAt,
-            eventCount24h: stats.eventCount24h,
-            eventCount24hByRepo: stats.eventCount24hByRepo,
-          });
-        }
-
-        // CTL-1100: GET /api/journey/:ticket — chronological hop timeline + gates + verdict.
-        // bun:sqlite-free (assembleJourney uses sqlite3 binary via ticket-runs.mjs).
-        // Mirrors ticketRunsMatch guard for input validation.
-        const journeyMatch = url.pathname.match(/^\/api\/journey\/([^/]+)$/);
-        if (journeyMatch) {
-          let ticket: string;
-          try {
-            ticket = decodeURIComponent(journeyMatch[1]);
-          } catch {
-            return new Response("Bad Request", { status: 400 });
-          }
-          if (!/^[A-Za-z]+-\d+$/.test(ticket)) {
-            return new Response("Bad Request", { status: 400 });
-          }
-          return Response.json(await assembleJourney(ticket, {
-            orchDir: wtDir,
-            workersDir: `${wtDir}/workers`,
-            dbPath: dbPath ?? undefined,
-          }));
-        }
-
-        // CTL-886 (BFF4) keystone P2: a ticket's full run history. One run entity
-        // per phase-*.json signal under ~/catalyst/execution-core/workers/<id>/
-        // (model, bg_job_id, attempt, generation, status, timestamps, host{},
-        // pr{} when present). FINISHED runs (no live BoardWorker) included by
-        // construction — we read the on-disk signals, not the live-agent list.
-        // Per-phase cost is JOINED from catalyst.db, never invented onto the
-        // signal. Pure file reads — no live Linear/GitHub call.
-        const ticketRunsMatch = url.pathname.match(/^\/api\/ticket-runs\/([^/]+)$/);
-        if (ticketRunsMatch) {
-          let ticket: string;
-          try {
-            ticket = decodeURIComponent(ticketRunsMatch[1]);
-          } catch {
-            return new Response("Bad Request", { status: 400 });
-          }
-          if (!/^[A-Za-z]+-\d+$/.test(ticket)) {
-            return new Response("Bad Request", { status: 400 });
-          }
-          return Response.json(await assembleTicketRuns(ticket));
-        }
-
-        // CTL-890 (BFF8) P10: the redesign's ONE destructive endpoint, gated last.
-        // POST /api/ec-worker/<ticket>/stop wraps the flaky `claude stop <shortId>`
-        // (pid-file absent on CC 2.1.152). Matched BEFORE the GET verbatim route
-        // and gated on POST so a stop request is never confused with the
-        // signal reader (and "stop" is not a valid phase, so a GET here 404s
-        // harmlessly). Contract (design §3.4):
-        //   • TYPED CONFIRM — body.confirm must equal the ticket id exactly.
-        //   • TARGET RUN    — body.phase selects which run (its phase-<phase>.json
-        //     signal carries the bg_job_id → shortId). The response echoes the
-        //     exact shortId+ticket+phase so the UI shows what it is killing.
-        //   • FENCE-AWARE   — single-host (hosts.json absent/len 1) is a no-op
-        //     pass; multi-host rejects a verified-stale generation (a partitioned
-        //     node) and refuses on an unconfirmable fence.
-        //   • OPTIMISTIC ROLLBACK is a UI-side ~10s timer; on success we return the
-        //     identity + a `stopping` status the client marks optimistically.
-        const ecStopMatch = url.pathname.match(
-          /^\/api\/ec-worker\/([^/]+)\/stop$/,
-        );
-        if (ecStopMatch && req.method === "POST") {
-          let ticket: string;
-          try {
-            ticket = decodeURIComponent(ecStopMatch[1]);
-          } catch {
-            return new Response("Bad Request", { status: 400 });
-          }
-          if (!/^[A-Za-z]+-\d+$/.test(ticket)) {
-            return new Response("Bad Request", { status: 400 });
-          }
-          let body: Record<string, unknown>;
-          try {
-            body = (await req.json()) as Record<string, unknown>;
-          } catch {
-            return Response.json({ error: "Invalid JSON body" }, { status: 400 });
-          }
-          const phase = typeof body.phase === "string" ? body.phase : "";
-          if (!/^[a-z][a-z-]*$/.test(phase)) {
-            return Response.json(
-              { error: "phase is required and must be a valid phase name" },
-              { status: 400 },
-            );
-          }
-          const result: StopWorkerResult = await stopWorker({
-            ticket,
-            phase,
-            confirm: body.confirm,
-          });
-          switch (result.status) {
-            case "not_found":
-              return Response.json(
-                { status: "not_found", error: `no run signal for ${ticket}:${phase}` },
-                { status: 404 },
-              );
-            case "confirm_mismatch":
-              return Response.json(
-                {
-                  status: "confirm_mismatch",
-                  error: "typed confirmation did not match the ticket id",
-                  expected: result.expected,
-                },
-                { status: 400 },
-              );
-            case "no_session":
-              return Response.json(result, { status: 409 });
-            case "fenced":
-              // A stale-generation node is fenced out — the worker is NOT killed.
-              return Response.json(
-                {
-                  ...result,
-                  error: "stop rejected: this node's generation is stale (fenced out)",
-                },
-                { status: 409 },
-              );
-            case "fence_indeterminate":
-              return Response.json(
-                {
-                  ...result,
-                  error: "stop rejected: fence could not be confirmed",
-                },
-                { status: 409 },
-              );
-            case "stop_failed":
-              return Response.json(result, { status: 502 });
-            case "stopping":
-              // Kill issued; the UI marks the worker `stopping` and arms its ~10s
-              // optimistic-rollback timer against the next board frame.
-              return Response.json(result, { status: 200 });
-          }
-        }
-
-        // CTL-924 (BFF12): the read-model's SECOND write endpoint — HOME5's Inbox
-        // `Answer / Unblock` verb. POST /api/ticket/<ticket>/respond records the
-        // operator's answer/unblock note, clears the `.linear-label-needs-human`
-        // marker, and emits ONE `linear.comment.created` event into the unified
-        // log — the daemon's handleCommentWake (CTL-549) consumes it, strips the
-        // held label, and re-dispatches the parked worker (CTL-876's resume loop).
-        // Contract mirrors BFF8's stop route:
-        //   • TYPED CONFIRM — body.confirm must equal the ticket id exactly.
-        //   • FENCE-AWARE   — single-host (hosts.json absent/len 1) is a no-op
-        //     pass; multi-host rejects a verified-stale generation (a partitioned
-        //     node) and refuses on an unconfirmable fence. NOTHING is mutated on
-        //     a fence rejection.
-        //   • OPTIMISTIC ROLLBACK is a UI-side timer; on success we return the
-        //     ticket+phase identity + a `resuming` status the client marks
-        //     optimistically (the held row should clear within the window).
-        const respondMatch = url.pathname.match(
-          /^\/api\/ticket\/([^/]+)\/respond$/,
-        );
-        if (respondMatch && req.method === "POST") {
-          let ticket: string;
-          try {
-            ticket = decodeURIComponent(respondMatch[1]);
-          } catch {
-            return new Response("Bad Request", { status: 400 });
-          }
-          if (!/^[A-Za-z]+-\d+$/.test(ticket)) {
-            return new Response("Bad Request", { status: 400 });
-          }
-          let body: Record<string, unknown>;
-          try {
-            body = (await req.json()) as Record<string, unknown>;
-          } catch {
-            return Response.json({ error: "Invalid JSON body" }, { status: 400 });
-          }
-          const response = typeof body.response === "string" ? body.response : "";
-          const result: RespondTicketResult = respondTicket({
-            ticket,
-            response,
-            confirm: body.confirm,
-          });
-          switch (result.status) {
-            case "not_held":
-              return Response.json(
-                {
-                  status: "not_held",
-                  error: `no parked (needs-input) run for ${ticket} to answer/unblock`,
-                },
-                { status: 404 },
-              );
-            case "confirm_mismatch":
-              return Response.json(
-                {
-                  status: "confirm_mismatch",
-                  error: "typed confirmation did not match the ticket id",
-                  expected: result.expected,
-                },
-                { status: 400 },
-              );
-            case "fenced":
-              // A stale-generation node is fenced out — nothing was mutated.
-              return Response.json(
-                {
-                  ...result,
-                  error: "respond rejected: this node's generation is stale (fenced out)",
-                },
-                { status: 409 },
-              );
-            case "fence_indeterminate":
-              return Response.json(
-                {
-                  ...result,
-                  error: "respond rejected: fence could not be confirmed",
-                },
-                { status: 409 },
-              );
-            case "resuming":
-              // Response recorded + marker cleared + resume event emitted; the UI
-              // marks the row `resuming` and arms its optimistic-rollback timer.
-              return Response.json(result, { status: 200 });
-          }
-        }
-
-        // ── CTL-1569: the inbox conversation surface ───────────────────────────
-        //
-        // GET /api/ticket/<ticket>/thread — the ask summary + the last few comments
-        // (newest first) + the ticket's Linear deep link. A pure REPLICA read: it
-        // makes ZERO Linear API calls, which is what makes it safe to fetch on every
-        // row selection against a shared, rate-limited fleet quota. Fails OPEN —
-        // an absent/locked replica yields an unavailable thread, never a 5xx.
-        const threadMatch = url.pathname.match(/^\/api\/ticket\/([^/]+)\/thread$/);
-        if (threadMatch && req.method === "GET") {
-          let ticket: string;
-          try {
-            ticket = decodeURIComponent(threadMatch[1]);
-          } catch {
-            return new Response("Bad Request", { status: 400 });
-          }
-          // CTL-1569: the canonical ticket key allows digits/underscores in the
-          // team prefix (e.g. `OPS_2-17`). A letters-only predicate 400s the entire
-          // conversation surface for such teams. Still anchored + no path
-          // characters, so traversal remains impossible.
-          if (!CONVERSATION_TICKET_RE.test(ticket)) {
-            return new Response("Bad Request", { status: 400 });
-          }
-          const limitParam = Number(url.searchParams.get("limit"));
-          const conversation = await getConversation(ticket, {
-            // Pass the SERVER-resolved Layer-1 path (--config / CATALYST_CONFIG_PATH).
-            // A cwd-relative fallback misses under launchd, which sets no working
-            // directory — and the legacy `catalyst.monitor.linear.botUserId` lives in
-            // that file, so missing it breaks the agent/human split on legacy hosts.
-            repoConfigPath: monitorConfigPath,
-            ...(Number.isFinite(limitParam) && limitParam > 0
-              ? { limit: Math.min(Math.floor(limitParam), 50) }
-              : {}),
-          });
-          return Response.json(conversation, { status: 200 });
-        }
-
-        // POST /api/ticket/<ticket>/reply — post the operator's reply to Linear as a
-        // REAL human-authored comment. This is the resolution mechanism: once the
-        // comment lands, Linear's webhook drives the daemon's comment-wake, which
-        // clears `needs-human` unconditionally and first (CTL-1567, ~4s end to end).
-        //
-        // Deliberately UNLIKE /respond:
-        //   • NO typed-confirm. The typed gate exists for destructive verbs (stop a
-        //     worker); forcing an operator to retype the ticket id to send a chat
-        //     reply would defeat the entire surface. The reply text IS the intent.
-        //   • NO held-run requirement. The tickets that most need answering are
-        //     parked with no worker dir at all, and /respond 404s exactly those.
-        //
-        // EVERY non-2xx here must cause the UI to RESTORE the row (§4) — the row is
-        // never silently lost. `bot_identity` is the loud refusal that prevents the
-        // whole feature from shipping inert: an app-actor comment is ignored by
-        // CTL-1567, so it is refused BEFORE posting rather than faking success.
-        const replyMatch = url.pathname.match(/^\/api\/ticket\/([^/]+)\/reply$/);
-        if (replyMatch && req.method === "POST") {
-          let ticket: string;
-          try {
-            ticket = decodeURIComponent(replyMatch[1]);
-          } catch {
-            return new Response("Bad Request", { status: 400 });
-          }
-          if (!CONVERSATION_TICKET_RE.test(ticket)) {
-            return new Response("Bad Request", { status: 400 });
-          }
-          // CROSS-ORIGIN GUARD. This route posts operator-authored text to Linear,
-          // and the server binds 0.0.0.0 with no auth. `req.json()` parses a body
-          // regardless of Content-Type, so a plain `text/plain` form POST from any
-          // page the operator visits would otherwise be a valid request — the
-          // browser could not read the response, but the comment would still be
-          // posted as them to any guessable ticket.
-          //
-          // CTL-1573 P1: this used to compare `Origin` against the request's own
-          // `Host` header. Both are attacker-chosen under DNS rebinding (the page
-          // and the target then share one origin), so that comparison could not
-          // reject the very case it existed for. `Origin` is now checked against
-          // an allowlist the attacker cannot influence — see lib/trusted-origin.mjs
-          // for the rebinding walkthrough and the inertness trade-off.
-          if (!originAllowed(req.headers.get("origin"))) {
-            return Response.json(
-              { status: "forbidden", error: "cross-origin reply rejected" },
-              { status: 403 },
-            );
-          }
-          let body: Record<string, unknown>;
-          try {
-            body = (await req.json()) as Record<string, unknown>;
-          } catch {
-            return Response.json({ error: "Invalid JSON body" }, { status: 400 });
-          }
-          const text = typeof body.body === "string" ? body.body : "";
-          const [globalConfig, projectConfig] = await Promise.all([
-            loadGlobalConfig(),
-            // Explicit resolved path — NOT process.cwd(). The launchd wrapper sets
-            // neither a working directory nor CATALYST_PROJECT_KEY, so a
-            // cwd-relative lookup leaves the Layer-2 token unresolved and every
-            // reply returns `no_token` on the persistent launch path.
-            loadProjectConfig({ repoConfigPath: monitorConfigPath }),
-          ]);
-          const result = await replyToTicket(
-            { ticket, body: text },
-            { config: globalConfig, projectConfig },
-          );
-          switch (result.status) {
-            case "replied":
-              // The comment is live and human-authored. The UI marks the row
-              // resolved optimistically and reconciles against the label.
-              return Response.json(result, { status: 200 });
-            case "empty_body":
-              return Response.json(
-                { ...result, error: "an empty reply was not sent" },
-                { status: 400 },
-              );
-            case "not_found":
-              return Response.json(
-                {
-                  ...result,
-                  error: `no Linear issue ${ticket} to reply to`,
-                },
-                { status: 404 },
-              );
-            case "bot_identity":
-            case "no_token":
-            case "error":
-            default:
-              // 502: the write did NOT act. Surfaced verbatim so the operator sees
-              // WHY (especially the app-actor refusal) and the row comes back.
-              return Response.json(
-                {
-                  ...result,
-                  error:
-                    (result as { message?: string }).message ??
-                    "reply was not posted to Linear",
-                },
-                { status: 502 },
-              );
-          }
-        }
-
-        // CTL-886 (BFF4) companion P3: one phase signal served VERBATIM — the raw
-        // phase-<phase>.json contents (model, bg_job_id, generation, status,
-        // timestamps, host, pr) untransformed, for the worker header / PHASE
-        // TIMESTAMPS / SIGNAL panel. 404 when the phase has no signal on disk.
-        const ecWorkerMatch = url.pathname.match(
-          /^\/api\/ec-worker\/([^/]+)\/([^/]+)$/,
-        );
-        if (ecWorkerMatch) {
-          let ticket: string;
-          let phase: string;
-          try {
-            ticket = decodeURIComponent(ecWorkerMatch[1]);
-            phase = decodeURIComponent(ecWorkerMatch[2]);
-          } catch {
-            return new Response("Bad Request", { status: 400 });
-          }
-          if (
-            !/^[A-Za-z]+-\d+$/.test(ticket) ||
-            !/^[a-z][a-z-]*$/.test(phase)
-          ) {
-            return new Response("Bad Request", { status: 400 });
-          }
-          const signal = await readPhaseSignalVerbatim(ticket, phase);
-          if (!signal) {
-            return new Response("Not Found", { status: 404 });
-          }
-          return Response.json(signal);
-        }
-
-        // CTL-887 (BFF5) + CTL-885 (BFF3): the live transcript tail, made
-        // NODE-AWARE. BFF5 resolves a CC session UUID to its
-        // ~/.claude/projects/<dir>/<sessionId>.jsonl path and streams typed
-        // StreamEvents over SSE as the file grows (the EC equivalent of the
-        // legacy /api/worker-stream, which is empty for execution-core workers).
-        // BFF3 wraps that host-local tail in the cross-node FAN-IN: the UI
-        // subscribes ONCE and the read-model multiplexes the OWNING node's
-        // per-host stream keyed by host.name.
-        //   • SINGLE-HOST (hosts.json absent/len 1): an EXACT identity no-op —
-        //     tail the LOCAL transcript with zero added latency, no owner
-        //     resolution, no remote hop (resolveTailRoute → { mode: "local" }).
-        //   • MULTI-HOST, owner is a DIFFERENT node: proxy that peer's
-        //     /api/ec-worker-stream/<sessionId> through unchanged (never a
-        //     shared/merged log — only the one owner's per-host stream).
-        const ecWorkerStreamMatch = url.pathname.match(
-          /^\/api\/ec-worker-stream\/([^/]+)$/,
-        );
-        if (ecWorkerStreamMatch) {
-          let sessionId: string;
-          try {
-            sessionId = decodeURIComponent(ecWorkerStreamMatch[1]);
-          } catch {
-            return new Response("Bad Request", { status: 400 });
-          }
-          // A CC session id is a UUID — reject anything else so no arbitrary
-          // path ever reaches the filesystem.
-          if (
-            !/^[0-9a-fA-F-]{8,64}$/.test(sessionId) ||
-            sessionId.includes("..") ||
-            sessionId.includes("/")
-          ) {
-            return new Response("Bad Request", { status: 400 });
-          }
-
-          // ── BFF3 fan-in routing (single-host = identity no-op) ──────────────
-          // Read the committed roster ONCE. SINGLE-HOST is the identity no-op:
-          // resolveTailRoute short-circuits to { mode: "local" } before any
-          // owner resolution, so we never even read the board snapshot — zero
-          // added latency. Only the MULTI-HOST branch resolves the owner: we
-          // read the board snapshot's per-worker host:{name,id} (BFF2/BFF10) —
-          // never a live attachment fetch, never a merged log — and pass a
-          // synchronous lookup over that resolved worker list. `hostBaseUrl` is
-          // the cross-node transport seam: no production roster→URL source
-          // exists yet (single-node MVP), so a multi-host owner with no
-          // resolvable base URL is reported unroutable (a 404) rather than
-          // mis-tailed to the wrong node's local file.
-          const roster = readClusterRoster();
-          const workers =
-            roster.length > 1 ? ((await boardSnapshot.getLatest())?.workers ?? []) : [];
-          const route = resolveTailRoute({
-            sessionId,
-            roster,
-            selfHost: hostName(),
-            ownerHostForSession: (sid) =>
-              workers.find((w) => w.sessionId === sid)?.host?.name ?? null,
-            hostBaseUrl: (host) => resolvePeerBaseUrl(host),
-          });
-          if (route.mode === "remote") {
-            // MULTI-HOST: fan in the owning node's per-host stream, keyed by
-            // host.name, by proxying its SSE body straight through (no re-frame
-            // — the client's StreamEventRow renderer consumes the peer's frames
-            // unchanged). A down/unreachable peer → 502 (never a wrong tail).
-            const abort = new AbortController();
-            const body = await proxyRemoteTail({ url: route.url, signal: abort.signal });
-            if (!body) {
-              return new Response("Bad Gateway", { status: 502 });
-            }
-            const proxied = new ReadableStream<Uint8Array>({
+            let captured: ReadableStreamDefaultController<Uint8Array> | null = null;
+            // CTL-1224: the live activity tail is now fed by the ONE shared
+            // event-ring (eventRing.onAppend) rather than a per-client
+            // tailEventLog poll loop + per-client backlog readFileSync. Each
+            // client keeps its OWN jq filter stream (predicates differ per
+            // client), but the expensive shared part — the file poll + byte read —
+            // is one backend loop (the ring's tick) regardless of client count.
+            let activityUnsub: (() => void) | null = null;
+            let activityFilter: FilterStream | null = null;
+            const stream = new ReadableStream<Uint8Array>({
               async start(controller) {
-                const reader = body.getReader();
+                captured = controller;
+                sseClients.set(controller, filter);
                 try {
-                  for (;;) {
-                    const { value, done } = await reader.read();
-                    if (done) break;
-                    if (value) controller.enqueue(value);
-                  }
-                  controller.close();
-                } catch {
-                  // upstream torn down (peer closed / client aborted) — end the
-                  // proxied stream cleanly rather than leaking the reader.
+                  // Initial snapshot always sent regardless of filter to bootstrap client state
+                  const snapshot = snapshotWithPrStatus();
+                  const envelope = createEvent("snapshot", snapshot, "filesystem");
+                  const msg = `event: snapshot\ndata: ${JSON.stringify(envelope)}\n\n`;
+                  controller.enqueue(encoder.encode(msg));
+                } catch (err) {
+                  console.error(`[server] initial snapshot enqueue failed:`, err);
+                }
+
+                // Activity stream multiplex: only when the client opted in via
+                // `?activity=` (predicate may be empty for "all events").
+                if (filter.activityPredicate !== undefined) {
+                  const predicate = filter.activityPredicate;
                   try {
-                    controller.close();
-                  } catch {
-                    /* already closed */
+                    // CTL-1224: serve the backlog from the shared ring when it
+                    // covers the window; bounded file fallback on underflow. No
+                    // unconditional full-file readFileSync on the SSE path.
+                    const backlogLines = await readBacklog({
+                      catalystDir: CATALYST_DIR,
+                      predicate,
+                      limit: 100,
+                      ring: eventRing,
+                    });
+                    const parsed = backlogLines
+                      .map((l) => safeParseJson(l))
+                      .filter((v): v is Record<string, unknown> => v !== null);
+                    const backlogEnv = createEvent(
+                      "global-event-backlog",
+                      { events: parsed },
+                      "filesystem",
+                    );
+                    // Enqueue may race with client cancel; swallow the
+                    // ERR_INVALID_STATE that comes back if the controller has
+                    // already closed.
+                    try {
+                      controller.enqueue(
+                        encoder.encode(
+                          `event: global-event-backlog\ndata: ${JSON.stringify(backlogEnv)}\n\n`,
+                        ),
+                      );
+                    } catch {
+                      /* client cancelled */
+                    }
+                  } catch (err) {
+                    console.error(`[server] activity backlog failed:`, err);
                   }
+
+                  // CTL-1224: per-client jq filter (or passthrough for an empty
+                  // predicate) fed by the SHARED ring tail. Matched lines are
+                  // wrapped in the SAME global-event envelope + framing as before.
+                  const filterStream = createFilterStream(predicate);
+                  activityFilter = filterStream;
+                  filterStream.onMatch((line) => {
+                    const parsed = safeParseJson(line);
+                    if (parsed === null) return;
+                    const env = createEvent("global-event", parsed, "filesystem");
+                    try {
+                      controller.enqueue(
+                        encoder.encode(`event: global-event\ndata: ${JSON.stringify(env)}\n\n`),
+                      );
+                    } catch {
+                      // client gone — stop feeding it
+                      activityUnsub?.();
+                      activityUnsub = null;
+                    }
+                  });
+                  activityUnsub = eventRing.onAppend((lines) => {
+                    for (const l of lines) filterStream.write(l);
+                    void filterStream.flush();
+                  });
                 }
               },
               cancel() {
-                // client disconnected → abort the upstream subscription so no
-                // per-host connection leaks.
-                abort.abort();
+                if (captured) sseClients.delete(captured);
+                activityUnsub?.(); // CTL-1224: deregister ring listener (no leak)
+                activityUnsub = null;
+                activityFilter?.close(); // CTL-1224: reap the per-client jq process
+                activityFilter = null;
               },
             });
-            return new Response(proxied, {
+            return new Response(stream, {
               headers: {
                 "Content-Type": "text/event-stream",
                 "Cache-Control": "no-cache",
@@ -4449,912 +2332,2938 @@ export function createServer(opts: CreateServerOptions): BunServer {
               },
             });
           }
-          if (route.mode === "unroutable") {
-            // MULTI-HOST: owner is a different node we can't reach (no transport
-            // address). 404 rather than blindly tailing THIS host's transcript
-            // (which would show the wrong node's session).
-            return new Response("Not Found", { status: 404 });
-          }
-          // route.mode === "local": the identity no-op — tail the LOCAL
-          // transcript exactly as the non-cluster BFF5 path does.
-          const transcriptPath = await resolveTranscriptPath(sessionId);
-          if (!transcriptPath) {
-            return new Response("Not Found", { status: 404 });
+
+          if (url.pathname === "/api/version") {
+            return Response.json({ version: CATALYST_DEV_VERSION });
           }
 
-          let timer: ReturnType<typeof setInterval> | null = null;
-          let inFlight = false;
-          let closed = false;
-          const tail = new TranscriptTail(transcriptPath);
-          const stream = new ReadableStream<Uint8Array>({
-            start(controller) {
-              const pump = () => {
-                if (inFlight || closed) return;
-                inFlight = true;
-                void (async () => {
+          if (url.pathname === "/api/snapshot") {
+            return Response.json(snapshotWithPrStatus());
+          }
+
+          if (url.pathname === "/api/config") {
+            const cfg = loadMonitorConfig(monitorConfigPath);
+            return Response.json(cfg);
+          }
+
+          // CTL-1653: GET /api/accounts — THIS node's Claude-account posture
+          // (active account + per-window utilization/resets/status +
+          // siblingWithHeadroom), token-free, cached ~5 min. `?refresh=true`
+          // forces a fresh probe. Disabled (accountsProbeExec:null) → a stable
+          // available:false response, matching the dbPath-gated endpoints.
+          if (url.pathname === "/api/accounts") {
+            if (!accountsProbe) return Response.json({ available: false, node: hostName() });
+            const refresh = url.searchParams.get("refresh") === "true";
+            const summary = await accountsProbe.get({ refresh });
+            return Response.json({ available: true, ...summary });
+          }
+
+          // CTL-1152: GET /api/projects — the config-driven project roster. One
+          // descriptor per configured catalyst.monitor.linear.teams[] entry PLUS a
+          // self-identifying unconfigured lane per observed-work repo (the live
+          // board snapshot's `.repos`) with no configured descriptor (union rule).
+          // Fail-open: ANY error degrades to { projects: [] } (mirrors /api/config
+          // and the repo-icon endpoint) so the nav renders its empty state, never 5xx.
+          if (url.pathname === "/api/projects") {
+            try {
+              const board = await boardSnapshot.getLatest();
+              const observedRepos = board?.repos ?? [];
+              return Response.json({
+                projects: loadProjects({ observedRepos, configPath: projectsConfigPath }),
+              });
+            } catch {
+              return Response.json({ projects: [] });
+            }
+          }
+
+          // CTL-1153 (M2): PUT /api/projects/:key — upsert one editable projects[] entry
+          // (name/color/icon/stateMap). First edit of a known team key migrates THAT project
+          // into catalyst.projects[]. READ (GET above) is fail-open; WRITE is fail-CLOSED on input.
+          // Validation → HTTP code table:
+          //   405  non-PUT method
+          //   400  bad JSON | non-object | unknown field (incl. vcsRepo/key) | bad name | bad hue | bad stateMap
+          //   404  key not in teams[] and not in existing projects[]
+          //   500  genuine persistence failure
+          //   200  { project, projects }
+          {
+            const projectKeyMatch = url.pathname.match(/^\/api\/projects\/([A-Za-z0-9._-]+)$/);
+            if (projectKeyMatch && projectKeyMatch[1]) {
+              if (req.method !== "PUT") return new Response("Method Not Allowed", { status: 405 });
+              let key: string;
+              try {
+                key = decodeURIComponent(projectKeyMatch[1]);
+              } catch {
+                return Response.json({ error: "Bad project key" }, { status: 400 });
+              }
+              let body: unknown;
+              try {
+                body = await req.json();
+              } catch {
+                return Response.json({ error: "Invalid JSON body" }, { status: 400 });
+              }
+              const v = validateProjectPatch(body);
+              if (!v.ok) return Response.json({ error: v.error }, { status: v.status });
+              let result: ReturnType<typeof writeProjectPatch>;
+              try {
+                result = writeProjectPatch(projectsConfigPath, key.toUpperCase(), v.patch);
+              } catch (err) {
+                console.error(`[server] PUT /api/projects/${key} failed:`, err);
+                return Response.json(
+                  { error: "Failed to persist project settings" },
+                  { status: 500 },
+                );
+              }
+              if (!result.ok) {
+                return Response.json(
+                  { error: `Unknown project key: ${key.toUpperCase()}` },
+                  { status: 404 },
+                );
+              }
+              const board = await boardSnapshot.getLatest();
+              const observedRepos = board?.repos ?? [];
+              const projects = loadProjects({ observedRepos, configPath: projectsConfigPath });
+              return Response.json({
+                project: projects.find((p) => p.key === key.toUpperCase()) ?? null,
+                projects,
+              });
+            }
+          }
+
+          // CTL-961: /api/repo-icon/<repoShortName> — auto-detect favicon from GitHub.
+          // Reads the owner/repo from the monitor config repoOwners map, probes common
+          // icon paths via `gh api`, caches the result for 7 days, returns a data URL.
+          // Fail-open: returns { found: false } (204) when not configured or not found.
+          if (url.pathname.startsWith("/api/repo-icon/")) {
+            // CTL-979: normalize to lowercase so /api/repo-icon/adva resolves "Adva" vcsRepo keys.
+            const repoKey = url.pathname.slice("/api/repo-icon/".length).trim().toLowerCase();
+            if (!repoKey || repoKey.includes("/")) {
+              return new Response("Bad repo key", { status: 400 });
+            }
+            const cfg = loadMonitorConfig(monitorConfigPath);
+            const ownerRepo = cfg.repoOwners[repoKey];
+            if (!ownerRepo) {
+              return Response.json({ found: false }, { status: 204 });
+            }
+            const cacheDir = join(CATALYST_DIR, "repo-icon-cache");
+            const result = await fetchRepoIcon(ownerRepo, cacheDir);
+            if (!result.found) return Response.json({ found: false }, { status: 204 });
+            return Response.json(result);
+          }
+
+          if (url.pathname === "/api/analytics") {
+            return Response.json(buildAnalyticsSnapshot(wtDir, buildOpts));
+          }
+
+          if (url.pathname === "/api/sessions") {
+            if (!dbPath) {
+              return Response.json({ available: false, sessions: [] });
+            }
+            const params = url.searchParams;
+            const limitRaw = params.get("limit");
+            const parsedLimit = limitRaw ? Number.parseInt(limitRaw, 10) : NaN;
+            const result = readSessionStore(dbPath, {
+              soloOnly: params.get("solo") === "true",
+              workflowId: params.get("workflow") ?? undefined,
+              ticket: params.get("ticket") ?? undefined,
+              status: params.get("status") ?? undefined,
+              limit: Number.isFinite(parsedLimit) ? parsedLimit : undefined,
+            });
+            const sessions: SessionState[] = result.sessions;
+            return Response.json({ available: result.available, sessions });
+          }
+
+          if (url.pathname === "/api/history") {
+            if (!dbPath) {
+              return Response.json({ entries: [], total: 0 });
+            }
+            const params = url.searchParams;
+            const limitRaw = params.get("limit");
+            const offsetRaw = params.get("offset");
+            const parsedLimit = limitRaw ? Number.parseInt(limitRaw, 10) : NaN;
+            const parsedOffset = offsetRaw ? Number.parseInt(offsetRaw, 10) : NaN;
+            return Response.json(
+              queryHistory(dbPath, {
+                skill: params.get("skill") ?? undefined,
+                ticket: params.get("ticket") ?? undefined,
+                since: params.get("since") ?? undefined,
+                search: params.get("search") ?? undefined,
+                limit: Number.isFinite(parsedLimit) ? parsedLimit : undefined,
+                offset: Number.isFinite(parsedOffset) ? parsedOffset : undefined,
+              }),
+            );
+          }
+
+          if (url.pathname === "/api/history/stats") {
+            if (!dbPath) {
+              return Response.json({
+                totalSessions: 0,
+                totalCostUsd: 0,
+                avgCostUsd: 0,
+                avgDurationMs: 0,
+                successRate: 0,
+                skillBreakdown: [],
+                dailyCosts: [],
+                topTools: [],
+              });
+            }
+            const params = url.searchParams;
+            return Response.json(
+              queryStats(dbPath, {
+                skill: params.get("skill") ?? undefined,
+                since: params.get("since") ?? undefined,
+              }),
+            );
+          }
+
+          if (url.pathname === "/api/history/compare") {
+            if (!dbPath) {
+              return Response.json(null);
+            }
+            const params = url.searchParams;
+            const a = params.get("a");
+            const b = params.get("b");
+            if (!a || !b) {
+              return new Response("Missing ?a=<id>&b=<id>", { status: 400 });
+            }
+            const result = compareSessions(dbPath, a, b);
+            if (!result) {
+              return new Response("Session(s) not found", { status: 404 });
+            }
+            return Response.json(result);
+          }
+
+          const rollupMatch = url.pathname.match(/^\/api\/rollup\/([^/]+)$/);
+          if (rollupMatch) {
+            let orchId: string;
+            try {
+              orchId = decodeURIComponent(rollupMatch[1]);
+            } catch {
+              return new Response("Bad Request", { status: 400 });
+            }
+            if (orchId.includes("..") || orchId.includes("/") || orchId.includes("\0")) {
+              return new Response("Bad Request", { status: 400 });
+            }
+            const snap = snapshotWithPrStatus();
+            const orch = snap.orchestrators.find((o) => o.id === orchId);
+            if (!orch) {
+              return new Response("Not Found", { status: 404 });
+            }
+            return Response.json({
+              orchId: orch.id,
+              rollup: orch.rollupBriefing ?? null,
+            });
+          }
+
+          const sessionMatch = url.pathname.match(/^\/api\/session\/([^/]+)\/([^/]+)$/);
+          if (sessionMatch) {
+            let orchId: string;
+            let ticket: string;
+            try {
+              orchId = decodeURIComponent(sessionMatch[1]);
+              ticket = decodeURIComponent(sessionMatch[2]);
+            } catch {
+              return new Response("Bad Request", { status: 400 });
+            }
+            if (
+              orchId.includes("..") ||
+              orchId.includes("\0") ||
+              ticket.includes("..") ||
+              ticket.includes("/") ||
+              ticket.includes("\0")
+            ) {
+              return new Response("Bad Request", { status: 400 });
+            }
+            const detail = buildSessionDetail(wtDir, orchId, ticket, { runsDir });
+            if (!detail) {
+              return new Response("Not Found", { status: 404 });
+            }
+            if (prFetcher && detail.worker.pr) {
+              const repo = parseRepoFromPrUrl(detail.worker.pr.url);
+              if (repo) {
+                const status = prFetcher.get(repo, detail.worker.pr.number);
+                if (status) {
+                  detail.worker.prState = status.state;
+                  detail.worker.prMergedAt = status.mergedAt;
+                }
+              }
+            }
+            return Response.json(detail);
+          }
+
+          const streamMatch = url.pathname.match(/^\/api\/worker-stream\/([^/]+)\/([^/]+)$/);
+          if (streamMatch) {
+            let orchId: string;
+            let ticket: string;
+            try {
+              orchId = decodeURIComponent(streamMatch[1]);
+              ticket = decodeURIComponent(streamMatch[2]);
+            } catch {
+              return new Response("Bad Request", { status: 400 });
+            }
+            if (
+              orchId.includes("..") ||
+              orchId.includes("\0") ||
+              ticket.includes("..") ||
+              ticket.includes("/") ||
+              ticket.includes("\0")
+            ) {
+              return new Response("Bad Request", { status: 400 });
+            }
+            const maxEventsRaw = url.searchParams.get("limit");
+            const maxEvents = maxEventsRaw ? Number.parseInt(maxEventsRaw, 10) : 30;
+            const stateReader = await import("./lib/state-reader");
+            const scanned = runsDir
+              ? stateReader.scanAllOrchestrators({ runsDir, wtDir })
+              : stateReader.scanOrchestrators(wtDir);
+            const entry = scanned.find((d) => basename(d.path) === orchId);
+            if (!entry) {
+              return new Response("Not Found", { status: 404 });
+            }
+            const events = readRecentStreamEvents(
+              entry.path,
+              ticket,
+              Number.isFinite(maxEvents) ? maxEvents : 30,
+            );
+            return Response.json({ orchId, ticket, events });
+          }
+
+          const subagentsMatch = url.pathname.match(/^\/api\/worker\/([^/]+)\/([^/]+)\/subagents$/);
+          if (subagentsMatch) {
+            let orchId: string;
+            let ticket: string;
+            try {
+              orchId = decodeURIComponent(subagentsMatch[1]);
+              ticket = decodeURIComponent(subagentsMatch[2]);
+            } catch {
+              return new Response("Bad Request", { status: 400 });
+            }
+            if (
+              orchId.includes("..") ||
+              orchId.includes("/") ||
+              orchId.includes("\0") ||
+              ticket.includes("..") ||
+              ticket.includes("/") ||
+              ticket.includes("\0")
+            ) {
+              return new Response("Bad Request", { status: 400 });
+            }
+            const stateReader = await import("./lib/state-reader");
+            const scanned = runsDir
+              ? stateReader.scanAllOrchestrators({ runsDir, wtDir })
+              : stateReader.scanOrchestrators(wtDir);
+            const entry = scanned.find((d) => basename(d.path) === orchId);
+            if (!entry) return new Response("Not Found", { status: 404 });
+            const tree = parseStreamForSubagents(streamFilePath(entry.path, ticket));
+            return Response.json({ orchId, ticket, tree });
+          }
+
+          const workerTodosMatch = url.pathname.match(/^\/api\/worker\/([^/]+)\/([^/]+)\/todos$/);
+          if (workerTodosMatch) {
+            let orchId: string;
+            let ticket: string;
+            try {
+              orchId = decodeURIComponent(workerTodosMatch[1]);
+              ticket = decodeURIComponent(workerTodosMatch[2]);
+            } catch {
+              return new Response("Bad Request", { status: 400 });
+            }
+            if (
+              orchId.includes("..") ||
+              orchId.includes("/") ||
+              orchId.includes("\0") ||
+              ticket.includes("..") ||
+              ticket.includes("/") ||
+              ticket.includes("\0")
+            ) {
+              return new Response("Bad Request", { status: 400 });
+            }
+            const stateReader = await import("./lib/state-reader");
+            const scanned = runsDir
+              ? stateReader.scanAllOrchestrators({ runsDir, wtDir })
+              : stateReader.scanOrchestrators(wtDir);
+            const entry = scanned.find((d) => basename(d.path) === orchId);
+            if (!entry) return new Response("Not Found", { status: 404 });
+            const tree = parseStreamForSubagents(streamFilePath(entry.path, ticket));
+            const todos = flattenTodosForWorker(tree, ticket);
+            return Response.json({ orchId, ticket, todos });
+          }
+
+          const orchTodosMatch = url.pathname.match(/^\/api\/orch\/([^/]+)\/todos$/);
+          if (orchTodosMatch) {
+            let orchId: string;
+            try {
+              orchId = decodeURIComponent(orchTodosMatch[1]);
+            } catch {
+              return new Response("Bad Request", { status: 400 });
+            }
+            if (orchId.includes("..") || orchId.includes("/") || orchId.includes("\0")) {
+              return new Response("Bad Request", { status: 400 });
+            }
+            const stateReader = await import("./lib/state-reader");
+            const scanned = runsDir
+              ? stateReader.scanAllOrchestrators({ runsDir, wtDir })
+              : stateReader.scanOrchestrators(wtDir);
+            const entry = scanned.find((d) => basename(d.path) === orchId);
+            if (!entry) return new Response("Not Found", { status: 404 });
+            const orchState = stateReader.readOrchestratorState(
+              entry.path,
+              "workspace" in entry ? entry.workspace : "default",
+            );
+            const todos = [];
+            for (const [, worker] of Object.entries(orchState.workers)) {
+              const ticket = worker.ticket;
+              if (!ticket) continue;
+              const tree = parseStreamForSubagents(streamFilePath(entry.path, ticket));
+              todos.push(...flattenTodosForWorker(tree, ticket));
+            }
+            return Response.json({ orchId, todos });
+          }
+
+          if (url.pathname === "/api/worker-tasks/debug") {
+            const pidRaw = url.searchParams.get("pid");
+            const sessionIdParam = url.searchParams.get("sessionId");
+            if (!pidRaw && !sessionIdParam) {
+              return new Response("pid or sessionId required", { status: 400 });
+            }
+            const diagnostic = getTaskDiagnostic({
+              pid: pidRaw ? Number(pidRaw) : undefined,
+              sessionId: sessionIdParam ?? undefined,
+            });
+            return Response.json(diagnostic);
+          }
+
+          const taskMatch = url.pathname.match(/^\/api\/worker-tasks$/);
+          if (taskMatch) {
+            const pidRaw = url.searchParams.get("pid");
+            const sessionIdParam = url.searchParams.get("sessionId");
+            if (!pidRaw && !sessionIdParam) {
+              return new Response("pid or sessionId required", { status: 400 });
+            }
+            const sessionId = sessionIdParam || (pidRaw ? sessionIdFromPid(Number(pidRaw)) : null);
+            if (!sessionId) {
+              return Response.json({ tasks: null });
+            }
+            const tasks = readWorkerTasks(sessionId);
+            return Response.json({ tasks });
+          }
+
+          if (url.pathname === "/api/comms/channels") {
+            if (!comms) return Response.json({ channels: [] });
+            return Response.json({ channels: await comms.listChannels() });
+          }
+
+          const commsStreamMatch = url.pathname.match(/^\/api\/comms\/channels\/([^/]+)\/stream$/);
+          if (commsStreamMatch) {
+            let channelName: string;
+            try {
+              channelName = decodeURIComponent(commsStreamMatch[1]);
+            } catch {
+              return new Response("Bad Request", { status: 400 });
+            }
+            if (!isValidChannelName(channelName)) {
+              return new Response("Invalid channel name", { status: 400 });
+            }
+            if (!comms) return new Response("Comms not available", { status: 503 });
+
+            const commsReader = comms;
+            let offset = 0;
+            let timer: ReturnType<typeof setInterval> | null = null;
+            let inFlight = false;
+            const stream = new ReadableStream<Uint8Array>({
+              async start(controller) {
+                const initial = await commsReader.getChannel(channelName, { limit: 200 });
+                if (!initial) {
+                  const errFrame = `event: error-event\ndata: ${JSON.stringify({ error: "channel-not-found", channel: channelName })}\n\n`;
                   try {
-                    const events = await tail.poll();
-                    if (closed) return;
-                    for (const ev of events) {
-                      controller.enqueue(
-                        encoder.encode(
-                          `event: stream-event\ndata: ${JSON.stringify(ev)}\n\n`,
-                        ),
-                      );
-                    }
+                    controller.enqueue(encoder.encode(errFrame));
                   } catch {
-                    // client likely went away mid-enqueue; stop pumping
-                    closed = true;
-                    if (timer) clearInterval(timer);
-                    timer = null;
-                  } finally {
-                    inFlight = false;
+                    // Client may have already disconnected.
                   }
-                })();
-              };
-              // Open frame so a cold connection paints the tail immediately,
-              // then poll for growth on a fixed cadence.
-              controller.enqueue(
-                encoder.encode(
-                  `event: open\ndata: ${JSON.stringify({ sessionId })}\n\n`,
-                ),
+                  controller.close();
+                  return;
+                }
+                offset = initial.tailOffset;
+                const snapshotFrame = `event: snapshot\ndata: ${JSON.stringify(initial)}\n\n`;
+                try {
+                  controller.enqueue(encoder.encode(snapshotFrame));
+                } catch {
+                  return;
+                }
+                timer = setInterval(() => {
+                  if (inFlight) return;
+                  inFlight = true;
+                  void (async () => {
+                    try {
+                      const tail = await commsReader.tailChannel(channelName, offset);
+                      offset = tail.newOffset;
+                      for (const m of tail.messages) {
+                        const frame = `event: message\ndata: ${JSON.stringify(m)}\n\n`;
+                        controller.enqueue(encoder.encode(frame));
+                      }
+                    } catch {
+                      // Keep the stream alive on transient read errors.
+                    } finally {
+                      inFlight = false;
+                    }
+                  })();
+                }, 500);
+              },
+              cancel() {
+                if (timer) clearInterval(timer);
+                timer = null;
+              },
+            });
+            return new Response(stream, {
+              headers: {
+                "Content-Type": "text/event-stream",
+                "Cache-Control": "no-cache",
+                Connection: "keep-alive",
+                "Access-Control-Allow-Origin": "*",
+              },
+            });
+          }
+
+          const commsChannelMatch = url.pathname.match(/^\/api\/comms\/channels\/([^/]+)$/);
+          if (commsChannelMatch) {
+            let channelName: string;
+            try {
+              channelName = decodeURIComponent(commsChannelMatch[1]);
+            } catch {
+              return new Response("Bad Request", { status: 400 });
+            }
+            if (!isValidChannelName(channelName)) {
+              return new Response("Invalid channel name", { status: 400 });
+            }
+            if (!comms) return new Response("Not Found", { status: 404 });
+            const limitRaw = url.searchParams.get("limit");
+            const parsedLimit = limitRaw ? Number.parseInt(limitRaw, 10) : NaN;
+            const limit = Number.isFinite(parsedLimit)
+              ? Math.max(1, Math.min(parsedLimit, 1000))
+              : 200;
+            const detail = await comms.getChannel(channelName, { limit });
+            if (!detail) return new Response("Not Found", { status: 404 });
+            return Response.json(detail);
+          }
+
+          const commsParticipantMatch = url.pathname.match(/^\/api\/comms\/participants\/([^/]+)$/);
+          if (commsParticipantMatch) {
+            let agentName: string;
+            try {
+              agentName = decodeURIComponent(commsParticipantMatch[1]);
+            } catch {
+              return new Response("Bad Request", { status: 400 });
+            }
+            if (agentName.includes("/") || agentName.includes("\0")) {
+              return new Response("Bad Request", { status: 400 });
+            }
+            if (!comms) return new Response("Not Found", { status: 404 });
+            const detail = await comms.getParticipant(agentName);
+            if (!detail) return new Response("Not Found", { status: 404 });
+            return Response.json(detail);
+          }
+
+          if (url.pathname === "/api/linear") {
+            const tickets: Record<string, LinearTicket> = {};
+            if (linear) {
+              for (const key of collectTicketKeys(buildSnapshot(wtDir, buildOpts))) {
+                const t = linear.get(key);
+                if (t) tickets[key] = t;
+              }
+            }
+            return Response.json({ tickets });
+          }
+
+          if (url.pathname === "/api/ticket-substeps") {
+            const ticketParam = url.searchParams.get("ticket");
+            if (!ticketParam) {
+              return new Response("Bad Request: missing ticket", { status: 400 });
+            }
+            if (
+              ticketParam.includes("..") ||
+              ticketParam.includes("/") ||
+              ticketParam.includes("\0")
+            ) {
+              return new Response("Bad Request", { status: 400 });
+            }
+            // CTL-1215: scan the shared event ring instead of reading the whole
+            // current-month log; the per-ticket substep slice is small + recent.
+            const subSteps = readSubStepEvents(eventRing, ticketParam);
+            return Response.json({ ticket: ticketParam, subSteps });
+          }
+
+          // CTL-889 (P8): cache-backed Linear ticket detail — description (null,
+          // not cached), labels[], the relation graph (forward + reverse
+          // blocks/related edges), assignee, and held classification. Read from
+          // filter-state.db ticket_state, NEVER a live `linearis` call. 404 when
+          // the ticket has no descriptor row.
+          const ticketDetailMatch = url.pathname.match(/^\/api\/ticket-detail\/([^/]+)$/);
+          if (ticketDetailMatch) {
+            let ticket: string;
+            try {
+              ticket = decodeURIComponent(ticketDetailMatch[1]);
+            } catch {
+              return new Response("Bad Request", { status: 400 });
+            }
+            if (ticket.includes("..") || ticket.includes("/") || ticket.includes("\0")) {
+              return new Response("Bad Request", { status: 400 });
+            }
+            const detail = await readTicketDetail(ticket, {
+              dbPath: filterStateDb,
+            });
+            if (!detail) {
+              return new Response("Not Found", { status: 404 });
+            }
+            return Response.json(detail);
+          }
+
+          // CTL-974 pattern: supplemental cached live Linear {title, description}
+          // fetch for the ticket-detail page. Separate from /api/ticket-detail to
+          // keep its 404-on-no-descriptor contract intact. The board title is
+          // stale-sourced (triage summary can win) and the durable cache has no
+          // description column, so BOTH the real title and the markdown
+          // description are live-fetched from Linear here — cached, TTL'd (5 min),
+          // batched, fail-open, NEVER spawning linearis on a request path.
+          // ALWAYS 200: an absent description is honest-empty, not an error.
+          const linearTicketMatch = url.pathname.match(/^\/api\/linear-ticket\/([^/]+)$/);
+          if (linearTicketMatch) {
+            let ticket: string;
+            try {
+              ticket = decodeURIComponent(linearTicketMatch[1]);
+            } catch {
+              return new Response("Bad Request", { status: 400 });
+            }
+            if (ticket.includes("..") || ticket.includes("/") || ticket.includes("\0")) {
+              return new Response("Bad Request", { status: 400 });
+            }
+            const map = await fillTitleDescriptionFallback([ticket]);
+            const entry = map[ticket] ?? {
+              title: null,
+              description: null,
+              labels: null,
+              relations: null,
+              state: null,
+              priority: null,
+              project: null,
+              estimate: null,
+            };
+            const available = entry.title !== null || entry.description !== null;
+            return Response.json({
+              id: ticket,
+              title: entry.title,
+              description: entry.description,
+              labels: entry.labels ?? null,
+              relations: entry.relations ?? null,
+              state: entry.state ?? null,
+              priority: entry.priority ?? null,
+              project: entry.project ?? null,
+              estimate: entry.estimate ?? null,
+              source: available ? "linear-live" : "unavailable",
+            });
+          }
+
+          // CTL-889 (P9): a ticket's research/plan thoughts artifacts for the
+          // spine 📄 links — repo-root-relative paths + a peek preview, read from
+          // the LOCAL thoughts tree. Surfaces the CTL-866 cross-node eventual-
+          // consistency caveat (artifacts authored on another node appear only
+          // after a thoughts-sync push).
+          const ticketArtifactsMatch = url.pathname.match(/^\/api\/ticket-artifacts\/([^/]+)$/);
+          if (ticketArtifactsMatch) {
+            let ticket: string;
+            try {
+              ticket = decodeURIComponent(ticketArtifactsMatch[1]);
+            } catch {
+              return new Response("Bad Request", { status: 400 });
+            }
+            if (ticket.includes("..") || ticket.includes("/") || ticket.includes("\0")) {
+              return new Response("Bad Request", { status: 400 });
+            }
+            const artifacts = await readTicketArtifacts(ticket);
+            return Response.json(artifacts);
+          }
+
+          // CTL-1574: a ticket's Linear discussion — comments + issue_history
+          // activity events, both read from the local CTC replica through the
+          // shared read-model builders. The reader never throws: an absent/locked
+          // replica or an unmirrored ticket comes back
+          // `{ available:false, comments:[], activity:[] }`, which the UI renders
+          // as an honest empty section (never a fabricated "no comments").
+          const ticketDiscussionMatch = url.pathname.match(/^\/api\/ticket-discussion\/([^/]+)$/);
+          if (ticketDiscussionMatch) {
+            let ticket: string;
+            try {
+              ticket = decodeURIComponent(ticketDiscussionMatch[1]);
+            } catch {
+              return new Response("Bad Request", { status: 400 });
+            }
+            if (ticket.includes("..") || ticket.includes("/") || ticket.includes("\0")) {
+              return new Response("Bad Request", { status: 400 });
+            }
+            const discussion = await readTicketDiscussion(ticket, {
+              catalystDir: CATALYST_DIR,
+            });
+            // Agent classification is `is_bot` OR a configured app-actor author —
+            // Catalyst worker/orchestrator app actors are stored as users with
+            // is_bot=0 (the linear-thread.mjs contract), so is_bot alone would
+            // badge every agent comment as human.
+            const botIds = linearBotUserIds ?? linearWebhookConfig?.botUserIds;
+            if (botIds && discussion.comments.length > 0) {
+              discussion.comments = discussion.comments.map((c) =>
+                c.author_id != null && botIds.has(c.author_id) ? { ...c, is_bot: 1 } : c,
               );
-              pump();
-              timer = setInterval(pump, 750);
-            },
-            cancel() {
-              closed = true;
-              if (timer) clearInterval(timer);
-              timer = null;
-            },
-          });
-          return new Response(stream, {
-            headers: {
-              "Content-Type": "text/event-stream",
-              "Cache-Control": "no-cache",
-              Connection: "keep-alive",
-              "Access-Control-Allow-Origin": "*",
-            },
-          });
-        }
-
-        // CTL-938: the live SCREEN SSE — the PRE-transcript wedge window. Given
-        // a worker's bg shortId (or full job UUID), poll `claude logs <shortId>`
-        // every screenPollMs, ANSI-normalize, diff against the last snapshot,
-        // and push only CHANGED frames (each carrying the FULL screen, never a
-        // delta — frames are droppable, so a slow client just paints the latest
-        // one). Terminal outcomes close the stream: session gone → `gone`
-        // event, claude CLI unusable → `unavailable` event. The FIRST poll runs
-        // before the SSE handshake so a dead session is an HTTP status (404 /
-        // 503), not an empty stream the client must time out on.
-        const ecWorkerScreenMatch = url.pathname.match(
-          /^\/api\/ec-worker-screen\/([^/]+)$/,
-        );
-        if (ecWorkerScreenMatch) {
-          let rawId: string;
-          try {
-            rawId = decodeURIComponent(ecWorkerScreenMatch[1]);
-          } catch {
-            return new Response("Bad Request", { status: 400 });
-          }
-          // `claude logs` only accepts the 8-char short form; deriveScreenShortId
-          // also truncates a full job UUID. null = malformed → nothing ever
-          // reaches the exec fn (no arbitrary string ever hits a subprocess).
-          const screenShortId = deriveScreenShortId(rawId);
-          if (!screenShortId) {
-            return new Response("Bad Request", { status: 400 });
+            }
+            return Response.json(discussion);
           }
 
-          const poller = new ScreenPoller(screenShortId, {
-            exec: screenLogsExecOpt ?? undefined,
-          });
-          const first = await poller.poll();
-          if (first.kind === "gone") {
-            return new Response("Not Found", { status: 404 });
-          }
-          if (first.kind === "unavailable") {
-            return new Response("Service Unavailable", { status: 503 });
+          // CTL-1042: serve a ticket's research/plan artifact CONTENT by kind for
+          // the reading-pane deep-dive pills. The list route above is anchored at
+          // the ticket segment ($), so it never matches this two-segment path;
+          // this opens the actual markdown the pill links to (without it the pill
+          // hit the SPA/404 fallback). The served file path is resolved by our own
+          // glob over the local thoughts tree — not attacker-supplied — but we
+          // still validate both URL segments defensively.
+          const ticketArtifactByKindMatch = url.pathname.match(
+            /^\/api\/ticket-artifacts\/([^/]+)\/([^/]+)$/,
+          );
+          if (ticketArtifactByKindMatch) {
+            let ticket: string;
+            let kind: string;
+            try {
+              ticket = decodeURIComponent(ticketArtifactByKindMatch[1]);
+              kind = decodeURIComponent(ticketArtifactByKindMatch[2]);
+            } catch {
+              return new Response("Bad Request", { status: 400 });
+            }
+            if (ticket.includes("..") || ticket.includes("/") || ticket.includes("\0")) {
+              return new Response("Bad Request", { status: 400 });
+            }
+            if (kind !== "research" && kind !== "plan") {
+              return new Response("Bad Request", { status: 400 });
+            }
+            const doc = await readTicketArtifactContent(ticket, kind);
+            if (!doc) {
+              return new Response("Not Found", { status: 404 });
+            }
+            return new Response(doc.content, {
+              headers: { "Content-Type": "text/markdown; charset=utf-8" },
+            });
           }
 
-          let timer: ReturnType<typeof setInterval> | null = null;
-          let inFlight = false;
-          let closed = false;
-          const stream = new ReadableStream<Uint8Array>({
-            start(controller) {
-              const close = () => {
-                if (closed) return;
+          // CTL-889 (P12): cache-backed fuzzy ticket search for the ⌘K palette's
+          // "Search all tickets in Linear" action. Fuzzy-matches the durable
+          // ticket_state cache — NO per-keystroke live Linear API call. An empty
+          // ?q= returns an empty result set (the palette renders the row idle).
+          if (url.pathname === "/api/search") {
+            const q = url.searchParams.get("q") ?? "";
+            const limitRaw = url.searchParams.get("limit");
+            const parsedLimit = limitRaw ? Number.parseInt(limitRaw, 10) : NaN;
+            const limit = Number.isFinite(parsedLimit)
+              ? Math.max(1, Math.min(parsedLimit, 100))
+              : 20;
+            if (q.trim() === "") {
+              return Response.json({
+                query: q,
+                results: [],
+                source: "filter-state.db",
+              });
+            }
+            const result = await readTicketSearch(q, {
+              dbPath: filterStateDb,
+              limit,
+            });
+            return Response.json(result);
+          }
+
+          if (url.pathname === "/api/briefing") {
+            if (!briefingProvider) {
+              return Response.json({ enabled: false });
+            }
+            const snap = snapshotWithPrStatus();
+            const tickets: Record<string, LinearTicket> = {};
+            if (linear) {
+              for (const key of collectTicketKeys(snap)) {
+                const t = linear.get(key);
+                if (t) tickets[key] = t;
+              }
+            }
+            const result = await briefingProvider.generate(snap, tickets);
+            if (!result) {
+              return Response.json({ enabled: true, briefing: null });
+            }
+            return Response.json({
+              enabled: true,
+              briefing: result.briefing,
+              suggestedLabels: result.suggestedLabels,
+              generatedAt: result.generatedAt,
+            });
+          }
+
+          // CTL-1042: per-inbox-item AI summary — lazy, on operator select.
+          const inboxSummaryMatch =
+            req.method === "GET" && url.pathname.match(/^\/api\/inbox\/([^/]+)\/summary$/);
+          if (inboxSummaryMatch) {
+            let ticket: string;
+            try {
+              ticket = decodeURIComponent(inboxSummaryMatch[1]);
+            } catch {
+              return new Response("Bad Request", { status: 400 });
+            }
+            if (ticket.includes("..") || ticket.includes("/") || ticket.includes("\0")) {
+              return new Response("Bad Request", { status: 400 });
+            }
+            if (!inboxSummaryProvider) return Response.json({ enabled: false });
+            const phase = url.searchParams.get("phase") ?? undefined;
+            const result = await inboxSummaryProvider.generate(ticket, phase);
+            if (!result)
+              return Response.json({
+                enabled: true,
+                ask: null,
+                summary: null,
+                options: null,
+                blocker: null,
+              });
+            return Response.json({ enabled: true, ...result });
+          }
+
+          if (url.pathname === "/api/briefing/activity") {
+            const windowParam = url.searchParams.get("window") ?? "30m";
+            if (!VALID_ACTIVITY_WINDOWS.has(windowParam as ActivityWindow)) {
+              return Response.json(
+                { error: "Invalid window. Use 30m, 1h, or 6h." },
+                { status: 400 },
+              );
+            }
+            const result = await generateActivityBriefing(
+              CATALYST_DIR,
+              activityBriefingConfig,
+              windowParam as ActivityWindow,
+              undefined,
+              eventRing,
+            );
+            return Response.json(result);
+          }
+
+          if (url.pathname === "/api/webhook" && req.method === "POST") {
+            if (!webhookHandler) {
+              return new Response("webhook receiver not configured", {
+                status: 503,
+              });
+            }
+            return webhookHandler.handle(req);
+          }
+
+          if (url.pathname === "/api/webhook/linear" && req.method === "POST") {
+            if (!linearWebhookHandler) {
+              return new Response("linear webhook receiver not configured", {
+                status: 503,
+              });
+            }
+            return linearWebhookHandler.handle(req);
+          }
+
+          if (url.pathname === "/api/summarize" && req.method === "POST") {
+            if (!summarizeHandler) {
+              return Response.json({ error: "AI not configured" }, { status: 503 });
+            }
+            return summarizeHandler.handle(req);
+          }
+
+          if (url.pathname === "/api/otel/status") {
+            return Response.json({
+              enabled: prom !== null || loki !== null,
+              prometheus: prom ? prom.isAvailable() : false,
+              loki: loki ? loki.isAvailable() : false,
+            });
+          }
+
+          if (url.pathname === "/api/health/otel") {
+            const health = await otelHealth.check();
+            return Response.json(health);
+          }
+
+          // CTL-1050: the service-health registry snapshot — every stack service's
+          // shared up|degraded|down|unknown severity, last-checked, target/source
+          // for the Fleet Ops strip hover. The registry reads ONLY the monitor's own
+          // probes/event-recency, so Fleet Ops stays Prometheus/Loki-FREE.
+          if (url.pathname === "/api/health/services") {
+            return Response.json(serviceHealth.snapshot());
+          }
+
+          if (url.pathname === "/api/otel/cost") {
+            if (!prom) return Response.json({ error: "OTel not configured" }, { status: 503 });
+            const range = url.searchParams.get("range") ?? "1h";
+            const result = await costByTicket(prom, range);
+            return Response.json({ data: result });
+          }
+
+          if (url.pathname === "/api/otel/tokens") {
+            if (!prom) return Response.json({ error: "OTel not configured" }, { status: 503 });
+            const range = url.searchParams.get("range") ?? "1h";
+            const tokens = await tokensByType(prom, range);
+            const hitRate = await cacheHitRate(prom, range);
+            return Response.json({ data: { tokens, cacheHitRate: hitRate } });
+          }
+
+          if (url.pathname === "/api/otel/cost-rate") {
+            if (!prom) return Response.json({ error: "OTel not configured" }, { status: 503 });
+            const interval = url.searchParams.get("interval") ?? "5m";
+            const result = await costRateByModel(prom, interval);
+            return Response.json({ data: result });
+          }
+
+          // OBS-9 (FINOPS P-B): cost by pipeline stage. Routes the EXISTING (but
+          // previously unrouted) `costByTaskType` — `sum by (task_type)(increase(
+          // cost[r]))` — with the OBS-9 zero-series filter applied at the query layer
+          // so the by-stage bar never renders the ~5 exact-0 phases. 503 when
+          // Prometheus is not configured (the P-B ChartCard degrades via the ladder).
+          if (url.pathname === "/api/otel/cost-by-stage") {
+            if (!prom) return Response.json({ error: "OTel not configured" }, { status: 503 });
+            const range = url.searchParams.get("range") ?? "24h";
+            const result = await costByTaskType(prom, range);
+            return Response.json({ data: result });
+          }
+
+          // OBS-11 (FINOPS P-D): cost by model / agent. Groups the cost counter by a
+          // WHITELISTED native dimension (`model` or `agent_name` — never interpolated
+          // from input, so no PromQL injection) with the OBS-9 zero-series filter
+          // applied so the ranked bar never shows the exact-0 models/agents an
+          // increase() window carries. `dim` defaults to model; an unknown dim → 400
+          // (honest, never a silently-empty bar). 503 when Prometheus is off.
+          if (url.pathname === "/api/otel/cost-by-dim") {
+            if (!prom) return Response.json({ error: "OTel not configured" }, { status: 503 });
+            const dim = url.searchParams.get("dim") ?? "model";
+            if (!isCostDimension(dim)) {
+              return Response.json({ error: "unknown dimension" }, { status: 400 });
+            }
+            const range = url.searchParams.get("range") ?? "24h";
+            const result = await costByDimension(prom, dim, range);
+            return Response.json({ data: result });
+          }
+
+          // CTL-1040 (FINOPS): cost grouped by work type. Board-backed — groups the SAME
+          // signal-file costs the expensive-tickets table shows (BoardTicket.costUSD) by
+          // BoardTicket.type. Prometheus carries no catalyst_ticket_type label, so this
+          // is the honest current-state source (UI carries a "data since 2026-06-11"
+          // caption). Always 200 — no Prometheus dependency.
+          if (url.pathname === "/api/otel/cost-by-work-type") {
+            const board = await boardSnapshot.getLatest();
+            const tickets = (board?.tickets ?? []).map((t) => ({
+              type: t.type,
+              costUSD: t.costUSD,
+            }));
+            return Response.json({ data: costByWorkType(tickets) });
+          }
+
+          // CTL-1040 (UTILIZATION): throughput grouped by work type. Loki-backed —
+          // counts phase.teardown.complete.* events per catalyst_ticket_type over the
+          // window. 503 when Loki is not configured (the ChartCard degrades via the ladder).
+          if (url.pathname === "/api/otel/throughput-by-work-type") {
+            if (!loki) return Response.json({ error: "OTel not configured" }, { status: 503 });
+            const range = url.searchParams.get("range") ?? "24h";
+            const result = await throughputByWorkType(loki, range);
+            if (result === null)
+              return Response.json({ error: "Loki unavailable" }, { status: 503 });
+            return Response.json({ data: result });
+          }
+
+          // OBS-9 (FINOPS HERO): the today-vs-7d dollar band. todayUsd (spend since
+          // local midnight) + avg7dUsd (the prior 7 FULL days' mean baseline) + the
+          // delta fraction + a linear EOD projection — all off the cost counter, no
+          // new plumbing. The partial current day is EXCLUDED from the 7d baseline so
+          // "is today normal?" compares like-for-like. 503 when Prometheus is absent.
+          if (url.pathname === "/api/otel/cost-today") {
+            if (!prom) return Response.json({ error: "OTel not configured" }, { status: 503 });
+            const result = await costToday(prom);
+            if (result === null) {
+              return Response.json({ error: "Prometheus unavailable" }, { status: 503 });
+            }
+            return Response.json({ data: result });
+          }
+
+          // OBS-9 (FINOPS P-A): hourly spend-over-time bars + spike flags. A
+          // query_range of `sum(increase(cost[1h]))` stepped at 1h over the window;
+          // each point carries `isSpike` (spend > max(2× median, μ+2σ) — the P-A
+          // `--chart-4` dot). 503 when Prometheus is absent; an honest `[]` for a
+          // quiet stack (the ChartCard empty state, never a fabricated bar).
+          if (url.pathname === "/api/otel/cost-series") {
+            if (!prom) return Response.json({ error: "OTel not configured" }, { status: 503 });
+            const range = url.searchParams.get("range") ?? "24h";
+            const result = await costSeries(prom, range);
+            if (result === null) {
+              return Response.json({ error: "Prometheus unavailable" }, { status: 503 });
+            }
+            return Response.json({ data: result });
+          }
+
+          // OBS-9 (FINOPS HERO-C, THE HEADLINE): cache-ROI $. Σ_model cacheRead_tokens
+          // × (input_price − cache_read_price) from a per-model price book — the real
+          // dollars the 99.8%-hit-rate prompt cache saved — plus the "(Nx)" multiplier
+          // (savings / actual spend). 503 when Prometheus is absent.
+          if (url.pathname === "/api/otel/cache-savings") {
+            if (!prom) return Response.json({ error: "OTel not configured" }, { status: 503 });
+            const range = url.searchParams.get("range") ?? "24h";
+            const result = await cacheSavings(prom, range);
+            if (result === null) {
+              return Response.json({ error: "Prometheus unavailable" }, { status: 503 });
+            }
+            return Response.json({ data: result });
+          }
+
+          // OBS-10 (FINOPS P-A drill): cost at a single spiking hour. Clicking a
+          // spiking bar in the spend-over-time chart re-queries THAT hour's by-ticket
+          // + by-model split (the "one re-query with the hour window"). `hour` is the
+          // clicked bar's epoch-SECOND timestamp; the query anchors a 1h `increase()`
+          // window to it via PromQL `offset`. Both maps are zero-filtered. 503 when
+          // Prometheus is absent; 400 when `hour` is missing/non-numeric (never a
+          // fabricated empty drill).
+          if (url.pathname === "/api/otel/cost-at-hour") {
+            if (!prom) return Response.json({ error: "OTel not configured" }, { status: 503 });
+            const hourParam = url.searchParams.get("hour");
+            const hour = hourParam !== null ? Number(hourParam) : NaN;
+            if (!Number.isFinite(hour) || hour <= 0) {
+              return Response.json({ error: "hour (epoch seconds) required" }, { status: 400 });
+            }
+            const result = await costAtHour(prom, hour);
+            if (result === null) {
+              return Response.json({ error: "Prometheus unavailable" }, { status: 503 });
+            }
+            return Response.json({ data: result });
+          }
+
+          if (url.pathname === "/api/otel/tools") {
+            if (!loki) return Response.json({ error: "OTel not configured" }, { status: 503 });
+            const range = url.searchParams.get("range") ?? "1h";
+            const result = await toolUsageByName(loki, range);
+            return Response.json({ data: result });
+          }
+
+          // OBS-7 (TELEMETRY P3): per-tool p50/p95 latency, the half /api/otel/tools
+          // (counts only) is missing so the panel can sort by TOTAL TIME (count × p95)
+          // rather than chattiness. unwrap duration_ms on tool_result by tool_name
+          // (toolLatency in otel-queries.ts). 503 when Loki is not configured; an
+          // empty stream is an HONEST 200 with `data:{}` (counts-only fallback).
+          if (url.pathname === "/api/otel/tool-latency") {
+            if (!loki) return Response.json({ error: "OTel not configured" }, { status: 503 });
+            const range = url.searchParams.get("range") ?? "1h";
+            const result = await toolLatency(loki, range);
+            if (result === null) {
+              // null means the queryRange came back null. Distinguish HONESTLY: if the
+              // /ready probe passed, Loki IS reachable and this is a QUERY/backend
+              // error (e.g. a LogQL 400), NOT "Loki unavailable" — don't mislabel it.
+              return otelDegradedResponse(loki, "tool-latency");
+            }
+            return Response.json({ data: result });
+          }
+
+          if (url.pathname === "/api/otel/errors") {
+            if (!loki) return Response.json({ error: "OTel not configured" }, { status: 503 });
+            const range = url.searchParams.get("range") ?? "1h";
+            const rawLimit = parseInt(url.searchParams.get("limit") ?? "50", 10);
+            const limit = Number.isFinite(rawLimit) ? Math.min(Math.max(1, rawLimit), 500) : 50;
+            // CTL-1039: alongside the panel's error rows, carry the proportional
+            // counts WITH EXPLICIT WINDOWS (15m + today) the hero reads to pick
+            // NOTED vs ERRORING. Backward-compatible: `data` stays the row array.
+            const [result, counts] = await Promise.all([
+              apiErrors(loki, range, limit),
+              apiErrorCounts(loki),
+            ]);
+            return Response.json({ data: result, counts });
+          }
+
+          // OBS-16 (UTILIZATION P_active): fleet-wide active-time ratio. A single
+          // Prometheus read of `sum(rate(claude_code_active_time_seconds_total[range]))`
+          // — the active seconds-per-second across the fleet (≈ slots' worth of
+          // wall-clock genuinely computing). The UI divides this by config.inFlight
+          // (busy-slot capacity it already holds) to render "X% computing / Y%
+          // waiting". 503 when Prometheus is absent (the P_active ChartCard degrades
+          // via the [prom] ladder); an idle fleet is an HONEST 200 with
+          // `data:{activeSecondsPerSecond:0}` (the genuine low read, never a
+          // fabricated number).
+          if (url.pathname === "/api/otel/active-time") {
+            if (!prom) return Response.json({ error: "OTel not configured" }, { status: 503 });
+            const range = url.searchParams.get("range") ?? "1h";
+            const result = await activeTimeRatio(prom, range);
+            if (result === null) {
+              return Response.json({ error: "Prometheus unavailable" }, { status: 503 });
+            }
+            return Response.json({ data: result });
+          }
+
+          // OBS-7 (TELEMETRY P4): per-model api_request latency (p50/p95) + error%,
+          // read off the SAME claude-code Loki stream as the tail/errors — NOT a new
+          // Prometheus dependency. The LogQL unwraps `duration_ms` on api_request and
+          // aggregates with quantile_over_time by model (modelLatency in
+          // otel-queries.ts). 503 when Loki is not configured (the P4 ChartCard
+          // degrades via the ladder); an empty stream is an HONEST 200 with `data:[]`
+          // (the card's "no data in range" state, NOT an error).
+          if (url.pathname === "/api/otel/model-latency") {
+            if (!loki) return Response.json({ error: "OTel not configured" }, { status: 503 });
+            const range = url.searchParams.get("range") ?? "1h";
+            const result = await modelLatency(loki, range);
+            if (result === null) {
+              // null means the queryRange came back null. Surface it HONESTLY: a
+              // passing /ready probe means Loki is reachable and this is a query/
+              // backend error (degraded), NOT a fabricated empty or a false
+              // "Loki unavailable".
+              return otelDegradedResponse(loki, "model-latency");
+            }
+            return Response.json({ data: result });
+          }
+
+          // OBS-6 (TELEMETRY): the fleet-wide grouped live tail + freshness. ONE
+          // newest-first scan of the claude-code Loki stream (same pipe as the
+          // per-session history, minus the session filter). The hero reads
+          // `freshnessMs` (age of the newest line) to pick FLOWING vs QUIET; the P1
+          // panel groups `rows` by worker client-side. 503 when Loki is not
+          // configured (the surface degrades via the ChartCard ladder). An empty
+          // stream is an HONEST 200 with `freshnessMs:null` (QUIET, not an error).
+          if (url.pathname === "/api/otel/tail") {
+            if (!loki) return Response.json({ error: "OTel not configured" }, { status: 503 });
+            const range = url.searchParams.get("range") ?? "15m";
+            const rawLimit = parseInt(url.searchParams.get("limit") ?? "300", 10);
+            const limit = Number.isFinite(rawLimit) ? Math.min(Math.max(1, rawLimit), 1000) : 300;
+            const result = await recentTail(loki, range, limit);
+            if (result === null) {
+              // Loki probe failed mid-flight — honest 503, not a fabricated empty.
+              return Response.json({ error: "Loki unavailable" }, { status: 503 });
+            }
+            return Response.json({ data: result });
+          }
+
+          // OBS-8 (TELEMETRY P5): events/min heatmap, workers × time. ONE metric
+          // query over the claude-code Loki stream — `count_over_time` of every line
+          // per `session_id` in 15m buckets (eventsHeatmap in otel-queries.ts). The
+          // payload is {buckets, cells}; the UI joins cells[].sessionId to board
+          // worker names and renders a row for EVERY running worker (silent ones
+          // included) so an early stall — a `running` worker with dark recent cells —
+          // is visible. 503 when Loki is not configured (the P5 ChartCard degrades via
+          // the ladder, but its board-sourced row headers still render per design
+          // §3.1); a reachable-but-quiet stream is an HONEST 200 with empty cells.
+          if (url.pathname === "/api/otel/events-heatmap") {
+            if (!loki) return Response.json({ error: "OTel not configured" }, { status: 503 });
+            const range = url.searchParams.get("range") ?? "6h";
+            const result = await eventsHeatmap(loki, range);
+            if (result === null) {
+              // Loki probe failed mid-flight — honest 503, not a fabricated empty.
+              return Response.json({ error: "Loki unavailable" }, { status: 503 });
+            }
+            return Response.json({ data: result });
+          }
+
+          if (url.pathname === "/api/otel/cost-validation") {
+            if (!prom) return Response.json({ error: "OTel not configured" }, { status: 503 });
+            const range = url.searchParams.get("range") ?? "6h";
+            const snap = buildSnapshot(wtDir, buildOpts);
+            const signalCosts: Record<string, number> = {};
+            for (const orch of snap.orchestrators) {
+              for (const [key, worker] of Object.entries(orch.workers)) {
+                if (worker.cost?.costUSD) signalCosts[key] = worker.cost.costUSD;
+              }
+            }
+            const result = await costValidation(prom, signalCosts, range);
+            return Response.json({ data: result });
+          }
+
+          // CTL-914 (DETAIL3): the worker-page [history] tail. Queries the
+          // `claude-code` Loki stream for ONE run's transcript by its CC session
+          // UUID — REAL today, no plumbing — so a dead worker's tail is readable
+          // hours later (why the worker page is never empty). The filter is a
+          // `| session_id=\`UUID\`` STRUCTURED-METADATA pipe inside
+          // workerHistoryBySession (a `{session_id=}` label matcher returns 0).
+          // sessionId is UUID-validated before it ever reaches the LogQL, so the
+          // pipe can never be an injection vector. 503 when Loki is not configured
+          // (the UI degrades to the resident-data page), 400 on a bad id.
+          const ecWorkerHistoryMatch = url.pathname.match(/^\/api\/ec-worker-history\/([^/]+)$/);
+          if (ecWorkerHistoryMatch) {
+            let sessionId: string;
+            try {
+              sessionId = decodeURIComponent(ecWorkerHistoryMatch[1]);
+            } catch {
+              return new Response("Bad Request", { status: 400 });
+            }
+            if (!isValidCcSessionId(sessionId)) {
+              return new Response("Bad Request", { status: 400 });
+            }
+            if (!loki) {
+              return Response.json({ error: "OTel not configured" }, { status: 503 });
+            }
+            const range = url.searchParams.get("range") ?? "24h";
+            const rawLimit = parseInt(url.searchParams.get("limit") ?? "500", 10);
+            const limit = Number.isFinite(rawLimit) ? Math.min(Math.max(1, rawLimit), 2000) : 500;
+            const rows = await workerHistoryBySession(loki, sessionId, range, limit);
+            if (rows === null) {
+              // Loki probe failed mid-flight — honest 503, not a fabricated empty.
+              return Response.json({ error: "Loki unavailable" }, { status: 503 });
+            }
+            return Response.json({ data: rows });
+          }
+
+          // CTL-917 (DETAIL6): the worker Burn Strip's REAL Prometheus sparklines.
+          // Four query_range series keyed on the CC session UUID (cost / tokens /
+          // tokens-by-type / active-seconds) — no new plumbing, the same already-
+          // emitting OTEL pipeline the `/api/otel/*` routes read. The UUID is
+          // UUID-validated before it reaches the PromQL `{session_id=…}` matcher,
+          // so the matcher can never be an injection vector. 503 when Prometheus is
+          // not configured (the UI falls back to the resident BoardWorker scalar),
+          // 400 on a bad id.
+          const otelBurnMatch = url.pathname.match(/^\/api\/otel\/burn\/([^/]+)$/);
+          if (otelBurnMatch) {
+            let sessionId: string;
+            try {
+              sessionId = decodeURIComponent(otelBurnMatch[1]);
+            } catch {
+              return new Response("Bad Request", { status: 400 });
+            }
+            if (!isValidCcSessionId(sessionId)) {
+              return new Response("Bad Request", { status: 400 });
+            }
+            if (!prom) {
+              return Response.json({ error: "OTel not configured" }, { status: 503 });
+            }
+            const range = url.searchParams.get("range") ?? "1h";
+            const series = await workerBurnSeries(prom, sessionId, range);
+            if (series === null) {
+              // Prometheus probe failed mid-flight — honest 503, never a fake series.
+              return Response.json({ error: "Prometheus unavailable" }, { status: 503 });
+            }
+            return Response.json({ data: series });
+          }
+
+          // CTL-917 (DETAIL6): the ticket telemetry strip's REAL Prometheus
+          // sparklines keyed on the Linear key (total cost / tokens-by-type +
+          // cost-by-phase `sum by(task_type)` + cost-by-model `sum by(model)`).
+          // commits/LoC stay git-sourced (NEEDS-PLUMBING) so they are NOT queried
+          // here. The linear_key is validated before it reaches the PromQL matcher.
+          const otelTicketTelemetryMatch = url.pathname.match(
+            /^\/api\/otel\/ticket-telemetry\/([^/]+)$/,
+          );
+          if (otelTicketTelemetryMatch) {
+            let linearKey: string;
+            try {
+              linearKey = decodeURIComponent(otelTicketTelemetryMatch[1]);
+            } catch {
+              return new Response("Bad Request", { status: 400 });
+            }
+            if (!isValidLinearKey(linearKey)) {
+              return new Response("Bad Request", { status: 400 });
+            }
+            if (!prom) {
+              return Response.json({ error: "OTel not configured" }, { status: 503 });
+            }
+            const range = url.searchParams.get("range") ?? "1h";
+            const series = await ticketTelemetrySeries(prom, linearKey, range);
+            if (series === null) {
+              return Response.json({ error: "Prometheus unavailable" }, { status: 503 });
+            }
+            return Response.json({ data: series });
+          }
+
+          if (url.pathname === "/api/annotations") {
+            return Response.json({ annotations: getAllAnnotations() });
+          }
+
+          const annMatch = url.pathname.match(/^\/api\/annotations\/([A-Za-z0-9._-]+)$/);
+          if (annMatch && annMatch[1]) {
+            const sessionId = decodeURIComponent(annMatch[1]);
+
+            if (req.method === "DELETE") {
+              deleteAnnotation(sessionId);
+              return Response.json({ ok: true });
+            }
+
+            if (req.method === "PUT") {
+              let body: Record<string, unknown>;
+              try {
+                body = (await req.json()) as Record<string, unknown>;
+              } catch {
+                return Response.json({ error: "Invalid JSON body" }, { status: 400 });
+              }
+
+              const VALID_FLAGS = new Set(["starred", "flagged", "archived"]);
+
+              if (Array.isArray(body.addFlags)) {
+                for (const f of body.addFlags) {
+                  if (typeof f !== "string" || !VALID_FLAGS.has(f)) {
+                    return Response.json(
+                      {
+                        error: `Invalid flag: ${String(f)}. Valid: starred, flagged, archived`,
+                      },
+                      { status: 400 },
+                    );
+                  }
+                }
+              }
+
+              if (typeof body.displayName === "string") {
+                setDisplayName(sessionId, body.displayName);
+              } else if (body.displayName === null) {
+                setDisplayName(sessionId, null);
+              }
+
+              if (Array.isArray(body.addFlags)) {
+                for (const f of body.addFlags) {
+                  if (typeof f === "string") addFlag(sessionId, f);
+                }
+              }
+              if (Array.isArray(body.removeFlags)) {
+                for (const f of body.removeFlags) {
+                  if (typeof f === "string") removeFlag(sessionId, f);
+                }
+              }
+              if (typeof body.addNote === "string") {
+                addNote(sessionId, body.addNote);
+              }
+              if (
+                typeof body.removeNoteIndex === "number" &&
+                Number.isInteger(body.removeNoteIndex)
+              ) {
+                removeNote(sessionId, body.removeNoteIndex);
+              }
+              if (Array.isArray(body.addTags)) {
+                for (const t of body.addTags) {
+                  if (typeof t === "string") addTag(sessionId, t);
+                }
+              }
+              if (Array.isArray(body.removeTags)) {
+                for (const t of body.removeTags) {
+                  if (typeof t === "string") removeTag(sessionId, t);
+                }
+              }
+
+              const annotation = getAnnotation(sessionId);
+              return Response.json({ annotation });
+            }
+
+            return new Response("Method Not Allowed", { status: 405 });
+          }
+
+          if (url.pathname === "/api/archive/orchestrators") {
+            if (!dbPath) {
+              return Response.json({ entries: [], total: 0 });
+            }
+            const params = url.searchParams;
+            const limitRaw = params.get("limit");
+            const offsetRaw = params.get("offset");
+            const parsedLimit = limitRaw ? Number.parseInt(limitRaw, 10) : NaN;
+            const parsedOffset = offsetRaw ? Number.parseInt(offsetRaw, 10) : NaN;
+            const result = listArchivedOrchestrators(dbPath, {
+              since: params.get("since") ?? undefined,
+              until: params.get("until") ?? undefined,
+              ticket: params.get("ticket") ?? undefined,
+              status: params.get("status") ?? undefined,
+              limit: Number.isFinite(parsedLimit) ? parsedLimit : undefined,
+              offset: Number.isFinite(parsedOffset) ? parsedOffset : undefined,
+            });
+            return Response.json(result);
+          }
+
+          const archiveFileMatch = url.pathname.match(
+            /^\/api\/archive\/orchestrators\/([^/]+)\/files\/(.+)$/,
+          );
+          if (archiveFileMatch) {
+            if (!dbPath) {
+              return new Response("Not Found", { status: 404 });
+            }
+            let orchId: string;
+            let fileRel: string;
+            try {
+              orchId = decodeURIComponent(archiveFileMatch[1]);
+              fileRel = decodeURIComponent(archiveFileMatch[2]);
+            } catch {
+              return new Response("Bad Request", { status: 400 });
+            }
+            if (!isSafeArchivePart(orchId) || !isSafeArchiveFileRel(fileRel)) {
+              return new Response("Bad Request", { status: 400 });
+            }
+            const archivePath = getArchivePath(dbPath, orchId);
+            if (!archivePath) {
+              return new Response("Not Found", { status: 404 });
+            }
+            const candidate = resolvePath(archivePath, fileRel);
+            let realRoot: string;
+            try {
+              realRoot = realpathSync(archivePath);
+            } catch {
+              return new Response("Not Found", { status: 404 });
+            }
+            let realTarget: string;
+            try {
+              realTarget = realpathSync(candidate);
+            } catch {
+              return new Response("Not Found", { status: 404 });
+            }
+            if (realTarget !== realRoot && !realTarget.startsWith(realRoot + sep)) {
+              return new Response("Forbidden", { status: 403 });
+            }
+            const file = Bun.file(realTarget);
+            if (!(await file.exists())) {
+              return new Response("Not Found", { status: 404 });
+            }
+            return new Response(file, {
+              headers: {
+                "Content-Type": contentTypeForArchive(realTarget),
+                "Cache-Control": "private, max-age=60",
+              },
+            });
+          }
+
+          const archiveDetailMatch = url.pathname.match(/^\/api\/archive\/orchestrators\/([^/]+)$/);
+          if (archiveDetailMatch) {
+            if (!dbPath) {
+              return new Response("Not Found", { status: 404 });
+            }
+            let orchId: string;
+            try {
+              orchId = decodeURIComponent(archiveDetailMatch[1]);
+            } catch {
+              return new Response("Bad Request", { status: 400 });
+            }
+            if (!isSafeArchivePart(orchId)) {
+              return new Response("Bad Request", { status: 400 });
+            }
+            const detail = getArchivedOrchestrator(dbPath, orchId);
+            if (!detail) {
+              return new Response("Not Found", { status: 404 });
+            }
+            return Response.json(detail);
+          }
+
+          // CTL-1133: PWA installability. The web app is installable as a
+          // chrome-less standalone window (desktop) / iOS home-screen app. The
+          // manifest and service worker are served from the ROOT (not /public/) so
+          // the SW's default scope is "/" and it controls the whole app — a SW at
+          // /public/service-worker.js would only scope /public/. Icons are plain
+          // PNGs served by the existing /public/* route.
+          if (url.pathname === "/manifest.webmanifest") {
+            const file = Bun.file(join(publicDir, "manifest.webmanifest"));
+            if (await file.exists()) {
+              return new Response(file, {
+                headers: {
+                  "Content-Type": "application/manifest+json; charset=utf-8",
+                  "Cache-Control": CACHE_REVALIDATE, // CTL-1374
+                },
+              });
+            }
+            return new Response("manifest not found", { status: 404 });
+          }
+          if (url.pathname === "/service-worker.js") {
+            const file = Bun.file(join(publicDir, "service-worker.js"));
+            if (await file.exists()) {
+              return new Response(file, {
+                headers: {
+                  "Content-Type": "text/javascript; charset=utf-8",
+                  // allow root scope even though the file lives under publicDir
+                  "Service-Worker-Allowed": "/",
+                  // never let a stale SW pin an old shell
+                  "Cache-Control": "no-cache",
+                },
+              });
+            }
+            return new Response("service worker not found", { status: 404 });
+          }
+
+          // CTL-989: the app shell (index.html → main.tsx → the unified TanStack
+          // Router → AppShell layout) is the SINGLE canonical entry. It hosts every
+          // surface (Home/Tickets/Workers/Queue/Observe) AND every detail page
+          // inside the shared AppShell chrome — so `/` serves the shell. The legacy
+          // standalone board.html bundle is RETIRED; `/board` is now just the
+          // Tickets surface route, served by this same index.html (see the unified
+          // SPA fallback below).
+          if (url.pathname === "/" || url.pathname === "/index.html") {
+            const file = Bun.file(join(publicDir, "index.html"));
+            if (await file.exists()) {
+              return new Response(file, {
+                headers: {
+                  "Content-Type": "text/html; charset=utf-8",
+                  "Cache-Control": CACHE_REVALIDATE, // CTL-1374: always revalidate the shell
+                },
+              });
+            }
+            return new Response("index.html not found", { status: 500 });
+          }
+
+          // CTL-989: the unified SPA fallback. EVERY app route — the flat surface
+          // paths (/board, /workers, /queue, /telemetry, /utilization, /finops,
+          // /fleetops, /devops, /settings) AND the detail/dep-graph deep links
+          // (/ticket/$id, /worker/$id, /dep-graph) — is served by the ONE TanStack
+          // Router mounted from index.html. A hard navigation / refresh / shared
+          // link to any of them serves index.html; the router boots, reads the URL,
+          // and lands on the right surface or detail page. (`/` and `/index.html`
+          // are handled by the dedicated block above; `/legacy` + `/history` keep
+          // their own handlers below.) Vite emits absolute /assets/* paths, so the
+          // nested /ticket/$id pathname is safe. GET-only: a POST to an app path is
+          // not the SPA entry.
+          if (req.method === "GET" && isAppRoute(url.pathname)) {
+            const file = Bun.file(join(publicDir, "index.html"));
+            if (await file.exists()) {
+              return new Response(file, {
+                headers: {
+                  "Content-Type": "text/html; charset=utf-8",
+                  "Cache-Control": CACHE_REVALIDATE, // CTL-1374: always revalidate the shell
+                },
+              });
+            }
+            return new Response("index.html not found", { status: 500 });
+          }
+
+          if (
+            url.pathname === "/legacy" ||
+            url.pathname === "/legacy/" ||
+            url.pathname === "/history"
+          ) {
+            const htmlFile = url.pathname === "/history" ? "history.html" : "index.html";
+            const file = Bun.file(join(publicDir, htmlFile));
+            if (await file.exists()) {
+              return new Response(file, {
+                headers: {
+                  "Content-Type": "text/html; charset=utf-8",
+                  "Cache-Control": CACHE_REVALIDATE, // CTL-1374
+                },
+              });
+            }
+            return new Response(`${htmlFile} not found`, { status: 500 });
+          }
+
+          if (url.pathname === "/mockups" || url.pathname === "/mockups/") {
+            const file = Bun.file(join(publicDir, "mockups", "index.html"));
+            if (await file.exists()) {
+              return new Response(file, {
+                headers: {
+                  "Content-Type": "text/html; charset=utf-8",
+                  "Cache-Control": CACHE_REVALIDATE, // CTL-1374
+                },
+              });
+            }
+          }
+
+          if (url.pathname.startsWith("/mockups/")) {
+            const rel = decodeURIComponent("mockups/" + url.pathname.slice("/mockups/".length));
+            const safe = resolveSafeStaticPath(publicDir, rel);
+            if (!safe) return new Response("Forbidden", { status: 403 });
+            const file = Bun.file(safe);
+            if (await file.exists()) {
+              const dot = safe.lastIndexOf(".");
+              const ext = dot >= 0 ? safe.slice(dot).toLowerCase() : "";
+              return new Response(file, {
+                headers: {
+                  "Content-Type": contentTypeForExt(ext),
+                  "Cache-Control": CACHE_REVALIDATE, // CTL-1374: mockups aren't content-hashed
+                },
+              });
+            }
+          }
+
+          if (url.pathname.startsWith("/public/") || url.pathname.startsWith("/assets/")) {
+            const rel = decodeURIComponent(
+              url.pathname.startsWith("/public/")
+                ? url.pathname.slice("/public/".length)
+                : url.pathname.slice(1),
+            );
+            const safe = resolveSafeStaticPath(publicDir, rel);
+            if (!safe) return new Response("Forbidden", { status: 403 });
+            const file = Bun.file(safe);
+            if (await file.exists()) {
+              const dot = safe.lastIndexOf(".");
+              const ext = dot >= 0 ? safe.slice(dot).toLowerCase() : "";
+              return new Response(file, {
+                headers: {
+                  "Content-Type": contentTypeForExt(ext),
+                  // CTL-1374: content-hashed /assets/* are immutable (forever-cacheable);
+                  // non-hashed /public/* icons revalidate so a redeploy can update them.
+                  "Cache-Control": cacheControlForStatic(url.pathname),
+                },
+              });
+            }
+          }
+
+          if (url.pathname === "/api/status/webhook-tunnel") {
+            const stats = readTunnelEventStats(CATALYST_DIR, eventRing);
+            if (!webhookConfig) {
+              return Response.json({
+                connected: false,
+                smeeUrl: null,
+                secretEnvName: null,
+                secretPresent: false,
+                lastEventAt: stats.lastEventAt,
+                eventCount24h: stats.eventCount24h,
+                eventCount24hByRepo: stats.eventCount24hByRepo,
+              });
+            }
+            return Response.json({
+              connected: webhookTunnel?.isStarted() ?? false,
+              smeeUrl: webhookConfig.smeeChannel || null,
+              secretEnvName: webhookConfig.secretEnvName ?? "CATALYST_WEBHOOK_SECRET",
+              secretPresent: webhookConfig.secret.length > 0,
+              lastEventAt: stats.lastEventAt,
+              eventCount24h: stats.eventCount24h,
+              eventCount24hByRepo: stats.eventCount24hByRepo,
+            });
+          }
+
+          // CTL-1100: GET /api/journey/:ticket — chronological hop timeline + gates + verdict.
+          // bun:sqlite-free (assembleJourney uses sqlite3 binary via ticket-runs.mjs).
+          // Mirrors ticketRunsMatch guard for input validation.
+          const journeyMatch = url.pathname.match(/^\/api\/journey\/([^/]+)$/);
+          if (journeyMatch) {
+            let ticket: string;
+            try {
+              ticket = decodeURIComponent(journeyMatch[1]);
+            } catch {
+              return new Response("Bad Request", { status: 400 });
+            }
+            if (!/^[A-Za-z]+-\d+$/.test(ticket)) {
+              return new Response("Bad Request", { status: 400 });
+            }
+            return Response.json(
+              await assembleJourney(ticket, {
+                orchDir: wtDir,
+                workersDir: `${wtDir}/workers`,
+                dbPath: dbPath ?? undefined,
+              }),
+            );
+          }
+
+          // CTL-886 (BFF4) keystone P2: a ticket's full run history. One run entity
+          // per phase-*.json signal under ~/catalyst/execution-core/workers/<id>/
+          // (model, bg_job_id, attempt, generation, status, timestamps, host{},
+          // pr{} when present). FINISHED runs (no live BoardWorker) included by
+          // construction — we read the on-disk signals, not the live-agent list.
+          // Per-phase cost is JOINED from catalyst.db, never invented onto the
+          // signal. Pure file reads — no live Linear/GitHub call.
+          const ticketRunsMatch = url.pathname.match(/^\/api\/ticket-runs\/([^/]+)$/);
+          if (ticketRunsMatch) {
+            let ticket: string;
+            try {
+              ticket = decodeURIComponent(ticketRunsMatch[1]);
+            } catch {
+              return new Response("Bad Request", { status: 400 });
+            }
+            if (!/^[A-Za-z]+-\d+$/.test(ticket)) {
+              return new Response("Bad Request", { status: 400 });
+            }
+            return Response.json(await assembleTicketRuns(ticket));
+          }
+
+          // CTL-890 (BFF8) P10: the redesign's ONE destructive endpoint, gated last.
+          // POST /api/ec-worker/<ticket>/stop wraps the flaky `claude stop <shortId>`
+          // (pid-file absent on CC 2.1.152). Matched BEFORE the GET verbatim route
+          // and gated on POST so a stop request is never confused with the
+          // signal reader (and "stop" is not a valid phase, so a GET here 404s
+          // harmlessly). Contract (design §3.4):
+          //   • TYPED CONFIRM — body.confirm must equal the ticket id exactly.
+          //   • TARGET RUN    — body.phase selects which run (its phase-<phase>.json
+          //     signal carries the bg_job_id → shortId). The response echoes the
+          //     exact shortId+ticket+phase so the UI shows what it is killing.
+          //   • FENCE-AWARE   — single-host (hosts.json absent/len 1) is a no-op
+          //     pass; multi-host rejects a verified-stale generation (a partitioned
+          //     node) and refuses on an unconfirmable fence.
+          //   • OPTIMISTIC ROLLBACK is a UI-side ~10s timer; on success we return the
+          //     identity + a `stopping` status the client marks optimistically.
+          const ecStopMatch = url.pathname.match(/^\/api\/ec-worker\/([^/]+)\/stop$/);
+          if (ecStopMatch && req.method === "POST") {
+            let ticket: string;
+            try {
+              ticket = decodeURIComponent(ecStopMatch[1]);
+            } catch {
+              return new Response("Bad Request", { status: 400 });
+            }
+            if (!/^[A-Za-z]+-\d+$/.test(ticket)) {
+              return new Response("Bad Request", { status: 400 });
+            }
+            let body: Record<string, unknown>;
+            try {
+              body = (await req.json()) as Record<string, unknown>;
+            } catch {
+              return Response.json({ error: "Invalid JSON body" }, { status: 400 });
+            }
+            const phase = typeof body.phase === "string" ? body.phase : "";
+            if (!/^[a-z][a-z-]*$/.test(phase)) {
+              return Response.json(
+                { error: "phase is required and must be a valid phase name" },
+                { status: 400 },
+              );
+            }
+            const result: StopWorkerResult = await stopWorker({
+              ticket,
+              phase,
+              confirm: body.confirm,
+            });
+            switch (result.status) {
+              case "not_found":
+                return Response.json(
+                  { status: "not_found", error: `no run signal for ${ticket}:${phase}` },
+                  { status: 404 },
+                );
+              case "confirm_mismatch":
+                return Response.json(
+                  {
+                    status: "confirm_mismatch",
+                    error: "typed confirmation did not match the ticket id",
+                    expected: result.expected,
+                  },
+                  { status: 400 },
+                );
+              case "no_session":
+                return Response.json(result, { status: 409 });
+              case "fenced":
+                // A stale-generation node is fenced out — the worker is NOT killed.
+                return Response.json(
+                  {
+                    ...result,
+                    error: "stop rejected: this node's generation is stale (fenced out)",
+                  },
+                  { status: 409 },
+                );
+              case "fence_indeterminate":
+                return Response.json(
+                  {
+                    ...result,
+                    error: "stop rejected: fence could not be confirmed",
+                  },
+                  { status: 409 },
+                );
+              case "stop_failed":
+                return Response.json(result, { status: 502 });
+              case "stopping":
+                // Kill issued; the UI marks the worker `stopping` and arms its ~10s
+                // optimistic-rollback timer against the next board frame.
+                return Response.json(result, { status: 200 });
+            }
+          }
+
+          // CTL-924 (BFF12): the read-model's SECOND write endpoint — HOME5's Inbox
+          // `Answer / Unblock` verb. POST /api/ticket/<ticket>/respond records the
+          // operator's answer/unblock note, clears the `.linear-label-needs-human`
+          // marker, and emits ONE `linear.comment.created` event into the unified
+          // log — the daemon's handleCommentWake (CTL-549) consumes it, strips the
+          // held label, and re-dispatches the parked worker (CTL-876's resume loop).
+          // Contract mirrors BFF8's stop route:
+          //   • TYPED CONFIRM — body.confirm must equal the ticket id exactly.
+          //   • FENCE-AWARE   — single-host (hosts.json absent/len 1) is a no-op
+          //     pass; multi-host rejects a verified-stale generation (a partitioned
+          //     node) and refuses on an unconfirmable fence. NOTHING is mutated on
+          //     a fence rejection.
+          //   • OPTIMISTIC ROLLBACK is a UI-side timer; on success we return the
+          //     ticket+phase identity + a `resuming` status the client marks
+          //     optimistically (the held row should clear within the window).
+          const respondMatch = url.pathname.match(/^\/api\/ticket\/([^/]+)\/respond$/);
+          if (respondMatch && req.method === "POST") {
+            let ticket: string;
+            try {
+              ticket = decodeURIComponent(respondMatch[1]);
+            } catch {
+              return new Response("Bad Request", { status: 400 });
+            }
+            if (!/^[A-Za-z]+-\d+$/.test(ticket)) {
+              return new Response("Bad Request", { status: 400 });
+            }
+            let body: Record<string, unknown>;
+            try {
+              body = (await req.json()) as Record<string, unknown>;
+            } catch {
+              return Response.json({ error: "Invalid JSON body" }, { status: 400 });
+            }
+            const response = typeof body.response === "string" ? body.response : "";
+            const result: RespondTicketResult = respondTicket({
+              ticket,
+              response,
+              confirm: body.confirm,
+            });
+            switch (result.status) {
+              case "not_held":
+                return Response.json(
+                  {
+                    status: "not_held",
+                    error: `no parked (needs-input) run for ${ticket} to answer/unblock`,
+                  },
+                  { status: 404 },
+                );
+              case "confirm_mismatch":
+                return Response.json(
+                  {
+                    status: "confirm_mismatch",
+                    error: "typed confirmation did not match the ticket id",
+                    expected: result.expected,
+                  },
+                  { status: 400 },
+                );
+              case "fenced":
+                // A stale-generation node is fenced out — nothing was mutated.
+                return Response.json(
+                  {
+                    ...result,
+                    error: "respond rejected: this node's generation is stale (fenced out)",
+                  },
+                  { status: 409 },
+                );
+              case "fence_indeterminate":
+                return Response.json(
+                  {
+                    ...result,
+                    error: "respond rejected: fence could not be confirmed",
+                  },
+                  { status: 409 },
+                );
+              case "resuming":
+                // Response recorded + marker cleared + resume event emitted; the UI
+                // marks the row `resuming` and arms its optimistic-rollback timer.
+                return Response.json(result, { status: 200 });
+            }
+          }
+
+          // ── CTL-1569: the inbox conversation surface ───────────────────────────
+          //
+          // GET /api/ticket/<ticket>/thread — the ask summary + the last few comments
+          // (newest first) + the ticket's Linear deep link. A pure REPLICA read: it
+          // makes ZERO Linear API calls, which is what makes it safe to fetch on every
+          // row selection against a shared, rate-limited fleet quota. Fails OPEN —
+          // an absent/locked replica yields an unavailable thread, never a 5xx.
+          const threadMatch = url.pathname.match(/^\/api\/ticket\/([^/]+)\/thread$/);
+          if (threadMatch && req.method === "GET") {
+            let ticket: string;
+            try {
+              ticket = decodeURIComponent(threadMatch[1]);
+            } catch {
+              return new Response("Bad Request", { status: 400 });
+            }
+            // CTL-1569: the canonical ticket key allows digits/underscores in the
+            // team prefix (e.g. `OPS_2-17`). A letters-only predicate 400s the entire
+            // conversation surface for such teams. Still anchored + no path
+            // characters, so traversal remains impossible.
+            if (!CONVERSATION_TICKET_RE.test(ticket)) {
+              return new Response("Bad Request", { status: 400 });
+            }
+            const limitParam = Number(url.searchParams.get("limit"));
+            const conversation = await getConversation(ticket, {
+              // Pass the SERVER-resolved Layer-1 path (--config / CATALYST_CONFIG_PATH).
+              // A cwd-relative fallback misses under launchd, which sets no working
+              // directory — and the legacy `catalyst.monitor.linear.botUserId` lives in
+              // that file, so missing it breaks the agent/human split on legacy hosts.
+              repoConfigPath: monitorConfigPath,
+              ...(Number.isFinite(limitParam) && limitParam > 0
+                ? { limit: Math.min(Math.floor(limitParam), 50) }
+                : {}),
+            });
+            return Response.json(conversation, { status: 200 });
+          }
+
+          // POST /api/ticket/<ticket>/reply — post the operator's reply to Linear as a
+          // REAL human-authored comment. This is the resolution mechanism: once the
+          // comment lands, Linear's webhook drives the daemon's comment-wake, which
+          // clears `needs-human` unconditionally and first (CTL-1567, ~4s end to end).
+          //
+          // Deliberately UNLIKE /respond:
+          //   • NO typed-confirm. The typed gate exists for destructive verbs (stop a
+          //     worker); forcing an operator to retype the ticket id to send a chat
+          //     reply would defeat the entire surface. The reply text IS the intent.
+          //   • NO held-run requirement. The tickets that most need answering are
+          //     parked with no worker dir at all, and /respond 404s exactly those.
+          //
+          // EVERY non-2xx here must cause the UI to RESTORE the row (§4) — the row is
+          // never silently lost. `bot_identity` is the loud refusal that prevents the
+          // whole feature from shipping inert: an app-actor comment is ignored by
+          // CTL-1567, so it is refused BEFORE posting rather than faking success.
+          const replyMatch = url.pathname.match(/^\/api\/ticket\/([^/]+)\/reply$/);
+          if (replyMatch && req.method === "POST") {
+            let ticket: string;
+            try {
+              ticket = decodeURIComponent(replyMatch[1]);
+            } catch {
+              return new Response("Bad Request", { status: 400 });
+            }
+            if (!CONVERSATION_TICKET_RE.test(ticket)) {
+              return new Response("Bad Request", { status: 400 });
+            }
+            // CROSS-ORIGIN GUARD. This route posts operator-authored text to Linear,
+            // and the server binds 0.0.0.0 with no auth. `req.json()` parses a body
+            // regardless of Content-Type, so a plain `text/plain` form POST from any
+            // page the operator visits would otherwise be a valid request — the
+            // browser could not read the response, but the comment would still be
+            // posted as them to any guessable ticket.
+            //
+            // CTL-1573 P1: this used to compare `Origin` against the request's own
+            // `Host` header. Both are attacker-chosen under DNS rebinding (the page
+            // and the target then share one origin), so that comparison could not
+            // reject the very case it existed for. `Origin` is now checked against
+            // an allowlist the attacker cannot influence — see lib/trusted-origin.mjs
+            // for the rebinding walkthrough and the inertness trade-off.
+            if (!originAllowed(req.headers.get("origin"))) {
+              return Response.json(
+                { status: "forbidden", error: "cross-origin reply rejected" },
+                { status: 403 },
+              );
+            }
+            let body: Record<string, unknown>;
+            try {
+              body = (await req.json()) as Record<string, unknown>;
+            } catch {
+              return Response.json({ error: "Invalid JSON body" }, { status: 400 });
+            }
+            const text = typeof body.body === "string" ? body.body : "";
+            const [globalConfig, projectConfig] = await Promise.all([
+              loadGlobalConfig(),
+              // Explicit resolved path — NOT process.cwd(). The launchd wrapper sets
+              // neither a working directory nor CATALYST_PROJECT_KEY, so a
+              // cwd-relative lookup leaves the Layer-2 token unresolved and every
+              // reply returns `no_token` on the persistent launch path.
+              loadProjectConfig({ repoConfigPath: monitorConfigPath }),
+            ]);
+            const result = await replyToTicket(
+              { ticket, body: text },
+              { config: globalConfig, projectConfig },
+            );
+            switch (result.status) {
+              case "replied":
+                // The comment is live and human-authored. The UI marks the row
+                // resolved optimistically and reconciles against the label.
+                return Response.json(result, { status: 200 });
+              case "empty_body":
+                return Response.json(
+                  { ...result, error: "an empty reply was not sent" },
+                  { status: 400 },
+                );
+              case "not_found":
+                return Response.json(
+                  {
+                    ...result,
+                    error: `no Linear issue ${ticket} to reply to`,
+                  },
+                  { status: 404 },
+                );
+              case "bot_identity":
+              case "no_token":
+              case "error":
+              default:
+                // 502: the write did NOT act. Surfaced verbatim so the operator sees
+                // WHY (especially the app-actor refusal) and the row comes back.
+                return Response.json(
+                  {
+                    ...result,
+                    error:
+                      (result as { message?: string }).message ?? "reply was not posted to Linear",
+                  },
+                  { status: 502 },
+                );
+            }
+          }
+
+          // CTL-886 (BFF4) companion P3: one phase signal served VERBATIM — the raw
+          // phase-<phase>.json contents (model, bg_job_id, generation, status,
+          // timestamps, host, pr) untransformed, for the worker header / PHASE
+          // TIMESTAMPS / SIGNAL panel. 404 when the phase has no signal on disk.
+          const ecWorkerMatch = url.pathname.match(/^\/api\/ec-worker\/([^/]+)\/([^/]+)$/);
+          if (ecWorkerMatch) {
+            let ticket: string;
+            let phase: string;
+            try {
+              ticket = decodeURIComponent(ecWorkerMatch[1]);
+              phase = decodeURIComponent(ecWorkerMatch[2]);
+            } catch {
+              return new Response("Bad Request", { status: 400 });
+            }
+            if (!/^[A-Za-z]+-\d+$/.test(ticket) || !/^[a-z][a-z-]*$/.test(phase)) {
+              return new Response("Bad Request", { status: 400 });
+            }
+            const signal = await readPhaseSignalVerbatim(ticket, phase);
+            if (!signal) {
+              return new Response("Not Found", { status: 404 });
+            }
+            return Response.json(signal);
+          }
+
+          // CTL-887 (BFF5) + CTL-885 (BFF3): the live transcript tail, made
+          // NODE-AWARE. BFF5 resolves a CC session UUID to its
+          // ~/.claude/projects/<dir>/<sessionId>.jsonl path and streams typed
+          // StreamEvents over SSE as the file grows (the EC equivalent of the
+          // legacy /api/worker-stream, which is empty for execution-core workers).
+          // BFF3 wraps that host-local tail in the cross-node FAN-IN: the UI
+          // subscribes ONCE and the read-model multiplexes the OWNING node's
+          // per-host stream keyed by host.name.
+          //   • SINGLE-HOST (hosts.json absent/len 1): an EXACT identity no-op —
+          //     tail the LOCAL transcript with zero added latency, no owner
+          //     resolution, no remote hop (resolveTailRoute → { mode: "local" }).
+          //   • MULTI-HOST, owner is a DIFFERENT node: proxy that peer's
+          //     /api/ec-worker-stream/<sessionId> through unchanged (never a
+          //     shared/merged log — only the one owner's per-host stream).
+          const ecWorkerStreamMatch = url.pathname.match(/^\/api\/ec-worker-stream\/([^/]+)$/);
+          if (ecWorkerStreamMatch) {
+            let sessionId: string;
+            try {
+              sessionId = decodeURIComponent(ecWorkerStreamMatch[1]);
+            } catch {
+              return new Response("Bad Request", { status: 400 });
+            }
+            // A CC session id is a UUID — reject anything else so no arbitrary
+            // path ever reaches the filesystem.
+            if (
+              !/^[0-9a-fA-F-]{8,64}$/.test(sessionId) ||
+              sessionId.includes("..") ||
+              sessionId.includes("/")
+            ) {
+              return new Response("Bad Request", { status: 400 });
+            }
+
+            // ── BFF3 fan-in routing (single-host = identity no-op) ──────────────
+            // Read the committed roster ONCE. SINGLE-HOST is the identity no-op:
+            // resolveTailRoute short-circuits to { mode: "local" } before any
+            // owner resolution, so we never even read the board snapshot — zero
+            // added latency. Only the MULTI-HOST branch resolves the owner: we
+            // read the board snapshot's per-worker host:{name,id} (BFF2/BFF10) —
+            // never a live attachment fetch, never a merged log — and pass a
+            // synchronous lookup over that resolved worker list. `hostBaseUrl` is
+            // the cross-node transport seam: no production roster→URL source
+            // exists yet (single-node MVP), so a multi-host owner with no
+            // resolvable base URL is reported unroutable (a 404) rather than
+            // mis-tailed to the wrong node's local file.
+            const roster = readClusterRoster();
+            const workers =
+              roster.length > 1 ? ((await boardSnapshot.getLatest())?.workers ?? []) : [];
+            const route = resolveTailRoute({
+              sessionId,
+              roster,
+              selfHost: hostName(),
+              ownerHostForSession: (sid) =>
+                workers.find((w) => w.sessionId === sid)?.host?.name ?? null,
+              hostBaseUrl: (host) => resolvePeerBaseUrl(host),
+            });
+            if (route.mode === "remote") {
+              // MULTI-HOST: fan in the owning node's per-host stream, keyed by
+              // host.name, by proxying its SSE body straight through (no re-frame
+              // — the client's StreamEventRow renderer consumes the peer's frames
+              // unchanged). A down/unreachable peer → 502 (never a wrong tail).
+              const abort = new AbortController();
+              const body = await proxyRemoteTail({ url: route.url, signal: abort.signal });
+              if (!body) {
+                return new Response("Bad Gateway", { status: 502 });
+              }
+              const proxied = new ReadableStream<Uint8Array>({
+                async start(controller) {
+                  const reader = body.getReader();
+                  try {
+                    for (;;) {
+                      const { value, done } = await reader.read();
+                      if (done) break;
+                      if (value) controller.enqueue(value);
+                    }
+                    controller.close();
+                  } catch {
+                    // upstream torn down (peer closed / client aborted) — end the
+                    // proxied stream cleanly rather than leaking the reader.
+                    try {
+                      controller.close();
+                    } catch {
+                      /* already closed */
+                    }
+                  }
+                },
+                cancel() {
+                  // client disconnected → abort the upstream subscription so no
+                  // per-host connection leaks.
+                  abort.abort();
+                },
+              });
+              return new Response(proxied, {
+                headers: {
+                  "Content-Type": "text/event-stream",
+                  "Cache-Control": "no-cache",
+                  Connection: "keep-alive",
+                  "Access-Control-Allow-Origin": "*",
+                },
+              });
+            }
+            if (route.mode === "unroutable") {
+              // MULTI-HOST: owner is a different node we can't reach (no transport
+              // address). 404 rather than blindly tailing THIS host's transcript
+              // (which would show the wrong node's session).
+              return new Response("Not Found", { status: 404 });
+            }
+            // route.mode === "local": the identity no-op — tail the LOCAL
+            // transcript exactly as the non-cluster BFF5 path does.
+            const transcriptPath = await resolveTranscriptPath(sessionId);
+            if (!transcriptPath) {
+              return new Response("Not Found", { status: 404 });
+            }
+
+            let timer: ReturnType<typeof setInterval> | null = null;
+            let inFlight = false;
+            let closed = false;
+            const tail = new TranscriptTail(transcriptPath);
+            const stream = new ReadableStream<Uint8Array>({
+              start(controller) {
+                const pump = () => {
+                  if (inFlight || closed) return;
+                  inFlight = true;
+                  void (async () => {
+                    try {
+                      const events = await tail.poll();
+                      if (closed) return;
+                      for (const ev of events) {
+                        controller.enqueue(
+                          encoder.encode(`event: stream-event\ndata: ${JSON.stringify(ev)}\n\n`),
+                        );
+                      }
+                    } catch {
+                      // client likely went away mid-enqueue; stop pumping
+                      closed = true;
+                      if (timer) clearInterval(timer);
+                      timer = null;
+                    } finally {
+                      inFlight = false;
+                    }
+                  })();
+                };
+                // Open frame so a cold connection paints the tail immediately,
+                // then poll for growth on a fixed cadence.
+                controller.enqueue(
+                  encoder.encode(`event: open\ndata: ${JSON.stringify({ sessionId })}\n\n`),
+                );
+                pump();
+                timer = setInterval(pump, 750);
+              },
+              cancel() {
                 closed = true;
                 if (timer) clearInterval(timer);
                 timer = null;
-                try {
-                  controller.close();
-                } catch {
-                  /* already closed */
+              },
+            });
+            return new Response(stream, {
+              headers: {
+                "Content-Type": "text/event-stream",
+                "Cache-Control": "no-cache",
+                Connection: "keep-alive",
+                "Access-Control-Allow-Origin": "*",
+              },
+            });
+          }
+
+          // CTL-938: the live SCREEN SSE — the PRE-transcript wedge window. Given
+          // a worker's bg shortId (or full job UUID), poll `claude logs <shortId>`
+          // every screenPollMs, ANSI-normalize, diff against the last snapshot,
+          // and push only CHANGED frames (each carrying the FULL screen, never a
+          // delta — frames are droppable, so a slow client just paints the latest
+          // one). Terminal outcomes close the stream: session gone → `gone`
+          // event, claude CLI unusable → `unavailable` event. The FIRST poll runs
+          // before the SSE handshake so a dead session is an HTTP status (404 /
+          // 503), not an empty stream the client must time out on.
+          const ecWorkerScreenMatch = url.pathname.match(/^\/api\/ec-worker-screen\/([^/]+)$/);
+          if (ecWorkerScreenMatch) {
+            let rawId: string;
+            try {
+              rawId = decodeURIComponent(ecWorkerScreenMatch[1]);
+            } catch {
+              return new Response("Bad Request", { status: 400 });
+            }
+            // `claude logs` only accepts the 8-char short form; deriveScreenShortId
+            // also truncates a full job UUID. null = malformed → nothing ever
+            // reaches the exec fn (no arbitrary string ever hits a subprocess).
+            const screenShortId = deriveScreenShortId(rawId);
+            if (!screenShortId) {
+              return new Response("Bad Request", { status: 400 });
+            }
+
+            const poller = new ScreenPoller(screenShortId, {
+              exec: screenLogsExecOpt ?? undefined,
+            });
+            const first = await poller.poll();
+            if (first.kind === "gone") {
+              return new Response("Not Found", { status: 404 });
+            }
+            if (first.kind === "unavailable") {
+              return new Response("Service Unavailable", { status: 503 });
+            }
+
+            let timer: ReturnType<typeof setInterval> | null = null;
+            let inFlight = false;
+            let closed = false;
+            const stream = new ReadableStream<Uint8Array>({
+              start(controller) {
+                const close = () => {
+                  if (closed) return;
+                  closed = true;
+                  if (timer) clearInterval(timer);
+                  timer = null;
+                  try {
+                    controller.close();
+                  } catch {
+                    /* already closed */
+                  }
+                };
+                const emit = (event: string, data: unknown) => {
+                  if (closed) return;
+                  try {
+                    controller.enqueue(
+                      encoder.encode(`event: ${event}\ndata: ${JSON.stringify(data)}\n\n`),
+                    );
+                  } catch {
+                    // client went away mid-enqueue — stop polling immediately
+                    close();
+                  }
+                };
+                emit("open", { shortId: screenShortId });
+                if (first.kind === "frame") {
+                  emit("screen", { screen: first.screen, ts: Date.now() });
                 }
-              };
-              const emit = (event: string, data: unknown) => {
-                if (closed) return;
+                // Backpressure: skip the tick while a poll is in flight (a slow
+                // `claude logs` never queues a pile-up — intermediate frames are
+                // simply never produced; the next completed poll diffs against
+                // the latest screen).
+                const pump = () => {
+                  if (inFlight || closed) return;
+                  inFlight = true;
+                  void (async () => {
+                    try {
+                      const res = await poller.poll();
+                      if (closed) return;
+                      if (res.kind === "frame") {
+                        emit("screen", { screen: res.screen, ts: Date.now() });
+                      } else if (res.kind === "gone") {
+                        emit("gone", { reason: res.reason });
+                        close();
+                      } else if (res.kind === "unavailable") {
+                        emit("unavailable", { reason: res.reason });
+                        close();
+                      }
+                      // "unchanged" → nothing on the wire (change-driven); the
+                      // client derives the frozen-screen age from its own clock.
+                    } catch {
+                      close();
+                    } finally {
+                      inFlight = false;
+                    }
+                  })();
+                };
+                timer = setInterval(pump, screenPollMs);
+                // Interval cleanup on client abort — Bun fires req.signal when
+                // the EventSource disconnects, in addition to stream cancel().
+                // CTL-967 SIDE-AC: guard against req.signal already being aborted
+                // at registration time (race between stream setup and client
+                // disconnect) — call close() immediately rather than leaking the
+                // interval.
+                if (req.signal.aborted) {
+                  close();
+                } else {
+                  req.signal.addEventListener("abort", close);
+                }
+              },
+              cancel() {
+                closed = true;
+                if (timer) clearInterval(timer);
+                timer = null;
+              },
+            });
+            return new Response(stream, {
+              headers: {
+                "Content-Type": "text/event-stream",
+                "Cache-Control": "no-cache",
+                Connection: "keep-alive",
+                "Access-Control-Allow-Origin": "*",
+              },
+            });
+          }
+
+          if (url.pathname === "/api/board") {
+            return Response.json(decorateBoard(await boardSnapshot.getLatest()));
+          }
+
+          // CTL-733: SSE push of the shared board snapshot. The client (Board.tsx /
+          // the board SharedWorker) opens ONE of these and receives a `board` event
+          // on connect and on every reactive recompute — no per-tab polling.
+          if (url.pathname === "/api/board/stream") {
+            let unsubscribe: (() => void) | null = null;
+            let closed = false;
+            const send = (
+              controller: ReadableStreamDefaultController<Uint8Array>,
+              snap: BoardPayload,
+            ) => {
+              if (closed) return;
+              try {
+                controller.enqueue(
+                  encoder.encode(`event: board\ndata: ${JSON.stringify(decorateBoard(snap))}\n\n`),
+                );
+              } catch {
+                // client went away between recompute and enqueue
+                unsubscribe?.();
+                unsubscribe = null;
+              }
+            };
+            const stream = new ReadableStream<Uint8Array>({
+              async start(controller) {
+                // subscribe first so no recompute is missed between bootstrap + subscribe
+                unsubscribe = boardSnapshot.subscribe((snap) => send(controller, snap));
+                try {
+                  send(controller, await boardSnapshot.getLatest());
+                } catch (err) {
+                  console.error(`[server] board stream initial snapshot failed:`, err);
+                }
+              },
+              cancel() {
+                closed = true;
+                unsubscribe?.();
+                unsubscribe = null;
+              },
+            });
+            return new Response(stream, {
+              headers: {
+                "Content-Type": "text/event-stream",
+                "Cache-Control": "no-cache",
+                Connection: "keep-alive",
+                "Access-Control-Allow-Origin": "*",
+              },
+            });
+          }
+
+          // CTL-896 (SHELL6): the nav-signal projection — worker count, queue depth,
+          // board anomaly, and the daemon-health dot — as a single one-shot read for
+          // the warm paint + the SSE reconcile. Derived off the SAME shared board
+          // snapshot the board endpoints serve plus the local daemon health; NEVER a
+          // synchronous per-request scan of the source signal files.
+          if (url.pathname === "/api/nav") {
+            return Response.json(await assembleNavSignal(await boardSnapshot.getLatest()));
+          }
+
+          // CTL-896 (SHELL6): SSE push of the nav signal. The rail opens ONE of these
+          // and receives a `nav` event on connect and on every reactive board
+          // recompute — the live badges update without a page reload and WITHOUT
+          // per-tab polling of the source files (Gherkin: "Live without thrash").
+          if (url.pathname === "/api/nav/stream") {
+            let unsubscribe: (() => void) | null = null;
+            let closed = false;
+            const sendNav = (
+              controller: ReadableStreamDefaultController<Uint8Array>,
+              signal: NavSignal,
+            ) => {
+              if (closed) return;
+              try {
+                controller.enqueue(
+                  encoder.encode(`event: nav\ndata: ${JSON.stringify(signal)}\n\n`),
+                );
+              } catch {
+                unsubscribe?.();
+                unsubscribe = null;
+              }
+            };
+            const stream = new ReadableStream<Uint8Array>({
+              async start(controller) {
+                // subscribe first so no recompute is missed between bootstrap +
+                // subscribe; each board frame is projected into a nav signal (the
+                // daemon health is re-read per frame so the dot tracks heartbeats).
+                unsubscribe = boardSnapshot.subscribe((snap) => {
+                  void assembleNavSignal(snap).then((signal) => sendNav(controller, signal));
+                });
+                try {
+                  sendNav(controller, await assembleNavSignal(await boardSnapshot.getLatest()));
+                } catch (err) {
+                  console.error(`[server] nav stream initial signal failed:`, err);
+                }
+              },
+              cancel() {
+                closed = true;
+                unsubscribe?.();
+                unsubscribe = null;
+              },
+            });
+            return new Response(stream, {
+              headers: {
+                "Content-Type": "text/event-stream",
+                "Cache-Control": "no-cache",
+                Connection: "keep-alive",
+                "Access-Control-Allow-Origin": "*",
+              },
+            });
+          }
+
+          // CTL-898 (SHELL8): the per-node cluster-health signal — one {host,status}
+          // per running node + the single-host flag — as a one-shot read for the
+          // footer's warm paint + the SSE reconcile. Projected off the SAME shared
+          // board snapshot the board/nav endpoints serve plus the cluster view's
+          // owner_host grouping + heartbeat liveness; NEVER a per-request scan.
+          // Single-host is the exact identity no-op (one node, the local daemon).
+          if (url.pathname === "/api/cluster") {
+            return Response.json(await assembleClusterSignal(await boardSnapshot.getLatest()));
+          }
+
+          // CTL-1092 (Phase 5): per-node capacity change history from the event log.
+          // Read-only; no writes. Scans the current-month JSONL for capacity events.
+          if (url.pathname === "/api/capacity-history") {
+            const month = new Date().toISOString().slice(0, 7); // YYYY-MM
+            const capLogPath = join(CATALYST_DIR, "events", `${month}.jsonl`);
+            const data = readCapacityHistory({ logPath: capLogPath });
+            return Response.json({ data });
+          }
+
+          // CTL-898 (SHELL8): SSE push of the cluster signal. The footer opens ONE
+          // of these and receives a `cluster` event on connect and on every reactive
+          // board recompute — a node going dark past its grace window flips its dot
+          // to offline WITHOUT a page reload and WITHOUT per-tab polling of the
+          // source files (Gherkin: "A node going dark is reflected").
+          if (url.pathname === "/api/cluster/stream") {
+            let unsubscribe: (() => void) | null = null;
+            let closed = false;
+            const sendCluster = (
+              controller: ReadableStreamDefaultController<Uint8Array>,
+              signal: ClusterSignal,
+            ) => {
+              if (closed) return;
+              try {
+                controller.enqueue(
+                  encoder.encode(`event: cluster\ndata: ${JSON.stringify(signal)}\n\n`),
+                );
+              } catch {
+                unsubscribe?.();
+                unsubscribe = null;
+              }
+            };
+            const stream = new ReadableStream<Uint8Array>({
+              async start(controller) {
+                // subscribe first so no recompute is missed between bootstrap +
+                // subscribe; each board frame is projected into a cluster signal
+                // (the heartbeat liveness is re-classified per frame so a node going
+                // dark surfaces without a reload).
+                unsubscribe = boardSnapshot.subscribe((snap) => {
+                  void assembleClusterSignal(snap).then((signal) =>
+                    sendCluster(controller, signal),
+                  );
+                });
+                try {
+                  sendCluster(
+                    controller,
+                    await assembleClusterSignal(await boardSnapshot.getLatest()),
+                  );
+                } catch (err) {
+                  console.error(`[server] cluster stream initial signal failed:`, err);
+                }
+              },
+              cancel() {
+                closed = true;
+                unsubscribe?.();
+                unsubscribe = null;
+              },
+            });
+            return new Response(stream, {
+              headers: {
+                "Content-Type": "text/event-stream",
+                "Cache-Control": "no-cache",
+                Connection: "keep-alive",
+                "Access-Control-Allow-Origin": "*",
+              },
+            });
+          }
+
+          // CTL-1167: serve the VAPID public key so the browser can build the
+          // applicationServerKey for pushManager.subscribe(). 503 when push was
+          // never initialized for this server instance (push not configured).
+          if (url.pathname === "/api/notifications/vapid-public-key") {
+            if (!vapidKeys) {
+              return new Response("push not configured", { status: 503 });
+            }
+            return new Response(vapidKeys.publicKey, {
+              headers: { "Content-Type": "text/plain" },
+            });
+          }
+
+          // CTL-1167: persist a browser push subscription (POST body is the
+          // serialised PushSubscription JSON from the browser). Returns 201 on
+          // success; 400 on missing/invalid fields.
+          if (url.pathname === "/api/notifications/subscribe" && req.method === "POST") {
+            if (!vapidKeys) {
+              return new Response("push not configured", { status: 503 });
+            }
+            let body: unknown;
+            try {
+              body = await req.json();
+            } catch {
+              return new Response("invalid JSON", { status: 400 });
+            }
+            const sub = body as Record<string, unknown>;
+            const keys = sub?.keys as Record<string, unknown> | undefined;
+            if (
+              typeof sub?.endpoint !== "string" ||
+              !sub.endpoint ||
+              typeof keys?.p256dh !== "string" ||
+              !keys.p256dh ||
+              typeof keys?.auth !== "string" ||
+              !keys.auth
+            ) {
+              return new Response("missing endpoint, keys.p256dh or keys.auth", {
+                status: 400,
+              });
+            }
+            pushStore.upsertSubscription({
+              endpoint: sub.endpoint,
+              keys: { p256dh: keys.p256dh, auth: keys.auth },
+            });
+            return new Response(null, { status: 201 });
+          }
+
+          // CTL-1167: SSE stream of novel push-worthy notifications. Mirrors
+          // /api/nav/stream: one per-connection projector, subscribe-first, emit on
+          // every board recompute that yields new notifications. Each event:
+          //   event: notification\ndata: {title,body,deepLink}\n\n
+          if (url.pathname === "/api/notifications/stream") {
+            let unsubNotif: (() => void) | null = null;
+            let closedNotif = false;
+            const notifProjector = createNotificationProjector({
+              daemonNotifyHoldMs,
+            });
+            const emitNotifications = (
+              controller: ReadableStreamDefaultController<Uint8Array>,
+              pb: ProjectorBoard,
+            ) => {
+              if (closedNotif) return;
+              for (const n of notifProjector.project(pb)) {
+                try {
+                  controller.enqueue(
+                    encoder.encode(`event: notification\ndata: ${JSON.stringify(n)}\n\n`),
+                  );
+                } catch {
+                  unsubNotif?.();
+                  unsubNotif = null;
+                }
+              }
+            };
+            const notifStream = new ReadableStream<Uint8Array>({
+              async start(controller) {
+                // Emit an immediate `open` frame so the connection is live even
+                // when the fleet yields no notifications. Without a first chunk,
+                // Bun does not resolve fetch()'s response headers (the client —
+                // and the route tests — would hang). Mirrors /api/beliefs/stream.
                 try {
                   controller.enqueue(
                     encoder.encode(
-                      `event: ${event}\ndata: ${JSON.stringify(data)}\n\n`,
+                      `event: open\ndata: ${JSON.stringify({ source: "notifications" })}\n\n`,
                     ),
                   );
                 } catch {
-                  // client went away mid-enqueue — stop polling immediately
-                  close();
+                  closedNotif = true;
+                  return;
                 }
-              };
-              emit("open", { shortId: screenShortId });
-              if (first.kind === "frame") {
-                emit("screen", { screen: first.screen, ts: Date.now() });
-              }
-              // Backpressure: skip the tick while a poll is in flight (a slow
-              // `claude logs` never queues a pile-up — intermediate frames are
-              // simply never produced; the next completed poll diffs against
-              // the latest screen).
-              const pump = () => {
-                if (inFlight || closed) return;
-                inFlight = true;
-                void (async () => {
-                  try {
-                    const res = await poller.poll();
-                    if (closed) return;
-                    if (res.kind === "frame") {
-                      emit("screen", { screen: res.screen, ts: Date.now() });
-                    } else if (res.kind === "gone") {
-                      emit("gone", { reason: res.reason });
-                      close();
-                    } else if (res.kind === "unavailable") {
-                      emit("unavailable", { reason: res.reason });
-                      close();
-                    }
-                    // "unchanged" → nothing on the wire (change-driven); the
-                    // client derives the frozen-screen age from its own clock.
-                  } catch {
-                    close();
-                  } finally {
-                    inFlight = false;
-                  }
-                })();
-              };
-              timer = setInterval(pump, screenPollMs);
-              // Interval cleanup on client abort — Bun fires req.signal when
-              // the EventSource disconnects, in addition to stream cancel().
-              // CTL-967 SIDE-AC: guard against req.signal already being aborted
-              // at registration time (race between stream setup and client
-              // disconnect) — call close() immediately rather than leaking the
-              // interval.
-              if (req.signal.aborted) {
-                close();
-              } else {
-                req.signal.addEventListener("abort", close);
-              }
-            },
-            cancel() {
-              closed = true;
-              if (timer) clearInterval(timer);
-              timer = null;
-            },
-          });
-          return new Response(stream, {
-            headers: {
-              "Content-Type": "text/event-stream",
-              "Cache-Control": "no-cache",
-              Connection: "keep-alive",
-              "Access-Control-Allow-Origin": "*",
-            },
-          });
-        }
-
-        if (url.pathname === "/api/board") {
-          return Response.json(decorateBoard(await boardSnapshot.getLatest()));
-        }
-
-        // CTL-733: SSE push of the shared board snapshot. The client (Board.tsx /
-        // the board SharedWorker) opens ONE of these and receives a `board` event
-        // on connect and on every reactive recompute — no per-tab polling.
-        if (url.pathname === "/api/board/stream") {
-          let unsubscribe: (() => void) | null = null;
-          let closed = false;
-          const send = (
-            controller: ReadableStreamDefaultController<Uint8Array>,
-            snap: BoardPayload,
-          ) => {
-            if (closed) return;
-            try {
-              controller.enqueue(
-                encoder.encode(
-                  `event: board\ndata: ${JSON.stringify(decorateBoard(snap))}\n\n`,
-                ),
-              );
-            } catch {
-              // client went away between recompute and enqueue
-              unsubscribe?.();
-              unsubscribe = null;
-            }
-          };
-          const stream = new ReadableStream<Uint8Array>({
-            async start(controller) {
-              // subscribe first so no recompute is missed between bootstrap + subscribe
-              unsubscribe = boardSnapshot.subscribe((snap) => send(controller, snap));
-              try {
-                send(controller, await boardSnapshot.getLatest());
-              } catch (err) {
-                console.error(`[server] board stream initial snapshot failed:`, err);
-              }
-            },
-            cancel() {
-              closed = true;
-              unsubscribe?.();
-              unsubscribe = null;
-            },
-          });
-          return new Response(stream, {
-            headers: {
-              "Content-Type": "text/event-stream",
-              "Cache-Control": "no-cache",
-              Connection: "keep-alive",
-              "Access-Control-Allow-Origin": "*",
-            },
-          });
-        }
-
-        // CTL-896 (SHELL6): the nav-signal projection — worker count, queue depth,
-        // board anomaly, and the daemon-health dot — as a single one-shot read for
-        // the warm paint + the SSE reconcile. Derived off the SAME shared board
-        // snapshot the board endpoints serve plus the local daemon health; NEVER a
-        // synchronous per-request scan of the source signal files.
-        if (url.pathname === "/api/nav") {
-          return Response.json(
-            await assembleNavSignal(await boardSnapshot.getLatest()),
-          );
-        }
-
-        // CTL-896 (SHELL6): SSE push of the nav signal. The rail opens ONE of these
-        // and receives a `nav` event on connect and on every reactive board
-        // recompute — the live badges update without a page reload and WITHOUT
-        // per-tab polling of the source files (Gherkin: "Live without thrash").
-        if (url.pathname === "/api/nav/stream") {
-          let unsubscribe: (() => void) | null = null;
-          let closed = false;
-          const sendNav = (
-            controller: ReadableStreamDefaultController<Uint8Array>,
-            signal: NavSignal,
-          ) => {
-            if (closed) return;
-            try {
-              controller.enqueue(
-                encoder.encode(`event: nav\ndata: ${JSON.stringify(signal)}\n\n`),
-              );
-            } catch {
-              unsubscribe?.();
-              unsubscribe = null;
-            }
-          };
-          const stream = new ReadableStream<Uint8Array>({
-            async start(controller) {
-              // subscribe first so no recompute is missed between bootstrap +
-              // subscribe; each board frame is projected into a nav signal (the
-              // daemon health is re-read per frame so the dot tracks heartbeats).
-              unsubscribe = boardSnapshot.subscribe((snap) => {
-                void assembleNavSignal(snap).then((signal) =>
-                  sendNav(controller, signal),
-                );
-              });
-              try {
-                sendNav(
-                  controller,
-                  await assembleNavSignal(await boardSnapshot.getLatest()),
-                );
-              } catch (err) {
-                console.error(`[server] nav stream initial signal failed:`, err);
-              }
-            },
-            cancel() {
-              closed = true;
-              unsubscribe?.();
-              unsubscribe = null;
-            },
-          });
-          return new Response(stream, {
-            headers: {
-              "Content-Type": "text/event-stream",
-              "Cache-Control": "no-cache",
-              Connection: "keep-alive",
-              "Access-Control-Allow-Origin": "*",
-            },
-          });
-        }
-
-        // CTL-898 (SHELL8): the per-node cluster-health signal — one {host,status}
-        // per running node + the single-host flag — as a one-shot read for the
-        // footer's warm paint + the SSE reconcile. Projected off the SAME shared
-        // board snapshot the board/nav endpoints serve plus the cluster view's
-        // owner_host grouping + heartbeat liveness; NEVER a per-request scan.
-        // Single-host is the exact identity no-op (one node, the local daemon).
-        if (url.pathname === "/api/cluster") {
-          return Response.json(
-            await assembleClusterSignal(await boardSnapshot.getLatest()),
-          );
-        }
-
-        // CTL-1092 (Phase 5): per-node capacity change history from the event log.
-        // Read-only; no writes. Scans the current-month JSONL for capacity events.
-        if (url.pathname === "/api/capacity-history") {
-          const month = new Date().toISOString().slice(0, 7); // YYYY-MM
-          const capLogPath = join(CATALYST_DIR, "events", `${month}.jsonl`);
-          const data = readCapacityHistory({ logPath: capLogPath });
-          return Response.json({ data });
-        }
-
-        // CTL-898 (SHELL8): SSE push of the cluster signal. The footer opens ONE
-        // of these and receives a `cluster` event on connect and on every reactive
-        // board recompute — a node going dark past its grace window flips its dot
-        // to offline WITHOUT a page reload and WITHOUT per-tab polling of the
-        // source files (Gherkin: "A node going dark is reflected").
-        if (url.pathname === "/api/cluster/stream") {
-          let unsubscribe: (() => void) | null = null;
-          let closed = false;
-          const sendCluster = (
-            controller: ReadableStreamDefaultController<Uint8Array>,
-            signal: ClusterSignal,
-          ) => {
-            if (closed) return;
-            try {
-              controller.enqueue(
-                encoder.encode(
-                  `event: cluster\ndata: ${JSON.stringify(signal)}\n\n`,
-                ),
-              );
-            } catch {
-              unsubscribe?.();
-              unsubscribe = null;
-            }
-          };
-          const stream = new ReadableStream<Uint8Array>({
-            async start(controller) {
-              // subscribe first so no recompute is missed between bootstrap +
-              // subscribe; each board frame is projected into a cluster signal
-              // (the heartbeat liveness is re-classified per frame so a node going
-              // dark surfaces without a reload).
-              unsubscribe = boardSnapshot.subscribe((snap) => {
-                void assembleClusterSignal(snap).then((signal) =>
-                  sendCluster(controller, signal),
-                );
-              });
-              try {
-                sendCluster(
-                  controller,
-                  await assembleClusterSignal(await boardSnapshot.getLatest()),
-                );
-              } catch (err) {
-                console.error(
-                  `[server] cluster stream initial signal failed:`,
-                  err,
-                );
-              }
-            },
-            cancel() {
-              closed = true;
-              unsubscribe?.();
-              unsubscribe = null;
-            },
-          });
-          return new Response(stream, {
-            headers: {
-              "Content-Type": "text/event-stream",
-              "Cache-Control": "no-cache",
-              Connection: "keep-alive",
-              "Access-Control-Allow-Origin": "*",
-            },
-          });
-        }
-
-        // CTL-1167: serve the VAPID public key so the browser can build the
-        // applicationServerKey for pushManager.subscribe(). 503 when push was
-        // never initialized for this server instance (push not configured).
-        if (url.pathname === "/api/notifications/vapid-public-key") {
-          if (!vapidKeys) {
-            return new Response("push not configured", { status: 503 });
-          }
-          return new Response(vapidKeys.publicKey, {
-            headers: { "Content-Type": "text/plain" },
-          });
-        }
-
-        // CTL-1167: persist a browser push subscription (POST body is the
-        // serialised PushSubscription JSON from the browser). Returns 201 on
-        // success; 400 on missing/invalid fields.
-        if (url.pathname === "/api/notifications/subscribe" && req.method === "POST") {
-          if (!vapidKeys) {
-            return new Response("push not configured", { status: 503 });
-          }
-          let body: unknown;
-          try {
-            body = await req.json();
-          } catch {
-            return new Response("invalid JSON", { status: 400 });
-          }
-          const sub = body as Record<string, unknown>;
-          const keys = sub?.keys as Record<string, unknown> | undefined;
-          if (
-            typeof sub?.endpoint !== "string" ||
-            !sub.endpoint ||
-            typeof keys?.p256dh !== "string" ||
-            !keys.p256dh ||
-            typeof keys?.auth !== "string" ||
-            !keys.auth
-          ) {
-            return new Response("missing endpoint, keys.p256dh or keys.auth", {
-              status: 400,
-            });
-          }
-          pushStore.upsertSubscription({
-            endpoint: sub.endpoint,
-            keys: { p256dh: keys.p256dh, auth: keys.auth },
-          });
-          return new Response(null, { status: 201 });
-        }
-
-        // CTL-1167: SSE stream of novel push-worthy notifications. Mirrors
-        // /api/nav/stream: one per-connection projector, subscribe-first, emit on
-        // every board recompute that yields new notifications. Each event:
-        //   event: notification\ndata: {title,body,deepLink}\n\n
-        if (url.pathname === "/api/notifications/stream") {
-          let unsubNotif: (() => void) | null = null;
-          let closedNotif = false;
-          const notifProjector = createNotificationProjector({
-            daemonNotifyHoldMs,
-          });
-          const emitNotifications = (
-            controller: ReadableStreamDefaultController<Uint8Array>,
-            pb: ProjectorBoard,
-          ) => {
-            if (closedNotif) return;
-            for (const n of notifProjector.project(pb)) {
-              try {
-                controller.enqueue(
-                  encoder.encode(
-                    `event: notification\ndata: ${JSON.stringify(n)}\n\n`,
-                  ),
-                );
-              } catch {
+                unsubNotif = boardSnapshot.subscribe((snap) => {
+                  // Fire-and-forget projection: a rejected chain here would become
+                  // an unhandled rejection (and stall bun:test), so swallow it.
+                  void toProjectorBoard(snap)
+                    .then((pb) => emitNotifications(controller, pb))
+                    .catch((err) => {
+                      console.error(`[server] notifications stream projection failed:`, err);
+                    });
+                });
+                try {
+                  emitNotifications(
+                    controller,
+                    await toProjectorBoard(await boardSnapshot.getLatest()),
+                  );
+                } catch (err) {
+                  console.error(`[server] notifications stream initial emit failed:`, err);
+                }
+              },
+              cancel() {
+                closedNotif = true;
                 unsubNotif?.();
                 unsubNotif = null;
-              }
-            }
-          };
-          const notifStream = new ReadableStream<Uint8Array>({
-            async start(controller) {
-              // Emit an immediate `open` frame so the connection is live even
-              // when the fleet yields no notifications. Without a first chunk,
-              // Bun does not resolve fetch()'s response headers (the client —
-              // and the route tests — would hang). Mirrors /api/beliefs/stream.
-              try {
-                controller.enqueue(
-                  encoder.encode(
-                    `event: open\ndata: ${JSON.stringify({ source: "notifications" })}\n\n`,
-                  ),
-                );
-              } catch {
-                closedNotif = true;
-                return;
-              }
-              unsubNotif = boardSnapshot.subscribe((snap) => {
-                // Fire-and-forget projection: a rejected chain here would become
-                // an unhandled rejection (and stall bun:test), so swallow it.
-                void toProjectorBoard(snap)
-                  .then((pb) => emitNotifications(controller, pb))
-                  .catch((err) => {
-                    console.error(
-                      `[server] notifications stream projection failed:`,
-                      err,
-                    );
-                  });
-              });
-              try {
-                emitNotifications(
-                  controller,
-                  await toProjectorBoard(await boardSnapshot.getLatest()),
-                );
-              } catch (err) {
-                console.error(`[server] notifications stream initial emit failed:`, err);
-              }
-            },
-            cancel() {
-              closedNotif = true;
-              unsubNotif?.();
-              unsubNotif = null;
-            },
-          });
-          return new Response(notifStream, {
-            headers: {
-              "Content-Type": "text/event-stream",
-              "Cache-Control": "no-cache",
-              Connection: "keep-alive",
-              "Access-Control-Allow-Origin": "*",
-            },
-          });
-        }
-
-        // CTL-967 (N5): read-only SSE feed of new belief rows from
-        // ~/catalyst/beliefs.db, tailed by a BeliefTail cursor. Each SSE
-        // event carries a single belief row (joined with tick.ts_ms/host) in
-        // the FiringFeed shape the Rules Explorer expects. The BeliefTail
-        // module is imported via a COMPUTED specifier so bun:sqlite never
-        // enters the vite/esbuild graph (same guard as linear-cache-reader).
-        // Graceful degradation: if beliefs.db is absent (shadow off), the
-        // endpoint emits only an `open` frame and stays alive — no crash.
-        if (url.pathname === "/api/beliefs/stream") {
-          // COMPUTED specifier — DO NOT inline to a literal (see belief-reader.mjs
-          // header and the CTL-883/vite-config-bun-sqlite trap notes).
-          const beliefReaderModule = [".", "lib", "belief-reader.mjs"].join("/");
-          let tail: {
-            poll(): Promise<unknown[]>;
-            close(): void;
-          } | null = null;
-          try {
-            const mod = await import(beliefReaderModule) as {
-              BeliefTail: new (opts?: { dbPath?: string; pageSize?: number }) => {
-                poll(): Promise<unknown[]>;
-                close(): void;
-              };
-            };
-            tail = new mod.BeliefTail();
-          } catch {
-            // module or bun:sqlite unavailable — degrade to null tail
-            tail = null;
+              },
+            });
+            return new Response(notifStream, {
+              headers: {
+                "Content-Type": "text/event-stream",
+                "Cache-Control": "no-cache",
+                Connection: "keep-alive",
+                "Access-Control-Allow-Origin": "*",
+              },
+            });
           }
 
-          let timer: ReturnType<typeof setInterval> | null = null;
-          let inFlight = false;
-          let closed = false;
-          const stream = new ReadableStream<Uint8Array>({
-            start(controller) {
-              const close = () => {
-                if (closed) return;
+          // CTL-967 (N5): read-only SSE feed of new belief rows from
+          // ~/catalyst/beliefs.db, tailed by a BeliefTail cursor. Each SSE
+          // event carries a single belief row (joined with tick.ts_ms/host) in
+          // the FiringFeed shape the Rules Explorer expects. The BeliefTail
+          // module is imported via a COMPUTED specifier so bun:sqlite never
+          // enters the vite/esbuild graph (same guard as linear-cache-reader).
+          // Graceful degradation: if beliefs.db is absent (shadow off), the
+          // endpoint emits only an `open` frame and stays alive — no crash.
+          if (url.pathname === "/api/beliefs/stream") {
+            // COMPUTED specifier — DO NOT inline to a literal (see belief-reader.mjs
+            // header and the CTL-883/vite-config-bun-sqlite trap notes).
+            const beliefReaderModule = [".", "lib", "belief-reader.mjs"].join("/");
+            let tail: {
+              poll(): Promise<unknown[]>;
+              close(): void;
+            } | null = null;
+            try {
+              const mod = (await import(beliefReaderModule)) as {
+                BeliefTail: new (opts?: { dbPath?: string; pageSize?: number }) => {
+                  poll(): Promise<unknown[]>;
+                  close(): void;
+                };
+              };
+              tail = new mod.BeliefTail();
+            } catch {
+              // module or bun:sqlite unavailable — degrade to null tail
+              tail = null;
+            }
+
+            let timer: ReturnType<typeof setInterval> | null = null;
+            let inFlight = false;
+            let closed = false;
+            const stream = new ReadableStream<Uint8Array>({
+              start(controller) {
+                const close = () => {
+                  if (closed) return;
+                  closed = true;
+                  if (timer) clearInterval(timer);
+                  timer = null;
+                  tail?.close();
+                  tail = null;
+                  try {
+                    controller.close();
+                  } catch {
+                    /* already closed */
+                  }
+                };
+                // Open frame so the client knows the connection is live even
+                // when beliefs.db is absent or the db has no new rows yet.
+                try {
+                  controller.enqueue(
+                    encoder.encode(
+                      `event: open\ndata: ${JSON.stringify({ source: "beliefs" })}\n\n`,
+                    ),
+                  );
+                } catch {
+                  closed = true;
+                  return;
+                }
+                const pump = () => {
+                  if (inFlight || closed || !tail) return;
+                  inFlight = true;
+                  void (async () => {
+                    try {
+                      const rows = await tail.poll();
+                      if (closed) return;
+                      for (const row of rows) {
+                        controller.enqueue(
+                          encoder.encode(`event: belief\ndata: ${JSON.stringify(row)}\n\n`),
+                        );
+                      }
+                    } catch {
+                      // client likely went away mid-enqueue; stop pumping
+                      close();
+                    } finally {
+                      inFlight = false;
+                    }
+                  })();
+                };
+                pump();
+                timer = setInterval(pump, 1000);
+                // Cleanup on client abort. Guard against already-aborted signal
+                // (same pattern as the screen SSE endpoint — CTL-967 SIDE-AC).
+                if (req.signal.aborted) {
+                  close();
+                } else {
+                  req.signal.addEventListener("abort", close);
+                }
+              },
+              cancel() {
                 closed = true;
                 if (timer) clearInterval(timer);
                 timer = null;
                 tail?.close();
                 tail = null;
-                try {
-                  controller.close();
-                } catch {
-                  /* already closed */
-                }
-              };
-              // Open frame so the client knows the connection is live even
-              // when beliefs.db is absent or the db has no new rows yet.
-              try {
-                controller.enqueue(
-                  encoder.encode(`event: open\ndata: ${JSON.stringify({ source: "beliefs" })}\n\n`),
-                );
-              } catch {
-                closed = true;
-                return;
-              }
-              const pump = () => {
-                if (inFlight || closed || !tail) return;
-                inFlight = true;
-                void (async () => {
-                  try {
-                    const rows = await tail.poll();
-                    if (closed) return;
-                    for (const row of rows) {
-                      controller.enqueue(
-                        encoder.encode(
-                          `event: belief\ndata: ${JSON.stringify(row)}\n\n`,
-                        ),
-                      );
-                    }
-                  } catch {
-                    // client likely went away mid-enqueue; stop pumping
-                    close();
-                  } finally {
-                    inFlight = false;
-                  }
-                })();
-              };
-              pump();
-              timer = setInterval(pump, 1000);
-              // Cleanup on client abort. Guard against already-aborted signal
-              // (same pattern as the screen SSE endpoint — CTL-967 SIDE-AC).
-              if (req.signal.aborted) {
-                close();
-              } else {
-                req.signal.addEventListener("abort", close);
-              }
-            },
-            cancel() {
-              closed = true;
-              if (timer) clearInterval(timer);
-              timer = null;
-              tail?.close();
-              tail = null;
-            },
-          });
-          return new Response(stream, {
-            headers: {
-              "Content-Type": "text/event-stream",
-              "Cache-Control": "no-cache",
-              Connection: "keep-alive",
-              "Access-Control-Allow-Origin": "*",
-            },
-          });
-        }
-
-        // ── CTL-1100 governance read endpoints ──────────────────────────────
-        // Inserted between the /api/beliefs/stream block and the 404 fallthrough.
-        // Re-locate by grep after each insertion — line numbers shift.
-
-        // GET /api/cluster/governance — per-host governance snapshot from the
-        // heartbeat event log (CTL-1104). Separate from /api/governance (local
-        // config snapshot, CTL-1100) — see plan §open-question 3. DO NOT inline
-        // the specifier (VITE-GRAPH GUARD, CTL-883).
-        if (url.pathname === "/api/cluster/governance") {
-          const govSpecifier = ["./lib/cluster-governance.mjs"].join("");
-          try {
-            const { readClusterGovernance } = await import(govSpecifier) as {
-              readClusterGovernance: () => Record<string, unknown>;
-            };
-            // CTL-1232: readClusterGovernance() full-reads the current-month log
-            // (no ring, no cache) on every hit — the OBSERVE FleetOps surface
-            // polls this every 15s. Count it so /debug/memory can attribute the
-            // RSS ratchet to this path.
-            const _govT0 = performance.now();
-            const gov = readClusterGovernance();
-            recordFullRead("governance", 0, performance.now() - _govT0);
-            return Response.json(gov);
-          } catch {
-            return Response.json({ singleHost: true, nodes: [], generatedAt: "" });
-          }
-        }
-
-        // GET /api/governance — current daemon governance config snapshot.
-        // DO NOT inline the specifier (computed import, VITE-GRAPH GUARD, CTL-883).
-        if (url.pathname === "/api/governance") {
-          const configSpecifier = ["../execution-core/config.mjs"].join("");
-          try {
-            const { readGovernanceConfig } = await import(configSpecifier) as {
-              readGovernanceConfig: (env?: NodeJS.ProcessEnv) => Record<string, unknown>;
-            };
-            return Response.json({ available: true, ...readGovernanceConfig() });
-          } catch {
-            return Response.json({ available: false });
-          }
-        }
-
-        if (url.pathname === "/api/fsm/descriptor") {
-          return Response.json(await buildFsmDescriptor());
-        }
-
-        // GET /api/beliefs/rules — served from frozen RULE_MANIFEST; no db required.
-        if (url.pathname === "/api/beliefs/rules") {
-          const govDeps = await loadGovernanceDeps();
-          const manifest = govDeps?.RULE_MANIFEST ?? null;
-          if (!manifest) return Response.json({ rules: [], strata: [] });
-          return Response.json(manifest);
-        }
-
-        // GET /api/beliefs/summary — latest-tick aggregate per belief name.
-        if (url.pathname === "/api/beliefs/summary") {
-          const dbPath = govDbPath();
-          const govDeps = await loadGovernanceDeps();
-          if (!govDeps) return Response.json({ tickId: null, rows: [] });
-          return Response.json(
-            await govDeps.withBeliefsDbRO(dbPath, (db) => beliefSummary(db), { tickId: null, rows: [] })
-          );
-        }
-
-        // GET /api/beliefs/rates — full belief counts per rule_id per tick (LRU cached).
-        if (url.pathname === "/api/beliefs/rates") {
-          const dbPath = govDbPath();
-          const govDeps = await loadGovernanceDeps();
-          if (!govDeps) return Response.json({ maxTick: null, rows: [] });
-          return Response.json(
-            await govDeps.withBeliefsDbRO(dbPath, (db) => beliefRates(db, beliefRatesCache), { maxTick: null, rows: [] })
-          );
-        }
-
-        // GET /api/beliefs/recent — newest-first belief rows, limit param.
-        if (url.pathname === "/api/beliefs/recent") {
-          const dbPath = govDbPath();
-          const govDeps = await loadGovernanceDeps();
-          if (!govDeps) return Response.json({ rows: [] });
-          const limitParam = url.searchParams.get("limit");
-          const limit = limitParam ? Math.max(1, parseInt(limitParam, 10) || 50) : undefined;
-          return Response.json(
-            await govDeps.withBeliefsDbRO(dbPath, (db) => beliefRecent(db, { limit }), { rows: [] })
-          );
-        }
-
-        // GET /api/beliefs/cfg — static config rows from the beliefs store.
-        if (url.pathname === "/api/beliefs/cfg") {
-          const dbPath = govDbPath();
-          const govDeps = await loadGovernanceDeps();
-          if (!govDeps) return Response.json({ rows: [] });
-          return Response.json(
-            await govDeps.withBeliefsDbRO(dbPath, (db) => beliefCfg(db), { rows: [] })
-          );
-        }
-
-        // GET /api/beliefs/why?ticket=<ticket>[&tick=<tickId>]
-        // HTTP wrapper over traceTicket() — same resolver as `catalyst why`.
-        // Input validation (ticket required, /^[A-Za-z]+-\d+$/, tick must be
-        // integer) happens BEFORE any db touch so traversal attempts are
-        // rejected before reaching the db. Degrades to 200+empty trace when
-        // beliefs.db absent or unreadable (no 500).
-        // NOTE: DO NOT inline the specifier — computed import required (CTL-883).
-        if (url.pathname === "/api/beliefs/why") {
-          const rawTicket = url.searchParams.get("ticket");
-          if (!rawTicket) return new Response("ticket required", { status: 400 });
-          let ticket: string;
-          try {
-            ticket = decodeURIComponent(rawTicket);
-          } catch {
-            return new Response("invalid ticket encoding", { status: 400 });
-          }
-          if (!/^[A-Za-z]+-\d+$/.test(ticket)) {
-            return new Response("invalid ticket format", { status: 400 });
-          }
-          const rawTick = url.searchParams.get("tick");
-          let tickId: number | undefined;
-          if (rawTick != null) {
-            const parsed = parseInt(rawTick, 10);
-            if (!Number.isInteger(parsed) || String(parsed) !== rawTick.trim()) {
-              return new Response("tick must be an integer", { status: 400 });
-            }
-            tickId = parsed;
-          }
-          // DO NOT inline this specifier (VITE-GRAPH GUARD, CTL-883).
-          const whyMod = ["./lib/belief-why.mjs"].join("");
-          try {
-            const { traceTicketJson } = await import(whyMod) as {
-              traceTicketJson: (opts: { ticket: string; tickId?: number; dbPath: string }) => Promise<unknown>;
-            };
-            const trace = await traceTicketJson({ ticket, tickId, dbPath: govDbPath() });
-            return Response.json(trace);
-          } catch {
-            return Response.json({ ticket, tickId: null, beliefs: [] });
-          }
-        }
-
-        // CTL-935 Phase 5: GET /api/beliefs/report — weekly shadow disagreement report.
-        // ?sinceDays=7 (default 7, clamped to [1,90]). Degrades gracefully when
-        // beliefs.db is absent. DO NOT inline the specifier (VITE-GRAPH GUARD, CTL-883).
-        if (url.pathname === "/api/beliefs/report") {
-          const rawDays = url.searchParams.get("sinceDays");
-          let sinceDays = 7;
-          if (rawDays != null) {
-            const parsed = Number(rawDays);
-            if (!Number.isFinite(parsed) || parsed <= 0 || !Number.isInteger(parsed)) {
-              return new Response("sinceDays must be a positive integer", { status: 400 });
-            }
-            sinceDays = Math.min(Math.max(parsed, 1), 90);
-          }
-          const nowMs = Date.now();
-          const sinceMs = nowMs - sinceDays * 86_400_000;
-          const reportMod = ["./lib/belief-report.mjs"].join("");
-          try {
-            const { computeReportJson } = await import(reportMod) as {
-              computeReportJson: (opts: { dbPath: string; sinceMs: number; nowMs: number }) => Promise<unknown>;
-            };
-            const report = await computeReportJson({ dbPath: govDbPath(), sinceMs, nowMs });
-            return Response.json(report);
-          } catch (err) {
-            // CTL-935 remediate: tag the error-path payload as degraded so the
-            // flag-live helper / operator can tell a broken report (failed
-            // import, corrupt/locked db) from a legitimately quiet week. The
-            // shape stays well-formed (200) so existing consumers don't break.
-            return Response.json({
-              window: { sinceMs, nowMs, tickCount: 0, rulesShaSet: [], multipleRulesSha: false },
-              perRule: [], perGuard: [], replays: [],
-              degraded: true,
-              degradedReason: err instanceof Error ? err.message : String(err),
+              },
+            });
+            return new Response(stream, {
+              headers: {
+                "Content-Type": "text/event-stream",
+                "Cache-Control": "no-cache",
+                Connection: "keep-alive",
+                "Access-Control-Allow-Origin": "*",
+              },
             });
           }
-        }
 
-        // CTL-1232 (profiling): GET /debug/memory[?gc=1] — live memory breakdown.
-        // process.memoryUsage() (MB) + event-ring stats + cache sizes + the
-        // full-log readFileSync fallback counters (fullReadMetrics). With ?gc=1
-        // it forces a synchronous Bun.gc(true) and reports the freed deltas, to
-        // distinguish reclaimable JS-heap garbage from RSS-not-returned-to-the-OS
-        // (the sticky high-water from repeated large transient reads).
-        if (url.pathname === "/debug/memory") {
-          const toMB = (b: number): number => Math.round((b / 1048576) * 10) / 10;
-          const usageMB = (
-            u: ReturnType<typeof process.memoryUsage>,
-          ): Record<string, number> => ({
-            rss: toMB(u.rss),
-            heapTotal: toMB(u.heapTotal),
-            heapUsed: toMB(u.heapUsed),
-            external: toMB(u.external),
-            arrayBuffers: toMB(u.arrayBuffers),
-          });
-          const before = process.memoryUsage();
-          let afterGcMB: Record<string, number> | null = null;
-          let freedMB: Record<string, number> | null = null;
-          if (url.searchParams.get("gc") === "1") {
-            Bun.gc(true);
-            const after = process.memoryUsage();
-            afterGcMB = usageMB(after);
-            freedMB = {
-              rss: toMB(before.rss - after.rss),
-              heapTotal: toMB(before.heapTotal - after.heapTotal),
-              heapUsed: toMB(before.heapUsed - after.heapUsed),
-              external: toMB(before.external - after.external),
-              arrayBuffers: toMB(before.arrayBuffers - after.arrayBuffers),
-            };
+          // ── CTL-1100 governance read endpoints ──────────────────────────────
+          // Inserted between the /api/beliefs/stream block and the 404 fallthrough.
+          // Re-locate by grep after each insertion — line numbers shift.
+
+          // GET /api/cluster/governance — per-host governance snapshot from the
+          // heartbeat event log (CTL-1104). Separate from /api/governance (local
+          // config snapshot, CTL-1100) — see plan §open-question 3. DO NOT inline
+          // the specifier (VITE-GRAPH GUARD, CTL-883).
+          if (url.pathname === "/api/cluster/governance") {
+            const govSpecifier = ["./lib/cluster-governance.mjs"].join("");
+            try {
+              const { readClusterGovernance } = (await import(govSpecifier)) as {
+                readClusterGovernance: () => Record<string, unknown>;
+              };
+              // CTL-1232: readClusterGovernance() full-reads the current-month log
+              // (no ring, no cache) on every hit — the OBSERVE FleetOps surface
+              // polls this every 15s. Count it so /debug/memory can attribute the
+              // RSS ratchet to this path.
+              const _govT0 = performance.now();
+              const gov = readClusterGovernance();
+              recordFullRead("governance", 0, performance.now() - _govT0);
+              return Response.json(gov);
+            } catch {
+              return Response.json({ singleHost: true, nodes: [], generatedAt: "" });
+            }
           }
-          const oldest = eventRing.oldestTs();
-          const spanHours =
-            oldest !== null
-              ? Math.round(((Date.now() - Date.parse(oldest)) / 3_600_000) * 100) / 100
-              : null;
-          return Response.json({
-            pid: process.pid,
-            uptimeSec: Math.round(process.uptime()),
-            memoryMB: usageMB(before),
-            ...(afterGcMB && freedMB ? { afterGcMB, freedMB } : {}),
-            ring: {
-              lineCount: eventRing.size(),
-              byteSizeMB: toMB(eventRing.byteSize()),
-              capacity: eventRing.capacity(),
-              oldestTs: oldest,
-              spanHours,
-              listenerCount: eventRing.listenerCount(),
-            },
-            caches: {
-              sseClients: sseClients.size,
-              transcriptPathCache: _getTranscriptCacheSize(),
-            },
-            fullReads: fullReadMetrics,
-          });
-        }
 
-        // CTL-1232 (profiling): GET /debug/heap-snapshot — write a Bun v8 heap
-        // snapshot (loadable in Chrome DevTools → Memory → Load profile) under
-        // ~/catalyst/heap-snapshots/. Heavy + blocking, so localhost-only (curl
-        // from the host) unless CATALYST_DEBUG_TOKEN is set and matched via
-        // ?token=. A small snapshot beside a large RSS confirms off-heap/native
-        // bloat rather than a JS-heap leak.
-        if (url.pathname === "/debug/heap-snapshot") {
-          const token = url.searchParams.get("token");
-          const required = process.env.CATALYST_DEBUG_TOKEN;
-          const ip = server.requestIP(req)?.address ?? "";
-          const isLocal =
-            ip === "127.0.0.1" || ip === "::1" || ip === "::ffff:127.0.0.1";
-          const allowed = required ? token === required : isLocal;
-          if (!allowed) {
-            return new Response(
-              "forbidden (localhost only, or pass ?token=$CATALYST_DEBUG_TOKEN)",
-              { status: 403 },
+          // GET /api/governance — current daemon governance config snapshot.
+          // DO NOT inline the specifier (computed import, VITE-GRAPH GUARD, CTL-883).
+          if (url.pathname === "/api/governance") {
+            const configSpecifier = ["../execution-core/config.mjs"].join("");
+            try {
+              const { readGovernanceConfig } = (await import(configSpecifier)) as {
+                readGovernanceConfig: (env?: NodeJS.ProcessEnv) => Record<string, unknown>;
+              };
+              return Response.json({ available: true, ...readGovernanceConfig() });
+            } catch {
+              return Response.json({ available: false });
+            }
+          }
+
+          if (url.pathname === "/api/fsm/descriptor") {
+            return Response.json(await buildFsmDescriptor());
+          }
+
+          // GET /api/beliefs/rules — served from frozen RULE_MANIFEST; no db required.
+          if (url.pathname === "/api/beliefs/rules") {
+            const govDeps = await loadGovernanceDeps();
+            const manifest = govDeps?.RULE_MANIFEST ?? null;
+            if (!manifest) return Response.json({ rules: [], strata: [] });
+            return Response.json(manifest);
+          }
+
+          // GET /api/beliefs/summary — latest-tick aggregate per belief name.
+          if (url.pathname === "/api/beliefs/summary") {
+            const dbPath = govDbPath();
+            const govDeps = await loadGovernanceDeps();
+            if (!govDeps) return Response.json({ tickId: null, rows: [] });
+            return Response.json(
+              await govDeps.withBeliefsDbRO(dbPath, (db) => beliefSummary(db), {
+                tickId: null,
+                rows: [],
+              }),
             );
           }
-          const dir = join(CATALYST_DIR, "heap-snapshots");
-          mkdirSync(dir, { recursive: true });
-          const stamp = new Date().toISOString().replace(/[:.]/g, "-");
-          const snapPath = join(dir, `monitor-${process.pid}-${stamp}.heapsnapshot`);
-          const rssBeforeMB = Math.round(process.memoryUsage().rss / 1048576);
-          const snap = Bun.generateHeapSnapshot("v8", "arraybuffer");
-          const bytes = await Bun.write(snapPath, snap);
-          return Response.json({
-            path: snapPath,
-            snapshotBytes: bytes,
-            snapshotMB: Math.round((bytes / 1048576) * 10) / 10,
-            rssBeforeMB,
-            note: "load in Chrome DevTools → Memory → Load profile; small snapshot vs large RSS ⇒ off-heap/native bloat",
-          });
-        }
 
-        return new Response("Not Found", { status: 404 });
-      } catch (err) {
-        console.error(`[server] fetch handler error:`, err);
-        return new Response("Internal Server Error", { status: 500 });
-      }
+          // GET /api/beliefs/rates — full belief counts per rule_id per tick (LRU cached).
+          if (url.pathname === "/api/beliefs/rates") {
+            const dbPath = govDbPath();
+            const govDeps = await loadGovernanceDeps();
+            if (!govDeps) return Response.json({ maxTick: null, rows: [] });
+            return Response.json(
+              await govDeps.withBeliefsDbRO(dbPath, (db) => beliefRates(db, beliefRatesCache), {
+                maxTick: null,
+                rows: [],
+              }),
+            );
+          }
+
+          // GET /api/beliefs/recent — newest-first belief rows, limit param.
+          if (url.pathname === "/api/beliefs/recent") {
+            const dbPath = govDbPath();
+            const govDeps = await loadGovernanceDeps();
+            if (!govDeps) return Response.json({ rows: [] });
+            const limitParam = url.searchParams.get("limit");
+            const limit = limitParam ? Math.max(1, parseInt(limitParam, 10) || 50) : undefined;
+            return Response.json(
+              await govDeps.withBeliefsDbRO(dbPath, (db) => beliefRecent(db, { limit }), {
+                rows: [],
+              }),
+            );
+          }
+
+          // GET /api/beliefs/cfg — static config rows from the beliefs store.
+          if (url.pathname === "/api/beliefs/cfg") {
+            const dbPath = govDbPath();
+            const govDeps = await loadGovernanceDeps();
+            if (!govDeps) return Response.json({ rows: [] });
+            return Response.json(
+              await govDeps.withBeliefsDbRO(dbPath, (db) => beliefCfg(db), { rows: [] }),
+            );
+          }
+
+          // GET /api/beliefs/why?ticket=<ticket>[&tick=<tickId>]
+          // HTTP wrapper over traceTicket() — same resolver as `catalyst why`.
+          // Input validation (ticket required, /^[A-Za-z]+-\d+$/, tick must be
+          // integer) happens BEFORE any db touch so traversal attempts are
+          // rejected before reaching the db. Degrades to 200+empty trace when
+          // beliefs.db absent or unreadable (no 500).
+          // NOTE: DO NOT inline the specifier — computed import required (CTL-883).
+          if (url.pathname === "/api/beliefs/why") {
+            const rawTicket = url.searchParams.get("ticket");
+            if (!rawTicket) return new Response("ticket required", { status: 400 });
+            let ticket: string;
+            try {
+              ticket = decodeURIComponent(rawTicket);
+            } catch {
+              return new Response("invalid ticket encoding", { status: 400 });
+            }
+            if (!/^[A-Za-z]+-\d+$/.test(ticket)) {
+              return new Response("invalid ticket format", { status: 400 });
+            }
+            const rawTick = url.searchParams.get("tick");
+            let tickId: number | undefined;
+            if (rawTick != null) {
+              const parsed = parseInt(rawTick, 10);
+              if (!Number.isInteger(parsed) || String(parsed) !== rawTick.trim()) {
+                return new Response("tick must be an integer", { status: 400 });
+              }
+              tickId = parsed;
+            }
+            // DO NOT inline this specifier (VITE-GRAPH GUARD, CTL-883).
+            const whyMod = ["./lib/belief-why.mjs"].join("");
+            try {
+              const { traceTicketJson } = (await import(whyMod)) as {
+                traceTicketJson: (opts: {
+                  ticket: string;
+                  tickId?: number;
+                  dbPath: string;
+                }) => Promise<unknown>;
+              };
+              const trace = await traceTicketJson({ ticket, tickId, dbPath: govDbPath() });
+              return Response.json(trace);
+            } catch {
+              return Response.json({ ticket, tickId: null, beliefs: [] });
+            }
+          }
+
+          // CTL-935 Phase 5: GET /api/beliefs/report — weekly shadow disagreement report.
+          // ?sinceDays=7 (default 7, clamped to [1,90]). Degrades gracefully when
+          // beliefs.db is absent. DO NOT inline the specifier (VITE-GRAPH GUARD, CTL-883).
+          if (url.pathname === "/api/beliefs/report") {
+            const rawDays = url.searchParams.get("sinceDays");
+            let sinceDays = 7;
+            if (rawDays != null) {
+              const parsed = Number(rawDays);
+              if (!Number.isFinite(parsed) || parsed <= 0 || !Number.isInteger(parsed)) {
+                return new Response("sinceDays must be a positive integer", { status: 400 });
+              }
+              sinceDays = Math.min(Math.max(parsed, 1), 90);
+            }
+            const nowMs = Date.now();
+            const sinceMs = nowMs - sinceDays * 86_400_000;
+            const reportMod = ["./lib/belief-report.mjs"].join("");
+            try {
+              const { computeReportJson } = (await import(reportMod)) as {
+                computeReportJson: (opts: {
+                  dbPath: string;
+                  sinceMs: number;
+                  nowMs: number;
+                }) => Promise<unknown>;
+              };
+              const report = await computeReportJson({ dbPath: govDbPath(), sinceMs, nowMs });
+              return Response.json(report);
+            } catch (err) {
+              // CTL-935 remediate: tag the error-path payload as degraded so the
+              // flag-live helper / operator can tell a broken report (failed
+              // import, corrupt/locked db) from a legitimately quiet week. The
+              // shape stays well-formed (200) so existing consumers don't break.
+              return Response.json({
+                window: { sinceMs, nowMs, tickCount: 0, rulesShaSet: [], multipleRulesSha: false },
+                perRule: [],
+                perGuard: [],
+                replays: [],
+                degraded: true,
+                degradedReason: err instanceof Error ? err.message : String(err),
+              });
+            }
+          }
+
+          // CTL-1232 (profiling): GET /debug/memory[?gc=1] — live memory breakdown.
+          // process.memoryUsage() (MB) + event-ring stats + cache sizes + the
+          // full-log readFileSync fallback counters (fullReadMetrics). With ?gc=1
+          // it forces a synchronous Bun.gc(true) and reports the freed deltas, to
+          // distinguish reclaimable JS-heap garbage from RSS-not-returned-to-the-OS
+          // (the sticky high-water from repeated large transient reads).
+          if (url.pathname === "/debug/memory") {
+            const toMB = (b: number): number => Math.round((b / 1048576) * 10) / 10;
+            const usageMB = (
+              u: ReturnType<typeof process.memoryUsage>,
+            ): Record<string, number> => ({
+              rss: toMB(u.rss),
+              heapTotal: toMB(u.heapTotal),
+              heapUsed: toMB(u.heapUsed),
+              external: toMB(u.external),
+              arrayBuffers: toMB(u.arrayBuffers),
+            });
+            const before = process.memoryUsage();
+            let afterGcMB: Record<string, number> | null = null;
+            let freedMB: Record<string, number> | null = null;
+            if (url.searchParams.get("gc") === "1") {
+              Bun.gc(true);
+              const after = process.memoryUsage();
+              afterGcMB = usageMB(after);
+              freedMB = {
+                rss: toMB(before.rss - after.rss),
+                heapTotal: toMB(before.heapTotal - after.heapTotal),
+                heapUsed: toMB(before.heapUsed - after.heapUsed),
+                external: toMB(before.external - after.external),
+                arrayBuffers: toMB(before.arrayBuffers - after.arrayBuffers),
+              };
+            }
+            const oldest = eventRing.oldestTs();
+            const spanHours =
+              oldest !== null
+                ? Math.round(((Date.now() - Date.parse(oldest)) / 3_600_000) * 100) / 100
+                : null;
+            return Response.json({
+              pid: process.pid,
+              uptimeSec: Math.round(process.uptime()),
+              memoryMB: usageMB(before),
+              ...(afterGcMB && freedMB ? { afterGcMB, freedMB } : {}),
+              ring: {
+                lineCount: eventRing.size(),
+                byteSizeMB: toMB(eventRing.byteSize()),
+                capacity: eventRing.capacity(),
+                oldestTs: oldest,
+                spanHours,
+                listenerCount: eventRing.listenerCount(),
+              },
+              caches: {
+                sseClients: sseClients.size,
+                transcriptPathCache: _getTranscriptCacheSize(),
+              },
+              fullReads: fullReadMetrics,
+            });
+          }
+
+          // CTL-1232 (profiling): GET /debug/heap-snapshot — write a Bun v8 heap
+          // snapshot (loadable in Chrome DevTools → Memory → Load profile) under
+          // ~/catalyst/heap-snapshots/. Heavy + blocking, so localhost-only (curl
+          // from the host) unless CATALYST_DEBUG_TOKEN is set and matched via
+          // ?token=. A small snapshot beside a large RSS confirms off-heap/native
+          // bloat rather than a JS-heap leak.
+          if (url.pathname === "/debug/heap-snapshot") {
+            const token = url.searchParams.get("token");
+            const required = process.env.CATALYST_DEBUG_TOKEN;
+            const ip = server.requestIP(req)?.address ?? "";
+            const isLocal = ip === "127.0.0.1" || ip === "::1" || ip === "::ffff:127.0.0.1";
+            const allowed = required ? token === required : isLocal;
+            if (!allowed) {
+              return new Response(
+                "forbidden (localhost only, or pass ?token=$CATALYST_DEBUG_TOKEN)",
+                { status: 403 },
+              );
+            }
+            const dir = join(CATALYST_DIR, "heap-snapshots");
+            mkdirSync(dir, { recursive: true });
+            const stamp = new Date().toISOString().replace(/[:.]/g, "-");
+            const snapPath = join(dir, `monitor-${process.pid}-${stamp}.heapsnapshot`);
+            const rssBeforeMB = Math.round(process.memoryUsage().rss / 1048576);
+            const snap = Bun.generateHeapSnapshot("v8", "arraybuffer");
+            const bytes = await Bun.write(snapPath, snap);
+            return Response.json({
+              path: snapPath,
+              snapshotBytes: bytes,
+              snapshotMB: Math.round((bytes / 1048576) * 10) / 10,
+              rssBeforeMB,
+              note: "load in Chrome DevTools → Memory → Load profile; small snapshot vs large RSS ⇒ off-heap/native bloat",
+            });
+          }
+
+          return new Response("Not Found", { status: 404 });
+        } catch (err) {
+          console.error(`[server] fetch handler error:`, err);
+          return new Response("Internal Server Error", { status: 500 });
+        }
       };
       const res = await _doFetch();
       // CTL-1330: emit one structured line for a slow request — where a monitor
@@ -5424,8 +5333,7 @@ export function createServer(opts: CreateServerOptions): BunServer {
   // in the live fleet declares a deployment mode yet — leaves this branch
   // false, so tunnel startup is byte-for-byte unchanged (design §9 PR3
   // success criterion: provable no-op on the live fleet).
-  const resolveDeploymentModeForTunnelGate =
-    deploymentModeReaderOpt ?? getDeploymentMode;
+  const resolveDeploymentModeForTunnelGate = deploymentModeReaderOpt ?? getDeploymentMode;
   const deploymentModeForTunnelGate = resolveDeploymentModeForTunnelGate();
   const cloudModeSuppressesTunnels = deploymentModeForTunnelGate === "cloud";
 
@@ -5439,8 +5347,7 @@ export function createServer(opts: CreateServerOptions): BunServer {
         `[server] suppressing GitHub webhook smee tunnel start: deployment mode is "cloud" (event ingestion is the cloud SDK connection, not the smee tunnel)`,
       );
     } else {
-      const tunnelTarget =
-        webhookConfig.target ?? `http://localhost:${server.port}/api/webhook`;
+      const tunnelTarget = webhookConfig.target ?? `http://localhost:${server.port}/api/webhook`;
       webhookTunnel = createWebhookTunnel({
         source: webhookConfig.smeeChannel,
         target: tunnelTarget,
@@ -5465,9 +5372,7 @@ export function createServer(opts: CreateServerOptions): BunServer {
         const watchRepos = webhookConfig.watchRepos ?? [];
         const watchSubscriptions =
           watchRepos.length > 0
-            ? Promise.allSettled(
-                watchRepos.map((repo) => subscriber.ensureSubscribed(repo)),
-              )
+            ? Promise.allSettled(watchRepos.map((repo) => subscriber.ensureSubscribed(repo)))
             : Promise.resolve();
         // 1-hour replay window — wide enough to cover most outages, narrow enough
         // to keep startup latency under a few seconds.
@@ -5476,9 +5381,7 @@ export function createServer(opts: CreateServerOptions): BunServer {
           .then(() => replay.replaySince(subscriber.listSubscribed(), since))
           .then((count) => {
             if (count > 0) {
-              console.info(
-                `[server] replayed ${count} webhook deliveries from the last hour`,
-              );
+              console.info(`[server] replayed ${count} webhook deliveries from the last hour`);
             }
           })
           .catch((err: unknown) => {
@@ -5574,10 +5477,10 @@ export function createServer(opts: CreateServerOptions): BunServer {
   // invariants (N clients ⇒ N onAppend listeners on the ONE ring; disconnect
   // deregisters both the listener and the sseClients entry). The UI never reads
   // these.
-  (server as unknown as { __ringListenerCount?: () => number }).__ringListenerCount =
-    () => eventRing.listenerCount();
-  (server as unknown as { __sseClientCount?: () => number }).__sseClientCount =
-    () => sseClients.size;
+  (server as unknown as { __ringListenerCount?: () => number }).__ringListenerCount = () =>
+    eventRing.listenerCount();
+  (server as unknown as { __sseClientCount?: () => number }).__sseClientCount = () =>
+    sseClients.size;
   // CTL-1612 post-merge #2978 (Codex P2 follow-up): same CTL-1224 debug-seam
   // convention — exposes the `stopped` lifecycle flag (see its comment above
   // daemonDepsPromise) so a test can assert it flips synchronously, before
@@ -5628,8 +5531,7 @@ export function resolveProjectConfigPath(
 }
 
 if (import.meta.main) {
-  const CATALYST_DIR =
-    process.env.CATALYST_DIR ?? `${process.env.HOME}/catalyst`;
+  const CATALYST_DIR = process.env.CATALYST_DIR ?? `${process.env.HOME}/catalyst`;
   const WT_DIR = `${CATALYST_DIR}/wt`;
   const RUNS_DIR = `${CATALYST_DIR}/runs`;
   const parsedPort = parseInt(process.env.MONITOR_PORT ?? "", 10);
@@ -5639,8 +5541,7 @@ if (import.meta.main) {
   // for the family-squatting residual — an undocumented remedy nobody can apply
   // is not a remedy.
   const HOST = (process.env.MONITOR_HOST ?? "").trim() || "0.0.0.0";
-  const DB_PATH =
-    process.env.CATALYST_DB_FILE ?? `${CATALYST_DIR}/catalyst.db`;
+  const DB_PATH = process.env.CATALYST_DB_FILE ?? `${CATALYST_DIR}/catalyst.db`;
 
   const pidFileIdx = process.argv.indexOf("--pid-file");
   let pidFilePath: string | undefined;
@@ -5659,8 +5560,7 @@ if (import.meta.main) {
 
   // CTL-1156: resolve config path once — --config flag > CATALYST_CONFIG_PATH > cwd default.
   const configPath = resolveProjectConfigPath(process.argv, process.env, process.cwd());
-  const projectKey =
-    detectProjectKeyFromConfig(configPath) ?? detectProjectKey(process.cwd());
+  const projectKey = detectProjectKeyFromConfig(configPath) ?? detectProjectKey(process.cwd());
   const otelCfg = loadOtelConfig(
     process.env.CATALYST_CONFIG_DIR ?? `${process.env.HOME}/.config/catalyst`,
     projectKey,
@@ -5693,12 +5593,14 @@ if (import.meta.main) {
       : null;
   const linearWebhookConfig =
     fullWebhookConfig &&
-    (fullWebhookConfig.linearSecrets.length > 0 ||
-      fullWebhookConfig.linearSmeeChannel.length > 0)
+    (fullWebhookConfig.linearSecrets.length > 0 || fullWebhookConfig.linearSmeeChannel.length > 0)
       ? {
           linearSecrets: fullWebhookConfig.linearSecrets,
           smeeChannel: fullWebhookConfig.linearSmeeChannel,
-          botUserIds: fullWebhookConfig.linearBotUserIds.size > 0 ? fullWebhookConfig.linearBotUserIds : undefined,
+          botUserIds:
+            fullWebhookConfig.linearBotUserIds.size > 0
+              ? fullWebhookConfig.linearBotUserIds
+              : undefined,
           linearTeams: fullWebhookConfig.linearTeams,
         }
       : null;
@@ -5782,13 +5684,14 @@ if (import.meta.main) {
       projectsConfigPath: configPath,
       monitorConfigPath: configPath,
     });
-    const displayHost =
-      srv.hostname === "0.0.0.0" ? "localhost" : String(srv.hostname);
+    const displayHost = srv.hostname === "0.0.0.0" ? "localhost" : String(srv.hostname);
     console.info(`Monitor v${CATALYST_DEV_VERSION} running at http://${displayHost}:${srv.port}`);
     if (useTerminal) {
       console.info("Terminal renderer active (--terminal)");
     }
-    console.info(`(bound on ${String(srv.hostname)}:${srv.port}; watching ${WT_DIR} and ${RUNS_DIR})`);
+    console.info(
+      `(bound on ${String(srv.hostname)}:${srv.port}; watching ${WT_DIR} and ${RUNS_DIR})`,
+    );
 
     for (const sig of ["SIGINT", "SIGTERM"] as const) {
       process.on(sig, () => {

--- a/plugins/dev/scripts/orch-monitor/server.ts
+++ b/plugins/dev/scripts/orch-monitor/server.ts
@@ -136,6 +136,7 @@ import { buildTrustedOrigins, isOriginAllowed } from "./lib/trusted-origin.mjs";
 // the async TTL cache serves /api/accounts + the /api/accounts/stream SSE.
 import { createAccountsProbe, defaultAccountsProbeExec } from "./lib/accounts-probe.mjs";
 import { createAccountsTimer } from "./lib/accounts-timer.mjs";
+import { checkAccountStatusTransition } from "./lib/account-status-latch.mjs";
 import type { CachedAccountsSummary } from "./lib/accounts-probe";
 /** CTL-1653: the injectable child-process seam for the Claude-account probe.
  *  Production is defaultAccountsProbeExec; tests inject a scripted fake record. */
@@ -1027,6 +1028,13 @@ export function createServer(opts: CreateServerOptions): BunServer {
             } catch {
               /* a dead subscriber is pruned on its own stream cancel */
             }
+          }
+          // CTL-1653 Phase 4: edge-triggered account.status.changed emit. Best-
+          // effort — a marker/IO hiccup must never kill the tick.
+          try {
+            void checkAccountStatusTransition(s);
+          } catch (err) {
+            console.error(`[server] account status transition check failed:`, err);
           }
         },
       })

--- a/plugins/dev/scripts/orch-monitor/server.ts
+++ b/plugins/dev/scripts/orch-monitor/server.ts
@@ -135,6 +135,8 @@ import { buildTrustedOrigins, isOriginAllowed } from "./lib/trusted-origin.mjs";
 // claude-accounts-usage.mjs in a token-scoped subshell (defaultAccountsProbeExec);
 // the async TTL cache serves /api/accounts + the /api/accounts/stream SSE.
 import { createAccountsProbe, defaultAccountsProbeExec } from "./lib/accounts-probe.mjs";
+import { createAccountsTimer } from "./lib/accounts-timer.mjs";
+import type { CachedAccountsSummary } from "./lib/accounts-probe";
 /** CTL-1653: the injectable child-process seam for the Claude-account probe.
  *  Production is defaultAccountsProbeExec; tests inject a scripted fake record. */
 type AccountsProbeExec = () => Promise<unknown>;
@@ -1009,6 +1011,32 @@ export function createServer(opts: CreateServerOptions): BunServer {
           ttlMs: accountsTtlMs,
           node: hostName(),
         });
+
+  // CTL-1653: per-connection SSE subscribers fed by the periodic timer. The
+  // timer refreshes the cache every accountsTtlMs and fans each fresh summary
+  // out to all subscribers (Phase 4 also folds the transition latch in here).
+  const accountsSubscribers = new Set<(s: CachedAccountsSummary) => void>();
+  const accountsTimer = accountsProbe
+    ? createAccountsTimer({
+        probe: accountsProbe,
+        intervalMs: accountsTtlMs,
+        onTick: (s) => {
+          for (const send of accountsSubscribers) {
+            try {
+              send(s);
+            } catch {
+              /* a dead subscriber is pruned on its own stream cancel */
+            }
+          }
+        },
+      })
+    : null;
+  // The timer spawns the real Claude-account probe (a Haiku call when
+  // claude-accounts.env exists), so it belongs to the long-running daemon path
+  // only — gate on startWatcher so the hundreds of `startWatcher:false` unit
+  // servers never fork a probe. Tests that exercise the stream inject a fake
+  // exec + leave startWatcher default (true).
+  if (accountsTimer && startWatcher !== false) accountsTimer.start();
 
   // CTL-1050: the service-health registry monitor — ONE severity model shared by
   // the Fleet Ops strip, the outage emitter, the inbox decoration, AND the
@@ -2356,6 +2384,54 @@ export function createServer(opts: CreateServerOptions): BunServer {
             const refresh = url.searchParams.get("refresh") === "true";
             const summary = await accountsProbe.get({ refresh });
             return Response.json({ available: true, ...summary });
+          }
+
+          // CTL-1653: SSE stream of the node's Claude-account posture. Each event:
+          //   event: account\ndata: <summary json>\n\n
+          // On connect, emit the current cached summary immediately (so a fresh
+          // dashboard renders without waiting a whole interval); thereafter the
+          // periodic timer broadcasts each fresh summary to every subscriber.
+          if (url.pathname === "/api/accounts/stream") {
+            const probeRef = accountsProbe;
+            let send: ((s: CachedAccountsSummary) => void) | null = null;
+            const stream = new ReadableStream<Uint8Array>({
+              async start(controller) {
+                const frame = (s: unknown) => {
+                  try {
+                    controller.enqueue(
+                      encoder.encode(`event: account\ndata: ${JSON.stringify(s)}\n\n`),
+                    );
+                  } catch {
+                    if (send) accountsSubscribers.delete(send);
+                    send = null;
+                  }
+                };
+                if (!probeRef) {
+                  // Disabled: emit one unavailable frame, no subscription.
+                  frame({ available: false, node: hostName() });
+                  return;
+                }
+                send = frame;
+                accountsSubscribers.add(send);
+                try {
+                  frame(await probeRef.get());
+                } catch (err) {
+                  console.error(`[server] accounts stream initial frame failed:`, err);
+                }
+              },
+              cancel() {
+                if (send) accountsSubscribers.delete(send);
+                send = null;
+              },
+            });
+            return new Response(stream, {
+              headers: {
+                "Content-Type": "text/event-stream",
+                "Cache-Control": "no-cache",
+                Connection: "keep-alive",
+                "Access-Control-Allow-Origin": "*",
+              },
+            });
           }
 
           // CTL-1152: GET /api/projects — the config-driven project roster. One
@@ -5443,6 +5519,8 @@ export function createServer(opts: CreateServerOptions): BunServer {
     watcher?.stop();
     boardSnapshot.stop();
     serviceHealth.stop();
+    accountsTimer?.stop(); // CTL-1653: stop the periodic Claude-account probe
+    accountsSubscribers.clear();
     prFetcher?.stop();
     previewFetcher?.stop();
     linear?.stop();

--- a/plugins/dev/scripts/orch-monitor/server.ts
+++ b/plugins/dev/scripts/orch-monitor/server.ts
@@ -54,7 +54,10 @@ import { readCapacityHistory } from "./lib/capacity-history.mjs";
 // queryable run entity (/api/ticket-runs/<id>) + serve one signal verbatim
 // (/api/ec-worker/<ticket>/<phase>). Pure file-reads of resident signals — no
 // live Linear/GitHub call per request.
-import { assembleTicketRuns, readPhaseSignalVerbatim } from "./lib/ticket-runs.mjs";
+import {
+  assembleTicketRuns,
+  readPhaseSignalVerbatim,
+} from "./lib/ticket-runs.mjs";
 // CTL-1100: FSM descriptor endpoint. Confirmed bun:sqlite-free (no computed
 // specifier needed — plain static import is safe for Vite/esbuild graph).
 import { buildFsmDescriptor } from "../lib/fsm-descriptor.mjs";
@@ -83,7 +86,10 @@ import { assembleJourney } from "./lib/journey.mjs";
 // is the EC equivalent — tails ~/.claude/projects/*/<sessionId>.jsonl and
 // emits typed StreamEvents over SSE for the worker [● live] tab + reasoning
 // rows + footer counters + the ticket active-node live tail.
-import { resolveTranscriptPath, TranscriptTail } from "./lib/ec-worker-stream.mjs";
+import {
+  resolveTranscriptPath,
+  TranscriptTail,
+} from "./lib/ec-worker-stream.mjs";
 // CTL-885 (BFF3): the cross-node live-tail SSE FAN-IN. The /api/ec-worker-stream
 // route is made node-aware: single-host (hosts.json absent/len 1) is an EXACT
 // identity no-op (tail the LOCAL transcript, zero added latency, no owner
@@ -102,7 +108,11 @@ import {
 // "Unknown command: /catalyst-dev:phase-plan" wedge). No follow flag exists, so
 // /api/ec-worker-screen/<shortId> polls every SCREEN_POLL_MS, ANSI-normalizes,
 // diffs, and pushes only CHANGED full-screen frames over SSE.
-import { ScreenPoller, deriveScreenShortId, SCREEN_POLL_MS } from "./lib/ec-worker-screen.mjs";
+import {
+  ScreenPoller,
+  deriveScreenShortId,
+  SCREEN_POLL_MS,
+} from "./lib/ec-worker-screen.mjs";
 import type { ScreenLogsExec } from "./lib/ec-worker-screen.mjs";
 import { hostName } from "./lib/canonical-event-shared.ts";
 // CTL-890 (BFF8): the read-model's ONE destructive endpoint (design P10) —
@@ -120,7 +130,10 @@ import { stopWorker, type StopWorkerResult } from "./lib/stop-worker.mjs";
 // multi-host rejects a stale/partitioned generation). Optimistic rollback is a
 // UI-side timer; the endpoint returns the verbatim ticket+phase identity the
 // client needs to mark the row `resuming` and arm that timer.
-import { respondTicket, type RespondTicketResult } from "./lib/respond-ticket.mjs";
+import {
+  respondTicket,
+  type RespondTicketResult,
+} from "./lib/respond-ticket.mjs";
 // CTL-1569: the inbox conversation surface. Two routes, deliberately split by
 // posture — GET /thread is a pure REPLICA read (zero Linear API calls, so it is
 // safe on a hover-speed path), POST /reply is the one write that posts a REAL,
@@ -128,7 +141,11 @@ import { respondTicket, type RespondTicketResult } from "./lib/respond-ticket.mj
 // via CTL-1567). The reply path is a SIBLING of /respond, not a replacement: see
 // lib/reply-ticket.mjs for why /respond's synthetic null-author event and its
 // hard held-run requirement make it unusable for this surface.
-import { getConversation, loadGlobalConfig, loadProjectConfig } from "./lib/inbox-conversation.mjs";
+import {
+  getConversation,
+  loadGlobalConfig,
+  loadProjectConfig,
+} from "./lib/inbox-conversation.mjs";
 import { replyToTicket } from "./lib/reply-ticket.mjs";
 import { buildTrustedOrigins, isOriginAllowed } from "./lib/trusted-origin.mjs";
 // CTL-1653: node-scoped Claude-account posture surface. The probe runner spawns
@@ -158,7 +175,11 @@ import {
   flattenTodosForWorker,
   streamFilePath,
 } from "./lib/subagent-tree";
-import { sessionIdFromPid, readWorkerTasks, getTaskDiagnostic } from "./lib/task-reader";
+import {
+  sessionIdFromPid,
+  readWorkerTasks,
+  getTaskDiagnostic,
+} from "./lib/task-reader";
 import {
   createEvent,
   parseFilter,
@@ -185,11 +206,7 @@ import { collectInboxItemState } from "./lib/inbox-state";
 import { loadAiConfig } from "./lib/ai-config";
 import type { SummarizeHandler } from "./lib/summarize";
 import { createSummarizeHandler } from "./lib/summarize";
-import {
-  loadSummarizeConfig,
-  type SummarizeConfig,
-  type ProviderName,
-} from "./lib/summarize/config";
+import { loadSummarizeConfig, type SummarizeConfig, type ProviderName } from "./lib/summarize/config";
 import { buildSummarizeSnapshot } from "./lib/summarize/snapshot";
 import { getProvider, type SummarizeProvider } from "./lib/summarize/providers";
 import { createCache } from "./lib/summarize/cache";
@@ -199,9 +216,15 @@ import {
   type ActivityWindow,
   VALID_ACTIVITY_WINDOWS,
 } from "./lib/activity-briefing";
-import { createPreviewFetcher, type PreviewFetcher } from "./lib/preview-status";
+import {
+  createPreviewFetcher,
+  type PreviewFetcher,
+} from "./lib/preview-status";
 import { writeMergedSignalFile } from "./lib/signal-writer";
-import { createWebhookHandler, type WebhookHandler } from "./lib/webhook-handler";
+import {
+  createWebhookHandler,
+  type WebhookHandler,
+} from "./lib/webhook-handler";
 import { createFileBasedPrCache } from "./lib/pr-cache";
 import {
   resolveOrchestrator as resolveOrchestratorFn,
@@ -222,8 +245,14 @@ import {
   type WebhookSubscriber,
   type SubscriberRunner,
 } from "./lib/webhook-subscriber";
-import { createWebhookReplay, type WebhookReplay } from "./lib/webhook-replay";
-import { createEventLogWriter, type EventLogWriter } from "./lib/event-log";
+import {
+  createWebhookReplay,
+  type WebhookReplay,
+} from "./lib/webhook-replay";
+import {
+  createEventLogWriter,
+  type EventLogWriter,
+} from "./lib/event-log";
 import { validatePredicate, createFilterStream, type FilterStream } from "./lib/event-filter";
 import {
   readBacklog,
@@ -247,9 +276,15 @@ import { loadProjects } from "./lib/project-roster";
 import { validateProjectPatch, writeProjectPatch } from "./lib/config-writer";
 // CTL-961: per-repo favicon auto-detection via GitHub API + disk cache.
 import { fetchRepoIcon } from "./lib/repo-icon-fetcher";
-import { createPrometheusFetcher, type PrometheusFetcher } from "./lib/prometheus";
+import {
+  createPrometheusFetcher,
+  type PrometheusFetcher,
+} from "./lib/prometheus";
 import { createLokiFetcher, type LokiFetcher } from "./lib/loki";
-import { createOtelHealthChecker, type OtelHealthChecker } from "./lib/otel-health";
+import {
+  createOtelHealthChecker,
+  type OtelHealthChecker,
+} from "./lib/otel-health";
 // CTL-1050: the service-health registry (one severity model, shared with CTL-1039).
 import {
   createServiceHealthMonitor,
@@ -305,7 +340,11 @@ import {
   deleteAnnotation,
 } from "./lib/annotations";
 import { startTerminalRenderer, type RenderOptions } from "./lib/terminal";
-import { createCommsReader, isValidChannelName, type CommsReader } from "./lib/comms-reader";
+import {
+  createCommsReader,
+  isValidChannelName,
+  type CommsReader,
+} from "./lib/comms-reader";
 // CTL-889 (P8/P9/P12): cache-backed Linear detail / artifacts / search readers.
 // All three read EXCLUSIVELY from durable caches (filter-state.db ticket_state +
 // the local thoughts tree) and NEVER do a synchronous live Linear call per
@@ -638,7 +677,10 @@ function collectPrRefs(snapshot: MonitorSnapshot): PrRef[] {
   return refs;
 }
 
-function applyPrStatus(snapshot: MonitorSnapshot, fetcher: PrStatusFetcher): MonitorSnapshot {
+function applyPrStatus(
+  snapshot: MonitorSnapshot,
+  fetcher: PrStatusFetcher,
+): MonitorSnapshot {
   for (const orch of snapshot.orchestrators) {
     for (const worker of Object.values(orch.workers)) {
       if (!worker.pr) continue;
@@ -681,7 +723,10 @@ function applyPrStatus(snapshot: MonitorSnapshot, fetcher: PrStatusFetcher): Mon
   return snapshot;
 }
 
-function applyPreviewStatus(snapshot: MonitorSnapshot, fetcher: PreviewFetcher): void {
+function applyPreviewStatus(
+  snapshot: MonitorSnapshot,
+  fetcher: PreviewFetcher,
+): void {
   for (const orch of snapshot.orchestrators) {
     for (const worker of Object.values(orch.workers)) {
       if (!worker.pr) continue;
@@ -717,17 +762,30 @@ const SSE_EVENTS = EVENT_TYPES;
 const BUS_BROADCAST_EVENTS = SSE_EVENTS.filter(
   (t) => t !== "global-event" && t !== "global-event-backlog",
 );
-const ALLOWED_PUBLIC_EXTENSIONS = new Set([".html", ".css", ".js", ".svg", ".png", ".ico"]);
+const ALLOWED_PUBLIC_EXTENSIONS = new Set([
+  ".html",
+  ".css",
+  ".js",
+  ".svg",
+  ".png",
+  ".ico",
+]);
 
 // CTL-1088: choose the served public dir. Prefer the out-of-repo dist the wrapper
 // built into (MONITOR_PUBLIC_DIR); fall back to the committed bundle when the env
 // var is unset/empty or points at a missing dir (cold-start path).
-export function resolvePublicDir(envDir: string | undefined, fallback: string): string {
+export function resolvePublicDir(
+  envDir: string | undefined,
+  fallback: string,
+): string {
   if (envDir && envDir.length > 0 && existsSync(envDir)) return envDir;
   return fallback;
 }
 
-function resolveSafeStaticPath(publicDir: string, relative: string): string | null {
+function resolveSafeStaticPath(
+  publicDir: string,
+  relative: string,
+): string | null {
   let realRoot: string;
   try {
     realRoot = realpathSync(publicDir);
@@ -762,7 +820,7 @@ function isSafeArchiveFileRel(s: string): boolean {
   if (s.length === 0 || s.length > 250) return false;
   if (s.startsWith("/")) return false;
   if (ARCHIVE_FILE_REL_FORBIDDEN.test(s)) return false;
-  return s.split("/").every((seg) => (seg === "" ? false : SAFE_ARCHIVE_PART.test(seg)));
+  return s.split("/").every((seg) => seg === "" ? false : SAFE_ARCHIVE_PART.test(seg));
 }
 
 function contentTypeForArchive(path: string): string {
@@ -846,7 +904,10 @@ export function createServer(opts: CreateServerOptions): BunServer {
     catalystDir: catalystDirOpt,
     runsDir = null,
     startWatcher = true,
-    publicDir = resolvePublicDir(process.env.MONITOR_PUBLIC_DIR, join(import.meta.dir, "public")),
+    publicDir = resolvePublicDir(
+      process.env.MONITOR_PUBLIC_DIR,
+      join(import.meta.dir, "public"),
+    ),
     pidFile,
     prStatusFetcher,
     prStatusRefreshMs = PR_STATUS_REFRESH_MS,
@@ -891,7 +952,8 @@ export function createServer(opts: CreateServerOptions): BunServer {
 
   const buildOpts: BuildSnapshotOptions = { dbPath, runsDir };
 
-  const CATALYST_DIR = catalystDirOpt ?? process.env.CATALYST_DIR ?? `${process.env.HOME}/catalyst`;
+  const CATALYST_DIR =
+    catalystDirOpt ?? process.env.CATALYST_DIR ?? `${process.env.HOME}/catalyst`;
   const annDbPath = annotationsDbPath ?? `${CATALYST_DIR}/annotations.db`;
   // CTL-1153 (M2): injectable config path for PUT /api/projects/:key + GET /api/projects.
   // Injected in tests to avoid rewriting the committed workspace config.json.
@@ -922,14 +984,21 @@ export function createServer(opts: CreateServerOptions): BunServer {
   // possibly-missing CATALYST_DIR nor open the module-level push-subscriptions
   // singleton, which would otherwise leak across tests in one `bun test` run.
   const pushConfigured =
-    pushBridgeOpt !== false || vapidKeysPath != null || pushSubscriptionsDbPath != null;
+    pushBridgeOpt !== false ||
+    vapidKeysPath != null ||
+    pushSubscriptionsDbPath != null;
   let vapidKeys: VapidKeys | null = null;
   if (pushConfigured) {
-    const pushSubsDbPath = pushSubscriptionsDbPath ?? `${CATALYST_DIR}/push-subscriptions.db`;
+    const pushSubsDbPath =
+      pushSubscriptionsDbPath ?? `${CATALYST_DIR}/push-subscriptions.db`;
     const vapidPath = vapidKeysPath ?? `${CATALYST_DIR}/vapid-keys.json`;
     vapidKeys = loadOrCreateVapidKeys(vapidPath);
     pushStore.openDb(pushSubsDbPath);
-    webpush.setVapidDetails("mailto:catalyst@localhost", vapidKeys.publicKey, vapidKeys.privateKey);
+    webpush.setVapidDetails(
+      "mailto:catalyst@localhost",
+      vapidKeys.publicKey,
+      vapidKeys.privateKey,
+    );
   }
 
   // CTL-1100: in-process LRU cache for /api/beliefs/rates (keyed by max tick_id,
@@ -959,7 +1028,8 @@ export function createServer(opts: CreateServerOptions): BunServer {
       ? null
       : (prStatusFetcher ??
         createPrStatusFetcher({
-          lastWebhookAt: (ref) => webhookHandlerRef?.getLastWebhookAt(ref.repo, ref.number) ?? null,
+          lastWebhookAt: (ref) =>
+            webhookHandlerRef?.getLastWebhookAt(ref.repo, ref.number) ?? null,
         }));
   let lastPrRefresh = 0;
 
@@ -971,7 +1041,9 @@ export function createServer(opts: CreateServerOptions): BunServer {
   // against the 2500/hr cap. Cache-backed by construction: an OPEN linear-breaker
   // can never be tripped from here.
   const linear: LinearFetcher | null =
-    linearFetcher === null ? null : (linearFetcher ?? createCacheBackedLinearFetcher());
+    linearFetcher === null
+      ? null
+      : (linearFetcher ?? createCacheBackedLinearFetcher());
   let linearStarted = false;
 
   const briefingProvider: BriefingProvider | null =
@@ -983,18 +1055,13 @@ export function createServer(opts: CreateServerOptions): BunServer {
   const summarizeHandler: SummarizeHandler | null =
     summarizeHandlerOpt === null ? null : (summarizeHandlerOpt ?? null);
 
-  const activityBriefingConfig: SummarizeConfig = summarizeConfigOpt ?? {
-    enabled: false,
-    defaultProvider: "anthropic",
-    defaultModel: "claude-sonnet-4-6",
-    providers: {},
-  };
+  const activityBriefingConfig: SummarizeConfig =
+    summarizeConfigOpt ?? { enabled: false, defaultProvider: "anthropic", defaultModel: "claude-sonnet-4-6", providers: {} };
 
   const prom: PrometheusFetcher | null =
     promFetcherOpt === null
       ? null
-      : (promFetcherOpt ??
-        (prometheusUrl ? createPrometheusFetcher({ baseUrl: prometheusUrl }) : null));
+      : (promFetcherOpt ?? (prometheusUrl ? createPrometheusFetcher({ baseUrl: prometheusUrl }) : null));
 
   const loki: LokiFetcher | null =
     lokiFetcherOpt === null
@@ -1013,9 +1080,9 @@ export function createServer(opts: CreateServerOptions): BunServer {
           node: hostName(),
         });
 
-  // CTL-1653: per-connection SSE subscribers fed by the periodic timer. The
-  // timer refreshes the cache every accountsTtlMs and fans each fresh summary
-  // out to all subscribers (Phase 4 also folds the transition latch in here).
+  // Per-connection SSE subscribers fed by the periodic timer. The timer refreshes
+  // the cache every accountsTtlMs and fans each fresh summary out to all
+  // subscribers, then folds in the Phase-4 edge-triggered transition emit.
   const accountsSubscribers = new Set<(s: CachedAccountsSummary) => void>();
   const accountsTimer = accountsProbe
     ? createAccountsTimer({
@@ -1042,8 +1109,7 @@ export function createServer(opts: CreateServerOptions): BunServer {
   // The timer spawns the real Claude-account probe (a Haiku call when
   // claude-accounts.env exists), so it belongs to the long-running daemon path
   // only — gate on startWatcher so the hundreds of `startWatcher:false` unit
-  // servers never fork a probe. Tests that exercise the stream inject a fake
-  // exec + leave startWatcher default (true).
+  // servers never fork a probe. Tests that exercise the stream inject a fake exec.
   if (accountsTimer && startWatcher !== false) accountsTimer.start();
 
   // CTL-1050: the service-health registry monitor — ONE severity model shared by
@@ -1117,7 +1183,8 @@ export function createServer(opts: CreateServerOptions): BunServer {
         lokiSeverity: () =>
           serviceHealth.snapshot().services.find((s) => s.id === "loki")?.severity ?? null,
         prometheusSeverity: () =>
-          serviceHealth.snapshot().services.find((s) => s.id === "prometheus")?.severity ?? null,
+          serviceHealth.snapshot().services.find((s) => s.id === "prometheus")?.severity ??
+          null,
       },
     });
 
@@ -1127,7 +1194,8 @@ export function createServer(opts: CreateServerOptions): BunServer {
       : (previewFetcherOpt ??
         createPreviewFetcher({
           getPrState: (ref) => prFetcher?.get(ref.repo, ref.number)?.state ?? null,
-          lastWebhookAt: (ref) => webhookHandlerRef?.getLastWebhookAt(ref.repo, ref.number) ?? null,
+          lastWebhookAt: (ref) =>
+            webhookHandlerRef?.getLastWebhookAt(ref.repo, ref.number) ?? null,
         }));
   let lastPreviewRefresh = 0;
 
@@ -1198,7 +1266,8 @@ export function createServer(opts: CreateServerOptions): BunServer {
       previewFetcher: previewFetcher ?? undefined,
       findSignalPaths: findSignalPathsForRef,
       eventLog,
-      resolveOrchestrator: (input) => resolveOrchestratorFn(input, getActiveOrchestrators()),
+      resolveOrchestrator: (input) =>
+        resolveOrchestratorFn(input, getActiveOrchestrators()),
       emit: (type, data) => emit(type, data),
       prCache: createFileBasedPrCache(),
       logger: {
@@ -1310,7 +1379,10 @@ export function createServer(opts: CreateServerOptions): BunServer {
     }
     if (linear && !linearStarted) {
       linearStarted = true;
-      linear.start(() => collectTicketKeys(buildSnapshot(wtDir, buildOpts)), linearRefreshMs);
+      linear.start(
+        () => collectTicketKeys(buildSnapshot(wtDir, buildOpts)),
+        linearRefreshMs,
+      );
     }
     // CTL-867: surface per-team reconcile health (last successful eligible
     // refresh age + the `alerting` flag) so the dashboard can show a team whose
@@ -1324,7 +1396,10 @@ export function createServer(opts: CreateServerOptions): BunServer {
     return snap;
   }
 
-  const sseClients = new Map<ReadableStreamDefaultController<Uint8Array>, SSEFilter>();
+  const sseClients = new Map<
+    ReadableStreamDefaultController<Uint8Array>,
+    SSEFilter
+  >();
   const encoder = new TextEncoder();
 
   // CTL-1215: ONE shared, incrementally-maintained recent-event ring. Per-request
@@ -1640,18 +1715,10 @@ export function createServer(opts: CreateServerOptions): BunServer {
   // DO NOT inline the specifiers to string literals (see governance-reader.mjs header).
   let governanceDepsPromise: Promise<{
     openBeliefsDbRO: (p: string) => Promise<import("bun:sqlite").Database | null>;
-    withBeliefsDbRO: <T>(
-      p: string,
-      fn: (db: import("bun:sqlite").Database) => T,
-      fallback: T,
-    ) => Promise<T>;
+    withBeliefsDbRO: <T>(p: string, fn: (db: import("bun:sqlite").Database) => T, fallback: T) => Promise<T>;
     defaultBeliefsDbPath: (env?: NodeJS.ProcessEnv) => string;
     isGovernanceEvent: (name: string) => boolean;
-    traceTicket: (
-      db: import("bun:sqlite").Database,
-      ticket: string,
-      opts?: { tickId?: number | null },
-    ) => unknown;
+    traceTicket: (db: import("bun:sqlite").Database, ticket: string, opts?: { tickId?: number | null }) => unknown;
     latestTickForTicket: (db: import("bun:sqlite").Database, ticket: string) => number | null;
     RULE_MANIFEST: unknown;
     RULES_SHA: string;
@@ -1671,24 +1738,13 @@ export function createServer(opts: CreateServerOptions): BunServer {
           const [reader, why, rules] = await Promise.all([
             import(readerMod) as Promise<{
               openBeliefsDbRO: (p: string) => Promise<import("bun:sqlite").Database | null>;
-              withBeliefsDbRO: <T>(
-                p: string,
-                fn: (db: import("bun:sqlite").Database) => T,
-                fallback: T,
-              ) => Promise<T>;
+              withBeliefsDbRO: <T>(p: string, fn: (db: import("bun:sqlite").Database) => T, fallback: T) => Promise<T>;
               defaultBeliefsDbPath: (env?: NodeJS.ProcessEnv) => string;
               isGovernanceEvent: (name: string) => boolean;
             }>,
             import(whyMod) as Promise<{
-              traceTicket: (
-                db: import("bun:sqlite").Database,
-                ticket: string,
-                opts?: { tickId?: number | null },
-              ) => unknown;
-              latestTickForTicket: (
-                db: import("bun:sqlite").Database,
-                ticket: string,
-              ) => number | null;
+              traceTicket: (db: import("bun:sqlite").Database, ticket: string, opts?: { tickId?: number | null }) => unknown;
+              latestTickForTicket: (db: import("bun:sqlite").Database, ticket: string) => number | null;
             }>,
             import(rulesMod) as Promise<{
               RULE_MANIFEST: unknown;
@@ -1725,7 +1781,9 @@ export function createServer(opts: CreateServerOptions): BunServer {
   // sensitive. Widening the display window to quiet notifications was tried once
   // (CTL-1169, 30s→90s) and the storm returned. Unset → the module default;
   // 0 restores the pre-CTL-1522 immediate-edge behavior.
-  const daemonNotifyHoldMs = resolveDaemonNotifyHoldMs(process.env.MONITOR_DAEMON_NOTIFY_HOLD_MS);
+  const daemonNotifyHoldMs = resolveDaemonNotifyHoldMs(
+    process.env.MONITOR_DAEMON_NOTIFY_HOLD_MS,
+  );
 
   const productionDaemonHealth = async (): Promise<DaemonHealth> => {
     try {
@@ -1741,7 +1799,8 @@ export function createServer(opts: CreateServerOptions): BunServer {
       // heartbeat intervals, set in nav-signal.mjs) so normal heartbeat jitter
       // doesn't flap healthy↔degraded and storm the desktop notifications.
       // MONITOR_DAEMON_HEALTHY_WINDOW_MS overrides it; unset → the module default.
-      const healthyWindowMs = Number(process.env.MONITOR_DAEMON_HEALTHY_WINDOW_MS) || undefined;
+      const healthyWindowMs =
+        Number(process.env.MONITOR_DAEMON_HEALTHY_WINDOW_MS) || undefined;
       return deps.deriveDaemonHealth(lastSeen, deps.getHostName(), {
         intervalMs: healthyWindowMs,
       });
@@ -1750,7 +1809,9 @@ export function createServer(opts: CreateServerOptions): BunServer {
     }
   };
   const readDaemonHealth: () => Promise<DaemonHealth> =
-    daemonHealthReaderOpt != null ? async () => daemonHealthReaderOpt() : productionDaemonHealth;
+    daemonHealthReaderOpt != null
+      ? async () => daemonHealthReaderOpt()
+      : productionDaemonHealth;
 
   // assembleNavSignal — project the four nav signals off the board snapshot the
   // read-model already computed, layering the local daemon health. One board read
@@ -1845,8 +1906,7 @@ export function createServer(opts: CreateServerOptions): BunServer {
   // checks live BEFORE grace, so a window ≥ grace would render a should-be-
   // offline host as live). Cap leaves a real degraded band.
   const PEER_WINDOW_GRACE_CAP_MS = 4 * 60_000;
-  const lokiPeerWindowMs =
-    HEARTBEAT_CADENCE_MS + peerPollMs + lokiCacheTtlMs + PEER_WINDOW_MARGIN_MS;
+  const lokiPeerWindowMs = HEARTBEAT_CADENCE_MS + peerPollMs + lokiCacheTtlMs + PEER_WINDOW_MARGIN_MS;
   const anchorPeerWindowMs = ANCHOR_PUBLISH_CADENCE_MS + peerPollMs + PEER_WINDOW_MARGIN_MS;
   let anchorPollTimer: ReturnType<typeof setInterval> | null = null;
   const pollAnchorHeartbeats = (): void => {
@@ -2103,7 +2163,9 @@ export function createServer(opts: CreateServerOptions): BunServer {
     if (clusterReaderOpt != null) return clusterReaderOpt(board);
     return clusterEntity.project(board);
   };
-  const assembleClusterSignal = async (board: BoardPayload): Promise<ClusterSignal> => {
+  const assembleClusterSignal = async (
+    board: BoardPayload,
+  ): Promise<ClusterSignal> => {
     try {
       return deriveClusterSignal(await readClusterView(board));
     } catch (err) {
@@ -2162,14 +2224,18 @@ export function createServer(opts: CreateServerOptions): BunServer {
   // lazy TTL only fires on re-read, so a key fetched once and never re-requested
   // would sit forever. A low-frequency sweep evicts abandoned keys. Cleared in
   // server.stop().
-  const titleDescSweepTimer = setInterval(() => _sweepTitleDescCache(), 5 * 60 * 1000);
+  const titleDescSweepTimer = setInterval(
+    () => _sweepTitleDescCache(),
+    5 * 60 * 1000,
+  );
 
   // CTL-1330 Tier 1: monitor request-timing. Surface only slow requests
   // (default >250ms) so healthy traffic doesn't flood the log. ON unless
   // CATALYST_TICK_TIMING=off. Fields land as structured attributes for the
   // OTL metrics pipeline.
   const MONITOR_REQUEST_TIMING = process.env.CATALYST_TICK_TIMING !== "off";
-  const MONITOR_SLOW_REQUEST_MS = Number(process.env.CATALYST_MONITOR_SLOW_REQUEST_MS) || 250;
+  const MONITOR_SLOW_REQUEST_MS =
+    Number(process.env.CATALYST_MONITOR_SLOW_REQUEST_MS) || 250;
 
   // CTL-1573 P1: the allowlist must use the port the server ACTUALLY bound, not
   // the requested one — `port: 0` asks the OS for an ephemeral port (the test
@@ -2247,3107 +2313,3171 @@ export function createServer(opts: CreateServerOptions): BunServer {
     async fetch(req) {
       const _reqT0 = performance.now();
       const _doFetch = async (): Promise<Response> => {
-        try {
-          const url = new URL(req.url);
+      try {
+        const url = new URL(req.url);
 
-          if (url.pathname === "/events") {
-            const filter = parseFilter(url);
+        if (url.pathname === "/events") {
+          const filter = parseFilter(url);
 
-            // Eagerly validate the activity predicate so we can return 400 before
-            // opening a stream. Empty-string predicate is allowed (means "no
-            // jq filter, all global events"); only validate non-empty.
-            if (filter.activityPredicate !== undefined && filter.activityPredicate.trim() !== "") {
-              const v = validatePredicate(filter.activityPredicate);
-              if (!v.ok) {
-                return new Response(`activity filter error: ${v.error ?? "invalid"}`, {
-                  status: 400,
-                });
-              }
-            }
-
-            let captured: ReadableStreamDefaultController<Uint8Array> | null = null;
-            // CTL-1224: the live activity tail is now fed by the ONE shared
-            // event-ring (eventRing.onAppend) rather than a per-client
-            // tailEventLog poll loop + per-client backlog readFileSync. Each
-            // client keeps its OWN jq filter stream (predicates differ per
-            // client), but the expensive shared part — the file poll + byte read —
-            // is one backend loop (the ring's tick) regardless of client count.
-            let activityUnsub: (() => void) | null = null;
-            let activityFilter: FilterStream | null = null;
-            const stream = new ReadableStream<Uint8Array>({
-              async start(controller) {
-                captured = controller;
-                sseClients.set(controller, filter);
-                try {
-                  // Initial snapshot always sent regardless of filter to bootstrap client state
-                  const snapshot = snapshotWithPrStatus();
-                  const envelope = createEvent("snapshot", snapshot, "filesystem");
-                  const msg = `event: snapshot\ndata: ${JSON.stringify(envelope)}\n\n`;
-                  controller.enqueue(encoder.encode(msg));
-                } catch (err) {
-                  console.error(`[server] initial snapshot enqueue failed:`, err);
-                }
-
-                // Activity stream multiplex: only when the client opted in via
-                // `?activity=` (predicate may be empty for "all events").
-                if (filter.activityPredicate !== undefined) {
-                  const predicate = filter.activityPredicate;
-                  try {
-                    // CTL-1224: serve the backlog from the shared ring when it
-                    // covers the window; bounded file fallback on underflow. No
-                    // unconditional full-file readFileSync on the SSE path.
-                    const backlogLines = await readBacklog({
-                      catalystDir: CATALYST_DIR,
-                      predicate,
-                      limit: 100,
-                      ring: eventRing,
-                    });
-                    const parsed = backlogLines
-                      .map((l) => safeParseJson(l))
-                      .filter((v): v is Record<string, unknown> => v !== null);
-                    const backlogEnv = createEvent(
-                      "global-event-backlog",
-                      { events: parsed },
-                      "filesystem",
-                    );
-                    // Enqueue may race with client cancel; swallow the
-                    // ERR_INVALID_STATE that comes back if the controller has
-                    // already closed.
-                    try {
-                      controller.enqueue(
-                        encoder.encode(
-                          `event: global-event-backlog\ndata: ${JSON.stringify(backlogEnv)}\n\n`,
-                        ),
-                      );
-                    } catch {
-                      /* client cancelled */
-                    }
-                  } catch (err) {
-                    console.error(`[server] activity backlog failed:`, err);
-                  }
-
-                  // CTL-1224: per-client jq filter (or passthrough for an empty
-                  // predicate) fed by the SHARED ring tail. Matched lines are
-                  // wrapped in the SAME global-event envelope + framing as before.
-                  const filterStream = createFilterStream(predicate);
-                  activityFilter = filterStream;
-                  filterStream.onMatch((line) => {
-                    const parsed = safeParseJson(line);
-                    if (parsed === null) return;
-                    const env = createEvent("global-event", parsed, "filesystem");
-                    try {
-                      controller.enqueue(
-                        encoder.encode(`event: global-event\ndata: ${JSON.stringify(env)}\n\n`),
-                      );
-                    } catch {
-                      // client gone — stop feeding it
-                      activityUnsub?.();
-                      activityUnsub = null;
-                    }
-                  });
-                  activityUnsub = eventRing.onAppend((lines) => {
-                    for (const l of lines) filterStream.write(l);
-                    void filterStream.flush();
-                  });
-                }
-              },
-              cancel() {
-                if (captured) sseClients.delete(captured);
-                activityUnsub?.(); // CTL-1224: deregister ring listener (no leak)
-                activityUnsub = null;
-                activityFilter?.close(); // CTL-1224: reap the per-client jq process
-                activityFilter = null;
-              },
-            });
-            return new Response(stream, {
-              headers: {
-                "Content-Type": "text/event-stream",
-                "Cache-Control": "no-cache",
-                Connection: "keep-alive",
-                "Access-Control-Allow-Origin": "*",
-              },
-            });
-          }
-
-          if (url.pathname === "/api/version") {
-            return Response.json({ version: CATALYST_DEV_VERSION });
-          }
-
-          if (url.pathname === "/api/snapshot") {
-            return Response.json(snapshotWithPrStatus());
-          }
-
-          if (url.pathname === "/api/config") {
-            const cfg = loadMonitorConfig(monitorConfigPath);
-            return Response.json(cfg);
-          }
-
-          // CTL-1653: GET /api/accounts — THIS node's Claude-account posture
-          // (active account + per-window utilization/resets/status +
-          // siblingWithHeadroom), token-free, cached ~5 min. `?refresh=true`
-          // forces a fresh probe. Disabled (accountsProbeExec:null) → a stable
-          // available:false response, matching the dbPath-gated endpoints.
-          if (url.pathname === "/api/accounts") {
-            if (!accountsProbe) return Response.json({ available: false, node: hostName() });
-            const refresh = url.searchParams.get("refresh") === "true";
-            const summary = await accountsProbe.get({ refresh });
-            return Response.json({ available: true, ...summary });
-          }
-
-          // CTL-1653: SSE stream of the node's Claude-account posture. Each event:
-          //   event: account\ndata: <summary json>\n\n
-          // On connect, emit the current cached summary immediately (so a fresh
-          // dashboard renders without waiting a whole interval); thereafter the
-          // periodic timer broadcasts each fresh summary to every subscriber.
-          if (url.pathname === "/api/accounts/stream") {
-            const probeRef = accountsProbe;
-            let send: ((s: CachedAccountsSummary) => void) | null = null;
-            const stream = new ReadableStream<Uint8Array>({
-              async start(controller) {
-                const frame = (s: unknown) => {
-                  try {
-                    controller.enqueue(
-                      encoder.encode(`event: account\ndata: ${JSON.stringify(s)}\n\n`),
-                    );
-                  } catch {
-                    if (send) accountsSubscribers.delete(send);
-                    send = null;
-                  }
-                };
-                if (!probeRef) {
-                  // Disabled: emit one unavailable frame, no subscription.
-                  frame({ available: false, node: hostName() });
-                  return;
-                }
-                send = frame;
-                accountsSubscribers.add(send);
-                try {
-                  frame(await probeRef.get());
-                } catch (err) {
-                  console.error(`[server] accounts stream initial frame failed:`, err);
-                }
-              },
-              cancel() {
-                if (send) accountsSubscribers.delete(send);
-                send = null;
-              },
-            });
-            return new Response(stream, {
-              headers: {
-                "Content-Type": "text/event-stream",
-                "Cache-Control": "no-cache",
-                Connection: "keep-alive",
-                "Access-Control-Allow-Origin": "*",
-              },
-            });
-          }
-
-          // CTL-1152: GET /api/projects — the config-driven project roster. One
-          // descriptor per configured catalyst.monitor.linear.teams[] entry PLUS a
-          // self-identifying unconfigured lane per observed-work repo (the live
-          // board snapshot's `.repos`) with no configured descriptor (union rule).
-          // Fail-open: ANY error degrades to { projects: [] } (mirrors /api/config
-          // and the repo-icon endpoint) so the nav renders its empty state, never 5xx.
-          if (url.pathname === "/api/projects") {
-            try {
-              const board = await boardSnapshot.getLatest();
-              const observedRepos = board?.repos ?? [];
-              return Response.json({
-                projects: loadProjects({ observedRepos, configPath: projectsConfigPath }),
-              });
-            } catch {
-              return Response.json({ projects: [] });
-            }
-          }
-
-          // CTL-1153 (M2): PUT /api/projects/:key — upsert one editable projects[] entry
-          // (name/color/icon/stateMap). First edit of a known team key migrates THAT project
-          // into catalyst.projects[]. READ (GET above) is fail-open; WRITE is fail-CLOSED on input.
-          // Validation → HTTP code table:
-          //   405  non-PUT method
-          //   400  bad JSON | non-object | unknown field (incl. vcsRepo/key) | bad name | bad hue | bad stateMap
-          //   404  key not in teams[] and not in existing projects[]
-          //   500  genuine persistence failure
-          //   200  { project, projects }
-          {
-            const projectKeyMatch = url.pathname.match(/^\/api\/projects\/([A-Za-z0-9._-]+)$/);
-            if (projectKeyMatch && projectKeyMatch[1]) {
-              if (req.method !== "PUT") return new Response("Method Not Allowed", { status: 405 });
-              let key: string;
-              try {
-                key = decodeURIComponent(projectKeyMatch[1]);
-              } catch {
-                return Response.json({ error: "Bad project key" }, { status: 400 });
-              }
-              let body: unknown;
-              try {
-                body = await req.json();
-              } catch {
-                return Response.json({ error: "Invalid JSON body" }, { status: 400 });
-              }
-              const v = validateProjectPatch(body);
-              if (!v.ok) return Response.json({ error: v.error }, { status: v.status });
-              let result: ReturnType<typeof writeProjectPatch>;
-              try {
-                result = writeProjectPatch(projectsConfigPath, key.toUpperCase(), v.patch);
-              } catch (err) {
-                console.error(`[server] PUT /api/projects/${key} failed:`, err);
-                return Response.json(
-                  { error: "Failed to persist project settings" },
-                  { status: 500 },
-                );
-              }
-              if (!result.ok) {
-                return Response.json(
-                  { error: `Unknown project key: ${key.toUpperCase()}` },
-                  { status: 404 },
-                );
-              }
-              const board = await boardSnapshot.getLatest();
-              const observedRepos = board?.repos ?? [];
-              const projects = loadProjects({ observedRepos, configPath: projectsConfigPath });
-              return Response.json({
-                project: projects.find((p) => p.key === key.toUpperCase()) ?? null,
-                projects,
-              });
-            }
-          }
-
-          // CTL-961: /api/repo-icon/<repoShortName> — auto-detect favicon from GitHub.
-          // Reads the owner/repo from the monitor config repoOwners map, probes common
-          // icon paths via `gh api`, caches the result for 7 days, returns a data URL.
-          // Fail-open: returns { found: false } (204) when not configured or not found.
-          if (url.pathname.startsWith("/api/repo-icon/")) {
-            // CTL-979: normalize to lowercase so /api/repo-icon/adva resolves "Adva" vcsRepo keys.
-            const repoKey = url.pathname.slice("/api/repo-icon/".length).trim().toLowerCase();
-            if (!repoKey || repoKey.includes("/")) {
-              return new Response("Bad repo key", { status: 400 });
-            }
-            const cfg = loadMonitorConfig(monitorConfigPath);
-            const ownerRepo = cfg.repoOwners[repoKey];
-            if (!ownerRepo) {
-              return Response.json({ found: false }, { status: 204 });
-            }
-            const cacheDir = join(CATALYST_DIR, "repo-icon-cache");
-            const result = await fetchRepoIcon(ownerRepo, cacheDir);
-            if (!result.found) return Response.json({ found: false }, { status: 204 });
-            return Response.json(result);
-          }
-
-          if (url.pathname === "/api/analytics") {
-            return Response.json(buildAnalyticsSnapshot(wtDir, buildOpts));
-          }
-
-          if (url.pathname === "/api/sessions") {
-            if (!dbPath) {
-              return Response.json({ available: false, sessions: [] });
-            }
-            const params = url.searchParams;
-            const limitRaw = params.get("limit");
-            const parsedLimit = limitRaw ? Number.parseInt(limitRaw, 10) : NaN;
-            const result = readSessionStore(dbPath, {
-              soloOnly: params.get("solo") === "true",
-              workflowId: params.get("workflow") ?? undefined,
-              ticket: params.get("ticket") ?? undefined,
-              status: params.get("status") ?? undefined,
-              limit: Number.isFinite(parsedLimit) ? parsedLimit : undefined,
-            });
-            const sessions: SessionState[] = result.sessions;
-            return Response.json({ available: result.available, sessions });
-          }
-
-          if (url.pathname === "/api/history") {
-            if (!dbPath) {
-              return Response.json({ entries: [], total: 0 });
-            }
-            const params = url.searchParams;
-            const limitRaw = params.get("limit");
-            const offsetRaw = params.get("offset");
-            const parsedLimit = limitRaw ? Number.parseInt(limitRaw, 10) : NaN;
-            const parsedOffset = offsetRaw ? Number.parseInt(offsetRaw, 10) : NaN;
-            return Response.json(
-              queryHistory(dbPath, {
-                skill: params.get("skill") ?? undefined,
-                ticket: params.get("ticket") ?? undefined,
-                since: params.get("since") ?? undefined,
-                search: params.get("search") ?? undefined,
-                limit: Number.isFinite(parsedLimit) ? parsedLimit : undefined,
-                offset: Number.isFinite(parsedOffset) ? parsedOffset : undefined,
-              }),
-            );
-          }
-
-          if (url.pathname === "/api/history/stats") {
-            if (!dbPath) {
-              return Response.json({
-                totalSessions: 0,
-                totalCostUsd: 0,
-                avgCostUsd: 0,
-                avgDurationMs: 0,
-                successRate: 0,
-                skillBreakdown: [],
-                dailyCosts: [],
-                topTools: [],
-              });
-            }
-            const params = url.searchParams;
-            return Response.json(
-              queryStats(dbPath, {
-                skill: params.get("skill") ?? undefined,
-                since: params.get("since") ?? undefined,
-              }),
-            );
-          }
-
-          if (url.pathname === "/api/history/compare") {
-            if (!dbPath) {
-              return Response.json(null);
-            }
-            const params = url.searchParams;
-            const a = params.get("a");
-            const b = params.get("b");
-            if (!a || !b) {
-              return new Response("Missing ?a=<id>&b=<id>", { status: 400 });
-            }
-            const result = compareSessions(dbPath, a, b);
-            if (!result) {
-              return new Response("Session(s) not found", { status: 404 });
-            }
-            return Response.json(result);
-          }
-
-          const rollupMatch = url.pathname.match(/^\/api\/rollup\/([^/]+)$/);
-          if (rollupMatch) {
-            let orchId: string;
-            try {
-              orchId = decodeURIComponent(rollupMatch[1]);
-            } catch {
-              return new Response("Bad Request", { status: 400 });
-            }
-            if (orchId.includes("..") || orchId.includes("/") || orchId.includes("\0")) {
-              return new Response("Bad Request", { status: 400 });
-            }
-            const snap = snapshotWithPrStatus();
-            const orch = snap.orchestrators.find((o) => o.id === orchId);
-            if (!orch) {
-              return new Response("Not Found", { status: 404 });
-            }
-            return Response.json({
-              orchId: orch.id,
-              rollup: orch.rollupBriefing ?? null,
-            });
-          }
-
-          const sessionMatch = url.pathname.match(/^\/api\/session\/([^/]+)\/([^/]+)$/);
-          if (sessionMatch) {
-            let orchId: string;
-            let ticket: string;
-            try {
-              orchId = decodeURIComponent(sessionMatch[1]);
-              ticket = decodeURIComponent(sessionMatch[2]);
-            } catch {
-              return new Response("Bad Request", { status: 400 });
-            }
-            if (
-              orchId.includes("..") ||
-              orchId.includes("\0") ||
-              ticket.includes("..") ||
-              ticket.includes("/") ||
-              ticket.includes("\0")
-            ) {
-              return new Response("Bad Request", { status: 400 });
-            }
-            const detail = buildSessionDetail(wtDir, orchId, ticket, { runsDir });
-            if (!detail) {
-              return new Response("Not Found", { status: 404 });
-            }
-            if (prFetcher && detail.worker.pr) {
-              const repo = parseRepoFromPrUrl(detail.worker.pr.url);
-              if (repo) {
-                const status = prFetcher.get(repo, detail.worker.pr.number);
-                if (status) {
-                  detail.worker.prState = status.state;
-                  detail.worker.prMergedAt = status.mergedAt;
-                }
-              }
-            }
-            return Response.json(detail);
-          }
-
-          const streamMatch = url.pathname.match(/^\/api\/worker-stream\/([^/]+)\/([^/]+)$/);
-          if (streamMatch) {
-            let orchId: string;
-            let ticket: string;
-            try {
-              orchId = decodeURIComponent(streamMatch[1]);
-              ticket = decodeURIComponent(streamMatch[2]);
-            } catch {
-              return new Response("Bad Request", { status: 400 });
-            }
-            if (
-              orchId.includes("..") ||
-              orchId.includes("\0") ||
-              ticket.includes("..") ||
-              ticket.includes("/") ||
-              ticket.includes("\0")
-            ) {
-              return new Response("Bad Request", { status: 400 });
-            }
-            const maxEventsRaw = url.searchParams.get("limit");
-            const maxEvents = maxEventsRaw ? Number.parseInt(maxEventsRaw, 10) : 30;
-            const stateReader = await import("./lib/state-reader");
-            const scanned = runsDir
-              ? stateReader.scanAllOrchestrators({ runsDir, wtDir })
-              : stateReader.scanOrchestrators(wtDir);
-            const entry = scanned.find((d) => basename(d.path) === orchId);
-            if (!entry) {
-              return new Response("Not Found", { status: 404 });
-            }
-            const events = readRecentStreamEvents(
-              entry.path,
-              ticket,
-              Number.isFinite(maxEvents) ? maxEvents : 30,
-            );
-            return Response.json({ orchId, ticket, events });
-          }
-
-          const subagentsMatch = url.pathname.match(/^\/api\/worker\/([^/]+)\/([^/]+)\/subagents$/);
-          if (subagentsMatch) {
-            let orchId: string;
-            let ticket: string;
-            try {
-              orchId = decodeURIComponent(subagentsMatch[1]);
-              ticket = decodeURIComponent(subagentsMatch[2]);
-            } catch {
-              return new Response("Bad Request", { status: 400 });
-            }
-            if (
-              orchId.includes("..") ||
-              orchId.includes("/") ||
-              orchId.includes("\0") ||
-              ticket.includes("..") ||
-              ticket.includes("/") ||
-              ticket.includes("\0")
-            ) {
-              return new Response("Bad Request", { status: 400 });
-            }
-            const stateReader = await import("./lib/state-reader");
-            const scanned = runsDir
-              ? stateReader.scanAllOrchestrators({ runsDir, wtDir })
-              : stateReader.scanOrchestrators(wtDir);
-            const entry = scanned.find((d) => basename(d.path) === orchId);
-            if (!entry) return new Response("Not Found", { status: 404 });
-            const tree = parseStreamForSubagents(streamFilePath(entry.path, ticket));
-            return Response.json({ orchId, ticket, tree });
-          }
-
-          const workerTodosMatch = url.pathname.match(/^\/api\/worker\/([^/]+)\/([^/]+)\/todos$/);
-          if (workerTodosMatch) {
-            let orchId: string;
-            let ticket: string;
-            try {
-              orchId = decodeURIComponent(workerTodosMatch[1]);
-              ticket = decodeURIComponent(workerTodosMatch[2]);
-            } catch {
-              return new Response("Bad Request", { status: 400 });
-            }
-            if (
-              orchId.includes("..") ||
-              orchId.includes("/") ||
-              orchId.includes("\0") ||
-              ticket.includes("..") ||
-              ticket.includes("/") ||
-              ticket.includes("\0")
-            ) {
-              return new Response("Bad Request", { status: 400 });
-            }
-            const stateReader = await import("./lib/state-reader");
-            const scanned = runsDir
-              ? stateReader.scanAllOrchestrators({ runsDir, wtDir })
-              : stateReader.scanOrchestrators(wtDir);
-            const entry = scanned.find((d) => basename(d.path) === orchId);
-            if (!entry) return new Response("Not Found", { status: 404 });
-            const tree = parseStreamForSubagents(streamFilePath(entry.path, ticket));
-            const todos = flattenTodosForWorker(tree, ticket);
-            return Response.json({ orchId, ticket, todos });
-          }
-
-          const orchTodosMatch = url.pathname.match(/^\/api\/orch\/([^/]+)\/todos$/);
-          if (orchTodosMatch) {
-            let orchId: string;
-            try {
-              orchId = decodeURIComponent(orchTodosMatch[1]);
-            } catch {
-              return new Response("Bad Request", { status: 400 });
-            }
-            if (orchId.includes("..") || orchId.includes("/") || orchId.includes("\0")) {
-              return new Response("Bad Request", { status: 400 });
-            }
-            const stateReader = await import("./lib/state-reader");
-            const scanned = runsDir
-              ? stateReader.scanAllOrchestrators({ runsDir, wtDir })
-              : stateReader.scanOrchestrators(wtDir);
-            const entry = scanned.find((d) => basename(d.path) === orchId);
-            if (!entry) return new Response("Not Found", { status: 404 });
-            const orchState = stateReader.readOrchestratorState(
-              entry.path,
-              "workspace" in entry ? entry.workspace : "default",
-            );
-            const todos = [];
-            for (const [, worker] of Object.entries(orchState.workers)) {
-              const ticket = worker.ticket;
-              if (!ticket) continue;
-              const tree = parseStreamForSubagents(streamFilePath(entry.path, ticket));
-              todos.push(...flattenTodosForWorker(tree, ticket));
-            }
-            return Response.json({ orchId, todos });
-          }
-
-          if (url.pathname === "/api/worker-tasks/debug") {
-            const pidRaw = url.searchParams.get("pid");
-            const sessionIdParam = url.searchParams.get("sessionId");
-            if (!pidRaw && !sessionIdParam) {
-              return new Response("pid or sessionId required", { status: 400 });
-            }
-            const diagnostic = getTaskDiagnostic({
-              pid: pidRaw ? Number(pidRaw) : undefined,
-              sessionId: sessionIdParam ?? undefined,
-            });
-            return Response.json(diagnostic);
-          }
-
-          const taskMatch = url.pathname.match(/^\/api\/worker-tasks$/);
-          if (taskMatch) {
-            const pidRaw = url.searchParams.get("pid");
-            const sessionIdParam = url.searchParams.get("sessionId");
-            if (!pidRaw && !sessionIdParam) {
-              return new Response("pid or sessionId required", { status: 400 });
-            }
-            const sessionId = sessionIdParam || (pidRaw ? sessionIdFromPid(Number(pidRaw)) : null);
-            if (!sessionId) {
-              return Response.json({ tasks: null });
-            }
-            const tasks = readWorkerTasks(sessionId);
-            return Response.json({ tasks });
-          }
-
-          if (url.pathname === "/api/comms/channels") {
-            if (!comms) return Response.json({ channels: [] });
-            return Response.json({ channels: await comms.listChannels() });
-          }
-
-          const commsStreamMatch = url.pathname.match(/^\/api\/comms\/channels\/([^/]+)\/stream$/);
-          if (commsStreamMatch) {
-            let channelName: string;
-            try {
-              channelName = decodeURIComponent(commsStreamMatch[1]);
-            } catch {
-              return new Response("Bad Request", { status: 400 });
-            }
-            if (!isValidChannelName(channelName)) {
-              return new Response("Invalid channel name", { status: 400 });
-            }
-            if (!comms) return new Response("Comms not available", { status: 503 });
-
-            const commsReader = comms;
-            let offset = 0;
-            let timer: ReturnType<typeof setInterval> | null = null;
-            let inFlight = false;
-            const stream = new ReadableStream<Uint8Array>({
-              async start(controller) {
-                const initial = await commsReader.getChannel(channelName, { limit: 200 });
-                if (!initial) {
-                  const errFrame = `event: error-event\ndata: ${JSON.stringify({ error: "channel-not-found", channel: channelName })}\n\n`;
-                  try {
-                    controller.enqueue(encoder.encode(errFrame));
-                  } catch {
-                    // Client may have already disconnected.
-                  }
-                  controller.close();
-                  return;
-                }
-                offset = initial.tailOffset;
-                const snapshotFrame = `event: snapshot\ndata: ${JSON.stringify(initial)}\n\n`;
-                try {
-                  controller.enqueue(encoder.encode(snapshotFrame));
-                } catch {
-                  return;
-                }
-                timer = setInterval(() => {
-                  if (inFlight) return;
-                  inFlight = true;
-                  void (async () => {
-                    try {
-                      const tail = await commsReader.tailChannel(channelName, offset);
-                      offset = tail.newOffset;
-                      for (const m of tail.messages) {
-                        const frame = `event: message\ndata: ${JSON.stringify(m)}\n\n`;
-                        controller.enqueue(encoder.encode(frame));
-                      }
-                    } catch {
-                      // Keep the stream alive on transient read errors.
-                    } finally {
-                      inFlight = false;
-                    }
-                  })();
-                }, 500);
-              },
-              cancel() {
-                if (timer) clearInterval(timer);
-                timer = null;
-              },
-            });
-            return new Response(stream, {
-              headers: {
-                "Content-Type": "text/event-stream",
-                "Cache-Control": "no-cache",
-                Connection: "keep-alive",
-                "Access-Control-Allow-Origin": "*",
-              },
-            });
-          }
-
-          const commsChannelMatch = url.pathname.match(/^\/api\/comms\/channels\/([^/]+)$/);
-          if (commsChannelMatch) {
-            let channelName: string;
-            try {
-              channelName = decodeURIComponent(commsChannelMatch[1]);
-            } catch {
-              return new Response("Bad Request", { status: 400 });
-            }
-            if (!isValidChannelName(channelName)) {
-              return new Response("Invalid channel name", { status: 400 });
-            }
-            if (!comms) return new Response("Not Found", { status: 404 });
-            const limitRaw = url.searchParams.get("limit");
-            const parsedLimit = limitRaw ? Number.parseInt(limitRaw, 10) : NaN;
-            const limit = Number.isFinite(parsedLimit)
-              ? Math.max(1, Math.min(parsedLimit, 1000))
-              : 200;
-            const detail = await comms.getChannel(channelName, { limit });
-            if (!detail) return new Response("Not Found", { status: 404 });
-            return Response.json(detail);
-          }
-
-          const commsParticipantMatch = url.pathname.match(/^\/api\/comms\/participants\/([^/]+)$/);
-          if (commsParticipantMatch) {
-            let agentName: string;
-            try {
-              agentName = decodeURIComponent(commsParticipantMatch[1]);
-            } catch {
-              return new Response("Bad Request", { status: 400 });
-            }
-            if (agentName.includes("/") || agentName.includes("\0")) {
-              return new Response("Bad Request", { status: 400 });
-            }
-            if (!comms) return new Response("Not Found", { status: 404 });
-            const detail = await comms.getParticipant(agentName);
-            if (!detail) return new Response("Not Found", { status: 404 });
-            return Response.json(detail);
-          }
-
-          if (url.pathname === "/api/linear") {
-            const tickets: Record<string, LinearTicket> = {};
-            if (linear) {
-              for (const key of collectTicketKeys(buildSnapshot(wtDir, buildOpts))) {
-                const t = linear.get(key);
-                if (t) tickets[key] = t;
-              }
-            }
-            return Response.json({ tickets });
-          }
-
-          if (url.pathname === "/api/ticket-substeps") {
-            const ticketParam = url.searchParams.get("ticket");
-            if (!ticketParam) {
-              return new Response("Bad Request: missing ticket", { status: 400 });
-            }
-            if (
-              ticketParam.includes("..") ||
-              ticketParam.includes("/") ||
-              ticketParam.includes("\0")
-            ) {
-              return new Response("Bad Request", { status: 400 });
-            }
-            // CTL-1215: scan the shared event ring instead of reading the whole
-            // current-month log; the per-ticket substep slice is small + recent.
-            const subSteps = readSubStepEvents(eventRing, ticketParam);
-            return Response.json({ ticket: ticketParam, subSteps });
-          }
-
-          // CTL-889 (P8): cache-backed Linear ticket detail — description (null,
-          // not cached), labels[], the relation graph (forward + reverse
-          // blocks/related edges), assignee, and held classification. Read from
-          // filter-state.db ticket_state, NEVER a live `linearis` call. 404 when
-          // the ticket has no descriptor row.
-          const ticketDetailMatch = url.pathname.match(/^\/api\/ticket-detail\/([^/]+)$/);
-          if (ticketDetailMatch) {
-            let ticket: string;
-            try {
-              ticket = decodeURIComponent(ticketDetailMatch[1]);
-            } catch {
-              return new Response("Bad Request", { status: 400 });
-            }
-            if (ticket.includes("..") || ticket.includes("/") || ticket.includes("\0")) {
-              return new Response("Bad Request", { status: 400 });
-            }
-            const detail = await readTicketDetail(ticket, {
-              dbPath: filterStateDb,
-            });
-            if (!detail) {
-              return new Response("Not Found", { status: 404 });
-            }
-            return Response.json(detail);
-          }
-
-          // CTL-974 pattern: supplemental cached live Linear {title, description}
-          // fetch for the ticket-detail page. Separate from /api/ticket-detail to
-          // keep its 404-on-no-descriptor contract intact. The board title is
-          // stale-sourced (triage summary can win) and the durable cache has no
-          // description column, so BOTH the real title and the markdown
-          // description are live-fetched from Linear here — cached, TTL'd (5 min),
-          // batched, fail-open, NEVER spawning linearis on a request path.
-          // ALWAYS 200: an absent description is honest-empty, not an error.
-          const linearTicketMatch = url.pathname.match(/^\/api\/linear-ticket\/([^/]+)$/);
-          if (linearTicketMatch) {
-            let ticket: string;
-            try {
-              ticket = decodeURIComponent(linearTicketMatch[1]);
-            } catch {
-              return new Response("Bad Request", { status: 400 });
-            }
-            if (ticket.includes("..") || ticket.includes("/") || ticket.includes("\0")) {
-              return new Response("Bad Request", { status: 400 });
-            }
-            const map = await fillTitleDescriptionFallback([ticket]);
-            const entry = map[ticket] ?? {
-              title: null,
-              description: null,
-              labels: null,
-              relations: null,
-              state: null,
-              priority: null,
-              project: null,
-              estimate: null,
-            };
-            const available = entry.title !== null || entry.description !== null;
-            return Response.json({
-              id: ticket,
-              title: entry.title,
-              description: entry.description,
-              labels: entry.labels ?? null,
-              relations: entry.relations ?? null,
-              state: entry.state ?? null,
-              priority: entry.priority ?? null,
-              project: entry.project ?? null,
-              estimate: entry.estimate ?? null,
-              source: available ? "linear-live" : "unavailable",
-            });
-          }
-
-          // CTL-889 (P9): a ticket's research/plan thoughts artifacts for the
-          // spine 📄 links — repo-root-relative paths + a peek preview, read from
-          // the LOCAL thoughts tree. Surfaces the CTL-866 cross-node eventual-
-          // consistency caveat (artifacts authored on another node appear only
-          // after a thoughts-sync push).
-          const ticketArtifactsMatch = url.pathname.match(/^\/api\/ticket-artifacts\/([^/]+)$/);
-          if (ticketArtifactsMatch) {
-            let ticket: string;
-            try {
-              ticket = decodeURIComponent(ticketArtifactsMatch[1]);
-            } catch {
-              return new Response("Bad Request", { status: 400 });
-            }
-            if (ticket.includes("..") || ticket.includes("/") || ticket.includes("\0")) {
-              return new Response("Bad Request", { status: 400 });
-            }
-            const artifacts = await readTicketArtifacts(ticket);
-            return Response.json(artifacts);
-          }
-
-          // CTL-1574: a ticket's Linear discussion — comments + issue_history
-          // activity events, both read from the local CTC replica through the
-          // shared read-model builders. The reader never throws: an absent/locked
-          // replica or an unmirrored ticket comes back
-          // `{ available:false, comments:[], activity:[] }`, which the UI renders
-          // as an honest empty section (never a fabricated "no comments").
-          const ticketDiscussionMatch = url.pathname.match(/^\/api\/ticket-discussion\/([^/]+)$/);
-          if (ticketDiscussionMatch) {
-            let ticket: string;
-            try {
-              ticket = decodeURIComponent(ticketDiscussionMatch[1]);
-            } catch {
-              return new Response("Bad Request", { status: 400 });
-            }
-            if (ticket.includes("..") || ticket.includes("/") || ticket.includes("\0")) {
-              return new Response("Bad Request", { status: 400 });
-            }
-            const discussion = await readTicketDiscussion(ticket, {
-              catalystDir: CATALYST_DIR,
-            });
-            // Agent classification is `is_bot` OR a configured app-actor author —
-            // Catalyst worker/orchestrator app actors are stored as users with
-            // is_bot=0 (the linear-thread.mjs contract), so is_bot alone would
-            // badge every agent comment as human.
-            const botIds = linearBotUserIds ?? linearWebhookConfig?.botUserIds;
-            if (botIds && discussion.comments.length > 0) {
-              discussion.comments = discussion.comments.map((c) =>
-                c.author_id != null && botIds.has(c.author_id) ? { ...c, is_bot: 1 } : c,
-              );
-            }
-            return Response.json(discussion);
-          }
-
-          // CTL-1042: serve a ticket's research/plan artifact CONTENT by kind for
-          // the reading-pane deep-dive pills. The list route above is anchored at
-          // the ticket segment ($), so it never matches this two-segment path;
-          // this opens the actual markdown the pill links to (without it the pill
-          // hit the SPA/404 fallback). The served file path is resolved by our own
-          // glob over the local thoughts tree — not attacker-supplied — but we
-          // still validate both URL segments defensively.
-          const ticketArtifactByKindMatch = url.pathname.match(
-            /^\/api\/ticket-artifacts\/([^/]+)\/([^/]+)$/,
-          );
-          if (ticketArtifactByKindMatch) {
-            let ticket: string;
-            let kind: string;
-            try {
-              ticket = decodeURIComponent(ticketArtifactByKindMatch[1]);
-              kind = decodeURIComponent(ticketArtifactByKindMatch[2]);
-            } catch {
-              return new Response("Bad Request", { status: 400 });
-            }
-            if (ticket.includes("..") || ticket.includes("/") || ticket.includes("\0")) {
-              return new Response("Bad Request", { status: 400 });
-            }
-            if (kind !== "research" && kind !== "plan") {
-              return new Response("Bad Request", { status: 400 });
-            }
-            const doc = await readTicketArtifactContent(ticket, kind);
-            if (!doc) {
-              return new Response("Not Found", { status: 404 });
-            }
-            return new Response(doc.content, {
-              headers: { "Content-Type": "text/markdown; charset=utf-8" },
-            });
-          }
-
-          // CTL-889 (P12): cache-backed fuzzy ticket search for the ⌘K palette's
-          // "Search all tickets in Linear" action. Fuzzy-matches the durable
-          // ticket_state cache — NO per-keystroke live Linear API call. An empty
-          // ?q= returns an empty result set (the palette renders the row idle).
-          if (url.pathname === "/api/search") {
-            const q = url.searchParams.get("q") ?? "";
-            const limitRaw = url.searchParams.get("limit");
-            const parsedLimit = limitRaw ? Number.parseInt(limitRaw, 10) : NaN;
-            const limit = Number.isFinite(parsedLimit)
-              ? Math.max(1, Math.min(parsedLimit, 100))
-              : 20;
-            if (q.trim() === "") {
-              return Response.json({
-                query: q,
-                results: [],
-                source: "filter-state.db",
-              });
-            }
-            const result = await readTicketSearch(q, {
-              dbPath: filterStateDb,
-              limit,
-            });
-            return Response.json(result);
-          }
-
-          if (url.pathname === "/api/briefing") {
-            if (!briefingProvider) {
-              return Response.json({ enabled: false });
-            }
-            const snap = snapshotWithPrStatus();
-            const tickets: Record<string, LinearTicket> = {};
-            if (linear) {
-              for (const key of collectTicketKeys(snap)) {
-                const t = linear.get(key);
-                if (t) tickets[key] = t;
-              }
-            }
-            const result = await briefingProvider.generate(snap, tickets);
-            if (!result) {
-              return Response.json({ enabled: true, briefing: null });
-            }
-            return Response.json({
-              enabled: true,
-              briefing: result.briefing,
-              suggestedLabels: result.suggestedLabels,
-              generatedAt: result.generatedAt,
-            });
-          }
-
-          // CTL-1042: per-inbox-item AI summary — lazy, on operator select.
-          const inboxSummaryMatch =
-            req.method === "GET" && url.pathname.match(/^\/api\/inbox\/([^/]+)\/summary$/);
-          if (inboxSummaryMatch) {
-            let ticket: string;
-            try {
-              ticket = decodeURIComponent(inboxSummaryMatch[1]);
-            } catch {
-              return new Response("Bad Request", { status: 400 });
-            }
-            if (ticket.includes("..") || ticket.includes("/") || ticket.includes("\0")) {
-              return new Response("Bad Request", { status: 400 });
-            }
-            if (!inboxSummaryProvider) return Response.json({ enabled: false });
-            const phase = url.searchParams.get("phase") ?? undefined;
-            const result = await inboxSummaryProvider.generate(ticket, phase);
-            if (!result)
-              return Response.json({
-                enabled: true,
-                ask: null,
-                summary: null,
-                options: null,
-                blocker: null,
-              });
-            return Response.json({ enabled: true, ...result });
-          }
-
-          if (url.pathname === "/api/briefing/activity") {
-            const windowParam = url.searchParams.get("window") ?? "30m";
-            if (!VALID_ACTIVITY_WINDOWS.has(windowParam as ActivityWindow)) {
-              return Response.json(
-                { error: "Invalid window. Use 30m, 1h, or 6h." },
+          // Eagerly validate the activity predicate so we can return 400 before
+          // opening a stream. Empty-string predicate is allowed (means "no
+          // jq filter, all global events"); only validate non-empty.
+          if (
+            filter.activityPredicate !== undefined &&
+            filter.activityPredicate.trim() !== ""
+          ) {
+            const v = validatePredicate(filter.activityPredicate);
+            if (!v.ok) {
+              return new Response(
+                `activity filter error: ${v.error ?? "invalid"}`,
                 { status: 400 },
               );
             }
-            const result = await generateActivityBriefing(
-              CATALYST_DIR,
-              activityBriefingConfig,
-              windowParam as ActivityWindow,
-              undefined,
-              eventRing,
-            );
-            return Response.json(result);
           }
 
-          if (url.pathname === "/api/webhook" && req.method === "POST") {
-            if (!webhookHandler) {
-              return new Response("webhook receiver not configured", {
-                status: 503,
-              });
-            }
-            return webhookHandler.handle(req);
-          }
-
-          if (url.pathname === "/api/webhook/linear" && req.method === "POST") {
-            if (!linearWebhookHandler) {
-              return new Response("linear webhook receiver not configured", {
-                status: 503,
-              });
-            }
-            return linearWebhookHandler.handle(req);
-          }
-
-          if (url.pathname === "/api/summarize" && req.method === "POST") {
-            if (!summarizeHandler) {
-              return Response.json({ error: "AI not configured" }, { status: 503 });
-            }
-            return summarizeHandler.handle(req);
-          }
-
-          if (url.pathname === "/api/otel/status") {
-            return Response.json({
-              enabled: prom !== null || loki !== null,
-              prometheus: prom ? prom.isAvailable() : false,
-              loki: loki ? loki.isAvailable() : false,
-            });
-          }
-
-          if (url.pathname === "/api/health/otel") {
-            const health = await otelHealth.check();
-            return Response.json(health);
-          }
-
-          // CTL-1050: the service-health registry snapshot — every stack service's
-          // shared up|degraded|down|unknown severity, last-checked, target/source
-          // for the Fleet Ops strip hover. The registry reads ONLY the monitor's own
-          // probes/event-recency, so Fleet Ops stays Prometheus/Loki-FREE.
-          if (url.pathname === "/api/health/services") {
-            return Response.json(serviceHealth.snapshot());
-          }
-
-          if (url.pathname === "/api/otel/cost") {
-            if (!prom) return Response.json({ error: "OTel not configured" }, { status: 503 });
-            const range = url.searchParams.get("range") ?? "1h";
-            const result = await costByTicket(prom, range);
-            return Response.json({ data: result });
-          }
-
-          if (url.pathname === "/api/otel/tokens") {
-            if (!prom) return Response.json({ error: "OTel not configured" }, { status: 503 });
-            const range = url.searchParams.get("range") ?? "1h";
-            const tokens = await tokensByType(prom, range);
-            const hitRate = await cacheHitRate(prom, range);
-            return Response.json({ data: { tokens, cacheHitRate: hitRate } });
-          }
-
-          if (url.pathname === "/api/otel/cost-rate") {
-            if (!prom) return Response.json({ error: "OTel not configured" }, { status: 503 });
-            const interval = url.searchParams.get("interval") ?? "5m";
-            const result = await costRateByModel(prom, interval);
-            return Response.json({ data: result });
-          }
-
-          // OBS-9 (FINOPS P-B): cost by pipeline stage. Routes the EXISTING (but
-          // previously unrouted) `costByTaskType` — `sum by (task_type)(increase(
-          // cost[r]))` — with the OBS-9 zero-series filter applied at the query layer
-          // so the by-stage bar never renders the ~5 exact-0 phases. 503 when
-          // Prometheus is not configured (the P-B ChartCard degrades via the ladder).
-          if (url.pathname === "/api/otel/cost-by-stage") {
-            if (!prom) return Response.json({ error: "OTel not configured" }, { status: 503 });
-            const range = url.searchParams.get("range") ?? "24h";
-            const result = await costByTaskType(prom, range);
-            return Response.json({ data: result });
-          }
-
-          // OBS-11 (FINOPS P-D): cost by model / agent. Groups the cost counter by a
-          // WHITELISTED native dimension (`model` or `agent_name` — never interpolated
-          // from input, so no PromQL injection) with the OBS-9 zero-series filter
-          // applied so the ranked bar never shows the exact-0 models/agents an
-          // increase() window carries. `dim` defaults to model; an unknown dim → 400
-          // (honest, never a silently-empty bar). 503 when Prometheus is off.
-          if (url.pathname === "/api/otel/cost-by-dim") {
-            if (!prom) return Response.json({ error: "OTel not configured" }, { status: 503 });
-            const dim = url.searchParams.get("dim") ?? "model";
-            if (!isCostDimension(dim)) {
-              return Response.json({ error: "unknown dimension" }, { status: 400 });
-            }
-            const range = url.searchParams.get("range") ?? "24h";
-            const result = await costByDimension(prom, dim, range);
-            return Response.json({ data: result });
-          }
-
-          // CTL-1040 (FINOPS): cost grouped by work type. Board-backed — groups the SAME
-          // signal-file costs the expensive-tickets table shows (BoardTicket.costUSD) by
-          // BoardTicket.type. Prometheus carries no catalyst_ticket_type label, so this
-          // is the honest current-state source (UI carries a "data since 2026-06-11"
-          // caption). Always 200 — no Prometheus dependency.
-          if (url.pathname === "/api/otel/cost-by-work-type") {
-            const board = await boardSnapshot.getLatest();
-            const tickets = (board?.tickets ?? []).map((t) => ({
-              type: t.type,
-              costUSD: t.costUSD,
-            }));
-            return Response.json({ data: costByWorkType(tickets) });
-          }
-
-          // CTL-1040 (UTILIZATION): throughput grouped by work type. Loki-backed —
-          // counts phase.teardown.complete.* events per catalyst_ticket_type over the
-          // window. 503 when Loki is not configured (the ChartCard degrades via the ladder).
-          if (url.pathname === "/api/otel/throughput-by-work-type") {
-            if (!loki) return Response.json({ error: "OTel not configured" }, { status: 503 });
-            const range = url.searchParams.get("range") ?? "24h";
-            const result = await throughputByWorkType(loki, range);
-            if (result === null)
-              return Response.json({ error: "Loki unavailable" }, { status: 503 });
-            return Response.json({ data: result });
-          }
-
-          // OBS-9 (FINOPS HERO): the today-vs-7d dollar band. todayUsd (spend since
-          // local midnight) + avg7dUsd (the prior 7 FULL days' mean baseline) + the
-          // delta fraction + a linear EOD projection — all off the cost counter, no
-          // new plumbing. The partial current day is EXCLUDED from the 7d baseline so
-          // "is today normal?" compares like-for-like. 503 when Prometheus is absent.
-          if (url.pathname === "/api/otel/cost-today") {
-            if (!prom) return Response.json({ error: "OTel not configured" }, { status: 503 });
-            const result = await costToday(prom);
-            if (result === null) {
-              return Response.json({ error: "Prometheus unavailable" }, { status: 503 });
-            }
-            return Response.json({ data: result });
-          }
-
-          // OBS-9 (FINOPS P-A): hourly spend-over-time bars + spike flags. A
-          // query_range of `sum(increase(cost[1h]))` stepped at 1h over the window;
-          // each point carries `isSpike` (spend > max(2× median, μ+2σ) — the P-A
-          // `--chart-4` dot). 503 when Prometheus is absent; an honest `[]` for a
-          // quiet stack (the ChartCard empty state, never a fabricated bar).
-          if (url.pathname === "/api/otel/cost-series") {
-            if (!prom) return Response.json({ error: "OTel not configured" }, { status: 503 });
-            const range = url.searchParams.get("range") ?? "24h";
-            const result = await costSeries(prom, range);
-            if (result === null) {
-              return Response.json({ error: "Prometheus unavailable" }, { status: 503 });
-            }
-            return Response.json({ data: result });
-          }
-
-          // OBS-9 (FINOPS HERO-C, THE HEADLINE): cache-ROI $. Σ_model cacheRead_tokens
-          // × (input_price − cache_read_price) from a per-model price book — the real
-          // dollars the 99.8%-hit-rate prompt cache saved — plus the "(Nx)" multiplier
-          // (savings / actual spend). 503 when Prometheus is absent.
-          if (url.pathname === "/api/otel/cache-savings") {
-            if (!prom) return Response.json({ error: "OTel not configured" }, { status: 503 });
-            const range = url.searchParams.get("range") ?? "24h";
-            const result = await cacheSavings(prom, range);
-            if (result === null) {
-              return Response.json({ error: "Prometheus unavailable" }, { status: 503 });
-            }
-            return Response.json({ data: result });
-          }
-
-          // OBS-10 (FINOPS P-A drill): cost at a single spiking hour. Clicking a
-          // spiking bar in the spend-over-time chart re-queries THAT hour's by-ticket
-          // + by-model split (the "one re-query with the hour window"). `hour` is the
-          // clicked bar's epoch-SECOND timestamp; the query anchors a 1h `increase()`
-          // window to it via PromQL `offset`. Both maps are zero-filtered. 503 when
-          // Prometheus is absent; 400 when `hour` is missing/non-numeric (never a
-          // fabricated empty drill).
-          if (url.pathname === "/api/otel/cost-at-hour") {
-            if (!prom) return Response.json({ error: "OTel not configured" }, { status: 503 });
-            const hourParam = url.searchParams.get("hour");
-            const hour = hourParam !== null ? Number(hourParam) : NaN;
-            if (!Number.isFinite(hour) || hour <= 0) {
-              return Response.json({ error: "hour (epoch seconds) required" }, { status: 400 });
-            }
-            const result = await costAtHour(prom, hour);
-            if (result === null) {
-              return Response.json({ error: "Prometheus unavailable" }, { status: 503 });
-            }
-            return Response.json({ data: result });
-          }
-
-          if (url.pathname === "/api/otel/tools") {
-            if (!loki) return Response.json({ error: "OTel not configured" }, { status: 503 });
-            const range = url.searchParams.get("range") ?? "1h";
-            const result = await toolUsageByName(loki, range);
-            return Response.json({ data: result });
-          }
-
-          // OBS-7 (TELEMETRY P3): per-tool p50/p95 latency, the half /api/otel/tools
-          // (counts only) is missing so the panel can sort by TOTAL TIME (count × p95)
-          // rather than chattiness. unwrap duration_ms on tool_result by tool_name
-          // (toolLatency in otel-queries.ts). 503 when Loki is not configured; an
-          // empty stream is an HONEST 200 with `data:{}` (counts-only fallback).
-          if (url.pathname === "/api/otel/tool-latency") {
-            if (!loki) return Response.json({ error: "OTel not configured" }, { status: 503 });
-            const range = url.searchParams.get("range") ?? "1h";
-            const result = await toolLatency(loki, range);
-            if (result === null) {
-              // null means the queryRange came back null. Distinguish HONESTLY: if the
-              // /ready probe passed, Loki IS reachable and this is a QUERY/backend
-              // error (e.g. a LogQL 400), NOT "Loki unavailable" — don't mislabel it.
-              return otelDegradedResponse(loki, "tool-latency");
-            }
-            return Response.json({ data: result });
-          }
-
-          if (url.pathname === "/api/otel/errors") {
-            if (!loki) return Response.json({ error: "OTel not configured" }, { status: 503 });
-            const range = url.searchParams.get("range") ?? "1h";
-            const rawLimit = parseInt(url.searchParams.get("limit") ?? "50", 10);
-            const limit = Number.isFinite(rawLimit) ? Math.min(Math.max(1, rawLimit), 500) : 50;
-            // CTL-1039: alongside the panel's error rows, carry the proportional
-            // counts WITH EXPLICIT WINDOWS (15m + today) the hero reads to pick
-            // NOTED vs ERRORING. Backward-compatible: `data` stays the row array.
-            const [result, counts] = await Promise.all([
-              apiErrors(loki, range, limit),
-              apiErrorCounts(loki),
-            ]);
-            return Response.json({ data: result, counts });
-          }
-
-          // OBS-16 (UTILIZATION P_active): fleet-wide active-time ratio. A single
-          // Prometheus read of `sum(rate(claude_code_active_time_seconds_total[range]))`
-          // — the active seconds-per-second across the fleet (≈ slots' worth of
-          // wall-clock genuinely computing). The UI divides this by config.inFlight
-          // (busy-slot capacity it already holds) to render "X% computing / Y%
-          // waiting". 503 when Prometheus is absent (the P_active ChartCard degrades
-          // via the [prom] ladder); an idle fleet is an HONEST 200 with
-          // `data:{activeSecondsPerSecond:0}` (the genuine low read, never a
-          // fabricated number).
-          if (url.pathname === "/api/otel/active-time") {
-            if (!prom) return Response.json({ error: "OTel not configured" }, { status: 503 });
-            const range = url.searchParams.get("range") ?? "1h";
-            const result = await activeTimeRatio(prom, range);
-            if (result === null) {
-              return Response.json({ error: "Prometheus unavailable" }, { status: 503 });
-            }
-            return Response.json({ data: result });
-          }
-
-          // OBS-7 (TELEMETRY P4): per-model api_request latency (p50/p95) + error%,
-          // read off the SAME claude-code Loki stream as the tail/errors — NOT a new
-          // Prometheus dependency. The LogQL unwraps `duration_ms` on api_request and
-          // aggregates with quantile_over_time by model (modelLatency in
-          // otel-queries.ts). 503 when Loki is not configured (the P4 ChartCard
-          // degrades via the ladder); an empty stream is an HONEST 200 with `data:[]`
-          // (the card's "no data in range" state, NOT an error).
-          if (url.pathname === "/api/otel/model-latency") {
-            if (!loki) return Response.json({ error: "OTel not configured" }, { status: 503 });
-            const range = url.searchParams.get("range") ?? "1h";
-            const result = await modelLatency(loki, range);
-            if (result === null) {
-              // null means the queryRange came back null. Surface it HONESTLY: a
-              // passing /ready probe means Loki is reachable and this is a query/
-              // backend error (degraded), NOT a fabricated empty or a false
-              // "Loki unavailable".
-              return otelDegradedResponse(loki, "model-latency");
-            }
-            return Response.json({ data: result });
-          }
-
-          // OBS-6 (TELEMETRY): the fleet-wide grouped live tail + freshness. ONE
-          // newest-first scan of the claude-code Loki stream (same pipe as the
-          // per-session history, minus the session filter). The hero reads
-          // `freshnessMs` (age of the newest line) to pick FLOWING vs QUIET; the P1
-          // panel groups `rows` by worker client-side. 503 when Loki is not
-          // configured (the surface degrades via the ChartCard ladder). An empty
-          // stream is an HONEST 200 with `freshnessMs:null` (QUIET, not an error).
-          if (url.pathname === "/api/otel/tail") {
-            if (!loki) return Response.json({ error: "OTel not configured" }, { status: 503 });
-            const range = url.searchParams.get("range") ?? "15m";
-            const rawLimit = parseInt(url.searchParams.get("limit") ?? "300", 10);
-            const limit = Number.isFinite(rawLimit) ? Math.min(Math.max(1, rawLimit), 1000) : 300;
-            const result = await recentTail(loki, range, limit);
-            if (result === null) {
-              // Loki probe failed mid-flight — honest 503, not a fabricated empty.
-              return Response.json({ error: "Loki unavailable" }, { status: 503 });
-            }
-            return Response.json({ data: result });
-          }
-
-          // OBS-8 (TELEMETRY P5): events/min heatmap, workers × time. ONE metric
-          // query over the claude-code Loki stream — `count_over_time` of every line
-          // per `session_id` in 15m buckets (eventsHeatmap in otel-queries.ts). The
-          // payload is {buckets, cells}; the UI joins cells[].sessionId to board
-          // worker names and renders a row for EVERY running worker (silent ones
-          // included) so an early stall — a `running` worker with dark recent cells —
-          // is visible. 503 when Loki is not configured (the P5 ChartCard degrades via
-          // the ladder, but its board-sourced row headers still render per design
-          // §3.1); a reachable-but-quiet stream is an HONEST 200 with empty cells.
-          if (url.pathname === "/api/otel/events-heatmap") {
-            if (!loki) return Response.json({ error: "OTel not configured" }, { status: 503 });
-            const range = url.searchParams.get("range") ?? "6h";
-            const result = await eventsHeatmap(loki, range);
-            if (result === null) {
-              // Loki probe failed mid-flight — honest 503, not a fabricated empty.
-              return Response.json({ error: "Loki unavailable" }, { status: 503 });
-            }
-            return Response.json({ data: result });
-          }
-
-          if (url.pathname === "/api/otel/cost-validation") {
-            if (!prom) return Response.json({ error: "OTel not configured" }, { status: 503 });
-            const range = url.searchParams.get("range") ?? "6h";
-            const snap = buildSnapshot(wtDir, buildOpts);
-            const signalCosts: Record<string, number> = {};
-            for (const orch of snap.orchestrators) {
-              for (const [key, worker] of Object.entries(orch.workers)) {
-                if (worker.cost?.costUSD) signalCosts[key] = worker.cost.costUSD;
-              }
-            }
-            const result = await costValidation(prom, signalCosts, range);
-            return Response.json({ data: result });
-          }
-
-          // CTL-914 (DETAIL3): the worker-page [history] tail. Queries the
-          // `claude-code` Loki stream for ONE run's transcript by its CC session
-          // UUID — REAL today, no plumbing — so a dead worker's tail is readable
-          // hours later (why the worker page is never empty). The filter is a
-          // `| session_id=\`UUID\`` STRUCTURED-METADATA pipe inside
-          // workerHistoryBySession (a `{session_id=}` label matcher returns 0).
-          // sessionId is UUID-validated before it ever reaches the LogQL, so the
-          // pipe can never be an injection vector. 503 when Loki is not configured
-          // (the UI degrades to the resident-data page), 400 on a bad id.
-          const ecWorkerHistoryMatch = url.pathname.match(/^\/api\/ec-worker-history\/([^/]+)$/);
-          if (ecWorkerHistoryMatch) {
-            let sessionId: string;
-            try {
-              sessionId = decodeURIComponent(ecWorkerHistoryMatch[1]);
-            } catch {
-              return new Response("Bad Request", { status: 400 });
-            }
-            if (!isValidCcSessionId(sessionId)) {
-              return new Response("Bad Request", { status: 400 });
-            }
-            if (!loki) {
-              return Response.json({ error: "OTel not configured" }, { status: 503 });
-            }
-            const range = url.searchParams.get("range") ?? "24h";
-            const rawLimit = parseInt(url.searchParams.get("limit") ?? "500", 10);
-            const limit = Number.isFinite(rawLimit) ? Math.min(Math.max(1, rawLimit), 2000) : 500;
-            const rows = await workerHistoryBySession(loki, sessionId, range, limit);
-            if (rows === null) {
-              // Loki probe failed mid-flight — honest 503, not a fabricated empty.
-              return Response.json({ error: "Loki unavailable" }, { status: 503 });
-            }
-            return Response.json({ data: rows });
-          }
-
-          // CTL-917 (DETAIL6): the worker Burn Strip's REAL Prometheus sparklines.
-          // Four query_range series keyed on the CC session UUID (cost / tokens /
-          // tokens-by-type / active-seconds) — no new plumbing, the same already-
-          // emitting OTEL pipeline the `/api/otel/*` routes read. The UUID is
-          // UUID-validated before it reaches the PromQL `{session_id=…}` matcher,
-          // so the matcher can never be an injection vector. 503 when Prometheus is
-          // not configured (the UI falls back to the resident BoardWorker scalar),
-          // 400 on a bad id.
-          const otelBurnMatch = url.pathname.match(/^\/api\/otel\/burn\/([^/]+)$/);
-          if (otelBurnMatch) {
-            let sessionId: string;
-            try {
-              sessionId = decodeURIComponent(otelBurnMatch[1]);
-            } catch {
-              return new Response("Bad Request", { status: 400 });
-            }
-            if (!isValidCcSessionId(sessionId)) {
-              return new Response("Bad Request", { status: 400 });
-            }
-            if (!prom) {
-              return Response.json({ error: "OTel not configured" }, { status: 503 });
-            }
-            const range = url.searchParams.get("range") ?? "1h";
-            const series = await workerBurnSeries(prom, sessionId, range);
-            if (series === null) {
-              // Prometheus probe failed mid-flight — honest 503, never a fake series.
-              return Response.json({ error: "Prometheus unavailable" }, { status: 503 });
-            }
-            return Response.json({ data: series });
-          }
-
-          // CTL-917 (DETAIL6): the ticket telemetry strip's REAL Prometheus
-          // sparklines keyed on the Linear key (total cost / tokens-by-type +
-          // cost-by-phase `sum by(task_type)` + cost-by-model `sum by(model)`).
-          // commits/LoC stay git-sourced (NEEDS-PLUMBING) so they are NOT queried
-          // here. The linear_key is validated before it reaches the PromQL matcher.
-          const otelTicketTelemetryMatch = url.pathname.match(
-            /^\/api\/otel\/ticket-telemetry\/([^/]+)$/,
-          );
-          if (otelTicketTelemetryMatch) {
-            let linearKey: string;
-            try {
-              linearKey = decodeURIComponent(otelTicketTelemetryMatch[1]);
-            } catch {
-              return new Response("Bad Request", { status: 400 });
-            }
-            if (!isValidLinearKey(linearKey)) {
-              return new Response("Bad Request", { status: 400 });
-            }
-            if (!prom) {
-              return Response.json({ error: "OTel not configured" }, { status: 503 });
-            }
-            const range = url.searchParams.get("range") ?? "1h";
-            const series = await ticketTelemetrySeries(prom, linearKey, range);
-            if (series === null) {
-              return Response.json({ error: "Prometheus unavailable" }, { status: 503 });
-            }
-            return Response.json({ data: series });
-          }
-
-          if (url.pathname === "/api/annotations") {
-            return Response.json({ annotations: getAllAnnotations() });
-          }
-
-          const annMatch = url.pathname.match(/^\/api\/annotations\/([A-Za-z0-9._-]+)$/);
-          if (annMatch && annMatch[1]) {
-            const sessionId = decodeURIComponent(annMatch[1]);
-
-            if (req.method === "DELETE") {
-              deleteAnnotation(sessionId);
-              return Response.json({ ok: true });
-            }
-
-            if (req.method === "PUT") {
-              let body: Record<string, unknown>;
+          let captured: ReadableStreamDefaultController<Uint8Array> | null = null;
+          // CTL-1224: the live activity tail is now fed by the ONE shared
+          // event-ring (eventRing.onAppend) rather than a per-client
+          // tailEventLog poll loop + per-client backlog readFileSync. Each
+          // client keeps its OWN jq filter stream (predicates differ per
+          // client), but the expensive shared part — the file poll + byte read —
+          // is one backend loop (the ring's tick) regardless of client count.
+          let activityUnsub: (() => void) | null = null;
+          let activityFilter: FilterStream | null = null;
+          const stream = new ReadableStream<Uint8Array>({
+            async start(controller) {
+              captured = controller;
+              sseClients.set(controller, filter);
               try {
-                body = (await req.json()) as Record<string, unknown>;
-              } catch {
-                return Response.json({ error: "Invalid JSON body" }, { status: 400 });
+                // Initial snapshot always sent regardless of filter to bootstrap client state
+                const snapshot = snapshotWithPrStatus();
+                const envelope = createEvent("snapshot", snapshot, "filesystem");
+                const msg = `event: snapshot\ndata: ${JSON.stringify(envelope)}\n\n`;
+                controller.enqueue(encoder.encode(msg));
+              } catch (err) {
+                console.error(`[server] initial snapshot enqueue failed:`, err);
               }
 
-              const VALID_FLAGS = new Set(["starred", "flagged", "archived"]);
-
-              if (Array.isArray(body.addFlags)) {
-                for (const f of body.addFlags) {
-                  if (typeof f !== "string" || !VALID_FLAGS.has(f)) {
-                    return Response.json(
-                      {
-                        error: `Invalid flag: ${String(f)}. Valid: starred, flagged, archived`,
-                      },
-                      { status: 400 },
+              // Activity stream multiplex: only when the client opted in via
+              // `?activity=` (predicate may be empty for "all events").
+              if (filter.activityPredicate !== undefined) {
+                const predicate = filter.activityPredicate;
+                try {
+                  // CTL-1224: serve the backlog from the shared ring when it
+                  // covers the window; bounded file fallback on underflow. No
+                  // unconditional full-file readFileSync on the SSE path.
+                  const backlogLines = await readBacklog({
+                    catalystDir: CATALYST_DIR,
+                    predicate,
+                    limit: 100,
+                    ring: eventRing,
+                  });
+                  const parsed = backlogLines
+                    .map((l) => safeParseJson(l))
+                    .filter((v): v is Record<string, unknown> => v !== null);
+                  const backlogEnv = createEvent(
+                    "global-event-backlog",
+                    { events: parsed },
+                    "filesystem",
+                  );
+                  // Enqueue may race with client cancel; swallow the
+                  // ERR_INVALID_STATE that comes back if the controller has
+                  // already closed.
+                  try {
+                    controller.enqueue(
+                      encoder.encode(
+                        `event: global-event-backlog\ndata: ${JSON.stringify(backlogEnv)}\n\n`,
+                      ),
                     );
+                  } catch {
+                    /* client cancelled */
                   }
+                } catch (err) {
+                  console.error(`[server] activity backlog failed:`, err);
                 }
-              }
 
-              if (typeof body.displayName === "string") {
-                setDisplayName(sessionId, body.displayName);
-              } else if (body.displayName === null) {
-                setDisplayName(sessionId, null);
+                // CTL-1224: per-client jq filter (or passthrough for an empty
+                // predicate) fed by the SHARED ring tail. Matched lines are
+                // wrapped in the SAME global-event envelope + framing as before.
+                const filterStream = createFilterStream(predicate);
+                activityFilter = filterStream;
+                filterStream.onMatch((line) => {
+                  const parsed = safeParseJson(line);
+                  if (parsed === null) return;
+                  const env = createEvent("global-event", parsed, "filesystem");
+                  try {
+                    controller.enqueue(
+                      encoder.encode(
+                        `event: global-event\ndata: ${JSON.stringify(env)}\n\n`,
+                      ),
+                    );
+                  } catch {
+                    // client gone — stop feeding it
+                    activityUnsub?.();
+                    activityUnsub = null;
+                  }
+                });
+                activityUnsub = eventRing.onAppend((lines) => {
+                  for (const l of lines) filterStream.write(l);
+                  void filterStream.flush();
+                });
               }
+            },
+            cancel() {
+              if (captured) sseClients.delete(captured);
+              activityUnsub?.(); // CTL-1224: deregister ring listener (no leak)
+              activityUnsub = null;
+              activityFilter?.close(); // CTL-1224: reap the per-client jq process
+              activityFilter = null;
+            },
+          });
+          return new Response(stream, {
+            headers: {
+              "Content-Type": "text/event-stream",
+              "Cache-Control": "no-cache",
+              Connection: "keep-alive",
+              "Access-Control-Allow-Origin": "*",
+            },
+          });
+        }
 
-              if (Array.isArray(body.addFlags)) {
-                for (const f of body.addFlags) {
-                  if (typeof f === "string") addFlag(sessionId, f);
-                }
-              }
-              if (Array.isArray(body.removeFlags)) {
-                for (const f of body.removeFlags) {
-                  if (typeof f === "string") removeFlag(sessionId, f);
-                }
-              }
-              if (typeof body.addNote === "string") {
-                addNote(sessionId, body.addNote);
-              }
-              if (
-                typeof body.removeNoteIndex === "number" &&
-                Number.isInteger(body.removeNoteIndex)
-              ) {
-                removeNote(sessionId, body.removeNoteIndex);
-              }
-              if (Array.isArray(body.addTags)) {
-                for (const t of body.addTags) {
-                  if (typeof t === "string") addTag(sessionId, t);
-                }
-              }
-              if (Array.isArray(body.removeTags)) {
-                for (const t of body.removeTags) {
-                  if (typeof t === "string") removeTag(sessionId, t);
-                }
-              }
+        if (url.pathname === "/api/version") {
+          return Response.json({ version: CATALYST_DEV_VERSION });
+        }
 
-              const annotation = getAnnotation(sessionId);
-              return Response.json({ annotation });
-            }
+        if (url.pathname === "/api/snapshot") {
+          return Response.json(snapshotWithPrStatus());
+        }
 
-            return new Response("Method Not Allowed", { status: 405 });
+        if (url.pathname === "/api/config") {
+          const cfg = loadMonitorConfig(monitorConfigPath);
+          return Response.json(cfg);
+        }
+
+        // CTL-1653: GET /api/accounts — THIS node's Claude-account posture
+        // (active account + per-window utilization/resets/status +
+        // siblingWithHeadroom), token-free, cached ~5 min. `?refresh=true`
+        // forces a fresh probe. Disabled (accountsProbeExec:null) → a stable
+        // available:false response, matching the dbPath-gated endpoints.
+        if (url.pathname === "/api/accounts") {
+          if (!accountsProbe) return Response.json({ available: false, node: hostName() });
+          const refresh = url.searchParams.get("refresh") === "true";
+          const summary = await accountsProbe.get({ refresh });
+          return Response.json({ available: true, ...summary });
+        }
+
+        // CTL-1653: SSE stream of the node's Claude-account posture. Each event:
+        //   event: account\ndata: <summary json>\n\n
+        // On connect, emit the current cached summary immediately (so a fresh
+        // dashboard renders without waiting a whole interval); thereafter the
+        // periodic timer broadcasts each fresh summary to every subscriber.
+        if (url.pathname === "/api/accounts/stream") {
+          const probeRef = accountsProbe;
+          let send: ((s: CachedAccountsSummary) => void) | null = null;
+          const stream = new ReadableStream<Uint8Array>({
+            async start(controller) {
+              const frame = (s: unknown) => {
+                try {
+                  controller.enqueue(encoder.encode(`event: account\ndata: ${JSON.stringify(s)}\n\n`));
+                } catch {
+                  if (send) accountsSubscribers.delete(send);
+                  send = null;
+                }
+              };
+              if (!probeRef) {
+                // Disabled: emit one unavailable frame, no subscription.
+                frame({ available: false, node: hostName() });
+                return;
+              }
+              send = frame;
+              accountsSubscribers.add(send);
+              try {
+                frame(await probeRef.get());
+              } catch (err) {
+                console.error(`[server] accounts stream initial frame failed:`, err);
+              }
+            },
+            cancel() {
+              if (send) accountsSubscribers.delete(send);
+              send = null;
+            },
+          });
+          return new Response(stream, {
+            headers: {
+              "Content-Type": "text/event-stream",
+              "Cache-Control": "no-cache",
+              Connection: "keep-alive",
+              "Access-Control-Allow-Origin": "*",
+            },
+          });
+        }
+
+        // CTL-1152: GET /api/projects — the config-driven project roster. One
+        // descriptor per configured catalyst.monitor.linear.teams[] entry PLUS a
+        // self-identifying unconfigured lane per observed-work repo (the live
+        // board snapshot's `.repos`) with no configured descriptor (union rule).
+        // Fail-open: ANY error degrades to { projects: [] } (mirrors /api/config
+        // and the repo-icon endpoint) so the nav renders its empty state, never 5xx.
+        if (url.pathname === "/api/projects") {
+          try {
+            const board = await boardSnapshot.getLatest();
+            const observedRepos = board?.repos ?? [];
+            return Response.json({ projects: loadProjects({ observedRepos, configPath: projectsConfigPath }) });
+          } catch {
+            return Response.json({ projects: [] });
           }
+        }
 
-          if (url.pathname === "/api/archive/orchestrators") {
-            if (!dbPath) {
-              return Response.json({ entries: [], total: 0 });
+        // CTL-1153 (M2): PUT /api/projects/:key — upsert one editable projects[] entry
+        // (name/color/icon/stateMap). First edit of a known team key migrates THAT project
+        // into catalyst.projects[]. READ (GET above) is fail-open; WRITE is fail-CLOSED on input.
+        // Validation → HTTP code table:
+        //   405  non-PUT method
+        //   400  bad JSON | non-object | unknown field (incl. vcsRepo/key) | bad name | bad hue | bad stateMap
+        //   404  key not in teams[] and not in existing projects[]
+        //   500  genuine persistence failure
+        //   200  { project, projects }
+        {
+          const projectKeyMatch = url.pathname.match(/^\/api\/projects\/([A-Za-z0-9._-]+)$/);
+          if (projectKeyMatch && projectKeyMatch[1]) {
+            if (req.method !== "PUT") return new Response("Method Not Allowed", { status: 405 });
+            let key: string;
+            try { key = decodeURIComponent(projectKeyMatch[1]); }
+            catch { return Response.json({ error: "Bad project key" }, { status: 400 }); }
+            let body: unknown;
+            try { body = await req.json(); }
+            catch { return Response.json({ error: "Invalid JSON body" }, { status: 400 }); }
+            const v = validateProjectPatch(body);
+            if (!v.ok) return Response.json({ error: v.error }, { status: v.status });
+            let result: ReturnType<typeof writeProjectPatch>;
+            try {
+              result = writeProjectPatch(projectsConfigPath, key.toUpperCase(), v.patch);
+            } catch (err) {
+              console.error(`[server] PUT /api/projects/${key} failed:`, err);
+              return Response.json({ error: "Failed to persist project settings" }, { status: 500 });
             }
-            const params = url.searchParams;
-            const limitRaw = params.get("limit");
-            const offsetRaw = params.get("offset");
-            const parsedLimit = limitRaw ? Number.parseInt(limitRaw, 10) : NaN;
-            const parsedOffset = offsetRaw ? Number.parseInt(offsetRaw, 10) : NaN;
-            const result = listArchivedOrchestrators(dbPath, {
-              since: params.get("since") ?? undefined,
-              until: params.get("until") ?? undefined,
+            if (!result.ok) {
+              return Response.json({ error: `Unknown project key: ${key.toUpperCase()}` }, { status: 404 });
+            }
+            const board = await boardSnapshot.getLatest();
+            const observedRepos = board?.repos ?? [];
+            const projects = loadProjects({ observedRepos, configPath: projectsConfigPath });
+            return Response.json({ project: projects.find((p) => p.key === key.toUpperCase()) ?? null, projects });
+          }
+        }
+
+        // CTL-961: /api/repo-icon/<repoShortName> — auto-detect favicon from GitHub.
+        // Reads the owner/repo from the monitor config repoOwners map, probes common
+        // icon paths via `gh api`, caches the result for 7 days, returns a data URL.
+        // Fail-open: returns { found: false } (204) when not configured or not found.
+        if (url.pathname.startsWith("/api/repo-icon/")) {
+          // CTL-979: normalize to lowercase so /api/repo-icon/adva resolves "Adva" vcsRepo keys.
+          const repoKey = url.pathname.slice("/api/repo-icon/".length).trim().toLowerCase();
+          if (!repoKey || repoKey.includes("/")) {
+            return new Response("Bad repo key", { status: 400 });
+          }
+          const cfg = loadMonitorConfig(monitorConfigPath);
+          const ownerRepo = cfg.repoOwners[repoKey];
+          if (!ownerRepo) {
+            return Response.json({ found: false }, { status: 204 });
+          }
+          const cacheDir = join(CATALYST_DIR, "repo-icon-cache");
+          const result = await fetchRepoIcon(ownerRepo, cacheDir);
+          if (!result.found) return Response.json({ found: false }, { status: 204 });
+          return Response.json(result);
+        }
+
+        if (url.pathname === "/api/analytics") {
+          return Response.json(buildAnalyticsSnapshot(wtDir, buildOpts));
+        }
+
+        if (url.pathname === "/api/sessions") {
+          if (!dbPath) {
+            return Response.json({ available: false, sessions: [] });
+          }
+          const params = url.searchParams;
+          const limitRaw = params.get("limit");
+          const parsedLimit = limitRaw ? Number.parseInt(limitRaw, 10) : NaN;
+          const result = readSessionStore(dbPath, {
+            soloOnly: params.get("solo") === "true",
+            workflowId: params.get("workflow") ?? undefined,
+            ticket: params.get("ticket") ?? undefined,
+            status: params.get("status") ?? undefined,
+            limit: Number.isFinite(parsedLimit) ? parsedLimit : undefined,
+          });
+          const sessions: SessionState[] = result.sessions;
+          return Response.json({ available: result.available, sessions });
+        }
+
+        if (url.pathname === "/api/history") {
+          if (!dbPath) {
+            return Response.json({ entries: [], total: 0 });
+          }
+          const params = url.searchParams;
+          const limitRaw = params.get("limit");
+          const offsetRaw = params.get("offset");
+          const parsedLimit = limitRaw ? Number.parseInt(limitRaw, 10) : NaN;
+          const parsedOffset = offsetRaw ? Number.parseInt(offsetRaw, 10) : NaN;
+          return Response.json(
+            queryHistory(dbPath, {
+              skill: params.get("skill") ?? undefined,
               ticket: params.get("ticket") ?? undefined,
-              status: params.get("status") ?? undefined,
+              since: params.get("since") ?? undefined,
+              search: params.get("search") ?? undefined,
               limit: Number.isFinite(parsedLimit) ? parsedLimit : undefined,
               offset: Number.isFinite(parsedOffset) ? parsedOffset : undefined,
+            }),
+          );
+        }
+
+        if (url.pathname === "/api/history/stats") {
+          if (!dbPath) {
+            return Response.json({
+              totalSessions: 0,
+              totalCostUsd: 0,
+              avgCostUsd: 0,
+              avgDurationMs: 0,
+              successRate: 0,
+              skillBreakdown: [],
+              dailyCosts: [],
+              topTools: [],
             });
-            return Response.json(result);
+          }
+          const params = url.searchParams;
+          return Response.json(
+            queryStats(dbPath, {
+              skill: params.get("skill") ?? undefined,
+              since: params.get("since") ?? undefined,
+            }),
+          );
+        }
+
+        if (url.pathname === "/api/history/compare") {
+          if (!dbPath) {
+            return Response.json(null);
+          }
+          const params = url.searchParams;
+          const a = params.get("a");
+          const b = params.get("b");
+          if (!a || !b) {
+            return new Response("Missing ?a=<id>&b=<id>", { status: 400 });
+          }
+          const result = compareSessions(dbPath, a, b);
+          if (!result) {
+            return new Response("Session(s) not found", { status: 404 });
+          }
+          return Response.json(result);
+        }
+
+        const rollupMatch = url.pathname.match(/^\/api\/rollup\/([^/]+)$/);
+        if (rollupMatch) {
+          let orchId: string;
+          try {
+            orchId = decodeURIComponent(rollupMatch[1]);
+          } catch {
+            return new Response("Bad Request", { status: 400 });
+          }
+          if (orchId.includes("..") || orchId.includes("/") || orchId.includes("\0")) {
+            return new Response("Bad Request", { status: 400 });
+          }
+          const snap = snapshotWithPrStatus();
+          const orch = snap.orchestrators.find((o) => o.id === orchId);
+          if (!orch) {
+            return new Response("Not Found", { status: 404 });
+          }
+          return Response.json({
+            orchId: orch.id,
+            rollup: orch.rollupBriefing ?? null,
+          });
+        }
+
+        const sessionMatch = url.pathname.match(
+          /^\/api\/session\/([^/]+)\/([^/]+)$/,
+        );
+        if (sessionMatch) {
+          let orchId: string;
+          let ticket: string;
+          try {
+            orchId = decodeURIComponent(sessionMatch[1]);
+            ticket = decodeURIComponent(sessionMatch[2]);
+          } catch {
+            return new Response("Bad Request", { status: 400 });
+          }
+          if (
+            orchId.includes("..") ||
+            orchId.includes("\0") ||
+            ticket.includes("..") ||
+            ticket.includes("/") ||
+            ticket.includes("\0")
+          ) {
+            return new Response("Bad Request", { status: 400 });
+          }
+          const detail = buildSessionDetail(wtDir, orchId, ticket, { runsDir });
+          if (!detail) {
+            return new Response("Not Found", { status: 404 });
+          }
+          if (prFetcher && detail.worker.pr) {
+            const repo = parseRepoFromPrUrl(detail.worker.pr.url);
+            if (repo) {
+              const status = prFetcher.get(repo, detail.worker.pr.number);
+              if (status) {
+                detail.worker.prState = status.state;
+                detail.worker.prMergedAt = status.mergedAt;
+              }
+            }
+          }
+          return Response.json(detail);
+        }
+
+        const streamMatch = url.pathname.match(
+          /^\/api\/worker-stream\/([^/]+)\/([^/]+)$/,
+        );
+        if (streamMatch) {
+          let orchId: string;
+          let ticket: string;
+          try {
+            orchId = decodeURIComponent(streamMatch[1]);
+            ticket = decodeURIComponent(streamMatch[2]);
+          } catch {
+            return new Response("Bad Request", { status: 400 });
+          }
+          if (
+            orchId.includes("..") ||
+            orchId.includes("\0") ||
+            ticket.includes("..") ||
+            ticket.includes("/") ||
+            ticket.includes("\0")
+          ) {
+            return new Response("Bad Request", { status: 400 });
+          }
+          const maxEventsRaw = url.searchParams.get("limit");
+          const maxEvents = maxEventsRaw ? Number.parseInt(maxEventsRaw, 10) : 30;
+          const stateReader = await import("./lib/state-reader");
+          const scanned = runsDir
+            ? stateReader.scanAllOrchestrators({ runsDir, wtDir })
+            : stateReader.scanOrchestrators(wtDir);
+          const entry = scanned.find((d) => basename(d.path) === orchId);
+          if (!entry) {
+            return new Response("Not Found", { status: 404 });
+          }
+          const events = readRecentStreamEvents(
+            entry.path,
+            ticket,
+            Number.isFinite(maxEvents) ? maxEvents : 30,
+          );
+          return Response.json({ orchId, ticket, events });
+        }
+
+        const subagentsMatch = url.pathname.match(
+          /^\/api\/worker\/([^/]+)\/([^/]+)\/subagents$/,
+        );
+        if (subagentsMatch) {
+          let orchId: string;
+          let ticket: string;
+          try {
+            orchId = decodeURIComponent(subagentsMatch[1]);
+            ticket = decodeURIComponent(subagentsMatch[2]);
+          } catch {
+            return new Response("Bad Request", { status: 400 });
+          }
+          if (
+            orchId.includes("..") ||
+            orchId.includes("/") ||
+            orchId.includes("\0") ||
+            ticket.includes("..") ||
+            ticket.includes("/") ||
+            ticket.includes("\0")
+          ) {
+            return new Response("Bad Request", { status: 400 });
+          }
+          const stateReader = await import("./lib/state-reader");
+          const scanned = runsDir
+            ? stateReader.scanAllOrchestrators({ runsDir, wtDir })
+            : stateReader.scanOrchestrators(wtDir);
+          const entry = scanned.find((d) => basename(d.path) === orchId);
+          if (!entry) return new Response("Not Found", { status: 404 });
+          const tree = parseStreamForSubagents(streamFilePath(entry.path, ticket));
+          return Response.json({ orchId, ticket, tree });
+        }
+
+        const workerTodosMatch = url.pathname.match(
+          /^\/api\/worker\/([^/]+)\/([^/]+)\/todos$/,
+        );
+        if (workerTodosMatch) {
+          let orchId: string;
+          let ticket: string;
+          try {
+            orchId = decodeURIComponent(workerTodosMatch[1]);
+            ticket = decodeURIComponent(workerTodosMatch[2]);
+          } catch {
+            return new Response("Bad Request", { status: 400 });
+          }
+          if (
+            orchId.includes("..") ||
+            orchId.includes("/") ||
+            orchId.includes("\0") ||
+            ticket.includes("..") ||
+            ticket.includes("/") ||
+            ticket.includes("\0")
+          ) {
+            return new Response("Bad Request", { status: 400 });
+          }
+          const stateReader = await import("./lib/state-reader");
+          const scanned = runsDir
+            ? stateReader.scanAllOrchestrators({ runsDir, wtDir })
+            : stateReader.scanOrchestrators(wtDir);
+          const entry = scanned.find((d) => basename(d.path) === orchId);
+          if (!entry) return new Response("Not Found", { status: 404 });
+          const tree = parseStreamForSubagents(streamFilePath(entry.path, ticket));
+          const todos = flattenTodosForWorker(tree, ticket);
+          return Response.json({ orchId, ticket, todos });
+        }
+
+        const orchTodosMatch = url.pathname.match(/^\/api\/orch\/([^/]+)\/todos$/);
+        if (orchTodosMatch) {
+          let orchId: string;
+          try {
+            orchId = decodeURIComponent(orchTodosMatch[1]);
+          } catch {
+            return new Response("Bad Request", { status: 400 });
+          }
+          if (orchId.includes("..") || orchId.includes("/") || orchId.includes("\0")) {
+            return new Response("Bad Request", { status: 400 });
+          }
+          const stateReader = await import("./lib/state-reader");
+          const scanned = runsDir
+            ? stateReader.scanAllOrchestrators({ runsDir, wtDir })
+            : stateReader.scanOrchestrators(wtDir);
+          const entry = scanned.find((d) => basename(d.path) === orchId);
+          if (!entry) return new Response("Not Found", { status: 404 });
+          const orchState = stateReader.readOrchestratorState(
+            entry.path,
+            "workspace" in entry ? entry.workspace : "default",
+          );
+          const todos = [];
+          for (const [, worker] of Object.entries(orchState.workers)) {
+            const ticket = worker.ticket;
+            if (!ticket) continue;
+            const tree = parseStreamForSubagents(streamFilePath(entry.path, ticket));
+            todos.push(...flattenTodosForWorker(tree, ticket));
+          }
+          return Response.json({ orchId, todos });
+        }
+
+        if (url.pathname === "/api/worker-tasks/debug") {
+          const pidRaw = url.searchParams.get("pid");
+          const sessionIdParam = url.searchParams.get("sessionId");
+          if (!pidRaw && !sessionIdParam) {
+            return new Response("pid or sessionId required", { status: 400 });
+          }
+          const diagnostic = getTaskDiagnostic({
+            pid: pidRaw ? Number(pidRaw) : undefined,
+            sessionId: sessionIdParam ?? undefined,
+          });
+          return Response.json(diagnostic);
+        }
+
+        const taskMatch = url.pathname.match(
+          /^\/api\/worker-tasks$/,
+        );
+        if (taskMatch) {
+          const pidRaw = url.searchParams.get("pid");
+          const sessionIdParam = url.searchParams.get("sessionId");
+          if (!pidRaw && !sessionIdParam) {
+            return new Response("pid or sessionId required", { status: 400 });
+          }
+          const sessionId = sessionIdParam
+            || (pidRaw ? sessionIdFromPid(Number(pidRaw)) : null);
+          if (!sessionId) {
+            return Response.json({ tasks: null });
+          }
+          const tasks = readWorkerTasks(sessionId);
+          return Response.json({ tasks });
+        }
+
+        if (url.pathname === "/api/comms/channels") {
+          if (!comms) return Response.json({ channels: [] });
+          return Response.json({ channels: await comms.listChannels() });
+        }
+
+        const commsStreamMatch = url.pathname.match(
+          /^\/api\/comms\/channels\/([^/]+)\/stream$/,
+        );
+        if (commsStreamMatch) {
+          let channelName: string;
+          try {
+            channelName = decodeURIComponent(commsStreamMatch[1]);
+          } catch {
+            return new Response("Bad Request", { status: 400 });
+          }
+          if (!isValidChannelName(channelName)) {
+            return new Response("Invalid channel name", { status: 400 });
+          }
+          if (!comms) return new Response("Comms not available", { status: 503 });
+
+          const commsReader = comms;
+          let offset = 0;
+          let timer: ReturnType<typeof setInterval> | null = null;
+          let inFlight = false;
+          const stream = new ReadableStream<Uint8Array>({
+            async start(controller) {
+              const initial = await commsReader.getChannel(channelName, { limit: 200 });
+              if (!initial) {
+                const errFrame = `event: error-event\ndata: ${JSON.stringify({ error: "channel-not-found", channel: channelName })}\n\n`;
+                try {
+                  controller.enqueue(encoder.encode(errFrame));
+                } catch {
+                  // Client may have already disconnected.
+                }
+                controller.close();
+                return;
+              }
+              offset = initial.tailOffset;
+              const snapshotFrame = `event: snapshot\ndata: ${JSON.stringify(initial)}\n\n`;
+              try {
+                controller.enqueue(encoder.encode(snapshotFrame));
+              } catch {
+                return;
+              }
+              timer = setInterval(() => {
+                if (inFlight) return;
+                inFlight = true;
+                void (async () => {
+                  try {
+                    const tail = await commsReader.tailChannel(channelName, offset);
+                    offset = tail.newOffset;
+                    for (const m of tail.messages) {
+                      const frame = `event: message\ndata: ${JSON.stringify(m)}\n\n`;
+                      controller.enqueue(encoder.encode(frame));
+                    }
+                  } catch {
+                    // Keep the stream alive on transient read errors.
+                  } finally {
+                    inFlight = false;
+                  }
+                })();
+              }, 500);
+            },
+            cancel() {
+              if (timer) clearInterval(timer);
+              timer = null;
+            },
+          });
+          return new Response(stream, {
+            headers: {
+              "Content-Type": "text/event-stream",
+              "Cache-Control": "no-cache",
+              Connection: "keep-alive",
+              "Access-Control-Allow-Origin": "*",
+            },
+          });
+        }
+
+        const commsChannelMatch = url.pathname.match(
+          /^\/api\/comms\/channels\/([^/]+)$/,
+        );
+        if (commsChannelMatch) {
+          let channelName: string;
+          try {
+            channelName = decodeURIComponent(commsChannelMatch[1]);
+          } catch {
+            return new Response("Bad Request", { status: 400 });
+          }
+          if (!isValidChannelName(channelName)) {
+            return new Response("Invalid channel name", { status: 400 });
+          }
+          if (!comms) return new Response("Not Found", { status: 404 });
+          const limitRaw = url.searchParams.get("limit");
+          const parsedLimit = limitRaw ? Number.parseInt(limitRaw, 10) : NaN;
+          const limit = Number.isFinite(parsedLimit)
+            ? Math.max(1, Math.min(parsedLimit, 1000))
+            : 200;
+          const detail = await comms.getChannel(channelName, { limit });
+          if (!detail) return new Response("Not Found", { status: 404 });
+          return Response.json(detail);
+        }
+
+        const commsParticipantMatch = url.pathname.match(
+          /^\/api\/comms\/participants\/([^/]+)$/,
+        );
+        if (commsParticipantMatch) {
+          let agentName: string;
+          try {
+            agentName = decodeURIComponent(commsParticipantMatch[1]);
+          } catch {
+            return new Response("Bad Request", { status: 400 });
+          }
+          if (agentName.includes("/") || agentName.includes("\0")) {
+            return new Response("Bad Request", { status: 400 });
+          }
+          if (!comms) return new Response("Not Found", { status: 404 });
+          const detail = await comms.getParticipant(agentName);
+          if (!detail) return new Response("Not Found", { status: 404 });
+          return Response.json(detail);
+        }
+
+        if (url.pathname === "/api/linear") {
+          const tickets: Record<string, LinearTicket> = {};
+          if (linear) {
+            for (const key of collectTicketKeys(buildSnapshot(wtDir, buildOpts))) {
+              const t = linear.get(key);
+              if (t) tickets[key] = t;
+            }
+          }
+          return Response.json({ tickets });
+        }
+
+        if (url.pathname === "/api/ticket-substeps") {
+          const ticketParam = url.searchParams.get("ticket");
+          if (!ticketParam) {
+            return new Response("Bad Request: missing ticket", { status: 400 });
+          }
+          if (
+            ticketParam.includes("..") ||
+            ticketParam.includes("/") ||
+            ticketParam.includes("\0")
+          ) {
+            return new Response("Bad Request", { status: 400 });
+          }
+          // CTL-1215: scan the shared event ring instead of reading the whole
+          // current-month log; the per-ticket substep slice is small + recent.
+          const subSteps = readSubStepEvents(eventRing, ticketParam);
+          return Response.json({ ticket: ticketParam, subSteps });
+        }
+
+        // CTL-889 (P8): cache-backed Linear ticket detail — description (null,
+        // not cached), labels[], the relation graph (forward + reverse
+        // blocks/related edges), assignee, and held classification. Read from
+        // filter-state.db ticket_state, NEVER a live `linearis` call. 404 when
+        // the ticket has no descriptor row.
+        const ticketDetailMatch = url.pathname.match(
+          /^\/api\/ticket-detail\/([^/]+)$/,
+        );
+        if (ticketDetailMatch) {
+          let ticket: string;
+          try {
+            ticket = decodeURIComponent(ticketDetailMatch[1]);
+          } catch {
+            return new Response("Bad Request", { status: 400 });
+          }
+          if (
+            ticket.includes("..") ||
+            ticket.includes("/") ||
+            ticket.includes("\0")
+          ) {
+            return new Response("Bad Request", { status: 400 });
+          }
+          const detail = await readTicketDetail(ticket, {
+            dbPath: filterStateDb,
+          });
+          if (!detail) {
+            return new Response("Not Found", { status: 404 });
+          }
+          return Response.json(detail);
+        }
+
+        // CTL-974 pattern: supplemental cached live Linear {title, description}
+        // fetch for the ticket-detail page. Separate from /api/ticket-detail to
+        // keep its 404-on-no-descriptor contract intact. The board title is
+        // stale-sourced (triage summary can win) and the durable cache has no
+        // description column, so BOTH the real title and the markdown
+        // description are live-fetched from Linear here — cached, TTL'd (5 min),
+        // batched, fail-open, NEVER spawning linearis on a request path.
+        // ALWAYS 200: an absent description is honest-empty, not an error.
+        const linearTicketMatch = url.pathname.match(
+          /^\/api\/linear-ticket\/([^/]+)$/,
+        );
+        if (linearTicketMatch) {
+          let ticket: string;
+          try {
+            ticket = decodeURIComponent(linearTicketMatch[1]);
+          } catch {
+            return new Response("Bad Request", { status: 400 });
+          }
+          if (
+            ticket.includes("..") ||
+            ticket.includes("/") ||
+            ticket.includes("\0")
+          ) {
+            return new Response("Bad Request", { status: 400 });
+          }
+          const map = await fillTitleDescriptionFallback([ticket]);
+          const entry = map[ticket] ?? { title: null, description: null, labels: null, relations: null, state: null, priority: null, project: null, estimate: null };
+          const available =
+            entry.title !== null || entry.description !== null;
+          return Response.json({
+            id: ticket,
+            title: entry.title,
+            description: entry.description,
+            labels: entry.labels ?? null,
+            relations: entry.relations ?? null,
+            state: entry.state ?? null,
+            priority: entry.priority ?? null,
+            project: entry.project ?? null,
+            estimate: entry.estimate ?? null,
+            source: available ? "linear-live" : "unavailable",
+          });
+        }
+
+        // CTL-889 (P9): a ticket's research/plan thoughts artifacts for the
+        // spine 📄 links — repo-root-relative paths + a peek preview, read from
+        // the LOCAL thoughts tree. Surfaces the CTL-866 cross-node eventual-
+        // consistency caveat (artifacts authored on another node appear only
+        // after a thoughts-sync push).
+        const ticketArtifactsMatch = url.pathname.match(
+          /^\/api\/ticket-artifacts\/([^/]+)$/,
+        );
+        if (ticketArtifactsMatch) {
+          let ticket: string;
+          try {
+            ticket = decodeURIComponent(ticketArtifactsMatch[1]);
+          } catch {
+            return new Response("Bad Request", { status: 400 });
+          }
+          if (
+            ticket.includes("..") ||
+            ticket.includes("/") ||
+            ticket.includes("\0")
+          ) {
+            return new Response("Bad Request", { status: 400 });
+          }
+          const artifacts = await readTicketArtifacts(ticket);
+          return Response.json(artifacts);
+        }
+
+        // CTL-1574: a ticket's Linear discussion — comments + issue_history
+        // activity events, both read from the local CTC replica through the
+        // shared read-model builders. The reader never throws: an absent/locked
+        // replica or an unmirrored ticket comes back
+        // `{ available:false, comments:[], activity:[] }`, which the UI renders
+        // as an honest empty section (never a fabricated "no comments").
+        const ticketDiscussionMatch = url.pathname.match(
+          /^\/api\/ticket-discussion\/([^/]+)$/,
+        );
+        if (ticketDiscussionMatch) {
+          let ticket: string;
+          try {
+            ticket = decodeURIComponent(ticketDiscussionMatch[1]);
+          } catch {
+            return new Response("Bad Request", { status: 400 });
+          }
+          if (
+            ticket.includes("..") ||
+            ticket.includes("/") ||
+            ticket.includes("\0")
+          ) {
+            return new Response("Bad Request", { status: 400 });
+          }
+          const discussion = await readTicketDiscussion(ticket, {
+            catalystDir: CATALYST_DIR,
+          });
+          // Agent classification is `is_bot` OR a configured app-actor author —
+          // Catalyst worker/orchestrator app actors are stored as users with
+          // is_bot=0 (the linear-thread.mjs contract), so is_bot alone would
+          // badge every agent comment as human.
+          const botIds = linearBotUserIds ?? linearWebhookConfig?.botUserIds;
+          if (botIds && discussion.comments.length > 0) {
+            discussion.comments = discussion.comments.map((c) =>
+              c.author_id != null && botIds.has(c.author_id) ? { ...c, is_bot: 1 } : c,
+            );
+          }
+          return Response.json(discussion);
+        }
+
+        // CTL-1042: serve a ticket's research/plan artifact CONTENT by kind for
+        // the reading-pane deep-dive pills. The list route above is anchored at
+        // the ticket segment ($), so it never matches this two-segment path;
+        // this opens the actual markdown the pill links to (without it the pill
+        // hit the SPA/404 fallback). The served file path is resolved by our own
+        // glob over the local thoughts tree — not attacker-supplied — but we
+        // still validate both URL segments defensively.
+        const ticketArtifactByKindMatch = url.pathname.match(
+          /^\/api\/ticket-artifacts\/([^/]+)\/([^/]+)$/,
+        );
+        if (ticketArtifactByKindMatch) {
+          let ticket: string;
+          let kind: string;
+          try {
+            ticket = decodeURIComponent(ticketArtifactByKindMatch[1]);
+            kind = decodeURIComponent(ticketArtifactByKindMatch[2]);
+          } catch {
+            return new Response("Bad Request", { status: 400 });
+          }
+          if (
+            ticket.includes("..") ||
+            ticket.includes("/") ||
+            ticket.includes("\0")
+          ) {
+            return new Response("Bad Request", { status: 400 });
+          }
+          if (kind !== "research" && kind !== "plan") {
+            return new Response("Bad Request", { status: 400 });
+          }
+          const doc = await readTicketArtifactContent(ticket, kind);
+          if (!doc) {
+            return new Response("Not Found", { status: 404 });
+          }
+          return new Response(doc.content, {
+            headers: { "Content-Type": "text/markdown; charset=utf-8" },
+          });
+        }
+
+        // CTL-889 (P12): cache-backed fuzzy ticket search for the ⌘K palette's
+        // "Search all tickets in Linear" action. Fuzzy-matches the durable
+        // ticket_state cache — NO per-keystroke live Linear API call. An empty
+        // ?q= returns an empty result set (the palette renders the row idle).
+        if (url.pathname === "/api/search") {
+          const q = url.searchParams.get("q") ?? "";
+          const limitRaw = url.searchParams.get("limit");
+          const parsedLimit = limitRaw ? Number.parseInt(limitRaw, 10) : NaN;
+          const limit = Number.isFinite(parsedLimit)
+            ? Math.max(1, Math.min(parsedLimit, 100))
+            : 20;
+          if (q.trim() === "") {
+            return Response.json({
+              query: q,
+              results: [],
+              source: "filter-state.db",
+            });
+          }
+          const result = await readTicketSearch(q, {
+            dbPath: filterStateDb,
+            limit,
+          });
+          return Response.json(result);
+        }
+
+        if (url.pathname === "/api/briefing") {
+          if (!briefingProvider) {
+            return Response.json({ enabled: false });
+          }
+          const snap = snapshotWithPrStatus();
+          const tickets: Record<string, LinearTicket> = {};
+          if (linear) {
+            for (const key of collectTicketKeys(snap)) {
+              const t = linear.get(key);
+              if (t) tickets[key] = t;
+            }
+          }
+          const result = await briefingProvider.generate(snap, tickets);
+          if (!result) {
+            return Response.json({ enabled: true, briefing: null });
+          }
+          return Response.json({
+            enabled: true,
+            briefing: result.briefing,
+            suggestedLabels: result.suggestedLabels,
+            generatedAt: result.generatedAt,
+          });
+        }
+
+        // CTL-1042: per-inbox-item AI summary — lazy, on operator select.
+        const inboxSummaryMatch =
+          req.method === "GET" && url.pathname.match(/^\/api\/inbox\/([^/]+)\/summary$/);
+        if (inboxSummaryMatch) {
+          let ticket: string;
+          try { ticket = decodeURIComponent(inboxSummaryMatch[1]); }
+          catch { return new Response("Bad Request", { status: 400 }); }
+          if (ticket.includes("..") || ticket.includes("/") || ticket.includes("\0")) {
+            return new Response("Bad Request", { status: 400 });
+          }
+          if (!inboxSummaryProvider) return Response.json({ enabled: false });
+          const phase = url.searchParams.get("phase") ?? undefined;
+          const result = await inboxSummaryProvider.generate(ticket, phase);
+          if (!result) return Response.json({ enabled: true, ask: null, summary: null, options: null, blocker: null });
+          return Response.json({ enabled: true, ...result });
+        }
+
+        if (url.pathname === "/api/briefing/activity") {
+          const windowParam = url.searchParams.get("window") ?? "30m";
+          if (!VALID_ACTIVITY_WINDOWS.has(windowParam as ActivityWindow)) {
+            return Response.json(
+              { error: "Invalid window. Use 30m, 1h, or 6h." },
+              { status: 400 },
+            );
+          }
+          const result = await generateActivityBriefing(
+            CATALYST_DIR,
+            activityBriefingConfig,
+            windowParam as ActivityWindow,
+            undefined,
+            eventRing,
+          );
+          return Response.json(result);
+        }
+
+        if (url.pathname === "/api/webhook" && req.method === "POST") {
+          if (!webhookHandler) {
+            return new Response("webhook receiver not configured", {
+              status: 503,
+            });
+          }
+          return webhookHandler.handle(req);
+        }
+
+        if (url.pathname === "/api/webhook/linear" && req.method === "POST") {
+          if (!linearWebhookHandler) {
+            return new Response("linear webhook receiver not configured", {
+              status: 503,
+            });
+          }
+          return linearWebhookHandler.handle(req);
+        }
+
+        if (url.pathname === "/api/summarize" && req.method === "POST") {
+          if (!summarizeHandler) {
+            return Response.json(
+              { error: "AI not configured" },
+              { status: 503 },
+            );
+          }
+          return summarizeHandler.handle(req);
+        }
+
+        if (url.pathname === "/api/otel/status") {
+          return Response.json({
+            enabled: prom !== null || loki !== null,
+            prometheus: prom ? prom.isAvailable() : false,
+            loki: loki ? loki.isAvailable() : false,
+          });
+        }
+
+        if (url.pathname === "/api/health/otel") {
+          const health = await otelHealth.check();
+          return Response.json(health);
+        }
+
+        // CTL-1050: the service-health registry snapshot — every stack service's
+        // shared up|degraded|down|unknown severity, last-checked, target/source
+        // for the Fleet Ops strip hover. The registry reads ONLY the monitor's own
+        // probes/event-recency, so Fleet Ops stays Prometheus/Loki-FREE.
+        if (url.pathname === "/api/health/services") {
+          return Response.json(serviceHealth.snapshot());
+        }
+
+        if (url.pathname === "/api/otel/cost") {
+          if (!prom) return Response.json({ error: "OTel not configured" }, { status: 503 });
+          const range = url.searchParams.get("range") ?? "1h";
+          const result = await costByTicket(prom, range);
+          return Response.json({ data: result });
+        }
+
+        if (url.pathname === "/api/otel/tokens") {
+          if (!prom) return Response.json({ error: "OTel not configured" }, { status: 503 });
+          const range = url.searchParams.get("range") ?? "1h";
+          const tokens = await tokensByType(prom, range);
+          const hitRate = await cacheHitRate(prom, range);
+          return Response.json({ data: { tokens, cacheHitRate: hitRate } });
+        }
+
+        if (url.pathname === "/api/otel/cost-rate") {
+          if (!prom) return Response.json({ error: "OTel not configured" }, { status: 503 });
+          const interval = url.searchParams.get("interval") ?? "5m";
+          const result = await costRateByModel(prom, interval);
+          return Response.json({ data: result });
+        }
+
+        // OBS-9 (FINOPS P-B): cost by pipeline stage. Routes the EXISTING (but
+        // previously unrouted) `costByTaskType` — `sum by (task_type)(increase(
+        // cost[r]))` — with the OBS-9 zero-series filter applied at the query layer
+        // so the by-stage bar never renders the ~5 exact-0 phases. 503 when
+        // Prometheus is not configured (the P-B ChartCard degrades via the ladder).
+        if (url.pathname === "/api/otel/cost-by-stage") {
+          if (!prom) return Response.json({ error: "OTel not configured" }, { status: 503 });
+          const range = url.searchParams.get("range") ?? "24h";
+          const result = await costByTaskType(prom, range);
+          return Response.json({ data: result });
+        }
+
+        // OBS-11 (FINOPS P-D): cost by model / agent. Groups the cost counter by a
+        // WHITELISTED native dimension (`model` or `agent_name` — never interpolated
+        // from input, so no PromQL injection) with the OBS-9 zero-series filter
+        // applied so the ranked bar never shows the exact-0 models/agents an
+        // increase() window carries. `dim` defaults to model; an unknown dim → 400
+        // (honest, never a silently-empty bar). 503 when Prometheus is off.
+        if (url.pathname === "/api/otel/cost-by-dim") {
+          if (!prom) return Response.json({ error: "OTel not configured" }, { status: 503 });
+          const dim = url.searchParams.get("dim") ?? "model";
+          if (!isCostDimension(dim)) {
+            return Response.json({ error: "unknown dimension" }, { status: 400 });
+          }
+          const range = url.searchParams.get("range") ?? "24h";
+          const result = await costByDimension(prom, dim, range);
+          return Response.json({ data: result });
+        }
+
+        // CTL-1040 (FINOPS): cost grouped by work type. Board-backed — groups the SAME
+        // signal-file costs the expensive-tickets table shows (BoardTicket.costUSD) by
+        // BoardTicket.type. Prometheus carries no catalyst_ticket_type label, so this
+        // is the honest current-state source (UI carries a "data since 2026-06-11"
+        // caption). Always 200 — no Prometheus dependency.
+        if (url.pathname === "/api/otel/cost-by-work-type") {
+          const board = await boardSnapshot.getLatest();
+          const tickets = (board?.tickets ?? []).map((t) => ({ type: t.type, costUSD: t.costUSD }));
+          return Response.json({ data: costByWorkType(tickets) });
+        }
+
+        // CTL-1040 (UTILIZATION): throughput grouped by work type. Loki-backed —
+        // counts phase.teardown.complete.* events per catalyst_ticket_type over the
+        // window. 503 when Loki is not configured (the ChartCard degrades via the ladder).
+        if (url.pathname === "/api/otel/throughput-by-work-type") {
+          if (!loki) return Response.json({ error: "OTel not configured" }, { status: 503 });
+          const range = url.searchParams.get("range") ?? "24h";
+          const result = await throughputByWorkType(loki, range);
+          if (result === null) return Response.json({ error: "Loki unavailable" }, { status: 503 });
+          return Response.json({ data: result });
+        }
+
+        // OBS-9 (FINOPS HERO): the today-vs-7d dollar band. todayUsd (spend since
+        // local midnight) + avg7dUsd (the prior 7 FULL days' mean baseline) + the
+        // delta fraction + a linear EOD projection — all off the cost counter, no
+        // new plumbing. The partial current day is EXCLUDED from the 7d baseline so
+        // "is today normal?" compares like-for-like. 503 when Prometheus is absent.
+        if (url.pathname === "/api/otel/cost-today") {
+          if (!prom) return Response.json({ error: "OTel not configured" }, { status: 503 });
+          const result = await costToday(prom);
+          if (result === null) {
+            return Response.json({ error: "Prometheus unavailable" }, { status: 503 });
+          }
+          return Response.json({ data: result });
+        }
+
+        // OBS-9 (FINOPS P-A): hourly spend-over-time bars + spike flags. A
+        // query_range of `sum(increase(cost[1h]))` stepped at 1h over the window;
+        // each point carries `isSpike` (spend > max(2× median, μ+2σ) — the P-A
+        // `--chart-4` dot). 503 when Prometheus is absent; an honest `[]` for a
+        // quiet stack (the ChartCard empty state, never a fabricated bar).
+        if (url.pathname === "/api/otel/cost-series") {
+          if (!prom) return Response.json({ error: "OTel not configured" }, { status: 503 });
+          const range = url.searchParams.get("range") ?? "24h";
+          const result = await costSeries(prom, range);
+          if (result === null) {
+            return Response.json({ error: "Prometheus unavailable" }, { status: 503 });
+          }
+          return Response.json({ data: result });
+        }
+
+        // OBS-9 (FINOPS HERO-C, THE HEADLINE): cache-ROI $. Σ_model cacheRead_tokens
+        // × (input_price − cache_read_price) from a per-model price book — the real
+        // dollars the 99.8%-hit-rate prompt cache saved — plus the "(Nx)" multiplier
+        // (savings / actual spend). 503 when Prometheus is absent.
+        if (url.pathname === "/api/otel/cache-savings") {
+          if (!prom) return Response.json({ error: "OTel not configured" }, { status: 503 });
+          const range = url.searchParams.get("range") ?? "24h";
+          const result = await cacheSavings(prom, range);
+          if (result === null) {
+            return Response.json({ error: "Prometheus unavailable" }, { status: 503 });
+          }
+          return Response.json({ data: result });
+        }
+
+        // OBS-10 (FINOPS P-A drill): cost at a single spiking hour. Clicking a
+        // spiking bar in the spend-over-time chart re-queries THAT hour's by-ticket
+        // + by-model split (the "one re-query with the hour window"). `hour` is the
+        // clicked bar's epoch-SECOND timestamp; the query anchors a 1h `increase()`
+        // window to it via PromQL `offset`. Both maps are zero-filtered. 503 when
+        // Prometheus is absent; 400 when `hour` is missing/non-numeric (never a
+        // fabricated empty drill).
+        if (url.pathname === "/api/otel/cost-at-hour") {
+          if (!prom) return Response.json({ error: "OTel not configured" }, { status: 503 });
+          const hourParam = url.searchParams.get("hour");
+          const hour = hourParam !== null ? Number(hourParam) : NaN;
+          if (!Number.isFinite(hour) || hour <= 0) {
+            return Response.json({ error: "hour (epoch seconds) required" }, { status: 400 });
+          }
+          const result = await costAtHour(prom, hour);
+          if (result === null) {
+            return Response.json({ error: "Prometheus unavailable" }, { status: 503 });
+          }
+          return Response.json({ data: result });
+        }
+
+        if (url.pathname === "/api/otel/tools") {
+          if (!loki) return Response.json({ error: "OTel not configured" }, { status: 503 });
+          const range = url.searchParams.get("range") ?? "1h";
+          const result = await toolUsageByName(loki, range);
+          return Response.json({ data: result });
+        }
+
+        // OBS-7 (TELEMETRY P3): per-tool p50/p95 latency, the half /api/otel/tools
+        // (counts only) is missing so the panel can sort by TOTAL TIME (count × p95)
+        // rather than chattiness. unwrap duration_ms on tool_result by tool_name
+        // (toolLatency in otel-queries.ts). 503 when Loki is not configured; an
+        // empty stream is an HONEST 200 with `data:{}` (counts-only fallback).
+        if (url.pathname === "/api/otel/tool-latency") {
+          if (!loki) return Response.json({ error: "OTel not configured" }, { status: 503 });
+          const range = url.searchParams.get("range") ?? "1h";
+          const result = await toolLatency(loki, range);
+          if (result === null) {
+            // null means the queryRange came back null. Distinguish HONESTLY: if the
+            // /ready probe passed, Loki IS reachable and this is a QUERY/backend
+            // error (e.g. a LogQL 400), NOT "Loki unavailable" — don't mislabel it.
+            return otelDegradedResponse(loki, "tool-latency");
+          }
+          return Response.json({ data: result });
+        }
+
+        if (url.pathname === "/api/otel/errors") {
+          if (!loki) return Response.json({ error: "OTel not configured" }, { status: 503 });
+          const range = url.searchParams.get("range") ?? "1h";
+          const rawLimit = parseInt(url.searchParams.get("limit") ?? "50", 10);
+          const limit = Number.isFinite(rawLimit) ? Math.min(Math.max(1, rawLimit), 500) : 50;
+          // CTL-1039: alongside the panel's error rows, carry the proportional
+          // counts WITH EXPLICIT WINDOWS (15m + today) the hero reads to pick
+          // NOTED vs ERRORING. Backward-compatible: `data` stays the row array.
+          const [result, counts] = await Promise.all([
+            apiErrors(loki, range, limit),
+            apiErrorCounts(loki),
+          ]);
+          return Response.json({ data: result, counts });
+        }
+
+        // OBS-16 (UTILIZATION P_active): fleet-wide active-time ratio. A single
+        // Prometheus read of `sum(rate(claude_code_active_time_seconds_total[range]))`
+        // — the active seconds-per-second across the fleet (≈ slots' worth of
+        // wall-clock genuinely computing). The UI divides this by config.inFlight
+        // (busy-slot capacity it already holds) to render "X% computing / Y%
+        // waiting". 503 when Prometheus is absent (the P_active ChartCard degrades
+        // via the [prom] ladder); an idle fleet is an HONEST 200 with
+        // `data:{activeSecondsPerSecond:0}` (the genuine low read, never a
+        // fabricated number).
+        if (url.pathname === "/api/otel/active-time") {
+          if (!prom) return Response.json({ error: "OTel not configured" }, { status: 503 });
+          const range = url.searchParams.get("range") ?? "1h";
+          const result = await activeTimeRatio(prom, range);
+          if (result === null) {
+            return Response.json({ error: "Prometheus unavailable" }, { status: 503 });
+          }
+          return Response.json({ data: result });
+        }
+
+        // OBS-7 (TELEMETRY P4): per-model api_request latency (p50/p95) + error%,
+        // read off the SAME claude-code Loki stream as the tail/errors — NOT a new
+        // Prometheus dependency. The LogQL unwraps `duration_ms` on api_request and
+        // aggregates with quantile_over_time by model (modelLatency in
+        // otel-queries.ts). 503 when Loki is not configured (the P4 ChartCard
+        // degrades via the ladder); an empty stream is an HONEST 200 with `data:[]`
+        // (the card's "no data in range" state, NOT an error).
+        if (url.pathname === "/api/otel/model-latency") {
+          if (!loki) return Response.json({ error: "OTel not configured" }, { status: 503 });
+          const range = url.searchParams.get("range") ?? "1h";
+          const result = await modelLatency(loki, range);
+          if (result === null) {
+            // null means the queryRange came back null. Surface it HONESTLY: a
+            // passing /ready probe means Loki is reachable and this is a query/
+            // backend error (degraded), NOT a fabricated empty or a false
+            // "Loki unavailable".
+            return otelDegradedResponse(loki, "model-latency");
+          }
+          return Response.json({ data: result });
+        }
+
+        // OBS-6 (TELEMETRY): the fleet-wide grouped live tail + freshness. ONE
+        // newest-first scan of the claude-code Loki stream (same pipe as the
+        // per-session history, minus the session filter). The hero reads
+        // `freshnessMs` (age of the newest line) to pick FLOWING vs QUIET; the P1
+        // panel groups `rows` by worker client-side. 503 when Loki is not
+        // configured (the surface degrades via the ChartCard ladder). An empty
+        // stream is an HONEST 200 with `freshnessMs:null` (QUIET, not an error).
+        if (url.pathname === "/api/otel/tail") {
+          if (!loki) return Response.json({ error: "OTel not configured" }, { status: 503 });
+          const range = url.searchParams.get("range") ?? "15m";
+          const rawLimit = parseInt(url.searchParams.get("limit") ?? "300", 10);
+          const limit = Number.isFinite(rawLimit)
+            ? Math.min(Math.max(1, rawLimit), 1000)
+            : 300;
+          const result = await recentTail(loki, range, limit);
+          if (result === null) {
+            // Loki probe failed mid-flight — honest 503, not a fabricated empty.
+            return Response.json({ error: "Loki unavailable" }, { status: 503 });
+          }
+          return Response.json({ data: result });
+        }
+
+        // OBS-8 (TELEMETRY P5): events/min heatmap, workers × time. ONE metric
+        // query over the claude-code Loki stream — `count_over_time` of every line
+        // per `session_id` in 15m buckets (eventsHeatmap in otel-queries.ts). The
+        // payload is {buckets, cells}; the UI joins cells[].sessionId to board
+        // worker names and renders a row for EVERY running worker (silent ones
+        // included) so an early stall — a `running` worker with dark recent cells —
+        // is visible. 503 when Loki is not configured (the P5 ChartCard degrades via
+        // the ladder, but its board-sourced row headers still render per design
+        // §3.1); a reachable-but-quiet stream is an HONEST 200 with empty cells.
+        if (url.pathname === "/api/otel/events-heatmap") {
+          if (!loki) return Response.json({ error: "OTel not configured" }, { status: 503 });
+          const range = url.searchParams.get("range") ?? "6h";
+          const result = await eventsHeatmap(loki, range);
+          if (result === null) {
+            // Loki probe failed mid-flight — honest 503, not a fabricated empty.
+            return Response.json({ error: "Loki unavailable" }, { status: 503 });
+          }
+          return Response.json({ data: result });
+        }
+
+        if (url.pathname === "/api/otel/cost-validation") {
+          if (!prom) return Response.json({ error: "OTel not configured" }, { status: 503 });
+          const range = url.searchParams.get("range") ?? "6h";
+          const snap = buildSnapshot(wtDir, buildOpts);
+          const signalCosts: Record<string, number> = {};
+          for (const orch of snap.orchestrators) {
+            for (const [key, worker] of Object.entries(orch.workers)) {
+              if (worker.cost?.costUSD) signalCosts[key] = worker.cost.costUSD;
+            }
+          }
+          const result = await costValidation(prom, signalCosts, range);
+          return Response.json({ data: result });
+        }
+
+        // CTL-914 (DETAIL3): the worker-page [history] tail. Queries the
+        // `claude-code` Loki stream for ONE run's transcript by its CC session
+        // UUID — REAL today, no plumbing — so a dead worker's tail is readable
+        // hours later (why the worker page is never empty). The filter is a
+        // `| session_id=\`UUID\`` STRUCTURED-METADATA pipe inside
+        // workerHistoryBySession (a `{session_id=}` label matcher returns 0).
+        // sessionId is UUID-validated before it ever reaches the LogQL, so the
+        // pipe can never be an injection vector. 503 when Loki is not configured
+        // (the UI degrades to the resident-data page), 400 on a bad id.
+        const ecWorkerHistoryMatch = url.pathname.match(
+          /^\/api\/ec-worker-history\/([^/]+)$/,
+        );
+        if (ecWorkerHistoryMatch) {
+          let sessionId: string;
+          try {
+            sessionId = decodeURIComponent(ecWorkerHistoryMatch[1]);
+          } catch {
+            return new Response("Bad Request", { status: 400 });
+          }
+          if (!isValidCcSessionId(sessionId)) {
+            return new Response("Bad Request", { status: 400 });
+          }
+          if (!loki) {
+            return Response.json({ error: "OTel not configured" }, { status: 503 });
+          }
+          const range = url.searchParams.get("range") ?? "24h";
+          const rawLimit = parseInt(url.searchParams.get("limit") ?? "500", 10);
+          const limit = Number.isFinite(rawLimit)
+            ? Math.min(Math.max(1, rawLimit), 2000)
+            : 500;
+          const rows = await workerHistoryBySession(loki, sessionId, range, limit);
+          if (rows === null) {
+            // Loki probe failed mid-flight — honest 503, not a fabricated empty.
+            return Response.json({ error: "Loki unavailable" }, { status: 503 });
+          }
+          return Response.json({ data: rows });
+        }
+
+        // CTL-917 (DETAIL6): the worker Burn Strip's REAL Prometheus sparklines.
+        // Four query_range series keyed on the CC session UUID (cost / tokens /
+        // tokens-by-type / active-seconds) — no new plumbing, the same already-
+        // emitting OTEL pipeline the `/api/otel/*` routes read. The UUID is
+        // UUID-validated before it reaches the PromQL `{session_id=…}` matcher,
+        // so the matcher can never be an injection vector. 503 when Prometheus is
+        // not configured (the UI falls back to the resident BoardWorker scalar),
+        // 400 on a bad id.
+        const otelBurnMatch = url.pathname.match(
+          /^\/api\/otel\/burn\/([^/]+)$/,
+        );
+        if (otelBurnMatch) {
+          let sessionId: string;
+          try {
+            sessionId = decodeURIComponent(otelBurnMatch[1]);
+          } catch {
+            return new Response("Bad Request", { status: 400 });
+          }
+          if (!isValidCcSessionId(sessionId)) {
+            return new Response("Bad Request", { status: 400 });
+          }
+          if (!prom) {
+            return Response.json({ error: "OTel not configured" }, { status: 503 });
+          }
+          const range = url.searchParams.get("range") ?? "1h";
+          const series = await workerBurnSeries(prom, sessionId, range);
+          if (series === null) {
+            // Prometheus probe failed mid-flight — honest 503, never a fake series.
+            return Response.json({ error: "Prometheus unavailable" }, { status: 503 });
+          }
+          return Response.json({ data: series });
+        }
+
+        // CTL-917 (DETAIL6): the ticket telemetry strip's REAL Prometheus
+        // sparklines keyed on the Linear key (total cost / tokens-by-type +
+        // cost-by-phase `sum by(task_type)` + cost-by-model `sum by(model)`).
+        // commits/LoC stay git-sourced (NEEDS-PLUMBING) so they are NOT queried
+        // here. The linear_key is validated before it reaches the PromQL matcher.
+        const otelTicketTelemetryMatch = url.pathname.match(
+          /^\/api\/otel\/ticket-telemetry\/([^/]+)$/,
+        );
+        if (otelTicketTelemetryMatch) {
+          let linearKey: string;
+          try {
+            linearKey = decodeURIComponent(otelTicketTelemetryMatch[1]);
+          } catch {
+            return new Response("Bad Request", { status: 400 });
+          }
+          if (!isValidLinearKey(linearKey)) {
+            return new Response("Bad Request", { status: 400 });
+          }
+          if (!prom) {
+            return Response.json({ error: "OTel not configured" }, { status: 503 });
+          }
+          const range = url.searchParams.get("range") ?? "1h";
+          const series = await ticketTelemetrySeries(prom, linearKey, range);
+          if (series === null) {
+            return Response.json({ error: "Prometheus unavailable" }, { status: 503 });
+          }
+          return Response.json({ data: series });
+        }
+
+        if (url.pathname === "/api/annotations") {
+          return Response.json({ annotations: getAllAnnotations() });
+        }
+
+        const annMatch = url.pathname.match(
+          /^\/api\/annotations\/([A-Za-z0-9._-]+)$/,
+        );
+        if (annMatch && annMatch[1]) {
+          const sessionId = decodeURIComponent(annMatch[1]);
+
+          if (req.method === "DELETE") {
+            deleteAnnotation(sessionId);
+            return Response.json({ ok: true });
           }
 
-          const archiveFileMatch = url.pathname.match(
-            /^\/api\/archive\/orchestrators\/([^/]+)\/files\/(.+)$/,
-          );
-          if (archiveFileMatch) {
-            if (!dbPath) {
-              return new Response("Not Found", { status: 404 });
-            }
-            let orchId: string;
-            let fileRel: string;
+          if (req.method === "PUT") {
+            let body: Record<string, unknown>;
             try {
-              orchId = decodeURIComponent(archiveFileMatch[1]);
-              fileRel = decodeURIComponent(archiveFileMatch[2]);
+              body = (await req.json()) as Record<string, unknown>;
             } catch {
-              return new Response("Bad Request", { status: 400 });
+              return Response.json(
+                { error: "Invalid JSON body" },
+                { status: 400 },
+              );
             }
-            if (!isSafeArchivePart(orchId) || !isSafeArchiveFileRel(fileRel)) {
-              return new Response("Bad Request", { status: 400 });
+
+            const VALID_FLAGS = new Set([
+              "starred",
+              "flagged",
+              "archived",
+            ]);
+
+            if (Array.isArray(body.addFlags)) {
+              for (const f of body.addFlags) {
+                if (typeof f !== "string" || !VALID_FLAGS.has(f)) {
+                  return Response.json(
+                    {
+                      error: `Invalid flag: ${String(f)}. Valid: starred, flagged, archived`,
+                    },
+                    { status: 400 },
+                  );
+                }
+              }
             }
-            const archivePath = getArchivePath(dbPath, orchId);
-            if (!archivePath) {
-              return new Response("Not Found", { status: 404 });
+
+            if (typeof body.displayName === "string") {
+              setDisplayName(sessionId, body.displayName);
+            } else if (body.displayName === null) {
+              setDisplayName(sessionId, null);
             }
-            const candidate = resolvePath(archivePath, fileRel);
-            let realRoot: string;
-            try {
-              realRoot = realpathSync(archivePath);
-            } catch {
-              return new Response("Not Found", { status: 404 });
+
+            if (Array.isArray(body.addFlags)) {
+              for (const f of body.addFlags) {
+                if (typeof f === "string") addFlag(sessionId, f);
+              }
             }
-            let realTarget: string;
-            try {
-              realTarget = realpathSync(candidate);
-            } catch {
-              return new Response("Not Found", { status: 404 });
+            if (Array.isArray(body.removeFlags)) {
+              for (const f of body.removeFlags) {
+                if (typeof f === "string") removeFlag(sessionId, f);
+              }
             }
-            if (realTarget !== realRoot && !realTarget.startsWith(realRoot + sep)) {
-              return new Response("Forbidden", { status: 403 });
+            if (typeof body.addNote === "string") {
+              addNote(sessionId, body.addNote);
             }
-            const file = Bun.file(realTarget);
-            if (!(await file.exists())) {
-              return new Response("Not Found", { status: 404 });
+            if (
+              typeof body.removeNoteIndex === "number" &&
+              Number.isInteger(body.removeNoteIndex)
+            ) {
+              removeNote(sessionId, body.removeNoteIndex);
             }
+            if (Array.isArray(body.addTags)) {
+              for (const t of body.addTags) {
+                if (typeof t === "string") addTag(sessionId, t);
+              }
+            }
+            if (Array.isArray(body.removeTags)) {
+              for (const t of body.removeTags) {
+                if (typeof t === "string") removeTag(sessionId, t);
+              }
+            }
+
+            const annotation = getAnnotation(sessionId);
+            return Response.json({ annotation });
+          }
+
+          return new Response("Method Not Allowed", { status: 405 });
+        }
+
+        if (url.pathname === "/api/archive/orchestrators") {
+          if (!dbPath) {
+            return Response.json({ entries: [], total: 0 });
+          }
+          const params = url.searchParams;
+          const limitRaw = params.get("limit");
+          const offsetRaw = params.get("offset");
+          const parsedLimit = limitRaw ? Number.parseInt(limitRaw, 10) : NaN;
+          const parsedOffset = offsetRaw ? Number.parseInt(offsetRaw, 10) : NaN;
+          const result = listArchivedOrchestrators(dbPath, {
+            since: params.get("since") ?? undefined,
+            until: params.get("until") ?? undefined,
+            ticket: params.get("ticket") ?? undefined,
+            status: params.get("status") ?? undefined,
+            limit: Number.isFinite(parsedLimit) ? parsedLimit : undefined,
+            offset: Number.isFinite(parsedOffset) ? parsedOffset : undefined,
+          });
+          return Response.json(result);
+        }
+
+        const archiveFileMatch = url.pathname.match(
+          /^\/api\/archive\/orchestrators\/([^/]+)\/files\/(.+)$/,
+        );
+        if (archiveFileMatch) {
+          if (!dbPath) {
+            return new Response("Not Found", { status: 404 });
+          }
+          let orchId: string;
+          let fileRel: string;
+          try {
+            orchId = decodeURIComponent(archiveFileMatch[1]);
+            fileRel = decodeURIComponent(archiveFileMatch[2]);
+          } catch {
+            return new Response("Bad Request", { status: 400 });
+          }
+          if (
+            !isSafeArchivePart(orchId) ||
+            !isSafeArchiveFileRel(fileRel)
+          ) {
+            return new Response("Bad Request", { status: 400 });
+          }
+          const archivePath = getArchivePath(dbPath, orchId);
+          if (!archivePath) {
+            return new Response("Not Found", { status: 404 });
+          }
+          const candidate = resolvePath(archivePath, fileRel);
+          let realRoot: string;
+          try {
+            realRoot = realpathSync(archivePath);
+          } catch {
+            return new Response("Not Found", { status: 404 });
+          }
+          let realTarget: string;
+          try {
+            realTarget = realpathSync(candidate);
+          } catch {
+            return new Response("Not Found", { status: 404 });
+          }
+          if (
+            realTarget !== realRoot &&
+            !realTarget.startsWith(realRoot + sep)
+          ) {
+            return new Response("Forbidden", { status: 403 });
+          }
+          const file = Bun.file(realTarget);
+          if (!(await file.exists())) {
+            return new Response("Not Found", { status: 404 });
+          }
+          return new Response(file, {
+            headers: {
+              "Content-Type": contentTypeForArchive(realTarget),
+              "Cache-Control": "private, max-age=60",
+            },
+          });
+        }
+
+        const archiveDetailMatch = url.pathname.match(
+          /^\/api\/archive\/orchestrators\/([^/]+)$/,
+        );
+        if (archiveDetailMatch) {
+          if (!dbPath) {
+            return new Response("Not Found", { status: 404 });
+          }
+          let orchId: string;
+          try {
+            orchId = decodeURIComponent(archiveDetailMatch[1]);
+          } catch {
+            return new Response("Bad Request", { status: 400 });
+          }
+          if (!isSafeArchivePart(orchId)) {
+            return new Response("Bad Request", { status: 400 });
+          }
+          const detail = getArchivedOrchestrator(dbPath, orchId);
+          if (!detail) {
+            return new Response("Not Found", { status: 404 });
+          }
+          return Response.json(detail);
+        }
+
+        // CTL-1133: PWA installability. The web app is installable as a
+        // chrome-less standalone window (desktop) / iOS home-screen app. The
+        // manifest and service worker are served from the ROOT (not /public/) so
+        // the SW's default scope is "/" and it controls the whole app — a SW at
+        // /public/service-worker.js would only scope /public/. Icons are plain
+        // PNGs served by the existing /public/* route.
+        if (url.pathname === "/manifest.webmanifest") {
+          const file = Bun.file(join(publicDir, "manifest.webmanifest"));
+          if (await file.exists()) {
             return new Response(file, {
               headers: {
-                "Content-Type": contentTypeForArchive(realTarget),
-                "Cache-Control": "private, max-age=60",
+                "Content-Type": "application/manifest+json; charset=utf-8",
+                "Cache-Control": CACHE_REVALIDATE, // CTL-1374
               },
             });
           }
-
-          const archiveDetailMatch = url.pathname.match(/^\/api\/archive\/orchestrators\/([^/]+)$/);
-          if (archiveDetailMatch) {
-            if (!dbPath) {
-              return new Response("Not Found", { status: 404 });
-            }
-            let orchId: string;
-            try {
-              orchId = decodeURIComponent(archiveDetailMatch[1]);
-            } catch {
-              return new Response("Bad Request", { status: 400 });
-            }
-            if (!isSafeArchivePart(orchId)) {
-              return new Response("Bad Request", { status: 400 });
-            }
-            const detail = getArchivedOrchestrator(dbPath, orchId);
-            if (!detail) {
-              return new Response("Not Found", { status: 404 });
-            }
-            return Response.json(detail);
+          return new Response("manifest not found", { status: 404 });
+        }
+        if (url.pathname === "/service-worker.js") {
+          const file = Bun.file(join(publicDir, "service-worker.js"));
+          if (await file.exists()) {
+            return new Response(file, {
+              headers: {
+                "Content-Type": "text/javascript; charset=utf-8",
+                // allow root scope even though the file lives under publicDir
+                "Service-Worker-Allowed": "/",
+                // never let a stale SW pin an old shell
+                "Cache-Control": "no-cache",
+              },
+            });
           }
+          return new Response("service worker not found", { status: 404 });
+        }
 
-          // CTL-1133: PWA installability. The web app is installable as a
-          // chrome-less standalone window (desktop) / iOS home-screen app. The
-          // manifest and service worker are served from the ROOT (not /public/) so
-          // the SW's default scope is "/" and it controls the whole app — a SW at
-          // /public/service-worker.js would only scope /public/. Icons are plain
-          // PNGs served by the existing /public/* route.
-          if (url.pathname === "/manifest.webmanifest") {
-            const file = Bun.file(join(publicDir, "manifest.webmanifest"));
-            if (await file.exists()) {
-              return new Response(file, {
-                headers: {
-                  "Content-Type": "application/manifest+json; charset=utf-8",
-                  "Cache-Control": CACHE_REVALIDATE, // CTL-1374
-                },
-              });
-            }
-            return new Response("manifest not found", { status: 404 });
+        // CTL-989: the app shell (index.html → main.tsx → the unified TanStack
+        // Router → AppShell layout) is the SINGLE canonical entry. It hosts every
+        // surface (Home/Tickets/Workers/Queue/Observe) AND every detail page
+        // inside the shared AppShell chrome — so `/` serves the shell. The legacy
+        // standalone board.html bundle is RETIRED; `/board` is now just the
+        // Tickets surface route, served by this same index.html (see the unified
+        // SPA fallback below).
+        if (url.pathname === "/" || url.pathname === "/index.html") {
+          const file = Bun.file(join(publicDir, "index.html"));
+          if (await file.exists()) {
+            return new Response(file, {
+              headers: {
+                "Content-Type": "text/html; charset=utf-8",
+                "Cache-Control": CACHE_REVALIDATE, // CTL-1374: always revalidate the shell
+              },
+            });
           }
-          if (url.pathname === "/service-worker.js") {
-            const file = Bun.file(join(publicDir, "service-worker.js"));
-            if (await file.exists()) {
-              return new Response(file, {
-                headers: {
-                  "Content-Type": "text/javascript; charset=utf-8",
-                  // allow root scope even though the file lives under publicDir
-                  "Service-Worker-Allowed": "/",
-                  // never let a stale SW pin an old shell
-                  "Cache-Control": "no-cache",
-                },
-              });
-            }
-            return new Response("service worker not found", { status: 404 });
-          }
+          return new Response("index.html not found", { status: 500 });
+        }
 
-          // CTL-989: the app shell (index.html → main.tsx → the unified TanStack
-          // Router → AppShell layout) is the SINGLE canonical entry. It hosts every
-          // surface (Home/Tickets/Workers/Queue/Observe) AND every detail page
-          // inside the shared AppShell chrome — so `/` serves the shell. The legacy
-          // standalone board.html bundle is RETIRED; `/board` is now just the
-          // Tickets surface route, served by this same index.html (see the unified
-          // SPA fallback below).
-          if (url.pathname === "/" || url.pathname === "/index.html") {
-            const file = Bun.file(join(publicDir, "index.html"));
-            if (await file.exists()) {
-              return new Response(file, {
-                headers: {
-                  "Content-Type": "text/html; charset=utf-8",
-                  "Cache-Control": CACHE_REVALIDATE, // CTL-1374: always revalidate the shell
-                },
-              });
-            }
-            return new Response("index.html not found", { status: 500 });
+        // CTL-989: the unified SPA fallback. EVERY app route — the flat surface
+        // paths (/board, /workers, /queue, /telemetry, /utilization, /finops,
+        // /fleetops, /devops, /settings) AND the detail/dep-graph deep links
+        // (/ticket/$id, /worker/$id, /dep-graph) — is served by the ONE TanStack
+        // Router mounted from index.html. A hard navigation / refresh / shared
+        // link to any of them serves index.html; the router boots, reads the URL,
+        // and lands on the right surface or detail page. (`/` and `/index.html`
+        // are handled by the dedicated block above; `/legacy` + `/history` keep
+        // their own handlers below.) Vite emits absolute /assets/* paths, so the
+        // nested /ticket/$id pathname is safe. GET-only: a POST to an app path is
+        // not the SPA entry.
+        if (req.method === "GET" && isAppRoute(url.pathname)) {
+          const file = Bun.file(join(publicDir, "index.html"));
+          if (await file.exists()) {
+            return new Response(file, {
+              headers: {
+                "Content-Type": "text/html; charset=utf-8",
+                "Cache-Control": CACHE_REVALIDATE, // CTL-1374: always revalidate the shell
+              },
+            });
           }
+          return new Response("index.html not found", { status: 500 });
+        }
 
-          // CTL-989: the unified SPA fallback. EVERY app route — the flat surface
-          // paths (/board, /workers, /queue, /telemetry, /utilization, /finops,
-          // /fleetops, /devops, /settings) AND the detail/dep-graph deep links
-          // (/ticket/$id, /worker/$id, /dep-graph) — is served by the ONE TanStack
-          // Router mounted from index.html. A hard navigation / refresh / shared
-          // link to any of them serves index.html; the router boots, reads the URL,
-          // and lands on the right surface or detail page. (`/` and `/index.html`
-          // are handled by the dedicated block above; `/legacy` + `/history` keep
-          // their own handlers below.) Vite emits absolute /assets/* paths, so the
-          // nested /ticket/$id pathname is safe. GET-only: a POST to an app path is
-          // not the SPA entry.
-          if (req.method === "GET" && isAppRoute(url.pathname)) {
-            const file = Bun.file(join(publicDir, "index.html"));
-            if (await file.exists()) {
-              return new Response(file, {
-                headers: {
-                  "Content-Type": "text/html; charset=utf-8",
-                  "Cache-Control": CACHE_REVALIDATE, // CTL-1374: always revalidate the shell
-                },
-              });
-            }
-            return new Response("index.html not found", { status: 500 });
+        if (
+          url.pathname === "/legacy" ||
+          url.pathname === "/legacy/" ||
+          url.pathname === "/history"
+        ) {
+          const htmlFile =
+            url.pathname === "/history" ? "history.html" : "index.html";
+          const file = Bun.file(join(publicDir, htmlFile));
+          if (await file.exists()) {
+            return new Response(file, {
+              headers: {
+                "Content-Type": "text/html; charset=utf-8",
+                "Cache-Control": CACHE_REVALIDATE, // CTL-1374
+              },
+            });
           }
+          return new Response(`${htmlFile} not found`, { status: 500 });
+        }
 
-          if (
-            url.pathname === "/legacy" ||
-            url.pathname === "/legacy/" ||
-            url.pathname === "/history"
-          ) {
-            const htmlFile = url.pathname === "/history" ? "history.html" : "index.html";
-            const file = Bun.file(join(publicDir, htmlFile));
-            if (await file.exists()) {
-              return new Response(file, {
-                headers: {
-                  "Content-Type": "text/html; charset=utf-8",
-                  "Cache-Control": CACHE_REVALIDATE, // CTL-1374
-                },
-              });
-            }
-            return new Response(`${htmlFile} not found`, { status: 500 });
+
+        if (url.pathname === "/mockups" || url.pathname === "/mockups/") {
+          const file = Bun.file(join(publicDir, "mockups", "index.html"));
+          if (await file.exists()) {
+            return new Response(file, {
+              headers: {
+                "Content-Type": "text/html; charset=utf-8",
+                "Cache-Control": CACHE_REVALIDATE, // CTL-1374
+              },
+            });
           }
+        }
 
-          if (url.pathname === "/mockups" || url.pathname === "/mockups/") {
-            const file = Bun.file(join(publicDir, "mockups", "index.html"));
-            if (await file.exists()) {
-              return new Response(file, {
-                headers: {
-                  "Content-Type": "text/html; charset=utf-8",
-                  "Cache-Control": CACHE_REVALIDATE, // CTL-1374
-                },
-              });
-            }
+        if (url.pathname.startsWith("/mockups/")) {
+          const rel = decodeURIComponent(
+            "mockups/" + url.pathname.slice("/mockups/".length),
+          );
+          const safe = resolveSafeStaticPath(publicDir, rel);
+          if (!safe) return new Response("Forbidden", { status: 403 });
+          const file = Bun.file(safe);
+          if (await file.exists()) {
+            const dot = safe.lastIndexOf(".");
+            const ext = dot >= 0 ? safe.slice(dot).toLowerCase() : "";
+            return new Response(file, {
+              headers: {
+                "Content-Type": contentTypeForExt(ext),
+                "Cache-Control": CACHE_REVALIDATE, // CTL-1374: mockups aren't content-hashed
+              },
+            });
           }
+        }
 
-          if (url.pathname.startsWith("/mockups/")) {
-            const rel = decodeURIComponent("mockups/" + url.pathname.slice("/mockups/".length));
-            const safe = resolveSafeStaticPath(publicDir, rel);
-            if (!safe) return new Response("Forbidden", { status: 403 });
-            const file = Bun.file(safe);
-            if (await file.exists()) {
-              const dot = safe.lastIndexOf(".");
-              const ext = dot >= 0 ? safe.slice(dot).toLowerCase() : "";
-              return new Response(file, {
-                headers: {
-                  "Content-Type": contentTypeForExt(ext),
-                  "Cache-Control": CACHE_REVALIDATE, // CTL-1374: mockups aren't content-hashed
-                },
-              });
-            }
+        if (url.pathname.startsWith("/public/") || url.pathname.startsWith("/assets/")) {
+          const rel = decodeURIComponent(
+            url.pathname.startsWith("/public/")
+              ? url.pathname.slice("/public/".length)
+              : url.pathname.slice(1),
+          );
+          const safe = resolveSafeStaticPath(publicDir, rel);
+          if (!safe) return new Response("Forbidden", { status: 403 });
+          const file = Bun.file(safe);
+          if (await file.exists()) {
+            const dot = safe.lastIndexOf(".");
+            const ext = dot >= 0 ? safe.slice(dot).toLowerCase() : "";
+            return new Response(file, {
+              headers: {
+                "Content-Type": contentTypeForExt(ext),
+                // CTL-1374: content-hashed /assets/* are immutable (forever-cacheable);
+                // non-hashed /public/* icons revalidate so a redeploy can update them.
+                "Cache-Control": cacheControlForStatic(url.pathname),
+              },
+            });
           }
+        }
 
-          if (url.pathname.startsWith("/public/") || url.pathname.startsWith("/assets/")) {
-            const rel = decodeURIComponent(
-              url.pathname.startsWith("/public/")
-                ? url.pathname.slice("/public/".length)
-                : url.pathname.slice(1),
-            );
-            const safe = resolveSafeStaticPath(publicDir, rel);
-            if (!safe) return new Response("Forbidden", { status: 403 });
-            const file = Bun.file(safe);
-            if (await file.exists()) {
-              const dot = safe.lastIndexOf(".");
-              const ext = dot >= 0 ? safe.slice(dot).toLowerCase() : "";
-              return new Response(file, {
-                headers: {
-                  "Content-Type": contentTypeForExt(ext),
-                  // CTL-1374: content-hashed /assets/* are immutable (forever-cacheable);
-                  // non-hashed /public/* icons revalidate so a redeploy can update them.
-                  "Cache-Control": cacheControlForStatic(url.pathname),
-                },
-              });
-            }
-          }
-
-          if (url.pathname === "/api/status/webhook-tunnel") {
-            const stats = readTunnelEventStats(CATALYST_DIR, eventRing);
-            if (!webhookConfig) {
-              return Response.json({
-                connected: false,
-                smeeUrl: null,
-                secretEnvName: null,
-                secretPresent: false,
-                lastEventAt: stats.lastEventAt,
-                eventCount24h: stats.eventCount24h,
-                eventCount24hByRepo: stats.eventCount24hByRepo,
-              });
-            }
+        if (url.pathname === "/api/status/webhook-tunnel") {
+          const stats = readTunnelEventStats(CATALYST_DIR, eventRing);
+          if (!webhookConfig) {
             return Response.json({
-              connected: webhookTunnel?.isStarted() ?? false,
-              smeeUrl: webhookConfig.smeeChannel || null,
-              secretEnvName: webhookConfig.secretEnvName ?? "CATALYST_WEBHOOK_SECRET",
-              secretPresent: webhookConfig.secret.length > 0,
+              connected: false,
+              smeeUrl: null,
+              secretEnvName: null,
+              secretPresent: false,
               lastEventAt: stats.lastEventAt,
               eventCount24h: stats.eventCount24h,
               eventCount24hByRepo: stats.eventCount24hByRepo,
             });
           }
+          return Response.json({
+            connected: webhookTunnel?.isStarted() ?? false,
+            smeeUrl: webhookConfig.smeeChannel || null,
+            secretEnvName: webhookConfig.secretEnvName ?? "CATALYST_WEBHOOK_SECRET",
+            secretPresent: webhookConfig.secret.length > 0,
+            lastEventAt: stats.lastEventAt,
+            eventCount24h: stats.eventCount24h,
+            eventCount24hByRepo: stats.eventCount24hByRepo,
+          });
+        }
 
-          // CTL-1100: GET /api/journey/:ticket — chronological hop timeline + gates + verdict.
-          // bun:sqlite-free (assembleJourney uses sqlite3 binary via ticket-runs.mjs).
-          // Mirrors ticketRunsMatch guard for input validation.
-          const journeyMatch = url.pathname.match(/^\/api\/journey\/([^/]+)$/);
-          if (journeyMatch) {
-            let ticket: string;
-            try {
-              ticket = decodeURIComponent(journeyMatch[1]);
-            } catch {
-              return new Response("Bad Request", { status: 400 });
-            }
-            if (!/^[A-Za-z]+-\d+$/.test(ticket)) {
-              return new Response("Bad Request", { status: 400 });
-            }
+        // CTL-1100: GET /api/journey/:ticket — chronological hop timeline + gates + verdict.
+        // bun:sqlite-free (assembleJourney uses sqlite3 binary via ticket-runs.mjs).
+        // Mirrors ticketRunsMatch guard for input validation.
+        const journeyMatch = url.pathname.match(/^\/api\/journey\/([^/]+)$/);
+        if (journeyMatch) {
+          let ticket: string;
+          try {
+            ticket = decodeURIComponent(journeyMatch[1]);
+          } catch {
+            return new Response("Bad Request", { status: 400 });
+          }
+          if (!/^[A-Za-z]+-\d+$/.test(ticket)) {
+            return new Response("Bad Request", { status: 400 });
+          }
+          return Response.json(await assembleJourney(ticket, {
+            orchDir: wtDir,
+            workersDir: `${wtDir}/workers`,
+            dbPath: dbPath ?? undefined,
+          }));
+        }
+
+        // CTL-886 (BFF4) keystone P2: a ticket's full run history. One run entity
+        // per phase-*.json signal under ~/catalyst/execution-core/workers/<id>/
+        // (model, bg_job_id, attempt, generation, status, timestamps, host{},
+        // pr{} when present). FINISHED runs (no live BoardWorker) included by
+        // construction — we read the on-disk signals, not the live-agent list.
+        // Per-phase cost is JOINED from catalyst.db, never invented onto the
+        // signal. Pure file reads — no live Linear/GitHub call.
+        const ticketRunsMatch = url.pathname.match(/^\/api\/ticket-runs\/([^/]+)$/);
+        if (ticketRunsMatch) {
+          let ticket: string;
+          try {
+            ticket = decodeURIComponent(ticketRunsMatch[1]);
+          } catch {
+            return new Response("Bad Request", { status: 400 });
+          }
+          if (!/^[A-Za-z]+-\d+$/.test(ticket)) {
+            return new Response("Bad Request", { status: 400 });
+          }
+          return Response.json(await assembleTicketRuns(ticket));
+        }
+
+        // CTL-890 (BFF8) P10: the redesign's ONE destructive endpoint, gated last.
+        // POST /api/ec-worker/<ticket>/stop wraps the flaky `claude stop <shortId>`
+        // (pid-file absent on CC 2.1.152). Matched BEFORE the GET verbatim route
+        // and gated on POST so a stop request is never confused with the
+        // signal reader (and "stop" is not a valid phase, so a GET here 404s
+        // harmlessly). Contract (design §3.4):
+        //   • TYPED CONFIRM — body.confirm must equal the ticket id exactly.
+        //   • TARGET RUN    — body.phase selects which run (its phase-<phase>.json
+        //     signal carries the bg_job_id → shortId). The response echoes the
+        //     exact shortId+ticket+phase so the UI shows what it is killing.
+        //   • FENCE-AWARE   — single-host (hosts.json absent/len 1) is a no-op
+        //     pass; multi-host rejects a verified-stale generation (a partitioned
+        //     node) and refuses on an unconfirmable fence.
+        //   • OPTIMISTIC ROLLBACK is a UI-side ~10s timer; on success we return the
+        //     identity + a `stopping` status the client marks optimistically.
+        const ecStopMatch = url.pathname.match(
+          /^\/api\/ec-worker\/([^/]+)\/stop$/,
+        );
+        if (ecStopMatch && req.method === "POST") {
+          let ticket: string;
+          try {
+            ticket = decodeURIComponent(ecStopMatch[1]);
+          } catch {
+            return new Response("Bad Request", { status: 400 });
+          }
+          if (!/^[A-Za-z]+-\d+$/.test(ticket)) {
+            return new Response("Bad Request", { status: 400 });
+          }
+          let body: Record<string, unknown>;
+          try {
+            body = (await req.json()) as Record<string, unknown>;
+          } catch {
+            return Response.json({ error: "Invalid JSON body" }, { status: 400 });
+          }
+          const phase = typeof body.phase === "string" ? body.phase : "";
+          if (!/^[a-z][a-z-]*$/.test(phase)) {
             return Response.json(
-              await assembleJourney(ticket, {
-                orchDir: wtDir,
-                workersDir: `${wtDir}/workers`,
-                dbPath: dbPath ?? undefined,
-              }),
+              { error: "phase is required and must be a valid phase name" },
+              { status: 400 },
             );
           }
-
-          // CTL-886 (BFF4) keystone P2: a ticket's full run history. One run entity
-          // per phase-*.json signal under ~/catalyst/execution-core/workers/<id>/
-          // (model, bg_job_id, attempt, generation, status, timestamps, host{},
-          // pr{} when present). FINISHED runs (no live BoardWorker) included by
-          // construction — we read the on-disk signals, not the live-agent list.
-          // Per-phase cost is JOINED from catalyst.db, never invented onto the
-          // signal. Pure file reads — no live Linear/GitHub call.
-          const ticketRunsMatch = url.pathname.match(/^\/api\/ticket-runs\/([^/]+)$/);
-          if (ticketRunsMatch) {
-            let ticket: string;
-            try {
-              ticket = decodeURIComponent(ticketRunsMatch[1]);
-            } catch {
-              return new Response("Bad Request", { status: 400 });
-            }
-            if (!/^[A-Za-z]+-\d+$/.test(ticket)) {
-              return new Response("Bad Request", { status: 400 });
-            }
-            return Response.json(await assembleTicketRuns(ticket));
-          }
-
-          // CTL-890 (BFF8) P10: the redesign's ONE destructive endpoint, gated last.
-          // POST /api/ec-worker/<ticket>/stop wraps the flaky `claude stop <shortId>`
-          // (pid-file absent on CC 2.1.152). Matched BEFORE the GET verbatim route
-          // and gated on POST so a stop request is never confused with the
-          // signal reader (and "stop" is not a valid phase, so a GET here 404s
-          // harmlessly). Contract (design §3.4):
-          //   • TYPED CONFIRM — body.confirm must equal the ticket id exactly.
-          //   • TARGET RUN    — body.phase selects which run (its phase-<phase>.json
-          //     signal carries the bg_job_id → shortId). The response echoes the
-          //     exact shortId+ticket+phase so the UI shows what it is killing.
-          //   • FENCE-AWARE   — single-host (hosts.json absent/len 1) is a no-op
-          //     pass; multi-host rejects a verified-stale generation (a partitioned
-          //     node) and refuses on an unconfirmable fence.
-          //   • OPTIMISTIC ROLLBACK is a UI-side ~10s timer; on success we return the
-          //     identity + a `stopping` status the client marks optimistically.
-          const ecStopMatch = url.pathname.match(/^\/api\/ec-worker\/([^/]+)\/stop$/);
-          if (ecStopMatch && req.method === "POST") {
-            let ticket: string;
-            try {
-              ticket = decodeURIComponent(ecStopMatch[1]);
-            } catch {
-              return new Response("Bad Request", { status: 400 });
-            }
-            if (!/^[A-Za-z]+-\d+$/.test(ticket)) {
-              return new Response("Bad Request", { status: 400 });
-            }
-            let body: Record<string, unknown>;
-            try {
-              body = (await req.json()) as Record<string, unknown>;
-            } catch {
-              return Response.json({ error: "Invalid JSON body" }, { status: 400 });
-            }
-            const phase = typeof body.phase === "string" ? body.phase : "";
-            if (!/^[a-z][a-z-]*$/.test(phase)) {
+          const result: StopWorkerResult = await stopWorker({
+            ticket,
+            phase,
+            confirm: body.confirm,
+          });
+          switch (result.status) {
+            case "not_found":
               return Response.json(
-                { error: "phase is required and must be a valid phase name" },
+                { status: "not_found", error: `no run signal for ${ticket}:${phase}` },
+                { status: 404 },
+              );
+            case "confirm_mismatch":
+              return Response.json(
+                {
+                  status: "confirm_mismatch",
+                  error: "typed confirmation did not match the ticket id",
+                  expected: result.expected,
+                },
                 { status: 400 },
               );
-            }
-            const result: StopWorkerResult = await stopWorker({
-              ticket,
-              phase,
-              confirm: body.confirm,
-            });
-            switch (result.status) {
-              case "not_found":
-                return Response.json(
-                  { status: "not_found", error: `no run signal for ${ticket}:${phase}` },
-                  { status: 404 },
-                );
-              case "confirm_mismatch":
-                return Response.json(
-                  {
-                    status: "confirm_mismatch",
-                    error: "typed confirmation did not match the ticket id",
-                    expected: result.expected,
-                  },
-                  { status: 400 },
-                );
-              case "no_session":
-                return Response.json(result, { status: 409 });
-              case "fenced":
-                // A stale-generation node is fenced out — the worker is NOT killed.
-                return Response.json(
-                  {
-                    ...result,
-                    error: "stop rejected: this node's generation is stale (fenced out)",
-                  },
-                  { status: 409 },
-                );
-              case "fence_indeterminate":
-                return Response.json(
-                  {
-                    ...result,
-                    error: "stop rejected: fence could not be confirmed",
-                  },
-                  { status: 409 },
-                );
-              case "stop_failed":
-                return Response.json(result, { status: 502 });
-              case "stopping":
-                // Kill issued; the UI marks the worker `stopping` and arms its ~10s
-                // optimistic-rollback timer against the next board frame.
-                return Response.json(result, { status: 200 });
-            }
-          }
-
-          // CTL-924 (BFF12): the read-model's SECOND write endpoint — HOME5's Inbox
-          // `Answer / Unblock` verb. POST /api/ticket/<ticket>/respond records the
-          // operator's answer/unblock note, clears the `.linear-label-needs-human`
-          // marker, and emits ONE `linear.comment.created` event into the unified
-          // log — the daemon's handleCommentWake (CTL-549) consumes it, strips the
-          // held label, and re-dispatches the parked worker (CTL-876's resume loop).
-          // Contract mirrors BFF8's stop route:
-          //   • TYPED CONFIRM — body.confirm must equal the ticket id exactly.
-          //   • FENCE-AWARE   — single-host (hosts.json absent/len 1) is a no-op
-          //     pass; multi-host rejects a verified-stale generation (a partitioned
-          //     node) and refuses on an unconfirmable fence. NOTHING is mutated on
-          //     a fence rejection.
-          //   • OPTIMISTIC ROLLBACK is a UI-side timer; on success we return the
-          //     ticket+phase identity + a `resuming` status the client marks
-          //     optimistically (the held row should clear within the window).
-          const respondMatch = url.pathname.match(/^\/api\/ticket\/([^/]+)\/respond$/);
-          if (respondMatch && req.method === "POST") {
-            let ticket: string;
-            try {
-              ticket = decodeURIComponent(respondMatch[1]);
-            } catch {
-              return new Response("Bad Request", { status: 400 });
-            }
-            if (!/^[A-Za-z]+-\d+$/.test(ticket)) {
-              return new Response("Bad Request", { status: 400 });
-            }
-            let body: Record<string, unknown>;
-            try {
-              body = (await req.json()) as Record<string, unknown>;
-            } catch {
-              return Response.json({ error: "Invalid JSON body" }, { status: 400 });
-            }
-            const response = typeof body.response === "string" ? body.response : "";
-            const result: RespondTicketResult = respondTicket({
-              ticket,
-              response,
-              confirm: body.confirm,
-            });
-            switch (result.status) {
-              case "not_held":
-                return Response.json(
-                  {
-                    status: "not_held",
-                    error: `no parked (needs-input) run for ${ticket} to answer/unblock`,
-                  },
-                  { status: 404 },
-                );
-              case "confirm_mismatch":
-                return Response.json(
-                  {
-                    status: "confirm_mismatch",
-                    error: "typed confirmation did not match the ticket id",
-                    expected: result.expected,
-                  },
-                  { status: 400 },
-                );
-              case "fenced":
-                // A stale-generation node is fenced out — nothing was mutated.
-                return Response.json(
-                  {
-                    ...result,
-                    error: "respond rejected: this node's generation is stale (fenced out)",
-                  },
-                  { status: 409 },
-                );
-              case "fence_indeterminate":
-                return Response.json(
-                  {
-                    ...result,
-                    error: "respond rejected: fence could not be confirmed",
-                  },
-                  { status: 409 },
-                );
-              case "resuming":
-                // Response recorded + marker cleared + resume event emitted; the UI
-                // marks the row `resuming` and arms its optimistic-rollback timer.
-                return Response.json(result, { status: 200 });
-            }
-          }
-
-          // ── CTL-1569: the inbox conversation surface ───────────────────────────
-          //
-          // GET /api/ticket/<ticket>/thread — the ask summary + the last few comments
-          // (newest first) + the ticket's Linear deep link. A pure REPLICA read: it
-          // makes ZERO Linear API calls, which is what makes it safe to fetch on every
-          // row selection against a shared, rate-limited fleet quota. Fails OPEN —
-          // an absent/locked replica yields an unavailable thread, never a 5xx.
-          const threadMatch = url.pathname.match(/^\/api\/ticket\/([^/]+)\/thread$/);
-          if (threadMatch && req.method === "GET") {
-            let ticket: string;
-            try {
-              ticket = decodeURIComponent(threadMatch[1]);
-            } catch {
-              return new Response("Bad Request", { status: 400 });
-            }
-            // CTL-1569: the canonical ticket key allows digits/underscores in the
-            // team prefix (e.g. `OPS_2-17`). A letters-only predicate 400s the entire
-            // conversation surface for such teams. Still anchored + no path
-            // characters, so traversal remains impossible.
-            if (!CONVERSATION_TICKET_RE.test(ticket)) {
-              return new Response("Bad Request", { status: 400 });
-            }
-            const limitParam = Number(url.searchParams.get("limit"));
-            const conversation = await getConversation(ticket, {
-              // Pass the SERVER-resolved Layer-1 path (--config / CATALYST_CONFIG_PATH).
-              // A cwd-relative fallback misses under launchd, which sets no working
-              // directory — and the legacy `catalyst.monitor.linear.botUserId` lives in
-              // that file, so missing it breaks the agent/human split on legacy hosts.
-              repoConfigPath: monitorConfigPath,
-              ...(Number.isFinite(limitParam) && limitParam > 0
-                ? { limit: Math.min(Math.floor(limitParam), 50) }
-                : {}),
-            });
-            return Response.json(conversation, { status: 200 });
-          }
-
-          // POST /api/ticket/<ticket>/reply — post the operator's reply to Linear as a
-          // REAL human-authored comment. This is the resolution mechanism: once the
-          // comment lands, Linear's webhook drives the daemon's comment-wake, which
-          // clears `needs-human` unconditionally and first (CTL-1567, ~4s end to end).
-          //
-          // Deliberately UNLIKE /respond:
-          //   • NO typed-confirm. The typed gate exists for destructive verbs (stop a
-          //     worker); forcing an operator to retype the ticket id to send a chat
-          //     reply would defeat the entire surface. The reply text IS the intent.
-          //   • NO held-run requirement. The tickets that most need answering are
-          //     parked with no worker dir at all, and /respond 404s exactly those.
-          //
-          // EVERY non-2xx here must cause the UI to RESTORE the row (§4) — the row is
-          // never silently lost. `bot_identity` is the loud refusal that prevents the
-          // whole feature from shipping inert: an app-actor comment is ignored by
-          // CTL-1567, so it is refused BEFORE posting rather than faking success.
-          const replyMatch = url.pathname.match(/^\/api\/ticket\/([^/]+)\/reply$/);
-          if (replyMatch && req.method === "POST") {
-            let ticket: string;
-            try {
-              ticket = decodeURIComponent(replyMatch[1]);
-            } catch {
-              return new Response("Bad Request", { status: 400 });
-            }
-            if (!CONVERSATION_TICKET_RE.test(ticket)) {
-              return new Response("Bad Request", { status: 400 });
-            }
-            // CROSS-ORIGIN GUARD. This route posts operator-authored text to Linear,
-            // and the server binds 0.0.0.0 with no auth. `req.json()` parses a body
-            // regardless of Content-Type, so a plain `text/plain` form POST from any
-            // page the operator visits would otherwise be a valid request — the
-            // browser could not read the response, but the comment would still be
-            // posted as them to any guessable ticket.
-            //
-            // CTL-1573 P1: this used to compare `Origin` against the request's own
-            // `Host` header. Both are attacker-chosen under DNS rebinding (the page
-            // and the target then share one origin), so that comparison could not
-            // reject the very case it existed for. `Origin` is now checked against
-            // an allowlist the attacker cannot influence — see lib/trusted-origin.mjs
-            // for the rebinding walkthrough and the inertness trade-off.
-            if (!originAllowed(req.headers.get("origin"))) {
+            case "no_session":
+              return Response.json(result, { status: 409 });
+            case "fenced":
+              // A stale-generation node is fenced out — the worker is NOT killed.
               return Response.json(
-                { status: "forbidden", error: "cross-origin reply rejected" },
-                { status: 403 },
+                {
+                  ...result,
+                  error: "stop rejected: this node's generation is stale (fenced out)",
+                },
+                { status: 409 },
               );
-            }
-            let body: Record<string, unknown>;
-            try {
-              body = (await req.json()) as Record<string, unknown>;
-            } catch {
-              return Response.json({ error: "Invalid JSON body" }, { status: 400 });
-            }
-            const text = typeof body.body === "string" ? body.body : "";
-            const [globalConfig, projectConfig] = await Promise.all([
-              loadGlobalConfig(),
-              // Explicit resolved path — NOT process.cwd(). The launchd wrapper sets
-              // neither a working directory nor CATALYST_PROJECT_KEY, so a
-              // cwd-relative lookup leaves the Layer-2 token unresolved and every
-              // reply returns `no_token` on the persistent launch path.
-              loadProjectConfig({ repoConfigPath: monitorConfigPath }),
-            ]);
-            const result = await replyToTicket(
-              { ticket, body: text },
-              { config: globalConfig, projectConfig },
+            case "fence_indeterminate":
+              return Response.json(
+                {
+                  ...result,
+                  error: "stop rejected: fence could not be confirmed",
+                },
+                { status: 409 },
+              );
+            case "stop_failed":
+              return Response.json(result, { status: 502 });
+            case "stopping":
+              // Kill issued; the UI marks the worker `stopping` and arms its ~10s
+              // optimistic-rollback timer against the next board frame.
+              return Response.json(result, { status: 200 });
+          }
+        }
+
+        // CTL-924 (BFF12): the read-model's SECOND write endpoint — HOME5's Inbox
+        // `Answer / Unblock` verb. POST /api/ticket/<ticket>/respond records the
+        // operator's answer/unblock note, clears the `.linear-label-needs-human`
+        // marker, and emits ONE `linear.comment.created` event into the unified
+        // log — the daemon's handleCommentWake (CTL-549) consumes it, strips the
+        // held label, and re-dispatches the parked worker (CTL-876's resume loop).
+        // Contract mirrors BFF8's stop route:
+        //   • TYPED CONFIRM — body.confirm must equal the ticket id exactly.
+        //   • FENCE-AWARE   — single-host (hosts.json absent/len 1) is a no-op
+        //     pass; multi-host rejects a verified-stale generation (a partitioned
+        //     node) and refuses on an unconfirmable fence. NOTHING is mutated on
+        //     a fence rejection.
+        //   • OPTIMISTIC ROLLBACK is a UI-side timer; on success we return the
+        //     ticket+phase identity + a `resuming` status the client marks
+        //     optimistically (the held row should clear within the window).
+        const respondMatch = url.pathname.match(
+          /^\/api\/ticket\/([^/]+)\/respond$/,
+        );
+        if (respondMatch && req.method === "POST") {
+          let ticket: string;
+          try {
+            ticket = decodeURIComponent(respondMatch[1]);
+          } catch {
+            return new Response("Bad Request", { status: 400 });
+          }
+          if (!/^[A-Za-z]+-\d+$/.test(ticket)) {
+            return new Response("Bad Request", { status: 400 });
+          }
+          let body: Record<string, unknown>;
+          try {
+            body = (await req.json()) as Record<string, unknown>;
+          } catch {
+            return Response.json({ error: "Invalid JSON body" }, { status: 400 });
+          }
+          const response = typeof body.response === "string" ? body.response : "";
+          const result: RespondTicketResult = respondTicket({
+            ticket,
+            response,
+            confirm: body.confirm,
+          });
+          switch (result.status) {
+            case "not_held":
+              return Response.json(
+                {
+                  status: "not_held",
+                  error: `no parked (needs-input) run for ${ticket} to answer/unblock`,
+                },
+                { status: 404 },
+              );
+            case "confirm_mismatch":
+              return Response.json(
+                {
+                  status: "confirm_mismatch",
+                  error: "typed confirmation did not match the ticket id",
+                  expected: result.expected,
+                },
+                { status: 400 },
+              );
+            case "fenced":
+              // A stale-generation node is fenced out — nothing was mutated.
+              return Response.json(
+                {
+                  ...result,
+                  error: "respond rejected: this node's generation is stale (fenced out)",
+                },
+                { status: 409 },
+              );
+            case "fence_indeterminate":
+              return Response.json(
+                {
+                  ...result,
+                  error: "respond rejected: fence could not be confirmed",
+                },
+                { status: 409 },
+              );
+            case "resuming":
+              // Response recorded + marker cleared + resume event emitted; the UI
+              // marks the row `resuming` and arms its optimistic-rollback timer.
+              return Response.json(result, { status: 200 });
+          }
+        }
+
+        // ── CTL-1569: the inbox conversation surface ───────────────────────────
+        //
+        // GET /api/ticket/<ticket>/thread — the ask summary + the last few comments
+        // (newest first) + the ticket's Linear deep link. A pure REPLICA read: it
+        // makes ZERO Linear API calls, which is what makes it safe to fetch on every
+        // row selection against a shared, rate-limited fleet quota. Fails OPEN —
+        // an absent/locked replica yields an unavailable thread, never a 5xx.
+        const threadMatch = url.pathname.match(/^\/api\/ticket\/([^/]+)\/thread$/);
+        if (threadMatch && req.method === "GET") {
+          let ticket: string;
+          try {
+            ticket = decodeURIComponent(threadMatch[1]);
+          } catch {
+            return new Response("Bad Request", { status: 400 });
+          }
+          // CTL-1569: the canonical ticket key allows digits/underscores in the
+          // team prefix (e.g. `OPS_2-17`). A letters-only predicate 400s the entire
+          // conversation surface for such teams. Still anchored + no path
+          // characters, so traversal remains impossible.
+          if (!CONVERSATION_TICKET_RE.test(ticket)) {
+            return new Response("Bad Request", { status: 400 });
+          }
+          const limitParam = Number(url.searchParams.get("limit"));
+          const conversation = await getConversation(ticket, {
+            // Pass the SERVER-resolved Layer-1 path (--config / CATALYST_CONFIG_PATH).
+            // A cwd-relative fallback misses under launchd, which sets no working
+            // directory — and the legacy `catalyst.monitor.linear.botUserId` lives in
+            // that file, so missing it breaks the agent/human split on legacy hosts.
+            repoConfigPath: monitorConfigPath,
+            ...(Number.isFinite(limitParam) && limitParam > 0
+              ? { limit: Math.min(Math.floor(limitParam), 50) }
+              : {}),
+          });
+          return Response.json(conversation, { status: 200 });
+        }
+
+        // POST /api/ticket/<ticket>/reply — post the operator's reply to Linear as a
+        // REAL human-authored comment. This is the resolution mechanism: once the
+        // comment lands, Linear's webhook drives the daemon's comment-wake, which
+        // clears `needs-human` unconditionally and first (CTL-1567, ~4s end to end).
+        //
+        // Deliberately UNLIKE /respond:
+        //   • NO typed-confirm. The typed gate exists for destructive verbs (stop a
+        //     worker); forcing an operator to retype the ticket id to send a chat
+        //     reply would defeat the entire surface. The reply text IS the intent.
+        //   • NO held-run requirement. The tickets that most need answering are
+        //     parked with no worker dir at all, and /respond 404s exactly those.
+        //
+        // EVERY non-2xx here must cause the UI to RESTORE the row (§4) — the row is
+        // never silently lost. `bot_identity` is the loud refusal that prevents the
+        // whole feature from shipping inert: an app-actor comment is ignored by
+        // CTL-1567, so it is refused BEFORE posting rather than faking success.
+        const replyMatch = url.pathname.match(/^\/api\/ticket\/([^/]+)\/reply$/);
+        if (replyMatch && req.method === "POST") {
+          let ticket: string;
+          try {
+            ticket = decodeURIComponent(replyMatch[1]);
+          } catch {
+            return new Response("Bad Request", { status: 400 });
+          }
+          if (!CONVERSATION_TICKET_RE.test(ticket)) {
+            return new Response("Bad Request", { status: 400 });
+          }
+          // CROSS-ORIGIN GUARD. This route posts operator-authored text to Linear,
+          // and the server binds 0.0.0.0 with no auth. `req.json()` parses a body
+          // regardless of Content-Type, so a plain `text/plain` form POST from any
+          // page the operator visits would otherwise be a valid request — the
+          // browser could not read the response, but the comment would still be
+          // posted as them to any guessable ticket.
+          //
+          // CTL-1573 P1: this used to compare `Origin` against the request's own
+          // `Host` header. Both are attacker-chosen under DNS rebinding (the page
+          // and the target then share one origin), so that comparison could not
+          // reject the very case it existed for. `Origin` is now checked against
+          // an allowlist the attacker cannot influence — see lib/trusted-origin.mjs
+          // for the rebinding walkthrough and the inertness trade-off.
+          if (!originAllowed(req.headers.get("origin"))) {
+            return Response.json(
+              { status: "forbidden", error: "cross-origin reply rejected" },
+              { status: 403 },
             );
-            switch (result.status) {
-              case "replied":
-                // The comment is live and human-authored. The UI marks the row
-                // resolved optimistically and reconciles against the label.
-                return Response.json(result, { status: 200 });
-              case "empty_body":
-                return Response.json(
-                  { ...result, error: "an empty reply was not sent" },
-                  { status: 400 },
-                );
-              case "not_found":
-                return Response.json(
-                  {
-                    ...result,
-                    error: `no Linear issue ${ticket} to reply to`,
-                  },
-                  { status: 404 },
-                );
-              case "bot_identity":
-              case "no_token":
-              case "error":
-              default:
-                // 502: the write did NOT act. Surfaced verbatim so the operator sees
-                // WHY (especially the app-actor refusal) and the row comes back.
-                return Response.json(
-                  {
-                    ...result,
-                    error:
-                      (result as { message?: string }).message ?? "reply was not posted to Linear",
-                  },
-                  { status: 502 },
-                );
-            }
+          }
+          let body: Record<string, unknown>;
+          try {
+            body = (await req.json()) as Record<string, unknown>;
+          } catch {
+            return Response.json({ error: "Invalid JSON body" }, { status: 400 });
+          }
+          const text = typeof body.body === "string" ? body.body : "";
+          const [globalConfig, projectConfig] = await Promise.all([
+            loadGlobalConfig(),
+            // Explicit resolved path — NOT process.cwd(). The launchd wrapper sets
+            // neither a working directory nor CATALYST_PROJECT_KEY, so a
+            // cwd-relative lookup leaves the Layer-2 token unresolved and every
+            // reply returns `no_token` on the persistent launch path.
+            loadProjectConfig({ repoConfigPath: monitorConfigPath }),
+          ]);
+          const result = await replyToTicket(
+            { ticket, body: text },
+            { config: globalConfig, projectConfig },
+          );
+          switch (result.status) {
+            case "replied":
+              // The comment is live and human-authored. The UI marks the row
+              // resolved optimistically and reconciles against the label.
+              return Response.json(result, { status: 200 });
+            case "empty_body":
+              return Response.json(
+                { ...result, error: "an empty reply was not sent" },
+                { status: 400 },
+              );
+            case "not_found":
+              return Response.json(
+                {
+                  ...result,
+                  error: `no Linear issue ${ticket} to reply to`,
+                },
+                { status: 404 },
+              );
+            case "bot_identity":
+            case "no_token":
+            case "error":
+            default:
+              // 502: the write did NOT act. Surfaced verbatim so the operator sees
+              // WHY (especially the app-actor refusal) and the row comes back.
+              return Response.json(
+                {
+                  ...result,
+                  error:
+                    (result as { message?: string }).message ??
+                    "reply was not posted to Linear",
+                },
+                { status: 502 },
+              );
+          }
+        }
+
+        // CTL-886 (BFF4) companion P3: one phase signal served VERBATIM — the raw
+        // phase-<phase>.json contents (model, bg_job_id, generation, status,
+        // timestamps, host, pr) untransformed, for the worker header / PHASE
+        // TIMESTAMPS / SIGNAL panel. 404 when the phase has no signal on disk.
+        const ecWorkerMatch = url.pathname.match(
+          /^\/api\/ec-worker\/([^/]+)\/([^/]+)$/,
+        );
+        if (ecWorkerMatch) {
+          let ticket: string;
+          let phase: string;
+          try {
+            ticket = decodeURIComponent(ecWorkerMatch[1]);
+            phase = decodeURIComponent(ecWorkerMatch[2]);
+          } catch {
+            return new Response("Bad Request", { status: 400 });
+          }
+          if (
+            !/^[A-Za-z]+-\d+$/.test(ticket) ||
+            !/^[a-z][a-z-]*$/.test(phase)
+          ) {
+            return new Response("Bad Request", { status: 400 });
+          }
+          const signal = await readPhaseSignalVerbatim(ticket, phase);
+          if (!signal) {
+            return new Response("Not Found", { status: 404 });
+          }
+          return Response.json(signal);
+        }
+
+        // CTL-887 (BFF5) + CTL-885 (BFF3): the live transcript tail, made
+        // NODE-AWARE. BFF5 resolves a CC session UUID to its
+        // ~/.claude/projects/<dir>/<sessionId>.jsonl path and streams typed
+        // StreamEvents over SSE as the file grows (the EC equivalent of the
+        // legacy /api/worker-stream, which is empty for execution-core workers).
+        // BFF3 wraps that host-local tail in the cross-node FAN-IN: the UI
+        // subscribes ONCE and the read-model multiplexes the OWNING node's
+        // per-host stream keyed by host.name.
+        //   • SINGLE-HOST (hosts.json absent/len 1): an EXACT identity no-op —
+        //     tail the LOCAL transcript with zero added latency, no owner
+        //     resolution, no remote hop (resolveTailRoute → { mode: "local" }).
+        //   • MULTI-HOST, owner is a DIFFERENT node: proxy that peer's
+        //     /api/ec-worker-stream/<sessionId> through unchanged (never a
+        //     shared/merged log — only the one owner's per-host stream).
+        const ecWorkerStreamMatch = url.pathname.match(
+          /^\/api\/ec-worker-stream\/([^/]+)$/,
+        );
+        if (ecWorkerStreamMatch) {
+          let sessionId: string;
+          try {
+            sessionId = decodeURIComponent(ecWorkerStreamMatch[1]);
+          } catch {
+            return new Response("Bad Request", { status: 400 });
+          }
+          // A CC session id is a UUID — reject anything else so no arbitrary
+          // path ever reaches the filesystem.
+          if (
+            !/^[0-9a-fA-F-]{8,64}$/.test(sessionId) ||
+            sessionId.includes("..") ||
+            sessionId.includes("/")
+          ) {
+            return new Response("Bad Request", { status: 400 });
           }
 
-          // CTL-886 (BFF4) companion P3: one phase signal served VERBATIM — the raw
-          // phase-<phase>.json contents (model, bg_job_id, generation, status,
-          // timestamps, host, pr) untransformed, for the worker header / PHASE
-          // TIMESTAMPS / SIGNAL panel. 404 when the phase has no signal on disk.
-          const ecWorkerMatch = url.pathname.match(/^\/api\/ec-worker\/([^/]+)\/([^/]+)$/);
-          if (ecWorkerMatch) {
-            let ticket: string;
-            let phase: string;
-            try {
-              ticket = decodeURIComponent(ecWorkerMatch[1]);
-              phase = decodeURIComponent(ecWorkerMatch[2]);
-            } catch {
-              return new Response("Bad Request", { status: 400 });
+          // ── BFF3 fan-in routing (single-host = identity no-op) ──────────────
+          // Read the committed roster ONCE. SINGLE-HOST is the identity no-op:
+          // resolveTailRoute short-circuits to { mode: "local" } before any
+          // owner resolution, so we never even read the board snapshot — zero
+          // added latency. Only the MULTI-HOST branch resolves the owner: we
+          // read the board snapshot's per-worker host:{name,id} (BFF2/BFF10) —
+          // never a live attachment fetch, never a merged log — and pass a
+          // synchronous lookup over that resolved worker list. `hostBaseUrl` is
+          // the cross-node transport seam: no production roster→URL source
+          // exists yet (single-node MVP), so a multi-host owner with no
+          // resolvable base URL is reported unroutable (a 404) rather than
+          // mis-tailed to the wrong node's local file.
+          const roster = readClusterRoster();
+          const workers =
+            roster.length > 1 ? ((await boardSnapshot.getLatest())?.workers ?? []) : [];
+          const route = resolveTailRoute({
+            sessionId,
+            roster,
+            selfHost: hostName(),
+            ownerHostForSession: (sid) =>
+              workers.find((w) => w.sessionId === sid)?.host?.name ?? null,
+            hostBaseUrl: (host) => resolvePeerBaseUrl(host),
+          });
+          if (route.mode === "remote") {
+            // MULTI-HOST: fan in the owning node's per-host stream, keyed by
+            // host.name, by proxying its SSE body straight through (no re-frame
+            // — the client's StreamEventRow renderer consumes the peer's frames
+            // unchanged). A down/unreachable peer → 502 (never a wrong tail).
+            const abort = new AbortController();
+            const body = await proxyRemoteTail({ url: route.url, signal: abort.signal });
+            if (!body) {
+              return new Response("Bad Gateway", { status: 502 });
             }
-            if (!/^[A-Za-z]+-\d+$/.test(ticket) || !/^[a-z][a-z-]*$/.test(phase)) {
-              return new Response("Bad Request", { status: 400 });
-            }
-            const signal = await readPhaseSignalVerbatim(ticket, phase);
-            if (!signal) {
-              return new Response("Not Found", { status: 404 });
-            }
-            return Response.json(signal);
-          }
-
-          // CTL-887 (BFF5) + CTL-885 (BFF3): the live transcript tail, made
-          // NODE-AWARE. BFF5 resolves a CC session UUID to its
-          // ~/.claude/projects/<dir>/<sessionId>.jsonl path and streams typed
-          // StreamEvents over SSE as the file grows (the EC equivalent of the
-          // legacy /api/worker-stream, which is empty for execution-core workers).
-          // BFF3 wraps that host-local tail in the cross-node FAN-IN: the UI
-          // subscribes ONCE and the read-model multiplexes the OWNING node's
-          // per-host stream keyed by host.name.
-          //   • SINGLE-HOST (hosts.json absent/len 1): an EXACT identity no-op —
-          //     tail the LOCAL transcript with zero added latency, no owner
-          //     resolution, no remote hop (resolveTailRoute → { mode: "local" }).
-          //   • MULTI-HOST, owner is a DIFFERENT node: proxy that peer's
-          //     /api/ec-worker-stream/<sessionId> through unchanged (never a
-          //     shared/merged log — only the one owner's per-host stream).
-          const ecWorkerStreamMatch = url.pathname.match(/^\/api\/ec-worker-stream\/([^/]+)$/);
-          if (ecWorkerStreamMatch) {
-            let sessionId: string;
-            try {
-              sessionId = decodeURIComponent(ecWorkerStreamMatch[1]);
-            } catch {
-              return new Response("Bad Request", { status: 400 });
-            }
-            // A CC session id is a UUID — reject anything else so no arbitrary
-            // path ever reaches the filesystem.
-            if (
-              !/^[0-9a-fA-F-]{8,64}$/.test(sessionId) ||
-              sessionId.includes("..") ||
-              sessionId.includes("/")
-            ) {
-              return new Response("Bad Request", { status: 400 });
-            }
-
-            // ── BFF3 fan-in routing (single-host = identity no-op) ──────────────
-            // Read the committed roster ONCE. SINGLE-HOST is the identity no-op:
-            // resolveTailRoute short-circuits to { mode: "local" } before any
-            // owner resolution, so we never even read the board snapshot — zero
-            // added latency. Only the MULTI-HOST branch resolves the owner: we
-            // read the board snapshot's per-worker host:{name,id} (BFF2/BFF10) —
-            // never a live attachment fetch, never a merged log — and pass a
-            // synchronous lookup over that resolved worker list. `hostBaseUrl` is
-            // the cross-node transport seam: no production roster→URL source
-            // exists yet (single-node MVP), so a multi-host owner with no
-            // resolvable base URL is reported unroutable (a 404) rather than
-            // mis-tailed to the wrong node's local file.
-            const roster = readClusterRoster();
-            const workers =
-              roster.length > 1 ? ((await boardSnapshot.getLatest())?.workers ?? []) : [];
-            const route = resolveTailRoute({
-              sessionId,
-              roster,
-              selfHost: hostName(),
-              ownerHostForSession: (sid) =>
-                workers.find((w) => w.sessionId === sid)?.host?.name ?? null,
-              hostBaseUrl: (host) => resolvePeerBaseUrl(host),
-            });
-            if (route.mode === "remote") {
-              // MULTI-HOST: fan in the owning node's per-host stream, keyed by
-              // host.name, by proxying its SSE body straight through (no re-frame
-              // — the client's StreamEventRow renderer consumes the peer's frames
-              // unchanged). A down/unreachable peer → 502 (never a wrong tail).
-              const abort = new AbortController();
-              const body = await proxyRemoteTail({ url: route.url, signal: abort.signal });
-              if (!body) {
-                return new Response("Bad Gateway", { status: 502 });
-              }
-              const proxied = new ReadableStream<Uint8Array>({
-                async start(controller) {
-                  const reader = body.getReader();
-                  try {
-                    for (;;) {
-                      const { value, done } = await reader.read();
-                      if (done) break;
-                      if (value) controller.enqueue(value);
-                    }
-                    controller.close();
-                  } catch {
-                    // upstream torn down (peer closed / client aborted) — end the
-                    // proxied stream cleanly rather than leaking the reader.
-                    try {
-                      controller.close();
-                    } catch {
-                      /* already closed */
-                    }
+            const proxied = new ReadableStream<Uint8Array>({
+              async start(controller) {
+                const reader = body.getReader();
+                try {
+                  for (;;) {
+                    const { value, done } = await reader.read();
+                    if (done) break;
+                    if (value) controller.enqueue(value);
                   }
-                },
-                cancel() {
-                  // client disconnected → abort the upstream subscription so no
-                  // per-host connection leaks.
-                  abort.abort();
-                },
-              });
-              return new Response(proxied, {
-                headers: {
-                  "Content-Type": "text/event-stream",
-                  "Cache-Control": "no-cache",
-                  Connection: "keep-alive",
-                  "Access-Control-Allow-Origin": "*",
-                },
-              });
-            }
-            if (route.mode === "unroutable") {
-              // MULTI-HOST: owner is a different node we can't reach (no transport
-              // address). 404 rather than blindly tailing THIS host's transcript
-              // (which would show the wrong node's session).
-              return new Response("Not Found", { status: 404 });
-            }
-            // route.mode === "local": the identity no-op — tail the LOCAL
-            // transcript exactly as the non-cluster BFF5 path does.
-            const transcriptPath = await resolveTranscriptPath(sessionId);
-            if (!transcriptPath) {
-              return new Response("Not Found", { status: 404 });
-            }
-
-            let timer: ReturnType<typeof setInterval> | null = null;
-            let inFlight = false;
-            let closed = false;
-            const tail = new TranscriptTail(transcriptPath);
-            const stream = new ReadableStream<Uint8Array>({
-              start(controller) {
-                const pump = () => {
-                  if (inFlight || closed) return;
-                  inFlight = true;
-                  void (async () => {
-                    try {
-                      const events = await tail.poll();
-                      if (closed) return;
-                      for (const ev of events) {
-                        controller.enqueue(
-                          encoder.encode(`event: stream-event\ndata: ${JSON.stringify(ev)}\n\n`),
-                        );
-                      }
-                    } catch {
-                      // client likely went away mid-enqueue; stop pumping
-                      closed = true;
-                      if (timer) clearInterval(timer);
-                      timer = null;
-                    } finally {
-                      inFlight = false;
-                    }
-                  })();
-                };
-                // Open frame so a cold connection paints the tail immediately,
-                // then poll for growth on a fixed cadence.
-                controller.enqueue(
-                  encoder.encode(`event: open\ndata: ${JSON.stringify({ sessionId })}\n\n`),
-                );
-                pump();
-                timer = setInterval(pump, 750);
-              },
-              cancel() {
-                closed = true;
-                if (timer) clearInterval(timer);
-                timer = null;
-              },
-            });
-            return new Response(stream, {
-              headers: {
-                "Content-Type": "text/event-stream",
-                "Cache-Control": "no-cache",
-                Connection: "keep-alive",
-                "Access-Control-Allow-Origin": "*",
-              },
-            });
-          }
-
-          // CTL-938: the live SCREEN SSE — the PRE-transcript wedge window. Given
-          // a worker's bg shortId (or full job UUID), poll `claude logs <shortId>`
-          // every screenPollMs, ANSI-normalize, diff against the last snapshot,
-          // and push only CHANGED frames (each carrying the FULL screen, never a
-          // delta — frames are droppable, so a slow client just paints the latest
-          // one). Terminal outcomes close the stream: session gone → `gone`
-          // event, claude CLI unusable → `unavailable` event. The FIRST poll runs
-          // before the SSE handshake so a dead session is an HTTP status (404 /
-          // 503), not an empty stream the client must time out on.
-          const ecWorkerScreenMatch = url.pathname.match(/^\/api\/ec-worker-screen\/([^/]+)$/);
-          if (ecWorkerScreenMatch) {
-            let rawId: string;
-            try {
-              rawId = decodeURIComponent(ecWorkerScreenMatch[1]);
-            } catch {
-              return new Response("Bad Request", { status: 400 });
-            }
-            // `claude logs` only accepts the 8-char short form; deriveScreenShortId
-            // also truncates a full job UUID. null = malformed → nothing ever
-            // reaches the exec fn (no arbitrary string ever hits a subprocess).
-            const screenShortId = deriveScreenShortId(rawId);
-            if (!screenShortId) {
-              return new Response("Bad Request", { status: 400 });
-            }
-
-            const poller = new ScreenPoller(screenShortId, {
-              exec: screenLogsExecOpt ?? undefined,
-            });
-            const first = await poller.poll();
-            if (first.kind === "gone") {
-              return new Response("Not Found", { status: 404 });
-            }
-            if (first.kind === "unavailable") {
-              return new Response("Service Unavailable", { status: 503 });
-            }
-
-            let timer: ReturnType<typeof setInterval> | null = null;
-            let inFlight = false;
-            let closed = false;
-            const stream = new ReadableStream<Uint8Array>({
-              start(controller) {
-                const close = () => {
-                  if (closed) return;
-                  closed = true;
-                  if (timer) clearInterval(timer);
-                  timer = null;
+                  controller.close();
+                } catch {
+                  // upstream torn down (peer closed / client aborted) — end the
+                  // proxied stream cleanly rather than leaking the reader.
                   try {
                     controller.close();
                   } catch {
                     /* already closed */
                   }
-                };
-                const emit = (event: string, data: unknown) => {
-                  if (closed) return;
-                  try {
-                    controller.enqueue(
-                      encoder.encode(`event: ${event}\ndata: ${JSON.stringify(data)}\n\n`),
-                    );
-                  } catch {
-                    // client went away mid-enqueue — stop polling immediately
-                    close();
-                  }
-                };
-                emit("open", { shortId: screenShortId });
-                if (first.kind === "frame") {
-                  emit("screen", { screen: first.screen, ts: Date.now() });
-                }
-                // Backpressure: skip the tick while a poll is in flight (a slow
-                // `claude logs` never queues a pile-up — intermediate frames are
-                // simply never produced; the next completed poll diffs against
-                // the latest screen).
-                const pump = () => {
-                  if (inFlight || closed) return;
-                  inFlight = true;
-                  void (async () => {
-                    try {
-                      const res = await poller.poll();
-                      if (closed) return;
-                      if (res.kind === "frame") {
-                        emit("screen", { screen: res.screen, ts: Date.now() });
-                      } else if (res.kind === "gone") {
-                        emit("gone", { reason: res.reason });
-                        close();
-                      } else if (res.kind === "unavailable") {
-                        emit("unavailable", { reason: res.reason });
-                        close();
-                      }
-                      // "unchanged" → nothing on the wire (change-driven); the
-                      // client derives the frozen-screen age from its own clock.
-                    } catch {
-                      close();
-                    } finally {
-                      inFlight = false;
-                    }
-                  })();
-                };
-                timer = setInterval(pump, screenPollMs);
-                // Interval cleanup on client abort — Bun fires req.signal when
-                // the EventSource disconnects, in addition to stream cancel().
-                // CTL-967 SIDE-AC: guard against req.signal already being aborted
-                // at registration time (race between stream setup and client
-                // disconnect) — call close() immediately rather than leaking the
-                // interval.
-                if (req.signal.aborted) {
-                  close();
-                } else {
-                  req.signal.addEventListener("abort", close);
                 }
               },
               cancel() {
+                // client disconnected → abort the upstream subscription so no
+                // per-host connection leaks.
+                abort.abort();
+              },
+            });
+            return new Response(proxied, {
+              headers: {
+                "Content-Type": "text/event-stream",
+                "Cache-Control": "no-cache",
+                Connection: "keep-alive",
+                "Access-Control-Allow-Origin": "*",
+              },
+            });
+          }
+          if (route.mode === "unroutable") {
+            // MULTI-HOST: owner is a different node we can't reach (no transport
+            // address). 404 rather than blindly tailing THIS host's transcript
+            // (which would show the wrong node's session).
+            return new Response("Not Found", { status: 404 });
+          }
+          // route.mode === "local": the identity no-op — tail the LOCAL
+          // transcript exactly as the non-cluster BFF5 path does.
+          const transcriptPath = await resolveTranscriptPath(sessionId);
+          if (!transcriptPath) {
+            return new Response("Not Found", { status: 404 });
+          }
+
+          let timer: ReturnType<typeof setInterval> | null = null;
+          let inFlight = false;
+          let closed = false;
+          const tail = new TranscriptTail(transcriptPath);
+          const stream = new ReadableStream<Uint8Array>({
+            start(controller) {
+              const pump = () => {
+                if (inFlight || closed) return;
+                inFlight = true;
+                void (async () => {
+                  try {
+                    const events = await tail.poll();
+                    if (closed) return;
+                    for (const ev of events) {
+                      controller.enqueue(
+                        encoder.encode(
+                          `event: stream-event\ndata: ${JSON.stringify(ev)}\n\n`,
+                        ),
+                      );
+                    }
+                  } catch {
+                    // client likely went away mid-enqueue; stop pumping
+                    closed = true;
+                    if (timer) clearInterval(timer);
+                    timer = null;
+                  } finally {
+                    inFlight = false;
+                  }
+                })();
+              };
+              // Open frame so a cold connection paints the tail immediately,
+              // then poll for growth on a fixed cadence.
+              controller.enqueue(
+                encoder.encode(
+                  `event: open\ndata: ${JSON.stringify({ sessionId })}\n\n`,
+                ),
+              );
+              pump();
+              timer = setInterval(pump, 750);
+            },
+            cancel() {
+              closed = true;
+              if (timer) clearInterval(timer);
+              timer = null;
+            },
+          });
+          return new Response(stream, {
+            headers: {
+              "Content-Type": "text/event-stream",
+              "Cache-Control": "no-cache",
+              Connection: "keep-alive",
+              "Access-Control-Allow-Origin": "*",
+            },
+          });
+        }
+
+        // CTL-938: the live SCREEN SSE — the PRE-transcript wedge window. Given
+        // a worker's bg shortId (or full job UUID), poll `claude logs <shortId>`
+        // every screenPollMs, ANSI-normalize, diff against the last snapshot,
+        // and push only CHANGED frames (each carrying the FULL screen, never a
+        // delta — frames are droppable, so a slow client just paints the latest
+        // one). Terminal outcomes close the stream: session gone → `gone`
+        // event, claude CLI unusable → `unavailable` event. The FIRST poll runs
+        // before the SSE handshake so a dead session is an HTTP status (404 /
+        // 503), not an empty stream the client must time out on.
+        const ecWorkerScreenMatch = url.pathname.match(
+          /^\/api\/ec-worker-screen\/([^/]+)$/,
+        );
+        if (ecWorkerScreenMatch) {
+          let rawId: string;
+          try {
+            rawId = decodeURIComponent(ecWorkerScreenMatch[1]);
+          } catch {
+            return new Response("Bad Request", { status: 400 });
+          }
+          // `claude logs` only accepts the 8-char short form; deriveScreenShortId
+          // also truncates a full job UUID. null = malformed → nothing ever
+          // reaches the exec fn (no arbitrary string ever hits a subprocess).
+          const screenShortId = deriveScreenShortId(rawId);
+          if (!screenShortId) {
+            return new Response("Bad Request", { status: 400 });
+          }
+
+          const poller = new ScreenPoller(screenShortId, {
+            exec: screenLogsExecOpt ?? undefined,
+          });
+          const first = await poller.poll();
+          if (first.kind === "gone") {
+            return new Response("Not Found", { status: 404 });
+          }
+          if (first.kind === "unavailable") {
+            return new Response("Service Unavailable", { status: 503 });
+          }
+
+          let timer: ReturnType<typeof setInterval> | null = null;
+          let inFlight = false;
+          let closed = false;
+          const stream = new ReadableStream<Uint8Array>({
+            start(controller) {
+              const close = () => {
+                if (closed) return;
                 closed = true;
                 if (timer) clearInterval(timer);
                 timer = null;
-              },
-            });
-            return new Response(stream, {
-              headers: {
-                "Content-Type": "text/event-stream",
-                "Cache-Control": "no-cache",
-                Connection: "keep-alive",
-                "Access-Control-Allow-Origin": "*",
-              },
-            });
-          }
-
-          if (url.pathname === "/api/board") {
-            return Response.json(decorateBoard(await boardSnapshot.getLatest()));
-          }
-
-          // CTL-733: SSE push of the shared board snapshot. The client (Board.tsx /
-          // the board SharedWorker) opens ONE of these and receives a `board` event
-          // on connect and on every reactive recompute — no per-tab polling.
-          if (url.pathname === "/api/board/stream") {
-            let unsubscribe: (() => void) | null = null;
-            let closed = false;
-            const send = (
-              controller: ReadableStreamDefaultController<Uint8Array>,
-              snap: BoardPayload,
-            ) => {
-              if (closed) return;
-              try {
-                controller.enqueue(
-                  encoder.encode(`event: board\ndata: ${JSON.stringify(decorateBoard(snap))}\n\n`),
-                );
-              } catch {
-                // client went away between recompute and enqueue
-                unsubscribe?.();
-                unsubscribe = null;
-              }
-            };
-            const stream = new ReadableStream<Uint8Array>({
-              async start(controller) {
-                // subscribe first so no recompute is missed between bootstrap + subscribe
-                unsubscribe = boardSnapshot.subscribe((snap) => send(controller, snap));
                 try {
-                  send(controller, await boardSnapshot.getLatest());
-                } catch (err) {
-                  console.error(`[server] board stream initial snapshot failed:`, err);
-                }
-              },
-              cancel() {
-                closed = true;
-                unsubscribe?.();
-                unsubscribe = null;
-              },
-            });
-            return new Response(stream, {
-              headers: {
-                "Content-Type": "text/event-stream",
-                "Cache-Control": "no-cache",
-                Connection: "keep-alive",
-                "Access-Control-Allow-Origin": "*",
-              },
-            });
-          }
-
-          // CTL-896 (SHELL6): the nav-signal projection — worker count, queue depth,
-          // board anomaly, and the daemon-health dot — as a single one-shot read for
-          // the warm paint + the SSE reconcile. Derived off the SAME shared board
-          // snapshot the board endpoints serve plus the local daemon health; NEVER a
-          // synchronous per-request scan of the source signal files.
-          if (url.pathname === "/api/nav") {
-            return Response.json(await assembleNavSignal(await boardSnapshot.getLatest()));
-          }
-
-          // CTL-896 (SHELL6): SSE push of the nav signal. The rail opens ONE of these
-          // and receives a `nav` event on connect and on every reactive board
-          // recompute — the live badges update without a page reload and WITHOUT
-          // per-tab polling of the source files (Gherkin: "Live without thrash").
-          if (url.pathname === "/api/nav/stream") {
-            let unsubscribe: (() => void) | null = null;
-            let closed = false;
-            const sendNav = (
-              controller: ReadableStreamDefaultController<Uint8Array>,
-              signal: NavSignal,
-            ) => {
-              if (closed) return;
-              try {
-                controller.enqueue(
-                  encoder.encode(`event: nav\ndata: ${JSON.stringify(signal)}\n\n`),
-                );
-              } catch {
-                unsubscribe?.();
-                unsubscribe = null;
-              }
-            };
-            const stream = new ReadableStream<Uint8Array>({
-              async start(controller) {
-                // subscribe first so no recompute is missed between bootstrap +
-                // subscribe; each board frame is projected into a nav signal (the
-                // daemon health is re-read per frame so the dot tracks heartbeats).
-                unsubscribe = boardSnapshot.subscribe((snap) => {
-                  void assembleNavSignal(snap).then((signal) => sendNav(controller, signal));
-                });
-                try {
-                  sendNav(controller, await assembleNavSignal(await boardSnapshot.getLatest()));
-                } catch (err) {
-                  console.error(`[server] nav stream initial signal failed:`, err);
-                }
-              },
-              cancel() {
-                closed = true;
-                unsubscribe?.();
-                unsubscribe = null;
-              },
-            });
-            return new Response(stream, {
-              headers: {
-                "Content-Type": "text/event-stream",
-                "Cache-Control": "no-cache",
-                Connection: "keep-alive",
-                "Access-Control-Allow-Origin": "*",
-              },
-            });
-          }
-
-          // CTL-898 (SHELL8): the per-node cluster-health signal — one {host,status}
-          // per running node + the single-host flag — as a one-shot read for the
-          // footer's warm paint + the SSE reconcile. Projected off the SAME shared
-          // board snapshot the board/nav endpoints serve plus the cluster view's
-          // owner_host grouping + heartbeat liveness; NEVER a per-request scan.
-          // Single-host is the exact identity no-op (one node, the local daemon).
-          if (url.pathname === "/api/cluster") {
-            return Response.json(await assembleClusterSignal(await boardSnapshot.getLatest()));
-          }
-
-          // CTL-1092 (Phase 5): per-node capacity change history from the event log.
-          // Read-only; no writes. Scans the current-month JSONL for capacity events.
-          if (url.pathname === "/api/capacity-history") {
-            const month = new Date().toISOString().slice(0, 7); // YYYY-MM
-            const capLogPath = join(CATALYST_DIR, "events", `${month}.jsonl`);
-            const data = readCapacityHistory({ logPath: capLogPath });
-            return Response.json({ data });
-          }
-
-          // CTL-898 (SHELL8): SSE push of the cluster signal. The footer opens ONE
-          // of these and receives a `cluster` event on connect and on every reactive
-          // board recompute — a node going dark past its grace window flips its dot
-          // to offline WITHOUT a page reload and WITHOUT per-tab polling of the
-          // source files (Gherkin: "A node going dark is reflected").
-          if (url.pathname === "/api/cluster/stream") {
-            let unsubscribe: (() => void) | null = null;
-            let closed = false;
-            const sendCluster = (
-              controller: ReadableStreamDefaultController<Uint8Array>,
-              signal: ClusterSignal,
-            ) => {
-              if (closed) return;
-              try {
-                controller.enqueue(
-                  encoder.encode(`event: cluster\ndata: ${JSON.stringify(signal)}\n\n`),
-                );
-              } catch {
-                unsubscribe?.();
-                unsubscribe = null;
-              }
-            };
-            const stream = new ReadableStream<Uint8Array>({
-              async start(controller) {
-                // subscribe first so no recompute is missed between bootstrap +
-                // subscribe; each board frame is projected into a cluster signal
-                // (the heartbeat liveness is re-classified per frame so a node going
-                // dark surfaces without a reload).
-                unsubscribe = boardSnapshot.subscribe((snap) => {
-                  void assembleClusterSignal(snap).then((signal) =>
-                    sendCluster(controller, signal),
-                  );
-                });
-                try {
-                  sendCluster(
-                    controller,
-                    await assembleClusterSignal(await boardSnapshot.getLatest()),
-                  );
-                } catch (err) {
-                  console.error(`[server] cluster stream initial signal failed:`, err);
-                }
-              },
-              cancel() {
-                closed = true;
-                unsubscribe?.();
-                unsubscribe = null;
-              },
-            });
-            return new Response(stream, {
-              headers: {
-                "Content-Type": "text/event-stream",
-                "Cache-Control": "no-cache",
-                Connection: "keep-alive",
-                "Access-Control-Allow-Origin": "*",
-              },
-            });
-          }
-
-          // CTL-1167: serve the VAPID public key so the browser can build the
-          // applicationServerKey for pushManager.subscribe(). 503 when push was
-          // never initialized for this server instance (push not configured).
-          if (url.pathname === "/api/notifications/vapid-public-key") {
-            if (!vapidKeys) {
-              return new Response("push not configured", { status: 503 });
-            }
-            return new Response(vapidKeys.publicKey, {
-              headers: { "Content-Type": "text/plain" },
-            });
-          }
-
-          // CTL-1167: persist a browser push subscription (POST body is the
-          // serialised PushSubscription JSON from the browser). Returns 201 on
-          // success; 400 on missing/invalid fields.
-          if (url.pathname === "/api/notifications/subscribe" && req.method === "POST") {
-            if (!vapidKeys) {
-              return new Response("push not configured", { status: 503 });
-            }
-            let body: unknown;
-            try {
-              body = await req.json();
-            } catch {
-              return new Response("invalid JSON", { status: 400 });
-            }
-            const sub = body as Record<string, unknown>;
-            const keys = sub?.keys as Record<string, unknown> | undefined;
-            if (
-              typeof sub?.endpoint !== "string" ||
-              !sub.endpoint ||
-              typeof keys?.p256dh !== "string" ||
-              !keys.p256dh ||
-              typeof keys?.auth !== "string" ||
-              !keys.auth
-            ) {
-              return new Response("missing endpoint, keys.p256dh or keys.auth", {
-                status: 400,
-              });
-            }
-            pushStore.upsertSubscription({
-              endpoint: sub.endpoint,
-              keys: { p256dh: keys.p256dh, auth: keys.auth },
-            });
-            return new Response(null, { status: 201 });
-          }
-
-          // CTL-1167: SSE stream of novel push-worthy notifications. Mirrors
-          // /api/nav/stream: one per-connection projector, subscribe-first, emit on
-          // every board recompute that yields new notifications. Each event:
-          //   event: notification\ndata: {title,body,deepLink}\n\n
-          if (url.pathname === "/api/notifications/stream") {
-            let unsubNotif: (() => void) | null = null;
-            let closedNotif = false;
-            const notifProjector = createNotificationProjector({
-              daemonNotifyHoldMs,
-            });
-            const emitNotifications = (
-              controller: ReadableStreamDefaultController<Uint8Array>,
-              pb: ProjectorBoard,
-            ) => {
-              if (closedNotif) return;
-              for (const n of notifProjector.project(pb)) {
-                try {
-                  controller.enqueue(
-                    encoder.encode(`event: notification\ndata: ${JSON.stringify(n)}\n\n`),
-                  );
+                  controller.close();
                 } catch {
-                  unsubNotif?.();
-                  unsubNotif = null;
+                  /* already closed */
                 }
-              }
-            };
-            const notifStream = new ReadableStream<Uint8Array>({
-              async start(controller) {
-                // Emit an immediate `open` frame so the connection is live even
-                // when the fleet yields no notifications. Without a first chunk,
-                // Bun does not resolve fetch()'s response headers (the client —
-                // and the route tests — would hang). Mirrors /api/beliefs/stream.
+              };
+              const emit = (event: string, data: unknown) => {
+                if (closed) return;
                 try {
                   controller.enqueue(
                     encoder.encode(
-                      `event: open\ndata: ${JSON.stringify({ source: "notifications" })}\n\n`,
+                      `event: ${event}\ndata: ${JSON.stringify(data)}\n\n`,
                     ),
                   );
                 } catch {
-                  closedNotif = true;
-                  return;
+                  // client went away mid-enqueue — stop polling immediately
+                  close();
                 }
-                unsubNotif = boardSnapshot.subscribe((snap) => {
-                  // Fire-and-forget projection: a rejected chain here would become
-                  // an unhandled rejection (and stall bun:test), so swallow it.
-                  void toProjectorBoard(snap)
-                    .then((pb) => emitNotifications(controller, pb))
-                    .catch((err) => {
-                      console.error(`[server] notifications stream projection failed:`, err);
-                    });
-                });
-                try {
-                  emitNotifications(
-                    controller,
-                    await toProjectorBoard(await boardSnapshot.getLatest()),
-                  );
-                } catch (err) {
-                  console.error(`[server] notifications stream initial emit failed:`, err);
-                }
-              },
-              cancel() {
-                closedNotif = true;
+              };
+              emit("open", { shortId: screenShortId });
+              if (first.kind === "frame") {
+                emit("screen", { screen: first.screen, ts: Date.now() });
+              }
+              // Backpressure: skip the tick while a poll is in flight (a slow
+              // `claude logs` never queues a pile-up — intermediate frames are
+              // simply never produced; the next completed poll diffs against
+              // the latest screen).
+              const pump = () => {
+                if (inFlight || closed) return;
+                inFlight = true;
+                void (async () => {
+                  try {
+                    const res = await poller.poll();
+                    if (closed) return;
+                    if (res.kind === "frame") {
+                      emit("screen", { screen: res.screen, ts: Date.now() });
+                    } else if (res.kind === "gone") {
+                      emit("gone", { reason: res.reason });
+                      close();
+                    } else if (res.kind === "unavailable") {
+                      emit("unavailable", { reason: res.reason });
+                      close();
+                    }
+                    // "unchanged" → nothing on the wire (change-driven); the
+                    // client derives the frozen-screen age from its own clock.
+                  } catch {
+                    close();
+                  } finally {
+                    inFlight = false;
+                  }
+                })();
+              };
+              timer = setInterval(pump, screenPollMs);
+              // Interval cleanup on client abort — Bun fires req.signal when
+              // the EventSource disconnects, in addition to stream cancel().
+              // CTL-967 SIDE-AC: guard against req.signal already being aborted
+              // at registration time (race between stream setup and client
+              // disconnect) — call close() immediately rather than leaking the
+              // interval.
+              if (req.signal.aborted) {
+                close();
+              } else {
+                req.signal.addEventListener("abort", close);
+              }
+            },
+            cancel() {
+              closed = true;
+              if (timer) clearInterval(timer);
+              timer = null;
+            },
+          });
+          return new Response(stream, {
+            headers: {
+              "Content-Type": "text/event-stream",
+              "Cache-Control": "no-cache",
+              Connection: "keep-alive",
+              "Access-Control-Allow-Origin": "*",
+            },
+          });
+        }
+
+        if (url.pathname === "/api/board") {
+          return Response.json(decorateBoard(await boardSnapshot.getLatest()));
+        }
+
+        // CTL-733: SSE push of the shared board snapshot. The client (Board.tsx /
+        // the board SharedWorker) opens ONE of these and receives a `board` event
+        // on connect and on every reactive recompute — no per-tab polling.
+        if (url.pathname === "/api/board/stream") {
+          let unsubscribe: (() => void) | null = null;
+          let closed = false;
+          const send = (
+            controller: ReadableStreamDefaultController<Uint8Array>,
+            snap: BoardPayload,
+          ) => {
+            if (closed) return;
+            try {
+              controller.enqueue(
+                encoder.encode(
+                  `event: board\ndata: ${JSON.stringify(decorateBoard(snap))}\n\n`,
+                ),
+              );
+            } catch {
+              // client went away between recompute and enqueue
+              unsubscribe?.();
+              unsubscribe = null;
+            }
+          };
+          const stream = new ReadableStream<Uint8Array>({
+            async start(controller) {
+              // subscribe first so no recompute is missed between bootstrap + subscribe
+              unsubscribe = boardSnapshot.subscribe((snap) => send(controller, snap));
+              try {
+                send(controller, await boardSnapshot.getLatest());
+              } catch (err) {
+                console.error(`[server] board stream initial snapshot failed:`, err);
+              }
+            },
+            cancel() {
+              closed = true;
+              unsubscribe?.();
+              unsubscribe = null;
+            },
+          });
+          return new Response(stream, {
+            headers: {
+              "Content-Type": "text/event-stream",
+              "Cache-Control": "no-cache",
+              Connection: "keep-alive",
+              "Access-Control-Allow-Origin": "*",
+            },
+          });
+        }
+
+        // CTL-896 (SHELL6): the nav-signal projection — worker count, queue depth,
+        // board anomaly, and the daemon-health dot — as a single one-shot read for
+        // the warm paint + the SSE reconcile. Derived off the SAME shared board
+        // snapshot the board endpoints serve plus the local daemon health; NEVER a
+        // synchronous per-request scan of the source signal files.
+        if (url.pathname === "/api/nav") {
+          return Response.json(
+            await assembleNavSignal(await boardSnapshot.getLatest()),
+          );
+        }
+
+        // CTL-896 (SHELL6): SSE push of the nav signal. The rail opens ONE of these
+        // and receives a `nav` event on connect and on every reactive board
+        // recompute — the live badges update without a page reload and WITHOUT
+        // per-tab polling of the source files (Gherkin: "Live without thrash").
+        if (url.pathname === "/api/nav/stream") {
+          let unsubscribe: (() => void) | null = null;
+          let closed = false;
+          const sendNav = (
+            controller: ReadableStreamDefaultController<Uint8Array>,
+            signal: NavSignal,
+          ) => {
+            if (closed) return;
+            try {
+              controller.enqueue(
+                encoder.encode(`event: nav\ndata: ${JSON.stringify(signal)}\n\n`),
+              );
+            } catch {
+              unsubscribe?.();
+              unsubscribe = null;
+            }
+          };
+          const stream = new ReadableStream<Uint8Array>({
+            async start(controller) {
+              // subscribe first so no recompute is missed between bootstrap +
+              // subscribe; each board frame is projected into a nav signal (the
+              // daemon health is re-read per frame so the dot tracks heartbeats).
+              unsubscribe = boardSnapshot.subscribe((snap) => {
+                void assembleNavSignal(snap).then((signal) =>
+                  sendNav(controller, signal),
+                );
+              });
+              try {
+                sendNav(
+                  controller,
+                  await assembleNavSignal(await boardSnapshot.getLatest()),
+                );
+              } catch (err) {
+                console.error(`[server] nav stream initial signal failed:`, err);
+              }
+            },
+            cancel() {
+              closed = true;
+              unsubscribe?.();
+              unsubscribe = null;
+            },
+          });
+          return new Response(stream, {
+            headers: {
+              "Content-Type": "text/event-stream",
+              "Cache-Control": "no-cache",
+              Connection: "keep-alive",
+              "Access-Control-Allow-Origin": "*",
+            },
+          });
+        }
+
+        // CTL-898 (SHELL8): the per-node cluster-health signal — one {host,status}
+        // per running node + the single-host flag — as a one-shot read for the
+        // footer's warm paint + the SSE reconcile. Projected off the SAME shared
+        // board snapshot the board/nav endpoints serve plus the cluster view's
+        // owner_host grouping + heartbeat liveness; NEVER a per-request scan.
+        // Single-host is the exact identity no-op (one node, the local daemon).
+        if (url.pathname === "/api/cluster") {
+          return Response.json(
+            await assembleClusterSignal(await boardSnapshot.getLatest()),
+          );
+        }
+
+        // CTL-1092 (Phase 5): per-node capacity change history from the event log.
+        // Read-only; no writes. Scans the current-month JSONL for capacity events.
+        if (url.pathname === "/api/capacity-history") {
+          const month = new Date().toISOString().slice(0, 7); // YYYY-MM
+          const capLogPath = join(CATALYST_DIR, "events", `${month}.jsonl`);
+          const data = readCapacityHistory({ logPath: capLogPath });
+          return Response.json({ data });
+        }
+
+        // CTL-898 (SHELL8): SSE push of the cluster signal. The footer opens ONE
+        // of these and receives a `cluster` event on connect and on every reactive
+        // board recompute — a node going dark past its grace window flips its dot
+        // to offline WITHOUT a page reload and WITHOUT per-tab polling of the
+        // source files (Gherkin: "A node going dark is reflected").
+        if (url.pathname === "/api/cluster/stream") {
+          let unsubscribe: (() => void) | null = null;
+          let closed = false;
+          const sendCluster = (
+            controller: ReadableStreamDefaultController<Uint8Array>,
+            signal: ClusterSignal,
+          ) => {
+            if (closed) return;
+            try {
+              controller.enqueue(
+                encoder.encode(
+                  `event: cluster\ndata: ${JSON.stringify(signal)}\n\n`,
+                ),
+              );
+            } catch {
+              unsubscribe?.();
+              unsubscribe = null;
+            }
+          };
+          const stream = new ReadableStream<Uint8Array>({
+            async start(controller) {
+              // subscribe first so no recompute is missed between bootstrap +
+              // subscribe; each board frame is projected into a cluster signal
+              // (the heartbeat liveness is re-classified per frame so a node going
+              // dark surfaces without a reload).
+              unsubscribe = boardSnapshot.subscribe((snap) => {
+                void assembleClusterSignal(snap).then((signal) =>
+                  sendCluster(controller, signal),
+                );
+              });
+              try {
+                sendCluster(
+                  controller,
+                  await assembleClusterSignal(await boardSnapshot.getLatest()),
+                );
+              } catch (err) {
+                console.error(
+                  `[server] cluster stream initial signal failed:`,
+                  err,
+                );
+              }
+            },
+            cancel() {
+              closed = true;
+              unsubscribe?.();
+              unsubscribe = null;
+            },
+          });
+          return new Response(stream, {
+            headers: {
+              "Content-Type": "text/event-stream",
+              "Cache-Control": "no-cache",
+              Connection: "keep-alive",
+              "Access-Control-Allow-Origin": "*",
+            },
+          });
+        }
+
+        // CTL-1167: serve the VAPID public key so the browser can build the
+        // applicationServerKey for pushManager.subscribe(). 503 when push was
+        // never initialized for this server instance (push not configured).
+        if (url.pathname === "/api/notifications/vapid-public-key") {
+          if (!vapidKeys) {
+            return new Response("push not configured", { status: 503 });
+          }
+          return new Response(vapidKeys.publicKey, {
+            headers: { "Content-Type": "text/plain" },
+          });
+        }
+
+        // CTL-1167: persist a browser push subscription (POST body is the
+        // serialised PushSubscription JSON from the browser). Returns 201 on
+        // success; 400 on missing/invalid fields.
+        if (url.pathname === "/api/notifications/subscribe" && req.method === "POST") {
+          if (!vapidKeys) {
+            return new Response("push not configured", { status: 503 });
+          }
+          let body: unknown;
+          try {
+            body = await req.json();
+          } catch {
+            return new Response("invalid JSON", { status: 400 });
+          }
+          const sub = body as Record<string, unknown>;
+          const keys = sub?.keys as Record<string, unknown> | undefined;
+          if (
+            typeof sub?.endpoint !== "string" ||
+            !sub.endpoint ||
+            typeof keys?.p256dh !== "string" ||
+            !keys.p256dh ||
+            typeof keys?.auth !== "string" ||
+            !keys.auth
+          ) {
+            return new Response("missing endpoint, keys.p256dh or keys.auth", {
+              status: 400,
+            });
+          }
+          pushStore.upsertSubscription({
+            endpoint: sub.endpoint,
+            keys: { p256dh: keys.p256dh, auth: keys.auth },
+          });
+          return new Response(null, { status: 201 });
+        }
+
+        // CTL-1167: SSE stream of novel push-worthy notifications. Mirrors
+        // /api/nav/stream: one per-connection projector, subscribe-first, emit on
+        // every board recompute that yields new notifications. Each event:
+        //   event: notification\ndata: {title,body,deepLink}\n\n
+        if (url.pathname === "/api/notifications/stream") {
+          let unsubNotif: (() => void) | null = null;
+          let closedNotif = false;
+          const notifProjector = createNotificationProjector({
+            daemonNotifyHoldMs,
+          });
+          const emitNotifications = (
+            controller: ReadableStreamDefaultController<Uint8Array>,
+            pb: ProjectorBoard,
+          ) => {
+            if (closedNotif) return;
+            for (const n of notifProjector.project(pb)) {
+              try {
+                controller.enqueue(
+                  encoder.encode(
+                    `event: notification\ndata: ${JSON.stringify(n)}\n\n`,
+                  ),
+                );
+              } catch {
                 unsubNotif?.();
                 unsubNotif = null;
-              },
-            });
-            return new Response(notifStream, {
-              headers: {
-                "Content-Type": "text/event-stream",
-                "Cache-Control": "no-cache",
-                Connection: "keep-alive",
-                "Access-Control-Allow-Origin": "*",
-              },
-            });
+              }
+            }
+          };
+          const notifStream = new ReadableStream<Uint8Array>({
+            async start(controller) {
+              // Emit an immediate `open` frame so the connection is live even
+              // when the fleet yields no notifications. Without a first chunk,
+              // Bun does not resolve fetch()'s response headers (the client —
+              // and the route tests — would hang). Mirrors /api/beliefs/stream.
+              try {
+                controller.enqueue(
+                  encoder.encode(
+                    `event: open\ndata: ${JSON.stringify({ source: "notifications" })}\n\n`,
+                  ),
+                );
+              } catch {
+                closedNotif = true;
+                return;
+              }
+              unsubNotif = boardSnapshot.subscribe((snap) => {
+                // Fire-and-forget projection: a rejected chain here would become
+                // an unhandled rejection (and stall bun:test), so swallow it.
+                void toProjectorBoard(snap)
+                  .then((pb) => emitNotifications(controller, pb))
+                  .catch((err) => {
+                    console.error(
+                      `[server] notifications stream projection failed:`,
+                      err,
+                    );
+                  });
+              });
+              try {
+                emitNotifications(
+                  controller,
+                  await toProjectorBoard(await boardSnapshot.getLatest()),
+                );
+              } catch (err) {
+                console.error(`[server] notifications stream initial emit failed:`, err);
+              }
+            },
+            cancel() {
+              closedNotif = true;
+              unsubNotif?.();
+              unsubNotif = null;
+            },
+          });
+          return new Response(notifStream, {
+            headers: {
+              "Content-Type": "text/event-stream",
+              "Cache-Control": "no-cache",
+              Connection: "keep-alive",
+              "Access-Control-Allow-Origin": "*",
+            },
+          });
+        }
+
+        // CTL-967 (N5): read-only SSE feed of new belief rows from
+        // ~/catalyst/beliefs.db, tailed by a BeliefTail cursor. Each SSE
+        // event carries a single belief row (joined with tick.ts_ms/host) in
+        // the FiringFeed shape the Rules Explorer expects. The BeliefTail
+        // module is imported via a COMPUTED specifier so bun:sqlite never
+        // enters the vite/esbuild graph (same guard as linear-cache-reader).
+        // Graceful degradation: if beliefs.db is absent (shadow off), the
+        // endpoint emits only an `open` frame and stays alive — no crash.
+        if (url.pathname === "/api/beliefs/stream") {
+          // COMPUTED specifier — DO NOT inline to a literal (see belief-reader.mjs
+          // header and the CTL-883/vite-config-bun-sqlite trap notes).
+          const beliefReaderModule = [".", "lib", "belief-reader.mjs"].join("/");
+          let tail: {
+            poll(): Promise<unknown[]>;
+            close(): void;
+          } | null = null;
+          try {
+            const mod = await import(beliefReaderModule) as {
+              BeliefTail: new (opts?: { dbPath?: string; pageSize?: number }) => {
+                poll(): Promise<unknown[]>;
+                close(): void;
+              };
+            };
+            tail = new mod.BeliefTail();
+          } catch {
+            // module or bun:sqlite unavailable — degrade to null tail
+            tail = null;
           }
 
-          // CTL-967 (N5): read-only SSE feed of new belief rows from
-          // ~/catalyst/beliefs.db, tailed by a BeliefTail cursor. Each SSE
-          // event carries a single belief row (joined with tick.ts_ms/host) in
-          // the FiringFeed shape the Rules Explorer expects. The BeliefTail
-          // module is imported via a COMPUTED specifier so bun:sqlite never
-          // enters the vite/esbuild graph (same guard as linear-cache-reader).
-          // Graceful degradation: if beliefs.db is absent (shadow off), the
-          // endpoint emits only an `open` frame and stays alive — no crash.
-          if (url.pathname === "/api/beliefs/stream") {
-            // COMPUTED specifier — DO NOT inline to a literal (see belief-reader.mjs
-            // header and the CTL-883/vite-config-bun-sqlite trap notes).
-            const beliefReaderModule = [".", "lib", "belief-reader.mjs"].join("/");
-            let tail: {
-              poll(): Promise<unknown[]>;
-              close(): void;
-            } | null = null;
-            try {
-              const mod = (await import(beliefReaderModule)) as {
-                BeliefTail: new (opts?: { dbPath?: string; pageSize?: number }) => {
-                  poll(): Promise<unknown[]>;
-                  close(): void;
-                };
-              };
-              tail = new mod.BeliefTail();
-            } catch {
-              // module or bun:sqlite unavailable — degrade to null tail
-              tail = null;
-            }
-
-            let timer: ReturnType<typeof setInterval> | null = null;
-            let inFlight = false;
-            let closed = false;
-            const stream = new ReadableStream<Uint8Array>({
-              start(controller) {
-                const close = () => {
-                  if (closed) return;
-                  closed = true;
-                  if (timer) clearInterval(timer);
-                  timer = null;
-                  tail?.close();
-                  tail = null;
-                  try {
-                    controller.close();
-                  } catch {
-                    /* already closed */
-                  }
-                };
-                // Open frame so the client knows the connection is live even
-                // when beliefs.db is absent or the db has no new rows yet.
-                try {
-                  controller.enqueue(
-                    encoder.encode(
-                      `event: open\ndata: ${JSON.stringify({ source: "beliefs" })}\n\n`,
-                    ),
-                  );
-                } catch {
-                  closed = true;
-                  return;
-                }
-                const pump = () => {
-                  if (inFlight || closed || !tail) return;
-                  inFlight = true;
-                  void (async () => {
-                    try {
-                      const rows = await tail.poll();
-                      if (closed) return;
-                      for (const row of rows) {
-                        controller.enqueue(
-                          encoder.encode(`event: belief\ndata: ${JSON.stringify(row)}\n\n`),
-                        );
-                      }
-                    } catch {
-                      // client likely went away mid-enqueue; stop pumping
-                      close();
-                    } finally {
-                      inFlight = false;
-                    }
-                  })();
-                };
-                pump();
-                timer = setInterval(pump, 1000);
-                // Cleanup on client abort. Guard against already-aborted signal
-                // (same pattern as the screen SSE endpoint — CTL-967 SIDE-AC).
-                if (req.signal.aborted) {
-                  close();
-                } else {
-                  req.signal.addEventListener("abort", close);
-                }
-              },
-              cancel() {
+          let timer: ReturnType<typeof setInterval> | null = null;
+          let inFlight = false;
+          let closed = false;
+          const stream = new ReadableStream<Uint8Array>({
+            start(controller) {
+              const close = () => {
+                if (closed) return;
                 closed = true;
                 if (timer) clearInterval(timer);
                 timer = null;
                 tail?.close();
                 tail = null;
-              },
-            });
-            return new Response(stream, {
-              headers: {
-                "Content-Type": "text/event-stream",
-                "Cache-Control": "no-cache",
-                Connection: "keep-alive",
-                "Access-Control-Allow-Origin": "*",
-              },
-            });
-          }
-
-          // ── CTL-1100 governance read endpoints ──────────────────────────────
-          // Inserted between the /api/beliefs/stream block and the 404 fallthrough.
-          // Re-locate by grep after each insertion — line numbers shift.
-
-          // GET /api/cluster/governance — per-host governance snapshot from the
-          // heartbeat event log (CTL-1104). Separate from /api/governance (local
-          // config snapshot, CTL-1100) — see plan §open-question 3. DO NOT inline
-          // the specifier (VITE-GRAPH GUARD, CTL-883).
-          if (url.pathname === "/api/cluster/governance") {
-            const govSpecifier = ["./lib/cluster-governance.mjs"].join("");
-            try {
-              const { readClusterGovernance } = (await import(govSpecifier)) as {
-                readClusterGovernance: () => Record<string, unknown>;
+                try {
+                  controller.close();
+                } catch {
+                  /* already closed */
+                }
               };
-              // CTL-1232: readClusterGovernance() full-reads the current-month log
-              // (no ring, no cache) on every hit — the OBSERVE FleetOps surface
-              // polls this every 15s. Count it so /debug/memory can attribute the
-              // RSS ratchet to this path.
-              const _govT0 = performance.now();
-              const gov = readClusterGovernance();
-              recordFullRead("governance", 0, performance.now() - _govT0);
-              return Response.json(gov);
-            } catch {
-              return Response.json({ singleHost: true, nodes: [], generatedAt: "" });
-            }
-          }
-
-          // GET /api/governance — current daemon governance config snapshot.
-          // DO NOT inline the specifier (computed import, VITE-GRAPH GUARD, CTL-883).
-          if (url.pathname === "/api/governance") {
-            const configSpecifier = ["../execution-core/config.mjs"].join("");
-            try {
-              const { readGovernanceConfig } = (await import(configSpecifier)) as {
-                readGovernanceConfig: (env?: NodeJS.ProcessEnv) => Record<string, unknown>;
-              };
-              return Response.json({ available: true, ...readGovernanceConfig() });
-            } catch {
-              return Response.json({ available: false });
-            }
-          }
-
-          if (url.pathname === "/api/fsm/descriptor") {
-            return Response.json(await buildFsmDescriptor());
-          }
-
-          // GET /api/beliefs/rules — served from frozen RULE_MANIFEST; no db required.
-          if (url.pathname === "/api/beliefs/rules") {
-            const govDeps = await loadGovernanceDeps();
-            const manifest = govDeps?.RULE_MANIFEST ?? null;
-            if (!manifest) return Response.json({ rules: [], strata: [] });
-            return Response.json(manifest);
-          }
-
-          // GET /api/beliefs/summary — latest-tick aggregate per belief name.
-          if (url.pathname === "/api/beliefs/summary") {
-            const dbPath = govDbPath();
-            const govDeps = await loadGovernanceDeps();
-            if (!govDeps) return Response.json({ tickId: null, rows: [] });
-            return Response.json(
-              await govDeps.withBeliefsDbRO(dbPath, (db) => beliefSummary(db), {
-                tickId: null,
-                rows: [],
-              }),
-            );
-          }
-
-          // GET /api/beliefs/rates — full belief counts per rule_id per tick (LRU cached).
-          if (url.pathname === "/api/beliefs/rates") {
-            const dbPath = govDbPath();
-            const govDeps = await loadGovernanceDeps();
-            if (!govDeps) return Response.json({ maxTick: null, rows: [] });
-            return Response.json(
-              await govDeps.withBeliefsDbRO(dbPath, (db) => beliefRates(db, beliefRatesCache), {
-                maxTick: null,
-                rows: [],
-              }),
-            );
-          }
-
-          // GET /api/beliefs/recent — newest-first belief rows, limit param.
-          if (url.pathname === "/api/beliefs/recent") {
-            const dbPath = govDbPath();
-            const govDeps = await loadGovernanceDeps();
-            if (!govDeps) return Response.json({ rows: [] });
-            const limitParam = url.searchParams.get("limit");
-            const limit = limitParam ? Math.max(1, parseInt(limitParam, 10) || 50) : undefined;
-            return Response.json(
-              await govDeps.withBeliefsDbRO(dbPath, (db) => beliefRecent(db, { limit }), {
-                rows: [],
-              }),
-            );
-          }
-
-          // GET /api/beliefs/cfg — static config rows from the beliefs store.
-          if (url.pathname === "/api/beliefs/cfg") {
-            const dbPath = govDbPath();
-            const govDeps = await loadGovernanceDeps();
-            if (!govDeps) return Response.json({ rows: [] });
-            return Response.json(
-              await govDeps.withBeliefsDbRO(dbPath, (db) => beliefCfg(db), { rows: [] }),
-            );
-          }
-
-          // GET /api/beliefs/why?ticket=<ticket>[&tick=<tickId>]
-          // HTTP wrapper over traceTicket() — same resolver as `catalyst why`.
-          // Input validation (ticket required, /^[A-Za-z]+-\d+$/, tick must be
-          // integer) happens BEFORE any db touch so traversal attempts are
-          // rejected before reaching the db. Degrades to 200+empty trace when
-          // beliefs.db absent or unreadable (no 500).
-          // NOTE: DO NOT inline the specifier — computed import required (CTL-883).
-          if (url.pathname === "/api/beliefs/why") {
-            const rawTicket = url.searchParams.get("ticket");
-            if (!rawTicket) return new Response("ticket required", { status: 400 });
-            let ticket: string;
-            try {
-              ticket = decodeURIComponent(rawTicket);
-            } catch {
-              return new Response("invalid ticket encoding", { status: 400 });
-            }
-            if (!/^[A-Za-z]+-\d+$/.test(ticket)) {
-              return new Response("invalid ticket format", { status: 400 });
-            }
-            const rawTick = url.searchParams.get("tick");
-            let tickId: number | undefined;
-            if (rawTick != null) {
-              const parsed = parseInt(rawTick, 10);
-              if (!Number.isInteger(parsed) || String(parsed) !== rawTick.trim()) {
-                return new Response("tick must be an integer", { status: 400 });
+              // Open frame so the client knows the connection is live even
+              // when beliefs.db is absent or the db has no new rows yet.
+              try {
+                controller.enqueue(
+                  encoder.encode(`event: open\ndata: ${JSON.stringify({ source: "beliefs" })}\n\n`),
+                );
+              } catch {
+                closed = true;
+                return;
               }
-              tickId = parsed;
-            }
-            // DO NOT inline this specifier (VITE-GRAPH GUARD, CTL-883).
-            const whyMod = ["./lib/belief-why.mjs"].join("");
-            try {
-              const { traceTicketJson } = (await import(whyMod)) as {
-                traceTicketJson: (opts: {
-                  ticket: string;
-                  tickId?: number;
-                  dbPath: string;
-                }) => Promise<unknown>;
+              const pump = () => {
+                if (inFlight || closed || !tail) return;
+                inFlight = true;
+                void (async () => {
+                  try {
+                    const rows = await tail.poll();
+                    if (closed) return;
+                    for (const row of rows) {
+                      controller.enqueue(
+                        encoder.encode(
+                          `event: belief\ndata: ${JSON.stringify(row)}\n\n`,
+                        ),
+                      );
+                    }
+                  } catch {
+                    // client likely went away mid-enqueue; stop pumping
+                    close();
+                  } finally {
+                    inFlight = false;
+                  }
+                })();
               };
-              const trace = await traceTicketJson({ ticket, tickId, dbPath: govDbPath() });
-              return Response.json(trace);
-            } catch {
-              return Response.json({ ticket, tickId: null, beliefs: [] });
-            }
-          }
-
-          // CTL-935 Phase 5: GET /api/beliefs/report — weekly shadow disagreement report.
-          // ?sinceDays=7 (default 7, clamped to [1,90]). Degrades gracefully when
-          // beliefs.db is absent. DO NOT inline the specifier (VITE-GRAPH GUARD, CTL-883).
-          if (url.pathname === "/api/beliefs/report") {
-            const rawDays = url.searchParams.get("sinceDays");
-            let sinceDays = 7;
-            if (rawDays != null) {
-              const parsed = Number(rawDays);
-              if (!Number.isFinite(parsed) || parsed <= 0 || !Number.isInteger(parsed)) {
-                return new Response("sinceDays must be a positive integer", { status: 400 });
+              pump();
+              timer = setInterval(pump, 1000);
+              // Cleanup on client abort. Guard against already-aborted signal
+              // (same pattern as the screen SSE endpoint — CTL-967 SIDE-AC).
+              if (req.signal.aborted) {
+                close();
+              } else {
+                req.signal.addEventListener("abort", close);
               }
-              sinceDays = Math.min(Math.max(parsed, 1), 90);
-            }
-            const nowMs = Date.now();
-            const sinceMs = nowMs - sinceDays * 86_400_000;
-            const reportMod = ["./lib/belief-report.mjs"].join("");
-            try {
-              const { computeReportJson } = (await import(reportMod)) as {
-                computeReportJson: (opts: {
-                  dbPath: string;
-                  sinceMs: number;
-                  nowMs: number;
-                }) => Promise<unknown>;
-              };
-              const report = await computeReportJson({ dbPath: govDbPath(), sinceMs, nowMs });
-              return Response.json(report);
-            } catch (err) {
-              // CTL-935 remediate: tag the error-path payload as degraded so the
-              // flag-live helper / operator can tell a broken report (failed
-              // import, corrupt/locked db) from a legitimately quiet week. The
-              // shape stays well-formed (200) so existing consumers don't break.
-              return Response.json({
-                window: { sinceMs, nowMs, tickCount: 0, rulesShaSet: [], multipleRulesSha: false },
-                perRule: [],
-                perGuard: [],
-                replays: [],
-                degraded: true,
-                degradedReason: err instanceof Error ? err.message : String(err),
-              });
-            }
-          }
-
-          // CTL-1232 (profiling): GET /debug/memory[?gc=1] — live memory breakdown.
-          // process.memoryUsage() (MB) + event-ring stats + cache sizes + the
-          // full-log readFileSync fallback counters (fullReadMetrics). With ?gc=1
-          // it forces a synchronous Bun.gc(true) and reports the freed deltas, to
-          // distinguish reclaimable JS-heap garbage from RSS-not-returned-to-the-OS
-          // (the sticky high-water from repeated large transient reads).
-          if (url.pathname === "/debug/memory") {
-            const toMB = (b: number): number => Math.round((b / 1048576) * 10) / 10;
-            const usageMB = (
-              u: ReturnType<typeof process.memoryUsage>,
-            ): Record<string, number> => ({
-              rss: toMB(u.rss),
-              heapTotal: toMB(u.heapTotal),
-              heapUsed: toMB(u.heapUsed),
-              external: toMB(u.external),
-              arrayBuffers: toMB(u.arrayBuffers),
-            });
-            const before = process.memoryUsage();
-            let afterGcMB: Record<string, number> | null = null;
-            let freedMB: Record<string, number> | null = null;
-            if (url.searchParams.get("gc") === "1") {
-              Bun.gc(true);
-              const after = process.memoryUsage();
-              afterGcMB = usageMB(after);
-              freedMB = {
-                rss: toMB(before.rss - after.rss),
-                heapTotal: toMB(before.heapTotal - after.heapTotal),
-                heapUsed: toMB(before.heapUsed - after.heapUsed),
-                external: toMB(before.external - after.external),
-                arrayBuffers: toMB(before.arrayBuffers - after.arrayBuffers),
-              };
-            }
-            const oldest = eventRing.oldestTs();
-            const spanHours =
-              oldest !== null
-                ? Math.round(((Date.now() - Date.parse(oldest)) / 3_600_000) * 100) / 100
-                : null;
-            return Response.json({
-              pid: process.pid,
-              uptimeSec: Math.round(process.uptime()),
-              memoryMB: usageMB(before),
-              ...(afterGcMB && freedMB ? { afterGcMB, freedMB } : {}),
-              ring: {
-                lineCount: eventRing.size(),
-                byteSizeMB: toMB(eventRing.byteSize()),
-                capacity: eventRing.capacity(),
-                oldestTs: oldest,
-                spanHours,
-                listenerCount: eventRing.listenerCount(),
-              },
-              caches: {
-                sseClients: sseClients.size,
-                transcriptPathCache: _getTranscriptCacheSize(),
-              },
-              fullReads: fullReadMetrics,
-            });
-          }
-
-          // CTL-1232 (profiling): GET /debug/heap-snapshot — write a Bun v8 heap
-          // snapshot (loadable in Chrome DevTools → Memory → Load profile) under
-          // ~/catalyst/heap-snapshots/. Heavy + blocking, so localhost-only (curl
-          // from the host) unless CATALYST_DEBUG_TOKEN is set and matched via
-          // ?token=. A small snapshot beside a large RSS confirms off-heap/native
-          // bloat rather than a JS-heap leak.
-          if (url.pathname === "/debug/heap-snapshot") {
-            const token = url.searchParams.get("token");
-            const required = process.env.CATALYST_DEBUG_TOKEN;
-            const ip = server.requestIP(req)?.address ?? "";
-            const isLocal = ip === "127.0.0.1" || ip === "::1" || ip === "::ffff:127.0.0.1";
-            const allowed = required ? token === required : isLocal;
-            if (!allowed) {
-              return new Response(
-                "forbidden (localhost only, or pass ?token=$CATALYST_DEBUG_TOKEN)",
-                { status: 403 },
-              );
-            }
-            const dir = join(CATALYST_DIR, "heap-snapshots");
-            mkdirSync(dir, { recursive: true });
-            const stamp = new Date().toISOString().replace(/[:.]/g, "-");
-            const snapPath = join(dir, `monitor-${process.pid}-${stamp}.heapsnapshot`);
-            const rssBeforeMB = Math.round(process.memoryUsage().rss / 1048576);
-            const snap = Bun.generateHeapSnapshot("v8", "arraybuffer");
-            const bytes = await Bun.write(snapPath, snap);
-            return Response.json({
-              path: snapPath,
-              snapshotBytes: bytes,
-              snapshotMB: Math.round((bytes / 1048576) * 10) / 10,
-              rssBeforeMB,
-              note: "load in Chrome DevTools → Memory → Load profile; small snapshot vs large RSS ⇒ off-heap/native bloat",
-            });
-          }
-
-          return new Response("Not Found", { status: 404 });
-        } catch (err) {
-          console.error(`[server] fetch handler error:`, err);
-          return new Response("Internal Server Error", { status: 500 });
+            },
+            cancel() {
+              closed = true;
+              if (timer) clearInterval(timer);
+              timer = null;
+              tail?.close();
+              tail = null;
+            },
+          });
+          return new Response(stream, {
+            headers: {
+              "Content-Type": "text/event-stream",
+              "Cache-Control": "no-cache",
+              Connection: "keep-alive",
+              "Access-Control-Allow-Origin": "*",
+            },
+          });
         }
+
+        // ── CTL-1100 governance read endpoints ──────────────────────────────
+        // Inserted between the /api/beliefs/stream block and the 404 fallthrough.
+        // Re-locate by grep after each insertion — line numbers shift.
+
+        // GET /api/cluster/governance — per-host governance snapshot from the
+        // heartbeat event log (CTL-1104). Separate from /api/governance (local
+        // config snapshot, CTL-1100) — see plan §open-question 3. DO NOT inline
+        // the specifier (VITE-GRAPH GUARD, CTL-883).
+        if (url.pathname === "/api/cluster/governance") {
+          const govSpecifier = ["./lib/cluster-governance.mjs"].join("");
+          try {
+            const { readClusterGovernance } = await import(govSpecifier) as {
+              readClusterGovernance: () => Record<string, unknown>;
+            };
+            // CTL-1232: readClusterGovernance() full-reads the current-month log
+            // (no ring, no cache) on every hit — the OBSERVE FleetOps surface
+            // polls this every 15s. Count it so /debug/memory can attribute the
+            // RSS ratchet to this path.
+            const _govT0 = performance.now();
+            const gov = readClusterGovernance();
+            recordFullRead("governance", 0, performance.now() - _govT0);
+            return Response.json(gov);
+          } catch {
+            return Response.json({ singleHost: true, nodes: [], generatedAt: "" });
+          }
+        }
+
+        // GET /api/governance — current daemon governance config snapshot.
+        // DO NOT inline the specifier (computed import, VITE-GRAPH GUARD, CTL-883).
+        if (url.pathname === "/api/governance") {
+          const configSpecifier = ["../execution-core/config.mjs"].join("");
+          try {
+            const { readGovernanceConfig } = await import(configSpecifier) as {
+              readGovernanceConfig: (env?: NodeJS.ProcessEnv) => Record<string, unknown>;
+            };
+            return Response.json({ available: true, ...readGovernanceConfig() });
+          } catch {
+            return Response.json({ available: false });
+          }
+        }
+
+        if (url.pathname === "/api/fsm/descriptor") {
+          return Response.json(await buildFsmDescriptor());
+        }
+
+        // GET /api/beliefs/rules — served from frozen RULE_MANIFEST; no db required.
+        if (url.pathname === "/api/beliefs/rules") {
+          const govDeps = await loadGovernanceDeps();
+          const manifest = govDeps?.RULE_MANIFEST ?? null;
+          if (!manifest) return Response.json({ rules: [], strata: [] });
+          return Response.json(manifest);
+        }
+
+        // GET /api/beliefs/summary — latest-tick aggregate per belief name.
+        if (url.pathname === "/api/beliefs/summary") {
+          const dbPath = govDbPath();
+          const govDeps = await loadGovernanceDeps();
+          if (!govDeps) return Response.json({ tickId: null, rows: [] });
+          return Response.json(
+            await govDeps.withBeliefsDbRO(dbPath, (db) => beliefSummary(db), { tickId: null, rows: [] })
+          );
+        }
+
+        // GET /api/beliefs/rates — full belief counts per rule_id per tick (LRU cached).
+        if (url.pathname === "/api/beliefs/rates") {
+          const dbPath = govDbPath();
+          const govDeps = await loadGovernanceDeps();
+          if (!govDeps) return Response.json({ maxTick: null, rows: [] });
+          return Response.json(
+            await govDeps.withBeliefsDbRO(dbPath, (db) => beliefRates(db, beliefRatesCache), { maxTick: null, rows: [] })
+          );
+        }
+
+        // GET /api/beliefs/recent — newest-first belief rows, limit param.
+        if (url.pathname === "/api/beliefs/recent") {
+          const dbPath = govDbPath();
+          const govDeps = await loadGovernanceDeps();
+          if (!govDeps) return Response.json({ rows: [] });
+          const limitParam = url.searchParams.get("limit");
+          const limit = limitParam ? Math.max(1, parseInt(limitParam, 10) || 50) : undefined;
+          return Response.json(
+            await govDeps.withBeliefsDbRO(dbPath, (db) => beliefRecent(db, { limit }), { rows: [] })
+          );
+        }
+
+        // GET /api/beliefs/cfg — static config rows from the beliefs store.
+        if (url.pathname === "/api/beliefs/cfg") {
+          const dbPath = govDbPath();
+          const govDeps = await loadGovernanceDeps();
+          if (!govDeps) return Response.json({ rows: [] });
+          return Response.json(
+            await govDeps.withBeliefsDbRO(dbPath, (db) => beliefCfg(db), { rows: [] })
+          );
+        }
+
+        // GET /api/beliefs/why?ticket=<ticket>[&tick=<tickId>]
+        // HTTP wrapper over traceTicket() — same resolver as `catalyst why`.
+        // Input validation (ticket required, /^[A-Za-z]+-\d+$/, tick must be
+        // integer) happens BEFORE any db touch so traversal attempts are
+        // rejected before reaching the db. Degrades to 200+empty trace when
+        // beliefs.db absent or unreadable (no 500).
+        // NOTE: DO NOT inline the specifier — computed import required (CTL-883).
+        if (url.pathname === "/api/beliefs/why") {
+          const rawTicket = url.searchParams.get("ticket");
+          if (!rawTicket) return new Response("ticket required", { status: 400 });
+          let ticket: string;
+          try {
+            ticket = decodeURIComponent(rawTicket);
+          } catch {
+            return new Response("invalid ticket encoding", { status: 400 });
+          }
+          if (!/^[A-Za-z]+-\d+$/.test(ticket)) {
+            return new Response("invalid ticket format", { status: 400 });
+          }
+          const rawTick = url.searchParams.get("tick");
+          let tickId: number | undefined;
+          if (rawTick != null) {
+            const parsed = parseInt(rawTick, 10);
+            if (!Number.isInteger(parsed) || String(parsed) !== rawTick.trim()) {
+              return new Response("tick must be an integer", { status: 400 });
+            }
+            tickId = parsed;
+          }
+          // DO NOT inline this specifier (VITE-GRAPH GUARD, CTL-883).
+          const whyMod = ["./lib/belief-why.mjs"].join("");
+          try {
+            const { traceTicketJson } = await import(whyMod) as {
+              traceTicketJson: (opts: { ticket: string; tickId?: number; dbPath: string }) => Promise<unknown>;
+            };
+            const trace = await traceTicketJson({ ticket, tickId, dbPath: govDbPath() });
+            return Response.json(trace);
+          } catch {
+            return Response.json({ ticket, tickId: null, beliefs: [] });
+          }
+        }
+
+        // CTL-935 Phase 5: GET /api/beliefs/report — weekly shadow disagreement report.
+        // ?sinceDays=7 (default 7, clamped to [1,90]). Degrades gracefully when
+        // beliefs.db is absent. DO NOT inline the specifier (VITE-GRAPH GUARD, CTL-883).
+        if (url.pathname === "/api/beliefs/report") {
+          const rawDays = url.searchParams.get("sinceDays");
+          let sinceDays = 7;
+          if (rawDays != null) {
+            const parsed = Number(rawDays);
+            if (!Number.isFinite(parsed) || parsed <= 0 || !Number.isInteger(parsed)) {
+              return new Response("sinceDays must be a positive integer", { status: 400 });
+            }
+            sinceDays = Math.min(Math.max(parsed, 1), 90);
+          }
+          const nowMs = Date.now();
+          const sinceMs = nowMs - sinceDays * 86_400_000;
+          const reportMod = ["./lib/belief-report.mjs"].join("");
+          try {
+            const { computeReportJson } = await import(reportMod) as {
+              computeReportJson: (opts: { dbPath: string; sinceMs: number; nowMs: number }) => Promise<unknown>;
+            };
+            const report = await computeReportJson({ dbPath: govDbPath(), sinceMs, nowMs });
+            return Response.json(report);
+          } catch (err) {
+            // CTL-935 remediate: tag the error-path payload as degraded so the
+            // flag-live helper / operator can tell a broken report (failed
+            // import, corrupt/locked db) from a legitimately quiet week. The
+            // shape stays well-formed (200) so existing consumers don't break.
+            return Response.json({
+              window: { sinceMs, nowMs, tickCount: 0, rulesShaSet: [], multipleRulesSha: false },
+              perRule: [], perGuard: [], replays: [],
+              degraded: true,
+              degradedReason: err instanceof Error ? err.message : String(err),
+            });
+          }
+        }
+
+        // CTL-1232 (profiling): GET /debug/memory[?gc=1] — live memory breakdown.
+        // process.memoryUsage() (MB) + event-ring stats + cache sizes + the
+        // full-log readFileSync fallback counters (fullReadMetrics). With ?gc=1
+        // it forces a synchronous Bun.gc(true) and reports the freed deltas, to
+        // distinguish reclaimable JS-heap garbage from RSS-not-returned-to-the-OS
+        // (the sticky high-water from repeated large transient reads).
+        if (url.pathname === "/debug/memory") {
+          const toMB = (b: number): number => Math.round((b / 1048576) * 10) / 10;
+          const usageMB = (
+            u: ReturnType<typeof process.memoryUsage>,
+          ): Record<string, number> => ({
+            rss: toMB(u.rss),
+            heapTotal: toMB(u.heapTotal),
+            heapUsed: toMB(u.heapUsed),
+            external: toMB(u.external),
+            arrayBuffers: toMB(u.arrayBuffers),
+          });
+          const before = process.memoryUsage();
+          let afterGcMB: Record<string, number> | null = null;
+          let freedMB: Record<string, number> | null = null;
+          if (url.searchParams.get("gc") === "1") {
+            Bun.gc(true);
+            const after = process.memoryUsage();
+            afterGcMB = usageMB(after);
+            freedMB = {
+              rss: toMB(before.rss - after.rss),
+              heapTotal: toMB(before.heapTotal - after.heapTotal),
+              heapUsed: toMB(before.heapUsed - after.heapUsed),
+              external: toMB(before.external - after.external),
+              arrayBuffers: toMB(before.arrayBuffers - after.arrayBuffers),
+            };
+          }
+          const oldest = eventRing.oldestTs();
+          const spanHours =
+            oldest !== null
+              ? Math.round(((Date.now() - Date.parse(oldest)) / 3_600_000) * 100) / 100
+              : null;
+          return Response.json({
+            pid: process.pid,
+            uptimeSec: Math.round(process.uptime()),
+            memoryMB: usageMB(before),
+            ...(afterGcMB && freedMB ? { afterGcMB, freedMB } : {}),
+            ring: {
+              lineCount: eventRing.size(),
+              byteSizeMB: toMB(eventRing.byteSize()),
+              capacity: eventRing.capacity(),
+              oldestTs: oldest,
+              spanHours,
+              listenerCount: eventRing.listenerCount(),
+            },
+            caches: {
+              sseClients: sseClients.size,
+              transcriptPathCache: _getTranscriptCacheSize(),
+            },
+            fullReads: fullReadMetrics,
+          });
+        }
+
+        // CTL-1232 (profiling): GET /debug/heap-snapshot — write a Bun v8 heap
+        // snapshot (loadable in Chrome DevTools → Memory → Load profile) under
+        // ~/catalyst/heap-snapshots/. Heavy + blocking, so localhost-only (curl
+        // from the host) unless CATALYST_DEBUG_TOKEN is set and matched via
+        // ?token=. A small snapshot beside a large RSS confirms off-heap/native
+        // bloat rather than a JS-heap leak.
+        if (url.pathname === "/debug/heap-snapshot") {
+          const token = url.searchParams.get("token");
+          const required = process.env.CATALYST_DEBUG_TOKEN;
+          const ip = server.requestIP(req)?.address ?? "";
+          const isLocal =
+            ip === "127.0.0.1" || ip === "::1" || ip === "::ffff:127.0.0.1";
+          const allowed = required ? token === required : isLocal;
+          if (!allowed) {
+            return new Response(
+              "forbidden (localhost only, or pass ?token=$CATALYST_DEBUG_TOKEN)",
+              { status: 403 },
+            );
+          }
+          const dir = join(CATALYST_DIR, "heap-snapshots");
+          mkdirSync(dir, { recursive: true });
+          const stamp = new Date().toISOString().replace(/[:.]/g, "-");
+          const snapPath = join(dir, `monitor-${process.pid}-${stamp}.heapsnapshot`);
+          const rssBeforeMB = Math.round(process.memoryUsage().rss / 1048576);
+          const snap = Bun.generateHeapSnapshot("v8", "arraybuffer");
+          const bytes = await Bun.write(snapPath, snap);
+          return Response.json({
+            path: snapPath,
+            snapshotBytes: bytes,
+            snapshotMB: Math.round((bytes / 1048576) * 10) / 10,
+            rssBeforeMB,
+            note: "load in Chrome DevTools → Memory → Load profile; small snapshot vs large RSS ⇒ off-heap/native bloat",
+          });
+        }
+
+        return new Response("Not Found", { status: 404 });
+      } catch (err) {
+        console.error(`[server] fetch handler error:`, err);
+        return new Response("Internal Server Error", { status: 500 });
+      }
       };
       const res = await _doFetch();
       // CTL-1330: emit one structured line for a slow request — where a monitor
@@ -5417,7 +5547,8 @@ export function createServer(opts: CreateServerOptions): BunServer {
   // in the live fleet declares a deployment mode yet — leaves this branch
   // false, so tunnel startup is byte-for-byte unchanged (design §9 PR3
   // success criterion: provable no-op on the live fleet).
-  const resolveDeploymentModeForTunnelGate = deploymentModeReaderOpt ?? getDeploymentMode;
+  const resolveDeploymentModeForTunnelGate =
+    deploymentModeReaderOpt ?? getDeploymentMode;
   const deploymentModeForTunnelGate = resolveDeploymentModeForTunnelGate();
   const cloudModeSuppressesTunnels = deploymentModeForTunnelGate === "cloud";
 
@@ -5431,7 +5562,8 @@ export function createServer(opts: CreateServerOptions): BunServer {
         `[server] suppressing GitHub webhook smee tunnel start: deployment mode is "cloud" (event ingestion is the cloud SDK connection, not the smee tunnel)`,
       );
     } else {
-      const tunnelTarget = webhookConfig.target ?? `http://localhost:${server.port}/api/webhook`;
+      const tunnelTarget =
+        webhookConfig.target ?? `http://localhost:${server.port}/api/webhook`;
       webhookTunnel = createWebhookTunnel({
         source: webhookConfig.smeeChannel,
         target: tunnelTarget,
@@ -5456,7 +5588,9 @@ export function createServer(opts: CreateServerOptions): BunServer {
         const watchRepos = webhookConfig.watchRepos ?? [];
         const watchSubscriptions =
           watchRepos.length > 0
-            ? Promise.allSettled(watchRepos.map((repo) => subscriber.ensureSubscribed(repo)))
+            ? Promise.allSettled(
+                watchRepos.map((repo) => subscriber.ensureSubscribed(repo)),
+              )
             : Promise.resolve();
         // 1-hour replay window — wide enough to cover most outages, narrow enough
         // to keep startup latency under a few seconds.
@@ -5465,7 +5599,9 @@ export function createServer(opts: CreateServerOptions): BunServer {
           .then(() => replay.replaySince(subscriber.listSubscribed(), since))
           .then((count) => {
             if (count > 0) {
-              console.info(`[server] replayed ${count} webhook deliveries from the last hour`);
+              console.info(
+                `[server] replayed ${count} webhook deliveries from the last hour`,
+              );
             }
           })
           .catch((err: unknown) => {
@@ -5563,10 +5699,10 @@ export function createServer(opts: CreateServerOptions): BunServer {
   // invariants (N clients ⇒ N onAppend listeners on the ONE ring; disconnect
   // deregisters both the listener and the sseClients entry). The UI never reads
   // these.
-  (server as unknown as { __ringListenerCount?: () => number }).__ringListenerCount = () =>
-    eventRing.listenerCount();
-  (server as unknown as { __sseClientCount?: () => number }).__sseClientCount = () =>
-    sseClients.size;
+  (server as unknown as { __ringListenerCount?: () => number }).__ringListenerCount =
+    () => eventRing.listenerCount();
+  (server as unknown as { __sseClientCount?: () => number }).__sseClientCount =
+    () => sseClients.size;
   // CTL-1612 post-merge #2978 (Codex P2 follow-up): same CTL-1224 debug-seam
   // convention — exposes the `stopped` lifecycle flag (see its comment above
   // daemonDepsPromise) so a test can assert it flips synchronously, before
@@ -5617,7 +5753,8 @@ export function resolveProjectConfigPath(
 }
 
 if (import.meta.main) {
-  const CATALYST_DIR = process.env.CATALYST_DIR ?? `${process.env.HOME}/catalyst`;
+  const CATALYST_DIR =
+    process.env.CATALYST_DIR ?? `${process.env.HOME}/catalyst`;
   const WT_DIR = `${CATALYST_DIR}/wt`;
   const RUNS_DIR = `${CATALYST_DIR}/runs`;
   const parsedPort = parseInt(process.env.MONITOR_PORT ?? "", 10);
@@ -5627,7 +5764,8 @@ if (import.meta.main) {
   // for the family-squatting residual — an undocumented remedy nobody can apply
   // is not a remedy.
   const HOST = (process.env.MONITOR_HOST ?? "").trim() || "0.0.0.0";
-  const DB_PATH = process.env.CATALYST_DB_FILE ?? `${CATALYST_DIR}/catalyst.db`;
+  const DB_PATH =
+    process.env.CATALYST_DB_FILE ?? `${CATALYST_DIR}/catalyst.db`;
 
   const pidFileIdx = process.argv.indexOf("--pid-file");
   let pidFilePath: string | undefined;
@@ -5646,7 +5784,8 @@ if (import.meta.main) {
 
   // CTL-1156: resolve config path once — --config flag > CATALYST_CONFIG_PATH > cwd default.
   const configPath = resolveProjectConfigPath(process.argv, process.env, process.cwd());
-  const projectKey = detectProjectKeyFromConfig(configPath) ?? detectProjectKey(process.cwd());
+  const projectKey =
+    detectProjectKeyFromConfig(configPath) ?? detectProjectKey(process.cwd());
   const otelCfg = loadOtelConfig(
     process.env.CATALYST_CONFIG_DIR ?? `${process.env.HOME}/.config/catalyst`,
     projectKey,
@@ -5679,14 +5818,12 @@ if (import.meta.main) {
       : null;
   const linearWebhookConfig =
     fullWebhookConfig &&
-    (fullWebhookConfig.linearSecrets.length > 0 || fullWebhookConfig.linearSmeeChannel.length > 0)
+    (fullWebhookConfig.linearSecrets.length > 0 ||
+      fullWebhookConfig.linearSmeeChannel.length > 0)
       ? {
           linearSecrets: fullWebhookConfig.linearSecrets,
           smeeChannel: fullWebhookConfig.linearSmeeChannel,
-          botUserIds:
-            fullWebhookConfig.linearBotUserIds.size > 0
-              ? fullWebhookConfig.linearBotUserIds
-              : undefined,
+          botUserIds: fullWebhookConfig.linearBotUserIds.size > 0 ? fullWebhookConfig.linearBotUserIds : undefined,
           linearTeams: fullWebhookConfig.linearTeams,
         }
       : null;
@@ -5770,14 +5907,13 @@ if (import.meta.main) {
       projectsConfigPath: configPath,
       monitorConfigPath: configPath,
     });
-    const displayHost = srv.hostname === "0.0.0.0" ? "localhost" : String(srv.hostname);
+    const displayHost =
+      srv.hostname === "0.0.0.0" ? "localhost" : String(srv.hostname);
     console.info(`Monitor v${CATALYST_DEV_VERSION} running at http://${displayHost}:${srv.port}`);
     if (useTerminal) {
       console.info("Terminal renderer active (--terminal)");
     }
-    console.info(
-      `(bound on ${String(srv.hostname)}:${srv.port}; watching ${WT_DIR} and ${RUNS_DIR})`,
-    );
+    console.info(`(bound on ${String(srv.hostname)}:${srv.port}; watching ${WT_DIR} and ${RUNS_DIR})`);
 
     for (const sig of ["SIGINT", "SIGTERM"] as const) {
       process.on(sig, () => {

--- a/plugins/dev/scripts/orch-monitor/ui/src/components/account-banner.tsx
+++ b/plugins/dev/scripts/orch-monitor/ui/src/components/account-banner.tsx
@@ -1,0 +1,59 @@
+// account-banner.tsx — CTL-1653. The LOUD, conditional banner that appears when
+// this node's ACTIVE Claude account's binding window is `rejected` (exhausted).
+// Structural clone of ui/otel-health-banner.tsx: returns null unless bannerModel()
+// is non-null; when shown, a red `role="alert"` div names the reset time and a
+// sibling account with headroom. It clears automatically once the SSE next reports
+// `ok` (the window reset or the account was switched) — no reload.
+//
+// error ≠ rejected: a transport `error` posture is the sensor being broken, NOT the
+// account being exhausted, so bannerModel() returns null for it and this stays quiet.
+
+import { cn } from "@/lib/utils";
+import { AlertCircle } from "lucide-react";
+import { useAccountSignalContext } from "@/hooks/use-account-signal";
+import { bannerModel } from "@/hooks/account-signal-lib";
+
+/** Local, human-readable reset time; passes the raw string through if unparseable. */
+function fmtReset(resetsAt: string | null): string {
+  if (!resetsAt) return "an unknown time";
+  const ms = Date.parse(resetsAt);
+  if (!Number.isFinite(ms)) return resetsAt;
+  return new Date(ms).toLocaleString(undefined, {
+    month: "short",
+    day: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+  });
+}
+
+export function AccountBanner({ className }: { className?: string }) {
+  const account = useAccountSignalContext();
+  const model = bannerModel(account);
+  if (!model) return null;
+
+  const who = model.handle ?? "the active account";
+
+  return (
+    <div
+      role="alert"
+      className={cn(
+        "flex items-start gap-2 rounded-lg border border-red/20 bg-red/10 px-4 py-2 text-[13px] text-red",
+        className,
+      )}
+    >
+      <AlertCircle className="mt-[2px] h-4 w-4 shrink-0" />
+      <div className="min-w-0">
+        <span>
+          Claude account <span className="font-medium">{who}</span> is out of budget — resets{" "}
+          {fmtReset(model.resetsAt)}.
+          {model.sibling ? (
+            <>
+              {" "}
+              Switch to <span className="font-medium">{model.sibling.label}</span> (has headroom).
+            </>
+          ) : null}
+        </span>
+      </div>
+    </div>
+  );
+}

--- a/plugins/dev/scripts/orch-monitor/ui/src/components/app-footer.test.tsx
+++ b/plugins/dev/scripts/orch-monitor/ui/src/components/app-footer.test.tsx
@@ -5,6 +5,7 @@ import { describe, it, expect, mock, afterAll } from "bun:test";
 import type { ReactNode, ReactElement } from "react";
 import type { NavSignal } from "@/lib/nav-signal";
 import type { ClusterSignal } from "@/lib/cluster-signal";
+import type { AccountSignal } from "@/hooks/account-signal-lib";
 import type { ServiceStatusView } from "@/components/observe/service-health-kit";
 import { severityDotColor } from "@/components/observe/service-health-kit";
 
@@ -31,6 +32,12 @@ let serviceHealthState: { services: ServiceStatusView[] | null; unavailable: boo
 
 let boardStatus: string = "connected";
 let boardWorkers: unknown[] = [];
+
+// CTL-1653: AppFooter now reads this node's Claude-account posture via
+// useAccountSignalContext(). Default null → the account indicator span is not
+// rendered (AppFooter guards on `account &&`), so the CTL-1172 assertions below
+// stay behavior-identical.
+let accountState: AccountSignal | null = null;
 
 function svc(partial: Partial<ServiceStatusView> & { id: string }): ServiceStatusView {
   return {
@@ -66,6 +73,15 @@ mock.module("@/hooks/use-cluster-signal", () => ({
   ClusterSignalContext: stubContext,
   useClusterSignalContext: () => clusterState,
   useClusterSignal: () => clusterState,
+}));
+
+// CTL-1653: stub the account-posture context hook so the direct-call (no React
+// dispatcher) tree-walk doesn't invoke the real useContext. Mirror the other
+// context-hook mocks; keep the pure account-signal-lib unmocked.
+mock.module("@/hooks/use-account-signal", () => ({
+  AccountSignalContext: stubContext,
+  useAccountSignalContext: () => accountState,
+  useAccountSignal: () => accountState,
 }));
 
 mock.module("@/hooks/use-service-health", () => ({

--- a/plugins/dev/scripts/orch-monitor/ui/src/components/app-footer.tsx
+++ b/plugins/dev/scripts/orch-monitor/ui/src/components/app-footer.tsx
@@ -23,6 +23,8 @@ import { deriveFooterCounts } from "@/components/footer-counts";
 import { useNavSignalContext } from "@/hooks/use-nav-signal";
 import { useClusterSignalContext } from "@/hooks/use-cluster-signal";
 import { nodeStatusLabel } from "@/lib/cluster-signal";
+import { useAccountSignalContext } from "@/hooks/use-account-signal";
+import { accountIndicatorLabel, type AccountTone } from "@/hooks/account-signal-lib";
 import { daemonLabel } from "@/lib/nav-signal";
 // CTL-1172: shared service-health context + fold helper for the right indicator.
 import { useServiceHealthContext } from "@/hooks/use-service-health";
@@ -50,10 +52,21 @@ const RIGHT_LABEL: Record<ServiceSeverity, string> = {
   unknown: "SERVICES ?",
 };
 
+// CTL-1653: the account-indicator tone → footer text color. It stays QUIET while
+// ok/unknown and never goes loud here (the AccountBanner owns the loud surface) —
+// a `rejected` posture reads as a colored-but-inline red text, not a banner.
+const ACCOUNT_TONE_COLOR: Record<AccountTone, string> = {
+  quiet: C.fgMuted,
+  warn: C.yellow,
+  loud: C.red,
+  muted: C.fgDim,
+};
+
 export function AppFooter() {
   const { payload, status } = useBoardSnapshot();
   const nav = useNavSignalContext();
   const cluster = useClusterSignalContext();
+  const account = useAccountSignalContext();
   const { services, unavailable } = useServiceHealthContext();
   const push = usePushSubscription();
 
@@ -179,6 +192,20 @@ export function AppFooter() {
         >
           ENABLE NOTIFS
         </button>
+      )}
+
+      {/* CTL-1653: compact, quiet-while-ok Claude-account indicator (active
+          handle + binding-window pct). Muted while `error` (sensor broken),
+          amber while `degraded`. It never goes loud here — the AccountBanner
+          owns the loud exhausted surface. Absent until the first SSE frame. */}
+      {account && (
+        <span
+          className="font-mono text-[10px]"
+          style={{ color: ACCOUNT_TONE_COLOR[accountIndicatorLabel(account).tone] }}
+          title="Active Claude account posture"
+        >
+          {accountIndicatorLabel(account).text}
+        </span>
       )}
 
       {/* Spacer */}

--- a/plugins/dev/scripts/orch-monitor/ui/src/components/app-shell.tsx
+++ b/plugins/dev/scripts/orch-monitor/ui/src/components/app-shell.tsx
@@ -37,6 +37,8 @@ import { ALL_NODES, NodeScopeContext, type NodeScope } from "@/lib/node-scope";
 // one EventSource each instead of opening independent duplicate connections.
 import { useNavSignal, NavSignalContext } from "@/hooks/use-nav-signal";
 import { useClusterSignal, ClusterSignalContext } from "@/hooks/use-cluster-signal";
+import { useAccountSignal, AccountSignalContext } from "@/hooks/use-account-signal";
+import { AccountBanner } from "@/components/account-banner";
 // CTL-1100: lift useBeliefs into AppShell so no surface opens a second EventSource.
 import { useBeliefs, BeliefsContext } from "@/hooks/use-beliefs";
 // CTL-1172: lift /api/health/services poll to AppShell so footer + FleetOps share one fetch.
@@ -162,6 +164,9 @@ export function AppShell({ children }: { children: React.ReactNode }) {
   // these hooks independently, reducing persistent EventSources from 6 → 4.
   const navSignal = useNavSignal();
   const clusterSignal = useClusterSignal();
+  // CTL-1653: single subscription point for this node's Claude-account posture.
+  // AppFooter + AccountBanner consume AccountSignalContext (one EventSource).
+  const accountSignal = useAccountSignal();
   // CTL-1100: single belief stream subscription — surfaces use useBeliefsContext().
   const beliefsState = useBeliefs();
   // CTL-1172: single /api/health/services poll — footer + FleetOps read ServiceHealthContext.
@@ -386,6 +391,7 @@ export function AppShell({ children }: { children: React.ReactNode }) {
     <BeliefsContext.Provider value={beliefsState}>
     <NavSignalContext.Provider value={navSignal}>
     <ClusterSignalContext.Provider value={clusterSignal}>
+    <AccountSignalContext.Provider value={accountSignal}>
       <NodeScopeContext.Provider value={nodeScopeCtx}>
       {/* Controlled provider → Cmd/Ctrl+B still fires through onOpenChange, so
           `[` and Cmd/Ctrl+B both work with no vendoring. h-screen, edge-to-edge:
@@ -450,6 +456,12 @@ export function AppShell({ children }: { children: React.ReactNode }) {
                 portals its prev/next chevrons here via <HeaderActions>. */}
             <HeaderActionsSlot />
           </header>
+
+          {/* CTL-1653: the LOUD account-exhausted banner. Quiet (null) unless the
+              active Claude account's binding window is `rejected`; names the reset
+              time + a sibling with headroom, and clears itself when the SSE next
+              reports `ok`. */}
+          <AccountBanner className="mx-3 mt-2" />
 
           {/* CTL-989: the matched ROUTE renders into the layout's content slot
               (children === the router <Outlet/>). Settings is now the /settings
@@ -565,6 +577,7 @@ export function AppShell({ children }: { children: React.ReactNode }) {
         </CommandList>
       </CommandDialog>
       </NodeScopeContext.Provider>
+    </AccountSignalContext.Provider>
     </ClusterSignalContext.Provider>
     </NavSignalContext.Provider>
     </BeliefsContext.Provider>

--- a/plugins/dev/scripts/orch-monitor/ui/src/hooks/__tests__/account-signal-decode.test.ts
+++ b/plugins/dev/scripts/orch-monitor/ui/src/hooks/__tests__/account-signal-decode.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect } from "bun:test";
+import {
+  decodeAccountSignalFrame,
+  isAccountSignal,
+  accountIndicatorLabel,
+  bannerModel,
+  type AccountSignal,
+} from "../account-signal-lib";
+
+describe("decodeAccountSignalFrame / isAccountSignal", () => {
+  it("parses a valid frame", () => {
+    const s = decodeAccountSignalFrame(
+      JSON.stringify({
+        node: "n",
+        status: "ok",
+        active: {
+          label: "a",
+          email: "a@x",
+          bindingWindow: "five_hour",
+          fiveHour: { pct: 12 },
+          sevenDay: { pct: 20 },
+        },
+      }),
+    );
+    expect(isAccountSignal(s)).toBe(true);
+    expect(s!.active!.label).toBe("a");
+  });
+  it("rejects malformed input → null", () =>
+    expect(decodeAccountSignalFrame("not json")).toBeNull());
+});
+
+describe("accountIndicatorLabel (quiet while ok)", () => {
+  it("shows active handle + binding-window pct", () => {
+    const l = accountIndicatorLabel({
+      status: "ok",
+      active: { label: "acctA", bindingWindow: "five_hour", fiveHour: { pct: 12 } },
+    } as AccountSignal);
+    expect(l.text).toContain("acctA");
+    expect(l.text).toContain("12%");
+    expect(l.tone).toBe("quiet");
+  });
+  it("error status is muted/neutral, not loud", () =>
+    expect(
+      accountIndicatorLabel({
+        status: "error",
+        active: { error: "network error" },
+      } as AccountSignal).tone,
+    ).toBe("muted"));
+});
+
+describe("bannerModel (loud only when active binding rejected)", () => {
+  it("null when ok", () => expect(bannerModel({ status: "ok" } as AccountSignal)).toBeNull());
+  it("names reset + sibling when rejected", () => {
+    const m = bannerModel({
+      status: "rejected",
+      active: {
+        label: "acctA",
+        bindingWindow: "seven_day",
+        sevenDay: { resetsAt: "2026-08-06T00:00:00.000Z" },
+      },
+      siblingWithHeadroom: { label: "acctB", email: "b@x" },
+    } as AccountSignal);
+    expect(m!.resetsAt).toBe("2026-08-06T00:00:00.000Z");
+    expect(m!.sibling).toEqual({ label: "acctB", email: "b@x" });
+  });
+  it("null on error (sensor broken, not exhausted)", () =>
+    expect(bannerModel({ status: "error" } as AccountSignal)).toBeNull());
+});

--- a/plugins/dev/scripts/orch-monitor/ui/src/hooks/account-signal-lib.ts
+++ b/plugins/dev/scripts/orch-monitor/ui/src/hooks/account-signal-lib.ts
@@ -1,0 +1,147 @@
+// account-signal-lib.ts — CTL-1653. The UI contract for the read-model's per-node
+// Claude-account posture (`/api/accounts` + `/api/accounts/stream`). Browser-side
+// mirror of the server's AccountsSummary shape (lib/accounts-probe.mjs) plus a
+// structural decode guard and the SINGLE canonical status→tone/copy mapping shared
+// by the footer indicator, the loud banner (Phase 5), and the HUD strip (Phase 6).
+//
+// Deliberately runtime-free + pure so it is unit-testable without a DOM (same
+// pattern lib/cluster-signal.ts follows). The subscription lifecycle lives in
+// hooks/use-account-signal.ts.
+//
+// error ≠ rejected: a transport `error` is "the sensor is broken" (MUTED, never
+// loud); only `rejected` (account exhausted) trips the loud banner/overlay.
+
+/** One rate-limit window's utilization/reset/status (token-free). */
+export interface AccountWindow {
+  pct?: number;
+  resetsAt?: string | null;
+  status?: string | null;
+}
+
+/** A token-free per-account view mirrored from the server. */
+export interface AccountView {
+  label?: string | null;
+  email?: string | null;
+  overallStatus?: string | null;
+  representativeClaim?: string | null;
+  bindingWindow?: string | null;
+  bindingStatus?: string | null;
+  fiveHour?: AccountWindow | null;
+  sevenDay?: AccountWindow | null;
+  error?: string | null;
+}
+
+/** The node status derived from the active account's binding window. */
+export type AccountNodeStatus = "ok" | "degraded" | "rejected" | "error" | "unknown";
+
+/** The per-node account posture wire shape the dashboards render. */
+export interface AccountSignal {
+  node?: string | null;
+  status: AccountNodeStatus;
+  active?: AccountView | null;
+  siblingWithHeadroom?: { label: string | null; email: string | null } | null;
+  generatedAt?: string | null;
+}
+
+const STATUS_VALUES: readonly AccountNodeStatus[] = [
+  "ok",
+  "degraded",
+  "rejected",
+  "error",
+  "unknown",
+];
+
+/** Structural guard: keep a truncated/garbage SSE frame from reaching the UI. */
+export function isAccountSignal(value: unknown): value is AccountSignal {
+  if (!value || typeof value !== "object") return false;
+  const v = value as Record<string, unknown>;
+  return (
+    typeof v.status === "string" &&
+    (STATUS_VALUES as readonly string[]).includes(v.status) &&
+    (v.active === null || v.active === undefined || typeof v.active === "object")
+  );
+}
+
+/** Decode an SSE `account` frame's data; returns null (skipped) on garbage. */
+export function decodeAccountSignalFrame(data: string): AccountSignal | null {
+  try {
+    const parsed: unknown = JSON.parse(data);
+    return isAccountSignal(parsed) ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+/** The tone vocabulary shared by the footer indicator + HUD strip. */
+export type AccountTone = "quiet" | "warn" | "loud" | "muted";
+
+const STATUS_TONE: Record<AccountNodeStatus, AccountTone> = {
+  ok: "quiet",
+  unknown: "quiet",
+  degraded: "warn",
+  rejected: "loud",
+  error: "muted",
+};
+
+/** Short label for a binding window (five_hour → "5h", seven_day → "7d"). */
+export function bindingWindowShort(bindingWindow?: string | null): string {
+  if (bindingWindow === "five_hour") return "5h";
+  if (bindingWindow === "seven_day") return "7d";
+  return "";
+}
+
+/** The window object the binding claim points at (five_hour → active.fiveHour). */
+export function bindingWindowOf(active?: AccountView | null): AccountWindow | null {
+  if (!active) return null;
+  if (active.bindingWindow === "five_hour") return active.fiveHour ?? null;
+  if (active.bindingWindow === "seven_day") return active.sevenDay ?? null;
+  return null;
+}
+
+/**
+ * accountIndicatorLabel — the compact, quiet-while-ok footer/strip label. Names the
+ * active handle + binding-window pct; the tone is the single canonical status map
+ * (ok/unknown quiet, degraded warn, rejected loud, error muted).
+ */
+export function accountIndicatorLabel(signal: AccountSignal | null | undefined): {
+  text: string;
+  tone: AccountTone;
+} {
+  if (!signal) return { text: "account —", tone: "muted" };
+  const tone = STATUS_TONE[signal.status] ?? "muted";
+  const active = signal.active;
+  if (!active || (!active.label && signal.status === "unknown")) {
+    return { text: "no active account", tone };
+  }
+  if (signal.status === "error") {
+    return { text: `${active.label ?? "account"} · error`, tone };
+  }
+  const win = bindingWindowShort(active.bindingWindow);
+  const w = bindingWindowOf(active);
+  const pct = typeof w?.pct === "number" ? `${w.pct}%` : "";
+  const parts = [active.label ?? "account", [win, pct].filter(Boolean).join(" ")].filter(Boolean);
+  return { text: parts.join(" · "), tone };
+}
+
+/** The loud banner/overlay model — non-null ONLY when the active binding is rejected. */
+export interface AccountBannerModel {
+  handle: string | null;
+  resetsAt: string | null;
+  sibling: { label: string | null; email: string | null } | null;
+}
+
+/**
+ * bannerModel — the loud model for the web banner / HUD overlay. Returns null unless
+ * the active account's binding window is `rejected` (an `error` sensor failure is
+ * NOT loud). Names the binding window's reset time + a sibling with headroom.
+ */
+export function bannerModel(signal: AccountSignal | null | undefined): AccountBannerModel | null {
+  if (!signal || signal.status !== "rejected") return null;
+  const active = signal.active ?? null;
+  const w = bindingWindowOf(active);
+  return {
+    handle: active?.label ?? null,
+    resetsAt: w?.resetsAt ?? null,
+    sibling: signal.siblingWithHeadroom ?? null,
+  };
+}

--- a/plugins/dev/scripts/orch-monitor/ui/src/hooks/use-account-signal.ts
+++ b/plugins/dev/scripts/orch-monitor/ui/src/hooks/use-account-signal.ts
@@ -1,0 +1,129 @@
+// use-account-signal.ts — subscribe the dashboard to the read-model's per-node
+// Claude-account posture (CTL-1653). One EventSource over `/api/accounts/stream`
+// that receives an `account` frame on connect and on every periodic probe — the
+// active account flipping to `rejected` (or its window resetting back to `ok`)
+// is reflected WITHOUT a page reload and WITHOUT per-tab polling.
+//
+// Mirrors use-cluster-signal.ts's direct-SSE + capped-backoff reconcile fallback:
+// under standalone `bun run dev` the SSE 404s, so a reconcile poll against
+// `/api/accounts` is the data source instead. The signal is tiny (one node's
+// posture), so a per-tab EventSource is fine.
+//
+// AppShell calls useAccountSignal() ONCE and distributes the result via
+// AccountSignalContext so the footer + banner share the same value without opening
+// a second EventSource. Consumers inside AppShell use useAccountSignalContext().
+import { createContext, useContext, useEffect, useState } from "react";
+import {
+  decodeAccountSignalFrame,
+  isAccountSignal,
+  type AccountSignal,
+} from "./account-signal-lib";
+
+// ── Shared context ────────────────────────────────────────────────────────────
+
+/** Context value: the latest AccountSignal from the single AppShell subscription. */
+export const AccountSignalContext = createContext<AccountSignal | null>(null);
+
+/**
+ * Consume the shared AccountSignal from AppShell's context.
+ * Only usable inside components rendered inside AppShell.
+ */
+export function useAccountSignalContext(): AccountSignal | null {
+  return useContext(AccountSignalContext);
+}
+
+// ── SSE subscription hook ─────────────────────────────────────────────────────
+
+const INITIAL_BACKOFF_MS = 500;
+const MAX_BACKOFF_MS = 15_000;
+
+/**
+ * Subscribe to the account-posture projection for the lifetime of the calling
+ * component. Returns the latest signal (null until the first frame lands).
+ */
+export function useAccountSignal(): AccountSignal | null {
+  const [signal, setSignal] = useState<AccountSignal | null>(null);
+
+  useEffect(() => {
+    let alive = true;
+    let es: EventSource | null = null;
+    let backoff = INITIAL_BACKOFF_MS;
+    let reconnectTimer: ReturnType<typeof setTimeout> | undefined;
+    let controller: AbortController | undefined;
+
+    const apply = (next: AccountSignal) => {
+      if (alive) setSignal(next);
+    };
+
+    const reconcile = async (): Promise<boolean> => {
+      if (!alive) return false;
+      controller?.abort();
+      controller = new AbortController();
+      try {
+        const r = await fetch("/api/accounts", { signal: controller.signal });
+        if (r.ok) {
+          const body: unknown = await r.json();
+          if (isAccountSignal(body)) {
+            apply(body);
+            return true;
+          }
+        }
+      } catch {
+        /* offline — the backoff loop retries */
+      }
+      return false;
+    };
+
+    const scheduleReconnect = () => {
+      if (!alive) return;
+      const delay = backoff;
+      backoff = Math.min(MAX_BACKOFF_MS, backoff * 2);
+      reconnectTimer = setTimeout(connect, delay);
+      void reconcile();
+    };
+
+    function connect() {
+      if (!alive) return;
+      try {
+        es = new EventSource("/api/accounts/stream");
+      } catch {
+        scheduleReconnect();
+        return;
+      }
+      es.addEventListener("account", (ev) => {
+        backoff = INITIAL_BACKOFF_MS; // reset on a real frame
+        const next = decodeAccountSignalFrame((ev as MessageEvent).data as string);
+        if (next) apply(next);
+      });
+      es.onerror = () => {
+        try {
+          es?.close();
+        } catch {
+          /* noop */
+        }
+        es = null;
+        scheduleReconnect();
+      };
+    }
+
+    connect();
+    const onVis = () => {
+      if (!document.hidden) void reconcile();
+    };
+    document.addEventListener("visibilitychange", onVis);
+
+    return () => {
+      alive = false;
+      try {
+        es?.close();
+      } catch {
+        /* noop */
+      }
+      clearTimeout(reconnectTimer);
+      controller?.abort();
+      document.removeEventListener("visibilitychange", onVis);
+    };
+  }, []);
+
+  return signal;
+}

--- a/website/src/content/docs/reference/catalyst-stack.md
+++ b/website/src/content/docs/reference/catalyst-stack.md
@@ -31,6 +31,24 @@ The core daemons start **monitor → broker → execution-core** (CTL-1084 known
 | `install-services` | Install the launchd LaunchAgents (stack keep-alive, thoughts-sync, log-shipper) that auto-start on boot. macOS only. |
 | `uninstall-services` | Unload and remove the auto-start LaunchAgents (leaves running daemons up). |
 | `services-status` | Show whether the auto-start LaunchAgents are installed and loaded. |
+| `claude-account status\|switch\|sync` | Inspect and control the fleet's active Claude OAuth account (see below). |
+
+## `claude-account` (CTL-1650)
+
+Fleet-wide Claude OAuth-account control, one command. Reads the durable `setup-token`s in
+`~/.config/catalyst/claude-accounts.env` and (for `switch`) the encrypted selector in the
+`catalyst-cluster` repo's `secrets/node-secret-files.sops.json`.
+
+| Subcommand | Description |
+|------------|-------------|
+| `status` | Run `claude-accounts-usage.mjs` and print each account's 5h/7d rate-limit utilization, reset times, status, and which account is **ACTIVE**. Exits nonzero if no account reported limits. |
+| `switch <handle> [--yes]` | Flip the fleet's active SDK account (handle form `acctN`, e.g. `acct2`). Guards on the local age key + a `catalyst-cluster` clone, validates the handle is provisioned, **probes the target token's auth before switching** (refuses a 401/expired account), flips the `_catalyst_active_token` selector via a non-interactive `sops edit`, commits + pushes the cluster repo, re-materializes `claude-accounts.env`, restarts the stack, and verifies the new account is now ACTIVE. |
+| `sync [--yes]` | For a second node after a switch was pushed elsewhere: `git pull` the cluster repo, re-materialize `claude-accounts.env`, restart, and verify. |
+
+**Secrets hygiene:** token values are never echoed, logged, or written anywhere but the `0600`
+`~/.config/catalyst/claude-accounts.env` target file. The same token-free posture is surfaced
+headlessly by the orch-monitor `GET /api/accounts` endpoint (see the
+[orch-monitor API](/reference/orch-monitor-api/)).
 
 ## Flags
 

--- a/website/src/content/docs/reference/cluster-config-mirror.md
+++ b/website/src/content/docs/reference/cluster-config-mirror.md
@@ -128,3 +128,32 @@ dotted event keys directly:
 
 Use the snake_case field names (strip the `ratelimit.` prefix) so the heartbeat attachment stays
 human-readable. The source event keys remain the canonical names — this shape is a derived view.
+
+---
+
+## Account status-transition event (CTL-1653)
+
+Event name: `account.status.changed` (v2 OTel envelope, `event.entity: "account"`, severity INFO).
+
+**Edge-triggered, not per-sample.** Unlike `account.ratelimit.sampled` (which is emitted every poll
+tick from the interactive-login `/api/oauth/usage` probe), `account.status.changed` is appended by
+the orch-monitor's periodic probe **only** on the ACTIVE account's `ok`↔`rejected` transition — one
+event per edge, never on a same-status repeat. It is sourced from the CTL-1650 durable-token header
+probe ([`claude-accounts-usage.mjs`](https://github.com/coalesce-labs/catalyst/blob/main/plugins/dev/scripts/claude-accounts-usage.mjs)),
+a different path from the CTL-812 usage sampler; the two coexist. A transport `error` (sensor
+failure) is distinct from `rejected` (account exhausted) and does **not** trip the transition.
+
+| Attribute key | Type | Meaning |
+|---|---|---|
+| `account.handle` | string | The account label (`acctN`) that transitioned |
+| `account.email` | string | The account email (from the env-file inline comment) |
+| `account.status` | string | The new status — `"rejected"` (exhausted) or `"ok"` (recovered) |
+| `account.binding_window` | string | The binding window driving the status — `"five_hour"` \| `"seven_day"` |
+| `node.name` | string | The node whose active account transitioned |
+
+The node identity is also carried on the envelope's `resource["host.name"]`. The edge is latched
+durably at `~/catalyst/account-status-latch.json` (atomic write, emit-then-advance) so a monitor
+restart mid-episode does not re-emit. Consumers must treat absent keys as unknown, not as a value.
+
+The same posture is available as a pull surface — the token-free `GET /api/accounts` endpoint and
+its `GET /api/accounts/stream` SSE (see the [orch-monitor API](/reference/orch-monitor-api/)).

--- a/website/src/content/docs/reference/orch-monitor-api.md
+++ b/website/src/content/docs/reference/orch-monitor-api.md
@@ -1,0 +1,83 @@
+---
+title: orch-monitor API
+description:
+  Read-only HTTP surfaces served by the orch-monitor process, including the per-node Claude-account
+  posture endpoint.
+sidebar:
+  order: 25
+---
+
+The orch-monitor process serves the dashboards (web + HUD) and a set of read-only HTTP endpoints.
+This page documents the **Claude-account posture** surface (CTL-1653); it is per-node and token-free
+by construction.
+
+## `GET /api/accounts`
+
+Returns **this node's** Claude-account posture: the active account, each account's 5h/7d utilization
+/ reset times / status, and a sibling account with headroom. The response is derived from the
+CTL-1650 durable-token probe run in a token-scoped subshell, so **no token value ever appears in the
+response** (or in the monitor's own environment).
+
+- **Cached** (~5 min TTL). Repeated calls within the TTL are served from cache — the same `probedAt`
+  is returned and no inference call is spent.
+- **`?refresh=true`** forces a fresh probe (operator-initiated; the only per-request probe path).
+- **Disabled** — on a node with no `claude-accounts.env` (or when the probe is disabled), the
+  endpoint returns `{ "available": false, "node": "<host>" }`.
+
+```json
+{
+  "available": true,
+  "node": "mini-2",
+  "generatedAt": "2026-08-05T12:00:00.000Z",
+  "probedAt": 1754395200000,
+  "cached": false,
+  "status": "rejected",
+  "active": {
+    "label": "acctA",
+    "email": "a@example.io",
+    "overallStatus": "rejected",
+    "representativeClaim": "seven_day",
+    "bindingWindow": "seven_day",
+    "bindingStatus": "rejected",
+    "fiveHour": { "pct": 40, "resetsAt": "2026-08-05T13:00:00.000Z", "status": "allowed" },
+    "sevenDay": { "pct": 100, "resetsAt": "2026-08-06T00:00:00.000Z", "status": "rejected" },
+    "error": null
+  },
+  "accounts": [/* one token-free view per account */],
+  "siblingWithHeadroom": { "label": "acctB", "email": "b@example.io" }
+}
+```
+
+The node-level `status` is one of:
+
+| `status`   | Meaning                                                                                  |
+| ---------- | ---------------------------------------------------------------------------------------- |
+| `ok`       | The active account's binding window is `allowed`.                                        |
+| `degraded` | The binding window is `allowed_warning` (nearing the limit).                             |
+| `rejected` | The active account is exhausted (binding window `rejected`) — the loud state.            |
+| `error`    | The probe hit a transport failure (the sensor is broken, **not** the account exhausted). |
+| `unknown`  | No account is active (`CLAUDE_CODE_OAUTH_TOKEN` unset).                                  |
+
+## `GET /api/accounts/stream`
+
+An SSE stream of the same posture. On connect it emits the current cached summary immediately; a
+periodic probe (default 5 min) then pushes a fresh frame on each refresh. Each event:
+
+```text
+event: account
+data: { …the /api/accounts summary body… }
+
+```
+
+The web footer + HUD strip subscribe to this stream so the active-account indicator and the loud
+exhausted banner/overlay update live without a reload. When the active account's binding window
+transitions `ok`↔`rejected`, the monitor also appends one edge-triggered
+[`account.status.changed`](/reference/cluster-config-mirror/#account-status-transition-event-ctl-1653)
+event to the unified event log.
+
+## Related
+
+- [`catalyst-stack claude-account`](/reference/catalyst-stack/#claude-account-ctl-1650) — the CLI
+  that inspects and switches the fleet's active account.
+- [Account status-transition event](/reference/cluster-config-mirror/#account-status-transition-event-ctl-1653)
+  — the `account.status.changed` v2 event schema.


### PR DESCRIPTION
<!-- Auto-generated: 2026-08-05T14:55:16Z -->
<!-- Last updated: 2026-08-05T14:55:16Z -->
<!-- PR: #3011 -->
<!-- Previous commits: 7a21ca86,304fa640,f94de96b,607495af,70475f47,9ceaf31f,744c7297,a58c297c,c65ff828,157b35d6,6d0ee21e -->

## Summary

Surfaces Claude account health across every orch-monitor observation surface. A new
accounts-probe library runs the account probe behind an async TTL cache; the orch-monitor
server exposes it as a `GET /api/accounts` endpoint plus a live `/api/accounts/stream` SSE
feed driven by a periodic timer. Account status changes fire an **edge-triggered**
`account.status.changed` transition event, and both the HUD (Ink TUI) and the web dashboard
render an account indicator — including a loud banner/overlay when an account degrades.
Docs cover the new API surface and the `claude-account` subcommand.

## Changes Made

### Accounts-probe library (`lib/`)

- `accounts-probe.mjs` — probe runner wrapped in an **async TTL cache** so concurrent callers
  share one in-flight probe and results are reused until the TTL expires. Ships companion
  `.d.ts` + `.d.mts` type declarations so both the `server.ts` (bundler resolution) and `.mjs`
  consumers type the import.
- `accounts-timer.mjs` — periodic timer that re-runs the probe on an interval to drive the SSE
  stream, with `.d.ts` / `.d.mts` declarations.
- `account-status-latch.mjs` — edge-triggered latch that compares the last observed account
  status to the current probe result and emits `account.status.changed` **only on a genuine
  transition** (never on steady-state ticks), with `.d.ts` / `.d.mts` declarations.

### orch-monitor server (`server.ts`)

- `GET /api/accounts` — returns the current cached account model.
- `GET /api/accounts/stream` — Server-Sent Events stream that pushes account updates as the
  periodic timer refreshes the probe.

### HUD (Ink TUI, `cli/`)

- `components/account-strip.ts` — account strip rendered in the HUD, with a loud overlay when
  an account is degraded.
- `hooks/useAccountModel.ts` — hook that consumes the account model / SSE stream with reconnect
  handling.
- `hud.tsx` — wires the account strip into the HUD layout.

### Web dashboard (`ui/src/`)

- `components/account-banner.tsx` — loud banner shown when an account degrades.
- `components/app-footer.tsx` / `components/app-shell.tsx` — account indicator surfaced in the
  dashboard chrome.
- `hooks/use-account-signal.ts` + `hooks/account-signal-lib.ts` — decode/consume the account
  signal from the SSE stream.

### Docs

- `website/src/content/docs/reference/orch-monitor-api.md` — documents `/api/accounts` and the
  `/api/accounts/stream` SSE endpoint.
- `website/src/content/docs/reference/catalyst-stack.md` — documents the `claude-account`
  subcommand.
- `website/src/content/docs/reference/cluster-config-mirror.md` — related reference updates.

### Tests

- `lib/__tests__/accounts-probe.test.mjs`, `accounts-timer.test.mjs`,
  `account-status-latch.test.mjs` — cover the cache, timer, and edge-triggered transition
  (including the never-lose-a-transition invariant).
- `__tests__/accounts-endpoint.test.ts`, `__tests__/server.test.ts` — endpoint + SSE coverage.
- `cli/__tests__/account-strip.test.ts` — HUD account strip.
- `ui/src/hooks/__tests__/account-signal-decode.test.ts`, `ui/src/components/app-footer.test.tsx`
  — web dashboard decode + footer indicator.

## How to Verify It

- [ ] orch-monitor quality gate passes (eslint / knip:ci / typecheck / bun test)
- [ ] docs gate passes (`astro build`)
- [ ] `GET /api/accounts` returns the account model; `/api/accounts/stream` streams updates
- [ ] Degrading an account fires exactly one `account.status.changed` transition and lights up
      the HUD overlay + web banner

## Changelog Entry

`feat(dev)`: surface Claude account health across orch-monitor — accounts-probe library
(TTL-cached probe runner), `GET /api/accounts` + `/api/accounts/stream` SSE, edge-triggered
`account.status.changed` transition event, HUD account strip, and web dashboard account
indicator.

## Related Issues/PRs

- Fixes https://linear.app/coalesce-labs/issue/CTL-1653
