### PR TITLE
fix(monitor): CTL-1653 scheme-aware Host check — never treat an https-only trusted host as plaintext

### DIFF
--- a/plugins/dev/scripts/orch-monitor/__tests__/accounts-endpoint.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/accounts-endpoint.test.ts
@@ -260,17 +260,31 @@ describe("/api/accounts refresh behind an HTTPS reverse proxy", () => {
       /* ignore */
     }
   });
-  it("a refresh whose Host matches an https-configured trusted origin is admitted", async () => {
+  it("a proxied refresh (X-Forwarded-Proto https from loopback) whose Host matches the https trusted origin is admitted", async () => {
     const before = calls;
     const r = await fetch(`${base}/api/accounts?refresh=true`, {
       headers: {
         [ACCOUNTS_REFRESH_HEADER]: "1",
         Host: "catalyst.internal.example",
         Origin: "https://catalyst.internal.example",
+        "X-Forwarded-Proto": "https",
       },
     });
     expect(r.status).toBe(200);
     expect(calls).toBe(before + 1);
+  });
+  it("the SAME request WITHOUT X-Forwarded-Proto is rejected — an https-only trusted host is never treated as plaintext", async () => {
+    // CTL-1653 Codex round-5: a page served over plain HTTP for the trusted
+    // hostname (originless same-origin GET) must not be able to spend the
+    // probe when the config trusts only the https:// origin. Without the
+    // proxy's X-Forwarded-Proto the effective scheme is http, and
+    // http://catalyst.internal.example is deliberately NOT in the trusted set.
+    const before = calls;
+    const r = await fetch(`${base}/api/accounts?refresh=true`, {
+      headers: { [ACCOUNTS_REFRESH_HEADER]: "1", Host: "catalyst.internal.example" },
+    });
+    expect(r.status).toBe(403);
+    expect(calls).toBe(before);
   });
   it("an untrusted Host is still rejected even with the https set configured", async () => {
     const before = calls;

--- a/plugins/dev/scripts/orch-monitor/server.ts
+++ b/plugins/dev/scripts/orch-monitor/server.ts
@@ -2518,13 +2518,25 @@ export function createServer(opts: CreateServerOptions): BunServer {
           if (refresh) {
             const hasRefreshHeader = req.headers.get(ACCOUNTS_REFRESH_HEADER) !== null;
             const hostHeader = req.headers.get("host");
-            // Check BOTH schemes (Codex round-4): Host carries no scheme, and a
-            // reverse-proxied deployment configures its MONITOR_TRUSTED_ORIGINS
-            // entry as the https:// origin — an http://-only probe would 403
-            // every legitimate proxied refresh.
+            // SCHEME-AWARE Host check (Codex round-5, refining round-4): Host
+            // carries no scheme, but an https://-only MONITOR_TRUSTED_ORIGINS
+            // entry deliberately does NOT trust the plaintext form of the same
+            // host — probing both schemes unconditionally would let a page
+            // served over plain HTTP for the trusted hostname spend the probe.
+            // The request's effective scheme is https ONLY when the co-located
+            // reverse proxy says so: X-Forwarded-Proto is honored solely from a
+            // loopback peer (this server always listens plaintext; TLS
+            // terminates at a proxy on the same host — the heap-snapshot
+            // route's existing localhost gate uses the same assumption). A
+            // remote client spoofing the header stays "http" and an https-only
+            // trusted set correctly rejects it.
+            const peer = server.requestIP(req)?.address ?? "";
+            const peerIsLoopback =
+              peer === "127.0.0.1" || peer === "::1" || peer === "::ffff:127.0.0.1";
+            const fwdProto = req.headers.get("x-forwarded-proto")?.split(",")[0]?.trim();
+            const effectiveScheme = peerIsLoopback && fwdProto === "https" ? "https" : "http";
             const hostTrusted =
-              hostHeader !== null &&
-              (originAllowed(`http://${hostHeader}`) || originAllowed(`https://${hostHeader}`));
+              hostHeader !== null && originAllowed(`${effectiveScheme}://${hostHeader}`);
             if (!hasRefreshHeader || !hostTrusted || !originAllowed(req.headers.get("origin"))) {
               return Response.json(
                 { status: "forbidden", error: "cross-origin refresh rejected" },


### PR DESCRIPTION
## Summary

Remediates the Codex round-5 finding on #3020: the round-4 either-scheme fallback would admit an originless refresh from a page served over plain HTTP for a hostname whose trusted-origins entry is deliberately https-only. The Host probe is now scheme-aware: the effective scheme is `https` only when `X-Forwarded-Proto: https` arrives **from a loopback peer** (the co-located reverse-proxy deployment shape this server documents; same localhost-gate assumption as the heap-snapshot route). A remote client spoofing the header is treated as plaintext and rejected by an https-only trusted set; the rebinding-shaped and untrusted-Host rejections are unchanged.

## Testing

accounts-endpoint suite 14/14: proxied admit (XFP https from loopback), plaintext-same-host deny (the round-5 scenario), untrusted-Host deny, plus all prior rounds' cases. tsc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)