### PR TITLE
fix(dev): CTL-1649 — fleet-wide triage cap + exclude launch-failure tickets from board-health recovery

### DIFF
--- a/plugins/dev/scripts/execution-core/board-health.mjs
+++ b/plugins/dev/scripts/execution-core/board-health.mjs
@@ -419,6 +419,11 @@ export function assembleBoardState({
   // observable:false (shadow-first seam: wiring lands before the timer populates).
   getStalledPrState = () => new Map(),
   now = () => Date.now(),
+  // CTL-1649: does a triage.json artifact exist for a given ticket? Injected so
+  // board-health.mjs stays fs-free (no fs import). Default () => true is
+  // inert/shadow-safe: !present is always false → nothing is excluded until the
+  // daemon binds the real fs check. See selectAnchorCandidates.
+  hasTriageArtifact = () => true,
 } = {}) {
   const nowMs = now();
   const safe = (fn, fallback) => {
@@ -451,6 +456,9 @@ export function assembleBoardState({
       // injected brief carries it per-ticket (consumed by the stuck-PR cohort
       // brief) without re-reading each signal file.
       failureReason: s.raw?.failureReason ?? s.failureReason ?? null,
+      // CTL-1649: preserve attentionReason so selectAnchorCandidates can exclude
+      // tickets whose ONLY non-clean signal is a triage launch failure.
+      attentionReason: s.raw?.attentionReason ?? s.attentionReason ?? null,
     };
   });
 
@@ -462,6 +470,42 @@ export function assembleBoardState({
     state: e.state ?? e.linear_state ?? null,
     updatedAt: e.updatedAt ?? e.updated_at ?? null,
   }));
