### PR TITLE
fix(dev): bound board-health delegate-lands grace

### DIFF
--- a/plugins/dev/scripts/execution-core/board-health.mjs
+++ b/plugins/dev/scripts/execution-core/board-health.mjs
@@ -2085,6 +2085,13 @@ export function boardHealthPass({
   // dropped by the destructure, which would pin checkStalledPr to the empty-Map
   // default and make `nudge-stalled-pr` unreachable even with the sweep enabled.
   getStalledPrState,
+  // CTL-1744: delegate-lands claim timestamps. Same forwarding contract as
+  // getStalledPrState above — and the same trap: the scheduler binds this at the
+  // daemon call site, but an undeclared property is silently dropped here, which
+  // would pin checkDispatchLiveness to assembleBoardState's empty-Map default and
+  // make the grace window unreachable in production while every direct-to-
+  // assembleBoardState unit test still passed. Declared AND forwarded below.
+  getDelegateClaims,
   getGithubQuota,
   githubQuotaMode,
   getPeerProductivity,
@@ -2117,6 +2124,7 @@ export function boardHealthPass({
     getDeferredBoardHealthTickets, // CTL-1432 (B2). CTL-1552: sanctionedNeedsHuman removed.
     getStrandedEvidence, // CTL-1644: per-ticket evidence seam (empty-Map default if unbound)
     getStalledPrState, // CTL-1608: stalled-PR stamp seam (empty-Map default if unbound)
+    getDelegateClaims, // CTL-1744: delegate-lands claim seam (empty-Map default if unbound)
     getGithubQuota,
     githubQuotaMode,
     getPeerProductivity,

--- a/plugins/dev/scripts/execution-core/board-health.mjs
+++ b/plugins/dev/scripts/execution-core/board-health.mjs
@@ -33,7 +33,7 @@
 // kill-switch; enforce (CTL-1300) dispatches ONE holistic recovery-pass delegate
 // per proceeding scan, anchored + carrying the whole-board context — operator-gated.
 
-import { HEARTBEAT_GRACE_MS, isThrottled } from "./config.mjs";
+import { HEARTBEAT_GRACE_MS, isThrottled, RECONCILE_INTERVAL_MS } from "./config.mjs";
 import { defaultEmitEvent } from "./recovery-reasoning.mjs"; // → buildRecoveryEnvelope (CTL-1291 promotes the numbers)
 import { evaluateQuotaHeadroom, GITHUB_QUOTA_DEFAULTS } from "./github-quota.mjs";
 
@@ -80,6 +80,20 @@ const DEFAULT_THRESHOLDS = {
   stalledPrNoPushMs: Number(process.env.CATALYST_BH_STALLED_PR_NOPUSH_MS) || 5 * 24 * 3_600_000,
   githubCoreRemainingPct: GITHUB_QUOTA_DEFAULTS.coreRemainingPct,
   githubQuotaStaleMs: GITHUB_QUOTA_DEFAULTS.stalenessMs,
+  // CTL-1744: the delegate-lands grace window. The CTL-1174 triage gate
+  // (monitor.mjs dispatchTriage) is deliberately TWO-PASS: pass 1 sees no
+  // delegate, CLAIMS the ticket by delegating it to the orchestrator app-actor,
+  // and returns false (holding this tick); pass 2 dispatches triage — but only
+  // on the next sweepMissingTriage, which runs on the RECONCILE timer. So every
+  // freshly-claimed ticket is eligible-but-undispatched for up to one reconcile
+  // interval BY DESIGN, and must not be counted as dispatch-stall evidence.
+  //
+  // Derived from the real interval rather than a magic number, plus 60s of slack
+  // so a sweep landing just after a board-health scan cannot race the grace
+  // expiring. Observed 2026-08-10: without this, a 2-minute-old claim actuated a
+  // holistic recovery-pass delegate (opus, worktree, slot) on a healthy board.
+  delegateGraceMs:
+    Number(process.env.CATALYST_BH_DELEGATE_GRACE_MS) || RECONCILE_INTERVAL_MS + 60_000,
 };
 
 // single-LLM cadence floor: most ticks are a near-instant no-op (cheap gates),
@@ -461,6 +475,41 @@ export function resolveRosterSeam(value, fallback) {
   }
 }
 
+// normalizeDelegateClaims — CTL-1744. Coerce whatever the delegate-claim seam
+// returns into a clean Map<ticketId, claimedAtMs> of USABLE evidence only.
+//
+// This is the single place the fail-closed contract is enforced, and it is
+// deliberately strict: grace is a SUPPRESSION of a recovery signal, so it may be
+// granted only on positive, well-formed evidence. Anything ambiguous — a missing
+// map, a non-Map, a non-numeric / NaN / Infinity / non-positive timestamp — is
+// DROPPED rather than coerced, which means that ticket gets no grace and
+// checkDispatchLiveness treats it exactly as it does today.
+//
+// A future-dated claim is kept here (not dropped) so the age check downstream can
+// distinguish "clock skew" from "no evidence" and reject it explicitly; dropping
+// it here would make the two indistinguishable in the published census.
+// Accepts a Map or any [key, value] iterable (plain objects are NOT accepted —
+// an object would silently pick up prototype keys). Never throws.
+export function normalizeDelegateClaims(raw) {
+  const out = new Map();
+  try {
+    if (!raw) return out;
+    const entries =
+      raw instanceof Map ? raw.entries() : typeof raw[Symbol.iterator] === "function" ? raw : null;
+    if (!entries) return out;
+    for (const entry of entries) {
+      if (!Array.isArray(entry) || entry.length < 2) continue;
+      const [ticket, ts] = entry;
+      if (typeof ticket !== "string" || ticket === "") continue;
+      if (typeof ts !== "number" || !Number.isFinite(ts) || ts <= 0) continue;
+      out.set(ticket, ts);
+    }
+  } catch {
+    return new Map();
+  }
+  return out;
+}
+
 export function assembleBoardState({
   orchDir,
   getBoard = () => [],
@@ -522,6 +571,13 @@ export function assembleBoardState({
   // inert/shadow-safe: !present is always false → nothing is excluded until the
   // daemon binds the real fs check. See selectAnchorCandidates.
   hasTriageArtifact = () => true,
+  // CTL-1744: Map<ticketId, claimedAtMs> — when the monitor DELEGATED each
+  // ticket to the orchestrator app-actor (the CTL-1174 pass-1 claim). Injected
+  // so board-health.mjs stays fs-free, same seam shape as getStalledPrState /
+  // getStrandedEvidence. The empty-Map default is inert AND fail-closed: with no
+  // claim evidence no ticket is ever granted grace, so an unwired daemon behaves
+  // byte-identically to before this change. See checkDispatchLiveness.
+  getDelegateClaims = () => new Map(),
 } = {}) {
   const nowMs = now();
   const safe = (fn, fallback) => {
@@ -647,6 +703,12 @@ export function assembleBoardState({
     githubQuotaMode: ["off", "shadow", "enforce"].includes(githubQuotaMode) ? githubQuotaMode : "shadow",
     productivityMode: ["off", "shadow", "enforce"].includes(productivityMode) ? productivityMode : "shadow",
     peerProductivity: mode === "off" || productivityMode === "off" ? null : safe(() => getPeerProductivity(), null),
+    // CTL-1744: per-ticket delegate-claim timestamps for the dispatch-liveness
+    // grace. `safe()` collapses a throwing/absent reader to the empty Map, which
+    // is the fail-closed direction (no evidence → no grace → recovery unchanged).
+    // Not gated on mode: an `off` scan never reaches evaluateInvariants anyway,
+    // and the reader is a cheap host-local marker read with no network cost.
+    delegateClaims: normalizeDelegateClaims(safe(() => getDelegateClaims(), new Map())),
     ring: deriveRing(safe(() => readEventRing({ orchDir }), []), nowMs, self ?? ""),
     ownerForTicket: typeof ownerForTicket === "function" ? ownerForTicket : null,
     // CTL-1157 (Codex #4): the ticket→owner/repo resolver for the composite
@@ -741,13 +803,53 @@ function checkCacheCoherence(b) {
 function checkDispatchLiveness(b, t) {
   const free = b.capacity.freeSlots;
   const owns = makeOwnsFilter(b, { scope: "dispatch" });
-  const ownedEligible = b.eligible.filter((e) => owns(e.id));
+  // CTL-1744: ownership is resolved FIRST and grace never touches it. Grace
+  // narrows the EVIDENCE set only, so the multi-host HRW path (makeOwnsFilter,
+  // dispatch scope) behaves exactly as before — a ticket this host does not own
+  // is still not this host's business, grace or no grace.
+  const owned = b.eligible.filter((e) => owns(e.id));
+
+  // CTL-1744: exclude tickets inside the legitimate delegate-lands wait. The
+  // CTL-1174 triage gate claims a ticket by delegating it, then HOLDS until the
+  // next reconcile sweep (up to RECONCILE_INTERVAL_MS later). Such a ticket is
+  // queued-and-undispatched BY DESIGN and is not evidence of a wedge.
+  //
+  // FAIL-CLOSED in every ambiguous case — grace suppresses a recovery signal, so
+  // it is granted only on positive, well-formed, non-future evidence:
+  //   no claims map / no entry / non-numeric ts → NO grace (today's behavior)
+  //   future-dated claim (clock skew)           → NO grace (age < 0)
+  const graceMs = t?.delegateGraceMs ?? DEFAULT_THRESHOLDS.delegateGraceMs;
+  const claims = b.delegateClaims instanceof Map ? b.delegateClaims : null;
+  const inDelegateGrace = (id) => {
+    if (!claims || !id) return false;
+    const claimedAt = claims.get(id);
+    if (typeof claimedAt !== "number" || !Number.isFinite(claimedAt)) return false;
+    const age = b.now - claimedAt;
+    if (!Number.isFinite(age) || age < 0) return false;
+    return age <= graceMs;
+  };
+  const waiting = owned.filter((e) => inDelegateGrace(e.id));
+  const ownedEligible = owned.filter((e) => !inDelegateGrace(e.id));
+
   const queuedTotal = b.eligible.length;
   const queued = ownedEligible.length;
-  const extra = { queuedTotal, queuedOwned: queued };
+  const extra = {
+    queuedTotal,
+    // Unchanged meaning: every owned candidate, grace or not. Kept stable so
+    // existing census consumers do not silently shift.
+    queuedOwned: owned.length,
+    // CTL-1744: publish the suppression rather than shrinking a count in
+    // silence — a census that quietly excludes work reads as "nothing queued".
+    queuedOwnedInDelegateGrace: waiting.length,
+    queuedOwnedEvidence: queued,
+    delegateGraceMs: graceMs,
+  };
+  const graceNote = waiting.length
+    ? ` (${waiting.length} in delegate-lands grace)`
+    : "";
   if (free <= 0 || queued <= 0) {
     return invariant(true, 0, true, [],
-      `no wedge (free=${free}, ${queued} owned of ${queuedTotal} queued)`, extra);
+      `no wedge (free=${free}, ${queued} owned of ${queuedTotal} queued)${graceNote}`, extra);
   }
   const last = b.ring?.recentDispatchTs ?? null;
   const staleMs = last == null ? null : b.now - last;
@@ -758,8 +860,8 @@ function checkDispatchLiveness(b, t) {
     true,
     wedged ? ownedEligible.slice(0, 5).map((e) => e.id).filter(Boolean) : [],
     wedged
-      ? `${free} free slot(s) + ${queued} owned queued (of ${queuedTotal}) + ${last == null ? "no recent dispatch seen" : `${Math.round(staleMs / 60_000)}m since dispatch`} → wedge`
-      : "dispatch live",
+      ? `${free} free slot(s) + ${queued} owned queued (of ${queuedTotal}) + ${last == null ? "no recent dispatch seen" : `${Math.round(staleMs / 60_000)}m since dispatch`} → wedge${graceNote}`
+      : `dispatch live${graceNote}`,
     extra,
   );
 }

--- a/plugins/dev/scripts/execution-core/board-health.test.mjs
+++ b/plugins/dev/scripts/execution-core/board-health.test.mjs
@@ -1431,6 +1431,45 @@ describe("boardHealthPass — mode branching + shadow safety", () => {
     expect(emits[0].details.mode).toBe("enforce");
   });
 
+  // CTL-1744 / Codex #3206 P1 — REGRESSION GUARD for a silent seam drop.
+  //
+  // The scheduler binds getDelegateClaims at the daemon call site, but
+  // boardHealthPass originally neither destructured nor forwarded it. JavaScript
+  // discards an undeclared property silently, so assembleBoardState always fell
+  // back to its empty-Map default: no ticket was ever granted grace and enforce
+  // could still launch the very delegate this fix exists to prevent — i.e. the
+  // whole change was INERT in production.
+  //
+  // It survived review because every other CTL-1744 test calls assembleBoardState
+  // DIRECTLY; none went through boardHealthPass, which is the only path the daemon
+  // actually uses. So assert the PRODUCTION path, and assert both halves: that the
+  // injected reader is really consulted, and that its value reaches the invariant.
+  test("CTL-1744: boardHealthPass FORWARDS getDelegateClaims through to assembleBoardState", () => {
+    const emits = [];
+    let calls = 0;
+    // flaggedDeps is, by construction, a dispatch wedge: free slots + a queue of
+    // CTL-1/CTL-2 + no dispatch events. Claim BOTH queued tickets well inside the
+    // grace window (grace = RECONCILE_INTERVAL_MS + 60s = 11 min; these are 1 min old)
+    // so a correctly-forwarded reader must clear the wedge entirely.
+    const r = boardHealthPass(
+      flaggedDeps({
+        mode: "shadow",
+        emit: (e) => emits.push(e),
+        getDelegateClaims: () => {
+          calls += 1;
+          return new Map([["CTL-1", NOW - 60_000], ["CTL-2", NOW - 60_000]]);
+        },
+      }),
+    );
+    expect(r.ran).toBe(true);
+    // (1) the forwarding contract itself: the reader was actually invoked.
+    //     Pre-fix this was 0 — the property never survived the destructure.
+    expect(calls).toBeGreaterThan(0);
+    // (2) the behavior that contract buys: every queued ticket is inside the
+    //     delegate-lands grace, so the board is NOT a wedge. Pre-fix: ok === false.
+    expect(emits[0].details.invariants.dispatchLiveness.ok).toBe(true);
+  });
+
   test("mode:enforce WITH act → ONE holistic dispatch carrying anchor + boardContext (CTL-1300)", () => {
     const emits = [];
     const acted = [];

--- a/plugins/dev/scripts/execution-core/board-health.test.mjs
+++ b/plugins/dev/scripts/execution-core/board-health.test.mjs
@@ -27,6 +27,8 @@ import {
   isParkedByHuman,
   eligibleDeferredAnchors,
   makeOwnsFilter,
+  // CTL-1744: delegate-claim evidence normalizer (fail-closed sanitization).
+  normalizeDelegateClaims,
   resolveRosterSeam,
 } from "./board-health.mjs";
 // CTL-1435 (Codex P1/P2): round-trip the REAL emit envelope so the ring test
@@ -111,6 +113,10 @@ function mkBoard(o = {}) {
     // CTL-1644: per-ticket evidence map for the stranded-mid-pipeline check.
     // Empty Map default ⇒ checkStrandedMidPipeline stays observable:false (shadow-first).
     strandedEvidence: o.strandedEvidence ?? new Map(),
+    // CTL-1744: per-ticket delegate-claim timestamps. Empty Map default ⇒ no
+    // ticket is ever granted delegate-lands grace, so every pre-existing test
+    // exercises exactly the pre-CTL-1744 behavior.
+    delegateClaims: o.delegateClaims ?? new Map(),
     now: o.now ?? NOW,
   };
 }
@@ -202,6 +208,183 @@ describe("evaluateInvariants — per-invariant green/fail", () => {
       mkBoard({ capacity: { freeSlots: 4 }, eligible: [], ring: { recentDispatchTs: null } }),
     );
     expect(noQueue.dispatchLiveness.ok).toBe(true);
+  });
+
+  // ── CTL-1744: delegate-lands grace ────────────────────────────────────────
+  //
+  // The CTL-1174 triage gate is TWO-PASS: pass 1 claims a ticket by delegating it
+  // to the orchestrator app-actor and HOLDS; pass 2 dispatches, but only on the
+  // next reconcile sweep (RECONCILE_INTERVAL_MS, 10 min). Without grace, that
+  // by-design wait reads as a wedge and actuates a recovery delegate — observed
+  // live 2026-08-10, where a 2-minute-old claim burned an opus session, a
+  // worktree and a slot on a perfectly healthy board.
+  //
+  // GRACE_MS mirrors the production default (RECONCILE_INTERVAL_MS + 60s slack).
+  const GRACE_MS = 10 * 60_000 + 60_000;
+  const wedgeBoard = (o = {}) =>
+    mkBoard({
+      capacity: { maxParallel: 4, liveCount: 0, freeSlots: 4 },
+      ring: { recentDispatchTs: NOW - 30 * MIN }, // far past the 10-min stall
+      ...o,
+    });
+
+  test("CTL-1744 (a) INSIDE grace: a freshly-claimed ticket is not wedge evidence → no recovery", () => {
+    const r = evaluateInvariants(
+      wedgeBoard({
+        eligible: [{ id: "CTL-1743" }],
+        delegateClaims: new Map([["CTL-1743", NOW - 2 * MIN]]), // claimed 2 min ago
+      }),
+    );
+    expect(r.dispatchLiveness.ok).toBe(true);
+    expect(r.dispatchLiveness.failed).toBe(0);
+    expect(r.dispatchLiveness.flagged).toEqual([]);
+    // census stays honest: the candidate is reported, not silently dropped
+    expect(r.dispatchLiveness.queuedOwned).toBe(1);
+    expect(r.dispatchLiveness.queuedOwnedInDelegateGrace).toBe(1);
+    expect(r.dispatchLiveness.queuedOwnedEvidence).toBe(0);
+    expect(r.dispatchLiveness.note).toContain("delegate-lands grace");
+  });
+
+  test("CTL-1744 (b) AFTER grace: recovery still fires — a genuinely wedged board is not masked", () => {
+    const r = evaluateInvariants(
+      wedgeBoard({
+        eligible: [{ id: "CTL-1743" }],
+        delegateClaims: new Map([["CTL-1743", NOW - (GRACE_MS + 1)]]), // 1ms past grace
+      }),
+    );
+    expect(r.dispatchLiveness.ok).toBe(false);
+    expect(r.dispatchLiveness.failed).toBe(1);
+    expect(r.dispatchLiveness.flagged).toContain("CTL-1743");
+    expect(r.dispatchLiveness.queuedOwnedInDelegateGrace).toBe(0);
+  });
+
+  test("CTL-1744 (b') boundary: exactly at grace is still granted; one ms past is not", () => {
+    const atEdge = evaluateInvariants(
+      wedgeBoard({
+        eligible: [{ id: "CTL-1" }],
+        delegateClaims: new Map([["CTL-1", NOW - GRACE_MS]]),
+      }),
+    );
+    expect(atEdge.dispatchLiveness.ok).toBe(true);
+    const pastEdge = evaluateInvariants(
+      wedgeBoard({
+        eligible: [{ id: "CTL-1" }],
+        delegateClaims: new Map([["CTL-1", NOW - GRACE_MS - 1]]),
+      }),
+    );
+    expect(pastEdge.dispatchLiveness.ok).toBe(false);
+  });
+
+  test("CTL-1744 (c) FAIL-CLOSED: every unusable claim timestamp grants NO grace", () => {
+    // Each case must behave exactly like today (wedge), because grace SUPPRESSES
+    // a recovery signal and may only be granted on positive, well-formed evidence.
+    const cases = [
+      ["no entry for the ticket", new Map([["CTL-OTHER", NOW]])],
+      ["empty map", new Map()],
+      ["non-numeric (string)", new Map([["CTL-1", String(NOW)]])],
+      ["NaN", new Map([["CTL-1", NaN]])],
+      ["Infinity", new Map([["CTL-1", Infinity]])],
+      ["null", new Map([["CTL-1", null]])],
+      ["undefined", new Map([["CTL-1", undefined]])],
+      ["zero", new Map([["CTL-1", 0]])],
+      ["negative", new Map([["CTL-1", -1]])],
+      ["FUTURE-dated (clock skew)", new Map([["CTL-1", NOW + 5 * MIN]])],
+      ["not a Map at all", { "CTL-1": NOW }],
+      ["null claims", null],
+    ];
+    for (const [label, delegateClaims] of cases) {
+      const r = evaluateInvariants(
+        wedgeBoard({ eligible: [{ id: "CTL-1" }], delegateClaims }),
+      );
+      expect(`${label}: ${r.dispatchLiveness.ok}`).toBe(`${label}: false`);
+      expect(`${label}: ${r.dispatchLiveness.flagged.includes("CTL-1")}`).toBe(`${label}: true`);
+    }
+  });
+
+  test("CTL-1744 (d) HRW UNCHANGED: grace narrows evidence only, never ownership", () => {
+    // A peer-owned ticket is not this host's business with or without a claim.
+    // Granting it grace must not change that, and must not make a peer-owned
+    // ticket become owned.
+    const peerOwned = evaluateInvariants(
+      mkOwnedBoard({
+        owner: () => "peer",
+        capacity: { maxParallel: 4, liveCount: 0, freeSlots: 4 },
+        ring: { recentDispatchTs: NOW - 30 * MIN },
+        eligible: [{ id: "CTL-PEER" }],
+        delegateClaims: new Map([["CTL-PEER", NOW - 2 * MIN]]),
+      }),
+    );
+    expect(peerOwned.dispatchLiveness.ok).toBe(true);      // not ours → never a wedge
+    expect(peerOwned.dispatchLiveness.queuedOwned).toBe(0); // ownership unaffected by grace
+    expect(peerOwned.dispatchLiveness.queuedOwnedInDelegateGrace).toBe(0);
+
+    // Mixed board: one owned+fresh (suppressed), one owned+stale (still evidence).
+    const mixed = evaluateInvariants(
+      mkOwnedBoard({
+        owner: () => "mini",
+        capacity: { maxParallel: 4, liveCount: 0, freeSlots: 4 },
+        ring: { recentDispatchTs: NOW - 30 * MIN },
+        eligible: [{ id: "CTL-FRESH" }, { id: "CTL-STALE" }],
+        delegateClaims: new Map([
+          ["CTL-FRESH", NOW - 1 * MIN],
+          ["CTL-STALE", NOW - 3 * HOUR],
+        ]),
+      }),
+    );
+    expect(mixed.dispatchLiveness.ok).toBe(false);
+    expect(mixed.dispatchLiveness.flagged).toContain("CTL-STALE");
+    expect(mixed.dispatchLiveness.flagged).not.toContain("CTL-FRESH");
+    expect(mixed.dispatchLiveness.queuedOwned).toBe(2);
+    expect(mixed.dispatchLiveness.queuedOwnedInDelegateGrace).toBe(1);
+    expect(mixed.dispatchLiveness.queuedOwnedEvidence).toBe(1);
+  });
+
+  test("CTL-1744: grace never RESURRECTS a wedge — recent dispatch still reads live", () => {
+    const r = evaluateInvariants(
+      mkBoard({
+        capacity: { maxParallel: 4, liveCount: 0, freeSlots: 4 },
+        eligible: [{ id: "CTL-1" }],
+        ring: { recentDispatchTs: NOW - 1 * MIN },
+        delegateClaims: new Map([["CTL-1", NOW - 3 * HOUR]]),
+      }),
+    );
+    expect(r.dispatchLiveness.ok).toBe(true);
+  });
+
+  test("CTL-1744: normalizeDelegateClaims keeps only usable evidence, never throws", () => {
+    expect(normalizeDelegateClaims(new Map([["CTL-1", 123]])).get("CTL-1")).toBe(123);
+    // future-dated is KEPT here so the age check can reject it explicitly
+    expect(normalizeDelegateClaims(new Map([["CTL-1", 9e15]])).get("CTL-1")).toBe(9e15);
+    // accepts any [k,v] iterable, not just a Map
+    expect(normalizeDelegateClaims([["CTL-2", 5]]).get("CTL-2")).toBe(5);
+    for (const bad of [null, undefined, 42, "nope", { "CTL-1": 1 }, new Set([1, 2])]) {
+      expect(normalizeDelegateClaims(bad).size).toBe(0);
+    }
+    const mixed = normalizeDelegateClaims(
+      new Map([["CTL-OK", 1], ["CTL-NAN", NaN], ["CTL-STR", "1"], ["", 1], ["CTL-NEG", -1]]),
+    );
+    expect([...mixed.keys()]).toEqual(["CTL-OK"]);
+    // a throwing iterable degrades to empty rather than propagating
+    const hostile = { [Symbol.iterator]() { throw new Error("boom"); } };
+    expect(normalizeDelegateClaims(hostile).size).toBe(0);
+  });
+
+  test("CTL-1744: assembleBoardState seam is inert by default and fail-closed on throw", () => {
+    const unwired = assembleBoardState({ orchDir: "/tmp/x" });
+    expect(unwired.delegateClaims).toBeInstanceOf(Map);
+    expect(unwired.delegateClaims.size).toBe(0);
+
+    const throwing = assembleBoardState({
+      orchDir: "/tmp/x",
+      getDelegateClaims: () => { throw new Error("unreadable"); },
+    });
+    expect(throwing.delegateClaims.size).toBe(0);
+
+    const wired = assembleBoardState({
+      orchDir: "/tmp/x",
+      getDelegateClaims: () => new Map([["CTL-1", 1234]]),
+    });
+    expect(wired.delegateClaims.get("CTL-1")).toBe(1234);
   });
 
   test("workerAge: non-terminal worker past phase-normal age flags; within-age + terminal do not", () => {

--- a/plugins/dev/scripts/execution-core/delegate-claims.mjs
+++ b/plugins/dev/scripts/execution-core/delegate-claims.mjs
@@ -1,0 +1,106 @@
+// delegate-claims.mjs — CTL-1744. Delegate-lands claim markers.
+//
+// WHY THIS EXISTS
+// ---------------
+// `dispatchTriage`'s CTL-1174 gate (monitor.mjs) is deliberately TWO-PASS:
+//
+//   pass 1  an undelegated Todo ticket is CLAIMED by delegating it to the
+//           orchestrator app-actor, then HELD for this tick;
+//   pass 2  triage is dispatched — but only on the next `sweepMissingTriage`,
+//           which runs on the reconcile timer (RECONCILE_INTERVAL_MS, 10 min).
+//
+// So a freshly-claimed ticket is legitimately eligible-but-undispatched for up
+// to one reconcile interval. board-health's `dispatchLiveness` invariant could
+// not see that wait and read it as a wedged board — on 2026-08-10 a claim two
+// minutes old actuated a holistic recovery-pass delegate (opus session, git
+// worktree, a concurrency slot) against a completely healthy board, and tripped
+// the "unexpected worker" abort condition of a live cutover verification.
+//
+// These markers are the evidence that lets the invariant grant a BOUNDED grace.
+//
+// WHY A SEPARATE LEAF MODULE
+// --------------------------
+// The producer lives in monitor.mjs and the consumer wiring in scheduler.mjs,
+// but monitor.mjs already imports scheduler.mjs — so putting the reader in
+// monitor.mjs would make scheduler→monitor a CYCLE. This module imports nothing
+// but `node:fs`/`node:path` (a zero-import leaf, same discipline as
+// secret-contract.mjs), so both sides can depend on it safely.
+//
+// FAILURE BIAS
+// ------------
+// Grace SUPPRESSES a recovery signal, so every ambiguous path here is biased
+// toward NO GRACE: absent directory, unreadable file, malformed JSON, or a
+// non-numeric / non-finite / non-positive timestamp all yield no entry, which
+// reproduces the pre-CTL-1744 behavior exactly. This file can never mask a
+// genuine wedge — the worst it can do is fail to excuse a legitimate wait.
+//
+// Placed at orchDir level (not under workers/<t>/) for the same reason as
+// .triage-dispatch-counts: the worker-dir GC must not be able to delete it.
+
+import { existsSync, mkdirSync, readFileSync, readdirSync, rmSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+
+export const DELEGATE_CLAIMS_DIR = ".delegate-claims";
+
+export function delegateClaimPath(orchDir, ticket) {
+  return join(orchDir, DELEGATE_CLAIMS_DIR, `${ticket}.json`);
+}
+
+// recordDelegateClaim — stamp WHEN a ticket was delegated to the orchestrator.
+// Returns true when a marker was written. Never throws: a marker write must
+// never break the claim path it is only observing.
+export function recordDelegateClaim(orchDir, ticket, { now = () => Date.now() } = {}) {
+  // Never manufacture the orch dir itself — a missing one means a hermetic or
+  // mocked context (several suites use a shared literal orchDir), and writing
+  // there would leak state across runs. Same rule as writeTriageDispatchRecord.
+  if (!orchDir || !ticket || !existsSync(orchDir)) return false;
+  try {
+    const p = delegateClaimPath(orchDir, ticket);
+    mkdirSync(dirname(p), { recursive: true });
+    writeFileSync(p, JSON.stringify({ ticket, claimedAt: now() }));
+    return true;
+  } catch {
+    return false; // no marker ⇒ no grace ⇒ prior behavior
+  }
+}
+
+// clearDelegateClaim — drop the marker once the ticket actually dispatches.
+// NOT load-bearing: a surviving marker expires on its own once
+// `now - claimedAt` exceeds the grace window, because the invariant compares
+// against wall-clock rather than trusting the file's existence. Housekeeping
+// only, so `.delegate-claims/` stays bounded.
+export function clearDelegateClaim(orchDir, ticket) {
+  if (!orchDir || !ticket) return false;
+  try {
+    rmSync(delegateClaimPath(orchDir, ticket), { force: true });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+// readDelegateClaims — Map<ticket, claimedAtMs> of USABLE evidence only.
+export function readDelegateClaims(orchDir) {
+  const out = new Map();
+  if (!orchDir) return out;
+  const dir = join(orchDir, DELEGATE_CLAIMS_DIR);
+  let names = [];
+  try {
+    names = readdirSync(dir);
+  } catch {
+    return out; // no directory → no evidence → nobody gets grace
+  }
+  for (const name of names) {
+    if (!name.endsWith(".json")) continue;
+    const ticket = name.slice(0, -".json".length);
+    if (!ticket) continue;
+    try {
+      const rec = JSON.parse(readFileSync(join(dir, name), "utf8"));
+      const ts = rec?.claimedAt;
+      if (typeof ts === "number" && Number.isFinite(ts) && ts > 0) out.set(ticket, ts);
+    } catch {
+      /* malformed → skip → no grace for this ticket */
+    }
+  }
+  return out;
+}

--- a/plugins/dev/scripts/execution-core/delegate-claims.mjs
+++ b/plugins/dev/scripts/execution-core/delegate-claims.mjs
@@ -46,9 +46,27 @@ export function delegateClaimPath(orchDir, ticket) {
   return join(orchDir, DELEGATE_CLAIMS_DIR, `${ticket}.json`);
 }
 
-// recordDelegateClaim — stamp WHEN a ticket was delegated to the orchestrator.
+// recordDelegateClaim — stamp WHEN a ticket was FIRST delegated to the orchestrator.
 // Returns true when a marker was written. Never throws: a marker write must
 // never break the claim path it is only observing.
+//
+// FIRST-CLAIM-WINS (CTC review, turn 113). An existing marker is never
+// overwritten, so `claimedAt` measures the age of the REAL wait rather than the
+// most recent re-claim. Without this the window is RENEWABLE: the pass-1 gate can
+// re-run and re-stamp, sliding `claimedAt` forward on every tick, and grace would
+// then last as long as the re-claim loop does instead of `graceMs` — suppressing
+// dispatch-liveness for exactly the ticket that is genuinely stuck.
+//
+// Two upstream brakes already make that loop hard to reach — the CTL-1174 latch
+// fix live-confirms a cached-null delegate before treating it as undelegated
+// (linear-query.mjs), and applyAssignee's read-back is a LIVE query so a write
+// that did not stick returns applied:false and never stamps — but the bound must
+// be STRUCTURAL, not contingent on two other mechanisms staying correct. A
+// flapping delegate, or any future change to either brake, would otherwise
+// silently reopen it.
+//
+// Costs nothing in the happy path: clearDelegateClaim removes the marker when the
+// ticket dispatches, so the next legitimate claim writes a fresh timestamp.
 export function recordDelegateClaim(orchDir, ticket, { now = () => Date.now() } = {}) {
   // Never manufacture the orch dir itself — a missing one means a hermetic or
   // mocked context (several suites use a shared literal orchDir), and writing
@@ -57,10 +75,18 @@ export function recordDelegateClaim(orchDir, ticket, { now = () => Date.now() } 
   try {
     const p = delegateClaimPath(orchDir, ticket);
     mkdirSync(dirname(p), { recursive: true });
-    writeFileSync(p, JSON.stringify({ ticket, claimedAt: now() }));
+    // ATOMIC first-claim-wins (MIGRATION turn 115): `wx` = create-exclusive, so
+    // the existence check and the write are one syscall. An `existsSync(p)` guard
+    // followed by a write would be TOCTOU — two callers could both observe
+    // "absent" and the second would slide `claimedAt` forward, reintroducing the
+    // renewable window this guard exists to close. EEXIST lands in the catch and
+    // returns false, which is the correct outcome: an existing marker (even a
+    // malformed one, which grants no grace anyway) is left exactly as it is.
+    // Bounding suppression matters more than refreshing an unreadable stamp.
+    writeFileSync(p, JSON.stringify({ ticket, claimedAt: now() }), { flag: "wx" });
     return true;
   } catch {
-    return false; // no marker ⇒ no grace ⇒ prior behavior
+    return false; // existing marker OR write failure ⇒ no NEW window ⇒ bounded
   }
 }
 

--- a/plugins/dev/scripts/execution-core/delegate-claims.test.mjs
+++ b/plugins/dev/scripts/execution-core/delegate-claims.test.mjs
@@ -1,0 +1,122 @@
+// delegate-claims.test.mjs — CTL-1744.
+//
+// The load-bearing property here is the FAILURE BIAS: grace suppresses a
+// recovery signal, so every ambiguous input must yield NO entry (⇒ no grace ⇒
+// pre-CTL-1744 behavior). These tests assert that direction explicitly for every
+// way a marker can be unusable, because a reader that "helpfully" coerced a bad
+// timestamp would silently mask real wedges.
+//
+// Run: cd plugins/dev/scripts/execution-core && bun test delegate-claims.test.mjs
+
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync, existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  DELEGATE_CLAIMS_DIR,
+  delegateClaimPath,
+  recordDelegateClaim,
+  clearDelegateClaim,
+  readDelegateClaims,
+} from "./delegate-claims.mjs";
+
+let orchDir;
+const claimsDir = () => join(orchDir, DELEGATE_CLAIMS_DIR);
+const writeRaw = (ticket, body) => {
+  mkdirSync(claimsDir(), { recursive: true });
+  writeFileSync(join(claimsDir(), `${ticket}.json`), body);
+};
+
+beforeEach(() => {
+  orchDir = mkdtempSync(join(tmpdir(), "ctl1744-"));
+});
+afterEach(() => {
+  rmSync(orchDir, { recursive: true, force: true });
+});
+
+describe("recordDelegateClaim", () => {
+  test("writes a usable marker and readDelegateClaims returns it", () => {
+    expect(recordDelegateClaim(orchDir, "CTL-1", { now: () => 1000 })).toBe(true);
+    expect(existsSync(delegateClaimPath(orchDir, "CTL-1"))).toBe(true);
+    expect(readDelegateClaims(orchDir).get("CTL-1")).toBe(1000);
+  });
+
+  test("NEVER manufactures the orch dir (hermetic/mocked context → no-op)", () => {
+    const missing = join(orchDir, "does", "not", "exist");
+    expect(recordDelegateClaim(missing, "CTL-1")).toBe(false);
+    expect(existsSync(missing)).toBe(false);
+  });
+
+  test("missing orchDir/ticket are no-ops rather than throws", () => {
+    expect(recordDelegateClaim(null, "CTL-1")).toBe(false);
+    expect(recordDelegateClaim(orchDir, "")).toBe(false);
+    expect(recordDelegateClaim(orchDir, null)).toBe(false);
+  });
+
+  test("re-claiming overwrites with the newer timestamp", () => {
+    recordDelegateClaim(orchDir, "CTL-1", { now: () => 1000 });
+    recordDelegateClaim(orchDir, "CTL-1", { now: () => 2000 });
+    expect(readDelegateClaims(orchDir).get("CTL-1")).toBe(2000);
+  });
+});
+
+describe("clearDelegateClaim", () => {
+  test("removes the marker; absent marker is not an error (idempotent)", () => {
+    recordDelegateClaim(orchDir, "CTL-1", { now: () => 1000 });
+    expect(clearDelegateClaim(orchDir, "CTL-1")).toBe(true);
+    expect(readDelegateClaims(orchDir).has("CTL-1")).toBe(false);
+    expect(clearDelegateClaim(orchDir, "CTL-1")).toBe(true); // already gone
+    expect(clearDelegateClaim(null, "CTL-1")).toBe(false);
+  });
+});
+
+describe("readDelegateClaims — FAIL-CLOSED on every unusable marker", () => {
+  test("absent directory → empty map (nobody gets grace)", () => {
+    expect(readDelegateClaims(orchDir).size).toBe(0);
+    expect(readDelegateClaims(null).size).toBe(0);
+    expect(readDelegateClaims("/nonexistent/path/xyz").size).toBe(0);
+  });
+
+  test("malformed / non-numeric / non-positive timestamps are DROPPED, not coerced", () => {
+    writeRaw("CTL-GOOD", JSON.stringify({ ticket: "CTL-GOOD", claimedAt: 1234 }));
+    writeRaw("CTL-NOTJSON", "{{{ not json");
+    writeRaw("CTL-EMPTY", "");
+    writeRaw("CTL-NULL", JSON.stringify({ claimedAt: null }));
+    writeRaw("CTL-STR", JSON.stringify({ claimedAt: "1234" }));
+    writeRaw("CTL-NAN", JSON.stringify({ claimedAt: "NaN" }));
+    writeRaw("CTL-ZERO", JSON.stringify({ claimedAt: 0 }));
+    writeRaw("CTL-NEG", JSON.stringify({ claimedAt: -5 }));
+    writeRaw("CTL-MISSING", JSON.stringify({ ticket: "CTL-MISSING" }));
+    writeRaw("CTL-ARRAY", JSON.stringify([1, 2, 3]));
+
+    const claims = readDelegateClaims(orchDir);
+    expect([...claims.keys()]).toEqual(["CTL-GOOD"]);
+    expect(claims.get("CTL-GOOD")).toBe(1234);
+  });
+
+  test("one malformed marker never poisons the others", () => {
+    writeRaw("CTL-A", JSON.stringify({ claimedAt: 1 }));
+    writeRaw("CTL-BAD", "}{");
+    writeRaw("CTL-B", JSON.stringify({ claimedAt: 2 }));
+    const claims = readDelegateClaims(orchDir);
+    expect(claims.get("CTL-A")).toBe(1);
+    expect(claims.get("CTL-B")).toBe(2);
+    expect(claims.has("CTL-BAD")).toBe(false);
+  });
+
+  test("non-.json files and stray entries are ignored", () => {
+    mkdirSync(claimsDir(), { recursive: true });
+    writeFileSync(join(claimsDir(), "README"), "not a claim");
+    writeFileSync(join(claimsDir(), ".json"), JSON.stringify({ claimedAt: 1 })); // empty ticket name
+    writeRaw("CTL-OK", JSON.stringify({ claimedAt: 7 }));
+    expect([...readDelegateClaims(orchDir).keys()]).toEqual(["CTL-OK"]);
+  });
+
+  test("a FUTURE-dated marker is returned as-is — the age check, not the reader, rejects it", () => {
+    // Deliberate: the reader must not silently drop clock-skewed evidence, or the
+    // invariant could not distinguish "skew" from "no evidence" in its census.
+    const future = Date.now() + 60_000;
+    writeRaw("CTL-FUTURE", JSON.stringify({ claimedAt: future }));
+    expect(readDelegateClaims(orchDir).get("CTL-FUTURE")).toBe(future);
+  });
+});

--- a/plugins/dev/scripts/execution-core/delegate-claims.test.mjs
+++ b/plugins/dev/scripts/execution-core/delegate-claims.test.mjs
@@ -9,7 +9,7 @@
 // Run: cd plugins/dev/scripts/execution-core && bun test delegate-claims.test.mjs
 
 import { describe, test, expect, beforeEach, afterEach } from "bun:test";
-import { mkdtempSync, rmSync, mkdirSync, writeFileSync, existsSync } from "node:fs";
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync, readFileSync, statSync, existsSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
@@ -19,6 +19,9 @@ import {
   clearDelegateClaim,
   readDelegateClaims,
 } from "./delegate-claims.mjs";
+// MIGRATION turn 119: the integrated bound test drives the REAL invariant off the
+// REAL reader, so the wiring is proven end-to-end rather than the arithmetic alone.
+import { assembleBoardState, evaluateInvariants } from "./board-health.mjs";
 
 let orchDir;
 const claimsDir = () => join(orchDir, DELEGATE_CLAIMS_DIR);
@@ -94,6 +97,94 @@ describe("recordDelegateClaim", () => {
     writeRaw("CTL-BADEXIST", "}{");
     expect(recordDelegateClaim(orchDir, "CTL-BADEXIST", { now: () => 1000 })).toBe(false);
     expect(readDelegateClaims(orchDir).has("CTL-BADEXIST")).toBe(false);
+  });
+
+  // MIGRATION turn 119: assert the file is BYTE-FOR-BYTE untouched, not merely that
+  // the parsed claim is unchanged. A re-claim that rewrote equivalent-but-different
+  // bytes would still prove the write path ran, which is what must not happen.
+  test("a colliding re-claim preserves the existing file BYTE-FOR-BYTE (valid / malformed / zero-byte)", () => {
+    const cases = [
+      ["CTL-VALID", JSON.stringify({ ticket: "CTL-VALID", claimedAt: 1000 })],
+      ["CTL-MALFORMED", "}{ not json at all"],
+      ["CTL-ZEROBYTE", ""],
+    ];
+    for (const [ticket, original] of cases) {
+      writeRaw(ticket, original);
+      const before = readFileSync(join(claimsDir(), `${ticket}.json`));
+      const beforeStat = statSync(join(claimsDir(), `${ticket}.json`));
+
+      // Attempt several re-claims with clocks that would obviously change the bytes.
+      expect(recordDelegateClaim(orchDir, ticket, { now: () => 777777 })).toBe(false);
+      expect(recordDelegateClaim(orchDir, ticket, { now: () => 888888 })).toBe(false);
+
+      const after = readFileSync(join(claimsDir(), `${ticket}.json`));
+      const afterStat = statSync(join(claimsDir(), `${ticket}.json`));
+      expect(`${ticket}: ${after.equals(before)}`).toBe(`${ticket}: true`);
+      expect(`${ticket}: ${afterStat.size}`).toBe(`${ticket}: ${beforeStat.size}`);
+      expect(after.toString()).toBe(original);
+    }
+  });
+
+  test("a ZERO-BYTE existing marker collides and is NOT replaced (explicit)", () => {
+    // The interesting case on its own: an empty file is falsy-looking but must
+    // still win the collision, or a crashed write would hand back a fresh window.
+    writeRaw("CTL-EMPTY0", "");
+    expect(statSync(join(claimsDir(), "CTL-EMPTY0.json")).size).toBe(0);
+    expect(recordDelegateClaim(orchDir, "CTL-EMPTY0", { now: () => 424242 })).toBe(false);
+    expect(statSync(join(claimsDir(), "CTL-EMPTY0.json")).size).toBe(0);
+    expect(readFileSync(join(claimsDir(), "CTL-EMPTY0.json")).length).toBe(0);
+    expect(readDelegateClaims(orchDir).has("CTL-EMPTY0")).toBe(false); // still no grace
+  });
+});
+
+// ── MIGRATION turn 119: INTEGRATED post-grace evaluation ─────────────────────
+//
+// The 500-reclaim test above proves timestamp arithmetic. This proves the thing
+// that actually matters: that the immutable claim map, read by the REAL reader off
+// REAL files, drives the REAL invariant to flag the ticket once the window elapses.
+// Arithmetic could be right while the wiring silently dropped the map.
+describe("CTL-1744 integrated: repeated re-claims still expire into a wedge", () => {
+  // Production default: RECONCILE_INTERVAL_MS (10m) + 60s slack.
+  const GRACE_MS = 10 * 60_000 + 60_000;
+  const T0 = 1_700_000_000_000;
+  const TICKET = "CTL-STUCK";
+
+  const boardAt = (nowMs) =>
+    assembleBoardState({
+      orchDir,
+      getEligible: () => [{ id: TICKET }],
+      capacity: { maxParallel: 4, liveCount: 0, freeSlots: 4 },
+      // No dispatch events → ring.recentDispatchTs === null → "no recent dispatch
+      // seen", i.e. the wedge precondition. Grace is then the ONLY thing that can
+      // hold the invariant green.
+      readEventRing: () => [],
+      getDelegateClaims: () => readDelegateClaims(orchDir),
+      now: () => nowMs,
+    });
+
+  test("inside grace → green; at graceMs+1 after 500 re-claims → wedge flagged", () => {
+    let clock = T0;
+    recordDelegateClaim(orchDir, TICKET, { now: () => clock });
+    for (let i = 0; i < 500; i++) {
+      clock += 2000; // 2s ticks — ~16 minutes of re-claiming, far beyond graceMs
+      recordDelegateClaim(orchDir, TICKET, { now: () => clock });
+    }
+    // The claim map really is immutable, read back off disk by the real reader.
+    expect(readDelegateClaims(orchDir).get(TICKET)).toBe(T0);
+
+    // Inside the window the invariant is suppressed...
+    const inside = evaluateInvariants(boardAt(T0 + GRACE_MS - 1));
+    expect(inside.dispatchLiveness.ok).toBe(true);
+    expect(inside.dispatchLiveness.queuedOwnedInDelegateGrace).toBe(1);
+
+    // ...and one millisecond past it, the ticket IS wedge evidence — despite 500
+    // re-claims that, pre-fix, would have kept sliding the window forward.
+    const past = evaluateInvariants(boardAt(T0 + GRACE_MS + 1));
+    expect(past.dispatchLiveness.ok).toBe(false);
+    expect(past.dispatchLiveness.failed).toBe(1);
+    expect(past.dispatchLiveness.flagged).toContain(TICKET);
+    expect(past.dispatchLiveness.queuedOwnedInDelegateGrace).toBe(0);
+    expect(past.dispatchLiveness.queuedOwnedEvidence).toBe(1);
   });
 });
 

--- a/plugins/dev/scripts/execution-core/delegate-claims.test.mjs
+++ b/plugins/dev/scripts/execution-core/delegate-claims.test.mjs
@@ -112,6 +112,32 @@ describe("readDelegateClaims — FAIL-CLOSED on every unusable marker", () => {
     expect([...readDelegateClaims(orchDir).keys()]).toEqual(["CTL-OK"]);
   });
 
+  test("PARTIAL / truncated marker files (interrupted write, full disk, kill -9) are dropped", () => {
+    // writeFileSync is not atomic, so a crash mid-write can leave a prefix of the
+    // JSON on disk. Every truncation point must read as "no evidence" rather than
+    // throwing or, worse, parsing into something that grants grace.
+    const full = JSON.stringify({ ticket: "CTL-T", claimedAt: 1699999999999 });
+    for (let cut = 1; cut < full.length; cut++) {
+      rmSync(claimsDir(), { recursive: true, force: true });
+      writeRaw("CTL-T", full.slice(0, cut));
+      const claims = readDelegateClaims(orchDir);
+      // A truncated prefix must never yield a usable claim. (The only way it could
+      // is if a prefix happened to be valid JSON with a numeric claimedAt — assert
+      // that never happens rather than assuming it.)
+      expect(`cut@${cut}: ${claims.has("CTL-T")}`).toBe(`cut@${cut}: false`);
+    }
+    // ...and the untruncated original is still accepted, so the loop above is
+    // proving truncation-rejection rather than a reader that rejects everything.
+    rmSync(claimsDir(), { recursive: true, force: true });
+    writeRaw("CTL-T", full);
+    expect(readDelegateClaims(orchDir).get("CTL-T")).toBe(1699999999999);
+  });
+
+  test("a zero-byte marker (file created, write never landed) is dropped", () => {
+    writeRaw("CTL-EMPTYFILE", "");
+    expect(readDelegateClaims(orchDir).has("CTL-EMPTYFILE")).toBe(false);
+  });
+
   test("a FUTURE-dated marker is returned as-is — the age check, not the reader, rejects it", () => {
     // Deliberate: the reader must not silently drop clock-skewed evidence, or the
     // invariant could not distinguish "skew" from "no evidence" in its census.

--- a/plugins/dev/scripts/execution-core/delegate-claims.test.mjs
+++ b/plugins/dev/scripts/execution-core/delegate-claims.test.mjs
@@ -53,10 +53,47 @@ describe("recordDelegateClaim", () => {
     expect(recordDelegateClaim(orchDir, null)).toBe(false);
   });
 
-  test("re-claiming overwrites with the newer timestamp", () => {
+  // CTC review (turn 113): FIRST-CLAIM-WINS. This test previously asserted the
+  // OPPOSITE (overwrite) and was therefore encoding the defect — an unconditional
+  // overwrite makes the grace window RENEWABLE, so `graceMs` stops being a bound
+  // on suppression and instead lasts as long as a re-claim loop does.
+  test("re-claiming does NOT extend the window — first claim wins", () => {
+    expect(recordDelegateClaim(orchDir, "CTL-1", { now: () => 1000 })).toBe(true);
+    expect(recordDelegateClaim(orchDir, "CTL-1", { now: () => 2000 })).toBe(false);
+    expect(recordDelegateClaim(orchDir, "CTL-1", { now: () => 9_999_999 })).toBe(false);
+    expect(readDelegateClaims(orchDir).get("CTL-1")).toBe(1000); // the REAL wait start
+  });
+
+  test("suppression stays bounded across an unbounded re-claim loop", () => {
+    // The invariant that actually constrains blast radius: no number of re-claims
+    // can slide the window forward, so a genuinely stuck ticket always exits grace
+    // graceMs after its FIRST claim regardless of tick rate or cache lag.
+    let clock = 1000;
+    recordDelegateClaim(orchDir, "CTL-STUCK", { now: () => clock });
+    for (let i = 0; i < 500; i++) {
+      clock += 2000; // 2s ticks, ~16 minutes of re-claiming
+      recordDelegateClaim(orchDir, "CTL-STUCK", { now: () => clock });
+    }
+    expect(readDelegateClaims(orchDir).get("CTL-STUCK")).toBe(1000);
+    // age is now the FULL elapsed span, not ~0 — so the grace check will reject it
+    expect(clock - readDelegateClaims(orchDir).get("CTL-STUCK")).toBe(1_000_000);
+  });
+
+  test("after clearDelegateClaim, the NEXT legitimate claim writes fresh", () => {
+    // first-claim-wins must not permanently pin a ticket to its first-ever claim:
+    // the dispatch path clears the marker, so a later cycle starts a new window.
     recordDelegateClaim(orchDir, "CTL-1", { now: () => 1000 });
-    recordDelegateClaim(orchDir, "CTL-1", { now: () => 2000 });
-    expect(readDelegateClaims(orchDir).get("CTL-1")).toBe(2000);
+    clearDelegateClaim(orchDir, "CTL-1");
+    expect(recordDelegateClaim(orchDir, "CTL-1", { now: () => 5000 })).toBe(true);
+    expect(readDelegateClaims(orchDir).get("CTL-1")).toBe(5000);
+  });
+
+  test("an existing MALFORMED marker is left alone (bounding beats refreshing)", () => {
+    // A malformed marker grants no grace anyway, so overwriting it would only
+    // reintroduce the sliding window for no benefit.
+    writeRaw("CTL-BADEXIST", "}{");
+    expect(recordDelegateClaim(orchDir, "CTL-BADEXIST", { now: () => 1000 })).toBe(false);
+    expect(readDelegateClaims(orchDir).has("CTL-BADEXIST")).toBe(false);
   });
 });
 

--- a/plugins/dev/scripts/execution-core/monitor.mjs
+++ b/plugins/dev/scripts/execution-core/monitor.mjs
@@ -26,6 +26,10 @@
 // missed-webhook backstop for all three handlers.
 
 import { watch, openSync, fstatSync, readSync, closeSync, mkdirSync, existsSync, readFileSync, writeFileSync, renameSync } from "node:fs";
+// CTL-1744: delegate-lands claim markers. A zero-import leaf so scheduler.mjs can
+// read them too without creating a scheduler↔monitor cycle (monitor already
+// imports scheduler). See delegate-claims.mjs for the full rationale.
+import { recordDelegateClaim, clearDelegateClaim } from "./delegate-claims.mjs";
 import { dirname, basename, join } from "node:path";
 import {
   getEventLogPath,
@@ -920,6 +924,11 @@ function dispatchTriage(
       // HELD this tick — it dispatches once the delegate lands in the cache
       // (webhook-projected). This is what gets queued-but-untriaged items moving.
       const d = applyAssignee({ ticket: identifier, userId: botWriteId });
+      // CTL-1744: stamp WHEN the claim was made, so board-health's
+      // dispatchLiveness can tell this legitimate two-pass wait from a wedge.
+      // Only on a confirmed apply — an unapplied claim is not a wait we should
+      // excuse, and stamping it anyway would suppress a real stall.
+      if (d.applied === true) recordDelegateClaim(orchDir, identifier);
       log.info(
         { identifier, applied: d.applied, reason: d.reason },
         "monitor: delegated to orchestrator — will dispatch once delegate lands (CTL-1174)"
@@ -1066,6 +1075,11 @@ function dispatchTriage(
   // retired above; the launcher short-circuits it). A dead-frozen "running"
   // signal is reset to stalled by the reclaim/revive path, after which counting
   // resumes; "failed"/"stalled" re-dispatches launch real workers and count.
+  // CTL-1744: the two-pass wait is over — this ticket is launching, so drop its
+  // delegate-claim marker. Pure housekeeping: a surviving marker would expire on
+  // its own once `now - claimedAt` passes graceMs, so this can never be
+  // load-bearing for correctness, only for keeping .delegate-claims/ bounded.
+  clearDelegateClaim(orchDir, identifier);
   const statusAtLaunch = readTriageSignalStatus(orchDir, identifier);
   if (!isTriageInFlight(statusAtLaunch) && statusAtLaunch !== "done") {
     bumpTriageDispatchCount(orchDir, identifier);

--- a/plugins/dev/scripts/execution-core/monitor.test.mjs
+++ b/plugins/dev/scripts/execution-core/monitor.test.mjs
@@ -2743,6 +2743,60 @@ describe("dispatchTriage — CTL-781 respect-assignment + self-assign", () => {
     expect(applyAssignee.mock.calls[0][0]).toMatchObject({ ticket: "ENG-N1", userId: BOT });
   });
 
+  // ── CTL-1744: the claim marker is stamped ONLY on a CONFIRMED delegate apply ──
+  //
+  // The marker is what buys a ticket dispatch-liveness grace, i.e. it SUPPRESSES a
+  // recovery signal. Stamping it for a delegate write that did not actually land
+  // would excuse a wait that never legitimately started, masking a real stall —
+  // so an unapplied (or ambiguously-applied) write must leave no marker at all.
+  //
+  // These use a REAL temp orchDir: recordDelegateClaim deliberately refuses to
+  // manufacture a missing orch dir, which is exactly why the literal "/orch-781"
+  // used by the tests above writes nothing and they stayed byte-identical.
+  describe("CTL-1744 delegate-claim marker", () => {
+    let realOrchDir;
+    const markerPath = (t) => join(realOrchDir, ".delegate-claims", `${t}.json`);
+    beforeEach(() => { realOrchDir = mkdtempSync(join(tmpdir(), "ctl1744-mon-")); });
+    afterEach(() => { rmSync(realOrchDir, { recursive: true, force: true }); });
+
+    const drive = (ticket, applyResult) => {
+      enroll("ENG", { status: "Ready" });
+      handleStateChangedEvent(toTriageEvent(ticket), {
+        dispatch: mock(() => ({ code: 0 })),
+        orchDir: realOrchDir,
+        botUserIds: new Set([BOT]),
+        botWriteId: BOT,
+        fetchAssignee: () => ({ known: true, assignee: null, delegate: null }),
+        applyAssignee: mock(() => applyResult),
+        triageBudget: { remaining: 5 },
+      });
+    };
+
+    test("applied:true → marker written with a usable numeric claimedAt", () => {
+      drive("ENG-OK", { applied: true, reason: null });
+      expect(existsSync(markerPath("ENG-OK"))).toBe(true);
+      const rec = JSON.parse(readFileSync(markerPath("ENG-OK"), "utf8"));
+      expect(rec.ticket).toBe("ENG-OK");
+      expect(typeof rec.claimedAt).toBe("number");
+      expect(Number.isFinite(rec.claimedAt)).toBe(true);
+      expect(rec.claimedAt).toBeGreaterThan(0);
+    });
+
+    test("UNAPPLIED delegate write → NO marker (an un-landed claim earns no grace)", () => {
+      for (const [label, result] of [
+        ["applied:false", { applied: false, reason: "linear write failed" }],
+        ["applied missing", { reason: "no transport" }],
+        ["applied:undefined", { applied: undefined }],
+        ["applied truthy-but-not-true", { applied: 1 }],
+        ["applied:'true' (string)", { applied: "true" }],
+      ]) {
+        const ticket = `ENG-NO-${label.replace(/[^A-Za-z0-9]/g, "")}`;
+        drive(ticket, result);
+        expect(`${label}: ${existsSync(markerPath(ticket))}`).toBe(`${label}: false`);
+      }
+    });
+  });
+
   test("→Triage DELEGATED to our orchestrator → dispatch fires (even if assignee is a human, CTL-1174)", () => {
     enroll("ENG", { status: "Ready" });
     const dispatch = mock(() => ({ code: 0 }));

--- a/plugins/dev/scripts/execution-core/scheduler.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.mjs
@@ -397,6 +397,7 @@ import { ownedBy, ownerForTicket } from "./hrw.mjs"; // CTL-850: HRW ownership f
 import { computeDispatchRoster, readDeflapState, writeDeflapState } from "./liveness-deflap.mjs"; // CTL-1091: restore-side deflap for the dispatch roster
 import { boardHealthPass, lookupPrStatus } from "./board-health.mjs"; // CTL-1290: the whole-board health delegate (shadow-first). CTL-1644 (Codex P2): lookupPrStatus reused for getStrandedEvidence's no-cross-repo-borrow PR resolution.
 import { readStalledPrState } from "./stalled-pr-timer.mjs"; // CTL-1608: aggregate workers/*/stalled-pr.json → Map for board-health
+import { readDelegateClaims } from "./delegate-claims.mjs"; // CTL-1744: orchDir/.delegate-claims/*.json → Map for the dispatch-liveness grace (zero-import leaf: monitor.mjs imports scheduler.mjs, so the reader cannot live there)
 import { readGithubQuota } from "./github-quota-timer.mjs";
 import { routeStuckTicketToDelegate } from "./delegate-first.mjs"; // CTL-1609: delegate-first escalation seam
 import {
@@ -6209,6 +6210,12 @@ export function schedulerTick(
           // The daemon binds this to read from the real orchDir; a bare tick passes
           // nothing → assembleBoardState defaults to () => new Map() (observable:false).
           getStalledPrState: _boardHealth.getStalledPrState ?? (() => readStalledPrState(orchDir)),
+          // CTL-1744: delegate-lands claim timestamps, so checkDispatchLiveness can
+          // tell the legitimate CTL-1174 two-pass wait from a genuine wedge. Reads
+          // orchDir/.delegate-claims/*.json (host-local, cheap, no network). A bare
+          // tick that passes neither gets assembleBoardState's empty-Map default →
+          // no ticket is granted grace → pre-CTL-1744 behavior exactly.
+          getDelegateClaims: _boardHealth.getDelegateClaims ?? (() => readDelegateClaims(orchDir)),
           getGithubQuota: _boardHealth.getGithubQuota ?? (() => readGithubQuota(orchDir)),
           githubQuotaMode: _boardHealth.githubQuotaMode ?? readGithubQuotaBoardHealthConfig().mode,
           getPeerProductivity:


### PR DESCRIPTION
## What changed

- Record a host-local delegate claim only after Linear confirms the delegate write was applied.
- Feed that evidence into board-health so the legitimate two-pass delegate-lands wait is not misclassified as a wedged board.
- Make claim creation atomic and first-claim-wins so repeated reclaims cannot renew the grace window.
- Clear the marker when dispatch starts; absent, malformed, partial, zero-byte, non-positive, or future-dated markers fail closed.

## Why

During the Coalesce Labs Linear cutover, the disposable P4 probe exposed a false board-health recovery: the first pass delegated the issue, but board-health could evaluate the queue before that delegate landed in the local projection. CTL-1744 gives that narrow wait bounded evidence without changing HRW ownership or masking a real wedge.

## Validation

- CTC and MIGRATION independently reviewed the implementation and invariants.
- bun test delegate-claims.test.mjs: 18 pass, 0 fail.
- bun test board-health.test.mjs plus delegate-claims.test.mjs: 254 pass, 0 fail.
- Integrated test proves 500 repeated reclaims do not extend grace and the real wedge alarm fires at graceMs + 1.
- Byte-preservation tests cover valid, malformed, and zero-byte collisions.
- One monitor seed-at-EOF test fails identically on the untouched origin/main baseline and is not introduced by this branch.

## Deployment gate

This PR does not restart execution-core, deploy the fix, or retry the live P4 probe. Those remain separately gated on CI, review, merge, deployment verification, and cutover consensus.