### PR TITLE
fix(dev): add otel-forward to the post-merge stack-reload chain

### DIFF
--- a/plugins/dev/scripts/broker/stack-reload.mjs
+++ b/plugins/dev/scripts/broker/stack-reload.mjs
@@ -140,6 +140,13 @@ export function pidFilePathForComponent(name) {
   if (name === "execution-core")
     return process.env.EXECUTION_CORE_PID_FILE
       || resolve(base, "execution-core", "daemon.pid");
+  // CTL-1506 follow-up: otel-forward. Mirrors catalyst-monitor.sh:54
+  // (FORWARD_PID_FILE="${CATALYST_DIR}/otel-forward.pid"), so the running-state
+  // gate below sees the same file the wrapper writes — without this the probe
+  // returns null, the component is treated as not-running, and the reload is
+  // silently skipped exactly like it was before it was wired up at all.
+  if (name === "otel-forward")
+    return process.env.FORWARD_PID_FILE || resolve(base, "otel-forward.pid");
   return null;
 }
 
@@ -202,11 +209,26 @@ export function decideStackReload({ results = [], loadedCommitRoot = null } = {}
   if (changed.length === 0) {
     return { shouldReload: false, brokerSelfReload: false, components: [] };
   }
-  // Both monitor and exec-core run from the advanced checkout — reload both.
+  // Monitor, exec-core AND otel-forward all run from the advanced checkout — reload all.
+  //
+  // CTL-1506 follow-up: otel-forward was MISSING from this list, and the omission
+  // was not theoretical. PR #2742 shipped the Loki age-drop that fixes a live
+  // export outage; the fix reached both minis' disks within seconds of the merge,
+  // but the forwarder processes had been running since the previous day and never
+  // restarted — so the fleet ran pre-fix code with the fix sitting right there,
+  // and the outage continued until the forwarders were restarted by hand. A merged
+  // fix that never restarts is indistinguishable from no fix.
+  //
+  // It restarts via `catalyst-monitor forward-restart` rather than a bare
+  // `restart` (which would bounce the MONITOR), hence the per-component args.
+  // That subcommand takes the same mutation lock as forward-start/-stop
+  // (catalyst-monitor.sh, CTL-1502 Codex P1), so it is safe against launchd's
+  // periodic `catalyst-stack start` and the daemon watchdog racing it.
   const { oldSha = null, newSha = null } = changed[0];
   const components = [
     { name: "monitor", cmd: "catalyst-monitor", oldSha, newSha },
     { name: "execution-core", cmd: "catalyst-execution-core", oldSha, newSha },
+    { name: "otel-forward", cmd: "catalyst-monitor", args: ["forward-restart"], oldSha, newSha },
   ];
   // brokerSelfReload only when restartNeeded for the broker's own checkout root.
   const brokerSelfReload = changed.some(
@@ -268,7 +290,9 @@ function performReload({
   const unconfirmed = [];
   const pending = [];
   for (const c of toReload) {
-    if (trySpawn(spawnFn, c.cmd, ["restart"])) {
+    // Per-component argv: defaults to ["restart"], but otel-forward is a
+    // sub-service of the monitor wrapper and needs ["forward-restart"].
+    if (trySpawn(spawnFn, c.cmd, c.args ?? ["restart"])) {
       pending.push({ c, attempts: 0, retried: false });
     } else {
       // Spawn threw synchronously — the restart never launched.

--- a/plugins/dev/scripts/broker/stack-reload.mjs
+++ b/plugins/dev/scripts/broker/stack-reload.mjs
@@ -99,7 +99,49 @@ let _lsofUnavailableWarned = false;
 // port we can probe from here. The waiting/polling between attempts lives in
 // performReload's setTimeoutFn loop (off the event loop) — this function does a
 // SINGLE probe and returns immediately, so it no longer blocks the daemon (M3).
+// readPidFor — the numeric pid a component's PID file currently names, or null.
+// Shared by defaultIsRunningFn and the otel-forward confirmation below.
+export function readPidFor(name) {
+  const pidPath = pidFilePathForComponent(name);
+  if (!pidPath || !existsSync(pidPath)) return null;
+  try {
+    const pid = parseInt(readFileSync(pidPath, "utf8").trim(), 10);
+    return Number.isInteger(pid) && pid > 0 ? pid : null;
+  } catch {
+    return null;
+  }
+}
+
+// confirmForwardRestarted — CTL-1506 follow-up (Codex #3164 P1). otel-forward
+// CANNOT use the best-effort `return true` path the other non-monitor components
+// take, because two silent failure modes make a skip indistinguishable from a
+// success — and both leave a STALE forwarder, which is the exact outage this
+// component was added to prevent:
+//   1. `cmd_forward_restart` returns 0 when it cannot take the mutation lock
+//      ("Forwarder busy … skipping restart", catalyst-monitor.sh) — a skip that
+//      reports success.
+//   2. The freshly spawned Bun process can exit during startup, leaving no
+//      forwarder at all.
+// Both are caught by requiring the PID file to name a LIVE pid that DIFFERS from
+// the one observed before the restart: a skip leaves the pid unchanged, a
+// startup crash leaves it dead or absent. Returns false until then, so the
+// existing retry loop keeps polling and an unconfirmed restart lands in
+// `stack.reload.degraded` instead of a false `complete`.
+function confirmForwardRestarted(component) {
+  const pid = readPidFor("otel-forward");
+  if (pid == null) return false; // no pid file yet → still starting (or dead)
+  // Unchanged pid ⇒ nothing actually restarted (lock-contention skip).
+  if (component?.prePid != null && pid === component.prePid) return false;
+  try {
+    process.kill(pid, 0); // alive?
+    return true;
+  } catch {
+    return false; // named a pid that is already gone
+  }
+}
+
 function defaultConfirmReload(component) {
+  if (component?.name === "otel-forward") return confirmForwardRestarted(component);
   if (!component || component.name !== "monitor") return true;
   const port = process.env.MONITOR_PORT || "7400";
   try {
@@ -290,6 +332,10 @@ function performReload({
   const unconfirmed = [];
   const pending = [];
   for (const c of toReload) {
+    // CTL-1506 follow-up (Codex #3164 P1): snapshot the pid BEFORE restarting so
+    // confirmation can prove the process actually turned over. Without this a
+    // lock-contention skip (which exits 0) confirms against its own unchanged pid.
+    if (c.name === "otel-forward") c.prePid = readPidFor("otel-forward");
     // Per-component argv: defaults to ["restart"], but otel-forward is a
     // sub-service of the monitor wrapper and needs ["forward-restart"].
     if (trySpawn(spawnFn, c.cmd, c.args ?? ["restart"])) {

--- a/plugins/dev/scripts/broker/stack-reload.test.mjs
+++ b/plugins/dev/scripts/broker/stack-reload.test.mjs
@@ -13,8 +13,9 @@
 // Run: bun test plugins/dev/scripts/broker/stack-reload.test.mjs
 
 import { describe, test, expect, beforeEach, afterEach } from "bun:test";
-import { writeFileSync, unlinkSync } from "node:fs";
+import { writeFileSync, unlinkSync, mkdirSync } from "node:fs";
 import { tmpdir } from "node:os";
+import { join } from "node:path";
 import {
   decideStackReload,
   handleStackReloadEvent,
@@ -23,6 +24,7 @@ import {
   STACK_RELOAD_CONFIRM_POLL_MS,
   pidFilePathForComponent,
   defaultIsRunningFn,
+  readPidFor,
 } from "./stack-reload.mjs";
 
 // ─── fake-timer helper ───────────────────────────────────────────────────────
@@ -1198,5 +1200,71 @@ describe("otel-forward is reloaded on checkout advance (CTL-1506 follow-up)", ()
     // must use forward-restart, never a bare `restart` (that would bounce the monitor).
     expect(spawned).toContain("catalyst-monitor forward-restart");
     expect(spawned).not.toContain("catalyst-monitor restart");
+  });
+});
+
+// ─── otel-forward restart CONFIRMATION (Codex #3164 P1) ─────────────────────
+// The other non-monitor components take defaultConfirmReload's best-effort
+// `return true`. otel-forward must not: `cmd_forward_restart` exits 0 when it
+// cannot take the mutation lock ("Forwarder busy … skipping restart"), and the
+// spawned Bun process can die during startup. Both leave a STALE forwarder while
+// `stack.reload.complete` claims success — the exact outage this component was
+// added to prevent. Confirmation therefore requires a LIVE pid that DIFFERS from
+// the pre-restart one.
+describe("otel-forward reload confirmation (Codex #3164 P1)", () => {
+  const changed = [{ root: "/co", oldSha: "a", newSha: "b", changed: true }];
+  const pidPath = join(tmpdir(), "sr-confirm-test", "otel-forward.pid");
+  let prevDir;
+
+  beforeEach(() => {
+    prevDir = process.env.CATALYST_DIR;
+    process.env.CATALYST_DIR = join(tmpdir(), "sr-confirm-test");
+    mkdirSync(join(tmpdir(), "sr-confirm-test"), { recursive: true });
+  });
+  afterEach(() => {
+    try { unlinkSync(pidPath); } catch { /* ok */ }
+    if (prevDir === undefined) delete process.env.CATALYST_DIR;
+    else process.env.CATALYST_DIR = prevDir;
+  });
+
+  // Drive a reload where ONLY otel-forward is running, using the REAL confirmFn.
+  const runReload = (emitted) =>
+    handleStackReloadEvent({
+      results: changed,
+      loadedCommitRoot: "/co",
+      spawnFn: () => {},
+      isRunningFn: (c) => c.name === "otel-forward",
+      emitFn: (e) => emitted.push(e),
+      now: 0,
+      ...immediate,
+    });
+
+  test("an UNCHANGED pid (lock-contention skip, which exits 0) is NOT confirmed", () => {
+    writeFileSync(pidPath, String(process.pid)); // alive, but never turns over
+    const emitted = [];
+    runReload(emitted);
+    // A skip must surface as degraded, never as a false complete.
+    expect(emitted.find((e) => e.event === "stack.reload.complete")).toBeUndefined();
+    const degraded = emitted.find((e) => e.event === "stack.reload.degraded");
+    expect(degraded).toBeDefined();
+    expect(degraded.detail.reason).toBe("restart_not_confirmed");
+    expect(degraded.detail.unconfirmed.map((c) => c.name)).toContain("otel-forward");
+  });
+
+  test("a pid file naming a DEAD pid (startup crash) is NOT confirmed", () => {
+    writeFileSync(pidPath, "2147483646"); // implausible pid → kill(pid,0) throws
+    const emitted = [];
+    runReload(emitted);
+    expect(emitted.find((e) => e.event === "stack.reload.complete")).toBeUndefined();
+    expect(emitted.find((e) => e.event === "stack.reload.degraded")).toBeDefined();
+  });
+
+  test("readPidFor returns null for an absent or malformed pid file", () => {
+    try { unlinkSync(pidPath); } catch { /* ok */ }
+    expect(readPidFor("otel-forward")).toBeNull();
+    writeFileSync(pidPath, "not-a-pid");
+    expect(readPidFor("otel-forward")).toBeNull();
+    writeFileSync(pidPath, "0");
+    expect(readPidFor("otel-forward")).toBeNull();
   });
 });

--- a/plugins/dev/scripts/broker/stack-reload.test.mjs
+++ b/plugins/dev/scripts/broker/stack-reload.test.mjs
@@ -70,7 +70,7 @@ describe("decideStackReload", () => {
       loadedCommitRoot: "/co",
     });
     expect(d.shouldReload).toBe(true);
-    expect(d.components.map((c) => c.name).sort()).toEqual(["execution-core", "monitor"]);
+    expect(d.components.map((c) => c.name).sort()).toEqual(["execution-core", "monitor", "otel-forward"]);
     expect(d.brokerSelfReload).toBe(false);
     expect(d.components.find((c) => c.name === "monitor").oldSha).toBe("a");
     expect(d.components.find((c) => c.name === "monitor").newSha).toBe("b");
@@ -355,7 +355,10 @@ describe("trailing debounce — merge trains (Tier 2)", () => {
     handleStackReloadEvent({ ...opts(3), now: 20_000 });
     expect(reloads).toEqual([]);
     timers.advance(STACK_RELOAD_DEBOUNCE_MS);
-    expect(reloads.filter((c) => c === "catalyst-monitor").length).toBe(1);
+    // catalyst-monitor is invoked TWICE per reload now: once for the monitor itself
+    // and once as `forward-restart` for otel-forward (a sub-service of the same
+    // wrapper). The debounce guarantee is still one RELOAD, not one spawn.
+    expect(reloads.filter((c) => c === "catalyst-monitor").length).toBe(2);
     expect(reloads.filter((c) => c === "catalyst-execution-core").length).toBe(1);
   });
 
@@ -375,7 +378,8 @@ describe("trailing debounce — merge trains (Tier 2)", () => {
     });
     expect(reloads).toEqual([]);
     timers.advance(STACK_RELOAD_DEBOUNCE_MS);
-    expect(reloads.length).toBe(2);
+    // monitor + execution-core + otel-forward
+    expect(reloads.length).toBe(3);
   });
 
   test("the last change's newSha wins in the deploy event", () => {
@@ -767,10 +771,13 @@ describe("running-state probe (CTL-1089)", () => {
     });
     const started = emitted.find((e) => e.event === "stack.reload.started");
     expect(started.detail.components).toEqual(["monitor"]);
-    expect(started.detail.skipped).toEqual(["execution-core"]);
+    expect(started.detail.skipped.sort()).toEqual(["execution-core", "otel-forward"]);
     const complete = emitted.find((e) => e.event === "stack.reload.complete");
     expect(complete.detail.components.map((c) => c.name)).toEqual(["monitor"]);
-    expect(complete.detail.skipped).toEqual([{ name: "execution-core", reason: "not_running" }]);
+    expect(complete.detail.skipped.sort((a, b) => a.name.localeCompare(b.name))).toEqual([
+      { name: "execution-core", reason: "not_running" },
+      { name: "otel-forward", reason: "not_running" },
+    ]);
   });
 
   test("both running → both restarted, empty skipped (no regression)", () => {
@@ -810,7 +817,7 @@ describe("running-state probe (CTL-1089)", () => {
     const complete = emitted.find((e) => e.event === "stack.reload.complete");
     expect(complete).toBeDefined();
     expect(complete.detail.components).toEqual([]);
-    expect(complete.detail.skipped.map((s) => s.name).sort()).toEqual(["execution-core", "monitor"]);
+    expect(complete.detail.skipped.map((s) => s.name).sort()).toEqual(["execution-core", "monitor", "otel-forward"]);
   });
 
   test("all stopped but broker code changed → broker still self-reloads", () => {
@@ -1133,5 +1140,63 @@ describe("defaultIsRunningFn / pidFilePathForComponent (CTL-1089)", () => {
     });
     expect(spawned.some((cmd) => cmd === "catalyst-monitor")).toBe(false);
     expect(spawned.some((cmd) => cmd === "catalyst-execution-core")).toBe(false);
+  });
+});
+
+// ─── otel-forward in the reload chain (CTL-1506 follow-up) ──────────────────
+// Regression guard for a real outage: PR #2742 shipped the Loki age-drop that
+// fixed a live export failure. It reached both minis' disks seconds after the
+// merge, but the forwarder processes had been running since the previous day and
+// were NOT in this component list — so the fleet ran pre-fix code with the fix
+// sitting on disk, and the outage continued until they were restarted by hand.
+describe("otel-forward is reloaded on checkout advance (CTL-1506 follow-up)", () => {
+  const changed = [{ changed: true, root: "/r", oldSha: "aaa", newSha: "bbb", restartNeeded: false }];
+
+  test("otel-forward is in the component set", () => {
+    const d = decideStackReload({ results: changed, loadedCommitRoot: "/other" });
+    const f = d.components.find((c) => c.name === "otel-forward");
+    expect(f).toBeDefined();
+    expect(f.oldSha).toBe("aaa");
+    expect(f.newSha).toBe("bbb");
+  });
+
+  test("it restarts via `forward-restart`, NOT a bare `restart` (which would bounce the monitor)", () => {
+    const d = decideStackReload({ results: changed, loadedCommitRoot: "/other" });
+    const f = d.components.find((c) => c.name === "otel-forward");
+    expect(f.cmd).toBe("catalyst-monitor");
+    expect(f.args).toEqual(["forward-restart"]);
+    // The monitor component must keep the default argv, or a reload would restart
+    // the forwarder twice and never the monitor.
+    const m = d.components.find((c) => c.name === "monitor");
+    expect(m.args ?? ["restart"]).toEqual(["restart"]);
+  });
+
+  test("its PID file matches the wrapper's FORWARD_PID_FILE, so the running-gate can see it", () => {
+    const prev = process.env.CATALYST_DIR;
+    process.env.CATALYST_DIR = "/tmp/ctest";
+    try {
+      expect(pidFilePathForComponent("otel-forward")).toBe("/tmp/ctest/otel-forward.pid");
+    } finally {
+      if (prev === undefined) delete process.env.CATALYST_DIR;
+      else process.env.CATALYST_DIR = prev;
+    }
+  });
+
+  test("a running forwarder is actually spawned with forward-restart", () => {
+    const spawned = [];
+    handleStackReloadEvent({
+      results: [{ root: "/co", oldSha: "a", newSha: "b", changed: true }],
+      loadedCommitRoot: "/co",
+      spawnFn: (cmd, args) => { spawned.push(`${cmd} ${(args ?? []).join(" ")}`); },
+      isRunningFn: (c) => c.name === "otel-forward",
+      confirmFn: () => true,
+      emitFn: () => {},
+      now: 0,
+      ...immediate,
+    });
+    // Only the forwarder is "running", so it is the ONLY thing restarted — and it
+    // must use forward-restart, never a bare `restart` (that would bounce the monitor).
+    expect(spawned).toContain("catalyst-monitor forward-restart");
+    expect(spawned).not.toContain("catalyst-monitor restart");
   });
 });


### PR DESCRIPTION
## Why

`stack-reload` restarted only `monitor` and `execution-core` on a checkout advance. **otel-forward was missing**, and that omission caused a real outage tonight.

PR #2742 shipped the Loki age-drop that fixes a live OTLP export failure (CTL-1731). The code reached both minis' disks within seconds of the merge — but the forwarder processes had been running since Aug 7 19:48 and were never restarted. The fleet ran pre-fix code with the fix sitting right there on disk, and the export failures continued until I bounced the forwarders by hand.

**A merged fix that never restarts is indistinguishable from no fix.**

## What changed

- **`pidFilePathForComponent`** gains `otel-forward`, mirroring `catalyst-monitor.sh:54` (`FORWARD_PID_FILE="${CATALYST_DIR}/otel-forward.pid"`). This is load-bearing: without it the probe returns `null`, the component reads as not-running, and the reload is *silently skipped* — wiring it into the list without this would have changed nothing.
- **`decideStackReload`** includes `otel-forward`.
- **Components may carry their own argv.** otel-forward restarts via `catalyst-monitor forward-restart`, not a bare `restart` (which would bounce the *monitor*). Everything else keeps the `["restart"]` default. `forward-restart` takes the same mutation lock as `forward-start`/`-stop` (CTL-1502 Codex P1), so it is safe against launchd's periodic `catalyst-stack start` and the daemon watchdog racing it.

## Tests

63 pass. 4 new guards: membership, the `forward-restart` argv *and* that monitor keeps its default, the PID path matching the wrapper, and a real spawn assertion (forwarder-only-running → exactly `forward-restart`, never a bare `restart`).

Updated existing assertions for the third component, including that `catalyst-monitor` is now invoked **twice** per reload — the debounce guarantee is one *reload*, not one spawn.

## Not covered — deliberately scoped out

`catalyst-stack start` also launches **coordination-publish**, **log-shipper**, **event-mirror** and **cloud-sync**. None are in the reload chain either, and `cloud-sync` on both minis has been running since Aug 6. They are excluded here because:

- none has a `restart` subcommand today (only `forward` does), so adding them means writing restart paths first;
- shipper and event-mirror are launchd `KeepAlive`-managed, so restart ownership is different and bouncing them from the broker may be wrong.

They are the same latent bug class and deserve their own ticket rather than being smuggled into this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QZu3Cn7aQ7Ti9smfjCzFgn