### PR TITLE
fix(monitor): CTL-1653 post-merge hardening — stale-strip clear, Bun execPath, non-simple refresh, EOF reconnect, empty-env contract

### DIFF
--- a/plugins/dev/scripts/orch-monitor/__tests__/accounts-endpoint.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/accounts-endpoint.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeAll, afterAll } from "bun:test";
 import { mkdtempSync, mkdirSync, rmSync } from "fs";
 import { tmpdir } from "os";
 import { join } from "path";
-import { createServer } from "../server";
+import { createServer, ACCOUNTS_REFRESH_HEADER } from "../server";
 
 const FAKE = {
   generatedAt: "2026-08-05T12:00:00.000Z",
@@ -92,20 +92,35 @@ describe("/api/accounts", () => {
     const b = (await (await fetch(`${base}/api/accounts`)).json()) as AccountsBody;
     expect(b.cached).toBe(true);
   });
-  it("?refresh=true forces a new probe", async () => {
-    const before = calls;
-    await fetch(`${base}/api/accounts?refresh=true`);
-    expect(calls).toBe(before + 1);
-  });
-  it("?refresh=true from an untrusted cross-origin caller is rejected (403), no probe spent", async () => {
+  it("?refresh=true WITH the required header forces a new probe (admit path)", async () => {
     const before = calls;
     const r = await fetch(`${base}/api/accounts?refresh=true`, {
-      headers: { Origin: "http://evil.example:1234" },
+      headers: { [ACCOUNTS_REFRESH_HEADER]: "1" },
+    });
+    expect(r.status).toBe(200);
+    expect(calls).toBe(before + 1);
+  });
+  it("?refresh=true WITHOUT the header is rejected (403), no probe spent (deny path)", async () => {
+    // CTL-1653 Codex round-2: the header is what closes the simple-request /
+    // originless-GET hole — an <img>/top-level-nav/plain-form GET (and a bare
+    // curl call, and this fetch()) can never carry it unless deliberately set.
+    const before = calls;
+    const r = await fetch(`${base}/api/accounts?refresh=true`);
+    expect(r.status).toBe(403);
+    expect(calls).toBe(before); // no probe spawned
+  });
+  it("?refresh=true WITH the header but an untrusted cross-origin caller is still rejected (403)", async () => {
+    // The header alone isn't sufficient either — the origin allowlist still
+    // applies on top of it (defense in depth for a same-origin-page-with-
+    // custom-header scenario the header check alone wouldn't catch).
+    const before = calls;
+    const r = await fetch(`${base}/api/accounts?refresh=true`, {
+      headers: { [ACCOUNTS_REFRESH_HEADER]: "1", Origin: "http://evil.example:1234" },
     });
     expect(r.status).toBe(403);
     expect(calls).toBe(before); // no probe spawned
   });
-  it("a plain (non-refresh) read is unaffected by a cross-origin caller", async () => {
+  it("a plain (non-refresh) read needs neither the header nor a trusted origin", async () => {
     const r = await fetch(`${base}/api/accounts`, {
       headers: { Origin: "http://evil.example:1234" },
     });

--- a/plugins/dev/scripts/orch-monitor/cli/hooks/useAccountModel.test.ts
+++ b/plugins/dev/scripts/orch-monitor/cli/hooks/useAccountModel.test.ts
@@ -1,0 +1,66 @@
+// useAccountModel.test.ts — covers shouldReconnectOnIdle directly (the pure
+// decision extracted from useAccountModel's connect()) plus an integration
+// check on the underlying createNodeEventSource behavior it reacts to.
+//
+// useAccountModel mixes React hook machinery (useEffect/useState) with a live
+// EventSource connection, so we can't invoke the hook directly in bun:test —
+// bun's runner has no React-hook renderer. This mirrors the established
+// pattern in useFilter.test.ts / useEventLog.test.ts: test the pure logic the
+// hook is built from, adjacent to the source so drift is obvious in review.
+
+import { describe, test, expect } from "bun:test";
+import { shouldReconnectOnIdle } from "./useAccountModel";
+import { createNodeEventSource } from "../lib/node-event-source";
+
+describe("shouldReconnectOnIdle (CTL-1653 Codex round-2: clean-EOF reconnect)", () => {
+  test("reconnects on a clean end-of-stream (no prior onerror, still mounted, still current)", () => {
+    expect(shouldReconnectOnIdle({ handled: false, alive: true, isCurrent: true })).toBe(true);
+  });
+  test("does NOT reconnect when onerror already handled this connection's end", () => {
+    // Avoids double-scheduling: onerror's own path already calls scheduleReconnect.
+    expect(shouldReconnectOnIdle({ handled: true, alive: true, isCurrent: true })).toBe(false);
+  });
+  test("does NOT reconnect after the component has unmounted", () => {
+    expect(shouldReconnectOnIdle({ handled: false, alive: false, isCurrent: true })).toBe(false);
+  });
+  test("does NOT reconnect when a newer connection has already superseded this one", () => {
+    expect(shouldReconnectOnIdle({ handled: false, alive: true, isCurrent: false })).toBe(false);
+  });
+});
+
+/** A fetch stub that streams the given chunks then ends the body cleanly (no error). */
+function fetchStreamingThenCloseCleanly(chunks: string[]): typeof fetch {
+  return (() => {
+    const enc = new TextEncoder();
+    const stream = new ReadableStream<Uint8Array>({
+      start(controller) {
+        for (const c of chunks) controller.enqueue(enc.encode(c));
+        controller.close(); // clean EOF — NOT an error
+      },
+    });
+    return Promise.resolve(new Response(stream, { status: 200 }));
+  }) as unknown as typeof fetch;
+}
+
+describe("createNodeEventSource: the gap shouldReconnectOnIdle exists to close", () => {
+  test("a clean end-of-stream resolves whenIdle() WITHOUT ever invoking onerror", async () => {
+    // This is the precise bug: before the fix, useAccountModel only scheduled a
+    // reconnect from onerror, and this proves onerror is silent on a graceful
+    // close — so a hook that reconnects ONLY from onerror can freeze forever.
+    const es = createNodeEventSource("http://x/api/accounts/stream", {
+      fetchImpl: fetchStreamingThenCloseCleanly([
+        'event: account\ndata: {"status":"ok"}\n\n',
+      ]),
+    });
+    let errorFired = false;
+    es.onerror = () => {
+      errorFired = true;
+    };
+    const got: string[] = [];
+    es.addEventListener("account", (ev) => got.push(ev.data));
+    await es.whenIdle();
+    expect(got.length).toBe(1); // the frame still delivered before EOF
+    expect(errorFired).toBe(false); // and yet onerror never fired
+    es.close();
+  });
+});

--- a/plugins/dev/scripts/orch-monitor/cli/hooks/useAccountModel.ts
+++ b/plugins/dev/scripts/orch-monitor/cli/hooks/useAccountModel.ts
@@ -14,7 +14,10 @@
 // bun). createNodeEventSource is a ONE-SHOT reader (reconnect policy is the hook's
 // job), so this hook owns capped-backoff reconnect + a snapshot reconcile — without
 // it the strip would freeze on its last value forever the first time the local
-// monitor restarts or the stream drops. Never throws.
+// monitor restarts or the stream drops. Reconnects on BOTH an errored close
+// (onerror) and a CLEAN end-of-stream (whenIdle() resolving with no prior
+// onerror — a graceful monitor restart / proxy close never fires onerror; see
+// shouldReconnectOnIdle). Never throws.
 
 import { useEffect, useState } from "react";
 import { createNodeEventSource, type NodeEventSource } from "../lib/node-event-source";
@@ -23,6 +26,39 @@ import type { AccountStripSignal } from "../components/account-strip";
 
 const INITIAL_BACKOFF_MS = 500;
 const MAX_BACKOFF_MS = 15_000;
+
+/**
+ * shouldReconnectOnIdle — pure decision for whether a NodeEventSource's clean
+ * end-of-stream (its `whenIdle()` resolving with NO prior `onerror`) should
+ * trigger a reconnect. A clean EOF happens when the monitor restarts or a
+ * proxy closes the connection gracefully — `createNodeEventSource`'s `pump()`
+ * returns normally on `done` from the reader in that case, never invoking
+ * `onerror`, so a hook that only reconnects from `onerror` freezes the strip
+ * on its last value forever (CTL-1653 Codex round-2 finding). Exported so the
+ * three guards are independently testable without a DOM, timers, or a real
+ * EventSource — bun's test runner has no React-hook renderer (see
+ * useFilter.test.ts for the established pattern this mirrors).
+ *
+ * @param handled   true if `onerror` already handled this connection's end
+ *                  (an errored close reconnects via its own onerror path —
+ *                  reconnecting here too would double-schedule)
+ * @param alive     false once the component has unmounted — never reconnect
+ *                  after teardown
+ * @param isCurrent false when a newer connection has already superseded this
+ *                  one — this stale `whenIdle()` resolving late must not
+ *                  reconnect a second time
+ */
+export function shouldReconnectOnIdle({
+  handled,
+  alive,
+  isCurrent,
+}: {
+  handled: boolean;
+  alive: boolean;
+  isCurrent: boolean;
+}): boolean {
+  return !handled && alive && isCurrent;
+}
 
 /** Resolve the LOCAL monitor base URL (no path). */
 function localMonitorBase(env: Record<string, string | undefined>): string {
@@ -94,12 +130,14 @@ export function useAccountModel(): AccountStripSignal | null {
         return;
       }
       es = src;
+      let handled = false; // true once onerror has already handled this src's end
       src.addEventListener("account", (ev) => {
         backoff = INITIAL_BACKOFF_MS; // reset on a real frame
         const next = decodeAccountFrame(ev.data);
         if (next && alive) setSignal(next);
       });
       src.onerror = () => {
+        handled = true;
         // One-shot reader errored (monitor restart / stream drop) — close and
         // reconnect with capped backoff so the strip resumes updating.
         try {
@@ -110,6 +148,22 @@ export function useAccountModel(): AccountStripSignal | null {
         if (es === src) es = null;
         scheduleReconnect();
       };
+      // A CLEAN end-of-stream never fires onerror (see shouldReconnectOnIdle's
+      // doc comment) — without this, the strip freezes forever the first time
+      // the local monitor restarts gracefully instead of dropping the
+      // connection with an error. onerror (when it fires) always completes
+      // synchronously before whenIdle() resolves, so `handled` is accurate by
+      // the time this runs.
+      void src
+        .whenIdle()
+        .then(() => {
+          if (!shouldReconnectOnIdle({ handled, alive, isCurrent: es === src })) return;
+          es = null;
+          scheduleReconnect();
+        })
+        .catch(() => {
+          /* whenIdle() never rejects in practice; defensive no-op */
+        });
     }
 
     void reconcile();

--- a/plugins/dev/scripts/orch-monitor/lib/__tests__/accounts-probe.test.mjs
+++ b/plugins/dev/scripts/orch-monitor/lib/__tests__/accounts-probe.test.mjs
@@ -236,6 +236,74 @@ describe("defaultAccountsProbeExec (secrets hygiene)", () => {
     expect(typeof r.generatedAt).toBe("string");
     expect(r.available).toBe(false);
   });
+  it("treats an EXISTING but empty env file as unavailable, no probe spawned (CTL-1653 Codex round-2)", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "accounts-env-empty-"));
+    const envFile = join(dir, "claude-accounts.env");
+    writeFileSync(envFile, "");
+    const stub = join(dir, "should-never-run.mjs");
+    writeFileSync(stub, "process.stdout.write(JSON.stringify({generatedAt:'t',accounts:[]}));");
+    try {
+      const r = await defaultAccountsProbeExec({ envFile, probePath: stub });
+      expect(r.available).toBe(false);
+      expect(r.accounts).toEqual([]);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+  it("treats a placeholder-only env file (every CLAUDE_TOKEN_* still PASTE_TOKEN_HERE) as unavailable", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "accounts-env-placeholder-"));
+    const envFile = join(dir, "claude-accounts.env");
+    writeFileSync(
+      envFile,
+      [
+        "# Catalyst Claude-account tokens — fill these in.",
+        'CLAUDE_TOKEN_acctA=PASTE_TOKEN_HERE  # acctA@x.io',
+        'export CLAUDE_TOKEN_acctB=PASTE_TOKEN_HERE',
+        "",
+      ].join("\n"),
+    );
+    const stub = join(dir, "should-never-run.mjs");
+    writeFileSync(stub, "process.stdout.write(JSON.stringify({generatedAt:'t',accounts:[]}));");
+    try {
+      const r = await defaultAccountsProbeExec({ envFile, probePath: stub });
+      expect(r.available).toBe(false);
+      expect(r.accounts).toEqual([]);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+  it("treats a comments-only env file (no CLAUDE_TOKEN_* line at all) as unavailable", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "accounts-env-comments-only-"));
+    const envFile = join(dir, "claude-accounts.env");
+    writeFileSync(envFile, "# nothing configured yet\n\n");
+    try {
+      const r = await defaultAccountsProbeExec({ envFile });
+      expect(r.available).toBe(false);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+  it("a file with at least one USABLE token entry still spawns the probe (positive control)", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "accounts-env-usable-"));
+    const envFile = join(dir, "claude-accounts.env");
+    writeFileSync(
+      envFile,
+      [
+        'CLAUDE_TOKEN_acctA=PASTE_TOKEN_HERE  # placeholder, still unusable',
+        'CLAUDE_TOKEN_acctB="sk-ant-oat-REAL"  # acctB@x.io — the one usable entry',
+        "",
+      ].join("\n"),
+    );
+    const stub = join(dir, "stub-probe.mjs");
+    writeFileSync(stub, "process.stdout.write(JSON.stringify({generatedAt:'t',accounts:[{label:'acctB',isActive:true}]}));");
+    try {
+      const r = await defaultAccountsProbeExec({ envFile, probePath: stub });
+      expect(r.available).toBeUndefined(); // real probe output — no available:false short-circuit
+      expect(r.accounts[0].label).toBe("acctB");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
   it("preserves the probe's stdout JSON when it exits nonzero (e.g. all accounts invalid)", async () => {
     // CTL-1653 Codex finding: a nonzero exit still writes the token-free record
     // to stdout first; execFileP rejects on nonzero, so the fix must recover
@@ -255,7 +323,13 @@ describe("defaultAccountsProbeExec (secrets hygiene)", () => {
       ].join("\n"),
     );
     const envFile = join(dir, "claude-accounts.env");
-    writeFileSync(envFile, 'CLAUDE_CODE_OAUTH_TOKEN="sk-ant-oat-X"\n');
+    // A CLAUDE_TOKEN_* line makes hasUsableAccountsEnv treat the file as
+    // usable (this fixture isn't testing that gate — the stub reads
+    // CLAUDE_CODE_OAUTH_TOKEN directly, unaffected by this extra line).
+    writeFileSync(
+      envFile,
+      'CLAUDE_TOKEN_ACCTA="sk-ant-oat-X"  # a@x.io\nCLAUDE_CODE_OAUTH_TOKEN="sk-ant-oat-X"\n',
+    );
     try {
       const r = await defaultAccountsProbeExec({ envFile, probePath: stub });
       expect(r.accounts[0].label).toBe("acctA");
@@ -269,7 +343,10 @@ describe("defaultAccountsProbeExec (secrets hygiene)", () => {
     const stub = join(dir, "stub-probe.mjs");
     writeFileSync(stub, ["process.stderr.write('boom');", "process.exit(1);"].join("\n"));
     const envFile = join(dir, "claude-accounts.env");
-    writeFileSync(envFile, 'CLAUDE_CODE_OAUTH_TOKEN="sk-ant-oat-X"\n');
+    writeFileSync(
+      envFile,
+      'CLAUDE_TOKEN_ACCTA="sk-ant-oat-X"  # a@x.io\nCLAUDE_CODE_OAUTH_TOKEN="sk-ant-oat-X"\n',
+    );
     try {
       await expect(defaultAccountsProbeExec({ envFile, probePath: stub })).rejects.toBeTruthy();
     } finally {
@@ -299,7 +376,13 @@ describe("defaultAccountsProbeExec (secrets hygiene)", () => {
       ].join("\n"),
     );
     const envFile = join(dir, "claude-accounts.env");
-    writeFileSync(envFile, 'CLAUDE_CODE_OAUTH_TOKEN="sk-ant-oat-SOURCED"\n');
+    // A CLAUDE_TOKEN_* line makes hasUsableAccountsEnv treat the file as
+    // usable; the stub reads CLAUDE_CODE_OAUTH_TOKEN directly (the sourcing
+    // mechanism under test), unaffected by this extra line.
+    writeFileSync(
+      envFile,
+      'CLAUDE_TOKEN_STUB="sk-ant-oat-SOURCED"  # stub@x.io\nCLAUDE_CODE_OAUTH_TOKEN="sk-ant-oat-SOURCED"\n',
+    );
 
     // Ambient token in THIS process's env — the strip must remove it from the child so
     // the sourced file is the sole authority; and it must remain in the parent unchanged.

--- a/plugins/dev/scripts/orch-monitor/lib/__tests__/accounts-probe.test.mjs
+++ b/plugins/dev/scripts/orch-monitor/lib/__tests__/accounts-probe.test.mjs
@@ -6,6 +6,7 @@ import {
   deriveAccountsSummary,
   createAccountsProbe,
   defaultAccountsProbeExec,
+  resolveRuntime,
 } from "../accounts-probe.mjs";
 
 const REJECTED_ACTIVE = {
@@ -315,5 +316,49 @@ describe("defaultAccountsProbeExec (secrets hygiene)", () => {
       else process.env.CLAUDE_CODE_OAUTH_TOKEN = prior;
       rmSync(dir, { recursive: true, force: true });
     }
+  });
+});
+
+describe("resolveRuntime (CTL-1653 Codex round-2: never the bare 'bun' command name)", () => {
+  it("prefers this process's own Bun executable (process.execPath) when running under bun", () => {
+    // The round-1 fix detected bun's PRESENCE correctly but still returned the
+    // literal string "bun" — a launchd/mise-managed monitor launched via an
+    // absolute Bun path on a restricted PATH has no `bun` command to resolve,
+    // so the bare name exits command-not-found in the probe's bash -c child.
+    expect(
+      resolveRuntime({ isBun: true, execPath: "/opt/homebrew/opt/bun/bin/bun" }),
+    ).toBe("/opt/homebrew/opt/bun/bin/bun");
+  });
+  it("falls back to an ABSOLUTE PATH-resolved bun (not a bare name) when not running under bun", () => {
+    expect(
+      resolveRuntime({
+        isBun: false,
+        resolveOnPath: (bin) => (bin === "bun" ? "/usr/local/bin/bun" : null),
+      }),
+    ).toBe("/usr/local/bin/bun");
+  });
+  it("falls back to the historical ~/.bun/bin/bun default-install path", () => {
+    expect(
+      resolveRuntime({
+        isBun: false,
+        resolveOnPath: () => null,
+        bunHomeExists: true,
+        bunHomeDefault: "/Users/x/.bun/bin/bun",
+      }),
+    ).toBe("/Users/x/.bun/bin/bun");
+  });
+  it("falls back to node (bare name, last resort) when bun is nowhere to be found", () => {
+    expect(
+      resolveRuntime({ isBun: false, resolveOnPath: () => null, bunHomeExists: false }),
+    ).toBe("node");
+  });
+  it("module default resolves to a real string given the actual test host (sanity)", () => {
+    // No overrides: exercises the real typeof Bun / PATH / homedir detection.
+    // Under `bun test` this process IS bun, so it must be process.execPath —
+    // an absolute path, never the bare literal "bun".
+    const rt = resolveRuntime();
+    expect(typeof rt).toBe("string");
+    expect(rt).not.toBe("bun");
+    expect(rt.startsWith("/")).toBe(true);
   });
 });

--- a/plugins/dev/scripts/orch-monitor/lib/accounts-probe.d.mts
+++ b/plugins/dev/scripts/orch-monitor/lib/accounts-probe.d.mts
@@ -76,3 +76,16 @@ export declare function createAccountsProbe(opts: {
   now?: () => number;
   node?: string;
 }): AccountsProbe;
+
+/**
+ * resolveRuntime — the CHILD runtime path used to run the probe (CTL-1653
+ * round-2). Always an absolute path when bun is chosen; "node" (bare) as the
+ * last resort. All inputs injectable — see accounts-probe.mjs's doc comment.
+ */
+export declare function resolveRuntime(opts?: {
+  isBun?: boolean;
+  execPath?: string;
+  resolveOnPath?: (bin: string) => string | null;
+  bunHomeDefault?: string;
+  bunHomeExists?: boolean;
+}): string;

--- a/plugins/dev/scripts/orch-monitor/lib/accounts-probe.d.ts
+++ b/plugins/dev/scripts/orch-monitor/lib/accounts-probe.d.ts
@@ -76,3 +76,16 @@ export declare function createAccountsProbe(opts: {
   now?: () => number;
   node?: string;
 }): AccountsProbe;
+
+/**
+ * resolveRuntime — the CHILD runtime path used to run the probe (CTL-1653
+ * round-2). Always an absolute path when bun is chosen; "node" (bare) as the
+ * last resort. All inputs injectable — see accounts-probe.mjs's doc comment.
+ */
+export declare function resolveRuntime(opts?: {
+  isBun?: boolean;
+  execPath?: string;
+  resolveOnPath?: (bin: string) => string | null;
+  bunHomeDefault?: string;
+  bunHomeExists?: boolean;
+}): string;

--- a/plugins/dev/scripts/orch-monitor/lib/accounts-probe.mjs
+++ b/plugins/dev/scripts/orch-monitor/lib/accounts-probe.mjs
@@ -37,27 +37,69 @@ const ENV_FILE =
   process.env.CLAUDE_ACCOUNTS_ENV ?? resolve(homedir(), ".config/catalyst/claude-accounts.env");
 
 // resolveOnPath — mirrors catalyst-stack's `_ca_node_runtime` (`command -v bun`):
-// scan $PATH for the binary rather than assuming one fixed install location.
+// scan $PATH for the binary and return its ABSOLUTE path (not a bare command
+// name) — see resolveRuntime's doc comment for why the bare name is unsafe.
 function resolveOnPath(bin) {
   for (const dir of (process.env.PATH ?? "").split(":")) {
-    if (dir && existsSync(resolve(dir, bin))) return true;
+    if (!dir) continue;
+    const candidate = resolve(dir, bin);
+    if (existsSync(candidate)) return candidate;
   }
-  return false;
+  return null;
 }
-// The CHILD runtime that runs the probe: bun else node — mirrors catalyst-stack's
-// _ca_node_runtime choice. The probe is pure node:* + fetch, so either runs it.
-// Preference order: (1) this process's OWN runtime — when the monitor itself is
-// running under bun, bun is proven present regardless of where it is installed;
-// (2) `bun` resolved from PATH (the _ca_node_runtime parity check, catches a
-// Homebrew/managed install this process happens not to be running under); (3)
-// the historical `~/.bun/bin/bun` default-install check, kept for back-compat;
-// (4) node.
-const RUNTIME =
-  typeof Bun !== "undefined" ||
-  resolveOnPath("bun") ||
-  existsSync(resolve(homedir(), ".bun/bin/bun"))
-    ? "bun"
-    : "node";
+
+const BUN_HOME_DEFAULT = resolve(homedir(), ".bun/bin/bun");
+
+/**
+ * resolveRuntime — the CHILD runtime that runs the probe. ALWAYS an absolute
+ * path when bun is the choice, never the bare `bun` command name: the bash -c
+ * subshell this spawns into (defaultAccountsProbeExec, below) inherits this
+ * process's PATH, but a launchd/mise-managed monitor can be launched via an
+ * ABSOLUTE Bun path on a restricted PATH that omits bun's own directory — the
+ * bare command name then exits command-not-found in the child and every real
+ * probe degrades to a spawn/error posture (CTL-1653 Codex round-2 finding: the
+ * round-1 fix detected bun's PRESENCE correctly but still returned the literal
+ * string "bun" instead of a usable path).
+ *
+ * Preference order, each one proven independently of the others:
+ *   (1) this process's OWN Bun executable (`process.execPath`) — when the
+ *       monitor itself is running under bun, this is proven valid regardless
+ *       of PATH;
+ *   (2) `bun` resolved from PATH, as an absolute path (mirrors catalyst-stack's
+ *       `_ca_node_runtime` / `command -v bun` — catches a Homebrew/managed
+ *       install this process happens not to be running under);
+ *   (3) the historical `~/.bun/bin/bun` default-install path, kept for
+ *       back-compat;
+ *   (4) `node` (bare command name; last resort — mirrors catalyst-stack's own
+ *       node fallback, which is also a bare name).
+ *
+ * All five inputs are injectable so every branch is independently testable
+ * without depending on whether THIS test process happens to be running under
+ * bun (it always is, under `bun test`) or what the test host's PATH contains.
+ *
+ * @param {object} [o]
+ * @param {boolean}  [o.isBun]         default: typeof Bun !== "undefined"
+ * @param {string}   [o.execPath]      default: process.execPath
+ * @param {Function} [o.resolveOnPath] default: the module's own PATH scanner
+ * @param {string}   [o.bunHomeDefault] default: BUN_HOME_DEFAULT
+ * @param {boolean}  [o.bunHomeExists] default: existsSync(BUN_HOME_DEFAULT)
+ * @returns {string}
+ */
+export function resolveRuntime({
+  isBun = typeof Bun !== "undefined",
+  execPath = process.execPath,
+  resolveOnPath: resolveOnPathFn = resolveOnPath,
+  bunHomeDefault = BUN_HOME_DEFAULT,
+  bunHomeExists = existsSync(BUN_HOME_DEFAULT),
+} = {}) {
+  if (isBun) return execPath;
+  const onPath = resolveOnPathFn("bun");
+  if (onPath) return onPath;
+  if (bunHomeExists) return bunHomeDefault;
+  return "node";
+}
+
+const RUNTIME = resolveRuntime();
 
 /**
  * defaultAccountsProbeExec — run the CTL-1650 probe in a subshell that sources the

--- a/plugins/dev/scripts/orch-monitor/lib/accounts-probe.mjs
+++ b/plugins/dev/scripts/orch-monitor/lib/accounts-probe.mjs
@@ -19,7 +19,7 @@
 
 import { execFile } from "node:child_process";
 import { promisify } from "node:util";
-import { existsSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { resolve, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -101,12 +101,63 @@ export function resolveRuntime({
 
 const RUNTIME = resolveRuntime();
 
+// The token-assignment line shape the env-file contract defines (mirrors
+// claude-accounts-usage.mjs's parseAccountsEnv regex byte-for-byte — see that
+// file's SECRETS HYGIENE header comment for the full contract).
+const CLAUDE_TOKEN_LINE_RE = /^(?:export\s+)?CLAUDE_TOKEN_[A-Za-z0-9_]+=(.*)$/;
+const PASTE_TOKEN_PLACEHOLDER = "PASTE_TOKEN_HERE";
+
+/**
+ * hasUsableAccountsEnv — cheap parse: does this env file define at least one
+ * non-empty, non-placeholder `CLAUDE_TOKEN_<label>=…` entry? The env-file
+ * contract (claude-accounts-usage.mjs's parseAccountsEnv, and its own exit-1
+ * "No CLAUDE_TOKEN_* tokens found" message) treats a file that exists but has
+ * no USABLE entry the same as an absent file — this mirrors that regex + the
+ * same placeholder skip so this check agrees with what the probe itself would
+ * find (CTL-1653 Codex round-2 finding: existence alone let an empty or
+ * placeholder-only file still spawn the probe, which then exits nonzero with
+ * no JSON and surfaced as available:true/status:"error" instead of the
+ * documented available:false contract).
+ *
+ * SECRETS HYGIENE: a candidate token value is held in a local var only long
+ * enough to test truthiness/placeholder-equality (identical discipline to
+ * parseAccountsEnv itself) — it is never logged, stored beyond this function,
+ * or returned.
+ */
+function hasUsableAccountsEnv(envFile) {
+  let raw;
+  try {
+    raw = readFileSync(envFile, "utf8");
+  } catch {
+    return false; // unreadable — existsSync already gated the ENOENT case above
+  }
+  for (const line of raw.split("\n")) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith("#")) continue;
+    const m = trimmed.match(CLAUDE_TOKEN_LINE_RE);
+    if (!m) continue;
+    const rhs = m[1].trimStart();
+    const q = rhs[0];
+    const token =
+      q === "'" || q === '"'
+        ? (() => {
+            const end = rhs.indexOf(q, 1);
+            return end === -1 ? rhs.slice(1) : rhs.slice(1, end);
+          })()
+        : (rhs.match(/^(\S+)/)?.[1] ?? "");
+    if (token && token !== PASTE_TOKEN_PLACEHOLDER) return true;
+  }
+  return false;
+}
+
 /**
  * defaultAccountsProbeExec — run the CTL-1650 probe in a subshell that sources the
  * accounts env so CLAUDE_CODE_OAUTH_TOKEN is visible for active-account detection
  * and never enters this (long-lived monitor) process's env. Returns the token-free
- * JSON record ({generatedAt, accounts:[…]}). When no env file exists, returns an
- * empty `available:false` record so the surfaces render "unavailable"/quiet rather
+ * JSON record ({generatedAt, accounts:[…]}). When no env file exists — OR one
+ * exists but defines no usable CLAUDE_TOKEN_* entry (empty file, comments-only,
+ * every entry still the PASTE_TOKEN_HERE placeholder) — returns an empty
+ * `available:false` record so the surfaces render "unavailable"/quiet rather
  * than erroring (deriveAccountsSummary propagates the flag; see below). When the
  * probe exits nonzero (e.g. every configured account is invalid/auth-failing), the
  * token-free JSON it already wrote to stdout is recovered from the rejected exec's
@@ -122,7 +173,7 @@ export async function defaultAccountsProbeExec({
   probePath = PROBE,
   runtime = RUNTIME,
 } = {}) {
-  if (!existsSync(envFile)) {
+  if (!existsSync(envFile) || !hasUsableAccountsEnv(envFile)) {
     return { generatedAt: new Date().toISOString(), accounts: [], available: false };
   }
   // `set -a` exports every sourced var to the exec'd child only; the token dies

--- a/plugins/dev/scripts/orch-monitor/server.ts
+++ b/plugins/dev/scripts/orch-monitor/server.ts
@@ -622,6 +622,13 @@ export interface CreateServerOptions {
 }
 
 const DEFAULT_PORT = 7400;
+/**
+ * CTL-1653 (Codex round-2): the header GET /api/accounts?refresh=true requires,
+ * on top of the trusted-origin allowlist — see that route's CROSS-ORIGIN +
+ * SIMPLE-REQUEST GUARD comment for why a header (not just Origin) is needed.
+ * Exported so tests and docs reference the one canonical name.
+ */
+export const ACCOUNTS_REFRESH_HEADER = "x-catalyst-refresh";
 
 function resolveVersion(): string {
   const candidates = [
@@ -2475,18 +2482,34 @@ export function createServer(opts: CreateServerOptions): BunServer {
         if (url.pathname === "/api/accounts") {
           if (!accountsProbe) return Response.json({ available: false, node: hostName() });
           const refresh = url.searchParams.get("refresh") === "true";
-          // CROSS-ORIGIN GUARD on the state-changing path only. The monitor binds
-          // 0.0.0.0 with no auth, and `refresh=true` is the one per-request probe
-          // trigger — spending a real Haiku call per account (bounded by the
-          // refresh floor, but not to zero). Without this, any page the operator
-          // visits could drive it repeatedly. Same allowlist as the reply route
-          // (lib/trusted-origin.mjs); an absent Origin (non-browser callers) is
-          // allowed — see isOriginAllowed's doc comment.
-          if (refresh && !originAllowed(req.headers.get("origin"))) {
-            return Response.json(
-              { status: "forbidden", error: "cross-origin refresh rejected" },
-              { status: 403 },
-            );
+          // CROSS-ORIGIN + SIMPLE-REQUEST GUARD on the state-changing path only.
+          // The monitor binds 0.0.0.0 with no auth, and `refresh=true` is the one
+          // per-request probe trigger — spending a real Haiku call per account
+          // (bounded by the refresh floor, but not to zero).
+          //
+          // The origin allowlist alone (originAllowed, same as the Linear-reply
+          // route) does NOT close this: this route is a GET, and browsers omit
+          // `Origin` on a SIMPLE cross-site request — a bare `<img
+          // src="...?refresh=true">`, a top-level navigation, or a plain <form>
+          // GET carries no Origin at all, and originAllowed(null) is (correctly,
+          // for the POST-route contract that guard was designed for) permissive
+          // (CTL-1653 Codex round-2 finding). Requiring this NON-STANDARD header
+          // closes that class of vector structurally rather than by allowlist:
+          // none of those simple-request mechanisms can ever attach a custom
+          // header, and a cross-origin fetch()/XHR that tried to would trigger a
+          // CORS preflight this server does not answer for arbitrary origins, so
+          // the browser never sends the real request. curl/non-browser callers
+          // stay usable by passing the header explicitly (documented in
+          // orch-monitor-api.md) — Origin remains permissively absent for them,
+          // same as before.
+          if (refresh) {
+            const hasRefreshHeader = req.headers.get(ACCOUNTS_REFRESH_HEADER) !== null;
+            if (!hasRefreshHeader || !originAllowed(req.headers.get("origin"))) {
+              return Response.json(
+                { status: "forbidden", error: "cross-origin refresh rejected" },
+                { status: 403 },
+              );
+            }
           }
           const summary = await accountsProbe.get({ refresh });
           return Response.json({ available: true, ...summary });

--- a/plugins/dev/scripts/orch-monitor/ui/src/hooks/__tests__/account-signal-decode.test.ts
+++ b/plugins/dev/scripts/orch-monitor/ui/src/hooks/__tests__/account-signal-decode.test.ts
@@ -2,6 +2,8 @@ import { describe, it, expect } from "bun:test";
 import {
   decodeAccountSignalFrame,
   isAccountSignal,
+  isAccountUnavailable,
+  accountFrameAction,
   accountIndicatorLabel,
   bannerModel,
   type AccountSignal,
@@ -27,6 +29,31 @@ describe("decodeAccountSignalFrame / isAccountSignal", () => {
   });
   it("rejects malformed input → null", () =>
     expect(decodeAccountSignalFrame("not json")).toBeNull());
+});
+
+describe("isAccountUnavailable / accountFrameAction (CTL-1653 Codex stale-strip fix)", () => {
+  it("recognizes the documented {available:false} unavailable contract", () => {
+    expect(isAccountUnavailable({ available: false, node: "mini-2" })).toBe(true);
+  });
+  it("does not confuse a valid signal or garbage with the unavailable contract", () => {
+    expect(isAccountUnavailable({ status: "ok" })).toBe(false);
+    expect(isAccountUnavailable("not an object")).toBe(false);
+    expect(isAccountUnavailable(null)).toBe(false);
+    expect(isAccountUnavailable({ available: true })).toBe(false);
+  });
+  it("accountFrameAction: apply for a valid signal", () => {
+    const action = accountFrameAction({ status: "rejected", active: { label: "acctA" } });
+    expect(action.type).toBe("apply");
+    expect(action.type === "apply" && action.signal.status).toBe("rejected");
+  });
+  it("accountFrameAction: clear for {available:false} — a REAL transition, not noise", () => {
+    expect(accountFrameAction({ available: false, node: "mini-2" })).toEqual({ type: "clear" });
+  });
+  it("accountFrameAction: ignore for garbage/truncated input", () => {
+    expect(accountFrameAction({ garbage: true })).toEqual({ type: "ignore" });
+    expect(accountFrameAction(null)).toEqual({ type: "ignore" });
+    expect(accountFrameAction("a string")).toEqual({ type: "ignore" });
+  });
 });
 
 describe("accountIndicatorLabel (quiet while ok)", () => {

--- a/plugins/dev/scripts/orch-monitor/ui/src/hooks/account-signal-lib.ts
+++ b/plugins/dev/scripts/orch-monitor/ui/src/hooks/account-signal-lib.ts
@@ -72,6 +72,40 @@ export function decodeAccountSignalFrame(data: string): AccountSignal | null {
   }
 }
 
+/**
+ * Structural guard: the documented `{available:false}` unavailable contract
+ * (disabled probe / no-env-file — see lib/accounts-probe.mjs deriveAccountsSummary
+ * and server.ts's /api/accounts). Distinct from `isAccountSignal`'s garbage check —
+ * this is a well-formed, DOCUMENTED response shape, not noise.
+ */
+export function isAccountUnavailable(value: unknown): boolean {
+  if (!value || typeof value !== "object") return false;
+  return (value as Record<string, unknown>).available === false;
+}
+
+/**
+ * What a consumer should do with a raw `/api/accounts` body or SSE `account`
+ * frame payload (already JSON-parsed): apply a valid signal, clear to the
+ * unavailable state, or ignore malformed/garbage input untouched.
+ *
+ * CTL-1653 Codex finding (stale-strip): before this existed, a decode that
+ * returned null for BOTH garbage AND the well-formed `{available:false}` frame
+ * meant callers treated a genuine "probe went unavailable" transition as a
+ * no-op — the footer/banner kept rendering a stale rejected/ok posture forever
+ * once the env file was removed or the probe was disabled. `clear` is the fix:
+ * it is a real state transition, not noise, and must reach the UI.
+ */
+export type AccountFrameAction =
+  | { type: "apply"; signal: AccountSignal }
+  | { type: "clear" }
+  | { type: "ignore" };
+
+export function accountFrameAction(value: unknown): AccountFrameAction {
+  if (isAccountSignal(value)) return { type: "apply", signal: value };
+  if (isAccountUnavailable(value)) return { type: "clear" };
+  return { type: "ignore" };
+}
+
 /** The tone vocabulary shared by the footer indicator + HUD strip. */
 export type AccountTone = "quiet" | "warn" | "loud" | "muted";
 

--- a/plugins/dev/scripts/orch-monitor/ui/src/hooks/use-account-signal.ts
+++ b/plugins/dev/scripts/orch-monitor/ui/src/hooks/use-account-signal.ts
@@ -13,11 +13,7 @@
 // AccountSignalContext so the footer + banner share the same value without opening
 // a second EventSource. Consumers inside AppShell use useAccountSignalContext().
 import { createContext, useContext, useEffect, useState } from "react";
-import {
-  decodeAccountSignalFrame,
-  isAccountSignal,
-  type AccountSignal,
-} from "./account-signal-lib";
+import { accountFrameAction, type AccountSignal } from "./account-signal-lib";
 
 // ── Shared context ────────────────────────────────────────────────────────────
 
@@ -51,8 +47,25 @@ export function useAccountSignal(): AccountSignal | null {
     let reconnectTimer: ReturnType<typeof setTimeout> | undefined;
     let controller: AbortController | undefined;
 
-    const apply = (next: AccountSignal) => {
+    const apply = (next: AccountSignal | null) => {
       if (alive) setSignal(next);
+    };
+
+    // Dispatch a raw (already JSON-parsed) frame/body per accountFrameAction:
+    // apply a valid signal, CLEAR to null on the documented {available:false}
+    // transition (CTL-1653 Codex stale-strip finding — this must reach the UI,
+    // not be dropped like garbage), or ignore malformed input untouched.
+    const dispatch = (raw: unknown): boolean => {
+      const action = accountFrameAction(raw);
+      if (action.type === "apply") {
+        apply(action.signal);
+        return true;
+      }
+      if (action.type === "clear") {
+        apply(null);
+        return true;
+      }
+      return false;
     };
 
     const reconcile = async (): Promise<boolean> => {
@@ -63,10 +76,7 @@ export function useAccountSignal(): AccountSignal | null {
         const r = await fetch("/api/accounts", { signal: controller.signal });
         if (r.ok) {
           const body: unknown = await r.json();
-          if (isAccountSignal(body)) {
-            apply(body);
-            return true;
-          }
+          if (dispatch(body)) return true;
         }
       } catch {
         /* offline — the backoff loop retries */
@@ -92,8 +102,13 @@ export function useAccountSignal(): AccountSignal | null {
       }
       es.addEventListener("account", (ev) => {
         backoff = INITIAL_BACKOFF_MS; // reset on a real frame
-        const next = decodeAccountSignalFrame((ev as MessageEvent).data as string);
-        if (next) apply(next);
+        let parsed: unknown;
+        try {
+          parsed = JSON.parse((ev as MessageEvent).data as string);
+        } catch {
+          return; // truncated/garbage frame — ignore
+        }
+        dispatch(parsed);
       });
       es.onerror = () => {
         try {

--- a/website/src/content/docs/reference/orch-monitor-api.md
+++ b/website/src/content/docs/reference/orch-monitor-api.md
@@ -21,6 +21,13 @@ response** (or in the monitor's own environment).
 - **Cached** (~5 min TTL). Repeated calls within the TTL are served from cache — the same `probedAt`
   is returned and no inference call is spent.
 - **`?refresh=true`** forces a fresh probe (operator-initiated; the only per-request probe path).
+  Requires the `X-Catalyst-Refresh` header (any value) **and** a trusted `Origin` when one is
+  present. The header is what actually stops the vector: this route is a GET, so a browser
+  navigating to (or embedding) the URL directly sends no `Origin` at all, and neither a header-less
+  request nor an untrusted `Origin` is accepted — a plain read (no `refresh`) needs neither.
+  ```bash
+  curl -H "X-Catalyst-Refresh: 1" "http://localhost:7400/api/accounts?refresh=true"
+  ```
 - **Disabled** — on a node with no `claude-accounts.env` (or when the probe is disabled), the
   endpoint returns `{ "available": false, "node": "<host>" }`.
 

--- a/website/src/content/docs/reference/orch-monitor-api.md
+++ b/website/src/content/docs/reference/orch-monitor-api.md
@@ -28,8 +28,10 @@ response** (or in the monitor's own environment).
   ```bash
   curl -H "X-Catalyst-Refresh: 1" "http://localhost:7400/api/accounts?refresh=true"
   ```
-- **Disabled** — on a node with no `claude-accounts.env` (or when the probe is disabled), the
-  endpoint returns `{ "available": false, "node": "<host>" }`.
+- **Disabled** — on a node with no `claude-accounts.env` (missing entirely, empty, or defining no
+  usable `CLAUDE_TOKEN_*` entry — every entry still the `PASTE_TOKEN_HERE` placeholder counts as
+  none), or when the probe is disabled, the endpoint returns
+  `{ "available": false, "node": "<host>" }`.
 
 ```json
 {


### PR DESCRIPTION
## Summary

Remediates all 5 findings from Codex's post-merge round on #3011 (the CTL-1653 accounts posture API + dashboard strip):

1. **Stale strip on unavailable frames**: `{available:false}` frames (env removed / probe disabled) were decoded to null and ignored once a real posture had rendered — the strip froze on stale data forever. Frames now route through a discriminated apply/clear/ignore action; the clear path blanks the strip.
2. **Bun runtime resolution**: detection was correct but returned the literal `bun`, which fails on launchd/mise installs where the daemon PATH lacks it. Now `process.execPath` when running under Bun (always absolute), else absolute PATH-resolved bun, else `~/.bun/bin/bun`, else node — all branches injectable and tested.
3. **Origin-less GET bypass on `refresh=true`**: browsers omit Origin on simple requests (`<img>`, top-level nav), and the origin allowlist admits absent-Origin by design — so the inference-spending refresh was triggerable cross-site. Now additionally requires the `x-catalyst-refresh` custom header: simple requests can't attach it, cross-origin `fetch()` would need a CORS preflight this server never grants, curl stays usable (documented).
4. **Permanent stale strip after clean EOF**: `createNodeEventSource` resolves `whenIdle()` on graceful stream end without firing `onerror`, and reconnect only scheduled from `onerror` — a monitor restart froze the HUD strip. Clean EOF now schedules reconnect via an extracted, tested decision function (with double-schedule protection when a real error also settles idle).
5. **Empty/placeholder env files**: availability tested file EXISTENCE only; an empty or all-`PASTE_TOKEN_HERE` file spawned a doomed probe and surfaced `available:true/status:error` instead of the documented `available:false`. A cheap usable-entry parse (mirroring the usage tool's own regex + placeholder skip byte-for-byte; values never logged) now short-circuits to unavailable.

## Testing

Targeted suites 84/84 (183 expects); tsc clean; knip clean; eslint 0 errors (one new `detect-unsafe-regex` warning judged a false positive — the regex is structurally identical to the usage tool's own, no nested quantifiers; left unsuppressed consistent with the codebase's existing warning posture). Full-repo `bun test` delta verified zero (same pre-existing config-loading failures + one root-caused flaky SSE timing test on clean checkout).

🤖 Generated with [Claude Code](https://claude.com/claude-code)