### PR TITLE
fix(dev): automated PR creation should target the repo with merge rights

### DIFF
--- a/.catalyst/config.json
+++ b/.catalyst/config.json
@@ -4,6 +4,9 @@
     "project": {
       "ticketPrefix": "CTL"
     },
+    "pr": {
+      "pushRemote": "fork"
+    },
     "linear": {
       "teamKey": "CTL",
       "stateMap": {

--- a/plugins/dev/scripts/lib/__tests__/draft-pr.test.sh
+++ b/plugins/dev/scripts/lib/__tests__/draft-pr.test.sh
@@ -1430,6 +1430,115 @@ new_fixture push-remote-missing
 )
 assert_eq "origin" "$(cat "${SCRATCH}/12c.out")" "12c: falls open to origin when the configured remote is absent"
 
+# ─── Suite 14: CAT-202 — gh pr create/view scoped to the push-remote's repo ────
+# gh pr create/view with no --repo resolve against "origin" via gh's own remote
+# detection, regardless of which remote the branch was actually pushed to. For
+# a repo where origin is a read-only upstream (coalesce-labs/catalyst) and the
+# writable fork lives on a separate remote (fork -> thagale/catalyst), every
+# automated PR was landing on origin — a repo this daemon can never merge on —
+# instead of the fork it just pushed to. _draft_pr_repo_slug/_draft_pr_gh_pr
+# fix this by resolving --repo from the SAME push-remote _draft_pr_push_remote
+# already selects.
+echo ""
+echo "Suite 14: CAT-202 — gh pr create/view scoped to the push-remote's repo"
+
+# 14a: _draft_pr_repo_slug parses an https://github.com/... remote URL
+echo "14a: _draft_pr_repo_slug parses an https github remote URL"
+new_fixture repo-slug-https
+(
+  cd "$WORK"
+  git remote set-url origin "https://github.com/thagale/catalyst.git"
+  source "$DRAFT_PR_LIB"
+  _draft_pr_repo_slug origin > "${SCRATCH}/14a.out" 2>/dev/null
+)
+assert_eq "thagale/catalyst" "$(cat "${SCRATCH}/14a.out")" "14a: https URL resolves to owner/repo"
+
+# 14b: _draft_pr_repo_slug parses a git@github.com:... (SSH) remote URL
+echo "14b: _draft_pr_repo_slug parses an ssh github remote URL"
+new_fixture repo-slug-ssh
+(
+  cd "$WORK"
+  git remote set-url origin "git@github.com:thagale/catalyst.git"
+  source "$DRAFT_PR_LIB"
+  _draft_pr_repo_slug origin > "${SCRATCH}/14b.out" 2>/dev/null
+)
+assert_eq "thagale/catalyst" "$(cat "${SCRATCH}/14b.out")" "14b: ssh URL resolves to owner/repo"
+
+# 14c: _draft_pr_repo_slug fails open (empty) for a non-github remote — the
+# local bare-repo fixtures every other suite in this file uses must keep
+# working with no --repo, exactly like before this fix.
+echo "14c: _draft_pr_repo_slug returns empty for a non-github remote (fail-open)"
+new_fixture repo-slug-local
+(
+  cd "$WORK"
+  source "$DRAFT_PR_LIB"
+  _draft_pr_repo_slug origin > "${SCRATCH}/14c.out" 2>/dev/null
+)
+assert_eq "" "$(cat "${SCRATCH}/14c.out")" "14c: local bare-repo remote yields no slug"
+
+# 14d: draft_pr_ensure passes --repo <fork's owner/repo> to `gh pr create`
+# when the configured push remote (fork) has a github.com URL — this is the
+# actual bug: the branch is pushed to fork/thagale/catalyst, but gh pr create
+# used to silently target origin/coalesce-labs-catalyst instead.
+echo "14d: draft_pr_ensure passes --repo (from the push remote) to gh pr create"
+new_fixture repo-scope-create
+git -C "$WORK" remote add fork "https://github.com/thagale/catalyst.git"
+(
+  cd "$WORK"
+  mkdir -p .catalyst
+  printf '{"catalyst":{"pr":{"pushRemote":"fork"}}}' > .catalyst/config.json
+  git push -u origin HEAD --quiet
+)
+P14D_BIN="${SCRATCH}/p14d-bin"
+P14D_LOG="${SCRATCH}/p14d.log"
+install_gh_stub_no_pr "$P14D_BIN" "$P14D_LOG"
+(
+  cd "$WORK"
+  PATH="${P14D_BIN}:${PATH}"
+  source "$DRAFT_PR_LIB"
+  draft_pr_ensure "main" "CAT-202" >/dev/null 2>/dev/null
+)
+if grep -A1 -- '--repo' "$P14D_LOG" | grep -q "thagale/catalyst"; then
+  pass "14d: gh pr create scoped to --repo thagale/catalyst (the fork), not origin"
+else
+  fail "14d: gh pr create scoped to --repo thagale/catalyst — log: $(cat "$P14D_LOG" 2>/dev/null)"
+fi
+
+# 14e: the idempotency check (gh pr view) is ALSO scoped to the fork's repo —
+# otherwise draft_pr_ensure would check origin for an existing PR (never find
+# one there) and could create a duplicate on the fork on every re-run.
+echo "14e: draft_pr_ensure's existing-PR check (gh pr view) is also --repo scoped"
+VIEW_HAS_REPO="$(awk '/^view$/{found=1} found && /^--repo$/{print "yes"; exit}' "$P14D_LOG")"
+if [[ "$VIEW_HAS_REPO" == "yes" ]]; then
+  pass "14e: gh pr view (idempotency check) received --repo"
+else
+  fail "14e: gh pr view (idempotency check) received --repo — log: $(cat "$P14D_LOG" 2>/dev/null)"
+fi
+
+# 14f: regression safety — with no fork remote configured (push remote stays
+# "origin", a local bare-repo test fixture with no github.com URL), gh pr
+# create/view are called with NO --repo flag at all, exactly like every
+# pre-CAT-202 test in this file already asserts (Suite 2's p2a). This proves
+# the fix is additive/fail-open and doesn't change behavior for a non-github
+# or single-remote checkout.
+echo "14f: no fork remote configured → gh pr create called with no --repo (unchanged)"
+new_fixture repo-scope-default
+(cd "$WORK" && git push -u origin HEAD --quiet)
+P14F_BIN="${SCRATCH}/p14f-bin"
+P14F_LOG="${SCRATCH}/p14f.log"
+install_gh_stub_no_pr "$P14F_BIN" "$P14F_LOG"
+(
+  cd "$WORK"
+  PATH="${P14F_BIN}:${PATH}"
+  source "$DRAFT_PR_LIB"
+  draft_pr_ensure "main" "CAT-202" >/dev/null 2>/dev/null
+)
+if grep -q -- '--repo' "$P14F_LOG" 2>/dev/null; then
+  fail "14f: no --repo expected for a non-github origin — log: $(cat "$P14F_LOG" 2>/dev/null)"
+else
+  pass "14f: gh pr create/view called with no --repo (unchanged, fail-open)"
+fi
+
 # ─── Summary ──────────────────────────────────────────────────────────────────
 echo ""
 echo "─────────────────────────────────────────────"

--- a/plugins/dev/scripts/lib/__tests__/draft-pr.test.sh
+++ b/plugins/dev/scripts/lib/__tests__/draft-pr.test.sh
@@ -1374,6 +1374,62 @@ new_fixture safety-blast-offset
 assert_eq "0" "$(cat "${SCRATCH}/safety-blast-offset.exit" 2>/dev/null)" "11c: offsetting insertion does not trip the gate"
 assert_eq "$(cat "${SCRATCH}/safety-blast-offset.local")" "$(cat "${SCRATCH}/safety-blast-offset.remote")" "11c: origin/feature advanced to HEAD (push succeeded)"
 
+# ─── Suite 12: _draft_pr_push_remote — fork-aware push routing (CAT-2026-08-08) ─
+# A repo where "origin" is a third-party upstream the daemon's identity only
+# has pull rights on (e.g. coalesce-labs/catalyst) needs pushes routed to a
+# writable fork remote via .catalyst/config.json's catalyst.pr.pushRemote.
+echo ""
+echo "Suite 12: _draft_pr_push_remote — fork-aware push routing"
+
+# 12a: no config file at all → default "origin" (existing behavior unchanged)
+echo "12a: no .catalyst/config.json → defaults to origin"
+new_fixture push-remote-default
+(
+  cd "$WORK"
+  source "$DRAFT_PR_LIB"
+  _draft_pr_push_remote > "${SCRATCH}/12a.out"
+)
+assert_eq "origin" "$(cat "${SCRATCH}/12a.out")" "12a: defaults to origin with no config"
+
+# 12b: catalyst.pr.pushRemote:"fork" configured AND a fork remote exists →
+#      resolves to "fork", and draft_pr_push_verify actually lands the push on
+#      the fork bare repo, leaving origin untouched.
+echo "12b: pushRemote:fork configured + fork remote exists → pushes to fork, not origin"
+new_fixture push-remote-fork
+FORK_BARE="${SCRATCH}/push-remote-fork/fork.git"
+git init --quiet --bare -b main "${FORK_BARE}"
+(
+  cd "$WORK"
+  git remote add fork "${FORK_BARE}"
+  mkdir -p .catalyst
+  printf '{"catalyst":{"pr":{"pushRemote":"fork"}}}' > .catalyst/config.json
+  source "$DRAFT_PR_LIB"
+  _draft_pr_push_remote > "${SCRATCH}/12b-remote.out"
+  set +e
+  draft_pr_push_verify >/dev/null 2>&1
+  set -e
+  git rev-parse HEAD > "${SCRATCH}/12b.local"
+)
+assert_eq "fork" "$(cat "${SCRATCH}/12b-remote.out")" "12b: _draft_pr_push_remote resolves to fork"
+FORK_FEATURE_SHA="$(git --git-dir="${FORK_BARE}" rev-parse --verify --quiet feature 2>/dev/null || echo '<none>')"
+ORIGIN_FEATURE_SHA="$(git --git-dir="${ORIGIN}" rev-parse --verify --quiet feature 2>/dev/null || echo '<none>')"
+assert_eq "$(cat "${SCRATCH}/12b.local")" "$FORK_FEATURE_SHA" "12b: push landed on the fork bare repo"
+assert_eq "<none>" "$ORIGIN_FEATURE_SHA" "12b: origin was never pushed to"
+
+# 12c: pushRemote:"fork" configured but no such remote exists in this checkout
+#      → fail-open back to "origin" rather than erroring (matches every other
+#      helper in this file's fail-open convention for a missing/bad config).
+echo "12c: pushRemote:fork configured but remote doesn't exist → fails open to origin"
+new_fixture push-remote-missing
+(
+  cd "$WORK"
+  mkdir -p .catalyst
+  printf '{"catalyst":{"pr":{"pushRemote":"fork"}}}' > .catalyst/config.json
+  source "$DRAFT_PR_LIB"
+  _draft_pr_push_remote > "${SCRATCH}/12c.out"
+)
+assert_eq "origin" "$(cat "${SCRATCH}/12c.out")" "12c: falls open to origin when the configured remote is absent"
+
 # ─── Summary ──────────────────────────────────────────────────────────────────
 echo ""
 echo "─────────────────────────────────────────────"

--- a/plugins/dev/scripts/lib/draft-pr.sh
+++ b/plugins/dev/scripts/lib/draft-pr.sh
@@ -4,8 +4,8 @@
 # POSIX/zsh-safe: no ${VAR,,}, no shopt, no ${BASH_SOURCE[0]} at top-level.
 #
 # Exported functions:
-#   draft_pr_push                 — push current branch to origin (idempotent, fail-open)
-#   draft_pr_push_verify          — push + prove origin==HEAD; fail-closed; rc=3 when
+#   draft_pr_push                 — push current branch to the push remote (idempotent, fail-open)
+#   draft_pr_push_verify          — push + prove push-remote==HEAD; fail-closed; rc=3 when
 #                                   the push is rejected for missing 'workflow' OAuth scope
 #                                   and no CATALYST_WORKFLOW_GITHUB_TOKEN is configured
 #   draft_pr_push_token TOKEN ... — push using an explicit PAT, bypassing GITHUB_TOKEN
@@ -14,6 +14,15 @@
 #   draft_pr_ensure BASE TICKET   — ensure a draft PR exists; echoes NUM<TAB>URL<TAB>ISDRAFT
 #   draft_pr_promote              — promote current branch's PR from draft to ready
 #   draft_pr_enabled              — read .catalyst/config.json knob (default true)
+#
+# Push target vs. diff base: every push site in this file pushes to the
+# CONFIGURED PUSH REMOTE (see _draft_pr_push_remote — defaults to "origin",
+# overridable via .catalyst/config.json's catalyst.pr.pushRemote for repos
+# where "origin" is a third-party upstream the daemon's identity can only
+# read). Diff/comparison sites (_draft_pr_pending_range, draft_pr_ensure's
+# commit range, draft_pr_diff_touches_workflows) intentionally keep comparing
+# against "origin" regardless — that's the authoritative default branch to
+# diff against either way, independent of where the branch gets pushed.
 #
 # Reserved return codes:
 #   3 — draft_pr_push_verify: push rejected for missing 'workflow' OAuth scope and no
@@ -190,7 +199,33 @@ _draft_pr_default_base() {
   printf 'main\n'
 }
 
-# draft_pr_push — idempotent push of current branch to origin. Fail-open.
+# _draft_pr_push_remote — resolve which git remote pushes go to. Reads
+# .catalyst/config.json's catalyst.pr.pushRemote (same read pattern as
+# draft_pr_enabled below); defaults to "origin" when unset, unparseable, or
+# the configured remote doesn't actually exist in this checkout.
+#
+# Exists because a repo where the daemon's own git identity has read-only
+# ("pull") access to "origin" (a third-party upstream it doesn't own, e.g.
+# coalesce-labs/catalyst) needs every push routed to a writable fork remote
+# instead. Before this, draft_pr_push/draft_pr_push_verify hardcoded "origin"
+# unconditionally, so the automated pr phase 403'd on every single attempt in
+# any repo shaped that way (confirmed 2026-08-08, CAT team's registry
+# repoRoot: git push -u origin HEAD → "has pull permission but no push
+# permission on coalesce-labs/catalyst"). "origin" stays correct everywhere
+# else in this file (diff/comparison base) — only the push target changes.
+_draft_pr_push_remote() {
+  local config_path="${CATALYST_CONFIG_PATH:-.catalyst/config.json}"
+  local remote="origin"
+  if [[ -f "$config_path" ]] && command -v jq >/dev/null 2>&1; then
+    local configured
+    configured="$(jq -r '.catalyst.pr.pushRemote // empty' "$config_path" 2>/dev/null || true)"
+    [[ -n "$configured" ]] && remote="$configured"
+  fi
+  git remote get-url "$remote" >/dev/null 2>&1 || remote="origin"
+  printf '%s\n' "$remote"
+}
+
+# draft_pr_push — idempotent push of current branch to the push remote. Fail-open.
 # CTL-693: suppress local pre-push hooks (trunk trufflehog/fmt/tests) on the
 # automated phase-agent push path — CI on origin/main already runs those gates.
 # Per-invocation `-c core.hooksPath=/dev/null` only; never mutates persistent
@@ -199,8 +234,9 @@ _draft_pr_default_base() {
 draft_pr_push() {
   command -v git >/dev/null 2>&1 || { _draft_pr_warn "git unavailable"; return 1; }
   _draft_pr_safety_gate || return "$_DRAFT_PR_SAFETY_GATE_RC"
-  local errf
+  local errf remote
   errf="$(mktemp -t draft-pr-push-XXXXXX 2>/dev/null || echo "/tmp/draft-pr-push-$$")"
+  remote="$(_draft_pr_push_remote)"
   if git rev-parse --abbrev-ref --symbolic-full-name '@{u}' >/dev/null 2>&1; then
     if ! git -c core.hooksPath=/dev/null push 2>"$errf"; then
       if _draft_pr_is_workflow_scope_error "$errf"; then
@@ -211,7 +247,7 @@ draft_pr_push() {
       rm -f "$errf"; return 1
     fi
   else
-    if ! git -c core.hooksPath=/dev/null push -u origin HEAD 2>"$errf"; then
+    if ! git -c core.hooksPath=/dev/null push -u "$remote" HEAD 2>"$errf"; then
       if _draft_pr_is_workflow_scope_error "$errf"; then
         _draft_pr_warn "git push -u failed: missing 'workflow' OAuth scope (continuing)"
       else
@@ -339,11 +375,12 @@ draft_pr_promote() {
 draft_pr_push_verify() {
   command -v git >/dev/null 2>&1 || { _draft_pr_warn "git unavailable"; return 1; }
   _draft_pr_safety_gate || return "$_DRAFT_PR_SAFETY_GATE_RC"
-  local branch local_sha remote_sha errf
+  local branch local_sha remote_sha errf remote
   branch="$(git rev-parse --abbrev-ref HEAD 2>/dev/null || true)"
   [[ -z "$branch" || "$branch" == "HEAD" ]] && { _draft_pr_warn "detached HEAD; cannot push-verify"; return 1; }
   local_sha="$(git rev-parse HEAD 2>/dev/null || true)"
   [[ -z "$local_sha" ]] && { _draft_pr_warn "cannot resolve local HEAD"; return 1; }
+  remote="$(_draft_pr_push_remote)"
 
   errf="$(mktemp -t draft-pr-push-XXXXXX 2>/dev/null || echo "/tmp/draft-pr-push-verify-$$")"
 
@@ -352,14 +389,14 @@ draft_pr_push_verify() {
   # scoped credential instead of attempting the plain push that will be rejected.
   if [[ -n "${CATALYST_WORKFLOW_GITHUB_TOKEN:-}" ]] && draft_pr_diff_touches_workflows; then
     _draft_pr_warn "workflow files + CATALYST_WORKFLOW_GITHUB_TOKEN set — routing through scoped token proactively"
-    if draft_pr_push_token "$CATALYST_WORKFLOW_GITHUB_TOKEN" -u origin HEAD >/dev/null 2>&1; then
+    if draft_pr_push_token "$CATALYST_WORKFLOW_GITHUB_TOKEN" -u "$remote" HEAD >/dev/null 2>&1; then
       rm -f "$errf"
-      git fetch --quiet origin "$branch" 2>/dev/null || true
-      remote_sha="$(git rev-parse "origin/${branch}" 2>/dev/null || true)"
+      git fetch --quiet "$remote" "$branch" 2>/dev/null || true
+      remote_sha="$(git rev-parse "${remote}/${branch}" 2>/dev/null || true)"
       if [[ -n "$remote_sha" && "$remote_sha" == "$local_sha" ]]; then
         printf '%s\n' "$local_sha"; return 0
       fi
-      _draft_pr_warn "post-push verify mismatch (proactive route): local=${local_sha} origin/${branch}=${remote_sha:-<none>}"
+      _draft_pr_warn "post-push verify mismatch (proactive route): local=${local_sha} ${remote}/${branch}=${remote_sha:-<none>}"
       return 1
     fi
     _draft_pr_warn "proactive scoped-token push failed"
@@ -367,7 +404,7 @@ draft_pr_push_verify() {
     return "$_DRAFT_PR_WORKFLOW_SCOPE_RC"
   fi
 
-  if ! git -c core.hooksPath=/dev/null push -u origin HEAD >/dev/null 2>"$errf"; then
+  if ! git -c core.hooksPath=/dev/null push -u "$remote" HEAD >/dev/null 2>"$errf"; then
     if _draft_pr_is_workflow_scope_error "$errf"; then
       _draft_pr_warn "push rejected: missing 'workflow' OAuth scope"
       rm -f "$errf"
@@ -376,7 +413,7 @@ draft_pr_push_verify() {
         _draft_pr_warn "retrying push with CATALYST_WORKFLOW_GITHUB_TOKEN"
         local tok_errf
         tok_errf="$(mktemp -t draft-pr-tok-XXXXXX 2>/dev/null || echo "/tmp/draft-pr-tok-$$")"
-        if draft_pr_push_token "$CATALYST_WORKFLOW_GITHUB_TOKEN" -u origin HEAD >/dev/null 2>"$tok_errf"; then
+        if draft_pr_push_token "$CATALYST_WORKFLOW_GITHUB_TOKEN" -u "$remote" HEAD >/dev/null 2>"$tok_errf"; then
           rm -f "$tok_errf"
         else
           _draft_pr_warn "token-routed push also failed"
@@ -388,7 +425,7 @@ draft_pr_push_verify() {
       fi
     else
       _draft_pr_warn "fast-forward push failed; retrying with --force-with-lease"
-      if ! git -c core.hooksPath=/dev/null push --force-with-lease -u origin HEAD >/dev/null 2>"$errf"; then
+      if ! git -c core.hooksPath=/dev/null push --force-with-lease -u "$remote" HEAD >/dev/null 2>"$errf"; then
         if _draft_pr_is_workflow_scope_error "$errf"; then
           _draft_pr_warn "force-with-lease push rejected: missing 'workflow' OAuth scope"
           rm -f "$errf"
@@ -396,7 +433,7 @@ draft_pr_push_verify() {
             _draft_pr_warn "retrying force-with-lease with CATALYST_WORKFLOW_GITHUB_TOKEN"
             local tok_errf2
             tok_errf2="$(mktemp -t draft-pr-tok-XXXXXX 2>/dev/null || echo "/tmp/draft-pr-tok2-$$")"
-            if draft_pr_push_token "$CATALYST_WORKFLOW_GITHUB_TOKEN" --force-with-lease -u origin HEAD >/dev/null 2>"$tok_errf2"; then
+            if draft_pr_push_token "$CATALYST_WORKFLOW_GITHUB_TOKEN" --force-with-lease -u "$remote" HEAD >/dev/null 2>"$tok_errf2"; then
               rm -f "$tok_errf2"
             else
               rm -f "$tok_errf2"
@@ -418,13 +455,13 @@ draft_pr_push_verify() {
     rm -f "$errf"
   fi
 
-  git fetch --quiet origin "$branch" 2>/dev/null || true
-  remote_sha="$(git rev-parse "origin/${branch}" 2>/dev/null || true)"
+  git fetch --quiet "$remote" "$branch" 2>/dev/null || true
+  remote_sha="$(git rev-parse "${remote}/${branch}" 2>/dev/null || true)"
   if [[ -n "$remote_sha" && "$remote_sha" == "$local_sha" ]]; then
     printf '%s\n' "$local_sha"
     return 0
   fi
-  _draft_pr_warn "post-push verify mismatch: local=${local_sha} origin/${branch}=${remote_sha:-<none>}"
+  _draft_pr_warn "post-push verify mismatch: local=${local_sha} ${remote}/${branch}=${remote_sha:-<none>}"
   return 1
 }
 

--- a/plugins/dev/scripts/lib/draft-pr.sh
+++ b/plugins/dev/scripts/lib/draft-pr.sh
@@ -47,6 +47,53 @@ _DRAFT_PR_WORKFLOW_SCOPE_RC=3
 # test's isolated mkdtemp sandbox, and pushed the result to a real branch.
 _DRAFT_PR_SAFETY_GATE_RC=4
 
+# _draft_pr_repo_slug REMOTE — resolve "OWNER/REPO" for a git remote's URL.
+# Handles github.com HTTPS and SSH remote URL forms. Empty output (rc=1) for
+# anything else (non-github host, local/bare-repo test fixture, unknown
+# remote) — callers fall back to gh's own remote-derived default.
+_draft_pr_repo_slug() {
+  local remote="$1" url
+  url="$(git remote get-url "$remote" 2>/dev/null || true)"
+  [[ -z "$url" ]] && return 1
+  case "$url" in
+    https://github.com/*|http://github.com/*)
+      printf '%s\n' "${url#*github.com/}" | sed -E 's#\.git$##'
+      ;;
+    git@github.com:*)
+      printf '%s\n' "${url#git@github.com:}" | sed -E 's#\.git$##'
+      ;;
+    ssh://git@github.com/*)
+      printf '%s\n' "${url#ssh://git@github.com/}" | sed -E 's#\.git$##'
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+}
+
+# _draft_pr_gh_pr SUBCMD [ARGS...] — run `gh pr SUBCMD` scoped to the repo
+# behind the configured push remote (CAT-202). `gh pr create`/`view`/`ready`
+# with no --repo resolve against "origin" via gh's own remote detection,
+# regardless of which remote the branch was actually pushed to. When origin
+# is a read-only upstream (e.g. coalesce-labs/catalyst) and pushes are routed
+# to a separate writable "fork" remote via catalyst.pr.pushRemote (see
+# _draft_pr_push_remote), every PR created/viewed with no --repo silently
+# targets origin instead of the fork that actually holds the branch — a repo
+# this daemon can never merge on. Falls open to gh's default remote
+# resolution when the push remote's URL isn't a parseable github.com slug
+# (local test fixtures, non-github remotes).
+_draft_pr_gh_pr() {
+  local subcmd="$1"; shift
+  local remote repo_slug
+  remote="$(_draft_pr_push_remote)"
+  repo_slug="$(_draft_pr_repo_slug "$remote" 2>/dev/null || true)"
+  if [[ -n "$repo_slug" ]]; then
+    gh pr "$subcmd" --repo "$repo_slug" "$@"
+  else
+    gh pr "$subcmd" "$@"
+  fi
+}
+
 # _draft_pr_pending_range — the commit range about to be pushed: unpushed
 # local commits ahead of the upstream tracking branch, or ahead of
 # origin/<default-base> when there is no upstream yet (first push of a new
@@ -290,7 +337,7 @@ draft_pr_ensure() {
 
   # Idempotency: check for an existing open PR on this branch.
   local existing_json
-  existing_json="$(gh pr view --json number,url,isDraft 2>/dev/null || true)"
+  existing_json="$(_draft_pr_gh_pr view --json number,url,isDraft 2>/dev/null || true)"
   if [[ -n "$existing_json" ]]; then
     local ex_num ex_url ex_draft
     ex_num="$(printf '%s' "$existing_json" | jq -r '.number // empty' 2>/dev/null || true)"
@@ -320,7 +367,7 @@ draft_pr_ensure() {
 
   # Try --draft first.
   local create_out
-  if create_out="$(gh pr create --draft --base "$base" --title "$title" --body "$body" 2>/dev/null)"; then
+  if create_out="$(_draft_pr_gh_pr create --draft --base "$base" --title "$title" --body "$body" 2>/dev/null)"; then
     local new_num new_url
     new_url="$(printf '%s' "$create_out" | grep -oE 'https://[^ ]*/pull/[0-9]+' | head -1 || true)"
     new_num="$(printf '%s' "$new_url" | grep -oE '[0-9]+$' || true)"
@@ -330,7 +377,7 @@ draft_pr_ensure() {
 
   # --draft rejected; retry without --draft (graceful fallback per deliverable #3).
   _draft_pr_warn "--draft rejected, retrying without --draft"
-  if create_out="$(gh pr create --base "$base" --title "$title" --body "$body" 2>/dev/null)"; then
+  if create_out="$(_draft_pr_gh_pr create --base "$base" --title "$title" --body "$body" 2>/dev/null)"; then
     local new_num new_url
     new_url="$(printf '%s' "$create_out" | grep -oE 'https://[^ ]*/pull/[0-9]+' | head -1 || true)"
     new_num="$(printf '%s' "$new_url" | grep -oE '[0-9]+$' || true)"
@@ -346,7 +393,7 @@ draft_pr_ensure() {
 draft_pr_promote() {
   command -v gh >/dev/null 2>&1 || { _draft_pr_warn "gh unavailable"; return 1; }
   local pr_json is_draft num
-  pr_json="$(gh pr view --json number,isDraft 2>/dev/null || true)"
+  pr_json="$(_draft_pr_gh_pr view --json number,isDraft 2>/dev/null || true)"
   [[ -z "$pr_json" ]] && { _draft_pr_warn "no PR found for current branch"; return 1; }
   is_draft="$(printf '%s' "$pr_json" | jq -r '.isDraft // false' 2>/dev/null || echo 'false')"
   num="$(printf '%s' "$pr_json" | jq -r '.number // empty' 2>/dev/null || true)"
@@ -355,7 +402,7 @@ draft_pr_promote() {
     return 1
   fi
   if [[ "$is_draft" == "true" ]]; then
-    gh pr ready "$num" 2>/dev/null || { _draft_pr_warn "gh pr ready failed (continuing)"; return 1; }
+    _draft_pr_gh_pr ready "$num" 2>/dev/null || { _draft_pr_warn "gh pr ready failed (continuing)"; return 1; }
   fi
   return 0
 }
@@ -470,7 +517,7 @@ draft_pr_push_verify() {
 draft_pr_head_oid() {
   command -v gh >/dev/null 2>&1 || return 1
   local oid
-  oid="$(gh pr view --json headRefOid -q '.headRefOid' 2>/dev/null || true)"
+  oid="$(_draft_pr_gh_pr view --json headRefOid -q '.headRefOid' 2>/dev/null || true)"
   [[ -n "$oid" ]] && { printf '%s\n' "$oid"; return 0; }
   return 1
 }

--- a/plugins/dev/skills/create-pr/SKILL.md
+++ b/plugins/dev/skills/create-pr/SKILL.md
@@ -95,7 +95,12 @@ If behind:
 ### 5. Check for existing PR
 
 ```bash
-gh pr view --json number,url,title,state 2>/dev/null
+# CAT-202: scope to the configured push remote's repo (draft-pr.sh's
+# _draft_pr_gh_pr), not the ambient `origin` remote — when origin is a
+# read-only upstream and pushes route to a separate `fork` remote, a bare
+# `gh pr view` silently checks the wrong repo for an existing PR.
+source "${CLAUDE_PLUGIN_ROOT}/scripts/lib/draft-pr.sh"
+_draft_pr_gh_pr view --json number,url,title,state 2>/dev/null
 ```
 
 If PR exists:
@@ -218,7 +223,9 @@ skip_block="$(linear_sibling_skip_block_from_branch "$ticket" "$branch")"
 $skip_block"
 
 # Create PR (author will be the git user)
-gh pr create --title "$title" --body "$body" --base "$base"
+# CAT-202: same repo-scoping as the existing-PR check above — see draft-pr.sh
+# already sourced in step 8.
+_draft_pr_gh_pr create --title "$title" --body "$body" --base "$base"
 ```
 
 The initial body uses commit messages so the PR is immediately readable even before `/describe-pr`

--- a/plugins/dev/skills/phase-monitor-merge/SKILL.md
+++ b/plugins/dev/skills/phase-monitor-merge/SKILL.md
@@ -79,7 +79,14 @@ if [[ -x "$SESSION_SCRIPT" ]]; then
   export CATALYST_SESSION_ID
 fi
 
-REPO=$(gh repo view --json nameWithOwner --jq '.nameWithOwner' 2>/dev/null || echo "")
+# CAT-202: resolve REPO from the PR's OWN recorded url, not the ambient
+# `origin` remote. `gh repo view` (no --repo) resolves against whatever repo
+# `origin` points to — for a checkout where `origin` is a read-only upstream
+# and pushes/PRs are routed to a separate `fork` remote (catalyst.pr.pushRemote),
+# that silently disagreed with the repo the tracked PR actually lives on.
+# phase-pr.json's `.pr.url` is the authoritative record of that repo.
+REPO=$(jq -r '.pr.url // empty' "$PR_SIGNAL" 2>/dev/null | sed -E 's#^https://github\.com/##; s#/pull/[0-9]+$##')
+[[ -n "$REPO" ]] || REPO=$(gh repo view --json nameWithOwner --jq '.nameWithOwner' 2>/dev/null || echo "")
 [[ -n "$REPO" ]] || { echo "phase-monitor-merge: cannot resolve repo" >&2; exit 1; }
 
 TS=$(date -u +%Y-%m-%dT%H:%M:%SZ)
@@ -420,7 +427,10 @@ if [[ "$REVIEWER_VERDICT_PRESENT" != true && -n "${HEAD_AGE_SEC:-}" ]]; then
   fi
   echo "phase-monitor-merge: reviewer-arrival window elapsed; proceeding to merge pr#${PR_NUMBER}" >&2
 fi
-gh pr merge "$PR_NUMBER" --squash --delete-branch
+# CAT-202: explicit --repo — a bare `gh pr merge` resolves against the
+# ambient `origin` remote, which can disagree with $REPO (the repo the PR was
+# actually opened on, resolved above from phase-pr.json's .pr.url).
+gh pr merge "$PR_NUMBER" --repo "${REPO}" --squash --delete-branch
 # REST is authoritative — confirm via REST, never GraphQL
 MERGED_OK=$(gh api "repos/${REPO}/pulls/${PR_NUMBER}" --jq '.merged' 2>/dev/null || echo "false")
 [[ "$MERGED_OK" = "true" ]] || { echo "phase-monitor-merge: merge not confirmed via REST" >&2; exit 1; }
@@ -539,7 +549,7 @@ if [[ ! -e "${LINEAR_MIRROR_MARKER}" ]]; then
   MERGED_AT="$(jq -r '.pr.mergedAt // empty' "${MM_SIGNAL}" 2>/dev/null || true)"
   PR_VIEW="{}"
   if [[ -n "${MM_PR_NUMBER}" ]]; then
-    PR_VIEW="$(gh pr view "${MM_PR_NUMBER}" --json url,baseRefName,createdAt,statusCheckRollup,reviews 2>/dev/null || echo '{}')"
+    PR_VIEW="$(gh pr view "${MM_PR_NUMBER}" --repo "${REPO}" --json url,baseRefName,createdAt,statusCheckRollup,reviews 2>/dev/null || echo '{}')"
   fi
   PR_URL="$(printf '%s' "${PR_VIEW}" | jq -r '.url // empty' 2>/dev/null || true)"
   BASE_REF="$(printf '%s' "${PR_VIEW}" | jq -r '.baseRefName // "main"' 2>/dev/null || echo 'main')"


### PR DESCRIPTION
Upstream contribution (courtesy PR — not intended to be merged by this fork's operator). Recreated after the original courtesy PR (#3229) was auto-closed when its shared branch name was deleted on the fork-side merge — see thagale/catalyst#82 for the original merged fix.

Also carries **#39 ("route automated PR pushes through a fork remote when origin is read-only")** as a prerequisite — discovered while recreating this PR that it was never successfully landed upstream either (same branch-deletion auto-close issue, or never had a courtesy PR at all). Without it, this PR's `_draft_pr_gh_pr`/`_draft_pr_repo_slug` additions reference `_draft_pr_push_remote`, which doesn't otherwise exist on this branch.