### PR TITLE
fix(execution-core): close two remaining codex-exec thoughts-symlink escape gaps

### DIFF
--- a/plugins/dev/scripts/execution-core/codex-run-phase-agent.mjs
+++ b/plugins/dev/scripts/execution-core/codex-run-phase-agent.mjs
@@ -314,6 +314,13 @@ function resolveDevPluginRoot(pluginDirs) {
 // could plant under thoughts/ with an arbitrary name (e.g. `thoughts/root`).
 const PROVISIONED_THOUGHTS_ENTRIES = new Set(["shared", "global"]);
 
+// THOUGHTS_GLOBAL_DIR_NAME — the exact subdirectory name `thoughts/global`
+// must resolve to under a config-validated THOUGHTS_REPO anchor. Hardcoded
+// to match lib/provision-thoughts.sh's write_config, which itself always
+// writes `globalDir: "global"` (a literal, not derived from anything) —
+// the same constant the local entry name `global` already encodes.
+const THOUGHTS_GLOBAL_DIR_NAME = "global";
+
 // isSaneThoughtsTarget — the resolved target of a thoughts/ symlink must not
 // be the filesystem root or a bare top-level directory (`/`, `/etc`, `/Users`,
 // …). Every legitimate thoughts-repo target nests at least one level below a
@@ -432,9 +439,23 @@ function resolveThoughtsRoots(worktreePath) {
     return [];
   }
   // Legacy/simple shape: `thoughts` itself is a symlink straight to the target.
+  // 2026-08-07 hardening, round 3 (round-4 review, same PR): this branch used
+  // to return early on the bare structural floor ONLY, skipping the
+  // configured-directory validation entirely — a `thoughts -> /home/alice`
+  // symlink (2 segments) passed the same way the real-directory shape's
+  // `shared`/`global` used to before round 2's fix. Apply the SAME
+  // CONFIGURED/UNCONFIGURED regime choice used below for `shared`.
   if (stat.isSymbolicLink()) {
     try {
       const real = realpathSync(thoughtsPath);
+      const directory = resolveConfiguredThoughtsDirectory(worktreePath);
+      if (directory) {
+        // CONFIGURED regime — same `/repos/<directory>/` segment contract as
+        // resolveConfiguredThoughtsAnchor, applied directly (no `global`
+        // sibling to anchor here, so no separate anchor derivation needed).
+        return real.includes(`/repos/${directory}/`) ? [real] : [];
+      }
+      // UNCONFIGURED regime — structural floor only (fail-open).
       return isSaneThoughtsTarget(real) ? [real] : [];
     } catch {
       return [];
@@ -498,10 +519,19 @@ function resolveThoughtsRoots(worktreePath) {
         }
         // else: declared directory present but `shared`'s target doesn't
         // contain the expected segment — reject outright, `anchor` stays null.
-      } else if (anchor && (real === anchor || real.startsWith(`${anchor}/`))) {
+      } else if (anchor && real === join(anchor, THOUGHTS_GLOBAL_DIR_NAME)) {
         out.push(real);
-        // else: no validated anchor (shared missing/mismatched), or global
-        // doesn't nest under it — reject outright.
+        // 2026-08-07 hardening, round 3 (round-4 review, same PR): "nested
+        // under the anchor" (real===anchor || startsWith(anchor+"/")) was too
+        // permissive — it accepted `global` re-pointed at the anchor ITSELF
+        // (granting the whole THOUGHTS_REPO, every project under repos/) or
+        // any other descendant. worktree-thoughts-init.sh:57-77 provisions
+        // `global` as the EXACT `<THOUGHTS_REPO>/<globalDir>` target (and
+        // lib/provision-thoughts.sh's write_config hardcodes globalDir to
+        // the literal "global" — see THOUGHTS_GLOBAL_DIR_NAME), so require
+        // that exact path, not merely "somewhere under the anchor". Any
+        // other case — no validated anchor (shared missing/mismatched), or
+        // global doesn't match exactly — is rejected outright.
       }
     } catch {
       // Broken symlink / permission error on this one entry — skip it, keep

--- a/plugins/dev/scripts/execution-core/codex-run-phase-agent.test.mjs
+++ b/plugins/dev/scripts/execution-core/codex-run-phase-agent.test.mjs
@@ -736,6 +736,122 @@ describe("buildCodexArgs — thoughts/ symlink resolution into writable_roots", 
       rmSync(root, { recursive: true, force: true });
     }
   });
