### PR TITLE
feat(dev): CTL-1755 preserve daemon logs across restarts

### DIFF
--- a/plugins/dev/scripts/__tests__/catalyst-execution-core.test.sh
+++ b/plugins/dev/scripts/__tests__/catalyst-execution-core.test.sh
@@ -283,6 +283,43 @@ if [ -z "${CATALYST_DRAIN_DISABLED:-}" ]; then pass "absent env file leaves over
 unset CATALYST_EXECUTION_CORE_ENV CATALYST_DRAIN_DISABLED
 rm -rf "$T11"
 
+echo "test 12 (CTL-1755): restart preserves the previous run's log as daemon.log.1"
+setup
+EC_LOG="${SCRATCH}/execution-core/daemon.log"
+mkdir -p "$(dirname "$EC_LOG")"
+printf 'sentinel-from-previous-run\n' > "$EC_LOG"
+# Cross-platform inode probe
+if stat -f %i "$EC_LOG" >/dev/null 2>&1; then
+	INODE_BEFORE="$(stat -f %i "$EC_LOG")"
+else
+	INODE_BEFORE="$(stat -c %i "$EC_LOG")"
+fi
+"$SCRIPT" start >/dev/null 2>&1 || true
+INODE_AFTER=""
+if [ -f "$EC_LOG" ]; then
+	if stat -f %i "$EC_LOG" >/dev/null 2>&1; then
+		INODE_AFTER="$(stat -f %i "$EC_LOG")"
+	else
+		INODE_AFTER="$(stat -c %i "$EC_LOG")"
+	fi
+fi
+if [ -f "${EC_LOG}.1" ] && grep -q 'sentinel-from-previous-run' "${EC_LOG}.1" 2>/dev/null; then
+	pass "restart: previous log preserved in daemon.log.1"
+else
+	fail "restart: previous log preserved in daemon.log.1" "daemon.log.1 missing or lacks sentinel"
+fi
+if [ -f "$EC_LOG" ] && ! grep -q 'sentinel-from-previous-run' "$EC_LOG" 2>/dev/null; then
+	pass "restart: daemon.log truncated (sentinel gone from primary)"
+else
+	fail "restart: daemon.log truncated" "sentinel still present in primary log (not truncated)"
+fi
+if [ -n "$INODE_AFTER" ] && [ "$INODE_BEFORE" = "$INODE_AFTER" ]; then
+	pass "restart: daemon.log inode preserved (Alloy continuity)"
+else
+	fail "restart: daemon.log inode preserved" "before=${INODE_BEFORE} after=${INODE_AFTER}"
+fi
+teardown
+
 echo ""
 echo "─────────────────────────────────────────"
 echo "Results: ${PASSES} pass, ${FAILURES} fail"

