### PR TITLE
fix(execution-core): preserve 0600 on Layer-2 config across autotune write-back (supersedes #3074)

### DIFF
--- a/plugins/dev/scripts/execution-core/autotune-writeback.test.mjs
+++ b/plugins/dev/scripts/execution-core/autotune-writeback.test.mjs
@@ -2,7 +2,7 @@
 // Run: cd plugins/dev/scripts/execution-core && bun test autotune-writeback.test.mjs
 
 import { describe, test, expect, beforeEach, afterEach } from "bun:test";
-import { mkdtempSync, rmSync, writeFileSync, readFileSync, existsSync } from "node:fs";
+import { mkdtempSync, rmSync, writeFileSync, readFileSync, existsSync, statSync, chmodSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { writeLayer2MaxParallel } from "./autotune.mjs";
@@ -74,6 +74,19 @@ describe("writeLayer2MaxParallel", () => {
     const files = require("node:fs").readdirSync(dir);
     const hasTmp = files.some((f) => f.includes(".tmp."));
     expect(hasTmp).toBe(false);
+  });
+
+  test("writes at mode 600, regardless of any prior looser mode on the file", () => {
+    // doctor's layer2-perms check FAILs on anything looser than 600 (Layer-2 can
+    // carry secrets). Start the file at a deliberately loose mode to pin that the
+    // write-back doesn't just preserve whatever was there — it sets 600 outright.
+    const p = join(dir, "config.json");
+    writeFileSync(p, JSON.stringify({ catalyst: {} }));
+    chmodSync(p, 0o644);
+    const ok = writeLayer2MaxParallel(p, 9);
+    expect(ok).toBe(true);
+    const mode = statSync(p).mode & 0o777;
+    expect(mode).toBe(0o600);
   });
 
   test("uses injected readFileSync / writeFileSync / renameSync seams", () => {

--- a/plugins/dev/scripts/execution-core/autotune-writeback.test.mjs
+++ b/plugins/dev/scripts/execution-core/autotune-writeback.test.mjs
@@ -89,6 +89,22 @@ describe("writeLayer2MaxParallel", () => {
     expect(mode).toBe(0o600);
   });
 
+  test("enforces 600 even when a stale .tmp file from an interrupted prior write is reused at a looser mode", () => {
+    // writeFileSync's `mode` option only governs *creation* permissions — it is a
+    // no-op when the path already exists. Simulate the interrupted-write + PID-reuse
+    // scenario directly: pre-create the exact tmp path writeLayer2MaxParallel will
+    // target, at a loose mode, before calling it.
+    const p = join(dir, "config.json");
+    writeFileSync(p, JSON.stringify({ catalyst: {} }));
+    const tmp = `${p}.tmp.${process.pid}`;
+    writeFileSync(tmp, "stale partial content");
+    chmodSync(tmp, 0o644);
+    const ok = writeLayer2MaxParallel(p, 11);
+    expect(ok).toBe(true);
+    const mode = statSync(p).mode & 0o777;
+    expect(mode).toBe(0o600);
+  });
+
   test("uses injected readFileSync / writeFileSync / renameSync seams", () => {
     const reads = [];
     const writes = [];

--- a/plugins/dev/scripts/execution-core/autotune.mjs
+++ b/plugins/dev/scripts/execution-core/autotune.mjs
@@ -452,7 +452,11 @@ export function writeLayer2MaxParallel(layer2Path, next, {
     if (!existing.catalyst.orchestration.executionCore) existing.catalyst.orchestration.executionCore = {};
     existing.catalyst.orchestration.executionCore.maxParallel = next;
     const tmp = `${layer2Path}.tmp.${process.pid}`;
-    writeFile(tmp, JSON.stringify(existing, null, 2));
+    // mode: 0o600 — Layer-2 can carry secrets (doctor's layer2-perms check requires
+    // 600). Without this the tmp file is created at the default 0o666&~umask (644),
+    // and POSIX rename() replaces the destination's permission bits along with its
+    // content, silently reverting any prior chmod 600 on every autotune write.
+    writeFile(tmp, JSON.stringify(existing, null, 2), { mode: 0o600 });
     rename(tmp, layer2Path);
     return true;
   } catch (err) {

--- a/plugins/dev/scripts/execution-core/autotune.mjs
+++ b/plugins/dev/scripts/execution-core/autotune.mjs
@@ -13,7 +13,7 @@ import {
   cpus as osCpus,
   platform as osPlatform,
 } from "node:os";
-import { readFileSync, writeFileSync, renameSync } from "node:fs";
+import { readFileSync, writeFileSync, renameSync, chmodSync } from "node:fs";
 import { execFileSync } from "node:child_process";
 import { clampToBounds } from "./scheduler.mjs";
 import {
@@ -433,6 +433,7 @@ export function writeLayer2MaxParallel(layer2Path, next, {
   readFileSync: readFile = readFileSync,
   writeFileSync: writeFile = writeFileSync,
   renameSync: rename = renameSync,
+  chmodSync: chmod = chmodSync,
 } = {}) {
   let existing = {};
   try {
@@ -456,7 +457,13 @@ export function writeLayer2MaxParallel(layer2Path, next, {
     // 600). Without this the tmp file is created at the default 0o666&~umask (644),
     // and POSIX rename() replaces the destination's permission bits along with its
     // content, silently reverting any prior chmod 600 on every autotune write.
+    // The `mode` option only governs *creation* permissions though — if the tmp
+    // path already exists (e.g. an interrupted prior write left it behind and the
+    // PID got reused), writeFileSync truncates it in place without touching its
+    // existing mode. Explicitly chmod after writing so reuse can't smuggle a
+    // looser mode through to the rename.
     writeFile(tmp, JSON.stringify(existing, null, 2), { mode: 0o600 });
+    chmod(tmp, 0o600);
     rename(tmp, layer2Path);
     return true;
   } catch (err) {


### PR DESCRIPTION
## Summary
- Same fix as #3074: `writeLayer2MaxParallel`'s tmp-then-rename write-back was creating the tmp file at the default mode (0o644 via umask), and POSIX `rename()` carries that mode onto the destination — silently reverting Layer-2 config (which can carry secrets) from 0600 back to 0644 on every autotune write.
- Additionally addresses the P2 Codex finding on #3074: `writeFileSync`'s `mode` option only governs *creation* permissions. If the tmp path already exists (e.g. an interrupted prior write left it behind and the PID got reused), the mode option is a no-op and the reused tmp file's existing (possibly looser) mode rides through the rename. Fixed by explicitly `chmodSync`-ing the tmp file to 0600 before the rename, with `chmodSync` added as an injectable seam alongside the existing `readFileSync`/`writeFileSync`/`renameSync` seams.
- Adds a regression test that pre-creates the exact tmp path at a loose mode (simulating the interrupted-write + PID-reuse scenario) and asserts the final file lands at 0600.

This is a same-base-repo re-open of #3074 (opened from a fork; Cloudflare Pages, a required check, does not run on fork-authored PRs so it could never reach CLEAN). #3074 will be closed in favor of this PR.

## Test plan
- [x] `node --check plugins/dev/scripts/execution-core/autotune.mjs`
- [x] `node --check plugins/dev/scripts/execution-core/autotune-writeback.test.mjs`
- [x] `bun test autotune-writeback.test.mjs` — 8/8 pass
- [x] `bun test autotune-capacity.test.mjs autotune-decision.test.mjs autotune-lifecycle.test.mjs autotune-writeback.test.mjs` — 119/119 pass