### PR TITLE
fix(dev): CAT-47 commit the audit-comment dedup latch only on confirmed delivery

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -443,11 +443,14 @@ The behavior is gated by `CATALYST_RECOVERY_PASS` (off by default); shadow mode 
 
 ### Orphan-stale merged-PR reconciliation (CAT-47)
 
-Pass 0r and Pass 0u share the same production act-seam dependencies. `runTick` constructs the
-PR-state resolver, background-job liveness probe, stall clearer, and status writer once; Pass 0u
-uses them to build its act registry, while Pass 0r receives both that registry and the raw bundle
-for capability-checked fallback construction. An injected partial registry therefore falls back to
-real dependencies instead of either using inert defaults or failing as unavailable.
+Pass 0r and Pass 0u act on the same production act-seam dependencies. `runTick` builds a
+`unstuckSeamDeps` bundle — PR-state resolver, background-job liveness probe, stall clearer, status
+writer — and threads it to Pass 0r, which receives both that bundle **and** Pass 0u's prebuilt act
+registry. `defaultInvokeSeam` then selects by capability: an absent or partial registry falls back
+to a registry rebuilt from the bundle's real dependencies instead of either using inert defaults or
+failing as unavailable. Pass 0u still constructs its own equivalent closures inline at its
+`buildUnstuckActSeams` call site, so the two constructions are equivalent by inspection but not yet
+literally shared — collapsing them onto the one bundle is deferred follow-up.
 
 The recovery candidate contract is `{ ticket, phase, signal }`. `phase` names the exact
 `.unstuck-orphan-merge-<phase>.applied` idempotency marker, and `signal.bg_job_id` feeds the

--- a/plugins/dev/scripts/execution-core/recovery-orphan-stale-e2e.test.mjs
+++ b/plugins/dev/scripts/execution-core/recovery-orphan-stale-e2e.test.mjs
@@ -160,4 +160,38 @@ describe("orphan-stale recovery end to end (CAT-47)", () => {
     reasoningRecoveryPass([item], options);
     expect(comments).toBe(2);
   });
+
+  // defaultPostComment fails CLOSED without throwing ({ok:false} on a non-zero
+  // linear-comment-post.sh exit), so the throw-based test above does not cover
+  // the production failure shape. Committing the hash there would suppress the
+  // audit comment permanently on a Linear outage.
+  test("a non-throwing {ok:false} post does not commit the dedup hash", () => {
+    const root = fresh();
+    let comments = 0;
+    const options = {
+      mode: "enforce", orchDir: root, shouldSkipItem: () => false,
+      classifyTicket: () => ({ decision: "fix", fix_class: "orphan_stale", details: { seam_id: "orphan-reconcile", reason: "stale" } }),
+      invokeSeam: () => { throw new Error("same failure"); }, recordIntent: () => {}, emitEvent: () => {}, log: () => {}, nowMs: () => 1000,
+      postComment: () => { comments += 1; return { ok: false, via: "app-actor", status: 1 }; },
+    };
+    const item = { ticket: "CAT-47", phase: "monitor-merge", evidence: { signal: {} } };
+    reasoningRecoveryPass([item], options);
+    reasoningRecoveryPass([item], options);
+    expect(comments).toBe(2);
+  });
+
+  test("a delivered {ok:true} post commits the hash and suppresses the duplicate", () => {
+    const root = fresh();
+    let comments = 0;
+    const options = {
+      mode: "enforce", orchDir: root, shouldSkipItem: () => false,
+      classifyTicket: () => ({ decision: "fix", fix_class: "orphan_stale", details: { seam_id: "orphan-reconcile", reason: "stale" } }),
+      invokeSeam: () => { throw new Error("same failure"); }, recordIntent: () => {}, emitEvent: () => {}, log: () => {}, nowMs: () => 1000,
+      postComment: () => { comments += 1; return { ok: true, via: "app-actor" }; },
+    };
+    const item = { ticket: "CAT-47", phase: "monitor-merge", evidence: { signal: {} } };
+    reasoningRecoveryPass([item], options);
+    reasoningRecoveryPass([item], options);
+    expect(comments).toBe(1);
+  });
 });

