### PR TITLE
fix(dev): CTL-1777 — fix write_phase_thoughts_doc under zsh (rename local path vars + static lint)

### DIFF
--- a/plugins/dev/scripts/__tests__/catalyst-version.test.sh
+++ b/plugins/dev/scripts/__tests__/catalyst-version.test.sh
@@ -177,6 +177,30 @@ else
   echo "  SKIP: t10 (catalyst-events not executable)"
 fi
 
+# ── 11. zsh source-safety: _cv_real_path resolves symlink identically under zsh (CTL-1777) ───
+# Under zsh, `local path` in _cv_real_path clobbers $PATH → readlink and
+# related utilities become unresolvable → function returns raw input instead
+# of the canonical path. Skip if zsh is absent.
+echo ""
+echo "Test 11: _cv_real_path symlink result matches bash under zsh (CTL-1777)"
+if command -v zsh >/dev/null 2>&1; then
+  _t11_dir="$(mktemp -d)"
+  touch "$_t11_dir/target.txt"
+  ln -s "$_t11_dir/target.txt" "$_t11_dir/link.txt"
+  _bash_rp="$(bash -c "source '$HELPER'; _cv_real_path '$_t11_dir/link.txt'")"
+  _zsh_rp="$(zsh -c "source '$HELPER'; _cv_real_path '$_t11_dir/link.txt'" 2>/dev/null)"
+  rm -rf "$_t11_dir"
+  if [[ -n "$_bash_rp" && "$_bash_rp" == "$_zsh_rp" ]]; then
+    PASSES=$((PASSES + 1)); echo "  PASS: t11: zsh _cv_real_path matches bash ($_bash_rp)"
+  else
+    FAILURES=$((FAILURES + 1)); echo "  FAIL: t11: zsh _cv_real_path mismatch"
+    echo "    bash: $_bash_rp"
+    echo "    zsh:  $_zsh_rp"
+  fi
+else
+  echo "  SKIP: t11 (zsh not installed)"
+fi
+
 echo ""
 echo "Results: ${PASSES} passed, ${FAILURES} failed"
 [[ "$FAILURES" -eq 0 ]] || exit 1

--- a/plugins/dev/scripts/__tests__/phase-skill-thoughts-doc.test.sh
+++ b/plugins/dev/scripts/__tests__/phase-skill-thoughts-doc.test.sh
@@ -184,6 +184,62 @@ else
 fi
 
 # --------------------------------------------------------------------------
+# CTL-1777 regression: write_phase_thoughts_doc must work under BOTH bash and
+# zsh. Under zsh, `local path` clobbers $PATH (zsh special array), making `tr`
+# and `date` unresolvable → DOC empty → gate miss → artifact_not_gate_visible.
+# Skips zsh rows (not a failure) when zsh is absent on the host.
+# --------------------------------------------------------------------------
+echo ""
+echo "=== multi-shell: write_phase_thoughts_doc gate-visible under bash + zsh (CTL-1777) ==="
+
+_WRITER="${REPO_ROOT}/plugins/dev/scripts/lib/write-phase-thoughts-doc.sh"
+_GATE="${REPO_ROOT}/plugins/dev/scripts/lib/phase-artifact-gate.sh"
+
+for _shell in bash zsh; do
+  if ! command -v "$_shell" >/dev/null 2>&1; then
+    echo "  SKIP: ${_shell} not installed on this host"
+    continue
+  fi
+  for _skill in phase-triage phase-verify phase-review phase-pr phase-monitor-merge phase-monitor-deploy; do
+    _phase="${_skill#phase-}"
+    echo ""
+    echo "--- ${_shell}/${_skill} (phase=${_phase}) ---"
+    _tmp="$(mktemp -d)"
+    _gate_result="$(
+      cd "$_tmp" || exit 3
+      "$_shell" -c "
+        source '$_WRITER' || exit 3
+        source '$_GATE' || exit 3
+        write_phase_thoughts_doc '$_phase' 'CTL-9999' 'body-for-${_phase}'
+        printf 'DOC=%s\n' \"\${CATALYST_PHASE_THOUGHTS_DOC:-}\"
+        if match_thoughts_artifact \"\$(own_thoughts_artifact_dir_for_phase '$_phase')\" CTL-9999 >/dev/null 2>&1; then
+          echo GATE_OK
+        else
+          echo GATE_MISS
+        fi
+      " 2>/dev/null
+    )"
+    rm -rf "$_tmp"
+    echo "Test: ${_shell}/${_skill} — DOC non-empty"
+    _doc_line="$(printf '%s' "$_gate_result" | grep '^DOC=')"
+    _doc_val="${_doc_line#DOC=}"
+    if [[ -n "$_doc_val" ]]; then
+      pass "${_shell}/${_skill} DOC non-empty (${_doc_val})"
+    else
+      fail "${_shell}/${_skill} DOC is empty — CATALYST_PHASE_THOUGHTS_DOC not set" \
+        "(result: ${_gate_result})"
+    fi
+    echo "Test: ${_shell}/${_skill} — gate visible"
+    if printf '%s' "$_gate_result" | grep -q '^GATE_OK$'; then
+      pass "${_shell}/${_skill} gate visible"
+    else
+      fail "${_shell}/${_skill} gate MISS — artifact not gate-visible" \
+        "(result: ${_gate_result})"
+    fi
+  done
+done
+
+# --------------------------------------------------------------------------
 echo ""
 echo "─────────────────────────────────────────────"
 echo "phase-skill-thoughts-doc: ${PASSES} passed, ${FAILURES} failed"

