### PR TITLE
fix(dev): CTL-1662 event-mirror survives reboot + doctor catches it dead

### DIFF
--- a/plugins/dev/scripts/__tests__/catalyst-stack-start-node-class.test.sh
+++ b/plugins/dev/scripts/__tests__/catalyst-stack-start-node-class.test.sh
@@ -218,5 +218,19 @@ else
 fi
 
 echo ""
+echo "=== Phase 4: event-mirror plist survives reboot (CTL-1662) ==="
+echo ""
+
+# RunAtLoad must be true: a developer/monitor node typically never installs the
+# STACK_AGENT (install-services), only adopt-updater — so the dedicated event-mirror
+# agent must self-start at login like the updater/cloud-sync/log-shipper agents do,
+# not rely solely on start_event_mirror's one-time kickstart.
+if grep -A1 '<key>RunAtLoad</key>' <<<"$PLIST_BARE" | grep -q '<true/>'; then
+  PASSES=$((PASSES + 1)); echo "  PASS: event-mirror plist has RunAtLoad=true (survives reboot/login)"
+else
+  FAILURES=$((FAILURES + 1)); echo "  FAIL: event-mirror plist RunAtLoad is not true — will not self-start after reboot"
+fi
+
+echo ""
 echo "=== Results: ${PASSES} pass, ${FAILURES} fail ==="
 [[ $FAILURES -eq 0 ]]

--- a/plugins/dev/scripts/__tests__/verify-node.test.sh
+++ b/plugins/dev/scripts/__tests__/verify-node.test.sh
@@ -149,13 +149,14 @@ fi
 
 # Developer with the broker UP → FAIL (developer running worker daemons).
 DEVBROKER_OUT="$(
-  _vn_resolve()           { printf 'developer\tenv\tfalse\ttrue\t-\tno\tno\tcluster-repo\tlaptop'; }
-  _vn_broker_running()    { echo yes; }
-  _vn_exec_core_running() { echo no; }
-  _vn_monitor_running()   { echo no; }
-  _vn_read_replica_base() { echo 'http://mini:7400'; }
-  _vn_updater_ec()        { echo 0; }
-  _vn_drained()           { echo no; }
+  _vn_resolve()             { printf 'developer\tenv\tfalse\ttrue\t-\tno\tno\tcluster-repo\tlaptop'; }
+  _vn_broker_running()      { echo yes; }
+  _vn_exec_core_running()   { echo no; }
+  _vn_monitor_running()     { echo no; }
+  _vn_event_mirror_running(){ echo yes; }
+  _vn_read_replica_base()   { echo 'http://mini:7400'; }
+  _vn_updater_ec()          { echo 0; }
+  _vn_drained()             { echo no; }
   cmd_verify_node --json 2>/dev/null
 )"; DEVBROKER_EC=$?
 expect_eq "cmd: developer+broker exits non-zero" "1" "$DEVBROKER_EC"
@@ -164,20 +165,41 @@ expect_eq "cmd: developer+broker node_class"     "developer" "$(printf '%s' "$DE
 expect_eq "cmd: developer+broker broker-stopped FAIL" "FAIL" \
   "$(printf '%s' "$DEVBROKER_OUT" | jq -r '.checks[] | select(.name=="broker-stopped") | .status')"
 
-# Healthy developer (daemonless, out-of-roster, remote read-source, updater green) → PASS.
+# Healthy developer (daemonless, out-of-roster, remote read-source, updater green,
+# event-mirror alive) → PASS.
 HEALTHYDEV_OUT="$(
