### PR TITLE
fix(dev): unbreak main — stop ps truncating the forwarder identity check

### DIFF
--- a/plugins/dev/scripts/catalyst-monitor.sh
+++ b/plugins/dev/scripts/catalyst-monitor.sh
@@ -815,7 +815,15 @@ acquire_forward_lock() {
 # rather than killing something we cannot identify.
 _forward_pid_is_ours() {
   local pid="$1" cmd
-  cmd="$(ps -o command= -p "$pid" 2>/dev/null)" || return 1
+  # -ww: NEVER let ps truncate. Linux procps wraps at 80 columns when stdout is
+  # not a tty, and the pre-exec command line here is
+  # `bash <tmp>/bin/bun run <repo>/plugins/dev/scripts/otel-forward/index.ts` —
+  # ~114 chars in CI, so the "otel-forward" marker this match depends on is cut
+  # off entirely. The identity check then answered "not ours", read_forward_pid
+  # deleted the pid file as stale, and forward-restart skipped the stop and
+  # started a SECOND forwarder (CI: "Forwarder not running" with pid 2413 still
+  # in state S). macOS ps does not truncate, so this reproduced only on Linux.
+  cmd="$(ps -ww -o command= -p "$pid" 2>/dev/null)" || return 1
   [[ -n "$cmd" ]] || return 1
   [[ "$cmd" == *"otel-forward"* ]]
 }
@@ -1002,7 +1010,15 @@ WATCHDOG_SCRIPT="${SCRIPT_DIR}/execution-core/daemon-watchdog-run.mjs"
 
 _watchdog_pid_is_ours() {
   local pid="$1" cmd
-  cmd="$(ps -o command= -p "$pid" 2>/dev/null)" || return 1
+  # -ww: NEVER let ps truncate. Linux procps wraps at 80 columns when stdout is
+  # not a tty, and the pre-exec command line here is
+  # `bash <tmp>/bin/bun run <repo>/plugins/dev/scripts/otel-forward/index.ts` —
+  # ~114 chars in CI, so the "otel-forward" marker this match depends on is cut
+  # off entirely. The identity check then answered "not ours", read_forward_pid
+  # deleted the pid file as stale, and forward-restart skipped the stop and
+  # started a SECOND forwarder (CI: "Forwarder not running" with pid 2413 still
+  # in state S). macOS ps does not truncate, so this reproduced only on Linux.
+  cmd="$(ps -ww -o command= -p "$pid" 2>/dev/null)" || return 1
   [[ -n "$cmd" ]] || return 1
   [[ "$cmd" == *"daemon-watchdog-run"* ]]
 }

--- a/plugins/dev/scripts/execution-core/__tests__/forward-restart.test.sh
+++ b/plugins/dev/scripts/execution-core/__tests__/forward-restart.test.sh
@@ -196,5 +196,39 @@ if ! _forward_pid_gone "$ZPID"; then
   echo "FAIL: _forward_pid_gone reported reaped pid $ZPID as still running"; exit 1
 fi
 
+# --- Test 6: the identity check survives a TRUNCATING ps ---
+#
+# The regression that made this suite red on CI while passing on every dev machine.
+# Linux procps wraps `ps -o command=` at 80 columns when stdout is not a tty. The
+# forwarder's pre-exec command line is
+#   bash <tmp>/bin/bun run <repo>/plugins/dev/scripts/otel-forward/index.ts
+# (~114 chars on the runner), so the "otel-forward" marker _forward_pid_is_ours
+# matches on was cut off. The check answered "not ours", read_forward_pid deleted
+# the pid file as stale, and forward-restart skipped the stop entirely and started
+# a SECOND forwarder — observed as `restart output: Forwarder not running` with the
+# old pid still in state S. macOS ps does not truncate, so this could not reproduce
+# locally; the stub below makes it deterministic on ANY host by truncating exactly
+# as procps does unless -ww is passed.
+PSW="$TMP/pswide"; mkdir -p "$PSW"
+cat > "$PSW/ps" <<'SH'
+#!/usr/bin/env bash
+# Emits a realistically LONG forwarder command line, truncated to 80 columns
+# unless -ww is given — i.e. Linux procps behaviour, deterministically.
+wide=0
+for a in "$@"; do case "$a" in -ww|-w) wide=1 ;; esac; done
+line="bash /tmp/tmp.aBcDeFgHiJ/bin/bun run /home/runner/work/catalyst/catalyst/plugins/dev/scripts/otel-forward/index.ts"
+if [[ "$wide" == "1" ]]; then printf '%s\n' "$line"; else printf '%s\n' "${line:0:80}"; fi
+SH
+chmod +x "$PSW/ps"
+
+if PATH="$PSW:$PATH" _forward_pid_is_ours 4242; then
+  echo "PASS: identity check survives a truncating ps (production passes -ww)"
+else
+  echo "FAIL: identity check broke under a truncating ps — forward-restart would skip the stop"
+  echo "  truncated view : [$(PATH="$PSW:$PATH" ps -o command= -p 4242)]"
+  echo "  wide view      : [$(PATH="$PSW:$PATH" ps -ww -o command= -p 4242)]"
+  exit 1
+fi
+
 echo "PASS: forward-restart cold-start, hot-swap, and idempotent back-to-back restarts + wiring"
 echo "PASS: defunct pid reads as gone (kill -0 cannot see it); live and reaped pids read correctly"


### PR DESCRIPTION
## Problem

`main` is red on `forward-restart.test.sh` (`FAIL: old forwarder pid ... still alive after restart`) since #3172 merged.

## Root cause — not the zombie fix

The diagnostics #3172 added identify it precisely:

```
restart output : Forwarder not running
kill -0        : succeeds
ps state       : [S]          ← genuinely sleeping, not defunct
ps command     : [bun run otel-forward/index.ts 300]
_forward_pid_gone: not-gone   ← correct; it IS alive
```

The stop path **never ran**. Linux procps wraps `ps -o command=` at 80 columns when stdout is not a tty. The forwarder's **pre-exec** command line is

```
bash <tmp>/bin/bun run <repo>/plugins/dev/scripts/otel-forward/index.ts
```

~114 chars on the runner, so the `otel-forward` marker `_forward_pid_is_ours` matches on is **cut off**. The check answers "not ours" → `read_forward_pid` deletes the pid file as stale → `forward-restart` skips the stop and starts a *second* forwarder.

macOS `ps` does not truncate, which is why it passed on every dev machine and only bit CI — and why it was intermittent: it depends on whether the check lands before or after the shim's `exec -a` shortens argv.

## Fix

Pass `-ww` so `ps` never truncates. Applied to **both** identity checks in the file — `_watchdog_pid_is_ours` matches `daemon-watchdog-run` in an equally long path and had the identical latent bug.

## Test

A `ps` stub that truncates at 80 columns unless `-ww` is passed — procps behaviour made deterministic on any host. Without that, the case is vacuous on macOS, which is exactly how this reached main.

Verified RED without `-ww` and GREEN with it. `daemon-watchdog-supervision` 22/22, `catalyst-monitor-bootstrap` 17/17.

🤖 Generated with [Claude Code](https://claude.com/claude-code)