--- a/plugins/dev/scripts/__tests__/zsh-safe-locals.test.sh
+++ b/plugins/dev/scripts/__tests__/zsh-safe-locals.test.sh
@@ -49,26 +49,22 @@ check_line_for_specials() {
   local stripped="${line#"${line%%[![:space:]]*}"}"
   # Skip pure comment lines.
   [[ "${stripped:0:1}" == "#" ]] && return 0
-  # Skip lines where '#' appears before any local/typeset keyword.
-  # We only care about `local `  or `typeset ` (with trailing space).
-  local before_keyword=""
-  case "$line" in
-    *"local "*|*"typeset "*)
-      # Extract everything before the first occurrence of local/typeset.
-      # Hack: remove from 'local '/'typeset ' onwards and check if '#' is in what's left.
-      before_keyword="${line%%local *}"
-      case "$before_keyword" in *"#"*) return 0;; esac
-      before_keyword="${line%%typeset *}"
-      case "$before_keyword" in *"#"*) return 0;; esac
-      ;;
-    *) return 0 ;;
-  esac
+  # Normalize tabs to spaces so a tab-separated declaration (`local\tpath`) is
+  # detected the same as a space-separated one, then strip any trailing inline
+  # comment (from the first ` #`). Stripping the comment BEFORE keyword
+  # detection closes two holes at once (CTL-1777 phase-review remediation):
+  #  - false-negative: `local path="$1"  # note` previously slipped through
+  #    because a `#` anywhere on the line short-circuited the scan.
+  #  - false-positive: a `#`-comment that merely mentions a special name (or
+  #    the keyword) can no longer be mistaken for a declaration.
+  local norm="${line//$'\t'/ }"
+  local nocomment="${norm%% #*}"
 
-  # Extract rest after 'local '/'typeset '.
+  # Extract rest after 'local '/'typeset ' (comment-free, tab-normalized).
   local rest=""
-  case "$line" in
-    *"local "*)  rest="${line#*local }"  ;;
-    *"typeset "*) rest="${line#*typeset }" ;;
+  case "$nocomment" in
+    *"local "*)   rest="${nocomment#*local }"  ;;
+    *"typeset "*) rest="${nocomment#*typeset }" ;;
     *) return 0 ;;
   esac
 
@@ -125,6 +121,13 @@ POSITIVE_FIXTURES=(
   'typeset path'
   '  local status="ok"'
   '  local argv'
+  # CTL-1777 phase-review remediation: trailing inline comment must not hide
+  # the declaration (false-negative fix).
+  'local path="$1"  # sets the resolved path'
+  '	local content="$1" path="$2" tmp  # atomic writer'
+  # Tab (not space) between keyword and name must still flag (false-negative fix).
+  'local	path="$1"'
+  'typeset	fpath'
 )
 for fixture_line in "${POSITIVE_FIXTURES[@]}"; do
   result="$(check_line_for_specials "$fixture_line")"