+
+  // CTL-1649: compute the set of tickets whose ONLY non-clean signal is a triage
+  // launch failure. These are excluded from selectAnchorCandidates (the actuation
+  // gate) so the monitor's triage retry path retains sole ownership of the worktree.
+  //
+  // A ticket is in the set iff:
+  //   - it has ≥1 triage launch-failure signal: phase=="triage", status∈NEEDS_HUMAN_STATUSES,
+  //     attentionReason truthy, and no triage.json artifact (hasTriageArtifact seam returns false)
+  //   - it has 0 other non-clean signals for OTHER phases/statuses
+  //
+  // With the default hasTriageArtifact seam (() => true), !present is always false
+  // → isLaunchFailure is always false → the set is always empty → inert (shadow-safe,
+  // the daemon activates it by binding the real fs check).
+  const isLaunchFailureSignal = (s) =>
+    s.phase === "triage" &&
+    NEEDS_HUMAN_STATUSES.has((s.status ?? "").toLowerCase()) &&
+    !!s.attentionReason &&
+    !hasTriageArtifact(s.ticket);
+
+  const isOtherStuckSignal = (s) =>
+    NEEDS_HUMAN_STATUSES.has((s.status ?? "").toLowerCase()) && !isLaunchFailureSignal(s);
+
+  const triageLaunchFailureOnlyTickets = new Set();
+  // Group signals by ticket to check for the "only launch-failure signals" predicate.
+  const signalsByTicket = new Map();
+  for (const s of signals) {
+    if (!s.ticket) continue;
+    const arr = signalsByTicket.get(s.ticket);
+    if (arr) arr.push(s);
+    else signalsByTicket.set(s.ticket, [s]);
+  }
+  for (const [ticket, sigs] of signalsByTicket) {
+    if (sigs.some(isLaunchFailureSignal) && !sigs.some(isOtherStuckSignal)) {
+      triageLaunchFailureOnlyTickets.add(ticket);
+    }
+  }
 
   return Object.freeze({
     ticketsById,
@@ -510,6 +554,12 @@ export function assembleBoardState({
     // shadow/enforce invoke getStrandedEvidence() once per proceeding scan.
     strandedEvidence: mode === "off" ? new Map() : safe(() => getStrandedEvidence(), new Map()),
     now: nowMs,
+    // CTL-1649: tickets whose ONLY non-clean signal is a triage launch failure.
+    // selectAnchorCandidates excludes these from anchor candidates so the monitor's
+    // triage retry path retains sole ownership of the worktree. With the default
+    // hasTriageArtifact seam this is always an empty Set (shadow-safe, inert until
+    // the daemon binds the real fs check at the scheduler call site).
+    triageLaunchFailureOnlyTickets,
   });
 }
 
@@ -1462,10 +1512,19 @@ export function selectAnchorCandidates(moves, board, { holistic = false, strande
       return true; // fail-open: a broken HRW read must not block self-owned actuation
     }
   };
+  // CTL-1649: tickets whose ONLY non-clean signal is a triage launch failure are
+  // excluded from anchor candidates — the monitor's triage retry path owns that
+  // worktree and must not be raced by a holistic recovery-pass.
+  // A ticket with a completed triage artifact and a stuck post-triage phase is
+  // NOT in this set and remains anchor-eligible. With the default board shape
+  // (no hasTriageArtifact seam bound), the set is empty and this is a no-op.
+  const excluded = board?.triageLaunchFailureOnlyTickets instanceof Set
+    ? board.triageLaunchFailureOnlyTickets
+    : new Set();
   const out = [];
   const seen = new Set();
   const add = (t) => {
-    if (t && !seen.has(t)) {
+    if (t && !excluded.has(t) && !seen.has(t)) {
       seen.add(t);
       out.push(t);
     }
@@ -1715,6 +1774,8 @@ export function boardHealthPass({
   act = undefined, // ONLY reachable in enforce; the daemon injects it (CTL-1300), shadow/off never do
   now = () => Date.now(),
   log = () => {},
+  // CTL-1649: triage artifact presence seam (daemon-bound); default inert (→ empty exclusion set).
+  hasTriageArtifact = undefined,
 } = {}) {
   if (mode === "off") return { ran: false, reason: "off" }; // strict no-op
   const nowMs = now();
@@ -1733,6 +1794,8 @@ export function boardHealthPass({
     getDeferredBoardHealthTickets, sanctionedNeedsHuman, // CTL-1432 (B2/B3)
     getStrandedEvidence, // CTL-1644: per-ticket evidence seam (empty-Map default if unbound)
     getStalledPrState, // CTL-1608: stalled-PR stamp seam (empty-Map default if unbound)
+    // CTL-1649: thread the daemon-injected triage artifact seam (undefined → default inert).
+    ...(hasTriageArtifact !== undefined ? { hasTriageArtifact } : {}),
   });
   const invariants = evaluateInvariants(board, { mode });
   const dec = decideBoardHealth(invariants, board);

--- a/plugins/dev/scripts/execution-core/board-health.test.mjs
+++ b/plugins/dev/scripts/execution-core/board-health.test.mjs
@@ -2358,3 +2358,197 @@ describe("CTL-1608 checkStalledPr — review/CI/no-push staleness, liveness-inde
     expect(ctx.stalledPrs).toContain("CTL-CI");
   });
 });
+// ─── CTL-1649: triageLaunchFailureOnlyTickets + selectAnchorCandidates exclusion ─
+
+describe("assembleBoardState — attentionReason on signals (CTL-1649)", () => {
+  test("attentionReason from s.raw?.attentionReason is carried on the normalised signal", () => {
+    const board = assembleBoardState({
+      getWorkerSignals: () => [
+        { ticket: "CTL-1", phase: "triage", status: "stalled", raw: { attentionReason: "sdk-overloaded-exhausted" } },
+      ],
+    });
+    expect(board.signals[0].attentionReason).toBe("sdk-overloaded-exhausted");
+  });
+
+  test("attentionReason from s.attentionReason (flat) is carried when raw is absent", () => {
+    const board = assembleBoardState({
+      getWorkerSignals: () => [
+        { ticket: "CTL-2", phase: "triage", status: "stalled", attentionReason: "sdk-launch-failed" },
+      ],
+    });
+    expect(board.signals[0].attentionReason).toBe("sdk-launch-failed");
+  });
+
+  test("attentionReason is null when absent on both raw and flat", () => {
+    const board = assembleBoardState({
+      getWorkerSignals: () => [{ ticket: "CTL-3", phase: "triage", status: "stalled" }],
+    });
+    expect(board.signals[0].attentionReason).toBeNull();
+  });
+
+  test("existing fields (ticket, phase, status, failureReason) are byte-identical (no regression)", () => {
+    const board = assembleBoardState({
+      getWorkerSignals: () => [
+        { ticket: "CTL-4", phase: "implement", status: "running", raw: { failureReason: "timeout" } },
+      ],
+    });
+    const s = board.signals[0];
+    expect(s.ticket).toBe("CTL-4");
+    expect(s.phase).toBe("implement");
+    expect(s.status).toBe("running");
+    expect(s.failureReason).toBe("timeout");
+  });
+});
+
+describe("assembleBoardState — triageLaunchFailureOnlyTickets (CTL-1649)", () => {
+  const launchFailSig = (ticket, overrides = {}) => ({
+    ticket,
+    phase: "triage",
+    status: "stalled",
+    attentionReason: "sdk-overloaded-exhausted",
+    ...overrides,
+  });
+
+  test("Scenario 1: triage launch-failure ticket with no artifact → IN the set (hasTriageArtifact returns false)", () => {
+    const board = assembleBoardState({
+      getWorkerSignals: () => [launchFailSig("CTL-1")],
+      hasTriageArtifact: () => false,
+    });
+    expect(board.triageLaunchFailureOnlyTickets instanceof Set).toBe(true);
+    expect(board.triageLaunchFailureOnlyTickets.has("CTL-1")).toBe(true);
+  });
+
+  test("Scenario 2: same ticket but hasTriageArtifact returns true → NOT in the set (real triage completed)", () => {
+    const board = assembleBoardState({
+      getWorkerSignals: () => [launchFailSig("CTL-1")],
+      hasTriageArtifact: () => true,
+    });
+    expect(board.triageLaunchFailureOnlyTickets.has("CTL-1")).toBe(false);
+  });
+
+  test("Scenario: triage stall without attentionReason → NOT in the set (non-launch triage stall stays actionable)", () => {
+    const board = assembleBoardState({
+      getWorkerSignals: () => [{ ticket: "CTL-1", phase: "triage", status: "stalled" }],
+      hasTriageArtifact: () => false,
+    });
+    expect(board.triageLaunchFailureOnlyTickets.has("CTL-1")).toBe(false);
+  });
+
+  test("Scenario 3: triage launch-failure AND a separate implement stall → NOT in the set (real post-triage work)", () => {
+    const board = assembleBoardState({
+      getWorkerSignals: () => [
+        launchFailSig("CTL-1"),
+        { ticket: "CTL-1", phase: "implement", status: "stalled" },
+      ],
+      hasTriageArtifact: () => false,
+    });
+    expect(board.triageLaunchFailureOnlyTickets.has("CTL-1")).toBe(false);
+  });
+
+  test("with default hasTriageArtifact seam (unbound), set is always empty (shadow-safe)", () => {
+    const board = assembleBoardState({
+      getWorkerSignals: () => [launchFailSig("CTL-1")],
+      // hasTriageArtifact defaults to () => true
+    });
+    expect(board.triageLaunchFailureOnlyTickets.size).toBe(0);
+  });
+
+  test("a ticket in the set with needs_human status variant is also excluded", () => {
+    const board = assembleBoardState({
+      getWorkerSignals: () => [{
+        ticket: "CTL-1", phase: "triage", status: "needs_human",
+        attentionReason: "sdk-launch-failed",
+      }],
+      hasTriageArtifact: () => false,
+    });
+    expect(board.triageLaunchFailureOnlyTickets.has("CTL-1")).toBe(true);
+  });
+});
+
+describe("selectAnchorCandidates — CTL-1649 triage-launch-failure exclusion", () => {
+  const launchFailBoard = (ticket, extraSignals = []) =>
+    assembleBoardState({
+      getWorkerSignals: () => [
+        { ticket, phase: "triage", status: "stalled", attentionReason: "sdk-overloaded" },
+        ...extraSignals,
+      ],
+      hasTriageArtifact: () => false,
+    });
+
+  test("Acceptance 2: a tier-1 holistic-triage move for a launch-failure-only ticket is ABSENT from candidates", () => {
+    const board = launchFailBoard("CTL-1");
+    const moves = { tier1: [{ ticket: "CTL-1" }], tier2: [], tier3: [] };
+    const out = selectAnchorCandidates(moves, board);
+    expect(out).not.toContain("CTL-1");
+  });
+
+  test("Acceptance 3: a ticket with triage artifact (completed triage) + stalled implement → STILL a candidate", () => {
+    const board = assembleBoardState({
+      getWorkerSignals: () => [
+        { ticket: "CTL-2", phase: "triage", status: "stalled", attentionReason: "sdk-overloaded" },
+        { ticket: "CTL-2", phase: "implement", status: "stalled" },
+      ],
+      hasTriageArtifact: () => false, // no artifact, but the other-stuck signal removes it from exclusion
+    });
+    const moves = { tier1: [{ ticket: "CTL-2" }], tier2: [], tier3: [] };
+    const out = selectAnchorCandidates(moves, board);
+    expect(out).toContain("CTL-2");
+  });
+
+  test("with empty exclusion set (unbound seam), output is byte-identical to today", () => {
+    // Use assembleBoardState with default seam → triageLaunchFailureOnlyTickets is empty
+    const board = assembleBoardState({
+      getWorkerSignals: () => [{ ticket: "CTL-3", phase: "triage", status: "stalled", attentionReason: "sdk" }],
+      // default hasTriageArtifact → () => true → exclusion set empty
+    });
+    const moves = { tier1: [{ ticket: "CTL-3" }], tier2: [], tier3: [] };
+    const out = selectAnchorCandidates(moves, board);
+    expect(out).toContain("CTL-3"); // NOT excluded — byte-identical to pre-CTL-1649
+  });
+
+  test("exclusion applies across all source lists (tier1, tier2, eligible, deferred)", () => {
+    const board = assembleBoardState({
+      getWorkerSignals: () => [
+        { ticket: "CTL-EXCL", phase: "triage", status: "stalled", attentionReason: "sdk" },
+      ],
+      hasTriageArtifact: () => false,
+      eligible: [{ identifier: "CTL-EXCL" }],
+      getDeferredBoardHealthTickets: () => ["CTL-EXCL"],
+    });
+    const moves = {
+      tier1: [{ ticket: "CTL-EXCL" }],
+      tier2: [{ ticket: "CTL-EXCL" }],
+      tier3: [],
+    };
+    const out = selectAnchorCandidates(moves, board);
+    expect(out).not.toContain("CTL-EXCL");
+  });
+});
+
+describe("boardHealthPass enforce — launch-failure exclusion prevents recovery-pass dispatch (CTL-1649)", () => {
+  test("when the sole flagged ticket is a launch-failure-only ticket, act is NOT invoked", () => {
+    let actInvoked = false;
+    boardHealthPass({
+      mode: "enforce",
+      lastRunMs: 0,
+      intervalMs: 0,
+      now: () => NOW,
+      emit: () => {},
+      act: (ctx) => {
+        // selectAnchorCandidates should return [] (the ticket is excluded),
+        // so act's candidates array is empty and it returns no-owned-anchor.
+        actInvoked = ctx.candidates && ctx.candidates.length > 0;
+        return { dispatched: false, anchor: null, skippedReason: "no-owned-anchor" };
+      },
+      getWorkerSignals: () => [
+        { ticket: "CTL-EXCL", phase: "triage", status: "stalled", attentionReason: "sdk-overloaded" },
+      ],
+      hasTriageArtifact: () => false,
+      // The invariant must fire so the gate proceeds
+      capacity: { maxParallel: 4, liveCount: 0, freeSlots: 4 },
+      eligible: [{ identifier: "CTL-EXCL", state: "Todo" }],
+    });
+    expect(actInvoked).toBe(false);
+  });
+});
+

--- a/plugins/dev/scripts/execution-core/cluster-claim-sync.mjs
+++ b/plugins/dev/scripts/execution-core/cluster-claim-sync.mjs
@@ -294,3 +294,112 @@ export function fenceCheckSyncCached({ ticket, generation }, { now = Date.now, e
   }
   return result;
 }
+
+// ─── in-process TTL cache around the triage attempt count read (CTL-1649) ────
+//
+// The triage re-dispatch cap gate (monitor.mjs dispatchTriage) calls
+// readTriageAttemptCountSync before EVERY triage sweep sweep for each
+// multi-host candidate. Each call spawns a FRESH `node cluster-claim.mjs
+// read-triage-attempt <ticket>` subprocess that issues a Linear attachment
+// read. A TTL cache mirrors fenceCheckSyncCached's design: keyed by ticket
+// (not ticket+generation — the count is the answer, not a generation check),
+// TTL 30s default (CATALYST_TRIAGE_ATTEMPT_CACHE_MS). Bumps always invalidate
+// the cache entry so a fresh count is visible on the very next cap-gate read.
+//
+// Only a determinate numeric count (>= 0) is cached. A null (fence-absent or
+// spawn failure) is never cached — null is the fail-open signal, and latching
+// it would suppress all future reads for the TTL duration.
+const TRIAGE_ATTEMPT_CACHE_MS_DEFAULT = 30_000;
+const triageAttemptCache = new Map();
+
+// clearTriageAttemptCacheSync — test-only reset of the module-scope cache.
+export function clearTriageAttemptCacheSync() {
+  triageAttemptCache.clear();
+}
+
+function resolveTriageAttemptCacheMs(env) {
+  const raw = Number(env?.CATALYST_TRIAGE_ATTEMPT_CACHE_MS);
+  return Number.isFinite(raw) && raw >= 0 ? raw : TRIAGE_ATTEMPT_CACHE_MS_DEFAULT;
+}
+
+// readTriageAttemptCountSync — spawn `node cluster-claim.mjs read-triage-attempt
+// <ticket>` and return `{ count }`. `count` is the fleet-wide triage attempt
+// count (>= 0) when a fence exists, or null when no fence is found (fence-absent
+// → caller fails open to host-local counting). Also null on any spawn failure.
+// A TTL cache (keyed by ticket) coalesces repeated reads within the same sweep
+// cycle. `now` is injectable for tests.
+export function readTriageAttemptCountSync(
+  { ticket },
+  {
+    spawn = spawnSync,
+    nodeBin = process.execPath,
+    cli = CLUSTER_CLAIM_CLI,
+    env = process.env,
+    timeout = CLAIM_TIMEOUT_MS,
+    now = Date.now,
+  } = {},
+) {
+  const ttlMs = resolveTriageAttemptCacheMs(env);
+  if (ttlMs > 0) {
+    const cached = triageAttemptCache.get(ticket);
+    if (cached && now() - cached.ts < ttlMs) {
+      return { count: cached.count };
+    }
+  }
+  try {
+    const res = spawn(nodeBin, [cli, "read-triage-attempt", ticket], {
+      encoding: "utf8",
+      env,
+      timeout,
+    });
+    if (!res || res.status !== 0 || typeof res.stdout !== "string") {
+      return { count: null };
+    }
+    const line = res.stdout.trim().split("\n").filter(Boolean).pop();
+    const parsed = JSON.parse(line);
+    const count = typeof parsed?.count === "number" ? parsed.count : null;
+    if (ttlMs > 0 && count !== null) {
+      triageAttemptCache.set(ticket, { count, ts: now() });
+    }
+    return { count };
+  } catch {
+    return { count: null };
+  }
+}
+
+// bumpTriageAttemptCountSync — spawn `node cluster-claim.mjs bump-triage-attempt
+// <ticket>`. Always invalidates the TTL cache for that ticket (a bump means the
+// stored count is now stale — the next read must go live). Returns `{ count }`
+// where `count` is the new fleet-wide count on success, or null on any failure
+// (best-effort — never throws).
+export function bumpTriageAttemptCountSync(
+  { ticket },
+  {
+    spawn = spawnSync,
+    nodeBin = process.execPath,
+    cli = CLUSTER_CLAIM_CLI,
+    env = process.env,
+    timeout = CLAIM_TIMEOUT_MS,
+  } = {},
+) {
+  // Invalidate before the spawn: even if the write fails, the caller
+  // (bumpTriageDispatchCount in monitor.mjs) is about to act on the count
+  // having changed — stale cached reads post-bump are always wrong.
+  triageAttemptCache.delete(ticket);
+  try {
+    const res = spawn(nodeBin, [cli, "bump-triage-attempt", ticket], {
+      encoding: "utf8",
+      env,
+      timeout,
+    });
+    if (!res || res.status !== 0 || typeof res.stdout !== "string") {
+      return { count: null };
+    }
+    const line = res.stdout.trim().split("\n").filter(Boolean).pop();
+    const parsed = JSON.parse(line);
+    const count = typeof parsed?.count === "number" ? parsed.count : null;
+    return { count };
+  } catch {
+    return { count: null };
+  }
+}

--- a/plugins/dev/scripts/execution-core/cluster-claim-sync.test.mjs
+++ b/plugins/dev/scripts/execution-core/cluster-claim-sync.test.mjs
@@ -12,6 +12,9 @@ import {
   resolveIssueIdSync,
   resolveIssueIdSyncCached,
   clearIssueIdCache,
+  readTriageAttemptCountSync,
+  bumpTriageAttemptCountSync,
+  clearTriageAttemptCacheSync,
 } from "./cluster-claim-sync.mjs";
 
 describe("claimDispatchSync — argv + parsing", () => {
@@ -419,5 +422,169 @@ describe("claimDispatchSync — pre-resolved issueId is threaded into the claim 
       { spawn, nodeBin: "/usr/bin/node", cli: "/x/cluster-claim.mjs" },
     );
     expect(claimArgs).toEqual(["/x/cluster-claim.mjs", "claim", "CTL-9", "mini", "triage"]);
+  });
+});
+
+// ─── CTL-1649: readTriageAttemptCountSync ────────────────────────────────────
+
+describe("readTriageAttemptCountSync — argv + parsing (CTL-1649)", () => {
+  beforeEach(() => {
+    clearTriageAttemptCacheSync();
+  });
+
+  it("builds the right argv: node <cli> read-triage-attempt <ticket>", () => {
+    let captured;
+    const spawn = (bin, args) => {
+      captured = { bin, args };
+      return { status: 0, stdout: JSON.stringify({ count: 2 }) + "\n" };
+    };
+    readTriageAttemptCountSync(
+      { ticket: "CTL-1649" },
+      { spawn, nodeBin: "/usr/bin/node", cli: "/x/cluster-claim.mjs", env: { CATALYST_TRIAGE_ATTEMPT_CACHE_MS: "0" } },
+    );
+    expect(captured.bin).toBe("/usr/bin/node");
+    expect(captured.args).toEqual(["/x/cluster-claim.mjs", "read-triage-attempt", "CTL-1649"]);
+  });
+
+  it("parses { count } from exit-0 stdout", () => {
+    const spawn = () => ({ status: 0, stdout: JSON.stringify({ count: 3 }) + "\n" });
+    const result = readTriageAttemptCountSync(
+      { ticket: "CTL-1649" },
+      { spawn, env: { CATALYST_TRIAGE_ATTEMPT_CACHE_MS: "0" } },
+    );
+    expect(result).toEqual({ count: 3 });
+  });
+
+  it("count:0 is a valid determinate result (fence exists, no bumps yet)", () => {
+    const spawn = () => ({ status: 0, stdout: JSON.stringify({ count: 0 }) + "\n" });
+    expect(readTriageAttemptCountSync({ ticket: "CTL-1649" }, { spawn, env: { CATALYST_TRIAGE_ATTEMPT_CACHE_MS: "0" } }))
+      .toEqual({ count: 0 });
+  });
+
+  it("count:null is passed through (fence-absent — fail-open)", () => {
+    const spawn = () => ({ status: 0, stdout: JSON.stringify({ count: null }) + "\n" });
+    expect(readTriageAttemptCountSync({ ticket: "CTL-1649" }, { spawn, env: { CATALYST_TRIAGE_ATTEMPT_CACHE_MS: "0" } }))
+      .toEqual({ count: null });
+  });
+
+  it("non-zero exit → { count: null } (fail-open)", () => {
+    const spawn = () => ({ status: 1, stdout: "" });
+    expect(readTriageAttemptCountSync({ ticket: "CTL-1649" }, { spawn, env: { CATALYST_TRIAGE_ATTEMPT_CACHE_MS: "0" } }))
+      .toEqual({ count: null });
+  });
+
+  it("spawn error → { count: null } (never propagates)", () => {
+    const spawn = () => { throw new Error("EACCES"); };
+    expect(readTriageAttemptCountSync({ ticket: "CTL-1649" }, { spawn, env: { CATALYST_TRIAGE_ATTEMPT_CACHE_MS: "0" } }))
+      .toEqual({ count: null });
+  });
+
+  it("two reads within TTL → ONE spawn call (cache hit)", () => {
+    let calls = 0;
+    const spawn = () => { calls++; return { status: 0, stdout: JSON.stringify({ count: 2 }) + "\n" }; };
+    let now = 1_000_000;
+    const env = { CATALYST_TRIAGE_ATTEMPT_CACHE_MS: "30000" };
+    readTriageAttemptCountSync({ ticket: "CTL-1649" }, { spawn, env, now: () => now });
+    now += 5_000; // within TTL
+    readTriageAttemptCountSync({ ticket: "CTL-1649" }, { spawn, env, now: () => now });
+    expect(calls).toBe(1);
+  });
+
+  it("two reads beyond TTL → TWO spawn calls (cache expired)", () => {
+    let calls = 0;
+    const spawn = () => { calls++; return { status: 0, stdout: JSON.stringify({ count: 2 }) + "\n" }; };
+    let now = 1_000_000;
+    const env = { CATALYST_TRIAGE_ATTEMPT_CACHE_MS: "30000" };
+    readTriageAttemptCountSync({ ticket: "CTL-1649" }, { spawn, env, now: () => now });
+    now += 31_000; // beyond TTL
+    readTriageAttemptCountSync({ ticket: "CTL-1649" }, { spawn, env, now: () => now });
+    expect(calls).toBe(2);
+  });
+
+  it("TTL=0 disables the cache (every call spawns)", () => {
+    let calls = 0;
+    const spawn = () => { calls++; return { status: 0, stdout: JSON.stringify({ count: 1 }) + "\n" }; };
+    const env = { CATALYST_TRIAGE_ATTEMPT_CACHE_MS: "0" };
+    readTriageAttemptCountSync({ ticket: "CTL-1649" }, { spawn, env });
+    readTriageAttemptCountSync({ ticket: "CTL-1649" }, { spawn, env });
+    expect(calls).toBe(2);
+  });
+
+  it("null result (fence-absent) is NOT cached (retries on the next call)", () => {
+    let calls = 0;
+    const spawn = () => { calls++; return { status: 0, stdout: JSON.stringify({ count: null }) + "\n" }; };
+    const env = { CATALYST_TRIAGE_ATTEMPT_CACHE_MS: "30000" };
+    let now = 1_000_000;
+    readTriageAttemptCountSync({ ticket: "CTL-1649" }, { spawn, env, now: () => now });
+    now += 1_000;
+    readTriageAttemptCountSync({ ticket: "CTL-1649" }, { spawn, env, now: () => now });
+    expect(calls).toBe(2);
+  });
+});
+
+describe("bumpTriageAttemptCountSync — argv + parsing (CTL-1649)", () => {
+  beforeEach(() => {
+    clearTriageAttemptCacheSync();
+  });
+
+  it("builds the right argv: node <cli> bump-triage-attempt <ticket>", () => {
+    let captured;
+    const spawn = (bin, args) => {
+      captured = { bin, args };
+      return { status: 0, stdout: JSON.stringify({ count: 1 }) + "\n" };
+    };
+    bumpTriageAttemptCountSync(
+      { ticket: "CTL-1649" },
+      { spawn, nodeBin: "/usr/bin/node", cli: "/x/cluster-claim.mjs" },
+    );
+    expect(captured.bin).toBe("/usr/bin/node");
+    expect(captured.args).toEqual(["/x/cluster-claim.mjs", "bump-triage-attempt", "CTL-1649"]);
+  });
+
+  it("returns parsed { count } on success", () => {
+    const spawn = () => ({ status: 0, stdout: JSON.stringify({ count: 3 }) + "\n" });
+    expect(bumpTriageAttemptCountSync({ ticket: "CTL-1649" }, { spawn })).toEqual({ count: 3 });
+  });
+
+  it("non-zero exit → { count: null } (best-effort, never throws)", () => {
+    const spawn = () => ({ status: 1, stdout: "" });
+    expect(bumpTriageAttemptCountSync({ ticket: "CTL-1649" }, { spawn })).toEqual({ count: null });
+  });
+
+  it("spawn throws → { count: null } (never propagates)", () => {
+    const spawn = () => { throw new Error("ETIMEDOUT"); };
+    expect(bumpTriageAttemptCountSync({ ticket: "CTL-1649" }, { spawn })).toEqual({ count: null });
+  });
+
+  it("invalidates the cache for that ticket after a bump (next read goes live)", () => {
+    let spawnCalls = 0;
+    const spawn = () => {
+      spawnCalls++;
+      return { status: 0, stdout: JSON.stringify({ count: spawnCalls }) + "\n" };
+    };
+    const env = { CATALYST_TRIAGE_ATTEMPT_CACHE_MS: "30000" };
+    let now = 1_000_000;
+    // Populate cache with count=1
+    readTriageAttemptCountSync({ ticket: "CTL-1649" }, { spawn, env, now: () => now });
+    expect(spawnCalls).toBe(1);
+    // Bump invalidates cache
+    bumpTriageAttemptCountSync({ ticket: "CTL-1649" }, { spawn, env });
+    expect(spawnCalls).toBe(2); // bump spawned
+    // Next read goes live (cache was invalidated)
+    now += 1_000;
+    readTriageAttemptCountSync({ ticket: "CTL-1649" }, { spawn, env, now: () => now });
+    expect(spawnCalls).toBe(3); // fresh spawn after invalidation
+  });
+
+  it("clearTriageAttemptCacheSync resets the module-scope cache", () => {
+    let calls = 0;
+    const spawn = () => { calls++; return { status: 0, stdout: JSON.stringify({ count: 1 }) + "\n" }; };
+    const env = { CATALYST_TRIAGE_ATTEMPT_CACHE_MS: "30000" };
+    let now = 1_000_000;
+    readTriageAttemptCountSync({ ticket: "CTL-1649" }, { spawn, env, now: () => now });
+    clearTriageAttemptCacheSync();
+    now += 1_000;
+    readTriageAttemptCountSync({ ticket: "CTL-1649" }, { spawn, env, now: () => now });
+    expect(calls).toBe(2);
   });
 });