--- a/plugins/dev/scripts/execution-core/recovery-reasoning.mjs
+++ b/plugins/dev/scripts/execution-core/recovery-reasoning.mjs
@@ -455,12 +455,38 @@ export function reasoningRecoveryPass(items, opts = {}) {
         const fixComment = formatFixComment(item.ticket, fixOutcome, classification);
         const commentHash = fixCommentHashFn(fixComment);
         if (shouldPostFixCommentFn(orchDir, item.ticket, fix_class, commentHash, nowMs())) {
+          // defaultPostComment fails CLOSED WITHOUT THROWING — a non-zero
+          // linear-comment-post.sh exit returns {ok:false}. Committing the dedup
+          // hash on that path would suppress this audit comment forever on a
+          // Linear outage, so only an explicitly non-failing result counts as
+          // delivery. An injected seam that returns nothing is treated as
+          // delivered (for those, a throw is the failure signal).
+          let delivered = false;
           try {
-            postComment(item.ticket, fixComment, { mode: "enforce" });
-            commitFixCommentHashFn(orchDir, item.ticket, fix_class, commentHash, nowMs());
-            actionLog.push("posted fix audit comment");
+            const posted = postComment(item.ticket, fixComment, { mode: "enforce" });
+            delivered = !(posted && posted.ok === false);
+            if (!delivered) {
+              log(
+                `recovery-reasoning: ${item.ticket} comment post reported failure; ` +
+                  `dedup hash not committed (comment stays eligible for retry)`,
+              );
+            }
           } catch (err) {
             log(`recovery-reasoning: ${item.ticket} comment post failed: ${err.message}`);
+          }
+          if (delivered) {
+            // Isolated from the post above: a failure HERE means the comment WAS
+            // delivered but the latch did not land, which must be logged as a
+            // latch-write failure rather than misattributed to the post.
+            try {
+              commitFixCommentHashFn(orchDir, item.ticket, fix_class, commentHash, nowMs());
+            } catch (err) {
+              log(
+                `recovery-reasoning: ${item.ticket} fix-comment dedup latch write failed: ` +
+                  `${err.message}`,
+              );
+            }
+            actionLog.push("posted fix audit comment");
           }
         } else {
           actionLog.push("suppressed duplicate fix audit comment");


### PR DESCRIPTION
## Summary

PR #3169 (CAT-47) merged without the phase-review remediation commit that fixed its own
HIGH-severity finding. This lands that commit against current `main`.

The gap surfaced during CAT-47's teardown open-PR/Done judgment: `main` today has 8 tests in
`recovery-orphan-stale-e2e.test.mjs` and no delivery gate, while the reviewed remediation
(`68f65b6e`, authored 2026-08-08) has 10 and the gate. It was never pushed to the branch that
became #3169.

## The bug

`reasoningRecoveryPass` committed the audit-comment dedup latch (`commitFixCommentHashFn`) on **any
non-throwing** `postComment` return. But `defaultPostComment` fails **closed without throwing** — a
non-zero `linear-comment-post.sh` exit returns `{ok: false}`, and the scheduler does not override
it. A Linear outage or auth failure therefore committed the hash and suppressed that audit comment
**permanently**.

This directly contradicts the contract `docs/architecture.md` already states on `main` (line 433):

> Audit-comment hashes are committed only after successful delivery, so an outage leaves the comment
> eligible for retry while delivered duplicate content is suppressed.

The branch's one delivery-failure test used a **throwing** stub, so the production failure shape was
uncovered.

## Changes

- `recovery-reasoning.mjs` — only an explicitly non-failing result counts as delivery. A seam that
  returns nothing is still treated as delivered (for those, a throw is the failure signal), so
  injected test seams keep working.
- Isolated the latch write from the post: a failure *there* means the comment **was** delivered but
  the latch did not land, and is now logged as a latch-write failure instead of being misattributed
  to the post.
- Two pinning tests: a non-throwing `{ok:false}` post re-posts next tick; an `{ok:true}` post
  commits the hash and suppresses the duplicate.
- `docs/architecture.md` — corrected the CAT-47 section, which claimed Pass 0u builds its registry
  from the shared `unstuckSeamDeps` bundle. It does not: Pass 0u still constructs its own equivalent
  closures inline; the bundle serves Pass 0r's capability-checked fallback only.

## Verification

```
$ bun test recovery-orphan-stale-e2e.test.mjs recovery-fix-backoff.test.mjs \
           unstuck-act-seams.test.mjs unstuck-orphan-merge.test.mjs
 69 pass, 0 fail — 137 expect() calls, 4 files
```

Non-vacuity checked: reverting only `recovery-reasoning.mjs` to `origin/main` makes
`a non-throwing {ok:false} post does not commit the dedup hash` fail (`Expected: 2, Received: 1`);
restoring it turns it green.

Refs: CAT-47