@@ -147,6 +150,10 @@ NEGATIVE_FIXTURES=(
   '  local dest_path="$2"'
   '  local wt_path="$1"'
   '  local p="$path"'
+  # CTL-1777 phase-review remediation: a trailing comment that merely mentions a
+  # special name (or the keyword) must not be mistaken for a declaration.
+  '  local doc_path="x"  # not path, doc_path'
+  '  count=1  # local path would wipe PATH'
 )
 for fixture_line in "${NEGATIVE_FIXTURES[@]}"; do
   result="$(check_line_for_specials "$fixture_line")"

--- a/plugins/dev/scripts/__tests__/zsh-safe-locals.test.sh
+++ b/plugins/dev/scripts/__tests__/zsh-safe-locals.test.sh
@@ -1,0 +1,185 @@
+#!/usr/bin/env bash
+# zsh-safe-locals.test.sh (CTL-1777) — static lint rejecting `local`/`typeset`
+# of zsh special parameter names in lib/*.sh.
+#
+# Scope: plugins/dev/scripts/lib/*.sh ONLY (not lib/__tests__/, not non-lib
+# scripts). Widening to non-lib scripts is a deferred follow-up ticket (see
+# research Open Q2 in thoughts/shared/research/2026-08-11-ctl-1777.md).
+#
+# Under zsh, the following names are SPECIAL — they are bound to zsh internals
+# (e.g. `path` ↔ $PATH, `status` ↔ $?, `argv` ↔ positional params). A
+# `local <name>` declaration scopes the special locally and resets it to its
+# default (often empty), wiping the binding for the rest of the function.
+# External commands called from within the function become unresolvable when
+# `path` is reset to empty — the production failure mode CTL-1777 fixes.
+# Bash treats these as ordinary variables, so the bug is zsh-only and bash
+# test suites miss it.
+#
+# Run: bash plugins/dev/scripts/__tests__/zsh-safe-locals.test.sh
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# Resolve LIB_DIR: two possible layouts (run from repo root vs from __tests__).
+if [[ -d "${SCRIPT_DIR}/../../../../plugins/dev/scripts/lib" ]]; then
+  LIB_DIR="$(cd "${SCRIPT_DIR}/../../../../plugins/dev/scripts/lib" && pwd)"
+elif [[ -d "${SCRIPT_DIR}/../lib" ]]; then
+  LIB_DIR="$(cd "${SCRIPT_DIR}/../lib" && pwd)"
+else
+  LIB_DIR="${SCRIPT_DIR}/../lib"
+fi
+
+PASS=0
+FAIL=0
+pass() { PASS=$((PASS+1)); echo "  PASS: $1"; }
+fail() { FAIL=$((FAIL+1)); echo "  FAIL: $1"; [[ $# -ge 2 ]] && echo "    $2"; }
+
+# ─── Canonical set of zsh special parameter names (Finding 8, CTL-1777 research)
+# Adding a future zsh special is a one-line addition to this list.
+ZSH_SPECIALS="path cdpath fpath manpath module_path status argv options signals pipestatus"
+
+# ─── Tokenizer ───────────────────────────────────────────────────────────────
+# check_line_for_specials <line>
+# Prints the special name(s) found if the line declares a zsh special via
+# local/typeset. Prints nothing if clean or if it is a comment.
+# Uses only POSIX shell + awk (no gawk extensions).
+check_line_for_specials() {
+  local line="$1"
+  # Strip leading whitespace for comment detection.
+  local stripped="${line#"${line%%[![:space:]]*}"}"
+  # Skip pure comment lines.
+  [[ "${stripped:0:1}" == "#" ]] && return 0
+  # Skip lines where '#' appears before any local/typeset keyword.
+  # We only care about `local `  or `typeset ` (with trailing space).
+  local before_keyword=""
+  case "$line" in
+    *"local "*|*"typeset "*)
+      # Extract everything before the first occurrence of local/typeset.
+      # Hack: remove from 'local '/'typeset ' onwards and check if '#' is in what's left.
+      before_keyword="${line%%local *}"
+      case "$before_keyword" in *"#"*) return 0;; esac
+      before_keyword="${line%%typeset *}"
+      case "$before_keyword" in *"#"*) return 0;; esac
+      ;;
+    *) return 0 ;;
+  esac
+
+  # Extract rest after 'local '/'typeset '.
+  local rest=""
+  case "$line" in
+    *"local "*)  rest="${line#*local }"  ;;
+    *"typeset "*) rest="${line#*typeset }" ;;
+    *) return 0 ;;
+  esac
+
+  # Tokenize rest on whitespace and check each declared name.
+  # Use awk for splitting; keep only POSIX awk features.
+  printf '%s\n' "$rest" | awk -v specials="$ZSH_SPECIALS" '
+    BEGIN {
+      n = split(specials, sp_arr, " ")
+      for (i = 1; i <= n; i++) special[sp_arr[i]] = 1
+    }
+    {
+      ntok = split($0, tokens, /[[:space:]]+/)
+      for (i = 1; i <= ntok; i++) {
+        tok = tokens[i]
+        if (tok == "") continue
+        # Strip everything from the first = onward to get the declared name.
+        eq = index(tok, "=")
+        if (eq > 0) { name = substr(tok, 1, eq - 1) } else { name = tok }
+        # Strip non-identifier characters (safety).
+        gsub(/[^A-Za-z0-9_]/, "", name)
+        if (name != "" && (name in special)) print name
+      }
+    }
+  '
+}
+
+# scan_for_zsh_special_locals <file>
+# Prints "file:linenum: name" for each offending declaration.
+scan_for_zsh_special_locals() {
+  local file="$1"
+  local lineno=0
+  while IFS= read -r line; do
+    lineno=$((lineno + 1))
+    local hit
+    hit="$(check_line_for_specials "$line")"
+    if [[ -n "$hit" ]]; then
+      # May be multiple names; print one entry per name.
+      while IFS= read -r name; do
+        [[ -n "$name" ]] && printf '%s:%d: %s\n' "$file" "$lineno" "$name"
+      done <<< "$hit"
+    fi
+  done < "$file"
+}
+
+# ─── Fixture precision tests ─────────────────────────────────────────────────
+echo "=== Fixture precision tests ==="
+
+# Positive fixtures — MUST flag a special name.
+POSITIVE_FIXTURES=(
+  'local path="$1"'
+  '  local ticket_lc date_prefix path'
+  '	local content="$1" path="$2" tmp'
+  '	local path="$1" ticket="$2" top="" branch=""'
+  'typeset path'
+  '  local status="ok"'
+  '  local argv'
+)
+for fixture_line in "${POSITIVE_FIXTURES[@]}"; do
+  result="$(check_line_for_specials "$fixture_line")"
+  if [[ -n "$result" ]]; then
+    pass "POSITIVE flagged: $(printf '%q' "$fixture_line") → $result"
+  else
+    fail "POSITIVE not flagged (should be): $(printf '%q' "$fixture_line")"
+  fi
+done
+
+# Negative fixtures — MUST NOT flag any special name.
+NEGATIVE_FIXTURES=(
+  '  local p="$path" dir'
+  '  # NB: named cache_path NOT path; local path; path=<file> would wipe PATH'
+  '  local mypath="$1"'
+  '  local path_to_x=something'
+  '  local cache_path'
+  '  local doc_path="x"'
+  '  local real_path_arg="$1"'
+  '  local dest_path="$2"'
+  '  local wt_path="$1"'
+  '  local p="$path"'
+)
+for fixture_line in "${NEGATIVE_FIXTURES[@]}"; do
+  result="$(check_line_for_specials "$fixture_line")"
+  if [[ -z "$result" ]]; then
+    pass "NEGATIVE not flagged (correct): $(printf '%q' "$fixture_line")"
+  else
+    fail "NEGATIVE false-positive: $(printf '%q' "$fixture_line") → flagged as: $result"
+  fi
+done
+
+# ─── Live scan of lib/*.sh ───────────────────────────────────────────────────
+echo ""
+echo "=== Live scan: lib/*.sh for zsh-special local/typeset declarations ==="
+
+if [[ ! -d "$LIB_DIR" ]]; then
+  fail "lib dir not found at $LIB_DIR — cannot scan"
+else
+  OFFENDER_COUNT=0
+  while IFS= read -r f; do
+    while IFS= read -r hit; do
+      echo "    OFFENDER: $hit"
+      OFFENDER_COUNT=$((OFFENDER_COUNT + 1))
+    done < <(scan_for_zsh_special_locals "$f")
+  done < <(find "$LIB_DIR" -maxdepth 1 -name '*.sh' | sort)
+
+  if [[ $OFFENDER_COUNT -eq 0 ]]; then
+    pass "0 offenders in lib/*.sh — all local/typeset declarations are zsh-safe"
+  else
+    fail "$OFFENDER_COUNT offender(s) in lib/*.sh (listed above)"
+  fi
+fi
+
+# ─── Summary ────────────────────────────────────────────────────────────────
+echo ""
+echo "Results: ${PASS} passed, ${FAIL} failed"
+[[ $FAIL -eq 0 ]] || exit 1

