### PR TITLE
fix(dev): unbreak main — inject the skills-dir seam in the install-profile tests

### DIFF
--- a/plugins/dev/scripts/execution-core/doctor.test.mjs
+++ b/plugins/dev/scripts/execution-core/doctor.test.mjs
@@ -3657,6 +3657,13 @@ const nodeClassOf = (over = {}) => ({
   ...over,
 });
 
+// passingSkillsDirCheck — the `skillsDirCheck` seam installChecksForClass exposes, stubbed healthy.
+// The real check probes the live ~/.claude tree, and for class=worker a missing symlink is a hard
+// FAIL (developer/monitor only WARN). Any test that asserts on runDoctor's aggregate FAIL COUNT for
+// a worker must inject this, or it grades the host it happens to run on instead of the code under
+// test — which is exactly how it went red in CI. checkSkillsDirPlugins keeps its own direct coverage.
+const passingSkillsDirCheck = () => [{ name: "skills-dir-plugins", status: "pass", detail: "stubbed" }];
+
 describe("checkNodeClass (CTL-1355)", () => {
   it("PASSes an explicit, recognized class", () => {
     const checks = checkNodeClass({ nodeClass: nodeClassOf({ class: "developer", raw: "developer" }) });
@@ -4934,10 +4941,11 @@ describe("installChecksForClass — the focused post-install verification (CTL-1
         hasStackAgent: true,
         hasUpdaterAgent: true, // the two-puller hazard
         pluginPullOwner: "broker",
+        skillsDirCheck: passingSkillsDirCheck,
       }),
       log: () => {},
     });
-    expect(code).toBe(1);
+    expect(code).toBe(1); // exactly one FAIL: the updater agent. The skills-dir seam is stubbed healthy.
   });
 
   it("PASSes a correctly-provisioned worker post-install (stack only, owner=broker)", async () => {
@@ -4947,6 +4955,7 @@ describe("installChecksForClass — the focused post-install verification (CTL-1
       hasStackAgent: true,
       hasUpdaterAgent: false,
       pluginPullOwner: "broker",
+      skillsDirCheck: passingSkillsDirCheck,
       log: () => {},
     });
     expect(code).toBe(0);
@@ -4991,6 +5000,7 @@ describe("runDoctor profile routing (CTL-1369 PR4)", () => {
       hasStackAgent: true,
       hasUpdaterAgent: false,
       pluginPullOwner: "broker",
+      skillsDirCheck: passingSkillsDirCheck,
       log: (m) => logs.push(m),
     });
     const parsed = JSON.parse(logs[0]);


### PR DESCRIPTION
## What's broken

`main` has been red on **`execution-core-unit-tests`** since #2664 landed (`12c454ff`, 2026-08-09 04:23 UTC). Every open PR inherits that failure through `refs/pull/n/merge`, so **nothing on the board can reach a green check set** — the board's merge queue is frozen.

3 tests fail:

```
(fail) installChecksForClass … > FAILs a worker post-install whose updater agent is still present (mixed profile)
(fail) installChecksForClass … > PASSes a correctly-provisioned worker post-install (stack only, owner=broker)
(fail) runDoctor profile routing (CTL-1369 PR4) > profile:install routes to installChecksForClass …
```

## Root cause

#2664 added `checkSkillsDirPlugins` to `installChecksForClass`. It probes the **live `~/.claude` tree**, and for node class `worker` a missing plugin symlink is a hard **FAIL** (developer/monitor only WARN).

These three tests assert on `runDoctor`'s **aggregate FAIL count**, but never inject the seam — so they grade whatever host they run on. CI runners have no catalyst skills symlinks ⇒ deterministic red. That asymmetry is also why only the *worker* cases broke while the sibling *developer* case stayed green.

```
worker     fails: skills-dir-plugins   | skills-dir: fail
developer  fails: (none)               | skills-dir: warn
monitor    fails: agents-for-class,…   | skills-dir: warn
```

## The fix

`installChecksForClass` **already exposes** a `skillsDirCheck` seam for exactly this reason, and a sibling test at `doctor.test.mjs:4853` already injects it. These three were simply missed. This applies that same established stub.

**No production code changes** — one test file, +11/-1.

The mixed-profile case still asserts `code === 1`, so it continues to prove the updater-agent FAIL rather than passing vacuously. `skills-dir-plugins` remains asserted as part of the install rubric by the existing test at :4857, and `checkSkillsDirPlugins` keeps its own direct coverage.

## Verification

On clean `origin/main` (`7988f2fe`) with a scrubbed `CATALYST_*` env (the phase-agent env otherwise contaminates unrelated suites):

| Suite | Before | After |
|---|---|---|
| `doctor.test.mjs` | 409 pass / **3 fail** | **412 pass / 0 fail** |
| `doctor` + `install-lifecycle` + `node-class-parity` | — | **572 pass / 0 fail** |

Full CI stable set (169 files, 5947 tests): the only remaining failures are pre-existing env/timing-coupled suites untouched by this diff (`CATALYST_CLUSTER_GENERATION`/`CATALYST_EXECUTOR_ID` leakage, the `fs.watch` timing suites already documented as excluded-flaky).

## Follow-ups already filed

- **CAT-147** — board health should detect a red default branch (this incident is its motivating case)
- **CAT-142** — the replica writer gap (unrelated, still open)

🤖 Generated with [Claude Code](https://claude.com/claude-code)