--- a/plugins/dev/scripts/execution-core/cluster-claim.mjs
+++ b/plugins/dev/scripts/execution-core/cluster-claim.mjs
@@ -139,16 +139,20 @@ const READ_ATTACHMENTS_QUERY = `query ReadFence($id: String!) {
 // parseClaimMetadata — normalise an attachment's metadata into the flat claim
 // record callers consume. `catalyst_generation` is coerced to a Number; a
 // missing/unparseable generation becomes null so isFenceCurrent never reads a
-// stale string as a match. Exported for unit coverage.
+// stale string as a match. `triage_attempt_count` is coerced similarly but
+// defaults to 0 (not null) — a count fails open to 0 so the cap gate
+// under-counts rather than falsely parks. Exported for unit coverage.
 export function parseClaimMetadata(metadata) {
   const m = metadata ?? {};
   const genRaw = m.catalyst_generation;
   const generation = Number(genRaw);
+  const attemptCount = Number(m.triage_attempt_count);
   return {
     owner_host: m.owner_host ?? null,
     generation: Number.isFinite(generation) ? generation : null,
     phase: m.phase ?? null,
     claimed_at: m.claimed_at ?? null,
+    triage_attempt_count: Number.isFinite(attemptCount) && attemptCount >= 0 ? attemptCount : 0,
   };
 }
 
@@ -192,19 +196,22 @@ const WRITE_ATTACHMENT_MUTATION = `mutation UpsertFence($input: AttachmentCreate
 // the original resolveIssueId(ticket) call, so behavior is unchanged when omitted.
 export async function writeClaim(
   ticket,
-  { owner_host, generation, phase },
-  { post = defaultPost, issueId: issueIdOverride = null } = {},
+  { owner_host, generation, phase, triage_attempt_count = 0 },
+  { post = defaultPost, issueId: issueIdOverride = null, preserveClaimedAt = null } = {},
 ) {
   const issueId = issueIdOverride || (await resolveIssueId(ticket, { post }));
   if (!issueId) {
     throw new Error(`cluster-claim: no issue found for identifier ${ticket}`);
   }
-  const claimed_at = new Date().toISOString();
+  // preserveClaimedAt allows a count-only bump to avoid resetting the CTL-1297
+  // staleness clock — a mere triage_attempt_count increment is not a takeover.
+  const claimed_at = preserveClaimedAt ?? new Date().toISOString();
   const metadata = {
     owner_host,
     catalyst_generation: generation,
     phase,
     claimed_at,
+    triage_attempt_count,
   };
   const data = await post(WRITE_ATTACHMENT_MUTATION, {
     input: {
@@ -218,6 +225,39 @@ export async function writeClaim(
     throw new Error(`cluster-claim: attachmentCreate returned success=false for ${ticket}`);
   }
   return parseClaimMetadata(metadata);
+}
+
+// ─── triage attempt count ────────────────────────────────────────────────────
+
+// readTriageAttemptCount — the fleet-wide triage attempt count from the fence
+// attachment. Returns the count (≥0) when a fence exists, or null when no
+// catalyst://fence/ attachment is found (fence-absent → caller fails open to
+// host-local counting). A zero count is a valid result (fence exists but no
+// attempts have been bumped yet, e.g. immediately after a fresh claim).
+export async function readTriageAttemptCount(ticket, { post = defaultPost } = {}) {
+  const c = await readClaim(ticket, { post });
+  return c ? (c.triage_attempt_count ?? 0) : null;
+}
+
+// bumpTriageAttemptCount — increment the fleet-wide triage attempt count on the
+// fence attachment. Preserves owner_host, catalyst_generation, phase, and
+// claimed_at (does NOT bump the generation — this is not a takeover). Returns
+// the new count on success, or null when no fence exists (best-effort no-op).
+export async function bumpTriageAttemptCount(ticket, { post = defaultPost, issueId = null } = {}) {
+  const current = await readClaim(ticket, { post });
+  if (!current) return null; // no fence — no-op, fail-open
+  const newCount = (current.triage_attempt_count ?? 0) + 1;
+  await writeClaim(
+    ticket,
+    {
+      owner_host: current.owner_host,
+      generation: current.generation,
+      phase: current.phase,
+      triage_attempt_count: newCount,
+    },
+    { post, issueId, preserveClaimedAt: current.claimed_at },
+  );
+  return newCount;
 }
 
 // ─── soft-CAS claim ──────────────────────────────────────────────────────────
@@ -333,10 +373,22 @@ export async function runCli(argv, { post = defaultPost } = {}) {
       process.stdout.write(JSON.stringify({ issueId }) + "\n");
       return 0;
     }
+    case "read-triage-attempt": {
+      const [ticket] = rest;
+      const count = await readTriageAttemptCount(ticket, { post });
+      process.stdout.write(JSON.stringify({ count }) + "\n");
+      return 0;
+    }
+    case "bump-triage-attempt": {
+      const [ticket] = rest;
+      const count = await bumpTriageAttemptCount(ticket, { post });
+      process.stdout.write(JSON.stringify({ count }) + "\n");
+      return 0;
+    }
     default:
       process.stderr.write(
         `cluster-claim.mjs: unknown subcommand: ${cmd ?? "(none)"}\n` +
-          "usage: cluster-claim.mjs <claim <ticket> <host> <phase> [issueId] | fence-check <ticket> <gen> | resolve-issue-id <ticket>>\n",
+          "usage: cluster-claim.mjs <claim <ticket> <host> <phase> [issueId] | fence-check <ticket> <gen> | resolve-issue-id <ticket> | read-triage-attempt <ticket> | bump-triage-attempt <ticket>>\n",
       );
       return 1;
   }

--- a/plugins/dev/scripts/execution-core/cluster-claim.test.mjs
+++ b/plugins/dev/scripts/execution-core/cluster-claim.test.mjs
@@ -16,6 +16,8 @@ import {
   writeClaim,
   claimTicket,
   isFenceCurrent,
+  readTriageAttemptCount,
+  bumpTriageAttemptCount,
   runCli,
 } from "./cluster-claim.mjs";
 
@@ -128,18 +130,20 @@ describe("parseClaimMetadata — normalisation", () => {
       generation: 3,
       phase: "implement",
       claimed_at: "2026-06-08T00:00:00.000Z",
+      triage_attempt_count: 0,
     });
   });
   it("missing/unparseable generation becomes null", () => {
     expect(parseClaimMetadata({ owner_host: "mini" }).generation).toBeNull();
     expect(parseClaimMetadata({ catalyst_generation: "nope" }).generation).toBeNull();
   });
-  it("empty metadata yields an all-null record", () => {
+  it("empty metadata yields an all-null record except triage_attempt_count which defaults to 0", () => {
     expect(parseClaimMetadata(undefined)).toEqual({
       owner_host: null,
       generation: null,
       phase: null,
       claimed_at: null,
+      triage_attempt_count: 0,
     });
   });
 });
@@ -188,6 +192,7 @@ describe("readClaim — parse the fence attachment", () => {
       generation: 7,
       phase: "verify",
       claimed_at: "2026-06-08T01:00:00.000Z",
+      triage_attempt_count: 0,
     });
   });
 });
