### PR TITLE
feat(dev): CAT-58 — distinguish account usage-limit blocks from dead workers

### DIFF
--- a/.github/workflows/execution-core-tests.yml
+++ b/.github/workflows/execution-core-tests.yml
@@ -593,6 +593,7 @@ jobs:
             lane-cooldown.test.mjs \
             dispatch-usage-limit-fallback.test.mjs \
             account-quota.test.mjs \
+            recovery-usage-limit-park.test.mjs \
             stall-janitor-throttle.test.mjs \
             phantom-worker-dir.test.mjs \
             in-flight-supersede.test.mjs \

--- a/.github/workflows/execution-core-tests.yml
+++ b/.github/workflows/execution-core-tests.yml
@@ -589,6 +589,10 @@ jobs:
             autotune-writeback.test.mjs \
             board-health.test.mjs \
             board-health-seam.test.mjs \
+            usage-limit.test.mjs \
+            lane-cooldown.test.mjs \
+            dispatch-usage-limit-fallback.test.mjs \
+            account-quota.test.mjs \
             stall-janitor-throttle.test.mjs \
             phantom-worker-dir.test.mjs \
             in-flight-supersede.test.mjs \

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -314,6 +314,16 @@ via `orchestrate-phase-advance`, and dispatches the next `--bg` job. Dispatcher:
 `plugins/dev/scripts/phase-agent-dispatch` (CTL-448). `oneshot-legacy` (single long-lived
 job/ticket) is the runtime fallback when the key is missing.
 
+### Usage-limit parking and executor fallback (CAT-58)
+
+When a terminal `bg` job's `timeline.jsonl` reports that the Claude account usage limit was hit,
+recovery parks the ticket phase until the reported reset instead of reviving it through the normal
+progress gate. The worker signal records `failureReason: "usage-limit-blocked"`; a ticket/phase
+dispatch cooldown and a node-local `.lane-cooldowns/bg.json` marker carry the reset deadline. While
+that lane marker is active, phase-aware dispatch routes `bg` work to `codex-exec` when its boot gate
+is healthy and emits an audit-only fallback event. Account rate-limit samples also derive the board
+health `nearCliff` invariant from five-hour and seven-day utilization (90% by default).
+
 ### Dispatch-time rebase (front-load conflict surfacing, CTL-667 + CTL-707)
 
 On a **fresh** dispatch of a **build** phase (`research`,`plan`,`implement`,`verify`,`review`),

