### PR TITLE
fix(monitor): CTL-1653 accept https-configured trusted origins in the refresh Host check

### DIFF
--- a/plugins/dev/scripts/orch-monitor/__tests__/accounts-endpoint.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/accounts-endpoint.test.ts
@@ -221,3 +221,63 @@ describe("/api/accounts disabled (accountsProbeExec:null)", () => {
     }
   });
 });
+
+describe("/api/accounts refresh behind an HTTPS reverse proxy", () => {
+  // CTL-1653 Codex round-4: MONITOR_TRUSTED_ORIGINS' documented reverse-proxy
+  // form is a FULL https:// origin, but Host carries no scheme — an
+  // http://-only probe of the trusted set would 403 every legitimate proxied
+  // refresh. The guard must accept a Host that matches a trusted origin under
+  // EITHER scheme.
+  let server: ReturnType<typeof createServer>;
+  let tmpDir = "";
+  let base = "";
+  let calls = 0;
+  let prevTrusted: string | undefined;
+  beforeAll(() => {
+    prevTrusted = process.env.MONITOR_TRUSTED_ORIGINS;
+    process.env.MONITOR_TRUSTED_ORIGINS = "https://catalyst.internal.example";
+    const dirs = mkWtDir("accounts-endpoint-https-");
+    tmpDir = dirs.tmpDir;
+    server = createServer({
+      port: 0,
+      wtDir: dirs.wtDir,
+      startWatcher: false,
+      accountsRefreshFloorMs: 0,
+      accountsProbeExec: () => {
+        calls += 1;
+        return Promise.resolve(FAKE);
+      },
+    });
+    base = `http://localhost:${server.port}`;
+  });
+  afterAll(() => {
+    if (prevTrusted === undefined) delete process.env.MONITOR_TRUSTED_ORIGINS;
+    else process.env.MONITOR_TRUSTED_ORIGINS = prevTrusted;
+    void server.stop(true);
+    try {
+      rmSync(tmpDir, { recursive: true, force: true });
+    } catch {
+      /* ignore */
+    }
+  });
+  it("a refresh whose Host matches an https-configured trusted origin is admitted", async () => {
+    const before = calls;
+    const r = await fetch(`${base}/api/accounts?refresh=true`, {
+      headers: {
+        [ACCOUNTS_REFRESH_HEADER]: "1",
+        Host: "catalyst.internal.example",
+        Origin: "https://catalyst.internal.example",
+      },
+    });
+    expect(r.status).toBe(200);
+    expect(calls).toBe(before + 1);
+  });
+  it("an untrusted Host is still rejected even with the https set configured", async () => {
+    const before = calls;
+    const r = await fetch(`${base}/api/accounts?refresh=true`, {
+      headers: { [ACCOUNTS_REFRESH_HEADER]: "1", Host: "evil.example" },
+    });
+    expect(r.status).toBe(403);
+    expect(calls).toBe(before);
+  });
+});

--- a/plugins/dev/scripts/orch-monitor/server.ts
+++ b/plugins/dev/scripts/orch-monitor/server.ts
@@ -2518,7 +2518,13 @@ export function createServer(opts: CreateServerOptions): BunServer {
           if (refresh) {
             const hasRefreshHeader = req.headers.get(ACCOUNTS_REFRESH_HEADER) !== null;
             const hostHeader = req.headers.get("host");
-            const hostTrusted = hostHeader !== null && originAllowed(`http://${hostHeader}`);
+            // Check BOTH schemes (Codex round-4): Host carries no scheme, and a
+            // reverse-proxied deployment configures its MONITOR_TRUSTED_ORIGINS
+            // entry as the https:// origin — an http://-only probe would 403
+            // every legitimate proxied refresh.
+            const hostTrusted =
+              hostHeader !== null &&
+              (originAllowed(`http://${hostHeader}`) || originAllowed(`https://${hostHeader}`));
             if (!hasRefreshHeader || !hostTrusted || !originAllowed(req.headers.get("origin"))) {
               return Response.json(
                 { status: "forbidden", error: "cross-origin refresh rejected" },


### PR DESCRIPTION
## Summary

Remediates the single Codex round-4 finding on #3019: the DNS-rebinding Host guard probed the trusted-origin set only as `http://<host>`, but the documented reverse-proxy configuration of `MONITOR_TRUSTED_ORIGINS` is a full `https://` origin — so every legitimate refresh through such a proxy would 403. The Host check now accepts a match under either scheme (Host itself carries no scheme); rebinding-shaped requests still reject identically.

## Testing

New describe with an https-configured trusted set: proxied-Host admit (200, probe spent) + untrusted-Host deny (403, no probe). Full accounts-endpoint suite 13/13; tsc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)