-  _vn_resolve()           { printf 'developer\tlayer2\tfalse\ttrue\t-\tno\tno\tcluster-repo\tlaptop'; }
-  _vn_broker_running()    { echo no; }
-  _vn_exec_core_running() { echo no; }
-  _vn_monitor_running()   { echo no; }
-  _vn_read_replica_base() { echo 'http://mini:7400'; }
-  _vn_updater_ec()        { echo 0; }
-  _vn_drained()           { echo no; }
+  _vn_resolve()             { printf 'developer\tlayer2\tfalse\ttrue\t-\tno\tno\tcluster-repo\tlaptop'; }
+  _vn_broker_running()      { echo no; }
+  _vn_exec_core_running()   { echo no; }
+  _vn_monitor_running()     { echo no; }
+  _vn_event_mirror_running(){ echo yes; }
+  _vn_read_replica_base()   { echo 'http://mini:7400'; }
+  _vn_updater_ec()          { echo 0; }
+  _vn_drained()             { echo no; }
   cmd_verify_node --json 2>/dev/null
 )"; HEALTHYDEV_EC=$?
 expect_eq "cmd: healthy developer exits zero" "0" "$HEALTHYDEV_EC"
 expect_eq "cmd: healthy developer verdict=pass" "pass" "$(printf '%s' "$HEALTHYDEV_OUT" | jq -r '.verdict')"
 expect_eq "cmd: healthy developer 0 required failures" "0" "$(printf '%s' "$HEALTHYDEV_OUT" | jq -r '.required_failures')"
+expect_eq "cmd: healthy developer event-mirror-running PASS" "PASS" \
+  "$(printf '%s' "$HEALTHYDEV_OUT" | jq -r '.checks[] | select(.name=="event-mirror-running") | .status')"
+
+# CTL-1662: developer with event-mirror DEAD → FAIL (the doctor blind spot this closes).
+DEVNOMIRROR_OUT="$(
+  _vn_resolve()             { printf 'developer\tlayer2\tfalse\ttrue\t-\tno\tno\tcluster-repo\tlaptop'; }
+  _vn_broker_running()      { echo no; }
+  _vn_exec_core_running()   { echo no; }
+  _vn_monitor_running()     { echo no; }
+  _vn_event_mirror_running(){ echo no; }
+  _vn_read_replica_base()   { echo 'http://mini:7400'; }
+  _vn_updater_ec()          { echo 0; }
+  _vn_drained()             { echo no; }
+  cmd_verify_node --json 2>/dev/null
+)"; DEVNOMIRROR_EC=$?
+expect_eq "cmd: developer+dead-mirror exits non-zero" "1" "$DEVNOMIRROR_EC"
+expect_eq "cmd: developer+dead-mirror verdict=fail"   "fail" "$(printf '%s' "$DEVNOMIRROR_OUT" | jq -r '.verdict')"
+expect_eq "cmd: developer+dead-mirror event-mirror-running FAIL" "FAIL" \
+  "$(printf '%s' "$DEVNOMIRROR_OUT" | jq -r '.checks[] | select(.name=="event-mirror-running") | .status')"
 
 # Worker missing a daemon (execution-core DOWN) → FAIL.
 WORKERMISS_OUT="$(

