### PR TITLE
fix(dev): CAT-23 keep dispatch ownership on live roster during outages

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -99,10 +99,18 @@ offline owner's slice fails over to a live host instead of stranding in Todo for
   is NOT reclaimed, since a never-seen host has no work to reclaim). The asymmetry is deliberate:
   dispatch fails an unseen owner's slice **over**; recovery must not reclaim a host's non-existent work.
 
-Both altitudes preserve the same fail-safes: single-host is a strict no-op, and a total liveness
-outage (heartbeat read throws / everyone looks dead) degrades to the **full roster** (each node owns
-only its own HRW slice — never double-acts). The Linear-CAS claim (`cluster-claim.mjs` soft-CAS on
-`catalyst://fence/<TICKET>`, applied HRW-first/claim-second) remains the transition-race serializer.
+Both altitudes preserve the single-host no-op. A transient total-liveness outage degrades to the
+**full roster**. After five minutes, dispatch defaults to the persisted last-known-good live roster;
+`catalyst.cluster.dispatchOutageFallback: "full-roster"` explicitly opts back into the old sustained
+outage behavior. A cold start with no last-known-good set remains on the full roster rather than
+using `[self]`, which would make every host own every ticket. The Linear-CAS claim
+(`cluster-claim.mjs` soft-CAS on `catalyst://fence/<TICKET>`, applied HRW-first/claim-second) remains
+the transition-race serializer.
+
+The daemon boot announcement reports `ownsRawRoster` and `ownsDispatchRoster`; only the latter
+reflects live dispatch ownership. Board health's `strandedNode` invariant is liveness-driven.
+Team-level reconcile failures remain visible as context but never authorize takeover of another
+host's work.
 
 **Board-health ownership scope (CAT-57).** Board-health uses the same dispatch roster as the
 scheduler's new-work gate when assigning eligible tickets, rather than hashing over the raw roster.

--- a/plugins/dev/scripts/execution-core/__tests__/config-dispatch-outage-fallback.test.mjs
+++ b/plugins/dev/scripts/execution-core/__tests__/config-dispatch-outage-fallback.test.mjs
@@ -20,4 +20,8 @@ describe("getDispatchOutageFallback", () => {
     process.env.CATALYST_DISPATCH_OUTAGE_FALLBACK = "invalid";
     expect(getDispatchOutageFallback()).toBe("last-known-good");
   });
+  test("an empty environment value is treated as absent", () => {
+    process.env.CATALYST_DISPATCH_OUTAGE_FALLBACK = "";
+    expect(getDispatchOutageFallback()).toBe("last-known-good");
+  });
 });

--- a/plugins/dev/scripts/execution-core/__tests__/config-dispatch-outage-fallback.test.mjs
+++ b/plugins/dev/scripts/execution-core/__tests__/config-dispatch-outage-fallback.test.mjs
@@ -1,0 +1,23 @@
+import { describe, test, expect, afterEach } from "bun:test";
+import { getDispatchOutageFallback } from "../config.mjs";
+
+const prior = process.env.CATALYST_DISPATCH_OUTAGE_FALLBACK;
+afterEach(() => {
+  if (prior === undefined) delete process.env.CATALYST_DISPATCH_OUTAGE_FALLBACK;
+  else process.env.CATALYST_DISPATCH_OUTAGE_FALLBACK = prior;
+});
+
+describe("getDispatchOutageFallback", () => {
+  test("defaults to last-known-good", () => {
+    delete process.env.CATALYST_DISPATCH_OUTAGE_FALLBACK;
+    expect(getDispatchOutageFallback()).toBe("last-known-good");
+  });
+  test("environment accepts the explicit full-roster opt-out", () => {
+    process.env.CATALYST_DISPATCH_OUTAGE_FALLBACK = "full-roster";
+    expect(getDispatchOutageFallback()).toBe("full-roster");
+  });
+  test("unknown values degrade to last-known-good", () => {
+    process.env.CATALYST_DISPATCH_OUTAGE_FALLBACK = "invalid";
+    expect(getDispatchOutageFallback()).toBe("last-known-good");
+  });
+});