--- a/plugins/dev/scripts/__tests__/zsh-safe-locals.test.sh
+++ b/plugins/dev/scripts/__tests__/zsh-safe-locals.test.sh
@@ -98,6 +98,21 @@ scan_for_zsh_special_locals() {
   local lineno=0
   while IFS= read -r line; do
     lineno=$((lineno + 1))
+    # Prefilter (CTL-1777 Codex P2, #3238): only pay the subshell+awk cost for
+    # lines that actually carry a `local `/`typeset ` declaration keyword. The
+    # live scan covers ~7,900 lines of lib/*.sh; without this, each line spawns a
+    # command-substitution subshell plus an awk, so one suite creates thousands
+    # of processes and runs slowly enough to risk CI timeouts. Tab-normalize
+    # first so `local<TAB>path` still qualifies — this is byte-identical to
+    # check_line_for_specials' own keyword `case`, so any line it would flag
+    # necessarily passes this gate (no detection semantics change; a comment that
+    # merely mentions the keyword still falls through to the real tokenizer,
+    # which strips the trailing comment and returns clean).
+    local norm_pf="${line//$'\t'/ }"
+    case "$norm_pf" in
+      *"local "*|*"typeset "*) : ;;
+      *) continue ;;
+    esac
     local hit
     hit="$(check_line_for_specials "$line")"
     if [[ -n "$hit" ]]; then

