### PR TITLE
feat(dev): CTL-1736 surface cloud-sync local-writer health in verify-node + status

### DIFF
--- a/plugins/dev/scripts/__tests__/catalyst-stack-status-cloud-sync.test.sh
+++ b/plugins/dev/scripts/__tests__/catalyst-stack-status-cloud-sync.test.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# Shell tests for the cloud-sync status line in `catalyst-stack status` (CTL-1736).
+#
+# Overrides _cloud_sync_state() inside isolating command-substitution subshells to
+# assert cmd_status output contains the correct line per state. NO real adoption /
+# daemon / network / mutation — catalyst-stack is SOURCED (its dispatch is guarded by
+# BASH_SOURCE[0]==$0, so sourcing runs no command).
+#
+# Run: bash plugins/dev/scripts/__tests__/catalyst-stack-status-cloud-sync.test.sh
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+STACK="${SCRIPT_DIR}/../catalyst-stack"
+
+FAILURES=0
+PASSES=0
+
+ok() {
+  local name="$1"
+  PASSES=$((PASSES + 1))
+  echo "  PASS: $name"
+}
+
+fail() {
+  local name="$1" detail="$2"
+  FAILURES=$((FAILURES + 1))
+  echo "  FAIL: $name"
+  echo "    $detail"
+}
+
+# Source the script (guarded dispatch → no side effects) to reach the helpers.
+# shellcheck disable=SC1090
+source "$STACK"
+
+# assert_status_line <name> <expected-substring> <state>
+# Overrides _cloud_sync_state inside a subshell, runs cmd_status (stderr suppressed
+# since broker/monitor/exec-core status CLIs are not available in the test env),
+# and checks that the output contains the expected substring.
+assert_status_line() {
+  local name="$1" expected="$2" state="$3"
+  local out
+  out="$( _cloud_sync_state() { echo "$state"; }; cmd_status 2>/dev/null )"
+  case "$out" in
+    *"$expected"*) ok "$name" ;;
+    *) fail "$name" "missing '$expected' in: $(printf '%s' "$out" | grep cloud-sync || echo '<no cloud-sync line>')" ;;
+  esac
+}
+
+assert_status_line "status: fresh line"    "cloud-sync       running  (replica fresh)"            fresh
+assert_status_line "status: stale line"    "cloud-sync       stale"                                stale
+assert_status_line "status: unseeded line" "cloud-sync       installed, not seeded"                unseeded
+assert_status_line "status: idle line"     "cloud-sync       not installed"                        idle
+
+# The stale line must include the kickstart hint.
+STALE_OUT="$( _cloud_sync_state() { echo stale; }; cmd_status 2>/dev/null )"
+case "$STALE_OUT" in
+  *"launchctl kickstart -k"*) ok "status: stale line has kickstart hint" ;;
+  *) fail "status: stale line has kickstart hint" "missing 'launchctl kickstart -k'" ;;
+esac
+case "$STALE_OUT" in
+  *"${CLOUD_SYNC_AGENT_LABEL}"*) ok "status: stale line names the agent label" ;;
+  *) fail "status: stale line names the agent label" "missing '${CLOUD_SYNC_AGENT_LABEL}'" ;;
+esac
+
+echo ""
+echo "Total: $((PASSES + FAILURES)), Passed: $PASSES, Failed: $FAILURES"
+exit "$FAILURES"

--- a/plugins/dev/scripts/__tests__/verify-node.test.sh
+++ b/plugins/dev/scripts/__tests__/verify-node.test.sh
@@ -199,6 +199,7 @@ HEALTHYDEV_OUT="$(
   _vn_read_replica_base()   { echo 'http://mini:7400'; }
   _vn_updater_ec()          { echo 0; }
   _vn_drained()             { echo no; }
+  _vn_cloud_sync_state()    { echo idle; }
   cmd_verify_node --json 2>/dev/null
 )"; HEALTHYDEV_EC=$?
 expect_eq "cmd: healthy developer exits zero" "0" "$HEALTHYDEV_EC"