@@ -587,6 +592,193 @@ describe("runCli — the spawnSync CLI surface (CTL-850)", () => {
     const result = JSON.parse(out);
     expect(result.won).toBe(true);
     expect(result.generation).toBe(3); // bumped past generation 2
+  });
+});
+
+// ─── CTL-1649: triage_attempt_count field ────────────────────────────────────
+
+describe("parseClaimMetadata — triage_attempt_count (CTL-1649)", () => {
+  it("a numeric value round-trips", () => {
+    const c = parseClaimMetadata({
+      owner_host: "mini",
+      catalyst_generation: "2",
+      phase: "triage",
+      claimed_at: "2026-08-06T00:00:00Z",
+      triage_attempt_count: 3,
+    });
+    expect(c.triage_attempt_count).toBe(3);
+  });
+
+  it("a string-encoded number is coerced", () => {
+    expect(parseClaimMetadata({ triage_attempt_count: "2" }).triage_attempt_count).toBe(2);
+  });
+
+  it("missing → 0 (fail-open: a count defaults to 0, not null)", () => {
+    expect(parseClaimMetadata({}).triage_attempt_count).toBe(0);
+  });
+
+  it("null → 0", () => {
+    expect(parseClaimMetadata({ triage_attempt_count: null }).triage_attempt_count).toBe(0);
+  });
+
+  it("unparseable string → 0", () => {
+    expect(parseClaimMetadata({ triage_attempt_count: "nope" }).triage_attempt_count).toBe(0);
+  });
+
+  it("existing four fields are byte-identical (no regression)", () => {
+    const c = parseClaimMetadata({
+      owner_host: "mac-studio",
+      catalyst_generation: 7,
+      phase: "implement",
+      claimed_at: "2026-08-06T00:00:00Z",
+    });
+    expect(c.owner_host).toBe("mac-studio");
+    expect(c.generation).toBe(7);
+    expect(c.phase).toBe("implement");
+    expect(c.claimed_at).toBe("2026-08-06T00:00:00Z");
+  });
+});
+
+describe("writeClaim — triage_attempt_count (CTL-1649)", () => {
+  it("writes triage_attempt_count into the metadata when supplied", async () => {
+    const { post, store } = makeFakeLinear();
+    await writeClaim("CTL-1649", { owner_host: "mini", generation: 1, phase: "triage", triage_attempt_count: 2 }, { post });
+    expect(store.get("CTL-1649").triage_attempt_count).toBe(2);
+  });
+
+  it("defaults triage_attempt_count to 0 when omitted", async () => {
+    const { post, store } = makeFakeLinear();
+    await writeClaim("CTL-1649", { owner_host: "mini", generation: 1, phase: "triage" }, { post });
+    expect(store.get("CTL-1649").triage_attempt_count).toBe(0);
+  });
+
+  it("preserveClaimedAt keeps the original claimed_at unchanged", async () => {
+    const { post, store } = makeFakeLinear();
+    const original = "2026-07-01T00:00:00Z";
+    await writeClaim(
+      "CTL-1649",
+      { owner_host: "mini", generation: 1, phase: "triage", triage_attempt_count: 1 },
+      { post, preserveClaimedAt: original },
+    );
+    expect(store.get("CTL-1649").claimed_at).toBe(original);
+  });
+
+  it("without preserveClaimedAt, claimed_at is re-stamped", async () => {
+    const { post, store } = makeFakeLinear();
+    const before = Date.now();
+    await writeClaim("CTL-1649", { owner_host: "mini", generation: 1, phase: "triage" }, { post });
+    const after = Date.now();
+    const writtenMs = Date.parse(store.get("CTL-1649").claimed_at);
+    expect(writtenMs).toBeGreaterThanOrEqual(before);
+    expect(writtenMs).toBeLessThanOrEqual(after + 1000);
+  });
+
+  it("other four keys (owner_host, catalyst_generation, phase) are byte-identical to today", async () => {
+    const { post, store } = makeFakeLinear();
+    await writeClaim("CTL-1649", { owner_host: "mac-studio", generation: 5, phase: "plan", triage_attempt_count: 1 }, { post });
+    const m = store.get("CTL-1649");
+    expect(m.owner_host).toBe("mac-studio");
+    expect(m.catalyst_generation).toBe(5);
+    expect(m.phase).toBe("plan");
+  });
+});
+
+describe("readTriageAttemptCount (CTL-1649)", () => {
+  it("returns the fence count when a fence exists", async () => {
+    const { post } = makeFakeLinear({
+      seed: { "CTL-1649": { owner_host: "mini", catalyst_generation: 2, phase: "triage", claimed_at: "t", triage_attempt_count: 3 } },
+    });
+    expect(await readTriageAttemptCount("CTL-1649", { post })).toBe(3);
+  });
+
+  it("returns 0 when fence exists but triage_attempt_count is absent (count fails open to 0)", async () => {
+    const { post } = makeFakeLinear({
+      seed: { "CTL-1649": { owner_host: "mini", catalyst_generation: 1, phase: "triage", claimed_at: "t" } },
+    });
+    expect(await readTriageAttemptCount("CTL-1649", { post })).toBe(0);
+  });
+
+  it("returns null when no catalyst://fence/ attachment exists", async () => {
+    const { post } = makeFakeLinear();
+    expect(await readTriageAttemptCount("CTL-1649", { post })).toBeNull();
+  });
+});
+
+describe("bumpTriageAttemptCount (CTL-1649)", () => {
+  it("increments the count and returns the new value", async () => {
+    const { post, store } = makeFakeLinear({
+      seed: { "CTL-1649": { owner_host: "mini", catalyst_generation: 2, phase: "triage", claimed_at: "2026-08-01T00:00:00Z", triage_attempt_count: 1 } },
+    });
+    const result = await bumpTriageAttemptCount("CTL-1649", { post });
+    expect(result).toBe(2);
+    expect(store.get("CTL-1649").triage_attempt_count).toBe(2);
+  });
+
+  it("preserves owner_host, catalyst_generation, phase (does NOT bump generation)", async () => {
+    const { post, store } = makeFakeLinear({
+      seed: { "CTL-1649": { owner_host: "mac-studio", catalyst_generation: 5, phase: "triage", claimed_at: "2026-08-01T00:00:00Z", triage_attempt_count: 0 } },
+    });
+    await bumpTriageAttemptCount("CTL-1649", { post });
+    const m = store.get("CTL-1649");
+    expect(m.owner_host).toBe("mac-studio");
+    expect(m.catalyst_generation).toBe(5);
+    expect(m.phase).toBe("triage");
+  });
+
+  it("preserves claimed_at (does not re-stamp the staleness clock)", async () => {
+    const original = "2026-07-01T00:00:00Z";
+    const { post, store } = makeFakeLinear({
+      seed: { "CTL-1649": { owner_host: "mini", catalyst_generation: 1, phase: "triage", claimed_at: original, triage_attempt_count: 0 } },
+    });
+    await bumpTriageAttemptCount("CTL-1649", { post });
+    expect(store.get("CTL-1649").claimed_at).toBe(original);
+  });
+
+  it("returns null (no-op) when no fence exists", async () => {
+    const { post } = makeFakeLinear();
+    expect(await bumpTriageAttemptCount("CTL-1649", { post })).toBeNull();
+  });
+
+  it("consecutive bumps accumulate correctly (0 → 1 → 2)", async () => {
+    const { post } = makeFakeLinear({
+      seed: { "CTL-1649": { owner_host: "mini", catalyst_generation: 1, phase: "triage", claimed_at: "t", triage_attempt_count: 0 } },
+    });
+    expect(await bumpTriageAttemptCount("CTL-1649", { post })).toBe(1);
+    expect(await bumpTriageAttemptCount("CTL-1649", { post })).toBe(2);
+    expect(await readTriageAttemptCount("CTL-1649", { post })).toBe(2);
+  });
+});
+
+describe("runCli — read-triage-attempt / bump-triage-attempt (CTL-1649)", () => {
+  it("read-triage-attempt prints { count } and exits 0 when fence exists", async () => {
+    const { post } = makeFakeLinear({
+      seed: { "CTL-1649": { owner_host: "mini", catalyst_generation: 1, phase: "triage", claimed_at: "t", triage_attempt_count: 2 } },
+    });
+    const { code, out } = await captureStdout(() => runCli(["read-triage-attempt", "CTL-1649"], { post }));
+    expect(code).toBe(0);
+    expect(JSON.parse(out.trim())).toEqual({ count: 2 });
+  });
+
+  it("read-triage-attempt prints { count: null } and exits 0 when no fence", async () => {
+    const { post } = makeFakeLinear();
+    const { code, out } = await captureStdout(() => runCli(["read-triage-attempt", "CTL-1649"], { post }));
+    expect(code).toBe(0);
+    expect(JSON.parse(out.trim())).toEqual({ count: null });
+  });
+
+  it("bump-triage-attempt prints { count } and exits 0 on success", async () => {
+    const { post } = makeFakeLinear({
+      seed: { "CTL-1649": { owner_host: "mini", catalyst_generation: 1, phase: "triage", claimed_at: "t", triage_attempt_count: 1 } },
+    });
+    const { code, out } = await captureStdout(() => runCli(["bump-triage-attempt", "CTL-1649"], { post }));
+    expect(code).toBe(0);
+    expect(JSON.parse(out.trim())).toEqual({ count: 2 });
+  });
+
+  it("unknown subcommand still exits 1 with usage", async () => {
+    const { post } = makeFakeLinear();
+    const { code } = await captureStdout(() => runCli(["bogus-cmd"], { post }));
+    expect(code).toBe(1);
   });
 });
 