--- a/plugins/dev/scripts/lib/__tests__/secrets-hygiene.test.sh
+++ b/plugins/dev/scripts/lib/__tests__/secrets-hygiene.test.sh
@@ -120,6 +120,31 @@ DIR_MODE_BEFORE="$(file_mode "$WF_DIR")"
 write_secret_file '{"x":1}' "$WF_PATH"
 assert_eq "$DIR_MODE_BEFORE" "$(file_mode "$WF_DIR")" "parent dir mode unchanged"
 
+# ─── zsh source-safety: write_secret_file works under zsh (CTL-1777) ────────
+# Under zsh, `local path` in write_secret_file clobbers $PATH → mktemp
+# becomes unresolvable → function returns 1 and file is never written.
+# Skip if zsh is absent.
+
+echo ""
+echo "write_secret_file: behaves identically under zsh (CTL-1777)"
+if command -v zsh >/dev/null 2>&1; then
+	WF_ZSH_DIR="${SCRATCH}/zsh-write-dir"
+	mkdir -p "$WF_ZSH_DIR"
+	WF_ZSH_PATH="${WF_ZSH_DIR}/secret.json"
+	_zsh_rc=0
+	zsh -c "source '$LIB'; write_secret_file 'zsh-content' '$WF_ZSH_PATH'" 2>/dev/null || _zsh_rc=$?
+	assert_eq "0" "$_zsh_rc" "zsh: write_secret_file exits 0"
+	if [[ -f "$WF_ZSH_PATH" ]]; then
+		assert_eq "zsh-content" "$(cat "$WF_ZSH_PATH")" "zsh: file content matches"
+		assert_eq "600" "$(file_mode "$WF_ZSH_PATH")" "zsh: file mode = 600"
+	else
+		fail "zsh: file not created at $WF_ZSH_PATH"
+		fail "zsh: (skipping mode/content checks)"
+	fi
+else
+	echo "  SKIP: zsh not installed on this host"
+fi
+
 # ─── Summary ─────────────────────────────────────────────────────────────────
 
 echo ""

--- a/plugins/dev/scripts/lib/__tests__/worktree-resolve.test.sh
+++ b/plugins/dev/scripts/lib/__tests__/worktree-resolve.test.sh
@@ -100,4 +100,19 @@ eq explicit-missing "$source_value" "non-worktree explicit keeps strict-mode sou
 capture "$ROOT/unrelated" CAT-1000 "$WT1000"
 eq "$(cd "$WT1000" && pwd -P)" "$out" "correct explicit worktree still accepted"
 eq explicit "$source_value" "correct explicit worktree keeps source=explicit"
