### PR TITLE
fix(dev): CAT-131 stub the skills-dir probe in the install-rubric tests

### DIFF
--- a/plugins/dev/scripts/execution-core/doctor.test.mjs
+++ b/plugins/dev/scripts/execution-core/doctor.test.mjs
@@ -3657,6 +3657,13 @@ const nodeClassOf = (over = {}) => ({
   ...over,
 });
 
+// The real skills-dir probe reads a live ~/.claude tree, so on any machine that has not
+// run the skills-dir cutover (every CI runner, and any dev box mid-migration) it FAILs —
+// which would silently change what the install-rubric tests below are asserting. They are
+// about the node-class/agent/owner grading, not the cutover; `checkSkillsDirPlugins` owns
+// its own coverage. Inject a passing stub so those assertions grade only their own subject.
+const passingSkillsDirCheck = () => [{ name: "skills-dir-plugins", status: "pass", detail: "stubbed" }];
+
 describe("checkNodeClass (CTL-1355)", () => {
   it("PASSes an explicit, recognized class", () => {
     const checks = checkNodeClass({ nodeClass: nodeClassOf({ class: "developer", raw: "developer" }) });
@@ -4934,10 +4941,11 @@ describe("installChecksForClass — the focused post-install verification (CTL-1
         hasStackAgent: true,
         hasUpdaterAgent: true, // the two-puller hazard
         pluginPullOwner: "broker",
+        skillsDirCheck: passingSkillsDirCheck,
       }),
       log: () => {},
     });
-    expect(code).toBe(1);
+    expect(code).toBe(1); // exactly ONE fail — the updater agent — not the ambient skills-dir state
   });
 
   it("PASSes a correctly-provisioned worker post-install (stack only, owner=broker)", async () => {
@@ -4947,6 +4955,7 @@ describe("installChecksForClass — the focused post-install verification (CTL-1
       hasStackAgent: true,
       hasUpdaterAgent: false,
       pluginPullOwner: "broker",
+      skillsDirCheck: passingSkillsDirCheck,
       log: () => {},
     });
     expect(code).toBe(0);
@@ -4991,6 +5000,7 @@ describe("runDoctor profile routing (CTL-1369 PR4)", () => {
       hasStackAgent: true,
       hasUpdaterAgent: false,
       pluginPullOwner: "broker",
+      skillsDirCheck: passingSkillsDirCheck,
       log: (m) => logs.push(m),
     });
     const parsed = JSON.parse(logs[0]);


### PR DESCRIPTION
## Summary

`main` has been red on `execution-core-unit-tests` since `12c454ff` (#2664), and because
`pull_request` CI runs against `refs/pull/<n>/merge`, **every open PR inherited the same three
failures on a required check its author could not fix on their own branch.** At the time of
writing that is 10 of the 11 open CAT PRs.

#2664 added `checkSkillsDirPlugins` to `installChecksForClass` and gave it an injectable
`skillsDirCheck` seam *precisely because* the real probe reads a live `~/.claude` tree. One test
adopted the stub; three did not, so they kept calling the real probe. On any machine that has not
run the skills-dir cutover — every GitHub runner, and any dev box mid-migration — the probe FAILs
and drags the exit code with it:

| Test | Expected | Got |
| --- | --- | --- |
| `installChecksForClass > FAILs a worker post-install whose updater agent is still present (mixed profile)` | 1 | 2 |
| `installChecksForClass > PASSes a correctly-provisioned worker post-install (stack only, owner=broker)` | 0 | 1 |
| `runDoctor profile routing > profile:install routes to installChecksForClass (the focused subset), not the full rubric` | 0 | 1 |

The extra failure in each case is the same one:

```
fail | skills-dir-plugins :: catalyst plugins do not load cleanly in-place via
       user-scope skills-dir (~/.claude/skills/catalyst-pm is missing; ...)
```

## The fix

Inject the same passing stub the sibling test already uses, via one shared
`passingSkillsDirCheck` helper. Test-only — no production code changes.

## What this does *not* weaken

The #2664 P1 intent (the best-effort cutover must be confirmed by the post-install pass) is
untouched:

- `checkSkillsDirPlugins` / `classifySkillsDirPlugins` keep their own **16 dedicated cases**.
- Its **membership in the install rubric** is still asserted by the developer-config test's exact
  check-name list: `["node-class", "agents-for-class", "plugin-pull-owner", "skills-dir-plugins"]`.

These three tests are about node-class / agent / pull-owner grading; they now grade only their own
subject instead of the ambient state of the host's home directory.

## Verification

Clean checkout of `main` (`7988f2fe`):

| | Result |
| --- | --- |
| before — `bun test doctor.test.mjs` | 409 pass / **3 fail** |
| after — `bun test doctor.test.mjs` | **412 pass / 0 fail** |
| after — full CI "Run stable unit tests" list (172 files) | **6020 pass / 0 fail** |

The full-suite run needs `CATALYST_*` unset: run inside a phase agent, 20 recovery tests fail on
the worker's inherited env (`CATALYST_CLUSTER_GENERATION`, `CATALYST_EXECUTOR_ID`, …). That is
pre-existing and tracked on CAT-125 / CAT-128 — untouched here.

Closes CAT-131.

🤖 Generated with [Claude Code](https://claude.com/claude-code)