### PR TITLE
fix(dev): CTL-1240 census fixtures must use canonical ticket keys

### DIFF
--- a/plugins/dev/scripts/execution-core/integration-ctl-1240.test.mjs
+++ b/plugins/dev/scripts/execution-core/integration-ctl-1240.test.mjs
@@ -111,6 +111,23 @@ const recoveryIntentMarker = (ticket) =>
 //          → fail-open non-terminal → both tickets processed).
 // POST-FIX: spy consulted; Done ticket filtered (terminal), In-Progress ticket kept.
 
+// CTL-1504 interaction — fixture naming is load-bearing, and the two groups differ:
+//
+//   * The Phase 2 CENSUS tests below must use CANONICAL Linear keys
+//     (`TICKET_KEY_RE = /^[A-Z][A-Z0-9_]*-\d+$/`, ticket-key.mjs). CTL-1504 added
+//     `if (!isTicketKey(ticket)) continue` to defaultCollectStallClearCandidates
+//     (stall-janitor.mjs) and defaultCollectUnstuckCandidates (unstuck-sweep.mjs)
+//     so a debris dir is never handed to a live `linearis issues read`. A suffixed
+//     name like `CTL-1240-STALL` does not end in `-<digits>`, so the census skipped
+//     the fixture's worker dir outright, the isLinearTerminal probe never ran, and
+//     the gateway spy went unconsulted — which is why the stall-clear assertion
+//     failed on `main` for reasons unrelated to its subject. Keep them numeric.
+//
+//   * The Phase 1 tickets below deliberately KEEP their suffixed names. That path
+//     has no isTicketKey guard, and a canonical key makes fetchTicketState fall
+//     through past the gateway spy to the live `linearis` tier (observed: 131ms →
+//     3.2s, and the would-defer event stops being emitted). The non-key name is
+//     what keeps this test hermetic and off the network.
 describe("CTL-1240 Phase 1 — gateway threaded through startScheduler spine", () => {
   const DONE_TICKET = "CTL-1240-DONE";
   const LIVE_TICKET = "CTL-1240-LIVE";
@@ -189,7 +206,7 @@ describe("CTL-1240 Phase 2 — census closures use { cache, gateway }", () => {
   //           → spy consulted.
 
   test("default stall-clear census uses { cache, gateway } via runningOpts", () => {
-    const STALL_TICKET = "CTL-1240-STALL";
+    const STALL_TICKET = "CTL-12401";
 
     writeFileSync(join(orchDir, "state.json"), JSON.stringify({ maxParallel: 1 }));
     // Seed the stalled signal — stalledReason triggers the J3 isLinearTerminal probe.
@@ -233,7 +250,7 @@ describe("CTL-1240 Phase 2 — census closures use { cache, gateway }", () => {
   //           → spy consulted.
 
   test("default unstuck census uses { cache, gateway } via runningOpts", () => {
-    const STUCK_TICKET = "CTL-1240-STUCK";
+    const STUCK_TICKET = "CTL-12402";
 
     writeFileSync(join(orchDir, "state.json"), JSON.stringify({ maxParallel: 1 }));
     writeSignal(STUCK_TICKET, "implement", "stalled", {


### PR DESCRIPTION
## Why

`CTL-1240 Phase 2 — default stall-clear census uses { cache, gateway } via runningOpts` is failing on `main`. `Execution Core Unit Tests` is a required check, so **every PR branched off main inherits a red check it cannot fix**.

Reproduced on a clean worktree at `origin/main` (`0165f78c`): 2 pass / 1 fail.

## Root cause — a stale fixture, not a product regression

The production wiring is correct and untouched. `defaultCollectStallClearCandidates` is already called with the full 3-tier read, exactly as CTL-1240 intended:

```js
const state = fetchTicketState(id, {
  cache: runningOpts.cache,
  gateway: runningOpts.gateway,
  replica: runningOpts.replica,
  probeBackoff: true,
});
```

The failure comes from CTL-1504. It added a guard to the worker-dir censuses so a debris dir is never handed to a live `linearis issues read`:

```js
if (!isTicketKey(ticket)) continue; // CTL-1504
```

`TICKET_KEY_RE = /^[A-Z][A-Z0-9_]*-\d+$/` requires a trailing `-<digits>`. The fixture ticket `CTL-1240-STALL` ends in `-STALL`, so `isTicketKey` returns `false`:

| fixture | isTicketKey |
| --- | --- |
| `CTL-1240-STALL` | `false` |
| `CTL-1240-STUCK` | `false` |
| `CTL-12401` | `true` |

The census skipped the fixture's worker dir outright → `isLinearTerminal` never ran → the gateway spy was never consulted → the assertion failed for reasons unrelated to its subject.

## The fix

Rename the two **census** fixtures to canonical keys so they exercise what they assert.

The **Phase 1** fixtures deliberately keep their suffixed names, and the comment says so. That path has no `isTicketKey` guard, and giving it a canonical key makes `fetchTicketState` fall through past the gateway spy to the live `linearis` tier — observed as 131ms → 3.2s with the `would-defer` event no longer emitted. The non-key name is what keeps that test hermetic and off the network.

## Evidence

Full `execution-core` suite (8100 tests), run twice on each side:

| | result | target test |
| --- | --- | --- |
| baseline #1 | 8044 pass / 56 fail | **FAIL** |
| baseline #2 | 8045 pass / 55 fail | **FAIL** |
| with fix #1 | 8046 pass / 54 fail | pass |
| with fix #2 | 8047 pass / 53 fail | pass |

No test is newly broken. The residual local failures are pre-existing and environment-dependent; two of them (`CTL-826` reduced-ladder and `CTL-705` preemption) each vary between two *identical* baseline runs, so they are flake rather than anything this change touches — both also pass in isolation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)