+
+  // 2026-08-07 P1 follow-up round 2 (Codex round-4, PR #3082): the LEGACY
+  // direct-symlink shape (`thoughts` itself is a symlink) returned before the
+  // configured-directory check entirely, so it still accepted an
+  // attacker-chosen 2-segment target (e.g. `thoughts -> /home/alice`) even in
+  // a worktree with a declared thoughts directory.
+  test("SECURITY (configured regime, LEGACY shape): thoughts -> /home/alice is rejected once a thoughts directory is configured, even though it passes the old bare structural floor", () => {
+    const { root, worktreePath } = makeWorktreeWithThoughts(({ worktreePath }) => {
+      writeThoughtsDirectoryConfig(worktreePath, "coppa");
+      symlinkSync("/private", join(worktreePath, "thoughts"));
+    });
+    try {
+      const spec = makeCodexSpec();
+      const args = buildCodexArgs(spec, CFG, { orchDir: "/ec", worktreePath });
+      const roots = extractWritableRoots(args);
+      expect(roots).toEqual([...CFG.writableRoots, "/ec"]);
+      expect(roots).not.toContain("/private");
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  test("configured regime, LEGACY shape: a target matching the declared directory's /repos/<dir>/ segment is accepted", () => {
+    const { root, worktreePath } = makeWorktreeWithThoughts(({ worktreePath, external }) => {
+      writeThoughtsDirectoryConfig(worktreePath, "coppa");
+      const legacyTarget = join(external, "repos", "coppa", "shared");
+      mkdirSync(legacyTarget, { recursive: true });
+      symlinkSync(legacyTarget, join(worktreePath, "thoughts"));
+    });
+    try {
+      const spec = makeCodexSpec();
+      const args = buildCodexArgs(spec, CFG, { orchDir: "/ec", worktreePath });
+      const roots = extractWritableRoots(args);
+      expect(roots).toContain(join(root, "external-thoughts-repo", "repos", "coppa", "shared"));
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  // 2026-08-07 P1 follow-up round 2 (Codex round-4, PR #3082): "nested under
+  // the anchor" was too permissive — `thoughts/global` re-pointed at the
+  // anchor ITSELF (the whole THOUGHTS_REPO, every project under repos/) used
+  // to pass. `global` must resolve to the EXACT `<THOUGHTS_REPO>/global`
+  // target lib/provision-thoughts.sh / worktree-thoughts-init.sh provision,
+  // not merely something under that root.
+  test("SECURITY (configured regime): thoughts/global re-pointed at the THOUGHTS_REPO anchor itself (not the exact global/ subdir) is rejected", () => {
+    const { root, worktreePath } = makeWorktreeWithThoughts(({ worktreePath, external }) => {
+      writeThoughtsDirectoryConfig(worktreePath, "coppa");
+      const thoughtsDir = join(worktreePath, "thoughts");
+      mkdirSync(thoughtsDir, { recursive: true });
+      const sharedTarget = join(external, "repos", "coppa", "shared");
+      mkdirSync(sharedTarget, { recursive: true });
+      symlinkSync(sharedTarget, join(thoughtsDir, "shared"));
+      // `global` re-pointed at the anchor root ITSELF — grants the whole
+      // THOUGHTS_REPO (every project under repos/), not just global/.
+      symlinkSync(external, join(thoughtsDir, "global"));
+    });
+    try {
+      const spec = makeCodexSpec();
+      const args = buildCodexArgs(spec, CFG, { orchDir: "/ec", worktreePath });
+      const roots = extractWritableRoots(args);
+      expect(roots).toContain(join(root, "external-thoughts-repo", "repos", "coppa", "shared"));
+      expect(roots).not.toContain(join(root, "external-thoughts-repo"));
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  test("SECURITY (configured regime): thoughts/global pointed at a DESCENDANT of the anchor (not the exact global/ subdir) is rejected", () => {
+    const { root, worktreePath } = makeWorktreeWithThoughts(({ worktreePath, external }) => {
+      writeThoughtsDirectoryConfig(worktreePath, "coppa");
+      const thoughtsDir = join(worktreePath, "thoughts");
+      mkdirSync(thoughtsDir, { recursive: true });
+      const sharedTarget = join(external, "repos", "coppa", "shared");
+      mkdirSync(sharedTarget, { recursive: true });
+      symlinkSync(sharedTarget, join(thoughtsDir, "shared"));
+      // `global` re-pointed at ANOTHER project's shared dir under the SAME
+      // anchor — nested under THOUGHTS_REPO, but not the exact global/ path.
+      const otherProjectShared = join(external, "repos", "other-project", "shared");
+      mkdirSync(otherProjectShared, { recursive: true });
+      symlinkSync(otherProjectShared, join(thoughtsDir, "global"));
+    });
+    try {
+      const spec = makeCodexSpec();
+      const args = buildCodexArgs(spec, CFG, { orchDir: "/ec", worktreePath });
+      const roots = extractWritableRoots(args);
+      expect(roots).toContain(join(root, "external-thoughts-repo", "repos", "coppa", "shared"));
+      expect(roots).not.toContain(
+        join(root, "external-thoughts-repo", "repos", "other-project", "shared"),
+      );
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  test("configured regime: thoughts/global resolving to the EXACT <anchor>/global target is accepted", () => {
+    const { root, worktreePath } = makeWorktreeWithThoughts(({ worktreePath, external }) => {
+      writeThoughtsDirectoryConfig(worktreePath, "coppa");
+      const thoughtsDir = join(worktreePath, "thoughts");
+      mkdirSync(thoughtsDir, { recursive: true });
+      const sharedTarget = join(external, "repos", "coppa", "shared");
+      const globalTarget = join(external, "global");
+      mkdirSync(sharedTarget, { recursive: true });
+      mkdirSync(globalTarget, { recursive: true });
+      symlinkSync(sharedTarget, join(thoughtsDir, "shared"));
+      symlinkSync(globalTarget, join(thoughtsDir, "global"));
+    });
+    try {
+      const spec = makeCodexSpec();
+      const args = buildCodexArgs(spec, CFG, { orchDir: "/ec", worktreePath });
+      const roots = extractWritableRoots(args);
+      expect(roots).toContain(join(root, "external-thoughts-repo", "global"));
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
 });
 
 // ── buildCodexEnv ───────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

PR #3082 (merged at 4d672d5e) fixed the core `resolveThoughtsRoots` cross-run sandbox-escape (thoughts symlink → arbitrary `writable_roots`), but a round-4 Codex re-review — which arrived a few seconds after PR #3082's auto-merge had already fired on the prior commit — found two remaining gaps in the same function. This PR carries the already-tested fix forward (cherry-picked from the commit that lost the race).

1. **Legacy direct-symlink shape not covered by the configured-directory validation.** `thoughts` itself being a symlink (the legacy/simple shape) returned before the configured-directory check entirely, so it still accepted an attacker-chosen 2-segment target (e.g. `thoughts -> /home/alice`) even in a worktree with a declared thoughts directory. Now applies the same CONFIGURED/UNCONFIGURED regime already used for `shared`/`global`.
2. **`thoughts/global`'s anchor check was "nested under", not "exact match".** It accepted `global` re-pointed at the THOUGHTS_REPO anchor itself (granting every project under `repos/`) or any other descendant. Now requires the EXACT `<THOUGHTS_REPO>/global` target `worktree-thoughts-init.sh` actually provisions.

## Test plan

- [x] `node --check` on both changed files
- [x] `bun test codex-run-phase-agent.test.mjs` — 72/72 green (67 pre-existing + 5 new regression tests covering both gaps)
- [x] Cherry-picked cleanly from the tested commit that was ready to push when PR #3082 auto-merged

🤖 Generated with [Claude Code](https://claude.com/claude-code)