### PR TITLE
feat(dev): CTL-1494 — wire coordination-publish into catalyst-stack lifecycle

### DIFF
--- a/plugins/dev/scripts/__tests__/catalyst-stack-coordination.test.sh
+++ b/plugins/dev/scripts/__tests__/catalyst-stack-coordination.test.sh
@@ -175,29 +175,44 @@ OUT_ST="$(PATH="${STUB_OFF}:${PATH}" CATALYST_DIR="$CDIR_ST" \
     start_coordination; echo "RC=$?"
     [[ -d "$COORDINATION_LOCK" ]] && echo "LOCK_KEPT" || echo "LOCK_REMOVED"
   ' 2>&1)"
-if grep -qi 'reclaimed an abandoned start lock' <<<"$OUT_ST"; then pass "stale-lock: reclaims an empty crashed start lock"; else failx "stale-lock: reclaims an empty crashed start lock" "$OUT_ST"; fi
+if grep -qi 'reclaimed an abandoned (empty) start lock' <<<"$OUT_ST"; then pass "stale-lock: reclaims an empty crashed start lock"; else failx "stale-lock: reclaims an empty crashed start lock" "$OUT_ST"; fi
 if grep -q 'RC=0' <<<"$OUT_ST"; then pass "stale-lock: proceeds after reclaim (rc 0)"; else failx "stale-lock: proceeds after reclaim (rc 0)" "$OUT_ST"; fi
 if grep -q 'LOCK_REMOVED' <<<"$OUT_ST"; then pass "stale-lock: releases the lock it acquired"; else failx "stale-lock: releases the lock it acquired" "$OUT_ST"; fi
 
-# --- sentinel safety (THE double-spawn-prevention invariant): a NON-EMPTY stale
-#     lock (a live holder's sentinel-bearing lock, or a crash-after-sentinel leak)
-#     is NEVER force-removed, even when older than the threshold — rmdir refuses a
-#     non-empty dir. This is what makes mkdir the sole arbiter of ownership, so a
-#     reclaimer can never delete a live peer's lock and let both spawn (Codex P1). ---
-CDIR_SN="${SCRATCH}/catalyst-sentinel"; mkdir -p "$CDIR_SN"
-OUT_SN="$(PATH="${STUB_OFF}:${PATH}" CATALYST_DIR="$CDIR_SN" \
+# --- live-owner lock: an OLD lock whose sentinel owner is still ALIVE is a live
+#     peer (never force-removed) ⇒ skip. Guards mkdir as the sole ownership arbiter
+#     so a reclaimer can't delete a live peer's lock and let both spawn (Codex P1). ---
+CDIR_LO="${SCRATCH}/catalyst-liveowner"; mkdir -p "$CDIR_LO"
+OUT_LO="$(PATH="${STUB_OFF}:${PATH}" CATALYST_DIR="$CDIR_LO" \
   bash --noprofile --norc -c '
     source "'"${STACK}"'" 2>/dev/null || true
     mkdir -p "$COORDINATION_LOCK"
-    : > "$COORDINATION_LOCK/owner"                # sentinel present (live-lock shape)
-    touch -t 202001010000 "$COORDINATION_LOCK"   # …and OLD (age gate would pass)
+    printf "%s" "$$" > "$COORDINATION_LOCK/owner"   # owner = THIS shell (alive)
+    touch -t 202001010000 "$COORDINATION_LOCK"      # OLD (age gate passes)
     start_coordination; echo "RC=$?"
     [[ -d "$COORDINATION_LOCK" ]] && echo "LOCK_KEPT" || echo "LOCK_REMOVED"
     [[ -f "$COORDINATION_PID" ]] && echo "PIDFILE_PRESENT" || echo "PIDFILE_GONE"
   ' 2>&1)"
-if grep -q 'RC=0' <<<"$OUT_SN"; then pass "sentinel-safety: non-empty stale lock ⇒ returns 0 (skips)"; else failx "sentinel-safety: non-empty stale lock ⇒ returns 0" "$OUT_SN"; fi
-if grep -q 'LOCK_KEPT' <<<"$OUT_SN"; then pass "sentinel-safety: never force-removes a sentinel-bearing lock"; else failx "sentinel-safety: never force-removes a sentinel-bearing lock" "$OUT_SN"; fi
-if grep -q 'PIDFILE_GONE' <<<"$OUT_SN"; then pass "sentinel-safety: spawns nothing (no double-spawn path)"; else failx "sentinel-safety: spawns nothing" "$OUT_SN"; fi
+if grep -q 'RC=0' <<<"$OUT_LO"; then pass "live-owner: returns 0 (skips)"; else failx "live-owner: returns 0" "$OUT_LO"; fi
+if grep -q 'LOCK_KEPT' <<<"$OUT_LO"; then pass "live-owner: never force-removes a live peer's lock"; else failx "live-owner: never force-removes a live peer's lock" "$OUT_LO"; fi
+if grep -q 'PIDFILE_GONE' <<<"$OUT_LO"; then pass "live-owner: spawns nothing"; else failx "live-owner: spawns nothing" "$OUT_LO"; fi
+
+# --- dead-owner lock: an OLD sentinel-bearing lock whose recorded owner is DEAD is a
+#     crash-after-sentinel carcass ⇒ reclaimed (atomic-rename takeover), not left
+#     wedged after reboot until manual deletion (Codex P1). ---
+CDIR_DO="${SCRATCH}/catalyst-deadowner"; mkdir -p "$CDIR_DO"
+OUT_DO="$(PATH="${STUB_OFF}:${PATH}" CATALYST_DIR="$CDIR_DO" \
+  bash --noprofile --norc -c '
+    source "'"${STACK}"'" 2>/dev/null || true
+    mkdir -p "$COORDINATION_LOCK"
+    printf "%s" "2147480000" > "$COORDINATION_LOCK/owner"   # a PID that is not alive
+    touch -t 202001010000 "$COORDINATION_LOCK"              # OLD
+    start_coordination; echo "RC=$?"
+    [[ -d "$COORDINATION_LOCK" ]] && echo "LOCK_KEPT" || echo "LOCK_REMOVED"
+  ' 2>&1)"
+if grep -qi 'reclaimed a dead-owner start lock' <<<"$OUT_DO"; then pass "dead-owner: reclaims a crash-after-sentinel carcass"; else failx "dead-owner: reclaims a crash-after-sentinel carcass" "$OUT_DO"; fi
+if grep -q 'RC=0' <<<"$OUT_DO"; then pass "dead-owner: proceeds after reclaim (rc 0)"; else failx "dead-owner: proceeds after reclaim (rc 0)" "$OUT_DO"; fi
+if grep -q 'LOCK_REMOVED' <<<"$OUT_DO"; then pass "dead-owner: releases the reclaimed lock"; else failx "dead-owner: releases the reclaimed lock" "$OUT_DO"; fi
 
 # --- plist Layer-2 pinning (Codex P2): the stack LaunchAgent must carry the
 #     operator's CATALYST_LAYER2_CONFIG_FILE so the keep-alive resolves coordination
@@ -212,6 +227,22 @@ OUT_P2U="$(bash --noprofile --norc -c 'unset CATALYST_LAYER2_CONFIG_FILE; source
 if grep -q 'CATALYST_LAYER2_CONFIG_FILE' <<<"$OUT_P2U"; then
   failx "plist-layer2: omits the key when unset" "$OUT_P2U"
 else pass "plist-layer2: omits the key when unset (default path)"; fi
+
+# --- plist coordination-override pinning (Codex P1): install-time
+#     CATALYST_COORDINATION_MODE / _HUB_URL overrides must ride into the agent env,
+#     else the scheduled job drops the operator's kill-switch/override. ---
+OUT_CO="$(CATALYST_COORDINATION_MODE="0" CATALYST_COORDINATION_HUB_URL="https://hub.example/x" \
+  bash --noprofile --norc -c 'source "'"${STACK}"'" 2>/dev/null || true; render_stack_plist catalyst-stack 600' 2>&1)"
+if grep -q '<key>CATALYST_COORDINATION_MODE</key>' <<<"$OUT_CO" && grep -q '<string>0</string>' <<<"$OUT_CO"; then
+  pass "plist-coord: pins CATALYST_COORDINATION_MODE kill-switch when set"
+else failx "plist-coord: pins CATALYST_COORDINATION_MODE when set" "$OUT_CO"; fi
+if grep -q '<key>CATALYST_COORDINATION_HUB_URL</key>' <<<"$OUT_CO" && grep -q '<string>https://hub.example/x</string>' <<<"$OUT_CO"; then
+  pass "plist-coord: pins CATALYST_COORDINATION_HUB_URL when set"
+else failx "plist-coord: pins CATALYST_COORDINATION_HUB_URL when set" "$OUT_CO"; fi
+OUT_COU="$(bash --noprofile --norc -c 'unset CATALYST_COORDINATION_MODE CATALYST_COORDINATION_HUB_URL; source "'"${STACK}"'" 2>/dev/null || true; render_stack_plist catalyst-stack 600' 2>&1)"
+if grep -q 'CATALYST_COORDINATION_MODE\|CATALYST_COORDINATION_HUB_URL' <<<"$OUT_COU"; then
+  failx "plist-coord: omits coordination keys when unset" "$OUT_COU"
+else pass "plist-coord: omits coordination keys when unset"; fi
 
 echo ""
 echo "  ${PASSES} passed, ${FAILURES} failed"

--- a/plugins/dev/scripts/__tests__/catalyst-stack-coordination.test.sh
+++ b/plugins/dev/scripts/__tests__/catalyst-stack-coordination.test.sh
@@ -143,6 +143,37 @@ OUT_D="$(CATALYST_DIR="$CDIR_D" COORD_FAKE="$FAKE_PUB" \
 REAL_D="$(grep -o 'REAL=\[[0-9]*\]' <<<"$OUT_D" | grep -o '[0-9]*')"
 if [[ -n "$REAL_D" ]] && grep -q "FOUND=\[${REAL_D}\]" <<<"$OUT_D"; then pass "pid-discovery: rediscovers the publisher after PID-file loss"; else failx "pid-discovery: rediscovers the publisher after PID-file loss" "$OUT_D"; fi
 
+# --- start serialization: a held (fresh) start lock ⇒ this invocation SKIPS the
+#     tick without spawning (Codex P1: overlapping starts must not both spawn). ---
+CDIR_L="${SCRATCH}/catalyst-lockheld"; mkdir -p "$CDIR_L"
+OUT_L="$(PATH="${STUB_OFF}:${PATH}" CATALYST_DIR="$CDIR_L" \
+  bash --noprofile --norc -c '
+    source "'"${STACK}"'" 2>/dev/null || true
+    mkdir -p "$COORDINATION_LOCK"      # simulate a concurrent start holding the lock
+    start_coordination; echo "RC=$?"
+    [[ -d "$COORDINATION_LOCK" ]] && echo "LOCK_KEPT" || echo "LOCK_REMOVED"
+    [[ -f "$COORDINATION_PID" ]] && echo "PIDFILE_PRESENT" || echo "PIDFILE_GONE"
+  ' 2>&1)"
+if grep -q 'RC=0' <<<"$OUT_L"; then pass "start-lock: held lock ⇒ returns 0 (skips tick)"; else failx "start-lock: held lock ⇒ returns 0" "$OUT_L"; fi
+if grep -qi 'already in progress' <<<"$OUT_L"; then pass "start-lock: logs the skip breadcrumb"; else failx "start-lock: logs the skip breadcrumb" "$OUT_L"; fi
+if grep -q 'LOCK_KEPT' <<<"$OUT_L"; then pass "start-lock: does NOT steal a live peer's lock"; else failx "start-lock: does NOT steal a live peer's lock" "$OUT_L"; fi
+if grep -q 'PIDFILE_GONE' <<<"$OUT_L"; then pass "start-lock: spawns nothing while lock is held"; else failx "start-lock: spawns nothing while lock is held" "$OUT_L"; fi
+
+# --- stale-lock reclaim: a lock older than the threshold (a crashed start) is
+#     reclaimed so startup can't wedge forever; the off-stub then no-ops cleanly. ---
+CDIR_ST="${SCRATCH}/catalyst-lockstale"; mkdir -p "$CDIR_ST"
+OUT_ST="$(PATH="${STUB_OFF}:${PATH}" CATALYST_DIR="$CDIR_ST" \
+  bash --noprofile --norc -c '
+    source "'"${STACK}"'" 2>/dev/null || true
+    mkdir -p "$COORDINATION_LOCK"
+    touch -t 202001010000 "$COORDINATION_LOCK"   # back-date well past the stale threshold
+    start_coordination; echo "RC=$?"
+    [[ -d "$COORDINATION_LOCK" ]] && echo "LOCK_KEPT" || echo "LOCK_REMOVED"
+  ' 2>&1)"
+if grep -qi 'reclaiming stale start lock' <<<"$OUT_ST"; then pass "stale-lock: reclaims a crashed start lock"; else failx "stale-lock: reclaims a crashed start lock" "$OUT_ST"; fi
+if grep -q 'RC=0' <<<"$OUT_ST"; then pass "stale-lock: proceeds after reclaim (rc 0)"; else failx "stale-lock: proceeds after reclaim (rc 0)" "$OUT_ST"; fi
+if grep -q 'LOCK_REMOVED' <<<"$OUT_ST"; then pass "stale-lock: releases the lock it acquired"; else failx "stale-lock: releases the lock it acquired" "$OUT_ST"; fi
+
 echo ""
 echo "  ${PASSES} passed, ${FAILURES} failed"
 [[ "$FAILURES" -eq 0 ]]

--- a/plugins/dev/scripts/__tests__/catalyst-stack-coordination.test.sh
+++ b/plugins/dev/scripts/__tests__/catalyst-stack-coordination.test.sh
@@ -269,6 +269,18 @@ if grep -q '<key>CATALYST_EVENTS_DIR</key>' <<<"$OUT_ED" && grep -q '<string>/da
   pass "plist-eventsdir: pins CATALYST_EVENTS_DIR when set"
 else failx "plist-eventsdir: pins CATALYST_EVENTS_DIR when set" "$OUT_ED"; fi
 
+# --- plist Loki/OTel endpoint pinning (Codex P2): the enforce-mode publisher derives
+#     its interim Loki-tail inbound source from these; dropping them silently stops
+#     cross-host merges after reboot/restart. ---
+OUT_LK="$(CATALYST_LOKI_QUERY_URL="http://loki:3100" OTEL_EXPORTER_OTLP_ENDPOINT="http://otel:4317" \
+  bash --noprofile --norc -c 'source "'"${STACK}"'" 2>/dev/null || true; render_stack_plist catalyst-stack 600' 2>&1)"
+if grep -q '<key>CATALYST_LOKI_QUERY_URL</key>' <<<"$OUT_LK" && grep -q '<string>http://loki:3100</string>' <<<"$OUT_LK"; then
+  pass "plist-loki: pins CATALYST_LOKI_QUERY_URL when set"
+else failx "plist-loki: pins CATALYST_LOKI_QUERY_URL when set" "$OUT_LK"; fi
+if grep -q '<key>OTEL_EXPORTER_OTLP_ENDPOINT</key>' <<<"$OUT_LK" && grep -q '<string>http://otel:4317</string>' <<<"$OUT_LK"; then
+  pass "plist-loki: pins OTEL_EXPORTER_OTLP_ENDPOINT when set"
+else failx "plist-loki: pins OTEL_EXPORTER_OTLP_ENDPOINT when set" "$OUT_LK"; fi
+
 # --- plist XML escaping (Codex P2): an env value with an XML metacharacter (e.g. a
 #     hub URL with &) must be escaped so the plist stays well-formed and loadable. ---
 OUT_XE="$(CATALYST_COORDINATION_HUB_URL='https://hub.example/p?x=1&y=2<z>"q"' \

--- a/plugins/dev/scripts/__tests__/catalyst-stack-coordination.test.sh
+++ b/plugins/dev/scripts/__tests__/catalyst-stack-coordination.test.sh
@@ -131,6 +131,29 @@ if grep -qi 'forcing SIGKILL' <<<"$OUT_S"; then pass "stop-grace: warns before f
 ELAPSED_S="$(grep -o 'ELAPSED=[0-9]*' <<<"$OUT_S" | cut -d= -f2)"
 if [[ -n "$ELAPSED_S" && "$ELAPSED_S" -ge 2 ]]; then pass "stop-grace: honors the ${ELAPSED_S}s graceful window (≥2s)"; else failx "stop-grace: honors the graceful window (≥2s)" "$OUT_S"; fi
 
