### PR TITLE
CAT-35: The Linear read replica should hold data so that triage swee

### DIFF
--- a/.github/workflows/execution-core-tests.yml
+++ b/.github/workflows/execution-core-tests.yml
@@ -590,6 +590,8 @@ jobs:
             dispatch.test.mjs \
             doctor.test.mjs \
             doctor-replica.test.mjs \
+            __tests__/replica-health.test.mjs \
+            __tests__/linear-query-triage-source.test.mjs \
             eligible-set.test.mjs \
             event-cursor.test.mjs \
             event-scan.test.mjs \

--- a/.github/workflows/execution-core-tests.yml
+++ b/.github/workflows/execution-core-tests.yml
@@ -259,7 +259,15 @@ jobs:
         working-directory: plugins/dev/scripts
         run: bash __tests__/catalyst-stack-cloud-sync-plist.test.sh
 
-      - name: linear-read-replica helper test (CTL-1397 + CTL-1403)
+      - name: Ensure zsh is available (linear-read-replica zsh regression coverage)
+        # CAT-35: the suite below sources the helper under `zsh -u` to lock down the
+        # nounset regression that broke the production phase-worker read path. Those
+        # two assertions SKIP (not fail) when zsh is absent, and this workflow's other
+        # zsh install lands hundreds of lines later — so without this step the required
+        # check could pass without ever exercising the shell that caused the regression.
+        run: command -v zsh >/dev/null 2>&1 || (sudo apt-get update -qq && sudo apt-get install -y --no-install-recommends zsh)
+
+      - name: linear-read-replica helper test (CTL-1397 + CTL-1403 + CAT-35)
         # CTL-1403: the bash linear_read_ticket helper is the canonical agent read
         # path; this asserts its two-gate freshness + the reads-by-source emit
         # (catalyst.linear.read on every branch: replica HIT / miss / stale / failure).

--- a/.github/workflows/execution-core-tests.yml
+++ b/.github/workflows/execution-core-tests.yml
@@ -591,6 +591,7 @@ jobs:
             doctor.test.mjs \
             doctor-replica.test.mjs \
             __tests__/replica-health.test.mjs \
+            __tests__/replica-health-event.test.mjs \
             __tests__/linear-query-triage-source.test.mjs \
             eligible-set.test.mjs \
             event-cursor.test.mjs \

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,5 +1,8 @@
 # Architecture
 
+For the local Linear writer, freshness gate, read tiers, configuration order, and health signals,
+see [Linear read replica](linear-replica.md).
+
 ## Three-Layer System
 
 1. **Plugin Source** (`plugins/dev/`, `plugins/meta/`, `plugins/pm/`, `plugins/legacy/`, …) —

--- a/docs/linear-replica.md
+++ b/docs/linear-replica.md
@@ -23,11 +23,11 @@ alone leaves readers disconnected; the flag alone produces replica misses agains
 ## Loki queries
 
 ```logql
-{service_name="catalyst.execution-core"} | field="event.name" =~ "monitor\\.replica\\.degraded\\..*"
+{service_name="catalyst.execution-core"} | json | attributes["event.name"] =~ "monitor\\.replica\\.degraded\\..*"
 ```
 
 ```logql
-{service_name="catalyst.linear-read"} | field="event.name" = "catalyst.replica.read_fallback"
+{service_name="catalyst.linear-read"} | json | attributes["event.name"] = "catalyst.replica.read_fallback"
 ```
 
 Grafana alert provisioning belongs in the sibling `catalyst-otel` repository. Validate any rule

--- a/docs/linear-replica.md
+++ b/docs/linear-replica.md
@@ -6,9 +6,24 @@ and the agent/daemon read paths serve single-ticket and board reads from that da
 
 ## Configuration order
 
-Two independent settings are required. Provision `CATALYST_CLOUD_TOKEN` first so the writer can
-authenticate and seed a schema. Then set `CATALYST_LINEAR_REPLICA=on` so readers use it. The token
-alone leaves readers disconnected; the flag alone produces replica misses against an empty file.
+Two independent settings are required, and neither takes effect on its own: the token alone leaves
+readers disconnected, and the flag alone produces replica misses against an empty file. Provision
+the token FIRST, activate the writer, wait for a verified seed, and only then flip the read flag.
+
+1. **Provision the resolved cloud-token variable.** The name defaults to `CATALYST_CLOUD_TOKEN`,
+   but `resolveCloudTokenName` honours the `CATALYST_CLOUD_TOKEN_ENV` env override and the Layer-2
+   `catalyst.cloud.tokenEnv` key — on a host that sets either, exporting `CATALYST_CLOUD_TOKEN`
+   does **not** authenticate the writer. Export whichever name resolves, into
+   `~/.config/catalyst/cloud-sync.env` (`chmod 600`).
+2. **Activate the writer**: `catalyst-stack adopt-cloud-sync`. Provisioning the token does not
+   itself install or start the supervised writer.
+3. **Wait for a verified seed** — `catalyst doctor`'s `replica-fresh` PASS, or
+   `sqlite3 ~/catalyst/catalyst-replica.db 'SELECT COUNT(*) FROM issues'` > 0.
+4. **Then set `CATALYST_LINEAR_REPLICA=on`** and restart execution-core on a worker — an
+   already-running process does not construct a reader just because the flag changed.
+
+The canonical seed-before-flip runbook, including every key's precedence, lives in
+`website/src/content/docs/reference/configuration.md`; this list is its replica-tier summary.
 
 ## Signals
 
@@ -22,13 +37,21 @@ alone leaves readers disconnected; the flag alone produces replica misses agains
 
 ## Loki queries
 
+`service_name` is the only stream label here; every other field — including the event name — arrives
+as **structured metadata**, because `otel-forward` sends the body as a plain string and the event
+attributes as OTLP log attributes (dots normalized to underscores). Do not `| json` these lines:
+there is no JSON body to parse, and `attributes["event.name"]` never matches.
+
 ```logql
-{service_name="catalyst.execution-core"} | json | attributes["event.name"] =~ "monitor\\.replica\\.degraded\\..*"
+{service_name="catalyst.execution-core"} | event_name=~"monitor\\.replica\\.degraded\\..*"
 ```
 
 ```logql
-{service_name="catalyst.linear-read"} | json | attributes["event.name"] = "catalyst.replica.read_fallback"
+{service_name="catalyst.linear-read"} | event_name="catalyst.replica.read_fallback"
 ```
+
+The degradation streak rides the `replica_consecutive_degraded` metadata field on those events, so
+`sum by (catalyst_team) (...)`-style aggregation over it works without touching the body.
 
 Grafana alert provisioning belongs in the sibling `catalyst-otel` repository. Validate any rule
 file against a throwaway Grafana before deploying it because malformed provisioned rules can stop

--- a/docs/linear-replica.md
+++ b/docs/linear-replica.md
@@ -1,0 +1,35 @@
+# Linear read replica
+
+The local Linear tier has three layers: the cloud-sync writer seeds and updates the SQLite
+database, its writer-lock heartbeat proves the writer is alive independently of feed activity,
+and the agent/daemon read paths serve single-ticket and board reads from that database.
+
+## Configuration order
+
+Two independent settings are required. Provision `CATALYST_CLOUD_TOKEN` first so the writer can
+authenticate and seed a schema. Then set `CATALYST_LINEAR_REPLICA=on` so readers use it. The token
+alone leaves readers disconnected; the flag alone produces replica misses against an empty file.
+
+## Signals
+
+| Signal | Where | Meaning |
+| --- | --- | --- |
+| `replica-schema WARN … 0 bytes` | `catalyst doctor` | The database was never seeded. |
+| `replica-tier WARN … INERT` | `catalyst doctor` | The token and read flag gaps are both open. |
+| `monitor.replica.degraded.<TEAM>` | Event log / Loki | N consecutive triage sweeps could not read the replica. |
+| `monitor.replica.recovered.<TEAM>` | Event log / Loki | A degraded team's replica read recovered. |
+| `catalyst.replica.read_fallback` | Event log / Loki | An agent read fell back to `linearis`. |
+
+## Loki queries
+
+```logql
+{service_name="catalyst.execution-core"} | field="event.name" =~ "monitor\\.replica\\.degraded\\..*"
+```
+
+```logql
+{service_name="catalyst.linear-read"} | field="event.name" = "catalyst.replica.read_fallback"
+```
+
+Grafana alert provisioning belongs in the sibling `catalyst-otel` repository. Validate any rule
+file against a throwaway Grafana before deploying it because malformed provisioned rules can stop
+the shared Grafana instance from starting.

--- a/plugins/dev/scripts/__tests__/linear-read-replica.test.sh
+++ b/plugins/dev/scripts/__tests__/linear-read-replica.test.sh
@@ -42,7 +42,7 @@ if command -v zsh >/dev/null 2>&1; then
 		source '${HELPER}'
 		_lrr_emit_fallback_event 'CAT-35' 'stale-absent' 'test'
 	" >/dev/null 2>&1
-	n="$(cat "${ev_dir}"/*.jsonl 2>/dev/null | grep -c 'catalyst.replica.read_fallback' || echo 0)"
+	n="$(cat "${ev_dir}"/*.jsonl 2>/dev/null | grep -c 'catalyst.replica.read_fallback' || true)"
 	assert_eq "T-zsh2 fallback event appended under zsh" "1" "$n"
 	rm -rf "$ev_dir"
 else