--- a/plugins/dev/scripts/execution-core/account-quota.mjs
+++ b/plugins/dev/scripts/execution-core/account-quota.mjs
@@ -57,5 +57,13 @@ export function readAccountQuota(orchDir, { now = Date.now, log = defaultLog } =
 
 export function resolveAccountResetsAt(orchDir, { now = Date.now } = {}) {
   const snapshot = readAccountQuota(orchDir, { now });
-  return snapshot?.sevenDayResetsAt ?? snapshot?.fiveHourResetsAt ?? null;
+  if (!snapshot) return null;
+  const fiveHourPct = Number(snapshot.fiveHourPct);
+  const sevenDayPct = Number(snapshot.sevenDayPct);
+  if (Number.isFinite(fiveHourPct) && Number.isFinite(sevenDayPct)) {
+    return fiveHourPct > sevenDayPct
+      ? snapshot.fiveHourResetsAt ?? snapshot.sevenDayResetsAt ?? null
+      : snapshot.sevenDayResetsAt ?? snapshot.fiveHourResetsAt ?? null;
+  }
+  return snapshot.sevenDayResetsAt ?? snapshot.fiveHourResetsAt ?? null;
 }

--- a/plugins/dev/scripts/execution-core/account-quota.mjs
+++ b/plugins/dev/scripts/execution-core/account-quota.mjs
@@ -1,0 +1,61 @@
+import { mkdirSync, readFileSync, renameSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { log as defaultLog } from "./config.mjs";
+
+export const ACCOUNT_QUOTA_MAX_AGE_MS =
+  Number(process.env.CATALYST_ACCOUNT_QUOTA_MAX_AGE_MS) || 1_800_000;
+
+export function accountQuotaPath(orchDir) {
+  return join(orchDir, "account-quota.json");
+}
+
+export function writeAccountQuota(
+  orchDir,
+  sample,
+  { now = Date.now, log = defaultLog, fileOps = { mkdirSync, writeFileSync, renameSync } } = {},
+) {
+  if (!orchDir) return false;
+  try {
+    const snapshot = {
+      sampledAt: sample?.sampledAt ?? new Date(now()).toISOString(),
+      fiveHourPct: sample?.fiveHourPct ?? null,
+      sevenDayPct: sample?.sevenDayPct ?? null,
+      fiveHourResetsAt: sample?.fiveHourResetsAt ?? null,
+      sevenDayResetsAt: sample?.sevenDayResetsAt ?? null,
+      opusPct: sample?.opusPct ?? null,
+      sonnetPct: sample?.sonnetPct ?? null,
+      subscriptionType: sample?.subscriptionType ?? null,
+      rateLimitTier: sample?.rateLimitTier ?? null,
+    };
+    fileOps.mkdirSync(orchDir, { recursive: true });
+    const finalPath = accountQuotaPath(orchDir);
+    const tmpPath = `${finalPath}.tmp.${process.pid}`;
+    fileOps.writeFileSync(tmpPath, JSON.stringify(snapshot));
+    fileOps.renameSync(tmpPath, finalPath);
+    return true;
+  } catch (err) {
+    log?.warn?.({ orchDir, err: err?.message }, "account-quota: snapshot write failed — continuing");
+    return false;
+  }
+}
+
+export function readAccountQuota(orchDir, { now = Date.now, log = defaultLog } = {}) {
+  const path = accountQuotaPath(orchDir);
+  try {
+    const snapshot = JSON.parse(readFileSync(path, "utf8"));
+    const sampledAtMs = Date.parse(snapshot?.sampledAt ?? "");
+    if (!Number.isFinite(sampledAtMs) || now() - sampledAtMs > ACCOUNT_QUOTA_MAX_AGE_MS) return null;
+    return snapshot;
+  } catch (err) {
+    if (err?.code !== "ENOENT") {
+      log?.warn?.({ path, err: err?.message }, "account-quota: snapshot unreadable — ignoring");
+    }
+    return null;
+  }
+}
+
+export function resolveAccountResetsAt(orchDir, { now = Date.now } = {}) {
+  const snapshot = readAccountQuota(orchDir, { now });
+  return snapshot?.sevenDayResetsAt ?? snapshot?.fiveHourResetsAt ?? null;
+}

--- a/plugins/dev/scripts/execution-core/account-quota.mjs
+++ b/plugins/dev/scripts/execution-core/account-quota.mjs
@@ -13,7 +13,7 @@ export function accountQuotaPath(orchDir) {
 export function writeAccountQuota(
   orchDir,
   sample,
-  { now = Date.now, log = defaultLog, fileOps = { mkdirSync, writeFileSync, renameSync } } = {},
+  { now = Date.now, log = defaultLog, fileOps = { mkdirSync, writeFileSync, renameSync } } = {}
 ) {
   if (!orchDir) return false;
   try {
@@ -35,7 +35,10 @@ export function writeAccountQuota(
     fileOps.renameSync(tmpPath, finalPath);
     return true;
   } catch (err) {
-    log?.warn?.({ orchDir, err: err?.message }, "account-quota: snapshot write failed — continuing");
+    log?.warn?.(
+      { orchDir, err: err?.message },
+      "account-quota: snapshot write failed — continuing"
+    );
     return false;
   }
 }
@@ -45,7 +48,8 @@ export function readAccountQuota(orchDir, { now = Date.now, log = defaultLog } =
   try {
     const snapshot = JSON.parse(readFileSync(path, "utf8"));
     const sampledAtMs = Date.parse(snapshot?.sampledAt ?? "");
-    if (!Number.isFinite(sampledAtMs) || now() - sampledAtMs > ACCOUNT_QUOTA_MAX_AGE_MS) return null;
+    if (!Number.isFinite(sampledAtMs) || now() - sampledAtMs > ACCOUNT_QUOTA_MAX_AGE_MS)
+      return null;
     return snapshot;
   } catch (err) {
     if (err?.code !== "ENOENT") {
@@ -64,8 +68,8 @@ export function resolveAccountResetsAt(orchDir, { now = Date.now } = {}) {
   const hasSevenDayPct = typeof sevenDayPct === "number" && Number.isFinite(sevenDayPct);
   if (hasFiveHourPct && hasSevenDayPct) {
     return fiveHourPct > sevenDayPct
-      ? snapshot.fiveHourResetsAt ?? snapshot.sevenDayResetsAt ?? null
-      : snapshot.sevenDayResetsAt ?? snapshot.fiveHourResetsAt ?? null;
+      ? (snapshot.fiveHourResetsAt ?? snapshot.sevenDayResetsAt ?? null)
+      : (snapshot.sevenDayResetsAt ?? snapshot.fiveHourResetsAt ?? null);
   }
   if (hasFiveHourPct) return snapshot.fiveHourResetsAt ?? snapshot.sevenDayResetsAt ?? null;
   if (hasSevenDayPct) return snapshot.sevenDayResetsAt ?? snapshot.fiveHourResetsAt ?? null;

--- a/plugins/dev/scripts/execution-core/account-quota.mjs
+++ b/plugins/dev/scripts/execution-core/account-quota.mjs
@@ -58,12 +58,16 @@ export function readAccountQuota(orchDir, { now = Date.now, log = defaultLog } =
 export function resolveAccountResetsAt(orchDir, { now = Date.now } = {}) {
   const snapshot = readAccountQuota(orchDir, { now });
   if (!snapshot) return null;
-  const fiveHourPct = Number(snapshot.fiveHourPct);
-  const sevenDayPct = Number(snapshot.sevenDayPct);
-  if (Number.isFinite(fiveHourPct) && Number.isFinite(sevenDayPct)) {
+  const fiveHourPct = snapshot.fiveHourPct;
+  const sevenDayPct = snapshot.sevenDayPct;
+  const hasFiveHourPct = typeof fiveHourPct === "number" && Number.isFinite(fiveHourPct);
+  const hasSevenDayPct = typeof sevenDayPct === "number" && Number.isFinite(sevenDayPct);
+  if (hasFiveHourPct && hasSevenDayPct) {
     return fiveHourPct > sevenDayPct
       ? snapshot.fiveHourResetsAt ?? snapshot.sevenDayResetsAt ?? null
       : snapshot.sevenDayResetsAt ?? snapshot.fiveHourResetsAt ?? null;
   }
+  if (hasFiveHourPct) return snapshot.fiveHourResetsAt ?? snapshot.sevenDayResetsAt ?? null;
+  if (hasSevenDayPct) return snapshot.sevenDayResetsAt ?? snapshot.fiveHourResetsAt ?? null;
   return snapshot.sevenDayResetsAt ?? snapshot.fiveHourResetsAt ?? null;
 }

--- a/plugins/dev/scripts/execution-core/account-quota.test.mjs
+++ b/plugins/dev/scripts/execution-core/account-quota.test.mjs
@@ -37,11 +37,13 @@ describe("account quota snapshot", () => {
     expect(readAccountQuota(orchDir)).toBeNull();
   });
 
-  test("resolveAccountResetsAt prefers seven-day, falls back to five-hour, then null", () => {
+  test("resolveAccountResetsAt selects the reset for the most exhausted window, then falls back", () => {
     const nowMs = Date.parse("2026-08-08T18:00:00.000Z");
     const orchDir = freshDir();
-    writeAccountQuota(orchDir, { fiveHourResetsAt: "2026-08-08T20:00:00.000Z", sevenDayResetsAt: "2026-08-10T18:00:00.000Z" }, { now: () => nowMs });
+    writeAccountQuota(orchDir, { fiveHourPct: 80, sevenDayPct: 100, fiveHourResetsAt: "2026-08-08T20:00:00.000Z", sevenDayResetsAt: "2026-08-10T18:00:00.000Z" }, { now: () => nowMs });
     expect(resolveAccountResetsAt(orchDir, { now: () => nowMs })).toBe("2026-08-10T18:00:00.000Z");
+    writeAccountQuota(orchDir, { fiveHourPct: 100, sevenDayPct: 80, fiveHourResetsAt: "2026-08-08T20:00:00.000Z", sevenDayResetsAt: "2026-08-10T18:00:00.000Z" }, { now: () => nowMs });
+    expect(resolveAccountResetsAt(orchDir, { now: () => nowMs })).toBe("2026-08-08T20:00:00.000Z");
     writeAccountQuota(orchDir, { fiveHourResetsAt: "2026-08-08T20:00:00.000Z" }, { now: () => nowMs });
     expect(resolveAccountResetsAt(orchDir, { now: () => nowMs })).toBe("2026-08-08T20:00:00.000Z");
     writeAccountQuota(orchDir, {}, { now: () => nowMs });

--- a/plugins/dev/scripts/execution-core/account-quota.test.mjs
+++ b/plugins/dev/scripts/execution-core/account-quota.test.mjs
@@ -46,6 +46,8 @@ describe("account quota snapshot", () => {
     expect(resolveAccountResetsAt(orchDir, { now: () => nowMs })).toBe("2026-08-08T20:00:00.000Z");
     writeAccountQuota(orchDir, { fiveHourResetsAt: "2026-08-08T20:00:00.000Z" }, { now: () => nowMs });
     expect(resolveAccountResetsAt(orchDir, { now: () => nowMs })).toBe("2026-08-08T20:00:00.000Z");
+    writeAccountQuota(orchDir, { fiveHourPct: null, sevenDayPct: 80, fiveHourResetsAt: "2026-08-08T20:00:00.000Z", sevenDayResetsAt: "2026-08-10T18:00:00.000Z" }, { now: () => nowMs });
+    expect(resolveAccountResetsAt(orchDir, { now: () => nowMs })).toBe("2026-08-10T18:00:00.000Z");
     writeAccountQuota(orchDir, {}, { now: () => nowMs });
     expect(resolveAccountResetsAt(orchDir, { now: () => nowMs })).toBeNull();
   });

--- a/plugins/dev/scripts/execution-core/account-quota.test.mjs
+++ b/plugins/dev/scripts/execution-core/account-quota.test.mjs
@@ -1,0 +1,57 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, readdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import {
+  ACCOUNT_QUOTA_MAX_AGE_MS,
+  accountQuotaPath,
+  readAccountQuota,
+  resolveAccountResetsAt,
+  writeAccountQuota,
+} from "./account-quota.mjs";
+
+const dirs = [];
+afterEach(() => {
+  for (const dir of dirs.splice(0)) rmSync(dir, { recursive: true, force: true });
+});
+
+function freshDir() {
+  const dir = mkdtempSync(join(tmpdir(), "cat58-account-quota-"));
+  dirs.push(dir);
+  return dir;
+}
+
+describe("account quota snapshot", () => {
+  test("writeAccountQuota publishes sampled resets atomically", () => {
+    const orchDir = freshDir();
+    writeAccountQuota(orchDir, { sevenDayResetsAt: "2026-08-10T18:00:00.000Z", sevenDayPct: 100 }, { now: () => Date.parse("2026-08-08T18:00:00.000Z") });
+    expect(readAccountQuota(orchDir, { now: () => Date.parse("2026-08-08T18:01:00.000Z") }).sevenDayResetsAt).toBe("2026-08-10T18:00:00.000Z");
+    expect(readdirSync(orchDir).filter((name) => name.includes(".tmp."))).toHaveLength(0);
+  });
+
+  test("readAccountQuota fails open on absent and corrupt files", () => {
+    expect(readAccountQuota("/nonexistent/cat58-account-quota")).toBeNull();
+    const orchDir = freshDir();
+    writeFileSync(accountQuotaPath(orchDir), "{not json");
+    expect(readAccountQuota(orchDir)).toBeNull();
+  });
+
+  test("resolveAccountResetsAt prefers seven-day, falls back to five-hour, then null", () => {
+    const nowMs = Date.parse("2026-08-08T18:00:00.000Z");
+    const orchDir = freshDir();
+    writeAccountQuota(orchDir, { fiveHourResetsAt: "2026-08-08T20:00:00.000Z", sevenDayResetsAt: "2026-08-10T18:00:00.000Z" }, { now: () => nowMs });
+    expect(resolveAccountResetsAt(orchDir, { now: () => nowMs })).toBe("2026-08-10T18:00:00.000Z");
+    writeAccountQuota(orchDir, { fiveHourResetsAt: "2026-08-08T20:00:00.000Z" }, { now: () => nowMs });
+    expect(resolveAccountResetsAt(orchDir, { now: () => nowMs })).toBe("2026-08-08T20:00:00.000Z");
+    writeAccountQuota(orchDir, {}, { now: () => nowMs });
+    expect(resolveAccountResetsAt(orchDir, { now: () => nowMs })).toBeNull();
+  });
+
+  test("a stale snapshot is ignored", () => {
+    const orchDir = freshDir();
+    const sampledAt = Date.parse("2026-08-08T18:00:00.000Z");
+    writeAccountQuota(orchDir, { sevenDayResetsAt: "2026-08-10T18:00:00.000Z" }, { now: () => sampledAt });
+    expect(readAccountQuota(orchDir, { now: () => sampledAt + ACCOUNT_QUOTA_MAX_AGE_MS + 1 })).toBeNull();
+  });
+});

--- a/plugins/dev/scripts/execution-core/board-health.mjs
+++ b/plugins/dev/scripts/execution-core/board-health.mjs
@@ -84,8 +84,7 @@ const DEFAULT_THRESHOLDS = {
 
 // single-LLM cadence floor: most ticks are a near-instant no-op (cheap gates),
 // but the LLM-bearing review is bounded to once per interval per host.
-export const BOARD_HEALTH_INTERVAL_MS =
-  Number(process.env.CATALYST_BH_INTERVAL_MS) || 5 * 60_000;
+export const BOARD_HEALTH_INTERVAL_MS = Number(process.env.CATALYST_BH_INTERVAL_MS) || 5 * 60_000;
 
 // per-phase "normal" worker age (v1 flat fallback; per-phase p95 is a follow-up).
 const PHASE_NORMAL_MS = {
@@ -347,13 +346,18 @@ function extractBlockers(descriptor) {
   if (!descriptor) return [];
   let rel = descriptor.relations ?? descriptor.blockedBy ?? null;
   if (typeof rel === "string") {
-    try { rel = JSON.parse(rel); } catch { return []; }
+    try {
+      rel = JSON.parse(rel);
+    } catch {
+      return [];
+    }
   }
   if (!rel) return [];
   const ids = [];
   const push = (x) => {
     if (!x) return;
-    const id = x.identifier ?? x.relatedIssue?.identifier ?? x.ticket ?? (typeof x === "string" ? x : null);
+    const id =
+      x.identifier ?? x.relatedIssue?.identifier ?? x.ticket ?? (typeof x === "string" ? x : null);
     if (id) ids.push(id);
   };
   if (Array.isArray(rel)) {
@@ -373,8 +377,11 @@ function extractBlockers(descriptor) {
 // yields null/empty, and the dependent invariant degrades to observable:false.
 export const NEAR_CLIFF_PCT = Number(process.env.CATALYST_NEAR_CLIFF_PCT) || 90;
 export function deriveNearCliff(payload) {
-  if (payload?.nearCliff != null || payload?.near_cliff != null) return !!(payload.nearCliff ?? payload.near_cliff);
-  const values = [payload?.fiveHourPct, payload?.sevenDayPct].filter((n) => typeof n === "number" && Number.isFinite(n));
+  if (payload?.nearCliff != null || payload?.near_cliff != null)
+    return !!(payload.nearCliff ?? payload.near_cliff);
+  const values = [payload?.fiveHourPct, payload?.sevenDayPct].filter(
+    (n) => typeof n === "number" && Number.isFinite(n)
+  );
   return values.length > 0 && Math.max(...values) >= NEAR_CLIFF_PCT;
 }
 
@@ -440,7 +447,7 @@ export function deriveRing(events, nowMs, self) {
     }
   }
   // guard against a stale dispatch ts in the future / absurd past
-  if (ring.recentDispatchTs != null && (ring.recentDispatchTs > nowMs + 60_000)) {
+  if (ring.recentDispatchTs != null && ring.recentDispatchTs > nowMs + 60_000) {
     ring.recentDispatchTs = nowMs;
   }
   return ring;
@@ -677,7 +684,10 @@ export function assembleBoardState({
 }
 
 // ── (2) evaluateInvariants — PURE. Each check fails-open on a throw. ─────────
-export function evaluateInvariants(boardState, { thresholds = DEFAULT_THRESHOLDS, mode = boardState?.mode } = {}) {
+export function evaluateInvariants(
+  boardState,
+  { thresholds = DEFAULT_THRESHOLDS, mode = boardState?.mode } = {}
+) {
   const checks = {
     cacheCoherence: () => checkCacheCoherence(boardState),
     dispatchLiveness: () => checkDispatchLiveness(boardState, thresholds),
@@ -735,7 +745,9 @@ export function evaluateInvariants(boardState, { thresholds = DEFAULT_THRESHOLDS
       out[name] = fn();
     } catch (err) {
       // a throwing invariant must never abort the scan — fail open, but record.
-      out[name] = invariant(true, 0, true, [], `check error: ${err.message}`, { error: err.message });
+      out[name] = invariant(true, 0, true, [], `check error: ${err.message}`, {
+        error: err.message,
+      });
     }
   }
   return out;
@@ -747,7 +759,13 @@ function checkCacheCoherence(b) {
   const cr = b.ring?.cacheReconcile;
   if (!cr) return invariant(true, 0, false, [], "cache reconcile off/unseen → coherence unknown");
   const changed = Number(cr.changed) || 0;
-  return invariant(changed === 0, changed > 0 ? 1 : 0, true, [], `last reconcile corrected ${changed} row(s)`);
+  return invariant(
+    changed === 0,
+    changed > 0 ? 1 : 0,
+    true,
+    [],
+    `last reconcile corrected ${changed} row(s)`
+  );
 }
 
 // #1 — dispatch liveness (the liveness-hold wedge): open slots + a waiting queue
@@ -793,17 +811,18 @@ function checkWorkerAge(b, t) {
     flagged.length,
     true,
     flagged,
-    flagged.length ? `${flagged.length} worker(s) past phase-normal age` : "all workers within normal age",
+    flagged.length
+      ? `${flagged.length} worker(s) past phase-normal age`
+      : "all workers within normal age"
   );
 }
 
 // #3 — blocked tree alive: nothing blocked by a blocker that is itself
 // unscheduled (not eligible/in-flight) and not done.
 function checkBlockedTree(b) {
-  const scheduled = new Set([
-    ...b.eligible.map((e) => e.id),
-    ...b.signals.map((s) => s.ticket),
-  ].filter(Boolean));
+  const scheduled = new Set(
+    [...b.eligible.map((e) => e.id), ...b.signals.map((s) => s.ticket)].filter(Boolean)
+  );
   const flagged = [];
   for (const [id, d] of b.ticketsById) {
     for (const blockerId of extractBlockers(d)) {
@@ -821,8 +840,10 @@ function checkBlockedTree(b) {
     flagged.length,
     true,
     flagged,
-    flagged.length ? `${flagged.length} ticket(s) blocked by an unscheduled/stuck blocker` : "blocked tree alive",
-    { caveat: "relations may be stale (cache; reconciled out-of-band)" },
+    flagged.length
+      ? `${flagged.length} ticket(s) blocked by an unscheduled/stuck blocker`
+      : "blocked tree alive",
+    { caveat: "relations may be stale (cache; reconciled out-of-band)" }
   );
 }
 
@@ -837,7 +858,8 @@ function checkProjectSilence(b, t) {
     byProject.set(project, Math.max(byProject.get(project) ?? 0, ms));
   };
   for (const e of b.eligible) consider(e.project, e.updatedAt);
-  for (const [, d] of b.ticketsById) consider(d.project ?? d.projectName, d.updatedAt ?? d.updated_at);
+  for (const [, d] of b.ticketsById)
+    consider(d.project ?? d.projectName, d.updatedAt ?? d.updated_at);
   if (byProject.size === 0) {
     return invariant(true, 0, false, [], "no project/updatedAt join available → not observable");
   }
@@ -851,7 +873,7 @@ function checkProjectSilence(b, t) {
     true,
     flagged,
     flagged.length ? `${flagged.length} project(s) silent past cadence` : "all projects moving",
-    { caveat: "updatedAt is a movement proxy" },
+    { caveat: "updatedAt is a movement proxy" }
   );
 }
 
@@ -861,12 +883,22 @@ function checkRateLimitHeadroom(b, t) {
   if (b.githubQuotaMode === "off") {
     return invariant(true, 0, false, [], "GitHub quota sampling off");
   }
-  const q = evaluateQuotaHeadroom(b.githubQuota, {
-    coreRemainingPct: t.githubCoreRemainingPct,
-    stalenessMs: t.githubQuotaStaleMs,
-  }, b.now);
+  const q = evaluateQuotaHeadroom(
+    b.githubQuota,
+    {
+      coreRemainingPct: t.githubCoreRemainingPct,
+      stalenessMs: t.githubQuotaStaleMs,
+    },
+    b.now
+  );
   if (q.state === "unknown") {
-    return invariant(true, 0, false, [], q.stale ? "GitHub quota snapshot stale" : "no GitHub quota snapshot");
+    return invariant(
+      true,
+      0,
+      false,
+      [],
+      q.stale ? "GitHub quota snapshot stale" : "no GitHub quota snapshot"
+    );
   }
   const note = `GitHub core quota ${q.remaining}/${q.limit} (${q.remainingPct.toFixed(1)}%) remaining; resets ${q.resetAt ?? "unknown"}`;
   if (b.githubQuotaMode !== "enforce") return invariant(true, 0, false, [], note);
@@ -883,18 +915,40 @@ function checkRateLimitHeadroom(b, t) {
 function checkAccountUsageHeadroom(b) {
   const rl = b.ring?.accountRatelimit;
   if (!rl) {
-    return invariant(true, 0, false, [], "no out-of-band account usage signal (subscription telemetry absent)");
+    return invariant(
+      true,
+      0,
+      false,
+      [],
+      "no out-of-band account usage signal (subscription telemetry absent)"
+    );
   }
   // Derived here rather than read off the ring: the ring is raw sampled telemetry
   // (CAT-40 locks that passthrough with a test), so the cliff judgment lives here.
   const near = deriveNearCliff(rl);
-  const values = [rl.fiveHourPct, rl.sevenDayPct].filter((n) => typeof n === "number" && Number.isFinite(n));
+  const values = [rl.fiveHourPct, rl.sevenDayPct].filter(
+    (n) => typeof n === "number" && Number.isFinite(n)
+  );
   if (values.length === 0) {
     return invariant(true, 0, false, [], "account usage sample carries no utilization data");
   }
   const pct = values.length ? Math.max(...values) : 0;
   const resetsAt = rl.sevenDayResetsAt ?? rl.fiveHourResetsAt ?? null;
-  return invariant(!near, near ? 1 : 0, true, near ? ["account-usage"] : [], near ? `account at ${pct}% utilization — resets ${resetsAt ?? "unknown"}` : `account usage headroom ok (${pct}%)`, { fiveHourPct: rl.fiveHourPct ?? null, sevenDayPct: rl.sevenDayPct ?? null, resetsAt, nearCliffPct: NEAR_CLIFF_PCT });
+  return invariant(
+    !near,
+    near ? 1 : 0,
+    true,
+    near ? ["account-usage"] : [],
+    near
+      ? `account at ${pct}% utilization — resets ${resetsAt ?? "unknown"}`
+      : `account usage headroom ok (${pct}%)`,
+    {
+      fiveHourPct: rl.fiveHourPct ?? null,
+      sevenDayPct: rl.sevenDayPct ?? null,
+      resetsAt,
+      nearCliffPct: NEAR_CLIFF_PCT,
+    }
+  );
 }
 
 // #6 — stranded node (mini-2 class): a rostered host that HRW-owns a share of
@@ -907,7 +961,11 @@ function checkStrandedNode(b) {
   const ownedByHost = new Map();
   for (const [id] of b.ticketsById) {
     let owner;
-    try { owner = b.ownerForTicket(id, b.roster); } catch { owner = null; }
+    try {
+      owner = b.ownerForTicket(id, b.roster);
+    } catch {
+      owner = null;
+    }
     if (!owner) continue;
     ownedByHost.set(owner, (ownedByHost.get(owner) ?? 0) + 1);
   }
@@ -932,7 +990,7 @@ function checkStrandedNode(b) {
       ? `node(s) stranded (own work, reconcile failing): ${flagged.join(", ")}`
       : haveSignal
         ? "all rostered nodes participating"
-        : "no reconcile-health signal → peer liveness not observable",
+        : "no reconcile-health signal → peer liveness not observable"
   );
 }
 
@@ -1029,7 +1087,13 @@ const WEDGE_SKIP_REASONS = new Set(["all-candidates-cooldown", "act-error", "no-
 // deduped Gherkin ticket is C3/C4. C2's job is DETECT + SURFACE.
 function checkActuationLiveness(b, t) {
   if (b.mode !== "enforce") {
-    return invariant(true, 0, false, [], "actuation liveness observable only when the host is currently enforce");
+    return invariant(
+      true,
+      0,
+      false,
+      [],
+      "actuation liveness observable only when the host is currently enforce"
+    );
   }
   const K = t.actuationLivenessScans;
   const scans = (b.ring?.boardScans ?? []).filter((s) => s.mode === "enforce");
@@ -1039,7 +1103,7 @@ function checkActuationLiveness(b, t) {
       0,
       false,
       [],
-      `insufficient enforce board-scan history (${scans.length}/${K}) → actuation liveness not observable`,
+      `insufficient enforce board-scan history (${scans.length}/${K}) → actuation liveness not observable`
     );
   }
   const recent = scans.slice(-K);
@@ -1053,7 +1117,7 @@ function checkActuationLiveness(b, t) {
       0,
       false,
       [],
-      `enforce scan window not recent/contiguous (>${Math.round(windowMs / 60_000)}m span or missing ts) → actuation liveness not observable`,
+      `enforce scan window not recent/contiguous (>${Math.round(windowMs / 60_000)}m span or missing ts) → actuation liveness not observable`
     );
   }
   // A dispatch anywhere in the window clears it; otherwise EVERY scan must be an
@@ -1075,7 +1139,7 @@ function checkActuationLiveness(b, t) {
     [], // fleet/host-scoped anomaly, no per-ticket flagged list
     wedged
       ? `${K} consecutive enforce scans proposed moves but dispatched nothing → actuation wedged (propose-forever/dispatch-never)`
-      : "board-health actuation live (recent scans dispatched or had nothing actionable)",
+      : "board-health actuation live (recent scans dispatched or had nothing actionable)"
   );
 }
 
@@ -1106,7 +1170,13 @@ function checkActuationLiveness(b, t) {
 function checkUnownedInFlight(b, t) {
   const tickets = b?.ticketsById;
   if (!(tickets instanceof Map) || tickets.size === 0) {
-    return invariant(true, 0, false, [], "no ticket descriptors → unowned-in-flight not observable");
+    return invariant(
+      true,
+      0,
+      false,
+      [],
+      "no ticket descriptors → unowned-in-flight not observable"
+    );
   }
   const nowMs = Number.isFinite(b?.now) ? b.now : Date.now();
   const limit = t?.unownedInFlightMs ?? DEFAULT_THRESHOLDS.unownedInFlightMs;
@@ -1119,7 +1189,7 @@ function checkUnownedInFlight(b, t) {
   // cohort already uses, and the scheduler's phantom-directory logic likewise treats a
   // `complete` signal as inert rather than as real pipeline work.
   const hasLiveSignal = new Set(
-    b.signals?.filter((s) => s?.ticket && isLiveWorkerStatus(s.status)).map((s) => s.ticket) ?? [],
+    b.signals?.filter((s) => s?.ticket && isLiveWorkerStatus(s.status)).map((s) => s.ticket) ?? []
   );
   const prMap = b.prStatusMap instanceof Map ? b.prStatusMap : null;
   const flagged = [];
@@ -1136,7 +1206,11 @@ function checkUnownedInFlight(b, t) {
     // open. Resolve the exact (repo, number) the way the sibling PR cohorts do.
     const prNum = prNumberOf(d);
     if (prNum != null && prMap) {
-      const pr = lookupPrStatus(prMap, prNum, b.repoForTicket ? safeRepoOf(b.repoForTicket, id) : null);
+      const pr = lookupPrStatus(
+        prMap,
+        prNum,
+        b.repoForTicket ? safeRepoOf(b.repoForTicket, id) : null
+      );
       if (pr && pr.ambiguous) continue; // cannot disambiguate → spare it
       if (pr && String(pr.status).toLowerCase() === "open") continue;
     }
@@ -1150,7 +1224,10 @@ function checkUnownedInFlight(b, t) {
     const ts = tsMillis(updatedAt);
     // Fail SAFE on an unreadable timestamp: without an age we cannot prove
     // staleness, and flagging on "unknown" would re-dispatch fresh work.
-    if (!Number.isFinite(ts)) { unobservableAges++; continue; }
+    if (!Number.isFinite(ts)) {
+      unobservableAges++;
+      continue;
+    }
     if (nowMs - ts >= limit) flagged.push(id);
   }
   return invariant(
@@ -1161,7 +1238,7 @@ function checkUnownedInFlight(b, t) {
     flagged.length === 0
       ? "no unowned in-flight tickets"
       : `${flagged.length} ticket(s) assert an in-flight state with no worker and no open PR past ${Math.round(limit / 3_600_000)}h`,
-    { unobservableAges, thresholdMs: limit },
+    { unobservableAges, thresholdMs: limit }
   );
 }
 
@@ -1172,8 +1249,11 @@ function checkUnownedInFlight(b, t) {
 // absent → restart-fresh; salvage NOT yet checked → unknown-salvage (held).
 export function classifyRevivalRoute(evidence = {}) {
   if (evidence.openPr) {
-    return { route: "pr-not-merged", dispatchable: true,
-      rationale: "open PR found — route through existing pr-not-merged remediation" };
+    return {
+      route: "pr-not-merged",
+      dispatchable: true,
+      rationale: "open PR found — route through existing pr-not-merged remediation",
+    };
   }
   // CTL-1644 (Codex P2 round 3): require an EXPLICIT negative local-salvage result
   // (worktreeUnpushed === false), not merely falsy. If the remote probe succeeded
@@ -1182,12 +1262,21 @@ export function classifyRevivalRoute(evidence = {}) {
   // discarding unpushed local commits that actually need the held `adopt` route.
   // Absent local evidence falls through to the unknown-salvage guard below (held).
   if (evidence.remoteBranchExists && evidence.worktreeUnpushed === false) {
-    return { route: "resume-from-remote", dispatchable: true,
-      rationale: "remote branch exists, no unpushed local — seed a fresh worktree from origin/<ticket> (CTL-1640)" };
+    return {
+      route: "resume-from-remote",
+      dispatchable: true,
+      rationale:
+        "remote branch exists, no unpushed local — seed a fresh worktree from origin/<ticket> (CTL-1640)",
+    };
   }
   if (evidence.worktreeUnpushed) {
-    return { route: "adopt", dispatchable: false, blockedBy: "CTL-1642",
-      rationale: "local worktree with unpushed commits — adopt orphaned worktree (CTL-1642, not yet implemented)" };
+    return {
+      route: "adopt",
+      dispatchable: false,
+      blockedBy: "CTL-1642",
+      rationale:
+        "local worktree with unpushed commits — adopt orphaned worktree (CTL-1642, not yet implemented)",
+    };
   }
   // CTL-1644 (Codex P1): restart-fresh re-admits the ticket to Todo — destructive
   // if it actually had a pushed branch or unpushed local commits. The Phase-2
@@ -1200,11 +1289,19 @@ export function classifyRevivalRoute(evidence = {}) {
   const salvageChecked =
     evidence.remoteBranchExists !== undefined && evidence.worktreeUnpushed !== undefined;
   if (!salvageChecked) {
-    return { route: "unknown-salvage", dispatchable: false, blockedBy: "CTL-1644-phase3",
-      rationale: "salvage evidence not yet populated (remoteBranchExists/worktreeUnpushed unwired until Phase 3) — cannot prove no salvageable state; hold rather than restart-fresh" };
+    return {
+      route: "unknown-salvage",
+      dispatchable: false,
+      blockedBy: "CTL-1644-phase3",
+      rationale:
+        "salvage evidence not yet populated (remoteBranchExists/worktreeUnpushed unwired until Phase 3) — cannot prove no salvageable state; hold rather than restart-fresh",
+    };
   }
-  return { route: "restart-fresh", dispatchable: true,
-    rationale: "no salvageable state — re-admit the ticket to Todo for a fresh dispatch" };
+  return {
+    route: "restart-fresh",
+    dispatchable: true,
+    rationale: "no salvageable state — re-admit the ticket to Todo for a fresh dispatch",
+  };
 }
 
 // CTL-1644: detect HRW-owned mid-pipeline tickets with no actuation past a
@@ -1235,8 +1332,14 @@ function checkStrandedMidPipeline(b, t) {
   // persisted dir as NOT-actuated in Phase 2 would risk restart-freshing a live
   // worker mid-run — the more dangerous error — so that exemption is intentional.)
   const hasLiveSignal = new Set(
-    b.signals?.filter((s) => s?.ticket && isLiveWorkerStatus(s.status)
-      && !(Number.isFinite(s.ageMs) && s.ageMs > limit)).map((s) => s.ticket) ?? [],
+    b.signals
+      ?.filter(
+        (s) =>
+          s?.ticket &&
+          isLiveWorkerStatus(s.status) &&
+          !(Number.isFinite(s.ageMs) && s.ageMs > limit)
+      )
+      .map((s) => s.ticket) ?? []
   );
   const flagged = [];
   const classified = {};
@@ -1248,7 +1351,11 @@ function checkStrandedMidPipeline(b, t) {
     // HRW self-ownership: only flag tickets this host owns (foreign owners handle theirs).
     if (b.ownerForTicket && b.self) {
       let owner = null;
-      try { owner = b.ownerForTicket(id, b.roster); } catch { owner = null; }
+      try {
+        owner = b.ownerForTicket(id, b.roster);
+      } catch {
+        owner = null;
+      }
       if (owner && owner !== b.self) continue;
     }
     // needs-human LABEL exemption — mirror checkFrozenNeedsHuman's label check.
@@ -1259,21 +1366,30 @@ function checkStrandedMidPipeline(b, t) {
     if (hasLiveSignal.has(id)) continue;
     // No evidence row for this ticket ⇒ we cannot prove it is stranded. Fail safe.
     const e = evidence.get(id);
-    if (!e) { unobservableAges++; continue; }
+    if (!e) {
+      unobservableAges++;
+      continue;
+    }
     // Any actuation flag exempts the ticket.
     if (e.hasWorkerDir || e.hasLiveBg || e.hasFreshIntent) continue;
     const ts = tsMillis(d?.updatedAt ?? d?.updated_at ?? null);
-    if (!Number.isFinite(ts)) { unobservableAges++; continue; }
+    if (!Number.isFinite(ts)) {
+      unobservableAges++;
+      continue;
+    }
     if (nowMs - ts < limit) continue;
     flagged.push(id);
     classified[id] = classifyRevivalRoute(e);
   }
   return invariant(
-    flagged.length === 0, flagged.length, true, flagged,
+    flagged.length === 0,
+    flagged.length,
+    true,
+    flagged,
     flagged.length === 0
       ? "no stranded mid-pipeline tickets"
       : `${flagged.length} HRW-owned in-flight ticket(s) with no actuation past ${Math.round(limit / 3_600_000)}h`,
-    { classified, unobservableAges, thresholdMs: limit },
+    { classified, unobservableAges, thresholdMs: limit }
   );
 }
 
@@ -1304,7 +1420,7 @@ function checkPhantomMergedPr(b) {
     flagged,
     flagged.length
       ? `${flagged.length} ticket(s) in a PR state with an already-merged/deployed PR`
-      : "no phantom merged-PR tickets",
+      : "no phantom merged-PR tickets"
   );
 }
 
@@ -1324,7 +1440,7 @@ function checkOrphanedOpenPr(b, t) {
   // behind a dead/failed worker is exactly the orphaned case this cohort catches
   // — do NOT let a terminal-FAILURE signal mask it as "has a live worker".
   const liveTickets = new Set(
-    b.signals.filter((s) => s.ticket && isLiveWorkerStatus(s.status)).map((s) => s.ticket),
+    b.signals.filter((s) => s.ticket && isLiveWorkerStatus(s.status)).map((s) => s.ticket)
   );
   const flagged = [];
   for (const [id, d] of b.ticketsById) {
@@ -1367,7 +1483,10 @@ function checkOrphanedOpenPr(b, t) {
     flagged.length
       ? `${flagged.length} open PR(s) with no live worker past ${Math.round(t.orphanedPrAgeMs / 3_600_000)}h`
       : "no orphaned open PRs",
-    { caveat: "filter_state.updated_at is last-webhook, not last-PR-activity — verify with gh pr view" },
+    {
+      caveat:
+        "filter_state.updated_at is last-webhook, not last-PR-activity — verify with gh pr view",
+    }
   );
 }
 
@@ -1413,7 +1532,7 @@ function checkStalledPr(b, t) {
     flagged.length
       ? `${flagged.length} open PR(s) stalled on ${[...new Set(Object.values(reasons).flat())].join("/")}`
       : "no stalled open PRs",
-    { reasons, caveat: "durations are timer-stamped from live gh probes — verify with gh pr view" },
+    { reasons, caveat: "durations are timer-stamped from live gh probes — verify with gh pr view" }
   );
 }
 
@@ -1447,7 +1566,7 @@ function checkFrozenNeedsHuman(b, t) {
       ? `${flagged.length} needs-human ticket(s) frozen past ${Math.round(t.frozenNeedsHumanMs / 3_600_000)}h`
       : haveLabels
         ? "no frozen needs-human tickets"
-        : "no labels in cache → frozen needs-human not observable",
+        : "no labels in cache → frozen needs-human not observable"
   );
 }
 
@@ -1478,7 +1597,9 @@ function checkNeedsHumanPile(b) {
     flagged.length,
     true,
     flagged,
-    flagged.length ? `${flagged.length} worker(s) parked at needs-human/stalled` : "no needs-human/stalled workers",
+    flagged.length
+      ? `${flagged.length} worker(s) parked at needs-human/stalled`
+      : "no needs-human/stalled workers"
   );
 }
 
@@ -1532,8 +1653,7 @@ export function decideBoardHealth(invariants, boardState) {
   // (not sanctioned, live + non-terminal) — a since-terminal / sanctioned defer must not
   // make the gate proceed (it would proceed then no-anchor). Same helper selectAnchorCandidates uses.
   const deferred = eligibleDeferredAnchors(boardState);
-  const hasActionableWork =
-    moves.tier1.length > 0 || moves.tier2.length > 0 || deferred.length > 0;
+  const hasActionableWork = moves.tier1.length > 0 || moves.tier2.length > 0 || deferred.length > 0;
 
   // Gate 1 — nothing actionable (all green, or every failure suppressed/escalate-only,
   // and no deferred work) → skip the holistic DISPATCH (no LLM thrash). CTL-1432 (Codex
@@ -1546,7 +1666,7 @@ export function decideBoardHealth(invariants, boardState) {
       observableFailed.length === 0 ? "all-green" : "no-actionable-moves",
       invariantsFailed,
       moves,
-      sanctioned,
+      sanctioned
     );
   }
   // Gate 2 — actionable work but no free slot to dispatch a fix → skip.
@@ -1604,30 +1724,60 @@ export function proposeMoves(invariants, _b) {
     tier1.push({ move: "kick-dispatch", rationale: invariants.dispatchLiveness.note });
   }
   for (const t of invariants.workerAge?.flagged ?? []) {
-    if (!invariants.workerAge.ok && !sanction(t)) tier1.push({ ticket: t, move: "nudge", rationale: "worker past phase-normal age" });
+    if (!invariants.workerAge.ok && !sanction(t))
+      tier1.push({ ticket: t, move: "nudge", rationale: "worker past phase-normal age" });
   }
-  if (invariants.cacheCoherence && invariants.cacheCoherence.observable && !invariants.cacheCoherence.ok) {
+  if (
+    invariants.cacheCoherence &&
+    invariants.cacheCoherence.observable &&
+    !invariants.cacheCoherence.ok
+  ) {
     tier1.push({ move: "note-cache-drift", rationale: invariants.cacheCoherence.note });
   }
   // CTL-1157: the most-actionable stuck work — phantom merged-PR tickets (judge
   // Done vs reopen) and orphaned open PRs (finish or close) — is tier1 (highest
   // anchor priority); the status-based needs-human pile is the untyped catch-all.
   for (const t of invariants.phantomMergedPr?.flagged ?? []) {
-    if (!invariants.phantomMergedPr.ok && !sanction(t)) tier1.push({ ticket: t, move: "judge-done-or-reopen", rationale: "PR merged/deployed but ticket still in a PR/in-review state" });
+    if (!invariants.phantomMergedPr.ok && !sanction(t))
+      tier1.push({
+        ticket: t,
+        move: "judge-done-or-reopen",
+        rationale: "PR merged/deployed but ticket still in a PR/in-review state",
+      });
   }
   for (const t of invariants.orphanedOpenPr?.flagged ?? []) {
-    if (!invariants.orphanedOpenPr.ok && !sanction(t)) tier1.push({ ticket: t, move: "finish-or-close-pr", rationale: "open PR with no live worker past age" });
+    if (!invariants.orphanedOpenPr.ok && !sanction(t))
+      tier1.push({
+        ticket: t,
+        move: "finish-or-close-pr",
+        rationale: "open PR with no live worker past age",
+      });
   }
   for (const t of invariants.needsHumanPile?.flagged ?? []) {
-    if (!invariants.needsHumanPile.ok && !sanction(t)) tier1.push({ ticket: t, move: "holistic-triage", rationale: "worker parked at needs-human/stalled" });
+    if (!invariants.needsHumanPile.ok && !sanction(t))
+      tier1.push({
+        ticket: t,
+        move: "holistic-triage",
+        rationale: "worker parked at needs-human/stalled",
+      });
   }
   for (const t of invariants.blockedTree?.flagged ?? []) {
-    if (!invariants.blockedTree.ok && !sanction(t)) tier2.push({ ticket: t, move: "re-dispatch-blocker", rationale: "blocked by unscheduled/stuck blocker" });
+    if (!invariants.blockedTree.ok && !sanction(t))
+      tier2.push({
+        ticket: t,
+        move: "re-dispatch-blocker",
+        rationale: "blocked by unscheduled/stuck blocker",
+      });
   }
   // CTL-1157: a needs-human-LABELLED ticket frozen past 48h has already been
   // escalated once → tier2 (review, lower urgency than the actionable PR work).
   for (const t of invariants.frozenNeedsHuman?.flagged ?? []) {
-    if (!invariants.frozenNeedsHuman.ok && !sanction(t)) tier2.push({ ticket: t, move: "review-needs-human", rationale: "needs-human label frozen past threshold" });
+    if (!invariants.frozenNeedsHuman.ok && !sanction(t))
+      tier2.push({
+        ticket: t,
+        move: "review-needs-human",
+        rationale: "needs-human label frozen past threshold",
+      });
   }
   // CTL-1475: tier2 = ANCHORABLE, so the delegate actually sweeps these up.
   //
@@ -1652,7 +1802,11 @@ export function proposeMoves(invariants, _b) {
   const strandedClassified = invariants.strandedMidPipeline?.classified ?? {};
   for (const t of invariants.unownedInFlight?.flagged ?? []) {
     if (!invariants.unownedInFlight.ok && !sanction(t) && !strandedClassified[t]) {
-      tier2.push({ ticket: t, move: "recover-unowned-in-flight", rationale: "Linear state claims in-flight but there is no worker and no open PR" });
+      tier2.push({
+        ticket: t,
+        move: "recover-unowned-in-flight",
+        rationale: "Linear state claims in-flight but there is no worker and no open PR",
+      });
     }
   }
   // CTL-1644: one tier2 route move per stranded ticket — the delegate picks the
@@ -1670,19 +1824,32 @@ export function proposeMoves(invariants, _b) {
     if (!invariants.strandedMidPipeline.ok && !sanction(t)) {
       const cls = strandedClassified[t] ?? {};
       if (cls.dispatchable === false) continue; // held — surface only, never anchor
-      tier2.push({ ticket: t, move: "route-stranded-mid-pipeline",
-        route: cls.route, rationale: cls.rationale ?? "stranded mid-pipeline ticket classified for revival" });
+      tier2.push({
+        ticket: t,
+        move: "route-stranded-mid-pipeline",
+        route: cls.route,
+        rationale: cls.rationale ?? "stranded mid-pipeline ticket classified for revival",
+      });
     }
   }
   // CTL-1608: a PR that stopped progressing (review/CI/no-push) is actionable
   // work → tier1, alongside the orphaned-PR cohort. Sanctioned latches suppressed.
   for (const t of invariants.stalledPr?.flagged ?? []) {
     if (!invariants.stalledPr.ok && !sanction(t)) {
-      tier1.push({ ticket: t, move: "nudge-stalled-pr", rationale: "open PR stopped progressing (review/CI/no-push) past threshold" });
+      tier1.push({
+        ticket: t,
+        move: "nudge-stalled-pr",
+        rationale: "open PR stopped progressing (review/CI/no-push) past threshold",
+      });
     }
   }
   for (const h of invariants.strandedNode?.flagged ?? []) {
-    if (!invariants.strandedNode.ok) tier3.push({ host: h, move: "escalate-stranded-node", rationale: "rostered node owns work but reconcile is failing" });
+    if (!invariants.strandedNode.ok)
+      tier3.push({
+        host: h,
+        move: "escalate-stranded-node",
+        rationale: "rostered node owns work but reconcile is failing",
+      });
   }
   for (const h of invariants.nodeProductivity?.flagged ?? []) {
     if (!invariants.nodeProductivity.ok) tier3.push({
@@ -1692,7 +1859,12 @@ export function proposeMoves(invariants, _b) {
     });
   }
   for (const p of invariants.projectSilence?.flagged ?? []) {
-    if (!invariants.projectSilence.ok) tier3.push({ project: p, move: "escalate-project-silence", rationale: "no movement in expected cadence" });
+    if (!invariants.projectSilence.ok)
+      tier3.push({
+        project: p,
+        move: "escalate-project-silence",
+        rationale: "no movement in expected cadence",
+      });
   }
   return { tier1, tier2, tier3 };
 }
@@ -1729,7 +1901,11 @@ export function proposeMoves(invariants, _b) {
 // of foreign-failover. N=1 (no roster / no ownerForTicket / !multiHost) ⇒ owns()
 // ≡ true and strandedOrDeadHosts is empty ⇒ the foreign branch is unreachable ⇒
 // byte-identical to today.
-export function selectAnchorCandidates(moves, board, { holistic = false, strandedOrDeadHosts = new Set() } = {}) {
+export function selectAnchorCandidates(
+  moves,
+  board,
+  { holistic = false, strandedOrDeadHosts = new Set() } = {}
+) {
   const multiHost = !!(board && board.multiHost && typeof board.ownerForTicket === "function");
   const baseOwns = makeOwnsFilter(board);
   const owns = (ticket) => !!ticket && baseOwns(ticket);
@@ -1739,9 +1915,10 @@ export function selectAnchorCandidates(moves, board, { holistic = false, strande
   // A ticket with a completed triage artifact and a stuck post-triage phase is
   // NOT in this set and remains anchor-eligible. With the default board shape
   // (no hasTriageArtifact seam bound), the set is empty and this is a no-op.
-  const excluded = board?.triageLaunchFailureOnlyTickets instanceof Set
-    ? board.triageLaunchFailureOnlyTickets
-    : new Set();
+  const excluded =
+    board?.triageLaunchFailureOnlyTickets instanceof Set
+      ? board.triageLaunchFailureOnlyTickets
+      : new Set();
   const out = [];
   const seen = new Set();
   const add = (t) => {
@@ -1761,7 +1938,11 @@ export function selectAnchorCandidates(moves, board, { holistic = false, strande
   // excludes Done/removed via getBoard's includeRemoved:false), so a stale defer marker
   // whose ticket has since gone terminal is dropped rather than re-anchored.
   for (const t of eligibleDeferredAnchors(board)) add(t); // already HRW-owns-filtered
-  for (const e of (board?.eligible ?? []).map((x) => x && x.id).filter(Boolean).filter(owns)) add(e);
+  for (const e of (board?.eligible ?? [])
+    .map((x) => x && x.id)
+    .filter(Boolean)
+    .filter(owns))
+    add(e);
   // holistic foreign-failover: a flagged tier1/tier2 ticket this host does NOT own,
   // ONLY when its owner is provably dead/stranded. Appended AFTER all self-owned.
   if (holistic && multiHost) {
@@ -1879,7 +2060,7 @@ export function buildBoardContext(boardState, invariants) {
       ownedTickets: invariants.nodeProductivity?.unproductive?.[host]?.ownedTickets ?? [],
     })),
     invariants: Object.fromEntries(
-      Object.entries(invariants).map(([k, v]) => [k, { ok: v.ok, failed: v.failed }]),
+      Object.entries(invariants).map(([k, v]) => [k, { ok: v.ok, failed: v.failed }])
     ),
   };
 }
@@ -1956,8 +2137,9 @@ export function buildBoardScanEvent({ mode, invariants, decision, act = null, bo
       // stranded tickets — the anchor filter keeps these out of tier2Moves and
       // boardContext, so this is the only chartable signal that the cohort exists
       // but is being deliberately held (e.g. the whole Phase-2 unknown-salvage set).
-      strandedHeldCount: Object.values(invariants.strandedMidPipeline?.classified ?? {})
-        .filter((c) => c?.dispatchable === false).length,
+      strandedHeldCount: Object.values(invariants.strandedMidPipeline?.classified ?? {}).filter(
+        (c) => c?.dispatchable === false
+      ).length,
       // CTL-1607: per-host slot census so fleet capacity is visible off-host
       // (computed above; occupancy-derived in_use, delegate-debited + gate-collapsed
       // free). A fleet consumer SUMs slotFree directly — never capacity − in_use:
@@ -1971,7 +2153,10 @@ export function buildBoardScanEvent({ mode, invariants, decision, act = null, bo
       githubCoreRemaining: githubQuota?.remaining ?? null,
       githubCoreRemainingPct: githubQuota?.remainingPct ?? null,
       invariants: Object.fromEntries(
-        Object.entries(invariants).map(([k, v]) => [k, { ok: v.ok, failed: v.failed, observable: v.observable }]),
+        Object.entries(invariants).map(([k, v]) => [
+          k,
+          { ok: v.ok, failed: v.failed, observable: v.observable },
+        ])
       ),
       // ── rosters/proposals: stay in body.payload, NEVER promoted (cardinality) ──
       flagged: dedupeFlagged(invariants),
@@ -2054,7 +2239,10 @@ export function boardHealthPass({
     // so the expensive whole-log heartbeat read behind the daemon's thunk is paid
     // only on a tick that actually proceeds, not on all ~59 throttled ticks between
     // 5-minute passes. Arrays still work unchanged (resolveDeadHosts is a no-op).
-    getPrStatusMap, deadHosts: resolveDeadHosts(deadHosts), mode, now,
+    getPrStatusMap,
+    deadHosts: resolveDeadHosts(deadHosts),
+    mode,
+    now,
     getDeferredBoardHealthTickets, // CTL-1432 (B2). CTL-1552: sanctionedNeedsHuman removed.
     getStrandedEvidence, // CTL-1644: per-ticket evidence seam (empty-Map default if unbound)
     getStalledPrState, // CTL-1608: stalled-PR stamp seam (empty-Map default if unbound)
@@ -2096,7 +2284,11 @@ export function boardHealthPass({
   if (mode === "enforce" && typeof act === "function") {
     if (dec.gate.decision !== "proceed") {
       // the gate held (all-green / no-actionable-moves / no-free-slots / rate-limit-cliff)
-      actOutcome = { dispatched: false, anchor: null, skippedReason: dec.gate.reason ?? "gate-hold" };
+      actOutcome = {
+        dispatched: false,
+        anchor: null,
+        skippedReason: dec.gate.reason ?? "gate-hold",
+      };
     } else {
       try {
         // CTL-1157 (MUST-FIX 1+2): compute the ORDERED holistic candidate list. The
@@ -2110,23 +2302,32 @@ export function boardHealthPass({
           ...(invariants.strandedNode?.flagged ?? []),
           ...(board.deadHosts ?? []),
         ]);
-        const candidates = selectAnchorCandidates(dec.moves, board, { holistic: true, strandedOrDeadHosts });
+        const candidates = selectAnchorCandidates(dec.moves, board, {
+          holistic: true,
+          strandedOrDeadHosts,
+        });
         const anchor = candidates[0] ?? null;
         if (!anchor) {
-          log({ reason: "no-owned-anchor" }, "board-health: proceed but no actionable ticket anchor — no holistic dispatch this scan");
+          log(
+            { reason: "no-owned-anchor" },
+            "board-health: proceed but no actionable ticket anchor — no holistic dispatch this scan"
+          );
           actOutcome = { dispatched: false, anchor: null, skippedReason: "no-owned-anchor" };
         } else {
           const boardContext = buildBoardContext(board, invariants);
           actResult = act({ anchor, candidates, boardContext, decision: dec, board }) ?? null;
-          log({ anchor, candidates: candidates.length, dispatched: actResult?.dispatched ?? null }, "board-health: holistic recovery-pass delegate actuated");
+          log(
+            { anchor, candidates: candidates.length, dispatched: actResult?.dispatched ?? null },
+            "board-health: holistic recovery-pass delegate actuated"
+          );
           const dispatched = actResult?.dispatched === true;
           actOutcome = {
             dispatched,
             // the ACTUALLY-dispatched candidate (holisticBoardHealthAct may skip the
             // [0] anchor and dispatch a later one); fall back to the intended anchor.
             anchor: (dispatched ? actResult?.candidate : null) ?? anchor,
-            skippedReason: dispatched ? null : actResult?.reason ?? "all-candidates-cooldown",
-            skippedReasonNoClock: dispatched ? false : (actResult?.latchedNoClock === true), // CTL-1610
+            skippedReason: dispatched ? null : (actResult?.reason ?? "all-candidates-cooldown"),
+            skippedReasonNoClock: dispatched ? false : actResult?.latchedNoClock === true, // CTL-1610
           };
         }
       } catch (err) {

--- a/plugins/dev/scripts/execution-core/board-health.mjs
+++ b/plugins/dev/scripts/execution-core/board-health.mjs
@@ -371,7 +371,14 @@ function extractBlockers(descriptor) {
 // deriveRing — distill the bounded recent-event tail into the few out-of-band
 // signals the invariants need. Best-effort: an event class that isn't present
 // yields null/empty, and the dependent invariant degrades to observable:false.
-function deriveRing(events, nowMs, self) {
+export const NEAR_CLIFF_PCT = Number(process.env.CATALYST_NEAR_CLIFF_PCT) || 90;
+export function deriveNearCliff(payload) {
+  if (payload?.nearCliff != null || payload?.near_cliff != null) return !!(payload.nearCliff ?? payload.near_cliff);
+  const values = [payload?.fiveHourPct, payload?.sevenDayPct].filter((n) => typeof n === "number" && Number.isFinite(n));
+  return values.length > 0 && Math.max(...values) >= NEAR_CLIFF_PCT;
+}
+
+export function deriveRing(events, nowMs, self) {
   const ring = {
     recentDispatchTs: null,
     cacheReconcile: null,
@@ -402,6 +409,9 @@ function deriveRing(events, nowMs, self) {
     } else if (/account\.ratelimit|ratelimit\.sampled/i.test(name)) {
       // Anthropic subscription telemetry only. GitHub core quota arrives through
       // the dedicated githubQuota snapshot seam below, never through this ring.
+      // The ring stays a faithful passthrough of the sampled payload — the
+      // usage-limit cliff is DERIVED in checkAccountUsageHeadroom (CAT-58), not
+      // synthesized here, so this stays raw telemetry.
       ring.accountRatelimit = { ...payload };
     } else if (/reconcile\.failing/i.test(name)) {
       const team = payload.team ?? name.split(".").pop();
@@ -713,6 +723,10 @@ export function evaluateInvariants(boardState, { thresholds = DEFAULT_THRESHOLDS
       // gated like its siblings so the off set stays byte-identical.
       stalledPr: () => checkStalledPr(boardState, thresholds),
       nodeProductivity: () => checkNodeProductivity(boardState, thresholds),
+      // CAT-58: the account's own subscription usage-limit cliff (5h / 7d), the
+      // condition that makes every Claude-lane re-dispatch futile until reset.
+      // Cohort-gated like its siblings so the off set stays byte-identical.
+      accountUsageHeadroom: () => checkAccountUsageHeadroom(boardState),
     });
   }
   const out = {};
@@ -858,6 +872,26 @@ function checkRateLimitHeadroom(b, t) {
   if (b.githubQuotaMode !== "enforce") return invariant(true, 0, false, [], note);
   const failed = q.state === "low" || q.state === "exhausted";
   return invariant(!failed, failed ? 1 : 0, true, [], note);
+}
+
+// #5b — Anthropic ACCOUNT usage-limit headroom (CAT-58). Distinct from #5: that
+// one reads the GitHub core REST quota snapshot, this one reads the account's own
+// 5-hour / 7-day subscription utilization off the `account.ratelimit` ring. Both
+// can wedge the fleet and they reset independently, so they are separate
+// invariants rather than one overloaded `rateLimitHeadroom` key. Cohort-gated in
+// evaluateInvariants so the `off` invariant set stays byte-identical to main.
+function checkAccountUsageHeadroom(b) {
+  const rl = b.ring?.accountRatelimit;
+  if (!rl) {
+    return invariant(true, 0, false, [], "no out-of-band account usage signal (subscription telemetry absent)");
+  }
+  // Derived here rather than read off the ring: the ring is raw sampled telemetry
+  // (CAT-40 locks that passthrough with a test), so the cliff judgment lives here.
+  const near = deriveNearCliff(rl);
+  const values = [rl.fiveHourPct, rl.sevenDayPct].filter((n) => typeof n === "number" && Number.isFinite(n));
+  const pct = values.length ? Math.max(...values) : 0;
+  const resetsAt = rl.sevenDayResetsAt ?? rl.fiveHourResetsAt ?? null;
+  return invariant(!near, near ? 1 : 0, true, near ? ["account-usage"] : [], near ? `account at ${pct}% utilization — resets ${resetsAt ?? "unknown"}` : `account usage headroom ok (${pct}%)`, { fiveHourPct: rl.fiveHourPct ?? null, sevenDayPct: rl.sevenDayPct ?? null, resetsAt, nearCliffPct: NEAR_CLIFF_PCT });
 }
 
 // #6 — stranded node (mini-2 class): a rostered host that HRW-owns a share of
@@ -1517,9 +1551,15 @@ export function decideBoardHealth(invariants, boardState) {
     return decision("skip", "no-free-slots", invariantsFailed, emptyMoves(), sanctioned);
   }
   // Gate 3 — near a rate-limit cliff → acting now risks 429s → skip (and obey it).
+  // Two independent cliffs gate here: the GitHub core REST quota (CAT-40) and the
+  // account's own subscription usage limit (CAT-58). Either one makes acting futile.
   const rl = invariants.rateLimitHeadroom;
   if (rl && rl.observable && !rl.ok) {
     return decision("skip", "rate-limit-cliff", invariantsFailed, emptyMoves(), sanctioned);
+  }
+  const au = invariants.accountUsageHeadroom;
+  if (au && au.observable && !au.ok) {
+    return decision("skip", "account-usage-cliff", invariantsFailed, emptyMoves(), sanctioned);
   }
   // Gate 4 — actionable work + headroom → proceed.
   const reason =

--- a/plugins/dev/scripts/execution-core/board-health.mjs
+++ b/plugins/dev/scripts/execution-core/board-health.mjs
@@ -889,6 +889,9 @@ function checkAccountUsageHeadroom(b) {
   // (CAT-40 locks that passthrough with a test), so the cliff judgment lives here.
   const near = deriveNearCliff(rl);
   const values = [rl.fiveHourPct, rl.sevenDayPct].filter((n) => typeof n === "number" && Number.isFinite(n));
+  if (values.length === 0) {
+    return invariant(true, 0, false, [], "account usage sample carries no utilization data");
+  }
   const pct = values.length ? Math.max(...values) : 0;
   const resetsAt = rl.sevenDayResetsAt ?? rl.fiveHourResetsAt ?? null;
   return invariant(!near, near ? 1 : 0, true, near ? ["account-usage"] : [], near ? `account at ${pct}% utilization — resets ${resetsAt ?? "unknown"}` : `account usage headroom ok (${pct}%)`, { fiveHourPct: rl.fiveHourPct ?? null, sevenDayPct: rl.sevenDayPct ?? null, resetsAt, nearCliffPct: NEAR_CLIFF_PCT });

--- a/plugins/dev/scripts/execution-core/board-health.test.mjs
+++ b/plugins/dev/scripts/execution-core/board-health.test.mjs
@@ -28,6 +28,7 @@ import {
   eligibleDeferredAnchors,
   makeOwnsFilter,
   resolveRosterSeam,
+  deriveRing,
 } from "./board-health.mjs";
 // CTL-1435 (Codex P1/P2): round-trip the REAL emit envelope so the ring test
 // exercises the production body.payload.details nesting + attribute promotion.
@@ -49,6 +50,16 @@ function quotaSnapshot({ remaining = 5000, sampledAt = new Date(NOW).toISOString
     sampledAt,
   };
 }
+
+// CAT-58: the account usage cliff is its OWN invariant (accountUsageHeadroom) —
+// `rateLimitHeadroom` belongs to CAT-40's GitHub core REST quota check.
+test("account usage headroom is derived from sampled utilization", () => {
+  const ring = deriveRing([{ "event.name": "account.ratelimit.sampled", payload: { sevenDayPct: 100, sevenDayResetsAt: "2026-08-10T17:59:59Z" } }]);
+  const inv = evaluateInvariants({ ring, mode: "enforce", ticketsById: new Map(), signals: [], eligible: [], capacity: { free: 0 }, now: NOW }).accountUsageHeadroom;
+  expect(inv.observable).toBe(true);
+  expect(inv.ok).toBe(false);
+  expect(inv).toMatchObject({ sevenDayPct: 100, resetsAt: "2026-08-10T17:59:59Z" });
+});
 
 // mkPrStatusMap — build the composite `Map<number, Map<repoKey, entry>>` shape
 // (CTL-1157, Codex #4) that broker-state.getAllPrStatuses now returns, from flat

--- a/plugins/dev/scripts/execution-core/board-health.test.mjs
+++ b/plugins/dev/scripts/execution-core/board-health.test.mjs
@@ -684,6 +684,30 @@ describe("decideBoardHealth — ordered gates, first match wins", () => {
     expect(d.gate.reason).toBe("rate-limit-cliff");
   });
 
+  test("Gate 3: failures + free slots + account usage cliff → skip/account-usage-cliff", () => {
+    const invs = { ...allGreen(), dispatchLiveness: inv(false, 1), accountUsageHeadroom: inv(false, 1, true, ["account-usage"]) };
+    const d = decideBoardHealth(invs, mkBoard({ capacity: { freeSlots: 4 } }));
+    expect(d.gate.decision).toBe("skip");
+    expect(d.gate.reason).toBe("account-usage-cliff");
+  });
+
+  test("Gate 3: an unobservable account usage invariant does not gate", () => {
+    const invs = { ...allGreen(), dispatchLiveness: inv(false, 1), accountUsageHeadroom: inv(false, 1, false) };
+    const d = decideBoardHealth(invs, mkBoard({ capacity: { freeSlots: 4 } }));
+    expect(d.gate.decision).toBe("proceed");
+  });
+
+  test("Gate 3: the GitHub cliff wins when both quota cliffs are tripped", () => {
+    const invs = {
+      ...allGreen(),
+      dispatchLiveness: inv(false, 1),
+      rateLimitHeadroom: inv(false, 1),
+      accountUsageHeadroom: inv(false, 1),
+    };
+    const d = decideBoardHealth(invs, mkBoard({ capacity: { freeSlots: 4 } }));
+    expect(d.gate.reason).toBe("rate-limit-cliff");
+  });
+
   test("Gate 4: real observable failures + headroom → proceed + tiered proposals", () => {
     const invs = { ...allGreen(), dispatchLiveness: inv(false, 1) };
     const d = decideBoardHealth(invs, mkBoard({ capacity: { freeSlots: 4 } }));

--- a/plugins/dev/scripts/execution-core/board-health.test.mjs
+++ b/plugins/dev/scripts/execution-core/board-health.test.mjs
@@ -61,6 +61,12 @@ test("account usage headroom is derived from sampled utilization", () => {
   expect(inv).toMatchObject({ sevenDayPct: 100, resetsAt: "2026-08-10T17:59:59Z" });
 });
 
+test("account usage headroom is unobservable without numeric utilization", () => {
+  const ring = { accountRatelimit: { fiveHourPct: null, sevenDayPct: null } };
+  const inv = evaluateInvariants({ ring, mode: "enforce", ticketsById: new Map(), signals: [], eligible: [], capacity: { free: 0 }, now: NOW }).accountUsageHeadroom;
+  expect(inv).toMatchObject({ ok: true, observable: false, note: "account usage sample carries no utilization data" });
+});
+
 // mkPrStatusMap — build the composite `Map<number, Map<repoKey, entry>>` shape
 // (CTL-1157, Codex #4) that broker-state.getAllPrStatuses now returns, from flat
 // {prNumber, repo, status, updatedAt} rows. Mirrors how the real reader nests

--- a/plugins/dev/scripts/execution-core/daemon.mjs
+++ b/plugins/dev/scripts/execution-core/daemon.mjs
@@ -1503,7 +1503,7 @@ export function startDaemon({
     // CTL-787: start the account-level rate-limit usage poller. Inside the same
     // try/catch so a throw triggers PID-file cleanup via stopDaemon.
     if (enableRatelimitPoller) {
-      _ratelimitPoller = startRatelimitPoller();
+      _ratelimitPoller = startRatelimitPoller({ orchDir });
     }
 
     // CTL-1654: _nodeClass / _isWorkerNode were resolved above (before the actuators)

--- a/plugins/dev/scripts/execution-core/daemon.mjs
+++ b/plugins/dev/scripts/execution-core/daemon.mjs
@@ -1159,6 +1159,7 @@ export function startDaemon({
       codexBootEligible: codexElig.eligible,
       sdkBootEligible,
       configPath,
+      orchDir,
       emitEvent: defaultAppendOperatorEvent,
       log,
     });

--- a/plugins/dev/scripts/execution-core/daemon.test.mjs
+++ b/plugins/dev/scripts/execution-core/daemon.test.mjs
@@ -797,18 +797,21 @@ describe("startDaemon", () => {
   // mirroring the CTL-685 memory-sampler wiring.
   test("starts the ratelimit-poller when enabled (CTL-787)", () => {
     let started = 0;
+    let pollerOptions = null;
     startDaemon({
       recover: () => {},
       startMonitor: () => {},
       startScheduler: () => {},
       watchRegistry: false,
-      startRatelimitPoller: () => {
+      startRatelimitPoller: (options) => {
         started++;
+        pollerOptions = options;
         return { stop: () => {} };
       },
       enableRatelimitPoller: true,
     });
     expect(started).toBe(1);
+    expect(pollerOptions?.orchDir).toBeTruthy();
   });
 
   test("skips the ratelimit-poller when disabled (CTL-787)", () => {

--- a/plugins/dev/scripts/execution-core/dispatch-usage-limit-fallback.test.mjs
+++ b/plugins/dev/scripts/execution-core/dispatch-usage-limit-fallback.test.mjs
@@ -27,6 +27,10 @@ test("a bg phase falls back to codex while bg is parked", () => {
         dispatched.push(executor);
         return { code: 0, args };
       },
+      // CAT-58 (Codex round 2, P1): the fallback now demands POSITIVE evidence. Inject the
+      // verdict so the test does not silently depend on whether the machine running it
+      // happens to have an authenticated codex CLI installed.
+      verifyCodexLane: () => true,
       emitEvent: (event) => events.push(event),
     });
     const result = fn({ ticket: "CAT-58", phase: "research" });
@@ -58,9 +62,83 @@ test("a parked bg phase is not dispatched when no healthy fallback exists", () =
       },
       emitEvent: (event) => events.push(event),
     });
-    expect(fn({ ticket: "CAT-58", phase: "research" })).toEqual({ code: 75, deferred: true, reason: "no-healthy-executor-lane" });
+    const result = fn({ ticket: "CAT-58", phase: "research" });
+    expect(result).toMatchObject({ code: 75, deferred: true, reason: "no-healthy-executor-lane" });
+    // CAT-58 (Codex round 2, P1): a parked lane with no fallback is a DEFERRAL, not a
+    // dispatch failure — callers keyed off `laneDeferred` must not retain approval
+    // sentinels and re-request dispatch on every tick for the whole cooldown.
+    expect(result.laneDeferred).toBe(true);
+    expect(result.lane).toBe("bg");
+    expect(result.retryAfter).toBe(Date.parse("2026-08-10T18:00:00Z"));
     expect(dispatched).toEqual([]);
     expect(events.some((event) => event["event.name"] === "execution-core.executor.no-healthy-lane")).toBe(true);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+// CAT-58 (Codex round 2, P1 "Verify Codex before using it as the fallback"): the keystone.
+// resolveCodexBootEligibility returns the SAME { eligible: true } both when codex was probed
+// and passed AND when nothing routes to codex so it probed nothing at all. On a normal bg-only
+// node the latter is the live case, so reading the sentinel as a healthy lane would reroute
+// every parked dispatch into an absent/unauthenticated codex — turning a clean deferral into
+// real dispatch failures and breaker trips. The fallback must demand a positive probe.
+test("the unverified codexBootEligible sentinel does NOT count as a healthy fallback lane", () => {
+  const dir = mkdtempSync(join(tmpdir(), "dispatch-unverified-codex-"));
+  try {
+    const now = Date.parse("2026-08-08T20:00:00Z");
+    parkLane(dir, "bg", { resetsAt: "2026-08-10T18:00:00Z", now });
+    const dispatched = [], events = [];
+    const fn = makePhaseAwareDispatchFn({
+      bootExecutor: "bg",
+      // The no-op sentinel from a node with NO codex route — checked nothing.
+      codexBootEligible: true,
+      orchDir: dir,
+      now: () => now,
+      resolveExecutorForPhase: () => ({ source: "executorByPhase", executor: "bg" }),
+      dispatchForExecutor: (executor) => () => {
+        dispatched.push(executor);
+        return { code: 0 };
+      },
+      // ...and the real probe says codex is not actually usable on this node.
+      verifyCodexLane: () => false,
+      emitEvent: (event) => events.push(event),
+    });
+    const result = fn({ ticket: "CAT-58", phase: "research" });
+    expect(dispatched).toEqual([]); // never launched into the unverified lane
+    expect(result).toMatchObject({ code: 75, deferred: true, laneDeferred: true });
+    expect(events.some((e) => e["event.name"] === "execution-core.executor.no-healthy-lane")).toBe(true);
+    expect(events.some((e) => e["event.name"] === "execution-core.executor.usage-limit-fallback")).toBe(false);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+// The probe is memoized per factory: a park episode pays the auth + `codex --version` cost
+// once, not once per dispatched phase.
+test("the codex lane probe is memoized across dispatches in one park episode", () => {
+  const dir = mkdtempSync(join(tmpdir(), "dispatch-codex-memo-"));
+  try {
+    const now = Date.parse("2026-08-08T20:00:00Z");
+    parkLane(dir, "bg", { resetsAt: "2026-08-10T18:00:00Z", now });
+    let probes = 0;
+    const fn = makePhaseAwareDispatchFn({
+      bootExecutor: "bg",
+      codexBootEligible: true,
+      orchDir: dir,
+      now: () => now,
+      resolveExecutorForPhase: () => ({ source: "executorByPhase", executor: "bg" }),
+      dispatchForExecutor: () => () => ({ code: 0 }),
+      verifyCodexLane: () => {
+        probes += 1;
+        return true;
+      },
+      emitEvent: () => {},
+    });
+    fn({ ticket: "CAT-58", phase: "research" });
+    fn({ ticket: "CAT-59", phase: "implement" });
+    fn({ ticket: "CAT-60", phase: "verify" });
+    expect(probes).toBe(1);
   } finally {
     rmSync(dir, { recursive: true, force: true });
   }

--- a/plugins/dev/scripts/execution-core/dispatch-usage-limit-fallback.test.mjs
+++ b/plugins/dev/scripts/execution-core/dispatch-usage-limit-fallback.test.mjs
@@ -1,0 +1,21 @@
+import { test, expect } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { makePhaseAwareDispatchFn } from "./dispatch.mjs";
+import { parkLane } from "./lane-cooldown.mjs";
+
+test("a bg phase falls back to codex while bg is parked", () => {
+  const dir = mkdtempSync(join(tmpdir(), "dispatch-fallback-"));
+  try {
+    const now = Date.parse("2026-08-08T20:00:00Z");
+    parkLane(dir, "bg", { resetsAt: "2026-08-10T18:00:00Z", now });
+    const dispatched = [], events = [];
+    const fn = makePhaseAwareDispatchFn({ bootExecutor: "bg", codexBootEligible: true, orchDir: dir, now: () => now,
+      resolveExecutorForPhase: () => ({ source: "executorByPhase", executor: "bg" }),
+      dispatchForExecutor: (executor) => (args) => { dispatched.push(executor); return { code: 0, args }; }, emitEvent: (event) => events.push(event) });
+    fn({ ticket: "CAT-58", phase: "research" });
+    expect(dispatched).toEqual(["codex-exec"]);
+    expect(events.some((event) => event["event.name"] === "execution-core.executor.usage-limit-fallback")).toBe(true);
+  } finally { rmSync(dir, { recursive: true, force: true }); }
+});

--- a/plugins/dev/scripts/execution-core/dispatch-usage-limit-fallback.test.mjs
+++ b/plugins/dev/scripts/execution-core/dispatch-usage-limit-fallback.test.mjs
@@ -38,3 +38,29 @@ test("a bg phase falls back to codex while bg is parked", () => {
     rmSync(dir, { recursive: true, force: true });
   }
 });
+
+test("a parked bg phase is not dispatched when no healthy fallback exists", () => {
+  const dir = mkdtempSync(join(tmpdir(), "dispatch-no-healthy-lane-"));
+  try {
+    const now = Date.parse("2026-08-08T20:00:00Z");
+    parkLane(dir, "bg", { resetsAt: "2026-08-10T18:00:00Z", now });
+    const dispatched = [], events = [];
+    const fn = makePhaseAwareDispatchFn({
+      bootExecutor: "bg",
+      codexBootEligible: false,
+      orchDir: dir,
+      now: () => now,
+      resolveExecutorForPhase: () => ({ source: "executorByPhase", executor: "bg" }),
+      dispatchForExecutor: (executor) => () => {
+        dispatched.push(executor);
+        return { code: 0 };
+      },
+      emitEvent: (event) => events.push(event),
+    });
+    expect(fn({ ticket: "CAT-58", phase: "research" })).toEqual({ code: 75, deferred: true, reason: "no-healthy-executor-lane" });
+    expect(dispatched).toEqual([]);
+    expect(events.some((event) => event["event.name"] === "execution-core.executor.no-healthy-lane")).toBe(true);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});

--- a/plugins/dev/scripts/execution-core/dispatch-usage-limit-fallback.test.mjs
+++ b/plugins/dev/scripts/execution-core/dispatch-usage-limit-fallback.test.mjs
@@ -1,9 +1,14 @@
 import { test, expect } from "bun:test";
-import { mkdtempSync, rmSync } from "node:fs";
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { makePhaseAwareDispatchFn } from "./dispatch.mjs";
 import { parkLane } from "./lane-cooldown.mjs";
+
+test("daemon threads orchDir into the production phase-aware dispatch factory", () => {
+  const daemonSource = readFileSync(new URL("./daemon.mjs", import.meta.url), "utf8");
+  expect(daemonSource).toMatch(/makePhaseAwareDispatchFn\(\{[\s\S]*?\borchDir,\s*[\s\S]*?\}\);/);
+});
 
 test("a bg phase falls back to codex while bg is parked", () => {
   const dir = mkdtempSync(join(tmpdir(), "dispatch-fallback-"));

--- a/plugins/dev/scripts/execution-core/dispatch-usage-limit-fallback.test.mjs
+++ b/plugins/dev/scripts/execution-core/dispatch-usage-limit-fallback.test.mjs
@@ -15,12 +15,26 @@ test("a bg phase falls back to codex while bg is parked", () => {
   try {
     const now = Date.parse("2026-08-08T20:00:00Z");
     parkLane(dir, "bg", { resetsAt: "2026-08-10T18:00:00Z", now });
-    const dispatched = [], events = [];
-    const fn = makePhaseAwareDispatchFn({ bootExecutor: "bg", codexBootEligible: true, orchDir: dir, now: () => now,
+    const dispatched = [],
+      events = [];
+    const fn = makePhaseAwareDispatchFn({
+      bootExecutor: "bg",
+      codexBootEligible: true,
+      orchDir: dir,
+      now: () => now,
       resolveExecutorForPhase: () => ({ source: "executorByPhase", executor: "bg" }),
-      dispatchForExecutor: (executor) => (args) => { dispatched.push(executor); return { code: 0, args }; }, emitEvent: (event) => events.push(event) });
+      dispatchForExecutor: (executor) => (args) => {
+        dispatched.push(executor);
+        return { code: 0, args };
+      },
+      emitEvent: (event) => events.push(event),
+    });
     fn({ ticket: "CAT-58", phase: "research" });
     expect(dispatched).toEqual(["codex-exec"]);
-    expect(events.some((event) => event["event.name"] === "execution-core.executor.usage-limit-fallback")).toBe(true);
-  } finally { rmSync(dir, { recursive: true, force: true }); }
+    expect(
+      events.some((event) => event["event.name"] === "execution-core.executor.usage-limit-fallback")
+    ).toBe(true);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
 });

--- a/plugins/dev/scripts/execution-core/dispatch-usage-limit-fallback.test.mjs
+++ b/plugins/dev/scripts/execution-core/dispatch-usage-limit-fallback.test.mjs
@@ -29,8 +29,9 @@ test("a bg phase falls back to codex while bg is parked", () => {
       },
       emitEvent: (event) => events.push(event),
     });
-    fn({ ticket: "CAT-58", phase: "research" });
+    const result = fn({ ticket: "CAT-58", phase: "research" });
     expect(dispatched).toEqual(["codex-exec"]);
+    expect(result.effectiveExecutor).toBe("codex-exec");
     expect(
       events.some((event) => event["event.name"] === "execution-core.executor.usage-limit-fallback")
     ).toBe(true);

--- a/plugins/dev/scripts/execution-core/dispatch.mjs
+++ b/plugins/dev/scripts/execution-core/dispatch.mjs
@@ -23,6 +23,7 @@ import { sdkRunPhaseAgent, defaultEmitBackstop, scrubSecrets } from "./sdk-run-p
 import { codexRunPhaseAgent } from "./codex-run-phase-agent.mjs"; // CTL-1457: the executor=codex-exec launch verb (spawns `codex exec --json` as a child process)
 import { hasFreshClaim } from "./signal-reader.mjs"; // CTL-1367 P2-G: a young single-flight claim makes a missing SDK signal a benign claim-lost no-op
 import { log, resolveExecutorForPhase } from "./config.mjs"; // CTL-1367 P1: log a swallowed async-dispatch rejection before the backstop fires; CTL-1457: per-phase executor routing hook (the default seam threaded into makePhaseAwareDispatchFn)
+import { inLaneCooldown, readLaneCooldown } from "./lane-cooldown.mjs";
 
 // phase-agent-dispatch sits one directory up from execution-core/.
 const PHASE_AGENT_DISPATCH_BIN = fileURLToPath(new URL("../phase-agent-dispatch", import.meta.url));
@@ -334,6 +335,8 @@ export function makePhaseAwareDispatchFn({
   resolveExecutorForPhase = _defaultResolveExecutorForPhase,
   dispatchForExecutor = _defaultDispatchForExecutor,
   log: logger = log,
+  orchDir = null,
+  now = Date.now,
 } = {}) {
   return (args, seams = {}) => {
     // Per-phase routing. Only an EXPLICITLY-routed phase (source "executorByPhase")
@@ -374,6 +377,16 @@ export function makePhaseAwareDispatchFn({
     // phase keeps effective === bootExecutor (which already carries the boot degrade).
     if (effective === "sdk" && !sdkBootEligible) {
       effective = bootExecutor === "sdk" ? "bg" : bootExecutor;
+    }
+    const bgParked = orchDir ? inLaneCooldown(orchDir, "bg", now()) : false;
+    if (bgParked && effective === "bg") {
+      const marker = readLaneCooldown(orchDir, "bg");
+      if (codexBootEligible) {
+        effective = "codex-exec";
+        emitEvent?.({ "event.name": "execution-core.executor.usage-limit-fallback", payload: { ticket: args.ticket, phase: args.phase, from: "bg", to: "codex-exec", expiresAt: marker?.expiresAt } });
+      } else {
+        emitEvent?.({ "event.name": "execution-core.executor.no-healthy-lane", payload: { ticket: args.ticket, phase: args.phase, lane: "bg", expiresAt: marker?.expiresAt } });
+      }
     }
     const fn = dispatchForExecutor(effective);
     if (effective === "sdk" || effective === "codex-exec") {

--- a/plugins/dev/scripts/execution-core/dispatch.mjs
+++ b/plugins/dev/scripts/execution-core/dispatch.mjs
@@ -390,8 +390,12 @@ export function makePhaseAwareDispatchFn({
       }
     }
     const fn = dispatchForExecutor(effective);
+    const withEffectiveExecutor = (result) => {
+      if (result && typeof result === "object") result.effectiveExecutor = effective;
+      return result;
+    };
     if (effective === "sdk" || effective === "codex-exec") {
-      return fn(args, {
+      const result = fn(args, {
         emitEvent: (name, payload) => emitEvent({ "event.name": name, payload }),
         // CTL-1457 (finding 4): the codex runner resolves its runtime codexConfig from
         // configPath — thread it so the runtime auth guard + buildCodexArgs honor the
@@ -400,8 +404,14 @@ export function makePhaseAwareDispatchFn({
         ...(effective === "codex-exec" ? { configPath } : {}),
         ...seams,
       });
+      if (result && typeof result.then === "function") {
+        const tagged = result.then(withEffectiveExecutor);
+        tagged.effectiveExecutor = effective;
+        return tagged;
+      }
+      return withEffectiveExecutor(result);
     }
-    return fn(args, seams);
+    return withEffectiveExecutor(fn(args, seams));
   };
 }
 

--- a/plugins/dev/scripts/execution-core/dispatch.mjs
+++ b/plugins/dev/scripts/execution-core/dispatch.mjs
@@ -20,10 +20,43 @@ import { fileURLToPath } from "node:url";
 import { getProjectConfig } from "./registry.mjs";
 import { createWorktree as defaultCreateWorktree } from "./worktree.mjs";
 import { sdkRunPhaseAgent, defaultEmitBackstop, scrubSecrets } from "./sdk-run-phase-agent.mjs"; // CTL-1365b: the executor=sdk launch verb (in-process Agent SDK query()); CTL-1367 P1: shared failed-terminal backstop for a rejected async dispatch; CTL-1367 item 11: scrub token-shaped substrings out of a rejected-dispatch reason before it is backstopped/logged
-import { codexRunPhaseAgent } from "./codex-run-phase-agent.mjs"; // CTL-1457: the executor=codex-exec launch verb (spawns `codex exec --json` as a child process)
+import { codexRunPhaseAgent, resolveCodexBootEligibility } from "./codex-run-phase-agent.mjs"; // CTL-1457: the executor=codex-exec launch verb (spawns `codex exec --json` as a child process); CAT-58: the auth+binary probe the usage-limit fallback needs POSITIVE evidence from
 import { hasFreshClaim } from "./signal-reader.mjs"; // CTL-1367 P2-G: a young single-flight claim makes a missing SDK signal a benign claim-lost no-op
-import { log, resolveExecutorForPhase } from "./config.mjs"; // CTL-1367 P1: log a swallowed async-dispatch rejection before the backstop fires; CTL-1457: per-phase executor routing hook (the default seam threaded into makePhaseAwareDispatchFn)
+import { log, resolveExecutorForPhase, codexConfig } from "./config.mjs"; // CTL-1367 P1: log a swallowed async-dispatch rejection before the backstop fires; CTL-1457: per-phase executor routing hook (the default seam threaded into makePhaseAwareDispatchFn); CAT-58: resolve the codex runtime config the fallback probe checks
 import { inLaneCooldown, readLaneCooldown } from "./lane-cooldown.mjs";
+
+// defaultVerifyCodexLane — CAT-58 (Codex round 2, P1 "Verify Codex before using it as the
+// fallback"). `codexBootEligible` is TRUE in two structurally different situations:
+//   (a) codex IS routed and its auth + binary were PROBED and passed, and
+//   (b) codex is NOT routed anywhere, so resolveCodexBootEligibility returned its no-op
+//       sentinel { eligible: true } having checked NOTHING.
+// The usage-limit fallback may only reroute onto a lane it has POSITIVE evidence for, so it
+// must not read (b) as a healthy lane — on a normal bg-only node that would send every parked
+// dispatch to an absent/unauthenticated codex, converting a clean "defer until reset" into a
+// storm of real dispatch failures and breaker trips. This helper force-ARMS the same boot gate
+// (bootExecutor: "codex-exec" makes routesToCodex true) so the auth + `codex --version` probe
+// actually runs, and reports only its verdict. Silent by construction: no logger and no
+// emitEvent are passed, so a negative verdict here neither WARN-logs nor emits the boot gate's
+// codex-fallback event (this is a per-park probe, not a boot-time configuration error).
+export function defaultVerifyCodexLane({ configPath, env = process.env } = {}) {
+  try {
+    const verdict = resolveCodexBootEligibility(
+      {},
+      {
+        codexCfg: codexConfig({ configPath, env }),
+        env,
+        bootExecutor: "codex-exec",
+        emitEvent: undefined,
+        log: null,
+      },
+    );
+    return verdict?.eligible === true;
+  } catch {
+    // Fail CLOSED: an unreadable codex config / throwing probe is NOT evidence of a
+    // healthy lane, so the caller defers rather than dispatching into the unknown.
+    return false;
+  }
+}
 
 // phase-agent-dispatch sits one directory up from execution-core/.
 const PHASE_AGENT_DISPATCH_BIN = fileURLToPath(new URL("../phase-agent-dispatch", import.meta.url));
@@ -337,7 +370,14 @@ export function makePhaseAwareDispatchFn({
   log: logger = log,
   orchDir = null,
   now = Date.now,
+  // CAT-58 (Codex round 2, P1): the usage-limit fallback's evidence source. Injectable so
+  // the unit tests drive the verdict without a real codex install; defaults to the live
+  // auth + `codex --version` probe.
+  verifyCodexLane = () => defaultVerifyCodexLane({ configPath }),
 } = {}) {
+  // Memoized verdict for `verifyCodexLane` (null = not yet probed). Scoped to the factory so
+  // it is per-daemon-process, and so each test's fresh fn re-probes.
+  let codexLaneVerified = null;
   return (args, seams = {}) => {
     // Per-phase routing. Only an EXPLICITLY-routed phase (source "executorByPhase")
     // overrides the boot executor; an unrouted phase keeps the boot executor (which
@@ -381,12 +421,36 @@ export function makePhaseAwareDispatchFn({
     const bgParked = orchDir ? inLaneCooldown(orchDir, "bg", now()) : false;
     if (bgParked && effective === "bg") {
       const marker = readLaneCooldown(orchDir, "bg");
-      if (codexBootEligible) {
+      // CAT-58 (Codex round 2, P1): consult a VERIFIED codex lane, never the
+      // codexBootEligible sentinel — see defaultVerifyCodexLane. Memoized for the life of
+      // this dispatch fn so a park episode pays the auth+binary probe once rather than once
+      // per dispatch; the daemon rebuilds the fn on restart, which is also when a newly
+      // provisioned codex should be re-probed.
+      // Both must hold. `codexBootEligible === false` is POSITIVE evidence the lane is bad
+      // (the boot gate probed it and it failed) and is decisive on its own; `true` is
+      // ambiguous, so the probe disambiguates verified-healthy from never-checked.
+      if (codexLaneVerified === null) {
+        codexLaneVerified = codexBootEligible === true && verifyCodexLane() === true;
+      }
+      if (codexLaneVerified) {
         effective = "codex-exec";
         emitEvent?.({ "event.name": "execution-core.executor.usage-limit-fallback", payload: { ticket: args.ticket, phase: args.phase, from: "bg", to: "codex-exec", expiresAt: marker?.expiresAt } });
       } else {
         emitEvent?.({ "event.name": "execution-core.executor.no-healthy-lane", payload: { ticket: args.ticket, phase: args.phase, lane: "bg", expiresAt: marker?.expiresAt } });
-        return { code: 75, deferred: true, reason: "no-healthy-executor-lane" };
+        // CAT-58 (Codex round 2, P1 "Suppress approved-resume retries while the lane is
+        // deferred"): `laneDeferred` marks this as a DEFERRAL, not a dispatch failure. A
+        // caller that retains approval sentinels + re-appends phase.dispatch.requested on
+        // every generic failure would otherwise self-wake the scheduler and retry the same
+        // approval for the whole cooldown. Callers branch on this flag to leave the ticket
+        // untouched until `retryAfter`.
+        return {
+          code: 75,
+          deferred: true,
+          laneDeferred: true,
+          lane: "bg",
+          retryAfter: marker?.expiresAt ?? null,
+          reason: "no-healthy-executor-lane",
+        };
       }
     }
     const fn = dispatchForExecutor(effective);

--- a/plugins/dev/scripts/execution-core/dispatch.mjs
+++ b/plugins/dev/scripts/execution-core/dispatch.mjs
@@ -386,6 +386,7 @@ export function makePhaseAwareDispatchFn({
         emitEvent?.({ "event.name": "execution-core.executor.usage-limit-fallback", payload: { ticket: args.ticket, phase: args.phase, from: "bg", to: "codex-exec", expiresAt: marker?.expiresAt } });
       } else {
         emitEvent?.({ "event.name": "execution-core.executor.no-healthy-lane", payload: { ticket: args.ticket, phase: args.phase, lane: "bg", expiresAt: marker?.expiresAt } });
+        return { code: 75, deferred: true, reason: "no-healthy-executor-lane" };
       }
     }
     const fn = dispatchForExecutor(effective);

--- a/plugins/dev/scripts/execution-core/lane-cooldown.mjs
+++ b/plugins/dev/scripts/execution-core/lane-cooldown.mjs
@@ -1,4 +1,4 @@
-import { readFileSync, mkdirSync, writeFileSync } from "node:fs";
+import { readFileSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { log } from "./config.mjs";
 import { USAGE_LIMIT_FALLBACK_MS } from "./usage-limit.mjs";
@@ -16,6 +16,15 @@ export function readLaneCooldown(orchDir, lane) {
 export function inLaneCooldown(orchDir, lane, now = Date.now()) {
   const marker = readLaneCooldown(orchDir, lane);
   return !!marker && typeof marker.expiresAt === "number" && now < marker.expiresAt;
+}
+export function clearLaneCooldown(orchDir, lane) {
+  try {
+    rmSync(laneCooldownPath(orchDir, lane), { force: true });
+    return true;
+  } catch (err) {
+    log.warn({ lane, err: err.message }, "cat-58: lane cool-down clear failed — continuing");
+    return false;
+  }
 }
 export function parkLane(
   orchDir,

--- a/plugins/dev/scripts/execution-core/lane-cooldown.mjs
+++ b/plugins/dev/scripts/execution-core/lane-cooldown.mjs
@@ -1,0 +1,25 @@
+import { readFileSync, mkdirSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { log } from "./config.mjs";
+
+export function laneCooldownPath(orchDir, lane) { return join(orchDir, ".lane-cooldowns", `${lane}.json`); }
+export function readLaneCooldown(orchDir, lane) {
+  try { return JSON.parse(readFileSync(laneCooldownPath(orchDir, lane), "utf8")); } catch { return null; }
+}
+export function inLaneCooldown(orchDir, lane, now = Date.now()) {
+  const marker = readLaneCooldown(orchDir, lane);
+  return !!marker && typeof marker.expiresAt === "number" && now < marker.expiresAt;
+}
+export function parkLane(orchDir, lane, { resetsAt, detail = null, ticket = null, phase = null, now = Date.now() }) {
+  const requested = Date.parse(resetsAt);
+  if (!Number.isFinite(requested) || requested <= now) return null;
+  const previous = readLaneCooldown(orchDir, lane);
+  const marker = { lane, code: "usage-limit", blockedAt: now, expiresAt: Math.max(requested, previous?.expiresAt ?? 0), detail, lastTicket: ticket, lastPhase: phase };
+  try {
+    mkdirSync(dirname(laneCooldownPath(orchDir, lane)), { recursive: true });
+    writeFileSync(laneCooldownPath(orchDir, lane), JSON.stringify(marker));
+  } catch (err) {
+    log.warn({ lane, err: err.message }, "cat-58: lane cool-down write failed — continuing");
+  }
+  return marker;
+}

--- a/plugins/dev/scripts/execution-core/lane-cooldown.mjs
+++ b/plugins/dev/scripts/execution-core/lane-cooldown.mjs
@@ -1,20 +1,40 @@
 import { readFileSync, mkdirSync, writeFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { log } from "./config.mjs";
+import { USAGE_LIMIT_FALLBACK_MS } from "./usage-limit.mjs";
 
-export function laneCooldownPath(orchDir, lane) { return join(orchDir, ".lane-cooldowns", `${lane}.json`); }
+export function laneCooldownPath(orchDir, lane) {
+  return join(orchDir, ".lane-cooldowns", `${lane}.json`);
+}
 export function readLaneCooldown(orchDir, lane) {
-  try { return JSON.parse(readFileSync(laneCooldownPath(orchDir, lane), "utf8")); } catch { return null; }
+  try {
+    return JSON.parse(readFileSync(laneCooldownPath(orchDir, lane), "utf8"));
+  } catch {
+    return null;
+  }
 }
 export function inLaneCooldown(orchDir, lane, now = Date.now()) {
   const marker = readLaneCooldown(orchDir, lane);
   return !!marker && typeof marker.expiresAt === "number" && now < marker.expiresAt;
 }
-export function parkLane(orchDir, lane, { resetsAt, detail = null, ticket = null, phase = null, now = Date.now() }) {
+export function parkLane(
+  orchDir,
+  lane,
+  { resetsAt, detail = null, ticket = null, phase = null, now = Date.now() }
+) {
   const requested = Date.parse(resetsAt);
-  if (!Number.isFinite(requested) || requested <= now) return null;
+  const expiresAt =
+    Number.isFinite(requested) && requested > now ? requested : now + USAGE_LIMIT_FALLBACK_MS;
   const previous = readLaneCooldown(orchDir, lane);
-  const marker = { lane, code: "usage-limit", blockedAt: now, expiresAt: Math.max(requested, previous?.expiresAt ?? 0), detail, lastTicket: ticket, lastPhase: phase };
+  const marker = {
+    lane,
+    code: "usage-limit",
+    blockedAt: now,
+    expiresAt: Math.max(expiresAt, previous?.expiresAt ?? 0),
+    detail,
+    lastTicket: ticket,
+    lastPhase: phase,
+  };
   try {
     mkdirSync(dirname(laneCooldownPath(orchDir, lane)), { recursive: true });
     writeFileSync(laneCooldownPath(orchDir, lane), JSON.stringify(marker));

--- a/plugins/dev/scripts/execution-core/lane-cooldown.test.mjs
+++ b/plugins/dev/scripts/execution-core/lane-cooldown.test.mjs
@@ -1,0 +1,21 @@
+import { test, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { laneCooldownPath, readLaneCooldown, inLaneCooldown, parkLane } from "./lane-cooldown.mjs";
+let dir;
+beforeEach(() => { dir = mkdtempSync(join(tmpdir(), "lane-cooldown-")); });
+afterEach(() => rmSync(dir, { recursive: true, force: true }));
+test("parked lane expires at reset and never shortens", () => {
+  const now = Date.parse("2026-08-08T20:00:00Z");
+  parkLane(dir, "bg", { resetsAt: "2026-08-10T18:00:00Z", now });
+  parkLane(dir, "bg", { resetsAt: "2026-08-09T18:00:00Z", now });
+  expect(readLaneCooldown(dir, "bg").expiresAt).toBe(Date.parse("2026-08-10T18:00:00Z"));
+  expect(inLaneCooldown(dir, "bg", now)).toBe(true);
+  expect(inLaneCooldown(dir, "bg", Date.parse("2026-08-11T00:00:00Z"))).toBe(false);
+});
+test("missing and malformed markers fail open", () => {
+  expect(inLaneCooldown(dir, "bg", Date.now())).toBe(false);
+  mkdirSync(join(dir, ".lane-cooldowns")); writeFileSync(laneCooldownPath(dir, "bg"), "{{{");
+  expect(inLaneCooldown(dir, "bg", Date.now())).toBe(false);
+});

--- a/plugins/dev/scripts/execution-core/lane-cooldown.test.mjs
+++ b/plugins/dev/scripts/execution-core/lane-cooldown.test.mjs
@@ -2,7 +2,7 @@ import { test, expect, beforeEach, afterEach } from "bun:test";
 import { mkdtempSync, rmSync, mkdirSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { laneCooldownPath, readLaneCooldown, inLaneCooldown, parkLane } from "./lane-cooldown.mjs";
+import { laneCooldownPath, readLaneCooldown, inLaneCooldown, parkLane, clearLaneCooldown } from "./lane-cooldown.mjs";
 import { USAGE_LIMIT_FALLBACK_MS } from "./usage-limit.mjs";
 let dir;
 beforeEach(() => {
@@ -27,4 +27,9 @@ test("stale reset timestamps use the bounded fallback", () => {
   const now = Date.parse("2026-08-08T20:00:00Z");
   const marker = parkLane(dir, "bg", { resetsAt: "2026-08-08T19:00:00Z", now });
   expect(marker.expiresAt).toBe(now + USAGE_LIMIT_FALLBACK_MS);
+});
+test("a recovered lane can be explicitly unparked", () => {
+  parkLane(dir, "bg", { resetsAt: "2026-08-10T18:00:00Z", now: Date.parse("2026-08-08T20:00:00Z") });
+  expect(clearLaneCooldown(dir, "bg")).toBe(true);
+  expect(readLaneCooldown(dir, "bg")).toBeNull();
 });

--- a/plugins/dev/scripts/execution-core/lane-cooldown.test.mjs
+++ b/plugins/dev/scripts/execution-core/lane-cooldown.test.mjs
@@ -3,8 +3,11 @@ import { mkdtempSync, rmSync, mkdirSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { laneCooldownPath, readLaneCooldown, inLaneCooldown, parkLane } from "./lane-cooldown.mjs";
+import { USAGE_LIMIT_FALLBACK_MS } from "./usage-limit.mjs";
 let dir;
-beforeEach(() => { dir = mkdtempSync(join(tmpdir(), "lane-cooldown-")); });
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), "lane-cooldown-"));
+});
 afterEach(() => rmSync(dir, { recursive: true, force: true }));
 test("parked lane expires at reset and never shortens", () => {
   const now = Date.parse("2026-08-08T20:00:00Z");
@@ -16,6 +19,12 @@ test("parked lane expires at reset and never shortens", () => {
 });
 test("missing and malformed markers fail open", () => {
   expect(inLaneCooldown(dir, "bg", Date.now())).toBe(false);
-  mkdirSync(join(dir, ".lane-cooldowns")); writeFileSync(laneCooldownPath(dir, "bg"), "{{{");
+  mkdirSync(join(dir, ".lane-cooldowns"));
+  writeFileSync(laneCooldownPath(dir, "bg"), "{{{");
   expect(inLaneCooldown(dir, "bg", Date.now())).toBe(false);
+});
+test("stale reset timestamps use the bounded fallback", () => {
+  const now = Date.parse("2026-08-08T20:00:00Z");
+  const marker = parkLane(dir, "bg", { resetsAt: "2026-08-08T19:00:00Z", now });
+  expect(marker.expiresAt).toBe(now + USAGE_LIMIT_FALLBACK_MS);
 });

--- a/plugins/dev/scripts/execution-core/monitor.mjs
+++ b/plugins/dev/scripts/execution-core/monitor.mjs
@@ -1067,18 +1067,6 @@ function dispatchTriage(
   // signal is reset to stalled by the reclaim/revive path, after which counting
   // resumes; "failed"/"stalled" re-dispatches launch real workers and count.
   const statusAtLaunch = readTriageSignalStatus(orchDir, identifier);
-  if (!isTriageInFlight(statusAtLaunch) && statusAtLaunch !== "done") {
-    bumpTriageDispatchCount(orchDir, identifier);
-    // CTL-1649: mirror the host-local bump on the fence attachment so the fleet-wide
-    // count stays in lockstep. Fail-open — a fence write failure never blocks launch.
-    if (multiHost) {
-      try {
-        bumpFenceTriageAttempt({ ticket: identifier });
-      } catch {
-        /* fail-open */
-      }
-    }
-  }
   // CTL-1367 P1: settle an async (executor=sdk) dispatch synchronously. bg returns a
   // plain object (passthrough → byte-identical). sdk returns a Promise whose
   // synchronous prelaunch already wrote the triage `dispatched` signal;
@@ -1098,6 +1086,25 @@ function dispatchTriage(
       ),
     },
   );
+  if (r.deferred) {
+    log.info(
+      { identifier, code: r.code, reason: r.reason },
+      "monitor: triage dispatch deferred — executor lane parked"
+    );
+    return false;
+  }
+  // Count only a real spawn attempt. A lane-parked dispatch returns before any
+  // worker launch and must not consume the ticket or fleet-wide triage budget.
+  if (!isTriageInFlight(statusAtLaunch) && statusAtLaunch !== "done") {
+    bumpTriageDispatchCount(orchDir, identifier);
+    if (multiHost) {
+      try {
+        bumpFenceTriageAttempt({ ticket: identifier });
+      } catch {
+        /* fail-open */
+      }
+    }
+  }
   if (r.code !== 0) {
     log.warn({ identifier, code: r.code }, "monitor: triage dispatch failed");
     return false;

--- a/plugins/dev/scripts/execution-core/ratelimit-poller.mjs
+++ b/plugins/dev/scripts/execution-core/ratelimit-poller.mjs
@@ -23,6 +23,7 @@ import { homedir } from "node:os";
 import { resolve } from "node:path";
 import { readRatelimitPollerConfig, log } from "./config.mjs";
 import { emitRatelimitEvent, RATELIMIT_EVENT_SAMPLED } from "./ratelimit-event.mjs";
+import { writeAccountQuota } from "./account-quota.mjs";
 
 const PROFILE_ENDPOINT = "https://api.anthropic.com/api/oauth/profile";
 const OAUTH_BETA = "oauth-2025-04-20";
@@ -182,6 +183,7 @@ async function defaultResolveEmail(token, { userAgent }) {
  * @param {Function} [opts.now]                              injectable envelope timestamp fn (forwarded to emit; defaults to real time)
  */
 export function startRatelimitPoller({
+  orchDir = null,
   clock = realClock(),
   config = readRatelimitPollerConfig(),
   readToken = defaultReadToken,
@@ -262,9 +264,7 @@ export function startRatelimitPoller({
 
       const fiveHour = body.five_hour ?? {};
       const sevenDay = body.seven_day ?? {};
-      emit(
-        RATELIMIT_EVENT_SAMPLED,
-        {
+      const payload = {
           email: cachedEmail,
           fiveHourPct: pctOf(body.five_hour),
           sevenDayPct: pctOf(body.seven_day),
@@ -274,9 +274,9 @@ export function startRatelimitPoller({
           sonnetPct: pctOf(body.seven_day_sonnet),
           subscriptionType: orgMeta.subscriptionType,
           rateLimitTier: orgMeta.rateLimitTier,
-        },
-        { now },
-      );
+      };
+      emit(RATELIMIT_EVENT_SAMPLED, payload, { now });
+      if (orchDir) writeAccountQuota(orchDir, payload, { now });
     } catch (err) {
       log.warn({ err: err?.message }, "ratelimit-poller: tick failed");
     }

--- a/plugins/dev/scripts/execution-core/ratelimit-poller.test.mjs
+++ b/plugins/dev/scripts/execution-core/ratelimit-poller.test.mjs
@@ -7,7 +7,7 @@
 // Run: cd plugins/dev/scripts/execution-core && bun test ratelimit-poller.test.mjs
 
 import { test, expect, describe } from "bun:test";
-import { mkdtempSync, writeFileSync, readFileSync } from "node:fs";
+import { mkdtempSync, writeFileSync, readFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { startRatelimitPoller } from "./ratelimit-poller.mjs";
@@ -80,6 +80,28 @@ function harness({
 // ─── 200 parse + emit ────────────────────────────────────────────────────────
 
 describe("tick — 200 body", () => {
+  test("publishes the successful sample to the orchestrator snapshot", async () => {
+    const orchDir = mkdtempSync(join(tmpdir(), "cat58-ratelimit-snapshot-"));
+    try {
+      const w = startRatelimitPoller({
+        orchDir,
+        clock: recordingClock(),
+        config: { enabled: true, intervalMs: 300000, usageEndpoint: "https://example/usage" },
+        readToken: () => TOKEN,
+        fetchUsage: async () => ({ status: 200, body: usageBody() }),
+        resolveEmail: async () => null,
+        emit: () => {},
+        now: () => Date.parse("2026-08-08T18:00:00.000Z"),
+      });
+      await w.tick();
+      const snapshot = JSON.parse(readFileSync(join(orchDir, "account-quota.json"), "utf8"));
+      expect(snapshot.sevenDayResetsAt).toBe("2026-06-13T00:00:00Z");
+      expect(snapshot.email).toBeUndefined();
+    } finally {
+      rmSync(orchDir, { recursive: true, force: true });
+    }
+  });
+
   test("parses a 200 body and emits one account.ratelimit.sampled with all fields", async () => {
     const { w, emitted } = harness();
     await w.tick();

--- a/plugins/dev/scripts/execution-core/recovery-usage-limit-park.test.mjs
+++ b/plugins/dev/scripts/execution-core/recovery-usage-limit-park.test.mjs
@@ -115,4 +115,14 @@ describe("reclaimDeadWorkIfPossible — CAT-58 usage-limit park", () => {
     reclaimDeadWorkIfPossible(s.orchDir, s.signal, s.opts);
     expect(s.appendUsageLimitEvent.calls[0][0].quota.resetSource).toBe("detail");
   });
+
+  test("an already-parked signal is idempotent until its recorded reset", () => {
+    const s = scenario();
+    expect(reclaimDeadWorkIfPossible(s.orchDir, s.signal, s.opts)).toBe("usage-limit-parked");
+    const persisted = JSON.parse(readFileSync(s.signalPath, "utf8"));
+    const replay = { ...s.signal, raw: persisted };
+    expect(reclaimDeadWorkIfPossible(s.orchDir, replay, s.opts)).toBe("usage-limit-parked");
+    expect(s.appendUsageLimitEvent.calls).toHaveLength(1);
+    expect(s.parkLaneFn.calls).toHaveLength(1);
+  });
 });

--- a/plugins/dev/scripts/execution-core/recovery-usage-limit-park.test.mjs
+++ b/plugins/dev/scripts/execution-core/recovery-usage-limit-park.test.mjs
@@ -1,0 +1,94 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { reclaimDeadWorkIfPossible } from "./recovery.mjs";
+
+const dirs = [];
+afterEach(() => {
+  for (const dir of dirs.splice(0)) rmSync(dir, { recursive: true, force: true });
+});
+
+function recorder(returnValue) {
+  const calls = [];
+  const fn = (...args) => {
+    calls.push(args);
+    return returnValue;
+  };
+  fn.calls = calls;
+  return fn;
+}
+
+function scenario({ writeSignal = true, detail = "You've hit your weekly limit · resets Aug 10 at 1pm (America/Chicago)" } = {}) {
+  const orchDir = mkdtempSync(join(tmpdir(), "cat58-park-"));
+  dirs.push(orchDir);
+  const ticket = "CAT-58";
+  const phase = "implement";
+  const signalPath = join(orchDir, "workers", ticket, `phase-${phase}.json`);
+  if (writeSignal) {
+    mkdirSync(join(orchDir, "workers", ticket), { recursive: true });
+    writeFileSync(signalPath, JSON.stringify({ ticket, phase, status: "running", bg_job_id: "job-58" }));
+  }
+  const signal = {
+    ticket,
+    phase,
+    status: "running",
+    liveness: { kind: "bg", value: "job-58" },
+    signalPath,
+    raw: { ticket, phase, status: "running", bg_job_id: "job-58" },
+  };
+  const appendUsageLimitEvent = recorder(undefined);
+  const parkLaneFn = recorder(undefined);
+  const applyStalledLabel = recorder({ applied: true });
+  const resetsAt = "2026-08-10T18:00:00.000Z";
+  const opts = {
+    repoRoot: "/repo",
+    jobLifecycle: () => "dead-gone",
+    probes: { implement: () => false },
+    detectUsageLimit: () => ({ blocked: true, resetsAt, resetSource: "detail", source: "timeline", detail }),
+    appendUsageLimitEvent,
+    parkLaneFn,
+    recordDispatchFailureFn: recorder(undefined),
+    applyStalledLabel,
+    killBgJob: recorder(undefined),
+    emitReapIntent: () => Promise.resolve(),
+    now: () => Date.parse("2026-08-08T18:00:00.000Z"),
+  };
+  return { orchDir, ticket, phase, signalPath, signal, opts, appendUsageLimitEvent, parkLaneFn, applyStalledLabel };
+}
+
+describe("reclaimDeadWorkIfPossible — CAT-58 usage-limit park", () => {
+  test("the park writes the operator explanation onto the phase signal", () => {
+    const s = scenario();
+    expect(reclaimDeadWorkIfPossible(s.orchDir, s.signal, s.opts)).toBe("usage-limit-parked");
+    const persisted = JSON.parse(readFileSync(s.signalPath, "utf8"));
+    expect(persisted.failureReason).toBe("usage-limit-blocked");
+    expect(persisted.usageLimitExplanation.observed.likely_cause).toBe("account-usage-limit");
+    expect(persisted.usageLimitExplanation.problem).toMatch(/usage limit is exhausted/i);
+    expect(persisted.usageLimitExplanation.call_to_action).toMatch(/codex-exec/);
+    expect(persisted.status).toBe("failed");
+    expect(s.applyStalledLabel.calls).toHaveLength(0);
+  });
+
+  test("the emitted event input carries the operator-facing explanation", () => {
+    const s = scenario();
+    reclaimDeadWorkIfPossible(s.orchDir, s.signal, s.opts);
+    const [envelope] = s.appendUsageLimitEvent.calls[0];
+    expect(envelope.explanation.problem).toMatch(/usage limit/i);
+    expect(envelope.explanation.call_to_action).toBeTruthy();
+    expect(envelope.quota.resetsAt).toBeTruthy();
+  });
+
+  test("a signal-write failure still parks the lane and returns the outcome", () => {
+    const s = scenario({ writeSignal: false });
+    expect(reclaimDeadWorkIfPossible(s.orchDir, s.signal, s.opts)).toBe("usage-limit-parked");
+    expect(s.parkLaneFn.calls).toHaveLength(1);
+  });
+
+  test("the park path does not write phase-recovery-pass.json", () => {
+    const s = scenario();
+    reclaimDeadWorkIfPossible(s.orchDir, s.signal, s.opts);
+    expect(existsSync(join(s.orchDir, "workers", s.ticket, "phase-recovery-pass.json"))).toBe(false);
+  });
+});

--- a/plugins/dev/scripts/execution-core/recovery-usage-limit-park.test.mjs
+++ b/plugins/dev/scripts/execution-core/recovery-usage-limit-park.test.mjs
@@ -20,7 +20,7 @@ function recorder(returnValue) {
   return fn;
 }
 
-function scenario({ writeSignal = true, detail = "You've hit your weekly limit · resets Aug 10 at 1pm (America/Chicago)" } = {}) {
+function scenario({ writeSignal = true, detail = "You've hit your weekly limit · resets Aug 10 at 1pm (America/Chicago)", pollerResetsAt = null } = {}) {
   const orchDir = mkdtempSync(join(tmpdir(), "cat58-park-"));
   dirs.push(orchDir);
   const ticket = "CAT-58";
@@ -46,7 +46,14 @@ function scenario({ writeSignal = true, detail = "You've hit your weekly limit �
     repoRoot: "/repo",
     jobLifecycle: () => "dead-gone",
     probes: { implement: () => false },
-    detectUsageLimit: () => ({ blocked: true, resetsAt, resetSource: "detail", source: "timeline", detail }),
+    detectUsageLimit: (_id, { pollerResetsAt: sampledReset } = {}) => ({
+      blocked: true,
+      resetsAt: sampledReset ?? resetsAt,
+      resetSource: sampledReset ? "poller" : "detail",
+      source: "timeline",
+      detail,
+    }),
+    resolveAccountResetsAtFn: () => pollerResetsAt,
     appendUsageLimitEvent,
     parkLaneFn,
     recordDispatchFailureFn: recorder(undefined),
@@ -90,5 +97,21 @@ describe("reclaimDeadWorkIfPossible — CAT-58 usage-limit park", () => {
     const s = scenario();
     reclaimDeadWorkIfPossible(s.orchDir, s.signal, s.opts);
     expect(existsSync(join(s.orchDir, "workers", s.ticket, "phase-recovery-pass.json"))).toBe(false);
+  });
+
+  test("a fresh account snapshot supplies the detector's poller reset tier", () => {
+    const futureIso = "2026-08-11T18:00:00.000Z";
+    const s = scenario({ pollerResetsAt: futureIso });
+    reclaimDeadWorkIfPossible(s.orchDir, s.signal, s.opts);
+    const persisted = JSON.parse(readFileSync(s.signalPath, "utf8"));
+    expect(persisted.usageLimitSource).toBe("timeline");
+    expect(persisted.usageLimitResetsAt).toBe(futureIso);
+    expect(s.appendUsageLimitEvent.calls[0][0].quota.resetSource).toBe("poller");
+  });
+
+  test("no account snapshot leaves the existing detail tier unchanged", () => {
+    const s = scenario();
+    reclaimDeadWorkIfPossible(s.orchDir, s.signal, s.opts);
+    expect(s.appendUsageLimitEvent.calls[0][0].quota.resetSource).toBe("detail");
   });
 });

--- a/plugins/dev/scripts/execution-core/recovery-usage-limit-park.test.mjs
+++ b/plugins/dev/scripts/execution-core/recovery-usage-limit-park.test.mjs
@@ -73,7 +73,8 @@ describe("reclaimDeadWorkIfPossible — CAT-58 usage-limit park", () => {
     expect(persisted.failureReason).toBe("usage-limit-blocked");
     expect(persisted.usageLimitExplanation.observed.likely_cause).toBe("account-usage-limit");
     expect(persisted.usageLimitExplanation.problem).toMatch(/usage limit is exhausted/i);
-    expect(persisted.usageLimitExplanation.call_to_action).toMatch(/codex-exec/);
+    expect(persisted.usageLimitExplanation.call_to_action).toMatch(/wait for the reset/i);
+    expect(persisted.usageLimitExplanation.observed.fallback_lane).toBeNull();
     expect(persisted.status).toBe("failed");
     expect(s.applyStalledLabel.calls).toHaveLength(0);
   });

--- a/plugins/dev/scripts/execution-core/recovery.mjs
+++ b/plugins/dev/scripts/execution-core/recovery.mjs
@@ -3455,13 +3455,25 @@ export function reclaimDeadWorkIfPossible(
   // CAT-58: a terminal bg worker blocked by the account quota must be parked
   // before the progress gate; otherwise forward progress causes an immediate
   // revive into the same exhausted lane.
+  const recordedResetMs = Date.parse(signal.raw?.usageLimitResetsAt ?? "");
+  if (
+    signal.raw?.failureReason === "usage-limit-blocked" &&
+    Number.isFinite(recordedResetMs) &&
+    recordedResetMs > now()
+  ) {
+    return "usage-limit-parked";
+  }
   let quota = { blocked: false };
   try {
     quota = detectUsageLimit(prevBgJobId, {
       now,
       pollerResetsAt: resolveAccountResetsAtFn?.(orchDir, { now }) ?? null,
     });
-  } catch {
+  } catch (err) {
+    log.warn(
+      { ticket, phase, err: err.message },
+      "cat-58: usage-limit detection failed — continuing with normal recovery"
+    );
     quota = { blocked: false };
   }
   if (quota.blocked) {

--- a/plugins/dev/scripts/execution-core/recovery.mjs
+++ b/plugins/dev/scripts/execution-core/recovery.mjs
@@ -3474,7 +3474,10 @@ export function reclaimDeadWorkIfPossible(
       phase,
       resetsAt: quota.resetsAt,
       lane: "bg",
-      fallbackLane: "codex-exec",
+      // Recovery cannot see the daemon's boot-time Codex eligibility verdict.
+      // Do not promise a reroute here; dispatch emits the authoritative fallback
+      // or no-healthy-lane event when it evaluates the live lane options.
+      fallbackLane: null,
       detail: quota.detail,
     });
     const signalPath = join(orchDir, "workers", ticket, `phase-${phase}.json`);

--- a/plugins/dev/scripts/execution-core/recovery.mjs
+++ b/plugins/dev/scripts/execution-core/recovery.mjs
@@ -49,6 +49,8 @@ import {
 // transcripts so a doc worker mid in-process fan-out is never judged silent
 // (CTL-662-safe). Used ONLY to break the cold-snapshot doc-phase 6h tie below.
 import { transcriptAgeMs as defaultTranscriptAgeMs } from "./transcript-silence.mjs";
+import { USAGE_LIMIT_TEXT_RE, detectUsageLimitBlock, buildUsageLimitExplanation } from "./usage-limit.mjs";
+import { parkLane } from "./lane-cooldown.mjs";
 import { scanEventsChunked, scanEventsSince, DEFAULT_TAIL_MAX_BYTES } from "./event-tail.mjs"; // CTL-1514 / CTL-1529: bounded event-log scans
 // CTL-863 fleet-unfreeze (entourage follow-up to #2552): readPeerHeartbeatsSyncCached is
 // the CACHED reader — a 45s in-process TTL cache around the same anchor-issue read, safe
@@ -245,7 +247,7 @@ export function detectSessionRateLimitHit(
       if (
         c?.type === "text" &&
         typeof c.text === "string" &&
-        /hit your (session|usage) limit/i.test(c.text)
+        USAGE_LIMIT_TEXT_RE.test(c.text)
       ) {
         return true;
       }
@@ -570,6 +572,14 @@ export function defaultAppendReclaimEvent({
     }),
     "reclaim"
   );
+}
+
+export function defaultAppendUsageLimitEvent({ phase, ticket, orchId, orchDir, bgJobId, quota }) {
+  return appendEnvelopeBestEffort(buildEventEnvelope({
+    phase, ticket, orchId, action: "usage-limit-blocked",
+    reason: "account-usage-limit", ticketType: resolveTicketType(orchDir, ticket),
+    payloadExtras: { bgJobId, lane: "bg", resetsAt: quota.resetsAt, resetSource: quota.resetSource, source: quota.source, detail: quota.detail },
+  }));
 }
 
 // CTL-868 — defaultAppendOrphanDetectedEvent — phase.<phase>.orphan-detected.<ticket>.
@@ -2065,6 +2075,10 @@ export function reclaimDeadWorkIfPossible(
     // see detectSessionRateLimitHit's own header for the full rationale.
     // Never changes the STOP/escalate decision itself, only its explanation.
     detectRateLimit = detectSessionRateLimitHit,
+    detectUsageLimit = (id, opts) => detectUsageLimitBlock(id, { ...opts, detectTranscriptFn: detectSessionRateLimitHit }),
+    appendUsageLimitEvent = defaultAppendUsageLimitEvent,
+    recordDispatchFailureFn = null,
+    parkLaneFn = parkLane,
     appendReviveSuppressedEvent = defaultAppendReviveSuppressedEvent,
     reviveDispatch = defaultReviveDispatch,
     applyStalledLabel = defaultApplyStalledLabel,
@@ -3425,6 +3439,32 @@ export function reclaimDeadWorkIfPossible(
       "ctl-735: signal too old to revive — abandoned historical dir, inert"
     );
     return "inert-stale";
+  }
+
+  // CAT-58: a terminal bg worker blocked by the account quota must be parked
+  // before the progress gate; otherwise forward progress causes an immediate
+  // revive into the same exhausted lane.
+  let quota = { blocked: false };
+  try { quota = detectUsageLimit(prevBgJobId, { now }); } catch { quota = { blocked: false }; }
+  if (quota.blocked) {
+    if (prevBgJobId) {
+      emitReapIntent("phase.terminal.reap-requested", { ticket, phase, bgJobId: prevBgJobId, worktreePath: signal.raw?.worktreePath, reason: "cat-58-usage-limit-blocked" }).catch(() => {});
+      intentAwareKill({ bgJobId: prevBgJobId });
+    }
+    const signalPath = join(orchDir, "workers", ticket, `phase-${phase}.json`);
+    try {
+      const raw = JSON.parse(readFileSync(signalPath, "utf8"));
+      Object.assign(raw, { status: "failed", failureReason: "usage-limit-blocked", usageLimitResetsAt: quota.resetsAt, usageLimitDetail: quota.detail ?? null, usageLimitSource: quota.source, updatedAt: new Date(now()).toISOString() });
+      const tmp = `${signalPath}.tmp.${process.pid}`;
+      writeFileSync(tmp, JSON.stringify(raw, null, 2)); renameSync(tmp, signalPath);
+    } catch (err) { log.warn({ ticket, phase, err: err.message }, "cat-58: usage-limit signal write failed"); }
+    const expiresAtOverride = Date.parse(quota.resetsAt);
+    recordDispatchFailureFn?.(orchDir, ticket, phase, 0, now(), { expiresAtOverride, reasonCode: "usage-limit-blocked", countsTowardBreaker: false });
+    parkLaneFn?.(orchDir, "bg", { resetsAt: quota.resetsAt, detail: quota.detail, ticket, phase, now: now() });
+    appendUsageLimitEvent({ phase, ticket, orchId, orchDir, bgJobId: prevBgJobId, quota });
+    const explanation = buildUsageLimitExplanation({ ticket, phase, resetsAt: quota.resetsAt, lane: "bg", fallbackLane: "codex-exec", detail: quota.detail });
+    log.warn({ ticket, phase, resetsAt: quota.resetsAt, explanation }, "cat-58: account usage limit — parking instead of reviving");
+    return "usage-limit-parked";
   }
 
   // CTL-736 Phase 3 — THE progress gate. Replaces the MAX_REVIVES per-ticket

--- a/plugins/dev/scripts/execution-core/recovery.mjs
+++ b/plugins/dev/scripts/execution-core/recovery.mjs
@@ -2075,7 +2075,7 @@ export function reclaimDeadWorkIfPossible(
     // see detectSessionRateLimitHit's own header for the full rationale.
     // Never changes the STOP/escalate decision itself, only its explanation.
     detectRateLimit = detectSessionRateLimitHit,
-    detectUsageLimit = (id, opts) => detectUsageLimitBlock(id, { ...opts, detectTranscriptFn: detectSessionRateLimitHit }),
+    detectUsageLimit = (id, opts) => detectUsageLimitBlock(id, opts),
     appendUsageLimitEvent = defaultAppendUsageLimitEvent,
     recordDispatchFailureFn = null,
     parkLaneFn = parkLane,

--- a/plugins/dev/scripts/execution-core/recovery.mjs
+++ b/plugins/dev/scripts/execution-core/recovery.mjs
@@ -51,6 +51,7 @@ import {
 import { transcriptAgeMs as defaultTranscriptAgeMs } from "./transcript-silence.mjs";
 import { USAGE_LIMIT_TEXT_RE, detectUsageLimitBlock, buildUsageLimitExplanation } from "./usage-limit.mjs";
 import { parkLane } from "./lane-cooldown.mjs";
+import { resolveAccountResetsAt } from "./account-quota.mjs";
 import { scanEventsChunked, scanEventsSince, DEFAULT_TAIL_MAX_BYTES } from "./event-tail.mjs"; // CTL-1514 / CTL-1529: bounded event-log scans
 // CTL-863 fleet-unfreeze (entourage follow-up to #2552): readPeerHeartbeatsSyncCached is
 // the CACHED reader — a 45s in-process TTL cache around the same anchor-issue read, safe
@@ -2088,6 +2089,7 @@ export function reclaimDeadWorkIfPossible(
     appendUsageLimitEvent = defaultAppendUsageLimitEvent,
     recordDispatchFailureFn = null,
     parkLaneFn = parkLane,
+    resolveAccountResetsAtFn = resolveAccountResetsAt,
     appendReviveSuppressedEvent = defaultAppendReviveSuppressedEvent,
     reviveDispatch = defaultReviveDispatch,
     applyStalledLabel = defaultApplyStalledLabel,
@@ -3454,7 +3456,14 @@ export function reclaimDeadWorkIfPossible(
   // before the progress gate; otherwise forward progress causes an immediate
   // revive into the same exhausted lane.
   let quota = { blocked: false };
-  try { quota = detectUsageLimit(prevBgJobId, { now }); } catch { quota = { blocked: false }; }
+  try {
+    quota = detectUsageLimit(prevBgJobId, {
+      now,
+      pollerResetsAt: resolveAccountResetsAtFn?.(orchDir, { now }) ?? null,
+    });
+  } catch {
+    quota = { blocked: false };
+  }
   if (quota.blocked) {
     if (prevBgJobId) {
       emitReapIntent("phase.terminal.reap-requested", { ticket, phase, bgJobId: prevBgJobId, worktreePath: signal.raw?.worktreePath, reason: "cat-58-usage-limit-blocked" }).catch(() => {});

--- a/plugins/dev/scripts/execution-core/recovery.mjs
+++ b/plugins/dev/scripts/execution-core/recovery.mjs
@@ -574,11 +574,20 @@ export function defaultAppendReclaimEvent({
   );
 }
 
-export function defaultAppendUsageLimitEvent({ phase, ticket, orchId, orchDir, bgJobId, quota }) {
+export function defaultAppendUsageLimitEvent({ phase, ticket, orchId, orchDir, bgJobId, quota, explanation = null }) {
   return appendEnvelopeBestEffort(buildEventEnvelope({
     phase, ticket, orchId, action: "usage-limit-blocked",
     reason: "account-usage-limit", ticketType: resolveTicketType(orchDir, ticket),
-    payloadExtras: { bgJobId, lane: "bg", resetsAt: quota.resetsAt, resetSource: quota.resetSource, source: quota.source, detail: quota.detail },
+    payloadExtras: {
+      bgJobId,
+      lane: "bg",
+      resetsAt: quota.resetsAt,
+      resetSource: quota.resetSource,
+      source: quota.source,
+      detail: quota.detail,
+      problem: explanation?.problem ?? null,
+      callToAction: explanation?.call_to_action ?? null,
+    },
   }));
 }
 
@@ -3451,19 +3460,26 @@ export function reclaimDeadWorkIfPossible(
       emitReapIntent("phase.terminal.reap-requested", { ticket, phase, bgJobId: prevBgJobId, worktreePath: signal.raw?.worktreePath, reason: "cat-58-usage-limit-blocked" }).catch(() => {});
       intentAwareKill({ bgJobId: prevBgJobId });
     }
+    const explanation = buildUsageLimitExplanation({
+      ticket,
+      phase,
+      resetsAt: quota.resetsAt,
+      lane: "bg",
+      fallbackLane: "codex-exec",
+      detail: quota.detail,
+    });
     const signalPath = join(orchDir, "workers", ticket, `phase-${phase}.json`);
     try {
       const raw = JSON.parse(readFileSync(signalPath, "utf8"));
-      Object.assign(raw, { status: "failed", failureReason: "usage-limit-blocked", usageLimitResetsAt: quota.resetsAt, usageLimitDetail: quota.detail ?? null, usageLimitSource: quota.source, updatedAt: new Date(now()).toISOString() });
+      Object.assign(raw, { status: "failed", failureReason: "usage-limit-blocked", usageLimitResetsAt: quota.resetsAt, usageLimitDetail: quota.detail ?? null, usageLimitSource: quota.source, usageLimitExplanation: explanation, updatedAt: new Date(now()).toISOString() });
       const tmp = `${signalPath}.tmp.${process.pid}`;
       writeFileSync(tmp, JSON.stringify(raw, null, 2)); renameSync(tmp, signalPath);
     } catch (err) { log.warn({ ticket, phase, err: err.message }, "cat-58: usage-limit signal write failed"); }
     const expiresAtOverride = Date.parse(quota.resetsAt);
     recordDispatchFailureFn?.(orchDir, ticket, phase, 0, now(), { expiresAtOverride, reasonCode: "usage-limit-blocked", countsTowardBreaker: false });
     parkLaneFn?.(orchDir, "bg", { resetsAt: quota.resetsAt, detail: quota.detail, ticket, phase, now: now() });
-    appendUsageLimitEvent({ phase, ticket, orchId, orchDir, bgJobId: prevBgJobId, quota });
-    const explanation = buildUsageLimitExplanation({ ticket, phase, resetsAt: quota.resetsAt, lane: "bg", fallbackLane: "codex-exec", detail: quota.detail });
-    log.warn({ ticket, phase, resetsAt: quota.resetsAt, explanation }, "cat-58: account usage limit — parking instead of reviving");
+    appendUsageLimitEvent({ phase, ticket, orchId, orchDir, bgJobId: prevBgJobId, quota, explanation });
+    log.warn({ ticket, phase, resetsAt: quota.resetsAt }, "cat-58: account usage limit — parking instead of reviving");
     return "usage-limit-parked";
   }
 

--- a/plugins/dev/scripts/execution-core/scheduler.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.mjs
@@ -4746,6 +4746,7 @@ export function schedulerTick(
       resumeSession,
       clusterGeneration,
     });
+    const effectiveExecutor = rawDispatch?.effectiveExecutor;
     const dispatchWasAsync = isThenable(rawDispatch);
     // CTL-1367 P1: on a REJECTED async (sdk) dispatch the detached handler logs the
     // rejection AND emits the failed-terminal backstop (stalled signal +
@@ -4766,7 +4767,9 @@ export function schedulerTick(
       const v = verifyDispatched(orchDir, ticket, phase, { requireBgJob: !dispatchWasAsync });
       if (v.ok) {
         clearDispatchCooldown(orchDir, ticket, phase); // CTL-624: success clears any prior cool-down
-        if (dispatch === defaultDispatch) clearLaneCooldown(orchDir, "bg");
+        if (effectiveExecutor === "bg" || (effectiveExecutor == null && dispatch === defaultDispatch)) {
+          clearLaneCooldown(orchDir, "bg");
+        }
         // CTL-660: record the VERIFIED launch. Re-read the signal for the
         // bg_job_id + worktreePath the launched worker wrote.
         const signal = readPhaseSignalRaw(orchDir, ticket, phase);

--- a/plugins/dev/scripts/execution-core/scheduler.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.mjs
@@ -2546,18 +2546,19 @@ export function inDispatchCooldown(orchDir, ticket, phase, now) {
 // pre-CTL-671 marker without the counter reads as 0 (the `?? 0` default) and
 // self-upgrades on this write. clearDispatchCooldown rmSync's the whole marker,
 // so a successful dispatch resets the counter for free.
-export function recordDispatchFailure(orchDir, ticket, phase, code, now) {
+export function recordDispatchFailure(orchDir, ticket, phase, code, now, { expiresAtOverride = null, reasonCode = null, countsTowardBreaker = true } = {}) {
   const dir = join(orchDir, ".dispatch-cooldowns");
   const path = dispatchCooldownPath(orchDir, ticket, phase);
   const prev = readCooldownMarker(orchDir, ticket, phase);
   let consecutiveFailures = 1;
   if (prev?.code === code && typeof prev.consecutiveFailures === "number") {
-    consecutiveFailures = prev.consecutiveFailures + 1;
+    consecutiveFailures = countsTowardBreaker ? prev.consecutiveFailures + 1 : prev.consecutiveFailures;
   }
   const ttl = PERMANENT_FAILURE_CODES.has(code)
     ? DISPATCH_PERMANENT_COOLDOWN_MS
     : DISPATCH_COOLDOWN_MS;
-  const marker = { ticket, phase, code, failedAt: now, expiresAt: now + ttl, consecutiveFailures };
+  const expiresAt = Number.isFinite(expiresAtOverride) && expiresAtOverride > now ? expiresAtOverride : now + ttl;
+  const marker = { ticket, phase, code, reasonCode, failedAt: now, expiresAt, consecutiveFailures };
   try {
     mkdirSync(dir, { recursive: true });
     writeFileSync(path, JSON.stringify(marker));
@@ -5848,6 +5849,7 @@ export function schedulerTick(
         // suppression. null when CATALYST_BELIEFS_SHADOW=0 (the default — legacy tests
         // unaffected; intentAwareKill falls through to plain killBgJob).
         intentDb,
+        recordDispatchFailureFn: recordDispatchFailure,
         // CTL-863: thread this tick's live cluster gate + host identity so
         // reclaimDeadWork's postReclaimMirror fence zombie-guard is armed on a real
         // ≥2-host cluster (roster resolved per-tick above → no boot-time staleness).
@@ -5906,6 +5908,11 @@ export function schedulerTick(
         case "no-progress-stopped":
           // CTL-736 Phase 3: a dead worker that made zero forward progress was
           // stopped + flagged needs-human, never respawned (the futile idle loop).
+          noProgressStopped.push(entry);
+          break;
+        case "usage-limit-parked":
+          // Account quota is infrastructure state, not a ticket defect. The
+          // reset-anchored cooldown owns re-entry; do not label needs-human.
           noProgressStopped.push(entry);
           break;
         case "escalated":

--- a/plugins/dev/scripts/execution-core/scheduler.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.mjs
@@ -77,6 +77,7 @@ import {
   isThenable,
   backstopOnRejection,
 } from "./dispatch.mjs"; // CTL-1367 P1: settle async (sdk) dispatch synchronously + backstop a rejected async dispatch
+import { clearLaneCooldown } from "./lane-cooldown.mjs";
 import {
   fetchTicketState,
   fetchTicketsBatch,
@@ -2550,7 +2551,7 @@ export function recordDispatchFailure(orchDir, ticket, phase, code, now, { expir
   const dir = join(orchDir, ".dispatch-cooldowns");
   const path = dispatchCooldownPath(orchDir, ticket, phase);
   const prev = readCooldownMarker(orchDir, ticket, phase);
-  let consecutiveFailures = 1;
+  let consecutiveFailures = countsTowardBreaker ? 1 : 0;
   if (prev?.code === code && typeof prev.consecutiveFailures === "number") {
     consecutiveFailures = countsTowardBreaker ? prev.consecutiveFailures + 1 : prev.consecutiveFailures;
   }
@@ -4765,6 +4766,7 @@ export function schedulerTick(
       const v = verifyDispatched(orchDir, ticket, phase, { requireBgJob: !dispatchWasAsync });
       if (v.ok) {
         clearDispatchCooldown(orchDir, ticket, phase); // CTL-624: success clears any prior cool-down
+        if (dispatch === defaultDispatch) clearLaneCooldown(orchDir, "bg");
         // CTL-660: record the VERIFIED launch. Re-read the signal for the
         // bg_job_id + worktreePath the launched worker wrote.
         const signal = readPhaseSignalRaw(orchDir, ticket, phase);
@@ -4824,6 +4826,17 @@ export function schedulerTick(
         });
       }
       return { ok: false, code: 0, reason, signal: null };
+    }
+
+    // A parked executor lane is infrastructure state, not a ticket failure.
+    // Arm a retry cooldown without incrementing the breaker or emitting a
+    // misleading phase.dispatch.failed event.
+    if (r.deferred) {
+      const cd = recordDispatchFailure(orchDir, ticket, phase, r.code, now(), {
+        countsTowardBreaker: false,
+        reasonCode: r.reason ?? "no-healthy-executor-lane",
+      });
+      return { ok: false, code: r.code, reason: r.reason, deferred: true, expiresAt: cd.expiresAt, signal: null };
     }
 
     // rc != 0 — real dispatch failure.

--- a/plugins/dev/scripts/execution-core/scheduler.test.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.test.mjs
@@ -105,6 +105,8 @@ import { removeLabel as realRemoveLabel } from "./linear-write.mjs"; // CTL-1079
 import { bootResumePendingPath, bootResumeApprovedPath } from "./boot-resume.mjs"; // CTL-1367 P2-C: per-tick approval-poll dispatch wiring
 import { recordRemovalFailure } from "./label-guard.mjs"; // CTL-1605 Codex thread: drive needs-human into CTL-1078 backoff for the terminal-stale multi-label tests
 import { getDrainFlagPath, getEventLogPath } from "./config.mjs"; // CTL-1678: drain-disabled override integration test
+import { makePhaseAwareDispatchFn } from "./dispatch.mjs";
+import { laneCooldownPath, parkLane } from "./lane-cooldown.mjs";
 
 let orchDir;
 let catalystDir;
@@ -11270,6 +11272,29 @@ describe("dispatchAndVerify shared core (CTL-826)", () => {
     });
     // No failure event on the success branch.
     expect(dispatchFailedEvents("CTL-826A")).toHaveLength(0);
+  });
+
+  test("verified production phase-aware bg launch clears the bg lane park", () => {
+    writeSignal("CTL-826-LANE", "research", "done");
+    writeFileSync(join(orchDir, "state.json"), JSON.stringify({ maxParallel: 1 }));
+    parkLane(orchDir, "bg", { resetsAt: "2026-08-10T18:00:00.000Z", now: 1_000 });
+    const dispatch = makePhaseAwareDispatchFn({
+      bootExecutor: "bg",
+      codexBootEligible: false,
+      orchDir,
+      now: () => Date.parse("2026-08-11T18:00:00.000Z"),
+      resolveExecutorForPhase: () => ({ source: "executor", executor: "bg" }),
+      dispatchForExecutor: () => dispatchWritesSignal(),
+    });
+
+    const r = schedulerTick(orchDir, {
+      readEligible: () => [],
+      dispatch,
+      now: () => Date.parse("2026-08-11T18:00:00.000Z"),
+    });
+
+    expect(r.advanced).toContainEqual({ ticket: "CTL-826-LANE", phase: "plan" });
+    expect(existsSync(laneCooldownPath(orchDir, "bg"))).toBe(false);
   });
 
   // ─── Branch 2: verify-failed (rc=0, no live signal) ───

--- a/plugins/dev/scripts/execution-core/scheduler.test.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.test.mjs
@@ -1793,6 +1793,33 @@ describe("phantom worker-dir validity sweep (CTL-671)", () => {
   });
 });
 
+describe("CAT-58 deferred executor-lane dispatch", () => {
+  test("does not count a deferred dispatch as a ticket failure", () => {
+    writeFileSync(join(orchDir, "state.json"), JSON.stringify({ maxParallel: 1 }));
+    const failedEvents = [];
+    schedulerTick(orchDir, {
+      readEligible: () => [{
+        identifier: "CAT-58-DEFERRED",
+        priority: 1,
+        createdAt: "x",
+        state: { name: "Todo" },
+        relations: { nodes: [] },
+        inverseRelations: { nodes: [] },
+      }],
+      dispatch: () => ({ code: 75, deferred: true, reason: "no-healthy-executor-lane" }),
+      liveBackgroundCount: () => 0,
+      hosts: ["vega"],
+      hostName: "vega",
+      appendDispatchFailedEvent: (event) => failedEvents.push(event),
+      hasTriageArtifact: () => true,
+      fetchBatch: mkBatch({ "CAT-58-DEFERRED": { state: "Todo", priority: 1, labels: [], relations: { nodes: [] }, inverseRelations: { nodes: [] } } }),
+    });
+    const marker = JSON.parse(readFileSync(dispatchCooldownPath(orchDir, "CAT-58-DEFERRED", "research"), "utf8"));
+    expect(marker).toMatchObject({ consecutiveFailures: 0, reasonCode: "no-healthy-executor-lane" });
+    expect(failedEvents).toHaveLength(0);
+  });
+});
+
 // ── CTL-671 Phase 4: runaway event-rate domination alert ──
 describe("runaway event-rate alert (CTL-671)", () => {
   test("emits exactly one runaway event per window when a ticket dominates", () => {

--- a/plugins/dev/scripts/execution-core/usage-limit.mjs
+++ b/plugins/dev/scripts/execution-core/usage-limit.mjs
@@ -10,7 +10,6 @@ export function readJobTimelineBlock(bgJobId, { readFileFn = readFileSync, jobsR
   if (!bgJobId) return miss;
   let raw;
   try {
-    // EVENT-LOG-FULL-READ-OK(CTL-1442): one job's bounded timeline, not the shared event log.
     raw = readFileFn(join(jobsRoot ?? getJobsRoot(), bgJobId, "timeline.jsonl"), "utf8");
   } catch {
     return miss;

--- a/plugins/dev/scripts/execution-core/usage-limit.mjs
+++ b/plugins/dev/scripts/execution-core/usage-limit.mjs
@@ -2,10 +2,15 @@ import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import { getJobsRoot } from "./config.mjs";
 
-export const USAGE_LIMIT_TEXT_RE = /\bhit\s+your\s+(?:[A-Za-z0-9][A-Za-z0-9-]*\s+){0,3}limit\b/i;
-export const USAGE_LIMIT_FALLBACK_MS = Number(process.env.CATALYST_USAGE_LIMIT_FALLBACK_MS) || 3_600_000;
+export const USAGE_LIMIT_TEXT_RE =
+  /\bhit\s+your\s+(?:(?:opus|sonnet)\s+)?(?:session|usage|weekly|daily|five-hour|5-hour)\s+limit\b/i;
+export const USAGE_LIMIT_FALLBACK_MS =
+  Number(process.env.CATALYST_USAGE_LIMIT_FALLBACK_MS) || 3_600_000;
 
-export function readJobTimelineBlock(bgJobId, { readFileFn = readFileSync, jobsRoot = null, tailLines = 50 } = {}) {
+export function readJobTimelineBlock(
+  bgJobId,
+  { readFileFn = readFileSync, jobsRoot = null, tailLines = 50 } = {}
+) {
   const miss = { blocked: false, at: null, detail: null };
   if (!bgJobId) return miss;
   let raw;
@@ -14,12 +19,18 @@ export function readJobTimelineBlock(bgJobId, { readFileFn = readFileSync, jobsR
   } catch {
     return miss;
   }
-  const lines = String(raw).split("\n").filter((line) => line.trim());
+  const lines = String(raw)
+    .split("\n")
+    .filter((line) => line.trim());
   for (let i = lines.length - 1; i >= Math.max(0, lines.length - tailLines); i--) {
     let entry;
-    try { entry = JSON.parse(lines[i]); } catch { continue; }
+    try {
+      entry = JSON.parse(lines[i]);
+    } catch {
+      continue;
+    }
     if (entry?.state !== "blocked") continue;
-    const detail = typeof entry.detail === "string" ? entry.detail : typeof entry.text === "string" ? entry.text : "";
+    const detail = typeof entry.detail === "string" ? entry.detail : "";
     if (USAGE_LIMIT_TEXT_RE.test(detail)) return { blocked: true, at: entry.at ?? null, detail };
   }
   return miss;
@@ -28,36 +39,102 @@ export function readJobTimelineBlock(bgJobId, { readFileFn = readFileSync, jobsR
 export function parseResetFromDetail(detail, { pollerResetsAt = null, now = Date.now } = {}) {
   const nowMs = now();
   const polled = Date.parse(pollerResetsAt ?? "");
-  if (Number.isFinite(polled) && polled > nowMs) return { resetsAt: new Date(polled).toISOString(), resetSource: "poller" };
-  const match = /resets\s+([A-Z][a-z]{2}\s+\d{1,2})\s+at\s+(\d{1,2})\s*(am|pm)/i.exec(detail ?? "");
+  if (Number.isFinite(polled) && polled > nowMs)
+    return { resetsAt: new Date(polled).toISOString(), resetSource: "poller" };
+  const match =
+    /resets\s+([A-Z][a-z]{2})\s+(\d{1,2})\s+at\s+(\d{1,2})\s*(am|pm)(?:\s+\(([^)]+)\))?/i.exec(
+      detail ?? ""
+    );
   if (match) {
-    const year = new Date(nowMs).getUTCFullYear();
-    let hour = Number(match[2]) % 12;
-    if (/pm/i.test(match[3])) hour += 12;
-    const parsed = Date.parse(`${match[1]} ${year} ${String(hour).padStart(2, "0")}:00:00Z`);
-    if (Number.isFinite(parsed) && parsed > nowMs) return { resetsAt: new Date(parsed).toISOString(), resetSource: "detail" };
+    const timeZone = match[5] || Intl.DateTimeFormat().resolvedOptions().timeZone;
+    const year = Number(
+      new Intl.DateTimeFormat("en-US", { timeZone, year: "numeric" }).format(new Date(nowMs))
+    );
+    const month = new Date(`${match[1]} 1, 2000 UTC`).getUTCMonth();
+    let hour = Number(match[3]) % 12;
+    if (/pm/i.test(match[4])) hour += 12;
+    const wallClockUtc = Date.UTC(year, month, Number(match[2]), hour);
+    let parsed = wallClockUtc;
+    try {
+      const formatter = new Intl.DateTimeFormat("en-US", {
+        timeZone,
+        year: "numeric",
+        month: "numeric",
+        day: "numeric",
+        hour: "numeric",
+        hourCycle: "h23",
+      });
+      for (let attempt = 0; attempt < 2; attempt++) {
+        const parts = Object.fromEntries(
+          formatter
+            .formatToParts(new Date(parsed))
+            .filter(({ type }) => type !== "literal")
+            .map(({ type, value }) => [type, Number(value)])
+        );
+        const renderedAsUtc = Date.UTC(parts.year, parts.month - 1, parts.day, parts.hour);
+        parsed += wallClockUtc - renderedAsUtc;
+      }
+    } catch {
+      parsed = Number.NaN;
+    }
+    if (Number.isFinite(parsed) && parsed > nowMs)
+      return { resetsAt: new Date(parsed).toISOString(), resetSource: "detail" };
   }
-  return { resetsAt: new Date(nowMs + USAGE_LIMIT_FALLBACK_MS).toISOString(), resetSource: "default" };
+  return {
+    resetsAt: new Date(nowMs + USAGE_LIMIT_FALLBACK_MS).toISOString(),
+    resetSource: "default",
+  };
 }
 
-export function detectUsageLimitBlock(bgJobId, { readTimelineFn = readJobTimelineBlock, detectTranscriptFn = null, pollerResetsAt = null, now = Date.now } = {}) {
-  const miss = { blocked: false, source: null, detail: null, at: null, resetsAt: null, resetSource: null };
+export function detectUsageLimitBlock(
+  bgJobId,
+  { readTimelineFn = readJobTimelineBlock, pollerResetsAt = null, now = Date.now } = {}
+) {
+  const miss = {
+    blocked: false,
+    source: null,
+    detail: null,
+    at: null,
+    resetsAt: null,
+    resetSource: null,
+  };
   if (!bgJobId) return miss;
   let timeline;
-  try { timeline = readTimelineFn(bgJobId); } catch { timeline = null; }
-  if (timeline?.blocked) return { blocked: true, source: "timeline", detail: timeline.detail, at: timeline.at, ...parseResetFromDetail(timeline.detail, { pollerResetsAt, now }) };
-  let transcript = false;
-  try { transcript = detectTranscriptFn ? !!detectTranscriptFn(bgJobId) : false; } catch { transcript = false; }
-  return transcript ? { blocked: true, source: "transcript", detail: null, at: null, ...parseResetFromDetail(null, { pollerResetsAt, now }) } : miss;
+  try {
+    timeline = readTimelineFn(bgJobId);
+  } catch {
+    timeline = null;
+  }
+  if (timeline?.blocked)
+    return {
+      blocked: true,
+      source: "timeline",
+      detail: timeline.detail,
+      at: timeline.at,
+      ...parseResetFromDetail(timeline.detail, { pollerResetsAt, now }),
+    };
+  return miss;
 }
 
-export function buildUsageLimitExplanation({ ticket = "ticket", phase = "phase", resetsAt = null, lane = "bg", fallbackLane = null, detail = null } = {}) {
+export function buildUsageLimitExplanation({
+  ticket = "ticket",
+  phase = "phase",
+  resetsAt = null,
+  lane = "bg",
+  fallbackLane = null,
+  detail = null,
+} = {}) {
   const when = resetsAt ? new Date(resetsAt).toISOString() : "an unknown time";
   return {
     problem: `${ticket} ${phase} did not fail — the Claude account's usage limit is exhausted, so the ${lane} worker blocked before doing any work (${detail ?? "usage limit reached"}). The ticket itself is healthy.`,
     call_to_action: fallbackLane
       ? `No action needed to keep ${ticket} moving — it is rerouted to the ${fallbackLane} lane and the ${lane} lane is suppressed until ${when}. Intervene only to change lanes or raise the account's quota.`
       : `Retrying cannot succeed before ${when} and no healthy alternate lane is available on this node. Either wait for the reset, raise the account's quota, or route this phase to another executor/host.`,
-    observed: { likely_cause: "account-usage-limit", resets_at: resetsAt, lane, fallback_lane: fallbackLane },
+    observed: {
+      likely_cause: "account-usage-limit",
+      resets_at: resetsAt,
+      lane,
+      fallback_lane: fallbackLane,
+    },
   };
 }

--- a/plugins/dev/scripts/execution-core/usage-limit.mjs
+++ b/plugins/dev/scripts/execution-core/usage-limit.mjs
@@ -1,0 +1,64 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { getJobsRoot } from "./config.mjs";
+
+export const USAGE_LIMIT_TEXT_RE = /\bhit\s+your\s+(?:[A-Za-z0-9][A-Za-z0-9-]*\s+){0,3}limit\b/i;
+export const USAGE_LIMIT_FALLBACK_MS = Number(process.env.CATALYST_USAGE_LIMIT_FALLBACK_MS) || 3_600_000;
+
+export function readJobTimelineBlock(bgJobId, { readFileFn = readFileSync, jobsRoot = null, tailLines = 50 } = {}) {
+  const miss = { blocked: false, at: null, detail: null };
+  if (!bgJobId) return miss;
+  let raw;
+  try {
+    // EVENT-LOG-FULL-READ-OK(CTL-1442): one job's bounded timeline, not the shared event log.
+    raw = readFileFn(join(jobsRoot ?? getJobsRoot(), bgJobId, "timeline.jsonl"), "utf8");
+  } catch {
+    return miss;
+  }
+  const lines = String(raw).split("\n").filter((line) => line.trim());
+  for (let i = lines.length - 1; i >= Math.max(0, lines.length - tailLines); i--) {
+    let entry;
+    try { entry = JSON.parse(lines[i]); } catch { continue; }
+    if (entry?.state !== "blocked") continue;
+    const detail = typeof entry.detail === "string" ? entry.detail : typeof entry.text === "string" ? entry.text : "";
+    if (USAGE_LIMIT_TEXT_RE.test(detail)) return { blocked: true, at: entry.at ?? null, detail };
+  }
+  return miss;
+}
+
+export function parseResetFromDetail(detail, { pollerResetsAt = null, now = Date.now } = {}) {
+  const nowMs = now();
+  const polled = Date.parse(pollerResetsAt ?? "");
+  if (Number.isFinite(polled) && polled > nowMs) return { resetsAt: new Date(polled).toISOString(), resetSource: "poller" };
+  const match = /resets\s+([A-Z][a-z]{2}\s+\d{1,2})\s+at\s+(\d{1,2})\s*(am|pm)/i.exec(detail ?? "");
+  if (match) {
+    const year = new Date(nowMs).getUTCFullYear();
+    let hour = Number(match[2]) % 12;
+    if (/pm/i.test(match[3])) hour += 12;
+    const parsed = Date.parse(`${match[1]} ${year} ${String(hour).padStart(2, "0")}:00:00Z`);
+    if (Number.isFinite(parsed) && parsed > nowMs) return { resetsAt: new Date(parsed).toISOString(), resetSource: "detail" };
+  }
+  return { resetsAt: new Date(nowMs + USAGE_LIMIT_FALLBACK_MS).toISOString(), resetSource: "default" };
+}
+
+export function detectUsageLimitBlock(bgJobId, { readTimelineFn = readJobTimelineBlock, detectTranscriptFn = null, pollerResetsAt = null, now = Date.now } = {}) {
+  const miss = { blocked: false, source: null, detail: null, at: null, resetsAt: null, resetSource: null };
+  if (!bgJobId) return miss;
+  let timeline;
+  try { timeline = readTimelineFn(bgJobId); } catch { timeline = null; }
+  if (timeline?.blocked) return { blocked: true, source: "timeline", detail: timeline.detail, at: timeline.at, ...parseResetFromDetail(timeline.detail, { pollerResetsAt, now }) };
+  let transcript = false;
+  try { transcript = detectTranscriptFn ? !!detectTranscriptFn(bgJobId) : false; } catch { transcript = false; }
+  return transcript ? { blocked: true, source: "transcript", detail: null, at: null, ...parseResetFromDetail(null, { pollerResetsAt, now }) } : miss;
+}
+
+export function buildUsageLimitExplanation({ ticket = "ticket", phase = "phase", resetsAt = null, lane = "bg", fallbackLane = null, detail = null } = {}) {
+  const when = resetsAt ? new Date(resetsAt).toISOString() : "an unknown time";
+  return {
+    problem: `${ticket} ${phase} did not fail — the Claude account's usage limit is exhausted, so the ${lane} worker blocked before doing any work (${detail ?? "usage limit reached"}). The ticket itself is healthy.`,
+    call_to_action: fallbackLane
+      ? `No action needed to keep ${ticket} moving — it is rerouted to the ${fallbackLane} lane and the ${lane} lane is suppressed until ${when}. Intervene only to change lanes or raise the account's quota.`
+      : `Retrying cannot succeed before ${when} and no healthy alternate lane is available on this node. Either wait for the reset, raise the account's quota, or route this phase to another executor/host.`,
+    observed: { likely_cause: "account-usage-limit", resets_at: resetsAt, lane, fallback_lane: fallbackLane },
+  };
+}

--- a/plugins/dev/scripts/execution-core/usage-limit.test.mjs
+++ b/plugins/dev/scripts/execution-core/usage-limit.test.mjs
@@ -1,0 +1,50 @@
+import { test, expect } from "bun:test";
+import {
+  USAGE_LIMIT_TEXT_RE,
+  USAGE_LIMIT_FALLBACK_MS,
+  parseResetFromDetail,
+  readJobTimelineBlock,
+  detectUsageLimitBlock,
+  buildUsageLimitExplanation,
+} from "./usage-limit.mjs";
+
+test("vocabulary covers account usage-limit phrasings without matching unrelated limits", () => {
+  for (const text of ["You've hit your weekly limit", "You've hit your session limit", "You've hit your usage limit", "You've hit your 5-hour limit", "you have hit your Opus weekly limit"]) {
+    expect(USAGE_LIMIT_TEXT_RE.test(text)).toBe(true);
+  }
+  for (const text of ["the rate limit on the GitHub API", "I hit your test's assertion limit of 3", "turn cap exhausted"]) {
+    expect(USAGE_LIMIT_TEXT_RE.test(text)).toBe(false);
+  }
+});
+
+test("timeline recognition returns the latest relevant block and fails closed", () => {
+  const raw = [
+    JSON.stringify({ at: "old", state: "blocked", detail: "You've hit your session limit" }),
+    JSON.stringify({ at: "noise", state: "blocked", detail: "stuck on a startup dialog" }),
+    JSON.stringify({ at: "new", state: "blocked", detail: "You've hit your weekly limit" }),
+  ].join("\n");
+  expect(readJobTimelineBlock("job", { readFileFn: () => raw })).toEqual({ blocked: true, at: "new", detail: "You've hit your weekly limit" });
+  expect(readJobTimelineBlock("job", { readFileFn: () => "not json\n{" }).blocked).toBe(false);
+  expect(readJobTimelineBlock("job", { readFileFn: () => { throw new Error("ENOENT"); } }).blocked).toBe(false);
+});
+
+test("reset selection prefers poller, then prose, then bounded default", () => {
+  const now = () => Date.parse("2026-08-08T20:29:57Z");
+  expect(parseResetFromDetail("resets Aug 10 at 1pm", { pollerResetsAt: "2026-08-10T17:59:59Z", now }).resetSource).toBe("poller");
+  expect(parseResetFromDetail("resets Aug 10 at 1pm (America/Chicago)", { now }).resetSource).toBe("detail");
+  expect(Date.parse(parseResetFromDetail("weekly limit", { now }).resetsAt)).toBe(now() + USAGE_LIMIT_FALLBACK_MS);
+});
+
+test("detector uses timeline then transcript and never throws", () => {
+  expect(detectUsageLimitBlock("job", { readTimelineFn: () => ({ blocked: false }), detectTranscriptFn: () => true, now: () => 1000 }).source).toBe("transcript");
+  expect(detectUsageLimitBlock(null, {}).blocked).toBe(false);
+  expect(detectUsageLimitBlock("job", { readTimelineFn: () => { throw new Error("boom"); } }).blocked).toBe(false);
+});
+
+test("usage-limit explanation names reset and fallback availability", () => {
+  const withFallback = buildUsageLimitExplanation({ ticket: "CAT-58", phase: "research", resetsAt: "2026-08-10T17:59:59Z", fallbackLane: "codex-exec" });
+  expect(withFallback.problem).toMatch(/usage limit/i);
+  expect(withFallback.call_to_action).toMatch(/codex-exec/);
+  expect(withFallback.call_to_action).toContain("2026-08-10");
+  expect(buildUsageLimitExplanation({ ticket: "CAT-58", phase: "research", fallbackLane: null }).call_to_action).toMatch(/no healthy/i);
+});

--- a/plugins/dev/scripts/execution-core/usage-limit.test.mjs
+++ b/plugins/dev/scripts/execution-core/usage-limit.test.mjs
@@ -9,10 +9,23 @@ import {
 } from "./usage-limit.mjs";
 
 test("vocabulary covers account usage-limit phrasings without matching unrelated limits", () => {
-  for (const text of ["You've hit your weekly limit", "You've hit your session limit", "You've hit your usage limit", "You've hit your 5-hour limit", "you have hit your Opus weekly limit"]) {
+  for (const text of [
+    "You've hit your weekly limit",
+    "You've hit your session limit",
+    "You've hit your usage limit",
+    "You've hit your 5-hour limit",
+    "you have hit your Opus weekly limit",
+  ]) {
     expect(USAGE_LIMIT_TEXT_RE.test(text)).toBe(true);
   }
-  for (const text of ["the rate limit on the GitHub API", "I hit your test's assertion limit of 3", "turn cap exhausted"]) {
+  for (const text of [
+    "the rate limit on the GitHub API",
+    "I hit your test's assertion limit of 3",
+    "turn cap exhausted",
+    "You have hit your context window limit",
+    "You hit your maximum output token limit",
+    "Prompt is too long: you hit your token limit",
+  ]) {
     expect(USAGE_LIMIT_TEXT_RE.test(text)).toBe(false);
   }
 });
@@ -23,28 +36,70 @@ test("timeline recognition returns the latest relevant block and fails closed", 
     JSON.stringify({ at: "noise", state: "blocked", detail: "stuck on a startup dialog" }),
     JSON.stringify({ at: "new", state: "blocked", detail: "You've hit your weekly limit" }),
   ].join("\n");
-  expect(readJobTimelineBlock("job", { readFileFn: () => raw })).toEqual({ blocked: true, at: "new", detail: "You've hit your weekly limit" });
+  expect(readJobTimelineBlock("job", { readFileFn: () => raw })).toEqual({
+    blocked: true,
+    at: "new",
+    detail: "You've hit your weekly limit",
+  });
   expect(readJobTimelineBlock("job", { readFileFn: () => "not json\n{" }).blocked).toBe(false);
-  expect(readJobTimelineBlock("job", { readFileFn: () => { throw new Error("ENOENT"); } }).blocked).toBe(false);
+  expect(
+    readJobTimelineBlock("job", {
+      readFileFn: () => {
+        throw new Error("ENOENT");
+      },
+    }).blocked
+  ).toBe(false);
 });
 
 test("reset selection prefers poller, then prose, then bounded default", () => {
   const now = () => Date.parse("2026-08-08T20:29:57Z");
-  expect(parseResetFromDetail("resets Aug 10 at 1pm", { pollerResetsAt: "2026-08-10T17:59:59Z", now }).resetSource).toBe("poller");
-  expect(parseResetFromDetail("resets Aug 10 at 1pm (America/Chicago)", { now }).resetSource).toBe("detail");
-  expect(Date.parse(parseResetFromDetail("weekly limit", { now }).resetsAt)).toBe(now() + USAGE_LIMIT_FALLBACK_MS);
+  expect(
+    parseResetFromDetail("resets Aug 10 at 1pm", { pollerResetsAt: "2026-08-10T17:59:59Z", now })
+      .resetSource
+  ).toBe("poller");
+  expect(parseResetFromDetail("resets Aug 10 at 1pm (America/Chicago)", { now }).resetSource).toBe(
+    "detail"
+  );
+  expect(
+    parseResetFromDetail("You've hit your weekly limit · resets Aug 10 at 1pm (America/Chicago)", {
+      now,
+    }).resetsAt
+  ).toBe("2026-08-10T18:00:00.000Z");
+  expect(Date.parse(parseResetFromDetail("weekly limit", { now }).resetsAt)).toBe(
+    now() + USAGE_LIMIT_FALLBACK_MS
+  );
 });
 
-test("detector uses timeline then transcript and never throws", () => {
-  expect(detectUsageLimitBlock("job", { readTimelineFn: () => ({ blocked: false }), detectTranscriptFn: () => true, now: () => 1000 }).source).toBe("transcript");
+test("detector uses timeline detail only and never throws", () => {
+  expect(
+    detectUsageLimitBlock("job", {
+      readTimelineFn: () => ({ blocked: false }),
+      detectTranscriptFn: () => true,
+      now: () => 1000,
+    }).blocked
+  ).toBe(false);
   expect(detectUsageLimitBlock(null, {}).blocked).toBe(false);
-  expect(detectUsageLimitBlock("job", { readTimelineFn: () => { throw new Error("boom"); } }).blocked).toBe(false);
+  expect(
+    detectUsageLimitBlock("job", {
+      readTimelineFn: () => {
+        throw new Error("boom");
+      },
+    }).blocked
+  ).toBe(false);
 });
 
 test("usage-limit explanation names reset and fallback availability", () => {
-  const withFallback = buildUsageLimitExplanation({ ticket: "CAT-58", phase: "research", resetsAt: "2026-08-10T17:59:59Z", fallbackLane: "codex-exec" });
+  const withFallback = buildUsageLimitExplanation({
+    ticket: "CAT-58",
+    phase: "research",
+    resetsAt: "2026-08-10T17:59:59Z",
+    fallbackLane: "codex-exec",
+  });
   expect(withFallback.problem).toMatch(/usage limit/i);
   expect(withFallback.call_to_action).toMatch(/codex-exec/);
   expect(withFallback.call_to_action).toContain("2026-08-10");
-  expect(buildUsageLimitExplanation({ ticket: "CAT-58", phase: "research", fallbackLane: null }).call_to_action).toMatch(/no healthy/i);
+  expect(
+    buildUsageLimitExplanation({ ticket: "CAT-58", phase: "research", fallbackLane: null })
+      .call_to_action
+  ).toMatch(/no healthy/i);
 });


### PR DESCRIPTION
<!-- Auto-generated: 2026-08-09T13:07:09Z -->
<!-- Last updated: 2026-08-09T13:12:46Z -->
<!-- PR: #3160 -->
<!-- Previous commits: 359d9f33a773f47c45e0b0687856a6e9a7122a82,950a22b933faad6ffc8004304b797d563f20f380,d6d23fdf2b8d088d74a95a67d6ea9be1527f900d,e822648e176a6812aaa585243235abc9a39ab9ed,4672394fe35b8d51837cff3f0188ce744c1e353a,c6057e1d4f86ae545580fe1fb93e2d971a20c322,6b0500658096269f20ed093448851a7ebe92e92e,e18230245785a34ac614e89bf68ed0fef5030b79,9d02a4b7824eaa26995be818f775e9f6fbb0962f,b4e152da6c973a3ed066bad9ef9669ba0540be9d -->

## Summary

A worker blocked on the Claude account's **weekly usage limit** is currently reported as a dead
process: it never writes a `bg_job_id`, the orphan sweep reads the absent job as a vanished
process, marks the phase `orphan-sweep-stale`, and the recovery ladder re-dispatches into the same
wall until the limit resets. The escalation that eventually reaches a human asks "retry or close?",
never mentioning the account is out of quota.

This adds a distinct signal for that state and stops the fleet from burning re-dispatch attempts on it.

- `usage-limit.mjs` — reads the job timeline's `state: "blocked"` entry and surfaces the reset time.
- `lane-cooldown.mjs` — suppresses re-dispatch on the blocked lane until the reset timestamp passes.
- `dispatch.mjs` — writes a distinct `failureReason` instead of falling through to `orphan-sweep-stale`.
- `board-health.mjs` — surfaces the account usage cliff as a board-health invariant so the
  fleet-wide condition is visible to the board scan.

## Rebase note (recovery-pass delegate)

This branch was stalled mid-rebase on a conflict with **CAT-40** (#3143), which landed the GitHub
core REST quota check and repurposed `checkRateLimitHeadroom` for it. Both concerns are real and
reset independently, so they are now **two separate invariants** rather than one overloaded key:

| Invariant | Measures | Origin |
| --- | --- | --- |
| `rateLimitHeadroom` | GitHub core REST quota snapshot | CAT-40 (unchanged) |
| `accountUsageHeadroom` | Anthropic 5h / 7d subscription utilization | CAT-58 (new) |

Both now gate the board-scan's Gate 3 — either cliff makes acting futile.

CAT-40 also locked in a passthrough contract for the `account.ratelimit` ring (a test asserts the
ring does **not** synthesize `nearCliff`). That contract is preserved: the ring stays raw sampled
telemetry and the cliff is derived inside `checkAccountUsageHeadroom` instead. `accountUsageHeadroom`
is registered in the cohort-gated block, so the `off`-mode invariant set stays byte-identical to main.

## Testing

`bun test board-health usage-limit lane-cooldown dispatch-usage-limit-fallback` — **227 pass, 0 fail**.


<!-- Linear automation guard (CTL-623/CTL-633): unlink sibling tickets so this PR does not drag their workflow status. -->
skip CAT-40
