### PR TITLE
fix(execution-core): use a valid ticket-key format in CTL-1240 stall-clear fixture

### DIFF
--- a/plugins/dev/scripts/execution-core/integration-ctl-1240.test.mjs
+++ b/plugins/dev/scripts/execution-core/integration-ctl-1240.test.mjs
@@ -189,7 +189,11 @@ describe("CTL-1240 Phase 2 — census closures use { cache, gateway }", () => {
   //           → spy consulted.
 
   test("default stall-clear census uses { cache, gateway } via runningOpts", () => {
-    const STALL_TICKET = "CTL-1240-STALL";
+    // CTL-1504 requires a canonical TEAM-123 key (`^[A-Z][A-Z0-9_]*-\d+$`) — a
+    // trailing letter suffix like the old "CTL-1240-STALL" is debris-filtered
+    // by isTicketKey() before defaultCollectStallClearCandidates ever reaches
+    // the isLinearTerminal probe, so the gateway spy was never consulted (CAT-62).
+    const STALL_TICKET = "CTL-99991240";
 
     writeFileSync(join(orchDir, "state.json"), JSON.stringify({ maxParallel: 1 }));
     // Seed the stalled signal — stalledReason triggers the J3 isLinearTerminal probe.


### PR DESCRIPTION
## Changes

The Site-4 "default stall-clear census" test in `integration-ctl-1240.test.mjs` seeded its stalled signal under ticket id `"CTL-1240-STALL"`, which does not match `TICKET_KEY_RE` (`^[A-Z][A-Z0-9_]*-\d+$`) — the trailing `-STALL` suffix isn't all digits.

`defaultCollectStallClearCandidates`'s CTL-1504 debris-filter guard (`if (!isTicketKey(ticket)) continue;`) skips any worker-dir name that isn't a canonical ticket key, so the fixture was filtered out before the census ever reached the `isLinearTerminal` probe. The gateway spy was never consulted, and the test's own assertion (`expect(gateway.calls).toContain(STALL_TICKET)`) failed — a pre-existing red required check (`execution-core-unit-tests`) on `main`, blocking every PR merge in the repo.

`scheduler.mjs`'s production code is correct as-is (the gateway threading itself works). This is purely a test-fixture naming bug, most likely introduced when CTL-1504's guard was added to `defaultCollectStallClearCandidates` sometime after this test was originally written with an intentionally-descriptive-but-invalid ticket id.

Fix: renamed the fixture ticket to a canonical `TEAM-123`-shaped id (`CTL-99991240`).

## Verification
- `bun test integration-ctl-1240.test.mjs`: 3 pass / 0 fail (was 2 pass / 1 fail on `main` at `0165f78c`)
- Full `execution-core` suite (245 files, 8100 tests): failure set is identical before/after this change (minus the one fixed test) — no regressions introduced.

## Test plan
- [x] Targeted test file passes
- [x] Full execution-core suite shows no new failures vs. baseline