### PR TITLE
fix(dev): CAT-15 promote completed draft PRs to ready for review

### DIFF
--- a/plugins/dev/scripts/__tests__/phase-monitor-merge-guard.test.sh
+++ b/plugins/dev/scripts/__tests__/phase-monitor-merge-guard.test.sh
@@ -130,6 +130,22 @@ else
 fi
 
 echo ""
+echo "CAT-15: draft self-heal keys off REST .draft and persists its attempt"
+
+if [[ -f "$SKILL" ]]; then
+  assert_contains "$BODY" 'PR_IS_DRAFT' \
+    "draft self-heal keys off the REST draft field"
+  assert_contains "$BODY" '.draft-promote-${PHASE}' \
+    "draft promotion attempt persists across agent-driven loop iterations"
+  assert_not_contains "$BODY" 'MERGEABLE_STATE" == "draft' \
+    "draft self-heal does not expect mergeable_state=draft"
+  assert_not_contains "$BODY" 'DRAFT_PROMOTE_ATTEMPTED' \
+    "draft self-heal does not use a process-local attempt variable"
+else
+  fail "SKILL.md missing for CAT-15 draft checks: $SKILL"
+fi
+
+echo ""
 echo "─────────────────────────────────────────────"
 echo "phase-monitor-merge-guard: ${PASSES} passed, ${FAILURES} failed"
 echo "─────────────────────────────────────────────"

--- a/plugins/dev/scripts/__tests__/phase-monitor-merge-guard.test.sh
+++ b/plugins/dev/scripts/__tests__/phase-monitor-merge-guard.test.sh
@@ -135,8 +135,12 @@ echo "CAT-15: draft self-heal keys off REST .draft and persists its attempt"
 if [[ -f "$SKILL" ]]; then
   assert_contains "$BODY" 'PR_IS_DRAFT' \
     "draft self-heal keys off the REST draft field"
-  assert_contains "$BODY" '.draft-promote-${PHASE}' \
-    "draft promotion attempt persists across agent-driven loop iterations"
+  assert_contains "$BODY" '.draft-promote-${PHASE}-${DRAFT_PROMOTE_RUN_ID}' \
+    "draft promotion attempt persists across loop iterations but is scoped to one phase run"
+  assert_contains "$BODY" 'PR_IS_DRAFT="$(gh api' \
+    "REST read concretely assigns PR_IS_DRAFT"
+  assert_contains "$BODY" '[[ "${PR_IS_DRAFT:-}" == "true" ]]' \
+    "draft comparison remains safe under nounset"
   assert_not_contains "$BODY" 'MERGEABLE_STATE" == "draft' \
     "draft self-heal does not expect mergeable_state=draft"
   assert_not_contains "$BODY" 'DRAFT_PROMOTE_ATTEMPTED' \

--- a/plugins/dev/scripts/execution-core/orphan-pr-sweep-timer.mjs
+++ b/plugins/dev/scripts/execution-core/orphan-pr-sweep-timer.mjs
@@ -13,6 +13,8 @@ import {
   renameSync,
   readdirSync,
   mkdirSync,
+  statSync,
+  existsSync,
 } from "node:fs";
 import { spawnSync } from "node:child_process";
 import { join } from "node:path";
@@ -88,6 +90,25 @@ export function defaultReadWorkerTrackedNumbers(orchDir) {
     }
   }
   return tracked;
+}
+
+// defaultDraftExpected — a draft PR is EXPECTED (not an orphan) while the pipeline is
+// still pre-`pr` for its ticket. `.draftPr` is written only by phase-implement's End-block
+// backstop, but implement-plan opens the draft at the FIRST plan-phase commit, so for the
+// whole implement phase — far longer than stableSeconds — no signal file names the number
+// and the number-based tracked set cannot see it. Fall back to the ticket: a worker dir
+// that has not yet produced phase-pr.json is actively working a legitimately-draft PR.
+// Once phase-pr has run (or the worker dir is gone), a still-draft PR IS the stuck case.
+export function defaultDraftExpected(orchDir, headRefName) {
+  const ticket = draftTicket(headRefName);
+  if (!ticket || !orchDir) return false;
+  try {
+    // Worker dir present + no phase-pr.json → pre-PR pipeline, draft is expected.
+    return (
+      statSync(join(orchDir, "workers", ticket)).isDirectory() &&
+      !existsSync(join(orchDir, "workers", ticket, "phase-pr.json"))
+    );
+  } catch { return false; } // no worker dir → nothing is tracking it → orphan candidate
 }
 
 // draftTicket — recover the Linear identifier from the PR branch name so draft