--- a/plugins/dev/scripts/__tests__/linear-read-replica.test.sh
+++ b/plugins/dev/scripts/__tests__/linear-read-replica.test.sh
@@ -21,6 +21,34 @@ fail() {
 }
 assert_eq() { if [ "$2" = "$3" ]; then ok "$1"; else fail "$1" "expected '$2' got '$3'"; fi; }
 
+# CAT-35: the helper is sourced by zsh phase workers with nounset enabled.
+if command -v zsh >/dev/null 2>&1; then
+	out="$(zsh -u -c "
+		set -uo pipefail
+		source '${HELPER}'
+		_lrr_emit_fallback_event 'CAT-35' 'stale-absent' 'test' 2>&1
+		echo EMIT_OK
+	" 2>&1)"
+	case "$out" in
+		*"parameter not set"*) fail "T-zsh1 emitters survive zsh -u" "$out" ;;
+		*EMIT_OK*)             ok   "T-zsh1 emitters survive zsh -u" ;;
+		*)                     fail "T-zsh1 emitters survive zsh -u" "$out" ;;
+	esac
+
+	ev_dir="$(mktemp -d)"
+	zsh -u -c "
+		set -uo pipefail
+		export CATALYST_EVENTS_DIR='${ev_dir}'
+		source '${HELPER}'
+		_lrr_emit_fallback_event 'CAT-35' 'stale-absent' 'test'
+	" >/dev/null 2>&1
+	n="$(cat "${ev_dir}"/*.jsonl 2>/dev/null | grep -c 'catalyst.replica.read_fallback' || echo 0)"
+	assert_eq "T-zsh2 fallback event appended under zsh" "1" "$n"
+	rm -rf "$ev_dir"
+else
+	echo "  SKIP: zsh not available (T-zsh1/T-zsh2)"
+fi
+
 command -v sqlite3 >/dev/null 2>&1 || {
 	echo "SKIP: sqlite3 not available"
 	exit 0

--- a/plugins/dev/scripts/__tests__/linear-read-replica.test.sh
+++ b/plugins/dev/scripts/__tests__/linear-read-replica.test.sh
@@ -23,12 +23,21 @@ assert_eq() { if [ "$2" = "$3" ]; then ok "$1"; else fail "$1" "expected '$2' go
 
 # CAT-35: the helper is sourced by zsh phase workers with nounset enabled.
 if command -v zsh >/dev/null 2>&1; then
+	# Both zsh probes CALL a real emitter, so each needs its own CATALYST_EVENTS_DIR.
+	# Without it the emitter resolves $HOME/catalyst/events and appends a synthetic
+	# `catalyst.replica.read_fallback` WARN to the operator's live unified event log
+	# on every CI run — the very signal this branch makes alertable. (The suite-wide
+	# export at the bottom of this file lands AFTER this block, so it does not cover
+	# these two.) T-zsh1 gets its own dir so T-zsh2's exact-count assert stays 1.
+	zsh1_dir="$(mktemp -d)"
 	out="$(zsh -u -c "
 		set -uo pipefail
+		export CATALYST_EVENTS_DIR='${zsh1_dir}'
 		source '${HELPER}'
 		_lrr_emit_fallback_event 'CAT-35' 'stale-absent' 'test' 2>&1
 		echo EMIT_OK
 	" 2>&1)"
+	rm -rf "$zsh1_dir"
 	case "$out" in
 		*"parameter not set"*) fail "T-zsh1 emitters survive zsh -u" "$out" ;;
 		*EMIT_OK*)             ok   "T-zsh1 emitters survive zsh -u" ;;