+# --- stop serialization (Codex P1): stop takes the SAME start lock so it can't
+#     interleave with an in-flight start. When the lock is held (a start in flight),
+#     stop waits the bounded window, then still stops best-effort — and does NOT
+#     remove a lock it never acquired (must not clobber the in-flight start's lock). ---
+CDIR_SS="${SCRATCH}/catalyst-stopserial"; mkdir -p "$CDIR_SS"
+OUT_SS="$(CATALYST_DIR="$CDIR_SS" COORD_FAKE="$FAKE_PUB" COORDINATION_STOP_LOCK_WAIT_SECONDS=2 \
+  bash --noprofile --norc -c '
+    source "'"${STACK}"'" 2>/dev/null || true
+    COORDINATION_SCRIPT="$COORD_FAKE"
+    mkdir -p "$COORDINATION_LOCK"; : > "$COORDINATION_LOCK/owner"   # a peer start holds the lock (fresh)
+    bash "$COORDINATION_SCRIPT" & echo $! > "$COORDINATION_PID"
+    sleep 1
+    livepid="$(cat "$COORDINATION_PID")"
+    t0="$SECONDS"; stop_coordination; t1="$SECONDS"
+    if [[ -z "$livepid" ]]; then echo "NO_PID"; elif ps -p "$livepid" >/dev/null 2>&1; then echo "STILL_ALIVE"; kill -9 "$livepid" 2>/dev/null; else echo "STOPPED"; fi
+    [[ -d "$COORDINATION_LOCK" ]] && echo "PEERLOCK_KEPT" || echo "PEERLOCK_REMOVED"
+    echo "ELAPSED=$((t1 - t0))"
+  ' 2>&1)"
+if grep -q 'STOPPED' <<<"$OUT_SS"; then pass "stop-serialize: stops best-effort even when it cannot take the lock"; else failx "stop-serialize: stops best-effort even when it cannot take the lock" "$OUT_SS"; fi
+if grep -q 'PEERLOCK_KEPT' <<<"$OUT_SS"; then pass "stop-serialize: never clobbers a lock it did not acquire"; else failx "stop-serialize: never clobbers a lock it did not acquire" "$OUT_SS"; fi
+ELAPSED_SS="$(grep -o 'ELAPSED=[0-9]*' <<<"$OUT_SS" | cut -d= -f2)"
+if [[ -n "$ELAPSED_SS" && "$ELAPSED_SS" -ge 2 ]]; then pass "stop-serialize: waits the bounded window for the in-flight start (≥2s)"; else failx "stop-serialize: waits the bounded window (≥2s)" "$OUT_SS"; fi
+
 # --- PID-discovery fallback: PID file deleted, but a publisher is still live ⇒
 #     coordination_pid rediscovers it by command line (Codex P1: no orphan/dup).
 CDIR_D="${SCRATCH}/catalyst-discover"; mkdir -p "$CDIR_D"
@@ -236,6 +259,15 @@ OUT_CD="$(CATALYST_DIR="/data/catalyst-root" \
 if grep -q '<key>CATALYST_DIR</key>' <<<"$OUT_CD" && grep -q '<string>/data/catalyst-root</string>' <<<"$OUT_CD"; then
   pass "plist-catdir: pins CATALYST_DIR when set"
 else failx "plist-catdir: pins CATALYST_DIR when set" "$OUT_CD"; fi
+
+# --- plist CATALYST_EVENTS_DIR pinning (Codex P2): the publisher tails this dir, so
+#     a supported override must ride into the agent env or a post-reboot start tails
+#     the default $CATALYST_DIR/events and misses configured events. ---
+OUT_ED="$(CATALYST_EVENTS_DIR="/data/ev" \
+  bash --noprofile --norc -c 'source "'"${STACK}"'" 2>/dev/null || true; render_stack_plist catalyst-stack 600' 2>&1)"
+if grep -q '<key>CATALYST_EVENTS_DIR</key>' <<<"$OUT_ED" && grep -q '<string>/data/ev</string>' <<<"$OUT_ED"; then
+  pass "plist-eventsdir: pins CATALYST_EVENTS_DIR when set"
+else failx "plist-eventsdir: pins CATALYST_EVENTS_DIR when set" "$OUT_ED"; fi
 
 # --- plist XML escaping (Codex P2): an env value with an XML metacharacter (e.g. a
 #     hub URL with &) must be escaped so the plist stays well-formed and loadable. ---

--- a/plugins/dev/scripts/__tests__/catalyst-stack-coordination.test.sh
+++ b/plugins/dev/scripts/__tests__/catalyst-stack-coordination.test.sh
@@ -175,47 +175,43 @@ OUT_ST="$(PATH="${STUB_OFF}:${PATH}" CATALYST_DIR="$CDIR_ST" \
     start_coordination; echo "RC=$?"
     [[ -d "$COORDINATION_LOCK" ]] && echo "LOCK_KEPT" || echo "LOCK_REMOVED"
   ' 2>&1)"
-if grep -qi 'reclaiming stale start lock' <<<"$OUT_ST"; then pass "stale-lock: reclaims a crashed start lock"; else failx "stale-lock: reclaims a crashed start lock" "$OUT_ST"; fi
+if grep -qi 'reclaimed an abandoned start lock' <<<"$OUT_ST"; then pass "stale-lock: reclaims an empty crashed start lock"; else failx "stale-lock: reclaims an empty crashed start lock" "$OUT_ST"; fi
 if grep -q 'RC=0' <<<"$OUT_ST"; then pass "stale-lock: proceeds after reclaim (rc 0)"; else failx "stale-lock: proceeds after reclaim (rc 0)" "$OUT_ST"; fi
 if grep -q 'LOCK_REMOVED' <<<"$OUT_ST"; then pass "stale-lock: releases the lock it acquired"; else failx "stale-lock: releases the lock it acquired" "$OUT_ST"; fi
 
-# --- ownership-safe reclaim: a stale main lock IS present, but a peer holds the
-#     reclaim mutex ⇒ this start must SKIP (not remove the stale lock out from under
-#     the peer that's reclaiming it) — proves the takeover decision is serialized so
-#     two starts can't both reclaim+reacquire and double-spawn (Codex P1). ---
-CDIR_A="${SCRATCH}/catalyst-atomicreclaim"; mkdir -p "$CDIR_A"
-OUT_A="$(PATH="${STUB_OFF}:${PATH}" CATALYST_DIR="$CDIR_A" \
+# --- sentinel safety (THE double-spawn-prevention invariant): a NON-EMPTY stale
+#     lock (a live holder's sentinel-bearing lock, or a crash-after-sentinel leak)
+#     is NEVER force-removed, even when older than the threshold — rmdir refuses a
+#     non-empty dir. This is what makes mkdir the sole arbiter of ownership, so a
+#     reclaimer can never delete a live peer's lock and let both spawn (Codex P1). ---
+CDIR_SN="${SCRATCH}/catalyst-sentinel"; mkdir -p "$CDIR_SN"
+OUT_SN="$(PATH="${STUB_OFF}:${PATH}" CATALYST_DIR="$CDIR_SN" \
   bash --noprofile --norc -c '
     source "'"${STACK}"'" 2>/dev/null || true
     mkdir -p "$COORDINATION_LOCK"
-    touch -t 202001010000 "$COORDINATION_LOCK"   # stale main lock…
-    mkdir -p "$COORDINATION_RECLAIM_LOCK"        # …but a peer owns the reclaim decision
+    : > "$COORDINATION_LOCK/owner"                # sentinel present (live-lock shape)
+    touch -t 202001010000 "$COORDINATION_LOCK"   # …and OLD (age gate would pass)
     start_coordination; echo "RC=$?"
-    [[ -d "$COORDINATION_LOCK" ]] && echo "MAINLOCK_KEPT" || echo "MAINLOCK_REMOVED"
+    [[ -d "$COORDINATION_LOCK" ]] && echo "LOCK_KEPT" || echo "LOCK_REMOVED"
     [[ -f "$COORDINATION_PID" ]] && echo "PIDFILE_PRESENT" || echo "PIDFILE_GONE"
   ' 2>&1)"
-if grep -q 'RC=0' <<<"$OUT_A"; then pass "atomic-reclaim: reclaim-mutex held ⇒ returns 0 (skips)"; else failx "atomic-reclaim: reclaim-mutex held ⇒ returns 0" "$OUT_A"; fi
-if grep -qi 'already in progress' <<<"$OUT_A"; then pass "atomic-reclaim: does not race the peer's reclaim"; else failx "atomic-reclaim: does not race the peer's reclaim" "$OUT_A"; fi
-if grep -q 'MAINLOCK_KEPT' <<<"$OUT_A"; then pass "atomic-reclaim: leaves the stale lock for its owner (no double-remove)"; else failx "atomic-reclaim: leaves the stale lock for its owner" "$OUT_A"; fi
-if grep -q 'PIDFILE_GONE' <<<"$OUT_A"; then pass "atomic-reclaim: spawns nothing"; else failx "atomic-reclaim: spawns nothing" "$OUT_A"; fi
+if grep -q 'RC=0' <<<"$OUT_SN"; then pass "sentinel-safety: non-empty stale lock ⇒ returns 0 (skips)"; else failx "sentinel-safety: non-empty stale lock ⇒ returns 0" "$OUT_SN"; fi
+if grep -q 'LOCK_KEPT' <<<"$OUT_SN"; then pass "sentinel-safety: never force-removes a sentinel-bearing lock"; else failx "sentinel-safety: never force-removes a sentinel-bearing lock" "$OUT_SN"; fi
+if grep -q 'PIDFILE_GONE' <<<"$OUT_SN"; then pass "sentinel-safety: spawns nothing (no double-spawn path)"; else failx "sentinel-safety: spawns nothing" "$OUT_SN"; fi
 
-# --- abandoned reclaim mutex recovery: a crash/power-off can leave the reclaim
-#     mutex behind; a STALE reclaim mutex must be recovered, not read as a live peer
-#     forever (Codex P2). Stale main lock + stale reclaim mutex ⇒ recover both,
-#     proceed (off-stub ⇒ inert), leaving no locks behind. ---
-CDIR_M="${SCRATCH}/catalyst-abandonedmutex"; mkdir -p "$CDIR_M"
-OUT_M="$(PATH="${STUB_OFF}:${PATH}" CATALYST_DIR="$CDIR_M" \
-  bash --noprofile --norc -c '
-    source "'"${STACK}"'" 2>/dev/null || true
-    mkdir -p "$COORDINATION_LOCK" "$COORDINATION_RECLAIM_LOCK"
-    touch -t 202001010000 "$COORDINATION_LOCK" "$COORDINATION_RECLAIM_LOCK"   # both abandoned
-    start_coordination; echo "RC=$?"
-    [[ -d "$COORDINATION_RECLAIM_LOCK" ]] && echo "MUTEX_KEPT" || echo "MUTEX_RECOVERED"
-    [[ -d "$COORDINATION_LOCK" ]] && echo "MAINLOCK_KEPT" || echo "MAINLOCK_CLEARED"
-  ' 2>&1)"
-if grep -qi 'reclaiming abandoned reclaim mutex' <<<"$OUT_M"; then pass "abandoned-mutex: recovers a stale reclaim mutex"; else failx "abandoned-mutex: recovers a stale reclaim mutex" "$OUT_M"; fi
-if grep -q 'RC=0' <<<"$OUT_M"; then pass "abandoned-mutex: proceeds after recovery (rc 0)"; else failx "abandoned-mutex: proceeds after recovery (rc 0)" "$OUT_M"; fi
-if grep -q 'MUTEX_RECOVERED' <<<"$OUT_M"; then pass "abandoned-mutex: leaves no reclaim mutex behind"; else failx "abandoned-mutex: leaves no reclaim mutex behind" "$OUT_M"; fi
+# --- plist Layer-2 pinning (Codex P2): the stack LaunchAgent must carry the
+#     operator's CATALYST_LAYER2_CONFIG_FILE so the keep-alive resolves coordination
+#     from the SAME config the operator used — else a shadow/enforce publisher is
+#     seen as `off` on the tick and reconcile-stopped. render_stack_plist is pure. ---
+OUT_P2="$(CATALYST_LAYER2_CONFIG_FILE="/custom/layer2.json" \
+  bash --noprofile --norc -c 'source "'"${STACK}"'" 2>/dev/null || true; render_stack_plist catalyst-stack 600' 2>&1)"
+if grep -q '<key>CATALYST_LAYER2_CONFIG_FILE</key>' <<<"$OUT_P2" && grep -q '<string>/custom/layer2.json</string>' <<<"$OUT_P2"; then
+  pass "plist-layer2: pins CATALYST_LAYER2_CONFIG_FILE when set"
+else failx "plist-layer2: pins CATALYST_LAYER2_CONFIG_FILE when set" "$OUT_P2"; fi
+OUT_P2U="$(bash --noprofile --norc -c 'unset CATALYST_LAYER2_CONFIG_FILE; source "'"${STACK}"'" 2>/dev/null || true; render_stack_plist catalyst-stack 600' 2>&1)"
+if grep -q 'CATALYST_LAYER2_CONFIG_FILE' <<<"$OUT_P2U"; then
+  failx "plist-layer2: omits the key when unset" "$OUT_P2U"
+else pass "plist-layer2: omits the key when unset (default path)"; fi
 
 echo ""
 echo "  ${PASSES} passed, ${FAILURES} failed"

--- a/plugins/dev/scripts/__tests__/catalyst-stack-coordination.test.sh
+++ b/plugins/dev/scripts/__tests__/catalyst-stack-coordination.test.sh
@@ -99,7 +99,10 @@ OUT_R="$(PATH="${STUB_OFF}:${PATH}" CATALYST_DIR="$CDIR_R" COORD_FAKE="$FAKE_PUB
     livepid="$(cat "$COORDINATION_PID")"
     start_coordination; echo "RC=$?"
     sleep 1
-    if kill -0 "$livepid" 2>/dev/null; then echo "PROC_ALIVE"; kill -9 "$livepid" 2>/dev/null; else echo "PROC_DEAD"; fi
+    # Fail CLOSED (AGENTS.md): PROC_DEAD only on a POSITIVE confirmation the pid is
+    # gone — an empty/uncapturable pid must NOT read as "dead" (that would let a
+    # shutdown regression pass silently).
+    if [[ -z "$livepid" ]]; then echo "NO_PID"; elif ps -p "$livepid" >/dev/null 2>&1; then echo "PROC_ALIVE"; kill -9 "$livepid" 2>/dev/null; else echo "PROC_DEAD"; fi
     [[ -f "$COORDINATION_PID" ]] && echo "PIDFILE_PRESENT" || echo "PIDFILE_GONE"
   ' 2>&1)"
 if grep -q 'RC=0' <<<"$OUT_R"; then pass "reconcile-off: returns 0"; else failx "reconcile-off: returns 0" "$OUT_R"; fi
@@ -118,7 +121,9 @@ OUT_S="$(CATALYST_DIR="$CDIR_S" COORD_FAKE="$FAKE_PUB" COORDINATION_STOP_GRACE_S
     sleep 1
     livepid="$(cat "$COORDINATION_PID")"
     t0="$SECONDS"; stop_coordination; t1="$SECONDS"
-    if kill -0 "$livepid" 2>/dev/null; then echo "STILL_ALIVE"; kill -9 "$livepid" 2>/dev/null; else echo "KILLED"; fi
+    # Fail CLOSED (AGENTS.md): KILLED only when we POSITIVELY confirm the pid is
+    # gone. An empty/uncapturable pid → NO_PID (asserts fail), never a false KILLED.
+    if [[ -z "$livepid" ]]; then echo "NO_PID"; elif ps -p "$livepid" >/dev/null 2>&1; then echo "STILL_ALIVE"; kill -9 "$livepid" 2>/dev/null; else echo "KILLED"; fi
     echo "ELAPSED=$((t1 - t0))"
   ' 2>&1)"
 if grep -q 'KILLED' <<<"$OUT_S"; then pass "stop-grace: SIGKILLs a SIGTERM-ignoring publisher"; else failx "stop-grace: SIGKILLs a SIGTERM-ignoring publisher" "$OUT_S"; fi
@@ -193,6 +198,24 @@ if grep -q 'RC=0' <<<"$OUT_A"; then pass "atomic-reclaim: reclaim-mutex held ⇒
 if grep -qi 'already in progress' <<<"$OUT_A"; then pass "atomic-reclaim: does not race the peer's reclaim"; else failx "atomic-reclaim: does not race the peer's reclaim" "$OUT_A"; fi
 if grep -q 'MAINLOCK_KEPT' <<<"$OUT_A"; then pass "atomic-reclaim: leaves the stale lock for its owner (no double-remove)"; else failx "atomic-reclaim: leaves the stale lock for its owner" "$OUT_A"; fi
 if grep -q 'PIDFILE_GONE' <<<"$OUT_A"; then pass "atomic-reclaim: spawns nothing"; else failx "atomic-reclaim: spawns nothing" "$OUT_A"; fi
+
+# --- abandoned reclaim mutex recovery: a crash/power-off can leave the reclaim
+#     mutex behind; a STALE reclaim mutex must be recovered, not read as a live peer
+#     forever (Codex P2). Stale main lock + stale reclaim mutex ⇒ recover both,
+#     proceed (off-stub ⇒ inert), leaving no locks behind. ---
+CDIR_M="${SCRATCH}/catalyst-abandonedmutex"; mkdir -p "$CDIR_M"
+OUT_M="$(PATH="${STUB_OFF}:${PATH}" CATALYST_DIR="$CDIR_M" \
+  bash --noprofile --norc -c '
+    source "'"${STACK}"'" 2>/dev/null || true
+    mkdir -p "$COORDINATION_LOCK" "$COORDINATION_RECLAIM_LOCK"
+    touch -t 202001010000 "$COORDINATION_LOCK" "$COORDINATION_RECLAIM_LOCK"   # both abandoned
+    start_coordination; echo "RC=$?"
+    [[ -d "$COORDINATION_RECLAIM_LOCK" ]] && echo "MUTEX_KEPT" || echo "MUTEX_RECOVERED"
+    [[ -d "$COORDINATION_LOCK" ]] && echo "MAINLOCK_KEPT" || echo "MAINLOCK_CLEARED"
+  ' 2>&1)"
+if grep -qi 'reclaiming abandoned reclaim mutex' <<<"$OUT_M"; then pass "abandoned-mutex: recovers a stale reclaim mutex"; else failx "abandoned-mutex: recovers a stale reclaim mutex" "$OUT_M"; fi
+if grep -q 'RC=0' <<<"$OUT_M"; then pass "abandoned-mutex: proceeds after recovery (rc 0)"; else failx "abandoned-mutex: proceeds after recovery (rc 0)" "$OUT_M"; fi
+if grep -q 'MUTEX_RECOVERED' <<<"$OUT_M"; then pass "abandoned-mutex: leaves no reclaim mutex behind"; else failx "abandoned-mutex: leaves no reclaim mutex behind" "$OUT_M"; fi
 
 echo ""
 echo "  ${PASSES} passed, ${FAILURES} failed"

