### PR TITLE
chore(dev): bump @catalyst-cloud/sdk ^0.8.0 → ^0.8.2

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -33,7 +33,7 @@
       "name": "catalyst-execution-core",
       "dependencies": {
         "@catalyst-cloud/read-model": "^0.1.0",
-        "@catalyst-cloud/sdk": "^0.8.0",
+        "@catalyst-cloud/sdk": "^0.8.2",
         "@modelcontextprotocol/sdk": "1.29.0",
         "@opentelemetry/api": "^1.9.1",
         "@opentelemetry/exporter-trace-otlp-http": "^0.219.0",
@@ -213,7 +213,7 @@
 
     "@catalyst-cloud/schema": ["@catalyst-cloud/schema@0.1.3", "", { "dependencies": { "drizzle-orm": "0.44.7" } }, "sha512-qZGbGvJuvputQlX2TCH5IYAGGVJjunh7tZc9tsp4YxoE82Bj34F+zjqgtCuMTAc6yzR7rNJv90ZjZBLDNoKYwg=="],
 
-    "@catalyst-cloud/sdk": ["@catalyst-cloud/sdk@0.8.1", "", { "dependencies": { "@catalyst-cloud/read-model": "^0.1.0", "@catalyst-cloud/replicate": "^0.1.3", "@catalyst-cloud/schema": "^0.1.3" }, "peerDependencies": { "@opentelemetry/api": ">=1.3.0 <2", "@sqlite.org/sqlite-wasm": "*", "better-sqlite3": "*" }, "optionalPeers": ["@opentelemetry/api", "@sqlite.org/sqlite-wasm", "better-sqlite3"] }, "sha512-k4S5gYI8IEP3MQCGjxw28AOZZXyL23vMUU3R+LB4yRW2/y75t7pxQJHBwM7Ei2Dz+EVBu9T2d5gRmD59mgG/nQ=="],
+    "@catalyst-cloud/sdk": ["@catalyst-cloud/sdk@0.8.2", "", { "dependencies": { "@catalyst-cloud/read-model": "^0.1.0", "@catalyst-cloud/replicate": "^0.1.3", "@catalyst-cloud/schema": "^0.1.3" }, "peerDependencies": { "@opentelemetry/api": ">=1.3.0 <2", "@sqlite.org/sqlite-wasm": "*", "better-sqlite3": "*" }, "optionalPeers": ["@opentelemetry/api", "@sqlite.org/sqlite-wasm", "better-sqlite3"] }, "sha512-QJZFWZAfDdLCr4jvfS05BfuZDR5jr6bN4n/DN2vgMQB9pRTTrZAtk+mbvcK8M3NwfxyuPD0ICVM4Qe+/8jtnEg=="],
 
     "@dagrejs/dagre": ["@dagrejs/dagre@3.1.0", "", { "dependencies": { "@dagrejs/graphlib": "4.0.3" } }, "sha512-22SWJOfiQVCSFF0qN43SMiYS7Ch9Z6HZoO8+5PycGzGgmtdXIvHoZ2DoT5BweVGf+wwHxBFZu4eO0do0RIYQaw=="],
 

--- a/plugins/dev/scripts/execution-core/package.json
+++ b/plugins/dev/scripts/execution-core/package.json
@@ -7,7 +7,7 @@
   },
   "dependencies": {
     "@catalyst-cloud/read-model": "^0.1.0",
-    "@catalyst-cloud/sdk": "^0.8.0",
+    "@catalyst-cloud/sdk": "^0.8.2",
     "@modelcontextprotocol/sdk": "1.29.0",
     "@opentelemetry/api": "^1.9.1",
     "@opentelemetry/exporter-trace-otlp-http": "^0.219.0",


### PR DESCRIPTION
Routine release pickup (same pattern as #2715 / #2915).

0.8.2's delta over the locked 0.8.1 is the **browser-only** OPFS corruption self-heal ([CTC-337](https://github.com/coalesce-labs/catalyst-cloud-sdk/releases/tag/v0.8.2)) — functionally inert for the node daemons. The node-relevant content (CTC-328 stale-frame guard) was already in 0.8.1. This is hygiene: a lock sitting a release behind keeps re-raising "why is catalyst on 0.8.1".

Note for reviewers: when this merges, the fleet's updater pulls a root-manifest change, which (post-CTL-1646) also exercises the stale-nest prune path on install. Running daemons will show `restart_needed` and keep 0.8.1 loaded until restarted — that skew gap is CTL-1659, and no restart is needed for this particular delta.

`cloud-sync.mjs` / `daemon.mjs` build clean against 0.8.2; cluster-sync suite 74/74.

🤖 Generated with [Claude Code](https://claude.com/claude-code)