### PR TITLE
feat(dev): CTL-1679 — recovery pass retries safe/retryable failures by default

### DIFF
--- a/plugins/dev/scripts/__tests__/phase-agent-emit-complete.test.sh
+++ b/plugins/dev/scripts/__tests__/phase-agent-emit-complete.test.sh
@@ -780,6 +780,41 @@ else
 	assert_eq "boom" "$P_REASON" "malformed payload: base failure_reason preserved"
 fi
 
+# CTL-1679 Phase 2: --payload-json retry_safe rides into BOTH the event payload
+# AND the phase-<P>.json signal (as retrySafe). Absent --payload-json → no
+# retrySafe key (back-compat).
+echo ""
+echo "Test 49 (CTL-1679): --payload-json retry_safe → event payload + signal.retrySafe"
+fresh_env t49
+SIGNAL="${CATALYST_ORCHESTRATOR_DIR}/workers/CTL-100/phase-pr.json"
+echo '{"status":"running","ticket":"CTL-100","phase":"pr","generation":3}' >"$SIGNAL"
+"$EMIT_SCRIPT" --phase pr --ticket CTL-100 --status failed \
+	--reason "cluster_fence_stale" --payload-json '{"retry_safe":true}' >/dev/null 2>&1
+LINE=$(read_event_line)
+if [[ -z $LINE ]]; then
+	fail "Test 49: no event line emitted"
+else
+	P_RETRY=$(echo "$LINE" | jq -r '.body.payload.retry_safe')
+	P_REASON=$(echo "$LINE" | jq -r '.body.payload.failure_reason')
+	assert_eq "true" "$P_RETRY" "event body.payload.retry_safe = true"
+	assert_eq "cluster_fence_stale" "$P_REASON" "event failure_reason still carried"
+fi
+SIG_RETRY=$(jq -r '.retrySafe' "$SIGNAL")
+SIG_REASON=$(jq -r '.failureReason' "$SIGNAL")
+SIG_GEN=$(jq -r '.generation' "$SIGNAL")
+assert_eq "true" "$SIG_RETRY" "signal.retrySafe = true"
+assert_eq "cluster_fence_stale" "$SIG_REASON" "signal.failureReason preserved"
+assert_eq "3" "$SIG_GEN" "signal.generation preserved"
+
+echo ""
+echo "Test 50 (CTL-1679): absent --payload-json → no retrySafe key on signal (back-compat)"
+fresh_env t50
+SIGNAL="${CATALYST_ORCHESTRATOR_DIR}/workers/CTL-100/phase-pr.json"
+echo '{"status":"running","ticket":"CTL-100","phase":"pr"}' >"$SIGNAL"
+"$EMIT_SCRIPT" --phase pr --ticket CTL-100 --status failed --reason "some_other_reason" >/dev/null 2>&1
+HAS_RETRY=$(jq -r 'has("retrySafe")' "$SIGNAL")
+assert_eq "false" "$HAS_RETRY" "no --payload-json → signal has no retrySafe key"
+
 echo ""
 echo "─────────────────────────────────────────────"
 echo "phase-agent-emit-complete: ${PASSES} passed, ${FAILURES} failed"

--- a/plugins/dev/scripts/execution-core/__tests__/fence-stale-redispatch-seam.test.mjs
+++ b/plugins/dev/scripts/execution-core/__tests__/fence-stale-redispatch-seam.test.mjs
@@ -1,0 +1,159 @@
+// fence-stale-redispatch-seam.test.mjs — CTL-1679 Phase 1.
+//
+// Hermetic tests for defaultInvokeSeam(ticket, "fence-stale-redispatch", ...).
+// The seam re-arms a cluster_fence_stale-failed phase for a fresh-generation
+// re-dispatch: delete the stale claim tombstone, reset the phase signal to
+// pending (dropping failureReason, preserving every other field), clear the
+// dispatch cooldown, and spawn a synthetic emit-complete wake. The emit binary
+// is injected (deps.spawnSyncFn) so no real dispatch fires.
+//
+// Run: cd plugins/dev/scripts/execution-core && bun test __tests__/fence-stale-redispatch-seam.test.mjs
+
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { defaultInvokeSeam } from "../recovery-reasoning.mjs";
+import {
+  mkdtempSync,
+  rmSync,
+  existsSync,
+  readFileSync,
+  mkdirSync,
+  writeFileSync,
+} from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+describe("CTL-1679 fence-stale-redispatch seam", () => {
+  let orchDir;
+  let calls;
+  // A hermetic spawnSync stub that records its invocation and returns success.
+  const spawnStub = (...args) => {
+    calls.push(args);
+    return { status: 0, stdout: "", stderr: "" };
+  };
+
+  function signalPath(ticket, phase) {
+    return join(orchDir, "workers", ticket, `phase-${phase}.json`);
+  }
+  function claimPath(ticket, phase, gen) {
+    return join(orchDir, "workers", ticket, `phase-${phase}.claim.${gen}`);
+  }
+  function cooldownPath(ticket, phase) {
+    return join(orchDir, ".dispatch-cooldowns", `${ticket}-${phase}.json`);
+  }
+  function writeSignal(ticket, phase, obj) {
+    const p = signalPath(ticket, phase);
+    mkdirSync(join(orchDir, "workers", ticket), { recursive: true });
+    writeFileSync(p, JSON.stringify(obj));
+  }
+
+  beforeEach(() => {
+    orchDir = mkdtempSync(join(tmpdir(), "fence-stale-seam-"));
+    calls = [];
+  });
+  afterEach(() => {
+    rmSync(orchDir, { recursive: true, force: true });
+  });
+
+  test("happy path: resets signal to pending, deletes tombstone, clears cooldown, wakes", () => {
+    const ticket = "CTL-1";
+    const phase = "pr";
+    writeSignal(ticket, phase, {
+      status: "failed",
+      failureReason: "cluster_fence_stale",
+      generation: 3,
+      worktreePath: "/tmp/wt/CTL-1",
+      attempt: 2,
+      ticket,
+      phase,
+    });
+    // Stale claim tombstone at the signal's generation.
+    writeFileSync(claimPath(ticket, phase, 3), "");
+    // Dispatch cooldown marker that must be cleared.
+    mkdirSync(join(orchDir, ".dispatch-cooldowns"), { recursive: true });
+    writeFileSync(cooldownPath(ticket, phase), JSON.stringify({ failedAt: Date.now() }));
+
+    const res = defaultInvokeSeam(
+      ticket,
+      "fence-stale-redispatch",
+      { reason: "stale fence" },
+      { orchDir, phase, spawnSyncFn: spawnStub },
+    );
+
+    expect(res.success).toBe(true);
+    // Tombstone deleted.
+    expect(existsSync(claimPath(ticket, phase, 3))).toBe(false);
+    // Cooldown marker cleared.
+    expect(existsSync(cooldownPath(ticket, phase))).toBe(false);
+    // Signal reset to pending, failureReason removed, other fields preserved.
+    const sig = JSON.parse(readFileSync(signalPath(ticket, phase), "utf8"));
+    expect(sig.status).toBe("pending");
+    expect(sig.failureReason).toBeUndefined();
+    expect(sig.generation).toBe(3);
+    expect(sig.worktreePath).toBe("/tmp/wt/CTL-1");
+    expect(sig.attempt).toBe(2);
+    // Synthetic wake spawned exactly once with --no-signal-update.
+    expect(calls.length).toBe(1);
+    const argv = calls[0][1];
+    expect(argv).toContain("--no-signal-update");
+    expect(argv).toContain("--ticket");
+    expect(argv).toContain(ticket);
+    expect(argv).toContain("--status");
+    expect(argv).toContain("complete");
+  });
+
+  test("idempotency: running twice does not throw and leaves the signal pending", () => {
+    const ticket = "CTL-2";
+    const phase = "implement";
+    writeSignal(ticket, phase, {
+      status: "failed",
+      failureReason: "cluster_fence_stale",
+      generation: 1,
+      ticket,
+      phase,
+    });
+    const first = defaultInvokeSeam(
+      ticket,
+      "fence-stale-redispatch",
+      {},
+      { orchDir, phase, spawnSyncFn: spawnStub },
+    );
+    expect(first.success).toBe(true);
+    const second = defaultInvokeSeam(
+      ticket,
+      "fence-stale-redispatch",
+      {},
+      { orchDir, phase, spawnSyncFn: spawnStub },
+    );
+    expect(second.success).toBe(true);
+    const sig = JSON.parse(readFileSync(signalPath(ticket, phase), "utf8"));
+    expect(sig.status).toBe("pending");
+    expect(sig.failureReason).toBeUndefined();
+  });
+
+  test("missing signal: returns a structured failure, does not throw", () => {
+    const ticket = "CTL-3";
+    const phase = "pr";
+    // No signal file written.
+    const res = defaultInvokeSeam(
+      ticket,
+      "fence-stale-redispatch",
+      {},
+      { orchDir, phase, spawnSyncFn: spawnStub },
+    );
+    expect(res.success).toBe(false);
+    expect(typeof res.reason).toBe("string");
+    // No wake spawned when there is nothing to re-arm.
+    expect(calls.length).toBe(0);
+  });
+
+  test("no orchDir: returns a structured failure", () => {
+    const res = defaultInvokeSeam(
+      "CTL-4",
+      "fence-stale-redispatch",
+      {},
+      { orchDir: null, phase: "pr", spawnSyncFn: spawnStub },
+    );
+    expect(res.success).toBe(false);
+    expect(typeof res.reason).toBe("string");
+  });
+});

