### PR TITLE
feat(dev): CTL-1667 — root fix for premature Done / monitor-deploy false-advance family

### DIFF
--- a/plugins/dev/scripts/__tests__/phase-agent-dispatch.test.sh
+++ b/plugins/dev/scripts/__tests__/phase-agent-dispatch.test.sh
@@ -2389,6 +2389,46 @@ LAUNCHED72="no"
 assert_eq "true" "$IDEMPOTENT72" "72: fresh monitor-merge (same PR#, newer ts) stays idempotent"
 assert_eq "no" "$LAUNCHED72" "72: no worker launched for fresh monitor-merge"
 
+# ─── Test 73 (CTL-1667, Codex P1 #3061): poststale signal WITHOUT a numeric
+# .generation + a leftover <phase>.claim.<gen> must still re-launch — not wedge as
+# claim-lost. This is the production shape Test 71 missed: the monitor-deploy
+# result branches rewrite the signal with no generation field, and the prior
+# run's claim file is still on disk. The revive target computes to gen 1 and
+# collides with that leftover claim; the reaper must recognize the poststale
+# tombstone (even though the signal generation is non-numeric) and free the orphan
+# claim so a fresh worker launches. TARGET stays deterministic (never high-water),
+# so CTL-736 single-flight is preserved.
+echo ""
+echo "Test 73 (CTL-1667): poststale signal w/o generation + leftover claim re-launches"
+fresh_env t73
+TS_NOW73="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+TS_OLD73="$(date -u -v-86400S +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || date -u -d '86400 seconds ago' +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || echo '2000-01-01T00:00:00Z')"
+# monitor-deploy's required prior artifact (the phase-artifact gate runs BEFORE
+# the poststale/claim logic and would otherwise refuse the dispatch outright).
+jq -n '{status:"done",pr:{number:200,mergedAt:"2026-08-01T00:00:00Z",ciStatus:"merged"}}' \
+  > "${WORKER_DIR}/phase-monitor-merge.json"
+# Prior run's leftover monitor-deploy signal: NO generation, NO .pr, OLD ts (the
+# exact shape a completed monitor-deploy result branch leaves behind).
+jq -n --arg ts "$TS_OLD73" \
+  '{status:"done",updatedAt:$ts,deploy_state:"skipped",completed_at:$ts}' \
+  > "${WORKER_DIR}/phase-monitor-deploy.json"
+# Current run's PR opener — newer than the stale signal → poststale by timestamp.
+jq -n --arg ts "$TS_NOW73" \
+  '{status:"done",updatedAt:$ts,pr:{number:200}}' \
+  > "${WORKER_DIR}/phase-pr.json"
+# Leftover claim from the prior run at the recomputed generation (1). Aged past the
+# 2-minute reaper grace so it is eligible for the atomic orphan reap.
+printf '%s\n' '{"generation":1,"claimedAt":"2020-01-01T00:00:00Z"}' > "${WORKER_DIR}/monitor-deploy.claim.1"
+touch -t 202001010000 "${WORKER_DIR}/monitor-deploy.claim.1"
+
+rm -f "$CLAUDE_STUB_LOG"
+STDOUT73=$("$DISPATCH" --phase monitor-deploy --ticket CTL-100 --orch-dir "$ORCH_DIR" --orch-id orch-test 2>/dev/null)
+STATUS73=$(echo "$STDOUT73" | jq -r '.status // ""')
+LAUNCHED73="no"
+[[ -f $CLAUDE_STUB_LOG ]] && LAUNCHED73="yes"
+assert_not_contains "$STATUS73" "claim-lost" "73: poststale w/o generation is NOT claim-lost (reaper frees orphan claim)"
+assert_eq "yes" "$LAUNCHED73" "73: fresh worker WAS launched despite leftover claim"
+
 echo ""
 echo "─────────────────────────────────────────────"
 echo "phase-agent-dispatch: ${PASSES} passed, ${FAILURES} failed"

--- a/plugins/dev/scripts/__tests__/phase-agent-dispatch.test.sh
+++ b/plugins/dev/scripts/__tests__/phase-agent-dispatch.test.sh
@@ -2429,6 +2429,50 @@ LAUNCHED73="no"
 assert_not_contains "$STATUS73" "claim-lost" "73: poststale w/o generation is NOT claim-lost (reaper frees orphan claim)"
 assert_eq "yes" "$LAUNCHED73" "73: fresh worker WAS launched despite leftover claim"
 
+# ─── Test 74 (CTL-1667 review fix, round 4, #3061): a poststale signal WITHOUT
+# a numeric .generation must recover the prior generation from on-disk claim
+# files rather than defaulting to 0 (→ TARGET_GENERATION 1). If the prior run
+# had already revived past generation 1 (a real monitor-deploy.claim.2 exists
+# on disk), recycling generation 1 lets a delayed worker from that EARLIER
+# generation later complete and pass phase-agent-emit-complete's `mine <
+# signal` fence on an EQUAL generation — overwriting the current run's signal.
+# TARGET_GENERATION must land at 3 here (one past the highest real claim ever
+# made for this phase), never 1.
+echo ""
+echo "Test 74 (CTL-1667, review fix round 4): poststale signal w/o generation recovers past a real prior generation (never recycles)"
+fresh_env t74
+TS_NOW74="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+TS_OLD74="$(date -u -v-86400S +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || date -u -d '86400 seconds ago' +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || echo '2000-01-01T00:00:00Z')"
+# monitor-deploy's required prior artifact.
+jq -n '{status:"done",pr:{number:200,mergedAt:"2026-08-01T00:00:00Z",ciStatus:"merged"}}' \
+  > "${WORKER_DIR}/phase-monitor-merge.json"
+# Prior run's leftover monitor-deploy signal: NO generation, OLD ts (same
+# poststale shape as Test 73) — but this time the prior run had ALREADY
+# revived to generation 2 before this signal was left behind.
+jq -n --arg ts "$TS_OLD74" \
+  '{status:"done",updatedAt:$ts,deploy_state:"skipped",completed_at:$ts}' \
+  > "${WORKER_DIR}/phase-monitor-deploy.json"
+# Current run's PR opener — newer than the stale signal → poststale by timestamp.
+jq -n --arg ts "$TS_NOW74" \
+  '{status:"done",updatedAt:$ts,pr:{number:200}}' \
+  > "${WORKER_DIR}/phase-pr.json"
+# The prior run's REAL generation-2 claim — proof this phase actually reached
+# generation 2, which TARGET_GENERATION must advance past, not recycle.
+printf '%s\n' '{"generation":2,"claimedAt":"2020-01-01T00:00:00Z"}' > "${WORKER_DIR}/monitor-deploy.claim.2"
+touch -t 202001010000 "${WORKER_DIR}/monitor-deploy.claim.2"
+
+rm -f "$CLAUDE_STUB_LOG"
+STDOUT74=$("$DISPATCH" --phase monitor-deploy --ticket CTL-100 --orch-dir "$ORCH_DIR" --orch-id orch-test 2>/dev/null)
+STATUS74=$(echo "$STDOUT74" | jq -r '.status // ""')
+LAUNCHED74="no"
+[[ -f $CLAUDE_STUB_LOG ]] && LAUNCHED74="yes"
+assert_not_contains "$STATUS74" "claim-lost" "74: poststale w/o generation (real prior gen 2) is NOT claim-lost"
+assert_eq "yes" "$LAUNCHED74" "74: fresh worker WAS launched"
+NEW_GEN74="$(jq -r '.generation' "${WORKER_DIR}/phase-monitor-deploy.json")"
+assert_eq "3" "$NEW_GEN74" "74: TARGET_GENERATION recovered past the real gen-2 claim (=3, never recycles gen 1 or 2)"
+assert_eq "yes" "$([[ -f "${WORKER_DIR}/monitor-deploy.claim.3" ]] && echo yes || echo no)" \
+	"74: new claim file is monitor-deploy.claim.3 (not a collision-prone gen-1 recycle)"
+
 echo ""
 echo "─────────────────────────────────────────────"
 echo "phase-agent-dispatch: ${PASSES} passed, ${FAILURES} failed"

--- a/plugins/dev/scripts/__tests__/phase-agent-dispatch.test.sh
+++ b/plugins/dev/scripts/__tests__/phase-agent-dispatch.test.sh
@@ -2429,17 +2429,24 @@ LAUNCHED73="no"
 assert_not_contains "$STATUS73" "claim-lost" "73: poststale w/o generation is NOT claim-lost (reaper frees orphan claim)"
 assert_eq "yes" "$LAUNCHED73" "73: fresh worker WAS launched despite leftover claim"
 
-# ─── Test 74 (CTL-1667 review fix, round 4, #3061): a poststale signal WITHOUT
-# a numeric .generation must recover the prior generation from on-disk claim
-# files rather than defaulting to 0 (→ TARGET_GENERATION 1). If the prior run
-# had already revived past generation 1 (a real monitor-deploy.claim.2 exists
-# on disk), recycling generation 1 lets a delayed worker from that EARLIER
-# generation later complete and pass phase-agent-emit-complete's `mine <
-# signal` fence on an EQUAL generation — overwriting the current run's signal.
-# TARGET_GENERATION must land at 3 here (one past the highest real claim ever
-# made for this phase), never 1.
+# ─── Test 74 (CTL-1667 review fix, round 5, #3061): a poststale signal WITHOUT
+# a numeric .generation must compute TARGET_GENERATION DETERMINISTICALLY, so
+# that two dispatchers racing on it converge on the SAME generation and exactly
+# one wins the O_EXCL claim.
+#
+# Round 4 recovered the prior generation by scanning the on-disk claim files for
+# the highest N. That reintroduced the double-spawn the CTL-736 invariant exists
+# to close: the claim set is MUTATED by this very computation, so a staggered
+# pair sees each other's claim and advances to DIFFERENT generations (A: max 2 →
+# 3, then B: max 3 → 4), each winning its own file, and BOTH spawn a worker that
+# can run the post-PR side effects. This test now pins the property that
+# actually matters — determinism ⇒ single-flight — rather than the specific
+# number the scan produced. The gap round 4 was patching is fixed at its source
+# (phase-monitor-deploy threads _MD_GEN through all three result branches, so it
+# no longer drops .generation); a signal reaching here without one came from the
+# un-fenced degraded path, where no generation was ever established.
 echo ""
-echo "Test 74 (CTL-1667, review fix round 4): poststale signal w/o generation recovers past a real prior generation (never recycles)"
+echo "Test 74 (CTL-1667, review fix round 5): poststale signal w/o generation is DETERMINISTIC — a racing twin cannot win a second generation"
 fresh_env t74
 TS_NOW74="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
 TS_OLD74="$(date -u -v-86400S +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || date -u -d '86400 seconds ago' +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || echo '2000-01-01T00:00:00Z')"