--- a/plugins/dev/scripts/__tests__/catalyst-stack-coordination.test.sh
+++ b/plugins/dev/scripts/__tests__/catalyst-stack-coordination.test.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+# CTL-1494: focused tests for catalyst-stack's coordination-publish lifecycle
+# primitives — the off-inert no-op path and the bun-missing fail-closed path.
+#
+#   - node-class gating (worker/monitor start it, developer doesn't) is covered by
+#     catalyst-stack-start-node-class.test.sh
+#   - the status-line inventory is covered by catalyst-stack.test.sh
+#   - LIVE shadow/enforce launch (the mirror is actually written) is a MANUAL step:
+#     it needs a real bun runtime and a coordination-stamped event on the log, which
+#     a hermetic shell test can't provide. Out of scope here (plan Testing Strategy).
+#
+# Run: bash plugins/dev/scripts/__tests__/catalyst-stack-coordination.test.sh
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../../.." && pwd)"
+STACK="${REPO_ROOT}/plugins/dev/scripts/catalyst-stack"
+
+FAILURES=0
+PASSES=0
+SCRATCH="$(mktemp -d)"
+trap 'rm -rf "$SCRATCH"' EXIT
+
+pass()  { PASSES=$((PASSES + 1)); echo "  PASS: $1"; }
+failx() { FAILURES=$((FAILURES + 1)); echo "  FAIL: $1"; [[ -n "${2:-}" ]] && sed 's/^/      /' <<<"$2"; }
+
+echo ""
+echo "=== catalyst-stack coordination-publish lifecycle (CTL-1494) ==="
+echo ""
+
+# --- off-skip: a fake bun that resolves mode=off ⇒ clean no-op, no PID file, rc 0 ---
+STUB_OFF="${SCRATCH}/stub-off"
+mkdir -p "$STUB_OFF"
+cat > "${STUB_OFF}/bun" <<'BUN'
+#!/usr/bin/env bash
+# Fake bun: the coordination_mode probe expects the resolved mode on stdout.
+printf 'off'
+BUN
+chmod +x "${STUB_OFF}/bun"
+
+CATALYST_DIR_OFF="${SCRATCH}/catalyst-off"
+mkdir -p "$CATALYST_DIR_OFF"
+OUT_OFF="$(PATH="${STUB_OFF}:${PATH}" CATALYST_DIR="$CATALYST_DIR_OFF" \
+  bash --noprofile --norc -c '
+    source "'"${STACK}"'" 2>/dev/null || true
+    start_coordination
+    echo "RC=$?"
+  ' 2>&1)"
+
+if grep -q 'RC=0' <<<"$OUT_OFF"; then pass "off-skip: start_coordination returns 0"; else failx "off-skip: start_coordination returns 0" "$OUT_OFF"; fi
+if grep -qi 'inert' <<<"$OUT_OFF"; then pass "off-skip: prints an inert/skip breadcrumb"; else failx "off-skip: prints an inert/skip breadcrumb" "$OUT_OFF"; fi
+if [[ ! -f "${CATALYST_DIR_OFF}/coordination-publish.pid" ]]; then pass "off-skip: writes NO PID file"; else failx "off-skip: writes NO PID file"; fi
+
+# --- bun-missing: coordination_mode fails closed to off ⇒ clean skip, rc 0, no PID file ---
+# Even with CATALYST_COORDINATION_MODE=shadow forced, a bun-less host cannot run the
+# bun daemon, so coordination_mode returns off and start_coordination is a clean skip.
+# This is the intended fail-closed collapse (plan Note under Tests First test 3).
+MINIMAL_PATH="/usr/bin:/bin:/usr/sbin:/sbin"
+CATALYST_DIR_NOBUN="${SCRATCH}/catalyst-nobun"
+mkdir -p "$CATALYST_DIR_NOBUN"
+OUT_NOBUN="$(PATH="$MINIMAL_PATH" CATALYST_DIR="$CATALYST_DIR_NOBUN" CATALYST_COORDINATION_MODE=shadow \
+  bash --noprofile --norc -c '
+    source "'"${STACK}"'" 2>/dev/null || true
+    start_coordination
+    echo "RC=$?"
+  ' 2>&1)"
+
+if grep -q 'RC=0' <<<"$OUT_NOBUN"; then pass "bun-missing: non-fatal (clean skip, returns 0 via off-fallback)"; else failx "bun-missing: non-fatal (clean skip, returns 0 via off-fallback)" "$OUT_NOBUN"; fi
+if [[ ! -f "${CATALYST_DIR_NOBUN}/coordination-publish.pid" ]]; then pass "bun-missing: writes NO PID file"; else failx "bun-missing: writes NO PID file"; fi
+
+echo ""
+echo "  ${PASSES} passed, ${FAILURES} failed"
+[[ "$FAILURES" -eq 0 ]]

--- a/plugins/dev/scripts/__tests__/catalyst-stack-coordination.test.sh
+++ b/plugins/dev/scripts/__tests__/catalyst-stack-coordination.test.sh
@@ -179,40 +179,25 @@ if grep -qi 'reclaimed an abandoned (empty) start lock' <<<"$OUT_ST"; then pass 
 if grep -q 'RC=0' <<<"$OUT_ST"; then pass "stale-lock: proceeds after reclaim (rc 0)"; else failx "stale-lock: proceeds after reclaim (rc 0)" "$OUT_ST"; fi
 if grep -q 'LOCK_REMOVED' <<<"$OUT_ST"; then pass "stale-lock: releases the lock it acquired"; else failx "stale-lock: releases the lock it acquired" "$OUT_ST"; fi
 
-# --- live-owner lock: an OLD lock whose sentinel owner is still ALIVE is a live
-#     peer (never force-removed) ⇒ skip. Guards mkdir as the sole ownership arbiter
-#     so a reclaimer can't delete a live peer's lock and let both spawn (Codex P1). ---
-CDIR_LO="${SCRATCH}/catalyst-liveowner"; mkdir -p "$CDIR_LO"
-OUT_LO="$(PATH="${STUB_OFF}:${PATH}" CATALYST_DIR="$CDIR_LO" \
+# --- non-empty stale lock is NEVER force-removed (safety over liveness): even an
+#     OLD, non-empty carcass is skipped, not force-removed — because a race-free
+#     takeover of a non-empty lock is impossible in pure shell, so we never attempt
+#     it (double-spawn is impossible; the residual is a bounded, recoverable wedge,
+#     Codex P1). rmdir refuses the non-empty dir, so the lock stays put. ---
+CDIR_NE="${SCRATCH}/catalyst-nonempty"; mkdir -p "$CDIR_NE"
+OUT_NE="$(PATH="${STUB_OFF}:${PATH}" CATALYST_DIR="$CDIR_NE" \
   bash --noprofile --norc -c '
     source "'"${STACK}"'" 2>/dev/null || true
     mkdir -p "$COORDINATION_LOCK"
-    printf "%s" "$$" > "$COORDINATION_LOCK/owner"   # owner = THIS shell (alive)
-    touch -t 202001010000 "$COORDINATION_LOCK"      # OLD (age gate passes)
+    : > "$COORDINATION_LOCK/owner"                # non-empty (sentinel-bearing) carcass
+    touch -t 202001010000 "$COORDINATION_LOCK"   # OLD (age gate would pass)
     start_coordination; echo "RC=$?"
     [[ -d "$COORDINATION_LOCK" ]] && echo "LOCK_KEPT" || echo "LOCK_REMOVED"
     [[ -f "$COORDINATION_PID" ]] && echo "PIDFILE_PRESENT" || echo "PIDFILE_GONE"
   ' 2>&1)"
-if grep -q 'RC=0' <<<"$OUT_LO"; then pass "live-owner: returns 0 (skips)"; else failx "live-owner: returns 0" "$OUT_LO"; fi
-if grep -q 'LOCK_KEPT' <<<"$OUT_LO"; then pass "live-owner: never force-removes a live peer's lock"; else failx "live-owner: never force-removes a live peer's lock" "$OUT_LO"; fi
-if grep -q 'PIDFILE_GONE' <<<"$OUT_LO"; then pass "live-owner: spawns nothing"; else failx "live-owner: spawns nothing" "$OUT_LO"; fi
-
-# --- dead-owner lock: an OLD sentinel-bearing lock whose recorded owner is DEAD is a
-#     crash-after-sentinel carcass ⇒ reclaimed (atomic-rename takeover), not left
-#     wedged after reboot until manual deletion (Codex P1). ---
-CDIR_DO="${SCRATCH}/catalyst-deadowner"; mkdir -p "$CDIR_DO"
-OUT_DO="$(PATH="${STUB_OFF}:${PATH}" CATALYST_DIR="$CDIR_DO" \
-  bash --noprofile --norc -c '
-    source "'"${STACK}"'" 2>/dev/null || true
-    mkdir -p "$COORDINATION_LOCK"
-    printf "%s" "2147480000" > "$COORDINATION_LOCK/owner"   # a PID that is not alive
-    touch -t 202001010000 "$COORDINATION_LOCK"              # OLD
-    start_coordination; echo "RC=$?"
-    [[ -d "$COORDINATION_LOCK" ]] && echo "LOCK_KEPT" || echo "LOCK_REMOVED"
-  ' 2>&1)"
-if grep -qi 'reclaimed a dead-owner start lock' <<<"$OUT_DO"; then pass "dead-owner: reclaims a crash-after-sentinel carcass"; else failx "dead-owner: reclaims a crash-after-sentinel carcass" "$OUT_DO"; fi
-if grep -q 'RC=0' <<<"$OUT_DO"; then pass "dead-owner: proceeds after reclaim (rc 0)"; else failx "dead-owner: proceeds after reclaim (rc 0)" "$OUT_DO"; fi
-if grep -q 'LOCK_REMOVED' <<<"$OUT_DO"; then pass "dead-owner: releases the reclaimed lock"; else failx "dead-owner: releases the reclaimed lock" "$OUT_DO"; fi
+if grep -q 'RC=0' <<<"$OUT_NE"; then pass "nonempty-stale: returns 0 (skips)"; else failx "nonempty-stale: returns 0" "$OUT_NE"; fi
+if grep -q 'LOCK_KEPT' <<<"$OUT_NE"; then pass "nonempty-stale: never force-removes a non-empty lock (no ABA takeover)"; else failx "nonempty-stale: never force-removes a non-empty lock" "$OUT_NE"; fi
+if grep -q 'PIDFILE_GONE' <<<"$OUT_NE"; then pass "nonempty-stale: spawns nothing"; else failx "nonempty-stale: spawns nothing" "$OUT_NE"; fi
 
 # --- plist Layer-2 pinning (Codex P2): the stack LaunchAgent must carry the
 #     operator's CATALYST_LAYER2_CONFIG_FILE so the keep-alive resolves coordination
@@ -243,6 +228,29 @@ OUT_COU="$(bash --noprofile --norc -c 'unset CATALYST_COORDINATION_MODE CATALYST
 if grep -q 'CATALYST_COORDINATION_MODE\|CATALYST_COORDINATION_HUB_URL' <<<"$OUT_COU"; then
   failx "plist-coord: omits coordination keys when unset" "$OUT_COU"
 else pass "plist-coord: omits coordination keys when unset"; fi
+
+# --- plist CATALYST_DIR pinning (Codex P2): a nondefault root must ride into the
+#     agent env, else the keep-alive relocates coordination state to $HOME/catalyst. ---
+OUT_CD="$(CATALYST_DIR="/data/catalyst-root" \
+  bash --noprofile --norc -c 'source "'"${STACK}"'" 2>/dev/null || true; render_stack_plist catalyst-stack 600' 2>&1)"
+if grep -q '<key>CATALYST_DIR</key>' <<<"$OUT_CD" && grep -q '<string>/data/catalyst-root</string>' <<<"$OUT_CD"; then
+  pass "plist-catdir: pins CATALYST_DIR when set"
+else failx "plist-catdir: pins CATALYST_DIR when set" "$OUT_CD"; fi
+
+# --- plist XML escaping (Codex P2): an env value with an XML metacharacter (e.g. a
+#     hub URL with &) must be escaped so the plist stays well-formed and loadable. ---
+OUT_XE="$(CATALYST_COORDINATION_HUB_URL='https://hub.example/p?x=1&y=2<z>"q"' \
+  bash --noprofile --norc -c 'source "'"${STACK}"'" 2>/dev/null || true; render_stack_plist catalyst-stack 600' 2>&1)"
+if grep -q 'x=1&amp;y=2&lt;z&gt;&quot;q&quot;' <<<"$OUT_XE" && ! grep -q 'x=1&y=2' <<<"$OUT_XE"; then
+  pass "plist-xml-escape: escapes & < > \" in env values"
+else failx "plist-xml-escape: escapes XML metacharacters" "$OUT_XE"; fi
+# And the escaped plist must be well-formed per plutil (macOS only).
+if command -v plutil >/dev/null 2>&1; then
+  XE_FILE="${SCRATCH}/escaped.plist"; printf '%s' "$OUT_XE" > "$XE_FILE"
+  if plutil -lint "$XE_FILE" >/dev/null 2>&1; then pass "plist-xml-escape: escaped plist passes plutil -lint"; else failx "plist-xml-escape: escaped plist passes plutil -lint" "$(plutil -lint "$XE_FILE" 2>&1)"; fi
+else
+  pass "plist-xml-escape: plutil unavailable — lint skipped"
+fi
 
 echo ""
 echo "  ${PASSES} passed, ${FAILURES} failed"

--- a/plugins/dev/scripts/__tests__/catalyst-stack-coordination.test.sh
+++ b/plugins/dev/scripts/__tests__/catalyst-stack-coordination.test.sh
@@ -174,6 +174,26 @@ if grep -qi 'reclaiming stale start lock' <<<"$OUT_ST"; then pass "stale-lock: r
 if grep -q 'RC=0' <<<"$OUT_ST"; then pass "stale-lock: proceeds after reclaim (rc 0)"; else failx "stale-lock: proceeds after reclaim (rc 0)" "$OUT_ST"; fi
 if grep -q 'LOCK_REMOVED' <<<"$OUT_ST"; then pass "stale-lock: releases the lock it acquired"; else failx "stale-lock: releases the lock it acquired" "$OUT_ST"; fi
 
+# --- ownership-safe reclaim: a stale main lock IS present, but a peer holds the
+#     reclaim mutex ⇒ this start must SKIP (not remove the stale lock out from under
+#     the peer that's reclaiming it) — proves the takeover decision is serialized so
+#     two starts can't both reclaim+reacquire and double-spawn (Codex P1). ---
+CDIR_A="${SCRATCH}/catalyst-atomicreclaim"; mkdir -p "$CDIR_A"
+OUT_A="$(PATH="${STUB_OFF}:${PATH}" CATALYST_DIR="$CDIR_A" \
+  bash --noprofile --norc -c '
+    source "'"${STACK}"'" 2>/dev/null || true
+    mkdir -p "$COORDINATION_LOCK"
+    touch -t 202001010000 "$COORDINATION_LOCK"   # stale main lock…
+    mkdir -p "$COORDINATION_RECLAIM_LOCK"        # …but a peer owns the reclaim decision
+    start_coordination; echo "RC=$?"
+    [[ -d "$COORDINATION_LOCK" ]] && echo "MAINLOCK_KEPT" || echo "MAINLOCK_REMOVED"
+    [[ -f "$COORDINATION_PID" ]] && echo "PIDFILE_PRESENT" || echo "PIDFILE_GONE"
+  ' 2>&1)"
+if grep -q 'RC=0' <<<"$OUT_A"; then pass "atomic-reclaim: reclaim-mutex held ⇒ returns 0 (skips)"; else failx "atomic-reclaim: reclaim-mutex held ⇒ returns 0" "$OUT_A"; fi
+if grep -qi 'already in progress' <<<"$OUT_A"; then pass "atomic-reclaim: does not race the peer's reclaim"; else failx "atomic-reclaim: does not race the peer's reclaim" "$OUT_A"; fi
+if grep -q 'MAINLOCK_KEPT' <<<"$OUT_A"; then pass "atomic-reclaim: leaves the stale lock for its owner (no double-remove)"; else failx "atomic-reclaim: leaves the stale lock for its owner" "$OUT_A"; fi
+if grep -q 'PIDFILE_GONE' <<<"$OUT_A"; then pass "atomic-reclaim: spawns nothing"; else failx "atomic-reclaim: spawns nothing" "$OUT_A"; fi
+
 echo ""
 echo "  ${PASSES} passed, ${FAILURES} failed"
 [[ "$FAILURES" -eq 0 ]]

--- a/plugins/dev/scripts/__tests__/catalyst-stack-coordination.test.sh
+++ b/plugins/dev/scripts/__tests__/catalyst-stack-coordination.test.sh
@@ -20,7 +20,24 @@ STACK="${REPO_ROOT}/plugins/dev/scripts/catalyst-stack"
 FAILURES=0
 PASSES=0
 SCRATCH="$(mktemp -d)"
-trap 'rm -rf "$SCRATCH"' EXIT
+# Cleanup also reaps any straggler fake-publisher process (self-bounded to 60s as a
+# backstop, but kill it eagerly so the suite never leaks a background process —
+# AGENTS.md "make the LOOP ITSELF self-limiting; never let cleanup be load-bearing").
+trap 'pkill -f "${SCRATCH}/coordination-publish" 2>/dev/null || true; rm -rf "$SCRATCH"' EXIT
+
+# A fake "live publisher": a bash script whose PATH contains the token
+# "coordination-publish" (so the coordination_pid command-grep guard + the
+# COORDINATION_SCRIPT-override pgrep fallback both recognize it) and which
+# self-bounds to 60s so a broken kill path can never strand it. IGNORE_TERM=1
+# makes it ignore SIGTERM, to exercise the SIGKILL-after-grace fallback.
+FAKE_PUB="${SCRATCH}/coordination-publish/index.ts"
+mkdir -p "$(dirname "$FAKE_PUB")"
+cat > "$FAKE_PUB" <<'PROC'
+#!/usr/bin/env bash
+[[ "${IGNORE_TERM:-0}" == "1" ]] && trap '' TERM
+end=$((SECONDS + 60)); while [ "$SECONDS" -lt "$end" ]; do sleep 1; done
+PROC
+chmod +x "$FAKE_PUB"
 
 pass()  { PASSES=$((PASSES + 1)); echo "  PASS: $1"; }
 failx() { FAILURES=$((FAILURES + 1)); echo "  FAIL: $1"; [[ -n "${2:-}" ]] && sed 's/^/      /' <<<"$2"; }