+# ─── CTL-1777: zsh source-safety for _wtr_path_serves_ticket ───────────────
+# Under zsh, `local path` clobbers $PATH → git becomes unresolvable → the
+# function returns 1 (false negative) even when the worktree is correct.
+# Create a ticket-named worktree and assert _wtr_path_serves_ticket returns
+# the same verdict (SERVES) under both bash and zsh. Skip when zsh absent.
+if command -v zsh >/dev/null 2>&1; then
+  ZSH_WT_REAL="$(cd "$WT" && pwd -P)"
+  ZSH_BASH_VERDICT="$(bash -c "source '$LIB'; _wtr_path_serves_ticket '$ZSH_WT_REAL' CAT-100 && echo SERVES || echo NOTSERVES")"
+  ZSH_ZSH_VERDICT="$(zsh -c "source '$LIB'; _wtr_path_serves_ticket '$ZSH_WT_REAL' CAT-100 && echo SERVES || echo NOTSERVES" 2>/dev/null)"
+  [[ "$ZSH_BASH_VERDICT" == "SERVES" ]] && ok "bash: _wtr_path_serves_ticket returns SERVES for correct worktree" || bad "bash: _wtr_path_serves_ticket unexpectedly returned $ZSH_BASH_VERDICT"
+  [[ "$ZSH_ZSH_VERDICT" == "$ZSH_BASH_VERDICT" ]] && ok "zsh: _wtr_path_serves_ticket matches bash ($ZSH_ZSH_VERDICT)" || bad "zsh: _wtr_path_serves_ticket mismatch (bash=$ZSH_BASH_VERDICT zsh=$ZSH_ZSH_VERDICT)"
+else
+  echo "SKIP: zsh source-safety test for _wtr_path_serves_ticket (zsh not installed)"
+fi
+
 echo "$P passed, $F failed"; [[ $F -eq 0 ]]