@@ -2466,12 +2473,38 @@ STDOUT74=$("$DISPATCH" --phase monitor-deploy --ticket CTL-100 --orch-dir "$ORCH
 STATUS74=$(echo "$STDOUT74" | jq -r '.status // ""')
 LAUNCHED74="no"
 [[ -f $CLAUDE_STUB_LOG ]] && LAUNCHED74="yes"
-assert_not_contains "$STATUS74" "claim-lost" "74: poststale w/o generation (real prior gen 2) is NOT claim-lost"
+assert_not_contains "$STATUS74" "claim-lost" "74: poststale w/o generation is NOT claim-lost"
 assert_eq "yes" "$LAUNCHED74" "74: fresh worker WAS launched"
 NEW_GEN74="$(jq -r '.generation' "${WORKER_DIR}/phase-monitor-deploy.json")"
-assert_eq "3" "$NEW_GEN74" "74: TARGET_GENERATION recovered past the real gen-2 claim (=3, never recycles gen 1 or 2)"
-assert_eq "yes" "$([[ -f "${WORKER_DIR}/monitor-deploy.claim.3" ]] && echo yes || echo no)" \
-	"74: new claim file is monitor-deploy.claim.3 (not a collision-prone gen-1 recycle)"
+# The value is whatever the DETERMINISTIC rule yields; what must hold is that it
+# is a fixed function of the signal, not of the mutable claim set — so the
+# racing twin below recomputes this SAME number.
+assert_eq "yes" "$([[ -f "${WORKER_DIR}/monitor-deploy.claim.${NEW_GEN74}" ]] && echo yes || echo no)" \
+	"74: the winner's claim file matches the generation it stamped"
+# The pre-existing higher claim from the prior run must NOT have moved the
+# target — that is exactly the mutable-input dependency round 5 removed.
+assert_eq "no" "$([[ -f "${WORKER_DIR}/monitor-deploy.claim.3" ]] && echo yes || echo no)" \
+	"74: target was NOT derived from the on-disk claim high-water mark (no gen-3 claim)"
+
+# ─── The race: a twin dispatcher on the same unchanged inputs ────────────────
+# It must recompute the SAME generation, collide on the O_EXCL claim, bow out as
+# claim-lost, and launch NO second worker. (Under the round-4 scan it would have
+# seen the winner's new claim, advanced past it, and won a second generation.)
+CLAIMS_BEFORE74="$(ls "${WORKER_DIR}"/monitor-deploy.claim.* 2>/dev/null | wc -l | tr -d ' ')"
+rm -f "$CLAUDE_STUB_LOG"
+STDOUT74B=$("$DISPATCH" --phase monitor-deploy --ticket CTL-100 --orch-dir "$ORCH_DIR" --orch-id orch-test 2>/dev/null)
+STATUS74B=$(echo "$STDOUT74B" | jq -r '.status // ""')
+LAUNCHED74B="no"
+[[ -f $CLAUDE_STUB_LOG ]] && LAUNCHED74B="yes"
+CLAIMS_AFTER74="$(ls "${WORKER_DIR}"/monitor-deploy.claim.* 2>/dev/null | wc -l | tr -d ' ')"
+# The twin is refused by whichever guard it reaches first — the soft status guard
+# (the winner's signal now reads dispatched/running) or, if it raced past that, the
+# O_EXCL claim collision. Either is single-flight; what must NEVER appear is a
+# second dispatch, so assert the refusal set rather than one specific guard.
+assert_eq "yes" "$(case "$STATUS74B" in claim-lost|running|dispatched|idempotent) echo yes ;; *) echo no ;; esac)" \
+	"74: the racing twin is refused (status='${STATUS74B}', single-flight held)"
+assert_eq "no" "$LAUNCHED74B" "74: the racing twin launched NO second worker (no double-spawn)"
+assert_eq "$CLAIMS_BEFORE74" "$CLAIMS_AFTER74" "74: the twin won no additional generation (claim count unchanged)"
 
 echo ""
 echo "─────────────────────────────────────────────"

--- a/plugins/dev/scripts/__tests__/phase-agent-dispatch.test.sh
+++ b/plugins/dev/scripts/__tests__/phase-agent-dispatch.test.sh
@@ -2334,6 +2334,61 @@ for FIELD in .env .prompt .settings .model .turnCap .sessionName .pluginDirs; do
 	assert_eq "$DRY_VAL" "$PL_VAL" "prelaunch ${FIELD} == dry-run ${FIELD} (pre-launch composition byte-identical)"
 done
 
+# ─── CTL-1667: stale post-PR signal invalidation ─────────────────────────────
+# Test 71: re-dispatch monitor-merge with a STALE done signal (old PR#) launches
+# a fresh worker instead of no-oping on the prior run's stale `done`.
+echo ""
+echo "Test 71 (CTL-1667): stale post-PR signal (old PR#) re-launches a fresh worker"
+fresh_env t71
+TS_NOW="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+# previous run's leftover terminal signal: PR#100, 24h ago
+TS_YESTERDAY="$(date -u -v-86400S +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || date -u -d '86400 seconds ago' +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || echo "2000-01-01T00:00:00Z")"
+jq -n --arg ts "$TS_YESTERDAY" \
+  '{status:"done",updatedAt:$ts,pr:{number:100,mergedAt:$ts,ciStatus:"merged"}}' \
+  > "${WORKER_DIR}/phase-monitor-merge.json"
+# current run's PR opener: PR#200
+jq -n --arg ts "$TS_NOW" \
+  '{status:"done",updatedAt:$ts,pr:{number:200}}' \
+  > "${WORKER_DIR}/phase-pr.json"
+
+rm -f "$CLAUDE_STUB_LOG"
+STDOUT71=$("$DISPATCH" --phase monitor-merge --ticket CTL-100 --orch-dir "$ORCH_DIR" --orch-id orch-test 2>/dev/null)
+IDEMPOTENT71=$(echo "$STDOUT71" | jq -r '.idempotent // false')
+LAUNCHED71="no"
+[[ -f $CLAUDE_STUB_LOG ]] && LAUNCHED71="yes"
+assert_eq "false" "$IDEMPOTENT71" "71: stale monitor-merge is NOT idempotent (re-launches)"
+assert_eq "yes" "$LAUNCHED71" "71: fresh worker WAS launched for stale monitor-merge"
+
+# ─── Test 72: re-dispatch monitor-merge with FRESH done signal (same PR#, newer
+# ts) still no-ops (the CTL-736 single-flight guard must not be broken).
+echo ""
+echo "Test 72 (CTL-1667): fresh post-PR signal (same PR#, newer ts) still idempotent"
+fresh_env t72
+TS_BASE="$(date -u -v-3600S +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || date -u -d '3600 seconds ago' +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || echo "2000-01-01T00:00:00Z")"
+TS_NOW2="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+# current run's PR opener — older than the monitor-merge signal
+jq -n --arg ts "$TS_BASE" \
+  '{status:"done",updatedAt:$ts,pr:{number:200}}' \
+  > "${WORKER_DIR}/phase-pr.json"
+# monitor-merge signal — newer than phase-pr AND same PR#
+jq -n --arg ts "$TS_NOW2" \
+  '{status:"done",updatedAt:$ts,pr:{number:200,mergedAt:$ts,ciStatus:"merged"}}' \
+  > "${WORKER_DIR}/phase-monitor-merge.json"
+# Claim file needed to match the generation the dispatcher computes (it reads
+# signal.generation for revive target). Write a gen-1 claim so the dispatcher
+# won't re-launch due to a missing claim (it would compute gen 2 as the target
+# and EXCL-create a new claim — which succeeds and spawns a worker). For the
+# "fresh stays idempotent" assertion we need the idempotency short-circuit (before
+# the claim) to fire, so the signal's generation and status must be non-stale.
+# The idempotency guard fires BEFORE the claim, so we just need a non-stale status.
+rm -f "$CLAUDE_STUB_LOG"
+STDOUT72=$("$DISPATCH" --phase monitor-merge --ticket CTL-100 --orch-dir "$ORCH_DIR" --orch-id orch-test 2>/dev/null)
+IDEMPOTENT72=$(echo "$STDOUT72" | jq -r '.idempotent // false')
+LAUNCHED72="no"
+[[ -f $CLAUDE_STUB_LOG ]] && LAUNCHED72="yes"
+assert_eq "true" "$IDEMPOTENT72" "72: fresh monitor-merge (same PR#, newer ts) stays idempotent"
+assert_eq "no" "$LAUNCHED72" "72: no worker launched for fresh monitor-merge"
+
 echo ""
 echo "─────────────────────────────────────────────"
 echo "phase-agent-dispatch: ${PASSES} passed, ${FAILURES} failed"

--- a/plugins/dev/scripts/__tests__/phase-teardown-e2e.test.sh
+++ b/plugins/dev/scripts/__tests__/phase-teardown-e2e.test.sh
@@ -757,6 +757,44 @@ B4_EMITTED="$(jq -r '.attributes."event.name" // empty' \
 assert_eq "case B4: emits teardown.failed on gh error" "phase.teardown.failed.CTL-9999" "$B4_EMITTED"
 
 # ─────────────────────────────────────────────────────────────────────────────
+echo ""
+echo "Case B5 (CTL-1667 review fix, round 3): EMPTY/malformed merge PR number → FAILS (fail-closed identity)"
+setup_b_case "caseb5"
+NOW_B5="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+jq -n '{status:"done",pr:{number:200}}' > "$WORKERB/phase-pr.json"
+# Legacy/malformed monitor-merge signal: file exists (passes the prior-artifact
+# guard) but carries no .pr.number at all.
+jq -nc --arg t "$NOW_B5" '{mergedAt:$t,ciStatus:"merged"}' \
+  > "$WORKERB/phase-monitor-merge.json"
+jq -nc --arg t "$NOW_B5" '{status:"done",deploy_state:"success",startedAt:$t,completedAt:$t}' \
+  > "$WORKERB/phase-monitor-deploy.json"
+jq -nc --arg t "$NOW_B5" '{status:"running",startedAt:$t}' > "$WORKERB/phase-teardown.json"
+# gh stub: current PR#200 IS merged — the empty merge artifact is the ONLY
+# thing that should block this from passing.
+GH_FIX_B5="$TMPROOT/caseb5-gh-fixture.json"
+jq -n --arg t "$NOW_B5" '{state:"MERGED",mergedAt:$t,number:200}' > "$GH_FIX_B5"
+install_gh_stub "$STUB_BINB" "$GH_FIX_B5"
+run_b_case "caseb5"
+B5_EXIT="$(cat "$CDIR/exit-code" 2>/dev/null || echo 0)"
+if [ "$B5_EXIT" -ne 0 ]; then
+  ok "case B5: exits non-zero (empty merge-signal PR number → fail-closed)"
+else
+  fail "case B5: exits non-zero (empty merge-signal PR number → fail-closed)" "got exit 0"
+fi
+if [ -d "$WT_PATHB" ]; then
+  ok "case B5: worktree NOT removed"
+else
+  fail "case B5: worktree NOT removed" "worktree was deleted"
+fi
+B5_EMITTED="$(jq -r '.attributes."event.name" // empty' \
+  "$FAKE_HOMEB/catalyst/events/$(date -u +%Y-%m).jsonl" 2>/dev/null | grep '^phase\.teardown\.' | tail -1)"
+assert_eq "case B5: emits teardown.failed" "phase.teardown.failed.CTL-9999" "$B5_EMITTED"
+B5_TRANS=0
+[ -f "$CDIR/linear-transition-calls.log" ] && \
+  B5_TRANS="$(wc -l < "$CDIR/linear-transition-calls.log" 2>/dev/null | tr -d ' ' || echo 0)"
+assert_eq "case B5: linear-transition NOT called" "0" "$B5_TRANS"
+
+# ─────────────────────────────────────────────────────────────────────────────
 # Summary
 
 echo ""

--- a/plugins/dev/scripts/__tests__/phase-teardown-e2e.test.sh
+++ b/plugins/dev/scripts/__tests__/phase-teardown-e2e.test.sh
@@ -119,12 +119,15 @@ write_fixture_signals() {
   jq -nc --arg s "$earlier" --arg c "$now" '{status:"done",startedAt:$s,completedAt:$c}' \
     > "$worker/phase-research.json"
 
+  # phase-pr.json — current run's PR opener (CTL-1667 gate uses this)
+  jq -nc '{status:"done",pr:{number:9999}}' > "$worker/phase-pr.json"
+
   # phase-monitor-merge.json — merged or not merged
   if [[ "$merged" == "true" ]]; then
-    jq -nc --arg now "$now" '{pr:{mergedAt:$now,ciStatus:"merged",mergeCommitSha:"deadbeef"}}' \
+    jq -nc --arg now "$now" '{pr:{number:9999,mergedAt:$now,ciStatus:"merged",mergeCommitSha:"deadbeef"}}' \
       > "$worker/phase-monitor-merge.json"
   else
-    jq -nc '{pr:{mergedAt:"",ciStatus:"open",mergeCommitSha:""}}' \
+    jq -nc '{pr:{number:9999,mergedAt:"",ciStatus:"open",mergeCommitSha:""}}' \
       > "$worker/phase-monitor-merge.json"
   fi
 
@@ -199,6 +202,13 @@ linearis_stub_install "$STUB_BIN" "$C1/linearis-calls.log"
 linear_comment_post_stub_install "$STUB_BIN" "$C1/linear-comment-calls.log"
 install_linear_transition_stub "$PLUGIN_ROOT1" "$C1/linear-transition-calls.log"
 install_presweep_stub "$PLUGIN_ROOT1"
+
+# CTL-1667: install a gh stub that reports PR#9999 as MERGED (the happy-path gate)
+cat > "$STUB_BIN/gh" <<'GH1'
+#!/usr/bin/env bash
+printf '{"state":"MERGED","mergedAt":"2026-01-01T00:00:00Z","number":9999}\n'
+GH1
+chmod +x "$STUB_BIN/gh"
 
 MONTH=$(date -u +%Y-%m)
 mkdir -p "$FAKE_HOME/catalyst/events"
@@ -402,6 +412,13 @@ linear_comment_post_stub_install "$STUB_BIN3" "$C3/linear-comment-calls.log"
 install_linear_transition_stub "$PLUGIN_ROOT3" "$C3/linear-transition-calls.log"
 install_presweep_stub "$PLUGIN_ROOT3"
 
+# CTL-1667: install a gh stub for Case 3 (idempotent re-run; mirror already posted)
+cat > "$STUB_BIN3/gh" <<'GH3'
+#!/usr/bin/env bash
+printf '{"state":"MERGED","mergedAt":"2026-01-01T00:00:00Z","number":9999}\n'
+GH3
+chmod +x "$STUB_BIN3/gh"
+
 # Pre-write the idempotency marker + reset signal to running
 : > "$WORKER3/.linear-mirror-teardown"
 jq -nc --arg s "$(date -u +%Y-%m-%dT%H:%M:%SZ)" '{status:"running",startedAt:$s}' \
@@ -548,6 +565,196 @@ run_prior_artifact_case "case4" "phase-monitor-deploy.json" "prior_artifact_miss
 echo ""
 echo "Case 5: prior-artifact guard (phase-monitor-merge.json absent)"
 run_prior_artifact_case "case5" "phase-monitor-merge.json" "prior_artifact_missing:monitor_merge"
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Cases B1–B4 (CTL-1667): current-PR-merged gate in the safety gate.
+#
+# The new gate requires:
+#   - phase-monitor-merge.json .pr.number == phase-pr.json .pr.number  (identity)
+#   - AND gh pr view <N> reports MERGED  (live truth, injectable via CATALYST_TEARDOWN_GH_BIN)
+#
+# Approach: injectable `gh` stub (CATALYST_TEARDOWN_GH_BIN) so no real `gh` needed.
+
+# Helper: write a per-case gh stub that reads from a fixture file.
+# The fixture file must contain a JSON object with at least {state, mergedAt}.
+install_gh_stub() {
+  local bin_dir="$1" fixture="$2"
+  mkdir -p "$bin_dir"
+  cat > "$bin_dir/gh-stub" <<GHSTUB
+#!/usr/bin/env bash
+# Stub: gh pr view <N> --json state,mergedAt
+cat "${fixture}"
+GHSTUB
+  chmod +x "$bin_dir/gh-stub"
+}
+
+# Helper: build a shared teardown fixture (git pair + stubs) for CTL-1667 cases.
+# Sets CDIR, WORKERB, WT_PATHB, ORCH_DIRB, FAKE_HOMEB, STUB_BINB, PLUGIN_ROOTB.
+setup_b_case() {
+  local label="$1"
+  CDIR="$TMPROOT/$label"
+  local PRIMARY_GITB="$CDIR/primary-repo"
+  WT_PATHB="$CDIR/ticket-wt"
+  ORCH_DIRB="$CDIR/orch"
+  FAKE_HOMEB="$CDIR/home"
+  WORKERB="$ORCH_DIRB/workers/CTL-9999"
+  mkdir -p "$WORKERB" "$FAKE_HOMEB/catalyst/archives"
+  make_git_pair "$PRIMARY_GITB" "$WT_PATHB" "ctl-9999-branch"
+  mkdir -p "$WT_PATHB/.catalyst"
+  echo '{"catalyst":{"projectKey":"CTL","orchestration":{"keepWorktreeAfterMerge":false}}}' \
+    > "$WT_PATHB/.catalyst/config.json"
+  STUB_BINB="$CDIR/bin"
+  PLUGIN_ROOTB="$CDIR/plugin-root"
+  mkdir -p "$STUB_BINB" "$PLUGIN_ROOTB/scripts/lib"
+  linearis_stub_install "$STUB_BINB" "$CDIR/linearis-calls.log"
+  linear_comment_post_stub_install "$STUB_BINB" "$CDIR/linear-comment-calls.log"
+  install_linear_transition_stub "$PLUGIN_ROOTB" "$CDIR/linear-transition-calls.log"
+  install_presweep_stub "$PLUGIN_ROOTB"
+  local MONTHB; MONTHB=$(date -u +%Y-%m)
+  mkdir -p "$FAKE_HOMEB/catalyst/events"
+  : > "$FAKE_HOMEB/catalyst/events/${MONTHB}.jsonl"
+}
+
+run_b_case() {
+  local label="$1"
+  (
+    cd "$WT_PATHB" || exit 1
+    HOME="$FAKE_HOMEB" \
+    PATH="$STUB_BINB:$PATH" \
+    TICKET=CTL-9999 \
+    CATALYST_ORCHESTRATOR_DIR="$ORCH_DIRB" \
+    CATALYST_ORCHESTRATOR_ID="orch-test-$label" \
+    CATALYST_DIR="$FAKE_HOMEB/catalyst" \
+    ORCH_DIR="$ORCH_DIRB" \
+    ORCH_ID="orch-test-$label" \
+    PLUGIN_ROOT="$PLUGIN_ROOTB" \
+    PHASE_AGENT_REPO_ROOT="$REPO_ROOT" \
+    PHASE_EMIT_HELPER="$EMIT_HELPER" \
+    PHASE_EMIT_WRAPPER="$EMIT_WRAPPER" \
+    CATALYST_COMMENT_POST_HELPER="$STUB_BINB/linear-comment-post.sh" \
+    CATALYST_TEARDOWN_GH_BIN="$STUB_BINB/gh-stub" \
+      bash "$SKILL_BODY_FILE" >"$CDIR/stdout.log" 2>"$CDIR/stderr.log"
+    echo $? > "$CDIR/exit-code"
+  )
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
+echo ""
+echo "Case B1 (CTL-1667): current PR (200) MERGED, numbers match → gate PASSES"
+setup_b_case "caseb1"
+# phase-pr.json — current run's PR
+jq -n '{status:"done",pr:{number:200}}' > "$WORKERB/phase-pr.json"
+# phase-monitor-merge.json — same PR, mergedAt present
+NOW_B1="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+jq -nc --arg t "$NOW_B1" '{pr:{number:200,mergedAt:$t,ciStatus:"merged"}}' \
+  > "$WORKERB/phase-monitor-merge.json"
+# phase-monitor-deploy.json
+jq -nc --arg t "$NOW_B1" '{status:"done",deploy_state:"success",startedAt:$t,completedAt:$t}' \
+  > "$WORKERB/phase-monitor-deploy.json"
+# phase-teardown.json (running)
+jq -nc --arg t "$NOW_B1" '{status:"running",startedAt:$t}' > "$WORKERB/phase-teardown.json"
+# gh stub: MERGED
+GH_FIX_B1="$TMPROOT/caseb1-gh-fixture.json"
+jq -n --arg t "$NOW_B1" '{state:"MERGED",mergedAt:$t,number:200}' > "$GH_FIX_B1"
+install_gh_stub "$STUB_BINB" "$GH_FIX_B1"
+run_b_case "caseb1"
+B1_EXIT="$(cat "$CDIR/exit-code" 2>/dev/null || echo 99)"
+assert_eq "case B1: exit code 0 (gate passes for merged current PR)" "0" "$B1_EXIT"
+B1_EMITTED="$(jq -r '.attributes."event.name" // empty' \
+  "$FAKE_HOMEB/catalyst/events/$(date -u +%Y-%m).jsonl" 2>/dev/null | grep '^phase\.teardown\.' | tail -1)"
+assert_eq "case B1: emits teardown.complete" "phase.teardown.complete.CTL-9999" "$B1_EMITTED"
+
+# ─────────────────────────────────────────────────────────────────────────────
+echo ""
+echo "Case B2 (CTL-1667): STALE merge signal (PR#100 merged) but current PR#200 is OPEN → FAILS"
+setup_b_case "caseb2"
+NOW_B2="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+jq -n '{status:"done",pr:{number:200}}' > "$WORKERB/phase-pr.json"
+# Old run's phase-monitor-merge signal (PR#100 was merged)
+jq -nc --arg t "$NOW_B2" '{pr:{number:100,mergedAt:$t,ciStatus:"merged"}}' \
+  > "$WORKERB/phase-monitor-merge.json"
+jq -nc --arg t "$NOW_B2" '{status:"done",deploy_state:"success",startedAt:$t,completedAt:$t}' \
+  > "$WORKERB/phase-monitor-deploy.json"
+jq -nc --arg t "$NOW_B2" '{status:"running",startedAt:$t}' > "$WORKERB/phase-teardown.json"
+# gh stub: current PR#200 is OPEN
+GH_FIX_B2="$TMPROOT/caseb2-gh-fixture.json"
+jq -n '{state:"OPEN",mergedAt:null,number:200}' > "$GH_FIX_B2"
+install_gh_stub "$STUB_BINB" "$GH_FIX_B2"
+run_b_case "caseb2"
+B2_EXIT="$(cat "$CDIR/exit-code" 2>/dev/null || echo 0)"
+if [ "$B2_EXIT" -ne 0 ]; then
+  ok "case B2: exits non-zero (stale merge signal / current PR open)"
+else
+  fail "case B2: exits non-zero (stale merge signal / current PR open)" "got exit 0"
+fi
+if [ -d "$WT_PATHB" ]; then
+  ok "case B2: worktree NOT removed"
+else
+  fail "case B2: worktree NOT removed" "worktree was deleted"
+fi
+B2_EMITTED="$(jq -r '.attributes."event.name" // empty' \
+  "$FAKE_HOMEB/catalyst/events/$(date -u +%Y-%m).jsonl" 2>/dev/null | grep '^phase\.teardown\.' | tail -1)"
+assert_eq "case B2: emits teardown.failed" "phase.teardown.failed.CTL-9999" "$B2_EMITTED"
+B2_TRANS=0
+[ -f "$CDIR/linear-transition-calls.log" ] && \
+  B2_TRANS="$(wc -l < "$CDIR/linear-transition-calls.log" 2>/dev/null | tr -d ' ' || echo 0)"
+assert_eq "case B2: linear-transition NOT called" "0" "$B2_TRANS"
+
+# ─────────────────────────────────────────────────────────────────────────────
+echo ""
+echo "Case B3 (CTL-1667): PR numbers match (200) but GitHub says OPEN → FAILS"
+setup_b_case "caseb3"
+NOW_B3="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+jq -n '{status:"done",pr:{number:200}}' > "$WORKERB/phase-pr.json"
+# monitor-merge signals PR#200 as merged (disk says so) — but live GitHub disagrees
+jq -nc --arg t "$NOW_B3" '{pr:{number:200,mergedAt:$t,ciStatus:"merged"}}' \
+  > "$WORKERB/phase-monitor-merge.json"
+jq -nc --arg t "$NOW_B3" '{status:"done",deploy_state:"success",startedAt:$t,completedAt:$t}' \
+  > "$WORKERB/phase-monitor-deploy.json"
+jq -nc --arg t "$NOW_B3" '{status:"running",startedAt:$t}' > "$WORKERB/phase-teardown.json"
+GH_FIX_B3="$TMPROOT/caseb3-gh-fixture.json"
+jq -n '{state:"OPEN",mergedAt:null,number:200}' > "$GH_FIX_B3"
+install_gh_stub "$STUB_BINB" "$GH_FIX_B3"
+run_b_case "caseb3"
+B3_EXIT="$(cat "$CDIR/exit-code" 2>/dev/null || echo 0)"
+if [ "$B3_EXIT" -ne 0 ]; then
+  ok "case B3: exits non-zero (gh says OPEN despite disk saying merged)"
+else
+  fail "case B3: exits non-zero (gh says OPEN despite disk saying merged)" "got exit 0"
+fi
+B3_EMITTED="$(jq -r '.attributes."event.name" // empty' \
+  "$FAKE_HOMEB/catalyst/events/$(date -u +%Y-%m).jsonl" 2>/dev/null | grep '^phase\.teardown\.' | tail -1)"
+assert_eq "case B3: emits teardown.failed" "phase.teardown.failed.CTL-9999" "$B3_EMITTED"
+
+# ─────────────────────────────────────────────────────────────────────────────
+echo ""
+echo "Case B4 (CTL-1667): gh errors (non-zero exit) → FAIL-CLOSED pr_not_merged"
+setup_b_case "caseb4"
+NOW_B4="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+jq -n '{status:"done",pr:{number:200}}' > "$WORKERB/phase-pr.json"
+jq -nc --arg t "$NOW_B4" '{pr:{number:200,mergedAt:$t,ciStatus:"merged"}}' \
+  > "$WORKERB/phase-monitor-merge.json"
+jq -nc --arg t "$NOW_B4" '{status:"done",deploy_state:"success",startedAt:$t,completedAt:$t}' \
+  > "$WORKERB/phase-monitor-deploy.json"
+jq -nc --arg t "$NOW_B4" '{status:"running",startedAt:$t}' > "$WORKERB/phase-teardown.json"
+# gh stub: exits non-zero (simulates failure)
+mkdir -p "$STUB_BINB"
+cat > "$STUB_BINB/gh-stub" <<'GHFAIL'
+#!/usr/bin/env bash
+echo "gh: error: could not reach GitHub" >&2
+exit 1
+GHFAIL
+chmod +x "$STUB_BINB/gh-stub"
+run_b_case "caseb4"
+B4_EXIT="$(cat "$CDIR/exit-code" 2>/dev/null || echo 0)"
+if [ "$B4_EXIT" -ne 0 ]; then
+  ok "case B4: exits non-zero (gh failure → fail-closed)"
+else
+  fail "case B4: exits non-zero (gh failure → fail-closed)" "got exit 0 — should fail-closed"
+fi
+B4_EMITTED="$(jq -r '.attributes."event.name" // empty' \
+  "$FAKE_HOMEB/catalyst/events/$(date -u +%Y-%m).jsonl" 2>/dev/null | grep '^phase\.teardown\.' | tail -1)"
+assert_eq "case B4: emits teardown.failed on gh error" "phase.teardown.failed.CTL-9999" "$B4_EMITTED"
 
 # ─────────────────────────────────────────────────────────────────────────────
 # Summary

--- a/plugins/dev/scripts/execution-core/scheduler.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.mjs
@@ -3244,14 +3244,29 @@ const TERMINAL_PR_CHECK_COOLDOWN_MS = (() => {
 // every time the cooldown expires and probes `gh` again, FOREVER. That is
 // still an unbounded synchronous GitHub poll (just a slow one), which
 // AGENTS.md ("Working the Loop") requires to be a bounded fallback, not an
-// indefinite one. TERMINAL_PR_CHECK_MAX_ATTEMPTS caps the total number of
-// refusals this gate will ever probe for a given worker dir; once the cap is
-// reached the gate stops calling `gh` for that dir entirely (it still refuses
-// Done — never the reverse — so exhausting the budget can only make the gate
-// MORE conservative, never less).
+// indefinite one. TERMINAL_PR_CHECK_MAX_ATTEMPTS is the threshold after which
+// the SHORT per-probe cooldown escalates to the much LONGER
+// TERMINAL_PR_CHECK_EXHAUSTED_COOLDOWN_MS below — RATE-bounded, never a hard
+// permanent stop.
+//
+// CTL-1667 (review fix, round 4): the first version of this cap made the gate
+// stop calling `gh` for a dir FOREVER once exhausted — a genuine merge
+// arriving after the budget was spent (or a later run reusing the same
+// worker dir) could then never reach `prView`/terminalDoneOnce again, leaving
+// Linear permanently non-Done with no recovery path (reconcileTerminalBackstop
+// is inert too: its GATE 1 requires the `.terminal-done.applied` marker, which
+// a permanently-refusing gate never writes). Escalating the cooldown instead
+// of hard-stopping keeps the total probe RATE bounded (the original ask) while
+// guaranteeing eventual convergence: a merge is still detected, just on a
+// much slower cadence once a dir has proven itself persistently stuck.
 const TERMINAL_PR_CHECK_MAX_ATTEMPTS = (() => {
   const v = Number(process.env.CATALYST_TERMINAL_PR_CHECK_MAX_ATTEMPTS);
   return Number.isFinite(v) && v > 0 ? v : 12; // default: ~1h of 5-min-cooldown probing
+})();
+
+const TERMINAL_PR_CHECK_EXHAUSTED_COOLDOWN_MS = (() => {
+  const v = Number(process.env.CATALYST_TERMINAL_PR_CHECK_EXHAUSTED_COOLDOWN_MS);
+  return Number.isFinite(v) && v > 0 ? v : 6 * 60 * 60_000; // default: 6h between probes once exhausted
 })();
 
 function terminalPrCheckMarkerPath(orchDir, ticket) {
@@ -3262,10 +3277,30 @@ function terminalPrCheckExhaustedMarkerPath(orchDir, ticket) {
   return join(orchDir, "workers", ticket, ".terminal-pr-check-exhausted");
 }
 
+// warnTerminalPrCheckExhaustedOnce — surface the escalation into the LONG
+// cooldown tier LOUDLY exactly once per worker dir (never a silent-forever
+// refusal — "Surface anomalies loudly"), via a dedicated marker so the WARN
+// doesn't repeat on every subsequent probe. Best-effort. The gate keeps
+// probing on the long cadence after this — it is a rate change, not a stop.
+function warnTerminalPrCheckExhaustedOnce(orchDir, ticket) {
+  const marker = terminalPrCheckExhaustedMarkerPath(orchDir, ticket);
+  if (existsSync(marker)) return;
+  log.warn(
+    { ticket, maxAttempts: TERMINAL_PR_CHECK_MAX_ATTEMPTS },
+    "ctl-1667: terminal-PR-merged probe budget exhausted — escalating to the long cooldown (still probing, far less often); Done stays refused"
+  );
+  try {
+    writeFileSync(marker, "");
+  } catch {
+    /* best-effort — a repeat WARN next tick is harmless */
+  }
+}
+
 // stampTerminalPrCheckSuppress — record that the current-PR-merged gate refused
 // Done this tick, and bump the total-attempts counter (CTL-1667 review fix:
 // bounds the total probe count, not just the per-probe cooldown). Best-effort:
-// a failed write just means we re-probe next tick.
+// a failed write just means we re-probe next tick. Fires the one-time
+// exhaustion WARN exactly on the tick the count first reaches the threshold.
 function stampTerminalPrCheckSuppress(orchDir, ticket, nowMs) {
   let count = 1;
   try {
@@ -3282,51 +3317,30 @@ function stampTerminalPrCheckSuppress(orchDir, ticket, nowMs) {
   } catch {
     /* best-effort — re-probe next tick */
   }
+  if (count === TERMINAL_PR_CHECK_MAX_ATTEMPTS) warnTerminalPrCheckExhaustedOnce(orchDir, ticket);
 }
 
-// isTerminalPrCheckSuppressFresh — true when the gate refused within the cooldown
-// window, so the caller should skip the `gh` PR-view this tick. A missing,
-// unparseable, or expired marker returns false (re-probe), so a PR that merges
-// converges to Done after at most one cooldown window.
+// isTerminalPrCheckSuppressFresh — true when the gate refused recently enough
+// that the caller should skip the `gh` PR-view this tick. Tiered: the first
+// TERMINAL_PR_CHECK_MAX_ATTEMPTS refusals use the SHORT cooldown; once that
+// count is reached, subsequent refusals use the much LONGER
+// TERMINAL_PR_CHECK_EXHAUSTED_COOLDOWN_MS — bounding the total probe RATE
+// without ever fully cutting a dir off from eventually converging (CTL-1667
+// review fix, round 4). A missing, unparseable, or expired marker returns
+// false (re-probe), so a genuine merge still converges to Done.
 function isTerminalPrCheckSuppressFresh(orchDir, ticket, nowMs) {
   try {
-    const { ts } = JSON.parse(
+    const { ts, count } = JSON.parse(
       readFileSync(terminalPrCheckMarkerPath(orchDir, ticket), "utf8")
     );
-    return Number.isFinite(ts) && nowMs - ts < TERMINAL_PR_CHECK_COOLDOWN_MS;
+    if (!Number.isFinite(ts)) return false;
+    const cooldown =
+      Number.isFinite(count) && count >= TERMINAL_PR_CHECK_MAX_ATTEMPTS
+        ? TERMINAL_PR_CHECK_EXHAUSTED_COOLDOWN_MS
+        : TERMINAL_PR_CHECK_COOLDOWN_MS;
+    return nowMs - ts < cooldown;
   } catch {
     return false;
-  }
-}
-
-// isTerminalPrCheckExhausted — true once the total refusal count recorded by
-// stampTerminalPrCheckSuppress has reached TERMINAL_PR_CHECK_MAX_ATTEMPTS
-// (CTL-1667 review fix, #3061). A missing/unparseable marker (never refused
-// yet) returns false.
-function isTerminalPrCheckExhausted(orchDir, ticket) {
-  try {
-    const { count } = JSON.parse(readFileSync(terminalPrCheckMarkerPath(orchDir, ticket), "utf8"));
-    return Number.isFinite(count) && count >= TERMINAL_PR_CHECK_MAX_ATTEMPTS;
-  } catch {
-    return false;
-  }
-}
-
-// warnTerminalPrCheckExhaustedOnce — surface the probe-budget exhaustion LOUDLY
-// exactly once per worker dir (never a silent-forever refusal — "Surface
-// anomalies loudly"), via a dedicated marker so the WARN doesn't repeat every
-// tick once the budget is spent. Best-effort.
-function warnTerminalPrCheckExhaustedOnce(orchDir, ticket) {
-  const marker = terminalPrCheckExhaustedMarkerPath(orchDir, ticket);
-  if (existsSync(marker)) return;
-  log.warn(
-    { ticket, maxAttempts: TERMINAL_PR_CHECK_MAX_ATTEMPTS },
-    "ctl-1667: terminal-PR-merged probe budget exhausted — no further gh polling for this dir; Done stays refused"
-  );
-  try {
-    writeFileSync(marker, "");
-  } catch {
-    /* best-effort — a repeat WARN next tick is harmless */
   }
 }
 
@@ -3416,13 +3430,17 @@ export function terminalDoneOnce(
   // nothing, so it is NOT treated as stale — a data gap never invents
   // staleness, it only ever fails to detect a genuine one.
   if (isTerminalTeardownStale(orchDir, ticket)) {
+    // CTL-1667 (review fix, round 4): throttle the WARN to once per cooldown
+    // window (was unconditional — a retained stale signal has no successor
+    // that ever clears this condition, so an unthrottled log.warn flooded
+    // daemon logs/telemetry at the full per-tick rate indefinitely).
     if (!isTerminalPrCheckSuppressFresh(orchDir, ticket, now())) {
       stampTerminalPrCheckSuppress(orchDir, ticket, now());
+      log.warn(
+        { ticket },
+        "ctl-1667: retained teardown:done signal predates a later phase dispatch — refusing Done (stale evidence)"
+      );
     }
-    log.warn(
-      { ticket },
-      "ctl-1667: retained teardown:done signal predates a later phase dispatch — refusing Done (stale evidence)"
-    );
     return null;
   }
   // CTL-1667 — GATE: the current run's PR must be MERGED before Done.
@@ -3447,19 +3465,16 @@ export function terminalDoneOnce(
   //   • Bounded TOTAL probes — the cooldown above only bounds the FREQUENCY. A
   //     dir stuck refusing forever (a permanently-open or unverifiable PR)
   //     would otherwise re-arm and re-probe `gh` every cooldown window
-  //     indefinitely. TERMINAL_PR_CHECK_MAX_ATTEMPTS caps the total refusal
-  //     count; once exhausted the gate stops calling `gh` for this dir at all
-  //     (it stays refused — exhausting the budget only makes it MORE
-  //     conservative, never less) and surfaces the exhaustion loudly exactly
-  //     once instead of polling silently forever.
+  //     indefinitely. Once the total refusal count reaches
+  //     TERMINAL_PR_CHECK_MAX_ATTEMPTS, isTerminalPrCheckSuppressFresh
+  //     escalates to the much longer TERMINAL_PR_CHECK_EXHAUSTED_COOLDOWN_MS
+  //     for this dir — RATE-bounded, never a hard permanent stop (round 4:
+  //     a genuine merge arriving after the budget is spent must still
+  //     eventually be detected).
   {
     const currentPrNum = readCurrentRunPrNumber(orchDir, ticket);
     if (currentPrNum != null) {
-      if (isTerminalPrCheckExhausted(orchDir, ticket)) {
-        warnTerminalPrCheckExhaustedOnce(orchDir, ticket);
-        return null; // bounded: total probe budget spent — stay refused, no further gh calls
-      }
-      if (isTerminalPrCheckSuppressFresh(orchDir, ticket, now())) return null; // bounded: within cooldown, skip the gh probe
+      if (isTerminalPrCheckSuppressFresh(orchDir, ticket, now())) return null; // bounded: within cooldown (short or, once exhausted, long), skip the gh probe
       if (!prAdapter || typeof prAdapter.prView !== "function") {
         stampTerminalPrCheckSuppress(orchDir, ticket, now());
         return null; // can't verify → fail-closed (bounded)
@@ -7643,6 +7658,11 @@ export function schedulerTick(
         emitDoneWithOpenPr,
         emitDoneApplied,
         prAdapter, // CTL-1667: thread through for the current-PR-merged gate
+        now, // CTL-1667 (review fix, round 4): thread the tick's injectable clock
+        // through so the terminal-PR-check / fence-suppress cooldowns are
+        // deterministically testable at the schedulerTick level, not only via
+        // a direct terminalDoneOnce call (previously always fell back to the
+        // real wall clock here regardless of a caller-supplied `now`).
       });
       // CTL-764 finding 7: emit the terminal Done stage transition on a REAL Done
       // write — independent of the needs-human clear below (a normally-completed

--- a/plugins/dev/scripts/execution-core/scheduler.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.mjs
@@ -941,6 +941,17 @@ export const PREEMPTED_STATUS = "preempted";
 // Cleared on stopScheduler/__resetForTests (see daemon module state section).
 const rankedAboveSince = new Map();
 
+// readCurrentRunPrNumber — return the current run's PR number from phase-pr.json,
+// or null if the file is absent or malformed (CTL-1667).
+export function readCurrentRunPrNumber(orchDir, ticket) {
+  try {
+    const p = join(orchDir, "workers", ticket, "phase-pr.json");
+    return JSON.parse(readFileSync(p, "utf8"))?.pr?.number ?? null;
+  } catch {
+    return null;
+  }
+}
+
 // readPhaseSignals — { phase: status } for one ticket's workers/<T>/phase-*.json.
 // CTL-1660 P1 (Codex #3081): entries are inserted in ASCENDING mtime order (oldest
 // dispatch first, most-recently-touched signal last), not raw readdirSync order
@@ -3108,6 +3119,10 @@ export function terminalDoneOnce(
     // CTL-1157 A1: injectable fence decision (deterministic in tests). Production
     // uses the real fenceGuard, which reads the cross-host claim generation.
     fence = fenceGuard,
+    // CTL-1667: injectable prAdapter for the current-PR-merged gate. The same
+    // prAdapter already threaded to reconcileTerminalBackstop; schedulerTick
+    // passes it through to both callers from the same opts object.
+    prAdapter = undefined,
   } = {}
 ) {
   const marker = join(orchDir, "workers", ticket, ".terminal-done.applied");
@@ -3133,6 +3148,27 @@ export function terminalDoneOnce(
     // stalled/failed branch uses immediately before its needs-human write.
     stampFenceSuppress(orchDir, ticket, now());
     return null;
+  }
+  // CTL-1667 — GATE: the current run's PR must be MERGED before Done.
+  // Mirrors reconcileTerminalBackstop GATE 2 (`prAdapter.prView`). Engages only
+  // when a current PR number is resolvable from phase-pr.json; when it is absent
+  // the gate is skipped and today's behavior (no-PR tickets complete) is preserved.
+  // Fail-closed: an unverifiable merge (prView throws or missing prAdapter while a
+  // PR number IS resolvable) refuses Done rather than assuming success.
+  // Reuses the same merged definition as reconcileTerminalBackstop:3126.
+  {
+    const currentPrNum = readCurrentRunPrNumber(orchDir, ticket);
+    if (currentPrNum != null) {
+      if (!prAdapter || typeof prAdapter.prView !== "function") return null; // can't verify → fail-closed
+      let merged = false;
+      try {
+        const view = prAdapter.prView(ticket, { number: currentPrNum });
+        merged = !!(view && (view.state === "MERGED" || view.mergedAt != null));
+      } catch {
+        return null; // unverifiable merge → fail-closed, refuse Done
+      }
+      if (!merged) return null; // current PR still open → do NOT write Done
+    }
   }
   // CTL-1157 (ALARM-NOT-BLOCK — THE REVERSAL): the terminal sweep writes Done
   // DIRECTLY (no agent to reason). The earlier behavior REFUSED the write when an
@@ -7289,6 +7325,7 @@ export function schedulerTick(
         checkOpenPrs,
         emitDoneWithOpenPr,
         emitDoneApplied,
+        prAdapter, // CTL-1667: thread through for the current-PR-merged gate
       });
       // CTL-764 finding 7: emit the terminal Done stage transition on a REAL Done
       // write — independent of the needs-human clear below (a normally-completed

--- a/plugins/dev/scripts/execution-core/scheduler.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.mjs
@@ -1235,7 +1235,19 @@ export function listInFlightTickets(orchDir) {
   }
   for (const d of dirs) {
     if (!d.isDirectory()) continue;
-    const signals = readPhaseSignals(orchDir, d.name);
+    // CTL-1667 (review fix, round 4, #3061): sanitize BEFORE the in-flight
+    // check, not only inside the advancement loop below. isTicketInFlight
+    // treats a `teardown: done` signal as terminal (not in-flight) — so a
+    // ticket carrying a STALE retained teardown signal (proven stale relative
+    // to a newer phase-pr.json) was excluded from this Set entirely, and the
+    // advancement loop's OWN sanitizeStalePostPrSignals call — scoped to
+    // tickets this function already returned — never got a chance to run for
+    // it. terminalDoneOnce correctly refuses Done for that ticket (its own
+    // isTerminalTeardownStale check), but with the ticket excluded here it
+    // ALSO never reaches the advancement sweep to be re-dispatched — wedging
+    // the run permanently: refused forever, advanced never. Sanitizing here
+    // first makes both checks see the same (correct) picture.
+    const signals = sanitizeStalePostPrSignals(orchDir, d.name, readPhaseSignals(orchDir, d.name));
     // CTL-1323: a phantom recovery-pass dir is not real in-flight work — skip it so it
     // isn't counted as occupying a slot (and so buildGlobalRanking doesn't list it both
     // as in-flight here AND as a fresh new-work candidate once listStartedTickets drops it).

--- a/plugins/dev/scripts/execution-core/scheduler.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.mjs
@@ -1021,6 +1021,56 @@ export function readPhaseSignals(orchDir, ticket) {
   return signals;
 }
 
+// readPhaseSignalTimestamp — `.updatedAt // .startedAt` off one phase's signal
+// file, mirroring is_poststale_signal's own timestamp precedence
+// (lib/phase-signal-freshness.sh). Returns null when the phase's signal file
+// is absent, unreadable, or carries neither field (CTL-1667 review fix, #3061).
+function readPhaseSignalTimestamp(orchDir, ticket, phase) {
+  try {
+    const sig = JSON.parse(readFileSync(join(orchDir, "workers", ticket, `phase-${phase}.json`), "utf8"));
+    return sig?.updatedAt ?? sig?.startedAt ?? null;
+  } catch {
+    return null;
+  }
+}
+
+// isTerminalTeardownStale — CTL-1667 (review fix, #3061): true when SOME OTHER
+// phase in the worker dir was (re)dispatched strictly AFTER the terminal
+// `teardown` signal's own timestamp. See the call site in terminalDoneOnce for
+// the full rationale — in short, a `teardown: done` signal has no FSM
+// successor to be invalidated by the dispatcher's post-stale handling the way
+// every other phase's stale signal is, so this is the one place that binds it
+// to the current run. Every phase-agent-dispatch write (fresh OR revive)
+// unconditionally stamps a fresh `startedAt`, so any sibling phase file newer
+// than teardown's own timestamp proves the worker dir was touched by a run
+// that started after teardown last reported done. Conservative: an
+// unestablishable baseline (teardown's own timestamp absent/unreadable) or no
+// comparably-timestamped sibling returns false — never invents staleness from
+// a data gap, only detects a genuine one.
+function isTerminalTeardownStale(orchDir, ticket) {
+  const teardownAt = readPhaseSignalTimestamp(orchDir, ticket, TERMINAL_PHASE);
+  if (!teardownAt) return false; // no baseline to compare against → not proven stale
+  const dir = join(orchDir, "workers", ticket);
+  let files;
+  try {
+    files = readdirSync(dir);
+  } catch {
+    return false;
+  }
+  for (const f of files) {
+    const m = /^phase-(.+)\.json$/.exec(f);
+    if (!m || m[1] === TERMINAL_PHASE || m[1].includes("-yield-")) continue;
+    let startedAt;
+    try {
+      startedAt = JSON.parse(readFileSync(join(dir, f), "utf8"))?.startedAt;
+    } catch {
+      continue; // unreadable sibling — not comparable evidence either way
+    }
+    if (typeof startedAt === "string" && startedAt > teardownAt) return true;
+  }
+  return false;
+}
+
 // isTicketInFlight — true when a ticket still occupies a worker slot. Pure over
 // a phase→status map. In-flight = has ≥1 signal AND is neither pipeline-complete
 // (monitor-deploy done) nor failed/stalled/aborted. A ticket mid-advance (plan
@@ -3129,14 +3179,50 @@ const TERMINAL_PR_CHECK_COOLDOWN_MS = (() => {
   return Number.isFinite(v) && v > 0 ? v : 5 * 60_000;
 })();
 
+// CTL-1667 (review fix, #3061): the cooldown above bounds the PROBE
+// FREQUENCY, not the total number of probes — a retained `teardown: done`
+// dir sitting on an OPEN or perpetually-unverifiable PR re-arms automatically
+// every time the cooldown expires and probes `gh` again, FOREVER. That is
+// still an unbounded synchronous GitHub poll (just a slow one), which
+// AGENTS.md ("Working the Loop") requires to be a bounded fallback, not an
+// indefinite one. TERMINAL_PR_CHECK_MAX_ATTEMPTS caps the total number of
+// refusals this gate will ever probe for a given worker dir; once the cap is
+// reached the gate stops calling `gh` for that dir entirely (it still refuses
+// Done — never the reverse — so exhausting the budget can only make the gate
+// MORE conservative, never less).
+const TERMINAL_PR_CHECK_MAX_ATTEMPTS = (() => {
+  const v = Number(process.env.CATALYST_TERMINAL_PR_CHECK_MAX_ATTEMPTS);
+  return Number.isFinite(v) && v > 0 ? v : 12; // default: ~1h of 5-min-cooldown probing
+})();
+
 function terminalPrCheckMarkerPath(orchDir, ticket) {
   return join(orchDir, "workers", ticket, ".terminal-pr-check-suppressed");
 }
 
+function terminalPrCheckExhaustedMarkerPath(orchDir, ticket) {
+  return join(orchDir, "workers", ticket, ".terminal-pr-check-exhausted");
+}
+
 // stampTerminalPrCheckSuppress — record that the current-PR-merged gate refused
-// Done this tick. Best-effort: a failed write just means we re-probe next tick.
+// Done this tick, and bump the total-attempts counter (CTL-1667 review fix:
+// bounds the total probe count, not just the per-probe cooldown). Best-effort:
+// a failed write just means we re-probe next tick.
 function stampTerminalPrCheckSuppress(orchDir, ticket, nowMs) {
-  stampCooldownMarker(terminalPrCheckMarkerPath(orchDir, ticket), nowMs);
+  let count = 1;
+  try {
+    const prior = JSON.parse(readFileSync(terminalPrCheckMarkerPath(orchDir, ticket), "utf8"));
+    if (Number.isFinite(prior?.count)) count = prior.count + 1;
+  } catch {
+    /* first refusal, or an unreadable prior marker — start the count at 1 */
+  }
+  try {
+    writeFileSync(
+      terminalPrCheckMarkerPath(orchDir, ticket),
+      JSON.stringify({ ts: nowMs, count })
+    );
+  } catch {
+    /* best-effort — re-probe next tick */
+  }
 }
 
 // isTerminalPrCheckSuppressFresh — true when the gate refused within the cooldown
@@ -3151,6 +3237,37 @@ function isTerminalPrCheckSuppressFresh(orchDir, ticket, nowMs) {
     return Number.isFinite(ts) && nowMs - ts < TERMINAL_PR_CHECK_COOLDOWN_MS;
   } catch {
     return false;
+  }
+}
+
+// isTerminalPrCheckExhausted — true once the total refusal count recorded by
+// stampTerminalPrCheckSuppress has reached TERMINAL_PR_CHECK_MAX_ATTEMPTS
+// (CTL-1667 review fix, #3061). A missing/unparseable marker (never refused
+// yet) returns false.
+function isTerminalPrCheckExhausted(orchDir, ticket) {
+  try {
+    const { count } = JSON.parse(readFileSync(terminalPrCheckMarkerPath(orchDir, ticket), "utf8"));
+    return Number.isFinite(count) && count >= TERMINAL_PR_CHECK_MAX_ATTEMPTS;
+  } catch {
+    return false;
+  }
+}
+
+// warnTerminalPrCheckExhaustedOnce — surface the probe-budget exhaustion LOUDLY
+// exactly once per worker dir (never a silent-forever refusal — "Surface
+// anomalies loudly"), via a dedicated marker so the WARN doesn't repeat every
+// tick once the budget is spent. Best-effort.
+function warnTerminalPrCheckExhaustedOnce(orchDir, ticket) {
+  const marker = terminalPrCheckExhaustedMarkerPath(orchDir, ticket);
+  if (existsSync(marker)) return;
+  log.warn(
+    { ticket, maxAttempts: TERMINAL_PR_CHECK_MAX_ATTEMPTS },
+    "ctl-1667: terminal-PR-merged probe budget exhausted — no further gh polling for this dir; Done stays refused"
+  );
+  try {
+    writeFileSync(marker, "");
+  } catch {
+    /* best-effort — a repeat WARN next tick is harmless */
   }
 }
 
@@ -3217,6 +3334,38 @@ export function terminalDoneOnce(
     stampFenceSuppress(orchDir, ticket, now());
     return null;
   }
+  // CTL-1667 (review fix, #3061) — bind the retained `teardown: done` evidence
+  // to the CURRENT run before trusting it at all. deriveAdvancement never
+  // re-dispatches a terminal `teardown` signal (transition() has no successor
+  // once `teardown` is `done`), so — unlike every non-terminal phase — a
+  // `teardown: done` signal left over from an EARLIER run is never invalidated
+  // by the dispatcher's post-stale handling (is_poststale_signal /
+  // POSTSTALE_SIGNAL, lib/phase-signal-freshness.sh, this same PR): nothing
+  // ever asks phase-agent-dispatch to dispatch `teardown` again, so that
+  // invalidation code path simply never runs for this phase. If the worker dir
+  // was reused for a later run (a revive/redispatch of an earlier phase, e.g.
+  // `pr`, after this teardown already reported done — without clearing the
+  // stale phase-teardown.json), that later dispatch always writes its OWN
+  // phase-<x>.json with a fresh `startedAt` (phase-agent-dispatch's
+  // unconditional skeleton write). A later phase's `startedAt` newer than this
+  // teardown's own completion is therefore proof the retained "done" evidence
+  // predates — and cannot cover — that later run, whether or not its own
+  // phase-pr.json currently resolves a PR number (it may not exist yet, or may
+  // have been overwritten again by a still-later redispatch). Conservative in
+  // the SAME direction as is_poststale_signal: no comparable timestamp on
+  // either side (this teardown signal, or every sibling phase file) proves
+  // nothing, so it is NOT treated as stale — a data gap never invents
+  // staleness, it only ever fails to detect a genuine one.
+  if (isTerminalTeardownStale(orchDir, ticket)) {
+    if (!isTerminalPrCheckSuppressFresh(orchDir, ticket, now())) {
+      stampTerminalPrCheckSuppress(orchDir, ticket, now());
+    }
+    log.warn(
+      { ticket },
+      "ctl-1667: retained teardown:done signal predates a later phase dispatch — refusing Done (stale evidence)"
+    );
+    return null;
+  }
   // CTL-1667 — GATE: the current run's PR must be MERGED before Done.
   // Mirrors reconcileTerminalBackstop GATE 2 (`prAdapter.prView`). Engages only
   // when a current PR number is resolvable from phase-pr.json; when it is absent
@@ -3236,9 +3385,21 @@ export function terminalDoneOnce(
   //     skipped for a window instead of re-running on every ~2x/sec tick (the
   //     AGENTS.md "bounded poll as fallback" contract). The merge still converges
   //     to Done once the cooldown expires and the next tick sees MERGED.
+  //   • Bounded TOTAL probes — the cooldown above only bounds the FREQUENCY. A
+  //     dir stuck refusing forever (a permanently-open or unverifiable PR)
+  //     would otherwise re-arm and re-probe `gh` every cooldown window
+  //     indefinitely. TERMINAL_PR_CHECK_MAX_ATTEMPTS caps the total refusal
+  //     count; once exhausted the gate stops calling `gh` for this dir at all
+  //     (it stays refused — exhausting the budget only makes it MORE
+  //     conservative, never less) and surfaces the exhaustion loudly exactly
+  //     once instead of polling silently forever.
   {
     const currentPrNum = readCurrentRunPrNumber(orchDir, ticket);
     if (currentPrNum != null) {
+      if (isTerminalPrCheckExhausted(orchDir, ticket)) {
+        warnTerminalPrCheckExhaustedOnce(orchDir, ticket);
+        return null; // bounded: total probe budget spent — stay refused, no further gh calls
+      }
       if (isTerminalPrCheckSuppressFresh(orchDir, ticket, now())) return null; // bounded: within cooldown, skip the gh probe
       if (!prAdapter || typeof prAdapter.prView !== "function") {
         stampTerminalPrCheckSuppress(orchDir, ticket, now());

--- a/plugins/dev/scripts/execution-core/scheduler.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.mjs
@@ -1514,6 +1514,65 @@ function readPhaseSignalRaw(orchDir, ticket, phase) {
   }
 }
 
+// POST_PR_PHASES — mirrors lib/phase-signal-freshness.sh's POST_PR_PHASES
+// exactly: the three phases whose signal can go stale relative to a LATER
+// phase-pr.json (CTL-1667 review fix, round 3, #3061).
+const POST_PR_PHASES = ["monitor-merge", "monitor-deploy", TERMINAL_PHASE];
+
+// isPostPrSignalStale — JS port of is_poststale_signal
+// (lib/phase-signal-freshness.sh) for the scheduler-side advancement sweep.
+// KEEP THE TWO RULES IN SYNC with that file (bash cannot import this .mjs):
+//   1. PR-number mismatch (both signal.pr.number and phase-pr.pr.number
+//      present and different) → STALE — definitive, takes precedence.
+//   2. Signal predates phase-pr.json's timestamp (`.updatedAt // .startedAt`
+//      on both sides) → STALE.
+//   3. Anything ambiguous (missing files, unresolvable timestamps, no PR
+//      numbers to compare) → NOT stale. A data gap never invents staleness,
+//      it only ever fails to detect a genuine one — the same fail-safe
+//      direction the bash predicate uses for its own caller (avoiding a
+//      spurious re-dispatch); here it avoids spuriously discarding a
+//      genuinely-current signal.
+function isPostPrSignalStale(orchDir, ticket, phase) {
+  if (!POST_PR_PHASES.includes(phase)) return false;
+  const sig = readPhaseSignalRaw(orchDir, ticket, phase);
+  const pr = readPhaseSignalRaw(orchDir, ticket, "pr");
+  if (!sig || !pr) return false; // either file absent → cannot prove staleness
+  const sigPr = sig?.pr?.number;
+  const curPr = pr?.pr?.number;
+  if (sigPr != null && curPr != null && sigPr !== curPr) return true;
+  const sigTs = sig?.updatedAt ?? sig?.startedAt ?? null;
+  const prTs = pr?.updatedAt ?? pr?.startedAt ?? null;
+  if (typeof sigTs === "string" && typeof prTs === "string") return sigTs < prTs;
+  return false;
+}
+
+// sanitizeStalePostPrSignals — CTL-1667 (review fix, round 3, #3061): strip any
+// post-PR phase signal (monitor-merge, monitor-deploy, teardown) proven stale
+// relative to the current phase-pr.json BEFORE deriveAdvancement ever sees it.
+// deriveAdvancement is pure and treats the highest-indexed phase present in
+// `signals` as "latest", then advances past it — so a RETAINED stale signal
+// (e.g. an old phase-monitor-merge.json left over from a run that was revived
+// at an earlier phase, with a new phase-pr.json but no fresh monitor-merge
+// dispatch yet) makes it skip straight past that phase for the current run
+// instead of re-dispatching it. is_poststale_signal already exists to catch
+// exactly this — but ONLY inside phase-agent-dispatch, which is never invoked
+// here in the first place: deriveAdvancement decided the phase was "already
+// dispatched" before any dispatcher call happens. Filtering the stale entries
+// out of the signals map here makes deriveAdvancement re-derive "latest" from
+// the next OLDER, still-fresh phase, so the stale phase is re-dispatched like
+// any other missing one — restoring monitor-merge/monitor-deploy/teardown
+// verification for the CURRENT PR instead of silently skipping it.
+function sanitizeStalePostPrSignals(orchDir, ticket, signals) {
+  let out = signals;
+  for (const phase of POST_PR_PHASES) {
+    if (phase in out && isPostPrSignalStale(orchDir, ticket, phase)) {
+      if (out === signals) out = { ...signals }; // copy-on-write — never mutate the caller's map
+      delete out[phase];
+    }
+  }
+  return out;
+}
+
 // predecessorPhaseOf — the completed phase whose happy-path successor is `next`
 // (i.e. the worker that just finished and triggered this advance), or null.
 // Uses the NEXT_PHASE inversion so it is unambiguous on every LINEAR edge. The
@@ -6762,7 +6821,14 @@ export function schedulerTick(
     // signals so deriveAdvancement re-dispatches a fresh verify this tick).
     maybeResetForRemediateCycle(orchDir, ticket);
 
-    const signals = readPhaseSignals(orchDir, ticket);
+    // CTL-1667 (review fix, round 3, #3061): strip any post-PR phase signal
+    // (monitor-merge/monitor-deploy/teardown) proven stale relative to the
+    // current phase-pr.json BEFORE deriveAdvancement sees it — see
+    // sanitizeStalePostPrSignals for the full rationale. Without this,
+    // deriveAdvancement treats a retained stale signal as "already dispatched"
+    // and advances PAST it, so the phase-agent-dispatch-side freshness check
+    // (is_poststale_signal) never even gets a chance to run for that phase.
+    const signals = sanitizeStalePostPrSignals(orchDir, ticket, readPhaseSignals(orchDir, ticket));
     // CTL-653: the verdict-router reads — verify.json verdict + event-counted
     // cycle budget. Injected into deriveAdvancement so the router stays pure.
     const verdict = readVerifyVerdict({ ticket, orchDir });

--- a/plugins/dev/scripts/execution-core/scheduler.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.mjs
@@ -952,6 +952,32 @@ export function readCurrentRunPrNumber(orchDir, ticket) {
   }
 }
 
+// readCurrentRunPrRepo — return the current run's repo slug (`owner/name`) from
+// phase-pr.json, or null when unresolvable (CTL-1667 review fix). Prefers an
+// explicit `.pr.repo`; otherwise derives it from the `.pr.url` GitHub PR link.
+//
+// Why this exists: the production `makePrView` adapter derives the repo slug
+// from the ticket's WORKTREE `origin` remote when the passed PR object carries
+// no `.repo`. But by the time the terminalDoneOnce Done-recovery gate runs, a
+// normal teardown has already removed that worktree, so the worktree-derived
+// slug resolves empty → prView returns an UNKNOWN view → the gate can never
+// confirm the merge. Preserving the repo identity that phase-pr.json already
+// stored lets prView run `gh -R <slug>` without the (removed) worktree.
+export function readCurrentRunPrRepo(orchDir, ticket) {
+  try {
+    const p = join(orchDir, "workers", ticket, "phase-pr.json");
+    const pr = JSON.parse(readFileSync(p, "utf8"))?.pr;
+    if (!pr) return null;
+    if (typeof pr.repo === "string" && pr.repo) return pr.repo;
+    const m =
+      typeof pr.url === "string" &&
+      pr.url.match(/github\.com\/([^/]+\/[^/]+)\/pull\/\d+/);
+    return m ? m[1] : null;
+  } catch {
+    return null;
+  }
+}
+
 // readPhaseSignals — { phase: status } for one ticket's workers/<T>/phase-*.json.
 // CTL-1660 P1 (Codex #3081): entries are inserted in ASCENDING mtime order (oldest
 // dispatch first, most-recently-touched signal last), not raw readdirSync order
@@ -3086,6 +3112,48 @@ function isEscalationProbeCooldownFresh(orchDir, ticket, nowMs) {
   return isCooldownMarkerFresh(escalationProbeCooldownPath(orchDir, ticket), nowMs);
 }
 
+// CTL-1667 (review fix): the terminalDoneOnce current-PR-merged gate makes a
+// synchronous `gh` PR-view call. On the REFUSAL path — the current PR is still
+// OPEN, or the merge is unverifiable (prView threw / GitHub is down) — a
+// retained `teardown: done` dir would otherwise re-run that `gh` call on EVERY
+// scheduler tick (~2x/sec) until the PR merges, an unbounded poll that burns the
+// shared GitHub-API quota and blocks the scheduler on network I/O. AGENTS.md
+// ("Working the Loop") requires waiting on the event log with only a BOUNDED
+// poll as fallback. This cooldown is that bound: after a refusal we stamp a
+// per-dir marker and skip the `gh` probe for a window. A genuine merge still
+// converges — the marker expires and the next post-cooldown tick re-checks,
+// sees MERGED, and writes Done. Marker lives in the worker dir (reaped with it),
+// mirroring .fence-suppressed / .terminal-done.applied.
+const TERMINAL_PR_CHECK_COOLDOWN_MS = (() => {
+  const v = Number(process.env.CATALYST_TERMINAL_PR_CHECK_COOLDOWN_MS);
+  return Number.isFinite(v) && v > 0 ? v : 5 * 60_000;
+})();
+
+function terminalPrCheckMarkerPath(orchDir, ticket) {
+  return join(orchDir, "workers", ticket, ".terminal-pr-check-suppressed");
+}
+
+// stampTerminalPrCheckSuppress — record that the current-PR-merged gate refused
+// Done this tick. Best-effort: a failed write just means we re-probe next tick.
+function stampTerminalPrCheckSuppress(orchDir, ticket, nowMs) {
+  stampCooldownMarker(terminalPrCheckMarkerPath(orchDir, ticket), nowMs);
+}
+
+// isTerminalPrCheckSuppressFresh — true when the gate refused within the cooldown
+// window, so the caller should skip the `gh` PR-view this tick. A missing,
+// unparseable, or expired marker returns false (re-probe), so a PR that merges
+// converges to Done after at most one cooldown window.
+function isTerminalPrCheckSuppressFresh(orchDir, ticket, nowMs) {
+  try {
+    const { ts } = JSON.parse(
+      readFileSync(terminalPrCheckMarkerPath(orchDir, ticket), "utf8")
+    );
+    return Number.isFinite(ts) && nowMs - ts < TERMINAL_PR_CHECK_COOLDOWN_MS;
+  } catch {
+    return false;
+  }
+}
+
 // terminalDoneOnce — write the terminal `Done` Linear state for a ticket at
 // most once for the run's lifetime (CTL-597). The terminal sweep revisits every
 // started worker dir each tick, and applyTerminalDone → linear-transition.sh
@@ -3156,18 +3224,40 @@ export function terminalDoneOnce(
   // Fail-closed: an unverifiable merge (prView throws or missing prAdapter while a
   // PR number IS resolvable) refuses Done rather than assuming success.
   // Reuses the same merged definition as reconcileTerminalBackstop:3126.
+  //
+  // CTL-1667 (review fixes):
+  //   • Repo identity — pass the repo slug from phase-pr.json so `makePrView`
+  //     resolves `gh -R <slug>` directly instead of falling back to the ticket's
+  //     WORKTREE origin, which a normal teardown has already removed (a
+  //     `{number}`-only lookup would resolve UNKNOWN → the gate could never
+  //     confirm the merge or run its documented Done recovery).
+  //   • Bounded poll — every refusal (PR still OPEN, prView throws, or missing
+  //     prAdapter) stamps a per-dir cooldown so the synchronous `gh` probe is
+  //     skipped for a window instead of re-running on every ~2x/sec tick (the
+  //     AGENTS.md "bounded poll as fallback" contract). The merge still converges
+  //     to Done once the cooldown expires and the next tick sees MERGED.
   {
     const currentPrNum = readCurrentRunPrNumber(orchDir, ticket);
     if (currentPrNum != null) {
-      if (!prAdapter || typeof prAdapter.prView !== "function") return null; // can't verify → fail-closed
+      if (isTerminalPrCheckSuppressFresh(orchDir, ticket, now())) return null; // bounded: within cooldown, skip the gh probe
+      if (!prAdapter || typeof prAdapter.prView !== "function") {
+        stampTerminalPrCheckSuppress(orchDir, ticket, now());
+        return null; // can't verify → fail-closed (bounded)
+      }
+      const repo = readCurrentRunPrRepo(orchDir, ticket);
+      const prRef = repo ? { number: currentPrNum, repo } : { number: currentPrNum };
       let merged = false;
       try {
-        const view = prAdapter.prView(ticket, { number: currentPrNum });
+        const view = prAdapter.prView(ticket, prRef);
         merged = !!(view && (view.state === "MERGED" || view.mergedAt != null));
       } catch {
-        return null; // unverifiable merge → fail-closed, refuse Done
+        stampTerminalPrCheckSuppress(orchDir, ticket, now());
+        return null; // unverifiable merge → fail-closed, refuse Done (bounded)
       }
-      if (!merged) return null; // current PR still open → do NOT write Done
+      if (!merged) {
+        stampTerminalPrCheckSuppress(orchDir, ticket, now());
+        return null; // current PR still open → do NOT write Done (bounded)
+      }
     }
   }
   // CTL-1157 (ALARM-NOT-BLOCK — THE REVERSAL): the terminal sweep writes Done

--- a/plugins/dev/scripts/execution-core/scheduler.test.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.test.mjs
@@ -13522,4 +13522,64 @@ describe("CTL-1667: terminalDoneOnce current-PR-merged gate", () => {
     mkdirSync(join(orchDir, "workers", "CTL-74b"), { recursive: true });
     expect(readCurrentRunPrNumber(orchDir, "CTL-74b")).toBeNull();
   });
+
+  // Review fix (Codex P2): the merge check must carry repo identity, because a
+  // normal teardown removed the worktree makePrView would otherwise resolve the
+  // slug from. The gate reads `.pr.url` from phase-pr.json and passes its slug
+  // to prView so `gh -R <slug>` works without the worktree.
+  test("CTL-1667: terminalDoneOnce threads the repo slug (from phase-pr.json url) to prView", () => {
+    writeSignalRaw("CTL-75", "pr", {
+      ticket: "CTL-75",
+      phase: "pr",
+      status: "done",
+      pr: { number: 750, url: "https://github.com/coalesce-labs/catalyst/pull/750" },
+    });
+    writeSignal("CTL-75", "teardown", "done");
+    const seen = [];
+    const dones = [];
+    schedulerTick(orchDir, {
+      readEligible: () => [],
+      dispatch: ctl1667Dispatch,
+      writeStatus: makeWriteStatus(dones),
+      prAdapter: {
+        prView: (_t, pr) => {
+          seen.push(pr);
+          return { state: "MERGED", mergedAt: "2026-08-07T00:00:00Z" };
+        },
+      },
+    });
+    expect(seen[0]).toEqual({ number: 750, repo: "coalesce-labs/catalyst" });
+    expect(dones).toContainEqual(expect.objectContaining({ ticket: "CTL-75" }));
+  });
+
+  // Review fix (Codex P1): the OPEN-PR refusal path must NOT re-run the gh
+  // prView on every tick. After the first refusal a per-dir cooldown is stamped,
+  // so the second tick within the window skips the probe entirely (bounded poll).
+  test("CTL-1667: terminalDoneOnce bounds the poll — OPEN PR is not re-probed within the cooldown", () => {
+    writePrSignals("CTL-76", 760);
+    let calls = 0;
+    const dones = [];
+    const openAdapter = {
+      prView: () => {
+        calls += 1;
+        return { state: "OPEN", mergedAt: null };
+      },
+    };
+    // Tick 1: probes GitHub, sees OPEN, refuses Done, stamps the cooldown.
+    schedulerTick(orchDir, {
+      readEligible: () => [],
+      dispatch: ctl1667Dispatch,
+      writeStatus: makeWriteStatus(dones),
+      prAdapter: openAdapter,
+    });
+    // Tick 2 (immediately after, within cooldown): must skip the gh probe.
+    schedulerTick(orchDir, {
+      readEligible: () => [],
+      dispatch: ctl1667Dispatch,
+      writeStatus: makeWriteStatus(dones),
+      prAdapter: openAdapter,
+    });
+    expect(calls).toBe(1); // second tick suppressed — no unbounded poll
+    expect(dones).toEqual([]); // still refused (PR never merged)
+  });
 });

--- a/plugins/dev/scripts/execution-core/scheduler.test.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.test.mjs
@@ -92,6 +92,8 @@ import {
   HELD_LABEL_NEEDS_INPUT,
   // CTL-1524 (C4a): hoisted dead-host computation (one surviving-roster read)
   computeDeadHosts,
+  // CTL-1667: current-run PR reader (for terminalDoneOnce gate tests)
+  readCurrentRunPrNumber,
 } from "./scheduler.mjs";
 import { createTicketStateCache } from "./linear-cache.mjs";
 import { fetchTicketsBatch } from "./linear-query.mjs"; // CTL-784: cache-reuse tests drive the real batch
@@ -13432,5 +13434,92 @@ describe("CTL-1605 review: STEP A terminal-stale live label refresh", () => {
     // SAME tick, even though its TTL has not elapsed — a later hydrate must
     // re-read fresh rather than serve the pre-write (unlabeled) descriptor.
     expect(cache.getRelations("CTL-32")).toBeUndefined();
+  });
+});
+
+// ─── CTL-1667: terminalDoneOnce current-PR-merged gate ───────────────────────
+// The gate inside terminalDoneOnce requires the current run's phase-pr.json
+// PR number to be MERGED on GitHub before writing Done.  Mirrors the existing
+// reconcileTerminalBackstop GATE 2 (`prAdapter.prView`), but applied by the
+// PRIMARY Done writer on every terminal sweep hit.
+describe("CTL-1667: terminalDoneOnce current-PR-merged gate", () => {
+  // Dispatch stub at module scope (fakeDispatch is module-level).
+  const ctl1667Dispatch = fakeDispatch();
+
+  // Helper: write phase-pr.json + a teardown "done" signal for a ticket.
+  function writePrSignals(ticket, prNumber) {
+    writeSignalRaw(ticket, "pr", { ticket, phase: "pr", status: "done", pr: { number: prNumber } });
+    writeSignal(ticket, "teardown", "done");
+  }
+
+  // Helper: minimal writeStatus stub that captures applyTerminalDone calls.
+  function makeWriteStatus(dones) {
+    return {
+      applyPhaseStatus: () => {},
+      applyTerminalDone: (a) => dones.push(a),
+      applyLabel: () => {},
+    };
+  }
+
+  test("CTL-1667: terminalDoneOnce does NOT write Done when current PR is OPEN", () => {
+    writePrSignals("CTL-70", 700);
+    const dones = [];
+    schedulerTick(orchDir, {
+      readEligible: () => [],
+      dispatch: ctl1667Dispatch,
+      writeStatus: makeWriteStatus(dones),
+      prAdapter: { prView: () => ({ state: "OPEN", mergedAt: null }) },
+    });
+    expect(dones).toEqual([]); // Done refused — current PR is OPEN
+  });
+
+  test("CTL-1667: terminalDoneOnce writes Done when current PR is MERGED", () => {
+    writePrSignals("CTL-71", 710);
+    const dones = [];
+    schedulerTick(orchDir, {
+      readEligible: () => [],
+      dispatch: ctl1667Dispatch,
+      writeStatus: makeWriteStatus(dones),
+      prAdapter: { prView: () => ({ state: "MERGED", mergedAt: "2026-08-07T00:00:00Z" }) },
+    });
+    expect(dones).toContainEqual(expect.objectContaining({ ticket: "CTL-71" }));
+  });
+
+  test("CTL-1667: no phase-pr.json and no PR number → legacy behavior (Done allowed)", () => {
+    // No phase-pr.json written: only teardown signal.
+    writeSignal("CTL-72", "teardown", "done");
+    const dones = [];
+    schedulerTick(orchDir, {
+      readEligible: () => [],
+      dispatch: ctl1667Dispatch,
+      writeStatus: makeWriteStatus(dones),
+      // prAdapter provided — but readCurrentRunPrNumber returns null (no phase-pr.json),
+      // so the gate is skipped and Done is allowed (preserves legacy / no-PR-opener behavior).
+      prAdapter: { prView: () => ({ state: "OPEN", mergedAt: null }) },
+    });
+    expect(dones).toContainEqual(expect.objectContaining({ ticket: "CTL-72" }));
+  });
+
+  test("CTL-1667: prView throws → fail-closed, do NOT write Done", () => {
+    writePrSignals("CTL-73", 730);
+    const dones = [];
+    schedulerTick(orchDir, {
+      readEligible: () => [],
+      dispatch: ctl1667Dispatch,
+      writeStatus: makeWriteStatus(dones),
+      prAdapter: { prView: () => { throw new Error("gh down"); } },
+    });
+    expect(dones).toEqual([]); // conservative: no Done on unverifiable merge
+  });
+
+  test("CTL-1667: readCurrentRunPrNumber returns the PR number from phase-pr.json", () => {
+    writeSignalRaw("CTL-74", "pr", { ticket: "CTL-74", phase: "pr", status: "done", pr: { number: 999 } });
+    expect(readCurrentRunPrNumber(orchDir, "CTL-74")).toBe(999);
+  });
+
+  test("CTL-1667: readCurrentRunPrNumber returns null when phase-pr.json absent", () => {
+    // CTL-74b has no phase-pr.json — just ensure the dir exists
+    mkdirSync(join(orchDir, "workers", "CTL-74b"), { recursive: true });
+    expect(readCurrentRunPrNumber(orchDir, "CTL-74b")).toBeNull();
   });
 });

--- a/plugins/dev/scripts/execution-core/scheduler.test.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.test.mjs
@@ -13587,16 +13587,28 @@ describe("CTL-1667: terminalDoneOnce current-PR-merged gate", () => {
   // FREQUENCY but not the TOTAL count — a dir stuck on a permanently-OPEN or
   // unverifiable PR would otherwise re-arm and re-probe `gh` every cooldown
   // window forever. Once the total refusal count reaches
-  // TERMINAL_PR_CHECK_MAX_ATTEMPTS (default 12), the gate must stop calling
-  // `gh` for that dir entirely — even outside the per-probe cooldown window.
-  test("CTL-1667 (review fix): terminalDoneOnce bounds the TOTAL probe count, not just the frequency", () => {
+  // TERMINAL_PR_CHECK_MAX_ATTEMPTS (default 12), the gate escalates to a much
+  // LONGER cooldown for that dir instead of the short one.
+  //
+  // Review fix (Codex P1, round 4, #3061): escalating to a longer cooldown —
+  // never a HARD, PERMANENT stop — is the fix for a follow-on finding: the
+  // first version of this cap stopped probing `gh` forever once exhausted, so
+  // a PR that genuinely merged after the budget was spent could never be
+  // detected and Linear could stay non-Done permanently with no recovery path
+  // (reconcileTerminalBackstop is inert too — its GATE 1 needs the
+  // `.terminal-done.applied` marker, which a permanently-refusing gate never
+  // writes). These two tests assert BOTH halves: the long cooldown suppresses
+  // a probe while fresh, and a probe still eventually fires once the long
+  // cooldown itself expires (eventual convergence).
+  test("CTL-1667 (review fix): terminalDoneOnce escalates to the LONG cooldown once the total probe count is exhausted", () => {
     writePrSignals("CTL-77", 770);
+    const NOW = 10_000_000;
     // Pre-seed the suppress marker at the exhaustion threshold, timestamped
-    // WELL outside the cooldown window so a frequency-only bound would allow
-    // (and this test would otherwise force) a re-probe.
+    // recently enough to still be within the LONG (exhausted) cooldown — a
+    // frequency-only (short-cooldown) bound would already have expired here.
     writeFileSync(
       join(orchDir, "workers", "CTL-77", ".terminal-pr-check-suppressed"),
-      JSON.stringify({ ts: 0, count: 12 })
+      JSON.stringify({ ts: NOW - 60 * 60_000, count: 12 }) // 1h ago: past the 5-min short cooldown, well within the 6h long one
     );
     let calls = 0;
     const dones = [];
@@ -13604,6 +13616,7 @@ describe("CTL-1667: terminalDoneOnce current-PR-merged gate", () => {
       readEligible: () => [],
       dispatch: ctl1667Dispatch,
       writeStatus: makeWriteStatus(dones),
+      now: () => NOW,
       prAdapter: {
         prView: () => {
           calls += 1;
@@ -13611,8 +13624,34 @@ describe("CTL-1667: terminalDoneOnce current-PR-merged gate", () => {
         },
       },
     });
-    expect(calls).toBe(0); // budget exhausted — no gh call at all
-    expect(dones).toEqual([]); // stays refused (exhausting the budget never grants Done)
+    expect(calls).toBe(0); // still within the long cooldown — no gh call
+    expect(dones).toEqual([]); // stays refused
+  });
+
+  test("CTL-1667 (review fix, round 4): terminalDoneOnce eventually re-probes and can still reach Done after the long cooldown expires", () => {
+    writePrSignals("CTL-78b", 771);
+    const NOW = 100_000_000;
+    // Exhausted, but the long cooldown has now fully expired (well past 6h).
+    writeFileSync(
+      join(orchDir, "workers", "CTL-78b", ".terminal-pr-check-suppressed"),
+      JSON.stringify({ ts: NOW - 7 * 60 * 60_000, count: 12 }) // 7h ago
+    );
+    let calls = 0;
+    const dones = [];
+    schedulerTick(orchDir, {
+      readEligible: () => [],
+      dispatch: ctl1667Dispatch,
+      writeStatus: makeWriteStatus(dones),
+      now: () => NOW,
+      prAdapter: {
+        prView: () => {
+          calls += 1;
+          return { state: "MERGED", mergedAt: "2026-08-08T00:00:00Z" };
+        },
+      },
+    });
+    expect(calls).toBe(1); // probe fires again — never permanently cut off
+    expect(dones).toContainEqual(expect.objectContaining({ ticket: "CTL-78b" })); // and Done is reachable again
   });
 
   // Review fix (Codex P1, #3061): binds a retained `teardown: done` signal to

--- a/plugins/dev/scripts/execution-core/scheduler.test.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.test.mjs
@@ -388,6 +388,42 @@ describe("listInFlightTickets / readMaxParallel / computeFreeSlots", () => {
     writeSignal("CTL-3", "triage", "failed");
     expect([...listInFlightTickets(orchDir)]).toEqual(["CTL-1"]);
   });
+
+  // CTL-1667 (review fix, round 4, #3061): a ticket carrying a STALE retained
+  // `teardown: done` signal (proven stale relative to a newer phase-pr.json)
+  // must still count as in-flight — otherwise it is excluded from this Set,
+  // the advancement sweep's own sanitizeStalePostPrSignals call never gets a
+  // chance to run for it (that loop only visits tickets THIS function
+  // returns), and the ticket wedges permanently: terminalDoneOnce correctly
+  // refuses Done (its own staleness check), but nothing ever re-dispatches it
+  // either. Without the fix inside listInFlightTickets itself, this ticket
+  // would be excluded exactly like CTL-2 above.
+  test("a STALE teardown:done signal (newer sibling phase-pr.json) still counts as in-flight", () => {
+    const dir = join(orchDir, "workers", "CTL-4");
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(
+      join(dir, "phase-teardown.json"),
+      JSON.stringify({
+        ticket: "CTL-4",
+        phase: "teardown",
+        status: "done",
+        completedAt: "2026-08-01T00:00:00Z",
+        updatedAt: "2026-08-01T00:00:00Z",
+      })
+    );
+    // pr (re)dispatched AFTER teardown completed — proves staleness.
+    writeFileSync(
+      join(dir, "phase-pr.json"),
+      JSON.stringify({
+        ticket: "CTL-4",
+        phase: "pr",
+        status: "done",
+        pr: { number: 400 },
+        startedAt: "2026-08-05T00:00:00Z",
+      })
+    );
+    expect([...listInFlightTickets(orchDir)]).toContain("CTL-4");
+  });
   test("readMaxParallel reads state.json, defaults to 1", () => {
     expect(readMaxParallel(orchDir)).toBe(1);
     writeFileSync(join(orchDir, "state.json"), JSON.stringify({ maxParallel: 3 }));
@@ -13872,5 +13908,52 @@ describe("CTL-1667 (review fix, round 3): sanitize stale post-PR signals before 
     });
     expect(dispatch.calls).toEqual([{ orchDir, ticket: "CTL-83", phase: "monitor-deploy" }]);
     expect(r.advanced).toEqual([{ ticket: "CTL-83", phase: "monitor-deploy" }]);
+  });
+
+  // Review fix (Codex P1, round 4, #3061): a stale TEARDOWN signal specifically
+  // (not just monitor-merge/monitor-deploy) is the deepest case — teardown is
+  // TERMINAL_PHASE, so isTicketInFlight treats it as terminal and
+  // listInFlightTickets excludes the ticket BEFORE the advancement loop (and
+  // its sanitizeStalePostPrSignals call) ever runs. terminalDoneOnce correctly
+  // refuses Done (isTerminalTeardownStale), but without sanitizing inside
+  // listInFlightTickets itself the ticket was permanently wedged: refused
+  // forever, advanced never. This end-to-end test drives a full schedulerTick
+  // and asserts the ticket actually gets RE-DISPATCHED (proving it was
+  // reachable), not just that the lower-level helpers return the right shape.
+  test("a ticket with a STALE teardown:done signal is reachable and gets RE-dispatched (not permanently wedged)", () => {
+    writeFileSync(join(orchDir, "state.json"), JSON.stringify({ maxParallel: 1 }));
+    const dir = join(orchDir, "workers", "CTL-84");
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(
+      join(dir, "phase-teardown.json"),
+      JSON.stringify({
+        ticket: "CTL-84",
+        phase: "teardown",
+        status: "done",
+        completedAt: "2026-08-01T00:00:00Z",
+        updatedAt: "2026-08-01T00:00:00Z",
+      })
+    );
+    // pr (re)dispatched AFTER teardown completed — proves staleness, and is
+    // the only OTHER phase signal present (a stripped-down repro: nothing
+    // else masks whether the ticket ever reached the advancement sweep).
+    writeSignalRaw("CTL-84", "pr", {
+      ticket: "CTL-84",
+      phase: "pr",
+      status: "done",
+      pr: { number: 240 },
+      startedAt: "2026-08-05T00:00:00Z",
+    });
+    const dispatch = fakeDispatch();
+    const r = schedulerTick(orchDir, {
+      readEligible: () => [],
+      dispatch,
+      verifyDispatched: verifyOk,
+      liveBackgroundCount: () => 0,
+    });
+    // Sanitized signals = {pr: "done"} → deriveAdvancement's owed next phase
+    // is monitor-merge — proof the ticket was reachable, not excluded.
+    expect(dispatch.calls).toEqual([{ orchDir, ticket: "CTL-84", phase: "monitor-merge" }]);
+    expect(r.advanced).toEqual([{ ticket: "CTL-84", phase: "monitor-merge" }]);
   });
 });

--- a/plugins/dev/scripts/execution-core/scheduler.test.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.test.mjs
@@ -13705,3 +13705,133 @@ describe("CTL-1667: terminalDoneOnce current-PR-merged gate", () => {
     expect(dones).toContainEqual(expect.objectContaining({ ticket: "CTL-79" }));
   });
 });
+
+// ─── CTL-1667 (review fix, round 3, #3061): sanitize stale post-PR signals
+// before the advancement sweep's deriveAdvancement call ────────────────────
+// Without this, a retained STALE monitor-merge/monitor-deploy/teardown signal
+// (referencing an EARLIER run's PR, left over after a revive at an earlier
+// phase produced a NEW phase-pr.json) makes deriveAdvancement treat that phase
+// as "already dispatched" and skip straight past it — so is_poststale_signal
+// inside phase-agent-dispatch never even gets a chance to run, since the
+// dispatcher is never invoked for that phase at all.
+describe("CTL-1667 (review fix, round 3): sanitize stale post-PR signals before advancement", () => {
+  test("advancement sweep RE-dispatches monitor-merge when its signal is stale (mismatched PR#)", () => {
+    writeFileSync(join(orchDir, "state.json"), JSON.stringify({ maxParallel: 1 }));
+    // Current run's PR (#200), just opened.
+    writeSignalRaw("CTL-80", "pr", {
+      ticket: "CTL-80",
+      phase: "pr",
+      status: "done",
+      pr: { number: 200 },
+      startedAt: "2026-08-05T00:00:00Z",
+      updatedAt: "2026-08-05T00:00:00Z",
+    });
+    // STALE monitor-merge signal retained from an EARLIER run's PR (#100) —
+    // predates the current PR entirely.
+    writeSignalRaw("CTL-80", "monitor-merge", {
+      ticket: "CTL-80",
+      phase: "monitor-merge",
+      status: "done",
+      pr: { number: 100 },
+      startedAt: "2026-08-01T00:00:00Z",
+      updatedAt: "2026-08-01T00:00:00Z",
+    });
+    const dispatch = fakeDispatch();
+    const r = schedulerTick(orchDir, {
+      readEligible: () => [],
+      dispatch,
+      verifyDispatched: verifyOk,
+      liveBackgroundCount: () => 0,
+    });
+    // Without sanitization, deriveAdvancement would see "latest=monitor-merge,
+    // done" and skip straight to monitor-deploy — silently bypassing merge
+    // verification for the CURRENT PR. With sanitization, the stale
+    // monitor-merge entry is dropped, "latest" falls back to `pr`, and
+    // monitor-merge is correctly RE-dispatched for the current run.
+    expect(dispatch.calls).toEqual([{ orchDir, ticket: "CTL-80", phase: "monitor-merge" }]);
+    expect(r.advanced).toEqual([{ ticket: "CTL-80", phase: "monitor-merge" }]);
+  });
+
+  test("advancement sweep RE-dispatches monitor-merge when its signal predates the current PR (stale timestamp, no PR# to compare)", () => {
+    writeFileSync(join(orchDir, "state.json"), JSON.stringify({ maxParallel: 1 }));
+    writeSignalRaw("CTL-81", "pr", {
+      ticket: "CTL-81",
+      phase: "pr",
+      status: "done",
+      pr: { number: 210 },
+      startedAt: "2026-08-05T00:00:00Z",
+      updatedAt: "2026-08-05T00:00:00Z",
+    });
+    // Stale monitor-merge with NO .pr.number at all (legacy/malformed shape) —
+    // falls through to the timestamp rule, which alone proves staleness here.
+    writeSignalRaw("CTL-81", "monitor-merge", {
+      ticket: "CTL-81",
+      phase: "monitor-merge",
+      status: "done",
+      startedAt: "2026-08-01T00:00:00Z",
+      updatedAt: "2026-08-01T00:00:00Z",
+    });
+    const dispatch = fakeDispatch();
+    schedulerTick(orchDir, {
+      readEligible: () => [],
+      dispatch,
+      verifyDispatched: verifyOk,
+      liveBackgroundCount: () => 0,
+    });
+    expect(dispatch.calls).toEqual([{ orchDir, ticket: "CTL-81", phase: "monitor-merge" }]);
+  });
+
+  test("advancement sweep still advances normally past a genuinely FRESH monitor-merge signal (matching PR#, correct ordering)", () => {
+    writeFileSync(join(orchDir, "state.json"), JSON.stringify({ maxParallel: 1 }));
+    writeSignalRaw("CTL-82", "pr", {
+      ticket: "CTL-82",
+      phase: "pr",
+      status: "done",
+      pr: { number: 220 },
+      startedAt: "2026-08-01T00:00:00Z",
+      updatedAt: "2026-08-01T00:00:00Z",
+    });
+    // monitor-merge for the SAME PR, completed AFTER pr — genuinely fresh.
+    writeSignalRaw("CTL-82", "monitor-merge", {
+      ticket: "CTL-82",
+      phase: "monitor-merge",
+      status: "done",
+      pr: { number: 220 },
+      startedAt: "2026-08-02T00:00:00Z",
+      updatedAt: "2026-08-02T00:00:00Z",
+    });
+    const dispatch = fakeDispatch();
+    const r = schedulerTick(orchDir, {
+      readEligible: () => [],
+      dispatch,
+      verifyDispatched: verifyOk,
+      liveBackgroundCount: () => 0,
+    });
+    // NOT stale → sanitization is a no-op → the sweep advances past
+    // monitor-merge to monitor-deploy, the normal happy path.
+    expect(dispatch.calls).toEqual([{ orchDir, ticket: "CTL-82", phase: "monitor-deploy" }]);
+    expect(r.advanced).toEqual([{ ticket: "CTL-82", phase: "monitor-deploy" }]);
+  });
+
+  test("advancement sweep is unaffected when phase-pr.json is absent (ambiguous — never invents staleness)", () => {
+    writeFileSync(join(orchDir, "state.json"), JSON.stringify({ maxParallel: 1 }));
+    // No phase-pr.json at all — sanitization must not touch monitor-merge here
+    // (matches is_poststale_signal's own conservative default).
+    writeSignalRaw("CTL-83", "monitor-merge", {
+      ticket: "CTL-83",
+      phase: "monitor-merge",
+      status: "done",
+      pr: { number: 230 },
+      startedAt: "2026-08-01T00:00:00Z",
+    });
+    const dispatch = fakeDispatch();
+    const r = schedulerTick(orchDir, {
+      readEligible: () => [],
+      dispatch,
+      verifyDispatched: verifyOk,
+      liveBackgroundCount: () => 0,
+    });
+    expect(dispatch.calls).toEqual([{ orchDir, ticket: "CTL-83", phase: "monitor-deploy" }]);
+    expect(r.advanced).toEqual([{ ticket: "CTL-83", phase: "monitor-deploy" }]);
+  });
+});

--- a/plugins/dev/scripts/execution-core/scheduler.test.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.test.mjs
@@ -13582,4 +13582,126 @@ describe("CTL-1667: terminalDoneOnce current-PR-merged gate", () => {
     expect(calls).toBe(1); // second tick suppressed — no unbounded poll
     expect(dones).toEqual([]); // still refused (PR never merged)
   });
+
+  // Review fix (Codex P1, round 2, #3061): the cooldown above bounds the PROBE
+  // FREQUENCY but not the TOTAL count — a dir stuck on a permanently-OPEN or
+  // unverifiable PR would otherwise re-arm and re-probe `gh` every cooldown
+  // window forever. Once the total refusal count reaches
+  // TERMINAL_PR_CHECK_MAX_ATTEMPTS (default 12), the gate must stop calling
+  // `gh` for that dir entirely — even outside the per-probe cooldown window.
+  test("CTL-1667 (review fix): terminalDoneOnce bounds the TOTAL probe count, not just the frequency", () => {
+    writePrSignals("CTL-77", 770);
+    // Pre-seed the suppress marker at the exhaustion threshold, timestamped
+    // WELL outside the cooldown window so a frequency-only bound would allow
+    // (and this test would otherwise force) a re-probe.
+    writeFileSync(
+      join(orchDir, "workers", "CTL-77", ".terminal-pr-check-suppressed"),
+      JSON.stringify({ ts: 0, count: 12 })
+    );
+    let calls = 0;
+    const dones = [];
+    schedulerTick(orchDir, {
+      readEligible: () => [],
+      dispatch: ctl1667Dispatch,
+      writeStatus: makeWriteStatus(dones),
+      prAdapter: {
+        prView: () => {
+          calls += 1;
+          return { state: "OPEN", mergedAt: null };
+        },
+      },
+    });
+    expect(calls).toBe(0); // budget exhausted — no gh call at all
+    expect(dones).toEqual([]); // stays refused (exhausting the budget never grants Done)
+  });
+
+  // Review fix (Codex P1, #3061): binds a retained `teardown: done` signal to
+  // the CURRENT run. A later phase (`pr`) dispatched AFTER teardown's own
+  // completion is proof the worker dir was reused by a run whose
+  // monitor-merge/monitor-deploy/teardown have not actually been verified —
+  // Done must be refused even though the (stale) teardown signal says "done"
+  // and even though the later PR happens to be merged.
+  test("CTL-1667 (review fix): terminalDoneOnce refuses Done when teardown evidence predates a later phase dispatch (stale signal)", () => {
+    const dir = join(orchDir, "workers", "CTL-78");
+    mkdirSync(dir, { recursive: true });
+    // Teardown "done" from an EARLIER run, completed at T0. Production always
+    // sets updatedAt alongside completedAt (phase-agent-emit-complete); the
+    // staleness check reads updatedAt (mirrors is_poststale_signal), so both
+    // are set here to match a real signal file's shape.
+    writeFileSync(
+      join(dir, "phase-teardown.json"),
+      JSON.stringify({
+        ticket: "CTL-78",
+        phase: "teardown",
+        status: "done",
+        completedAt: "2026-08-01T00:00:00Z",
+        updatedAt: "2026-08-01T00:00:00Z",
+      })
+    );
+    // `pr` phase (re)dispatched LATER, at T1 > T0 — a revived/newer run.
+    writeFileSync(
+      join(dir, "phase-pr.json"),
+      JSON.stringify({
+        ticket: "CTL-78",
+        phase: "pr",
+        status: "done",
+        pr: { number: 780 },
+        startedAt: "2026-08-05T00:00:00Z",
+      })
+    );
+    let calls = 0;
+    const dones = [];
+    schedulerTick(orchDir, {
+      readEligible: () => [],
+      dispatch: ctl1667Dispatch,
+      writeStatus: makeWriteStatus(dones),
+      prAdapter: {
+        prView: () => {
+          calls += 1;
+          return { state: "MERGED", mergedAt: "2026-08-05T01:00:00Z" }; // the NEW PR IS merged
+        },
+      },
+    });
+    expect(dones).toEqual([]); // refused: stale teardown evidence, despite the merged PR
+    expect(calls).toBe(0); // never even reaches the merge-check gh call — caught earlier
+  });
+
+  // Companion: the SAME staleness check must NOT interfere with a genuine,
+  // single-run completion — the common case every other CTL-1667 test above
+  // already exercises implicitly (no sibling phase file is ever newer than
+  // teardown there). This test makes the non-interference explicit by setting
+  // real, correctly-ordered timestamps end to end.
+  test("CTL-1667 (review fix): terminalDoneOnce still writes Done for a genuinely fresh, correctly-ordered run", () => {
+    const dir = join(orchDir, "workers", "CTL-79");
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(
+      join(dir, "phase-pr.json"),
+      JSON.stringify({
+        ticket: "CTL-79",
+        phase: "pr",
+        status: "done",
+        pr: { number: 790 },
+        startedAt: "2026-08-01T00:00:00Z",
+      })
+    );
+    // Teardown completes AFTER pr started — the normal, non-stale ordering.
+    writeFileSync(
+      join(dir, "phase-teardown.json"),
+      JSON.stringify({
+        ticket: "CTL-79",
+        phase: "teardown",
+        status: "done",
+        completedAt: "2026-08-03T00:00:00Z",
+        updatedAt: "2026-08-03T00:00:00Z",
+      })
+    );
+    const dones = [];
+    schedulerTick(orchDir, {
+      readEligible: () => [],
+      dispatch: ctl1667Dispatch,
+      writeStatus: makeWriteStatus(dones),
+      prAdapter: { prView: () => ({ state: "MERGED", mergedAt: "2026-08-02T00:00:00Z" }) },
+    });
+    expect(dones).toContainEqual(expect.objectContaining({ ticket: "CTL-79" }));
+  });
 });

--- a/plugins/dev/scripts/lib/__tests__/phase-signal-freshness.test.sh
+++ b/plugins/dev/scripts/lib/__tests__/phase-signal-freshness.test.sh
@@ -1,0 +1,213 @@
+#!/usr/bin/env bash
+# Unit tests for plugins/dev/scripts/lib/phase-signal-freshness.sh (CTL-1667).
+# Tests the is_poststale_signal predicate in isolation (no dispatch involved).
+#
+# Run: bash plugins/dev/scripts/lib/__tests__/phase-signal-freshness.test.sh
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+HELPER="${SCRIPT_DIR}/../phase-signal-freshness.sh"
+
+PASS=0
+FAIL=0
+
+ok()   { PASS=$((PASS+1)); printf '  PASS: %s\n' "$1"; }
+fail() { FAIL=$((FAIL+1)); printf '  FAIL: %s\n    %s\n' "$1" "${2:-}"; }
+
+[ -f "$HELPER" ] || { echo "FATAL: helper not found: $HELPER" >&2; exit 1; }
+
+# shellcheck source=../phase-signal-freshness.sh
+source "$HELPER"
+
+SCRATCH="$(mktemp -d -t phase-freshness-test-XXXXXX)"
+trap 'rm -rf "$SCRATCH"' EXIT
+
+# Helper: write a minimal signal JSON
+write_signal() {
+  local path="$1"; shift
+  local json="$1"
+  mkdir -p "$(dirname "$path")"
+  printf '%s\n' "$json" > "$path"
+}
+
+# Helper: compute an ISO-8601 timestamp offset from now (macOS + GNU portable)
+ts_offset() {
+  local delta="$1"  # e.g. "-3600" (1 hour ago) or "+3600" (1 hour from now)
+  if date -v "${delta}S" +%Y-%m-%dT%H:%M:%SZ 2>/dev/null >&2; then
+    date -v "${delta}S" -u +%Y-%m-%dT%H:%M:%SZ 2>/dev/null
+  else
+    date -u -d "${delta} seconds" +%Y-%m-%dT%H:%M:%SZ 2>/dev/null
+  fi
+}
+
+YESTERDAY="$(ts_offset "-86400")"   # 24 hours ago
+NOW="$(ts_offset "0")"              # now (for phase-pr.json)
+FUTURE="$(ts_offset "+3600")"       # 1 hour from now (signal newer than pr)
+
+echo "phase-signal-freshness unit tests"
+echo ""
+
+# ─────────────────────────────────────────────────────────────────────────────
+echo "Case A: monitor-merge signal older than phase-pr.json → STALE (exit 0)"
+D_A="$SCRATCH/case-a"
+write_signal "$D_A/phase-pr.json" \
+  "{\"status\":\"done\",\"updatedAt\":\"$NOW\",\"pr\":{\"number\":200}}"
+write_signal "$D_A/phase-monitor-merge.json" \
+  "{\"status\":\"done\",\"updatedAt\":\"$YESTERDAY\",\"pr\":{\"number\":100,\"mergedAt\":\"$YESTERDAY\",\"ciStatus\":\"merged\"}}"
+
+is_poststale_signal "$D_A" "monitor-merge"
+RC_A=$?
+if [ "$RC_A" -eq 0 ]; then
+  ok "Case A: signal older than phase-pr → STALE (exit 0)"
+else
+  fail "Case A: signal older than phase-pr → STALE (exit 0)" "got exit $RC_A"
+fi
+
+# ─────────────────────────────────────────────────────────────────────────────
+echo ""
+echo "Case B: monitor-merge .pr.number != phase-pr .pr.number (same/newer ts) → STALE"
+D_B="$SCRATCH/case-b"
+write_signal "$D_B/phase-pr.json" \
+  "{\"status\":\"done\",\"updatedAt\":\"$NOW\",\"pr\":{\"number\":200}}"
+write_signal "$D_B/phase-monitor-merge.json" \
+  "{\"status\":\"done\",\"updatedAt\":\"$FUTURE\",\"pr\":{\"number\":100,\"mergedAt\":\"$NOW\",\"ciStatus\":\"merged\"}}"
+
+is_poststale_signal "$D_B" "monitor-merge"
+RC_B=$?
+if [ "$RC_B" -eq 0 ]; then
+  ok "Case B: PR-number mismatch → STALE (exit 0) even if signal is newer"
+else
+  fail "Case B: PR-number mismatch → STALE (exit 0) even if signal is newer" "got exit $RC_B"
+fi
+
+# ─────────────────────────────────────────────────────────────────────────────
+echo ""
+echo "Case C: monitor-merge newer than phase-pr AND same .pr.number → FRESH (exit 1)"
+D_C="$SCRATCH/case-c"
+write_signal "$D_C/phase-pr.json" \
+  "{\"status\":\"done\",\"updatedAt\":\"$YESTERDAY\",\"pr\":{\"number\":200}}"
+write_signal "$D_C/phase-monitor-merge.json" \
+  "{\"status\":\"done\",\"updatedAt\":\"$NOW\",\"pr\":{\"number\":200,\"mergedAt\":\"$NOW\",\"ciStatus\":\"merged\"}}"
+
+is_poststale_signal "$D_C" "monitor-merge"
+RC_C=$?
+if [ "$RC_C" -ne 0 ]; then
+  ok "Case C: same PR# + newer ts → FRESH (exit 1)"
+else
+  fail "Case C: same PR# + newer ts → FRESH (exit 1)" "got exit $RC_C (0=stale)"
+fi
+
+# ─────────────────────────────────────────────────────────────────────────────
+echo ""
+echo "Case D: no phase-pr.json present → FRESH (cannot prove stale)"
+D_D="$SCRATCH/case-d"
+mkdir -p "$D_D"
+write_signal "$D_D/phase-monitor-merge.json" \
+  "{\"status\":\"done\",\"updatedAt\":\"$YESTERDAY\",\"pr\":{\"number\":100}}"
+# no phase-pr.json written
+
+is_poststale_signal "$D_D" "monitor-merge"
+RC_D=$?
+if [ "$RC_D" -ne 0 ]; then
+  ok "Case D: no phase-pr.json → FRESH (exit 1, conservative)"
+else
+  fail "Case D: no phase-pr.json → FRESH (exit 1, conservative)" "got exit $RC_D (0=stale)"
+fi
+
+# ─────────────────────────────────────────────────────────────────────────────
+echo ""
+echo "Case E: non-post-PR phase (implement) → always FRESH (out of scope)"
+D_E="$SCRATCH/case-e"
+write_signal "$D_E/phase-pr.json" \
+  "{\"status\":\"done\",\"updatedAt\":\"$NOW\",\"pr\":{\"number\":200}}"
+write_signal "$D_E/phase-implement.json" \
+  "{\"status\":\"done\",\"updatedAt\":\"$YESTERDAY\"}"
+
+is_poststale_signal "$D_E" "implement"
+RC_E=$?
+if [ "$RC_E" -ne 0 ]; then
+  ok "Case E: non-post-PR phase → FRESH (exit 1)"
+else
+  fail "Case E: non-post-PR phase → FRESH (exit 1)" "got exit $RC_E (0=stale)"
+fi
+
+# ─────────────────────────────────────────────────────────────────────────────
+echo ""
+echo "Case F: malformed/absent timestamps → FRESH (fail-safe)"
+D_F="$SCRATCH/case-f"
+write_signal "$D_F/phase-pr.json" \
+  "{\"status\":\"done\",\"pr\":{\"number\":200}}"
+# no updatedAt in either signal
+write_signal "$D_F/phase-monitor-merge.json" \
+  "{\"status\":\"done\",\"pr\":{\"number\":100}}"
+
+is_poststale_signal "$D_F" "monitor-merge"
+RC_F=$?
+# PR-number mismatch (100 vs 200) IS definitive staleness even with missing timestamps
+if [ "$RC_F" -eq 0 ]; then
+  ok "Case F: PR-number mismatch with missing timestamps → STALE (PR-number check before timestamp check)"
+else
+  fail "Case F: PR-number mismatch with missing timestamps → STALE" "got exit $RC_F"
+fi
+
+# ─────────────────────────────────────────────────────────────────────────────
+echo ""
+echo "Case F2: malformed/absent timestamps, same PR# → FRESH (fail-safe)"
+D_F2="$SCRATCH/case-f2"
+write_signal "$D_F2/phase-pr.json" \
+  "{\"status\":\"done\",\"pr\":{\"number\":200}}"
+write_signal "$D_F2/phase-monitor-merge.json" \
+  "{\"status\":\"done\",\"pr\":{\"number\":200}}"
+# no updatedAt anywhere — cannot determine ordering
+
+is_poststale_signal "$D_F2" "monitor-merge"
+RC_F2=$?
+if [ "$RC_F2" -ne 0 ]; then
+  ok "Case F2: same PR# + missing timestamps → FRESH (exit 1, fail-safe)"
+else
+  fail "Case F2: same PR# + missing timestamps → FRESH (exit 1, fail-safe)" "got exit $RC_F2 (0=stale)"
+fi
+
+# ─────────────────────────────────────────────────────────────────────────────
+echo ""
+echo "Case G: teardown signal stale → STALE (all three post-PR phases covered)"
+D_G="$SCRATCH/case-g"
+write_signal "$D_G/phase-pr.json" \
+  "{\"status\":\"done\",\"updatedAt\":\"$NOW\",\"pr\":{\"number\":200}}"
+write_signal "$D_G/phase-teardown.json" \
+  "{\"status\":\"done\",\"updatedAt\":\"$YESTERDAY\"}"
+
+is_poststale_signal "$D_G" "teardown"
+RC_G=$?
+if [ "$RC_G" -eq 0 ]; then
+  ok "Case G: stale teardown signal → STALE (exit 0)"
+else
+  fail "Case G: stale teardown signal → STALE (exit 0)" "got exit $RC_G"
+fi
+
+# ─────────────────────────────────────────────────────────────────────────────
+echo ""
+echo "Case H: monitor-deploy signal stale → STALE"
+D_H="$SCRATCH/case-h"
+write_signal "$D_H/phase-pr.json" \
+  "{\"status\":\"done\",\"updatedAt\":\"$NOW\",\"pr\":{\"number\":200}}"
+write_signal "$D_H/phase-monitor-deploy.json" \
+  "{\"status\":\"done\",\"updatedAt\":\"$YESTERDAY\"}"
+
+is_poststale_signal "$D_H" "monitor-deploy"
+RC_H=$?
+if [ "$RC_H" -eq 0 ]; then
+  ok "Case H: stale monitor-deploy signal → STALE (exit 0)"
+else
+  fail "Case H: stale monitor-deploy signal → STALE (exit 0)" "got exit $RC_H"
+fi
+
+# ─────────────────────────────────────────────────────────────────────────────
+echo ""
+echo "─── Results ───────────────────────────────────────────────"
+echo "PASS: $PASS  FAIL: $FAIL"
+if [ "$FAIL" -gt 0 ]; then
+  exit 1
+fi
+exit 0

--- a/plugins/dev/scripts/lib/phase-signal-freshness.sh
+++ b/plugins/dev/scripts/lib/phase-signal-freshness.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# phase-signal-freshness.sh — detect a post-PR phase signal left over from a
+# previous pipeline run (CTL-1667). A post-PR signal is STALE-for-this-run when
+# it names a different PR number than the current run's phase-pr.json, or predates
+# that phase-pr.json's timestamp. Only the three phases that run after the PR is
+# opened are in scope; all others are always "fresh" (out of scope for this guard).
+
+POST_PR_PHASES=(monitor-merge monitor-deploy teardown)
+
+# _iso_epoch — convert an ISO-8601 UTC string to epoch seconds.
+# Supports BSD date (macOS -j -f) and GNU date (-d). Returns empty on failure.
+_iso_epoch() {
+  local ts="$1"
+  [[ -z "$ts" ]] && { printf ''; return; }
+  date -u -j -f "%Y-%m-%dT%H:%M:%SZ" "$ts" +%s 2>/dev/null \
+    || date -u -d "$ts" +%s 2>/dev/null \
+    || printf ''
+}
+
+# is_poststale_signal WORKER_DIR PHASE
+#   → exit 0  if the signal is STALE for the current run (safe to re-launch)
+#   → exit 1  if the signal is FRESH / the answer is unknown (do not re-launch)
+#
+# Conservative: any ambiguity (missing file, unresolvable timestamp, no phase-pr)
+# returns FRESH (exit 1) — we never re-launch spuriously due to a data gap.
+is_poststale_signal() {
+  local dir="$1" phase="$2"
+
+  # Out of scope — only post-PR phases are checked.
+  local p is_post=1
+  for p in "${POST_PR_PHASES[@]}"; do
+    [[ "$p" == "$phase" ]] && is_post=0
+  done
+  [[ $is_post -eq 0 ]] || return 1   # not a post-PR phase → fresh
+
+  local sig="${dir}/phase-${phase}.json"
+  local pr="${dir}/phase-pr.json"
+
+  # If either file is absent we cannot prove staleness — conservative fresh.
+  [[ -f "$sig" && -f "$pr" ]] || return 1
+
+  local sig_pr cur_pr
+  sig_pr="$(jq -r '.pr.number // empty' "$sig" 2>/dev/null)"
+  cur_pr="$(jq -r '.pr.number // empty' "$pr"  2>/dev/null)"
+
+  # PR-number mismatch is definitive staleness — takes precedence over timestamps
+  # (a newer signal with an old PR# is absolutely from the prior run).
+  if [[ -n "$sig_pr" && -n "$cur_pr" && "$sig_pr" != "$cur_pr" ]]; then
+    return 0  # STALE
+  fi
+
+  # Timestamp ordering: signal must be older than the current run's PR opener.
+  local sig_ts pr_ts
+  sig_ts="$(jq -r '.updatedAt // .startedAt // empty' "$sig" 2>/dev/null)"
+  pr_ts="$(jq -r '.updatedAt // .startedAt // empty' "$pr"  2>/dev/null)"
+
+  local se pe
+  se="$(_iso_epoch "$sig_ts")"
+  pe="$(_iso_epoch "$pr_ts")"
+
+  # Unresolvable timestamps — fail-safe: cannot prove stale → fresh.
+  [[ -n "$se" && -n "$pe" ]] || return 1
+
+  [[ "$se" -lt "$pe" ]] && return 0  # signal predates current run's PR → STALE
+
+  return 1  # fresh
+}

--- a/plugins/dev/scripts/phase-agent-dispatch
+++ b/plugins/dev/scripts/phase-agent-dispatch
@@ -577,9 +577,11 @@ fi
 # {dispatched,running,done}: it skips the idempotency short-circuit below and,
 # being non-empty, takes the `EXISTING_GENERATION + 1` branch — the same rail a
 # stalled/failed revive already rides.
+POSTSTALE_SIGNAL=0
 if [[ -n "$EXISTING_STATUS" ]] \
    && is_poststale_signal "$WORKER_DIR" "$PHASE"; then
 	EXISTING_STATUS="poststale"   # revive path: overwrite + launch at generation+1
+	POSTSTALE_SIGNAL=1            # prior-run tombstone → its leftover claim is reapable (CTL-1667, Codex P1 #3061)
 fi
 
 if [[ $EXISTING_STATUS == "dispatched" || $EXISTING_STATUS == "running" || $EXISTING_STATUS == "done" ]]; then
@@ -704,6 +706,23 @@ if [[ $DRY_RUN -eq 0 ]]; then
 			else
 				CUR_SIG_GEN=$(jq -r '.generation // empty' "$SIGNAL_FILE" 2>/dev/null || echo "")
 				if [[ $CUR_SIG_GEN =~ ^[0-9]+$ ]] && ((CUR_SIG_GEN < TARGET_GENERATION)); then
+					SIG_IS_STALE=1
+				elif [[ ${POSTSTALE_SIGNAL:-0} -eq 1 ]]; then
+					# CTL-1667 (Codex P1, #3061): a poststale post-PR signal is a
+					# prior-run tombstone — is_poststale_signal already proved it
+					# (different PR# or older than the current run's phase-pr.json).
+					# Its result-branch rewrite often DROPS a numeric .generation
+					# (phase-monitor-deploy/-merge compose the file with `jq -nc`
+					# and no generation field), so CUR_SIG_GEN is empty and the
+					# numeric `< TARGET` test above cannot recognize it. Without
+					# this, the leftover <phase>.claim.<gen> from the prior run
+					# wedges every re-dispatch as claim-lost and the fresh post-PR
+					# worker never launches. Mark it stale so the age-guarded ATOMIC
+					# reaper below frees the orphan claim. TARGET_GENERATION stays
+					# deterministic (never the claim-file high-water mark), so the
+					# CTL-736 single-flight invariant holds: concurrent racers all
+					# compute the same target and exactly one wins the O_EXCL
+					# re-create; the losers bow out claim-lost as before.
 					SIG_IS_STALE=1
 				fi
 			fi

--- a/plugins/dev/scripts/phase-agent-dispatch
+++ b/plugins/dev/scripts/phase-agent-dispatch
@@ -90,6 +90,8 @@ source "${SCRIPT_DIR}/lib/ctl708-resolve.sh"
 ctl708_wire_resolver
 # shellcheck source=lib/phase-artifact-gate.sh
 source "${SCRIPT_DIR}/lib/phase-artifact-gate.sh"
+# shellcheck source=lib/phase-signal-freshness.sh
+source "${SCRIPT_DIR}/lib/phase-signal-freshness.sh"
 
 # _removal_guard_ok <path> — the single fail-closed predicate the recreate
 # `git worktree remove --force` site gates on (CTL-1417). Returns 0 (safe to
@@ -551,6 +553,18 @@ EXISTING_GENERATION=""
 if [[ -f $SIGNAL_FILE ]]; then
 	EXISTING_STATUS=$(jq -r '.status // empty' "$SIGNAL_FILE" 2>/dev/null || echo "")
 	EXISTING_GENERATION=$(jq -r '.generation // empty' "$SIGNAL_FILE" 2>/dev/null || echo "")
+fi
+
+# CTL-1667: a post-PR signal left over from a previous pipeline run must NOT
+# short-circuit the current run — invalidate it so a fresh worker launches.
+# is_poststale_signal returns 0 (stale) only for the three phases that run after
+# the PR is opened (monitor-merge, monitor-deploy, teardown); all others are
+# always fresh (the predicate returns 1). Conservative: any ambiguity (missing
+# phase-pr.json, unresolvable timestamps) leaves EXISTING_STATUS unchanged so
+# the existing idempotency guard continues to protect against double-dispatch.
+if [[ -n "$EXISTING_STATUS" ]] \
+   && is_poststale_signal "$WORKER_DIR" "$PHASE"; then
+	EXISTING_STATUS=""   # fall through to the fresh-dispatch path (overwrite + launch)
 fi
 
 if [[ $EXISTING_STATUS == "dispatched" || $EXISTING_STATUS == "running" || $EXISTING_STATUS == "done" ]]; then

--- a/plugins/dev/scripts/phase-agent-dispatch
+++ b/plugins/dev/scripts/phase-agent-dispatch
@@ -636,36 +636,28 @@ fi
 # The claim-file FORMAT is kept in sync with execution-core/claim.mjs
 # claimPath(): ${WORKER_DIR}/<phase>.claim.<generation>.
 #
-# CTL-1667 (review fix, round 4, #3061): recover the prior generation from
-# on-disk claim files when the signal itself carries no numeric .generation.
-# The post-PR result-branch rewrites (monitor-merge/monitor-deploy/teardown)
-# compose the signal with `jq -nc` and can drop the field (this is the same
-# class of gap the earlier missing-generation fix closed for the
-# poststale-signal case specifically — this recovers it generally, for ANY
-# revive whose signal lacks .generation). Defaulting to 0 (→ TARGET_GENERATION
-# 1) in that case REUSES a generation the worker dir may already have live: if
-# the prior run had already revived to generation 2+, a delayed generation-1
-# (or -2) worker from that run can still complete later and, because
-# phase-agent-emit-complete's fence (`mine < signal` bows out) does NOT fire
-# on an EQUAL generation, its stale result can overwrite the current run's
-# fresh signal. The claim body's OWN .generation is always numeric — a claim
-# file is never subject to the JSON-rewrite drop — so scanning
-# ${PHASE}.claim.<N> for the highest N ever actually claimed for this phase
-# and recovering EXISTING_GENERATION from it guarantees TARGET_GENERATION
-# strictly advances past every claim this worker dir has made, never recycles
-# one.
-if [[ -n $EXISTING_STATUS && -z $EXISTING_GENERATION ]]; then
-	MAX_CLAIM_GEN=0
-	for _cf in "${WORKER_DIR}/${PHASE}.claim."*; do
-		[[ -f "$_cf" ]] || continue
-		_cg="${_cf##*.claim.}"
-		[[ $_cg =~ ^[0-9]+$ ]] || continue
-		((_cg > MAX_CLAIM_GEN)) && MAX_CLAIM_GEN="$_cg"
-	done
-	((MAX_CLAIM_GEN > 0)) && EXISTING_GENERATION="$MAX_CLAIM_GEN"
-	unset _cf _cg
-fi
-
+# CTL-1667 (review fix, round 5, #3061): a previous round recovered the prior
+# generation here by scanning ${PHASE}.claim.<N> for the highest N on disk when
+# the signal carried no numeric .generation. That has been REMOVED — it derived
+# TARGET_GENERATION from the live claim set, which is precisely what the CTL-736
+# invariant above forbids, and it reintroduced the double-spawn that invariant
+# exists to close: two redispatches racing on a generation-less signal see each
+# OTHER's claim, compute DIFFERENT targets (A: max 2 → 3, then B: max 3 → 4),
+# and each wins its own O_EXCL file, so both spawn a worker and both can run the
+# post-PR side effects. The claim set is mutated by this very computation, so it
+# can never be a stable input to it. (The CTL-837 orphan-GC below depends on the
+# same determinism: it reaps a pre-spawn orphan only because "every later fresh
+# dispatch recomputes the SAME generation".)
+#
+# The gap that scan was patching is fixed at its SOURCE instead: phase-monitor-deploy
+# — the only phase that recomposes its signal from scratch with `jq -nc`, and so
+# the only one that could drop the field — now threads the dispatcher-stamped
+# generation through all three of its result branches (_MD_GEN, phase-monitor-deploy
+# SKILL.md). phase-monitor-merge and phase-teardown never recompose the signal that
+# way, so nothing else drops it. A signal that still carries no .generation is one
+# the dispatcher never stamped (the un-fenced degraded path), where no generation
+# was ever established and the deterministic default of 0 → TARGET_GENERATION 1 is
+# the correct answer rather than a recycled one.
 # --dry-run NEVER claims (a preview must be side-effect-free): it computes the
 # would-be generation without creating the claim file.
 if [[ -z $EXISTING_STATUS ]]; then

--- a/plugins/dev/scripts/phase-agent-dispatch
+++ b/plugins/dev/scripts/phase-agent-dispatch
@@ -562,9 +562,24 @@ fi
 # always fresh (the predicate returns 1). Conservative: any ambiguity (missing
 # phase-pr.json, unresolvable timestamps) leaves EXISTING_STATUS unchanged so
 # the existing idempotency guard continues to protect against double-dispatch.
+#
+# CTL-1667 (review fix): route the invalidated signal to the REVIVE path
+# (TARGET_GENERATION = EXISTING_GENERATION + 1), NOT the fresh path (generation
+# 1). The stale signal came from a prior run whose matching
+# <phase>.claim.<generation> file is ALSO still on disk. Clearing EXISTING_STATUS
+# to "" would recompute a gen-1 claim, collide with that leftover claim
+# (O_EXCL EEXIST), and — because the on-disk signal is already AT gen 1 — the
+# orphan reaper would NOT reap it, so the dispatcher would bow out `claim-lost`
+# and never launch the fresh post-PR worker (the guard would not actually repair
+# the production stale-signal case). A non-idempotent sentinel instead keeps
+# EXISTING_GENERATION intact so the generation ADVANCES past the leftover claim
+# and the fresh worker genuinely launches. The sentinel is any value outside
+# {dispatched,running,done}: it skips the idempotency short-circuit below and,
+# being non-empty, takes the `EXISTING_GENERATION + 1` branch — the same rail a
+# stalled/failed revive already rides.
 if [[ -n "$EXISTING_STATUS" ]] \
    && is_poststale_signal "$WORKER_DIR" "$PHASE"; then
-	EXISTING_STATUS=""   # fall through to the fresh-dispatch path (overwrite + launch)
+	EXISTING_STATUS="poststale"   # revive path: overwrite + launch at generation+1
 fi
 
 if [[ $EXISTING_STATUS == "dispatched" || $EXISTING_STATUS == "running" || $EXISTING_STATUS == "done" ]]; then

--- a/plugins/dev/scripts/phase-agent-dispatch
+++ b/plugins/dev/scripts/phase-agent-dispatch
@@ -636,13 +636,46 @@ fi
 # The claim-file FORMAT is kept in sync with execution-core/claim.mjs
 # claimPath(): ${WORKER_DIR}/<phase>.claim.<generation>.
 #
+# CTL-1667 (review fix, round 4, #3061): recover the prior generation from
+# on-disk claim files when the signal itself carries no numeric .generation.
+# The post-PR result-branch rewrites (monitor-merge/monitor-deploy/teardown)
+# compose the signal with `jq -nc` and can drop the field (this is the same
+# class of gap the earlier missing-generation fix closed for the
+# poststale-signal case specifically — this recovers it generally, for ANY
+# revive whose signal lacks .generation). Defaulting to 0 (→ TARGET_GENERATION
+# 1) in that case REUSES a generation the worker dir may already have live: if
+# the prior run had already revived to generation 2+, a delayed generation-1
+# (or -2) worker from that run can still complete later and, because
+# phase-agent-emit-complete's fence (`mine < signal` bows out) does NOT fire
+# on an EQUAL generation, its stale result can overwrite the current run's
+# fresh signal. The claim body's OWN .generation is always numeric — a claim
+# file is never subject to the JSON-rewrite drop — so scanning
+# ${PHASE}.claim.<N> for the highest N ever actually claimed for this phase
+# and recovering EXISTING_GENERATION from it guarantees TARGET_GENERATION
+# strictly advances past every claim this worker dir has made, never recycles
+# one.
+if [[ -n $EXISTING_STATUS && -z $EXISTING_GENERATION ]]; then
+	MAX_CLAIM_GEN=0
+	for _cf in "${WORKER_DIR}/${PHASE}.claim."*; do
+		[[ -f "$_cf" ]] || continue
+		_cg="${_cf##*.claim.}"
+		[[ $_cg =~ ^[0-9]+$ ]] || continue
+		((_cg > MAX_CLAIM_GEN)) && MAX_CLAIM_GEN="$_cg"
+	done
+	((MAX_CLAIM_GEN > 0)) && EXISTING_GENERATION="$MAX_CLAIM_GEN"
+	unset _cf _cg
+fi
+
 # --dry-run NEVER claims (a preview must be side-effect-free): it computes the
 # would-be generation without creating the claim file.
 if [[ -z $EXISTING_STATUS ]]; then
 	TARGET_GENERATION=1
 else
 	# Any non-(dispatched|running|done) signal that reached here is a revive or
-	# retry (stalled, failed, refused, …) → claim the next generation.
+	# retry (stalled, failed, refused, …) → claim the next generation. (Or, per
+	# the recovery block above, one past the highest generation this phase has
+	# ever actually claimed on disk, when the signal's own .generation was
+	# unreadable.)
 	TARGET_GENERATION=$((${EXISTING_GENERATION:-0} + 1))
 fi
 GENERATION="$TARGET_GENERATION"

--- a/plugins/dev/skills/phase-monitor-deploy/SKILL.md
+++ b/plugins/dev/skills/phase-monitor-deploy/SKILL.md
@@ -104,6 +104,14 @@ WORKER_DIR="${WORKER_DIR:-${ORCH_DIR:+${ORCH_DIR}/workers/${TICKET}}}"
 WORKER_DIR="${WORKER_DIR:-$(pwd)}"
 mkdir -p "$WORKER_DIR"
 
+# CTL-1667 (Codex P1, #3061): capture the dispatcher-stamped generation so the
+# result-branch rewrites below PRESERVE it. Each branch recomposes
+# phase-monitor-deploy.json from scratch with `jq -nc`; without carrying the
+# generation forward the completed signal loses .generation, and a later post-PR
+# re-dispatch (next run) reading it back computes a colliding revive target that
+# wedges as claim-lost. Empty when the dispatcher wrote none (un-fenced path).
+_MD_GEN="$(jq -r '.generation // empty' "$WORKER_DIR/phase-monitor-deploy.json" 2>/dev/null || echo "")"
+
 DEPLOY_TIMEOUT="${PHASE_DEPLOY_TIMEOUT_SEC:-1800}"
 DEPLOY_ENV="${PHASE_DEPLOY_ENV:-production}"
 CANARY_CMD="${PHASE_CANARY_CMD:-claude --model haiku -p /canary --output-format json}"
@@ -168,8 +176,10 @@ if [[ -z "$DEPLOY_EVENT" ]]; then
     --arg sha "$MERGE_SHA" \
     --arg env "$DEPLOY_ENV" \
     --arg ts "$DEPLOY_TIME" \
+    --arg gen "$_MD_GEN" \
     '{
       ticket: $ticket,
+      generation: (if $gen == "" then null else ($gen | tonumber) end),
       deploy_sha: $sha,
       deploy_env: $env,
       deploy_state: "skipped",
@@ -214,8 +224,10 @@ case "$DEPLOY_STATE" in
       --arg env "$DEPLOY_ENV" \
       --arg state "$DEPLOY_STATE" \
       --arg ts "$DEPLOY_TIME" \
+      --arg gen "$_MD_GEN" \
       '{
         ticket: $ticket,
+        generation: (if $gen == "" then null else ($gen | tonumber) end),
         deploy_sha: $sha,
         deploy_env: $env,
         deploy_state: $state,
@@ -266,10 +278,12 @@ jq -nc \
   --arg sha "$MERGE_SHA" \
   --arg env "$DEPLOY_ENV" \
   --arg ts "$DEPLOY_TIME" \
+  --arg gen "$_MD_GEN" \
   --arg url "$DEPLOY_URL" \
   --slurpfile canary "$CANARY_OUT_FILE" \
   '{
     ticket: $ticket,
+    generation: (if $gen == "" then null else ($gen | tonumber) end),
     deploy_sha: $sha,
     deploy_env: $env,
     deploy_state: "success",

--- a/plugins/dev/skills/phase-teardown/SKILL.md
+++ b/plugins/dev/skills/phase-teardown/SKILL.md
@@ -122,12 +122,17 @@ PR_FILE="$WORKER_DIR/phase-pr.json"
 CUR_PR="$(jq -r '.pr.number // empty' "$PR_FILE" 2>/dev/null)"
 MERGE_PR="$(jq -r '.pr.number // empty' "$MERGE_FILE" 2>/dev/null)"
 
-# Resolve the PR number to verify: prefer the current run's phase-pr.json;
-# fall back to the merge signal only when phase-pr.json is absent.
-VERIFY_PR="${CUR_PR:-$MERGE_PR}"
+# Fail CLOSED when the current run's PR artifact is unavailable. phase-pr.json is
+# the ONLY signal that identifies THIS run's PR, and teardown DISPATCH requires
+# only phase-monitor-deploy.json — so a retained signal set from a PRIOR run (a
+# stale phase-monitor-merge.json whose PR GitHub still reports merged) could
+# otherwise reach this gate and mark the ticket Done + destroy the current
+# worktree WITHOUT ever identifying the current run's PR. Do NOT fall back to the
+# merge signal's PR number; require phase-pr.json (Codex P1, #3061).
+VERIFY_PR="$CUR_PR"
 if [[ -z "$VERIFY_PR" ]]; then
   "$__TD_WRAPPER" --phase teardown --ticket "$TICKET" --status failed \
-    --reason "pr_not_merged:no_pr_number" \
+    --reason "pr_not_merged:phase_pr_artifact_missing" \
     ${ORCH_ID:+--orch-id "$ORCH_ID"} ${ORCH_DIR:+--orch-dir "$ORCH_DIR"} \
     || echo "phase-teardown: CRITICAL — phase-agent-emit-complete failed; no terminal teardown event landed" >&2
   exit 1

--- a/plugins/dev/skills/phase-teardown/SKILL.md
+++ b/plugins/dev/skills/phase-teardown/SKILL.md
@@ -140,9 +140,17 @@ fi
 
 # Identity: the merge signal must be for the current run's PR.
 # A prior run's merged PR in phase-monitor-merge.json must not satisfy this gate.
-if [[ -n "$CUR_PR" && -n "$MERGE_PR" && "$CUR_PR" != "$MERGE_PR" ]]; then
+# CTL-1667 (review fix, round 3, #3061): require MERGE_PR itself to be present,
+# not just matching when both happen to resolve. phase-monitor-merge.json is
+# REQUIRED to exist above (prior_artifact_missing:monitor_merge), but an EMPTY,
+# malformed, or legacy-shaped merge artifact (no `.pr.number`) previously
+# skipped this whole identity check entirely (the `-n "$MERGE_PR"` conjunct was
+# false), letting a stale/malformed merge artifact authorize Done on the
+# current PR's live-merged state without ever proving monitor-merge actually
+# ran for THIS run's PR.
+if [[ -n "$CUR_PR" && ( -z "$MERGE_PR" || "$CUR_PR" != "$MERGE_PR" ) ]]; then
   "$__TD_WRAPPER" --phase teardown --ticket "$TICKET" --status failed \
-    --reason "pr_not_merged:stale_merge_signal(pr=${MERGE_PR},cur=${CUR_PR})" \
+    --reason "pr_not_merged:stale_merge_signal(pr=${MERGE_PR:-<empty>},cur=${CUR_PR})" \
     ${ORCH_ID:+--orch-id "$ORCH_ID"} ${ORCH_DIR:+--orch-dir "$ORCH_DIR"} \
     || echo "phase-teardown: CRITICAL — phase-agent-emit-complete failed; no terminal teardown event landed" >&2
   exit 1

--- a/plugins/dev/skills/phase-teardown/SKILL.md
+++ b/plugins/dev/skills/phase-teardown/SKILL.md
@@ -117,12 +117,41 @@ if [[ ! -f "$MERGE_FILE" ]]; then
   exit 1
 fi
 
-MERGE_CI_STATUS="$(jq -r '.pr.ciStatus // empty' "$MERGE_FILE" 2>/dev/null)"
-MERGED_AT="$(jq -r '.pr.mergedAt // empty' "$MERGE_FILE" 2>/dev/null)"
+# --- CTL-1667: Done requires the CURRENT run's PR to be MERGED on GitHub ---
+PR_FILE="$WORKER_DIR/phase-pr.json"
+CUR_PR="$(jq -r '.pr.number // empty' "$PR_FILE" 2>/dev/null)"
+MERGE_PR="$(jq -r '.pr.number // empty' "$MERGE_FILE" 2>/dev/null)"
 
-if [[ "$MERGE_CI_STATUS" != "merged" && -z "$MERGED_AT" ]]; then
+# Resolve the PR number to verify: prefer the current run's phase-pr.json;
+# fall back to the merge signal only when phase-pr.json is absent.
+VERIFY_PR="${CUR_PR:-$MERGE_PR}"
+if [[ -z "$VERIFY_PR" ]]; then
   "$__TD_WRAPPER" --phase teardown --ticket "$TICKET" --status failed \
-    --reason "pr_not_merged" \
+    --reason "pr_not_merged:no_pr_number" \
+    ${ORCH_ID:+--orch-id "$ORCH_ID"} ${ORCH_DIR:+--orch-dir "$ORCH_DIR"} \
+    || echo "phase-teardown: CRITICAL — phase-agent-emit-complete failed; no terminal teardown event landed" >&2
+  exit 1
+fi
+
+# Identity: the merge signal must be for the current run's PR.
+# A prior run's merged PR in phase-monitor-merge.json must not satisfy this gate.
+if [[ -n "$CUR_PR" && -n "$MERGE_PR" && "$CUR_PR" != "$MERGE_PR" ]]; then
+  "$__TD_WRAPPER" --phase teardown --ticket "$TICKET" --status failed \
+    --reason "pr_not_merged:stale_merge_signal(pr=${MERGE_PR},cur=${CUR_PR})" \
+    ${ORCH_ID:+--orch-id "$ORCH_ID"} ${ORCH_DIR:+--orch-dir "$ORCH_DIR"} \
+    || echo "phase-teardown: CRITICAL — phase-agent-emit-complete failed; no terminal teardown event landed" >&2
+  exit 1
+fi
+
+# Live truth: is $VERIFY_PR actually MERGED on GitHub?
+# CATALYST_TEARDOWN_GH_BIN is injectable for tests (mirrors CATALYST_AUTO_REBASE_GH_BIN).
+GH_BIN="${CATALYST_TEARDOWN_GH_BIN:-gh}"
+PR_STATE="$("$GH_BIN" pr view "$VERIFY_PR" --json state,mergedAt 2>/dev/null || true)"
+MERGED_STATE="$(printf '%s' "$PR_STATE" | jq -r '.state // empty' 2>/dev/null)"
+MERGED_AT_LIVE="$(printf '%s' "$PR_STATE" | jq -r '.mergedAt // empty' 2>/dev/null)"
+if [[ "$MERGED_STATE" != "MERGED" && -z "$MERGED_AT_LIVE" ]]; then
+  "$__TD_WRAPPER" --phase teardown --ticket "$TICKET" --status failed \
+    --reason "pr_not_merged:pr#${VERIFY_PR}_state=${MERGED_STATE:-unknown}" \
     ${ORCH_ID:+--orch-id "$ORCH_ID"} ${ORCH_DIR:+--orch-dir "$ORCH_DIR"} \
     || echo "phase-teardown: CRITICAL — phase-agent-emit-complete failed; no terminal teardown event landed" >&2
   exit 1


### PR DESCRIPTION
<!-- Auto-generated: 2026-08-07T05:21:00Z -->
<!-- Last updated: 2026-08-07T05:21:00Z -->
<!-- PR: #3061 -->
<!-- Previous commits: 680e4f7ad9db3c071552eb429bf12d9db7031f3a,be679fa57c8383768356dfd1cd9041728cb56cdf,cd0f6d2549303fd342c9ed0a3e1fcf76a88c1a78 -->

## Summary

Defense-in-depth against the false-Done / false-advance incident family (CTL-1667). Three independent changes close the three distinct paths by which the orchestrator could advance a ticket to Done before its current PR actually merged.

- **Phase A (dispatch freshness guard)**: `phase-signal-freshness.sh` + `phase-agent-dispatch` — post-PR phase signals (monitor-merge, monitor-deploy, teardown) from a previous pipeline run can no longer idempotently short-circuit fresh dispatch. Detects staleness via PR-number mismatch or timestamp ordering vs `phase-pr.json`. Fail-safe: falls back to FRESH when files are absent or timestamps unresolvable.
- **Phase B (teardown SKILL gate)**: `phase-teardown/SKILL.md` — replaces the disk-field `mergedAt` check with a three-step live-GitHub gate: (1) read current PR number from `phase-pr.json`, (2) detect PR-number mismatch with the monitor-merge signal, (3) confirm MERGED via `gh pr view`. Fail-closed on `gh` errors. Injectable `CATALYST_TEARDOWN_GH_BIN` seam for hermetic testing, consistent with `CATALYST_AUTO_REBASE_GH_BIN`.
- **Phase C (scheduler terminal sweep)**: `scheduler.mjs terminalDoneOnce` — mirrors the existing `reconcileTerminalBackstop` GATE 2 (`prAdapter.prView`) pattern into the primary Done writer. Adds `readCurrentRunPrNumber` export. Threads `prAdapter` from `schedulerTick` opts consistently to both Done-writing callers so both gates share one prAdapter instance.

## Changes Made

### New files

- `plugins/dev/scripts/lib/phase-signal-freshness.sh` (67 lines) — pure-bash predicate `is_poststale_signal WORKER_DIR PHASE`. Returns 0 (stale) when the signal's `.pr.number` differs from `phase-pr.json` or its timestamp predates `phase-pr.json`. Fail-safe to FRESH on absent/unresolvable inputs.
- `plugins/dev/scripts/lib/__tests__/phase-signal-freshness.test.sh` (213 lines) — 9 unit cases: STALE via PR mismatch, STALE via old timestamp, FRESH on matching PR, FRESH on absent signal, FRESH on absent phase-pr.json, FRESH across all three post-PR phase names, edge case (same PR same timestamp → FRESH).

### Modified files

- `plugins/dev/scripts/phase-agent-dispatch` (+14 lines) — wires `is_poststale_signal` before the idempotent short-circuit for post-PR phases. A stale signal causes re-launch instead of skip.
- `plugins/dev/scripts/__tests__/phase-agent-dispatch.test.sh` (+55 lines) — Tests 71–72: stale-signal re-launch and idempotent-fresh integration cases.
- `plugins/dev/skills/phase-teardown/SKILL.md` (+33 / -4 lines) — three-step live-GitHub merged gate replaces disk-field check. `CATALYST_TEARDOWN_GH_BIN` injectable seam documented inline.
- `plugins/dev/scripts/__tests__/phase-teardown-e2e.test.sh` (+209 / -2 lines) — 4 new B-cases: B1 happy-path (merged), B2 stale merge signal (different PR#), B3 gh-says-OPEN, B4 gh-errors.
- `plugins/dev/scripts/execution-core/scheduler.mjs` (+37 lines) — `terminalDoneOnce` gains current-PR-merged gate; `readCurrentRunPrNumber` new export; `prAdapter` threaded through `schedulerTick` opts to both Done-writing callers.
- `plugins/dev/scripts/execution-core/scheduler.test.mjs` (+89 lines) — 6 new tests: gate skipped (no phase-pr.json), gate skipped (no PR number), gate skipped (no prAdapter), OPEN PR defers Done, MERGED PR allows Done, prView throws defers Done.

## How to Verify It

- [x] `bash plugins/dev/scripts/lib/__tests__/phase-signal-freshness.test.sh` — 9/9 pass ✅
- [x] `bash plugins/dev/scripts/__tests__/phase-agent-dispatch.test.sh` — Tests 71–72 pass; Test 38 pre-existing failure confirmed on origin/main baseline ✅
- [x] `bash plugins/dev/scripts/__tests__/phase-teardown-e2e.test.sh` — 38/38 pass (4 new B-cases) ✅
- [x] `bun test plugins/dev/scripts/execution-core/scheduler.test.mjs` — 6 new CTL-1667 tests pass; 9 pre-existing flaky failures confirmed on origin/main baseline (scheduler-test-mjs-flaky-order-env) ✅
- [x] All 13 CI checks green ✅

## Changelog Entry

`feat(dev): CTL-1667 — three-layer guard against premature Done / false-advance (dispatch freshness gate + teardown live-GitHub MERGED check + scheduler terminalDoneOnce PR-merged gate)`

## Related Issues/PRs

- Fixes https://linear.app/rozich/issue/CTL-1667/orchestrator-should-mark-a-ticket-done-only-once-its-pr-actually