@@ -206,6 +207,14 @@ expect_eq "cmd: healthy developer verdict=pass" "pass" "$(printf '%s' "$HEALTHYD
 expect_eq "cmd: healthy developer 0 required failures" "0" "$(printf '%s' "$HEALTHYDEV_OUT" | jq -r '.required_failures')"
 expect_eq "cmd: healthy developer event-mirror-running PASS" "PASS" \
   "$(printf '%s' "$HEALTHYDEV_OUT" | jq -r '.checks[] | select(.name=="event-mirror-running") | .status')"
+# CTL-1736: the replica-writer-local check is wired into the developer rubric, is
+# advisory (required=false so a legitimately idle laptop never flips the run), and
+# maps idle → PASS end-to-end (closes the wiring-line coverage gap left by the
+# pure-helper cases above).
+expect_eq "cmd: healthy developer replica-writer-local PASS" "PASS" \
+  "$(printf '%s' "$HEALTHYDEV_OUT" | jq -r '.checks[] | select(.name=="replica-writer-local") | .status')"
+expect_eq "cmd: healthy developer replica-writer-local advisory" "false" \
+  "$(printf '%s' "$HEALTHYDEV_OUT" | jq -r '.checks[] | select(.name=="replica-writer-local") | .required')"
 
 # CTL-1662: developer with event-mirror DEAD → FAIL (the doctor blind spot this closes).
 DEVNOMIRROR_OUT="$(

--- a/plugins/dev/scripts/__tests__/verify-node.test.sh
+++ b/plugins/dev/scripts/__tests__/verify-node.test.sh
@@ -114,6 +114,29 @@ expect_eq "dev-no-work: unknown roster never FAILs"     "WARN" "$(status_of "$(_
 # F3: boot-drain is genuinely safe even when the roster is unknown.
 expect_eq "dev-no-work: drained wins over unknown roster" "PASS" "$(status_of "$(_vn_v_dev_no_work yes yes yes unknown)")"
 
+# ── _vn_v_cloud_sync (CTL-1736: LOCAL replica writer freshness, developer) ────
+expect_eq "cloud-sync: fresh → PASS"    "PASS" "$(status_of "$(_vn_v_cloud_sync fresh)")"
+expect_eq "cloud-sync: stale → FAIL"    "FAIL" "$(status_of "$(_vn_v_cloud_sync stale)")"
+expect_eq "cloud-sync: unseeded → WARN" "WARN" "$(status_of "$(_vn_v_cloud_sync unseeded)")"
+expect_eq "cloud-sync: idle → PASS"     "PASS" "$(status_of "$(_vn_v_cloud_sync idle)")"
+expect_eq "cloud-sync: unknown → WARN"  "WARN" "$(status_of "$(_vn_v_cloud_sync bogus)")"
+
+# _cloud_sync_state classification via injected leaf seams (each in an isolating subshell).
+( _cs_agent_installed() { return 0; }; _cs_token_present() { return 0; }
+  _cs_lock_age() { echo 10; }; _cs_cursor_seeded() { return 0; }
+  expect_eq "state: adopted+young+seeded → fresh" "fresh" "$(_cloud_sync_state)" )
+( _cs_agent_installed() { return 0; }; _cs_token_present() { return 0; }
+  _cs_lock_age() { echo 999999; }; _cs_cursor_seeded() { return 0; }
+  expect_eq "state: adopted+old-lock → stale" "stale" "$(_cloud_sync_state)" )
+( _cs_agent_installed() { return 0; }; _cs_token_present() { return 0; }
+  _cs_lock_age() { echo ""; }; _cs_cursor_seeded() { return 1; }
+  expect_eq "state: adopted+no-lock → unseeded" "unseeded" "$(_cloud_sync_state)" )
+( _cs_agent_installed() { return 0; }; _cs_token_present() { return 0; }
+  _cs_lock_age() { echo 10; }; _cs_cursor_seeded() { return 1; }
+  expect_eq "state: adopted+seeded-fail → unseeded" "unseeded" "$(_cloud_sync_state)" )
+( _cs_agent_installed() { return 1; }; _cs_token_present() { return 1; }
+  expect_eq "state: no-agent+no-token → idle" "idle" "$(_cloud_sync_state)" )
+
 # ── _vn_read_replica_base extractor (env override + Layer-2 baseUrl) ──────────
 SCRATCH="$(mktemp -d)"
 CFG="${SCRATCH}/config.json"

--- a/plugins/dev/scripts/catalyst-stack
+++ b/plugins/dev/scripts/catalyst-stack
@@ -1332,6 +1332,16 @@ cmd_status() {
     if pid_alive "$sp"; then echo "  log-shipper      running  pid=$sp"; else echo "  log-shipper      stopped"; fi
   fi
 
+  # CTL-1736: local Linear replica writer (cloud-sync) — surfaced on the primary status
+  # view so an operator on any node class can see writer liveness without running doctor.
+  case "$(_cloud_sync_state)" in
+    fresh)    echo "  cloud-sync       running  (replica fresh)" ;;
+    stale)    echo "  cloud-sync       stale    (writer wedged — launchctl kickstart -k gui/$UID/${CLOUD_SYNC_AGENT_LABEL})" ;;
+    unseeded) echo "  cloud-sync       installed, not seeded (reads fall back to linearis)" ;;
+    idle)     echo "  cloud-sync       not installed (no local replica; reads fall back to linearis)" ;;
+    *)        echo "  cloud-sync       unknown" ;;
+  esac
+
   # CTL-1084: governance section from the last node.boot event.
   local boot_json
   boot_json="$(latest_boot_event 2>/dev/null || true)"