--- a/plugins/dev/scripts/lib/catalyst-version.sh
+++ b/plugins/dev/scripts/lib/catalyst-version.sh
@@ -30,16 +30,21 @@ _cv_read_trim() {
 # Resolve the real (symlink-followed) path of $1. Uses readlink -f when
 # available, falls back to a portable loop.
 _cv_real_path() {
-  local path="$1"
-  if [[ -z "$path" ]]; then return 0; fi
+  # NB: the local is named real_path_arg, NOT path. Under zsh, `path` is a
+  # special array tied to $PATH; `local path` scopes it locally and resets it
+  # to empty, making `readlink` and related utilities unresolvable for the rest
+  # of the function. Bash treats `path` as ordinary. CTL-1777; see also
+  # linear-team-keys.sh:22-27 for the prior fix in the same class.
+  local real_path_arg="$1"
+  if [[ -z "$real_path_arg" ]]; then return 0; fi
   # readlink -f works on Linux + macOS GNU coreutils; macOS BSD readlink does
   # not. Try GNU first, then fall back.
   local resolved
-  resolved=$(readlink -f "$path" 2>/dev/null) && [[ -n "$resolved" ]] && {
+  resolved=$(readlink -f "$real_path_arg" 2>/dev/null) && [[ -n "$resolved" ]] && {
     printf '%s' "$resolved"; return 0;
   }
   # Portable fallback — walk symlinks manually.
-  local p="$path" dir
+  local p="$real_path_arg" dir
   while [[ -L "$p" ]]; do
     dir=$(cd -P "$(dirname "$p")" 2>/dev/null && pwd) || break
     p=$(readlink "$p" 2>/dev/null) || break
@@ -49,10 +54,10 @@ _cv_real_path() {
     esac
   done
   if [[ -e "$p" ]]; then
-    dir=$(cd -P "$(dirname "$p")" 2>/dev/null && pwd) || { printf '%s' "$path"; return 0; }
+    dir=$(cd -P "$(dirname "$p")" 2>/dev/null && pwd) || { printf '%s' "$real_path_arg"; return 0; }
     printf '%s/%s' "$dir" "$(basename "$p")"
   else
-    printf '%s' "$path"
+    printf '%s' "$real_path_arg"
   fi
 }
 

--- a/plugins/dev/scripts/lib/secrets-hygiene.sh
+++ b/plugins/dev/scripts/lib/secrets-hygiene.sh
@@ -32,9 +32,13 @@ ensure_secrets_gitignore() {
 # write_secret_file <content> <path>
 # Atomic writer: write under umask 077, chmod 600, mv into place.
 write_secret_file() {
-	local content="$1" path="$2" tmp
+	# NB: the second local is named dest_path, NOT path. Under zsh, `path` is a
+	# special array tied to $PATH; `local path` scopes it locally and resets it
+	# to empty, making `mktemp` unresolvable (command not found). Bash treats
+	# `path` as ordinary. CTL-1777; see also linear-team-keys.sh:22-27.
+	local content="$1" dest_path="$2" tmp
 	tmp="$(mktemp)" || return 1
 	( umask 077; printf '%s' "$content" > "$tmp" ) || { rm -f "$tmp"; return 1; }
 	chmod 600 "$tmp"
-	mv "$tmp" "$path"
+	mv "$tmp" "$dest_path"
 }

--- a/plugins/dev/scripts/lib/worktree-resolve.sh
+++ b/plugins/dev/scripts/lib/worktree-resolve.sh
@@ -70,13 +70,18 @@ _wtr_branch_serves_ticket() {
 # serving this ticket closes that without loosening anything: the in-tree caller
 # passes a freshly created worktree root checked out on the ticket branch.
 _wtr_path_serves_ticket() {
-	local path="$1" ticket="$2" top="" branch=""
-	[[ -n $path && -n $ticket ]] || return 1
-	top="$(git -C "$path" rev-parse --show-toplevel 2>/dev/null)" || return 1
+	# NB: the first local is named wt_path, NOT path. Under zsh, `path` is a
+	# special array tied to $PATH; `local path` scopes it locally and resets it
+	# to empty, making `git` unresolvable (command not found) so the function
+	# always returns 1. Bash treats `path` as ordinary. CTL-1777; see also
+	# linear-team-keys.sh:22-27 for the prior fix in the same class.
+	local wt_path="$1" ticket="$2" top="" branch=""
+	[[ -n $wt_path && -n $ticket ]] || return 1
+	top="$(git -C "$wt_path" rev-parse --show-toplevel 2>/dev/null)" || return 1
 	[[ -n $top ]] || return 1
 	top="$(cd "$top" 2>/dev/null && pwd -P)" || return 1
-	[[ $top == "$path" ]] || return 1
-	branch="$(git -C "$path" rev-parse --abbrev-ref HEAD 2>/dev/null)" || return 1
+	[[ $top == "$wt_path" ]] || return 1
+	branch="$(git -C "$wt_path" rev-parse --abbrev-ref HEAD 2>/dev/null)" || return 1
 	_wtr_branch_serves_ticket "$branch" "$ticket"
 }
 

--- a/plugins/dev/scripts/lib/write-phase-thoughts-doc.sh
+++ b/plugins/dev/scripts/lib/write-phase-thoughts-doc.sh
@@ -29,13 +29,24 @@ _WRITE_PHASE_THOUGHTS_DOC_LOADED=1
 write_phase_thoughts_doc() {
   local phase="$1" ticket="$2" body="$3"
   local dir="thoughts/shared/phase-${phase}"
-  local ticket_lc date_prefix path
+  # NB: the local is named doc_path, NOT path. Under zsh, `path` is a special
+  # array tied to $PATH; `local path` scopes it locally and resets it to empty,
+  # making `tr`, `date`, and `mkdir` unresolvable for the rest of the function
+  # (silently swallowed by the pre-existing 2>/dev/null guards). Bash treats
+  # `path` as ordinary, so the bug is zsh-only. See linear-team-keys.sh:22-27
+  # for the prior fix in the same class. CTL-1777.
+  local ticket_lc date_prefix doc_path
   ticket_lc="$(printf '%s' "$ticket" | tr '[:upper:]' '[:lower:]')"
   date_prefix="$(date +%Y-%m-%d)"
   export CATALYST_PHASE_THOUGHTS_DOC=""
-  mkdir -p "$dir" 2>/dev/null || return 0
-  path="${dir}/${date_prefix}-${ticket_lc}.md"
-  if printf '%s\n' "$body" > "$path" 2>/dev/null; then
-    export CATALYST_PHASE_THOUGHTS_DOC="$path"
+  if ! mkdir -p "$dir" 2>/dev/null; then
+    echo "write_phase_thoughts_doc: mkdir failed for ${dir}" >&2
+    return 0
+  fi
+  doc_path="${dir}/${date_prefix}-${ticket_lc}.md"
+  if printf '%s\n' "$body" > "$doc_path" 2>/dev/null; then
+    export CATALYST_PHASE_THOUGHTS_DOC="$doc_path"
+  else
+    echo "write_phase_thoughts_doc: write failed for ${doc_path}" >&2
   fi
 }


### PR DESCRIPTION
<!-- Auto-generated: 2026-08-11T19:47:00Z -->
<!-- Last updated: 2026-08-11T19:47:00Z -->
<!-- PR: #3238 -->
<!-- Previous commits: 0097065f5ecebbce567e8d6d08a993c049377f30,aa13771aa7aebd2b0174eb212f1b65559f2d8793,5f4714a737c5c5c4167608a4d1cf1fb3d1f184ed,2ccaf8a49e019a721c13b86035f9edfd8ab14ce2 -->

## Summary

Fixes phantom `artifact_not_gate_visible` phase failures that occur when a phase agent runs under zsh. `write_phase_thoughts_doc` declared `local path`, which under zsh scopes the special `path` array (bound to `$PATH`) — emptying it for the rest of the function so external commands like `tr`, `date`, and `mkdir` become unresolvable and the thoughts artifact is never written. Four shell scripts are fixed and a static lint is added to prevent regressions.

## Changes Made

### Bug Fixes

- **`write-phase-thoughts-doc.sh`**: Rename `local path` → `local doc_path` to avoid clobbering `$PATH` under zsh. Add `>&2` redirection on `mkdir`/write failures (preserving best-effort `return 0`) and an explanatory NB: comment matching the `linear-team-keys.sh:22-27` template.

- **`catalyst-version.sh`**: Rename `local path` → `local real_path_arg` in `_cv_real_path`. Add NB: comment.

- **`secrets-hygiene.sh`**: Rename `local path` → `local dest_path` in `write_secret_file`. Add NB: comment.

- **`worktree-resolve.sh`**: Rename `local path` → `local wt_path` in `_wtr_path_serves_ticket`. Add NB: comment.

### Tests

- **`plugins/dev/scripts/__tests__/zsh-safe-locals.test.sh`** (new): Static lint that scans `lib/*.sh` for `local`/`typeset` declarations of zsh special parameter names (`path`, `cdpath`, `fpath`, `status`, `argv`, etc.). Fixture-driven with positive and negative cases. Auto-discovered by `run-tests.sh` via `__tests__/*.test.sh` glob. Includes phase-review remediations: strips trailing inline comments before keyword detection (closing a false-negative where `local path="$1"  # note` was skipped) and normalizes tabs to spaces (closing a false-negative for `local\tpath`).

- **`phase-skill-thoughts-doc.test.sh`**: Adds multi-shell (bash × zsh) loop asserting `write_phase_thoughts_doc` produces a non-empty `CATALYST_PHASE_THOUGHTS_DOC` and that the artifact is gate-visible for all six phases.

- **`catalyst-version.test.sh`**: Adds t11 asserting `_cv_real_path` returns the same symlink-resolved path under both bash and zsh.

- **`secrets-hygiene.test.sh`**, **`worktree-resolve.test.sh`**: Add zsh source-safety rows asserting each renamed function behaves identically under zsh.

## How to Verify It

- [x] All fast CI checks pass (agents-md-gate, audit-references, check-versions, detect-changes, docs-gate, gitleaks, validate) ✅
- [ ] `execution-core-unit-tests` passes (pending)
- [ ] Cloudflare Pages build passes (pending)
- [ ] Run `bash plugins/dev/scripts/__tests__/zsh-safe-locals.test.sh` — should report 0 offenders in `lib/*.sh`
- [ ] Run `bash plugins/dev/scripts/__tests__/phase-skill-thoughts-doc.test.sh` — multi-shell rows should pass for both bash and zsh

## Changelog Entry

```
fix(dev): fix write_phase_thoughts_doc under zsh — rename local path vars and add static lint (CTL-1777)
```

## Related Issues/PRs

- Fixes https://linear.app/coalesce/issue/CTL-1777