### PR TITLE
fix(dev): board-health-seam test expects capacity.admissionGated (CTL-1607)

### DIFF
--- a/plugins/dev/scripts/execution-core/board-health-seam.test.mjs
+++ b/plugins/dev/scripts/execution-core/board-health-seam.test.mjs
@@ -53,7 +53,7 @@ describe("schedulerTick — board-health seam (CTL-1290 §9.4)", () => {
     expect(calls.length).toBe(1);
     const o = calls[0];
     expect(o.mode).toBe("shadow");
-    expect(o.capacity).toEqual({ maxParallel: 4, liveCount: 4, freeSlots: 0 });
+    expect(o.capacity).toEqual({ maxParallel: 4, liveCount: 4, freeSlots: 0, admissionGated: false });
     expect(o.getEligible().map((e) => e.identifier)).toEqual(["CTL-1", "CTL-2"]);
     expect(typeof o.getWorkerSignals).toBe("function");
   });


### PR DESCRIPTION
## Problem

The required `execution-core-unit-tests` check is **RED on main fleet-wide**, blocking every PR merge. The single failing test is:

```
(fail) schedulerTick — board-health seam (CTL-1290 §9.4) > threads boardHealth → boardHealthPassFn called once with capacity + eligible
```

CTL-1607 added `admissionGated` to the capacity object the scheduler threads into `boardHealthPassFn` (`scheduler.mjs:5417`) but did not update this seam test's exact-match `toEqual` at `board-health-seam.test.mjs:56`. The received object now carries `admissionGated: false`, so the assertion fails.

## Fix

One-line, test-only: add the expected `admissionGated: false` field to the asserted capacity object. Value in the harness is `false` (liveness fresh, not draining). No runtime change.

## Verification

`bun test board-health-seam.test.mjs` → 13 pass / 0 fail (was 12/1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)