--- a/plugins/dev/scripts/execution-core/__tests__/fence-stale-redispatch-seam.test.mjs
+++ b/plugins/dev/scripts/execution-core/__tests__/fence-stale-redispatch-seam.test.mjs
@@ -60,6 +60,7 @@ describe("CTL-1679 fence-stale-redispatch seam", () => {
     writeSignal(ticket, phase, {
       status: "failed",
       failureReason: "cluster_fence_stale",
+      retrySafe: true,
       generation: 3,
       worktreePath: "/tmp/wt/CTL-1",
       attempt: 2,
@@ -88,6 +89,8 @@ describe("CTL-1679 fence-stale-redispatch seam", () => {
     const sig = JSON.parse(readFileSync(signalPath(ticket, phase), "utf8"));
     expect(sig.status).toBe("pending");
     expect(sig.failureReason).toBeUndefined();
+    // retrySafe is cleared so a later unrelated failure doesn't inherit it.
+    expect(sig.retrySafe).toBeUndefined();
     expect(sig.generation).toBe(3);
     expect(sig.worktreePath).toBe("/tmp/wt/CTL-1");
     expect(sig.attempt).toBe(2);

--- a/plugins/dev/scripts/execution-core/recovery-evidence.test.mjs
+++ b/plugins/dev/scripts/execution-core/recovery-evidence.test.mjs
@@ -156,3 +156,24 @@ describe("buildRecoveryItems — signalPath threading (CTL-1680)", () => {
     expect(items[0].evidence.signalPath).toBe("/orch/workers/CTL-3/phase-pr.json");
   });
 });
+
+// CTL-1679 Phase 2: surface the signal's retrySafe flag on the evidence so the
+// Phase-3 generic retry rule can read evidence.retrySafe. The fence guard stamps
+// retry_safe → phase-agent-emit-complete writes signal.retrySafe → here it rides
+// onto evidence.retrySafe.
+describe("buildRecoveryItems — retrySafe threading (CTL-1679)", () => {
+  const sig = (ticket, raw = {}) => ({ ticket, phase: raw.phase ?? "pr", raw });
+
+  test("surfaces signal.retrySafe onto evidence.retrySafe when present", () => {
+    const items = buildRecoveryItems(
+      [sig("CTL-4", { retrySafe: true, failureReason: "cluster_fence_stale" })],
+      {},
+    );
+    expect(items[0].evidence.retrySafe).toBe(true);
+  });
+
+  test("evidence.retrySafe is undefined when the signal omits it", () => {
+    const items = buildRecoveryItems([sig("CTL-5", { failureReason: "other" })], {});
+    expect(items[0].evidence.retrySafe).toBeUndefined();
+  });
+});

--- a/plugins/dev/scripts/execution-core/recovery-reasoning.mjs
+++ b/plugins/dev/scripts/execution-core/recovery-reasoning.mjs
@@ -187,11 +187,30 @@ export function reasoningRecoveryPass(items, opts = {}) {
     terminalSkipped: [],
   };
 
+  // CTL-1679 Phase 3: per-ticket skip breadcrumb. A reason-bearing failure that is
+  // skipped (cooldown / escalated-latch) previously emitted ONLY the coarse
+  // recovery.tick roster — the specific reason that keeps getting skipped was not
+  // per-ticket queryable, so a coverage gap (e.g. an unrecognized retry-safe reason
+  // latched to a human) was invisible in Loki. Emit recovery.skipped.<sanitized
+  // reason> so `count by (reason)` over the JSONL log surfaces every gap.
+  // recovery.* is deliberately UNPROTECTED — no namespace registration needed.
+  const emitSkipBreadcrumb = (item) => {
+    const reason =
+      item.evidence?.failureReason ?? item.evidence?.signal?.failureReason ?? null;
+    if (!reason) return; // only reason-bearing skips are queryable gaps
+    emitEvent({
+      type: `recovery.skipped.${sanitizeReasonForEvent(reason)}`,
+      ticket: item.ticket,
+      reason,
+    });
+  };
+
   for (const item of items) {
     // Check cooldown / already-escalated
     if (shouldSkipItem(item.ticket)) {
       log(`recovery-reasoning: ${item.ticket} skipped (cooldown/escalated)`);
       tickStats.ledgerSkipped.push(item.ticket);
+      emitSkipBreadcrumb(item);
       continue;
     }
 
@@ -236,9 +255,15 @@ export function reasoningRecoveryPass(items, opts = {}) {
     }
 
     // PROPOSE: classify per CTL-828
+    // CTL-1679 Phase 3: thread the ticket id + intent-budget reader so the
+    // retry-safe rules can bound their retries against the shared ledger.
     let classification;
     try {
-      classification = classifyTicket(evidence, { log });
+      classification = classifyTicket(evidence, {
+        log,
+        ticket: item.ticket,
+        readIntentAttempts,
+      });
     } catch (err) {
       log(`recovery-reasoning: ${item.ticket} classification error: ${err.message}`);
       tickStats.actions.errors += 1;
@@ -345,6 +370,19 @@ export function reasoningRecoveryPass(items, opts = {}) {
           details,
         });
         actionLog.push("emitted recovery.would-fix");
+        // CTL-1679 Phase 3: a retry-safe redispatch is a bounded RETRY, not an
+        // open-ended fix — emit the recovery.would-retry twin so the shadow-rollout
+        // LogQL can distinguish "would have retried" from other would-fixes.
+        // recovery.* is deliberately UNPROTECTED — no namespace registration needed.
+        if (fix_class === "retry_safe_redispatch" || fix_class === "fence_stale_redispatch") {
+          emitEvent({
+            type: "recovery.would-retry",
+            ticket: item.ticket,
+            fix_class,
+            reason: details?.reason ?? null,
+          });
+          actionLog.push("emitted recovery.would-retry");
+        }
       } else if (decision === "escalate") {
         emitEvent({
           type: "recovery.would-escalate",
@@ -805,11 +843,82 @@ function _prNotMergedReasonText(probe) {
   return `PR #${probe.prNumber} not merged — ${parts.join("; ")}`;
 }
 
+// CTL-1679 Phase 3: the shared bounded-retry budget decision for a retry-safe
+// failure. Consults the recovery-intent ledger (attempts auto-increment; the same
+// RECOVERY_MAX_ATTEMPTS budget the fix/escalate cooldown ledger already uses) so
+// NO retry-safe reason — the deterministic cluster_fence_stale OR a generic
+// unrecognized-but-safe failure — can loop unboundedly:
+//   attempts < MAX → { retry: true }  (redispatch via the fence-stale seam)
+//   attempts ≥ MAX → { retry: false } (escalate with a reason-named coverage-gap
+//                     explanation carrying the attempts history)
+// Pure over the injected reader; readIntentAttempts defaults to the on-disk ledger
+// reader (orchDir from env) but is injectable for hermetic tests.
+export function retrySafeBudgetDecision(ticket, { readIntentAttempts = defaultReadIntentAttempts } = {}) {
+  let attempts = 0;
+  try {
+    attempts = readIntentAttempts(ticket) ?? 0;
+  } catch {
+    attempts = 0; // fail-open: an unreadable ledger means "never retried" → allow
+  }
+  return { retry: attempts < RECOVERY_MAX_ATTEMPTS, attempts };
+}
+
+// CTL-1679 Phase 3: build the reason-named coverage-gap escalation for a
+// retry-safe failure whose retry budget is exhausted. Reuses the buildEscalationPayload
+// tagged-union shape (escalation_type + problem/call_to_action) so the existing
+// escalate path writes it verbatim, and names the reason so the operator inbox
+// renders a real "unrecognized retry-safe failure <reason>" card instead of a bare label.
+export function buildRetrySafeExhaustionExplanation(ticket, reason, attempts) {
+  return {
+    escalation_type: "coverage_gap",
+    problem:
+      `${ticket}: the retry-safe failure "${reason}" exhausted its ${RECOVERY_MAX_ATTEMPTS}-attempt ` +
+      `bounded-retry budget (${attempts} attempts) without resolving — it is an unrecognized ` +
+      `coverage gap (no deterministic seam or bounded-LLM rule matches this reason).`,
+    call_to_action:
+      `Investigate why re-dispatching ${ticket} did not clear "${reason}"; if this reason is ` +
+      `mechanically recoverable, add a classifier rule for it, otherwise resolve the ticket by hand.`,
+    blocked_capability:
+      `automatic recovery of the retry-safe failure "${reason}" — it survived the bounded retry budget`,
+    instructions: [
+      `Read ${ticket}'s worker evidence (claude logs + the failed phase signal)`,
+      `Decide whether "${reason}" needs a new classifier rule or a hand fix`,
+    ],
+    attempts: [{ reason, count: attempts, budget: RECOVERY_MAX_ATTEMPTS }],
+    why_not_auto:
+      `the retry-safe redispatch was attempted ${attempts} time(s) and did not resolve "${reason}", ` +
+      `so further automatic retries would loop without progress`,
+    timestamp: new Date().toISOString(),
+  };
+}
+
+// CTL-1679 Phase 3: sanitize an arbitrary failure reason into a safe event-name
+// suffix for the per-ticket recovery.skipped.<reason> breadcrumb (dots break the
+// phase-event name parser; keep it to a bounded [a-z0-9_-] slug).
+export function sanitizeReasonForEvent(reason) {
+  if (typeof reason !== "string" || reason === "") return "unknown";
+  return reason
+    .toLowerCase()
+    .replace(/[^a-z0-9_-]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 64) || "unknown";
+}
+
 export function defaultClassifyTicket(evidence, opts = {}) {
-  const { log = defaultLogFn, probePrBlock } = opts;
+  const {
+    log = defaultLogFn,
+    probePrBlock,
+    // CTL-1679 Phase 3: the intent-budget reader + the ticket id, threaded from
+    // reasoningRecoveryPass so the retry-safe rules can bound their retries.
+    // Default to the on-disk ledger reader (orchDir from env); a bare classifier
+    // call (no ticket) reads attempts=0 → the retry path stays available.
+    readIntentAttempts = defaultReadIntentAttempts,
+    ticket: optTicket,
+  } = opts;
 
   // Extract evidence fields
   const { logsOutput, jobState, signal, beliefState, failureReason } = evidence;
+  const ticket = optTicket ?? evidence.ticket ?? signal?.ticket ?? null;
 
   // CTL-1496 / CTL-1680: route to the live PR-state probe for any "merge not confirmed" failure.
   // Covers teardown's literal "pr_not_merged" (CTL-1496) AND phase-monitor-deploy's bespoke
@@ -826,6 +935,30 @@ export function defaultClassifyTicket(evidence, opts = {}) {
   // to derive the failed phase for the fence-stale-redispatch seam.
   const deterministic = checkDeterministicErrors(logsOutput, effectiveFailureReason, signal);
   if (deterministic) {
+    // CTL-1679 Phase 3: the cluster_fence_stale deterministic redispatch is
+    // retry-safe but must NOT loop forever on an infinitely-stale fence — gate it
+    // on the shared retry budget. Within budget → fix; exhausted → escalate with a
+    // reason-named coverage-gap explanation. Other deterministic seams (orphan,
+    // workflow-token) are unbounded as before.
+    if (deterministic.fix_class === "fence_stale_redispatch") {
+      const budget = retrySafeBudgetDecision(ticket, { readIntentAttempts });
+      if (!budget.retry) {
+        return {
+          decision: "escalate",
+          fix_class: "human",
+          details: {
+            reason:
+              `cluster_fence_stale: retry budget exhausted (${budget.attempts}/${RECOVERY_MAX_ATTEMPTS}) ` +
+              `— a repeatedly-stale fence needs a human`,
+            explanation: buildRetrySafeExhaustionExplanation(
+              ticket,
+              "cluster_fence_stale",
+              budget.attempts,
+            ),
+          },
+        };
+      }
+    }
     return {
       decision: "fix",
       fix_class: deterministic.fix_class,
@@ -846,6 +979,41 @@ export function defaultClassifyTicket(evidence, opts = {}) {
       details: {
         reason: boundedLlm.reason,
         brief: boundedLlm.brief,
+      },
+    };
+  }
+
+  // CTL-1679 Phase 3: generalized bounded-retry for UNRECOGNIZED-but-retry-safe
+  // failures. Reached only when no Rule-1/Rule-2 handler matched. When the signal
+  // carries retrySafe:true (the fence guard stamps it; any future retry-safe reason
+  // can too), consult the shared budget: within budget → redispatch via the generic
+  // fence-stale-redispatch seam (it is the reason-neutral "reset to pending +
+  // re-dispatch" actuator); exhausted → escalate naming the reason as an
+  // unrecognized coverage gap. An unrecognized UNSAFE failure (no retrySafe) skips
+  // this rule entirely and falls through to Rule 3's immediate escalate (unchanged).
+  if (evidence.retrySafe === true) {
+    const reason = effectiveFailureReason ?? "unrecognized-retry-safe";
+    const phase = signal?.phase;
+    const budget = retrySafeBudgetDecision(ticket, { readIntentAttempts });
+    if (budget.retry) {
+      return {
+        decision: "fix",
+        fix_class: "retry_safe_redispatch",
+        details: {
+          reason: `retry-safe failure "${reason}" (attempt ${budget.attempts + 1}/${RECOVERY_MAX_ATTEMPTS}); re-dispatching`,
+          seam_id: "fence-stale-redispatch",
+          ...(phase !== undefined ? { phase } : {}),
+        },
+      };
+    }
+    return {
+      decision: "escalate",
+      fix_class: "human",
+      details: {
+        reason:
+          `unrecognized retry-safe failure "${reason}": retry budget exhausted ` +
+          `(${budget.attempts}/${RECOVERY_MAX_ATTEMPTS})`,
+        explanation: buildRetrySafeExhaustionExplanation(ticket, reason, budget.attempts),
       },
     };
   }

--- a/plugins/dev/scripts/execution-core/recovery-reasoning.mjs
+++ b/plugins/dev/scripts/execution-core/recovery-reasoning.mjs
@@ -1902,9 +1902,16 @@ export function defaultInvokeSeam(ticket, seamId, brief = {}, deps = {}) {
           /* best-effort — a leftover tombstone is the very thing we're clearing */
         }
       }
-      // (2) reset signal → pending, drop failureReason, preserve all other fields.
+      // (2) reset signal → pending, drop failureReason AND retrySafe, preserve all
+      // other fields. Clearing retrySafe is load-bearing: a re-dispatched phase that
+      // later fails for a DIFFERENT, unrecognized-and-UNSAFE reason (emitted without
+      // --payload-json, so it stamps no retry_safe) must NOT inherit this run's stale
+      // retrySafe:true — that would misroute it into the bounded-retry rule instead of
+      // an immediate escalate (Codex finding). The next genuine fence-stale bow-out
+      // re-stamps it fresh via emit-complete's --payload-json.
       sig.status = "pending";
       delete sig.failureReason;
+      delete sig.retrySafe;
       const tmp = `${signalPath}.tmp.${process.pid}`;
       writeFileSync(tmp, JSON.stringify(sig, null, 2));
       renameSync(tmp, signalPath);

--- a/plugins/dev/scripts/execution-core/recovery-reasoning.mjs
+++ b/plugins/dev/scripts/execution-core/recovery-reasoning.mjs
@@ -34,6 +34,7 @@ import {
   existsSync,
   renameSync,
   unlinkSync,
+  rmSync,
 } from "node:fs";
 import { dirname, join } from "node:path";
 // CTL-1568: read-only predicate — is the belief engine the needs-human owner?
@@ -819,8 +820,11 @@ export function defaultClassifyTicket(evidence, opts = {}) {
     return classifyPrNotMerged(evidence, { probePrBlock: probePrBlock ?? defaultProbePrBlock, log });
   }
 
-  // Rule 1: Check for deterministic errors in logs
-  const deterministic = checkDeterministicErrors(logsOutput, failureReason);
+  // Rule 1: Check for deterministic errors in logs.
+  // CTL-1679: pass the EFFECTIVE failure reason (top-level or signal-borne) plus
+  // the signal itself, so the cluster_fence_stale shortcut can read signal.phase
+  // to derive the failed phase for the fence-stale-redispatch seam.
+  const deterministic = checkDeterministicErrors(logsOutput, effectiveFailureReason, signal);
   if (deterministic) {
     return {
       decision: "fix",
@@ -828,6 +832,7 @@ export function defaultClassifyTicket(evidence, opts = {}) {
       details: {
         reason: deterministic.reason,
         seam_id: deterministic.seam_id,
+        ...(deterministic.phase !== undefined ? { phase: deterministic.phase } : {}),
       },
     };
   }
@@ -870,7 +875,22 @@ export function defaultClassifyTicket(evidence, opts = {}) {
 }
 
 // Check for deterministic errors that have registered seams
-export function checkDeterministicErrors(logsOutput, failureReason) {
+export function checkDeterministicErrors(logsOutput, failureReason, signal = null) {
+  // CTL-1679: cluster_fence_stale is provably retry-safe — cluster-fence-guard.sh
+  // emits it BEFORE any guarded side-effect and exit-10s, and a fresh dispatch
+  // bumps the cluster generation so the next fence-check passes. So it is a
+  // deterministic FIX (re-dispatch the failed phase at generation N+1), NOT a
+  // human escalate. Routed to the fence-stale-redispatch seam; the failed phase
+  // rides in details.phase (read from the signal) so the seam knows which
+  // phase-<P>.json to re-arm. Checked first — it needs no log scan.
+  if (failureReason === "cluster_fence_stale") {
+    return {
+      fix_class: "fence_stale_redispatch",
+      seam_id: "fence-stale-redispatch",
+      reason: "Cluster fence stale (side-effect not taken); re-dispatch the failed phase at a fresh generation",
+      phase: signal?.phase,
+    };
+  }
   // Check failureReason shortcuts first (no log scan needed)
   if (failureReason === "orphan-sweep-stale") {
     return {
@@ -1177,7 +1197,15 @@ function attemptFix(item, classification, { invokeSeam, invokeRecoveryPass, evid
       const seamResult = invokeSeam(
         ticket,
         details.seam_id,
-        { reason: details.reason, fix_class },
+        {
+          reason: details.reason,
+          fix_class,
+          // CTL-1679: the fence-stale-redispatch seam needs the failed phase to
+          // know which phase-<P>.json to re-arm. The classifier stamped it on
+          // details.phase; thread it through the brief so defaultInvokeSeam reads
+          // it (it prefers deps.phase for test injection, else brief.phase).
+          ...(details.phase !== undefined ? { phase: details.phase } : {}),
+        },
         {
           candidate: {
             ticket,
@@ -1643,7 +1671,107 @@ const SEAM_ID_TO_CATEGORY = {
   "orphan-reconcile": "orphan-stale",
 };
 
+// CTL-1679: derive the phase whose synthetic `complete` wakes the scheduler to
+// re-dispatch `phase` (its immediate predecessor in the pipeline). Mirrors the
+// workflow-token-redispatch template, which emits `review` (prev of `pr`) to
+// re-arm `pr`. PHASES is loaded lazily via requireSync to avoid a static cycle
+// (phase-fsm re-exports the workflow descriptor's ordered phase list). Fail-safe:
+// if the phase is the first / unknown, fall back to the phase itself (an
+// idempotent wake — deriveAdvancement still re-derives `pending` as next).
+export function fenceStalePrevPhase(phase) {
+  try {
+    const { PHASES } = requireSync("../lib/phase-fsm.mjs");
+    const idx = Array.isArray(PHASES) ? PHASES.indexOf(phase) : -1;
+    if (idx > 0) return PHASES[idx - 1];
+  } catch {
+    /* descriptor unavailable → fall back to the phase itself */
+  }
+  return phase;
+}
+
 export function defaultInvokeSeam(ticket, seamId, brief = {}, deps = {}) {
+  // CTL-1679: fence-stale-redispatch — re-arm the phase that bowed out on a stale
+  // cluster fence (cluster_fence_stale) for a fresh-generation re-dispatch. It is
+  // the workflow-token-redispatch template plus two extra steps the fence case
+  // needs (research Addendum): (1) delete the stale claim tombstone
+  // workers/<T>/phase-<P>.claim.<N> — a leftover collides on the next O_EXCL claim
+  // create → "claim-lost" silent stall (mirrors scheduler.mjs maybeResetForRemediateCycle);
+  // (2) clear the dispatch cooldown so a 30-min window / armed circuit breaker
+  // doesn't suppress the redispatch. `spawnSyncFn` is injectable for hermetic tests.
+  if (seamId === "fence-stale-redispatch") {
+    const orchDir = deps.orchDir ?? resolveOrchDir();
+    if (!orchDir) {
+      return { success: false, reason: "no orchDir for fence-stale re-dispatch", details: {} };
+    }
+    const spawnSyncFn = deps.spawnSyncFn ?? spawnSync;
+    // Production threads the failed phase through the brief (attemptFix sets
+    // brief.phase from classification details.phase); tests inject deps.phase.
+    const phase = deps.phase ?? brief?.phase;
+    if (!phase) {
+      return { success: false, reason: "no phase for fence-stale re-dispatch", details: {} };
+    }
+    const signalPath = join(orchDir, "workers", ticket, `phase-${phase}.json`);
+    if (!existsSync(signalPath)) {
+      return {
+        success: false,
+        reason: `fence-stale re-dispatch: signal file absent (${signalPath})`,
+        details: { phase, signalPath },
+      };
+    }
+    try {
+      let sig = {};
+      try {
+        sig = JSON.parse(readFileSync(signalPath, "utf8"));
+      } catch {
+        sig = {};
+      }
+      // (1) delete the stale claim tombstone at the signal's generation.
+      const gen = sig.generation;
+      if (gen !== undefined && gen !== null) {
+        try {
+          rmSync(join(orchDir, "workers", ticket, `phase-${phase}.claim.${gen}`), { force: true });
+        } catch {
+          /* best-effort — a leftover tombstone is the very thing we're clearing */
+        }
+      }
+      // (2) reset signal → pending, drop failureReason, preserve all other fields.
+      sig.status = "pending";
+      delete sig.failureReason;
+      const tmp = `${signalPath}.tmp.${process.pid}`;
+      writeFileSync(tmp, JSON.stringify(sig, null, 2));
+      renameSync(tmp, signalPath);
+      // (3) clear the dispatch cooldown marker (inline — importing scheduler.mjs
+      // here would be a cycle; the marker lives at .dispatch-cooldowns/<T>-<P>.json).
+      try {
+        rmSync(join(orchDir, ".dispatch-cooldowns", `${ticket}-${phase}.json`), { force: true });
+      } catch {
+        /* best-effort — a stale marker just suppresses one re-dispatch */
+      }
+      // (4) synthetic wake: emit prev-phase complete so deriveAdvancement re-derives
+      // <phase> as next and re-dispatches it. --no-signal-update: we own the reset.
+      const wakePhase = fenceStalePrevPhase(phase);
+      const res = spawnSyncFn(
+        EMIT_COMPLETE_BIN,
+        [
+          "--phase", wakePhase,
+          "--ticket", ticket,
+          "--status", "complete",
+          "--no-signal-update",
+          "--orch-dir", orchDir,
+          "--orch-id", ticket,
+        ],
+        { encoding: "utf8" },
+      );
+      return {
+        success: res.status === 0 || res.status == null,
+        reason: "re-armed fence-stale phase (reset failed→pending) and woke the scheduler",
+        details: { phase, wakePhase, signalPath, wakeStatus: res.status ?? null, seam_id: seamId },
+      };
+    } catch (err) {
+      return { success: false, reason: err.message, details: { error: err.message } };
+    }
+  }
+
   // CTL-1186 / CTL-1219: the two workflow-token classifications re-arm phase-pr
   // (reset its failed signal → pending) then wake the scheduler. Fully
   // synchronous — the file ops + emit are synchronous spawnSync underneath.

--- a/plugins/dev/scripts/execution-core/recovery-reasoning.test.mjs
+++ b/plugins/dev/scripts/execution-core/recovery-reasoning.test.mjs
@@ -681,10 +681,20 @@ describe("reasoningRecoveryPass", () => {
     },
   };
 
+  // Hermetic injections shared by the CTL-1679 reasoningRecoveryPass tests: the
+  // default shouldSkipItem/readIntentAttempts read the LIVE host ledger under
+  // ~/catalyst/execution-core/.recovery-intents/ (a real CTL-9.json on a worker
+  // host would skip the item / exhaust the budget), so pin them here.
+  const hermeticRecovery = {
+    shouldSkipItem: () => false,
+    readIntentAttempts: () => 0,
+  };
+
   test("CTL-1679: cluster_fence_stale in SHADOW → would-fix, no seam", () => {
     const events = [];
     let seamCalls = 0;
     const result = reasoningRecoveryPass([fenceStaleItem], {
+      ...hermeticRecovery,
       mode: "shadow",
       invokeSeam: () => {
         seamCalls += 1;
@@ -703,6 +713,7 @@ describe("reasoningRecoveryPass", () => {
     const events = [];
     const seamCalls = [];
     reasoningRecoveryPass([fenceStaleItem], {
+      ...hermeticRecovery,
       mode: "enforce",
       invokeSeam: (ticket, seamId, brief) => {
         seamCalls.push({ ticket, seamId, brief });
@@ -721,6 +732,7 @@ describe("reasoningRecoveryPass", () => {
   test("CTL-1679: cluster_fence_stale ENFORCE seam failure → recovery.fix-failed", () => {
     const events = [];
     reasoningRecoveryPass([fenceStaleItem], {
+      ...hermeticRecovery,
       mode: "enforce",
       invokeSeam: () => ({ success: false, reason: "signal absent", details: {} }),
       recordIntent: () => {},
@@ -747,6 +759,7 @@ describe("reasoningRecoveryPass", () => {
     const events = [];
     let seamCalls = 0;
     reasoningRecoveryPass([retrySafeItem], {
+      ...hermeticRecovery,
       mode: "shadow",
       classifyTicket: () => ({
         decision: "fix",

--- a/plugins/dev/scripts/execution-core/recovery-reasoning.test.mjs
+++ b/plugins/dev/scripts/execution-core/recovery-reasoning.test.mjs
@@ -384,6 +384,45 @@ describe("defaultClassifyTicket", () => {
     expect(result.decision).toBe("fix");
     expect(result.fix_class).toBe("bounded-llm");
   });
+
+  // CTL-1679 Phase 1: cluster_fence_stale is provably retry-safe (the guard bows
+  // out BEFORE any side-effect and exit-10s) — it must classify as a deterministic
+  // FIX routed to the fence-stale-redispatch seam, NOT fall to the Rule-3 escalate.
+  test("CTL-1679: cluster_fence_stale (signal) → fix / fence_stale_redispatch (not escalate)", () => {
+    const result = defaultClassifyTicket({
+      logsOutput: null,
+      jobState: null,
+      signal: { failureReason: "cluster_fence_stale", phase: "pr" },
+    });
+    expect(result.decision).toBe("fix");
+    expect(result.fix_class).toBe("fence_stale_redispatch");
+    expect(result.details.seam_id).toBe("fence-stale-redispatch");
+    expect(result.details.phase).toBe("pr");
+  });
+
+  test("CTL-1679: cluster_fence_stale (top-level failureReason) → fix / fence_stale_redispatch", () => {
+    const result = defaultClassifyTicket({
+      logsOutput: null,
+      failureReason: "cluster_fence_stale",
+      signal: { phase: "monitor-merge" },
+    });
+    expect(result.decision).toBe("fix");
+    expect(result.fix_class).toBe("fence_stale_redispatch");
+    expect(result.details.seam_id).toBe("fence-stale-redispatch");
+    expect(result.details.phase).toBe("monitor-merge");
+  });
+
+  // CTL-1679 Phase 1: rule precedence — a cluster_fence_stale signal that ALSO
+  // carries a bounded-LLM-matching log pattern still classifies deterministically
+  // (Rule 1 wins over Rule 2), mirroring the existing deterministic > bounded-LLM order.
+  test("CTL-1679: cluster_fence_stale wins over a bounded-LLM log match (deterministic precedence)", () => {
+    const result = defaultClassifyTicket({
+      logsOutput: "CONFLICT (content): Merge conflict in src/server.ts",
+      signal: { failureReason: "cluster_fence_stale", phase: "implement" },
+    });
+    expect(result.decision).toBe("fix");
+    expect(result.fix_class).toBe("fence_stale_redispatch");
+  });
 });
 
 describe("reasoningRecoveryPass", () => {
@@ -542,6 +581,69 @@ describe("reasoningRecoveryPass", () => {
     expect(result.results[2].fix_class).toBe("human");
     expect(events.filter((e) => e.type === "recovery.would-fix").length).toBe(2);
     expect(events.filter((e) => e.type === "recovery.would-escalate").length).toBe(1);
+  });
+
+  // CTL-1679 Phase 1: gating — a cluster_fence_stale item flows through the
+  // classifier as a deterministic FIX. In SHADOW it emits recovery.would-fix and
+  // invokes NO seam; in ENFORCE it invokes the fence-stale-redispatch seam exactly
+  // once and emits recovery.fixed on success / recovery.fix-failed on failure.
+  const fenceStaleItem = {
+    ticket: "CTL-9",
+    evidence: {
+      logsOutput: null,
+      jobState: null,
+      signal: { failureReason: "cluster_fence_stale", phase: "pr" },
+      failureReason: "cluster_fence_stale",
+    },
+  };
+
+  test("CTL-1679: cluster_fence_stale in SHADOW → would-fix, no seam", () => {
+    const events = [];
+    let seamCalls = 0;
+    const result = reasoningRecoveryPass([fenceStaleItem], {
+      mode: "shadow",
+      invokeSeam: () => {
+        seamCalls += 1;
+        return { success: true };
+      },
+      emitEvent: (e) => events.push(e),
+      postComment: () => {},
+    });
+    expect(result.results[0].decision).toBe("fix");
+    expect(result.results[0].fix_class).toBe("fence_stale_redispatch");
+    expect(seamCalls).toBe(0);
+    expect(events.some((e) => e.type === "recovery.would-fix")).toBe(true);
+  });
+
+  test("CTL-1679: cluster_fence_stale in ENFORCE → invokes seam once, emits recovery.fixed", () => {
+    const events = [];
+    const seamCalls = [];
+    reasoningRecoveryPass([fenceStaleItem], {
+      mode: "enforce",
+      invokeSeam: (ticket, seamId, brief) => {
+        seamCalls.push({ ticket, seamId, brief });
+        return { success: true, reason: "re-armed", details: {} };
+      },
+      recordIntent: () => {},
+      emitEvent: (e) => events.push(e),
+      postComment: () => {},
+    });
+    expect(seamCalls).toHaveLength(1);
+    expect(seamCalls[0].seamId).toBe("fence-stale-redispatch");
+    expect(seamCalls[0].brief.phase).toBe("pr");
+    expect(events.some((e) => e.type === "recovery.fixed")).toBe(true);
+  });
+
+  test("CTL-1679: cluster_fence_stale ENFORCE seam failure → recovery.fix-failed", () => {
+    const events = [];
+    reasoningRecoveryPass([fenceStaleItem], {
+      mode: "enforce",
+      invokeSeam: () => ({ success: false, reason: "signal absent", details: {} }),
+      recordIntent: () => {},
+      emitEvent: (e) => events.push(e),
+      postComment: () => {},
+    });
+    expect(events.some((e) => e.type === "recovery.fix-failed")).toBe(true);
   });
 
   // CTL-1157 F #5 (Codex round-4): a `defer` decision must NOT write the cooldown

--- a/plugins/dev/scripts/execution-core/recovery-reasoning.test.mjs
+++ b/plugins/dev/scripts/execution-core/recovery-reasoning.test.mjs
@@ -425,6 +425,90 @@ describe("defaultClassifyTicket", () => {
   });
 });
 
+describe("CTL-1679 Phase 3 — generalized retry_safe bounded retry", () => {
+  const zeroAttempts = () => 0;
+  const maxAttempts = () => RECOVERY_MAX_ATTEMPTS;
+
+  // (b) Unrecognized failure + retrySafe, budget remaining → bounded retry via the
+  // shared fence-stale-redispatch seam (NOT escalate).
+  test("unrecognized + retrySafe + budget remaining → fix / retry_safe_redispatch", () => {
+    const result = defaultClassifyTicket(
+      {
+        logsOutput: null,
+        failureReason: "some_unrecognized_reason",
+        retrySafe: true,
+        signal: { failureReason: "some_unrecognized_reason", phase: "verify" },
+      },
+      { ticket: "CTL-77", readIntentAttempts: zeroAttempts },
+    );
+    expect(result.decision).toBe("fix");
+    expect(result.fix_class).toBe("retry_safe_redispatch");
+    expect(result.details.seam_id).toBe("fence-stale-redispatch");
+    expect(result.details.phase).toBe("verify");
+  });
+
+  // (b→exhaustion) budget exhausted → escalate with a reason-named coverage-gap
+  // explanation carrying an attempts history.
+  test("unrecognized + retrySafe + budget exhausted → escalate with named reason", () => {
+    const result = defaultClassifyTicket(
+      {
+        logsOutput: null,
+        failureReason: "some_unrecognized_reason",
+        retrySafe: true,
+        signal: { failureReason: "some_unrecognized_reason", phase: "verify" },
+      },
+      { ticket: "CTL-77", readIntentAttempts: maxAttempts },
+    );
+    expect(result.decision).toBe("escalate");
+    expect(result.details.reason).toContain("some_unrecognized_reason");
+    expect(result.details.explanation).toBeDefined();
+    expect(result.details.explanation.escalation_type).toBeDefined();
+    expect(result.details.explanation.problem).toContain("some_unrecognized_reason");
+  });
+
+  // (c) Unrecognized + NOT retrySafe → immediate escalate exactly as today
+  // (regression guard — no retry budget consulted).
+  test("unrecognized + NOT retrySafe → immediate escalate (unchanged)", () => {
+    const result = defaultClassifyTicket(
+      {
+        logsOutput: null,
+        failureReason: "design-decision-required",
+        signal: { failureReason: "design-decision-required", phase: "implement" },
+      },
+      { ticket: "CTL-78", readIntentAttempts: zeroAttempts },
+    );
+    expect(result.decision).toBe("escalate");
+    expect(result.fix_class).toBe("human");
+  });
+
+  // Phase 1's deterministic cluster_fence_stale is ALSO budget-gated so an
+  // infinitely-stale fence can't loop forever: budget exhausted → escalate.
+  test("cluster_fence_stale budget exhausted → escalate with named reason", () => {
+    const result = defaultClassifyTicket(
+      {
+        logsOutput: null,
+        signal: { failureReason: "cluster_fence_stale", phase: "pr" },
+      },
+      { ticket: "CTL-79", readIntentAttempts: maxAttempts },
+    );
+    expect(result.decision).toBe("escalate");
+    expect(result.details.reason).toContain("cluster_fence_stale");
+  });
+
+  // cluster_fence_stale with budget remaining still fixes (Phase 1 preserved).
+  test("cluster_fence_stale budget remaining → fix (Phase 1 preserved)", () => {
+    const result = defaultClassifyTicket(
+      {
+        logsOutput: null,
+        signal: { failureReason: "cluster_fence_stale", phase: "pr" },
+      },
+      { ticket: "CTL-79", readIntentAttempts: zeroAttempts },
+    );
+    expect(result.decision).toBe("fix");
+    expect(result.fix_class).toBe("fence_stale_redispatch");
+  });
+});
+
 describe("reasoningRecoveryPass", () => {
   const baseItem = {
     ticket: "CTL-1",
@@ -644,6 +728,56 @@ describe("reasoningRecoveryPass", () => {
       postComment: () => {},
     });
     expect(events.some((e) => e.type === "recovery.fix-failed")).toBe(true);
+  });
+
+  // CTL-1679 Phase 3: shadow twin. An unrecognized retrySafe failure that the
+  // classifier would RETRY emits recovery.would-retry (twin of would-fix) in
+  // shadow, but still records the shadow intent / does not invoke the seam.
+  const retrySafeItem = {
+    ticket: "CTL-88",
+    evidence: {
+      logsOutput: null,
+      failureReason: "unrecognized_retry_safe",
+      retrySafe: true,
+      signal: { failureReason: "unrecognized_retry_safe", phase: "verify" },
+    },
+  };
+
+  test("CTL-1679 Phase 3: retrySafe retry in SHADOW → recovery.would-retry twin", () => {
+    const events = [];
+    let seamCalls = 0;
+    reasoningRecoveryPass([retrySafeItem], {
+      mode: "shadow",
+      classifyTicket: () => ({
+        decision: "fix",
+        fix_class: "retry_safe_redispatch",
+        details: { seam_id: "fence-stale-redispatch", phase: "verify", reason: "retry unrecognized_retry_safe" },
+      }),
+      invokeSeam: () => {
+        seamCalls += 1;
+        return { success: true };
+      },
+      recordIntent: () => {},
+      emitEvent: (e) => events.push(e),
+      postComment: () => {},
+    });
+    expect(seamCalls).toBe(0);
+    expect(events.some((e) => e.type === "recovery.would-retry")).toBe(true);
+  });
+
+  // CTL-1679 Phase 3: a reason-bearing item skipped by shouldSkipItem emits a
+  // per-ticket recovery.skipped.<reason> breadcrumb so coverage gaps stay queryable.
+  test("CTL-1679 Phase 3: ledger-skipped reason-bearing item → recovery.skipped.<reason>", () => {
+    const events = [];
+    reasoningRecoveryPass([fenceStaleItem], {
+      mode: "enforce",
+      shouldSkipItem: () => true, // latched / cooldown
+      emitEvent: (e) => events.push(e),
+      postComment: () => {},
+    });
+    const skipped = events.find((e) => typeof e.type === "string" && e.type.startsWith("recovery.skipped."));
+    expect(skipped).toBeDefined();
+    expect(skipped.type).toContain("cluster_fence_stale");
   });
 
   // CTL-1157 F #5 (Codex round-4): a `defer` decision must NOT write the cooldown

--- a/plugins/dev/scripts/lib/__tests__/cluster-fence-guard.test.sh
+++ b/plugins/dev/scripts/lib/__tests__/cluster-fence-guard.test.sh
@@ -104,6 +104,10 @@ C_EMIT_LOG="$(cat "$EMIT_LOG" 2>/dev/null || echo "")"
 assert_contains "$C_EMIT_LOG" "--status" "stale gen → emit-complete called with --status"
 assert_contains "$C_EMIT_LOG" "failed" "stale gen → emit-complete called with failed status"
 assert_contains "$C_EMIT_LOG" "cluster_fence_stale" "stale gen → emit-complete reason=cluster_fence_stale"
+# CTL-1679 Phase 2: the stale branch stamps retry_safe:true via --payload-json so
+# the recovery-pass classifier can read retry-safety off the signal/evidence.
+assert_contains "$C_EMIT_LOG" "--payload-json" "stale gen → emit-complete called with --payload-json"
+assert_contains "$C_EMIT_LOG" "retry_safe" "stale gen → --payload-json carries retry_safe"
 
 echo ""
 echo "─────────────────────────────────────────────"

--- a/plugins/dev/scripts/lib/cluster-fence-guard.sh
+++ b/plugins/dev/scripts/lib/cluster-fence-guard.sh
@@ -39,8 +39,13 @@ if node "$CLUSTER_CLAIM_CLI" fence-check "$TICKET" "$CATALYST_CLUSTER_GENERATION
 fi
 
 # Stale (exit 10 or any non-current result) — bow out without the side-effect.
+# CTL-1679: stamp retry_safe:true. The bow-out happens BEFORE any guarded
+# side-effect and a fresh dispatch bumps the generation so the next fence-check
+# passes — so this failure is safe to mechanically re-dispatch. The recovery-pass
+# classifier reads retry_safe off the signal/evidence to redispatch instead of
+# escalating a human.
 echo "${PHASE}: cluster fence stale (gen=${CATALYST_CLUSTER_GENERATION}) — bowing out, no side-effect" >&2
 "${EMIT}" \
   --phase "$PHASE" --ticket "$TICKET" --status failed \
-  --reason "cluster_fence_stale" || true
+  --reason "cluster_fence_stale" --payload-json '{"retry_safe":true}' || true
 exit 10

--- a/plugins/dev/scripts/phase-agent-emit-complete
+++ b/plugins/dev/scripts/phase-agent-emit-complete
@@ -370,6 +370,15 @@ if [[ -n $CALLER_PAYLOAD ]]; then
 	[[ -n $PAYLOAD ]] || PAYLOAD="$BASE_PAYLOAD"
 fi
 
+# CTL-1679: extract retry_safe from the caller payload so the signal writer below
+# can persist it as `retrySafe` on the phase signal (the recovery-pass classifier
+# reads it off the signal/evidence). Only "true" propagates; a malformed / absent
+# payload leaves it empty and the signal gains no retrySafe key (back-compat).
+RETRY_SAFE=""
+if [[ -n $CALLER_PAYLOAD ]]; then
+	RETRY_SAFE=$(jq -r 'if (.retry_safe == true) then "true" else empty end' <<<"$CALLER_PAYLOAD" 2>/dev/null || echo "")
+fi
+
 LINE=$(build_canonical_line \
 	--ts "$TS" \
 	--severity "$SEVERITY" \
@@ -439,6 +448,7 @@ if [[ -n $ORCH_DIR && $NO_SIGNAL_UPDATE -eq 0 ]]; then
 			--arg phase "$PHASE" \
 			--arg host_name "$_EMIT_HOST_NAME" \
 			--arg host_id "$_EMIT_HOST_ID" \
+			--arg retry_safe "$RETRY_SAFE" \
 			".status = \$status
            | ${SET_COMPLETED}
            | .updatedAt = \$ts
@@ -446,6 +456,7 @@ if [[ -n $ORCH_DIR && $NO_SIGNAL_UPDATE -eq 0 ]]; then
               elif \$reason == \"\" then .
               else .failureReason = \$reason end)
            | (if \$handoff == \"\" then . else .handoffPath    = \$handoff end)
+           | (if \$retry_safe == \"true\" then .retrySafe = true else . end)
            | (if \$status  == \"needs-input\" then .parkedFrom = \$phase
                 | (if (.needsHumanSince == null) then .needsHumanSince = \$ts else . end)
               else . end)


### PR DESCRIPTION
<!-- Auto-generated: 2026-08-08T10:05:00Z -->
<!-- Last updated: 2026-08-08T10:05:00Z -->
<!-- PR: #3146 -->
<!-- Previous commits: 51439e22,915c1bcc,ba578586,42575031 -->

## Summary

The recovery pass now **retries safe, retryable failures by default** instead of silently skipping
unrecognized ones. Previously the classifier's default for any failure reason outside its allowlist
was skip/escalate — so a provably side-effect-free failure (e.g. `cluster_fence_stale`) was skipped
every tick, indefinitely, with no per-ticket record. In the motivating 2026-08-07 incident a
fence-stale implement failure sat idle for 4.5+ hours (`"0 processed, 11 skipped"`), neither
remediated nor escalated, until a human noticed. This was the third instance of the same pattern in
24h.

This PR closes that gap in three layers:

1. **Emission site as proof of safety.** The CTL-864 fence guard bows out *before* any guarded
   side-effect, so a fresh redispatch (which bumps the cluster generation) is always safe. It now
   stamps `retry_safe: true` into the failure payload, so the classifier need not hardcode reason
   strings.
2. **Signal plumbing.** `phase-agent-emit-complete` propagates `retry_safe` from the caller payload
   onto the phase signal as `retrySafe: true`, where the recovery-pass classifier reads it off the
   signal/evidence.
3. **Generalized bounded retry.** Any retry-safe failure — the deterministic `cluster_fence_stale`
   shortcut *or* a generic unrecognized-but-safe failure — gets a bounded default retry budget
   (the shared `RECOVERY_MAX_ATTEMPTS`) with backoff via the recovery-intent ledger. Only budget
   exhaustion escalates, and the escalation names the concrete reason and carries the retry history
   so classifier coverage gaps stay visible. Unknown-and-**unsafe** failures still escalate on the
   first evaluation (existing behavior preserved).

Per ADR-023, the new retry behavior ships shadow-observable: a `recovery.would-retry` twin event and
per-ticket `recovery.skipped.<reason>` breadcrumbs make previously-invisible silent skips queryable
in Loki.

## Changes Made

### Recovery classifier (`execution-core/recovery-reasoning.mjs`, +305/-5)

- `retrySafeBudgetDecision(ticket, { readIntentAttempts })` — the shared bounded-retry budget
  decision. Pure over an injected ledger reader (defaults to the on-disk intent ledger; injectable
  for hermetic tests); fail-open on an unreadable ledger (`attempts=0` → retry allowed).
  `attempts < MAX → { retry: true }`, `attempts ≥ MAX → { retry: false }`.
- `buildRetrySafeExhaustionExplanation(ticket, reason, attempts)` — reason-named `coverage_gap`
  escalation reusing the existing `buildEscalationPayload` tagged-union shape, so the operator inbox
  renders a real "unrecognized retry-safe failure `<reason>`" card carrying the attempts history.
- `sanitizeReasonForEvent(reason)` — slugs an arbitrary failure reason into a safe
  `[a-z0-9_-]` event-name suffix for the `recovery.skipped.<reason>` breadcrumb.
- Per-ticket `recovery.skipped.<reason>` breadcrumb for reason-bearing skips, and a
  `recovery.would-retry` twin for retry-safe redispatches (both on the deliberately-unprotected
  `recovery.*` namespace). The `cluster_fence_stale` deterministic redispatch is gated through the
  same budget so an infinitely-stale fence can't loop forever.

### Fence guard (`lib/cluster-fence-guard.sh`, +6/-1)

- The stale bow-out now emits `--payload-json '{"retry_safe":true}'` alongside the
  `cluster_fence_stale` reason.

### Signal writer (`phase-agent-emit-complete`, +11/0)

- Extracts `retry_safe` from the caller payload and persists it as `retrySafe: true` on the phase
  signal. Back-compatible: only a literal `true` propagates; a malformed/absent payload leaves the
  signal unchanged (no `retrySafe` key).

### Tests (+471)

- `recovery-reasoning.test.mjs` (+249), `fence-stale-redispatch-seam.test.mjs` (+162),
  `recovery-evidence.test.mjs` (+21), `phase-agent-emit-complete.test.sh` (+35),
  `cluster-fence-guard.test.sh` (+4). Budget/escalation decisions tested against injected ledger
  readers (hermetic).

## How to Verify It

- [x] Bun unit tests (execution-core): `bun test recovery-reasoning.test.mjs fence-stale-redispatch-seam.test.mjs recovery-evidence.test.mjs` — pass
- [x] Shell tests: `phase-agent-emit-complete.test.sh`, `cluster-fence-guard.test.sh` — pass
- [x] Back-compat: a failure with no `retry_safe` payload leaves the signal free of `retrySafe`

> ⚠️ CI `execution-core-unit-tests` currently reports one failing test —
> `CTL-1240 Phase 2 — census closures use { cache, gateway } > default stall-clear census uses { cache, gateway } via runningOpts`
> (`integration-ctl-1240.test.mjs`). This test **also fails on a clean `origin/main`** and is
> **unrelated to this change** (this PR touches neither `scheduler.mjs` nor that test). It is a
> pre-existing stale-test failure on `main` and should be fixed in its own PR.

## Related Issues/PRs

- Fixes https://linear.app/coalesce/issue/CTL-1679
- Rollout per ADR-023 (shadow → enforce).

<!-- Linear automation guard (CTL-623/CTL-633): unlink sibling tickets so this PR does not drag their workflow status. -->
skip ADR-023
skip CTL-1240
skip CTL-864