### PR TITLE
fix(execution-core): codex-exec thoughts symlink resolution + no-progress escalation count

### DIFF
--- a/plugins/dev/scripts/execution-core/codex-run-phase-agent.mjs
+++ b/plugins/dev/scripts/execution-core/codex-run-phase-agent.mjs
@@ -306,17 +306,69 @@ function resolveDevPluginRoot(pluginDirs) {
   return pluginDirs.find((p) => typeof p === "string" && p.length > 0);
 }
 
-// resolveThoughtsRoot — the REAL path the worktree's `thoughts/` symlink points
-// to (it points OUTSIDE the workspace — see the protocol doc). Added to the
-// writable roots so codex can write research/plan artifacts under thoughts/.
-// null when there is no thoughts symlink (best-effort — never throws).
-function resolveThoughtsRoot(worktreePath) {
-  if (!worktreePath) return null;
+// resolveThoughtsRoots — the REAL path(s) any symlink under the worktree's
+// `thoughts/` points to (they point OUTSIDE the workspace — see the protocol
+// doc). Added to the writable roots so codex can write research/plan artifacts
+// under thoughts/. Best-effort throughout: a missing thoughts/ dir, an
+// unreadable directory, or a broken/dangling symlink is skipped rather than
+// thrown — never lets a sandbox-roots computation crash a dispatch.
+//
+// 2026-08-03 fix: the ACTUAL on-disk convention (lib/provision-thoughts.sh) is
+// NOT "thoughts is a symlink" — it's "thoughts is a REAL directory whose
+// immediate entries (`global`, `shared`) are themselves symlinks pointing
+// outside the worktree." The prior version only ever `realpathSync`'d the
+// `thoughts` directory itself; since `thoughts` isn't a symlink in that shape,
+// that just returned the unchanged worktree-local path and never added the
+// actual external target at all. Confirmed live: this silently broke every
+// research/plan artifact write for codex-exec-routed phases (4+ real tickets,
+// each failing with a "thoughts/shared symlink target outside writable roots"
+// sandbox denial) — the bug had existed since codex-exec's original CTL-1457
+// build (2026-07-14) with zero test coverage on this function, only surfacing
+// once research/plan started getting routed through codex-exec.
+//
+// Handles BOTH shapes: `thoughts` itself being a symlink (the legacy/simple
+// case this function originally assumed), and `thoughts` being a real
+// directory whose entries are symlinks (the actual, far more common shape).
+function resolveThoughtsRoots(worktreePath) {
+  if (!worktreePath) return [];
+  const thoughtsPath = join(worktreePath, "thoughts");
+  let stat;
   try {
-    return realpathSync(join(worktreePath, "thoughts"));
+    stat = lstatSync(thoughtsPath);
   } catch {
-    return null;
+    return [];
   }
+  // Legacy/simple shape: `thoughts` itself is a symlink straight to the target.
+  if (stat.isSymbolicLink()) {
+    try {
+      return [realpathSync(thoughtsPath)];
+    } catch {
+      return [];
+    }
+  }
+  if (!stat.isDirectory()) return [];
+  // Real-directory shape: resolve each immediate entry that is ITSELF a
+  // symlink (e.g. thoughts/global, thoughts/shared) to its real target. A
+  // real (non-symlink) entry, e.g. thoughts/searchable, is left alone — it's
+  // already inside the worktree and needs no additional writable root.
+  const out = [];
+  let entries;
+  try {
+    entries = readdirSync(thoughtsPath);
+  } catch {
+    return [];
+  }
+  for (const entry of entries) {
+    const entryPath = join(thoughtsPath, entry);
+    try {
+      if (!lstatSync(entryPath).isSymbolicLink()) continue;
+      out.push(realpathSync(entryPath));
+    } catch {
+      // Broken symlink / permission error on this one entry — skip it, keep
+      // going; never let one bad entry drop the rest of the census.
+    }
+  }
+  return out;
 }
 
 // resolveWorktreeGitDirs — the REAL git metadata paths for a linked worktree.
@@ -350,7 +402,7 @@ function resolveWorktreeGitDirs(worktreePath) {
 
 // resolveWritableRoots — the de-duplicated, absolute writable-root set for the
 // `-c sandbox_workspace_write.writable_roots=[…]` override: the configured roots
-// ∪ {orchDir} ∪ {the resolved thoughts real-root of the worktree if present}
+// ∪ {orchDir} ∪ {every resolved thoughts real-root of the worktree}
 // ∪ {the worktree's real git-dir and git-common-dir, for linked worktrees}.
 // Order-preserving; drops non-absolute / empty / duplicate entries.
 function resolveWritableRoots(cfg, { orchDir, worktreePath } = {}) {
@@ -364,7 +416,7 @@ function resolveWritableRoots(cfg, { orchDir, worktreePath } = {}) {
   };
   for (const r of cfg?.writableRoots ?? []) add(r);
   add(orchDir);
-  add(resolveThoughtsRoot(worktreePath));
+  for (const r of resolveThoughtsRoots(worktreePath)) add(r);
   const { gitDir, commonDir } = resolveWorktreeGitDirs(worktreePath);
   add(gitDir);
   add(commonDir);

--- a/plugins/dev/scripts/execution-core/codex-run-phase-agent.mjs
+++ b/plugins/dev/scripts/execution-core/codex-run-phase-agent.mjs
@@ -306,6 +306,31 @@ function resolveDevPluginRoot(pluginDirs) {
   return pluginDirs.find((p) => typeof p === "string" && p.length > 0);
 }
 
+// PROVISIONED_THOUGHTS_ENTRIES — the only immediate `thoughts/` entry names
+// lib/provision-thoughts.sh ever creates as symlinks (see its `globalDir:
+// "global"` / shared-dir provisioning). resolveThoughtsRoots enumerates ONLY
+// these — never every symlink an attacker (or a prior compromised codex turn,
+// which already has write access to its OWN worktree, including thoughts/)
+// could plant under thoughts/ with an arbitrary name (e.g. `thoughts/root`).
+const PROVISIONED_THOUGHTS_ENTRIES = new Set(["shared", "global"]);
+
+// isSaneThoughtsTarget — the resolved target of a thoughts/ symlink must not
+// be the filesystem root or a bare top-level directory (`/`, `/etc`, `/Users`,
+// …). Every legitimate thoughts-repo target nests at least one level below a
+// real checkout (e.g. `/Users/x/thoughts/repos/proj/shared`,
+// `/home/x/thoughts-repo/global`) — a resolved depth of 0–1 is exactly the
+// shape a malicious `thoughts/shared -> /` (or `-> /etc`) symlink produces,
+// and is the concrete cross-run sandbox-escape vector this guards against:
+// codex's own worktree writes are already sandboxed to the worktree, so
+// planting such a symlink costs an attacker nothing, but a FUTURE dispatch's
+// resolveWritableRoots would otherwise hand that resolved path (up to `/`
+// itself) real filesystem write access.
+function isSaneThoughtsTarget(p) {
+  if (typeof p !== "string" || !isAbsolute(p)) return false;
+  const segments = p.split("/").filter(Boolean);
+  return segments.length >= 2;
+}
+
 // resolveThoughtsRoots — the REAL path(s) any symlink under the worktree's
 // `thoughts/` points to (they point OUTSIDE the workspace — see the protocol
 // doc). Added to the writable roots so codex can write research/plan artifacts
@@ -326,6 +351,10 @@ function resolveDevPluginRoot(pluginDirs) {
 // build (2026-07-14) with zero test coverage on this function, only surfacing
 // once research/plan started getting routed through codex-exec.
 //
+// 2026-08-07 hardening (round-2 review, PR #3082): both shapes below are now
+// gated by isSaneThoughtsTarget — see its comment for the sandbox-escape
+// scenario this closes.
+//
 // Handles BOTH shapes: `thoughts` itself being a symlink (the legacy/simple
 // case this function originally assumed), and `thoughts` being a real
 // directory whose entries are symlinks (the actual, far more common shape).
@@ -341,16 +370,19 @@ function resolveThoughtsRoots(worktreePath) {
   // Legacy/simple shape: `thoughts` itself is a symlink straight to the target.
   if (stat.isSymbolicLink()) {
     try {
-      return [realpathSync(thoughtsPath)];
+      const real = realpathSync(thoughtsPath);
+      return isSaneThoughtsTarget(real) ? [real] : [];
     } catch {
       return [];
     }
   }
   if (!stat.isDirectory()) return [];
-  // Real-directory shape: resolve each immediate entry that is ITSELF a
-  // symlink (e.g. thoughts/global, thoughts/shared) to its real target. A
-  // real (non-symlink) entry, e.g. thoughts/searchable, is left alone — it's
-  // already inside the worktree and needs no additional writable root.
+  // Real-directory shape: resolve ONLY the provisioned entries (`global`,
+  // `shared` — see PROVISIONED_THOUGHTS_ENTRIES) that are themselves symlinks,
+  // to their real target. A real (non-symlink) entry, e.g. thoughts/searchable,
+  // is left alone — it's already inside the worktree and needs no additional
+  // writable root. Any OTHER symlinked entry (unprovisioned name) is skipped
+  // outright, never resolved.
   const out = [];
   let entries;
   try {
@@ -359,10 +391,12 @@ function resolveThoughtsRoots(worktreePath) {
     return [];
   }
   for (const entry of entries) {
+    if (!PROVISIONED_THOUGHTS_ENTRIES.has(entry)) continue;
     const entryPath = join(thoughtsPath, entry);
     try {
       if (!lstatSync(entryPath).isSymbolicLink()) continue;
-      out.push(realpathSync(entryPath));
+      const real = realpathSync(entryPath);
+      if (isSaneThoughtsTarget(real)) out.push(real);
     } catch {
       // Broken symlink / permission error on this one entry — skip it, keep
       // going; never let one bad entry drop the rest of the census.

--- a/plugins/dev/scripts/execution-core/codex-run-phase-agent.mjs
+++ b/plugins/dev/scripts/execution-core/codex-run-phase-agent.mjs
@@ -325,10 +325,67 @@ const PROVISIONED_THOUGHTS_ENTRIES = new Set(["shared", "global"]);
 // planting such a symlink costs an attacker nothing, but a FUTURE dispatch's
 // resolveWritableRoots would otherwise hand that resolved path (up to `/`
 // itself) real filesystem write access.
+//
+// 2026-08-07 P1 follow-up (Codex round-3, PR #3082): a bare segment-count
+// floor alone is NOT sufficient — `thoughts/shared -> /home/alice` (or any
+// other 2+-segment path an attacker chooses) still passes a `>= 2` (or even
+// a raised `>= 3`) check while granting write access to an arbitrary,
+// unrelated directory. The real, structural defense is
+// resolveConfiguredThoughtsAnchor below: validate the resolved target
+// against the WORKTREE'S OWN configured thoughts repository (the same
+// `.catalyst/config.json` → `catalyst.thoughts.directory` source of truth
+// lib/assert-thoughts-project.sh already uses for exactly this purpose), not
+// a shape heuristic. isSaneThoughtsTarget is kept ONLY as a last-resort
+// structural floor for the legacy direct-symlink shape and as a fallback
+// when a worktree genuinely has no thoughts config to validate against
+// (fail-open, mirroring assert-thoughts-project.sh's own precedent) — it is
+// no longer the primary guard for the common `shared`/`global` shape.
 function isSaneThoughtsTarget(p) {
   if (typeof p !== "string" || !isAbsolute(p)) return false;
   const segments = p.split("/").filter(Boolean);
   return segments.length >= 2;
+}
+
+// resolveConfiguredThoughtsDirectory — reads the SAME field
+// lib/assert-thoughts-project.sh validates thoughts/shared against:
+// `.catalyst/config.json` → `catalyst.thoughts.directory`, from the worktree
+// root. Returns null (not an empty string) when the file is missing,
+// unparsable, or the field is absent — the caller treats null as "no
+// authoritative anchor available" and falls back to the structural check,
+// same fail-open precedent as assert-thoughts-project.sh.
+function resolveConfiguredThoughtsDirectory(worktreePath) {
+  if (!worktreePath) return null;
+  try {
+    const cfg = JSON.parse(readFileSync(join(worktreePath, ".catalyst", "config.json"), "utf8"));
+    const dir = cfg?.catalyst?.thoughts?.directory;
+    return typeof dir === "string" && dir.length > 0 ? dir : null;
+  } catch {
+    return null;
+  }
+}
+
+// resolveConfiguredThoughtsAnchor — validates a resolved `thoughts/shared`
+// target against the worktree's configured thoughts directory, requiring the
+// SAME `/repos/<directory>/` segment lib/assert-thoughts-project.sh requires
+// (the two checks are independent implementations of the identical contract
+// on purpose — one shell, one JS — not a shared function call). On a match,
+// derives and returns the THOUGHTS_REPO root (everything before that
+// segment) so the sibling `thoughts/global` target — always
+// `<THOUGHTS_REPO>/<globalDir>` per lib/provision-thoughts.sh /
+// worktree-thoughts-init.sh — can be validated as nested under that SAME,
+// now-trusted root rather than trusted independently. Returns null when
+// there is no configured directory to check (fail-open — caller falls back
+// to isSaneThoughtsTarget) OR when a configured directory is present but the
+// resolved target does NOT contain the expected segment (fail-CLOSED — a
+// declared, non-matching directory is a genuine mismatch, not an absence,
+// and the caller must reject the target outright rather than fall back).
+function resolveConfiguredThoughtsAnchor(worktreePath, resolvedSharedTarget) {
+  const directory = resolveConfiguredThoughtsDirectory(worktreePath);
+  if (!directory) return { anchor: null, mismatch: false };
+  const expectedSegment = `/repos/${directory}/`;
+  const idx = resolvedSharedTarget.indexOf(expectedSegment);
+  if (idx === -1) return { anchor: null, mismatch: true };
+  return { anchor: resolvedSharedTarget.slice(0, idx), mismatch: false };
 }
 
 // resolveThoughtsRoots — the REAL path(s) any symlink under the worktree's
@@ -354,6 +411,13 @@ function isSaneThoughtsTarget(p) {
 // 2026-08-07 hardening (round-2 review, PR #3082): both shapes below are now
 // gated by isSaneThoughtsTarget — see its comment for the sandbox-escape
 // scenario this closes.
+//
+// 2026-08-07 hardening, round 2 (round-3 review, same PR): a bare structural
+// floor alone was insufficient (any attacker-chosen 2+-segment path still
+// passed). The real-directory shape below now validates `shared`/`global`
+// against the worktree's CONFIGURED thoughts directory when one is declared
+// — see resolveConfiguredThoughtsAnchor's doc comment — falling back to the
+// structural floor only when no thoughts directory is configured at all.
 //
 // Handles BOTH shapes: `thoughts` itself being a symlink (the legacy/simple
 // case this function originally assumed), and `thoughts` being a real
@@ -383,20 +447,62 @@ function resolveThoughtsRoots(worktreePath) {
   // is left alone — it's already inside the worktree and needs no additional
   // writable root. Any OTHER symlinked entry (unprovisioned name) is skipped
   // outright, never resolved.
+  //
+  // `shared` is resolved FIRST (fixed iteration order below, not readdir
+  // order) so its config-validated target can anchor `global`'s validation —
+  // see resolveConfiguredThoughtsAnchor's doc comment.
+  //
+  // Two DISTINCT validation regimes, chosen ONCE by whether this worktree
+  // declares a thoughts directory at all (`configuredDirectory`, read once
+  // up front — not re-derived per entry):
+  //   - CONFIGURED (the common case for every catalyst-managed worktree):
+  //     `shared` must match the declared `/repos/<directory>/` segment or is
+  //     rejected outright (fail-CLOSED — a declared, non-matching directory
+  //     is a genuine mismatch). `global` must nest under THAT validated
+  //     anchor or is likewise rejected outright — no structural fallback for
+  //     either entry once a directory is declared, since a fixed segment
+  //     count alone is exactly the insufficient guard Codex's round-3 finding
+  //     flagged (an attacker-chosen 2+-segment target still passes a bare
+  //     length check).
+  //   - UNCONFIGURED (no `.catalyst/config.json` thoughts directory at all):
+  //     nothing to validate against — fall back to the structural floor
+  //     (isSaneThoughtsTarget) independently for each entry, the same
+  //     fail-open precedent lib/assert-thoughts-project.sh already sets for
+  //     an unconfigured project.
   const out = [];
   let entries;
   try {
-    entries = readdirSync(thoughtsPath);
+    entries = new Set(readdirSync(thoughtsPath));
   } catch {
     return [];
   }
-  for (const entry of entries) {
-    if (!PROVISIONED_THOUGHTS_ENTRIES.has(entry)) continue;
+  const configuredDirectory = resolveConfiguredThoughtsDirectory(worktreePath);
+  let anchor = null; // THOUGHTS_REPO root, once `shared` validates against config
+  for (const entry of ["shared", "global"]) {
+    if (!entries.has(entry) || !PROVISIONED_THOUGHTS_ENTRIES.has(entry)) continue;
     const entryPath = join(thoughtsPath, entry);
     try {
       if (!lstatSync(entryPath).isSymbolicLink()) continue;
       const real = realpathSync(entryPath);
-      if (isSaneThoughtsTarget(real)) out.push(real);
+      if (!configuredDirectory) {
+        // UNCONFIGURED regime — structural floor only, no anchor tracking.
+        if (isSaneThoughtsTarget(real)) out.push(real);
+        continue;
+      }
+      // CONFIGURED regime — anchor-only, no structural fallback.
+      if (entry === "shared") {
+        const { anchor: derived } = resolveConfiguredThoughtsAnchor(worktreePath, real);
+        if (derived) {
+          anchor = derived;
+          out.push(real);
+        }
+        // else: declared directory present but `shared`'s target doesn't
+        // contain the expected segment — reject outright, `anchor` stays null.
+      } else if (anchor && (real === anchor || real.startsWith(`${anchor}/`))) {
+        out.push(real);
+        // else: no validated anchor (shared missing/mismatched), or global
+        // doesn't nest under it — reject outright.
+      }
     } catch {
       // Broken symlink / permission error on this one entry — skip it, keep
       // going; never let one bad entry drop the rest of the census.

--- a/plugins/dev/scripts/execution-core/codex-run-phase-agent.test.mjs
+++ b/plugins/dev/scripts/execution-core/codex-run-phase-agent.test.mjs
@@ -635,6 +635,107 @@ describe("buildCodexArgs — thoughts/ symlink resolution into writable_roots", 
       rmSync(root, { recursive: true, force: true });
     }
   });
+
+  // 2026-08-07 P1 follow-up (Codex round-3, PR #3082): a bare segment-count
+  // floor alone is insufficient — an attacker-chosen target with 2+ segments
+  // (e.g. `/home/alice`) still passes a length-only check while granting
+  // write access to an unrelated directory. Once a worktree declares
+  // `.catalyst/config.json` → `catalyst.thoughts.directory`, resolution must
+  // be validated against THAT configured repository, not shape alone.
+  function writeThoughtsDirectoryConfig(worktreePath, directory) {
+    mkdirSync(join(worktreePath, ".catalyst"), { recursive: true });
+    writeFileSync(
+      join(worktreePath, ".catalyst", "config.json"),
+      JSON.stringify({ catalyst: { thoughts: { directory } } }),
+    );
+  }
+
+  test("SECURITY (configured regime): thoughts/shared -> /home/alice (2 segments, matches the OLD floor) is rejected once a thoughts directory is configured and doesn't match", () => {
+    const { root, worktreePath } = makeWorktreeWithThoughts(({ worktreePath }) => {
+      writeThoughtsDirectoryConfig(worktreePath, "coppa");
+      const thoughtsDir = join(worktreePath, "thoughts");
+      mkdirSync(thoughtsDir, { recursive: true });
+      // Attacker-chosen, unrelated, but structurally "sane" (2-segment) target.
+      symlinkSync("/private", join(thoughtsDir, "shared"));
+    });
+    try {
+      const spec = makeCodexSpec();
+      const args = buildCodexArgs(spec, CFG, { orchDir: "/ec", worktreePath });
+      const roots = extractWritableRoots(args);
+      expect(roots).toEqual([...CFG.writableRoots, "/ec"]);
+      expect(roots).not.toContain("/private");
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  test("configured regime: a MATCHING thoughts/shared (…/repos/<directory>/shared) is accepted, and thoughts/global is validated against the SAME derived anchor", () => {
+    const { root, worktreePath } = makeWorktreeWithThoughts(({ worktreePath, external }) => {
+      writeThoughtsDirectoryConfig(worktreePath, "coppa");
+      const thoughtsDir = join(worktreePath, "thoughts");
+      mkdirSync(thoughtsDir, { recursive: true });
+      const sharedTarget = join(external, "repos", "coppa", "shared");
+      const globalTarget = join(external, "global");
+      mkdirSync(sharedTarget, { recursive: true });
+      mkdirSync(globalTarget, { recursive: true });
+      symlinkSync(sharedTarget, join(thoughtsDir, "shared"));
+      symlinkSync(globalTarget, join(thoughtsDir, "global"));
+    });
+    try {
+      const spec = makeCodexSpec();
+      const args = buildCodexArgs(spec, CFG, { orchDir: "/ec", worktreePath });
+      const roots = extractWritableRoots(args);
+      expect(roots).toContain(join(root, "external-thoughts-repo", "repos", "coppa", "shared"));
+      expect(roots).toContain(join(root, "external-thoughts-repo", "global"));
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  test("configured regime: thoughts/global pointed OUTSIDE the validated shared anchor (a sibling repo, not nested under THOUGHTS_REPO) is rejected even though shared itself is legitimate", () => {
+    const { root, worktreePath } = makeWorktreeWithThoughts(({ root, worktreePath, external }) => {
+      writeThoughtsDirectoryConfig(worktreePath, "coppa");
+      const thoughtsDir = join(worktreePath, "thoughts");
+      mkdirSync(thoughtsDir, { recursive: true });
+      const sharedTarget = join(external, "repos", "coppa", "shared");
+      mkdirSync(sharedTarget, { recursive: true });
+      symlinkSync(sharedTarget, join(thoughtsDir, "shared"));
+      // `global` re-pointed at a structurally-sane directory that is NOT
+      // nested under the shared-derived THOUGHTS_REPO anchor (`external`) —
+      // a sibling directory under `root` instead.
+      const rogueGlobal = join(root, "unrelated-sibling-dir");
+      mkdirSync(rogueGlobal, { recursive: true });
+      symlinkSync(rogueGlobal, join(thoughtsDir, "global"));
+    });
+    try {
+      const spec = makeCodexSpec();
+      const args = buildCodexArgs(spec, CFG, { orchDir: "/ec", worktreePath });
+      const roots = extractWritableRoots(args);
+      expect(roots).toContain(join(root, "external-thoughts-repo", "repos", "coppa", "shared"));
+      expect(roots).not.toContain(join(root, "unrelated-sibling-dir"));
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  test("configured regime: a DECLARED-but-mismatched directory rejects shared outright even though it resolves elsewhere on-disk", () => {
+    const { root, worktreePath } = makeWorktreeWithThoughts(({ worktreePath, external }) => {
+      writeThoughtsDirectoryConfig(worktreePath, "wrong-project");
+      const thoughtsDir = join(worktreePath, "thoughts");
+      mkdirSync(thoughtsDir, { recursive: true });
+      const sharedTarget = join(external, "repos", "coppa", "shared");
+      mkdirSync(sharedTarget, { recursive: true });
+      symlinkSync(sharedTarget, join(thoughtsDir, "shared"));
+    });
+    try {
+      const spec = makeCodexSpec();
+      const args = buildCodexArgs(spec, CFG, { orchDir: "/ec", worktreePath });
+      const roots = extractWritableRoots(args);
+      expect(roots).toEqual([...CFG.writableRoots, "/ec"]);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
 });
 
 // ── buildCodexEnv ───────────────────────────────────────────────────────────

--- a/plugins/dev/scripts/execution-core/codex-run-phase-agent.test.mjs
+++ b/plugins/dev/scripts/execution-core/codex-run-phase-agent.test.mjs
@@ -580,6 +580,61 @@ describe("buildCodexArgs — thoughts/ symlink resolution into writable_roots", 
       rmSync(root, { recursive: true, force: true });
     }
   });
+
+  // 2026-08-07 hardening (round-2 review, PR #3082): a prior codex turn already
+  // has write access to its OWN worktree (including thoughts/), so it can plant
+  // an arbitrary symlink there for free. These tests prove that planted symlink
+  // can't turn into a FUTURE dispatch's filesystem-wide writable_roots grant.
+
+  test("an UNPROVISIONED symlink name under thoughts/ (e.g. thoughts/root -> /) is never resolved into writable_roots", () => {
+    const { root, worktreePath } = makeWorktreeWithThoughts(({ worktreePath }) => {
+      const thoughtsDir = join(worktreePath, "thoughts");
+      mkdirSync(thoughtsDir, { recursive: true });
+      // Not "shared" or "global" — an attacker/compromised-turn-planted name.
+      symlinkSync("/", join(thoughtsDir, "root"));
+    });
+    try {
+      const spec = makeCodexSpec();
+      const args = buildCodexArgs(spec, CFG, { orchDir: "/ec", worktreePath });
+      const roots = extractWritableRoots(args);
+      expect(roots).toEqual([...CFG.writableRoots, "/ec"]);
+      expect(roots).not.toContain("/");
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  test("a PROVISIONED entry (thoughts/shared) resolving to a dangerously shallow target (/) is excluded, not granted", () => {
+    const { root, worktreePath } = makeWorktreeWithThoughts(({ worktreePath }) => {
+      const thoughtsDir = join(worktreePath, "thoughts");
+      mkdirSync(thoughtsDir, { recursive: true });
+      symlinkSync("/", join(thoughtsDir, "shared"));
+    });
+    try {
+      const spec = makeCodexSpec();
+      const args = buildCodexArgs(spec, CFG, { orchDir: "/ec", worktreePath });
+      const roots = extractWritableRoots(args);
+      expect(roots).toEqual([...CFG.writableRoots, "/ec"]);
+      expect(roots).not.toContain("/");
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  test("LEGACY shape: thoughts itself symlinked straight to / is excluded, not granted", () => {
+    const { root, worktreePath } = makeWorktreeWithThoughts(({ worktreePath }) => {
+      symlinkSync("/", join(worktreePath, "thoughts"));
+    });
+    try {
+      const spec = makeCodexSpec();
+      const args = buildCodexArgs(spec, CFG, { orchDir: "/ec", worktreePath });
+      const roots = extractWritableRoots(args);
+      expect(roots).toEqual([...CFG.writableRoots, "/ec"]);
+      expect(roots).not.toContain("/");
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
 });
 
 // ── buildCodexEnv ───────────────────────────────────────────────────────────

--- a/plugins/dev/scripts/execution-core/codex-run-phase-agent.test.mjs
+++ b/plugins/dev/scripts/execution-core/codex-run-phase-agent.test.mjs
@@ -16,7 +16,9 @@ import {
   readdirSync,
   readFileSync,
   readlinkSync,
+  realpathSync,
   rmSync,
+  symlinkSync,
   writeFileSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
@@ -453,6 +455,130 @@ describe("buildCodexArgs", () => {
 
     Bun.spawnSync(["git", "worktree", "remove", "--force", wt], { cwd: main });
     rmSync(main, { recursive: true, force: true });
+  });
+});
+
+// ── buildCodexArgs: thoughts/ symlink resolution into writable_roots ─────────
+//
+// The REAL on-disk convention (lib/provision-thoughts.sh) is NOT "thoughts is a
+// symlink" — it's "thoughts is a real directory whose immediate entries (global,
+// shared) are themselves symlinks pointing OUTSIDE the worktree." A prior version
+// of resolveThoughtsRoot only ever `realpathSync`'d the `thoughts` directory
+// itself, which — since `thoughts` isn't a symlink in this shape — just returned
+// the unchanged worktree-local path and never added the actual external target
+// at all. Confirmed live 2026-08-03: this silently broke every research/plan
+// artifact write for codex-exec-routed phases across 4+ real tickets
+// (COP-3/COP-5/CQD-5/CQD-7), each failing with a "thoughts/shared symlink target
+// outside writable roots" sandbox denial.
+describe("buildCodexArgs — thoughts/ symlink resolution into writable_roots", () => {
+  function extractWritableRoots(args) {
+    const idx = args.indexOf("-c");
+    for (let i = idx; i < args.length; i += 2) {
+      const flag = args[i + 1];
+      if (typeof flag === "string" && flag.startsWith("sandbox_workspace_write.writable_roots=")) {
+        return JSON.parse(flag.slice("sandbox_workspace_write.writable_roots=".length));
+      }
+    }
+    throw new Error("writable_roots flag not found in args");
+  }
+
+  function makeWorktreeWithThoughts(build) {
+    // realpathSync the temp root immediately: macOS's /tmp (and /var) are
+    // themselves symlinks into /private/..., so anything resolveThoughtsRoots
+    // resolves via realpathSync comes back CANONICALIZED — comparing against
+    // an un-canonicalized `root` would spuriously fail on macOS specifically.
+    const root = realpathSync(mkdtempSync(join(tmpdir(), "codex-thoughts-")));
+    const worktreePath = join(root, "wt", "CTL-100");
+    mkdirSync(worktreePath, { recursive: true });
+    const external = join(root, "external-thoughts-repo");
+    mkdirSync(external, { recursive: true });
+    build({ root, worktreePath, external });
+    return { root, worktreePath, external };
+  }
+
+  test("REAL on-disk shape: thoughts/ is a real dir; its shared + global entries are symlinks — both real targets land in writable_roots", () => {
+    const { root, worktreePath } = makeWorktreeWithThoughts(({ root, worktreePath, external }) => {
+      const thoughtsDir = join(worktreePath, "thoughts");
+      mkdirSync(thoughtsDir, { recursive: true });
+      const sharedTarget = join(external, "repos", "coppa", "shared");
+      const globalTarget = join(external, "global");
+      mkdirSync(sharedTarget, { recursive: true });
+      mkdirSync(globalTarget, { recursive: true });
+      symlinkSync(sharedTarget, join(thoughtsDir, "shared"));
+      symlinkSync(globalTarget, join(thoughtsDir, "global"));
+      // A REAL (non-symlink) subdirectory alongside the symlinks — must be ignored.
+      mkdirSync(join(thoughtsDir, "searchable"), { recursive: true });
+    });
+    try {
+      const spec = makeCodexSpec();
+      const args = buildCodexArgs(spec, CFG, { orchDir: "/ec", worktreePath });
+      const roots = extractWritableRoots(args);
+      expect(roots).toContain(join(root, "external-thoughts-repo", "repos", "coppa", "shared"));
+      expect(roots).toContain(join(root, "external-thoughts-repo", "global"));
+      // The worktree-local thoughts/ path itself is not a useful ADDITIONAL root
+      // (it's already inside the worktree) and must not be added redundantly.
+      expect(roots).not.toContain(join(worktreePath, "thoughts"));
+      expect(roots).not.toContain(join(worktreePath, "thoughts", "searchable"));
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  test("LEGACY shape preserved: thoughts itself IS a direct symlink — still resolves to its target", () => {
+    const { root, worktreePath } = makeWorktreeWithThoughts(({ worktreePath, external }) => {
+      symlinkSync(external, join(worktreePath, "thoughts"));
+    });
+    try {
+      const spec = makeCodexSpec();
+      const args = buildCodexArgs(spec, CFG, { orchDir: "/ec", worktreePath });
+      const roots = extractWritableRoots(args);
+      expect(roots).toContain(join(root, "external-thoughts-repo"));
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  test("thoughts/ has no symlinked entries at all (real subdirs only) — adds nothing, does not throw", () => {
+    const { root, worktreePath } = makeWorktreeWithThoughts(({ worktreePath }) => {
+      mkdirSync(join(worktreePath, "thoughts", "searchable"), { recursive: true });
+    });
+    try {
+      const spec = makeCodexSpec();
+      const args = buildCodexArgs(spec, CFG, { orchDir: "/ec", worktreePath });
+      const roots = extractWritableRoots(args);
+      expect(roots).toEqual([...CFG.writableRoots, "/ec"]);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  test("no thoughts/ directory at all under the worktree — adds nothing, does not throw", () => {
+    const { root, worktreePath } = makeWorktreeWithThoughts(() => {});
+    try {
+      const spec = makeCodexSpec();
+      const args = buildCodexArgs(spec, CFG, { orchDir: "/ec", worktreePath });
+      const roots = extractWritableRoots(args);
+      expect(roots).toEqual([...CFG.writableRoots, "/ec"]);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  test("a BROKEN symlink inside thoughts/ (dangling target) is skipped, not thrown", () => {
+    const { root, worktreePath } = makeWorktreeWithThoughts(({ worktreePath, external }) => {
+      const thoughtsDir = join(worktreePath, "thoughts");
+      mkdirSync(thoughtsDir, { recursive: true });
+      symlinkSync(join(external, "does-not-exist"), join(thoughtsDir, "shared"));
+    });
+    try {
+      const spec = makeCodexSpec();
+      // Must not throw despite the dangling symlink.
+      const args = buildCodexArgs(spec, CFG, { orchDir: "/ec", worktreePath });
+      const roots = extractWritableRoots(args);
+      expect(roots).toEqual([...CFG.writableRoots, "/ec"]);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
   });
 });
 

--- a/plugins/dev/scripts/execution-core/event-log-read-guard.test.mjs
+++ b/plugins/dev/scripts/execution-core/event-log-read-guard.test.mjs
@@ -160,6 +160,21 @@ const ALLOWLIST = [
       "it), so a fixed tail would intermittently report 'no question raised' — the exact false " +
       "negative the inbox exists to catch. Bounding needs a backwards CHUNKED scan, not a byte cap.",
   },
+  {
+    file: "execution-core/recovery.mjs",
+    count: 2,
+    symbol: "readExecCoreBootEpoch + readBootEpoch",
+    ticket: "CTL-1442",
+    reason:
+      "NEITHER site reads anything resembling a JSONL log. readExecCoreBootEpoch reads " +
+      "daemon-boot.json (a single small JSON object: `{bootedAt}`) and readBootEpoch's linux branch " +
+      "reads `/proc/stat` (a kernel pseudo-file). Both pre-date this ticket; they were never flagged " +
+      "before (0 violations in this file) and only started matching once detectSessionRateLimitHit " +
+      "was added elsewhere in this same (large, module-global-taint-scanned) file — a false-positive " +
+      "side effect of the detector's over-approximation, exactly the tradeoff its own header accepts " +
+      "('prefer allowlistable false positives over silent false negatives'). Nothing to bound: neither " +
+      "file is JSONL, let alone append-only or growing.",
+  },
 ];
 
 // ─── the scanner ────────────────────────────────────────────────────────────

--- a/plugins/dev/scripts/execution-core/recovery.mjs
+++ b/plugins/dev/scripts/execution-core/recovery.mjs
@@ -2464,6 +2464,16 @@ export function reclaimDeadWorkIfPossible(
     // cycling through the ask-cap, so their caller-supplied finalAttemptCount
     // already carries real, correct meaning and must not be overridden.
     const effectiveAttemptCount = capApplies ? priorAsks + 1 : finalAttemptCount;
+    // Codex P2 (round 1, PR #3082): reassertTerminalIfLost is a REPAIR — it
+    // re-writes a lost/malformed stalled signal without recording a new ask
+    // (no appendEscalatedEvent/recordEscalationFn call on this path). When the
+    // repair is triggered by a spent cap, the "+1" in effectiveAttemptCount
+    // wrongly counts THIS repair as a new attempt, inflating a 3-ask cap into
+    // a persisted "4 attempt(s)". Use the recorded priorAsks (no +1) for a
+    // capSpent repair; the no-probe-for-phase repair path (capSpent === false)
+    // already carries the correct caller-supplied finalAttemptCount via
+    // effectiveAttemptCount, so it is left untouched.
+    const repairAttemptCount = capSpent ? priorAsks : effectiveAttemptCount;
     const reassertTerminalIfLost = () => {
       let already = null;
       try {
@@ -2478,7 +2488,7 @@ export function reclaimDeadWorkIfPossible(
         orchDir,
         ticket,
         phase,
-        explanation: buildEscExplanation(),
+        explanation: buildEscExplanation(repairAttemptCount),
         stalledReason: capSpent ? "escalation-ask-cap" : reason,
       });
       log.warn(
@@ -2500,15 +2510,19 @@ export function reclaimDeadWorkIfPossible(
     // all other reasons → AUTHORIZATION (agent can retry with authority).
     // CTL-1442: wrapped as a (pure) builder so the spent-cap re-assert can
     // produce a fresh brief lazily without duplicating the CTL-1130 logic.
-    function buildEscExplanation() {
+    // Codex P2 (round 1, PR #3082): accepts an explicit `attemptCount`
+    // (defaulting to effectiveAttemptCount, the genuine-new-ask value) so a
+    // capSpent REPAIR call can pass the recorded priorAsks instead — see
+    // repairAttemptCount above.
+    function buildEscExplanation(attemptCount = effectiveAttemptCount) {
     const escType = reasonToType(reason);
-    const whyField = reasonToWhyField(reason, effectiveAttemptCount);
+    const whyField = reasonToWhyField(reason, attemptCount);
     let explanation;
     const explanationFields =
       escType === "manual"
         ? {
             escalation_type: "manual",
-            problem: `${phase} escalated after ${effectiveAttemptCount} attempt(s): ${reason}`,
+            problem: `${phase} escalated after ${attemptCount} attempt(s): ${reason}`,
             call_to_action:
               extras?.call_to_action ??
               `grant the required capability and re-run ${ticket} ${phase}, or push manually?`,
@@ -2517,20 +2531,20 @@ export function reclaimDeadWorkIfPossible(
             instructions: extras?.instructions ?? ["check CATALYST_WORKFLOW_GITHUB_TOKEN"],
             remediation_then_retry: `re-run ${ticket} ${phase} after granting the capability`,
             why_not_auto: whyField.value,
-            observed: { final_attempt_count: effectiveAttemptCount, ...(extras?.observed ?? {}) },
+            observed: { final_attempt_count: attemptCount, ...(extras?.observed ?? {}) },
             attempts: extras?.attempts ?? [],
           }
         : {
             escalation_type: "authorization",
-            problem: `${phase} escalated after ${effectiveAttemptCount} attempt(s): ${reason}`,
+            problem: `${phase} escalated after ${attemptCount} attempt(s): ${reason}`,
             call_to_action:
               extras?.call_to_action ?? `authorize ${ticket} ${phase} to retry or change approach?`,
             recommendation: `retry ${ticket} ${phase} after investigating ${reason}`,
-            risk: `continued retries risk wasting budget; ${effectiveAttemptCount} attempt(s) already made`,
+            risk: `continued retries risk wasting budget; ${attemptCount} attempt(s) already made`,
             why_asking: whyField.value,
             could_higher_tier_resolve: tierProducer(extras?.model ?? signal?.raw?.model),
             authorize_label: `retry ${ticket} ${phase}`,
-            observed: { final_attempt_count: effectiveAttemptCount, ...(extras?.observed ?? {}) },
+            observed: { final_attempt_count: attemptCount, ...(extras?.observed ?? {}) },
             // CTL-1442: truthful ask history — this call site historically passed
             // no extras, so the payload showed attempts:[] forever while asking
             // "authorize retry?" every window (audit RC4). Scoped to the SAME
@@ -3454,11 +3468,15 @@ export function reclaimDeadWorkIfPossible(
       currentProgress,
       rateLimited
         ? {
+            // Codex P2 (round 1, PR #3082): detectRateLimit only inspects the
+            // ONE latest dead session (prevBgJobId) — earlier attempts may
+            // have done real work or failed for unrelated reasons, so this
+            // must describe the detected attempt only, not claim "every".
             call_to_action:
-              `${ticket} ${phase} looks like it hit a Claude account usage/rate limit on every ` +
-              "attempt (its dead session transcript shows the harness's own rate-limit reply, " +
-              "not real work) — wait for the usage window to reset and reply to retry, or reroute " +
-              "this phase to a different executor?",
+              `${ticket} ${phase}'s latest dead attempt looks like it hit a Claude account ` +
+              "usage/rate limit (its dead session transcript shows the harness's own " +
+              "rate-limit reply, not real work) — wait for the usage window to reset and " +
+              "reply to retry, or reroute this phase to a different executor?",
             observed: { likely_cause: "account-rate-limited" },
           }
         : undefined,

--- a/plugins/dev/scripts/execution-core/recovery.mjs
+++ b/plugins/dev/scripts/execution-core/recovery.mjs
@@ -2348,6 +2348,21 @@ export function reclaimDeadWorkIfPossible(
     // as capSpent, since markEscalationCapTerminal is purely a local
     // tmp+rename write with no Linear/event I/O of its own.
     const mustTerminalizeLocally = capSpent || reason === "no-probe-for-phase";
+    // 2026-08-03 fix (confirmed live across 11 real tickets): for "no-progress",
+    // the caller passes the CTL-736 progress QUANTITY (commits-ahead / doc-size)
+    // as `finalAttemptCount` — not an attempt count. Since the escalate-vs-
+    // continue decision is made by the caller BEFORE this call, keyed on that
+    // quantity being <= the prior value, it is almost always 0 — so every
+    // no-progress escalation's human-facing text read "escalated after 0
+    // attempt(s)" regardless of how many real ask/retry cycles actually ran.
+    // The `attempts` array below is correctly built from the REAL ask history
+    // (priorAsks, +1 for the current ask) — use that same real count for every
+    // display/audit field too, but ONLY for this reason: the other three
+    // reasons (busy-ceiling-exceeded, no-probe-for-phase,
+    // wedged-never-started-exhausted) escalate on a single call rather than
+    // cycling through the ask-cap, so their caller-supplied finalAttemptCount
+    // already carries real, correct meaning and must not be overridden.
+    const effectiveAttemptCount = capApplies ? priorAsks + 1 : finalAttemptCount;
     const reassertTerminalIfLost = () => {
       let already = null;
       try {
@@ -2386,13 +2401,13 @@ export function reclaimDeadWorkIfPossible(
     // produce a fresh brief lazily without duplicating the CTL-1130 logic.
     function buildEscExplanation() {
     const escType = reasonToType(reason);
-    const whyField = reasonToWhyField(reason, finalAttemptCount);
+    const whyField = reasonToWhyField(reason, effectiveAttemptCount);
     let explanation;
     const explanationFields =
       escType === "manual"
         ? {
             escalation_type: "manual",
-            problem: `${phase} escalated after ${finalAttemptCount} attempt(s): ${reason}`,
+            problem: `${phase} escalated after ${effectiveAttemptCount} attempt(s): ${reason}`,
             call_to_action:
               extras?.call_to_action ??
               `grant the required capability and re-run ${ticket} ${phase}, or push manually?`,
@@ -2401,20 +2416,20 @@ export function reclaimDeadWorkIfPossible(
             instructions: extras?.instructions ?? ["check CATALYST_WORKFLOW_GITHUB_TOKEN"],
             remediation_then_retry: `re-run ${ticket} ${phase} after granting the capability`,
             why_not_auto: whyField.value,
-            observed: { final_attempt_count: finalAttemptCount, ...(extras?.observed ?? {}) },
+            observed: { final_attempt_count: effectiveAttemptCount, ...(extras?.observed ?? {}) },
             attempts: extras?.attempts ?? [],
           }
         : {
             escalation_type: "authorization",
-            problem: `${phase} escalated after ${finalAttemptCount} attempt(s): ${reason}`,
+            problem: `${phase} escalated after ${effectiveAttemptCount} attempt(s): ${reason}`,
             call_to_action:
               extras?.call_to_action ?? `authorize ${ticket} ${phase} to retry or change approach?`,
             recommendation: `retry ${ticket} ${phase} after investigating ${reason}`,
-            risk: `continued retries risk wasting budget; ${finalAttemptCount} attempt(s) already made`,
+            risk: `continued retries risk wasting budget; ${effectiveAttemptCount} attempt(s) already made`,
             why_asking: whyField.value,
             could_higher_tier_resolve: tierProducer(extras?.model ?? signal?.raw?.model),
             authorize_label: `retry ${ticket} ${phase}`,
-            observed: { final_attempt_count: finalAttemptCount, ...(extras?.observed ?? {}) },
+            observed: { final_attempt_count: effectiveAttemptCount, ...(extras?.observed ?? {}) },
             // CTL-1442: truthful ask history — this call site historically passed
             // no extras, so the payload showed attempts:[] forever while asking
             // "authorize retry?" every window (audit RC4). Scoped to the SAME
@@ -2472,7 +2487,7 @@ export function reclaimDeadWorkIfPossible(
         ticket,
         orchId,
         reason,
-        final_attempt_count: finalAttemptCount,
+        final_attempt_count: effectiveAttemptCount,
         extras: enrichedExtras,
       });
     }

--- a/plugins/dev/scripts/execution-core/recovery.mjs
+++ b/plugins/dev/scripts/execution-core/recovery.mjs
@@ -191,9 +191,15 @@ export function detectSessionRateLimitHit(
   bgJobId,
   {
     resolveSession = resolvePhaseSessionId,
-    findTranscript: findT = findTranscript,
+    // Both seams below are named distinctly (no `key: alias = outerName`
+    // destructuring-default shape) so the event-log-read-guard's module-
+    // global, name-keyed heuristic has no ambiguous `key = value` line to
+    // misread as a taint-relevant assignment — see the CTL-1442 allowlist
+    // entry in event-log-read-guard.test.mjs for the reads this file's
+    // scanner already flags for unrelated reasons.
+    findTranscriptFn = findTranscript,
     projectsDir = defaultProjectsDir(),
-    readFileSync: readFile = readFileSync,
+    readTranscriptFn = readFileSync,
     // Only the tail of the transcript is inspected — a genuine rate-limit hit
     // ends the session immediately, so the tell-tale text is at or near the
     // end even for a longer-lived worker that hit the limit mid-run.
@@ -210,14 +216,17 @@ export function detectSessionRateLimitHit(
   if (!sessionId) return false;
   let transcriptPath;
   try {
-    transcriptPath = findT(sessionId, projectsDir);
+    transcriptPath = findTranscriptFn(sessionId, projectsDir);
   } catch {
     return false;
   }
   if (!transcriptPath) return false;
   let lines;
   try {
-    lines = readFile(transcriptPath, "utf8").split("\n").filter((l) => l.trim() !== "");
+    // EVENT-LOG-FULL-READ-OK(CTL-1442): NOT the shared event log — one dead
+    // worker's own session transcript, bounded by that single run's turn
+    // count, checked once per no-progress STOP (a cold, rare path).
+    lines = readTranscriptFn(transcriptPath, "utf8").split("\n").filter((l) => l.trim() !== "");
   } catch {
     return false;
   }
@@ -1663,6 +1672,8 @@ export function readBootSince(orchDir) {
 // refreshes), this is THIS exec-core instance's own start time — written
 // atomically by writeBootMarker at startDaemon line 1, before detectColdStart
 // runs. Any --bg worker whose state.json mtime predates it is provably dead.
+// EVENT-LOG-FULL-READ-OK(CTL-1442): daemon-boot.json is a single small JSON
+// object ({bootedAt}), never a JSONL log.
 export function readExecCoreBootEpoch(orchDir, { read = (p) => readFileSync(p, "utf8") } = {}) {
   if (!orchDir) return 0;
   try {
@@ -1743,6 +1754,8 @@ export function clearProgressMarks(orchDir, { rm = rmSync } = {}) {
 //   linux:  /proc/stat line "btime <n>" (absolute boot epoch seconds; stable,
 //           unlike /proc/uptime which drifts with clock adjustments).
 // Injectable platform/spawn/readFile for deterministic tests. Never throws.
+// EVENT-LOG-FULL-READ-OK(CTL-1442): the linux branch reads /proc/stat, a
+// kernel pseudo-file, never a JSONL log.
 export function readBootEpoch({
   platform = process.platform,
   spawn = spawnSync,

--- a/plugins/dev/scripts/execution-core/recovery.mjs
+++ b/plugins/dev/scripts/execution-core/recovery.mjs
@@ -163,6 +163,88 @@ import { resolvePhaseSessionId } from "./session-resolve.mjs";
 export { resolvePhaseSessionId };
 import { buildExplanation, coerceExplanation, tierProducer } from "./escalation-explanation.mjs";
 
+// detectSessionRateLimitHit — best-effort: did the dead worker's OWN session
+// immediately hit a Claude account usage/session limit, rather than genuinely
+// failing to make progress on the ticket's actual work?
+//
+// Confirmed live 2026-08-03: 11 tickets across 2 hosts all escalated as
+// generic "no-progress" after 3 real retry cycles, each ~10 min apart — but
+// every one of their dead sessions' transcripts consisted of nothing but the
+// harness's own canned reply ("You've hit your session limit · resets
+// <time>") with ZERO tool use, for EVERY attempt. The CTL-736 progress gate
+// correctly measured zero forward progress (nothing was ever attempted), and
+// the 3-strikes ask-cap correctly escalated — the STOP/escalate MACHINERY was
+// never wrong. What was wrong is the human-facing explanation: "no forward
+// progress" reads as "the WORK is stuck," when the true story is "the
+// ACCOUNT was rate-limited," which took real session-transcript archaeology
+// to uncover and cost real operator time. This function lets the no-progress
+// escalation's `extras` carry that distinction so the NEXT occurrence is
+// immediately diagnosable from the Linear comment alone.
+//
+// Deliberately does NOT change the STOP/escalate/ask-cap decision or timing —
+// only enriches the explanation once that decision has already been made
+// (see the no-progress call site). Best-effort throughout: a missing
+// bg_job_id, an unresolvable session, a missing/unreadable transcript, or a
+// malformed line never throws — it just means "we couldn't tell," not "it
+// didn't happen."
+export function detectSessionRateLimitHit(
+  bgJobId,
+  {
+    resolveSession = resolvePhaseSessionId,
+    findTranscript: findT = findTranscript,
+    projectsDir = defaultProjectsDir(),
+    readFileSync: readFile = readFileSync,
+    // Only the tail of the transcript is inspected — a genuine rate-limit hit
+    // ends the session immediately, so the tell-tale text is at or near the
+    // end even for a longer-lived worker that hit the limit mid-run.
+    tailLines = 20,
+  } = {},
+) {
+  if (!bgJobId) return false;
+  let sessionId;
+  try {
+    sessionId = resolveSession(bgJobId);
+  } catch {
+    return false;
+  }
+  if (!sessionId) return false;
+  let transcriptPath;
+  try {
+    transcriptPath = findT(sessionId, projectsDir);
+  } catch {
+    return false;
+  }
+  if (!transcriptPath) return false;
+  let lines;
+  try {
+    lines = readFile(transcriptPath, "utf8").split("\n").filter((l) => l.trim() !== "");
+  } catch {
+    return false;
+  }
+  const start = Math.max(0, lines.length - tailLines);
+  for (let i = lines.length - 1; i >= start; i--) {
+    let entry;
+    try {
+      entry = JSON.parse(lines[i]);
+    } catch {
+      continue;
+    }
+    if (entry?.type !== "assistant") continue;
+    const content = entry?.message?.content;
+    if (!Array.isArray(content)) continue;
+    for (const c of content) {
+      if (
+        c?.type === "text" &&
+        typeof c.text === "string" &&
+        /hit your (session|usage) limit/i.test(c.text)
+      ) {
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
 // defaultStatJob — stat ~/.claude/jobs/<bgJobId>/state.json. Returns null when
 // the job dir is gone (the worker's process no longer exists), else its mtime,
 // parsed .state, and .firstTerminalAt. Injectable so tests never touch real
@@ -1964,6 +2046,12 @@ export function reclaimDeadWorkIfPossible(
     appendEvent = defaultAppendReclaimEvent,
     appendReviveEvent = defaultAppendReviveEvent,
     appendEscalatedEvent = defaultAppendEscalatedEvent,
+    // 2026-08-03: best-effort session-transcript check so a no-progress
+    // escalation caused by the WORKER hitting a Claude account rate limit is
+    // labeled accurately rather than as a generic "no forward progress" —
+    // see detectSessionRateLimitHit's own header for the full rationale.
+    // Never changes the STOP/escalate decision itself, only its explanation.
+    detectRateLimit = detectSessionRateLimitHit,
     appendReviveSuppressedEvent = defaultAppendReviveSuppressedEvent,
     reviveDispatch = defaultReviveDispatch,
     applyStalledLabel = defaultApplyStalledLabel,
@@ -3331,14 +3419,37 @@ export function reclaimDeadWorkIfPossible(
       }).catch(() => {});
       intentAwareKill({ bgJobId: prevBgJobId });
     }
+    // 2026-08-03: best-effort check on the DEAD worker's own transcript —
+    // never changes this STOP/escalate decision, only enriches the human-
+    // facing explanation when the true cause was an account rate limit
+    // rather than the work itself stalling. See detectSessionRateLimitHit.
+    let rateLimited = false;
+    try {
+      rateLimited = detectRateLimit(prevBgJobId);
+    } catch {
+      rateLimited = false;
+    }
     log.warn(
-      { ticket, phase, prevBgJobId, currentProgress, lastProgress },
+      { ticket, phase, prevBgJobId, currentProgress, lastProgress, rateLimited },
       "ctl-736: no forward progress since last attempt — stopping, not respawning"
     );
     // needs-human (cool-down + breaker guarded). When the Linear breaker is open
     // the escalation defers — surface that so the scheduler does not record a
     // clean stop (the worker is killed, but the label retries next tick).
-    const esc = escalateOnce("no-progress", currentProgress);
+    const esc = escalateOnce(
+      "no-progress",
+      currentProgress,
+      rateLimited
+        ? {
+            call_to_action:
+              `${ticket} ${phase} looks like it hit a Claude account usage/rate limit on every ` +
+              "attempt (its dead session transcript shows the harness's own rate-limit reply, " +
+              "not real work) — wait for the usage window to reset and reply to retry, or reroute " +
+              "this phase to a different executor?",
+            observed: { likely_cause: "account-rate-limited" },
+          }
+        : undefined,
+    );
     return esc === "rate-limited-deferred" ? "rate-limited-deferred" : "no-progress-stopped";
   }
   // Forward progress was made → record the new high-water mark and revive below.

--- a/plugins/dev/scripts/execution-core/recovery.test.mjs
+++ b/plugins/dev/scripts/execution-core/recovery.test.mjs
@@ -44,6 +44,8 @@ import {
   defaultAppendBootResumePhaseRegressionEvent,
   // CTL-1044
   defaultAppendOperatorEvent,
+  // 2026-08-03
+  detectSessionRateLimitHit,
 } from "./recovery.mjs";
 import { saveCursor } from "./event-cursor.mjs";
 import { dropProject } from "./eligible-set.mjs";
@@ -2477,6 +2479,60 @@ describe("reclaimDeadWorkIfPossible — CTL-736 progress gate", () => {
     expect(explanation.attempts).toEqual([111, 222, 1_000_000]);
   });
 
+  // 2026-08-03 fix: confirmed live across 11 real tickets on 2 hosts — every
+  // one's dead session transcript showed nothing but the Claude harness's own
+  // "You've hit your session limit" reply on every attempt (zero real tool
+  // use), yet the escalation read as generic "no forward progress," which
+  // reads as "the WORK is stuck" when the true story is "the ACCOUNT is
+  // rate-limited." This does NOT change the STOP/escalate decision or the
+  // ask-cap — only enriches the explanation once that decision is made.
+  test("a no-progress STOP whose dead session hit an account rate limit gets an accurate call_to_action + observed.likely_cause", () => {
+    const appendEscalatedEvent = recorder(undefined);
+    const r = reclaimDeadWorkIfPossible(orch, implementSignal({ status: "running" }), gateSeams({
+      progressMark: () => 2,
+      readProgressMark: () => 2, // no forward progress → no-progress STOP
+      appendEscalatedEvent,
+      detectRateLimit: (bgJobId) => {
+        expect(bgJobId).toBe("job-x"); // the seam receives the dead worker's OWN bg_job_id
+        return true;
+      },
+    }));
+    expect(r).toBe("no-progress-stopped");
+    const explanation = appendEscalatedEvent.calls[0][0].extras.explanation;
+    expect(explanation.observed.likely_cause).toBe("account-rate-limited");
+    expect(explanation.call_to_action).toMatch(/usage\/rate limit/);
+    expect(explanation.call_to_action).toMatch(/wait for the usage window to reset/);
+    // The underlying reason/cap machinery is UNCHANGED — still "no-progress".
+    expect(appendEscalatedEvent.calls[0][0].reason).toBe("no-progress");
+  });
+
+  test("a no-progress STOP whose dead session shows NO rate-limit signature keeps the original generic explanation", () => {
+    const appendEscalatedEvent = recorder(undefined);
+    const r = reclaimDeadWorkIfPossible(orch, implementSignal({ status: "running" }), gateSeams({
+      progressMark: () => 2,
+      readProgressMark: () => 2,
+      appendEscalatedEvent,
+      detectRateLimit: () => false,
+    }));
+    expect(r).toBe("no-progress-stopped");
+    const explanation = appendEscalatedEvent.calls[0][0].extras.explanation;
+    expect(explanation.observed.likely_cause).toBeUndefined();
+    expect(explanation.call_to_action).toBe("authorize CTL-9 implement to retry or change approach?");
+  });
+
+  test("a throwing detectRateLimit seam degrades to the generic explanation, never breaks the STOP", () => {
+    const appendEscalatedEvent = recorder(undefined);
+    const r = reclaimDeadWorkIfPossible(orch, implementSignal({ status: "running" }), gateSeams({
+      progressMark: () => 2,
+      readProgressMark: () => 2,
+      appendEscalatedEvent,
+      detectRateLimit: () => { throw new Error("boom"); },
+    }));
+    expect(r).toBe("no-progress-stopped");
+    const explanation = appendEscalatedEvent.calls[0][0].extras.explanation;
+    expect(explanation.observed.likely_cause).toBeUndefined();
+  });
+
   test("first death with no prior mark (readProgressMark -1) always gets one revive — even at zero progress", () => {
     const reviveDispatch = recorder({ code: 0 });
     const r = reclaimDeadWorkIfPossible(orch, implementSignal({ status: "running" }), gateSeams({
@@ -4549,6 +4605,143 @@ describe("resolvePhaseSessionId", () => {
     mkdirSync(join(jobsDir, "nolink"), { recursive: true });
     writeFileSync(join(jobsDir, "nolink", "state.json"), JSON.stringify({ state: "stopped" }));
     expect(resolvePhaseSessionId("nolink", { jobsDir })).toBeNull();
+  });
+});
+
+// 2026-08-03: detectSessionRateLimitHit — see recovery.mjs's own header comment
+// for the full incident (11 real tickets, 2 hosts, escalated as generic
+// "no-progress" when every dead session's transcript showed nothing but the
+// Claude harness's own rate-limit reply).
+describe("detectSessionRateLimitHit", () => {
+  function assistantLine(text) {
+    return JSON.stringify({ type: "assistant", message: { content: [{ type: "text", text }] } });
+  }
+
+  test("no bgJobId → false, resolveSession never called", () => {
+    const resolveSession = () => { throw new Error("must not be called"); };
+    expect(detectSessionRateLimitHit(null, { resolveSession })).toBe(false);
+    expect(detectSessionRateLimitHit(undefined, { resolveSession })).toBe(false);
+  });
+
+  test("resolveSession returns null (no resolvable session) → false", () => {
+    expect(
+      detectSessionRateLimitHit("job-x", { resolveSession: () => null, findTranscript: () => "/should-not-be-used" }),
+    ).toBe(false);
+  });
+
+  test("findTranscript returns null (no transcript on disk) → false", () => {
+    expect(
+      detectSessionRateLimitHit("job-x", {
+        resolveSession: () => "uuid-1",
+        findTranscript: () => null,
+        readFileSync: () => { throw new Error("must not read — no transcript path"); },
+      }),
+    ).toBe(false);
+  });
+
+  test("a transcript whose tail shows the literal session-limit reply → true", () => {
+    const lines = [
+      JSON.stringify({ type: "system", subtype: "init" }),
+      assistantLine("You've hit your session limit · resets 10:50pm (America/Chicago)"),
+    ].join("\n");
+    const result = detectSessionRateLimitHit("job-x", {
+      resolveSession: () => "uuid-1",
+      findTranscript: () => "/fake/transcript.jsonl",
+      readFileSync: () => lines,
+    });
+    expect(result).toBe(true);
+  });
+
+  test("the 'usage limit' phrasing variant also matches", () => {
+    const lines = assistantLine("You've hit your usage limit · resets tomorrow");
+    expect(
+      detectSessionRateLimitHit("job-x", {
+        resolveSession: () => "uuid-1",
+        findTranscript: () => "/fake/transcript.jsonl",
+        readFileSync: () => lines,
+      }),
+    ).toBe(true);
+  });
+
+  test("a transcript with real research content (no rate-limit phrase) → false", () => {
+    const lines = [
+      assistantLine("I'll start by reading the coordinator module..."),
+      JSON.stringify({ type: "assistant", message: { content: [{ type: "tool_use", name: "Read", input: {} }] } }),
+    ].join("\n");
+    expect(
+      detectSessionRateLimitHit("job-x", {
+        resolveSession: () => "uuid-1",
+        findTranscript: () => "/fake/transcript.jsonl",
+        readFileSync: () => lines,
+      }),
+    ).toBe(false);
+  });
+
+  test("the phrase appears only OUTSIDE the tail window → false (tail-only scan, not full-file)", () => {
+    const earlyHit = assistantLine("You've hit your session limit · resets soon");
+    const filler = Array.from({ length: 30 }, () => assistantLine("real work happening here")).join("\n");
+    const lines = [earlyHit, filler].join("\n");
+    expect(
+      detectSessionRateLimitHit("job-x", {
+        resolveSession: () => "uuid-1",
+        findTranscript: () => "/fake/transcript.jsonl",
+        readFileSync: () => lines,
+        tailLines: 5,
+      }),
+    ).toBe(false);
+  });
+
+  test("malformed JSON lines interspersed do not prevent finding the real match", () => {
+    const lines = [
+      "{not valid json",
+      assistantLine("You've hit your session limit · resets later"),
+      "another { broken line",
+    ].join("\n");
+    expect(
+      detectSessionRateLimitHit("job-x", {
+        resolveSession: () => "uuid-1",
+        findTranscript: () => "/fake/transcript.jsonl",
+        readFileSync: () => lines,
+      }),
+    ).toBe(true);
+  });
+
+  test("resolveSession throwing degrades to false, never throws", () => {
+    expect(
+      detectSessionRateLimitHit("job-x", { resolveSession: () => { throw new Error("boom"); } }),
+    ).toBe(false);
+  });
+
+  test("findTranscript throwing degrades to false, never throws", () => {
+    expect(
+      detectSessionRateLimitHit("job-x", {
+        resolveSession: () => "uuid-1",
+        findTranscript: () => { throw new Error("boom"); },
+      }),
+    ).toBe(false);
+  });
+
+  test("readFileSync throwing (unreadable transcript) degrades to false, never throws", () => {
+    expect(
+      detectSessionRateLimitHit("job-x", {
+        resolveSession: () => "uuid-1",
+        findTranscript: () => "/fake/transcript.jsonl",
+        readFileSync: () => { throw new Error("EACCES"); },
+      }),
+    ).toBe(false);
+  });
+
+  test("a non-assistant entry (e.g. user/system) mentioning the phrase in passing is ignored", () => {
+    const lines = [
+      JSON.stringify({ type: "user", message: { content: "did you hit your session limit earlier?" } }),
+    ].join("\n");
+    expect(
+      detectSessionRateLimitHit("job-x", {
+        resolveSession: () => "uuid-1",
+        findTranscript: () => "/fake/transcript.jsonl",
+        readFileSync: () => lines,
+      }),
+    ).toBe(false);
   });
 });
 

--- a/plugins/dev/scripts/execution-core/recovery.test.mjs
+++ b/plugins/dev/scripts/execution-core/recovery.test.mjs
@@ -4625,7 +4625,7 @@ describe("detectSessionRateLimitHit", () => {
 
   test("resolveSession returns null (no resolvable session) → false", () => {
     expect(
-      detectSessionRateLimitHit("job-x", { resolveSession: () => null, findTranscript: () => "/should-not-be-used" }),
+      detectSessionRateLimitHit("job-x", { resolveSession: () => null, findTranscriptFn: () => "/should-not-be-used" }),
     ).toBe(false);
   });
 
@@ -4633,8 +4633,8 @@ describe("detectSessionRateLimitHit", () => {
     expect(
       detectSessionRateLimitHit("job-x", {
         resolveSession: () => "uuid-1",
-        findTranscript: () => null,
-        readFileSync: () => { throw new Error("must not read — no transcript path"); },
+        findTranscriptFn: () => null,
+        readTranscriptFn: () => { throw new Error("must not read — no transcript path"); },
       }),
     ).toBe(false);
   });
@@ -4646,8 +4646,8 @@ describe("detectSessionRateLimitHit", () => {
     ].join("\n");
     const result = detectSessionRateLimitHit("job-x", {
       resolveSession: () => "uuid-1",
-      findTranscript: () => "/fake/transcript.jsonl",
-      readFileSync: () => lines,
+      findTranscriptFn: () => "/fake/transcript.jsonl",
+      readTranscriptFn: () => lines,
     });
     expect(result).toBe(true);
   });
@@ -4657,8 +4657,8 @@ describe("detectSessionRateLimitHit", () => {
     expect(
       detectSessionRateLimitHit("job-x", {
         resolveSession: () => "uuid-1",
-        findTranscript: () => "/fake/transcript.jsonl",
-        readFileSync: () => lines,
+        findTranscriptFn: () => "/fake/transcript.jsonl",
+        readTranscriptFn: () => lines,
       }),
     ).toBe(true);
   });
@@ -4671,8 +4671,8 @@ describe("detectSessionRateLimitHit", () => {
     expect(
       detectSessionRateLimitHit("job-x", {
         resolveSession: () => "uuid-1",
-        findTranscript: () => "/fake/transcript.jsonl",
-        readFileSync: () => lines,
+        findTranscriptFn: () => "/fake/transcript.jsonl",
+        readTranscriptFn: () => lines,
       }),
     ).toBe(false);
   });
@@ -4684,8 +4684,8 @@ describe("detectSessionRateLimitHit", () => {
     expect(
       detectSessionRateLimitHit("job-x", {
         resolveSession: () => "uuid-1",
-        findTranscript: () => "/fake/transcript.jsonl",
-        readFileSync: () => lines,
+        findTranscriptFn: () => "/fake/transcript.jsonl",
+        readTranscriptFn: () => lines,
         tailLines: 5,
       }),
     ).toBe(false);
@@ -4700,8 +4700,8 @@ describe("detectSessionRateLimitHit", () => {
     expect(
       detectSessionRateLimitHit("job-x", {
         resolveSession: () => "uuid-1",
-        findTranscript: () => "/fake/transcript.jsonl",
-        readFileSync: () => lines,
+        findTranscriptFn: () => "/fake/transcript.jsonl",
+        readTranscriptFn: () => lines,
       }),
     ).toBe(true);
   });
@@ -4716,7 +4716,7 @@ describe("detectSessionRateLimitHit", () => {
     expect(
       detectSessionRateLimitHit("job-x", {
         resolveSession: () => "uuid-1",
-        findTranscript: () => { throw new Error("boom"); },
+        findTranscriptFn: () => { throw new Error("boom"); },
       }),
     ).toBe(false);
   });
@@ -4725,8 +4725,8 @@ describe("detectSessionRateLimitHit", () => {
     expect(
       detectSessionRateLimitHit("job-x", {
         resolveSession: () => "uuid-1",
-        findTranscript: () => "/fake/transcript.jsonl",
-        readFileSync: () => { throw new Error("EACCES"); },
+        findTranscriptFn: () => "/fake/transcript.jsonl",
+        readTranscriptFn: () => { throw new Error("EACCES"); },
       }),
     ).toBe(false);
   });
@@ -4738,8 +4738,8 @@ describe("detectSessionRateLimitHit", () => {
     expect(
       detectSessionRateLimitHit("job-x", {
         resolveSession: () => "uuid-1",
-        findTranscript: () => "/fake/transcript.jsonl",
-        readFileSync: () => lines,
+        findTranscriptFn: () => "/fake/transcript.jsonl",
+        readTranscriptFn: () => lines,
       }),
     ).toBe(false);
   });

--- a/plugins/dev/scripts/execution-core/recovery.test.mjs
+++ b/plugins/dev/scripts/execution-core/recovery.test.mjs
@@ -2445,6 +2445,38 @@ describe("reclaimDeadWorkIfPossible — CTL-736 progress gate", () => {
     expect(writeProgressMark.calls.length).toBe(0); // no new high-water on a stop
   });
 
+  // 2026-08-03 fix: confirmed live across 11 real tickets — every no-progress
+  // escalation's human-facing text/observed field read "escalated after 0
+  // attempt(s)" regardless of how many REAL ask/retry cycles actually ran,
+  // because escalateOnce's finalAttemptCount param historically received the
+  // CTL-736 progress QUANTITY (always 0 here — that's what triggers the STOP
+  // branch), not an attempt count, while the `attempts` array was correctly
+  // built from the real ask history. This is the 3rd-cycle case (2 prior asks
+  // on record, this ask trips the ask-cap): the count must now read 3
+  // everywhere, matching `attempts.length`.
+  test("no-progress escalation on its 3rd real cycle reports final_attempt_count:3 (not 0), matching the real ask history", () => {
+    const appendEscalatedEvent = recorder(undefined);
+    const r = reclaimDeadWorkIfPossible(orch, implementSignal({ status: "running" }), gateSeams({
+      progressMark: () => 2,
+      readProgressMark: () => 2, // no forward progress → no-progress STOP
+      appendEscalatedEvent,
+      readEscalationRecordFn: () => ({ reason: "no-progress", askCount: 2, asks: [111, 222] }),
+    }));
+    expect(r).toBe("no-progress-stopped");
+    const call = appendEscalatedEvent.calls[0][0];
+    expect(call.reason).toBe("no-progress");
+    // The bug: this used to always be 0 (the progress quantity), never the
+    // real ask count — even when `attempts` (below) correctly showed 3.
+    expect(call.final_attempt_count).toBe(3);
+    const explanation = call.extras.explanation;
+    expect(explanation.problem).toBe("implement escalated after 3 attempt(s): no-progress");
+    expect(explanation.risk).toBe("continued retries risk wasting budget; 3 attempt(s) already made");
+    expect(explanation.observed.final_attempt_count).toBe(3);
+    expect(explanation.why_asking).toBe("no forward progress after 3 attempt(s) — stop-and-escalate");
+    // The real ask history: 2 prior + this one = 3, exactly matching the count above.
+    expect(explanation.attempts).toEqual([111, 222, 1_000_000]);
+  });
+
   test("first death with no prior mark (readProgressMark -1) always gets one revive — even at zero progress", () => {
     const reviveDispatch = recorder({ code: 0 });
     const r = reclaimDeadWorkIfPossible(orch, implementSignal({ status: "running" }), gateSeams({


### PR DESCRIPTION
Supersedes #2923 — migrated off the fork branch to `tony/codex-thoughts-symlinks-escalation-count` on this repo since Cloudflare Pages and Codex review don't run on fork-branch heads. Same commits/content as #2923, authored by @thagale.

## Summary
Three related fixes in execution-core's dispatch/escalation path, found while investigating a batch of failed tickets in a real multi-tenant deployment.

**1. resolveThoughtsRoot never actually resolved the thoughts symlink target.** The real on-disk convention (`lib/provision-thoughts.sh`) is: `thoughts/` is a real directory whose immediate entries (`global`, `shared`) are themselves symlinks pointing outside the worktree — not "`thoughts` itself is a symlink" as the function assumed. Fixed to resolve every symlink entry under `thoughts/`, handling both the legacy direct-symlink shape and the real nested shape.

**2. no-progress escalations always reported "0 attempt(s)" regardless of real retry history.** For "no-progress", the caller passes a progress *quantity* (commits-ahead / doc size) instead of an attempt count as `finalAttemptCount`. Now uses the real ask count (`priorAsks + 1`) for display/audit fields when the reason is `no-progress`, leaving the other three escalation reasons untouched.

**3. no-progress escalations couldn't distinguish "genuinely stuck" from "the Claude account backing this bg executor hit its usage/session limit."** Added `detectSessionRateLimitHit`, which inspects the dead worker's own session transcript (tail-only, bounded) for the harness's session-limit reply and, when found, gives the escalation an accurate `call_to_action` and `observed.likely_cause: "account-rate-limited"`.

Also allowlists two pre-existing, unrelated reads (`daemon-boot.json`, `/proc/stat`) that `event-log-read-guard.test.mjs`'s taint-scan started flagging as a side effect of the new transcript read.

## What changed migrating off the fork
Rebased onto current `origin/main` — real conflicts in `codex-run-phase-agent.mjs` (main's since-landed git-dir/common-dir writable-roots addition, PR #2851/#3052) and `recovery.mjs` (main's since-landed PROJ-1657 no-probe-for-phase terminalization gate, CTL-1609 delegate-first line). Both were additive-vs-additive; resolved by keeping both features. Full test suite (`codex-run-phase-agent.test.mjs`, `recovery.test.mjs`, `event-log-read-guard.test.mjs`) passes clean post-rebase: 434/434.

## Test plan
- [x] `codex-run-phase-agent.test.mjs` — 5 new tests (real on-disk shape with nested symlinks, legacy direct-symlink shape preserved, no-symlink dir, no thoughts dir, dangling symlink)
- [x] `recovery.test.mjs` — 1 regression test proving a 3rd-cycle no-progress escalation reports `final_attempt_count: 3`, not the old `0`; 15 new tests for `detectSessionRateLimitHit`
- [x] `event-log-read-guard.test.mjs` — 40/40 pass with the new allowlist entry
- [x] All three files, post-rebase on current main: 434 pass, 0 fail