### PR TITLE
fix(dev): CTL-1764 handle async spawn 'error' so EAGAIN cannot kill the daemon

### DIFF
--- a/plugins/dev/scripts/execution-core/delegate-runner.mjs
+++ b/plugins/dev/scripts/execution-core/delegate-runner.mjs
@@ -153,6 +153,22 @@ export function startDelegateRunnerTimer({
           // correct queue even when the daemon's own env doesn't carry it.
           env: { ...process.env, CATALYST_EXECUTION_CORE_DIR: orchDir },
         });
+        // CTL-1764: a spawn FAILURE (EAGAIN/EMFILE/ENOMEM) is reported by an
+        // asynchronous 'error' event on the child, NOT by a synchronous throw —
+        // so neither the `finally` below nor the outer try/catch can see it. An
+        // unhandled 'error' on an EventEmitter is re-raised as a top-level
+        // uncaughtException, which is precisely how a transient EAGAIN killed the
+        // whole daemon twice in 18 minutes on 2026-08-11 while this call site
+        // *looked* guarded. Attaching a listener is what makes the failure
+        // catchable at all; the kick is best-effort and the next interval retries.
+        if (child && typeof child.on === "function") {
+          child.on("error", (err) => {
+            log.warn(
+              { err: err?.message, code: err?.code, entryPath },
+              "delegate-runner: spawn failed; skipping this kick"
+            );
+          });
+        }
         if (child && typeof child.unref === "function") child.unref();
       } finally {
         // (4) CTL-1519: close the PARENT's copy of the log fd. The detached

--- a/plugins/dev/scripts/execution-core/delegate-runner.test.mjs
+++ b/plugins/dev/scripts/execution-core/delegate-runner.test.mjs
@@ -33,6 +33,7 @@ import {
 } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { EventEmitter } from "node:events"; // CTL-1764: authentic unhandled-'error' semantics
 import { startDelegateRunnerTimer } from "./delegate-runner.mjs";
 import { drainOnce, resolveEffectiveDelegateExecutor } from "./delegate-runner-entry.mjs";
 import { DELEGATE_QUEUE_DIR, claimIntent } from "./delegate-queue.mjs";
@@ -674,6 +675,48 @@ function makeSpawnSpy() {
 }
 
 describe("startDelegateRunnerTimer — detached spawn().unref() kick", () => {
+  // CTL-1764 REGRESSION GUARD.
+  //
+  // A spawn FAILURE (EAGAIN/EMFILE/ENOMEM) is not a synchronous throw — Node
+  // reports it by emitting 'error' on the returned child, asynchronously. So the
+  // kick's `try { spawn } finally { closeLogFd }` and even the outer try/catch
+  // are both blind to it: an unhandled 'error' on an EventEmitter is re-raised as
+  // a top-level uncaughtException. That is exactly how a transient EAGAIN killed
+  // the execution-core daemon twice in 18 minutes on 2026-08-11, at a call site
+  // whose own comment claimed to handle "EAGAIN/EMFILE".
+  //
+  // Uses a REAL EventEmitter as the child so the semantics are authentic rather
+  // than mocked: with no listener attached, .emit("error") throws.
+  test("CTL-1764: an async spawn 'error' (EAGAIN) is handled, never re-raised", () => {
+    const clock = fakeClock();
+    let child = null;
+    const spawn = () => {
+      child = new EventEmitter();
+      child.unref = () => {};
+      return child;
+    };
+    startDelegateRunnerTimer({
+      enabled: true,
+      intervalMs: 15000,
+      orchDir,
+      entryPath: "/fake/delegate-runner-entry.mjs",
+      spawn,
+      clock,
+      isRunnerRunning: () => false,
+    });
+    clock.advance(15000);
+    expect(child).not.toBeNull();
+
+    const eagain = Object.assign(
+      new Error("EAGAIN: resource temporarily unavailable, posix_spawn '/path/to/bun'"),
+      { code: "EAGAIN", errno: -35, syscall: "spawn" }
+    );
+    // Pre-fix this THROWS (unhandled 'error' → uncaughtException → daemon exits).
+    expect(() => child.emit("error", eagain)).not.toThrow();
+    // And the timer survives: the next interval still kicks (best-effort retry).
+    expect(() => clock.advance(15000)).not.toThrow();
+  });
+
   test("each interval kicks the entry via spawn(process.execPath, [entry], {detached}).unref()", () => {
     const clock = fakeClock();
     const spy = makeSpawnSpy();


### PR DESCRIPTION
## Problem

The execution-core daemon died **twice in 18 minutes** during a live end-to-end pipeline run (2026-08-11, 15:10:16Z and 15:28:30Z), both times with the same fatal:

```
EAGAIN: resource temporarily unavailable, posix_spawn '/…/bun'
  at <anonymous> (execution-core/delegate-runner.mjs:148)
"execution-core daemon: uncaught exception — exiting"
```

Each death froze the entire pipeline — no dispatcher, in-flight phases stranded at `status: dispatched` with no worker, recovery gated behind launchd's 600 s `StartInterval`. Meanwhile Linear still said `Implement` and every health signal read green.

## Why the existing guards missed it

The call site *looks* defended — the spawn is inside `try { … } finally { closeLogFd }`, nested in an outer `try/catch`, and the `finally` comment explicitly claims to cover "the very error path" of `EAGAIN/EMFILE`.

That reasoning assumes `spawn()` throws **synchronously**. It doesn't. `child_process.spawn` reports a spawn failure by emitting **`'error'` on the returned child, asynchronously**. An unhandled `'error'` on an EventEmitter is re-raised as a top-level `uncaughtException`, which no surrounding `try`/`catch` can intercept.

So the guard was structurally incapable of catching the one error it named.

## Fix

Attach an `'error'` listener to the child. That is what makes the failure catchable at all. The kick is best-effort by design and the next 15 s interval retries, so a logged `warn` is the right response to a transient spawn failure.

## Test

A regression guard that uses a **real `EventEmitter`** as the child, so the semantics are authentic rather than mocked — with no listener attached, `.emit("error")` throws.

- **RED against HEAD**: fails with the EAGAIN propagating out of `emit()`
- **GREEN with the fix**
- Full `delegate-runner` suite: **39 pass / 0 fail**

## Scope

This stops a transient spawn failure from being fatal. It does **not** address why the host runs out of spawn capacity: the daemon spawns a fresh `bun` process every 15 s to drain an always-empty queue — **207,398 spawns in 47 days, zero of them productive** — tracked separately as **CTL-1769**. Safety-net and cause; both should land.

Refs CTL-1764.