### PR TITLE
fix(dev): CAT-128 stub the live skills-dir probe in doctor install tests

### DIFF
--- a/plugins/dev/scripts/execution-core/doctor.test.mjs
+++ b/plugins/dev/scripts/execution-core/doctor.test.mjs
@@ -4934,6 +4934,9 @@ describe("installChecksForClass — the focused post-install verification (CTL-1
         hasStackAgent: true,
         hasUpdaterAgent: true, // the two-puller hazard
         pluginPullOwner: "broker",
+        // Hermeticity: the real skills-dir probe reads a live ~/.claude tree, which a
+        // unit test must not depend on (its own coverage lives with checkSkillsDirPlugins).
+        skillsDirCheck: () => [{ name: "skills-dir-plugins", status: "pass", detail: "stubbed" }],
       }),
       log: () => {},
     });
@@ -4947,6 +4950,8 @@ describe("installChecksForClass — the focused post-install verification (CTL-1
       hasStackAgent: true,
       hasUpdaterAgent: false,
       pluginPullOwner: "broker",
+      // Hermeticity: stub the live ~/.claude skills-dir probe (see checkSkillsDirPlugins).
+      skillsDirCheck: () => [{ name: "skills-dir-plugins", status: "pass", detail: "stubbed" }],
       log: () => {},
     });
     expect(code).toBe(0);
@@ -4959,6 +4964,8 @@ describe("installChecksForClass — the focused post-install verification (CTL-1
       hasStackAgent: false,
       hasUpdaterAgent: true,
       pluginPullOwner: "updater",
+      // Hermeticity: stub the live ~/.claude skills-dir probe (see checkSkillsDirPlugins).
+      skillsDirCheck: () => [{ name: "skills-dir-plugins", status: "pass", detail: "stubbed" }],
       log: () => {},
     });
     expect(code).toBe(0);
@@ -4991,6 +4998,8 @@ describe("runDoctor profile routing (CTL-1369 PR4)", () => {
       hasStackAgent: true,
       hasUpdaterAgent: false,
       pluginPullOwner: "broker",
+      // Hermeticity: stub the live ~/.claude skills-dir probe (see checkSkillsDirPlugins).
+      skillsDirCheck: () => [{ name: "skills-dir-plugins", status: "pass", detail: "stubbed" }],
       log: (m) => logs.push(m),
     });
     const parsed = JSON.parse(logs[0]);


### PR DESCRIPTION
## Why

`execution-core-unit-tests` is **red on `main`** (run [31294460725](https://github.com/coalesce-labs/catalyst/actions/runs/31294460725), sha `12c454ff`), so every open PR inherits a failing required check and cannot merge. Six are blocked on it today: #3140, #3141, #3147, #3156, #3166, #3170.

## Root cause

The `skills-dir-plugins` check added to the install rubric in #2664 probes a real `~/.claude` tree. Four `installChecksForClass` / `runDoctor({ profile: "install" })` tests never stubbed it, so their verdict depends on whether the host happens to have the catalyst plugin symlinks present. On a CI runner (and any clean checkout) the probe FAILs and takes the suite down with it:

```
fail  skills-dir-plugins :: catalyst plugins do not load cleanly in-place via
      user-scope skills-dir (~/.claude/skills/catalyst-pm is missing; ...)
```

This is a **test-hermeticity defect, not a product defect** — `checkSkillsDirPlugins` is behaving correctly.

## Fix

`installChecksForClass` already exposes a `skillsDirCheck` seam for exactly this reason, and `runDoctor` already forwards it. A sibling test at doctor.test.mjs:4853 uses it, with a comment explaining why. These four tests simply omitted it — so this stubs them the same way. No product code changes.

Three of the four were failing. The fourth (developer post-install) passes today only by environmental luck and carried the identical latent defect, so it is stubbed too rather than left as a future flake.

## Verification

```
bun test plugins/dev/scripts/execution-core/doctor.test.mjs
  412 pass / 0 fail    (before: 409 pass / 3 fail)
```

Refs CAT-62, CAT-131, CAT-135.

🤖 Generated with [Claude Code](https://claude.com/claude-code)