@@ -68,6 +85,63 @@ OUT_NOBUN="$(PATH="$MINIMAL_PATH" CATALYST_DIR="$CATALYST_DIR_NOBUN" CATALYST_CO
 
 if grep -q 'RC=0' <<<"$OUT_NOBUN"; then pass "bun-missing: non-fatal (clean skip, returns 0 via off-fallback)"; else failx "bun-missing: non-fatal (clean skip, returns 0 via off-fallback)" "$OUT_NOBUN"; fi
 if [[ ! -f "${CATALYST_DIR_NOBUN}/coordination-publish.pid" ]]; then pass "bun-missing: writes NO PID file"; else failx "bun-missing: writes NO PID file"; fi
+
+# --- reconcile-on-off: mode=off while a publisher is live ⇒ stop it, no PID file ---
+# Codex P1: the daemon reads config only at startup, so a prior shadow/enforce process
+# must be STOPPED when the resolved mode flips to off — not left mirroring/egressing.
+CDIR_R="${SCRATCH}/catalyst-reconcile"; mkdir -p "$CDIR_R"
+OUT_R="$(PATH="${STUB_OFF}:${PATH}" CATALYST_DIR="$CDIR_R" COORD_FAKE="$FAKE_PUB" \
+  bash --noprofile --norc -c '
+    source "'"${STACK}"'" 2>/dev/null || true
+    COORDINATION_SCRIPT="$COORD_FAKE"
+    bash "$COORDINATION_SCRIPT" & echo $! > "$COORDINATION_PID"
+    sleep 1
+    livepid="$(cat "$COORDINATION_PID")"
+    start_coordination; echo "RC=$?"
+    sleep 1
+    if kill -0 "$livepid" 2>/dev/null; then echo "PROC_ALIVE"; kill -9 "$livepid" 2>/dev/null; else echo "PROC_DEAD"; fi
+    [[ -f "$COORDINATION_PID" ]] && echo "PIDFILE_PRESENT" || echo "PIDFILE_GONE"
+  ' 2>&1)"
+if grep -q 'RC=0' <<<"$OUT_R"; then pass "reconcile-off: returns 0"; else failx "reconcile-off: returns 0" "$OUT_R"; fi
+if grep -qi 'stale config' <<<"$OUT_R"; then pass "reconcile-off: logs the stale-config stop"; else failx "reconcile-off: logs the stale-config stop" "$OUT_R"; fi
+if grep -q 'PROC_DEAD' <<<"$OUT_R"; then pass "reconcile-off: stops the live publisher"; else failx "reconcile-off: stops the live publisher" "$OUT_R"; fi
+if grep -q 'PIDFILE_GONE' <<<"$OUT_R"; then pass "reconcile-off: removes the PID file"; else failx "reconcile-off: removes the PID file" "$OUT_R"; fi
+
+# --- bounded shutdown: a SIGTERM-ignoring publisher survives the grace window, then
+#     is SIGKILLed — proves stop_coordination waits for the flush instead of a hard 1s.
+CDIR_S="${SCRATCH}/catalyst-stopgrace"; mkdir -p "$CDIR_S"
+OUT_S="$(CATALYST_DIR="$CDIR_S" COORD_FAKE="$FAKE_PUB" COORDINATION_STOP_GRACE_SECONDS=2 \
+  bash --noprofile --norc -c '
+    source "'"${STACK}"'" 2>/dev/null || true
+    COORDINATION_SCRIPT="$COORD_FAKE"
+    IGNORE_TERM=1 bash "$COORDINATION_SCRIPT" & echo $! > "$COORDINATION_PID"
+    sleep 1
+    livepid="$(cat "$COORDINATION_PID")"
+    t0="$SECONDS"; stop_coordination; t1="$SECONDS"
+    if kill -0 "$livepid" 2>/dev/null; then echo "STILL_ALIVE"; kill -9 "$livepid" 2>/dev/null; else echo "KILLED"; fi
+    echo "ELAPSED=$((t1 - t0))"
+  ' 2>&1)"
+if grep -q 'KILLED' <<<"$OUT_S"; then pass "stop-grace: SIGKILLs a SIGTERM-ignoring publisher"; else failx "stop-grace: SIGKILLs a SIGTERM-ignoring publisher" "$OUT_S"; fi
+if grep -qi 'forcing SIGKILL' <<<"$OUT_S"; then pass "stop-grace: warns before forcing"; else failx "stop-grace: warns before forcing" "$OUT_S"; fi
+ELAPSED_S="$(grep -o 'ELAPSED=[0-9]*' <<<"$OUT_S" | cut -d= -f2)"
+if [[ -n "$ELAPSED_S" && "$ELAPSED_S" -ge 2 ]]; then pass "stop-grace: honors the ${ELAPSED_S}s graceful window (≥2s)"; else failx "stop-grace: honors the graceful window (≥2s)" "$OUT_S"; fi
+
+# --- PID-discovery fallback: PID file deleted, but a publisher is still live ⇒
+#     coordination_pid rediscovers it by command line (Codex P1: no orphan/dup).
+CDIR_D="${SCRATCH}/catalyst-discover"; mkdir -p "$CDIR_D"
+OUT_D="$(CATALYST_DIR="$CDIR_D" COORD_FAKE="$FAKE_PUB" \
+  bash --noprofile --norc -c '
+    source "'"${STACK}"'" 2>/dev/null || true
+    COORDINATION_SCRIPT="$COORD_FAKE"
+    bash "$COORDINATION_SCRIPT" & realpid=$!
+    sleep 1
+    rm -f "$COORDINATION_PID"      # simulate a lost/corrupt PID file
+    found="$(coordination_pid)"
+    echo "FOUND=[$found] REAL=[$realpid]"
+    kill -9 "$realpid" 2>/dev/null
+  ' 2>&1)"
+REAL_D="$(grep -o 'REAL=\[[0-9]*\]' <<<"$OUT_D" | grep -o '[0-9]*')"
+if [[ -n "$REAL_D" ]] && grep -q "FOUND=\[${REAL_D}\]" <<<"$OUT_D"; then pass "pid-discovery: rediscovers the publisher after PID-file loss"; else failx "pid-discovery: rediscovers the publisher after PID-file loss" "$OUT_D"; fi
 
 echo ""
 echo "  ${PASSES} passed, ${FAILURES} failed"

--- a/plugins/dev/scripts/__tests__/catalyst-stack-start-node-class.test.sh
+++ b/plugins/dev/scripts/__tests__/catalyst-stack-start-node-class.test.sh
@@ -50,7 +50,7 @@ INVOCATIONS="${SCRATCH}/invocations"
 # Stub every service command to record which ones were called.
 make_stubs() {
   rm -f "$INVOCATIONS"
-  for svc in start_monitor start_broker start_daemon start_forward start_shipper start_event_mirror; do
+  for svc in start_monitor start_broker start_daemon start_forward start_shipper start_event_mirror start_coordination; do
     echo "recorded: ${svc}" >> "${SCRATCH}/stub_src_${svc}"
   done
 }
@@ -79,6 +79,7 @@ start_daemon()        { echo start_daemon >> "\${INVOCATIONS_FILE}"; }
 start_forward()       { echo start_forward >> "\${INVOCATIONS_FILE}"; }
 start_shipper()       { echo start_shipper >> "\${INVOCATIONS_FILE}"; return 0; }
 start_event_mirror()  { echo start_event_mirror >> "\${INVOCATIONS_FILE}"; return 0; }
+start_coordination()  { echo start_coordination >> "\${INVOCATIONS_FILE}"; return 0; }
 # Suppress the trailing cmd_status call.
 cmd_status()          { :; }
 _cloud_token_env_run() { :; }
@@ -113,6 +114,7 @@ check "monitor: start_forward called" assert_called start_forward
 check "monitor: start_daemon NOT called" assert_not_called start_daemon
 check "monitor: start_shipper NOT called" assert_not_called start_shipper
 check "monitor: start_event_mirror called" assert_called start_event_mirror
+check "monitor: start_coordination called" assert_called start_coordination
 
 echo ""
 
@@ -126,6 +128,7 @@ check "worker: start_forward called" assert_called start_forward
 check "worker: start_daemon called" assert_called start_daemon
 check "worker: start_shipper called" assert_called start_shipper
 check "worker: start_event_mirror NOT called" assert_not_called start_event_mirror
+check "worker: start_coordination called" assert_called start_coordination
 
 echo ""
 
@@ -139,6 +142,7 @@ check "developer: start_forward NOT called" assert_not_called start_forward
 check "developer: start_daemon NOT called" assert_not_called start_daemon
 check "developer: start_shipper NOT called" assert_not_called start_shipper
 check "developer: start_event_mirror called" assert_called start_event_mirror
+check "developer: start_coordination NOT called" assert_not_called start_coordination
 
 echo ""
 echo "=== Phase 2: _resolve_node_class fail-closed on invalid config (Codex P2 F5) ==="

--- a/plugins/dev/scripts/__tests__/catalyst-stack.test.sh
+++ b/plugins/dev/scripts/__tests__/catalyst-stack.test.sh
@@ -151,6 +151,14 @@ run "status lists execution-core" bash -c "
   PATH='${STUBDIR}:${REAL_PATH}' '${STACK}' status 2>&1 | grep -q execution-core
 "
 
+# CTL-1494: status must inventory the coordination-publish daemon. With no
+# CATALYST_COORDINATION_MODE set (default off) the line reads
+# 'coordination     off (inert)'; must remain green even with no bun on PATH
+# (coordination_mode falls back to off).
+run "status lists coordination" bash -c "
+  PATH='${STUBDIR}:${REAL_PATH}' '${STACK}' status 2>&1 | grep -q coordination
+"
+
 run "stop exits 0" bash -c "
   PATH='${STUBDIR}:${REAL_PATH}' '${STACK}' stop >/dev/null 2>&1
 "

