### PR TITLE
fix(dev): CTL-1640 resume worktree from origin/<ticket> instead of orphaning pushed commits

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -357,6 +357,12 @@ active work:
   flip draft→ready (avoids `create-pr`'s "PR already exists" hang).
 - **Config**: `orchestration.draftPr.enabled` (default `true`) — set `false` for no early draft, so
   the PR is created only at the `pr` phase.
+- **Resume consumer (CTL-1640)**: the pushed commits on `origin/<ticket>` are the durable record a
+  new worktree resumes from. `create-worktree.sh` seeds a fresh branch from `origin/<ticket>` when
+  it exists (default-on; `--no-from-remote` opts out), so both normal dispatch and cross-host
+  reclaim (`defaultRebuildWorktree`) rebuild on the dead host's pushed work instead of orphaning it
+  under a fresh branch off base. Resolved straight from git (`origin/<ticket>`), not by reading
+  `.draftPr`.
 - **Deferred**: reading `.draftPr` draft-state as a secondary advancement signal (advancement
   currently driven by signal `status === "done"` only).
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -362,7 +362,8 @@ active work:
   it exists (default-on; `--no-from-remote` opts out), so both normal dispatch and cross-host
   reclaim (`defaultRebuildWorktree`) rebuild on the dead host's pushed work instead of orphaning it
   under a fresh branch off base. Resolved straight from git (`origin/<ticket>`), not by reading
-  `.draftPr`.
+  `.draftPr`. The operator-facing CLI contract (default-on, the `--no-from-remote` / `--skip-fetch`
+  opt-outs) is owned by and documented in `plugins/dev/skills/create-worktree/SKILL.md`.
 - **Deferred**: reading `.draftPr` draft-state as a secondary advancement signal (advancement
   currently driven by signal `status === "done"` only).
 

--- a/plugins/dev/scripts/__tests__/create-worktree-base-ref.test.sh
+++ b/plugins/dev/scripts/__tests__/create-worktree-base-ref.test.sh
@@ -64,6 +64,18 @@ build_scratch() {
 	mkdir -p "$SRC/.catalyst"
 	printf '{"catalyst":{"projectKey":"t"}}\n' >"$SRC/.catalyst/config.json"
 
+	# Hermetic humanlayer.json under the fake HOME so the CTL-845 vendored
+	# thoughts-init (scripts/worktree-thoughts-init.sh) resolves a thoughtsRepo
+	# INSIDE the scratch and succeeds. On CI (no `humanlayer` binary installed)
+	# create-worktree skips thoughts-init entirely and this file is never read;
+	# on a dev box that HAS humanlayer, without it the vendored init exits 1
+	# (no $HOME/.config/humanlayer/humanlayer.json) and rolls the worktree back
+	# before any assertion — so the whole suite is un-runnable locally. Keeps
+	# the fixture fully hermetic in both environments.
+	mkdir -p "$FAKEHOME/.config/humanlayer"
+	printf '{"thoughts":{"user":"tester","thoughtsRepo":"%s/thoughts-repo","reposDir":"repos","globalDir":"global","defaultProfile":"testprofile"}}\n' \
+		"$SCRATCH" >"$FAKEHOME/.config/humanlayer/humanlayer.json"
+
 	cat >"$BIN/humanlayer" <<'STUB'
 #!/usr/bin/env bash
 case "$1 $2" in
@@ -73,6 +85,22 @@ case "$1 $2" in
 esac
 STUB
 	chmod +x "$BIN/humanlayer"
+}
+
+# push_remote_ticket_branch <name> <n_commits> — CTL-1640: create <name> off
+# origin/main with <n_commits> extra commits and push it to origin, using a
+# throwaway clone so $SRC keeps NO local ref (mirrors a surviving host that has
+# never seen the ticket branch, only origin/<ticket> from a pushed draft PR).
+push_remote_ticket_branch() {
+	local NAME="$1" N="$2" i
+	local PUSH="$SCRATCH/pusher-$NAME"
+	git clone -q "$ORIGIN" "$PUSH"
+	git -C "$PUSH" config user.email t@t.t
+	git -C "$PUSH" config user.name t
+	git -C "$PUSH" checkout -q -b "$NAME" origin/main
+	for ((i = 1; i <= N; i++)); do git -C "$PUSH" commit -q --allow-empty -m "$NAME-c$i"; done
+	git -C "$PUSH" push -q -u origin "$NAME"
+	REMOTE_TICKET_TIP="$(git -C "$PUSH" rev-parse "$NAME")"
 }
 
 run_create() { # $1 worktree name; $@ extra args
@@ -108,7 +136,14 @@ rm -rf "$SCRATCH"
 # Case 3 — --reuse-existing on an already-present dir: no fetch, no change.
 echo "Test 3: --reuse-existing short-circuits before fetch"
 build_scratch
-mkdir -p "$WT/wt-reuse" # pre-create the path
+mkdir -p "$WT/wt-reuse/thoughts" # pre-create the path
+# Pre-seed a HEALTHY thoughts/shared symlink so the CTL-1497 reuse-path repair
+# is skipped (it only fires on an unhealthy link, and on a dev box with
+# humanlayer installed the repair of this empty non-git dir cannot resolve a
+# repo and fails). On CI (no humanlayer) the repair block is skipped anyway;
+# this keeps the fixture hermetic in both environments.
+mkdir -p "$SCRATCH/reuse-shared"
+ln -sfn "$SCRATCH/reuse-shared" "$WT/wt-reuse/thoughts/shared"
 run_create wt-reuse --reuse-existing
 assert_eq "0" "$EXIT" "exits 0 on reuse"
 assert_contains "$OUTPUT" "Reusing existing worktree" "reuse path taken"
@@ -128,6 +163,63 @@ else
 fi
 HEAD_SHA="$(git -C "$WT_PATH" rev-parse HEAD 2>/dev/null || echo NA)"
 assert_eq "$LOCAL_TIP" "$HEAD_SHA" "worktree HEAD matches local main when fetch is skipped"
+rm -rf "$SCRATCH"
+
+# Case 5 — resume from an origin-only ticket branch (CTL-1640 Scenario 1).
+echo "Test 5: resume from origin-only ticket branch (no local ref)"
+build_scratch
+push_remote_ticket_branch wt-remote-only 3
+# precondition: SRC must have NO local ref for the ticket branch
+if git -C "$SRC" show-ref --verify --quiet refs/heads/wt-remote-only; then
+	fail "precondition: SRC must NOT have a local wt-remote-only ref"
+else
+	pass "precondition: no local wt-remote-only ref in SRC"
+fi
+run_create wt-remote-only
+assert_eq "0" "$EXIT" "exits 0 resuming from origin ticket branch"
+HEAD_SHA="$(git -C "$WT_PATH" rev-parse HEAD 2>/dev/null || echo NA)"
+assert_eq "$REMOTE_TICKET_TIP" "$HEAD_SHA" "worktree HEAD matches the pushed ticket tip (commits resumed)"
+if [[ $HEAD_SHA != "$ORIGIN_TIP" ]]; then
+	pass "worktree HEAD is NOT the base tip (not cut from base)"
+else
+	fail "worktree HEAD equals base tip — remote commits orphaned"
+fi
+assert_contains "$OUTPUT" "origin/wt-remote-only" "resume banner mentions origin/wt-remote-only"
+rm -rf "$SCRATCH"
+
+# Case 6 — no remote ticket branch → fresh-from-base unchanged (CTL-1640 Scenario 3).
+echo "Test 6: no remote ticket branch falls through to fresh-from-base"
+build_scratch
+run_create wt-fresh-none
+assert_eq "0" "$EXIT" "exits 0 with no remote ticket branch"
+HEAD_SHA="$(git -C "$WT_PATH" rev-parse HEAD 2>/dev/null || echo NA)"
+assert_eq "$ORIGIN_TIP" "$HEAD_SHA" "worktree HEAD matches origin/main base tip"
+if [[ $OUTPUT != *"Resuming from origin/"* ]]; then
+	pass "no resume banner when no remote ticket branch exists"
+else
+	fail "resume banner printed with no remote ticket branch"
+fi
+rm -rf "$SCRATCH"
+
+# Case 7 — --no-from-remote escape hatch overrides an existing remote branch.
+echo "Test 7: --no-from-remote ignores an existing remote ticket branch"
+build_scratch
+push_remote_ticket_branch wt-optout 2
+run_create wt-optout --no-from-remote
+assert_eq "0" "$EXIT" "exits 0 with --no-from-remote"
+HEAD_SHA="$(git -C "$WT_PATH" rev-parse HEAD 2>/dev/null || echo NA)"
+assert_eq "$ORIGIN_TIP" "$HEAD_SHA" "worktree HEAD is base tip, not the remote ticket tip"
+rm -rf "$SCRATCH"
+
+# Case 8 — reclaim's own argv (<ticket> main --reuse-existing, dir absent) seeds
+# from origin/<ticket> (CTL-1640 Scenario 2 — cross-host reclaim round-trip).
+echo "Test 8: reclaim argv (--reuse-existing, dir absent) resumes pushed commits"
+build_scratch
+push_remote_ticket_branch wt-reclaim 2
+run_create wt-reclaim --reuse-existing # dir does NOT exist → falls through to branch block
+assert_eq "0" "$EXIT" "reclaim argv exits 0"
+HEAD_SHA="$(git -C "$WT_PATH" rev-parse HEAD 2>/dev/null || echo NA)"
+assert_eq "$REMOTE_TICKET_TIP" "$HEAD_SHA" "reclaim rebuild contains the dead host's pushed commits"
 rm -rf "$SCRATCH"
 
 echo ""

--- a/plugins/dev/scripts/create-worktree.sh
+++ b/plugins/dev/scripts/create-worktree.sh
@@ -30,6 +30,11 @@ ORCHESTRATION_NAME=""
 REUSE_EXISTING=false
 SKIP_FETCH=false
 EXPECTED_BRANCH=""
+# CTL-1640: resume-from-remote is default-on. When no local branch exists and
+# origin has this ticket branch (pushed draft-PR commits, CTL-783), seed the
+# worktree from that remote tip instead of orphaning it under a fresh branch off
+# base. --no-from-remote opts out; --from-remote affirms the default.
+FROM_REMOTE=true
 
 while [[ $# -gt 0 ]]; do
 	case $1 in
@@ -38,6 +43,8 @@ while [[ $# -gt 0 ]]; do
 		--orchestration) ORCHESTRATION_NAME="$2"; shift 2 ;;
 		--reuse-existing) REUSE_EXISTING=true; shift ;;
 		--skip-fetch) SKIP_FETCH=true; shift ;;
+		--from-remote) FROM_REMOTE=true; shift ;;
+		--no-from-remote) FROM_REMOTE=false; shift ;;
 		# CTL-615: when --reuse-existing returns an existing worktree dir,
 		# assert its HEAD is on this branch. Mismatch → exit 64 with a
 		# clear diagnostic. The daemon's revive path passes the ticket name
@@ -52,12 +59,17 @@ done
 # Get worktree name from positional args
 if [ ${#POSITIONAL[@]} -eq 0 ]; then
 	echo -e "${RED}Error: Worktree name is required${NC}"
-	echo "Usage: ./create-worktree.sh <worktree_name> [base_branch] [--worktree-dir <path>] [--hooks-json <json>]"
+	echo "Usage: ./create-worktree.sh <worktree_name> [base_branch] [--worktree-dir <path>] [--hooks-json <json>] [--no-from-remote]"
+	echo ""
+	echo "  --from-remote / --no-from-remote  Seed a new branch from origin/<worktree_name>"
+	echo "                                    when it exists (default: --from-remote); opt out"
+	echo "                                    to always root a fresh branch on the base tip."
 	echo ""
 	echo "Examples:"
 	echo "  ./create-worktree.sh ENG-123"
 	echo "  ./create-worktree.sh feature-auth main"
 	echo "  ./create-worktree.sh orch-1-ENG-123 main --worktree-dir ~/catalyst/my-app"
+	echo "  ./create-worktree.sh ENG-123 main --no-from-remote   # ignore origin/ENG-123, root on base"
 	exit 1
 fi
 
@@ -186,12 +198,44 @@ fi
 CREATED_BRANCH=false
 if git show-ref --verify --quiet "refs/heads/${WORKTREE_NAME}"; then
 	echo "📋 Using existing branch: ${WORKTREE_NAME}"
+	# CTL-1640: local branch wins (policy: no auto-merge), but surface a
+	# divergence from origin/<name> so a stale local branch atop pushed work is
+	# visible. Best-effort, gated like the base fetch; never changes behavior.
+	if [ "$SKIP_FETCH" = false ] && [ "$FROM_REMOTE" = true ] \
+		&& git ls-remote --exit-code --heads origin "$WORKTREE_NAME" >/dev/null 2>&1; then
+		LOCAL_SHA="$(git rev-parse --verify --quiet "refs/heads/${WORKTREE_NAME}" 2>/dev/null || true)"
+		REMOTE_SHA="$(git ls-remote --heads origin "$WORKTREE_NAME" 2>/dev/null | awk '{print $1}')"
+		if [ -n "$REMOTE_SHA" ] && [ -n "$LOCAL_SHA" ] && [ "$LOCAL_SHA" != "$REMOTE_SHA" ]; then
+			echo -e "${YELLOW}⚠️  local ${WORKTREE_NAME} (${LOCAL_SHA:0:8}) diverges from origin (${REMOTE_SHA:0:8}); keeping local, not merging (CTL-1640)${NC}" >&2
+		fi
+	fi
 	git worktree add "$WORKTREE_PATH" "$WORKTREE_NAME"
 else
 	echo "🆕 Creating new branch: ${WORKTREE_NAME}"
+	# CREATED_BRANCH=true is correct even when seeded from origin/<name> below:
+	# the local branch head then equals origin/<name>, so the rollback helpers'
+	# `git branch -D` can never lose unpushed work (every commit is on origin).
 	CREATED_BRANCH=true
 	START_POINT="$BASE_BRANCH"
-	if [ "$SKIP_FETCH" = false ]; then
+	SEEDED_FROM_REMOTE=false
+	# CTL-1640: resume-from-remote — if origin already has this ticket branch
+	# (e.g. a pushed draft PR's commits, CTL-783), seed the worktree from that
+	# remote tip instead of orphaning it under a fresh branch off base. The local
+	# branch already took precedence above; --skip-fetch (offline) and
+	# --no-from-remote opt out. This is the missing CTL-783 "resume consumer" —
+	# both normal dispatch and cross-host reclaim funnel through this script, so
+	# they both resume automatically with no .mjs change.
+	if [ "$SKIP_FETCH" = false ] && [ "$FROM_REMOTE" = true ] \
+		&& git ls-remote --exit-code --heads origin "$WORKTREE_NAME" >/dev/null 2>&1; then
+		if git fetch --quiet origin "$WORKTREE_NAME" 2>/dev/null; then
+			START_POINT="refs/remotes/origin/${WORKTREE_NAME}"
+			SEEDED_FROM_REMOTE=true
+			echo "🌱 Resuming from origin/${WORKTREE_NAME}; seeding worktree from its pushed tip (CTL-1640)"
+		else
+			echo -e "${YELLOW}⚠️  origin/${WORKTREE_NAME} exists but could not be fetched; falling back to base${NC}" >&2
+		fi
+	fi
+	if [ "$SEEDED_FROM_REMOTE" = false ] && [ "$SKIP_FETCH" = false ]; then
 		if git fetch --quiet origin "$BASE_BRANCH" 2>/dev/null; then
 			START_POINT="refs/remotes/origin/${BASE_BRANCH}"
 			echo "🔄 Fetched origin/${BASE_BRANCH}; rooting on remote tip"

--- a/plugins/dev/scripts/create-worktree.sh
+++ b/plugins/dev/scripts/create-worktree.sh
@@ -253,6 +253,21 @@ else
 		else
 			echo -e "${YELLOW}⚠️  Could not fetch origin/${BASE_BRANCH}; falling back to local ${BASE_BRANCH} (worker may branch off stale ref)${NC}" >&2
 		fi
+		# CTL-1640 (Codex #3025 P2): re-check origin/<ticket> immediately before creating
+		# the branch. A superseded worker's early-draft push (implement-plan-draft-pr-early,
+		# CTL-783) can land AFTER the negative ticket fetch above but before `git worktree
+		# add -b` — a TOCTOU window that would otherwise root the survivor on base and never
+		# resume the pushed commits (the local-branch-wins path then takes over on every later
+		# provisioning). This last-moment fetch narrows that window to the gap between here and
+		# the add. It does NOT fully close the race — the durable fix is a cluster-fence guard
+		# on the producer's early-draft push — but it converts the common case back to a resume.
+		if [ "$FROM_REMOTE" = true ] \
+			&& git fetch --quiet origin \
+				"+refs/heads/${WORKTREE_NAME}:refs/remotes/origin/${WORKTREE_NAME}" 2>/dev/null; then
+			START_POINT="refs/remotes/origin/${WORKTREE_NAME}"
+			SEEDED_FROM_REMOTE=true
+			echo "🌱 origin/${WORKTREE_NAME} appeared during provisioning; resuming from its pushed tip (CTL-1640)"
+		fi
 	fi
 	git worktree add -b "$WORKTREE_NAME" "$WORKTREE_PATH" "$START_POINT"
 fi

--- a/plugins/dev/scripts/create-worktree.sh
+++ b/plugins/dev/scripts/create-worktree.sh
@@ -200,11 +200,16 @@ if git show-ref --verify --quiet "refs/heads/${WORKTREE_NAME}"; then
 	echo "📋 Using existing branch: ${WORKTREE_NAME}"
 	# CTL-1640: local branch wins (policy: no auto-merge), but surface a
 	# divergence from origin/<name> so a stale local branch atop pushed work is
-	# visible. Best-effort, gated like the base fetch; never changes behavior.
-	if [ "$SKIP_FETCH" = false ] && [ "$FROM_REMOTE" = true ] \
-		&& git ls-remote --exit-code --heads origin "$WORKTREE_NAME" >/dev/null 2>&1; then
+	# visible. Read the LOCALLY-CACHED remote-tracking ref (git rev-parse, no
+	# network) rather than a synchronous `git ls-remote` (Codex #3025 P2): the
+	# reuse path needs no remote data to add the worktree, and createWorktree()
+	# spawns this script without a timeout, so a live ls-remote against a slow or
+	# unreachable origin would block dispatch/reclaim until the transport times out
+	# — all for a cosmetic warning. Best-effort: if the remote-tracking ref is not
+	# present locally, we simply skip the warning.
+	if [ "$SKIP_FETCH" = false ] && [ "$FROM_REMOTE" = true ]; then
 		LOCAL_SHA="$(git rev-parse --verify --quiet "refs/heads/${WORKTREE_NAME}" 2>/dev/null || true)"
-		REMOTE_SHA="$(git ls-remote --heads origin "$WORKTREE_NAME" 2>/dev/null | awk '{print $1}')"
+		REMOTE_SHA="$(git rev-parse --verify --quiet "refs/remotes/origin/${WORKTREE_NAME}" 2>/dev/null || true)"
 		if [ -n "$REMOTE_SHA" ] && [ -n "$LOCAL_SHA" ] && [ "$LOCAL_SHA" != "$REMOTE_SHA" ]; then
 			echo -e "${YELLOW}⚠️  local ${WORKTREE_NAME} (${LOCAL_SHA:0:8}) diverges from origin (${REMOTE_SHA:0:8}); keeping local, not merging (CTL-1640)${NC}" >&2
 		fi
@@ -225,15 +230,21 @@ else
 	# --no-from-remote opt out. This is the missing CTL-783 "resume consumer" —
 	# both normal dispatch and cross-host reclaim funnel through this script, so
 	# they both resume automatically with no .mjs change.
+	# CTL-1640 (Codex #3025 P1/P2): fetch with an EXPLICIT destination refspec so the
+	# remote-tracking ref is written even in a restricted-refspec (e.g. single-branch)
+	# clone, where a bare `git fetch origin <ticket>` returns success but lands the tip
+	# only in FETCH_HEAD — leaving START_POINT (refs/remotes/origin/<ticket>) nonexistent
+	# and failing the worktree add. A single fetch also collapses remote discovery and
+	# retrieval into ONE round-trip: no separate `git ls-remote` existence snapshot (which
+	# both added serial remote I/O and opened a split-window race where a concurrent push
+	# between the snapshot and the fetch could be missed), and a missing ticket ref simply
+	# makes the fetch exit non-zero so we fall through to seeding from base.
 	if [ "$SKIP_FETCH" = false ] && [ "$FROM_REMOTE" = true ] \
-		&& git ls-remote --exit-code --heads origin "$WORKTREE_NAME" >/dev/null 2>&1; then
-		if git fetch --quiet origin "$WORKTREE_NAME" 2>/dev/null; then
-			START_POINT="refs/remotes/origin/${WORKTREE_NAME}"
-			SEEDED_FROM_REMOTE=true
-			echo "🌱 Resuming from origin/${WORKTREE_NAME}; seeding worktree from its pushed tip (CTL-1640)"
-		else
-			echo -e "${YELLOW}⚠️  origin/${WORKTREE_NAME} exists but could not be fetched; falling back to base${NC}" >&2
-		fi
+		&& git fetch --quiet origin \
+			"+refs/heads/${WORKTREE_NAME}:refs/remotes/origin/${WORKTREE_NAME}" 2>/dev/null; then
+		START_POINT="refs/remotes/origin/${WORKTREE_NAME}"
+		SEEDED_FROM_REMOTE=true
+		echo "🌱 Resuming from origin/${WORKTREE_NAME}; seeding worktree from its pushed tip (CTL-1640)"
 	fi
 	if [ "$SEEDED_FROM_REMOTE" = false ] && [ "$SKIP_FETCH" = false ]; then
 		if git fetch --quiet origin "$BASE_BRANCH" 2>/dev/null; then

--- a/plugins/dev/scripts/execution-core/recovery.mjs
+++ b/plugins/dev/scripts/execution-core/recovery.mjs
@@ -4200,8 +4200,13 @@ function defaultThoughtsPull(cwd) {
   }
 }
 
-// defaultRebuildWorktree — fetch the ticket branch and add/reuse the worktree.
-// Best-effort; returns { ok, cwd }. Fail-open: errors produce { ok: false, cwd: null }.
+// defaultRebuildWorktree — rebuild the ticket's worktree on a surviving host.
+// CTL-1640: create-worktree.sh now seeds a fresh branch from origin/<ticket>
+// when it exists (the dead host's pushed draft-PR commits, CTL-783), so reclaim
+// rebuilds on that pushed work; it falls back to the base tip otherwise. Both
+// this reclaim path and normal dispatch share the same script argv, so neither
+// needs a flag. Best-effort; returns { ok, cwd }. Fail-open: errors produce
+// { ok: false, cwd: null }.
 function defaultRebuildWorktree(ticket, { orchDir }) {
   try {
     const repoRoot = join(orchDir, "..", "..");

--- a/plugins/dev/skills/create-worktree/SKILL.md
+++ b/plugins/dev/skills/create-worktree/SKILL.md
@@ -34,13 +34,26 @@ When this command is invoked:
 3. **Create the worktree**: Use the create-worktree.sh script:
 
    ```bash
-   "${CLAUDE_PLUGIN_ROOT}/scripts/create-worktree.sh" <worktree_name> [base_branch]
+   "${CLAUDE_PLUGIN_ROOT}/scripts/create-worktree.sh" <worktree_name> [base_branch] [--no-from-remote] [--skip-fetch]
    ```
 
    The script automatically:
    - Reads `catalyst.worktree.setup` from config for project-specific setup
    - Copies `.claude/` and `.catalyst/` directories
    - Falls back to auto-detected setup if no config (dependency install + thoughts init)
+
+   **Resume-from-remote (default-on, CTL-1640).** When a NEW branch is being created and
+   `origin/<worktree_name>` already exists (e.g. a pushed draft PR's commits, CTL-783), the worktree
+   is seeded from that remote tip instead of being cut fresh off the base branch — so a re-dispatch
+   or a cross-host reclaim rebuilds on the pushed work rather than orphaning it under a fresh branch.
+   This is automatic; the script prints a `🌱 Resuming from origin/<name>` banner when it fires. An
+   existing **local** branch always wins over the remote (no auto-merge); the resume applies only
+   when there is no local branch yet.
+
+   To opt out and force a fresh branch off the base (ignore any matching origin branch), pass
+   **`--no-from-remote`**. To suppress all origin fetches entirely (offline), pass **`--skip-fetch`**
+   (which also disables the resume). Confirm with the user which they want before overriding the
+   default when a matching origin branch may carry stale or already-merged history.
 
 4. **Project setup** (handled by script based on config):
 


### PR DESCRIPTION
<!-- Auto-generated: 2026-08-06T00:29:02Z -->
<!-- Last updated: 2026-08-06T00:29:02Z -->
<!-- PR: #3025 -->
<!-- Previous commits: 7904001ac88744280f545686dfae4080e49852ee,305f05be270dfc7874a31056e770e1403b1aee1b -->

## Summary

When a worktree was (re)created for a ticket — normal dispatch, or a cross-host reclaim after the
owning host died — `create-worktree.sh` always cut a fresh branch off the base tip. Any commits the
prior worker had already pushed to `origin/<ticket>` (the durable draft-PR work record, CTL-783)
were silently **orphaned**: the new branch didn't contain them, so the pipeline resumed from scratch
and the pushed work was stranded.

This change makes worktree creation **resume from the pushed work**: when `origin/<ticket>` exists,
the fresh branch is seeded from it instead of from base. Both normal dispatch and cross-host reclaim
(`defaultRebuildWorktree`) rebuild on the dead host's pushed commits rather than discarding them.

## Changes Made

- **`plugins/dev/scripts/create-worktree.sh`** — seed a fresh branch from `origin/<ticket>` when
  that remote branch exists (default-on). New `--no-from-remote` flag opts out and preserves the
  old base-tip behavior. The remote ref is resolved straight from git, not by reading `.draftPr`.
- **`plugins/dev/scripts/execution-core/recovery.mjs`** — comment-only: document that
  `defaultRebuildWorktree` now inherits the origin-seed behavior through the shared `create-worktree.sh`
  argv, so cross-host reclaim rebuilds on pushed work with no extra flag.
- **`plugins/dev/scripts/__tests__/create-worktree-base-ref.test.sh`** — coverage for the
  origin-seed path and the `--no-from-remote` opt-out.
- **`docs/architecture.md`** — "PR as the durable work record" gains a resume-consumer note:
  `origin/<ticket>` is the durable record a new worktree resumes from.

## How to Verify It

- [x] `create-worktree-base-ref.test.sh` covers origin-seed + `--no-from-remote` (green on CI;
      note: this suite is CI-green-only — it rolls back locally on humanlayer-installed hosts).
- [ ] execution-core-unit-tests — 1 unrelated failure: `schedulerTick — board-health seam
      (CTL-1290)`, in `scheduler.mjs` which this PR does not touch (only a comment-only
      `recovery.mjs` edit). Pre-existing scheduler-suite flakiness, not a regression from this diff.
- [x] All other required checks pass (Analyze, CodeQL, docs-gate, validate, agents-md-gate,
      audit-references, check-versions, gitleaks, Cloudflare Pages).

## Related Issues/PRs

- Fixes https://linear.app/coalesce-labs/issue/CTL-1640

<!-- Linear automation guard (CTL-623/CTL-633): unlink sibling tickets so this PR does not drag their workflow status. -->
skip CTL-1290
skip CTL-783