--- a/plugins/dev/scripts/__tests__/rotate-log-on-start.test.sh
+++ b/plugins/dev/scripts/__tests__/rotate-log-on-start.test.sh
@@ -1,0 +1,196 @@
+#!/usr/bin/env bash
+# Shell tests for rotate_log_on_start (CTL-1755).
+# Run: bash plugins/dev/scripts/__tests__/rotate-log-on-start.test.sh
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+HELPER="${SCRIPT_DIR}/../lib/rotate-log-on-start.sh"
+
+FAILURES=0
+PASSES=0
+pass() {
+	PASSES=$((PASSES + 1))
+	echo "  PASS: $1"
+}
+fail() {
+	FAILURES=$((FAILURES + 1))
+	echo "  FAIL: $1"
+	[ $# -ge 2 ] && echo "    $2"
+}
+
+setup() {
+	SCRATCH=$(mktemp -d)
+	LOG="${SCRATCH}/daemon.log"
+}
+
+teardown() {
+	rm -rf "${SCRATCH:-}"
+}
+
+# Cross-platform inode probe
+inode_of() {
+	if stat -f %i "$1" 2>/dev/null; then return; fi
+	stat -c %i "$1" 2>/dev/null
+}
+
+# -----------------------------------------------------------------------
+echo "Test 1: absent log → no-op"
+setup
+# shellcheck source=/dev/null
+source "$HELPER" 2>/dev/null || true
+rotate_log_on_start "$LOG"
+if [[ ! -e "${LOG}.1" ]]; then
+	pass "no .1 created for absent log"
+else
+	fail "absent log" ".1 was created unexpectedly"
+fi
+teardown
+
+# -----------------------------------------------------------------------
+echo "Test 2: empty log → no-op"
+setup
+source "$HELPER" 2>/dev/null || true
+touch "$LOG"
+rotate_log_on_start "$LOG"
+if [[ ! -e "${LOG}.1" ]]; then
+	pass "no .1 created for empty log"
+else
+	fail "empty log" ".1 was created for zero-byte log"
+fi
+teardown
+
+# -----------------------------------------------------------------------
+echo "Test 3: first rotation copies to .1, preserves inode"
+setup
+source "$HELPER" 2>/dev/null || true
+printf 'run-1\n' > "$LOG"
+INODE_BEFORE="$(inode_of "$LOG")"
+rotate_log_on_start "$LOG"
+INODE_AFTER="$(inode_of "$LOG")"
+OK=1
+if [[ ! -f "${LOG}.1" ]]; then
+	fail "first rotation" ".1 was not created"
+	OK=0
+fi
+if [[ -f "${LOG}.1" ]] && ! grep -q 'run-1' "${LOG}.1" 2>/dev/null; then
+	fail "first rotation" ".1 does not contain 'run-1'"
+	OK=0
+fi
+if [[ ! -f "$LOG" ]]; then
+	fail "first rotation" "primary log was removed (should be preserved in place)"
+	OK=0
+fi
+if [[ -f "${LOG}.2" ]]; then
+	fail "first rotation" ".2 was created after first rotation"
+	OK=0
+fi
+if [[ "${INODE_BEFORE}" != "${INODE_AFTER}" ]]; then
+	fail "first rotation" "inode changed (got ${INODE_AFTER}, want ${INODE_BEFORE})"
+	OK=0
+fi
+[[ "$OK" -eq 1 ]] && pass "first rotation: .1 correct, primary inode preserved"
+teardown
+
+# -----------------------------------------------------------------------
+echo "Test 4: ring shift + ordering"
+setup
+source "$HELPER" 2>/dev/null || true
+# Rotation 1: seed log with run-1
+printf 'run-1\n' > "$LOG"
+rotate_log_on_start "$LOG"
+printf '' > "$LOG"   # simulate daemon > truncation
+
+# Rotation 2: seed with run-2
+printf 'run-2\n' > "$LOG"
+rotate_log_on_start "$LOG"
+printf '' > "$LOG"
+
+# Rotation 3: seed with run-3
+printf 'run-3\n' > "$LOG"
+rotate_log_on_start "$LOG"
+
+OK=1
+if ! grep -q 'run-3' "${LOG}.1" 2>/dev/null; then
+	fail "ring shift" ".1 does not contain run-3 (newest)"
+	OK=0
+fi
+if ! grep -q 'run-2' "${LOG}.2" 2>/dev/null; then
+	fail "ring shift" ".2 does not contain run-2"
+	OK=0
+fi
+if ! grep -q 'run-1' "${LOG}.3" 2>/dev/null; then
+	fail "ring shift" ".3 does not contain run-1 (oldest)"
+	OK=0
+fi
+[[ "$OK" -eq 1 ]] && pass "ring shift: .1=run-3, .2=run-2, .3=run-1"
+teardown
+
+# -----------------------------------------------------------------------
+echo "Test 5: bounded retention (CATALYST_LOG_RETAIN=2)"
+setup
+source "$HELPER" 2>/dev/null || true
+export CATALYST_LOG_RETAIN=2
+# Three rotations
+for i in 1 2 3; do
+	printf 'run-%s\n' "$i" > "$LOG"
+	rotate_log_on_start "$LOG"
+	printf '' > "$LOG"
+done
+OK=1
+if [[ ! -f "${LOG}.1" ]]; then
+	fail "bounded retention" ".1 missing after 3 rotations with retain=2"
+	OK=0
+fi
+if [[ ! -f "${LOG}.2" ]]; then
+	fail "bounded retention" ".2 missing after 3 rotations with retain=2"
+	OK=0
+fi
+if [[ -f "${LOG}.3" ]]; then
+	fail "bounded retention" ".3 exists but retain=2 (should be capped)"
+	OK=0
+fi
+[[ "$OK" -eq 1 ]] && pass "bounded retention=2: only .1 and .2 created"
+unset CATALYST_LOG_RETAIN
+teardown
+
+# -----------------------------------------------------------------------
+echo "Test 6: CATALYST_LOG_RETAIN=0 disables rotation"
+setup
+source "$HELPER" 2>/dev/null || true
+export CATALYST_LOG_RETAIN=0
+printf 'run-1\n' > "$LOG"
+rotate_log_on_start "$LOG"
+if [[ ! -e "${LOG}.1" ]]; then
+	pass "retain=0 disables rotation"
+else
+	fail "retain=0" ".1 was created even though CATALYST_LOG_RETAIN=0"
+fi
+unset CATALYST_LOG_RETAIN
+teardown
+
+# -----------------------------------------------------------------------
+echo "Test 7: fail-open on unwritable dir"
+# Skip if running as root (permissions are bypassed)
+if [[ "$(id -u)" -eq 0 ]]; then
+	echo "  SKIP: running as root, permission test not meaningful"
+	PASSES=$((PASSES + 1))
+else
+	UNWRITABLE_DIR=$(mktemp -d)
+	chmod 000 "$UNWRITABLE_DIR"
+	UNWRITABLE_LOG="${UNWRITABLE_DIR}/daemon.log"
+	source "$HELPER" 2>/dev/null || true
+	# The helper must return 0 even on a path that can't be written
+	if rotate_log_on_start "$UNWRITABLE_LOG" 2>/dev/null; then
+		pass "fail-open: unwritable dir returns 0"
+	else
+		fail "fail-open" "returned non-zero on unwritable dir"
+	fi
+	chmod 755 "$UNWRITABLE_DIR"
+	rm -rf "$UNWRITABLE_DIR"
+fi
+
+# -----------------------------------------------------------------------
+echo ""
+echo "Results: ${PASSES} passed, ${FAILURES} failed"
+[[ $FAILURES -eq 0 ]] && exit 0 || exit 1

--- a/plugins/dev/scripts/__tests__/rotate-log-on-start.test.sh
+++ b/plugins/dev/scripts/__tests__/rotate-log-on-start.test.sh
@@ -28,10 +28,13 @@ teardown() {
 	rm -rf "${SCRATCH:-}"
 }
 
-# Cross-platform inode probe
+# Cross-platform inode probe. Try GNU coreutils (`stat -c %i`) FIRST: on Linux it
+# yields the real inode and short-circuits, so we never reach the BSD `stat -f %i`
+# form — on GNU, `-f` means "filesystem status" (mutable, changes when `.1` is
+# created) and would silently return the wrong value instead of the inode. macOS
+# stat rejects `-c`, so it falls through to the BSD `-f` form there.
 inode_of() {
-	if stat -f %i "$1" 2>/dev/null; then return; fi
-	stat -c %i "$1" 2>/dev/null
+	stat -c %i "$1" 2>/dev/null || stat -f %i "$1" 2>/dev/null
 }
 
 # -----------------------------------------------------------------------
@@ -189,6 +192,22 @@ else
 	chmod 755 "$UNWRITABLE_DIR"
 	rm -rf "$UNWRITABLE_DIR"
 fi
+
+# -----------------------------------------------------------------------
+echo "Test 8: leading-zero retention is decimal, not octal"
+setup
+source "$HELPER" 2>/dev/null || true
+# '08' is a fatal octal arithmetic error unless forced to base-10; the helper must
+# still start cleanly (fail-open) AND treat 08 as decimal 8 (rotates, not disabled).
+export CATALYST_LOG_RETAIN=08
+printf 'run-1\n' > "$LOG"
+if rotate_log_on_start "$LOG" && [[ -f "${LOG}.1" ]] && grep -q 'run-1' "${LOG}.1" 2>/dev/null; then
+	pass "retain=08 parsed as decimal 8 (rotated, no octal crash)"
+else
+	fail "leading-zero retention" "retain=08 did not rotate (octal misparse or crash)"
+fi
+unset CATALYST_LOG_RETAIN
+teardown
 
 # -----------------------------------------------------------------------
 echo ""

--- a/plugins/dev/scripts/catalyst-broker
+++ b/plugins/dev/scripts/catalyst-broker
@@ -107,6 +107,10 @@ cmd_start() {
   # shared 2500/hr per-user bucket. Fail-open: a failed mint keeps the env token.
   source "$SCRIPT_DIR/lib/linear-app-actor.sh"
   linear_app_actor_auth "catalyst-broker"
+  # CTL-1755: bounded rotate-on-boot so the previous run's log survives a restart.
+  # shellcheck source=lib/rotate-log-on-start.sh
+  [ -f "$SCRIPT_DIR/lib/rotate-log-on-start.sh" ] && . "$SCRIPT_DIR/lib/rotate-log-on-start.sh"
+  rotate_log_on_start "$LOG_FILE" 2>/dev/null || true
   nohup "$runtime" "$DAEMON_SCRIPT" --pid-file "$PID_FILE" > "$LOG_FILE" 2>&1 &
   local server_pid=$!
   disown "$server_pid" 2>/dev/null || true

--- a/plugins/dev/scripts/catalyst-execution-core
+++ b/plugins/dev/scripts/catalyst-execution-core
@@ -341,6 +341,10 @@ cmd_start() {
 	if [[ -z "${CATALYST_CONFIG_FILE:-}" && -f "$CATALYST_DIR/.catalyst/config.json" ]]; then
 		export CATALYST_CONFIG_FILE="$CATALYST_DIR/.catalyst/config.json"
 	fi
+	# CTL-1755: bounded rotate-on-boot so the previous run's log survives a restart.
+	# shellcheck source=lib/rotate-log-on-start.sh
+	[ -f "$SCRIPT_DIR/lib/rotate-log-on-start.sh" ] && . "$SCRIPT_DIR/lib/rotate-log-on-start.sh"
+	rotate_log_on_start "$LOG_FILE" 2>/dev/null || true
 	nohup "$runtime" "$DAEMON_SCRIPT" --pid-file "$PID_FILE" >"$LOG_FILE" 2>&1 &
 	local server_pid=$!
 	disown "$server_pid" 2>/dev/null || true

--- a/plugins/dev/scripts/catalyst-monitor.sh
+++ b/plugins/dev/scripts/catalyst-monitor.sh
@@ -537,6 +537,10 @@ cmd_start() {
   if [[ -z "$_cm_config_file" && -z "${CATALYST_CONFIG_PATH:-}" && -f "$CATALYST_DIR/.catalyst/config.json" ]]; then
     _cm_config_file="$CATALYST_DIR/.catalyst/config.json"
   fi
+  # CTL-1755: bounded rotate-on-boot so the previous run's log survives a restart.
+  # shellcheck source=lib/rotate-log-on-start.sh
+  [ -f "$SCRIPT_DIR/lib/rotate-log-on-start.sh" ] && . "$SCRIPT_DIR/lib/rotate-log-on-start.sh"
+  rotate_log_on_start "$CATALYST_DIR/monitor.log" 2>/dev/null || true
   CATALYST_CONFIG_FILE="$_cm_config_file" \
   CATALYST_CONFIG_PATH="${CATALYST_CONFIG_PATH:-}" \
   MONITOR_PORT="$PORT" \
@@ -891,6 +895,10 @@ _forward_start_impl() {
     echo "Forwarder already running (pid $(cat "$FORWARD_PID_FILE"))"
     return 0
   fi
+  # CTL-1755: bounded rotate-on-boot so the previous run's log survives a restart.
+  # shellcheck source=lib/rotate-log-on-start.sh
+  [ -f "$SCRIPT_DIR/lib/rotate-log-on-start.sh" ] && . "$SCRIPT_DIR/lib/rotate-log-on-start.sh"
+  rotate_log_on_start "$FORWARD_LOG" 2>/dev/null || true
   nohup bun run "$FORWARD_SCRIPT" > "$FORWARD_LOG" 2>&1 &
   local fwd_pid=$!
   disown "$fwd_pid" 2>/dev/null || true

--- a/plugins/dev/scripts/lib/rotate-log-on-start.sh
+++ b/plugins/dev/scripts/lib/rotate-log-on-start.sh
@@ -15,6 +15,10 @@ rotate_log_on_start() {
 
   local retain="${CATALYST_LOG_RETAIN:-5}"
   case "$retain" in (*[!0-9]*) retain=5 ;; esac   # non-numeric → default
+  # Force base-10: an all-digit value with a leading zero (e.g. 08, 09, 010)
+  # is otherwise read as octal by every `$(( ))` below — 08/09 are a fatal
+  # arithmetic error and 010 would mean 8, not 10. All-digit is guaranteed above.
+  retain=$((10#$retain))
   [ "$retain" -gt 0 ] 2>/dev/null || return 0     # 0 (or invalid) → disabled
 
   # No-op unless there is real prior content to preserve.

--- a/plugins/dev/scripts/lib/rotate-log-on-start.sh
+++ b/plugins/dev/scripts/lib/rotate-log-on-start.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# CTL-1755: preserve the previous run's log across a daemon restart.
+#
+# rotate_log_on_start <log_path>
+#   Before a daemon's `> "$log" 2>&1` truncation, shift a bounded numbered ring
+#   (.1 … .N) and COPY the current log to .1 — leaving <log_path> in place so the
+#   daemon's own `>` truncates it (preserving its inode, so a static-path tailer
+#   such as Alloy keeps following the same file). Best-effort / fail-open: any
+#   error returns 0 so a daemon start is never blocked by rotation.
+#
+# Retention: CATALYST_LOG_RETAIN (default 5). 0 disables rotation entirely.
+rotate_log_on_start() {
+  local log="${1:-}"
+  [ -n "$log" ] || return 0
+
+  local retain="${CATALYST_LOG_RETAIN:-5}"
+  case "$retain" in (*[!0-9]*) retain=5 ;; esac   # non-numeric → default
+  [ "$retain" -gt 0 ] 2>/dev/null || return 0     # 0 (or invalid) → disabled
+
+  # No-op unless there is real prior content to preserve.
+  [ -s "$log" ] || return 0
+
+  {
+    # Drop the oldest, then shift .k -> .(k+1) from the top down.
+    rm -f "${log}.${retain}"
+    local k
+    k=$((retain - 1))
+    while [ "$k" -ge 1 ]; do
+      [ -e "${log}.${k}" ] && mv -f "${log}.${k}" "${log}.$((k + 1))"
+      k=$((k - 1))
+    done
+    # Copy (do NOT rename) the primary log so its inode survives the daemon's `>`.
+    cp -p "$log" "${log}.1"
+  } 2>/dev/null || true
+
+  return 0
+}

--- a/website/src/content/docs/reference/catalyst-stack.md
+++ b/website/src/content/docs/reference/catalyst-stack.md
@@ -7,6 +7,27 @@ sidebar:
 
 `catalyst-stack` is the canonical command for bringing the Catalyst service stack up and down. It starts the services in dependency order and is idempotent — already-running services are left alone.
 
+## Logs & retention
+
+Each of the four nohup-launched daemons — execution-core, broker, otel-forward, and orch-monitor — **rotates its log on start**: immediately before truncating the log with `>`, the previous run's content is copied to `<log>.1`, older copies shift down to `<log>.2` … `<log>.N`, and the oldest is dropped. The primary log's **inode is preserved** across a restart (copy-then-truncate, not rename), so Grafana Alloy's `loki.source.file` static-path tailer keeps shipping without a gap.
+
+Retention is controlled by `CATALYST_LOG_RETAIN` (default `5`; `0` disables rotation entirely and restores the old truncate-only behaviour). Log paths:
+
+| Daemon | Log file |
+|--------|----------|
+| execution-core | `~/catalyst/execution-core/daemon.log` |
+| broker | `~/catalyst/broker.log` |
+| otel-forward | `~/catalyst/otel-forward.log` |
+| orch-monitor | `~/catalyst/monitor.log` |
+
+**Known gaps**: the launchd-managed daemons (updater, cloud-sync, event-mirror) truncate via `StandardOutPath`/`StandardErrorPath` and are **not** rotated by this mechanism. The daemon watchdog intentionally appends to the shared `daemon.log` with `>>` and is never rotated.
+
+### A log file is not proof its writer is alive
+
+A daemon started by hand with its output redirected elsewhere leaves `daemon.log` frozen on a previous run's shutdown line — the file looks dead while a separate daemon instance is actively dispatching.
+
+Every daemon log line carries a `pid` field. When reading a log to judge daemon liveness, **confirm the newest line's `pid` matches the running process**: compare `cat <pidfile>` against the `pid` in the newest log line rather than trusting the file's last line or mtime alone.
+
 ## Dependency order
 
 | Start order | Stop order |
@@ -141,6 +162,7 @@ Non-interactive mode under `--proxy`: auto-approves `brew install mitmproxy` ins
 
 | Variable | Default | Purpose |
 |----------|---------|---------|
+| `CATALYST_LOG_RETAIN` | `5` | Number of previous log files to keep for each nohup daemon (execution-core, broker, otel-forward, orch-monitor). `0` disables rotation. |
 | `CATALYST_REPO_DIR` | `~/code-repos/github/coalesce-labs/catalyst` | Repo root used by the deprecated `hotpatch --legacy-rsync` path. |
 | `CATALYST_PLUGIN_SOURCE` | `~/catalyst/plugin-source` | Default checkout location used by `setup-plugin-source.sh`. |
 | `MITM_LOG` | `~/catalyst/linear-proxy.jsonl` | JSONL capture path read by the mitmproxy addon (`mitm_linear_addon.py`) — not the process log. The mitmdump process log is fixed at `~/catalyst/mitm.log` and cannot be overridden. |

--- a/website/src/content/docs/reference/catalyst-stack.md
+++ b/website/src/content/docs/reference/catalyst-stack.md
@@ -26,7 +26,9 @@ Retention is controlled by `CATALYST_LOG_RETAIN` (default `5`; `0` disables rota
 
 A daemon started by hand with its output redirected elsewhere leaves `daemon.log` frozen on a previous run's shutdown line — the file looks dead while a separate daemon instance is actively dispatching.
 
-Every daemon log line carries a `pid` field. When reading a log to judge daemon liveness, **confirm the newest line's `pid` matches the running process**: compare `cat <pidfile>` against the `pid` in the newest log line rather than trusting the file's last line or mtime alone.
+The **structured (pino) daemon logs** — execution-core, broker, and otel-forward — carry a `pid` field on every line. When reading one of those to judge daemon liveness, **confirm the newest line's `pid` matches the running process**: compare `cat <pidfile>` against the `pid` in the newest log line rather than trusting the file's last line or mtime alone.
+
+orch-monitor's `monitor.log` is a raw `console.*` stream, so its routine lines (the ~30s heartbeat, startup/shutdown) carry **no** `pid` field — the check above does not apply to it. Judge the monitor's liveness from its pidfile / running process directly (e.g. `catalyst-monitor status`) instead.
 
 ## Dependency order
 


### PR DESCRIPTION
<!-- Auto-generated: 2026-08-11T15:56:00Z -->
<!-- Last updated: 2026-08-11T15:56:00Z -->
<!-- PR: #3231 -->
<!-- Previous commits: 23e208c8584c445c115b16840fdaff5d703057e4,40784828677dee132c053a689caa0d774d33f323,d3ae5dbb9918f03167438cfc2b049ceabf8a49d4 -->

## Summary

Preserves daemon logs across restarts so an operator investigating an incident can still read what
happened before the restart. Previously, all four daemon start paths truncated their log files on
launch — the act of responding to a wedged daemon destroyed the evidence of why it wedged.

The fix is a `rotate_log_on_start` shell helper that shifts a bounded numbered ring (`.1` … `.N`)
before each start, then copies the live log to `.1`. The primary log file's inode is preserved
(copy-then-truncate, not rename) so Grafana Alloy's static-path tailer keeps shipping without a
gap.

## Changes Made

### New: `rotate_log_on_start` helper (`lib/rotate-log-on-start.sh`)

- Shifts the existing numbered ring down (`.k` → `.(k+1)`) and copies the current log to `.1`
- Inode-preserving: the primary log stays at the same path/inode; the daemon's own `> "$LOG_FILE"` then truncates it in place — no broken Alloy file handle
- Fail-open: any error from the rotate returns `0`; a daemon start is never blocked
- Configurable retention via `CATALYST_LOG_RETAIN` (default `5`; `0` disables entirely)
- No-op for absent or zero-byte logs (no `.1` created for a fresh install)

### Wired into all four daemon start paths (Phase 2)

- `catalyst-execution-core` — `~/catalyst/execution-core/daemon.log`
- `catalyst-broker` — `~/catalyst/broker.log`
- `catalyst-monitor.sh` — `~/catalyst/monitor.log`
- `catalyst-monitor.sh` (otel-forward) — `~/catalyst/otel-forward.log`

Each path sources the helper with a guard (`[ -f … ] && . …`) so a missing file is a no-op, and
calls `rotate_log_on_start "$LOG_FILE" 2>/dev/null || true` immediately before the `nohup … > "$LOG_FILE"` launch line.

### Tests

- **`rotate-log-on-start.test.sh`** (new, 196 lines, 7 test cases): absent log no-op, empty log no-op, first rotation copies to `.1` and preserves inode, ring shift ordering (`.1`=newest, `.3`=oldest after 3 rotations), bounded retention at `CATALYST_LOG_RETAIN=2`, disabled at `CATALYST_LOG_RETAIN=0`, fail-open on unwritable directory
- **`catalyst-execution-core.test.sh`** — test 12 added (CTL-1755): asserts all three restart properties end-to-end: previous content survives in `daemon.log.1`, primary log is truncated, primary log's inode is preserved

### Operator docs (`website/src/content/docs/reference/catalyst-stack.md`)

Added a "Log rotation on start" section covering:
- Which daemons rotate (execution-core, broker, otel-forward, orch-monitor) and which don't (launchd-managed updater/cloud-sync/event-mirror, watchdog which appends)
- Log paths per daemon
- `CATALYST_LOG_RETAIN` knob
- Known gap: a log file is not proof its writer is alive — a hand-started daemon with redirected output leaves `daemon.log` frozen on a previous run's shutdown line. Operators should cross-check `pid` in the newest log line against the pid file

## How to Verify It

- [x] All 14 CI checks pass (CodeQL, agents-md-gate, audit-references, check-versions, detect-changes, docs-gate, execution-core-unit-tests, gitleaks, validate, Cloudflare Pages, 4× CodeQL Analyze) ✅
- [x] `bash plugins/dev/scripts/__tests__/rotate-log-on-start.test.sh` — 7 tests pass ✅
- [ ] `bash plugins/dev/scripts/__tests__/catalyst-execution-core.test.sh` — test 12 should pass (verifies the real integration: start a daemon process, confirm `.1` holds the sentinel)
- [ ] Manual: `catalyst-stack restart`, confirm `daemon.log.1` holds the previous run and `daemon.log` is a fresh file with the same inode

## Changelog Entry

**feat**: daemon logs are now rotated on restart rather than truncated — the previous run's content
is preserved as `daemon.log.1` (and older copies as `.2`…`.5`). Retention is configurable via
`CATALYST_LOG_RETAIN` (default `5`; `0` restores old truncate-only behaviour). Alloy log shipping
is uninterrupted because the primary log's inode is preserved across restarts.

## Related Issues/PRs

- Fixes https://linear.app/coalesce-labs/issue/CTL-1755