### PR TITLE
fix(dev): make match_thoughts_artifact shell-agnostic (zsh/shopt bug)

### DIFF
--- a/plugins/dev/scripts/__tests__/phase-artifact-gate.test.sh
+++ b/plugins/dev/scripts/__tests__/phase-artifact-gate.test.sh
@@ -153,6 +153,28 @@ assert_eq "0" "$RC10" "slugged plan doc satisfies the gate (writer↔gate agreem
 assert_contains "$OUT10" "phase-artifact-gate-contracts.md" "slugged plan doc found by matcher"
 
 echo ""
+echo "Test 11 (regression): match_thoughts_artifact behaves identically sourced under zsh"
+# `shopt` is not a zsh builtin, and the prior bash-array-glob implementation
+# relied on it (`shopt -s nullglob nocaseglob`). Under zsh that call silently
+# failed (non-fatal), then the array-glob assignment hit zsh's own default
+# no-match behavior (error, not empty-expand) on the FIRST alternative pattern
+# that didn't match — which poisoned the ENTIRE assignment, so even an
+# alternative that DID match never made it into `matches`. Confirmed root
+# cause of at least one false "prior artifact missing" plan-phase stall (see
+# CAT-39's friction log — sourced this file under an interactive zsh session,
+# not via `bash -c` as intended). Skips (not a failure) when zsh isn't installed.
+if command -v zsh >/dev/null 2>&1; then
+	ZSH_OUT="$(zsh -c "source '$LIB'; match_thoughts_artifact '$FIXTURES' CTL-1081" 2>&1)"
+	ZSH_RC=$?
+	assert_eq "0" "$ZSH_RC" "zsh: return code is 0 (at least one match)"
+	assert_contains "$ZSH_OUT" "2026-06-12-ctl-1081.md" "zsh: output includes tail form"
+	assert_contains "$ZSH_OUT" "2026-06-12-ctl-1081-per-image-ai-captions.md" "zsh: output includes lowercase slug"
+	assert_not_contains "$ZSH_OUT" "shopt" "zsh: no shopt/command-not-found noise in output"
+else
+	echo "  SKIP: zsh not installed on this host"
+fi
+
+echo ""
 echo "─────────────────────────────────────────────"
 echo "phase-artifact-gate: ${PASSES} passed, ${FAILURES} failed"
 if [[ $FAILURES -gt 0 ]]; then

--- a/plugins/dev/scripts/lib/phase-artifact-gate.sh
+++ b/plugins/dev/scripts/lib/phase-artifact-gate.sh
@@ -72,22 +72,38 @@ own_thoughts_artifact_dir_for_phase() {
 # Finds thoughts artifacts in <dir> that belong to <ticket>.
 # Accepts both the tail form (…-ctl-1081.md) and the slug form (…-ctl-1081-<slug>.md).
 # The word-boundary guard (-${lc}. and -${lc}-) rejects cross-ticket lookalikes
-# (e.g. ctl-10812 does NOT satisfy a ctl-1081 gate). nocaseglob absorbs the
-# uppercase-ticket convention (CTL-1081 writer, ctl-1081 glob) in one step.
-# Bash-3.2 safe: uses tr for lowercasing, no mapfile.
+# (e.g. ctl-10812 does NOT satisfy a ctl-1081 gate). Case-insensitive matching
+# absorbs the uppercase-ticket convention (CTL-1081 writer, ctl-1081 glob) in
+# one step.
+#
+# Deliberately shell-agnostic (no `shopt`, no bash array-glob): this file's
+# shebang says bash, but in practice callers have sourced it under an
+# interactive zsh session rather than invoking via `bash -c` as intended.
+# `shopt` is not a zsh builtin, so `shopt -s nullglob nocaseglob` silently
+# failed under zsh (non-fatal, execution continued) and the SUBSEQUENT glob ran
+# under zsh's own default (non-nullglob, error-on-no-match) semantics instead
+# of bash's — producing an empty match with no error surfaced, which this
+# function's callers read as "prior artifact missing" even when it existed.
+# Confirmed root cause behind at least one false plan-phase stall (see
+# CAT-39's friction log) — real research/plan docs existed on disk, but the
+# gate reported them missing. `find -iname` performs the identical
+# slug-tolerant, boundary-safe, case-insensitive match without depending on
+# either shell's array/glob-option extensions, so sourcing this file under
+# bash OR zsh now behaves identically. Bash-3.2 safe: uses tr for lowercasing,
+# no mapfile.
 match_thoughts_artifact() {
 	local dir="$1" ticket="$2" lc
+
+	# Missing dir → no match, no error (mirrors the prior nullglob behavior).
+	[[ -d "$dir" ]] || return 1
+
 	lc="$(printf '%s' "$ticket" | tr '[:upper:]' '[:lower:]')"
 
-	# nullglob: missing dir → empty array, no error.
-	# nocaseglob: absorbs uppercase ticket names in one pass.
-	shopt -s nullglob nocaseglob
-	# shellcheck disable=SC2206
-	local matches=( "${dir}"/*-"${lc}".md "${dir}"/*-"${lc}"-*.md )
-	shopt -u nullglob nocaseglob
+	local matches
+	matches="$(find "$dir" -maxdepth 1 -type f \( -iname "*-${lc}.md" -o -iname "*-${lc}-*.md" \) 2>/dev/null)"
 
-	if [[ ${#matches[@]} -gt 0 ]]; then
-		printf '%s\n' "${matches[@]}"
+	if [[ -n "$matches" ]]; then
+		printf '%s\n' "$matches"
 		return 0
 	fi
 	return 1


### PR DESCRIPTION
## Summary

Same fix as thagale/catalyst#33, proposed here per the dual-PR policy since this code is shared.

\`shopt -s nullglob nocaseglob\` is a bash builtin. This file has a bash shebang
but in practice gets sourced under an interactive zsh session rather than
invoked via \`bash -c\` as intended. Under zsh, \`shopt\` silently fails
(non-fatal), and the subsequent bash array-glob assignment then hits zsh's own
default no-match behavior (errors rather than expanding to nothing) on
whichever alternative pattern doesn't match — poisoning the WHOLE assignment,
so even an alternative that DID match never made it into the array.

Rewrote \`match_thoughts_artifact\` with \`find -iname\`, which performs the
identical slug-tolerant, boundary-safe, case-insensitive match without
depending on either shell's array/glob-option extensions.

## Test plan

- [x] Reproduced the bug live under zsh, confirmed the fix resolves it
- [x] \`bash plugins/dev/scripts/__tests__/phase-artifact-gate.test.sh\` — 26/26 pass
- [x] \`bash plugins/dev/scripts/lib/__tests__/phase-artifact-gate.test.sh\` — 13/13 pass
- [x] \`bash plugins/dev/scripts/__tests__/phase-skill-globs.test.sh\` — 5/5 pass
- [x] \`shellcheck\` — clean