### PR TITLE
fix(execution-core): preserve 0600 on Layer-2 config across autotune write-back

### DIFF
--- a/plugins/dev/scripts/execution-core/autotune-writeback.test.mjs
+++ b/plugins/dev/scripts/execution-core/autotune-writeback.test.mjs
@@ -2,7 +2,7 @@
 // Run: cd plugins/dev/scripts/execution-core && bun test autotune-writeback.test.mjs
 
 import { describe, test, expect, beforeEach, afterEach } from "bun:test";
-import { mkdtempSync, rmSync, writeFileSync, readFileSync, existsSync } from "node:fs";
+import { mkdtempSync, rmSync, writeFileSync, readFileSync, existsSync, statSync, chmodSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { writeLayer2MaxParallel } from "./autotune.mjs";
@@ -74,6 +74,19 @@ describe("writeLayer2MaxParallel", () => {
     const files = require("node:fs").readdirSync(dir);
     const hasTmp = files.some((f) => f.includes(".tmp."));
     expect(hasTmp).toBe(false);
+  });
+
+  test("writes at mode 600, regardless of any prior looser mode on the file", () => {
+    // doctor's layer2-perms check FAILs on anything looser than 600 (Layer-2 can
+    // carry secrets). Start the file at a deliberately loose mode to pin that the
+    // write-back doesn't just preserve whatever was there — it sets 600 outright.
+    const p = join(dir, "config.json");
+    writeFileSync(p, JSON.stringify({ catalyst: {} }));
+    chmodSync(p, 0o644);
+    const ok = writeLayer2MaxParallel(p, 9);
+    expect(ok).toBe(true);
+    const mode = statSync(p).mode & 0o777;
+    expect(mode).toBe(0o600);
   });
 
   test("uses injected readFileSync / writeFileSync / renameSync seams", () => {

--- a/plugins/dev/scripts/execution-core/autotune.mjs
+++ b/plugins/dev/scripts/execution-core/autotune.mjs
@@ -452,7 +452,11 @@ export function writeLayer2MaxParallel(layer2Path, next, {
     if (!existing.catalyst.orchestration.executionCore) existing.catalyst.orchestration.executionCore = {};
     existing.catalyst.orchestration.executionCore.maxParallel = next;
     const tmp = `${layer2Path}.tmp.${process.pid}`;
-    writeFile(tmp, JSON.stringify(existing, null, 2));
+    // mode: 0o600 — Layer-2 can carry secrets (doctor's layer2-perms check requires
+    // 600). Without this the tmp file is created at the default 0o666&~umask (644),
+    // and POSIX rename() replaces the destination's permission bits along with its
+    // content, silently reverting any prior chmod 600 on every autotune write.
+    writeFile(tmp, JSON.stringify(existing, null, 2), { mode: 0o600 });
     rename(tmp, layer2Path);
     return true;
   } catch (err) {


### PR DESCRIPTION
## Summary

Same fix as thagale/catalyst#31, proposed here per the dual-PR policy since this code is shared.

\`writeLayer2MaxParallel\`'s tmp-file + \`rename()\` write-back creates the tmp file
at the default mode and POSIX \`rename()\` carries the source file's permission
bits into the destination — so every autotune write silently reverts a
\`chmod 600\` on \`~/.config/catalyst/config.json\` (Layer-2, can carry secrets)
back to 644. \`catalyst doctor\`'s layer2-perms check already hard-FAILs on
anything looser than 600.

Fix: pass \`{ mode: 0o600 }\` to the tmp-file write.

## Test plan

- [x] \`bun test autotune-writeback.test.mjs\` — 7/7 pass (incl. new mode test)
- [x] \`bun test autotune-decision.test.mjs autotune-lifecycle.test.mjs\` — 107/107 pass