@@ -1389,6 +1399,68 @@ CLOUD_SYNC_AGENT_LABEL="ai.coalesce.catalyst-cloud-sync"
 CLOUD_SYNC_AGENT_PLIST="${HOME}/Library/LaunchAgents/${CLOUD_SYNC_AGENT_LABEL}.plist"
 _cloud_sync_agent_installed() { [[ -f "$CLOUD_SYNC_AGENT_PLIST" ]]; }
 _resolve_cloud_sync_launcher() { printf '%s\n' "$CLOUD_SYNC_LAUNCHER"; }
+
+# CTL-1736: leaf seams for cloud-sync local-writer freshness (overridable in tests).
+# _cs_agent_installed — true when the KeepAlive LaunchAgent plist is present.
+_cs_agent_installed() { _cloud_sync_agent_installed; }
+# _cs_token_present — true when the canonical provisioning file is non-empty.
+_cs_token_present() { [[ -s "$HOME/.config/catalyst/cloud-sync.env" ]]; }
+# _cs_lock_age — epoch-seconds age of the writer heartbeat lock; empty if absent.
+# GNU stat -c %Y first (macOS lacks -c; it errors cleanly and falls through to BSD -f %m).
+_cs_lock_age() {
+  local lock="${CATALYST_REPLICA_DB:-${CATALYST_DIR:-$HOME/catalyst}/catalyst-replica.db}.writer.lock"
+  local m; m=$(stat -c %Y "$lock" 2>/dev/null || stat -f %m "$lock" 2>/dev/null) || true
+  [[ -n "$m" ]] || return 0
+  printf '%s\n' "$(( $(date +%s) - m ))"
+}
+# _cs_cursor_seeded — rc 0 when sync_meta has a non-empty cursor row (seed complete).
+_cs_cursor_seeded() {
+  command -v sqlite3 >/dev/null 2>&1 || return 1
+  local db="${CATALYST_REPLICA_DB:-${CATALYST_DIR:-$HOME/catalyst}/catalyst-replica.db}"
+  [[ -n "$(sqlite3 "$db" "SELECT 1 FROM sync_meta WHERE key='cursor' AND value<>'' LIMIT 1;" 2>/dev/null)" ]]
+}
+
+# _cloud_sync_state — classify the local writer into fresh|stale|unseeded|idle.
+# Severity table (plan §"Key discriminator"):
+#   idle     : no plist AND no token  → clean idle by design
+#   unseeded : adopted/provisioned but lock absent or cursor empty → not seeding yet
+#   stale    : lock present but older than CATALYST_LINEAR_REPLICA_STALE_MS/1000
+#   fresh    : lock young + cursor seeded
+_cloud_sync_state() {
+  if ! _cs_agent_installed && ! _cs_token_present; then
+    echo idle; return
+  fi
+  local age; age="$(_cs_lock_age)"
+  if [[ -z "$age" ]] || ! _cs_cursor_seeded; then
+    echo unseeded; return
+  fi
+  local thr=$(( ${CATALYST_LINEAR_REPLICA_STALE_MS:-300000} / 1000 ))
+  if (( age > thr )); then
+    echo stale; return
+  fi
+  echo fresh
+}
+
+# _vn_cloud_sync_state — thin seam (tests override this, not _cloud_sync_state directly).
+_vn_cloud_sync_state() { _cloud_sync_state; }
+
+# _vn_v_cloud_sync <state> — CTL-1736: pure verdict for the local replica writer.
+# Advisory (required=false): a legitimately idle developer node must not flip the run.
+_vn_v_cloud_sync() {
+  local state="${1:-}"
+  case "$state" in
+    fresh)
+      printf 'PASS|local replica writer fresh (cloud-sync seeding ~/catalyst/catalyst-replica.db)\n' ;;
+    stale)
+      printf 'FAIL|local replica writer STALE — writer.lock older than threshold; reads fall back to linearis (burns quota). Kickstart: launchctl kickstart -k gui/$UID/%s\n' "$CLOUD_SYNC_AGENT_LABEL" ;;
+    unseeded)
+      printf 'WARN|cloud-sync installed/provisioned but replica not seeded yet — reads fall back to linearis until seed completes\n' ;;
+    idle)
+      printf 'PASS|cloud-sync not adopted and no token — clean idle (developer reads fall back to linearis by design)\n' ;;
+    *)
+      printf 'WARN|cloud-sync state unverified\n' ;;
+  esac
+}
 
 # CTL-1654: event-mirror LaunchAgent — fans fleet events into the local event file on
 # observation nodes (monitor/developer). Installed/uninstalled by start/stop_event_mirror