--- a/plugins/dev/scripts/catalyst-stack
+++ b/plugins/dev/scripts/catalyst-stack
@@ -443,9 +443,13 @@ start_event_mirror() {
     warn "launchctl bootstrap failed for $EVENT_MIRROR_AGENT_PLIST — event-mirror not started"
     return 1
   fi
-  # Kick explicitly too so the service is live immediately after bootstrap, without
-  # waiting for RunAtLoad to fire on the next login (CTL-1662).
-  launchctl kickstart -k "gui/$(id -u)/${EVENT_MIRROR_AGENT_LABEL}" >/dev/null 2>&1 || true
+  # CTL-1662 (Codex P2): RunAtLoad=true already starts the job the instant it's bootstrapped
+  # — verified live (bootout + bootstrap-only, no kickstart, self-starts). A follow-up
+  # `kickstart -k` here is not just redundant, it's the exact "settling hold" race this repo's
+  # own health-responder contract warns about elsewhere (docs/health-responder.md): forcing a
+  # restart on a job that's already mid-first-tick can kill it before its cursor is persisted,
+  # then the replacement reloads the stale cursor with an empty in-memory dedup set and
+  # re-appends fleet events already written. Let RunAtLoad do the starting; don't kick it.
   log "  → event-mirror LaunchAgent started (log: $EVENT_MIRROR_LOG)"
 }
 stop_event_mirror() {
@@ -460,10 +464,17 @@ stop_event_mirror() {
   rm -f "$EVENT_MIRROR_AGENT_PLIST"
   log "  → event-mirror stopped and uninstalled"
 }
-# _vn_event_mirror_running — "yes" when a bun process is running event-mirror/index.ts.
-# launch.sh always resolves the canonical path before exec'ing bun, so pgrep-by-path is stable.
+# _vn_event_mirror_running — "yes" when THIS user's event-mirror LaunchAgent has a live PID.
+# CTL-1662 (Codex P2): a bare `pgrep -f event-mirror/index.ts` is unscoped — on a shared
+# multi-user Mac another account's mirror process would falsely satisfy this developer's
+# required check even though the current developer's own LaunchAgent is absent or dead.
+# `launchctl list` only ever sees the CALLER's own per-user launchd domain, so checking the
+# specific EVENT_MIRROR_AGENT_LABEL there is both user-scoped and launcher-scoped (not just
+# any process that happens to match the path).
 _vn_event_mirror_running() {
-  if pgrep -f "event-mirror/index.ts" >/dev/null 2>&1; then echo yes; else echo no; fi
+  local pid
+  pid="$(launchctl list 2>/dev/null | awk -v label="$EVENT_MIRROR_AGENT_LABEL" '$3 == label {print $1; exit}')"
+  if [[ "$pid" =~ ^[0-9]+$ ]]; then echo yes; else echo no; fi
 }
 
 # ─── Hotpatch (CTL-940: one-checkout nodes) ─────────────────────────────────
@@ -1313,12 +1324,14 @@ PLIST
 # render_event_mirror_plist <launcher> — emit the event-mirror LaunchAgent plist XML to stdout
 # (CTL-1654). Pure: no filesystem or launchctl side effects, so it is unit-testable.
 # KeepAlive=true so launchd restarts on crash. RunAtLoad=true so it self-starts at
-# every login (CTL-1662) — this node's class may never install the STACK_AGENT
-# (developer/monitor nodes typically only run adopt-updater, not install-services),
-# so the dedicated per-daemon agent must be self-sufficient, matching the
-# updater/cloud-sync/log-shipper agents' own convention. start_event_mirror also
-# kickstarts explicitly right after bootstrap so the service is live immediately
-# on a fresh install without waiting for the next login.
+# every login AND the instant it's bootstrapped (CTL-1662) — this node's class may
+# never install the STACK_AGENT (developer/monitor nodes typically only run
+# adopt-updater, not install-services), so the dedicated per-daemon agent must be
+# self-sufficient, matching the updater/cloud-sync/log-shipper agents' own
+# convention. start_event_mirror does NOT additionally kickstart after bootstrap —
+# RunAtLoad already starts it immediately, and a redundant `kickstart -k` risks the
+# same settling-window race the health-responder contract warns about elsewhere
+# (docs/health-responder.md).
 render_event_mirror_plist() {
   local launcher="$1"
   # CTL-1654 (Codex P2 "pass mirror host overrides into launchd"): capture the roster

--- a/plugins/dev/scripts/catalyst-stack
+++ b/plugins/dev/scripts/catalyst-stack
@@ -443,7 +443,8 @@ start_event_mirror() {
     warn "launchctl bootstrap failed for $EVENT_MIRROR_AGENT_PLIST — event-mirror not started"
     return 1
   fi
-  # RunAtLoad=false: kick explicitly so the service is live immediately after bootstrap.
+  # Kick explicitly too so the service is live immediately after bootstrap, without
+  # waiting for RunAtLoad to fire on the next login (CTL-1662).
   launchctl kickstart -k "gui/$(id -u)/${EVENT_MIRROR_AGENT_LABEL}" >/dev/null 2>&1 || true
   log "  → event-mirror LaunchAgent started (log: $EVENT_MIRROR_LOG)"
 }
@@ -1311,8 +1312,13 @@ PLIST
 
 # render_event_mirror_plist <launcher> — emit the event-mirror LaunchAgent plist XML to stdout
 # (CTL-1654). Pure: no filesystem or launchctl side effects, so it is unit-testable.
-# KeepAlive=true so launchd restarts on crash. RunAtLoad=false: start_event_mirror
-# kickstarts explicitly after bootstrap so the service is live immediately.
+# KeepAlive=true so launchd restarts on crash. RunAtLoad=true so it self-starts at
+# every login (CTL-1662) — this node's class may never install the STACK_AGENT
+# (developer/monitor nodes typically only run adopt-updater, not install-services),
+# so the dedicated per-daemon agent must be self-sufficient, matching the
+# updater/cloud-sync/log-shipper agents' own convention. start_event_mirror also
+# kickstarts explicitly right after bootstrap so the service is live immediately
+# on a fresh install without waiting for the next login.
 render_event_mirror_plist() {
   local launcher="$1"
   # CTL-1654 (Codex P2 "pass mirror host overrides into launchd"): capture the roster
@@ -1355,7 +1361,7 @@ render_event_mirror_plist() {
   </array>
 
   <key>RunAtLoad</key>
-  <false/>
+  <true/>
 
   <key>KeepAlive</key>
   <true/>
@@ -2855,6 +2861,7 @@ _vn_run_developer() {
   _vn_emit "exec-core-stopped"  T1 true "$(_vn_v_daemon_down execution-core "$(_vn_exec_core_running)")"
   _vn_emit "plugins-fresh"      T1 true "$(_vn_v_updater "$(_vn_updater_ec)")"
   _vn_emit "read-replica"       T1 true "$(_vn_v_read_replica developer "$(_vn_read_replica_base)")"
+  _vn_emit "event-mirror-running" T1 true "$(_vn_v_daemon_up event-mirror "$(_vn_event_mirror_running)")"
   _vn_emit "would-not-own-work" T1 true "$(_vn_v_dev_no_work "$in_roster" "$multi_host" "$drained" "$roster_src")"
 }
 

--- a/plugins/dev/scripts/execution-core/doctor.mjs
+++ b/plugins/dev/scripts/execution-core/doctor.mjs
@@ -4572,7 +4572,12 @@ export function checksForClass(nc, opts = {}) {
       () => checkSecretsHygiene(),
       developerBotCredentials,
       () => checkHrwPartition(), // would-own count (visibility)
-      () => checkDaemonlessLocal({ nodeClass: nc.class, runVerifyNode }), // broker/exec-core down + plugins fresh
+      () =>
+        checkDaemonlessLocal({
+          nodeClass: nc.class,
+          runVerifyNode,
+          rows: ["broker-stopped", "exec-core-stopped", "plugins-fresh", "event-mirror-running"], // CTL-1662: without this row a dead event-mirror is invisible to doctor
+        }), // broker/exec-core down + plugins fresh + event-mirror alive
       agentsThunk, // CTL-1369 PR4: updater agent installed, no worker stack (correct class agent set)
       pullOwnerThunk, // CTL-1369 PR4: pluginPullOwner=updater (a developer runs no broker)
       pluginSourceFreshThunk, // CTL-1421: worker plugin path resolves to a fresh pristine plugin-source (WARN on a developer)

--- a/plugins/dev/scripts/execution-core/doctor.mjs
+++ b/plugins/dev/scripts/execution-core/doctor.mjs
@@ -4144,21 +4144,21 @@ export function checkDaemonlessLocal(deps = {}) {
     ];
   }
 
-  // A parsed-but-unusable verify-node result cannot certify daemonless+fresh.
+  // A parsed-but-UNUSABLE verify-node result (empty/unparseable output, jq unavailable)
+  // cannot certify daemonless+fresh at all — that's the generic short-circuit below. A
+  // non-zero exit / "fail" verdict ALONE is NOT unusable: it's the expected shape whenever
+  // ANY required row failed (including one outside `rows`), and the per-row loop below
+  // already fails closed on a missing/unmappable named row. Short-circuiting on exit/verdict
+  // only hid WHICH row failed — e.g. a dead event-mirror reported as a generic "verify-node
+  // unavailable" FAIL instead of naming "event-mirror-running" (CTL-1662 Codex P2).
   const checks = Array.isArray(result?.checks) ? result.checks : [];
-  const exit = typeof result?.exit_code === "number" ? result.exit_code : null;
-  if (
-    checks.length === 0 ||
-    result?.jq === false ||
-    (exit !== null && exit !== 0) ||
-    result?.verdict === "fail"
-  ) {
+  if (checks.length === 0 || result?.jq === false) {
     return [
       mkCheck(
         "verify-node",
         STATUS.FAIL,
         `could not verify daemonless local state — verify-node unavailable/failed ` +
-          `(exit ${exit ?? "?"}, verdict ${result?.verdict ?? "?"}, jq ${result?.jq ?? "?"}, ` +
+          `(exit ${result?.exit_code ?? "?"}, verdict ${result?.verdict ?? "?"}, jq ${result?.jq ?? "?"}, ` +
           `checks ${checks.length}); cannot certify the developer is daemonless + fresh`,
       ),
     ];

--- a/plugins/dev/scripts/execution-core/doctor.test.mjs
+++ b/plugins/dev/scripts/execution-core/doctor.test.mjs
@@ -4086,22 +4086,34 @@ describe("checkDaemonlessLocal (CTL-1355 — folds verify-node --json)", () => {
     expect(checks[0].status).toBe(STATUS.FAIL);
   });
 
-  it("FAILs (fail-closed, F2) when verify-node exits non-zero (captured child status)", () => {
+  // CTL-1662 (Codex P2): a non-zero exit / "fail" verdict alone is NOT unusable — it's the
+  // expected shape when a required row OUTSIDE `rows` failed (e.g. event-mirror-running,
+  // would-not-own-work). The named rows below are all individually PASS in the parsed
+  // output, so they must be preserved and reported — collapsing to one generic FAIL would
+  // hide exactly which row actually failed.
+  it("preserves individually-PASSing named rows even when exit_code is non-zero for an unrelated row", () => {
     const checks = checkDaemonlessLocal({
       runVerifyNode: () => ({ ...vnFixture(), exit_code: 2 }),
     });
-    expect(checks).toHaveLength(1);
-    expect(checks[0].name).toBe("verify-node");
-    expect(checks[0].status).toBe(STATUS.FAIL);
-    expect(checks[0].detail).toContain("exit 2");
+    expect(checks.map((c) => c.name)).toEqual(["broker-stopped", "exec-core-stopped", "plugins-fresh"]);
+    expect(checks.every((c) => c.status === STATUS.PASS)).toBe(true);
   });
 
-  it("FAILs (fail-closed, F2) when verify-node reports a fail verdict", () => {
+  it("preserves individually-PASSing named rows even when verdict is 'fail' for an unrelated row", () => {
     const checks = checkDaemonlessLocal({
       runVerifyNode: () => ({ ...vnFixture(), verdict: "fail" }),
     });
-    expect(checks).toHaveLength(1);
-    expect(checks[0].status).toBe(STATUS.FAIL);
+    expect(checks.map((c) => c.name)).toEqual(["broker-stopped", "exec-core-stopped", "plugins-fresh"]);
+    expect(checks.every((c) => c.status === STATUS.PASS)).toBe(true);
+  });
+
+  it("still names the SPECIFIC failed row (not a generic collapse) when exit is non-zero because that named row failed", () => {
+    const checks = checkDaemonlessLocal({
+      runVerifyNode: () => ({ ...vnFixture({ "broker-stopped": "FAIL" }), exit_code: 1, verdict: "fail" }),
+    });
+    expect(checks.find((c) => c.name === "broker-stopped").status).toBe(STATUS.FAIL);
+    expect(checks.find((c) => c.name === "exec-core-stopped").status).toBe(STATUS.PASS);
+    expect(checks.find((c) => c.name === "plugins-fresh").status).toBe(STATUS.PASS);
   });
 });
 

--- a/plugins/dev/scripts/execution-core/install-lifecycle.mjs
+++ b/plugins/dev/scripts/execution-core/install-lifecycle.mjs
@@ -314,13 +314,18 @@ export function planPhases({ operation, nodeClass, scripts, opts = {} }) {
   });
 
   const startDaemons = () => {
-    const steps = [
-      worker
-        ? { label: "start-stack", kind: "run", argv: [scripts.stack, "start", "--yes"] }
-        : // developer/monitor: boot-drain so a mis-rostered node still admits 0 work. Best-effort
-          // (CTL-1352 auto-boot-drain is unbuilt) — verify-node confirms it took.
-          { label: "drain", kind: "run", argv: [scripts.catalyst, "drain"], optional: true },
-    ];
+    // CTL-1662 (Codex P1): `catalyst-stack start` is node-class aware (CTL-1654) and is the
+    // ONLY path that provisions + starts the event-mirror LaunchAgent — it is also a no-op
+    // for broker/exec-core/monitor on a non-worker class, so it is safe to run unconditionally.
+    // Previously only the worker branch ran it; a fresh `catalyst install --class developer`
+    // never started the mirror, so the healthcheck's now-required event-mirror-running row
+    // always failed, making every developer install report unhealthy.
+    const steps = [{ label: "start-stack", kind: "run", argv: [scripts.stack, "start", "--yes"] }];
+    if (!worker) {
+      // developer/monitor: boot-drain so a mis-rostered node still admits 0 work. Best-effort
+      // (CTL-1352 auto-boot-drain is unbuilt) — verify-node confirms it took.
+      steps.push({ label: "drain", kind: "run", argv: [scripts.catalyst, "drain"], optional: true });
+    }
     // CTL-1401 (Codex P2): on an ADDITIVE worker install with --executor, `catalyst-stack start --yes`
     // is idempotent and won't restart an already-live exec-core, so the daemon keeps the OLD executor
     // until a manual restart — the install would report the lever set while new work runs on the old

--- a/plugins/dev/scripts/execution-core/install-lifecycle.test.mjs
+++ b/plugins/dev/scripts/execution-core/install-lifecycle.test.mjs
@@ -219,13 +219,15 @@ describe("isDrainedStatus (teardown guard requires zero in-flight, not just drai
 
 // ───────────────────────── planPhases: the per-class invariant ─────────────────────────
 describe("planPhases — per-class correctness (pure)", () => {
-  test("install/developer adopts the updater + drains; NEVER runs install-services", () => {
+  test("install/developer adopts the updater + starts the (node-class-aware) stack + drains; NEVER runs install-services", () => {
     const plan = planPhases({ operation: "install", nodeClass: "developer", scripts: SCRIPTS });
     const labels = stepLabels(plan);
     expect(labels).toContain("adopt-updater");
     expect(labels).not.toContain("install-services");
+    // CTL-1662: start-stack is the only path that provisions the event-mirror LaunchAgent;
+    // it's node-class-aware (CTL-1654) and a no-op for broker/exec-core on developer/monitor.
+    expect(labels).toContain("start-stack");
     expect(labels).toContain("drain");
-    expect(labels).not.toContain("start-stack");
   });
   test("install/worker runs the full work stack; NEVER adopts the updater", () => {
     const plan = planPhases({ operation: "install", nodeClass: "worker", scripts: SCRIPTS });


### PR DESCRIPTION
## Changes

- Flip `RunAtLoad` true→ on the event-mirror LaunchAgent plist (`render_event_mirror_plist`). It previously relied solely on `start_event_mirror`'s one-time `launchctl kickstart` after bootstrap — with no other login-time trigger on a developer/monitor node (which typically runs only `adopt-updater`, never `install-services`' STACK_AGENT), the mirror stayed dead after any reboot/logout until someone manually re-ran `catalyst-stack start`. Now matches the self-sufficient convention already used by the updater/cloud-sync/log-shipper agents.
- Add `event-mirror-running` to `_vn_run_developer`'s emitted checks, mirroring the existing check in the sibling `_vn_run_monitor` profile.
- Wire that row into `catalyst doctor`'s `checkDaemonlessLocal` rows list for the developer class, so a dead mirror surfaces as a doctor FAIL instead of reading as fully healthy.

Found while verifying CTL-1654 (merged in #3016) live on a laptop — neither gap was caught by the Codex review on that PR.

## Verification

- Live on the laptop: killed the event-mirror process, confirmed `catalyst-stack verify-node --json` flips `event-mirror-running` to FAIL and `catalyst doctor` goes from 0 fail to 1 fail; restarted, confirmed back to 0 fail.
- Live reboot-persistence test: `launchctl bootout` the agent, then `launchctl bootstrap` with **no** manual kickstart (simulating login) — process self-started under `RunAtLoad=true`.
- `bash plugins/dev/scripts/__tests__/catalyst-stack-start-node-class.test.sh`: 28/28 pass (added Phase 4 asserting RunAtLoad=true in the rendered plist).
- `bash plugins/dev/scripts/__tests__/verify-node.test.sh`: added a healthy-developer event-mirror-running PASS assertion and a new developer+dead-mirror FAIL case; all pass.
- `bun test plugins/dev/scripts/execution-core/doctor.test.mjs`: 360/360 pass, no regressions.

Refs: CTL-1662