--- a/plugins/dev/scripts/catalyst-stack
+++ b/plugins/dev/scripts/catalyst-stack
@@ -498,29 +498,30 @@ _coordination_lock_stale() {
 # publisher (Codex P1). The design is deliberately single-primitive — one mkdir
 # lock, no secondary mutex — because a nested reclaim mutex only RELOCATES the
 # stale-lock race up a level (each layer's own age-check + removal is itself a
-# TOCTOU). Two invariants make reclaim structurally unable to remove a live lock,
-# so `mkdir` stays the SOLE arbiter of ownership and double-spawn is impossible:
+# TOCTOU). `mkdir` is the SOLE arbiter of ownership: ownership is ONLY ever a
+# successful `mkdir "$COORDINATION_LOCK"`, and every reclaim path `continue`s and
+# must win a fresh mkdir to proceed. A live holder records its PID in a sentinel
+# file inside the lock dir immediately after acquiring.
 #
-#   1. Ownership is ONLY ever a successful `mkdir "$COORDINATION_LOCK"`. Every
-#      reclaim path `continue`s and must win a fresh mkdir to proceed.
-#   2. A live holder writes a sentinel file into the lock dir immediately after
-#      acquiring, and reclaim removes a stale lock with `rmdir` — which REFUSES a
-#      non-empty directory. So a live (sentinel-bearing) lock can never be removed
-#      by a reclaimer; the age gate additionally covers the microsecond
-#      mkdir→sentinel window (a fresh lock is age ~0, far under the threshold).
-#
-# Two reclaimers racing a genuinely-stale (empty, aged) lock both `rmdir` it
-# (idempotent) then both `mkdir` — mkdir arbitrates a single winner; the loser sees
-# the winner's fresh lock and skips. (A lock leaked by SIGKILL/power-loss AFTER the
-# sentinel write is non-empty, so rmdir won't auto-clear it — force-removing it
-# would reintroduce exactly the ABA double-spawn race, so we deliberately don't;
-# it's cleared out-of-band, and impact is bounded since coordination-publish is
-# off by default.)
+# Reclaim (lock held, mkdir failed) fires only past the age gate — old enough that
+# no live sub-minute check-and-spawn could still hold it — and then:
+#   * empty carcass (crashed before the sentinel write) → `rmdir` (refuses a
+#     non-empty dir, so it can never touch a sentinel-bearing lock);
+#   * sentinel present but its recorded owner PID is DEAD (crash/power-off AFTER the
+#     sentinel write — the case a pure rmdir scheme would wedge until manual
+#     deletion) → atomic-rename takeover: `mv` the carcass to a private name; only
+#     one racer's rename of that inode succeeds, so it can't be split-brained.
+# A sentinel whose owner is still ALIVE is a live peer → skip. Two reclaimers of the
+# same carcass converge on a single mkdir winner; the loser sees the winner's fresh
+# lock (young → age gate; or live owner) and skips. The tight residual (two starts
+# racing the SAME dead-owner takeover within the mkdir window) is additionally
+# backstopped by _start_coordination_locked's own `coordination_pid` idempotency
+# check, which refuses to spawn when a publisher is already running.
 start_coordination() {
   local guard=0
   while true; do
     if mkdir "$COORDINATION_LOCK" 2>/dev/null; then
-      : > "$COORDINATION_LOCK/owner"   # sentinel: a live lock is non-empty → rmdir-proof
+      printf '%s' "$$" > "$COORDINATION_LOCK/owner"   # sentinel records the owner pid
       break
     fi
     guard=$((guard + 1))
@@ -528,14 +529,27 @@ start_coordination() {
       log "coordination-publish start already in progress — skipping this tick"
       return 0
     fi
-    # Reclaim ONLY an abandoned lock — old enough that no live check-and-spawn could
-    # still hold it. rmdir refuses a non-empty (live, sentinel-bearing) lock, so
-    # this can never delete a live lock; the age gate covers the mkdir→sentinel
-    # window. A fresh peer lock fails both the age gate and (once its sentinel
-    # lands) the rmdir, so a live peer is simply skipped.
-    if _coordination_lock_stale "$COORDINATION_LOCK" && rmdir "$COORDINATION_LOCK" 2>/dev/null; then
-      log "coordination-publish: reclaimed an abandoned start lock"
-      continue
+    if _coordination_lock_stale "$COORDINATION_LOCK"; then
+      local lock_owner; lock_owner="$(cat "$COORDINATION_LOCK/owner" 2>/dev/null || true)"
+      if [[ -z "$lock_owner" ]]; then
+        # Empty carcass (crashed before the sentinel write). rmdir refuses a
+        # non-empty dir, so this can never remove a sentinel-bearing lock.
+        if rmdir "$COORDINATION_LOCK" 2>/dev/null; then
+          log "coordination-publish: reclaimed an abandoned (empty) start lock"
+        fi
+        continue
+      fi
+      if ! pid_alive "$lock_owner"; then
+        # Sentinel present but its owner is confirmed dead — a crash-after-sentinel
+        # carcass. Atomic-rename takeover (single winner) so a stopped publisher
+        # doesn't stay wedged after reboot until manual deletion.
+        if mv "$COORDINATION_LOCK" "${COORDINATION_LOCK}.dead.$$" 2>/dev/null; then
+          rm -rf "${COORDINATION_LOCK}.dead.$$" 2>/dev/null || true
+          log "coordination-publish: reclaimed a dead-owner start lock (owner ${lock_owner})"
+        fi
+        continue
+      fi
+      # Owner alive → a live peer holding the lock past the age gate — skip.
     fi
     log "coordination-publish start already in progress — skipping this tick"
     return 0
@@ -1366,6 +1380,23 @@ render_stack_plist() {
     <key>CATALYST_LAYER2_CONFIG_FILE</key>
     <string>${CATALYST_LAYER2_CONFIG_FILE}</string>"
   fi
+  # CTL-1494 (Codex P1): pin the coordination env OVERRIDES the operator installed
+  # with, so the scheduled keep-alive resolves the SAME mode the operator intended.
+  # Without this, installing with the CATALYST_COORDINATION_MODE=0 kill-switch (while
+  # Layer-2 still says enforce) would leave the tick job resolving `enforce` and
+  # re-launching the publisher with network egress — silently undoing the kill. Same
+  # for CATALYST_COORDINATION_HUB_URL. Captured at install time; omitted when unset.
+  local coord_env=""
+  if [[ -n "${CATALYST_COORDINATION_MODE:-}" ]]; then
+    coord_env="${coord_env}
+    <key>CATALYST_COORDINATION_MODE</key>
+    <string>${CATALYST_COORDINATION_MODE}</string>"
+  fi
+  if [[ -n "${CATALYST_COORDINATION_HUB_URL:-}" ]]; then
+    coord_env="${coord_env}
+    <key>CATALYST_COORDINATION_HUB_URL</key>
+    <string>${CATALYST_COORDINATION_HUB_URL}</string>"
+  fi
   cat <<PLIST
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
@@ -1399,7 +1430,7 @@ render_stack_plist() {
     <key>PATH</key>
     <string>$(_stack_agent_path)</string>
     <key>HOME</key>
-    <string>${HOME}</string>${host_env}${layer2_env}
+    <string>${HOME}</string>${host_env}${layer2_env}${coord_env}
   </dict>
 
   <!--

--- a/plugins/dev/scripts/catalyst-stack
+++ b/plugins/dev/scripts/catalyst-stack
@@ -185,6 +185,18 @@ SHIPPER_STORAGE="${CATALYST_DIR:-$HOME/catalyst}/alloy-data"
 SHIPPER_CONFIG="${SCRIPT_DIR}/log-shipper/config.alloy"
 SHIPPER_LAUNCHER="${SCRIPT_DIR}/log-shipper/launch.sh"
 
+# CTL-1494: the coordination-publish daemon (CTL-1488 Phase 3). A raw bun `.ts`
+# with no CLI wrapper, so — like the log-shipper above — catalyst-stack owns its
+# pid/log inline via the self-managed nohup-child idiom. These paths are distinct
+# from the daemon's own mirror (~/catalyst/coordination.jsonl), checkpoint
+# (coordination-publish.checkpoint.json), and DLQ (coordination-publish-dlq.jsonl)
+# — no clobber. The daemon self-exits when the resolved mode is `off` (ADR-023),
+# which coordination_mode() short-circuits so we never spawn a bun that immediately
+# dies (and never false-alarm the post-launch liveness re-check on that self-exit).
+COORDINATION_PID="${CATALYST_DIR:-$HOME/catalyst}/coordination-publish.pid"
+COORDINATION_LOG="${CATALYST_DIR:-$HOME/catalyst}/coordination-publish.log"
+COORDINATION_SCRIPT="${SCRIPT_DIR}/coordination-publish/index.ts"
+
 # CTL-1348: the standalone catalyst-updater daemon (the 5th launchd agent). Installed
 # ONLY by the explicit 'catalyst-stack adopt-updater' cutover — NOT by install-services,
 # which is re-run routinely and would silently cut nodes over. UPDATER_LOG matches the
@@ -381,6 +393,100 @@ stop_shipper() {
     log "log-shipper not running"
   fi
   rm -f "$SHIPPER_PID"
+}
+
+# ─── coordination-publish (CTL-1494 / CTL-1488) ──────────────────────────────
+# Lifecycle primitives for the coordination-publish daemon, mirroring the
+# shipper_* nohup-child template. The daemon is inert-by-default (ADR-023: mode
+# `off` → process.exit(0)); coordination_mode() resolves the SAME mode the daemon
+# would, so start_coordination short-circuits cleanly on `off` instead of spawning
+# a bun that immediately self-exits.
+
+# coordination_mode — resolve the coordination mode IDENTICALLY to the daemon's own
+# readCoordinationConfig() (env kill-switch/override > Layer-2 > default off), by
+# importing config.mjs under bun. Fail-CLOSED to "off" on any bun/import failure —
+# a bun-less host cannot run the bun daemon anyway, so inert is the correct posture.
+coordination_mode() {
+  local cfgmjs="${SCRIPT_DIR}/execution-core/config.mjs"
+  if command -v bun >/dev/null 2>&1 && [[ -f "$cfgmjs" ]]; then
+    local out
+    if out="$(CFG_MJS="$cfgmjs" bun -e '
+        const m = await import(process.env.CFG_MJS);
+        try { process.stdout.write(String(m.readCoordinationConfig().mode || "off")); }
+        catch { process.stdout.write("off"); }
+      ' 2>/dev/null)" && [[ -n "$out" ]]; then
+      printf '%s' "$out"; return 0
+    fi
+  fi
+  printf 'off'
+}
+
+# coordination_pid — print the live coordination-publish pid recorded in
+# COORDINATION_PID, or nothing. Validates the pid is alive AND is actually the
+# coordination-publish process (guards pid reuse), mirroring shipper_pid.
+coordination_pid() {
+  local pid
+  [[ -f "$COORDINATION_PID" ]] || return 0
+  pid="$(cat "$COORDINATION_PID" 2>/dev/null || true)"
+  [[ -n "$pid" ]] || return 0
+  pid_alive "$pid" || return 0
+  if ps -p "$pid" -o command= 2>/dev/null | grep -q 'coordination-publish'; then
+    printf '%s\n' "$pid"
+  fi
+}
+
+start_coordination() {
+  # 0. MODE GATE — off (default) is a clean no-op (ADR-023 inert contract). Also
+  #    covers the bun-less host (coordination_mode → off), so no launch is attempted
+  #    there. Short-circuiting here means the sleep-1 liveness re-check below only
+  #    runs in shadow/enforce, where a fast exit genuinely IS a failure.
+  local mode; mode="$(coordination_mode)"
+  if [[ "$mode" == "off" ]]; then
+    log "coordination-publish mode=off — inert, skipping"
+    return 0
+  fi
+  # 1. IDEMPOTENT — never double-start a live daemon (re-run every 600s keep-alive tick).
+  local pid; pid="$(coordination_pid)"
+  if pid_alive "$pid"; then
+    log "coordination-publish already running (pid $pid, mode $mode)"
+    return 0
+  fi
+  # 2. MISSING-BINARY LOUD, NON-FATAL (shipper posture — return 1, never exit).
+  if ! command -v bun >/dev/null 2>&1; then
+    warn "bun not found — coordination-publish NOT started (mode=$mode)"
+    return 1
+  fi
+  # 3. Entrypoint presence guard.
+  if [[ ! -f "$COORDINATION_SCRIPT" ]]; then
+    warn "coordination-publish entrypoint missing at $COORDINATION_SCRIPT — skipping"
+    return 1
+  fi
+  # 4. Launch detached (the daemon reads CATALYST_DIR/EVENTS_DIR + config from env/Layer-2).
+  log "starting coordination-publish (mode: $mode, log: $COORDINATION_LOG)"
+  nohup bun run "$COORDINATION_SCRIPT" >"$COORDINATION_LOG" 2>&1 &
+  echo $! > "$COORDINATION_PID"
+  disown $! 2>/dev/null || true
+  sleep 1
+  pid="$(coordination_pid)"
+  if pid_alive "$pid"; then
+    log "  → coordination-publish started (pid $pid)"
+  else
+    warn "coordination-publish failed to start — see $COORDINATION_LOG"
+    return 1
+  fi
+}
+
+stop_coordination() {
+  local pid; pid="$(coordination_pid)"
+  if pid_alive "$pid"; then
+    log "stopping coordination-publish (pid $pid)"
+    kill "$pid" 2>/dev/null            # daemon traps SIGTERM → graceful flush + checkpoint
+    sleep 1
+    pid_alive "$pid" && kill -9 "$pid" 2>/dev/null || true
+  else
+    log "coordination-publish not running"
+  fi
+  rm -f "$COORDINATION_PID"
 }
 
 start_broker()   { catalyst-broker start 2>&1 | sed 's/^/  /'; }
@@ -780,6 +886,14 @@ cmd_start() {
   if [[ "$node_class" != "developer" ]]; then
     start_forward
   fi
+  # CTL-1494: coordination-publish follows the reporting substrate (worker + monitor,
+  # gated != developer, same as start_forward). Non-fatal — a broken/absent publisher
+  # must never block the stack (CTL-988 non-load-bearing). When the mode resolves to
+  # `off` (the default) start_coordination is a clean no-op, so this is byte-identical
+  # inert on an unconfigured node.
+  if [[ "$node_class" != "developer" ]]; then
+    start_coordination || warn "continuing without coordination-publish (coordination mirror won't be written)"
+  fi
   # CTL-1263: the log-shipper comes up LAST — it only tails the daemons' .log
   # files, so it should start after the daemons it observes. start_shipper is
   # idempotent + non-fatal (warns loudly on a missing binary, returns 1).
@@ -813,6 +927,9 @@ cmd_stop() {
   stop_shipper
   # CTL-1654: stop event-mirror on observation nodes; idempotent no-op on workers.
   stop_event_mirror
+  # CTL-1494: coordination-publish started after forward/before shipper, so stop it
+  # here (after the shipper/event-mirror, before stop_daemon/stop_forward).
+  stop_coordination
   stop_daemon
   stop_forward
   stop_monitor
@@ -852,6 +969,16 @@ cmd_status() {
   echo -n "  monitor          "; catalyst-monitor status 2>&1 | head -1
   echo -n "  execution-core   "; catalyst-execution-core status 2>&1 | head -1
   echo -n "  otel-forward     "; catalyst-monitor forward-status 2>&1 | head -1
+  # CTL-1494: coordination-publish. off (the default / bun-less host) reports
+  # "off (inert)"; otherwise report running+pid+mode or stopped+mode.
+  local cmode; cmode="$(coordination_mode)"
+  if [[ "$cmode" == "off" ]]; then
+    echo "  coordination     off (inert)"
+  else
+    local cp; cp="$(coordination_pid)"
+    if pid_alive "$cp"; then echo "  coordination     running  pid=$cp  mode=$cmode"
+    else echo "  coordination     stopped  mode=$cmode"; fi
+  fi
   # CTL-1285: when the dedicated KeepAlive agent owns Alloy it writes no pidfile,
   # so detect it by plist + a live `alloy run` matching our config. Falling back to
   # the pidfile-only check would mis-report a launchd-managed shipper as "stopped".

--- a/plugins/dev/scripts/catalyst-stack
+++ b/plugins/dev/scripts/catalyst-stack
@@ -205,6 +205,10 @@ COORDINATION_FP="${CATALYST_DIR:-$HOME/catalyst}/coordination-publish.fingerprin
 # drains through the hub with 5s request timeouts + retries, so one second is not
 # enough (Codex P1: let the shutdown flush finish before forcing termination).
 COORDINATION_STOP_GRACE_SECONDS="${COORDINATION_STOP_GRACE_SECONDS:-30}"
+# Atomic start lock (a directory — mkdir is the repo's portable lock idiom, see
+# catalyst-state.sh; flock is absent on stock macOS). Serializes check-and-spawn so
+# two overlapping starts can't both pass the pid check and both spawn (Codex P1).
+COORDINATION_LOCK="${CATALYST_DIR:-$HOME/catalyst}/coordination-publish.start.lock"
 
 # CTL-1348: the standalone catalyst-updater daemon (the 5th launchd agent). Installed
 # ONLY by the explicit 'catalyst-stack adopt-updater' cutover — NOT by install-services,
@@ -472,7 +476,36 @@ coordination_resolve() {
   printf 'off\t'
 }
 
+# start_coordination — serialize the whole check-and-spawn under an atomic mkdir
+# lock so two overlapping invocations (the recurring stack LaunchAgent tick + a
+# manual or second `catalyst-stack start`) can't both pass the pid check and both
+# spawn a detached publisher — a TOCTOU the pid-rediscovery fallback alone can't
+# close, since it selects one match and doesn't serialize check-and-spawn (Codex
+# P1). The lock is held only across check-and-spawn, so contention is a keep-alive
+# tick racing a manual start — the loser skips the tick (the winner establishes the
+# single publisher) rather than queueing a redundant spawn.
 start_coordination() {
+  local tries=0
+  while ! mkdir "$COORDINATION_LOCK" 2>/dev/null; do
+    # Reclaim a stale lock from a crashed start (mtime older than the threshold —
+    # comfortably above the <1min a real check-and-spawn takes, even with a 30s
+    # stop-grace on a config-change restart), so a crash can't wedge startup.
+    if [[ "$tries" -lt 3 && -n "$(find "$COORDINATION_LOCK" -maxdepth 0 -mmin +"${COORDINATION_LOCK_STALE_MIN:-5}" 2>/dev/null)" ]]; then
+      log "coordination-publish: reclaiming stale start lock"
+      rmdir "$COORDINATION_LOCK" 2>/dev/null || true
+      tries=$((tries + 1)); continue
+    fi
+    # Held by a concurrent, live start — it will establish the publisher.
+    log "coordination-publish start already in progress — skipping this tick"
+    return 0
+  done
+  local rc=0
+  _start_coordination_locked || rc=$?
+  rmdir "$COORDINATION_LOCK" 2>/dev/null || true
+  return "$rc"
+}
+
+_start_coordination_locked() {
   # Resolve mode + hubUrl exactly as the daemon would, in ONE bun import, and
   # fingerprint them. The daemon reads its config only at startup, so this
   # fingerprint is how a keep-alive tick notices a config change and reconciles.

--- a/plugins/dev/scripts/catalyst-stack
+++ b/plugins/dev/scripts/catalyst-stack
@@ -520,31 +520,38 @@ _coordination_lock_stale() {
 # Impact is minimal: coordination-publish is off by default, the leak window is a
 # sub-second SIGKILL, and `_start_coordination_locked`'s `coordination_pid` check is
 # an independent belt-and-suspenders against a running publisher being duplicated.
-start_coordination() {
+# _coordination_lock_acquire — win the start lock. mkdir is the sole ownership
+# arbiter; reclaim ONLY an EMPTY, aged carcass (rmdir refuses a non-empty dir, so it
+# can never remove a live/leaked lock; the age gate covers the mkdir→sentinel
+# window). Returns 0 acquired, 1 if held by a live peer / non-empty leak. Shared by
+# start AND stop so the two lifecycle transitions serialize (Codex P1).
+_coordination_lock_acquire() {
   local guard=0
   while true; do
     if mkdir "$COORDINATION_LOCK" 2>/dev/null; then
       : > "$COORDINATION_LOCK/owner"   # sentinel: a live lock is non-empty → rmdir-proof
-      break
-    fi
-    guard=$((guard + 1))
-    if [[ "$guard" -gt 8 ]]; then
-      log "coordination-publish start already in progress — skipping this tick"
       return 0
     fi
-    # Reclaim ONLY an EMPTY, aged carcass. rmdir refuses a non-empty (sentinel-
-    # bearing) lock, so this can never remove a live lock; the age gate covers the
-    # microsecond mkdir→sentinel window. A live/leaked non-empty lock → skip.
+    guard=$((guard + 1))
+    [[ "$guard" -gt 8 ]] && return 1
     if _coordination_lock_stale "$COORDINATION_LOCK" && rmdir "$COORDINATION_LOCK" 2>/dev/null; then
       log "coordination-publish: reclaimed an abandoned (empty) start lock"
       continue
     fi
+    return 1
+  done
+}
+
+_coordination_lock_release() { rm -rf "$COORDINATION_LOCK" 2>/dev/null || true; }
+
+start_coordination() {
+  if ! _coordination_lock_acquire; then
     log "coordination-publish start already in progress — skipping this tick"
     return 0
-  done
+  fi
   local rc=0
   _start_coordination_locked || rc=$?
-  rm -rf "$COORDINATION_LOCK" 2>/dev/null || true   # release (contains the sentinel)
+  _coordination_lock_release
   return "$rc"
 }
 
@@ -578,7 +585,7 @@ _start_coordination_locked() {
   if [[ "$mode" == "off" ]]; then
     if pid_alive "$pid"; then
       log "coordination-publish mode=off but pid $pid still live (stale config) — stopping"
-      stop_coordination
+      _stop_coordination_unlocked   # we already hold the start lock
     else
       log "coordination-publish mode=off — inert, skipping"
     fi
@@ -595,7 +602,7 @@ _start_coordination_locked() {
       return 0
     fi
     log "coordination-publish config changed (${live_fp:-<unknown>} → $fp) — restarting (pid $pid)"
-    stop_coordination
+    _stop_coordination_unlocked   # we already hold the start lock
     pid=""
   fi
   # 2. MISSING-BINARY LOUD, NON-FATAL (shipper posture — return 1, never exit).
@@ -624,7 +631,26 @@ _start_coordination_locked() {
   fi
 }
 
+# stop_coordination — public stop. Serializes against an in-flight start by taking
+# the SAME start lock (Codex P1): otherwise a manual stop racing a scheduled start
+# (after start acquired the lock but before it wrote the PID file) sees no publisher,
+# returns, and the start then spawns a detached publisher AFTER the stop completed —
+# leaving mirroring/egress running despite a successful stop. Bounded wait for the
+# in-flight start to finish; if the lock can't be taken (still in-flight, or a
+# non-empty leak), fall through and stop best-effort anyway — stopping is always
+# safe. Internal callers that already hold the lock use _stop_coordination_unlocked.
 stop_coordination() {
+  local got=0 tries=0
+  while [[ "$tries" -lt "${COORDINATION_STOP_LOCK_WAIT_SECONDS:-15}" ]]; do
+    if _coordination_lock_acquire; then got=1; break; fi
+    tries=$((tries + 1)); sleep 1
+  done
+  _stop_coordination_unlocked
+  [[ "$got" == "1" ]] && _coordination_lock_release
+  return 0
+}
+
+_stop_coordination_unlocked() {
   local pid; pid="$(coordination_pid)"
   if pid_alive "$pid"; then
     log "stopping coordination-publish (pid $pid)"
@@ -1345,15 +1371,12 @@ _stack_agent_path() {
 
 # _xml_escape <value> — escape the five XML predefined entities so an env value with
 # a metacharacter (e.g. a hub URL like https://h/p?x=1&y=2) can't emit a malformed
-# plist that launchd then refuses to load (Codex P2). `&` MUST be substituted first.
+# plist that launchd then refuses to load (Codex P2). Uses sed, NOT bash `${//}`
+# substitution: under Bash 5's default `patsub_replacement`, an unescaped `&` in the
+# replacement expands to the matched text (so `<` would wrongly become `<lt;`). `&`
+# MUST be substituted first; in sed replacements a literal `&` is written `\&`.
 _xml_escape() {
-  local s="$1"
-  s="${s//&/&amp;}"
-  s="${s//</&lt;}"
-  s="${s//>/&gt;}"
-  s="${s//\"/&quot;}"
-  s="${s//\'/&apos;}"
-  printf '%s' "$s"
+  printf '%s' "$1" | sed -e 's/&/\&amp;/g' -e 's/</\&lt;/g' -e 's/>/\&gt;/g' -e 's/"/\&quot;/g' -e "s/'/\&apos;/g"
 }
 
 # render_stack_plist <cmd> <interval> [host_name] — emit the LaunchAgent plist XML to stdout.
@@ -1380,6 +1403,15 @@ render_stack_plist() {
     catdir_env="
     <key>CATALYST_DIR</key>
     <string>$(_xml_escape "${CATALYST_DIR}")</string>"
+  fi
+  # CTL-1494 (Codex P2): pin CATALYST_EVENTS_DIR too — the publisher tails this
+  # directory, so a supported override must ride into the scheduled env or a
+  # post-reboot/restart start tails $CATALYST_DIR/events and misses events written
+  # to the configured directory. Captured at install time; omitted when unset.
+  if [[ -n "${CATALYST_EVENTS_DIR:-}" ]]; then
+    catdir_env="${catdir_env}
+    <key>CATALYST_EVENTS_DIR</key>
+    <string>$(_xml_escape "${CATALYST_EVENTS_DIR}")</string>"
   fi
   # CTL-1494 (Codex P2): pin the operator's Layer-2 config path into the agent env.
   # launchd hands the keep-alive an otherwise-minimal environment, so without this a

--- a/plugins/dev/scripts/catalyst-stack
+++ b/plugins/dev/scripts/catalyst-stack
@@ -196,6 +196,15 @@ SHIPPER_LAUNCHER="${SCRIPT_DIR}/log-shipper/launch.sh"
 COORDINATION_PID="${CATALYST_DIR:-$HOME/catalyst}/coordination-publish.pid"
 COORDINATION_LOG="${CATALYST_DIR:-$HOME/catalyst}/coordination-publish.log"
 COORDINATION_SCRIPT="${SCRIPT_DIR}/coordination-publish/index.ts"
+# Resolved-config fingerprint (mode|hubUrl) captured at launch. The daemon reads
+# its config ONLY at startup, so a later keep-alive tick compares this against the
+# freshly-resolved config and bounces the process when they diverge (Codex P1:
+# reconcile a running publisher when its mode/hub changes).
+COORDINATION_FP="${CATALYST_DIR:-$HOME/catalyst}/coordination-publish.fingerprint"
+# Bounded graceful-shutdown window (seconds) before SIGKILL. Enforce-mode flush
+# drains through the hub with 5s request timeouts + retries, so one second is not
+# enough (Codex P1: let the shutdown flush finish before forcing termination).
+COORDINATION_STOP_GRACE_SECONDS="${COORDINATION_STOP_GRACE_SECONDS:-30}"
 
 # CTL-1348: the standalone catalyst-updater daemon (the 5th launchd agent). Installed
 # ONLY by the explicit 'catalyst-stack adopt-updater' cutover — NOT by install-services,
@@ -402,54 +411,107 @@ stop_shipper() {
 # would, so start_coordination short-circuits cleanly on `off` instead of spawning
 # a bun that immediately self-exits.
 
-# coordination_mode — resolve the coordination mode IDENTICALLY to the daemon's own
-# readCoordinationConfig() (env kill-switch/override > Layer-2 > default off), by
-# importing config.mjs under bun. Fail-CLOSED to "off" on any bun/import failure —
-# a bun-less host cannot run the bun daemon anyway, so inert is the correct posture.
+# coordination_mode — resolve just the coordination mode, IDENTICALLY to the
+# daemon's own readCoordinationConfig(). Thin wrapper over coordination_resolve()
+# (defined below) so mode + hubUrl always come from one resolution path.
 coordination_mode() {
+  local resolved; resolved="$(coordination_resolve)"
+  printf '%s' "${resolved%%$'\t'*}"
+}
+
+# coordination_pid — print the live coordination-publish pid, or nothing.
+# Prefers the pid recorded in COORDINATION_PID; both branches validate the pid is
+# alive AND is actually the coordination-publish process (guards pid reuse),
+# mirroring shipper_pid.
+#
+# Codex P1 (bounded supervisor): the nohup child reparents to init and outlives
+# this command, so its only handle is the PID file. If that file is deleted,
+# emptied, or overwritten, a naive lookup would (a) let `start` spawn a DUPLICATE
+# publisher and (b) leave `stop` unable to reach the original — an unbounded
+# orphan making network egress in enforce mode. So when the PID file can't resolve
+# a live publisher, fall back to discovering it by command line. That keeps `start`
+# idempotent and `stop` reachable regardless of PID-file state.
+coordination_pid() {
+  local pid
+  if [[ -f "$COORDINATION_PID" ]]; then
+    pid="$(cat "$COORDINATION_PID" 2>/dev/null || true)"
+    if [[ -n "$pid" ]] && pid_alive "$pid" \
+       && ps -p "$pid" -o command= 2>/dev/null | grep -q 'coordination-publish'; then
+      printf '%s\n' "$pid"; return 0
+    fi
+  fi
+  # Fallback: PID file missing/stale but a publisher may still be running. Discover
+  # by the entrypoint path, then re-confirm via the command grep (guards a match on
+  # this script or an unrelated process). head -1 picks the oldest match.
+  pid="$(pgrep -f "$COORDINATION_SCRIPT" 2>/dev/null | head -1 || true)"
+  if [[ -n "$pid" ]] && pid_alive "$pid" \
+     && ps -p "$pid" -o command= 2>/dev/null | grep -q 'coordination-publish'; then
+    printf '%s\n' "$pid"; return 0
+  fi
+  return 0
+}
+
+# coordination_resolve — print "<mode>\t<hubUrl>" resolved IDENTICALLY to the
+# daemon's own readCoordinationConfig() (env kill-switch/override > Layer-2 >
+# default off), via one bun import. Fail-CLOSED to "off\t" on any bun/import
+# failure — a bun-less host cannot run the bun daemon anyway, so inert is correct.
+coordination_resolve() {
   local cfgmjs="${SCRIPT_DIR}/execution-core/config.mjs"
   if command -v bun >/dev/null 2>&1 && [[ -f "$cfgmjs" ]]; then
     local out
     if out="$(CFG_MJS="$cfgmjs" bun -e '
         const m = await import(process.env.CFG_MJS);
-        try { process.stdout.write(String(m.readCoordinationConfig().mode || "off")); }
-        catch { process.stdout.write("off"); }
+        try {
+          const c = m.readCoordinationConfig();
+          process.stdout.write(String(c.mode || "off") + "\t" + String(c.hubUrl || ""));
+        } catch { process.stdout.write("off\t"); }
       ' 2>/dev/null)" && [[ -n "$out" ]]; then
       printf '%s' "$out"; return 0
     fi
   fi
-  printf 'off'
-}
-
-# coordination_pid — print the live coordination-publish pid recorded in
-# COORDINATION_PID, or nothing. Validates the pid is alive AND is actually the
-# coordination-publish process (guards pid reuse), mirroring shipper_pid.
-coordination_pid() {
-  local pid
-  [[ -f "$COORDINATION_PID" ]] || return 0
-  pid="$(cat "$COORDINATION_PID" 2>/dev/null || true)"
-  [[ -n "$pid" ]] || return 0
-  pid_alive "$pid" || return 0
-  if ps -p "$pid" -o command= 2>/dev/null | grep -q 'coordination-publish'; then
-    printf '%s\n' "$pid"
-  fi
+  printf 'off\t'
 }
 
 start_coordination() {
-  # 0. MODE GATE — off (default) is a clean no-op (ADR-023 inert contract). Also
-  #    covers the bun-less host (coordination_mode → off), so no launch is attempted
-  #    there. Short-circuiting here means the sleep-1 liveness re-check below only
-  #    runs in shadow/enforce, where a fast exit genuinely IS a failure.
-  local mode; mode="$(coordination_mode)"
+  # Resolve mode + hubUrl exactly as the daemon would, in ONE bun import, and
+  # fingerprint them. The daemon reads its config only at startup, so this
+  # fingerprint is how a keep-alive tick notices a config change and reconciles.
+  local resolved mode hub fp
+  resolved="$(coordination_resolve)"
+  mode="${resolved%%$'\t'*}"
+  hub="${resolved#*$'\t'}"
+  fp="${mode}|${hub}"
+
+  local pid; pid="$(coordination_pid)"
+
+  # 0. MODE GATE — off (default) is inert (ADR-023). But if a publisher is STILL
+  #    running from a prior shadow/enforce config (operator flipped Layer-2 to off,
+  #    or CATALYST_COORDINATION_MODE=0 kill-switch), it keeps mirroring and — in
+  #    enforce — making network requests until stopped, since it can't re-read
+  #    config in place. Reconcile by stopping it, THEN short-circuit (Codex P1).
+  #    Also covers the bun-less host (coordination_resolve → off): nothing to stop.
   if [[ "$mode" == "off" ]]; then
-    log "coordination-publish mode=off — inert, skipping"
+    if pid_alive "$pid"; then
+      log "coordination-publish mode=off but pid $pid still live (stale config) — stopping"
+      stop_coordination
+    else
+      log "coordination-publish mode=off — inert, skipping"
+    fi
     return 0
   fi
-  # 1. IDEMPOTENT — never double-start a live daemon (re-run every 600s keep-alive tick).
-  local pid; pid="$(coordination_pid)"
+  # 1. IDEMPOTENT — never double-start a live daemon (re-run every 600s keep-alive
+  #    tick), BUT bounce it when the resolved config changed since launch: the
+  #    daemon can't hot-reload mode/hubUrl, so a change requires a restart to take
+  #    effect (Codex P1: reconcile the running publisher when config changes).
   if pid_alive "$pid"; then
-    log "coordination-publish already running (pid $pid, mode $mode)"
-    return 0
+    local live_fp; live_fp="$(cat "$COORDINATION_FP" 2>/dev/null || true)"
+    if [[ "$live_fp" == "$fp" ]]; then
+      log "coordination-publish already running (pid $pid, mode $mode)"
+      return 0
+    fi
+    log "coordination-publish config changed (${live_fp:-<unknown>} → $fp) — restarting (pid $pid)"
+    stop_coordination
+    pid=""
   fi
   # 2. MISSING-BINARY LOUD, NON-FATAL (shipper posture — return 1, never exit).
   if ! command -v bun >/dev/null 2>&1; then
@@ -465,6 +527,7 @@ start_coordination() {
   log "starting coordination-publish (mode: $mode, log: $COORDINATION_LOG)"
   nohup bun run "$COORDINATION_SCRIPT" >"$COORDINATION_LOG" 2>&1 &
   echo $! > "$COORDINATION_PID"
+  printf '%s' "$fp" > "$COORDINATION_FP"   # record the config this pid was launched with
   disown $! 2>/dev/null || true
   sleep 1
   pid="$(coordination_pid)"
@@ -481,12 +544,23 @@ stop_coordination() {
   if pid_alive "$pid"; then
     log "stopping coordination-publish (pid $pid)"
     kill "$pid" 2>/dev/null            # daemon traps SIGTERM → graceful flush + checkpoint
-    sleep 1
-    pid_alive "$pid" && kill -9 "$pid" 2>/dev/null || true
+    # Codex P1: give the graceful flush a bounded window to finish before forcing.
+    # An enforce-mode publisher drains through the hub (5s request timeouts +
+    # retries), so a 1s deadline would SIGKILL mid-flush and drop coordination rows
+    # that mirror-dedup then never rebuilds. Poll (sleep, don't spin) up to the
+    # grace bound; only then force. No `timeout(1)` dep — stock macOS lacks it.
+    local waited=0
+    while pid_alive "$pid" && [[ "$waited" -lt "$COORDINATION_STOP_GRACE_SECONDS" ]]; do
+      sleep 1; waited=$((waited + 1))
+    done
+    if pid_alive "$pid"; then
+      warn "coordination-publish pid $pid still alive after ${COORDINATION_STOP_GRACE_SECONDS}s — forcing SIGKILL"
+      kill -9 "$pid" 2>/dev/null || true
+    fi
   else
     log "coordination-publish not running"
   fi
-  rm -f "$COORDINATION_PID"
+  rm -f "$COORDINATION_PID" "$COORDINATION_FP"
 }
 
 start_broker()   { catalyst-broker start 2>&1 | sed 's/^/  /'; }

--- a/plugins/dev/scripts/catalyst-stack
+++ b/plugins/dev/scripts/catalyst-stack
@@ -489,11 +489,20 @@ coordination_resolve() {
 # P1). The lock is held only across check-and-spawn, so contention is a keep-alive
 # tick racing a manual start — the loser skips the tick (the winner establishes the
 # single publisher) rather than queueing a redundant spawn.
+# _coordination_lock_stale — true if the lock dir at $1 is older than the stale
+# threshold (mtime, via portable `find -mmin`). Both the main lock and the reclaim
+# mutex are held only briefly (the main across a sub-minute check-and-spawn incl. a
+# 30s stop-grace; the reclaim across a sub-second age-check + rmdir), so anything
+# past the threshold is an abandoned lock from a crashed start / powered-off host.
+_coordination_lock_stale() {
+  [[ -n "$(find "$1" -maxdepth 0 -mmin +"${COORDINATION_LOCK_STALE_MIN:-5}" 2>/dev/null)" ]]
+}
+
 start_coordination() {
   local guard=0
   while ! mkdir "$COORDINATION_LOCK" 2>/dev/null; do
     guard=$((guard + 1))
-    if [[ "$guard" -gt 5 ]]; then
+    if [[ "$guard" -gt 8 ]]; then
       log "coordination-publish start already in progress — skipping this tick"
       return 0
     fi
@@ -506,17 +515,28 @@ start_coordination() {
     # the main lock dir exists nobody can mkdir it, so removing it here — after
     # re-confirming staleness under the mutex — can never delete a live lock.
     if mkdir "$COORDINATION_RECLAIM_LOCK" 2>/dev/null; then
-      if [[ -n "$(find "$COORDINATION_LOCK" -maxdepth 0 -mmin +"${COORDINATION_LOCK_STALE_MIN:-5}" 2>/dev/null)" ]]; then
+      if _coordination_lock_stale "$COORDINATION_LOCK"; then
         log "coordination-publish: reclaiming stale start lock"
         rmdir "$COORDINATION_LOCK" 2>/dev/null || true
         rmdir "$COORDINATION_RECLAIM_LOCK" 2>/dev/null || true
         continue    # stale cleared — contend for a fresh mkdir
       fi
+      # Main lock is live (a peer's in-flight start) — leave it, skip this tick.
       rmdir "$COORDINATION_RECLAIM_LOCK" 2>/dev/null || true
+      log "coordination-publish start already in progress — skipping this tick"
+      return 0
     fi
-    # A live peer holds the lock, or another start owns the in-flight reclaim
-    # decision — either way it will establish the single publisher; skip this tick
-    # rather than pile a redundant spawn on.
+    # Couldn't take the reclaim mutex. If IT is stale, a start was killed / the host
+    # powered off after acquiring it but before releasing — recover it too, else it
+    # would wedge every future tick (Codex P2). Removing an abandoned reclaim mutex
+    # is benign even under a race (it guards only the decision, not the spawn — the
+    # eventual re-mkdir has a single winner). If it's fresh, a live peer owns the
+    # in-flight reclaim decision: skip.
+    if _coordination_lock_stale "$COORDINATION_RECLAIM_LOCK"; then
+      log "coordination-publish: reclaiming abandoned reclaim mutex"
+      rmdir "$COORDINATION_RECLAIM_LOCK" 2>/dev/null || true
+      continue
+    fi
     log "coordination-publish start already in progress — skipping this tick"
     return 0
   done

--- a/plugins/dev/scripts/catalyst-stack
+++ b/plugins/dev/scripts/catalyst-stack
@@ -209,11 +209,6 @@ COORDINATION_STOP_GRACE_SECONDS="${COORDINATION_STOP_GRACE_SECONDS:-30}"
 # catalyst-state.sh; flock is absent on stock macOS). Serializes check-and-spawn so
 # two overlapping starts can't both pass the pid check and both spawn (Codex P1).
 COORDINATION_LOCK="${CATALYST_DIR:-$HOME/catalyst}/coordination-publish.start.lock"
-# Reclaim mutex: serializes the stale-lock takeover DECISION so two overlapping
-# starts can't both age-check the same stale lock and both remove+reacquire it —
-# an ownership-safe atomic takeover (Codex P1). Held only across the age-check +
-# removal (sub-second), never across the spawn.
-COORDINATION_RECLAIM_LOCK="${CATALYST_DIR:-$HOME/catalyst}/coordination-publish.reclaim.lock"
 
 # CTL-1348: the standalone catalyst-updater daemon (the 5th launchd agent). Installed
 # ONLY by the explicit 'catalyst-stack adopt-updater' cutover — NOT by install-services,
@@ -490,51 +485,56 @@ coordination_resolve() {
 # tick racing a manual start — the loser skips the tick (the winner establishes the
 # single publisher) rather than queueing a redundant spawn.
 # _coordination_lock_stale — true if the lock dir at $1 is older than the stale
-# threshold (mtime, via portable `find -mmin`). Both the main lock and the reclaim
-# mutex are held only briefly (the main across a sub-minute check-and-spawn incl. a
-# 30s stop-grace; the reclaim across a sub-second age-check + rmdir), so anything
-# past the threshold is an abandoned lock from a crashed start / powered-off host.
+# threshold (mtime, via portable `find -mmin`). The lock is held only briefly (a
+# sub-minute check-and-spawn, incl. a 30s stop-grace on a config-change restart),
+# so anything past the threshold is an abandoned lock from a crashed start /
+# powered-off host — never a live hold.
 _coordination_lock_stale() {
   [[ -n "$(find "$1" -maxdepth 0 -mmin +"${COORDINATION_LOCK_STALE_MIN:-5}" 2>/dev/null)" ]]
 }
 
+# start_coordination — serialize check-and-spawn so two overlapping starts (the
+# recurring LaunchAgent tick racing a manual `start`) can't both spawn a detached
+# publisher (Codex P1). The design is deliberately single-primitive — one mkdir
+# lock, no secondary mutex — because a nested reclaim mutex only RELOCATES the
+# stale-lock race up a level (each layer's own age-check + removal is itself a
+# TOCTOU). Two invariants make reclaim structurally unable to remove a live lock,
+# so `mkdir` stays the SOLE arbiter of ownership and double-spawn is impossible:
+#
+#   1. Ownership is ONLY ever a successful `mkdir "$COORDINATION_LOCK"`. Every
+#      reclaim path `continue`s and must win a fresh mkdir to proceed.
+#   2. A live holder writes a sentinel file into the lock dir immediately after
+#      acquiring, and reclaim removes a stale lock with `rmdir` — which REFUSES a
+#      non-empty directory. So a live (sentinel-bearing) lock can never be removed
+#      by a reclaimer; the age gate additionally covers the microsecond
+#      mkdir→sentinel window (a fresh lock is age ~0, far under the threshold).
+#
+# Two reclaimers racing a genuinely-stale (empty, aged) lock both `rmdir` it
+# (idempotent) then both `mkdir` — mkdir arbitrates a single winner; the loser sees
+# the winner's fresh lock and skips. (A lock leaked by SIGKILL/power-loss AFTER the
+# sentinel write is non-empty, so rmdir won't auto-clear it — force-removing it
+# would reintroduce exactly the ABA double-spawn race, so we deliberately don't;
+# it's cleared out-of-band, and impact is bounded since coordination-publish is
+# off by default.)
 start_coordination() {
   local guard=0
-  while ! mkdir "$COORDINATION_LOCK" 2>/dev/null; do
+  while true; do
+    if mkdir "$COORDINATION_LOCK" 2>/dev/null; then
+      : > "$COORDINATION_LOCK/owner"   # sentinel: a live lock is non-empty → rmdir-proof
+      break
+    fi
     guard=$((guard + 1))
     if [[ "$guard" -gt 8 ]]; then
       log "coordination-publish start already in progress — skipping this tick"
       return 0
     fi
-    # Lock held. Decide UNDER a dedicated reclaim mutex whether this is a crashed
-    # start (reclaim it) or a live peer (skip). Serializing the DECISION is what
-    # makes the takeover ownership-safe: two overlapping starts can no longer both
-    # age-check the same stale dir and both remove-then-reacquire it (Codex P1). A
-    # bare rmdir/mv can't fix this — a peer that already reclaimed leaves a FRESH
-    # live lock at the same path, so an unconditional removal would delete it. While
-    # the main lock dir exists nobody can mkdir it, so removing it here — after
-    # re-confirming staleness under the mutex — can never delete a live lock.
-    if mkdir "$COORDINATION_RECLAIM_LOCK" 2>/dev/null; then
-      if _coordination_lock_stale "$COORDINATION_LOCK"; then
-        log "coordination-publish: reclaiming stale start lock"
-        rmdir "$COORDINATION_LOCK" 2>/dev/null || true
-        rmdir "$COORDINATION_RECLAIM_LOCK" 2>/dev/null || true
-        continue    # stale cleared — contend for a fresh mkdir
-      fi
-      # Main lock is live (a peer's in-flight start) — leave it, skip this tick.
-      rmdir "$COORDINATION_RECLAIM_LOCK" 2>/dev/null || true
-      log "coordination-publish start already in progress — skipping this tick"
-      return 0
-    fi
-    # Couldn't take the reclaim mutex. If IT is stale, a start was killed / the host
-    # powered off after acquiring it but before releasing — recover it too, else it
-    # would wedge every future tick (Codex P2). Removing an abandoned reclaim mutex
-    # is benign even under a race (it guards only the decision, not the spawn — the
-    # eventual re-mkdir has a single winner). If it's fresh, a live peer owns the
-    # in-flight reclaim decision: skip.
-    if _coordination_lock_stale "$COORDINATION_RECLAIM_LOCK"; then
-      log "coordination-publish: reclaiming abandoned reclaim mutex"
-      rmdir "$COORDINATION_RECLAIM_LOCK" 2>/dev/null || true
+    # Reclaim ONLY an abandoned lock — old enough that no live check-and-spawn could
+    # still hold it. rmdir refuses a non-empty (live, sentinel-bearing) lock, so
+    # this can never delete a live lock; the age gate covers the mkdir→sentinel
+    # window. A fresh peer lock fails both the age gate and (once its sentinel
+    # lands) the rmdir, so a live peer is simply skipped.
+    if _coordination_lock_stale "$COORDINATION_LOCK" && rmdir "$COORDINATION_LOCK" 2>/dev/null; then
+      log "coordination-publish: reclaimed an abandoned start lock"
       continue
     fi
     log "coordination-publish start already in progress — skipping this tick"
@@ -542,19 +542,28 @@ start_coordination() {
   done
   local rc=0
   _start_coordination_locked || rc=$?
-  rmdir "$COORDINATION_LOCK" 2>/dev/null || true
+  rm -rf "$COORDINATION_LOCK" 2>/dev/null || true   # release (contains the sentinel)
   return "$rc"
 }
 
 _start_coordination_locked() {
   # Resolve mode + hubUrl exactly as the daemon would, in ONE bun import, and
-  # fingerprint them. The daemon reads its config only at startup, so this
-  # fingerprint is how a keep-alive tick notices a config change and reconciles.
-  local resolved mode hub fp
+  # fingerprint them PLUS the checkout identity. The daemon reads its config only
+  # at startup AND runs from a fixed plugin checkout, so this fingerprint is how a
+  # keep-alive tick notices a change and reconciles by restarting: a config change
+  # (mode/hubUrl) OR a plugin-checkout advance. The checkout HEAD SHA is what makes
+  # a `git pull`-style refresh redeploy the publisher — otherwise the long-lived
+  # bun process keeps executing the OLD checkout's modules until a manual restart
+  # (Codex P1: restart the publisher after checkout updates; the broker's immediate
+  # hot-reload path covers monitor/exec-core but not this CLI-less daemon, so it
+  # rides the keep-alive tick instead). Fail-safe: a non-git checkout just omits the
+  # SHA and the fingerprint stays mode|hub.
+  local resolved mode hub fp checkout_id
   resolved="$(coordination_resolve)"
   mode="${resolved%%$'\t'*}"
   hub="${resolved#*$'\t'}"
-  fp="${mode}|${hub}"
+  checkout_id="$(git -C "$SCRIPT_DIR" rev-parse HEAD 2>/dev/null || true)"
+  fp="${mode}|${hub}|${checkout_id}"
 
   local pid; pid="$(coordination_pid)"
 
@@ -1344,6 +1353,19 @@ render_stack_plist() {
     <key>CATALYST_HOST_NAME</key>
     <string>${host_name}</string>"
   fi
+  # CTL-1494 (Codex P2): pin the operator's Layer-2 config path into the agent env.
+  # launchd hands the keep-alive an otherwise-minimal environment, so without this a
+  # host configured via a nondefault CATALYST_LAYER2_CONFIG_FILE would resolve
+  # coordination (and every other Layer-2 read) from the DEFAULT file on each tick —
+  # so a publisher an operator started interactively in shadow/enforce would be seen
+  # as `off` and reconcile-stopped, and would never start after reboot. Captured at
+  # install time from the invoking environment; omitted (default path) when unset.
+  local layer2_env=""
+  if [[ -n "${CATALYST_LAYER2_CONFIG_FILE:-}" ]]; then
+    layer2_env="
+    <key>CATALYST_LAYER2_CONFIG_FILE</key>
+    <string>${CATALYST_LAYER2_CONFIG_FILE}</string>"
+  fi
   cat <<PLIST
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
@@ -1377,7 +1399,7 @@ render_stack_plist() {
     <key>PATH</key>
     <string>$(_stack_agent_path)</string>
     <key>HOME</key>
-    <string>${HOME}</string>${host_env}
+    <string>${HOME}</string>${host_env}${layer2_env}
   </dict>
 
   <!--

--- a/plugins/dev/scripts/catalyst-stack
+++ b/plugins/dev/scripts/catalyst-stack
@@ -567,12 +567,17 @@ _start_coordination_locked() {
   # hot-reload path covers monitor/exec-core but not this CLI-less daemon, so it
   # rides the keep-alive tick instead). Fail-safe: a non-git checkout just omits the
   # SHA and the fingerprint stays mode|hub.
+  # The fingerprint captures everything the LONG-LIVED daemon reads only at startup:
+  # resolved config (mode/hubUrl), the plugin checkout (so a refresh redeploys), and
+  # the state/events roots it derives its paths from — CATALYST_DIR and
+  # CATALYST_EVENTS_DIR (Codex P2: a reinstall that changes the events dir must bounce
+  # the publisher, else it keeps tailing the old directory). Any change → restart.
   local resolved mode hub fp checkout_id
   resolved="$(coordination_resolve)"
   mode="${resolved%%$'\t'*}"
   hub="${resolved#*$'\t'}"
   checkout_id="$(git -C "$SCRIPT_DIR" rev-parse HEAD 2>/dev/null || true)"
-  fp="${mode}|${hub}|${checkout_id}"
+  fp="${mode}|${hub}|${checkout_id}|${CATALYST_DIR:-}|${CATALYST_EVENTS_DIR:-}"
 
   local pid; pid="$(coordination_pid)"
 
@@ -635,13 +640,17 @@ _start_coordination_locked() {
 # the SAME start lock (Codex P1): otherwise a manual stop racing a scheduled start
 # (after start acquired the lock but before it wrote the PID file) sees no publisher,
 # returns, and the start then spawns a detached publisher AFTER the stop completed —
-# leaving mirroring/egress running despite a successful stop. Bounded wait for the
-# in-flight start to finish; if the lock can't be taken (still in-flight, or a
-# non-empty leak), fall through and stop best-effort anyway — stopping is always
-# safe. Internal callers that already hold the lock use _stop_coordination_unlocked.
+# leaving mirroring/egress running despite a successful stop. The wait bound MUST
+# exceed the start's own worst-case critical section — a config-change restart holds
+# the lock across the up-to-COORDINATION_STOP_GRACE_SECONDS graceful stop plus the
+# launch — or stop could expire and race it (Codex P1); default = grace + 20s margin.
+# If the lock still can't be taken (a truly stuck start, or a non-empty leak), fall
+# through and stop best-effort anyway — stopping is always safe. Internal callers
+# that already hold the lock use _stop_coordination_unlocked.
 stop_coordination() {
   local got=0 tries=0
-  while [[ "$tries" -lt "${COORDINATION_STOP_LOCK_WAIT_SECONDS:-15}" ]]; do
+  local wait_bound="${COORDINATION_STOP_LOCK_WAIT_SECONDS:-$((COORDINATION_STOP_GRACE_SECONDS + 20))}"
+  while [[ "$tries" -lt "$wait_bound" ]]; do
     if _coordination_lock_acquire; then got=1; break; fi
     tries=$((tries + 1)); sleep 1
   done

--- a/plugins/dev/scripts/catalyst-stack
+++ b/plugins/dev/scripts/catalyst-stack
@@ -209,6 +209,11 @@ COORDINATION_STOP_GRACE_SECONDS="${COORDINATION_STOP_GRACE_SECONDS:-30}"
 # catalyst-state.sh; flock is absent on stock macOS). Serializes check-and-spawn so
 # two overlapping starts can't both pass the pid check and both spawn (Codex P1).
 COORDINATION_LOCK="${CATALYST_DIR:-$HOME/catalyst}/coordination-publish.start.lock"
+# Reclaim mutex: serializes the stale-lock takeover DECISION so two overlapping
+# starts can't both age-check the same stale lock and both remove+reacquire it —
+# an ownership-safe atomic takeover (Codex P1). Held only across the age-check +
+# removal (sub-second), never across the spawn.
+COORDINATION_RECLAIM_LOCK="${CATALYST_DIR:-$HOME/catalyst}/coordination-publish.reclaim.lock"
 
 # CTL-1348: the standalone catalyst-updater daemon (the 5th launchd agent). Installed
 # ONLY by the explicit 'catalyst-stack adopt-updater' cutover — NOT by install-services,
@@ -485,17 +490,33 @@ coordination_resolve() {
 # tick racing a manual start — the loser skips the tick (the winner establishes the
 # single publisher) rather than queueing a redundant spawn.
 start_coordination() {
-  local tries=0
+  local guard=0
   while ! mkdir "$COORDINATION_LOCK" 2>/dev/null; do
-    # Reclaim a stale lock from a crashed start (mtime older than the threshold —
-    # comfortably above the <1min a real check-and-spawn takes, even with a 30s
-    # stop-grace on a config-change restart), so a crash can't wedge startup.
-    if [[ "$tries" -lt 3 && -n "$(find "$COORDINATION_LOCK" -maxdepth 0 -mmin +"${COORDINATION_LOCK_STALE_MIN:-5}" 2>/dev/null)" ]]; then
-      log "coordination-publish: reclaiming stale start lock"
-      rmdir "$COORDINATION_LOCK" 2>/dev/null || true
-      tries=$((tries + 1)); continue
+    guard=$((guard + 1))
+    if [[ "$guard" -gt 5 ]]; then
+      log "coordination-publish start already in progress — skipping this tick"
+      return 0
     fi
-    # Held by a concurrent, live start — it will establish the publisher.
+    # Lock held. Decide UNDER a dedicated reclaim mutex whether this is a crashed
+    # start (reclaim it) or a live peer (skip). Serializing the DECISION is what
+    # makes the takeover ownership-safe: two overlapping starts can no longer both
+    # age-check the same stale dir and both remove-then-reacquire it (Codex P1). A
+    # bare rmdir/mv can't fix this — a peer that already reclaimed leaves a FRESH
+    # live lock at the same path, so an unconditional removal would delete it. While
+    # the main lock dir exists nobody can mkdir it, so removing it here — after
+    # re-confirming staleness under the mutex — can never delete a live lock.
+    if mkdir "$COORDINATION_RECLAIM_LOCK" 2>/dev/null; then
+      if [[ -n "$(find "$COORDINATION_LOCK" -maxdepth 0 -mmin +"${COORDINATION_LOCK_STALE_MIN:-5}" 2>/dev/null)" ]]; then
+        log "coordination-publish: reclaiming stale start lock"
+        rmdir "$COORDINATION_LOCK" 2>/dev/null || true
+        rmdir "$COORDINATION_RECLAIM_LOCK" 2>/dev/null || true
+        continue    # stale cleared — contend for a fresh mkdir
+      fi
+      rmdir "$COORDINATION_RECLAIM_LOCK" 2>/dev/null || true
+    fi
+    # A live peer holds the lock, or another start owns the in-flight reclaim
+    # decision — either way it will establish the single publisher; skip this tick
+    # rather than pile a redundant spawn on.
     log "coordination-publish start already in progress — skipping this tick"
     return 0
   done

--- a/plugins/dev/scripts/catalyst-stack
+++ b/plugins/dev/scripts/catalyst-stack
@@ -568,16 +568,17 @@ _start_coordination_locked() {
   # rides the keep-alive tick instead). Fail-safe: a non-git checkout just omits the
   # SHA and the fingerprint stays mode|hub.
   # The fingerprint captures everything the LONG-LIVED daemon reads only at startup:
-  # resolved config (mode/hubUrl), the plugin checkout (so a refresh redeploys), and
-  # the state/events roots it derives its paths from — CATALYST_DIR and
-  # CATALYST_EVENTS_DIR (Codex P2: a reinstall that changes the events dir must bounce
-  # the publisher, else it keeps tailing the old directory). Any change → restart.
+  # resolved config (mode/hubUrl), the plugin checkout (so a refresh redeploys), the
+  # state/events roots it derives its paths from (CATALYST_DIR/CATALYST_EVENTS_DIR),
+  # and the enforce-mode interim inbound source (CATALYST_LOKI_QUERY_URL /
+  # OTEL_EXPORTER_OTLP_ENDPOINT) — Codex P2: a reinstall that changes any of these
+  # must bounce the publisher, else it keeps using the old value. Any change → restart.
   local resolved mode hub fp checkout_id
   resolved="$(coordination_resolve)"
   mode="${resolved%%$'\t'*}"
   hub="${resolved#*$'\t'}"
   checkout_id="$(git -C "$SCRIPT_DIR" rev-parse HEAD 2>/dev/null || true)"
-  fp="${mode}|${hub}|${checkout_id}|${CATALYST_DIR:-}|${CATALYST_EVENTS_DIR:-}"
+  fp="${mode}|${hub}|${checkout_id}|${CATALYST_DIR:-}|${CATALYST_EVENTS_DIR:-}|${CATALYST_LOKI_QUERY_URL:-}|${OTEL_EXPORTER_OTLP_ENDPOINT:-}"
 
   local pid; pid="$(coordination_pid)"
 
@@ -1452,6 +1453,23 @@ render_stack_plist() {
     <key>CATALYST_COORDINATION_HUB_URL</key>
     <string>$(_xml_escape "${CATALYST_COORDINATION_HUB_URL}")</string>"
   fi
+  # CTL-1494 (Codex P2): pin the enforce-mode interim inbound-source inputs. With no
+  # hub URL, the publisher derives its Loki-tail source from CATALYST_LOKI_QUERY_URL
+  # (or the OTEL_EXPORTER_OTLP_ENDPOINT it falls back to); dropping them makes
+  # getLokiQueryUrl() return null after reboot/restart, so no inbound timer is created
+  # and cross-host coordination rows silently stop merging while status still says
+  # enforce. Captured at install time; omitted when unset.
+  local otel_env=""
+  if [[ -n "${CATALYST_LOKI_QUERY_URL:-}" ]]; then
+    otel_env="${otel_env}
+    <key>CATALYST_LOKI_QUERY_URL</key>
+    <string>$(_xml_escape "${CATALYST_LOKI_QUERY_URL}")</string>"
+  fi
+  if [[ -n "${OTEL_EXPORTER_OTLP_ENDPOINT:-}" ]]; then
+    otel_env="${otel_env}
+    <key>OTEL_EXPORTER_OTLP_ENDPOINT</key>
+    <string>$(_xml_escape "${OTEL_EXPORTER_OTLP_ENDPOINT}")</string>"
+  fi
   cat <<PLIST
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
@@ -1485,7 +1503,7 @@ render_stack_plist() {
     <key>PATH</key>
     <string>$(_stack_agent_path)</string>
     <key>HOME</key>
-    <string>$(_xml_escape "${HOME}")</string>${host_env}${catdir_env}${layer2_env}${coord_env}
+    <string>$(_xml_escape "${HOME}")</string>${host_env}${catdir_env}${layer2_env}${coord_env}${otel_env}
   </dict>
 
   <!--

--- a/plugins/dev/scripts/catalyst-stack
+++ b/plugins/dev/scripts/catalyst-stack
@@ -495,33 +495,36 @@ _coordination_lock_stale() {
 
 # start_coordination — serialize check-and-spawn so two overlapping starts (the
 # recurring LaunchAgent tick racing a manual `start`) can't both spawn a detached
-# publisher (Codex P1). The design is deliberately single-primitive — one mkdir
-# lock, no secondary mutex — because a nested reclaim mutex only RELOCATES the
-# stale-lock race up a level (each layer's own age-check + removal is itself a
-# TOCTOU). `mkdir` is the SOLE arbiter of ownership: ownership is ONLY ever a
-# successful `mkdir "$COORDINATION_LOCK"`, and every reclaim path `continue`s and
-# must win a fresh mkdir to proceed. A live holder records its PID in a sentinel
-# file inside the lock dir immediately after acquiring.
+# publisher (Codex P1). Single-primitive by design: one `mkdir` lock, and `mkdir`
+# is the SOLE arbiter of ownership — ownership is ONLY ever a successful
+# `mkdir "$COORDINATION_LOCK"`, and every reclaim path `continue`s and must win a
+# fresh mkdir to proceed. This is deliberately the PROVABLY-SAFE subset, not a
+# fuller stale-recovery, because a race-free takeover of a NON-EMPTY (already-held-
+# looking) lock is impossible with pure shell primitives — there is no atomic
+# compare-and-swap / flock on stock macOS, so every "inspect then remove/rename"
+# scheme is a TOCTOU: a second racer acts on the pathname, not the inode it
+# inspected, and can delete a peer's freshly-reacquired lock (the ABA that each
+# prior takeover attempt reintroduced one level down).
 #
-# Reclaim (lock held, mkdir failed) fires only past the age gate — old enough that
-# no live sub-minute check-and-spawn could still hold it — and then:
-#   * empty carcass (crashed before the sentinel write) → `rmdir` (refuses a
-#     non-empty dir, so it can never touch a sentinel-bearing lock);
-#   * sentinel present but its recorded owner PID is DEAD (crash/power-off AFTER the
-#     sentinel write — the case a pure rmdir scheme would wedge until manual
-#     deletion) → atomic-rename takeover: `mv` the carcass to a private name; only
-#     one racer's rename of that inode succeeds, so it can't be split-brained.
-# A sentinel whose owner is still ALIVE is a live peer → skip. Two reclaimers of the
-# same carcass converge on a single mkdir winner; the loser sees the winner's fresh
-# lock (young → age gate; or live owner) and skips. The tight residual (two starts
-# racing the SAME dead-owner takeover within the mkdir window) is additionally
-# backstopped by _start_coordination_locked's own `coordination_pid` idempotency
-# check, which refuses to spawn when a publisher is already running.
+# The two invariants that make double-spawn IMPOSSIBLE:
+#   1. A live holder writes a sentinel file into the lock dir immediately after
+#      acquiring, so a live lock is NON-EMPTY.
+#   2. Reclaim removes a stale lock with `rmdir`, which REFUSES a non-empty dir —
+#      and only past the age gate (older than any live sub-minute check-and-spawn).
+# So a reclaimer can ONLY ever remove an EMPTY, aged-out carcass (a crash before the
+# sentinel write); it can never remove a live OR a non-empty leaked lock, and mkdir
+# arbitrates a single winner among racers. A lock leaked by SIGKILL/power-loss AFTER
+# the sentinel write is non-empty and is NOT auto-reclaimed — force-removing it is
+# exactly the impossible race above, so we accept the bounded, operator-recoverable
+# wedge instead (matching `catalyst-state.sh`, which does no stale reclaim at all).
+# Impact is minimal: coordination-publish is off by default, the leak window is a
+# sub-second SIGKILL, and `_start_coordination_locked`'s `coordination_pid` check is
+# an independent belt-and-suspenders against a running publisher being duplicated.
 start_coordination() {
   local guard=0
   while true; do
     if mkdir "$COORDINATION_LOCK" 2>/dev/null; then
-      printf '%s' "$$" > "$COORDINATION_LOCK/owner"   # sentinel records the owner pid
+      : > "$COORDINATION_LOCK/owner"   # sentinel: a live lock is non-empty → rmdir-proof
       break
     fi
     guard=$((guard + 1))
@@ -529,27 +532,12 @@ start_coordination() {
       log "coordination-publish start already in progress — skipping this tick"
       return 0
     fi
-    if _coordination_lock_stale "$COORDINATION_LOCK"; then
-      local lock_owner; lock_owner="$(cat "$COORDINATION_LOCK/owner" 2>/dev/null || true)"
-      if [[ -z "$lock_owner" ]]; then
-        # Empty carcass (crashed before the sentinel write). rmdir refuses a
-        # non-empty dir, so this can never remove a sentinel-bearing lock.
-        if rmdir "$COORDINATION_LOCK" 2>/dev/null; then
-          log "coordination-publish: reclaimed an abandoned (empty) start lock"
-        fi
-        continue
-      fi
-      if ! pid_alive "$lock_owner"; then
-        # Sentinel present but its owner is confirmed dead — a crash-after-sentinel
-        # carcass. Atomic-rename takeover (single winner) so a stopped publisher
-        # doesn't stay wedged after reboot until manual deletion.
-        if mv "$COORDINATION_LOCK" "${COORDINATION_LOCK}.dead.$$" 2>/dev/null; then
-          rm -rf "${COORDINATION_LOCK}.dead.$$" 2>/dev/null || true
-          log "coordination-publish: reclaimed a dead-owner start lock (owner ${lock_owner})"
-        fi
-        continue
-      fi
-      # Owner alive → a live peer holding the lock past the age gate — skip.
+    # Reclaim ONLY an EMPTY, aged carcass. rmdir refuses a non-empty (sentinel-
+    # bearing) lock, so this can never remove a live lock; the age gate covers the
+    # microsecond mkdir→sentinel window. A live/leaked non-empty lock → skip.
+    if _coordination_lock_stale "$COORDINATION_LOCK" && rmdir "$COORDINATION_LOCK" 2>/dev/null; then
+      log "coordination-publish: reclaimed an abandoned (empty) start lock"
+      continue
     fi
     log "coordination-publish start already in progress — skipping this tick"
     return 0
@@ -1355,17 +1343,43 @@ _stack_agent_path() {
   printf '%s\n' "${HOME}/.catalyst/bin:${HOME}/.local/node/bin:${HOME}/.local/bin:${HOME}/.bun/bin:/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"
 }
 
+# _xml_escape <value> — escape the five XML predefined entities so an env value with
+# a metacharacter (e.g. a hub URL like https://h/p?x=1&y=2) can't emit a malformed
+# plist that launchd then refuses to load (Codex P2). `&` MUST be substituted first.
+_xml_escape() {
+  local s="$1"
+  s="${s//&/&amp;}"
+  s="${s//</&lt;}"
+  s="${s//>/&gt;}"
+  s="${s//\"/&quot;}"
+  s="${s//\'/&apos;}"
+  printf '%s' "$s"
+}
+
 # render_stack_plist <cmd> <interval> [host_name] — emit the LaunchAgent plist XML to stdout.
 # Pure: no filesystem or launchctl side effects, so it is unit-testable and the
 # `--print` flag can show exactly what would be installed. host_name is optional;
 # when non-empty, CATALYST_HOST_NAME is pinned in EnvironmentVariables (CTL-1202).
+# All interpolated env VALUES pass through _xml_escape (Codex P2).
 render_stack_plist() {
   local cmd="$1" interval="$2" host_name="${3:-}"
   local host_env=""
   if [[ -n "$host_name" ]]; then
     host_env="
     <key>CATALYST_HOST_NAME</key>
-    <string>${host_name}</string>"
+    <string>$(_xml_escape "$host_name")</string>"
+  fi
+  # CTL-1494 (Codex P2): pin the operator's CATALYST_DIR so the keep-alive derives
+  # the publisher's pid/fingerprint/lock/checkpoint/mirror from the SAME root the
+  # operator used — else a nondefault-root publisher is found by command line, read
+  # with no fingerprint under the default root, and restarted against $HOME/catalyst,
+  # relocating coordination state (and likewise mis-starting after reboot). Captured
+  # at install time; omitted (default root) when unset.
+  local catdir_env=""
+  if [[ -n "${CATALYST_DIR:-}" ]]; then
+    catdir_env="
+    <key>CATALYST_DIR</key>
+    <string>$(_xml_escape "${CATALYST_DIR}")</string>"
   fi
   # CTL-1494 (Codex P2): pin the operator's Layer-2 config path into the agent env.
   # launchd hands the keep-alive an otherwise-minimal environment, so without this a
@@ -1378,7 +1392,7 @@ render_stack_plist() {
   if [[ -n "${CATALYST_LAYER2_CONFIG_FILE:-}" ]]; then
     layer2_env="
     <key>CATALYST_LAYER2_CONFIG_FILE</key>
-    <string>${CATALYST_LAYER2_CONFIG_FILE}</string>"
+    <string>$(_xml_escape "${CATALYST_LAYER2_CONFIG_FILE}")</string>"
   fi
   # CTL-1494 (Codex P1): pin the coordination env OVERRIDES the operator installed
   # with, so the scheduled keep-alive resolves the SAME mode the operator intended.
@@ -1390,12 +1404,12 @@ render_stack_plist() {
   if [[ -n "${CATALYST_COORDINATION_MODE:-}" ]]; then
     coord_env="${coord_env}
     <key>CATALYST_COORDINATION_MODE</key>
-    <string>${CATALYST_COORDINATION_MODE}</string>"
+    <string>$(_xml_escape "${CATALYST_COORDINATION_MODE}")</string>"
   fi
   if [[ -n "${CATALYST_COORDINATION_HUB_URL:-}" ]]; then
     coord_env="${coord_env}
     <key>CATALYST_COORDINATION_HUB_URL</key>
-    <string>${CATALYST_COORDINATION_HUB_URL}</string>"
+    <string>$(_xml_escape "${CATALYST_COORDINATION_HUB_URL}")</string>"
   fi
   cat <<PLIST
 <?xml version="1.0" encoding="UTF-8"?>
@@ -1430,7 +1444,7 @@ render_stack_plist() {
     <key>PATH</key>
     <string>$(_stack_agent_path)</string>
     <key>HOME</key>
-    <string>${HOME}</string>${host_env}${layer2_env}${coord_env}
+    <string>$(_xml_escape "${HOME}")</string>${host_env}${catdir_env}${layer2_env}${coord_env}
   </dict>
 
   <!--

--- a/website/src/content/docs/reference/configuration.md
+++ b/website/src/content/docs/reference/configuration.md
@@ -1128,8 +1128,19 @@ hub is wired, an interim Loki-tail transport).
 It ships behind the same **off→shadow→enforce** rollout discipline as the recovery family, but —
 unlike the board-health delegate — its floor is **`off`**, not `shadow`: coordination adds an
 always-on publisher process and, in enforce, network egress, so the safe default is fully inert until
-an operator promotes it. This is **groundwork** — the publisher is not launched by the standard stack
-yet; enforce + hub wiring lands in a later phase.
+an operator promotes it.
+
+The publisher is launched by `catalyst-stack` — after `otel-forward`, on **worker + monitor** nodes
+(gated `catalyst.node.class != developer`, following the reporting substrate) — as a self-managed
+nohup child ([`catalyst-stack`](https://github.com/coalesce-labs/catalyst/blob/main/plugins/dev/scripts/catalyst-stack)
+`start_coordination`). Because the daemon self-exits when the resolved mode is `off` (the default),
+`catalyst-stack` short-circuits before spawning it, so launching it unconditionally is safe and an
+unconfigured node is byte-identical to before: no publisher process, no PID file, no mirror. When the
+mode is `shadow`/`enforce`, the daemon comes up idempotently (a re-run of `catalyst-stack start` — or
+the keep-alive tick — never double-starts it); `catalyst-stack status` reports a `coordination` line
+(`off (inert)`, or `running … mode=<mode>`). A missing `bun` is non-fatal (a bun-less host resolves to
+`off` and never blocks the rest of the stack). **Enforce and the hub transport stay operator-gated** —
+this wiring only makes `shadow`/`enforce` take effect where they were previously dark.
 
 Mode resolves from the env var (a single operator knob) over Layer-2 over the default. The `0`
 kill-switch and any unset/garbage value both resolve to `off`.


### PR DESCRIPTION
<!-- Auto-generated: 2026-08-07T06:43:12Z -->
<!-- Last updated: 2026-08-07T06:43:12Z -->
<!-- PR: #3066 -->
<!-- Previous commits: 2dc71cbc6250280228423c0dd122eedc0256e689,0707c7ae70f53a23d091a5e11332bf7dadc0859c -->

## Summary

Wires the `coordination-publish` daemon (CTL-1488 Phase 3, ADR-022/ADR-023) into the
`catalyst-stack` lifecycle so `CATALYST_COORDINATION_MODE` finally has a runtime effect. The
daemon was already fully built and inert-by-default, but nothing launched it — setting the mode to
`shadow`/`enforce` was dark. This PR adds `start_coordination`/`stop_coordination` lifecycle
primitives (modeled on the self-managed nohup-child log-shipper template), gates them to the
reporting substrate (worker + monitor, `node.class != developer`, same as `start_forward`), and
short-circuits cleanly when the resolved mode is `off` (the default) so an unconfigured node stays
byte-identical inert — no publisher process, no PID file, no mirror.

This is a wiring change only: the daemon's behavior, its own mirror/checkpoint/DLQ paths, and the
enforce/hub transport are untouched. **Enforce and the hub transport stay operator-gated** — this
only makes `shadow`/`enforce` take effect where they were previously dark.

## Changes Made

### `catalyst-stack` (+127)

- **`coordination_mode()`** — resolves the mode IDENTICALLY to the daemon's own
  `readCoordinationConfig()` (env kill-switch/override > Layer-2 > default `off`) via a bun probe
  of `execution-core/config.mjs`. Fails **closed to `off`** on any bun/import failure — a bun-less
  host cannot run the bun daemon anyway, so inert is the correct posture.
- **`coordination_pid()`** — prints the live pid from the PID file, validating it is both alive
  **and** actually the `coordination-publish` process (guards pid reuse), mirroring `shipper_pid`.
- **`start_coordination()`** — mode gate (`off` ⇒ clean no-op, ADR-023 inert contract), idempotent
  (never double-starts on the keep-alive tick), loud-but-non-fatal on missing `bun` / missing
  entrypoint (returns 1, never `exit`), then launches detached via `nohup` and does a `sleep 1`
  liveness re-check (which only runs in `shadow`/`enforce`, where a fast exit genuinely is a
  failure).
- **`stop_coordination()`** — SIGTERM (daemon traps it → graceful flush + checkpoint), then
  SIGKILL fallback, then removes the PID file.
- **Wiring**: `cmd_start` calls it after `start_forward` (gated `!= developer`), non-fatal;
  `cmd_stop` calls it after `stop_event_mirror`; `cmd_status` prints a `coordination` line
  (`off (inert)` | `running … pid=… mode=…` | `stopped … mode=…`).
- The daemon's own paths (`~/catalyst/coordination.jsonl` mirror,
  `coordination-publish.checkpoint.json`, `coordination-publish-dlq.jsonl`) are distinct from the
  stack-owned `coordination-publish.pid`/`.log` — no clobber.

### Tests

- **`catalyst-stack-coordination.test.sh`** (new, +74) — focused coverage of the off-inert no-op
  path (mode=`off` ⇒ rc 0, inert breadcrumb, **no** PID file) and the bun-missing fail-closed path
  (even with `CATALYST_COORDINATION_MODE=shadow` forced, a bun-less host collapses to `off` ⇒
  clean skip, no PID file). Live shadow/enforce launch is a documented manual step (needs a real
  bun runtime + a coordination-stamped event), out of scope for a hermetic shell test.
- **`catalyst-stack-start-node-class.test.sh`** (+5/-1) — extends node-class gating: worker +
  monitor **start** `start_coordination`, developer does **not**.
- **`catalyst-stack.test.sh`** (+8) — asserts `status` inventories the `coordination` line
  (green even with no bun on PATH).

### Docs

- **`website/src/content/docs/reference/configuration.md`** (+13/-2) — updates the
  "Coordination substrate (CTL-1488)" section: the publisher is now stack-launched (after
  `otel-forward`, on worker + monitor, gated `node.class != developer`); `off` short-circuits
  before spawn; missing `bun` is non-fatal; `status` reports a `coordination` line. Removes the
  stale "not launched by the standard stack yet" groundwork note.

## How to Verify It

- [x] Coordination lifecycle tests pass: `bash plugins/dev/scripts/__tests__/catalyst-stack-coordination.test.sh` — 5/5 pass
- [x] Node-class gating tests pass: `bash plugins/dev/scripts/__tests__/catalyst-stack-start-node-class.test.sh` — 31/31 pass
- [ ] Manual (needs real bun + coordination-stamped event): `CATALYST_COORDINATION_MODE=shadow catalyst-stack start` launches the daemon; `catalyst-stack status` shows `coordination  running … mode=shadow`; `catalyst-stack stop` tears it down

## Changelog Entry

`feat(dev)`: `catalyst-stack` now launches the `coordination-publish` daemon (worker + monitor
nodes) so `CATALYST_COORDINATION_MODE=shadow|enforce` takes effect; `off` (the default) stays a
clean no-op and `status` reports a `coordination` line.

## Related Issues/PRs

- Fixes https://linear.app/coalesce-labs/issue/CTL-1494
- Follow-up to CTL-1488 (ADR-022 coordination substrate); addresses the Codex P1 review finding on that PR that the daemon was built but never wired into the stack.

Refs: CTL-1494

<!-- Linear automation guard (CTL-623/CTL-633): unlink sibling tickets so this PR does not drag their workflow status. -->
skip ADR-022
skip ADR-023
skip CTL-1488