--- a/plugins/dev/scripts/execution-core/board-health.mjs
+++ b/plugins/dev/scripts/execution-core/board-health.mjs
@@ -2080,9 +2080,14 @@ export function boardHealthPass({
         // peer's branch. The act site iterates the list and dispatches the first
         // ACTIONABLE (non-cooldown/non-latched) candidate, one per scan, so a single
         // latched anchor no longer wedges the whole flagged cohort.
+        // Positive-liveness absence is intentionally broader than fail-open
+        // deadHosts: a never-seen roster member is "not live" but is not proven
+        // dead. Keep strandedNode escalation observable, but require the recovery
+        // proof before it can authorize foreign-work takeover.
+        const deadHosts = new Set(board.deadHosts ?? []);
         const strandedOrDeadHosts = new Set([
-          ...(invariants.strandedNode?.flagged ?? []),
-          ...(board.deadHosts ?? []),
+          ...(invariants.strandedNode?.flagged ?? []).filter((host) => deadHosts.has(host)),
+          ...deadHosts,
         ]);
         const candidates = selectAnchorCandidates(dec.moves, board, { holistic: true, strandedOrDeadHosts });
         const anchor = candidates[0] ?? null;

--- a/plugins/dev/scripts/execution-core/board-health.mjs
+++ b/plugins/dev/scripts/execution-core/board-health.mjs
@@ -461,6 +461,17 @@ export function resolveRosterSeam(value, fallback) {
   }
 }
 
+// `null` is deliberately distinct from `[]`: null means the liveness signal
+// could not be observed, while [] means it was observed and every host is live.
+export function resolveNotLiveHosts(notLiveHosts) {
+  try {
+    const value = typeof notLiveHosts === "function" ? notLiveHosts() : notLiveHosts;
+    return Array.isArray(value) ? value : null;
+  } catch {
+    return null;
+  }
+}
+
 export function assembleBoardState({
   orchDir,
   getBoard = () => [],
@@ -473,6 +484,7 @@ export function assembleBoardState({
   // (scheduler.mjs); empty default keeps the holistic foreign-failover unreachable
   // (shadow-safe AND N=1-safe).
   deadHosts = [],
+  getNotLiveHosts = () => null,
   self = "",
   multiHost = false,
   capacity = { maxParallel: 0, liveCount: 0, freeSlots: 0 },
@@ -615,6 +627,7 @@ export function assembleBoardState({
     // CTL-1524 (C4b): resolve here too, so a direct assembleBoardState caller may
     // also pass a thunk. Already-resolved arrays pass through untouched.
     deadHosts: resolveDeadHosts(deadHosts),
+    notLiveHosts: safe(() => resolveNotLiveHosts(getNotLiveHosts), null),
     self: self ?? "",
     multiHost: !!multiHost,
     // CTL-1157 off-gate: carried so evaluateInvariants can skip the cohort checks
@@ -860,12 +873,15 @@ function checkRateLimitHeadroom(b, t) {
   return invariant(!failed, failed ? 1 : 0, true, [], note);
 }
 
-// #6 — stranded node (mini-2 class): a rostered host that HRW-owns a share of
-// the board but whose team reconcile is failing. Cross-host PEER liveness needs
-// the heartbeat/Loki path → only the local-marker form ships now.
+// #6 — stranded node: a rostered host that HRW-owns a share of the board but is
+// NOT live. Only liveness reaches `flagged`, because it authorizes foreign-work
+// takeover. Fleet-wide, team-keyed reconcile failures are operator context only.
 function checkStrandedNode(b) {
   if (!b.ownerForTicket || b.roster.length === 0) {
     return invariant(true, 0, false, [], "no roster/HRW → stranded-node not observable");
+  }
+  if (b.notLiveHosts == null) {
+    return invariant(true, 0, false, [], "liveness signal unbound → stranded-node not observable");
   }
   const ownedByHost = new Map();
   for (const [id] of b.ticketsById) {
@@ -876,26 +892,26 @@ function checkStrandedNode(b) {
   }
   const failing = b.ring?.reconcileFailing ?? new Set();
   const markers = b.reconcileMarkers ?? {};
+  const notLive = new Set(b.notLiveHosts);
   const flagged = [];
   for (const host of b.roster) {
     const share = ownedByHost.get(host) ?? 0;
     if (share <= 0) continue;
-    const markerFail = (markers[host]?.consecutiveFailures ?? 0) > 0;
-    const ringFail = failing.has(host);
-    if (markerFail || ringFail) flagged.push(host);
+    if (notLive.has(host)) flagged.push(host);
   }
-  // observable only if we have SOME reconcile signal to judge against.
-  const haveSignal = Object.keys(markers).length > 0 || failing.size > 0;
+  const reconcileFailingTeams = [...new Set([
+    ...Object.entries(markers).filter(([, marker]) => (marker?.consecutiveFailures ?? 0) > 0).map(([team]) => team),
+    ...failing,
+  ])].sort();
   return invariant(
     flagged.length === 0,
     flagged.length,
-    haveSignal,
+    true,
     flagged,
     flagged.length
-      ? `node(s) stranded (own work, reconcile failing): ${flagged.join(", ")}`
-      : haveSignal
-        ? "all rostered nodes participating"
-        : "no reconcile-health signal → peer liveness not observable",
+      ? `${flagged.length} rostered host(s) own work but are not live: ${flagged.join(", ")}`
+      : "all rostered nodes participating",
+    { reconcileFailingTeams },
   );
 }
 
@@ -1639,7 +1655,7 @@ export function proposeMoves(invariants, _b) {
     }
   }
   for (const h of invariants.strandedNode?.flagged ?? []) {
-    if (!invariants.strandedNode.ok) tier3.push({ host: h, move: "escalate-stranded-node", rationale: "rostered node owns work but reconcile is failing" });
+    if (!invariants.strandedNode.ok) tier3.push({ host: h, move: "escalate-stranded-node", rationale: "rostered node owns work but is not live" });
   }
   for (const h of invariants.nodeProductivity?.flagged ?? []) {
     if (!invariants.nodeProductivity.ok) tier3.push({
@@ -1988,6 +2004,7 @@ export function boardHealthPass({
   getPeerProductivity,
   productivityMode,
   deadHosts, // CTL-1157: provably-dead host set (daemon-computed)
+  getNotLiveHosts,
   lastRunMs = _lastRunMs,
   intervalMs = BOARD_HEALTH_INTERVAL_MS,
   isThrottledFn = isThrottled,
@@ -2011,7 +2028,7 @@ export function boardHealthPass({
     // so the expensive whole-log heartbeat read behind the daemon's thunk is paid
     // only on a tick that actually proceeds, not on all ~59 throttled ticks between
     // 5-minute passes. Arrays still work unchanged (resolveDeadHosts is a no-op).
-    getPrStatusMap, deadHosts: resolveDeadHosts(deadHosts), mode, now,
+    getPrStatusMap, deadHosts: resolveDeadHosts(deadHosts), getNotLiveHosts, mode, now,
     getDeferredBoardHealthTickets, // CTL-1432 (B2). CTL-1552: sanctionedNeedsHuman removed.
     getStrandedEvidence, // CTL-1644: per-ticket evidence seam (empty-Map default if unbound)
     getStalledPrState, // CTL-1608: stalled-PR stamp seam (empty-Map default if unbound)

--- a/plugins/dev/scripts/execution-core/board-health.mjs
+++ b/plugins/dev/scripts/execution-core/board-health.mjs
@@ -2084,10 +2084,10 @@ export function boardHealthPass({
         // deadHosts: a never-seen roster member is "not live" but is not proven
         // dead. Keep strandedNode escalation observable, but require the recovery
         // proof before it can authorize foreign-work takeover.
-        const deadHosts = new Set(board.deadHosts ?? []);
+        const boardDeadHosts = new Set(board.deadHosts ?? []);
         const strandedOrDeadHosts = new Set([
-          ...(invariants.strandedNode?.flagged ?? []).filter((host) => deadHosts.has(host)),
-          ...deadHosts,
+          ...(invariants.strandedNode?.flagged ?? []).filter((host) => boardDeadHosts.has(host)),
+          ...boardDeadHosts,
         ]);
         const candidates = selectAnchorCandidates(dec.moves, board, { holistic: true, strandedOrDeadHosts });
         const anchor = candidates[0] ?? null;

--- a/plugins/dev/scripts/execution-core/board-health.test.mjs
+++ b/plugins/dev/scripts/execution-core/board-health.test.mjs
@@ -1352,6 +1352,37 @@ describe("boardHealthPass — mode branching + shadow safety", () => {
     expect(acted.length).toBe(0);
   });
 
+  test("a never-seen foreign owner cannot authorize holistic takeover without fail-open dead proof", () => {
+    const acted = [];
+    boardHealthPass({
+      orchDir: "/tmp/x",
+      mode: "enforce",
+      getBoard: () => [{ identifier: "CTL-FOREIGN" }],
+      getWorkerSignals: () => [{
+        ticket: "CTL-FOREIGN",
+        phase: "implement",
+        status: "running",
+        updatedAt: new Date(NOW - 5 * HOUR).toISOString(),
+      }],
+      getEligible: () => [],
+      roster: ["mini", "never-seen"],
+      self: "mini",
+      multiHost: true,
+      capacity: { maxParallel: 4, liveCount: 1, freeSlots: 3 },
+      readEventRing: () => [],
+      ownerForTicket: () => "never-seen",
+      getNotLiveHosts: () => ["never-seen"],
+      deadHosts: [],
+      getReconcileMarkers: () => ({}),
+      lastRunMs: 0,
+      intervalMs: 0,
+      now: () => NOW,
+      emit: () => {},
+      act: (payload) => acted.push(payload),
+    });
+    expect(acted).toEqual([]);
+  });
+
   test("selectAnchor: tier-1 nudge > tier-2 re-dispatch-blocker > top eligible > null", () => {
     const board = { eligible: [{ id: "CTL-ELIG" }] };
     expect(selectAnchor({ tier1: [{ move: "kick-dispatch" }, { ticket: "CTL-N", move: "nudge" }], tier2: [{ ticket: "CTL-B", move: "re-dispatch-blocker" }], tier3: [] }, board)).toBe("CTL-N");

--- a/plugins/dev/scripts/execution-core/board-health.test.mjs
+++ b/plugins/dev/scripts/execution-core/board-health.test.mjs
@@ -78,6 +78,7 @@ function mkBoard(o = {}) {
     eligible: o.eligible ?? [],
     roster: o.roster ?? [],
     dispatchRoster: o.dispatchRoster ?? o.roster ?? [],
+    notLiveHosts: Object.prototype.hasOwnProperty.call(o, "notLiveHosts") ? o.notLiveHosts : [],
     self: o.self ?? "mini",
     multiHost: o.multiHost ?? false,
     // CTL-1157: assembleBoardState now records the run mode on the board so
@@ -298,7 +299,7 @@ describe("evaluateInvariants — per-invariant green/fail", () => {
     expect(stale).toMatchObject({ ok: true, failed: 0, observable: false });
   });
 
-  test("strandedNode: rostered host owns work + reconcile failing → flag (observable)", () => {
+  test("strandedNode: team reconcile failure is reported but cannot authorize takeover", () => {
     const ticketsById = new Map([["CTL-A", { identifier: "CTL-A" }]]);
     const ownerForTicket = () => "mini-2";
     const r = evaluateInvariants(
@@ -306,23 +307,36 @@ describe("evaluateInvariants — per-invariant green/fail", () => {
         ticketsById,
         roster: ["mini", "mini-2"],
         ownerForTicket,
-        reconcileMarkers: { "mini-2": { consecutiveFailures: 3 } },
+        reconcileMarkers: { CAT: { consecutiveFailures: 3 } },
+        notLiveHosts: [],
       }),
     );
-    expect(r.strandedNode.ok).toBe(false);
+    expect(r.strandedNode.ok).toBe(true);
     expect(r.strandedNode.observable).toBe(true);
-    expect(r.strandedNode.flagged).toEqual(["mini-2"]);
+    expect(r.strandedNode.flagged).toEqual([]);
+    expect(r.strandedNode.reconcileFailingTeams).toEqual(["CAT"]);
   });
 
-  test("strandedNode: no HRW owner fn OR no reconcile signal → not observable", () => {
+  test("strandedNode: no HRW owner fn OR unbound liveness → not observable", () => {
     const noHrw = evaluateInvariants(mkBoard({ roster: ["mini", "mini-2"], ownerForTicket: null }));
     expect(noHrw.strandedNode.observable).toBe(false);
 
     const ticketsById = new Map([["CTL-A", { identifier: "CTL-A" }]]);
     const noSignal = evaluateInvariants(
-      mkBoard({ ticketsById, roster: ["mini", "mini-2"], ownerForTicket: () => "mini-2", reconcileMarkers: {} }),
+      mkBoard({ ticketsById, roster: ["mini", "mini-2"], ownerForTicket: () => "mini-2", notLiveHosts: null }),
     );
     expect(noSignal.strandedNode.observable).toBe(false);
+  });
+
+  test("strandedNode: not-live host with an HRW share is flagged", () => {
+    const ticketsById = new Map([["CTL-A", { identifier: "CTL-A" }]]);
+    const r = evaluateInvariants(mkBoard({
+      ticketsById,
+      roster: ["mini", "mini-2"],
+      ownerForTicket: () => "mini-2",
+      notLiveHosts: ["mini-2"],
+    }));
+    expect(r.strandedNode).toMatchObject({ ok: false, failed: 1, observable: true, flagged: ["mini-2"] });
   });
 
   test("a throwing invariant fails OPEN ({ok:true,error}) and never aborts the scan", () => {

--- a/plugins/dev/scripts/execution-core/config.mjs
+++ b/plugins/dev/scripts/execution-core/config.mjs
@@ -1269,6 +1269,27 @@ export const HEARTBEAT_RESTORE_HOLD_MS = resolveRestoreHoldMs(
   HEARTBEAT_GRACE_MS,
 );
 
+export const DISPATCH_OUTAGE_SUSTAINED_MS =
+  Number(process.env.CATALYST_DISPATCH_OUTAGE_SUSTAINED_MS) || 300_000;
+
+export function getDispatchOutageFallback() {
+  const fallback = "last-known-good";
+  try {
+    const envValue = process.env.CATALYST_DISPATCH_OUTAGE_FALLBACK;
+    let configValue;
+    try {
+      configValue = JSON.parse(readFileSync(getLayer2ConfigPath(), "utf8"))
+        ?.catalyst?.cluster?.dispatchOutageFallback;
+    } catch {
+      configValue = undefined;
+    }
+    const value = envValue ?? configValue ?? fallback;
+    return value === "last-known-good" || value === "full-roster" ? value : fallback;
+  } catch {
+    return fallback;
+  }
+}
+
 // CLUSTER_SYNC_INTERVAL_MS — how often the daemon git-pulls the catalyst-cluster
 // clone so a roster change committed on one node (CTL-1274 cluster cli) reaches
 // every running daemon without a restart. 5 min keeps the pull cheap while

--- a/plugins/dev/scripts/execution-core/config.mjs
+++ b/plugins/dev/scripts/execution-core/config.mjs
@@ -1283,7 +1283,7 @@ export function getDispatchOutageFallback() {
     } catch {
       configValue = undefined;
     }
-    const value = envValue ?? configValue ?? fallback;
+    const value = envValue || configValue || fallback;
     return value === "last-known-good" || value === "full-roster" ? value : fallback;
   } catch {
     return fallback;

--- a/plugins/dev/scripts/execution-core/config.mjs
+++ b/plugins/dev/scripts/execution-core/config.mjs
@@ -1269,8 +1269,15 @@ export const HEARTBEAT_RESTORE_HOLD_MS = resolveRestoreHoldMs(
   HEARTBEAT_GRACE_MS,
 );
 
+const dispatchOutageSustainedRaw = process.env.CATALYST_DISPATCH_OUTAGE_SUSTAINED_MS;
+const dispatchOutageSustainedMs = Number(dispatchOutageSustainedRaw);
 export const DISPATCH_OUTAGE_SUSTAINED_MS =
-  Number(process.env.CATALYST_DISPATCH_OUTAGE_SUSTAINED_MS) || 300_000;
+  typeof dispatchOutageSustainedRaw === "string"
+    && dispatchOutageSustainedRaw.trim() !== ""
+    && Number.isFinite(dispatchOutageSustainedMs)
+    && dispatchOutageSustainedMs >= 0
+    ? dispatchOutageSustainedMs
+    : 300_000;
 
 export function getDispatchOutageFallback() {
   const fallback = "last-known-good";
@@ -1280,7 +1287,11 @@ export function getDispatchOutageFallback() {
     try {
       configValue = JSON.parse(readFileSync(getLayer2ConfigPath(), "utf8"))
         ?.catalyst?.cluster?.dispatchOutageFallback;
-    } catch {
+    } catch (err) {
+      log.warn(
+        { layer2Path: getLayer2ConfigPath(), err: err?.message ?? String(err) },
+        "execution-core: Layer-2 dispatch outage fallback config unreadable; using environment/default",
+      );
       configValue = undefined;
     }
     const value = envValue || configValue || fallback;

--- a/plugins/dev/scripts/execution-core/daemon.mjs
+++ b/plugins/dev/scripts/execution-core/daemon.mjs
@@ -1731,10 +1731,13 @@ export function startDaemon({
 
   if (bootMultiHost && Array.isArray(dispatchRosterForBoot)) {
     const bootLivenessState = readDeflapState(orchDir);
+    const hasPriorLivenessObservation = Object.keys(bootLivenessState).some(
+      (key) => !key.startsWith("__"),
+    );
     const neverLivePeers = bootRoster.filter(
       (host) => host !== bootSelf && bootLivenessState[host]?.everLive !== true,
     );
-    if (neverLivePeers.length > 0) {
+    if (hasPriorLivenessObservation && neverLivePeers.length > 0) {
       log.warn(
         { host: bootSelf, neverLiveHosts: neverLivePeers, roster: bootRoster, dispatchRoster: dispatchRosterForBoot },
         "execution-core daemon: rostered worker(s) are not live. Their HRW share fails over while peer liveness is healthy but may revert during a peer-view outage; start the daemon there, or remove a non-worker node from catalyst.cluster.staticRoster / catalyst-cluster cluster.json.",

--- a/plugins/dev/scripts/execution-core/daemon.mjs
+++ b/plugins/dev/scripts/execution-core/daemon.mjs
@@ -131,6 +131,7 @@ import {
   clearHoldStopCooldown, // CTL-768
   defaultClearStall, // CTL-1067: J3 stall-clear seam
   readMaxParallel, // CTL-1551: the SCHEDULER-ENFORCED slot ceiling for the heartbeat
+  resolveDispatchRoster,
   clearDispositionEmit as defaultClearDispositionEmit, // Codex #2970 round 3: reset the in-process worker.transition dedup after an out-of-band clear
 } from "./scheduler.mjs";
 import * as linearWrite from "./linear-write.mjs"; // CTL-1067: writeStatus for defaultClearStall
@@ -1711,6 +1712,31 @@ export function startDaemon({
   const bootSelf = _ident.action === "noop" ? (bootHostName ?? getHostName()) : _ident.name;
   const bootEligible = readAllEligible();
   const bootOwns = bootEligible.filter((t) => ownedBy(t.identifier, bootRoster, bootSelf)).length;
+  let dispatchRosterForBoot = null;
+  let bootOwnsDispatch = null;
+  try {
+    dispatchRosterForBoot = resolveDispatchRoster({
+      roster: bootRoster,
+      orchDir,
+      self: bootSelf,
+      persist: false,
+    });
+    bootOwnsDispatch = bootEligible.filter((t) =>
+      ownedBy(t.identifier, dispatchRosterForBoot, bootSelf)
+    ).length;
+  } catch {
+    /* boot observability is fail-open */
+  }
+
+  if (bootMultiHost && Array.isArray(dispatchRosterForBoot)) {
+    const absentPeers = bootRoster.filter((host) => host !== bootSelf && !dispatchRosterForBoot.includes(host));
+    if (absentPeers.length > 0) {
+      log.warn(
+        { host: bootSelf, neverLiveHosts: absentPeers, roster: bootRoster, dispatchRoster: dispatchRosterForBoot },
+        "execution-core daemon: rostered worker(s) are not live. Their HRW share fails over while peer liveness is healthy but may revert during a peer-view outage; start the daemon there, or remove a non-worker node from catalyst.cluster.staticRoster / catalyst-cluster cluster.json.",
+      );
+    }
+  }
 
   // CTL-1271: a multi-host configuration that resolves to a single-host roster is
   // a SILENT eviction — every peer drops out of HRW and this node owns the whole
@@ -1770,7 +1796,9 @@ export function startDaemon({
     {
       orchDir,
       host: bootSelf,
-      owns: bootOwns,
+      ownsRawRoster: bootOwns,
+      ownsDispatchRoster: bootOwnsDispatch,
+      owns: bootOwns, // compatibility alias for existing log consumers
       eligible: bootEligible.length,
       roster: bootRoster,
       source: bootSource,

--- a/plugins/dev/scripts/execution-core/daemon.mjs
+++ b/plugins/dev/scripts/execution-core/daemon.mjs
@@ -63,6 +63,7 @@ import {
   readGovernanceSources, // CTL-1552: which config layer each governance mode resolved from
 } from "./config.mjs";
 import { resolveBootIdentity } from "./host-boot-identity.mjs"; // CTL-1093
+import { readDeflapState } from "./liveness-deflap.mjs"; // CAT-23: distinguish never-live peers at boot
 import { readStickyIdentity, writeStickyIdentity } from "./host-sticky.mjs"; // CTL-1093
 import { ownedBy } from "./hrw.mjs"; // CTL-862: HRW ownership filter
 import {
@@ -1729,10 +1730,13 @@ export function startDaemon({
   }
 
   if (bootMultiHost && Array.isArray(dispatchRosterForBoot)) {
-    const absentPeers = bootRoster.filter((host) => host !== bootSelf && !dispatchRosterForBoot.includes(host));
-    if (absentPeers.length > 0) {
+    const bootLivenessState = readDeflapState(orchDir);
+    const neverLivePeers = bootRoster.filter(
+      (host) => host !== bootSelf && bootLivenessState[host]?.everLive !== true,
+    );
+    if (neverLivePeers.length > 0) {
       log.warn(
-        { host: bootSelf, neverLiveHosts: absentPeers, roster: bootRoster, dispatchRoster: dispatchRosterForBoot },
+        { host: bootSelf, neverLiveHosts: neverLivePeers, roster: bootRoster, dispatchRoster: dispatchRosterForBoot },
         "execution-core daemon: rostered worker(s) are not live. Their HRW share fails over while peer liveness is healthy but may revert during a peer-view outage; start the daemon there, or remove a non-worker node from catalyst.cluster.staticRoster / catalyst-cluster cluster.json.",
       );
     }

--- a/plugins/dev/scripts/execution-core/liveness-deflap.mjs
+++ b/plugins/dev/scripts/execution-core/liveness-deflap.mjs
@@ -13,7 +13,10 @@
 // Applies to the DISPATCH roster only (not recovery — see plan Phase 2 Overview):
 // recovery keeps its grace-only surviving roster.
 //
-// Per-host observation state is a tiny `{ <host>: { liveSince: <ms>|null } }` map
+// Per-host observation state is a tiny `{ <host>: { liveSince: <ms>|null,
+// everLive: <boolean> } }` map. `everLive` is monotonic-once-true and exists
+// solely to distinguish "never checked in" from "went quiet"; admission does
+// not read it. `__`-prefixed entries are metadata, never hosts.
 // the caller persists (scheduler is the sole writer; monitor reads it read-only).
 
 import { readFileSync, writeFileSync, renameSync } from "node:fs";
@@ -21,6 +24,29 @@ import { join } from "node:path";
 
 // The on-disk observation-state file, relative to an orchestrator dir.
 export const DEFLAP_STATE_FILE = ".liveness-deflap.json";
+
+export function markOutage(prevState = {}, nowMs = Date.now()) {
+  if (prevState.__outage?.sinceMs != null) return { ...prevState };
+  return { ...prevState, __outage: { sinceMs: nowMs } };
+}
+
+export function clearOutage(state = {}) {
+  const { __outage: _ignored, ...rest } = state;
+  return rest;
+}
+
+export function outageDurationMs(state = {}, nowMs = Date.now()) {
+  const since = Number(state.__outage?.sinceMs);
+  return Number.isFinite(since) ? Math.max(0, nowMs - since) : 0;
+}
+
+export function lastGoodRoster(state = {}) {
+  return Array.isArray(state.__lastGoodRoster) ? [...state.__lastGoodRoster] : [];
+}
+
+export function withLastGoodRoster(state = {}, roster = []) {
+  return { ...state, __lastGoodRoster: [...new Set((roster ?? []).filter(Boolean))] };
+}
 
 // computeDispatchRoster — apply the restore-side deflap to the surviving roster.
 //
@@ -76,14 +102,14 @@ export function computeDispatchRoster({
     // self appears in the live set this tick.
     if (self !== undefined && h === self) {
       const liveSince = nowMs - holdMs;
-      nextState[h] = { liveSince };
+      nextState[h] = { liveSince, everLive: true };
       dispatchRoster.push(h);
       continue;
     }
 
     if (!surviving.has(h)) {
       // Shed / dead this tick → reset the restore hold; not dispatch-eligible.
-      nextState[h] = { liveSince: null };
+      nextState[h] = { liveSince: null, everLive: prevState[h]?.everLive === true };
       continue;
     }
 
@@ -100,7 +126,7 @@ export function computeDispatchRoster({
       liveSince = nowMs;
     }
 
-    nextState[h] = { liveSince };
+    nextState[h] = { liveSince, everLive: true };
     if (nowMs - liveSince >= holdMs) dispatchRoster.push(h);
   }
 

--- a/plugins/dev/scripts/execution-core/liveness-deflap.test.mjs
+++ b/plugins/dev/scripts/execution-core/liveness-deflap.test.mjs
@@ -80,6 +80,17 @@ describe("computeDispatchRoster — restore deflap (CTL-1091)", () => {
     expect(dispatchRoster).toEqual(["mini"]);
   });
 
+  test("everLive distinguishes never-seen from went-dead and remains monotonic", () => {
+    const { nextState } = computeDispatchRoster({
+      survivingRoster: ["a"], roster: ["a", "b", "c"],
+      prevState: { b: { liveSince: 123, everLive: true } },
+      holdMs: HOLD, nowMs: 5_000, self: "a",
+    });
+    expect(nextState.a.everLive).toBe(true);
+    expect(nextState.b).toEqual({ liveSince: null, everLive: true });
+    expect(nextState.c.everLive).toBe(false);
+  });
+
   test("never delays the SELF host, even if it looks freshly restored", () => {
     // A host never defers taking its OWN work — self is admitted regardless of hold.
     const { dispatchRoster } = computeDispatchRoster({

--- a/plugins/dev/scripts/execution-core/scheduler.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.mjs
@@ -4617,6 +4617,21 @@ export function schedulerTick(
       : roster;
     return _dispatchRosterMemo;
   };
+  // CTL-925 cycle escalation happens before a dispatch claim exists, so its
+  // ownership roster must not depend on host-local deflap/outage state (two
+  // hosts could otherwise narrow differently and both write Linear). It still
+  // needs normal offline-owner failover, however. Use the raw positive-liveness
+  // view: partial liveness re-homes to the live host, while an unreadable/empty
+  // feed fails safe to the full configured roster. The injected dispatch roster
+  // is the deterministic positive-liveness seam used by schedulerTick tests.
+  let _cycleEscalationRosterMemo = null;
+  const _cycleEscalationRoster = () => {
+    if (_cycleEscalationRosterMemo) return _cycleEscalationRosterMemo;
+    _cycleEscalationRosterMemo = Array.isArray(dispatchSurvivingRoster)
+      ? dispatchSurvivingRoster
+      : computeDispatchSurvivingRoster(roster, { readHeartbeats: tickReadHeartbeats });
+    return _cycleEscalationRosterMemo;
+  };
   // CTL-757: emitStateWrite — caller-emit the canonical linear.state.write audit
   // event for ONE scheduler write site. `writerResult` is the runTransition return
   // ({applied, reason, from_state, to_state, ...}) from applyPhaseStatus /
@@ -7244,11 +7259,11 @@ export function schedulerTick(
           // of them, and labelOnce's marker is host-local: N hosts → N Linear label
           // writes and N worker.transition events for one ticket. Unlike actual
           // dispatch, this pre-claim external write has no cluster-claim CAS to
-          // serialize hosts. Use the stable configured roster here: sustained
-          // outage fallback state is host-local and may diverge, so it is not a
-          // safe ownership authority for non-claim-gated side effects.
+          // serialize hosts. Use raw positive liveness here: it preserves normal
+          // offline-owner failover without consulting host-local sustained-outage
+          // or deflap state, which may diverge across hosts.
           // STRICT no-op at N=1.
-          if (multiHost && !ownedBy(member, roster, self)) continue;
+          if (multiHost && !ownedBy(member, _cycleEscalationRoster(), self)) continue;
           log.warn(
             { member, members: anomaly.members },
             "ctl-925 sweep-2: eligible ticket in dependency cycle → needs-human"

--- a/plugins/dev/scripts/execution-core/scheduler.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.mjs
@@ -378,6 +378,8 @@ import {
   getDrainedMarkerPath, // CTL-1321: shared resolver for the drain.drained sentinel
   HEARTBEAT_GRACE_MS, // CTL-1191: dead-host grace for surviving-roster recovery gate
   HEARTBEAT_RESTORE_HOLD_MS, // CTL-1091: restore-side deflap hold for the dispatch roster
+  DISPATCH_OUTAGE_SUSTAINED_MS,
+  getDispatchOutageFallback,
   isInProcessDispatchMode, // CTL-1457 (T2): sdk|codex-exec occupancy gate predicate
 } from "./config.mjs";
 import {
@@ -386,7 +388,16 @@ import {
 } from "./drain-event.mjs";
 import { defaultCheckSequencing } from "./sequencing.mjs"; // CTL-537
 import { ownedBy, ownerForTicket } from "./hrw.mjs"; // CTL-850: HRW ownership filter (CTL-1191 also uses it for the diagnostician gate); ownerForTicket: CTL-1290 board-health stranded-node + enforce HRW gate
-import { computeDispatchRoster, readDeflapState, writeDeflapState } from "./liveness-deflap.mjs"; // CTL-1091: restore-side deflap for the dispatch roster
+import {
+  computeDispatchRoster,
+  readDeflapState,
+  writeDeflapState,
+  markOutage,
+  clearOutage,
+  outageDurationMs,
+  lastGoodRoster,
+  withLastGoodRoster,
+} from "./liveness-deflap.mjs"; // CTL-1091: restore-side deflap for the dispatch roster
 import { boardHealthPass, lookupPrStatus } from "./board-health.mjs"; // CTL-1290: the whole-board health delegate (shadow-first). CTL-1644 (Codex P2): lookupPrStatus reused for getStrandedEvidence's no-cross-repo-borrow PR resolution.
 import { readStalledPrState } from "./stalled-pr-timer.mjs"; // CTL-1608: aggregate workers/*/stalled-pr.json → Map for board-health
 import { readGithubQuota } from "./github-quota-timer.mjs";
@@ -553,6 +564,14 @@ function readPositiveLive(
   }
 }
 
+export function computeNotLiveHosts(roster, opts = {}) {
+  if (!Array.isArray(roster)) return null;
+  const { live } = readPositiveLive(roster, opts);
+  if (!Array.isArray(live)) return null;
+  const liveSet = new Set(live);
+  return roster.filter((host) => !liveSet.has(host));
+}
+
 // computeDispatchSurvivingRoster — the positive-liveness dispatch roster with the
 // outage fail-safe folded in: sheds a NEVER-live rostered host (absent from
 // lastSeen — the CTL-1057 permanently-offline case) so its HRW slice fails over,
@@ -592,6 +611,8 @@ export function resolveDispatchRoster({
   persist = false,
   readHeartbeats = readClusterHeartbeats,
   holdMs = HEARTBEAT_RESTORE_HOLD_MS,
+  sustainedMs = DISPATCH_OUTAGE_SUSTAINED_MS,
+  outageFallback = undefined,
   // CTL-1091 review F2: observability hook fired ONLY on the outage→full-roster
   // degradation (below). Default no-op keeps the pure resolve silent for unit
   // callers and the read-only monitor site; the scheduler's write path wires the
@@ -602,23 +623,33 @@ export function resolveDispatchRoster({
   const prevState = readDeflapState(orchDir);
   const { live, error } = readPositiveLive(roster, { readHeartbeats, nowMs });
   if (!live || live.length === 0) {
-    // Total outage → full roster, observation state untouched. Surface the
-    // degradation (its silence was CTL-1091 verify F2): cross-host failover has
-    // effectively turned OFF this tick and every host has dropped back to owning
-    // only its own HRW slice. The fail-safe is correct; only its silence was the
-    // risk. Never let an observability throw break the roster resolve.
+    const nextState = markOutage(prevState, nowMs);
+    const outageMs = outageDurationMs(nextState, nowMs);
+    const sustained = outageMs >= sustainedMs;
+    const mode = outageFallback ?? getDispatchOutageFallback();
+    const lkg = lastGoodRoster(nextState);
+    const narrowed = [...new Set([
+      ...lkg.filter((h) => roster.includes(h)),
+      ...(typeof self === "string" && self ? [self] : []),
+    ])];
+    const useLastGood = sustained && mode === "last-known-good" && lkg.length > 0 && narrowed.length > 0;
+    const degradedRoster = useLastGood ? narrowed : roster;
     try {
       onDegrade({
         roster,
         self,
         reason: error ? "heartbeat-read-threw" : "nobody-positively-live",
         error: error ? (error.message ?? String(error)) : null,
+        sustained,
+        outageMs,
+        degradedTo: useLastGood ? "last-known-good" : "full-roster",
+        lastGoodRoster: lkg,
       });
     } catch {
       /* observability is best-effort */
     }
-    if (persist) writeDeflapState(orchDir, prevState);
-    return roster;
+    if (persist) writeDeflapState(orchDir, nextState);
+    return degradedRoster;
   }
   const { dispatchRoster, nextState } = computeDispatchRoster({
     survivingRoster: live,
@@ -628,7 +659,8 @@ export function resolveDispatchRoster({
     nowMs,
     self,
   });
-  if (persist) writeDeflapState(orchDir, nextState);
+  const healthyState = withLastGoodRoster(clearOutage(nextState), dispatchRoster);
+  if (persist) writeDeflapState(orchDir, healthyState);
   return dispatchRoster;
 }
 
@@ -641,13 +673,23 @@ export function resolveDispatchRoster({
 // read-path bug. The read-only monitor site stays silent (no onDegrade), so the
 // scheduler is the sole emitter and there is no double-logging.
 const DISPATCH_ROSTER_OUTAGE_WARN_INTERVAL_MS = 60_000;
+const DISPATCH_ROSTER_SUSTAINED_WARN_INTERVAL_MS = 600_000;
 let _lastDispatchRosterOutageWarnMs = 0;
-function warnDispatchRosterOutage({ roster, self, reason, error } = {}) {
+let _lastSustainedWarnMs = 0;
+let _sustainedEpisodeLogged = false;
+function warnDispatchRosterOutage({ roster, self, reason, error, sustained = false, outageMs = 0, degradedTo = "full-roster", lastGoodRoster = [] } = {}) {
   const nowMs = Date.now();
-  if (nowMs - _lastDispatchRosterOutageWarnMs < DISPATCH_ROSTER_OUTAGE_WARN_INTERVAL_MS) return;
-  _lastDispatchRosterOutageWarnMs = nowMs;
+  if (sustained) {
+    if (_sustainedEpisodeLogged && nowMs - _lastSustainedWarnMs < DISPATCH_ROSTER_SUSTAINED_WARN_INTERVAL_MS) return;
+    _sustainedEpisodeLogged = true;
+    _lastSustainedWarnMs = nowMs;
+  } else {
+    _sustainedEpisodeLogged = false;
+    if (nowMs - _lastDispatchRosterOutageWarnMs < DISPATCH_ROSTER_OUTAGE_WARN_INTERVAL_MS) return;
+    _lastDispatchRosterOutageWarnMs = nowMs;
+  }
   log.warn(
-    { roster, self, reason, error, degradedTo: "full-roster" },
+    { roster, self, reason, error, sustained, outageMs, degradedTo, lastGoodRoster },
     "ctl-1091: dispatch-roster liveness read degraded to the FULL roster — cross-host failover is OFF this tick (every host owns only its own HRW slice). This is the correct fail-safe; investigate the heartbeat/Loki feed if it persists.",
   );
 }
@@ -6132,6 +6174,7 @@ export function schedulerTick(
             typeof _boardHealth.deadHosts === "function"
               ? () => _boardHealth.deadHosts(roster, { readHeartbeats: tickReadHeartbeats })
               : (_boardHealth.deadHosts ?? []),
+          getNotLiveHosts: () => computeNotLiveHosts(roster, { readHeartbeats: tickReadHeartbeats }),
           lastRunMs: _boardHealthLastRunMs,
           // emit defaults to defaultEmitEvent. CTL-1300: thread the optional `act`
           // seam — supplied ONLY by the daemon binding (the holistic recovery-pass

--- a/plugins/dev/scripts/execution-core/scheduler.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.mjs
@@ -665,13 +665,24 @@ export function resolveDispatchRoster({
     self,
   });
   // The LKG is evidence about the heartbeat view, not the post-deflap dispatch
-  // roster. Persist it only when the positive view is complete; otherwise a
+  // roster. REFRESH it only when the positive view is complete; otherwise a
   // healthy tick with never-live/restore-held peers could record [self] and
   // collapse HRW partitioning during the next sustained feed outage.
+  //
+  // A partial view must not REFRESH the LKG, but it must not ERASE it either:
+  // computeDispatchRoster returns a freshly-built `{}` (per-host entries only),
+  // and writeDeflapState replaces the file wholesale, so simply not refreshing
+  // would drop the recorded roster. The realistic outage progression is
+  // full-view → one peer goes quiet (partial view) → feed dies, which is exactly
+  // the path that would have wiped the evidence one tick before it is needed.
   const clearedState = clearOutage(nextState);
-  const healthyState = live.length === roster.length
-    ? withLastGoodRoster(clearedState, live)
-    : clearedState;
+  const priorGood = lastGoodRoster(prevState);
+  const healthyState =
+    live.length === roster.length
+      ? withLastGoodRoster(clearedState, live)
+      : priorGood.length > 0
+        ? withLastGoodRoster(clearedState, priorGood)
+        : clearedState;
   if (persist) writeDeflapState(orchDir, healthyState);
   return dispatchRoster;
 }

--- a/plugins/dev/scripts/execution-core/scheduler.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.mjs
@@ -566,6 +566,7 @@ function readPositiveLive(
 
 export function computeNotLiveHosts(roster, opts = {}) {
   if (!Array.isArray(roster)) return null;
+  if (roster.length <= 1) return [];
   const { live } = readPositiveLive(roster, opts);
   if (!Array.isArray(live)) return null;
   const liveSet = new Set(live);
@@ -591,9 +592,10 @@ export function computeDispatchSurvivingRoster(roster, opts = {}) {
 // cleanup #1). Composes positive-liveness → restore deflap → outage fail-safe:
 //
 //  1. Read the raw positively-live set once.
-//  2. TOTAL OUTAGE (read threw, or NOBODY positively live) → degrade to the FULL
-//     roster and DO NOT mutate the deflap observation state (we learned nothing
-//     this tick). This preserves the "outage → full roster, never re-home" invariant
+//  2. TOTAL OUTAGE (read threw, or NOBODY positively live) → mark the outage while
+//     preserving the per-host observations and last-known-good roster. Before the
+//     sustained threshold, degrade to the FULL roster. This preserves the
+//     "transient outage → full roster, never re-home" invariant
 //     that a naive deflap-on-fail-open-roster would violate: without this guard a
 //     just-departed host (prevState liveSince:null) would be held out and its slice
 //     re-homed to a peer during an outage (CTL-1091 correctness review #1).
@@ -7240,10 +7242,13 @@ export function schedulerTick(
           // EVERY cycle member. An unstarted eligible ticket has no worker dir and
           // no claim generation, so fenceGuard's escalation fail-open passes on all
           // of them, and labelOnce's marker is host-local: N hosts → N Linear label
-          // writes and N worker.transition events for one ticket. Same dispatch
-          // roster the ready-filter below uses, so exactly one host acts.
+          // writes and N worker.transition events for one ticket. Unlike actual
+          // dispatch, this pre-claim external write has no cluster-claim CAS to
+          // serialize hosts. Use the stable configured roster here: sustained
+          // outage fallback state is host-local and may diverge, so it is not a
+          // safe ownership authority for non-claim-gated side effects.
           // STRICT no-op at N=1.
-          if (multiHost && !ownedBy(member, _dispatchRoster(), self)) continue;
+          if (multiHost && !ownedBy(member, roster, self)) continue;
           log.warn(
             { member, members: anomaly.members },
             "ctl-925 sweep-2: eligible ticket in dependency cycle → needs-human"

--- a/plugins/dev/scripts/execution-core/scheduler.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.mjs
@@ -634,7 +634,10 @@ export function resolveDispatchRoster({
       ...lkg.filter((h) => roster.includes(h)),
       ...(typeof self === "string" && self ? [self] : []),
     ])];
-    const useLastGood = sustained && mode === "last-known-good" && lkg.length > 0 && narrowed.length > 0;
+    // A singleton LKG on a multi-host roster is not a partition: every host
+    // would union in itself and own the whole board. Only narrow to a roster
+    // that still contains multiple independently observed workers.
+    const useLastGood = sustained && mode === "last-known-good" && narrowed.length > 1;
     const degradedRoster = useLastGood ? narrowed : roster;
     try {
       onDegrade({
@@ -661,7 +664,14 @@ export function resolveDispatchRoster({
     nowMs,
     self,
   });
-  const healthyState = withLastGoodRoster(clearOutage(nextState), dispatchRoster);
+  // The LKG is evidence about the heartbeat view, not the post-deflap dispatch
+  // roster. Persist it only when the positive view is complete; otherwise a
+  // healthy tick with never-live/restore-held peers could record [self] and
+  // collapse HRW partitioning during the next sustained feed outage.
+  const clearedState = clearOutage(nextState);
+  const healthyState = live.length === roster.length
+    ? withLastGoodRoster(clearedState, live)
+    : clearedState;
   if (persist) writeDeflapState(orchDir, healthyState);
   return dispatchRoster;
 }
@@ -679,7 +689,7 @@ const DISPATCH_ROSTER_SUSTAINED_WARN_INTERVAL_MS = 600_000;
 let _lastDispatchRosterOutageWarnMs = 0;
 let _lastSustainedWarnMs = 0;
 let _sustainedEpisodeLogged = false;
-function warnDispatchRosterOutage({ roster, self, reason, error, sustained = false, outageMs = 0, degradedTo = "full-roster", lastGoodRoster = [] } = {}) {
+function warnDispatchRosterOutage({ roster, self, reason, error, sustained = false, outageMs = 0, degradedTo = "full-roster", lastGoodRoster: lastGoodRosterHosts = [] } = {}) {
   const nowMs = Date.now();
   if (sustained) {
     if (_sustainedEpisodeLogged && nowMs - _lastSustainedWarnMs < DISPATCH_ROSTER_SUSTAINED_WARN_INTERVAL_MS) return;
@@ -691,7 +701,7 @@ function warnDispatchRosterOutage({ roster, self, reason, error, sustained = fal
     _lastDispatchRosterOutageWarnMs = nowMs;
   }
   log.warn(
-    { roster, self, reason, error, sustained, outageMs, degradedTo, lastGoodRoster },
+    { roster, self, reason, error, sustained, outageMs, degradedTo, lastGoodRoster: lastGoodRosterHosts },
     "ctl-1091: dispatch-roster liveness read degraded to the FULL roster — cross-host failover is OFF this tick (every host owns only its own HRW slice). This is the correct fail-safe; investigate the heartbeat/Loki feed if it persists.",
   );
 }

--- a/plugins/dev/scripts/execution-core/scheduler.test.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.test.mjs
@@ -22,6 +22,7 @@ import {
   isTicketInFlight,
   listInFlightTickets,
   computeDispatchSurvivingRoster, // CTL-1091 Phase 3: positive-liveness dispatch roster
+  computeNotLiveHosts,
   resolveDispatchRoster, // CTL-1091: shared dispatch-roster resolver (liveness + deflap + outage)
   readMaxParallel,
   readExecutionCoreConcurrency,
@@ -10371,6 +10372,19 @@ describe("computeDispatchSurvivingRoster — positive liveness (CTL-1091/CTL-105
       nowMs: NOW,
     });
     expect(out).toEqual(["solo"]);
+    expect(read).toBe(false);
+  });
+
+  test("not-live computation is also a strict single-host no-op", () => {
+    let read = false;
+    const out = computeNotLiveHosts(["solo"], {
+      readHeartbeats: () => {
+        read = true;
+        return {};
+      },
+      nowMs: NOW,
+    });
+    expect(out).toEqual([]);
     expect(read).toBe(false);
   });
 });

--- a/plugins/dev/scripts/execution-core/scheduler.test.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.test.mjs
@@ -10546,6 +10546,77 @@ describe("resolveDispatchRoster — shared dispatch resolver (CTL-1091)", () => 
     expect(outage).toEqual(roster);
   });
 
+  test("a partial healthy view carries the LKG forward instead of erasing it", () => {
+    const roster = ["mini", "laptop", "tower"];
+    // Tick 1 — complete view records the LKG.
+    resolveDispatchRoster({
+      roster,
+      orchDir,
+      self: "mini",
+      nowMs: NOW,
+      holdMs: HOLD,
+      readHeartbeats: () => ({ mini: recent, laptop: recent, tower: recent }),
+      persist: true,
+    });
+
+    // Tick 2 — `tower` goes quiet. Still a healthy (non-outage) read, so the LKG
+    // must NOT be refreshed to the narrower view, but must NOT be dropped either.
+    resolveDispatchRoster({
+      roster,
+      orchDir,
+      self: "mini",
+      nowMs: NOW + 1_000,
+      holdMs: HOLD,
+      readHeartbeats: () => ({ mini: recent, laptop: recent }),
+      persist: true,
+    });
+    const persisted = JSON.parse(readFileSync(join(orchDir, ".liveness-deflap.json"), "utf8"));
+    expect(persisted.__lastGoodRoster).toEqual(roster);
+
+    // Tick 3 — feed dies. The surviving evidence is still consumable.
+    const outage = resolveDispatchRoster({
+      roster,
+      orchDir,
+      self: "mini",
+      nowMs: NOW + 10_000,
+      sustainedMs: 0,
+      readHeartbeats: () => ({}),
+      persist: true,
+    });
+    expect(outage).toEqual(roster);
+  });
+
+  test("a partial healthy view narrows a later sustained outage to the recorded LKG", () => {
+    const roster = ["mini", "laptop", "ghost"];
+    // Tick 1 — only mini+laptop have ever been live; `ghost` never checks in, so
+    // the view is never complete and no LKG is ever recorded from it.
+    writeFileSync(
+      join(orchDir, ".liveness-deflap.json"),
+      JSON.stringify({ __lastGoodRoster: ["mini", "laptop"] }),
+    );
+    // Tick 2 — partial healthy view (ghost absent) must preserve the LKG.
+    resolveDispatchRoster({
+      roster,
+      orchDir,
+      self: "mini",
+      nowMs: NOW,
+      holdMs: HOLD,
+      readHeartbeats: () => ({ mini: recent, laptop: recent }),
+      persist: true,
+    });
+    // Tick 3 — sustained outage narrows to the preserved LKG, shedding ghost.
+    const outage = resolveDispatchRoster({
+      roster,
+      orchDir,
+      self: "mini",
+      nowMs: NOW + 10_000,
+      sustainedMs: 0,
+      readHeartbeats: () => ({}),
+      persist: true,
+    });
+    expect(outage.sort()).toEqual(["laptop", "mini"]);
+  });
+
   test("cold-start sustained outage remains on the full roster", () => {
     const out = resolveDispatchRoster({
       roster: ["mini", "ghost"],

--- a/plugins/dev/scripts/execution-core/scheduler.test.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.test.mjs
@@ -10488,6 +10488,23 @@ describe("resolveDispatchRoster — shared dispatch resolver (CTL-1091)", () => 
   test("sustained outage narrows to the last-known-good roster by default", () => {
     writeFileSync(
       join(orchDir, ".liveness-deflap.json"),
+      JSON.stringify({ __lastGoodRoster: ["mini", "laptop"], __outage: { sinceMs: 1_000 } }),
+    );
+    const out = resolveDispatchRoster({
+      roster: ["mini", "laptop", "gone"],
+      orchDir,
+      self: "mini",
+      nowMs: 10_000,
+      sustainedMs: 5_000,
+      readHeartbeats: () => ({}),
+      persist: true,
+    });
+    expect(out).toEqual(["mini", "laptop"]);
+  });
+
+  test("sustained outage refuses to narrow a multi-host roster to self", () => {
+    writeFileSync(
+      join(orchDir, ".liveness-deflap.json"),
       JSON.stringify({ __lastGoodRoster: ["mini"], __outage: { sinceMs: 1_000 } }),
     );
     const out = resolveDispatchRoster({
@@ -10499,7 +10516,34 @@ describe("resolveDispatchRoster — shared dispatch resolver (CTL-1091)", () => 
       readHeartbeats: () => ({}),
       persist: true,
     });
-    expect(out).toEqual(["mini"]);
+    expect(out).toEqual(["mini", "ghost", "gone"]);
+  });
+
+  test("complete healthy view persists a safe LKG consumed by a later sustained outage", () => {
+    const roster = ["mini", "laptop", "tower"];
+    const healthy = resolveDispatchRoster({
+      roster,
+      orchDir,
+      self: "mini",
+      nowMs: NOW,
+      holdMs: HOLD,
+      readHeartbeats: () => ({ mini: recent, laptop: recent, tower: recent }),
+      persist: true,
+    });
+    expect(healthy).toEqual(roster);
+    const persisted = JSON.parse(readFileSync(join(orchDir, ".liveness-deflap.json"), "utf8"));
+    expect(persisted.__lastGoodRoster).toEqual(roster);
+
+    const outage = resolveDispatchRoster({
+      roster,
+      orchDir,
+      self: "mini",
+      nowMs: NOW + 10_000,
+      sustainedMs: 0,
+      readHeartbeats: () => ({}),
+      persist: true,
+    });
+    expect(outage).toEqual(roster);
   });
 
   test("cold-start sustained outage remains on the full roster", () => {

--- a/plugins/dev/scripts/execution-core/scheduler.test.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.test.mjs
@@ -10471,6 +10471,48 @@ describe("resolveDispatchRoster — shared dispatch resolver (CTL-1091)", () => 
     expect(persisted.laptop.liveSince).toBe(1234);
   });
 
+  test("sustained outage narrows to the last-known-good roster by default", () => {
+    writeFileSync(
+      join(orchDir, ".liveness-deflap.json"),
+      JSON.stringify({ __lastGoodRoster: ["mini"], __outage: { sinceMs: 1_000 } }),
+    );
+    const out = resolveDispatchRoster({
+      roster: ["mini", "ghost", "gone"],
+      orchDir,
+      self: "mini",
+      nowMs: 10_000,
+      sustainedMs: 5_000,
+      readHeartbeats: () => ({}),
+      persist: true,
+    });
+    expect(out).toEqual(["mini"]);
+  });
+
+  test("cold-start sustained outage remains on the full roster", () => {
+    const out = resolveDispatchRoster({
+      roster: ["mini", "ghost"],
+      orchDir,
+      self: "mini",
+      nowMs: 10_000,
+      sustainedMs: 0,
+      readHeartbeats: () => ({}),
+    });
+    // `[self]` on every host would make every host own every ticket.
+    expect(out).toEqual(["mini", "ghost"]);
+  });
+
+  test("full-roster opt-out retains the old sustained-outage behavior", () => {
+    writeFileSync(
+      join(orchDir, ".liveness-deflap.json"),
+      JSON.stringify({ __lastGoodRoster: ["mini"], __outage: { sinceMs: 1_000 } }),
+    );
+    const out = resolveDispatchRoster({
+      roster: ["mini", "ghost"], orchDir, self: "mini", nowMs: 10_000,
+      sustainedMs: 5_000, outageFallback: "full-roster", readHeartbeats: () => ({}),
+    });
+    expect(out).toEqual(["mini", "ghost"]);
+  });
+
   test("persist:false does NOT write the deflap file", () => {
     resolveDispatchRoster({
       roster: ["mini", "ghost"],

--- a/website/src/content/docs/reference/configuration.md
+++ b/website/src/content/docs/reference/configuration.md
@@ -13,6 +13,12 @@ rarely edit them by hand. This page covers the keys you're most likely to touch.
 - **`.catalyst/config.json`** — plain project info. Safe to commit to git.
 - **`~/.config/catalyst/config-{projectKey}.json`** — secrets like API keys. Never commit this.
 
+For a multi-host execution-core installation, the machine-local
+`catalyst.cluster.dispatchOutageFallback` key controls sustained peer-view outages. Its values are
+`last-known-good` (the default) and `full-roster`. The environment variable
+`CATALYST_DISPATCH_OUTAGE_FALLBACK` takes precedence. The setting is consulted only on the outage
+path; healthy dispatch does not read machine configuration for it.
+
 The `projectKey` links the two files.
 
 ## Project config (`.catalyst/config.json`)


### PR DESCRIPTION
8fe9a144 fix(dev): keep dispatch ownership on live roster during outages

Refs: CAT-23