### PR TITLE
fix(dev): clear the 7 lint errors red on main in pr-status-backfill

### DIFF
--- a/plugins/dev/scripts/orch-monitor/__tests__/pr-status-backfill.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/pr-status-backfill.test.ts
@@ -17,7 +17,7 @@ afterEach(() => {
 });
 
 const cache = () => createFileBasedPrCache(join(dir, "t.db"));
-const okRunner = (rows: unknown) => async () => ({ ok: true, stdout: JSON.stringify(rows) });
+const okRunner = (rows: unknown) => () => Promise.resolve({ ok: true, stdout: JSON.stringify(rows) });
 
 test("normalizePrState maps GitHub states, preferring merged over closed", () => {
   expect(normalizePrState("MERGED", null)).toBe("merged");
@@ -52,9 +52,9 @@ test("is ONE-SHOT — a non-empty store is left completely alone", async () => {
   const n = await backfillPrStatuses({
     cache: c,
     repos: ["org/x"],
-    runner: async () => {
+    runner: () => {
       called = true;
-      return { ok: true, stdout: "[]" };
+      return Promise.resolve({ ok: true, stdout: "[]" });
     },
   });
   expect(n).toBe(0);
@@ -67,7 +67,7 @@ test("a failing gh invocation is non-fatal and leaves the store unseeded", async
   const n = await backfillPrStatuses({
     cache: c,
     repos: ["org/x"],
-    runner: async () => ({ ok: false, stdout: "" }),
+    runner: () => Promise.resolve({ ok: false, stdout: "" }),
   });
   expect(n).toBe(0);
   expect(c.getAllStatuses()).toHaveLength(0);
@@ -78,9 +78,7 @@ test("a throwing runner is non-fatal (missing gh / spawn failure)", async () => 
   const n = await backfillPrStatuses({
     cache: c,
     repos: ["org/x"],
-    runner: async () => {
-      throw new Error("gh: not found");
-    },
+    runner: () => Promise.reject(new Error("gh: not found")),
   });
   expect(n).toBe(0);
 });
@@ -90,7 +88,7 @@ test("unparseable gh output is non-fatal", async () => {
   const n = await backfillPrStatuses({
     cache: c,
     repos: ["org/x"],
-    runner: async () => ({ ok: true, stdout: "not json" }),
+    runner: () => Promise.resolve({ ok: true, stdout: "not json" }),
   });
   expect(n).toBe(0);
 });
@@ -100,10 +98,12 @@ test("one bad repo does not abort the remaining repos", async () => {
   const n = await backfillPrStatuses({
     cache: c,
     repos: ["org/bad", "org/good"],
-    runner: async (argv: string[]) =>
-      argv.includes("org/bad")
-        ? { ok: false, stdout: "" }
-        : { ok: true, stdout: JSON.stringify([{ number: 5, state: "MERGED", mergedAt: null }]) },
+    runner: (argv: string[]) =>
+      Promise.resolve(
+        argv.includes("org/bad")
+          ? { ok: false, stdout: "" }
+          : { ok: true, stdout: JSON.stringify([{ number: 5, state: "MERGED", mergedAt: null }]) },
+      ),
   });
   expect(n).toBe(1);
   expect(c.getAllStatuses().find((r) => r.pr_number === 5)?.status).toBe("merged");

--- a/plugins/dev/scripts/orch-monitor/lib/pr-status-backfill.ts
+++ b/plugins/dev/scripts/orch-monitor/lib/pr-status-backfill.ts
@@ -37,7 +37,12 @@ export interface BackfillDeps {
 // lowercase "open" | "closed" | "merged" triple, and treats a merged PR as
 // terminal — so map MERGED first and never infer it from `closed` alone.
 export function normalizePrState(state: unknown, mergedAt: unknown): string | null {
-  const s = String(state ?? "").toUpperCase();
+  // `state` is typed `unknown` (it comes straight off parsed gh JSON), so it can
+  // be an object — and `String(someObject)` yields "[object Object]", which is
+  // both meaningless here and a lint error (no-base-to-string). Only a string is
+  // ever a real GitHub state; anything else falls through to the `null` return
+  // below, which is the documented "unrecognized → skip rather than guess" path.
+  const s = typeof state === "string" ? state.toUpperCase() : "";
   if (s === "MERGED" || (mergedAt != null && mergedAt !== "")) return "merged";
   if (s === "CLOSED") return "closed";
   if (s === "OPEN") return "open";


### PR DESCRIPTION
`bun lint` fails on `origin/main` with **7 errors**, all in the CTL-1606 `pr-status-backfill` pair. Because the `quality` check runs against `refs/pull/<n>/merge`, **every open PR inherits the failure** and cannot reach a green required-check set, so the merge stage stalls board-wide on a fault none of those branches introduced.

Found by the recovery-pass board delegate while unsticking CAT-53, whose PR #3167 was red on two checks it did not cause. Reproduced against `origin/main` (`7988f2fe`) locally — all 7 errors present with no PR code in the tree.

## The fixes

**`no-base-to-string`** — `pr-status-backfill.ts:40`. `state` is typed `unknown` and comes straight off parsed `gh` JSON, so `String(state ?? "")` can stringify an object to `"[object Object]"`. Narrowed to `typeof state === "string"`; anything else now falls through to the existing `null` return — the function's own documented "unrecognized → skip rather than guess a lifecycle state" path. Behaviour is unchanged for every real GitHub state (`OPEN`/`CLOSED`/`MERGED`).

**`require-await` ×6** — the test file. `async` was present only to satisfy `BackfillRunner`'s `Promise` return type, with nothing awaited. Each now returns the promise explicitly. The throwing-runner case uses `Promise.reject` rather than a bare `throw`, so it stays an **async rejection** and does not silently become a synchronous throw.

## Verification

- `bunx eslint` on both files: **exit 0, no output** (was 7 errors).
- `bun test pr-status-backfill.test.ts`: **9 pass / 0 fail**.

No behavioural change is intended; this is a pure lint-debt clear so the board's PRs can go green again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)