@@ -172,7 +193,7 @@ function defaultEmit(name, payload) {
  * All seams are injected; this function has no I/O of its own.
  * Exported for unit tests.
  */
-export async function runOrphanSweep({ repo, nowMs, cfg, prList, readWorkerTrackedNumbers, ownsDraft = () => true, readState, persist, emit }) {
+export async function runOrphanSweep({ repo, nowMs, cfg, prList, readWorkerTrackedNumbers, ownsDraft = () => true, draftExpected = () => false, readState, persist, emit }) {
   if (!repo) return; // fail-open: no slug → no-op
 
   const prs = await prList(repo); // may throw → per-tick catch in the timer
@@ -187,6 +208,9 @@ export async function runOrphanSweep({ repo, nowMs, cfg, prList, readWorkerTrack
     // their HRW owner may classify one as orphaned; otherwise every peer lacks
     // the owner's local worker signal and emits a duplicate false escalation.
     if (pr.isDraft && !ownsDraft(pr)) continue;
+    // A draft opened by implement-plan's early fence is not yet named by any signal
+    // file, so the number-based tracked set above cannot see it. Resolve by ticket.
+    if (pr.isDraft && draftExpected(pr)) continue;
     const key = `${repo}#${pr.number}`;
     const entry = prior[key] ?? null;
     const decision = decideOrphanNotify({
@@ -241,6 +265,7 @@ export function startOrphanPrSweepTimer({
     const ticket = draftTicket(pr.headRefName);
     return ticket !== null && ownedBy(ticket, getClusterHosts(), getHostName());
   },
+  draftExpected = (pr) => defaultDraftExpected(orchDir, pr.headRefName),
   clock = realClock(),
 } = {}) {
   if (!enabled || !orchDir) return { stop: () => {} };
@@ -260,6 +285,7 @@ export function startOrphanPrSweepTimer({
         prList,
         readWorkerTrackedNumbers: () => readWorkerTrackedNumbersFn(orchDir),
         ownsDraft,
+        draftExpected,
         readState: () => readStateFn(orchDir),
         persist: (s) => persistFn(orchDir, s),
         emit,

--- a/plugins/dev/scripts/execution-core/orphan-pr-sweep-timer.mjs
+++ b/plugins/dev/scripts/execution-core/orphan-pr-sweep-timer.mjs
@@ -17,8 +17,9 @@ import {
 import { spawnSync } from "node:child_process";
 import { join } from "node:path";
 import { appendFileSync } from "node:fs";
-import { log, getEventLogPath } from "./config.mjs";
+import { log, getEventLogPath, getClusterHosts, getHostName } from "./config.mjs";
 import { DEFAULTS, decideOrphanNotify } from "./orphan-pr-sweep.mjs";
+import { ownedBy } from "./hrw.mjs";
 
 // readOrphanPrSweepConfig — read catalyst.orchestration.orphanPrSweep.*
 // from .catalyst/config.json. Returns {} for missing/unreadable/absent key.
@@ -87,6 +88,15 @@ export function defaultReadWorkerTrackedNumbers(orchDir) {
     }
   }
   return tracked;
+}
+
+// draftTicket — recover the Linear identifier from the PR branch name so draft
+// notification can use the same fleet-wide HRW ownership boundary as dispatch.
+// A branch without an identifier cannot be safely assigned to this host.
+export function draftTicket(headRefName) {
+  return typeof headRefName === "string"
+    ? headRefName.match(/(?:^|\/)([A-Z][A-Z0-9]+-\d+)(?:$|[-_/])/i)?.[1]?.toUpperCase() ?? null
+    : null;
 }
 
 // defaultResolveRepoSlug — determine the repo slug for gh pr list.
@@ -162,7 +172,7 @@ function defaultEmit(name, payload) {
  * All seams are injected; this function has no I/O of its own.
  * Exported for unit tests.
  */
-export async function runOrphanSweep({ repo, nowMs, cfg, prList, readWorkerTrackedNumbers, readState, persist, emit }) {
+export async function runOrphanSweep({ repo, nowMs, cfg, prList, readWorkerTrackedNumbers, ownsDraft = () => true, readState, persist, emit }) {
   if (!repo) return; // fail-open: no slug → no-op
 
   const prs = await prList(repo); // may throw → per-tick catch in the timer
@@ -173,6 +183,10 @@ export async function runOrphanSweep({ repo, nowMs, cfg, prList, readWorkerTrack
   const next = {}; // rebuilt each tick → prunes vanished/recovered PRs
   for (const pr of prs) {
     if (tracked.has(pr.number)) continue; // worker-tracked → not an orphan
+    // Drafts legitimately remain open throughout implement→verify→review. Only
+    // their HRW owner may classify one as orphaned; otherwise every peer lacks
+    // the owner's local worker signal and emits a duplicate false escalation.
+    if (pr.isDraft && !ownsDraft(pr)) continue;
     const key = `${repo}#${pr.number}`;
     const entry = prior[key] ?? null;
     const decision = decideOrphanNotify({
@@ -223,6 +237,10 @@ export function startOrphanPrSweepTimer({
   readState: readStateFn = (od) => defaultReadState(od),
   persist: persistFn = (od, s) => defaultPersist(od, s),
   emit = defaultEmit,
+  ownsDraft = (pr) => {
+    const ticket = draftTicket(pr.headRefName);
+    return ticket !== null && ownedBy(ticket, getClusterHosts(), getHostName());
+  },
   clock = realClock(),
 } = {}) {
   if (!enabled || !orchDir) return { stop: () => {} };
@@ -241,6 +259,7 @@ export function startOrphanPrSweepTimer({
         cfg,
         prList,
         readWorkerTrackedNumbers: () => readWorkerTrackedNumbersFn(orchDir),
+        ownsDraft,
         readState: () => readStateFn(orchDir),
         persist: (s) => persistFn(orchDir, s),
         emit,

--- a/plugins/dev/scripts/execution-core/orphan-pr-sweep-timer.mjs
+++ b/plugins/dev/scripts/execution-core/orphan-pr-sweep-timer.mjs
@@ -177,13 +177,9 @@ export async function runOrphanSweep({ repo, nowMs, cfg, prList, readWorkerTrack
     if (decision.action === "skip" && decision.reason === "not_blocked") {
       continue; // not a blocker / recovered → drop (prune)
     }
-    if (decision.action === "skip" && decision.reason === "draft") {
-      continue; // draft → skip
-    }
-
     const base = {
       repo, number: pr.number, url: pr.url, title: pr.title,
-      headRefName: pr.headRefName, mergeStateStatus: pr.mergeStateStatus,
+      headRefName: pr.headRefName, mergeStateStatus: pr.mergeStateStatus, isDraft: pr.isDraft,
     };
 
     if (decision.action === "stamp") {
@@ -192,7 +188,10 @@ export async function runOrphanSweep({ repo, nowMs, cfg, prList, readWorkerTrack
       next[key] = { ...base, firstSeenAt: entry.firstSeenAt }; // carry forward, refresh state
     } else if (decision.action === "notify") {
       next[key] = { ...base, firstSeenAt: entry.firstSeenAt, notifiedAt: new Date(nowMs).toISOString() };
-      emit(`phase.orphan-pr.detected.${pr.number}`, { repo, number: pr.number, url: pr.url, mergeStateStatus: pr.mergeStateStatus });
+      emit(`phase.orphan-pr.detected.${pr.number}`, {
+        repo, number: pr.number, url: pr.url, mergeStateStatus: pr.mergeStateStatus,
+        reason: decision.reason,
+      });
     } else if (decision.action === "skip" && decision.reason === "already_notified") {
       // Keep the entry alive so the inbox row persists across ticks.
       next[key] = { ...base, firstSeenAt: entry.firstSeenAt, notifiedAt: entry.notifiedAt };

--- a/plugins/dev/scripts/execution-core/orphan-pr-sweep-timer.mjs
+++ b/plugins/dev/scripts/execution-core/orphan-pr-sweep-timer.mjs
@@ -63,7 +63,7 @@ async function defaultPrList(repo) {
 
 // defaultReadWorkerTrackedNumbers — scan worker phase signal files for PR numbers.
 // Returns a Set of PR numbers that the pipeline is already tracking.
-function defaultReadWorkerTrackedNumbers(orchDir) {
+export function defaultReadWorkerTrackedNumbers(orchDir) {
   const tracked = new Set();
   let ticketDirs;
   try {
@@ -73,10 +73,16 @@ function defaultReadWorkerTrackedNumbers(orchDir) {
   } catch { return tracked; }
 
   for (const ticket of ticketDirs) {
-    for (const fname of ["phase-pr.json", "phase-monitor-merge.json"]) {
+    const sources = [
+      ["phase-pr.json", (raw) => raw?.pr?.number],
+      ["phase-monitor-merge.json", (raw) => raw?.pr?.number],
+      ["phase-implement.json", (raw) => raw?.draftPr?.number],
+    ];
+    for (const [fname, pick] of sources) {
       try {
         const raw = JSON.parse(readFileSync(join(orchDir, "workers", ticket, fname), "utf8"));
-        if (raw?.pr?.number) tracked.add(raw.pr.number);
+        const number = pick(raw);
+        if (number) tracked.add(number);
       } catch { /* absent or unreadable */ }
     }
   }

--- a/plugins/dev/scripts/execution-core/orphan-pr-sweep-timer.test.mjs
+++ b/plugins/dev/scripts/execution-core/orphan-pr-sweep-timer.test.mjs
@@ -34,6 +34,25 @@ test("draft PR tracked by phase-implement is filtered out", async () => {
   expect(Object.keys(persisted)).toHaveLength(0);
 });
 
+test("draft PR owned by a peer is filtered out when no local worker tracks it", async () => {
+  const persisted = {}; const events = [];
+  await runOrphanSweep({
+    repo, nowMs: 300_000, cfg: { stableSeconds: 300 },
+    prList: async () => [mkPr(2061, {
+      headRefName: "fork/CAT-15", isDraft: true, mergeStateStatus: "CLEAN",
+    })],
+    readWorkerTrackedNumbers: () => new Set(),
+    ownsDraft: () => false,
+    readState: () => ({ [`${repo}#2061`]: {
+      repo, number: 2061, firstSeenAt: new Date(0).toISOString(),
+    } }),
+    persist: (s) => Object.assign(persisted, s),
+    emit: (n, p) => events.push({ n, p }),
+  });
+  expect(Object.keys(persisted)).toHaveLength(0);
+  expect(events).toHaveLength(0);
+});
+
 test("orphan blocker, first sighting → stamps firstSeenAt, no notify event yet", async () => {
   let persisted = null; const events = [];
   await runOrphanSweep({

--- a/plugins/dev/scripts/execution-core/orphan-pr-sweep-timer.test.mjs
+++ b/plugins/dev/scripts/execution-core/orphan-pr-sweep-timer.test.mjs
@@ -1,5 +1,8 @@
 import { test, expect } from "bun:test";
-import { runOrphanSweep } from "./orphan-pr-sweep-timer.mjs";
+import { mkdtempSync, mkdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { defaultReadWorkerTrackedNumbers, runOrphanSweep } from "./orphan-pr-sweep-timer.mjs";
 
 const repo = "org/repo";
 const mkPr = (n, o = {}) => ({ number: n, url: `https://github.com/${repo}/pull/${n}`,
@@ -11,6 +14,21 @@ test("PR tracked by a worker is filtered out (not an orphan)", async () => {
     repo, nowMs: 1000, cfg: { stableSeconds: 300 },
     prList: async () => [mkPr(2061)],
     readWorkerTrackedNumbers: () => new Set([2061]),
+    readState: () => ({}), persist: (s) => Object.assign(persisted, s), emit: () => {},
+  });
+  expect(Object.keys(persisted)).toHaveLength(0);
+});
+
+test("draft PR tracked by phase-implement is filtered out", async () => {
+  const orchDir = mkdtempSync(join(tmpdir(), "orphan-pr-sweep-"));
+  const workerDir = join(orchDir, "workers", "CAT-15");
+  mkdirSync(workerDir, { recursive: true });
+  writeFileSync(join(workerDir, "phase-implement.json"), JSON.stringify({ draftPr: { number: 2061 } }));
+  const persisted = {};
+  await runOrphanSweep({
+    orchDir, repo, nowMs: 1000, cfg: { stableSeconds: 300 },
+    prList: async () => [mkPr(2061, { isDraft: true, mergeStateStatus: "CLEAN" })],
+    readWorkerTrackedNumbers: () => defaultReadWorkerTrackedNumbers(orchDir),
     readState: () => ({}), persist: (s) => Object.assign(persisted, s), emit: () => {},
   });
   expect(Object.keys(persisted)).toHaveLength(0);

--- a/plugins/dev/scripts/execution-core/orphan-pr-sweep-timer.test.mjs
+++ b/plugins/dev/scripts/execution-core/orphan-pr-sweep-timer.test.mjs
@@ -2,7 +2,7 @@ import { test, expect } from "bun:test";
 import { mkdtempSync, mkdirSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
-import { defaultReadWorkerTrackedNumbers, runOrphanSweep } from "./orphan-pr-sweep-timer.mjs";
+import { defaultDraftExpected, defaultReadWorkerTrackedNumbers, runOrphanSweep } from "./orphan-pr-sweep-timer.mjs";
 
 const repo = "org/repo";
 const mkPr = (n, o = {}) => ({ number: n, url: `https://github.com/${repo}/pull/${n}`,
@@ -32,6 +32,43 @@ test("draft PR tracked by phase-implement is filtered out", async () => {
     readState: () => ({}), persist: (s) => Object.assign(persisted, s), emit: () => {},
   });
   expect(Object.keys(persisted)).toHaveLength(0);
+});
+
+// CAT-15 review: implement-plan opens the draft at the first plan-phase commit, but
+// .draftPr is only written by phase-implement's End block — so a draft is untracked by
+// number for the whole implement phase and would false-notify past the stable window.
+test("draft PR of a pre-PR worker dir is expected, not an orphan", async () => {
+  const orchDir = mkdtempSync(join(tmpdir(), "orphan-pr-sweep-"));
+  mkdirSync(join(orchDir, "workers", "CAT-15"), { recursive: true });
+  writeFileSync(join(orchDir, "workers", "CAT-15", "phase-implement.json"), JSON.stringify({}));
+  expect(defaultDraftExpected(orchDir, "ryan/cat-15-promote-drafts")).toBe(true);
+
+  const persisted = {}; const events = [];
+  await runOrphanSweep({
+    repo, nowMs: 300_000, cfg: { stableSeconds: 300 },
+    prList: async () => [mkPr(2061, {
+      headRefName: "ryan/cat-15-promote-drafts", isDraft: true, mergeStateStatus: "CLEAN",
+    })],
+    readWorkerTrackedNumbers: () => new Set(),
+    draftExpected: (pr) => defaultDraftExpected(orchDir, pr.headRefName),
+    readState: () => ({ [`${repo}#2061`]: {
+      repo, number: 2061, firstSeenAt: new Date(0).toISOString(),
+    } }),
+    persist: (s) => Object.assign(persisted, s),
+    emit: (n, p) => events.push({ n, p }),
+  });
+  expect(Object.keys(persisted)).toHaveLength(0);
+  expect(events).toHaveLength(0);
+});
+
+test("draft PR is NOT expected once phase-pr has run, or with no worker dir", () => {
+  const orchDir = mkdtempSync(join(tmpdir(), "orphan-pr-sweep-"));
+  const workerDir = join(orchDir, "workers", "CAT-15");
+  mkdirSync(workerDir, { recursive: true });
+  writeFileSync(join(workerDir, "phase-pr.json"), JSON.stringify({ pr: {} }));
+  expect(defaultDraftExpected(orchDir, "ryan/cat-15-promote-drafts")).toBe(false);
+  expect(defaultDraftExpected(orchDir, "ryan/cat-99-never-dispatched")).toBe(false);
+  expect(defaultDraftExpected(orchDir, "hand-opened-branch")).toBe(false);
 });
 
 test("draft PR owned by a peer is filtered out when no local worker tracks it", async () => {

--- a/plugins/dev/scripts/execution-core/orphan-pr-sweep.mjs
+++ b/plugins/dev/scripts/execution-core/orphan-pr-sweep.mjs
@@ -30,7 +30,7 @@ export function isOrphanBlocked(mergeStateStatus) {
 //   Returns { action: 'skip'|'stamp'|'wait'|'notify', reason }.
 // The timer owns all side-effects (stamping firstSeenAt, setting notifiedAt, emit).
 export function decideOrphanNotify({ mergeStateStatus, isDraft, entry, nowMs, stableSeconds = DEFAULTS.stableSeconds }) {
-  if (!isOrphanBlocked(mergeStateStatus)) return { action: "skip", reason: "not_blocked" };
+  if (!isOrphanBlocked(mergeStateStatus) && !isDraft) return { action: "skip", reason: "not_blocked" };
   if (!entry?.firstSeenAt) return { action: "stamp", reason: "first_sighting" };
   if (entry.notifiedAt) return { action: "skip", reason: "already_notified" };
 

--- a/plugins/dev/scripts/execution-core/orphan-pr-sweep.mjs
+++ b/plugins/dev/scripts/execution-core/orphan-pr-sweep.mjs
@@ -31,8 +31,6 @@ export function isOrphanBlocked(mergeStateStatus) {
 // The timer owns all side-effects (stamping firstSeenAt, setting notifiedAt, emit).
 export function decideOrphanNotify({ mergeStateStatus, isDraft, entry, nowMs, stableSeconds = DEFAULTS.stableSeconds }) {
   if (!isOrphanBlocked(mergeStateStatus)) return { action: "skip", reason: "not_blocked" };
-  if (isDraft) return { action: "skip", reason: "draft" };
-
   if (!entry?.firstSeenAt) return { action: "stamp", reason: "first_sighting" };
   if (entry.notifiedAt) return { action: "skip", reason: "already_notified" };
 
@@ -40,5 +38,5 @@ export function decideOrphanNotify({ mergeStateStatus, isDraft, entry, nowMs, st
   if (Number.isNaN(seenMs)) return { action: "stamp", reason: "restamp_unparsable" };
   if (nowMs - seenMs < stableSeconds * 1000) return { action: "wait", reason: "stability_window" };
 
-  return { action: "notify", reason: "blocker_stable" };
+  return { action: "notify", reason: isDraft ? "draft_stable" : "blocker_stable" };
 }

--- a/plugins/dev/scripts/execution-core/orphan-pr-sweep.test.mjs
+++ b/plugins/dev/scripts/execution-core/orphan-pr-sweep.test.mjs
@@ -22,6 +22,17 @@ test("CAT-15: draft PR in a blocker state → stamp", () => {
   expect(d.reason).toBe("first_sighting");
 });
 
+test("CAT-15: draft PR with CLEAN merge state → stamp", () => {
+  const d = decideOrphanNotify({ mergeStateStatus: "CLEAN", isDraft: true, entry: null, nowMs: 1000, stableSeconds: 300 });
+  expect(d).toEqual({ action: "stamp", reason: "first_sighting" });
+});
+
+test("draft PR with CLEAN merge state past stable window → notify:draft_stable", () => {
+  const entry = { firstSeenAt: new Date(0).toISOString() };
+  const d = decideOrphanNotify({ mergeStateStatus: "CLEAN", isDraft: true, entry, nowMs: 300_000, stableSeconds: 300 });
+  expect(d).toEqual({ action: "notify", reason: "draft_stable" });
+});
+
 test("draft blocker past stable window → notify:draft_stable", () => {
   const entry = { firstSeenAt: new Date(0).toISOString() };
   const d = decideOrphanNotify({ mergeStateStatus: "BLOCKED", isDraft: true, entry, nowMs: 300_000, stableSeconds: 300 });

--- a/plugins/dev/scripts/execution-core/orphan-pr-sweep.test.mjs
+++ b/plugins/dev/scripts/execution-core/orphan-pr-sweep.test.mjs
@@ -8,7 +8,7 @@ test("isOrphanBlocked: DIRTY/BLOCKED/UNSTABLE are blockers; CLEAN/HAS_HOOKS/UNKN
     expect(isOrphanBlocked(s)).toBe(false);
 });
 
-// decideOrphanNotify state machine: skip (not blocker / draft) | stamp (first blocker sighting)
+// decideOrphanNotify state machine: skip (not blocker) | stamp (first blocker sighting)
 //   | wait (within window) | notify (window elapsed, not yet notified) | skip (already notified).
 test("non-blocker state → skip:not_blocked, never stamps", () => {
   const d = decideOrphanNotify({ mergeStateStatus: "CLEAN", isDraft: false, entry: null, nowMs: 1000, stableSeconds: 300 });
@@ -16,10 +16,16 @@ test("non-blocker state → skip:not_blocked, never stamps", () => {
   expect(d.reason).toBe("not_blocked");
 });
 
-test("draft PR in a blocker state → skip:draft", () => {
+test("CAT-15: draft PR in a blocker state → stamp", () => {
   const d = decideOrphanNotify({ mergeStateStatus: "UNSTABLE", isDraft: true, entry: null, nowMs: 1000, stableSeconds: 300 });
-  expect(d.action).toBe("skip");
-  expect(d.reason).toBe("draft");
+  expect(d.action).toBe("stamp");
+  expect(d.reason).toBe("first_sighting");
+});
+
+test("draft blocker past stable window → notify:draft_stable", () => {
+  const entry = { firstSeenAt: new Date(0).toISOString() };
+  const d = decideOrphanNotify({ mergeStateStatus: "BLOCKED", isDraft: true, entry, nowMs: 300_000, stableSeconds: 300 });
+  expect(d).toEqual({ action: "notify", reason: "draft_stable" });
 });
 
 test("first blocker sighting → stamp firstSeenAt", () => {

--- a/plugins/dev/scripts/execution-core/pr-block-probe.mjs
+++ b/plugins/dev/scripts/execution-core/pr-block-probe.mjs
@@ -119,7 +119,7 @@ function emptyProbe() {
 // merge SHA when a PR resolves as MERGED — the empty-mergeCommitSha family fires on
 // PRs that actually merged but whose SHA monitor-merge failed to record.
 const PR_VIEW_FIELDS =
-  "number,state,mergeStateStatus,mergeable,statusCheckRollup,reviewDecision,mergeCommit";
+  "number,state,isDraft,mergeStateStatus,mergeable,statusCheckRollup,reviewDecision,mergeCommit";
 
 // Resolve the ticket's PR EXPLICITLY — never by the daemon's current branch.
 // classifyPrNotMerged runs inside the daemon process (daemon cwd), so a bare
@@ -293,6 +293,7 @@ export function defaultProbePrBlock(
   return {
     prNumber: view.number,
     state: view.state,
+    isDraft: view.isDraft === true,
     // CTL-1680: recovered merge SHA for a PR that resolved as MERGED; null for open PRs.
     mergeCommitSha: view.mergeCommit?.oid ?? null,
     mergeStateStatus: view.mergeStateStatus,

--- a/plugins/dev/scripts/execution-core/pr-block-probe.mjs
+++ b/plugins/dev/scripts/execution-core/pr-block-probe.mjs
@@ -100,6 +100,7 @@ function emptyProbe() {
   return {
     prNumber: null,
     state: null,
+    isDraft: false,
     mergeCommitSha: null,
     mergeStateStatus: null,
     mergeable: null,

--- a/plugins/dev/scripts/execution-core/recovery-reasoning.mjs
+++ b/plugins/dev/scripts/execution-core/recovery-reasoning.mjs
@@ -565,6 +565,9 @@ export function reasoningRecoveryPass(items, opts = {}) {
 // CTL-1496: the failureReason value emitted by phase-teardown's pr_not_merged gate.
 export const PR_NOT_MERGED_REASON = "pr_not_merged";
 export const DRAFT_PROMOTE_FAILED_REASON = "draft_promote_failed";
+// CAT-15: phase-monitor-merge's draft handler emits its own reason (two sites) when a
+// PR is still draft after one promote attempt. Distinct string, same recovery route.
+export const PR_STUCK_IN_DRAFT_REASON = "pr_stuck_in_draft";
 
 // CTL-1680: phase-monitor-deploy's empty-mergeCommitSha false-done guard emits bespoke prose
 // reasons (not teardown's literal "pr_not_merged"). They all share this recognizable prefix.
@@ -645,6 +648,7 @@ export function isPrMergeUnconfirmedReason(reason) {
   return (
     reason === PR_NOT_MERGED_REASON ||
     reason === DRAFT_PROMOTE_FAILED_REASON ||
+    reason === PR_STUCK_IN_DRAFT_REASON ||
     (typeof reason === "string" && reason.startsWith(MONITOR_DEPLOY_EMPTY_SHA_PREFIX))
   );
 }

--- a/plugins/dev/scripts/execution-core/recovery-reasoning.mjs
+++ b/plugins/dev/scripts/execution-core/recovery-reasoning.mjs
@@ -682,6 +682,10 @@ export function classifyPrNotMerged(evidence, { probePrBlock = defaultProbePrBlo
   // production reasons carry no `pr#<N>` at all, so fall back to the sibling phase
   // artifacts on disk, where the exact number is still recorded.
   const prNumber = resolvePrNumberForRecovery(evidence);
+  // CTL-1680 (Codex #3192 P1): the ORIGINATING failure reason decides where a
+  // now-ready draft resumes (see the draft-resume branch below). Read from the
+  // same two places defaultClassifyTicket used to route here, so the two agree.
+  const originReason = evidence.failureReason ?? evidence.signal?.failureReason;
   let probe;
   try {
     probe = probePrBlock(ticket, { branch, repo, worktreePath, prNumber });
@@ -750,12 +754,72 @@ export function classifyPrNotMerged(evidence, { probePrBlock = defaultProbePrBlo
   }
 
   if (probe.isDraft) {
+    // CTL-1680 (Codex #3192 P2): a CLOSED draft is terminal for this fix path.
+    // `gh pr ready` cannot promote a closed PR, so dispatching the bounded worker
+    // would burn recovery attempts on an impossible action, once per cycle until
+    // the attempt budget is exhausted. Whether to reopen it is a human decision,
+    // so escalate with the concrete state rather than deferring or silently
+    // skipping. Gated on an explicit CLOSED (not `!== "OPEN"`) so a probe that
+    // never resolved `state` keeps its existing promotion behavior — MERGED is
+    // already returned above, and the only other value is OPEN.
+    if (probe.state === "CLOSED") {
+      return {
+        decision: "escalate",
+        fix_class: "human",
+        details: {
+          reason:
+            `PR #${probe.prNumber} is CLOSED and still a draft; it cannot be promoted — ` +
+            `reopen it or close out the ticket`,
+        },
+      };
+    }
     return {
       decision: "fix",
       fix_class: "bounded-llm",
       details: {
         reason: `PR #${probe.prNumber} is still a DRAFT; promote it to ready-for-review before merging`,
         brief: generateRemediateBrief("pr-stuck-in-draft", probe),
+      },
+    };
+  }
+
+  // CTL-1680 (Codex #3192 P1): a DRAFT-ORIGIN failure whose PR is now ready and
+  // CLEAN must resume its ORIGINATING phase — never collapse into direct-merge
+  // remediation. Both draft reasons can reach here with `isDraft === false`:
+  // the promotion actually succeeded and only the REST verification failed, or a
+  // human promoted the PR before recovery ran. Falling through to the generic
+  // `remediable` branch below hands the worker a "pr-not-merged" brief that says
+  // `gh pr merge --squash` outright, which (a) for pr_stuck_in_draft bypasses
+  // phase-monitor-merge's reviewer-arrival window — the guard that stops a fresh
+  // CLEAN PR merging before the automated reviewer lands its verdict — and
+  // (b) for draft_promote_failed additionally skips phase-pr's still-unfinished
+  // describe-pr and Linear state-transition work.
+  //
+  // Scoped deliberately to the CLEAN sub-case: when the now-ready PR still has a
+  // failing check or an unresolved bot thread, that IS genuine LLM-actionable
+  // remediation, so the generic branch below still owns it. Once the worker
+  // clears those blockers the item re-enters, the PR is CLEAN, and this branch
+  // then routes it back to its phase — convergent, not a bypass.
+  const draftResumePhase =
+    originReason === PR_STUCK_IN_DRAFT_REASON
+      ? "monitor-merge"
+      : originReason === DRAFT_PROMOTE_FAILED_REASON
+        ? "pr"
+        : null;
+  if (
+    draftResumePhase &&
+    probe.mergeStateStatus === "CLEAN" &&
+    probe.failingChecks.length === 0 &&
+    probe.unresolvedBotThreads.length === 0
+  ) {
+    return {
+      decision: "fix",
+      fix_class: "bounded-llm",
+      details: {
+        reason:
+          `PR #${probe.prNumber} is no longer a draft (mergeState=CLEAN); ` +
+          `resume phase-${draftResumePhase} rather than merging directly`,
+        brief: generateRemediateBrief(`pr-draft-resume-${draftResumePhase}`, probe),
       },
     };
   }
@@ -1096,6 +1160,34 @@ export function generateRemediateBrief(category, probe = null) {
       probe ? `PR #${probe.prNumber} is still a draft.` : "The ticket PR is still a draft.",
       "Run `gh pr ready <n>`, then verify with `gh api repos/{owner}/{repo}/pulls/<n> --jq .draft`.",
       "Continue only after REST returns false; otherwise escalate with the PR number and API error.",
+    ].join(" "),
+    // CTL-1680 (Codex #3192 P1): the draft-origin failure resolved itself — the PR
+    // is ready and CLEAN. Hand the work back to the phase that owns the remaining
+    // steps instead of merging here. Neither brief mentions `gh pr merge`: the
+    // merge is monitor-merge's to perform, behind its reviewer-arrival window.
+    "pr-draft-resume-monitor-merge": [
+      probe
+        ? `PR #${probe.prNumber} is no longer a draft and is CLEAN.`
+        : "The ticket PR is no longer a draft and is CLEAN.",
+      "Do NOT merge it here. phase-monitor-merge owns the merge, and it gates on a",
+      "reviewer-arrival window that stops a fresh CLEAN PR from merging before the",
+      "automated reviewer has posted a verdict on the CURRENT head — merging directly",
+      "would skip that window entirely.",
+      "Clear the stale failure and re-dispatch phase-monitor-merge for this ticket so",
+      "it re-reads live PR state and completes the merge through its own gates.",
+      "Escalate ONLY if the PR cannot be re-entered into monitor-merge, with the PR number linked.",
+    ].join(" "),
+    "pr-draft-resume-pr": [
+      probe
+        ? `PR #${probe.prNumber} was promoted out of draft after phase-pr's promotion step failed.`
+        : "The ticket PR was promoted out of draft after phase-pr's promotion step failed.",
+      "Do NOT merge it here. phase-pr had not finished its remaining work when it failed —",
+      "the generated PR description (describe-pr) and the Linear transition to inReview —",
+      "and merging now would ship the ticket with neither.",
+      "Re-dispatch phase-pr for this ticket; it is idempotent about an already-ready PR and",
+      "will complete the description and state transition, after which the pipeline advances",
+      "to monitor-merge normally.",
+      "Escalate ONLY if phase-pr cannot be re-entered, with the PR number linked.",
     ].join(" "),
     // CTL-1680: the PR merged but monitor-merge recorded an empty merge SHA, so
     // monitor-deploy's empty-SHA guard false-failed. No code fix is needed — the work

--- a/plugins/dev/scripts/execution-core/recovery-reasoning.mjs
+++ b/plugins/dev/scripts/execution-core/recovery-reasoning.mjs
@@ -564,6 +564,7 @@ export function reasoningRecoveryPass(items, opts = {}) {
 
 // CTL-1496: the failureReason value emitted by phase-teardown's pr_not_merged gate.
 export const PR_NOT_MERGED_REASON = "pr_not_merged";
+export const DRAFT_PROMOTE_FAILED_REASON = "draft_promote_failed";
 
 // CTL-1680: phase-monitor-deploy's empty-mergeCommitSha false-done guard emits bespoke prose
 // reasons (not teardown's literal "pr_not_merged"). They all share this recognizable prefix.
@@ -643,6 +644,7 @@ export function resolvePrNumberForRecovery(evidence, { readFile = readFileSync }
 export function isPrMergeUnconfirmedReason(reason) {
   return (
     reason === PR_NOT_MERGED_REASON ||
+    reason === DRAFT_PROMOTE_FAILED_REASON ||
     (typeof reason === "string" && reason.startsWith(MONITOR_DEPLOY_EMPTY_SHA_PREFIX))
   );
 }

--- a/plugins/dev/scripts/execution-core/recovery-reasoning.mjs
+++ b/plugins/dev/scripts/execution-core/recovery-reasoning.mjs
@@ -743,6 +743,17 @@ export function classifyPrNotMerged(evidence, { probePrBlock = defaultProbePrBlo
     };
   }
 
+  if (probe.isDraft) {
+    return {
+      decision: "fix",
+      fix_class: "bounded-llm",
+      details: {
+        reason: `PR #${probe.prNumber} is still a DRAFT; promote it to ready-for-review before merging`,
+        brief: generateRemediateBrief("pr-stuck-in-draft", probe),
+      },
+    };
+  }
+
   // Remediable when there is a concrete LLM-actionable cause (failing checks or
   // unresolved bot threads), or the PR is already CLEAN and just needs merging.
   // A BLOCKED PR with NO actionable cause (awaiting a required approving review
@@ -1075,6 +1086,11 @@ export function generateRemediateBrief(category, probe = null) {
     ]
       .filter(Boolean)
       .join(" "),
+    "pr-stuck-in-draft": [
+      probe ? `PR #${probe.prNumber} is still a draft.` : "The ticket PR is still a draft.",
+      "Run `gh pr ready <n>`, then verify with `gh api repos/{owner}/{repo}/pulls/<n> --jq .draft`.",
+      "Continue only after REST returns false; otherwise escalate with the PR number and API error.",
+    ].join(" "),
     // CTL-1680: the PR merged but monitor-merge recorded an empty merge SHA, so
     // monitor-deploy's empty-SHA guard false-failed. No code fix is needed — the work
     // shipped; recover the SHA and let the pipeline proceed.

--- a/plugins/dev/scripts/execution-core/recovery-reasoning.test.mjs
+++ b/plugins/dev/scripts/execution-core/recovery-reasoning.test.mjs
@@ -2573,6 +2573,142 @@ describe("classifyPrNotMerged (CTL-1496)", () => {
     expect(r.decision).toBe("fix");
   });
 
+  // ─── CTL-1680 (Codex #3192 P1): a now-ready draft failure must resume its
+  // ORIGINATING phase, not collapse into direct-merge remediation ────────────
+  //
+  // `pr_stuck_in_draft` / `draft_promote_failed` both enter classifyPrNotMerged.
+  // When the promotion actually succeeded (REST verification merely failed, or a
+  // human promoted the PR first), `isDraft` is false and the PR is CLEAN, so the
+  // generic `remediable` branch produced a "pr-not-merged" brief that instructs
+  // `gh pr merge --squash`. For pr_stuck_in_draft that bypasses
+  // phase-monitor-merge's reviewer-arrival window; for draft_promote_failed it
+  // additionally skips phase-pr's describe-pr + Linear state-transition work.
+  const mkDraftEvidence = (reason) => ({
+    logsOutput: null,
+    signal: { failureReason: reason },
+    failureReason: reason,
+    ticket: "CTL-1",
+  });
+  const nowReadyCleanProbe = (prNumber) =>
+    probeReturning({
+      prNumber,
+      isDraft: false,
+      mergeStateStatus: "CLEAN",
+      failingChecks: [],
+      pendingChecks: [],
+      unresolvedBotThreads: [],
+      unresolvedHumanThreads: [],
+      hasChangesRequested: false,
+    });
+
+  test("pr_stuck_in_draft + PR now ready/CLEAN → resume monitor-merge, never direct-merge", () => {
+    const r = defaultClassifyTicket(mkDraftEvidence(PR_STUCK_IN_DRAFT_REASON), {
+      probePrBlock: nowReadyCleanProbe(50),
+    });
+    expect(r.decision).toBe("fix");
+    expect(r.fix_class).toBe("bounded-llm");
+    // The whole point: the worker must NOT be told to merge it itself.
+    expect(r.details.brief).not.toContain("gh pr merge");
+    expect(r.details.brief).toContain("monitor-merge");
+    expect(r.details.reason).toContain("50");
+  });
+
+  test("draft_promote_failed + PR now ready/CLEAN → resume phase-pr, never direct-merge", () => {
+    const r = defaultClassifyTicket(mkDraftEvidence(DRAFT_PROMOTE_FAILED_REASON), {
+      probePrBlock: nowReadyCleanProbe(51),
+    });
+    expect(r.decision).toBe("fix");
+    expect(r.fix_class).toBe("bounded-llm");
+    expect(r.details.brief).not.toContain("gh pr merge");
+    // phase-pr still owes describe-pr + the Linear inReview transition.
+    expect(r.details.brief).toContain("pr");
+    expect(r.details.reason).toContain("51");
+  });
+
+  // CTL-1680 (Codex #3192 P2): a CLOSED draft cannot be promoted — `gh pr ready`
+  // fails on it — so dispatching the promotion fix burns recovery attempts on an
+  // impossible action. Reopening is a human decision, so this escalates.
+  test("CLOSED draft → escalate, never a gh-pr-ready promotion fix", () => {
+    const r = defaultClassifyTicket(mkEvidence(), {
+      probePrBlock: probeReturning({
+        prNumber: 55,
+        state: "CLOSED",
+        isDraft: true,
+        mergeStateStatus: "DRAFT",
+        failingChecks: [],
+        pendingChecks: [],
+        unresolvedBotThreads: [],
+        unresolvedHumanThreads: [],
+        hasChangesRequested: false,
+      }),
+    });
+    expect(r.decision).toBe("escalate");
+    expect(r.fix_class).toBe("human");
+    expect(r.details.reason).toContain("55");
+    expect(r.details.reason).toMatch(/closed/i);
+    expect(r.details.brief ?? "").not.toContain("gh pr ready");
+  });
+
+  test("OPEN draft still gets the promotion fix (closed-gate regression guard)", () => {
+    const r = defaultClassifyTicket(mkEvidence(), {
+      probePrBlock: probeReturning({
+        prNumber: 56,
+        state: "OPEN",
+        isDraft: true,
+        mergeStateStatus: "DRAFT",
+        failingChecks: [],
+        pendingChecks: [],
+        unresolvedBotThreads: [],
+        unresolvedHumanThreads: [],
+        hasChangesRequested: false,
+      }),
+    });
+    expect(r.decision).toBe("fix");
+    expect(r.details.brief).toContain("gh pr ready");
+  });
+
+  test("draft-origin resume does NOT apply while the PR is still a draft", () => {
+    const r = defaultClassifyTicket(mkDraftEvidence(PR_STUCK_IN_DRAFT_REASON), {
+      probePrBlock: probeReturning({
+        prNumber: 52,
+        isDraft: true,
+        mergeStateStatus: "DRAFT",
+        failingChecks: [],
+        pendingChecks: [],
+        unresolvedBotThreads: [],
+        unresolvedHumanThreads: [],
+        hasChangesRequested: false,
+      }),
+    });
+    // Still the promotion fix — the draft branch wins.
+    expect(r.details.brief).toContain("gh pr ready");
+  });
+
+  test("draft-origin resume does NOT apply when the now-ready PR still has blockers", () => {
+    const r = defaultClassifyTicket(mkDraftEvidence(PR_STUCK_IN_DRAFT_REASON), {
+      probePrBlock: probeReturning({
+        prNumber: 53,
+        isDraft: false,
+        mergeStateStatus: "BLOCKED",
+        failingChecks: [{ name: "quality", detailsUrl: null }],
+        pendingChecks: [],
+        unresolvedBotThreads: [],
+        unresolvedHumanThreads: [],
+        hasChangesRequested: false,
+      }),
+    });
+    // A real blocker is still LLM-actionable remediation, not a phase resume.
+    expect(r.details.brief).toContain("quality");
+  });
+
+  test("plain pr_not_merged + CLEAN keeps the direct-merge brief (no regression)", () => {
+    const r = defaultClassifyTicket(mkEvidence(), {
+      probePrBlock: nowReadyCleanProbe(54),
+    });
+    expect(r.decision).toBe("fix");
+    expect(r.details.brief).toContain("gh pr merge");
+  });
+
   test("BLOCKED with no actionable cause → escalate (awaiting required approval, not LLM-fixable)", () => {
     const r = defaultClassifyTicket(mkEvidence(), {
       probePrBlock: probeReturning({

--- a/plugins/dev/scripts/execution-core/recovery-reasoning.test.mjs
+++ b/plugins/dev/scripts/execution-core/recovery-reasoning.test.mjs
@@ -30,6 +30,7 @@ import {
   readEscalationDeferrals, // CTL-1568
   classifyPrNotMerged,
   PR_NOT_MERGED_REASON,
+  DRAFT_PROMOTE_FAILED_REASON,
   MONITOR_DEPLOY_EMPTY_SHA_PREFIX,
   isPrMergeUnconfirmedReason,
   defaultClearIntentCooldown,
@@ -2965,6 +2966,10 @@ describe("CTL-1680: monitor-deploy empty-SHA routes to PR-state probe", () => {
   // isPrMergeUnconfirmedReason predicate unit tests
   test("isPrMergeUnconfirmedReason: true for pr_not_merged", () => {
     expect(isPrMergeUnconfirmedReason(PR_NOT_MERGED_REASON)).toBe(true);
+  });
+
+  test("isPrMergeUnconfirmedReason: true for draft promotion failures", () => {
+    expect(isPrMergeUnconfirmedReason(DRAFT_PROMOTE_FAILED_REASON)).toBe(true);
   });
 
   test("isPrMergeUnconfirmedReason: true for empty-SHA prefixed reasons", () => {

--- a/plugins/dev/scripts/execution-core/recovery-reasoning.test.mjs
+++ b/plugins/dev/scripts/execution-core/recovery-reasoning.test.mjs
@@ -2522,6 +2522,41 @@ describe("classifyPrNotMerged (CTL-1496)", () => {
     expect(r.details.reason).not.toBe("Failure reason: pr_not_merged");
   });
 
+  test("draft PR → bounded-llm promotion fix", () => {
+    const r = defaultClassifyTicket(mkEvidence(), {
+      probePrBlock: probeReturning({
+        prNumber: 48,
+        isDraft: true,
+        mergeStateStatus: "DRAFT",
+        failingChecks: [],
+        pendingChecks: [],
+        unresolvedBotThreads: [],
+        unresolvedHumanThreads: [],
+        hasChangesRequested: false,
+      }),
+    });
+    expect(r.decision).toBe("fix");
+    expect(r.fix_class).toBe("bounded-llm");
+    expect(r.details.reason).toContain("DRAFT");
+    expect(r.details.brief).toContain("gh pr ready");
+  });
+
+  test("human CHANGES_REQUESTED takes precedence over draft promotion", () => {
+    const r = defaultClassifyTicket(mkEvidence(), {
+      probePrBlock: probeReturning({
+        prNumber: 49,
+        isDraft: true,
+        mergeStateStatus: "DRAFT",
+        failingChecks: [],
+        unresolvedBotThreads: [],
+        unresolvedHumanThreads: [],
+        hasChangesRequested: true,
+      }),
+    });
+    expect(r.decision).toBe("escalate");
+    expect(r.fix_class).toBe("human");
+  });
+
   test("no blockers / CLEAN → bounded-llm fix (finish the merge)", () => {
     const r = defaultClassifyTicket(mkEvidence(), {
       probePrBlock: probeReturning({

--- a/plugins/dev/scripts/execution-core/recovery-reasoning.test.mjs
+++ b/plugins/dev/scripts/execution-core/recovery-reasoning.test.mjs
@@ -31,6 +31,7 @@ import {
   classifyPrNotMerged,
   PR_NOT_MERGED_REASON,
   DRAFT_PROMOTE_FAILED_REASON,
+  PR_STUCK_IN_DRAFT_REASON,
   MONITOR_DEPLOY_EMPTY_SHA_PREFIX,
   isPrMergeUnconfirmedReason,
   defaultClearIntentCooldown,
@@ -2970,6 +2971,11 @@ describe("CTL-1680: monitor-deploy empty-SHA routes to PR-state probe", () => {
 
   test("isPrMergeUnconfirmedReason: true for draft promotion failures", () => {
     expect(isPrMergeUnconfirmedReason(DRAFT_PROMOTE_FAILED_REASON)).toBe(true);
+  });
+
+  test("isPrMergeUnconfirmedReason: true for phase-monitor-merge's pr_stuck_in_draft", () => {
+    expect(PR_STUCK_IN_DRAFT_REASON).toBe("pr_stuck_in_draft");
+    expect(isPrMergeUnconfirmedReason(PR_STUCK_IN_DRAFT_REASON)).toBe(true);
   });
 
   test("isPrMergeUnconfirmedReason: true for empty-SHA prefixed reasons", () => {

--- a/plugins/dev/scripts/lib/__tests__/draft-pr.test.sh
+++ b/plugins/dev/scripts/lib/__tests__/draft-pr.test.sh
@@ -179,7 +179,7 @@ STUB
 # install_gh_stub_promote <bin_dir> <log_file> [is_draft]
 # gh pr view returns JSON; gh pr ready succeeds.
 install_gh_stub_promote() {
-  local bin_dir="$1" log_file="$2" is_draft="${3:-true}"
+  local bin_dir="$1" log_file="$2" is_draft="${3:-true}" draft_after="${4:-false}" ready_rc="${5:-0}"
   mkdir -p "$bin_dir"
   cat > "${bin_dir}/gh" <<STUB
 #!/usr/bin/env bash
@@ -192,6 +192,14 @@ JSON
   exit 0
 fi
 if [[ "\$1" == "pr" && "\$2" == "ready" ]]; then
+  exit ${ready_rc}
+fi
+if [[ "\$1" == "repo" && "\$2" == "view" ]]; then
+  echo "test/repo"
+  exit 0
+fi
+if [[ "\$1" == "api" ]]; then
+  echo "${draft_after}"
   exit 0
 fi
 exit 0
@@ -258,7 +266,7 @@ echo "Suite 0: library file exists + zsh-safe"
 assert_file "$DRAFT_PR_LIB" "lib/draft-pr.sh exists"
 if [[ -f "$DRAFT_PR_LIB" ]]; then
   # Zsh-safe: sourcing under zsh gives access to all four functions.
-  ZSH_CHECK="$(zsh -c "source '${DRAFT_PR_LIB}' && type draft_pr_push && type draft_pr_ensure && type draft_pr_promote && type draft_pr_enabled" 2>&1)"
+  ZSH_CHECK="$(zsh -c "source '${DRAFT_PR_LIB}' && type draft_pr_push && type draft_pr_ensure && type draft_pr_promote && type draft_pr_promote_verify && type draft_pr_enabled" 2>&1)"
   if echo "$ZSH_CHECK" | grep -qE 'not found|error|Error'; then
     fail "lib is zsh-safe (type all functions) — got: $ZSH_CHECK"
   else
@@ -573,6 +581,23 @@ if [[ "$P3C_EXIT" != "0" ]]; then pass "3c: no-PR returns non-zero"
 else fail "3c: no-PR should return non-zero"; fi
 if grep -q "caller_survived" "${SCRATCH}/p3c.exit" 2>/dev/null; then pass "3c: caller survives no-PR"
 else fail "3c: caller should survive"; fi
+
+# ─── Suite 3v: draft_pr_promote_verify ───────────────────────────────────────
+echo "3v: verified promotion"
+for spec in "a true false 0 0" "b false false 0 0" "c true true 0 5" "d true true 1 5"; do
+  set -- $spec
+  label="$1"; before="$2"; after="$3"; ready_rc="$4"; expected="$5"
+  bin="${SCRATCH}/p3v${label}-bin"; log="${SCRATCH}/p3v${label}.log"
+  install_gh_stub_promote "$bin" "$log" "$before" "$after" "$ready_rc"
+  (
+    cd "$WORK"; PATH="${bin}:${PATH}"; source "$DRAFT_PR_LIB"; set +e
+    draft_pr_promote_verify >/dev/null 2>/dev/null
+    echo "$?" > "${SCRATCH}/p3v${label}.exit"
+  ) || true
+  assert_eq "$expected" "$(cat "${SCRATCH}/p3v${label}.exit")" "3v-${label}: verified promote rc"
+done
+assert_eq "1" "$(grep -c '^ready$' "${SCRATCH}/p3va.log" || true)" "3v-a: promotes exactly once"
+assert_eq "0" "$(grep -c '^ready$' "${SCRATCH}/p3vb.log" || true)" "3v-b: already-ready is idempotent"
 
 # ─── Suite 4: draft_pr_enabled ────────────────────────────────────────────────
 echo ""

--- a/plugins/dev/scripts/lib/draft-pr.sh
+++ b/plugins/dev/scripts/lib/draft-pr.sh
@@ -332,7 +332,7 @@ draft_pr_promote() {
 draft_pr_promote_verify() {
   command -v gh >/dev/null 2>&1 || { _draft_pr_warn "gh unavailable"; return 1; }
   local pr_json num repo draft_after
-  pr_json="$(gh pr view --json number,isDraft 2>/dev/null || true)"
+  pr_json="$(gh pr view --json number 2>/dev/null || true)"
   [[ -z "$pr_json" ]] && { _draft_pr_warn "no PR found for current branch"; return 1; }
   num="$(printf '%s' "$pr_json" | jq -r '.number // empty' 2>/dev/null || true)"
   [[ -z "$num" ]] && { _draft_pr_warn "no PR found for current branch"; return 1; }

--- a/plugins/dev/scripts/lib/draft-pr.sh
+++ b/plugins/dev/scripts/lib/draft-pr.sh
@@ -13,6 +13,7 @@
 #                                   .github/workflows/ file (CTL-1119)
 #   draft_pr_ensure BASE TICKET   — ensure a draft PR exists; echoes NUM<TAB>URL<TAB>ISDRAFT
 #   draft_pr_promote              — promote current branch's PR from draft to ready
+#   draft_pr_promote_verify       — promote and prove REST .draft == false (rc=5 otherwise)
 #   draft_pr_enabled              — read .catalyst/config.json knob (default true)
 #
 # Reserved return codes:
@@ -22,6 +23,7 @@
 #   4 — draft_pr_push / draft_pr_push_verify: the pre-push safety gate refused the
 #       push (placeholder-identity commit or anomalous tree-wide deletion). Callers
 #       translate this into a push_safety_gate_blocked escalation.
+#   5 — draft_pr_promote_verify: PR is still draft or promotion cannot be verified.
 
 _draft_pr_warn() {
   printf 'draft-pr: %s\n' "$*" >&2
@@ -320,6 +322,27 @@ draft_pr_promote() {
   fi
   if [[ "$is_draft" == "true" ]]; then
     gh pr ready "$num" 2>/dev/null || { _draft_pr_warn "gh pr ready failed (continuing)"; return 1; }
+  fi
+  return 0
+}
+
+# draft_pr_promote_verify — promote AND PROVE the PR left draft. Fail-closed:
+# rc=0 only when a REST re-read confirms .draft=false; rc=5 means still draft
+# or unverifiable; rc=1 means no PR / gh unavailable.
+draft_pr_promote_verify() {
+  command -v gh >/dev/null 2>&1 || { _draft_pr_warn "gh unavailable"; return 1; }
+  local pr_json num repo draft_after
+  pr_json="$(gh pr view --json number,isDraft 2>/dev/null || true)"
+  [[ -z "$pr_json" ]] && { _draft_pr_warn "no PR found for current branch"; return 1; }
+  num="$(printf '%s' "$pr_json" | jq -r '.number // empty' 2>/dev/null || true)"
+  [[ -z "$num" ]] && { _draft_pr_warn "no PR found for current branch"; return 1; }
+  draft_pr_promote || _draft_pr_warn "promote attempt failed; verifying anyway"
+  repo="$(gh repo view --json nameWithOwner --jq .nameWithOwner 2>/dev/null || true)"
+  [[ -z "$repo" ]] && { _draft_pr_warn "cannot resolve repo for verify"; return 5; }
+  draft_after="$(gh api "repos/${repo}/pulls/${num}" --jq '.draft' 2>/dev/null || true)"
+  if [[ "$draft_after" != "false" ]]; then
+    _draft_pr_warn "PR #${num} still draft after promote (rest=.draft=${draft_after:-<unreadable>})"
+    return 5
   fi
   return 0
 }

--- a/plugins/dev/scripts/orch-monitor/__tests__/board-orphan-pr.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/board-orphan-pr.test.ts
@@ -47,6 +47,12 @@ describe("synthesizeOrphanTickets", () => {
     expect(cards[0].prStuckReason).toBeTruthy();
   });
 
+  it("draft orphan always has an actionable reason regardless of merge state", () => {
+    const cards = synthesizeOrphanTickets(notified({ isDraft: true, mergeStateStatus: "CLEAN" }), 600_000);
+    expect(cards[0].humanQuestion).toContain("still a draft");
+    expect(cards[0].prStuckReason).toContain("promote it or close it");
+  });
+
   it("does NOT emit a card for an entry that has firstSeenAt but no notifiedAt (still in window)", () => {
     const state = notified();
     delete (state["org/repo#2061"] as Record<string, unknown>).notifiedAt;

--- a/plugins/dev/scripts/orch-monitor/lib/board-data.d.mts
+++ b/plugins/dev/scripts/orch-monitor/lib/board-data.d.mts
@@ -378,7 +378,8 @@ export function isPrStuck(
 /** CTL-1158: operator CTA string for a stuck PR; null when not a blocker state. */
 export function prStuckReason(
   mergeStateStatus: string | null | undefined,
-  prNumber: number | null | undefined
+  prNumber: number | null | undefined,
+  isDraft?: boolean
 ): string | null;
 
 /** CTL-928: a single ticket's lane on the queue board (live | between-phases |

--- a/plugins/dev/scripts/orch-monitor/lib/board-data.mjs
+++ b/plugins/dev/scripts/orch-monitor/lib/board-data.mjs
@@ -1244,8 +1244,11 @@ export function isPrStuck(prStatus, prPhaseStartedAt, now) {
   return now - startedMs >= PR_STUCK_DEBOUNCE_MS;
 }
 
-export function prStuckReason(mergeStateStatus, prNumber) {
+export function prStuckReason(mergeStateStatus, prNumber, isDraft = false) {
   const n = prNumber ? `#${prNumber}` : "the PR";
+  if (isDraft) {
+    return `PR ${n} is still a draft and no worker is tracking it — promote it or close it`;
+  }
   switch (mergeStateStatus) {
     case "DIRTY":
       return `PR ${n} has a merge conflict the pipeline couldn't auto-resolve — decide which change wins`;
@@ -1380,7 +1383,7 @@ export function synthesizeOrphanTickets(orphanState, now) {
   return Object.values(orphanState)
     .filter((e) => e && e.notifiedAt)
     .map((e) => {
-      const reason = prStuckReason(e.mergeStateStatus, e.number);
+      const reason = prStuckReason(e.mergeStateStatus, e.number, e.isDraft === true);
       return {
         id: `orphan:${e.repo}#${e.number}`,
         title: e.title || `Orphan PR #${e.number}`,

--- a/plugins/dev/skills/phase-monitor-merge/SKILL.md
+++ b/plugins/dev/skills/phase-monitor-merge/SKILL.md
@@ -154,6 +154,30 @@ this skill copies the body verbatim, substituting `phase-monitor-merge` framing 
    the wait (defeats the assistant `end_turn` rendering bleed described in [[monitor-events]] §
    Narration). Shape: `wake: <event.name> #<PR_NUMBER> — <action being taken>`.
 
+Before the `clean` merge handler, handle a draft exactly once per phase run:
+
+```bash
+if [[ "$MERGEABLE_STATE" == "draft" ]]; then
+  if [[ -n "${DRAFT_PROMOTE_ATTEMPTED:-}" ]]; then
+    echo "phase-monitor-merge: PR #${PR_NUMBER} still draft after one promote attempt" >&2
+    "${PLUGIN_ROOT}/scripts/phase-agent-emit-complete" \
+      --phase "$PHASE" --ticket "$TICKET" --status failed \
+      --reason "pr_stuck_in_draft"
+    exit 1
+  fi
+  DRAFT_PROMOTE_ATTEMPTED=1
+  source "${PLUGIN_ROOT}/scripts/lib/draft-pr.sh"
+  if ! draft_pr_promote_verify; then
+    "${PLUGIN_ROOT}/scripts/phase-agent-emit-complete" \
+      --phase "$PHASE" --ticket "$TICKET" --status failed \
+      --reason "pr_stuck_in_draft"
+    exit 1
+  fi
+  echo "wake: pr#${PR_NUMBER} — PR was draft; promoted to ready"
+  continue
+fi
+```
+
 ## Merge
 
 Once `mergeable_state == "clean"` (and the PR isn't already merged):
@@ -677,3 +701,4 @@ Plan architectural commitment #3. The listen loop logic lives in [[oneshot]] SKI
 exercised every day. Lifting it into a phase-agent skill without duplicating the body keeps both
 paths in lockstep — when the legacy oneshot path retires (plan §Initiative 1 Phase 6), this skill
 becomes the sole owner.
+   | draft            | attempt `draft_pr_promote_verify` once; re-read on success, otherwise fail with `pr_stuck_in_draft`                                    |

--- a/plugins/dev/skills/phase-monitor-merge/SKILL.md
+++ b/plugins/dev/skills/phase-monitor-merge/SKILL.md
@@ -128,7 +128,8 @@ this skill copies the body verbatim, substituting `phase-monitor-merge` framing 
    wait can block far past the window (600s broker / 180+7200s raw) and delay an already-earned merge.
 
 2. **REST is authoritative.** Every loop iteration calls `gh api repos/${REPO}/pulls/${PR_NUMBER}`
-   and reads `.merged` + `.mergeable_state`. Never use `gh pr view --json mergeable` (GraphQL is
+   and reads `.merged` + `.draft` + `.mergeable_state` into `MERGED_OK`, `PR_IS_DRAFT`, and
+   `MERGEABLE_STATE`. Never use `gh pr view --json mergeable` (GraphQL is
    eventually consistent for the merge-state fields and frequently lies).
 
 3. **State machine.** Branch on `mergeable_state`:
@@ -139,6 +140,7 @@ this skill copies the body verbatim, substituting `phase-monitor-merge` framing 
    | blocked          | resolve via `/catalyst-dev:review-comments` (bot threads) or run an inline CI fix-up commit (up to 3 attempts); 4th attempt → `stalled` |
    | behind           | `git fetch && git rebase origin/<base> && git -c core.hooksPath=/dev/null push --force-with-lease`                                      |
    | dirty            | merge conflicts — emit `failed` with reason "merge conflicts (DIRTY)"                                                                   |
+   | draft            | when REST `.draft` is true, attempt `draft_pr_promote_verify` once; re-enter the event wait on success, otherwise fail                  |
    | unknown/unstable | continue waiting for the next event                                                                                                     |
 
 4. **Human reviewer changes-requested.** After every wake, query `gh pr view --json reviews` for the
@@ -157,15 +159,16 @@ this skill copies the body verbatim, substituting `phase-monitor-merge` framing 
 Before the `clean` merge handler, handle a draft exactly once per phase run:
 
 ```bash
-if [[ "$MERGEABLE_STATE" == "draft" ]]; then
-  if [[ -n "${DRAFT_PROMOTE_ATTEMPTED:-}" ]]; then
+if [[ "$PR_IS_DRAFT" == "true" ]]; then
+  DRAFT_PROMOTE_MARKER="${ORCH_DIR}/workers/${TICKET}/.draft-promote-${PHASE}"
+  if [[ -e "$DRAFT_PROMOTE_MARKER" ]]; then
     echo "phase-monitor-merge: PR #${PR_NUMBER} still draft after one promote attempt" >&2
     "${PLUGIN_ROOT}/scripts/phase-agent-emit-complete" \
       --phase "$PHASE" --ticket "$TICKET" --status failed \
       --reason "pr_stuck_in_draft"
     exit 1
   fi
-  DRAFT_PROMOTE_ATTEMPTED=1
+  : > "$DRAFT_PROMOTE_MARKER"
   source "${PLUGIN_ROOT}/scripts/lib/draft-pr.sh"
   if ! draft_pr_promote_verify; then
     "${PLUGIN_ROOT}/scripts/phase-agent-emit-complete" \
@@ -174,9 +177,11 @@ if [[ "$MERGEABLE_STATE" == "draft" ]]; then
     exit 1
   fi
   echo "wake: pr#${PR_NUMBER} — PR was draft; promoted to ready"
-  continue
 fi
 ```
+
+After a successful promotion, re-enter step 1's event wait. Do not evaluate the
+`clean` handler using the REST payload captured before promotion.
 
 ## Merge
 
@@ -701,4 +706,3 @@ Plan architectural commitment #3. The listen loop logic lives in [[oneshot]] SKI
 exercised every day. Lifting it into a phase-agent skill without duplicating the body keeps both
 paths in lockstep — when the legacy oneshot path retires (plan §Initiative 1 Phase 6), this skill
 becomes the sole owner.
-   | draft            | attempt `draft_pr_promote_verify` once; re-read on success, otherwise fail with `pr_stuck_in_draft`                                    |

--- a/plugins/dev/skills/phase-monitor-merge/SKILL.md
+++ b/plugins/dev/skills/phase-monitor-merge/SKILL.md
@@ -159,8 +159,11 @@ this skill copies the body verbatim, substituting `phase-monitor-merge` framing 
 Before the `clean` merge handler, handle a draft exactly once per phase run:
 
 ```bash
-if [[ "$PR_IS_DRAFT" == "true" ]]; then
-  DRAFT_PROMOTE_MARKER="${ORCH_DIR}/workers/${TICKET}/.draft-promote-${PHASE}"
+PR_IS_DRAFT="$(gh api "repos/${REPO}/pulls/${PR_NUMBER}" --jq '.draft' 2>/dev/null || true)"
+if [[ "${PR_IS_DRAFT:-}" == "true" ]]; then
+  DRAFT_PROMOTE_RUN_ID="$(jq -r '.bg_job_id // .bgJobId // empty' "$SIGNAL_FILE" 2>/dev/null || true)"
+  : "${DRAFT_PROMOTE_RUN_ID:=${CATALYST_SESSION_ID:-${CATALYST_GENERATION:-run}}}"
+  DRAFT_PROMOTE_MARKER="${ORCH_DIR}/workers/${TICKET}/.draft-promote-${PHASE}-${DRAFT_PROMOTE_RUN_ID}"
   if [[ -e "$DRAFT_PROMOTE_MARKER" ]]; then
     echo "phase-monitor-merge: PR #${PR_NUMBER} still draft after one promote attempt" >&2
     "${PLUGIN_ROOT}/scripts/phase-agent-emit-complete" \

--- a/plugins/dev/skills/phase-pr/SKILL.md
+++ b/plugins/dev/skills/phase-pr/SKILL.md
@@ -248,10 +248,18 @@ if [[ -n "$EXISTING_PR_NUMBER" ]]; then
     exit 1
   fi
   if [[ "$EXISTING_PR_IS_DRAFT" == "true" ]]; then
-    if type draft_pr_promote >/dev/null 2>&1; then
-      draft_pr_promote || gh pr ready "$EXISTING_PR_NUMBER" 2>/dev/null || true
+    PROMOTE_RC=0
+    if type draft_pr_promote_verify >/dev/null 2>&1; then
+      draft_pr_promote_verify || PROMOTE_RC=$?
     else
-      gh pr ready "$EXISTING_PR_NUMBER" 2>/dev/null || true
+      gh pr ready "$EXISTING_PR_NUMBER" 2>/dev/null || PROMOTE_RC=5
+    fi
+    if [[ "$PROMOTE_RC" -ne 0 ]]; then
+      echo "phase-pr: PR #${EXISTING_PR_NUMBER} still draft after promote (rc=${PROMOTE_RC})" >&2
+      "${PLUGIN_ROOT}/scripts/phase-agent-emit-complete" \
+        --phase "$PHASE" --ticket "$TICKET" --status failed \
+        --reason "draft_promote_failed"
+      exit 1
     fi
   fi
   # Enrich the PR body now that the draft is ready (deferred from phase-implement to keep


### PR DESCRIPTION
<!-- Auto-generated: 2026-08-11T16:35:00Z -->
<!-- Last updated: 2026-08-11T16:35:00Z -->
<!-- PR: #3192 -->
<!-- Previous commits: d762bf53b35a215ff40d0487aa0c8cdb184c32de,98fb9e042489e9866454d061441d011d63ef79c9,0203009b0669b3817259e763543126f9da2d4bca,bc15955a13490e7650c300fa88aa474dbe6cab31,95cdf96d95c331f07479f618fbb3c16e584737ea,6dffb925e68725b187e34ddd417a3bfee533bbb5,69f11000bbf22bf3c41e4a748cbef97dddb3c0c8 -->

## Summary

Promotes completed implementation draft PRs to ready-for-review with fail-closed verification, and extends recovery handling so draft-related failures can be detected and remediated instead of leaving the merge pipeline stuck.

## Changes Made

- Verify draft promotion through the GitHub REST API and fail the PR phase when the draft flag remains set or cannot be confirmed.
- Teach merge monitoring to make one verified promotion attempt before resuming its event-driven wait.
- Route draft-promotion failures through recovery reasoning as bounded remediation work.
- Surface stable orphan draft PRs in the recovery sweep and operator board while avoiding false orphan alerts for actively implementing tickets.
- Add focused shell, execution-core, and board tests for promotion, recovery classification, ownership, and draft visibility.

## How to Verify It

- [x] TypeScript typecheck passes for orch-monitor.
- [x] Targeted execution-core suites pass (236/236 after review remediation).
- [x] Draft PR shell suite passes (91/91).
- [x] Phase monitor merge guard suite passes (26/26).
- [x] Board orphan PR suite passes (9/9).
- [x] ESLint reports no errors.
- [x] Reward-hacking and security checks pass.

The broader execution-core and orch-monitor test runs retain only failures reproduced on `origin/main`; none occur in changed modules.

## Reviewer Notes

The review phase remediated both high-severity findings in commit `69f11000bbf22bf3c41e4a748cbef97dddb3c0c8`. Medium- and low-severity follow-up work is tracked separately.

## Related Issues/PRs

- Fixes https://linear.app/coalesce/issue/CAT-15

## Changelog Entry

Fixed the orchestration pipeline so completed draft PRs are promoted to ready for review and draft-related stalls enter recovery handling.