--- a/plugins/dev/scripts/execution-core/monitor.mjs
+++ b/plugins/dev/scripts/execution-core/monitor.mjs
@@ -49,7 +49,7 @@ import {
 // (linear-query.mjs never imports replica-read.mjs either; daemon.mjs:681 builds
 // the reader and passes it in). monitor.mjs stays Node-loadable.
 import { ownedBy } from "./hrw.mjs"; // CTL-862: HRW ownership filter
-import { claimDispatchSync } from "./cluster-claim-sync.mjs"; // CTL-862: cross-host claim soft-CAS
+import { claimDispatchSync, readTriageAttemptCountSync, bumpTriageAttemptCountSync } from "./cluster-claim-sync.mjs"; // CTL-862: cross-host claim soft-CAS; CTL-1649: fleet-wide triage attempt count
 import { listProjects, getProjectConfig, resolveEligibleQuery } from "./registry.mjs";
 import {
   runEligibleQuery,
@@ -803,6 +803,11 @@ function dispatchTriage(
     // updated AFTER a cached negative verdict invalidates the marker — the
     // ticket may have legitimately re-entered Triage.
     candidateUpdatedAt = null,
+    // CTL-1649: fleet-wide triage attempt count seams (multiHost-gated).
+    // Defaults to the sync implementations (TTL-cached in cluster-claim-sync.mjs).
+    // Single-host paths never call these.
+    readFenceTriageAttempt = readTriageAttemptCountSync,
+    bumpFenceTriageAttempt = bumpTriageAttemptCountSync,
   }
 ) {
   if (!orchDir) {
@@ -864,7 +869,9 @@ function dispatchTriage(
   // markers are the idempotence guard (a transient Linear failure leaves none);
   // cappedAt in the counter record gates only the duplicate WARN. Re-arm by
   // deleting orchDir/.triage-dispatch-counts/<ticket>.json.
-  if (readTriageDispatchCount(orchDir, identifier) >= TRIAGE_DISPATCH_CAP) {
+  // CTL-1649: use fleet-wide count (max of host-local and fence) so an ownership
+  // churn cannot restart the counter at 0 on the new owner.
+  if (fleetTriageDispatchCount(orchDir, identifier, { multiHost, readFenceCount: readFenceTriageAttempt }) >= TRIAGE_DISPATCH_CAP) {
     // Codex R2: the final allowed attempt may still be RUNNING — triage.json is
     // naturally absent until it finishes. Defer the park while in flight.
     if (isTriageInFlight(readTriageSignalStatus(orchDir, identifier))) return false;
@@ -1055,6 +1062,15 @@ function dispatchTriage(
   const statusAtLaunch = readTriageSignalStatus(orchDir, identifier);
   if (!isTriageInFlight(statusAtLaunch) && statusAtLaunch !== "done") {
     bumpTriageDispatchCount(orchDir, identifier);
+    // CTL-1649: mirror the host-local bump on the fence attachment so the fleet-wide
+    // count stays in lockstep. Fail-open — a fence write failure never blocks launch.
+    if (multiHost) {
+      try {
+        bumpFenceTriageAttempt({ ticket: identifier });
+      } catch {
+        /* fail-open */
+      }
+    }
   }
   // CTL-1367 P1: settle an async (executor=sdk) dispatch synchronously. bg returns a
   // plain object (passthrough → byte-identical). sdk returns a Promise whose
@@ -1233,6 +1249,37 @@ export function markTriageCapped(orchDir, ticket, { now = () => new Date().toISO
   if (prior.cappedAt) return false; // already parked once
   writeTriageDispatchRecord(orchDir, ticket, { ...prior, cappedAt: now(), cap: TRIAGE_DISPATCH_CAP });
   return true;
+}
+
+// fleetTriageDispatchCount — the CTL-1649 fleet-wide dispatch count for a ticket.
+//
+// On single-host (multiHost:false), returns the host-local count unchanged —
+// no fence read, no new subprocess, byte-identical to the pre-CTL-1649 path.
+//
+// On multi-host, reads the fence's triage_attempt_count via the injected
+// readFenceCount seam and returns max(host-local, fence). A null from the fence
+// read (fence-absent or spawn failure) is the fail-open signal — fall back to
+// host-local so a temporary Linear outage never falsely parks a ticket.
+//
+// The seam default (readTriageAttemptCountSync) is TTL-cached in
+// cluster-claim-sync.mjs (CATALYST_TRIAGE_ATTEMPT_CACHE_MS, 30s default) to
+// bound the Linear read rate — mirrors fenceCheckSyncCached's design.
+//
+// Exported for unit coverage.
+export function fleetTriageDispatchCount(
+  orchDir,
+  identifier,
+  { multiHost = false, readFenceCount = readTriageAttemptCountSync } = {},
+) {
+  const hostLocal = readTriageDispatchCount(orchDir, identifier);
+  if (!multiHost) return hostLocal;
+  try {
+    const { count } = readFenceCount({ ticket: identifier });
+    if (count === null) return hostLocal; // fence-absent or failure — fail-open
+    return Math.max(hostLocal, count);
+  } catch {
+    return hostLocal; // fail-open on any unexpected throw
+  }
 }
 
 // triageStateTickets — the CTL-1589 half of the sweep's ticket source: the

--- a/plugins/dev/scripts/execution-core/scheduler.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.mjs
@@ -5535,6 +5535,10 @@ export function schedulerTick(
           act: _boardHealth.act,
           log: (o, m) => log.warn?.(o, m),
           now,
+          // CTL-1649: bind the real triage artifact check so selectAnchorCandidates
+          // can exclude tickets whose only non-clean signal is a triage launch failure.
+          // existsSync/join are already imported in scheduler.mjs.
+          hasTriageArtifact: (ticket) => existsSync(join(orchDir, "workers", ticket, "triage.json")),
         });
         if (_bhResult?.ran) _boardHealthLastRunMs = _bhResult.ranAtMs;
         // CTL-1157 (Codex round-5): a successful board-health ENFORCE dispatch enqueued

--- a/plugins/dev/scripts/execution-core/triage-redispatch-guard.test.mjs
+++ b/plugins/dev/scripts/execution-core/triage-redispatch-guard.test.mjs
@@ -16,6 +16,7 @@ import {
   readTriageSignalStatus,
   readTriageDispatchCount,
   bumpTriageDispatchCount,
+  fleetTriageDispatchCount,
 } from "./monitor.mjs";
 
 let orchDir;
@@ -96,5 +97,74 @@ describe("triage dispatch counter (CTL-1441 guard b)", () => {
     bumpTriageDispatchCount(orchDir, "CTL-12");
     expect(readTriageDispatchCount(orchDir, "CTL-12")).toBe(1);
     expect(readTriageDispatchCount(orchDir, "CTL-13")).toBe(0);
+  });
+});
+
+// ─── CTL-1649: fleetTriageDispatchCount ──────────────────────────────────────
+
+describe("fleetTriageDispatchCount — fleet-wide cap (CTL-1649)", () => {
+  test("multiHost:false returns host-local count verbatim (fence seam never called)", () => {
+    bumpTriageDispatchCount(orchDir, "CTL-1649"); // host-local = 1
+    let fenceCalled = false;
+    const count = fleetTriageDispatchCount(orchDir, "CTL-1649", {
+      multiHost: false,
+      readFenceCount: () => { fenceCalled = true; return { count: 99 }; },
+    });
+    expect(count).toBe(1);
+    expect(fenceCalled).toBe(false);
+  });
+
+  test("multiHost:true with fence count > host-local → returns fence count (cross-host churn scenario)", () => {
+    // Simulate: new owner has host-local count=0, fence carries count=3 from prior owner.
+    // Fleet count = max(0, 3) = 3 → cap is reached.
+    const count = fleetTriageDispatchCount(orchDir, "CTL-1649", {
+      multiHost: true,
+      readFenceCount: () => ({ count: 3 }),
+    });
+    expect(count).toBe(3);
+    expect(count).toBeGreaterThanOrEqual(TRIAGE_DISPATCH_CAP); // regression guard: would park
+  });
+
+  test("multiHost:true with fence count < host-local → returns host-local (normal same-owner case)", () => {
+    bumpTriageDispatchCount(orchDir, "CTL-1649");
+    bumpTriageDispatchCount(orchDir, "CTL-1649"); // host-local = 2
+    const count = fleetTriageDispatchCount(orchDir, "CTL-1649", {
+      multiHost: true,
+      readFenceCount: () => ({ count: 1 }), // fence behind host-local
+    });
+    expect(count).toBe(2);
+  });
+
+  test("multiHost:true with fence returning null (fail-open) → returns host-local", () => {
+    bumpTriageDispatchCount(orchDir, "CTL-1649"); // host-local = 1
+    const count = fleetTriageDispatchCount(orchDir, "CTL-1649", {
+      multiHost: true,
+      readFenceCount: () => ({ count: null }),
+    });
+    expect(count).toBe(1);
+  });
+
+  test("multiHost:true with fence seam throwing (fail-open) → returns host-local", () => {
+    bumpTriageDispatchCount(orchDir, "CTL-1649"); // host-local = 1
+    const count = fleetTriageDispatchCount(orchDir, "CTL-1649", {
+      multiHost: true,
+      readFenceCount: () => { throw new Error("network"); },
+    });
+    expect(count).toBe(1);
+  });
+
+  // ─── REGRESSION: cross-host double-spend (CTL-1649, the headline bug) ────
+  // On a two-host ownership churn, the new owner starts with host-local count=0.
+  // Before CTL-1649 the cap gate read host-local only → saw 0 → dispatched even
+  // though the fleet had already consumed all 3 allowed attempts. With the fix,
+  // fleetTriageDispatchCount reads the fence (count=3) and returns 3 → parks.
+  test("regression — cross-host churn: host-local 0 but fence 3 → cap fires, no dispatch", () => {
+    // host-local is 0 (new owner, fresh orchDir)
+    expect(readTriageDispatchCount(orchDir, "CTL-1649")).toBe(0);
+    const fleetCount = fleetTriageDispatchCount(orchDir, "CTL-1649", {
+      multiHost: true,
+      readFenceCount: () => ({ count: TRIAGE_DISPATCH_CAP }),
+    });
+    expect(fleetCount).toBeGreaterThanOrEqual(TRIAGE_DISPATCH_CAP);
   });
 });


### PR DESCRIPTION
<!-- Auto-generated: 2026-08-06T06:22:00Z -->
<!-- Last updated: 2026-08-06T06:22:00Z -->
<!-- PR: #3030 -->
<!-- Previous commits: ef83a4e2fefb2b82650aec423bdbf4a9e2e13473,b27170fea458f3bc728d09c47ac778a1be107ba9 -->

## Summary

Two independent bugs that compound each other in multi-host clusters: triage dispatch attempts were counted host-locally, so HRW ownership churn let each new owner spend a fresh cap — meaning up to `cap × N_churn` real triage spawns fleet-wide. And when a triage phase agent failed to launch (sdk-overloaded, sdk-launch-failed, etc.), the board-health recovery pass treated the resulting `needs_human` signal as a stuck-and-actionable ticket and piled a recovery attempt on top, racing the triage monitor.

**Phase 1** adds `triage_attempt_count` to the Linear fence attachment (`catalyst://fence/<TICKET>`) so the cap is enforced fleet-wide across ownership churn. `fleetTriageDispatchCount` takes `max(host-local, fence)` at evaluation time; `bumpTriageAttemptCount` increments the fence in lockstep with the host-local counter. A 30 s TTL sync cache (`cluster-claim-sync.mjs`) mirrors the async `cluster-claim.mjs` pattern for the blocking scheduler path.

**Phase 2** adds a `triageLaunchFailureOnlyTickets` set to `assembleBoardState` — tickets where the only stalled signal is a triage-phase launch failure (`attentionReason` set, no `triage.json` artifact, no other-phase stuck signal). `selectAnchorCandidates` excludes any ticket in that set, so the board-health recovery pass never anchors on them. The `hasTriageArtifact` seam defaults to `() => true` (set always empty) on single-host or unwired builds, making the exclusion inert until the daemon wires the real `existsSync(triage.json)` check.

## Changes Made

### Phase 1 — Fleet-wide triage dispatch cap via fence attachment

**`cluster-claim.mjs`**
- `parseClaimMetadata`: reads `triage_attempt_count` from fence attachment
- `writeClaim`: writes `triage_attempt_count` through (with `preserveClaimedAt` to avoid resetting the CTL-1297 staleness clock)
- `readTriageAttemptCount` / `bumpTriageAttemptCount`: async read-max + bump seams (fail-open to host-local when fence unavailable)
- CLI: `read-triage-attempt` + `bump-triage-attempt` cases

**`cluster-claim-sync.mjs`** _(new file sections)_
- `readTriageAttemptCountSync` + `bumpTriageAttemptCountSync` with 30 s TTL cache (mirrors `fenceCheckSyncCached` pattern)
- Used by `monitor.mjs` on the blocking scheduler path

**`monitor.mjs`**
- `fleetTriageDispatchCount`: `max(host-local, fence)` via `readTriageAttemptCountSync`
- Cap gate (`:860`) and increment site (`:1055`) updated to call fence seam when `multiHost=true`

### Phase 2 — Exclude triage-launch-failure tickets from board-health recovery anchor

**`board-health.mjs`**
- `attentionReason` normalized from raw/flat signal shape
- `isLaunchFailureSignal` + `isOtherStuckSignal` predicates
- `triageLaunchFailureOnlyTickets` Set on the frozen board object
- `selectAnchorCandidates` filters on excluded set
- `hasTriageArtifact` seam plumbed through `boardHealthPass`

**`scheduler.mjs`**
- Wires `hasTriageArtifact: ticket => existsSync(join(orchDir, "workers", ticket, "triage.json"))` at the real enforce call site

### Tests

| Suite | Result |
|---|---|
| `cluster-claim.test.mjs` | 63 pass / 0 fail |
| `cluster-claim-sync.test.mjs` | 49 pass / 0 fail |
| `board-health.test.mjs` | 160 pass / 0 fail |
| `triage-redispatch-guard.test.mjs` | 15 pass / 0 fail |
| `monitor.test.mjs` (adjacent) | 173 pass / 2 fail (pre-existing env flakiness on `origin/main`) |
| `board-health-seam` (adjacent) | 13 pass / 0 fail |

## How to Verify It

- [x] Node syntax check passes on all 5 modified `.mjs` files (`node --check`)
- [x] Unit tests: 287 pass / 0 fail across the 4 directly-affected suites
- [x] Adjacent monitor tests: 2 pre-existing failures reproduce on `origin/main` baseline (not regressions)
- [x] No reward-hacking patterns in added lines (no `as-any` / `@ts-ignore` / silent catches)
- [x] No secrets or tokens in added code
- [x] Code review: both fixes are `multiHost`-gated + `shadow-first-seam`-defaulted (single-host behavior byte-identical)
- [ ] Live cluster test: confirm `triage_attempt_count` increments in the fence attachment on triage dispatch in a 2-host cluster
- [ ] Live cluster test: confirm `needs_human` triage-launch-failure tickets are absent from board-health recovery candidates

## Related Issues/PRs

- Fixes https://linear.app/coalesce-labs/issue/CTL-1649

## Reviewer Notes

**Known design decision**: the 30 s TTL cache on `readTriageAttemptCountSync` means a second host's cached fence count can lag a peer's bump by up to the TTL, so fleet-wide dispatch can briefly reach `cap+1` across a churn window before the cache expires. This is intentional (the CTL-863 read-rate bound) and a massive improvement over the `cap × N_churn` double-spend it replaces. Noted in the verify phase for awareness; no remediation needed.

<!-- Linear automation guard (CTL-623/CTL-633): unlink sibling tickets so this PR does not drag their workflow status. -->
skip CTL-1297
skip CTL-863