### PR TITLE
fix(monitor): CTL-1653 post-merge hardening r3 — unavailable transition, Host validation, unreadable-env error

### DIFF
--- a/plugins/dev/scripts/orch-monitor/__tests__/accounts-endpoint.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/accounts-endpoint.test.ts
@@ -126,6 +126,32 @@ describe("/api/accounts", () => {
     });
     expect(r.status).toBe(200);
   });
+  it("a DNS-rebinding-shaped request (foreign Host, header present, no Origin) is rejected (403)", async () => {
+    // CTL-1653 Codex round-3: a page loaded as http://evil.example:<port> that
+    // later re-resolves to THIS server's IP is same-origin to the browser once
+    // rebound — its JS can attach the refresh header with no CORS preflight,
+    // and a same-origin fetch isn't guaranteed to carry Origin either (which
+    // originAllowed(null) would otherwise admit). The Host header is what the
+    // browser's own HTTP stack sets from the page's URL — the attacker's
+    // domain, not this server's real name — so it must be checked too. Same
+    // physical connection (127.0.0.1/localhost) as every other test here, but
+    // an untrusted Host is exactly what a rebound browser would send.
+    const before = calls;
+    const r = await fetch(`${base}/api/accounts?refresh=true`, {
+      headers: { [ACCOUNTS_REFRESH_HEADER]: "1", Host: "evil.example:1234" },
+    });
+    expect(r.status).toBe(403);
+    expect(calls).toBe(before); // no probe spawned
+  });
+  it("a request with the REAL Host (localhost:<port>) + the header succeeds (positive control)", async () => {
+    const before = calls;
+    const port = new URL(base).port;
+    const r = await fetch(`${base}/api/accounts?refresh=true`, {
+      headers: { [ACCOUNTS_REFRESH_HEADER]: "1", Host: `localhost:${port}` },
+    });
+    expect(r.status).toBe(200);
+    expect(calls).toBe(before + 1);
+  });
 });
 
 describe("/api/accounts when the accounts env file is absent", () => {

--- a/plugins/dev/scripts/orch-monitor/cli/hooks/useAccountModel.test.ts
+++ b/plugins/dev/scripts/orch-monitor/cli/hooks/useAccountModel.test.ts
@@ -9,7 +9,7 @@
 // hook is built from, adjacent to the source so drift is obvious in review.
 
 import { describe, test, expect } from "bun:test";
-import { shouldReconnectOnIdle } from "./useAccountModel";
+import { shouldReconnectOnIdle, accountFrameAction } from "./useAccountModel";
 import { createNodeEventSource } from "../lib/node-event-source";
 
 describe("shouldReconnectOnIdle (CTL-1653 Codex round-2: clean-EOF reconnect)", () => {
@@ -41,6 +41,26 @@ function fetchStreamingThenCloseCleanly(chunks: string[]): typeof fetch {
     return Promise.resolve(new Response(stream, { status: 200 }));
   }) as unknown as typeof fetch;
 }
+
+describe("accountFrameAction (CTL-1653 Codex round-3: HUD clears on unavailable, mirrors the web fix)", () => {
+  test("apply for a valid posture frame", () => {
+    const action = accountFrameAction({ status: "rejected", active: { label: "acctA" } });
+    expect(action.type).toBe("apply");
+    expect(action.type === "apply" && action.signal.status).toBe("rejected");
+  });
+  test("clear for {available:false} — a REAL transition the strip must react to, not noise", () => {
+    // Before this fix, the HUD's decode returned null for this shape (same as
+    // garbage) and the caller only called setSignal on a non-null value, so an
+    // already-open HUD kept showing the PREVIOUS posture forever after the
+    // node's env file was emptied/reset-to-placeholders.
+    expect(accountFrameAction({ available: false, node: "mini-2" })).toEqual({ type: "clear" });
+  });
+  test("ignore for garbage/truncated input", () => {
+    expect(accountFrameAction({ garbage: true })).toEqual({ type: "ignore" });
+    expect(accountFrameAction(null)).toEqual({ type: "ignore" });
+    expect(accountFrameAction("a string")).toEqual({ type: "ignore" });
+  });
+});
 
 describe("createNodeEventSource: the gap shouldReconnectOnIdle exists to close", () => {
   test("a clean end-of-stream resolves whenIdle() WITHOUT ever invoking onerror", async () => {

--- a/plugins/dev/scripts/orch-monitor/cli/hooks/useAccountModel.ts
+++ b/plugins/dev/scripts/orch-monitor/cli/hooks/useAccountModel.ts
@@ -69,17 +69,34 @@ function localMonitorBase(env: Record<string, string | undefined>): string {
   return `http://127.0.0.1:${port}`;
 }
 
-/** Decode an `account` SSE frame; null on garbage or a non-posture (available:false) frame. */
-function decodeAccountFrame(data: string): AccountStripSignal | null {
-  try {
-    const parsed: unknown = JSON.parse(data);
-    if (!parsed || typeof parsed !== "object") return null;
-    const p = parsed as Record<string, unknown>;
-    if (typeof p.status !== "string") return null; // e.g. {available:false} → no posture
-    return p as unknown as AccountStripSignal;
-  } catch {
-    return null;
+/**
+ * What to do with a raw (already JSON.parse'd) `/api/accounts` body or SSE
+ * `account` frame payload: apply a valid posture, CLEAR to unavailable, or
+ * ignore malformed/garbage input untouched.
+ *
+ * MIRROR of ui/src/hooks/account-signal-lib.ts's `accountFrameAction` — same
+ * three-way contract, hand-synced per this file's cli/lib mirroring
+ * convention (see account-strip.ts's "MIRROR, not import" note: the cli
+ * bundle never reaches into ui/src). CTL-1653 Codex round-3 finding: before
+ * this existed, the HUD's decode returned null for BOTH garbage AND the
+ * documented `{available:false}` frame, so an already-open HUD kept showing
+ * a stale posture after a node's env file was emptied/reset-to-placeholders
+ * instead of clearing — the round-2 fix closed this gap on the web dashboard
+ * (accountFrameAction) but missed the HUD's separate decode path.
+ */
+export type AccountFrameAction =
+  | { type: "apply"; signal: AccountStripSignal }
+  | { type: "clear" }
+  | { type: "ignore" };
+
+export function accountFrameAction(value: unknown): AccountFrameAction {
+  if (!value || typeof value !== "object") return { type: "ignore" };
+  const p = value as Record<string, unknown>;
+  if (typeof p.status === "string") {
+    return { type: "apply", signal: p as unknown as AccountStripSignal };
   }
+  if (p.available === false) return { type: "clear" };
+  return { type: "ignore" };
 }
 
 /**
@@ -97,6 +114,19 @@ export function useAccountModel(): AccountStripSignal | null {
     let backoff = INITIAL_BACKOFF_MS;
     let reconnectTimer: ReturnType<typeof setTimeout> | undefined;
 
+    const applySignal = (next: AccountStripSignal | null) => {
+      if (alive) setSignal(next);
+    };
+
+    // Dispatch a raw (already JSON-parsed) frame/body per accountFrameAction:
+    // apply a valid posture, CLEAR to unavailable (a REAL transition, not
+    // noise — must reach the strip), or ignore malformed input untouched.
+    const dispatch = (raw: unknown) => {
+      const action = accountFrameAction(raw);
+      if (action.type === "apply") applySignal(action.signal);
+      else if (action.type === "clear") applySignal(null);
+    };
+
     // Snapshot from /api/accounts so the strip populates immediately (and re-seeds
     // after a drop), not only on the next stream frame. Best-effort.
     const reconcile = async () => {
@@ -104,8 +134,7 @@ export function useAccountModel(): AccountStripSignal | null {
         const r = await fetch(`${base}/api/accounts`);
         if (r.ok && alive) {
           const body: unknown = await r.json();
-          const s = decodeAccountFrame(JSON.stringify(body));
-          if (s && alive) setSignal(s);
+          dispatch(body);
         }
       } catch {
         /* offline — the stream (or a later snapshot) will populate it */
@@ -133,8 +162,13 @@ export function useAccountModel(): AccountStripSignal | null {
       let handled = false; // true once onerror has already handled this src's end
       src.addEventListener("account", (ev) => {
         backoff = INITIAL_BACKOFF_MS; // reset on a real frame
-        const next = decodeAccountFrame(ev.data);
-        if (next && alive) setSignal(next);
+        let parsed: unknown;
+        try {
+          parsed = JSON.parse(ev.data);
+        } catch {
+          return; // truncated/garbage frame — ignore
+        }
+        dispatch(parsed);
       });
       src.onerror = () => {
         handled = true;

--- a/plugins/dev/scripts/orch-monitor/lib/__tests__/accounts-probe.test.mjs
+++ b/plugins/dev/scripts/orch-monitor/lib/__tests__/accounts-probe.test.mjs
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "bun:test";
-import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
+import { mkdtempSync, writeFileSync, chmodSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
@@ -280,6 +280,45 @@ describe("defaultAccountsProbeExec (secrets hygiene)", () => {
       const r = await defaultAccountsProbeExec({ envFile });
       expect(r.available).toBe(false);
     } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+  it("an UNREADABLE (permission-denied) env file THROWS instead of looking disabled (CTL-1653 Codex round-3)", async () => {
+    // Root ignores file-mode permission bits, so chmod 000 doesn't actually
+    // block root's own read — skip gracefully rather than false-fail in a
+    // root-run CI container.
+    if (typeof process.getuid === "function" && process.getuid() === 0) return;
+    const dir = mkdtempSync(join(tmpdir(), "accounts-env-unreadable-"));
+    const envFile = join(dir, "claude-accounts.env");
+    writeFileSync(envFile, 'CLAUDE_TOKEN_ACCTA="sk-ant-oat-X"  # a@x.io\n');
+    chmodSync(envFile, 0o000);
+    try {
+      // A real misconfiguration (broken perms/ownership) must surface as an
+      // error, NOT be swallowed into the same available:false shape as a
+      // genuinely absent/empty/placeholder-only file — that would hide the
+      // permission problem from an operator entirely.
+      await expect(defaultAccountsProbeExec({ envFile })).rejects.toBeTruthy();
+    } finally {
+      chmodSync(envFile, 0o600); // restore so rmSync can clean up
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+  it("that same unreadable-file error becomes the usual status:\"error\" posture through the cache (not available:false)", async () => {
+    if (typeof process.getuid === "function" && process.getuid() === 0) return;
+    const dir = mkdtempSync(join(tmpdir(), "accounts-env-unreadable-cache-"));
+    const envFile = join(dir, "claude-accounts.env");
+    writeFileSync(envFile, 'CLAUDE_TOKEN_ACCTA="sk-ant-oat-X"  # a@x.io\n');
+    chmodSync(envFile, 0o000);
+    try {
+      const exec = () => defaultAccountsProbeExec({ envFile });
+      const p = createAccountsProbe({ exec, ttlMs: 5000, now: () => 1000, node: "n" });
+      const r = await p.get();
+      // createAccountsProbe.runProbe()'s existing catch synthesizes THIS shape
+      // for any exec() rejection — reused as-is, not a new error contract.
+      expect(r.status).toBe("error");
+      expect(r.available).toBeUndefined(); // never silently "disabled"
+    } finally {
+      chmodSync(envFile, 0o600);
       rmSync(dir, { recursive: true, force: true });
     }
   });

--- a/plugins/dev/scripts/orch-monitor/lib/accounts-probe.mjs
+++ b/plugins/dev/scripts/orch-monitor/lib/accounts-probe.mjs
@@ -123,13 +123,27 @@ const PASTE_TOKEN_PLACEHOLDER = "PASTE_TOKEN_HERE";
  * enough to test truthiness/placeholder-equality (identical discipline to
  * parseAccountsEnv itself) — it is never logged, stored beyond this function,
  * or returned.
+ *
+ * THROWS on a read failure that is NOT "the file is gone" (permission denied,
+ * ownership, or any other I/O error) — CTL-1653 Codex round-3 finding: an
+ * unreadable-but-present file (broken permissions/ownership on a real secret
+ * deployment) must surface as a probe ERROR, not silently look like the same
+ * "intentionally disabled" state as a genuinely absent/empty file. The throw
+ * propagates out of defaultAccountsProbeExec (below) uncaught, so
+ * createAccountsProbe's existing runProbe() catch synthesizes the SAME
+ * status:"error" posture it already builds for any other exec() failure —
+ * reusing that machinery rather than inventing a second error shape.
  */
 function hasUsableAccountsEnv(envFile) {
   let raw;
   try {
     raw = readFileSync(envFile, "utf8");
-  } catch {
-    return false; // unreadable — existsSync already gated the ENOENT case above
+  } catch (err) {
+    // ENOENT here (vs. the existsSync gate above) is a benign TOCTOU race —
+    // the file vanished between the two checks — and is still "absent".
+    // Anything else (EACCES, EPERM, ownership, …) is a real misconfiguration.
+    if (err?.code === "ENOENT") return false;
+    throw err;
   }
   for (const line of raw.split("\n")) {
     const trimmed = line.trim();
@@ -159,10 +173,14 @@ function hasUsableAccountsEnv(envFile) {
  * every entry still the PASTE_TOKEN_HERE placeholder) — returns an empty
  * `available:false` record so the surfaces render "unavailable"/quiet rather
  * than erroring (deriveAccountsSummary propagates the flag; see below). When the
- * probe exits nonzero (e.g. every configured account is invalid/auth-failing), the
- * token-free JSON it already wrote to stdout is recovered from the rejected exec's
- * `.stdout` rather than discarded — otherwise a diagnosable per-account auth error
- * collapses into a synthetic unlabeled spawn-error posture.
+ * file EXISTS but is unreadable (permission/ownership — a real misconfiguration,
+ * not an intentional disabled state), THROWS instead — see hasUsableAccountsEnv's
+ * doc comment; the caller's createAccountsProbe.runProbe() catch turns that into
+ * the usual status:"error" posture. When the probe exits nonzero (e.g. every
+ * configured account is invalid/auth-failing), the token-free JSON it already
+ * wrote to stdout is recovered from the rejected exec's `.stdout` rather than
+ * discarded — otherwise a diagnosable per-account auth error collapses into a
+ * synthetic unlabeled spawn-error posture.
  */
 export async function defaultAccountsProbeExec({
   envFile = ENV_FILE,

--- a/plugins/dev/scripts/orch-monitor/server.ts
+++ b/plugins/dev/scripts/orch-monitor/server.ts
@@ -2482,10 +2482,11 @@ export function createServer(opts: CreateServerOptions): BunServer {
         if (url.pathname === "/api/accounts") {
           if (!accountsProbe) return Response.json({ available: false, node: hostName() });
           const refresh = url.searchParams.get("refresh") === "true";
-          // CROSS-ORIGIN + SIMPLE-REQUEST GUARD on the state-changing path only.
-          // The monitor binds 0.0.0.0 with no auth, and `refresh=true` is the one
-          // per-request probe trigger — spending a real Haiku call per account
-          // (bounded by the refresh floor, but not to zero).
+          // CROSS-ORIGIN + SIMPLE-REQUEST + DNS-REBINDING GUARD on the
+          // state-changing path only. The monitor binds 0.0.0.0 with no auth,
+          // and `refresh=true` is the one per-request probe trigger — spending
+          // a real Haiku call per account (bounded by the refresh floor, but
+          // not to zero).
           //
           // The origin allowlist alone (originAllowed, same as the Linear-reply
           // route) does NOT close this: this route is a GET, and browsers omit
@@ -2494,17 +2495,31 @@ export function createServer(opts: CreateServerOptions): BunServer {
           // GET carries no Origin at all, and originAllowed(null) is (correctly,
           // for the POST-route contract that guard was designed for) permissive
           // (CTL-1653 Codex round-2 finding). Requiring this NON-STANDARD header
-          // closes that class of vector structurally rather than by allowlist:
-          // none of those simple-request mechanisms can ever attach a custom
-          // header, and a cross-origin fetch()/XHR that tried to would trigger a
-          // CORS preflight this server does not answer for arbitrary origins, so
-          // the browser never sends the real request. curl/non-browser callers
-          // stay usable by passing the header explicitly (documented in
-          // orch-monitor-api.md) — Origin remains permissively absent for them,
-          // same as before.
+          // closes THAT class of vector: none of those simple-request mechanisms
+          // can ever attach a custom header, and a cross-origin fetch()/XHR that
+          // tried to would trigger a CORS preflight this server does not answer
+          // for arbitrary origins, so the browser never sends the real request.
+          //
+          // DNS REBINDING defeats the header check alone (CTL-1653 Codex
+          // round-3 finding): a page loaded as `http://evil.example:<port>`
+          // that later re-resolves to THIS server's IP is same-origin to the
+          // browser once rebound, so its JS can attach the header with no
+          // preflight — and a same-origin fetch/XHR is not guaranteed to carry
+          // `Origin` either, which originAllowed(null) then admits. The `Host`
+          // header is the fix: it is NOT rebindable to a name we recognize —
+          // the rebound request still arrives with `Host: evil.example:<port>`
+          // (the browser sends whatever host the page's URL named, never OUR
+          // real name/address), so validating Host against the SAME trusted-
+          // origin set used for Origin (reusing `originAllowed` — Host is just
+          // an origin without a scheme) rejects it regardless of whether
+          // Origin is present. curl/non-browser callers stay usable: curl sets
+          // Host from the URL it was given, and localhost/127.0.0.1/the node's
+          // own address are exactly what's trusted.
           if (refresh) {
             const hasRefreshHeader = req.headers.get(ACCOUNTS_REFRESH_HEADER) !== null;
-            if (!hasRefreshHeader || !originAllowed(req.headers.get("origin"))) {
+            const hostHeader = req.headers.get("host");
+            const hostTrusted = hostHeader !== null && originAllowed(`http://${hostHeader}`);
+            if (!hasRefreshHeader || !hostTrusted || !originAllowed(req.headers.get("origin"))) {
               return Response.json(
                 { status: "forbidden", error: "cross-origin refresh rejected" },
                 { status: 403 },

--- a/website/src/content/docs/reference/orch-monitor-api.md
+++ b/website/src/content/docs/reference/orch-monitor-api.md
@@ -21,10 +21,13 @@ response** (or in the monitor's own environment).
 - **Cached** (~5 min TTL). Repeated calls within the TTL are served from cache — the same `probedAt`
   is returned and no inference call is spent.
 - **`?refresh=true`** forces a fresh probe (operator-initiated; the only per-request probe path).
-  Requires the `X-Catalyst-Refresh` header (any value) **and** a trusted `Origin` when one is
-  present. The header is what actually stops the vector: this route is a GET, so a browser
-  navigating to (or embedding) the URL directly sends no `Origin` at all, and neither a header-less
-  request nor an untrusted `Origin` is accepted — a plain read (no `refresh`) needs neither.
+  Requires the `X-Catalyst-Refresh` header (any value), a trusted `Host` header, **and** a trusted
+  `Origin` when one is present. The header is what stops a simple cross-site request (an `<img>`,
+  a top-level navigation, a plain `<form>` GET — none of those can attach a custom header); the
+  `Host` check is what stops a DNS-rebinding page (one that starts on an attacker domain and later
+  re-resolves to this server's own address, at which point it is same-origin to the browser and can
+  attach the header with no CORS preflight, and may carry no `Origin` at all) — a plain read (no
+  `refresh`) needs none of this.
   ```bash
   curl -H "X-Catalyst-Refresh: 1" "http://localhost:7400/api/accounts?refresh=true"
   ```


### PR DESCRIPTION
## Summary

Remediates the 3 findings from Codex's post-merge round on #3017:

1. **HUD ignores the unavailable transition**: the round-2 clear-path fix reached the web dashboard but not the terminal HUD — `useAccountModel`'s own decoder still nulled `{available:false}` frames, so an open HUD froze on stale posture after a node's env was emptied. The apply/clear/ignore action is now mirrored into the HUD (per the file's documented mirror-not-import convention) and wired into both the SSE and reconcile paths. (Server-side transition emission was verified already correct — frames fire on every tick including live transitions.)
2. **DNS-rebinding bypass of the refresh guard**: a page whose domain rebinds to the monitor's IP is same-origin to the browser — its JS attaches the refresh header with no preflight and no guaranteed Origin. The Host header is now validated through the SAME trusted-origin set as Origin (`originAllowed("http://" + host)`) — rebinding can redirect an IP but cannot make the browser send our hostname as Host. Tested with a byte-accurate rebinding-shaped request (foreign Host + header + no Origin → 403) and a localhost positive control.
3. **Unreadable env files masked as disabled**: any read failure (including EACCES on a valid secret file) collapsed into the same `available:false` shape as an intentionally-empty file, hiding real permission misconfigurations. Only ENOENT is benign now; other read errors propagate into the probe's existing `status:"error"` machinery. chmod-000 fixture tests (root-skip guarded).

## Testing

Targeted suites 91/91 (196 expects); tsc clean; eslint 0 errors (warning count unchanged); knip clean; full-repo `bun test` zero delta vs the known baseline. No secret material touched by any of the three fixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)