--- a/plugins/dev/scripts/broker/namespace-parity.test.mjs
+++ b/plugins/dev/scripts/broker/namespace-parity.test.mjs
@@ -53,6 +53,8 @@ const INLINE_EVENT_NAMES = [
   "monitor.reconcile.failing.team",   // reconcile-health-event.mjs:66 (team is param; prefix is safe)
   "monitor.reconcile.recovered.team", // reconcile-health-event.mjs:66
   "monitor.reconcile.eligible_persist_failure.team", // reconcile-health-event.mjs (CTL-1628 persist-write escalation)
+  "monitor.replica.degraded.team", // replica-health-event.mjs (CAT-35)
+  "monitor.replica.recovered.team", // replica-health-event.mjs (CAT-35)
   "phase.triage.linear-transition.CTL-1", // triage-transition-event.mjs:53
   "linear.state.write.CTL-1",         // linear-state-write-event.mjs:77
   "agent.waiting_on_user",            // wait-event.mjs:buildWaitEnvelope

--- a/plugins/dev/scripts/execution-core/__tests__/doctor-replica.test.mjs
+++ b/plugins/dev/scripts/execution-core/__tests__/doctor-replica.test.mjs
@@ -77,6 +77,24 @@ describe("checkCloudSync", () => {
     expect(m["replica-fresh"].detail).toMatch(/tiny|seed/i);
   });
 
+  test("0-byte replica reports never-seeded schema", () => {
+    const m = byName(checkCloudSync(deps({ statFile: () => ({ size: 0, mtimeMs: NOW }) })));
+    expect(m["replica-schema"].status).toBe("warn");
+    expect(m["replica-schema"].detail).toMatch(/never seeded|no schema|0 bytes/i);
+  });
+
+  test("seeded-but-stale replica passes schema check", () => {
+    const m = byName(checkCloudSync(deps({ statFile: () => ({ size: 4_000_000, mtimeMs: NOW - 86_400_000 }) })));
+    expect(m["replica-schema"].status).toBe("pass");
+  });
+
+  test("tier-inert summary names token and read flag gaps", () => {
+    const m = byName(checkCloudSync(deps({ mode: "off", env: {}, statFile: () => ({ size: 0, mtimeMs: NOW }) })));
+    expect(m["replica-tier"].status).toBe("warn");
+    expect(m["replica-tier"].detail).toMatch(/token/i);
+    expect(m["replica-tier"].detail).toMatch(/CATALYST_LINEAR_REPLICA/);
+  });
+
   test("all mtimes old incl the writer-lock (heartbeat stopped) → replica-fresh WARN (likely down)", () => {
     const m = byName(checkCloudSync(deps({ statFile: () => ({ size: 64_000_000, mtimeMs: NOW - 600_000 }) })));
     expect(m["replica-fresh"].status).toBe("warn");

--- a/plugins/dev/scripts/execution-core/__tests__/doctor-replica.test.mjs
+++ b/plugins/dev/scripts/execution-core/__tests__/doctor-replica.test.mjs
@@ -26,6 +26,10 @@ function deps(over = {}) {
     now: NOW,
     staleMs: 120_000,
     sizeFloorBytes: 65_536,
+    // CAT-35: schema verification seams — injected so this suite keeps touching no
+    // fs/spawn. Healthy default = a real SQLite file carrying both required tables.
+    isSqliteFile: () => true,
+    readDbTables: () => ["issues", "sync_meta", "labels"],
     ...over,
   };
 }
@@ -93,6 +97,34 @@ describe("checkCloudSync", () => {
   test("seeded-but-stale replica passes schema check", () => {
     const m = byName(checkCloudSync(deps({ statFile: () => ({ size: 4_000_000, mtimeMs: NOW - 86_400_000 }) })));
     expect(m["replica-schema"].status).toBe("pass");
+    expect(m["replica-schema"].detail).toMatch(/issues \+ sync_meta present/);
+  });
+
+  // CAT-35 (Codex round 1): size alone must never earn a PASS. A large file that is
+  // not a database, or is a database missing the tables the production reader
+  // prepares against, previously reported "schema seeded" while every read missed.
+  test("large non-SQLite file above the floor does NOT pass schema check", () => {
+    const m = byName(checkCloudSync(deps({ isSqliteFile: () => false })));
+    expect(m["replica-schema"].status).toBe("warn");
+    expect(m["replica-schema"].detail).toMatch(/no SQLite header|corrupt/i);
+  });
+
+  test("valid SQLite file missing a required table does NOT pass schema check", () => {
+    const m = byName(checkCloudSync(deps({ readDbTables: () => ["issues"] })));
+    expect(m["replica-schema"].status).toBe("warn");
+    expect(m["replica-schema"].detail).toMatch(/sync_meta/);
+  });
+
+  test("no sqlite3 reader → unverified INFO, never a PASS claiming a seeded schema", () => {
+    const m = byName(checkCloudSync(deps({ readDbTables: () => null })));
+    expect(m["replica-schema"].status).toBe("info");
+    expect(m["replica-schema"].detail).toMatch(/unverified/i);
+  });
+
+  test("header/table verification never introduces a FAIL", () => {
+    for (const over of [{ isSqliteFile: () => false }, { readDbTables: () => [] }, { readDbTables: () => null }]) {
+      expect(noFail(checkCloudSync(deps(over)))).toBe(true);
+    }
   });
 
   test("tier-inert summary names token and read flag gaps", () => {

--- a/plugins/dev/scripts/execution-core/__tests__/doctor-replica.test.mjs
+++ b/plugins/dev/scripts/execution-core/__tests__/doctor-replica.test.mjs
@@ -83,6 +83,13 @@ describe("checkCloudSync", () => {
     expect(m["replica-schema"].detail).toMatch(/never seeded|no schema|0 bytes/i);
   });
 
+  test("unreadable replica does not report a never-seeded schema", () => {
+    const m = byName(checkCloudSync(deps({ statFile: () => { throw new Error("permission denied"); } })));
+    expect(m["replica-schema"].status).toBe("warn");
+    expect(m["replica-schema"].detail).toMatch(/unreadable/i);
+    expect(m["replica-schema"].detail).not.toMatch(/never seeded|0 bytes/i);
+  });
+
   test("seeded-but-stale replica passes schema check", () => {
     const m = byName(checkCloudSync(deps({ statFile: () => ({ size: 4_000_000, mtimeMs: NOW - 86_400_000 }) })));
     expect(m["replica-schema"].status).toBe("pass");

--- a/plugins/dev/scripts/execution-core/__tests__/linear-query-triage-source.test.mjs
+++ b/plugins/dev/scripts/execution-core/__tests__/linear-query-triage-source.test.mjs
@@ -1,0 +1,24 @@
+import { test, expect } from "bun:test";
+import { runTriageStateQuery } from "../linear-query.mjs";
+
+test("no-replica branch records a skipped daemon read (CAT-35)", () => {
+  const reads = [];
+  runTriageStateQuery(
+    { team: "CAT", triageStatus: "Triage" },
+    { replica: undefined, onSource: () => {}, recordRead: (...args) => reads.push(args) },
+  );
+  expect(reads).toEqual([["replica", "skipped", null, null, "triage_list"]]);
+});
+
+test("replica-miss still records failed", () => {
+  const reads = [];
+  runTriageStateQuery(
+    { team: "CAT", triageStatus: "Triage" },
+    {
+      replica: { triageState: () => undefined },
+      onSource: () => {},
+      recordRead: (...args) => reads.push(args),
+    },
+  );
+  expect(reads[0]).toEqual(["replica", "failed", null, null, "triage_list"]);
+});

--- a/plugins/dev/scripts/execution-core/__tests__/linear-query-triage-source.test.mjs
+++ b/plugins/dev/scripts/execution-core/__tests__/linear-query-triage-source.test.mjs
@@ -1,13 +1,13 @@
 import { test, expect } from "bun:test";
 import { runTriageStateQuery } from "../linear-query.mjs";
 
-test("no-replica branch records a skipped daemon read (CAT-35)", () => {
+test("no-replica branch does not record a daemon read (CAT-35)", () => {
   const reads = [];
   runTriageStateQuery(
     { team: "CAT", triageStatus: "Triage" },
     { replica: undefined, onSource: () => {}, recordRead: (...args) => reads.push(args) },
   );
-  expect(reads).toEqual([["replica", "skipped", null, null, "triage_list"]]);
+  expect(reads).toEqual([]);
 });
 
 test("replica-miss still records failed", () => {

--- a/plugins/dev/scripts/execution-core/__tests__/replica-health-event.test.mjs
+++ b/plugins/dev/scripts/execution-core/__tests__/replica-health-event.test.mjs
@@ -81,14 +81,16 @@ describe("buildReplicaHealthEvent", () => {
       source: "no-replica",
       consecutiveDegraded: 7,
     });
-    // NOTE (CAT-35 verify finding): consecutiveDegraded currently lives ONLY in
-    // body.payload, and otel-forward's OTLP conversion (otel-forward/lib/
-    // destinations/otlp.ts) forwards only `resource`, `body.message`, and
-    // `attributes` — so the streak count never reaches Loki/Grafana. The
-    // sibling reconcile-health-event.mjs mirrors its equivalent field into
-    // attributes for exactly this reason (CTL-1628). This assertion pins the
-    // current shape; it is deliberately NOT an endorsement of the gap.
-    expect(ev.attributes["replica.consecutive_degraded"]).toBeUndefined();
+    // CAT-35 (Codex round 1): the streak ALSO has to ride an attribute. otel-forward's
+    // OTLP conversion (otel-forward/lib/destinations/otlp.ts) forwards only `resource`,
+    // `body.message`, and `attributes` — body.payload is dropped off-machine, so a
+    // payload-only count never reaches Loki/Grafana, which is where this signal is read.
+    expect(ev.attributes["replica.consecutive_degraded"]).toBe(7);
+  });
+
+  test("streak attribute is present (as 0) on recovered, so the series closes out", () => {
+    const ev = JSON.parse(buildReplicaHealthEvent({ team: "CAT", action: REPLICA_RECOVERED_ACTION }));
+    expect(ev.attributes["replica.consecutive_degraded"]).toBe(0);
   });
 
   test("each event gets a fresh id / traceId / spanId", () => {

--- a/plugins/dev/scripts/execution-core/__tests__/replica-health-event.test.mjs
+++ b/plugins/dev/scripts/execution-core/__tests__/replica-health-event.test.mjs
@@ -1,0 +1,141 @@
+// replica-health-event.test.mjs — CAT-35: canonical
+// monitor.replica.{degraded,recovered} events.
+// Run: cd plugins/dev/scripts/execution-core && bun test __tests__/replica-health-event.test.mjs
+//
+// Mirrors reconcile-health-event.test.mjs, the sibling this module was modeled
+// on. Every `append` seam is injected — a test must never write the real
+// unified event log.
+import { describe, test, expect } from "bun:test";
+import {
+  buildReplicaHealthEvent,
+  appendReplicaHealthEvent,
+  REPLICA_DEGRADED_ACTION,
+  REPLICA_RECOVERED_ACTION,
+} from "../replica-health-event.mjs";
+
+describe("buildReplicaHealthEvent", () => {
+  test("degraded envelope — WARN, team-keyed name, source attribute", () => {
+    const line = buildReplicaHealthEvent({
+      team: "CAT",
+      action: REPLICA_DEGRADED_ACTION,
+      source: "replica-miss",
+      consecutiveDegraded: 3,
+    });
+    expect(typeof line).toBe("string");
+    expect(line.endsWith("\n")).toBe(true);
+    const ev = JSON.parse(line);
+    expect(ev.attributes["event.name"]).toBe("monitor.replica.degraded.CAT");
+    expect(ev.attributes["event.entity"]).toBe("monitor");
+    expect(ev.attributes["event.action"]).toBe("replica.degraded");
+    expect(ev.attributes["event.label"]).toBe("CAT");
+    expect(ev.attributes["catalyst.team"]).toBe("CAT");
+    expect(ev.attributes["replica.source"]).toBe("replica-miss");
+    // A team-wide replica outage has no Linear issue identifier.
+    expect(ev.attributes["linear.issue.identifier"]).toBeUndefined();
+    expect(ev.resource["service.name"]).toBe("catalyst.execution-core");
+    expect(ev.severityText).toBe("WARN");
+    expect(ev.severityNumber).toBe(13);
+    expect(ev.ts).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$/);
+    expect(ev.observedTs).toBe(ev.ts);
+    expect(ev.id).toMatch(/^[0-9a-f]{16}$/);
+    expect(ev.traceId).toMatch(/^[0-9a-f]{32}$/);
+    expect(ev.spanId).toMatch(/^[0-9a-f]{16}$/);
+  });
+
+  test("recovered envelope — INFO severity, recovered action", () => {
+    const ev = JSON.parse(
+      buildReplicaHealthEvent({
+        team: "CAT",
+        action: REPLICA_RECOVERED_ACTION,
+        source: "replica",
+        consecutiveDegraded: 0,
+      }),
+    );
+    expect(ev.attributes["event.name"]).toBe("monitor.replica.recovered.CAT");
+    expect(ev.attributes["event.action"]).toBe("replica.recovered");
+    expect(ev.severityText).toBe("INFO");
+    expect(ev.severityNumber).toBe(9);
+  });
+
+  test("source is omitted entirely — not empty-string — when absent", () => {
+    const ev = JSON.parse(
+      buildReplicaHealthEvent({ team: "CAT", action: REPLICA_DEGRADED_ACTION }),
+    );
+    expect("replica.source" in ev.attributes).toBe(false);
+    expect(ev.body.payload.source).toBeNull();
+    expect(ev.body.payload.consecutiveDegraded).toBe(0);
+  });
+
+  test("body.payload carries the full context", () => {
+    const ev = JSON.parse(
+      buildReplicaHealthEvent({
+        team: "SKI",
+        action: REPLICA_DEGRADED_ACTION,
+        source: "no-replica",
+        consecutiveDegraded: 7,
+      }),
+    );
+    expect(ev.body.payload).toEqual({
+      team: "SKI",
+      action: "degraded",
+      source: "no-replica",
+      consecutiveDegraded: 7,
+    });
+    // NOTE (CAT-35 verify finding): consecutiveDegraded currently lives ONLY in
+    // body.payload, and otel-forward's OTLP conversion (otel-forward/lib/
+    // destinations/otlp.ts) forwards only `resource`, `body.message`, and
+    // `attributes` — so the streak count never reaches Loki/Grafana. The
+    // sibling reconcile-health-event.mjs mirrors its equivalent field into
+    // attributes for exactly this reason (CTL-1628). This assertion pins the
+    // current shape; it is deliberately NOT an endorsement of the gap.
+    expect(ev.attributes["replica.consecutive_degraded"]).toBeUndefined();
+  });
+
+  test("each event gets a fresh id / traceId / spanId", () => {
+    const a = JSON.parse(buildReplicaHealthEvent({ team: "CAT", action: REPLICA_DEGRADED_ACTION }));
+    const b = JSON.parse(buildReplicaHealthEvent({ team: "CAT", action: REPLICA_DEGRADED_ACTION }));
+    expect(a.id).not.toBe(b.id);
+    expect(a.traceId).not.toBe(b.traceId);
+    expect(a.spanId).not.toBe(b.spanId);
+  });
+
+  test("no-arg call does not throw and yields a parseable line", () => {
+    const ev = JSON.parse(buildReplicaHealthEvent());
+    expect(ev.attributes["event.name"]).toBe("monitor.replica.undefined.undefined");
+    // action !== "degraded" ⇒ the INFO branch; documents the defaulting, which
+    // is unreachable from recordReplicaRead (it always passes a real action).
+    expect(ev.severityText).toBe("INFO");
+  });
+});
+
+describe("appendReplicaHealthEvent", () => {
+  test("returns true and hands the built line to the injected append", () => {
+    const lines = [];
+    const ok = appendReplicaHealthEvent({
+      append: (line) => lines.push(line),
+      team: "CAT",
+      action: REPLICA_DEGRADED_ACTION,
+      source: "no-replica",
+      consecutiveDegraded: 3,
+    });
+    expect(ok).toBe(true);
+    expect(lines).toHaveLength(1);
+    expect(JSON.parse(lines[0]).attributes["event.name"]).toBe("monitor.replica.degraded.CAT");
+  });
+
+  test("returns false and never throws when the append fails", () => {
+    let result;
+    expect(() => {
+      result = appendReplicaHealthEvent({
+        append: () => {
+          throw new Error("ENOSPC: no space left on device");
+        },
+        team: "CAT",
+        action: REPLICA_DEGRADED_ACTION,
+      });
+    }).not.toThrow();
+    // false is load-bearing: recordReplicaRead leaves `alerting` unset on a
+    // false return so the degraded alert retries on the next read.
+    expect(result).toBe(false);
+  });
+});

--- a/plugins/dev/scripts/execution-core/__tests__/replica-health.test.mjs
+++ b/plugins/dev/scripts/execution-core/__tests__/replica-health.test.mjs
@@ -1,0 +1,68 @@
+import { test, expect } from "bun:test";
+import { recordReplicaRead, resetReplicaHealth } from "../replica-health.mjs";
+
+const opts = (events) => ({
+  appendEvent: (event) => events.push(event),
+  writeMarker: () => {},
+  threshold: 3,
+});
+
+test("degraded emits exactly once at the threshold", () => {
+  const events = [];
+  resetReplicaHealth();
+  for (let i = 0; i < 6; i += 1) recordReplicaRead("CAT", "no-replica", opts(events));
+  expect(events.filter((event) => event.action === "degraded")).toHaveLength(1);
+});
+
+test("below threshold emits nothing", () => {
+  const events = [];
+  resetReplicaHealth();
+  recordReplicaRead("CAT", "no-replica", opts(events));
+  recordReplicaRead("CAT", "no-replica", opts(events));
+  expect(events).toHaveLength(0);
+});
+
+test("healthy read after an alert emits recovered and resets", () => {
+  const events = [];
+  resetReplicaHealth();
+  for (let i = 0; i < 3; i += 1) recordReplicaRead("CAT", "replica", opts(events));
+  for (let i = 0; i < 3; i += 1) recordReplicaRead("CAT", "no-replica", opts(events));
+  recordReplicaRead("CAT", "replica", opts(events));
+  expect(events.at(-1).action).toBe("recovered");
+});
+
+test("healthy without a prior alert emits nothing", () => {
+  const events = [];
+  resetReplicaHealth();
+  recordReplicaRead("CAT", "replica", opts(events));
+  expect(events).toHaveLength(0);
+});
+
+test("no-triage-status is not degradation", () => {
+  const events = [];
+  resetReplicaHealth();
+  for (let i = 0; i < 9; i += 1) recordReplicaRead("CAT", "no-triage-status", opts(events));
+  expect(events).toHaveLength(0);
+});
+
+test("streaks are per team", () => {
+  const events = [];
+  resetReplicaHealth();
+  for (let i = 0; i < 3; i += 1) {
+    recordReplicaRead("CAT", "no-replica", opts(events));
+    recordReplicaRead("SKI", "replica", opts(events));
+  }
+  expect(events.filter((event) => event.team === "CAT")).toHaveLength(1);
+  expect(events.filter((event) => event.team === "SKI")).toHaveLength(0);
+});
+
+test("appendEvent throw never propagates", () => {
+  resetReplicaHealth();
+  expect(() =>
+    recordReplicaRead("CAT", "no-replica", {
+      appendEvent: () => { throw new Error("disk full"); },
+      writeMarker: () => {},
+      threshold: 1,
+    }),
+  ).not.toThrow();
+});

--- a/plugins/dev/scripts/execution-core/__tests__/replica-health.test.mjs
+++ b/plugins/dev/scripts/execution-core/__tests__/replica-health.test.mjs
@@ -48,6 +48,41 @@ test("healthy read after restart hydrates alert and emits recovered", () => {
   ]);
 });
 
+// CAT-35 (Codex round 1): the alert latch must survive a failed recovery append.
+// Clearing `alerting` before the append landed meant one failed write (disk full,
+// EACCES) permanently swallowed the recovery — the persisted marker said "not
+// alerting", so no later healthy read had an alert to recover from, and consumers
+// stayed pinned to monitor.replica.degraded.<TEAM> forever. Mirrors the degraded
+// branch, which has always gated its latch on a successful append.
+test("failed recovery append keeps the latch so a later healthy read retries", () => {
+  const events = [];
+  const persisted = [];
+  resetReplicaHealth();
+  const hydrated = () => ({ consecutiveDegraded: 3, lastHealthyTs: null, alerting: true });
+
+  // First healthy read: the append fails, so the latch must NOT clear.
+  recordReplicaRead("CAT", "replica", {
+    appendEvent: () => false,
+    readMarker: hydrated,
+    writeMarker: (_team, state) => persisted.push({ ...state }),
+    threshold: 3,
+  });
+  expect(events).toHaveLength(0);
+  expect(persisted.at(-1).alerting).toBe(true);
+
+  // Second healthy read: the append succeeds, the recovery finally lands, latch clears.
+  recordReplicaRead("CAT", "replica", {
+    appendEvent: (event) => events.push(event),
+    readMarker: hydrated,
+    writeMarker: (_team, state) => persisted.push({ ...state }),
+    threshold: 3,
+  });
+  expect(events).toEqual([
+    { team: "CAT", action: "recovered", source: "replica", consecutiveDegraded: 0 },
+  ]);
+  expect(persisted.at(-1).alerting).toBe(false);
+});
+
 test("healthy without a prior alert emits nothing", () => {
   const events = [];
   resetReplicaHealth();

--- a/plugins/dev/scripts/execution-core/__tests__/replica-health.test.mjs
+++ b/plugins/dev/scripts/execution-core/__tests__/replica-health.test.mjs
@@ -3,6 +3,7 @@ import { recordReplicaRead, resetReplicaHealth } from "../replica-health.mjs";
 
 const opts = (events) => ({
   appendEvent: (event) => events.push(event),
+  readMarker: () => null,
   writeMarker: () => {},
   threshold: 3,
 });
@@ -29,6 +30,22 @@ test("healthy read after an alert emits recovered and resets", () => {
   for (let i = 0; i < 3; i += 1) recordReplicaRead("CAT", "no-replica", opts(events));
   recordReplicaRead("CAT", "replica", opts(events));
   expect(events.at(-1).action).toBe("recovered");
+});
+
+test("healthy read after restart hydrates alert and emits recovered", () => {
+  const events = [];
+  resetReplicaHealth();
+  recordReplicaRead("CAT", "replica", {
+    ...opts(events),
+    readMarker: () => ({
+      consecutiveDegraded: 3,
+      lastHealthyTs: "2026-08-08T00:00:00.000Z",
+      alerting: true,
+    }),
+  });
+  expect(events).toEqual([
+    { team: "CAT", action: "recovered", source: "replica", consecutiveDegraded: 0 },
+  ]);
 });
 
 test("healthy without a prior alert emits nothing", () => {

--- a/plugins/dev/scripts/execution-core/__tests__/replica-health.test.mjs
+++ b/plugins/dev/scripts/execution-core/__tests__/replica-health.test.mjs
@@ -57,9 +57,36 @@ test("healthy without a prior alert emits nothing", () => {
 
 test("no-triage-status is not degradation", () => {
   const events = [];
+  let writes = 0;
   resetReplicaHealth();
-  for (let i = 0; i < 9; i += 1) recordReplicaRead("CAT", "no-triage-status", opts(events));
+  for (let i = 0; i < 9; i += 1) {
+    recordReplicaRead("CAT", "no-triage-status", {
+      ...opts(events),
+      writeMarker: () => { writes += 1; },
+    });
+  }
   expect(events).toHaveLength(0);
+  expect(writes).toBe(0);
+});
+
+test("failed degraded event append retries on the next read", () => {
+  const events = [];
+  let attempts = 0;
+  resetReplicaHealth();
+  const retryingOpts = {
+    ...opts(events),
+    threshold: 1,
+    appendEvent: (event) => {
+      attempts += 1;
+      if (attempts === 1) return false;
+      events.push(event);
+      return true;
+    },
+  };
+  recordReplicaRead("CAT", "no-replica", retryingOpts);
+  recordReplicaRead("CAT", "no-replica", retryingOpts);
+  expect(attempts).toBe(2);
+  expect(events).toHaveLength(1);
 });
 
 test("streaks are per team", () => {

--- a/plugins/dev/scripts/execution-core/config.mjs
+++ b/plugins/dev/scripts/execution-core/config.mjs
@@ -306,6 +306,10 @@ export function getReconcileHealthDir() {
   return resolve(getExecutionCoreDir(), "reconcile-health");
 }
 
+export function getReplicaHealthDir() {
+  return resolve(getExecutionCoreDir(), "replica-health");
+}
+
 // CTL-1503 — fleet-health durable-latch dir. Holds the edge-trigger latch marker
 // (fleet-health-latch.json) the probe persists on the healthy→degraded /
 // degraded→healthy edges and hydrates on start, so a daemon restart mid-episode
@@ -1293,6 +1297,9 @@ export const RECONCILE_INTERVAL_MS =
 // Env-overridable for tuning/tests.
 export const RECONCILE_FAILURE_ALERT_THRESHOLD =
   Number(process.env.EXECUTION_CORE_RECONCILE_FAILURE_ALERT_THRESHOLD) || 3;
+
+export const REPLICA_DEGRADED_ALERT_THRESHOLD =
+  Number(process.env.EXECUTION_CORE_REPLICA_DEGRADED_ALERT_THRESHOLD) || 3;
 
 // Debounce window: state_changed events that enter the eligible state coalesce
 // into one reconcile poll per affected project per burst.

--- a/plugins/dev/scripts/execution-core/doctor.mjs
+++ b/plugins/dev/scripts/execution-core/doctor.mjs
@@ -3083,10 +3083,10 @@ export function checkCloudSync(deps = {}) {
   // measures "time since last mirrored change", NOT writer liveness. The feed-independent
   // liveness signal is the writer-lock HEARTBEAT (<db>.writer.lock), rewritten ~every 5s.
   // Gate liveness on the lock heartbeat; report the data-age as info only, never as "down".
+  let size = 0;
   if (!dbPresent) {
     checks.push(mkCheck("replica-fresh", STATUS.WARN, "replica db not present — writer has not seeded yet (not connected)"));
   } else {
-    let size = 0;
     let dataNewest = 0; // newest of DB + non-empty -wal mtime = last mirrored change
     try { const s = statFile(dbPath); size = s.size; dataNewest = s.mtimeMs; } catch { /* unreadable → handled below */ }
     try { const w = statFile(`${dbPath}-wal`); if (w.size > 0) dataNewest = Math.max(dataNewest, w.mtimeMs); } catch { /* no -wal sidecar */ }
@@ -3113,6 +3113,17 @@ export function checkCloudSync(deps = {}) {
     }
   }
 
+  // CAT-35: distinguish a never-seeded/no-schema file from ordinary staleness.
+  if (dbPresent) {
+    checks.push(
+      size === 0
+        ? mkCheck("replica-schema", STATUS.WARN, "replica db is 0 bytes — no schema, never seeded; the writer has never authenticated")
+        : size < sizeFloorBytes
+          ? mkCheck("replica-schema", STATUS.WARN, `replica db is ${size}B (< ${sizeFloorBytes}B floor) — seed incomplete`)
+          : mkCheck("replica-schema", STATUS.PASS, `replica db ${Math.round(size / 1024)}KiB — schema seeded`),
+    );
+  }
+
   // (c) token presence — by NAME only, NEVER the value.
   const tokenVal = env[tokenEnv.envVar];
   const tokenSet = typeof tokenVal === "string" && tokenVal.length > 0;
@@ -3133,6 +3144,18 @@ export function checkCloudSync(deps = {}) {
     checks.push(mkCheck("replica-read-flag", STATUS.WARN, "writer running + replica present but CATALYST_LINEAR_REPLICA=off — flip it on to read from the replica"));
   } else {
     checks.push(mkCheck("replica-read-flag", STATUS.INFO, "replica read tier off (CATALYST_LINEAR_REPLICA unset/off)"));
+  }
+
+  const tokenMissing = !tokenSet;
+  const flagOff = mode !== "on";
+  if (tokenMissing && flagOff) {
+    checks.push(mkCheck("replica-tier", STATUS.WARN,
+      `replica tier INERT end-to-end: token ${tokenEnv.envVar} unset AND CATALYST_LINEAR_REPLICA off. Both must be fixed, token FIRST`));
+  } else if (tokenMissing || flagOff) {
+    checks.push(mkCheck("replica-tier", STATUS.WARN,
+      `replica tier partially configured (${tokenMissing ? `token ${tokenEnv.envVar} unset` : "CATALYST_LINEAR_REPLICA off"}) — reads still fall back`));
+  } else {
+    checks.push(mkCheck("replica-tier", STATUS.PASS, "replica tier fully configured (token set + read flag on)"));
   }
 
   return checks;

--- a/plugins/dev/scripts/execution-core/doctor.mjs
+++ b/plugins/dev/scripts/execution-core/doctor.mjs
@@ -24,7 +24,7 @@
 //
 // Exit code: number of FAIL-level checks (0 = all clear).
 
-import { readFileSync, statSync, existsSync, realpathSync } from "node:fs";
+import { readFileSync, statSync, existsSync, realpathSync, openSync, readSync, closeSync } from "node:fs";
 import { resolve, dirname, isAbsolute } from "node:path";
 import { homedir } from "node:os";
 import { fileURLToPath } from "node:url";
@@ -3028,6 +3028,41 @@ export function checkCloudTokenEnv(deps = {}) {
   return checks;
 }
 
+// CAT-35 replica-schema verification helpers. The production reader (replica-read.mjs)
+// prepares queries against `issues` and `sync_meta`; a file that lacks either is unusable
+// no matter how large it is, so `replica-schema` must not PASS on size alone.
+export const REQUIRED_REPLICA_TABLES = ["issues", "sync_meta"];
+const SQLITE_MAGIC = "SQLite format 3\0";
+
+// defaultIsSqliteFile — read ONLY the 16-byte magic header (never the whole file, which
+// can be hundreds of MiB). Returns false on any read error: unreadable is not verified.
+function defaultIsSqliteFile(path) {
+  let fd = null;
+  try {
+    fd = openSync(path, "r");
+    const buf = Buffer.alloc(SQLITE_MAGIC.length);
+    const read = readSync(fd, buf, 0, buf.length, 0);
+    return read === buf.length && buf.toString("latin1") === SQLITE_MAGIC;
+  } catch {
+    return false;
+  } finally {
+    if (fd !== null) { try { closeSync(fd); } catch { /* already closed */ } }
+  }
+}
+
+// defaultReadDbTables — table names via the sqlite3 CLI (an OPTIONAL dependency; doctor
+// runs under bare node and must not import bun:sqlite). Returns null — meaning "could not
+// verify", distinct from [] meaning "verified, no tables" — when sqlite3 is absent or the
+// query fails, so the caller reports unverified instead of inventing a WARN.
+function defaultReadDbTables(path) {
+  const r = spawnSync("sqlite3", ["-readonly", path, "SELECT name FROM sqlite_master WHERE type='table'"], {
+    encoding: "utf8",
+    timeout: 10_000,
+  });
+  if (r.error || r.status !== 0 || typeof r.stdout !== "string") return null;
+  return r.stdout.split("\n").map((l) => l.trim()).filter((l) => l.length > 0);
+}
+
 // checkCloudSync — CTL-1394. Advisory health of the per-node supervised Linear-replica
 // writer + its read tier. EVERY condition is WARN/INFO/PASS, NEVER FAIL: doctor's exit code
 // is the FAIL count and gates catalyst-join activation — a FAIL here would block a node that
@@ -3054,6 +3089,8 @@ export function checkCloudSync(deps = {}) {
     // (4× the SDK's 15s lock-stale) absorbs heartbeat jitter; > this ⇒ heartbeat stopped.
     lockStaleMs = Number(process.env.CATALYST_REPLICA_LOCK_STALE_MS) || 60_000,
     sizeFloorBytes = 65_536,
+    isSqliteFile = defaultIsSqliteFile, // CAT-35
+    readDbTables = defaultReadDbTables, // CAT-35
   } = deps;
 
   const installed = agentInstalled(label, laDir);
@@ -3115,16 +3152,35 @@ export function checkCloudSync(deps = {}) {
   }
 
   // CAT-35: distinguish a never-seeded/no-schema file from ordinary staleness.
+  // Size alone must never earn a PASS: a truncated, corrupt, or entirely unrelated
+  // file above the floor would otherwise be declared "schema seeded" while every
+  // production read misses, which is the exact failure this check exists to catch.
+  // So a PASS additionally requires the SQLite magic header AND — when a sqlite3
+  // reader is available — the two tables the production reader actually prepares
+  // against (`issues`, `sync_meta`). With no reader present we say so rather than
+  // claiming verification we did not perform.
   if (dbPresent) {
-    checks.push(
-      !statOk
-        ? mkCheck("replica-schema", STATUS.WARN, "replica db is present but unreadable — cannot determine whether schema is seeded")
-        : size === 0
-        ? mkCheck("replica-schema", STATUS.WARN, "replica db is 0 bytes — no schema, never seeded; the writer has never authenticated")
-        : size < sizeFloorBytes
-          ? mkCheck("replica-schema", STATUS.WARN, `replica db is ${size}B (< ${sizeFloorBytes}B floor) — seed incomplete`)
-          : mkCheck("replica-schema", STATUS.PASS, `replica db ${Math.round(size / 1024)}KiB — schema seeded`),
-    );
+    if (!statOk) {
+      checks.push(mkCheck("replica-schema", STATUS.WARN, "replica db is present but unreadable — cannot determine whether schema is seeded"));
+    } else if (size === 0) {
+      checks.push(mkCheck("replica-schema", STATUS.WARN, "replica db is 0 bytes — no schema, never seeded; the writer has never authenticated"));
+    } else if (size < sizeFloorBytes) {
+      checks.push(mkCheck("replica-schema", STATUS.WARN, `replica db is ${size}B (< ${sizeFloorBytes}B floor) — seed incomplete`));
+    } else if (!isSqliteFile(dbPath)) {
+      checks.push(mkCheck("replica-schema", STATUS.WARN, `replica db is ${Math.round(size / 1024)}KiB but has no SQLite header — corrupt or not a database; every read will miss`));
+    } else {
+      const tables = readDbTables(dbPath);
+      if (tables === null) {
+        checks.push(mkCheck("replica-schema", STATUS.INFO, `replica db ${Math.round(size / 1024)}KiB, valid SQLite header — table presence unverified (no sqlite3 reader available)`));
+      } else {
+        const missing = REQUIRED_REPLICA_TABLES.filter((t) => !tables.includes(t));
+        checks.push(
+          missing.length > 0
+            ? mkCheck("replica-schema", STATUS.WARN, `replica db ${Math.round(size / 1024)}KiB is missing required table(s): ${missing.join(", ")} — the reader cannot prepare its queries`)
+            : mkCheck("replica-schema", STATUS.PASS, `replica db ${Math.round(size / 1024)}KiB — schema seeded (${REQUIRED_REPLICA_TABLES.join(" + ")} present)`),
+        );
+      }
+    }
   }
 
   // (c) token presence — by NAME only, NEVER the value.

--- a/plugins/dev/scripts/execution-core/doctor.mjs
+++ b/plugins/dev/scripts/execution-core/doctor.mjs
@@ -3084,11 +3084,12 @@ export function checkCloudSync(deps = {}) {
   // liveness signal is the writer-lock HEARTBEAT (<db>.writer.lock), rewritten ~every 5s.
   // Gate liveness on the lock heartbeat; report the data-age as info only, never as "down".
   let size = 0;
+  let statOk = false;
   if (!dbPresent) {
     checks.push(mkCheck("replica-fresh", STATUS.WARN, "replica db not present — writer has not seeded yet (not connected)"));
   } else {
     let dataNewest = 0; // newest of DB + non-empty -wal mtime = last mirrored change
-    try { const s = statFile(dbPath); size = s.size; dataNewest = s.mtimeMs; } catch { /* unreadable → handled below */ }
+    try { const s = statFile(dbPath); size = s.size; dataNewest = s.mtimeMs; statOk = true; } catch { /* unreadable → handled below */ }
     try { const w = statFile(`${dbPath}-wal`); if (w.size > 0) dataNewest = Math.max(dataNewest, w.mtimeMs); } catch { /* no -wal sidecar */ }
     let lockMtime = 0;
     try { lockMtime = statFile(`${dbPath}.writer.lock`).mtimeMs; } catch { /* no lock: guard disabled / writer not started */ }
@@ -3116,7 +3117,9 @@ export function checkCloudSync(deps = {}) {
   // CAT-35: distinguish a never-seeded/no-schema file from ordinary staleness.
   if (dbPresent) {
     checks.push(
-      size === 0
+      !statOk
+        ? mkCheck("replica-schema", STATUS.WARN, "replica db is present but unreadable — cannot determine whether schema is seeded")
+        : size === 0
         ? mkCheck("replica-schema", STATUS.WARN, "replica db is 0 bytes — no schema, never seeded; the writer has never authenticated")
         : size < sizeFloorBytes
           ? mkCheck("replica-schema", STATUS.WARN, `replica db is ${size}B (< ${sizeFloorBytes}B floor) — seed incomplete`)

--- a/plugins/dev/scripts/execution-core/integration-ctl-1240.test.mjs
+++ b/plugins/dev/scripts/execution-core/integration-ctl-1240.test.mjs
@@ -75,14 +75,25 @@ function fakeDispatch({ code = 0 } = {}) {
 }
 
 // Recording gateway spy: tracks every getDescriptor call.
+//
+// The spy also records each call's stack so a test can assert WHICH census
+// consulted the gateway. A bare `calls.toContain(ticket)` does not discriminate:
+// several passes in one tick resolve the same ticket's state (the terminal sweep
+// via isTicketTerminalOrMerged, for one), so that assertion stays green even when
+// the census under test never ran at all. calledFrom() pins it to the caller.
 function makeGatewaySpy(descriptors = {}) {
   const calls = [];
+  const stacks = [];
   const spy = {
     getDescriptor: (id) => {
       calls.push(id);
+      stacks.push({ id, stack: new Error().stack ?? "" });
       return descriptors[id] ?? null;
     },
     get calls() { return calls; },
+    // True iff `id` was resolved through a call originating in `sourceFile`.
+    calledFrom: (id, sourceFile) =>
+      stacks.some((s) => s.id === id && s.stack.includes(sourceFile)),
   };
   return spy;
 }
@@ -189,7 +200,11 @@ describe("CTL-1240 Phase 2 — census closures use { cache, gateway }", () => {
   //           → spy consulted.
 
   test("default stall-clear census uses { cache, gateway } via runningOpts", () => {
-    const STALL_TICKET = "CTL-1240-STALL";
+    // Must be a canonical TEAM-123 key: CTL-1504 added an isTicketKey guard to the
+    // worker-dir censuses (stall-janitor.mjs, unstuck-sweep.mjs), so a descriptive
+    // id like "CTL-1240-STALL" is skipped as debris and the closure under test never
+    // runs — the spy stays empty and the assertion fails for the wrong reason.
+    const STALL_TICKET = "STALL-1240";
 
     writeFileSync(join(orchDir, "state.json"), JSON.stringify({ maxParallel: 1 }));
     // Seed the stalled signal — stalledReason triggers the J3 isLinearTerminal probe.
@@ -219,7 +234,9 @@ describe("CTL-1240 Phase 2 — census closures use { cache, gateway }", () => {
 
     // The stall-clear census isLinearTerminal closure must have consulted the gateway.
     // PRE-FIX: fetchTicketState(id) bare → spy never called → assertion fails.
-    expect(gateway.calls).toContain(STALL_TICKET);
+    // Pinned to stall-janitor.mjs so an unrelated pass resolving the same ticket
+    // cannot satisfy this on the census's behalf.
+    expect(gateway.calledFrom(STALL_TICKET, "stall-janitor.mjs")).toBe(true);
   });
 
   // ── Site 5: default unstuck census (scheduler.mjs:5356–5361) ─────────────────
@@ -233,7 +250,11 @@ describe("CTL-1240 Phase 2 — census closures use { cache, gateway }", () => {
   //           → spy consulted.
 
   test("default unstuck census uses { cache, gateway } via runningOpts", () => {
-    const STUCK_TICKET = "CTL-1240-STUCK";
+    // Canonical TEAM-123 key for the same CTL-1504 isTicketKey reason as above.
+    // "CTL-1240-STUCK" was likewise skipped by the census; this assertion only
+    // passed because another pass in the same tick happened to consult the spy,
+    // so it was not actually exercising the unstuck census closure.
+    const STUCK_TICKET = "STUCK-1240";
 
     writeFileSync(join(orchDir, "state.json"), JSON.stringify({ maxParallel: 1 }));
     writeSignal(STUCK_TICKET, "implement", "stalled", {
@@ -260,6 +281,7 @@ describe("CTL-1240 Phase 2 — census closures use { cache, gateway }", () => {
 
     // The unstuck census isLinearTerminal closure must have consulted the gateway.
     // PRE-FIX: fetchTicketState(id) bare → spy never called → assertion fails.
-    expect(gateway.calls).toContain(STUCK_TICKET);
+    // Pinned to unstuck-sweep.mjs for the same reason as the stall-clear case.
+    expect(gateway.calledFrom(STUCK_TICKET, "unstuck-sweep.mjs")).toBe(true);
   });
 });

--- a/plugins/dev/scripts/execution-core/linear-query.mjs
+++ b/plugins/dev/scripts/execution-core/linear-query.mjs
@@ -1397,13 +1397,14 @@ export function runEligibleQuery(
 // onSource(source, count) markers: "replica" (served) · "no-triage-status" (the
 // team configures none) · "no-replica" (tier off / no reader wired) ·
 // "replica-miss" (dead writer, mid-reseed, or a throw).
-export function runTriageStateQuery(query, { replica, onSource } = {}) {
+export function runTriageStateQuery(query, { replica, onSource, recordRead = recordDaemonRead } = {}) {
   if (!query?.triageStatus) {
     onSource?.("no-triage-status", 0);
     return [];
   }
   if (!replica?.triageState) {
     onSource?.("no-replica", 0);
+    recordRead("replica", "skipped", null, null, "triage_list");
     return [];
   }
   let local;
@@ -1414,11 +1415,11 @@ export function runTriageStateQuery(query, { replica, onSource } = {}) {
   }
   if (!local || !Array.isArray(local.nodes)) {
     onSource?.("replica-miss", 0);
-    recordDaemonRead("replica", "failed", null, null, "triage_list");
+    recordRead("replica", "failed", null, null, "triage_list");
     return [];
   }
   const tickets = local.nodes.map(normalizeTicket);
   onSource?.("replica", tickets.length);
-  recordDaemonRead("replica", "ok", null, null, "triage_list");
+  recordRead("replica", "ok", null, null, "triage_list");
   return tickets;
 }

--- a/plugins/dev/scripts/execution-core/linear-query.mjs
+++ b/plugins/dev/scripts/execution-core/linear-query.mjs
@@ -1404,7 +1404,6 @@ export function runTriageStateQuery(query, { replica, onSource, recordRead = rec
   }
   if (!replica?.triageState) {
     onSource?.("no-replica", 0);
-    recordRead("replica", "skipped", null, null, "triage_list");
     return [];
   }
   let local;

--- a/plugins/dev/scripts/execution-core/linear-query.mjs
+++ b/plugins/dev/scripts/execution-core/linear-query.mjs
@@ -1399,6 +1399,7 @@ export function runEligibleQuery(
 // "replica-miss" (dead writer, mid-reseed, or a throw).
 export function runTriageStateQuery(query, { replica, onSource, recordRead = recordDaemonRead } = {}) {
   if (!query?.triageStatus) {
+    // Ratified Option A above: no metric because this branch consults neither replica nor API.
     onSource?.("no-triage-status", 0);
     return [];
   }

--- a/plugins/dev/scripts/execution-core/monitor.mjs
+++ b/plugins/dev/scripts/execution-core/monitor.mjs
@@ -124,6 +124,7 @@ import {
   ELIGIBLE_PERSIST_FAILURE_ACTION,
 } from "./reconcile-health-event.mjs";
 import { checkFleetFreeze } from "./fleet-freeze-alert.mjs"; // CTL-1420: fleet-frozen-for-admission alert
+import { recordReplicaRead } from "./replica-health.mjs"; // CAT-35
 
 // DRAG_OUT_STATES — the Linear workflow states that signal "stop work on this
 // ticket". The monitor classifies these as a kill: remove the ticket from the
@@ -1305,6 +1306,7 @@ function triageStateTickets(entry, { replica, runTriageState }) {
         line,
         "triage sweep: Triage-state board unavailable — sweeping the eligible set only (CTL-1589)"
       );
+    recordReplicaRead(query.team, source);
   };
   try {
     const rows = runTriageState(query, { replica, onSource });

--- a/plugins/dev/scripts/execution-core/replica-health-event.mjs
+++ b/plugins/dev/scripts/execution-core/replica-health-event.mjs
@@ -27,6 +27,12 @@ export function buildReplicaHealthEvent({ team, action, source = null, consecuti
       "event.entity": "monitor", "event.action": `replica.${action}`,
       "event.label": team, "catalyst.team": team,
       ...(source ? { "replica.source": source } : {}),
+      // otel-forward's OTLP conversion (lib/destinations/otlp.ts buildOtlpPayload)
+      // forwards ONLY `attributes` + `body.message` — `body.payload` is dropped
+      // off-machine. The degradation streak therefore has to ride an attribute or
+      // it is silently absent from Loki/Grafana, which is where this signal is
+      // actually consumed. Same reason reconcile-health-event mirrors its `reason`.
+      "replica.consecutive_degraded": consecutiveDegraded,
     },
     body: { payload: { team, action, source, consecutiveDegraded } },
   })}\n`;

--- a/plugins/dev/scripts/execution-core/replica-health-event.mjs
+++ b/plugins/dev/scripts/execution-core/replica-health-event.mjs
@@ -1,0 +1,41 @@
+// replica-health-event.mjs — canonical monitor.replica degraded/recovered events (CAT-35).
+import { randomBytes } from "node:crypto";
+import { appendFileSync, mkdirSync } from "node:fs";
+import { dirname } from "node:path";
+import { getEventLogPath, log } from "./config.mjs";
+import { buildCatalystResource } from "./lib/catalyst-resource.mjs";
+
+export const REPLICA_DEGRADED_ACTION = "degraded";
+export const REPLICA_RECOVERED_ACTION = "recovered";
+
+function defaultAppend(line) {
+  const path = getEventLogPath();
+  mkdirSync(dirname(path), { recursive: true });
+  appendFileSync(path, line);
+}
+
+export function buildReplicaHealthEvent({ team, action, source = null, consecutiveDegraded = 0 } = {}) {
+  const ts = new Date().toISOString().replace(/\.\d{3}Z$/, "Z");
+  const degraded = action === REPLICA_DEGRADED_ACTION;
+  return `${JSON.stringify({
+    ts, id: randomBytes(8).toString("hex"), observedTs: ts,
+    severityText: degraded ? "WARN" : "INFO", severityNumber: degraded ? 13 : 9,
+    traceId: randomBytes(16).toString("hex"), spanId: randomBytes(8).toString("hex"),
+    resource: buildCatalystResource({ serviceName: "catalyst.execution-core" }),
+    attributes: {
+      "event.name": `monitor.replica.${action}.${team}`,
+      "event.entity": "monitor", "event.action": `replica.${action}`,
+      "event.label": team, "catalyst.team": team,
+      ...(source ? { "replica.source": source } : {}),
+    },
+    body: { payload: { team, action, source, consecutiveDegraded } },
+  })}\n`;
+}
+
+export function appendReplicaHealthEvent({ append = defaultAppend, ...fields } = {}) {
+  try { append(buildReplicaHealthEvent(fields)); return true; }
+  catch (err) {
+    log.error({ team: fields.team, action: fields.action, err: err.message }, "replica-health-event: append failed");
+    return false;
+  }
+}

--- a/plugins/dev/scripts/execution-core/replica-health.mjs
+++ b/plugins/dev/scripts/execution-core/replica-health.mjs
@@ -1,6 +1,6 @@
 // replica-health.mjs — per-team replica-read health escalation (CAT-35).
 // SIBLING: reconcile-health.mjs — same shape, deliberately not shared (CAT-35).
-import { mkdirSync, renameSync, writeFileSync } from "node:fs";
+import { mkdirSync, readFileSync, renameSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { getReplicaHealthDir, REPLICA_DEGRADED_ALERT_THRESHOLD, log } from "./config.mjs";
 import { appendReplicaHealthEvent as defaultAppendEvent, REPLICA_DEGRADED_ACTION, REPLICA_RECOVERED_ACTION } from "./replica-health-event.mjs";
@@ -8,10 +8,41 @@ import { appendReplicaHealthEvent as defaultAppendEvent, REPLICA_DEGRADED_ACTION
 const DEGRADED_SOURCES = new Set(["no-replica", "replica-miss"]);
 const health = new Map();
 
+function healthPath(team) {
+  return join(getReplicaHealthDir(), `${team}.json`);
+}
+
+function defaultReadMarker(team) {
+  try {
+    const parsed = JSON.parse(readFileSync(healthPath(team), "utf8"));
+    return {
+      consecutiveDegraded:
+        typeof parsed.consecutiveDegraded === "number" ? parsed.consecutiveDegraded : 0,
+      lastHealthyTs: parsed.lastHealthyTs ?? null,
+      alerting: parsed.alerting === true,
+    };
+  } catch {
+    return null;
+  }
+}
+
+function ensureEntry(team, readMarker) {
+  let entry = health.get(team);
+  if (!entry) {
+    entry = readMarker(team) ?? {
+      consecutiveDegraded: 0,
+      lastHealthyTs: null,
+      alerting: false,
+    };
+    health.set(team, entry);
+  }
+  return entry;
+}
+
 function defaultWriteMarker(team, state) {
   const dir = getReplicaHealthDir();
   mkdirSync(dir, { recursive: true });
-  const path = join(dir, `${team}.json`);
+  const path = healthPath(team);
   const tmp = `${path}.tmp`;
   writeFileSync(tmp, `${JSON.stringify({ team, ...state, updatedAt: new Date().toISOString() }, null, 2)}\n`);
   renameSync(tmp, path);
@@ -19,12 +50,12 @@ function defaultWriteMarker(team, state) {
 
 export function recordReplicaRead(team, source, {
   appendEvent = defaultAppendEvent,
+  readMarker = defaultReadMarker,
   writeMarker = defaultWriteMarker,
   threshold = REPLICA_DEGRADED_ALERT_THRESHOLD,
 } = {}) {
   try {
-    const entry = health.get(team) ?? { consecutiveDegraded: 0, lastHealthyTs: null, alerting: false };
-    health.set(team, entry);
+    const entry = ensureEntry(team, readMarker);
     if (DEGRADED_SOURCES.has(source)) {
       entry.consecutiveDegraded += 1;
       if (entry.consecutiveDegraded >= threshold && !entry.alerting) {

--- a/plugins/dev/scripts/execution-core/replica-health.mjs
+++ b/plugins/dev/scripts/execution-core/replica-health.mjs
@@ -64,11 +64,17 @@ export function recordReplicaRead(team, source, {
         if (appended !== false) entry.alerting = true;
       }
     } else if (source === "replica") {
-      const wasAlerting = entry.alerting;
       entry.consecutiveDegraded = 0;
       entry.lastHealthyTs = new Date().toISOString();
-      entry.alerting = false;
-      if (wasAlerting) appendEvent({ team, action: REPLICA_RECOVERED_ACTION, source, consecutiveDegraded: 0 });
+      // Clear the alert latch ONLY after the recovery event actually lands, mirroring
+      // the degraded branch. Clearing first meant a failed append (disk full, EACCES)
+      // permanently swallowed the recovery: the marker persisted alerting:false, so no
+      // later healthy read saw a prior alert to recover from, and consumers stayed
+      // stuck on monitor.replica.degraded.<TEAM> forever.
+      if (entry.alerting) {
+        const appended = appendEvent({ team, action: REPLICA_RECOVERED_ACTION, source, consecutiveDegraded: 0 });
+        if (appended !== false) entry.alerting = false;
+      }
     }
     writeMarker(team, entry);
   } catch (err) {

--- a/plugins/dev/scripts/execution-core/replica-health.mjs
+++ b/plugins/dev/scripts/execution-core/replica-health.mjs
@@ -1,0 +1,47 @@
+// replica-health.mjs — per-team replica-read health escalation (CAT-35).
+// SIBLING: reconcile-health.mjs — same shape, deliberately not shared (CAT-35).
+import { mkdirSync, renameSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { getReplicaHealthDir, REPLICA_DEGRADED_ALERT_THRESHOLD, log } from "./config.mjs";
+import { appendReplicaHealthEvent as defaultAppendEvent, REPLICA_DEGRADED_ACTION, REPLICA_RECOVERED_ACTION } from "./replica-health-event.mjs";
+
+const DEGRADED_SOURCES = new Set(["no-replica", "replica-miss"]);
+const health = new Map();
+
+function defaultWriteMarker(team, state) {
+  const dir = getReplicaHealthDir();
+  mkdirSync(dir, { recursive: true });
+  const path = join(dir, `${team}.json`);
+  const tmp = `${path}.tmp`;
+  writeFileSync(tmp, `${JSON.stringify({ team, ...state, updatedAt: new Date().toISOString() }, null, 2)}\n`);
+  renameSync(tmp, path);
+}
+
+export function recordReplicaRead(team, source, {
+  appendEvent = defaultAppendEvent,
+  writeMarker = defaultWriteMarker,
+  threshold = REPLICA_DEGRADED_ALERT_THRESHOLD,
+} = {}) {
+  try {
+    const entry = health.get(team) ?? { consecutiveDegraded: 0, lastHealthyTs: null, alerting: false };
+    health.set(team, entry);
+    if (DEGRADED_SOURCES.has(source)) {
+      entry.consecutiveDegraded += 1;
+      if (entry.consecutiveDegraded >= threshold && !entry.alerting) {
+        entry.alerting = true;
+        appendEvent({ team, action: REPLICA_DEGRADED_ACTION, source, consecutiveDegraded: entry.consecutiveDegraded });
+      }
+    } else if (source === "replica") {
+      const wasAlerting = entry.alerting;
+      entry.consecutiveDegraded = 0;
+      entry.lastHealthyTs = new Date().toISOString();
+      entry.alerting = false;
+      if (wasAlerting) appendEvent({ team, action: REPLICA_RECOVERED_ACTION, source, consecutiveDegraded: 0 });
+    }
+    writeMarker(team, entry);
+  } catch (err) {
+    log.warn({ team, source, err: err.message }, "replica-health: update failed");
+  }
+}
+
+export function resetReplicaHealth() { health.clear(); }

--- a/plugins/dev/scripts/execution-core/replica-health.mjs
+++ b/plugins/dev/scripts/execution-core/replica-health.mjs
@@ -55,12 +55,13 @@ export function recordReplicaRead(team, source, {
   threshold = REPLICA_DEGRADED_ALERT_THRESHOLD,
 } = {}) {
   try {
+    if (!DEGRADED_SOURCES.has(source) && source !== "replica") return;
     const entry = ensureEntry(team, readMarker);
     if (DEGRADED_SOURCES.has(source)) {
       entry.consecutiveDegraded += 1;
       if (entry.consecutiveDegraded >= threshold && !entry.alerting) {
-        entry.alerting = true;
-        appendEvent({ team, action: REPLICA_DEGRADED_ACTION, source, consecutiveDegraded: entry.consecutiveDegraded });
+        const appended = appendEvent({ team, action: REPLICA_DEGRADED_ACTION, source, consecutiveDegraded: entry.consecutiveDegraded });
+        if (appended !== false) entry.alerting = true;
       }
     } else if (source === "replica") {
       const wasAlerting = entry.alerting;

--- a/plugins/dev/scripts/lib/linear-read-replica.sh
+++ b/plugins/dev/scripts/lib/linear-read-replica.sh
@@ -39,6 +39,12 @@ _CATALYST_LINEAR_READ_REPLICA_SH=1
 # Live-read fallback cap in ms (matches catalyst-linear's runLinearis); default 8s.
 : "${CATALYST_LINEARIS_TIMEOUT_MS:=8000}"
 
+# Portable self-path: BASH_SOURCE under bash, prompt-expansion %x under zsh
+# (CTL-618, same idiom as lib/canonical-event.sh). Resolve once while sourcing;
+# expanding BASH_SOURCE inside the emitters throws under zsh -u (CAT-35).
+__LRR_SELF="${BASH_SOURCE[0]:-${(%):-%x}}"
+__LRR_LIB_DIR="$(cd "$(dirname "$__LRR_SELF")" && pwd)"
+
 # _lrr_emit_fallback_event <ID> <reason> <source> — best-effort: append a WARN
 # `catalyst.replica.read_fallback` event to the unified log so every replica
 # miss/stale fallback is measurable in Loki (otel-forward ships this log; agent
@@ -47,7 +53,7 @@ _CATALYST_LINEAR_READ_REPLICA_SH=1
 # burst this at read-rate × outage-duration).
 _lrr_emit_fallback_event() {
   local id="$1" reason="$2" source="${3:-helper}"
-  local lib; lib="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/canonical-event.sh"
+  local lib="${__LRR_LIB_DIR}/canonical-event.sh"
   [[ -r "$lib" ]] || return 0
   command -v jq >/dev/null 2>&1 || return 0
   # shellcheck disable=SC1090
@@ -81,7 +87,7 @@ _lrr_emit_fallback_event() {
 # (CTL-988: a diagnostic tap with no fallback once froze the fleet 17-37h).
 _lrr_emit_read_event() {
   local id="$1" source="$2" result="$3" age_ms="${4:-}"
-  local lib; lib="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/canonical-event.sh"
+  local lib="${__LRR_LIB_DIR}/canonical-event.sh"
   [[ -r "$lib" ]] || return 0
   command -v jq >/dev/null 2>&1 || return 0
   # shellcheck disable=SC1090

--- a/plugins/dev/scripts/lib/linear-read-replica.sh
+++ b/plugins/dev/scripts/lib/linear-read-replica.sh
@@ -42,6 +42,7 @@ _CATALYST_LINEAR_READ_REPLICA_SH=1
 # Portable self-path: BASH_SOURCE under bash, prompt-expansion %x under zsh
 # (CTL-618, same idiom as lib/canonical-event.sh). Resolve once while sourcing;
 # expanding BASH_SOURCE inside the emitters throws under zsh -u (CAT-35).
+# shellcheck disable=SC2296
 __LRR_SELF="${BASH_SOURCE[0]:-${(%):-%x}}"
 __LRR_LIB_DIR="$(cd "$(dirname "$__LRR_SELF")" && pwd)"
 

--- a/plugins/dev/skills/linearis/SKILL.md
+++ b/plugins/dev/skills/linearis/SKILL.md
@@ -85,6 +85,9 @@ Scripts should use the shared helper instead of re-implementing this: source
 `plugins/dev/scripts/lib/linear-read-replica.sh` and call `linear_read_ticket <ID>` (freshness
 gate → SQL → loud `linearis` fallback).
 
+If that loud fallback persists, treat it as a replica-tier outage; the configuration order and
+health signals are documented in `docs/linear-replica.md`.
+
 ### Querying (discover the schema — don't guess columns)
 
 Run `sqlite3 "$DB" .schema` (or `.schema issues`) to see the live columns. Verified 2026-07-01:


### PR DESCRIPTION
<!-- Auto-generated: 2026-08-08T06:50:00Z -->
<!-- Last updated: 2026-08-08T06:50:00Z -->
<!-- PR: #3144 -->
<!-- Previous commits: bea99b747ab297a55a6afa425b612e2a6aa2e8cb,c78ecac374433907f7b9b64174724a1eb0f8d2e5,007f1da5c3097c4e3a2b5fbfcdbb15a73bba1639,9b131bbaf96e6f386deef41be6b7ba2bc7430bd1,b3f62278e79435e0ee259d577af5e622effdb1d9,3d2bd1d1fb4ba6e9cb5f01cbf186c74561f16481,0dc993eb3f62fc9ef9b99e410a61bf55e8b3e0e4,c7ee8ebaf1b3af3f66790a0c7cc66bedd68fe441 -->

## Summary

Adds durable monitoring for degraded Linear replica reads. Replica fallback and recovery transitions now produce structured Catalyst events, persist per-team health state across restarts, and surface an inert or degraded replica tier through `catalyst doctor`.

## Changes Made

- Make replica fallback event emission safe when the helper is sourced under both Bash and zsh.
- Track consecutive degraded reads per Linear team, latch alert state, and emit recovery events after service returns.
- Add structured replica-health event envelopes and monitor integration.
- Extend doctor output to report replica tier configuration and operational state.
- Document the replica health signals and their operational meaning.
- Add focused shell and Bun coverage, including CI wiring for the event-envelope suite.
- Apply review remediations that isolate test event output from the operator's live event log.

## How to Verify It

- [x] Replica health, query-source, doctor, config, broker parity, and event-envelope Bun tests pass.
- [x] `linear-read-replica.test.sh` passes under the shell test suite.
- [x] Modified shell helper passes shellcheck.
- [x] Modified workflow passes actionlint.
- [x] Security and reward-hacking checks pass.
- [x] Review completed; high-severity findings were remediated and remaining findings were captured in a follow-up ticket.

## Reviewer Notes

The verification phase rated regression risk 2/10. A pre-existing, non-CI-gated `monitor.test.mjs` cursor assertion also fails on `origin/main` and is not caused by this branch.

## Related Issues/PRs

- Fixes https://linear.app/coalesce/issue/CAT-35

## Changelog Entry

Linear replica degradation and recovery are now observable through durable health state, structured events, documentation, and doctor diagnostics.