@@ -3642,6 +3714,7 @@ _vn_run_developer() {
   _vn_emit "exec-core-stopped"  T1 true "$(_vn_v_daemon_down execution-core "$(_vn_exec_core_running)")"
   _vn_emit "plugins-fresh"      T1 true "$(_vn_v_updater "$(_vn_updater_ec)")"
   _vn_emit "read-replica"       T1 true "$(_vn_v_read_replica developer "$(_vn_read_replica_base)")"
+  _vn_emit "replica-writer-local" T1 false "$(_vn_v_cloud_sync "$(_vn_cloud_sync_state)")"
   _vn_emit "event-mirror-running" T1 true "$(_vn_v_daemon_up event-mirror "$(_vn_event_mirror_running)")"
   _vn_emit "would-not-own-work" T1 true "$(_vn_v_dev_no_work "$in_roster" "$multi_host" "$drained" "$roster_src")"
 }


### PR DESCRIPTION
Closes CTL-1736

## Summary
- Adds shared `_cloud_sync_state()` classifier (fresh|stale|unseeded|idle) with overridable leaf seams
- Wires advisory `replica-writer-local` check into `_vn_run_developer` (developer verify-node rubric)
- Adds `cloud-sync` line to `cmd_status` primary status view
- Backed by 10 new unit tests in verify-node.test.sh + new catalyst-stack-status-cloud-sync.test.sh

_Generated by phase-implement (CTL-1736)._